### PR TITLE
[Misc] remove compatibility with dispatch_v1/combine_v1 interface

### DIFF
--- a/tests/ut/ops/a2/test_token_dispatcher.py
+++ b/tests/ut/ops/a2/test_token_dispatcher.py
@@ -21,7 +21,6 @@ from unittest.mock import MagicMock, PropertyMock, patch
 import numpy as np
 import pytest
 import torch
-import torch_npu
 
 from tests.ut.base import TestBase
 from vllm_ascend.ops.fused_moe.dataclass.router_input import MoeRouterInput
@@ -166,7 +165,6 @@ class TestTokenDispatcherWithMC2(TestBase):
     def test_init(self):
         self.assertEqual(self.dispatcher.ep_rank_id, 0)
         self.assertEqual(self.dispatcher.ep_world_size, 8)
-        self.assertEqual(self.dispatcher.enable_dispatch_v2, hasattr(torch_npu, "npu_moe_distribute_dispatch_v2"))
         self.assertTrue(self.dispatcher.need_extra_args)
         self.assertEqual(self.dispatcher.global_bs, 0)
 

--- a/vllm_ascend/ops/fused_moe/token_dispatcher.py
+++ b/vllm_ascend/ops/fused_moe/token_dispatcher.py
@@ -119,7 +119,6 @@ class TokenDispatcherWithMC2(MoETokenDispatcher[MoEMC2CombineMetadata]):
         self.moe_all_to_all_group_name = backend.get_hccl_comm_name(local_rank)
         self.ep_rank_id = get_mc2_group().rank_in_group
         self.ep_world_size = get_mc2_group().world_size
-        self.enable_dispatch_v2 = hasattr(torch_npu, "npu_moe_distribute_dispatch_v2")
         self.need_extra_args = get_ascend_device_type() in [AscendDeviceType.A3, AscendDeviceType.A5]
         self.a5_need_extra_args = get_ascend_device_type() == AscendDeviceType.A5
         self.mc2_comm_alg = get_ascend_config().get_mc2_comm_alg()
@@ -145,11 +144,6 @@ class TokenDispatcherWithMC2(MoETokenDispatcher[MoEMC2CombineMetadata]):
         # When allreduce is skipped, tokens may differ per rank:
         # use the real global_bs and do NOT pass mc2_mask.
         self.global_bs = _max_global_bs if should_skip_allreduce_across_dp_group(vllm_config) else 0
-
-        if not self.enable_dispatch_v2 and self.mc2_comm_alg == "hierarchy":
-            raise RuntimeError(
-                "PTA and CANN version is too old to support mc2 hierarchy comm, please upgrade your version."
-            )
 
     def refresh_hccl_group(self) -> None:
         """Refresh MC2 communicator metadata after HCCL groups are recreated."""
@@ -237,11 +231,7 @@ class TokenDispatcherWithMC2(MoETokenDispatcher[MoEMC2CombineMetadata]):
         token_dispatch_input: MoETokenDispatchInput,
     ):
         kwargs_mc2 = self.get_dispatch_mc2_kwargs(token_dispatch_input)
-        output = (
-            torch_npu.npu_moe_distribute_dispatch_v2(**kwargs_mc2)
-            if self.enable_dispatch_v2
-            else torch_npu.npu_moe_distribute_dispatch(**kwargs_mc2)
-        )
+        output = torch_npu.npu_moe_distribute_dispatch_v2(**kwargs_mc2)
         # comm_stream.wait_stream(torch.npu.current_stream())
         (
             expand_x,
@@ -315,12 +305,8 @@ class TokenDispatcherWithMC2(MoETokenDispatcher[MoEMC2CombineMetadata]):
             "expand_scales": expand_scales,
             "comm_quant_mode": quant_mode,
             "comm_alg": self.mc2_comm_alg,
+            "assist_info_for_combine": assist_info_for_combine,
         }
-
-        if self.enable_dispatch_v2:
-            stage3_kwargs["assist_info_for_combine"] = assist_info_for_combine
-        else:
-            stage3_kwargs["expand_idx"] = assist_info_for_combine
 
         if self.need_extra_args:
             stage3_kwargs.update(
@@ -339,11 +325,7 @@ class TokenDispatcherWithMC2(MoETokenDispatcher[MoEMC2CombineMetadata]):
         assert bias is None, "Bias is not supported in MoEAlltoAllvTokenDispatcher."
 
         kwargs_mc2 = self.get_combine_mc_kwargs(hidden_states, combine_metadata)
-        combined_output = (
-            torch_npu.npu_moe_distribute_combine_v2(**kwargs_mc2)
-            if self.enable_dispatch_v2
-            else torch_npu.npu_moe_distribute_combine(**kwargs_mc2)
-        )
+        combined_output = torch_npu.npu_moe_distribute_combine_v2(**kwargs_mc2)
 
         return combined_output
 


### PR DESCRIPTION
### What this PR does / why we need it?

Remove compatibility with `torch_npu.npu_moe_distribute_dispatch`/`torch_npu.npu_moe_distribute_combine` interface, which is only used in very old version.

### Does this PR introduce _any_ user-facing change?

None.

### How was this patch tested?

- vLLM version: v0.27.1
- vLLM main: https://github.com/vllm-project/vllm/commit/ba07e4a48fc951300d97eb506217dd530583dea3
