### PR TITLE
[BugFix][Worker] Align compatible Full/SWA logical blocks in hybrid caches

### DIFF
--- a/tests/ut/worker/test_model_runner_v1.py
+++ b/tests/ut/worker/test_model_runner_v1.py
@@ -1,6 +1,7 @@
 import unittest
 from collections import deque
 from contextlib import nullcontext
+from dataclasses import replace
 from types import SimpleNamespace
 from unittest.mock import MagicMock, call, patch
 
@@ -19,6 +20,7 @@ from vllm.v1.kv_cache_interface import (
     KVCacheTensor,
     MambaSpec,
     MLAAttentionSpec,
+    SlidingWindowSpec,
     UniformTypeKVCacheSpecs,
 )
 from vllm.v1.utils import CpuGpuBuffer
@@ -31,6 +33,7 @@ from vllm_ascend.core.kv_cache_interface import (
     AscendIndexerKPoolStateSpec,
     AscendMLAAttentionSpec,
     AscendSFAIndexerCacheSpec,
+    AscendSlidingWindowMLASpec,
 )
 from vllm_ascend.device.hardware_profile import get_hardware_profile
 from vllm_ascend.models.glm5next.kv_cache import (
@@ -41,7 +44,7 @@ from vllm_ascend.patch.platform.patch_kv_cache_utils import (
     _get_kv_cache_config_deepseek_v4_main,
 )
 from vllm_ascend.utils import AscendDeviceType, vllm_version_is
-from vllm_ascend.worker.model_runner_v1 import NPUModelRunner
+from vllm_ascend.worker.model_runner_v1 import NPUModelRunner, _align_hybrid_sliding_window_block_sizes
 
 
 class TestDummyRunSlotInvalidation(unittest.TestCase):
@@ -390,6 +393,194 @@ def _ratio_kwargs(ratio: int) -> dict[str, int]:
 
 
 class TestNPUModelRunnerKVCache(unittest.TestCase):
+    def _hybrid_swa_specs(self):
+        return {
+            "full": FullAttentionSpec(
+                block_size=1536,
+                num_kv_heads=1,
+                head_size=1,
+                head_size_v=1,
+                dtype=torch.bfloat16,
+                page_size_padded=8192,
+            ),
+            "swa": SlidingWindowSpec(
+                block_size=128,
+                num_kv_heads=1,
+                head_size=1,
+                dtype=torch.bfloat16,
+                sliding_window=2048,
+                extra_retained_tokens=16,
+                page_size_padded=8192,
+            ),
+            "mamba": MambaSpec(
+                block_size=1536,
+                shapes=((1,), (1,)),
+                dtypes=(torch.bfloat16, torch.float32),
+                page_size_padded=8192,
+            ),
+        }
+
+    def test_hybrid_swa_aligns_logical_block_not_attention_window(self):
+        specs = self._hybrid_swa_specs()
+        original = specs.copy()
+        _align_hybrid_sliding_window_block_sizes(specs)
+        self.assertEqual(specs["swa"].block_size, 1536)
+        self.assertEqual(specs["swa"].sliding_window, 2048)
+        self.assertEqual(specs["swa"].extra_retained_tokens, 16)
+        self.assertEqual(specs["swa"].page_size_padded, 8192)
+        self.assertEqual(original["swa"].block_size, 128)
+        self.assertIs(specs["full"], original["full"])
+        self.assertIs(specs["mamba"], original["mamba"])
+        aligned = specs["swa"]
+        _align_hybrid_sliding_window_block_sizes(specs)
+        self.assertIs(specs["swa"], aligned)
+
+    def test_hybrid_swa_without_mamba_is_unchanged(self):
+        specs = self._hybrid_swa_specs()
+        del specs["mamba"]
+        original = specs["swa"]
+        _align_hybrid_sliding_window_block_sizes(specs)
+        self.assertIs(specs["swa"], original)
+
+    def test_hybrid_swa_specialized_attention_specs_are_unchanged(self):
+        specialized_specs = (
+            (
+                "full",
+                AscendMLAAttentionSpec(
+                    block_size=1536,
+                    num_kv_heads=1,
+                    head_size=1,
+                    dtype=torch.bfloat16,
+                    page_size_padded=8192,
+                ),
+            ),
+            (
+                "full",
+                AscendSFAIndexerCacheSpec(
+                    block_size=1536,
+                    num_kv_heads=1,
+                    head_size=1,
+                    dtype=torch.bfloat16,
+                    page_size_padded=8192,
+                ),
+            ),
+            (
+                "swa",
+                AscendSlidingWindowMLASpec(
+                    block_size=128,
+                    num_kv_heads=1,
+                    head_size=1,
+                    dtype=torch.bfloat16,
+                    sliding_window=2048,
+                    page_size_padded=8192,
+                ),
+            ),
+        )
+
+        for name, specialized_spec in specialized_specs:
+            with self.subTest(spec_type=type(specialized_spec).__name__):
+                specs = self._hybrid_swa_specs()
+                specs[name] = specialized_spec
+                original_swa = specs["swa"]
+                _align_hybrid_sliding_window_block_sizes(specs)
+                self.assertIs(specs["swa"], original_swa)
+
+    def test_hybrid_swa_matches_equal_kv_width_with_different_head_shapes(self):
+        # Qwen3.8-27B / DFlash2 with TP2: both store 512 K and V values
+        # per token, despite different head counts and head dimensions.
+        specs = self._hybrid_swa_specs()
+        specs["full"] = replace(
+            specs["full"], num_kv_heads=2, head_size=256, head_size_v=256, page_size_padded=4 * 1024**2
+        )
+        specs["swa"] = replace(
+            specs["swa"], num_kv_heads=4, head_size=128, head_size_v=128, page_size_padded=4 * 1024**2
+        )
+        _align_hybrid_sliding_window_block_sizes(specs)
+        self.assertEqual(specs["swa"].block_size, 1536)
+        self.assertEqual(specs["swa"].num_kv_heads, 4)
+        self.assertEqual(specs["swa"].head_size, 128)
+        self.assertEqual(specs["swa"].sliding_window, 2048)
+
+    def test_hybrid_swa_does_not_match_different_value_width(self):
+        specs = self._hybrid_swa_specs()
+        specs["full"] = replace(specs["full"], head_size_v=2)
+        original = specs["swa"]
+        _align_hybrid_sliding_window_block_sizes(specs)
+        self.assertIs(specs["swa"], original)
+
+    def test_hybrid_swa_does_not_match_other_dense_layouts(self):
+        for changes in (
+            {"num_kv_heads": 2},
+            {"head_size": 2},
+            {"dtype": torch.float32},
+            {"block_size": 1024},
+            {"block_size": 3072},
+        ):
+            with self.subTest(changes=changes):
+                specs = self._hybrid_swa_specs()
+                specs["swa"] = replace(specs["swa"], **changes)
+                original = specs["swa"]
+                _align_hybrid_sliding_window_block_sizes(specs)
+                self.assertIs(specs["swa"], original)
+
+    def test_hybrid_swa_ambiguous_full_block_width_is_unchanged(self):
+        specs = self._hybrid_swa_specs()
+        specs["other_full"] = replace(specs["full"], block_size=1024)
+        original = specs["swa"]
+        _align_hybrid_sliding_window_block_sizes(specs)
+        self.assertIs(specs["swa"], original)
+
+    @patch("vllm_ascend.worker.model_runner_v1.enable_fa_quant", return_value=False)
+    def test_hybrid_swa_distinct_pool_blocks_do_not_alias(self, _mock_quant):
+        runner = self._build_runner()
+        runner.use_hybrid_blocks = True
+        runner.hybrid_with_attn_and_mamba = True
+        runner.attn_backend.get_supported_kernel_block_sizes.return_value = [128]
+        specs = self._hybrid_swa_specs()
+        # Scaled target/draft geometries have equal flat K/V widths but
+        # different head shapes, as in the actual TP2 deployment.
+        specs["full"] = replace(specs["full"], head_size=2, head_size_v=2, page_size_padded=16384)
+        specs["swa"] = replace(specs["swa"], num_kv_heads=2, page_size_padded=16384)
+        specs["mamba"] = replace(specs["mamba"], page_size_padded=16384)
+        _align_hybrid_sliding_window_block_sizes(specs)
+        groups = [
+            SimpleNamespace(
+                kv_cache_spec=specs[name],
+                backend=runner.attn_backend,
+                layer_names=[name],
+            )
+            for name in ("full", "swa")
+        ]
+        runner._kv_cache_spec_attn_group_iterator = lambda: iter(groups)
+        runner._get_layer_kv_cache_specs = lambda config: specs
+        # Exercise the real allocator as well as the reshaper: main now uses
+        # one descriptor per group into a standardized shared backing.
+        num_blocks = 24
+        page_size = specs["full"].page_size_bytes
+        layer_size = num_blocks * page_size
+        descriptor_layers = [list(specs)] if vllm_version_is("0.28.0") else [[name] for name in specs]
+        config = KVCacheConfig(
+            num_blocks=num_blocks,
+            kv_cache_tensors=[_make_kv_cache_tensor(layer_size, names, page_size) for names in descriptor_layers],
+            kv_cache_groups=[KVCacheGroupSpec(layer_names=[name], kv_cache_spec=spec) for name, spec in specs.items()],
+        )
+        runner.vllm_config.cache_config.get_resolved_kv_cache_layout.return_value = SimpleNamespace(
+            is_layer_compact=True, is_block_compact=True
+        )
+        raw_caches = runner._allocate_kv_cache_tensors(config)
+        self.assertEqual(len({raw.untyped_storage().data_ptr() for raw in raw_caches.values()}), 1)
+        self.assertEqual(raw_caches["full"].storage_offset(), raw_caches["swa"].storage_offset())
+        caches = runner._reshape_kv_cache_tensors(
+            config,
+            raw_caches,
+        )
+        # Global pool IDs 20 and 0 may be simultaneously owned by different
+        # cache groups. The old 128-token SWA view overlapped these two IDs.
+        caches["full"][1][20 * 12 : 21 * 12].fill_(7)
+        self.assertEqual(torch.count_nonzero(caches["swa"][0][:12]).item(), 0)
+        self.assertEqual(caches["full"][0].data_ptr(), caches["swa"][0].data_ptr())
+        self.assertEqual(caches["full"][1].data_ptr(), caches["swa"][1].data_ptr())
+
     def _build_runner(self):
         runner = NPUModelRunner.__new__(NPUModelRunner)
         runner.device = torch.device("cpu")

--- a/vllm_ascend/worker/model_runner_v1.py
+++ b/vllm_ascend/worker/model_runner_v1.py
@@ -77,11 +77,13 @@ from vllm.v1.core.sched.output import SchedulerOutput
 from vllm.v1.kv_cache_interface import (
     AttentionSpec,
     EncoderOnlyAttentionSpec,
+    FullAttentionSpec,
     HiddenStateCacheSpec,
     KVCacheConfig,
     KVCacheGroupSpec,
     KVCacheSpec,
     MambaSpec,
+    SlidingWindowSpec,
     UniformTypeKVCacheSpecs,
 )
 from vllm.v1.outputs import (
@@ -5710,6 +5712,7 @@ class NPUModelRunner(GPUModelRunner):
                 if spec := mamba_module.get_kv_cache_spec(self.vllm_config):
                     kv_cache_spec[layer_name] = spec
                     mamba_page_size_padded = spec.page_size_bytes
+            _align_hybrid_sliding_window_block_sizes(kv_cache_spec)
             # align attn_page_size to mamba_page_size_padded
             for layer_name in attn_layer_names:
                 if kv_cache_spec[layer_name].page_size_bytes < mamba_page_size_padded:  # type: ignore[attr-defined]
@@ -5854,6 +5857,46 @@ class NPUModelRunner(GPUModelRunner):
             runner_only_attn_layers=self.runner_only_attn_layers,
             static_forward_context=(self.compilation_config.static_forward_context),
         )
+
+
+def _align_hybrid_sliding_window_block_sizes(specs: dict[str, KVCacheSpec]) -> None:
+    """Keep dense SWA and full-attention pages on the same hybrid byte layout.
+
+    Ascend stores hybrid caches as contiguous conv/K/V columns, rather than
+    interleaving the components of each logical page. Padding page_size_bytes
+    alone therefore cannot make different K/V block strides safe to share:
+    a full-attention block can overlap a *different* SWA block ID. Match the
+    logical block width when the two dense attention formats have the same
+    per-token K/V widths. Head counts and dimensions may factor differently.
+    The backend still splits these pages into its supported kernel blocks.
+    """
+    if not any(isinstance(spec, MambaSpec) for spec in specs.values()):
+        return
+
+    def layout_key(spec: AttentionSpec) -> tuple:
+        return (
+            spec.num_kv_heads * spec.head_size,
+            spec.num_kv_heads * (getattr(spec, "head_size_v", None) or spec.head_size),
+            spec.dtype,
+            getattr(spec, "cache_dtype_str", None),
+            getattr(spec, "kv_quant_mode", None),
+        )
+
+    full_block_sizes: dict[tuple, set[int]] = defaultdict(set)
+    for spec in specs.values():
+        # Restrict this helper to the exact dense layouts validated below.
+        # MLA and other subclasses can use different physical cache layouts.
+        if type(spec) is FullAttentionSpec:
+            full_block_sizes[layout_key(spec)].add(spec.block_size)
+    for name, spec in specs.items():
+        if type(spec) is not SlidingWindowSpec:
+            continue
+        matching = full_block_sizes.get(layout_key(spec), set())
+        if len(matching) != 1:
+            continue
+        block_size = next(iter(matching))
+        if block_size > spec.block_size and block_size % spec.block_size == 0:
+            specs[name] = replace(spec, block_size=block_size)
 
 
 def _post_process_cudagraph_mode(tensor: torch.Tensor) -> int:


### PR DESCRIPTION
### What this PR does / why we need it?

Ascend's hybrid cache reshaper stores contiguous conv/K/V columns, while cache groups share backing buffers by logical pool block ID. Equal padded `page_size_bytes` alone does not make different K/V block strides safe: a write by one group can overlap a different, simultaneously live pool ID owned by another group.

The observed Qwen3.8-27B/DFlash2 TP2 geometry uses full-attention blocks of 1536 tokens with `2×256` K/V values per token, and draft SWA blocks of 128 tokens with `4×128` values. The flattened widths match, but the logical strides do not. A CPU probe using the actual reshaper reproduced a target V write at pool ID 20 changing 65,536 BF16 draft K elements at pool ID 0; aligning the logical widths eliminates this overlap.

For Mamba hybrid configurations, align a dense SWA logical block width to an unambiguous larger, divisible FullAttention width only when flattened K/V dimensions, dtype and quantization layout match. Preserve the attention window, retained-token policy and existing kernel-block splitting. Specialized layouts, mismatches and ambiguous full-attention widths are unchanged.

Only the model-runner implementation and its regression tests are changed.

### Does this PR introduce _any_ user-facing change?

It prevents cross-group corruption for the compatible dense hybrid layout and can change logical cache-allocation granularity. It does not increase the attention window or speculative K. Unsupported layouts are not claimed to be repaired.

### How was this patch tested?

#### Current rebase validation (2026-09-10)

Patch commit: `52a822a4f0fe2a2c10b554809524b136252cf91d`, rebased onto Ascend `5e062cbc85c3c9a1dc6297eb31c4884e9a660e1b`, with the base's verified vLLM main `b2f685834a6456197e7033966fdef52a23f1abcd`.

- Resolved the import conflict with GLM-Next KV management (#15913), retaining its MLA/indexer imports and tests. Preserved current upstream runner behavior and migrated the tests from `tests/ut/worker/a2/` into `tests/ut/worker/`. The cross-pool regression now exercises the real allocator and reshaper through the current standardized KV descriptors, with the existing descriptor helper preserving the v0.28.0 lane.
- `python3 -m pytest -q tests/ut/worker/test_model_runner_v1.py`: **56 passed**, no failures or skips. This is the complete module count, including the eight regression tests, not 56 new tests.
- A separate model-free NPU probe using the same allocator/reshaper and full TP2 geometry passed both cases. FullAttention uses 1536 tokens with 2x256 K/V values, SWA initially uses 128 tokens with 4x128 values, and 24 shared pages of 4 MiB are allocated on one Ascend 910B3. Writing Full V at pool ID 20 overwrites **65,536 BF16 SWA K elements at pool ID 0 with alignment disabled**, and **zero with alignment enabled**. The SWA logical block becomes 1536 while its attention window remains 2048. This is an alignment-disabled control of the same path, not a separate unpatched-upstream image run.
- Complete module plus the two NPU probe cases in one process: **58 passed**. The standalone probe must be collected with the UT module to initialize the shared test fixtures; collecting it alone outside the UT directory exposed an import-order cycle.
- CPU-only diagnostic: **55 passed, 1 failed**. The unchanged upstream `test_mtp3_placeholder_metadata_is_preserved_before_sanitizing_forward` calls `pin_memory()` and fails in this local torch-npu runtime without registered PrivateUse1 hooks. It passes in the NPU-enabled complete run above. This is not a claim of a clean local CPU-only module run.
- Complete manual pre-commit suite (including ShellCheck with `format.sh` options), `git diff --check`, and the PR commit secret scan passed.
- Runtime: CANN 9.1.0, PyTorch 2.10.0+cpu, torch-npu 2.10.0.post4. Source paths/hashes were checked. The dedicated image used vLLM's empty-device build and Ascend `COMPILE_CUSTOM_KERNELS=0`; the probe executes native NPU tensor allocation/write/count operations, not custom kernels. No model checkpoint or runtime source overlay was used. Existing service containers were not stopped or restarted.

These results verify current module behavior and the targeted NPU memory-isolation regression. They do not repeat the historical model/throughput validation below or establish arbitrary-layout, C4 or async correctness. Upstream hardware CI still needs a maintainer's `ready-precise` or `ready-all` label.

#### Historical integration validation (before this rebase)

The regression tests are in:

```bash
pytest -q tests/ut/worker/a2/test_model_runner_v1.py
```

- The repository's complete manual pre-commit suite passed locally with `pre-commit==4.6.2` and the ShellCheck options used by `format.sh`, including secret scanning. No unrelated files were changed by the checks.
- Eight focused tests cover property preservation/idempotence, no-Mamba behavior, exclusion of specialized MLA/SFA layouts, matching flattened dimensions with different head shapes, value-width mismatch, incompatible formats/block widths, ambiguous widths and cross-ID isolation through the actual reshaper. The reshaper unit test uses a scaled geometry; the separate full-geometry probe reproduced 65,536 overwritten BF16 elements before alignment and zero after it.
- After rebasing onto current `main`, the complete target module passed 45 tests in a separate Ascend test container on NPU 4. Before the rebase, the functional patch was also included in a 104-test suite of the complete attention, model-runner and GDN modules in a freshly rebuilt Ascend image. These are combined suite counts, not claims of 45 or 104 new tests.
- Built and tested Ascend base: `72059e41b239e2ea469a0fb2d9eb0cb7ee4e3085`; vLLM: `ba07e4a48fc951300d97eb506217dd530583dea3`. Full sources and custom extensions were rebuilt; installed imports and source hashes were checked, with no source overlays.
- Hardware/configuration: 2 × Ascend 910B3 64GB, Qwen3.8-27B + DFlash2, TP2/C1, BF16 weights, FP32 Mamba state, K7/block8, `FULL_DECODE_ONLY`/capture8, explicit synchronous scheduling, draft window 2048 and prefix caching enabled.
- Integrated cold/prime/first-hot checks, natural 64K/128K requests, both multimodal 5×2 grids, public GSM8K 10/300 questions, three text/tool API checks and the 262144-token success/overflow boundary passed. Public300 outputs and all speculative metrics matched the frozen optimized reference: 288/300 correct, the same 12 wrong answers and two capped responses.
- Public300 used GSM8K revision `3101c7d5072418e28b9008a6636bde82a006892c`, the first five training examples and first 300 test questions, T=0, seed 42, no thinking, max 512, natural EOS and same-request one-token priming.

The integrated service also contains separate non-causal attention, zeroer/H2D and Mamba-snapshot safeguards, plus a separately evaluated GDN metadata candidate. These are **not included in this PR**. These checks do not establish an isolated performance gain, arbitrary-layout compatibility or C4/async correctness. The capacity probe is synthetic text, not a 262K visual-quality claim; private request texts and logs are not attached.

### Related work

- #14340 proposes a broader non-contiguous hybrid-cache reshape and kernel-block interface refactor. This PR addresses the current contiguous-column implementation; its necessity should be reassessed if that refactor lands.
- #14543 fixes K+V page-size derivation in platform configuration, rather than this Full/SWA cross-group stride mismatch.
- #14693 detects MLA/Mamba cross-ID overlap; this PR repairs the compatible dense Full/SWA case.
- #15085 overlaps the separately documented H2D/zeroer prerequisite, which is not part of this patch.

The historical validation above followed a rebase onto `4b25eb34793efa9f00201d654eb2f107ecebfbbd`; the current rebase and test results are listed separately above.

- vLLM main: https://github.com/vllm-project/vllm/commit/b2f685834a6456197e7033966fdef52a23f1abcd
