### PR TITLE
[CI] Add Rust tool parser to Docker images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -88,8 +88,7 @@ RUN export PIP_EXTRA_INDEX_URL="${ASCEND_INDEX_URL}" && \
 # Install _rust_tool_parser for the Rust frontend.
 RUN cd /vllm-workspace/vllm && \
     python3 -m pip install setuptools-rust && \
-    ./build_rust.sh && \
-    rm -rf rust/target
+    ./build_rust.sh
 
 # Append `libascend_hal.so` path (devlib) to LD_LIBRARY_PATH
 RUN echo "export LD_PRELOAD=/usr/lib/$(uname -m)-linux-gnu/libjemalloc.so.2:$LD_PRELOAD" >> ~/.bashrc

--- a/Dockerfile
+++ b/Dockerfile
@@ -66,6 +66,11 @@ RUN VLLM_TARGET_DEVICE="empty" python3 -m pip install -e /vllm-workspace/vllm/[a
     python3 -m pip uninstall -y triton && \
     python3 -m pip cache purge
 
+# Install _rust_tool_parser for the Rust frontend.
+RUN cd /vllm-workspace/vllm && \
+    pip install setuptools-rust && \
+    ./build_rust.sh
+
 # Install vllm-ascend
 ARG SOC_VERSION="ascend910b1"
 ARG COMPILE_CUSTOM_KERNELS=1

--- a/Dockerfile
+++ b/Dockerfile
@@ -66,11 +66,6 @@ RUN VLLM_TARGET_DEVICE="empty" python3 -m pip install -e /vllm-workspace/vllm/[a
     python3 -m pip uninstall -y triton && \
     python3 -m pip cache purge
 
-# Install _rust_tool_parser for the Rust frontend.
-RUN cd /vllm-workspace/vllm && \
-    python3 -m pip install setuptools-rust && \
-    ./build_rust.sh
-
 # Install vllm-ascend
 ARG SOC_VERSION="ascend910b1"
 ARG COMPILE_CUSTOM_KERNELS=1
@@ -89,6 +84,13 @@ RUN export PIP_EXTRA_INDEX_URL="${ASCEND_INDEX_URL}" && \
     python3 -m pip install triton-ascend==3.2.2 --extra-index-url ${ASCEND_INDEX_URL} && \
     python3 -m pip install concurrent-log-handler && \
     python3 -m pip cache purge
+
+# Install _rust_tool_parser for the Rust frontend.
+RUN cd /vllm-workspace/vllm && \
+    python3 -m pip install setuptools-rust && \
+    ./build_rust.sh && \
+    python3 -m pip cache purge && \
+    rm -rf rust/target ~/.cargo ~/.rustup
 
 # Append `libascend_hal.so` path (devlib) to LD_LIBRARY_PATH
 RUN echo "export LD_PRELOAD=/usr/lib/$(uname -m)-linux-gnu/libjemalloc.so.2:$LD_PRELOAD" >> ~/.bashrc

--- a/Dockerfile
+++ b/Dockerfile
@@ -35,7 +35,7 @@ RUN if [ -n "$APTMIRROR" ]; then \
         sed -Ei "s@(ports|archive).ubuntu.com@${APTMIRROR#http://}@g" /etc/apt/sources.list; \
     fi && \
     apt-get update -y && \
-    apt-get install -y git vim wget net-tools gcc g++ cmake numactl libnuma-dev libibverbs-dev libjemalloc2 libhiredis-dev clang-15 && \
+    apt-get install -y git vim wget curl protobuf-compiler net-tools gcc g++ cmake numactl libnuma-dev libibverbs-dev libjemalloc2 libhiredis-dev clang-15 && \
     update-alternatives --install /usr/bin/clang clang /usr/bin/clang-15 20 && \
     update-alternatives --install /usr/bin/clang++ clang++ /usr/bin/clang++-15 20 && \
     source /usr/local/Ascend/ascend-toolkit/set_env.sh && \
@@ -68,7 +68,7 @@ RUN VLLM_TARGET_DEVICE="empty" python3 -m pip install -e /vllm-workspace/vllm/[a
 
 # Install _rust_tool_parser for the Rust frontend.
 RUN cd /vllm-workspace/vllm && \
-    pip install setuptools-rust && \
+    python3 -m pip install setuptools-rust && \
     ./build_rust.sh
 
 # Install vllm-ascend

--- a/Dockerfile
+++ b/Dockerfile
@@ -89,8 +89,7 @@ RUN export PIP_EXTRA_INDEX_URL="${ASCEND_INDEX_URL}" && \
 RUN cd /vllm-workspace/vllm && \
     python3 -m pip install setuptools-rust && \
     ./build_rust.sh && \
-    python3 -m pip cache purge && \
-    rm -rf rust/target ~/.cargo ~/.rustup
+    rm -rf rust/target
 
 # Append `libascend_hal.so` path (devlib) to LD_LIBRARY_PATH
 RUN echo "export LD_PRELOAD=/usr/lib/$(uname -m)-linux-gnu/libjemalloc.so.2:$LD_PRELOAD" >> ~/.bashrc

--- a/Dockerfile.310p
+++ b/Dockerfile.310p
@@ -61,6 +61,11 @@ RUN VLLM_TARGET_DEVICE="empty" python3 -m pip install -e /vllm-workspace/vllm/[a
     python3 -m pip uninstall -y triton && \
     python3 -m pip cache purge
 
+# Install _rust_tool_parser for the Rust frontend.
+RUN cd /vllm-workspace/vllm && \
+    pip install setuptools-rust && \
+    ./build_rust.sh
+
 # Install vllm-ascend
 ARG SOC_VERSION="ascend310p1"
 ARG COMPILE_CUSTOM_KERNELS=1

--- a/Dockerfile.310p
+++ b/Dockerfile.310p
@@ -61,11 +61,6 @@ RUN VLLM_TARGET_DEVICE="empty" python3 -m pip install -e /vllm-workspace/vllm/[a
     python3 -m pip uninstall -y triton && \
     python3 -m pip cache purge
 
-# Install _rust_tool_parser for the Rust frontend.
-RUN cd /vllm-workspace/vllm && \
-    python3 -m pip install setuptools-rust && \
-    ./build_rust.sh
-
 # Install vllm-ascend
 ARG SOC_VERSION="ascend310p1"
 ARG COMPILE_CUSTOM_KERNELS=1
@@ -81,6 +76,13 @@ RUN export PIP_EXTRA_INDEX_URL="${ASCEND_INDEX_URL}" && \
     python3 -m pip install -e /vllm-workspace/vllm-ascend/ --extra-index-url ${PYTORCH_INDEX_URL} && \
     python3 -m pip uninstall -y triton-ascend triton && \
     python3 -m pip cache purge
+
+# Install _rust_tool_parser for the Rust frontend.
+RUN cd /vllm-workspace/vllm && \
+    python3 -m pip install setuptools-rust && \
+    ./build_rust.sh && \
+    python3 -m pip cache purge && \
+    rm -rf rust/target ~/.cargo ~/.rustup
 
 # Append `libascend_hal.so` path (devlib) to LD_LIBRARY_PATH
 RUN echo "export LD_PRELOAD=/usr/lib/$(uname -m)-linux-gnu/libjemalloc.so.2:$LD_PRELOAD" >> ~/.bashrc

--- a/Dockerfile.310p
+++ b/Dockerfile.310p
@@ -34,7 +34,7 @@ RUN if [ -n "$APTMIRROR" ]; then \
         sed -Ei "s@(ports|archive).ubuntu.com@${APTMIRROR#http://}@g" /etc/apt/sources.list; \
     fi && \
     apt-get update -y && \
-    apt-get install -y python3-pip git vim wget net-tools gcc g++ cmake numactl libnuma-dev libjemalloc2 pciutils && \
+    apt-get install -y python3-pip git vim wget curl protobuf-compiler net-tools gcc g++ cmake numactl libnuma-dev libjemalloc2 pciutils && \
     rm -rf /var/cache/apt/* && \
     rm -rf /var/lib/apt/lists/*
 
@@ -63,7 +63,7 @@ RUN VLLM_TARGET_DEVICE="empty" python3 -m pip install -e /vllm-workspace/vllm/[a
 
 # Install _rust_tool_parser for the Rust frontend.
 RUN cd /vllm-workspace/vllm && \
-    pip install setuptools-rust && \
+    python3 -m pip install setuptools-rust && \
     ./build_rust.sh
 
 # Install vllm-ascend

--- a/Dockerfile.310p
+++ b/Dockerfile.310p
@@ -81,8 +81,7 @@ RUN export PIP_EXTRA_INDEX_URL="${ASCEND_INDEX_URL}" && \
 RUN cd /vllm-workspace/vllm && \
     python3 -m pip install setuptools-rust && \
     ./build_rust.sh && \
-    python3 -m pip cache purge && \
-    rm -rf rust/target ~/.cargo ~/.rustup
+    rm -rf rust/target
 
 # Append `libascend_hal.so` path (devlib) to LD_LIBRARY_PATH
 RUN echo "export LD_PRELOAD=/usr/lib/$(uname -m)-linux-gnu/libjemalloc.so.2:$LD_PRELOAD" >> ~/.bashrc

--- a/Dockerfile.310p
+++ b/Dockerfile.310p
@@ -80,8 +80,7 @@ RUN export PIP_EXTRA_INDEX_URL="${ASCEND_INDEX_URL}" && \
 # Install _rust_tool_parser for the Rust frontend.
 RUN cd /vllm-workspace/vllm && \
     python3 -m pip install setuptools-rust && \
-    ./build_rust.sh && \
-    rm -rf rust/target
+    ./build_rust.sh
 
 # Append `libascend_hal.so` path (devlib) to LD_LIBRARY_PATH
 RUN echo "export LD_PRELOAD=/usr/lib/$(uname -m)-linux-gnu/libjemalloc.so.2:$LD_PRELOAD" >> ~/.bashrc

--- a/Dockerfile.310p.openEuler
+++ b/Dockerfile.310p.openEuler
@@ -57,11 +57,6 @@ RUN VLLM_TARGET_DEVICE="empty" python3 -m pip install -e /vllm-workspace/vllm/[a
     python3 -m pip uninstall -y triton && \
     python3 -m pip cache purge
 
-# Install _rust_tool_parser for the Rust frontend.
-RUN cd /vllm-workspace/vllm && \
-    python3 -m pip install setuptools-rust && \
-    ./build_rust.sh
-
 # Install vllm-ascend
 ARG SOC_VERSION="ascend310p1"
 ARG COMPILE_CUSTOM_KERNELS=1
@@ -76,6 +71,13 @@ RUN export PIP_EXTRA_INDEX_URL="${ASCEND_INDEX_URL}" && \
     python3 -m pip install -e /vllm-workspace/vllm-ascend/ --extra-index-url ${PYTORCH_INDEX_URL} && \
     python3 -m pip uninstall -y triton-ascend triton && \
     python3 -m pip cache purge
+
+# Install _rust_tool_parser for the Rust frontend.
+RUN cd /vllm-workspace/vllm && \
+    python3 -m pip install setuptools-rust && \
+    ./build_rust.sh && \
+    python3 -m pip cache purge && \
+    rm -rf rust/target ~/.cargo ~/.rustup
 
 RUN echo "export LD_PRELOAD=/usr/lib64/libjemalloc.so.2:$LD_PRELOAD" >> ~/.bashrc
 RUN echo "export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/local/lib" >> ~/.bashrc

--- a/Dockerfile.310p.openEuler
+++ b/Dockerfile.310p.openEuler
@@ -57,6 +57,11 @@ RUN VLLM_TARGET_DEVICE="empty" python3 -m pip install -e /vllm-workspace/vllm/[a
     python3 -m pip uninstall -y triton && \
     python3 -m pip cache purge
 
+# Install _rust_tool_parser for the Rust frontend.
+RUN cd /vllm-workspace/vllm && \
+    pip install setuptools-rust && \
+    ./build_rust.sh
+
 # Install vllm-ascend
 ARG SOC_VERSION="ascend310p1"
 ARG COMPILE_CUSTOM_KERNELS=1

--- a/Dockerfile.310p.openEuler
+++ b/Dockerfile.310p.openEuler
@@ -76,8 +76,7 @@ RUN export PIP_EXTRA_INDEX_URL="${ASCEND_INDEX_URL}" && \
 RUN cd /vllm-workspace/vllm && \
     python3 -m pip install setuptools-rust && \
     ./build_rust.sh && \
-    python3 -m pip cache purge && \
-    rm -rf rust/target ~/.cargo ~/.rustup
+    rm -rf rust/target
 
 RUN echo "export LD_PRELOAD=/usr/lib64/libjemalloc.so.2:$LD_PRELOAD" >> ~/.bashrc
 RUN echo "export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/local/lib" >> ~/.bashrc

--- a/Dockerfile.310p.openEuler
+++ b/Dockerfile.310p.openEuler
@@ -75,8 +75,7 @@ RUN export PIP_EXTRA_INDEX_URL="${ASCEND_INDEX_URL}" && \
 # Install _rust_tool_parser for the Rust frontend.
 RUN cd /vllm-workspace/vllm && \
     python3 -m pip install setuptools-rust && \
-    ./build_rust.sh && \
-    rm -rf rust/target
+    ./build_rust.sh
 
 RUN echo "export LD_PRELOAD=/usr/lib64/libjemalloc.so.2:$LD_PRELOAD" >> ~/.bashrc
 RUN echo "export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/local/lib" >> ~/.bashrc

--- a/Dockerfile.310p.openEuler
+++ b/Dockerfile.310p.openEuler
@@ -31,7 +31,7 @@ ARG PIP_TRUSTED_HOST=""
 WORKDIR /workspace
 
 RUN yum update -y && \
-    yum install -y python3-pip git vim wget net-tools gcc gcc-c++ make cmake numactl numactl-devel jemalloc patch && \
+    yum install -y python3-pip git vim wget protobuf-compiler curl net-tools gcc gcc-c++ make cmake numactl numactl-devel jemalloc patch && \
     rm -rf /var/cache/yum
 
 # Install modelscope (for fast download) and ray (for multinode)
@@ -59,7 +59,7 @@ RUN VLLM_TARGET_DEVICE="empty" python3 -m pip install -e /vllm-workspace/vllm/[a
 
 # Install _rust_tool_parser for the Rust frontend.
 RUN cd /vllm-workspace/vllm && \
-    pip install setuptools-rust && \
+    python3 -m pip install setuptools-rust && \
     ./build_rust.sh
 
 # Install vllm-ascend

--- a/Dockerfile.a3
+++ b/Dockerfile.a3
@@ -38,7 +38,7 @@ RUN if [ -n "$APTMIRROR" ]; then \
         sed -Ei "s@(ports|archive).ubuntu.com@${APTMIRROR#http://}@g" /etc/apt/sources.list; \
     fi && \
     apt-get update -y && \
-    apt-get install -y git vim wget net-tools gcc g++ cmake numactl libnuma-dev libibverbs-dev libjemalloc2 libhiredis-dev clang-15 && \
+    apt-get install -y git vim wget curl protobuf-compiler net-tools gcc g++ cmake numactl libnuma-dev libibverbs-dev libjemalloc2 libhiredis-dev clang-15 && \
     update-alternatives --install /usr/bin/clang clang /usr/bin/clang-15 20 && \
     update-alternatives --install /usr/bin/clang++ clang++ /usr/bin/clang++-15 20 && \
     source /usr/local/Ascend/ascend-toolkit/set_env.sh && \
@@ -71,7 +71,7 @@ RUN VLLM_TARGET_DEVICE="empty" python3 -m pip install -e /vllm-workspace/vllm/[a
 
 # Install _rust_tool_parser for the Rust frontend.
 RUN cd /vllm-workspace/vllm && \
-    pip install setuptools-rust && \
+    python3 -m pip install setuptools-rust && \
     ./build_rust.sh
 
 # Install vllm-ascend

--- a/Dockerfile.a3
+++ b/Dockerfile.a3
@@ -92,8 +92,7 @@ RUN export PIP_EXTRA_INDEX_URL="${ASCEND_INDEX_URL}" && \
 RUN cd /vllm-workspace/vllm && \
     python3 -m pip install setuptools-rust && \
     ./build_rust.sh && \
-    python3 -m pip cache purge && \
-    rm -rf rust/target ~/.cargo ~/.rustup
+    rm -rf rust/target
 
 # Append `libascend_hal.so` path (devlib) to LD_LIBRARY_PATH
 RUN echo "export LD_PRELOAD=/usr/lib/$(uname -m)-linux-gnu/libjemalloc.so.2:$LD_PRELOAD" >> ~/.bashrc

--- a/Dockerfile.a3
+++ b/Dockerfile.a3
@@ -69,11 +69,6 @@ RUN VLLM_TARGET_DEVICE="empty" python3 -m pip install -e /vllm-workspace/vllm/[a
     python3 -m pip uninstall -y triton && \
     python3 -m pip cache purge
 
-# Install _rust_tool_parser for the Rust frontend.
-RUN cd /vllm-workspace/vllm && \
-    python3 -m pip install setuptools-rust && \
-    ./build_rust.sh
-
 # Install vllm-ascend
 ARG SOC_VERSION="ascend910_9391"
 ARG COMPILE_CUSTOM_KERNELS=1
@@ -92,6 +87,13 @@ RUN export PIP_EXTRA_INDEX_URL="${ASCEND_INDEX_URL}" && \
     python3 -m pip install triton-ascend==3.2.2 --extra-index-url ${ASCEND_INDEX_URL} && \
     python3 -m pip install concurrent-log-handler && \
     python3 -m pip cache purge
+
+# Install _rust_tool_parser for the Rust frontend.
+RUN cd /vllm-workspace/vllm && \
+    python3 -m pip install setuptools-rust && \
+    ./build_rust.sh && \
+    python3 -m pip cache purge && \
+    rm -rf rust/target ~/.cargo ~/.rustup
 
 # Append `libascend_hal.so` path (devlib) to LD_LIBRARY_PATH
 RUN echo "export LD_PRELOAD=/usr/lib/$(uname -m)-linux-gnu/libjemalloc.so.2:$LD_PRELOAD" >> ~/.bashrc

--- a/Dockerfile.a3
+++ b/Dockerfile.a3
@@ -69,6 +69,11 @@ RUN VLLM_TARGET_DEVICE="empty" python3 -m pip install -e /vllm-workspace/vllm/[a
     python3 -m pip uninstall -y triton && \
     python3 -m pip cache purge
 
+# Install _rust_tool_parser for the Rust frontend.
+RUN cd /vllm-workspace/vllm && \
+    pip install setuptools-rust && \
+    ./build_rust.sh
+
 # Install vllm-ascend
 ARG SOC_VERSION="ascend910_9391"
 ARG COMPILE_CUSTOM_KERNELS=1

--- a/Dockerfile.a3
+++ b/Dockerfile.a3
@@ -91,8 +91,7 @@ RUN export PIP_EXTRA_INDEX_URL="${ASCEND_INDEX_URL}" && \
 # Install _rust_tool_parser for the Rust frontend.
 RUN cd /vllm-workspace/vllm && \
     python3 -m pip install setuptools-rust && \
-    ./build_rust.sh && \
-    rm -rf rust/target
+    ./build_rust.sh
 
 # Append `libascend_hal.so` path (devlib) to LD_LIBRARY_PATH
 RUN echo "export LD_PRELOAD=/usr/lib/$(uname -m)-linux-gnu/libjemalloc.so.2:$LD_PRELOAD" >> ~/.bashrc

--- a/Dockerfile.a3.openEuler
+++ b/Dockerfile.a3.openEuler
@@ -84,8 +84,7 @@ RUN export PIP_EXTRA_INDEX_URL="${ASCEND_INDEX_URL}" && \
 # Install _rust_tool_parser for the Rust frontend.
 RUN cd /vllm-workspace/vllm && \
     python3 -m pip install setuptools-rust && \
-    ./build_rust.sh && \
-    rm -rf rust/target
+    ./build_rust.sh
 
 RUN echo "export LD_PRELOAD=/usr/lib64/libjemalloc.so.2:$LD_PRELOAD" >> ~/.bashrc
 RUN echo "export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/local/lib" >> ~/.bashrc

--- a/Dockerfile.a3.openEuler
+++ b/Dockerfile.a3.openEuler
@@ -63,6 +63,11 @@ RUN VLLM_TARGET_DEVICE="empty" python3 -m pip install -e /vllm-workspace/vllm/[a
     python3 -m pip uninstall -y triton && \
     python3 -m pip cache purge
 
+# Install _rust_tool_parser for the Rust frontend.
+RUN cd /vllm-workspace/vllm && \
+    pip install setuptools-rust && \
+    ./build_rust.sh
+
 # Install vllm-ascend
 ARG SOC_VERSION="ascend910_9391"
 ARG COMPILE_CUSTOM_KERNELS=1

--- a/Dockerfile.a3.openEuler
+++ b/Dockerfile.a3.openEuler
@@ -35,7 +35,7 @@ SHELL ["/bin/bash", "-c"]
 # Install clang (for triton-ascend) and Mooncake
 ARG MOONCAKE_TAG=0.3.11.post1
 RUN yum update -y && \
-    yum install -y git vim wget net-tools gcc gcc-c++ make cmake numactl numactl-devel libibverbs-devel jemalloc hiredis-devel clang patch && \
+    yum install -y git vim wget curl protobuf-compiler net-tools gcc gcc-c++ make cmake numactl numactl-devel libibverbs-devel jemalloc hiredis-devel clang patch && \
     source /usr/local/Ascend/ascend-toolkit/set_env.sh && \
     python3 -m pip install mooncake-transfer-engine-npu==${MOONCAKE_TAG} --extra-index-url ${MOONCAKE_INDEX_URL} && \
     rm -rf /var/cache/yum/*
@@ -65,7 +65,7 @@ RUN VLLM_TARGET_DEVICE="empty" python3 -m pip install -e /vllm-workspace/vllm/[a
 
 # Install _rust_tool_parser for the Rust frontend.
 RUN cd /vllm-workspace/vllm && \
-    pip install setuptools-rust && \
+    python3 -m pip install setuptools-rust && \
     ./build_rust.sh
 
 # Install vllm-ascend

--- a/Dockerfile.a3.openEuler
+++ b/Dockerfile.a3.openEuler
@@ -85,8 +85,7 @@ RUN export PIP_EXTRA_INDEX_URL="${ASCEND_INDEX_URL}" && \
 RUN cd /vllm-workspace/vllm && \
     python3 -m pip install setuptools-rust && \
     ./build_rust.sh && \
-    python3 -m pip cache purge && \
-    rm -rf rust/target ~/.cargo ~/.rustup
+    rm -rf rust/target
 
 RUN echo "export LD_PRELOAD=/usr/lib64/libjemalloc.so.2:$LD_PRELOAD" >> ~/.bashrc
 RUN echo "export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/local/lib" >> ~/.bashrc

--- a/Dockerfile.a3.openEuler
+++ b/Dockerfile.a3.openEuler
@@ -63,11 +63,6 @@ RUN VLLM_TARGET_DEVICE="empty" python3 -m pip install -e /vllm-workspace/vllm/[a
     python3 -m pip uninstall -y triton && \
     python3 -m pip cache purge
 
-# Install _rust_tool_parser for the Rust frontend.
-RUN cd /vllm-workspace/vllm && \
-    python3 -m pip install setuptools-rust && \
-    ./build_rust.sh
-
 # Install vllm-ascend
 ARG SOC_VERSION="ascend910_9391"
 ARG COMPILE_CUSTOM_KERNELS=1
@@ -85,6 +80,13 @@ RUN export PIP_EXTRA_INDEX_URL="${ASCEND_INDEX_URL}" && \
     python3 -m pip install triton-ascend==3.2.2 --extra-index-url ${ASCEND_INDEX_URL} && \
     python3 -m pip install concurrent-log-handler && \
     python3 -m pip cache purge
+
+# Install _rust_tool_parser for the Rust frontend.
+RUN cd /vllm-workspace/vllm && \
+    python3 -m pip install setuptools-rust && \
+    ./build_rust.sh && \
+    python3 -m pip cache purge && \
+    rm -rf rust/target ~/.cargo ~/.rustup
 
 RUN echo "export LD_PRELOAD=/usr/lib64/libjemalloc.so.2:$LD_PRELOAD" >> ~/.bashrc
 RUN echo "export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/local/lib" >> ~/.bashrc

--- a/Dockerfile.a5
+++ b/Dockerfile.a5
@@ -38,7 +38,7 @@ RUN if [ -n "$APTMIRROR" ]; then \
         sed -Ei "s@(ports|archive).ubuntu.com@${APTMIRROR#http://}@g" /etc/apt/sources.list; \
     fi && \
     apt-get update -y && \
-    apt-get install -y git vim wget net-tools gcc g++ cmake numactl libnuma-dev libibverbs-dev libjemalloc2 libhiredis-dev clang-15 && \
+    apt-get install -y git vim wget curl protobuf-compiler net-tools gcc g++ cmake numactl libnuma-dev libibverbs-dev libjemalloc2 libhiredis-dev clang-15 && \
     update-alternatives --install /usr/bin/clang clang /usr/bin/clang-15 20 && \
     update-alternatives --install /usr/bin/clang++ clang++ /usr/bin/clang++-15 20 && \
     source /usr/local/Ascend/ascend-toolkit/set_env.sh && \
@@ -64,7 +64,7 @@ RUN VLLM_TARGET_DEVICE="empty" python3 -m pip install -e /vllm-workspace/vllm/[a
 
 # Install _rust_tool_parser for the Rust frontend.
 RUN cd /vllm-workspace/vllm && \
-    pip install setuptools-rust && \
+    python3 -m pip install setuptools-rust && \
     ./build_rust.sh
 
 # Install vllm-ascend

--- a/Dockerfile.a5
+++ b/Dockerfile.a5
@@ -62,6 +62,11 @@ RUN VLLM_TARGET_DEVICE="empty" python3 -m pip install -e /vllm-workspace/vllm/[a
     python3 -m pip uninstall -y triton && \
     python3 -m pip cache purge
 
+# Install _rust_tool_parser for the Rust frontend.
+RUN cd /vllm-workspace/vllm && \
+    pip install setuptools-rust && \
+    ./build_rust.sh
+
 # Install vllm-ascend
 ARG SOC_VERSION="ascend950dt_9582"
 ARG COMPILE_CUSTOM_KERNELS=1

--- a/Dockerfile.a5
+++ b/Dockerfile.a5
@@ -84,8 +84,7 @@ RUN export PIP_EXTRA_INDEX_URL="${ASCEND_INDEX_URL}" && \
 RUN cd /vllm-workspace/vllm && \
     python3 -m pip install setuptools-rust && \
     ./build_rust.sh && \
-    python3 -m pip cache purge && \
-    rm -rf rust/target ~/.cargo ~/.rustup
+    rm -rf rust/target
 
 # Append `libascend_hal.so` path (devlib) to LD_LIBRARY_PATH
 RUN echo "export LD_PRELOAD=/usr/lib/$(uname -m)-linux-gnu/libjemalloc.so.2:$LD_PRELOAD" >> ~/.bashrc

--- a/Dockerfile.a5
+++ b/Dockerfile.a5
@@ -83,8 +83,7 @@ RUN export PIP_EXTRA_INDEX_URL="${ASCEND_INDEX_URL}" && \
 # Install _rust_tool_parser for the Rust frontend.
 RUN cd /vllm-workspace/vllm && \
     python3 -m pip install setuptools-rust && \
-    ./build_rust.sh && \
-    rm -rf rust/target
+    ./build_rust.sh
 
 # Append `libascend_hal.so` path (devlib) to LD_LIBRARY_PATH
 RUN echo "export LD_PRELOAD=/usr/lib/$(uname -m)-linux-gnu/libjemalloc.so.2:$LD_PRELOAD" >> ~/.bashrc

--- a/Dockerfile.a5
+++ b/Dockerfile.a5
@@ -62,11 +62,6 @@ RUN VLLM_TARGET_DEVICE="empty" python3 -m pip install -e /vllm-workspace/vllm/[a
     python3 -m pip uninstall -y triton && \
     python3 -m pip cache purge
 
-# Install _rust_tool_parser for the Rust frontend.
-RUN cd /vllm-workspace/vllm && \
-    python3 -m pip install setuptools-rust && \
-    ./build_rust.sh
-
 # Install vllm-ascend
 ARG SOC_VERSION="ascend950dt_9582"
 ARG COMPILE_CUSTOM_KERNELS=1
@@ -84,6 +79,13 @@ RUN export PIP_EXTRA_INDEX_URL="${ASCEND_INDEX_URL}" && \
     python3 -m pip install triton-ascend==3.2.2 --extra-index-url ${ASCEND_INDEX_URL} && \
     python3 -m pip install concurrent-log-handler && \
     python3 -m pip cache purge
+
+# Install _rust_tool_parser for the Rust frontend.
+RUN cd /vllm-workspace/vllm && \
+    python3 -m pip install setuptools-rust && \
+    ./build_rust.sh && \
+    python3 -m pip cache purge && \
+    rm -rf rust/target ~/.cargo ~/.rustup
 
 # Append `libascend_hal.so` path (devlib) to LD_LIBRARY_PATH
 RUN echo "export LD_PRELOAD=/usr/lib/$(uname -m)-linux-gnu/libjemalloc.so.2:$LD_PRELOAD" >> ~/.bashrc

--- a/Dockerfile.a5.openEuler
+++ b/Dockerfile.a5.openEuler
@@ -76,8 +76,7 @@ RUN export PIP_EXTRA_INDEX_URL="${ASCEND_INDEX_URL}" && \
 # Install _rust_tool_parser for the Rust frontend.
 RUN cd /vllm-workspace/vllm && \
     python3 -m pip install setuptools-rust && \
-    ./build_rust.sh && \
-    rm -rf rust/target
+    ./build_rust.sh
 
 RUN echo "export LD_PRELOAD=/usr/lib64/libjemalloc.so.2:$LD_PRELOAD" >> ~/.bashrc
 RUN echo "export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/local/lib" >> ~/.bashrc

--- a/Dockerfile.a5.openEuler
+++ b/Dockerfile.a5.openEuler
@@ -77,8 +77,7 @@ RUN export PIP_EXTRA_INDEX_URL="${ASCEND_INDEX_URL}" && \
 RUN cd /vllm-workspace/vllm && \
     python3 -m pip install setuptools-rust && \
     ./build_rust.sh && \
-    python3 -m pip cache purge && \
-    rm -rf rust/target ~/.cargo ~/.rustup
+    rm -rf rust/target
 
 RUN echo "export LD_PRELOAD=/usr/lib64/libjemalloc.so.2:$LD_PRELOAD" >> ~/.bashrc
 RUN echo "export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/local/lib" >> ~/.bashrc

--- a/Dockerfile.a5.openEuler
+++ b/Dockerfile.a5.openEuler
@@ -56,6 +56,11 @@ RUN VLLM_TARGET_DEVICE="empty" python3 -m pip install -e /vllm-workspace/vllm/[a
     python3 -m pip uninstall -y triton && \
     python3 -m pip cache purge
 
+# Install _rust_tool_parser for the Rust frontend.
+RUN cd /vllm-workspace/vllm && \
+    pip install setuptools-rust && \
+    ./build_rust.sh
+
 # Install vllm-ascend
 ARG SOC_VERSION="ascend950dt_9582"
 ARG COMPILE_CUSTOM_KERNELS=1

--- a/Dockerfile.a5.openEuler
+++ b/Dockerfile.a5.openEuler
@@ -56,11 +56,6 @@ RUN VLLM_TARGET_DEVICE="empty" python3 -m pip install -e /vllm-workspace/vllm/[a
     python3 -m pip uninstall -y triton && \
     python3 -m pip cache purge
 
-# Install _rust_tool_parser for the Rust frontend.
-RUN cd /vllm-workspace/vllm && \
-    python3 -m pip install setuptools-rust && \
-    ./build_rust.sh
-
 # Install vllm-ascend
 ARG SOC_VERSION="ascend950dt_9582"
 ARG COMPILE_CUSTOM_KERNELS=1
@@ -77,6 +72,13 @@ RUN export PIP_EXTRA_INDEX_URL="${ASCEND_INDEX_URL}" && \
     python3 -m pip install triton-ascend==3.2.2 --extra-index-url ${ASCEND_INDEX_URL} && \
     python3 -m pip install concurrent-log-handler && \
     python3 -m pip cache purge
+
+# Install _rust_tool_parser for the Rust frontend.
+RUN cd /vllm-workspace/vllm && \
+    python3 -m pip install setuptools-rust && \
+    ./build_rust.sh && \
+    python3 -m pip cache purge && \
+    rm -rf rust/target ~/.cargo ~/.rustup
 
 RUN echo "export LD_PRELOAD=/usr/lib64/libjemalloc.so.2:$LD_PRELOAD" >> ~/.bashrc
 RUN echo "export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/local/lib" >> ~/.bashrc

--- a/Dockerfile.a5.openEuler
+++ b/Dockerfile.a5.openEuler
@@ -35,7 +35,7 @@ SHELL ["/bin/bash", "-c"]
 # Install clang (for triton-ascend) and Mooncake
 ARG MOONCAKE_TAG=0.3.11.post1
 RUN yum update -y && \
-    yum install -y git vim wget net-tools gcc gcc-c++ make cmake numactl numactl-devel libibverbs-devel jemalloc hiredis-devel clang patch && \
+    yum install -y git vim wget curl protobuf-compiler net-tools gcc gcc-c++ make cmake numactl numactl-devel libibverbs-devel jemalloc hiredis-devel clang patch && \
     source /usr/local/Ascend/ascend-toolkit/set_env.sh && \
     python3 -m pip install mooncake-transfer-engine-npu==${MOONCAKE_TAG} --extra-index-url ${MOONCAKE_INDEX_URL} && \
     rm -rf /var/cache/yum/*
@@ -58,7 +58,7 @@ RUN VLLM_TARGET_DEVICE="empty" python3 -m pip install -e /vllm-workspace/vllm/[a
 
 # Install _rust_tool_parser for the Rust frontend.
 RUN cd /vllm-workspace/vllm && \
-    pip install setuptools-rust && \
+    python3 -m pip install setuptools-rust && \
     ./build_rust.sh
 
 # Install vllm-ascend

--- a/Dockerfile.openEuler
+++ b/Dockerfile.openEuler
@@ -84,8 +84,7 @@ RUN export PIP_EXTRA_INDEX_URL="${ASCEND_INDEX_URL}" && \
 # Install _rust_tool_parser for the Rust frontend.
 RUN cd /vllm-workspace/vllm && \
     python3 -m pip install setuptools-rust && \
-    ./build_rust.sh && \
-    rm -rf rust/target
+    ./build_rust.sh
 
 RUN echo "export LD_PRELOAD=/usr/lib64/libjemalloc.so.2:$LD_PRELOAD" >> ~/.bashrc
 RUN echo "export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/local/lib" >> ~/.bashrc

--- a/Dockerfile.openEuler
+++ b/Dockerfile.openEuler
@@ -35,7 +35,7 @@ SHELL ["/bin/bash", "-c"]
 # Install clang (for triton-ascend) and Mooncake
 ARG MOONCAKE_TAG=0.3.11.post1
 RUN yum update -y && \
-    yum install -y git vim wget net-tools gcc gcc-c++ make cmake numactl numactl-devel libibverbs-devel jemalloc hiredis-devel clang patch && \
+    yum install -y git vim wget curl protobuf-compiler net-tools gcc gcc-c++ make cmake numactl numactl-devel libibverbs-devel jemalloc hiredis-devel clang patch && \
     source /usr/local/Ascend/ascend-toolkit/set_env.sh && \
     python3 -m pip install mooncake-transfer-engine-npu==${MOONCAKE_TAG} --extra-index-url ${MOONCAKE_INDEX_URL} && \
     rm -rf /var/cache/yum/*
@@ -65,7 +65,7 @@ RUN VLLM_TARGET_DEVICE="empty" python3 -m pip install -e /vllm-workspace/vllm/[a
 
 # Install _rust_tool_parser for the Rust frontend.
 RUN cd /vllm-workspace/vllm && \
-    pip install setuptools-rust && \
+    python3 -m pip install setuptools-rust && \
     ./build_rust.sh
 
 # Install vllm-ascend

--- a/Dockerfile.openEuler
+++ b/Dockerfile.openEuler
@@ -63,11 +63,6 @@ RUN VLLM_TARGET_DEVICE="empty" python3 -m pip install -e /vllm-workspace/vllm/[a
     python3 -m pip uninstall -y triton && \
     python3 -m pip cache purge
 
-# Install _rust_tool_parser for the Rust frontend.
-RUN cd /vllm-workspace/vllm && \
-    python3 -m pip install setuptools-rust && \
-    ./build_rust.sh
-
 # Install vllm-ascend
 ARG SOC_VERSION="ascend910b1"
 ARG COMPILE_CUSTOM_KERNELS=1
@@ -85,6 +80,13 @@ RUN export PIP_EXTRA_INDEX_URL="${ASCEND_INDEX_URL}" && \
     python3 -m pip install triton-ascend==3.2.2 --extra-index-url ${ASCEND_INDEX_URL} && \
     python3 -m pip install concurrent-log-handler && \
     python3 -m pip cache purge
+
+# Install _rust_tool_parser for the Rust frontend.
+RUN cd /vllm-workspace/vllm && \
+    python3 -m pip install setuptools-rust && \
+    ./build_rust.sh && \
+    python3 -m pip cache purge && \
+    rm -rf rust/target ~/.cargo ~/.rustup
 
 RUN echo "export LD_PRELOAD=/usr/lib64/libjemalloc.so.2:$LD_PRELOAD" >> ~/.bashrc
 RUN echo "export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/local/lib" >> ~/.bashrc

--- a/Dockerfile.openEuler
+++ b/Dockerfile.openEuler
@@ -85,8 +85,7 @@ RUN export PIP_EXTRA_INDEX_URL="${ASCEND_INDEX_URL}" && \
 RUN cd /vllm-workspace/vllm && \
     python3 -m pip install setuptools-rust && \
     ./build_rust.sh && \
-    python3 -m pip cache purge && \
-    rm -rf rust/target ~/.cargo ~/.rustup
+    rm -rf rust/target
 
 RUN echo "export LD_PRELOAD=/usr/lib64/libjemalloc.so.2:$LD_PRELOAD" >> ~/.bashrc
 RUN echo "export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/local/lib" >> ~/.bashrc

--- a/Dockerfile.openEuler
+++ b/Dockerfile.openEuler
@@ -63,6 +63,11 @@ RUN VLLM_TARGET_DEVICE="empty" python3 -m pip install -e /vllm-workspace/vllm/[a
     python3 -m pip uninstall -y triton && \
     python3 -m pip cache purge
 
+# Install _rust_tool_parser for the Rust frontend.
+RUN cd /vllm-workspace/vllm && \
+    pip install setuptools-rust && \
+    ./build_rust.sh
+
 # Install vllm-ascend
 ARG SOC_VERSION="ascend910b1"
 ARG COMPILE_CUSTOM_KERNELS=1


### PR DESCRIPTION
### What this PR does / why we need it?

Add `protobuf-compiler` and build `_rust_tool_parser` (via `setuptools-rust` and `build_rust.sh`) in all Ascend Dockerfiles, so official images include the Rust tool parser frontend.

### Does this PR introduce _any_ user-facing change?

Yes. Official Docker images will ship with the Rust tool parser built in.

### How was this patch tested?
In the new code image container, MiniMax M3 can be started and executed using the --reasoning-parser minimax_m3 \ --tool-call-parser minimax_m3 \ command.

In the new code image container, calling the common model Qwen3.5-27B does not affect the Python frontend calling.
[root@node-97-39 Qwen3.5-27B]# curl -X POST "http://localhost:8000/v1/chat/completions" \
>   -H "Content-Type: application/json" \
>   -d '{
>     "model": "qwen3.5",
>     "messages": [
>       {"role": "user", "content": "东京今天的天气怎么样？"}
>     ],
>     "tools": [{
>       "type": "function",
>       "function": {
>         "name": "get_weather",
>         "description": "获取指定城市的当前天气信息",
>         "parameters": {
>           "type": "object",
>           "properties": {
>             "location": {
>               "type": "string",
>               "description": "城市名称，如：北京、上海、东京"
>             },
>             "unit": {
>               "type": "string",
>               "enum": ["celsius", "fahrenheit"],
>               "description": "温度单位"
>             }
>           },
>           "required": ["location"]
>         }
>       }
>     }],
>     "tool_choice": "auto"
>   }'
{"id":"chatcmpl-a41b29f8c8fd659d","object":"chat.completion","created":1788240140,"model":"qwen3.5","choices":[{"index":0,"message":{"role":"assistant","content":null,"refusal":null,"annotations":null,"audio":null,"function_call":null,"tool_calls":[{"id":"chatcmpl-tool-be4e6a9a6efad74c","type":"function","function":{"name":"get_weather","arguments":"{\"location\": \"东京\"}"}}],"reasoning":"用户想知道东京今天的天气情况。我需要使用get_weather工具来获取东京的天气信息。\n\n根据工具参数：\n- location: 必填参数，用户指定了\"东京\"\n- unit: 可选参数，温度单位，用户没有指定，我可以不设置或使用默认值\n\n我应该调用get_weather函数，location参数设为\"东京\"。\n"},"logprobs":null,"finish_reason":"tool_calls","stop_reason":null,"token_ids":null,"routed_experts":null}],"service_tier":null,"system_fingerprint":"vllm-0.27.1-tp2-896d8824","usage":{"prompt_tokens":315,"total_tokens":415,"completion_tokens":100,"prompt_tokens_details":null},"prompt_logprobs":null,"prompt
When the MiniMax M3 model is called in a common image container, the model cannot be called if Rust is not installed. The error message {"error":{"message":"Rust tool parsing requires the vllm._rust_tool_parser PyO3 extension. Rebuild vLLM with Rust frontend/extensions enabled.","type":"InternalServerError","param":null,"code":500}} is displayed.
Dockerfile changes only. Install commands use `python3 -m pip` for openEuler compatibility. Image build CI should cover this.

- vLLM main: https://github.com/vllm-project/vllm/commit/ba07e4a48fc951300d97eb506217dd530583dea3
