### PR TITLE
[Feature] : add adaptive speculative (Dcut) verification for vllm-ascend

### DIFF
--- a/dcut/__init__.py
+++ b/dcut/__init__.py
@@ -1,0 +1,5 @@
+# SPDX-License-Identifier: Apache-2.0
+"""D-Cut adaptive verifier step-length for DFlash/PARD on NPU."""
+from .install import install
+
+__all__ = ["install"]

--- a/dcut/controller.py
+++ b/dcut/controller.py
@@ -1,0 +1,170 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Controller init + drafter-probs enablement."""
+from __future__ import annotations
+
+import os
+
+import torch
+
+from .globals import (
+    ENV_CONFIG,
+    ENV_DISABLE,
+    ENV_FORCE_DRAFTER_EAGER,
+    ENV_FULL_DECODE_ONLY,
+    ENV_SKIP_UNREADY_PROBS,
+    ENV_TRIM_STATS_OUT,
+    logger,
+)
+from .utils import (
+    _dcut_process_probs_stage,
+    _dcut_reuse_argmax_enabled,
+    _env_flag,
+    _npu_event,
+    _supports_adaptive_verify,
+)
+from .drafter import _dcut_patch_drafter_instance
+from .patch_full_graph import _dcut_setup_full_decode_drafter
+from .verify_adaptive_config import VerifyAdaptiveConfig
+from .verify_adaptive_controller import VerifyAdaptiveController
+
+# ---------------------------------------------------------------------------
+# Runner-side helpers (installed as methods or used by the wrappers).
+# Device-agnostic except where noted; identical to the CUDA plugin.
+# ---------------------------------------------------------------------------
+
+def _dcut_init_controller(self) -> None:
+    """Build the controller + async-probs buffers on an NPUModelRunner instance.
+
+    Enabled iff ``VLLM_DCUT_CONFIG`` points to a JSON config AND the speculative
+    method is parallel (dflash / PARD).  Otherwise leaves the runner untouched.
+    """
+    self._verify_adaptive_controller = None
+    self._adaptive_probs_event = None
+    self._adaptive_probs_pinned = None
+    self._adaptive_probs_pending = False
+    self._adaptive_probs_expired = False
+    self._adaptive_probs_source = "none"
+    self._adaptive_probs_last_consumed_source = "none"
+    self._adaptive_probs_generation = 0
+    self._adaptive_probs_last_consumed_generation = 0
+    self._adaptive_probs_last_consumed_mean_by_position = []
+    self._adaptive_num_reqs = 0
+    self._adaptive_req_ids = []
+    self._adaptive_active = set()
+    # Verify-reduction stats (how much D-Cut trimmed); logged every N steps.
+    self._dcut_stat_full = 0
+    self._dcut_stat_trimmed = 0
+    self._dcut_stat_reqs = 0
+    self._dcut_stat_steps = 0
+    self._dcut_stat_log_every = int(os.environ.get("VLLM_DCUT_STAT_EVERY", "200") or 0)
+    self._dcut_trim_stats_out = os.environ.get(ENV_TRIM_STATS_OUT) or None
+    self._dcut_skip_unready_probs = _env_flag(ENV_SKIP_UNREADY_PROBS)
+    self._dcut_process_probs_stage = _dcut_process_probs_stage()
+    self._dcut_missing_probs_steps = 0
+    self._dcut_logged_drafter_probs = False
+
+    cfg_path = os.environ.get(ENV_CONFIG) or None
+    if not cfg_path:
+        return
+
+    if _env_flag(ENV_DISABLE):
+        logger.info(
+            "D-Cut trimming and draft-probability control disabled by %s; "
+            "D-Cut GDN operator patches remain active.",
+            ENV_DISABLE,
+        )
+        return
+
+    if os.environ.get(ENV_FULL_DECODE_ONLY):
+        logger.info(
+            "D-Cut adaptive verify disabled by %s; running full decode-only "
+            "baseline with the D-Cut plugin loaded.",
+            ENV_FULL_DECODE_ONLY,
+        )
+        return
+
+    spec_cfg = getattr(self, "speculative_config", None)
+    if not _supports_adaptive_verify(spec_cfg):
+        logger.warning(
+            "VLLM_DCUT_CONFIG is set but the speculative method does not support "
+            "adaptive verifier step-length (requires dflash or "
+            "draft_model+parallel_drafting); D-Cut disabled."
+        )
+        return
+
+    num_spec = getattr(self, "num_spec_tokens", 0) or 0
+    if num_spec <= 0:
+        logger.warning("D-Cut: num_spec_tokens <= 0; disabled.")
+        return
+
+    acfg = VerifyAdaptiveConfig.from_json(cfg_path)
+    self._verify_adaptive_controller = VerifyAdaptiveController(
+        config=acfg,
+        num_spec_tokens=num_spec,
+        max_batch_size=self.scheduler_config.max_num_seqs,
+        device=self.device,
+    )
+    # NPU: torch.npu.Event instead of torch.cuda.Event.
+    self._adaptive_probs_event = _npu_event()
+    self._adaptive_probs_pinned = torch.empty(
+        (self.max_num_reqs, num_spec),
+        dtype=torch.float32,
+        device="cpu",
+        pin_memory=self.pin_memory,
+    )
+    _dcut_enable_drafter_probs(self)
+    logger.info(
+        "D-Cut adaptive verify ENABLED on NPU "
+        "(config=%s process_probs_stage=%s skip_unready_probs=%s "
+        "reuse_argmax=%s).",
+        cfg_path,
+        self._dcut_process_probs_stage,
+        self._dcut_skip_unready_probs,
+        _dcut_reuse_argmax_enabled(),
+    )
+
+
+def _dcut_enable_drafter_probs(self) -> None:
+    """Enable draft-prob collection once the Ascend drafter object exists."""
+    if getattr(self, "_verify_adaptive_controller", None) is None:
+        return
+    drafter = getattr(self, "drafter", None)
+    if drafter is None:
+        return
+    if not hasattr(drafter, "needs_draft_probs"):
+        if not getattr(self, "_dcut_logged_drafter_probs", False):
+            logger.warning(
+                "D-Cut: drafter %s has no needs_draft_probs flag.",
+                type(drafter).__name__,
+            )
+            self._dcut_logged_drafter_probs = True
+        return
+    _dcut_patch_drafter_instance(drafter)
+    _dcut_setup_full_decode_drafter(self, drafter)
+    if _env_flag(ENV_FORCE_DRAFTER_EAGER):
+        drafter.use_cuda_graph = False
+        if not getattr(self, "_dcut_logged_force_drafter_eager", False):
+            logger.warning(
+                "D-Cut: forced drafter eager via %s; target graph mode "
+                "remains %s.",
+                ENV_FORCE_DRAFTER_EAGER,
+                getattr(
+                    getattr(self, "compilation_config", None),
+                    "cudagraph_mode",
+                    None,
+                ),
+            )
+            self._dcut_logged_force_drafter_eager = True
+    drafter.needs_draft_probs = True
+    if not getattr(self, "_dcut_logged_drafter_probs", False):
+        logger.warning(
+            "D-Cut: enabled selected draft probs on drafter %s "
+            "(method=%s parallel=%s instance_compute_patched=%s "
+            "graph_owner_attached=%s).",
+            type(drafter).__name__,
+            getattr(drafter, "method", None),
+            getattr(drafter, "parallel_drafting", None),
+            getattr(drafter, "_dcut_instance_compute_patched", False),
+            getattr(drafter, "_dcut_graph_owner_attached", False),
+        )
+        self._dcut_logged_drafter_probs = True

--- a/dcut/dcut_profile.py
+++ b/dcut/dcut_profile.py
@@ -1,0 +1,253 @@
+# SPDX-License-Identifier: Apache-2.0
+"""NPU adaptive cost-table profiling run."""
+from __future__ import annotations
+
+import os
+
+import numpy as np
+import torch
+
+from vllm.config import CUDAGraphMode
+from vllm.distributed import get_pp_group, get_tp_group
+
+from .globals import logger, ENV_PROFILE_FORCE_EAGER
+from .utils import _npu_event
+
+@torch.inference_mode()
+def _adaptive_profile_run(
+    self,
+    scheduled_tokens: "list[int]",
+    seq_lens: int = 1024,
+    n_warmup: int = 3,
+    n_measure: int = 5,
+):
+    """Profile verifier forward latency for one (batch_size, query_len) shape.
+
+    **NPU port** of PR #44885's GPUModelRunner._adaptive_profile_run.  Modelled
+    on vllm-ascend's ``NPUModelRunner._dummy_run``: it builds attention metadata
+    with the NPU signature of ``_build_attention_metadata`` (no ``slot_mappings``
+    kwarg, no ``_get_slot_mappings`` pre-step), then times ``self._model_forward``
+    inside ``set_ascend_forward_context`` using ``torch.npu.Event``.  Profiling
+    is forced eager by default for safety; set
+    ``VLLM_DCUT_PROFILE_FORCE_EAGER=0`` to let the dispatcher pick the same
+    graph/eager runtime mode as serving.
+
+    Returns (runtime_mode, avg_forward_ms, num_tokens_padded).
+    """
+    # Import here so a stand-alone `import dcut` never hard-requires vllm-ascend.
+    from vllm_ascend.ascend_forward_context import set_ascend_forward_context
+    from vllm_ascend.attention.attention_v1 import AscendAttentionState
+
+    num_scheduled_tokens = np.array(scheduled_tokens, dtype=np.int32)
+    self.query_lens = torch.from_numpy(num_scheduled_tokens)
+    self.attn_state = AscendAttentionState.ChunkedPrefill
+    num_reqs = len(scheduled_tokens)
+    num_tokens_unpadded = int(num_scheduled_tokens.sum())
+    max_query_len = int(num_scheduled_tokens.max())
+
+    assert num_tokens_unpadded <= self.max_num_tokens, (
+        f"adaptive profile: num_tokens={num_tokens_unpadded} > "
+        f"max_num_tokens={self.max_num_tokens}"
+    )
+
+    profile_force_eager = (
+        os.environ.get(ENV_PROFILE_FORCE_EAGER, "1").lower()
+        not in ("0", "false", "no")
+    )
+    profile_uniform_decode = (
+        not profile_force_eager
+        and max_query_len == self.uniform_decode_query_len
+        and num_tokens_unpadded == max_query_len * num_reqs
+    )
+    # Same dispatcher entrypoint as _dummy_run. By default the profile run is
+    # eager because manual graph replay on NPU is more fragile; the env override
+    # is useful when comparing eager vs graph cost curves. Only the untrimmed
+    # rectangle is uniform; shorter D-Cut candidates must profile ragged FULL.
+    _cudagraph_mode, batch_desc, _should_ubatch, num_tokens_across_dp, _ = (
+        self._determine_batch_execution_and_padding(
+            num_tokens=num_tokens_unpadded,
+            num_reqs=num_reqs,
+            num_scheduled_tokens_np=num_scheduled_tokens,
+            max_num_scheduled_tokens=max_query_len,
+            use_cascade_attn=False,
+            allow_microbatching=False,
+            force_eager=profile_force_eager,
+            force_uniform_decode=profile_uniform_decode,
+        )
+    )
+
+    num_tokens_padded = batch_desc.num_tokens
+    num_reqs_padded = (
+        batch_desc.num_reqs if batch_desc.num_reqs is not None else num_reqs
+    )
+    # allow_microbatching=False -> no ubatching for the profile run.
+    ubatch_slices = None
+
+    with self.synchronize_input_prep():
+        # seq_lens / query_start_loc are needed by attention backends in all
+        # modes.  Use the configured warmup_seq_lens so attention cost reflects
+        # realistic long-context inference rather than trivial seq_len=1.
+        self.optimistic_seq_lens_cpu[:num_reqs] = seq_lens
+        self.optimistic_seq_lens_cpu[num_reqs:].fill_(0)
+        self.seq_lens.copy_(self.optimistic_seq_lens_cpu, non_blocking=True)
+
+        cum_num_tokens = self._get_cumsum_and_arange(
+            num_scheduled_tokens, self.query_pos.np
+        )
+        self.query_start_loc.np[0] = 0
+        self.query_start_loc.np[1 : num_reqs + 1] = cum_num_tokens
+        self.query_start_loc.np[num_reqs + 1 : num_reqs_padded + 1].fill(
+            cum_num_tokens[-1]
+        )
+        if _cudagraph_mode == CUDAGraphMode.FULL:
+            num_reqs_padded = self._pad_query_start_loc_for_fia(
+                self.query_start_loc,
+                num_tokens_padded,
+                num_reqs_padded,
+                num_reqs,
+                _cudagraph_mode,
+                batch_desc.num_reqs,
+            )
+        else:
+            # PIECEWISE capture expects its final cuSeqlen to equal padded Q.
+            self.query_start_loc.np[num_reqs_padded] = num_tokens_padded
+            self.query_start_loc.copy_to_gpu()
+
+        # GDN must retain the real ragged boundaries. FIA may append one dummy
+        # request to the main qsl, but passing that row into GDN changes its
+        # spec/decode classification and can update the wrong recurrent state.
+        if self._has_gdn:
+            self.gdn_query_start_loc.np[0] = 0
+            self.gdn_query_start_loc.np[1 : num_reqs + 1] = cum_num_tokens
+            self.gdn_query_start_loc.np[num_reqs + 1 :].fill(
+                cum_num_tokens[-1]
+            )
+            self.gdn_query_start_loc.copy_to_gpu()
+        self.input_batch.block_table.commit_block_table(num_reqs_padded)
+
+        # Mark requests as decode (num_computed_tokens > 0) so the model
+        # treats them as decode-phase, not prefill.  Required for the
+        # dispatcher to select PIECEWISE cudagraph during profiling.
+        for i in range(num_reqs):
+            self.input_batch.num_computed_tokens_cpu[i] = seq_lens
+        self.input_batch.num_computed_tokens_cpu[num_reqs:].fill(0)
+
+        # Mark every sequence as a spec-decode so hybrid GDN/Mamba backends
+        # take the cheap incremental spec-decode path instead of the expensive
+        # prefill chunk-scan.  Per-request draft_len must respect the
+        # spec_state_indices_tensor width (num_spec + 1) to avoid OOB in
+        # npu_causal_conv1d_custom / npu_recurrent_gated_delta_rule.
+        if self.speculative_config is not None:
+            num_spec = self.num_spec_tokens
+            if hasattr(self, "num_decode_draft_tokens"):
+                for i in range(num_reqs):
+                    self.num_decode_draft_tokens.np[i] = min(
+                        int(num_scheduled_tokens[i]) - 1, num_spec
+                    )
+                self.num_decode_draft_tokens.np[num_reqs:].fill(-1)
+                self.num_decode_draft_tokens.copy_to_gpu()
+            if hasattr(self, "num_accepted_tokens"):
+                # num_accepted_tokens must be <= num_spec + 1 (the width of
+                # spec_state_indices_tensor) to prevent OOB state access in
+                # the Mamba/GDN conv1d sliding-window update.
+                for i in range(num_reqs):
+                    self.num_accepted_tokens.np[i] = min(
+                        int(num_scheduled_tokens[i]), num_spec + 1
+                    )
+                self.num_accepted_tokens.np[num_reqs:].fill(1)
+                self.num_accepted_tokens.copy_to_gpu()
+
+        # NPU _build_attention_metadata: no `slot_mappings` kwarg; takes
+        # `num_scheduled_tokens_np` and `num_reqs_padded` instead.
+        attn_metadata, _ = self._build_attention_metadata(
+            num_tokens=num_tokens_unpadded,
+            num_reqs=num_reqs,
+            max_query_len=max_query_len,
+            num_tokens_padded=num_tokens_padded,
+            num_reqs_padded=num_reqs_padded,
+            ubatch_slices=ubatch_slices,
+            for_cudagraph_capture=False,
+            use_spec_decode=self.speculative_config is not None,
+            num_scheduled_tokens_np=num_scheduled_tokens,
+        )
+
+    # Inputs — identical construction to _dummy_run so model kwargs (e.g. aux
+    # hidden states for DFlash/Eagle3) are always provided.  Real verifier decode
+    # steps are text-only, so we skip the vision encoder: mm-wrapped models route
+    # through inputs_embeds, so we still supply a dummy embeds buffer for them —
+    # just without the mm kwargs that would trigger the encoder.
+    use_embeds = self.enable_prompt_embeds or (
+        self.supports_mm_inputs and not self.model_config.is_encoder_decoder
+    )
+    if use_embeds:
+        input_ids = None
+        inputs_embeds = self.inputs_embeds.gpu[:num_tokens_padded]
+    else:
+        input_ids = self.input_ids.gpu[:num_tokens_padded]
+        inputs_embeds = None
+
+    if self.uses_mrope:
+        positions = self.mrope_positions.gpu[:, :num_tokens_padded]
+    elif self.uses_xdrope_dim > 0:
+        positions = self.xdrope_positions.gpu[:, :num_tokens_padded]
+    else:
+        positions = self.positions[:num_tokens_padded]
+
+    intermediate_tensors = None
+    if not get_pp_group().is_first_rank:
+        from vllm.v1.outputs import IntermediateTensors  # lazy: PP>1 only
+        if self.intermediate_tensors is None:
+            self.intermediate_tensors = self.model.make_empty_intermediate_tensors(
+                batch_size=self.max_num_tokens,
+                dtype=self.model_config.dtype,
+                device=self.device,
+            )
+        intermediate_tensors = IntermediateTensors(
+            {k: v[:num_tokens_padded] for k, v in self.intermediate_tensors.items()}
+        )
+
+    _mode_names = {
+        CUDAGraphMode.FULL: "FCG",
+        CUDAGraphMode.PIECEWISE: "PCG",
+        CUDAGraphMode.NONE: "eager",
+    }
+    avg_ms = 0.0
+    with set_ascend_forward_context(
+        attn_metadata,
+        self.vllm_config,
+        num_tokens=num_tokens_padded,
+        num_tokens_across_dp=num_tokens_across_dp,
+        in_profile_run=True,
+        num_actual_tokens=num_tokens_padded,
+        aclgraph_runtime_mode=_cudagraph_mode,
+        batch_descriptor=batch_desc,
+        model_instance=self.model,
+        has_sinks=self._has_sinks,
+        input_ids=input_ids,
+    ):
+
+        def _forward() -> None:
+            self._model_forward(
+                num_tokens_padded,
+                input_ids,
+                positions,
+                intermediate_tensors,
+                inputs_embeds,
+            )
+
+        for _ in range(max(n_warmup, 0)):
+            _forward()
+        torch.npu.synchronize()
+
+        if n_measure > 0:
+            start_ev = _npu_event(enable_timing=True)
+            end_ev = _npu_event(enable_timing=True)
+            start_ev.record()
+            for _ in range(n_measure):
+                _forward()
+            end_ev.record()
+            torch.npu.synchronize()
+            avg_ms = start_ev.elapsed_time(end_ev) / n_measure
+
+    mode_str = _mode_names.get(_cudagraph_mode, str(_cudagraph_mode))
+    return mode_str, avg_ms, int(num_tokens_padded)

--- a/dcut/draft_profile.py
+++ b/dcut/draft_profile.py
@@ -1,0 +1,113 @@
+# SPDX-License-Identifier: Apache-2.0
+"""DFlash proposer cost profiling for D-Cut."""
+from __future__ import annotations
+
+import os
+
+import torch
+from vllm.config import CUDAGraphMode
+
+from .globals import ENV_PROFILE_FORCE_EAGER, logger
+from .utils import _npu_event
+
+
+@torch.inference_mode()
+def _adaptive_profile_draft_run(
+    self,
+    batch_size: int,
+    context_tokens: int,
+    n_warmup: int = 3,
+    n_measure: int = 5,
+):
+    """Profile one complete DFlash proposer run for a D-Cut candidate.
+
+    D-Cut truncates the verifier input after the proposer has produced the
+    configured full K draft tokens. The next proposer invocation therefore
+    still runs with ``B * (K + 1)`` query tokens. DFlash additionally prepares
+    context K/V from this verifier step's Q target hidden states, so Q is passed
+    separately as ``context_tokens`` instead of being conflated with the fixed
+    draft query shape.
+
+    The dummy buffers are overwritten by every real DFlash call. Profiling them
+    after graph warmup and before serving requests therefore cannot leak draft
+    context into a request.
+
+    Returns ``(runtime_mode, avg_ms, padded_draft_query_tokens)``.
+    """
+    drafter = getattr(self, "drafter", None)
+    if drafter is None:
+        return "none", 0.0, 0
+    if getattr(drafter, "method", None) != "dflash":
+        if not getattr(self, "_dcut_draft_profile_fallback_logged", False):
+            self._dcut_draft_profile_fallback_logged = True
+            logger.warning(
+                "D-Cut draft-cost profiling supports DFlash only; using "
+                "target-only costs for method=%r.",
+                getattr(drafter, "method", None),
+            )
+        return "unsupported", 0.0, 0
+
+    draft_query_tokens = batch_size * (drafter.num_speculative_tokens + 1)
+    has_lora = bool(self.input_batch.lora_id_to_lora_request)
+
+    profile_force_eager = (
+        os.environ.get(ENV_PROFILE_FORCE_EAGER, "1").lower()
+        not in ("0", "false", "no")
+    )
+    if drafter.use_cuda_graph and not profile_force_eager:
+        _, batch_desc = self.cudagraph_dispatcher.dispatch(
+            num_tokens=draft_query_tokens,
+            uniform_decode=True,
+            has_lora=has_lora,
+        )
+        draft_input_tokens = batch_desc.num_tokens
+        draft_input_tokens, _, _ = self._sync_metadata_across_dp(
+            draft_input_tokens,
+            is_draft_model=True,
+        )
+        runtime_mode, batch_desc = self.cudagraph_dispatcher.dispatch(
+            num_tokens=draft_input_tokens,
+            uniform_decode=True,
+            has_lora=has_lora,
+        )
+        draft_input_tokens = batch_desc.num_tokens
+    else:
+        runtime_mode = CUDAGraphMode.NONE
+        batch_desc = None
+        draft_input_tokens = draft_query_tokens
+
+    def _draft_forward() -> None:
+        drafter.dummy_run(
+            num_tokens=draft_input_tokens,
+            num_reqs=batch_size,
+            aclgraph_runtime_mode=runtime_mode,
+            batch_descriptor=batch_desc,
+            is_profile=False,
+            context_num_tokens=context_tokens,
+        )
+
+    for _ in range(max(n_warmup, 0)):
+        _draft_forward()
+    torch.npu.synchronize()
+
+    avg_ms = 0.0
+    if n_measure > 0:
+        start_ev = _npu_event(enable_timing=True)
+        end_ev = _npu_event(enable_timing=True)
+        start_ev.record()
+        for _ in range(n_measure):
+            _draft_forward()
+        end_ev.record()
+        torch.npu.synchronize()
+        avg_ms = start_ev.elapsed_time(end_ev) / n_measure
+
+    mode_names = {
+        CUDAGraphMode.FULL: "FCG",
+        CUDAGraphMode.PIECEWISE: "PCG",
+        CUDAGraphMode.NONE: "eager",
+    }
+    return (
+        mode_names.get(runtime_mode, str(runtime_mode)),
+        avg_ms,
+        int(draft_input_tokens),
+    )

--- a/dcut/drafter.py
+++ b/dcut/drafter.py
@@ -1,0 +1,137 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Patch live Ascend drafter instance for selected draft probs."""
+from __future__ import annotations
+
+from types import MethodType
+
+import torch
+
+from .globals import logger
+from .utils import (
+    _dcut_can_reuse_argmax_for_probs,
+    _dcut_greedy_sample_with_selected_probs,
+    _dcut_should_collect_draft_probs,
+    _dcut_selected_token_probs,
+)
+
+
+def _dcut_attach_graph_owner(drafter) -> bool:
+    """Bind a live proposer to its already-created ACLGraph wrapper."""
+    runnable = getattr(drafter, "_runnable", None)
+    runnable_state = getattr(runnable, "__dict__", None)
+    if not (
+        isinstance(runnable_state, dict)
+        and "concrete_aclgraph_entries" in runnable_state
+    ):
+        return False
+    runnable_state["_dcut_descriptor_owner"] = drafter
+    drafter._dcut_graph_owner_attached = True
+    return True
+
+
+def _dcut_patch_drafter_instance(drafter) -> None:
+    """Patch the live Ascend drafter instance; robust to MRO/load order quirks."""
+    if _dcut_attach_graph_owner(drafter) and not getattr(
+        drafter,
+        "_dcut_logged_graph_owner_attached",
+        False,
+    ):
+        logger.warning(
+            "D-Cut: attached live drafter to its ACLGraphWrapper."
+        )
+        drafter._dcut_logged_graph_owner_attached = True
+    if not hasattr(drafter, "take_last_selected_probs"):
+        drafter.take_last_selected_probs = lambda: getattr(
+            drafter, "_last_selected_probs", None
+        )
+
+    model = getattr(drafter, "model", None)
+    if (
+        model is not None
+        and hasattr(model, "compute_logits")
+        and not getattr(model, "_dcut_compute_logits_patched", False)
+    ):
+        orig_compute_logits = model.compute_logits
+
+        def compute_logits(self_model, hidden_states, *args, **kwargs):
+            logits = orig_compute_logits(hidden_states, *args, **kwargs)
+            if _dcut_should_collect_draft_probs(drafter) and logits is not None:
+                try:
+                    can_reuse_argmax = _dcut_can_reuse_argmax_for_probs(
+                        drafter
+                    )
+                    if can_reuse_argmax:
+                        # _run_merged_draft returns the actual selected IDs.
+                        # Keep logits alive so its shared eager/graph wrapper
+                        # derives probabilities from exactly those IDs.
+                        drafter._dcut_last_logits_for_probs = logits
+                        drafter._last_selected_probs = None
+                    else:
+                        token_ids = logits.argmax(dim=-1)
+                        selected_probs = _dcut_selected_token_probs(
+                            logits,
+                            token_ids,
+                        )
+                        drafter._last_selected_probs = (
+                            selected_probs.float().contiguous()
+                        )
+                    if not getattr(
+                        drafter, "_dcut_logged_compute_logits_probs", False
+                    ):
+                        logger.warning(
+                            "D-Cut: captured selected draft probs/logits from "
+                            "compute_logits on %s "
+                            "(logits_shape=%s reuse_argmax=%s).",
+                            type(drafter).__name__,
+                            tuple(logits.shape),
+                            can_reuse_argmax,
+                        )
+                        drafter._dcut_logged_compute_logits_probs = True
+                except Exception as e:  # pragma: no cover - defensive
+                    logger.warning(
+                        "D-Cut: gather selected probs from compute_logits "
+                        "failed: %s",
+                        e,
+                    )
+                    drafter._last_selected_probs = None
+            return logits
+
+        model.compute_logits = MethodType(compute_logits, model)
+        model._dcut_compute_logits_patched = True
+
+    if (
+        not hasattr(drafter, "compute_draft_token_ids")
+        or getattr(drafter, "_dcut_instance_compute_patched", False)
+    ):
+        return
+
+    orig_compute = drafter.compute_draft_token_ids
+
+    def compute_draft_token_ids(self, hidden_states):
+        self._last_selected_probs = None
+        if not _dcut_should_collect_draft_probs(self):
+            return orig_compute(hidden_states)
+        try:
+            logits = self.model.logits_processor(self.model.lm_head, hidden_states)
+            logits = logits.contiguous()
+            next_token, selected_probs = _dcut_greedy_sample_with_selected_probs(
+                logits
+            )
+            self._last_selected_probs = selected_probs.float().contiguous()
+
+            draft_map = getattr(self.model, "draft_id_to_target_id", None)
+            if draft_map is None:
+                return next_token
+            bias = torch.index_select(
+                draft_map, dim=0, index=next_token.view(-1)
+            ).view(next_token.shape)
+            return next_token + bias
+        except Exception as e:  # pragma: no cover - defensive
+            logger.warning(
+                "D-Cut: gather selected probs in live drafter failed: %s", e
+            )
+            self._last_selected_probs = None
+            return orig_compute(hidden_states)
+
+    drafter.compute_draft_token_ids = MethodType(compute_draft_token_ids, drafter)
+    drafter._dcut_instance_compute_patched = True

--- a/dcut/gdn_buffers.py
+++ b/dcut/gdn_buffers.py
@@ -1,0 +1,898 @@
+# SPDX-License-Identifier: Apache-2.0
+"""GDN metadata buffers used by eager and PIECEWISE GDN execution.
+
+The legacy helpers keep their shared ASL/NAT layout for the retired
+``patch_gdn.py`` path. The active v0.23 capture path owns batch-level fixed
+buffers per model instance and padded token bucket. State indices are shared
+by layer prefixes that reference the same attention metadata object, while
+different metadata groups remain isolated. This keeps graph input addresses
+stable without repeating the same metadata update for every GDN layer.
+"""
+from __future__ import annotations
+
+import os
+
+import torch
+
+from vllm.v1.attention.backends.utils import PAD_SLOT_ID
+
+from .globals import logger, _dcut_gdn_static
+
+ENV_GDN_SHARED_STATIC = "VLLM_DCUT_GDN_SHARED_STATIC"
+
+
+def _dcut_use_shared_gdn_static() -> bool:
+    return os.environ.get(ENV_GDN_SHARED_STATIC, "1").lower() not in (
+        "0", "false", "no"
+    )
+
+
+def _dcut_gdn_static_key(prefix, num_tokens, kind):
+    # ASL/NAT are batch-level values shared by all Qwen3.5 GDN layers.
+    # SSI comes from the per-layer metadata's state-index tuple and must stay
+    # prefix-local, matching the original full-decode path.
+    if kind in ("spec_asl_nat", "nonspec_asl") and _dcut_use_shared_gdn_static():
+        owner = "__shared__"
+    else:
+        owner = prefix
+    return (owner, num_tokens, kind)
+
+
+def _to_int_tuple(value) -> tuple[int, ...]:
+    if value is None:
+        return ()
+    if isinstance(value, tuple):
+        return tuple(int(v) for v in value)
+    if isinstance(value, list):
+        return tuple(int(v) for v in value)
+    if hasattr(value, "tolist"):
+        return tuple(int(v) for v in value.tolist())
+    return (int(value),)
+
+
+def _spec_host_args(meta) -> tuple[tuple[int, ...], tuple[int, ...], tuple[int, ...]]:
+    """Read spec conv1d host args from CPU metadata (no NPU sync)."""
+    fallback_meta = getattr(meta, "spec_decode_fallback_meta", None)
+    if fallback_meta is not None:
+        conv_meta = fallback_meta.spec_causal_conv1d
+        return (
+            _to_int_tuple(conv_meta.query_start_loc_cpu),
+            _to_int_tuple(conv_meta.cache_indices_cpu),
+            _to_int_tuple(conv_meta.num_accepted_tokens_cpu),
+        )
+    # Fallback: .tolist() on device tensors causes NPU sync — avoid on hot path.
+    return (
+        _to_int_tuple(meta.spec_query_start_loc),
+        _to_int_tuple(meta.spec_state_indices_tensor.reshape(-1)),
+        _to_int_tuple(meta.num_accepted_tokens),
+    )
+
+
+def _nonspec_host_args(meta) -> tuple[tuple[int, ...], tuple[int, ...]]:
+    """Read non-spec conv1d host args from CPU metadata (no NPU sync)."""
+    fallback_meta = getattr(meta, "non_spec_decode_fallback_meta", None)
+    if fallback_meta is not None:
+        conv_meta = fallback_meta.causal_conv1d
+        return (
+            _to_int_tuple(conv_meta.query_start_loc_cpu),
+            _to_int_tuple(conv_meta.cache_indices_cpu),
+        )
+    return (
+        _to_int_tuple(meta.non_spec_query_start_loc),
+        _to_int_tuple(meta.non_spec_state_indices_tensor),
+    )
+
+
+def _dcut_alloc_gdn_spec_bufs(prefix, num_tokens, spec_state_indices_tensor, device):
+    """Allocate shared ASL/NAT + per-layer SSI buffers for spec decode path."""
+    b_cap = spec_state_indices_tensor.size(0)
+    nsp1 = spec_state_indices_tensor.size(1)  # num_spec + 1
+    t_cap = b_cap * nsp1
+
+    # Shared ASL/NAT (all layers share same batch composition)
+    shared_key = _dcut_gdn_static_key(prefix, num_tokens, "spec_asl_nat")
+    if shared_key not in _dcut_gdn_static:
+        _dcut_gdn_static[shared_key] = {
+            "asl": torch.zeros(b_cap + 1, dtype=torch.int32, device=device),
+            "nat": torch.zeros(b_cap, dtype=torch.int32, device=device),
+            "asl_cpu": torch.zeros(b_cap + 1, dtype=torch.int32, device="cpu"),
+            "nat_cpu": torch.zeros(b_cap, dtype=torch.int32, device="cpu"),
+            "b_cap": b_cap,
+        }
+        logger.debug(
+            "D-Cut: alloc GDN shared spec ASL/NAT num_tokens=%d b_cap=%d",
+            num_tokens, b_cap)
+
+    # Per-layer SSI
+    ssi_key = _dcut_gdn_static_key(prefix, num_tokens, "spec_ssi")
+    if ssi_key not in _dcut_gdn_static:
+        _dcut_gdn_static[ssi_key] = {
+            "ssi": torch.full((t_cap,), PAD_SLOT_ID, dtype=torch.int32, device=device),
+            "col_idx": torch.arange(nsp1, device=device),
+            "b_cap": b_cap,
+            "nsp1": nsp1,
+            "t_cap": t_cap,
+        }
+        logger.debug(
+            "D-Cut: alloc GDN spec SSI prefix=%s num_tokens=%d b_cap=%d t_cap=%d",
+            prefix, num_tokens, b_cap, t_cap)
+
+    # Return combined dict for convenience
+    return {**_dcut_gdn_static[shared_key], **_dcut_gdn_static[ssi_key]}
+
+
+def _dcut_fill_gdn_spec_bufs(prefix, num_tokens, meta, device,
+                              fill_shared_asl_nat=True):
+    """Fill ASL/SSI/NAT buffers before graph replay.
+
+    Optimization: ASL/NAT built on CPU from conv1d host args, one copy to GPU.
+    SSI still uses NPU ops (source is device tensor, unavoidable).
+    """
+    spec_state_indices_tensor = meta.spec_state_indices_tensor
+    num_spec_decodes = meta.num_spec_decodes
+    spec_query_start_loc = meta.spec_query_start_loc
+    num_accepted_tokens = meta.num_accepted_tokens
+
+    bufs = _dcut_alloc_gdn_spec_bufs(
+        prefix, num_tokens, spec_state_indices_tensor, device)
+
+    # --- Shared ASL/NAT: CPU build + one GPU copy ---
+    if fill_shared_asl_nat:
+        asl_cpu = bufs["asl_cpu"]
+        nat_cpu = bufs["nat_cpu"]
+        asl_cpu.zero_()
+        nat_cpu.zero_()
+
+        if num_spec_decodes > 0:
+            # Try CPU host args first (no NPU sync)
+            qsl_host, _, nat_host = _spec_host_args(meta)
+
+            if qsl_host and nat_host:
+                # ASL: diff of cumulative query_start_loc
+                n = min(num_spec_decodes, len(qsl_host) - 1)
+                for i in range(n):
+                    asl_cpu[i + 1] = qsl_host[i + 1] - qsl_host[i]
+                # NAT: from host args, clamped to segment length
+                n_nat = min(num_spec_decodes, len(nat_host))
+                for i in range(n_nat):
+                    val = nat_host[i]
+                    if i + 1 < len(qsl_host):
+                        seg_len = qsl_host[i + 1] - qsl_host[i]
+                        val = min(val, seg_len)
+                    nat_cpu[i] = val
+            else:
+                # Fallback: build from NPU tensors (causes sync, but correct)
+                cu = spec_query_start_loc[:num_spec_decodes + 1]
+                per_seq_lens = cu[1:] - cu[:-1]
+                asl_cpu[1:num_spec_decodes + 1].copy_(per_seq_lens.cpu())
+                clamped = torch.minimum(
+                    num_accepted_tokens[:num_spec_decodes].to(torch.int32),
+                    per_seq_lens.to(torch.int32)
+                )
+                nat_cpu[:num_spec_decodes].copy_(clamped.cpu())
+
+        # One copy CPU -> GPU
+        bufs["asl"].copy_(asl_cpu, non_blocking=True)
+        bufs["nat"].copy_(nat_cpu, non_blocking=True)
+
+    # --- Per-layer SSI: NPU path (unavoidable, source is device tensor) ---
+    ssi = bufs["ssi"]
+    ssi.fill_(PAD_SLOT_ID)
+
+    if num_spec_decodes > 0:
+        cu = spec_query_start_loc[:num_spec_decodes + 1]
+        per_seq_lens = cu[1:] - cu[:-1]
+        col_idx = bufs["col_idx"]
+        mask = col_idx.unsqueeze(0) < per_seq_lens.unsqueeze(1)
+        real = spec_state_indices_tensor[:num_spec_decodes][mask]
+        ssi[:real.size(0)].copy_(real)
+
+    return bufs
+
+
+def _dcut_alloc_gdn_nonspec_bufs(prefix, num_tokens,
+                                  non_spec_state_indices_tensor, device):
+    """Allocate shared ASL + per-layer SSI buffers for non-spec decode path."""
+    b_cap = non_spec_state_indices_tensor.size(0)
+
+    # Shared ASL
+    shared_key = _dcut_gdn_static_key(prefix, num_tokens, "nonspec_asl")
+    if shared_key not in _dcut_gdn_static:
+        _dcut_gdn_static[shared_key] = {
+            "asl": torch.zeros(b_cap + 1, dtype=torch.int32, device=device),
+            "asl_cpu": torch.zeros(b_cap + 1, dtype=torch.int32, device="cpu"),
+            "b_cap": b_cap,
+        }
+        logger.debug(
+            "D-Cut: alloc GDN shared nonspec ASL num_tokens=%d b_cap=%d",
+            num_tokens, b_cap)
+
+    # Per-layer SSI
+    ssi_key = _dcut_gdn_static_key(prefix, num_tokens, "nonspec_ssi")
+    if ssi_key not in _dcut_gdn_static:
+        _dcut_gdn_static[ssi_key] = {
+            "ssi": torch.full((b_cap,), PAD_SLOT_ID, dtype=torch.int32, device=device),
+        }
+        logger.debug(
+            "D-Cut: alloc GDN nonspec SSI prefix=%s num_tokens=%d b_cap=%d",
+            prefix, num_tokens, b_cap)
+
+    return {**_dcut_gdn_static[shared_key], **_dcut_gdn_static[ssi_key]}
+
+
+def _dcut_fill_gdn_nonspec_bufs(prefix, num_tokens, meta, device,
+                                 fill_shared_asl=True):
+    """Fill ASL/SSI buffers for non-spec decode before graph replay."""
+    non_spec_query_start_loc = meta.non_spec_query_start_loc
+    non_spec_state_indices_tensor = meta.non_spec_state_indices_tensor
+    num_decodes = meta.num_decodes
+
+    bufs = _dcut_alloc_gdn_nonspec_bufs(
+        prefix, num_tokens, non_spec_state_indices_tensor, device)
+
+    # --- Shared ASL: CPU build + one GPU copy ---
+    if fill_shared_asl:
+        asl_cpu = bufs["asl_cpu"]
+        asl_cpu.zero_()
+
+        if num_decodes > 0:
+            qsl_host, _ = _nonspec_host_args(meta)
+            if qsl_host:
+                n = min(num_decodes, len(qsl_host) - 1)
+                for i in range(n):
+                    asl_cpu[i + 1] = qsl_host[i + 1] - qsl_host[i]
+            else:
+                cu = non_spec_query_start_loc[:num_decodes + 1]
+                asl_cpu[1:num_decodes + 1].copy_((cu[1:] - cu[:-1]).cpu())
+
+        bufs["asl"].copy_(asl_cpu, non_blocking=True)
+
+    # --- Per-layer SSI: NPU path ---
+    ssi = bufs["ssi"]
+    ssi.fill_(PAD_SLOT_ID)
+    if num_decodes > 0:
+        ssi[:num_decodes].copy_(non_spec_state_indices_tensor[:num_decodes])
+
+    return bufs
+
+
+def _dcut_update_gdn_static(forward_context, num_tokens, GDNAttentionMetadata):
+    """Update GDN static buffers from forward context's attn_metadata.
+
+    Called from patched _model_forward before _orig_model_forward (i.e. before
+    graph replay). ASL/NAT are filled once (shared), SSI per-layer.
+    """
+    attn_metadata = forward_context.attn_metadata
+    if attn_metadata is None or not isinstance(attn_metadata, dict):
+        return
+    filled_shared_keys = set()
+    for prefix, meta in attn_metadata.items():
+        if not isinstance(meta, GDNAttentionMetadata):
+            continue
+        if meta.spec_sequence_masks is not None and meta.num_spec_decodes > 0:
+            shared_key = _dcut_gdn_static_key(prefix, num_tokens, "spec_asl_nat")
+            fill_shared = shared_key not in filled_shared_keys
+            filled_shared_keys.add(shared_key)
+            _dcut_fill_gdn_spec_bufs(
+                prefix, num_tokens, meta, meta.spec_query_start_loc.device,
+                fill_shared_asl_nat=fill_shared,
+            )
+        elif meta.num_decodes > 0:
+            shared_key = _dcut_gdn_static_key(prefix, num_tokens, "nonspec_asl")
+            fill_shared = shared_key not in filled_shared_keys
+            filled_shared_keys.add(shared_key)
+            _dcut_fill_gdn_nonspec_bufs(
+                prefix, num_tokens, meta, meta.non_spec_query_start_loc.device,
+                fill_shared_asl=fill_shared,
+            )
+
+
+def _dcut_prepare_gdn_eager_state(
+    forward_context,
+    GDNAttentionMetadata,
+    *,
+    initial_spec_rows=(),
+) -> bool:
+    """Build batch-level speculative state once for all eager GDN layers.
+
+    ``query_start_loc`` and ``num_accepted_tokens`` describe the batch and
+    are identical for every GDN layer. Keep state indices layer-local, but
+    share these batch-level tensors for the duration of one model forward.
+    """
+    forward_context._dcut_gdn_eager_spec_state = None
+    attn_metadata = getattr(forward_context, "attn_metadata", None)
+    if not isinstance(attn_metadata, dict):
+        return False
+
+    spec_items = [
+        meta
+        for meta in attn_metadata.values()
+        if (
+            isinstance(meta, GDNAttentionMetadata)
+            and meta.spec_sequence_masks is not None
+            and int(meta.num_spec_decodes) > 0
+            and meta.spec_decode_metadata is not None
+        )
+    ]
+    if not spec_items:
+        return False
+
+    reference = spec_items[0]
+    num_spec_decodes = int(reference.num_spec_decodes)
+    spec_decode_metadata = reference.spec_decode_metadata
+    conv_metadata = spec_decode_metadata.spec_causal_conv1d
+    num_accepted_tokens = conv_metadata.num_accepted_tokens
+    query_start_loc = conv_metadata.query_start_loc
+    num_conv_requests = int(conv_metadata.cache_indices.shape[0])
+    if (
+        num_accepted_tokens is None
+        or query_start_loc is None
+        or num_accepted_tokens.numel() < num_conv_requests
+    ):
+        return False
+
+    # Only share metadata when every GDN layer describes the same batch
+    # shape. Values are produced from the same scheduler output; state indices
+    # intentionally remain on each layer's metadata object.
+    for meta in spec_items[1:]:
+        layer_spec_metadata = meta.spec_decode_metadata
+        layer_conv_metadata = layer_spec_metadata.spec_causal_conv1d
+        if (
+            int(meta.num_spec_decodes) != num_spec_decodes
+            or tuple(layer_conv_metadata.num_accepted_tokens.shape)
+            != tuple(num_accepted_tokens.shape)
+            or int(layer_conv_metadata.cache_indices.shape[0])
+            != num_conv_requests
+            or tuple(layer_conv_metadata.query_start_loc.shape)
+            != tuple(query_start_loc.shape)
+        ):
+            return False
+
+    accepted_tokens_int32 = num_accepted_tokens
+    if accepted_tokens_int32.dtype != torch.int32:
+        accepted_tokens_int32 = accepted_tokens_int32.to(torch.int32)
+
+    initial_spec_rows = tuple(int(row) for row in initial_spec_rows)
+    if initial_spec_rows:
+        if any(
+            row < 0 or row >= num_spec_decodes
+            for row in initial_spec_rows
+        ):
+            raise RuntimeError(
+                "D-Cut eager handoff row is outside the compact speculative "
+                f"batch: rows={initial_spec_rows}, requests={num_spec_decodes}"
+            )
+        # The graph-unsafe fallback must preserve the same first-step state
+        # selector as graph replay. Clone only for a handoff batch so ordinary
+        # eager decode keeps the allocation-free shared metadata path.
+        accepted_tokens_int32 = accepted_tokens_int32.clone()
+        if initial_spec_rows == tuple(range(num_spec_decodes)):
+            accepted_tokens_int32[:num_spec_decodes].fill_(1)
+        else:
+            row_indices = torch.tensor(
+                initial_spec_rows,
+                dtype=torch.long,
+                device=accepted_tokens_int32.device,
+            )
+            accepted_tokens_int32.index_fill_(0, row_indices, 1)
+
+    forward_context._dcut_gdn_eager_spec_state = {
+        "query_start_loc": query_start_loc,
+        "num_accepted_tokens": accepted_tokens_int32,
+    }
+    return True
+
+
+def _dcut_gdn_piecewise_spec_key(forward_context, prefix, num_tokens):
+    """Return a prefix lookup key that does not alias model instances."""
+    model_instance = getattr(forward_context, "model_instance", None)
+    return (
+        id(model_instance),
+        prefix,
+        num_tokens,
+        "v023_piecewise_spec_ssi",
+    )
+
+
+def _dcut_gdn_piecewise_shared_key(forward_context, num_tokens):
+    """Return the key for batch metadata shared by all GDN graph segments."""
+    model_instance = getattr(forward_context, "model_instance", None)
+    return (
+        id(model_instance),
+        num_tokens,
+        "v023_piecewise_spec_shared",
+    )
+
+
+def _dcut_alloc_gdn_piecewise_spec_bufs(
+    forward_context,
+    prefixes,
+    num_tokens,
+    state_indices,
+    max_num_seqs,
+):
+    """Allocate fixed-shape inputs consumed by a PIECEWISE GDN graph.
+
+    PIECEWISE ACLGraph keys contain the padded token count, but not the live
+    number of speculative requests, so its caller uses the scheduler request
+    capacity. Ragged FULL uses the maximum request count reachable by that token
+    bucket. In both modes, the capacity is fixed for every graph of a given
+    token size so different live request compositions can safely replay it.
+    Batch-level inputs are shared across GDN layers. Prefixes backed by one
+    attention metadata object also share state indices; separate metadata
+    groups keep separate state-index buffers.
+    """
+    if state_indices.ndim != 2:
+        raise RuntimeError(
+            "D-Cut PIECEWISE GDN requires 2-D per-request state indices, "
+            f"got shape={tuple(state_indices.shape)}"
+        )
+
+    if not prefixes:
+        raise RuntimeError(
+            "D-Cut PIECEWISE GDN buffer group has no layer prefixes"
+        )
+
+    layer_keys = [
+        _dcut_gdn_piecewise_spec_key(
+            forward_context, prefix, num_tokens
+        )
+        for prefix in prefixes
+    ]
+    state_index_stride = state_indices.shape[1]
+    expected_shape = (max_num_seqs, state_index_stride)
+    existing_bufs = [
+        _dcut_gdn_static[key]
+        for key in layer_keys
+        if key in _dcut_gdn_static
+    ]
+    bufs = existing_bufs[0] if existing_bufs else None
+    if bufs is not None:
+        if any(existing is not bufs for existing in existing_bufs[1:]):
+            raise RuntimeError(
+                "D-Cut PIECEWISE GDN prefixes resolved to different "
+                f"state-index buffers: prefixes={tuple(prefixes)}"
+            )
+        if tuple(bufs["ssi"].shape) != expected_shape:
+            raise RuntimeError(
+                "D-Cut PIECEWISE GDN buffer shape changed for an existing "
+                f"graph key: expected={expected_shape}, "
+                f"actual={tuple(bufs['ssi'].shape)}"
+            )
+        for key in layer_keys:
+            _dcut_gdn_static[key] = bufs
+        return bufs
+
+    shared_key = _dcut_gdn_piecewise_shared_key(
+        forward_context, num_tokens
+    )
+    shared_bufs = _dcut_gdn_static.get(shared_key)
+    if shared_bufs is None:
+        device = state_indices.device
+        shared_bufs = {
+            "qsl": torch.zeros(
+                max_num_seqs + 1, dtype=torch.int32, device=device
+            ),
+            "nat": torch.zeros(
+                max_num_seqs, dtype=torch.int32, device=device
+            ),
+        }
+        _dcut_gdn_static[shared_key] = shared_bufs
+        logger.info(
+            "D-Cut: allocated shared v0.23 PIECEWISE GDN buffers "
+            "num_tokens=%d max_num_seqs=%d",
+            num_tokens,
+            max_num_seqs,
+        )
+    elif tuple(shared_bufs["qsl"].shape) != (max_num_seqs + 1,):
+        raise RuntimeError(
+            "D-Cut PIECEWISE GDN shared buffer shape changed for an "
+            f"existing graph key: expected={(max_num_seqs + 1,)}, "
+            f"actual={tuple(shared_bufs['qsl'].shape)}"
+        )
+
+    bufs = {
+        **shared_bufs,
+        "ssi": torch.full(
+            expected_shape,
+            PAD_SLOT_ID,
+            dtype=torch.int32,
+            device=state_indices.device,
+        ),
+    }
+    for key in layer_keys:
+        _dcut_gdn_static[key] = bufs
+    logger.info(
+        "D-Cut: allocated metadata-group v0.23 PIECEWISE GDN state "
+        "indices group_prefix=%s group_layers=%d num_tokens=%d "
+        "max_num_seqs=%d stride=%d",
+        prefixes[0],
+        len(prefixes),
+        num_tokens,
+        max_num_seqs,
+        state_index_stride,
+    )
+    return bufs
+
+
+def _dcut_fill_gdn_piecewise_spec_bufs(
+    forward_context,
+    prefixes,
+    num_tokens,
+    meta,
+    max_num_seqs,
+    *,
+    fill_shared_batch,
+    clear_unused_rows,
+    initial_spec_rows=(),
+):
+    """Refresh shared batch inputs once and layer-local state indices."""
+    num_spec_decodes = int(meta.num_spec_decodes)
+    if num_spec_decodes <= 0 or num_spec_decodes > max_num_seqs:
+        raise RuntimeError(
+            "D-Cut PIECEWISE GDN speculative request count is outside "
+            f"the configured capacity: requests={num_spec_decodes}, "
+            f"capacity={max_num_seqs}"
+        )
+
+    spec_decode_metadata = meta.spec_decode_metadata
+    conv_meta = spec_decode_metadata.spec_causal_conv1d
+    state_indices = meta.spec_state_indices_tensor
+    if state_indices is None:
+        raise RuntimeError(
+            "D-Cut PIECEWISE GDN is missing spec_state_indices_tensor"
+        )
+
+    bufs = _dcut_alloc_gdn_piecewise_spec_bufs(
+        forward_context,
+        prefixes,
+        num_tokens,
+        state_indices,
+        max_num_seqs,
+    )
+
+    if fill_shared_batch:
+        qsl = bufs["qsl"]
+        if clear_unused_rows:
+            # FULL replay reuses these addresses across unrelated request
+            # lifetimes. Rebuild the complete fixed-capacity buffer before
+            # publishing the active prefix, so neither a shrinking batch nor
+            # an interrupted prior update can leave a valid-looking boundary.
+            terminal = conv_meta.query_start_loc[
+                num_spec_decodes : num_spec_decodes + 1
+            ]
+            qsl.copy_(terminal.expand_as(qsl), non_blocking=True)
+        qsl[: num_spec_decodes + 1].copy_(
+            conv_meta.query_start_loc[: num_spec_decodes + 1],
+            non_blocking=True,
+        )
+        if not clear_unused_rows:
+            qsl_tail = qsl[num_spec_decodes + 1 :]
+            if qsl_tail.numel() > 0:
+                qsl_tail.copy_(
+                    qsl[num_spec_decodes].expand_as(qsl_tail),
+                    non_blocking=True,
+                )
+
+        nat = bufs["nat"]
+        if clear_unused_rows:
+            # One is vLLM's valid default state position. Inactive rows have a
+            # zero-length QSL segment, but initializing NAT as well makes the
+            # fixed graph input deterministic before the active copy.
+            nat.fill_(1)
+        accepted_tokens = conv_meta.num_accepted_tokens[:num_spec_decodes]
+        if accepted_tokens.dtype != torch.int32:
+            accepted_tokens = accepted_tokens.to(torch.int32)
+        # This selects the state produced by the *previous* verifier step. Its
+        # position is independent of the number of tokens retained by D-Cut for
+        # the current step. Clamping it to the current segment length makes a
+        # shrinking verifier read an older conv/recurrent state than eager mode.
+        nat[:num_spec_decodes].copy_(
+            accepted_tokens,
+            non_blocking=True,
+        )
+        # A zero-draft KV handoff is the consumer's first verifier step. Its
+        # transferred state is h(N - 1), so the state selector must be one.
+        # FULL replay reuses fixed metadata addresses across request lifetimes;
+        # normalize only these explicit first-step rows so a recycled batch
+        # slot cannot select an accepted-token offset from the previous request.
+        initial_spec_rows = tuple(int(row) for row in initial_spec_rows)
+        if initial_spec_rows:
+            if any(
+                row < 0 or row >= num_spec_decodes
+                for row in initial_spec_rows
+            ):
+                raise RuntimeError(
+                    "D-Cut initial handoff row is outside the compact "
+                    f"speculative batch: rows={initial_spec_rows}, "
+                    f"requests={num_spec_decodes}"
+                )
+            if initial_spec_rows == tuple(range(num_spec_decodes)):
+                nat[:num_spec_decodes].fill_(1)
+            else:
+                row_key = (
+                    id(getattr(forward_context, "model_instance", None)),
+                    num_tokens,
+                    initial_spec_rows,
+                    "v023_initial_spec_rows",
+                )
+                row_indices = _dcut_gdn_static.get(row_key)
+                if row_indices is None:
+                    row_indices = torch.tensor(
+                        initial_spec_rows,
+                        dtype=torch.long,
+                        device=nat.device,
+                    )
+                    _dcut_gdn_static[row_key] = row_indices
+                nat.index_fill_(0, row_indices, 1)
+
+    ssi = bufs["ssi"]
+    if clear_unused_rows:
+        # Reinitialize the complete request axis. The custom Conv1D operator
+        # rejects PAD_SLOT_ID, while the recurrent operator skips the matching
+        # zero-length QSL rows before reading SSI.
+        ssi.fill_(PAD_SLOT_ID)
+    ssi[:num_spec_decodes].copy_(
+        state_indices[:num_spec_decodes],
+        non_blocking=True,
+    )
+    return bufs
+
+
+def _dcut_graph_capture_qsl(
+    num_tokens: int,
+    spec_query_len: int,
+    max_num_seqs: int,
+) -> tuple[int, ...]:
+    """Build a synthetic pure-spec layout for one graph token bucket."""
+    if num_tokens <= 0 or spec_query_len <= 0 or max_num_seqs <= 0:
+        return ()
+    num_spec_decodes = (
+        num_tokens + spec_query_len - 1
+    ) // spec_query_len
+    if num_spec_decodes > max_num_seqs:
+        return ()
+    return tuple(
+        min(row * spec_query_len, num_tokens)
+        for row in range(num_spec_decodes + 1)
+    )
+
+
+def _dcut_prepare_gdn_graph_capture(
+    forward_context,
+    num_tokens,
+    GDNAttentionMetadata,
+    max_num_seqs,
+    spec_query_len,
+):
+    """Prepare fixed GDN inputs while vLLM captures a non-uniform graph key.
+
+    PIECEWISE deliberately reuses one key for mixed and uniform batches, while
+    ragged FULL fixes request capacity independently of the live batch size.
+    Their stock dummy metadata therefore need not describe the pure-spec batch
+    that D-Cut later replays. Build only the GDN inputs as a synthetic
+    pure-spec batch; attention and the rest of the model retain stock capture
+    metadata.
+    """
+    capture_qsl = _dcut_graph_capture_qsl(
+        int(num_tokens),
+        int(spec_query_len),
+        int(max_num_seqs),
+    )
+    if not capture_qsl:
+        return False
+    num_spec_decodes = len(capture_qsl) - 1
+
+    attn_metadata = getattr(forward_context, "attn_metadata", None)
+    if not isinstance(attn_metadata, dict):
+        return False
+
+    gdn_items = [
+        (prefix, meta)
+        for prefix, meta in attn_metadata.items()
+        if isinstance(meta, GDNAttentionMetadata)
+    ]
+    if not gdn_items:
+        return False
+
+    metadata_groups = {}
+    for prefix, meta in gdn_items:
+        group = metadata_groups.setdefault(
+            id(meta), {"meta": meta, "prefixes": []}
+        )
+        group["prefixes"].append(prefix)
+
+    for group in metadata_groups.values():
+        meta = group["meta"]
+        spec_indices = getattr(meta, "spec_state_indices_tensor", None)
+        non_spec_indices = getattr(
+            meta, "non_spec_state_indices_tensor", None
+        )
+        state_indices = None
+        if (
+            spec_indices is not None
+            and spec_indices.ndim == 2
+            and int(spec_indices.shape[0]) >= num_spec_decodes
+            and int(spec_indices.shape[1]) >= spec_query_len
+        ):
+            state_indices = spec_indices[:, :spec_query_len]
+        elif (
+            non_spec_indices is not None
+            and non_spec_indices.ndim == 1
+            and int(non_spec_indices.shape[0]) >= num_spec_decodes
+        ):
+            # Stock mixed PIECEWISE dummy metadata exposes one state slot per
+            # request. The real speculative path exposes num_spec + 1 slots.
+            # Repeat the valid dummy slot only to establish the captured
+            # tensor geometry; runtime replay overwrites all active rows with
+            # the real speculative state-index matrix.
+            state_indices = non_spec_indices.unsqueeze(1).expand(
+                -1, spec_query_len
+            )
+        elif (
+            non_spec_indices is not None
+            and non_spec_indices.ndim == 2
+            and int(non_spec_indices.shape[0]) >= num_spec_decodes
+        ):
+            if int(non_spec_indices.shape[1]) == spec_query_len:
+                state_indices = non_spec_indices
+            elif int(non_spec_indices.shape[1]) == 1:
+                state_indices = non_spec_indices.expand(
+                    -1, spec_query_len
+                )
+        if state_indices is None:
+            return False
+        group["state_indices"] = state_indices
+
+    claimed_buffer_ids = set()
+    for group in metadata_groups.values():
+        existing_buffer_ids = set()
+        for prefix in group["prefixes"]:
+            key = _dcut_gdn_piecewise_spec_key(
+                forward_context, prefix, num_tokens
+            )
+            if key in _dcut_gdn_static:
+                existing_buffer_ids.add(id(_dcut_gdn_static[key]))
+        if (
+            len(existing_buffer_ids) > 1
+            or not claimed_buffer_ids.isdisjoint(existing_buffer_ids)
+        ):
+            return False
+        claimed_buffer_ids.update(existing_buffer_ids)
+
+    for index, group in enumerate(metadata_groups.values()):
+        state_indices = group["state_indices"]
+        bufs = _dcut_alloc_gdn_piecewise_spec_bufs(
+            forward_context,
+            tuple(group["prefixes"]),
+            num_tokens,
+            state_indices,
+            max_num_seqs,
+        )
+        if index == 0:
+            qsl = bufs["qsl"]
+            qsl.fill_(num_tokens)
+            qsl[: num_spec_decodes + 1].copy_(
+                torch.tensor(
+                    capture_qsl,
+                    dtype=torch.int32,
+                    device=qsl.device,
+                ),
+                non_blocking=True,
+            )
+            bufs["nat"].fill_(1)
+
+        ssi = bufs["ssi"]
+        ssi.fill_(PAD_SLOT_ID)
+        ssi[:num_spec_decodes].copy_(
+            state_indices[:num_spec_decodes],
+            non_blocking=True,
+        )
+    return True
+
+
+def _dcut_prepare_gdn_piecewise_replay(
+    forward_context,
+    num_tokens,
+    GDNAttentionMetadata,
+    max_num_seqs,
+    *,
+    clear_unused_rows=False,
+    initial_spec_rows=(),
+):
+    """Prepare fixed pure-spec GDN metadata, or reject it safely.
+
+    The GDN custom op chooses prefill/decode/spec branches from Python
+    metadata that is not part of the compiled graph signature. Only a pure
+    speculative batch may enter the expanded graph. Other compositions retain
+    the whole-core eager boundary while outer PIECEWISE stays active.
+    """
+    attn_metadata = getattr(forward_context, "attn_metadata", None)
+    if not isinstance(attn_metadata, dict):
+        return False
+
+    gdn_items = [
+        (prefix, meta)
+        for prefix, meta in attn_metadata.items()
+        if isinstance(meta, GDNAttentionMetadata)
+    ]
+    if not gdn_items:
+        return False
+
+    # vLLM assigns the same metadata object to every layer prefix in one
+    # attention group. Group by identity so QSL/NAT/SSI are refreshed once per
+    # group while hybrid-cache groups remain independent.
+    metadata_groups = {}
+    for prefix, meta in gdn_items:
+        group = metadata_groups.setdefault(
+            id(meta), {"meta": meta, "prefixes": []}
+        )
+        group["prefixes"].append(prefix)
+
+    for group in metadata_groups.values():
+        meta = group["meta"]
+        if (
+            meta.spec_sequence_masks is None
+            or int(meta.num_spec_decodes) <= 0
+            or int(meta.num_prefills) != 0
+            or int(meta.num_decodes) != 0
+            or meta.spec_decode_metadata is None
+        ):
+            return False
+        state_indices = meta.spec_state_indices_tensor
+        if (
+            state_indices is None
+            or state_indices.ndim != 2
+            or int(meta.num_spec_decodes) > max_num_seqs
+        ):
+            return False
+
+    # A captured prefix must keep the same alias topology. Reject a runtime
+    # attention-group change instead of overwriting a buffer captured for a
+    # different metadata group.
+    claimed_buffer_ids = set()
+    for group in metadata_groups.values():
+        existing_buffer_ids = set()
+        for prefix in group["prefixes"]:
+            key = _dcut_gdn_piecewise_spec_key(
+                forward_context, prefix, num_tokens
+            )
+            if key in _dcut_gdn_static:
+                existing_buffer_ids.add(id(_dcut_gdn_static[key]))
+        if (
+            len(existing_buffer_ids) > 1
+            or not claimed_buffer_ids.isdisjoint(existing_buffer_ids)
+        ):
+            return False
+        claimed_buffer_ids.update(existing_buffer_ids)
+
+    for index, group in enumerate(metadata_groups.values()):
+        _dcut_fill_gdn_piecewise_spec_bufs(
+            forward_context,
+            tuple(group["prefixes"]),
+            num_tokens,
+            group["meta"],
+            max_num_seqs,
+            fill_shared_batch=index == 0,
+            clear_unused_rows=clear_unused_rows,
+            initial_spec_rows=initial_spec_rows,
+        )
+    return True
+
+
+def _dcut_get_gdn_piecewise_spec_bufs(
+    forward_context,
+    prefix,
+    num_tokens,
+):
+    """Get buffers already prepared by the graph-external runner hook."""
+    key = _dcut_gdn_piecewise_spec_key(
+        forward_context, prefix, num_tokens
+    )
+    try:
+        return _dcut_gdn_static[key]
+    except KeyError as exc:
+        raise RuntimeError(
+            "D-Cut PIECEWISE GDN buffers were not prepared before capture: "
+            f"prefix={prefix}, num_tokens={num_tokens}"
+        ) from exc

--- a/dcut/gdn_eager.py
+++ b/dcut/gdn_eager.py
@@ -1,0 +1,96 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Per-request conv1d fallback for variable query_len spec-decode."""
+from __future__ import annotations
+
+import torch
+from torch.nn import functional as _F
+
+# === GDN D-Cut monkeypatch additions ===
+# Appended to monkeypatch.py. These changes were previously applied directly
+# to /vllm-workspace/vllm-ascend/vllm_ascend/ops/gdn.py in vllm_dcut.
+# Moved here so vllm-ascend stays at vllm_src baseline.
+#
+# Changes:
+# 1. _conv1d_spec_varlen_eager — per-request F.conv1d fallback for variable
+#    query_len (D-Cut truncation on hybrid Mamba/GDN)
+# 2. _patch_gdn_dcut — patches AscendGatedDeltaNetAttention._forward_core to:
+#    a. Use _conv1d_spec_varlen_eager in the spec Conv1D eager path
+#    b. Align ssm_state_indices with actual token positions (boolean mask)
+#    c. Clamp num_accepted_tokens to actual seq lengths
+
+from torch.nn import functional as _F
+
+
+def _conv1d_spec_varlen_eager(
+    output_spec,
+    mixed_qkv_spec,
+    conv_weights,
+    conv_state,
+    bias,
+    activation,
+    num_spec,
+    spec_query_start_loc,
+    spec_state_indices_tensor,
+    num_accepted_tokens,
+    num_spec_decodes,
+):
+    """Per-request conv1d for variable query_len spec-decode (D-Cut).
+
+    When D-Cut truncates draft tokens, spec-decode requests have variable
+    query_len.  The CANN operator npu_causal_conv1d_custom with run_mode=1
+    requires uniform q_per_seq = num_spec + 1 and crashes on variable-length
+    input.  This fallback processes each request independently using F.conv1d
+    and updates the conv_state following the kernel's spec-decode state-update
+    semantics (shift=1, offset from num_accepted_tokens).
+
+    conv_state layout is SD: (num_cache_lines, state_len, dim).
+    """
+    from vllm.v1.attention.backends.utils import PAD_SLOT_ID
+
+    width = conv_weights.size(1)  # conv_kernel_size
+    state_len = width - 1 + num_spec  # conv_kernel_size - 1 + num_spec
+    dim = conv_weights.size(0)
+    # Depthwise conv weight: (dim, 1, width)
+    dw_weight = conv_weights.unsqueeze(1)
+
+    spec_total = mixed_qkv_spec.size(0)
+    out_total = output_spec.size(0)
+    for b in range(num_spec_decodes):
+        qs = int(spec_query_start_loc[b])
+        qe = int(spec_query_start_loc[b + 1])
+        # Clamp to actual tensor size — D-Cut RANDOM_CUT may trim tokens,
+        # making spec_query_start_loc offsets exceed the tensor length.
+        qe = min(qe, spec_total, out_total)
+        ql = qe - qs
+        ci = int(spec_state_indices_tensor[b, 0])
+        nat_b = min(int(num_accepted_tokens[b]), ql)
+
+        if ci == PAD_SLOT_ID or ql <= 0:
+            continue
+
+        offset = nat_b - 1  # conv_state_token_offset in kernel
+
+        # --- Conv1d computation ---
+        initial_state = conv_state[ci, offset:offset + width - 1, :].t()
+        x_b = mixed_qkv_spec[qs:qe].t()
+        x_concat = torch.cat([initial_state, x_b], dim=1)
+        out = _F.conv1d(
+            x_concat.unsqueeze(0),
+            dw_weight,
+            bias,
+            padding=0,
+            groups=dim,
+        )
+
+        if activation:
+            out = _F.silu(out)
+
+        output_spec[qs:qe] = out.squeeze(0).t()
+
+        # --- Conv-state update (kernel spec-decode semantics) ---
+        state_len_run = width - 2 + ql
+        keep = state_len_run - ql  # = width - 2
+        old_state = conv_state[ci, offset:offset + state_len_run, :].clone()
+        if keep > 0:
+            conv_state[ci, 0:keep, :] = old_state[1:1 + keep, :]
+        conv_state[ci, keep:keep + ql, :] = x_b.t()

--- a/dcut/gdn_forward_v023.py
+++ b/dcut/gdn_forward_v023.py
@@ -1,0 +1,735 @@
+#
+# Copyright (c) 2025 Huawei Technologies Co., Ltd. All Rights Reserved.
+# This file is a part of the vllm-ascend project.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import torch
+from einops import rearrange
+from vllm.distributed import get_pcp_group
+from vllm.forward_context import get_forward_context
+from vllm.model_executor.layers.fla.ops.l2norm import l2norm_fwd
+from vllm.model_executor.layers.mamba.gdn.base import GatedDeltaNetAttention
+from vllm.model_executor.layers.mamba.mamba_utils import MambaStateShapeCalculator
+from vllm.triton_utils import triton
+from vllm.utils.torch_utils import direct_register_custom_op
+from vllm.v1.attention.backend import AttentionBackend, AttentionMetadata  # type: ignore
+from vllm.v1.attention.backends.gdn_attn import GDNAttentionMetadata
+from vllm.v1.attention.backends.utils import PAD_SLOT_ID
+
+from vllm_ascend.attention.utils import maybe_save_kv_layer_to_connector
+from vllm_ascend.device.device_op import DeviceOperator
+from vllm_ascend.ops.gdn_attn_builder import AscendGDNAttentionBackend
+from vllm_ascend.ops.triton.fla.chunk import chunk_gated_delta_rule
+from vllm_ascend.ops.triton.fla.fused_qkvzba_split_reshape import fused_qkvzba_split_reshape_cat
+from vllm_ascend.ops.triton.fla.utils import clear_ssm_states
+from vllm_ascend.ops.triton.mamba.causal_conv1d import extract_last_width
+
+from .gdn_buffers import _dcut_get_gdn_piecewise_spec_bufs
+
+
+DCUT_PAD_SLOT_ID = -1
+
+
+def dcut_gdn_recurrent(
+    query: torch.Tensor,
+    key: torch.Tensor,
+    value: torch.Tensor,
+    g: torch.Tensor,
+    beta: torch.Tensor,
+    state: torch.Tensor,
+    scale: float,
+    query_start_loc: torch.Tensor,
+    ssm_state_indices: torch.Tensor,
+    num_accepted_tokens: torch.Tensor,
+    zero_padded_output: bool,
+) -> torch.Tensor:
+    """Graph-visible stateful GDN op used by the pure-spec PIECEWISE core."""
+    return torch.ops._C_ascend.npu_dcut_recurrent_gated_delta_rule(
+        query=query,
+        key=key,
+        value=value,
+        g=g,
+        beta=beta,
+        state=state,
+        scale=scale,
+        query_start_loc=query_start_loc,
+        ssm_state_indices=ssm_state_indices,
+        num_accepted_tokens=num_accepted_tokens,
+        zero_padded_output=zero_padded_output,
+    )
+
+
+def dcut_gdn_recurrent_fake(
+    query: torch.Tensor,
+    key: torch.Tensor,
+    value: torch.Tensor,
+    g: torch.Tensor,
+    beta: torch.Tensor,
+    state: torch.Tensor,
+    scale: float,
+    query_start_loc: torch.Tensor,
+    ssm_state_indices: torch.Tensor,
+    num_accepted_tokens: torch.Tensor,
+    zero_padded_output: bool,
+) -> torch.Tensor:
+    """Fake implementation used while Dynamo traces the surrounding core."""
+    del query, key, g, beta, state, scale
+    del query_start_loc, ssm_state_indices, num_accepted_tokens
+    del zero_padded_output
+    return torch.empty_like(value, dtype=torch.bfloat16)
+
+
+direct_register_custom_op(
+    op_name="dcut_gdn_recurrent",
+    op_func=dcut_gdn_recurrent,
+    mutates_args=["state"],
+    fake_impl=dcut_gdn_recurrent_fake,
+)
+
+
+def _run_spec_causal_conv1d(
+    output: torch.Tensor,
+    x: torch.Tensor,
+    weight: torch.Tensor,
+    conv_state: torch.Tensor,
+    bias: torch.Tensor | None,
+    query_start_loc: torch.Tensor,
+    cache_indices: torch.Tensor,
+    num_accepted_tokens: torch.Tensor,
+    activation_mode: int,
+) -> None:
+    """Read the previous conv window independently of this round's length."""
+    torch.ops._C_ascend.npu_dcut_causal_conv1d(
+        output=output,
+        x=x,
+        weight=weight,
+        conv_state=conv_state,
+        bias=bias,
+        query_start_loc=query_start_loc,
+        cache_indices=cache_indices,
+        num_accepted_tokens=num_accepted_tokens,
+        activation_mode=activation_mode,
+        pad_slot_id=DCUT_PAD_SLOT_ID,
+    )
+
+
+class AscendGatedDeltaNetAttention(GatedDeltaNetAttention):
+    def _split_ba_for_tp(self, ba: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
+        if hasattr(self, "split_ba"):
+            return self.split_ba(ba)
+        return ba.chunk(2, dim=-1)
+
+    def get_state_shape(
+        self,
+    ) -> tuple[tuple[int, ...], tuple[int, ...], tuple[int, ...], tuple[int, ...]]:
+        return MambaStateShapeCalculator.gated_delta_net_state_shape(
+            self.tp_size,
+            self.num_k_heads,
+            self.num_v_heads,
+            self.head_k_dim,
+            self.head_v_dim,
+            self.conv_kernel_size,
+            self.num_spec,
+        )
+
+    def _warmup_prefill_kernels(self, qkv_or_qkvz: torch.Tensor, v_dim: int) -> None:
+        return
+
+    def _warmup_prefill_kernels_v0202(self, mixed_qkv: torch.Tensor) -> None:
+        return
+
+    def get_attn_backend(self) -> type[AttentionBackend]:
+        return AscendGDNAttentionBackend
+
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+        output: torch.Tensor,
+    ):
+        """
+        Forward pass with three parts:
+        1. Input projection
+        2. Core attention (custom op)
+        3. Output projection
+        """
+        num_tokens = hidden_states.size(0)
+        if hasattr(self, "in_proj_qkv"):
+            mixed_qkv, _ = self.in_proj_qkv(hidden_states)
+            ba, _ = self.in_proj_ba(hidden_states)
+            z, _ = self.in_proj_z(hidden_states)
+            z = z.reshape(z.size(0), -1, self.head_v_dim)
+            b, a = self._split_ba_for_tp(ba)
+            b = b.contiguous()
+            a = a.contiguous()
+        else:
+            if not self.gqa_interleaved_layout:
+                mixed_qkvz, _ = self.in_proj_qkvz(hidden_states)
+                num_tokens = mixed_qkvz.size(0)
+                qkv_size = (self.key_dim * 2 + self.value_dim) // self.tp_size
+                z_size = self.value_dim // self.tp_size
+                mixed_qkv, z = mixed_qkvz.split([qkv_size, z_size], dim=-1)
+                z = z.reshape(z.size(0), -1, self.head_v_dim)
+                ba, _ = self.in_proj_ba(hidden_states)
+                b, a = self._split_ba_for_tp(ba)
+
+                b = b.contiguous()
+                a = a.contiguous()
+            else:
+                projected_states_qkvz, _ = self.in_proj_qkvz(hidden_states)
+                projected_states_ba, _ = self.in_proj_ba(hidden_states)
+                num_tokens = projected_states_qkvz.size(0)
+
+                mixed_qkv, z, b, a = fused_qkvzba_split_reshape_cat(
+                    projected_states_qkvz,
+                    projected_states_ba,
+                    triton.cdiv(self.num_k_heads, self.tp_size),
+                    triton.cdiv(self.num_v_heads, self.tp_size),
+                    self.head_k_dim,
+                    self.head_v_dim,
+                )
+
+        # ============================================================
+        # Part 2: Core Attention (Custom Op)
+        # ============================================================
+        # Note: we should not use torch.empty here like other attention backends,
+        # see discussions in https://github.com/vllm-project/vllm/pull/28182
+        core_attn_out = torch.zeros(
+            (num_tokens, self.num_v_heads // self.tp_size, self.head_v_dim),
+            dtype=hidden_states.dtype,
+            device=hidden_states.device,
+        )
+
+        torch.ops.vllm.qwen_gdn_attention_core(
+            mixed_qkv,
+            b,
+            a,
+            core_attn_out,
+            self.prefix,
+            False,
+        )
+
+        # ============================================================
+        # Part 3: Output Projection
+        # ============================================================
+        maybe_save_kv_layer_to_connector("", [])
+        z_shape_og = z.shape
+        # Reshape input data into 2D tensor
+        core_attn_out = core_attn_out.reshape(-1, core_attn_out.shape[-1])
+        z = z.reshape(-1, z.shape[-1])
+        core_attn_out = self.norm(core_attn_out, z)
+        core_attn_out = core_attn_out.reshape(z_shape_og)
+        core_attn_out = rearrange(core_attn_out, "... h d -> ... (h d)")
+        output[:num_tokens], _ = self.out_proj(core_attn_out)
+
+    def forward_with_graphable_recurrent(
+        self,
+        hidden_states: torch.Tensor,
+        output: torch.Tensor,
+    ):
+        """Run pure-spec GDN without the opaque whole-core custom op."""
+        num_tokens = hidden_states.size(0)
+        if hasattr(self, "in_proj_qkv"):
+            mixed_qkv, _ = self.in_proj_qkv(hidden_states)
+            ba, _ = self.in_proj_ba(hidden_states)
+            z, _ = self.in_proj_z(hidden_states)
+            z = z.reshape(z.size(0), -1, self.head_v_dim)
+            b, a = AscendGatedDeltaNetAttention._split_ba_for_tp(self, ba)
+            b = b.contiguous()
+            a = a.contiguous()
+        elif not self.gqa_interleaved_layout:
+            mixed_qkvz, _ = self.in_proj_qkvz(hidden_states)
+            num_tokens = mixed_qkvz.size(0)
+            qkv_size = (self.key_dim * 2 + self.value_dim) // self.tp_size
+            z_size = self.value_dim // self.tp_size
+            mixed_qkv, z = mixed_qkvz.split([qkv_size, z_size], dim=-1)
+            z = z.reshape(z.size(0), -1, self.head_v_dim)
+            ba, _ = self.in_proj_ba(hidden_states)
+            b, a = AscendGatedDeltaNetAttention._split_ba_for_tp(self, ba)
+            b = b.contiguous()
+            a = a.contiguous()
+        else:
+            projected_states_qkvz, _ = self.in_proj_qkvz(hidden_states)
+            projected_states_ba, _ = self.in_proj_ba(hidden_states)
+            num_tokens = projected_states_qkvz.size(0)
+            mixed_qkv, z, b, a = fused_qkvzba_split_reshape_cat(
+                projected_states_qkvz,
+                projected_states_ba,
+                triton.cdiv(self.num_k_heads, self.tp_size),
+                triton.cdiv(self.num_v_heads, self.tp_size),
+                self.head_k_dim,
+                self.head_v_dim,
+            )
+
+        core_attn_out = torch.zeros(
+            (num_tokens, self.num_v_heads // self.tp_size, self.head_v_dim),
+            dtype=hidden_states.dtype,
+            device=hidden_states.device,
+        )
+        forward_context = get_forward_context()
+        piecewise_spec_bufs = _dcut_get_gdn_piecewise_spec_bufs(
+            forward_context,
+            self.prefix,
+            num_tokens,
+        )
+        AscendGatedDeltaNetAttention._forward_core_impl(
+            self,
+            mixed_qkv,
+            b,
+            a,
+            core_attn_out,
+            piecewise_spec_bufs,
+            True,
+        )
+
+        maybe_save_kv_layer_to_connector("", [])
+        z_shape_og = z.shape
+        core_attn_out = core_attn_out.reshape(-1, core_attn_out.shape[-1])
+        z = z.reshape(-1, z.shape[-1])
+        core_attn_out = self.norm(core_attn_out, z)
+        core_attn_out = core_attn_out.reshape(z_shape_og)
+        core_attn_out = rearrange(core_attn_out, "... h d -> ... (h d)")
+        output[:num_tokens], _ = self.out_proj(core_attn_out)
+
+    def _forward_core(
+        self,
+        mixed_qkv: torch.Tensor,
+        b: torch.Tensor,
+        a: torch.Tensor,
+        core_attn_out: torch.Tensor,
+    ):
+        """Route native GDN batches and ragged FULL capture safely."""
+        forward_context = get_forward_context()
+        if getattr(
+            forward_context,
+            "_dcut_gdn_full_graph_safe",
+            False,
+        ):
+            full_graph_spec_bufs = _dcut_get_gdn_piecewise_spec_bufs(
+                forward_context,
+                self.prefix,
+                mixed_qkv.shape[0],
+            )
+            # Execute the implementation directly while the outer FULL graph
+            # is captured. Replay then consumes the same fixed-address qsl,
+            # accepted-token and state-index buffers refreshed by the runner.
+            return AscendGatedDeltaNetAttention._forward_core_impl(
+                self,
+                mixed_qkv,
+                b,
+                a,
+                core_attn_out,
+                full_graph_spec_bufs,
+            )
+
+
+        return AscendGatedDeltaNetAttention._forward_core_impl(
+            self,
+            mixed_qkv,
+            b,
+            a,
+            core_attn_out,
+            None,
+        )
+
+    def _forward_core_impl(
+        self,
+        mixed_qkv: torch.Tensor,
+        b: torch.Tensor,
+        a: torch.Tensor,
+        core_attn_out: torch.Tensor,
+        piecewise_spec_bufs,
+        use_graphable_recurrent: bool = False,
+    ):
+        """
+        Core attention computation (called by custom op).
+        """
+        forward_context = get_forward_context()
+        attn_metadata: AttentionMetadata = forward_context.attn_metadata
+
+        if attn_metadata is None:
+            # V1 profile run
+            return
+
+        assert isinstance(attn_metadata, dict)
+        attn_metadata = attn_metadata[self.prefix]
+        assert isinstance(attn_metadata, GDNAttentionMetadata)
+        eager_spec_state = (
+            getattr(
+                forward_context,
+                "_dcut_gdn_eager_spec_state",
+                None,
+            )
+            if piecewise_spec_bufs is None
+            else None
+        )
+        pure_piecewise_spec = piecewise_spec_bufs is not None
+        spec_sequence_masks = (
+            piecewise_spec_bufs
+            if pure_piecewise_spec
+            else attn_metadata.spec_sequence_masks
+        )
+        num_prefills = (
+            0 if pure_piecewise_spec else int(attn_metadata.num_prefills)
+        )
+        num_decodes = (
+            0 if pure_piecewise_spec else int(attn_metadata.num_decodes)
+        )
+        spec_token_indx = attn_metadata.spec_token_indx
+        non_spec_token_indx = attn_metadata.non_spec_token_indx
+        spec_state_indices_tensor = attn_metadata.spec_state_indices_tensor  # noqa: E501
+        non_spec_state_indices_tensor = attn_metadata.non_spec_state_indices_tensor  # noqa: E501
+        if pure_piecewise_spec:
+            spec_state_indices_tensor = piecewise_spec_bufs["ssi"]
+        self_kv_cache = self.kv_cache
+        ssm_state = self_kv_cache[1]
+        num_actual_tokens = (
+            mixed_qkv.shape[0]
+            if piecewise_spec_bufs is not None
+            else attn_metadata.num_actual_tokens
+        )
+
+        mixed_qkv = mixed_qkv[:num_actual_tokens]
+        b = b[:num_actual_tokens]
+        a = a[:num_actual_tokens]
+
+        # 1. Convolution sequence transformation
+        conv_weights = self.conv1d.weight.view(self.conv1d.weight.size(0), self.conv1d.weight.size(2))
+        if spec_sequence_masks is not None:
+            if num_prefills == 0 and num_decodes == 0:
+                mixed_qkv_spec = mixed_qkv
+                mixed_qkv_non_spec = None
+            else:
+                mixed_qkv_spec = mixed_qkv.index_select(0, spec_token_indx)
+                mixed_qkv_non_spec = mixed_qkv.index_select(0, non_spec_token_indx)
+        else:
+            mixed_qkv_spec = None
+            mixed_qkv_non_spec = mixed_qkv
+
+        # 1.1: Process the multi-query part
+        if spec_sequence_masks is not None:
+            conv_weights_T = conv_weights.transpose(0, 1)
+            activation_num = 1 if self.activation else 0
+            spec_causal_conv1d_meta = (
+                None
+                if pure_piecewise_spec
+                else attn_metadata.spec_decode_metadata.spec_causal_conv1d
+            )
+            spec_query_start_loc_device = (
+                piecewise_spec_bufs["qsl"]
+                if piecewise_spec_bufs is not None
+                else spec_causal_conv1d_meta.query_start_loc
+            )
+            spec_cache_indices = (
+                piecewise_spec_bufs["ssi"]
+                if piecewise_spec_bufs is not None
+                else spec_causal_conv1d_meta.cache_indices
+            )
+            spec_num_accepted_tokens = (
+                piecewise_spec_bufs["nat"]
+                if piecewise_spec_bufs is not None
+                else (
+                    eager_spec_state["num_accepted_tokens"]
+                    if eager_spec_state is not None
+                    else spec_causal_conv1d_meta.num_accepted_tokens
+                )
+            )
+            output_spec = (
+                torch.zeros_like(mixed_qkv_spec)
+                if piecewise_spec_bufs is not None
+                else torch.empty_like(mixed_qkv_spec)
+            )
+            _run_spec_causal_conv1d(
+                output_spec,
+                mixed_qkv_spec,
+                conv_weights_T,
+                self_kv_cache[0],
+                self.conv1d.bias,
+                spec_query_start_loc_device,
+                spec_cache_indices,
+                spec_num_accepted_tokens,
+                activation_num,
+            )
+            mixed_qkv_spec = output_spec
+
+        # 1.2: Process the remaining part
+        if num_prefills > 0:
+            if mixed_qkv_non_spec is not None:
+                non_spec_causal_conv1d_meta = attn_metadata.non_spec_prefill_metadata.causal_conv1d
+                query_start_loc_opt = non_spec_causal_conv1d_meta.query_start_loc
+                cache_indices_opt = non_spec_causal_conv1d_meta.cache_indices
+                initial_state_mode_opt = non_spec_causal_conv1d_meta.initial_state_mode
+                if get_pcp_group().world_size > 1:
+                    conv_weights_T = conv_weights.transpose(0, 1)
+                    activation_num = 1 if self.activation else 0
+                    non_spec_query_start_loc = attn_metadata.non_spec_query_start_loc
+                    assert non_spec_query_start_loc is not None
+                    non_spec_state_indices_tensor = attn_metadata.non_spec_state_indices_tensor
+                    width = conv_weights.shape[1]
+                    state_len = width - 1
+                    num_seqs = non_spec_query_start_loc.shape[0] - 1
+                    prefill_seq_offset = max(0, num_seqs - num_prefills)
+                    prefill_cache_indices = non_spec_state_indices_tensor[prefill_seq_offset:]
+                    mixed_qkv_non_spec_T = mixed_qkv_non_spec.transpose(0, 1)
+                    last_width_prefill_x = extract_last_width(
+                        mixed_qkv_non_spec_T, non_spec_query_start_loc[prefill_seq_offset:], state_len
+                    )
+                    pcp_rank = get_pcp_group().rank_in_group
+                    all_last_width_prefill_x = get_pcp_group().all_gather(
+                        last_width_prefill_x.unsqueeze(0).contiguous(), 0
+                    )
+                    if pcp_rank > 0 and prefill_cache_indices.shape[0] > 0:
+                        self_kv_cache[0][prefill_cache_indices, :state_len, :] = all_last_width_prefill_x[
+                            pcp_rank - 1, ...
+                        ].transpose(-1, -2)
+                    mixed_qkv_non_spec_output = torch.empty_like(mixed_qkv_non_spec)
+                    torch.ops._C_ascend.npu_causal_conv1d_custom(
+                        mixed_qkv_non_spec_output,
+                        mixed_qkv_non_spec,
+                        conv_weights_T,
+                        conv_state=self_kv_cache[0],
+                        bias_opt=self.conv1d.bias,
+                        query_start_loc_opt=query_start_loc_opt,
+                        cache_indices_opt=cache_indices_opt,
+                        initial_state_mode_opt=initial_state_mode_opt,
+                        num_accepted_tokens_opt=None,
+                        activation_mode=activation_num,
+                        pad_slot_id=PAD_SLOT_ID,
+                        run_mode=0,
+                    )
+                    mixed_qkv_non_spec = mixed_qkv_non_spec_output
+                    if prefill_cache_indices.shape[0] > 0:
+                        self_kv_cache[0][prefill_cache_indices, :state_len, :] = all_last_width_prefill_x[
+                            -1, ...
+                        ].transpose(-1, -2)
+                else:
+                    conv_weights_T = conv_weights.transpose(0, 1)
+                    activation_num = 1 if self.activation else 0
+                    mixed_qkv_non_spec_output = torch.empty_like(mixed_qkv_non_spec)
+                    torch.ops._C_ascend.npu_causal_conv1d_custom(
+                        mixed_qkv_non_spec_output,
+                        mixed_qkv_non_spec,
+                        conv_weights_T,
+                        conv_state=self_kv_cache[0],
+                        bias_opt=self.conv1d.bias,
+                        query_start_loc_opt=query_start_loc_opt,
+                        cache_indices_opt=cache_indices_opt,
+                        initial_state_mode_opt=initial_state_mode_opt,
+                        num_accepted_tokens_opt=None,
+                        activation_mode=activation_num,
+                        pad_slot_id=PAD_SLOT_ID,
+                        run_mode=0,
+                    )
+                    mixed_qkv_non_spec = mixed_qkv_non_spec_output
+        elif num_decodes > 0:
+            conv_weights_T = conv_weights.transpose(0, 1)
+            activation_num = 1 if self.activation else 0
+            non_spec_causal_conv1d_meta = attn_metadata.non_spec_decode_metadata.causal_conv1d
+            non_spec_query_start_loc_device = non_spec_causal_conv1d_meta.query_start_loc
+            output_non_spec = torch.empty_like(mixed_qkv_non_spec)
+            torch.ops._C_ascend.npu_causal_conv1d_custom(
+                output_non_spec,
+                mixed_qkv_non_spec,
+                conv_weights_T,
+                conv_state=self_kv_cache[0],
+                bias_opt=self.conv1d.bias,
+                query_start_loc_opt=non_spec_query_start_loc_device,
+                cache_indices_opt=non_spec_causal_conv1d_meta.cache_indices,
+                initial_state_mode_opt=None,
+                num_accepted_tokens_opt=None,
+                activation_mode=activation_num,
+                pad_slot_id=PAD_SLOT_ID,
+                run_mode=1,
+            )
+            mixed_qkv_non_spec = output_non_spec
+        else:
+            mixed_qkv_non_spec = None
+
+        query_spec, key_spec, value_spec = self.rearrange_mixed_qkv(mixed_qkv_spec)
+        query_non_spec, key_non_spec, value_non_spec = self.rearrange_mixed_qkv(mixed_qkv_non_spec)
+
+        # 2. Recurrent attention
+        g, beta = DeviceOperator.fused_gdn_gating(self.A_log, a, b, self.dt_bias)
+        if spec_sequence_masks is not None:
+            if num_prefills == 0 and num_decodes == 0:
+                g_spec = g
+                beta_spec = beta
+                g_non_spec = None
+                beta_non_spec = None
+            else:
+                g_spec = g.index_select(1, spec_token_indx)
+                beta_spec = beta.index_select(1, spec_token_indx)
+                g_non_spec = g.index_select(1, non_spec_token_indx)
+                beta_non_spec = beta.index_select(1, non_spec_token_indx)
+        else:
+            g_spec = None
+            beta_spec = None
+            g_non_spec = g
+            beta_non_spec = beta
+
+        split_non_spec = (
+            spec_sequence_masks is None
+            and num_prefills > 0
+            and num_decodes > 0
+        )
+        num_decode_tokens = (
+            0
+            if pure_piecewise_spec
+            else int(attn_metadata.num_decode_tokens)
+        )
+
+        # 2.1: Process the multi-query part
+        if spec_sequence_masks is not None:
+            recurrent_query_start_loc = (
+                piecewise_spec_bufs["qsl"]
+                if piecewise_spec_bufs is not None
+                else (
+                    eager_spec_state["query_start_loc"]
+                    if eager_spec_state is not None
+                    else spec_causal_conv1d_meta.query_start_loc
+                )
+            )
+            recurrent_num_accepted_tokens = (
+                piecewise_spec_bufs["nat"]
+                if piecewise_spec_bufs is not None
+                else (
+                    eager_spec_state["num_accepted_tokens"]
+                    if eager_spec_state is not None
+                    else spec_causal_conv1d_meta.num_accepted_tokens.to(
+                        torch.int32
+                    )
+                )
+            )
+            query_spec = l2norm_fwd(query_spec)
+            key_spec = l2norm_fwd(key_spec)
+            # Dispatches to the vllm-ascend AscendC custom operator
+            # (csrc/recurrent_gated_delta_rule), NOT the built-in CANN operator.
+            # The custom op extends dtype support (e.g. float32 state) and is
+            # loaded at runtime via ASCEND_CUSTOM_OPP_PATH.
+            recurrent_op = (
+                torch.ops.vllm.dcut_gdn_recurrent
+                if use_graphable_recurrent
+                else torch.ops._C_ascend.npu_dcut_recurrent_gated_delta_rule
+            )
+            core_attn_out_spec = recurrent_op(
+                query=query_spec.squeeze(0),
+                key=key_spec.squeeze(0),
+                value=value_spec.squeeze(0),
+                g=g_spec.squeeze(0),
+                beta=beta_spec.squeeze(0),
+                state=ssm_state,
+                scale=key_spec.shape[-1] ** -0.5,
+                query_start_loc=recurrent_query_start_loc,
+                ssm_state_indices=spec_state_indices_tensor,
+                num_accepted_tokens=recurrent_num_accepted_tokens,
+                zero_padded_output=piecewise_spec_bufs is not None,
+            ).unsqueeze(0)
+        else:
+            core_attn_out_spec, last_recurrent_state = None, None
+
+        # 2.2: Process non-spec-decode part in mixed non-spec batches
+        if split_non_spec:
+            assert mixed_qkv_non_spec is not None
+            assert g_non_spec is not None
+            assert beta_non_spec is not None
+            query_decode, key_decode, value_decode = self.rearrange_mixed_qkv(mixed_qkv_non_spec[:num_decode_tokens])
+            actual_seq_lengths = attn_metadata.non_spec_decode_metadata.actual_seq_lengths
+            query_decode = l2norm_fwd(query_decode)
+            key_decode = l2norm_fwd(key_decode)
+            core_attn_out_decode = torch.ops._C_ascend.npu_recurrent_gated_delta_rule(
+                query=query_decode.squeeze(0),
+                key=key_decode.squeeze(0),
+                value=value_decode.squeeze(0),
+                g=g_non_spec[:, :num_decode_tokens].squeeze(0),
+                beta=beta_non_spec[:, :num_decode_tokens].squeeze(0),
+                state=ssm_state,
+                scale=key_decode.shape[-1] ** -0.5,
+                actual_seq_lengths=actual_seq_lengths,
+                ssm_state_indices=non_spec_state_indices_tensor[:num_decodes],
+            ).unsqueeze(0)
+        else:
+            core_attn_out_decode = None
+
+        # 2.3: Process the remaining part
+        if num_prefills > 0:
+            prefill_query_start_loc = attn_metadata.prefill_query_start_loc
+            prefill_state_indices = attn_metadata.prefill_state_indices
+            prefill_has_initial_state = attn_metadata.prefill_has_initial_state
+            assert prefill_query_start_loc is not None
+            assert prefill_state_indices is not None
+            assert prefill_has_initial_state is not None
+            assert g_non_spec is not None
+            assert beta_non_spec is not None
+            if split_non_spec:
+                query_non_spec = query_non_spec[:, num_decode_tokens:]
+                key_non_spec = key_non_spec[:, num_decode_tokens:]
+                value_non_spec = value_non_spec[:, num_decode_tokens:]
+                g_non_spec = g_non_spec[:, num_decode_tokens:]
+                beta_non_spec = beta_non_spec[:, num_decode_tokens:]
+
+            initial_state = ssm_state[prefill_state_indices].transpose(-1, -2).contiguous()
+            clear_ssm_states(initial_state, prefill_has_initial_state)
+            (core_attn_out_non_spec, last_recurrent_state) = chunk_gated_delta_rule(
+                q=query_non_spec,
+                k=key_non_spec,
+                v=value_non_spec,
+                g=g_non_spec,
+                beta=beta_non_spec,
+                initial_state=initial_state,
+                output_final_state=True,
+                cu_seqlens=prefill_query_start_loc,
+                prebuilt_meta=attn_metadata.non_spec_prefill_metadata.chunk,
+                head_first=False,
+                use_qk_l2norm_in_kernel=True,
+            )
+            ssm_state[prefill_state_indices] = last_recurrent_state.transpose(-1, -2).contiguous().to(ssm_state.dtype)
+            if split_non_spec:
+                core_attn_out_non_spec = torch.cat(
+                    [core_attn_out_decode, core_attn_out_non_spec],
+                    dim=1,
+                )
+        elif num_decodes > 0:
+            actual_seq_lengths = attn_metadata.non_spec_decode_metadata.actual_seq_lengths
+            query_non_spec = l2norm_fwd(query_non_spec)
+            key_non_spec = l2norm_fwd(key_non_spec)
+            # Dispatches to the vllm-ascend AscendC custom operator
+            # (csrc/recurrent_gated_delta_rule), NOT the built-in CANN operator.
+            core_attn_out_non_spec = torch.ops._C_ascend.npu_recurrent_gated_delta_rule(
+                query=query_non_spec.squeeze(0),
+                key=key_non_spec.squeeze(0),
+                value=value_non_spec.squeeze(0),
+                g=g_non_spec.squeeze(0) if g_non_spec is not None else g_non_spec,
+                beta=beta_non_spec.squeeze(0) if beta_non_spec is not None else beta_non_spec,
+                state=ssm_state,
+                scale=key_non_spec.shape[-1] ** -0.5,
+                actual_seq_lengths=actual_seq_lengths,
+                ssm_state_indices=non_spec_state_indices_tensor,
+            ).unsqueeze(0)
+        else:
+            core_attn_out_non_spec, last_recurrent_state = None, None
+
+        # 3. Merge core attention output
+        if spec_sequence_masks is not None and core_attn_out_non_spec is not None:
+            merged_out = torch.empty(
+                (1, num_actual_tokens, *core_attn_out_spec.shape[2:]),
+                dtype=core_attn_out_non_spec.dtype,
+                device=core_attn_out_non_spec.device,
+            )
+            merged_out.index_copy_(1, spec_token_indx, core_attn_out_spec)
+            merged_out.index_copy_(1, non_spec_token_indx, core_attn_out_non_spec)
+            core_attn_out[:num_actual_tokens] = merged_out.squeeze(0)
+        elif spec_sequence_masks is not None:
+            core_attn_out[:num_actual_tokens] = core_attn_out_spec.squeeze(0)
+        else:
+            core_attn_out[:num_actual_tokens] = core_attn_out_non_spec.squeeze(0)

--- a/dcut/globals.py
+++ b/dcut/globals.py
@@ -1,0 +1,111 @@
+# SPDX-License-Identifier: Apache-2.0
+# ruff: noqa: F401, SIM105
+"""Monkey-patch installer for D-Cut adaptive verifier step-length on **vLLM-Ascend / NPU**.
+
+Ported from the CUDA plugin in ``Bensong0506/vllm`` branch
+``feat/dcut-adaptive-verify`` (itself a port of the closed, unmerged vLLM
+PR #44885) to run on Huawei Ascend NPU via vllm-ascend (vLLM v0.23.0 base).
+The adaptive controller remains a vLLM *general plugin*. This fork also adds
+a self-contained 0.23 GDN core plus two D-Cut AscendC state operators.
+
+Algorithm is unchanged (see AngelSlim D-Cut,
+https://angelslim.readthedocs.io/zh-cn/latest/dcut.html): the drafter still
+proposes ``num_speculative_tokens`` every step, but the verifier only checks a
+batch-adaptive subset chosen by a hardware-profiled ITL cost table +
+draft-confidence prefix-product scores + batch-wide global top-K.
+
+Only active for parallel speculative methods: ``method=dflash``, or
+``method=draft_model`` with ``parallel_drafting=true`` (PARD).
+
+------------------------------------------------------------------------------
+GPU -> NPU deltas include two D-Cut state-aware custom operators for GDN
+spec-decode. The Python control loop still patches only the NPU runner and
+the GDN ``_forward_core`` invoked behind the native custom-op API:
+
+  1. Patch targets: ``NPUModelRunner`` (vllm_ascend.worker.model_runner_v1) /
+     ``NPUWorker`` (vllm_ascend.worker.worker) / the Ascend spec-decode
+     proposer — NOT the vLLM GPU classes.  This is mandatory: NPUModelRunner
+     *overrides* ``execute_model``, ``sample_tokens``,
+     ``_copy_draft_token_ids_to_cpu``, ``_update_states`` and ``__init__``, so
+     patching ``GPUModelRunner`` would be shadowed by the NPU overrides and the
+     plugin would silently no-op.  Likewise ``NPUWorker`` subclasses
+     ``WorkerBase`` directly, not ``gpu_worker.Worker``.
+
+  2. Device API: ``torch.cuda.Event`` / ``torch.cuda.synchronize`` ->
+     ``torch.npu.Event`` / ``torch.npu.synchronize``.
+
+  3. ``_adaptive_profile_run`` is rebuilt on the NPU forward path
+     (``set_ascend_forward_context`` + ``self._model_forward`` + the NPU
+     signature of ``_build_attention_metadata``).  The CUDA version relied on
+     ``_get_slot_mappings`` / ``_init_model_kwargs`` / a ``slot_mappings=``
+     kwarg that **do not exist** on NPUModelRunner, so that path is replaced
+     with the NPU ``_dummy_run``-style plumbing.  Profiling is forced eager
+     (no ACLGraph capture) — the cost table only needs *relative* ITL.
+
+Enable: ``pip install -e .`` (this dir) + set ``VLLM_DCUT_CONFIG=/path/to.json``
++ ``VLLM_PLUGINS=dcut_adaptive_verify``.  See RUN.md.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import time
+from dataclasses import replace
+from types import MethodType
+
+import numpy as np
+import torch
+
+try:  # torch_npu registers the ``torch.npu`` namespace; already imported in a
+    # real vllm-ascend worker process, but keep the plugin importable stand-alone.
+    import torch_npu  # noqa: F401
+except ImportError:  # pragma: no cover
+    pass
+
+from vllm.config import CUDAGraphMode
+from vllm.distributed import get_pp_group, get_tp_group
+from vllm.logger import init_logger
+from vllm.v1.attention.backends.utils import PAD_SLOT_ID
+
+from .verify_adaptive_config import VerifyAdaptiveConfig
+from .verify_adaptive_controller import VerifyAdaptiveController
+
+logger = init_logger(__name__)
+
+_INSTALLED = False  # WorkerBase deferred-trigger armed (per process)
+_PATCHED = False  # real monkey patches applied (per process)
+ENV_CONFIG = "VLLM_DCUT_CONFIG"
+ENV_DISABLE = "VLLM_DCUT_DISABLE"
+ENV_TRIM_STATS_OUT = "VLLM_DCUT_TRIM_STATS_OUT"
+ENV_PROFILE_FORCE_EAGER = "VLLM_DCUT_PROFILE_FORCE_EAGER"
+ENV_FULL_DECODE_ONLY = "VLLM_DCUT_FULL_DECODE_ONLY"
+# Diagnostic-only, non-sensitive boolean flag (default: false). When enabled,
+# only the speculative drafter bypasses ACLGraph capture/replay; the target
+# verifier keeps its configured graph mode.
+ENV_FORCE_DRAFTER_EAGER = "VLLM_DCUT_FORCE_DRAFTER_EAGER"
+ENV_GDN_SHARED_STATIC = "VLLM_DCUT_GDN_SHARED_STATIC"
+
+# Adaptive-probability pipeline controls. These are centralized here because
+# the D-Cut directory is installed as an independent vLLM general plugin.
+# They are non-sensitive runtime tuning flags:
+#
+# * PROCESS_PROBS_STAGE: "pre_truncate" (default, overlap the previous D2H
+#   copy with the rest of the step) or "post_sample" (synchronous baseline).
+# * SKIP_UNREADY_PROBS: when true, never wait for the D2H event; reuse the
+#   previous cached decision until the copy becomes ready. Default: false.
+# * REUSE_ARGMAX: reuse the token IDs already selected by DFlash when deriving
+#   selected-token probabilities. Default: true.
+ENV_PROCESS_PROBS_STAGE = "VLLM_DCUT_PROCESS_PROBS_STAGE"
+ENV_SKIP_UNREADY_PROBS = "VLLM_DCUT_SKIP_UNREADY_PROBS"
+ENV_REUSE_ARGMAX = "VLLM_DCUT_REUSE_ARGMAX"
+
+# Compatibility flag used only by the retired patch_gdn.py path. The active
+# v0.23 path is controlled by the registered
+# VLLM_ASCEND_ENABLE_DCUT_GDN_PIECEWISE variable in vllm_ascend/envs.py.
+ENABLE_GDN_MAIN_PIECEWISE_GRAPH = False
+
+# Fixed-address GDN metadata buffers. The active v0.23 graph keys isolate
+# target/draft model instances and padded token buckets. Batch metadata is
+# shared across GDN layers, while each layer keeps separate state indices.
+_dcut_gdn_static = {}

--- a/dcut/install.py
+++ b/dcut/install.py
@@ -1,0 +1,127 @@
+# SPDX-License-Identifier: Apache-2.0
+"""D-Cut patch application + vLLM general-plugin entrypoint."""
+
+from __future__ import annotations
+
+import os
+
+# Module-level print so the user can see WHICH process imports dcut.install.
+# Using print(flush=True) because logger.* is silently swallowed in the dcut
+# vLLM service process.
+print(
+    f"[D-Cut] install module imported by pid={os.getpid()} "
+    "(GDN PIECEWISE graph switch is evaluated during config creation).",
+    flush=True,
+)
+
+from .globals import ENV_CONFIG, logger
+from .patch_attention import _patch_attention
+from .patch_full_graph import _patch_full_decode_multishape
+# Importing patch_piecewise triggers its module-level arming of the
+# CompilationConfig.set_splitting_ops_for_v1 patch — this is what makes the
+# GDN PIECEWISE patch take effect in the EngineCore process (where
+# install() is never called).  The explicit _arm_* call in install() below
+# is kept as a belt-and-suspenders for the Worker process.
+from .patch_piecewise import (
+    _arm_gdn_piecewise_splitting_patch,
+    _is_enabled as _gdn_piecewise_graph_enabled,
+)
+from .patch_proposer import _patch_proposer
+from .patch_runner import _patch_runner
+from .patch_worker import _patch_worker
+
+
+def _apply_patches_once() -> None:
+    """Apply the real monkey patches.  Runs once per process, deferred to the
+    first worker construction (see ``install``) so that importing the NPU
+    worker/runner/proposer modules is safe."""
+    from . import globals as _g
+
+    if _g._PATCHED:
+        return
+    # Mark done up-front so a failure (e.g. non-Ascend platform) is not retried
+    # on every subsequent worker construction and does not spam the log.
+    _g._PATCHED = True
+    try:
+        from .patch_gdn_v023 import _patch_gdn_dcut
+
+        if os.environ.get(ENV_CONFIG) and not _patch_gdn_dcut():
+            raise RuntimeError(
+                "D-Cut GDN state operators are unavailable; run `bash dcut/kernel/build.sh` first"
+            )
+        if (
+            os.environ.get(ENV_CONFIG)
+            and _gdn_piecewise_graph_enabled()
+            and not _patch_attention()
+        ):
+            raise RuntimeError(
+                "D-Cut could not preserve the eager full-attention "
+                "boundary while capturing GDN"
+            )
+        _patch_full_decode_multishape()
+        _patch_proposer()
+        _patch_runner()
+        _patch_worker()
+        logger.info(
+            "D-Cut adaptive-verify patches applied for NPU "
+            "(active only if VLLM_DCUT_CONFIG is set + method is dflash/PARD)."
+        )
+    except Exception as e:  # pragma: no cover - never break vLLM startup
+        logger.error("D-Cut patching failed (vLLM continues normally): %s", e)
+
+
+def install(*args, **kwargs) -> None:
+    """vLLM general-plugin entrypoint.  Idempotent; safe to call per process.
+
+    IMPORTANT — deferred by design.  ``install`` runs during *general-plugin
+    load*, which happens BEFORE vllm-ascend has finished importing its own
+    ``ops/fused_moe`` / ``device`` graph.  Eagerly importing the NPU
+    worker/runner/proposer modules here re-enters that partially-initialised
+    graph and raises a circular ``ImportError`` that poisons ``sys.modules`` —
+    which then breaks vllm-ascend's *own* later imports (e.g.
+    ``pre_register_and_update`` -> ``select_experts``), taking down even vanilla
+    serving.  So here we only *arm* a deferred trigger on the vLLM-core
+    ``WorkerBase`` (safe to import at this point) and apply the real patches on
+    the first worker construction, by which time vllm-ascend is fully imported.
+
+    The GDN PIECEWISE splitting_ops patch is an exception: it wraps a
+    vLLM-core ``CompilationConfig`` method that runs during config creation
+    (before any worker exists), so it must be armed here *before* the deferred
+    trigger.  Only vLLM-core symbols are imported — no vllm_ascend.worker —
+    so there is no circular-import risk.
+    """
+    from . import globals as _g
+
+    if _g._INSTALLED:
+        return
+    _g._INSTALLED = True
+    try:
+        # Arm the GDN PIECEWISE splitting_ops patch early — must run before
+        # vllm-ascend platform creates the compilation config.  (Also armed
+        # at module-import time above, but re-call here for the Worker
+        # process in case the import was somehow skipped.)
+        _arm_gdn_piecewise_splitting_patch()
+
+        from vllm.v1.worker.worker_base import WorkerBase
+
+        if getattr(WorkerBase, "_dcut_defer_armed", False):
+            return
+        _orig_wb_init = WorkerBase.__init__
+
+        def __init__(self, *a, **k):
+            # NPUWorker.__init__ calls super().__init__() (this) early, before it
+            # builds the model runner — so patching here lands before any
+            # NPUModelRunner / proposer instance exists.
+            _apply_patches_once()
+            return _orig_wb_init(self, *a, **k)
+
+        WorkerBase.__init__ = __init__
+        WorkerBase._dcut_defer_armed = True
+        print(
+            "[D-Cut] deferred installer armed on WorkerBase "
+            "(patches apply on first worker init to avoid a vllm-ascend "
+            "circular import).",
+            flush=True,
+        )
+    except Exception as e:  # pragma: no cover - never break vLLM startup
+        logger.error("D-Cut install (arm) failed (vLLM continues normally): %s", e)

--- a/dcut/kernel/.gitignore
+++ b/dcut/kernel/.gitignore
@@ -1,0 +1,2 @@
+/build/
+/output/

--- a/dcut/kernel/CMakeLists.txt
+++ b/dcut/kernel/CMakeLists.txt
@@ -1,0 +1,17 @@
+# D-Cut operator sources are self-contained under this directory. The native
+# vllm-ascend build wrapper selects only these two directories.
+set(DCUT_OPERATOR_DIRS
+    dcut_recurrent_gated_delta_rule
+    dcut_causal_conv1d
+)
+
+foreach(SUB_DIR IN LISTS DCUT_OPERATOR_DIRS)
+    if(DEFINED ASCEND_OP_NAME AND NOT "${ASCEND_OP_NAME}" STREQUAL "")
+        if(NOT "${ASCEND_OP_NAME}" STREQUAL "all" AND NOT "${ASCEND_OP_NAME}" STREQUAL "ALL")
+            if(NOT SUB_DIR IN_LIST ASCEND_OP_NAME)
+                continue()
+            endif()
+        endif()
+    endif()
+    add_subdirectory(${SUB_DIR})
+endforeach()

--- a/dcut/kernel/build.sh
+++ b/dcut/kernel/build.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+KERNEL_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${KERNEL_DIR}/../.." && pwd)"
+OPS="dcut_recurrent_gated_delta_rule,dcut_causal_conv1d"
+SOC="${SOC_VERSION:-ascend910b}"
+BUILD_TORCH=1
+TORCH_ONLY=0
+JOBS="${MAX_JOBS:-8}"
+
+usage() {
+    cat <<'EOF'
+Usage: bash dcut/kernel/build.sh [options]
+
+Options:
+  --ops=<op1,op2>       Build one or both D-Cut AscendC operators.
+  --soc=<soc>           ascend910b, ascend910_93, or ascend950.
+  --torch-only          Build only the Torch registration library.
+  --skip-torch          Build only the AscendC custom-op package.
+  -j<N>                 Parallel jobs for the Torch registration library.
+EOF
+}
+
+for arg in "$@"; do
+    case "${arg}" in
+        --ops=*) OPS="${arg#*=}" ;;
+        --soc=*) SOC="${arg#*=}" ;;
+        --torch-only) TORCH_ONLY=1 ;;
+        --skip-torch) BUILD_TORCH=0 ;;
+        -j*) JOBS="${arg#-j}" ;;
+        -h|--help) usage; exit 0 ;;
+        *) echo "Unknown option: ${arg}" >&2; usage >&2; exit 2 ;;
+    esac
+done
+
+case "${SOC}" in
+    ascend910b*|ascend910_93*|ascend950*) ;;
+    *) echo "D-Cut GDN kernels do not support SOC ${SOC}" >&2; exit 2 ;;
+esac
+
+IFS=',' read -r -a OP_NAMES <<< "${OPS}"
+OVERLAYS=()
+cleanup() {
+    local overlay
+    for overlay in "${OVERLAYS[@]:-}"; do
+        if [[ -L "${overlay}" ]]; then
+            rm -- "${overlay}"
+        fi
+    done
+}
+trap cleanup EXIT
+
+if [[ "${TORCH_ONLY}" == "0" ]]; then
+    for op_name in "${OP_NAMES[@]}"; do
+        case "${op_name}" in
+            dcut_recurrent_gated_delta_rule|dcut_causal_conv1d) ;;
+            *) echo "Unknown D-Cut operator: ${op_name}" >&2; exit 2 ;;
+        esac
+        source_dir="${KERNEL_DIR}/${op_name}"
+        overlay="${REPO_ROOT}/csrc/attention/${op_name}"
+        if [[ -e "${overlay}" || -L "${overlay}" ]]; then
+            echo "Refusing to replace existing path: ${overlay}" >&2
+            exit 1
+        fi
+        ln -s "${source_dir}" "${overlay}"
+        OVERLAYS+=("${overlay}")
+    done
+
+    (
+        cd "${REPO_ROOT}/csrc"
+        bash build.sh --pkg --vendor_name=dcut --ops="${OPS}" --soc="${SOC}"
+    )
+    cleanup
+    OVERLAYS=()
+fi
+
+if [[ "${BUILD_TORCH}" == "1" ]]; then
+    BUILD_DIR="${KERNEL_DIR}/build/torch_extension"
+    cmake -S "${KERNEL_DIR}/torch_extension" -B "${BUILD_DIR}" \
+        -DREPO_ROOT="${REPO_ROOT}" \
+        -DASCEND_HOME_PATH="${ASCEND_HOME_PATH:-${ASCEND_TOOLKIT_HOME:-/usr/local/Ascend/ascend-toolkit/latest}}"
+    cmake --build "${BUILD_DIR}" --parallel "${JOBS}"
+    echo "Torch registration library: ${BUILD_DIR}/dcut_torch_ops.so"
+fi

--- a/dcut/kernel/dcut_causal_conv1d/CMakeLists.txt
+++ b/dcut/kernel/dcut_causal_conv1d/CMakeLists.txt
@@ -1,0 +1,6 @@
+file(GLOB CURRENT_DIRS RELATIVE ${CMAKE_CURRENT_SOURCE_DIR} ${CMAKE_CURRENT_SOURCE_DIR}/*)
+foreach(SUB_DIR ${CURRENT_DIRS})
+    if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/${SUB_DIR}/CMakeLists.txt")
+        add_subdirectory(${SUB_DIR})
+    endif()
+endforeach()

--- a/dcut/kernel/dcut_causal_conv1d/dcut_causal_conv1d_torch_adpt.h
+++ b/dcut/kernel/dcut_causal_conv1d/dcut_causal_conv1d_torch_adpt.h
@@ -1,0 +1,23 @@
+#ifndef DCUT_CAUSAL_CONV1D_TORCH_ADPT_H
+#define DCUT_CAUSAL_CONV1D_TORCH_ADPT_H
+
+namespace vllm_ascend {
+
+at::Tensor npu_dcut_causal_conv1d(const at::Tensor& output, const at::Tensor& x, const at::Tensor& weight,
+                                  const at::Tensor& conv_state, const c10::optional<at::Tensor>& bias,
+                                  const c10::optional<at::Tensor>& query_start_loc,
+                                  const c10::optional<at::Tensor>& cache_indices,
+                                  const c10::optional<at::Tensor>& num_accepted_tokens, int64_t activation_mode,
+                                  int64_t pad_slot_id) {
+  TORCH_CHECK(query_start_loc.has_value(), "query_start_loc cannot be empty.");
+  TORCH_CHECK(cache_indices.has_value(), "cache_indices cannot be empty.");
+  TORCH_CHECK(num_accepted_tokens.has_value(), "num_accepted_tokens cannot be empty.");
+
+  int64_t store_mode = 1;
+  EXEC_NPU_CMD(aclnnDcutCausalConv1d, x, weight, bias, conv_state, query_start_loc, cache_indices, c10::nullopt,
+               num_accepted_tokens, activation_mode, pad_slot_id, store_mode, output);
+  return output;
+}
+
+}  // namespace vllm_ascend
+#endif

--- a/dcut/kernel/dcut_causal_conv1d/op_host/CMakeLists.txt
+++ b/dcut/kernel/dcut_causal_conv1d/op_host/CMakeLists.txt
@@ -1,0 +1,22 @@
+add_op_to_compiled_list()
+
+if (BUILD_OPEN_PROJECT)
+    target_sources(op_host_aclnn PRIVATE
+        dcut_causal_conv1d_def.cpp
+    )
+endif()
+
+add_ops_compile_options(
+    OP_NAME DcutCausalConv1d
+    OPTIONS
+        --cce-auto-sync=on
+        -Wno-deprecated-declarations
+        -Werror
+)
+
+if (NOT BUILD_OPS_RTY_KERNEL)
+    add_modules_sources(OPTYPE dcut_causal_conv1d ACLNNTYPE aclnn)
+    target_include_directories(${OPHOST_NAME}_tiling_obj PRIVATE
+        ${CMAKE_CURRENT_SOURCE_DIR}
+    )
+endif()

--- a/dcut/kernel/dcut_causal_conv1d/op_host/dcut_causal_conv1d_def.cpp
+++ b/dcut/kernel/dcut_causal_conv1d/op_host/dcut_causal_conv1d_def.cpp
@@ -1,0 +1,73 @@
+#include "register/op_def_registry.h"
+
+namespace ops {
+class DcutCausalConv1d : public OpDef {
+ public:
+  explicit DcutCausalConv1d(const char* name) : OpDef(name) {
+    this->Input("x")
+        .ParamType(REQUIRED)
+        .DataType({ge::DT_FLOAT16, ge::DT_BF16})
+        .FormatList({ge::FORMAT_ND})
+        .AutoContiguous();
+    this->Input("weight")
+        .ParamType(REQUIRED)
+        .DataType({ge::DT_FLOAT16, ge::DT_BF16})
+        .FormatList({ge::FORMAT_ND})
+        .AutoContiguous();
+    this->Input("bias")
+        .ParamType(OPTIONAL)
+        .DataType({ge::DT_FLOAT16, ge::DT_BF16})
+        .FormatList({ge::FORMAT_ND})
+        .AutoContiguous();
+    this->Input("convStates")
+        .ParamType(REQUIRED)
+        .DataType({ge::DT_FLOAT16, ge::DT_BF16})
+        .FormatList({ge::FORMAT_ND})
+        .AutoContiguous();
+    this->Input("queryStartLoc")
+        .ParamType(OPTIONAL)
+        .DataTypeList({ge::DT_INT32, ge::DT_INT64})
+        .FormatList({ge::FORMAT_ND})
+        .AutoContiguous();
+    this->Input("cacheIndices")
+        .ParamType(OPTIONAL)
+        .DataTypeList({ge::DT_INT32, ge::DT_INT64})
+        .FormatList({ge::FORMAT_ND})
+        .AutoContiguous();
+    this->Input("initialStateMode")
+        .ParamType(OPTIONAL)
+        .DataTypeList({ge::DT_BOOL, ge::DT_INT32, ge::DT_INT64})
+        .FormatList({ge::FORMAT_ND})
+        .AutoContiguous();
+    // Previous-step accepted counts; the kernel derives zero-based offsets.
+    this->Input("numAcceptedTokens")
+        .ParamType(OPTIONAL)
+        .DataTypeList({ge::DT_INT32, ge::DT_INT64})
+        .FormatList({ge::FORMAT_ND})
+        .AutoContiguous();
+    this->Output("y")
+        .ParamType(REQUIRED)
+        .DataType({ge::DT_FLOAT16, ge::DT_BF16})
+        .FormatList({ge::FORMAT_ND})
+        .AutoContiguous();
+
+    this->Attr("activationMode").AttrType(OPTIONAL).Int(0);
+    this->Attr("padSlotId").AttrType(OPTIONAL).Int(-1);
+    this->Attr("runMode").AttrType(OPTIONAL).Int(1);
+
+    OpAICoreConfig aicoreConfig;
+    aicoreConfig.DynamicCompileStaticFlag(true)
+        .DynamicFormatFlag(false)
+        .DynamicRankSupportFlag(true)
+        .DynamicShapeSupportFlag(true)
+        .NeedCheckSupportFlag(false)
+        .PrecisionReduceFlag(true)
+        .ExtendCfgInfo("coreType.value", "AiCore");
+    this->AICore().AddConfig("ascend910b", aicoreConfig);
+    this->AICore().AddConfig("ascend910_93", aicoreConfig);
+    this->AICore().AddConfig("ascend950", aicoreConfig);
+  }
+};
+
+OP_ADD(DcutCausalConv1d);
+}  // namespace ops

--- a/dcut/kernel/dcut_causal_conv1d/op_host/dcut_causal_conv1d_infershape.cpp
+++ b/dcut/kernel/dcut_causal_conv1d/op_host/dcut_causal_conv1d_infershape.cpp
@@ -1,0 +1,2 @@
+#define CausalConv1d DcutCausalConv1d
+#include "../../../../csrc/moe/causal_conv1d/op_host/causal_conv1d_infershape.cpp"

--- a/dcut/kernel/dcut_causal_conv1d/op_host/dcut_causal_conv1d_tiling.cpp
+++ b/dcut/kernel/dcut_causal_conv1d/op_host/dcut_causal_conv1d_tiling.cpp
@@ -1,0 +1,22 @@
+#define CausalConv1d DcutCausalConv1d
+
+// Include the CANN header FIRST so its IMPL_OP_OPTILING definition is processed
+// and the include guard INC_EXTERNAL_REGISTER_OP_IMPL_REGISTRY_H_ is set.
+// Otherwise the header (pulled in transitively by the tiling file) would
+// re-define IMPL_OP_OPTILING and clobber our override below.
+#include "register/op_impl_registry.h"
+
+// Override IMPL_OP_OPTILING to force macro expansion in #op_type (stringification)
+// and ##op_type (token pasting). Per C standard, # and ## do NOT expand macro
+// arguments, so without this override IMPL_OP_OPTILING(CausalConv1d) would
+// register the op type as "CausalConv1d" instead of "DcutCausalConv1d", and the
+// runtime would fail with "Do not find tiling func of DcutCausalConv1d!".
+#undef IMPL_OP_OPTILING
+#define DCUT_STRINGIFY(x) #x
+#define DCUT_STRINGIFY_EXPAND(x) DCUT_STRINGIFY(x)
+#define DCUT_CAT(a, b) DCUT_CAT_INNER(a, b)
+#define DCUT_CAT_INNER(a, b) a##b
+#define IMPL_OP_OPTILING(op_type) \
+  gert::OpImplRegisterV2 VAR_UNUSED DCUT_CAT(op_impl_register_optiling_, op_type) = gert::OpImplRegisterV2(DCUT_STRINGIFY_EXPAND(op_type))
+
+#include "../../../../csrc/moe/causal_conv1d/op_host/causal_conv1d_tiling.cpp"

--- a/dcut/kernel/dcut_causal_conv1d/op_kernel/dcut_causal_conv1d.cpp
+++ b/dcut/kernel/dcut_causal_conv1d/op_kernel/dcut_causal_conv1d.cpp
@@ -1,0 +1,2 @@
+#define causal_conv1d dcut_causal_conv1d
+#include "../vendor/op_kernel/causal_conv1d.cpp"

--- a/dcut/kernel/dcut_causal_conv1d/vendor/op_kernel/arch35/causal_conv1d_regbase.h
+++ b/dcut/kernel/dcut_causal_conv1d/vendor/op_kernel/arch35/causal_conv1d_regbase.h
@@ -1,0 +1,176 @@
+/**
+ * This program is free software, you can redistribute it and/or modify it.
+ * Copyright (c) 2025 Huawei Technologies Co., Ltd.
+ * This file is a part of the CANN Open Software.
+ * Licensed under CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING
+ * BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ */
+
+/*!
+ * \file causal_conv1d_regbase.h
+ * \brief
+ */
+#ifndef CAUSAL_CONV1D_REGBASE_H
+#define CAUSAL_CONV1D_REGBASE_H
+
+namespace NsCausalConv1d {
+using namespace AscendC;
+using namespace AscendC::MicroAPI;
+
+constexpr uint16_t V_LENGTH = VECTOR_REG_WIDTH / sizeof(float);
+
+constexpr CastTrait castTraitB16ToB32 = {
+    RegLayout::ZERO, SatMode::UNKNOWN, MaskMergeMode::ZEROING, RoundMode::UNKNOWN};
+
+template <typename T, bool hasActivation>
+__aicore__ inline void ComputeFnRollingOutputRegbase(LocalTensor<T> ring, LocalTensor<float> currF,
+    LocalTensor<float> state0F, LocalTensor<float> weightF, uint32_t dataCount)
+{
+    __ubuf__ T* ringAddr = (__ubuf__ T*)ring.GetPhyAddr();
+    __ubuf__ float* currFAddr = (__ubuf__ float*)currF.GetPhyAddr();
+    __ubuf__ float* state0FAddr = (__ubuf__ float*)state0F.GetPhyAddr();
+    __ubuf__ float* weightFAddr = (__ubuf__ float*)weightF.GetPhyAddr();
+
+    uint16_t colLoopTimes = static_cast<uint16_t>(Ceil(dataCount, V_LENGTH));
+    __VEC_SCOPE__
+    {
+        RegTensor<T> ring;
+        RegTensor<float> currF;
+        RegTensor<float> state0F;
+        RegTensor<float> weightF;
+        RegTensor<float> tmp;
+        MaskReg pregLoop;
+        for (uint16_t j = 0; j < colLoopTimes; j++) {
+            pregLoop = UpdateMask<float>(dataCount);
+            DataCopy<T, LoadDist::DIST_UNPACK_B16>(ring, ringAddr + j * V_LENGTH);
+            DataCopy(state0F, state0FAddr + j * V_LENGTH);
+            DataCopy(weightF, weightFAddr + j * V_LENGTH);
+            Cast<float, T, castTraitB16ToB32>(currF, ring, pregLoop);
+            Mul(currF, currF, weightF, pregLoop);
+            Add(state0F, state0F, currF, pregLoop);
+            if constexpr (hasActivation) {
+                Muls(tmp, state0F, -1.0f, pregLoop);
+                Exp(tmp, tmp, pregLoop);
+                Adds(tmp, tmp, 1.0f, pregLoop);
+                Div(currF, state0F, tmp, pregLoop);
+                DataCopy(currFAddr + j * V_LENGTH, currF, pregLoop);
+            } else {
+                DataCopy(state0FAddr + j * V_LENGTH, state0F, pregLoop);
+            }
+        }
+    }
+}
+
+template <typename T>
+static __simd_vf__ inline void AdvanceFnLocalPartialsWidthTwo(__ubuf__ T* ringAddr, __ubuf__ float* weight0FAddr,
+    __ubuf__ float* state0FAddr, uint32_t dataCount, uint16_t colLoopTimes)
+{
+    RegTensor<T> ring;
+    RegTensor<float> currF;
+    RegTensor<float> weight0F;
+    RegTensor<float> state0F;
+    MaskReg pregLoop;
+    for (uint16_t j = 0; j < colLoopTimes; j++) {
+        pregLoop = UpdateMask<float>(dataCount);
+        DataCopy<T, LoadDist::DIST_UNPACK_B16>(ring, ringAddr + j * V_LENGTH);
+        DataCopy(weight0F, weight0FAddr + j * V_LENGTH);
+        Cast<float, T, castTraitB16ToB32>(currF, ring, pregLoop);
+        Mul(state0F, currF, weight0F, pregLoop);
+        DataCopy(state0FAddr + j * V_LENGTH, state0F, pregLoop);
+    }
+}
+
+template <typename T>
+static __simd_vf__ inline void AdvanceFnLocalPartialsWidthThree(__ubuf__ T* ringAddr, __ubuf__ float* weight0FAddr,
+    __ubuf__ float* weight1FAddr, __ubuf__ float* state0FAddr, __ubuf__ float* state1FAddr, uint32_t dataCount,
+    uint16_t colLoopTimes)
+{
+    RegTensor<T> ring;
+    RegTensor<float> currF;
+    RegTensor<float> weight0F;
+    RegTensor<float> weight1F;
+    RegTensor<float> state0F;
+    RegTensor<float> state1F;
+    MaskReg pregLoop;
+    for (uint16_t j = 0; j < colLoopTimes; j++) {
+        pregLoop = UpdateMask<float>(dataCount);
+        DataCopy<T, LoadDist::DIST_UNPACK_B16>(ring, ringAddr + j * V_LENGTH);
+        DataCopy(state1F, state1FAddr + j * V_LENGTH);
+        Cast<float, T, castTraitB16ToB32>(currF, ring, pregLoop);
+        DataCopy(weight1F, weight1FAddr + j * V_LENGTH);
+        Mul(state0F, currF, weight1F, pregLoop);
+        DataCopy(weight0F, weight0FAddr + j * V_LENGTH);
+        Add(state0F, state0F, state1F, pregLoop);
+        Mul(state1F, currF, weight0F, pregLoop);
+        DataCopy(state0FAddr + j * V_LENGTH, state0F, pregLoop);
+        DataCopy(state1FAddr + j * V_LENGTH, state1F, pregLoop);
+    }
+}
+
+template <typename T>
+static __simd_vf__ inline void AdvanceFnLocalPartialsWidthFour(__ubuf__ T* ringAddr, __ubuf__ float* weight0FAddr,
+    __ubuf__ float* weight1FAddr, __ubuf__ float* weight2FAddr, __ubuf__ float* state0FAddr, __ubuf__ float* state1FAddr,
+    __ubuf__ float* state2FAddr, uint32_t dataCount, uint16_t colLoopTimes)
+{
+    RegTensor<T> ring;
+    RegTensor<float> currF;
+    RegTensor<float> weight0F;
+    RegTensor<float> weight1F;
+    RegTensor<float> weight2F;
+    RegTensor<float> state0F;
+    RegTensor<float> state1F;
+    RegTensor<float> state2F;
+    MaskReg pregLoop;
+    for (uint16_t j = 0; j < colLoopTimes; j++) {
+        pregLoop = UpdateMask<float>(dataCount);
+        DataCopy<T, LoadDist::DIST_UNPACK_B16>(ring, ringAddr + j * V_LENGTH);
+        DataCopy(state1F, state1FAddr + j * V_LENGTH);
+        DataCopy(state2F, state2FAddr + j * V_LENGTH);
+        Cast<float, T, castTraitB16ToB32>(currF, ring, pregLoop);
+        DataCopy(weight2F, weight2FAddr + j * V_LENGTH);
+        Mul(state0F, currF, weight2F, pregLoop);
+        DataCopy(weight1F, weight1FAddr + j * V_LENGTH);
+        Add(state0F, state0F, state1F, pregLoop);
+        Mul(state1F, currF, weight1F, pregLoop);
+        DataCopy(weight0F, weight0FAddr + j * V_LENGTH);
+        Add(state1F, state1F, state2F, pregLoop);
+        Mul(state2F, currF, weight0F, pregLoop);
+        DataCopy(state0FAddr + j * V_LENGTH, state0F, pregLoop);
+        DataCopy(state1FAddr + j * V_LENGTH, state1F, pregLoop);
+        DataCopy(state2FAddr + j * V_LENGTH, state2F, pregLoop);
+    }
+}
+
+template <typename T, int32_t kTemplateWidth>
+__aicore__ inline void AdvanceFnLocalPartialsRegbase(LocalTensor<T> ring, LocalTensor<float> weightF,
+    LocalTensor<float> state0F, LocalTensor<float> state1F, LocalTensor<float> state2F, uint32_t dataCount,
+    uint32_t weightStep)
+{
+    uint16_t colLoopTimes = static_cast<uint16_t>(Ceil(dataCount, V_LENGTH));
+
+    __ubuf__ T* ringAddr = (__ubuf__ T*)ring.GetPhyAddr();
+    __ubuf__ float* weight0FAddr = (__ubuf__ float*)weightF.GetPhyAddr();
+    __ubuf__ float* state0FAddr = (__ubuf__ float*)state0F.GetPhyAddr();
+    if constexpr (kTemplateWidth == 2) {
+        AscendC::VF_CALL<AdvanceFnLocalPartialsWidthTwo<T>>(ringAddr, weight0FAddr, state0FAddr, dataCount, colLoopTimes);
+    } else if constexpr (kTemplateWidth == 3) {
+        __ubuf__ float* weight1FAddr = weight0FAddr + weightStep;
+        __ubuf__ float* state1FAddr = (__ubuf__ float*)state1F.GetPhyAddr();
+        AscendC::VF_CALL<AdvanceFnLocalPartialsWidthThree<T>>(ringAddr, weight0FAddr, weight1FAddr, state0FAddr,
+            state1FAddr, dataCount, colLoopTimes);
+    } else if constexpr (kTemplateWidth == 4) {
+        __ubuf__ float* weight1FAddr = weight0FAddr + weightStep;
+        __ubuf__ float* weight2FAddr = weight1FAddr + weightStep;
+        __ubuf__ float* state1FAddr = (__ubuf__ float*)state1F.GetPhyAddr();
+        __ubuf__ float* state2FAddr = (__ubuf__ float*)state2F.GetPhyAddr();
+        AscendC::VF_CALL<AdvanceFnLocalPartialsWidthFour<T>>(ringAddr, weight0FAddr, weight1FAddr, weight2FAddr,
+            state0FAddr, state1FAddr, state2FAddr, dataCount, colLoopTimes);
+    }
+}
+
+} // namespace NsCausalConv1d
+
+#endif // CAUSAL_CONV1D_REGBASE_H

--- a/dcut/kernel/dcut_causal_conv1d/vendor/op_kernel/causal_conv1d.cpp
+++ b/dcut/kernel/dcut_causal_conv1d/vendor/op_kernel/causal_conv1d.cpp
@@ -1,0 +1,57 @@
+/**
+ * This program is free software, you can redistribute it and/or modify it.
+ * Copyright (c) 2025 Huawei Technologies Co., Ltd.
+ * This file is a part of the CANN Open Software.
+ * Licensed under CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING
+ * BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ */
+
+/*!
+ * \file causal_conv1d.cpp
+ * \brief
+ */
+
+#include "causal_conv1d_fn.h"
+#include "causal_conv1d_update.h"
+
+namespace {
+
+template <typename T, uint32_t runModeKey, uint32_t widthKey, uint32_t fnPlanKey>
+__aicore__ inline void RunCausalConv1d(GM_ADDR x, GM_ADDR weight, GM_ADDR bias, GM_ADDR convStates,
+                                       GM_ADDR queryStartLoc, GM_ADDR cacheIndices, GM_ADDR initialStateMode,
+                                       GM_ADDR numAcceptedTokens, GM_ADDR y, GM_ADDR workspace,
+                                       const CausalConv1dTilingData *tilingData)
+{
+    if constexpr (runModeKey == CAUSAL_CONV1D_TPL_RUN_MODE_FN) {
+        NsCausalConv1d::RunCausalConv1dFn<T, widthKey, fnPlanKey>(
+            x, weight, bias, convStates, queryStartLoc, cacheIndices, initialStateMode, numAcceptedTokens, y, workspace,
+            tilingData);
+    } else {
+        NsCausalConv1d::RunCausalConv1dUpdate<T>(
+            x, weight, bias, convStates, queryStartLoc, cacheIndices, initialStateMode, numAcceptedTokens, y, workspace,
+            tilingData);
+    }
+}
+
+} // namespace
+
+template <uint32_t runModeKey, uint32_t widthKey, uint32_t fnPlanKey>
+__global__ __aicore__ void causal_conv1d(GM_ADDR x, GM_ADDR weight, GM_ADDR bias, GM_ADDR convStates,
+                                         GM_ADDR queryStartLoc, GM_ADDR cacheIndices, GM_ADDR initialStateMode,
+                                         GM_ADDR numAcceptedTokens, GM_ADDR y, GM_ADDR workspace, GM_ADDR tiling)
+{
+    REGISTER_TILING_DEFAULT(CausalConv1dTilingData);
+    GET_TILING_DATA(tilingData, tiling);
+    KERNEL_TASK_TYPE_DEFAULT(KERNEL_TYPE_MIX_AIV_1_0);
+    GM_ADDR userWorkspace = workspace;
+    if (workspace != nullptr) {
+        userWorkspace = AscendC::GetUserWorkspace(workspace);
+    }
+
+    RunCausalConv1d<DTYPE_X, runModeKey, widthKey, fnPlanKey>(
+        x, weight, bias, convStates, queryStartLoc, cacheIndices, initialStateMode, numAcceptedTokens, y,
+        userWorkspace, &tilingData);
+}

--- a/dcut/kernel/dcut_causal_conv1d/vendor/op_kernel/causal_conv1d.h
+++ b/dcut/kernel/dcut_causal_conv1d/vendor/op_kernel/causal_conv1d.h
@@ -1,0 +1,1092 @@
+/**
+ * This program is free software, you can redistribute it and/or modify it.
+ * Copyright (c) 2025 Huawei Technologies Co., Ltd.
+ * This file is a part of the CANN Open Software.
+ * Licensed under CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING
+ * BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ */
+
+/*!
+ * \file causal_conv1d.h
+ */
+
+#ifndef CAUSAL_CONV1D_H
+#define CAUSAL_CONV1D_H
+
+#include "kernel_operator.h"
+#include "kernel_tiling/kernel_tiling.h"
+#include "causal_conv1d_tiling_data.h"
+#include "causal_conv1d_tiling_key.h"
+#include "causal_conv1d_common.h"
+#if defined(__CCE_AICORE__) && __CCE_AICORE__ == 310
+#include "arch35/causal_conv1d_regbase.h"
+#endif
+
+ namespace NsCausalConv1d {
+
+ using namespace AscendC;
+ using namespace NsCausalConv1dCommon;
+
+ #define CAUSAL_CONV1D_TEMPLATE_ARGS typename T, uint32_t runModeKey, uint32_t widthKey, uint32_t fnPlanKey
+ #define CAUSAL_CONV1D_CLASS CausalConv1d<T, runModeKey, widthKey, fnPlanKey>
+
+ enum SeqTaskWindowMode : int32_t {
+     SEQ_TASK_WINDOW_MODE_VARLEN = 0,
+     SEQ_TASK_WINDOW_MODE_BATCH = 1,
+     SEQ_TASK_WINDOW_MODE_DECODE2D = 2,
+ };
+
+ inline constexpr int32_t INIT_STATE_SYNCALL_NEED_SIZE = 8;
+ inline constexpr int32_t INIT_STATE_SYNCALL_MAX_BLOCKS = 64;
+ inline constexpr int64_t INT32_MAX_VALUE = 2147483647LL;
+
+ struct SeqTaskWindow {
+     bool valid = false;
+     int32_t start = 0;
+     int32_t len = 0;
+ };
+
+ __aicore__ inline int32_t GetSeqTaskWindowMode(int32_t inputMode)
+ {
+     if (inputMode == 0) {
+         return SEQ_TASK_WINDOW_MODE_VARLEN;
+     }
+     if (inputMode == 2) {
+         return SEQ_TASK_WINDOW_MODE_DECODE2D;
+     }
+     return SEQ_TASK_WINDOW_MODE_BATCH;
+ }
+
+ __aicore__ inline SeqTaskWindow BuildSeqTaskWindowVarlen(int32_t startVal, int32_t endVal)
+ {
+     SeqTaskWindow window;
+     window.start = startVal;
+     window.len = endVal - startVal;
+     window.valid = (window.len > 0);
+     return window;
+ }
+
+ __aicore__ inline int32_t RetreatRingSlot(int32_t slot, int32_t delta)
+ {
+     int32_t prev = slot - delta;
+     return (prev >= 0) ? prev : (prev + RING_SLOTS);
+ }
+
+ __aicore__ inline SeqTaskWindow BuildSeqTaskWindowBatch(int32_t seq, int32_t seqLen)
+ {
+     SeqTaskWindow window;
+     window.start = seq * seqLen;
+     window.len = seqLen;
+     window.valid = (window.len > 0);
+     return window;
+ }
+
+ __aicore__ inline SeqTaskWindow BuildSeqTaskWindowDecode2D(int32_t seq)
+ {
+     SeqTaskWindow window;
+     window.valid = true;
+     window.start = seq;
+     window.len = 1;
+     return window;
+ }
+
+ __aicore__ inline constexpr int32_t DecodeWidthTplKey(uint32_t widthKey)
+ {
+     switch (widthKey) {
+         case CAUSAL_CONV1D_TPL_WIDTH_2:
+             return 2;
+         case CAUSAL_CONV1D_TPL_WIDTH_3:
+             return 3;
+         case CAUSAL_CONV1D_TPL_WIDTH_4:
+             return 4;
+         default:
+             return 0;
+     }
+ }
+
+ template <CAUSAL_CONV1D_TEMPLATE_ARGS>
+ class CausalConv1d {
+ public:
+     __aicore__ inline CausalConv1d() = default;
+
+ protected:
+     static constexpr bool kIsUpdateMode = (runModeKey == CAUSAL_CONV1D_TPL_RUN_MODE_UPDATE);
+     static constexpr int32_t kTemplateWidth = DecodeWidthTplKey(widthKey);
+     static constexpr bool kHasCompileTimeWidth =
+         (runModeKey == CAUSAL_CONV1D_TPL_RUN_MODE_FN) && (kTemplateWidth >= 2) && (kTemplateWidth <= MAX_WIDTH);
+     static constexpr FnExecutionPlan kFnExecutionPlan = static_cast<FnExecutionPlan>(fnPlanKey);
+
+     __aicore__ inline void ResetRuntimeState(const CausalConv1dTilingData *tilingData);
+     __aicore__ inline void InitSharedBuffersAndEvents();
+     __aicore__ inline void LoadWeightAndBias(int32_t channelStart, int32_t baseDim);
+     __aicore__ inline void InitRing(int32_t cacheIdx, bool hasInit, int32_t stateTokenOffset, int32_t start,
+                                     int32_t len, int32_t channelStart, int32_t baseDim, int32_t dim);
+     __aicore__ inline void InitRingSeqSplit(int32_t seq, int32_t cacheIdx, bool hasInit, int32_t seqStart,
+                                             int32_t tileStart, int32_t tileLen, int32_t channelStart, int32_t baseDim,
+                                             int32_t dim);
+     __aicore__ inline void PrefetchInitStatesToWorkspace(int32_t channelStart, int32_t baseDimSize);
+     __aicore__ inline void RestoreFnLocalPartials(int32_t baseDim);
+     __aicore__ inline void ComputeFnRollingOutput(int32_t slotCurr, int32_t baseDim);
+     __aicore__ inline void AdvanceFnLocalPartials(int32_t slotCurr, int32_t baseDim);
+     __aicore__ inline void RunSeqFnRolling(int32_t start, int32_t len, int32_t channelStart, int32_t baseDim,
+                                            int32_t dim);
+     __aicore__ inline void RunSeq(int32_t start, int32_t len, int32_t channelStart, int32_t baseDim, int32_t dim);
+     __aicore__ inline void WriteBackState(int32_t cacheIdx, int32_t len, int32_t channelStart, int32_t baseDim,
+                                           int32_t dim);
+     __aicore__ inline void WriteBackStateSpec(int32_t cacheIdx, bool hasInit, int32_t stateTokenOffset, int32_t start,
+                                               int32_t len, int32_t channelStart, int32_t baseDim, int32_t dim);
+     __aicore__ inline void DrainTaskMte3();
+     __aicore__ inline void AllocEvents();
+     __aicore__ inline void ReleaseEvents();
+     __aicore__ inline int32_t FindVarlenSeqByToken(int32_t tokenIdx) const;
+     __aicore__ inline bool ResolveExplicitTokenTileSeqRange(int32_t tokenTileId, int32_t &startSeq, int32_t &endSeq) const;
+     __aicore__ inline bool ResolveSeqTaskWindow(int32_t seq, int32_t inputMode, int32_t seqLen, int32_t &start,
+                                                 int32_t &len) const;
+     template <int32_t kWindowMode>
+     __aicore__ inline bool ResolveSeqTaskWindowByMode(int32_t seq, int32_t seqLen, int32_t &start, int32_t &len) const;
+     __aicore__ inline int32_t ReadQueryStartLocValue(int32_t index) const;
+     __aicore__ inline int64_t ReadCacheIndexValue(int32_t seq) const;
+     __aicore__ inline bool ReadInitialStateModeValue(int32_t seq) const;
+     __aicore__ inline int32_t ReadNumAcceptedTokensValue(int32_t seq) const;
+     __aicore__ inline bool ResolveSeqCacheIndex(int32_t seq, bool hasCacheIndices, int32_t &cacheIdx) const;
+     __aicore__ inline bool ResolveSeqHasInit(int32_t seq, bool hasInitialStateMode) const;
+     __aicore__ inline void MaybeWriteBackSeqSplitTailChunk(int32_t chunkStart, int32_t chunkLen, int32_t seqStart,
+                                                            int32_t seqLen, int32_t cacheIdx, int32_t channelStart,
+                                                            int32_t baseDim, int32_t dim);
+     __aicore__ inline void ProcessDefault();
+     template <int32_t kWindowMode>
+     __aicore__ inline void ProcessDefaultByWindowMode();
+     __aicore__ inline void ProcessVarlenTokenTiled();
+     __aicore__ inline void ProcessFnChunk(int32_t seq, int32_t cacheIdx, bool hasInit, int32_t seqStart,
+                                           int32_t seqLen, int32_t chunkStart, int32_t chunkLen, int32_t channelStart,
+                                           int32_t baseDim, int32_t dim);
+     __aicore__ inline const CausalConv1dTilingData *GetTilingData() const;
+     __aicore__ inline bool HasActivation() const;
+     __aicore__ inline bool HasBias() const;
+     __aicore__ inline bool IsUpdateMode() const;
+     __aicore__ inline bool IsFnRollingFastPathEnabled() const;
+     __aicore__ inline bool HasExplicitFnTokenSeqRanges() const;
+     __aicore__ inline bool IsUpdateSpecDecodingEnabled() const;
+
+ protected:
+     TPipe pipe;
+     TBuf<QuePosition::VECIN> inBuf;
+     TBuf<QuePosition::VECOUT> outBuf;
+     TBuf<QuePosition::VECCALC> calcBuf;
+
+     TEventID weightBiasMte2ToVEvent_;
+     TEventID stateMte2ToVEvent_;
+     TEventID inputMte2ToVEvent_[RING_SLOTS];
+     TEventID inputVToMte2Event_;
+     TEventID outMte3ToVEvent_[2];
+     TEventID outVToMte3Event_[2];
+     TEventID stateWritebackMte3ToVEvent_;
+     TEventID stateWritebackMte3ToMte2Event_;
+     TEventID stateShiftMte2ToMte3Event_;
+     TEventID stateShiftVToMte3Event_;
+     TEventID stateShiftMte3ToMte2Event_;
+     TEventID initSnapshotMte2ToMte3Event_;
+     TEventID initSnapshotMte3ToMte2Event_;
+     TEventID initSyncVToMte3Event_;
+     TEventID initSyncMte3ToVEvent_;
+     TEventID specWritebackMte2ToMte3Event_[2];
+     TEventID specWritebackMte3ToMte2Event_[2];
+
+     GlobalTensor<T> xGm;
+     GlobalTensor<T> weightGm;
+     GlobalTensor<T> biasGm;
+     GlobalTensor<T> convStatesGm;
+     GlobalTensor<int32_t> queryStartLocGmInt32;
+     GlobalTensor<int64_t> queryStartLocGmInt64;
+     GlobalTensor<int32_t> cacheIndicesGmInt32;
+     GlobalTensor<int64_t> cacheIndicesGmInt64;
+     GlobalTensor<bool> initialStateModeGmBool;
+     GlobalTensor<int32_t> initialStateModeGmInt32;
+     GlobalTensor<int64_t> initialStateModeGmInt64;
+     GlobalTensor<int32_t> numAcceptedTokensGmInt32;
+     GlobalTensor<int64_t> numAcceptedTokensGmInt64;
+     GlobalTensor<T> yGm;
+     GlobalTensor<int32_t> initStateSyncGm_;
+     GlobalTensor<T> initStateWorkspaceGm_;
+
+     const CausalConv1dTilingData *tilingData_{nullptr};
+ };
+
+ template <CAUSAL_CONV1D_TEMPLATE_ARGS>
+ __aicore__ inline void CAUSAL_CONV1D_CLASS::ResetRuntimeState(const CausalConv1dTilingData *tilingData)
+ {
+     tilingData_ = tilingData;
+ }
+
+ template <CAUSAL_CONV1D_TEMPLATE_ARGS>
+ __aicore__ inline void CAUSAL_CONV1D_CLASS::InitSharedBuffersAndEvents()
+ {
+     pipe.InitBuffer(inBuf, RING_SLOTS * MAX_BLOCK_DIM * sizeof(T));
+     pipe.InitBuffer(outBuf, 2 * MAX_BLOCK_DIM * sizeof(T));
+     pipe.InitBuffer(calcBuf, (MAX_WIDTH + 4) * MAX_BLOCK_DIM * sizeof(float));
+     AllocEvents();
+ }
+
+ template <CAUSAL_CONV1D_TEMPLATE_ARGS>
+ __aicore__ inline void CAUSAL_CONV1D_CLASS::AllocEvents()
+ {
+     weightBiasMte2ToVEvent_ = GetTPipePtr()->AllocEventID<HardEvent::MTE2_V>();
+     stateMte2ToVEvent_ = GetTPipePtr()->AllocEventID<HardEvent::MTE2_V>();
+     for (int32_t i = 0; i < RING_SLOTS; ++i) {
+         inputMte2ToVEvent_[i] = GetTPipePtr()->AllocEventID<HardEvent::MTE2_V>();
+     }
+     inputVToMte2Event_ = GetTPipePtr()->AllocEventID<HardEvent::V_MTE2>();
+     outMte3ToVEvent_[0] = GetTPipePtr()->AllocEventID<HardEvent::MTE3_V>();
+     outMte3ToVEvent_[1] = GetTPipePtr()->AllocEventID<HardEvent::MTE3_V>();
+     outVToMte3Event_[0] = GetTPipePtr()->AllocEventID<HardEvent::V_MTE3>();
+     outVToMte3Event_[1] = GetTPipePtr()->AllocEventID<HardEvent::V_MTE3>();
+     stateWritebackMte3ToVEvent_ = GetTPipePtr()->AllocEventID<HardEvent::MTE3_V>();
+     stateWritebackMte3ToMte2Event_ = GetTPipePtr()->AllocEventID<HardEvent::MTE3_MTE2>();
+     stateShiftMte2ToMte3Event_ = GetTPipePtr()->AllocEventID<HardEvent::MTE2_MTE3>();
+     stateShiftVToMte3Event_ = GetTPipePtr()->AllocEventID<HardEvent::V_MTE3>();
+     stateShiftMte3ToMte2Event_ = GetTPipePtr()->AllocEventID<HardEvent::MTE3_MTE2>();
+     initSnapshotMte2ToMte3Event_ = GetTPipePtr()->AllocEventID<HardEvent::MTE2_MTE3>();
+     initSnapshotMte3ToMte2Event_ = GetTPipePtr()->AllocEventID<HardEvent::MTE3_MTE2>();
+     initSyncVToMte3Event_ = GetTPipePtr()->AllocEventID<HardEvent::V_MTE3>();
+     initSyncMte3ToVEvent_ = GetTPipePtr()->AllocEventID<HardEvent::MTE3_V>();
+     specWritebackMte2ToMte3Event_[0] = GetTPipePtr()->AllocEventID<HardEvent::MTE2_MTE3>();
+     specWritebackMte2ToMte3Event_[1] = GetTPipePtr()->AllocEventID<HardEvent::MTE2_MTE3>();
+     specWritebackMte3ToMte2Event_[0] = GetTPipePtr()->AllocEventID<HardEvent::MTE3_MTE2>();
+     specWritebackMte3ToMte2Event_[1] = GetTPipePtr()->AllocEventID<HardEvent::MTE3_MTE2>();
+ }
+
+ template <CAUSAL_CONV1D_TEMPLATE_ARGS>
+ __aicore__ inline void CAUSAL_CONV1D_CLASS::ReleaseEvents()
+ {
+     GetTPipePtr()->ReleaseEventID<HardEvent::MTE2_V>(weightBiasMte2ToVEvent_);
+     GetTPipePtr()->ReleaseEventID<HardEvent::MTE2_V>(stateMte2ToVEvent_);
+     for (int32_t i = 0; i < RING_SLOTS; ++i) {
+         GetTPipePtr()->ReleaseEventID<HardEvent::MTE2_V>(inputMte2ToVEvent_[i]);
+     }
+     GetTPipePtr()->ReleaseEventID<HardEvent::V_MTE2>(inputVToMte2Event_);
+     GetTPipePtr()->ReleaseEventID<HardEvent::MTE3_V>(outMte3ToVEvent_[0]);
+     GetTPipePtr()->ReleaseEventID<HardEvent::MTE3_V>(outMte3ToVEvent_[1]);
+     GetTPipePtr()->ReleaseEventID<HardEvent::V_MTE3>(outVToMte3Event_[0]);
+     GetTPipePtr()->ReleaseEventID<HardEvent::V_MTE3>(outVToMte3Event_[1]);
+     GetTPipePtr()->ReleaseEventID<HardEvent::MTE3_V>(stateWritebackMte3ToVEvent_);
+     GetTPipePtr()->ReleaseEventID<HardEvent::MTE3_MTE2>(stateWritebackMte3ToMte2Event_);
+     GetTPipePtr()->ReleaseEventID<HardEvent::MTE2_MTE3>(stateShiftMte2ToMte3Event_);
+     GetTPipePtr()->ReleaseEventID<HardEvent::V_MTE3>(stateShiftVToMte3Event_);
+     GetTPipePtr()->ReleaseEventID<HardEvent::MTE3_MTE2>(stateShiftMte3ToMte2Event_);
+     GetTPipePtr()->ReleaseEventID<HardEvent::MTE2_MTE3>(initSnapshotMte2ToMte3Event_);
+     GetTPipePtr()->ReleaseEventID<HardEvent::MTE3_MTE2>(initSnapshotMte3ToMte2Event_);
+     GetTPipePtr()->ReleaseEventID<HardEvent::V_MTE3>(initSyncVToMte3Event_);
+     GetTPipePtr()->ReleaseEventID<HardEvent::MTE3_V>(initSyncMte3ToVEvent_);
+     GetTPipePtr()->ReleaseEventID<HardEvent::MTE2_MTE3>(specWritebackMte2ToMte3Event_[0]);
+     GetTPipePtr()->ReleaseEventID<HardEvent::MTE2_MTE3>(specWritebackMte2ToMte3Event_[1]);
+     GetTPipePtr()->ReleaseEventID<HardEvent::MTE3_MTE2>(specWritebackMte3ToMte2Event_[0]);
+     GetTPipePtr()->ReleaseEventID<HardEvent::MTE3_MTE2>(specWritebackMte3ToMte2Event_[1]);
+ }
+
+ template <CAUSAL_CONV1D_TEMPLATE_ARGS>
+ __aicore__ inline void CAUSAL_CONV1D_CLASS::LoadWeightAndBias(int32_t channelStart, int32_t baseDim)
+ {
+     const int32_t dim = tilingData_->dim;
+     const int32_t width = static_cast<int32_t>(tilingData_->width);
+     const int32_t jStart = MAX_WIDTH - width;
+     const bool hasBias = HasBias();
+     auto cl = CalcBufLayout::FromCalcBuf(calcBuf);
+     LocalTensor<float> &weightF = cl.weightF;
+     LocalTensor<float> &biasF = cl.biasF;
+     LocalTensor<T> weightT;
+     LocalTensor<T> biasT;
+
+     if constexpr (!std::is_same<T, float>::value) {
+         weightT = weightF.ReinterpretCast<T>();
+         biasT = biasF.ReinterpretCast<T>();
+     }
+
+     for (int32_t j = 0; j < jStart; ++j) {
+         Duplicate(weightF[j * MAX_BLOCK_DIM], 0.0f, baseDim);
+     }
+
+     for (int32_t j = 0; j < width; ++j) {
+         const int32_t jDst = jStart + j;
+         const int64_t weightOffset = static_cast<int64_t>(j) * dim + channelStart;
+
+         if constexpr (std::is_same<T, float>::value) {
+             DataCopy(weightF[jDst * MAX_BLOCK_DIM], weightGm[weightOffset], baseDim);
+         } else {
+             DataCopy(weightT[jDst * MAX_BLOCK_DIM * 2 + MAX_BLOCK_DIM], weightGm[weightOffset], baseDim);
+         }
+     }
+
+     if (hasBias) {
+         if constexpr (std::is_same<T, float>::value) {
+             DataCopy(biasF, biasGm[channelStart], baseDim);
+         } else {
+             DataCopy(biasT[MAX_BLOCK_DIM], biasGm[channelStart], baseDim);
+         }
+     }
+
+     SetFlag<HardEvent::MTE2_V>(weightBiasMte2ToVEvent_);
+     WaitFlag<HardEvent::MTE2_V>(weightBiasMte2ToVEvent_);
+
+     if constexpr (!std::is_same<T, float>::value) {
+         for (int32_t j = 0; j < width; ++j) {
+             const int32_t jDst = jStart + j;
+             Cast(weightF[jDst * MAX_BLOCK_DIM], weightT[jDst * MAX_BLOCK_DIM * 2 + MAX_BLOCK_DIM], RoundMode::CAST_NONE,
+                  baseDim);
+         }
+         if (hasBias) {
+             Cast(biasF, biasT[MAX_BLOCK_DIM], RoundMode::CAST_NONE, baseDim);
+         }
+         PipeBarrier<PIPE_V>();
+     }
+
+     if (!hasBias) {
+         Duplicate(biasF, 0.0f, baseDim);
+     }
+ }
+
+ template <CAUSAL_CONV1D_TEMPLATE_ARGS>
+ __aicore__ inline void CAUSAL_CONV1D_CLASS::InitRing(int32_t cacheIdx, bool hasInit, int32_t stateTokenOffset,
+                                                      int32_t start, int32_t len, int32_t channelStart,
+                                                      int32_t baseDim, int32_t dim)
+ {
+     const int32_t stateLen = tilingData_->stateLen;
+     const int32_t width = static_cast<int32_t>(tilingData_->width);
+     const int32_t ringStart = MAX_WIDTH - width;
+     LocalTensor<T> ring = inBuf.Get<T>();
+
+     for (int32_t i = 0; i < ringStart; ++i) {
+         Duplicate(ring[i * MAX_BLOCK_DIM], static_cast<T>(0), baseDim);
+     }
+     if (ringStart > 0) {
+         PipeBarrier<PIPE_V>();
+     }
+
+     if (hasInit) {
+         for (int32_t i = 0; i < (width - 1); ++i) {
+             const int32_t pos = stateTokenOffset + i;
+             const int64_t stateOffset =
+                 static_cast<int64_t>(cacheIdx) * stateLen * dim + static_cast<int64_t>(pos) * dim + channelStart;
+             DataCopy(ring[(ringStart + i) * MAX_BLOCK_DIM], convStatesGm[stateOffset], baseDim);
+         }
+         SetFlag<HardEvent::MTE2_V>(stateMte2ToVEvent_);
+         WaitFlag<HardEvent::MTE2_V>(stateMte2ToVEvent_);
+     } else {
+         for (int32_t i = 0; i < (width - 1); ++i) {
+             Duplicate(ring[(ringStart + i) * MAX_BLOCK_DIM], static_cast<T>(0), baseDim);
+         }
+         PipeBarrier<PIPE_V>();
+     }
+
+     if (len > 0) {
+         const int32_t slot0 = SlotCurr(0);
+         const int64_t xOffset = static_cast<int64_t>(start) * dim + channelStart;
+         DataCopy(ring[slot0 * MAX_BLOCK_DIM], xGm[xOffset], baseDim);
+         SetFlag<HardEvent::MTE2_V>(inputMte2ToVEvent_[slot0]);
+     }
+
+     if (len > 1) {
+         SetFlag<HardEvent::V_MTE2>(inputVToMte2Event_);
+     }
+ }
+
+ template <CAUSAL_CONV1D_TEMPLATE_ARGS>
+ __aicore__ inline void CAUSAL_CONV1D_CLASS::RunSeq(int32_t start, int32_t len, int32_t channelStart,
+                                                    int32_t baseDim, int32_t dim)
+ {
+     if (IsFnRollingFastPathEnabled()) {
+         RunSeqFnRolling(start, len, channelStart, baseDim, dim);
+         return;
+     }
+
+     const int32_t width = static_cast<int32_t>(tilingData_->width);
+     const int32_t jStart = MAX_WIDTH - width;
+     auto cl = CalcBufLayout::FromCalcBuf(calcBuf);
+     LocalTensor<float> &weightF = cl.weightF;
+     LocalTensor<float> &biasF = cl.biasF;
+     LocalTensor<float> &accF = cl.accF;
+     LocalTensor<float> &tmpF = cl.tmpF;
+     LocalTensor<T> ring = inBuf.Get<T>();
+     LocalTensor<T> outT = outBuf.Get<T>();
+     const bool hasBias = HasBias();
+     const bool hasActivation = HasActivation();
+     for (int32_t t = 0; t < len; ++t) {
+         const int32_t slotCurr = SlotCurr(t);
+
+         WaitFlag<HardEvent::MTE2_V>(inputMte2ToVEvent_[slotCurr]);
+
+         if (t + 1 < len) {
+             const int32_t slotNext = SlotPrefetch(t);
+             const int64_t xOffsetNext = static_cast<int64_t>(start + t + 1) * dim + channelStart;
+             WaitFlag<HardEvent::V_MTE2>(inputVToMte2Event_);
+             DataCopy(ring[slotNext * MAX_BLOCK_DIM], xGm[xOffsetNext], baseDim);
+             SetFlag<HardEvent::MTE2_V>(inputMte2ToVEvent_[slotNext]);
+         }
+
+         bool accInitialized = false;
+         if (hasBias) {
+             Adds(accF, biasF, 0.0f, baseDim);
+             PipeBarrier<PIPE_V>();
+             accInitialized = true;
+         }
+
+         for (int32_t j = jStart; j < MAX_WIDTH; ++j) {
+             const int32_t tap = (MAX_WIDTH - 1) - j;
+             const int32_t slot = (tap == 0) ? slotCurr : SlotHist(t, tap);
+             Cast(tmpF, ring[slot * MAX_BLOCK_DIM], RoundMode::CAST_NONE, baseDim);
+             PipeBarrier<PIPE_V>();
+             if (!accInitialized) {
+                 Mul(accF, tmpF, weightF[j * MAX_BLOCK_DIM], baseDim);
+                 accInitialized = true;
+             } else {
+                 MulAddDst(accF, tmpF, weightF[j * MAX_BLOCK_DIM], baseDim);
+             }
+         }
+
+         PipeBarrier<PIPE_V>();
+
+         if (hasActivation) {
+             Silu(tmpF, accF, baseDim);
+         }
+
+         const int32_t outSlot = t & 1;
+         LocalTensor<T> outSlotT = outT[outSlot * MAX_BLOCK_DIM];
+         if (t >= 2) {
+             WaitFlag<HardEvent::MTE3_V>(outMte3ToVEvent_[outSlot]);
+         }
+
+         if constexpr (IsSameType<T, float>::value) {
+             if (hasActivation) {
+                 DataCopy(outSlotT, tmpF, baseDim);
+             } else {
+                 DataCopy(outSlotT, accF, baseDim);
+             }
+         } else {
+             if (hasActivation) {
+                 Cast(outSlotT, tmpF, RoundMode::CAST_RINT, baseDim);
+             } else {
+                 Cast(outSlotT, accF, RoundMode::CAST_RINT, baseDim);
+             }
+         }
+
+         SetFlag<HardEvent::V_MTE3>(outVToMte3Event_[outSlot]);
+
+         const int64_t outOffset = static_cast<int64_t>(start + t) * dim + channelStart;
+         WaitFlag<HardEvent::V_MTE3>(outVToMte3Event_[outSlot]);
+         DataCopy(yGm[outOffset], outSlotT, baseDim);
+         if (t + 2 < len) {
+             SetFlag<HardEvent::MTE3_V>(outMte3ToVEvent_[outSlot]);
+         }
+
+         if (t + 2 < len) {
+             SetFlag<HardEvent::V_MTE2>(inputVToMte2Event_);
+         }
+     }
+ }
+
+ template <CAUSAL_CONV1D_TEMPLATE_ARGS>
+ __aicore__ inline void CAUSAL_CONV1D_CLASS::RestoreFnLocalPartials(int32_t baseDim)
+ {
+     if constexpr (!kHasCompileTimeWidth) {
+         return;
+     }
+
+     auto cl = CalcBufLayout::FromCalcBuf(calcBuf);
+     LocalTensor<float> &weightF = cl.weightF;
+     LocalTensor<float> &state2F = cl.biasF;
+     LocalTensor<float> &state1F = cl.accF;
+     LocalTensor<float> &state0F = cl.tmpF;
+     LocalTensor<float> &currF = cl.currF;
+     LocalTensor<T> ring = inBuf.Get<T>();
+     constexpr int32_t ringStart = MAX_WIDTH - kTemplateWidth;
+     constexpr int32_t w0Idx = MAX_WIDTH - kTemplateWidth;
+
+     if constexpr (kTemplateWidth == 2) {
+         Duplicate(state2F, 0.0f, baseDim);
+         Duplicate(state1F, 0.0f, baseDim);
+         PipeBarrier<PIPE_V>();
+
+         Cast(currF, ring[ringStart * MAX_BLOCK_DIM], RoundMode::CAST_NONE, baseDim);
+         PipeBarrier<PIPE_V>();
+         Mul(state0F, currF, weightF[w0Idx * MAX_BLOCK_DIM], baseDim);
+         PipeBarrier<PIPE_V>();
+     } else if constexpr (kTemplateWidth == 3) {
+         Duplicate(state2F, 0.0f, baseDim);
+         PipeBarrier<PIPE_V>();
+
+         Cast(currF, ring[ringStart * MAX_BLOCK_DIM], RoundMode::CAST_NONE, baseDim);
+         PipeBarrier<PIPE_V>();
+         Mul(state0F, currF, weightF[w0Idx * MAX_BLOCK_DIM], baseDim);
+         PipeBarrier<PIPE_V>();
+
+         Cast(currF, ring[(ringStart + 1) * MAX_BLOCK_DIM], RoundMode::CAST_NONE, baseDim);
+         PipeBarrier<PIPE_V>();
+         Mul(state1F, currF, weightF[w0Idx * MAX_BLOCK_DIM], baseDim);
+         PipeBarrier<PIPE_V>();
+         MulAddDst(state0F, currF, weightF[(w0Idx + 1) * MAX_BLOCK_DIM], baseDim);
+         PipeBarrier<PIPE_V>();
+     } else if constexpr (kTemplateWidth == 4) {
+         Cast(currF, ring[ringStart * MAX_BLOCK_DIM], RoundMode::CAST_NONE, baseDim);
+         PipeBarrier<PIPE_V>();
+         Mul(state0F, currF, weightF[w0Idx * MAX_BLOCK_DIM], baseDim);
+         PipeBarrier<PIPE_V>();
+
+         Cast(currF, ring[(ringStart + 1) * MAX_BLOCK_DIM], RoundMode::CAST_NONE, baseDim);
+         PipeBarrier<PIPE_V>();
+         Mul(state1F, currF, weightF[w0Idx * MAX_BLOCK_DIM], baseDim);
+         PipeBarrier<PIPE_V>();
+         MulAddDst(state0F, currF, weightF[(w0Idx + 1) * MAX_BLOCK_DIM], baseDim);
+         PipeBarrier<PIPE_V>();
+
+         Cast(currF, ring[(ringStart + 2) * MAX_BLOCK_DIM], RoundMode::CAST_NONE, baseDim);
+         PipeBarrier<PIPE_V>();
+         Mul(state2F, currF, weightF[w0Idx * MAX_BLOCK_DIM], baseDim);
+         PipeBarrier<PIPE_V>();
+         MulAddDst(state1F, currF, weightF[(w0Idx + 1) * MAX_BLOCK_DIM], baseDim);
+         PipeBarrier<PIPE_V>();
+         MulAddDst(state0F, currF, weightF[(w0Idx + 2) * MAX_BLOCK_DIM], baseDim);
+         PipeBarrier<PIPE_V>();
+     }
+ }
+
+ template <CAUSAL_CONV1D_TEMPLATE_ARGS>
+ __aicore__ inline void CAUSAL_CONV1D_CLASS::ComputeFnRollingOutput(int32_t slotCurr, int32_t baseDim)
+ {
+     if constexpr (!kHasCompileTimeWidth) {
+         return;
+     }
+
+     auto cl = CalcBufLayout::FromCalcBuf(calcBuf);
+     LocalTensor<float> &weightF = cl.weightF;
+     LocalTensor<float> &state0F = cl.tmpF;
+     LocalTensor<float> &currF = cl.currF;
+     LocalTensor<T> ring = inBuf.Get<T>();
+
+#if defined(__CCE_AICORE__) && __CCE_AICORE__ == 310
+    const bool hasActivation = HasActivation();
+    if (hasActivation) {
+        ComputeFnRollingOutputRegbase<T, true>(ring[slotCurr * MAX_BLOCK_DIM], currF, state0F, weightF[3 * MAX_BLOCK_DIM], baseDim);
+    } else {
+        ComputeFnRollingOutputRegbase<T, false>(ring[slotCurr * MAX_BLOCK_DIM], currF, state0F, weightF[3 * MAX_BLOCK_DIM], baseDim);
+    }
+#else
+    Cast(currF, ring[slotCurr * MAX_BLOCK_DIM], RoundMode::CAST_NONE, baseDim);
+    PipeBarrier<PIPE_V>();
+    MulAddDst(state0F, currF, weightF[3 * MAX_BLOCK_DIM], baseDim);
+    PipeBarrier<PIPE_V>();
+
+    const bool hasActivation = HasActivation();
+    if (hasActivation) {
+        PipeBarrier<PIPE_V>();
+        Silu(currF, state0F, baseDim);
+    }
+#endif
+ }
+
+ template <CAUSAL_CONV1D_TEMPLATE_ARGS>
+ __aicore__ inline void CAUSAL_CONV1D_CLASS::AdvanceFnLocalPartials(int32_t slotCurr, int32_t baseDim)
+ {
+     if constexpr (!kHasCompileTimeWidth) {
+         return;
+     }
+
+     auto cl = CalcBufLayout::FromCalcBuf(calcBuf);
+     LocalTensor<float> &weightF = cl.weightF;
+     LocalTensor<float> &state2F = cl.biasF;
+     LocalTensor<float> &state1F = cl.accF;
+     LocalTensor<float> &state0F = cl.tmpF;
+     LocalTensor<float> &currF = cl.currF;
+     LocalTensor<T> ring = inBuf.Get<T>();
+     constexpr int32_t w0Idx = MAX_WIDTH - kTemplateWidth;
+
+#if defined(__CCE_AICORE__) && __CCE_AICORE__ == 310
+    AdvanceFnLocalPartialsRegbase<T, kTemplateWidth>(ring[slotCurr * MAX_BLOCK_DIM], weightF[w0Idx * MAX_BLOCK_DIM],
+        state0F, state1F, state2F, baseDim, MAX_BLOCK_DIM);
+#else
+    Cast(currF, ring[slotCurr * MAX_BLOCK_DIM], RoundMode::CAST_NONE, baseDim);
+    PipeBarrier<PIPE_V>();
+
+    if constexpr (kTemplateWidth == 2) {
+        Mul(state0F, currF, weightF[w0Idx * MAX_BLOCK_DIM], baseDim);
+        PipeBarrier<PIPE_V>();
+    } else if constexpr (kTemplateWidth == 3) {
+        Mul(state0F, currF, weightF[(w0Idx + 1) * MAX_BLOCK_DIM], baseDim);
+        PipeBarrier<PIPE_V>();
+        Add(state0F, state0F, state1F, baseDim);
+        PipeBarrier<PIPE_V>();
+
+        Mul(state1F, currF, weightF[w0Idx * MAX_BLOCK_DIM], baseDim);
+        PipeBarrier<PIPE_V>();
+    } else if constexpr (kTemplateWidth == 4) {
+        Mul(state0F, currF, weightF[(w0Idx + 2) * MAX_BLOCK_DIM], baseDim);
+        PipeBarrier<PIPE_V>();
+        Add(state0F, state0F, state1F, baseDim);
+        PipeBarrier<PIPE_V>();
+
+        Mul(state1F, currF, weightF[(w0Idx + 1) * MAX_BLOCK_DIM], baseDim);
+        PipeBarrier<PIPE_V>();
+        Add(state1F, state1F, state2F, baseDim);
+        PipeBarrier<PIPE_V>();
+
+        Mul(state2F, currF, weightF[w0Idx * MAX_BLOCK_DIM], baseDim);
+        PipeBarrier<PIPE_V>();
+    }
+#endif
+ }
+
+ template <CAUSAL_CONV1D_TEMPLATE_ARGS>
+ __aicore__ inline void CAUSAL_CONV1D_CLASS::RunSeqFnRolling(int32_t start, int32_t len, int32_t channelStart,
+                                                             int32_t baseDim, int32_t dim)
+ {
+     if constexpr (!kHasCompileTimeWidth) {
+         return;
+     }
+
+     auto cl = CalcBufLayout::FromCalcBuf(calcBuf);
+     LocalTensor<float> &state0F = cl.tmpF;
+     LocalTensor<float> &currF = cl.currF;
+     LocalTensor<T> ring = inBuf.Get<T>();
+     LocalTensor<T> outT = outBuf.Get<T>();
+     const bool hasActivation = HasActivation();
+     RestoreFnLocalPartials(baseDim);
+
+     for (int32_t t = 0; t < len; ++t) {
+         const int32_t slotCurr = SlotCurr(t);
+
+         WaitFlag<HardEvent::MTE2_V>(inputMte2ToVEvent_[slotCurr]);
+
+         if (t + 1 < len) {
+             const int32_t slotNext = SlotPrefetch(t);
+             const int64_t xOffsetNext = static_cast<int64_t>(start + t + 1) * dim + channelStart;
+             WaitFlag<HardEvent::V_MTE2>(inputVToMte2Event_);
+             DataCopy(ring[slotNext * MAX_BLOCK_DIM], xGm[xOffsetNext], baseDim);
+             SetFlag<HardEvent::MTE2_V>(inputMte2ToVEvent_[slotNext]);
+         }
+
+         ComputeFnRollingOutput(slotCurr, baseDim);
+
+         const int32_t outSlot = t & 1;
+         LocalTensor<T> outSlotT = outT[outSlot * MAX_BLOCK_DIM];
+         if (t >= 2) {
+             WaitFlag<HardEvent::MTE3_V>(outMte3ToVEvent_[outSlot]);
+         }
+
+         if constexpr (IsSameType<T, float>::value) {
+             if (hasActivation) {
+                 DataCopy(outSlotT, currF, baseDim);
+             } else {
+                 DataCopy(outSlotT, state0F, baseDim);
+             }
+         } else {
+             if (hasActivation) {
+                 Cast(outSlotT, currF, RoundMode::CAST_RINT, baseDim);
+             } else {
+                 Cast(outSlotT, state0F, RoundMode::CAST_RINT, baseDim);
+             }
+         }
+
+         AdvanceFnLocalPartials(slotCurr, baseDim);
+
+         SetFlag<HardEvent::V_MTE3>(outVToMte3Event_[outSlot]);
+
+         const int64_t outOffset = static_cast<int64_t>(start + t) * dim + channelStart;
+         WaitFlag<HardEvent::V_MTE3>(outVToMte3Event_[outSlot]);
+         DataCopy(yGm[outOffset], outSlotT, baseDim);
+         if (t + 2 < len) {
+             SetFlag<HardEvent::MTE3_V>(outMte3ToVEvent_[outSlot]);
+         }
+
+         if (t + 2 < len) {
+             SetFlag<HardEvent::V_MTE2>(inputVToMte2Event_);
+         }
+     }
+ }
+
+ template <CAUSAL_CONV1D_TEMPLATE_ARGS>
+ __aicore__ inline void CAUSAL_CONV1D_CLASS::DrainTaskMte3()
+ {
+     SetFlag<HardEvent::MTE3_V>(stateWritebackMte3ToVEvent_);
+     WaitFlag<HardEvent::MTE3_V>(stateWritebackMte3ToVEvent_);
+     SetFlag<HardEvent::MTE3_MTE2>(stateWritebackMte3ToMte2Event_);
+     WaitFlag<HardEvent::MTE3_MTE2>(stateWritebackMte3ToMte2Event_);
+ }
+
+ template <CAUSAL_CONV1D_TEMPLATE_ARGS>
+ __aicore__ inline void CAUSAL_CONV1D_CLASS::WriteBackState(int32_t cacheIdx, int32_t len, int32_t channelStart,
+                                                            int32_t baseDim, int32_t dim)
+ {
+     const int32_t stateLen = tilingData_->stateLen;
+     const int32_t width = static_cast<int32_t>(tilingData_->width);
+     if (len <= 0) {
+         return;
+     }
+
+     const int32_t lastT = len - 1;
+     LocalTensor<T> ring = inBuf.Get<T>();
+     const int32_t lastSlot = SlotCurr(lastT);
+     const int64_t stateBaseOffset = static_cast<int64_t>(cacheIdx) * stateLen * dim + channelStart;
+
+     for (int32_t pos = 0; pos < (width - 1); ++pos) {
+         const int32_t tap = (width - 2) - pos;
+         const int32_t slot = RetreatRingSlot(lastSlot, tap);
+         const int64_t stateOffset = stateBaseOffset + static_cast<int64_t>(pos) * dim;
+         DataCopy(convStatesGm[stateOffset], ring[slot * MAX_BLOCK_DIM], baseDim);
+     }
+ }
+
+ template <CAUSAL_CONV1D_TEMPLATE_ARGS>
+ __aicore__ inline void CAUSAL_CONV1D_CLASS::WriteBackStateSpec(int32_t cacheIdx, bool hasInit,
+                                                                int32_t stateTokenOffset, int32_t start, int32_t len,
+                                                                int32_t channelStart, int32_t baseDim, int32_t dim)
+ {
+     const int32_t width = static_cast<int32_t>(tilingData_->width);
+     const int32_t stateLen = tilingData_->stateLen;
+     if (len <= 0) {
+         return;
+     }
+
+     if (width != 4) {
+         WriteBackState(cacheIdx, len, channelStart, baseDim, dim);
+         return;
+     }
+
+     constexpr int32_t keep = MAX_WIDTH - 2;
+     const int32_t reqStateLen = keep + len;
+     if (reqStateLen > stateLen) {
+         WriteBackState(cacheIdx, len, channelStart, baseDim, dim);
+         return;
+     }
+
+     LocalTensor<T> ring = inBuf.Get<T>();
+     LocalTensor<T> buf0 = ring[0 * MAX_BLOCK_DIM];
+     LocalTensor<T> buf1 = ring[1 * MAX_BLOCK_DIM];
+
+     if (hasInit) {
+         const int32_t srcPos0 = stateTokenOffset + 1;
+         const int32_t srcPos1 = stateTokenOffset + 2;
+         const int64_t srcOffset0 =
+             static_cast<int64_t>(cacheIdx) * stateLen * dim + static_cast<int64_t>(srcPos0) * dim + channelStart;
+         const int64_t srcOffset1 =
+             static_cast<int64_t>(cacheIdx) * stateLen * dim + static_cast<int64_t>(srcPos1) * dim + channelStart;
+         DataCopy(buf0, convStatesGm[srcOffset0], baseDim);
+         DataCopy(buf1, convStatesGm[srcOffset1], baseDim);
+         SetFlag<HardEvent::MTE2_MTE3>(stateShiftMte2ToMte3Event_);
+         WaitFlag<HardEvent::MTE2_MTE3>(stateShiftMte2ToMte3Event_);
+         const int64_t dstOffset0 =
+             static_cast<int64_t>(cacheIdx) * stateLen * dim + static_cast<int64_t>(0) * dim + channelStart;
+         const int64_t dstOffset1 =
+             static_cast<int64_t>(cacheIdx) * stateLen * dim + static_cast<int64_t>(1) * dim + channelStart;
+         DataCopy(convStatesGm[dstOffset0], buf0, baseDim);
+         DataCopy(convStatesGm[dstOffset1], buf1, baseDim);
+         SetFlag<HardEvent::MTE3_MTE2>(stateShiftMte3ToMte2Event_);
+         WaitFlag<HardEvent::MTE3_MTE2>(stateShiftMte3ToMte2Event_);
+     } else {
+         Duplicate(buf0, static_cast<T>(0), baseDim);
+         SetFlag<HardEvent::V_MTE3>(stateShiftVToMte3Event_);
+         WaitFlag<HardEvent::V_MTE3>(stateShiftVToMte3Event_);
+         const int64_t dstOffset0 =
+             static_cast<int64_t>(cacheIdx) * stateLen * dim + static_cast<int64_t>(0) * dim + channelStart;
+         const int64_t dstOffset1 =
+             static_cast<int64_t>(cacheIdx) * stateLen * dim + static_cast<int64_t>(1) * dim + channelStart;
+         DataCopy(convStatesGm[dstOffset0], buf0, baseDim);
+         DataCopy(convStatesGm[dstOffset1], buf0, baseDim);
+         SetFlag<HardEvent::MTE3_MTE2>(stateShiftMte3ToMte2Event_);
+         WaitFlag<HardEvent::MTE3_MTE2>(stateShiftMte3ToMte2Event_);
+     }
+
+     const int64_t xOffset0 = static_cast<int64_t>(start) * dim + channelStart;
+     DataCopy(buf0, xGm[xOffset0], baseDim);
+     SetFlag<HardEvent::MTE2_MTE3>(specWritebackMte2ToMte3Event_[0]);
+
+     for (int32_t t = 0; t < len; ++t) {
+         const int32_t curr = t & 1;
+         const int32_t next = curr ^ 1;
+         LocalTensor<T> currBuf = (curr == 0) ? buf0 : buf1;
+         LocalTensor<T> nextBuf = (next == 0) ? buf0 : buf1;
+
+         WaitFlag<HardEvent::MTE2_MTE3>(specWritebackMte2ToMte3Event_[curr]);
+
+         if (t + 1 < len) {
+             const int64_t xOffsetNext = static_cast<int64_t>(start + t + 1) * dim + channelStart;
+             if (t > 0) {
+                 WaitFlag<HardEvent::MTE3_MTE2>(specWritebackMte3ToMte2Event_[next]);
+             }
+             DataCopy(nextBuf, xGm[xOffsetNext], baseDim);
+             SetFlag<HardEvent::MTE2_MTE3>(specWritebackMte2ToMte3Event_[next]);
+         }
+
+         const int64_t dstOffset =
+             static_cast<int64_t>(cacheIdx) * stateLen * dim + static_cast<int64_t>(keep + t) * dim + channelStart;
+         DataCopy(convStatesGm[dstOffset], currBuf, baseDim);
+         SetFlag<HardEvent::MTE3_MTE2>(specWritebackMte3ToMte2Event_[curr]);
+     }
+
+     WaitFlag<HardEvent::MTE3_MTE2>(specWritebackMte3ToMte2Event_[0]);
+     if (len > 1) {
+         WaitFlag<HardEvent::MTE3_MTE2>(specWritebackMte3ToMte2Event_[1]);
+     }
+ }
+
+ template <CAUSAL_CONV1D_TEMPLATE_ARGS>
+ __aicore__ inline bool CAUSAL_CONV1D_CLASS::ResolveSeqTaskWindow(int32_t seq, int32_t inputMode, int32_t seqLen,
+                                                                  int32_t &start, int32_t &len) const
+ {
+     switch (GetSeqTaskWindowMode(inputMode)) {
+         case SEQ_TASK_WINDOW_MODE_VARLEN:
+             return ResolveSeqTaskWindowByMode<SEQ_TASK_WINDOW_MODE_VARLEN>(seq, seqLen, start, len);
+         case SEQ_TASK_WINDOW_MODE_DECODE2D:
+             return ResolveSeqTaskWindowByMode<SEQ_TASK_WINDOW_MODE_DECODE2D>(seq, seqLen, start, len);
+         default:
+             return ResolveSeqTaskWindowByMode<SEQ_TASK_WINDOW_MODE_BATCH>(seq, seqLen, start, len);
+     }
+ }
+
+ template <CAUSAL_CONV1D_TEMPLATE_ARGS>
+ template <int32_t kWindowMode>
+ __aicore__ inline bool CAUSAL_CONV1D_CLASS::ResolveSeqTaskWindowByMode(int32_t seq, int32_t seqLen, int32_t &start,
+                                                                        int32_t &len) const
+ {
+     SeqTaskWindow window;
+     if constexpr (kWindowMode == SEQ_TASK_WINDOW_MODE_VARLEN) {
+         const int32_t startVal = ReadQueryStartLocValue(seq);
+         const int32_t endVal = ReadQueryStartLocValue(seq + 1);
+         if (startVal < 0 || endVal < startVal || endVal > tilingData_->cuSeqlen) {
+             return false;
+         }
+         window = BuildSeqTaskWindowVarlen(startVal, endVal);
+     } else if constexpr (kWindowMode == SEQ_TASK_WINDOW_MODE_DECODE2D) {
+         window = BuildSeqTaskWindowDecode2D(seq);
+     } else {
+         window = BuildSeqTaskWindowBatch(seq, seqLen);
+     }
+
+     if (!window.valid) {
+         return false;
+     }
+     start = window.start;
+     len = window.len;
+     return true;
+ }
+
+ template <CAUSAL_CONV1D_TEMPLATE_ARGS>
+ __aicore__ inline int32_t CAUSAL_CONV1D_CLASS::ReadQueryStartLocValue(int32_t index) const
+ {
+     if (tilingData_->queryStartLocUseInt64 != 0) {
+         const int64_t value = queryStartLocGmInt64.GetValue(index);
+         if (value < 0 || value > INT32_MAX_VALUE) {
+             return -1;
+         }
+         return static_cast<int32_t>(value);
+     }
+     return queryStartLocGmInt32.GetValue(index);
+ }
+
+ template <CAUSAL_CONV1D_TEMPLATE_ARGS>
+ __aicore__ inline int64_t CAUSAL_CONV1D_CLASS::ReadCacheIndexValue(int32_t seq) const
+ {
+     const int32_t offset = seq * static_cast<int32_t>(tilingData_->cacheIndicesStride);
+     if (tilingData_->cacheIndicesUseInt64 != 0) {
+         return cacheIndicesGmInt64.GetValue(offset);
+     }
+     return static_cast<int64_t>(cacheIndicesGmInt32.GetValue(offset));
+ }
+
+ template <CAUSAL_CONV1D_TEMPLATE_ARGS>
+ __aicore__ inline bool CAUSAL_CONV1D_CLASS::ReadInitialStateModeValue(int32_t seq) const
+ {
+     if (tilingData_->initialStateModeDtype == 2) {
+         return initialStateModeGmInt64.GetValue(seq) != 0;
+     }
+     if (tilingData_->initialStateModeDtype == 1) {
+         return initialStateModeGmInt32.GetValue(seq) != 0;
+     }
+     return initialStateModeGmBool.GetValue(seq);
+ }
+
+ template <CAUSAL_CONV1D_TEMPLATE_ARGS>
+ __aicore__ inline int32_t CAUSAL_CONV1D_CLASS::ReadNumAcceptedTokensValue(int32_t seq) const
+ {
+     if (tilingData_->numAcceptedTokensUseInt64 != 0) {
+         const int64_t value = numAcceptedTokensGmInt64.GetValue(seq);
+         if (value <= 0) {
+             return 0;
+         }
+         if (value > INT32_MAX_VALUE) {
+             return static_cast<int32_t>(INT32_MAX_VALUE);
+         }
+         return static_cast<int32_t>(value);
+     }
+     return numAcceptedTokensGmInt32.GetValue(seq);
+ }
+
+ template <CAUSAL_CONV1D_TEMPLATE_ARGS>
+ __aicore__ inline bool CAUSAL_CONV1D_CLASS::ResolveSeqCacheIndex(int32_t seq, bool hasCacheIndices,
+                                                                  int32_t &cacheIdx) const
+ {
+     cacheIdx = seq;
+     if (!hasCacheIndices) {
+         return true;
+     }
+
+     const int64_t cacheIdx64 = ReadCacheIndexValue(seq);
+     if (cacheIdx64 == tilingData_->padSlotId) {
+         return false;
+     }
+     if (cacheIdx64 < 0 || cacheIdx64 >= tilingData_->numCacheLines) {
+         return false;
+     }
+     cacheIdx = static_cast<int32_t>(cacheIdx64);
+     return true;
+ }
+
+ template <CAUSAL_CONV1D_TEMPLATE_ARGS>
+ __aicore__ inline bool CAUSAL_CONV1D_CLASS::ResolveSeqHasInit(int32_t seq, bool hasInitialStateMode) const
+ {
+     return hasInitialStateMode ? ReadInitialStateModeValue(seq) : false;
+ }
+
+ template <CAUSAL_CONV1D_TEMPLATE_ARGS>
+ __aicore__ inline void CAUSAL_CONV1D_CLASS::ProcessDefault()
+ {
+     switch (GetSeqTaskWindowMode(tilingData_->inputMode)) {
+         case SEQ_TASK_WINDOW_MODE_VARLEN:
+             ProcessDefaultByWindowMode<SEQ_TASK_WINDOW_MODE_VARLEN>();
+             return;
+         case SEQ_TASK_WINDOW_MODE_DECODE2D:
+             ProcessDefaultByWindowMode<SEQ_TASK_WINDOW_MODE_DECODE2D>();
+             return;
+         default:
+             ProcessDefaultByWindowMode<SEQ_TASK_WINDOW_MODE_BATCH>();
+             return;
+     }
+ }
+
+ template <CAUSAL_CONV1D_TEMPLATE_ARGS>
+ template <int32_t kWindowMode>
+ __aicore__ inline void CAUSAL_CONV1D_CLASS::ProcessDefaultByWindowMode()
+ {
+     const int32_t dim = tilingData_->dim;
+     const int32_t batch = tilingData_->batch;
+     const int32_t seqLen = tilingData_->seqLen;
+     const int32_t baseDim = static_cast<int32_t>(tilingData_->baseDim);
+     const int32_t baseDimCnt = static_cast<int32_t>(tilingData_->baseDimCnt);
+     const int32_t width = static_cast<int32_t>(tilingData_->width);
+     const bool hasCacheIndices = (tilingData_->hasCacheIndices != 0);
+     const bool hasInit = true;
+     const bool isSpecDecodingGlobal = IsUpdateSpecDecodingEnabled();
+
+     const uint32_t blockIdx = GetBlockIdx();
+     const uint32_t blockNum = GetBlockNum();
+
+     if (baseDim <= 0 || baseDimCnt <= 0 || baseDim > MAX_BLOCK_DIM || width < 2 || width > MAX_WIDTH) {
+         ReleaseEvents();
+         return;
+     }
+
+     const int64_t gridSize = static_cast<int64_t>(batch) * baseDimCnt;
+     for (int64_t task = static_cast<int64_t>(blockIdx); task < gridSize; task += static_cast<int64_t>(blockNum)) {
+         const int32_t seq = static_cast<int32_t>(task / baseDimCnt);
+         const int32_t baseDimIdx = static_cast<int32_t>(task % baseDimCnt);
+         const int32_t channelStart = baseDimIdx * baseDim;
+         if (channelStart >= dim) {
+             continue;
+         }
+         const int32_t curBaseDim = (channelStart + baseDim <= dim) ? baseDim : (dim - channelStart);
+
+         int32_t start = 0;
+         int32_t len = 0;
+         if (!ResolveSeqTaskWindowByMode<kWindowMode>(seq, seqLen, start, len)) {
+             continue;
+         }
+
+         int32_t cacheIdx = 0;
+         if (!ResolveSeqCacheIndex(seq, hasCacheIndices, cacheIdx)) {
+             continue;
+         }
+
+         int32_t stateTokenOffset = 0;
+         if (isSpecDecodingGlobal) {
+#if defined(DCUT_CAUSAL_CONV_DIRECT_STATE_OFFSETS)
+             stateTokenOffset = ReadNumAcceptedTokensValue(seq);
+#else
+             int32_t accepted = ReadNumAcceptedTokensValue(seq);
+             stateTokenOffset = accepted - 1;
+#endif
+             const int32_t maxOffset = static_cast<int32_t>(tilingData_->stateLen - (width - 1));
+             if (stateTokenOffset < 0) {
+                 stateTokenOffset = 0;
+             } else if (stateTokenOffset > maxOffset) {
+                 stateTokenOffset = maxOffset;
+             }
+         }
+
+         LoadWeightAndBias(channelStart, curBaseDim);
+
+         InitRing(cacheIdx, hasInit, stateTokenOffset, start, len, channelStart, curBaseDim, dim);
+         RunSeq(start, len, channelStart, curBaseDim, dim);
+
+         if (isSpecDecodingGlobal) {
+             DrainTaskMte3();
+             WriteBackStateSpec(cacheIdx, hasInit, stateTokenOffset, start, len, channelStart, curBaseDim, dim);
+         } else {
+             WriteBackState(cacheIdx, len, channelStart, curBaseDim, dim);
+         }
+
+         DrainTaskMte3();
+     }
+ }
+
+ template <CAUSAL_CONV1D_TEMPLATE_ARGS>
+ __aicore__ inline const CausalConv1dTilingData *CAUSAL_CONV1D_CLASS::GetTilingData() const
+ {
+     return tilingData_;
+ }
+
+ template <CAUSAL_CONV1D_TEMPLATE_ARGS>
+ __aicore__ inline bool CAUSAL_CONV1D_CLASS::HasActivation() const
+ {
+     return (tilingData_ != nullptr) && (tilingData_->activationMode != 0);
+ }
+
+ template <CAUSAL_CONV1D_TEMPLATE_ARGS>
+ __aicore__ inline bool CAUSAL_CONV1D_CLASS::HasBias() const
+ {
+     return (tilingData_ != nullptr) && (tilingData_->hasBias != 0);
+ }
+
+ template <CAUSAL_CONV1D_TEMPLATE_ARGS>
+ __aicore__ inline bool CAUSAL_CONV1D_CLASS::IsUpdateMode() const
+ {
+     return kIsUpdateMode;
+ }
+
+ template <CAUSAL_CONV1D_TEMPLATE_ARGS>
+ __aicore__ inline bool CAUSAL_CONV1D_CLASS::IsFnRollingFastPathEnabled() const
+ {
+     return !kIsUpdateMode && (tilingData_ != nullptr) && (kFnExecutionPlan != FN_EXECUTION_PLAN_INVALID) &&
+            (tilingData_->hasNumAcceptedTokens == 0) && !HasBias();
+ }
+
+ template <CAUSAL_CONV1D_TEMPLATE_ARGS>
+ __aicore__ inline bool CAUSAL_CONV1D_CLASS::HasExplicitFnTokenSeqRanges() const
+ {
+     return !kIsUpdateMode && (tilingData_ != nullptr) && (tilingData_->inputMode == 0) &&
+            (tilingData_->hasExplicitTokenSeqRanges != 0) &&
+            (tilingData_->explicitTokenSeqRangeCount >= tilingData_->tokenBlockCnt);
+ }
+
+ template <CAUSAL_CONV1D_TEMPLATE_ARGS>
+ __aicore__ inline bool CAUSAL_CONV1D_CLASS::IsUpdateSpecDecodingEnabled() const
+ {
+     return kIsUpdateMode && (tilingData_->hasNumAcceptedTokens != 0) && (tilingData_->width == 4);
+ }
+
+ #include "causal_conv1d_fn_tasks.h"
+
+ #undef CAUSAL_CONV1D_CLASS
+ #undef CAUSAL_CONV1D_TEMPLATE_ARGS
+
+} // namespace NsCausalConv1d
+#endif // CAUSAL_CONV1D_H

--- a/dcut/kernel/dcut_causal_conv1d/vendor/op_kernel/causal_conv1d_common.h
+++ b/dcut/kernel/dcut_causal_conv1d/vendor/op_kernel/causal_conv1d_common.h
@@ -1,0 +1,66 @@
+/**
+ * This program is free software, you can redistribute it and/or modify it.
+ * Copyright (c) 2025 Huawei Technologies Co., Ltd.
+ * This file is a part of the CANN Open Software.
+ * Licensed under CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING
+ * BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ */
+
+/*!
+ * \file causal_conv1d_common.h
+ */
+
+#ifndef CAUSAL_CONV1D_COMMON_H
+#define CAUSAL_CONV1D_COMMON_H
+
+#include "kernel_operator.h"
+
+namespace NsCausalConv1dCommon {
+
+constexpr int32_t MAX_WIDTH = 4;
+constexpr int32_t MAX_BLOCK_DIM = 4096;
+constexpr int32_t RING_SLOTS = 5;
+
+__aicore__ inline int32_t SlotCurr(int32_t t)
+{
+    return (t + 3) % RING_SLOTS;
+}
+
+__aicore__ inline int32_t SlotHist(int32_t t, int32_t i)
+{
+    return (t + 3 - i) % RING_SLOTS;
+}
+
+__aicore__ inline int32_t SlotPrefetch(int32_t t)
+{
+    return (t + 4) % RING_SLOTS;
+}
+
+struct CalcBufLayout {
+    AscendC::LocalTensor<float> weightF;
+    AscendC::LocalTensor<float> biasF;
+    AscendC::LocalTensor<float> accF;
+    AscendC::LocalTensor<float> tmpF;
+    AscendC::LocalTensor<float> currF;
+
+    __aicore__ inline CalcBufLayout() = default;
+
+    __aicore__ static inline CalcBufLayout FromCalcBuf(AscendC::TBuf<AscendC::QuePosition::VECCALC> &calcBuf)
+    {
+        CalcBufLayout layout;
+        AscendC::LocalTensor<float> calc = calcBuf.template Get<float>();
+        layout.weightF = calc;
+        layout.biasF = calc[MAX_WIDTH * MAX_BLOCK_DIM];
+        layout.accF = layout.biasF[MAX_BLOCK_DIM];
+        layout.tmpF = layout.accF[MAX_BLOCK_DIM];
+        layout.currF = layout.tmpF[MAX_BLOCK_DIM];
+        return layout;
+    }
+};
+
+} // namespace NsCausalConv1dCommon
+
+#endif // CAUSAL_CONV1D_COMMON_H

--- a/dcut/kernel/dcut_causal_conv1d/vendor/op_kernel/causal_conv1d_fn.h
+++ b/dcut/kernel/dcut_causal_conv1d/vendor/op_kernel/causal_conv1d_fn.h
@@ -1,0 +1,93 @@
+/**
+ * This program is free software, you can redistribute it and/or modify it.
+ * Copyright (c) 2025 Huawei Technologies Co., Ltd.
+ * This file is a part of the CANN Open Software.
+ * Licensed under CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING
+ * BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ */
+
+ #ifndef CAUSAL_CONV1D_FN_H
+ #define CAUSAL_CONV1D_FN_H
+
+ #include "causal_conv1d.h"
+
+ namespace NsCausalConv1d {
+
+ template <typename T, uint32_t widthKey, uint32_t fnPlanKey>
+ class CausalConv1dFn : public CausalConv1d<T, CAUSAL_CONV1D_TPL_RUN_MODE_FN, widthKey, fnPlanKey> {
+ public:
+     __aicore__ inline void Init(GM_ADDR x, GM_ADDR weight, GM_ADDR bias, GM_ADDR convStates, GM_ADDR queryStartLoc,
+                                 GM_ADDR cacheIndices, GM_ADDR initialStateMode, GM_ADDR numAcceptedTokens, GM_ADDR y,
+                                 GM_ADDR workspace, const CausalConv1dTilingData *tilingData)
+     {
+         (void)numAcceptedTokens;
+         this->ResetRuntimeState(tilingData);
+         this->xGm.SetGlobalBuffer(reinterpret_cast<__gm__ T *>(x));
+         this->weightGm.SetGlobalBuffer(reinterpret_cast<__gm__ T *>(weight));
+         this->biasGm.SetGlobalBuffer(reinterpret_cast<__gm__ T *>(bias));
+         this->convStatesGm.SetGlobalBuffer(reinterpret_cast<__gm__ T *>(convStates));
+         if (tilingData->hasQueryStartLoc != 0) {
+             if (tilingData->queryStartLocUseInt64 != 0) {
+                 this->queryStartLocGmInt64.SetGlobalBuffer(reinterpret_cast<__gm__ int64_t *>(queryStartLoc));
+             } else {
+                 this->queryStartLocGmInt32.SetGlobalBuffer(reinterpret_cast<__gm__ int32_t *>(queryStartLoc));
+             }
+         }
+         if (tilingData->hasCacheIndices != 0) {
+             if (tilingData->cacheIndicesUseInt64 != 0) {
+                 this->cacheIndicesGmInt64.SetGlobalBuffer(reinterpret_cast<__gm__ int64_t *>(cacheIndices));
+             } else {
+                 this->cacheIndicesGmInt32.SetGlobalBuffer(reinterpret_cast<__gm__ int32_t *>(cacheIndices));
+             }
+         }
+         if (tilingData->hasInitialStateMode != 0) {
+             if (tilingData->initialStateModeDtype == 2) {
+                 this->initialStateModeGmInt64.SetGlobalBuffer(reinterpret_cast<__gm__ int64_t *>(initialStateMode));
+             } else if (tilingData->initialStateModeDtype == 1) {
+                 this->initialStateModeGmInt32.SetGlobalBuffer(reinterpret_cast<__gm__ int32_t *>(initialStateMode));
+             } else {
+                 this->initialStateModeGmBool.SetGlobalBuffer(reinterpret_cast<__gm__ bool *>(initialStateMode));
+             }
+         }
+         this->yGm.SetGlobalBuffer(reinterpret_cast<__gm__ T *>(y));
+         if (tilingData->hasInitStateWorkspace != 0) {
+             const uint64_t syncElems =
+                 static_cast<uint64_t>(GetBlockNum()) * INIT_STATE_SYNCALL_NEED_SIZE;
+             const uint64_t syncBytes = syncElems * sizeof(int32_t);
+             const uint64_t workspaceElems =
+                 static_cast<uint64_t>(tilingData->batch) *
+                 static_cast<uint64_t>(tilingData->width - 1) *
+                 static_cast<uint64_t>(tilingData->dim);
+             this->initStateSyncGm_.SetGlobalBuffer(reinterpret_cast<__gm__ int32_t *>(workspace), syncElems);
+             auto *workspaceBytes = reinterpret_cast<__gm__ uint8_t *>(workspace);
+             this->initStateWorkspaceGm_.SetGlobalBuffer(reinterpret_cast<__gm__ T *>(workspaceBytes + syncBytes),
+                                                         workspaceElems);
+         }
+         this->InitSharedBuffersAndEvents();
+     }
+
+     __aicore__ inline void Process()
+     {
+         this->ProcessVarlenTokenTiled();
+         this->ReleaseEvents();
+     }
+ };
+
+ template <typename T, uint32_t widthKey, uint32_t fnPlanKey>
+ __aicore__ inline void RunCausalConv1dFn(GM_ADDR x, GM_ADDR weight, GM_ADDR bias, GM_ADDR convStates,
+                                          GM_ADDR queryStartLoc, GM_ADDR cacheIndices, GM_ADDR initialStateMode,
+                                          GM_ADDR numAcceptedTokens, GM_ADDR y, GM_ADDR workspace,
+                                          const CausalConv1dTilingData *tilingData)
+ {
+     CausalConv1dFn<T, widthKey, fnPlanKey> op;
+     op.Init(x, weight, bias, convStates, queryStartLoc, cacheIndices, initialStateMode, numAcceptedTokens, y, workspace,
+             tilingData);
+     op.Process();
+ }
+
+ }
+
+ #endif

--- a/dcut/kernel/dcut_causal_conv1d/vendor/op_kernel/causal_conv1d_fn_tasks.h
+++ b/dcut/kernel/dcut_causal_conv1d/vendor/op_kernel/causal_conv1d_fn_tasks.h
@@ -1,0 +1,306 @@
+/**
+ * This program is free software, you can redistribute it and/or modify it.
+ * Copyright (c) 2025 Huawei Technologies Co., Ltd.
+ * This file is a part of the CANN Open Software.
+ * Licensed under CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING
+ * BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ */
+
+ #ifndef CAUSAL_CONV1D_FN_TASKS_H
+ #define CAUSAL_CONV1D_FN_TASKS_H
+
+ struct FnDirectBlockTask {
+     bool valid = false;
+     int32_t tokenTileId = 0;
+     int32_t baseDimIdx = 0;
+     int32_t tokenStart = 0;
+     int32_t tokenEnd = 0;
+     int32_t channelStart = 0;
+     int32_t baseDimSize = 0;
+ };
+
+ __aicore__ inline FnDirectBlockTask ResolveFnDirectBlockTask(int32_t blockIdx, int32_t tokenBlockCnt, int32_t tokenBlockSize,
+                                                              int32_t cuSeqlen, int32_t baseDimCnt, int32_t baseDim,
+                                                              int32_t dim)
+ {
+     FnDirectBlockTask task;
+     if (blockIdx < 0 || tokenBlockCnt <= 0 || tokenBlockSize <= 0 || cuSeqlen <= 0 || baseDimCnt <= 0 || baseDim <= 0 ||
+         dim <= 0) {
+         return task;
+     }
+
+     const int64_t phase1Grid = static_cast<int64_t>(tokenBlockCnt) * baseDimCnt;
+     if (phase1Grid <= 0 || static_cast<int64_t>(blockIdx) >= phase1Grid) {
+         return task;
+     }
+
+     task.tokenTileId = blockIdx / baseDimCnt;
+     task.baseDimIdx = blockIdx % baseDimCnt;
+     task.channelStart = task.baseDimIdx * baseDim;
+     if (task.channelStart >= dim) {
+         return task;
+     }
+
+     task.baseDimSize = (task.channelStart + baseDim <= dim) ? baseDim : (dim - task.channelStart);
+     task.tokenStart = task.tokenTileId * tokenBlockSize;
+     if (task.tokenStart >= cuSeqlen) {
+         return task;
+     }
+
+     const int32_t tokenEndRaw = task.tokenStart + tokenBlockSize;
+     task.tokenEnd = (tokenEndRaw <= cuSeqlen) ? tokenEndRaw : cuSeqlen;
+     if (task.baseDimSize <= 0 || task.tokenEnd <= task.tokenStart) {
+         return {};
+     }
+
+     task.valid = true;
+     return task;
+ }
+
+ __aicore__ inline bool IsFnInitStateSnapshotOwnerBlock(const FnDirectBlockTask &task)
+ {
+     return task.valid && task.tokenTileId == 0;
+ }
+
+ template <CAUSAL_CONV1D_TEMPLATE_ARGS>
+ __aicore__ inline int32_t CAUSAL_CONV1D_CLASS::FindVarlenSeqByToken(int32_t tokenIdx) const
+ {
+     int32_t left = 0;
+     int32_t right = static_cast<int32_t>(tilingData_->batch);
+     while (left < right) {
+         const int32_t mid = left + ((right - left) >> 1);
+         const int32_t endVal = ReadQueryStartLocValue(mid + 1);
+         if (tokenIdx < endVal) {
+             right = mid;
+         } else {
+             left = mid + 1;
+         }
+     }
+     return left;
+ }
+
+ template <CAUSAL_CONV1D_TEMPLATE_ARGS>
+ __aicore__ inline bool CAUSAL_CONV1D_CLASS::ResolveExplicitTokenTileSeqRange(int32_t tokenTileId, int32_t &startSeq,
+                                                                               int32_t &endSeq) const
+ {
+     if (!HasExplicitFnTokenSeqRanges() || tokenTileId < 0 || tokenTileId >= tilingData_->explicitTokenSeqRangeCount) {
+         return false;
+     }
+     startSeq = static_cast<int32_t>(tilingData_->tokenTileStartSeq[tokenTileId]);
+     endSeq = static_cast<int32_t>(tilingData_->tokenTileEndSeq[tokenTileId]);
+     return (startSeq >= 0) && (endSeq >= startSeq);
+ }
+
+ template <CAUSAL_CONV1D_TEMPLATE_ARGS>
+ __aicore__ inline void CAUSAL_CONV1D_CLASS::InitRingSeqSplit(int32_t seq, int32_t cacheIdx, bool hasInit,
+                                                              int32_t seqStart, int32_t tileStart, int32_t tileLen,
+                                                              int32_t channelStart, int32_t baseDim, int32_t dim)
+ {
+     const int32_t stateLen = tilingData_->stateLen;
+     const int32_t width = static_cast<int32_t>(tilingData_->width);
+     const int32_t historyCount = width - 1;
+     const int32_t ringStart = MAX_WIDTH - width;
+     const int32_t historyStartTok = tileStart - historyCount;
+     LocalTensor<T> ring = inBuf.Get<T>();
+     bool hasGmHistoryCopy = false;
+     bool hasVectorInit = false;
+     const int64_t stateBaseOffset = static_cast<int64_t>(cacheIdx) * stateLen * dim + channelStart;
+     int64_t xHistoryOffset = static_cast<int64_t>(historyStartTok) * dim + channelStart;
+
+     for (int32_t i = 0; i < ringStart; ++i) {
+         Duplicate(ring[i * MAX_BLOCK_DIM], static_cast<T>(0), baseDim);
+         hasVectorInit = true;
+     }
+
+     for (int32_t i = 0, srcTok = historyStartTok; i < historyCount; ++i, ++srcTok, xHistoryOffset += dim) {
+         LocalTensor<T> histSlot = ring[(ringStart + i) * MAX_BLOCK_DIM];
+         if (srcTok >= seqStart) {
+             DataCopy(histSlot, xGm[xHistoryOffset], baseDim);
+             hasGmHistoryCopy = true;
+         } else if (hasInit) {
+             const int32_t statePos = srcTok - seqStart + historyCount;
+             const int64_t stateOffset = stateBaseOffset + static_cast<int64_t>(statePos) * dim;
+             if (tilingData_->hasInitStateWorkspace != 0) {
+                 const int64_t snapshotOffset =
+                     (static_cast<int64_t>(seq) * historyCount + statePos) * dim + channelStart;
+                 DataCopy(histSlot, initStateWorkspaceGm_[snapshotOffset], baseDim);
+             } else {
+                 DataCopy(histSlot, convStatesGm[stateOffset], baseDim);
+             }
+             hasGmHistoryCopy = true;
+         } else {
+             Duplicate(histSlot, static_cast<T>(0), baseDim);
+             hasVectorInit = true;
+         }
+     }
+
+     if (hasGmHistoryCopy) {
+         SetFlag<HardEvent::MTE2_V>(stateMte2ToVEvent_);
+         WaitFlag<HardEvent::MTE2_V>(stateMte2ToVEvent_);
+     }
+     if (hasVectorInit) {
+         PipeBarrier<PIPE_V>();
+     }
+
+     if (tileLen > 0) {
+         const int32_t slot0 = SlotCurr(0);
+         const int64_t xOffset = static_cast<int64_t>(tileStart) * dim + channelStart;
+         DataCopy(ring[slot0 * MAX_BLOCK_DIM], xGm[xOffset], baseDim);
+         SetFlag<HardEvent::MTE2_V>(inputMte2ToVEvent_[slot0]);
+     }
+
+     if (tileLen > 1) {
+         SetFlag<HardEvent::V_MTE2>(inputVToMte2Event_);
+     }
+ }
+
+ template <CAUSAL_CONV1D_TEMPLATE_ARGS>
+ __aicore__ inline void CAUSAL_CONV1D_CLASS::ProcessFnChunk(int32_t seq, int32_t cacheIdx, bool hasInit,
+                                                            int32_t seqStart, int32_t seqLen, int32_t chunkStart,
+                                                            int32_t chunkLen, int32_t channelStart, int32_t baseDim,
+                                                            int32_t dim)
+ {
+     LoadWeightAndBias(channelStart, baseDim);
+     InitRingSeqSplit(seq, cacheIdx, hasInit, seqStart, chunkStart, chunkLen, channelStart, baseDim, dim);
+
+     RunSeq(chunkStart, chunkLen, channelStart, baseDim, dim);
+
+     MaybeWriteBackSeqSplitTailChunk(chunkStart, chunkLen, seqStart, seqLen, cacheIdx, channelStart, baseDim, dim);
+     DrainTaskMte3();
+ }
+
+ template <CAUSAL_CONV1D_TEMPLATE_ARGS>
+ __aicore__ inline void
+ CAUSAL_CONV1D_CLASS::MaybeWriteBackSeqSplitTailChunk(int32_t chunkStart, int32_t chunkLen, int32_t seqStart,
+                                                      int32_t seqLen, int32_t cacheIdx, int32_t channelStart,
+                                                      int32_t baseDim, int32_t dim)
+ {
+     if (chunkStart + chunkLen != seqStart + seqLen) {
+         return;
+     }
+
+     DrainTaskMte3();
+     WriteBackState(cacheIdx, chunkLen, channelStart, baseDim, dim);
+ }
+
+ template <CAUSAL_CONV1D_TEMPLATE_ARGS>
+ __aicore__ inline void CAUSAL_CONV1D_CLASS::PrefetchInitStatesToWorkspace(int32_t channelStart, int32_t baseDimSize)
+ {
+     if (tilingData_->hasInitStateWorkspace == 0) {
+         return;
+     }
+
+     const int32_t dim = tilingData_->dim;
+     const int32_t historyCount = static_cast<int32_t>(tilingData_->width - 1);
+     const int32_t batch = tilingData_->batch;
+     const bool hasCacheIndices = (tilingData_->hasCacheIndices != 0);
+     const bool hasInitialStateMode = (tilingData_->hasInitialStateMode != 0);
+     LocalTensor<T> tmpBuf = inBuf.Get<T>()[0 * MAX_BLOCK_DIM];
+
+     for (int32_t seq = 0; seq < batch; ++seq) {
+         if (!ResolveSeqHasInit(seq, hasInitialStateMode)) {
+             continue;
+         }
+
+         int32_t cacheIdx = 0;
+         if (!ResolveSeqCacheIndex(seq, hasCacheIndices, cacheIdx)) {
+             continue;
+         }
+
+         const int64_t stateBaseOffset = static_cast<int64_t>(cacheIdx) * tilingData_->stateLen * dim + channelStart;
+         const int64_t snapshotBaseOffset = static_cast<int64_t>(seq) * historyCount * dim + channelStart;
+         for (int32_t statePos = 0; statePos < historyCount; ++statePos) {
+             const int64_t stateOffset = stateBaseOffset + static_cast<int64_t>(statePos) * dim;
+             const int64_t snapshotOffset = snapshotBaseOffset + static_cast<int64_t>(statePos) * dim;
+             DataCopy(tmpBuf, convStatesGm[stateOffset], baseDimSize);
+             SetFlag<HardEvent::MTE2_MTE3>(initSnapshotMte2ToMte3Event_);
+             WaitFlag<HardEvent::MTE2_MTE3>(initSnapshotMte2ToMte3Event_);
+             DataCopy(initStateWorkspaceGm_[snapshotOffset], tmpBuf, baseDimSize);
+             SetFlag<HardEvent::MTE3_MTE2>(initSnapshotMte3ToMte2Event_);
+             WaitFlag<HardEvent::MTE3_MTE2>(initSnapshotMte3ToMte2Event_);
+         }
+     }
+ }
+
+ template <CAUSAL_CONV1D_TEMPLATE_ARGS>
+ __aicore__ inline void CAUSAL_CONV1D_CLASS::ProcessVarlenTokenTiled()
+ {
+     const int32_t dim = tilingData_->dim;
+     const int32_t batch = tilingData_->batch;
+     const int32_t seqLen = tilingData_->seqLen;
+     const int32_t cuSeqlen = tilingData_->cuSeqlen;
+     const int32_t baseDim = static_cast<int32_t>(tilingData_->baseDim);
+     const int32_t baseDimCnt = static_cast<int32_t>(tilingData_->baseDimCnt);
+     const int32_t tokenBlockSize = static_cast<int32_t>(tilingData_->tokenBlockSize);
+     const int32_t tokenBlockCnt = static_cast<int32_t>(tilingData_->tokenBlockCnt);
+     const bool hasCacheIndices = (tilingData_->hasCacheIndices != 0);
+     const bool hasInitialStateMode = (tilingData_->hasInitialStateMode != 0);
+     const bool isVarlenMode = (tilingData_->inputMode == 0);
+
+     const int32_t blockIdx = static_cast<int32_t>(GetBlockIdx());
+     const auto blockTask = ResolveFnDirectBlockTask(blockIdx, tokenBlockCnt, tokenBlockSize, cuSeqlen, baseDimCnt,
+                                                     baseDim, dim);
+     if (tilingData_->hasInitStateWorkspace != 0) {
+         if (IsFnInitStateSnapshotOwnerBlock(blockTask)) {
+             PrefetchInitStatesToWorkspace(blockTask.channelStart, blockTask.baseDimSize);
+         }
+         SyncAll();
+     }
+     if (!blockTask.valid) {
+         return;
+     }
+
+     int32_t seq = 0;
+     int32_t seqUpperBound = batch;
+     if (isVarlenMode) {
+         if (!ResolveExplicitTokenTileSeqRange(blockTask.tokenTileId, seq, seqUpperBound)) {
+             seq = FindVarlenSeqByToken(blockTask.tokenStart);
+         }
+     } else {
+         seq = (seqLen > 0) ? (blockTask.tokenStart / seqLen) : 0;
+     }
+
+     int32_t cursor = blockTask.tokenStart;
+     while (cursor < blockTask.tokenEnd && seq < seqUpperBound) {
+         int32_t seqStart = 0;
+         int32_t curSeqLen = 0;
+         if (!ResolveSeqTaskWindow(seq, tilingData_->inputMode, seqLen, seqStart, curSeqLen)) {
+             ++seq;
+             continue;
+         }
+         const int32_t curSeqEnd = seqStart + curSeqLen;
+         if (cursor < seqStart) {
+             cursor = seqStart;
+         }
+         if (cursor >= curSeqEnd) {
+             ++seq;
+             continue;
+         }
+
+         const int32_t tileEnd = (blockTask.tokenEnd <= curSeqEnd) ? blockTask.tokenEnd : curSeqEnd;
+         const int32_t tileLen = tileEnd - cursor;
+         if (tileLen <= 0) {
+             ++seq;
+             continue;
+         }
+
+         int32_t cacheIdx = 0;
+         if (!ResolveSeqCacheIndex(seq, hasCacheIndices, cacheIdx)) {
+             cursor = tileEnd;
+             ++seq;
+             continue;
+         }
+
+         const bool hasInit = ResolveSeqHasInit(seq, hasInitialStateMode);
+         ProcessFnChunk(seq, cacheIdx, hasInit, seqStart, curSeqLen, cursor, tileLen, blockTask.channelStart,
+                        blockTask.baseDimSize, dim);
+
+         cursor = tileEnd;
+         ++seq;
+     }
+ }
+
+ #endif

--- a/dcut/kernel/dcut_causal_conv1d/vendor/op_kernel/causal_conv1d_tiling_data.h
+++ b/dcut/kernel/dcut_causal_conv1d/vendor/op_kernel/causal_conv1d_tiling_data.h
@@ -1,0 +1,68 @@
+/**
+ * This program is free software, you can redistribute it and/or modify it.
+ * Copyright (c) 2025 Huawei Technologies Co., Ltd.
+ * This file is a part of the CANN Open Software.
+ * Licensed under CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING
+ * BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ */
+
+/*!
+ * \file causal_conv1d_tiling_data.h
+ */
+
+#ifndef CAUSAL_CONV1D_TILING_DATA_H_
+#define CAUSAL_CONV1D_TILING_DATA_H_
+
+#include <cstdint>
+
+enum FnExecutionPlan : int64_t {
+    FN_EXECUTION_PLAN_INVALID = 0,
+    FN_EXECUTION_PLAN_CUTBS = 1,
+    FN_EXECUTION_PLAN_CUTBSD = 2,
+};
+
+inline constexpr int64_t ResolveFnExecutionPlan(int64_t baseDimCnt)
+{
+    return (baseDimCnt <= 0) ? FN_EXECUTION_PLAN_INVALID
+        : (baseDimCnt <= 1) ? FN_EXECUTION_PLAN_CUTBS
+        :                     FN_EXECUTION_PLAN_CUTBSD;
+}
+
+
+struct CausalConv1dTilingData {
+    int64_t dim;
+    int64_t cuSeqlen;
+    int64_t seqLen;
+    int64_t inputMode;
+
+    int64_t width;
+
+    int64_t stateLen;
+    int64_t numCacheLines;
+    int64_t batch;
+    int64_t activationMode;
+    int64_t padSlotId;
+    int64_t hasBias;
+    int64_t baseDim;
+    int64_t baseDimCnt;
+    int64_t hasNumAcceptedTokens;
+    int64_t hasQueryStartLoc;
+    int64_t hasCacheIndices;
+    int64_t hasInitialStateMode;
+    int64_t queryStartLocUseInt64;
+    int64_t cacheIndicesStride;
+    int64_t cacheIndicesUseInt64;
+    int64_t initialStateModeDtype;
+    int64_t numAcceptedTokensUseInt64;
+    int64_t tokenBlockSize;
+    int64_t tokenBlockCnt;
+    int64_t hasExplicitTokenSeqRanges;
+    int64_t explicitTokenSeqRangeCount;
+    int64_t tokenTileStartSeq[128];
+    int64_t tokenTileEndSeq[128];
+    int64_t hasInitStateWorkspace;
+};
+#endif // CAUSAL_CONV1D_TILING_DATA_H_

--- a/dcut/kernel/dcut_causal_conv1d/vendor/op_kernel/causal_conv1d_tiling_key.h
+++ b/dcut/kernel/dcut_causal_conv1d/vendor/op_kernel/causal_conv1d_tiling_key.h
@@ -1,0 +1,66 @@
+/**
+ * This program is free software, you can redistribute it and/or modify it.
+ * Copyright (c) 2025 Huawei Technologies Co., Ltd.
+ * This file is a part of the CANN Open Software.
+ * Licensed under CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING
+ * BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ */
+
+/*!
+ * \file causal_conv1d_tiling_key.h
+ * \brief causal_conv1d tiling key declare
+ */
+
+#ifndef __CAUSAL_CONV1D_TILING_KEY_H__
+#define __CAUSAL_CONV1D_TILING_KEY_H__
+
+#include "causal_conv1d_tiling_data.h"
+#include "ascendc/host_api/tiling/template_argument.h"
+
+#define CAUSAL_CONV1D_TPL_RUN_MODE_FN 0
+#define CAUSAL_CONV1D_TPL_RUN_MODE_UPDATE 1
+#define CAUSAL_CONV1D_TPL_WIDTH_RUNTIME 0
+#define CAUSAL_CONV1D_TPL_WIDTH_2 1
+#define CAUSAL_CONV1D_TPL_WIDTH_3 2
+#define CAUSAL_CONV1D_TPL_WIDTH_4 3
+#define CAUSAL_CONV1D_TPL_FN_PLAN_INVALID 0
+#define CAUSAL_CONV1D_TPL_FN_PLAN_CUTBS 1
+#define CAUSAL_CONV1D_TPL_FN_PLAN_CUTBSD 2
+ASCENDC_TPL_ARGS_DECL(CausalConv1d,
+                      ASCENDC_TPL_UINT_DECL(runModeKey, 1, ASCENDC_TPL_UI_LIST, CAUSAL_CONV1D_TPL_RUN_MODE_FN,
+                                            CAUSAL_CONV1D_TPL_RUN_MODE_UPDATE),
+                      ASCENDC_TPL_UINT_DECL(widthKey, 2, ASCENDC_TPL_UI_LIST, CAUSAL_CONV1D_TPL_WIDTH_RUNTIME,
+                                            CAUSAL_CONV1D_TPL_WIDTH_2, CAUSAL_CONV1D_TPL_WIDTH_3,
+                                            CAUSAL_CONV1D_TPL_WIDTH_4),
+                      ASCENDC_TPL_UINT_DECL(fnPlanKey, 2, ASCENDC_TPL_UI_LIST, CAUSAL_CONV1D_TPL_FN_PLAN_INVALID,
+                                            CAUSAL_CONV1D_TPL_FN_PLAN_CUTBS, CAUSAL_CONV1D_TPL_FN_PLAN_CUTBSD));
+
+#define CAUSAL_CONV1D_TPL_SEL_ENTRY(RUN_MODE, WIDTH, FN_PLAN)                                                 \
+    ASCENDC_TPL_ARGS_SEL(ASCENDC_TPL_UINT_SEL(runModeKey, ASCENDC_TPL_UI_LIST, RUN_MODE),                    \
+                         ASCENDC_TPL_UINT_SEL(widthKey, ASCENDC_TPL_UI_LIST, WIDTH),                          \
+                         ASCENDC_TPL_UINT_SEL(fnPlanKey, ASCENDC_TPL_UI_LIST, FN_PLAN),                       \
+                         ASCENDC_TPL_TILING_STRUCT_SEL(CausalConv1dTilingData))
+
+// Keep entries in encoded tiling-key order: real-device sub-kernel dispatch is sensitive to declaration order.
+ASCENDC_TPL_SEL(
+    CAUSAL_CONV1D_TPL_SEL_ENTRY(CAUSAL_CONV1D_TPL_RUN_MODE_UPDATE, CAUSAL_CONV1D_TPL_WIDTH_RUNTIME,
+                                CAUSAL_CONV1D_TPL_FN_PLAN_INVALID),
+    CAUSAL_CONV1D_TPL_SEL_ENTRY(CAUSAL_CONV1D_TPL_RUN_MODE_FN, CAUSAL_CONV1D_TPL_WIDTH_2,
+                                CAUSAL_CONV1D_TPL_FN_PLAN_CUTBS),
+    CAUSAL_CONV1D_TPL_SEL_ENTRY(CAUSAL_CONV1D_TPL_RUN_MODE_FN, CAUSAL_CONV1D_TPL_WIDTH_3,
+                                CAUSAL_CONV1D_TPL_FN_PLAN_CUTBS),
+    CAUSAL_CONV1D_TPL_SEL_ENTRY(CAUSAL_CONV1D_TPL_RUN_MODE_FN, CAUSAL_CONV1D_TPL_WIDTH_4,
+                                CAUSAL_CONV1D_TPL_FN_PLAN_CUTBS),
+    CAUSAL_CONV1D_TPL_SEL_ENTRY(CAUSAL_CONV1D_TPL_RUN_MODE_FN, CAUSAL_CONV1D_TPL_WIDTH_2,
+                                CAUSAL_CONV1D_TPL_FN_PLAN_CUTBSD),
+    CAUSAL_CONV1D_TPL_SEL_ENTRY(CAUSAL_CONV1D_TPL_RUN_MODE_FN, CAUSAL_CONV1D_TPL_WIDTH_3,
+                                CAUSAL_CONV1D_TPL_FN_PLAN_CUTBSD),
+    CAUSAL_CONV1D_TPL_SEL_ENTRY(CAUSAL_CONV1D_TPL_RUN_MODE_FN, CAUSAL_CONV1D_TPL_WIDTH_4,
+                                CAUSAL_CONV1D_TPL_FN_PLAN_CUTBSD));
+
+#undef CAUSAL_CONV1D_TPL_SEL_ENTRY
+
+#endif // __CAUSAL_CONV1D_TILING_KEY_H__

--- a/dcut/kernel/dcut_causal_conv1d/vendor/op_kernel/causal_conv1d_update.h
+++ b/dcut/kernel/dcut_causal_conv1d/vendor/op_kernel/causal_conv1d_update.h
@@ -1,0 +1,91 @@
+/**
+ * This program is free software, you can redistribute it and/or modify it.
+ * Copyright (c) 2025 Huawei Technologies Co., Ltd.
+ * This file is a part of the CANN Open Software.
+ * Licensed under CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING
+ * BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ */
+
+#ifndef CAUSAL_CONV1D_UPDATE_H
+#define CAUSAL_CONV1D_UPDATE_H
+
+#include "causal_conv1d.h"
+
+namespace NsCausalConv1d {
+
+template <typename T>
+class CausalConv1dUpdate
+    : public CausalConv1d<T, CAUSAL_CONV1D_TPL_RUN_MODE_UPDATE, CAUSAL_CONV1D_TPL_WIDTH_RUNTIME,
+                          CAUSAL_CONV1D_TPL_FN_PLAN_INVALID> {
+public:
+    __aicore__ inline void Init(GM_ADDR x, GM_ADDR weight, GM_ADDR bias, GM_ADDR convStates, GM_ADDR queryStartLoc,
+                                GM_ADDR cacheIndices, GM_ADDR, GM_ADDR numAcceptedTokens, GM_ADDR y, GM_ADDR workspace,
+                                const CausalConv1dTilingData *tilingData)
+    {
+        (void)workspace;
+        this->ResetRuntimeState(tilingData);
+        this->xGm.SetGlobalBuffer(reinterpret_cast<__gm__ T *>(x));
+        this->weightGm.SetGlobalBuffer(reinterpret_cast<__gm__ T *>(weight));
+        this->biasGm.SetGlobalBuffer(reinterpret_cast<__gm__ T *>(bias));
+        this->convStatesGm.SetGlobalBuffer(reinterpret_cast<__gm__ T *>(convStates));
+        if (tilingData->hasQueryStartLoc != 0) {
+            if (tilingData->queryStartLocUseInt64 != 0) {
+                this->queryStartLocGmInt64.SetGlobalBuffer(reinterpret_cast<__gm__ int64_t *>(queryStartLoc));
+            } else {
+                this->queryStartLocGmInt32.SetGlobalBuffer(reinterpret_cast<__gm__ int32_t *>(queryStartLoc));
+            }
+        }
+        if (tilingData->hasCacheIndices != 0) {
+            if (tilingData->cacheIndicesUseInt64 != 0) {
+                this->cacheIndicesGmInt64.SetGlobalBuffer(reinterpret_cast<__gm__ int64_t *>(cacheIndices));
+            } else {
+                this->cacheIndicesGmInt32.SetGlobalBuffer(reinterpret_cast<__gm__ int32_t *>(cacheIndices));
+            }
+        }
+        if (tilingData->hasNumAcceptedTokens != 0) {
+            if (tilingData->numAcceptedTokensUseInt64 != 0) {
+                this->numAcceptedTokensGmInt64.SetGlobalBuffer(reinterpret_cast<__gm__ int64_t *>(numAcceptedTokens));
+            } else {
+                this->numAcceptedTokensGmInt32.SetGlobalBuffer(reinterpret_cast<__gm__ int32_t *>(numAcceptedTokens));
+            }
+        }
+        this->yGm.SetGlobalBuffer(reinterpret_cast<__gm__ T *>(y));
+        this->InitSharedBuffersAndEvents();
+    }
+
+    __aicore__ inline void Process()
+    {
+        const CausalConv1dTilingData *tilingData = this->GetTilingData();
+        const int32_t dim = tilingData->dim;
+        const int32_t baseDimCnt = static_cast<int32_t>(tilingData->baseDimCnt);
+        const int32_t width = static_cast<int32_t>(tilingData->width);
+        const int32_t baseDim = static_cast<int32_t>(tilingData->baseDim);
+        if (baseDim <= 0 || baseDimCnt <= 0 || baseDim > MAX_BLOCK_DIM || width < 2 || width > MAX_WIDTH || dim <= 0 ||
+            tilingData->batch <= 0) {
+            this->ReleaseEvents();
+            return;
+        }
+
+        this->ProcessDefault();
+        this->ReleaseEvents();
+    }
+};
+
+template <typename T>
+__aicore__ inline void RunCausalConv1dUpdate(GM_ADDR x, GM_ADDR weight, GM_ADDR bias, GM_ADDR convStates,
+                                             GM_ADDR queryStartLoc, GM_ADDR cacheIndices, GM_ADDR initialStateMode,
+                                             GM_ADDR numAcceptedTokens, GM_ADDR y, GM_ADDR workspace,
+                                             const CausalConv1dTilingData *tilingData)
+{
+    CausalConv1dUpdate<T> op;
+    op.Init(x, weight, bias, convStates, queryStartLoc, cacheIndices, initialStateMode, numAcceptedTokens, y, workspace,
+            tilingData);
+    op.Process();
+}
+
+} // namespace NsCausalConv1d
+
+#endif // CAUSAL_CONV1D_UPDATE_H

--- a/dcut/kernel/dcut_recurrent_gated_delta_rule/CMakeLists.txt
+++ b/dcut/kernel/dcut_recurrent_gated_delta_rule/CMakeLists.txt
@@ -1,0 +1,6 @@
+file(GLOB CURRENT_DIRS RELATIVE ${CMAKE_CURRENT_SOURCE_DIR} ${CMAKE_CURRENT_SOURCE_DIR}/*)
+foreach(SUB_DIR ${CURRENT_DIRS})
+    if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/${SUB_DIR}/CMakeLists.txt")
+        add_subdirectory(${SUB_DIR})
+    endif()
+endforeach()

--- a/dcut/kernel/dcut_recurrent_gated_delta_rule/dcut_recurrent_gated_delta_rule_torch_adpt.h
+++ b/dcut/kernel/dcut_recurrent_gated_delta_rule/dcut_recurrent_gated_delta_rule_torch_adpt.h
@@ -1,0 +1,29 @@
+#ifndef DCUT_RECURRENT_GATED_DELTA_RULE_TORCH_ADPT_H
+#define DCUT_RECURRENT_GATED_DELTA_RULE_TORCH_ADPT_H
+
+namespace vllm_ascend {
+
+at::Tensor npu_dcut_recurrent_gated_delta_rule(const at::Tensor& query, const at::Tensor& key, const at::Tensor& value,
+                                               at::Tensor& state, const c10::optional<at::Tensor>& beta,
+                                               const c10::optional<double> scale,
+                                               const c10::optional<at::Tensor>& query_start_loc,
+                                               const c10::optional<at::Tensor>& ssm_state_indices,
+                                               const c10::optional<at::Tensor>& num_accepted_tokens,
+                                               const c10::optional<at::Tensor>& g,
+                                               const c10::optional<at::Tensor>& gk,
+                                               bool zero_padded_output) {
+  TORCH_CHECK(scale.has_value(), "scale cannot be empty.");
+  TORCH_CHECK(query_start_loc.has_value(), "query_start_loc cannot be empty.");
+  TORCH_CHECK(num_accepted_tokens.has_value(), "num_accepted_tokens cannot be empty.");
+
+  auto options = value.options().dtype(at::ScalarType::BFloat16);
+  at::Tensor output =
+      zero_padded_output ? at::zeros(value.sizes(), options) : at::empty(value.sizes(), options);
+  float scale_real = static_cast<float>(scale.value());
+  EXEC_NPU_CMD(aclnnDcutRecurrentGatedDeltaRule, query, key, value, beta, state, query_start_loc, ssm_state_indices, g,
+               gk, num_accepted_tokens, scale_real, output);
+  return output;
+}
+
+}  // namespace vllm_ascend
+#endif

--- a/dcut/kernel/dcut_recurrent_gated_delta_rule/op_host/CMakeLists.txt
+++ b/dcut/kernel/dcut_recurrent_gated_delta_rule/op_host/CMakeLists.txt
@@ -1,0 +1,27 @@
+add_op_to_compiled_list()
+
+if (BUILD_OPEN_PROJECT)
+    target_sources(op_host_aclnnExc PRIVATE
+        dcut_recurrent_gated_delta_rule_def.cpp
+    )
+endif()
+
+add_ops_compile_options(
+    OP_NAME DcutRecurrentGatedDeltaRule
+    OPTIONS
+        --cce-auto-sync=on
+        -Wno-deprecated-declarations
+        -Werror
+)
+
+if (NOT BUILD_OPS_RTY_KERNEL)
+    add_modules_sources(OPTYPE dcut_recurrent_gated_delta_rule ACLNNTYPE aclnn_exclude)
+    target_include_directories(${OPHOST_NAME}_tiling_obj PRIVATE
+        ${CMAKE_CURRENT_SOURCE_DIR}
+        ${CMAKE_CURRENT_SOURCE_DIR}/../vendor/op_host
+    )
+    # add_modules_sources does not recurse into the legacy arch35 directory.
+    target_sources(${OPHOST_NAME}_tiling_obj PRIVATE
+        arch35/dcut_recurrent_gated_delta_rule_tiling_arch35.cpp
+    )
+endif()

--- a/dcut/kernel/dcut_recurrent_gated_delta_rule/op_host/arch35/dcut_recurrent_gated_delta_rule_tiling_arch35.cpp
+++ b/dcut/kernel/dcut_recurrent_gated_delta_rule/op_host/arch35/dcut_recurrent_gated_delta_rule_tiling_arch35.cpp
@@ -1,0 +1,26 @@
+#define DCUT_RECURRENT_FIXED_STATE_ROWS 1
+#define RecurrentGatedDeltaRule DcutRecurrentGatedDeltaRule
+#define RecurrentGatedDeltaRuleCompileInfo DcutRecurrentGatedDeltaRuleCompileInfo
+#define RecurrentGatedDeltaRuleInfo DcutRecurrentGatedDeltaRuleInfo
+#define RecurrentGatedDeltaRuleTiling DcutRecurrentGatedDeltaRuleTiling
+#define RecurrentGatedDeltaRuleTilingArch35 DcutRecurrentGatedDeltaRuleTilingArch35
+#define RecurrentGatedDeltaRuleTilingData DcutRecurrentGatedDeltaRuleTilingData
+
+// Include tiling_templates_registry.h first so REGISTER_OPS_TILING_TEMPLATE
+// is defined before we override it.
+#include "tiling_base/tiling_templates_registry.h"
+
+// Override REGISTER_OPS_TILING_TEMPLATE: #op_type and ##op_type do NOT expand
+// macros (C standard), so the tiling class would be registered under
+// "RecurrentGatedDeltaRule" instead of "DcutRecurrentGatedDeltaRule".
+// Variable names are fixed (only one call per TU).
+#undef REGISTER_OPS_TILING_TEMPLATE
+#define DCUT_STRINGIFY(x) #x
+#define DCUT_STRINGIFY_EXPAND(x) DCUT_STRINGIFY(x)
+#define REGISTER_OPS_TILING_TEMPLATE(op_type, class_name, priority)                       \
+    [[maybe_unused]] uint32_t dcut_arch35_op_impl_register_template;                      \
+    static Ops::Transformer::OpTiling::Register                                           \
+        __attribute__((unused)) dcut_arch35_tiling_template_register =                     \
+            Ops::Transformer::OpTiling::Register(DCUT_STRINGIFY_EXPAND(op_type)).tiling<class_name>(priority)
+
+#include "../../vendor/op_host/arch35/recurrent_gated_delta_rule_tiling_arch35.cpp"

--- a/dcut/kernel/dcut_recurrent_gated_delta_rule/op_host/dcut_recurrent_gated_delta_rule.h
+++ b/dcut/kernel/dcut_recurrent_gated_delta_rule/op_host/dcut_recurrent_gated_delta_rule.h
@@ -1,0 +1,15 @@
+#ifndef DCUT_RECURRENT_GATED_DELTA_RULE_HOST_H
+#define DCUT_RECURRENT_GATED_DELTA_RULE_HOST_H
+
+#include "opdev/op_executor.h"
+
+namespace l0op {
+const aclTensor* DcutRecurrentGatedDeltaRule(const aclTensor* query, const aclTensor* key, const aclTensor* value,
+                                             const aclTensor* beta, aclTensor* stateRef,
+                                             const aclTensor* actualSeqLengths, const aclTensor* ssmStateIndices,
+                                             const aclTensor* g, const aclTensor* gk,
+                                             const aclTensor* numAcceptedTokens, float scaleValue,
+                                             aclOpExecutor* executor);
+}
+
+#endif

--- a/dcut/kernel/dcut_recurrent_gated_delta_rule/op_host/dcut_recurrent_gated_delta_rule_def.cpp
+++ b/dcut/kernel/dcut_recurrent_gated_delta_rule/op_host/dcut_recurrent_gated_delta_rule_def.cpp
@@ -1,0 +1,85 @@
+#include "register/op_def_registry.h"
+
+namespace ops {
+class DcutRecurrentGatedDeltaRule : public OpDef {
+ public:
+  explicit DcutRecurrentGatedDeltaRule(const char* name) : OpDef(name) {
+    this->Input("query")
+        .ParamType(REQUIRED)
+        .DataType({ge::DT_BF16, ge::DT_BF16})
+        .Format({ge::FORMAT_ND, ge::FORMAT_ND})
+        .UnknownShapeFormat({ge::FORMAT_ND, ge::FORMAT_ND});
+    this->Input("key")
+        .ParamType(REQUIRED)
+        .DataType({ge::DT_BF16, ge::DT_BF16})
+        .Format({ge::FORMAT_ND, ge::FORMAT_ND})
+        .UnknownShapeFormat({ge::FORMAT_ND, ge::FORMAT_ND});
+    this->Input("value")
+        .ParamType(REQUIRED)
+        .DataType({ge::DT_BF16, ge::DT_BF16})
+        .Format({ge::FORMAT_ND, ge::FORMAT_ND})
+        .UnknownShapeFormat({ge::FORMAT_ND, ge::FORMAT_ND});
+    this->Input("beta")
+        .ParamType(REQUIRED)
+        .DataType({ge::DT_BF16, ge::DT_BF16})
+        .Format({ge::FORMAT_ND, ge::FORMAT_ND})
+        .UnknownShapeFormat({ge::FORMAT_ND, ge::FORMAT_ND});
+    this->Input("state")
+        .ParamType(REQUIRED)
+        .DataType({ge::DT_BF16, ge::DT_FLOAT})
+        .Format({ge::FORMAT_ND, ge::FORMAT_ND})
+        .UnknownShapeFormat({ge::FORMAT_ND, ge::FORMAT_ND});
+    this->Input("query_start_loc")
+        .ParamType(REQUIRED)
+        .DataType({ge::DT_INT32, ge::DT_INT32})
+        .Format({ge::FORMAT_ND, ge::FORMAT_ND})
+        .UnknownShapeFormat({ge::FORMAT_ND, ge::FORMAT_ND});
+    this->Input("ssm_state_indices")
+        .ParamType(REQUIRED)
+        .DataType({ge::DT_INT32, ge::DT_INT32})
+        .Format({ge::FORMAT_ND, ge::FORMAT_ND})
+        .UnknownShapeFormat({ge::FORMAT_ND, ge::FORMAT_ND});
+    this->Input("g")
+        .ParamType(OPTIONAL)
+        .DataType({ge::DT_FLOAT, ge::DT_FLOAT})
+        .Format({ge::FORMAT_ND, ge::FORMAT_ND})
+        .UnknownShapeFormat({ge::FORMAT_ND, ge::FORMAT_ND});
+    this->Input("gk")
+        .ParamType(OPTIONAL)
+        .DataType({ge::DT_FLOAT, ge::DT_FLOAT})
+        .Format({ge::FORMAT_ND, ge::FORMAT_ND})
+        .UnknownShapeFormat({ge::FORMAT_ND, ge::FORMAT_ND});
+    // Previous-step accepted counts select a column in the fixed
+    // ssm_state_indices[B, S] rows, independent of this step's length.
+    this->Input("num_accepted_tokens")
+        .ParamType(OPTIONAL)
+        .DataType({ge::DT_INT32, ge::DT_INT32})
+        .Format({ge::FORMAT_ND, ge::FORMAT_ND})
+        .UnknownShapeFormat({ge::FORMAT_ND, ge::FORMAT_ND});
+    this->Output("out")
+        .ParamType(REQUIRED)
+        .DataType({ge::DT_BF16, ge::DT_BF16})
+        .Format({ge::FORMAT_ND, ge::FORMAT_ND})
+        .UnknownShapeFormat({ge::FORMAT_ND, ge::FORMAT_ND});
+    this->Output("state")
+        .ParamType(REQUIRED)
+        .DataType({ge::DT_BF16, ge::DT_FLOAT})
+        .Format({ge::FORMAT_ND, ge::FORMAT_ND})
+        .UnknownShapeFormat({ge::FORMAT_ND, ge::FORMAT_ND});
+    this->Attr("scale_value").AttrType(OPTIONAL).Float(1.0);
+
+    OpAICoreConfig aicConfig;
+    aicConfig.DynamicCompileStaticFlag(true)
+        .DynamicFormatFlag(true)
+        .DynamicRankSupportFlag(true)
+        .DynamicShapeSupportFlag(true)
+        .NeedCheckSupportFlag(false)
+        .ExtendCfgInfo("softsync.flag", "true");
+    this->AICore().AddConfig("ascend910b", aicConfig);
+    this->AICore().AddConfig("ascend910_93", aicConfig);
+    this->AICore().AddConfig("ascend950", aicConfig);
+  }
+};
+
+OP_ADD(DcutRecurrentGatedDeltaRule);
+}  // namespace ops

--- a/dcut/kernel/dcut_recurrent_gated_delta_rule/op_host/dcut_recurrent_gated_delta_rule_infershape.cpp
+++ b/dcut/kernel/dcut_recurrent_gated_delta_rule/op_host/dcut_recurrent_gated_delta_rule_infershape.cpp
@@ -1,0 +1,23 @@
+#define RecurrentGatedDeltaRule DcutRecurrentGatedDeltaRule
+
+// Include the CANN header FIRST so its IMPL_OP_INFERSHAPE definition is processed
+// and the include guard INC_EXTERNAL_REGISTER_OP_IMPL_REGISTRY_H_ is set.
+// Otherwise the header (pulled in transitively by the infershape file) would
+// re-define IMPL_OP_INFERSHAPE and clobber our override below.
+#include "register/op_impl_registry.h"
+
+// Override IMPL_OP_INFERSHAPE to force macro expansion in #op_type (stringification)
+// and ##op_type (token pasting). Per C standard, # and ## do NOT expand macro
+// arguments, so without this override IMPL_OP_INFERSHAPE(RecurrentGatedDeltaRule)
+// would register the infershape for "RecurrentGatedDeltaRule" instead of
+// "DcutRecurrentGatedDeltaRule", and the runtime would fail with
+// "Op has no infershape func, opType: DcutRecurrentGatedDeltaRule".
+#undef IMPL_OP_INFERSHAPE
+#define DCUT_STRINGIFY(x) #x
+#define DCUT_STRINGIFY_EXPAND(x) DCUT_STRINGIFY(x)
+#define DCUT_CAT(a, b) DCUT_CAT_INNER(a, b)
+#define DCUT_CAT_INNER(a, b) a##b
+#define IMPL_OP_INFERSHAPE(op_type) \
+  gert::OpImplRegisterV2 VAR_UNUSED DCUT_CAT(op_impl_register_infershape_, op_type) = gert::OpImplRegisterV2(DCUT_STRINGIFY_EXPAND(op_type))
+
+#include "../../../../csrc/attention/recurrent_gated_delta_rule/op_host/recurrent_gated_delta_rule_infershape.cpp"

--- a/dcut/kernel/dcut_recurrent_gated_delta_rule/op_host/dcut_recurrent_gated_delta_rule_tiling.cpp
+++ b/dcut/kernel/dcut_recurrent_gated_delta_rule/op_host/dcut_recurrent_gated_delta_rule_tiling.cpp
@@ -1,0 +1,44 @@
+#define DCUT_RECURRENT_FIXED_STATE_ROWS 1
+#define RecurrentGatedDeltaRule DcutRecurrentGatedDeltaRule
+#define RecurrentGatedDeltaRuleCompileInfo DcutRecurrentGatedDeltaRuleCompileInfo
+#define RecurrentGatedDeltaRuleInfo DcutRecurrentGatedDeltaRuleInfo
+#define RecurrentGatedDeltaRuleTiling DcutRecurrentGatedDeltaRuleTiling
+#define RecurrentGatedDeltaRuleTilingData DcutRecurrentGatedDeltaRuleTilingData
+
+// Include the CANN header FIRST so its IMPL_OP_OPTILING definition is processed
+// and the include guard INC_EXTERNAL_REGISTER_OP_IMPL_REGISTRY_H_ is set.
+// Otherwise the header (pulled in transitively by the tiling file) would
+// re-define IMPL_OP_OPTILING and clobber our override below.
+#include "register/op_impl_registry.h"
+
+// Also include tiling_templates_registry.h first so REGISTER_OPS_TILING_TEMPLATE
+// is defined before we override it.
+#include "tiling_base/tiling_templates_registry.h"
+
+// Override IMPL_OP_OPTILING to force macro expansion in #op_type (stringification)
+// and ##op_type (token pasting). Per C standard, # and ## do NOT expand macro
+// arguments, so without this override IMPL_OP_OPTILING(RecurrentGatedDeltaRule)
+// would register the op type as "RecurrentGatedDeltaRule" instead of
+// "DcutRecurrentGatedDeltaRule", and the runtime would fail with
+// "Do not find tiling func of DcutRecurrentGatedDeltaRule!".
+#undef IMPL_OP_OPTILING
+#define DCUT_STRINGIFY(x) #x
+#define DCUT_STRINGIFY_EXPAND(x) DCUT_STRINGIFY(x)
+#define DCUT_CAT(a, b) DCUT_CAT_INNER(a, b)
+#define DCUT_CAT_INNER(a, b) a##b
+#define IMPL_OP_OPTILING(op_type) \
+  gert::OpImplRegisterV2 VAR_UNUSED DCUT_CAT(op_impl_register_optiling_, op_type) = gert::OpImplRegisterV2(DCUT_STRINGIFY_EXPAND(op_type))
+
+// Override REGISTER_OPS_TILING_TEMPLATE for the same reason: #op_type and
+// ##op_type do NOT expand macros, so the tiling class would be registered
+// under "RecurrentGatedDeltaRule" instead of "DcutRecurrentGatedDeltaRule",
+// and DoTilingImpl would fail to find the class.
+// Variable names are fixed (only one call per TU) to avoid complex token pasting.
+#undef REGISTER_OPS_TILING_TEMPLATE
+#define REGISTER_OPS_TILING_TEMPLATE(op_type, class_name, priority)                       \
+    [[maybe_unused]] uint32_t dcut_op_impl_register_template;                             \
+    static Ops::Transformer::OpTiling::Register                                           \
+        __attribute__((unused)) dcut_tiling_template_register =                            \
+            Ops::Transformer::OpTiling::Register(DCUT_STRINGIFY_EXPAND(op_type)).tiling<class_name>(priority)
+
+#include "../vendor/op_host/recurrent_gated_delta_rule_tiling.cpp"

--- a/dcut/kernel/dcut_recurrent_gated_delta_rule/op_host/op_api/aclnn_dcut_recurrent_gated_delta_rule.cpp
+++ b/dcut/kernel/dcut_recurrent_gated_delta_rule/op_host/op_api/aclnn_dcut_recurrent_gated_delta_rule.cpp
@@ -1,0 +1,5 @@
+#define CFG_BUILD_DEBUG
+#define RecurrentGatedDeltaRule DcutRecurrentGatedDeltaRule
+#define aclnnRecurrentGatedDeltaRule aclnnDcutRecurrentGatedDeltaRule
+#define aclnnRecurrentGatedDeltaRuleGetWorkspaceSize aclnnDcutRecurrentGatedDeltaRuleGetWorkspaceSize
+#include "../../../../../csrc/attention/recurrent_gated_delta_rule/op_host/op_api/aclnn_recurrent_gated_delta_rule.cpp"

--- a/dcut/kernel/dcut_recurrent_gated_delta_rule/op_host/op_api/dcut_recurrent_gated_delta_rule.cpp
+++ b/dcut/kernel/dcut_recurrent_gated_delta_rule/op_host/op_api/dcut_recurrent_gated_delta_rule.cpp
@@ -1,0 +1,115 @@
+#define CFG_BUILD_DEBUG
+#define RecurrentGatedDeltaRule DcutRecurrentGatedDeltaRule
+
+// Include CANN headers FIRST so their include guards are set and our
+// overrides below are NOT clobbered when the l0op file re-includes them.
+#include "opdev/make_op_executor.h"
+#include "opdev/op_dfx.h"
+
+// Override OP_TYPE_REGISTER and ADD_TO_LAUNCHER_LIST_AICORE: # (stringify)
+// and ## (token paste) do NOT expand macro arguments (C standard), so without
+// this override OP_TYPE_REGISTER(RecurrentGatedDeltaRule) registers the op type
+// as "RecurrentGatedDeltaRule" instead of "DcutRecurrentGatedDeltaRule", and
+// ADD_TO_LAUNCHER_LIST_AICORE calls RecurrentGatedDeltaRuleOpTypeId() (wrong ID)
+// instead of DcutRecurrentGatedDeltaRuleOpTypeId(). The runtime then fails with
+// "RecurrentGatedDeltaRule ADD_TO_LAUNCHER_LIST_AICORE failed."
+#undef OP_TYPE_REGISTER
+#undef ADD_TO_LAUNCHER_LIST_AICORE
+#undef INFER_SHAPE
+#undef ADD_TO_LAUNCHER_LIST_DSA
+
+#define DCUT_STRINGIFY(x) #x
+#define DCUT_STRINGIFY_EXPAND(x) DCUT_STRINGIFY(x)
+#define DCUT_CAT(a, b) DCUT_CAT_INNER(a, b)
+#define DCUT_CAT_INNER(a, b) a##b
+
+#define INFER_SHAPE(KERNEL_NAME, op_args...)                                                           \
+    ({  aclnnStatus inferShapeRet;                                                                     \
+        do {                                                                                           \
+            op::OpArgContext *opArgCtx = GetOpArgContext(op_args);                                     \
+            if (opArgCtx == nullptr){                                                                  \
+                inferShapeRet = ACLNN_ERR_PARAM_NULLPTR;                                               \
+            } else {                                                                                   \
+                inferShapeRet = InferShape(DCUT_CAT(KERNEL_NAME, OpTypeId)(),                          \
+                                            *opArgCtx->GetOpArg(op::OP_INPUT_ARG),                     \
+                                            *opArgCtx->GetOpArg(op::OP_OUTPUT_ARG),                    \
+                                            *opArgCtx->GetOpArg(op::OP_ATTR_ARG));                     \
+                op::DestroyOpArgContext(opArgCtx);                                                     \
+            }                                                                                          \
+        } while (0); inferShapeRet;                                                                    \
+    })
+
+#define ADD_TO_LAUNCHER_LIST_AICORE(KERNEL_NAME, op_args...)                                 \
+    ({  aclnnStatus addToLaunchRet;                                                          \
+        do {                                                                                 \
+            op::OpArgContext *opArgCtx = GetOpArgContext(op_args);                           \
+            addToLaunchRet = CreatAiCoreKernelLauncher(DCUT_STRINGIFY_EXPAND(KERNEL_NAME),  \
+                                                       DCUT_CAT(KERNEL_NAME, OpTypeId)(),     \
+                                                       executor, opArgCtx);                   \
+        } while (0); addToLaunchRet;                                                         \
+    })
+
+#define ADD_TO_LAUNCHER_LIST_DSA(KERNEL_NAME, op_args...)                                    \
+    do {                                                                                     \
+        op::OpArgContext *opArgCtx = GetOpArgContext(op_args);                               \
+        CreatDSAKernelLauncher(DCUT_STRINGIFY_EXPAND(KERNEL_NAME),                          \
+                               DCUT_CAT(KERNEL_NAME, OpTypeId)(),                           \
+                               DCUT_CAT(KERNEL_NAME, TaskType),                             \
+                               executor, opArgCtx);                                         \
+    } while (0)
+
+#ifdef ACLNN_WITH_BINARY
+#undef OP_RESOURCE
+#undef DECLARE_OP_RESOURCE
+#undef OP_RESOURCES_VALUE
+
+#define DECLARE_OP_RESOURCE(kernelName)                            \
+    extern void* DCUT_CAT(kernelName, TilingRegisterResource)();            \
+    extern void* DCUT_CAT(kernelName, InferShapeRegisterResource)();       \
+    extern void* DCUT_CAT(kernelName, TuningRegisterResource)();            \
+    extern const op::OP_BINARY_RES& DCUT_CAT(kernelName, KernelResource)(); \
+    extern const op::OP_RUNTIME_KB_RES& DCUT_CAT(kernelName, TuningResource)()
+
+#define OP_RESOURCES_VALUE(kernelName)                                                                  \
+    {                                                                                                   \
+        {                                                                                               \
+            ge::AscendString(DCUT_STRINGIFY_EXPAND(kernelName)),                                        \
+            {                                                                                           \
+                {l0op::DCUT_CAT(kernelName, TilingRegisterResource)(),                                  \
+                 l0op::DCUT_CAT(kernelName, InferShapeRegisterResource)(),                             \
+                 l0op::DCUT_CAT(kernelName, TuningRegisterResource)()},                                  \
+                    l0op::DCUT_CAT(kernelName, KernelResource)(),                                       \
+                    l0op::DCUT_CAT(kernelName, TuningResource)()                                        \
+            }                                                                                           \
+        }                                                                                               \
+    }
+
+#define OP_RESOURCE(kernelName)      \
+    DECLARE_OP_RESOURCE(kernelName); \
+    const op::OP_RESOURCES DCUT_CAT(kernelName, _RESOURCES) OP_RESOURCES_VALUE(kernelName)
+
+#define OP_TYPE_REGISTER(kernelName)                                                                    \
+    OP_RESOURCE(kernelName);                                                                            \
+    [[maybe_unused]] uint32_t DCUT_CAT(kernelName, _kernelName_Be_Defined_Multi_Times__);               \
+    [[maybe_unused]] inline uint32_t DCUT_CAT(kernelName, OpTypeId)()                                   \
+    {                                                                                                   \
+        DCUT_CAT(kernelName, _kernelName_Be_Defined_Multi_Times__) = 0;                                 \
+        op::GenInternalOpTypeId();                                                                      \
+        static uint32_t DCUT_CAT(kernelName, OpTypeId) =                                                \
+            op::GenOpTypeId(DCUT_STRINGIFY_EXPAND(kernelName), DCUT_CAT(kernelName, _RESOURCES));       \
+        return DCUT_CAT(kernelName, OpTypeId);                                                           \
+    }
+#else
+#define OP_TYPE_REGISTER(kernelName)                                                    \
+    [[maybe_unused]] uint32_t DCUT_CAT(kernelName, _kernelName_Be_Defined_Multi_Times__);\
+    [[maybe_unused]] inline uint32_t DCUT_CAT(kernelName, OpTypeId)()                   \
+    {                                                                                    \
+        DCUT_CAT(kernelName, _kernelName_Be_Defined_Multi_Times__) = 0;                  \
+        op::GenInternalOpTypeId();                                                       \
+        static uint32_t DCUT_CAT(kernelName, OpTypeId) =                                 \
+            op::GenOpTypeId(DCUT_STRINGIFY_EXPAND(kernelName));                          \
+        return DCUT_CAT(kernelName, OpTypeId);                                           \
+    }
+#endif
+
+#include "../../../../../csrc/attention/recurrent_gated_delta_rule/op_host/op_api/recurrent_gated_delta_rule.cpp"

--- a/dcut/kernel/dcut_recurrent_gated_delta_rule/op_kernel/dcut_recurrent_gated_delta_rule.cpp
+++ b/dcut/kernel/dcut_recurrent_gated_delta_rule/op_kernel/dcut_recurrent_gated_delta_rule.cpp
@@ -1,0 +1,6 @@
+#define DCUT_RECURRENT_FIXED_STATE_ROWS 1
+#define DCUT_RECURRENT_QUERY_START_LOC 1
+#define RecurrentGatedDeltaRule DcutRecurrentGatedDeltaRule
+#define RecurrentGatedDeltaRuleTilingData DcutRecurrentGatedDeltaRuleTilingData
+#define recurrent_gated_delta_rule dcut_recurrent_gated_delta_rule
+#include "../vendor/op_kernel/recurrent_gated_delta_rule.cpp"

--- a/dcut/kernel/dcut_recurrent_gated_delta_rule/vendor/op_host/arch35/recurrent_gated_delta_rule_tiling_arch35.cpp
+++ b/dcut/kernel/dcut_recurrent_gated_delta_rule/vendor/op_host/arch35/recurrent_gated_delta_rule_tiling_arch35.cpp
@@ -1,0 +1,210 @@
+/**
+ * Copyright (c) 2026 Huawei Technologies Co., Ltd.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ */
+
+/*!
+ * \file recurrent_gated_delta_rule_tiling_arch35.cpp
+ * \brief
+ */
+#include "recurrent_gated_delta_rule_tiling.h"
+
+#include <array>
+
+#include "platform/platform_ascendc.h"
+#include "tiling_base/tiling_templates_registry.h"
+
+namespace optiling {
+namespace {
+
+constexpr uint64_t RGDR_ASCEND_950_TEMPLATE_PRIORITY = 1000;
+
+constexpr size_t QUERY_INDEX = 0;
+constexpr size_t KEY_INDEX = 1;
+constexpr size_t VALUE_INDEX = 2;
+constexpr size_t BETA_INDEX = 3;
+constexpr size_t STATE_INDEX = 4;
+constexpr size_t CUSEQLENS_INDEX = 5;
+constexpr size_t SSM_STATE_INDICES_INDEX = 6;
+
+constexpr size_t DIM_0 = 0;
+constexpr size_t DIM_1 = 1;
+constexpr size_t DIM_2 = 2;
+
+class RecurrentGatedDeltaRuleTilingArch35 final : public RecurrentGatedDeltaRuleTiling {
+public:
+    explicit RecurrentGatedDeltaRuleTilingArch35(gert::TilingContext *context)
+        : RecurrentGatedDeltaRuleTiling(context)
+    {
+    }
+
+protected:
+    bool IsCapable() override
+    {
+        auto platformInfo = context_->GetPlatformInfo();
+        if (platformInfo == nullptr) {
+            return false;
+        }
+        auto ascendcPlatform = platform_ascendc::PlatformAscendC(platformInfo);
+        return ascendcPlatform.GetSocVersion() == platform_ascendc::SocVersion::ASCEND950;
+    }
+
+    ge::graphStatus GetShapeAttrsInfo() override
+    {
+        OP_CHECK_IF(CheckContext() != ge::GRAPH_SUCCESS, OP_LOGE(inputParams_.opName, "Invalid context."),
+                    return ge::GRAPH_FAILED);
+
+        OP_CHECK_IF(AnalyzeDtype() != ge::GRAPH_SUCCESS, OP_LOGE(inputParams_.opName, "Invalid dtypes."),
+                    return ge::GRAPH_FAILED);
+
+        OP_CHECK_IF(AnalyzeShapesArch35() != ge::GRAPH_SUCCESS, OP_LOGE(inputParams_.opName, "Invalid shapes."),
+                    return ge::GRAPH_FAILED);
+
+        OP_CHECK_IF(GetScale() != ge::GRAPH_SUCCESS, OP_LOGE(inputParams_.opName, "Invalid GetScale."),
+                    return ge::GRAPH_FAILED);
+
+        OP_CHECK_IF(GetOptionalInput() != ge::GRAPH_SUCCESS, OP_LOGE(inputParams_.opName, "Invalid GetOptionalInput."),
+                    return ge::GRAPH_FAILED);
+
+        OP_CHECK_IF(AnalyzeFormat() != ge::GRAPH_SUCCESS, OP_LOGE(inputParams_.opName, "Invalid Format."),
+                    return ge::GRAPH_FAILED);
+
+        return ge::GRAPH_SUCCESS;
+    }
+
+    ge::graphStatus DoOpTiling() override
+    {
+        OP_CHECK_IF(CalUbSizeArch35() != ge::GRAPH_SUCCESS, OP_LOGE(inputParams_.opName, "CalUbSize failed."),
+                    return ge::GRAPH_FAILED);
+
+        PrintTilingData();
+        return ge::GRAPH_SUCCESS;
+    }
+
+private:
+    ge::graphStatus AnalyzeShapesArch35()
+    {
+        const auto &queryShape = context_->GetInputShape(QUERY_INDEX)->GetOriginShape();
+        const auto &keyShape = context_->GetInputShape(KEY_INDEX)->GetOriginShape();
+        const auto &valueShape = context_->GetInputShape(VALUE_INDEX)->GetOriginShape();
+        const auto &betaShape = context_->GetInputShape(BETA_INDEX)->GetOriginShape();
+        const auto &stateShape = context_->GetInputShape(STATE_INDEX)->GetOriginShape();
+        const auto &cuSeqlensShape = context_->GetInputShape(CUSEQLENS_INDEX)->GetOriginShape();
+        const auto &ssmStateShape = context_->GetInputShape(SSM_STATE_INDICES_INDEX)->GetOriginShape();
+
+        OP_CHECK_IF(CheckShapeDimAndRelation(queryShape, keyShape, valueShape, betaShape, stateShape, cuSeqlensShape,
+                                             ssmStateShape) != ge::GRAPH_SUCCESS,
+                    OP_LOGE(inputParams_.opName, "AnalyzeShapes rule failed: CheckShapeDimAndRelation"),
+                    return ge::GRAPH_FAILED);
+
+        tilingData_.t = queryShape.GetDim(DIM_0);
+        tilingData_.nk = queryShape.GetDim(DIM_1);
+        tilingData_.dk = queryShape.GetDim(DIM_2);
+        tilingData_.nv = valueShape.GetDim(DIM_1);
+        tilingData_.dv = valueShape.GetDim(DIM_2);
+        tilingData_.sBlockNum = stateShape.GetDim(DIM_0);
+        tilingData_.b = cuSeqlensShape.GetDim(DIM_0) - 1;
+#if defined(DCUT_RECURRENT_FIXED_STATE_ROWS)
+        tilingData_.stateIndexStride = ssmStateShape.GetDim(DIM_1);
+#endif
+
+        OP_CHECK_IF(CheckShapeValueRangeAndRule() != ge::GRAPH_SUCCESS,
+                    OP_LOGE(inputParams_.opName, "AnalyzeShapes rule failed: CheckShapeValueRangeAndRule"),
+                    return ge::GRAPH_FAILED);
+
+        UpdateDynamicBlockDimByTaskUnits();
+        return ge::GRAPH_SUCCESS;
+    }
+
+    ge::graphStatus CalUbSizeArch35()
+    {
+        struct RuleItem {
+            const char *name;
+            HostRuleFn fn;
+        };
+
+        OP_CHECK_IF(RuleInitUbCalcContext() != ge::GRAPH_SUCCESS,
+            OP_LOGE(inputParams_.opName, "CalUbSize rule failed: RuleInitUbCalcContext"),
+            return ge::GRAPH_FAILED);
+
+        OP_CHECK_IF(RuleCalcFixedUbBytes() != ge::GRAPH_SUCCESS,
+                    OP_LOGE(inputParams_.opName, "CalUbSize rule failed: RuleCalcFixedUbBytes"),
+                    return ge::GRAPH_FAILED);
+
+        OP_CHECK_IF(RuleCalcWorkingUbBytes() != ge::GRAPH_SUCCESS,
+                    OP_LOGE(inputParams_.opName, "CalUbSize rule failed: RuleCalcWorkingUbBytes"),
+                    return ge::GRAPH_FAILED);
+
+        OP_CHECK_IF(RuleCalcVStepCoeff() != ge::GRAPH_SUCCESS,
+                    OP_LOGE(inputParams_.opName, "CalUbSize rule failed: RuleCalcVStepCoeff"),
+                    return ge::GRAPH_FAILED);
+
+        OP_CHECK_IF(FinalizeVStepFromUbArch35() != ge::GRAPH_SUCCESS,
+                    OP_LOGE(inputParams_.opName, "CalUbSize rule failed: FinalizeVStepFromUbArch35"),
+                    return ge::GRAPH_FAILED);
+        return ge::GRAPH_SUCCESS;
+    }
+
+    ge::graphStatus FinalizeVStepFromUbArch35()
+    {
+        BufferProfile selected;
+        const std::array<BufferProfile, 3> candidates = {{
+            BufferProfile(1u, 1u, 0u, 0u, false),
+            BufferProfile(1u, 2u, 0u, 0u, false),
+            BufferProfile(2u, 2u, 0u, 0u, false),
+        }};
+
+        for (const auto &candidate : candidates) {
+            BufferProfile profile;
+            if (!EvaluateBufferProfile(ubCalcCtx_.ubSize, ubCalcCtx_.workingUbBytes, ubCalcCtx_.aDk,
+                                       candidate.stateOutBufferNum, candidate.attnOutBufferNum, profile)) {
+                continue;
+            }
+            if (IsBetterProfile(profile, selected)) {
+                selected = profile;
+            }
+        }
+
+        OP_LOGD(context_->GetNodeName(),
+                "selected profile: stateOutBufferNum=[%u], attnOutBufferNum=[%u], vStep=[%u], repeatTime=[%u], "
+                "valid=[%d]",
+                selected.stateOutBufferNum, selected.attnOutBufferNum, selected.vStep, selected.repeatTime,
+                selected.valid);
+
+        if (!selected.valid) {
+            OP_LOGE(context_->GetNodeName(), "vStep should be bigger than 8, shape is too big");
+            return ge::GRAPH_FAILED;
+        }
+
+        auto stateDtype = context_->GetInputDesc(STATE_INDEX)->GetDataType();
+        int64_t stateDtypeSize = (stateDtype == ge::DT_FLOAT) ? 4 : 2;
+        int64_t queueCoeff =
+            (stateDtypeSize + static_cast<int64_t>(stateDtypeSize * selected.stateOutBufferNum)) * ubCalcCtx_.aDk +
+            static_cast<int64_t>(4 * selected.attnOutBufferNum);
+        int64_t ubRestBytes =
+            ubCalcCtx_.ubSize - ubCalcCtx_.fixedUbBytes - queueCoeff * static_cast<int64_t>(selected.vStep);
+        if (ubRestBytes < 0) {
+            OP_LOGE(context_->GetNodeName(), "ubRestBytes should be non-negative, but got %ld", ubRestBytes);
+            return ge::GRAPH_FAILED;
+        }
+
+        tilingData_.ubCalSize = compileInfo_.ubSize;
+        tilingData_.vStep = selected.vStep;
+        tilingData_.stateOutBufferNum = selected.stateOutBufferNum;
+        tilingData_.attnOutBufferNum = selected.attnOutBufferNum;
+        tilingData_.ubRestBytes = static_cast<uint32_t>(ubRestBytes);
+        return ge::GRAPH_SUCCESS;
+    }
+};
+
+} // namespace
+
+REGISTER_OPS_TILING_TEMPLATE(RecurrentGatedDeltaRule,
+                             RecurrentGatedDeltaRuleTilingArch35,
+                             RGDR_ASCEND_950_TEMPLATE_PRIORITY);
+
+} // namespace optiling

--- a/dcut/kernel/dcut_recurrent_gated_delta_rule/vendor/op_host/math_util.h
+++ b/dcut/kernel/dcut_recurrent_gated_delta_rule/vendor/op_host/math_util.h
@@ -1,0 +1,61 @@
+/**
+* Copyright (c) 2025 Huawei Technologies Co., Ltd.
+* This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+* CANN Open Software License Agreement Version 2.0 (the "License").
+* Please refer to the License for details. You may not use this file except in compliance with the License.
+* THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+* INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+* See LICENSE in the root of the software repository for the full text of the License.
+*/
+
+/*!
+ * \file math_util.h
+ * \brief
+ */
+
+#ifndef TILING_MATMUL_MATH_UTIL_H
+#define TILING_MATMUL_MATH_UTIL_H
+
+#include <array>
+#include <cstdint>
+#include <vector>
+#include <utility>
+namespace matmul_tiling {
+class MathUtil {
+public:
+    static bool IsEqual(float leftValue, float rightValue);
+    template<typename T>
+    static auto CeilDivision(T num1, T num2) -> T
+    {
+        if (num2 == 0) {
+            return 0;
+        }
+        return static_cast<T>((static_cast<int64_t>(num1) + static_cast<int64_t>(num2) - 1) /
+            static_cast<int64_t>(num2));
+    }
+    template<typename T>
+    static auto Align(T num1, T num2) -> T
+    {
+        return CeilDivision(num1, num2) * num2;
+    }
+    static int32_t AlignDown(int32_t num1, int32_t num2);
+    static bool CheckMulOverflow(int32_t a, int32_t b, int32_t &c);
+    static int32_t MapShape(int32_t shape, bool roundUpFlag = true);
+    static void AddFactor(std::vector<int32_t> &dimsFactors, int32_t dim);
+    static void GetFactorCnt(const int32_t shape, int32_t &factorCnt, const int32_t factorStart,
+        const int32_t factorEnd);
+    static void GetFactorLayerCnt(const int32_t shape, int32_t &factorCnt, const int32_t factorStart,
+        const int32_t factorEnd);
+    static bool CheckFactorNumSatisfy(const int32_t dim);
+    static int32_t FindBestSingleCore(const int32_t oriShape, const int32_t mappedShape, const int32_t coreNum,
+        bool isKDim);
+    static void GetFactors(std::vector<int32_t> &factorList, int32_t srcNum, int32_t minFactor, int32_t maxFactor);
+    static void GetFactors(std::vector<int32_t> &factorList, int32_t srcNum, int32_t maxFactor);
+    static void GetBlockFactors(std::vector<int32_t> &factorList, const int32_t oriShape, const int32_t mpShape,
+        const int32_t coreNum, const int32_t maxNum);
+    static int32_t GetNonFactorMap(std::vector<int32_t> &factorList, int32_t srcNum, int32_t maxFactor);
+    static std::vector<std::pair<int, int>> GetFactorPairs(int32_t num);
+    static std::pair<int32_t, int32_t> DivideIntoMainAndTail(int32_t num, int32_t divisor);
+};
+} // namespace matmul_tiling
+#endif // _MATH_UTIL_H_

--- a/dcut/kernel/dcut_recurrent_gated_delta_rule/vendor/op_host/recurrent_gated_delta_rule_tiling.cpp
+++ b/dcut/kernel/dcut_recurrent_gated_delta_rule/vendor/op_host/recurrent_gated_delta_rule_tiling.cpp
@@ -1,0 +1,699 @@
+/**
+ * Copyright (c) 2025 Huawei Technologies Co., Ltd.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ */
+
+/*!
+ * \file recurrent_gated_delta_rule_tiling.cpp
+ * \brief
+ */
+#include "recurrent_gated_delta_rule_tiling.h"
+
+#include "tiling_base/tiling_templates_registry.h"
+#include "register/op_def_registry.h"
+#include "platform/platform_infos_def.h"
+#include "tiling_base/error_log.h"
+#include "tiling/platform/platform_ascendc.h"
+#include "math_util.h"
+#include "error/ops_error.h"
+#include <array>
+
+namespace optiling {
+
+REGISTER_OPS_TILING_TEMPLATE(RecurrentGatedDeltaRule, RecurrentGatedDeltaRuleTiling, 0);
+
+const size_t QUERY_INDEX = 0;
+const size_t KEY_INDEX = 1;
+const size_t VALUE_INDEX = 2;
+const size_t BETA_INDEX = 3;
+const size_t STATE_INDEX = 4;
+const size_t CUSEQLENS_INDEX = 5;
+const size_t SSM_STATE_INDICES_INDEX = 6;
+const size_t G_INDEX = 7;
+const size_t GK_INDEX = 8;
+const size_t ACC_TO_INDEX = 9;
+
+const size_t QKV_DIM_NUM = 3;
+const size_t BETA_DIM_NUM = 2;
+const size_t STATE_DIM_NUM = 4;
+const size_t CUSEQLENS_DIM_NUM = 1;
+#if defined(DCUT_RECURRENT_FIXED_STATE_ROWS)
+const size_t SSM_STATE_INDICES_DIM_NUM = 2;
+#else
+const size_t SSM_STATE_INDICES_DIM_NUM = 1;
+#endif
+const size_t G_DIM_NUM = 2;
+
+const size_t DIM_0 = 0;
+const size_t DIM_1 = 1;
+const size_t DIM_2 = 2;
+const size_t DIM_3 = 3;
+
+const size_t MAX_MTP = 16;
+
+template <typename T1, typename T2>
+static T1 CeilDiv(T1 a, T2 b)
+{
+    if (b == 0) {
+        return 0;
+    }
+    return (a + b - 1) / b;
+}
+
+template <typename T>
+typename std::enable_if <std::is_integral<T>::value, T>::type CeilAlign(T x, T align) {
+    return CeilDiv(x, align) * align;
+}
+
+void RecurrentGatedDeltaRuleTiling::InitCompileInfo()
+{
+    auto platformInfoPtr = context_->GetPlatformInfo();
+    if (platformInfoPtr == nullptr) {
+        OP_LOGE(context_->GetNodeName(), "platformInfoPtr is null");
+        return;
+    }
+    const auto &ascendcPlatform = platform_ascendc::PlatformAscendC(platformInfoPtr);
+    ascendcPlatform.GetCoreMemSize(platform_ascendc::CoreMemType::UB, compileInfo_.ubSize);
+    compileInfo_.aivNum = ascendcPlatform.GetCoreNumAiv();
+
+    if (compileInfo_.aivNum <= 0) {
+        OP_LOGE(context_->GetNodeName(), "aivNum <= 0");
+        return;
+    }
+    tilingData_.vectorCoreNum = compileInfo_.aivNum;
+}
+
+ge::graphStatus RecurrentGatedDeltaRuleTiling::GetPlatformInfo()
+{
+    return ge::GRAPH_SUCCESS;
+};
+
+ge::graphStatus RecurrentGatedDeltaRuleTiling::GetShapeAttrsInfo()
+{
+    OP_CHECK_IF(CheckContext() != ge::GRAPH_SUCCESS, OP_LOGE(inputParams_.opName, "Invalid context."),
+                return ge::GRAPH_FAILED);
+
+    OP_CHECK_IF(AnalyzeDtype() != ge::GRAPH_SUCCESS, OP_LOGE(inputParams_.opName, "Invalid dtypes."),
+                return ge::GRAPH_FAILED);
+
+    OP_CHECK_IF(AnalyzeShapes() != ge::GRAPH_SUCCESS, OP_LOGE(inputParams_.opName, "Invalid shapes."),
+                return ge::GRAPH_FAILED);
+
+    OP_CHECK_IF(GetScale() != ge::GRAPH_SUCCESS, OP_LOGE(inputParams_.opName, "Invalid GetScale."),
+                return ge::GRAPH_FAILED);
+
+    OP_CHECK_IF(GetOptionalInput() != ge::GRAPH_SUCCESS, OP_LOGE(inputParams_.opName, "Invalid GetOptionalInput."),
+                return ge::GRAPH_FAILED);
+
+    OP_CHECK_IF(AnalyzeFormat() != ge::GRAPH_SUCCESS, OP_LOGE(inputParams_.opName, "Invalid Format."),
+                return ge::GRAPH_FAILED);
+
+    return ge::GRAPH_SUCCESS;
+}
+
+ge::graphStatus RecurrentGatedDeltaRuleTiling::DoOpTiling()
+{
+    OP_CHECK_IF(CalUbSize() != ge::GRAPH_SUCCESS, OP_LOGE(inputParams_.opName, "CalUbSize failed."),
+                return ge::GRAPH_FAILED);
+
+    PrintTilingData();
+    return ge::GRAPH_SUCCESS;
+}
+
+ge::graphStatus RecurrentGatedDeltaRuleTiling::DoLibApiTiling()
+{
+    tilingKey_ = 0;
+    return ge::GRAPH_SUCCESS;
+};
+
+uint64_t RecurrentGatedDeltaRuleTiling::GetTilingKey() const
+{
+    return tilingKey_;
+};
+
+ge::graphStatus RecurrentGatedDeltaRuleTiling::GetWorkspaceSize()
+{
+    // system workspace size is 16 * 1024 * 1024 = 16M;
+    constexpr int64_t sysWorkspaceSize = 16777216;
+    workspaceSize_ = sysWorkspaceSize;
+
+    return ge::GRAPH_SUCCESS;
+};
+
+ge::graphStatus RecurrentGatedDeltaRuleTiling::PostTiling()
+{
+    context_->SetBlockDim(tilingData_.vectorCoreNum);
+    auto tilingDataSize = sizeof(RecurrentGatedDeltaRuleTilingData);
+    errno_t ret = memcpy_s(context_->GetRawTilingData()->GetData(), context_->GetRawTilingData()->GetCapacity(),
+                           reinterpret_cast<void *>(&tilingData_), tilingDataSize);
+    if (ret != EOK) {
+        OP_LOGE(context_->GetNodeName(), "memcpy_s failed, ret=%d", ret);
+        return ge::GRAPH_FAILED;
+    }
+    context_->GetRawTilingData()->SetDataSize(tilingDataSize);
+
+    size_t *workspaces = context_->GetWorkspaceSizes(1); // set workspace
+    OP_CHECK_IF(workspaces == nullptr, OPS_REPORT_CUBE_INNER_ERR(context_->GetNodeName(), "workspaces is null"),
+                return ge::GRAPH_FAILED);
+    workspaces[0] = workspaceSize_;
+
+    return ge::GRAPH_SUCCESS;
+}
+
+ge::graphStatus RecurrentGatedDeltaRuleTiling::CheckContext()
+{
+    OP_CHECK_NULL_WITH_CONTEXT(context_, context_->GetInputShape(QUERY_INDEX));
+    OP_CHECK_NULL_WITH_CONTEXT(context_, context_->GetInputDesc(QUERY_INDEX));
+
+    OP_CHECK_NULL_WITH_CONTEXT(context_, context_->GetInputShape(KEY_INDEX));
+    OP_CHECK_NULL_WITH_CONTEXT(context_, context_->GetInputDesc(KEY_INDEX));
+
+    OP_CHECK_NULL_WITH_CONTEXT(context_, context_->GetInputShape(VALUE_INDEX));
+    OP_CHECK_NULL_WITH_CONTEXT(context_, context_->GetInputDesc(VALUE_INDEX));
+
+    OP_CHECK_NULL_WITH_CONTEXT(context_, context_->GetInputShape(BETA_INDEX));
+    OP_CHECK_NULL_WITH_CONTEXT(context_, context_->GetInputDesc(BETA_INDEX));
+
+    OP_CHECK_NULL_WITH_CONTEXT(context_, context_->GetInputShape(STATE_INDEX));
+    OP_CHECK_NULL_WITH_CONTEXT(context_, context_->GetInputDesc(STATE_INDEX));
+
+    OP_CHECK_NULL_WITH_CONTEXT(context_, context_->GetInputShape(CUSEQLENS_INDEX));
+    OP_CHECK_NULL_WITH_CONTEXT(context_, context_->GetInputDesc(CUSEQLENS_INDEX));
+
+    OP_CHECK_NULL_WITH_CONTEXT(context_, context_->GetInputShape(SSM_STATE_INDICES_INDEX));
+    OP_CHECK_NULL_WITH_CONTEXT(context_, context_->GetInputDesc(SSM_STATE_INDICES_INDEX));
+
+    return ge::GRAPH_SUCCESS;
+}
+
+ge::graphStatus RecurrentGatedDeltaRuleTiling::AnalyzeDtype()
+{
+    auto queryDtype = context_->GetInputDesc(QUERY_INDEX)->GetDataType();
+    auto keyDtype = context_->GetInputDesc(KEY_INDEX)->GetDataType();
+    auto valueDtype = context_->GetInputDesc(VALUE_INDEX)->GetDataType();
+    OP_CHECK_IF(queryDtype != ge::DT_BF16 || keyDtype != ge::DT_BF16 || valueDtype != ge::DT_BF16,
+                OP_LOGE(context_->GetNodeName(), "query dtype, key dtype and value dtype should be bfloat16"),
+                return ge::GRAPH_FAILED);
+
+    auto betaDtype = context_->GetInputDesc(BETA_INDEX)->GetDataType();
+    auto stateDtype = context_->GetInputDesc(STATE_INDEX)->GetDataType();
+    OP_CHECK_IF(betaDtype != ge::DT_BF16 ,
+                OP_LOGE(context_->GetNodeName(), "beta dtype should be bfloat16"),
+                return ge::GRAPH_FAILED);
+    OP_CHECK_IF(stateDtype != ge::DT_FLOAT && stateDtype != ge::DT_BF16,
+                OP_LOGE(context_->GetNodeName(), "state dtype should be bfloat16 or float32"),
+                return ge::GRAPH_FAILED);
+    auto cuSeqlensDtype = context_->GetInputDesc(CUSEQLENS_INDEX)->GetDataType();
+    auto ssmStateIndicesDtype = context_->GetInputDesc(SSM_STATE_INDICES_INDEX)->GetDataType();
+    OP_CHECK_IF(cuSeqlensDtype != ge::DT_INT32 || ssmStateIndicesDtype != ge::DT_INT32,
+                OP_LOGE(context_->GetNodeName(), "cuSeqlens dtype and ssmStateIndices dtype should be int32"),
+                return ge::GRAPH_FAILED);
+
+    if (context_->GetOptionalInputDesc(G_INDEX) != nullptr) {
+        auto gamaDtype = context_->GetOptionalInputDesc(G_INDEX)->GetDataType();
+        OP_CHECK_IF(gamaDtype != ge::DT_FLOAT, OP_LOGE(context_->GetNodeName(), "gama dtype should be float32"),
+                    return ge::GRAPH_FAILED);
+    }
+
+    if (context_->GetOptionalInputDesc(GK_INDEX) != nullptr) {
+        auto gamaKDtype = context_->GetOptionalInputDesc(GK_INDEX)->GetDataType();
+        OP_CHECK_IF(gamaKDtype != ge::DT_FLOAT, OP_LOGE(context_->GetNodeName(), "gamaK dtype should be float32"),
+                    return ge::GRAPH_FAILED);
+    }
+
+    if (context_->GetOptionalInputDesc(ACC_TO_INDEX) != nullptr) {
+        auto numAcceptedTokensDtype = context_->GetOptionalInputDesc(ACC_TO_INDEX)->GetDataType();
+        OP_CHECK_IF(numAcceptedTokensDtype != ge::DT_INT32,
+                    OP_LOGE(context_->GetNodeName(), "numAcceptedTokens dtype should be int32"),
+                    return ge::GRAPH_FAILED);
+    }
+
+    return ge::GRAPH_SUCCESS;
+}
+
+
+bool RecurrentGatedDeltaRuleTiling::CheckDimEqual(const gert::Shape a, const int64_t dimA, gert::Shape b, const int64_t dimB,
+                                                  const std::string &nameA, const std::string &nameB,
+                                                  const std::string &dimDesc)
+{
+    if (a.GetDim(dimA) != b.GetDim(dimB)) {
+        OP_LOGE(context_->GetNodeName(), "The %s of %s and %s should be the same, but %s is %ld while %s is %ld",
+                dimDesc.c_str(), nameA.c_str(), nameB.c_str(), nameA.c_str(), a.GetDim(dimA), nameB.c_str(),
+                b.GetDim(dimB));
+        return false;
+    }
+    return true;
+}
+
+bool RecurrentGatedDeltaRuleTiling::CheckDim(const gert::Shape shape, const size_t dim, const std::string &dimDesc)
+{
+    if (shape.GetDimNum() != dim) {
+        OP_LOGE(context_->GetNodeName(), "The number of dimensions of %s should be %zu, but it is %zu",
+                dimDesc.c_str(), dim, shape.GetDimNum());
+        return false;
+    }
+    return true;
+}
+
+// Split shape checks/fill/scheduling decisions to improve readability and maintenance.
+ge::graphStatus RecurrentGatedDeltaRuleTiling::CheckShapeDimAndRelation(const gert::Shape &queryShape,
+                                                                         const gert::Shape &keyShape,
+                                                                         const gert::Shape &valueShape,
+                                                                         const gert::Shape &betaShape,
+                                                                         const gert::Shape &stateShape,
+                                                                         const gert::Shape &cuSeqlensShape,
+                                                                         const gert::Shape &ssmStateShape)
+{
+    if (!CheckDim(queryShape, QKV_DIM_NUM, "query") || !CheckDim(keyShape, QKV_DIM_NUM, "key") ||
+        !CheckDim(valueShape, QKV_DIM_NUM, "value") || !CheckDim(betaShape, BETA_DIM_NUM, "beta") ||
+        !CheckDim(stateShape, STATE_DIM_NUM, "state") ||
+        !CheckDim(cuSeqlensShape, CUSEQLENS_DIM_NUM, "query_start_loc") ||
+        !CheckDim(ssmStateShape, SSM_STATE_INDICES_DIM_NUM, "ssm_state_indices")) {
+        return ge::GRAPH_FAILED;
+    }
+
+#if defined(DCUT_RECURRENT_FIXED_STATE_ROWS)
+    OP_CHECK_IF(ssmStateShape.GetDim(DIM_0) != cuSeqlensShape.GetDim(DIM_0) - 1 ||
+                    ssmStateShape.GetDim(DIM_1) <= 0 || ssmStateShape.GetDim(DIM_1) > MAX_MTP,
+                OP_LOGE(inputParams_.opName,
+                    "ssm_state_indices must have shape [B, S], where B matches query_start_loc and 1 <= S <= %zu",
+                        MAX_MTP),
+                return ge::GRAPH_FAILED);
+#endif
+    if (!CheckDimEqual(queryShape, DIM_0, keyShape, DIM_0, "query", "key", "T dimension") ||
+        !CheckDimEqual(queryShape, DIM_1, keyShape, DIM_1, "query", "key", "Nk dimension") ||
+        !CheckDimEqual(queryShape, DIM_2, keyShape, DIM_2, "query", "key", "Dk dimension") ||
+        !CheckDimEqual(stateShape, DIM_1, valueShape, DIM_1, "state", "value", "Nv dimension") ||
+        !CheckDimEqual(stateShape, DIM_2, valueShape, DIM_2, "state", "value", "Dv dimension") ||
+        !CheckDimEqual(valueShape, DIM_0, queryShape, DIM_0, "value", "query", "T dimension") ||
+        !CheckDimEqual(betaShape, DIM_0, queryShape, DIM_0, "beta", "query", "T dimension") ||
+        !CheckDimEqual(betaShape, DIM_1, valueShape, DIM_1, "beta", "value", "Nv dimension") ||
+        !CheckDimEqual(stateShape, DIM_3, queryShape, DIM_2, "state", "query", "Dk dimension")) {
+        return ge::GRAPH_FAILED;
+    }
+
+    return ge::GRAPH_SUCCESS;
+}
+
+void RecurrentGatedDeltaRuleTiling::FillTilingShapeData(const gert::Shape &queryShape, const gert::Shape &valueShape,
+                                                         const gert::Shape &stateShape,
+                                                         const gert::Shape &cuSeqlensShape)
+{
+    tilingData_.t = queryShape.GetDim(DIM_0);
+    tilingData_.nk = queryShape.GetDim(DIM_1);
+    tilingData_.dk = queryShape.GetDim(DIM_2);
+    tilingData_.nv = valueShape.GetDim(DIM_1);
+    tilingData_.dv = valueShape.GetDim(DIM_2);
+    tilingData_.sBlockNum = stateShape.GetDim(DIM_0);
+    tilingData_.b = cuSeqlensShape.GetDim(DIM_0) - 1;
+}
+
+ge::graphStatus RecurrentGatedDeltaRuleTiling::CheckShapeValueRangeAndRule()
+{
+    OP_CHECK_IF(tilingData_.nk > 256 || tilingData_.nv > 256 || tilingData_.dk > 512 || tilingData_.dv > 512,
+                OP_LOGE(inputParams_.opName,
+                        "nk and nv should no bigger than 256, dk and dv should no bigger than 512, but nk is %u, nv is "
+                        "%u, dk is %u, dv is %u",
+                        tilingData_.nk, tilingData_.nv, tilingData_.dk, tilingData_.dv),
+                return ge::GRAPH_FAILED);
+
+    OP_CHECK_IF(tilingData_.nv % tilingData_.nk != 0,
+                OP_LOGE(inputParams_.opName,
+                        "nv should be an integer multiple of nk, but nv is %u, nk is %u",
+                        tilingData_.nv, tilingData_.nk),
+                return ge::GRAPH_FAILED);
+
+    return ge::GRAPH_SUCCESS;
+}
+
+void RecurrentGatedDeltaRuleTiling::UpdateDynamicBlockDimByTaskUnits()
+{
+    // Dynamic blockDim: do not launch more cores than effective (batch, head) task units.
+    uint64_t taskUnits = static_cast<uint64_t>(tilingData_.b) * static_cast<uint64_t>(tilingData_.nv);
+    if (taskUnits == 0) {
+        taskUnits = 1;
+    }
+    uint64_t maxCoreNum = (compileInfo_.aivNum > 0) ? compileInfo_.aivNum : 1;
+    uint64_t selectedCoreNum = (taskUnits < maxCoreNum) ? taskUnits : maxCoreNum;
+    tilingData_.vectorCoreNum = static_cast<uint32_t>(selectedCoreNum);
+    OP_LOGD(context_->GetNodeName(), "taskUnits: [%llu], selected vectorCoreNum: [%u]",
+            static_cast<unsigned long long>(taskUnits), tilingData_.vectorCoreNum);
+}
+
+ge::graphStatus RecurrentGatedDeltaRuleTiling::RuleCheckShapeDimAndRelation()
+{
+    const auto &queryShape = context_->GetInputShape(QUERY_INDEX)->GetOriginShape();
+    const auto &keyShape = context_->GetInputShape(KEY_INDEX)->GetOriginShape();
+    const auto &valueShape = context_->GetInputShape(VALUE_INDEX)->GetOriginShape();
+    const auto &betaShape = context_->GetInputShape(BETA_INDEX)->GetOriginShape();
+    const auto &stateShape = context_->GetInputShape(STATE_INDEX)->GetOriginShape();
+    const auto &cuSeqlensShape = context_->GetInputShape(CUSEQLENS_INDEX)->GetOriginShape();
+    const auto &ssmStateShape = context_->GetInputShape(SSM_STATE_INDICES_INDEX)->GetOriginShape();
+    return CheckShapeDimAndRelation(queryShape, keyShape, valueShape, betaShape, stateShape, cuSeqlensShape, ssmStateShape);
+}
+
+ge::graphStatus RecurrentGatedDeltaRuleTiling::RuleFillTilingShapeData()
+{
+    const auto &queryShape = context_->GetInputShape(QUERY_INDEX)->GetOriginShape();
+    const auto &valueShape = context_->GetInputShape(VALUE_INDEX)->GetOriginShape();
+    const auto &stateShape = context_->GetInputShape(STATE_INDEX)->GetOriginShape();
+    const auto &cuSeqlensShape = context_->GetInputShape(CUSEQLENS_INDEX)->GetOriginShape();
+    FillTilingShapeData(queryShape, valueShape, stateShape, cuSeqlensShape);
+#if defined(DCUT_RECURRENT_FIXED_STATE_ROWS)
+    const auto &ssmStateShape = context_->GetInputShape(SSM_STATE_INDICES_INDEX)->GetOriginShape();
+    tilingData_.stateIndexStride = ssmStateShape.GetDim(DIM_1);
+#endif
+    return ge::GRAPH_SUCCESS;
+}
+
+ge::graphStatus RecurrentGatedDeltaRuleTiling::RuleCheckShapeValueRangeAndRule()
+{
+    return CheckShapeValueRangeAndRule();
+}
+
+ge::graphStatus RecurrentGatedDeltaRuleTiling::RuleUpdateDynamicBlockDimByTaskUnits()
+{
+    UpdateDynamicBlockDimByTaskUnits();
+    return ge::GRAPH_SUCCESS;
+}
+
+ge::graphStatus RecurrentGatedDeltaRuleTiling::RuleInitUbCalcContext()
+{
+    ubCalcCtx_.ubSize = compileInfo_.ubSize;
+    ubCalcCtx_.aNv = CeilAlign(tilingData_.nv, static_cast<uint32_t>(16)); // 16 * 2 = 32B
+    ubCalcCtx_.aDv = CeilAlign(tilingData_.dv, static_cast<uint32_t>(16)); // 16 * 2 = 32B
+    ubCalcCtx_.aDk = CeilAlign(tilingData_.dk, static_cast<uint32_t>(16)); // 16 * 2 = 32B
+    return ge::GRAPH_SUCCESS;
+}
+
+ge::graphStatus RecurrentGatedDeltaRuleTiling::RuleCalcFixedUbBytes()
+{
+    ubCalcCtx_.fixedUbBytes = CalcFixedUbBytes(ubCalcCtx_.aNv, ubCalcCtx_.aDv, ubCalcCtx_.aDk);
+    tilingData_.ubRestBytes = ubCalcCtx_.ubSize - ubCalcCtx_.fixedUbBytes;
+    return ge::GRAPH_SUCCESS;
+}
+
+ge::graphStatus RecurrentGatedDeltaRuleTiling::RuleCalcWorkingUbBytes()
+{
+    ubCalcCtx_.workingUbBytes = CalcWorkingUbBytes(ubCalcCtx_.aNv, ubCalcCtx_.aDv, ubCalcCtx_.aDk);
+    return ge::GRAPH_SUCCESS;
+}
+
+ge::graphStatus RecurrentGatedDeltaRuleTiling::RuleCalcVStepCoeff()
+{
+    ubCalcCtx_.coeff = CalcVStepCoeff(ubCalcCtx_.aDk, 1, 1);
+    return ge::GRAPH_SUCCESS;
+}
+
+ge::graphStatus RecurrentGatedDeltaRuleTiling::RuleFinalizeVStepFromUb()
+{
+    return FinalizeVStepFromUb(ubCalcCtx_.ubSize, ubCalcCtx_.workingUbBytes, ubCalcCtx_.coeff);
+}
+
+// AnalyzeShapes now executes a deterministic rule-chain, easier to extend/maintain.
+ge::graphStatus RecurrentGatedDeltaRuleTiling::AnalyzeShapes()
+{
+    struct RuleItem {
+        const char *name;
+        HostRuleFn fn;
+    };
+    const std::array<RuleItem, 4> shapeRules = {{
+        {"RuleCheckShapeDimAndRelation", &RecurrentGatedDeltaRuleTiling::RuleCheckShapeDimAndRelation},
+        {"RuleFillTilingShapeData", &RecurrentGatedDeltaRuleTiling::RuleFillTilingShapeData},
+        {"RuleCheckShapeValueRangeAndRule", &RecurrentGatedDeltaRuleTiling::RuleCheckShapeValueRangeAndRule},
+        {"RuleUpdateDynamicBlockDimByTaskUnits", &RecurrentGatedDeltaRuleTiling::RuleUpdateDynamicBlockDimByTaskUnits},
+    }};
+    for (const auto &rule : shapeRules) {
+        OP_CHECK_IF((this->*(rule.fn))() != ge::GRAPH_SUCCESS,
+                    OP_LOGE(inputParams_.opName, "AnalyzeShapes rule failed: %s", rule.name),
+                    return ge::GRAPH_FAILED);
+    }
+    return ge::GRAPH_SUCCESS;
+}
+
+
+bool RecurrentGatedDeltaRuleTiling::CheckFormat(ge::Format format, const std::string &Desc)
+{
+    if (format == ge::FORMAT_FRACTAL_NZ) {
+        OP_LOGE(context_->GetNodeName(), "%s format not support NZ", Desc.c_str());
+        return false;
+    }
+    return true;
+}
+
+ge::graphStatus RecurrentGatedDeltaRuleTiling::AnalyzeFormat()
+{
+    if (!CheckFormat(context_->GetInputDesc(QUERY_INDEX)->GetStorageFormat(), "query") ||
+        !CheckFormat(context_->GetInputDesc(KEY_INDEX)->GetStorageFormat(), "key") ||
+        !CheckFormat(context_->GetInputDesc(VALUE_INDEX)->GetStorageFormat(), "value") ||
+        !CheckFormat(context_->GetInputDesc(STATE_INDEX)->GetStorageFormat(), "state") ||
+        !CheckFormat(context_->GetInputDesc(CUSEQLENS_INDEX)->GetStorageFormat(), "query_start_loc") ||
+        !CheckFormat(context_->GetInputDesc(SSM_STATE_INDICES_INDEX)->GetStorageFormat(), "ssm_state_indices")) {
+        return ge::GRAPH_FAILED;
+    }
+
+    if (context_->GetOptionalInputDesc(G_INDEX) != nullptr) {
+        auto gamaFormat = context_->GetOptionalInputDesc(G_INDEX)->GetStorageFormat();
+        OP_CHECK_IF(gamaFormat == ge::FORMAT_FRACTAL_NZ, OP_LOGE(context_->GetNodeName(), "gama format not support NZ"),
+                    return ge::GRAPH_FAILED);
+    }
+    if (context_->GetOptionalInputDesc(GK_INDEX) != nullptr) {
+        auto gamaKFormat = context_->GetOptionalInputDesc(GK_INDEX)->GetStorageFormat();
+        OP_CHECK_IF(gamaKFormat == ge::FORMAT_FRACTAL_NZ, OP_LOGE(context_->GetNodeName(), "gamaK format not support NZ"),
+                    return ge::GRAPH_FAILED);
+    }
+    if (context_->GetOptionalInputDesc(ACC_TO_INDEX) != nullptr) {
+        auto numAcceptedTokensFormat = context_->GetOptionalInputDesc(ACC_TO_INDEX)->GetStorageFormat();
+        OP_CHECK_IF(numAcceptedTokensFormat == ge::FORMAT_FRACTAL_NZ,
+                    OP_LOGE(context_->GetNodeName(), "numAcceptedTokens format not support NZ"), return ge::GRAPH_FAILED);
+    }
+
+    return ge::GRAPH_SUCCESS;
+}
+
+ge::graphStatus RecurrentGatedDeltaRuleTiling::GetScale()
+{
+    auto attrs = context_->GetAttrs();
+    float scaleValue = *attrs->GetAttrPointer<float>(0);
+    tilingData_.scale = scaleValue;
+
+    return ge::GRAPH_SUCCESS;
+}
+
+ge::graphStatus RecurrentGatedDeltaRuleTiling::GetOptionalInput()
+{
+    if (context_->GetOptionalInputDesc(G_INDEX) == nullptr) {
+        tilingData_.hasGama = 0;
+    } else {
+        tilingData_.hasGama = 1;
+    }
+    if (context_->GetOptionalInputDesc(GK_INDEX) == nullptr) {
+        tilingData_.hasGamaK = 0;
+    } else {
+        tilingData_.hasGamaK = 1;
+    }
+    if (context_->GetOptionalInputDesc(ACC_TO_INDEX) == nullptr) {
+        tilingData_.hasAcceptedTokens = 0;
+    } else {
+        tilingData_.hasAcceptedTokens = 1;
+    }
+
+    return ge::GRAPH_SUCCESS;
+}
+
+void RecurrentGatedDeltaRuleTiling::PrintTilingData()
+{
+    OP_LOGD(context_->GetNodeName(), "vectorCoreNum: [%u]", tilingData_.vectorCoreNum);
+    OP_LOGD(context_->GetNodeName(), "ubCalSize: [%u]", tilingData_.ubCalSize);
+    OP_LOGD(context_->GetNodeName(), "ubRestBytes: [%u]", tilingData_.ubRestBytes);
+    OP_LOGD(context_->GetNodeName(), "t: [%u]", tilingData_.t);
+    OP_LOGD(context_->GetNodeName(), "nk: [%u]", tilingData_.nk);
+    OP_LOGD(context_->GetNodeName(), "dk: [%u]", tilingData_.dk);
+    OP_LOGD(context_->GetNodeName(), "nv: [%u]", tilingData_.nv);
+    OP_LOGD(context_->GetNodeName(), "dv: [%u]", tilingData_.dv);
+    OP_LOGD(context_->GetNodeName(), "sBlockNum: [%u]", tilingData_.sBlockNum);
+    OP_LOGD(context_->GetNodeName(), "b: [%u]", tilingData_.b);
+    OP_LOGD(context_->GetNodeName(), "vStep: [%u]", tilingData_.vStep);
+    OP_LOGD(context_->GetNodeName(), "stateOutBufferNum: [%u]", tilingData_.stateOutBufferNum);
+    OP_LOGD(context_->GetNodeName(), "attnOutBufferNum: [%u]", tilingData_.attnOutBufferNum);
+    OP_LOGD(context_->GetNodeName(), "scale: [%f]", tilingData_.scale);
+    OP_LOGD(context_->GetNodeName(), "hasGama: [%u]", tilingData_.hasGama);
+    OP_LOGD(context_->GetNodeName(), "hasGamaK: [%u]", tilingData_.hasGamaK);
+    OP_LOGD(context_->GetNodeName(), "hasAcceptedTokens: [%u]", tilingData_.hasAcceptedTokens);
+#if defined(DCUT_RECURRENT_FIXED_STATE_ROWS)
+    OP_LOGD(context_->GetNodeName(), "stateIndexStride: [%u]", tilingData_.stateIndexStride);
+#endif
+}
+
+int64_t RecurrentGatedDeltaRuleTiling::CalcFixedUbBytes(int64_t aNv, int64_t aDv, int64_t aDk) const
+{
+    int64_t usedUbBytes = MAX_MTP * (4 * aDk + 2 * aDv); // 4 for qInQueue_ & kInQueue_, 2 for vInQueue_
+    usedUbBytes += 128;                                  // reserve 128 Bytes
+    if (tilingData_.hasGamaK) {
+        usedUbBytes += MAX_MTP * 4 * aDk; // 4 for gk gamaInQueue_
+    }
+    if (tilingData_.hasGama) {
+        usedUbBytes += MAX_MTP * 4 * aNv; // 4 for g gamaInQueue_
+    }
+    usedUbBytes += MAX_MTP * 2 * aNv; // 2 for betaInQueue_
+    return usedUbBytes;
+}
+
+int64_t RecurrentGatedDeltaRuleTiling::CalcWorkingUbBytes(int64_t aNv, int64_t aDv, int64_t aDk) const
+{
+    int64_t usedUbBytes = CalcFixedUbBytes(aNv, aDv, aDk);
+    usedUbBytes += MAX_MTP * (8 * aDk + 4 * aDv + 4 * aNv); // 8 for qk in ub, 4 for v in ub, 4 for beta in ub
+    return usedUbBytes;
+}
+
+int64_t RecurrentGatedDeltaRuleTiling::CalcVStepCoeff(int64_t aDk, uint32_t stateOutBufferNum,
+                                                       uint32_t attnOutBufferNum) const
+{
+    auto stateDtype = context_->GetInputDesc(STATE_INDEX)->GetDataType();
+    int64_t stateDtypeSize = (stateDtype == ge::DT_FLOAT) ? 4 : 2;
+    int64_t coeff = (stateDtypeSize + static_cast<int64_t>(stateDtypeSize * stateOutBufferNum)) * aDk +
+                    static_cast<int64_t>(4 * attnOutBufferNum); // stateIn/stateOut/attnOut queues
+    coeff += (4 + 4) * aDk + 4 + 4;                             // qInUb/kInUb/vInUb/deltaInUb/attnInUb
+    return coeff;
+}
+
+bool RecurrentGatedDeltaRuleTiling::EvaluateBufferProfile(int64_t ubSize, int64_t usedUbBytes, int64_t aDk,
+                                                           uint32_t stateOutBufferNum, uint32_t attnOutBufferNum,
+                                                           BufferProfile &profile) const
+{
+    int64_t coeff = CalcVStepCoeff(aDk, stateOutBufferNum, attnOutBufferNum);
+    int64_t vStep = (ubSize - usedUbBytes) / coeff / 8 * 8; // 8 * sizeof(float) = 32
+    if (vStep < 8) {
+        return false;
+    }
+    int64_t repeatTime = CeilDiv(tilingData_.dv, static_cast<uint32_t>(vStep));
+    vStep = CeilAlign(CeilDiv(tilingData_.dv, static_cast<uint32_t>(repeatTime)),
+                                 static_cast<uint32_t>(8));
+    if (vStep < 8) {
+        return false;
+    }
+    profile.stateOutBufferNum = stateOutBufferNum;
+    profile.attnOutBufferNum = attnOutBufferNum;
+    profile.vStep = static_cast<uint32_t>(vStep);
+    profile.repeatTime = static_cast<uint32_t>(repeatTime);
+    profile.valid = true;
+    return true;
+}
+
+bool RecurrentGatedDeltaRuleTiling::IsBetterProfile(const BufferProfile &candidate, const BufferProfile &current) const
+{
+    if (!current.valid) {
+        return true;
+    }
+    if (candidate.repeatTime != current.repeatTime) {
+        return candidate.repeatTime < current.repeatTime;
+    }
+    uint32_t candidateDepth = candidate.stateOutBufferNum + candidate.attnOutBufferNum;
+    uint32_t currentDepth = current.stateOutBufferNum + current.attnOutBufferNum;
+    if (candidateDepth != currentDepth) {
+        return candidateDepth > currentDepth;
+    }
+    return candidate.vStep > current.vStep;
+}
+
+ge::graphStatus RecurrentGatedDeltaRuleTiling::FinalizeVStepFromUb(int64_t ubSize, int64_t usedUbBytes, int64_t coeff)
+{
+    (void)coeff;
+    int64_t aDk = CeilAlign(tilingData_.dk, static_cast<uint32_t>(16)); // 16 * 2 = 32B
+    BufferProfile selected;
+    const std::array<BufferProfile, 4> candidates = {{
+        BufferProfile(1u, 1u, 0u, 0u, false),
+        BufferProfile(1u, 2u, 0u, 0u, false),
+        BufferProfile(2u, 2u, 0u, 0u, false),
+        BufferProfile(3u, 3u, 0u, 0u, false)
+    }};
+    for (const auto &candidate : candidates) {
+        BufferProfile profile;
+        if (!EvaluateBufferProfile(ubSize, usedUbBytes, aDk, candidate.stateOutBufferNum, candidate.attnOutBufferNum,
+                                   profile)) {
+            continue;
+        }
+        if (IsBetterProfile(profile, selected)) {
+            selected = profile;
+        }
+    }
+
+    OP_LOGD(context_->GetNodeName(), "selected profile: stateOutBufferNum=[%u], attnOutBufferNum=[%u], vStep=[%u], repeatTime=[%u], valid=[%d]",
+            selected.stateOutBufferNum, selected.attnOutBufferNum, selected.vStep, selected.repeatTime, selected.valid);
+
+    if (!selected.valid) {
+        OP_LOGE(context_->GetNodeName(), "vStep should be bigger than 8, shape is too big");
+        return ge::GRAPH_FAILED;
+    }
+    auto stateDtype = context_->GetInputDesc(STATE_INDEX)->GetDataType();
+
+    int64_t stateDtypeSize = (stateDtype == ge::DT_FLOAT) ? 4 : 2;
+
+    int64_t queueCoeff = (stateDtypeSize + static_cast<int64_t>(stateDtypeSize * selected.stateOutBufferNum)) * aDk +
+                         static_cast<int64_t>(4 * selected.attnOutBufferNum);
+    int64_t ubRestBytes = ubSize - ubCalcCtx_.fixedUbBytes - queueCoeff * static_cast<int64_t>(selected.vStep);
+    if (ubRestBytes < 0) {
+        OP_LOGE(context_->GetNodeName(), "ubRestBytes should be non-negative, but got %ld", ubRestBytes);
+        return ge::GRAPH_FAILED;
+    }
+    tilingData_.ubCalSize = compileInfo_.ubSize;
+    tilingData_.vStep = selected.vStep;
+    tilingData_.stateOutBufferNum = selected.stateOutBufferNum;
+    tilingData_.attnOutBufferNum = selected.attnOutBufferNum;
+    tilingData_.ubRestBytes = static_cast<uint32_t>(ubRestBytes);
+    return ge::GRAPH_SUCCESS;
+}
+
+// CalUbSize now runs an ordered UB rule-chain with explicit intermediate states.
+ge::graphStatus RecurrentGatedDeltaRuleTiling::CalUbSize()
+{
+    struct RuleItem {
+        const char *name;
+        HostRuleFn fn;
+    };
+    const std::array<RuleItem, 5> ubRules = {{
+        {"RuleInitUbCalcContext", &RecurrentGatedDeltaRuleTiling::RuleInitUbCalcContext},
+        {"RuleCalcFixedUbBytes", &RecurrentGatedDeltaRuleTiling::RuleCalcFixedUbBytes},
+        {"RuleCalcWorkingUbBytes", &RecurrentGatedDeltaRuleTiling::RuleCalcWorkingUbBytes},
+        {"RuleCalcVStepCoeff", &RecurrentGatedDeltaRuleTiling::RuleCalcVStepCoeff},
+        {"RuleFinalizeVStepFromUb", &RecurrentGatedDeltaRuleTiling::RuleFinalizeVStepFromUb},
+    }};
+    for (const auto &rule : ubRules) {
+        OP_CHECK_IF((this->*(rule.fn))() != ge::GRAPH_SUCCESS,
+                    OP_LOGE(inputParams_.opName, "CalUbSize rule failed: %s", rule.name),
+                    return ge::GRAPH_FAILED);
+    }
+    return ge::GRAPH_SUCCESS;
+}
+
+static ge::graphStatus RecurrentGatedDeltaRuleTilingFunc(gert::TilingContext *context)
+{
+    OP_CHECK_IF(context == nullptr, OPS_REPORT_CUBE_INNER_ERR("RecurrentGatedDeltaRule", "context is null"),
+                return ge::GRAPH_FAILED);
+    return Ops::Transformer::OpTiling::TilingRegistry::GetInstance().DoTilingImpl(context);
+}
+
+static ge::graphStatus TilingPrepareForRecurrentGatedDeltaRule(gert::TilingParseContext *context)
+{
+    OP_CHECK_IF(context == nullptr, OPS_REPORT_CUBE_INNER_ERR("RecurrentGatedDeltaRule", "context is null"),
+                return ge::GRAPH_FAILED);
+
+    fe::PlatFormInfos *platformInfo = context->GetPlatformInfo();
+    OP_CHECK_IF(platformInfo == nullptr, OPS_REPORT_CUBE_INNER_ERR(context->GetNodeName(), "platformInfoPtr is null"),
+                return ge::GRAPH_FAILED);
+
+    auto compileInfoPtr = context->GetCompiledInfo<RecurrentGatedDeltaRuleCompileInfo>();
+    OP_CHECK_IF(compileInfoPtr == nullptr, OPS_REPORT_CUBE_INNER_ERR(context->GetNodeName(), "compileInfoPtr is null"),
+                return ge::GRAPH_FAILED);
+
+    return ge::GRAPH_SUCCESS;
+}
+
+IMPL_OP_OPTILING(RecurrentGatedDeltaRule)
+    .Tiling(RecurrentGatedDeltaRuleTilingFunc)
+    .TilingParse<RecurrentGatedDeltaRuleCompileInfo>(TilingPrepareForRecurrentGatedDeltaRule);
+} // namespace optiling

--- a/dcut/kernel/dcut_recurrent_gated_delta_rule/vendor/op_host/recurrent_gated_delta_rule_tiling.h
+++ b/dcut/kernel/dcut_recurrent_gated_delta_rule/vendor/op_host/recurrent_gated_delta_rule_tiling.h
@@ -1,0 +1,137 @@
+/**
+ * Copyright (c) 2025 Huawei Technologies Co., Ltd.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ */
+
+/*!
+ * \file recurrent_gated_delta_rule_tiling.h
+ * \brief
+ */
+#ifndef __OP_HOST_RECURRENT_GETED_DELTA_RULE_TILING_H__
+#define __OP_HOST_RECURRENT_GETED_DELTA_RULE_TILING_H__
+#include <tiling/tiling_api.h>
+#include "register/tilingdata_base.h"
+#include "tiling_base/tiling_base.h"
+#include "tiling_base/error_log.h"
+#include "../op_kernel/recurrent_gated_delta_rule_tiling_data.h"
+
+namespace optiling {
+using namespace RecurrentGatedDeltaRule;
+
+struct RecurrentGatedDeltaRuleCompileInfo {
+    uint64_t aivNum{0UL};
+    uint64_t ubSize{0UL};
+};
+
+struct RecurrentGatedDeltaRuleInfo {
+public:
+    int64_t usedCoreNum = 0;
+    const char *opName = "RecurrentGatedDeltaRule";
+};
+
+class RecurrentGatedDeltaRuleTiling : public Ops::Transformer::OpTiling::TilingBaseClass {
+public:
+    explicit RecurrentGatedDeltaRuleTiling(gert::TilingContext *context) : Ops::Transformer::OpTiling::TilingBaseClass(context)
+    {
+        InitCompileInfo();
+    };
+    ~RecurrentGatedDeltaRuleTiling() override = default;
+
+protected:
+    bool IsCapable() override
+    {
+        return true;
+    }
+    // 1、获取平台信息比如CoreNum、UB/L1/L0C资源大小
+    ge::graphStatus GetPlatformInfo() override;
+    // 2、获取INPUT/OUTPUT/ATTR信息
+    ge::graphStatus GetShapeAttrsInfo() override;
+    // 3、计算数据切分TilingData
+    ge::graphStatus DoOpTiling() override;
+    // 4、计算高阶API的TilingData
+    ge::graphStatus DoLibApiTiling() override;
+    // 5、计算TilingKey
+    uint64_t GetTilingKey() const override;
+    // 6、计算Workspace 大小
+    ge::graphStatus GetWorkspaceSize() override;
+    // 7、保存Tiling数据
+    ge::graphStatus PostTiling() override;
+
+protected:
+    void InitCompileInfo();
+    void PrintTilingData();
+
+    //Host tiling rule-chain engine: compose shape/UB steps by ordered rules.
+    using HostRuleFn = ge::graphStatus (RecurrentGatedDeltaRuleTiling::*)();
+    struct UbCalcContext {
+        int64_t ubSize = 0;
+        int64_t aNv = 0;
+        int64_t aDv = 0;
+        int64_t aDk = 0;
+        int64_t fixedUbBytes = 0;
+        int64_t workingUbBytes = 0;
+        int64_t coeff = 0;
+    };
+
+    struct BufferProfile {
+        BufferProfile() = default;
+        BufferProfile(uint32_t s, uint32_t a, uint32_t v, uint32_t r, bool val)
+            : stateOutBufferNum(s), attnOutBufferNum(a), vStep(v), repeatTime(r), valid(val) {}
+
+        uint32_t stateOutBufferNum = 1;
+        uint32_t attnOutBufferNum = 1;
+        uint32_t vStep = 0;
+        uint32_t repeatTime = 0;
+        bool valid = false;
+    };
+
+    ge::graphStatus CheckContext();
+    ge::graphStatus AnalyzeDtype();
+    ge::graphStatus AnalyzeShapes();
+    ge::graphStatus CalUbSize();
+    ge::graphStatus GetScale();
+    ge::graphStatus GetOptionalInput();
+    ge::graphStatus AnalyzeFormat();
+    //Host tiling refactor helpers: split shape validation/fill and UB calculation.
+    ge::graphStatus CheckShapeDimAndRelation(const gert::Shape &queryShape, const gert::Shape &keyShape,
+                                             const gert::Shape &valueShape, const gert::Shape &betaShape,
+                                             const gert::Shape &stateShape, const gert::Shape &cuSeqlensShape,
+                                             const gert::Shape &ssmStateShape);
+    void FillTilingShapeData(const gert::Shape &queryShape, const gert::Shape &valueShape, const gert::Shape &stateShape,
+                             const gert::Shape &cuSeqlensShape);
+    ge::graphStatus CheckShapeValueRangeAndRule();
+    void UpdateDynamicBlockDimByTaskUnits();
+    int64_t CalcFixedUbBytes(int64_t aNv, int64_t aDv, int64_t aDk) const;
+    int64_t CalcWorkingUbBytes(int64_t aNv, int64_t aDv, int64_t aDk) const;
+    int64_t CalcVStepCoeff(int64_t aDk, uint32_t stateOutBufferNum, uint32_t attnOutBufferNum) const;
+    bool EvaluateBufferProfile(int64_t ubSize, int64_t usedUbBytes, int64_t aDk, uint32_t stateOutBufferNum,
+                               uint32_t attnOutBufferNum, BufferProfile &profile) const;
+    bool IsBetterProfile(const BufferProfile &candidate, const BufferProfile &current) const;
+    ge::graphStatus FinalizeVStepFromUb(int64_t ubSize, int64_t usedUbBytes, int64_t coeff);
+    ge::graphStatus RuleCheckShapeDimAndRelation();
+    ge::graphStatus RuleFillTilingShapeData();
+    ge::graphStatus RuleCheckShapeValueRangeAndRule();
+    ge::graphStatus RuleUpdateDynamicBlockDimByTaskUnits();
+    ge::graphStatus RuleInitUbCalcContext();
+    ge::graphStatus RuleCalcFixedUbBytes();
+    ge::graphStatus RuleCalcWorkingUbBytes();
+    ge::graphStatus RuleCalcVStepCoeff();
+    ge::graphStatus RuleFinalizeVStepFromUb();
+
+    bool CheckDimEqual(const gert::Shape a, const int64_t dimA, gert::Shape b, const int64_t dimB, const std::string &nameA,
+                       const std::string &nameB, const std::string &dimDesc);
+    bool CheckDim(const gert::Shape shape, const size_t dim, const std::string &dimDesc);
+    bool CheckFormat(ge::Format format, const std::string &Desc);
+
+    RecurrentGatedDeltaRuleCompileInfo compileInfo_;
+    RecurrentGatedDeltaRuleTilingData tilingData_;
+    RecurrentGatedDeltaRuleInfo inputParams_;
+    UbCalcContext ubCalcCtx_;
+};
+
+} // namespace optiling
+#endif // __OP_HOST_RECURRENT_GETED_DELTA_RULE_TILING_H__

--- a/dcut/kernel/dcut_recurrent_gated_delta_rule/vendor/op_kernel/arch35/recurrent_gated_delta_rule.h
+++ b/dcut/kernel/dcut_recurrent_gated_delta_rule/vendor/op_kernel/arch35/recurrent_gated_delta_rule.h
@@ -1,0 +1,696 @@
+/**
+ * Copyright (c) 2026 Tianjin University, Ltd.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ */
+
+/*!
+ * \file recurrent_gated_delta_rule.h
+ * \brief
+ */
+
+#ifndef __RECURRENT_GATED_DELTA_RULE_KERNEL_H_
+#define __RECURRENT_GATED_DELTA_RULE_KERNEL_H_
+
+#include "kernel_operator.h"
+#include "lib/matmul_intf.h"
+#include "../recurrent_gated_delta_rule_tiling_data.h"
+
+namespace RecurrentGatedDeltaRule {
+
+using namespace matmul;
+using namespace AscendC;
+using namespace AscendC::MicroAPI;
+constexpr uint64_t BUFFER_NUM = 1;
+constexpr uint32_t MAX_OUT_BUFFER_NUM = 2;
+constexpr uint64_t MAX_MTP = 16;
+constexpr uint64_t BF16_NUM_PER_BLOCK = 16;
+constexpr uint64_t FP32_NUM_PER_BLOCK = 8;
+constexpr uint32_t REPEAT_LENTH = 64; // 256Byte for float
+constexpr uint32_t MAX_REPEAT_TIME = 255;
+constexpr uint32_t ADD_FOLD_REDUCE_MIN_K = 128;
+constexpr uint16_t V_LENGTH = VECTOR_REG_WIDTH / sizeof(float);
+constexpr uint16_t TWO_V_LENGTH = 2 * V_LENGTH;
+
+constexpr CastTrait castTraitB16ToB32 = {
+    RegLayout::ZERO, SatMode::UNKNOWN, MaskMergeMode::ZEROING, RoundMode::UNKNOWN};
+
+#ifndef RGDR_ENABLE_ADD_FOLD_REDUCE
+#define RGDR_ENABLE_ADD_FOLD_REDUCE  1
+#endif
+struct RGDRInitParams {
+    GM_ADDR query;
+    GM_ADDR key;
+    GM_ADDR value;
+    GM_ADDR gama;
+    GM_ADDR gamaK;
+    GM_ADDR beta;
+    GM_ADDR initState;
+    GM_ADDR cuSeqlens;
+    GM_ADDR ssmStateIndices;
+    GM_ADDR numAcceptedTokens;
+    GM_ADDR attnOut;
+    GM_ADDR finalState;
+};
+
+template <typename inType, typename outType, typename stateType>
+class RGDR {
+public:
+    __aicore__ inline RGDR(const RecurrentGatedDeltaRuleTilingData *tilingData)
+    {
+        B_ = tilingData->b;
+        T_ = tilingData->t;
+        NK_ = tilingData->nk;
+        realK_ = tilingData->dk;
+        NV_ = tilingData->nv;
+        realV_ = tilingData->dv;
+        scale_ = tilingData->scale;
+        hasAcceptedTokens_ = (tilingData->hasAcceptedTokens == 1);
+#if defined(DCUT_RECURRENT_FIXED_STATE_ROWS)
+        stateIndexStride_ = tilingData->stateIndexStride;
+#endif
+        hasGama_ = (tilingData->hasGama == 1);
+        hasGamaK_ = (tilingData->hasGamaK == 1);
+        useAddFoldReduce_ = (RGDR_ENABLE_ADD_FOLD_REDUCE != 0);
+        vStep_ = tilingData->vStep;
+        stateOutBufferNum_ = (tilingData->stateOutBufferNum == MAX_OUT_BUFFER_NUM) ? MAX_OUT_BUFFER_NUM : BUFFER_NUM;
+        attnOutBufferNum_ = (tilingData->attnOutBufferNum == MAX_OUT_BUFFER_NUM) ? MAX_OUT_BUFFER_NUM : BUFFER_NUM;
+        restUbSize_ = tilingData->ubRestBytes;
+        alignK_ = Ceil(tilingData->dk, BF16_NUM_PER_BLOCK) * BF16_NUM_PER_BLOCK;
+        alignV_ = Ceil(tilingData->dv, BF16_NUM_PER_BLOCK) * BF16_NUM_PER_BLOCK;
+        load = 0;
+        usedblk = 0;
+    }
+
+    __aicore__ inline void Init(const RGDRInitParams &initParams, TPipe *pipe)
+    {
+        uint64_t blockDim = GetBlockNum();
+        blockIdx = GetBlockIdx();
+        if (blockIdx >= blockDim) {
+            return;
+        }
+        pipe_ = pipe;
+        SetGlobalTensors(initParams);
+        InitLocalBuffers();
+    }
+
+    __aicore__ inline void SetGlobalTensors(const RGDRInitParams &initParams)
+    {
+        queryGm_.SetGlobalBuffer((__gm__ inType *)initParams.query);
+        keyGm_.SetGlobalBuffer((__gm__ inType *)initParams.key);
+        valueGm_.SetGlobalBuffer((__gm__ inType *)initParams.value);
+        gamaGm_.SetGlobalBuffer((__gm__ float *)initParams.gama);
+        gamaKGm_.SetGlobalBuffer((__gm__ float *)initParams.gamaK);
+        betaGm_.SetGlobalBuffer((__gm__ inType *)initParams.beta);
+        initStateGm_.SetGlobalBuffer((__gm__ stateType *)initParams.initState);
+        cuSeqlensGm_.SetGlobalBuffer((__gm__ int32_t *)initParams.cuSeqlens);
+        ssmStateIndicesGm_.SetGlobalBuffer((__gm__ int32_t *)initParams.ssmStateIndices);
+        numAcceptedTokensGm_.SetGlobalBuffer((__gm__ int32_t *)initParams.numAcceptedTokens);
+        finalStateGm_.SetGlobalBuffer((__gm__ stateType *)initParams.finalState);
+        attnOutGm_.SetGlobalBuffer((__gm__ outType *)initParams.attnOut);
+    }
+
+    __aicore__ inline void InitLocalBuffers()
+    {
+        uint32_t cubeSize = alignK_ * vStep_ * sizeof(float);
+        uint32_t singleVSize = vStep_ * sizeof(float);
+        uint32_t vSize = MAX_MTP * alignV_ * sizeof(float);
+        uint32_t kSize = MAX_MTP * alignK_ * sizeof(float);
+        uint32_t betaNumAlign = Ceil(MAX_MTP * NV_, BF16_NUM_PER_BLOCK) * BF16_NUM_PER_BLOCK;
+        pipe_->InitBuffer(qInQueue_, BUFFER_NUM, MAX_MTP * alignK_ * sizeof(inType));
+        pipe_->InitBuffer(kInQueue_, BUFFER_NUM, MAX_MTP * alignK_ * sizeof(inType));
+        pipe_->InitBuffer(vInQueue_, BUFFER_NUM, MAX_MTP * alignV_ * sizeof(inType));
+        pipe_->InitBuffer(stateInQueue_, BUFFER_NUM, alignK_ * vStep_ * sizeof(stateType));
+        if (hasGama_) {
+            pipe_->InitBuffer(gamaInQueue_, BUFFER_NUM, MAX_MTP * NV_ * sizeof(float));
+        }
+        if (hasGamaK_) {
+            pipe_->InitBuffer(gamaKInQueue_, BUFFER_NUM, MAX_MTP * alignK_ * sizeof(float));
+        }
+        pipe_->InitBuffer(betaInQueue_, BUFFER_NUM, MAX_MTP * NV_ * sizeof(inType));
+        pipe_->InitBuffer(stateOutQueue_, stateOutBufferNum_, alignK_ * vStep_ * sizeof(stateType));
+        pipe_->InitBuffer(attnOutQueue_, attnOutBufferNum_, vStep_ * sizeof(outType));
+        pipe_->InitBuffer(tmpBuff, restUbSize_);
+        uint32_t buffOffset = 0;
+        deltaInUb = tmpBuff.GetWithOffset<float>(static_cast<uint32_t>(vStep_), buffOffset);
+        buffOffset += singleVSize;
+        attnInUb = tmpBuff.GetWithOffset<float>(static_cast<uint32_t>(vStep_), buffOffset);
+        buffOffset += singleVSize;
+        vInUb = tmpBuff.GetWithOffset<float>(static_cast<uint32_t>(MAX_MTP * alignV_), buffOffset);
+        buffOffset += vSize;
+        qInUb = tmpBuff.GetWithOffset<float>(static_cast<uint32_t>(MAX_MTP * alignK_), buffOffset);
+        buffOffset += kSize;
+        kInUb = tmpBuff.GetWithOffset<float>(static_cast<uint32_t>(MAX_MTP * alignK_), buffOffset);
+        buffOffset += kSize;
+        stateInUb = tmpBuff.GetWithOffset<float>(static_cast<uint32_t>(alignK_ * vStep_), buffOffset);
+        buffOffset += cubeSize;
+        broadTmpInUb = tmpBuff.GetWithOffset<float>(static_cast<uint32_t>(alignK_ * vStep_), buffOffset);
+        buffOffset += cubeSize;
+        betaInUb = tmpBuff.GetWithOffset<float>(static_cast<uint32_t>(betaNumAlign), buffOffset);
+        // gamaInUb is NOT carved from tmpBuff. It reuses the gamaInQueue_ tensor
+        // directly (see CopyInGamaBeta), matching the generic kernel. Otherwise
+        // the host-side UB accounting (CalcWorkingUbBytes, which reserves beta
+        // but not gama in tmpBuff) under-counts by betaNumAlign floats, and the
+        // shortfall doubles with MAX_MTP -> risk of tmpBuff overflow.
+    }
+
+    __aicore__ inline void ComputeAvgload()
+    {
+        uint64_t realT = 0;
+#if defined(DCUT_RECURRENT_QUERY_START_LOC)
+        if (B_ > 0) {
+            const int32_t firstToken = cuSeqlensGm_.GetValue(0);
+            const int32_t lastToken = cuSeqlensGm_.GetValue(B_);
+            if (firstToken >= 0 && lastToken >= firstToken) {
+                realT = static_cast<uint64_t>(lastToken - firstToken);
+            }
+        }
+#else
+        for (uint64_t batch_i = 1; batch_i < B_ + 1; batch_i++) {
+            realT += cuSeqlensGm_.GetValue(batch_i);
+        }
+#endif
+        avgload = Ceil(realT * NV_, GetBlockNum());
+    }
+
+    __aicore__ inline void Process()
+    {
+        ComputeAvgload();
+        int32_t seq0 = cuSeqlensGm_.GetValue(0);
+        for (uint64_t batch_i = 0; batch_i < B_; batch_i++) {
+#if defined(DCUT_RECURRENT_QUERY_START_LOC)
+            const int32_t seq1 = cuSeqlensGm_.GetValue(batch_i + 1);
+            const int32_t seqLen = seq1 - seq0;
+#else
+            const int32_t seqLen = cuSeqlensGm_.GetValue(batch_i + 1);
+            const int32_t seq1 = seq0 + seqLen;
+#endif
+            if (seqLen < 0) {
+                return;
+            }
+            if (seqLen == 0) {
+                seq0 = seq1;
+                continue;
+            }
+            if (seqLen > static_cast<int32_t>(MAX_MTP)) {
+                return;
+            }
+#if defined(DCUT_RECURRENT_FIXED_STATE_ROWS)
+            if (stateIndexStride_ == 0 || seqLen > static_cast<int32_t>(stateIndexStride_)) {
+                return;
+            }
+#endif
+            if (seq0 < 0 || seq1 < seq0 || seq1 > static_cast<int32_t>(T_)) {
+                return;
+            }
+            uint32_t copyFlag = 0;
+            uint64_t stateOffset;
+            for (uint64_t head_i = 0; head_i < NV_; head_i++) {
+                if (!IsCurrentBlock(seq1 - seq0)) {
+                    continue;
+                }
+                copyFlag++;
+                if (copyFlag == 1) {
+                    int32_t stateTokenIdx = seq0;
+#if defined(DCUT_RECURRENT_FIXED_STATE_ROWS)
+                    stateTokenIdx = static_cast<int32_t>(batch_i * stateIndexStride_);
+                    if (hasAcceptedTokens_) {
+                        const int32_t acceptedTokenNum = numAcceptedTokensGm_.GetValue(batch_i);
+                        if (acceptedTokenNum <= 0 || acceptedTokenNum > static_cast<int32_t>(stateIndexStride_)) {
+                            return;
+                        }
+                        stateTokenIdx += acceptedTokenNum - 1;
+                    }
+#else
+                    if (hasAcceptedTokens_) {
+                        int32_t acceptedTokenNum = numAcceptedTokensGm_.GetValue(batch_i);
+                        if (acceptedTokenNum <= 0 || acceptedTokenNum > seqLen) {
+                            return;
+                        }
+                        stateTokenIdx = seq0 + acceptedTokenNum - 1;
+                    }
+#endif
+#if defined(DCUT_RECURRENT_FIXED_STATE_ROWS)
+                    const int32_t stateOffsetValue = ssmStateIndicesGm_.GetValue(stateTokenIdx);
+                    if (stateOffsetValue < 0) {
+                        return;
+                    }
+                    stateOffset = static_cast<uint64_t>(stateOffsetValue);
+#else
+                    stateOffset = ssmStateIndicesGm_.GetValue(stateTokenIdx);
+#endif
+                    CopyInGamaBeta(seq0, seq1);
+                }
+#if defined(DCUT_RECURRENT_FIXED_STATE_ROWS)
+                ProcessHead(seq0, seq1, head_i, stateOffset, batch_i);
+#else
+                ProcessHead(seq0, seq1, head_i, stateOffset);
+#endif
+            }
+            if (hasGama_ && copyFlag != 0) {
+                gamaInQueue_.FreeTensor(gamaInUb);
+            }
+            seq0 = seq1;
+        }
+    }
+
+private:
+    __aicore__ inline void CopyInQKV(uint64_t vOffset, uint64_t qkOffset, int32_t seqLen)
+    {
+        LocalTensor<inType> qLocal = qInQueue_.AllocTensor<inType>();
+        LocalTensor<inType> kLocal = kInQueue_.AllocTensor<inType>();
+        LocalTensor<inType> vLocal = vInQueue_.AllocTensor<inType>();
+        DataCopyExtParams qkInParams{static_cast<uint16_t>(seqLen), static_cast<uint32_t>(realK_ * sizeof(inType)),
+                                     static_cast<uint32_t>((NK_ - 1) * realK_ * sizeof(inType)), 0, 0};
+        DataCopyExtParams vInParams{static_cast<uint16_t>(seqLen), static_cast<uint32_t>(realV_ * sizeof(inType)),
+                                    static_cast<uint32_t>((NV_ - 1) * realV_ * sizeof(inType)), 0, 0};
+        DataCopyPadExtParams<inType> qkPadParams{true, 0, static_cast<uint8_t>(alignK_ - realK_), 0};
+        DataCopyPadExtParams<inType> vPadParams{true, 0, static_cast<uint8_t>(alignV_ - realV_), 0};
+        if (hasGamaK_) {
+            uint32_t alignKGamma = Ceil(realK_, FP32_NUM_PER_BLOCK) * FP32_NUM_PER_BLOCK;
+            uint32_t stride = alignKGamma < alignK_ ? 1 : 0;
+            DataCopyExtParams gkInParams{static_cast<uint16_t>(seqLen), static_cast<uint32_t>(realK_ * sizeof(float)),
+                                     static_cast<uint32_t>((NV_ - 1) * realK_ * sizeof(float)), stride, 0};
+            DataCopyPadExtParams<float> gkPadParams{true, 0, static_cast<uint8_t>(alignKGamma - realK_), 0};
+            LocalTensor<float> gamaKLocal = gamaKInQueue_.AllocTensor<float>();
+            Duplicate<float>(gamaKLocal, 0, alignK_ * seqLen);
+            TEventID evevtIdVtoMte2 = GetTPipePtr()->FetchEventID(HardEvent::V_MTE2);
+            SetFlag<HardEvent::V_MTE2>(evevtIdVtoMte2);
+            WaitFlag<HardEvent::V_MTE2>(evevtIdVtoMte2);
+            DataCopyPad(gamaKLocal, gamaKGm_[vOffset / realV_ * realK_], gkInParams, gkPadParams);
+            gamaKInQueue_.EnQue<float>(gamaKLocal);
+            gamaKInUb = gamaKInQueue_.DeQue<float>();
+            Exp(gamaKInUb, gamaKInUb, alignK_ * seqLen);
+            AscendC::PipeBarrier<PIPE_V>();
+        }
+        DataCopyPad(qLocal, queryGm_[qkOffset], qkInParams, qkPadParams);
+        DataCopyPad(kLocal, keyGm_[qkOffset], qkInParams, qkPadParams);
+        DataCopyPad(vLocal, valueGm_[vOffset], vInParams, vPadParams);
+        qInQueue_.EnQue<inType>(qLocal);
+        kInQueue_.EnQue<inType>(kLocal);
+        vInQueue_.EnQue<inType>(vLocal);
+        qLocal = qInQueue_.DeQue<inType>();
+        kLocal = kInQueue_.DeQue<inType>();
+        vLocal = vInQueue_.DeQue<inType>();
+        Cast(qInUb, qLocal, AscendC::RoundMode::CAST_NONE, alignK_ * seqLen);
+        Cast(kInUb, kLocal, AscendC::RoundMode::CAST_NONE, alignK_ * seqLen);
+        Cast(vInUb, vLocal, AscendC::RoundMode::CAST_NONE, alignV_ * seqLen);
+        AscendC::PipeBarrier<PIPE_V>();
+        Muls(qInUb, qInUb, scale_, seqLen * alignK_);
+        qInQueue_.FreeTensor(qLocal);
+        kInQueue_.FreeTensor(kLocal);
+        vInQueue_.FreeTensor(vLocal);
+    }
+
+    __aicore__ inline void PrefetchState(uint64_t stateOffest, uint32_t curSingleV)
+    {
+        LocalTensor<stateType> stateLocal = stateInQueue_.AllocTensor<stateType>();
+        DataCopyExtParams stateInParams{static_cast<uint16_t>(curSingleV),
+                                        static_cast<uint16_t>(realK_ * sizeof(stateType)), 0, 0, 0};
+        DataCopyPadExtParams<stateType> padParams{true, 0, static_cast<uint8_t>(alignK_ - realK_), 0};
+        DataCopyPad(stateLocal, initStateGm_[stateOffest], stateInParams, padParams);
+        stateInQueue_.EnQue<stateType>(stateLocal);
+    }
+
+    __aicore__ inline void LoadPrefetchedState(uint32_t curSingleV)
+    {
+        LocalTensor<stateType> stateLocal = stateInQueue_.DeQue<stateType>();
+        if constexpr (std::is_same<stateType, float32_t>()) {
+            DataCopy(stateInUb, stateLocal, alignK_ * curSingleV);
+        } else {
+            Cast(stateInUb, stateLocal, AscendC::RoundMode::CAST_NONE, alignK_ * curSingleV);
+        }
+        stateInQueue_.FreeTensor(stateLocal);
+    }
+
+    __aicore__ inline void MatVecMul(const LocalTensor<float> &cubeTensor, const LocalTensor<float> &vecTensor,
+                                          LocalTensor<float> &dstTensor, uint32_t rows)
+    {
+        __ubuf__ float* cubeAddr = (__ubuf__ float*)cubeTensor.GetPhyAddr();
+        __ubuf__ float* vecAddr = (__ubuf__ float*)vecTensor.GetPhyAddr();
+        __ubuf__ float* dstAddr = (__ubuf__ float*)dstTensor.GetPhyAddr();
+
+        uint16_t rowNum = static_cast<uint16_t>(rows);
+        uint16_t colLoopTimes = static_cast<uint16_t>(Ceil(alignK_, V_LENGTH));
+        uint32_t colLength = alignK_;
+        __VEC_SCOPE__
+        {
+            RegTensor<float> cube;
+            RegTensor<float> vec;
+            RegTensor<float> dst;
+            MaskReg pregLoop;
+            for (uint16_t j = 0; j < colLoopTimes; j++) {
+                pregLoop = UpdateMask<float>(colLength);
+                DataCopy(vec, vecAddr + j * V_LENGTH);
+                for (uint16_t i = 0; i < rowNum; i ++) {
+                    DataCopy(cube, cubeAddr + i * alignK_ + j * V_LENGTH);
+                    Mul(dst, cube, vec, pregLoop);
+                    DataCopy(dstAddr + i * alignK_ + j * V_LENGTH, dst, pregLoop);
+                }
+            }
+        }
+    }
+
+    __aicore__ inline void ProcessKQ(const LocalTensor<float> &cubeTensor, const LocalTensor<float> &vec1Tensor,
+                                          LocalTensor<float> &dst1Tensor, const LocalTensor<float> &vec2Tensor,
+                                          LocalTensor<float> &dst2Tensor, uint32_t rows)
+    {
+        __ubuf__ float* cubeAddr = (__ubuf__ float*)cubeTensor.GetPhyAddr();
+        __ubuf__ float* vec1Addr = (__ubuf__ float*)vec1Tensor.GetPhyAddr();
+        __ubuf__ float* vec2Addr = (__ubuf__ float*)vec2Tensor.GetPhyAddr();
+        __ubuf__ float* dst1Addr = (__ubuf__ float*)dst1Tensor.GetPhyAddr();
+        __ubuf__ float* dst2Addr = (__ubuf__ float*)dst2Tensor.GetPhyAddr();
+
+        uint16_t rowNum = static_cast<uint16_t>(rows);
+        uint16_t colLoopTimes = static_cast<uint16_t>(Ceil(alignK_, V_LENGTH));
+        uint32_t colLength = alignK_;
+        __VEC_SCOPE__
+        {
+            RegTensor<float> cube;
+            RegTensor<float> vec1;
+            RegTensor<float> vec2;
+            RegTensor<float> dst1;
+            RegTensor<float> dst2;
+            MaskReg pregLoop;
+            for (uint16_t j = 0; j < colLoopTimes; j++) {
+                pregLoop = UpdateMask<float>(colLength);
+                DataCopy(vec1, vec1Addr + j * V_LENGTH);
+                DataCopy(vec2, vec2Addr + j * V_LENGTH);
+                for (uint16_t i = 0; i < rowNum; i ++) {
+                    DataCopy<float, LoadDist::DIST_BRC_B32>(cube, cubeAddr + i);
+                    DataCopy(dst1, dst1Addr + i * alignK_ + j * V_LENGTH);
+                    Mul(cube, cube, vec1, pregLoop);
+                    Add(dst1, dst1, cube, pregLoop);
+                    Mul(dst2, dst1, vec2, pregLoop);
+                    DataCopy(dst1Addr + i * alignK_ + j * V_LENGTH, dst1, pregLoop);
+                    DataCopy(dst2Addr + i * alignK_ + j * V_LENGTH, dst2, pregLoop);
+                }
+            }
+        }
+    }
+
+    __aicore__ inline void ReduceSum64(__ubuf__ float* dstAddr, __ubuf__ float* srcAddr, uint16_t rowNum)
+    {
+        uint32_t colLength = alignK_;
+        __VEC_SCOPE__
+        {
+            RegTensor<float> src;
+            RegTensor<float> sum;
+            MaskReg pregLoop = UpdateMask<float>(colLength);
+            for (uint16_t i = 0;i < rowNum;i ++) {
+                DataCopy(src, srcAddr + i * alignK_);
+                ReduceSum(sum, src, pregLoop);
+                DataCopy<float, StoreDist::DIST_FIRST_ELEMENT_B32>(dstAddr + i, sum, pregLoop);
+            }
+        }
+    }
+
+    __aicore__ inline void ReduceSum128(__ubuf__ float* dstAddr, __ubuf__ float* srcAddr, uint16_t rowNum)
+    {
+        uint32_t colLength = alignK_ - V_LENGTH;
+        __VEC_SCOPE__
+        {
+            RegTensor<float> src1;
+            RegTensor<float> src2;
+            RegTensor<float> sum;
+            MaskReg pregFull = CreateMask<float, MaskPattern::ALL>();
+            MaskReg pregLoop = UpdateMask<float>(colLength);
+            for (uint16_t i = 0;i < rowNum;i ++) {
+                DataCopy(src1, srcAddr + i * alignK_);
+                DataCopy(src2, srcAddr + i * alignK_ + V_LENGTH);
+                Add<float, MaskMergeMode::MERGING>(src1, src1, src2, pregLoop);
+                ReduceSum(sum, src1, pregFull);
+                DataCopy<float, StoreDist::DIST_FIRST_ELEMENT_B32>(dstAddr + i, sum, pregFull);
+            }
+        }
+    }
+
+    __aicore__ inline void ReduceSumVF(__ubuf__ float* dstAddr, __ubuf__ float* srcAddr, uint16_t rowNum)
+    {
+        uint16_t colLoopTimes = static_cast<uint16_t>(Ceil(alignK_, V_LENGTH));
+        __VEC_SCOPE__
+        {
+            RegTensor<float> src;
+            RegTensor<float> tmp;
+            RegTensor<float> sum;
+            MaskReg pregFull = CreateMask<float, MaskPattern::ALL>();
+            MaskReg pregLoop;
+            for (uint16_t i = 0;i < rowNum;i ++) {
+                uint32_t colLength = alignK_;
+                Duplicate(tmp, 0.0f);
+                for (uint16_t j = 0; j < colLoopTimes; j++) {
+                    pregLoop = UpdateMask<float>(colLength);
+                    DataCopy(src, srcAddr + i * alignK_ + j * V_LENGTH);
+                    Add<float, MaskMergeMode::MERGING>(tmp, tmp, src, pregLoop);
+                }
+                ReduceSum(sum, tmp, pregFull);
+                DataCopy<float, StoreDist::DIST_FIRST_ELEMENT_B32>(dstAddr + i, sum, pregFull);
+            }
+        }
+    }
+
+    __aicore__ inline void ReduceSumDispatch(LocalTensor<float> &dstTensor, LocalTensor<float> &srcTensor,
+                                             uint32_t rows)
+    {
+        __ubuf__ float* srcAddr = (__ubuf__ float*)srcTensor.GetPhyAddr();
+        __ubuf__ float* dstAddr = (__ubuf__ float*)dstTensor.GetPhyAddr();
+        uint16_t rowNum = static_cast<uint16_t>(rows);
+        if (alignK_ <= V_LENGTH) {
+            ReduceSum64(dstAddr, srcAddr, rowNum);
+        } else if (alignK_ <= TWO_V_LENGTH) {
+            ReduceSum128(dstAddr, srcAddr, rowNum);
+        } else {
+            ReduceSumVF(dstAddr, srcAddr, rowNum);
+        }
+    }
+
+    __aicore__ inline void Compute(uint32_t curSingleV, uint64_t curQKOffset, uint64_t curVOffset)
+    {
+        if (hasGama_) {
+            Muls(stateInUb, stateInUb, gama_, alignK_ * curSingleV);
+        }
+        if (hasGamaK_) {
+            MatVecMul(stateInUb, gamaKInUb[curQKOffset], stateInUb, curSingleV);
+        }
+        if (hasGama_ || hasGamaK_) {
+            AscendC::PipeBarrier<PIPE_V>();
+        }
+        MatVecMul(stateInUb, kInUb[curQKOffset], broadTmpInUb, curSingleV);
+        AscendC::PipeBarrier<PIPE_V>();
+        ReduceSumDispatch(deltaInUb, broadTmpInUb, curSingleV);
+        AscendC::PipeBarrier<PIPE_V>();
+        Sub(deltaInUb, vInUb[curVOffset], deltaInUb, curSingleV);
+        AscendC::PipeBarrier<PIPE_V>();
+        Muls(deltaInUb, deltaInUb, beta_, curSingleV);
+        AscendC::PipeBarrier<PIPE_V>();
+        ProcessKQ(deltaInUb, kInUb[curQKOffset], stateInUb, qInUb[curQKOffset], broadTmpInUb, curSingleV);
+        AscendC::PipeBarrier<PIPE_V>();
+        ReduceSumDispatch(attnInUb, broadTmpInUb, curSingleV);
+        LocalTensor<stateType> stateOutLocal = stateOutQueue_.AllocTensor<stateType>();
+        LocalTensor<outType> attnOutLocal = attnOutQueue_.AllocTensor<outType>();
+        if constexpr (std::is_same<stateType, float32_t>()) {
+            DataCopy(stateOutLocal, stateInUb, alignK_ * curSingleV);
+        } else {
+            Cast(stateOutLocal, stateInUb, AscendC::RoundMode::CAST_RINT, alignK_ * curSingleV);
+        }
+        stateOutQueue_.EnQue<stateType>(stateOutLocal);
+        Cast(attnOutLocal, attnInUb, AscendC::RoundMode::CAST_RINT, curSingleV);
+        attnOutQueue_.EnQue<outType>(attnOutLocal);
+    }
+
+    __aicore__ inline void CopyOutAttn(uint64_t attnOffset, uint32_t curSingleV)
+    {
+        LocalTensor<outType> attnLocal = attnOutQueue_.DeQue<outType>();
+        DataCopyParams attnOutParams{1, static_cast<uint16_t>(curSingleV * sizeof(outType)), 0, 0};
+        DataCopyPad(attnOutGm_[attnOffset], attnLocal, attnOutParams);
+        attnOutQueue_.FreeTensor(attnLocal);
+    }
+
+    __aicore__ inline void CopyOutState(uint64_t stateOffset, uint32_t curSingleV)
+    {
+        LocalTensor<stateType> stateOutLocal = stateOutQueue_.DeQue<stateType>();
+        DataCopyParams stateOutParams{static_cast<uint16_t>(curSingleV),
+                                      static_cast<uint16_t>(realK_ * sizeof(stateType)), 0, 0};
+        DataCopyPad(finalStateGm_[stateOffset], stateOutLocal, stateOutParams);
+        stateOutQueue_.FreeTensor(stateOutLocal);
+    }
+
+    __aicore__ inline void CopyInGamaBeta(int32_t seq0, int32_t seq1)
+    {
+        int32_t seqLen = seq1 - seq0;
+        LocalTensor<inType> betaLocal = betaInQueue_.AllocTensor<inType>();
+        DataCopyParams betaInParams{1, static_cast<uint16_t>(seqLen * NV_ * sizeof(inType)), 0, 0};
+        DataCopyPadParams padParams;
+        DataCopyPad(betaLocal, betaGm_[seq0 * NV_], betaInParams, padParams);
+        betaInQueue_.EnQue<inType>(betaLocal);
+        betaLocal = betaInQueue_.DeQue<inType>();
+        Cast(betaInUb, betaLocal, AscendC::RoundMode::CAST_NONE, seqLen * NV_);
+        betaInQueue_.FreeTensor(betaLocal);
+        if (hasGama_) {
+            LocalTensor<float> gamaLocal = gamaInQueue_.AllocTensor<float>();
+            DataCopyParams gamaInParams{1, static_cast<uint16_t>(seqLen * NV_ * sizeof(float)), 0, 0};
+            DataCopyPad(gamaLocal, gamaGm_[seq0 * NV_], gamaInParams, padParams);
+            gamaInQueue_.EnQue<float>(gamaLocal);
+            gamaInUb = gamaInQueue_.DeQue<float>();
+            Exp(gamaInUb, gamaInUb, seqLen * NV_);
+            AscendC::PipeBarrier<PIPE_V>();
+            // gamaInUb (the queue tensor) stays live until the batch-boundary
+            // FreeTensor in Process(), mirroring the generic kernel.
+        }
+    }
+
+#if defined(DCUT_RECURRENT_FIXED_STATE_ROWS)
+    __aicore__ inline void ProcessHead(int32_t seq0, int32_t seq1, uint64_t head_i, uint64_t stateOffset,
+                                        uint64_t batch_i)
+#else
+    __aicore__ inline void ProcessHead(int32_t seq0, int32_t seq1, uint64_t head_i, uint64_t stateOffset)
+#endif
+    {
+        uint64_t vOffset = (seq0 * NV_ + head_i) * realV_;
+        uint64_t qkOffset = (seq0 * NK_ + head_i / (NV_ / NK_)) * realK_;
+        CopyInQKV(vOffset, qkOffset, seq1 - seq0);
+        if (realV_ == 0) {
+            if (hasGamaK_) {
+                gamaKInQueue_.FreeTensor(gamaKInUb);
+            }
+            return;
+        }
+        uint64_t nextVOffset = 0;
+        uint32_t nextSingleV = realV_ > vStep_ ? vStep_ : realV_;
+        uint64_t nextStateOffset = ((stateOffset * NV_ + head_i) * realV_) * realK_;
+        PrefetchState(nextStateOffset, nextSingleV);
+        for (uint64_t v_i = 0; v_i < realV_; v_i += vStep_) {
+            uint32_t curSingleV = v_i + vStep_ > realV_ ? realV_ - v_i : vStep_;
+            LoadPrefetchedState(curSingleV);
+            nextVOffset = v_i + vStep_;
+            if (nextVOffset < realV_) {
+                nextSingleV = nextVOffset + vStep_ > realV_ ? realV_ - nextVOffset : vStep_;
+                nextStateOffset = ((stateOffset * NV_ + head_i) * realV_ + nextVOffset) * realK_;
+                PrefetchState(nextStateOffset, nextSingleV);
+            }
+            uint64_t pendingAttnOffset = 0;
+            uint64_t pendingStateOffset = 0;
+            bool hasPendingAttn = false;
+            bool hasPendingState = false;
+            for (uint64_t seq_i = seq0; seq_i < seq1; seq_i++) {
+                uint64_t gbOffset = head_i + (seq_i - seq0) * NV_;
+                uint64_t curQKOffset = (seq_i - seq0) * alignK_;
+                uint64_t curVOffset = (seq_i - seq0) * alignV_ + v_i;
+                uint64_t attnOffset = (seq_i * NV_ + head_i) * realV_ + v_i;
+#if defined(DCUT_RECURRENT_FIXED_STATE_ROWS)
+                const uint64_t stateTokenIdx = batch_i * stateIndexStride_ + (seq_i - seq0);
+#else
+                const uint64_t stateTokenIdx = seq_i;
+#endif
+                uint64_t curStateOutOffset =
+                    ((ssmStateIndicesGm_.GetValue(stateTokenIdx) * NV_ + head_i) * realV_ + v_i) * realK_;
+                gama_ = hasGama_ ? gamaInUb.GetValue(gbOffset) : 1;
+                beta_ = betaInUb.GetValue(gbOffset);
+                Compute(curSingleV, curQKOffset, curVOffset);
+                if (attnOutBufferNum_ == BUFFER_NUM) {
+                    CopyOutAttn(attnOffset, curSingleV);
+                } else {
+                    if (hasPendingAttn) {
+                        CopyOutAttn(pendingAttnOffset, curSingleV);
+                    }
+                    pendingAttnOffset = attnOffset;
+                    hasPendingAttn = true;
+                }
+                if (stateOutBufferNum_ == BUFFER_NUM) {
+                    CopyOutState(curStateOutOffset, curSingleV);
+                } else {
+                    if (hasPendingState) {
+                        CopyOutState(pendingStateOffset, curSingleV);
+                    }
+                    pendingStateOffset = curStateOutOffset;
+                    hasPendingState = true;
+                }
+            }
+            if (hasPendingAttn) {
+                CopyOutAttn(pendingAttnOffset, curSingleV);
+            }
+            if (hasPendingState) {
+                CopyOutState(pendingStateOffset, curSingleV);
+            }
+        }
+        if (hasGamaK_) {
+            gamaKInQueue_.FreeTensor(gamaKInUb);
+        }
+    }
+
+    __aicore__ inline bool IsCurrentBlock(int32_t seqlen)
+    {
+        load += seqlen;
+        bool ret = (blockIdx == usedblk && seqlen > 0);
+        if (load >= avgload) {
+            load = 0;
+            usedblk++;
+        }
+        return ret;
+    }
+
+private:
+    GlobalTensor<inType> queryGm_;
+    GlobalTensor<inType> keyGm_;
+    GlobalTensor<inType> valueGm_;
+    GlobalTensor<inType> betaGm_;
+    GlobalTensor<float> gamaGm_;
+    GlobalTensor<float> gamaKGm_;
+    GlobalTensor<stateType> initStateGm_;
+    GlobalTensor<int32_t> cuSeqlensGm_;
+    GlobalTensor<int32_t> ssmStateIndicesGm_;
+    GlobalTensor<int32_t> numAcceptedTokensGm_;
+    GlobalTensor<stateType> finalStateGm_;
+    GlobalTensor<outType> attnOutGm_;
+    TPipe *pipe_;
+    TQue<QuePosition::VECIN, 1> qInQueue_;
+    TQue<QuePosition::VECIN, 1> kInQueue_;
+    TQue<QuePosition::VECIN, 1> vInQueue_;
+    TQue<QuePosition::VECIN, 1> gamaInQueue_;
+    TQue<QuePosition::VECIN, 1> gamaKInQueue_;
+    TQue<QuePosition::VECIN, 1> betaInQueue_;
+    TQue<QuePosition::VECIN, 1> stateInQueue_;
+    TQue<QuePosition::VECOUT, MAX_OUT_BUFFER_NUM> attnOutQueue_;
+    TQue<QuePosition::VECOUT, MAX_OUT_BUFFER_NUM> stateOutQueue_;
+    TBuf<TPosition::VECCALC> tmpBuff;
+    LocalTensor<float> qInUb;
+    LocalTensor<float> kInUb;
+    LocalTensor<float> vInUb;
+    LocalTensor<float> gamaInUb;
+    LocalTensor<float> gamaKInUb;
+    LocalTensor<float> betaInUb;
+    LocalTensor<float> deltaInUb;
+    LocalTensor<float> broadTmpInUb;
+    LocalTensor<float> attnInUb;
+    LocalTensor<float> stateInUb;
+    uint32_t B_;
+    uint32_t T_;
+    uint32_t NK_;
+    uint32_t alignK_;
+    uint32_t realK_;
+    uint32_t NV_;
+    uint32_t alignV_;
+    uint32_t realV_;
+    uint32_t vStep_;
+    uint32_t stateOutBufferNum_;
+    uint32_t attnOutBufferNum_;
+    uint32_t restUbSize_;
+#if defined(DCUT_RECURRENT_FIXED_STATE_ROWS)
+    uint32_t stateIndexStride_;
+#endif
+    uint32_t load;
+    uint32_t usedblk;
+    uint32_t avgload;
+    bool hasAcceptedTokens_;
+    bool hasGama_;
+    bool hasGamaK_;
+    bool useAddFoldReduce_;
+    float gama_;
+    float beta_;
+    float scale_;
+    uint64_t blockIdx;
+};
+} // namespace RecurrentGatedDeltaRule
+#endif

--- a/dcut/kernel/dcut_recurrent_gated_delta_rule/vendor/op_kernel/recurrent_gated_delta_rule.cpp
+++ b/dcut/kernel/dcut_recurrent_gated_delta_rule/vendor/op_kernel/recurrent_gated_delta_rule.cpp
@@ -1,0 +1,41 @@
+/**
+ * Copyright (c) 2025 Huawei Technologies Co., Ltd.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ */
+
+/*!
+ * \file recurrent_gated_delta_rule.cpp
+ * \brief
+ */
+#if defined(__CCE_AICORE__) && __CCE_AICORE__ == 310
+#include "arch35/recurrent_gated_delta_rule.h"
+#else
+#include "recurrent_gated_delta_rule.h"
+#endif
+#include "recurrent_gated_delta_rule_tiling_data.h"
+
+
+using namespace AscendC;
+using namespace matmul;
+using namespace RecurrentGatedDeltaRule;
+
+
+extern "C" __global__ __aicore__ void
+recurrent_gated_delta_rule(GM_ADDR query, GM_ADDR key, GM_ADDR value, GM_ADDR beta, GM_ADDR state, GM_ADDR cuSeqlens,
+                           GM_ADDR ssmStateIndices, GM_ADDR g, GM_ADDR gk, GM_ADDR numAcceptedTokens, GM_ADDR out,
+                           GM_ADDR stateOut, GM_ADDR workspaceGM, GM_ADDR tilingGM)
+{
+    REGISTER_TILING_DEFAULT(RecurrentGatedDeltaRuleTilingData);
+    GET_TILING_DATA(tilingData, tilingGM);
+    KERNEL_TASK_TYPE_DEFAULT(KERNEL_TYPE_AIV_ONLY);
+    TPipe pipe;
+    RGDR<bfloat16_t, bfloat16_t, DTYPE_STATE> op(&tilingData);
+    RGDRInitParams initParams{query, key, value, g, gk, beta, state, cuSeqlens,
+                              ssmStateIndices, numAcceptedTokens, out, stateOut};
+    op.Init(initParams, &pipe);
+    op.Process();
+}

--- a/dcut/kernel/dcut_recurrent_gated_delta_rule/vendor/op_kernel/recurrent_gated_delta_rule.h
+++ b/dcut/kernel/dcut_recurrent_gated_delta_rule/vendor/op_kernel/recurrent_gated_delta_rule.h
@@ -1,0 +1,644 @@
+/**
+?* Copyright (c) 2025 Huawei Technologies Co., Ltd.
+?* This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+?* Please refer to the License for details. You may not use this file except in compliance with the License.
+?* THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+?* INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+?* See LICENSE in the root of the software repository for the full text of the License.
+?*/
+
+/*!
+ * \file grouped_matmul_finalize_routing.h
+ * \brief
+ */
+
+#ifndef __RECURRENT_GATED_DELTA_RULE_KERNEL_H_
+#define __RECURRENT_GATED_DELTA_RULE_KERNEL_H_
+
+#include "kernel_operator.h"
+#include "lib/matmul_intf.h"
+#include "recurrent_gated_delta_rule_tiling_data.h"
+
+namespace RecurrentGatedDeltaRule {
+
+using namespace matmul;
+using namespace AscendC;
+constexpr uint64_t BUFFER_NUM = 1;
+constexpr uint32_t MAX_OUT_BUFFER_NUM = 2;
+constexpr uint64_t MAX_MTP = 16;
+constexpr uint64_t BF16_NUM_PER_BLOCK = 16;
+constexpr uint64_t FP32_NUM_PER_BLOCK = 8;
+constexpr uint32_t REPEAT_LENTH = 64; // 256Byte for float
+constexpr uint32_t MAX_REPEAT_TIME = 255;
+constexpr uint32_t ADD_FOLD_REDUCE_MIN_K = 128;
+
+#ifndef RGDR_ENABLE_ADD_FOLD_REDUCE
+#define RGDR_ENABLE_ADD_FOLD_REDUCE  1
+#endif
+struct RGDRInitParams {
+    GM_ADDR query;
+    GM_ADDR key;
+    GM_ADDR value;
+    GM_ADDR gama;
+    GM_ADDR gamaK;
+    GM_ADDR beta;
+    GM_ADDR initState;
+    GM_ADDR cuSeqlens;
+    GM_ADDR ssmStateIndices;
+    GM_ADDR numAcceptedTokens;
+    GM_ADDR attnOut;
+    GM_ADDR finalState;
+};
+
+template <typename inType, typename outType, typename stateType>
+class RGDR {
+public:
+    __aicore__ inline RGDR(const RecurrentGatedDeltaRuleTilingData *tilingData)
+    {
+        B_ = tilingData->b;
+        T_ = tilingData->t;
+        NK_ = tilingData->nk;
+        realK_ = tilingData->dk;
+        NV_ = tilingData->nv;
+        realV_ = tilingData->dv;
+        scale_ = tilingData->scale;
+        hasAcceptedTokens_ = (tilingData->hasAcceptedTokens == 1);
+#if defined(DCUT_RECURRENT_FIXED_STATE_ROWS)
+        stateIndexStride_ = tilingData->stateIndexStride;
+#endif
+        hasGama_ = (tilingData->hasGama == 1);
+        hasGamaK_ = (tilingData->hasGamaK == 1);
+        useAddFoldReduce_ = (RGDR_ENABLE_ADD_FOLD_REDUCE != 0);
+        vStep_ = tilingData->vStep;
+        stateOutBufferNum_ = (tilingData->stateOutBufferNum == MAX_OUT_BUFFER_NUM) ? MAX_OUT_BUFFER_NUM : BUFFER_NUM;
+        attnOutBufferNum_ = (tilingData->attnOutBufferNum == MAX_OUT_BUFFER_NUM) ? MAX_OUT_BUFFER_NUM : BUFFER_NUM;
+        restUbSize_ = tilingData->ubRestBytes;
+        alignK_ = Ceil(tilingData->dk, BF16_NUM_PER_BLOCK) * BF16_NUM_PER_BLOCK;
+        alignV_ = Ceil(tilingData->dv, BF16_NUM_PER_BLOCK) * BF16_NUM_PER_BLOCK;
+        load = 0;
+        usedblk = 0;
+    }
+
+    __aicore__ inline void Init(const RGDRInitParams &initParams, TPipe *pipe)
+    {
+        uint64_t blockDim = GetBlockNum();
+        blockIdx = GetBlockIdx();
+        if (blockIdx >= blockDim) {
+            return;
+        }
+        pipe_ = pipe;
+        SetGlobalTensors(initParams);
+        InitLocalBuffers();
+    }
+
+    __aicore__ inline void SetGlobalTensors(const RGDRInitParams &initParams)
+    {
+        queryGm_.SetGlobalBuffer((__gm__ inType *)initParams.query);
+        keyGm_.SetGlobalBuffer((__gm__ inType *)initParams.key);
+        valueGm_.SetGlobalBuffer((__gm__ inType *)initParams.value);
+        gamaGm_.SetGlobalBuffer((__gm__ float *)initParams.gama);
+        gamaKGm_.SetGlobalBuffer((__gm__ float *)initParams.gamaK);
+        betaGm_.SetGlobalBuffer((__gm__ inType *)initParams.beta);
+        initStateGm_.SetGlobalBuffer((__gm__ stateType *)initParams.initState);
+        cuSeqlensGm_.SetGlobalBuffer((__gm__ int32_t *)initParams.cuSeqlens);
+        ssmStateIndicesGm_.SetGlobalBuffer((__gm__ int32_t *)initParams.ssmStateIndices);
+        numAcceptedTokensGm_.SetGlobalBuffer((__gm__ int32_t *)initParams.numAcceptedTokens);
+        finalStateGm_.SetGlobalBuffer((__gm__ stateType *)initParams.finalState);
+        attnOutGm_.SetGlobalBuffer((__gm__ outType *)initParams.attnOut);
+    }
+
+    __aicore__ inline void InitLocalBuffers()
+    {
+        uint32_t cubeSize = alignK_ * vStep_ * sizeof(float);
+        uint32_t singleVSize = vStep_ * sizeof(float);
+        uint32_t vSize = MAX_MTP * alignV_ * sizeof(float);
+        uint32_t kSize = MAX_MTP * alignK_ * sizeof(float);
+        uint32_t betaUbSize =
+            Ceil(MAX_MTP * NV_, BF16_NUM_PER_BLOCK) * BF16_NUM_PER_BLOCK * sizeof(float); //  8: 8 * 4 = 32B;
+        pipe_->InitBuffer(qInQueue_, BUFFER_NUM, MAX_MTP * alignK_ * sizeof(inType));
+        pipe_->InitBuffer(kInQueue_, BUFFER_NUM, MAX_MTP * alignK_ * sizeof(inType));
+        pipe_->InitBuffer(vInQueue_, BUFFER_NUM, MAX_MTP * alignV_ * sizeof(inType));
+        pipe_->InitBuffer(stateInQueue_, BUFFER_NUM, alignK_ * vStep_ * sizeof(stateType));
+        if (hasGama_) {
+            pipe_->InitBuffer(gamaInQueue_, BUFFER_NUM, MAX_MTP * NV_ * sizeof(float));
+        }
+        if (hasGamaK_) {
+            pipe_->InitBuffer(gamaKInQueue_, BUFFER_NUM, MAX_MTP * alignK_ * sizeof(float));
+        }
+        pipe_->InitBuffer(betaInQueue_, BUFFER_NUM, MAX_MTP * NV_ * sizeof(inType));
+        pipe_->InitBuffer(stateOutQueue_, stateOutBufferNum_, alignK_ * vStep_ * sizeof(stateType));
+        pipe_->InitBuffer(attnOutQueue_, attnOutBufferNum_, vStep_ * sizeof(outType));
+        pipe_->InitBuffer(tmpBuff, restUbSize_);
+        uint32_t buffOffset = 0;
+        deltaInUb = tmpBuff.GetWithOffset<float>(static_cast<uint32_t>(vStep_), buffOffset);
+        buffOffset += singleVSize;
+        attnInUb = tmpBuff.GetWithOffset<float>(static_cast<uint32_t>(vStep_), buffOffset);
+        buffOffset += singleVSize;
+        vInUb = tmpBuff.GetWithOffset<float>(static_cast<uint32_t>(MAX_MTP * alignV_), buffOffset);
+        buffOffset += vSize;
+        qInUb = tmpBuff.GetWithOffset<float>(static_cast<uint32_t>(MAX_MTP * alignK_), buffOffset);
+        buffOffset += kSize;
+        kInUb = tmpBuff.GetWithOffset<float>(static_cast<uint32_t>(MAX_MTP * alignK_), buffOffset);
+        buffOffset += kSize;
+        stateInUb = tmpBuff.GetWithOffset<float>(static_cast<uint32_t>(alignK_ * vStep_), buffOffset);
+        buffOffset += cubeSize;
+        broadTmpInUb = tmpBuff.GetWithOffset<float>(static_cast<uint32_t>(alignK_ * vStep_), buffOffset);
+        buffOffset += cubeSize;
+        betaInUb = tmpBuff.GetWithOffset<float>(static_cast<uint32_t>(betaUbSize), buffOffset);
+    }
+
+    __aicore__ inline void ComputeAvgload()
+    {
+        uint64_t realT = 0;
+#if defined(DCUT_RECURRENT_QUERY_START_LOC)
+        const int32_t firstToken = cuSeqlensGm_.GetValue(0);
+        const int32_t lastToken = cuSeqlensGm_.GetValue(B_);
+        if (lastToken > firstToken) {
+            realT = static_cast<uint64_t>(lastToken - firstToken);
+        }
+#else
+        for (uint64_t batch_i = 1; batch_i < B_ + 1; batch_i++) {
+            realT += cuSeqlensGm_.GetValue(batch_i);
+        }
+#endif
+        avgload = Ceil(realT * NV_, GetBlockNum());
+    }
+
+    __aicore__ inline void Process()
+    {
+        ComputeAvgload();
+        int32_t seq0 = cuSeqlensGm_.GetValue(0);
+        for (uint64_t batch_i = 0; batch_i < B_; batch_i++) {
+#if defined(DCUT_RECURRENT_QUERY_START_LOC)
+            const int32_t seq1 = cuSeqlensGm_.GetValue(batch_i + 1);
+            const int32_t seqLen = seq1 - seq0;
+#else
+            const int32_t seqLen = cuSeqlensGm_.GetValue(batch_i + 1);
+            const int32_t seq1 = seq0 + seqLen;
+#endif
+            if (seqLen <= 0) {
+#if defined(DCUT_RECURRENT_QUERY_START_LOC)
+                if (seqLen < 0) {
+                    return;
+                }
+                seq0 = seq1;
+#endif
+                continue;
+            }
+            if (seqLen > static_cast<int32_t>(MAX_MTP)) {
+                return;
+            }
+#if defined(DCUT_RECURRENT_FIXED_STATE_ROWS)
+            if (stateIndexStride_ == 0 || seqLen > static_cast<int32_t>(stateIndexStride_)) {
+                return;
+            }
+#endif
+            if (seq0 < 0 || seq1 < seq0 || seq1 > static_cast<int32_t>(T_)) {
+                return;
+            }
+            uint32_t copyFlag = 0;
+            uint64_t stateOffset;
+            for (uint64_t head_i = 0; head_i < NV_; head_i++) {
+                if (!IsCurrentBlock(seq1 - seq0)) {
+                    continue;
+                }
+                copyFlag++;
+                if (copyFlag == 1) {
+                    int32_t stateTokenIdx = seq0;
+#if defined(DCUT_RECURRENT_FIXED_STATE_ROWS)
+                    stateTokenIdx = static_cast<int32_t>(batch_i * stateIndexStride_);
+                    if (hasAcceptedTokens_) {
+                        const int32_t acceptedTokenNum = numAcceptedTokensGm_.GetValue(batch_i);
+                        if (acceptedTokenNum <= 0 || acceptedTokenNum > static_cast<int32_t>(stateIndexStride_)) {
+                            return;
+                        }
+                        stateTokenIdx += acceptedTokenNum - 1;
+                    }
+#else
+                    if (hasAcceptedTokens_) {
+                        int32_t acceptedTokenNum = numAcceptedTokensGm_.GetValue(batch_i);
+                        if (acceptedTokenNum <= 0 || acceptedTokenNum > seqLen) {
+                            return;
+                        }
+                        stateTokenIdx = seq0 + acceptedTokenNum - 1;
+                    }
+#endif
+#if defined(DCUT_RECURRENT_FIXED_STATE_ROWS)
+                    const int32_t stateOffsetValue = ssmStateIndicesGm_.GetValue(stateTokenIdx);
+                    if (stateOffsetValue < 0) {
+                        return;
+                    }
+                    stateOffset = static_cast<uint64_t>(stateOffsetValue);
+#else
+                    stateOffset = ssmStateIndicesGm_.GetValue(stateTokenIdx);
+#endif
+                    CopyInGamaBeta(seq0, seq1);
+                }
+#if defined(DCUT_RECURRENT_FIXED_STATE_ROWS)
+                ProcessHead(seq0, seq1, head_i, stateOffset, batch_i);
+#else
+                ProcessHead(seq0, seq1, head_i, stateOffset);
+#endif
+            }
+            if (hasGama_ && copyFlag != 0) {
+                gamaInQueue_.FreeTensor(gamaInUb);
+            }
+            seq0 = seq1;
+        }
+    }
+
+private:
+    __aicore__ inline void CopyInQKV(uint64_t vOffset, uint64_t qkOffset, int32_t seqLen)
+    {
+        LocalTensor<inType> qLocal = qInQueue_.AllocTensor<inType>();
+        LocalTensor<inType> kLocal = kInQueue_.AllocTensor<inType>();
+        LocalTensor<inType> vLocal = vInQueue_.AllocTensor<inType>();
+        DataCopyExtParams qkInParams{static_cast<uint16_t>(seqLen), static_cast<uint32_t>(realK_ * sizeof(inType)),
+                                     static_cast<uint32_t>((NK_ - 1) * realK_ * sizeof(inType)), 0, 0};
+        DataCopyExtParams vInParams{static_cast<uint16_t>(seqLen), static_cast<uint32_t>(realV_ * sizeof(inType)),
+                                    static_cast<uint32_t>((NV_ - 1) * realV_ * sizeof(inType)), 0, 0};
+        DataCopyPadExtParams<inType> qkPadParams{true, 0, static_cast<uint8_t>(alignK_ - realK_), 0};
+        DataCopyPadExtParams<inType> vPadParams{true, 0, static_cast<uint8_t>(alignV_ - realV_), 0};
+        if (hasGamaK_) {
+            uint32_t alignKGamma = Ceil(realK_, FP32_NUM_PER_BLOCK) * FP32_NUM_PER_BLOCK;
+            uint32_t stride = alignKGamma < alignK_ ? 1 : 0;
+            DataCopyExtParams gkInParams{static_cast<uint16_t>(seqLen), static_cast<uint32_t>(realK_ * sizeof(float)),
+                                     static_cast<uint32_t>((NV_ - 1) * realK_ * sizeof(float)), stride, 0};
+            DataCopyPadExtParams<float> gkPadParams{true, 0, static_cast<uint8_t>(alignKGamma - realK_), 0};
+            LocalTensor<float> gamaKLocal = gamaKInQueue_.AllocTensor<float>();
+            Duplicate<float>(gamaKLocal, 0, alignK_ * seqLen);
+            TEventID evevtIdVtoMte2 = GetTPipePtr()->FetchEventID(HardEvent::V_MTE2);
+            SetFlag<HardEvent::V_MTE2>(evevtIdVtoMte2);
+            WaitFlag<HardEvent::V_MTE2>(evevtIdVtoMte2);
+            DataCopyPad(gamaKLocal, gamaKGm_[vOffset / realV_ * realK_], gkInParams, gkPadParams);
+            gamaKInQueue_.EnQue<float>(gamaKLocal);
+            gamaKInUb = gamaKInQueue_.DeQue<float>();
+            Exp(gamaKInUb, gamaKInUb, alignK_ * seqLen);
+            AscendC::PipeBarrier<PIPE_V>();
+        }
+        DataCopyPad(qLocal, queryGm_[qkOffset], qkInParams, qkPadParams);
+        DataCopyPad(kLocal, keyGm_[qkOffset], qkInParams, qkPadParams);
+        DataCopyPad(vLocal, valueGm_[vOffset], vInParams, vPadParams);
+        qInQueue_.EnQue<inType>(qLocal);
+        kInQueue_.EnQue<inType>(kLocal);
+        vInQueue_.EnQue<inType>(vLocal);
+        qLocal = qInQueue_.DeQue<inType>();
+        kLocal = kInQueue_.DeQue<inType>();
+        vLocal = vInQueue_.DeQue<inType>();
+        Cast(qInUb, qLocal, AscendC::RoundMode::CAST_NONE, alignK_ * seqLen);
+        Cast(kInUb, kLocal, AscendC::RoundMode::CAST_NONE, alignK_ * seqLen);
+        Cast(vInUb, vLocal, AscendC::RoundMode::CAST_NONE, alignV_ * seqLen);
+        AscendC::PipeBarrier<PIPE_V>();
+        Muls(qInUb, qInUb, scale_, seqLen * alignK_);
+        qInQueue_.FreeTensor(qLocal);
+        kInQueue_.FreeTensor(kLocal);
+        vInQueue_.FreeTensor(vLocal);
+    }
+
+    __aicore__ inline void PrefetchState(uint64_t stateOffest, uint32_t curSingleV)
+    {
+        LocalTensor<stateType> stateLocal = stateInQueue_.AllocTensor<stateType>();
+        DataCopyExtParams stateInParams{static_cast<uint16_t>(curSingleV),
+                                        static_cast<uint16_t>(realK_ * sizeof(stateType)), 0, 0, 0};
+        DataCopyPadExtParams<stateType> padParams{true, 0, static_cast<uint8_t>(alignK_ - realK_), 0};
+        DataCopyPad(stateLocal, initStateGm_[stateOffest], stateInParams, padParams);
+        stateInQueue_.EnQue<stateType>(stateLocal);
+    }
+
+    __aicore__ inline void LoadPrefetchedState(uint32_t curSingleV)
+    {
+        LocalTensor<stateType> stateLocal = stateInQueue_.DeQue<stateType>();
+        if constexpr (std::is_same<stateType, float32_t>()) {
+            DataCopy(stateInUb, stateLocal, alignK_ * curSingleV);
+        } else {
+            Cast(stateInUb, stateLocal, AscendC::RoundMode::CAST_NONE, alignK_ * curSingleV);
+        }
+        stateInQueue_.FreeTensor(stateLocal);
+    }
+
+    __aicore__ inline void MatVecMul(const LocalTensor<float> &cubeTensor, const LocalTensor<float> &vecTensor,
+                                          LocalTensor<float> &dstTensor, uint32_t cols, bool isAdd)
+    {
+        uint8_t repeatStride = alignK_ / FP32_NUM_PER_BLOCK;
+        for (uint32_t i = 0; i < alignK_; i += REPEAT_LENTH) {
+            uint64_t mask = Std::min(REPEAT_LENTH, alignK_ - i);
+            for (uint32_t j = 0; j < cols; j += MAX_REPEAT_TIME) {
+                uint64_t repeatTime = Std::min(MAX_REPEAT_TIME, cols - j);
+                if (isAdd) {
+                    MulAddDst(dstTensor[j * alignK_ + i], cubeTensor[j * alignK_ + i], vecTensor[i], mask, repeatTime,
+                              {1, 1, 1, repeatStride, repeatStride, 0});
+                } else {
+                    Mul(dstTensor[j * alignK_ + i], cubeTensor[j * alignK_ + i], vecTensor[i], mask, repeatTime,
+                        {1, 1, 1, repeatStride, repeatStride, 0});
+                }
+            }
+        }
+    }
+
+    __aicore__ inline void ReduceSumBaseline(LocalTensor<float> &dstTensor, const LocalTensor<float> &srcTensor,
+                                             uint32_t rows)
+    {
+        uint32_t stateShape[2] = {rows, alignK_};
+        ReduceSum<float, Pattern::Reduce::AR, true>(dstTensor, srcTensor, stateShape, true);
+    }
+
+    __aicore__ inline bool CanUseK128AddFoldFastPath(uint32_t rows) const
+    {
+        if (alignK_ != ADD_FOLD_REDUCE_MIN_K) {
+            return false;
+        }
+        if (rows == 0 || rows > MAX_REPEAT_TIME) {
+            return false;
+        }
+        return true;
+    }
+
+    __aicore__ inline void ReduceSumAddFoldK128(LocalTensor<float> &dstTensor, LocalTensor<float> &srcTensor,
+                                                uint32_t rows)
+    {
+        const uint8_t repeatTime = static_cast<uint8_t>(rows);
+        const uint8_t rowRepStride = static_cast<uint8_t>(alignK_ / FP32_NUM_PER_BLOCK);
+
+        // Write the folded result to the upper half to avoid the multi-repeat src0/dst overlap case.
+        Add(srcTensor[REPEAT_LENTH], srcTensor, srcTensor[REPEAT_LENTH], REPEAT_LENTH, repeatTime,
+            {1, 1, 1, rowRepStride, rowRepStride, rowRepStride});
+        AscendC::PipeBarrier<PIPE_V>();
+        WholeReduceSum(dstTensor, srcTensor[REPEAT_LENTH], REPEAT_LENTH, repeatTime, 1, 1, rowRepStride);
+    }
+
+    __aicore__ inline void ReduceSumAddFold(LocalTensor<float> &dstTensor, LocalTensor<float> &srcTensor,
+                                            uint32_t rows)
+    {
+        if (alignK_ < REPEAT_LENTH) {
+            ReduceSumBaseline(dstTensor, srcTensor, rows);
+            return;
+        }
+
+        if ((alignK_ & (alignK_ - 1)) != 0) {
+            ReduceSumBaseline(dstTensor, srcTensor, rows);
+            return;
+        }
+
+        if (CanUseK128AddFoldFastPath(rows)) {
+            ReduceSumAddFoldK128(dstTensor, srcTensor, rows);
+            return;
+        }
+
+        for (uint32_t row = 0; row < rows; ++row) {
+            uint32_t rowOffset = row * alignK_;
+            uint32_t activeLen = alignK_;
+            while (activeLen > REPEAT_LENTH) {
+                uint32_t half = activeLen >> 1;
+                Add(srcTensor[rowOffset], srcTensor[rowOffset], srcTensor[rowOffset + half], half);
+                AscendC::PipeBarrier<PIPE_V>();
+                activeLen = half;
+            }
+
+            WholeReduceSum(dstTensor[row], srcTensor[rowOffset], REPEAT_LENTH, 1, 1, 1, FP32_NUM_PER_BLOCK);
+        }
+    }
+
+    __aicore__ inline void ReduceSumDispatch(LocalTensor<float> &dstTensor, LocalTensor<float> &srcTensor,
+                                             uint32_t rows)
+    {
+        if (useAddFoldReduce_ && alignK_ >= ADD_FOLD_REDUCE_MIN_K) {
+            ReduceSumAddFold(dstTensor, srcTensor, rows);
+            return;
+        }
+        ReduceSumBaseline(dstTensor, srcTensor, rows);
+    }
+
+    __aicore__ inline void Compute(uint32_t curSingleV, uint64_t curQKOffset, uint64_t curVOffset)
+    {
+        uint32_t stateShape[2] = {curSingleV, alignK_};
+        uint32_t ktShape[2] = {1, alignK_};
+        uint32_t deltaShape[2] = {curSingleV, 1};
+        if (hasGama_) {
+            Muls(stateInUb, stateInUb, gama_, alignK_ * curSingleV);
+        }
+        if (hasGamaK_) {
+            MatVecMul(stateInUb, gamaKInUb[curQKOffset], stateInUb, curSingleV, false);
+        }
+        if (hasGama_ || hasGamaK_) {
+            AscendC::PipeBarrier<PIPE_V>();
+        }
+        MatVecMul(stateInUb, kInUb[curQKOffset], broadTmpInUb, curSingleV, false);
+        AscendC::PipeBarrier<PIPE_V>();
+        ReduceSumDispatch(deltaInUb, broadTmpInUb, curSingleV);
+        AscendC::PipeBarrier<PIPE_V>();
+        deltaInUb = vInUb[curVOffset] - deltaInUb;
+        AscendC::PipeBarrier<PIPE_V>();
+        Muls(deltaInUb, deltaInUb, beta_, curSingleV);
+        AscendC::PipeBarrier<PIPE_V>();
+        Broadcast<float, 2, 1>(broadTmpInUb, deltaInUb, stateShape, deltaShape); //  2: Dim Number 1: Second Dim
+        AscendC::PipeBarrier<PIPE_V>();
+        MatVecMul(broadTmpInUb, kInUb[curQKOffset], stateInUb, curSingleV, true);
+        AscendC::PipeBarrier<PIPE_V>();
+        MatVecMul(stateInUb, qInUb[curQKOffset], broadTmpInUb, curSingleV, false);
+        AscendC::PipeBarrier<PIPE_V>();
+        ReduceSumDispatch(attnInUb, broadTmpInUb, curSingleV);
+        LocalTensor<stateType> stateOutLocal = stateOutQueue_.AllocTensor<stateType>();
+        LocalTensor<outType> attnOutLocal = attnOutQueue_.AllocTensor<outType>();
+        if constexpr (std::is_same<stateType, float32_t>()) {
+            DataCopy(stateOutLocal, stateInUb, alignK_ * curSingleV);
+        } else {
+            Cast(stateOutLocal, stateInUb, AscendC::RoundMode::CAST_RINT, alignK_ * curSingleV);
+        }
+        stateOutQueue_.EnQue<stateType>(stateOutLocal);
+        Cast(attnOutLocal, attnInUb, AscendC::RoundMode::CAST_RINT, curSingleV);
+        attnOutQueue_.EnQue<outType>(attnOutLocal);
+    }
+
+    __aicore__ inline void CopyOutAttn(uint64_t attnOffset, uint32_t curSingleV)
+    {
+        LocalTensor<outType> attnLocal = attnOutQueue_.DeQue<outType>();
+        DataCopyParams attnOutParams{1, static_cast<uint16_t>(curSingleV * sizeof(outType)), 0, 0};
+        DataCopyPad(attnOutGm_[attnOffset], attnLocal, attnOutParams);
+        attnOutQueue_.FreeTensor(attnLocal);
+    }
+
+    __aicore__ inline void CopyOutState(uint64_t stateOffset, uint32_t curSingleV)
+    {
+        LocalTensor<stateType> stateOutLocal = stateOutQueue_.DeQue<stateType>();
+        DataCopyParams stateOutParams{static_cast<uint16_t>(curSingleV),
+                                      static_cast<uint16_t>(realK_ * sizeof(stateType)), 0, 0};
+        DataCopyPad(finalStateGm_[stateOffset], stateOutLocal, stateOutParams);
+        stateOutQueue_.FreeTensor(stateOutLocal);
+    }
+
+    __aicore__ inline void CopyInGamaBeta(int32_t seq0, int32_t seq1)
+    {
+        int32_t seqLen = seq1 - seq0;
+        uint64_t bBatchSize = Ceil(seqLen * NV_, BF16_NUM_PER_BLOCK) * BF16_NUM_PER_BLOCK;
+        LocalTensor<inType> betaLocal = betaInQueue_.AllocTensor<inType>();
+        DataCopyParams betaInParams{1, static_cast<uint16_t>(seqLen * NV_ * sizeof(inType)), 0, 0};
+        DataCopyPadParams padParams;
+        DataCopyPad(betaLocal, betaGm_[seq0 * NV_], betaInParams, padParams);
+        betaInQueue_.EnQue<inType>(betaLocal);
+        betaLocal = betaInQueue_.DeQue<inType>();
+        Cast(betaInUb, betaLocal, AscendC::RoundMode::CAST_NONE, bBatchSize);
+        betaInQueue_.FreeTensor(betaLocal);
+        if (hasGama_) {
+            LocalTensor<float> gamaLocal = gamaInQueue_.AllocTensor<float>();
+            DataCopyParams gamaInParams{1, static_cast<uint16_t>(seqLen * NV_ * sizeof(float)), 0, 0};
+            DataCopyPad(gamaLocal, gamaGm_[seq0 * NV_], gamaInParams, padParams);
+            gamaInQueue_.EnQue<float>(gamaLocal);
+            gamaInUb = gamaInQueue_.DeQue<float>();
+            Exp(gamaInUb, gamaInUb, seqLen * NV_);
+            AscendC::PipeBarrier<PIPE_V>();
+        }
+    }
+
+#if defined(DCUT_RECURRENT_FIXED_STATE_ROWS)
+    __aicore__ inline void ProcessHead(int32_t seq0, int32_t seq1, uint64_t head_i, uint64_t stateOffset,
+                                        uint64_t batch_i)
+#else
+    __aicore__ inline void ProcessHead(int32_t seq0, int32_t seq1, uint64_t head_i, uint64_t stateOffset)
+#endif
+    {
+        uint64_t vOffset = (seq0 * NV_ + head_i) * realV_;
+        uint64_t qkOffset = (seq0 * NK_ + head_i / (NV_ / NK_)) * realK_;
+        CopyInQKV(vOffset, qkOffset, seq1 - seq0);
+        if (realV_ == 0) {
+            if (hasGamaK_) {
+                gamaKInQueue_.FreeTensor(gamaKInUb);
+            }
+            return;
+        }
+        uint64_t nextVOffset = 0;
+        uint32_t nextSingleV = realV_ > vStep_ ? vStep_ : realV_;
+        uint64_t nextStateOffset = ((stateOffset * NV_ + head_i) * realV_) * realK_;
+        PrefetchState(nextStateOffset, nextSingleV);
+        for (uint64_t v_i = 0; v_i < realV_; v_i += vStep_) {
+            uint32_t curSingleV = v_i + vStep_ > realV_ ? realV_ - v_i : vStep_;
+            LoadPrefetchedState(curSingleV);
+            nextVOffset = v_i + vStep_;
+            if (nextVOffset < realV_) {
+                nextSingleV = nextVOffset + vStep_ > realV_ ? realV_ - nextVOffset : vStep_;
+                nextStateOffset = ((stateOffset * NV_ + head_i) * realV_ + nextVOffset) * realK_;
+                PrefetchState(nextStateOffset, nextSingleV);
+            }
+            uint64_t pendingAttnOffset = 0;
+            uint64_t pendingStateOffset = 0;
+            bool hasPendingAttn = false;
+            bool hasPendingState = false;
+            for (uint64_t seq_i = seq0; seq_i < seq1; seq_i++) {
+                uint64_t gbOffset = head_i + (seq_i - seq0) * NV_;
+                uint64_t curQKOffset = (seq_i - seq0) * alignK_;
+                uint64_t curVOffset = (seq_i - seq0) * alignV_ + v_i;
+                uint64_t attnOffset = (seq_i * NV_ + head_i) * realV_ + v_i;
+#if defined(DCUT_RECURRENT_FIXED_STATE_ROWS)
+                const uint64_t stateTokenIdx = batch_i * stateIndexStride_ + (seq_i - seq0);
+#else
+                const uint64_t stateTokenIdx = seq_i;
+#endif
+                uint64_t curStateOutOffset =
+                    ((ssmStateIndicesGm_.GetValue(stateTokenIdx) * NV_ + head_i) * realV_ + v_i) * realK_;
+                gama_ = hasGama_ ? gamaInUb.GetValue(gbOffset) : 1;
+                beta_ = betaInUb.GetValue(gbOffset);
+                Compute(curSingleV, curQKOffset, curVOffset);
+                if (attnOutBufferNum_ == BUFFER_NUM) {
+                    CopyOutAttn(attnOffset, curSingleV);
+                } else {
+                    if (hasPendingAttn) {
+                        CopyOutAttn(pendingAttnOffset, curSingleV);
+                    }
+                    pendingAttnOffset = attnOffset;
+                    hasPendingAttn = true;
+                }
+                if (stateOutBufferNum_ == BUFFER_NUM) {
+                    CopyOutState(curStateOutOffset, curSingleV);
+                } else {
+                    if (hasPendingState) {
+                        CopyOutState(pendingStateOffset, curSingleV);
+                    }
+                    pendingStateOffset = curStateOutOffset;
+                    hasPendingState = true;
+                }
+            }
+            if (hasPendingAttn) {
+                CopyOutAttn(pendingAttnOffset, curSingleV);
+            }
+            if (hasPendingState) {
+                CopyOutState(pendingStateOffset, curSingleV);
+            }
+        }
+        if (hasGamaK_) {
+            gamaKInQueue_.FreeTensor(gamaKInUb);
+        }
+    }
+
+    __aicore__ inline bool IsCurrentBlock(int32_t seqlen)
+    {
+        load += seqlen;
+        bool ret = (blockIdx == usedblk && seqlen > 0);
+        if (load >= avgload) {
+            load = 0;
+            usedblk++;
+        }
+        return ret;
+    }
+
+private:
+    GlobalTensor<inType> queryGm_;
+    GlobalTensor<inType> keyGm_;
+    GlobalTensor<inType> valueGm_;
+    GlobalTensor<inType> betaGm_;
+    GlobalTensor<float> gamaGm_;
+    GlobalTensor<float> gamaKGm_;
+    GlobalTensor<stateType> initStateGm_;
+    GlobalTensor<int32_t> cuSeqlensGm_;
+    GlobalTensor<int32_t> ssmStateIndicesGm_;
+    GlobalTensor<int32_t> numAcceptedTokensGm_;
+    GlobalTensor<stateType> finalStateGm_;
+    GlobalTensor<outType> attnOutGm_;
+    TPipe *pipe_;
+    TQue<QuePosition::VECIN, 1> qInQueue_;
+    TQue<QuePosition::VECIN, 1> kInQueue_;
+    TQue<QuePosition::VECIN, 1> vInQueue_;
+    TQue<QuePosition::VECIN, 1> gamaInQueue_;
+    TQue<QuePosition::VECIN, 1> gamaKInQueue_;
+    TQue<QuePosition::VECIN, 1> betaInQueue_;
+    TQue<QuePosition::VECIN, 1> stateInQueue_;
+    TQue<QuePosition::VECOUT, MAX_OUT_BUFFER_NUM> attnOutQueue_;
+    TQue<QuePosition::VECOUT, MAX_OUT_BUFFER_NUM> stateOutQueue_;
+    TBuf<TPosition::VECCALC> tmpBuff;
+    LocalTensor<float> qInUb;
+    LocalTensor<float> kInUb;
+    LocalTensor<float> vInUb;
+    LocalTensor<float> gamaInUb;
+    LocalTensor<float> gamaKInUb;
+    LocalTensor<float> betaInUb;
+    LocalTensor<float> deltaInUb;
+    LocalTensor<float> broadTmpInUb;
+    LocalTensor<float> attnInUb;
+    LocalTensor<float> stateInUb;
+    uint32_t B_;
+    uint32_t T_;
+    uint32_t NK_;
+    uint32_t alignK_;
+    uint32_t realK_;
+    uint32_t NV_;
+    uint32_t alignV_;
+    uint32_t realV_;
+    uint32_t vStep_;
+    uint32_t stateOutBufferNum_;
+    uint32_t attnOutBufferNum_;
+    uint32_t restUbSize_;
+#if defined(DCUT_RECURRENT_FIXED_STATE_ROWS)
+    uint32_t stateIndexStride_;
+#endif
+    uint32_t load;
+    uint32_t usedblk;
+    uint32_t avgload;
+    bool hasAcceptedTokens_;
+    bool hasGama_;
+    bool hasGamaK_;
+    bool useAddFoldReduce_;
+    float gama_;
+    float beta_;
+    float scale_;
+    uint64_t blockIdx;
+};
+} // namespace RecurrentGatedDeltaRule
+#endif

--- a/dcut/kernel/dcut_recurrent_gated_delta_rule/vendor/op_kernel/recurrent_gated_delta_rule_tiling_data.h
+++ b/dcut/kernel/dcut_recurrent_gated_delta_rule/vendor/op_kernel/recurrent_gated_delta_rule_tiling_data.h
@@ -1,0 +1,47 @@
+/**
+ * Copyright (c) 2025 Huawei Technologies Co., Ltd.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ */
+
+/*!
+ * \file recurrent_gated_delta_rule.cpp
+ * \brief
+ */
+#ifndef RECURRENT_GATED_DELTA_RULE_TILING_DATA_H
+#define RECURRENT_GATED_DELTA_RULE_TILING_DATA_H
+
+#include "kernel_tiling/kernel_tiling.h"
+
+namespace RecurrentGatedDeltaRule {
+#pragma pack(push, 8)
+struct alignas(8) RecurrentGatedDeltaRuleTilingData { // alignas(8)确保8字节对齐
+    uint32_t vectorCoreNum;
+    uint32_t ubCalSize;
+    uint32_t ubRestBytes;
+    uint32_t t;
+    uint32_t nk;
+    uint32_t dk;
+    uint32_t nv;
+    uint32_t dv;
+    uint32_t sBlockNum;
+    uint32_t b;
+    uint32_t vStep;
+    uint32_t stateOutBufferNum;
+    uint32_t attnOutBufferNum;
+    float scale;
+    uint32_t hasGama;
+    uint32_t hasGamaK;
+    uint32_t hasAcceptedTokens;
+#if defined(DCUT_RECURRENT_FIXED_STATE_ROWS)
+    // Width of one request row in ssm_state_indices[B, stateIndexStride].
+    uint32_t stateIndexStride;
+#endif
+};
+#pragma pack(pop)
+} // RecurrentGatedDeltaRule
+
+#endif // RECURRENT_GATED_DELTA_RULE_TILING_DATA_H

--- a/dcut/kernel/torch_extension/CMakeLists.txt
+++ b/dcut/kernel/torch_extension/CMakeLists.txt
@@ -1,0 +1,68 @@
+cmake_minimum_required(VERSION 3.16)
+project(dcut_torch_ops LANGUAGES CXX)
+
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+if(NOT DEFINED REPO_ROOT)
+    get_filename_component(REPO_ROOT "${CMAKE_CURRENT_SOURCE_DIR}/../../.." ABSOLUTE)
+endif()
+
+find_package(Python3 REQUIRED COMPONENTS Interpreter)
+execute_process(
+    COMMAND "${Python3_EXECUTABLE}" -c "import torch; print(torch.utils.cmake_prefix_path)"
+    OUTPUT_VARIABLE TORCH_CMAKE_PREFIX
+    OUTPUT_STRIP_TRAILING_WHITESPACE
+    COMMAND_ERROR_IS_FATAL ANY
+)
+list(APPEND CMAKE_PREFIX_PATH "${TORCH_CMAKE_PREFIX}")
+find_package(Torch REQUIRED)
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${TORCH_CXX_FLAGS}")
+
+if(NOT DEFINED TORCH_NPU_PATH)
+    execute_process(
+        COMMAND "${Python3_EXECUTABLE}" -c "import pathlib, torch_npu; print(pathlib.Path(torch_npu.__file__).resolve().parent)"
+        OUTPUT_VARIABLE TORCH_NPU_PATH
+        OUTPUT_STRIP_TRAILING_WHITESPACE
+        COMMAND_ERROR_IS_FATAL ANY
+    )
+endif()
+
+if(NOT DEFINED ASCEND_HOME_PATH)
+    if(DEFINED ENV{ASCEND_HOME_PATH})
+        set(ASCEND_HOME_PATH "$ENV{ASCEND_HOME_PATH}")
+    elseif(DEFINED ENV{ASCEND_TOOLKIT_HOME})
+        set(ASCEND_HOME_PATH "$ENV{ASCEND_TOOLKIT_HOME}")
+    else()
+        set(ASCEND_HOME_PATH "/usr/local/Ascend/ascend-toolkit/latest")
+    endif()
+endif()
+
+add_library(dcut_torch_ops SHARED
+    dcut_torch_binding.cpp
+    /vllm-workspace/vllm-ascend/csrc/aclnn_torch_adapter/NPUBridge.cpp
+    /vllm-workspace/vllm-ascend/csrc/aclnn_torch_adapter/NPUStorageImpl.cpp
+)
+set_target_properties(dcut_torch_ops PROPERTIES PREFIX "" OUTPUT_NAME "dcut_torch_ops")
+target_include_directories(dcut_torch_ops PRIVATE
+    ${TORCH_INCLUDE_DIRS}
+    "${TORCH_NPU_PATH}/include"
+    "${ASCEND_HOME_PATH}/include"
+    "/vllm-workspace/vllm-ascend/csrc"
+)
+target_link_directories(dcut_torch_ops PRIVATE
+    ${TORCH_LIBRARY_DIRS}
+    "${TORCH_NPU_PATH}/lib"
+    "${ASCEND_HOME_PATH}/lib64"
+)
+target_link_libraries(dcut_torch_ops PRIVATE
+    ${TORCH_LIBRARIES}
+    torch_npu
+    ascendcl
+    tiling_api
+    register
+    platform
+    ascendalog
+    dl
+    opapi
+)

--- a/dcut/kernel/torch_extension/dcut_torch_binding.cpp
+++ b/dcut/kernel/torch_extension/dcut_torch_binding.cpp
@@ -1,0 +1,80 @@
+#include <ATen/ATen.h>
+#include <torch/library.h>
+
+#include "aclnn_torch_adapter/op_api_common.h"
+#include "../dcut_causal_conv1d/dcut_causal_conv1d_torch_adpt.h"
+#include "../dcut_recurrent_gated_delta_rule/dcut_recurrent_gated_delta_rule_torch_adpt.h"
+
+namespace vllm_ascend::dcut_meta {
+
+at::Tensor npu_dcut_causal_conv1d_meta(
+    const at::Tensor& output,
+    const at::Tensor& x,
+    const at::Tensor& weight,
+    const at::Tensor& conv_state,
+    const c10::optional<at::Tensor>& bias,
+    const c10::optional<at::Tensor>& query_start_loc,
+    const c10::optional<at::Tensor>& cache_indices,
+    const c10::optional<at::Tensor>& num_accepted_tokens,
+    int64_t activation_mode,
+    int64_t pad_slot_id) {
+  return output;
+}
+
+at::Tensor npu_dcut_recurrent_gated_delta_rule_meta(
+    const at::Tensor& query,
+    const at::Tensor& key,
+    const at::Tensor& value,
+    at::Tensor& state,
+    const c10::optional<at::Tensor>& beta,
+    const c10::optional<double> scale,
+    const c10::optional<at::Tensor>& query_start_loc,
+    const c10::optional<at::Tensor>& ssm_state_indices,
+    const c10::optional<at::Tensor>& num_accepted_tokens,
+    const c10::optional<at::Tensor>& g,
+    const c10::optional<at::Tensor>& gk,
+    bool zero_padded_output) {
+  auto options = value.options().dtype(at::ScalarType::BFloat16);
+  return at::empty_symint(value.sym_sizes(), options);
+}
+
+}  // namespace vllm_ascend::dcut_meta
+
+TORCH_LIBRARY_FRAGMENT(_C_ascend, ops) {
+  ops.def(
+      "npu_dcut_recurrent_gated_delta_rule(Tensor query, "
+      "                                    Tensor key, "
+      "                                    Tensor value, "
+      "                                    Tensor(a!) state, "
+      "                                    *, "
+      "                                    Tensor? beta=None, "
+      "                                    float? scale=None, "
+      "                                    Tensor? query_start_loc=None, "
+      "                                    Tensor? ssm_state_indices=None, "
+      "                                    Tensor? num_accepted_tokens=None, "
+      "                                    Tensor? g=None, "
+      "                                    Tensor? gk=None, "
+      "                                    bool zero_padded_output=False) -> Tensor");
+  ops.def(
+      "npu_dcut_causal_conv1d(Tensor(a!) output, Tensor x, "
+      "                         Tensor weight, Tensor(b!) conv_state, "
+      "                         Tensor? bias=None, "
+      "                         Tensor? query_start_loc=None, "
+      "                         Tensor? cache_indices=None, "
+      "                         Tensor? num_accepted_tokens=None, "
+      "                         int activation_mode=0, "
+      "                         int pad_slot_id=-1) -> Tensor(a!)");
+}
+
+TORCH_LIBRARY_IMPL(_C_ascend, PrivateUse1, ops) {
+  ops.impl("npu_dcut_recurrent_gated_delta_rule",
+           &vllm_ascend::npu_dcut_recurrent_gated_delta_rule);
+  ops.impl("npu_dcut_causal_conv1d", &vllm_ascend::npu_dcut_causal_conv1d);
+}
+
+TORCH_LIBRARY_IMPL(_C_ascend, Meta, ops) {
+  ops.impl("npu_dcut_recurrent_gated_delta_rule",
+           &vllm_ascend::dcut_meta::npu_dcut_recurrent_gated_delta_rule_meta);
+  ops.impl("npu_dcut_causal_conv1d",
+           &vllm_ascend::dcut_meta::npu_dcut_causal_conv1d_meta);
+}

--- a/dcut/patch_attention.py
+++ b/dcut/patch_attention.py
@@ -1,0 +1,71 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Patch FIA to skip capturing branch in PIECEWISE mode."""
+from __future__ import annotations
+
+import torch
+
+from vllm.config import CUDAGraphMode
+
+from .globals import logger
+
+
+def _patch_attention() -> bool:
+    """Patch full-attention (FIA) to skip the capturing branch in PIECEWISE mode.
+
+    In PIECEWISE mode, full-attention ops are splitting ops — they run eagerly
+    between graph pieces.  But ``_EXTRA_CTX.capturing`` is True during the
+    entire capture process, so ``forward_fused_infer_attention`` enters its
+    capturing branch and calls ``full_graph_fia`` → ``graph_task_group_begin``,
+    which fails because the stream is not in capture status.
+
+    Fix: temporarily set ``capturing=False`` for the duration of the full-
+    attention forward pass when in PIECEWISE mode, so it uses the eager code
+    path (correct for splitting ops).
+    """
+    try:
+        from vllm_ascend.attention.attention_v1 import AscendAttentionBackendImpl
+        from vllm_ascend.ascend_forward_context import (
+            _EXTRA_CTX,
+            get_forward_context,
+        )
+    except Exception as e:
+        logger.warning("D-Cut: cannot import AscendAttentionBackendImpl: %s", e)
+        return False
+
+    patch_marker = "_dcut_piecewise_fia_patched"
+    if getattr(AscendAttentionBackendImpl, patch_marker, False):
+        return True
+
+    _orig_ffia = AscendAttentionBackendImpl.forward_fused_infer_attention
+
+    def _forward_fused_infer_attention(
+        self, query, key, value, attn_metadata, output, kv_cache=None
+    ):
+        if _EXTRA_CTX.capturing or torch.compiler.is_compiling():
+            ctx = get_forward_context()
+            mode = getattr(ctx, "cudagraph_runtime_mode", None)
+            if mode == CUDAGraphMode.PIECEWISE:
+                # Full attention is a splitting op in PIECEWISE mode.
+                # Temporarily disable capturing so the original method
+                # uses the eager code path instead of full_graph_fia.
+                orig_capturing = ctx.capturing
+                ctx.capturing = False
+                try:
+                    return _orig_ffia(
+                        self, query, key, value, attn_metadata, output, kv_cache
+                    )
+                finally:
+                    ctx.capturing = orig_capturing
+        return _orig_ffia(
+            self, query, key, value, attn_metadata, output, kv_cache
+        )
+
+    AscendAttentionBackendImpl.forward_fused_infer_attention = (
+        _forward_fused_infer_attention
+    )
+    setattr(AscendAttentionBackendImpl, patch_marker, True)
+    logger.warning(
+        "D-Cut: patched forward_fused_infer_attention to skip capturing "
+        "branch in PIECEWISE mode (full attention is a splitting op)."
+    )
+    return True

--- a/dcut/patch_full_graph.py
+++ b/dcut/patch_full_graph.py
@@ -1,0 +1,475 @@
+# SPDX-License-Identifier: Apache-2.0
+"""FULL_DECODE_ONLY multi-shape support for D-Cut.
+
+D-Cut turns the verifier batch from a uniform ``num_spec + 1`` rectangle into
+a ragged decode batch.  Stock vLLM only registers uniform FULL keys for
+``FULL_DECODE_ONLY``, so every useful trimmed step otherwise falls back to
+eager execution.
+
+This module keeps the stock uniform keys (used by untrimmed verification and
+the draft model), adds non-uniform FULL keys for the same token buckets, and
+isolates Ascend full-attention graph parameters by ``BatchDescriptor``.  The
+latter is required because uniform and ragged graphs can have the same padded
+token count but capture different task-group handles and tensor addresses.
+"""
+
+from __future__ import annotations
+
+import os
+from collections.abc import Iterator, MutableMapping
+from dataclasses import replace
+from typing import Any
+
+import torch
+
+from .globals import ENV_CONFIG, ENV_FULL_DECODE_ONLY, logger
+from .truncate import _dcut_has_prefill
+from .utils import _supports_adaptive_verify
+
+
+def _dcut_full_decode_multishape_enabled(vllm_config=None) -> bool:
+    """Return whether D-Cut should extend FULL_DECODE_ONLY graph dispatch."""
+    if not os.environ.get(ENV_CONFIG) or os.environ.get(ENV_FULL_DECODE_ONLY):
+        return False
+    if vllm_config is None:
+        return True
+    return _supports_adaptive_verify(
+        getattr(vllm_config, "speculative_config", None)
+    )
+
+
+def _dcut_ragged_full_request_capacity(
+    num_tokens: int,
+    max_num_seqs: int,
+) -> int:
+    """Return the fixed request capacity for one ragged token bucket.
+
+    A verifier request always contributes at least its anchor token, so a
+    ``num_tokens`` graph can never contain more than ``num_tokens`` requests.
+    Keeping this capacity a pure function of the token bucket lets all live
+    batch sizes reuse one FULL graph without introducing a second graph axis.
+    """
+    num_tokens = int(num_tokens)
+    max_num_seqs = int(max_num_seqs)
+    if num_tokens <= 0 or max_num_seqs <= 0:
+        raise ValueError(
+            "D-Cut ragged FULL capacity requires positive token and request "
+            f"limits, got num_tokens={num_tokens}, max_num_seqs={max_num_seqs}"
+        )
+    return min(num_tokens, max_num_seqs)
+
+
+class _DescriptorGraphParamMap(MutableMapping[int, Any]):
+    """Map graph parameters by ``(num_tokens, BatchDescriptor)``.
+
+    Ascend's graph-parameter APIs index these mappings with an integer token
+    count.  Resolve the active descriptor from ForwardContext so existing
+    attention implementations need no changes.  Iteration intentionally still
+    exposes integer capture sizes for ``weak_ref_workspaces`` compatibility.
+    """
+
+    def __init__(self, initial: dict[int, Any], *, list_values: bool) -> None:
+        self._sizes = tuple(initial)
+        self._list_values = list_values
+        self._values: dict[tuple[int, Any], Any] = {}
+
+    @staticmethod
+    def _descriptor():
+        try:
+            from vllm.forward_context import get_forward_context
+
+            context = get_forward_context()
+            return getattr(context, "batch_descriptor", None)
+        except Exception:
+            return None
+
+    def _key(self, num_tokens: int) -> tuple[int, Any]:
+        return int(num_tokens), self._descriptor()
+
+    def __getitem__(self, num_tokens: int) -> Any:
+        key = self._key(num_tokens)
+        if key not in self._values:
+            self._values[key] = [] if self._list_values else None
+        return self._values[key]
+
+    def __setitem__(self, num_tokens: int, value: Any) -> None:
+        self._values[self._key(num_tokens)] = value
+
+    def __delitem__(self, num_tokens: int) -> None:
+        del self._values[self._key(num_tokens)]
+
+    def __iter__(self) -> Iterator[int]:
+        return iter(self._sizes)
+
+    def __len__(self) -> int:
+        return len(self._sizes)
+
+
+def _dcut_rebind_live_fia_block_tables(
+    captured_params,
+    attn_metadata,
+) -> None:
+    """Rebind captured FIA task params to the runtime live-row block table."""
+    if not isinstance(attn_metadata, dict) or not attn_metadata:
+        return
+    metadata_keys = tuple(attn_metadata)
+    for index, param in enumerate(tuple(captured_params)):
+        if not isinstance(param, tuple) or len(param) < 4:
+            continue
+        layer_name = param[-1] if isinstance(param[-1], str) else None
+        metadata_key = (
+            layer_name
+            if layer_name is not None and layer_name in attn_metadata
+            else metadata_keys[index % len(metadata_keys)]
+        )
+        live_block_tables = getattr(
+            attn_metadata[metadata_key], "block_tables", None
+        )
+        if live_block_tables is None:
+            continue
+        captured_params[index] = (
+            *param[:3],
+            live_block_tables,
+            *param[4:],
+        )
+
+
+def _patch_live_fia_graph_params() -> None:
+    """Refresh sink-FIA block tables when ragged FULL request rows change."""
+    from vllm_ascend.ascend_forward_context import _EXTRA_CTX
+    from vllm_ascend.attention.attention_v1 import AscendAttentionBackend
+    from vllm_ascend.attention.utils import using_paged_attention
+    from vllm_ascend.compilation.acl_graph import get_graph_params
+
+    impl_cls = AscendAttentionBackend.get_impl_cls()
+    if getattr(impl_cls, "_dcut_live_fia_rows_patched", False):
+        return
+
+    original_update = impl_cls.update_graph_params
+
+    def update_graph_params(
+        update_stream,
+        forward_context,
+        num_tokens,
+        vllm_config,
+        speculative_config=None,
+        num_dcp_pcp_tokens=None,
+        draft_attn_metadatas=None,
+    ):
+        descriptor = getattr(forward_context, "batch_descriptor", None)
+        runtime_mode = getattr(forward_context, "cudagraph_runtime_mode", None)
+        use_live_fia_rows = bool(
+            descriptor is not None
+            and not getattr(descriptor, "uniform", True)
+            and getattr(runtime_mode, "name", runtime_mode) == "FULL"
+            and not using_paged_attention(num_tokens, vllm_config)
+        )
+        # The sink-FIA replay branch retains its captured block table, unlike
+        # the ordinary FIA branch. Replace only that captured argument with the
+        # stable runtime view whose row count matches actual_seq_lengths_q.
+        if use_live_fia_rows and _EXTRA_CTX.sinks:
+            graph_params = get_graph_params()
+            captured_params = graph_params.attn_params[num_tokens]
+            _dcut_rebind_live_fia_block_tables(
+                captured_params,
+                forward_context.attn_metadata,
+            )
+        return original_update(
+            update_stream,
+            forward_context,
+            num_tokens,
+            vllm_config,
+            speculative_config,
+            num_dcp_pcp_tokens,
+            draft_attn_metadatas,
+        )
+
+    impl_cls.update_graph_params = staticmethod(update_graph_params)
+    impl_cls._dcut_live_fia_rows_patched = True
+    logger.info(
+        "D-Cut: enabled live FIA request rows for ragged FULL graph replay."
+    )
+
+
+def _patch_graph_params_by_descriptor() -> None:
+    """Make full-attention graph state safe for duplicate token buckets."""
+    from vllm_ascend.compilation import acl_graph
+
+    graph_params_cls = acl_graph.GraphParams
+    if getattr(graph_params_cls, "_dcut_descriptor_patched", False):
+        return
+
+    original_init = graph_params_cls.__init__
+
+    def __init__(self, events, workspaces, handles, attn_params):
+        original_init(
+            self,
+            _DescriptorGraphParamMap(events, list_values=True),
+            _DescriptorGraphParamMap(workspaces, list_values=False),
+            _DescriptorGraphParamMap(handles, list_values=True),
+            _DescriptorGraphParamMap(attn_params, list_values=True),
+        )
+
+    graph_params_cls.__init__ = __init__
+    graph_params_cls._dcut_descriptor_patched = True
+    logger.info(
+        "D-Cut: isolated FULL graph attention parameters by BatchDescriptor."
+    )
+
+
+def _patch_full_decode_dispatcher() -> None:
+    """Register ragged FULL keys beside stock uniform decode keys."""
+    from vllm.config import CUDAGraphMode
+    from vllm.v1.cudagraph_dispatcher import CudagraphDispatcher
+
+    dispatcher_cls = CudagraphDispatcher
+    if getattr(dispatcher_cls, "_dcut_full_multishape_patched", False):
+        return
+
+    original_initialize = dispatcher_cls.initialize_cudagraph_keys
+
+    def initialize_cudagraph_keys(
+        self,
+        cudagraph_mode,
+        uniform_decode_query_len=1,
+    ):
+        original_initialize(
+            self,
+            cudagraph_mode,
+            uniform_decode_query_len,
+        )
+        if (
+            cudagraph_mode != CUDAGraphMode.FULL_DECODE_ONLY
+            or not _dcut_full_decode_multishape_enabled(self.vllm_config)
+        ):
+            return
+
+        # GraphParams are created after dispatcher initialization. Patch them
+        # only for this mode so PIECEWISE keeps its original data structures.
+        _patch_graph_params_by_descriptor()
+        _patch_live_fia_graph_params()
+
+        # Derive the token grid from the keys accepted by stock vLLM.  This
+        # automatically preserves its speculative-query-length and max-seq
+        # filtering instead of reimplementing configuration validation here.
+        uniform_keys = tuple(
+            descriptor
+            for descriptor in self.cudagraph_keys[CUDAGraphMode.FULL]
+            if descriptor.uniform
+        )
+        max_num_seqs = self.vllm_config.scheduler_config.max_num_seqs
+        added = 0
+        for descriptor in uniform_keys:
+            ragged = self._create_padded_batch_descriptor(
+                descriptor.num_tokens,
+                False,
+                descriptor.has_lora,
+                descriptor.num_active_loras,
+            )
+            ragged = replace(
+                ragged,
+                uniform=False,
+                num_reqs=_dcut_ragged_full_request_capacity(
+                    descriptor.num_tokens,
+                    max_num_seqs,
+                ),
+            )
+            if ragged not in self.cudagraph_keys[CUDAGraphMode.FULL]:
+                self.add_cudagraph_key(CUDAGraphMode.FULL, ragged)
+                added += 1
+
+        logger.warning(
+            "D-Cut: registered %d ragged FULL_DECODE_ONLY graph keys "
+            "beside %d uniform keys.",
+            added,
+            len(uniform_keys),
+        )
+
+    dispatcher_cls.initialize_cudagraph_keys = initialize_cudagraph_keys
+    dispatcher_cls._dcut_full_multishape_patched = True
+
+
+def _dcut_setup_full_decode_drafter(runner, drafter) -> None:
+    """Keep the draft on stock uniform FULL graphs.
+
+    The verifier descriptor becomes non-uniform after trimming, but the draft
+    still emits exactly ``num_spec`` tokens per request.  Propagating the
+    verifier's ragged descriptor would capture/replay an unnecessary and, for
+    DFlash attention, unsupported non-uniform draft graph.
+    """
+    from vllm.config import CUDAGraphMode
+
+    if not _dcut_full_decode_multishape_enabled(runner.vllm_config):
+        return
+    if (
+        runner.compilation_config.cudagraph_mode
+        != CUDAGraphMode.FULL_DECODE_ONLY
+    ):
+        return
+    if getattr(drafter, "_dcut_full_decode_multishape_setup", False):
+        return
+
+    if hasattr(drafter, "_propose"):
+        original_propose = drafter._propose
+
+        def _propose(*args, **kwargs):
+            descriptor = kwargs.get("target_model_batch_desc")
+            descriptor_arg = None
+            if descriptor is None and len(args) > 6:
+                descriptor = args[6]
+                descriptor_arg = 6
+
+            scheduler_output = kwargs.get("scheduler_output")
+            if scheduler_output is None and len(args) > 13:
+                scheduler_output = args[13]
+            zero_draft_handoffs = getattr(
+                runner,
+                "_dcut_zero_draft_handoffs_for_proposal",
+                frozenset(),
+            )
+            has_prefill = (
+                _dcut_has_prefill(
+                    runner,
+                    scheduler_output,
+                    zero_draft_handoffs,
+                )
+                if scheduler_output is not None
+                else getattr(
+                    runner,
+                    "_dcut_gdn_scheduler_has_prefill",
+                    None,
+                )
+            )
+            if (
+                descriptor is not None
+                and not descriptor.uniform
+                and has_prefill is False
+            ):
+                uniform_descriptor = replace(descriptor, uniform=True)
+                if descriptor_arg is None:
+                    kwargs = {
+                        **kwargs,
+                        "target_model_batch_desc": uniform_descriptor,
+                    }
+                else:
+                    args = (
+                        args[:descriptor_arg]
+                        + (uniform_descriptor,)
+                        + args[descriptor_arg + 1 :]
+                    )
+
+                # execute_model() and sample_tokens() are separate worker
+                # calls. Carry the ragged-verifier origin explicitly while
+                # the uniform draft prepares FIA metadata; the target-side
+                # batch flag is not lifetime-safe here.
+                padding_attr = "_dcut_drafter_from_nonuniform_decode"
+                had_padding_attr = hasattr(runner, padding_attr)
+                previous_padding = getattr(runner, padding_attr, None)
+                setattr(runner, padding_attr, True)
+                try:
+                    return original_propose(*args, **kwargs)
+                finally:
+                    if had_padding_attr:
+                        setattr(runner, padding_attr, previous_padding)
+                    elif hasattr(runner, padding_attr):
+                        delattr(runner, padding_attr)
+
+            if descriptor is not None and not descriptor.uniform:
+                # Prefill-containing target batches are eager. The ragged
+                # FULL keys added for pure verifier decode must not make the
+                # drafter graph such a batch after execute_model() returns.
+                use_cuda_graph = getattr(drafter, "use_cuda_graph", None)
+                if use_cuda_graph is not None:
+                    drafter.use_cuda_graph = False
+                    try:
+                        return original_propose(*args, **kwargs)
+                    finally:
+                        drafter.use_cuda_graph = use_cuda_graph
+
+            return original_propose(*args, **kwargs)
+
+        drafter._propose = _propose
+
+
+    drafter._dcut_full_decode_multishape_setup = True
+    logger.warning(
+        "D-Cut: FULL_DECODE_ONLY draft remains on uniform FULL graphs; "
+        "ragged draft capture is disabled."
+    )
+
+
+def _dcut_validate_gdn_full_graph_weights(runner) -> None:
+    """Verify every captured GDN layer belongs to the target model.
+
+    ``qwen_gdn_attention_core`` resolves its layer through
+    ``static_forward_context``.  A stale or draft-owned entry would make every
+    multi-shape graph permanently capture the wrong ``conv1d/A_log/dt_bias``
+    addresses.  Validate ownership after all weights are loaded and before the
+    first graph capture; no weights are copied per shape.
+    """
+    from vllm.config import CUDAGraphMode
+
+    if not _dcut_full_decode_multishape_enabled(runner.vllm_config):
+        return
+    if (
+        runner.compilation_config.cudagraph_mode
+        != CUDAGraphMode.FULL_DECODE_ONLY
+        or not getattr(runner, "_has_gdn", False)
+    ):
+        return
+    if getattr(runner, "pcp_size", 1) != 1 or getattr(runner, "dcp_size", 1) != 1:
+        raise RuntimeError(
+            "D-Cut ragged FULL_DECODE_ONLY GDN currently requires PCP=1 and DCP=1"
+        )
+
+    target_model = runner.get_model()
+    target_module_ids = {id(module) for module in target_model.modules()}
+    static_context = runner.compilation_config.static_forward_context
+    bindings = []
+    for prefix, layer in static_context.items():
+        if not all(
+            hasattr(layer, attr)
+            for attr in ("conv1d", "A_log", "dt_bias", "_forward_core")
+        ):
+            continue
+        if id(layer) not in target_module_ids:
+            raise RuntimeError(
+                "D-Cut FULL graph GDN binding is not owned by the target "
+                f"model: prefix={prefix}, layer={type(layer).__name__}"
+            )
+        if getattr(layer, "prefix", prefix) != prefix:
+            raise RuntimeError(
+                "D-Cut FULL graph GDN prefix mismatch: "
+                f"registry={prefix}, layer={getattr(layer, 'prefix', None)}"
+            )
+
+        tensors = (
+            layer.conv1d.weight,
+            layer.A_log,
+            layer.dt_bias,
+        )
+        if not all(isinstance(tensor, torch.Tensor) for tensor in tensors):
+            raise RuntimeError(
+                f"D-Cut FULL graph GDN weights are not tensors: prefix={prefix}"
+            )
+        bindings.append(
+            (prefix, *(int(tensor.data_ptr()) for tensor in tensors))
+        )
+
+    if not bindings:
+        raise RuntimeError(
+            "D-Cut detected GDN layers but found no target-owned GDN weight bindings"
+        )
+    runner._dcut_gdn_full_graph_weight_bindings = tuple(bindings)
+    logger.warning(
+        "D-Cut: validated %d target-owned GDN weight bindings for all "
+        "FULL_DECODE_ONLY shapes (weights are shared, not copied).",
+        len(bindings),
+    )
+
+
+def _patch_full_decode_multishape() -> None:
+    """Install early, process-wide FULL_DECODE_ONLY support."""
+    if not _dcut_full_decode_multishape_enabled():
+        return
+    _patch_full_decode_dispatcher()

--- a/dcut/patch_gdn.py
+++ b/dcut/patch_gdn.py
@@ -1,0 +1,499 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Patch QwenGatedDeltaNetAttention._forward_core for D-Cut."""
+from __future__ import annotations
+import os
+
+from .globals import logger, ENABLE_GDN_MAIN_PIECEWISE_GRAPH, ENV_CONFIG
+from .gdn_buffers import _dcut_alloc_gdn_spec_bufs, _dcut_alloc_gdn_nonspec_bufs
+from .gdn_eager import _conv1d_spec_varlen_eager
+
+def _patch_gdn_dcut() -> None:
+    """Patch AscendGatedDeltaNetAttention._forward_core for D-Cut.
+
+    Two changes:
+    1. Spec Conv1D eager path: use _conv1d_spec_varlen_eager fallback instead
+       of CANN op (which crashes on variable query_len from D-Cut truncation).
+    2. Recurrent GDN spec kernel call: align ssm_state_indices with actual
+       token positions (boolean mask) and clamp num_accepted_tokens to actual
+       seq lengths.
+    """
+    try:
+        import torch
+        import torch_npu
+        from einops import rearrange
+        from vllm.distributed import get_pcp_group
+        from vllm.forward_context import get_forward_context
+        from vllm.model_executor.layers.fla.ops.l2norm import l2norm_fwd
+        from vllm.v1.attention.backend import AttentionMetadata
+        from vllm.v1.attention.backends.gdn_attn import GDNAttentionMetadata
+        from vllm.v1.attention.backends.utils import PAD_SLOT_ID
+
+        from vllm_ascend.ascend_forward_context import _EXTRA_CTX
+        from vllm_ascend.attention.utils import maybe_save_kv_layer_to_connector
+        from vllm_ascend.compilation.acl_graph import (
+            get_draft_graph_params,
+            get_graph_params,
+        )
+        from vllm_ascend.device.device_op import DeviceOperator
+        from vllm.model_executor.layers.mamba.gdn.qwen_gdn_linear_attn import QwenGatedDeltaNetAttention
+        from vllm_ascend.ops.gdn import (
+            AscendGatedDeltaNetAttention,
+            to_int64_tuple,
+            get_non_spec_causal_conv1d_host_args,
+            get_causal_conv1d_update_host_args,
+            get_spec_causal_conv1d_update_host_args,
+            get_non_spec_chunked_prefill_meta,
+        )
+        from vllm_ascend.ops.triton.fla.chunk import chunk_gated_delta_rule
+        from vllm_ascend.ops.triton.fla.utils import clear_ssm_states
+        from vllm_ascend.ops.triton.mamba.causal_conv1d import causal_conv1d_fn
+        from vllm_ascend.utils import weak_ref_tensors
+    except Exception as e:
+        import sys as _dbg2
+        logger.warning("D-Cut: cannot import GDN ops for patching: %s", e)
+        return
+
+
+    if getattr(QwenGatedDeltaNetAttention, "_dcut_gdn_patched", False):
+        return
+
+    # Monkeypatch _pad_conv1d_host_args_to_capture to handle pad_tokens < q_per_seq.
+    # When D-Cut truncation reduces spec tokens, the padding falls short.
+    from vllm_ascend.ops.gdn import _pad_conv1d_host_args_to_capture as _orig_pad
+    if not getattr(_orig_pad, '_dcut_patched', False):
+        def _dcut_pad_conv1d_host_args(qsl_host, cidx_host, num_accepted_host,
+                                        cap_x_dim0, q_per_seq, with_num_accepted):
+            result = _orig_pad(qsl_host, cidx_host, num_accepted_host,
+                               cap_x_dim0, q_per_seq, with_num_accepted)
+            qsl, cidx, nat = result
+            # If still short (pad_tokens < q_per_seq case), add one final dummy
+            if qsl and int(qsl[-1]) != cap_x_dim0:
+                qsl = tuple(qsl) + (int(cap_x_dim0),)
+                cidx = tuple(cidx) + (PAD_SLOT_ID,)
+                if with_num_accepted:
+                    nat = tuple(nat) + (1,)
+            # Clamp num_accepted_tokens to not exceed segment lengths.
+            # D-Cut truncation can make nat[i] > (qsl[i+1] - qsl[i]),
+            # causing EZ9999: "numAcceptedTokens[i]=X exceeds varlen segment length=Y".
+            if with_num_accepted and nat:
+                clamped = []
+                for i in range(len(nat)):
+                    if i + 1 < len(qsl):
+                        seg_len = int(qsl[i + 1]) - int(qsl[i])
+                        clamped.append(min(int(nat[i]), seg_len))
+                    else:
+                        clamped.append(int(nat[i]))
+                nat = tuple(clamped)
+            return qsl, cidx, nat
+        _dcut_pad_conv1d_host_args._dcut_patched = True
+        # Patch in the gdn module so update_conv1d_graph_params uses the fixed version
+        import vllm_ascend.ops.gdn as _gdn_mod
+        _gdn_mod._pad_conv1d_host_args_to_capture = _dcut_pad_conv1d_host_args
+        logger.warning("D-Cut: patched _pad_conv1d_host_args_to_capture for sub-q_per_seq padding")
+
+
+    def _forward_core(
+        self,
+        mixed_qkv: torch.Tensor,
+        b: torch.Tensor,
+        a: torch.Tensor,
+        core_attn_out: torch.Tensor,
+    ):
+        """Core attention computation (called by custom op). D-Cut patched."""
+        forward_context = get_forward_context()
+        attn_metadata: AttentionMetadata = forward_context.attn_metadata
+
+        if attn_metadata is None:
+            return
+
+        assert isinstance(attn_metadata, dict)
+        attn_metadata = attn_metadata[self.prefix]
+        assert isinstance(attn_metadata, GDNAttentionMetadata)
+        has_initial_state = attn_metadata.has_initial_state
+        spec_query_start_loc = attn_metadata.spec_query_start_loc
+        non_spec_query_start_loc = attn_metadata.non_spec_query_start_loc
+        spec_sequence_masks = attn_metadata.spec_sequence_masks
+        spec_token_indx = attn_metadata.spec_token_indx
+        non_spec_token_indx = attn_metadata.non_spec_token_indx
+        spec_state_indices_tensor = attn_metadata.spec_state_indices_tensor  # noqa: E501
+        non_spec_state_indices_tensor = attn_metadata.non_spec_state_indices_tensor  # noqa: E501
+        self_kv_cache = self.kv_cache
+        ssm_state = self_kv_cache[1]
+        num_actual_tokens = attn_metadata.num_actual_tokens
+        num_accepted_tokens = attn_metadata.num_accepted_tokens
+
+        mixed_qkv = mixed_qkv[:num_actual_tokens]
+        b = b[:num_actual_tokens]
+        a = a[:num_actual_tokens]
+
+        # 1. Convolution sequence transformation
+        conv_weights = self.conv1d.weight.view(self.conv1d.weight.size(0), self.conv1d.weight.size(2))
+        if spec_sequence_masks is not None:
+            if attn_metadata.num_prefills == 0 and attn_metadata.num_decodes == 0:
+                mixed_qkv_spec = mixed_qkv
+                mixed_qkv_non_spec = None
+            else:
+                mixed_qkv_spec = mixed_qkv.index_select(0, spec_token_indx)
+                mixed_qkv_non_spec = mixed_qkv.index_select(0, non_spec_token_indx)
+        else:
+            mixed_qkv_spec = None
+            mixed_qkv_non_spec = mixed_qkv
+
+        # 1.1: Process the multi-query part
+        if spec_sequence_masks is not None:
+            conv_weights_T = conv_weights.transpose(0, 1)
+            activation_num = 1 if self.activation else 0
+            (spec_qsl_host, spec_ci_host, spec_nat_host) = get_spec_causal_conv1d_update_host_args(attn_metadata)
+            if _EXTRA_CTX.capturing or torch.compiler.is_compiling():
+                stream = torch_npu.npu.current_stream()
+                event = torch.npu.ExternalEvent()
+                event.wait(stream)
+                event.reset(stream)
+                graph_params = get_graph_params() if not _EXTRA_CTX.is_draft_model else get_draft_graph_params()
+                graph_params.conv1d_events[num_actual_tokens].append(event)
+
+                output_spec = torch.empty_like(mixed_qkv_spec)
+                spec_q_per_seq = int(attn_metadata.spec_state_indices_tensor.size(-1))
+                graph_params.conv1d_params[num_actual_tokens].append(
+                    (
+                        weak_ref_tensors(output_spec),
+                        weak_ref_tensors(mixed_qkv_spec),
+                        weak_ref_tensors(conv_weights_T),
+                        weak_ref_tensors(self_kv_cache[0]),
+                        self.conv1d.bias,
+                        activation_num,
+                        PAD_SLOT_ID,
+                        1,
+                        "spec",
+                        self.prefix,
+                        spec_qsl_host,
+                        spec_ci_host,
+                        spec_nat_host,
+                        spec_q_per_seq,
+                    )
+                )
+
+                torch.npu.graph_task_group_begin(stream)
+                torch.ops._C_ascend.npu_causal_conv1d_custom(
+                    output_spec,
+                    mixed_qkv_spec,
+                    conv_weights_T,
+                    conv_state=self_kv_cache[0],
+                    bias_opt=self.conv1d.bias,
+                    query_start_loc_opt=spec_qsl_host,
+                    cache_indices_opt=spec_ci_host,
+                    initial_state_mode_opt=(),
+                    num_accepted_tokens_opt=spec_nat_host,
+                    activation_mode=activation_num,
+                    pad_slot_id=PAD_SLOT_ID,
+                    run_mode=1,
+                )
+                handle = torch.npu.graph_task_group_end(stream)
+                graph_params.conv1d_handles[num_actual_tokens].append(handle)
+                mixed_qkv_spec = output_spec
+            else:
+                # D-Cut: per-request F.conv1d fallback for variable query_len.
+                num_spec_decodes = attn_metadata.num_spec_decodes
+                use_cann = True  # Use CANN op (fast); padding fix handles variable query_len
+
+                if use_cann:
+                    output_spec = torch.empty_like(mixed_qkv_spec)
+                    # D-Cut: clamp num_accepted_tokens to segment lengths.
+                    # D-Cut truncation can make nat[i] > (qsl[i+1] - qsl[i]),
+                    # causing EZ9999: numAcceptedTokens[i]=X exceeds varlen segment length=Y
+                    if spec_nat_host:
+                        _clamped = []
+                        for _i in range(len(spec_nat_host)):
+                            if _i + 1 < len(spec_qsl_host):
+                                _seg = int(spec_qsl_host[_i + 1]) - int(spec_qsl_host[_i])
+                                _clamped.append(min(int(spec_nat_host[_i]), _seg))
+                            else:
+                                _clamped.append(int(spec_nat_host[_i]))
+                        spec_nat_host = tuple(_clamped)
+                    torch.ops._C_ascend.npu_causal_conv1d_custom(
+                        output_spec,
+                        mixed_qkv_spec,
+                        conv_weights_T,
+                        conv_state=self_kv_cache[0],
+                        bias_opt=self.conv1d.bias,
+                        query_start_loc_opt=spec_qsl_host,
+                        cache_indices_opt=spec_ci_host,
+                        initial_state_mode_opt=(),
+                        num_accepted_tokens_opt=spec_nat_host,
+                        activation_mode=activation_num,
+                        pad_slot_id=PAD_SLOT_ID,
+                        run_mode=1,
+                    )
+                    mixed_qkv_spec = output_spec
+                else:
+                    output_spec = torch.empty_like(mixed_qkv_spec)
+                    _conv1d_spec_varlen_eager(
+                        output_spec,
+                        mixed_qkv_spec,
+                        conv_weights,
+                        self_kv_cache[0],
+                        self.conv1d.bias,
+                        self.activation,
+                        self.num_spec,
+                        spec_query_start_loc,
+                        spec_state_indices_tensor,
+                        num_accepted_tokens,
+                        num_spec_decodes,
+                    )
+                    mixed_qkv_spec = output_spec
+
+        # 1.2: Process the remaining part
+        if attn_metadata.num_prefills > 0:
+            if mixed_qkv_non_spec is not None:
+                if get_pcp_group().world_size > 1:
+                    mixed_qkv_non_spec_T = mixed_qkv_non_spec.transpose(0, 1)
+                    has_initial_state = attn_metadata.has_initial_state
+                    non_spec_state_indices_tensor = attn_metadata.non_spec_state_indices_tensor  # noqa: E501
+                    conv_state = self_kv_cache[0].transpose(-1, -2)
+                    mixed_qkv_non_spec = causal_conv1d_fn(
+                        mixed_qkv_non_spec_T,
+                        conv_weights,
+                        self.conv1d.bias,
+                        activation=self.activation,
+                        conv_states=conv_state,
+                        has_initial_state=has_initial_state,
+                        cache_indices=non_spec_state_indices_tensor,
+                        query_start_loc=non_spec_query_start_loc,
+                        metadata=attn_metadata,
+                    ).transpose(0, 1)
+                else:
+                    conv_weights_T = conv_weights.transpose(0, 1)
+                    activation_num = 1 if self.activation else 0
+                    (
+                        query_start_loc_opt,
+                        cache_indices_opt,
+                        initial_state_mode_opt,
+                    ) = get_non_spec_causal_conv1d_host_args(attn_metadata)
+                    mixed_qkv_non_spec_output = torch.empty_like(mixed_qkv_non_spec)
+                    torch.ops._C_ascend.npu_causal_conv1d_custom(
+                        mixed_qkv_non_spec_output,
+                        mixed_qkv_non_spec,
+                        conv_weights_T,
+                        conv_state=self_kv_cache[0],
+                        bias_opt=self.conv1d.bias,
+                        query_start_loc_opt=query_start_loc_opt,
+                        cache_indices_opt=cache_indices_opt,
+                        initial_state_mode_opt=initial_state_mode_opt,
+                        num_accepted_tokens_opt=[],
+                        activation_mode=activation_num,
+                        pad_slot_id=PAD_SLOT_ID,
+                        run_mode=0,
+                    )
+                    mixed_qkv_non_spec = mixed_qkv_non_spec_output
+        elif attn_metadata.num_decodes > 0:
+            conv_weights_T = conv_weights.transpose(0, 1)
+            activation_num = 1 if self.activation else 0
+            non_spec_qsl_host, non_spec_ci_host = get_causal_conv1d_update_host_args(attn_metadata)
+            if _EXTRA_CTX.capturing or torch.compiler.is_compiling():
+                stream = torch_npu.npu.current_stream()
+                event = torch.npu.ExternalEvent()
+                event.wait(stream)
+                event.reset(stream)
+                graph_params = get_graph_params() if not _EXTRA_CTX.is_draft_model else get_draft_graph_params()
+                graph_params.conv1d_events[num_actual_tokens].append(event)
+
+                output_non_spec = torch.empty_like(mixed_qkv_non_spec)
+                non_spec_q_per_seq = 1
+                graph_params.conv1d_params[num_actual_tokens].append(
+                    (
+                        weak_ref_tensors(output_non_spec),
+                        weak_ref_tensors(mixed_qkv_non_spec),
+                        weak_ref_tensors(conv_weights_T),
+                        weak_ref_tensors(self_kv_cache[0]),
+                        self.conv1d.bias,
+                        activation_num,
+                        PAD_SLOT_ID,
+                        1,
+                        "non_spec_decode",
+                        self.prefix,
+                        non_spec_qsl_host,
+                        non_spec_ci_host,
+                        [],
+                        non_spec_q_per_seq,
+                    )
+                )
+
+                torch.npu.graph_task_group_begin(stream)
+                torch.ops._C_ascend.npu_causal_conv1d_custom(
+                    output_non_spec,
+                    mixed_qkv_non_spec,
+                    conv_weights_T,
+                    conv_state=self_kv_cache[0],
+                    bias_opt=self.conv1d.bias,
+                    query_start_loc_opt=non_spec_qsl_host,
+                    cache_indices_opt=non_spec_ci_host,
+                    initial_state_mode_opt=(),
+                    num_accepted_tokens_opt=[],
+                    activation_mode=activation_num,
+                    pad_slot_id=PAD_SLOT_ID,
+                    run_mode=1,
+                )
+                handle = torch.npu.graph_task_group_end(stream)
+                graph_params.conv1d_handles[num_actual_tokens].append(handle)
+                mixed_qkv_non_spec = output_non_spec
+            else:
+                output_non_spec = torch.empty_like(mixed_qkv_non_spec)
+                torch.ops._C_ascend.npu_causal_conv1d_custom(
+                    output_non_spec,
+                    mixed_qkv_non_spec,
+                    conv_weights_T,
+                    conv_state=self_kv_cache[0],
+                    bias_opt=self.conv1d.bias,
+                    query_start_loc_opt=to_int64_tuple(non_spec_query_start_loc[: num_actual_tokens + 1]),
+                    cache_indices_opt=to_int64_tuple(non_spec_state_indices_tensor[:num_actual_tokens]),
+                    initial_state_mode_opt=[],
+                    num_accepted_tokens_opt=[],
+                    activation_mode=activation_num,
+                    pad_slot_id=PAD_SLOT_ID,
+                    run_mode=1,
+                )
+                mixed_qkv_non_spec = output_non_spec
+        else:
+            mixed_qkv_non_spec = None
+
+        query_spec, key_spec, value_spec = self.rearrange_mixed_qkv(mixed_qkv_spec)
+        query_non_spec, key_non_spec, value_non_spec = self.rearrange_mixed_qkv(mixed_qkv_non_spec)
+
+        # 2. Recurrent attention
+        g, beta = DeviceOperator.fused_gdn_gating(self.A_log, a, b, self.dt_bias)
+        if spec_sequence_masks is not None:
+            if attn_metadata.num_prefills == 0 and attn_metadata.num_decodes == 0:
+                g_spec = g
+                beta_spec = beta
+                g_non_spec = None
+                beta_non_spec = None
+            else:
+                g_spec = g.index_select(1, spec_token_indx)
+                beta_spec = beta.index_select(1, spec_token_indx)
+                g_non_spec = g.index_select(1, non_spec_token_indx)
+                beta_non_spec = beta.index_select(1, non_spec_token_indx)
+        else:
+            g_spec = None
+            beta_spec = None
+            g_non_spec = g
+            beta_non_spec = beta
+
+        # 2.1: Process the multi-query part
+        if spec_sequence_masks is not None:
+            query_spec = l2norm_fwd(query_spec)
+            key_spec = l2norm_fwd(key_spec)
+            if _EXTRA_CTX.capturing or torch.compiler.is_compiling():
+                # Graph capture OR Dynamo tracing: use pre-allocated static
+                # buffers (stable data_ptr).  _model_forward fills them
+                # graph-externally before each replay via _dcut_fill_gdn_spec_bufs.
+                # This replaces the old torch.cat/flatten/.to() which created
+                # new tensors each call → stale data_ptr at replay → 0% accuracy.
+                # NOTE: Must check torch.compiler.is_compiling() too because
+                # _EXTRA_CTX.capturing is False during Dynamo tracing.
+                _gdn_bufs = _dcut_alloc_gdn_spec_bufs(
+                    self.prefix, num_actual_tokens,
+                    spec_state_indices_tensor, spec_query_start_loc.device)
+                actual_seq_lengths = _gdn_bufs["asl"]
+                aligned_ssm_indices = _gdn_bufs["ssi"]
+                clamped_nat = _gdn_bufs["nat"]
+            else:
+                # Eager mode: D-Cut per-request fallback (torch.cat is safe
+                # here — no graph, data_ptr stability irrelevant).
+                cu_seqlens = spec_query_start_loc[: attn_metadata.num_spec_decodes + 1]
+                actual_seq_lengths = torch.cat([cu_seqlens[:1], cu_seqlens[1:] - cu_seqlens[:-1]])
+                per_seq_lens = actual_seq_lengths[1:]
+                max_tokens = spec_state_indices_tensor.size(1)
+                col_idx = torch.arange(max_tokens, device=spec_state_indices_tensor.device)
+                mask = col_idx.unsqueeze(0) < per_seq_lens.unsqueeze(1)
+                aligned_ssm_indices = spec_state_indices_tensor[mask].clone()
+                clamped_nat = torch.minimum(
+                    num_accepted_tokens.to(torch.int32),
+                    per_seq_lens.to(torch.int32)
+                )
+            core_attn_out_spec = torch.ops._C_ascend.npu_recurrent_gated_delta_rule(
+                query=query_spec.squeeze(0),
+                key=key_spec.squeeze(0),
+                value=value_spec.squeeze(0),
+                g=g_spec.squeeze(0),
+                beta=beta_spec.squeeze(0),
+                state=ssm_state,
+                scale=key_spec.shape[-1] ** -0.5,
+                actual_seq_lengths=actual_seq_lengths,
+                ssm_state_indices=aligned_ssm_indices,
+                num_accepted_tokens=clamped_nat,
+            ).unsqueeze(0)
+        else:
+            core_attn_out_spec, last_recurrent_state = None, None
+
+        # 2.2: Process the remaining part
+        if attn_metadata.num_prefills > 0:
+            initial_state = ssm_state[non_spec_state_indices_tensor].transpose(-1, -2).contiguous()
+            clear_ssm_states(initial_state, has_initial_state)
+            (core_attn_out_non_spec, last_recurrent_state) = chunk_gated_delta_rule(
+                q=query_non_spec,
+                k=key_non_spec,
+                v=value_non_spec,
+                g=g_non_spec,
+                beta=beta_non_spec,
+                initial_state=initial_state,
+                output_final_state=True,
+                cu_seqlens=non_spec_query_start_loc,
+                prebuilt_meta=get_non_spec_chunked_prefill_meta(attn_metadata),
+                head_first=False,
+                use_qk_l2norm_in_kernel=True,
+            )
+            ssm_state[non_spec_state_indices_tensor] = (
+                last_recurrent_state.transpose(-1, -2).contiguous().to(ssm_state.dtype)
+            )
+        elif attn_metadata.num_decodes > 0:
+            query_non_spec = l2norm_fwd(query_non_spec)
+            key_non_spec = l2norm_fwd(key_non_spec)
+            if _EXTRA_CTX.capturing or torch.compiler.is_compiling():
+                # Graph capture: use pre-allocated static buffers (stable
+                # data_ptr).  _model_forward fills them before each replay.
+                _gdn_ns_bufs = _dcut_alloc_gdn_nonspec_bufs(
+                    self.prefix, num_actual_tokens,
+                    non_spec_state_indices_tensor,
+                    non_spec_query_start_loc.device)
+                actual_seq_lengths = _gdn_ns_bufs["asl"]
+                _ns_ssi = _gdn_ns_bufs["ssi"]
+            else:
+                cu_seqlens = non_spec_query_start_loc[: attn_metadata.num_decodes + 1]
+                actual_seq_lengths = torch.cat([cu_seqlens[:1], cu_seqlens[1:] - cu_seqlens[:-1]])
+                _ns_ssi = non_spec_state_indices_tensor
+            core_attn_out_non_spec = torch.ops._C_ascend.npu_recurrent_gated_delta_rule(
+                query=query_non_spec.squeeze(0),
+                key=key_non_spec.squeeze(0),
+                value=value_non_spec.squeeze(0),
+                g=g_non_spec.squeeze(0) if g_non_spec is not None else g_non_spec,
+                beta=beta_non_spec.squeeze(0) if beta_non_spec is not None else beta_non_spec,
+                state=ssm_state,
+                scale=key_non_spec.shape[-1] ** -0.5,
+                actual_seq_lengths=actual_seq_lengths,
+                ssm_state_indices=_ns_ssi,
+            ).unsqueeze(0)
+        else:
+            core_attn_out_non_spec, last_recurrent_state = None, None
+
+        # 3. Merge core attention output
+        if spec_sequence_masks is not None and core_attn_out_non_spec is not None:
+            merged_out = torch.empty(
+                (1, num_actual_tokens, *core_attn_out_spec.shape[2:]),
+                dtype=core_attn_out_non_spec.dtype,
+                device=core_attn_out_non_spec.device,
+            )
+            merged_out.index_copy_(1, spec_token_indx, core_attn_out_spec)
+            merged_out.index_copy_(1, non_spec_token_indx, core_attn_out_non_spec)
+            core_attn_out[:num_actual_tokens] = merged_out.squeeze(0)
+        elif spec_sequence_masks is not None:
+            core_attn_out[:num_actual_tokens] = core_attn_out_spec.squeeze(0)
+        else:
+            core_attn_out[:num_actual_tokens] = core_attn_out_non_spec.squeeze(0)
+
+    QwenGatedDeltaNetAttention._forward_core = _forward_core
+    QwenGatedDeltaNetAttention._dcut_gdn_patched = True
+    _check_fn = getattr(QwenGatedDeltaNetAttention, '_forward_core', None)
+    logger.warning(
+        "D-Cut: patched AscendGatedDeltaNetAttention._forward_core "
+        "(D-Cut conv1d varlen eager + ssm_state_indices alignment + NAT clamping)."
+    )

--- a/dcut/patch_gdn_v023.py
+++ b/dcut/patch_gdn_v023.py
@@ -1,0 +1,352 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Install the graph-capturable D-Cut GDN core for vLLM 0.23."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import torch
+
+from .globals import logger
+
+ENV_TORCH_OP_LIBRARY = "VLLM_DCUT_TORCH_OP_LIBRARY"
+_REQUIRED_OPS = (
+    "npu_dcut_causal_conv1d",
+    "npu_dcut_recurrent_gated_delta_rule",
+)
+
+
+def _dcut_gdn_has_prefill(forward_context, prefix: str | None = None) -> bool:
+    """Return whether the current GDN batch contains prefill work."""
+    if forward_context is None:
+        return False
+    attn_metadata = getattr(forward_context, "attn_metadata", None)
+    if not isinstance(attn_metadata, dict):
+        return False
+    metadata = (
+        attn_metadata.values()
+        if prefix is None
+        else (attn_metadata.get(prefix),)
+    )
+    return any(
+        int(getattr(meta, "num_prefills", 0)) > 0
+        for meta in metadata
+        if meta is not None
+    )
+
+
+def _dcut_gdn_use_native_core(forward_context, prefix: str) -> bool:
+    """Route prefill-containing batches around every D-Cut GDN operator."""
+    if forward_context is None:
+        return False
+
+    # D-Cut adds non-uniform FULL descriptors next to vLLM's stock uniform
+    # descriptors. Keep the stock descriptors bit-for-bit native, including
+    # recompute handoff; only the added ragged descriptors need D-Cut's core.
+    runtime_mode = getattr(forward_context, "cudagraph_runtime_mode", None)
+    descriptor = getattr(forward_context, "batch_descriptor", None)
+    if (
+        getattr(runtime_mode, "name", runtime_mode) == "FULL"
+        and bool(getattr(descriptor, "uniform", False))
+    ):
+        return True
+
+    # ``GDNAttentionMetadata.num_prefills`` is overloaded for mixed
+    # speculative/non-speculative decode: the native builder folds ordinary
+    # decode rows into that count even though no prompt tokens are present.
+    # When the model runner has propagated the scheduler's real-prefill
+    # decision, it must therefore be authoritative, including when False.
+    native_batch = getattr(
+        forward_context,
+        "_dcut_gdn_native_batch",
+        None,
+    )
+    if native_batch is not None:
+        return bool(native_batch)
+
+    # Dummy graph capture and direct unit paths do not have a SchedulerOutput.
+    return _dcut_gdn_has_prefill(forward_context, prefix)
+
+
+def _ops_registered() -> bool:
+    return all(hasattr(torch.ops._C_ascend, name) for name in _REQUIRED_OPS)
+
+
+def _load_dcut_torch_ops() -> bool:
+    """Load the D-Cut-only Torch registration library before graph capture."""
+    if _ops_registered():
+        return True
+
+    configured_path = os.environ.get(ENV_TORCH_OP_LIBRARY)
+    if configured_path:
+        candidates = (Path(configured_path).expanduser(),)
+    else:
+        candidates = (
+            Path(__file__).resolve().parent
+            / "kernel"
+            / "build"
+            / "torch_extension"
+            / "dcut_torch_ops.so",
+        )
+
+    load_errors: list[str] = []
+    for candidate in candidates:
+        if not candidate.is_file():
+            load_errors.append(f"{candidate} (not found)")
+            continue
+        try:
+            torch.ops.load_library(str(candidate))
+        except (OSError, RuntimeError) as exc:
+            load_errors.append(f"{candidate} ({exc})")
+            continue
+        if _ops_registered():
+            return True
+        load_errors.append(f"{candidate} (loaded, but schemas are missing)")
+
+    logger.error(
+        "D-Cut: custom GDN Torch operators are unavailable: %s. "
+        "Build them with `bash dcut/kernel/build.sh` or set %s.",
+        "; ".join(load_errors),
+        ENV_TORCH_OP_LIBRARY,
+    )
+    return False
+
+
+def _patch_gdn_spec_metadata_builder(gdn_attn_builder) -> None:
+    """Use compact D-Cut metadata only for decode-only batches."""
+    target_class = gdn_attn_builder.AscendGDNAttentionMetadataBuilder
+    current_build = target_class.build
+    if not getattr(current_build, "_dcut_fia_dummy_patched", False):
+
+        def _dcut_build(
+            self,
+            common_prefix_len,
+            common_attn_metadata,
+            num_accepted_tokens=None,
+            num_decode_draft_tokens_cpu=None,
+            fast_build=False,
+        ):
+            configured_mode = getattr(
+                self.vllm_config.compilation_config.cudagraph_mode,
+                "name",
+                None,
+            )
+            if (
+                configured_mode != "FULL_DECODE_ONLY"
+                or getattr(
+                    self,
+                    "_dcut_force_native_gdn_metadata",
+                    False,
+                )
+            ):
+                return current_build(
+                    self,
+                    common_prefix_len,
+                    common_attn_metadata,
+                    num_accepted_tokens,
+                    num_decode_draft_tokens_cpu,
+                    fast_build,
+                )
+
+            # FULL attention appends a virtual FIA request to reach padded Q,
+            # while GDN intentionally receives its unpadded query_start_loc.
+            # Keep that FIA-only row out of GDN classification/state updates.
+            query_start_loc_cpu = (
+                common_attn_metadata.query_start_loc_cpu
+            )
+            actual_num_reqs = min(
+                common_attn_metadata.num_reqs,
+                len(query_start_loc_cpu) - 1,
+            )
+            # GDN qsl keeps real boundaries, so FIA padding appears as one
+            # or more trailing zero-length rows. Real scheduled requests always
+            # own at least the verifier backbone token. This is the pinned CPU
+            # snapshot, so the scalar checks below never synchronize the NPU.
+            while (
+                actual_num_reqs > 0
+                and int(query_start_loc_cpu[actual_num_reqs])
+                == int(query_start_loc_cpu[actual_num_reqs - 1])
+            ):
+                actual_num_reqs -= 1
+            if actual_num_reqs < common_attn_metadata.num_reqs:
+                common_attn_metadata = common_attn_metadata.unpadded(
+                    common_attn_metadata.num_actual_tokens,
+                    actual_num_reqs,
+                )
+                if num_accepted_tokens is not None:
+                    num_accepted_tokens = num_accepted_tokens[:actual_num_reqs]
+                if num_decode_draft_tokens_cpu is not None:
+                    num_decode_draft_tokens_cpu = (
+                        num_decode_draft_tokens_cpu[:actual_num_reqs]
+                    )
+            return current_build(
+                self,
+                common_prefix_len,
+                common_attn_metadata,
+                num_accepted_tokens,
+                num_decode_draft_tokens_cpu,
+                fast_build,
+            )
+
+        _dcut_build._dcut_fia_dummy_patched = True
+        target_class.build = _dcut_build
+
+    current = target_class._attach_spec_decode_metadata
+    if getattr(current, "_dcut_patched", False):
+        return
+
+    def _dcut_attach_spec_decode_metadata(self, attn_metadata):
+        # Prefill-containing batches bypass the D-Cut GDN core. Preserve the
+        # native actual_seq_lengths layout consumed by its recurrent kernel.
+        if (
+            int(attn_metadata.num_prefills) > 0
+            or getattr(
+                self,
+                "_dcut_force_native_gdn_metadata",
+                False,
+            )
+        ):
+            return current(self, attn_metadata)
+
+        attn_metadata.spec_decode_metadata = None
+        if attn_metadata.spec_sequence_masks is None:
+            return attn_metadata
+
+        if attn_metadata.spec_query_start_loc is None:
+            raise RuntimeError(
+                "Expected attn_metadata.spec_query_start_loc for Ascend "
+                "GDN speculative path."
+            )
+        if attn_metadata.spec_state_indices_tensor is None:
+            raise RuntimeError(
+                "Expected spec_state_indices_tensor for Ascend GDN "
+                "speculative conv1d path."
+            )
+        if attn_metadata.num_accepted_tokens is None:
+            raise RuntimeError(
+                "Expected num_accepted_tokens for Ascend GDN speculative "
+                "conv1d path."
+            )
+
+        spec_num_rows = attn_metadata.spec_query_start_loc.size(0) - 1
+        attn_metadata.spec_decode_metadata = (
+            gdn_attn_builder.GDNSpecDecodeMetadata(
+                spec_causal_conv1d=gdn_attn_builder.GDNSpecCausalConv1dMetadata(
+                    query_start_loc=attn_metadata.spec_query_start_loc,
+                    cache_indices=attn_metadata.spec_state_indices_tensor[:spec_num_rows],
+                    num_accepted_tokens=attn_metadata.num_accepted_tokens[:spec_num_rows],
+                ),
+                actual_seq_lengths=attn_metadata.spec_query_start_loc,
+            )
+        )
+        return attn_metadata
+
+    _dcut_attach_spec_decode_metadata._dcut_patched = True
+    target_class._attach_spec_decode_metadata = _dcut_attach_spec_decode_metadata
+
+
+def _patch_gdn_dcut() -> bool:
+    """Patch GDN routing and expose the graphable pure-spec PIECEWISE path."""
+    try:
+        from vllm.forward_context import get_forward_context
+        from vllm_ascend.ops import gdn as ascend_gdn
+        from vllm_ascend.ops import gdn_attn_builder
+        from vllm_ascend.patch.worker import patch_qwen3_5 as qwen_patch
+        from vllm_ascend.utils import is_310p
+    except Exception as exc:  # pragma: no cover - depends on runtime imports
+        logger.warning("D-Cut: cannot import vLLM 0.23 GDN symbols: %s", exc)
+        return False
+
+    if is_310p():
+        logger.warning("D-Cut: variable-length GDN verification is not enabled on 310P.")
+        return False
+
+    target_class = qwen_patch._GDN_PATCH_TARGET
+
+    if not _load_dcut_torch_ops():
+        return False
+
+    _patch_gdn_spec_metadata_builder(gdn_attn_builder)
+    if (
+        getattr(target_class._forward_core, "_dcut_patched", False)
+        and getattr(target_class.forward, "_dcut_patched", False)
+    ):
+        return True
+
+    from .gdn_forward_v023 import AscendGatedDeltaNetAttention as DcutGatedDeltaNetAttention
+
+    native_forward_core = target_class._forward_core
+    native_forward = target_class.forward
+    dcut_forward_core = DcutGatedDeltaNetAttention._forward_core
+    graphable_spec_forward = (
+        DcutGatedDeltaNetAttention.forward_with_graphable_recurrent
+    )
+
+    def _dcut_forward_core(
+        self,
+        mixed_qkv,
+        b,
+        a,
+        core_attn_out,
+    ):
+        forward_context = get_forward_context()
+        if _dcut_gdn_use_native_core(forward_context, self.prefix):
+            return native_forward_core(
+                self,
+                mixed_qkv,
+                b,
+                a,
+                core_attn_out,
+            )
+        return dcut_forward_core(
+            self,
+            mixed_qkv,
+            b,
+            a,
+            core_attn_out,
+        )
+
+    _dcut_forward_core._dcut_patched = True  # type: ignore[attr-defined]
+    _dcut_forward_core._dcut_native_forward_core = (  # type: ignore[attr-defined]
+        native_forward_core
+    )
+
+    def _dcut_forward(self, hidden_states, output):
+        forward_context = get_forward_context()
+        piecewise_graph_safe = getattr(
+            forward_context,
+            "_dcut_gdn_recurrent_piecewise_safe",
+            False,
+        )
+        full_graph_safe = getattr(
+            forward_context,
+            "_dcut_gdn_full_graph_safe",
+            False,
+        )
+        if piecewise_graph_safe or full_graph_safe:
+            # Use the same expanded GDN path in both graph modes. In
+            # particular, ragged FULL must not re-enter the opaque
+            # qwen_gdn_attention_core custom op: its hidden recurrent-state
+            # mutation is not part of that op's explicit tensor signature.
+            # The graphable recurrent wrapper declares ``state`` as mutated
+            # and is already accuracy-validated by the PIECEWISE path.
+            return graphable_spec_forward(
+                self,
+                hidden_states,
+                output,
+            )
+        return native_forward(self, hidden_states, output)
+
+    _dcut_forward._dcut_patched = True  # type: ignore[attr-defined]
+    _dcut_forward._dcut_native_forward = native_forward  # type: ignore[attr-defined]
+
+    ascend_gdn.AscendGatedDeltaNetAttention._forward_core = _dcut_forward_core
+    target_class._forward_core = _dcut_forward_core
+    ascend_gdn.AscendGatedDeltaNetAttention.forward = _dcut_forward
+    target_class.forward = _dcut_forward
+    logger.info(
+        "D-Cut: enabled native prefill/mixed GDN routing and the "
+        "graphable pure-spec PIECEWISE/FULL core."
+    )
+    return True

--- a/dcut/patch_piecewise.py
+++ b/dcut/patch_piecewise.py
@@ -1,0 +1,152 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Capture pure-spec GDN, including its recurrent update, in PIECEWISE mode.
+
+When explicitly enabled, the expanded pure-spec GDN core is compiled into the
+outer PIECEWISE graph. Native prefill and mixed batches retain the whole-core
+boundary and therefore preserve the stock vLLM-Ascend path.
+"""
+
+from __future__ import annotations
+
+import os
+
+_WHOLE_GDN_OP = "vllm::qwen_gdn_attention_core"
+_RECURRENT_OP = "vllm::dcut_gdn_recurrent"
+ENV_DCUT_CONFIG = "VLLM_DCUT_CONFIG"
+ENV_GDN_PIECEWISE = "VLLM_ASCEND_ENABLE_DCUT_GDN_PIECEWISE"
+LEGACY_ENV_GDN_PIECEWISE = "VLLM_DCUT_GDN_PIECEWISE"
+
+
+def _ensure_gdn_splitting_ops(ops):
+    """Keep native GDN outside while capturing the pure-spec recurrent op."""
+    result = [op for op in (ops or ()) if op != _RECURRENT_OP]
+    # Keep this boundary for the untouched native prefill/mixed path and for
+    # vLLM's PIECEWISE attention validation. It is absent from the expanded
+    # pure-spec decode graph when the graphable recurrent route is active.
+    if _WHOLE_GDN_OP not in result:
+        result.append(_WHOLE_GDN_OP)
+    return result
+
+
+def _env_flag(value: str) -> bool:
+    return value.strip().lower() in ("1", "true", "yes", "on")
+
+
+def _is_enabled() -> bool:
+    """Return whether GDN may be captured by PIECEWISE ACLGraph.
+
+    The registered vllm-ascend variable is authoritative. The earlier
+    D-Cut-only spelling remains accepted so existing launch scripts do not
+    silently lose the optimization.
+    """
+    if not os.environ.get(ENV_DCUT_CONFIG):
+        return False
+
+    legacy = os.environ.get(LEGACY_ENV_GDN_PIECEWISE)
+    if legacy is not None:
+        return _env_flag(legacy)
+
+    try:
+        from vllm_ascend import envs
+
+        return bool(envs.VLLM_ASCEND_ENABLE_DCUT_GDN_PIECEWISE)
+    except (AttributeError, ImportError, ValueError):
+        return _env_flag(os.environ.get(ENV_GDN_PIECEWISE, "0"))
+
+
+def _arm_gdn_piecewise_splitting_patch():
+    """Configure native fallback and recurrent capture in every process.
+    Must be called **before** vllm-ascend platform code invokes
+    ``set_splitting_ops_for_v1`` (i.e. during ``install()``, not during the
+    deferred ``WorkerBase.__init__`` trigger).  Only vLLM-core symbols are
+    imported here — no vllm_ascend.worker / model_runner — so there is no
+    circular-import risk.
+
+    Using ``print(flush=True)`` for all diagnostics because ``logger.*`` calls
+    are silently swallowed in the dcut vLLM service process.
+    """
+    if not _is_enabled():
+        print(
+            "[D-Cut] GDN PIECEWISE boundary patch SKIPPED "
+            f"(requires {ENV_DCUT_CONFIG} and "
+            f"{ENV_GDN_PIECEWISE}=1).",
+            flush=True,
+        )
+        return
+
+    try:
+        from vllm.config import CUDAGraphMode, CompilationConfig
+    except Exception as exc:  # pragma: no cover - vLLM not installed
+        print(
+            f"[D-Cut] cannot import CompilationConfig, "
+            f"GDN PIECEWISE graph patch NOT armed: {exc}",
+            flush=True,
+        )
+        return
+
+    if getattr(
+        CompilationConfig.set_splitting_ops_for_v1,
+        "_dcut_piecewise_patched",
+        False,
+    ):
+        print(
+            "[D-Cut] GDN PIECEWISE graph patch already armed (skip).",
+            flush=True,
+        )
+        return
+
+    _ORIG_SET_SPLITTING_OPS = CompilationConfig.set_splitting_ops_for_v1
+
+    def _patched_set_splitting_ops_for_v1(self, *args, **kwargs):
+        _ORIG_SET_SPLITTING_OPS(self, *args, **kwargs)
+
+        if self.cudagraph_mode != CUDAGraphMode.PIECEWISE:
+            print(
+                "[D-Cut] GDN graph split configuration skipped for "
+                f"cudagraph_mode={self.cudagraph_mode}.",
+                flush=True,
+            )
+            return
+
+        before = list(self.splitting_ops or ())
+        after = _ensure_gdn_splitting_ops(self.splitting_ops)
+        self.splitting_ops = after
+
+        if before != after:
+            print(
+                "[D-Cut] configured GDN PIECEWISE splitting boundaries "
+                f"(before={len(before)} ops, after={len(after)} ops).",
+                flush=True,
+            )
+            print(f"[D-Cut] splitting_ops before={before}", flush=True)
+            print(f"[D-Cut] splitting_ops after ={after}", flush=True)
+        print(
+            "[D-Cut] GDN PIECEWISE strategy: expanded pure-spec core with "
+            "recurrent update inside the graph "
+            f"(recurrent_is_boundary={_RECURRENT_OP in after}).",
+            flush=True,
+        )
+
+    _patched_set_splitting_ops_for_v1._dcut_piecewise_patched = True  # type: ignore[attr-defined]
+    CompilationConfig.set_splitting_ops_for_v1 = (  # type: ignore[assignment]
+        _patched_set_splitting_ops_for_v1
+    )
+    print(
+        "[D-Cut] GDN PIECEWISE graph selection patch armed.",
+        flush=True,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Module-level arming — runs at import time so the patch is applied in EVERY
+# process that imports the dcut package (EngineCore + Worker), not just where
+# ``install()`` is called.  The vLLM general-plugin ``install()`` entrypoint
+# is only invoked in Worker processes; the EngineCore process (where
+# ``set_splitting_ops_for_v1`` actually runs during config creation) never
+# calls ``install()``.  Arming at import time closes that gap.
+# ---------------------------------------------------------------------------
+print("[D-Cut] patch_piecewise module imported — arming patch.", flush=True)
+try:
+    _arm_gdn_piecewise_splitting_patch()
+except Exception as _e:  # pragma: no cover - never break import
+    print(f"[D-Cut] patch_piecewise module-level arm failed: {_e}", flush=True)

--- a/dcut/patch_proposer.py
+++ b/dcut/patch_proposer.py
@@ -1,0 +1,592 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Patch Ascend spec-decode proposer for selected draft probs."""
+from __future__ import annotations
+
+import os
+
+import torch
+from vllm.v1.spec_decode.utils import PADDING_SLOT_ID
+
+from .globals import ENV_CONFIG, logger
+from .utils import (
+    _dcut_greedy_sample_with_selected_probs,
+    _dcut_in_graph_capture,
+    _dcut_should_collect_draft_probs,
+    _dcut_selected_token_probs,
+)
+
+# ---------------------------------------------------------------------------
+# Patch installers (idempotent, per class).  Targets are the *NPU* classes.
+# ---------------------------------------------------------------------------
+
+
+def _dcut_store_unique_graph_buffer(owner, attr_name, key, tensor) -> None:
+    """Retain *tensor* only while *key* identifies one graph allocation.
+
+    Ascend uses a global ACLGraph pool, so different graph entries are allowed
+    to reuse an output address. Shape and numel keys are even less specific.
+    Mark a key ambiguous instead of silently replacing it with the final graph
+    captured during startup.
+    """
+    buffers = getattr(owner, attr_name, None)
+    if buffers is None:
+        buffers = {}
+        setattr(owner, attr_name, buffers)
+    if key not in buffers:
+        buffers[key] = tensor
+        return
+    existing = buffers[key]
+    if existing is None:
+        return
+    if int(existing.data_ptr()) != int(tensor.data_ptr()):
+        buffers[key] = None
+
+
+def _dcut_selected_probs_for_output(logits, output):
+    """Gather probabilities for the exact draft IDs returned to vLLM."""
+    flat_token_ids = output.reshape(-1)
+    n_tokens = min(int(logits.shape[0]), int(flat_token_ids.numel()))
+    selected_probs = _dcut_selected_token_probs(
+        logits[:n_tokens],
+        flat_token_ids[:n_tokens],
+    )
+    if selected_probs.numel() == output.numel():
+        selected_probs = selected_probs.view(output.shape)
+    return selected_probs.float().contiguous()
+
+
+def _dcut_register_graph_selected_probs(
+    owner,
+    descriptor,
+    output,
+    selected_probs,
+) -> bool:
+    """Register the probability tensor retained by one captured draft graph."""
+    if selected_probs is None:
+        return False
+
+    if descriptor is not None:
+        by_descriptor = getattr(
+            owner,
+            "_dcut_graph_selected_probs_by_descriptor",
+            None,
+        )
+        if by_descriptor is None:
+            by_descriptor = {}
+            owner._dcut_graph_selected_probs_by_descriptor = by_descriptor
+        by_descriptor[descriptor] = selected_probs
+
+    _dcut_store_unique_graph_buffer(
+        owner,
+        "_dcut_graph_selected_probs_by_output_ptr",
+        int(output.data_ptr()),
+        selected_probs,
+    )
+    _dcut_store_unique_graph_buffer(
+        owner,
+        "_dcut_graph_selected_probs_by_shape",
+        tuple(output.shape),
+        selected_probs,
+    )
+    _dcut_store_unique_graph_buffer(
+        owner,
+        "_dcut_graph_selected_probs_by_numel",
+        int(output.numel()),
+        selected_probs,
+    )
+    owner._dcut_graph_selected_probs_ready = True
+    return True
+
+
+def _dcut_graph_owner_from_runnable(runnable):
+    """Return the draft proposer owning an ACLGraph bound runnable."""
+    owner = getattr(runnable, "__self__", None)
+    if owner is None:
+        return None
+    if not hasattr(owner, "compute_draft_token_ids"):
+        return None
+    if not hasattr(owner, "_run_merged_draft"):
+        return None
+    return owner
+
+
+def _dcut_prepare_dflash_graph_context(
+    owner,
+    descriptor,
+    graph_context_tokens,
+    capture_pending: bool,
+):
+    """Mask the fixed-shape DFlash context tail before capture/replay."""
+    if getattr(owner, "method", None) != "dflash" or descriptor is None:
+        return None
+
+    slot_mapping = getattr(owner, "_context_slot_mapping_buffer", None)
+    actual_context = getattr(owner, "_dflash_num_context", None)
+    if slot_mapping is None or actual_context is None:
+        return None
+
+    actual_context = int(actual_context)
+    captured_by_descriptor = getattr(
+        owner,
+        "_dcut_dflash_context_tokens_by_descriptor",
+        None,
+    )
+    if captured_by_descriptor is None:
+        captured_by_descriptor = {}
+        owner._dcut_dflash_context_tokens_by_descriptor = (
+            captured_by_descriptor
+        )
+
+    restore_context = None
+    if capture_pending:
+        if graph_context_tokens is None:
+            return None
+        captured_context = min(
+            int(graph_context_tokens),
+            int(slot_mapping.shape[0]),
+        )
+        captured_by_descriptor[descriptor] = captured_context
+        restore_context = actual_context
+    else:
+        captured_context = captured_by_descriptor.get(descriptor)
+        if captured_context is None:
+            return None
+
+    if actual_context < 0 or actual_context > captured_context:
+        raise RuntimeError(
+            "D-Cut DFlash graph context exceeds its captured length: "
+            f"actual={actual_context}, captured={captured_context}, "
+            f"descriptor={descriptor}."
+        )
+
+    if capture_pending:
+        owner._dflash_num_context = captured_context
+
+    tail_masked = actual_context < captured_context
+    if tail_masked:
+        # Keep stale graph-tail slots out of the replayed DFlash context.
+        slot_mapping[actual_context:captured_context].fill_(
+            PADDING_SLOT_ID
+        )
+        if not getattr(
+            owner,
+            "_dcut_logged_dflash_context_padding",
+            False,
+        ):
+            logger.warning(
+                "D-Cut: masked the DFlash FULL-graph context tail with "
+                "a standalone fill (actual=%d captured=%d descriptor=%s).",
+                actual_context,
+                captured_context,
+                descriptor,
+            )
+            owner._dcut_logged_dflash_context_padding = True
+
+    owner._dcut_last_dflash_context_actual = actual_context
+    owner._dcut_last_dflash_context_captured = captured_context
+    owner._dcut_last_dflash_context_tail_masked = tail_masked
+    return restore_context
+
+
+def _patch_aclgraph_descriptor_tracking() -> None:
+    """Expose the exact draft ``BatchDescriptor`` selected for replay."""
+    from vllm.forward_context import get_forward_context
+    from vllm_ascend.compilation.acl_graph import ACLGraphWrapper
+
+    if getattr(ACLGraphWrapper, "_dcut_descriptor_tracking_patched", False):
+        return
+
+    original_init = ACLGraphWrapper.__init__
+    original_call = ACLGraphWrapper.__call__
+
+    def __init__(graph_wrapper, runnable, *args, **kwargs):
+        original_init(graph_wrapper, runnable, *args, **kwargs)
+        proposer = _dcut_graph_owner_from_runnable(runnable)
+        if proposer is not None:
+            graph_wrapper.__dict__["_dcut_descriptor_owner"] = proposer
+            proposer._dcut_graph_owner_attached = True
+
+    def __call__(graph_wrapper, *args, **kwargs):
+        forward_context = get_forward_context()
+        descriptor = getattr(forward_context, "batch_descriptor", None)
+        proposer = graph_wrapper.__dict__.get("_dcut_descriptor_owner")
+        if proposer is None:
+            runnable = graph_wrapper.__dict__.get("runnable")
+            proposer = _dcut_graph_owner_from_runnable(runnable)
+            if proposer is not None:
+                graph_wrapper.__dict__["_dcut_descriptor_owner"] = proposer
+                proposer._dcut_graph_owner_attached = True
+        capture_pending = False
+        graph_active = False
+        if proposer is not None:
+            proposer._dcut_current_graph_descriptor = descriptor
+            runtime_mode = getattr(
+                forward_context,
+                "cudagraph_runtime_mode",
+                None,
+            )
+            entries = getattr(graph_wrapper, "concrete_aclgraph_entries", {})
+            entry = entries.get(descriptor)
+            graph_active = runtime_mode == getattr(
+                graph_wrapper,
+                "runtime_mode",
+                None,
+            )
+            capture_pending = graph_active and (
+                entry is None or getattr(entry, "aclgraph", None) is None
+            )
+
+        restore_dflash_context = None
+        if proposer is not None and graph_active:
+            restore_dflash_context = _dcut_prepare_dflash_graph_context(
+                proposer,
+                descriptor,
+                kwargs.get("num_input_tokens"),
+                capture_pending,
+            )
+        try:
+            output = original_call(graph_wrapper, *args, **kwargs)
+        finally:
+            if restore_dflash_context is not None:
+                proposer._dflash_num_context = restore_dflash_context
+        if proposer is None or not capture_pending:
+            return output
+
+        selected_probs = getattr(proposer, "_last_selected_probs", None)
+        if _dcut_register_graph_selected_probs(
+            proposer,
+            descriptor,
+            output,
+            selected_probs,
+        ):
+            if not getattr(
+                proposer,
+                "_dcut_logged_graph_prob_capture",
+                False,
+            ):
+                logger.warning(
+                    "D-Cut: registered output-aligned draft probs directly after "
+                    "ACLGraph capture (descriptor=%s output_shape=%s "
+                    "probs_shape=%s).",
+                    descriptor,
+                    tuple(output.shape),
+                    tuple(selected_probs.shape),
+                )
+                proposer._dcut_logged_graph_prob_capture = True
+        elif not getattr(
+            proposer,
+            "_dcut_logged_missing_graph_prob_capture",
+            False,
+        ):
+            logger.warning(
+                "D-Cut: ACLGraph capture completed without a selected-prob "
+                "tensor (descriptor=%s needs=%s method=%s).",
+                descriptor,
+                getattr(proposer, "needs_draft_probs", False),
+                getattr(proposer, "method", None),
+            )
+            proposer._dcut_logged_missing_graph_prob_capture = True
+        return output
+
+    ACLGraphWrapper.__init__ = __init__
+    ACLGraphWrapper.__call__ = __call__
+    ACLGraphWrapper._dcut_descriptor_tracking_patched = True
+
+
+def _patch_proposer() -> None:
+    """Patch the Ascend spec-decode proposer to expose selected draft probs.
+
+    vLLM 0.23 Ascend proposers sample through compute_draft_token_ids.
+    Patch the concrete method owner so DFlash and parallel draft-model
+    proposers expose the selected-token probabilities used by D-Cut.
+    """
+    from vllm.forward_context import get_forward_context
+    from vllm.v1.spec_decode.llm_base_proposer import SpecDecodeBaseProposer
+
+    _patch_aclgraph_descriptor_tracking()
+
+    # Collect the concrete Ascend proposers that can run D-Cut (dflash / PARD).
+    proposer_classes = []
+    try:
+        from vllm_ascend.spec_decode.dflash_proposer import AscendDflashProposer
+        proposer_classes.append(AscendDflashProposer)
+    except Exception as e:  # pragma: no cover
+        logger.warning("D-Cut: could not import AscendDflashProposer: %s", e)
+    try:
+        from vllm_ascend.spec_decode.draft_proposer import AscendDraftModelProposer
+        proposer_classes.append(AscendDraftModelProposer)
+    except Exception:  # PARD path is optional
+        pass
+
+    # Helper functions live on the shared base so every proposer can call them.
+    if not getattr(SpecDecodeBaseProposer, "_dcut_helpers", False):
+        @staticmethod
+        def _should_collect_draft_probs(self):
+            return _dcut_should_collect_draft_probs(self)
+
+        @staticmethod
+        def _gather_selected_probs(logits, token_ids, full_probs):
+            idx = token_ids.long().unsqueeze(-1)
+            if full_probs is not None:
+                return full_probs.gather(-1, idx).squeeze(-1)
+            return _dcut_selected_token_probs(logits, token_ids)
+
+        @staticmethod
+        def _greedy_sample_with_selected_probs(logits):
+            return _dcut_greedy_sample_with_selected_probs(logits)
+
+        def take_last_selected_probs(self):
+            return getattr(self, "_last_selected_probs", None)
+
+        SpecDecodeBaseProposer.needs_draft_probs = bool(os.environ.get(ENV_CONFIG))
+        SpecDecodeBaseProposer._last_selected_probs = None
+        SpecDecodeBaseProposer._should_collect_draft_probs = (
+            _should_collect_draft_probs
+        )
+        SpecDecodeBaseProposer._gather_selected_probs = _gather_selected_probs
+        SpecDecodeBaseProposer._greedy_sample_with_selected_probs = (
+            _greedy_sample_with_selected_probs
+        )
+        SpecDecodeBaseProposer.take_last_selected_probs = take_last_selected_probs
+        SpecDecodeBaseProposer._dcut_helpers = True
+
+    compute_owners = []
+    for pc in proposer_classes:
+        for klass in pc.__mro__:
+            if "compute_draft_token_ids" in klass.__dict__:
+                if klass not in compute_owners:
+                    compute_owners.append(klass)
+                break
+
+    for owner in compute_owners:
+        if getattr(owner, "_dcut_compute_patched", False):
+            continue
+        _orig_compute = owner.compute_draft_token_ids
+
+        def _make_compute_wrapper(orig):
+            def compute_draft_token_ids(self, hidden_states):
+                self._last_selected_probs = None
+                if not type(self)._should_collect_draft_probs(self):
+                    return orig(self, hidden_states)
+                try:
+                    logits = self.model.logits_processor(
+                        self.model.lm_head, hidden_states
+                    )
+                    logits = logits.contiguous()
+                    next_token, selected_probs = (
+                        type(self)._greedy_sample_with_selected_probs(logits)
+                    )
+                    # Keep this flat here. Ascend may pad sample_hidden_states for
+                    # lmhead TP; the runner slices and reshapes using real batch size.
+                    self._last_selected_probs = selected_probs.float().contiguous()
+
+                    draft_map = getattr(self.model, "draft_id_to_target_id", None)
+                    if draft_map is None:
+                        return next_token
+                    bias = torch.index_select(
+                        draft_map, dim=0, index=next_token.view(-1)
+                    ).view(next_token.shape)
+                    return next_token + bias
+                except Exception as e:  # pragma: no cover - defensive
+                    logger.warning(
+                        "D-Cut: gather selected probs in compute_draft_token_ids "
+                        "failed: %s",
+                        e,
+                    )
+                    self._last_selected_probs = None
+                    return orig(self, hidden_states)
+
+            return compute_draft_token_ids
+
+        owner.compute_draft_token_ids = _make_compute_wrapper(_orig_compute)
+        owner._dcut_compute_patched = True
+        logger.info(
+            "D-Cut: patched compute_draft_token_ids on %s.", owner.__name__
+        )
+
+    run_merged_owners = []
+    for pc in proposer_classes:
+        for klass in pc.__mro__:
+            if "_run_merged_draft" in klass.__dict__:
+                if klass not in run_merged_owners:
+                    run_merged_owners.append(klass)
+                break
+
+    for owner in run_merged_owners:
+        if getattr(owner, "_dcut_run_merged_patched", False):
+            continue
+        original_run_merged = owner._run_merged_draft
+
+        def _make_run_merged_wrapper(orig):
+            def _run_merged_draft(self, *args, **kwargs):
+                in_graph_capture = _dcut_in_graph_capture()
+                self._dcut_last_draft_ran_python = True
+                self._dcut_last_logits_for_probs = None
+                self._last_selected_probs = None
+                out = orig(self, *args, **kwargs)
+                if not type(self)._should_collect_draft_probs(self):
+                    return out
+
+                selected_probs = getattr(self, "_last_selected_probs", None)
+                logits = getattr(self, "_dcut_last_logits_for_probs", None)
+                if selected_probs is None and logits is not None:
+                    try:
+                        # Use the IDs actually returned by the proposer. This
+                        # is the PIECEWISE behavior and keeps FULL aligned when
+                        # DFlash applies vocab remapping, padding, or tie breaks.
+                        selected_probs = _dcut_selected_probs_for_output(
+                            logits,
+                            out,
+                        )
+                        self._last_selected_probs = selected_probs
+                    except Exception as e:  # pragma: no cover - defensive
+                        logger.warning(
+                            "D-Cut: output-aligned selected-prob capture "
+                            "failed: %s",
+                            e,
+                        )
+                        self._last_selected_probs = None
+                        selected_probs = None
+                    finally:
+                        self._dcut_last_logits_for_probs = None
+                        logits = None
+                if in_graph_capture:
+                    # Bind the probability tensor to the exact graph descriptor.
+                    # Replay updates these tensors without running this Python
+                    # wrapper again. Output address, shape and numel are retained
+                    # only as compatibility fallbacks when they are unique.
+                    if selected_probs is not None:
+                        forward_context = get_forward_context()
+                        self._dcut_current_graph_descriptor = getattr(
+                            forward_context,
+                            "batch_descriptor",
+                            None,
+                        )
+                        runnable = getattr(self, "_runnable", None)
+                        runnable_state = getattr(runnable, "__dict__", None)
+                        if (
+                            isinstance(runnable_state, dict)
+                            and "concrete_aclgraph_entries" in runnable_state
+                        ):
+                            runnable_state["_dcut_descriptor_owner"] = self
+                        descriptor = getattr(
+                            self,
+                            "_dcut_current_graph_descriptor",
+                            None,
+                        )
+                        if descriptor is not None:
+                            by_descriptor = getattr(
+                                self,
+                                "_dcut_graph_selected_probs_by_descriptor",
+                                None,
+                            )
+                            if by_descriptor is None:
+                                by_descriptor = {}
+                                self._dcut_graph_selected_probs_by_descriptor = (
+                                    by_descriptor
+                                )
+                            by_descriptor[descriptor] = selected_probs
+                        _dcut_store_unique_graph_buffer(
+                            self,
+                            "_dcut_graph_selected_probs_by_output_ptr",
+                            int(out.data_ptr()),
+                            selected_probs,
+                        )
+                        _dcut_store_unique_graph_buffer(
+                            self,
+                            "_dcut_graph_selected_probs_by_shape",
+                            tuple(out.shape),
+                            selected_probs,
+                        )
+                        _dcut_store_unique_graph_buffer(
+                            self,
+                            "_dcut_graph_selected_probs_by_numel",
+                            int(out.numel()),
+                            selected_probs,
+                        )
+                        self._dcut_graph_selected_probs_ready = True
+                        if not getattr(
+                            self,
+                            "_dcut_logged_graph_prob_capture",
+                            False,
+                        ):
+                            logger.warning(
+                                "D-Cut: captured output-aligned draft probs in ACLGraph "
+                                "(descriptor=%s output_shape=%s probs_shape=%s).",
+                                descriptor,
+                                tuple(out.shape),
+                                tuple(selected_probs.shape),
+                            )
+                            self._dcut_logged_graph_prob_capture = True
+
+                    # Retain logits only as a compatibility fallback for a
+                    # proposer path that could not produce probabilities while
+                    # being captured.
+                    if logits is not None:
+                        descriptor = getattr(
+                            self,
+                            "_dcut_current_graph_descriptor",
+                            None,
+                        )
+                        if descriptor is not None:
+                            by_descriptor = getattr(
+                                self,
+                                "_dcut_graph_logits_for_probs_by_descriptor",
+                                None,
+                            )
+                            if by_descriptor is None:
+                                by_descriptor = {}
+                                self._dcut_graph_logits_for_probs_by_descriptor = (
+                                    by_descriptor
+                                )
+                            by_descriptor[descriptor] = logits
+                        _dcut_store_unique_graph_buffer(
+                            self,
+                            "_dcut_graph_logits_for_probs_by_shape",
+                            tuple(out.shape),
+                            logits,
+                        )
+                        _dcut_store_unique_graph_buffer(
+                            self,
+                            "_dcut_graph_logits_for_probs_by_numel",
+                            int(out.numel()),
+                            logits,
+                        )
+                        self._dcut_graph_logits_for_probs_ready = True
+                    if (
+                        selected_probs is None
+                        and not getattr(
+                            self,
+                            "_dcut_logged_missing_graph_prob_capture",
+                            False,
+                        )
+                    ):
+                        logger.warning(
+                            "D-Cut: ACLGraph capture produced no selected draft "
+                            "probs (needs=%s method=%s parallel=%s logits=%s "
+                            "descriptor=%s).",
+                            getattr(self, "needs_draft_probs", False),
+                            getattr(self, "method", None),
+                            getattr(self, "parallel_drafting", False),
+                            logits is not None,
+                            getattr(
+                                self,
+                                "_dcut_current_graph_descriptor",
+                                None,
+                            ),
+                        )
+                        self._dcut_logged_missing_graph_prob_capture = True
+                    return out
+
+                return out
+
+            return _run_merged_draft
+
+        owner._run_merged_draft = _make_run_merged_wrapper(
+            original_run_merged
+        )
+        owner._dcut_run_merged_patched = True
+        logger.info(
+            "D-Cut: patched _run_merged_draft on %s.",
+            owner.__name__,
+        )

--- a/dcut/patch_runner.py
+++ b/dcut/patch_runner.py
@@ -1,0 +1,1732 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Patch NPUModelRunner for D-Cut adaptive verify."""
+from __future__ import annotations
+
+import os
+
+import torch
+
+from vllm.distributed import get_pp_group, get_tp_group, get_world_group
+
+from .controller import _dcut_init_controller, _dcut_enable_drafter_probs
+from .dcut_profile import _adaptive_profile_run
+from .draft_profile import _adaptive_profile_draft_run
+from .gdn_buffers import (
+    _dcut_prepare_gdn_eager_state,
+    _dcut_prepare_gdn_graph_capture,
+    _dcut_prepare_gdn_piecewise_replay,
+)
+from .globals import ENV_DISABLE, ENV_FULL_DECODE_ONLY, logger
+from .patch_gdn_v023 import _dcut_gdn_has_prefill
+from .patch_full_graph import _dcut_full_decode_multishape_enabled
+from .patch_piecewise import _is_enabled as _gdn_piecewise_graph_enabled
+from .probs import (
+    _dcut_bypass_prob_capture_for_prefill,
+    _dcut_prepare_prob_capture,
+    _dcut_queue_probs,
+    _maybe_process_adaptive_probs,
+    profile_adaptive_cost,
+)
+from .truncate import (
+    _dcut_add_zero_draft_handoffs,
+    _dcut_apply_zero_prob_recompute_caps,
+    _dcut_has_prefill,
+    _dcut_is_recompute_handoff,
+    _dcut_recompute_placeholder_req_ids,
+    _dcut_truncate,
+    _dcut_zero_draft_kv_handoff_req_ids,
+)
+from .utils import _env_flag
+
+ENV_DEBUG_STATS = "VLLM_DCUT_DEBUG_STATS"
+DUMMY_FIA_KV_SEQ_LEN = 1
+
+
+def _dcut_ragged_full_fia_rows(
+    actual_tokens: int,
+    num_tokens_padded: int,
+    num_reqs: int,
+    request_capacity: int,
+) -> int:
+    """Return live FIA rows: real requests plus one token-padding request."""
+    actual_tokens = int(actual_tokens)
+    num_tokens_padded = int(num_tokens_padded)
+    num_reqs = int(num_reqs)
+    request_capacity = int(request_capacity)
+    if num_reqs > request_capacity:
+        raise RuntimeError(
+            "D-Cut ragged FULL request count exceeds graph capacity: "
+            f"requests={num_reqs}, capacity={request_capacity}"
+        )
+    if actual_tokens > num_tokens_padded:
+        raise RuntimeError(
+            "D-Cut ragged FULL query length exceeds token bucket: "
+            f"actual={actual_tokens}, padded={num_tokens_padded}"
+        )
+    return num_reqs + int(actual_tokens < num_tokens_padded)
+
+
+def _dcut_pad_fia_dummy_seq_len(
+    metadata,
+    num_reqs: int,
+    fia_rows: int,
+) -> None:
+    """Give the optional FIA token-padding request a valid dummy KV length."""
+    dummy_start = int(num_reqs)
+    dummy_stop = int(fia_rows)
+    if dummy_stop not in (dummy_start, dummy_start + 1):
+        raise RuntimeError(
+            "D-Cut ragged FULL FIA must expose only live requests and at "
+            f"most one padding request: requests={dummy_start}, rows={dummy_stop}"
+        )
+    if dummy_start == dummy_stop:
+        return
+
+    seq_lens_list = getattr(metadata, "seq_lens_list", None)
+    if seq_lens_list is None or len(seq_lens_list) < dummy_stop:
+        length = None if seq_lens_list is None else len(seq_lens_list)
+        raise RuntimeError(
+            "D-Cut ragged FULL FIA seq-lens list is shorter than its live "
+            f"request rows: length={length}, rows={dummy_stop}"
+        )
+    seq_lens_list[dummy_start:dummy_stop] = [DUMMY_FIA_KV_SEQ_LEN]
+
+    updated_tensors = set()
+    for field in ("seq_lens", "seq_lens_cpu"):
+        seq_lens = getattr(metadata, field, None)
+        if seq_lens is None or id(seq_lens) in updated_tensors:
+            continue
+        if int(seq_lens.shape[0]) < dummy_stop:
+            raise RuntimeError(
+                "D-Cut ragged FULL FIA seq-lens tensor is shorter than its "
+                f"live request rows: field={field}, "
+                f"shape={tuple(seq_lens.shape)}, rows={dummy_stop}"
+            )
+        seq_lens[dummy_start:dummy_stop].fill_(DUMMY_FIA_KV_SEQ_LEN)
+        updated_tensors.add(id(seq_lens))
+
+
+def _dcut_pad_fixed_drafter_fia_seq_lens(
+    metadata,
+    num_reqs: int,
+    request_capacity: int,
+) -> None:
+    """Keep the uniform drafter's fixed FIA request axis valid."""
+    inactive_start = int(num_reqs)
+    # The fixed axis contains request_capacity rows plus the final FIA-only
+    # token-padding row. Every zero-query row still needs a positive KV len.
+    inactive_stop = int(request_capacity) + 1
+    if inactive_start >= inactive_stop:
+        return
+
+    seq_lens_list = getattr(metadata, "seq_lens_list", None)
+    if seq_lens_list is None or len(seq_lens_list) < inactive_stop:
+        length = None if seq_lens_list is None else len(seq_lens_list)
+        raise RuntimeError(
+            "D-Cut FULL drafter FIA seq-lens list is shorter than its "
+            f"request capacity: length={length}, capacity={inactive_stop}"
+        )
+    seq_lens_list[inactive_start:inactive_stop] = [
+        DUMMY_FIA_KV_SEQ_LEN
+    ] * (inactive_stop - inactive_start)
+
+    updated_tensors = set()
+    for field in ("seq_lens", "seq_lens_cpu"):
+        seq_lens = getattr(metadata, field, None)
+        if seq_lens is None or id(seq_lens) in updated_tensors:
+            continue
+        if int(seq_lens.shape[0]) < inactive_stop:
+            raise RuntimeError(
+                "D-Cut FULL drafter FIA seq-lens tensor is shorter than its "
+                f"request capacity: field={field}, "
+                f"shape={tuple(seq_lens.shape)}, capacity={inactive_stop}"
+            )
+        seq_lens[inactive_start:inactive_stop].fill_(
+            DUMMY_FIA_KV_SEQ_LEN
+        )
+        updated_tensors.add(id(seq_lens))
+
+
+def _dcut_debug_rank_info() -> dict[str, int | bool]:
+    """Return stable distributed identifiers for single-writer debug logs."""
+    world_group = get_world_group()
+    world_rank = int(world_group.rank)
+    return {
+        "world_rank": world_rank,
+        "tp_rank": int(get_tp_group().rank_in_group),
+        "pp_rank": int(get_pp_group().rank_in_group),
+        "is_writer": world_rank == 0,
+    }
+
+
+def _dcut_adaptive_handoff_graph_enabled(runner) -> bool:
+    """Return whether recompute placeholders may join adaptive graph decode."""
+    mode = getattr(
+        getattr(runner, "compilation_config", None),
+        "cudagraph_mode",
+        None,
+    )
+    mode_name = getattr(mode, "name", mode)
+    if mode_name == "PIECEWISE":
+        return True
+    return bool(
+        mode_name == "FULL_DECODE_ONLY"
+        and _dcut_full_decode_multishape_enabled(runner.vllm_config)
+    )
+
+
+def _dcut_initial_handoff_spec_rows(runner) -> tuple[int, ...]:
+    """Map first-step handoff requests to compact speculative GDN rows."""
+    handoff_req_ids = getattr(
+        runner,
+        "_dcut_zero_draft_handoffs_for_proposal",
+        frozenset(),
+    )
+    if not handoff_req_ids:
+        return ()
+
+    draft_lens = getattr(
+        getattr(runner, "num_decode_draft_tokens", None),
+        "np",
+        None,
+    )
+    input_batch = getattr(runner, "input_batch", None)
+    if draft_lens is None or input_batch is None:
+        return ()
+
+    num_reqs = int(input_batch.num_reqs)
+    compact_spec_row = 0
+    rows = []
+    for req_index, req_id in enumerate(input_batch.req_ids[:num_reqs]):
+        if int(draft_lens[req_index]) < 0:
+            continue
+        if req_id in handoff_req_ids:
+            rows.append(compact_spec_row)
+        compact_spec_row += 1
+    return tuple(rows)
+
+
+def _dcut_execute_with_gdn_prefill_route(
+    runner,
+    execute_model,
+    scheduler_output,
+    intermediate_tensors,
+    has_prefill: bool,
+):
+    """Expose real prefill to GDN without overriding the outer graph mode."""
+    attr = "_dcut_gdn_scheduler_has_prefill"
+    had_previous = hasattr(runner, attr)
+    previous = getattr(runner, attr, None)
+    setattr(runner, attr, bool(has_prefill))
+    try:
+        return execute_model(
+            runner,
+            scheduler_output,
+            intermediate_tensors,
+        )
+    finally:
+        if had_previous:
+            setattr(runner, attr, previous)
+        elif hasattr(runner, attr):
+            delattr(runner, attr)
+
+
+def _dcut_execute_native_recompute_handoff(
+    runner,
+    execute_model,
+    scheduler_output,
+    intermediate_tensors,
+):
+    """Run a recompute handoff through stock dispatch and GDN metadata."""
+    runner_attr = "_dcut_recompute_handoff_active"
+    builder_attr = "_dcut_force_native_gdn_metadata"
+    had_runner_attr = hasattr(runner, runner_attr)
+    previous_runner_value = getattr(runner, runner_attr, None)
+    builder_states = []
+    seen_builders = set()
+    for attention_groups in getattr(runner, "attn_groups", ()):
+        for attention_group in attention_groups:
+            get_builder = getattr(
+                attention_group,
+                "get_metadata_builder",
+                None,
+            )
+            if get_builder is None:
+                continue
+            builder = get_builder(0)
+            if id(builder) in seen_builders:
+                continue
+            attach = getattr(
+                type(builder),
+                "_attach_spec_decode_metadata",
+                None,
+            )
+            if not getattr(attach, "_dcut_patched", False):
+                continue
+            seen_builders.add(id(builder))
+            builder_states.append(
+                (
+                    builder,
+                    hasattr(builder, builder_attr),
+                    getattr(builder, builder_attr, None),
+                )
+            )
+            setattr(builder, builder_attr, True)
+
+    setattr(runner, runner_attr, True)
+    try:
+        # The native GDN core and its native metadata must be selected as a
+        # pair. Placeholder speculative tokens are not prompt prefill, but the
+        # existing boolean route is the runner-to-core native-path signal.
+        return _dcut_execute_with_gdn_prefill_route(
+            runner,
+            execute_model,
+            scheduler_output,
+            intermediate_tensors,
+            True,
+        )
+    finally:
+        for builder, had_attr, previous_value in reversed(builder_states):
+            if had_attr:
+                setattr(builder, builder_attr, previous_value)
+            elif hasattr(builder, builder_attr):
+                delattr(builder, builder_attr)
+        if had_runner_attr:
+            setattr(runner, runner_attr, previous_runner_value)
+        elif hasattr(runner, runner_attr):
+            delattr(runner, runner_attr)
+
+
+def _dcut_set_full_gdn_metadata_route(runner, use_native: bool) -> None:
+    """Pair each FULL descriptor with the matching GDN metadata contract."""
+    seen_builders = set()
+    for attention_groups in getattr(runner, "attn_groups", ()):
+        for attention_group in attention_groups:
+            get_builder = getattr(
+                attention_group,
+                "get_metadata_builder",
+                None,
+            )
+            if get_builder is None:
+                continue
+            builder = get_builder(0)
+            if id(builder) in seen_builders:
+                continue
+            attach = getattr(
+                type(builder),
+                "_attach_spec_decode_metadata",
+                None,
+            )
+            if not getattr(attach, "_dcut_patched", False):
+                continue
+            seen_builders.add(id(builder))
+            builder._dcut_force_native_gdn_metadata = bool(use_native)
+
+
+def _dcut_is_ragged_full_capture(
+    runner,
+    cudagraph_runtime_mode,
+    uniform_decode,
+    is_graph_capturing,
+) -> bool:
+    """Return whether this dummy run captures a target-only ragged FULL key."""
+    runtime_mode_name = getattr(
+        cudagraph_runtime_mode,
+        "name",
+        cudagraph_runtime_mode,
+    )
+    return bool(
+        is_graph_capturing
+        and not uniform_decode
+        and runtime_mode_name == "FULL"
+        and _dcut_full_decode_multishape_enabled(runner.vllm_config)
+    )
+
+
+def _dcut_call_dummy_without_drafter(
+    runner,
+    dummy_run,
+    num_tokens,
+    args,
+    kwargs,
+    skip_drafter,
+):
+    """Run target dummy capture while suppressing only the drafter call."""
+    if not skip_drafter:
+        return dummy_run(runner, num_tokens, *args, **kwargs)
+
+    drafter = getattr(runner, "drafter", None)
+    if drafter is None:
+        return dummy_run(runner, num_tokens, *args, **kwargs)
+
+    runner.drafter = None
+    try:
+        return dummy_run(runner, num_tokens, *args, **kwargs)
+    finally:
+        runner.drafter = drafter
+
+
+def _dcut_piecewise_capture_dummy_enabled(
+    runner,
+    cudagraph_runtime_mode,
+    is_profile: bool = False,
+    is_graph_capturing: bool = False,
+) -> bool:
+    """Return whether this dummy run must capture the spec GDN branch."""
+    from vllm.config import CUDAGraphMode
+
+    compilation_config = getattr(runner, "compilation_config", None)
+    graph_enabled = bool(
+        getattr(
+            runner,
+            "_dcut_gdn_piecewise_enabled",
+            _gdn_piecewise_graph_enabled(),
+        )
+    )
+    return (
+        graph_enabled
+        and not is_profile
+        and is_graph_capturing
+        and getattr(runner, "_dcut_in_real_warmup", False)
+        and getattr(runner, "pcp_size", 1) == 1
+        and getattr(runner, "dcp_size", 1) == 1
+        and getattr(compilation_config, "cudagraph_mode", None)
+        == CUDAGraphMode.PIECEWISE
+        and cudagraph_runtime_mode == CUDAGraphMode.PIECEWISE
+    )
+
+
+def _patch_runner() -> None:
+    import vllm_ascend.worker.model_runner_v1 as m
+
+    R = m.NPUModelRunner
+    if getattr(R, "_dcut_patched", False):
+        return
+
+    _orig_init = R.__init__
+
+    def __init__(self, *a, **k):
+        _orig_init(self, *a, **k)
+        self._dcut_gdn_piecewise_enabled = (
+            _gdn_piecewise_graph_enabled()
+            and getattr(self, "_has_gdn", False)
+            and getattr(
+                self.compilation_config.cudagraph_mode,
+                "name",
+                None,
+            )
+            == "PIECEWISE"
+        )
+        try:
+            _dcut_init_controller(self)
+        except Exception as e:
+            logger.error("D-Cut init failed; running vanilla: %s", e)
+            self._verify_adaptive_controller = None
+
+    _orig_exec = R.execute_model
+    _orig_model_forward = R._model_forward
+    _orig_dummy_run = R._dummy_run
+    _orig_should_build_dummy = R._should_build_dummy_attn_metadata
+    _orig_determine = R._determine_batch_execution_and_padding
+    _orig_build_attention_metadata = R._build_attention_metadata
+    _orig_pad_query_start_loc_for_fia = R._pad_query_start_loc_for_fia
+
+    def _determine_batch_execution_and_padding(
+        self,
+        num_tokens,
+        num_reqs,
+        num_scheduled_tokens_np,
+        max_num_scheduled_tokens,
+        use_cascade_attn,
+        allow_microbatching=False,
+        force_eager=False,
+        force_uniform_decode=None,
+        force_has_lora=None,
+        force_num_active_loras=None,
+        num_encoder_reqs=0,
+    ):
+        from vllm.config import CUDAGraphMode
+
+        full_multishape = (
+            _dcut_full_decode_multishape_enabled(self.vllm_config)
+            and self.compilation_config.cudagraph_mode
+            == CUDAGraphMode.FULL_DECODE_ONLY
+        )
+        if (
+            full_multishape
+            and getattr(self, "_dcut_ragged_full_capture_dummy", False)
+            and num_reqs > 0
+        ):
+            # Stock mixed dummy construction puts the entire remainder in the
+            # final request (for example 128 tokens / 96 requests becomes
+            # 95x1 + 1x33). That captures a prefill-shaped FIA branch and then
+            # replays it for a pure speculative batch whose query lengths are
+            # all <= num_spec + 1. Keep the same request capacity and token
+            # count, but capture the representative pure-decode geometry.
+            base, remainder = divmod(int(num_tokens), int(num_reqs))
+            num_scheduled_tokens_np[:num_reqs] = base
+            if remainder:
+                num_scheduled_tokens_np[:remainder] += 1
+            capture_max_query_len = int(
+                num_scheduled_tokens_np[:num_reqs].max()
+            )
+            if capture_max_query_len > int(self.uniform_decode_query_len):
+                raise RuntimeError(
+                    "D-Cut ragged FULL capture cannot represent the token "
+                    "bucket with speculative query lengths: "
+                    f"tokens={num_tokens}, requests={num_reqs}, "
+                    f"max_query_len={self.uniform_decode_query_len}"
+                )
+            logger.warning(
+                "D-Cut: ragged FULL capture uses pure-decode dummy "
+                "token_bucket=%d request_capacity=%d query_len=[%d,%d] "
+                "fia_rows=%d.",
+                num_tokens,
+                num_reqs,
+                int(num_scheduled_tokens_np[:num_reqs].min()),
+                capture_max_query_len,
+                num_reqs + 1,
+            )
+
+        if (
+            full_multishape
+            and getattr(self, "_dcut_recompute_handoff_active", False)
+        ):
+            # Stock FULL_DECODE_ONLY only graphs a rectangular decode batch.
+            # Do not let D-Cut's added ragged keys capture a recompute handoff.
+            expected_query_len = self.uniform_decode_query_len
+            computed = self.input_batch.num_computed_tokens_cpu[:num_reqs]
+            is_all_decode = bool(num_reqs > 0 and (computed > 0).all())
+            stock_uniform_decode = bool(
+                (is_all_decode if self.speculative_config else True)
+                and max_num_scheduled_tokens == expected_query_len
+                and num_tokens == expected_query_len * num_reqs
+            )
+            if not stock_uniform_decode:
+                force_eager = True
+        elif full_multishape and force_uniform_decode is None:
+            computed = self.input_batch.num_computed_tokens_cpu[:num_reqs]
+            is_all_decode = bool(num_reqs > 0 and (computed > 0).all())
+            draft_lens = getattr(
+                getattr(self, "num_decode_draft_tokens", None),
+                "np",
+                None,
+            )
+            is_all_spec_decode = bool(
+                draft_lens is not None
+                and num_reqs > 0
+                and (draft_lens[:num_reqs] >= 0).all()
+            )
+            # Injected FULL keys are valid only for a pure speculative decode
+            # verifier. Prompt prefill, PD mixed and ordinary decode preserve
+            # the exact original eager route.
+            if not is_all_decode or not is_all_spec_decode:
+                force_eager = True
+
+        result = _orig_determine(
+            self,
+            num_tokens,
+            num_reqs,
+            num_scheduled_tokens_np,
+            max_num_scheduled_tokens,
+            use_cascade_attn,
+            allow_microbatching,
+            force_eager,
+            force_uniform_decode,
+            force_has_lora,
+            force_num_active_loras,
+            num_encoder_reqs,
+        )
+        runtime_mode, descriptor = result[:2]
+        self._dcut_nonuniform_full_batch = bool(
+            full_multishape
+            and runtime_mode == CUDAGraphMode.FULL
+            and not descriptor.uniform
+        )
+        self._dcut_ragged_full_request_capacity = (
+            int(descriptor.num_reqs)
+            if self._dcut_nonuniform_full_batch
+            and descriptor.num_reqs is not None
+            else None
+        )
+        if full_multishape:
+            _dcut_set_full_gdn_metadata_route(
+                self,
+                runtime_mode == CUDAGraphMode.FULL and descriptor.uniform,
+            )
+        return result
+
+    def _pad_query_start_loc_for_fia(
+        self,
+        query_start_loc,
+        num_tokens_padded,
+        num_reqs_padded,
+        num_reqs,
+        cudagraph_runtime_mode=None,
+        batch_desc_num_reqs=None,
+    ):
+        use_ragged_target_fia = bool(
+            getattr(self, "_dcut_nonuniform_full_batch", False)
+        )
+        use_fixed_drafter_fia = bool(
+            getattr(
+                self,
+                "_dcut_drafter_from_nonuniform_decode",
+                False,
+            )
+        )
+        if not use_ragged_target_fia and not use_fixed_drafter_fia:
+            return _orig_pad_query_start_loc_for_fia(
+                self,
+                query_start_loc,
+                num_tokens_padded,
+                num_reqs_padded,
+                num_reqs,
+                cudagraph_runtime_mode,
+                batch_desc_num_reqs,
+            )
+
+        from vllm_ascend.worker.utils import copy_snapshot_to_gpu
+
+        request_capacity = (
+            int(batch_desc_num_reqs)
+            if batch_desc_num_reqs is not None
+            else int(num_reqs_padded)
+        )
+        actual_tokens = int(query_start_loc.np[num_reqs])
+        fia_rows = _dcut_ragged_full_fia_rows(
+            actual_tokens,
+            num_tokens_padded,
+            num_reqs,
+            request_capacity,
+        )
+        if use_fixed_drafter_fia:
+            # The draft remains on its stock uniform FULL graph. Preserve that
+            # already-working request axis; only the ragged target FIA becomes
+            # live-row dynamic.
+            query_start_loc.np[
+                num_reqs + 1 : request_capacity + 1
+            ] = actual_tokens
+            query_start_loc.np[request_capacity + 1] = num_tokens_padded
+            self._dcut_fixed_drafter_fia_request_capacity = request_capacity
+            copy_snapshot_to_gpu(query_start_loc)
+            return request_capacity + 1
+
+        # GDN keeps its own fixed-capacity metadata buffers. Target FIA instead
+        # sees real request boundaries plus one dummy request only when the token
+        # bucket has padding. The graph key remains one-dimensional in tokens.
+        if fia_rows > num_reqs:
+            query_start_loc.np[num_reqs + 1] = num_tokens_padded
+        copy_snapshot_to_gpu(query_start_loc)
+        return fia_rows
+
+    def _build_attention_metadata(self, *args, **kwargs):
+        result = _orig_build_attention_metadata(self, *args, **kwargs)
+        use_ragged_target_fia = bool(
+            getattr(self, "_dcut_nonuniform_full_batch", False)
+        )
+        use_fixed_drafter_fia = bool(
+            getattr(
+                self,
+                "_dcut_drafter_from_nonuniform_decode",
+                False,
+            )
+        )
+        if not use_ragged_target_fia and not use_fixed_drafter_fia:
+            return result
+
+        attn_metadata = result[0]
+        if not isinstance(attn_metadata, dict):
+            return result
+        if use_fixed_drafter_fia:
+            request_capacity = getattr(
+                self, "_dcut_fixed_drafter_fia_request_capacity", None
+            )
+            route = "drafter"
+        else:
+            request_capacity = getattr(
+                self, "_dcut_ragged_full_request_capacity", None
+            )
+            route = "target"
+        if request_capacity is None:
+            return result
+        num_reqs = kwargs.get("num_reqs")
+        if num_reqs is None and len(args) > 1:
+            num_reqs = args[1]
+        if num_reqs is None:
+            raise RuntimeError(
+                "D-Cut ragged FULL attention metadata is missing num_reqs"
+            )
+        num_reqs = int(num_reqs)
+        max_fia_rows = int(request_capacity) + 1
+        persistent = getattr(
+            self, "_dcut_ragged_full_fia_block_tables", None
+        )
+        if persistent is None:
+            persistent = {}
+            self._dcut_ragged_full_fia_block_tables = persistent
+
+        normalized_metadata = set()
+        seen = {}
+        for prefix, metadata in attn_metadata.items():
+            block_tables = getattr(metadata, "block_tables", None)
+            if block_tables is None:
+                continue
+            actual_seq_lengths_q = getattr(
+                metadata, "actual_seq_lengths_q", None
+            )
+            if actual_seq_lengths_q is None:
+                continue
+            fia_rows = len(actual_seq_lengths_q)
+            if use_fixed_drafter_fia:
+                if fia_rows != max_fia_rows:
+                    raise RuntimeError(
+                        "D-Cut FULL drafter FIA request axis changed: "
+                        f"rows={fia_rows}, expected={max_fia_rows}"
+                    )
+            elif not num_reqs <= fia_rows <= num_reqs + 1:
+                raise RuntimeError(
+                    "D-Cut ragged FULL FIA request rows do not match the live "
+                    f"batch: requests={num_reqs}, rows={fia_rows}"
+                )
+            if fia_rows > max_fia_rows:
+                raise RuntimeError(
+                    "D-Cut ragged FULL FIA request rows exceed graph storage: "
+                    f"rows={fia_rows}, capacity={max_fia_rows}"
+                )
+            metadata_id = id(metadata)
+            if metadata_id not in normalized_metadata:
+                if use_fixed_drafter_fia:
+                    _dcut_pad_fixed_drafter_fia_seq_lens(
+                        metadata,
+                        num_reqs,
+                        int(request_capacity),
+                    )
+                else:
+                    # Only the optional target token-padding request needs a
+                    # synthetic KV length. Fixed GDN rows never enter FIA.
+                    _dcut_pad_fia_dummy_seq_len(
+                        metadata,
+                        num_reqs,
+                        fia_rows,
+                    )
+                normalized_metadata.add(metadata_id)
+            stable = seen.get(metadata_id)
+            if stable is None:
+                key = (
+                    route,
+                    str(prefix),
+                    max_fia_rows,
+                    tuple(block_tables.shape[1:]),
+                    block_tables.dtype,
+                    block_tables.device,
+                )
+                entry = persistent.get(key)
+                expected_shape = (
+                    max_fia_rows,
+                    *block_tables.shape[1:],
+                )
+                if entry is None:
+                    storage = torch.zeros(
+                        expected_shape,
+                        dtype=block_tables.dtype,
+                        device=block_tables.device,
+                    )
+                    entry = (storage, {})
+                    persistent[key] = entry
+                else:
+                    storage = entry[0]
+                if tuple(storage.shape) != expected_shape:
+                    raise RuntimeError(
+                        "D-Cut ragged FULL FIA block-table shape changed: "
+                        f"expected={expected_shape}, "
+                        f"actual={tuple(storage.shape)}"
+                    )
+                copy_rows = min(fia_rows, int(block_tables.shape[0]))
+                storage[:copy_rows].copy_(
+                    block_tables[:copy_rows], non_blocking=True
+                )
+                if copy_rows < fia_rows:
+                    storage[copy_rows:fia_rows].zero_()
+                views = entry[1]
+                stable = views.get(fia_rows)
+                if stable is None:
+                    stable = storage[:fia_rows]
+                    views[fia_rows] = stable
+                seen[metadata_id] = stable
+            metadata.block_tables = stable
+        return result
+
+    def _dummy_run(self, num_tokens, *args, **kwargs):
+        cudagraph_runtime_mode = kwargs.get("cudagraph_runtime_mode")
+        if cudagraph_runtime_mode is None and len(args) > 1:
+            cudagraph_runtime_mode = args[1]
+        is_profile = kwargs.get("is_profile", False)
+        if len(args) > 4:
+            is_profile = args[4]
+        is_graph_capturing = kwargs.get("is_graph_capturing", False)
+        if len(args) > 9:
+            is_graph_capturing = args[9]
+        uniform_decode = kwargs.get("uniform_decode", False)
+        if len(args) > 3:
+            uniform_decode = args[3]
+        piecewise_capture_dummy = _dcut_piecewise_capture_dummy_enabled(
+            self,
+            cudagraph_runtime_mode,
+            is_profile=bool(is_profile),
+            is_graph_capturing=bool(is_graph_capturing),
+        )
+        ragged_full_capture_dummy = _dcut_is_ragged_full_capture(
+            self,
+            cudagraph_runtime_mode,
+            bool(uniform_decode),
+            bool(is_graph_capturing),
+        )
+        skip_drafter = ragged_full_capture_dummy
+        if skip_drafter and not getattr(
+            self,
+            "_dcut_logged_ragged_full_drafter_skip",
+            False,
+        ):
+            logger.warning(
+                "D-Cut: skipping drafter dummy runs for ragged FULL "
+                "target-only graph capture."
+            )
+            self._dcut_logged_ragged_full_drafter_skip = True
+        if is_graph_capturing:
+            from vllm.config import CUDAGraphMode
+
+            if cudagraph_runtime_mode == CUDAGraphMode.PIECEWISE:
+                logger.warning(
+                    "D-Cut: PIECEWISE capture dummy token_bucket=%d "
+                    "uniform_decode=%s enabled=%s real_warmup=%s.",
+                    num_tokens,
+                    bool(uniform_decode),
+                    piecewise_capture_dummy,
+                    getattr(self, "_dcut_in_real_warmup", False),
+                )
+        previous_piecewise = getattr(
+            self,
+            "_dcut_piecewise_capture_dummy",
+            False,
+        )
+        previous_full = getattr(
+            self,
+            "_dcut_ragged_full_capture_dummy",
+            False,
+        )
+        self._dcut_piecewise_capture_dummy = piecewise_capture_dummy
+        self._dcut_ragged_full_capture_dummy = ragged_full_capture_dummy
+        try:
+            return _dcut_call_dummy_without_drafter(
+                self,
+                _orig_dummy_run,
+                num_tokens,
+                args,
+                kwargs,
+                skip_drafter,
+            )
+        finally:
+            self._dcut_piecewise_capture_dummy = previous_piecewise
+            self._dcut_ragged_full_capture_dummy = previous_full
+
+    def _should_build_dummy_attn_metadata(
+        self,
+        force_attention=False,
+        is_profile=False,
+        cudagraph_runtime_mode=None,
+    ):
+        return (
+            _orig_should_build_dummy(
+                self,
+                force_attention,
+                is_profile,
+                cudagraph_runtime_mode,
+            )
+            or getattr(
+                self,
+                "_dcut_piecewise_capture_dummy",
+                False,
+            )
+        )
+
+    def _model_forward(self, num_tokens_padded, *args, **kwargs):
+        from vllm.forward_context import get_forward_context
+        from vllm.v1.attention.backends.gdn_attn import (
+            GDNAttentionMetadata,
+        )
+
+        capture_dummy = getattr(
+            self,
+            "_dcut_piecewise_capture_dummy",
+            False,
+        )
+        ragged_full_capture_dummy = getattr(
+            self,
+            "_dcut_ragged_full_capture_dummy",
+            False,
+        )
+        graph_safe = False
+        forward_context = get_forward_context()
+        scheduler_has_prefill = getattr(
+            self,
+            "_dcut_gdn_scheduler_has_prefill",
+            None,
+        )
+        runtime_mode = getattr(
+            forward_context,
+            "cudagraph_runtime_mode",
+            None,
+        )
+        batch_descriptor = getattr(
+            forward_context,
+            "batch_descriptor",
+            None,
+        )
+        stock_uniform_full = bool(
+            _dcut_full_decode_multishape_enabled(self.vllm_config)
+            and getattr(
+                self.compilation_config.cudagraph_mode,
+                "name",
+                None,
+            )
+            == "FULL_DECODE_ONLY"
+            and getattr(runtime_mode, "name", runtime_mode) == "FULL"
+            and getattr(batch_descriptor, "uniform", False)
+        )
+        native_gdn_batch = stock_uniform_full or (
+            _dcut_gdn_has_prefill(forward_context)
+            if scheduler_has_prefill is None
+            else bool(scheduler_has_prefill)
+        )
+        if forward_context is not None:
+            # The context may be reused across forwards. Never let prepared
+            # eager state outlive the metadata values it was derived from.
+            forward_context._dcut_gdn_eager_spec_state = None
+            forward_context._dcut_gdn_native_batch = native_gdn_batch
+            forward_context._dcut_gdn_full_graph_safe = False
+            forward_context._dcut_gdn_recurrent_piecewise_safe = False
+
+        from vllm.config import CUDAGraphMode
+
+        full_gdn_graph = (
+            forward_context is not None
+            and getattr(self, "_has_gdn", False)
+            and (ragged_full_capture_dummy or not native_gdn_batch)
+            and _dcut_full_decode_multishape_enabled(self.vllm_config)
+            and self.compilation_config.cudagraph_mode
+            == CUDAGraphMode.FULL_DECODE_ONLY
+            and getattr(forward_context, "cudagraph_runtime_mode", None)
+            == CUDAGraphMode.FULL
+        )
+        initial_spec_rows = _dcut_initial_handoff_spec_rows(self)
+        if full_gdn_graph:
+            if (
+                getattr(self, "pcp_size", 1) != 1
+                or getattr(self, "dcp_size", 1) != 1
+            ):
+                raise RuntimeError(
+                    "D-Cut ragged FULL_DECODE_ONLY GDN requires PCP=1 "
+                    "and DCP=1"
+                )
+            graph_request_capacity = getattr(
+                batch_descriptor,
+                "num_reqs",
+                None,
+            )
+            expected_capacity = min(
+                int(num_tokens_padded),
+                int(self.vllm_config.scheduler_config.max_num_seqs),
+            )
+            if (
+                graph_request_capacity is None
+                or int(graph_request_capacity) != expected_capacity
+            ):
+                raise RuntimeError(
+                    "D-Cut ragged FULL descriptor has an inconsistent fixed "
+                    "request capacity: "
+                    f"token_bucket={num_tokens_padded}, "
+                    f"descriptor_capacity={graph_request_capacity}, "
+                    f"expected_capacity={expected_capacity}"
+                )
+            try:
+                if ragged_full_capture_dummy:
+                    graph_safe = _dcut_prepare_gdn_graph_capture(
+                        forward_context,
+                        num_tokens_padded,
+                        GDNAttentionMetadata,
+                        expected_capacity,
+                        self.uniform_decode_query_len,
+                    )
+                else:
+                    graph_safe = _dcut_prepare_gdn_piecewise_replay(
+                        forward_context,
+                        num_tokens_padded,
+                        GDNAttentionMetadata,
+                        expected_capacity,
+                        clear_unused_rows=True,
+                        initial_spec_rows=initial_spec_rows,
+                    )
+            except Exception as exc:
+                forward_context._dcut_gdn_full_graph_safe = False
+                raise RuntimeError(
+                    "D-Cut could not prepare fixed GDN metadata for FULL "
+                    f"token bucket {num_tokens_padded}"
+                ) from exc
+            if not graph_safe:
+                forward_context._dcut_gdn_full_graph_safe = False
+                raise RuntimeError(
+                    "D-Cut FULL_DECODE_ONLY GDN graph requires a pure "
+                    "speculative decode batch"
+                )
+            forward_context._dcut_gdn_full_graph_safe = True
+
+        if (
+            self._dcut_gdn_piecewise_enabled
+            and forward_context is not None
+            and (capture_dummy or not native_gdn_batch)
+            and getattr(
+                forward_context, "cudagraph_runtime_mode", None
+            )
+            == CUDAGraphMode.PIECEWISE
+        ):
+            if (
+                getattr(self, "pcp_size", 1) == 1
+                and getattr(self, "dcp_size", 1) == 1
+            ):
+                try:
+                    if capture_dummy:
+                        graph_safe = (
+                            _dcut_prepare_gdn_graph_capture(
+                                forward_context,
+                                num_tokens_padded,
+                                GDNAttentionMetadata,
+                                self.vllm_config.scheduler_config.max_num_seqs,
+                                self.uniform_decode_query_len,
+                            )
+                        )
+                    else:
+                        graph_safe = _dcut_prepare_gdn_piecewise_replay(
+                            forward_context,
+                            num_tokens_padded,
+                            GDNAttentionMetadata,
+                            self.vllm_config.scheduler_config.max_num_seqs,
+                            clear_unused_rows=True,
+                            initial_spec_rows=initial_spec_rows,
+                        )
+                except Exception as exc:
+                    logger.warning(
+                        "D-Cut: graphable PIECEWISE GDN metadata "
+                        "preparation failed; whole GDN remains eager: %s",
+                        exc,
+                    )
+            elif not getattr(
+                self, "_dcut_gdn_parallel_fallback_logged", False
+            ):
+                logger.warning(
+                    "D-Cut: graphable PIECEWISE GDN is disabled "
+                    "for PCP/DCP (pcp=%d, dcp=%d); whole GDN remains eager.",
+                    getattr(self, "pcp_size", 1),
+                    getattr(self, "dcp_size", 1),
+                )
+                self._dcut_gdn_parallel_fallback_logged = True
+            forward_context._dcut_gdn_recurrent_piecewise_safe = graph_safe
+
+        if (
+            forward_context is not None
+            and not graph_safe
+            and not native_gdn_batch
+        ):
+            try:
+                _dcut_prepare_gdn_eager_state(
+                    forward_context,
+                    GDNAttentionMetadata,
+                    initial_spec_rows=initial_spec_rows,
+                )
+            except Exception as exc:
+                forward_context._dcut_gdn_eager_spec_state = None
+                if not getattr(
+                    self, "_dcut_gdn_eager_prepare_fallback_logged", False
+                ):
+                    logger.warning(
+                        "D-Cut: eager GDN shared-state preparation failed; "
+                        "falling back to per-layer preparation: %s",
+                        exc,
+                    )
+                    self._dcut_gdn_eager_prepare_fallback_logged = True
+
+        if capture_dummy and not graph_safe:
+            raise RuntimeError(
+                "D-Cut could not build pure speculative GDN metadata "
+                f"while capturing PIECEWISE token bucket "
+                f"{num_tokens_padded}"
+            )
+
+        self._dcut_last_num_tokens_padded = num_tokens_padded
+        self._dcut_last_graph_safe = graph_safe
+        runtime_mode = (
+            getattr(forward_context, "cudagraph_runtime_mode", None)
+            if forward_context is not None
+            else None
+        )
+        self._dcut_last_runtime_mode = (
+            getattr(runtime_mode, "name", None)
+            or (str(runtime_mode) if runtime_mode is not None else "UNKNOWN")
+        )
+        result = _orig_model_forward(
+            self, num_tokens_padded, *args, **kwargs
+        )
+        if ragged_full_capture_dummy:
+            logger.warning(
+                "D-Cut: captured ragged FULL GDN graph through the "
+                "expanded graphable recurrent path for token bucket %d "
+                "(request_capacity=%s)",
+                num_tokens_padded,
+                getattr(batch_descriptor, "num_reqs", None),
+            )
+        if capture_dummy and self._dcut_gdn_piecewise_enabled:
+            logger.warning(
+                "D-Cut: captured PIECEWISE GDN graph with recurrent update "
+                "inside for token bucket %d",
+                num_tokens_padded,
+            )
+        return result
+
+    def execute_model(self, scheduler_output, intermediate_tensors=None):
+        debug_stats = bool(os.environ.get(ENV_DEBUG_STATS))
+        self._dcut_debug_stats_enabled = debug_stats
+        if debug_stats:
+            import time as _time
+
+            _t_entry = _time.perf_counter()
+            _last_end = getattr(self, "_dcut_last_debug_end", None)
+            _has_gap_sample = _last_end is not None
+            _gap_after_prev_ms = (
+                (_t_entry - _last_end) * 1000
+                if _has_gap_sample
+                else 0.0
+            )
+            _prev_step = getattr(self, "_dcut_last_debug_step", None)
+            _stats_io_after_prev_ms = getattr(
+                self,
+                "_dcut_last_stats_io_ms",
+                0.0,
+            )
+            _rank_info = getattr(self, "_dcut_debug_rank_info", None)
+            if _rank_info is None:
+                _rank_info = _dcut_debug_rank_info()
+                self._dcut_debug_rank_info = _rank_info
+        # Drafter proposal is a separate worker call. Reset the per-step
+        # marker so a skipped proposal cannot leak an old request set.
+        self._dcut_zero_draft_handoffs_for_proposal = frozenset()
+        if os.environ.get(ENV_FULL_DECODE_ONLY):
+            return _orig_exec(self, scheduler_output, intermediate_tensors)
+
+        _ctrl = getattr(self, "_verify_adaptive_controller", None)
+        dcut_enabled = _ctrl is not None and not _env_flag(ENV_DISABLE)
+        _recompute_handoff = _dcut_is_recompute_handoff(scheduler_output)
+        _recompute_placeholder_req_ids = (
+            _dcut_recompute_placeholder_req_ids(scheduler_output)
+        )
+        _adaptive_handoff_graph = _dcut_adaptive_handoff_graph_enabled(self)
+        _adaptive_recompute_handoff = bool(
+            dcut_enabled
+            and _recompute_handoff
+            and _recompute_placeholder_req_ids
+            and _adaptive_handoff_graph
+        )
+        _native_recompute_handoff = bool(
+            _recompute_handoff and not _adaptive_recompute_handoff
+        )
+        if debug_stats:
+            _adaptive_probs_process_ms = 0.0
+            _drafter_enable_ms = 0.0
+            _truncate_ms = 0.0
+            _prob_capture_bypass_ms = 0.0
+            _prob_capture_reset_ms = 0.0
+        if _native_recompute_handoff:
+            # RecomputeScheduler's placeholder spec tokens have no drafter
+            # probabilities. Bypass the complete D-Cut control/data path for
+            # the whole handoff batch and use the native GDN implementation.
+            self._dcut_capture_mixed_probs = False
+            self._dcut_skip_current_prob_capture = True
+            if debug_stats:
+                _classify_ms = (
+                    _time.perf_counter() - _t_entry
+                ) * 1000
+                _t_component = _time.perf_counter()
+            _dcut_bypass_prob_capture_for_prefill(self)
+            if debug_stats:
+                _prob_capture_bypass_ms = (
+                    _time.perf_counter() - _t_component
+                ) * 1000
+            if not getattr(self, "_dcut_logged_recompute_handoff", False):
+                logger.info(
+                    "D-Cut: PD recompute handoff detected; bypassing cut and "
+                    "using native GDN metadata with stock graph dispatch."
+                )
+                self._dcut_logged_recompute_handoff = True
+            # Preserve the zero-overhead production bypass. Debug mode keeps
+            # going through the common timing/JSON path so the native handoff
+            # forward is not incorrectly charged to the next step's gap.
+            if not debug_stats:
+                return _dcut_execute_native_recompute_handoff(
+                    self,
+                    _orig_exec,
+                    scheduler_output,
+                    intermediate_tensors,
+                )
+        elif _adaptive_recompute_handoff:
+            self._dcut_capture_mixed_probs = False
+            self._dcut_skip_current_prob_capture = False
+            if not getattr(
+                self,
+                "_dcut_logged_adaptive_recompute_handoff",
+                False,
+            ):
+                logger.info(
+                    "D-Cut: routing RecomputeScheduler placeholders through "
+                    "the adaptive PIECEWISE/FULL verifier with zero draft "
+                    "caps."
+                )
+                self._dcut_logged_adaptive_recompute_handoff = True
+
+        _zero_draft_handoffs = frozenset()
+        if (
+            dcut_enabled
+            and not _recompute_handoff
+            and _dcut_full_decode_multishape_enabled(self.vllm_config)
+            and getattr(
+                self.compilation_config.cudagraph_mode,
+                "name",
+                None,
+            ) == "FULL_DECODE_ONLY"
+        ):
+            _zero_draft_handoffs = _dcut_zero_draft_kv_handoff_req_ids(
+                self,
+                scheduler_output,
+            )
+        _prefill_exempt_req_ids = _zero_draft_handoffs
+        if _adaptive_recompute_handoff:
+            _prefill_exempt_req_ids = (
+                _prefill_exempt_req_ids
+                | _recompute_placeholder_req_ids
+            )
+        self._dcut_zero_draft_handoffs_for_proposal = (
+            _prefill_exempt_req_ids
+        )
+        _has_prefill = _dcut_has_prefill(
+            self,
+            scheduler_output,
+            _prefill_exempt_req_ids,
+        )
+        _has_spec = bool(getattr(scheduler_output, "scheduled_spec_decode_tokens", None))
+        # Capture trim info before truncation only when optional debug timing is
+        # enabled.  The regular D-Cut trim logger already records verify-token
+        # reduction inside _dcut_truncate; keeping a second unconditional stats
+        # path here adds Python work to every decode iteration.
+        _full_draft = 0
+        _batch_size = 0
+        _spec_batch_size = 0
+        _full_num_tokens = 0
+        if debug_stats:
+            _num_scheduled = getattr(
+                scheduler_output,
+                "num_scheduled_tokens",
+                {},
+            )
+            _orig_spec = getattr(
+                scheduler_output,
+                "scheduled_spec_decode_tokens",
+                {},
+            )
+            _full_draft = sum(len(t) for t in _orig_spec.values())
+            _batch_size = len(_num_scheduled)
+            _spec_batch_size = len(_orig_spec)
+            _full_num_tokens = int(
+                getattr(scheduler_output, "total_num_scheduled_tokens", 0)
+            )
+        if not _native_recompute_handoff:
+            self._dcut_capture_mixed_probs = bool(
+                _ctrl is not None and _has_prefill and _has_spec
+            )
+            self._dcut_skip_current_prob_capture = bool(
+                _ctrl is not None and _has_prefill and not _has_spec
+            )
+        if debug_stats and not _native_recompute_handoff:
+            _classify_ms = (_time.perf_counter() - _t_entry) * 1000
+        if (
+            _ctrl is not None
+            and _has_prefill
+            and not _native_recompute_handoff
+        ):
+            if debug_stats:
+                _t_component = _time.perf_counter()
+            _dcut_bypass_prob_capture_for_prefill(self)
+            if debug_stats:
+                _prob_capture_bypass_ms = (
+                    _time.perf_counter() - _t_component
+                ) * 1000
+
+        if (
+            _ctrl is not None
+            and not _has_prefill
+            and not _native_recompute_handoff
+        ):
+            if getattr(self, "_adaptive_probs_pending", False):
+                if debug_stats:
+                    _t_component = _time.perf_counter()
+                try:
+                    _maybe_process_adaptive_probs(
+                        self,
+                        stage="pre_truncate",
+                    )
+                except Exception as e:
+                    logger.warning("D-Cut: process probs failed: %s", e)
+                    self._adaptive_probs_pending = False
+                    self._adaptive_probs_source = "process_error"
+                    _ctrl.clear_adaptive_decision()
+                finally:
+                    if debug_stats:
+                        _adaptive_probs_process_ms = (
+                            _time.perf_counter() - _t_component
+                        ) * 1000
+            if debug_stats:
+                _t_component = _time.perf_counter()
+            _dcut_enable_drafter_probs(self)
+            if debug_stats:
+                _drafter_enable_ms = (
+                    _time.perf_counter() - _t_component
+                ) * 1000
+            if dcut_enabled:
+                if _adaptive_recompute_handoff:
+                    _dcut_apply_zero_prob_recompute_caps(
+                        _ctrl,
+                        scheduler_output,
+                        _recompute_placeholder_req_ids,
+                    )
+                if debug_stats:
+                    _t_component = _time.perf_counter()
+                scheduler_output = _dcut_truncate(
+                    self,
+                    scheduler_output,
+                    has_prefill=_has_prefill,
+                    zero_draft_handoff_req_ids=_zero_draft_handoffs,
+                )
+                if debug_stats:
+                    _truncate_ms = (
+                        _time.perf_counter() - _t_component
+                    ) * 1000
+            if debug_stats:
+                _t_component = _time.perf_counter()
+            if dcut_enabled and _zero_draft_handoffs:
+                scheduler_output = _dcut_add_zero_draft_handoffs(
+                    scheduler_output,
+                    _zero_draft_handoffs,
+                )
+                _current_spec = getattr(
+                    scheduler_output,
+                    "scheduled_spec_decode_tokens",
+                    None,
+                )
+                _has_spec = bool(_current_spec)
+                if debug_stats:
+                    _spec_batch_size = len(_current_spec or {})
+                if not getattr(
+                    self,
+                    "_dcut_logged_zero_draft_kv_handoff",
+                    False,
+                ):
+                    logger.info(
+                        "D-Cut: routing KV-consumer first-token handoffs as "
+                        "zero-draft rows in the ragged FULL graph."
+                    )
+                    self._dcut_logged_zero_draft_kv_handoff = True
+            _dcut_prepare_prob_capture(self, scheduler_output)
+            if debug_stats:
+                _prob_capture_reset_ms = (
+                    _time.perf_counter() - _t_component
+                ) * 1000
+
+        if not debug_stats:
+            return _dcut_execute_with_gdn_prefill_route(
+                self,
+                _orig_exec,
+                scheduler_output,
+                intermediate_tensors,
+                _has_prefill,
+            )
+
+        # Optional slow-path debug timing.  Keep it behind an env gate because
+        # perf_counter plus per-step Python aggregation is visible at high ITL.
+        _kept_draft = _full_draft
+        if (
+            dcut_enabled
+            and _has_spec
+            and not _native_recompute_handoff
+        ):
+            _new_spec = getattr(scheduler_output, "scheduled_spec_decode_tokens", {})
+            _kept_draft = sum(len(t) for t in _new_spec.values())
+        _num_tokens_actual = int(
+            getattr(scheduler_output, "total_num_scheduled_tokens", 0)
+        )
+        import torch as _torch
+
+        _t_pre_cpu_end = _time.perf_counter()
+        _pre_cpu_total_ms = (_t_pre_cpu_end - _t_entry) * 1000
+        _pre_cpu_other_ms = max(
+            0.0,
+            _pre_cpu_total_ms
+            - _classify_ms
+            - _adaptive_probs_process_ms
+            - _drafter_enable_ms
+            - _truncate_ms
+            - _prob_capture_bypass_ms
+            - _prob_capture_reset_ms,
+        )
+        _torch.npu.synchronize()
+        _t_execute_start = _time.perf_counter()
+        _pre_sync_ms = (_t_execute_start - _t_pre_cpu_end) * 1000
+        if _native_recompute_handoff:
+            result = _dcut_execute_native_recompute_handoff(
+                self,
+                _orig_exec,
+                scheduler_output,
+                intermediate_tensors,
+            )
+        else:
+            result = _dcut_execute_with_gdn_prefill_route(
+                self,
+                _orig_exec,
+                scheduler_output,
+                intermediate_tensors,
+                _has_prefill,
+            )
+        _t_execute_return = _time.perf_counter()
+        _execute_call_ms = (
+            _t_execute_return - _t_execute_start
+        ) * 1000
+        _torch.npu.synchronize()
+        _t_fwd_end = _time.perf_counter()
+        _post_sync_ms = (_t_fwd_end - _t_execute_return) * 1000
+        _fwd_ms = (_t_fwd_end - _t_execute_start) * 1000
+        if not hasattr(self, "_dcut_fwd_accum"):
+            self._dcut_fwd_accum = {
+                "full": 0,
+                "kept": 0,
+                "cut": 0,
+                "fwd_ms": 0.0,
+                "gap_after_prev_ms": 0.0,
+                "gap_samples": 0,
+                "steps": 0,
+                "spec_steps": 0,
+            }
+        acc = self._dcut_fwd_accum
+        acc["steps"] += 1
+        acc["fwd_ms"] += _fwd_ms
+        if _has_gap_sample:
+            acc["gap_after_prev_ms"] += _gap_after_prev_ms
+            acc["gap_samples"] += 1
+        if _has_spec and not _native_recompute_handoff:
+            acc["spec_steps"] += 1
+            acc["full"] += _full_draft
+            acc["kept"] += _kept_draft
+            acc["cut"] += (_full_draft - _kept_draft)
+        if acc["steps"] % 50 == 0 and _rank_info["is_writer"]:
+            _avg_fwd = acc["fwd_ms"] / acc["steps"]
+            _avg_gap = (
+                acc["gap_after_prev_ms"] / acc["gap_samples"]
+                if acc["gap_samples"]
+                else 0.0
+            )
+            if acc["full"] > 0:
+                _cut_pct = 100.0 * acc["cut"] / acc["full"]
+                logger.warning(
+                    "D-Cut step %d: full_draft=%d cut=%d (%.1f%%) "
+                    "kept=%d avg_fwd=%.1fms avg_inter_call_gap=%.1fms",
+                    acc["steps"],
+                    acc["full"],
+                    acc["cut"],
+                    _cut_pct,
+                    acc["kept"],
+                    _avg_fwd,
+                    _avg_gap,
+                )
+            else:
+                logger.warning(
+                    "D-Cut step %d: no spec reqs, avg_fwd=%.1fms "
+                    "avg_inter_call_gap=%.1fms",
+                    acc["steps"],
+                    _avg_fwd,
+                    _avg_gap,
+                )
+
+        _t_post_cpu_end = _time.perf_counter()
+        _post_cpu_ms = (_t_post_cpu_end - _t_fwd_end) * 1000
+        _fwd_stats_out = os.environ.get("VLLM_DCUT_FWD_STATS_OUT")
+        _stats_io_ms = 0.0
+        if _fwd_stats_out and _rank_info["is_writer"]:
+            import json as _json
+
+            _num_padded = getattr(self, "_dcut_last_num_tokens_padded", 0)
+            _graph_safe = getattr(self, "_dcut_last_graph_safe", False)
+            _runtime_mode = getattr(
+                self,
+                "_dcut_last_runtime_mode",
+                "UNKNOWN",
+            )
+            _is_eager = _runtime_mode in {
+                "NONE",
+                "EAGER",
+            }
+            _t_stats_io_start = _time.perf_counter()
+            _entry = {
+                "step": acc["steps"],
+                "pid": os.getpid(),
+                "world_rank": _rank_info["world_rank"],
+                "tp_rank": _rank_info["tp_rank"],
+                "pp_rank": _rank_info["pp_rank"],
+                "bs": _batch_size,
+                "spec_bs": _spec_batch_size,
+                "has_prefill": _has_prefill,
+                "has_spec": _has_spec,
+                "mixed_batch": _has_prefill and _has_spec,
+                "pure_prefill": _has_prefill and not _has_spec,
+                "decode_only": not _has_prefill,
+                "dcut_enabled": dcut_enabled,
+                "recompute_handoff": _recompute_handoff,
+                "recompute_placeholder_dcut": (
+                    _adaptive_recompute_handoff
+                ),
+                "recompute_placeholder_count": len(
+                    _recompute_placeholder_req_ids
+                ),
+                "zero_draft_handoff_count": len(
+                    _zero_draft_handoffs
+                ),
+                "reused_handoff_decision": bool(
+                    getattr(
+                        self,
+                        "_dcut_last_reused_handoff_decision",
+                        False,
+                    )
+                ),
+                "reused_survivor_decision": bool(
+                    getattr(
+                        self,
+                        "_dcut_last_reused_survivor_decision",
+                        False,
+                    )
+                ),
+                "dcut_bypassed": bool(
+                    _native_recompute_handoff or _has_prefill
+                ),
+                "dcut_bypass_reason": (
+                    "recompute_handoff"
+                    if _native_recompute_handoff
+                    else "recompute_placeholder_dcut"
+                    if _adaptive_recompute_handoff
+                    else "prefill"
+                    if _has_prefill
+                    else "none"
+                ),
+                "prob_capture_enabled": (
+                    _ctrl is not None
+                    and not self._dcut_skip_current_prob_capture
+                ),
+                "mixed_prob_capture_planned": bool(
+                    getattr(self, "_dcut_capture_mixed_probs", False)
+                ),
+                "drafter_needs_draft_probs": bool(
+                    getattr(
+                        getattr(self, "drafter", None),
+                        "needs_draft_probs",
+                        False,
+                    )
+                ),
+                "draft_ran_python": bool(
+                    getattr(
+                        getattr(self, "drafter", None),
+                        "_dcut_last_draft_ran_python",
+                        False,
+                    )
+                ),
+                "adaptive_probs_pending_after_step": bool(
+                    getattr(self, "_adaptive_probs_pending", False)
+                ),
+                "prob_decision_source": getattr(
+                    self,
+                    "_adaptive_probs_last_consumed_source",
+                    "none",
+                ),
+                "prob_decision_generation": int(
+                    getattr(self, "_adaptive_probs_last_consumed_generation", 0)
+                ),
+                "prob_pending_source": getattr(
+                    self,
+                    "_adaptive_probs_source",
+                    "none",
+                ),
+                "prob_pending_generation": int(
+                    getattr(self, "_adaptive_probs_generation", 0)
+                ),
+                "prob_decision_mean_by_position": getattr(
+                    self,
+                    "_adaptive_probs_last_consumed_mean_by_position",
+                    [],
+                ),
+                "prob_capture_skipped_for_prefill": (
+                    self._dcut_skip_current_prob_capture
+                ),
+                "full_draft": _full_draft,
+                "kept_draft": _kept_draft,
+                "trimmed": _full_draft - _kept_draft,
+                "cut_applied": _full_draft != _kept_draft,
+                "full_num_tokens": _full_num_tokens,
+                "num_tokens_actual": _num_tokens_actual,
+                "num_tokens_padded": _num_padded,
+                "runtime_mode": _runtime_mode,
+                "is_eager": _is_eager,
+                "gdn_native_path": bool(
+                    _has_prefill or _native_recompute_handoff
+                ),
+                "gdn_graph_safe": _graph_safe,
+                "prev_step": _prev_step,
+                "gap_sample_valid": _has_gap_sample,
+                "inter_call_gap_after_prev_step_ms": round(
+                    _gap_after_prev_ms,
+                    3,
+                ),
+                "stats_io_after_prev_step_ms": round(
+                    _stats_io_after_prev_ms,
+                    3,
+                ),
+                "classify_ms": round(_classify_ms, 3),
+                "adaptive_probs_process_ms": round(
+                    _adaptive_probs_process_ms,
+                    3,
+                ),
+                "drafter_enable_ms": round(_drafter_enable_ms, 3),
+                "truncate_ms": round(_truncate_ms, 3),
+                "prob_capture_bypass_ms": round(
+                    _prob_capture_bypass_ms,
+                    3,
+                ),
+                "prob_capture_reset_ms": round(
+                    _prob_capture_reset_ms,
+                    3,
+                ),
+                "pre_cpu_other_ms": round(_pre_cpu_other_ms, 3),
+                "pre_cpu_total_ms": round(_pre_cpu_total_ms, 3),
+                "pre_sync_ms": round(_pre_sync_ms, 3),
+                "pre_total_ms": round(
+                    _pre_cpu_total_ms + _pre_sync_ms,
+                    3,
+                ),
+                "execute_call_ms": round(_execute_call_ms, 3),
+                "post_sync_ms": round(_post_sync_ms, 3),
+                "fwd_ms": round(_fwd_ms, 2),
+                "post_cpu_ms": round(_post_cpu_ms, 3),
+            }
+            try:
+                with open(_fwd_stats_out, "a") as _f:
+                    _f.write(_json.dumps(_entry) + chr(10))
+            except Exception:
+                pass
+            _stats_io_ms = (
+                _time.perf_counter() - _t_stats_io_start
+            ) * 1000
+        self._dcut_last_stats_io_ms = _stats_io_ms
+        self._dcut_last_debug_step = acc["steps"]
+        self._dcut_last_debug_end = _time.perf_counter()
+        return result
+
+    _orig_sample_tokens = R.sample_tokens
+
+    def sample_tokens(self, *a, **k):
+        # The target side of a mixed prefill/decode batch stays on the native
+        # eager path. Re-enable selected-prob collection only for the draft
+        # proposal produced afterwards: those exact tokens are verified by the
+        # next decode-only iteration, which otherwise has to run uncut.
+        if getattr(self, "_dcut_capture_mixed_probs", False):
+            _dcut_enable_drafter_probs(self)
+        out = _orig_sample_tokens(self, *a, **k)
+        if (
+            os.environ.get(ENV_FULL_DECODE_ONLY)
+            or getattr(self, "_dcut_skip_current_prob_capture", False)
+        ):
+            return out
+        if (
+            getattr(self, "_adaptive_probs_pending", False)
+            and not getattr(self, "_dcut_skip_unready_probs", False)
+            and getattr(
+                self,
+                "_dcut_process_probs_stage",
+                "pre_truncate",
+            )
+            == "post_sample"
+        ):
+            try:
+                _maybe_process_adaptive_probs(self, stage="post_sample")
+            except Exception as e:
+                logger.warning("D-Cut: process probs failed: %s", e)
+                self._adaptive_probs_pending = False
+                self._adaptive_probs_source = "process_error"
+                controller = getattr(self, "_verify_adaptive_controller", None)
+                if controller is not None:
+                    controller.clear_adaptive_decision()
+        return out
+
+    _orig_copy = R._copy_draft_token_ids_to_cpu
+
+    def _copy_draft_token_ids_to_cpu(self, scheduler_output, zeros_only=False):
+        _orig_copy(self, scheduler_output, zeros_only)
+        if (
+            os.environ.get(ENV_FULL_DECODE_ONLY)
+            or getattr(self, "_dcut_skip_current_prob_capture", False)
+        ):
+            return
+        if getattr(self, "_verify_adaptive_controller", None) is not None:
+            try:
+                _dcut_queue_probs(self, zeros_only)
+            except Exception as e:
+                logger.warning("D-Cut: queue probs failed: %s", e)
+                self._adaptive_probs_pending = False
+                self._adaptive_probs_source = "queue_error"
+                controller = getattr(self, "_verify_adaptive_controller", None)
+                if controller is not None:
+                    controller.clear_adaptive_decision()
+
+    _orig_update = R._update_states
+
+    def _update_states(self, scheduler_output):
+        ret = _orig_update(self, scheduler_output)
+        ctrl = getattr(self, "_verify_adaptive_controller", None)
+        if ctrl is not None:
+            for rid in scheduler_output.finished_req_ids:
+                ctrl.invalidate(rid)
+        return ret
+
+    R.__init__ = __init__
+    R._model_forward = _model_forward
+    R._dummy_run = _dummy_run
+    R._should_build_dummy_attn_metadata = _should_build_dummy_attn_metadata
+    R._determine_batch_execution_and_padding = (
+        _determine_batch_execution_and_padding
+    )
+    R._pad_query_start_loc_for_fia = _pad_query_start_loc_for_fia
+    R._build_attention_metadata = _build_attention_metadata
+    R.execute_model = execute_model
+    R.sample_tokens = sample_tokens
+    R._copy_draft_token_ids_to_cpu = _copy_draft_token_ids_to_cpu
+    R._update_states = _update_states
+    R._adaptive_profile_run = _adaptive_profile_run
+    R._adaptive_profile_draft_run = _adaptive_profile_draft_run
+    R.profile_adaptive_cost = profile_adaptive_cost
+    R._maybe_process_adaptive_probs = _maybe_process_adaptive_probs
+    R._dcut_enable_drafter_probs = _dcut_enable_drafter_probs
+    R._dcut_patched = True
+
+    logger.info(
+        "D-Cut: using graph-captured GDN in the vLLM 0.23 PIECEWISE path."
+    )

--- a/dcut/patch_worker.py
+++ b/dcut/patch_worker.py
@@ -1,0 +1,94 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Patch NPUWorker: warmup hook + cost profiling trigger."""
+from __future__ import annotations
+
+from .globals import logger
+from .patch_full_graph import _dcut_validate_gdn_full_graph_weights
+
+
+def _patch_worker() -> None:
+    import vllm_ascend.worker.worker as m
+
+    W = m.NPUWorker
+    if getattr(W, "_dcut_patched", False):
+        return
+
+    _orig = W.compile_or_warm_up_model
+
+    def compile_or_warm_up_model(self, *a, **k):
+        runner = getattr(self, "model_runner", None)
+        if runner is not None and hasattr(runner, "_dcut_enable_drafter_probs"):
+            try:
+                runner._dcut_enable_drafter_probs()
+            except Exception as e:
+                logger.warning("D-Cut: enabling draft probs before warmup failed: %s", e)
+        if runner is not None:
+            dropped = _dcut_drop_pre_warmup_draft_graphs(runner)
+            if dropped:
+                logger.warning(
+                    "D-Cut: dropped %d draft graph(s) captured before "
+                    "probability collection; recapturing during warmup.",
+                    dropped,
+                )
+        if runner is not None:
+            _dcut_validate_gdn_full_graph_weights(runner)
+        # Mark that we're in the REAL warmup (not profile_cudagraph_memory).
+        # _build_attention_metadata patch checks this to force use_spec_decode=True
+        # only during real warmup, not during profile_cudagraph_memory (which uses
+        # a minimal KV cache that can't support spec-decode conv1d).
+        if runner is not None:
+            runner._dcut_in_real_warmup = True
+        try:
+            ret = _orig(self, *a, **k)
+            if runner is not None and hasattr(runner, "profile_adaptive_cost"):
+                try:
+                    runner.profile_adaptive_cost()
+                except Exception as e:
+                    # Empty cost table => controller no-ops => graceful fall back to
+                    # vanilla DFlash (full-length verify).
+                    import traceback
+                    logger.error("D-Cut: cost profiling failed; falling back: %s", e)
+                    logger.error("D-Cut: full traceback: %s", traceback.format_exc())
+                    ctrl = getattr(runner, "_verify_adaptive_controller", None)
+                    if ctrl is not None:
+                        ctrl._cost_table.clear()
+                        ctrl._sorted_bs.clear()
+                        ctrl._sorted_sql_per_bs.clear()
+        finally:
+            if runner is not None:
+                runner._dcut_in_real_warmup = False
+        return ret
+
+    W.compile_or_warm_up_model = compile_or_warm_up_model
+    W._dcut_patched = True
+    logger.info("D-Cut: patched NPUWorker.")
+
+
+def _dcut_drop_pre_warmup_draft_graphs(runner) -> int:
+    """Drop draft graphs captured before probability collection was enabled."""
+    drafter = getattr(runner, "drafter", None)
+    if drafter is None or not getattr(drafter, "needs_draft_probs", False):
+        return 0
+
+    runnable = getattr(drafter, "_runnable", None)
+    runnable_state = getattr(runnable, "__dict__", None)
+    if not isinstance(runnable_state, dict):
+        return 0
+    entries = runnable_state.get("concrete_aclgraph_entries")
+    if not entries:
+        return 0
+
+    by_descriptor = getattr(
+        drafter,
+        "_dcut_graph_selected_probs_by_descriptor",
+        None,
+    ) or {}
+    stale_descriptors = [
+        descriptor
+        for descriptor, entry in entries.items()
+        if getattr(entry, "aclgraph", None) is not None
+        and by_descriptor.get(descriptor) is None
+    ]
+    for descriptor in stale_descriptors:
+        entries.pop(descriptor, None)
+    return len(stale_descriptors)

--- a/dcut/probs.py
+++ b/dcut/probs.py
@@ -1,0 +1,318 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Async D2H selected-probs queue + controller cache update."""
+from __future__ import annotations
+
+
+from .controller import _dcut_enable_drafter_probs
+from .globals import logger
+from .utils import (
+    _dcut_selected_probs_from_graph,
+    _dcut_selected_probs_from_reused_logits,
+)
+
+
+def _dcut_bypass_prob_capture_for_prefill(self) -> None:
+    """Disable D-Cut decision work while the target runs real prefill.
+
+    Prefill-containing batches are never truncated and run through the
+    native eager model path. Keeping ``needs_draft_probs`` enabled in that
+    target path would retain state that belongs to the previous proposal.
+    Drop that stale decision here. A mixed batch may re-enable probability
+    capture later, immediately before its draft proposal, because those newly
+    proposed tokens are consumed by the next decode-only verifier step. Pure
+    prefill keeps probability capture disabled until decode resumes.
+    """
+    drafter = getattr(self, "drafter", None)
+    if drafter is not None:
+        if hasattr(drafter, "needs_draft_probs"):
+            drafter.needs_draft_probs = False
+        drafter._dcut_last_draft_ran_python = False
+        drafter._dcut_last_logits_for_probs = None
+        drafter._last_selected_probs = None
+
+    self._adaptive_probs_pending = False
+    self._adaptive_probs_expired = False
+    self._adaptive_probs_source = "prefill_bypass"
+    self._adaptive_probs_last_consumed_source = "prefill_bypass"
+    self._adaptive_num_reqs = 0
+    self._adaptive_req_ids = []
+    self._adaptive_active = set()
+    controller = getattr(self, "_verify_adaptive_controller", None)
+    if controller is not None:
+        controller.clear_adaptive_decision()
+
+
+def _dcut_prepare_prob_capture(self, scheduler_output) -> None:
+    """Reset per-step execution state before the drafter runs or replays."""
+    drafter = getattr(self, "drafter", None)
+    if drafter is not None:
+        drafter._dcut_last_draft_ran_python = False
+        drafter._dcut_current_graph_descriptor = None
+        drafter._dcut_last_graph_prob_source = "none"
+        # Graph replay updates the fixed-address tensor retained per bucket;
+        # it does not reassign this Python attribute. Clear it so a replay can
+        # never consume the final bucket captured during startup by accident.
+        drafter._last_selected_probs = None
+        # Force graph replay to select retained logits by the current graph
+        # descriptor instead of reusing the final startup-capture bucket.
+        drafter._dcut_last_logits_for_probs = None
+
+    # The decision was consumed by the truncation immediately before this call.
+    # Make every decision single-use so a failed probability capture cannot
+    # silently apply the previous cap to another verifier step.
+    controller = getattr(self, "_verify_adaptive_controller", None)
+    if controller is not None:
+        controller.clear_adaptive_decision()
+    if not getattr(self, "_adaptive_probs_pending", False):
+        self._adaptive_probs_source = "capture_pending"
+
+
+def _dcut_probability_req_ids(self, num_reqs: int) -> list[str]:
+    """Return the request IDs aligned with the captured draft-prob rows.
+
+    ``_copy_draft_token_ids_to_cpu`` snapshots ``_draft_token_req_ids`` at
+    proposal time. Use that same snapshot instead of re-classifying rows from
+    ``num_computed_tokens_cpu``: a request that just finished prefill already
+    has valid next-step draft tokens, while its computed-token bookkeeping can
+    still look like prefill until the following runner iteration.
+    """
+    draft_req_ids = getattr(self, "_draft_token_req_ids", None)
+    if draft_req_ids is None:
+        draft_req_ids = self.input_batch.req_ids
+    return list(draft_req_ids[:num_reqs])
+
+
+def _dcut_queue_probs(self, zeros_only: bool) -> None:
+    """Queue this step's selected_probs D2H (non-blocking) for next-step use.
+
+    Device-agnostic apart from the async D2H copy + event record, which work
+    the same on NPU (torch_npu supports non_blocking copies + npu.Event).
+    """
+    if (
+        zeros_only
+        or self._adaptive_probs_pending
+        or self._adaptive_probs_pinned is None
+        or self._adaptive_probs_event is None
+    ):
+        return
+    self._adaptive_probs_source = "missing"
+    _dcut_enable_drafter_probs(self)
+    drafter = getattr(self, "drafter", None)
+    if drafter is None or not hasattr(drafter, "take_last_selected_probs"):
+        self._adaptive_probs_source = "no_selected_probs_hook"
+        cnt = getattr(self, "_dcut_missing_probs_steps", 0) + 1
+        self._dcut_missing_probs_steps = cnt
+        if cnt <= 3 or cnt % 200 == 0:
+            logger.warning(
+                "D-Cut: drafter has no selected-probs hook; decision stats "
+                "will not update (count=%s).",
+                cnt,
+            )
+        return
+    draft_token_ids = getattr(self, "_draft_token_ids", None)
+    ran_python = getattr(drafter, "_dcut_last_draft_ran_python", False)
+    if ran_python:
+        probs = drafter.take_last_selected_probs()
+        prob_source = "eager_python"
+    else:
+        probs = _dcut_selected_probs_from_graph(
+            drafter,
+            draft_token_ids,
+        )
+        prob_source = getattr(drafter, "_dcut_last_graph_prob_source", "missing")
+        if (
+            probs is not None
+            and not getattr(
+                self,
+                "_dcut_logged_graph_selected_probs",
+                False,
+            )
+        ):
+            logger.info(
+                "D-Cut: using selected probabilities produced by the "
+                "replayed draft graph."
+            )
+            self._dcut_logged_graph_selected_probs = True
+    if probs is None:
+        if (
+            not ran_python
+            and not getattr(
+                self,
+                "_dcut_logged_graph_probs_fallback",
+                False,
+            )
+        ):
+            logger.warning(
+                "D-Cut: replayed draft graph has no matching selected-prob "
+                "buffer; trying the guarded logits compatibility path."
+            )
+            self._dcut_logged_graph_probs_fallback = True
+        try:
+            probs = _dcut_selected_probs_from_reused_logits(
+                drafter,
+                draft_token_ids,
+            )
+            if probs is not None:
+                prob_source = "guarded_reused_logits"
+        except Exception as e:  # pragma: no cover - defensive
+            logger.warning(
+                "D-Cut: deriving selected probs from reused logits failed: %s",
+                e,
+            )
+            probs = None
+    if probs is None:
+        self._adaptive_probs_source = f"missing_{prob_source}"
+        cnt = getattr(self, "_dcut_missing_probs_steps", 0) + 1
+        self._dcut_missing_probs_steps = cnt
+        if cnt <= 3 or cnt % 200 == 0:
+            graph_ready = bool(
+                getattr(drafter, "_dcut_graph_selected_probs_ready", False)
+            )
+            draft_shape = (
+                tuple(getattr(draft_token_ids, "shape", ()))
+                if draft_token_ids is not None
+                else None
+            )
+            descriptor = getattr(
+                drafter, "_dcut_current_graph_descriptor", None
+            )
+            logger.warning(
+                "D-Cut: drafter did not expose selected draft probs; decision "
+                "stats will not update (count=%s source=%s graph_ready=%s "
+                "draft_shape=%s descriptor=%s).",
+                cnt,
+                prob_source,
+                graph_ready,
+                draft_shape,
+                descriptor,
+            )
+        return
+    num_reqs = self.input_batch.num_reqs
+    num_spec = self.num_spec_tokens
+    if probs.dim() == 1:
+        needed = num_reqs * num_spec
+        if probs.numel() < needed:
+            self._adaptive_probs_source = "prob_length_mismatch"
+            logger.warning(
+                "D-Cut: selected draft probs too short: got=%s need=%s",
+                probs.numel(),
+                needed,
+            )
+            return
+        probs = probs[:needed].view(num_reqs, num_spec)
+    else:
+        probs = probs[:num_reqs]
+        if probs.shape[-1] != num_spec:
+            self._adaptive_probs_source = "prob_shape_mismatch"
+            logger.warning(
+                "D-Cut: selected draft probs shape mismatch: shape=%s num_spec=%s",
+                tuple(probs.shape),
+                num_spec,
+            )
+            return
+    prob_req_ids = _dcut_probability_req_ids(self, num_reqs)
+    if len(prob_req_ids) != num_reqs:
+        self._adaptive_probs_source = "request_id_mismatch"
+        logger.warning(
+            "D-Cut: draft probability request IDs are misaligned: "
+            "got=%s expected=%s",
+            len(prob_req_ids),
+            num_reqs,
+        )
+        return
+    self._adaptive_probs_pending = True
+    self._adaptive_probs_expired = False
+    self._adaptive_probs_source = prob_source
+    self._adaptive_probs_generation = getattr(self, "_adaptive_probs_generation", 0) + 1
+    self._adaptive_num_reqs = num_reqs
+    self._adaptive_req_ids = prob_req_ids
+    # Every probability row came from this proposal output. In particular,
+    # include a request that completed prefill in this iteration; the scheduler
+    # can place its freshly proposed tokens in the very next spec batch.
+    self._adaptive_active = set(prob_req_ids)
+    # Non-blocking D2H on the default stream (the drafter runs there too). The
+    # next execute_model consumes it immediately before truncation, allowing
+    # this copy to overlap the remainder of the current scheduler step.
+    self._adaptive_probs_pinned[:num_reqs].copy_(
+        probs.contiguous(),
+        non_blocking=True,
+    )
+    self._adaptive_probs_event.record()
+
+
+def _maybe_process_adaptive_probs(
+    self,
+    stage: str = "pre_truncate",
+) -> None:
+    """Consume queued probs before truncating the next verifier batch."""
+    if not self._adaptive_probs_pending:
+        return
+    controller = self._verify_adaptive_controller
+    assert self._adaptive_probs_event is not None
+    if not self._adaptive_probs_event.query():
+        if getattr(self, "_dcut_skip_unready_probs", False):
+            self._adaptive_probs_expired = True
+            if controller is not None:
+                controller.clear_adaptive_decision()
+            return
+        # In the default pre_truncate path the copy has had the rest of the
+        # previous iteration to complete. Synchronize only if it is still late,
+        # so this step uses fresh probabilities and the next D2H queue is free.
+        self._adaptive_probs_event.synchronize()
+    self._adaptive_probs_pending = False
+    if getattr(self, "_adaptive_probs_expired", False):
+        self._adaptive_probs_expired = False
+        self._adaptive_probs_source = "expired"
+        if controller is not None:
+            controller.clear_adaptive_decision()
+        return
+    self._adaptive_probs_last_consumed_source = getattr(
+        self, "_adaptive_probs_source", "unknown"
+    )
+    self._adaptive_probs_last_consumed_generation = (
+        getattr(self, "_adaptive_probs_generation", 0)
+    )
+
+    num_reqs = self._adaptive_num_reqs
+    active = self._adaptive_active
+    if active:
+        current_req_ids = set(
+            self.input_batch.req_ids[
+                : getattr(self.input_batch, "num_reqs", 0)
+            ]
+        )
+        active = active & current_req_ids
+    if getattr(self, "_dcut_debug_stats_enabled", False):
+        self._adaptive_probs_last_consumed_mean_by_position = []
+        active_indices = [
+            index
+            for index, req_id in enumerate(
+                self._adaptive_req_ids[:num_reqs]
+            )
+            if req_id in active
+        ]
+        if active_indices:
+            assert self._adaptive_probs_pinned is not None
+            mean_by_position = self._adaptive_probs_pinned[
+                active_indices
+            ].float().mean(dim=0)
+            self._adaptive_probs_last_consumed_mean_by_position = [
+                round(float(value), 6)
+                for value in mean_by_position.tolist()
+            ]
+    if active and controller is not None:
+        assert self._adaptive_probs_pinned is not None
+        controller.process_draft_output(
+            selected_probs=self._adaptive_probs_pinned[:num_reqs],
+            req_ids=self._adaptive_req_ids,
+            active_draft_req_ids=active,
+            batch_size=num_reqs,
+        )
+    elif controller is not None:
+        controller.clear_adaptive_decision()
+
+
+def profile_adaptive_cost(self) -> None:
+    """Profile verifier ITL after warmup (called from NPUWorker)."""
+    if getattr(self, "_verify_adaptive_controller", None) is not None:
+        self._verify_adaptive_controller.profile_cost_table(self)

--- a/dcut/pyproject.toml
+++ b/dcut/pyproject.toml
@@ -1,0 +1,21 @@
+[build-system]
+requires = ["setuptools>=61"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "dcut-adaptive-verify"
+version = "0.2.0"
+description = "D-Cut adaptive verifier step-length for DFlash/PARD speculative decoding on Ascend NPU with vLLM 0.23.0."
+requires-python = ">=3.9"
+dependencies = ["numpy"]
+
+# Loaded automatically by vLLM in every engine/worker process at startup.
+# This is what makes the monkey patch take effect under tensor parallelism
+# (a plain `import dcut` would only patch the main process, not TP workers).
+[project.entry-points."vllm.general_plugins"]
+dcut_adaptive_verify = "dcut:install"
+
+# Flat layout: the package `dcut` lives in this directory (next to pyproject).
+[tool.setuptools]
+packages = ["dcut"]
+package-dir = { "dcut" = "." }

--- a/dcut/test_ops_quick.py
+++ b/dcut/test_ops_quick.py
@@ -1,0 +1,68 @@
+#!/usr/bin/env python3
+"""Quick test: load dcut torch extension and test operator registration."""
+import sys, os
+
+# Load dcut torch extension
+ext_path = "/data/c00954457/tmp/VLLM0.23.0/dcut/kernel/build/torch_extension/dcut_torch_ops.so"
+if os.path.exists(ext_path):
+    print(f"[1] Loading torch extension: {ext_path}")
+    import torch
+    torch.ops.load_library(ext_path)
+    print("    OK")
+else:
+    print(f"[!] Extension not found: {ext_path}")
+    sys.exit(1)
+
+# List all registered _C_ascend ops that contain "recurrent" or "dcut"
+print("\n[2] Searching for registered ops...")
+import torch_npu  # ensure _C_ascend dispatcher is ready
+ops = [name for name in dir(torch.ops._C_ascend) if "recurrent" in name.lower() or "dcut" in name.lower()]
+for o in sorted(ops):
+    print(f"    {o}")
+if not ops:
+    print("    (none found in dir(); checking hasattr instead)")
+    for name in ("npu_dcut_recurrent_gated_delta_rule", "npu_recurrent_gated_delta_rule"):
+        exists = hasattr(torch.ops._C_ascend, name)
+        print(f"    hasattr({name}) = {exists}")
+
+# Call dcut op with the CORRECT signature:
+# (q, k, v, state, *, beta, scale, query_start_loc,
+#  ssm_state_indices, num_accepted_tokens, g, gk, zero_padded_output) -> Tensor
+print("\n[3] Calling npu_dcut_recurrent_gated_delta_rule (correct sig) ...")
+import torch
+dev = "npu:0"
+dt  = torch.bfloat16
+B, S, H, D = 2, 4, 8, 64
+T = B * S  # packed sequence length
+# 3D packed format: (T, H, D)
+q  = torch.randn(T, H, D,  device=dev, dtype=dt)
+k  = torch.randn(T, H, D,  device=dev, dtype=dt)
+v  = torch.randn(T, H, D,  device=dev, dtype=dt)
+g  = torch.randn(T, H, D,  device=dev, dtype=torch.float32)  # gate must be float32
+# 4D state: (B, H, D, D_state)
+state = torch.randn(B, H, D, D, device=dev, dtype=dt)
+# 2D beta: (T, H)
+beta  = torch.randn(T, H,    device=dev, dtype=dt)
+# query_start_loc: cumulative packed-token offsets, shape (B+1,)
+qsl   = torch.tensor([0, S, 2*S], device=dev, dtype=torch.int32)
+# ssm_state_indices: (B, S) where 1 <= S <= 16
+ssi   = torch.tensor([[0]*S]*B, device=dev, dtype=torch.int32)
+nat   = torch.tensor([S]*B, device=dev, dtype=torch.int32)
+
+try:
+    out = torch.ops._C_ascend.npu_dcut_recurrent_gated_delta_rule(
+        q, k, v, state,
+        g=g,
+        beta=beta,
+        scale=1.0,
+        query_start_loc=qsl,
+        ssm_state_indices=ssi,
+        num_accepted_tokens=nat,
+    )
+    print(f"    OK  output shape: {out.shape if not isinstance(out,tuple) else [o.shape for o in out]}")
+except Exception as e:
+    print(f"    FAIL: {e}")
+    import traceback
+    traceback.print_exc()
+
+print("\nDone.")

--- a/dcut/tests/test_cost_table_override.py
+++ b/dcut/tests/test_cost_table_override.py
@@ -1,0 +1,119 @@
+# SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
+
+import ast
+import json
+import math
+from pathlib import Path
+
+
+CONTROLLER_PATH = (
+    Path(__file__).resolve().parents[1] / "verify_adaptive_controller.py"
+)
+
+
+def _load_parser():
+    tree = ast.parse(CONTROLLER_PATH.read_text(encoding="utf-8"))
+    function = next(
+        node
+        for node in tree.body
+        if isinstance(node, ast.FunctionDef)
+        and node.name == "_parse_cost_table_override"
+    )
+    module = ast.Module(
+        body=[
+            ast.ImportFrom(
+                module="__future__",
+                names=[ast.alias(name="annotations")],
+                level=0,
+            ),
+            function,
+        ],
+        type_ignores=[],
+    )
+    ast.fix_missing_locations(module)
+    namespace = {"math": math}
+    exec(compile(module, str(CONTROLLER_PATH), "exec"), namespace)
+    return namespace["_parse_cost_table_override"]
+
+
+def _payload() -> dict:
+    return {
+        "schema_version": 2,
+        "num_spec_tokens": 15,
+        "max_batch_size": 32,
+        "batch_size_levels": [16, 32],
+        "query_len_levels": [2, 4, 6, 16],
+        "cost_table": [
+            {
+                "batch_size": 32,
+                "sum_query_len": 128,
+                "query_len_per_req": 4,
+                "cost_s": 0.05,
+                "target_cost_s": 0.04,
+                "draft_cost_s": 0.01,
+            },
+            {
+                "batch_size": 32,
+                "sum_query_len": 192,
+                "query_len_per_req": 6,
+                "cost_s": 0.055,
+                "target_cost_s": 0.044,
+                "draft_cost_s": 0.011,
+            },
+        ],
+    }
+
+
+def _parse(payload: dict, *, num_spec_tokens: int = 15):
+    return _load_parser()(
+        payload,
+        num_spec_tokens=num_spec_tokens,
+        max_batch_size=32,
+        batch_size_levels=[16, 32],
+        query_len_levels=[2, 4, 6, 16],
+    )
+
+
+def test_schema_v2_cost_table_can_override_profiled_costs() -> None:
+    target, draft = _parse(_payload())
+
+    assert target == {(32, 128): 0.04, (32, 192): 0.044}
+    assert draft == {(32, 128): 0.01, (32, 192): 0.011}
+
+
+def test_override_rejects_runtime_grid_mismatch() -> None:
+    try:
+        _parse(_payload(), num_spec_tokens=7)
+    except ValueError as exc:
+        assert "num_spec_tokens mismatch" in str(exc)
+    else:
+        raise AssertionError("expected incompatible override to be rejected")
+
+
+def test_override_rejects_inconsistent_component_total() -> None:
+    payload = json.loads(json.dumps(_payload()))
+    payload["cost_table"][0]["cost_s"] = 0.5
+
+    try:
+        _parse(payload)
+    except ValueError as exc:
+        assert "total does not match" in str(exc)
+    else:
+        raise AssertionError("expected malformed override to be rejected")
+
+
+def test_override_is_optional_and_applied_after_profile_dump() -> None:
+    source = CONTROLLER_PATH.read_text(encoding="utf-8")
+    override_branch = source.index("if override_path:")
+    profile_dump = source.index(
+        "self._dump_cost_table_if_requested()", override_branch
+    )
+    replace_table = source.index(
+        "self._cost_table = override_target", override_branch
+    )
+
+    assert 'os.getenv(ENV_COST_TABLE_OVERRIDE)' in source
+    assert profile_dump < replace_table
+    assert "if not override_path:" in source
+    assert "replaced the profiled cost" in source

--- a/dcut/tests/test_debug_stats_contract.py
+++ b/dcut/tests/test_debug_stats_contract.py
@@ -1,0 +1,111 @@
+# SPDX-License-Identifier: Apache-2.0
+
+from pathlib import Path
+
+
+PATCH_RUNNER = Path(__file__).resolve().parents[1] / "patch_runner.py"
+
+
+def _execute_source() -> str:
+    source = PATCH_RUNNER.read_text(encoding="utf-8")
+    start = source.index("    def execute_model(")
+    end = source.index("    _orig_sample_tokens", start)
+    return source[start:end]
+
+
+def test_fast_path_execution_order_is_unchanged() -> None:
+    source = _execute_source()
+    fast_start = source.index("        if not debug_stats:")
+    fast_end = source.index(
+        "        # Optional slow-path debug timing.",
+        fast_start,
+    )
+    fast_path = source[fast_start:fast_end]
+
+    assert "return _dcut_execute_with_gdn_prefill_route(" in fast_path
+    assert ".npu.synchronize()" not in fast_path
+
+
+def test_debug_stats_name_gap_as_inter_call_time() -> None:
+    source = _execute_source()
+
+    assert '"prev_step": _prev_step' in source
+    assert '"gap_sample_valid": _has_gap_sample' in source
+    assert '"inter_call_gap_after_prev_step_ms"' in source
+    assert '"stats_io_after_prev_step_ms"' in source
+    assert '"gap_ms"' not in source
+    assert '"scheduler_ms"' not in source
+
+
+def test_debug_stats_partition_runner_time() -> None:
+    source = _execute_source()
+    expected_fields = {
+        "classify_ms",
+        "adaptive_probs_process_ms",
+        "drafter_enable_ms",
+        "truncate_ms",
+        "prob_capture_reset_ms",
+        "pre_cpu_other_ms",
+        "pre_cpu_total_ms",
+        "pre_sync_ms",
+        "pre_total_ms",
+        "execute_call_ms",
+        "post_sync_ms",
+        "fwd_ms",
+        "post_cpu_ms",
+        "prob_decision_source",
+        "prob_decision_generation",
+        "prob_pending_source",
+        "prob_pending_generation",
+        "prob_decision_mean_by_position",
+        "recompute_handoff",
+        "zero_draft_handoff_count",
+        "reused_handoff_decision",
+        "dcut_bypassed",
+        "dcut_bypass_reason",
+    }
+
+    for field in expected_fields:
+        assert f'"{field}"' in source
+
+
+def test_debug_file_has_one_distributed_writer_and_logs_all_batches() -> None:
+    source = _execute_source()
+
+    assert 'if _fwd_stats_out and _rank_info["is_writer"]:' in source
+    assert 'if _fwd_stats_out and _has_spec:' not in source
+    assert '"world_rank": _rank_info["world_rank"]' in source
+    assert '"has_prefill": _has_prefill' in source
+    assert '"mixed_batch": _has_prefill and _has_spec' in source
+    assert '"runtime_mode": _runtime_mode' in source
+    assert '"is_eager": _is_eager' in source
+    assert '"gdn_graph_safe": _graph_safe' in source
+
+
+def test_recompute_handoff_uses_common_debug_timing_path() -> None:
+    source = _execute_source()
+    handoff_start = source.index(
+        "        if _native_recompute_handoff:"
+    )
+    classify_start = source.index(
+        "        _has_prefill = _dcut_has_prefill",
+        handoff_start,
+    )
+    handoff_branch = source[handoff_start:classify_start]
+
+    assert "if not debug_stats:" in handoff_branch
+    assert "return _dcut_execute_native_recompute_handoff(" in (
+        handoff_branch
+    )
+
+    debug_timing_start = source.index(
+        "        # Optional slow-path debug timing."
+    )
+    debug_timing = source[debug_timing_start:]
+    assert "if _native_recompute_handoff:" in debug_timing
+    assert "result = _dcut_execute_native_recompute_handoff(" in (
+        debug_timing
+    )
+    assert '"recompute_handoff": _recompute_handoff' in debug_timing
+    assert '"dcut_bypassed": bool(' in debug_timing
+    assert '"dcut_bypass_reason": (' in debug_timing

--- a/dcut/tests/test_draft_cost_profile.py
+++ b/dcut/tests/test_draft_cost_profile.py
@@ -1,0 +1,127 @@
+# SPDX-License-Identifier: Apache-2.0
+
+import ast
+from pathlib import Path
+from types import SimpleNamespace
+
+PROFILE_PATH = Path(__file__).resolve().parents[1] / "draft_profile.py"
+DFLASH_PATH = (
+    Path(__file__).resolve().parents[2]
+    / "vllm_ascend"
+    / "spec_decode"
+    / "dflash_proposer.py"
+)
+
+
+class _Mode:
+    FULL = "full"
+    PIECEWISE = "piecewise"
+    NONE = "none"
+
+
+class _Event:
+    def record(self) -> None:
+        pass
+
+    def elapsed_time(self, other) -> float:
+        return 8.0
+
+
+class _Drafter:
+    method = "dflash"
+    use_cuda_graph = True
+    num_speculative_tokens = 15
+
+    def __init__(self) -> None:
+        self.calls = []
+
+    def dummy_run(self, **kwargs) -> None:
+        self.calls.append(kwargs)
+
+
+class _Dispatcher:
+    def __init__(self) -> None:
+        self.calls = []
+
+    def dispatch(self, **kwargs):
+        self.calls.append(kwargs)
+        return _Mode.PIECEWISE, SimpleNamespace(num_tokens=64)
+
+
+class _Runner:
+    def __init__(self) -> None:
+        self.drafter = _Drafter()
+        self.cudagraph_dispatcher = _Dispatcher()
+        self.input_batch = SimpleNamespace(lora_id_to_lora_request={})
+
+    @staticmethod
+    def _sync_metadata_across_dp(num_tokens, is_draft_model):
+        assert is_draft_model
+        return num_tokens, None, None
+
+
+def _load_profile_function():
+    tree = ast.parse(PROFILE_PATH.read_text(encoding="utf-8"))
+    function = next(
+        node
+        for node in tree.body
+        if isinstance(node, ast.FunctionDef)
+        and node.name == "_adaptive_profile_draft_run"
+    )
+    function.decorator_list = []
+    module = ast.Module(
+        body=[
+            ast.ImportFrom(
+                module="__future__",
+                names=[ast.alias(name="annotations")],
+                level=0,
+            ),
+            function,
+        ],
+        type_ignores=[],
+    )
+    ast.fix_missing_locations(module)
+    namespace = {
+        "CUDAGraphMode": _Mode,
+        "ENV_PROFILE_FORCE_EAGER": "VLLM_DCUT_PROFILE_FORCE_EAGER",
+        "os": SimpleNamespace(
+            environ={"VLLM_DCUT_PROFILE_FORCE_EAGER": "0"},
+        ),
+        "_npu_event": lambda enable_timing: _Event(),
+        "logger": SimpleNamespace(warning=lambda *args, **kwargs: None),
+        "torch": SimpleNamespace(
+            npu=SimpleNamespace(synchronize=lambda: None),
+        ),
+    }
+    exec(compile(module, str(PROFILE_PATH), "exec"), namespace)
+    return namespace["_adaptive_profile_draft_run"]
+
+
+def test_draft_profile_keeps_full_query_shape_and_separate_context_q() -> None:
+    profile = _load_profile_function()
+    runner = _Runner()
+
+    mode, avg_ms, padded_tokens = profile(
+        runner,
+        batch_size=2,
+        context_tokens=6,
+        n_warmup=1,
+        n_measure=2,
+    )
+
+    assert mode == "PCG"
+    assert avg_ms == 4.0
+    assert padded_tokens == 64
+    assert runner.cudagraph_dispatcher.calls[0]["num_tokens"] == 32
+    assert len(runner.drafter.calls) == 3
+    for call in runner.drafter.calls:
+        assert call["num_tokens"] == 64
+        assert call["num_reqs"] == 2
+        assert call["context_num_tokens"] == 6
+
+
+def test_dflash_dummy_uses_separate_context_length() -> None:
+    source = DFLASH_PATH.read_text(encoding="utf-8")
+    assert "context_num_tokens: int | None = None" in source
+    assert "self._dflash_num_context = num_context_tokens" in source
+    assert "self._context_positions_buffer[:num_context_tokens]" in source

--- a/dcut/tests/test_full_decode_multishape.py
+++ b/dcut/tests/test_full_decode_multishape.py
@@ -1,0 +1,577 @@
+# SPDX-License-Identifier: Apache-2.0
+
+import ast
+import sys
+from collections.abc import Iterator, MutableMapping
+from dataclasses import dataclass, replace
+from pathlib import Path
+from types import ModuleType, SimpleNamespace
+from typing import Any
+from unittest.mock import patch
+
+FULL_GRAPH_PATH = Path(__file__).resolve().parents[1] / "patch_full_graph.py"
+RUNNER_PATH = Path(__file__).resolve().parents[1] / "patch_runner.py"
+PROFILE_PATH = Path(__file__).resolve().parents[1] / "dcut_profile.py"
+GDN_FORWARD_PATH = Path(__file__).resolve().parents[1] / "gdn_forward_v023.py"
+GDN_PATCH_PATH = Path(__file__).resolve().parents[1] / "patch_gdn_v023.py"
+PIECEWISE_PATH = Path(__file__).resolve().parents[1] / "patch_piecewise.py"
+
+
+def _load_descriptor_map():
+    tree = ast.parse(FULL_GRAPH_PATH.read_text(encoding="utf-8"))
+    node = next(
+        item
+        for item in tree.body
+        if isinstance(item, ast.ClassDef)
+        and item.name == "_DescriptorGraphParamMap"
+    )
+    module = ast.Module(body=[node], type_ignores=[])
+    ast.fix_missing_locations(module)
+    namespace = {
+        "Any": Any,
+        "Iterator": Iterator,
+        "MutableMapping": MutableMapping,
+    }
+    exec(compile(module, str(FULL_GRAPH_PATH), "exec"), namespace)
+    return namespace["_DescriptorGraphParamMap"]
+
+
+def test_graph_params_are_isolated_for_same_q_and_different_layouts() -> None:
+    graph_param_map = _load_descriptor_map()
+    active_descriptor = {"value": "uniform"}
+    graph_param_map._descriptor = staticmethod(
+        lambda: active_descriptor["value"]
+    )
+    values = graph_param_map({128: []}, list_values=True)
+
+    values[128].append("uniform-handle")
+    active_descriptor["value"] = "ragged"
+    assert values[128] == []
+    values[128].append("ragged-handle")
+
+    active_descriptor["value"] = "uniform"
+    assert values[128] == ["uniform-handle"]
+    active_descriptor["value"] = "ragged"
+    assert values[128] == ["ragged-handle"]
+    assert list(values) == [128]
+
+
+def test_full_decode_contract_keeps_prefill_eager_and_draft_uniform() -> None:
+    full_graph = FULL_GRAPH_PATH.read_text(encoding="utf-8")
+    runner = RUNNER_PATH.read_text(encoding="utf-8")
+
+    assert "CUDAGraphMode.FULL_DECODE_ONLY" in full_graph
+    assert "original_initialize" in full_graph
+    assert "self.add_cudagraph_key(CUDAGraphMode.FULL, ragged)" in full_graph
+    assert "uniform_descriptor = replace(descriptor, uniform=True)" in full_graph
+
+    assert "if not is_all_decode or not is_all_spec_decode:" in runner
+    assert "force_eager = True" in runner
+    assert "_dcut_nonuniform_full_batch" in runner
+    assert "_dcut_is_ragged_full_capture(" in runner
+    assert "_dcut_call_dummy_without_drafter(" in runner
+    assert "max_fia_rows = int(request_capacity) + 1" in runner
+    assert "_dcut_ragged_full_fia_block_tables" in runner
+    assert (
+        "self.compilation_config.cudagraph_mode = CUDAGraphMode.FULL"
+        not in runner
+    )
+    assert "_dcut_zero_draft_handoffs_for_proposal" in runner
+    assert "_patch_live_fia_graph_params()" in full_graph
+
+
+def test_ragged_full_capture_uses_decode_geometry_and_live_fia_rows() -> None:
+    runner = RUNNER_PATH.read_text(encoding="utf-8")
+
+    assert "base, remainder = divmod(int(num_tokens), int(num_reqs))" in runner
+    assert "num_scheduled_tokens_np[:remainder] += 1" in runner
+    assert "self.uniform_decode_query_len" in runner
+    pad_patch = runner[
+        runner.index("    def _pad_query_start_loc_for_fia") :
+        runner.index("    def _build_attention_metadata")
+    ]
+    assert "use_fixed_drafter_fia" in pad_patch
+    assert "return request_capacity + 1" in pad_patch
+    target_fia_patch = pad_patch[
+        pad_patch.index("        # GDN keeps its own fixed-capacity") :
+    ]
+    assert "fia_rows = _dcut_ragged_full_fia_rows(" in pad_patch
+    assert "if fia_rows > num_reqs:" in target_fia_patch
+    assert (
+        "query_start_loc.np[num_reqs + 1] = num_tokens_padded"
+        in target_fia_patch
+    )
+    assert (
+        "query_start_loc.np[request_capacity + 1]"
+        not in target_fia_patch
+    )
+    assert "num_reqs + 1 : request_capacity + 1" not in target_fia_patch
+    assert "gdn_query_start_loc" not in target_fia_patch
+
+    metadata_patch = runner[
+        runner.index("    def _build_attention_metadata") :
+        runner.index("    def _dummy_run")
+    ]
+    assert "max_fia_rows = int(request_capacity) + 1" in metadata_patch
+    assert "stable = storage[:fia_rows]" in metadata_patch
+    assert "_dcut_pad_fia_dummy_seq_len(" in metadata_patch
+    assert "_dcut_pad_fixed_drafter_fia_seq_lens(" in metadata_patch
+    assert "route = \"drafter\"" in metadata_patch
+    assert "route = \"target\"" in metadata_patch
+    assert "metadata.block_tables = stable" in metadata_patch
+
+
+def test_ragged_full_fia_uses_only_one_optional_dummy_row() -> None:
+    tree = ast.parse(RUNNER_PATH.read_text(encoding="utf-8"))
+    names = {
+        "_dcut_ragged_full_fia_rows",
+        "_dcut_pad_fia_dummy_seq_len",
+        "_dcut_pad_fixed_drafter_fia_seq_lens",
+    }
+    nodes = [
+        item
+        for item in tree.body
+        if isinstance(item, ast.FunctionDef) and item.name in names
+    ]
+    assert {item.name for item in nodes} == names
+    module = ast.Module(body=nodes, type_ignores=[])
+    ast.fix_missing_locations(module)
+    namespace = {"DUMMY_FIA_KV_SEQ_LEN": 1}
+    exec(compile(module, str(RUNNER_PATH), "exec"), namespace)
+    fia_rows = namespace["_dcut_ragged_full_fia_rows"]
+    pad_dummy = namespace["_dcut_pad_fia_dummy_seq_len"]
+    pad_fixed_drafter = namespace["_dcut_pad_fixed_drafter_fia_seq_lens"]
+
+    assert fia_rows(96, 128, 32, 96) == 33
+    assert fia_rows(128, 128, 32, 96) == 32
+    assert fia_rows(96, 128, 96, 96) == 97
+    try:
+        fia_rows(96, 128, 97, 96)
+    except RuntimeError as exc:
+        assert "exceeds graph capacity" in str(exc)
+    else:
+        raise AssertionError("expected request-capacity validation")
+
+    class FakeTensorView:
+        def __init__(self, values, selection):
+            self.values = values
+            self.selection = selection
+
+        def fill_(self, value):
+            start, stop, step = self.selection.indices(len(self.values))
+            for index in range(start, stop, step):
+                self.values[index] = value
+
+    class FakeTensor:
+        def __init__(self, values):
+            self.values = values
+            self.shape = (len(values),)
+
+        def __getitem__(self, selection):
+            return FakeTensorView(self.values, selection)
+
+        def tolist(self):
+            return self.values.copy()
+
+    seq_lens = FakeTensor([128, 256, 0, 0, 0])
+    metadata = SimpleNamespace(
+        seq_lens_list=[128, 256, 0, 0, 0],
+        seq_lens=seq_lens,
+        seq_lens_cpu=seq_lens,
+    )
+    pad_dummy(metadata, num_reqs=2, fia_rows=3)
+
+    assert metadata.seq_lens_list == [128, 256, 1, 0, 0]
+    assert metadata.seq_lens.tolist() == [128, 256, 1, 0, 0]
+
+    fixed_seq_lens = FakeTensor([128, 256, 0, 0, 0])
+    fixed_metadata = SimpleNamespace(
+        seq_lens_list=[128, 256, 0, 0, 0],
+        seq_lens=fixed_seq_lens,
+        seq_lens_cpu=fixed_seq_lens,
+    )
+    pad_fixed_drafter(fixed_metadata, num_reqs=2, request_capacity=4)
+
+    assert fixed_metadata.seq_lens_list == [128, 256, 1, 1, 1]
+    assert fixed_metadata.seq_lens.tolist() == [128, 256, 1, 1, 1]
+
+
+def test_full_gdn_contract_uses_fixed_metadata_and_target_weights() -> None:
+    full_graph = FULL_GRAPH_PATH.read_text(encoding="utf-8")
+    runner = RUNNER_PATH.read_text(encoding="utf-8")
+    gdn_forward = GDN_FORWARD_PATH.read_text(encoding="utf-8")
+    gdn_patch = GDN_PATCH_PATH.read_text(encoding="utf-8")
+
+    for weight in ("conv1d.weight", "A_log", "dt_bias"):
+        assert weight in full_graph
+    assert "target_module_ids" in full_graph
+    assert "tensor.data_ptr()" in full_graph
+    assert "_dcut_prepare_gdn_piecewise_replay" in runner
+    assert "_dcut_prepare_gdn_graph_capture" in runner
+    assert "if ragged_full_capture_dummy:" in runner
+    assert "expected_capacity," in runner
+    assert "self.uniform_decode_query_len" in runner
+    assert "graph_request_capacity = getattr(" in runner
+    assert "expected_capacity = min(" in runner
+    assert "int(num_tokens_padded)" in runner
+    assert "_dcut_gdn_full_graph_safe = True" in runner
+    assert '"_dcut_gdn_full_graph_safe"' in gdn_forward
+    assert "full_graph_spec_bufs" in gdn_forward
+    assert "full_graph_safe = getattr(" in gdn_patch
+    assert "if piecewise_graph_safe or full_graph_safe:" in gdn_patch
+    assert "return graphable_spec_forward(" in gdn_patch
+    assert "qwen_gdn_attention_core custom op" in gdn_patch
+    assert "captured ragged FULL GDN graph through the " in runner
+
+
+def test_sink_fia_task_params_rebind_to_live_block_table_view() -> None:
+    tree = ast.parse(FULL_GRAPH_PATH.read_text(encoding="utf-8"))
+    node = next(
+        item
+        for item in tree.body
+        if isinstance(item, ast.FunctionDef)
+        and item.name == "_dcut_rebind_live_fia_block_tables"
+    )
+    module = ast.Module(body=[node], type_ignores=[])
+    ast.fix_missing_locations(module)
+    namespace: dict[str, Any] = {}
+    exec(compile(module, str(FULL_GRAPH_PATH), "exec"), namespace)
+    rebind = namespace["_dcut_rebind_live_fia_block_tables"]
+
+    first = SimpleNamespace(block_tables="live-first")
+    second = SimpleNamespace(block_tables="live-second")
+    captured = [
+        ("q0", "k0", "v0", "captured-0", "tail", "layer.1"),
+        ("q1", "k1", "v1", "captured-1", "tail", None),
+    ]
+    rebind(
+        captured,
+        {
+            "layer.0": first,
+            "layer.1": second,
+        },
+    )
+
+    assert captured[0][3] == "live-second"
+    assert captured[1][3] == "live-second"
+    assert captured[0][:3] == ("q0", "k0", "v0")
+    assert captured[0][4:] == ("tail", "layer.1")
+
+
+def test_live_fia_patch_wraps_attention_implementation_class() -> None:
+    tree = ast.parse(FULL_GRAPH_PATH.read_text(encoding="utf-8"))
+    node = next(
+        item
+        for item in tree.body
+        if isinstance(item, ast.FunctionDef)
+        and item.name == "_patch_live_fia_graph_params"
+    )
+    module = ast.Module(body=[node], type_ignores=[])
+    ast.fix_missing_locations(module)
+
+    observed = []
+
+    class AttentionImpl:
+        @staticmethod
+        def update_graph_params(*args, **kwargs):
+            observed.append((args, kwargs))
+            return "native-update"
+
+    class AttentionBackend:
+        @staticmethod
+        def get_impl_cls():
+            return AttentionImpl
+
+    root_module = ModuleType("vllm_ascend")
+    root_module.__path__ = []
+    attention_package = ModuleType("vllm_ascend.attention")
+    attention_package.__path__ = []
+    compilation_package = ModuleType("vllm_ascend.compilation")
+    compilation_package.__path__ = []
+    forward_context_module = ModuleType(
+        "vllm_ascend.ascend_forward_context"
+    )
+    forward_context_module._EXTRA_CTX = SimpleNamespace(sinks=None)
+    attention_module = ModuleType("vllm_ascend.attention.attention_v1")
+    attention_module.AscendAttentionBackend = AttentionBackend
+    attention_utils_module = ModuleType("vllm_ascend.attention.utils")
+    attention_utils_module.using_paged_attention = lambda *_args: False
+    acl_graph_module = ModuleType("vllm_ascend.compilation.acl_graph")
+    acl_graph_module.get_graph_params = lambda: SimpleNamespace()
+
+    namespace = {
+        "logger": SimpleNamespace(info=lambda *_args, **_kwargs: None),
+        "_dcut_rebind_live_fia_block_tables": lambda *_args: None,
+    }
+    exec(compile(module, str(FULL_GRAPH_PATH), "exec"), namespace)
+    patch_live_fia = namespace["_patch_live_fia_graph_params"]
+
+    modules = {
+        "vllm_ascend": root_module,
+        "vllm_ascend.attention": attention_package,
+        "vllm_ascend.compilation": compilation_package,
+        "vllm_ascend.ascend_forward_context": forward_context_module,
+        "vllm_ascend.attention.attention_v1": attention_module,
+        "vllm_ascend.attention.utils": attention_utils_module,
+        "vllm_ascend.compilation.acl_graph": acl_graph_module,
+    }
+    with patch.dict(sys.modules, modules):
+        patch_live_fia()
+        patched_update = AttentionImpl.update_graph_params
+        patch_live_fia()
+
+    assert not hasattr(AttentionBackend, "_dcut_live_fia_rows_patched")
+    assert AttentionImpl._dcut_live_fia_rows_patched is True
+    assert patched_update is AttentionImpl.update_graph_params
+    forward_context = SimpleNamespace(
+        batch_descriptor=None,
+        cudagraph_runtime_mode=None,
+    )
+    assert (
+        patched_update(None, forward_context, 128, object())
+        == "native-update"
+    )
+    assert len(observed) == 1
+
+
+def test_ragged_full_capacity_is_fixed_by_token_bucket() -> None:
+    tree = ast.parse(FULL_GRAPH_PATH.read_text(encoding="utf-8"))
+    node = next(
+        item
+        for item in tree.body
+        if isinstance(item, ast.FunctionDef)
+        and item.name == "_dcut_ragged_full_request_capacity"
+    )
+    module = ast.Module(body=[node], type_ignores=[])
+    ast.fix_missing_locations(module)
+    namespace: dict[str, Any] = {}
+    exec(compile(module, str(FULL_GRAPH_PATH), "exec"), namespace)
+    capacity = namespace["_dcut_ragged_full_request_capacity"]
+
+    assert capacity(32, 96) == 32
+    assert capacity(64, 96) == 64
+    assert capacity(128, 96) == 96
+    assert capacity(512, 96) == 96
+
+
+def test_profile_only_marks_the_full_rectangle_uniform() -> None:
+    profile = PROFILE_PATH.read_text(encoding="utf-8")
+
+    assert "profile_uniform_decode = (" in profile
+    assert "force_uniform_decode=profile_uniform_decode" in profile
+    assert "force_uniform_decode=True" not in profile
+    assert "self._pad_query_start_loc_for_fia(" in profile
+    assert "self.gdn_query_start_loc.np[num_reqs + 1 :].fill(" in profile
+
+
+def test_full_only_hooks_are_inert_in_piecewise_mode() -> None:
+    full_graph = FULL_GRAPH_PATH.read_text(encoding="utf-8")
+    gdn_patch = GDN_PATCH_PATH.read_text(encoding="utf-8")
+    piecewise = PIECEWISE_PATH.read_text(encoding="utf-8")
+    runner = RUNNER_PATH.read_text(encoding="utf-8")
+
+    assert "self.cudagraph_mode != CUDAGraphMode.PIECEWISE" in piecewise
+    assert "configured_mode != \"FULL_DECODE_ONLY\"" in gdn_patch
+    assert (
+        "_patch_graph_params_by_descriptor()"
+        in full_graph[full_graph.index("CUDAGraphMode.FULL_DECODE_ONLY") :]
+    )
+    assert '== "PIECEWISE"' in runner
+    assert "clear_unused_rows=True" in runner
+
+
+@dataclass(frozen=True)
+class _Descriptor:
+    uniform: bool
+
+
+def _load_drafter_setup():
+    tree = ast.parse(FULL_GRAPH_PATH.read_text(encoding="utf-8"))
+    node = next(
+        item
+        for item in tree.body
+        if isinstance(item, ast.FunctionDef)
+        and item.name == "_dcut_setup_full_decode_drafter"
+    )
+    module = ast.Module(body=[node], type_ignores=[])
+    ast.fix_missing_locations(module)
+    namespace = {
+        "replace": replace,
+        "_dcut_full_decode_multishape_enabled": lambda config: True,
+        "_dcut_has_prefill": (
+            lambda runner, scheduler_output, zero_draft_handoffs: (
+                scheduler_output.has_prefill
+                and not zero_draft_handoffs
+            )
+        ),
+        "logger": SimpleNamespace(warning=lambda *args, **kwargs: None),
+    }
+    exec(compile(module, str(FULL_GRAPH_PATH), "exec"), namespace)
+    return namespace["_dcut_setup_full_decode_drafter"]
+
+
+def test_drafter_routes_ragged_decode_to_uniform_and_prefill_to_eager() -> None:
+    setup_drafter = _load_drafter_setup()
+
+    class CUDAGraphMode:
+        FULL_DECODE_ONLY = "FULL_DECODE_ONLY"
+        NONE = "NONE"
+
+    vllm_module = ModuleType("vllm")
+    config_module = ModuleType("vllm.config")
+    config_module.CUDAGraphMode = CUDAGraphMode
+    vllm_module.config = config_module
+
+    runner = SimpleNamespace(
+        vllm_config=SimpleNamespace(),
+        compilation_config=SimpleNamespace(
+            cudagraph_mode=CUDAGraphMode.FULL_DECODE_ONLY
+        ),
+    )
+    observed = []
+
+    class Drafter:
+        use_cuda_graph = True
+        fail = False
+
+        def _propose(self, *args, **kwargs):
+            observed.append(
+                (
+                    kwargs["target_model_batch_desc"].uniform,
+                    self.use_cuda_graph,
+                    getattr(
+                        runner,
+                        "_dcut_drafter_from_nonuniform_decode",
+                        False,
+                    ),
+                )
+            )
+            if self.fail:
+                raise RuntimeError("injected proposer failure")
+            return "ok"
+
+    drafter = Drafter()
+    with patch.dict(
+        sys.modules,
+        {"vllm": vllm_module, "vllm.config": config_module},
+    ):
+        setup_drafter(runner, drafter)
+        assert drafter._propose(
+            target_model_batch_desc=_Descriptor(uniform=False),
+            scheduler_output=SimpleNamespace(has_prefill=False),
+        ) == "ok"
+        assert not hasattr(
+            runner,
+            "_dcut_drafter_from_nonuniform_decode",
+        )
+        assert drafter._propose(
+            target_model_batch_desc=_Descriptor(uniform=False),
+            scheduler_output=SimpleNamespace(has_prefill=True),
+        ) == "ok"
+
+        runner._dcut_zero_draft_handoffs_for_proposal = frozenset(
+            {"handoff"}
+        )
+        assert drafter._propose(
+            target_model_batch_desc=_Descriptor(uniform=False),
+            scheduler_output=SimpleNamespace(has_prefill=True),
+        ) == "ok"
+        del runner._dcut_zero_draft_handoffs_for_proposal
+
+        drafter.fail = True
+        for has_prefill in (False, True):
+            try:
+                drafter._propose(
+                    target_model_batch_desc=_Descriptor(uniform=False),
+                    scheduler_output=SimpleNamespace(
+                        has_prefill=has_prefill
+                    ),
+                )
+            except RuntimeError as exc:
+                assert str(exc) == "injected proposer failure"
+            else:
+                raise AssertionError("expected injected proposer failure")
+            assert drafter.use_cuda_graph is True
+            assert not hasattr(
+                runner,
+                "_dcut_drafter_from_nonuniform_decode",
+            )
+
+    assert observed == [
+        (True, True, True),
+        (False, False, False),
+        (True, True, True),
+        (True, True, True),
+        (False, False, False),
+    ]
+    assert drafter.use_cuda_graph is True
+
+
+def test_runner_suppresses_drafter_for_ragged_full_capture() -> None:
+    tree = ast.parse(RUNNER_PATH.read_text(encoding="utf-8"))
+    names = {
+        "_dcut_call_dummy_without_drafter",
+        "_dcut_is_ragged_full_capture",
+    }
+    nodes = [
+        item
+        for item in tree.body
+        if isinstance(item, ast.FunctionDef) and item.name in names
+    ]
+    assert {item.name for item in nodes} == names
+    module = ast.Module(body=nodes, type_ignores=[])
+    ast.fix_missing_locations(module)
+    namespace = {
+        "_dcut_full_decode_multishape_enabled": lambda config: True,
+    }
+    exec(compile(module, str(RUNNER_PATH), "exec"), namespace)
+
+    is_ragged_full = namespace["_dcut_is_ragged_full_capture"]
+    call_dummy = namespace["_dcut_call_dummy_without_drafter"]
+    full_mode = SimpleNamespace(name="FULL")
+    runner = SimpleNamespace(vllm_config=object(), drafter=object())
+
+    assert is_ragged_full(runner, full_mode, False, True) is True
+    assert is_ragged_full(runner, full_mode, True, True) is False
+    assert is_ragged_full(
+        runner,
+        SimpleNamespace(name="PIECEWISE"),
+        False,
+        True,
+    ) is False
+    assert is_ragged_full(runner, full_mode, False, False) is False
+
+    original_drafter = runner.drafter
+    observed = []
+
+    def dummy(active_runner, num_tokens, marker=None):
+        observed.append((active_runner.drafter, num_tokens, marker))
+        return "target-ran"
+
+    assert call_dummy(
+        runner,
+        dummy,
+        448,
+        (),
+        {"marker": "ragged"},
+        True,
+    ) == "target-ran"
+    assert observed == [(None, 448, "ragged")]
+    assert runner.drafter is original_drafter
+
+    try:
+        call_dummy(
+            runner,
+            lambda *_args, **_kwargs: (_ for _ in ()).throw(
+                RuntimeError("injected failure")
+            ),
+            448,
+            (),
+            {},
+            True,
+        )
+    except RuntimeError as exc:
+        assert str(exc) == "injected failure"
+    else:
+        raise AssertionError("expected injected failure")
+    assert runner.drafter is original_drafter

--- a/dcut/tests/test_gdn_kernels_v023.py
+++ b/dcut/tests/test_gdn_kernels_v023.py
@@ -1,0 +1,136 @@
+# SPDX-License-Identifier: Apache-2.0
+
+from pathlib import Path
+
+DCUT_ROOT = Path(__file__).resolve().parents[1]
+KERNEL_ROOT = DCUT_ROOT / "kernel"
+
+
+def _read(relative_path: str) -> str:
+    return (DCUT_ROOT / relative_path).read_text(encoding="utf-8")
+
+
+def test_piecewise_gdn_core_uses_recurrent_boundary_inputs() -> None:
+    patch = _read("patch_gdn_v023.py")
+    piecewise = _read("patch_piecewise.py")
+    core = _read("gdn_forward_v023.py")
+    assert "native_forward = target_class.forward" in patch
+    runner = _read("patch_runner.py")
+
+    assert "native_forward_core = target_class._forward_core" in patch
+    assert "target_class._forward_core = _dcut_forward_core" in patch
+    assert "return dcut_forward_core(" in patch
+    assert "target_class.forward = _dcut_forward" in patch
+    assert "_patch_gdn_spec_metadata_builder" in patch
+    assert "actual_seq_lengths=attn_metadata.spec_query_start_loc" in patch
+    assert "_build_actual_seq_lengths(" not in patch
+    assert "torch.ops.vllm.qwen_gdn_attention_core" in core
+    assert '_WHOLE_GDN_OP = "vllm::qwen_gdn_attention_core"' in piecewise
+    assert '_RECURRENT_OP = "vllm::dcut_gdn_recurrent"' in piecewise
+    assert "_ensure_gdn_splitting_ops(" in piecewise
+    assert "_dcut_get_gdn_piecewise_spec_bufs" in core
+    assert "piecewise_spec_bufs[\"token_mask\"]" not in core
+    assert "zero_padded_output=piecewise_spec_bufs is not None" in core
+    assert "_dcut_prepare_gdn_eager_state" in runner
+    assert "_dcut_prepare_gdn_piecewise_replay" in runner
+    assert "CUDAGraphMode.NONE" not in runner
+    assert "_dcut_gdn_local_graph" not in runner
+    assert "_dcut_gdn_piecewise_capture_sizes" not in runner
+    assert "torch.npu.NPUGraph" not in core
+    assert "graph.replay()" not in core
+    assert "clear_unused_rows=True" in runner
+    assert "_dcut_gdn_recurrent_piecewise_safe" in runner
+    assert "npu_dcut_causal_conv1d" in core
+    assert "torch.ops.vllm.dcut_gdn_recurrent" in core
+    assert 'op_name="dcut_gdn_recurrent"' in core
+    assert 'mutates_args=["state"]' in core
+    assert "ssm_state_indices=spec_state_indices_tensor.flatten()" not in core
+    assert "if use_recurrent_boundary" in core
+    assert "else torch.ops._C_ascend.npu_dcut_recurrent_gated_delta_rule" in core
+    assert 'eager_spec_state["query_start_loc"]' in core
+    assert 'piecewise_spec_bufs["qsl"]' in core
+    assert 'eager_spec_state["conv_state_offsets"]' not in core
+    assert 'piecewise_spec_bufs["conv_state_offsets"]' not in core
+    assert 'eager_spec_state["num_accepted_tokens"]' in core
+
+
+def test_piecewise_replay_preserves_previous_accepted_state() -> None:
+    buffers = _read("gdn_buffers.py")
+    fill_start = buffers.index(
+        "def _dcut_fill_gdn_piecewise_spec_bufs("
+    )
+    fill_end = buffers.index(
+        "def _dcut_prepare_gdn_piecewise_replay("
+    )
+    fill = buffers[fill_start:fill_end]
+
+    assert "nat[:num_spec_decodes].copy_(" in fill
+    assert "torch.sub(nat, 1, out=conv_state_offsets)" not in fill
+    assert "torch.lt(" not in fill
+    assert "qsl.zero_()" not in fill
+    assert "if clear_unused_rows:" in fill
+    assert "ssi.fill_(PAD_SLOT_ID)" in fill
+    assert "torch.minimum(" not in fill
+    assert "current segment length" in fill
+    assert "fill_shared_batch=index == 0" in buffers
+
+
+def test_recurrent_kernel_uses_fixed_request_rows() -> None:
+    for relative_path in (
+        "kernel/dcut_recurrent_gated_delta_rule/vendor/op_kernel/recurrent_gated_delta_rule.h",
+        "kernel/dcut_recurrent_gated_delta_rule/vendor/op_kernel/arch35/recurrent_gated_delta_rule.h",
+    ):
+        kernel = _read(relative_path)
+        assert "batch_i * stateIndexStride_ + (seq_i - seq0)" in kernel
+        assert "stateTokenIdx += acceptedTokenNum - 1" in kernel
+        assert "acceptedTokenNum > static_cast<int32_t>(stateIndexStride_)" in kernel
+
+
+def test_recurrent_kernel_consumes_query_start_locations() -> None:
+    wrapper = _read(
+        "kernel/dcut_recurrent_gated_delta_rule/op_kernel/"
+        "dcut_recurrent_gated_delta_rule.cpp"
+    )
+    assert "DCUT_RECURRENT_QUERY_START_LOC" in wrapper
+
+    for relative_path in (
+        "kernel/dcut_recurrent_gated_delta_rule/vendor/op_kernel/recurrent_gated_delta_rule.h",
+        "kernel/dcut_recurrent_gated_delta_rule/vendor/op_kernel/arch35/recurrent_gated_delta_rule.h",
+    ):
+        kernel = _read(relative_path)
+        assert "#if defined(DCUT_RECURRENT_QUERY_START_LOC)" in kernel
+        assert "const int32_t seqLen = seq1 - seq0;" in kernel
+        assert (
+            "gamaInQueue_.FreeTensor(gamaInUb);\n"
+            "            }\n"
+            "            seq0 = seq1;"
+        ) in kernel
+
+
+def test_conv_kernel_derives_state_offsets_from_accepted_counts() -> None:
+    wrapper = _read("kernel/dcut_causal_conv1d/op_kernel/dcut_causal_conv1d.cpp")
+    kernel = _read("kernel/dcut_causal_conv1d/vendor/op_kernel/causal_conv1d.h")
+
+    assert "DCUT_CAUSAL_CONV_DIRECT_STATE_OFFSETS" not in wrapper
+    assert "int32_t accepted = ReadNumAcceptedTokensValue(seq);" in kernel
+    assert "stateTokenOffset = accepted - 1;" in kernel
+
+
+def test_torch_registration_has_graph_metadata() -> None:
+    binding = _read("kernel/torch_extension/dcut_torch_binding.cpp")
+
+    assert "TORCH_LIBRARY_FRAGMENT(_C_ascend, ops)" in binding
+    assert "TORCH_LIBRARY_IMPL(_C_ascend, PrivateUse1, ops)" in binding
+    assert "TORCH_LIBRARY_IMPL(_C_ascend, Meta, ops)" in binding
+    assert "Tensor(a!) state" in binding
+    assert "Tensor(b!) conv_state" in binding
+    assert "Tensor? query_start_loc=None" in binding
+    assert "Tensor? num_accepted_tokens=None" in binding
+    assert "bool zero_padded_output=False" in binding
+
+
+def test_truncation_has_no_previous_acceptance_floor() -> None:
+    truncate = _read("truncate.py")
+
+    assert "_get_gdn_min_draft_lens" not in truncate
+    assert "gdn_min_draft_lens" not in truncate

--- a/dcut/tests/test_gdn_local_graph_router.py
+++ b/dcut/tests/test_gdn_local_graph_router.py
@@ -1,0 +1,22 @@
+# SPDX-License-Identifier: Apache-2.0
+
+from pathlib import Path
+
+DCUT_ROOT = Path(__file__).resolve().parents[1]
+
+
+def _read(relative_path: str) -> str:
+    return (DCUT_ROOT / relative_path).read_text(encoding="utf-8")
+
+
+def test_piecewise_gdn_does_not_nest_a_local_npugraph() -> None:
+    core = _read("gdn_forward_v023.py")
+    runner = _read("patch_runner.py")
+
+    assert "torch.npu.NPUGraph" not in core
+    assert "graph.replay()" not in core
+    assert "_dcut_gdn_local_graph" not in core
+    assert "_dcut_gdn_local_graph" not in runner
+    assert "forward_with_recurrent_boundary" in core
+    assert "torch.ops.vllm.dcut_gdn_recurrent" in core
+    assert "_dcut_gdn_recurrent_piecewise_safe" in runner

--- a/dcut/tests/test_gdn_native_prefill_route.py
+++ b/dcut/tests/test_gdn_native_prefill_route.py
@@ -1,0 +1,339 @@
+# SPDX-License-Identifier: Apache-2.0
+
+import ast
+from dataclasses import dataclass, replace
+from pathlib import Path
+from types import SimpleNamespace
+
+PATCH_PATH = Path(__file__).resolve().parents[1] / "patch_gdn_v023.py"
+RUNNER_PATCH_PATH = Path(__file__).resolve().parents[1] / "patch_runner.py"
+
+
+def _load_prefill_routers():
+    tree = ast.parse(PATCH_PATH.read_text(encoding="utf-8"))
+    functions = [
+        node
+        for node in tree.body
+        if isinstance(node, ast.FunctionDef)
+        and node.name
+        in {"_dcut_gdn_has_prefill", "_dcut_gdn_use_native_core"}
+    ]
+    module = ast.Module(body=functions, type_ignores=[])
+    ast.fix_missing_locations(module)
+    namespace = {}
+    exec(compile(module, str(PATCH_PATH), "exec"), namespace)
+    return (
+        namespace["_dcut_gdn_has_prefill"],
+        namespace["_dcut_gdn_use_native_core"],
+    )
+
+
+def test_prefill_batch_routes_to_native_gdn_core() -> None:
+    has_prefill, use_native = _load_prefill_routers()
+    context = SimpleNamespace(
+        attn_metadata={
+            "layers.0.mixer": SimpleNamespace(num_prefills=1),
+            "layers.1.mixer": SimpleNamespace(num_prefills=1),
+        }
+    )
+
+    assert has_prefill(context)
+    assert has_prefill(context, "layers.0.mixer")
+    assert use_native(context, "layers.0.mixer")
+
+
+def test_pure_spec_batch_keeps_dcut_gdn_core() -> None:
+    has_prefill, use_native = _load_prefill_routers()
+    context = SimpleNamespace(
+        attn_metadata={
+            "layers.0.mixer": SimpleNamespace(num_prefills=0),
+        }
+    )
+
+    assert not has_prefill(context)
+    assert not has_prefill(context, "layers.0.mixer")
+    assert not use_native(context, "layers.0.mixer")
+
+
+def test_uniform_full_graph_keeps_stock_gdn_core() -> None:
+    _, use_native = _load_prefill_routers()
+    context = SimpleNamespace(
+        cudagraph_runtime_mode=SimpleNamespace(name="FULL"),
+        batch_descriptor=SimpleNamespace(uniform=True),
+        _dcut_gdn_native_batch=False,
+        attn_metadata={
+            "layers.0.mixer": SimpleNamespace(num_prefills=0),
+        },
+    )
+
+    assert use_native(context, "layers.0.mixer")
+    context.batch_descriptor.uniform = False
+    assert not use_native(context, "layers.0.mixer")
+
+
+def test_scheduler_non_prefill_overrides_synthetic_gdn_prefill() -> None:
+    has_prefill, use_native = _load_prefill_routers()
+    context = SimpleNamespace(
+        _dcut_gdn_native_batch=False,
+        attn_metadata={
+            # The native GDN builder reports ordinary decode rows here when
+            # speculative and non-speculative decode coexist.
+            "layers.0.mixer": SimpleNamespace(num_prefills=3),
+        },
+    )
+
+    assert has_prefill(context, "layers.0.mixer")
+    assert not use_native(context, "layers.0.mixer")
+
+
+def test_reused_context_can_return_to_pure_spec_route() -> None:
+    has_prefill, use_native = _load_prefill_routers()
+    context = SimpleNamespace(
+        _dcut_gdn_native_batch=True,
+        attn_metadata={
+            "layers.0.mixer": SimpleNamespace(num_prefills=0),
+        },
+    )
+
+    assert not has_prefill(context)
+    assert use_native(context, "layers.0.mixer")
+
+    context._dcut_gdn_native_batch = False
+    assert not use_native(context, "layers.0.mixer")
+
+
+def test_prefill_metadata_uses_native_builder() -> None:
+    tree = ast.parse(PATCH_PATH.read_text(encoding="utf-8"))
+    function = next(
+        node
+        for node in tree.body
+        if isinstance(node, ast.FunctionDef)
+        and node.name == "_patch_gdn_spec_metadata_builder"
+    )
+    module = ast.Module(body=[function], type_ignores=[])
+    ast.fix_missing_locations(module)
+    namespace = {"replace": replace}
+    exec(compile(module, str(PATCH_PATH), "exec"), namespace)
+
+    calls = []
+
+    def native_builder(self, attn_metadata):
+        calls.append(attn_metadata)
+        return "native"
+
+    def native_build(
+        self,
+        common_prefix_len,
+        common_attn_metadata,
+        num_accepted_tokens=None,
+        num_decode_draft_tokens_cpu=None,
+        fast_build=False,
+    ):
+        return common_attn_metadata
+
+    class MetadataBuilder:
+        build = native_build
+        _attach_spec_decode_metadata = native_builder
+
+    fake_module = SimpleNamespace(
+        AscendGDNAttentionMetadataBuilder=MetadataBuilder
+    )
+    namespace["_patch_gdn_spec_metadata_builder"](fake_module)
+    metadata = SimpleNamespace(num_prefills=1)
+
+    builder = MetadataBuilder()
+    assert builder._attach_spec_decode_metadata(metadata) == "native"
+
+    # A recompute handoff is decode-only from the metadata builder's point of
+    # view, but must still keep the native metadata paired with the native core.
+    handoff_metadata = SimpleNamespace(num_prefills=0)
+    builder._dcut_force_native_gdn_metadata = True
+    assert builder._attach_spec_decode_metadata(handoff_metadata) == "native"
+    assert calls == [metadata, handoff_metadata]
+
+
+def test_fia_dummy_request_is_removed_from_gdn_metadata() -> None:
+    tree = ast.parse(PATCH_PATH.read_text(encoding="utf-8"))
+    function = next(
+        node
+        for node in tree.body
+        if isinstance(node, ast.FunctionDef)
+        and node.name == "_patch_gdn_spec_metadata_builder"
+    )
+    module = ast.Module(body=[function], type_ignores=[])
+    ast.fix_missing_locations(module)
+
+    calls = []
+
+    def native_build(
+        self,
+        common_prefix_len,
+        common_attn_metadata,
+        num_accepted_tokens=None,
+        num_decode_draft_tokens_cpu=None,
+        fast_build=False,
+    ):
+        calls.append(
+            (
+                common_attn_metadata.num_reqs,
+                len(common_attn_metadata.query_start_loc_cpu),
+                len(num_accepted_tokens),
+                len(num_decode_draft_tokens_cpu),
+            )
+        )
+        return common_attn_metadata
+
+    def native_attach(self, attn_metadata):
+        return attn_metadata
+
+    class MetadataBuilder:
+        vllm_config = SimpleNamespace(
+            compilation_config=SimpleNamespace(
+                cudagraph_mode=SimpleNamespace(name="FULL_DECODE_ONLY")
+            )
+        )
+        build = native_build
+        _attach_spec_decode_metadata = native_attach
+
+    namespace = {"replace": replace}
+    exec(compile(module, str(PATCH_PATH), "exec"), namespace)
+    namespace["_patch_gdn_spec_metadata_builder"](
+        SimpleNamespace(AscendGDNAttentionMetadataBuilder=MetadataBuilder)
+    )
+
+    @dataclass
+    class CommonMetadata:
+        query_start_loc_cpu: list[int]
+        num_reqs: int
+        num_actual_tokens: int
+
+        def unpadded(self, num_actual_tokens, num_actual_reqs):
+            return replace(
+                self,
+                query_start_loc_cpu=self.query_start_loc_cpu[
+                    : num_actual_reqs + 1
+                ],
+                num_reqs=num_actual_reqs,
+                num_actual_tokens=num_actual_tokens,
+            )
+
+    common = CommonMetadata(
+        query_start_loc_cpu=[0, 2, 5, 5],
+        num_reqs=3,
+        num_actual_tokens=5,
+    )
+    accepted = [1, 1, 1]
+    draft_lens = [1, 2, -1]
+    result = MetadataBuilder().build(
+        0, common, accepted, draft_lens, False
+    )
+
+    assert result.num_reqs == 2
+    assert calls == [(2, 3, 2, 2)]
+
+    # The same wrapper is inert under PIECEWISE: no FIA-specific request
+    # unpadding or per-request tensor slicing is allowed to leak across modes.
+    MetadataBuilder.vllm_config.compilation_config.cudagraph_mode.name = (
+        "PIECEWISE"
+    )
+    piecewise_result = MetadataBuilder().build(
+        0, common, accepted, draft_lens, False
+    )
+    assert piecewise_result.num_reqs == 3
+    assert calls[-1] == (3, 4, 3, 3)
+
+    # FULL_DECODE_ONLY normally removes the FIA dummy request. Recompute
+    # handoff routing must bypass that D-Cut wrapper as well.
+    MetadataBuilder.vllm_config.compilation_config.cudagraph_mode.name = (
+        "FULL_DECODE_ONLY"
+    )
+    native_builder = MetadataBuilder()
+    native_builder._dcut_force_native_gdn_metadata = True
+    native_result = native_builder.build(
+        0, common, accepted, draft_lens, False
+    )
+    assert native_result.num_reqs == 3
+    assert calls[-1] == (3, 4, 3, 3)
+
+
+def _load_native_recompute_handoff_router():
+    tree = ast.parse(RUNNER_PATCH_PATH.read_text(encoding="utf-8"))
+    names = {
+        "_dcut_execute_with_gdn_prefill_route",
+        "_dcut_execute_native_recompute_handoff",
+    }
+    functions = [
+        node
+        for node in tree.body
+        if isinstance(node, ast.FunctionDef) and node.name in names
+    ]
+    module = ast.Module(body=functions, type_ignores=[])
+    ast.fix_missing_locations(module)
+    namespace = {}
+    exec(compile(module, str(RUNNER_PATCH_PATH), "exec"), namespace)
+    return namespace["_dcut_execute_native_recompute_handoff"]
+
+
+def test_recompute_handoff_pairs_native_core_and_metadata() -> None:
+    def patched_attach(self, metadata):
+        return metadata
+
+    patched_attach._dcut_patched = True
+
+    class Builder:
+        _attach_spec_decode_metadata = patched_attach
+
+    builder = Builder()
+    group = SimpleNamespace(get_metadata_builder=lambda _ubid=0: builder)
+    runner = SimpleNamespace(attn_groups=[[group]])
+    route = _load_native_recompute_handoff_router()
+
+    def execute(runner_arg, scheduler_output, intermediate_tensors):
+        assert runner_arg is runner
+        assert scheduler_output == "scheduler"
+        assert intermediate_tensors == "intermediate"
+        assert runner._dcut_recompute_handoff_active is True
+        assert runner._dcut_gdn_scheduler_has_prefill is True
+        assert builder._dcut_force_native_gdn_metadata is True
+        return "native-result"
+
+    assert route(runner, execute, "scheduler", "intermediate") == (
+        "native-result"
+    )
+    assert not hasattr(runner, "_dcut_recompute_handoff_active")
+    assert not hasattr(runner, "_dcut_gdn_scheduler_has_prefill")
+    assert not hasattr(builder, "_dcut_force_native_gdn_metadata")
+
+
+def test_recompute_handoff_restores_route_flags_after_failure() -> None:
+    def patched_attach(self, metadata):
+        return metadata
+
+    patched_attach._dcut_patched = True
+
+    class Builder:
+        _attach_spec_decode_metadata = patched_attach
+
+    builder = Builder()
+    builder._dcut_force_native_gdn_metadata = "previous-builder"
+    group = SimpleNamespace(get_metadata_builder=lambda _ubid=0: builder)
+    runner = SimpleNamespace(
+        attn_groups=[[group]],
+        _dcut_recompute_handoff_active="previous-runner",
+        _dcut_gdn_scheduler_has_prefill="previous-core-route",
+    )
+    route = _load_native_recompute_handoff_router()
+
+    def fail(*_args):
+        raise RuntimeError("expected")
+
+    try:
+        route(runner, fail, None, None)
+    except RuntimeError as exc:
+        assert str(exc) == "expected"
+    else:
+        raise AssertionError("expected recompute handoff execution to fail")
+
+    assert runner._dcut_recompute_handoff_active == "previous-runner"
+    assert runner._dcut_gdn_scheduler_has_prefill == "previous-core-route"
+    assert builder._dcut_force_native_gdn_metadata == "previous-builder"

--- a/dcut/tests/test_gdn_piecewise_graph_switch.py
+++ b/dcut/tests/test_gdn_piecewise_graph_switch.py
@@ -1,0 +1,173 @@
+# SPDX-License-Identifier: Apache-2.0
+
+import ast
+from pathlib import Path
+
+DCUT_ROOT = Path(__file__).resolve().parents[1]
+REPO_ROOT = DCUT_ROOT.parent
+
+
+def _read(relative_path: str) -> str:
+    return (DCUT_ROOT / relative_path).read_text(encoding="utf-8")
+
+
+def _load_piecewise_helpers():
+    tree = ast.parse(_read("patch_piecewise.py"))
+    names = {
+        "_env_flag",
+        "_is_enabled",
+        "_ensure_gdn_splitting_ops",
+    }
+    functions = [
+        node
+        for node in tree.body
+        if isinstance(node, ast.FunctionDef) and node.name in names
+    ]
+    assignments = [
+        node
+        for node in tree.body
+        if isinstance(node, ast.Assign)
+        and any(
+            isinstance(target, ast.Name)
+            and target.id.startswith(
+                ("ENV_", "LEGACY_ENV_", "_WHOLE_", "_RECURRENT_")
+            )
+            for target in node.targets
+        )
+    ]
+    module = ast.Module(body=assignments + functions, type_ignores=[])
+    namespace = {"os": __import__("os")}
+    exec(compile(module, "patch_piecewise.py", "exec"), namespace)
+    return namespace
+
+
+def _load_capture_qsl_helper():
+    tree = ast.parse(_read("gdn_buffers.py"))
+    function = next(
+        node
+        for node in tree.body
+        if isinstance(node, ast.FunctionDef)
+        and node.name == "_dcut_graph_capture_qsl"
+    )
+    namespace = {}
+    exec(
+        compile(
+            ast.Module(body=[function], type_ignores=[]),
+            "gdn_buffers.py",
+            "exec",
+        ),
+        namespace,
+    )
+    return namespace["_dcut_graph_capture_qsl"]
+
+
+def test_piecewise_capture_qsl_supports_ragged_token_buckets() -> None:
+    build_qsl = _load_capture_qsl_helper()
+
+    qsl_1480 = build_qsl(1480, 16, 96)
+    assert len(qsl_1480) == 94
+    assert qsl_1480[-2:] == (1472, 1480)
+
+    qsl_1408 = build_qsl(1408, 16, 96)
+    assert len(qsl_1408) == 89
+    assert qsl_1408[-1] == 1408
+
+    assert build_qsl(1536, 16, 96)[-1] == 1536
+    assert build_qsl(1537, 16, 96) == ()
+
+
+def test_piecewise_switch_is_registered_and_default_off() -> None:
+    envs = (REPO_ROOT / "vllm_ascend" / "envs.py").read_text(
+        encoding="utf-8"
+    )
+    piecewise = _read("patch_piecewise.py")
+
+    assert '"VLLM_ASCEND_ENABLE_DCUT_GDN_PIECEWISE": lambda: bool(' in envs
+    assert (
+        'os.getenv("VLLM_ASCEND_ENABLE_DCUT_GDN_PIECEWISE", "0")'
+        in envs
+    )
+    assert 'ENV_DCUT_CONFIG = "VLLM_DCUT_CONFIG"' in piecewise
+    assert (
+        'ENV_GDN_PIECEWISE = "VLLM_ASCEND_ENABLE_DCUT_GDN_PIECEWISE"'
+        in piecewise
+    )
+    assert "if not _is_enabled():" in piecewise
+    assert "self.cudagraph_mode != CUDAGraphMode.PIECEWISE" in piecewise
+
+
+def test_enabled_switch_keeps_native_boundary_and_captures_recurrent(
+    monkeypatch,
+) -> None:
+    helpers = _load_piecewise_helpers()
+    monkeypatch.setenv("VLLM_DCUT_CONFIG", "/tmp/dcut.json")
+    monkeypatch.setenv("VLLM_DCUT_GDN_PIECEWISE", "1")
+
+    assert helpers["_is_enabled"]()
+    ops = helpers["_ensure_gdn_splitting_ops"](
+        [
+            "vllm::qwen_gdn_attention_core",
+            "vllm::dcut_gdn_recurrent",
+            "vllm::unrelated_boundary",
+        ]
+    )
+    assert ops.count("vllm::qwen_gdn_attention_core") == 1
+    assert ops.count("vllm::dcut_gdn_recurrent") == 0
+    assert ops.count("vllm::unrelated_boundary") == 1
+
+    monkeypatch.setenv("VLLM_DCUT_GDN_PIECEWISE", "0")
+    assert not helpers["_is_enabled"]()
+
+
+def test_runner_expands_only_pure_spec_piecewise_gdn() -> None:
+    runner = _read("patch_runner.py")
+
+    assert "_dcut_prepare_gdn_piecewise_replay" in runner
+    assert "_dcut_gdn_piecewise_enabled" in runner
+    assert "_dcut_gdn_recurrent_piecewise_safe" in runner
+    assert "clear_unused_rows=True" in runner
+    assert 'getattr(self, "pcp_size", 1) == 1' in runner
+    assert 'getattr(self, "dcp_size", 1) == 1' in runner
+    assert "CUDAGraphMode.NONE" not in runner
+    assert "runtime_mode_overridden" not in runner
+    assert "_dcut_gdn_local_graph" not in runner
+    assert "_dcut_gdn_recurrent_piecewise_enabled" not in runner
+    assert "_dcut_piecewise_capture_dummy" in runner
+    assert "_should_build_dummy_attn_metadata" in runner
+    assert "_dcut_prepare_gdn_graph_capture" in runner
+    assert "self.uniform_decode_query_len" in runner
+    assert "(capture_dummy or not native_gdn_batch)" in runner
+    assert "uniform_decode=%s enabled=%s" in runner
+
+
+def test_forward_places_recurrent_wrapper_in_piecewise_graph() -> None:
+    core = _read("gdn_forward_v023.py")
+    patch = _read("patch_gdn_v023.py")
+    buffers = _read("gdn_buffers.py")
+
+    assert "forward_with_graphable_recurrent" in core
+    assert "torch.ops.vllm.dcut_gdn_recurrent" in core
+    assert "pure_piecewise_spec = piecewise_spec_bufs is not None" in core
+    assert "0 if pure_piecewise_spec" in core
+    assert 'op_name="dcut_gdn_recurrent"' in core
+    assert 'mutates_args=["state"]' in core
+    assert "if use_graphable_recurrent" in core
+    assert "torch.npu.NPUGraph" not in core
+    assert "graph.replay()" not in core
+    assert "_dcut_gdn_local_graph" not in core
+    assert "_dcut_gdn_recurrent_piecewise_safe" in patch
+    assert "if piecewise_graph_safe or full_graph_safe:" in patch
+    assert "return native_forward(self, hidden_states, output)" in patch
+    assert "target_class.forward = _dcut_forward" in patch
+    assert "_dcut_gdn_local_graph_expected_prefixes" not in buffers
+
+
+def test_full_attention_remains_an_eager_piecewise_boundary() -> None:
+    install = _read("install.py")
+    attention = _read("patch_attention.py")
+
+    assert "and not _patch_attention()" in install
+    assert 'patch_marker = "_dcut_piecewise_fia_patched"' in attention
+    assert "mode == CUDAGraphMode.PIECEWISE" in attention
+    assert "ctx.capturing = False" in attention
+    assert "ctx.capturing = orig_capturing" in attention

--- a/dcut/tests/test_gdn_piecewise_static_buffers.py
+++ b/dcut/tests/test_gdn_piecewise_static_buffers.py
@@ -1,0 +1,466 @@
+# SPDX-License-Identifier: Apache-2.0
+
+from types import SimpleNamespace
+
+import pytest
+
+torch = pytest.importorskip("torch")
+pytest.importorskip("vllm")
+
+from dcut.gdn_buffers import (  # noqa: E402
+    _dcut_get_gdn_piecewise_spec_bufs,
+    _dcut_prepare_gdn_eager_state,
+    _dcut_prepare_gdn_piecewise_replay,
+)
+from dcut.globals import _dcut_gdn_static  # noqa: E402
+
+
+class _GDNMetadata:
+    pass
+
+
+def _make_metadata(
+    query_start_loc: list[int],
+    state_indices: list[list[int]],
+    accepted_tokens: list[int],
+) -> _GDNMetadata:
+    meta = _GDNMetadata()
+    meta.num_spec_decodes = len(state_indices)
+    meta.num_prefills = 0
+    meta.num_decodes = 0
+    meta.spec_sequence_masks = torch.ones(
+        len(state_indices), dtype=torch.bool
+    )
+    meta.spec_state_indices_tensor = torch.tensor(
+        state_indices, dtype=torch.int32
+    )
+    conv_meta = SimpleNamespace(
+        query_start_loc=torch.tensor(
+            query_start_loc, dtype=torch.int32
+        ),
+        num_accepted_tokens=torch.tensor(
+            accepted_tokens, dtype=torch.int64
+        ),
+        cache_indices=torch.arange(
+            len(state_indices), dtype=torch.int32
+        ),
+    )
+    meta.spec_decode_metadata = SimpleNamespace(spec_causal_conv1d=conv_meta)
+    return meta
+
+
+def test_piecewise_spec_buffers_keep_addresses_and_refresh_values() -> None:
+    _dcut_gdn_static.clear()
+    meta = _make_metadata(
+        [0, 2, 3],
+        [[10, 11, 12], [20, 21, 22]],
+        [2, 3],
+    )
+    context = SimpleNamespace(
+        model_instance=object(),
+        attn_metadata={"layers.0.mixer": meta},
+    )
+
+    assert _dcut_prepare_gdn_piecewise_replay(
+        context, 8, _GDNMetadata, 4
+    )
+    bufs = _dcut_get_gdn_piecewise_spec_bufs(
+        context, "layers.0.mixer", 8
+    )
+    pointers = {
+        name: tensor.data_ptr() for name, tensor in bufs.items()
+    }
+
+    assert set(bufs) == {"qsl", "nat", "ssi"}
+    assert bufs["qsl"].tolist() == [0, 2, 3, 3, 3]
+    # NAT selects state from the previous verifier step. The second request
+    # accepted three tokens previously even though this step has one token, so
+    # the accepted count must not be clamped to the current segment length.
+    assert bufs["nat"].tolist() == [2, 3, 0, 0]
+    assert bufs["ssi"].tolist() == [
+        [10, 11, 12],
+        [20, 21, 22],
+        [-1, -1, -1],
+        [-1, -1, -1],
+    ]
+
+    # FULL replay clears unused rows explicitly; PIECEWISE keeps the default
+    # and preserves its original update path.
+    meta.num_spec_decodes = 1
+    meta.spec_decode_metadata.spec_causal_conv1d.query_start_loc = (
+        torch.tensor([0, 1], dtype=torch.int32)
+    )
+    meta.spec_decode_metadata.spec_causal_conv1d.num_accepted_tokens = (
+        torch.tensor([3], dtype=torch.int64)
+    )
+    meta.spec_state_indices_tensor = torch.tensor(
+        [[30, 31, 32]], dtype=torch.int32
+    )
+
+    # Simulate arbitrary values left by a prior FULL capture/replay. The next
+    # replay must reconstruct every fixed-capacity input, not merely overwrite
+    # values that happen to be active in both batches.
+    bufs["qsl"].fill_(99)
+    bufs["nat"].fill_(99)
+    bufs["ssi"].fill_(99)
+
+    assert _dcut_prepare_gdn_piecewise_replay(
+        context,
+        8,
+        _GDNMetadata,
+        4,
+        clear_unused_rows=True,
+    )
+    assert all(
+        bufs[name].data_ptr() == pointer
+        for name, pointer in pointers.items()
+    )
+    assert bufs["qsl"].tolist() == [0, 1, 1, 1, 1]
+    assert bufs["nat"].tolist() == [3, 1, 1, 1]
+    assert bufs["ssi"].tolist() == [
+        [30, 31, 32],
+        [-1, -1, -1],
+        [-1, -1, -1],
+        [-1, -1, -1],
+    ]
+
+
+def test_full_fixed_capacity_survives_live_batch_size_changes() -> None:
+    _dcut_gdn_static.clear()
+    capacity = 96
+    meta = _make_metadata(
+        list(range(capacity + 1)),
+        [[row, row + 1, row + 2] for row in range(capacity)],
+        [1] * capacity,
+    )
+    context = SimpleNamespace(
+        model_instance=object(),
+        attn_metadata={"layers.0.mixer": meta},
+    )
+
+    assert _dcut_prepare_gdn_piecewise_replay(
+        context,
+        512,
+        _GDNMetadata,
+        capacity,
+        clear_unused_rows=True,
+    )
+    bufs = _dcut_get_gdn_piecewise_spec_bufs(
+        context, "layers.0.mixer", 512
+    )
+    pointers = {
+        name: tensor.data_ptr() for name, tensor in bufs.items()
+    }
+
+    for live_batch_size in (32, 64, 1):
+        meta.num_spec_decodes = live_batch_size
+        meta.spec_decode_metadata.spec_causal_conv1d.query_start_loc = (
+            torch.arange(live_batch_size + 1, dtype=torch.int32)
+        )
+        meta.spec_decode_metadata.spec_causal_conv1d.num_accepted_tokens = (
+            torch.ones(live_batch_size, dtype=torch.int64)
+        )
+        meta.spec_state_indices_tensor = torch.tensor(
+            [
+                [1000 + row, 2000 + row, 3000 + row]
+                for row in range(live_batch_size)
+            ],
+            dtype=torch.int32,
+        )
+
+        assert _dcut_prepare_gdn_piecewise_replay(
+            context,
+            512,
+            _GDNMetadata,
+            capacity,
+            clear_unused_rows=True,
+        )
+        assert all(
+            bufs[name].data_ptr() == pointer
+            for name, pointer in pointers.items()
+        )
+        assert bufs["qsl"][: live_batch_size + 1].tolist() == list(
+            range(live_batch_size + 1)
+        )
+        assert bufs["qsl"][live_batch_size + 1 :].tolist() == [
+            live_batch_size
+        ] * (capacity - live_batch_size)
+        assert bufs["nat"].tolist() == [1] * capacity
+        assert torch.all(bufs["ssi"][live_batch_size:] == -1)
+
+
+def test_piecewise_batch_buffers_are_shared_across_gdn_layers() -> None:
+    _dcut_gdn_static.clear()
+    first = _make_metadata(
+        [0, 2, 3],
+        [[10, 11, 12], [20, 21, 22]],
+        [2, 3],
+    )
+    second = _make_metadata(
+        [0, 2, 3],
+        [[30, 31, 32], [40, 41, 42]],
+        [2, 3],
+    )
+    context = SimpleNamespace(
+        model_instance=object(),
+        attn_metadata={
+            "layers.0.mixer": first,
+            "layers.1.mixer": second,
+        },
+    )
+
+    assert _dcut_prepare_gdn_piecewise_replay(
+        context, 8, _GDNMetadata, 4
+    )
+    first_bufs = _dcut_get_gdn_piecewise_spec_bufs(
+        context, "layers.0.mixer", 8
+    )
+    second_bufs = _dcut_get_gdn_piecewise_spec_bufs(
+        context, "layers.1.mixer", 8
+    )
+
+    for name in ("qsl", "nat"):
+        assert first_bufs[name].data_ptr() == second_bufs[name].data_ptr()
+    assert first_bufs["ssi"].data_ptr() != second_bufs["ssi"].data_ptr()
+    assert first_bufs["ssi"][:2].tolist() == [
+        [10, 11, 12],
+        [20, 21, 22],
+    ]
+    assert second_bufs["ssi"][:2].tolist() == [
+        [30, 31, 32],
+        [40, 41, 42],
+    ]
+
+
+def test_piecewise_metadata_group_shares_state_indices_once() -> None:
+    _dcut_gdn_static.clear()
+    shared = _make_metadata(
+        [0, 2, 3],
+        [[10, 11, 12], [20, 21, 22]],
+        [2, 3],
+    )
+    context = SimpleNamespace(
+        model_instance=object(),
+        attn_metadata={
+            "layers.0.mixer": shared,
+            "layers.1.mixer": shared,
+            "layers.2.mixer": shared,
+        },
+    )
+
+    assert _dcut_prepare_gdn_piecewise_replay(
+        context, 8, _GDNMetadata, 4, clear_unused_rows=True
+    )
+    grouped_bufs = [
+        _dcut_get_gdn_piecewise_spec_bufs(context, prefix, 8)
+        for prefix in context.attn_metadata
+    ]
+
+    for name in ("qsl", "nat", "ssi"):
+        assert len({bufs[name].data_ptr() for bufs in grouped_bufs}) == 1
+    assert grouped_bufs[0]["ssi"].tolist() == [
+        [10, 11, 12],
+        [20, 21, 22],
+        [-1, -1, -1],
+        [-1, -1, -1],
+    ]
+
+    # A shrinking replay clears inactive rows and preserves the fixed tensor
+    # addresses captured by FULL graphs.
+    shared.num_spec_decodes = 1
+    shared.spec_decode_metadata.spec_causal_conv1d.query_start_loc = (
+        torch.tensor([0, 1], dtype=torch.int32)
+    )
+    shared.spec_decode_metadata.spec_causal_conv1d.num_accepted_tokens = (
+        torch.tensor([4], dtype=torch.int64)
+    )
+    shared.spec_state_indices_tensor = torch.tensor(
+        [[30, 31, 32]], dtype=torch.int32
+    )
+    pointers = {
+        name: grouped_bufs[0][name].data_ptr()
+        for name in ("qsl", "nat", "ssi")
+    }
+
+    assert _dcut_prepare_gdn_piecewise_replay(
+        context, 8, _GDNMetadata, 4, clear_unused_rows=True
+    )
+    assert all(
+        grouped_bufs[0][name].data_ptr() == pointer
+        for name, pointer in pointers.items()
+    )
+    assert grouped_bufs[0]["nat"].tolist() == [4, 1, 1, 1]
+    assert grouped_bufs[0]["ssi"].tolist() == [
+        [30, 31, 32],
+        [-1, -1, -1],
+        [-1, -1, -1],
+        [-1, -1, -1],
+    ]
+
+
+def test_piecewise_replay_rejects_metadata_group_topology_changes() -> None:
+    _dcut_gdn_static.clear()
+    shared = _make_metadata([0, 1], [[10, 11, 12]], [1])
+    context = SimpleNamespace(
+        model_instance=object(),
+        attn_metadata={
+            "layers.0.mixer": shared,
+            "layers.1.mixer": shared,
+        },
+    )
+
+    assert _dcut_prepare_gdn_piecewise_replay(
+        context, 8, _GDNMetadata, 4, clear_unused_rows=True
+    )
+
+    # These prefixes were captured with one shared SSI address. Splitting them
+    # into two runtime metadata groups must fall back instead of letting either
+    # group overwrite the other group's captured input.
+    context.attn_metadata["layers.1.mixer"] = _make_metadata(
+        [0, 1], [[20, 21, 22]], [1]
+    )
+    assert not _dcut_prepare_gdn_piecewise_replay(
+        context, 8, _GDNMetadata, 4, clear_unused_rows=True
+    )
+
+
+def test_graph_replay_normalizes_only_initial_handoff_state_rows() -> None:
+    _dcut_gdn_static.clear()
+    meta = _make_metadata(
+        [0, 1, 2],
+        [[10, 11, 12], [20, 21, 22]],
+        [7, 5],
+    )
+    context = SimpleNamespace(
+        model_instance=object(),
+        attn_metadata={"layers.0.mixer": meta},
+    )
+
+    assert _dcut_prepare_gdn_piecewise_replay(
+        context,
+        8,
+        _GDNMetadata,
+        4,
+        clear_unused_rows=True,
+        initial_spec_rows=(1,),
+    )
+    bufs = _dcut_get_gdn_piecewise_spec_bufs(
+        context, "layers.0.mixer", 8
+    )
+    assert bufs["nat"].tolist() == [7, 1, 1, 1]
+
+    # The override belongs only to the first consumer step. A subsequent
+    # verifier replay must use the accepted-token offsets it actually receives.
+    meta.spec_decode_metadata.spec_causal_conv1d.num_accepted_tokens = (
+        torch.tensor([4, 3], dtype=torch.int64)
+    )
+    assert _dcut_prepare_gdn_piecewise_replay(
+        context,
+        8,
+        _GDNMetadata,
+        4,
+        clear_unused_rows=True,
+    )
+    assert bufs["nat"].tolist() == [4, 3, 1, 1]
+
+
+def test_eager_spec_state_is_prepared_once_per_forward() -> None:
+    first = _make_metadata(
+        [0, 2, 3],
+        [[10, 11, 12], [20, 21, 22]],
+        [2, 0],
+    )
+    second = _make_metadata(
+        [0, 2, 3],
+        [[30, 31, 32], [40, 41, 42]],
+        [2, 0],
+    )
+    context = SimpleNamespace(
+        attn_metadata={
+            "layers.0.mixer": first,
+            "layers.1.mixer": second,
+        }
+    )
+
+    assert _dcut_prepare_gdn_eager_state(context, _GDNMetadata)
+    state = context._dcut_gdn_eager_spec_state
+    assert state["num_accepted_tokens"].dtype == torch.int32
+    assert state["num_accepted_tokens"].tolist() == [2, 0]
+    assert set(state) == {"query_start_loc", "num_accepted_tokens"}
+    assert (
+        state["query_start_loc"]
+        is first.spec_decode_metadata.spec_causal_conv1d.query_start_loc
+    )
+
+    assert _dcut_prepare_gdn_eager_state(
+        context,
+        _GDNMetadata,
+        initial_spec_rows=(1,),
+    )
+    assert context._dcut_gdn_eager_spec_state[
+        "num_accepted_tokens"
+    ].tolist() == [2, 1]
+    original_accepted = (
+        first.spec_decode_metadata.spec_causal_conv1d.num_accepted_tokens
+    )
+    assert original_accepted.tolist() == [2, 0]
+    first.spec_sequence_masks = None
+    second.spec_sequence_masks = None
+    assert not _dcut_prepare_gdn_eager_state(
+        context, _GDNMetadata
+    )
+    assert context._dcut_gdn_eager_spec_state is None
+
+
+def test_piecewise_replay_rejects_non_spec_and_mixed_batches() -> None:
+    _dcut_gdn_static.clear()
+    meta = _make_metadata([0, 1], [[10, 11, 12]], [1])
+    context = SimpleNamespace(
+        model_instance=object(),
+        attn_metadata={"layers.0.mixer": meta},
+    )
+
+    meta.spec_sequence_masks = None
+    assert not _dcut_prepare_gdn_piecewise_replay(
+        context, 8, _GDNMetadata, 4
+    )
+
+    meta.spec_sequence_masks = torch.ones(1, dtype=torch.bool)
+    meta.num_prefills = 1
+    assert not _dcut_prepare_gdn_piecewise_replay(
+        context, 8, _GDNMetadata, 4
+    )
+
+    meta.num_prefills = 0
+    meta.num_decodes = 1
+    assert not _dcut_prepare_gdn_piecewise_replay(
+        context, 8, _GDNMetadata, 4
+    )
+
+
+def test_piecewise_buffers_do_not_alias_model_instances() -> None:
+    _dcut_gdn_static.clear()
+    meta = _make_metadata([0, 1], [[10, 11]], [1])
+    first = SimpleNamespace(
+        model_instance=object(),
+        attn_metadata={"layers.0.mixer": meta},
+    )
+    second = SimpleNamespace(
+        model_instance=object(),
+        attn_metadata={"layers.0.mixer": meta},
+    )
+
+    assert _dcut_prepare_gdn_piecewise_replay(
+        first, 4, _GDNMetadata, 2
+    )
+    assert _dcut_prepare_gdn_piecewise_replay(
+        second, 4, _GDNMetadata, 2
+    )
+    first_bufs = _dcut_get_gdn_piecewise_spec_bufs(
+        first, "layers.0.mixer", 4
+    )
+    second_bufs = _dcut_get_gdn_piecewise_spec_bufs(
+        second, "layers.0.mixer", 4
+    )
+
+    assert first_bufs["qsl"].data_ptr() != second_bufs["qsl"].data_ptr()

--- a/dcut/tests/test_gdn_prefill_piecewise_route.py
+++ b/dcut/tests/test_gdn_prefill_piecewise_route.py
@@ -1,0 +1,38 @@
+# SPDX-License-Identifier: Apache-2.0
+
+from pathlib import Path
+
+
+DCUT_DIR = Path(__file__).resolve().parents[1]
+RUNNER_PATH = DCUT_DIR / "patch_runner.py"
+GDN_PATH = DCUT_DIR / "patch_gdn_v023.py"
+
+
+def test_prefill_does_not_override_outer_runtime_selection() -> None:
+    runner = RUNNER_PATH.read_text(encoding="utf-8")
+
+    assert "_dcut_force_prefill_eager" not in runner
+    assert "_FORCE_EAGER_ARG_POSITION" not in runner
+    assert "_orig_determine_batch_execution_and_padding" not in runner
+    assert "R._determine_batch_execution_and_padding" not in runner
+
+
+def test_prefill_still_routes_only_gdn_to_native_core() -> None:
+    runner = RUNNER_PATH.read_text(encoding="utf-8")
+    gdn = GDN_PATH.read_text(encoding="utf-8")
+
+    assert "_dcut_execute_with_gdn_prefill_route" in runner
+    assert 'attr = "_dcut_gdn_scheduler_has_prefill"' in runner
+    assert "forward_context._dcut_gdn_native_batch = native_gdn_batch" in runner
+    assert '"gdn_native_path": _has_prefill' in runner
+    assert '"_dcut_gdn_native_batch"' in gdn
+    assert "return bool(native_batch)" in gdn
+
+
+def test_eager_log_uses_actual_outer_runtime_mode() -> None:
+    runner = RUNNER_PATH.read_text(encoding="utf-8")
+
+    assert "_is_eager = _runtime_mode in" in runner
+    assert "_is_eager = _has_prefill or" not in runner
+    assert '"runtime_mode": _runtime_mode' in runner
+    assert '"is_eager": _is_eager' in runner

--- a/dcut/tests/test_prefill_probability_bypass.py
+++ b/dcut/tests/test_prefill_probability_bypass.py
@@ -1,0 +1,324 @@
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+from types import SimpleNamespace
+
+
+DCUT_DIR = Path(__file__).resolve().parents[1]
+
+
+def _load_bypass():
+    path = DCUT_DIR / "probs.py"
+    tree = ast.parse(path.read_text(encoding="utf-8"))
+    function = next(
+        node
+        for node in tree.body
+        if isinstance(node, ast.FunctionDef)
+        and node.name == "_dcut_bypass_prob_capture_for_prefill"
+    )
+    module = ast.Module(body=[function], type_ignores=[])
+    ast.fix_missing_locations(module)
+    namespace = {}
+    exec(compile(module, str(path), "exec"), namespace)
+    return namespace["_dcut_bypass_prob_capture_for_prefill"]
+
+
+def _load_drafter_enable():
+    path = DCUT_DIR / "controller.py"
+    tree = ast.parse(path.read_text(encoding="utf-8"))
+    function = next(
+        node
+        for node in tree.body
+        if isinstance(node, ast.FunctionDef)
+        and node.name == "_dcut_enable_drafter_probs"
+    )
+    module = ast.Module(body=[function], type_ignores=[])
+    ast.fix_missing_locations(module)
+    namespace = {
+        "_dcut_patch_drafter_instance": lambda drafter: None,
+        "_dcut_setup_full_decode_drafter": lambda runner, drafter: None,
+        "_env_flag": lambda name: False,
+        "ENV_FORCE_DRAFTER_EAGER": "VLLM_DCUT_FORCE_DRAFTER_EAGER",
+        "logger": SimpleNamespace(warning=lambda *args: None),
+    }
+    exec(compile(module, str(path), "exec"), namespace)
+    return namespace["_dcut_enable_drafter_probs"]
+
+
+def _load_runner_helper(name: str, **namespace):
+    path = DCUT_DIR / "patch_runner.py"
+    tree = ast.parse(path.read_text(encoding="utf-8"))
+    function = next(
+        node
+        for node in tree.body
+        if isinstance(node, ast.FunctionDef) and node.name == name
+    )
+    module = ast.Module(body=[function], type_ignores=[])
+    ast.fix_missing_locations(module)
+    exec(compile(module, str(path), "exec"), namespace)
+    return namespace[name]
+
+
+def test_prefill_bypass_disables_drafter_and_drops_stale_decision() -> None:
+    class Controller:
+        cleared = 0
+
+        def clear_adaptive_decision(self):
+            self.cleared += 1
+
+    controller = Controller()
+    drafter = SimpleNamespace(
+        needs_draft_probs=True,
+        _dcut_last_draft_ran_python=True,
+        _dcut_last_logits_for_probs=object(),
+        _last_selected_probs=object(),
+    )
+    runner = SimpleNamespace(
+        drafter=drafter,
+        _adaptive_probs_pending=True,
+        _adaptive_num_reqs=2,
+        _adaptive_req_ids=["old-0", "old-1"],
+        _adaptive_active={"old-0", "old-1"},
+        _verify_adaptive_controller=controller,
+    )
+
+    _load_bypass()(runner)
+
+    assert drafter.needs_draft_probs is False
+    assert drafter._dcut_last_draft_ran_python is False
+    assert drafter._dcut_last_logits_for_probs is None
+    assert drafter._last_selected_probs is None
+    assert runner._adaptive_probs_pending is False
+    assert runner._adaptive_probs_expired is False
+    assert runner._adaptive_probs_source == "prefill_bypass"
+    assert runner._adaptive_num_reqs == 0
+    assert runner._adaptive_req_ids == []
+    assert runner._adaptive_active == set()
+    assert controller.cleared == 1
+
+
+def test_decode_after_prefill_reenables_drafter_probabilities() -> None:
+    controller = SimpleNamespace(clear_adaptive_decision=lambda: None)
+    drafter = SimpleNamespace(
+        needs_draft_probs=True,
+        _dcut_last_draft_ran_python=True,
+        _dcut_last_logits_for_probs=object(),
+        _last_selected_probs=object(),
+        method="dflash",
+        parallel_drafting=False,
+    )
+    runner = SimpleNamespace(
+        drafter=drafter,
+        _adaptive_probs_pending=False,
+        _adaptive_num_reqs=0,
+        _adaptive_req_ids=[],
+        _adaptive_active=set(),
+        _verify_adaptive_controller=controller,
+        _dcut_logged_drafter_probs=True,
+    )
+
+    _load_bypass()(runner)
+    _load_drafter_enable()(runner)
+
+    assert drafter.needs_draft_probs is True
+
+
+def test_prefill_execute_branch_skips_all_probability_work() -> None:
+    source = (DCUT_DIR / "patch_runner.py").read_text(encoding="utf-8")
+    execute_start = source.index("    def execute_model(")
+    execute_end = source.index("    _orig_sample_tokens", execute_start)
+    execute_source = source[execute_start:execute_end]
+
+    prefill_start = execute_source.index(
+        "        if (\n"
+        "            _ctrl is not None\n"
+        "            and _has_prefill\n"
+        "            and not _native_recompute_handoff\n"
+        "        ):"
+    )
+    decode_start = execute_source.index(
+        "        if (\n"
+        "            _ctrl is not None\n"
+        "            and not _has_prefill\n"
+        "            and not _native_recompute_handoff\n"
+        "        ):",
+        prefill_start,
+    )
+    prefill_branch = execute_source[prefill_start:decode_start]
+
+    assert "_dcut_bypass_prob_capture_for_prefill(self)" in prefill_branch
+    assert "_maybe_process_adaptive_probs" not in prefill_branch
+    assert "_dcut_enable_drafter_probs" not in prefill_branch
+    assert "_dcut_truncate" not in prefill_branch
+    assert "_dcut_prepare_prob_capture" not in prefill_branch
+
+    decode_end = execute_source.index(
+        "        if not debug_stats:", decode_start
+    )
+    decode_branch = execute_source[decode_start:decode_end]
+    assert "_dcut_enable_drafter_probs(self)" in decode_branch
+    assert "_dcut_prepare_prob_capture(self, scheduler_output)" in decode_branch
+
+    assert '"drafter_needs_draft_probs"' in execute_source
+    assert '"adaptive_probs_pending_after_step"' in execute_source
+    assert '"prob_capture_skipped_for_prefill"' in execute_source
+    assert '"mixed_prob_capture_planned"' in execute_source
+    assert '"draft_ran_python"' in execute_source
+
+
+def test_mixed_draft_capture_is_enabled_before_proposal() -> None:
+    source = (DCUT_DIR / "patch_runner.py").read_text(encoding="utf-8")
+    sample_start = source.index("    def sample_tokens(")
+    copy_start = source.index(
+        "    def _copy_draft_token_ids_to_cpu(",
+        sample_start,
+    )
+    update_start = source.index("    def _update_states(", copy_start)
+
+    sample_source = source[sample_start:copy_start]
+    copy_source = source[copy_start:update_start]
+    guard = 'getattr(self, "_dcut_skip_current_prob_capture", False)'
+    mixed_flag = 'getattr(self, "_dcut_capture_mixed_probs", False)'
+
+    assert mixed_flag in sample_source
+    assert sample_source.index(mixed_flag) < sample_source.index(
+        "out = _orig_sample_tokens"
+    )
+    assert sample_source.index("_dcut_enable_drafter_probs(self)") < (
+        sample_source.index("out = _orig_sample_tokens")
+    )
+    assert guard in sample_source
+    assert sample_source.index(guard) < sample_source.index(
+        "_maybe_process_adaptive_probs"
+    )
+    assert guard in copy_source
+    assert copy_source.index(guard) < copy_source.index("_dcut_queue_probs")
+
+
+def test_only_pure_prefill_skips_next_proposal_probabilities() -> None:
+    source = (DCUT_DIR / "patch_runner.py").read_text(encoding="utf-8")
+    execute_start = source.index("    def execute_model(")
+    execute_end = source.index("    _orig_sample_tokens", execute_start)
+    execute_source = source[execute_start:execute_end]
+
+    assert (
+        "_ctrl is not None and _has_prefill and _has_spec"
+        in execute_source
+    )
+    assert (
+        "_ctrl is not None and _has_prefill and not _has_spec"
+        in execute_source
+    )
+
+
+def test_recompute_handoff_uses_dcut_for_piecewise_and_supported_full() -> None:
+    graph_enabled = _load_runner_helper(
+        "_dcut_adaptive_handoff_graph_enabled",
+        _dcut_full_decode_multishape_enabled=lambda config: config.full,
+    )
+    runner = SimpleNamespace(
+        compilation_config=SimpleNamespace(
+            cudagraph_mode=SimpleNamespace(name="PIECEWISE")
+        ),
+        vllm_config=SimpleNamespace(full=False),
+    )
+    assert graph_enabled(runner) is True
+
+    runner.compilation_config.cudagraph_mode = SimpleNamespace(
+        name="FULL_DECODE_ONLY"
+    )
+    assert graph_enabled(runner) is False
+    runner.vllm_config.full = True
+    assert graph_enabled(runner) is True
+
+    runner.compilation_config.cudagraph_mode = SimpleNamespace(name="NONE")
+    assert graph_enabled(runner) is False
+
+    source = (DCUT_DIR / "patch_runner.py").read_text(encoding="utf-8")
+    execute_start = source.index("    def execute_model(")
+    execute_end = source.index("    _orig_sample_tokens", execute_start)
+    execute_source = source[execute_start:execute_end]
+
+    assert "_adaptive_recompute_handoff = bool(" in execute_source
+    assert "and _recompute_placeholder_req_ids" in execute_source
+    assert "and _adaptive_handoff_graph" in execute_source
+    assert "_dcut_adaptive_handoff_graph_enabled(self)" in execute_source
+    assert "_native_recompute_handoff = bool(" in execute_source
+
+    native_start = execute_source.index(
+        "        if _native_recompute_handoff:"
+    )
+    regular_start = execute_source.index(
+        "        _zero_draft_handoffs = frozenset()",
+        native_start,
+    )
+    handoff_branch = execute_source[native_start:regular_start]
+
+    assert "self._dcut_capture_mixed_probs = False" in handoff_branch
+    assert "self._dcut_skip_current_prob_capture = True" in handoff_branch
+    assert "_dcut_bypass_prob_capture_for_prefill(self)" in handoff_branch
+    assert "return _dcut_execute_native_recompute_handoff" in handoff_branch
+    assert "elif _adaptive_recompute_handoff:" in handoff_branch
+    assert "self._dcut_skip_current_prob_capture = False" in handoff_branch
+
+    assert "_dcut_apply_zero_prob_recompute_caps(" in execute_source
+    assert "_dcut_truncate(" in execute_source
+    assert "and not _native_recompute_handoff" in execute_source
+    assert (
+        "self._dcut_zero_draft_handoffs_for_proposal = (\n"
+        "            _prefill_exempt_req_ids\n"
+        "        )"
+        in execute_source
+    )
+    assert "| _recompute_placeholder_req_ids" in execute_source
+
+    determine_start = source.index(
+        "    def _determine_batch_execution_and_padding("
+    )
+    determine_end = source.index(
+        "    def _pad_query_start_loc_for_fia(", determine_start
+    )
+    determine_source = source[determine_start:determine_end]
+    assert '"_dcut_recompute_handoff_active"' in determine_source
+    assert "stock_uniform_decode" in determine_source
+    assert "is_all_decode" in determine_source
+    assert "num_tokens == expected_query_len * num_reqs" in determine_source
+    assert "force_eager = True" in determine_source
+    assert "_dcut_set_full_gdn_metadata_route(" in determine_source
+    assert "runtime_mode == CUDAGraphMode.FULL and descriptor.uniform" in (
+        determine_source
+    )
+
+    model_forward_start = source.index("    def _model_forward(")
+    model_forward_end = source.index(
+        "    def execute_model(", model_forward_start
+    )
+    model_forward_source = source[model_forward_start:model_forward_end]
+    assert "stock_uniform_full = bool(" in model_forward_source
+    assert "native_gdn_batch = stock_uniform_full or (" in model_forward_source
+    assert "initial_spec_rows = _dcut_initial_handoff_spec_rows(self)" in (
+        model_forward_source
+    )
+    piecewise_replay = model_forward_source[
+        model_forward_source.index("self._dcut_gdn_piecewise_enabled") :
+    ]
+    assert "initial_spec_rows=initial_spec_rows" in piecewise_replay
+
+
+def test_initial_handoff_rows_follow_compact_spec_order() -> None:
+    initial_rows = _load_runner_helper("_dcut_initial_handoff_spec_rows")
+    runner = SimpleNamespace(
+        _dcut_zero_draft_handoffs_for_proposal=frozenset(
+            {"handoff-0", "handoff-1"}
+        ),
+        num_decode_draft_tokens=SimpleNamespace(np=[3, -1, 0, 0]),
+        input_batch=SimpleNamespace(
+            num_reqs=4,
+            req_ids=["decode", "ordinary", "handoff-0", "handoff-1"],
+        ),
+    )
+
+    assert initial_rows(runner) == (1, 2)

--- a/dcut/tests/test_runtime_optimizations.py
+++ b/dcut/tests/test_runtime_optimizations.py
@@ -1,0 +1,984 @@
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import ast
+import os
+from pathlib import Path
+from types import SimpleNamespace
+
+import torch
+
+DCUT_DIR = Path(__file__).resolve().parents[1]
+
+
+def _load_functions(path: Path, names: set[str], namespace: dict):
+    tree = ast.parse(path.read_text(encoding="utf-8"))
+    functions = [
+        node
+        for node in tree.body
+        if isinstance(node, ast.FunctionDef) and node.name in names
+    ]
+    assert {node.name for node in functions} == names
+    module = ast.Module(
+        body=[
+            ast.ImportFrom(
+                module="__future__",
+                names=[ast.alias(name="annotations")],
+                level=0,
+            ),
+            *functions,
+        ],
+        type_ignores=[],
+    )
+    ast.fix_missing_locations(module)
+    exec(compile(module, str(path), "exec"), namespace)
+    return namespace
+
+
+def _load_utils():
+    names = {
+        "_env_flag",
+        "_dcut_process_probs_stage",
+        "_dcut_reuse_argmax_enabled",
+        "_dcut_in_graph_capture",
+        "_dcut_graph_capture_mode_name",
+        "_dcut_should_collect_draft_probs",
+        "_dcut_selected_token_probs",
+        "_dcut_greedy_sample_with_selected_probs",
+        "_dcut_can_reuse_argmax_for_probs",
+        "_dcut_selected_probs_from_graph",
+        "_dcut_selected_probs_from_reused_logits",
+    }
+    return _load_functions(
+        DCUT_DIR / "utils.py",
+        names,
+        {
+            "os": os,
+            "torch": torch,
+            "get_tp_group": lambda: SimpleNamespace(world_size=1),
+            "ENV_CONFIG": "VLLM_DCUT_CONFIG",
+            "ENV_DISABLE": "VLLM_DCUT_DISABLE",
+            "ENV_PROCESS_PROBS_STAGE": "VLLM_DCUT_PROCESS_PROBS_STAGE",
+            "ENV_REUSE_ARGMAX": "VLLM_DCUT_REUSE_ARGMAX",
+        },
+    )
+
+
+def _load_controller_methods(names: set[str]):
+    path = DCUT_DIR / "verify_adaptive_controller.py"
+    tree = ast.parse(path.read_text(encoding="utf-8"))
+    controller = next(
+        node
+        for node in tree.body
+        if isinstance(node, ast.ClassDef)
+        and node.name == "VerifyAdaptiveController"
+    )
+    methods = [
+        node
+        for node in controller.body
+        if isinstance(node, ast.FunctionDef) and node.name in names
+    ]
+    assert {node.name for node in methods} == names
+    module = ast.Module(body=methods, type_ignores=[])
+    ast.fix_missing_locations(module)
+    namespace = {}
+    exec(compile(module, str(path), "exec"), namespace)
+    return namespace
+
+
+def test_deferred_processing_and_argmax_reuse_defaults(monkeypatch) -> None:
+    utils = _load_utils()
+    monkeypatch.delenv("VLLM_DCUT_PROCESS_PROBS_STAGE", raising=False)
+    monkeypatch.delenv("VLLM_DCUT_REUSE_ARGMAX", raising=False)
+
+    assert utils["_dcut_process_probs_stage"]() == "pre_truncate"
+    assert utils["_dcut_reuse_argmax_enabled"]() is True
+
+    monkeypatch.setenv("VLLM_DCUT_PROCESS_PROBS_STAGE", "post-sample")
+    monkeypatch.setenv("VLLM_DCUT_REUSE_ARGMAX", "0")
+    assert utils["_dcut_process_probs_stage"]() == "post_sample"
+    assert utils["_dcut_reuse_argmax_enabled"]() is False
+
+
+def test_selected_probs_share_the_stock_two_tp_gathers() -> None:
+    local_logits = torch.tensor(
+        [[0.0, 2.0, 1.0], [5.0, 1.0, 0.0]],
+        dtype=torch.float32,
+    )
+    remote_logits = torch.tensor(
+        [[4.0, 0.0, -1.0], [4.0, 6.0, 1.0]],
+        dtype=torch.float32,
+    )
+
+    class FakeTpGroup:
+        world_size = 2
+        rank_in_group = 0
+
+        def __init__(self) -> None:
+            self.gathered_shapes = []
+
+        def all_gather(self, tensor, dim=-1):
+            assert dim == -1
+            self.gathered_shapes.append(tuple(tensor.shape))
+            if tensor.is_floating_point():
+                remote_max = remote_logits.amax(dim=-1)
+                remote_lse = remote_logits.logsumexp(dim=-1)
+                remote = torch.stack((remote_max, remote_lse), dim=-1)
+            else:
+                remote = (
+                    remote_logits.argmax(dim=-1)
+                    + remote_logits.shape[-1]
+                ).unsqueeze(-1)
+            return torch.cat((tensor, remote), dim=-1)
+
+    group = FakeTpGroup()
+    sample = _load_functions(
+        DCUT_DIR / "utils.py",
+        {"_dcut_greedy_sample_with_selected_probs"},
+        {
+            "torch": torch,
+            "get_tp_group": lambda: group,
+        },
+    )["_dcut_greedy_sample_with_selected_probs"]
+
+    token_ids, selected_probs = sample(local_logits)
+    global_logits = torch.cat((local_logits, remote_logits), dim=-1)
+    expected_ids = global_logits.argmax(dim=-1)
+    expected_probs = global_logits.softmax(dim=-1).gather(
+        -1,
+        expected_ids.unsqueeze(-1),
+    ).squeeze(-1)
+
+    assert group.gathered_shapes == [(2, 2), (2, 1)]
+    torch.testing.assert_close(token_ids, expected_ids)
+    torch.testing.assert_close(selected_probs, expected_probs)
+
+
+def test_full_graph_capture_forces_probs_when_runtime_flag_is_disabled(
+    monkeypatch,
+) -> None:
+    utils = _load_utils()
+    drafter = SimpleNamespace(
+        needs_draft_probs=False,
+        method="dflash",
+        parallel_drafting=True,
+    )
+    monkeypatch.delenv("VLLM_DCUT_CONFIG", raising=False)
+    monkeypatch.delenv("VLLM_DCUT_DISABLE", raising=False)
+    utils["_dcut_in_graph_capture"] = lambda: True
+    utils["_dcut_graph_capture_mode_name"] = lambda: "FULL"
+
+    assert utils["_dcut_should_collect_draft_probs"](drafter) is False
+
+    monkeypatch.setenv("VLLM_DCUT_CONFIG", "/tmp/dcut-config.json")
+    utils["_dcut_graph_capture_mode_name"] = lambda: "PIECEWISE"
+    assert utils["_dcut_should_collect_draft_probs"](drafter) is False
+    utils["_dcut_graph_capture_mode_name"] = lambda: "FULL"
+    assert utils["_dcut_should_collect_draft_probs"](drafter) is True
+
+    monkeypatch.setenv("VLLM_DCUT_DISABLE", "1")
+    assert utils["_dcut_should_collect_draft_probs"](drafter) is False
+    monkeypatch.delenv("VLLM_DCUT_DISABLE")
+
+    utils["_dcut_in_graph_capture"] = lambda: False
+    assert utils["_dcut_should_collect_draft_probs"](drafter) is False
+
+    monkeypatch.delenv("VLLM_DCUT_CONFIG")
+    drafter.needs_draft_probs = True
+    assert utils["_dcut_should_collect_draft_probs"](drafter) is True
+
+    drafter.method = "unsupported"
+    drafter.parallel_drafting = False
+    assert utils["_dcut_should_collect_draft_probs"](drafter) is False
+
+
+def test_draft_probability_paths_use_capture_aware_gate() -> None:
+    proposer = (DCUT_DIR / "patch_proposer.py").read_text(encoding="utf-8")
+    drafter = (DCUT_DIR / "drafter.py").read_text(encoding="utf-8")
+
+    assert (
+        "needs_draft_probs = bool(os.environ.get(ENV_CONFIG))" in proposer
+    )
+    assert "return _dcut_should_collect_draft_probs(self)" in proposer
+    assert "if _dcut_should_collect_draft_probs(drafter)" in drafter
+    assert "_dcut_selected_probs_for_output(" in proposer
+    assert proposer.index(
+        "selected_probs = _dcut_selected_probs_for_output("
+    ) < proposer.index("if in_graph_capture:")
+    assert "if not _dcut_should_collect_draft_probs(self)" in drafter
+    assert "_dcut_attach_graph_owner(drafter)" in drafter
+    assert "capture_pending" in proposer
+    assert "_dcut_graph_owner_from_runnable(runnable)" in proposer
+    assert "ACLGraphWrapper.__init__ = __init__" in proposer
+    assert "_dcut_register_graph_selected_probs(" in proposer
+    assert "_dcut_prepare_dflash_graph_context(" in proposer
+    assert "proposer._dflash_num_context = restore_dflash_context" in proposer
+
+
+def test_output_aligned_probs_follow_returned_draft_ids() -> None:
+    gather = _load_functions(
+        DCUT_DIR / "patch_proposer.py",
+        {"_dcut_selected_probs_for_output"},
+        {
+            "_dcut_selected_token_probs": lambda logits, token_ids: (
+                logits.softmax(dim=-1)
+                .gather(-1, token_ids.long().unsqueeze(-1))
+                .squeeze(-1)
+            ),
+        },
+    )["_dcut_selected_probs_for_output"]
+    logits = torch.tensor(
+        [[4.0, 1.0, -1.0], [0.2, 0.3, 3.0]],
+        dtype=torch.float32,
+    )
+    returned_ids = torch.tensor([[2, 0]], dtype=torch.int64)
+
+    actual = gather(logits, returned_ids)
+    expected = logits.softmax(dim=-1).gather(
+        -1,
+        returned_ids.reshape(-1, 1),
+    ).view_as(returned_ids)
+
+    torch.testing.assert_close(actual, expected)
+    assert not torch.allclose(
+        actual.reshape(-1),
+        logits.softmax(dim=-1).amax(dim=-1),
+    )
+
+
+class _Drafter:
+    method = "dflash"
+    _dcut_run_merged_patched = True
+
+
+def test_reused_logits_match_selected_softmax_probability(monkeypatch) -> None:
+    utils = _load_utils()
+    monkeypatch.delenv("VLLM_DCUT_REUSE_ARGMAX", raising=False)
+    logits = torch.tensor(
+        [[1.0, 3.0, -2.0], [2.0, 0.5, 1.0]],
+        dtype=torch.float32,
+    )
+    token_ids = torch.tensor([[1, 0]])
+    drafter = _Drafter()
+    drafter._dcut_last_logits_for_probs = logits
+    drafter._dcut_last_draft_ran_python = True
+
+    actual = utils["_dcut_selected_probs_from_reused_logits"](
+        drafter,
+        token_ids,
+    )
+    expected = logits.softmax(dim=-1).gather(
+        -1,
+        token_ids.reshape(-1, 1),
+    ).reshape_as(token_ids)
+
+    assert actual is not None
+    torch.testing.assert_close(actual, expected)
+
+
+def test_reused_logits_reject_mapped_vocab_and_tp_shards(monkeypatch) -> None:
+    utils = _load_utils()
+    monkeypatch.delenv("VLLM_DCUT_REUSE_ARGMAX", raising=False)
+    logits = torch.tensor([[1.0, 3.0, -2.0]], dtype=torch.float32)
+    token_ids = torch.tensor([[1]])
+    drafter = _Drafter()
+    drafter._dcut_last_logits_for_probs = logits
+    drafter._dcut_last_draft_ran_python = True
+    drafter.model = SimpleNamespace(
+        draft_id_to_target_id=torch.arange(3),
+    )
+
+    mapped_vocab_probs = utils[
+        "_dcut_selected_probs_from_reused_logits"
+    ](drafter, token_ids)
+
+    assert mapped_vocab_probs is None
+
+    drafter.model = SimpleNamespace(draft_id_to_target_id=None)
+    utils["get_tp_group"] = lambda: SimpleNamespace(world_size=2)
+    sharded_probs = utils[
+        "_dcut_selected_probs_from_reused_logits"
+    ](drafter, token_ids)
+
+    assert sharded_probs is None
+
+
+def test_graph_selected_probs_are_selected_by_output_bucket() -> None:
+    utils = _load_utils()
+    small = torch.tensor([[0.8, 0.6]], dtype=torch.float32)
+    large = torch.tensor(
+        [[0.9, 0.7], [0.5, 0.3]],
+        dtype=torch.float32,
+    )
+    draft_token_ids = torch.zeros((1, 2), dtype=torch.int64)
+    drafter = SimpleNamespace(
+        _dcut_last_draft_ran_python=False,
+        _dcut_graph_selected_probs_ready=True,
+        _dcut_graph_selected_probs_by_output_ptr={
+            int(draft_token_ids.data_ptr()): small,
+        },
+        # Deliberately point the same-shape fallback at another bucket. The
+        # fixed output address must win when multiple graphs share a shape.
+        _dcut_graph_selected_probs_by_shape={
+            (1, 2): large,
+        },
+        _dcut_graph_selected_probs_by_numel={
+            2: large,
+        },
+    )
+
+    actual = utils["_dcut_selected_probs_from_graph"](
+        drafter,
+        draft_token_ids,
+    )
+
+    assert actual is not None
+    torch.testing.assert_close(actual, small)
+
+
+def test_graph_selected_probs_prefer_exact_descriptor() -> None:
+    utils = _load_utils()
+    exact = torch.tensor([[0.81, 0.61]], dtype=torch.float32)
+    wrong = torch.tensor([[0.22, 0.12]], dtype=torch.float32)
+    draft_token_ids = torch.zeros((1, 2), dtype=torch.int64)
+    descriptor = object()
+    drafter = SimpleNamespace(
+        _dcut_last_draft_ran_python=False,
+        _dcut_graph_selected_probs_ready=True,
+        _dcut_current_graph_descriptor=descriptor,
+        _dcut_graph_selected_probs_by_descriptor={descriptor: exact},
+        _dcut_graph_selected_probs_by_output_ptr={
+            int(draft_token_ids.data_ptr()): wrong,
+        },
+        _dcut_graph_selected_probs_by_shape={(1, 2): wrong},
+        _dcut_graph_selected_probs_by_numel={2: wrong},
+    )
+
+    actual = utils["_dcut_selected_probs_from_graph"](
+        drafter,
+        draft_token_ids,
+    )
+
+    assert actual is not None
+    assert drafter._dcut_last_graph_prob_source == "graph_descriptor"
+    torch.testing.assert_close(actual, exact)
+
+
+def test_graph_descriptor_miss_rejects_unsafe_shape_fallback() -> None:
+    utils = _load_utils()
+    draft_token_ids = torch.zeros((1, 2), dtype=torch.int64)
+    captured_descriptor = object()
+    wrong = torch.tensor([[0.22, 0.12]], dtype=torch.float32)
+    drafter = SimpleNamespace(
+        _dcut_last_draft_ran_python=False,
+        _dcut_graph_selected_probs_ready=True,
+        _dcut_current_graph_descriptor=object(),
+        _dcut_graph_selected_probs_by_descriptor={captured_descriptor: wrong},
+        _dcut_graph_selected_probs_by_output_ptr={
+            int(draft_token_ids.data_ptr()): wrong,
+        },
+        _dcut_graph_selected_probs_by_shape={(1, 2): wrong},
+        _dcut_graph_selected_probs_by_numel={2: wrong},
+    )
+
+    actual = utils["_dcut_selected_probs_from_graph"](
+        drafter,
+        draft_token_ids,
+    )
+
+    assert actual is None
+    assert drafter._dcut_last_graph_prob_source == "missing"
+
+
+def test_graph_compatibility_key_is_disabled_when_ambiguous() -> None:
+    store = _load_functions(
+        DCUT_DIR / "patch_proposer.py",
+        {"_dcut_store_unique_graph_buffer"},
+        {},
+    )["_dcut_store_unique_graph_buffer"]
+    owner = SimpleNamespace()
+    first = torch.zeros((1, 2))
+    second = torch.ones((1, 2))
+
+    store(owner, "buffers", "same-shape", first)
+    assert owner.buffers["same-shape"] is first
+
+    store(owner, "buffers", "same-shape", second)
+    assert owner.buffers["same-shape"] is None
+
+
+def test_graph_capture_registration_records_exact_descriptor() -> None:
+    functions = _load_functions(
+        DCUT_DIR / "patch_proposer.py",
+        {
+            "_dcut_store_unique_graph_buffer",
+            "_dcut_register_graph_selected_probs",
+        },
+        {},
+    )
+    register = functions["_dcut_register_graph_selected_probs"]
+    owner = SimpleNamespace()
+    descriptor = object()
+    output = torch.zeros((2, 3), dtype=torch.int64)
+    probs = torch.full((2, 3), 0.5)
+
+    assert register(owner, descriptor, output, probs) is True
+    assert owner._dcut_graph_selected_probs_ready is True
+    assert owner._dcut_graph_selected_probs_by_descriptor[descriptor] is probs
+    assert (
+        owner._dcut_graph_selected_probs_by_output_ptr[int(output.data_ptr())]
+        is probs
+    )
+    assert owner._dcut_graph_selected_probs_by_shape[(2, 3)] is probs
+    assert owner._dcut_graph_selected_probs_by_numel[6] is probs
+
+
+def test_live_drafter_is_attached_to_aclgraph_wrapper() -> None:
+    attach = _load_functions(
+        DCUT_DIR / "drafter.py",
+        {"_dcut_attach_graph_owner"},
+        {},
+    )["_dcut_attach_graph_owner"]
+    runnable = SimpleNamespace(concrete_aclgraph_entries={})
+    drafter = SimpleNamespace(_runnable=runnable)
+
+    assert attach(drafter) is True
+    assert runnable._dcut_descriptor_owner is drafter
+    assert drafter._dcut_graph_owner_attached is True
+
+    eager = SimpleNamespace(_runnable=lambda: None)
+    assert attach(eager) is False
+
+
+def test_dflash_graph_context_uses_standalone_fill_on_capture_and_replay() -> None:
+    warnings = []
+    prepare = _load_functions(
+        DCUT_DIR / "patch_proposer.py",
+        {"_dcut_prepare_dflash_graph_context"},
+        {
+            "PADDING_SLOT_ID": -1,
+            "logger": SimpleNamespace(
+                warning=lambda *args: warnings.append(args)
+            ),
+        },
+    )["_dcut_prepare_dflash_graph_context"]
+    descriptor = ("FULL", 8)
+    slot_mapping = torch.arange(8, dtype=torch.int32)
+    drafter = SimpleNamespace(
+        method="dflash",
+        _dflash_num_context=4,
+        _context_slot_mapping_buffer=slot_mapping,
+    )
+
+    restore_context = prepare(
+        drafter,
+        descriptor,
+        graph_context_tokens=8,
+        capture_pending=True,
+    )
+
+    assert restore_context == 4
+    assert drafter._dflash_num_context == 8
+    assert drafter._dcut_dflash_context_tokens_by_descriptor[descriptor] == 8
+    torch.testing.assert_close(
+        slot_mapping[:4], torch.arange(4, dtype=torch.int32)
+    )
+    torch.testing.assert_close(
+        slot_mapping[4:], torch.full((4,), -1, dtype=torch.int32)
+    )
+
+    # Emulate the graph wrapper's finally block, then replay with a new
+    # actual context length against the descriptor's fixed captured length.
+    drafter._dflash_num_context = restore_context
+    slot_mapping.fill_(9)
+    drafter._dflash_num_context = 6
+    restore_context = prepare(
+        drafter,
+        descriptor,
+        graph_context_tokens=None,
+        capture_pending=False,
+    )
+
+    assert restore_context is None
+    assert drafter._dflash_num_context == 6
+    torch.testing.assert_close(
+        slot_mapping[:6], torch.full((6,), 9, dtype=torch.int32)
+    )
+    torch.testing.assert_close(
+        slot_mapping[6:], torch.full((2,), -1, dtype=torch.int32)
+    )
+    assert drafter._dcut_last_dflash_context_actual == 6
+    assert drafter._dcut_last_dflash_context_captured == 8
+    assert drafter._dcut_last_dflash_context_tail_masked is True
+    assert len(warnings) == 1
+    assert "standalone fill" in warnings[0][0]
+
+
+def test_dflash_graph_rejects_context_larger_than_capture() -> None:
+    prepare = _load_functions(
+        DCUT_DIR / "patch_proposer.py",
+        {"_dcut_prepare_dflash_graph_context"},
+        {
+            "PADDING_SLOT_ID": -1,
+            "logger": SimpleNamespace(warning=lambda *args: None),
+        },
+    )["_dcut_prepare_dflash_graph_context"]
+    descriptor = ("FULL", 4)
+    drafter = SimpleNamespace(
+        method="dflash",
+        _dflash_num_context=5,
+        _context_slot_mapping_buffer=torch.arange(8, dtype=torch.int32),
+        _dcut_dflash_context_tokens_by_descriptor={descriptor: 4},
+    )
+
+    try:
+        prepare(drafter, descriptor, None, capture_pending=False)
+    except RuntimeError as error:
+        assert "exceeds its captured length" in str(error)
+    else:
+        raise AssertionError("oversized DFlash graph context should fail")
+
+
+def test_bound_draft_runnable_exposes_graph_owner() -> None:
+    get_owner = _load_functions(
+        DCUT_DIR / "patch_proposer.py",
+        {"_dcut_graph_owner_from_runnable"},
+        {},
+    )["_dcut_graph_owner_from_runnable"]
+
+    class Drafter:
+        def compute_draft_token_ids(self):
+            pass
+
+        def _run_merged_draft(self):
+            pass
+
+    drafter = Drafter()
+
+    assert get_owner(drafter._run_merged_draft) is drafter
+    assert get_owner(lambda: None) is None
+    assert get_owner(SimpleNamespace(__self__=SimpleNamespace())) is None
+
+
+def test_pre_warmup_drops_only_graphs_without_probs() -> None:
+    drop_stale = _load_functions(
+        DCUT_DIR / "patch_worker.py",
+        {"_dcut_drop_pre_warmup_draft_graphs"},
+        {},
+    )["_dcut_drop_pre_warmup_draft_graphs"]
+
+    stale = object()
+    retained = object()
+    pending = object()
+    entries = {
+        stale: SimpleNamespace(aclgraph=object()),
+        retained: SimpleNamespace(aclgraph=object()),
+        pending: SimpleNamespace(aclgraph=None),
+    }
+    runnable = SimpleNamespace(concrete_aclgraph_entries=entries)
+    drafter = SimpleNamespace(
+        needs_draft_probs=True,
+        _runnable=runnable,
+        _dcut_graph_selected_probs_by_descriptor={retained: object()},
+    )
+    runner = SimpleNamespace(drafter=drafter)
+
+    assert drop_stale(runner) == 1
+    assert stale not in entries
+    assert retained in entries
+    assert pending in entries
+
+    disabled = SimpleNamespace(
+        drafter=SimpleNamespace(needs_draft_probs=False),
+    )
+    assert drop_stale(disabled) == 0
+
+
+def test_eager_draft_does_not_reuse_graph_selected_probs() -> None:
+    utils = _load_utils()
+    drafter = SimpleNamespace(
+        _dcut_last_draft_ran_python=True,
+        _dcut_graph_selected_probs_ready=True,
+        _dcut_graph_selected_probs_by_output_ptr={},
+        _dcut_graph_selected_probs_by_shape={
+            (1, 2): torch.ones((1, 2)),
+        },
+        _dcut_graph_selected_probs_by_numel={},
+    )
+
+    actual = utils["_dcut_selected_probs_from_graph"](
+        drafter,
+        torch.zeros((1, 2), dtype=torch.int64),
+    )
+
+    assert actual is None
+
+
+def test_probability_rows_include_request_that_just_finished_prefill() -> None:
+    functions = _load_functions(
+        DCUT_DIR / "probs.py",
+        {"_dcut_probability_req_ids", "_dcut_queue_probs"},
+        {
+            "_dcut_enable_drafter_probs": lambda runner: None,
+            "_dcut_selected_probs_from_graph": lambda *args: None,
+            "_dcut_selected_probs_from_reused_logits": lambda *args: None,
+            "logger": SimpleNamespace(
+                info=lambda *args: None,
+                warning=lambda *args: None,
+            ),
+        },
+    )
+
+    class Event:
+        recorded = 0
+
+        def record(self):
+            self.recorded += 1
+
+    selected_probs = torch.tensor(
+        [[0.9, 0.8, 0.7], [0.6, 0.5, 0.4]],
+        dtype=torch.float32,
+    )
+    drafter = SimpleNamespace(
+        _dcut_last_draft_ran_python=True,
+        take_last_selected_probs=lambda: selected_probs,
+    )
+    event = Event()
+    runner = SimpleNamespace(
+        drafter=drafter,
+        _draft_token_ids=torch.zeros((2, 3), dtype=torch.int64),
+        _draft_token_req_ids=["decode", "just-finished-prefill"],
+        _adaptive_probs_pending=False,
+        _adaptive_probs_pinned=torch.zeros((2, 3)),
+        _adaptive_probs_event=event,
+        num_spec_tokens=3,
+        input_batch=SimpleNamespace(
+            num_reqs=2,
+            req_ids=["decode", "just-finished-prefill"],
+            num_computed_tokens_cpu=[10, 9],
+            num_prompt_tokens=[10, 10],
+        ),
+    )
+
+    functions["_dcut_queue_probs"](runner, zeros_only=False)
+
+    assert runner._adaptive_req_ids == [
+        "decode",
+        "just-finished-prefill",
+    ]
+    assert runner._adaptive_active == {
+        "decode",
+        "just-finished-prefill",
+    }
+    torch.testing.assert_close(runner._adaptive_probs_pinned, selected_probs)
+    assert event.recorded == 1
+
+
+def test_adaptive_decision_signature_is_atomic() -> None:
+    methods = _load_controller_methods({
+        "set_adaptive_decision",
+        "clear_adaptive_decision",
+        "matches_adaptive_request_set",
+    })
+    controller = SimpleNamespace(
+        _adaptive_draft_lens={"stale": 15},
+        _adaptive_decision_req_ids=frozenset({"stale"}),
+        _adaptive_decision_batch_size=1,
+    )
+
+    methods["set_adaptive_decision"](
+        controller,
+        ["request-0", "request-1"],
+        [2, 3],
+        2,
+    )
+
+    assert controller._adaptive_draft_lens == {
+        "request-0": 2,
+        "request-1": 3,
+    }
+    assert methods["matches_adaptive_request_set"](
+        controller,
+        ["request-1", "request-0"],
+    )
+    assert not methods["matches_adaptive_request_set"](
+        controller,
+        ["request-0", "new-request"],
+    )
+
+    methods["clear_adaptive_decision"](controller)
+    assert controller._adaptive_draft_lens == {}
+    assert not methods["matches_adaptive_request_set"](
+        controller,
+        ["request-0", "request-1"],
+    )
+
+
+def test_pre_truncate_waits_once_and_filters_finished_requests() -> None:
+    process = _load_functions(
+        DCUT_DIR / "probs.py",
+        {"_maybe_process_adaptive_probs"},
+        {},
+    )["_maybe_process_adaptive_probs"]
+
+    class Event:
+        synchronized = 0
+
+        def query(self):
+            return False
+
+        def synchronize(self):
+            self.synchronized += 1
+
+    class Controller:
+        call = None
+
+        def process_draft_output(self, **kwargs):
+            self.call = kwargs
+
+    event = Event()
+    controller = Controller()
+    runner = SimpleNamespace(
+        _adaptive_probs_pending=True,
+        _adaptive_probs_event=event,
+        _dcut_skip_unready_probs=False,
+        _dcut_debug_stats_enabled=True,
+        _adaptive_probs_source="graph_descriptor",
+        _adaptive_probs_generation=7,
+        _adaptive_num_reqs=2,
+        _adaptive_active={"keep", "finished"},
+        _adaptive_req_ids=["keep", "finished"],
+        _adaptive_probs_pinned=torch.ones((2, 3)),
+        _verify_adaptive_controller=controller,
+        input_batch=SimpleNamespace(
+            req_ids=["keep", "new"],
+            num_reqs=2,
+        ),
+    )
+
+    process(runner, stage="pre_truncate")
+
+    assert event.synchronized == 1
+    assert runner._adaptive_probs_pending is False
+    assert controller.call is not None
+    assert controller.call["active_draft_req_ids"] == {"keep"}
+    assert runner._adaptive_probs_last_consumed_source == "graph_descriptor"
+    assert runner._adaptive_probs_last_consumed_generation == 7
+    assert runner._adaptive_probs_last_consumed_mean_by_position == [
+        1.0, 1.0, 1.0
+    ]
+
+
+def test_skip_unready_probability_expires_without_cross_step_reuse() -> None:
+    process = _load_functions(
+        DCUT_DIR / "probs.py",
+        {"_maybe_process_adaptive_probs"},
+        {},
+    )["_maybe_process_adaptive_probs"]
+
+    class Event:
+        ready = False
+
+        def query(self):
+            return self.ready
+
+    class Controller:
+        cleared = 0
+        processed = 0
+
+        def clear_adaptive_decision(self):
+            self.cleared += 1
+
+        def process_draft_output(self, **kwargs):
+            self.processed += 1
+
+    event = Event()
+    controller = Controller()
+    runner = SimpleNamespace(
+        _adaptive_probs_pending=True,
+        _adaptive_probs_event=event,
+        _dcut_skip_unready_probs=True,
+        _adaptive_probs_expired=False,
+        _adaptive_probs_source="graph_descriptor",
+        _adaptive_probs_generation=3,
+        _adaptive_num_reqs=1,
+        _adaptive_active={"request-0"},
+        _adaptive_req_ids=["request-0"],
+        _adaptive_probs_pinned=torch.ones((1, 3)),
+        _verify_adaptive_controller=controller,
+        input_batch=SimpleNamespace(req_ids=["request-0"], num_reqs=1),
+    )
+
+    process(runner, stage="pre_truncate")
+
+    assert runner._adaptive_probs_pending is True
+    assert runner._adaptive_probs_expired is True
+    assert controller.cleared == 1
+    assert controller.processed == 0
+
+    event.ready = True
+    process(runner, stage="pre_truncate")
+
+    assert runner._adaptive_probs_pending is False
+    assert runner._adaptive_probs_expired is False
+    assert runner._adaptive_probs_source == "expired"
+    assert controller.cleared == 2
+    assert controller.processed == 0
+
+
+def test_prepare_clears_transient_graph_logits_pointer() -> None:
+    prepare = _load_functions(
+        DCUT_DIR / "probs.py",
+        {"_dcut_prepare_prob_capture"},
+        {},
+    )["_dcut_prepare_prob_capture"]
+
+    class Controller:
+        cleared = 0
+
+        def clear_adaptive_decision(self):
+            self.cleared += 1
+
+    drafter = SimpleNamespace(
+        _dcut_last_draft_ran_python=True,
+        _dcut_last_logits_for_probs=object(),
+        _last_selected_probs=object(),
+    )
+    controller = Controller()
+    runner = SimpleNamespace(
+        drafter=drafter,
+        _verify_adaptive_controller=controller,
+    )
+
+    prepare(runner, SimpleNamespace())
+
+    assert drafter._dcut_last_draft_ran_python is False
+    assert drafter._dcut_last_logits_for_probs is None
+    assert drafter._last_selected_probs is None
+    assert drafter._dcut_current_graph_descriptor is None
+    assert drafter._dcut_last_graph_prob_source == "none"
+    assert controller.cleared == 1
+
+
+def test_no_low_batch_or_eager_fallback_was_migrated() -> None:
+    sources = "\n".join(
+        (DCUT_DIR / name).read_text(encoding="utf-8")
+        for name in (
+            "controller.py",
+            "drafter.py",
+            "globals.py",
+            "patch_proposer.py",
+            "patch_runner.py",
+            "probs.py",
+            "truncate.py",
+            "utils.py",
+        )
+    )
+    assert "MIN_SPEC_BATCH" not in sources
+    assert "min_spec_batch" not in sources
+    assert "use_cuda_graph = False" not in sources
+
+
+def test_pending_probs_are_processed_before_truncation() -> None:
+    source = (DCUT_DIR / "patch_runner.py").read_text(encoding="utf-8")
+    execute_start = source.index("    def execute_model(")
+    execute_end = source.index("    _orig_sample_tokens", execute_start)
+    execute_source = source[execute_start:execute_end]
+
+    process_at = execute_source.index("_maybe_process_adaptive_probs")
+    truncate_at = execute_source.index("scheduler_output = _dcut_truncate")
+    assert process_at < truncate_at
+
+
+def test_scheduler_prefill_route_is_scoped_to_execute_model() -> None:
+    route = _load_functions(
+        DCUT_DIR / "patch_runner.py",
+        {"_dcut_execute_with_gdn_prefill_route"},
+        {},
+    )["_dcut_execute_with_gdn_prefill_route"]
+    runner = SimpleNamespace()
+    observed = []
+
+    def execute(active_runner, scheduler_output, intermediate_tensors):
+        observed.append(active_runner._dcut_gdn_scheduler_has_prefill)
+        return scheduler_output, intermediate_tensors
+
+    result = route(runner, execute, "schedule", "intermediate", False)
+
+    assert result == ("schedule", "intermediate")
+    assert observed == [False]
+    assert not hasattr(runner, "_dcut_gdn_scheduler_has_prefill")
+
+
+def test_force_drafter_eager_keeps_target_graph_mode() -> None:
+    forced = {"enabled": True}
+    warnings = []
+    patched = []
+    setup = []
+    enable = _load_functions(
+        DCUT_DIR / "controller.py",
+        {"_dcut_enable_drafter_probs"},
+        {
+            "ENV_FORCE_DRAFTER_EAGER": "VLLM_DCUT_FORCE_DRAFTER_EAGER",
+            "_env_flag": lambda _name: forced["enabled"],
+            "_dcut_patch_drafter_instance": patched.append,
+            "_dcut_setup_full_decode_drafter": (
+                lambda runner, drafter: setup.append((runner, drafter))
+            ),
+            "logger": SimpleNamespace(
+                warning=lambda *args, **kwargs: warnings.append((args, kwargs))
+            ),
+        },
+    )["_dcut_enable_drafter_probs"]
+
+    drafter = SimpleNamespace(
+        needs_draft_probs=False,
+        use_cuda_graph=True,
+        method="dflash",
+        parallel_drafting=True,
+    )
+    runner = SimpleNamespace(
+        _verify_adaptive_controller=object(),
+        drafter=drafter,
+        compilation_config=SimpleNamespace(cudagraph_mode="FULL_DECODE_ONLY"),
+        _dcut_logged_drafter_probs=True,
+    )
+
+    enable(runner)
+    enable(runner)
+
+    assert drafter.use_cuda_graph is False
+    assert drafter.needs_draft_probs is True
+    assert patched == [drafter, drafter]
+    assert setup == [(runner, drafter), (runner, drafter)]
+    assert len(warnings) == 1
+    assert warnings[0][0][1] == "VLLM_DCUT_FORCE_DRAFTER_EAGER"
+    assert warnings[0][0][2] == "FULL_DECODE_ONLY"
+
+    forced["enabled"] = False
+    drafter.use_cuda_graph = True
+    enable(runner)
+    assert drafter.use_cuda_graph is True
+
+    globals_source = (DCUT_DIR / "globals.py").read_text(encoding="utf-8")
+    assert (
+        'ENV_FORCE_DRAFTER_EAGER = "VLLM_DCUT_FORCE_DRAFTER_EAGER"'
+        in globals_source
+    )
+
+
+def test_no_cut_keeps_gdn_patch_but_skips_control_plane() -> None:
+    controller = (DCUT_DIR / "controller.py").read_text(encoding="utf-8")
+    runner = (DCUT_DIR / "patch_runner.py").read_text(encoding="utf-8")
+    install = (DCUT_DIR / "install.py").read_text(encoding="utf-8")
+
+    assert "if _env_flag(ENV_DISABLE):" in controller
+    assert "D-Cut GDN operator patches remain active" in controller
+    assert "not _env_flag(ENV_DISABLE)" in runner
+    fast_path = runner[
+        runner.index("        if not debug_stats:"):
+        runner.index("        # Optional slow-path debug timing.")
+    ]
+    assert "npu.synchronize" not in fast_path
+    assert "if os.environ.get(ENV_CONFIG) and not _patch_gdn_dcut()" in install

--- a/dcut/tests/test_truncate_zero_draft.py
+++ b/dcut/tests/test_truncate_zero_draft.py
@@ -1,0 +1,597 @@
+# SPDX-License-Identifier: Apache-2.0
+
+import ast
+from dataclasses import dataclass, field, replace
+from pathlib import Path
+from types import SimpleNamespace
+
+TRUNCATE_PATH = Path(__file__).resolve().parents[1] / "truncate.py"
+REPO_ROOT = TRUNCATE_PATH.parents[1]
+
+
+@dataclass
+class _SchedulerOutput:
+    scheduled_spec_decode_tokens: dict[str, list[int]]
+    num_scheduled_tokens: dict[str, int]
+    total_num_scheduled_tokens: int
+    scheduled_new_reqs: list[object] = field(default_factory=list)
+
+
+def _load_truncate_module(target_draft_lens: list[int]):
+    tree = ast.parse(TRUNCATE_PATH.read_text(encoding="utf-8"))
+    functions = [
+        node
+        for node in tree.body
+        if isinstance(node, ast.FunctionDef)
+        and node.name in {
+            "_dcut_add_zero_draft_handoffs",
+            "_dcut_apply_zero_prob_recompute_caps",
+            "_dcut_can_reuse_decision_for_surviving_requests",
+            "_dcut_can_reuse_decision_for_zero_draft_handoffs",
+            "_dcut_has_prefill",
+            "_dcut_is_recompute_handoff",
+            "_dcut_recompute_placeholder_req_ids",
+            "_dcut_truncate",
+            "_dcut_zero_draft_kv_handoff_req_ids",
+        }
+    ]
+    module = ast.Module(body=functions, type_ignores=[])
+    ast.fix_missing_locations(module)
+
+    trim_records = []
+    namespace = {
+        "replace": replace,
+        "_dcut_get_target_draft_lens": (
+            lambda controller, original: target_draft_lens
+        ),
+        "_dcut_record_trim": lambda *args: trim_records.append(args[1:]),
+        "PLACEHOLDER_TOKEN_ID": -1,
+    }
+    exec(compile(module, str(TRUNCATE_PATH), "exec"), namespace)
+    return namespace, trim_records
+
+
+def _load_truncate(target_draft_lens: list[int]):
+    namespace, trim_records = _load_truncate_module(target_draft_lens)
+    return namespace["_dcut_truncate"], trim_records
+
+
+def test_recompute_handoff_placeholder_is_detected() -> None:
+    namespace, _ = _load_truncate_module([])
+    is_handoff = namespace["_dcut_is_recompute_handoff"]
+    output = _SchedulerOutput(
+        scheduled_spec_decode_tokens={
+            "handoff": [-1] * 15,
+            "existing-decode": [10, 11, 12],
+        },
+        num_scheduled_tokens={"handoff": 16, "existing-decode": 4},
+        total_num_scheduled_tokens=20,
+        scheduled_new_reqs=[SimpleNamespace(req_id="handoff")],
+    )
+
+    assert is_handoff(output) is True
+    assert namespace["_dcut_recompute_placeholder_req_ids"](output) == (
+        frozenset({"handoff"})
+    )
+
+
+def test_mixed_real_and_placeholder_row_uses_native_fallback() -> None:
+    namespace, _ = _load_truncate_module([])
+    output = _SchedulerOutput(
+        scheduled_spec_decode_tokens={"handoff": [-1, 42, -1]},
+        num_scheduled_tokens={"handoff": 4},
+        total_num_scheduled_tokens=4,
+    )
+
+    assert namespace["_dcut_is_recompute_handoff"](output) is True
+    assert (
+        namespace["_dcut_recompute_placeholder_req_ids"](output)
+        == frozenset()
+    )
+
+
+def test_recompute_placeholders_force_zero_cap_and_keep_real_cap() -> None:
+    namespace, _ = _load_truncate_module([])
+
+    class Controller:
+        def __init__(self):
+            self.decision = None
+
+        def get_adaptive_draft_len(self, req_id):
+            return 2 if req_id == "decode" else None
+
+        def set_adaptive_decision(self, req_ids, draft_lens, batch_size):
+            self.decision = (req_ids, draft_lens, batch_size)
+
+    output = _SchedulerOutput(
+        scheduled_spec_decode_tokens={
+            "handoff": [-1] * 15,
+            "decode": [10, 11, 12],
+        },
+        num_scheduled_tokens={"handoff": 16, "decode": 4},
+        total_num_scheduled_tokens=20,
+    )
+    controller = Controller()
+
+    assert namespace["_dcut_apply_zero_prob_recompute_caps"](
+        controller,
+        output,
+        frozenset({"handoff"}),
+    )
+    assert controller.decision == (
+        ["handoff", "decode"],
+        [0, 2],
+        2,
+    )
+
+
+def test_recompute_placeholders_trim_to_anchor_only_full_row() -> None:
+    truncate, trim_records = _load_truncate([0, 2])
+    original = _SchedulerOutput(
+        scheduled_spec_decode_tokens={
+            "handoff": [-1] * 15,
+            "decode": [10, 11, 12],
+        },
+        num_scheduled_tokens={"handoff": 16, "decode": 4},
+        total_num_scheduled_tokens=20,
+    )
+
+    result = truncate(
+        SimpleNamespace(_verify_adaptive_controller=object()),
+        original,
+        has_prefill=False,
+    )
+
+    assert result.scheduled_spec_decode_tokens == {
+        "handoff": [],
+        "decode": [10, 11],
+    }
+    assert result.num_scheduled_tokens == {
+        "handoff": 1,
+        "decode": 3,
+    }
+    assert result.total_num_scheduled_tokens == 4
+    assert trim_records == [(18, 16, 2)]
+
+
+def test_real_draft_tokens_on_new_request_are_not_recompute_handoff() -> None:
+    namespace, _ = _load_truncate_module([])
+    is_handoff = namespace["_dcut_is_recompute_handoff"]
+    output = _SchedulerOutput(
+        scheduled_spec_decode_tokens={"new": [10, 11, 12]},
+        num_scheduled_tokens={"new": 4},
+        total_num_scheduled_tokens=4,
+        scheduled_new_reqs=[SimpleNamespace(req_id="new")],
+    )
+
+    assert is_handoff(output) is False
+    assert namespace["_dcut_has_prefill"](
+        SimpleNamespace(is_kv_consumer=True),
+        output,
+    ) is True
+
+
+def test_kv_consumer_first_token_handoff_becomes_zero_draft_decode() -> None:
+    namespace, _ = _load_truncate_module([])
+    detect_handoffs = namespace["_dcut_zero_draft_kv_handoff_req_ids"]
+    add_handoffs = namespace["_dcut_add_zero_draft_handoffs"]
+    has_prefill = namespace["_dcut_has_prefill"]
+    original = _SchedulerOutput(
+        scheduled_spec_decode_tokens={"existing": [10, 11]},
+        num_scheduled_tokens={"existing": 3, "handoff": 1},
+        total_num_scheduled_tokens=4,
+        scheduled_new_reqs=[
+            SimpleNamespace(req_id="handoff", num_computed_tokens=128)
+        ],
+    )
+    runner = SimpleNamespace(is_kv_consumer=True)
+
+    handoff_req_ids = detect_handoffs(runner, original)
+    result = add_handoffs(original, handoff_req_ids)
+
+    assert handoff_req_ids == frozenset({"handoff"})
+    assert has_prefill(runner, original, handoff_req_ids) is False
+    assert result is not original
+    assert result.scheduled_spec_decode_tokens == {
+        "existing": [10, 11],
+        "handoff": [],
+    }
+    assert result.num_scheduled_tokens == original.num_scheduled_tokens
+    assert result.total_num_scheduled_tokens == 4
+
+
+def test_real_new_prefill_is_not_promoted_to_zero_draft_decode() -> None:
+    namespace, _ = _load_truncate_module([])
+    detect_handoffs = namespace["_dcut_zero_draft_kv_handoff_req_ids"]
+    has_prefill = namespace["_dcut_has_prefill"]
+    output = _SchedulerOutput(
+        scheduled_spec_decode_tokens={"existing": [10, 11]},
+        num_scheduled_tokens={"existing": 3, "prefill": 8},
+        total_num_scheduled_tokens=11,
+        scheduled_new_reqs=[
+            SimpleNamespace(req_id="prefill", num_computed_tokens=0)
+        ],
+    )
+    runner = SimpleNamespace(is_kv_consumer=True)
+
+    handoff_req_ids = detect_handoffs(runner, output)
+
+    assert handoff_req_ids == frozenset()
+    assert has_prefill(runner, output, handoff_req_ids) is True
+
+
+def test_placeholder_on_resumed_request_is_recompute_handoff() -> None:
+    namespace, _ = _load_truncate_module([])
+    is_handoff = namespace["_dcut_is_recompute_handoff"]
+    output = _SchedulerOutput(
+        scheduled_spec_decode_tokens={"existing": [-1] * 15},
+        num_scheduled_tokens={"existing": 16},
+        total_num_scheduled_tokens=16,
+    )
+
+    assert is_handoff(output) is True
+
+
+def test_mixed_prefill_decode_batch_is_not_truncated() -> None:
+    truncate, trim_records = _load_truncate([1])
+    original = _SchedulerOutput(
+        scheduled_spec_decode_tokens={"decode": [10, 11, 12]},
+        num_scheduled_tokens={"decode": 4, "prefill": 8},
+        total_num_scheduled_tokens=12,
+        scheduled_new_reqs=[SimpleNamespace(req_id="prefill")],
+    )
+
+    result = truncate(
+        SimpleNamespace(_verify_adaptive_controller=object()),
+        original,
+    )
+
+    assert result is original
+    assert result.scheduled_spec_decode_tokens["decode"] == [10, 11, 12]
+    assert trim_records == []
+
+
+def test_single_token_prefill_tail_is_not_truncated() -> None:
+    truncate, trim_records = _load_truncate([1])
+    original = _SchedulerOutput(
+        scheduled_spec_decode_tokens={"decode": [10, 11, 12]},
+        num_scheduled_tokens={"decode": 4, "prefill": 1},
+        total_num_scheduled_tokens=5,
+    )
+    input_batch = SimpleNamespace(
+        req_id_to_index={"decode": 0, "prefill": 1},
+        num_computed_tokens_cpu=[32, 7],
+        num_prompt_tokens=[32, 8],
+    )
+
+    result = truncate(
+        SimpleNamespace(
+            _verify_adaptive_controller=object(),
+            input_batch=input_batch,
+        ),
+        original,
+    )
+
+    assert result is original
+    assert result.scheduled_spec_decode_tokens["decode"] == [10, 11, 12]
+    assert trim_records == []
+
+
+def test_request_set_change_skips_stale_partial_truncation() -> None:
+    truncate, trim_records = _load_truncate([1, 1])
+
+    class Controller:
+        def matches_adaptive_request_set(self, req_ids):
+            return frozenset(req_ids) == frozenset({"old-0", "old-1"})
+
+    original = _SchedulerOutput(
+        scheduled_spec_decode_tokens={
+            "old-0": [10, 11, 12],
+            "new-from-prefill": [20, 21, 22],
+        },
+        num_scheduled_tokens={"old-0": 4, "new-from-prefill": 4},
+        total_num_scheduled_tokens=8,
+    )
+
+    result = truncate(
+        SimpleNamespace(_verify_adaptive_controller=Controller()),
+        original,
+    )
+
+    assert result is original
+    assert result.scheduled_spec_decode_tokens == {
+        "old-0": [10, 11, 12],
+        "new-from-prefill": [20, 21, 22],
+    }
+    assert trim_records == []
+
+
+def test_finished_requests_reuse_caps_for_surviving_subset() -> None:
+    truncate, trim_records = _load_truncate([1, 2])
+
+    class Controller:
+        _adaptive_decision_req_ids = frozenset(
+            {"survivor-0", "survivor-1", "finished"}
+        )
+        _adaptive_decision_batch_size = 3
+        _sorted_bs = (4,)
+
+        def matches_adaptive_request_set(self, req_ids):
+            return False
+
+        def get_adaptive_draft_len(self, req_id):
+            return {"survivor-0": 1, "survivor-1": 2}.get(req_id)
+
+    original = _SchedulerOutput(
+        scheduled_spec_decode_tokens={
+            "survivor-0": [10, 11, 12],
+            "survivor-1": [20, 21, 22],
+        },
+        num_scheduled_tokens={"survivor-0": 4, "survivor-1": 4},
+        total_num_scheduled_tokens=8,
+    )
+    runner = SimpleNamespace(
+        _verify_adaptive_controller=Controller(),
+    )
+
+    result = truncate(runner, original, has_prefill=False)
+
+    assert result.scheduled_spec_decode_tokens == {
+        "survivor-0": [10],
+        "survivor-1": [20, 21],
+    }
+    assert result.total_num_scheduled_tokens == 5
+    assert runner._dcut_last_reused_survivor_decision is True
+    assert trim_records == [(6, 3, 2)]
+
+
+def test_missing_survivor_cap_does_not_reuse_partial_decision() -> None:
+    truncate, trim_records = _load_truncate([1, 3])
+
+    class Controller:
+        _adaptive_decision_req_ids = frozenset(
+            {"survivor-0", "survivor-1", "finished"}
+        )
+        _adaptive_decision_batch_size = 3
+        _sorted_bs = (4,)
+
+        def matches_adaptive_request_set(self, req_ids):
+            return False
+
+        def get_adaptive_draft_len(self, req_id):
+            return 1 if req_id == "survivor-0" else None
+
+    original = _SchedulerOutput(
+        scheduled_spec_decode_tokens={
+            "survivor-0": [10, 11, 12],
+            "survivor-1": [20, 21, 22],
+        },
+        num_scheduled_tokens={"survivor-0": 4, "survivor-1": 4},
+        total_num_scheduled_tokens=8,
+    )
+    runner = SimpleNamespace(
+        _verify_adaptive_controller=Controller(),
+    )
+
+    result = truncate(runner, original, has_prefill=False)
+
+    assert result is original
+    assert runner._dcut_last_reused_survivor_decision is False
+    assert trim_records == []
+
+
+def test_survivor_caps_are_not_reused_across_batch_bucket() -> None:
+    truncate, trim_records = _load_truncate([1, 1])
+
+    class Controller:
+        _adaptive_decision_req_ids = frozenset(
+            {"survivor-0", "survivor-1", "finished"}
+        )
+        _adaptive_decision_batch_size = 3
+        _sorted_bs = (2, 4)
+
+        def matches_adaptive_request_set(self, req_ids):
+            return False
+
+        def get_adaptive_draft_len(self, req_id):
+            return 1
+
+    original = _SchedulerOutput(
+        scheduled_spec_decode_tokens={
+            "survivor-0": [10, 11, 12],
+            "survivor-1": [20, 21, 22],
+        },
+        num_scheduled_tokens={"survivor-0": 4, "survivor-1": 4},
+        total_num_scheduled_tokens=8,
+    )
+    runner = SimpleNamespace(
+        _verify_adaptive_controller=Controller(),
+    )
+
+    result = truncate(runner, original, has_prefill=False)
+
+    assert result is original
+    assert runner._dcut_last_reused_survivor_decision is False
+    assert trim_records == []
+
+
+def test_zero_draft_handoff_reuses_surviving_cached_decisions() -> None:
+    truncate, trim_records = _load_truncate([1])
+
+    class Controller:
+        _adaptive_decision_req_ids = frozenset({"old-0", "old-1"})
+        _adaptive_decision_batch_size = 2
+
+        def matches_adaptive_request_set(self, req_ids):
+            return False
+
+    original = _SchedulerOutput(
+        scheduled_spec_decode_tokens={
+            "old-0": [10, 11, 12],
+        },
+        num_scheduled_tokens={"old-0": 4, "handoff": 1},
+        total_num_scheduled_tokens=5,
+        scheduled_new_reqs=[
+            SimpleNamespace(req_id="handoff", num_computed_tokens=128)
+        ],
+    )
+    runner = SimpleNamespace(
+        _verify_adaptive_controller=Controller(),
+    )
+
+    truncated = truncate(
+        runner,
+        original,
+        has_prefill=False,
+        zero_draft_handoff_req_ids=frozenset({"handoff"}),
+    )
+
+    assert truncated.scheduled_spec_decode_tokens == {
+        "old-0": [10],
+    }
+    assert truncated.num_scheduled_tokens == {
+        "old-0": 2,
+        "handoff": 1,
+    }
+    assert truncated.total_num_scheduled_tokens == 3
+    assert runner._dcut_last_reused_handoff_decision is True
+    assert trim_records == [(3, 2, 1)]
+
+
+def test_zero_draft_handoff_does_not_cover_unknown_spec_request() -> None:
+    truncate, trim_records = _load_truncate([1, 0])
+
+    class Controller:
+        _adaptive_decision_req_ids = frozenset({"old-0", "old-1"})
+        _adaptive_decision_batch_size = 3
+
+        def matches_adaptive_request_set(self, req_ids):
+            return False
+
+    original = _SchedulerOutput(
+        scheduled_spec_decode_tokens={
+            "old-0": [10, 11, 12],
+            "unknown": [20, 21, 22],
+        },
+        num_scheduled_tokens={
+            "old-0": 4,
+            "unknown": 4,
+            "handoff": 1,
+        },
+        total_num_scheduled_tokens=9,
+    )
+    runner = SimpleNamespace(
+        _verify_adaptive_controller=Controller(),
+    )
+
+    result = truncate(
+        runner,
+        original,
+        has_prefill=False,
+        zero_draft_handoff_req_ids=frozenset({"handoff"}),
+    )
+
+    assert result is original
+    assert runner._dcut_last_reused_handoff_decision is False
+    assert trim_records == []
+
+
+def test_matching_request_set_applies_one_coherent_decision() -> None:
+    truncate, trim_records = _load_truncate([1, 2])
+
+    class Controller:
+        def matches_adaptive_request_set(self, req_ids):
+            return frozenset(req_ids) == frozenset({"request-0", "request-1"})
+
+    original = _SchedulerOutput(
+        scheduled_spec_decode_tokens={
+            "request-0": [10, 11, 12],
+            "request-1": [20, 21, 22],
+        },
+        num_scheduled_tokens={"request-0": 4, "request-1": 4},
+        total_num_scheduled_tokens=8,
+    )
+
+    result = truncate(
+        SimpleNamespace(_verify_adaptive_controller=Controller()),
+        original,
+    )
+
+    assert result.scheduled_spec_decode_tokens == {
+        "request-0": [10],
+        "request-1": [20, 21],
+    }
+    assert result.num_scheduled_tokens == {"request-0": 2, "request-1": 3}
+    assert result.total_num_scheduled_tokens == 5
+    assert trim_records == [(6, 3, 2)]
+
+
+def test_zero_draft_decision_stays_on_spec_path_without_adding_tokens() -> None:
+    truncate, trim_records = _load_truncate([0, 2])
+    original = _SchedulerOutput(
+        scheduled_spec_decode_tokens={
+            "zero": [10, 11, 12],
+            "kept": [20, 21, 22],
+        },
+        num_scheduled_tokens={"zero": 4, "kept": 4, "ordinary": 1},
+        total_num_scheduled_tokens=9,
+    )
+
+    result = truncate(
+        SimpleNamespace(_verify_adaptive_controller=object()),
+        original,
+    )
+
+    assert result is not original
+    assert result.scheduled_spec_decode_tokens == {
+        "zero": [],
+        "kept": [20, 21],
+    }
+    assert result.num_scheduled_tokens == {
+        "zero": 1,
+        "kept": 3,
+        "ordinary": 1,
+    }
+    assert result.total_num_scheduled_tokens == 5
+    assert "ordinary" not in result.scheduled_spec_decode_tokens
+    assert original.scheduled_spec_decode_tokens["zero"] == [10, 11, 12]
+    assert trim_records == [(6, 4, 2)]
+
+
+def test_all_zero_draft_decisions_keep_a_truthy_spec_mapping() -> None:
+    truncate, _ = _load_truncate([0, 0])
+    original = _SchedulerOutput(
+        scheduled_spec_decode_tokens={"first": [1, 2], "second": [3]},
+        num_scheduled_tokens={"first": 3, "second": 2},
+        total_num_scheduled_tokens=5,
+    )
+
+    result = truncate(
+        SimpleNamespace(_verify_adaptive_controller=object()),
+        original,
+    )
+
+    assert result.scheduled_spec_decode_tokens == {
+        "first": [],
+        "second": [],
+    }
+    assert result.scheduled_spec_decode_tokens
+    assert result.num_scheduled_tokens == {"first": 1, "second": 1}
+    assert result.total_num_scheduled_tokens == 2
+
+
+def test_gdn_uses_zero_as_spec_and_minus_one_as_non_spec() -> None:
+    runner = (
+        REPO_ROOT / "vllm_ascend" / "worker" / "model_runner_v1.py"
+    ).read_text(encoding="utf-8")
+    builder = (
+        REPO_ROOT / "vllm_ascend" / "ops" / "gdn_attn_builder.py"
+    ).read_text(encoding="utf-8")
+
+    assert "num_decode_draft_tokens = np.full(num_reqs, -1" in runner
+    assert "num_decode_draft_tokens[req_idx] = draft_len" in runner
+    assert (
+        "torch.ge(\n"
+        "                num_decode_draft_tokens_cpu,\n"
+        "                0,"
+    ) in builder

--- a/dcut/tests/test_verify_adaptive_costs.py
+++ b/dcut/tests/test_verify_adaptive_costs.py
@@ -1,0 +1,91 @@
+# SPDX-License-Identifier: Apache-2.0
+
+import ast
+import math
+from pathlib import Path
+
+import numpy as np
+
+CONTROLLER_PATH = (
+    Path(__file__).resolve().parents[1]
+    / "verify_adaptive_controller.py"
+)
+
+
+def _load_choose_query_lens_discrete():
+    tree = ast.parse(CONTROLLER_PATH.read_text(encoding="utf-8"))
+    function = next(
+        node
+        for node in tree.body
+        if isinstance(node, ast.FunctionDef)
+        and node.name == "choose_query_lens_discrete"
+    )
+    module = ast.Module(
+        body=[
+            ast.ImportFrom(
+                module="__future__",
+                names=[ast.alias(name="annotations")],
+                level=0,
+            ),
+            function,
+        ],
+        type_ignores=[],
+    )
+    ast.fix_missing_locations(module)
+    namespace = {"np": np, "math": math}
+    exec(compile(module, str(CONTROLLER_PATH), "exec"), namespace)
+    return namespace["choose_query_lens_discrete"]
+
+
+def test_fixed_draft_cost_can_make_longer_verify_shape_optimal() -> None:
+    choose = _load_choose_query_lens_discrete()
+    probs = [[0.8, 0.8, 0.8], [0.8, 0.8, 0.8]]
+    target_costs = {4: 1.0, 8: 2.0}
+
+    target_only = choose(
+        probs=probs,
+        base_batch_size=2,
+        q_levels=[4, 8],
+        cost_lookup=target_costs.__getitem__,
+        max_draft_len=3,
+    )
+    end_to_end = choose(
+        probs=probs,
+        base_batch_size=2,
+        q_levels=[4, 8],
+        cost_lookup=target_costs.__getitem__,
+        max_draft_len=3,
+        draft_cost_lookup=lambda _q: 4.0,
+    )
+
+    assert target_only["best_Q"] == 4
+    assert end_to_end["best_Q"] == 8
+
+
+def test_q_dependent_draft_cost_is_included_in_records() -> None:
+    choose = _load_choose_query_lens_discrete()
+    result = choose(
+        probs=[[0.9, 0.9]],
+        base_batch_size=1,
+        q_levels=[2, 3],
+        cost_lookup=lambda q: {2: 2.0, 3: 3.0}[q],
+        max_draft_len=2,
+        collect_records=True,
+        draft_cost_lookup=lambda q: {2: 0.5, 3: 1.5}[q],
+    )
+
+    records = result["records"]
+    assert records is not None
+    assert records[0]["Q"] == 2
+    assert records[0]["target_cost"] == 2.0
+    assert records[0]["draft_cost"] == 0.5
+    assert records[0]["cost"] == 2.5
+    assert math.isclose(records[0]["score"], (1.0 + 0.9) / 2.5)
+    assert records[1]["Q"] == 3
+    assert records[1]["target_cost"] == 3.0
+    assert records[1]["draft_cost"] == 1.5
+    assert records[1]["cost"] == 4.5
+    assert math.isclose(
+        records[1]["score"],
+        (1.0 + 0.9 + 0.81) / 4.5,
+    )

--- a/dcut/truncate.py
+++ b/dcut/truncate.py
@@ -1,0 +1,554 @@
+# SPDX-License-Identifier: Apache-2.0
+"""D-Cut draft truncation + verify-reduction stats."""
+
+from __future__ import annotations
+
+import json
+import os
+import time
+from dataclasses import replace
+
+from vllm.distributed import get_pp_group, get_tp_group
+from vllm.v1.sample.rejection_sampler import PLACEHOLDER_TOKEN_ID
+
+from .globals import logger
+
+
+def _dcut_is_recompute_handoff(scheduler_output) -> bool:
+    """Return whether this batch contains a PD recompute handoff request.
+
+    Match the stock runner's placeholder handling: any scheduled speculative
+    row containing ``PLACEHOLDER_TOKEN_ID`` belongs to recompute handoff, not
+    to the drafter. The request may be new or resumed.
+    """
+    scheduled_spec = getattr(
+        scheduler_output,
+        "scheduled_spec_decode_tokens",
+        None,
+    ) or {}
+    return any(
+        PLACEHOLDER_TOKEN_ID in draft_token_ids
+        for draft_token_ids in scheduled_spec.values()
+    )
+
+
+def _dcut_recompute_placeholder_req_ids(
+    scheduler_output,
+) -> frozenset[str]:
+    """Return requests whose complete draft row is recompute padding.
+
+    RecomputeScheduler creates one real anchor plus a row of placeholder
+    speculative tokens. A row containing both placeholders and real tokens
+    is not a supported handoff representation; return an empty set so the
+    caller keeps the stock recompute path for the complete batch.
+    """
+    scheduled_spec = getattr(
+        scheduler_output,
+        "scheduled_spec_decode_tokens",
+        None,
+    ) or {}
+    placeholder_req_ids = set()
+    for req_id, draft_token_ids in scheduled_spec.items():
+        if PLACEHOLDER_TOKEN_ID not in draft_token_ids:
+            continue
+        if not draft_token_ids or any(
+            token_id != PLACEHOLDER_TOKEN_ID
+            for token_id in draft_token_ids
+        ):
+            return frozenset()
+        placeholder_req_ids.add(req_id)
+    return frozenset(placeholder_req_ids)
+
+
+def _dcut_apply_zero_prob_recompute_caps(
+    ctrl,
+    scheduler_output,
+    placeholder_req_ids: frozenset[str],
+) -> bool:
+    """Install a coherent decision with zero-value recompute drafts.
+
+    A literal zero-probability row can still receive tokens when the smallest
+    profiled query level is larger than the anchor-only batch. Force the
+    equivalent cap of zero instead. Preserve any fresh cap for ordinary
+    speculative requests and use their full length when no cap is available.
+    """
+    original_spec = getattr(
+        scheduler_output,
+        "scheduled_spec_decode_tokens",
+        None,
+    ) or {}
+    if (
+        not placeholder_req_ids
+        or not placeholder_req_ids.issubset(original_spec)
+    ):
+        return False
+
+    req_ids = list(original_spec)
+    draft_lens = []
+    for req_id, draft_token_ids in original_spec.items():
+        if req_id in placeholder_req_ids:
+            draft_lens.append(0)
+            continue
+        adaptive_len = ctrl.get_adaptive_draft_len(req_id)
+        if adaptive_len is None:
+            adaptive_len = len(draft_token_ids)
+        draft_lens.append(
+            min(max(int(adaptive_len), 0), len(draft_token_ids))
+        )
+
+    ctrl.set_adaptive_decision(
+        req_ids,
+        draft_lens,
+        len(getattr(scheduler_output, "num_scheduled_tokens", {})),
+    )
+    return True
+
+
+def _dcut_zero_draft_kv_handoff_req_ids(
+    self,
+    scheduler_output,
+) -> frozenset[str]:
+    """Return new KV-consumer requests that can enter decode with no draft.
+
+    A disaggregated decoder can receive a request whose prompt KV is already
+    available and schedule only its first decode token. The stock Ascend
+    runner already treats an empty speculative entry for such a new request as
+    ``num_decode_draft_tokens == 0``. Detect only that exact case here so it
+    can share the ragged FULL graph with ordinary speculative rows. Real
+    prompt prefill and recompute placeholder rows remain on their native path.
+    """
+    if not getattr(self, "is_kv_consumer", False):
+        return frozenset()
+
+    scheduled_spec = getattr(
+        scheduler_output,
+        "scheduled_spec_decode_tokens",
+        None,
+    ) or {}
+    num_scheduled_tokens = getattr(
+        scheduler_output,
+        "num_scheduled_tokens",
+        None,
+    ) or {}
+    handoff_req_ids = set()
+    for new_req in getattr(scheduler_output, "scheduled_new_reqs", ()) or ():
+        req_id = getattr(new_req, "req_id", None)
+        if req_id is None or req_id in scheduled_spec:
+            continue
+        if int(num_scheduled_tokens.get(req_id, 0)) != 1:
+            continue
+        if int(getattr(new_req, "num_computed_tokens", 0)) <= 0:
+            continue
+        handoff_req_ids.add(req_id)
+    return frozenset(handoff_req_ids)
+
+
+def _dcut_add_zero_draft_handoffs(
+    scheduler_output,
+    req_ids: frozenset[str],
+):
+    """Represent eligible KV handoffs as zero-draft speculative rows."""
+    if not req_ids:
+        return scheduler_output
+
+    scheduled_spec = dict(
+        getattr(
+            scheduler_output,
+            "scheduled_spec_decode_tokens",
+            None,
+        )
+        or {}
+    )
+    changed = False
+    for new_req in getattr(scheduler_output, "scheduled_new_reqs", ()) or ():
+        req_id = getattr(new_req, "req_id", None)
+        if req_id in req_ids and req_id not in scheduled_spec:
+            scheduled_spec[req_id] = []
+            changed = True
+    if not changed:
+        return scheduler_output
+    return replace(
+        scheduler_output,
+        scheduled_spec_decode_tokens=scheduled_spec,
+    )
+
+
+def _dcut_can_reuse_decision_for_zero_draft_handoffs(
+    ctrl,
+    scheduler_output,
+    original_spec,
+    zero_draft_handoff_req_ids: frozenset[str],
+) -> bool:
+    """Allow a coherent cached decision across a one-for-one PD handoff.
+
+    The previous proposal may contain decisions for a full batch just before
+    one or more requests finish. A KV-consumer can replace those requests in
+    the next verifier iteration with newly received first-token handoffs that
+    intentionally contribute zero draft tokens. Reusing the cached caps for
+    the surviving speculative requests can only reduce the previously chosen
+    token budget; unlike assigning a full draft to the new rows, it cannot
+    overflow into a larger graph bucket.
+
+    Keep the gate deliberately strict: the total batch size must be unchanged,
+    every speculative request must have a cached decision, every replacement
+    must be an explicitly detected zero-draft handoff, and no replacement may
+    alias a request from the cached snapshot.
+    """
+    if not zero_draft_handoff_req_ids:
+        return False
+
+    decision_req_ids = frozenset(
+        getattr(ctrl, "_adaptive_decision_req_ids", ())
+    )
+    decision_batch_size = int(
+        getattr(ctrl, "_adaptive_decision_batch_size", 0)
+    )
+    spec_req_ids = frozenset(original_spec)
+    current_req_ids = frozenset(
+        getattr(scheduler_output, "num_scheduled_tokens", {})
+    )
+    return bool(
+        decision_batch_size > 0
+        and len(current_req_ids) == decision_batch_size
+        and current_req_ids == spec_req_ids | zero_draft_handoff_req_ids
+        and spec_req_ids.issubset(decision_req_ids)
+        and zero_draft_handoff_req_ids.isdisjoint(decision_req_ids)
+    )
+
+
+def _dcut_can_reuse_decision_for_surviving_requests(
+    ctrl,
+    original_spec,
+) -> bool:
+    """Reuse caps when requests only left the previous proposal batch.
+
+    Every surviving request must still own a cached cap and the current
+    request set must be a strict subset of the decision snapshot. This
+    excludes new/replacement requests while allowing a draining bs=32 batch
+    to keep cutting at bs=31/30/29.
+    """
+    current_req_ids = frozenset(original_spec)
+    decision_req_ids = frozenset(
+        getattr(ctrl, "_adaptive_decision_req_ids", ())
+    )
+    if not current_req_ids or not current_req_ids < decision_req_ids:
+        return False
+    decision_batch_size = int(
+        getattr(ctrl, "_adaptive_decision_batch_size", 0)
+    )
+    sorted_batch_sizes = tuple(getattr(ctrl, "_sorted_bs", ()))
+    if decision_batch_size <= 0 or not sorted_batch_sizes:
+        return False
+
+    def _batch_bucket(batch_size: int) -> int | None:
+        return next(
+            (size for size in sorted_batch_sizes if size >= batch_size),
+            None,
+        )
+
+    if _batch_bucket(len(current_req_ids)) != _batch_bucket(
+        decision_batch_size
+    ):
+        return False
+    return all(
+        ctrl.get_adaptive_draft_len(req_id) is not None
+        for req_id in current_req_ids
+    )
+
+
+def _dcut_has_prefill(
+    self,
+    scheduler_output,
+    zero_draft_handoff_req_ids: frozenset[str] = frozenset(),
+) -> bool:
+    """Return whether the current scheduler batch contains prefill work.
+
+    D-Cut's cost model assumes that every request contributes exactly one
+    anchor token. That assumption does not hold for mixed prefill/decode
+    batches, so leave all speculative drafts intact whenever prefill work is
+    present.
+    """
+
+    scheduled_spec = getattr(
+        scheduler_output,
+        "scheduled_spec_decode_tokens",
+        None,
+    ) or {}
+    for new_req in getattr(scheduler_output, "scheduled_new_reqs", ()) or ():
+        req_id = getattr(new_req, "req_id", None)
+        if req_id in zero_draft_handoff_req_ids:
+            continue
+        return True
+
+    num_scheduled_tokens = getattr(
+        scheduler_output,
+        "num_scheduled_tokens",
+        None,
+    ) or {}
+
+    input_batch = getattr(self, "input_batch", None)
+    req_id_to_index = getattr(input_batch, "req_id_to_index", {})
+    num_computed_tokens = getattr(
+        input_batch,
+        "num_computed_tokens_cpu",
+        None,
+    )
+    num_prompt_tokens = getattr(input_batch, "num_prompt_tokens", None)
+
+    for req_id, num_scheduled in num_scheduled_tokens.items():
+        if req_id in scheduled_spec:
+            continue
+
+        # Ordinary decode contributes one token. Any larger non-spec query is
+        # prefill (including a continuation chunk).
+        if int(num_scheduled) != 1:
+            return True
+
+        # The final chunk of a prefill can contain exactly one token. Use the
+        # runner's request state to distinguish it from ordinary decode.
+        req_idx = req_id_to_index.get(req_id)
+        if (
+            req_idx is not None
+            and num_computed_tokens is not None
+            and num_prompt_tokens is not None
+            and num_computed_tokens[req_idx] < num_prompt_tokens[req_idx]
+        ):
+            return True
+
+    return False
+
+
+def _dcut_get_target_draft_lens(ctrl, original_spec) -> list[int]:
+    """Return rank-0's draft-length decisions in scheduler request order.
+
+    The async selected-probability D2H event can become ready on different
+    scheduler ticks on different TP ranks. Letting every rank consume its
+    local controller cache would then produce different verifier token counts
+    and eventually deadlock a later TP collective. Broadcast one small Python
+    integer list because truncation immediately consumes the result on CPU;
+    using a device tensor here would add an avoidable NPU-to-CPU sync.
+    """
+    tp_group = get_tp_group()
+    target_draft_lens = None
+    if tp_group.rank_in_group == 0:
+        target_draft_lens = []
+        for req_id, draft_tokens in original_spec.items():
+            max_draft_len = len(draft_tokens)
+            adaptive_len = ctrl.get_adaptive_draft_len(req_id)
+            if adaptive_len is None:
+                adaptive_len = max_draft_len
+            target_draft_lens.append(
+                min(max(int(adaptive_len), 0), max_draft_len)
+            )
+
+    if tp_group.world_size > 1:
+        target_draft_lens = tp_group.broadcast_object(
+            target_draft_lens,
+            src=0,
+        )
+
+    if target_draft_lens is None or len(target_draft_lens) != len(original_spec):
+        raise RuntimeError(
+            "D-Cut received an invalid TP decision broadcast: "
+            f"expected {len(original_spec)} draft lengths, got "
+            f"{target_draft_lens!r}"
+        )
+    return target_draft_lens
+
+
+def _dcut_truncate(
+    self,
+    scheduler_output,
+    has_prefill: bool | None = None,
+    zero_draft_handoff_req_ids: frozenset[str] = frozenset(),
+):
+    """Apply cached per-request draft caps without a GDN state floor.
+
+    The D-Cut recurrent and conv1d kernels read the previous accepted state
+    through independent device-side indices, so the current verifier length no
+    longer needs to preserve the previous accepted position.
+    """
+    self._dcut_last_reused_handoff_decision = False
+    self._dcut_last_reused_survivor_decision = False
+    ctrl = self._verify_adaptive_controller
+    scheduled_spec = getattr(
+        scheduler_output,
+        "scheduled_spec_decode_tokens",
+        None,
+    )
+    if ctrl is None or not scheduled_spec:
+        return scheduler_output
+    if has_prefill is None:
+        has_prefill = _dcut_has_prefill(self, scheduler_output)
+    if has_prefill:
+        return scheduler_output
+
+    original_spec = scheduler_output.scheduled_spec_decode_tokens
+    matches_request_set = getattr(
+        ctrl,
+        "matches_adaptive_request_set",
+        None,
+    )
+    exact_request_set = not (
+        matches_request_set is not None
+        and not matches_request_set(original_spec.keys())
+    )
+    reused_handoff_decision = False
+    reused_survivor_decision = False
+    if not exact_request_set:
+        reused_handoff_decision = (
+            _dcut_can_reuse_decision_for_zero_draft_handoffs(
+                ctrl,
+                scheduler_output,
+                original_spec,
+                zero_draft_handoff_req_ids,
+            )
+        )
+        if not reused_handoff_decision:
+            reused_survivor_decision = (
+                _dcut_can_reuse_decision_for_surviving_requests(
+                    ctrl,
+                    original_spec,
+                )
+            )
+    self._dcut_last_reused_handoff_decision = reused_handoff_decision
+    self._dcut_last_reused_survivor_decision = reused_survivor_decision
+    if (
+        not exact_request_set
+        and not reused_handoff_decision
+        and not reused_survivor_decision
+    ):
+        # The probabilities are produced one runner iteration before their
+        # verifier batch. Requests can finish, enter decode after prefill, or
+        # be replaced during that gap. Never combine caps optimized for the
+        # old set with full-length defaults for new requests: that creates
+        # intermediate totals such as kept=111 that pad to a larger graph
+        # bucket without using its available verifier capacity.
+        return scheduler_output
+    full_draft = sum(len(tokens) for tokens in original_spec.values())
+    num_spec_requests = len(original_spec)
+    new_spec = original_spec.copy()
+    new_num_scheduled = scheduler_output.num_scheduled_tokens.copy()
+
+    target_draft_lens = _dcut_get_target_draft_lens(ctrl, original_spec)
+
+    trimmed_tokens = 0
+    for (req_id, draft_tokens), target_len in zip(
+        list(new_spec.items()),
+        target_draft_lens,
+    ):
+        max_draft_len = len(draft_tokens)
+        if target_len >= max_draft_len:
+            continue
+
+        trimmed_tokens += max_draft_len - target_len
+        new_num_scheduled[req_id] -= max_draft_len - target_len
+        # Keep zero-length decisions as empty speculative entries. The model
+        # runner represents a speculative request with no draft tokens as
+        # num_decode_draft_tokens == 0 (ordinary decode/prefill uses -1).
+        # Dropping the key would therefore turn a pure-spec batch into a mixed
+        # spec/non-spec batch, making GDN take its prefill fallback and miss the
+        # local PIECEWISE graph. Retaining the key keeps the one anchor token
+        # on the speculative path without adding verifier tokens.
+        new_spec[req_id] = draft_tokens[:target_len]
+
+    _dcut_record_trim(
+        self,
+        full_draft,
+        trimmed_tokens,
+        num_spec_requests,
+    )
+    if trimmed_tokens == 0:
+        return scheduler_output
+
+    return replace(
+        scheduler_output,
+        scheduled_spec_decode_tokens=new_spec,
+        num_scheduled_tokens=new_num_scheduled,
+        total_num_scheduled_tokens=(scheduler_output.total_num_scheduled_tokens - trimmed_tokens),
+    )
+
+
+def _dcut_record_trim(self, full_draft: int, trimmed: int, n_spec_reqs: int) -> None:
+    """Accumulate verify-reduction stats and log them every N steps (rank 0).
+
+    Answers "how much verify did D-Cut save": trimmed vs full draft positions
+    (the verifier checks one position per draft token).  Cadence is controlled
+    by ``VLLM_DCUT_STAT_EVERY`` (steps; 0 disables).  Cumulative totals, so the
+    running percentage is stable.
+    """
+    self._dcut_stat_full += full_draft
+    self._dcut_stat_trimmed += trimmed
+    self._dcut_stat_reqs += n_spec_reqs
+    self._dcut_stat_steps += 1
+    every = self._dcut_stat_log_every
+    if not every or (self._dcut_stat_steps % every) != 0:
+        return
+    if get_tp_group().rank_in_group != 0 or not get_pp_group().is_first_rank:
+        return
+    full = self._dcut_stat_full
+    trimmed_tot = self._dcut_stat_trimmed
+    pct = 100.0 * trimmed_tot / full if full else 0.0
+    kept = full - trimmed_tot
+    reqs = max(self._dcut_stat_reqs, 1)
+    _dcut_dump_trim_stats(
+        self,
+        full=full,
+        trimmed_tot=trimmed_tot,
+        kept=kept,
+        pct=pct,
+        reqs=reqs,
+        last_full=full_draft,
+        last_trimmed=trimmed,
+        last_reqs=n_spec_reqs,
+    )
+    logger.info(
+        "D-Cut verify trim: cut %d/%d draft positions (%.1f%% fewer verifies) "
+        "over %d steps; avg %.2f->%.2f verified tok/spec-req",
+        trimmed_tot,
+        full,
+        pct,
+        self._dcut_stat_steps,
+        full / reqs,
+        kept / reqs,
+    )
+
+
+def _dcut_dump_trim_stats(
+    self,
+    *,
+    full: int,
+    trimmed_tot: int,
+    kept: int,
+    pct: float,
+    reqs: int,
+    last_full: int,
+    last_trimmed: int,
+    last_reqs: int,
+) -> None:
+    """Append rank-0 trim stats to JSONL for scripts that cannot see worker logs."""
+    path = getattr(self, "_dcut_trim_stats_out", None)
+    if not path:
+        return
+    row = {
+        "time_unix": time.time(),
+        "steps": self._dcut_stat_steps,
+        "spec_reqs": self._dcut_stat_reqs,
+        "full_draft_positions": full,
+        "trimmed_draft_positions": trimmed_tot,
+        "kept_draft_positions": kept,
+        "trim_pct": pct,
+        "avg_full_per_spec_req": full / reqs,
+        "avg_kept_per_spec_req": kept / reqs,
+        "last_full_draft_positions": last_full,
+        "last_trimmed_draft_positions": last_trimmed,
+        "last_spec_reqs": last_reqs,
+    }
+    try:
+        dirname = os.path.dirname(path)
+        if dirname:
+            os.makedirs(dirname, exist_ok=True)
+        with open(path, "a", encoding="utf-8") as f:
+            f.write(json.dumps(row, ensure_ascii=False) + "\n")
+    except Exception as e:  # pragma: no cover - observability must not affect serving
+        logger.debug("D-Cut: failed to write trim stats: %s", e)

--- a/dcut/utils.py
+++ b/dcut/utils.py
@@ -1,0 +1,343 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Small utility functions."""
+from __future__ import annotations
+
+import os
+
+import torch
+
+from vllm.distributed import get_tp_group
+
+from .globals import (
+    ENV_CONFIG,
+    ENV_DISABLE,
+    ENV_PROCESS_PROBS_STAGE,
+    ENV_REUSE_ARGMAX,
+)
+
+
+def _env_flag(name: str, default: bool = False) -> bool:
+    raw = os.environ.get(name)
+    if raw is None:
+        return default
+    return raw.strip().lower() in {"1", "true", "yes", "y", "on"}
+
+
+def _dcut_process_probs_stage() -> str:
+    raw = (
+        os.environ.get(ENV_PROCESS_PROBS_STAGE, "pre_truncate")
+        or "pre_truncate"
+    ).strip().lower()
+    stage = raw.replace("-", "_")
+    if stage in {"post", "post_sample", "sync", "synchronous"}:
+        return "post_sample"
+    return "pre_truncate"
+
+
+def _dcut_reuse_argmax_enabled() -> bool:
+    return _env_flag(ENV_REUSE_ARGMAX, True)
+
+
+def _dcut_in_graph_capture() -> bool:
+    """Return whether the current Ascend forward is recording an ACLGraph."""
+    try:
+        from vllm.forward_context import get_forward_context
+
+        forward_context = get_forward_context()
+        if bool(getattr(forward_context, "capturing", False)):
+            return True
+    except Exception:
+        pass
+
+    try:
+        from vllm_ascend.ascend_forward_context import _EXTRA_CTX
+
+        return bool(getattr(_EXTRA_CTX, "capturing", False))
+    except Exception:
+        return False
+
+
+def _dcut_graph_capture_mode_name() -> str | None:
+    """Return the active graph mode without depending on enum identity."""
+    try:
+        from vllm.forward_context import get_forward_context
+
+        mode = getattr(get_forward_context(), "cudagraph_runtime_mode", None)
+        mode_name = getattr(mode, "name", None)
+        if mode_name is not None:
+            return str(mode_name)
+        return str(mode).rsplit(".", 1)[-1]
+    except Exception:
+        return None
+
+
+def _dcut_should_collect_draft_probs(drafter) -> bool:
+    """Keep probability ops in every D-Cut draft graph capture.
+
+    Native prefill/eager batches deliberately disable ``needs_draft_probs``.
+    A lazy FULL graph capture can therefore observe the flag as false and
+    permanently omit the probability branch from that graph. Force the branch
+    only while an enabled D-Cut process is recording an ACLGraph.
+    """
+    if _env_flag(ENV_DISABLE):
+        return False
+
+    supported = bool(
+        getattr(drafter, "parallel_drafting", False)
+        or getattr(drafter, "method", None) == "dflash"
+    )
+    if not supported:
+        return False
+    if getattr(drafter, "needs_draft_probs", False):
+        return True
+    return bool(
+        os.environ.get(ENV_CONFIG)
+        and _dcut_in_graph_capture()
+        and _dcut_graph_capture_mode_name() == "FULL"
+    )
+
+
+def _dcut_selected_token_probs(
+    logits: torch.Tensor,
+    token_ids: torch.Tensor,
+) -> torch.Tensor:
+    """Compute probabilities for token IDs already selected from *logits*.
+
+    This avoids repeating argmax over the full vocabulary. The caller only
+    uses this helper on paths where the original sampler selected IDs directly
+    from the same logits tensor, so their vocab indexing is identical.
+    """
+    idx = token_ids.long().unsqueeze(-1)
+    chosen = logits.gather(-1, idx).squeeze(-1)
+    return (chosen - logits.logsumexp(dim=-1)).exp()
+
+
+def _dcut_can_reuse_argmax_for_probs(drafter) -> bool:
+    return (
+        _dcut_reuse_argmax_enabled()
+        and getattr(drafter, "method", None) == "dflash"
+        and getattr(type(drafter), "_dcut_run_merged_patched", False)
+    )
+
+
+def _dcut_selected_probs_from_reused_logits(
+    drafter,
+    draft_token_ids: torch.Tensor | None,
+) -> torch.Tensor | None:
+    """Derive selected probabilities only for an unsharded matching vocab.
+
+    The normal path retains selected probabilities inside the draft graph.
+    Reused logits are a last-resort compatibility path and must fail closed.
+    """
+    if (
+        draft_token_ids is None
+        or not torch.is_tensor(draft_token_ids)
+        or not _dcut_can_reuse_argmax_for_probs(drafter)
+    ):
+        return None
+
+    model = getattr(drafter, "model", None)
+    if getattr(model, "draft_id_to_target_id", None) is not None:
+        # ``draft_token_ids`` have already been mapped to target-vocab IDs,
+        # while these logits are indexed by the reduced draft vocabulary.
+        return None
+    try:
+        tp_world_size = int(get_tp_group().world_size)
+    except Exception:
+        # Never guess whether a tensor is sharded in a correctness fallback.
+        return None
+    if tp_world_size != 1:
+        # The retained tensor may be one vocab shard; local logsumexp would not
+        # be the global softmax denominator and global IDs cannot index it.
+        return None
+
+    logits = getattr(drafter, "_dcut_last_logits_for_probs", None)
+    if logits is None:
+        # A Python execution should have populated the per-step logits. Only a
+        # graph replay is allowed to fall back to the fixed-address capture
+        # tensors retained below.
+        if getattr(drafter, "_dcut_last_draft_ran_python", False):
+            return None
+        if getattr(drafter, "_dcut_graph_logits_for_probs_ready", False):
+            descriptor = getattr(
+                drafter,
+                "_dcut_current_graph_descriptor",
+                None,
+            )
+            by_descriptor = getattr(
+                drafter,
+                "_dcut_graph_logits_for_probs_by_descriptor",
+                {},
+            )
+            if by_descriptor:
+                logits = (
+                    by_descriptor.get(descriptor)
+                    if descriptor is not None
+                    else None
+                )
+                if logits is None:
+                    return None
+            shape_key = tuple(draft_token_ids.shape)
+            by_shape = getattr(
+                drafter,
+                "_dcut_graph_logits_for_probs_by_shape",
+                {},
+            )
+            by_numel = getattr(
+                drafter,
+                "_dcut_graph_logits_for_probs_by_numel",
+                {},
+            )
+            if logits is None:
+                logits = by_shape.get(shape_key)
+            if logits is None:
+                logits = by_numel.get(int(draft_token_ids.numel()))
+    if logits is None:
+        return None
+
+    flat_token_ids = draft_token_ids.reshape(-1)
+    n_tokens = min(int(logits.shape[0]), int(flat_token_ids.numel()))
+    if n_tokens <= 0:
+        return None
+    selected_probs = _dcut_selected_token_probs(
+        logits[:n_tokens],
+        flat_token_ids[:n_tokens],
+    )
+    if selected_probs.numel() == draft_token_ids.numel():
+        selected_probs = selected_probs.view(draft_token_ids.shape)
+    return selected_probs.float().contiguous()
+
+
+def _dcut_selected_probs_from_graph(
+    drafter,
+    draft_token_ids: torch.Tensor | None,
+) -> torch.Tensor | None:
+    """Return the selected-prob tensor produced by the replayed draft graph.
+
+    The merged draft function is captured once per output bucket. Python
+    instance attributes are not reassigned during graph replay. Bind retained
+    selected probabilities to the same ``BatchDescriptor`` that selects the
+    ACLGraph entry; use address/shape compatibility keys only when no exact
+    descriptor table was captured.
+    """
+    if (
+        draft_token_ids is None
+        or not torch.is_tensor(draft_token_ids)
+        or getattr(drafter, "_dcut_last_draft_ran_python", False)
+        or not getattr(
+            drafter,
+            "_dcut_graph_selected_probs_ready",
+            False,
+        )
+    ):
+        return None
+
+    drafter._dcut_last_graph_prob_source = "missing"
+    descriptor = getattr(
+        drafter,
+        "_dcut_current_graph_descriptor",
+        None,
+    )
+    by_descriptor = getattr(
+        drafter,
+        "_dcut_graph_selected_probs_by_descriptor",
+        {},
+    )
+    selected_probs = None
+    if by_descriptor:
+        selected_probs = (
+            by_descriptor.get(descriptor)
+            if descriptor is not None
+            else None
+        )
+        if selected_probs is None:
+            return None
+        drafter._dcut_last_graph_prob_source = "graph_descriptor"
+
+    shape_key = tuple(draft_token_ids.shape)
+    by_output_ptr = getattr(
+        drafter,
+        "_dcut_graph_selected_probs_by_output_ptr",
+        {},
+    )
+    by_shape = getattr(
+        drafter,
+        "_dcut_graph_selected_probs_by_shape",
+        {},
+    )
+    by_numel = getattr(
+        drafter,
+        "_dcut_graph_selected_probs_by_numel",
+        {},
+    )
+    if selected_probs is None:
+        selected_probs = by_output_ptr.get(int(draft_token_ids.data_ptr()))
+        if selected_probs is not None:
+            drafter._dcut_last_graph_prob_source = "graph_output_ptr"
+    if selected_probs is None:
+        selected_probs = by_shape.get(shape_key)
+        if selected_probs is not None:
+            drafter._dcut_last_graph_prob_source = "graph_unique_shape"
+    if selected_probs is None:
+        selected_probs = by_numel.get(int(draft_token_ids.numel()))
+        if selected_probs is not None:
+            drafter._dcut_last_graph_prob_source = "graph_unique_numel"
+    if selected_probs is None:
+        return None
+
+    flat_probs = selected_probs.reshape(-1)
+    num_tokens = int(draft_token_ids.numel())
+    if num_tokens <= 0 or flat_probs.numel() < num_tokens:
+        return None
+    return flat_probs[:num_tokens].view(draft_token_ids.shape)
+
+
+def _npu_event(enable_timing: bool = False):
+    """torch.npu.Event, mirroring torch.cuda.Event on the CUDA plugin."""
+    return torch.npu.Event(enable_timing=enable_timing)
+
+
+def _supports_adaptive_verify(spec_cfg) -> bool:
+    """Mirror of SpeculativeConfig.supports_adaptive_verify (which 0.22.x lacks)."""
+    if spec_cfg is None:
+        return False
+    method = getattr(spec_cfg, "method", None)
+    parallel = getattr(spec_cfg, "parallel_drafting", False)
+    return method == "dflash" or (method == "draft_model" and parallel)
+
+
+def _dcut_greedy_sample_with_selected_probs(logits):
+    tp_group = get_tp_group()
+    _, v_local = logits.shape
+    rank = tp_group.rank_in_group
+
+    local_max_logits, local_max_indices = logits.max(dim=-1)
+    local_global_idx = local_max_indices + rank * v_local
+    local_lse = logits.logsumexp(dim=-1)
+
+    # The stock DFlash greedy sampler already gathers each rank's local max.
+    # Piggyback the local logsumexp on that collective instead of issuing a
+    # third TP all-gather solely for selected-token probabilities. The payload
+    # grows by one scalar per token, while the latency-sensitive collective
+    # count remains identical to the stock two-gather path.
+    local_stats = torch.stack((local_max_logits, local_lse), dim=-1)
+    gathered_stats = tp_group.all_gather(local_stats, dim=-1)
+    gathered_stats = gathered_stats.reshape(
+        *local_max_logits.shape,
+        tp_group.world_size,
+        2,
+    )
+    gathered_logits = gathered_stats[..., 0]
+    gathered_lse = gathered_stats[..., 1]
+    gathered_global_idx = tp_group.all_gather(local_global_idx.unsqueeze(-1), dim=-1)
+    global_max_rank = gathered_logits.argmax(dim=-1)
+    next_token = gathered_global_idx.gather(
+        dim=-1, index=global_max_rank.unsqueeze(-1)
+    ).squeeze(-1)
+    selected_logits = gathered_logits.gather(
+        dim=-1, index=global_max_rank.unsqueeze(-1)
+    ).squeeze(-1)
+
+    global_lse = gathered_lse.logsumexp(dim=-1)
+    selected_probs = (selected_logits - global_lse).exp()
+    return next_token, selected_probs

--- a/dcut/verify_adaptive_config.json
+++ b/dcut/verify_adaptive_config.json
@@ -1,0 +1,19 @@
+{
+  "enabled": true,
+  "warmup_batch_sizes": [
+    2,
+    4,
+    8,
+    16,
+    32
+  ],
+  "min_warmup_batch_size": 2,
+  "max_warmup_batch_size": 32,
+  "min_query_len_per_req": 2,
+  "max_query_len_per_req": null,
+  "query_len_step_per_req": 2,
+  "warmup_seq_lens": 4096,
+  "n_warmup_iters": 3,
+  "n_measure_iters": 5,
+  "cost_table_dump_path": null
+}

--- a/dcut/verify_adaptive_config.py
+++ b/dcut/verify_adaptive_config.py
@@ -1,0 +1,105 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field, fields
+from typing import Optional
+
+
+# Optional schema-v2 cost table applied after normal profiling. Unset keeps the
+# measured table unchanged. This path is non-sensitive and read only at startup.
+ENV_COST_TABLE_OVERRIDE = "VLLM_DCUT_COST_TABLE_OVERRIDE"
+
+
+@dataclass
+class VerifyAdaptiveConfig:
+    """Config for the verifier adaptive step-length controller.
+
+    ``query_len = 1 (anchor) + draft_len``.
+
+    Load from a JSON path passed as ``--speculative-adaptive-verify-config``
+    (or the ``speculative_adaptive_verify_config`` key in
+    ``--speculative-config``), via :meth:`from_json` / :meth:`from_dict`.
+    Unknown keys are silently ignored.  See ``verify_adaptive.md`` and
+    ``verify_adaptive_config.example.json``.
+    """
+
+    # batch-size axis
+    warmup_batch_sizes: list[int] = field(default_factory=list)
+    """Explicit levels.  Empty → step-2 range from *min_warmup_batch_size*."""
+
+    min_warmup_batch_size: int = 2
+    """Start of the auto-generated batch-size range."""
+
+    max_warmup_batch_size: Optional[int] = None
+    """Cap for auto-generated levels.  None → engine max_num_seqs."""
+
+    # query-length axis
+    query_len_step_per_req: int = 2
+    """Step between query-len levels.  Baseline 1 is always prepended."""
+
+    max_query_len_per_req: Optional[int] = None
+    """None → num_speculative_tokens + 1."""
+
+    min_query_len_per_req: int = 2
+    """Start of the step-range (must be ≥ 2)."""
+
+    # measurement
+    warmup_seq_lens: int = 4096
+    """Simulated KV-context length (seq_lens) used during cost profiling.
+    A larger value makes attention cost closer to real long-context inference.
+    Defaults to 4096 for multimodal / long-context DFlash runs."""
+
+    n_warmup_iters: int = 3
+    n_measure_iters: int = 5
+
+    cost_table_dump_path: Optional[str] = None
+    """Optional JSON path for exporting the profiled verifier cost table.
+    The environment variable ``VLLM_DCUT_COST_TABLE_OUT`` overrides this."""
+
+    enabled: bool = True
+
+    @classmethod
+    def from_json(cls, path: str) -> "VerifyAdaptiveConfig":
+        with open(path) as f:
+            return cls.from_dict(json.load(f))
+
+    @classmethod
+    def from_dict(cls, d: dict) -> "VerifyAdaptiveConfig":
+        known = {f.name for f in fields(cls)}
+        return cls(**{k: v for k, v in d.items() if k in known})
+
+    def validate(self, num_speculative_tokens: int) -> None:
+        eff_max_q = (
+            self.max_query_len_per_req
+            if self.max_query_len_per_req is not None
+            else num_speculative_tokens + 1
+        )
+        if self.min_query_len_per_req < 2:
+            raise ValueError(
+                "min_query_len_per_req must be >= 2 "
+                "(baseline query_len=1 is added automatically)."
+            )
+        if self.query_len_step_per_req < 1:
+            raise ValueError("query_len_step_per_req must be >= 1.")
+        if self.min_query_len_per_req > eff_max_q:
+            raise ValueError(
+                f"min_query_len_per_req ({self.min_query_len_per_req}) > "
+                f"effective max_query_len_per_req ({eff_max_q})."
+            )
+        if self.warmup_seq_lens < 1:
+            raise ValueError("warmup_seq_lens must be >= 1.")
+        if self.n_warmup_iters < 0:
+            raise ValueError("n_warmup_iters must be >= 0.")
+        if self.n_measure_iters < 1:
+            raise ValueError("n_measure_iters must be >= 1.")
+        if self.warmup_batch_sizes and any(
+            bs < 1 for bs in self.warmup_batch_sizes
+        ):
+            raise ValueError("All warmup_batch_sizes entries must be >= 1.")
+        if self.min_warmup_batch_size < 1:
+            raise ValueError("min_warmup_batch_size must be >= 1.")
+        if self.max_warmup_batch_size is not None and self.max_warmup_batch_size < 1:
+            raise ValueError("max_warmup_batch_size must be >= 1.")

--- a/dcut/verify_adaptive_controller.py
+++ b/dcut/verify_adaptive_controller.py
@@ -1,0 +1,789 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from __future__ import annotations
+
+import bisect
+import json
+import math
+import os
+from collections.abc import Callable
+from typing import Any
+
+import numpy as np
+import torch
+
+from vllm.distributed import get_pp_group, get_tp_group
+from vllm.logger import init_logger
+from .verify_adaptive_config import (
+    ENV_COST_TABLE_OVERRIDE,
+    VerifyAdaptiveConfig,
+)
+
+logger = init_logger(__name__)
+
+
+def _parse_cost_table_override(
+    payload: Any,
+    *,
+    num_spec_tokens: int,
+    max_batch_size: int,
+    batch_size_levels: list[int],
+    query_len_levels: list[int],
+) -> tuple[
+    dict[tuple[int, int], float],
+    dict[tuple[int, int], float],
+]:
+    """Validate and decode an exported schema-v2 cost table."""
+    if not isinstance(payload, dict):
+        raise ValueError("cost table override must be a JSON object")
+    if payload.get("schema_version") != 2:
+        raise ValueError("cost table override schema_version must be 2")
+    if payload.get("num_spec_tokens") != num_spec_tokens:
+        raise ValueError(
+            "cost table override num_spec_tokens mismatch: "
+            f"file={payload.get('num_spec_tokens')} runtime={num_spec_tokens}"
+        )
+    if payload.get("max_batch_size") != max_batch_size:
+        raise ValueError(
+            "cost table override max_batch_size mismatch: "
+            f"file={payload.get('max_batch_size')} runtime={max_batch_size}"
+        )
+    if payload.get("batch_size_levels") != batch_size_levels:
+        raise ValueError(
+            "cost table override batch_size_levels do not match runtime config"
+        )
+    if payload.get("query_len_levels") != query_len_levels:
+        raise ValueError(
+            "cost table override query_len_levels do not match runtime config"
+        )
+
+    rows = payload.get("cost_table")
+    if not isinstance(rows, list) or not rows:
+        raise ValueError("cost table override must contain at least one row")
+
+    valid_bs = set(batch_size_levels)
+    valid_ql = set(query_len_levels)
+    target_table: dict[tuple[int, int], float] = {}
+    draft_table: dict[tuple[int, int], float] = {}
+    for index, row in enumerate(rows):
+        if not isinstance(row, dict):
+            raise ValueError(f"cost table override row {index} must be an object")
+        bs = row.get("batch_size")
+        sum_query_len = row.get("sum_query_len")
+        if (
+            not isinstance(bs, int)
+            or isinstance(bs, bool)
+            or not isinstance(sum_query_len, int)
+            or isinstance(sum_query_len, bool)
+            or bs not in valid_bs
+            or sum_query_len <= 0
+            or sum_query_len % bs != 0
+            or sum_query_len // bs not in valid_ql
+        ):
+            raise ValueError(
+                f"cost table override row {index} has an invalid batch/query shape"
+            )
+
+        query_len_per_req = row.get("query_len_per_req")
+        if (
+            query_len_per_req is not None
+            and query_len_per_req != sum_query_len // bs
+        ):
+            raise ValueError(
+                f"cost table override row {index} has inconsistent "
+                "query_len_per_req"
+            )
+        try:
+            target_cost = float(row["target_cost_s"])
+            draft_cost = float(row["draft_cost_s"])
+        except (KeyError, TypeError, ValueError) as exc:
+            raise ValueError(
+                f"cost table override row {index} has invalid component costs"
+            ) from exc
+        if (
+            not math.isfinite(target_cost)
+            or target_cost <= 0.0
+            or not math.isfinite(draft_cost)
+            or draft_cost < 0.0
+        ):
+            raise ValueError(
+                f"cost table override row {index} has invalid component costs"
+            )
+
+        total_cost = row.get("cost_s")
+        if total_cost is not None:
+            try:
+                total_cost = float(total_cost)
+            except (TypeError, ValueError) as exc:
+                raise ValueError(
+                    f"cost table override row {index} has an invalid total cost"
+                ) from exc
+            if not math.isclose(
+                total_cost,
+                target_cost + draft_cost,
+                rel_tol=1e-6,
+                abs_tol=1e-9,
+            ):
+                raise ValueError(
+                    f"cost table override row {index} total does not match "
+                    "its components"
+                )
+
+        key = (bs, sum_query_len)
+        if key in target_table:
+            raise ValueError(f"cost table override contains duplicate shape {key}")
+        target_table[key] = target_cost
+        draft_table[key] = draft_cost
+
+    return target_table, draft_table
+
+
+# ---------------------------------------------------------------------------
+# Core algorithm — pure function, stateless, unit-testable independently.
+# ---------------------------------------------------------------------------
+
+def choose_query_lens_discrete(
+    probs: "list[list[float]] | np.ndarray",
+    base_batch_size: int,
+    q_levels: list[int],
+    cost_lookup: Callable[[int], float],
+    max_draft_len: int,
+    collect_records: bool = False,
+    draft_cost_lookup: Callable[[int], float] | None = None,
+) -> dict[str, Any]:
+    """Discrete marginal-gain scan over the *measured* sum_query_len levels.
+
+    Since verifier cost depends only on ``(batch_size, sum_query_len)``, the
+    candidate Q values are exactly the profiled sum_query_len levels for the
+    fixed batch size (e.g. ``bs*2, bs*4, …``).  For each level Q we greedily
+    fill the ``S = Q - base_batch_size`` highest marginal gains and divide the
+    expected progress by ``target_cost(Q) + draft_cost(Q)``, keeping the best
+    end-to-end Q.
+
+    Args:
+        probs: per-active-sequence accept probs; ``probs[i][t]`` is the
+            predicted accept prob of draft position ``t`` for sequence ``i``.
+        base_batch_size: full verifier batch size B.  Every sequence always
+            contributes one anchor token, so ``sum_query_len = B + S``.
+        q_levels: candidate sum_query_len values; must be real cost-table keys.
+        cost_lookup: ``Q -> verifier ITL cost`` (batch size already fixed).
+        max_draft_len: max draft tokens per sequence (``max_query_len - 1``).
+        collect_records: if True, also return per-level debug records.
+    """
+    A = len(probs)
+
+    # Marginal gains m[i,t] = prod_{k<=t} p[i,k], vectorised over the batch.
+    mat = np.asarray(probs, dtype=np.float64).reshape(A, -1)[:, :max_draft_len]
+    gains = np.cumprod(mat, axis=1)
+
+    seq_ids = np.repeat(np.arange(A), gains.shape[1])
+    flat_gains = gains.ravel()
+    order = np.argsort(-flat_gains, kind="stable")
+    sorted_seq = seq_ids[order]
+    # prefix_gain[S] = sum of the top-S marginal gains.
+    prefix_gain = np.concatenate(([0.0], np.cumsum(flat_gains[order])))
+    total_available = flat_gains.shape[0]
+
+    best_score = -math.inf
+    best_Q, best_S = base_batch_size, 0
+    records: list[dict[str, Any]] | None = [] if collect_records else None
+
+    for Q in q_levels:
+        S = Q - base_batch_size
+        if S < 0:
+            continue
+        S = min(S, total_available)
+        target_cost = cost_lookup(Q)
+        draft_cost = (
+            draft_cost_lookup(Q)
+            if draft_cost_lookup is not None
+            else 0.0
+        )
+        cost = target_cost + draft_cost
+        if target_cost <= 0.0 or draft_cost < 0.0 or cost <= 0.0:
+            continue
+        score = (base_batch_size + prefix_gain[S]) / cost
+        if records is not None:
+            records.append({
+                "Q": Q,
+                "S": int(S),
+                "score": score,
+                "cost": cost,
+                "target_cost": target_cost,
+                "draft_cost": draft_cost,
+            })
+        if score > best_score:
+            best_score, best_Q, best_S = score, Q, S
+
+    # Reconstruct per-sequence draft lengths from the top-best_S marginals.
+    draft_lens = np.bincount(sorted_seq[:best_S], minlength=A).tolist()
+
+    return {
+        "draft_lens": draft_lens,
+        "best_Q": best_Q,
+        "best_S": int(best_S),
+        "best_score": best_score,
+        "records": records,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Controller
+# ---------------------------------------------------------------------------
+
+class VerifyAdaptiveController:
+    """Per-request draft-length selector for the verifier step.
+
+    Call order: ``__init__`` → ``profile_cost_table`` (once, after CUDA
+    graph capture / JIT warmup) → ``process_draft_output`` (each step) →
+    ``get_adaptive_draft_len`` (inside ``_prepare_inputs``).
+    Call ``invalidate`` on request completion.
+    """
+
+    def __init__(
+        self,
+        config: VerifyAdaptiveConfig,
+        num_spec_tokens: int,
+        max_batch_size: int,
+        device: torch.device,
+    ) -> None:
+        config.validate(num_spec_tokens)
+
+        self.config = config
+        self.num_spec_tokens = num_spec_tokens
+        self.max_batch_size = max_batch_size
+        self.device = device
+        self.max_query_len_per_req: int = (
+            config.max_query_len_per_req
+            if config.max_query_len_per_req is not None
+            else num_spec_tokens + 1
+        )
+
+        self._batch_size_levels: list[int] = self._build_batch_size_levels()
+        self._query_len_levels: list[int] = self._build_query_len_levels()
+
+        # (batch_size, sum_query_len) → ITL in seconds
+        self._cost_table: dict[tuple[int, int], float] = {}
+        # DFlash full proposer cost. Although its draft query shape is fixed by
+        # (B, K), context-KV preparation still consumes Q target hidden states.
+        self._draft_cost_table: dict[tuple[int, int], float] = {}
+        self._cost_records: list[dict[str, Any]] = []
+        self._sorted_bs: list[int] = []
+        self._sorted_sql_per_bs: dict[int, list[int]] = {}
+
+        # req_id → recommended draft_len for the next verifier step
+        self._adaptive_draft_lens: dict[str, int] = {}
+        self._adaptive_decision_req_ids: frozenset[str] = frozenset()
+        self._adaptive_decision_batch_size = 0
+        self._decision_step = 0
+
+        if get_tp_group().rank_in_group == 0 and get_pp_group().is_first_rank:
+            logger.info(
+                "VerifyAdaptiveController: bs_levels=%s  ql_levels=%s",
+                self._batch_size_levels,
+                self._query_len_levels,
+            )
+
+    def _build_batch_size_levels(self) -> list[int]:
+        """Step-2 range from min_warmup_batch_size to cap."""
+        if self.config.warmup_batch_sizes:
+            return sorted(set(self.config.warmup_batch_sizes))
+        cap = (
+            self.config.max_warmup_batch_size
+            if self.config.max_warmup_batch_size is not None
+            else self.max_batch_size
+        )
+        start = self.config.min_warmup_batch_size
+        levels = list(range(start, cap + 1, 2))
+        if not levels or levels[-1] < cap:
+            levels.append(cap)
+        return levels
+
+    def _build_query_len_levels(self) -> list[int]:
+        """``{min_q, min_q+step, …, max_q}`` with max_q forced in."""
+        min_q = self.config.min_query_len_per_req
+        max_q = self.max_query_len_per_req
+        step = self.config.query_len_step_per_req
+
+        levels = list(range(min_q, max_q + 1, step))
+        if not levels or levels[-1] < max_q:
+            levels.append(max_q)
+        return sorted(set(levels))
+
+    def profile_cost_table(self, runner: Any) -> None:
+        """Measure target and full DFlash proposer cost at every (B, Q).
+
+        The two component tables are retained separately and summed only by
+        the decision objective, so profiling output remains diagnosable.
+        """
+        if not self.config.enabled:
+            return
+
+        # Random cut mode: skip profiling
+        if os.getenv("VLLM_DCUT_RANDOM_CUT"):
+            logger.info("VerifyAdaptiveController: random cut mode enabled, skipping profiling")
+            return
+
+        if get_tp_group().rank_in_group == 0 and get_pp_group().is_first_rank:
+            logger.info(
+                "VerifyAdaptiveController: profiling %d ITL cost points "
+                "(%d bs × %d ql).",
+                len(self._batch_size_levels) * len(self._query_len_levels),
+                len(self._batch_size_levels),
+                len(self._query_len_levels),
+            )
+
+        max_tokens = getattr(runner, "max_num_tokens", None)
+
+        for bs in self._batch_size_levels:
+            self._sorted_sql_per_bs[bs] = []
+
+            for ql in self._query_len_levels:
+                num_tokens = bs * ql
+                if max_tokens is not None and num_tokens > max_tokens:
+                    logger.info(
+                        "profile skip: bs=%d ql=%d num_tokens=%d > %d",
+                        bs, ql, num_tokens, max_tokens,
+                    )
+                    continue
+
+                sched_tokens = [ql] * bs
+                logger.info('D-Cut profile: starting bs=%d ql=%d num_tokens=%d', bs, ql, num_tokens)
+
+                runtime_mode, avg_ms, padded_tokens = runner._adaptive_profile_run(
+                    sched_tokens,
+                    self.config.warmup_seq_lens,
+                    self.config.n_warmup_iters,
+                    self.config.n_measure_iters,
+                )
+                elapsed_s = avg_ms / 1e3
+
+                (
+                    draft_runtime_mode,
+                    draft_avg_ms,
+                    draft_padded_tokens,
+                ) = runner._adaptive_profile_draft_run(
+                    batch_size=bs,
+                    context_tokens=num_tokens,
+                    n_warmup=self.config.n_warmup_iters,
+                    n_measure=self.config.n_measure_iters,
+                )
+                draft_elapsed_s = draft_avg_ms / 1e3
+
+                self._cost_table[(bs, num_tokens)] = elapsed_s
+                self._draft_cost_table[(bs, num_tokens)] = draft_elapsed_s
+                self._cost_records.append({
+                    "batch_size": bs,
+                    "query_len_per_req": ql,
+                    "sum_query_len": num_tokens,
+                    "padded_tokens": padded_tokens,
+                    "seq_lens": self.config.warmup_seq_lens,
+                    "runtime_mode": runtime_mode,
+                    "avg_ms": avg_ms + draft_avg_ms,
+                    "cost_s": elapsed_s + draft_elapsed_s,
+                    "target_avg_ms": avg_ms,
+                    "target_cost_s": elapsed_s,
+                    "draft_runtime_mode": draft_runtime_mode,
+                    "draft_padded_tokens": draft_padded_tokens,
+                    "draft_avg_ms": draft_avg_ms,
+                    "draft_cost_s": draft_elapsed_s,
+                    "total_avg_ms": avg_ms + draft_avg_ms,
+                    "total_cost_s": elapsed_s + draft_elapsed_s,
+                })
+                self._sorted_sql_per_bs[bs].append(num_tokens)
+                if (
+                    get_tp_group().rank_in_group == 0
+                    and get_pp_group().is_first_rank
+                ):
+                    logger.info(
+                        "profile  bs=%-4d  ql=%-4d  sql=%-6d  padded=%-6d  "
+                        "seq_lens=%-6d  target=%-6s %.3f ms  "
+                        "draft=%-6s %.3f ms  total=%.3f ms",
+                        bs, ql, num_tokens, padded_tokens,
+                        self.config.warmup_seq_lens,
+                        runtime_mode,
+                        avg_ms,
+                        draft_runtime_mode,
+                        draft_avg_ms,
+                        avg_ms + draft_avg_ms,
+                    )
+
+        override_path = os.getenv(ENV_COST_TABLE_OVERRIDE)
+        if override_path:
+            # Read and validate before dumping so source==destination cannot
+            # change the values that will be used by this process.
+            with open(override_path, encoding="utf-8") as f:
+                override_payload = json.load(f)
+            override_target, override_draft = _parse_cost_table_override(
+                override_payload,
+                num_spec_tokens=self.num_spec_tokens,
+                max_batch_size=self.max_batch_size,
+                batch_size_levels=self._batch_size_levels,
+                query_len_levels=self._query_len_levels,
+            )
+
+            # VLLM_DCUT_COST_TABLE_OUT remains the table measured by this run.
+            # Only the in-memory decision table is replaced afterwards.
+            self._dump_cost_table_if_requested()
+            self._cost_table = override_target
+            self._draft_cost_table = override_draft
+
+        # TP correctness: GPU timings differ slightly per rank, which can
+        # flip the argmax and cause divergent draft_lens -> NCCL deadlock.
+        # Broadcast rank-0's table so all ranks decide identically.
+        tp_group = get_tp_group()
+        if tp_group.world_size > 1:
+            self._cost_table = tp_group.broadcast_object(self._cost_table, src=0)
+            self._draft_cost_table = tp_group.broadcast_object(
+                self._draft_cost_table,
+                src=0,
+            )
+
+        self._refresh_cost_indices()
+
+        if get_tp_group().rank_in_group == 0 and get_pp_group().is_first_rank:
+            if override_path:
+                logger.warning(
+                    "VerifyAdaptiveController: replaced the profiled cost "
+                    "table with %d entries from %s via %s.",
+                    len(self._cost_table),
+                    override_path,
+                    ENV_COST_TABLE_OVERRIDE,
+                )
+            logger.info(
+                "VerifyAdaptiveController: cost table ready (%d entries).",
+                len(self._cost_table),
+            )
+            self._log_cost_table()
+        if not override_path:
+            self._dump_cost_table_if_requested()
+
+    def _refresh_cost_indices(self) -> None:
+        """Rebuild lookup axes from the active profiled or overridden table."""
+        self._sorted_sql_per_bs = {
+            bs: [] for bs in self._batch_size_levels
+        }
+        for bs, sum_query_len in self._cost_table:
+            self._sorted_sql_per_bs[bs].append(sum_query_len)
+
+        # Keep only buckets with at least one available query length. An empty
+        # table leaves the controller dormant instead of returning zero drafts.
+        self._sorted_bs = [
+            bs
+            for bs in sorted(self._sorted_sql_per_bs)
+            if self._sorted_sql_per_bs[bs]
+        ]
+        for bs in self._sorted_bs:
+            self._sorted_sql_per_bs[bs].sort()
+
+    def process_draft_output(
+        self,
+        selected_probs: torch.Tensor,  # [B, T] on CPU (pinned), already transferred
+        req_ids: list[str],
+        active_draft_req_ids: set[str],
+        batch_size: int,
+    ) -> None:
+        """Compute and cache adaptive draft_lens from this step's drafter probs."""
+        if not self.config.enabled or not active_draft_req_ids:
+            self.clear_adaptive_decision()
+            return
+
+        # A decision is valid only as one coherent request-set snapshot. Clear
+        # the previous one before any mode or cost-table lookup so an early
+        # return can never reuse stale per-request caps.
+        self.clear_adaptive_decision()
+
+        # Random cut mode: assign random draft_lens (must be BEFORE _sorted_bs
+        # check because random cut skips profiling -> _sorted_bs is empty)
+        if os.getenv("VLLM_DCUT_RANDOM_CUT"):
+            max_draft_len = self.max_query_len_per_req - 1
+            n_rows = min(selected_probs.shape[0], len(req_ids), batch_size)
+            active_req_ids = [req_ids[i] for i in range(n_rows) if req_ids[i] in active_draft_req_ids]
+            draft_lens = []
+            for req_id in active_req_ids:
+                draft_lens.append(
+                    int(np.random.randint(2, max_draft_len + 1))
+                )
+            self.set_adaptive_decision(
+                active_req_ids,
+                draft_lens,
+                batch_size,
+            )
+            _dbg = getattr(self, "_dcut_rand_dbg_cnt", 0)
+            if _dbg < 20:
+                self._dcut_rand_dbg_cnt = _dbg + 1
+                for rid in active_req_ids:
+                    pass  # DCUT_DBG disabled
+            # Periodic distribution statistics: track how many times each
+            # draft_len value is assigned, print every 200 steps.
+            _dist = getattr(self, "_dcut_rand_dist", None)
+            if _dist is None:
+                _dist = {}
+                self._dcut_rand_dist = _dist
+            for rid in active_req_ids:
+                _dl = int(self._adaptive_draft_lens[rid])
+                _dist[_dl] = _dist.get(_dl, 0) + 1
+            _step = getattr(self, "_dcut_rand_step_cnt", 0) + 1
+            self._dcut_rand_step_cnt = _step
+            if _step % 200 == 0:
+                _items = sorted(_dist.items())
+                _total = sum(_dist.values())
+                _parts = " ".join(f"{k}:{v}" for k, v in _items)
+                print(f"[DCUT_RAND_DIST] step={_step} total={_total} dist({_parts})", flush=True)
+            logger.debug(
+                "random_cut: assigned random draft_lens to %d active requests (max_draft_len=%d)",
+                len(active_req_ids), max_draft_len
+            )
+            return
+
+        n_rows = min(selected_probs.shape[0], len(req_ids), batch_size)
+        all_probs_np: np.ndarray = selected_probs[:n_rows].numpy()
+
+        active_indices: list[int] = [
+            i for i in range(n_rows) if req_ids[i] in active_draft_req_ids
+        ]
+        if not active_indices:
+            return
+        active_probs: np.ndarray = all_probs_np[active_indices]
+        active_req_ids: list[str] = [req_ids[i] for i in active_indices]
+
+        bs_key = _ceil_lookup(batch_size, self._sorted_bs)
+        q_levels = self._sorted_sql_per_bs.get(bs_key) or []
+        if not q_levels:
+            return
+
+        decision_dump_path = os.getenv("VLLM_DCUT_DECISION_STATS_OUT")
+        result = choose_query_lens_discrete(
+            probs=active_probs,
+            base_batch_size=batch_size,
+            q_levels=q_levels,
+            cost_lookup=lambda q: self._cost_table[(bs_key, q)],
+            max_draft_len=self.max_query_len_per_req - 1,
+            collect_records=bool(decision_dump_path),
+            draft_cost_lookup=lambda q: self._draft_cost_table[(bs_key, q)],
+        )
+
+        draft_lens = result["draft_lens"]
+        self.set_adaptive_decision(
+            active_req_ids,
+            draft_lens,
+            batch_size,
+        )
+
+        self._dump_decision_if_requested(
+            decision_dump_path,
+            batch_size=batch_size,
+            active_count=len(active_req_ids),
+            bs_key=bs_key,
+            result=result,
+            draft_lens=draft_lens,
+        )
+
+        logger.debug(
+            "adaptive: bs_key=%d best_Q=%d best_S=%d score=%.4f draft_lens=%s",
+            bs_key, result["best_Q"], result["best_S"],
+            result["best_score"], draft_lens,
+        )
+
+    def get_adaptive_draft_len(self, req_id: str) -> int | None:
+        """Cached draft_len for *req_id*, or None (→ use full spec tokens)."""
+        return self._adaptive_draft_lens.get(req_id)
+
+    def set_adaptive_decision(
+        self,
+        req_ids: list[str],
+        draft_lens: list[int],
+        batch_size: int,
+    ) -> None:
+        """Atomically replace the per-request caps and their source batch."""
+        if len(req_ids) != len(draft_lens):
+            raise ValueError(
+                "D-Cut decision length mismatch: "
+                f"req_ids={len(req_ids)} draft_lens={len(draft_lens)}"
+            )
+        self._adaptive_draft_lens = dict(zip(req_ids, draft_lens))
+        self._adaptive_decision_req_ids = frozenset(req_ids)
+        self._adaptive_decision_batch_size = int(batch_size)
+
+    def clear_adaptive_decision(self) -> None:
+        """Invalidate the complete cached decision snapshot."""
+        self._adaptive_draft_lens.clear()
+        self._adaptive_decision_req_ids = frozenset()
+        self._adaptive_decision_batch_size = 0
+
+    def matches_adaptive_request_set(self, req_ids) -> bool:
+        """Whether cached caps were optimized for exactly this spec batch."""
+        current_req_ids = frozenset(req_ids)
+        return (
+            len(current_req_ids) == self._adaptive_decision_batch_size
+            and current_req_ids == self._adaptive_decision_req_ids
+        )
+
+    def invalidate(self, req_id: str) -> None:
+        """Drop cached state for a completed or evicted request."""
+        self._adaptive_draft_lens.pop(req_id, None)
+
+    def _dump_decision_if_requested(
+        self,
+        dump_path: str | None,
+        *,
+        batch_size: int,
+        active_count: int,
+        bs_key: int,
+        result: dict[str, Any],
+        draft_lens: list[int],
+    ) -> None:
+        if not dump_path:
+            return
+        if get_tp_group().rank_in_group != 0 or not get_pp_group().is_first_rank:
+            return
+
+        self._decision_step += 1
+        controller_cap_draft_len = self.max_query_len_per_req - 1
+        draft_sum = int(sum(draft_lens))
+        cap_sum = int(active_count * controller_cap_draft_len)
+        best_Q = int(result["best_Q"])
+        records = result.get("records") or []
+        scores = []
+        for record in records:
+            Q = int(record["Q"])
+            scores.append({
+                "Q": Q,
+                "query_len_per_req": (
+                    Q // bs_key if bs_key > 0 and Q % bs_key == 0 else None
+                ),
+                "S": int(record["S"]),
+                "score": float(record["score"]),
+                "cost_ms": float(record["cost"]) * 1e3,
+                "target_cost_ms": float(record["target_cost"]) * 1e3,
+                "draft_cost_ms": float(record["draft_cost"]) * 1e3,
+            })
+
+        payload = {
+            "step": self._decision_step,
+            "batch_size": int(batch_size),
+            "active_count": int(active_count),
+            "bs_key": int(bs_key),
+            "best_Q": best_Q,
+            "best_query_len_per_req": (
+                best_Q // bs_key if bs_key > 0 and best_Q % bs_key == 0 else None
+            ),
+            "best_S": int(result["best_S"]),
+            "best_score": float(result["best_score"]),
+            "controller_cap_draft_len": int(controller_cap_draft_len),
+            "draft_len_sum": draft_sum,
+            "controller_cap_draft_len_sum": cap_sum,
+            "trimmed_vs_controller_cap": cap_sum - draft_sum,
+            "avg_draft_len": draft_sum / active_count if active_count else 0.0,
+            "min_draft_len": int(min(draft_lens)) if draft_lens else 0,
+            "max_draft_len": int(max(draft_lens)) if draft_lens else 0,
+            "cap_like_reqs": int(sum(
+                d >= controller_cap_draft_len for d in draft_lens
+            )),
+            "scores": scores,
+        }
+
+        dirname = os.path.dirname(dump_path)
+        if dirname:
+            os.makedirs(dirname, exist_ok=True)
+        with open(dump_path, "a", encoding="utf-8") as f:
+            f.write(json.dumps(payload, sort_keys=True) + "\n")
+
+    def _log_cost_table(self) -> None:
+        """Log the full profiled cost table as a bs x query_len grid (ms).
+
+        Runs once after profiling on rank 0.  This is purely observability — the
+        per-point ``profile bs=...`` lines and the JSON dump already carry the
+        same numbers; this gives an at-a-glance view in the server log.
+        """
+        if not self._cost_table:
+            return
+        qls = list(self._query_len_levels)
+        bss = list(self._batch_size_levels)
+        logger.info(
+            "D-Cut total cost table (ms/target+draft, seq_lens=%d; rows=batch_size, cols=query_len/req):",
+            self.config.warmup_seq_lens,
+        )
+        header = "  bs\\ql |" + "".join(f"{q:>9d}" for q in qls)
+        logger.info("%s", header)
+        logger.info("  %s", "-" * (len(header) - 2))
+        for bs in bss:
+            cells = []
+            for ql in qls:
+                key = (bs, bs * ql)
+                target_cost_s = self._cost_table.get(key)
+                draft_cost_s = self._draft_cost_table.get(key)
+                cost_s = (
+                    target_cost_s + draft_cost_s
+                    if target_cost_s is not None
+                    and draft_cost_s is not None
+                    else None
+                )
+                cells.append(
+                    f"{cost_s * 1e3:>9.2f}" if cost_s is not None else f"{'-':>9}"
+                )
+            logger.info("  %5d |%s", bs, "".join(cells))
+
+    def _dump_cost_table_if_requested(self) -> None:
+        dump_path = (
+            os.getenv("VLLM_DCUT_COST_TABLE_OUT")
+            or self.config.cost_table_dump_path
+        )
+        if not dump_path:
+            return
+        if get_tp_group().rank_in_group != 0 or not get_pp_group().is_first_rank:
+            return
+
+        rows = []
+        for (bs, sum_query_len), target_cost_s in sorted(self._cost_table.items()):
+            draft_cost_s = self._draft_cost_table.get((bs, sum_query_len), 0.0)
+            cost_s = target_cost_s + draft_cost_s
+            rows.append({
+                "batch_size": bs,
+                "sum_query_len": sum_query_len,
+                "query_len_per_req": (
+                    sum_query_len // bs if bs > 0 and sum_query_len % bs == 0
+                    else None
+                ),
+                "cost_s": cost_s,
+                "cost_ms": cost_s * 1e3,
+                "target_cost_s": target_cost_s,
+                "target_cost_ms": target_cost_s * 1e3,
+                "draft_cost_s": draft_cost_s,
+                "draft_cost_ms": draft_cost_s * 1e3,
+            })
+
+        payload = {
+            "schema_version": 2,
+            "num_spec_tokens": self.num_spec_tokens,
+            "max_batch_size": self.max_batch_size,
+            "warmup_seq_lens": self.config.warmup_seq_lens,
+            "n_warmup_iters": self.config.n_warmup_iters,
+            "n_measure_iters": self.config.n_measure_iters,
+            "batch_size_levels": self._batch_size_levels,
+            "query_len_levels": self._query_len_levels,
+            "cost_table": rows,
+            "profile_records": self._cost_records,
+        }
+
+        dirname = os.path.dirname(dump_path)
+        if dirname:
+            os.makedirs(dirname, exist_ok=True)
+        tmp_path = f"{dump_path}.tmp"
+        with open(tmp_path, "w", encoding="utf-8") as f:
+            json.dump(payload, f, indent=2, sort_keys=True)
+            f.write("\n")
+        os.replace(tmp_path, dump_path)
+        logger.info("VerifyAdaptiveController: dumped cost table to %s",
+                    dump_path)
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+def _ceil_lookup(val: int, sorted_keys: list[int]) -> int:
+    """Smallest key ≥ val; falls back to max key when val is out of range."""
+    idx = bisect.bisect_left(sorted_keys, val)
+    return sorted_keys[min(idx, len(sorted_keys) - 1)]


### PR DESCRIPTION
# D-Cut Adaptation for Qwen3.5 and Qwen3.6 on Ascend NPU

> Variable-length speculative verification for Gated Delta Network (GDN) models

## Executive summary

This document describes an Ascend NPU implementation of **D-Cut**, a
hardware-aware adaptive verification policy for parallel speculative decoding.
The implementation targets vLLM Ascend 0.23.0 and focuses on DFlash/PARD-style
speculation for Qwen3.5 and Qwen3.6 models that contain Gated Delta Network
(GDN) layers.

A conventional speculative decoder verifies the same maximum number of draft
tokens for every request. D-Cut instead chooses a per-request draft prefix at
each decode step. The decision combines:

- selected-token confidence from the draft model;
- a measured Ascend cost table indexed by batch size and total query length;
- a batch-wide marginal-gain optimizer; and
- graph-aware safety rules for GDN state, KV cache, and PD handoff semantics.

The target model therefore verifies fewer low-value draft tokens while every
request keeps its mandatory anchor token. The drafter remains unchanged from a
model-quality perspective: D-Cut changes the amount of target verification, not
the token-generation algorithm.

### Results at a glance

At concurrency 64, D-Cut currently runs in PIECEWISE mode. Against the matching
native PIECEWISE path it improves throughput by **8.5% on Math500** and **19.1%
on Dolly**, while reducing TPOT by **9.2%** and **17.4%**. It also exceeds the
native FULL path by **4.8%** and **10.8%** on throughput, respectively. The
PIECEWISE integration is the correctness-isolation path; `FULL_DECODE_ONLY`
support is under development and is expected to deliver further gains once the
remaining partial-batch validation issues are resolved.

| Dataset | Baseline | Baseline wall time | D-Cut wall time | Wall-time change | Baseline throughput | D-Cut throughput | Throughput change | Baseline TPOT | D-Cut TPOT | TPOT change |
| --- | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| Math500 | PIECEWISE | 78.4 s | **72.0 s** | **-8.2%** | 3254 tok/s | **3529 tok/s** | **+8.5%** | 15.3 ms | **13.9 ms** | **-9.2%** |
| Math500 | FULL | 76.1 s | **72.0 s** | **-5.4%** | 3366 tok/s | **3529 tok/s** | **+4.8%** | 14.9 ms | **13.9 ms** | **-6.7%** |
| Dolly | PIECEWISE | 136.0 s | **113.8 s** | **-16.3%** | 1809 tok/s | **2154 tok/s** | **+19.1%** | 28.1 ms | **23.2 ms** | **-17.4%** |
| Dolly | FULL | 127.1 s | **113.8 s** | **-10.5%** | 1944 tok/s | **2154 tok/s** | **+10.8%** | 27.0 ms | **23.2 ms** | **-14.1%** |

The benefit is workload-dependent. When acceptance is already high and the FULL
baseline is efficient, probability collection and runtime bookkeeping can
outweigh the saved verification work. This is why D-Cut uses measured costs
rather than a fixed confidence threshold.

## 1. Motivation

Parallel speculative decoding creates a rectangular verification batch:

```text
batch size B × (1 anchor + K draft tokens)
```

The target model pays for all `B × (K + 1)` query tokens even when later draft
positions have little probability of being accepted. The waste is especially
visible on workloads with heterogeneous request difficulty.

A naive probability threshold is not sufficient on NPU hardware. Ascend
execution time is bucketed and nonlinear: reducing the logical token count does
not help unless the resulting workload reaches a cheaper graph or kernel shape.
D-Cut therefore solves a hardware-aware objective:

> Select the draft-token prefixes that maximize expected decode progress per
> measured target-plus-drafter cost.

The implementation has four goals:

1. Preserve speculative-decoding semantics and per-request prefix ordering.
2. Support variable-length verification in GDN layers without corrupting
   convolution or recurrent state.
3. Retain ACLGraph acceleration in PIECEWISE and `FULL_DECODE_ONLY` modes.
4. Preserve native behavior for prefill, PD handoff, and graph-unsafe inputs.

## 2. Architecture

```mermaid
flowchart LR
    subgraph Offline[Offline or startup profiling]
        Profiler[Ascend cost profiler]
        Table[(Cost table<br/>batch size, total query length)]
        Profiler --> Table
    end

    subgraph Runtime[Decode runtime]
        Scheduler[Scheduler output]
        Previous[Selected-token probabilities<br/>from the previous step]
        Controller[D-Cut controller]
        Caps[Per-request draft caps]
        Truncate[Prefix-preserving truncation]
        Sampler[Speculative sampler]
        Drafter[Draft proposal]
        Capture[Selected-probability capture]

        Scheduler --> Truncate
        Previous --> Controller
        Table --> Controller
        Controller --> Caps --> Truncate
        Sampler --> Drafter --> Capture
        Capture -. asynchronous D2H .-> Previous
    end

    subgraph TargetGraph[Target verification graph]
        TargetLayers[Attention, GDN, and MLP layers]
        Metadata[Fixed-address ragged metadata]
        Conv[D-Cut causal Conv1D]
        Recurrent[D-Cut recurrent gated-delta rule]

        Metadata --> Conv --> Recurrent
        Conv -. custom-op path .-> TargetLayers
        Recurrent -. custom-op path .-> TargetLayers
    end

    Truncate --> TargetLayers --> Sampler
    Truncate --> Metadata
```

The controller consumes probabilities produced by step `N-1` and selects the
verification shape for step `N`. This one-step pipeline overlaps probability
transfer with model execution and avoids a synchronous device-to-host copy in
the critical path.

## 3. Runtime flow

```mermaid
sequenceDiagram
    participant S as Scheduler
    participant C as D-Cut controller
    participant T as Target model
    participant A as Speculative sampler
    participant D as Drafter
    participant P as Probability pipeline

    S->>C: scheduled requests and draft tokens
    P-->>C: probabilities from step N-1
    C->>C: evaluate profiled Q levels
    C->>T: ragged, prefix-preserving verification batch
    T->>A: target logits
    A->>D: accepted tokens and next anchors
    D->>P: selected draft-token logits
    P-->>P: probability reduction and asynchronous D2H
    Note over P,C: Result is consumed by the next decode step
```

For each request, the transformation is:

```text
anchor, d1, d2, ... dK  ->  anchor, d1, d2, ... dk    where 0 <= k <= K
```

D-Cut never creates holes inside a draft sequence. It only shortens the suffix,
so token positions, KV slots, and recurrent-state transitions remain ordered.

## 4. Hardware-aware decision algorithm

Let:

- `A` be the number of active requests;
- `K` be the maximum draft length;
- `p[i, t]` be the predicted acceptance probability for draft position `t` of
  request `i`;
- `Q` be a profiled total query length; and
- `S = Q - A` be the number of draft tokens that can be retained, because each
  request contributes one mandatory anchor.

The marginal expected gain of retaining position `t` is the probability that
all draft tokens up to that position are accepted:

```text
m[i, t] = product(p[i, j], j = 0 ... t)
```

For every profiled `Q`, the controller selects the top `S` marginal gains across
the batch. Since cumulative products are non-increasing within each request,
the result naturally remains prefix-closed. The score is:

```text
score(Q) = (A + sum(top-S marginal gains))
           / (target_cost(A, Q) + draft_cost(A, Q))
```

The `Q` with the largest score is selected. The sequence IDs of the top marginal
gains are then counted to reconstruct an individual draft cap for every
request. The controller therefore does **not** apply a uniform
`best_S / batch_size` length.

```mermaid
flowchart TD
    Probs[Per-request selected-token probabilities]
    Cumprod[Cumulative products<br/>marginal expected gains]
    Sort[Stable global descending sort]
    Levels[Measured Q levels from the cost table]
    Scan[Compute progress / measured cost for each Q]
    Best[Choose best Q]
    Reconstruct[Count selected gains per request]
    Output[Per-request prefix caps]

    Probs --> Cumprod --> Sort
    Sort --> Scan
    Levels --> Scan
    Scan --> Best --> Reconstruct --> Output
```

## 5. Why GDN needs a dedicated variable-length path

Qwen3.5 and Qwen3.6 use GDN layers whose decode path maintains two mutable state
families:

- `conv_state`, containing the causal convolution history; and
- `ssm_state`, containing recurrent gated-delta-rule state.

The original speculative GDN path assumes a fixed number of tokens per request.
After D-Cut, requests have different query lengths and their packed token
positions no longer follow a rectangular `B × T` layout. Reusing the fixed-
length mapping can read the wrong history position or update the wrong state
slot.

The Ascend implementation introduces two state-aware custom operators:

- `npu_dcut_causal_conv1d`; and
- `npu_dcut_recurrent_gated_delta_rule`.

```mermaid
flowchart LR
    Hidden[Packed hidden states<br/>total Q tokens]
    Projection[QKV / QKVZ projection]
    Conv[D-Cut causal Conv1D]
    Recurrent[D-Cut recurrent<br/>gated-delta rule]
    Scatter[Scatter to packed output]
    Output[Output projection]

    QSL[query_start_loc]
    NAT[num_accepted_tokens]
    SSI[state-slot indices]
    ConvState[(conv_state)]
    SSMState[(ssm_state)]

    Hidden --> Projection --> Conv --> Recurrent --> Scatter --> Output
    QSL --> Conv
    QSL --> Recurrent
    NAT --> Conv
    NAT --> Recurrent
    SSI --> Conv
    SSI --> Recurrent
    ConvState <--> Conv
    SSMState <--> Recurrent
```

The operators consume flattened TND-style input together with explicit request
boundaries and state-slot indices. Padding rows use `PAD_SLOT_ID`, and unused
rows are initialized deterministically before graph replay. This is essential:
an inactive row must never retain a previous request's accepted-token count or
state index.

Both operators are registered as graph-visible custom operations. Their state
arguments are declared mutable, allowing ACLGraph to preserve the intended
in-place state updates.

## 6. ACLGraph integration

### 6.1 PIECEWISE mode

PIECEWISE was the first graph-enabled integration:

- full attention remains at its native graph boundary;
- GDN variable-length operators can be captured with fixed-address metadata;
- target and draft metadata are isolated; and
- eager fallback remains available for unsupported input shapes.

This mode is useful for correctness isolation because it limits the amount of
stateful execution captured in a single graph.

### 6.2 `FULL_DECODE_ONLY` mode

D-Cut turns the uniform verifier rectangle into a ragged batch. Stock vLLM only
registers uniform FULL keys for speculative decode, so the implementation adds
non-uniform descriptors beside the native keys.

```mermaid
flowchart TB
    Dispatch[Runtime batch descriptor]
    Uniform{Uniform verification?}
    Native[Native FULL graph<br/>drafter and untrimmed verifier]
    Ragged[Ragged FULL graph<br/>trimmed target verifier]
    Eager[Native eager fallback<br/>prefill or unsafe shape]

    Dispatch --> Uniform
    Uniform -- yes --> Native
    Uniform -- no, pure decode --> Ragged
    Uniform -- prefill / unsafe --> Eager

    subgraph RaggedContract[Ragged FULL replay contract]
        TokenBucket[Fixed token bucket]
        RequestAxis[Fixed request capacity]
        GDNBuffers[Stable GDN metadata buffers]
        FIABuffers[Stable FIA block-table address]
        Padding[Deterministic inactive-row padding]
        TokenBucket --> GDNBuffers
        RequestAxis --> GDNBuffers
        RequestAxis --> FIABuffers
        Padding --> GDNBuffers
        Padding --> FIABuffers
    end

    Ragged --> RaggedContract
```

Important implementation details include:

- graph parameters are keyed by both token count and `BatchDescriptor`, so a
  uniform graph and a ragged graph cannot share attention handles accidentally;
- the drafter continues to use the native uniform FULL descriptor;
- GDN metadata buffers keep stable addresses across capture and replay;
- the target FIA block table is copied into persistent graph-owned storage;
- padded token slots use invalid cache mappings; and
- inactive FIA request rows use zero query length, a zero block-table row, and a
  valid dummy KV length.

These rules prevent stale graph buffers from becoming request-visible state.

### 6.3 Target and drafter are intentionally separated

The target verifier becomes ragged after truncation, while the drafter still
produces the configured maximum number of speculative tokens per request. Using
one descriptor for both models would either capture unsupported ragged draft
attention or force the target back to the full rectangle. The implementation
therefore keeps:

```text
Target:  ragged descriptor selected by D-Cut
Drafter: native uniform descriptor
```

The separation changes execution geometry only; model weights and acceptance
semantics remain unchanged.

## 7. Cost-table profiling

The profiler measures candidate `(batch_size, total_query_length)` levels on the
same Ascend execution path used by serving.

```mermaid
flowchart LR
    Shapes[Generate batch and Q levels]
    Warmup[Warm up each level]
    Target[Measure target NPU time]
    Draft[Measure drafter NPU time]
    Aggregate[Aggregate robust samples]
    Broadcast[Broadcast the table to TP ranks]
    JSON[(Optional JSON export / override)]

    Shapes --> Warmup --> Target --> Draft --> Aggregate --> Broadcast --> JSON
```

Each cost-table row contains target, drafter, and combined costs. Profiling can
follow the configured graph mode; forced eager profiling is retained as an
isolation option. A JSON override makes calibration reusable across runs, while
the measured table can still be exported for inspection.

The profiler broadcasts the same cost table to every TP rank. At runtime, rank
0 converts its cached probabilities into per-request draft caps and broadcasts
one small Python integer list in scheduler order. This explicit per-step
synchronization prevents rank-local asynchronous D2H readiness from producing
different verifier shapes or deadlocking a later TP collective.

## 8. Probability pipeline

The draft token ID already selected by DFlash is reused. D-Cut computes only the
probability of that selected token, rather than transferring the full vocabulary
logits to CPU.

The runtime pipeline is:

1. capture selected-token logits/probabilities on NPU;
2. copy the compact result into pinned CPU storage asynchronously;
3. overlap the copy with the rest of the decode step; and
4. consume it before the next truncation decision.

If probabilities are not ready or not semantically valid for the current batch,
the controller reuses a safe cached decision or preserves the native path.
Random-cut diagnostic mode bypasses exact probability calculation entirely and
is not part of the production policy.

## 9. PD-disaggregated serving

In a disaggregated deployment, the prefill node transfers target KV cache to the
decode node through the configured connector. The decode node owns speculative
verification, DFlash proposal, D-Cut decisions, and GDN recurrent state.

```mermaid
sequenceDiagram
    participant Client
    participant P as Prefill node
    participant K as KV connector
    participant D as Decode node

    Client->>P: prompt
    P->>P: target prefill
    P->>K: KV cache and handoff metadata
    K->>D: transfer completion
    D->>D: native handoff / recompute semantics
    D->>D: speculative decode with D-Cut
    D-->>Client: streamed tokens
```

Handoff and recompute batches are correctness-sensitive. D-Cut does not infer
that a placeholder token is equivalent to a normal decode token. When the
required probability or state contract is unavailable, the implementation
preserves the native vLLM Ascend semantics and resumes adaptive truncation only
when the batch is safe.

## 10. Correctness and fallback invariants

The implementation is designed around the following invariants:

1. **Anchor preservation:** every active request contributes at least one target
   query token.
2. **Prefix closure:** a retained draft position implies that every earlier
   position of the request is retained.
3. **State ownership:** inactive GDN rows use `PAD_SLOT_ID` and cannot update a
   live request's `conv_state` or `ssm_state`.
4. **KV safety:** padded target tokens use invalid slot mappings and never write
   target KV cache.
5. **Graph address stability:** graph-visible metadata and block tables retain
   their capture-time addresses.
6. **Native prefill semantics:** prompt prefill and unsafe mixed batches do not
   enter ragged FULL graphs.
7. **TP consistency:** every tensor-parallel rank receives the same cost table
   and rank-0 draft-cap decision before truncation.
8. **Fail-safe behavior:** missing costs, unavailable probabilities, or invalid
   metadata disable truncation instead of guessing.

## 11. Benchmark results

D-Cut runs in PIECEWISE mode at concurrency 64, using 500 requests per dataset
and a two-run average. Throughput and TPOT are the primary serving metrics;
latency percentiles are included for completeness.

| Dataset | Mode | Wall time (s) | Throughput (tok/s) | Mean latency (s) | p50 (s) | p99 (s) | TTFT (s) | TPOT (ms) |
| --- | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| Math500 | Native PIECEWISE | 78.4 | 3254 | 9.44 | 9.16 | 15.38 | 1.636 | 15.3 |
| Math500 | Native FULL_DECODE_ONLY | 76.1 | 3366 | 8.93 | 8.64 | 14.82 | **1.306** | 14.9 |
| Math500 | D-Cut PIECEWISE | **72.0** | **3529** | **8.51** | **8.33** | **13.88** | 1.491 | **13.9** |
| Dolly | Native PIECEWISE | 136.0 | 1809 | 16.42 | 16.82 | 27.03 | 2.628 | 28.1 |
| Dolly | Native FULL_DECODE_ONLY | 127.1 | 1944 | 15.25 | 15.62 | 25.05 | **1.945** | 27.0 |
| Dolly | D-Cut PIECEWISE | **113.8** | **2154** | **13.54** | **14.03** | **21.21** | 2.180 | **23.2** |

Against the matching native PIECEWISE path, D-Cut improves throughput by
**8.5% on Math500** and **19.1% on Dolly**, and reduces TPOT by **9.2%** and
**17.4%**, respectively. As a secondary reference, it also exceeds the native
FULL throughput by 4.8% on Math500 and 10.8% on Dolly. Native FULL retains the
best TTFT in this run.


Before upstream merge, benchmark reports should also record the exact Ascend
SKU, CANN version, model checkpoint, tensor-parallel degree, concurrency,
request count, speculative length, and launch command.

## 12. Implementation status

| Capability | Status | Notes |
| --- | --- | --- |
| Adaptive controller and cost table | Implemented | Unit-testable pure decision function |
| DFlash selected-probability capture | Implemented | Compact asynchronous D2H pipeline |
| Variable-length GDN eager path | Implemented | State-aware Conv1D and recurrent operators |
| PIECEWISE with graph-captured GDN | Validated | Full attention keeps its native boundary |
| `FULL_DECODE_ONLY` ragged target graph | Experimental | Main graph contracts implemented; dynamic partial-batch validation is continuing |
| TP=4 execution | Validated in current evaluation | Cost table is broadcast to all ranks |
| PD disaggregation | Implemented with native fallback | Handoff/recompute paths preserve baseline semantics |
| Random-cut diagnostic mode | Implemented | Does not compute exact probabilities |

The `FULL_DECODE_ONLY` path is intentionally marked experimental until repeated
partial-batch and high-`max_num_seqs` accuracy sweeps are complete. PIECEWISE
remains the correctness-isolation path.

## 13. Engineering evolution

The design was reached in five stages:

| Stage | Development scope | Main result |
| --- | --- | --- |
| 1. Variable-length GDN operators | Qwen3-8B, single NPU | Removed the fixed-length state-index assumption |
| 2. PIECEWISE integration | Qwen3-8B, single NPU | Established graph-visible custom ops and safe eager boundaries |
| 3. GDN graph capture under TP | Qwen3.6-35B, TP=4 | Resolved the flat cost table caused by GDN plus TP work remaining outside the graph |
| 4. Full-model graph capture | Qwen3.6-35B, TP=4 | Added ragged FULL descriptors, stable buffers, and target/drafter isolation |
| 5. PD disaggregation | Separate prefill and decode nodes | Integrated KV handoff, recompute behavior, and D-Cut fallbacks |

A key lesson is that operator support alone is insufficient. On multiple TP
ranks, graph boundaries and communication overhead can dominate the reduced
arithmetic. This motivated the progression from eager correctness to PIECEWISE
capture and finally to ragged FULL graphs.

## 14. Code map

| File or directory | Responsibility |
| --- | --- |
| `install.py` | Deferred general-plugin installation and patch ordering |
| `controller.py` | Controller initialization and probability enablement |
| `verify_adaptive_controller.py` | Cost loading and marginal-gain optimizer |
| `verify_adaptive_config.py` | Configuration parsing |
| `truncate.py` | Prefix-preserving scheduler-output transformation |
| `probs.py` | Probability capture, asynchronous D2H, and processing |
| `drafter.py` | DFlash `compute_logits` integration |
| `patch_runner.py` | NPU model-runner integration and graph-safe routing |
| `patch_proposer.py` | Draft proposer integration and context-tail masking |
| `patch_piecewise.py` | PIECEWISE graph boundaries |
| `patch_full_graph.py` | Ragged `FULL_DECODE_ONLY` descriptors and graph-state isolation |
| `patch_attention.py` | Attention graph-boundary integration |
| `patch_gdn_v023.py` | GDN operator registration and routing |
| `gdn_forward_v023.py` | Graphable variable-length GDN forward path |
| `gdn_buffers.py` | Fixed-address GDN metadata buffers |
| `gdn_eager.py` | Eager GDN fallback |
| `dcut_profile.py` | Target cost profiling |
| `draft_profile.py` | Drafter cost profiling |
| `kernel/dcut_causal_conv1d/` | AscendC variable-length causal Conv1D |
| `kernel/dcut_recurrent_gated_delta_rule/` | AscendC recurrent gated-delta-rule operator |
| `tests/` | Decision, graph-contract, GDN-buffer, and fallback regression tests |

## 15. Proposed upstream review plan

For easier review and bisectability, the feature can be upstreamed in focused
pieces:

1. variable-length GDN operators and metadata contracts;
2. hardware-aware controller and cost-table profiler;
3. NPU runner, proposer, and probability-pipeline integration;
4. PIECEWISE graph support;
5. experimental ragged `FULL_DECODE_ONLY` support; and
6. PD handoff integration and end-to-end tests.

This split separates reusable GDN capability from the adaptive policy and keeps
the highest-risk graph changes independently reviewable.

## References

- [AngelSlim D-Cut documentation](https://angelslim.readthedocs.io/zh-cn/latest/dcut.html)
- vLLM speculative decoding and vLLM Ascend ACLGraph execution paths
