### PR TITLE
[v0.26.0rc][Performance] Pipeline AscendStore saves across model steps

### DIFF
--- a/tests/ut/distributed/ascend_store/test_ascend_store_connector.py
+++ b/tests/ut/distributed/ascend_store/test_ascend_store_connector.py
@@ -304,7 +304,12 @@ class TestAscendStoreConnector(unittest.TestCase):
         # start_load_kv
         connector._get_connector_metadata = MagicMock(return_value=MagicMock())
         connector.start_load_kv(MagicMock())
+        mock_worker.prepare_save.assert_called_once()
         mock_worker.start_load_kv.assert_called_once()
+
+        metadata = MagicMock(preempted_req_ids={"r1"})
+        connector.handle_preemptions(metadata)
+        mock_worker.wait_for_preempted_saves.assert_called_once_with({"r1"})
 
         # wait_for_save (non-consumer)
         connector.kv_role = "kv_producer"

--- a/tests/ut/distributed/ascend_store/test_ascend_store_connector.py
+++ b/tests/ut/distributed/ascend_store/test_ascend_store_connector.py
@@ -307,10 +307,6 @@ class TestAscendStoreConnector(unittest.TestCase):
         mock_worker.prepare_save.assert_called_once()
         mock_worker.start_load_kv.assert_called_once()
 
-        metadata = MagicMock(preempted_req_ids={"r1"})
-        connector.handle_preemptions(metadata)
-        mock_worker.wait_for_preempted_saves.assert_called_once_with({"r1"})
-
         # wait_for_save (non-consumer)
         connector.kv_role = "kv_producer"
         connector.use_layerwise = False

--- a/tests/ut/distributed/ascend_store/test_kv_transfer.py
+++ b/tests/ut/distributed/ascend_store/test_kv_transfer.py
@@ -633,7 +633,7 @@ class TestKVCacheStoreSendingThread(unittest.TestCase):
             t._pending_batches.append(batch)
         self.assertEqual(t.lookup_after_pending_saves(["k1"]), [1])
 
-    def test_save_batch_failure_releases_fence(self):
+    def test_save_batch_put_failure_is_nonfatal(self):
         t, store = self._make_thread([0])
         store.put = MagicMock(side_effect=RuntimeError("put failed"))
         t.start()
@@ -647,8 +647,7 @@ class TestKVCacheStoreSendingThread(unittest.TestCase):
         batch = t.prepare_save_batch([req])
         self.assertTrue(batch.prepared.wait(timeout=1))
         t.commit_save_batch(batch, MagicMock())
-        with self.assertRaises(RuntimeError):
-            t.wait_for_batch(batch)
+        t.wait_for_batch(batch)
         self.assertTrue(batch.done.is_set())
         self.assertNotIn("r1", t.stored_requests)
 

--- a/tests/ut/distributed/ascend_store/test_kv_transfer.py
+++ b/tests/ut/distributed/ascend_store/test_kv_transfer.py
@@ -17,7 +17,7 @@
 
 import threading
 import unittest
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 import numpy as np
 
@@ -635,7 +635,8 @@ class TestKVCacheStoreSendingThread(unittest.TestCase):
 
     def test_save_batch_put_failure_is_nonfatal(self):
         t, store = self._make_thread([0])
-        store.put = MagicMock(side_effect=RuntimeError("put failed"))
+        error = RuntimeError("put failed")
+        store.put = MagicMock(side_effect=error)
         t.start()
         self.assertTrue(t.ready_event.wait(timeout=1))
         req = ReqMeta(
@@ -646,8 +647,16 @@ class TestKVCacheStoreSendingThread(unittest.TestCase):
         )
         batch = t.prepare_save_batch([req])
         self.assertTrue(batch.prepared.wait(timeout=1))
-        t.commit_save_batch(batch, MagicMock())
-        t.wait_for_batch(batch)
+        with patch(
+            "vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.kv_transfer.logger.exception"
+        ) as log_exception:
+            t.commit_save_batch(batch, MagicMock())
+            t.wait_for_batch(batch)
+        log_exception.assert_called_once_with(
+            "Failed to put AscendStore save batch. type=%s, error=%s",
+            "RuntimeError",
+            error,
+        )
         self.assertTrue(batch.done.is_set())
         self.assertNotIn("r1", t.stored_requests)
 

--- a/tests/ut/distributed/ascend_store/test_kv_transfer.py
+++ b/tests/ut/distributed/ascend_store/test_kv_transfer.py
@@ -607,7 +607,7 @@ class TestKVCacheStoreSendingThread(unittest.TestCase):
 
     def test_lookup_waits_only_for_conflicting_pending_batch(self):
         t, _ = self._make_thread([1])
-        batch = KVCacheStoreBatch(1, [])
+        batch = KVCacheStoreBatch([])
         batch.pending_keys.add("k1")
         batch.prepared.set()
         with t._pending_batches_lock:
@@ -626,7 +626,7 @@ class TestKVCacheStoreSendingThread(unittest.TestCase):
 
     def test_non_conflicting_lookup_does_not_wait_for_put(self):
         t, _ = self._make_thread([1])
-        batch = KVCacheStoreBatch(1, [])
+        batch = KVCacheStoreBatch([])
         batch.pending_keys.add("other-key")
         batch.prepared.set()
         with t._pending_batches_lock:

--- a/tests/ut/distributed/ascend_store/test_kv_transfer.py
+++ b/tests/ut/distributed/ascend_store/test_kv_transfer.py
@@ -573,7 +573,7 @@ class TestKVCacheStoreSendingThread(unittest.TestCase):
         )
 
         batch = t.prepare_save_batch([req])
-        self.assertTrue(batch.prepared.wait(timeout=1))
+        t.request_queue.join()
         self.assertEqual(store.put_calls, [])
 
         event = MagicMock()
@@ -597,7 +597,6 @@ class TestKVCacheStoreSendingThread(unittest.TestCase):
         ]
 
         batch = t.prepare_save_batch(requests)
-        self.assertTrue(batch.prepared.wait(timeout=1))
         t.commit_save_batch(batch, MagicMock())
         t.wait_for_batch(batch)
 
@@ -617,7 +616,6 @@ class TestKVCacheStoreSendingThread(unittest.TestCase):
             block_hashes=[b"h0"],  # type: ignore[arg-type]
         )
         batch = t.prepare_save_batch([req])
-        self.assertTrue(batch.prepared.wait(timeout=1))
         with patch(
             "vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.kv_transfer.logger.exception"
         ) as log_exception:
@@ -628,6 +626,21 @@ class TestKVCacheStoreSendingThread(unittest.TestCase):
             "RuntimeError",
             error,
         )
+        self.assertTrue(batch.done.is_set())
+        self.assertNotIn("r1", t.stored_requests)
+
+    def test_save_batch_prepare_failure_is_nonfatal(self):
+        t, _ = self._make_thread()
+        t._prepare_stored_request = MagicMock(side_effect=RuntimeError("prepare failed"))
+        t.start()
+        self.assertTrue(t.ready_event.wait(timeout=1))
+        request = MagicMock(req_id="r1", event_id=None)
+
+        with patch("vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.kv_transfer.logger.exception"):
+            batch = t.prepare_save_batch([request])
+            t.commit_save_batch(batch, MagicMock())
+            t.wait_for_batch(batch)
+
         self.assertTrue(batch.done.is_set())
         self.assertNotIn("r1", t.stored_requests)
 

--- a/tests/ut/distributed/ascend_store/test_kv_transfer.py
+++ b/tests/ut/distributed/ascend_store/test_kv_transfer.py
@@ -40,7 +40,6 @@ from vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.config_data import
 
 # isort: on
 from vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.kv_transfer import (
-    KVCacheStoreBatch,
     KVCacheStoreLayerRecvingThread,
     KVCacheStoreLayerSendingThread,
     KVCacheStoreRecvingThread,
@@ -604,34 +603,6 @@ class TestKVCacheStoreSendingThread(unittest.TestCase):
 
         self.assertEqual(len(store.put_calls), 1)
         self.assertEqual(len(store.put_calls[0][0]), 1)
-
-    def test_lookup_waits_only_for_conflicting_pending_batch(self):
-        t, _ = self._make_thread([1])
-        batch = KVCacheStoreBatch([])
-        batch.pending_keys.add("k1")
-        batch.prepared.set()
-        with t._pending_batches_lock:
-            t._pending_batches.append(batch)
-
-        result = []
-        lookup_thread = threading.Thread(target=lambda: result.extend(t.lookup_after_pending_saves(["k1"])))
-        lookup_thread.start()
-        lookup_thread.join(timeout=0.05)
-        self.assertTrue(lookup_thread.is_alive())
-
-        batch.done.set()
-        lookup_thread.join(timeout=1)
-        self.assertFalse(lookup_thread.is_alive())
-        self.assertEqual(result, [1])
-
-    def test_non_conflicting_lookup_does_not_wait_for_put(self):
-        t, _ = self._make_thread([1])
-        batch = KVCacheStoreBatch([])
-        batch.pending_keys.add("other-key")
-        batch.prepared.set()
-        with t._pending_batches_lock:
-            t._pending_batches.append(batch)
-        self.assertEqual(t.lookup_after_pending_saves(["k1"]), [1])
 
     def test_save_batch_put_failure_is_nonfatal(self):
         t, store = self._make_thread([0])

--- a/tests/ut/distributed/ascend_store/test_kv_transfer.py
+++ b/tests/ut/distributed/ascend_store/test_kv_transfer.py
@@ -40,6 +40,7 @@ from vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.config_data import
 
 # isort: on
 from vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.kv_transfer import (
+    KVCacheStoreBatch,
     KVCacheStoreLayerRecvingThread,
     KVCacheStoreLayerSendingThread,
     KVCacheStoreRecvingThread,
@@ -560,6 +561,96 @@ class TestKVCacheStoreSendingThread(unittest.TestCase):
         t.request_queue.put(req)
         t._handle_request(req)
         event.synchronize.assert_called_once()
+
+    def test_save_batch_prepares_before_commit(self):
+        t, store = self._make_thread([0])
+        t.start()
+        self.assertTrue(t.ready_event.wait(timeout=1))
+        req = ReqMeta(
+            req_id="r1",
+            token_len_chunk=16,
+            block_ids=[0],
+            block_hashes=[b"h0"],  # type: ignore[arg-type]
+        )
+
+        batch = t.prepare_save_batch([req])
+        self.assertTrue(batch.prepared.wait(timeout=1))
+        self.assertEqual(store.put_calls, [])
+
+        event = MagicMock()
+        t.commit_save_batch(batch, event)
+        t.wait_for_batch(batch)
+        self.assertEqual(len(store.put_calls), 1)
+        event.synchronize.assert_called_once()
+
+    def test_save_batch_deduplicates_keys_across_requests(self):
+        t, store = self._make_thread([0])
+        t.start()
+        self.assertTrue(t.ready_event.wait(timeout=1))
+        requests = [
+            ReqMeta(
+                req_id=req_id,
+                token_len_chunk=16,
+                block_ids=[block_id],
+                block_hashes=[b"same-hash"],  # type: ignore[arg-type]
+            )
+            for req_id, block_id in [("r1", 0), ("r2", 1)]
+        ]
+
+        batch = t.prepare_save_batch(requests)
+        self.assertTrue(batch.prepared.wait(timeout=1))
+        t.commit_save_batch(batch, MagicMock())
+        t.wait_for_batch(batch)
+
+        self.assertEqual(len(store.put_calls), 1)
+        self.assertEqual(len(store.put_calls[0][0]), 1)
+
+    def test_lookup_waits_only_for_conflicting_pending_batch(self):
+        t, _ = self._make_thread([1])
+        batch = KVCacheStoreBatch(1, [])
+        batch.pending_keys.add("k1")
+        batch.prepared.set()
+        with t._pending_batches_lock:
+            t._pending_batches.append(batch)
+
+        result = []
+        lookup_thread = threading.Thread(target=lambda: result.extend(t.lookup_after_pending_saves(["k1"])))
+        lookup_thread.start()
+        lookup_thread.join(timeout=0.05)
+        self.assertTrue(lookup_thread.is_alive())
+
+        batch.done.set()
+        lookup_thread.join(timeout=1)
+        self.assertFalse(lookup_thread.is_alive())
+        self.assertEqual(result, [1])
+
+    def test_non_conflicting_lookup_does_not_wait_for_put(self):
+        t, _ = self._make_thread([1])
+        batch = KVCacheStoreBatch(1, [])
+        batch.pending_keys.add("other-key")
+        batch.prepared.set()
+        with t._pending_batches_lock:
+            t._pending_batches.append(batch)
+        self.assertEqual(t.lookup_after_pending_saves(["k1"]), [1])
+
+    def test_save_batch_failure_releases_fence(self):
+        t, store = self._make_thread([0])
+        store.put = MagicMock(side_effect=RuntimeError("put failed"))
+        t.start()
+        self.assertTrue(t.ready_event.wait(timeout=1))
+        req = ReqMeta(
+            req_id="r1",
+            token_len_chunk=16,
+            block_ids=[0],
+            block_hashes=[b"h0"],  # type: ignore[arg-type]
+        )
+        batch = t.prepare_save_batch([req])
+        self.assertTrue(batch.prepared.wait(timeout=1))
+        t.commit_save_batch(batch, MagicMock())
+        with self.assertRaises(RuntimeError):
+            t.wait_for_batch(batch)
+        self.assertTrue(batch.done.is_set())
+        self.assertNotIn("r1", t.stored_requests)
 
     def test_handle_request_dcp_size_gt_1(self):
         store = FakeStore([0, 0])

--- a/tests/ut/distributed/ascend_store/test_pool_worker.py
+++ b/tests/ut/distributed/ascend_store/test_pool_worker.py
@@ -30,6 +30,10 @@ from vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.config_data import
     ReqMeta,
     SharedBlockData,
 )
+from vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.kv_transfer import (
+    KVCacheStoreBatch,
+    KVCacheStoreSendingThread,
+)
 
 
 class TestKVPoolWorkerHelpers(unittest.TestCase):
@@ -624,6 +628,44 @@ class TestKVPoolWorkerRegisterAndTransfer(unittest.TestCase):
         worker.m_store.ensure_initialized.assert_called_once_with()
         worker.m_store.register_buffer.assert_called_once()
 
+    def test_worker_constructed_sender_prepares_before_put(self):
+        worker = self._make_worker()
+        worker.token_database.set_group_buffers(
+            {0: [1000]},
+            {0: [16]},
+            {0: [16]},
+            group_num_layers={0: 1},
+        )
+        worker.m_store.exists.return_value = [0]
+        worker._start_kv_transfer_threads()
+        self.assertIsInstance(worker.kv_send_thread, KVCacheStoreSendingThread)
+        send_thread = worker.kv_send_thread
+        assert isinstance(send_thread, KVCacheStoreSendingThread)
+        self.assertTrue(send_thread.put_thread.is_alive())
+
+        req = ReqMeta(
+            req_id="r1",
+            token_len_chunk=16,
+            block_ids=[0],
+            block_hashes=["h0"],
+            can_save=True,
+        )
+        meta = AscendConnectorMetadata(set(), set())
+        meta.add_request(req)
+        worker.prepare_save(meta)
+        batch = worker._prepared_save_batch
+        assert batch is not None
+        self.assertTrue(batch.prepared.wait(timeout=1))
+        worker.m_store.put.assert_not_called()
+
+        with patch(
+            "vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.pool_worker.torch.npu",
+            create=True,
+        ):
+            worker.wait_for_save(meta)
+        send_thread.wait_for_batch(batch)
+        worker.m_store.put.assert_called_once()
+
     @patch("vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.pool_worker.threading.Event")
     @patch("vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.pool_worker.KVCacheStoreRecvingThread")
     @patch("vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.pool_worker.KVCacheStoreSendingThread")
@@ -717,27 +759,84 @@ class TestKVPoolWorkerRegisterAndTransfer(unittest.TestCase):
         kwargs["invalid_block_ids"].add(7)
         self.assertEqual(worker.get_block_ids_with_load_errors(), {7})
 
-    def test_wait_for_save_waits_for_save(self):
+    def test_wait_for_save_pipelines_one_step(self):
         worker = self._make_worker()
-        worker.kv_send_thread = MagicMock()
+        send_thread = MagicMock(spec=KVCacheStoreSendingThread)
+        first_batch = KVCacheStoreBatch(1, [])
+        second_batch = KVCacheStoreBatch(2, [])
+        send_thread.prepare_save_batch.side_effect = [first_batch, second_batch]
+        worker.kv_send_thread = send_thread
 
-        req = ReqMeta(
+        first_req = ReqMeta(
             req_id="r1",
             token_len_chunk=16,
             block_ids=[0],
             block_hashes=["h0"],
             can_save=True,
         )
+        first_meta = AscendConnectorMetadata(set(), set())
+        first_meta.add_request(first_req)
+        worker.prepare_save(first_meta)
+        with patch(
+            "vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.pool_worker.torch.npu",
+            create=True,
+        ):
+            worker.wait_for_save(first_meta)
+
+        send_thread.commit_save_batch.assert_called_once()
+        send_thread.wait_for_batch.assert_not_called()
+
+        second_req = ReqMeta(
+            req_id="r2",
+            token_len_chunk=16,
+            block_ids=[1],
+            block_hashes=["h1"],
+            can_save=True,
+        )
+        second_meta = AscendConnectorMetadata(set(), set())
+        second_meta.add_request(second_req)
+        worker.prepare_save(second_meta)
+        with patch(
+            "vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.pool_worker.torch.npu",
+            create=True,
+        ):
+            worker.wait_for_save(second_meta)
+
+        send_thread.wait_for_batch.assert_called_once_with(first_batch)
+        self.assertIs(worker._previous_save_batch, second_batch)
+
+    def test_partial_save_forces_current_step_fence(self):
+        worker = self._make_worker()
+        send_thread = MagicMock(spec=KVCacheStoreSendingThread)
+        batch = KVCacheStoreBatch(1, [])
+        send_thread.prepare_save_batch.return_value = batch
+        worker.kv_send_thread = send_thread
+
+        req = ReqMeta(
+            req_id="r1",
+            token_len_chunk=15,
+            save_end_token=15,
+            block_ids=[0],
+            block_hashes=["h0"],
+            can_save=True,
+        )
         meta = AscendConnectorMetadata(set(), set())
         meta.add_request(req)
-        worker.wait_for_save(meta)
-        worker.kv_send_thread.add_stored_request.assert_called_with("r1")
-        worker.kv_send_thread.add_request.assert_called_once()
-        worker.kv_send_thread.request_queue.join.assert_called_once()
+        worker.prepare_save(meta)
+        self.assertTrue(send_thread.prepare_save_batch.call_args.kwargs["force_current_step"])
+
+        batch.force_current_step = True
+        with patch(
+            "vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.pool_worker.torch.npu",
+            create=True,
+        ):
+            worker.wait_for_save(meta)
+        send_thread.wait_for_batch.assert_called_once_with(batch)
+        self.assertIsNone(worker._previous_save_batch)
 
     def test_wait_for_save_skip_non_save(self):
         worker = self._make_worker()
-        worker.kv_send_thread = MagicMock()
+        worker.kv_send_thread = MagicMock(spec=KVCacheStoreSendingThread)
 
         req = ReqMeta(
             req_id="r1",
@@ -749,8 +848,14 @@ class TestKVPoolWorkerRegisterAndTransfer(unittest.TestCase):
         meta = AscendConnectorMetadata(set(), set())
         meta.add_request(req)
         worker.wait_for_save(meta)
-        worker.kv_send_thread.add_stored_request.assert_not_called()
-        worker.kv_send_thread.request_queue.join.assert_not_called()
+        worker.kv_send_thread.prepare_save_batch.assert_not_called()
+        worker.kv_send_thread.wait_for_batch.assert_not_called()
+
+    def test_preemption_waits_only_matching_save_batches(self):
+        worker = self._make_worker()
+        worker.kv_send_thread = MagicMock(spec=KVCacheStoreSendingThread)
+        worker.wait_for_preempted_saves({"r1"})
+        worker.kv_send_thread.wait_for_requests.assert_called_once_with({"r1"})
 
     def test_get_finished_producer(self):
         worker = self._make_worker(kv_role="kv_producer")

--- a/tests/ut/distributed/ascend_store/test_pool_worker.py
+++ b/tests/ut/distributed/ascend_store/test_pool_worker.py
@@ -755,6 +755,7 @@ class TestKVPoolWorkerRegisterAndTransfer(unittest.TestCase):
             block_hashes=["h1"],
             can_save=True,
         )
+        second_batch.requests = [second_req]
         second_meta = AscendConnectorMetadata(set(), set())
         second_meta.add_request(second_req)
         worker.prepare_save(second_meta)
@@ -766,6 +767,11 @@ class TestKVPoolWorkerRegisterAndTransfer(unittest.TestCase):
 
         send_thread.wait_for_batch.assert_called_once_with(first_batch)
         self.assertIs(worker._previous_save_batch, second_batch)
+
+        send_thread.wait_for_batch.reset_mock()
+        worker.wait_for_preempted_saves({"r2"})
+        send_thread.wait_for_batch.assert_called_once_with(second_batch)
+        self.assertIsNone(worker._previous_save_batch)
 
     def test_partial_save_forces_current_step_fence(self):
         worker = self._make_worker()

--- a/tests/ut/distributed/ascend_store/test_pool_worker.py
+++ b/tests/ut/distributed/ascend_store/test_pool_worker.py
@@ -628,44 +628,6 @@ class TestKVPoolWorkerRegisterAndTransfer(unittest.TestCase):
         worker.m_store.ensure_initialized.assert_called_once_with()
         worker.m_store.register_buffer.assert_called_once()
 
-    def test_worker_constructed_sender_prepares_before_put(self):
-        worker = self._make_worker()
-        worker.token_database.set_group_buffers(
-            {0: [1000]},
-            {0: [16]},
-            {0: [16]},
-            group_num_layers={0: 1},
-        )
-        worker.m_store.exists.return_value = [0]
-        worker._start_kv_transfer_threads()
-        self.assertIsInstance(worker.kv_send_thread, KVCacheStoreSendingThread)
-        send_thread = worker.kv_send_thread
-        assert isinstance(send_thread, KVCacheStoreSendingThread)
-        self.assertTrue(send_thread.put_thread.is_alive())
-
-        req = ReqMeta(
-            req_id="r1",
-            token_len_chunk=16,
-            block_ids=[0],
-            block_hashes=["h0"],
-            can_save=True,
-        )
-        meta = AscendConnectorMetadata(set(), set())
-        meta.add_request(req)
-        worker.prepare_save(meta)
-        batch = worker._prepared_save_batch
-        assert batch is not None
-        self.assertTrue(batch.prepared.wait(timeout=1))
-        worker.m_store.put.assert_not_called()
-
-        with patch(
-            "vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.pool_worker.torch.npu",
-            create=True,
-        ):
-            worker.wait_for_save(meta)
-        send_thread.wait_for_batch(batch)
-        worker.m_store.put.assert_called_once()
-
     @patch("vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.pool_worker.threading.Event")
     @patch("vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.pool_worker.KVCacheStoreRecvingThread")
     @patch("vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.pool_worker.KVCacheStoreSendingThread")
@@ -850,12 +812,6 @@ class TestKVPoolWorkerRegisterAndTransfer(unittest.TestCase):
         worker.wait_for_save(meta)
         worker.kv_send_thread.prepare_save_batch.assert_not_called()
         worker.kv_send_thread.wait_for_batch.assert_not_called()
-
-    def test_preemption_waits_only_matching_save_batches(self):
-        worker = self._make_worker()
-        worker.kv_send_thread = MagicMock(spec=KVCacheStoreSendingThread)
-        worker.wait_for_preempted_saves({"r1"})
-        worker.kv_send_thread.wait_for_requests.assert_called_once_with({"r1"})
 
     def test_get_finished_producer(self):
         worker = self._make_worker(kv_role="kv_producer")

--- a/tests/ut/distributed/ascend_store/test_pool_worker.py
+++ b/tests/ut/distributed/ascend_store/test_pool_worker.py
@@ -724,8 +724,8 @@ class TestKVPoolWorkerRegisterAndTransfer(unittest.TestCase):
     def test_wait_for_save_pipelines_one_step(self):
         worker = self._make_worker()
         send_thread = MagicMock(spec=KVCacheStoreSendingThread)
-        first_batch = KVCacheStoreBatch(1, [])
-        second_batch = KVCacheStoreBatch(2, [])
+        first_batch = KVCacheStoreBatch([])
+        second_batch = KVCacheStoreBatch([])
         send_thread.prepare_save_batch.side_effect = [first_batch, second_batch]
         worker.kv_send_thread = send_thread
 
@@ -770,7 +770,7 @@ class TestKVPoolWorkerRegisterAndTransfer(unittest.TestCase):
     def test_partial_save_forces_current_step_fence(self):
         worker = self._make_worker()
         send_thread = MagicMock(spec=KVCacheStoreSendingThread)
-        batch = KVCacheStoreBatch(1, [])
+        batch = KVCacheStoreBatch([])
         send_thread.prepare_save_batch.return_value = batch
         worker.kv_send_thread = send_thread
 

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/ascend_store_connector.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/ascend_store_connector.py
@@ -226,6 +226,10 @@ class AscendStoreConnector(KVConnectorBase_V1, SupportsHMA):
         assert self.connector_worker is not None
         metadata = self._get_connector_metadata()
         self._current_step_has_real_forward = forward_context is not None
+        # This hook runs before both target-model and deferred MTP forward.
+        # Only CPU-side key/exists/address preparation is submitted here; the
+        # NPU data dependency is recorded and released by wait_for_save.
+        self.connector_worker.prepare_save(metadata)
         logger.debug(
             "KV pool connector start_load_kv metadata_requests=%d specs=%s",
             len(metadata.requests),
@@ -240,6 +244,11 @@ class AscendStoreConnector(KVConnectorBase_V1, SupportsHMA):
             ],
         )
         self.connector_worker.start_load_kv(metadata)
+
+    def handle_preemptions(self, kv_connector_metadata: KVConnectorMetadata) -> None:
+        assert self.connector_worker is not None
+        preempted_req_ids = getattr(kv_connector_metadata, "preempted_req_ids", set())
+        self.connector_worker.wait_for_preempted_saves(preempted_req_ids)
 
     def wait_for_layer_load(self, layer_name: str) -> None:
         if not self.use_layerwise:

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/kv_transfer.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/kv_transfer.py
@@ -32,8 +32,6 @@ from vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.config_data import
 )
 # isort: on
 
-SAVE_FENCE_POLL_INTERVAL_SECONDS = 1.0
-
 
 def _circular_shift(lst: list, offset: int) -> list:
     if not lst or offset == 0:
@@ -49,15 +47,11 @@ class PreparedStore:
     stored_events: list[BlockStored] = field(default_factory=list)
 
 
-@dataclass
-class PreparedRequest:
-    request: ReqMeta
-    stores: list[PreparedStore] = field(default_factory=list)
+PreparedRequest = tuple[ReqMeta, list[PreparedStore]]
 
 
 @dataclass(eq=False)
 class KVCacheStoreBatch:
-    sequence_id: int
     requests: list[ReqMeta]
     force_current_step: bool = False
     prepared: threading.Event = field(default_factory=threading.Event)
@@ -66,10 +60,6 @@ class KVCacheStoreBatch:
     current_event: Any = None
     pending_keys: set[str] = field(default_factory=set)
     error: BaseException | None = None
-
-    @property
-    def request_ids(self) -> set[str]:
-        return {request.req_id for request in self.requests}
 
 
 class LayerBatchBuilder:
@@ -687,13 +677,8 @@ class KVCacheStoreSendingThread(KVTransferThread):
         self.completed_events_lock = threading.Lock()
         self.completed_events: dict[int, int] = {}
         self.worker = worker
-        self._batch_sequence = 0
         self._pending_batches: list[KVCacheStoreBatch] = []
         self._pending_batches_lock = threading.Lock()
-        # Serializes batch registration with the final recheck + backend lookup.
-        # It is deliberately not held while waiting for a batch, so the prepare
-        # thread can make progress and publish its pending keys.
-        self._submission_lock = threading.Lock()
         self.put_thread = KVCacheStorePutThread(self)
 
     def run(self):
@@ -706,18 +691,12 @@ class KVCacheStoreSendingThread(KVTransferThread):
         requests: list[ReqMeta],
         force_current_step: bool = False,
     ) -> KVCacheStoreBatch:
-        with self._submission_lock:
-            self._batch_sequence += 1
-            batch = KVCacheStoreBatch(
-                sequence_id=self._batch_sequence,
-                requests=requests,
-                force_current_step=force_current_step,
-            )
-            for request in requests:
-                self.add_stored_request(request.req_id)
-            with self._pending_batches_lock:
-                self._pending_batches.append(batch)
-            self.add_request(batch)  # type: ignore[arg-type]
+        batch = KVCacheStoreBatch(requests=requests, force_current_step=force_current_step)
+        for request in requests:
+            self.add_stored_request(request.req_id)
+        with self._pending_batches_lock:
+            self._pending_batches.append(batch)
+        self.add_request(batch)  # type: ignore[arg-type]
         return batch
 
     @staticmethod
@@ -726,20 +705,22 @@ class KVCacheStoreSendingThread(KVTransferThread):
         batch.committed.set()
 
     def wait_for_batch(self, batch: KVCacheStoreBatch) -> None:
-        while not batch.done.wait(timeout=SAVE_FENCE_POLL_INTERVAL_SECONDS):
+        while not batch.done.wait(timeout=1.0):
             self.raise_if_failed()
             self.put_thread.raise_if_failed()
         if batch.error is not None:
-            raise RuntimeError(f"AscendStore save batch {batch.sequence_id} failed") from batch.error
+            raise RuntimeError("AscendStore save batch failed") from batch.error
 
     def wait_for_requests(self, req_ids: set[str]) -> None:
         if not req_ids:
             return
         with self._pending_batches_lock:
-            batches = [batch for batch in self._pending_batches if batch.request_ids & req_ids]
+            batches = [
+                batch for batch in self._pending_batches if any(request.req_id in req_ids for request in batch.requests)
+            ]
         for batch in batches:
             if not batch.committed.is_set():
-                raise RuntimeError(f"Preempted request reached uncommitted AscendStore save batch {batch.sequence_id}")
+                raise RuntimeError("Preempted request reached an uncommitted AscendStore save batch")
             self.wait_for_batch(batch)
 
     def lookup_after_pending_saves(
@@ -755,19 +736,13 @@ class KVCacheStoreSendingThread(KVTransferThread):
                 batches = [
                     batch for batch in self._pending_batches if batch is not exclude_batch and batch not in observed
                 ]
+                if not batches:
+                    return self.m_store.exists(keys)
             for batch in batches:
                 batch.prepared.wait()
                 observed.add(batch)
                 if key_set & batch.pending_keys:
                     self.wait_for_batch(batch)
-
-            with self._submission_lock:
-                with self._pending_batches_lock:
-                    has_unseen = any(
-                        batch is not exclude_batch and batch not in observed for batch in self._pending_batches
-                    )
-                if not has_unseen:
-                    return self.m_store.exists(keys)
 
     def _remove_pending_batch(self, batch: KVCacheStoreBatch) -> None:
         with self._pending_batches_lock:
@@ -817,12 +792,6 @@ class KVCacheStoreSendingThread(KVTransferThread):
         return completed_events
 
     def _handle_request_exception(self, request_data: Any):
-        if isinstance(request_data, KVCacheStoreBatch):
-            for request in request_data.requests:
-                self._complete_request(request)
-            self._fail_batch(request_data, RuntimeError("Unhandled AscendStore prepare-thread failure"))
-            self.request_queue.task_done()
-            return
         req_id = getattr(request_data, "req_id", None)
         if req_id is not None:
             with self.done_task_lock:
@@ -848,13 +817,13 @@ class KVCacheStoreSendingThread(KVTransferThread):
                     if batch.error is None:
                         batch.error = error
                     stores = []
-                prepared_requests.append(PreparedRequest(request=request, stores=stores))
+                prepared_requests.append((request, stores))
                 for store in stores:
                     batch.pending_keys.update(store.keys)
             batch.prepared.set()
             self.put_thread.add_request((batch, prepared_requests))  # type: ignore[arg-type]
         except Exception as error:
-            logger.exception("Failed to prepare AscendStore save batch %d", batch.sequence_id)
+            logger.exception("Failed to prepare AscendStore save batch")
             for request in batch.requests:
                 self._complete_request(request)
             self._fail_batch(batch, error)
@@ -912,21 +881,21 @@ class KVCacheStoreSendingThread(KVTransferThread):
     def _put_batch(self, batch: KVCacheStoreBatch, prepared_requests: list[PreparedRequest]) -> None:
         batch.committed.wait()
         try:
-            has_data = any(prepared.stores for prepared in prepared_requests)
+            has_data = any(stores for _, stores in prepared_requests)
             if batch.current_event is not None and has_data:
                 batch.current_event.synchronize()
-            for prepared in prepared_requests:
-                for store in prepared.stores:
+            for _, stores in prepared_requests:
+                for store in stores:
                     self.m_store.put(store.keys, store.addrs, store.sizes)
                     if self.enable_kv_event and store.stored_events:
                         self.update_kv_event(store.stored_events)
         except Exception as error:
-            logger.exception("Failed to put AscendStore save batch %d", batch.sequence_id)
+            logger.exception("Failed to put AscendStore save batch")
             if batch.error is None:
                 batch.error = error
         finally:
-            for prepared in prepared_requests:
-                self._complete_request(prepared.request)
+            for request, _ in prepared_requests:
+                self._complete_request(request)
             self._remove_pending_batch(batch)
             batch.done.set()
 

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/kv_transfer.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/kv_transfer.py
@@ -6,6 +6,7 @@ import threading
 import time
 from collections import defaultdict
 from collections.abc import Callable
+from dataclasses import dataclass, field
 from typing import Any
 
 import numpy as np
@@ -31,11 +32,44 @@ from vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.config_data import
 )
 # isort: on
 
+SAVE_FENCE_POLL_INTERVAL_SECONDS = 1.0
+
 
 def _circular_shift(lst: list, offset: int) -> list:
     if not lst or offset == 0:
         return lst
     return lst[offset:] + lst[:offset]
+
+
+@dataclass
+class PreparedStore:
+    keys: list[str]
+    addrs: list[list[int]]
+    sizes: list[list[int]]
+    stored_events: list[BlockStored] = field(default_factory=list)
+
+
+@dataclass
+class PreparedRequest:
+    request: ReqMeta
+    stores: list[PreparedStore] = field(default_factory=list)
+
+
+@dataclass(eq=False)
+class KVCacheStoreBatch:
+    sequence_id: int
+    requests: list[ReqMeta]
+    force_current_step: bool = False
+    prepared: threading.Event = field(default_factory=threading.Event)
+    committed: threading.Event = field(default_factory=threading.Event)
+    done: threading.Event = field(default_factory=threading.Event)
+    current_event: Any = None
+    pending_keys: set[str] = field(default_factory=set)
+    error: BaseException | None = None
+
+    @property
+    def request_ids(self) -> set[str]:
+        return {request.req_id for request in self.requests}
 
 
 class LayerBatchBuilder:
@@ -605,6 +639,27 @@ class KVTransferThread(threading.Thread):
             return self.token_database.decode_adaptor_prefill_pp(keys, addrs, sizes)
 
 
+class KVCacheStorePutThread(KVTransferThread):
+    def __init__(self, owner: KVCacheStoreSendingThread) -> None:
+        super().__init__(
+            owner.m_store,
+            owner.token_database,
+            owner.block_size,
+            owner.tp_rank,
+            owner.tp_size,
+            owner.dcp_size,
+            name="KVCacheStorePutThread",
+        )
+        self.owner = owner
+
+    def _handle_request(self, request_data: tuple[KVCacheStoreBatch, list[PreparedRequest]]) -> None:
+        batch, prepared_requests = request_data
+        try:
+            self.owner._put_batch(batch, prepared_requests)
+        finally:
+            self.request_queue.task_done()
+
+
 class KVCacheStoreSendingThread(KVTransferThread):
     def __init__(
         self,
@@ -632,6 +687,99 @@ class KVCacheStoreSendingThread(KVTransferThread):
         self.completed_events_lock = threading.Lock()
         self.completed_events: dict[int, int] = {}
         self.worker = worker
+        self._batch_sequence = 0
+        self._pending_batches: list[KVCacheStoreBatch] = []
+        self._pending_batches_lock = threading.Lock()
+        # Serializes batch registration with the final recheck + backend lookup.
+        # It is deliberately not held while waiting for a batch, so the prepare
+        # thread can make progress and publish its pending keys.
+        self._submission_lock = threading.Lock()
+        self.put_thread = KVCacheStorePutThread(self)
+
+    def run(self):
+        self.put_thread.start()
+        self.put_thread.ready_event.wait()
+        super().run()
+
+    def prepare_save_batch(
+        self,
+        requests: list[ReqMeta],
+        force_current_step: bool = False,
+    ) -> KVCacheStoreBatch:
+        with self._submission_lock:
+            self._batch_sequence += 1
+            batch = KVCacheStoreBatch(
+                sequence_id=self._batch_sequence,
+                requests=requests,
+                force_current_step=force_current_step,
+            )
+            for request in requests:
+                self.add_stored_request(request.req_id)
+            with self._pending_batches_lock:
+                self._pending_batches.append(batch)
+            self.add_request(batch)  # type: ignore[arg-type]
+        return batch
+
+    @staticmethod
+    def commit_save_batch(batch: KVCacheStoreBatch, current_event: Any) -> None:
+        batch.current_event = current_event
+        batch.committed.set()
+
+    def wait_for_batch(self, batch: KVCacheStoreBatch) -> None:
+        while not batch.done.wait(timeout=SAVE_FENCE_POLL_INTERVAL_SECONDS):
+            self.raise_if_failed()
+            self.put_thread.raise_if_failed()
+        if batch.error is not None:
+            raise RuntimeError(f"AscendStore save batch {batch.sequence_id} failed") from batch.error
+
+    def wait_for_requests(self, req_ids: set[str]) -> None:
+        if not req_ids:
+            return
+        with self._pending_batches_lock:
+            batches = [batch for batch in self._pending_batches if batch.request_ids & req_ids]
+        for batch in batches:
+            if not batch.committed.is_set():
+                raise RuntimeError(f"Preempted request reached uncommitted AscendStore save batch {batch.sequence_id}")
+            self.wait_for_batch(batch)
+
+    def lookup_after_pending_saves(
+        self,
+        keys: list[str],
+        exclude_batch: KVCacheStoreBatch | None = None,
+    ) -> list[int]:
+        """Fence only save batches that may publish one of ``keys``."""
+        observed: set[KVCacheStoreBatch] = set()
+        key_set = set(keys)
+        while True:
+            with self._pending_batches_lock:
+                batches = [
+                    batch for batch in self._pending_batches if batch is not exclude_batch and batch not in observed
+                ]
+            for batch in batches:
+                batch.prepared.wait()
+                observed.add(batch)
+                if key_set & batch.pending_keys:
+                    self.wait_for_batch(batch)
+
+            with self._submission_lock:
+                with self._pending_batches_lock:
+                    has_unseen = any(
+                        batch is not exclude_batch and batch not in observed for batch in self._pending_batches
+                    )
+                if not has_unseen:
+                    return self.m_store.exists(keys)
+
+    def _remove_pending_batch(self, batch: KVCacheStoreBatch) -> None:
+        with self._pending_batches_lock:
+            if batch in self._pending_batches:
+                self._pending_batches.remove(batch)
+
+    def _fail_batch(self, batch: KVCacheStoreBatch, error: BaseException) -> None:
+        if batch.error is None:
+            batch.error = error
+        batch.prepared.set()
+        self._remove_pending_batch(batch)
+        batch.done.set()
 
     def add_stored_request(self, req_id: str):
         with self.done_task_lock:
@@ -669,6 +817,12 @@ class KVCacheStoreSendingThread(KVTransferThread):
         return completed_events
 
     def _handle_request_exception(self, request_data: Any):
+        if isinstance(request_data, KVCacheStoreBatch):
+            for request in request_data.requests:
+                self._complete_request(request)
+            self._fail_batch(request_data, RuntimeError("Unhandled AscendStore prepare-thread failure"))
+            self.request_queue.task_done()
+            return
         req_id = getattr(request_data, "req_id", None)
         if req_id is not None:
             with self.done_task_lock:
@@ -677,7 +831,37 @@ class KVCacheStoreSendingThread(KVTransferThread):
                 self.dec_stored_request(req_id)
         self.request_queue.task_done()
 
-    def _handle_request(self, req_meta: ReqMeta):
+    def _handle_request(self, request_data: ReqMeta | KVCacheStoreBatch):
+        if isinstance(request_data, KVCacheStoreBatch):
+            self._handle_save_batch(request_data)
+            return
+        self._handle_legacy_request(request_data)
+
+    def _handle_save_batch(self, batch: KVCacheStoreBatch) -> None:
+        prepared_requests: list[PreparedRequest] = []
+        try:
+            for request in batch.requests:
+                try:
+                    stores = self._prepare_stored_request(request, batch)
+                except Exception as error:
+                    logger.exception("Failed to prepare KV cache save for request %s", request.req_id)
+                    if batch.error is None:
+                        batch.error = error
+                    stores = []
+                prepared_requests.append(PreparedRequest(request=request, stores=stores))
+                for store in stores:
+                    batch.pending_keys.update(store.keys)
+            batch.prepared.set()
+            self.put_thread.add_request((batch, prepared_requests))  # type: ignore[arg-type]
+        except Exception as error:
+            logger.exception("Failed to prepare AscendStore save batch %d", batch.sequence_id)
+            for request in batch.requests:
+                self._complete_request(request)
+            self._fail_batch(batch, error)
+        finally:
+            self.request_queue.task_done()
+
+    def _handle_legacy_request(self, req_meta: ReqMeta):
         if self.worker is not None and getattr(self.worker, "tp_mismatch", False):
             req_id = req_meta.req_id
             try:
@@ -702,23 +886,58 @@ class KVCacheStoreSendingThread(KVTransferThread):
                 tracked_request = req_id in self.stored_requests
             if not tracked_request:
                 return
-            self._handle_stored_request(req_meta)
+            stores = self._prepare_stored_request(req_meta)
+            if req_meta.current_event is not None and stores:
+                req_meta.current_event.synchronize()
+            for store in stores:
+                self.m_store.put(store.keys, store.addrs, store.sizes)
+                if self.enable_kv_event and store.stored_events:
+                    self.update_kv_event(store.stored_events)
         except Exception:
             logger.exception("Failed to store KV cache for request %s", req_id)
         finally:
-            remaining = self.dec_stored_request(req_id) if tracked_request else None
-            if tracked_request and remaining == 0:
-                self.delete_finished_stored_request(req_id)
-                self.set_finished_request(req_id)
-            if req_meta.event_id is not None:
-                with self.completed_events_lock:
-                    self.completed_events[req_meta.event_id] = 1
+            if tracked_request:
+                self._complete_request(req_meta)
             self.request_queue.task_done()
 
-    def _handle_stored_request(self, req_meta: ReqMeta):
+    def _complete_request(self, req_meta: ReqMeta) -> None:
+        remaining = self.dec_stored_request(req_meta.req_id)
+        if remaining == 0:
+            self.delete_finished_stored_request(req_meta.req_id)
+            self.set_finished_request(req_meta.req_id)
+        if req_meta.event_id is not None:
+            with self.completed_events_lock:
+                self.completed_events[req_meta.event_id] = 1
+
+    def _put_batch(self, batch: KVCacheStoreBatch, prepared_requests: list[PreparedRequest]) -> None:
+        batch.committed.wait()
+        try:
+            has_data = any(prepared.stores for prepared in prepared_requests)
+            if batch.current_event is not None and has_data:
+                batch.current_event.synchronize()
+            for prepared in prepared_requests:
+                for store in prepared.stores:
+                    self.m_store.put(store.keys, store.addrs, store.sizes)
+                    if self.enable_kv_event and store.stored_events:
+                        self.update_kv_event(store.stored_events)
+        except Exception as error:
+            logger.exception("Failed to put AscendStore save batch %d", batch.sequence_id)
+            if batch.error is None:
+                batch.error = error
+        finally:
+            for prepared in prepared_requests:
+                self._complete_request(prepared.request)
+            self._remove_pending_batch(batch)
+            batch.done.set()
+
+    def _prepare_stored_request(
+        self,
+        req_meta: ReqMeta,
+        batch: KVCacheStoreBatch | None = None,
+    ) -> list[PreparedStore]:
         token_len = req_meta.token_len_chunk
         req_id = req_meta.req_id
-        current_event = req_meta.current_event
+        prepared_stores: list[PreparedStore] = []
         try:
             store_masks = self.token_database.store_mask(token_len, req_meta.num_prompt_tokens)
         except AssertionError as exc:
@@ -807,7 +1026,11 @@ class KVCacheStoreSendingThread(KVTransferThread):
 
             if not keys:
                 continue
-            exists_states = self.lookup(keys)
+            exists_states = [value == 1 for value in self.lookup_after_pending_saves(keys, exclude_batch=batch)]
+            if batch is not None and batch.pending_keys:
+                exists_states = [
+                    exists or key in batch.pending_keys for key, exists in zip(keys, exists_states, strict=True)
+                ]
             missing_indices = [index for index, exists in enumerate(exists_states) if not exists]
             if not missing_indices:
                 continue
@@ -886,11 +1109,15 @@ class KVCacheStoreSendingThread(KVTransferThread):
                     sizes,
                     kv_cache_group_id=group_id,
                 )
-            if current_event is not None:
-                current_event.synchronize()
-            self.m_store.put(keys, addrs, sizes)
-            if self.enable_kv_event and stored_events:
-                self.update_kv_event(stored_events)
+            prepared_stores.append(
+                PreparedStore(
+                    keys=keys,
+                    addrs=addrs,
+                    sizes=sizes,
+                    stored_events=stored_events,
+                )
+            )
+        return prepared_stores
 
 
 class KVCacheStoreRecvingThread(KVTransferThread):

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/kv_transfer.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/kv_transfer.py
@@ -889,10 +889,8 @@ class KVCacheStoreSendingThread(KVTransferThread):
                     self.m_store.put(store.keys, store.addrs, store.sizes)
                     if self.enable_kv_event and store.stored_events:
                         self.update_kv_event(store.stored_events)
-        except Exception as error:
+        except Exception:
             logger.exception("Failed to put AscendStore save batch")
-            if batch.error is None:
-                batch.error = error
         finally:
             for request, _ in prepared_requests:
                 self._complete_request(request)

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/kv_transfer.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/kv_transfer.py
@@ -889,8 +889,12 @@ class KVCacheStoreSendingThread(KVTransferThread):
                     self.m_store.put(store.keys, store.addrs, store.sizes)
                     if self.enable_kv_event and store.stored_events:
                         self.update_kv_event(store.stored_events)
-        except Exception:
-            logger.exception("Failed to put AscendStore save batch")
+        except Exception as error:
+            logger.exception(
+                "Failed to put AscendStore save batch. type=%s, error=%s",
+                type(error).__name__,
+                error,
+            )
         finally:
             for request, _ in prepared_requests:
                 self._complete_request(request)

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/kv_transfer.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/kv_transfer.py
@@ -723,27 +723,6 @@ class KVCacheStoreSendingThread(KVTransferThread):
                 raise RuntimeError("Preempted request reached an uncommitted AscendStore save batch")
             self.wait_for_batch(batch)
 
-    def lookup_after_pending_saves(
-        self,
-        keys: list[str],
-        exclude_batch: KVCacheStoreBatch | None = None,
-    ) -> list[int]:
-        """Fence only save batches that may publish one of ``keys``."""
-        observed: set[KVCacheStoreBatch] = set()
-        key_set = set(keys)
-        while True:
-            with self._pending_batches_lock:
-                batches = [
-                    batch for batch in self._pending_batches if batch is not exclude_batch and batch not in observed
-                ]
-                if not batches:
-                    return self.m_store.exists(keys)
-            for batch in batches:
-                batch.prepared.wait()
-                observed.add(batch)
-                if key_set & batch.pending_keys:
-                    self.wait_for_batch(batch)
-
     def _remove_pending_batch(self, batch: KVCacheStoreBatch) -> None:
         with self._pending_batches_lock:
             if batch in self._pending_batches:
@@ -997,7 +976,7 @@ class KVCacheStoreSendingThread(KVTransferThread):
 
             if not keys:
                 continue
-            exists_states = [value == 1 for value in self.lookup_after_pending_saves(keys, exclude_batch=batch)]
+            exists_states = self.lookup(keys)
             if batch is not None and batch.pending_keys:
                 exists_states = [
                     exists or key in batch.pending_keys for key, exists in zip(keys, exists_states, strict=True)

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/kv_transfer.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/kv_transfer.py
@@ -50,16 +50,14 @@ class PreparedStore:
 PreparedRequest = tuple[ReqMeta, list[PreparedStore]]
 
 
-@dataclass(eq=False)
+@dataclass
 class KVCacheStoreBatch:
     requests: list[ReqMeta]
     force_current_step: bool = False
-    prepared: threading.Event = field(default_factory=threading.Event)
     committed: threading.Event = field(default_factory=threading.Event)
     done: threading.Event = field(default_factory=threading.Event)
     current_event: Any = None
     pending_keys: set[str] = field(default_factory=set)
-    error: BaseException | None = None
 
 
 class LayerBatchBuilder:
@@ -677,8 +675,6 @@ class KVCacheStoreSendingThread(KVTransferThread):
         self.completed_events_lock = threading.Lock()
         self.completed_events: dict[int, int] = {}
         self.worker = worker
-        self._pending_batches: list[KVCacheStoreBatch] = []
-        self._pending_batches_lock = threading.Lock()
         self.put_thread = KVCacheStorePutThread(self)
 
     def run(self):
@@ -694,8 +690,6 @@ class KVCacheStoreSendingThread(KVTransferThread):
         batch = KVCacheStoreBatch(requests=requests, force_current_step=force_current_step)
         for request in requests:
             self.add_stored_request(request.req_id)
-        with self._pending_batches_lock:
-            self._pending_batches.append(batch)
         self.add_request(batch)  # type: ignore[arg-type]
         return batch
 
@@ -708,32 +702,6 @@ class KVCacheStoreSendingThread(KVTransferThread):
         while not batch.done.wait(timeout=1.0):
             self.raise_if_failed()
             self.put_thread.raise_if_failed()
-        if batch.error is not None:
-            raise RuntimeError("AscendStore save batch failed") from batch.error
-
-    def wait_for_requests(self, req_ids: set[str]) -> None:
-        if not req_ids:
-            return
-        with self._pending_batches_lock:
-            batches = [
-                batch for batch in self._pending_batches if any(request.req_id in req_ids for request in batch.requests)
-            ]
-        for batch in batches:
-            if not batch.committed.is_set():
-                raise RuntimeError("Preempted request reached an uncommitted AscendStore save batch")
-            self.wait_for_batch(batch)
-
-    def _remove_pending_batch(self, batch: KVCacheStoreBatch) -> None:
-        with self._pending_batches_lock:
-            if batch in self._pending_batches:
-                self._pending_batches.remove(batch)
-
-    def _fail_batch(self, batch: KVCacheStoreBatch, error: BaseException) -> None:
-        if batch.error is None:
-            batch.error = error
-        batch.prepared.set()
-        self._remove_pending_batch(batch)
-        batch.done.set()
 
     def add_stored_request(self, req_id: str):
         with self.done_task_lock:
@@ -791,21 +759,13 @@ class KVCacheStoreSendingThread(KVTransferThread):
             for request in batch.requests:
                 try:
                     stores = self._prepare_stored_request(request, batch)
-                except Exception as error:
+                except Exception:
                     logger.exception("Failed to prepare KV cache save for request %s", request.req_id)
-                    if batch.error is None:
-                        batch.error = error
                     stores = []
                 prepared_requests.append((request, stores))
                 for store in stores:
                     batch.pending_keys.update(store.keys)
-            batch.prepared.set()
             self.put_thread.add_request((batch, prepared_requests))  # type: ignore[arg-type]
-        except Exception as error:
-            logger.exception("Failed to prepare AscendStore save batch")
-            for request in batch.requests:
-                self._complete_request(request)
-            self._fail_batch(batch, error)
         finally:
             self.request_queue.task_done()
 
@@ -877,7 +837,6 @@ class KVCacheStoreSendingThread(KVTransferThread):
         finally:
             for request, _ in prepared_requests:
                 self._complete_request(request)
-            self._remove_pending_batch(batch)
             batch.done.set()
 
     def _prepare_stored_request(

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/pool_worker.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/pool_worker.py
@@ -52,6 +52,7 @@ from vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.coordinator import
     ExternalCachedBlockPool,
 )
 from vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.kv_transfer import (
+    KVCacheStoreBatch,
     KVCacheStoreKeyLayerRecvingThread,
     KVCacheStoreKeyLayerSendingThread,
     KVCacheStoreLayerRecvingThread,
@@ -332,6 +333,8 @@ class KVPoolWorker:
         self.kv_send_thread: KVTransferThread | None = None
         self.kv_recv_thread: KVTransferThread | None = None
         self._transfer_threads_started = False
+        self._prepared_save_batch: KVCacheStoreBatch | None = None
+        self._previous_save_batch: KVCacheStoreBatch | None = None
         self.external_slot_release_waiter: Callable[[int], None] | None = None
         # Per-rank GVA cache: maps per-rank store key to its allocated GVA.
         # batch_alloc is non-idempotent (returns MMC_DUPLICATED_OBJECT for an
@@ -1759,7 +1762,38 @@ class KVPoolWorker:
 
         self.current_layer = self.current_layer + 1
 
-    def wait_for_save(self, connector_metadata: AscendConnectorMetadata):
+    def _requires_current_step_save_fence(self, request: ReqMeta) -> bool:
+        if request.partial_block_index is not None:
+            return True
+        for group_id in request.kv_cache_group_ids or [0]:
+            if request.save_end_token % self._get_effective_group_block_size(group_id) != 0:
+                return True
+        return False
+
+    def prepare_save(self, connector_metadata: AscendConnectorMetadata) -> None:
+        """Submit key/exists/address preparation before model forward."""
+        if self.use_layerwise or self.tp_mismatch:
+            return
+        if self.kv_role == "kv_consumer" and not self.consumer_is_to_put:
+            return
+        if self._prepared_save_batch is not None:
+            raise RuntimeError("AscendStore save batch was prepared twice without a commit")
+        if not isinstance(self.kv_send_thread, KVCacheStoreSendingThread):
+            return
+
+        self.kv_send_thread.raise_if_failed()
+        requests = [request for request in connector_metadata.requests if request.can_save]
+        if not requests:
+            return
+        for request in requests:
+            request.skip_null_blocks_by_group = self.group_uses_align_state
+        force_current_step = any(self._requires_current_step_save_fence(request) for request in requests)
+        self._prepared_save_batch = self.kv_send_thread.prepare_save_batch(
+            requests,
+            force_current_step=force_current_step,
+        )
+
+    def _wait_for_save_tp_mismatch(self, connector_metadata: AscendConnectorMetadata) -> None:
         current_event = None
         assert self.kv_send_thread is not None
         send_thread = self.kv_send_thread
@@ -1778,6 +1812,36 @@ class KVPoolWorker:
 
         if current_event is not None:
             send_thread.request_queue.join()
+
+    def wait_for_save(self, connector_metadata: AscendConnectorMetadata) -> None:
+        if self.tp_mismatch:
+            self._wait_for_save_tp_mismatch(connector_metadata)
+            return
+        if self.use_layerwise:
+            return
+        if not isinstance(self.kv_send_thread, KVCacheStoreSendingThread):
+            return
+
+        if self._prepared_save_batch is None:
+            self.prepare_save(connector_metadata)
+
+        current_batch = self._prepared_save_batch
+        self._prepared_save_batch = None
+        previous_batch = self._previous_save_batch
+
+        if current_batch is not None:
+            current_event = torch.npu.Event()
+            current_event.record()
+            self.kv_send_thread.commit_save_batch(current_batch, current_event)
+
+        if previous_batch is not None:
+            self.kv_send_thread.wait_for_batch(previous_batch)
+
+        if current_batch is not None and current_batch.force_current_step:
+            self.kv_send_thread.wait_for_batch(current_batch)
+            self._previous_save_batch = None
+        else:
+            self._previous_save_batch = current_batch
 
     def retrieve_layer(
         self,
@@ -2115,10 +2179,21 @@ class KVPoolWorker:
         )
         return done_sending, done_recving
 
+    def wait_for_preempted_saves(self, req_ids: set[str]) -> None:
+        """Fence saves whose source KV blocks are about to be reused."""
+        if isinstance(self.kv_send_thread, KVCacheStoreSendingThread):
+            self.kv_send_thread.wait_for_requests(req_ids)
+
     def ensure_store_initialized(self) -> None:
         ensure_initialized = getattr(self.m_store, "ensure_initialized", None)
         if ensure_initialized is not None:
             ensure_initialized()
+
+    def _exists_after_save_fence(self, keys: list[str]) -> list[int]:
+        send_thread = getattr(self, "kv_send_thread", None)
+        if isinstance(send_thread, KVCacheStoreSendingThread):
+            return send_thread.lookup_after_pending_saves(keys)
+        return self.m_store.exists(keys)
 
     def _build_lookup_keys(
         self,
@@ -2177,7 +2252,7 @@ class KVPoolWorker:
                     hits.append(0)
                     continue
 
-                res = self.m_store.exists(keys)  # type: ignore[assignment]
+                res = self._exists_after_save_fence(keys)
 
                 if use_layerwise:
                     res = self.check_all_layers_exists(res, self.num_layers)
@@ -2313,7 +2388,7 @@ class KVPoolWorker:
 
             if not keys:
                 continue
-            res = self.m_store.exists(keys)  # type: ignore[assignment]
+            res = self._exists_after_save_fence(keys)
             offset = 0
             for chunk_hash, count in zip(chunk_hashes, variant_counts, strict=True):
                 values = res[offset : offset + count]  # type: ignore[index]
@@ -2380,7 +2455,7 @@ class KVPoolWorker:
 
                 multi_tp_keys = self._expand_lookup_keys_by_rank(keys, group_id)
                 num_ranks = len(multi_tp_keys) // len(keys)
-                res = self.m_store.exists(multi_tp_keys)  # type: ignore[assignment]
+                res = self._exists_after_save_fence(multi_tp_keys)
                 num_block = len(keys)
                 if use_layerwise:
                     res = self.check_all_layers_exists(res, self.num_layers)

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/pool_worker.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/pool_worker.py
@@ -2182,12 +2182,6 @@ class KVPoolWorker:
         if ensure_initialized is not None:
             ensure_initialized()
 
-    def _exists_after_save_fence(self, keys: list[str]) -> list[int]:
-        send_thread = getattr(self, "kv_send_thread", None)
-        if isinstance(send_thread, KVCacheStoreSendingThread):
-            return send_thread.lookup_after_pending_saves(keys)
-        return self.m_store.exists(keys)
-
     def _build_lookup_keys(
         self,
         token_len: int,
@@ -2245,7 +2239,7 @@ class KVPoolWorker:
                     hits.append(0)
                     continue
 
-                res = self._exists_after_save_fence(keys)
+                res = self.m_store.exists(keys)
 
                 if use_layerwise:
                     res = self.check_all_layers_exists(res, self.num_layers)
@@ -2381,7 +2375,7 @@ class KVPoolWorker:
 
             if not keys:
                 continue
-            res = self._exists_after_save_fence(keys)
+            res = self.m_store.exists(keys)
             offset = 0
             for chunk_hash, count in zip(chunk_hashes, variant_counts, strict=True):
                 values = res[offset : offset + count]  # type: ignore[index]
@@ -2448,7 +2442,7 @@ class KVPoolWorker:
 
                 multi_tp_keys = self._expand_lookup_keys_by_rank(keys, group_id)
                 num_ranks = len(multi_tp_keys) // len(keys)
-                res = self._exists_after_save_fence(multi_tp_keys)
+                res = self.m_store.exists(multi_tp_keys)
                 num_block = len(keys)
                 if use_layerwise:
                     res = self.check_all_layers_exists(res, self.num_layers)

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/pool_worker.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/pool_worker.py
@@ -1815,9 +1815,6 @@ class KVPoolWorker:
         if not isinstance(self.kv_send_thread, KVCacheStoreSendingThread):
             return
 
-        if self._prepared_save_batch is None:
-            self.prepare_save(connector_metadata)
-
         current_batch = self._prepared_save_batch
         self._prepared_save_batch = None
         previous_batch = self._previous_save_batch
@@ -2174,8 +2171,14 @@ class KVPoolWorker:
 
     def wait_for_preempted_saves(self, req_ids: set[str]) -> None:
         """Fence saves whose source KV blocks are about to be reused."""
-        if isinstance(self.kv_send_thread, KVCacheStoreSendingThread):
-            self.kv_send_thread.wait_for_requests(req_ids)
+        batch = self._previous_save_batch
+        if (
+            isinstance(self.kv_send_thread, KVCacheStoreSendingThread)
+            and batch is not None
+            and any(request.req_id in req_ids for request in batch.requests)
+        ):
+            self.kv_send_thread.wait_for_batch(batch)
+            self._previous_save_batch = None
 
     def ensure_store_initialized(self) -> None:
         ensure_initialized = getattr(self.m_store, "ensure_initialized", None)

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/pool_worker.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/pool_worker.py
@@ -1793,29 +1793,22 @@ class KVPoolWorker:
             force_current_step=force_current_step,
         )
 
-    def _wait_for_save_tp_mismatch(self, connector_metadata: AscendConnectorMetadata) -> None:
-        current_event = None
-        assert self.kv_send_thread is not None
-        send_thread = self.kv_send_thread
-
-        for request in connector_metadata.requests:
-            can_save = request.can_save
-            if can_save is None or not can_save:
-                continue
-            if current_event is None:
-                current_event = torch.npu.Event()
-                current_event.record()
-            request.skip_null_blocks_by_group = self.group_uses_align_state
-            request.current_event = current_event
-            send_thread.add_stored_request(request.req_id)
-            send_thread.add_request(request)
-
-        if current_event is not None:
-            send_thread.request_queue.join()
-
     def wait_for_save(self, connector_metadata: AscendConnectorMetadata) -> None:
         if self.tp_mismatch:
-            self._wait_for_save_tp_mismatch(connector_metadata)
+            current_event = None
+            assert self.kv_send_thread is not None
+            for request in connector_metadata.requests:
+                if not request.can_save:
+                    continue
+                if current_event is None:
+                    current_event = torch.npu.Event()
+                    current_event.record()
+                request.skip_null_blocks_by_group = self.group_uses_align_state
+                request.current_event = current_event
+                self.kv_send_thread.add_stored_request(request.req_id)
+                self.kv_send_thread.add_request(request)
+            if current_event is not None:
+                self.kv_send_thread.request_queue.join()
             return
         if self.use_layerwise:
             return


### PR DESCRIPTION
### What this PR does / why we need it?

AscendStore currently performs key construction, existence checks, address preparation, NPU synchronization, and backend puts at the end of `wait_for_save`. This exposes the entire save path after target-model and MTP forward.

This change:

- submits CPU-side key construction, existence checks, and value/address preparation before target-model and deferred MTP forward;
- moves NPU-dependent backend puts to a dedicated put thread;
- pipelines puts by one model step, so step N fences batch N-1 instead of globally joining the current send queue;
- keeps partial-block saves on a current-step fence;
- fences the matching previous batch for preemption while ordinary lookups remain non-blocking;
- deduplicates identical keys within a save batch and keeps prepare/backend put failures non-fatal.

Layerwise and TP-mismatch saves retain their existing synchronous behavior.

### Does this PR introduce _any_ user-facing change?

No API or configuration change. AscendStore save scheduling changes internally to reduce exposed step-tail latency.

### How was this patch tested?

- `python -m pytest -q tests/ut/distributed/ascend_store`: 400 passed, 10 skipped.
- `ws-verify --repo <worktree> hooks`: all hooks passed.
- Added unit coverage for pre-forward preparation, one-step fencing, partial saves, preemption, duplicate keys, and failure cleanup.

NPU performance and end-to-end accuracy validation require an Ascend runner and are left to hardware CI.

- vLLM version: v0.26.0
- vLLM main: https://github.com/vllm-project/vllm/commit/d02df748bf9efd99022f1a062597dc3cb3808485
