### PR TITLE
[v0.26.0rc][Performance] Track asynchronous AscendStore saves per request

### DIFF
--- a/tests/ut/distributed/ascend_store/test_ascend_store_connector.py
+++ b/tests/ut/distributed/ascend_store/test_ascend_store_connector.py
@@ -304,6 +304,7 @@ class TestAscendStoreConnector(unittest.TestCase):
         # start_load_kv
         connector._get_connector_metadata = MagicMock(return_value=MagicMock())
         connector.start_load_kv(MagicMock())
+        mock_worker.prepare_save.assert_called_once()
         mock_worker.start_load_kv.assert_called_once()
 
         # wait_for_save (non-consumer)

--- a/tests/ut/distributed/ascend_store/test_ascend_store_connector.py
+++ b/tests/ut/distributed/ascend_store/test_ascend_store_connector.py
@@ -303,9 +303,15 @@ class TestAscendStoreConnector(unittest.TestCase):
 
         # start_load_kv
         connector._get_connector_metadata = MagicMock(return_value=MagicMock())
-        connector.start_load_kv(MagicMock())
+        connector.start_load_kv(MagicMock(attn_metadata=MagicMock()))
         mock_worker.prepare_save.assert_called_once()
         mock_worker.start_load_kv.assert_called_once()
+
+        # A zero-token scheduler step still loads metadata but has no save to
+        # commit, so it must not prepare one.
+        connector.start_load_kv(MagicMock(attn_metadata=None))
+        mock_worker.prepare_save.assert_called_once()
+        self.assertEqual(mock_worker.start_load_kv.call_count, 2)
 
         # wait_for_save (non-consumer)
         connector.kv_role = "kv_producer"

--- a/tests/ut/distributed/ascend_store/test_kv_transfer.py
+++ b/tests/ut/distributed/ascend_store/test_kv_transfer.py
@@ -538,18 +538,22 @@ class TestKVCacheStoreSendingThread(unittest.TestCase):
         t.delete_finished_stored_request("r1")
         self.assertNotIn("r1", t.stored_requests)
 
-    def test_pending_request_removed_after_all_saves_complete(self):
+    def test_terminal_request_reported_once_after_all_saves_complete(self):
         t, _ = self._make_thread()
         req = MagicMock(req_id="r1", event_id=None)
 
         t.add_stored_request("r1")
         t.add_stored_request("r1")
-        t._complete_request(req)
-        self.assertEqual(t.get_pending_request_ids(), {"r1"})
+        self.assertEqual(t.get_newly_finished_requests({"r1"}), set())
 
         t._complete_request(req)
-        self.assertEqual(t.get_pending_request_ids(), set())
-        self.assertEqual(t.get_and_clear_finished_requests(), set())
+        self.assertEqual(t.get_newly_finished_requests({"r1"}), set())
+
+        t._complete_request(req)
+        self.assertEqual(t.get_newly_finished_requests({"r1"}), {"r1"})
+        self.assertEqual(t.get_newly_finished_requests({"r1"}), set())
+        t.get_newly_finished_requests(set())
+        self.assertEqual(t.finished_requests, set())
 
     def test_dec_nonexistent_request(self):
         t, _ = self._make_thread()

--- a/tests/ut/distributed/ascend_store/test_kv_transfer.py
+++ b/tests/ut/distributed/ascend_store/test_kv_transfer.py
@@ -17,7 +17,7 @@
 
 import threading
 import unittest
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 import numpy as np
 
@@ -538,6 +538,30 @@ class TestKVCacheStoreSendingThread(unittest.TestCase):
         t.delete_finished_stored_request("r1")
         self.assertNotIn("r1", t.stored_requests)
 
+    def test_new_save_invalidates_earlier_completion(self):
+        t, _ = self._make_thread()
+        req = MagicMock(req_id="r1", event_id=None)
+
+        t.add_stored_request("r1")
+        t._complete_request(req)
+        self.assertIn("r1", t.finished_requests)
+
+        t.add_stored_request("r1")
+        self.assertEqual(t.get_and_clear_finished_requests({"r1"}), set())
+
+        t._complete_request(req)
+        self.assertEqual(t.get_and_clear_finished_requests({"r1"}), {"r1"})
+
+    def test_drain_waits_for_prepare_and_put_queues(self):
+        t, _ = self._make_thread()
+        t.request_queue = MagicMock()
+        t.put_thread.request_queue = MagicMock()
+
+        t.drain()
+
+        t.request_queue.join.assert_called_once()
+        t.put_thread.request_queue.join.assert_called_once()
+
     def test_dec_nonexistent_request(self):
         t, _ = self._make_thread()
         t.dec_stored_request("nonexist")  # should not raise
@@ -560,6 +584,89 @@ class TestKVCacheStoreSendingThread(unittest.TestCase):
         t.request_queue.put(req)
         t._handle_request(req)
         event.synchronize.assert_called_once()
+
+    def test_save_batch_prepares_before_commit(self):
+        t, store = self._make_thread([0])
+        t.start()
+        self.assertTrue(t.ready_event.wait(timeout=1))
+        req = ReqMeta(
+            req_id="r1",
+            token_len_chunk=16,
+            block_ids=[0],
+            block_hashes=[b"h0"],  # type: ignore[arg-type]
+        )
+
+        batch = t.prepare_save_batch([req])
+        t.request_queue.join()
+        self.assertEqual(store.put_calls, [])
+
+        event = MagicMock()
+        t.commit_save_batch(batch, event)
+        t.wait_for_batch(batch)
+        self.assertEqual(len(store.put_calls), 1)
+        event.synchronize.assert_called_once()
+
+    def test_save_batch_deduplicates_keys_across_requests(self):
+        t, store = self._make_thread([0])
+        t.start()
+        self.assertTrue(t.ready_event.wait(timeout=1))
+        requests = [
+            ReqMeta(
+                req_id=req_id,
+                token_len_chunk=16,
+                block_ids=[block_id],
+                block_hashes=[b"same-hash"],  # type: ignore[arg-type]
+            )
+            for req_id, block_id in [("r1", 0), ("r2", 1)]
+        ]
+
+        batch = t.prepare_save_batch(requests)
+        t.commit_save_batch(batch, MagicMock())
+        t.wait_for_batch(batch)
+
+        self.assertEqual(len(store.put_calls), 1)
+        self.assertEqual(len(store.put_calls[0][0]), 1)
+
+    def test_save_batch_put_failure_is_nonfatal(self):
+        t, store = self._make_thread([0])
+        error = RuntimeError("put failed")
+        store.put = MagicMock(side_effect=error)
+        t.start()
+        self.assertTrue(t.ready_event.wait(timeout=1))
+        req = ReqMeta(
+            req_id="r1",
+            token_len_chunk=16,
+            block_ids=[0],
+            block_hashes=[b"h0"],  # type: ignore[arg-type]
+        )
+        batch = t.prepare_save_batch([req])
+        with patch(
+            "vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.kv_transfer.logger.exception"
+        ) as log_exception:
+            t.commit_save_batch(batch, MagicMock())
+            t.wait_for_batch(batch)
+        log_exception.assert_called_once_with(
+            "Failed to put AscendStore save batch. type=%s, error=%s",
+            "RuntimeError",
+            error,
+        )
+        self.assertTrue(batch.done.is_set())
+        self.assertNotIn("r1", t.stored_requests)
+
+    def test_save_batch_prepare_failure_is_nonfatal(self):
+        t, _ = self._make_thread()
+        t._prepare_stored_request = MagicMock(side_effect=RuntimeError("prepare failed"))
+        t.start()
+        self.assertTrue(t.ready_event.wait(timeout=1))
+        request = MagicMock(req_id="r1", event_id=None)
+
+        with patch("vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.kv_transfer.logger.exception"):
+            batch = t.prepare_save_batch([request])
+            t.commit_save_batch(batch, MagicMock())
+            t.wait_for_batch(batch)
+
+        self.assertTrue(batch.done.is_set())
+        self.assertNotIn("r1", t.stored_requests)
 
     def test_handle_request_dcp_size_gt_1(self):
         store = FakeStore([0, 0])

--- a/tests/ut/distributed/ascend_store/test_kv_transfer.py
+++ b/tests/ut/distributed/ascend_store/test_kv_transfer.py
@@ -538,19 +538,18 @@ class TestKVCacheStoreSendingThread(unittest.TestCase):
         t.delete_finished_stored_request("r1")
         self.assertNotIn("r1", t.stored_requests)
 
-    def test_new_save_invalidates_earlier_completion(self):
+    def test_pending_request_removed_after_all_saves_complete(self):
         t, _ = self._make_thread()
         req = MagicMock(req_id="r1", event_id=None)
 
         t.add_stored_request("r1")
-        t._complete_request(req)
-        self.assertIn("r1", t.finished_requests)
-
         t.add_stored_request("r1")
-        self.assertEqual(t.get_and_clear_finished_requests({"r1"}), set())
+        t._complete_request(req)
+        self.assertEqual(t.get_pending_request_ids(), {"r1"})
 
         t._complete_request(req)
-        self.assertEqual(t.get_and_clear_finished_requests({"r1"}), {"r1"})
+        self.assertEqual(t.get_pending_request_ids(), set())
+        self.assertEqual(t.get_and_clear_finished_requests(), set())
 
     def test_dec_nonexistent_request(self):
         t, _ = self._make_thread()

--- a/tests/ut/distributed/ascend_store/test_kv_transfer.py
+++ b/tests/ut/distributed/ascend_store/test_kv_transfer.py
@@ -552,16 +552,6 @@ class TestKVCacheStoreSendingThread(unittest.TestCase):
         t._complete_request(req)
         self.assertEqual(t.get_and_clear_finished_requests({"r1"}), {"r1"})
 
-    def test_drain_waits_for_prepare_and_put_queues(self):
-        t, _ = self._make_thread()
-        t.request_queue = MagicMock()
-        t.put_thread.request_queue = MagicMock()
-
-        t.drain()
-
-        t.request_queue.join.assert_called_once()
-        t.put_thread.request_queue.join.assert_called_once()
-
     def test_dec_nonexistent_request(self):
         t, _ = self._make_thread()
         t.dec_stored_request("nonexist")  # should not raise

--- a/tests/ut/distributed/ascend_store/test_pool_worker.py
+++ b/tests/ut/distributed/ascend_store/test_pool_worker.py
@@ -724,48 +724,28 @@ class TestKVPoolWorkerRegisterAndTransfer(unittest.TestCase):
     def test_wait_for_save_keeps_full_batches_async(self):
         worker = self._make_worker()
         send_thread = MagicMock(spec=KVCacheStoreSendingThread)
-        first_batch = KVCacheStoreBatch([])
-        second_batch = KVCacheStoreBatch([])
-        send_thread.prepare_save_batch.side_effect = [first_batch, second_batch]
+        send_thread.prepare_save_batch.return_value = KVCacheStoreBatch([])
         worker.kv_send_thread = send_thread
 
-        first_req = ReqMeta(
+        req = ReqMeta(
             req_id="r1",
             token_len_chunk=16,
+            save_end_token=16,
+            partial_block_index=1,
             block_ids=[0],
             block_hashes=["h0"],
             can_save=True,
         )
-        first_meta = AscendConnectorMetadata(set(), set())
-        first_meta.add_request(first_req)
-        worker.prepare_save(first_meta)
+        meta = AscendConnectorMetadata(set(), set())
+        meta.add_request(req)
+        worker.prepare_save(meta)
         with patch(
             "vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.pool_worker.torch.npu",
             create=True,
         ):
-            worker.wait_for_save(first_meta)
+            worker.wait_for_save(meta)
 
         send_thread.commit_save_batch.assert_called_once()
-        send_thread.wait_for_batch.assert_not_called()
-
-        second_req = ReqMeta(
-            req_id="r2",
-            token_len_chunk=16,
-            block_ids=[1],
-            block_hashes=["h1"],
-            can_save=True,
-        )
-        second_batch.requests = [second_req]
-        second_meta = AscendConnectorMetadata(set(), set())
-        second_meta.add_request(second_req)
-        worker.prepare_save(second_meta)
-        with patch(
-            "vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.pool_worker.torch.npu",
-            create=True,
-        ):
-            worker.wait_for_save(second_meta)
-
-        self.assertEqual(send_thread.commit_save_batch.call_count, 2)
         send_thread.wait_for_batch.assert_not_called()
 
     def test_preemption_drains_only_conflicting_saves(self):
@@ -807,26 +787,6 @@ class TestKVPoolWorkerRegisterAndTransfer(unittest.TestCase):
         ):
             worker.wait_for_save(meta)
         send_thread.wait_for_batch.assert_called_once_with(batch)
-
-    def test_discarded_partial_does_not_force_current_step_fence(self):
-        worker = self._make_worker()
-        send_thread = MagicMock(spec=KVCacheStoreSendingThread)
-        worker.kv_send_thread = send_thread
-        req = ReqMeta(
-            req_id="r1",
-            token_len_chunk=16,
-            save_end_token=16,
-            partial_block_index=1,
-            block_ids=[0],
-            block_hashes=["h0"],
-            can_save=True,
-        )
-        meta = AscendConnectorMetadata(set(), set())
-        meta.add_request(req)
-
-        worker.prepare_save(meta)
-
-        self.assertFalse(send_thread.prepare_save_batch.call_args.kwargs["force_current_step"])
 
     def test_wait_for_save_skip_non_save(self):
         worker = self._make_worker()

--- a/tests/ut/distributed/ascend_store/test_pool_worker.py
+++ b/tests/ut/distributed/ascend_store/test_pool_worker.py
@@ -809,14 +809,14 @@ class TestKVPoolWorkerRegisterAndTransfer(unittest.TestCase):
         worker = self._make_worker(kv_role="kv_producer")
 
         send_thread = MagicMock(spec=KVCacheStoreSendingThread)
-        send_thread.get_pending_request_ids.return_value = {"r2"}
+        send_thread.get_newly_finished_requests.return_value = {"r1"}
         worker.kv_send_thread = send_thread
 
         meta = AscendConnectorMetadata(set(), set(), delayed_free_req_ids={"r1", "r2"})
         done_s, done_r = worker.get_finished({"r1", "r2"}, meta)
         self.assertEqual(done_s, {"r1"})
         self.assertEqual(done_r, set())
-        send_thread.get_pending_request_ids.assert_called_once()
+        send_thread.get_newly_finished_requests.assert_called_once_with({"r1", "r2"})
 
     def test_get_finished_consumer(self):
         worker = self._make_worker(kv_role="kv_consumer")

--- a/tests/ut/distributed/ascend_store/test_pool_worker.py
+++ b/tests/ut/distributed/ascend_store/test_pool_worker.py
@@ -753,7 +753,7 @@ class TestKVPoolWorkerRegisterAndTransfer(unittest.TestCase):
         send_thread = MagicMock(spec=KVCacheStoreSendingThread)
         worker.kv_send_thread = send_thread
 
-        send_thread.get_stored_requests_snapshot.return_value = {"r1": 1}
+        send_thread.get_pending_request_ids.return_value = {"r1"}
         worker.wait_for_preempted_saves({"r2"})
         send_thread.drain.assert_not_called()
 
@@ -808,15 +808,15 @@ class TestKVPoolWorkerRegisterAndTransfer(unittest.TestCase):
     def test_get_finished_producer(self):
         worker = self._make_worker(kv_role="kv_producer")
 
-        send_thread = MagicMock()
-        send_thread.get_and_clear_finished_requests.return_value = {"r1"}
+        send_thread = MagicMock(spec=KVCacheStoreSendingThread)
+        send_thread.get_pending_request_ids.return_value = {"r2"}
         worker.kv_send_thread = send_thread
 
-        meta = AscendConnectorMetadata(set(), set(), delayed_free_req_ids={"r1"})
-        done_s, done_r = worker.get_finished({"r1"}, meta)
-        self.assertIn("r1", done_s)
+        meta = AscendConnectorMetadata(set(), set(), delayed_free_req_ids={"r1", "r2"})
+        done_s, done_r = worker.get_finished({"r1", "r2"}, meta)
+        self.assertEqual(done_s, {"r1"})
         self.assertEqual(done_r, set())
-        send_thread.get_and_clear_finished_requests.assert_called_once_with({"r1"})
+        send_thread.get_pending_request_ids.assert_called_once()
 
     def test_get_finished_consumer(self):
         worker = self._make_worker(kv_role="kv_consumer")

--- a/tests/ut/distributed/ascend_store/test_pool_worker.py
+++ b/tests/ut/distributed/ascend_store/test_pool_worker.py
@@ -30,6 +30,10 @@ from vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.config_data import
     ReqMeta,
     SharedBlockData,
 )
+from vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.kv_transfer import (
+    KVCacheStoreBatch,
+    KVCacheStoreSendingThread,
+)
 
 
 class TestKVPoolWorkerHelpers(unittest.TestCase):
@@ -717,27 +721,116 @@ class TestKVPoolWorkerRegisterAndTransfer(unittest.TestCase):
         kwargs["invalid_block_ids"].add(7)
         self.assertEqual(worker.get_block_ids_with_load_errors(), {7})
 
-    def test_wait_for_save_waits_for_save(self):
+    def test_wait_for_save_keeps_full_batches_async(self):
         worker = self._make_worker()
-        worker.kv_send_thread = MagicMock()
+        send_thread = MagicMock(spec=KVCacheStoreSendingThread)
+        first_batch = KVCacheStoreBatch([])
+        second_batch = KVCacheStoreBatch([])
+        send_thread.prepare_save_batch.side_effect = [first_batch, second_batch]
+        worker.kv_send_thread = send_thread
 
-        req = ReqMeta(
+        first_req = ReqMeta(
             req_id="r1",
             token_len_chunk=16,
             block_ids=[0],
             block_hashes=["h0"],
             can_save=True,
         )
+        first_meta = AscendConnectorMetadata(set(), set())
+        first_meta.add_request(first_req)
+        worker.prepare_save(first_meta)
+        with patch(
+            "vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.pool_worker.torch.npu",
+            create=True,
+        ):
+            worker.wait_for_save(first_meta)
+
+        send_thread.commit_save_batch.assert_called_once()
+        send_thread.wait_for_batch.assert_not_called()
+
+        second_req = ReqMeta(
+            req_id="r2",
+            token_len_chunk=16,
+            block_ids=[1],
+            block_hashes=["h1"],
+            can_save=True,
+        )
+        second_batch.requests = [second_req]
+        second_meta = AscendConnectorMetadata(set(), set())
+        second_meta.add_request(second_req)
+        worker.prepare_save(second_meta)
+        with patch(
+            "vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.pool_worker.torch.npu",
+            create=True,
+        ):
+            worker.wait_for_save(second_meta)
+
+        self.assertEqual(send_thread.commit_save_batch.call_count, 2)
+        send_thread.wait_for_batch.assert_not_called()
+
+    def test_preemption_drains_only_conflicting_saves(self):
+        worker = self._make_worker()
+        send_thread = MagicMock(spec=KVCacheStoreSendingThread)
+        worker.kv_send_thread = send_thread
+
+        send_thread.get_stored_requests_snapshot.return_value = {"r1": 1}
+        worker.wait_for_preempted_saves({"r2"})
+        send_thread.drain.assert_not_called()
+
+        worker.wait_for_preempted_saves({"r1"})
+        send_thread.drain.assert_called_once()
+
+    def test_partial_save_forces_current_step_fence(self):
+        worker = self._make_worker()
+        send_thread = MagicMock(spec=KVCacheStoreSendingThread)
+        batch = KVCacheStoreBatch([])
+        send_thread.prepare_save_batch.return_value = batch
+        worker.kv_send_thread = send_thread
+
+        req = ReqMeta(
+            req_id="r1",
+            token_len_chunk=15,
+            save_end_token=15,
+            block_ids=[0],
+            block_hashes=["h0"],
+            can_save=True,
+        )
         meta = AscendConnectorMetadata(set(), set())
         meta.add_request(req)
-        worker.wait_for_save(meta)
-        worker.kv_send_thread.add_stored_request.assert_called_with("r1")
-        worker.kv_send_thread.add_request.assert_called_once()
-        worker.kv_send_thread.request_queue.join.assert_called_once()
+        worker.prepare_save(meta)
+        self.assertTrue(send_thread.prepare_save_batch.call_args.kwargs["force_current_step"])
+
+        batch.force_current_step = True
+        with patch(
+            "vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.pool_worker.torch.npu",
+            create=True,
+        ):
+            worker.wait_for_save(meta)
+        send_thread.wait_for_batch.assert_called_once_with(batch)
+
+    def test_discarded_partial_does_not_force_current_step_fence(self):
+        worker = self._make_worker()
+        send_thread = MagicMock(spec=KVCacheStoreSendingThread)
+        worker.kv_send_thread = send_thread
+        req = ReqMeta(
+            req_id="r1",
+            token_len_chunk=16,
+            save_end_token=16,
+            partial_block_index=1,
+            block_ids=[0],
+            block_hashes=["h0"],
+            can_save=True,
+        )
+        meta = AscendConnectorMetadata(set(), set())
+        meta.add_request(req)
+
+        worker.prepare_save(meta)
+
+        self.assertFalse(send_thread.prepare_save_batch.call_args.kwargs["force_current_step"])
 
     def test_wait_for_save_skip_non_save(self):
         worker = self._make_worker()
-        worker.kv_send_thread = MagicMock()
+        worker.kv_send_thread = MagicMock(spec=KVCacheStoreSendingThread)
 
         req = ReqMeta(
             req_id="r1",
@@ -749,8 +842,8 @@ class TestKVPoolWorkerRegisterAndTransfer(unittest.TestCase):
         meta = AscendConnectorMetadata(set(), set())
         meta.add_request(req)
         worker.wait_for_save(meta)
-        worker.kv_send_thread.add_stored_request.assert_not_called()
-        worker.kv_send_thread.request_queue.join.assert_not_called()
+        worker.kv_send_thread.prepare_save_batch.assert_not_called()
+        worker.kv_send_thread.wait_for_batch.assert_not_called()
 
     def test_get_finished_producer(self):
         worker = self._make_worker(kv_role="kv_producer")
@@ -759,10 +852,11 @@ class TestKVPoolWorkerRegisterAndTransfer(unittest.TestCase):
         send_thread.get_and_clear_finished_requests.return_value = {"r1"}
         worker.kv_send_thread = send_thread
 
-        meta = AscendConnectorMetadata(set(), set())
+        meta = AscendConnectorMetadata(set(), set(), delayed_free_req_ids={"r1"})
         done_s, done_r = worker.get_finished({"r1"}, meta)
         self.assertIn("r1", done_s)
         self.assertEqual(done_r, set())
+        send_thread.get_and_clear_finished_requests.assert_called_once_with({"r1"})
 
     def test_get_finished_consumer(self):
         worker = self._make_worker(kv_role="kv_consumer")

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/ascend_store_connector.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/ascend_store_connector.py
@@ -226,9 +226,6 @@ class AscendStoreConnector(KVConnectorBase_V1, SupportsHMA):
         assert self.connector_worker is not None
         metadata = self._get_connector_metadata()
         self._current_step_has_real_forward = forward_context is not None
-        # This hook runs before both target-model and deferred MTP forward.
-        # Only CPU-side key/exists/address preparation is submitted here; the
-        # NPU data dependency is recorded and released by wait_for_save.
         self.connector_worker.prepare_save(metadata)
         logger.debug(
             "KV pool connector start_load_kv metadata_requests=%d specs=%s",

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/ascend_store_connector.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/ascend_store_connector.py
@@ -226,6 +226,10 @@ class AscendStoreConnector(KVConnectorBase_V1, SupportsHMA):
         assert self.connector_worker is not None
         metadata = self._get_connector_metadata()
         self._current_step_has_real_forward = forward_context is not None
+        # This hook runs before both target-model and deferred MTP forward.
+        # Only CPU-side key/exists/address preparation is submitted here; the
+        # NPU data dependency is recorded and released by wait_for_save.
+        self.connector_worker.prepare_save(metadata)
         logger.debug(
             "KV pool connector start_load_kv metadata_requests=%d specs=%s",
             len(metadata.requests),
@@ -240,6 +244,11 @@ class AscendStoreConnector(KVConnectorBase_V1, SupportsHMA):
             ],
         )
         self.connector_worker.start_load_kv(metadata)
+
+    def handle_preemptions(self, kv_connector_metadata: KVConnectorMetadata) -> None:
+        assert self.connector_worker is not None
+        preempted_req_ids = getattr(kv_connector_metadata, "preempted_req_ids", set())
+        self.connector_worker.wait_for_preempted_saves(preempted_req_ids)
 
     def wait_for_layer_load(self, layer_name: str) -> None:
         if not self.use_layerwise:

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/ascend_store_connector.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/ascend_store_connector.py
@@ -225,8 +225,9 @@ class AscendStoreConnector(KVConnectorBase_V1, SupportsHMA):
     def start_load_kv(self, forward_context: "ForwardContext", **kwargs) -> None:
         assert self.connector_worker is not None
         metadata = self._get_connector_metadata()
-        self._current_step_has_real_forward = forward_context is not None
-        self.connector_worker.prepare_save(metadata)
+        self._current_step_has_real_forward = forward_context is not None and forward_context.attn_metadata is not None
+        if self._current_step_has_real_forward:
+            self.connector_worker.prepare_save(metadata)
         logger.debug(
             "KV pool connector start_load_kv metadata_requests=%d specs=%s",
             len(metadata.requests),

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/ascend_store_connector.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/ascend_store_connector.py
@@ -244,7 +244,7 @@ class AscendStoreConnector(KVConnectorBase_V1, SupportsHMA):
 
     def handle_preemptions(self, kv_connector_metadata: KVConnectorMetadata) -> None:
         assert self.connector_worker is not None
-        preempted_req_ids = getattr(kv_connector_metadata, "preempted_req_ids", set())
+        preempted_req_ids: set[str] = getattr(kv_connector_metadata, "preempted_req_ids", set())
         self.connector_worker.wait_for_preempted_saves(preempted_req_ids)
 
     def wait_for_layer_load(self, layer_name: str) -> None:

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/kv_transfer.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/kv_transfer.py
@@ -6,6 +6,7 @@ import threading
 import time
 from collections import defaultdict
 from collections.abc import Callable
+from dataclasses import dataclass, field
 from typing import Any
 
 import numpy as np
@@ -36,6 +37,27 @@ def _circular_shift(lst: list, offset: int) -> list:
     if not lst or offset == 0:
         return lst
     return lst[offset:] + lst[:offset]
+
+
+@dataclass
+class PreparedStore:
+    keys: list[str]
+    addrs: list[list[int]]
+    sizes: list[list[int]]
+    stored_events: list[BlockStored] = field(default_factory=list)
+
+
+PreparedRequest = tuple[ReqMeta, list[PreparedStore]]
+
+
+@dataclass
+class KVCacheStoreBatch:
+    requests: list[ReqMeta]
+    force_current_step: bool = False
+    committed: threading.Event = field(default_factory=threading.Event)
+    done: threading.Event = field(default_factory=threading.Event)
+    current_event: Any = None
+    pending_keys: set[str] = field(default_factory=set)
 
 
 class LayerBatchBuilder:
@@ -605,6 +627,27 @@ class KVTransferThread(threading.Thread):
             return self.token_database.decode_adaptor_prefill_pp(keys, addrs, sizes)
 
 
+class KVCacheStorePutThread(KVTransferThread):
+    def __init__(self, owner: KVCacheStoreSendingThread) -> None:
+        super().__init__(
+            owner.m_store,
+            owner.token_database,
+            owner.block_size,
+            owner.tp_rank,
+            owner.tp_size,
+            owner.dcp_size,
+            name="KVCacheStorePutThread",
+        )
+        self.owner = owner
+
+    def _handle_request(self, request_data: tuple[KVCacheStoreBatch, list[PreparedRequest]]) -> None:
+        batch, prepared_requests = request_data
+        try:
+            self.owner._put_batch(batch, prepared_requests)
+        finally:
+            self.request_queue.task_done()
+
+
 class KVCacheStoreSendingThread(KVTransferThread):
     def __init__(
         self,
@@ -632,9 +675,44 @@ class KVCacheStoreSendingThread(KVTransferThread):
         self.completed_events_lock = threading.Lock()
         self.completed_events: dict[int, int] = {}
         self.worker = worker
+        self.put_thread = KVCacheStorePutThread(self)
+
+    def run(self):
+        self.put_thread.start()
+        self.put_thread.ready_event.wait()
+        super().run()
+
+    def prepare_save_batch(
+        self,
+        requests: list[ReqMeta],
+        force_current_step: bool = False,
+    ) -> KVCacheStoreBatch:
+        batch = KVCacheStoreBatch(requests=requests, force_current_step=force_current_step)
+        for request in requests:
+            self.add_stored_request(request.req_id)
+        self.add_request(batch)  # type: ignore[arg-type]
+        return batch
+
+    @staticmethod
+    def commit_save_batch(batch: KVCacheStoreBatch, current_event: Any) -> None:
+        batch.current_event = current_event
+        batch.committed.set()
+
+    def wait_for_batch(self, batch: KVCacheStoreBatch) -> None:
+        while not batch.done.wait(timeout=1.0):
+            self.raise_if_failed()
+            self.put_thread.raise_if_failed()
+
+    def drain(self) -> None:
+        """Finish all saves submitted before the current model step."""
+        self.request_queue.join()
+        self.put_thread.request_queue.join()
 
     def add_stored_request(self, req_id: str):
         with self.done_task_lock:
+            # A request may enqueue multiple save batches. Invalidate a
+            # completion left by an earlier batch before tracking the next one.
+            self.finished_requests.discard(req_id)
             self.stored_requests[req_id] += 1
 
     def is_stored_request(self, req_id: str) -> bool:
@@ -677,7 +755,29 @@ class KVCacheStoreSendingThread(KVTransferThread):
                 self.dec_stored_request(req_id)
         self.request_queue.task_done()
 
-    def _handle_request(self, req_meta: ReqMeta):
+    def _handle_request(self, request_data: ReqMeta | KVCacheStoreBatch):
+        if isinstance(request_data, KVCacheStoreBatch):
+            self._handle_save_batch(request_data)
+            return
+        self._handle_legacy_request(request_data)
+
+    def _handle_save_batch(self, batch: KVCacheStoreBatch) -> None:
+        prepared_requests: list[PreparedRequest] = []
+        try:
+            for request in batch.requests:
+                try:
+                    stores = self._prepare_stored_request(request, batch)
+                except Exception:
+                    logger.exception("Failed to prepare KV cache save for request %s", request.req_id)
+                    stores = []
+                prepared_requests.append((request, stores))
+                for store in stores:
+                    batch.pending_keys.update(store.keys)
+            self.put_thread.add_request((batch, prepared_requests))  # type: ignore[arg-type]
+        finally:
+            self.request_queue.task_done()
+
+    def _handle_legacy_request(self, req_meta: ReqMeta):
         if self.worker is not None and getattr(self.worker, "tp_mismatch", False):
             req_id = req_meta.req_id
             try:
@@ -702,23 +802,60 @@ class KVCacheStoreSendingThread(KVTransferThread):
                 tracked_request = req_id in self.stored_requests
             if not tracked_request:
                 return
-            self._handle_stored_request(req_meta)
+            stores = self._prepare_stored_request(req_meta)
+            if req_meta.current_event is not None and stores:
+                req_meta.current_event.synchronize()
+            for store in stores:
+                self.m_store.put(store.keys, store.addrs, store.sizes)
+                if self.enable_kv_event and store.stored_events:
+                    self.update_kv_event(store.stored_events)
         except Exception:
             logger.exception("Failed to store KV cache for request %s", req_id)
         finally:
-            remaining = self.dec_stored_request(req_id) if tracked_request else None
-            if tracked_request and remaining == 0:
-                self.delete_finished_stored_request(req_id)
-                self.set_finished_request(req_id)
-            if req_meta.event_id is not None:
-                with self.completed_events_lock:
-                    self.completed_events[req_meta.event_id] = 1
+            if tracked_request:
+                self._complete_request(req_meta)
             self.request_queue.task_done()
 
-    def _handle_stored_request(self, req_meta: ReqMeta):
+    def _complete_request(self, req_meta: ReqMeta) -> None:
+        remaining = self.dec_stored_request(req_meta.req_id)
+        if remaining == 0:
+            self.delete_finished_stored_request(req_meta.req_id)
+            self.set_finished_request(req_meta.req_id)
+        if req_meta.event_id is not None:
+            with self.completed_events_lock:
+                self.completed_events[req_meta.event_id] = 1
+
+    def _put_batch(self, batch: KVCacheStoreBatch, prepared_requests: list[PreparedRequest]) -> None:
+        batch.committed.wait()
+        try:
+            has_data = any(stores for _, stores in prepared_requests)
+            if batch.current_event is not None and has_data:
+                batch.current_event.synchronize()
+            for _, stores in prepared_requests:
+                for store in stores:
+                    self.m_store.put(store.keys, store.addrs, store.sizes)
+                    if self.enable_kv_event and store.stored_events:
+                        self.update_kv_event(store.stored_events)
+        except Exception as error:
+            logger.exception(
+                "Failed to put AscendStore save batch. type=%s, error=%s",
+                type(error).__name__,
+                error,
+            )
+        finally:
+            for request, _ in prepared_requests:
+                self._complete_request(request)
+            batch.done.set()
+
+    def _prepare_stored_request(
+        self,
+        req_meta: ReqMeta,
+        batch: KVCacheStoreBatch | None = None,
+    ) -> list[PreparedStore]:
+        """Build missing-key store payloads without waiting for model output."""
         token_len = req_meta.token_len_chunk
         req_id = req_meta.req_id
-        current_event = req_meta.current_event
+        prepared_stores: list[PreparedStore] = []
         try:
             store_masks = self.token_database.store_mask(token_len, req_meta.num_prompt_tokens)
         except AssertionError as exc:
@@ -808,6 +945,10 @@ class KVCacheStoreSendingThread(KVTransferThread):
             if not keys:
                 continue
             exists_states = self.lookup(keys)
+            if batch is not None and batch.pending_keys:
+                exists_states = [
+                    exists or key in batch.pending_keys for key, exists in zip(keys, exists_states, strict=True)
+                ]
             missing_indices = [index for index, exists in enumerate(exists_states) if not exists]
             if not missing_indices:
                 continue
@@ -886,11 +1027,15 @@ class KVCacheStoreSendingThread(KVTransferThread):
                     sizes,
                     kv_cache_group_id=group_id,
                 )
-            if current_event is not None:
-                current_event.synchronize()
-            self.m_store.put(keys, addrs, sizes)
-            if self.enable_kv_event and stored_events:
-                self.update_kv_event(stored_events)
+            prepared_stores.append(
+                PreparedStore(
+                    keys=keys,
+                    addrs=addrs,
+                    sizes=sizes,
+                    stored_events=stored_events,
+                )
+            )
+        return prepared_stores
 
 
 class KVCacheStoreRecvingThread(KVTransferThread):

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/kv_transfer.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/kv_transfer.py
@@ -710,8 +710,7 @@ class KVCacheStoreSendingThread(KVTransferThread):
 
     def add_stored_request(self, req_id: str):
         with self.done_task_lock:
-            # A request may enqueue multiple save batches. Invalidate a
-            # completion left by an earlier batch before tracking the next one.
+            # Invalidate completion from an earlier batch.
             self.finished_requests.discard(req_id)
             self.stored_requests[req_id] += 1
 

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/kv_transfer.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/kv_transfer.py
@@ -710,28 +710,27 @@ class KVCacheStoreSendingThread(KVTransferThread):
 
     def add_stored_request(self, req_id: str):
         with self.done_task_lock:
-            # Invalidate completion from an earlier batch.
-            self.finished_requests.discard(req_id)
             self.stored_requests[req_id] += 1
 
     def is_stored_request(self, req_id: str) -> bool:
         with self.done_task_lock:
             return req_id in self.stored_requests
 
-    def get_stored_request_count(self, req_id: str) -> int | None:
+    def get_pending_request_ids(self) -> set[str]:
         with self.done_task_lock:
-            return self.stored_requests.get(req_id)
-
-    def get_stored_requests_snapshot(self) -> dict[str, int]:
-        with self.done_task_lock:
-            return dict(self.stored_requests)
+            return set(self.stored_requests)
 
     def dec_stored_request(self, req_id: str):
         with self.done_task_lock:
-            if req_id in self.stored_requests:
-                self.stored_requests[req_id] -= 1
-                return self.stored_requests[req_id]
-            return None
+            count = self.stored_requests.get(req_id)
+            if count is None:
+                return None
+            remaining = count - 1
+            if remaining:
+                self.stored_requests[req_id] = remaining
+            else:
+                del self.stored_requests[req_id]
+            return remaining
 
     def delete_finished_stored_request(self, req_id: str):
         with self.done_task_lock:
@@ -784,10 +783,6 @@ class KVCacheStoreSendingThread(KVTransferThread):
             except Exception:
                 logger.exception("Failed to store KV cache for TP-mismatch request %s", req_id)
             finally:
-                remaining = self.get_stored_request_count(req_id)
-                if remaining == 0:
-                    self.delete_finished_stored_request(req_id)
-                    self.set_finished_request(req_id)
                 if req_meta.event_id is not None:
                     with self.completed_events_lock:
                         self.completed_events[req_meta.event_id] = 1
@@ -816,10 +811,7 @@ class KVCacheStoreSendingThread(KVTransferThread):
             self.request_queue.task_done()
 
     def _complete_request(self, req_meta: ReqMeta) -> None:
-        remaining = self.dec_stored_request(req_meta.req_id)
-        if remaining == 0:
-            self.delete_finished_stored_request(req_meta.req_id)
-            self.set_finished_request(req_meta.req_id)
+        self.dec_stored_request(req_meta.req_id)
         if req_meta.event_id is not None:
             with self.completed_events_lock:
                 self.completed_events[req_meta.event_id] = 1

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/kv_transfer.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/kv_transfer.py
@@ -720,6 +720,14 @@ class KVCacheStoreSendingThread(KVTransferThread):
         with self.done_task_lock:
             return set(self.stored_requests)
 
+    def get_newly_finished_requests(self, req_ids: set[str]) -> set[str]:
+        with self.done_task_lock:
+            # Keep reports sticky until the scheduler drops the request.
+            self.finished_requests.intersection_update(req_ids)
+            newly_finished = req_ids.difference(self.stored_requests.keys(), self.finished_requests)
+            self.finished_requests.update(newly_finished)
+            return newly_finished
+
     def dec_stored_request(self, req_id: str):
         with self.done_task_lock:
             count = self.stored_requests.get(req_id)

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/pool_worker.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/pool_worker.py
@@ -52,6 +52,7 @@ from vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.coordinator import
     ExternalCachedBlockPool,
 )
 from vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.kv_transfer import (
+    KVCacheStoreBatch,
     KVCacheStoreKeyLayerRecvingThread,
     KVCacheStoreKeyLayerSendingThread,
     KVCacheStoreLayerRecvingThread,
@@ -332,6 +333,7 @@ class KVPoolWorker:
         self.kv_send_thread: KVTransferThread | None = None
         self.kv_recv_thread: KVTransferThread | None = None
         self._transfer_threads_started = False
+        self._prepared_save_batch: KVCacheStoreBatch | None = None
         self.external_slot_release_waiter: Callable[[int], None] | None = None
         # Per-rank GVA cache: maps per-rank store key to its allocated GVA.
         # batch_alloc is non-idempotent (returns MMC_DUPLICATED_OBJECT for an
@@ -1759,25 +1761,67 @@ class KVPoolWorker:
 
         self.current_layer = self.current_layer + 1
 
-    def wait_for_save(self, connector_metadata: AscendConnectorMetadata):
-        current_event = None
-        assert self.kv_send_thread is not None
-        send_thread = self.kv_send_thread
+    def _requires_current_step_save_fence(self, request: ReqMeta) -> bool:
+        return any(
+            request.save_end_token % self._get_effective_group_block_size(group_id) != 0
+            for group_id in request.kv_cache_group_ids or [0]
+        )
 
-        for request in connector_metadata.requests:
-            can_save = request.can_save
-            if can_save is None or not can_save:
-                continue
-            if current_event is None:
-                current_event = torch.npu.Event()
-                current_event.record()
+    def prepare_save(self, connector_metadata: AscendConnectorMetadata) -> None:
+        """Submit key/exists/address preparation before model forward."""
+        if self.use_layerwise or self.tp_mismatch:
+            return
+        if self.kv_role == "kv_consumer" and not self.consumer_is_to_put:
+            return
+        if self._prepared_save_batch is not None:
+            raise RuntimeError("AscendStore save batch was prepared twice without a commit")
+        if not isinstance(self.kv_send_thread, KVCacheStoreSendingThread):
+            return
+
+        self.kv_send_thread.raise_if_failed()
+        requests = [request for request in connector_metadata.requests if request.can_save]
+        if not requests:
+            return
+        for request in requests:
             request.skip_null_blocks_by_group = self.group_uses_align_state
-            request.current_event = current_event
-            send_thread.add_stored_request(request.req_id)
-            send_thread.add_request(request)
+        force_current_step = any(self._requires_current_step_save_fence(request) for request in requests)
+        self._prepared_save_batch = self.kv_send_thread.prepare_save_batch(
+            requests,
+            force_current_step=force_current_step,
+        )
 
-        if current_event is not None:
-            send_thread.request_queue.join()
+    def wait_for_save(self, connector_metadata: AscendConnectorMetadata) -> None:
+        if self.tp_mismatch:
+            current_event = None
+            assert self.kv_send_thread is not None
+            for request in connector_metadata.requests:
+                if not request.can_save:
+                    continue
+                if current_event is None:
+                    current_event = torch.npu.Event()
+                    current_event.record()
+                request.skip_null_blocks_by_group = self.group_uses_align_state
+                request.current_event = current_event
+                self.kv_send_thread.add_stored_request(request.req_id)
+                self.kv_send_thread.add_request(request)
+            if current_event is not None:
+                self.kv_send_thread.request_queue.join()
+            return
+        if self.use_layerwise:
+            return
+        if not isinstance(self.kv_send_thread, KVCacheStoreSendingThread):
+            return
+
+        current_batch = self._prepared_save_batch
+        self._prepared_save_batch = None
+
+        if current_batch is not None:
+            current_event = torch.npu.Event()
+            current_event.record()
+            self.kv_send_thread.commit_save_batch(current_batch, current_event)
+
+        if current_batch is not None and current_batch.force_current_step:
+            self.kv_send_thread.wait_for_batch(current_batch)
 
     def retrieve_layer(
         self,
@@ -2114,6 +2158,13 @@ class KVPoolWorker:
             self.tp_rank,
         )
         return done_sending, done_recving
+
+    def wait_for_preempted_saves(self, req_ids: set[str]) -> None:
+        """Fence saves whose source KV blocks are about to be reused."""
+        if not req_ids or not isinstance(self.kv_send_thread, KVCacheStoreSendingThread):
+            return
+        if not req_ids.isdisjoint(self.kv_send_thread.get_stored_requests_snapshot()):
+            self.kv_send_thread.drain()
 
     def ensure_store_initialized(self) -> None:
         ensure_initialized = getattr(self.m_store, "ensure_initialized", None)

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/pool_worker.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/pool_worker.py
@@ -2138,8 +2138,7 @@ class KVPoolWorker:
                 done_sending = set()
             else:
                 assert isinstance(send_thread, KVCacheStoreSendingThread)
-                pending_req_ids = send_thread.get_pending_request_ids()
-                done_sending = meta.delayed_free_req_ids - pending_req_ids
+                done_sending = send_thread.get_newly_finished_requests(meta.delayed_free_req_ids)
         else:
             done_sending = set()
 

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/pool_worker.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/pool_worker.py
@@ -2126,7 +2126,7 @@ class KVPoolWorker:
         finally:
             send_thread.dec_stored_request(req_id)  # type: ignore[attr-defined]
 
-    def get_finished(self, finished_req_ids: set[str], meta: AscendConnectorMetadata) -> tuple[set[str], set[str]]:
+    def get_finished(self, _finished_req_ids: set[str], meta: AscendConnectorMetadata) -> tuple[set[str], set[str]]:
         if self.kv_send_thread is not None:
             send_thread = self.kv_send_thread
             for req_id in meta.preempted_req_ids:
@@ -2137,9 +2137,9 @@ class KVPoolWorker:
                 self.kv_send_thread.get_and_clear_finished_requests()
                 done_sending = set()
             else:
-                stale_finished_req_ids = finished_req_ids - meta.delayed_free_req_ids
-                self.kv_send_thread.discard_finished_requests(stale_finished_req_ids)
-                done_sending = self.kv_send_thread.get_and_clear_finished_requests(meta.delayed_free_req_ids)
+                assert isinstance(send_thread, KVCacheStoreSendingThread)
+                pending_req_ids = send_thread.get_pending_request_ids()
+                done_sending = meta.delayed_free_req_ids - pending_req_ids
         else:
             done_sending = set()
 
@@ -2161,7 +2161,7 @@ class KVPoolWorker:
         """Fence saves whose source KV blocks are about to be reused."""
         if not req_ids or not isinstance(self.kv_send_thread, KVCacheStoreSendingThread):
             return
-        if not req_ids.isdisjoint(self.kv_send_thread.get_stored_requests_snapshot()):
+        if not req_ids.isdisjoint(self.kv_send_thread.get_pending_request_ids()):
             self.kv_send_thread.drain()
 
     def ensure_store_initialized(self) -> None:

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/pool_worker.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/pool_worker.py
@@ -1761,12 +1761,6 @@ class KVPoolWorker:
 
         self.current_layer = self.current_layer + 1
 
-    def _requires_current_step_save_fence(self, request: ReqMeta) -> bool:
-        return any(
-            request.save_end_token % self._get_effective_group_block_size(group_id) != 0
-            for group_id in request.kv_cache_group_ids or [0]
-        )
-
     def prepare_save(self, connector_metadata: AscendConnectorMetadata) -> None:
         """Submit key/exists/address preparation before model forward."""
         if self.use_layerwise or self.tp_mismatch:
@@ -1784,7 +1778,11 @@ class KVPoolWorker:
             return
         for request in requests:
             request.skip_null_blocks_by_group = self.group_uses_align_state
-        force_current_step = any(self._requires_current_step_save_fence(request) for request in requests)
+        force_current_step = any(
+            request.save_end_token % self._get_effective_group_block_size(group_id) != 0
+            for request in requests
+            for group_id in request.kv_cache_group_ids or [0]
+        )
         self._prepared_save_batch = self.kv_send_thread.prepare_save_batch(
             requests,
             force_current_step=force_current_step,
@@ -1814,13 +1812,13 @@ class KVPoolWorker:
 
         current_batch = self._prepared_save_batch
         self._prepared_save_batch = None
+        if current_batch is None:
+            return
 
-        if current_batch is not None:
-            current_event = torch.npu.Event()
-            current_event.record()
-            self.kv_send_thread.commit_save_batch(current_batch, current_event)
-
-        if current_batch is not None and current_batch.force_current_step:
+        current_event = torch.npu.Event()
+        current_event.record()
+        self.kv_send_thread.commit_save_batch(current_batch, current_event)
+        if current_batch.force_current_step:
             self.kv_send_thread.wait_for_batch(current_batch)
 
     def retrieve_layer(


### PR DESCRIPTION
### What this PR does / why we need it?

This is an independent alternative to #15150. It prepares AscendStore keys, existence results, and addresses before target-model/MTP forward, then runs backend puts on a dedicated thread.

Full-block saves remain asynchronous across steps. `get_finished()` reports each scheduler-terminal request once per worker after its pending puts finish, without generating per-step completion markers. Actual partial blocks keep the current-step fence, and preemption drains only when the preempted request still has a pending save. Layerwise and TP-mismatch paths remain synchronous; backlog throttling is intentionally out of scope.

### Does this PR introduce _any_ user-facing change?

No API or configuration change.

### How was this patch tested?

- `python -m pytest -q tests/ut/distributed/ascend_store`: 402 passed, 10 skipped.
- `ws-verify --repo <worktree> hooks`: all hooks passed.

NPU performance and end-to-end accuracy validation require an Ascend runner.

- vLLM main: https://github.com/vllm-project/vllm/commit/d02df748bf9efd99022f1a062597dc3cb3808485
