### PR TITLE
[BugFix][Attention] Honor non-causal metadata in FULL FIA with a sliding window

### DIFF
--- a/tests/ut/attention/test_attention_v1.py
+++ b/tests/ut/attention/test_attention_v1.py
@@ -51,6 +51,20 @@ class TestAttentionGraphHelpers(TestBase):
         self.assertEqual(result.numel(), 8)
         self.assertEqual(graph_params.workspaces[1].numel(), 8)
 
+    def test_full_graph_fia_sparse_config_follows_causality(self):
+        cases = (
+            (False, None, (0, attn_module.SWA_INT_MAX, attn_module.SWA_INT_MAX)),
+            (False, 0, (0, attn_module.SWA_INT_MAX, attn_module.SWA_INT_MAX)),
+            (False, 2048, (0, attn_module.SWA_INT_MAX, attn_module.SWA_INT_MAX)),
+            (True, 2048, (4, 2048, 0)),
+            (True, 0, (3, attn_module.SWA_INT_MAX, attn_module.SWA_INT_MAX)),
+            (True, None, (3, attn_module.SWA_INT_MAX, attn_module.SWA_INT_MAX)),
+        )
+
+        for causal, sliding_window, expected in cases:
+            with self.subTest(causal=causal, sliding_window=sliding_window):
+                self.assertEqual(attn_module._get_full_graph_fia_sparse_config(causal, sliding_window), expected)
+
     def test_large_head_uses_paged_attention_on_a2(self):
         vllm_config = MagicMock()
         vllm_config.speculative_config = None

--- a/vllm_ascend/attention/attention_v1.py
+++ b/vllm_ascend/attention/attention_v1.py
@@ -75,6 +75,16 @@ SWA_INT_MAX = 2147483647
 _ATTN_KEYS_BUFFER = None
 
 
+def _get_full_graph_fia_sparse_config(causal: bool, sliding_window: int | None) -> tuple[int, int, int]:
+    if not causal:
+        return 0, SWA_INT_MAX, SWA_INT_MAX
+
+    if sliding_window:
+        return 4, sliding_window, 0
+
+    return 3, SWA_INT_MAX, SWA_INT_MAX
+
+
 @register_backend(AttentionBackendEnum.CUSTOM, "ASCEND")
 class AscendAttentionBackend(AttentionBackend):
     accept_output_buffer: bool = True
@@ -916,9 +926,9 @@ class AscendAttentionBackendImpl(AttentionImpl):
         softmax_lse = torch.empty(1, dtype=query.dtype, device=query.device)
         input_layout = "TND"
         attn_mask = attn_metadata.attn_mask
-        sparse_mode = 4 if self.sliding_window else 3 if attn_metadata.causal else 0
-        pre_tokens = self.sliding_window or SWA_INT_MAX
-        next_tokens = 0 if self.sliding_window else SWA_INT_MAX
+        sparse_mode, pre_tokens, next_tokens = _get_full_graph_fia_sparse_config(
+            attn_metadata.causal, self.sliding_window
+        )
 
         extra_args = {}
         if self.enable_c8_quant and layer is not None:


### PR DESCRIPTION
### What this PR does / why we need it?

`full_graph_fia()` currently prioritizes `self.sliding_window` over `attn_metadata.causal`. A non-causal draft layer with a configured window therefore selects sparse mode 4 with `next_tokens=0`, unlike the eager non-causal path. On the tested Ascend A2 configuration, the missing attention mask also results in `sparseMode must be 0`.

This change selects the non-causal configuration first: sparse mode 0 with unrestricted backward/forward windows. It preserves both causal branches, including the existing interpretation of a zero window as disabled. A small helper makes all six combinations of causality and positive/zero/absent window directly testable.

Only the attention implementation and its regression test are changed.

### Does this PR introduce _any_ user-facing change?

It corrects the affected non-causal FULL graph attention path. No CLI option, model parameter or causal attention behavior changes. This is not a complete fix for every DFlash2 hybrid-cache or prefix-state issue.

### How was this patch tested?

The regression is in:

```bash
pytest -q tests/ut/attention/a2/test_attention_v1.py
```

- `bash format.sh ci` passed locally with the repository-pinned `pre-commit==4.0.1`, including secret scanning. No unrelated files were changed by the checks.
- The exact changed implementation/test files were included in a 104-test suite covering the complete attention, model-runner and GDN modules; all passed in a freshly rebuilt Ascend image. The count is for the combined suite, not this file alone.
- Built and tested Ascend base: `72059e41b239e2ea469a0fb2d9eb0cb7ee4e3085`; vLLM: `ba07e4a48fc951300d97eb506217dd530583dea3`. Full Ascend sources and custom extensions were rebuilt; installed imports and source hashes were checked, with no source overlays.
- Hardware/configuration: 2 × Ascend 910B3 64GB, Qwen3.8-27B + DFlash2, TP2/C1, BF16 weights, FP32 Mamba state, K7/block8, `FULL_DECODE_ONLY` with capture size 8, explicit synchronous scheduling, draft window 2048 and prefix caching enabled.
- Integrated serving passed cold/prime/first-hot checks, natural 64K/128K requests, fixed and natural multimodal 5×2 grids, public GSM8K 10/300 questions, plain-text and streaming/nonstreaming tool-call checks, and the 262144-token success/overflow boundary.
- Public300 used the first five training examples and first 300 test questions from GSM8K revision `3101c7d5072418e28b9008a6636bde82a006892c`, T=0, seed42, no thinking, max512, natural EOS and same-request one-token priming. All outputs and speculative metrics matched the frozen optimized reference: 288/300 correct, the same 12 wrong answers and two capped responses.

The serving checks used a combined integration stack with separate hybrid-layout, zeroer/H2D and Mamba-snapshot safeguards, plus a separately evaluated GDN metadata candidate. Those changes are **not included in this PR**; the integration result is not an isolated speedup claim for this patch. No C4/async correctness claim is made. Private request texts and container logs are not attached.

### Related work

- #9654 propagates a drafter's causal setting but does not repair FULL FIA sparse-mode precedence.
- #12993 touches the same area with different semantics: it supplies a band mask for SWA and retains mode 4 even for non-causal draft metadata. This PR instead honors the non-causal flag and retains mode 4 only for causal sliding-window attention. These approaches should not be silently combined as equivalent fixes.

The current main checked before submission was `933737c9e7f4903c613d65b7cb6fcd046f64dfd3`; the implementation and test files in this PR were unchanged between that revision and the tested base.

- vLLM main: https://github.com/vllm-project/vllm/commit/ba07e4a48fc951300d97eb506217dd530583dea3
