### PR TITLE
fix(model): stabilize Qwen3.8 Flash-Next graph and eager MTP on Ascend

### DIFF
--- a/docs/source/tutorials/models/Qwen3.8-Flash-Next.md
+++ b/docs/source/tutorials/models/Qwen3.8-Flash-Next.md
@@ -1,0 +1,222 @@
+# Qwen3.8-Flash-Next
+
+## 1 Introduction
+
+Qwen3.8-Flash-Next is an experimental multimodal MoE model with 125B language-model parameters (6B activated), a 51B n-gram embedding, and a 4B MTP head. Its `Qwen4ExpForConditionalGeneration` architecture combines Gated DeltaNet and Qwen Sparse Attention (QSA), four-stream Gated Residual connections, Position Learning Enhancement (PLE), vision input, and a native 262,144-token context window.
+
+Support on Ascend is experimental. For the v0.26.0 release stack, the plugin
+vendors the Qwen4Exp model and weight loader from upstream vLLM PRs 53896 and
+53899, then replaces CUDA-only QSA, PLE, and HyperConnection glue with
+NPU-compatible implementations. Run the real-weight and accuracy gates on the
+target hardware before production use.
+
+## 2 Supported Features
+
+| Feature | Status | Notes |
+|---|---|---|
+| Text generation | Experimental | The v0.26 adapter contains the required Qwen4Exp backport |
+| Image and video input | Experimental | Reuses the Qwen3-VL processor and vision encoder |
+| Expert parallelism | Experimental | The model has 512 routed experts |
+| ACLGraph | Unverified | Start with graph mode; use eager mode only for isolation |
+| FlashComm1 | Unverified | Deprecated in current vLLM Ascend; do not use for the initial gate |
+| MTP | Experimental | Register `Qwen4ExpMTP` through the Ascend adapter |
+| PLE CPU offload | Unsupported | Upstream implementation uses CUDA IPC stream semaphores |
+
+Refer to the [Supported Features List](../../user_guide/support_matrix/supported_models.md) and [Feature Guide](../../user_guide/feature_guide/index.md) for general platform options.
+
+## 3 Environment Preparation
+
+The BF16 checkpoint contains approximately 176B parameters including the n-gram embedding and MTP weights. TP8 is the initial single-node validation configuration because 24 query heads are divisible by 8; confirm actual memory use on the selected machine.
+
+=== "Atlas 800 A3"
+
+    ```bash
+    export IMAGE=quay.io/ascend/vllm-ascend:latest-a3
+    docker run --rm -it \
+      --shm-size=1g \
+      --name vllm-ascend-qwen38-flash-next \
+      --device /dev/davinci0 \
+      --device /dev/davinci1 \
+      --device /dev/davinci2 \
+      --device /dev/davinci3 \
+      --device /dev/davinci4 \
+      --device /dev/davinci5 \
+      --device /dev/davinci6 \
+      --device /dev/davinci7 \
+      --device /dev/davinci_manager \
+      --device /dev/devmm_svm \
+      --device /dev/hisi_hdc \
+      -v /usr/local/dcmi:/usr/local/dcmi \
+      -v /usr/local/bin/npu-smi:/usr/local/bin/npu-smi \
+      -v /usr/local/Ascend/driver/lib64:/usr/local/Ascend/driver/lib64 \
+      -v /models:/models \
+      -p 8000:8000 \
+      "$IMAGE" bash
+    ```
+
+=== "Atlas 800 A2"
+
+    ```bash
+    export IMAGE=quay.io/ascend/vllm-ascend:latest
+    docker run --rm -it \
+      --shm-size=1g \
+      --name vllm-ascend-qwen38-flash-next \
+      --device /dev/davinci0 \
+      --device /dev/davinci1 \
+      --device /dev/davinci2 \
+      --device /dev/davinci3 \
+      --device /dev/davinci4 \
+      --device /dev/davinci5 \
+      --device /dev/davinci6 \
+      --device /dev/davinci7 \
+      --device /dev/davinci_manager \
+      --device /dev/devmm_svm \
+      --device /dev/hisi_hdc \
+      -v /usr/local/dcmi:/usr/local/dcmi \
+      -v /usr/local/bin/npu-smi:/usr/local/bin/npu-smi \
+      -v /usr/local/Ascend/driver/lib64:/usr/local/Ascend/driver/lib64 \
+      -v /models:/models \
+      -p 8000:8000 \
+      "$IMAGE" bash
+    ```
+
+Install the paired vLLM v0.26.0 build, then install the vLLM Ascend adapter from
+source. The Qwen4Exp model sources required by this release are contained in the
+adapter; a separately patched vLLM checkout is not required. Do not upgrade
+`transformers` independently from the versions pinned by the two projects.
+
+```bash
+cd /vllm-workspace/vllm
+pip install -e .
+cd /vllm-workspace/vllm-ascend
+pip install -e .
+python -c "import vllm, vllm_ascend; print(vllm.__file__); print(vllm_ascend.__file__)"
+```
+
+## 4 Deployment
+
+First validate architecture and API wiring with dummy weights:
+
+```bash
+cd /workspace
+HCCL_OP_EXPANSION_MODE=AIV \
+vllm serve /models/Qwen3.8-Flash-Next \
+  --served-model-name qwen3.8-flash-next \
+  --trust-remote-code \
+  --dtype bfloat16 \
+  --tensor-parallel-size 8 \
+  --enable-expert-parallel \
+  --max-model-len 131072 \
+  --max-num-seqs 16 \
+  --load-format dummy \
+  --port 8000
+```
+
+Dummy weights do not validate the PLE embedding shards, QSA cache updates, quantization scales, or checkpoint key mapping. Repeat the command without `--load-format dummy` for the mandatory real-weight gate.
+
+The real-weight MTP and graph-mode verification configuration is:
+
+```bash
+mkdir -p /home/w00804037/Qwen3.8-flash/Logs
+
+vllm serve /models/Qwen3.8-Flash-Next \
+  --host 0.0.0.0 \
+  --port 8010 \
+  --served-model-name qwen3.8-flash-next \
+  --trust-remote-code \
+  --tensor-parallel-size 8 \
+  --pipeline-parallel-size 2 \
+  --enable-expert-parallel \
+  --max-model-len 4096 \
+  --max-num-seqs 1 \
+  --max-num-batched-tokens 4096 \
+  --async-scheduling \
+  --no-enable-prefix-caching \
+  --speculative-config '{"method":"qwen4_exp_mtp","num_speculative_tokens":3}' \
+  --compilation-config '{"cudagraph_mode":"FULL_DECODE_ONLY"}' \
+  --additional-config '{"ascend_compilation_config":{"fuse_norm_quant":false}}' \
+  > /home/w00804037/Qwen3.8-flash/Logs/serve-mtp-full-decode.log 2>&1
+```
+
+Do not specify `cudagraph_capture_sizes`; this configuration deliberately uses
+the platform defaults. `fuse_norm_quant` is disabled because CANN versions that
+do not provide `aclnnAddRmsNormBias` cannot compile that fusion. This does not
+disable `FULL_DECODE_ONLY` graph capture.
+
+If graph capture fails, add `--enforce-eager` to isolate the failure. Do not enable `VLLM_PLE_CPU_OFFLOAD`; the upstream offload transport is CUDA-only.
+
+If eager mode still fails inside TorchDynamo while isolating a portable QSA
+operator, retry once with `TORCHDYNAMO_DISABLE=1` before reporting the first
+failing operator and stack trace. This is a diagnostic fallback, not the
+supported performance configuration.
+
+## 5 Functional Verification
+
+Check readiness and then require a non-empty generated response:
+
+```bash
+curl -sf http://127.0.0.1:8000/v1/models
+
+curl -s http://127.0.0.1:8000/v1/chat/completions \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "model": "qwen3.8-flash-next",
+    "messages": [{"role": "user", "content": "Say hi."}],
+    "temperature": 0,
+    "max_tokens": 16
+  }'
+```
+
+For multimodal verification, send one image request using the same OpenAI-compatible endpoint and require HTTP 200 with non-empty `choices`. A successful startup log without a successful request is not a pass.
+
+## 6 Accuracy Evaluation
+
+Run the model evaluation suite only after real-weight text and multimodal smoke tests pass:
+
+```bash
+pytest -sv tests/e2e/models/test_lm_eval_correctness.py \
+  --config tests/e2e/models/configs/Qwen3.8-Flash-Next.yaml \
+  --tp-size 8
+```
+
+Add the YAML baseline after recording the real Ascend result. Do not use the model-card score as an Ascend accuracy result because the evaluation harness and runtime differ.
+
+## 7 Performance
+
+The Torch QSA fallback prioritizes functional portability and has not been performance-tuned. After correctness validation, benchmark representative text and multimodal workloads:
+
+```bash
+vllm bench serve \
+  --model Qwen/Qwen3.8-Flash-Next \
+  --served-model-name qwen3.8-flash-next \
+  --dataset-name random \
+  --random-input-len 2048 \
+  --random-output-len 256 \
+  --num-prompts 200 \
+  --request-rate 1
+```
+
+Report the theoretical context limit (262,144 tokens) separately from the largest context that passes real-weight inference on the tested hardware. The initial capacity gate is 131,072 tokens with `max-num-seqs=16`.
+
+## 8 Validation Status
+
+The real-weight eager baseline was validated on 16 Ascend NPUs with CANN 9.1.0,
+TP8, PP2, and expert parallelism. `/health`, `/v1/models`, and a two-token text
+completion succeeded and the service remained healthy.
+
+The MTP3, asynchronous-scheduling, and `FULL_DECODE_ONLY` validation was then
+used to identify and fix these integration failures:
+
+- unsupported generic `mtp` method: use `qwen4_exp_mtp` and normalize the draft config;
+- unavailable `aclnnAddRmsNormBias`: set `fuse_norm_quant=false`;
+- missing multimodal arguments on `embed_input_ids`: accept the runner signature;
+- invalid dynamic specialization of `query_start_loc`: keep its graph shape static;
+- PP2 MTP feedback width of 2560 instead of four HC streams: use
+  `hidden_size * hc_count` and treat the local last-stage drafter as its first
+  logical stage.
+
+The graph-mode service and GPQA accuracy gates have not passed yet. The current
+logs under `/home/w00804037/Qwen3.8-flash/Logs` end during engine initialization,
+so no GPQA score is reported by this PR. Rerun both gates after deploying the
+integrated patch; do not interpret the eager smoke test as graph-mode or
+accuracy validation.

--- a/docs/source/tutorials/models/index.md
+++ b/docs/source/tutorials/models/index.md
@@ -1,3 +1,5 @@
 # Model Tutorials
 
 This section provides tutorials for different models of vLLM Ascend.
+
+- [Qwen3.8-Flash-Next](Qwen3.8-Flash-Next.md)

--- a/tests/ut/models/qwen4_exp/test_ops.py
+++ b/tests/ut/models/qwen4_exp/test_ops.py
@@ -1,0 +1,129 @@
+# Copyright (c) 2026 Huawei Technologies Co., Ltd. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import torch
+
+from vllm_ascend.models.qwen4_exp.ops import (
+    grouped_gemma_rmsnorm,
+    hc_combine,
+    hc_gate_mix,
+    qsa_compress_groups_with_ratio,
+    qsa_select_paged_tokens,
+    qsa_sparse_paged_attention,
+    qsa_store_cache_rows,
+)
+
+
+def test_hyperconnection_torch_fallbacks() -> None:
+    hidden_states = torch.tensor([[1.0, 2.0, 3.0, 4.0]])
+    weight = torch.zeros(2)
+    normalized = grouped_gemma_rmsnorm(hidden_states, weight, 1e-6, 2)
+    expected = hidden_states.unflatten(-1, (2, 2))
+    expected = expected / torch.sqrt(expected.square().mean(-1, keepdim=True) + 1e-6)
+    torch.testing.assert_close(normalized, expected.flatten(-2))
+
+    gate = torch.zeros_like(hidden_states)
+    mixed = hc_gate_mix(hidden_states, gate, 2)
+    torch.testing.assert_close(mixed, hidden_states.unflatten(-1, (2, 2)).mean(-2) / 2)
+
+    block_output = torch.tensor([[2.0, 4.0]])
+    injection = torch.zeros((1, 2))
+    combined = hc_combine(hidden_states, block_output, injection, 2)
+    torch.testing.assert_close(
+        combined,
+        (hidden_states.unflatten(-1, (2, 2)) + block_output.unsqueeze(-2)).flatten(-2),
+    )
+
+
+def test_qsa_store_cache_rows_ignores_padding_slots() -> None:
+    cache = torch.zeros((2, 2, 1, 2))
+    rows = torch.tensor([[[1.0, 2.0]], [[3.0, 4.0]], [[5.0, 6.0]]])
+    qsa_store_cache_rows(cache, torch.tensor([2, -1, 0]), rows)
+    torch.testing.assert_close(cache.reshape(-1, 2)[0], rows[2, 0])
+    torch.testing.assert_close(cache.reshape(-1, 2)[2], rows[0, 0])
+    assert torch.count_nonzero(cache).item() == 4
+
+
+def test_qsa_store_cache_rows_updates_non_contiguous_layout() -> None:
+    storage = torch.zeros((2, 2, 2, 3))
+    cache = storage.transpose(1, 2)
+    assert not cache.is_contiguous()
+    rows = torch.tensor(
+        [
+            [[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]],
+            [[7.0, 8.0, 9.0], [10.0, 11.0, 12.0]],
+        ]
+    )
+    qsa_store_cache_rows(cache, torch.tensor([1, 2]), rows)
+    torch.testing.assert_close(cache[0, 1], rows[0])
+    torch.testing.assert_close(cache[1, 0], rows[1])
+    torch.testing.assert_close(storage[0, :, 1], rows[0])
+    torch.testing.assert_close(storage[1, :, 0], rows[1])
+
+
+def test_qsa_compresses_current_group() -> None:
+    raw_keys = torch.arange(8, dtype=torch.float32).reshape(4, 1, 2)
+    positions = torch.arange(4).reshape(4, 1, 1).expand(-1, 1, 3)
+    state_cache = torch.zeros((1, 4, 1, 2))
+    pooled, first_positions = qsa_compress_groups_with_ratio(
+        raw_keys,
+        positions,
+        state_cache,
+        torch.tensor([[0]]),
+        torch.zeros(4, dtype=torch.int32),
+        torch.tensor([0, 4]),
+        torch.arange(4),
+        torch.tensor([-1, -1, -1, 0]),
+        4,
+        None,
+    )
+    torch.testing.assert_close(pooled[3], raw_keys.float().mean(0))
+    torch.testing.assert_close(first_positions[3], torch.zeros(3, dtype=torch.int64))
+    assert torch.count_nonzero(pooled[:3]).item() == 0
+
+
+def test_qsa_selection_and_sparse_attention() -> None:
+    compressed_cache = torch.zeros((1, 4, 1, 2))
+    compressed_cache[0, :, 0] = torch.tensor([[1.0, 0.0], [0.0, 1.0], [2.0, 0.0], [0.0, 2.0]])
+    query = torch.tensor([[[1.0, 0.0]]])
+    selected = qsa_select_paged_tokens(
+        query,
+        compressed_cache,
+        torch.tensor([[0]]),
+        torch.tensor([0]),
+        torch.tensor([15]),
+        torch.tensor([16]),
+        token_topk=4,
+        compress_ratio=2,
+    )
+    assert selected.shape == (1, 5)
+    assert set(selected[0, :4].tolist()) == {0, 1, 4, 5}
+
+    key_cache = torch.zeros((1, 8, 1, 2))
+    value_cache = torch.zeros_like(key_cache)
+    key_cache[0, 0, 0] = torch.tensor([1.0, 0.0])
+    key_cache[0, 1, 0] = torch.tensor([0.0, 1.0])
+    value_cache[0, 0, 0] = torch.tensor([2.0, 0.0])
+    value_cache[0, 1, 0] = torch.tensor([0.0, 4.0])
+    output = qsa_sparse_paged_attention(
+        query,
+        key_cache,
+        value_cache,
+        torch.tensor([[0, 1]], dtype=torch.int32),
+        torch.tensor([[0]]),
+        torch.tensor([0]),
+    )
+    probabilities = torch.softmax(torch.tensor([1.0, 0.0]) / 2**0.5, dim=0)
+    expected = probabilities[0] * value_cache[0, 0, 0] + probabilities[1] * value_cache[0, 1, 0]
+    torch.testing.assert_close(output[0, 0], expected)

--- a/tests/ut/models/qwen4_exp/test_ops.py
+++ b/tests/ut/models/qwen4_exp/test_ops.py
@@ -72,6 +72,28 @@ def test_qsa_store_cache_rows_updates_non_contiguous_layout() -> None:
     torch.testing.assert_close(storage[1, :, 0], rows[1])
 
 
+def test_qsa_store_cache_rows_uses_only_aligned_prefix() -> None:
+    cache = torch.zeros((1, 4, 1, 2))
+    rows = torch.tensor([[[1.0, 2.0]], [[3.0, 4.0]], [[5.0, 6.0]]])
+    qsa_store_cache_rows(cache, torch.tensor([2]), rows)
+    torch.testing.assert_close(cache[0, 2], rows[0])
+    assert torch.count_nonzero(cache).item() == 2
+
+    cache.zero_()
+    qsa_store_cache_rows(cache, torch.tensor([1, 2, 3]), rows[:1])
+    torch.testing.assert_close(cache[0, 1], rows[0])
+    assert torch.count_nonzero(cache).item() == 2
+
+
+def test_qsa_store_cache_rows_invalid_slots_do_not_change_slot_zero() -> None:
+    cache = torch.zeros((1, 4, 1, 2))
+    cache[0, 0] = torch.tensor([[9.0, 10.0]])
+    rows = torch.tensor([[[1.0, 2.0]], [[3.0, 4.0]], [[5.0, 6.0]]])
+    qsa_store_cache_rows(cache, torch.tensor([-1, 0, 99]), rows)
+    torch.testing.assert_close(cache[0, 0], rows[1])
+    assert torch.count_nonzero(cache).item() == 2
+
+
 def test_qsa_compresses_current_group() -> None:
     raw_keys = torch.arange(8, dtype=torch.float32).reshape(4, 1, 2)
     positions = torch.arange(4).reshape(4, 1, 1).expand(-1, 1, 3)

--- a/tests/ut/models/qwen4_exp/test_ple_source_regression.py
+++ b/tests/ut/models/qwen4_exp/test_ple_source_regression.py
@@ -1,0 +1,125 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Source and CPU regressions for the Qwen4Exp PLE graph-safe path."""
+
+from __future__ import annotations
+
+import ast
+import copy
+from pathlib import Path
+from typing import Callable
+
+import torch
+import torch.nn.functional as F
+
+ROOT = Path(__file__).resolve().parents[4]
+NVIDIA_PLE = (
+    ROOT / "vllm_ascend" / "models" / "qwen4_exp" / "nvidia" / "ple_layer.py"
+)
+NVIDIA_MODEL = (
+    ROOT / "vllm_ascend" / "models" / "qwen4_exp" / "nvidia" / "model.py"
+)
+AMD_PLE = ROOT / "vllm_ascend" / "models" / "qwen4_exp" / "amd" / "ple_layer.py"
+AMD_MODEL = ROOT / "vllm_ascend" / "models" / "qwen4_exp" / "amd" / "model.py"
+
+
+def _method_node(path: Path, class_name: str, method_name: str) -> ast.FunctionDef:
+    tree = ast.parse(path.read_text())
+    for node in tree.body:
+        if isinstance(node, ast.ClassDef) and node.name == class_name:
+            for child in node.body:
+                if isinstance(child, ast.FunctionDef) and child.name == method_name:
+                    return child
+    raise AssertionError(f"method {class_name}.{method_name} not found in {path}")
+
+
+def _standalone_method(method_name: str) -> Callable:
+    method = copy.deepcopy(
+        _method_node(NVIDIA_PLE, "Qwen4ExpPLELayer", method_name)
+    )
+    method.decorator_list = []
+    module = ast.Module(body=[method], type_ignores=[])
+    ast.fix_missing_locations(module)
+    namespace = {"torch": torch}
+    exec(compile(module, NVIDIA_PLE, "exec"), namespace)
+    return namespace[method_name]
+
+
+def test_short_conv_cross_correlation_matches_conv1d() -> None:
+    implementation = _standalone_method("_short_conv_cross_correlation")
+    torch.manual_seed(20260827)
+    channels = 8
+    kernel_size = 4
+    dilation = 3
+    effective_kernel_size = dilation * (kernel_size - 1) + 1
+    weights = torch.randn(channels, kernel_size)
+
+    for history_len in (effective_kernel_size, effective_kernel_size + 4):
+        history = torch.randn(2, channels, history_len)
+        expected = F.conv1d(
+            history,
+            weights.unsqueeze(1),
+            groups=channels,
+            dilation=dilation,
+        )
+        actual = implementation(history, weights, dilation)
+        torch.testing.assert_close(actual, expected)
+
+
+def test_conv_state_rows_use_contiguous_storage_layout() -> None:
+    gather = _standalone_method("_gather_conv_state_rows")
+    scatter = _standalone_method("_scatter_conv_state_rows")
+    storage = torch.arange(4 * 7 * 5, dtype=torch.float32).reshape(4, 7, 5)
+    conv_state = storage.transpose(-1, -2)
+    indices = torch.tensor([3, 1])
+    assert conv_state.stride() == (35, 1, 5)
+    assert conv_state.transpose(-1, -2).is_contiguous()
+
+    selected = gather(conv_state, indices)
+    torch.testing.assert_close(selected, conv_state.index_select(0, indices))
+
+    updated = selected + 1000
+    scatter(conv_state, indices, updated)
+    torch.testing.assert_close(conv_state.index_select(0, indices), updated)
+
+
+def test_ple_state_shape_reserves_speculative_history() -> None:
+    for path in (NVIDIA_MODEL, AMD_MODEL):
+        source = ast.unparse(
+            _method_node(
+                path,
+                "Qwen4ExpForCausalLM",
+                "get_ple_mamba_state_shape_from_config",
+            )
+        )
+        assert "vllm_config.num_speculative_tokens" in source
+
+    for path in (NVIDIA_PLE, AMD_PLE):
+        source = ast.unparse(
+            _method_node(path, "Qwen4ExpPLELayer", "get_state_shape")
+        )
+        assert "self.num_spec_tokens" in source
+
+
+def test_nvidia_model_does_not_compile_query_start_loc_as_dynamic() -> None:
+    tree = ast.parse(NVIDIA_MODEL.read_text())
+    model = next(
+        node
+        for node in tree.body
+        if isinstance(node, ast.ClassDef) and node.name == "Qwen4ExpModel"
+    )
+    assignment = next(
+        node
+        for node in model.body
+        if isinstance(node, ast.Assign)
+        and any(
+            isinstance(target, ast.Name) and target.id == "dynamic_arg_dims"
+            for target in node.targets
+        )
+    )
+    assert isinstance(assignment.value, ast.Dict)
+    keys = {
+        key.value
+        for key in assignment.value.keys
+        if isinstance(key, ast.Constant) and isinstance(key.value, str)
+    }
+    assert "query_start_loc" not in keys

--- a/tests/ut/models/test_qwen4_exp_hc.py
+++ b/tests/ut/models/test_qwen4_exp_hc.py
@@ -1,0 +1,107 @@
+import torch
+
+from vllm_ascend import models
+from vllm_ascend.models.qwen4_exp.config import Qwen4ExpTextConfig
+from vllm_ascend.ops.triton.qwen4_exp.hc import (
+    grouped_gemma_rmsnorm,
+    hc_combine,
+    hc_combine_norm,
+    hc_gate_mix,
+    hc_silu,
+)
+
+
+def test_qwen4_exp_architectures_are_registered(monkeypatch) -> None:
+    registered: dict[str, str] = {}
+
+    monkeypatch.setattr(
+        models.ModelRegistry,
+        "register_model",
+        lambda architecture, target: registered.__setitem__(architecture, target),
+    )
+
+    models.register_model()
+
+    assert registered["Qwen4ExpForCausalLM"] == ("vllm_ascend.models.qwen4_exp:AscendQwen4ExpForCausalLM")
+    assert registered["Qwen4ExpForConditionalGeneration"] == (
+        "vllm_ascend.models.qwen4_exp:AscendQwen4ExpForConditionalGeneration"
+    )
+    assert registered["Qwen4ExpMTP"] == ("vllm_ascend.models.qwen4_exp:AscendQwen4ExpMTP")
+
+
+def test_qwen4_exp_config_is_owned_by_plugin() -> None:
+    config = Qwen4ExpTextConfig(
+        hidden_size=64,
+        num_hidden_layers=2,
+        num_attention_heads=4,
+        num_key_value_heads=2,
+        intermediate_size=128,
+        head_dim=16,
+        ple_layer_ids=[1],
+        ple_embed_dim=64,
+        ngram_size=3,
+        heads_per_ngram=4,
+        layer_types=["full_attention", "linear_attention"],
+    )
+
+    assert config.model_type == "qwen4_exp_text"
+    assert config.short_conv_layer_ids == [0]
+    assert config.ngram_context_len == 2
+
+
+def test_hyperconnection_ops_match_torch_reference() -> None:
+    torch.manual_seed(0)
+    hc_count = 4
+    group_dim = 8
+    residual = torch.randn(3, hc_count * group_dim, dtype=torch.bfloat16)
+    gate = torch.randn_like(residual)
+    block_output = torch.randn(3, group_dim, dtype=torch.bfloat16)
+    injection = torch.randn(3, hc_count, dtype=torch.bfloat16)
+    weight = torch.randn(hc_count * group_dim, dtype=torch.bfloat16)
+    eps = 1e-6
+
+    actual_silu = hc_silu(gate, hc_count)
+    expected_silu = torch.nn.functional.silu(gate.float() / hc_count).to(gate.dtype)
+    torch.testing.assert_close(actual_silu, expected_silu)
+
+    actual_mix = hc_gate_mix(residual, gate, hc_count)
+    expected_mix = (
+        (torch.sigmoid(gate.float()) * residual.float()).view(3, hc_count, group_dim).mean(1).to(residual.dtype)
+    )
+    torch.testing.assert_close(actual_mix, expected_mix)
+
+    actual_combined = hc_combine(residual, block_output, injection, hc_count)
+    expected_injection = 2 * torch.sigmoid(injection.float() / hc_count)
+    expected_combined = residual.float().view(3, hc_count, group_dim)
+    expected_combined = expected_combined + (block_output.float().unsqueeze(1) * expected_injection.unsqueeze(-1))
+    expected_combined = expected_combined.to(residual.dtype).view_as(residual)
+    torch.testing.assert_close(actual_combined, expected_combined)
+
+    actual_norm = grouped_gemma_rmsnorm(actual_combined, weight, eps, hc_count)
+    grouped = actual_combined.float().view(3, hc_count, group_dim)
+    expected_norm = grouped * torch.rsqrt(grouped.square().mean(-1, keepdim=True) + eps)
+    expected_norm = (
+        (expected_norm * (1 + weight.float().view(1, hc_count, group_dim))).to(residual.dtype).view_as(residual)
+    )
+    torch.testing.assert_close(actual_norm, expected_norm)
+
+    combined, normalized = hc_combine_norm(
+        residual,
+        block_output,
+        injection,
+        weight,
+        eps,
+        hc_count,
+    )
+    torch.testing.assert_close(combined, actual_combined)
+    torch.testing.assert_close(normalized, actual_norm)
+
+
+def test_grouped_norm_accepts_shared_affine() -> None:
+    x = torch.randn(2, 16, dtype=torch.bfloat16)
+    shared_weight = torch.randn(4, dtype=torch.bfloat16)
+
+    result = grouped_gemma_rmsnorm(x, shared_weight, 1e-6, 4)
+
+    assert result.shape == x.shape
+    assert result.dtype == x.dtype

--- a/tests/ut/spec_decode/test_qwen4_exp_cache_groups.py
+++ b/tests/ut/spec_decode/test_qwen4_exp_cache_groups.py
@@ -1,0 +1,65 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Unit regressions for Qwen4Exp MTP hybrid KV-cache groups."""
+
+from types import SimpleNamespace
+
+import torch
+from vllm.v1.kv_cache_interface import (
+    FullAttentionSpec,
+    KVCacheConfig,
+    KVCacheGroupSpec,
+    UniformTypeKVCacheSpecs,
+)
+
+from vllm_ascend.spec_decode.qwen4_exp import Qwen4ExpMTPProposer
+
+
+def _attention_spec() -> FullAttentionSpec:
+    return FullAttentionSpec(
+        block_size=16,
+        num_kv_heads=1,
+        head_size=64,
+        dtype=torch.bfloat16,
+    )
+
+
+def test_map_draft_layer_accepts_direct_group_spec() -> None:
+    layer_name = "model.mtp.0.self_attn"
+    spec = _attention_spec()
+    config = KVCacheConfig(
+        num_blocks=2,
+        kv_cache_tensors=[],
+        kv_cache_groups=[
+            KVCacheGroupSpec(layer_names=[layer_name], kv_cache_spec=spec)
+        ],
+    )
+    proposer = SimpleNamespace(_draft_attn_layer_names={layer_name})
+
+    layer_to_gid, layer_to_spec = (
+        Qwen4ExpMTPProposer._map_draft_layers_to_groups(proposer, config)
+    )
+
+    assert layer_to_gid == {layer_name: 0}
+    assert layer_to_spec == {layer_name: spec}
+
+
+def test_map_draft_layer_accepts_uniform_group_spec() -> None:
+    layer_name = "model.mtp.0.self_attn"
+    spec = _attention_spec()
+    uniform = UniformTypeKVCacheSpecs.from_specs({layer_name: spec})
+    assert uniform is not None
+    config = KVCacheConfig(
+        num_blocks=2,
+        kv_cache_tensors=[],
+        kv_cache_groups=[
+            KVCacheGroupSpec(layer_names=[layer_name], kv_cache_spec=uniform)
+        ],
+    )
+    proposer = SimpleNamespace(_draft_attn_layer_names={layer_name})
+
+    layer_to_gid, layer_to_spec = (
+        Qwen4ExpMTPProposer._map_draft_layers_to_groups(proposer, config)
+    )
+
+    assert layer_to_gid == {layer_name: 0}
+    assert layer_to_spec == {layer_name: spec}

--- a/tests/ut/spec_decode/test_qwen4_exp_source_regression.py
+++ b/tests/ut/spec_decode/test_qwen4_exp_source_regression.py
@@ -13,6 +13,9 @@ PROPOSER = ROOT / "vllm_ascend" / "spec_decode" / "eagle_proposer.py"
 DISPATCHER = ROOT / "vllm_ascend" / "spec_decode" / "__init__.py"
 QSA = ROOT / "vllm_ascend" / "models" / "qwen4_exp" / "qsa.py"
 EAGLE = ROOT / "vllm_ascend" / "spec_decode" / "eagle_proposer.py"
+LOCAL_PROPOSER = ROOT / "vllm_ascend" / "spec_decode" / "qwen4_exp.py"
+BASE_PROPOSER = ROOT / "vllm_ascend" / "spec_decode" / "llm_base_proposer.py"
+MODEL_RUNNER = ROOT / "vllm_ascend" / "worker" / "model_runner_v1.py"
 
 
 def _class(path: Path, name: str) -> ast.ClassDef:
@@ -92,3 +95,33 @@ def test_qwen4_exp_mtp_type_is_registered_for_vllm_026() -> None:
     ).read_text()
     assert "qwen4_exp_mtp" in patch
     assert "MTPModelTypes" in patch
+
+
+def test_qwen4_exp_proposer_allocates_full_hc_hidden_buffer() -> None:
+    source = ast.unparse(
+        _method(PROPOSER, "AscendQwen4ExpMTPProposer", "__init__")
+    )
+    assert "qwen_hidden_size = self._get_hidden_size()" in source
+    assert "self.hidden_states = torch.zeros" in source
+
+
+def test_qwen4_exp_proposer_accepts_both_cache_group_forms() -> None:
+    source = ast.unparse(
+        _method(LOCAL_PROPOSER, "Qwen4ExpMTPProposer", "_map_draft_layers_to_groups")
+    )
+    assert "isinstance(group_spec, UniformTypeKVCacheSpecs)" in source
+    assert "spec = group_spec" in source
+
+
+def test_qwen4_exp_runner_forwards_per_group_block_tables() -> None:
+    source = MODEL_RUNNER.read_text()
+    assert "AscendQwen4ExpMTPProposer" in source
+    assert "set_per_group_block_table" in source
+
+
+def test_spec_proposer_normalizes_multiple_of_block_size() -> None:
+    source = ast.unparse(
+        _method(BASE_PROPOSER, "AscendSpecDecodeBaseProposer", "__init__")
+    )
+    assert "isinstance(kernel_block_size, MultipleOf)" in source
+    assert "kernel_block_size.base" in source

--- a/tests/ut/spec_decode/test_qwen4_exp_source_regression.py
+++ b/tests/ut/spec_decode/test_qwen4_exp_source_regression.py
@@ -33,6 +33,8 @@ def _method(path: Path, cls_name: str, method_name: str) -> ast.FunctionDef:
 def test_qwen4_exp_mtp_uses_local_drafter_inputs_on_last_pp_stage() -> None:
     source = ast.unparse(_method(MTP, "AscendQwen4ExpMultiTokenPredictor", "forward"))
     assert "get_pp_group().is_first_rank or intermediate_tensors is None" in source
+    assert "positions.ndim > 1" in source
+    assert "hidden_states.reshape(-1, hidden_size)" in source
 
 
 def test_qwen4_exp_mtp_accepts_multimodal_embedding_arguments() -> None:
@@ -76,3 +78,17 @@ def test_qwen4_exp_proposer_uses_local_backport() -> None:
     source = EAGLE.read_text()
     assert "from vllm_ascend.spec_decode.qwen4_exp import" in source
     assert "from vllm.v1.spec_decode.qwen4_exp import" not in source
+
+
+def test_qwen4_exp_proposer_bypasses_generic_tp_padding() -> None:
+    source = ast.unparse(_class(PROPOSER, "AscendQwen4ExpMTPProposer"))
+    assert "def maybe_pad_and_reduce" in source
+    assert "def maybe_all_gather_and_unpad" in source
+
+
+def test_qwen4_exp_mtp_type_is_registered_for_vllm_026() -> None:
+    patch = (
+        ROOT / "vllm_ascend" / "patch" / "platform" / "patch_speculative_config.py"
+    ).read_text()
+    assert "qwen4_exp_mtp" in patch
+    assert "MTPModelTypes" in patch

--- a/tests/ut/spec_decode/test_qwen4_exp_source_regression.py
+++ b/tests/ut/spec_decode/test_qwen4_exp_source_regression.py
@@ -16,6 +16,7 @@ EAGLE = ROOT / "vllm_ascend" / "spec_decode" / "eagle_proposer.py"
 LOCAL_PROPOSER = ROOT / "vllm_ascend" / "spec_decode" / "qwen4_exp.py"
 BASE_PROPOSER = ROOT / "vllm_ascend" / "spec_decode" / "llm_base_proposer.py"
 MODEL_RUNNER = ROOT / "vllm_ascend" / "worker" / "model_runner_v1.py"
+OPS = ROOT / "vllm_ascend" / "models" / "qwen4_exp" / "ops.py"
 
 
 def _class(path: Path, name: str) -> ast.ClassDef:
@@ -125,3 +126,43 @@ def test_spec_proposer_normalizes_multiple_of_block_size() -> None:
     )
     assert "isinstance(kernel_block_size, MultipleOf)" in source
     assert "kernel_block_size.base" in source
+
+
+def test_qsa_indexer_uses_portable_torch_chain() -> None:
+    source = ast.unparse(_method(QSA, "AscendQSAIndexer", "forward"))
+    project = source.index("self.project_qk")
+    update = source.index("self._update_and_compress")
+    select = source.index("self._select")
+    assert project < update < select
+
+
+def test_qsa_graph_path_has_no_host_sync_or_debug_probes() -> None:
+    metadata = ast.unparse(_method(QSA, "AscendQSAIndexer", "_metadata"))
+    assert "torch.equal" not in metadata
+    qsa_source = QSA.read_text()
+    for diagnostic in (
+        "QSA_CAPTURE_",
+        "sys.getrefcount",
+        "data_ptr()",
+        "logging.getLogger",
+    ):
+        assert diagnostic not in qsa_source
+
+
+def test_qsa_cache_write_keeps_static_update_width() -> None:
+    source = ast.unparse(
+        next(
+            node
+            for node in ast.parse(OPS.read_text()).body
+            if isinstance(node, ast.FunctionDef)
+            and node.name == "qsa_store_cache_rows"
+        )
+    )
+    assert "masked_select" not in source
+    assert "index_put_" in source
+    assert "accumulate=True" in source
+
+
+def test_qsa_ascend_backend_uses_merged_cache_layout() -> None:
+    source = MODEL_RUNNER.read_text()
+    assert '"QWEN4_EXP_QSA_ASCEND"' in source

--- a/tests/ut/spec_decode/test_qwen4_exp_source_regression.py
+++ b/tests/ut/spec_decode/test_qwen4_exp_source_regression.py
@@ -1,0 +1,78 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Source-level regressions for Qwen3.8-Flash-Next MTP integration."""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[3]
+MODEL = ROOT / "vllm_ascend" / "models" / "qwen4_exp" / "model.py"
+MTP = ROOT / "vllm_ascend" / "models" / "qwen4_exp" / "mtp.py"
+PROPOSER = ROOT / "vllm_ascend" / "spec_decode" / "eagle_proposer.py"
+DISPATCHER = ROOT / "vllm_ascend" / "spec_decode" / "__init__.py"
+QSA = ROOT / "vllm_ascend" / "models" / "qwen4_exp" / "qsa.py"
+EAGLE = ROOT / "vllm_ascend" / "spec_decode" / "eagle_proposer.py"
+
+
+def _class(path: Path, name: str) -> ast.ClassDef:
+    tree = ast.parse(path.read_text())
+    for node in tree.body:
+        if isinstance(node, ast.ClassDef) and node.name == name:
+            return node
+    raise AssertionError(f"class {name} not found in {path}")
+
+
+def _method(path: Path, cls_name: str, method_name: str) -> ast.FunctionDef:
+    for node in _class(path, cls_name).body:
+        if isinstance(node, ast.FunctionDef) and node.name == method_name:
+            return node
+    raise AssertionError(f"method {cls_name}.{method_name} not found")
+
+
+def test_qwen4_exp_mtp_uses_local_drafter_inputs_on_last_pp_stage() -> None:
+    source = ast.unparse(_method(MTP, "AscendQwen4ExpMultiTokenPredictor", "forward"))
+    assert "get_pp_group().is_first_rank or intermediate_tensors is None" in source
+
+
+def test_qwen4_exp_mtp_accepts_multimodal_embedding_arguments() -> None:
+    method = _method(MTP, "AscendQwen4ExpMTP", "embed_input_ids")
+    arguments = [argument.arg for argument in method.args.args]
+    assert arguments == [
+        "self",
+        "input_ids",
+        "multimodal_embeddings",
+        "is_multimodal",
+    ]
+
+
+def test_qwen4_exp_proposer_uses_text_hyperconnection_width() -> None:
+    source = ast.unparse(_method(PROPOSER, "AscendQwen4ExpMTPProposer", "_get_hidden_size"))
+    assert "self.draft_model_config.hf_text_config" in source
+    assert "text_config.hidden_size * text_config.hc_count" in source
+    assert ".get_hidden_size()" not in source
+
+
+def test_qwen4_exp_proposer_is_dispatched_before_generic_mtp() -> None:
+    source = DISPATCHER.read_text()
+    qwen_dispatch = source.index("use_qwen4_exp_mtp")
+    generic_dispatch = source.index("return AscendEagleProposer", qwen_dispatch)
+    assert qwen_dispatch < generic_dispatch
+
+
+def test_qwen4_exp_graph_does_not_mark_query_start_loc_dynamic() -> None:
+    source = ast.unparse(_method(MODEL, "AscendQwen4ExpModel", "__init__"))
+    assert "name !=" in source
+    assert "query_start_loc" in source
+
+
+def test_qwen4_exp_wrappers_use_vendored_model_sources() -> None:
+    sources = "\n".join(path.read_text() for path in (MODEL, MTP, QSA))
+    assert "vllm.models.qwen4_exp" not in sources
+    assert "from .nvidia" in sources
+
+
+def test_qwen4_exp_proposer_uses_local_backport() -> None:
+    source = EAGLE.read_text()
+    assert "from vllm_ascend.spec_decode.qwen4_exp import" in source
+    assert "from vllm.v1.spec_decode.qwen4_exp import" not in source

--- a/tests/ut/worker/a2/test_model_runner_v1.py
+++ b/tests/ut/worker/a2/test_model_runner_v1.py
@@ -704,6 +704,67 @@ class TestNPUModelRunnerKVCache(unittest.TestCase):
         self.assertEqual(indexer_scale_cache.dtype, torch.float16)
 
 
+class TestQwen4ExpPleInputs(unittest.TestCase):
+    def _build_runner(self):
+        runner = NPUModelRunner.__new__(NPUModelRunner)
+        runner.model_config = SimpleNamespace(
+            hf_text_config=SimpleNamespace(
+                ple_layer_ids=[0],
+                ngram_size=3,
+                eos_token_id=999,
+            )
+        )
+        runner.max_num_reqs = 2
+        runner.device = torch.device("cpu")
+        runner._qwen4_exp_ngram_context_buffer = None
+        runner.input_ids = SimpleNamespace(gpu=torch.tensor([5], dtype=torch.int32))
+        runner.query_start_loc = SimpleNamespace(
+            gpu=torch.tensor([0, 1], dtype=torch.int32)
+        )
+        runner.input_batch = SimpleNamespace(
+            num_computed_tokens_cpu=np.array([3], dtype=np.int32),
+            token_ids_cpu=np.array([[7, 8, 9, 0]], dtype=np.int32),
+        )
+        return runner
+
+    def test_ngram_context_keeps_address_and_refreshes_values(self):
+        runner = self._build_runner()
+        dummy_kwargs = {}
+        runner._maybe_add_qwen4_exp_ple_inputs(
+            dummy_kwargs,
+            num_tokens=1,
+            num_reqs=1,
+            num_reqs_padded=1,
+            is_dummy=True,
+        )
+        dummy_context = dummy_kwargs["ngram_context"]
+        stable_ptr = dummy_context.data_ptr()
+        self.assertEqual(dummy_context.tolist(), [[999, 999]])
+
+        real_kwargs = {}
+        runner._maybe_add_qwen4_exp_ple_inputs(
+            real_kwargs,
+            num_tokens=1,
+            num_reqs=1,
+            num_reqs_padded=1,
+        )
+        real_context = real_kwargs["ngram_context"]
+        self.assertEqual(real_context.data_ptr(), stable_ptr)
+        self.assertEqual(real_context.tolist(), [[8, 9]])
+
+        external = torch.tensor([[33, 44]], dtype=torch.int32)
+        external_kwargs = {"ngram_context": external}
+        runner._maybe_add_qwen4_exp_ple_inputs(
+            external_kwargs,
+            num_tokens=1,
+            num_reqs=1,
+            num_reqs_padded=1,
+        )
+        copied_context = external_kwargs["ngram_context"]
+        self.assertEqual(copied_context.data_ptr(), stable_ptr)
+        self.assertEqual(copied_context.tolist(), [[33, 44]])
+
+
 class TestNPUModelRunnerOutputTokenIds(unittest.TestCase):
     def _build_runner(self):
         runner = NPUModelRunner.__new__(NPUModelRunner)

--- a/tests/ut/worker/a2/test_model_runner_v1.py
+++ b/tests/ut/worker/a2/test_model_runner_v1.py
@@ -120,6 +120,40 @@ class TestNPUModelRunnerKVCache(unittest.TestCase):
         self.assertEqual(k_cache_raw.numel(), kv_cache_spec.page_size_bytes)
         self.assertEqual(v_cache_raw.numel(), kv_cache_spec.page_size_bytes)
 
+    def test_allocate_packed_kv_cache_reuses_one_backing(self):
+        runner = self._build_runner()
+        layer_names = ["model.layers.0.attn", "model.layers.1.attn"]
+        layer_specs = {
+            name: FullAttentionSpec(
+                block_size=2,
+                num_kv_heads=1,
+                head_size=4,
+                dtype=torch.bfloat16,
+            )
+            for name in layer_names
+        }
+        runner._get_layer_kv_cache_specs = MagicMock(return_value=layer_specs)
+        total_size = 128
+        block_stride = 32
+        kv_cache_config = KVCacheConfig(
+            num_blocks=total_size // block_stride,
+            kv_cache_tensors=[
+                KVCacheTensor(
+                    size=total_size,
+                    shared_by=[name],
+                    offset=index * 16,
+                    block_stride=block_stride,
+                )
+                for index, name in enumerate(layer_names)
+            ],
+            kv_cache_groups=[],
+        )
+
+        raw_caches = runner._allocate_kv_cache_tensors(kv_cache_config)
+
+        self.assertIs(raw_caches[layer_names[0]], raw_caches[layer_names[1]])
+        self.assertEqual(raw_caches[layer_names[0]].numel(), total_size)
+
     def test_get_layer_kv_cache_specs_restores_sfa_indexer_spec(self):
         runner = self._build_runner()
         layer_name = "model.layers.1.self_attn.indexer.k_cache"

--- a/vllm_ascend/__init__.py
+++ b/vllm_ascend/__init__.py
@@ -70,8 +70,14 @@ def register_service_profiling():
 
 
 def register_model():
+    _ensure_global_patch()
+
+    from vllm_ascend.models.qwen4_exp.config import register_qwen4_exp_config
+    from vllm_ascend.models.qwen4_exp.vllm_config import register_qwen4_exp_vllm_config
     from vllm_ascend.transformers_utils.configs.kimi_k3 import register_kimi_k3_config
 
+    register_qwen4_exp_config()
+    register_qwen4_exp_vllm_config()
     register_kimi_k3_config()
 
     from vllm_ascend.patch.hunyuan_vl_processor_compat import (

--- a/vllm_ascend/core/kv_cache_interface.py
+++ b/vllm_ascend/core/kv_cache_interface.py
@@ -9,10 +9,46 @@ from vllm.config import VllmConfig
 from vllm.utils.math_utils import cdiv
 from vllm.utils.torch_utils import get_dtype_size
 from vllm.v1.core.single_type_kv_cache_manager import FullAttentionManager, SlidingWindowManager
-from vllm.v1.kv_cache_interface import FullAttentionSpec, MLAAttentionSpec, SlidingWindowMLASpec
+from vllm.v1.kv_cache_interface import (
+    AttentionSpec,
+    FullAttentionSpec,
+    KVCacheSpec,
+    MLAAttentionSpec,
+    SlidingWindowMLASpec,
+)
 from vllm.v1.kv_cache_spec_registry import KVCacheSpecRegistry
 
-from vllm_ascend.core.single_type_kv_cache_manager import CompressAttentionManager
+from vllm_ascend.core.single_type_kv_cache_manager import (
+    CircularBufferManager,
+    CompressAttentionManager,
+)
+
+
+@dataclass(frozen=True, kw_only=True)
+class AscendCircularBufferSpec(AttentionSpec):
+    """One fixed-capacity raw-key ring block for each active request."""
+
+    @property
+    def real_page_size_bytes(self) -> int:
+        # This cache stores keys only. vLLM 0.26's AttentionSpec assumes a
+        # conventional K/V pair, so override its factor-of-two page sizing.
+        return (
+            self.block_size
+            * self.num_kv_heads
+            * self.head_size
+            * get_dtype_size(self.dtype)
+        )
+
+    def max_memory_usage_bytes(self, vllm_config: VllmConfig) -> int:
+        del vllm_config
+        return self.page_size_bytes
+
+    def max_num_blocks_per_req(self, vllm_config: VllmConfig, max_len: int) -> int:
+        del vllm_config, max_len
+        return 1
+
+    def is_uniform_with_collection(self, kv_cache_specs: dict[str, KVCacheSpec]) -> bool:
+        return all(isinstance(spec, AscendCircularBufferSpec) for spec in kv_cache_specs.values())
 
 
 @dataclass(frozen=True, kw_only=True)
@@ -218,6 +254,11 @@ class AscendSlidingWindowMLASpec(SlidingWindowMLASpec):
 
 
 def register_ascend_kv_cache_specs() -> None:
+    KVCacheSpecRegistry.register(
+        kvcache_spec_cls=AscendCircularBufferSpec,
+        manager_class=CircularBufferManager,
+        uniform_type_base_spec=AscendCircularBufferSpec,
+    )
     KVCacheSpecRegistry.register(
         kvcache_spec_cls=AscendMLAAttentionSpec,
         manager_class=CompressAttentionManager,

--- a/vllm_ascend/core/single_type_kv_cache_manager.py
+++ b/vllm_ascend/core/single_type_kv_cache_manager.py
@@ -2,7 +2,7 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 import itertools
 from collections.abc import Sequence
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, ClassVar
 
 from vllm.utils.math_utils import cdiv
 from vllm.v1.core.block_pool import BlockPool
@@ -61,6 +61,7 @@ class CompressAttentionManager(FullAttentionManager):
             num_tokens_main_model,
             apply_admission_cap=apply_admission_cap,
         )
+
 
     def allocate_new_computed_blocks(
         self,
@@ -324,3 +325,117 @@ def get_manager_for_kv_cache_spec(
             )
     manager = manager_class(kv_cache_spec, **kwargs)
     return manager
+
+
+class CircularBufferManager(FullAttentionManager):
+    """Own exactly one non-prefix-cacheable ring block per request."""
+
+    supports_fine_grained_hash_lookup: ClassVar[bool] = False
+
+    def _claim_ring_block(self, request_id: str) -> list[KVCacheBlock]:
+        req_blocks = self.req_to_blocks[request_id]
+        if req_blocks:
+            return []
+        new_blocks = self.block_pool.get_new_blocks(1)
+        req_blocks.extend(new_blocks)
+        if self._record_new_block_ids:
+            self.new_block_ids.extend(block.block_id for block in new_blocks)
+        return new_blocks
+
+    def get_num_blocks_to_allocate(
+        self,
+        request_id: str,
+        num_tokens: int,
+        new_computed_blocks: Sequence[KVCacheBlock],
+        total_computed_tokens: int,
+        num_local_computed_tokens: int,
+        num_tokens_main_model: int,
+        apply_admission_cap: bool = False,
+    ) -> int:
+        del (
+            num_tokens,
+            new_computed_blocks,
+            total_computed_tokens,
+            num_local_computed_tokens,
+            num_tokens_main_model,
+            apply_admission_cap,
+        )
+        return 0 if self.req_to_blocks.get(request_id) else 1
+
+    def allocate_new_blocks(
+        self, request_id: str, num_tokens: int, num_tokens_main_model: int
+    ) -> list[KVCacheBlock]:
+        del num_tokens, num_tokens_main_model
+        return self._claim_ring_block(request_id)
+
+    def allocate_external_computed_blocks(
+        self,
+        request_id: str,
+        num_local_computed_tokens: int,
+        num_external_computed_tokens: int,
+    ) -> None:
+        del num_local_computed_tokens, num_external_computed_tokens
+        self._claim_ring_block(request_id)
+
+    @classmethod
+    def find_longest_cache_hit(
+        cls,
+        block_hashes: BlockHashList,
+        max_length: int,
+        kv_cache_group_ids: list[int],
+        block_pool: BlockPool,
+        kv_cache_spec: KVCacheSpec,
+        drop_eagle_block: bool,
+        alignment_tokens: int,
+        dcp_world_size: int = 1,
+        pcp_world_size: int = 1,
+    ) -> tuple[tuple[list[KVCacheBlock], ...], int]:
+        del (
+            block_hashes,
+            max_length,
+            block_pool,
+            kv_cache_spec,
+            drop_eagle_block,
+            alignment_tokens,
+            dcp_world_size,
+            pcp_world_size,
+        )
+        return tuple([] for _ in kv_cache_group_ids), 0
+
+    def cache_blocks(
+        self,
+        request: Request,
+        num_tokens: int,
+        retention_interval: int | None = None,
+    ) -> None:
+        del request, num_tokens, retention_interval
+
+    def add_local_computed_blocks(
+        self,
+        request_id: str,
+        new_computed_blocks: Sequence[KVCacheBlock],
+        num_local_computed_tokens: int,
+        num_external_computed_tokens: int,
+    ) -> None:
+        del (
+            request_id,
+            new_computed_blocks,
+            num_local_computed_tokens,
+            num_external_computed_tokens,
+        )
+
+    def remove_skipped_blocks(
+        self,
+        request_id: str,
+        processed_computed_tokens: int,
+        num_prompt_tokens: int | None = None,
+    ) -> None:
+        del request_id, processed_computed_tokens, num_prompt_tokens
+
+    def get_num_common_prefix_blocks(self, running_request_id: str) -> int:
+        del running_request_id
+        return 0
+
+    def get_num_skipped_tokens(self, num_computed_tokens: int) -> int:
+        del num_computed_tokens
+        return 0

--- a/vllm_ascend/envs.py
+++ b/vllm_ascend/envs.py
@@ -104,6 +104,14 @@ env_variables: dict[str, Callable[[], Any]] = {
     # Control the aclrtMemcpyBatchAsync compile path for KV cache offloading.
     # "1": force enable, "0": force disable, None: auto-detect from CANN headers.
     "VLLM_ASCEND_ENABLE_BATCH_MEMCPY": lambda: os.getenv("VLLM_ASCEND_ENABLE_BATCH_MEMCPY", None),
+    # Compatibility switches for Qwen3.8 Flash-Next on older CANN/Triton images.
+    # Both are non-sensitive booleans and default to the optimized kernel paths.
+    "VLLM_ASCEND_FORCE_GDN_TORCH_FALLBACK": lambda: bool(
+        int(os.getenv("VLLM_ASCEND_FORCE_GDN_TORCH_FALLBACK", "0"))
+    ),
+    "VLLM_ASCEND_FORCE_QSA_REFERENCE": lambda: bool(
+        int(os.getenv("VLLM_ASCEND_FORCE_QSA_REFERENCE", "0"))
+    ),
 }
 
 # end-env-vars-definition

--- a/vllm_ascend/models/__init__.py
+++ b/vllm_ascend/models/__init__.py
@@ -3,6 +3,18 @@ from vllm import ModelRegistry
 
 def register_model():
     ModelRegistry.register_model(
+        "Qwen4ExpForCausalLM",
+        "vllm_ascend.models.qwen4_exp:AscendQwen4ExpForCausalLM",
+    )
+    ModelRegistry.register_model(
+        "Qwen4ExpForConditionalGeneration",
+        "vllm_ascend.models.qwen4_exp:AscendQwen4ExpForConditionalGeneration",
+    )
+    ModelRegistry.register_model(
+        "Qwen4ExpMTP",
+        "vllm_ascend.models.qwen4_exp:AscendQwen4ExpMTP",
+    )
+    ModelRegistry.register_model(
         "KimiK3ForCausalLM",
         "vllm_ascend.models.kimi_k3:AscendKimiK3ForCausalLM",
     )

--- a/vllm_ascend/models/qwen4_exp/__init__.py
+++ b/vllm_ascend/models/qwen4_exp/__init__.py
@@ -1,0 +1,18 @@
+# Copyright (c) 2026 Huawei Technologies Co., Ltd. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Self-contained Qwen3.8-Flash-Next support for Ascend NPU."""
+
+from .model import (
+    AscendQwen4ExpForCausalLM,
+    AscendQwen4ExpForConditionalGeneration,
+    AscendQwen4ExpModel,
+)
+from .mtp import AscendQwen4ExpMTP, AscendQwen4ExpMultiTokenPredictor
+
+__all__ = [
+    "AscendQwen4ExpForCausalLM",
+    "AscendQwen4ExpForConditionalGeneration",
+    "AscendQwen4ExpMTP",
+    "AscendQwen4ExpModel",
+    "AscendQwen4ExpMultiTokenPredictor",
+]

--- a/vllm_ascend/models/qwen4_exp/amd/__init__.py
+++ b/vllm_ascend/models/qwen4_exp/amd/__init__.py
@@ -1,0 +1,2 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project

--- a/vllm_ascend/models/qwen4_exp/amd/hyperconnection.py
+++ b/vllm_ascend/models/qwen4_exp/amd/hyperconnection.py
@@ -1,0 +1,204 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""HyperConnection (Gated Residual) utilities for the AMD model variant.
+
+Implements the HyperConnection residual scheme proposed in
+"HyperConnections" (https://arxiv.org/abs/2409.19606). This AMD variant
+delays each HC combine to the following HC mix boundary. HC glue kernels,
+including fused combine+RMSNorm, live in ``ops/hc.py``; projections remain
+standard vLLM Linear modules.
+
+Hidden states between layers have shape ``[..., HC*HS]`` with HS inner
+(HC outer, HS inner — checkpoint-native layout).
+
+Typical usage inside a transformer decoder layer::
+
+    self.attn_hc = GatedResidual(hc_config)
+
+    hidden_states, block_input, injection = self.attn_hc.mix(hidden_states)
+    attention_output = attention(block_input)
+    hidden_states, block_input, injection = self.mlp_hc.combine_and_mix(
+        hidden_states, attention_output, injection
+    )
+"""
+
+import torch
+from torch import nn
+from vllm.model_executor.layers.linear import (
+    MergedColumnParallelLinear,
+    ReplicatedLinear,
+)
+from vllm.model_executor.models.utils import maybe_prefix
+
+from ..common.hyperconnection import (
+    GroupedGemmaRMSNorm,
+    HyperConnectionConfig,
+)
+from .ops.hc import (
+    grouped_gemma_rmsnorm,
+    hc_combine,
+    hc_combine_norm,
+    hc_gate_mix,
+    hc_silu,
+)
+
+
+# ---------------------------------------------------------------------------
+# Gated-residual variant
+# ---------------------------------------------------------------------------
+class GatedResidual(nn.Module):
+    """Gated HyperConnection with learnable low-rank mixing and injection.
+
+    ``combine_and_mix()`` runs the pre pipeline (grouped GemmaRMSNorm -> merged
+    low-rank down+inject GEMM -> silu -> up GEMM -> sigmoid -> gated mean
+    over the HC streams). When passed a pending block output and an injection,
+    it fuses their residual combine with the RMSNorm. Final mixers use
+    ``use_combine=False`` and do not produce a new injection.
+
+    Weights: the norm owns the grouped GemmaRMSNorm affine; the projections
+    are vLLM Linear modules (merged replicated linear for down+inject), so
+    GEMM dispatch (e.g. the low-latency skinny GEMM) applies through the
+    standard quant_method mechanism.
+    """
+
+    def __init__(
+        self,
+        config: HyperConnectionConfig,
+        use_combine: bool = True,
+        prefix: str = "",
+    ) -> None:
+        super().__init__()
+        self.config = config
+        self.lora_rank = config.hc_lowrank
+        self.hc_count = config.hc_count
+        self.hidden_size = config.hidden_size
+        self.use_combine = use_combine
+
+        norm_size = (
+            self.hyper_hidden_size if config.hc_per_branch_norm else config.hidden_size
+        )
+        group_size = config.hidden_size if config.hc_per_branch_norm else None
+        # Normalize each H-sized HC stream independently while retaining a
+        # separate affine weight for every element of the HC*H layout.
+        self.hc_norm = GroupedGemmaRMSNorm(
+            norm_size,
+            eps=config.rms_norm_eps,
+            group_size=group_size,
+            dtype=config.params_dtype,
+        )
+
+        # -- vLLM Linear weights --------------------------------------------
+        # The merged skinny-GEMM shape is physically padded to 16 rows for
+        # alignment and efficient backend dispatch.
+        self.pad_size = (-(self.lora_rank + self.hc_count)) % 16 if use_combine else 0
+        if use_combine:
+            self.input_mix_weight_down_block_inject = MergedColumnParallelLinear(
+                self.hyper_hidden_size,
+                [self.lora_rank, self.hc_count]
+                + ([self.pad_size] if self.pad_size else []),
+                bias=False,
+                params_dtype=config.params_dtype,
+                quant_config=None,
+                prefix=maybe_prefix(prefix, "input_mix_weight_down_block_inject"),
+                return_bias=False,
+                disable_tp=True,
+            )
+        else:
+            self.input_mix_weight_down = ReplicatedLinear(
+                self.hyper_hidden_size,
+                self.lora_rank,
+                bias=False,
+                params_dtype=config.params_dtype,
+                quant_config=None,
+                prefix=maybe_prefix(prefix, "input_mix_weight_down"),
+                return_bias=False,
+            )
+        self.input_mix_weight_up = ReplicatedLinear(
+            self.lora_rank,
+            self.hyper_hidden_size,
+            bias=False,
+            params_dtype=config.params_dtype,
+            quant_config=None,
+            prefix=maybe_prefix(prefix, "input_mix_weight_up"),
+            return_bias=False,
+        )
+
+    def mix(
+        self, hidden_states: torch.Tensor
+    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor | None]:
+        xn = grouped_gemma_rmsnorm(
+            hidden_states,
+            self.hc_norm.weight,
+            self.config.rms_norm_eps,
+            self.hc_count,
+        )
+
+        if self.use_combine:
+            # produce injection logits for combine
+            split_sizes = [self.lora_rank, self.hc_count, self.pad_size]
+            down_and_injection = self.input_mix_weight_down_block_inject(xn)
+            lora, injection, _ = down_and_injection.split(split_sizes, dim=-1)
+        else:
+            lora = self.input_mix_weight_down(xn)
+            injection = None
+
+        lora = hc_silu(lora, self.hc_count)
+        gate = self.input_mix_weight_up(lora)  # [M, D]
+        block_input = hc_gate_mix(xn, gate, self.hc_count)
+
+        return hidden_states, block_input, injection
+
+    def combine_and_mix(
+        self,
+        hidden_states: torch.Tensor,
+        prev_block_output: torch.Tensor,
+        prev_injection: torch.Tensor,
+    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor | None]:
+        """Consume a pending combine, then prepare the next block input.
+
+        ``hidden_states`` is the multi-stream state from before the pending
+        block's mix. Its combine with ``block_output`` is fused with this
+        module's input RMSNorm.
+        """
+        hidden_states, xn = hc_combine_norm(
+            hidden_states,
+            prev_block_output,
+            prev_injection,
+            self.hc_norm.weight,
+            self.config.rms_norm_eps,
+            self.hc_count,
+        )
+
+        if self.use_combine:
+            # produce injection logits for combine
+            split_sizes = [self.lora_rank, self.hc_count, self.pad_size]
+            down_and_injection = self.input_mix_weight_down_block_inject(xn)
+            lora, injection, _ = down_and_injection.split(split_sizes, dim=-1)
+        else:
+            lora = self.input_mix_weight_down(xn)
+            injection = None
+
+        lora = hc_silu(lora, self.hc_count)
+        gate = self.input_mix_weight_up(lora)  # [M, D]
+        block_input = hc_gate_mix(xn, gate, self.hc_count)
+
+        return hidden_states, block_input, injection
+
+    def combine(
+        self,
+        hidden_states: torch.Tensor,
+        block_output: torch.Tensor,
+        injection: torch.Tensor,
+    ) -> torch.Tensor:
+        return hc_combine(hidden_states, block_output, injection, self.hc_count)
+
+    @property
+    def hyper_hidden_size(self) -> int:
+        return self.hc_count * self.hidden_size
+
+
+__all__ = [
+    "GatedResidual",
+    "GroupedGemmaRMSNorm",
+    "HyperConnectionConfig",
+]

--- a/vllm_ascend/models/qwen4_exp/amd/indexer_qsa.py
+++ b/vllm_ascend/models/qwen4_exp/amd/indexer_qsa.py
@@ -1,0 +1,321 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Qwen4Exp weight-free QSA indexer."""
+
+from __future__ import annotations
+
+from typing import cast
+
+import torch
+from torch import nn
+from vllm.config import VllmConfig
+from vllm.forward_context import get_forward_context
+from vllm.model_executor.layers.layernorm import GemmaRMSNorm
+from vllm.model_executor.layers.linear import ReplicatedLinear
+from vllm.model_executor.layers.quantization import QuantizationConfig
+from vllm.model_executor.layers.rotary_embedding.mrope import triton_mrope
+
+from vllm_ascend.models.qwen4_exp.config import (
+    Qwen4ExpTextConfig,
+)
+
+from ..common.qsa_cache import (
+    QSACompressedKeyCache,
+    QSAForwardMetadata,
+    QSAKeyStateCache,
+    canonical_qsa_rope_positions,
+)
+
+
+def apply_qsa_rope(
+    rotary_emb: nn.Module,
+    positions: torch.Tensor,
+    tensor: torch.Tensor,
+) -> torch.Tensor:
+    """Apply the main attention's exact 1D/MRoPE composition to QSA heads."""
+
+    num_tokens, _, head_dim = tensor.shape
+    rotary_dim = rotary_emb.rotary_dim
+    cache = rotary_emb._match_cos_sin_cache_dtype(tensor)  # noqa: SLF001
+    cos_sin = cache[positions]
+    cos, sin = cos_sin.chunk(2, dim=-1)
+    if positions.ndim == 2:
+        shape = tensor.shape
+        tensor, _ = triton_mrope(
+            tensor.reshape(num_tokens, -1),
+            tensor.new_empty((num_tokens, head_dim)),
+            cos,
+            sin,
+            rotary_emb.mrope_section,
+            head_dim,
+            rotary_dim,
+            rotary_emb.mrope_interleaved,
+            rotary_emb.is_neox_style,
+        )
+        return tensor.reshape(shape)
+
+    rotated = rotary_emb.apply_rotary_emb(
+        tensor[..., :rotary_dim],
+        cos,
+        sin,
+    )
+    return torch.cat((rotated, tensor[..., rotary_dim:]), dim=-1)
+
+
+def apply_qsa_rmsnorm(
+    norm: GemmaRMSNorm,
+    tensor: torch.Tensor,
+) -> torch.Tensor:
+    """Use vLLM's portable RMSNorm implementation on ROCm."""
+
+    return cast(torch.Tensor, norm(tensor))
+
+
+class QSAIndexer(nn.Module):
+    """Replicated Q/K projection plus paged, weight-free QSA selection.
+
+    ``prefix`` must be the checkpoint's indexer prefix, normally
+    ``model.layers.N.self_attn.indexer``.  Consequently the trainable names are
+    ``index_qk_proj``, ``q_layernorm`` and ``k_layernorm`` under that prefix.
+    """
+
+    def __init__(
+        self,
+        *,
+        vllm_config: VllmConfig,
+        config: Qwen4ExpTextConfig,
+        layer_id: int,
+        rotary_emb: nn.Module,
+        quant_config: QuantizationConfig | None = None,
+        prefix: str = "",
+    ) -> None:
+        super().__init__()
+        if vllm_config.cache_config is None:
+            raise ValueError("QSA requires a paged KV cache")
+        if vllm_config.model_config.dtype != torch.bfloat16:
+            raise NotImplementedError("Qwen4Exp QSA currently requires BF16")
+
+        self.layer_id = int(layer_id)
+        self.index_n_heads = int(config.indexer_n_heads)
+        self.index_kv_heads = int(config.indexer_kv_heads)
+        self.index_head_dim = int(config.indexer_head_dim)
+        self.token_topk = int(config.indexer_budget)
+        self.compress_ratio = int(config.indexer_compress_ratio)
+        self.rotary_emb = rotary_emb
+        self.prefix = prefix
+        # MTP step 0 selects the target-aligned rows; later steps reuse them
+        # while continuing to update the QSA side cache.
+        self.skip_topk = False
+
+        self.index_qk_proj = ReplicatedLinear(
+            int(config.hidden_size),
+            (self.index_n_heads + self.index_kv_heads) * self.index_head_dim,
+            bias=False,
+            quant_config=quant_config,
+            prefix=f"{prefix}.index_qk_proj" if prefix else "index_qk_proj",
+        )
+        self.q_layernorm = GemmaRMSNorm(
+            self.index_head_dim,
+            eps=float(getattr(config, "rms_norm_eps", 1e-6)),
+        )
+        self.k_layernorm = GemmaRMSNorm(
+            self.index_head_dim,
+            eps=float(getattr(config, "rms_norm_eps", 1e-6)),
+        )
+
+        cache_config = vllm_config.cache_config
+        cache_prefix = f"{prefix}." if prefix else ""
+        self.raw_key_cache = QSAKeyStateCache(
+            head_size=self.index_head_dim,
+            dtype=torch.bfloat16,
+            cache_rope_positions=vllm_config.model_config.uses_mrope,
+            prefix=f"{cache_prefix}raw_key_cache",
+            cache_config=cache_config,
+            compress_ratio=self.compress_ratio,
+            vllm_config=vllm_config,
+        )
+        self.compressed_key_cache = QSACompressedKeyCache(
+            head_size=self.index_head_dim,
+            dtype=torch.bfloat16,
+            compress_ratio=self.compress_ratio,
+            prefix=f"{cache_prefix}compressed_key_cache",
+            cache_config=cache_config,
+            vllm_config=vllm_config,
+        )
+
+    @property
+    def output_width(self) -> int:
+        return self.token_topk + self.compress_ratio - 1
+
+    def project_qk(
+        self,
+        hidden_states: torch.Tensor,
+        positions: torch.Tensor,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        """Project replicated Q/K, normalize+rotate Q, and preserve raw K."""
+
+        qk, _ = self.index_qk_proj(hidden_states)
+        q_raw, token_k = qk.split(
+            (
+                self.index_n_heads * self.index_head_dim,
+                self.index_kv_heads * self.index_head_dim,
+            ),
+            dim=-1,
+        )
+        q = q_raw.reshape(-1, self.index_n_heads, self.index_head_dim)
+        q = apply_qsa_rmsnorm(
+            self.q_layernorm,
+            q.reshape(-1, self.index_head_dim),
+        ).reshape_as(q)
+        q = apply_qsa_rope(self.rotary_emb, positions, q)
+        return q, token_k.reshape(-1, 1, self.index_head_dim)
+
+    def normalize_compressed_keys(
+        self,
+        compressed_keys: torch.Tensor,
+        first_rope_positions: torch.Tensor,
+    ) -> torch.Tensor:
+        """Normalize pooled K and apply the first token's exact group position."""
+
+        keys = compressed_keys.reshape(-1, self.index_head_dim)
+        keys = apply_qsa_rmsnorm(self.k_layernorm, keys).reshape(
+            -1, 1, self.index_head_dim
+        )
+        if getattr(self.rotary_emb, "mrope_section", None):
+            positions = first_rope_positions.transpose(0, 1)
+        else:
+            positions = first_rope_positions[:, 0]
+        return apply_qsa_rope(self.rotary_emb, positions, keys)
+
+    def _metadata(
+        self,
+    ) -> tuple[QSAForwardMetadata, QSAForwardMetadata] | None:
+        metadata = get_forward_context().attn_metadata
+        if isinstance(metadata, list):
+            metadata = metadata[0]
+        if not isinstance(metadata, dict):
+            return None
+        raw = cast(QSAForwardMetadata, metadata[self.raw_key_cache.prefix])
+        compressed = cast(
+            QSAForwardMetadata, metadata[self.compressed_key_cache.prefix]
+        )
+        if raw.num_actual_tokens != compressed.num_actual_tokens:
+            raise RuntimeError("QSA side-cache metadata token counts disagree")
+        if not raw.logical_positions.is_cuda and (
+            not torch.equal(raw.logical_positions, compressed.logical_positions)
+        ):
+            raise RuntimeError("QSA side-cache metadata positions disagree")
+        return raw, compressed
+
+    def _update_and_compress(
+        self,
+        token_k: torch.Tensor,
+        positions: torch.Tensor,
+        raw_metadata: QSAForwardMetadata,
+        compressed_metadata: QSAForwardMetadata,
+    ) -> None:
+        num_tokens = raw_metadata.num_actual_tokens
+        raw_key_cache = self.raw_key_cache.key_cache
+        rope_position_cache = self.raw_key_cache.rope_position_cache
+        from .ops.qsa import qsa_compress_groups_with_ratio, qsa_store_cache_rows
+
+        if rope_position_cache is None:
+            position_rows = raw_metadata.logical_positions.view(-1, 1, 1).expand(
+                -1, 1, 3
+            )
+        else:
+            position_rows = canonical_qsa_rope_positions(positions)[:num_tokens].to(
+                device=raw_key_cache.device
+            )
+        pooled, first_positions = qsa_compress_groups_with_ratio(
+            token_k[:num_tokens],
+            position_rows,
+            raw_key_cache,
+            raw_metadata.block_table,
+            raw_metadata.token_to_req,
+            raw_metadata.query_start_loc,
+            raw_metadata.logical_positions,
+            compressed_metadata.slot_mapping,
+            self.compress_ratio,
+            rope_position_cache,
+        )
+        normalized = self.normalize_compressed_keys(pooled, first_positions)
+        qsa_store_cache_rows(
+            self.compressed_key_cache.kv_cache,
+            compressed_metadata.slot_mapping,
+            normalized,
+        )
+        qsa_store_cache_rows(
+            raw_key_cache,
+            raw_metadata.slot_mapping,
+            token_k[:num_tokens],
+        )
+        if rope_position_cache is not None:
+            qsa_store_cache_rows(
+                rope_position_cache,
+                raw_metadata.slot_mapping,
+                position_rows,
+            )
+
+    def _select(
+        self,
+        q: torch.Tensor,
+        metadata: QSAForwardMetadata,
+        out: torch.Tensor | None,
+    ) -> torch.Tensor:
+        from .ops.qsa import qsa_select_paged_tokens
+
+        return qsa_select_paged_tokens(
+            q,
+            self.compressed_key_cache.kv_cache,
+            metadata.block_table,
+            metadata.token_to_req,
+            metadata.logical_positions,
+            metadata.seq_lens,
+            self.token_topk,
+            self.compress_ratio,
+            out,
+        )
+
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+        positions: torch.Tensor,
+        out: torch.Tensor | None = None,
+    ) -> torch.Tensor:
+        """Return fixed-width request-relative token indices padded with ``-1``."""
+
+        metadata = self._metadata()
+        if metadata is None:
+            # Preserve step-0 indices when later MTP steps reuse the buffer.
+            if self.skip_topk and out is not None:
+                return out
+            result = torch.full(
+                (hidden_states.shape[0], self.output_width),
+                -1,
+                dtype=torch.int32,
+                device=hidden_states.device,
+            )
+            if out is not None:
+                out.copy_(result)
+                return out
+            return result
+        raw_metadata, compressed_metadata = metadata
+        num_tokens = raw_metadata.num_actual_tokens
+        q, token_k = self.project_qk(
+            hidden_states[:num_tokens], positions[..., :num_tokens]
+        )
+        self._update_and_compress(
+            token_k,
+            positions[..., :num_tokens],
+            raw_metadata,
+            compressed_metadata,
+        )
+        if self.skip_topk:
+            if out is None:
+                raise RuntimeError("QSA top-k reuse requires an output buffer")
+            return out
+        return self._select(q, compressed_metadata, out)
+
+
+__all__ = ["QSAIndexer", "apply_qsa_rope"]

--- a/vllm_ascend/models/qwen4_exp/amd/low_latency_gemm.py
+++ b/vllm_ascend/models/qwen4_exp/amd/low_latency_gemm.py
@@ -1,0 +1,15 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Qwen4Exp low-latency GEMM hook for AMD ROCm."""
+
+import torch
+from torch import nn
+
+
+def enable_qwen4_exp_low_latency_gemm(
+    module: nn.Module,
+    dtype: torch.dtype,
+) -> None:
+    """Keep the standard vLLM linear methods on AMD ROCm."""
+
+    del module, dtype

--- a/vllm_ascend/models/qwen4_exp/amd/model.py
+++ b/vllm_ascend/models/qwen4_exp/amd/model.py
@@ -687,7 +687,10 @@ class Qwen4ExpForCausalLM(
         hf_config = vllm_config.model_config.hf_text_config
         conv_kernel_size = hf_config.ple_conv_kernel_size
         short_conv_dilation = hf_config.ngram_size
-        conv_state_len = (conv_kernel_size - 1) * short_conv_dilation
+        conv_state_len = (
+            (conv_kernel_size - 1) * short_conv_dilation
+            + vllm_config.num_speculative_tokens
+        )
         hc_count = hf_config.hc_count
         hc_hidden_size = hf_config.hidden_size * hc_count
         return MambaStateShapeCalculator.short_conv_state_shape(

--- a/vllm_ascend/models/qwen4_exp/amd/model.py
+++ b/vllm_ascend/models/qwen4_exp/amd/model.py
@@ -1,0 +1,1052 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Inference-only Qwen4Exp model."""
+
+from collections.abc import Iterable
+from itertools import islice
+
+import torch
+import vllm.model_executor.models.qwen3_next as _qwen3_next
+from torch import nn
+from vllm.compilation.decorators import support_torch_compile
+from vllm.config import VllmConfig
+from vllm.distributed import get_pp_group
+from vllm.model_executor.layers.logits_processor import LogitsProcessor
+from vllm.model_executor.layers.mamba.gdn.qwen_gdn_linear_attn import (
+    QwenGatedDeltaNetAttention,
+)
+from vllm.model_executor.layers.mamba.mamba_utils import (
+    MambaStateCopyFunc,
+    MambaStateCopyFuncCalculator,
+    MambaStateDtypeCalculator,
+    MambaStateShapeCalculator,
+)
+from vllm.model_executor.layers.quantization import QuantizationConfig
+from vllm.model_executor.layers.vocab_parallel_embedding import (
+    ParallelLMHead,
+    VocabParallelEmbedding,
+)
+from vllm.model_executor.models.interfaces import (
+    HasInnerState,
+    IsHybrid,
+    MixtureOfExperts,
+    MultiModalEmbeddings,
+    SupportsLoRA,
+    SupportsMRoPE,
+    SupportsPP,
+    _require_is_multimodal,
+)
+from vllm.model_executor.models.qwen3_5 import (
+    Qwen3_5ForConditionalGeneration,
+    Qwen3_5Model,
+)
+from vllm.model_executor.models.qwen3_next import (
+    Qwen3NextAttention,
+    Qwen3NextMLP,
+    Qwen3NextSparseMoeBlock,
+)
+from vllm.model_executor.models.qwen3_vl import (
+    Qwen3_VisionTransformer,
+    Qwen3VLDummyInputsBuilder,
+    Qwen3VLMultiModalProcessor,
+    Qwen3VLProcessingInfo,
+)
+from vllm.model_executor.models.utils import (
+    AutoWeightsLoader,
+    StageMissingLayer,
+    WeightsMapper,
+    _merge_multimodal_embeddings,
+    extract_layer_index,
+    make_empty_intermediate_tensors_factory,
+    make_layers,
+    maybe_fuse_shared_experts,
+    maybe_prefix,
+)
+from vllm.multimodal import MULTIMODAL_REGISTRY
+from vllm.multimodal.inputs import MultiModalFeatureSpec
+from vllm.sequence import IntermediateTensors
+from vllm.tokenizers.registry import cached_tokenizer_from_config
+from vllm.v1.attention.backends.registry import MambaAttentionBackendEnum
+from vllm.v1.kv_cache_interface import MambaSpec
+
+from vllm_ascend.models.qwen4_exp.config import (
+    Qwen4ExpTextConfig,
+)
+from vllm_ascend.patch.platform.patch_fused_moe import _ascend_FusedMoE
+
+from ..config import Qwen4ExpConfig
+from .hyperconnection import GatedResidual, HyperConnectionConfig
+from .low_latency_gemm import enable_qwen4_exp_low_latency_gemm
+from .ple_layer import Qwen4ExpPLELayer
+from .qsa import Qwen4ExpQSAAttention
+
+_qwen3_next.FusedMoE = _ascend_FusedMoE
+
+
+def without_modelopt_fp4(
+    quant_config: QuantizationConfig | None,
+) -> QuantizationConfig | None:
+    """Return ``None`` for weights excluded from Qwen4Exp ModelOpt-FP4."""
+
+    if quant_config is not None and quant_config.get_name() == "modelopt_fp4":
+        return None
+    return quant_config
+
+
+def _remap_qsa_cache_scale_name(
+    name: str,
+    qsa_layer_ids: frozenset[int],
+) -> str:
+    """Map serialized main-cache scales onto the merged QSA owner.
+
+    Regular attention keeps cache scales below its ``attn`` child. QSA owns
+    that cache directly, so only QSA layers need the final path component
+    moved to the owner's persistent ``_k_scale``/``_v_scale`` buffers.
+    """
+
+    scale_suffixes = {
+        "k_proj.k_scale": "_k_scale",
+        "k_proj.output_scale": "_k_scale",
+        "attn.k_scale": "_k_scale",
+        "attn._k_scale": "_k_scale",
+        "k_scale": "_k_scale",
+        "_k_scale": "_k_scale",
+        "v_proj.v_scale": "_v_scale",
+        "v_proj.output_scale": "_v_scale",
+        "attn.v_scale": "_v_scale",
+        "attn._v_scale": "_v_scale",
+        "v_scale": "_v_scale",
+        "_v_scale": "_v_scale",
+    }
+    for layer_id in qsa_layer_ids:
+        marker = f"layers.{layer_id}.self_attn."
+        marker_start = name.find(marker)
+        if marker_start < 0 or (marker_start > 0 and name[marker_start - 1] != "."):
+            continue
+        suffix = name[marker_start + len(marker) :]
+        mapped_suffix = scale_suffixes.get(suffix)
+        if mapped_suffix is not None:
+            return f"{name[: marker_start + len(marker)]}{mapped_suffix}"
+    return name
+
+
+_QWEN4_EXP_IGNORED_MISSING_SUFFIXES = [
+    ".bias",
+    "_bias",
+    ".k_scale",
+    "_k_scale",
+    ".v_scale",
+    "_v_scale",
+    "_weight_scale",
+    "_input_scale",
+]
+
+# The checkpoint keeps down and injection projections separate; runtime packs
+# them into adjacent logical shards of one MergedColumnParallelLinear.
+_HC_WEIGHTS_MAPPER = WeightsMapper(
+    orig_to_new_stacked={
+        "hyper_connection.input_mix_weight_down.weight": (
+            "hyper_connection.input_mix_weight_down_block_inject.weight",
+            0,
+        ),
+        "hyper_connection.block_inject_weight.weight": (
+            "hyper_connection.input_mix_weight_down_block_inject.weight",
+            1,
+        ),
+    }
+)
+
+
+class Qwen4ExpSparseMoeBlock(Qwen3NextSparseMoeBlock):
+    """Qwen3Next MoE with Qwen4Exp HC validation."""
+
+    def __init__(self, vllm_config: VllmConfig, prefix: str = "") -> None:
+        parallel_config = vllm_config.parallel_config
+        if parallel_config.use_sequence_parallel_moe:
+            raise NotImplementedError(
+                "Qwen4Exp HC does not support sequence-parallel MoE"
+            )
+        super().__init__(vllm_config=vllm_config, prefix=prefix)
+        config = vllm_config.model_config.hf_text_config
+        self.n_shared_experts = int(config.shared_expert_intermediate_size > 0)
+
+
+class Qwen4ExpDecoderLayer(nn.Module):
+    def __init__(
+        self,
+        vllm_config: VllmConfig,
+        layer_type: str,
+        prefix: str = "",
+    ) -> None:
+        super().__init__()
+        config: Qwen4ExpTextConfig = vllm_config.model_config.hf_text_config
+        model_config = vllm_config.model_config
+        cache_config = vllm_config.cache_config
+        quant_config = vllm_config.quant_config
+
+        self.config = config
+        self.layer_type = layer_type
+        self.layer_idx = extract_layer_index(prefix)
+        if vllm_config.parallel_config.use_sequence_parallel_moe:
+            raise NotImplementedError(
+                "Qwen4Exp HC does not support sequence-parallel MoE"
+            )
+        self.ple: Qwen4ExpPLELayer | None = None
+        ple_layer_ids = config.ple_layer_ids
+        if (self.layer_idx + 1) in ple_layer_ids:
+            ple_layer_ids_sorted = sorted(set(ple_layer_ids))
+            ple_dense_layer_id_map = {
+                abs_id: idx for idx, abs_id in enumerate(ple_layer_ids_sorted)
+            }
+            ple_dense_layer_id = ple_dense_layer_id_map[self.layer_idx + 1]
+            self.ple = Qwen4ExpPLELayer(
+                config,
+                vllm_config=vllm_config,
+                layer_idx=self.layer_idx,
+                ple_dense_layer_id=ple_dense_layer_id,
+                prefix=f"{prefix}.ple",
+            )
+
+        if layer_type == "linear_attention":
+            self.linear_attn = QwenGatedDeltaNetAttention(
+                config,
+                vllm_config=vllm_config,
+                prefix=f"{prefix}.linear_attn",
+                gqa_interleaved_layout=False,
+            )
+        elif layer_type == "full_attention":
+            use_qsa = getattr(config, "indexer_n_heads", None) is not None
+            if not use_qsa:
+                self.self_attn = Qwen3NextAttention(
+                    config,
+                    model_config=model_config,
+                    cache_config=cache_config,
+                    quant_config=quant_config,
+                    prefix=f"{prefix}.self_attn",
+                )
+            else:
+                self.self_attn = Qwen4ExpQSAAttention(
+                    vllm_config=vllm_config,
+                    config=config,
+                    layer_id=self.layer_idx,
+                    quant_config=quant_config,
+                    prefix=f"{prefix}.self_attn",
+                )
+        else:
+            raise ValueError(f"Invalid layer_type {layer_type}")
+
+        mlp_only_layers = getattr(config, "mlp_only_layers", [])
+        num_experts = getattr(config, "num_experts", 0) or 0
+        absolute_layer_id = self.layer_idx + 1
+        is_moe_layer = self.layer_idx not in mlp_only_layers and (
+            num_experts > 0 and absolute_layer_id % config.decoder_sparse_step == 0
+        )
+        if is_moe_layer:
+            self.mlp = Qwen4ExpSparseMoeBlock(
+                vllm_config=vllm_config, prefix=f"{prefix}.mlp"
+            )
+        else:
+            self.mlp = Qwen3NextMLP(
+                hidden_size=config.hidden_size,
+                intermediate_size=config.intermediate_size,
+                hidden_act=config.hidden_act,
+                quant_config=quant_config,
+                prefix=f"{prefix}.mlp",
+            )
+
+        hc_config = HyperConnectionConfig(
+            hc_count=config.hc_count,
+            hidden_size=config.hidden_size,
+            params_dtype=torch.bfloat16,
+            hc_lowrank=config.hc_lowrank,
+            rms_norm_eps=config.rms_norm_eps,
+            hc_per_branch_norm=True,
+        )
+        self.attn_hyper_connection = GatedResidual(
+            hc_config,
+            prefix=maybe_prefix(prefix, "attn_hyper_connection"),
+        )
+        self.mlp_hyper_connection = GatedResidual(
+            hc_config,
+            prefix=maybe_prefix(prefix, "mlp_hyper_connection"),
+        )
+
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+        prev_block_output: torch.Tensor | None,
+        prev_injection: torch.Tensor | None,
+        positions: torch.Tensor,
+        *,
+        input_ids: torch.Tensor | None,
+        query_start_loc: torch.Tensor | None,
+        ngram_context: torch.Tensor | None,
+    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+        attn_hc = self.attn_hyper_connection
+        if self.ple is not None:
+            # PLE adds directly to the multi-stream state, so pending HC state
+            # must be materialized before the addition.
+            if prev_block_output is not None and prev_injection is not None:
+                hidden_states = attn_hc.combine(
+                    hidden_states, prev_block_output, prev_injection
+                )
+                prev_block_output = prev_injection = None
+
+            if input_ids is None or query_start_loc is None or ngram_context is None:
+                raise RuntimeError("PLE inputs were not prepared")
+            hidden_states = hidden_states + self.ple(
+                hidden_states,
+                input_ids,
+                query_start_loc,
+                ngram_context,
+            )
+
+        # Fuse a pending combine with this HC module's mix when possible.
+        if prev_block_output is not None and prev_injection is not None:
+            hidden_states, block_input, injection = attn_hc.combine_and_mix(
+                hidden_states, prev_block_output, prev_injection
+            )
+        else:
+            hidden_states, block_input, injection = attn_hc.mix(hidden_states)
+
+        if self.layer_type == "linear_attention":
+            attn_out = self.linear_attn(hidden_states=block_input)
+        elif self.layer_type == "full_attention":
+            attn_out = self.self_attn(
+                hidden_states=block_input,
+                positions=positions,
+            )
+        else:
+            raise ValueError("Invalid layer_type")
+
+        mlp_hc = self.mlp_hyper_connection
+        hidden_states, block_input, injection = mlp_hc.combine_and_mix(
+            hidden_states, attn_out, injection
+        )
+        mlp_out = self.mlp(block_input)
+        return hidden_states, mlp_out, injection
+
+
+class Qwen4ExpMixtureOfExperts(MixtureOfExperts):
+    """Expose Qwen4Exp routed experts through vLLM's EPLB protocol."""
+
+    def set_moe_parameters(self, layers: Iterable[nn.Module]) -> None:
+        self.moe_layers = []
+        self.moe_mlp_layers = []
+        example_moe = None
+        for layer in layers:
+            if isinstance(layer, Qwen4ExpDecoderLayer) and isinstance(
+                layer.mlp, Qwen4ExpSparseMoeBlock
+            ):
+                example_moe = layer.mlp
+                self.moe_mlp_layers.append(layer.mlp)
+                self.moe_layers.append(layer.mlp.experts)
+
+        self.num_moe_layers = len(self.moe_layers)
+        if example_moe is None:
+            self.num_expert_groups = 0
+            self.num_shared_experts = 0
+            self.num_logical_experts = 0
+            self.num_physical_experts = 0
+            self.num_local_physical_experts = 0
+            self.num_routed_experts = 0
+            self.num_redundant_experts = 0
+            return
+
+        self.num_expert_groups = 1
+        self.num_shared_experts = example_moe.n_shared_experts
+        self.num_logical_experts = example_moe.n_logical_experts
+        self.num_physical_experts = example_moe.n_physical_experts
+        self.num_local_physical_experts = example_moe.n_local_physical_experts
+        self.num_routed_experts = example_moe.n_routed_experts
+        self.num_redundant_experts = example_moe.n_redundant_experts
+
+    def update_physical_experts_metadata(
+        self,
+        num_physical_experts: int,
+        num_local_physical_experts: int,
+    ) -> None:
+        assert self.num_local_physical_experts == num_local_physical_experts
+        self.num_physical_experts = num_physical_experts
+        self.num_local_physical_experts = num_local_physical_experts
+        self.num_redundant_experts = num_physical_experts - self.num_logical_experts
+        for moe in self.moe_mlp_layers:
+            moe.n_physical_experts = num_physical_experts
+            moe.n_local_physical_experts = num_local_physical_experts
+            moe.n_redundant_experts = self.num_redundant_experts
+            moe.experts.update_expert_map()
+
+
+@support_torch_compile(
+    dynamic_arg_dims={
+        "input_ids": 0,
+        "positions": -1,
+        "intermediate_tensors": 0,
+        "inputs_embeds": 0,
+        "query_start_loc": 0,
+        "ngram_context": 0,
+        "deepstack_input_embeds": 0,
+    }
+)
+class Qwen4ExpModel(nn.Module):
+    hf_to_vllm_mapper = Qwen3_5Model.hf_to_vllm_mapper | _HC_WEIGHTS_MAPPER
+
+    def __init__(self, *, vllm_config: VllmConfig, prefix: str = "") -> None:
+        super().__init__()
+        config: Qwen4ExpTextConfig = vllm_config.model_config.hf_text_config
+        self.config = config
+        self.num_redundant_experts = (
+            vllm_config.parallel_config.eplb_config.num_redundant_experts
+        )
+        self.vocab_size = config.vocab_size
+        self._qsa_layer_ids = frozenset(
+            layer_idx
+            for layer_idx, layer_type in enumerate(config.layer_types)
+            if layer_type == "full_attention"
+            and getattr(config, "indexer_n_heads", None) is not None
+        )
+        self.embed_tokens = VocabParallelEmbedding(self.vocab_size, config.hidden_size)
+
+        def get_layer(prefix: str) -> Qwen4ExpDecoderLayer:
+            layer_idx = extract_layer_index(prefix)
+            return Qwen4ExpDecoderLayer(
+                vllm_config,
+                layer_type=config.layer_types[layer_idx],
+                prefix=prefix,
+            )
+
+        self.start_layer, self.end_layer, self.layers = make_layers(
+            config.num_hidden_layers, get_layer, prefix=f"{prefix}.layers"
+        )
+        intermediate_size = config.hidden_size * config.hc_count
+        self.make_empty_intermediate_tensors = make_empty_intermediate_tensors_factory(
+            ["hidden_states"], intermediate_size
+        )
+
+        self.hyper_connection_mixer: GatedResidual | None
+        if get_pp_group().is_last_rank:
+            hc_config = HyperConnectionConfig(
+                hc_count=config.hc_count,
+                hidden_size=config.hidden_size,
+                params_dtype=torch.bfloat16,
+                hc_lowrank=config.hc_lowrank,
+                rms_norm_eps=config.rms_norm_eps,
+                hc_per_branch_norm=True,
+            )
+            self.hyper_connection_mixer = GatedResidual(
+                hc_config,
+                use_combine=False,
+                prefix=maybe_prefix(prefix, "hyper_connection_mixer"),
+            )
+        else:
+            self.hyper_connection_mixer = None
+
+        spec_config = vllm_config.speculative_config
+        # MTP HC multi-stream outputs: when speculative method=="mtp" and the
+        # model uses HC with hc_count>1, retain the pre-final-mixer multi-stream
+        # hidden state [T, hc_count*H] so the MTP drafter can feed a real
+        # multi-stream backbone hidden on its first step (scheme A). Derived
+        # purely from config (NOT node identity) so P/D nodes stay consistent.
+        needs_mtp_hidden = (
+            spec_config is not None
+            and getattr(spec_config, "method", None) == "mtp"
+            and get_pp_group().is_last_rank
+        )
+        if needs_mtp_hidden:
+            self._mtp_hidden_buffer = torch.empty(
+                vllm_config.scheduler_config.max_num_batched_tokens,
+                config.hc_count * config.hidden_size,
+                dtype=vllm_config.model_config.dtype,
+            )
+        else:
+            self._mtp_hidden_buffer = None
+
+    def embed_input_ids(self, input_ids: torch.Tensor) -> torch.Tensor:
+        return self.embed_tokens(input_ids)
+
+    def forward(
+        self,
+        input_ids: torch.Tensor | None,
+        positions: torch.Tensor,
+        intermediate_tensors: IntermediateTensors | None = None,
+        inputs_embeds: torch.Tensor | None = None,
+        query_start_loc: torch.Tensor | None = None,
+        ngram_context: torch.Tensor | None = None,
+        deepstack_input_embeds: IntermediateTensors | None = None,
+    ) -> torch.Tensor | IntermediateTensors:
+        if get_pp_group().is_first_rank:
+            if inputs_embeds is not None:
+                hidden_states = inputs_embeds
+            else:
+                if input_ids is None:
+                    raise ValueError("input_ids or inputs_embeds is required")
+                hidden_states = self.embed_input_ids(input_ids)
+            hidden_states = hidden_states.repeat(1, self.config.hc_count)
+        else:
+            if intermediate_tensors is None:
+                raise ValueError("pipeline stage requires intermediate tensors")
+            hidden_states = intermediate_tensors["hidden_states"]
+
+        block_output = None
+        injection = None
+        last_layer = None
+        for layer_idx, layer in islice(
+            enumerate(self.layers), self.start_layer, self.end_layer
+        ):
+            last_layer = layer
+            hidden_states, block_output, injection = layer(
+                hidden_states=hidden_states,
+                prev_block_output=block_output,
+                prev_injection=injection,
+                positions=positions,
+                input_ids=input_ids,
+                query_start_loc=query_start_loc,
+                ngram_context=ngram_context,
+            )
+            if deepstack_input_embeds is not None and layer_idx < len(
+                deepstack_input_embeds
+            ):
+                deepstack_embed = deepstack_input_embeds[
+                    f"deepstack_input_embeds_{layer_idx}"
+                ]
+                deepstack_embed = (
+                    deepstack_embed.unsqueeze(-2)
+                    .expand(
+                        *deepstack_embed.shape[:-1],
+                        self.config.hc_count,
+                        self.config.hidden_size,
+                    )
+                    .flatten(-2)
+                )
+                # Deepstack is an external addition to the materialized
+                # multi-stream state and therefore terminates delayed combine.
+                hidden_states = layer.mlp_hyper_connection.combine(
+                    hidden_states, block_output, injection
+                )
+                block_output = None
+                injection = None
+                hidden_states = hidden_states + deepstack_embed
+
+        if not get_pp_group().is_last_rank:
+            # PP transports one tensor, not the delayed HC tuple. Materialize
+            # with the HC module that produced the pending injection.
+            if last_layer is not None and block_output is not None:
+                hidden_states = last_layer.mlp_hyper_connection.combine(
+                    hidden_states, block_output, injection
+                )
+            return IntermediateTensors({"hidden_states": hidden_states})
+
+        # The final mixer consumes the last pending combine and returns both
+        # the sampled single stream and the materialized multi-stream state.
+        final_mixer = self.hyper_connection_mixer
+        assert final_mixer is not None
+        multi_hidden, sample_hidden_states, _ = final_mixer.combine_and_mix(
+            hidden_states, block_output, injection
+        )
+        if self._mtp_hidden_buffer is not None:
+            # Capture the pre-final-mixer multi-stream hidden state
+            # [T, hc_count*H] for the MTP drafter (zero extra compute:
+            # this tensor is needed by the final mixer regardless).
+            num_tokens = multi_hidden.shape[0]
+            self._mtp_hidden_buffer[:num_tokens].copy_(multi_hidden)
+        return sample_hidden_states
+
+    def load_weights(self, weights: Iterable[tuple[str, torch.Tensor]]) -> set[str]:
+        weights = (
+            (
+                _remap_qsa_cache_scale_name(name, self._qsa_layer_ids),
+                weight,
+            )
+            for name, weight in weights
+        )
+        weights = maybe_fuse_shared_experts(
+            weights,
+            n_routed_experts=getattr(self.config, "num_experts", 0) or 0,
+            n_shared_experts=1,
+            ckpt_prefix="mlp.shared_expert",
+        )
+        # Non-persistent PLE state rebuilt in __init__; skip any ckpt
+        # column for them.
+        skip_substrs = [
+            "hashstats_",
+            "token_lookup",
+            "hyper_connection_mixer.block_inject_weight",
+        ]
+        loader = AutoWeightsLoader(
+            self,
+            skip_prefixes=(
+                ["hyper_connection_mixer."]
+                if not get_pp_group().is_last_rank
+                else None
+            ),
+            skip_substrs=skip_substrs,
+            ignore_unexpected_suffixes=_QWEN4_EXP_IGNORED_MISSING_SUFFIXES.copy(),
+        )
+        loaded = loader.load_weights(
+            weights,
+            mapper=self.hf_to_vllm_mapper,
+        )
+        return loaded
+
+
+class Qwen4ExpForCausalLM(
+    nn.Module,
+    HasInnerState,
+    SupportsLoRA,
+    SupportsMRoPE,
+    SupportsPP,
+    Qwen4ExpMixtureOfExperts,
+    IsHybrid,
+):
+    packed_modules_mapping = {
+        "qkv_proj": ["q_proj", "k_proj", "v_proj"],
+        "gate_up_proj": ["gate_proj", "up_proj"],
+        "in_proj_qkvz": ["in_proj_qkv", "in_proj_z"],
+        "in_proj_ba": ["in_proj_b", "in_proj_a"],
+        "input_mix_weight_down_block_inject": [
+            "input_mix_weight_down",
+            "block_inject_weight",
+            "_input_mix_padding",
+        ],
+    }
+    hf_to_vllm_mapper = WeightsMapper(
+        orig_to_new_prefix={"model.language_model.": "model."}
+    )
+    requires_raw_input_tokens = True
+
+    def __init__(self, *, vllm_config: VllmConfig, prefix: str = "") -> None:
+        super().__init__()
+        config: Qwen4ExpTextConfig = vllm_config.model_config.hf_text_config
+        self.vllm_config = vllm_config
+        self.model_config = vllm_config.model_config
+        self.quant_config = vllm_config.quant_config
+        self.config = config
+        self.scheduler_config = vllm_config.scheduler_config
+        if vllm_config.cache_config.mamba_cache_mode == "all":
+            raise NotImplementedError(
+                "Qwen4Exp currently does not support 'all' prefix caching, "
+                "please use '--mamba-cache-mode=align' instead"
+            )
+        self.model = Qwen4ExpModel(
+            vllm_config=vllm_config, prefix=maybe_prefix(prefix, "model")
+        )
+        self.lm_head = ParallelLMHead(
+            config.vocab_size,
+            config.hidden_size,
+            prefix=maybe_prefix(prefix, "lm_head"),
+        )
+        self.logits_processor = LogitsProcessor(config.vocab_size)
+        self.make_empty_intermediate_tensors = (
+            self.model.make_empty_intermediate_tensors
+        )
+        self.set_moe_parameters(self.model.layers)
+        enable_qwen4_exp_low_latency_gemm(self, self.model_config.dtype)
+
+    @staticmethod
+    def get_model_state_cls():
+        from .model_state import Qwen4ExpModelState
+
+        return Qwen4ExpModelState
+
+    def forward(
+        self,
+        input_ids: torch.Tensor | None,
+        positions: torch.Tensor,
+        intermediate_tensors: IntermediateTensors | None = None,
+        inputs_embeds: torch.Tensor | None = None,
+        **kwargs: object,
+    ) -> torch.Tensor | IntermediateTensors:
+        # Forward kwargs unchanged so the runner's _maybe_add_ngram_kwargs
+        # path (query_start_loc / ngram_context) reaches Qwen4ExpModel.
+        ple_input_ids = kwargs.pop("ple_input_ids", input_ids)
+        return self.model(
+            ple_input_ids,
+            positions,
+            intermediate_tensors,
+            inputs_embeds,
+            **kwargs,
+        )
+
+    def embed_input_ids(self, input_ids: torch.Tensor) -> torch.Tensor:
+        return self.model.embed_input_ids(input_ids)
+
+    @classmethod
+    def get_ple_mamba_state_dtype_from_config(
+        cls,
+        vllm_config: VllmConfig,
+    ) -> tuple[torch.dtype, ...]:
+        return MambaStateDtypeCalculator.short_conv_state_dtype(
+            vllm_config.model_config.dtype,
+            vllm_config.cache_config.mamba_cache_dtype,
+        )
+
+    @classmethod
+    def get_ple_mamba_state_shape_from_config(
+        cls, vllm_config: VllmConfig
+    ) -> tuple[tuple[int, int]]:
+        hf_config = vllm_config.model_config.hf_text_config
+        conv_kernel_size = hf_config.ple_conv_kernel_size
+        short_conv_dilation = hf_config.ngram_size
+        conv_state_len = (conv_kernel_size - 1) * short_conv_dilation
+        hc_count = hf_config.hc_count
+        hc_hidden_size = hf_config.hidden_size * hc_count
+        return MambaStateShapeCalculator.short_conv_state_shape(
+            tp_world_size=1,
+            intermediate_size=hc_hidden_size,
+            conv_kernel=conv_state_len + 1,
+        )
+
+    @classmethod
+    def get_gdn_mamba_state_dtype_from_config(
+        cls, vllm_config: VllmConfig
+    ) -> tuple[torch.dtype, torch.dtype]:
+        return MambaStateDtypeCalculator.gated_delta_net_state_dtype(
+            vllm_config.model_config.dtype,
+            vllm_config.cache_config.mamba_cache_dtype,
+            vllm_config.cache_config.mamba_ssm_cache_dtype,
+        )
+
+    @classmethod
+    def get_gdn_mamba_state_shape_from_config(
+        cls, vllm_config: VllmConfig
+    ) -> tuple[tuple[int, int], tuple[int, int]]:
+        parallel_config = vllm_config.parallel_config
+        hf_config = vllm_config.model_config.hf_text_config
+        tp_size = parallel_config.tensor_parallel_size
+        num_spec = (
+            vllm_config.speculative_config.num_speculative_tokens
+            if vllm_config.speculative_config
+            else 0
+        )
+        return MambaStateShapeCalculator.gated_delta_net_state_shape(
+            tp_size,
+            hf_config.linear_num_key_heads,
+            hf_config.linear_num_value_heads,
+            hf_config.linear_key_head_dim,
+            hf_config.linear_value_head_dim,
+            hf_config.linear_conv_kernel_dim,
+            num_spec,
+        )
+
+    @classmethod
+    def get_mamba_state_dtype_from_config(
+        cls,
+        vllm_config: VllmConfig,
+    ) -> tuple[torch.dtype, torch.dtype]:
+        return cls.get_gdn_mamba_state_dtype_from_config(vllm_config)
+
+    @classmethod
+    def get_mamba_state_shape_from_config(
+        cls, vllm_config: VllmConfig
+    ) -> tuple[tuple[int, int], tuple[int, int]]:
+        return cls.get_gdn_mamba_state_shape_from_config(vllm_config)
+
+    @classmethod
+    def get_mamba_state_copy_func(
+        cls,
+    ) -> tuple[MambaStateCopyFunc, MambaStateCopyFunc]:
+        return MambaStateCopyFuncCalculator.gated_delta_net_state_copy_func()
+
+    @classmethod
+    def get_mamba_state_copy_funcs(
+        cls,
+        mamba_types: set[MambaAttentionBackendEnum],
+    ) -> dict[MambaAttentionBackendEnum, tuple[MambaStateCopyFunc, ...]]:
+        copy_funcs_by_type = {
+            MambaAttentionBackendEnum.GDN_ATTN: cls.get_mamba_state_copy_func(),
+            MambaAttentionBackendEnum.SHORT_CONV: (
+                MambaStateCopyFuncCalculator.short_conv_state_copy_func()
+            ),
+        }
+        missing_types = mamba_types - copy_funcs_by_type.keys()
+        assert not missing_types, f"missing state copy funcs for {missing_types}"
+        return {
+            mamba_type: copy_funcs_by_type[mamba_type] for mamba_type in mamba_types
+        }
+
+    @classmethod
+    def get_mamba_specs_from_config(
+        cls, vllm_config: VllmConfig
+    ) -> tuple[MambaSpec, ...]:
+        """Return all MambaSpecs for this model (GDN layers + PLE layer).
+
+        The PLE layer uses a separate short_conv MambaSpec whose page_size_bytes
+        may exceed the GDN spec; callers should take the maximum.
+        """
+        return (
+            MambaSpec(
+                shapes=cls.get_gdn_mamba_state_shape_from_config(vllm_config),
+                dtypes=cls.get_gdn_mamba_state_dtype_from_config(vllm_config),
+                block_size=-1,
+            ),
+            MambaSpec(
+                shapes=cls.get_ple_mamba_state_shape_from_config(vllm_config),
+                dtypes=cls.get_ple_mamba_state_dtype_from_config(vllm_config),
+                block_size=-1,
+            ),
+        )
+
+    def compute_logits(self, hidden_states: torch.Tensor) -> torch.Tensor | None:
+        return self.logits_processor(self.lm_head, hidden_states)
+
+    def get_mtp_target_hidden_states(self) -> torch.Tensor | None:
+        return self.model._mtp_hidden_buffer
+
+    def get_mrope_input_positions(
+        self,
+        input_tokens: list[int],
+        mm_features: list[MultiModalFeatureSpec],
+    ) -> tuple[torch.Tensor, int]:
+        positions = torch.arange(len(input_tokens), dtype=torch.long)
+        return positions.unsqueeze(0).expand(3, -1), 0
+
+    def load_weights(self, weights: Iterable[tuple[str, torch.Tensor]]) -> set[str]:
+        loader = AutoWeightsLoader(
+            self,
+            skip_substrs=["mtp."],
+            ignore_unexpected_suffixes=_QWEN4_EXP_IGNORED_MISSING_SUFFIXES.copy(),
+        )
+        return loader.load_weights(weights, mapper=self.hf_to_vllm_mapper)
+
+
+class Qwen4ExpProcessingInfo(Qwen3VLProcessingInfo):
+    def get_hf_config(self) -> Qwen4ExpConfig:
+        return self.ctx.get_hf_config(Qwen4ExpConfig)
+
+
+@MULTIMODAL_REGISTRY.register_processor(
+    Qwen3VLMultiModalProcessor,
+    info=Qwen4ExpProcessingInfo,
+    dummy_inputs=Qwen3VLDummyInputsBuilder,
+)
+class Qwen4ExpForConditionalGeneration(
+    Qwen3_5ForConditionalGeneration,
+    HasInnerState,
+    Qwen4ExpMixtureOfExperts,
+):
+    """Qwen3-VL vision tower backed by the Qwen4Exp language model."""
+
+    requires_raw_input_tokens = True
+
+    packed_modules_mapping = Qwen3_5ForConditionalGeneration.packed_modules_mapping | {
+        "input_mix_weight_down_block_inject": [
+            "input_mix_weight_down",
+            "block_inject_weight",
+            "_input_mix_padding",
+        ]
+    }
+
+    @staticmethod
+    def get_model_state_cls():
+        from .model_state import Qwen4ExpModelState
+
+        return Qwen4ExpModelState
+
+    def _init_video_pruning(self, multimodal_config) -> None:
+        """Keep compatibility with the Qwen3.5 base in vLLM 0.26.0."""
+        del multimodal_config
+        self.is_multimodal_pruning_enabled = False
+        self.video_pruning_method = None
+        self.video_pruning_rate = 0.0
+
+    def __init__(self, *, vllm_config: VllmConfig, prefix: str = "model") -> None:
+        nn.Module.__init__(self)
+        config: Qwen4ExpConfig = vllm_config.model_config.hf_config
+        quant_config = vllm_config.quant_config
+        multimodal_config = vllm_config.model_config.multimodal_config
+        if multimodal_config is None:
+            raise ValueError(
+                "Qwen4ExpForConditionalGeneration requires multimodal_config"
+            )
+
+        self.config = config
+        self.model_config = vllm_config.model_config
+        self.multimodal_config = multimodal_config
+        self.language_model_only = multimodal_config.language_model_only
+        if self.language_model_only:
+            self.use_data_parallel = False
+            self.is_multimodal_pruning_enabled = False
+            self.video_pruning_method = None
+            self.video_pruning_rate = 0.0
+            self._tokenizer = None
+            self.visual = StageMissingLayer("vision_tower")
+            self._tower_model_names = []
+        else:
+            self.use_data_parallel = multimodal_config.mm_encoder_tp_mode == "data"
+            self._init_video_pruning(multimodal_config)
+            self._tokenizer = cached_tokenizer_from_config(vllm_config.model_config)
+
+            with self._mark_tower_model(vllm_config, {"image", "video"}):
+                self.visual = Qwen3_VisionTransformer(
+                    config.vision_config,
+                    norm_eps=config.text_config.rms_norm_eps,
+                    quant_config=quant_config,
+                    prefix=maybe_prefix(prefix, "visual"),
+                )
+
+        self.use_deepstack = (
+            not self.language_model_only
+            and bool(config.vision_config.deepstack_visual_indexes)
+            and not isinstance(self.visual, StageMissingLayer)
+        )
+        self.deepstack_num_level = (
+            len(config.vision_config.deepstack_visual_indexes)
+            if self.use_deepstack
+            else 0
+        )
+        self.visual_dim = config.vision_config.out_hidden_size
+        self.multiscale_dim = self.visual_dim * self.deepstack_num_level
+
+        if self.use_deepstack:
+            self.deepstack_input_embeds = [
+                torch.zeros(
+                    vllm_config.scheduler_config.max_num_batched_tokens,
+                    config.text_config.hidden_size,
+                )
+                for _ in range(self.deepstack_num_level)
+            ]
+            self.deepstack_input_embeds_num_tokens = 0
+
+        with self._mark_language_model(vllm_config):
+            self.language_model = Qwen4ExpForCausalLM(
+                vllm_config=vllm_config,
+                prefix=maybe_prefix(prefix, "language_model"),
+            )
+
+        self.make_empty_intermediate_tensors = (
+            self.language_model.make_empty_intermediate_tensors
+        )
+        if not get_pp_group().is_first_rank and self.use_deepstack:
+            assert self.language_model.model.start_layer >= len(
+                config.vision_config.deepstack_visual_indexes
+            ), (
+                "start_layer should be greater than or equal to "
+                "len(deepstack_visual_indexes)"
+            )
+        self.set_moe_parameters(self.language_model.model.layers)
+
+    def embed_input_ids(
+        self,
+        input_ids: torch.Tensor,
+        multimodal_embeddings: MultiModalEmbeddings | None = None,
+        *,
+        is_multimodal: torch.Tensor | None = None,
+    ) -> torch.Tensor:
+        inputs_embeds = self._embed_text_input_ids(
+            input_ids,
+            self.language_model.embed_input_ids,
+            is_multimodal=is_multimodal,
+        )
+        if multimodal_embeddings is None or len(multimodal_embeddings) == 0:
+            return inputs_embeds
+        if self.language_model_only:
+            raise ValueError(
+                "Qwen4Exp language_model_only does not accept multimodal embeddings"
+            )
+
+        is_multimodal = _require_is_multimodal(is_multimodal)
+        if self.use_deepstack:
+            deepstack_input_embeds, multimodal_embeddings = (
+                self._compute_deepstack_embeds(
+                    inputs_embeds=inputs_embeds,
+                    multimodal_embeddings=multimodal_embeddings,
+                    is_multimodal=is_multimodal,
+                )
+            )
+        else:
+            deepstack_input_embeds = None
+
+        inputs_embeds = _merge_multimodal_embeddings(
+            inputs_embeds=inputs_embeds,
+            multimodal_embeddings=multimodal_embeddings,
+            is_multimodal=is_multimodal,
+        )
+        if deepstack_input_embeds is not None:
+            self._set_deepstack_input_embeds(deepstack_input_embeds)
+        return inputs_embeds
+
+    def get_mtp_target_hidden_states(self) -> torch.Tensor | None:
+        return self.language_model.get_mtp_target_hidden_states()
+
+    def forward(
+        self,
+        input_ids: torch.Tensor | None,
+        positions: torch.Tensor,
+        intermediate_tensors: IntermediateTensors | None = None,
+        inputs_embeds: torch.Tensor | None = None,
+        **kwargs: object,
+    ) -> torch.Tensor | IntermediateTensors:
+        if intermediate_tensors is not None:
+            inputs_embeds = None
+        if inputs_embeds is not None and get_pp_group().is_first_rank:
+            deepstack_input_embeds = self._get_deepstack_input_embeds(
+                inputs_embeds.size(0)
+            )
+        else:
+            deepstack_input_embeds = None
+
+        ple_input_ids = kwargs.get("ple_input_ids", input_ids)
+        hidden_states = self.language_model.model(
+            input_ids=ple_input_ids,
+            positions=positions,
+            intermediate_tensors=intermediate_tensors,
+            inputs_embeds=inputs_embeds,
+            query_start_loc=kwargs.get("query_start_loc"),
+            ngram_context=kwargs.get("ngram_context"),
+            deepstack_input_embeds=deepstack_input_embeds,
+        )
+        if inputs_embeds is not None and get_pp_group().is_first_rank:
+            self._clear_deepstack_input_embeds(inputs_embeds.size(0))
+        return hidden_states
+
+    def load_weights(self, weights: Iterable[tuple[str, torch.Tensor]]) -> set[str]:
+        loader = AutoWeightsLoader(
+            self,
+            skip_prefixes=["visual."] if self.language_model_only else None,
+            skip_substrs=["mtp."],
+            ignore_unexpected_suffixes=_QWEN4_EXP_IGNORED_MISSING_SUFFIXES.copy(),
+        )
+        return loader.load_weights(weights, mapper=self.hf_to_vllm_mapper)
+
+    @classmethod
+    def get_mamba_state_dtype_from_config(
+        cls,
+        vllm_config: VllmConfig,
+    ) -> tuple[torch.dtype, torch.dtype]:
+        return Qwen4ExpForCausalLM.get_mamba_state_dtype_from_config(vllm_config)
+
+    @classmethod
+    def get_mamba_state_shape_from_config(
+        cls,
+        vllm_config: VllmConfig,
+    ) -> tuple[tuple[int, int], tuple[int, int]]:
+        return Qwen4ExpForCausalLM.get_mamba_state_shape_from_config(vllm_config)
+
+    @classmethod
+    def get_mamba_state_copy_func(
+        cls,
+    ) -> tuple[MambaStateCopyFunc, MambaStateCopyFunc]:
+        return Qwen4ExpForCausalLM.get_mamba_state_copy_func()
+
+    @classmethod
+    def get_mamba_state_copy_funcs(
+        cls,
+        mamba_types: set[MambaAttentionBackendEnum],
+    ) -> dict[MambaAttentionBackendEnum, tuple[MambaStateCopyFunc, ...]]:
+        return Qwen4ExpForCausalLM.get_mamba_state_copy_funcs(mamba_types)
+
+    @classmethod
+    def get_mamba_specs_from_config(
+        cls, vllm_config: VllmConfig
+    ) -> tuple[MambaSpec, ...]:
+        return Qwen4ExpForCausalLM.get_mamba_specs_from_config(vllm_config)
+
+
+__all__ = [
+    "Qwen4ExpDecoderLayer",
+    "Qwen4ExpForCausalLM",
+    "Qwen4ExpForConditionalGeneration",
+    "Qwen4ExpMixtureOfExperts",
+    "Qwen4ExpModel",
+    "Qwen4ExpSparseMoeBlock",
+]

--- a/vllm_ascend/models/qwen4_exp/amd/model_state.py
+++ b/vllm_ascend/models/qwen4_exp/amd/model_state.py
@@ -1,0 +1,142 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Model-runner state for Qwen4Exp PLE inputs."""
+
+from typing import Any
+
+import torch
+import torch.nn as nn
+from vllm.config import VllmConfig
+from vllm.v1.worker.gpu.input_batch import InputBatch
+from vllm.v1.worker.gpu.mm.encoder_cache import EncoderCache
+from vllm.v1.worker.gpu.model_states.mamba_hybrid import MambaHybridModelState
+from vllm.v1.worker.gpu.states import RequestState
+
+
+class Qwen4ExpModelState(MambaHybridModelState):
+    """Add rollback-safe PLE n-gram context to the model inputs."""
+
+    def __init__(
+        self,
+        vllm_config: VllmConfig,
+        model: nn.Module,
+        encoder_cache: EncoderCache | None,
+        device: torch.device,
+    ) -> None:
+        super().__init__(vllm_config, model, encoder_cache, device)
+        config = self.model_config.hf_text_config
+        self.uses_ngram_embedding = bool(config.ple_layer_ids)
+        if not self.uses_ngram_embedding:
+            self.ngram_context_len = 0
+            self.ngram_eos_token_id = 0
+            return
+
+        if vllm_config.parallel_config.pipeline_parallel_size > 1:
+            raise RuntimeError(
+                "N-gram PLE embedding currently requires "
+                "pipeline_parallel_size=1 because non-first pipeline ranks do "
+                "not receive the raw input_ids required by PLE. Please run "
+                "with PP=1."
+            )
+
+        self.ngram_context_len = int(config.ngram_size) - 1
+        if self.ngram_context_len <= 0:
+            raise ValueError("N-gram embedding requires context length >= 1.")
+        self.ngram_eos_token_id = int(config.eos_token_id)
+        self.ngram_context = torch.full(
+            (self.max_num_reqs, self.ngram_context_len),
+            self.ngram_eos_token_id,
+            dtype=torch.int32,
+            device=self.device,
+        )
+        self.ngram_context_offsets = torch.arange(
+            -self.ngram_context_len,
+            0,
+            dtype=torch.int64,
+            device=self.device,
+        )
+        self.ple_query_start_loc = torch.zeros(
+            self.max_num_reqs + 1,
+            dtype=torch.int32,
+            device=self.device,
+        )
+
+    def _prepare_ngram_context(
+        self,
+        input_batch: InputBatch,
+        req_states: RequestState,
+    ) -> torch.Tensor:
+        num_reqs = input_batch.num_reqs
+        num_reqs_padded = input_batch.num_reqs_after_padding
+        context = self.ngram_context[:num_reqs_padded]
+        context.fill_(self.ngram_eos_token_id)
+        if num_reqs == 0:
+            return context
+
+        request_indices = input_batch.idx_mapping[:num_reqs].long()
+        context_end = req_states.num_computed_tokens.gpu[request_indices].long()
+        token_indices = context_end.unsqueeze(1) + self.ngram_context_offsets
+        valid_tokens = token_indices >= 0
+        token_indices.clamp_min_(0)
+        context_tokens = req_states.all_token_ids.gpu[
+            request_indices.unsqueeze(1), token_indices
+        ]
+        context[:num_reqs].copy_(
+            torch.where(
+                valid_tokens,
+                context_tokens,
+                context_tokens.new_full((), self.ngram_eos_token_id),
+            )
+        )
+        return context
+
+    def prepare_inputs(
+        self,
+        input_batch: InputBatch,
+        req_states: RequestState,
+    ) -> dict[str, Any]:
+        model_inputs = super().prepare_inputs(input_batch, req_states)
+        if not self.uses_ngram_embedding:
+            return model_inputs
+
+        num_reqs_padded = input_batch.num_reqs_after_padding
+        query_start_loc = self.ple_query_start_loc[: num_reqs_padded + 1]
+        query_start_loc.copy_(input_batch.query_start_loc[: num_reqs_padded + 1])
+        model_inputs.update(
+            query_start_loc=query_start_loc,
+            ngram_context=self._prepare_ngram_context(input_batch, req_states),
+        )
+        return model_inputs
+
+    def prepare_dummy_inputs(
+        self,
+        num_reqs: int,
+        num_tokens: int,
+    ) -> dict[str, Any]:
+        model_inputs = super().prepare_dummy_inputs(num_reqs, num_tokens)
+        if not self.uses_ngram_embedding:
+            return model_inputs
+
+        query_start_loc = self.ple_query_start_loc[: num_reqs + 1]
+        query_start_loc[0] = 0
+        tokens_per_req, num_extra_tokens = divmod(num_tokens, num_reqs)
+        query_lens = torch.full(
+            (num_reqs,),
+            tokens_per_req,
+            dtype=query_start_loc.dtype,
+            device=query_start_loc.device,
+        )
+        if num_extra_tokens > 0:
+            query_lens[-num_extra_tokens:] += 1
+        torch.cumsum(query_lens, dim=0, out=query_start_loc[1:])
+
+        ngram_context = self.ngram_context[:num_reqs]
+        ngram_context.fill_(self.ngram_eos_token_id)
+        model_inputs.update(
+            query_start_loc=query_start_loc,
+            ngram_context=ngram_context,
+        )
+        return model_inputs
+
+
+__all__ = ["Qwen4ExpModelState"]

--- a/vllm_ascend/models/qwen4_exp/amd/mtp.py
+++ b/vllm_ascend/models/qwen4_exp/amd/mtp.py
@@ -1,0 +1,447 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Inference-only Qwen4Exp MTP (Multi-Token Predictor) model.
+
+The MTP draft model reuses the Qwen4Exp backbone (PLE/HC/MoE) but:
+  - drops all multi-modal handling (text-only),
+  - forces PLE off while keeping the main model's HC stream count,
+  - fuses the backbone hidden and the new-token embedding via
+    ``residual_linear_shared`` (fc_embedding + shared fc_hidden) instead of
+    the ``Linear(2H, H)`` + repeat used by other MTP variants,
+  - emits TWO hidden streams per step (scheme A): a single stream [T, H]
+    (final-mixer collapsed, fed to the LM head) and a pre-final-mixer
+    multi stream [T, hc_count*H] (fed to the next draft step).
+"""
+
+from collections.abc import Iterable
+
+import regex as re
+import torch
+from torch import nn
+from vllm.compilation.decorators import support_torch_compile
+from vllm.config import VllmConfig, replace, set_current_vllm_config
+from vllm.distributed import get_pp_group
+from vllm.model_executor.layers.layernorm import GemmaRMSNorm
+from vllm.model_executor.layers.linear import ColumnParallelLinear
+from vllm.model_executor.layers.logits_processor import LogitsProcessor
+from vllm.model_executor.layers.vocab_parallel_embedding import (
+    ParallelLMHead,
+    VocabParallelEmbedding,
+)
+from vllm.model_executor.model_loader.utils import configure_quant_config
+from vllm.model_executor.models.interfaces import SupportsPP
+from vllm.model_executor.models.qwen3_5 import Qwen3_5Model
+from vllm.model_executor.models.utils import (
+    AutoWeightsLoader,
+    PPMissingLayer,
+    get_draft_quant_config,
+    make_empty_intermediate_tensors_factory,
+    maybe_fuse_shared_experts,
+    maybe_prefix,
+)
+from vllm.sequence import IntermediateTensors
+
+from vllm_ascend.models.qwen4_exp.config import (
+    Qwen4ExpTextConfig,
+)
+
+from .hyperconnection import GatedResidual, HyperConnectionConfig
+from .low_latency_gemm import enable_qwen4_exp_low_latency_gemm
+from .model import (
+    _HC_WEIGHTS_MAPPER,
+    _QWEN4_EXP_IGNORED_MISSING_SUFFIXES,
+    Qwen4ExpDecoderLayer,
+    Qwen4ExpMixtureOfExperts,
+)
+
+
+def _remap_ignored_layers(
+    ignored_layers: list[str],
+    mtp_start_layer_idx: int,
+) -> list[str]:
+    remapped: list[str] = []
+    for name in ignored_layers:
+        if name.startswith("mtp."):
+            new_name = re.sub(
+                r"(?<=\.layers\.)\d+",
+                lambda m: str(mtp_start_layer_idx + int(m.group(0))),
+                name,
+            )
+            remapped.append(new_name)
+        else:
+            remapped.append(name)
+    return remapped
+
+
+def _remap_mtp_weight_name(name: str) -> str | None:
+    """Map Qwen4Exp checkpoint paths into the standalone draft model."""
+
+    for checkpoint_prefix in (
+        "model.language_model.",
+        "language_model.",
+    ):
+        if name.startswith(checkpoint_prefix):
+            name = name.removeprefix(checkpoint_prefix)
+            break
+
+    if name.startswith("embed_tokens."):
+        name = f"model.{name}"
+    if name.startswith("model.mtp."):
+        name = name.removeprefix("model.")
+    if name.startswith("mtp.shared_head.head."):
+        return name.replace("mtp.shared_head.head.", "lm_head.", 1)
+    if name.startswith("model.shared_head.head."):
+        return name.replace("model.shared_head.head.", "lm_head.", 1)
+    if name.startswith("shared_head.head."):
+        return name.replace("shared_head.head.", "lm_head.", 1)
+    if name.startswith("model.lm_head."):
+        return name.removeprefix("model.")
+    if name.startswith("mtp."):
+        return name.replace("mtp.", "model.", 1)
+    if name.startswith("model.embed_tokens.") or name.startswith("lm_head."):
+        return name
+    return None
+
+
+def _make_draft_vllm_config(
+    vllm_config: VllmConfig,
+    mtp_start_layer_idx: int,
+) -> VllmConfig:
+    """Ensure that the draft model config is set in the vLLM config."""
+    speculative_config = vllm_config.speculative_config
+    if speculative_config is None or speculative_config.draft_model_config is None:
+        raise ValueError("speculative_config.draft_model_config must be set")
+
+    draft_quant_config = get_draft_quant_config(vllm_config)
+
+    # inject packed and ignored modules to the quantization config of draft model
+    if draft_quant_config is not None:
+        configure_quant_config(draft_quant_config, Qwen4ExpMTP)
+        ignored_layers = getattr(draft_quant_config, "ignored_layers", None)
+        if ignored_layers:
+            setattr(  # noqa: B010
+                draft_quant_config,
+                "ignored_layers",
+                _remap_ignored_layers(ignored_layers, mtp_start_layer_idx),
+            )
+        exclude_modules = getattr(draft_quant_config, "exclude_modules", None)
+        if exclude_modules:
+            setattr(  # noqa: B010
+                draft_quant_config,
+                "exclude_modules",
+                _remap_ignored_layers(exclude_modules, mtp_start_layer_idx),
+            )
+
+    draft_vllm_config = replace(
+        vllm_config,
+        model_config=speculative_config.draft_model_config,
+    )
+    # VllmConfig post-init derives the target quant config, so restore the
+    # independently resolved draft quant config after replacement.
+    draft_vllm_config.quant_config = draft_quant_config
+    return draft_vllm_config
+
+
+@support_torch_compile(
+    dynamic_arg_dims={
+        "input_ids": 0,
+        "positions": -1,
+        "intermediate_tensors": 0,
+        "inputs_embeds": 0,
+        "hidden_states": 0,
+    }
+)
+class Qwen4ExpMultiTokenPredictor(nn.Module):
+    hf_to_vllm_mapper = Qwen3_5Model.hf_to_vllm_mapper | _HC_WEIGHTS_MAPPER
+
+    def __init__(self, *, vllm_config: VllmConfig, prefix: str = "") -> None:
+        super().__init__()
+
+        model_config = vllm_config.model_config
+        config: Qwen4ExpTextConfig = model_config.hf_text_config
+
+        self.config = config
+        self.vocab_size = config.vocab_size
+
+        self.mtp_start_layer_idx = config.num_hidden_layers
+        self.num_mtp_layers = getattr(config, "mtp_num_hidden_layers", 1)
+
+        self.hidden_size = config.hidden_size
+        self.hc_count = config.hc_count
+
+        self.embed_tokens = VocabParallelEmbedding(self.vocab_size, self.hidden_size)
+        draft_vllm_config = _make_draft_vllm_config(
+            vllm_config,
+            self.mtp_start_layer_idx,
+        )
+        with set_current_vllm_config(draft_vllm_config, prefix=prefix):
+            # residual_linear_shared fusion: fc_embedding projects the token
+            # embedding, fc_hidden (shared across HC branches) projects the
+            # backbone hidden; the embedding is added as a residual to every
+            # branch (see mtp_residual_linear_shared.md).
+            self.fc_embedding = ColumnParallelLinear(
+                self.hidden_size,
+                self.hidden_size,
+                gather_output=True,
+                bias=False,
+                return_bias=False,
+                quant_config=draft_vllm_config.quant_config,
+                prefix=f"{prefix}.fc_embedding",
+            )
+            self.fc_hidden = ColumnParallelLinear(
+                self.hidden_size,
+                self.hidden_size,
+                gather_output=True,
+                bias=False,
+                return_bias=False,
+                quant_config=draft_vllm_config.quant_config,
+                prefix=f"{prefix}.fc_hidden",
+            )
+            self.layers = nn.ModuleList(
+                Qwen4ExpDecoderLayer(
+                    draft_vllm_config,
+                    layer_type="full_attention",
+                    prefix=f"{prefix}.layers.{self.mtp_start_layer_idx + idx}",
+                )
+                for idx in range(self.num_mtp_layers)
+            )
+
+        self.pre_fc_norm_embedding = GemmaRMSNorm(
+            self.hidden_size, eps=config.rms_norm_eps
+        )
+        self.pre_fc_norm_hidden = GemmaRMSNorm(
+            self.hidden_size * self.hc_count, eps=config.rms_norm_eps
+        )
+        # HC final mixer collapses the multi stream into [T, H] for the LM head.
+        hc_config = HyperConnectionConfig(
+            hc_count=config.hc_count,
+            hidden_size=config.hidden_size,
+            params_dtype=torch.bfloat16,
+            hc_lowrank=config.hc_lowrank,
+            rms_norm_eps=config.rms_norm_eps,
+            hc_per_branch_norm=True,
+        )
+        self.hyper_connection_mixer = GatedResidual(
+            hc_config,
+            use_combine=False,
+            prefix=maybe_prefix(prefix, "hyper_connection_mixer"),
+        )
+        self.make_empty_intermediate_tensors = make_empty_intermediate_tensors_factory(
+            ["hidden_states"], self.hidden_size * self.hc_count
+        )
+
+    def _iter_qsa_attentions(self):
+        """Yield MTP attention modules that own a QSA indexer."""
+
+        for layer in self.layers:
+            attention = getattr(layer, "self_attn", None)
+            if (
+                attention is not None
+                and getattr(attention, "indexer", None) is not None
+            ):
+                yield attention
+
+    def set_skip_topk(self, skip: bool) -> None:
+        """Select on MTP step 0 and reuse its QSA indices on later steps."""
+
+        for attention in self._iter_qsa_attentions():
+            attention.indexer.skip_topk = skip
+
+    def compact_topk_indices(self, row_indices: torch.Tensor) -> None:
+        """Keep each request's target-aligned step-0 sparse-index row."""
+
+        num_rows = row_indices.numel()
+        for attention in self._iter_qsa_attentions():
+            buffer = attention.topk_indices_buffer
+            selected = buffer.index_select(0, row_indices)
+            buffer[:num_rows].copy_(selected)
+
+    def embed_input_ids(self, input_ids: torch.Tensor) -> torch.Tensor:
+        return self.embed_tokens(input_ids)
+
+    def forward(
+        self,
+        input_ids: torch.Tensor | None,
+        positions: torch.Tensor,
+        hidden_states: torch.Tensor | None = None,
+        intermediate_tensors: IntermediateTensors | None = None,
+        inputs_embeds: torch.Tensor | None = None,
+        spec_step_idx: int = 0,
+    ) -> torch.Tensor | tuple[torch.Tensor, torch.Tensor] | IntermediateTensors:
+        hc_count = self.hc_count
+        hidden_size = self.hidden_size
+
+        if get_pp_group().is_first_rank:
+            assert hidden_states is not None
+            if inputs_embeds is None:
+                assert input_ids is not None
+                inputs_embeds = self.embed_input_ids(input_ids)
+            # Embedding branch: pre-norm -> fc_embedding -> [T, H].
+            inputs_embeds = self.pre_fc_norm_embedding(inputs_embeds)
+            inputs_embeds = self.fc_embedding(inputs_embeds)
+
+            # Backbone hidden is multi-stream [T, hc_count*H] (scheme A:
+            # the main model truly emits the pre-final-mixer multi stream
+            # on the first step; subsequent steps reuse the prior draft
+            # step's multi stream).
+            num_tokens = hidden_states.shape[0]
+            hidden_states = hidden_states.view(num_tokens, hc_count, hidden_size)
+            hidden_states = self.pre_fc_norm_hidden(hidden_states.flatten(-2)).view(
+                num_tokens, hc_count, hidden_size
+            )
+            hidden_states = self.fc_hidden(hidden_states)
+            # Add the embedding residual to every branch, then fold back
+            # to [T, hc_count*H] (HC outer, HS inner) for the HC decoder.
+            hidden_states = inputs_embeds.unsqueeze(-2) + hidden_states
+            hidden_states = hidden_states.flatten(-2)
+        else:
+            assert intermediate_tensors is not None
+            hidden_states = intermediate_tensors["hidden_states"]
+
+        current_step_idx = spec_step_idx % self.num_mtp_layers
+        layer = self.layers[current_step_idx]
+        hidden_states, block_output, injection = layer(
+            hidden_states=hidden_states,
+            prev_block_output=None,
+            prev_injection=None,
+            positions=positions,
+            input_ids=None,
+            query_start_loc=None,
+            ngram_context=None,
+        )
+        if not get_pp_group().is_last_rank:
+            # As in the target model, PP carries a materialized tensor rather
+            # than the delayed hidden/output/injection tuple.
+            hidden_states = layer.mlp_hyper_connection.combine(
+                hidden_states, block_output, injection
+            )
+            return IntermediateTensors({"hidden_states": hidden_states})
+
+        # Last PP rank finalize. Keep both:
+        #   (A) sample_hidden_states [T, H]  -> single stream for the LM head
+        #   (B) multi_hidden [T, hc_count*H] -> pre-final-mixer multi stream
+        #       for the next draft step (zero extra compute, just kept).
+        multi_hidden, sample_hidden_states, _ = (
+            self.hyper_connection_mixer.combine_and_mix(
+                hidden_states, block_output, injection
+            )
+        )
+        return sample_hidden_states, multi_hidden
+
+    def load_weights(self, weights: Iterable[tuple[str, torch.Tensor]]) -> set[str]:
+        weights = maybe_fuse_shared_experts(
+            weights,
+            n_routed_experts=getattr(self.config, "num_experts", 0) or 0,
+            n_shared_experts=1,
+            ckpt_prefix="mlp.shared_expert",
+        )
+        loader = AutoWeightsLoader(
+            self,
+            skip_substrs=["hyper_connection_mixer.block_inject_weight"],
+            ignore_unexpected_suffixes=_QWEN4_EXP_IGNORED_MISSING_SUFFIXES.copy(),
+        )
+        return loader.load_weights(weights, mapper=self.hf_to_vllm_mapper)
+
+
+@support_torch_compile(
+    dynamic_arg_dims={
+        "input_ids": 0,
+        "positions": -1,
+        "intermediate_tensors": 0,
+        "inputs_embeds": 0,
+        "hidden_states": 0,
+    }
+)
+class Qwen4ExpMTP(nn.Module, SupportsPP, Qwen4ExpMixtureOfExperts):
+    packed_modules_mapping = {
+        "qkv_proj": ["q_proj", "k_proj", "v_proj"],
+        "gate_up_proj": ["gate_proj", "up_proj"],
+        "in_proj_qkvz": ["in_proj_qkv", "in_proj_z"],
+        "in_proj_ba": ["in_proj_b", "in_proj_a"],
+        "input_mix_weight_down_block_inject": [
+            "input_mix_weight_down",
+            "block_inject_weight",
+            "_input_mix_padding",
+        ],
+    }
+
+    def __init__(self, *, vllm_config: VllmConfig, prefix: str = "") -> None:
+        config: Qwen4ExpTextConfig = vllm_config.model_config.hf_text_config
+        self.vllm_config = vllm_config
+        cache_config = vllm_config.cache_config
+        if cache_config.mamba_cache_mode == "all":
+            raise NotImplementedError(
+                "Qwen4ExpMTP currently does not support 'all' prefix caching, "
+                "please use '--mamba-cache-mode=align' instead"
+            )
+
+        self.quant_config = vllm_config.quant_config
+
+        super().__init__()
+        self.config = config
+        self.model = Qwen4ExpMultiTokenPredictor(
+            vllm_config=vllm_config,
+            prefix=maybe_prefix(prefix, "mtp"),
+        )
+
+        if get_pp_group().is_last_rank:
+            if config.tie_word_embeddings:
+                self.lm_head = self.model.embed_tokens
+            else:
+                self.lm_head = ParallelLMHead(
+                    config.vocab_size,
+                    config.hidden_size,
+                    prefix=maybe_prefix(prefix, "lm_head"),
+                )
+        else:
+            self.lm_head = PPMissingLayer()
+
+        self.logits_processor = LogitsProcessor(config.vocab_size)
+        self.make_empty_intermediate_tensors = (
+            self.model.make_empty_intermediate_tensors
+        )
+        self.set_moe_parameters(self.model.layers)
+        enable_qwen4_exp_low_latency_gemm(self, vllm_config.model_config.dtype)
+
+    def embed_input_ids(self, input_ids: torch.Tensor) -> torch.Tensor:
+        return self.model.embed_input_ids(input_ids)
+
+    def forward(
+        self,
+        input_ids: torch.Tensor | None,
+        positions: torch.Tensor,
+        hidden_states: torch.Tensor | None = None,
+        intermediate_tensors: IntermediateTensors | None = None,
+        inputs_embeds: torch.Tensor | None = None,
+        spec_step_idx: int = 0,
+    ) -> torch.Tensor | tuple[torch.Tensor, torch.Tensor] | IntermediateTensors:
+        return self.model(
+            input_ids,
+            positions,
+            hidden_states,
+            intermediate_tensors,
+            inputs_embeds,
+            spec_step_idx=spec_step_idx,
+        )
+
+    def compute_logits(
+        self, hidden_states: torch.Tensor, spec_step_idx: int = 0
+    ) -> torch.Tensor | None:
+        return self.logits_processor(self.lm_head, hidden_states)
+
+    def load_weights(self, weights: Iterable[tuple[str, torch.Tensor]]) -> set[str]:
+        def remap_weight_names():
+            for name, weight in weights:
+                remapped_name = _remap_mtp_weight_name(name)
+                if remapped_name is not None:
+                    yield remapped_name, weight
+
+        loader = AutoWeightsLoader(
+            self,
+            skip_substrs=["hyper_connection_mixer.block_inject_weight"],
+            ignore_unexpected_suffixes=_QWEN4_EXP_IGNORED_MISSING_SUFFIXES.copy(),
+        )
+        return loader.load_weights(remap_weight_names())
+
+
+__all__ = ["Qwen4ExpMTP", "Qwen4ExpMultiTokenPredictor"]

--- a/vllm_ascend/models/qwen4_exp/amd/ops/__init__.py
+++ b/vllm_ascend/models/qwen4_exp/amd/ops/__init__.py
@@ -1,0 +1,3 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""AMD ROCm Qwen4Exp kernels; import leaf modules directly."""

--- a/vllm_ascend/models/qwen4_exp/amd/ops/hc.py
+++ b/vllm_ascend/models/qwen4_exp/amd/ops/hc.py
@@ -1,0 +1,486 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""AMD ROCm HyperConnection kernels for Qwen4Exp."""
+
+import torch
+from vllm.platforms import current_platform
+from vllm.triton_utils import tl, triton
+from vllm.utils.torch_utils import direct_register_custom_op
+
+
+@triton.jit
+def _grouped_gemma_rmsnorm_kernel(
+    x_ptr,
+    w_ptr,
+    y_ptr,
+    stride_x,
+    stride_y,
+    DIM: tl.constexpr,
+    NUM_GROUPS: tl.constexpr,
+    W_SHARED: tl.constexpr,
+    EPS: tl.constexpr,
+    launch_pdl: tl.constexpr,
+) -> None:
+    GROUP_DIM: tl.constexpr = DIM // NUM_GROUPS
+    BLOCK_SIZE: tl.constexpr = triton.next_power_of_2(GROUP_DIM)
+
+    pid = tl.program_id(0)
+    group_id = pid % NUM_GROUPS
+    row = pid // NUM_GROUPS
+
+    offs_g = tl.arange(0, BLOCK_SIZE)
+    offsets = group_id * GROUP_DIM + offs_g
+    mask = offs_g < GROUP_DIM
+    # A [GROUP_DIM] affine is shared; a [DIM] affine follows the grouped
+    # checkpoint layout.
+    w_offs = offs_g if W_SHARED else offsets
+
+    if launch_pdl:
+        tl.extra.cuda.gdc_wait()
+
+    x = tl.load(x_ptr + row * stride_x + offsets, mask, other=0.0).to(tl.float32)
+    w = tl.load(w_ptr + w_offs, mask, other=0.0)
+
+    rrms = tl.rsqrt(tl.sum(x * x) / GROUP_DIM + EPS)
+    # Gemma's (1 + w) affine is written this way to lower to an FMA.
+    y = x * rrms
+    y += y * w.to(tl.float32)
+
+    if launch_pdl:
+        tl.extra.cuda.gdc_launch_dependents()
+    tl.store(y_ptr + row * stride_y + offsets, y, mask)
+
+
+def _grouped_gemma_rmsnorm(
+    x: torch.Tensor, weight: torch.Tensor, eps: float, num_groups: int
+) -> torch.Tensor:
+    N, DIM = x.shape
+    assert x.stride(1) == 1, "grouped Gemma RMSNorm requires unit inner stride"
+    assert weight.is_contiguous(), "grouped Gemma RMSNorm weight must be contiguous"
+    assert DIM % num_groups == 0
+    group_dim = DIM // num_groups
+    assert weight.numel() in (group_dim, DIM)
+
+    y = x.new_empty(x.shape)
+    _grouped_gemma_rmsnorm_kernel[(N * num_groups,)](
+        x,
+        weight,
+        y,
+        x.stride(0),
+        y.stride(0),
+        DIM,
+        num_groups,
+        W_SHARED=weight.numel() == group_dim,
+        EPS=eps,
+        launch_pdl=current_platform.is_arch_support_pdl(),
+    )
+    return y
+
+
+@triton.jit
+def _hc_silu_kernel(
+    x_ptr,
+    y_ptr,
+    stride_x,
+    stride_y,
+    DIM: tl.constexpr,
+    HC: tl.constexpr,
+    launch_pdl: tl.constexpr,
+) -> None:
+    BLOCK_SIZE: tl.constexpr = triton.next_power_of_2(DIM)
+
+    row = tl.program_id(0)
+    offs = tl.arange(0, BLOCK_SIZE)
+    mask = offs < DIM
+
+    if launch_pdl:
+        tl.extra.cuda.gdc_wait()
+
+    x = tl.load(x_ptr + row * stride_x + offs, mask).to(tl.float32) / HC
+    y = x * tl.sigmoid(x)
+
+    if launch_pdl:
+        tl.extra.cuda.gdc_launch_dependents()
+    tl.store(y_ptr + row * stride_y + offs, y, mask)
+
+
+def _hc_silu(x: torch.Tensor, hc_count: int) -> torch.Tensor:
+    num_tokens, DIM = x.shape
+    assert x.stride(1) == 1
+
+    output = x.new_empty(x.shape)
+    _hc_silu_kernel[(num_tokens,)](
+        x,
+        output,
+        x.stride(0),
+        output.stride(0),
+        DIM=DIM,
+        HC=hc_count,
+        launch_pdl=current_platform.is_arch_support_pdl(),
+    )
+    return output
+
+
+@triton.jit
+def _hc_gate_mix_kernel(
+    x_ptr,
+    g_ptr,
+    y_ptr,
+    stride_x,
+    stride_g,
+    stride_y,
+    DIM: tl.constexpr,
+    HC: tl.constexpr,
+    BLOCK_SIZE: tl.constexpr,
+    launch_pdl: tl.constexpr,
+) -> None:
+    HC_DIM: tl.constexpr = DIM // HC
+
+    row = tl.program_id(0)
+    tile_id = tl.program_id(1)
+    offs_inner = tile_id * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
+    mask = offs_inner < HC_DIM
+
+    if launch_pdl:
+        tl.extra.cuda.gdc_wait()
+
+    # The constexpr loop is unrolled and keeps one stream live at a time.
+    # Materializing [HC, BLOCK_SIZE] more than doubles latency at large M.
+    acc = tl.zeros([BLOCK_SIZE], dtype=tl.float32)
+    for stream in tl.static_range(HC):
+        offsets = stream * HC_DIM + offs_inner
+        g = tl.load(g_ptr + row * stride_g + offsets, mask, other=0.0)
+        x = tl.load(x_ptr + row * stride_x + offsets, mask, other=0.0)
+        acc += tl.sigmoid(g.to(tl.float32)) * x.to(tl.float32)
+    acc /= HC
+
+    if launch_pdl:
+        tl.extra.cuda.gdc_launch_dependents()
+    tl.store(y_ptr + row * stride_y + offs_inner, acc, mask)
+
+
+def _hc_gate_mix(x: torch.Tensor, gate: torch.Tensor, hc_count: int) -> torch.Tensor:
+    N, DIM = gate.shape
+    assert x.shape == gate.shape
+    assert DIM % hc_count == 0
+    assert x.stride(1) == 1
+    assert gate.stride(1) == 1
+
+    HC_DIM = DIM // hc_count
+    out = x.new_empty(N, HC_DIM)
+    BLOCK_SIZE = 512
+    _hc_gate_mix_kernel[(N, triton.cdiv(HC_DIM, BLOCK_SIZE))](
+        x,
+        gate,
+        out,
+        x.stride(0),
+        gate.stride(0),
+        out.stride(0),
+        DIM,
+        hc_count,
+        BLOCK_SIZE,
+        launch_pdl=current_platform.is_arch_support_pdl(),
+    )
+    return out
+
+
+@triton.jit
+def _hc_combine_kernel(
+    block_ptr,
+    res_ptr,
+    inj_ptr,
+    out_ptr,
+    stride_block,
+    stride_res,
+    stride_inj,
+    stride_out,
+    HC_DIM: tl.constexpr,
+    HC: tl.constexpr,
+    BLOCK_SIZE: tl.constexpr,
+    launch_pdl: tl.constexpr,
+) -> None:
+    HC_PAD: tl.constexpr = triton.next_power_of_2(HC)
+
+    row = tl.program_id(0)
+    tile_id = tl.program_id(1)
+
+    offs_inner = tile_id * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
+    mask_inner = offs_inner < HC_DIM
+    offs_hc = tl.arange(0, HC_PAD)
+    mask_hc = offs_hc < HC
+    offs = offs_hc[:, None] * HC_DIM + offs_inner[None, :]
+    mask = mask_hc[:, None] & mask_inner[None, :]
+
+    if launch_pdl:
+        tl.extra.cuda.gdc_wait()
+
+    inj = tl.load(inj_ptr + row * stride_inj + offs_hc, mask_hc, other=0.0)
+    block = tl.load(block_ptr + row * stride_block + offs_inner, mask_inner, other=0.0)
+    res = tl.load(res_ptr + row * stride_res + offs, mask, other=0.0)
+
+    # Keeping HC as a broadcast dimension is faster here than four separate
+    # residual load/store sequences.
+    inj = 2.0 * tl.sigmoid(inj.to(tl.float32) / HC)
+    out = res.to(tl.float32) + block.to(tl.float32)[None, :] * inj[:, None]
+
+    if launch_pdl:
+        tl.extra.cuda.gdc_launch_dependents()
+    tl.store(out_ptr + row * stride_out + offs, out, mask=mask)
+
+
+def _hc_combine(
+    residual: torch.Tensor,
+    block_output: torch.Tensor,
+    injection_logits: torch.Tensor,
+    hc_count: int,
+) -> torch.Tensor:
+    N, DIM = residual.shape
+    assert DIM % hc_count == 0
+    hc_dim = DIM // hc_count
+    assert block_output.shape == (N, hc_dim)
+    assert injection_logits.shape == (N, hc_count)
+    assert residual.stride(1) == 1
+    assert block_output.stride(1) == 1
+    assert injection_logits.stride(1) == 1
+
+    out = residual.new_empty(residual.shape)
+    BLOCK_SIZE = 512
+    _hc_combine_kernel[(N, triton.cdiv(hc_dim, BLOCK_SIZE))](
+        block_output,
+        residual,
+        injection_logits,
+        out,
+        block_output.stride(0),
+        residual.stride(0),
+        injection_logits.stride(0),
+        out.stride(0),
+        hc_dim,
+        hc_count,
+        BLOCK_SIZE,
+        launch_pdl=current_platform.is_arch_support_pdl(),
+    )
+    return out
+
+
+@triton.jit
+def _hc_combine_norm_kernel(
+    block_ptr,
+    res_ptr,
+    inj_ptr,
+    w_ptr,
+    out_ptr,
+    y_ptr,
+    stride_block,
+    stride_res,
+    stride_inj,
+    stride_out,
+    stride_y,
+    HC_DIM: tl.constexpr,
+    HC: tl.constexpr,
+    W_SHARED: tl.constexpr,
+    EPS: tl.constexpr,
+    BLOCK_SIZE: tl.constexpr,
+    launch_pdl: tl.constexpr,
+) -> None:
+    HC_PAD: tl.constexpr = triton.next_power_of_2(HC)
+    NUM_TILES: tl.constexpr = triton.cdiv(HC_DIM, BLOCK_SIZE)
+    NUM_TILES_PAD: tl.constexpr = triton.next_power_of_2(NUM_TILES)
+
+    row = tl.program_id(0)
+    stream = tl.program_id(1)
+    offs_hc = tl.arange(0, HC_PAD)
+    mask_hc = offs_hc < HC
+    tile_ids = tl.arange(0, NUM_TILES_PAD)
+    offs_inner = tile_ids[:, None] * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)[None, :]
+    mask_inner = offs_inner < HC_DIM
+    offs = stream * HC_DIM + offs_inner
+    # Shared norm weights repeat across streams; per-branch weights use the
+    # same flattened HC layout as the residual.
+    w_offs = offs_inner if W_SHARED else offs
+
+    if launch_pdl:
+        tl.extra.cuda.gdc_wait()
+
+    # Start the uncached residual load first, then issue the other combine
+    # loads before consuming any of them.
+    res = tl.load(res_ptr + row * stride_res + offs, mask_inner, other=0.0)
+    inj = tl.load(inj_ptr + row * stride_inj + offs_hc, mask_hc, other=0.0)
+    block = tl.load(block_ptr + row * stride_block + offs_inner, mask_inner, other=0.0)
+    inj = 2.0 * tl.sigmoid(inj.to(tl.float32) / HC)
+    inj = tl.sum(tl.where(offs_hc == stream, inj, 0.0))
+    # Round the materialized combine result before normalization. This matches
+    # the unfused combine -> RMSNorm boundary.
+    out = (res.to(tl.float32) + block.to(tl.float32) * inj).to(out_ptr.dtype.element_ty)
+    tl.store(out_ptr + row * stride_out + offs, out, mask=mask_inner)
+
+    out = out.to(tl.float32)
+    # Keep the two-axis reduction: flattening the padded tile is ~40% slower
+    # at decode sizes.
+    sum_sq = tl.sum(tl.sum(out * out, axis=1), axis=0)
+    rrms = tl.rsqrt(sum_sq / HC_DIM + EPS)
+
+    if launch_pdl:
+        tl.extra.cuda.gdc_launch_dependents()
+
+    # Loading the weight earlier helps decode but keeps the tile live across
+    # the reduction and regresses larger batches, so defer it to the norm.
+    w = tl.load(w_ptr + w_offs, mask_inner, other=0.0)
+    y = out * rrms
+    y += y * w.to(tl.float32)
+    tl.store(y_ptr + row * stride_y + offs, y, mask_inner)
+
+
+def _hc_combine_norm(
+    residual: torch.Tensor,
+    block_output: torch.Tensor,
+    injection_logits: torch.Tensor,
+    norm_weight: torch.Tensor,
+    eps: float,
+    hc_count: int,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    N, DIM = residual.shape
+    assert DIM % hc_count == 0
+    hc_dim = DIM // hc_count
+    assert block_output.shape == (N, hc_dim)
+    assert injection_logits.shape == (N, hc_count)
+    assert residual.stride(1) == 1
+    assert block_output.stride(1) == 1
+    assert injection_logits.stride(1) == 1
+    assert norm_weight.is_contiguous()
+    assert norm_weight.numel() in (hc_dim, DIM)
+
+    out = residual.new_empty(residual.shape)
+    y = residual.new_empty(residual.shape)
+    BLOCK_SIZE = 512
+    _hc_combine_norm_kernel[(N, hc_count)](
+        block_output,
+        residual,
+        injection_logits,
+        norm_weight,
+        out,
+        y,
+        block_output.stride(0),
+        residual.stride(0),
+        injection_logits.stride(0),
+        out.stride(0),
+        y.stride(0),
+        hc_dim,
+        hc_count,
+        W_SHARED=norm_weight.numel() == hc_dim,
+        EPS=eps,
+        BLOCK_SIZE=BLOCK_SIZE,
+        launch_pdl=current_platform.is_arch_support_pdl(),
+    )
+    return out, y
+
+
+def _same_shape_fake(x: torch.Tensor, *args) -> torch.Tensor:
+    return x.new_empty(x.shape)
+
+
+def _hc_gate_mix_fake(
+    x: torch.Tensor, gate: torch.Tensor, hc_count: int
+) -> torch.Tensor:
+    del gate
+    return x.new_empty((x.shape[0], x.shape[1] // hc_count))
+
+
+def _hc_combine_fake(
+    residual: torch.Tensor,
+    block_output: torch.Tensor,
+    injection_logits: torch.Tensor,
+    hc_count: int,
+) -> torch.Tensor:
+    del block_output, injection_logits, hc_count
+    return residual.new_empty(residual.shape)
+
+
+def _hc_combine_norm_fake(
+    residual: torch.Tensor,
+    block_output: torch.Tensor,
+    injection_logits: torch.Tensor,
+    norm_weight: torch.Tensor,
+    eps: float,
+    hc_count: int,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    del block_output, injection_logits, norm_weight, eps, hc_count
+    return residual.new_empty(residual.shape), residual.new_empty(residual.shape)
+
+
+direct_register_custom_op(
+    op_name="qwen4_exp_grouped_gemma_rmsnorm",
+    op_func=_grouped_gemma_rmsnorm,
+    fake_impl=_same_shape_fake,
+)
+direct_register_custom_op(
+    op_name="qwen4_exp_hc_silu",
+    op_func=_hc_silu,
+    fake_impl=_same_shape_fake,
+)
+direct_register_custom_op(
+    op_name="qwen4_exp_hc_gate_mix",
+    op_func=_hc_gate_mix,
+    fake_impl=_hc_gate_mix_fake,
+)
+direct_register_custom_op(
+    op_name="qwen4_exp_hc_combine",
+    op_func=_hc_combine,
+    fake_impl=_hc_combine_fake,
+)
+direct_register_custom_op(
+    op_name="qwen4_exp_hc_combine_norm",
+    op_func=_hc_combine_norm,
+    fake_impl=_hc_combine_norm_fake,
+)
+
+
+def grouped_gemma_rmsnorm(
+    x: torch.Tensor, weight: torch.Tensor, eps: float, num_groups: int
+) -> torch.Tensor:
+    return torch.ops.vllm.qwen4_exp_grouped_gemma_rmsnorm(x, weight, eps, num_groups)
+
+
+def hc_silu(x: torch.Tensor, hc_count: int) -> torch.Tensor:
+    return torch.ops.vllm.qwen4_exp_hc_silu(x, hc_count)
+
+
+def hc_gate_mix(x: torch.Tensor, gate: torch.Tensor, hc_count: int) -> torch.Tensor:
+    return torch.ops.vllm.qwen4_exp_hc_gate_mix(x, gate, hc_count)
+
+
+def hc_combine(
+    residual: torch.Tensor,
+    block_output: torch.Tensor,
+    injection_logits: torch.Tensor,
+    hc_count: int,
+) -> torch.Tensor:
+    return torch.ops.vllm.qwen4_exp_hc_combine(
+        residual, block_output, injection_logits, hc_count
+    )
+
+
+def hc_combine_norm(
+    residual: torch.Tensor,
+    block_output: torch.Tensor,
+    injection_logits: torch.Tensor,
+    norm_weight: torch.Tensor,
+    eps: float,
+    hc_count: int,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    return torch.ops.vllm.qwen4_exp_hc_combine_norm(
+        residual,
+        block_output,
+        injection_logits,
+        norm_weight,
+        eps,
+        hc_count,
+    )
+
+
+__all__ = [
+    "grouped_gemma_rmsnorm",
+    "hc_combine",
+    "hc_combine_norm",
+    "hc_gate_mix",
+    "hc_silu",
+]

--- a/vllm_ascend/models/qwen4_exp/amd/ops/qsa.py
+++ b/vllm_ascend/models/qwen4_exp/amd/ops/qsa.py
@@ -1,0 +1,1127 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Triton kernels for the Qwen4Exp weight-free QSA path."""
+
+from __future__ import annotations
+
+import math
+
+import torch
+from vllm import _custom_ops as ops
+from vllm.platforms import current_platform
+from vllm.triton_utils import HAS_TRITON, tl, triton
+
+_LOGITS_WORKSPACE_BYTES = 128 * 1024 * 1024
+_TOPK_WORKSPACE_BYTES = 1024 * 1024
+
+
+@triton.jit
+def _qsa_mqa_paged_kernel(
+    q_ptr,
+    k_cache_ptr,
+    page_table_ptr,
+    token_to_req_ptr,
+    query_positions_ptr,
+    sequence_lengths_ptr,
+    visible_blocks_ptr,
+    logits_ptr,
+    stride_q_row,
+    stride_q_head,
+    stride_q_dim,
+    stride_cache_block,
+    stride_cache_token,
+    stride_cache_dim,
+    stride_table_req,
+    stride_table_page,
+    stride_logits_row,
+    num_rows,
+    num_columns,
+    num_pages,
+    num_requests,
+    score_divisor,
+    PAGE_SIZE: tl.constexpr,
+    PAGE_TABLE_WIDTH: tl.constexpr,
+    NUM_HEADS: tl.constexpr,
+    HEAD_DIM: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+    BLOCK_D: tl.constexpr,
+    COMPRESS_RATIO: tl.constexpr,
+) -> None:
+    row = tl.program_id(0)
+    columns = tl.program_id(1) * BLOCK_N + tl.arange(0, BLOCK_N)
+    dims = tl.arange(0, BLOCK_D)
+    request = tl.load(token_to_req_ptr + row)
+    safe_request = tl.minimum(tl.maximum(request, 0), num_requests - 1)
+    query_position = tl.load(query_positions_ptr + row)
+    sequence_length = tl.load(
+        sequence_lengths_ptr + safe_request,
+        mask=(request >= 0) & (request < num_requests),
+        other=0,
+    )
+    visible = tl.minimum(
+        (query_position + 1) // COMPRESS_RATIO,
+        sequence_length // COMPRESS_RATIO,
+    )
+    if tl.program_id(1) == 0:
+        tl.store(visible_blocks_ptr + row, visible)
+    logical_page = columns // PAGE_SIZE
+    page_offset = columns % PAGE_SIZE
+    valid = (
+        (row < num_rows)
+        & (columns < num_columns)
+        & (columns < visible)
+        & (request >= 0)
+        & (request < num_requests)
+        & (logical_page < PAGE_TABLE_WIDTH)
+    )
+    safe_logical_page = tl.minimum(logical_page, PAGE_TABLE_WIDTH - 1)
+    physical_page = tl.load(
+        page_table_ptr
+        + safe_request * stride_table_req
+        + safe_logical_page * stride_table_page,
+        mask=valid,
+        other=-1,
+    )
+    valid &= (physical_page >= 0) & (physical_page < num_pages)
+    # physical_page * block stride can overflow int32 for large caches.
+    safe_physical_page = tl.maximum(physical_page, 0).to(tl.int64)
+    score = tl.zeros((BLOCK_N,), dtype=tl.float32)
+
+    for head in tl.static_range(0, NUM_HEADS):
+        query = tl.load(
+            q_ptr + row * stride_q_row + head * stride_q_head + dims * stride_q_dim,
+            mask=dims < HEAD_DIM,
+            other=0.0,
+        ).to(tl.float32)
+        keys = tl.load(
+            k_cache_ptr
+            + safe_physical_page[:, None] * stride_cache_block
+            + page_offset[:, None] * stride_cache_token
+            + dims[None, :] * stride_cache_dim,
+            mask=valid[:, None] & (dims[None, :] < HEAD_DIM),
+            other=0.0,
+        ).to(tl.float32)
+        dot = tl.sum(keys * query[None, :], axis=1)
+        score += tl.maximum(dot, 0.0)
+
+    score /= score_divisor
+    tl.store(
+        logits_ptr + row * stride_logits_row + columns,
+        tl.where(valid, score, -float("inf")),
+        mask=(row < num_rows) & (columns < num_columns),
+    )
+
+
+@triton.jit
+def _expand_qsa_indices_kernel(
+    block_indices_ptr,
+    query_positions_ptr,
+    sequence_lengths_ptr,
+    token_to_req_ptr,
+    output_ptr,
+    stride_blocks_row,
+    stride_blocks_column,
+    stride_output_row,
+    stride_output_column,
+    rows,
+    num_requests,
+    BLOCK_TOPK: tl.constexpr,
+    COMPRESS_RATIO: tl.constexpr,
+    TOKEN_TOPK: tl.constexpr,
+    OUTPUT_WIDTH: tl.constexpr,
+    COLUMN_BLOCK: tl.constexpr,
+) -> None:
+    row = tl.program_id(0)
+    columns = tl.program_id(1) * COLUMN_BLOCK + tl.arange(0, COLUMN_BLOCK)
+    query_position = tl.load(query_positions_ptr + row)
+    request = tl.load(token_to_req_ptr + row)
+    safe_request = tl.minimum(tl.maximum(request, 0), num_requests - 1)
+    sequence_length = tl.load(
+        sequence_lengths_ptr + safe_request,
+        mask=(request >= 0) & (request < num_requests),
+        other=0,
+    )
+    complete_blocks = tl.minimum(
+        tl.minimum(
+            (query_position + 1) // COMPRESS_RATIO,
+            sequence_length // COMPRESS_RATIO,
+        ),
+        BLOCK_TOPK,
+    )
+    expanded_count = complete_blocks * COMPRESS_RATIO
+    tail_start = ((query_position + 1) // COMPRESS_RATIO) * COMPRESS_RATIO
+    tail_count = (query_position + 1) - tail_start
+
+    is_expanded = columns < expanded_count
+    block_rank = columns // COMPRESS_RATIO
+    offset = columns % COMPRESS_RATIO
+    safe_rank = tl.minimum(block_rank, BLOCK_TOPK - 1)
+    block = tl.load(
+        block_indices_ptr + row * stride_blocks_row + safe_rank * stride_blocks_column,
+        mask=(row < rows) & is_expanded,
+        other=-1,
+    )
+    expanded = block * COMPRESS_RATIO + offset
+    tail_offset = columns - expanded_count
+    is_tail = (
+        (columns >= expanded_count)
+        & (tail_offset < tail_count)
+        & (tail_offset < COMPRESS_RATIO - 1)
+    )
+    token = tl.where(is_expanded, expanded, tail_start + tail_offset)
+    valid = (
+        (row < rows)
+        & (columns < OUTPUT_WIDTH)
+        & (is_expanded | is_tail)
+        & (token >= 0)
+        & (token < sequence_length)
+    )
+    tl.store(
+        output_ptr + row * stride_output_row + columns * stride_output_column,
+        tl.where(valid, token, -1),
+        mask=(row < rows) & (columns < OUTPUT_WIDTH),
+    )
+
+
+@triton.jit
+def _qsa_sparse_paged_gqa_splitk_kernel(
+    q_ptr,
+    k_cache_ptr,
+    v_cache_ptr,
+    indices_ptr,
+    block_table_ptr,
+    token_to_req_ptr,
+    partial_output_ptr,
+    partial_lse_ptr,
+    output_ptr,
+    stride_q_row,
+    stride_q_head,
+    stride_k_block,
+    stride_k_token,
+    stride_k_head,
+    stride_v_block,
+    stride_v_token,
+    stride_v_head,
+    stride_indices_row,
+    stride_table_req,
+    stride_output_row,
+    stride_output_head,
+    num_rows,
+    num_cache_blocks,
+    num_requests,
+    TOPK: tl.constexpr,
+    PAGE_SIZE: tl.constexpr,
+    PAGE_TABLE_WIDTH: tl.constexpr,
+    GROUP_SIZE: tl.constexpr,
+    HEAD_DIM: tl.constexpr,
+    NUM_QUERY_HEADS: tl.constexpr,
+    NUM_SPLITS: tl.constexpr,
+    NUM_TILES: tl.constexpr,
+    BLOCK_M: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+) -> None:
+    row = tl.program_id(0)
+    kv_head = tl.program_id(1)
+    split_id = tl.program_id(2)
+    request = tl.load(token_to_req_ptr + row)
+    safe_request = tl.minimum(tl.maximum(request, 0), num_requests - 1)
+
+    head_offsets = tl.arange(0, BLOCK_M)
+    dim_offsets = tl.arange(0, HEAD_DIM)
+    column_offsets = tl.arange(0, BLOCK_N)
+    first_head = kv_head * GROUP_SIZE
+    query = tl.load(
+        q_ptr
+        + row * stride_q_row
+        + (first_head + head_offsets[:, None]) * stride_q_head
+        + dim_offsets[None, :],
+        mask=head_offsets[:, None] < GROUP_SIZE,
+        other=0.0,
+    )
+
+    max_value = tl.full((BLOCK_M,), -1.0e20, dtype=tl.float32)
+    normalizer = tl.zeros((BLOCK_M,), dtype=tl.float32)
+    accumulator = tl.zeros((BLOCK_M, HEAD_DIM), dtype=tl.float32)
+    softmax_scale_log2: tl.constexpr = (HEAD_DIM**-0.5) * 1.4426950408889634
+
+    # Dynamic bounds avoid padded main-loop iterations for uneven splits.
+    split_tile_start = split_id * NUM_TILES // NUM_SPLITS
+    split_tile_end = (split_id + 1) * NUM_TILES // NUM_SPLITS
+    for tile in range(split_tile_start, split_tile_end):
+        columns = tile * BLOCK_N + column_offsets
+        logical_token = tl.load(
+            indices_ptr + row * stride_indices_row + columns,
+            mask=columns < TOPK,
+            other=-1,
+        )
+        safe_token = tl.maximum(logical_token, 0)
+        logical_page = safe_token // PAGE_SIZE
+        page_offset = safe_token % PAGE_SIZE
+        valid = (
+            (request >= 0)
+            & (request < num_requests)
+            & (logical_token >= 0)
+            & (logical_page < PAGE_TABLE_WIDTH)
+        )
+        physical_page = tl.load(
+            block_table_ptr
+            + safe_request * stride_table_req
+            + tl.minimum(logical_page, PAGE_TABLE_WIDTH - 1),
+            mask=valid,
+            other=-1,
+        )
+        valid &= (physical_page >= 0) & (physical_page < num_cache_blocks)
+        # physical_page * block stride can overflow int32 for large caches.
+        safe_page = tl.maximum(physical_page, 0).to(tl.int64)
+        keys = tl.load(
+            k_cache_ptr
+            + safe_page[None, :] * stride_k_block
+            + page_offset[None, :] * stride_k_token
+            + kv_head * stride_k_head
+            + dim_offsets[:, None],
+            mask=valid[None, :],
+            other=0.0,
+        )
+        values = tl.load(
+            v_cache_ptr
+            + safe_page[:, None] * stride_v_block
+            + page_offset[:, None] * stride_v_token
+            + kv_head * stride_v_head
+            + dim_offsets[None, :],
+            mask=valid[:, None],
+            other=0.0,
+        )
+        scores = tl.dot(query, keys)
+        # Scaling scores avoids re-quantizing a scaled query to BF16.
+        scores *= softmax_scale_log2
+        scores = tl.where(valid[None, :], scores, -1.0e20)
+        next_max = tl.maximum(max_value, tl.max(scores, axis=1))
+        alpha = tl.math.exp2(max_value - next_max)
+        probabilities = tl.where(
+            valid[None, :], tl.math.exp2(scores - next_max[:, None]), 0.0
+        )
+        accumulator = tl.dot(
+            probabilities.to(values.dtype),
+            values,
+            acc=accumulator * alpha[:, None],
+        )
+        normalizer = normalizer * alpha + tl.sum(probabilities, axis=1)
+        max_value = next_max
+
+    has_values = normalizer > 0
+    normalized_output = tl.where(
+        has_values[:, None],
+        accumulator / tl.maximum(normalizer[:, None], 1.0e-20),
+        0.0,
+    )
+    output_mask = head_offsets[:, None] < GROUP_SIZE
+    if NUM_SPLITS == 1:
+        tl.store(
+            output_ptr
+            + row * stride_output_row
+            + (first_head + head_offsets[:, None]) * stride_output_head
+            + dim_offsets[None, :],
+            normalized_output,
+            mask=output_mask,
+        )
+    else:
+        partial_lse = tl.where(
+            has_values,
+            max_value + tl.math.log2(tl.maximum(normalizer, 1.0e-20)),
+            -float("inf"),
+        )
+        tl.store(
+            partial_output_ptr
+            + (
+                (split_id * num_rows + row) * NUM_QUERY_HEADS
+                + first_head
+                + head_offsets[:, None]
+            )
+            * HEAD_DIM
+            + dim_offsets[None, :],
+            normalized_output,
+            mask=output_mask,
+        )
+        tl.store(
+            partial_lse_ptr
+            + (split_id * num_rows + row) * NUM_QUERY_HEADS
+            + first_head
+            + head_offsets,
+            partial_lse,
+            mask=head_offsets < GROUP_SIZE,
+        )
+
+
+@triton.jit
+def _qsa_merge_splitk_kernel(
+    partial_output_ptr,
+    partial_lse_ptr,
+    output_ptr,
+    stride_output_row,
+    stride_output_head,
+    num_rows,
+    HEAD_DIM: tl.constexpr,
+    NUM_QUERY_HEADS: tl.constexpr,
+    NUM_SPLITS: tl.constexpr,
+    BLOCK_SPLITS: tl.constexpr,
+) -> None:
+    row = tl.program_id(0)
+    head = tl.program_id(1)
+    split_offsets = tl.arange(0, BLOCK_SPLITS)
+    dim_offsets = tl.arange(0, HEAD_DIM)
+    split_mask = split_offsets < NUM_SPLITS
+    lse = tl.load(
+        partial_lse_ptr + (split_offsets * num_rows + row) * NUM_QUERY_HEADS + head,
+        mask=split_mask,
+        other=-float("inf"),
+    )
+    lse_max = tl.max(lse, axis=0)
+    has_values = lse_max > -float("inf")
+    shifted = tl.where(split_mask & has_values, lse - lse_max, -float("inf"))
+    weights = tl.math.exp2(shifted)
+    denominator = tl.sum(weights, axis=0)
+    partial_output = tl.load(
+        partial_output_ptr
+        + ((split_offsets[:, None] * num_rows + row) * NUM_QUERY_HEADS + head)
+        * HEAD_DIM
+        + dim_offsets[None, :],
+        mask=split_mask[:, None],
+        other=0.0,
+    )
+    merged = tl.sum(partial_output * weights[:, None], axis=0)
+    merged = tl.where(denominator > 0, merged / denominator, 0.0)
+    tl.store(
+        output_ptr + row * stride_output_row + head * stride_output_head + dim_offsets,
+        merged,
+    )
+
+
+@triton.jit
+def _store_qsa_rows_kernel(
+    cache_ptr,
+    slots_ptr,
+    rows_ptr,
+    stride_cache_block,
+    stride_cache_token,
+    stride_cache_dim,
+    stride_rows_row,
+    stride_rows_dim,
+    num_rows,
+    num_blocks,
+    PAGE_SIZE: tl.constexpr,
+    WIDTH: tl.constexpr,
+    BLOCK_D: tl.constexpr,
+) -> None:
+    row = tl.program_id(0)
+    dims = tl.arange(0, BLOCK_D)
+    slot = tl.load(slots_ptr + row)
+    valid = (row < num_rows) & (slot >= 0) & (slot < num_blocks * PAGE_SIZE)
+    block = tl.maximum(slot, 0) // PAGE_SIZE
+    token = tl.maximum(slot, 0) % PAGE_SIZE
+    values = tl.load(
+        rows_ptr + row * stride_rows_row + dims * stride_rows_dim,
+        mask=valid & (dims < WIDTH),
+        other=0,
+    )
+    tl.store(
+        cache_ptr
+        + block * stride_cache_block
+        + token * stride_cache_token
+        + dims * stride_cache_dim,
+        values,
+        mask=valid & (dims < WIDTH),
+    )
+
+
+@triton.jit
+def _compress_qsa_groups_kernel(
+    raw_keys_ptr,  # this step's raw key rows, straight from activations
+    raw_positions_ptr,  # this step's per-token positions
+    compressor_state_cache_ptr,  # per-request ring of previous raw keys
+    rope_cache_ptr,  # packed RoPE position tail of the ring
+    compressor_state_table_ptr,
+    token_to_req_ptr,
+    query_start_loc_ptr,
+    logical_positions_ptr,
+    compressed_slots_ptr,
+    pooled_ptr,
+    first_positions_ptr,
+    stride_raw_row,
+    stride_raw_dim,
+    stride_raw_positions_row,
+    stride_raw_positions_dim,
+    stride_compressor_state_block,
+    stride_compressor_state_token,
+    stride_compressor_state_dim,
+    stride_rope_block,
+    stride_rope_token,
+    stride_rope_dim,
+    stride_compressor_state_table_req,
+    stride_pooled_row,
+    stride_pooled_dim,
+    stride_positions_row,
+    stride_positions_dim,
+    num_rows,
+    num_compressor_state_blocks,
+    num_requests,
+    COMPRESSOR_STATE_SIZE: tl.constexpr,
+    COMPRESS_RATIO: tl.constexpr,
+    HEAD_DIM: tl.constexpr,
+    BLOCK_D: tl.constexpr,
+    LOAD_ROPE_POSITIONS: tl.constexpr,
+) -> None:
+    row = tl.program_id(0)
+    dims = tl.arange(0, BLOCK_D)
+    request = tl.load(token_to_req_ptr + row)
+    end_position = tl.load(logical_positions_ptr + row)
+    compressed_slot = tl.load(compressed_slots_ptr + row)
+    valid_request = (request >= 0) & (request < num_requests)
+    safe_request = tl.minimum(tl.maximum(request, 0), num_requests - 1)
+    query_row_start = tl.load(
+        query_start_loc_ptr + safe_request, mask=valid_request, other=0
+    )
+    query_row_end = tl.load(
+        query_start_loc_ptr + safe_request + 1, mask=valid_request, other=0
+    )
+    chunk_start_position = end_position - (row - query_row_start)
+    compressor_state_block = tl.load(
+        compressor_state_table_ptr + safe_request * stride_compressor_state_table_req,
+        mask=valid_request,
+        other=-1,
+    )
+    valid_compressor_state_block = (compressor_state_block >= 0) & (
+        compressor_state_block < num_compressor_state_blocks
+    )
+    valid_row = (
+        (row < num_rows)
+        & valid_request
+        & (row >= query_row_start)
+        & (row < query_row_end)
+        & (end_position >= COMPRESS_RATIO - 1)
+        & (compressed_slot >= 0)
+    )
+    accumulator = tl.zeros((BLOCK_D,), dtype=tl.float32)
+
+    # A group can span the compressor-state ring (older members) and this
+    # step's raw rows (members at positions >= chunk_start_position).
+    for group_offset in tl.range(0, COMPRESS_RATIO):
+        position = end_position - (COMPRESS_RATIO - 1 - group_offset)
+        use_raw = position >= chunk_start_position
+        raw_row = query_row_start + position - chunk_start_position
+        raw_values = tl.load(
+            raw_keys_ptr + raw_row * stride_raw_row + dims * stride_raw_dim,
+            mask=valid_row
+            & use_raw
+            & (raw_row >= query_row_start)
+            & (raw_row < query_row_end)
+            & (raw_row < num_rows)
+            & (dims < HEAD_DIM),
+            other=0.0,
+        ).to(tl.float32)
+        compressor_state_values = tl.load(
+            compressor_state_cache_ptr
+            + tl.maximum(compressor_state_block, 0).to(tl.int64)
+            * stride_compressor_state_block
+            + (position % COMPRESSOR_STATE_SIZE) * stride_compressor_state_token
+            + dims * stride_compressor_state_dim,
+            mask=valid_row
+            & ~use_raw
+            & valid_compressor_state_block
+            & (dims < HEAD_DIM),
+            other=0.0,
+        ).to(tl.float32)
+        accumulator += tl.where(use_raw, raw_values, compressor_state_values)
+
+    tl.store(
+        pooled_ptr + row * stride_pooled_row + dims * stride_pooled_dim,
+        accumulator / COMPRESS_RATIO,
+        mask=(row < num_rows) & (dims < HEAD_DIM),
+    )
+
+    position_dims = tl.arange(0, 4)
+    first_position = end_position - COMPRESS_RATIO + 1
+    if LOAD_ROPE_POSITIONS:
+        first_from_raw = first_position >= chunk_start_position
+        raw_first_row = query_row_start + first_position - chunk_start_position
+        raw_position_values = tl.load(
+            raw_positions_ptr
+            + raw_first_row * stride_raw_positions_row
+            + position_dims * stride_raw_positions_dim,
+            mask=valid_row
+            & first_from_raw
+            & (raw_first_row >= query_row_start)
+            & (raw_first_row < query_row_end)
+            & (raw_first_row < num_rows)
+            & (position_dims < 3),
+            other=0,
+        )
+        compressor_state_position_values = tl.load(
+            rope_cache_ptr
+            + tl.maximum(compressor_state_block, 0).to(tl.int64) * stride_rope_block
+            + (first_position % COMPRESSOR_STATE_SIZE) * stride_rope_token
+            + position_dims * stride_rope_dim,
+            mask=valid_row
+            & ~first_from_raw
+            & valid_compressor_state_block
+            & (position_dims < 3),
+            other=0,
+        )
+        position_values = tl.where(
+            first_from_raw,
+            raw_position_values,
+            compressor_state_position_values,
+        )
+    else:
+        position_values = tl.where(valid_row, first_position, 0)
+    tl.store(
+        first_positions_ptr
+        + row * stride_positions_row
+        + position_dims * stride_positions_dim,
+        position_values,
+        mask=(row < num_rows) & (position_dims < 3),
+    )
+
+
+def _validate_mqa(q: torch.Tensor) -> None:
+    if q.ndim != 3 or q.shape[1] <= 0 or q.shape[2] <= 0:
+        raise ValueError("QSA query must be [rows, heads, head_dim]")
+
+
+def qsa_mqa_paged(
+    q: torch.Tensor,
+    k_cache: torch.Tensor,
+    page_table: torch.Tensor,
+    token_to_req: torch.Tensor,
+    query_positions: torch.Tensor,
+    sequence_lengths: torch.Tensor,
+    compress_ratio: int,
+    num_columns: int | None = None,
+    score_scale: float | None = None,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Compute QSA scores directly from a paged compressed-key cache."""
+
+    _validate_mqa(q)
+    if not q.is_cuda or not HAS_TRITON:
+        raise RuntimeError("paged QSA scoring requires a GPU and Triton")
+    if k_cache.ndim != 4 or k_cache.shape[2] != 1:
+        raise ValueError("QSA cache must be [pages, page_size, 1, head_dim]")
+    if k_cache.shape[3] != q.shape[2]:
+        raise ValueError("QSA query and cache dimensions must match")
+    if page_table.ndim != 2:
+        raise ValueError("QSA page table must be two-dimensional")
+    if q.shape[0] and (not all(k_cache.shape[:2]) or not all(page_table.shape)):
+        raise ValueError("QSA paged scoring cache and page table must be nonempty")
+    if token_to_req.shape != (q.shape[0],):
+        raise ValueError("QSA request mapping must match query rows")
+    if query_positions.shape != (q.shape[0],):
+        raise ValueError("QSA query positions must match query rows")
+    if sequence_lengths.shape != (page_table.shape[0],):
+        raise ValueError("QSA sequence lengths must match page-table requests")
+    if compress_ratio <= 0:
+        raise ValueError("QSA compression ratio must be positive")
+    score_divisor = math.sqrt(q.shape[2]) if score_scale is None else score_scale
+    if score_divisor <= 0:
+        raise ValueError("QSA score scale must be positive")
+
+    capacity = page_table.shape[1] * k_cache.shape[1]
+    columns = capacity if num_columns is None else num_columns
+    if columns < 0:
+        raise ValueError("QSA score width must be non-negative")
+    logits = torch.empty((q.shape[0], columns), dtype=torch.float32, device=q.device)
+    visible_blocks = torch.empty(q.shape[0], dtype=torch.int32, device=q.device)
+    if not q.shape[0] or not columns:
+        return logits, visible_blocks
+    block_n = 32
+    _qsa_mqa_paged_kernel[(q.shape[0], triton.cdiv(columns, block_n))](
+        q,
+        k_cache,
+        page_table,
+        token_to_req,
+        query_positions,
+        sequence_lengths,
+        visible_blocks,
+        logits,
+        q.stride(0),
+        q.stride(1),
+        q.stride(2),
+        k_cache.stride(0),
+        k_cache.stride(1),
+        k_cache.stride(3),
+        page_table.stride(0),
+        page_table.stride(1),
+        logits.stride(0),
+        q.shape[0],
+        columns,
+        k_cache.shape[0],
+        page_table.shape[0],
+        float(score_divisor),
+        PAGE_SIZE=k_cache.shape[1],
+        PAGE_TABLE_WIDTH=page_table.shape[1],
+        NUM_HEADS=q.shape[1],
+        HEAD_DIM=q.shape[2],
+        BLOCK_N=block_n,
+        BLOCK_D=triton.next_power_of_2(q.shape[2]),
+        COMPRESS_RATIO=compress_ratio,
+        num_warps=4,
+    )
+    return logits, visible_blocks
+
+
+def expand_qsa_block_indices_cuda(
+    block_indices: torch.Tensor,
+    query_positions: torch.Tensor,
+    sequence_lengths: torch.Tensor,
+    token_to_req: torch.Tensor,
+    compress_ratio: int,
+    token_topk: int,
+    out: torch.Tensor | None = None,
+) -> torch.Tensor:
+    """Expand compressed blocks and compact the causal tail of the open group."""
+
+    if not block_indices.is_cuda or not HAS_TRITON:
+        raise RuntimeError("QSA index expansion requires a GPU and Triton")
+    if token_topk % compress_ratio:
+        raise ValueError("QSA token top-k must be divisible by compression ratio")
+    block_topk = token_topk // compress_ratio
+    output_width = token_topk + compress_ratio - 1
+    if block_indices.shape != (query_positions.numel(), block_topk):
+        raise ValueError("QSA compressed top-k has an invalid shape")
+    if token_to_req.shape != query_positions.shape:
+        raise ValueError("QSA request mapping must match query positions")
+    if sequence_lengths.ndim != 1 or not sequence_lengths.shape[0]:
+        raise ValueError("QSA request sequence lengths must be nonempty")
+    if out is None:
+        out = torch.empty(
+            (block_indices.shape[0], output_width),
+            dtype=torch.int32,
+            device=block_indices.device,
+        )
+    elif out.shape != (block_indices.shape[0], output_width):
+        raise ValueError("QSA expansion output has an invalid shape")
+    if not block_indices.shape[0]:
+        return out
+    column_block = 256
+    _expand_qsa_indices_kernel[
+        (block_indices.shape[0], triton.cdiv(output_width, column_block))
+    ](
+        block_indices,
+        query_positions,
+        sequence_lengths,
+        token_to_req,
+        out,
+        block_indices.stride(0),
+        block_indices.stride(1),
+        out.stride(0),
+        out.stride(1),
+        block_indices.shape[0],
+        sequence_lengths.shape[0],
+        BLOCK_TOPK=block_topk,
+        COMPRESS_RATIO=compress_ratio,
+        TOKEN_TOPK=token_topk,
+        OUTPUT_WIDTH=output_width,
+        COLUMN_BLOCK=column_block,
+        num_warps=4,
+    )
+    return out
+
+
+def qsa_select_paged_tokens(
+    q: torch.Tensor,
+    k_cache: torch.Tensor,
+    page_table: torch.Tensor,
+    token_to_req: torch.Tensor,
+    query_positions: torch.Tensor,
+    sequence_lengths: torch.Tensor,
+    token_topk: int,
+    compress_ratio: int,
+    out: torch.Tensor | None = None,
+) -> torch.Tensor:
+    """Score, select, and expand QSA indices without host synchronization."""
+
+    rows = q.shape[0]
+    output_width = token_topk + compress_ratio - 1
+    if out is None:
+        out = torch.empty((rows, output_width), dtype=torch.int32, device=q.device)
+    if out.shape != (rows, output_width):
+        raise ValueError("QSA selection output has an invalid shape")
+    if not rows:
+        return out
+
+    columns = page_table.shape[1] * k_cache.shape[1]
+    block_topk = token_topk // compress_ratio
+    rows_per_chunk = max(1, _LOGITS_WORKSPACE_BYTES // max(columns * 4, 1))
+    chunk_rows = min(rows, rows_per_chunk)
+    blocks_buffer = torch.empty(
+        (chunk_rows, block_topk), dtype=torch.int32, device=q.device
+    )
+    topk_workspace = torch.empty(
+        (_TOPK_WORKSPACE_BYTES,), dtype=torch.uint8, device=q.device
+    )
+    for row_start in range(0, rows, rows_per_chunk):
+        row_end = min(row_start + rows_per_chunk, rows)
+        row_slice = slice(row_start, row_end)
+        logits, visible_blocks = qsa_mqa_paged(
+            q[row_slice],
+            k_cache,
+            page_table,
+            token_to_req[row_slice],
+            query_positions[row_slice],
+            sequence_lengths,
+            compress_ratio,
+        )
+        blocks = blocks_buffer[: row_end - row_start]
+        use_cooperative_topk = (
+            current_platform.is_cuda()
+            and blocks.shape[0] <= 32
+            and logits.stride(0) % 4 == 0
+            and current_platform.has_device_capability(90)
+            and not current_platform.is_device_capability_family(120)
+        )
+        if use_cooperative_topk:
+            torch.ops._C.cooperative_topk(
+                logits,
+                visible_blocks,
+                blocks,
+                topk_workspace,
+                block_topk,
+                columns,
+            )
+        elif current_platform.is_cuda():
+            torch.ops._C.persistent_topk(
+                logits,
+                visible_blocks,
+                blocks,
+                topk_workspace,
+                block_topk,
+                columns,
+            )
+        else:
+            ops.top_k_per_row_decode(
+                logits,
+                1,
+                visible_blocks,
+                blocks,
+                blocks.shape[0],
+                logits.stride(0),
+                logits.stride(1),
+                block_topk,
+            )
+        expand_qsa_block_indices_cuda(
+            blocks,
+            query_positions[row_slice],
+            sequence_lengths,
+            token_to_req[row_slice],
+            compress_ratio,
+            token_topk,
+            out[row_slice],
+        )
+    return out
+
+
+def qsa_sparse_paged_attention(
+    q: torch.Tensor,
+    k_cache: torch.Tensor,
+    v_cache: torch.Tensor,
+    logical_indices: torch.Tensor,
+    block_table: torch.Tensor,
+    token_to_req: torch.Tensor,
+    out: torch.Tensor | None = None,
+) -> torch.Tensor:
+    """Run sparse GQA directly over paged BF16 K/V caches."""
+
+    if not q.is_cuda or not HAS_TRITON:
+        raise RuntimeError("paged QSA sparse attention requires a GPU and Triton")
+    if q.ndim != 3 or k_cache.ndim != 4 or v_cache.shape != k_cache.shape:
+        raise ValueError("QSA sparse attention received invalid Q/K/V shapes")
+    if logical_indices.ndim != 2 or logical_indices.shape[0] != q.shape[0]:
+        raise ValueError("QSA indices must have one row per query")
+    if token_to_req.shape != (q.shape[0],) or block_table.ndim != 2:
+        raise ValueError("QSA sparse attention metadata has invalid shapes")
+    if not all(k_cache.shape[:3]) or not all(block_table.shape):
+        raise ValueError("QSA sparse attention cache and block table must be nonempty")
+    if logical_indices.shape[1] <= 0:
+        raise ValueError("QSA sparse attention requires a positive selection width")
+    if q.shape[2] != k_cache.shape[3] or q.shape[1] % k_cache.shape[2]:
+        raise ValueError("QSA sparse attention requires valid grouped-query heads")
+    head_dim = q.shape[2]
+    assert head_dim >= 16 and (head_dim & (head_dim - 1)) == 0
+    assert q.dtype == k_cache.dtype == v_cache.dtype == torch.bfloat16
+    assert logical_indices.dtype == block_table.dtype == torch.int32
+    assert token_to_req.dtype == torch.int32
+    assert q.device == k_cache.device == v_cache.device
+    assert q.device == logical_indices.device == block_table.device
+    assert q.device == token_to_req.device
+    assert q.stride(2) == k_cache.stride(3) == v_cache.stride(3) == 1
+    assert logical_indices.stride(1) == block_table.stride(1) == 1
+    assert token_to_req.stride(0) == 1
+    if out is None:
+        out = torch.empty_like(q)
+    if out.shape != q.shape:
+        raise ValueError("QSA sparse output must match its query")
+    assert out.dtype == q.dtype and out.device == q.device
+    assert out.stride(2) == 1
+    if not q.shape[0]:
+        return out
+
+    group_size = q.shape[1] // k_cache.shape[2]
+    block_m = triton.next_power_of_2(group_size)
+    base_programs = q.shape[0] * k_cache.shape[2]
+    small_profile_limit = 8 if block_m <= 8 else 4
+
+    # Tuned on GB300 for the Qwen-Air TP1, TP2, and TP4 attention shapes.
+    # Narrow tiles favor decode; wide tiles improve throughput for prefill.
+    if base_programs <= small_profile_limit:
+        block_n, target_splits, partial_warps = 16, 64, 4
+    elif base_programs < 32:
+        block_n, target_splits, partial_warps = 16, 32, 4
+    elif base_programs <= 256:
+        block_n, target_splits, partial_warps = 64, 8, 2
+    elif base_programs <= 512:
+        block_n, target_splits, partial_warps = 64, 4, 2
+    else:
+        block_n, target_splits, partial_warps = 64, 1, 2
+    # gfx942 and gfx950 have a 64 KiB LDS limit. One software-pipelining
+    # stage keeps the wide TP4 tile within that shared-memory budget.
+    partial_stages = 1 if current_platform.is_rocm() else 2
+
+    num_tiles = triton.cdiv(logical_indices.shape[1], block_n)
+    # Avoid empty splits when the selection width is smaller than the profile.
+    max_useful_splits = 1 << (num_tiles.bit_length() - 1)
+    num_splits = min(max_useful_splits, target_splits)
+
+    # Split=1 writes output directly and compiles out all workspace accesses.
+    if num_splits == 1:
+        partial_output = out
+        partial_lse = out
+    else:
+        # FP32 partials preserve accuracy when merging independently normalized
+        # splits.
+        partial_output = torch.empty(
+            (num_splits, *q.shape), dtype=torch.float32, device=q.device
+        )
+        partial_lse = torch.empty(
+            (num_splits, q.shape[0], q.shape[1]),
+            dtype=torch.float32,
+            device=q.device,
+        )
+
+    partial_grid = (q.shape[0], k_cache.shape[2], num_splits)
+    _qsa_sparse_paged_gqa_splitk_kernel[partial_grid](
+        q,
+        k_cache,
+        v_cache,
+        logical_indices,
+        block_table,
+        token_to_req,
+        partial_output,
+        partial_lse,
+        out,
+        q.stride(0),
+        q.stride(1),
+        k_cache.stride(0),
+        k_cache.stride(1),
+        k_cache.stride(2),
+        v_cache.stride(0),
+        v_cache.stride(1),
+        v_cache.stride(2),
+        logical_indices.stride(0),
+        block_table.stride(0),
+        out.stride(0),
+        out.stride(1),
+        q.shape[0],
+        k_cache.shape[0],
+        block_table.shape[0],
+        TOPK=logical_indices.shape[1],
+        PAGE_SIZE=k_cache.shape[1],
+        PAGE_TABLE_WIDTH=block_table.shape[1],
+        GROUP_SIZE=group_size,
+        HEAD_DIM=q.shape[2],
+        NUM_QUERY_HEADS=q.shape[1],
+        NUM_SPLITS=num_splits,
+        NUM_TILES=num_tiles,
+        BLOCK_M=block_m,
+        BLOCK_N=block_n,
+        num_warps=partial_warps,
+        num_stages=partial_stages,
+    )
+    if num_splits == 1:
+        return out
+
+    _qsa_merge_splitk_kernel[(q.shape[0], q.shape[1])](
+        partial_output,
+        partial_lse,
+        out,
+        out.stride(0),
+        out.stride(1),
+        q.shape[0],
+        HEAD_DIM=q.shape[2],
+        NUM_QUERY_HEADS=q.shape[1],
+        NUM_SPLITS=num_splits,
+        BLOCK_SPLITS=triton.next_power_of_2(num_splits),
+        num_warps=2,
+        num_stages=1,
+    )
+    return out
+
+
+def qsa_store_cache_rows(
+    cache: torch.Tensor,
+    slot_mapping: torch.Tensor,
+    rows: torch.Tensor,
+) -> None:
+    """Store fixed-width rows in a QSA cache without boolean indexing."""
+
+    if not cache.is_cuda or not HAS_TRITON:
+        raise RuntimeError("QSA cache stores require a GPU and Triton")
+    if cache.ndim != 4 or cache.shape[2] != 1:
+        raise ValueError("QSA cache must be [pages, page_size, 1, width]")
+    if not all(cache.shape):
+        raise ValueError("QSA cache dimensions must be nonzero")
+    if rows.ndim == 3:
+        if rows.shape[1] != 1:
+            raise ValueError("QSA cache rows must have one head")
+        rows = rows[:, 0]
+    if rows.shape != (slot_mapping.numel(), cache.shape[3]):
+        raise ValueError("QSA cache rows and slots have incompatible shapes")
+    if not rows.shape[0]:
+        return
+    _store_qsa_rows_kernel[(rows.shape[0],)](
+        cache,
+        slot_mapping,
+        rows,
+        cache.stride(0),
+        cache.stride(1),
+        cache.stride(3),
+        rows.stride(0),
+        rows.stride(1),
+        rows.shape[0],
+        cache.shape[0],
+        PAGE_SIZE=cache.shape[1],
+        WIDTH=cache.shape[3],
+        BLOCK_D=triton.next_power_of_2(cache.shape[3]),
+        num_warps=4,
+    )
+
+
+def qsa_compress_groups_with_ratio(
+    raw_keys: torch.Tensor,  # this step's raw key rows [rows, 1, head_size]
+    raw_positions: torch.Tensor,  # this step's positions [rows, 1, 3] int64
+    compressor_state_cache: torch.Tensor,
+    compressor_state_block_table: torch.Tensor,
+    token_to_req: torch.Tensor,
+    query_start_loc: torch.Tensor,
+    logical_positions: torch.Tensor,
+    compressed_slots: torch.Tensor,
+    compress_ratio: int,
+    rope_cache: torch.Tensor | None = None,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Pool completed groups from the compressor-state ring and raw token rows."""
+
+    if not raw_keys.is_cuda or not HAS_TRITON:
+        raise RuntimeError("QSA compression requires a GPU and Triton")
+    rows = token_to_req.numel()
+    if compress_ratio <= 0:
+        raise ValueError("QSA compression ratio must be positive")
+    if raw_keys.ndim != 3 or raw_keys.shape[:2] != (rows, 1):
+        raise ValueError("QSA raw keys must be [rows, 1, head_size]")
+    if raw_positions.shape != (rows, 1, 3) or raw_positions.dtype != torch.int64:
+        raise ValueError("QSA raw positions must be [rows, 1, 3] int64")
+    if logical_positions.shape != (rows,) or compressed_slots.shape != (rows,):
+        raise ValueError("QSA compression metadata must match token rows")
+    if compressor_state_cache.ndim != 4 or compressor_state_cache.shape[2] != 1:
+        raise ValueError("QSA compressor-state cache has an invalid shape")
+    if (
+        # The ring is wider than one group so speculative rows cannot alias
+        # onto the committed keys of the group still being collected.
+        compressor_state_cache.shape[1] < compress_ratio
+        or compressor_state_cache.shape[3] != raw_keys.shape[2]
+        or compressor_state_cache.dtype != raw_keys.dtype
+    ):
+        raise ValueError(
+            "QSA compressor-state cache does not match the compression layout"
+        )
+    if (
+        compressor_state_block_table.ndim != 2
+        or compressor_state_block_table.shape[1] < 1
+    ):
+        raise ValueError(
+            "QSA compressor-state block table must contain one block per request"
+        )
+    if query_start_loc.ndim != 1 or query_start_loc.shape[0] < 2:
+        raise ValueError("QSA query starts must contain a terminal offset")
+    num_requests = query_start_loc.shape[0] - 1
+    if compressor_state_block_table.shape[0] < num_requests:
+        raise ValueError("QSA compressor-state block table has too few request rows")
+    if rope_cache is not None and (
+        rope_cache.ndim != 4
+        or rope_cache.shape[:3] != compressor_state_cache.shape[:3]
+        or rope_cache.shape[3] != 3
+        or rope_cache.dtype != torch.int64
+    ):
+        raise ValueError("QSA packed position view has an invalid shape or dtype")
+    if rows and (
+        not all(compressor_state_cache.shape)
+        or not all(compressor_state_block_table.shape)
+    ):
+        raise ValueError("QSA compressor-state cache and block table must be nonempty")
+    pooled = torch.empty(
+        (rows, 1, raw_keys.shape[2]),
+        dtype=raw_keys.dtype,
+        device=raw_keys.device,
+    )
+    first_positions = torch.empty((rows, 3), dtype=torch.int64, device=raw_keys.device)
+    if not rows:
+        return pooled, first_positions
+    if rope_cache is None:
+        rope_cache = compressor_state_cache
+        load_rope_positions = False
+    else:
+        load_rope_positions = True
+    _compress_qsa_groups_kernel[(rows,)](
+        raw_keys,
+        raw_positions,
+        compressor_state_cache,
+        rope_cache,
+        compressor_state_block_table,
+        token_to_req,
+        query_start_loc,
+        logical_positions,
+        compressed_slots,
+        pooled,
+        first_positions,
+        raw_keys.stride(0),
+        raw_keys.stride(2),
+        raw_positions.stride(0),
+        raw_positions.stride(2),
+        compressor_state_cache.stride(0),
+        compressor_state_cache.stride(1),
+        compressor_state_cache.stride(3),
+        rope_cache.stride(0),
+        rope_cache.stride(1),
+        rope_cache.stride(3),
+        compressor_state_block_table.stride(0),
+        pooled.stride(0),
+        pooled.stride(2),
+        first_positions.stride(0),
+        first_positions.stride(1),
+        rows,
+        compressor_state_cache.shape[0],
+        num_requests,
+        COMPRESSOR_STATE_SIZE=compressor_state_cache.shape[1],
+        COMPRESS_RATIO=compress_ratio,
+        HEAD_DIM=raw_keys.shape[2],
+        LOAD_ROPE_POSITIONS=load_rope_positions,
+        BLOCK_D=triton.next_power_of_2(raw_keys.shape[2]),
+        num_warps=4,
+    )
+    return pooled, first_positions
+
+
+__all__ = [
+    "expand_qsa_block_indices_cuda",
+    "qsa_compress_groups_with_ratio",
+    "qsa_mqa_paged",
+    "qsa_select_paged_tokens",
+    "qsa_sparse_paged_attention",
+    "qsa_store_cache_rows",
+]

--- a/vllm_ascend/models/qwen4_exp/amd/ple_layer.py
+++ b/vllm_ascend/models/qwen4_exp/amd/ple_layer.py
@@ -492,7 +492,7 @@ class Qwen4ExpPLELayer(nn.Module, MambaBase):
         return MambaStateShapeCalculator.short_conv_state_shape(
             tp_world_size=1,
             intermediate_size=self.hc_hidden_size,
-            conv_kernel=self.conv_state_len + 1,
+            conv_kernel=self.conv_state_len + self.num_spec_tokens + 1,
         )
 
     def _apply_norm(

--- a/vllm_ascend/models/qwen4_exp/amd/ple_layer.py
+++ b/vllm_ascend/models/qwen4_exp/amd/ple_layer.py
@@ -1,0 +1,1103 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""GPU-resident Qwen4Exp position-learning enhancement layers."""
+
+import math
+from collections.abc import Iterable, Sequence
+
+import torch
+import torch.nn.functional as F
+from torch import nn
+from vllm.config import CacheConfig, ModelConfig, VllmConfig, get_current_vllm_config
+from vllm.forward_context import get_forward_context
+from vllm.model_executor.layers.linear import ReplicatedLinear
+from vllm.model_executor.layers.mamba.abstract import MambaBase
+from vllm.model_executor.layers.mamba.mamba_utils import (
+    MambaStateDtypeCalculator,
+    MambaStateShapeCalculator,
+    is_conv_state_dim_first,
+)
+from vllm.model_executor.models.utils import AutoWeightsLoader
+from vllm.utils.torch_utils import direct_register_custom_op
+from vllm.v1.attention.backends.registry import MambaAttentionBackendEnum
+from vllm.v1.attention.backends.utils import NULL_BLOCK_ID
+
+from vllm_ascend.models.qwen4_exp.config import (
+    Qwen4ExpTextConfig,
+)
+from vllm_ascend.models.qwen4_exp.short_conv_attn import (
+    PleShortConvAttentionBackend,
+    PleShortConvAttentionMetadata,
+)
+from vllm_ascend.models.qwen4_exp.vocab_parallel_embedding import (
+    VocabParallelEmbedding,
+)
+
+from ..common.ple import copy_ple_embedding_shard_
+
+_MASK64 = (1 << 64) - 1
+_SPLITMIX_GAMMA = 0x9E3779B97F4A7C15
+_SPLITMIX_M1 = 0xBF58476D1CE4E5B9
+_SPLITMIX_M2 = 0x94D049BB133111EB
+_PLE_LAYER_PRIME = 10007
+
+
+def _splitmix64(value: int) -> int:
+    value = (value + _SPLITMIX_GAMMA) & _MASK64
+    value = ((value ^ (value >> 30)) * _SPLITMIX_M1) & _MASK64
+    value = ((value ^ (value >> 27)) * _SPLITMIX_M2) & _MASK64
+    return (value ^ (value >> 31)) & _MASK64
+
+
+def _is_prime_64(value: int) -> bool:
+    if value < 2:
+        return False
+    for prime in (2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37):
+        if value % prime == 0:
+            return value == prime
+    exponent = value - 1
+    shifts = 0
+    while exponent % 2 == 0:
+        exponent //= 2
+        shifts += 1
+    for base in (2, 325, 9375, 28178, 450775, 9780504, 1795265022):
+        if base % value == 0:
+            continue
+        witness = pow(base, exponent, value)
+        if witness in (1, value - 1):
+            continue
+        for _ in range(shifts - 1):
+            witness = pow(witness, 2, value)
+            if witness == value - 1:
+                break
+        else:
+            return False
+    return True
+
+
+def _nth_prime_after(start: int, count: int) -> int:
+    prime = int(start)
+    for _ in range(count):
+        candidate = prime + 1
+        if candidate <= 2:
+            prime = 2
+            continue
+        if candidate % 2 == 0:
+            candidate += 1
+        while not _is_prime_64(candidate):
+            candidate += 2
+        prime = candidate
+    return prime
+
+
+class Qwen4ExpPLEGroupedNorm(nn.Module):
+    def __init__(
+        self,
+        hidden_size: int,
+        eps: float,
+        group_size: int | None,
+        dtype: torch.dtype | None,
+    ) -> None:
+        super().__init__()
+        if group_size is not None and hidden_size % group_size:
+            raise ValueError(
+                f"hidden_size ({hidden_size}) must be divisible by "
+                f"group_size ({group_size})"
+            )
+        self.eps = eps
+        self.group_size = group_size
+        self.weight = nn.Parameter(torch.zeros(hidden_size, dtype=dtype))
+
+    def forward(self, hidden_states: torch.Tensor) -> torch.Tensor:
+        input_dtype = hidden_states.dtype
+        hidden_states = hidden_states.float()
+        if self.group_size is None:
+            variance = hidden_states.square().mean(dim=-1, keepdim=True)
+            normalized = hidden_states * torch.rsqrt(variance + self.eps)
+        else:
+            grouped = hidden_states.unflatten(
+                -1, (hidden_states.shape[-1] // self.group_size, self.group_size)
+            )
+            variance = grouped.square().mean(dim=-1, keepdim=True)
+            normalized = (grouped * torch.rsqrt(variance + self.eps)).flatten(-2)
+        return (normalized * (1.0 + self.weight.float())).to(input_dtype)
+
+
+class Qwen4ExpNGramEmbedding(nn.Module):
+    def __init__(
+        self,
+        config: Qwen4ExpTextConfig,
+        embedding_dim: int,
+        ple_dense_layer_id: int,
+        max_total_tokens: int,
+        max_num_reqs: int,
+        prefix: str,
+        layer_name: str,
+    ) -> None:
+        super().__init__()
+        self.embedding_dim = embedding_dim
+        self.layer_name = layer_name
+        self.ngram_size = int(config.ngram_size)
+        self.heads_per_ngram = int(config.heads_per_ngram)
+        self.ngram_heads = (self.ngram_size - 1) * self.heads_per_ngram
+        if self.ngram_size < 2:
+            raise ValueError(f"ngram_size must be >= 2, got {self.ngram_size}")
+        if self.heads_per_ngram <= 0:
+            raise ValueError(f"heads_per_ngram must be > 0, got {self.heads_per_ngram}")
+        if embedding_dim % self.ngram_heads:
+            raise ValueError(
+                "ple_embed_dim must be divisible by total ngram heads: "
+                f"{embedding_dim} % {self.ngram_heads} != 0"
+            )
+        self.head_dim = embedding_dim // self.ngram_heads
+        self.eos_token_id = int(config.eos_token_id)
+        self.unigram_vocab_size = int(config.vocab_size)
+        self.split_ngram_parts = int(getattr(config, "split_ngram_parts", 512))
+        if self.split_ngram_parts <= 0:
+            raise ValueError("split_ngram_parts must be positive")
+
+        max_multiplier = ((1 << 63) - 1) // self.unigram_vocab_size
+        half_bound = max(1, max_multiplier // 2)
+        seed = int(getattr(config, "seed", 1234))
+        base_seed = seed + _PLE_LAYER_PRIME * ple_dense_layer_id
+        multipliers = []
+        for index in range(self.ngram_size):
+            value = base_seed + _SPLITMIX_GAMMA * (index + 1)
+            multipliers.append(2 * (_splitmix64(value) % half_bound) + 1)
+        self.register_buffer(
+            "layer_multipliers",
+            torch.tensor(multipliers, dtype=torch.long),
+            persistent=True,
+        )
+
+        ngram_vocab_size_base = int(config.ngram_vocab_size_base)
+        sizes: list[int] = []
+        offsets: list[int] = []
+        offset = 0
+        for local_head in range(self.ngram_heads):
+            global_head = ple_dense_layer_id * self.ngram_heads + local_head
+            size = _nth_prime_after(ngram_vocab_size_base - 1, global_head + 1)
+            sizes.append(size)
+            offsets.append(offset)
+            offset += size
+        self.register_buffer(
+            "ngram_heads_vocab_sizes",
+            torch.tensor(sizes, dtype=torch.long),
+            persistent=True,
+        )
+        self.register_buffer(
+            "ngram_heads_offsets",
+            torch.tensor(offsets, dtype=torch.long),
+            persistent=True,
+        )
+        divisor = int(config.make_ngram_vocab_size_divisible_by)
+        padded_vocab_size = ((offset + divisor - 1) // divisor) * divisor
+        self.ngram_embedding = VocabParallelEmbedding(
+            padded_vocab_size,
+            self.head_dim,
+            padding_size=divisor,
+            prefix=f"{prefix}.ngram_embedding",
+        )
+        self.register_buffer(
+            "positions_buffer",
+            torch.arange(max_total_tokens, dtype=torch.int64),
+            persistent=False,
+        )
+        self.register_buffer(
+            "padded_buffer",
+            torch.full(
+                (max_num_reqs, max_total_tokens),
+                self.eos_token_id,
+                dtype=torch.int64,
+            ),
+            persistent=False,
+        )
+
+    @staticmethod
+    def _shift_precompute(
+        tokens: torch.Tensor, eos_token_id: int
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        if tokens.dim() != 2:
+            raise ValueError("tokens must be a 2D tensor")
+        batch_size, seq_len = tokens.shape
+        positions = torch.arange(seq_len, device=tokens.device, dtype=torch.int64)
+        eos_positions = torch.where(tokens == eos_token_id, positions, -1)
+        previous_eos_inclusive = torch.cummax(eos_positions, dim=1).values
+        previous_eos = torch.cat(
+            [
+                eos_positions.new_full((batch_size, 1), -1),
+                previous_eos_inclusive[:, :-1],
+            ],
+            dim=1,
+        )
+        return positions, positions.unsqueeze(0) - previous_eos - 1
+
+    @staticmethod
+    def _shift_apply(
+        tokens: torch.Tensor,
+        positions: torch.Tensor,
+        position_in_segment: torch.Tensor,
+        shift: int,
+        eos_token_id: int,
+    ) -> torch.Tensor:
+        if shift == 0:
+            return tokens
+        source = positions - shift
+        gather_indices = source.clamp_min(0).unsqueeze(0).expand(tokens.shape[0], -1)
+        shifted = tokens.gather(1, gather_indices)
+        valid = (source.unsqueeze(0) >= 0) & (position_in_segment >= shift)
+        return torch.where(valid, shifted, tokens.new_full((), eos_token_id))
+
+    def forward(
+        self,
+        input_ids: torch.Tensor,
+        query_start_loc: torch.Tensor,
+        ngram_context: torch.Tensor,
+    ) -> torch.Tensor:
+        input_ids = input_ids.reshape(-1).long()
+        query_start_loc = query_start_loc.long()
+        num_reqs = query_start_loc.numel() - 1
+        num_tokens = input_ids.shape[0]
+        if num_tokens > self.positions_buffer.numel():
+            raise ValueError(
+                f"PLE received {num_tokens} tokens, but its workspace supports "
+                f"at most {self.positions_buffer.numel()}"
+            )
+        if num_reqs > self.padded_buffer.shape[0]:
+            raise ValueError(
+                f"PLE received {num_reqs} requests, but its workspace supports "
+                f"at most {self.padded_buffer.shape[0]}"
+            )
+
+        positions = self.positions_buffer[:num_tokens]
+        packed = self.padded_buffer[:num_reqs]
+        packed.fill_(self.eos_token_id)
+        request_indices = torch.searchsorted(query_start_loc, positions, right=True) - 1
+        request_indices.clamp_(max=num_reqs - 1)
+        columns = (positions - query_start_loc[request_indices]).clamp(
+            0, packed.shape[1] - 1
+        )
+        packed[request_indices, columns] = input_ids
+        ngram_context = ngram_context[:num_reqs].to(
+            device=input_ids.device, dtype=torch.long
+        )
+
+        context = torch.cat([ngram_context, packed], dim=-1)
+        positions_2d, position_in_segment = self._shift_precompute(
+            context, self.eos_token_id
+        )
+        shifted = [context]
+        for shift in range(1, self.ngram_size):
+            shifted.append(
+                self._shift_apply(
+                    context,
+                    positions_2d,
+                    position_in_segment,
+                    shift,
+                    self.eos_token_id,
+                )
+            )
+        adjusted_columns = columns + self.ngram_size - 1
+        id_blocks = []
+        for ngram in range(2, self.ngram_size + 1):
+            start = (ngram - 2) * self.heads_per_ngram
+            end = start + self.heads_per_ngram
+            mixed = shifted[0] * self.layer_multipliers[0]
+            for index in range(1, ngram):
+                mixed = torch.bitwise_xor(
+                    mixed, shifted[index] * self.layer_multipliers[index]
+                )
+            sizes = self.ngram_heads_vocab_sizes[start:end]
+            offsets = self.ngram_heads_offsets[start:end]
+            ids = torch.remainder(mixed.unsqueeze(-1), sizes) + offsets
+            id_blocks.append(ids[request_indices, adjusted_columns])
+        ngram_ids = torch.cat(id_blocks, dim=-1)
+        output = ngram_ids.new_empty(
+            (ngram_ids.shape[0], self.embedding_dim),
+            dtype=self.ngram_embedding.params_dtype,
+        )
+        torch.ops.vllm.qwen4_exp_amd_ple_ngram_embedding(
+            ngram_ids,
+            output,
+            self.layer_name,
+        )
+        return output
+
+    def load_weights(self, weights: Iterable[tuple[str, torch.Tensor]]) -> set[str]:
+        """Load hash buffers and checkpoint-split embedding rows."""
+
+        persistent_buffers = {
+            "layer_multipliers": self.layer_multipliers,
+            "ngram_heads_offsets": self.ngram_heads_offsets,
+            "ngram_heads_vocab_sizes": self.ngram_heads_vocab_sizes,
+        }
+        loaded: set[str] = set()
+        regular_weights: list[tuple[str, torch.Tensor]] = []
+        shard_prefix = "ngram_embedding.shard_"
+
+        for name, loaded_weight in weights:
+            leaf_name = name.rsplit(".", 1)[-1]
+            if leaf_name.startswith("hashstats_") or leaf_name == "token_lookup":
+                continue
+            if name in persistent_buffers:
+                buffer = persistent_buffers[name]
+                if buffer.shape != loaded_weight.shape:
+                    raise ValueError(
+                        f"Shape mismatch for {name}: expected "
+                        f"{tuple(buffer.shape)}, got {tuple(loaded_weight.shape)}"
+                    )
+                buffer.copy_(loaded_weight.to(device=buffer.device, dtype=buffer.dtype))
+                loaded.add(name)
+                continue
+            if name.startswith(shard_prefix) and name.endswith(".weight"):
+                shard_text = name[len(shard_prefix) : -len(".weight")]
+                if not shard_text.isdigit():
+                    regular_weights.append((name, loaded_weight))
+                    continue
+                shard_index = int(shard_text)
+                if shard_index >= self.split_ngram_parts:
+                    raise ValueError(
+                        f"PLE embedding shard index {shard_index} exceeds "
+                        f"split_ngram_parts={self.split_ngram_parts}"
+                    )
+                embedding = self.ngram_embedding
+                shard_size = (
+                    embedding.org_vocab_size + self.split_ngram_parts - 1
+                ) // self.split_ngram_parts
+                checkpoint_start = shard_index * shard_size
+                expected_rows = max(
+                    0,
+                    min(shard_size, embedding.org_vocab_size - checkpoint_start),
+                )
+                expected_shape = (expected_rows, embedding.embedding_dim)
+                if tuple(loaded_weight.shape) != expected_shape:
+                    raise ValueError(
+                        f"Shape mismatch for PLE embedding shard {shard_index}: "
+                        f"expected {expected_shape}, got "
+                        f"{tuple(loaded_weight.shape)}"
+                    )
+                copy_ple_embedding_shard_(
+                    embedding.weight.data,
+                    loaded_weight,
+                    checkpoint_start=checkpoint_start,
+                    tp_start=embedding.shard_indices.org_vocab_start_index,
+                    tp_end=embedding.shard_indices.org_vocab_end_index,
+                )
+                loaded.add("ngram_embedding.weight")
+                continue
+            regular_weights.append((name, loaded_weight))
+
+        if regular_weights:
+            loaded.update(AutoWeightsLoader(self).load_weights(regular_weights))
+        return loaded
+
+
+class Qwen4ExpPLELayer(nn.Module, MambaBase):
+    def __init__(
+        self,
+        config: Qwen4ExpTextConfig,
+        vllm_config: VllmConfig,
+        layer_idx: int = 0,
+        ple_dense_layer_id: int | None = None,
+        prefix: str = "",
+    ) -> None:
+        super().__init__()
+        model_config = vllm_config.model_config
+        cache_config = vllm_config.cache_config
+        quant_config = vllm_config.quant_config
+        self.model_config: ModelConfig = model_config
+        self.cache_config: CacheConfig = cache_config
+        self.layer_idx = layer_idx
+        self.ple_dense_layer_id = (
+            int(ple_dense_layer_id)
+            if ple_dense_layer_id is not None
+            else int(layer_idx)
+        )
+        self.prefix = prefix
+        self.hidden_size = int(config.hidden_size)
+        self.hc_count = config.hc_count
+        self.hc_hidden_size = self.hidden_size * self.hc_count
+        self.conv_kernel_size = int(config.ple_conv_kernel_size)
+        self.short_conv_dilation = int(config.ngram_size)
+        self.conv_state_len = (self.conv_kernel_size - 1) * self.short_conv_dilation
+        self.num_spec_tokens = vllm_config.num_speculative_tokens
+        self.activation = "silu"
+        self.ple_embedding: nn.Module = Qwen4ExpNGramEmbedding(
+            config,
+            int(config.ple_embed_dim),
+            self.ple_dense_layer_id,
+            vllm_config.scheduler_config.max_num_batched_tokens,
+            vllm_config.scheduler_config.max_num_seqs,
+            f"{prefix}.ple_embedding",
+            prefix,
+        )
+        self.key_proj = ReplicatedLinear(
+            int(config.ple_embed_dim),
+            self.hc_hidden_size,
+            bias=False,
+            quant_config=quant_config,
+            prefix=f"{prefix}.key_proj",
+        )
+        self.value_proj = ReplicatedLinear(
+            int(config.ple_embed_dim),
+            self.hidden_size,
+            bias=False,
+            quant_config=quant_config,
+            prefix=f"{prefix}.value_proj",
+        )
+        norm_args = (
+            self.hc_hidden_size,
+            config.rms_norm_eps,
+            self.hidden_size,
+            model_config.dtype,
+        )
+        self.norm_key = Qwen4ExpPLEGroupedNorm(*norm_args)
+        self.norm_query = Qwen4ExpPLEGroupedNorm(*norm_args)
+        self.norm_conv = Qwen4ExpPLEGroupedNorm(*norm_args)
+        self.conv1d = nn.Conv1d(
+            self.hc_hidden_size,
+            self.hc_hidden_size,
+            self.conv_kernel_size,
+            groups=self.hc_hidden_size,
+            padding=self.conv_state_len,
+            dilation=self.short_conv_dilation,
+            bias=False,
+            dtype=model_config.dtype,
+        )
+        nn.init.zeros_(self.conv1d.weight)
+        self.conv1d.weight._no_reinit = True
+        self.kv_cache = (torch.tensor([]),)
+        compilation_config = get_current_vllm_config().compilation_config
+        if prefix in compilation_config.static_forward_context:
+            raise ValueError(f"Duplicate layer name: {prefix}")
+        compilation_config.static_forward_context[prefix] = self
+
+    @property
+    def mamba_type(self) -> MambaAttentionBackendEnum:
+        return MambaAttentionBackendEnum.SHORT_CONV
+
+    @property
+    def is_kv_cache_tp_replicated(self) -> bool:
+        return True
+
+    def get_attn_backend(self) -> type[PleShortConvAttentionBackend]:
+        return PleShortConvAttentionBackend
+
+    def get_state_dtype(self) -> tuple[torch.dtype, ...]:
+        return MambaStateDtypeCalculator.short_conv_state_dtype(
+            self.model_config.dtype, self.cache_config.mamba_cache_dtype
+        )
+
+    def get_state_shape(self) -> Sequence[tuple[int, ...]]:
+        return MambaStateShapeCalculator.short_conv_state_shape(
+            tp_world_size=1,
+            intermediate_size=self.hc_hidden_size,
+            conv_kernel=self.conv_state_len + 1,
+        )
+
+    def _apply_norm(
+        self, norm: Qwen4ExpPLEGroupedNorm, hidden_states: torch.Tensor
+    ) -> torch.Tensor:
+        shape = hidden_states.shape
+        return norm(hidden_states.flatten(-2)).reshape(shape)
+
+    def _short_conv_fallback(self, inputs: torch.Tensor) -> torch.Tensor:
+        # Profiling / CUDA graph capture only; conv state is not updated.
+        inputs_t = inputs.transpose(0, 1).unsqueeze(0)
+        output = self.conv1d(inputs_t)[..., : inputs_t.size(-1)]
+        return F.silu(output).squeeze(0).transpose(0, 1)
+
+    def _short_conv_dilated_decode_batched(
+        self,
+        x_d: torch.Tensor,
+        conv_state: torch.Tensor,
+        conv_weights: torch.Tensor,
+        state_indices_tensor_d: torch.Tensor,
+        has_initial_states_d: torch.Tensor | None,
+    ) -> torch.Tensor:
+        state_indices = state_indices_tensor_d.to(
+            device=conv_state.device, dtype=torch.int64
+        )
+        # TODO: need double-check
+        # FULL cudagraph padded decode rows use NULL_BLOCK_ID. Remap them to
+        # slot 0 for a safe gather, then zero output and skip write-back.
+        valid_state = state_indices != NULL_BLOCK_ID
+        state_indices = torch.where(
+            valid_state, state_indices, torch.zeros_like(state_indices)
+        )
+        if has_initial_states_d is None:
+            has_initial_state = valid_state
+        else:
+            if has_initial_states_d.numel() < state_indices_tensor_d.numel():
+                raise ValueError(
+                    "has_initial_states_d size mismatch: "
+                    f"got {has_initial_states_d.numel()}, "
+                    f"need >= {state_indices_tensor_d.numel()}."
+                )
+            has_initial_state = has_initial_states_d[
+                : state_indices_tensor_d.numel()
+            ].to(device=conv_state.device, dtype=torch.bool)
+            has_initial_state = has_initial_state & valid_state
+
+        cached_state = conv_state.index_select(0, state_indices)
+        state = cached_state[..., : self.conv_state_len].to(x_d.dtype)
+        if self.conv_state_len > 0:
+            initial_state = torch.where(
+                has_initial_state.view(-1, 1, 1),
+                state,
+                torch.zeros_like(state),
+            )
+            history = torch.cat((initial_state, x_d.unsqueeze(-1)), dim=-1)
+        else:
+            history = x_d.unsqueeze(-1)
+
+        conv_output = F.conv1d(
+            history,
+            conv_weights.unsqueeze(1).contiguous(),
+            groups=history.size(1),
+            dilation=self.short_conv_dilation,
+        ).squeeze(-1)
+        output = F.silu(conv_output)
+        output = output * valid_state.view(-1, 1).to(output.dtype)
+
+        if self.conv_state_len > 0:
+            next_state = history[..., -self.conv_state_len :]
+            # Padded rows are remapped to the reserved null slot. Preserve its
+            # existing value while writing the new states for valid rows.
+            existing_base_state = cached_state[..., : self.conv_state_len]
+            safe_next_state = torch.where(
+                valid_state.view(-1, 1, 1),
+                next_state.to(conv_state.dtype),
+                existing_base_state,
+            )
+            cached_state[..., : self.conv_state_len] = safe_next_state
+            conv_state.index_copy_(0, state_indices, cached_state)
+
+        return output
+
+    def _short_conv_dilated_prefill_batched(
+        self,
+        x_p: torch.Tensor,
+        metadata: PleShortConvAttentionMetadata,
+        conv_state: torch.Tensor,
+        conv_weights: torch.Tensor,
+        state_indices_tensor_p: torch.Tensor,
+        num_prefills: int,
+        num_decode_tokens: int,
+        num_prefill_tokens: int,
+    ) -> torch.Tensor:
+        # ``non_spec_query_start_loc`` covers the non-spec (decode + prefill)
+        # requests and equals ``query_start_loc`` when spec-decode is inactive.
+        non_spec_query_start_loc = metadata.non_spec_query_start_loc
+        if non_spec_query_start_loc is None:
+            raise ValueError("query_start_loc is required for prefill short-conv")
+        query_start_loc_p = (
+            non_spec_query_start_loc[-num_prefills - 1 :] - num_decode_tokens
+        )
+        # The metadata builder guarantees that the prefill query offsets start
+        # at 0 and end at num_prefill_tokens. Avoid reading those values here,
+        # since doing so would force a device-to-host synchronization.
+        has_initial_states_p = metadata.has_initial_states_p
+        if has_initial_states_p is None:
+            raise ValueError("has_initial_states_p is required for prefill short-conv")
+
+        output = torch.empty_like(x_p)
+        q_starts = query_start_loc_p.to(torch.int64)
+        if state_indices_tensor_p.numel() < num_prefills:
+            raise ValueError(
+                "state_indices_tensor_p size mismatch: "
+                f"got {state_indices_tensor_p.numel()}, "
+                f"need >= {num_prefills}."
+            )
+        if has_initial_states_p.numel() < num_prefills:
+            raise ValueError(
+                "has_initial_states_p size mismatch: "
+                f"got {has_initial_states_p.numel()}, "
+                f"need >= {num_prefills}."
+            )
+        if num_prefills == 0 or x_p.numel() == 0:
+            return output
+        lengths = q_starts[1:] - q_starts[:-1]
+        # Use the CPU-computed packing width from the metadata builder instead
+        # of synchronizing on lengths.max().
+        max_len = metadata.max_prefill_query_len
+        if max_len <= 0:
+            return output
+
+        hidden_size = x_p.shape[1]
+        positions = torch.arange(
+            num_prefill_tokens, device=x_p.device, dtype=torch.int64
+        )
+        req_indices = torch.searchsorted(q_starts[1:], positions, right=True)
+        col_indices = positions - q_starts[req_indices]
+
+        packed_tokens = x_p.new_zeros((num_prefills, max_len, hidden_size))
+        packed_tokens[req_indices, col_indices] = x_p
+        packed_tokens = packed_tokens.transpose(1, 2).contiguous()
+
+        state_indices = state_indices_tensor_p[:num_prefills].to(
+            device=conv_state.device, dtype=torch.int64
+        )
+        valid_state = state_indices != NULL_BLOCK_ID
+        state_indices = torch.where(
+            valid_state, state_indices, torch.zeros_like(state_indices)
+        )
+        has_initial = has_initial_states_p[:num_prefills].to(
+            device=conv_state.device, dtype=torch.bool
+        )
+        if self.conv_state_len > 0:
+            if conv_state.shape[0] == 0:
+                state = conv_state.new_zeros(
+                    (num_prefills, hidden_size, self.conv_state_len),
+                    dtype=x_p.dtype,
+                )
+            else:
+                state = conv_state.index_select(0, state_indices)[
+                    ..., : self.conv_state_len
+                ].to(x_p.dtype)
+            use_initial_mask = (valid_state & has_initial).view(num_prefills, 1, 1)
+            initial_state = torch.where(
+                use_initial_mask,
+                state,
+                torch.zeros_like(state),
+            )
+            history = torch.cat((initial_state, packed_tokens), dim=-1)
+        else:
+            history = packed_tokens
+
+        conv_output = F.conv1d(
+            history,
+            conv_weights.unsqueeze(1).contiguous(),
+            groups=history.size(1),
+            dilation=self.short_conv_dilation,
+        )
+        conv_output = F.silu(conv_output).transpose(1, 2).contiguous()
+
+        token_positions = torch.arange(max_len, device=x_p.device, dtype=torch.int64)
+        valid_tokens = token_positions.view(1, max_len) < lengths.view(num_prefills, 1)
+        valid_output_mask = valid_tokens & valid_state.to(device=x_p.device).view(
+            num_prefills, 1
+        )
+        conv_output.masked_fill_(~valid_output_mask.unsqueeze(-1), 0)
+        output.copy_(conv_output[req_indices, col_indices])
+
+        if self.conv_state_len > 0 and conv_state.shape[0] > 0:
+            state_starts = lengths.to(device=history.device, dtype=torch.int64).view(
+                num_prefills, 1, 1
+            )
+            state_offsets = torch.arange(
+                self.conv_state_len, device=history.device, dtype=torch.int64
+            ).view(1, 1, self.conv_state_len)
+            next_state = history.gather(
+                dim=2,
+                index=(state_starts + state_offsets).expand(-1, history.size(1), -1),
+            )
+            # Write back without a host synchronization. Valid, non-empty rows
+            # receive their new state; padding and zero-length rows keep the
+            # current cache value.
+            existing_state = conv_state.index_select(0, state_indices)
+            existing_base_state = existing_state[..., : self.conv_state_len]
+            update_mask = valid_state & (lengths.to(device=conv_state.device) > 0)
+            safe_next_state = torch.where(
+                update_mask.view(num_prefills, 1, 1),
+                next_state.to(conv_state.dtype),
+                existing_base_state,
+            )
+            existing_state[..., : self.conv_state_len] = safe_next_state
+            conv_state.index_copy_(0, state_indices, existing_state)
+        return output
+
+    def _short_conv_dilated_spec_batched(
+        self,
+        x_spec: torch.Tensor,
+        conv_state: torch.Tensor,
+        conv_weights: torch.Tensor,
+        spec_state_indices_tensor: torch.Tensor,
+        spec_query_start_loc: torch.Tensor,
+        num_accepted_tokens: torch.Tensor,
+        spec_query_len: int,
+    ) -> torch.Tensor:
+        """Dilated short-conv for speculative-decode (MTP) requests.
+
+        Each spec request feeds multiple (draft + 1) query tokens. The conv
+        outputs are computed causally after rolling back the previous draft
+        state by ``num_accepted_tokens - 1``. The current candidate inputs stay
+        in the extended cache for the next forward, matching
+        ``causal_conv1d_update``.
+
+        ``spec_query_len`` (== num_speculative_tokens + 1) is the maximum query
+        length and is a Python int, so no host synchronization is needed; this
+        keeps the path safe for full CUDA-graph capture/replay where the buffers
+        are padded at the request level.
+        """
+        num_reqs = spec_state_indices_tensor.numel()
+        hidden_size = x_spec.size(-1)
+        # Use a fixed packing width instead of synchronizing on lengths.max().
+        max_len = spec_query_len
+        # Full CUDA graphs can pad these buffers. Only the first num_reqs
+        # accepted-token counts belong to actual speculative requests.
+        num_accepted_tokens = num_accepted_tokens[:num_reqs]
+        q_starts = spec_query_start_loc[: num_reqs + 1].to(torch.int64)
+        # Keep the number of real speculative tokens on the device.
+        total_real_tokens = q_starts[num_reqs]
+
+        state_indices = spec_state_indices_tensor.to(
+            device=conv_state.device, dtype=torch.int64
+        )
+        valid_state = state_indices != NULL_BLOCK_ID
+        state_indices = torch.where(
+            valid_state, state_indices, torch.zeros_like(state_indices)
+        )
+        positions = torch.arange(
+            x_spec.size(0), device=x_spec.device, dtype=torch.int64
+        )
+        # Route graph-padded token rows to the discarded dummy request so that
+        # they cannot overwrite real packed data.
+        req_indices = torch.searchsorted(q_starts[1:], positions, right=True)
+        valid_tokens = (positions < total_real_tokens) & (req_indices < num_reqs)
+        clamped_req_indices = req_indices.clamp_max(max(num_reqs - 1, 0))
+        col_indices = (positions - q_starts[clamped_req_indices]).clamp_(0, max_len - 1)
+        pack_req_indices = torch.where(
+            valid_tokens,
+            clamped_req_indices,
+            torch.full_like(req_indices, num_reqs),
+        )
+        pack_col_indices = torch.where(
+            valid_tokens, col_indices, torch.zeros_like(col_indices)
+        )
+
+        # The last request row is the dummy sink for graph padding.
+        packed = x_spec.new_zeros((num_reqs + 1, max_len, hidden_size))
+        packed[pack_req_indices, pack_col_indices] = x_spec
+        packed = packed.transpose(1, 2).contiguous()
+
+        if self.conv_state_len > 0:
+            cached_state = conv_state.index_select(0, state_indices)
+            rollback_offsets = num_accepted_tokens.to(
+                device=conv_state.device, dtype=torch.int64
+            ).sub(1)
+            rollback_offsets = torch.where(
+                valid_state,
+                rollback_offsets.clamp_(0, max_len - 1),
+                torch.zeros_like(rollback_offsets),
+            )
+            state_offsets = torch.arange(
+                self.conv_state_len, device=conv_state.device, dtype=torch.int64
+            ).view(1, 1, self.conv_state_len)
+            rollback_indices = rollback_offsets.view(-1, 1, 1) + state_offsets
+            state = cached_state.gather(
+                2, rollback_indices.expand(-1, hidden_size, -1)
+            ).to(x_spec.dtype)
+            state = torch.where(
+                valid_state.view(num_reqs, 1, 1),
+                state,
+                torch.zeros_like(state),
+            )
+            # Append a zeroed dummy-row state to match the [num_reqs + 1] pack.
+            dummy_state = state.new_zeros((1, hidden_size, self.conv_state_len))
+            state_full = torch.cat((state, dummy_state), dim=0)
+            history = torch.cat((state_full, packed), dim=-1)
+        else:
+            history = packed
+
+        conv_output = F.conv1d(
+            history,
+            conv_weights.unsqueeze(1).contiguous(),
+            groups=history.size(1),
+            dilation=self.short_conv_dilation,
+        )
+        conv_output = F.silu(conv_output).transpose(1, 2).contiguous()
+
+        output = conv_output[pack_req_indices, pack_col_indices]
+        output = output * valid_tokens.view(-1, 1).to(output.dtype)
+
+        # Keep all current candidate inputs in the extended state. On the next
+        # target forward, ``num_accepted_tokens - 1`` selects the rollback
+        # window before processing the newly scheduled tokens.
+        if self.conv_state_len > 0:
+            state_capacity = self.conv_state_len + max_len - 1
+            if conv_state.size(-1) < state_capacity:
+                raise RuntimeError(
+                    "PLE short-conv cache cannot retain speculative tokens: "
+                    f"got {conv_state.size(-1)}, need {state_capacity}."
+                )
+            candidate_state = history[:num_reqs, :, 1 : state_capacity + 1]
+            query_lengths = q_starts[1:] - q_starts[:-1]
+            state_positions = torch.arange(
+                state_capacity, device=history.device, dtype=torch.int64
+            ).view(1, 1, state_capacity)
+            update_lengths = (self.conv_state_len + query_lengths - 1).view(
+                num_reqs, 1, 1
+            )
+            update_mask = valid_state.view(num_reqs, 1, 1) & (
+                state_positions < update_lengths
+            )
+            existing_state = cached_state[..., :state_capacity]
+            next_state = torch.where(
+                update_mask,
+                candidate_state.to(conv_state.dtype),
+                existing_state,
+            )
+            cached_state[..., :state_capacity] = next_state
+            conv_state.index_copy_(0, state_indices, cached_state)
+
+        return output
+
+    def _short_conv_dilated_dispatch(
+        self,
+        inputs: torch.Tensor,
+        metadata: PleShortConvAttentionMetadata,
+        conv_state: torch.Tensor,
+        conv_weights: torch.Tensor,
+    ) -> torch.Tensor:
+        num_prefills = metadata.num_prefills
+        num_decodes = metadata.num_decodes
+        num_decode_tokens = metadata.num_decode_tokens
+        num_prefill_tokens = metadata.num_prefill_tokens
+        has_prefill = num_prefills > 0
+        has_decode = num_decodes > 0
+        has_spec = metadata.spec_sequence_masks is not None
+        x = inputs[: metadata.num_actual_tokens]
+
+        # Split spec / non-spec tokens.
+        if has_spec:
+            if has_prefill or has_decode:
+                assert metadata.spec_token_indx is not None
+                assert metadata.non_spec_token_indx is not None
+                x_spec = x.index_select(0, metadata.spec_token_indx.long())
+                x_non_spec = x.index_select(0, metadata.non_spec_token_indx.long())
+            else:
+                x_spec = x
+                x_non_spec = None
+        else:
+            x_spec = None
+            x_non_spec = x
+
+        spec_output = None
+        # 1. Run the multi-query speculative-decode part.
+        if has_spec:
+            assert metadata.spec_state_indices_tensor is not None
+            assert metadata.spec_query_start_loc is not None
+            assert metadata.num_accepted_tokens is not None
+            spec_output = self._short_conv_dilated_spec_batched(
+                x_spec=x_spec,
+                conv_state=conv_state,
+                conv_weights=conv_weights,
+                spec_state_indices_tensor=metadata.spec_state_indices_tensor[
+                    : metadata.num_spec_decodes
+                ],
+                spec_query_start_loc=metadata.spec_query_start_loc,
+                num_accepted_tokens=metadata.num_accepted_tokens,
+                spec_query_len=metadata.spec_query_len,
+            )
+
+        # 2. Run regular decode and prefill requests.
+        conv_out_non_spec = None
+        state_indices_tensor = metadata.state_indices_tensor
+        if x_non_spec is not None:
+            assert state_indices_tensor is not None
+            if has_prefill:
+                state_indices_tensor_d, state_indices_tensor_p = torch.split(
+                    state_indices_tensor,
+                    [num_decodes, num_prefills],
+                    dim=0,
+                )
+                x_d, x_p = torch.split(
+                    x_non_spec,
+                    [num_decode_tokens, num_prefill_tokens],
+                    dim=0,
+                )
+                non_spec_parts: list[torch.Tensor] = []
+                if has_decode:
+                    non_spec_parts.append(
+                        self._short_conv_dilated_decode_batched(
+                            x_d=x_d,
+                            conv_state=conv_state,
+                            conv_weights=conv_weights,
+                            state_indices_tensor_d=state_indices_tensor_d,
+                            has_initial_states_d=metadata.has_initial_states_d,
+                        )
+                    )
+                non_spec_parts.append(
+                    self._short_conv_dilated_prefill_batched(
+                        x_p=x_p,
+                        metadata=metadata,
+                        conv_state=conv_state,
+                        conv_weights=conv_weights,
+                        state_indices_tensor_p=state_indices_tensor_p,
+                        num_prefills=num_prefills,
+                        num_decode_tokens=num_decode_tokens,
+                        num_prefill_tokens=num_prefill_tokens,
+                    )
+                )
+                conv_out_non_spec = torch.vstack(non_spec_parts)
+            else:
+                conv_out_non_spec = self._short_conv_dilated_decode_batched(
+                    x_d=x_non_spec,
+                    conv_state=conv_state,
+                    conv_weights=conv_weights,
+                    state_indices_tensor_d=state_indices_tensor[: x_non_spec.size(0)],
+                    has_initial_states_d=metadata.has_initial_states_d,
+                )
+
+        # 3. Merge both parts back into the original token order.
+        if has_spec and conv_out_non_spec is not None:
+            assert metadata.spec_token_indx is not None
+            assert metadata.non_spec_token_indx is not None
+            assert spec_output is not None
+            output = x.new_empty((metadata.num_actual_tokens, x.size(-1)))
+            output.index_copy_(0, metadata.spec_token_indx, spec_output)
+            output.index_copy_(0, metadata.non_spec_token_indx, conv_out_non_spec)
+            return output
+        elif has_spec:
+            assert spec_output is not None
+            return spec_output
+        if conv_out_non_spec is None:
+            return x
+        return conv_out_non_spec
+
+    def _short_conv(self, inputs: torch.Tensor) -> torch.Tensor:
+        forward_context = get_forward_context()
+        attn_metadata = forward_context.attn_metadata
+        if attn_metadata is None:
+            return self._short_conv_fallback(inputs)
+
+        if not isinstance(attn_metadata, dict):
+            raise RuntimeError(
+                "PLE short-conv expects per-layer attention metadata dict "
+                f"during inference, got {type(attn_metadata).__name__}."
+            )
+
+        layer_attn_metadata = attn_metadata.get(self.prefix)
+        if layer_attn_metadata is None:
+            raise RuntimeError(
+                f"Missing short-conv metadata for layer '{self.prefix}'. "
+                "This would bypass conv-state updates and is not allowed."
+            )
+        if not isinstance(layer_attn_metadata, PleShortConvAttentionMetadata):
+            raise TypeError(
+                "Expected PleShortConvAttentionMetadata for layer "
+                f"'{self.prefix}', got "
+                f"{type(layer_attn_metadata).__name__}."
+            )
+
+        conv_state = self.kv_cache[0]
+        if not is_conv_state_dim_first():
+            conv_state = conv_state.transpose(-1, -2)
+        conv_weights = self.conv1d.weight.squeeze(1)
+
+        state_capacity = self.conv_state_len + self.num_spec_tokens
+        if state_capacity > 0:
+            if conv_state.size(-1) < state_capacity:
+                raise RuntimeError(
+                    "PLE short-conv cache is smaller than expected for "
+                    f"dilated convolution: got {conv_state.size(-1)}, "
+                    f"expect at least {state_capacity}."
+                )
+            conv_state = conv_state[..., -state_capacity:]
+        return self._short_conv_dilated_dispatch(
+            inputs,
+            layer_attn_metadata,
+            conv_state,
+            conv_weights.to(dtype=inputs.dtype),
+        )
+
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+        input_ids: torch.Tensor,
+        query_start_loc: torch.Tensor,
+        ngram_context: torch.Tensor,
+    ) -> torch.Tensor:
+        input_ids = input_ids.reshape(-1)
+        if input_ids.shape[0] != hidden_states.shape[0]:
+            raise ValueError(
+                "PLE expects input_ids and hidden_states to have the same "
+                f"token length, got {input_ids.shape[0]} and "
+                f"{hidden_states.shape[0]}"
+            )
+        embeddings = self.ple_embedding(input_ids, query_start_loc, ngram_context)
+        key, _ = self.key_proj(embeddings)
+        value, _ = self.value_proj(embeddings)
+        token_count = hidden_states.shape[0]
+        key = key.reshape(token_count, self.hc_count, self.hidden_size)
+        query = hidden_states.reshape(token_count, self.hc_count, self.hidden_size)
+        key = self._apply_norm(self.norm_key, key)
+        query = self._apply_norm(self.norm_query, query)
+        gate = (key * query).sum(dim=-1, keepdim=True) / math.sqrt(self.hidden_size)
+        gate = torch.sigmoid(gate.sign() * gate.abs().clamp_min(1e-6).sqrt())
+        gated_value = gate * value.unsqueeze(-2)
+        normalized = self._apply_norm(self.norm_conv, gated_value).flatten(-2)
+        conv_output = torch.zeros_like(normalized)
+        torch.ops.vllm.qwen4_exp_ple_short_conv(
+            normalized,
+            conv_output,
+            self.prefix,
+        )
+        return gated_value.flatten(-2) + conv_output
+
+
+def qwen4_exp_amd_ple_ngram_embedding(
+    ngram_ids: torch.Tensor,
+    output: torch.Tensor,
+    layer_name: str,
+) -> None:
+    """Run the large PLE embedding lookup outside Inductor's FX graph.
+
+    Keeping the embedding weight in ``static_forward_context`` prevents AOT
+    compile-time autotuning from materializing a synthetic copy of the weight.
+    """
+    layer = get_forward_context().no_compile_layers[layer_name]
+    if not isinstance(layer, Qwen4ExpPLELayer):
+        raise TypeError(f"{layer_name} is not a Qwen4Exp PLE owner")
+    result = layer.ple_embedding.ngram_embedding(ngram_ids).flatten(-2)
+    output.copy_(result)
+
+
+def qwen4_exp_amd_ple_ngram_embedding_fake(
+    ngram_ids: torch.Tensor,
+    output: torch.Tensor,
+    layer_name: str,
+) -> None:
+    return
+
+
+def qwen4_exp_ple_short_conv(
+    inputs: torch.Tensor,
+    output: torch.Tensor,
+    layer_name: str,
+) -> None:
+    layer = get_forward_context().no_compile_layers[layer_name]
+    result = layer._short_conv(inputs)
+    output[: result.shape[0]].copy_(result)
+
+
+def qwen4_exp_ple_short_conv_fake(
+    inputs: torch.Tensor,
+    output: torch.Tensor,
+    layer_name: str,
+) -> None:
+    return
+
+
+direct_register_custom_op(
+    op_name="qwen4_exp_amd_ple_ngram_embedding",
+    op_func=qwen4_exp_amd_ple_ngram_embedding,
+    mutates_args=["output"],
+    fake_impl=qwen4_exp_amd_ple_ngram_embedding_fake,
+)
+
+
+direct_register_custom_op(
+    op_name="qwen4_exp_ple_short_conv",
+    op_func=qwen4_exp_ple_short_conv,
+    mutates_args=["output"],
+    fake_impl=qwen4_exp_ple_short_conv_fake,
+)
+
+
+__all__ = [
+    "Qwen4ExpNGramEmbedding",
+    "Qwen4ExpPLEGroupedNorm",
+    "Qwen4ExpPLELayer",
+]

--- a/vllm_ascend/models/qwen4_exp/amd/qsa.py
+++ b/vllm_ascend/models/qwen4_exp/amd/qsa.py
@@ -1,0 +1,468 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""AMD ROCm QSA owner with Triton kernels."""
+
+from __future__ import annotations
+
+from typing import ClassVar, cast
+
+import torch
+from torch import nn
+from vllm.config import VllmConfig
+from vllm.config.cache import CacheDType
+from vllm.distributed import get_tensor_model_parallel_world_size
+from vllm.forward_context import get_forward_context
+from vllm.model_executor.layers.attention.attention import (
+    set_default_quant_scales,
+)
+from vllm.model_executor.layers.attention_layer_base import AttentionLayerBase
+from vllm.model_executor.layers.layernorm import GemmaRMSNorm
+from vllm.model_executor.layers.linear import QKVParallelLinear, RowParallelLinear
+from vllm.model_executor.layers.quantization import QuantizationConfig
+from vllm.model_executor.layers.rotary_embedding import get_rope
+from vllm.model_executor.models.qwen3_next import Qwen3NextAttention
+from vllm.platforms import current_platform
+from vllm.utils.torch_utils import (
+    LayerNameType,
+    _encode_layer_name,
+    _resolve_layer_name,
+    canonicalize_singleton_dim_strides,
+    direct_register_custom_op,
+    kv_cache_dtype_str_to_dtype,
+)
+from vllm.v1.attention.backend import (
+    AttentionBackend,
+    AttentionCGSupport,
+    AttentionType,
+)
+from vllm.v1.attention.backends.fa_utils import is_flash_attn_varlen_func_available
+from vllm.v1.attention.backends.flash_attn import (
+    FlashAttentionBackend,
+    FlashAttentionImpl,
+    FlashAttentionMetadata,
+    FlashAttentionMetadataBuilder,
+)
+from vllm.v1.kv_cache_interface import (
+    FullAttentionSpec,
+    KVCacheSpec,
+    get_kv_quant_mode,
+)
+
+from vllm_ascend.models.qwen4_exp.config import (
+    Qwen4ExpTextConfig,
+)
+
+from ..common.qsa_cache import QSAForwardMetadata
+from . import model
+from .indexer_qsa import QSAIndexer
+
+
+class Qwen4ExpQSAMetadataBuilder(FlashAttentionMetadataBuilder):
+    """Flash metadata supporting uniform decode and target-verify graphs."""
+
+    _cudagraph_support: ClassVar[AttentionCGSupport] = AttentionCGSupport.UNIFORM_BATCH
+
+
+class Qwen4ExpQSAFlashAttentionBackend(FlashAttentionBackend):
+    """FullAttentionSpec backend used by the merged QSA owner."""
+
+    supported_dtypes: ClassVar[list[torch.dtype]] = [torch.bfloat16]
+    supported_kv_cache_dtypes: ClassVar[list[CacheDType]] = ["auto", "bfloat16"]
+
+    @staticmethod
+    def get_name() -> str:
+        return "QWEN4_EXP_QSA_TRITON"
+
+    @staticmethod
+    def get_impl_cls() -> type[Qwen4ExpQSAFlashAttentionImpl]:
+        return Qwen4ExpQSAFlashAttentionImpl
+
+    @staticmethod
+    def get_builder_cls() -> type[Qwen4ExpQSAMetadataBuilder]:
+        return Qwen4ExpQSAMetadataBuilder
+
+    @classmethod
+    def is_sparse(cls) -> bool:
+        return True
+
+    @classmethod
+    def supports_kv_connector(cls) -> bool:
+        return False
+
+
+class Qwen4ExpQSAFlashAttentionImpl(FlashAttentionImpl):
+    """Run paged sparse GQA with the QSA Triton kernel."""
+
+    supports_dcp: bool = False
+    supports_pcp: bool = False
+
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
+        if not is_flash_attn_varlen_func_available():
+            raise NotImplementedError("Qwen4Exp QSA requires FlashAttention")
+        if self.dcp_world_size != 1:
+            raise NotImplementedError(
+                "Qwen4Exp QSA does not support decode context parallelism"
+            )
+        if self.kv_cache_dtype not in ("auto", "bfloat16"):
+            raise NotImplementedError("Qwen4Exp QSA requires a BF16 main KV cache")
+        self.supports_quant_query_input = False
+
+    def forward_qsa(
+        self,
+        layer: torch.nn.Module,
+        query: torch.Tensor,
+        key: torch.Tensor,
+        value: torch.Tensor,
+        kv_cache: torch.Tensor,
+        attn_metadata: FlashAttentionMetadata,
+        output: torch.Tensor,
+        token_to_req: torch.Tensor,
+        output_scale: torch.Tensor | None = None,
+        output_block_scale: torch.Tensor | None = None,
+    ) -> torch.Tensor:
+        del key, value
+        if output_scale is not None or output_block_scale is not None:
+            raise NotImplementedError("QSA does not support fused output quantization")
+        if self.alibi_slopes is not None or self.sinks is not None:
+            raise NotImplementedError("QSA does not support ALiBi or attention sinks")
+        if self.sliding_window != (-1, -1):
+            raise NotImplementedError("QSA does not support sliding-window attention")
+
+        num_tokens = attn_metadata.num_actual_tokens
+        output.zero_()
+        if num_tokens == 0:
+            return output
+
+        topk_buffer = getattr(layer, "topk_indices_buffer", None)
+        if topk_buffer is None:
+            raise RuntimeError("QSA owner did not provide its top-k buffer")
+        logical_indices = topk_buffer[:num_tokens]
+        token_to_req = token_to_req[:num_tokens]
+        key_cache, value_cache = kv_cache.transpose(1, 2).split(self.head_size, dim=-1)
+        key_cache = canonicalize_singleton_dim_strides(key_cache)
+        value_cache = canonicalize_singleton_dim_strides(value_cache)
+        if key_cache.dtype != torch.bfloat16 or query.dtype != torch.bfloat16:
+            raise NotImplementedError("Qwen4Exp QSA requires BF16 Q/K/V")
+
+        from .ops.qsa import qsa_sparse_paged_attention
+
+        qsa_sparse_paged_attention(
+            query[:num_tokens],
+            key_cache,
+            value_cache,
+            logical_indices,
+            attn_metadata.block_table,
+            token_to_req,
+            output[:num_tokens],
+        )
+        return output
+
+
+class Qwen4ExpQSAAttention(Qwen3NextAttention, AttentionLayerBase):
+    """Merged Qwen full-attention owner with a QSA index side branch."""
+
+    supports_dcp = False
+
+    def __init__(
+        self,
+        *,
+        vllm_config: VllmConfig,
+        config: Qwen4ExpTextConfig,
+        layer_id: int,
+        quant_config: QuantizationConfig | None = None,
+        reduce_results: bool = True,
+        prefix: str = "",
+    ) -> None:
+        nn.Module.__init__(self)
+        cache_config = vllm_config.cache_config
+        model_config = vllm_config.model_config
+        if cache_config is None:
+            raise ValueError("Qwen4Exp QSA requires a paged KV cache")
+        if model_config.dtype != torch.bfloat16:
+            raise NotImplementedError("Qwen4Exp QSA currently requires BF16")
+        if cache_config.cache_dtype not in ("auto", "bfloat16"):
+            raise NotImplementedError("Qwen4Exp QSA requires a BF16 main KV cache")
+        if getattr(quant_config, "kv_cache_scheme", None) is not None:
+            raise NotImplementedError("Qwen4Exp QSA does not support KV quantization")
+        parallel_config = vllm_config.parallel_config
+        if (
+            parallel_config.prefill_context_parallel_size > 1
+            or parallel_config.decode_context_parallel_size > 1
+        ):
+            raise NotImplementedError(
+                "Qwen4Exp QSA does not support context parallelism"
+            )
+        if not getattr(config, "is_causal", True):
+            raise NotImplementedError("Qwen4Exp QSA requires causal decoder attention")
+
+        self.config = config
+        self.hidden_size = int(config.hidden_size)
+        tp_size = get_tensor_model_parallel_world_size()
+        self.total_num_heads = int(config.num_attention_heads)
+        if self.total_num_heads % tp_size:
+            raise ValueError("QSA attention heads must be divisible by TP size")
+        self.num_heads = self.total_num_heads // tp_size
+        self.total_num_kv_heads = int(config.num_key_value_heads)
+        if self.total_num_kv_heads >= tp_size:
+            if self.total_num_kv_heads % tp_size:
+                raise ValueError("QSA KV heads must be divisible by TP size")
+        elif tp_size % self.total_num_kv_heads:
+            raise ValueError("TP size must be divisible by replicated QSA KV heads")
+        self.num_kv_heads = max(1, self.total_num_kv_heads // tp_size)
+        self.head_dim = int(config.head_dim or self.hidden_size // self.num_heads)
+        self.q_size = self.num_heads * self.head_dim
+        self.kv_size = self.num_kv_heads * self.head_dim
+        self.scaling = self.head_dim**-0.5
+        self.dual_chunk_attention_config = getattr(
+            config, "dual_chunk_attention_config", None
+        )
+        if self.dual_chunk_attention_config is not None:
+            raise NotImplementedError("Qwen4Exp QSA does not support dual-chunk RoPE")
+        # Qwen4Exp full-attention checkpoints always pack a sigmoid output
+        # gate next to Q, even when an inherited config default says otherwise.
+        self.attn_output_gate = True
+
+        self.qkv_proj = QKVParallelLinear(
+            self.hidden_size,
+            self.head_dim,
+            self.total_num_heads * (1 + self.attn_output_gate),
+            self.total_num_kv_heads,
+            bias=False,
+            quant_config=model.without_modelopt_fp4(quant_config),
+            prefix=f"{prefix}.qkv_proj",
+        )
+        self.o_proj = RowParallelLinear(
+            self.total_num_heads * self.head_dim,
+            self.hidden_size,
+            bias=False,
+            reduce_results=reduce_results,
+            quant_config=quant_config,
+            prefix=f"{prefix}.o_proj",
+        )
+        self.rotary_emb = get_rope(
+            head_size=self.head_dim,
+            max_position=config.max_position_embeddings,
+            rope_parameters=config.rope_parameters,
+        )
+        self.q_norm = GemmaRMSNorm(self.head_dim, eps=config.rms_norm_eps)
+        self.k_norm = GemmaRMSNorm(self.head_dim, eps=config.rms_norm_eps)
+
+        mm_config = model_config.multimodal_config
+        text_only = mm_config is None or mm_config.language_model_only
+        self.use_fused_qk_norm_rope_gate = (
+            self.attn_output_gate
+            and getattr(self.rotary_emb, "is_neox_style", False)
+            and current_platform.is_cuda()
+            and text_only
+        )
+
+        self.layer_name = f"{prefix}.attn"
+        self.attn_type = AttentionType.DECODER
+        self.kv_cache_dtype = cache_config.cache_dtype
+        self.kv_cache_torch_dtype = kv_cache_dtype_str_to_dtype(
+            self.kv_cache_dtype, model_config
+        )
+        if self.kv_cache_torch_dtype != torch.bfloat16:
+            raise NotImplementedError("Qwen4Exp QSA requires BF16 cache storage")
+        self.kv_sharing_target_layer_name = None
+        self.kv_cache = torch.tensor([])
+        set_default_quant_scales(self, register_buffer=True)
+
+        self.attn_backend = Qwen4ExpQSAFlashAttentionBackend
+        self.impl = Qwen4ExpQSAFlashAttentionImpl(
+            self.num_heads,
+            self.head_dim,
+            self.scaling,
+            self.num_kv_heads,
+            None,
+            None,
+            self.kv_cache_dtype,
+            None,
+            AttentionType.DECODER,
+            None,
+        )
+        self.indexer = QSAIndexer(
+            vllm_config=vllm_config,
+            config=config,
+            layer_id=layer_id,
+            rotary_emb=self.rotary_emb,
+            quant_config=quant_config,
+            prefix=f"{prefix}.indexer",
+        )
+        max_tokens = vllm_config.scheduler_config.max_num_batched_tokens
+        self.register_buffer(
+            "topk_indices_buffer",
+            torch.empty(
+                max_tokens,
+                self.indexer.output_width,
+                dtype=torch.int32,
+            ),
+            persistent=False,
+        )
+
+        static_context = vllm_config.compilation_config.static_forward_context
+        if self.layer_name in static_context:
+            raise ValueError(f"Duplicate layer name: {self.layer_name}")
+        static_context[self.layer_name] = self
+
+    def get_attn_backend(self) -> type[AttentionBackend]:
+        return self.attn_backend
+
+    def get_kv_cache_spec(self, vllm_config: VllmConfig) -> KVCacheSpec:
+        return FullAttentionSpec(
+            block_size=vllm_config.cache_config.block_size,
+            num_kv_heads=self.num_kv_heads,
+            head_size=self.head_dim,
+            head_size_v=self.head_dim,
+            dtype=self.kv_cache_torch_dtype,
+            kv_quant_mode=get_kv_quant_mode(self.kv_cache_dtype),
+        )
+
+    def _run_qsa(
+        self,
+        hidden_states: torch.Tensor,
+        positions: torch.Tensor,
+        query: torch.Tensor,
+        key: torch.Tensor,
+        value: torch.Tensor,
+        output: torch.Tensor,
+    ) -> None:
+        metadata = get_forward_context().attn_metadata
+        if isinstance(metadata, list):
+            metadata = metadata[0]
+        if not isinstance(metadata, dict):
+            output.zero_()
+            return
+        main_metadata = cast(FlashAttentionMetadata, metadata[self.layer_name])
+        if self.kv_cache.numel() == 0:
+            raise RuntimeError("QSA main K/V cache is not bound")
+
+        num_tokens = main_metadata.num_actual_tokens
+        side_metadata = cast(
+            QSAForwardMetadata,
+            metadata[self.indexer.raw_key_cache.prefix],
+        )
+        if side_metadata.num_actual_tokens != num_tokens:
+            raise RuntimeError("QSA main and side metadata token counts disagree")
+        selected = self.indexer(
+            hidden_states,
+            positions,
+            self.topk_indices_buffer[:num_tokens],
+        )
+        if selected.shape != (
+            num_tokens,
+            self.indexer.output_width,
+        ):
+            raise RuntimeError("QSA indexer returned an invalid selection shape")
+        impl = cast(Qwen4ExpQSAFlashAttentionImpl, self.impl)
+        impl.do_kv_cache_update(
+            self,
+            key,
+            value,
+            self.kv_cache,
+            main_metadata.slot_mapping,
+        )
+        impl.forward_qsa(
+            self,
+            query,
+            key,
+            value,
+            self.kv_cache,
+            main_metadata,
+            output,
+            token_to_req=side_metadata.token_to_req,
+        )
+
+    def forward(
+        self,
+        positions: torch.Tensor,
+        hidden_states: torch.Tensor,
+    ) -> torch.Tensor:
+        qkv, _ = self.qkv_proj(hidden_states)
+        q, k, v, gate = self._project_qkv_gate(qkv, positions)
+        num_tokens = hidden_states.shape[0]
+        query = q.view(num_tokens, self.num_heads, self.head_dim)
+        key = k.view(num_tokens, self.num_kv_heads, self.head_dim)
+        value = v.view(num_tokens, self.num_kv_heads, self.head_dim)
+        attn_output = torch.empty_like(query)
+        encoded_layer_name = _encode_layer_name(self.layer_name)
+        if current_platform.opaque_attention_op():
+            torch.ops.vllm.qwen4_exp_qsa_with_output(
+                hidden_states,
+                positions,
+                query,
+                key,
+                value,
+                attn_output,
+                encoded_layer_name,
+            )
+        else:
+            qwen4_exp_qsa_with_output(
+                hidden_states,
+                positions,
+                query,
+                key,
+                value,
+                attn_output,
+                encoded_layer_name,
+            )
+        flat_output = attn_output.view(num_tokens, -1)
+        if gate is not None:
+            flat_output = flat_output * torch.sigmoid(gate)
+        output, _ = self.o_proj(flat_output)
+        return output
+
+
+def qwen4_exp_qsa_with_output(
+    hidden_states: torch.Tensor,
+    positions: torch.Tensor,
+    query: torch.Tensor,
+    key: torch.Tensor,
+    value: torch.Tensor,
+    output: torch.Tensor,
+    layer_name: LayerNameType,
+) -> None:
+    """Run the complete QSA state/update/attend transaction."""
+
+    layer_name = _resolve_layer_name(layer_name)
+    layer = get_forward_context().no_compile_layers[layer_name]
+    if not isinstance(layer, Qwen4ExpQSAAttention):
+        raise TypeError(f"{layer_name} is not a Qwen4Exp QSA owner")
+    layer._run_qsa(
+        hidden_states,
+        positions,
+        query,
+        key,
+        value,
+        output,
+    )
+
+
+def qwen4_exp_qsa_with_output_fake(
+    hidden_states: torch.Tensor,
+    positions: torch.Tensor,
+    query: torch.Tensor,
+    key: torch.Tensor,
+    value: torch.Tensor,
+    output: torch.Tensor,
+    layer_name: LayerNameType,
+) -> None:
+    del hidden_states, positions, query, key, value, output, layer_name
+
+
+direct_register_custom_op(
+    op_name="qwen4_exp_qsa_with_output",
+    op_func=qwen4_exp_qsa_with_output,
+    mutates_args=["output"],
+    fake_impl=qwen4_exp_qsa_with_output_fake,
+)
+
+
+__all__ = [
+    "QSAIndexer",
+    "Qwen4ExpQSAAttention",
+    "Qwen4ExpQSAFlashAttentionBackend",
+    "Qwen4ExpQSAFlashAttentionImpl",
+    "qwen4_exp_qsa_with_output",
+]

--- a/vllm_ascend/models/qwen4_exp/common/__init__.py
+++ b/vllm_ascend/models/qwen4_exp/common/__init__.py
@@ -1,0 +1,17 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Common Qwen4Exp model components."""
+
+from .hyperconnection import (
+    GatedResidual,
+    GroupedGemmaRMSNorm,
+    HyperConnectionBase,
+    HyperConnectionConfig,
+)
+
+__all__ = [
+    "GatedResidual",
+    "GroupedGemmaRMSNorm",
+    "HyperConnectionBase",
+    "HyperConnectionConfig",
+]

--- a/vllm_ascend/models/qwen4_exp/common/hyperconnection.py
+++ b/vllm_ascend/models/qwen4_exp/common/hyperconnection.py
@@ -1,0 +1,250 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""HyperConnection (Gated Residual) utilities.
+
+Implements the HyperConnection residual scheme proposed in
+"HyperConnections" (https://arxiv.org/abs/2409.19606).
+
+The two concrete variants are:
+  - ``HyperConnectionBase``  - simple average pooling across hc_count parallel
+    streams (equivalent to hyperconnection_average).
+  - ``GatedResidual``  - learnable low-rank gated mixing and injection
+    (gated_residual).
+
+Hidden states between layers have shape ``[..., HC*HS]`` with HS inner
+(HC outer, HS inner — checkpoint-native layout). The local torch
+implementation consumes the hyper input viewed as ``[..., HC, HS]``.
+
+Typical usage inside a transformer decoder layer::
+
+    self.attn_hc = GatedResidual(hc_config, role="attn")
+    self.mlp_hc = GatedResidual(hc_config, role="mlp")
+
+    hidden_states, residual = self.attn_hc.mix(hidden_states)
+    hidden_states = attention(hidden_states)
+    hidden_states = self.attn_hc.combine(hidden_states, residual)
+
+    hidden_states, residual = self.mlp_hc.mix(hidden_states)
+    hidden_states = mlp(hidden_states)
+    hidden_states = self.mlp_hc.combine(hidden_states, residual)
+"""
+
+from dataclasses import dataclass
+
+import torch
+import torch.nn.functional as F
+from torch import nn
+
+
+# ---------------------------------------------------------------------------
+# Config
+# ---------------------------------------------------------------------------
+@dataclass
+class HyperConnectionConfig:
+    """Configuration shared by all HyperConnection variants."""
+
+    hc_count: int = 4
+    hidden_size: int = 64
+    params_dtype: torch.dtype = torch.bfloat16
+    mtp_hc: bool = False
+    hc_lowrank: int = 16
+    rms_norm_eps: float = 1e-6
+    hc_per_branch_norm: bool = False
+
+
+class GroupedGemmaRMSNorm(nn.Module):
+    def __init__(
+        self,
+        hidden_size: int,
+        eps: float,
+        group_size: int | None,
+        dtype: torch.dtype | None,
+    ) -> None:
+        super().__init__()
+        if group_size is not None and hidden_size % group_size:
+            raise ValueError(
+                f"hidden_size ({hidden_size}) must be divisible by "
+                f"group_size ({group_size})"
+            )
+        self.variance_epsilon = eps
+        self.group_size = group_size
+        self.weight = nn.Parameter(torch.zeros(hidden_size, dtype=dtype))
+
+    def forward(self, hidden_states: torch.Tensor) -> torch.Tensor:
+        input_dtype = hidden_states.dtype
+        hidden_states = hidden_states.float()
+        if self.group_size is None:
+            variance = hidden_states.square().mean(dim=-1, keepdim=True)
+            normalized = hidden_states * torch.rsqrt(variance + self.variance_epsilon)
+        else:
+            grouped = hidden_states.unflatten(
+                -1, (hidden_states.shape[-1] // self.group_size, self.group_size)
+            )
+            variance = grouped.square().mean(dim=-1, keepdim=True)
+            normalized = (
+                grouped * torch.rsqrt(variance + self.variance_epsilon)
+            ).flatten(-2)
+        return (normalized * (1.0 + self.weight.float())).to(input_dtype)
+
+
+# ---------------------------------------------------------------------------
+# Average-pooling variant
+# ---------------------------------------------------------------------------
+class HyperConnectionBase(nn.Module):
+    """Average-pooling HyperConnection (``hyperconnection_average``).
+
+    Splits the incoming ``[..., HC*HS]`` tensor (HC outer, HS inner) into
+    ``HC`` parallel streams, averages them for the block input, and
+    broadcasts the block output back to every stream.
+    """
+
+    def __init__(
+        self,
+        config: HyperConnectionConfig,
+        layer_idx: int | None = None,
+        role: str | None = None,
+    ) -> None:
+        super().__init__()
+        self.config = config
+        self.hc_count = config.hc_count
+        self.hidden_size = config.hidden_size
+        self.layer_idx = layer_idx
+        self.role = role
+
+    @property
+    def hyper_hidden_size(self) -> int:
+        return self.hc_count * self.hidden_size
+
+    def mix(self, hyper_input: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
+        """Average the HC streams into a single block input."""
+        assert hyper_input.shape[-1] == self.hc_count * self.hidden_size
+        # [*, HC, HS] — mean over HC (dim=-2).
+        unflat = hyper_input.unflatten(-1, (self.hc_count, self.hidden_size))
+        mixed_input = unflat.mean(dim=-2)
+        return mixed_input, hyper_input
+
+    def combine(
+        self, block_output: torch.Tensor, residual: torch.Tensor
+    ) -> torch.Tensor:
+        """Broadcast the block output back to every stream."""
+        assert residual.shape[-1] == self.hc_count * self.hidden_size
+        assert block_output.shape[-1] == self.hidden_size
+        residual_reshaped = residual.unflatten(-1, (self.hc_count, self.hidden_size))
+        combined = residual_reshaped + block_output.unsqueeze(-2)
+        return combined.flatten(-2)
+
+
+# ---------------------------------------------------------------------------
+# Gated-residual variant
+# ---------------------------------------------------------------------------
+class GatedResidual(HyperConnectionBase):
+    """Gated HyperConnection with learnable low-rank mixing and injection.
+
+    ``mix()`` applies GemmaRMSNorm per HC stream and projects through a
+    low-rank sigmoid gate to produce a single block input. ``combine()``
+    injects the block output back into each stream through a learned
+    per-stream injection weight.
+
+    This implementation uses only PyTorch operators. Tensor-parallel
+    collectives are supplied by its caller.
+    """
+
+    def __init__(
+        self,
+        config: HyperConnectionConfig,
+        layer_idx: int | None = None,
+        role: str | None = None,
+        use_mix: bool = True,
+        use_combine: bool = True,
+    ) -> None:
+        super().__init__(config, layer_idx, role)
+        norm_size = (
+            self.hyper_hidden_size if config.hc_per_branch_norm else config.hidden_size
+        )
+        group_size = config.hidden_size if config.hc_per_branch_norm else None
+        # Normalize each H-sized HC stream independently while retaining a
+        # separate affine weight for every element of the HC*H layout.
+        self.hc_norm = GroupedGemmaRMSNorm(
+            norm_size,
+            eps=config.rms_norm_eps,
+            group_size=group_size,
+            dtype=config.params_dtype,
+        )
+
+        # -- raw Linear weights (checkpoint-compatible) ----------------------
+        if use_mix:
+            self.input_mix_weight_down = nn.Linear(
+                self.hyper_hidden_size,
+                config.hc_lowrank,
+                bias=False,
+                dtype=config.params_dtype,
+            )
+            self.input_mix_weight_up = nn.Linear(
+                config.hc_lowrank,
+                self.hyper_hidden_size,
+                bias=False,
+                dtype=config.params_dtype,
+            )
+        if use_combine:
+            self.block_inject_weight = nn.Linear(
+                self.hyper_hidden_size,
+                self.hc_count,
+                bias=False,
+                dtype=config.params_dtype,
+            )
+
+    def _normalize(self, hyper_input: torch.Tensor) -> torch.Tensor:
+        if self.config.hc_per_branch_norm:
+            return self.hc_norm(hyper_input)
+        return self.hc_norm(
+            hyper_input.unflatten(-1, (self.hc_count, self.hidden_size))
+        ).flatten(-2)
+
+    def mix(
+        self, hyper_input: torch.Tensor
+    ) -> tuple[torch.Tensor, tuple[torch.Tensor, torch.Tensor]]:
+        """Mix: RMSNorm -> low-rank gate -> gated mean."""
+        assert hyper_input.shape[-1] == self.hc_count * self.hidden_size
+        if not hasattr(self, "input_mix_weight_down"):
+            raise RuntimeError("mix was disabled for this hyper-connection")
+        hyper_input_normed = self._normalize(hyper_input)
+        # Gate — original mix order: linear+silu then linear+sigmoid.
+        gate = F.silu(
+            F.linear(hyper_input_normed, self.input_mix_weight_down.weight)
+            / self.hc_count
+        )
+        gate = torch.sigmoid(F.linear(gate, self.input_mix_weight_up.weight)).unflatten(
+            -1, (self.hc_count, self.hidden_size)
+        )
+        mixed_input = (
+            gate * hyper_input_normed.unflatten(-1, (self.hc_count, self.hidden_size))
+        ).mean(dim=-2)
+        return mixed_input.to(hyper_input.dtype), (hyper_input, hyper_input_normed)
+
+    def combine(
+        self,
+        block_output: torch.Tensor,
+        residuals: tuple[torch.Tensor, torch.Tensor],
+    ) -> torch.Tensor:
+        if not hasattr(self, "block_inject_weight"):
+            raise RuntimeError("combine was disabled for this hyper-connection")
+        hyper_input, hyper_input_normed = residuals
+        assert hyper_input.shape[-1] == self.hc_count * self.hidden_size
+        assert block_output.shape[-1] == self.hidden_size
+        residual = hyper_input.unflatten(-1, (self.hc_count, self.hidden_size))
+        # The paired mix keeps its normalized hyper input so combine uses the
+        # same HC module's injection weight.
+        injection_weight = 2.0 * torch.sigmoid(
+            F.linear(hyper_input_normed, self.block_inject_weight.weight)
+            / self.hc_count
+        )
+        output = residual + block_output.unsqueeze(-2) * injection_weight.unsqueeze(-1)
+        return output.flatten(-2).to(hyper_input.dtype)
+
+
+__all__ = [
+    "GatedResidual",
+    "GroupedGemmaRMSNorm",
+    "HyperConnectionBase",
+    "HyperConnectionConfig",
+]

--- a/vllm_ascend/models/qwen4_exp/common/ple.py
+++ b/vllm_ascend/models/qwen4_exp/common/ple.py
@@ -1,0 +1,75 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Common Qwen4Exp PLE helpers."""
+
+from dataclasses import dataclass
+
+import torch
+
+
+@dataclass(frozen=True)
+class PLEShardOverlap:
+    """Source and destination slices for one checkpoint embedding shard."""
+
+    source_start: int
+    destination_start: int
+    row_count: int
+
+
+def compute_ple_shard_overlap(
+    *,
+    checkpoint_start: int,
+    checkpoint_rows: int,
+    tp_start: int,
+    tp_end: int,
+) -> PLEShardOverlap | None:
+    """Compute the overlap of a checkpoint shard and one TP vocabulary range."""
+
+    if checkpoint_start < 0 or checkpoint_rows < 0:
+        raise ValueError("checkpoint shard bounds must be non-negative")
+    if tp_start < 0 or tp_end < tp_start:
+        raise ValueError("invalid TP vocabulary range")
+    checkpoint_end = checkpoint_start + checkpoint_rows
+    overlap_start = max(checkpoint_start, tp_start)
+    overlap_end = min(checkpoint_end, tp_end)
+    if overlap_start >= overlap_end:
+        return None
+    return PLEShardOverlap(
+        source_start=overlap_start - checkpoint_start,
+        destination_start=overlap_start - tp_start,
+        row_count=overlap_end - overlap_start,
+    )
+
+
+def copy_ple_embedding_shard_(
+    destination: torch.Tensor,
+    loaded_weight: torch.Tensor,
+    *,
+    checkpoint_start: int,
+    tp_start: int,
+    tp_end: int,
+) -> int:
+    """Copy the overlapping rows of a PLE checkpoint shard into a TP table."""
+
+    if destination.ndim == 0 or loaded_weight.ndim != destination.ndim:
+        raise ValueError("destination and loaded weight must have matching ranks")
+    if destination.shape[1:] != loaded_weight.shape[1:]:
+        raise ValueError(
+            "embedding shard dimensions do not match: "
+            f"{tuple(destination.shape[1:])} != {tuple(loaded_weight.shape[1:])}"
+        )
+    if destination.shape[0] < tp_end - tp_start:
+        raise ValueError("destination does not cover the requested TP range")
+    overlap = compute_ple_shard_overlap(
+        checkpoint_start=checkpoint_start,
+        checkpoint_rows=loaded_weight.shape[0],
+        tp_start=tp_start,
+        tp_end=tp_end,
+    )
+    if overlap is None:
+        return 0
+    source = loaded_weight.narrow(0, overlap.source_start, overlap.row_count)
+    target = destination.narrow(0, overlap.destination_start, overlap.row_count)
+    with torch.no_grad():
+        target.copy_(source.to(device=target.device, dtype=target.dtype))
+    return overlap.row_count

--- a/vllm_ascend/models/qwen4_exp/common/qsa_cache.py
+++ b/vllm_ascend/models/qwen4_exp/common/qsa_cache.py
@@ -1,0 +1,821 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Paged side-cache ownership and metadata for Qwen4Exp QSA.
+
+Each QSA layer keeps a fixed circular buffer of raw index keys (the
+compressor state) and one compressed key. MRoPE models pack exact three-axis
+positions beside the raw keys; text models derive group positions from
+logical positions. The compressor state uses one block per request, while
+the compressed owner uses ``MLAAttentionSpec.compress_ratio`` so its block
+table follows the main KV-cache lifecycle. Their physical tensor storage is
+shared by the generic cache-layout planner.
+"""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+from functools import cache
+from typing import ClassVar
+
+import torch
+from torch import nn
+from vllm.config import CacheConfig, VllmConfig
+from vllm.config.cache import CacheDType
+from vllm.model_executor.layers.attention_layer_base import AttentionLayerBase
+from vllm.platforms import current_platform
+from vllm.triton_utils import HAS_TRITON, tl, triton
+from vllm.utils.math_utils import cdiv
+from vllm.v1.attention.backend import (
+    AttentionBackend,
+    AttentionCGSupport,
+    AttentionMetadata,
+    AttentionMetadataBuilder,
+    CommonAttentionMetadata,
+)
+from vllm.v1.attention.backends.utils import PAD_SLOT_ID
+from vllm.v1.kv_cache_interface import (
+    AttentionSpec,
+    KVCacheSpec,
+    MLAAttentionSpec,
+)
+
+from vllm_ascend.core.kv_cache_interface import AscendCircularBufferSpec
+
+
+def canonical_qsa_rope_positions(positions: torch.Tensor) -> torch.Tensor:
+    """Return exact per-token positions as ``[tokens, 1, 3]`` int64 rows."""
+
+    if positions.ndim == 1:
+        positions = positions.unsqueeze(0).expand(3, -1)
+    elif positions.ndim != 2 or positions.shape[0] not in (1, 3):
+        raise ValueError("QSA RoPE positions must be [tokens] or [1|3, tokens]")
+    if positions.shape[0] == 1:
+        positions = positions.expand(3, -1)
+    return positions.transpose(0, 1).unsqueeze(1).to(torch.int64)
+
+
+def _logical_positions(
+    query_start_loc: torch.Tensor,
+    seq_lens: torch.Tensor,
+    token_to_req: torch.Tensor,
+    num_tokens: int,
+) -> torch.Tensor:
+    if num_tokens == 0:
+        return seq_lens.new_empty((0,), dtype=torch.int64)
+    arange = torch.arange(num_tokens, device=query_start_loc.device)
+    requests = token_to_req[:num_tokens].long()
+    query_lens = torch.diff(query_start_loc)
+    within_query = arange - query_start_loc.index_select(0, requests)
+    return (
+        seq_lens.index_select(0, requests).long()
+        - query_lens.index_select(0, requests).long()
+        + within_query.long()
+    )
+
+
+def _logical_to_physical_qsa_slots(
+    block_table: torch.Tensor,
+    request_indices: torch.Tensor,
+    logical_positions: torch.Tensor,
+    block_size: int,
+) -> torch.Tensor:
+    if block_size <= 0:
+        raise ValueError("QSA cache block size must be positive")
+    if block_table.ndim != 2:
+        raise ValueError("QSA block table must be two-dimensional")
+    if request_indices.shape != logical_positions.shape:
+        request_indices = torch.broadcast_to(request_indices, logical_positions.shape)
+
+    requests = request_indices.to(device=block_table.device, dtype=torch.long)
+    positions = logical_positions.to(device=block_table.device, dtype=torch.long)
+    valid = (requests >= 0) & (requests < block_table.shape[0]) & (positions >= 0)
+    logical_blocks = torch.div(
+        positions.clamp_min(0), block_size, rounding_mode="floor"
+    )
+    valid &= logical_blocks < block_table.shape[1]
+    safe_requests = requests.clamp(0, max(block_table.shape[0] - 1, 0))
+    safe_blocks = logical_blocks.clamp(0, max(block_table.shape[1] - 1, 0))
+    if not all(block_table.shape):
+        return torch.full_like(positions, PAD_SLOT_ID)
+    physical_blocks = block_table[safe_requests, safe_blocks].long()
+    valid &= physical_blocks >= 0
+    slots = physical_blocks * block_size + positions.remainder(block_size)
+    return torch.where(valid, slots, PAD_SLOT_ID)
+
+
+def circular_qsa_slot_mapping(
+    block_table: torch.Tensor,
+    token_to_req: torch.Tensor,
+    logical_positions: torch.Tensor,
+    compressor_state_size: int,
+    query_start_loc: torch.Tensor | None = None,
+    out: torch.Tensor | None = None,
+) -> torch.Tensor:
+    """Map each request to its fixed physical block as a circular token ring."""
+
+    if compressor_state_size <= 0:
+        raise ValueError("QSA circular buffer size must be positive")
+    if block_table.ndim != 2:
+        raise ValueError("QSA block table must be two-dimensional")
+
+    requests = token_to_req.to(device=block_table.device, dtype=torch.long)
+    positions = logical_positions.to(device=block_table.device, dtype=torch.long)
+    if not all(block_table.shape):
+        slots = torch.full_like(positions, PAD_SLOT_ID)
+    else:
+        valid = (requests >= 0) & (requests < block_table.shape[0]) & (positions >= 0)
+        safe_requests = requests.clamp(0, block_table.shape[0] - 1)
+        physical_blocks = block_table[safe_requests, 0].long()
+        valid &= physical_blocks >= 0
+        slots = physical_blocks * compressor_state_size + positions.remainder(
+            compressor_state_size
+        )
+        slots = torch.where(valid, slots, PAD_SLOT_ID)
+
+    if query_start_loc is not None:
+        if query_start_loc.ndim != 1 or query_start_loc.shape[0] < 2:
+            raise ValueError("QSA query starts must contain a terminal offset")
+        query_start_loc = query_start_loc.to(block_table.device)
+        num_requests = query_start_loc.shape[0] - 1
+        safe_requests = requests.clamp(0, num_requests - 1)
+        request_ends = query_start_loc.index_select(0, safe_requests + 1)
+        rows = torch.arange(slots.numel(), device=slots.device)
+        keep = (
+            (requests >= 0)
+            & (requests < num_requests)
+            & (rows + compressor_state_size >= request_ends)
+        )
+        slots = torch.where(keep, slots, PAD_SLOT_ID)
+
+    slots = slots.to(torch.int64)
+    if out is not None:
+        out.fill_(PAD_SLOT_ID)
+        out[: slots.numel()].copy_(slots)
+        return out[: slots.numel()]
+    return slots
+
+
+def compressed_qsa_slot_mapping(
+    block_table: torch.Tensor,
+    token_to_req: torch.Tensor,
+    logical_positions: torch.Tensor,
+    storage_block_size: int,
+    compress_ratio: int,
+    out: torch.Tensor | None = None,
+) -> torch.Tensor:
+    """Build boundary-only slots for an ``MLAAttentionSpec`` QSA cache."""
+
+    if storage_block_size <= 0 or compress_ratio <= 0:
+        raise ValueError("QSA block size and compression ratio must be positive")
+    compressed_positions = torch.div(
+        logical_positions.clamp_min(0), compress_ratio, rounding_mode="floor"
+    )
+    slots = _logical_to_physical_qsa_slots(
+        block_table,
+        token_to_req,
+        compressed_positions,
+        storage_block_size,
+    )
+    valid = (logical_positions >= 0) & (
+        (logical_positions + 1).remainder(compress_ratio) == 0
+    )
+    slots = torch.where(valid, slots, PAD_SLOT_ID).to(torch.int64)
+    if out is not None:
+        out.fill_(PAD_SLOT_ID)
+        out[: slots.numel()].copy_(slots)
+        return out[: slots.numel()]
+    return slots
+
+
+@cache
+def _metadata_launch_pdl() -> bool:
+    return current_platform.is_arch_support_pdl()
+
+
+@triton.jit(
+    do_not_specialize=[
+        "num_reqs",
+        "num_mapped_tokens",
+        "num_tokens",
+        "max_num_work",
+        "num_search_steps",
+        "work_search_steps",
+    ]
+)
+def _build_qsa_metadata_kernel(
+    query_start_loc_ptr,
+    seq_lens_ptr,
+    common_slot_mapping_ptr,
+    block_table_ptr,
+    token_to_req_ptr,
+    logical_positions_ptr,
+    slot_mapping_ptr,
+    k_work_metadata_ptr,
+    block_table_stride_0: tl.constexpr,
+    block_table_stride_1: tl.constexpr,
+    num_reqs,
+    num_mapped_tokens,
+    num_tokens,
+    max_num_work,
+    num_search_steps,
+    work_search_steps,
+    storage_block_size: tl.constexpr,
+    compress_ratio: tl.constexpr,
+    circular_buffer_size: tl.constexpr,
+    num_block_table_columns: tl.constexpr,
+    launch_pdl: tl.constexpr,
+    TOKEN_BLOCK_SIZE: tl.constexpr,
+    REQUEST_SCAN_SIZE: tl.constexpr,
+    WORK_BLOCK_SIZE: tl.constexpr,
+):
+    if launch_pdl:
+        tl.extra.cuda.gdc_wait()
+
+    pid = tl.program_id(0)
+    token_idx = pid * TOKEN_BLOCK_SIZE + tl.arange(0, TOKEN_BLOCK_SIZE)
+    store_mask = token_idx < num_tokens
+    mapped = token_idx < num_mapped_tokens
+    search_token_idx = tl.minimum(token_idx, num_mapped_tokens - 1)
+    request_idx = tl.zeros((TOKEN_BLOCK_SIZE,), tl.int32)
+    # Find the last query start at or before each token. The dynamic loop avoids
+    # compiling a kernel variant for every ceil(log2(num_reqs)).
+    for step in tl.range(0, num_search_steps):
+        candidate = request_idx + (1 << (num_search_steps - step - 1))
+        valid_candidate = candidate < num_reqs
+        candidate_start = tl.load(
+            query_start_loc_ptr + candidate,
+            mask=valid_candidate,
+            other=num_mapped_tokens + 1,
+        )
+        advance = valid_candidate & (candidate_start <= search_token_idx)
+        request_idx = tl.where(advance, candidate, request_idx)
+    query_start = tl.load(query_start_loc_ptr + request_idx, mask=mapped, other=0)
+    query_end = tl.load(query_start_loc_ptr + request_idx + 1, mask=mapped, other=0)
+    seq_len = tl.load(seq_lens_ptr + request_idx, mask=mapped, other=0)
+    logical_position = seq_len - (query_end - query_start) + token_idx - query_start
+    logical_position = tl.where(mapped, logical_position, -1)
+    tl.store(
+        token_to_req_ptr + token_idx,
+        tl.where(mapped, request_idx, 0),
+        mask=store_mask,
+    )
+    tl.store(
+        logical_positions_ptr + token_idx,
+        logical_position,
+        mask=store_mask,
+    )
+
+    # circular_buffer_size is constexpr, so each builder instance compiles out
+    # the other QSA cache owner's slot-mapping rule.
+    if circular_buffer_size > 0:
+        valid = (
+            mapped
+            & (logical_position >= 0)
+            & (token_idx + circular_buffer_size >= query_end)
+            & (num_block_table_columns > 0)
+        )
+        physical_block = tl.load(
+            block_table_ptr + request_idx * block_table_stride_0,
+            mask=valid,
+            other=-1,
+        )
+        valid &= physical_block >= 0
+        slot = physical_block * circular_buffer_size + (
+            logical_position % circular_buffer_size
+        )
+    elif compress_ratio != 1:
+        compressed_position = tl.maximum(logical_position, 0) // compress_ratio
+        logical_block = compressed_position // storage_block_size
+        valid = (
+            mapped
+            & (logical_position >= 0)
+            & ((logical_position + 1) % compress_ratio == 0)
+            & (logical_block < num_block_table_columns)
+        )
+        physical_block = tl.load(
+            block_table_ptr
+            + request_idx * block_table_stride_0
+            + logical_block * block_table_stride_1,
+            mask=valid,
+            other=-1,
+        )
+        valid &= physical_block >= 0
+        valid &= (
+            tl.load(common_slot_mapping_ptr + token_idx, mask=mapped, other=-1) >= 0
+        )
+        slot = physical_block * storage_block_size + (
+            compressed_position % storage_block_size
+        )
+    if (circular_buffer_size > 0) or (compress_ratio != 1):
+        tl.store(
+            slot_mapping_ptr + token_idx,
+            tl.where(valid, slot, -1),
+            mask=store_mask,
+        )
+    work_tile_start = pid * WORK_BLOCK_SIZE
+    has_work_tile = work_tile_start < max_num_work
+    if k_work_metadata_ptr is not None and has_work_tile:
+        # Every work CTA builds the request prefix in registers. Recomputing this
+        # small vector lets CTAs write disjoint work tiles without a grid barrier.
+        requests = tl.arange(0, REQUEST_SCAN_SIZE)
+        valid_request = requests < num_reqs
+        request_query_start = tl.load(
+            query_start_loc_ptr + requests, mask=valid_request, other=0
+        )
+        request_query_end = tl.load(
+            query_start_loc_ptr + requests + 1, mask=valid_request, other=0
+        )
+        request_seq_len = tl.load(seq_lens_ptr + requests, mask=valid_request, other=0)
+        request_query_len = request_query_end - request_query_start
+        chunk_start = request_seq_len - request_query_len
+        num_groups = request_seq_len // compress_ratio - chunk_start // compress_ratio
+        # Nonempty requests need one item even without a completed compression
+        # group because work item zero also commits the current raw-K suffix.
+        work_counts = tl.where(request_query_len > 0, tl.maximum(num_groups, 1), 0)
+        work_ends = tl.cumsum(tl.where(valid_request, work_counts, 0), axis=0)
+        total_work = tl.sum(tl.where(valid_request, work_counts, 0), axis=0)
+        work_offsets = tl.arange(0, WORK_BLOCK_SIZE)
+        work = work_tile_start + work_offsets
+        in_bounds = work < max_num_work
+        active = in_bounds & (work < total_work)
+        request = tl.zeros((WORK_BLOCK_SIZE,), dtype=tl.int32)
+        # Request zero starts at zero for every active work item. Descending
+        # steps find the last request starting at or before this item.
+        for step_idx in tl.range(0, work_search_steps):
+            step = 1 << (work_search_steps - step_idx - 1)
+            candidate = request + step
+            valid_candidate = candidate < num_reqs
+            candidate_start = tl.gather(work_ends, candidate - 1, 0)
+            advance = active & valid_candidate & (candidate_start <= work)
+            request = tl.where(advance, candidate, request)
+
+        if launch_pdl:
+            # Let the dependent grid start launch setup while these CTAs finish
+            # stores; its gdc_wait still orders access to the completed metadata.
+            tl.extra.cuda.gdc_launch_dependents()
+
+        owner_work_start = tl.gather(work_ends, tl.maximum(request - 1, 0), 0)
+        owner_work_start = tl.where(request == 0, 0, owner_work_start)
+        work_in_request = work - owner_work_start
+        tl.store(
+            k_work_metadata_ptr + work * 2,
+            tl.where(active, request, -1),
+            mask=in_bounds,
+        )
+        tl.store(
+            k_work_metadata_ptr + work * 2 + 1,
+            tl.where(active, work_in_request, -1),
+            mask=in_bounds,
+        )
+
+    else:
+        if launch_pdl:
+            # A dependent grid launches only after every CTA has signaled.
+            tl.extra.cuda.gdc_launch_dependents()
+
+
+def build_qsa_metadata_triton(
+    common_attn_metadata: CommonAttentionMetadata,
+    token_to_req_buffer: torch.Tensor,
+    logical_positions_buffer: torch.Tensor,
+    slot_mapping_buffer: torch.Tensor,
+    *,
+    storage_block_size: int,
+    compress_ratio: int,
+    circular_buffer_size: int = 0,
+    k_work_metadata_buffer: torch.Tensor | None = None,
+    request_capacity: int | None = None,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    """Build QSA side-cache and optional pre-indexer work metadata."""
+    num_tokens = common_attn_metadata.num_actual_tokens
+    num_mapped_tokens = int(common_attn_metadata.query_start_loc_cpu[-1])
+    token_to_req = token_to_req_buffer[:num_tokens]
+    logical_positions = logical_positions_buffer[:num_tokens]
+    slot_mapping = slot_mapping_buffer[:num_tokens]
+    num_reqs = common_attn_metadata.query_start_loc.shape[0] - 1
+    assert num_reqs > 0
+
+    if k_work_metadata_buffer is not None:
+        if request_capacity is None:
+            request_capacity = num_reqs
+        assert request_capacity >= num_reqs
+        # Pad for tl.arange while keeping the scan width stable across live batches.
+        request_scan_size = 1 << int(math.ceil(math.log2(request_capacity)))
+        max_num_work = k_work_metadata_buffer.shape[0]
+    else:
+        request_scan_size = 1
+        max_num_work = 0
+
+    if num_tokens == 0 and k_work_metadata_buffer is None:
+        return token_to_req, logical_positions, slot_mapping
+
+    block_table = common_attn_metadata.block_table_tensor
+    num_search_steps = int(math.ceil(math.log2(num_reqs)))
+    work_search_steps = int(math.ceil(math.log2(num_reqs)))
+    # The same grid covers token tiles and, for the compressed cache, work tiles.
+    num_token_blocks = cdiv(num_tokens, 128)
+    num_work_blocks = (
+        cdiv(max_num_work, 256) if k_work_metadata_buffer is not None else 0
+    )
+    _build_qsa_metadata_kernel[(max(num_token_blocks, num_work_blocks, 1),)](
+        common_attn_metadata.query_start_loc,
+        common_attn_metadata.seq_lens,
+        common_attn_metadata.slot_mapping,
+        block_table,
+        token_to_req,
+        logical_positions,
+        slot_mapping,
+        k_work_metadata_buffer,
+        block_table.stride(0),
+        block_table.stride(1),
+        num_reqs,
+        num_mapped_tokens,
+        num_tokens,
+        max_num_work,
+        num_search_steps,
+        work_search_steps,
+        storage_block_size,
+        compress_ratio,
+        circular_buffer_size,
+        block_table.shape[1],
+        launch_pdl=_metadata_launch_pdl(),
+        TOKEN_BLOCK_SIZE=128,
+        REQUEST_SCAN_SIZE=request_scan_size,
+        WORK_BLOCK_SIZE=256,
+        num_warps=4,
+    )
+    if circular_buffer_size == 0 and compress_ratio == 1:
+        slot_mapping = common_attn_metadata.slot_mapping[:num_tokens]
+    return token_to_req, logical_positions, slot_mapping
+
+
+def _build_qsa_metadata_torch(
+    common_attn_metadata: CommonAttentionMetadata,
+    token_to_req_buffer: torch.Tensor,
+    logical_positions_buffer: torch.Tensor,
+    slot_mapping_buffer: torch.Tensor,
+    *,
+    storage_block_size: int,
+    compress_ratio: int,
+    circular_buffer_size: int = 0,
+    k_work_metadata_buffer: torch.Tensor | None = None,
+    request_capacity: int | None = None,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    del request_capacity
+    num_tokens = common_attn_metadata.num_actual_tokens
+    num_mapped_tokens = int(common_attn_metadata.query_start_loc_cpu[-1])
+    logical_positions = logical_positions_buffer[:num_tokens]
+
+    token_to_req = common_attn_metadata.token_to_req_indices(token_to_req_buffer)[
+        :num_tokens
+    ]
+    logical_positions[:num_mapped_tokens].copy_(
+        _logical_positions(
+            common_attn_metadata.query_start_loc,
+            common_attn_metadata.seq_lens,
+            token_to_req[:num_mapped_tokens],
+            num_mapped_tokens,
+        )
+    )
+    if num_mapped_tokens < num_tokens:
+        logical_positions[num_mapped_tokens:].fill_(-1)
+    if circular_buffer_size > 0:
+        slot_mapping = circular_qsa_slot_mapping(
+            common_attn_metadata.block_table_tensor,
+            token_to_req,
+            logical_positions,
+            circular_buffer_size,
+            query_start_loc=common_attn_metadata.query_start_loc,
+            out=slot_mapping_buffer,
+        )
+    elif compress_ratio == 1:
+        slot_mapping = common_attn_metadata.slot_mapping[:num_tokens]
+    else:
+        slot_mapping = compressed_qsa_slot_mapping(
+            common_attn_metadata.block_table_tensor,
+            token_to_req,
+            logical_positions,
+            storage_block_size,
+            compress_ratio,
+            slot_mapping_buffer,
+        )
+        slot_mapping.masked_fill_(
+            common_attn_metadata.slot_mapping[:num_tokens] < 0, -1
+        )
+    if k_work_metadata_buffer is not None:
+        query_lens = (
+            common_attn_metadata.query_start_loc[1:]
+            - common_attn_metadata.query_start_loc[:-1]
+        )
+        chunk_starts = common_attn_metadata.seq_lens - query_lens
+        num_work_per_request = (
+            common_attn_metadata.seq_lens // compress_ratio
+            - chunk_starts // compress_ratio
+        )
+        num_work_per_request = torch.where(
+            query_lens > 0, num_work_per_request.clamp_min(1), 0
+        )
+        k_start_loc = torch.empty(
+            query_lens.shape[0] + 1,
+            dtype=torch.int32,
+            device=query_lens.device,
+        )
+        k_start_loc[0] = 0
+        torch.cumsum(num_work_per_request, 0, out=k_start_loc[1:])
+        work = torch.arange(
+            k_work_metadata_buffer.shape[0],
+            device=k_work_metadata_buffer.device,
+        )
+        requests = torch.searchsorted(k_start_loc[1:], work, right=True)
+        active = work < k_start_loc[-1]
+        work_in_request = (
+            work - k_start_loc[requests.clamp_max(query_lens.shape[0] - 1)]
+        )
+        k_work_metadata_buffer[:, 0].copy_(
+            torch.where(active, requests, -1).to(torch.int32)
+        )
+        k_work_metadata_buffer[:, 1].copy_(
+            torch.where(active, work_in_request, -1).to(torch.int32)
+        )
+    return token_to_req, logical_positions, slot_mapping
+
+
+# Resolve the fallback outside the per-step metadata hot path.
+build_qsa_metadata = (
+    build_qsa_metadata_triton if HAS_TRITON else _build_qsa_metadata_torch
+)
+
+
+@dataclass
+class QSAForwardMetadata(AttentionMetadata):
+    """Common per-forward metadata for one QSA side cache."""
+
+    block_table: torch.Tensor
+    slot_mapping: torch.Tensor
+    seq_lens: torch.Tensor
+    query_start_loc: torch.Tensor
+    token_to_req: torch.Tensor
+    logical_positions: torch.Tensor
+    k_work_metadata: torch.Tensor
+    num_actual_tokens: int
+    storage_block_size: int
+    compress_ratio: int
+
+
+class QSAMetadataBuilder(AttentionMetadataBuilder[QSAForwardMetadata]):
+    """Build QSA metadata from vLLM's cache-group-specific common metadata."""
+
+    _cudagraph_support: ClassVar[AttentionCGSupport] = AttentionCGSupport.UNIFORM_BATCH
+
+    def __init__(
+        self,
+        kv_cache_spec: AttentionSpec,
+        layer_names: list[str],
+        vllm_config: VllmConfig,
+        device: torch.device,
+    ) -> None:
+        super().__init__(kv_cache_spec, layer_names, vllm_config, device)
+        self.is_circular_buffer = isinstance(kv_cache_spec, AscendCircularBufferSpec)
+        if isinstance(kv_cache_spec, MLAAttentionSpec):
+            self.compress_ratio = kv_cache_spec.compress_ratio
+        else:
+            self.compress_ratio = 1
+        self.storage_block_size = kv_cache_spec.storage_block_size
+        max_tokens = vllm_config.scheduler_config.max_num_batched_tokens
+        self.token_to_req_buffer = torch.empty(
+            max_tokens, dtype=torch.int32, device=device
+        )
+        self.slot_mapping_buffer = torch.empty(
+            max_tokens, dtype=torch.int64, device=device
+        )
+        self.logical_positions_buffer = torch.empty(
+            max_tokens, dtype=torch.int64, device=device
+        )
+        max_requests = vllm_config.scheduler_config.max_num_seqs
+        self.request_capacity = max_requests
+        if not self.is_circular_buffer and self.compress_ratio != 1:
+            max_k_work = (
+                max_tokens + (self.compress_ratio - 1) * max_requests
+            ) // self.compress_ratio
+            self.k_work_metadata_buffer = torch.empty(
+                max_k_work, 2, dtype=torch.int32, device=device
+            )
+        else:
+            self.k_work_metadata_buffer = torch.empty(
+                0, 2, dtype=torch.int32, device=device
+            )
+
+    def build(
+        self,
+        common_prefix_len: int,
+        common_attn_metadata: CommonAttentionMetadata,
+        fast_build: bool = False,
+    ) -> QSAForwardMetadata:
+        del common_prefix_len, fast_build
+        num_tokens = common_attn_metadata.num_actual_tokens
+        build_k_work = not self.is_circular_buffer and self.compress_ratio != 1
+        k_work_metadata = self.k_work_metadata_buffer
+        request_capacity = None
+        if build_k_work:
+            num_requests = common_attn_metadata.query_start_loc.shape[0] - 1
+            request_capacity = self.request_capacity
+            max_num_work = (
+                num_tokens + (self.compress_ratio - 1) * num_requests
+            ) // self.compress_ratio
+            k_work_metadata = self.k_work_metadata_buffer[:max_num_work]
+        token_to_req, logical_positions, slot_mapping = build_qsa_metadata(
+            common_attn_metadata,
+            self.token_to_req_buffer,
+            self.logical_positions_buffer,
+            self.slot_mapping_buffer,
+            storage_block_size=self.storage_block_size,
+            compress_ratio=self.compress_ratio,
+            circular_buffer_size=(
+                self.kv_cache_spec.block_size if self.is_circular_buffer else 0
+            ),
+            k_work_metadata_buffer=k_work_metadata if build_k_work else None,
+            request_capacity=request_capacity,
+        )
+        return QSAForwardMetadata(
+            block_table=common_attn_metadata.block_table_tensor,
+            slot_mapping=slot_mapping,
+            seq_lens=common_attn_metadata.seq_lens,
+            query_start_loc=common_attn_metadata.query_start_loc,
+            token_to_req=token_to_req,
+            logical_positions=logical_positions,
+            k_work_metadata=k_work_metadata,
+            num_actual_tokens=num_tokens,
+            storage_block_size=self.storage_block_size,
+            compress_ratio=self.compress_ratio,
+        )
+
+
+class QSAStateBackend(AttentionBackend):
+    """Key-only dummy backend for out-of-band BF16 QSA side-cache operations."""
+
+    supported_dtypes: ClassVar[list[torch.dtype]] = [torch.bfloat16]
+    supported_kv_cache_dtypes: ClassVar[list[CacheDType]] = ["auto", "bfloat16"]
+
+    @staticmethod
+    def get_name() -> str:
+        return "QWEN4_EXP_EXP_QSA_STATE"
+
+    @staticmethod
+    def get_impl_cls():
+        raise NotImplementedError(
+            "QSA state caches run out-of-band and have no attention impl"
+        )
+
+    @staticmethod
+    def get_builder_cls() -> type[QSAMetadataBuilder]:
+        return QSAMetadataBuilder
+
+    @staticmethod
+    def get_kv_cache_shape(
+        num_blocks: int,
+        block_size: int,
+        num_kv_heads: int,
+        head_size: int,
+        cache_dtype_str: str = "auto",
+    ) -> tuple[int, ...]:
+        del cache_dtype_str
+        if num_kv_heads != 1:
+            raise ValueError("QSA side caches require exactly one KV head")
+        return (num_blocks, block_size, num_kv_heads, head_size)
+
+    @classmethod
+    def indexes_kv_by_block_stride(cls) -> bool:
+        return True
+
+    @staticmethod
+    def get_kv_cache_stride_order(
+        include_num_layers_dimension: bool = False,
+    ) -> tuple[int, ...]:
+        if include_num_layers_dimension:
+            return (0, 1, 2, 3, 4)
+        return (0, 1, 2, 3)
+
+
+class _QSAStateCache(nn.Module, AttentionLayerBase):
+    supports_dcp = False
+
+    def __init__(
+        self,
+        *,
+        head_size: int,
+        dtype: torch.dtype,
+        cache_config: CacheConfig,
+        prefix: str,
+        vllm_config: VllmConfig,
+        compress_ratio: int = 1,
+    ) -> None:
+        super().__init__()
+        if head_size <= 0:
+            raise ValueError("QSA cache head size must be positive")
+        if compress_ratio <= 0:
+            raise ValueError("QSA compression ratio must be positive")
+        if cache_config.block_size % compress_ratio:
+            raise ValueError(
+                "QSA cache block size must be divisible by the compression ratio"
+            )
+        self.head_size = head_size
+        self.dtype = dtype
+        self.cache_config = cache_config
+        self.prefix = prefix
+        self.compress_ratio = compress_ratio
+        self.kv_cache = torch.tensor([])
+
+        static_context = vllm_config.compilation_config.static_forward_context
+        if prefix in static_context:
+            raise ValueError(f"Duplicate layer name: {prefix}")
+        static_context[prefix] = self
+
+    def forward(self) -> None: ...
+
+    def get_attn_backend(self) -> type[AttentionBackend]:
+        return QSAStateBackend
+
+    def bind_kv_cache(self, kv_cache: torch.Tensor) -> None:
+        # vLLM 0.26 binds caches by assigning ``kv_cache`` directly and does
+        # not provide the newer AttentionLayerBase hook used by Qwen4Exp.
+        self.kv_cache = kv_cache
+
+
+class QSAKeyStateCache(_QSAStateCache):
+    """Raw BF16 key, optionally followed by exact int64 MRoPE positions."""
+
+    _BF16_PER_INT64 = 4
+    _NUM_ROPE_AXES = 3
+
+    def __init__(self, *, cache_rope_positions: bool = False, **kwargs) -> None:
+        key_head_size = int(kwargs.pop("head_size"))
+        self.key_head_size = key_head_size
+        self.cache_rope_positions = bool(cache_rope_positions)
+        self.rope_position_offset = (
+            (key_head_size + self._BF16_PER_INT64 - 1) // self._BF16_PER_INT64
+        ) * self._BF16_PER_INT64
+        storage_head_size = key_head_size
+        if self.cache_rope_positions:
+            storage_head_size = self.rope_position_offset + (
+                self._NUM_ROPE_AXES * self._BF16_PER_INT64
+            )
+        super().__init__(head_size=storage_head_size, **kwargs)
+
+    def bind_kv_cache(self, kv_cache: torch.Tensor) -> None:
+        if kv_cache.ndim != 4 or kv_cache.shape[2] != 1:
+            raise ValueError("QSA raw cache must be [blocks, block_size, 1, width]")
+        if kv_cache.dtype != torch.bfloat16 or kv_cache.shape[3] != self.head_size:
+            raise ValueError("QSA raw cache does not match its packed BF16 cache spec")
+        super().bind_kv_cache(kv_cache)
+        self.key_cache = kv_cache[..., : self.key_head_size]
+        if self.cache_rope_positions:
+            position_tail = kv_cache[..., self.rope_position_offset :]
+            self.rope_position_cache = position_tail.view(torch.int64)
+        else:
+            self.rope_position_cache = None
+
+    def get_kv_cache_spec(self, vllm_config: VllmConfig) -> KVCacheSpec:
+        # Hold the open group's committed keys plus every row a speculative
+        # step stores before acceptance is known, rounded up to whole groups so
+        # the ring divides the attention block size (it joins the LCM that sets
+        # the scheduler block size). Anything narrower lets a rejected draft row
+        # overwrite a committed key the next step needs to close the group.
+        span = self.compress_ratio + vllm_config.num_speculative_tokens
+        capacity = self.compress_ratio * cdiv(span, self.compress_ratio)
+        assert self.cache_config.block_size % capacity == 0, (
+            f"QSA ring capacity {capacity} must divide the attention block "
+            f"size {self.cache_config.block_size}"
+        )
+        return AscendCircularBufferSpec(
+            block_size=capacity,
+            num_kv_heads=1,
+            head_size=self.head_size,
+            dtype=self.dtype,
+        )
+
+
+class QSACompressedKeyCache(_QSAStateCache):
+    """Normalized, group-first-RoPE BF16 key at one row per complete group."""
+
+    def get_kv_cache_spec(self, vllm_config: VllmConfig) -> KVCacheSpec:
+        del vllm_config
+        return MLAAttentionSpec(
+            block_size=self.cache_config.block_size,
+            num_kv_heads=1,
+            head_size=self.head_size,
+            dtype=self.dtype,
+            compress_ratio=self.compress_ratio,
+        )
+
+
+__all__ = [
+    "QSACompressedKeyCache",
+    "QSAForwardMetadata",
+    "QSAKeyStateCache",
+    "QSAMetadataBuilder",
+    "QSAStateBackend",
+    "canonical_qsa_rope_positions",
+    "circular_qsa_slot_mapping",
+    "compressed_qsa_slot_mapping",
+]

--- a/vllm_ascend/models/qwen4_exp/config.py
+++ b/vllm_ascend/models/qwen4_exp/config.py
@@ -1,0 +1,266 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Qwen4Exp model configuration."""
+
+from typing import Any, ClassVar, cast
+
+from transformers import PretrainedConfig
+from transformers.models.qwen3_vl.configuration_qwen3_vl import (
+    Qwen3VLVisionConfig,
+)
+from vllm.transformers_utils.configs.qwen3_next import Qwen3NextConfig
+
+_QSA_CONFIG_FIELDS = (
+    "indexer_n_heads",
+    "indexer_kv_heads",
+    "indexer_head_dim",
+    "indexer_budget",
+    "indexer_compress_ratio",
+)
+
+
+class Qwen4ExpVisionConfig(Qwen3VLVisionConfig):
+    model_type = "qwen4_exp"
+    base_config_key = "vision_config"
+
+
+class Qwen4ExpTextConfig(Qwen3NextConfig):
+    model_type = "qwen4_exp_text"
+    base_config_key = "text_config"
+    keys_to_ignore_at_inference = ["past_key_values"]
+
+    def __init__(
+        self,
+        hc_count: int = 4,
+        hc_lowrank: int = 320,
+        ple_layer_ids: list[int] | None = None,
+        ple_embed_dim: int | None = None,
+        ple_conv_kernel_size: int = 4,
+        ngram_size: int = 3,
+        heads_per_ngram: int = 8,
+        ngram_vocab_size_base: int = 20_000_000,
+        make_ngram_vocab_size_divisible_by: int = 128,
+        output_gate_type: str = "sigmoid",
+        rope_parameters: dict[str, Any] | None = None,
+        layer_types: list[str] | None = None,
+        **kwargs: Any,
+    ) -> None:
+        if hc_count <= 1:
+            raise ValueError(f"Qwen4Exp requires hc_count > 1, got {hc_count}.")
+
+        if rope_parameters is not None:
+            if kwargs.get("rope_scaling") is None:
+                kwargs["rope_scaling"] = rope_parameters
+            if kwargs.get("rope_theta") is None and "rope_theta" in rope_parameters:
+                kwargs["rope_theta"] = rope_parameters["rope_theta"]
+            if (
+                kwargs.get("partial_rotary_factor") is None
+                and "partial_rotary_factor" in rope_parameters
+            ):
+                kwargs["partial_rotary_factor"] = rope_parameters[
+                    "partial_rotary_factor"
+                ]
+
+        rope_scaling = kwargs.get("rope_scaling")
+        rope_theta = kwargs.get("rope_theta", 10_000.0)
+        super().__init__(layer_types=layer_types, **kwargs)
+
+        normalized_rope_parameters = self.rope_parameters
+        self.rope_scaling = (
+            rope_scaling or rope_parameters or normalized_rope_parameters
+        )
+        self.rope_parameters = rope_parameters or normalized_rope_parameters
+        self.rope_theta = rope_theta
+
+        self.hc_count = hc_count
+        self.hc_lowrank = hc_lowrank
+        self.ple_layer_ids = ple_layer_ids or []
+        self.ple_embed_dim = (
+            self.hidden_size if ple_embed_dim is None else ple_embed_dim
+        )
+        self.ple_conv_kernel_size = ple_conv_kernel_size
+        self.ngram_size = ngram_size
+        self.heads_per_ngram = heads_per_ngram
+        self.ngram_vocab_size_base = ngram_vocab_size_base
+        self.make_ngram_vocab_size_divisible_by = make_ngram_vocab_size_divisible_by
+        self.output_gate_type = output_gate_type
+
+        self._validate_ple_config()
+        self._validate_ple_layer_ids()
+        self._validate_qsa_config()
+
+    def _validate_ple_config(self) -> None:
+        if self.hc_lowrank <= 0:
+            raise ValueError(f"hc_lowrank must be positive, got {self.hc_lowrank}")
+        if self.ngram_size < 2:
+            raise ValueError(f"ngram_size must be >= 2, got {self.ngram_size}")
+        if self.heads_per_ngram <= 0:
+            raise ValueError(
+                f"heads_per_ngram must be positive, got {self.heads_per_ngram}"
+            )
+        if self.ple_embed_dim <= 0:
+            raise ValueError(
+                f"ple_embed_dim must be positive, got {self.ple_embed_dim}"
+            )
+        ngram_heads = (self.ngram_size - 1) * self.heads_per_ngram
+        if self.ple_embed_dim % ngram_heads:
+            raise ValueError(
+                "ple_embed_dim must be divisible by total ngram heads: "
+                f"{self.ple_embed_dim} % {ngram_heads} != 0"
+            )
+        if self.ple_conv_kernel_size <= 0:
+            raise ValueError(
+                "ple_conv_kernel_size must be positive, got "
+                f"{self.ple_conv_kernel_size}"
+            )
+        if self.ngram_vocab_size_base <= 0:
+            raise ValueError("ngram_vocab_size_base must be positive")
+        if self.make_ngram_vocab_size_divisible_by <= 0:
+            raise ValueError("make_ngram_vocab_size_divisible_by must be positive")
+
+    def _validate_ple_layer_ids(self) -> None:
+        invalid = [
+            layer_id
+            for layer_id in self.ple_layer_ids
+            if not 1 <= int(layer_id) <= self.num_hidden_layers
+        ]
+        if invalid:
+            raise ValueError(
+                "ple_layer_ids are 1-based and must refer to an existing layer; "
+                f"got {invalid} for {self.num_hidden_layers} layers"
+            )
+
+    def _validate_qsa_config(self) -> None:
+        configured = {name: getattr(self, name, None) for name in _QSA_CONFIG_FIELDS}
+        if all(value is None for value in configured.values()):
+            return
+
+        missing = [name for name, value in configured.items() if value is None]
+        if missing:
+            raise ValueError(f"QSA config is missing required fields: {missing}")
+
+        values = {name: int(cast(int, value)) for name, value in configured.items()}
+        if any(value <= 0 for value in values.values()):
+            raise ValueError(f"QSA config values must be positive: {values}")
+        if values["indexer_kv_heads"] != 1:
+            raise ValueError("the QSA MQA operators require indexer_kv_heads=1")
+        if values["indexer_budget"] % values["indexer_compress_ratio"] != 0:
+            raise ValueError(
+                "indexer_budget must be divisible by indexer_compress_ratio"
+            )
+        block_topk = values["indexer_budget"] // values["indexer_compress_ratio"]
+        if block_topk not in (512, 2048):
+            raise ValueError(
+                "QSA requires indexer_budget / indexer_compress_ratio "
+                f"to be 512 or 2048, got {block_topk}"
+            )
+        rotary_dim = int(self.head_dim * self.partial_rotary_factor)
+        if rotary_dim > values["indexer_head_dim"]:
+            raise ValueError(
+                "QSA indexer_head_dim must cover the attention rotary "
+                f"dimension, got {values['indexer_head_dim']} < {rotary_dim}"
+            )
+
+    @property
+    def layers_block_type(self) -> list[str]:
+        return [
+            "attention" if layer_type == "full_attention" else layer_type
+            for layer_type in self.layer_types
+        ]
+
+    @property
+    def short_conv_layer_ids(self) -> list[int]:
+        if not self.ple_layer_ids:
+            return []
+        return sorted({int(layer_id) - 1 for layer_id in self.ple_layer_ids})
+
+    @property
+    def short_conv_state_shape(self) -> tuple[int, int] | None:
+        if not self.short_conv_layer_ids:
+            return None
+        ple_state_len = (self.ple_conv_kernel_size - 1) * self.ngram_size
+        ple_channels = self.hidden_size * self.hc_count
+        return ple_channels, ple_state_len
+
+    @property
+    def ngram_context_len(self) -> int:
+        if not self.ple_layer_ids:
+            return 0
+        return max(int(self.ngram_size) - 1, 0)
+
+
+class Qwen4ExpConfig(PretrainedConfig):
+    model_type = "qwen4_exp"
+    sub_configs: ClassVar[dict[str, type[PretrainedConfig]]] = {
+        "vision_config": Qwen4ExpVisionConfig,
+        "text_config": Qwen4ExpTextConfig,
+    }
+    keys_to_ignore_at_inference = ["past_key_values"]
+
+    def __init__(
+        self,
+        text_config: Qwen4ExpTextConfig | dict[str, Any] | None = None,
+        vision_config: Qwen4ExpVisionConfig | dict[str, Any] | None = None,
+        image_token_id: int = 248056,
+        video_token_id: int = 248057,
+        vision_start_token_id: int = 248053,
+        vision_end_token_id: int = 248054,
+        tie_word_embeddings: bool = False,
+        rope_parameters: dict[str, Any] | None = None,
+        **kwargs: Any,
+    ) -> None:
+        if text_config is not None:
+            kwargs.pop("split_ngram_parts", None)
+
+        text_kwargs = (
+            dict(kwargs)
+            if text_config is None
+            and "hidden_size" in kwargs
+            and "num_hidden_layers" in kwargs
+            else {}
+        )
+
+        if isinstance(vision_config, dict):
+            self.vision_config = self.sub_configs["vision_config"](**vision_config)
+        elif vision_config is None:
+            self.vision_config = self.sub_configs["vision_config"]()
+        else:
+            self.vision_config = vision_config
+
+        if isinstance(text_config, dict):
+            self.text_config = self.sub_configs["text_config"](**text_config)
+        elif text_config is None:
+            self.text_config = self.sub_configs["text_config"](**text_kwargs)
+        else:
+            self.text_config = text_config
+
+        self.image_token_id = image_token_id
+        self.video_token_id = video_token_id
+        self.vision_start_token_id = vision_start_token_id
+        self.vision_end_token_id = vision_end_token_id
+        self.rope_parameters = rope_parameters or getattr(
+            self.text_config, "rope_parameters", {}
+        )
+        super().__init__(**kwargs, tie_word_embeddings=tie_word_embeddings)
+
+
+def register_qwen4_exp_config() -> None:
+    """Register the plugin-owned configs with Transformers and vLLM."""
+    from transformers import AutoConfig
+    from vllm.transformers_utils import config as vllm_config_module
+
+    registrations = {
+        "qwen4_exp": Qwen4ExpConfig,
+        "qwen4_exp_text": Qwen4ExpTextConfig,
+    }
+    vllm_config_module._CONFIG_REGISTRY.update(registrations)
+    for model_type, config_cls in registrations.items():
+        AutoConfig.register(model_type, config_cls, exist_ok=True)
+
+
+__all__ = [
+    "Qwen4ExpConfig",
+    "Qwen4ExpTextConfig",
+    "Qwen4ExpVisionConfig",
+    "register_qwen4_exp_config",
+]

--- a/vllm_ascend/models/qwen4_exp/model.py
+++ b/vllm_ascend/models/qwen4_exp/model.py
@@ -1,0 +1,141 @@
+# Copyright (c) 2026 Huawei Technologies Co., Ltd. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Ascend wrappers for the upstream Qwen4Exp model implementation."""
+
+import sys
+import types
+
+import torch
+import vllm.envs as vllm_envs
+from torch import nn
+from vllm.config import VllmConfig
+from vllm.platforms import current_platform
+
+from vllm_ascend.ops.triton.qwen4_exp import hc as ascend_hc_ops
+from vllm_ascend.ops.triton.qwen4_exp import qsa as ascend_qsa_ops
+
+from .ops import (
+    grouped_gemma_rmsnorm,
+    hc_combine,
+    hc_combine_norm,
+    hc_gate_mix,
+    hc_silu,
+)
+from .ple_offload_layer import PleOffloadLayer
+
+# The vendored NVIDIA modules use relative imports for their platform kernels.
+# Bind those names to Ascend implementations before importing any model module.
+_PACKAGE = __package__
+sys.modules[f"{_PACKAGE}.nvidia.ops.hc"] = ascend_hc_ops
+sys.modules[f"{_PACKAGE}.nvidia.ops.qsa"] = ascend_qsa_ops
+
+from .nvidia import hyperconnection as upstream_hc  # noqa: E402
+
+# Keep the upstream model and weight loader authoritative. HyperConnection's
+# CUDA glue functions are module globals, so replace them before importing the
+# model classes that instantiate GatedResidual.
+upstream_hc.grouped_gemma_rmsnorm = grouped_gemma_rmsnorm
+upstream_hc.hc_combine = hc_combine
+upstream_hc.hc_combine_norm = hc_combine_norm
+upstream_hc.hc_gate_mix = hc_gate_mix
+upstream_hc.hc_silu = hc_silu
+
+
+def _raise_for_ple_cpu_offload() -> None:
+    if getattr(vllm_envs, "VLLM_PLE_CPU_OFFLOAD", False):
+        raise NotImplementedError(
+            "VLLM_PLE_CPU_OFFLOAD uses CUDA IPC stream semaphores and is not "
+            "supported on Ascend. Disable it to run Qwen3.8-Flash-Next."
+        )
+
+def _get_ascend_ple_device(cls: type[PleOffloadLayer]) -> torch.device:
+    del cls
+    _raise_for_ple_cpu_offload()
+    return torch.device(
+        current_platform.device_type,
+        torch.accelerator.current_device_index(),
+    )
+
+
+PleOffloadLayer.get_target_device = classmethod(_get_ascend_ple_device)
+
+
+# The NVIDIA model imports a Blackwell-only CuTe DSL GEMM hook eagerly. It is
+# an optional decode optimization and the standard vLLM linear path is the
+# correct Ascend fallback, so prevent that CUDA module from becoming a hard
+# import dependency while retaining the current upstream model definition.
+low_latency_compat = types.ModuleType(
+    "vllm_ascend.models.qwen4_exp.nvidia.low_latency_gemm"
+)
+
+
+def _keep_standard_linear_methods(module: nn.Module, dtype: torch.dtype) -> None:
+    del module, dtype
+
+
+low_latency_compat.enable_qwen4_exp_low_latency_gemm = _keep_standard_linear_methods
+sys.modules[low_latency_compat.__name__] = low_latency_compat
+
+
+from .nvidia import model as upstream_model  # noqa: E402
+from .qsa import AscendQwen4ExpQSAAttention  # noqa: E402
+
+upstream_model.Qwen4ExpQSAAttention = AscendQwen4ExpQSAAttention
+
+
+class AscendQwen4ExpModel(upstream_model.Qwen4ExpModel):
+    """Qwen4Exp backbone with Ascend-safe graph shape annotations."""
+
+    def __init__(self, *, vllm_config: VllmConfig, prefix: str = "") -> None:
+        super().__init__(vllm_config=vllm_config, prefix=prefix)
+        # With max_num_seqs=1 the PLE query-start buffer has a static length of
+        # two. Marking that length dynamic makes TorchDynamo reject the static
+        # specialization used by PLE during FULL_DECODE_ONLY graph capture.
+        dynamic_arg_dims = getattr(self, "_dynamic_arg_dims", None)
+        if dynamic_arg_dims is not None:
+            self._dynamic_arg_dims = {
+                name: dims for name, dims in dynamic_arg_dims.items() if name != "query_start_loc"
+            }
+
+
+# Qwen4ExpForCausalLM resolves this module global when it creates the backbone.
+upstream_model.Qwen4ExpModel = AscendQwen4ExpModel
+
+
+class AscendQwen4ExpForCausalLM(upstream_model.Qwen4ExpForCausalLM):
+    """Qwen3.8-Flash-Next text model using Ascend platform operators."""
+
+    @staticmethod
+    def get_model_state_cls() -> type:
+        from vllm_ascend.models.qwen4_exp_model_state import (
+            AscendQwen4ExpModelState,
+        )
+
+        return AscendQwen4ExpModelState
+
+
+class AscendQwen4ExpForConditionalGeneration(upstream_model.Qwen4ExpForConditionalGeneration):
+    """Qwen3.8-Flash-Next multimodal model using Ascend operators."""
+
+    get_model_state_cls = staticmethod(
+        AscendQwen4ExpForCausalLM.get_model_state_cls
+    )
+
+
+__all__ = [
+    "AscendQwen4ExpForCausalLM",
+    "AscendQwen4ExpForConditionalGeneration",
+    "AscendQwen4ExpModel",
+]

--- a/vllm_ascend/models/qwen4_exp/mtp.py
+++ b/vllm_ascend/models/qwen4_exp/mtp.py
@@ -38,6 +38,10 @@ class AscendQwen4ExpMultiTokenPredictor(upstream_mtp.Qwen4ExpMultiTokenPredictor
     ) -> torch.Tensor | tuple[torch.Tensor, torch.Tensor] | IntermediateTensors:
         hc_count = self.hc_count
         hidden_size = self.hidden_size
+        # The draft is text-only; M-RoPE rows are identical for text tokens.
+        if positions.ndim > 1:
+            positions = positions[0]
+
 
         # Ascend PP loads the local MTP drafter on the last target stage. It is
         # therefore the first logical draft stage even though the global PP
@@ -53,7 +57,9 @@ class AscendQwen4ExpMultiTokenPredictor(upstream_mtp.Qwen4ExpMultiTokenPredictor
             num_tokens = hidden_states.shape[0]
             hidden_states = hidden_states.view(num_tokens, hc_count, hidden_size)
             hidden_states = self.pre_fc_norm_hidden(hidden_states.flatten(-2)).view(num_tokens, hc_count, hidden_size)
-            hidden_states = self.fc_hidden(hidden_states)
+            hidden_states = self.fc_hidden(
+                hidden_states.reshape(-1, hidden_size)
+            ).view(num_tokens, hc_count, hidden_size)
             hidden_states = inputs_embeds.unsqueeze(-2) + hidden_states
             hidden_states = hidden_states.flatten(-2)
         else:

--- a/vllm_ascend/models/qwen4_exp/mtp.py
+++ b/vllm_ascend/models/qwen4_exp/mtp.py
@@ -1,0 +1,101 @@
+# Copyright (c) 2026 Huawei Technologies Co., Ltd. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Ascend wrapper for Qwen3.8-Flash-Next MTP."""
+
+import torch
+from vllm.distributed import get_pp_group
+from vllm.sequence import IntermediateTensors
+
+# Import the target wrapper first so the upstream decoder resolves Ascend QSA
+# and HyperConnection components before the MTP module is initialized.
+from . import model as _model  # noqa: F401
+from .nvidia import mtp as upstream_mtp
+
+
+class AscendQwen4ExpMultiTokenPredictor(upstream_mtp.Qwen4ExpMultiTokenPredictor):
+    """Qwen4Exp predictor adapted to Ascend's local PP drafter layout."""
+
+    def forward(
+        self,
+        input_ids: torch.Tensor | None,
+        positions: torch.Tensor,
+        hidden_states: torch.Tensor | None = None,
+        intermediate_tensors: IntermediateTensors | None = None,
+        inputs_embeds: torch.Tensor | None = None,
+        spec_step_idx: int = 0,
+    ) -> torch.Tensor | tuple[torch.Tensor, torch.Tensor] | IntermediateTensors:
+        hc_count = self.hc_count
+        hidden_size = self.hidden_size
+
+        # Ascend PP loads the local MTP drafter on the last target stage. It is
+        # therefore the first logical draft stage even though the global PP
+        # coordinator reports that it is not the first target stage.
+        if get_pp_group().is_first_rank or intermediate_tensors is None:
+            assert hidden_states is not None
+            if inputs_embeds is None:
+                assert input_ids is not None
+                inputs_embeds = self.embed_input_ids(input_ids)
+            inputs_embeds = self.pre_fc_norm_embedding(inputs_embeds)
+            inputs_embeds = self.fc_embedding(inputs_embeds)
+
+            num_tokens = hidden_states.shape[0]
+            hidden_states = hidden_states.view(num_tokens, hc_count, hidden_size)
+            hidden_states = self.pre_fc_norm_hidden(hidden_states.flatten(-2)).view(num_tokens, hc_count, hidden_size)
+            hidden_states = self.fc_hidden(hidden_states)
+            hidden_states = inputs_embeds.unsqueeze(-2) + hidden_states
+            hidden_states = hidden_states.flatten(-2)
+        else:
+            hidden_states = intermediate_tensors["hidden_states"]
+
+        current_step_idx = spec_step_idx % self.num_mtp_layers
+        layer = self.layers[current_step_idx]
+        hidden_states, block_output, injection = layer(
+            hidden_states=hidden_states,
+            prev_block_output=None,
+            prev_injection=None,
+            positions=positions,
+            input_ids=None,
+            query_start_loc=None,
+            ngram_context=None,
+        )
+        if not get_pp_group().is_last_rank:
+            hidden_states = layer.mlp_hyper_connection.combine(hidden_states, block_output, injection)
+            return IntermediateTensors({"hidden_states": hidden_states})
+
+        multi_hidden, sample_hidden_states, _ = self.hyper_connection_mixer.combine_and_mix(
+            hidden_states, block_output, injection
+        )
+        return sample_hidden_states, multi_hidden
+
+
+# Qwen4ExpMTP resolves this module global when constructing its predictor.
+upstream_mtp.Qwen4ExpMultiTokenPredictor = AscendQwen4ExpMultiTokenPredictor
+Qwen4ExpMTP = upstream_mtp.Qwen4ExpMTP
+
+
+class AscendQwen4ExpMTP(Qwen4ExpMTP):
+    """Qwen4Exp MTP model bound to the Ascend-patched decoder."""
+
+    def embed_input_ids(
+        self,
+        input_ids: torch.Tensor,
+        multimodal_embeddings=None,
+        is_multimodal: torch.Tensor | None = None,
+    ) -> torch.Tensor:
+        del multimodal_embeddings, is_multimodal
+        return self.model.embed_input_ids(input_ids)
+
+
+__all__ = ["AscendQwen4ExpMTP", "AscendQwen4ExpMultiTokenPredictor"]

--- a/vllm_ascend/models/qwen4_exp/nvidia/__init__.py
+++ b/vllm_ascend/models/qwen4_exp/nvidia/__init__.py
@@ -1,0 +1,2 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project

--- a/vllm_ascend/models/qwen4_exp/nvidia/hyperconnection.py
+++ b/vllm_ascend/models/qwen4_exp/nvidia/hyperconnection.py
@@ -1,0 +1,204 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""HyperConnection (Gated Residual) utilities — NVIDIA model variant.
+
+Implements the HyperConnection residual scheme proposed in
+"HyperConnections" (https://arxiv.org/abs/2409.19606). This NVIDIA variant
+delays each HC combine to the following HC mix boundary. HC glue kernels,
+including fused combine+RMSNorm, live in ``ops/hc.py``; projections remain
+standard vLLM Linear modules.
+
+Hidden states between layers have shape ``[..., HC*HS]`` with HS inner
+(HC outer, HS inner — checkpoint-native layout).
+
+Typical usage inside a transformer decoder layer::
+
+    self.attn_hc = GatedResidual(hc_config)
+
+    hidden_states, block_input, injection = self.attn_hc.mix(hidden_states)
+    attention_output = attention(block_input)
+    hidden_states, block_input, injection = self.mlp_hc.combine_and_mix(
+        hidden_states, attention_output, injection
+    )
+"""
+
+import torch
+from torch import nn
+from vllm.model_executor.layers.linear import (
+    MergedColumnParallelLinear,
+    ReplicatedLinear,
+)
+from vllm.model_executor.models.utils import maybe_prefix
+
+from ..common.hyperconnection import (
+    GroupedGemmaRMSNorm,
+    HyperConnectionConfig,
+)
+from .ops.hc import (
+    grouped_gemma_rmsnorm,
+    hc_combine,
+    hc_combine_norm,
+    hc_gate_mix,
+    hc_silu,
+)
+
+
+# ---------------------------------------------------------------------------
+# Gated-residual variant
+# ---------------------------------------------------------------------------
+class GatedResidual(nn.Module):
+    """Gated HyperConnection with learnable low-rank mixing and injection.
+
+    ``combine_and_mix()`` runs the pre pipeline (grouped GemmaRMSNorm -> merged
+    low-rank down+inject GEMM -> silu -> up GEMM -> sigmoid -> gated mean
+    over the HC streams). When passed a pending block output and an injection,
+    it fuses their residual combine with the RMSNorm. Final mixers use
+    ``use_combine=False`` and do not produce a new injection.
+
+    Weights: the norm owns the grouped GemmaRMSNorm affine; the projections
+    are vLLM Linear modules (merged replicated linear for down+inject), so
+    GEMM dispatch (e.g. the low-latency skinny GEMM) applies through the
+    standard quant_method mechanism.
+    """
+
+    def __init__(
+        self,
+        config: HyperConnectionConfig,
+        use_combine: bool = True,
+        prefix: str = "",
+    ) -> None:
+        super().__init__()
+        self.config = config
+        self.lora_rank = config.hc_lowrank
+        self.hc_count = config.hc_count
+        self.hidden_size = config.hidden_size
+        self.use_combine = use_combine
+
+        norm_size = (
+            self.hyper_hidden_size if config.hc_per_branch_norm else config.hidden_size
+        )
+        group_size = config.hidden_size if config.hc_per_branch_norm else None
+        # Normalize each H-sized HC stream independently while retaining a
+        # separate affine weight for every element of the HC*H layout.
+        self.hc_norm = GroupedGemmaRMSNorm(
+            norm_size,
+            eps=config.rms_norm_eps,
+            group_size=group_size,
+            dtype=config.params_dtype,
+        )
+
+        # -- vLLM Linear weights --------------------------------------------
+        # The merged skinny-GEMM shape is physically padded to 16 rows to ensure
+        # good alignment and performant implementation chosen by CuBLAS heuristics.
+        self.pad_size = (-(self.lora_rank + self.hc_count)) % 16 if use_combine else 0
+        if use_combine:
+            self.input_mix_weight_down_block_inject = MergedColumnParallelLinear(
+                self.hyper_hidden_size,
+                [self.lora_rank, self.hc_count]
+                + ([self.pad_size] if self.pad_size else []),
+                bias=False,
+                params_dtype=config.params_dtype,
+                quant_config=None,
+                prefix=maybe_prefix(prefix, "input_mix_weight_down_block_inject"),
+                return_bias=False,
+                disable_tp=True,
+            )
+        else:
+            self.input_mix_weight_down = ReplicatedLinear(
+                self.hyper_hidden_size,
+                self.lora_rank,
+                bias=False,
+                params_dtype=config.params_dtype,
+                quant_config=None,
+                prefix=maybe_prefix(prefix, "input_mix_weight_down"),
+                return_bias=False,
+            )
+        self.input_mix_weight_up = ReplicatedLinear(
+            self.lora_rank,
+            self.hyper_hidden_size,
+            bias=False,
+            params_dtype=config.params_dtype,
+            quant_config=None,
+            prefix=maybe_prefix(prefix, "input_mix_weight_up"),
+            return_bias=False,
+        )
+
+    def mix(
+        self, hidden_states: torch.Tensor
+    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor | None]:
+        xn = grouped_gemma_rmsnorm(
+            hidden_states,
+            self.hc_norm.weight,
+            self.config.rms_norm_eps,
+            self.hc_count,
+        )
+
+        if self.use_combine:
+            # produce injection logits for combine
+            split_sizes = [self.lora_rank, self.hc_count, self.pad_size]
+            down_and_injection = self.input_mix_weight_down_block_inject(xn)
+            lora, injection, _ = down_and_injection.split(split_sizes, dim=-1)
+        else:
+            lora = self.input_mix_weight_down(xn)
+            injection = None
+
+        lora = hc_silu(lora, self.hc_count)
+        gate = self.input_mix_weight_up(lora)  # [M, D]
+        block_input = hc_gate_mix(xn, gate, self.hc_count)
+
+        return hidden_states, block_input, injection
+
+    def combine_and_mix(
+        self,
+        hidden_states: torch.Tensor,
+        prev_block_output: torch.Tensor,
+        prev_injection: torch.Tensor,
+    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor | None]:
+        """Consume a pending combine, then prepare the next block input.
+
+        ``hidden_states`` is the multi-stream state from before the pending
+        block's mix. Its combine with ``block_output`` is fused with this
+        module's input RMSNorm.
+        """
+        hidden_states, xn = hc_combine_norm(
+            hidden_states,
+            prev_block_output,
+            prev_injection,
+            self.hc_norm.weight,
+            self.config.rms_norm_eps,
+            self.hc_count,
+        )
+
+        if self.use_combine:
+            # produce injection logits for combine
+            split_sizes = [self.lora_rank, self.hc_count, self.pad_size]
+            down_and_injection = self.input_mix_weight_down_block_inject(xn)
+            lora, injection, _ = down_and_injection.split(split_sizes, dim=-1)
+        else:
+            lora = self.input_mix_weight_down(xn)
+            injection = None
+
+        lora = hc_silu(lora, self.hc_count)
+        gate = self.input_mix_weight_up(lora)  # [M, D]
+        block_input = hc_gate_mix(xn, gate, self.hc_count)
+
+        return hidden_states, block_input, injection
+
+    def combine(
+        self,
+        hidden_states: torch.Tensor,
+        block_output: torch.Tensor,
+        injection: torch.Tensor,
+    ) -> torch.Tensor:
+        return hc_combine(hidden_states, block_output, injection, self.hc_count)
+
+    @property
+    def hyper_hidden_size(self) -> int:
+        return self.hc_count * self.hidden_size
+
+
+__all__ = [
+    "GatedResidual",
+    "GroupedGemmaRMSNorm",
+    "HyperConnectionConfig",
+]

--- a/vllm_ascend/models/qwen4_exp/nvidia/indexer_qsa.py
+++ b/vllm_ascend/models/qwen4_exp/nvidia/indexer_qsa.py
@@ -1,0 +1,369 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Qwen4Exp weight-free QSA indexer."""
+
+from __future__ import annotations
+
+from typing import cast
+
+import torch
+from torch import nn
+from vllm.config import VllmConfig
+from vllm.forward_context import get_forward_context
+from vllm.model_executor.layers.layernorm import GemmaRMSNorm
+from vllm.model_executor.layers.linear import ReplicatedLinear
+from vllm.model_executor.layers.quantization import QuantizationConfig
+from vllm.model_executor.layers.rotary_embedding.mrope import triton_mrope
+
+from vllm_ascend import envs
+from vllm_ascend.models.qwen4_exp.config import (
+    Qwen4ExpTextConfig,
+)
+
+from ..common.qsa_cache import (
+    QSACompressedKeyCache,
+    QSAForwardMetadata,
+    QSAKeyStateCache,
+    canonical_qsa_rope_positions,
+)
+from .ops.qsa_pre_indexer import qsa_pre_indexer
+
+
+def apply_qsa_rope(
+    rotary_emb: nn.Module,
+    positions: torch.Tensor,
+    tensor: torch.Tensor,
+) -> torch.Tensor:
+    """Apply the main attention's exact 1D/MRoPE composition to QSA heads."""
+
+    num_tokens, _, head_dim = tensor.shape
+    rotary_dim = rotary_emb.rotary_dim
+    cache = rotary_emb._match_cos_sin_cache_dtype(tensor)  # noqa: SLF001
+    cos_sin = cache[positions]
+    cos, sin = cos_sin.chunk(2, dim=-1)
+    if positions.ndim == 2:
+        shape = tensor.shape
+        args = (
+            tensor.reshape(num_tokens, -1),
+            tensor.new_empty((num_tokens, head_dim)),
+            cos,
+            sin,
+            rotary_emb.mrope_section,
+            head_dim,
+            rotary_dim,
+            rotary_emb.mrope_interleaved,
+        )
+        try:
+            tensor, _ = triton_mrope(*args, rotary_emb.is_neox_style)
+        except TypeError as exc:
+            if "takes 8 positional arguments" not in str(exc):
+                raise
+            tensor, _ = triton_mrope(*args)
+        return tensor.reshape(shape)
+
+    rotated = rotary_emb.apply_rotary_emb.forward_cuda(
+        tensor[..., :rotary_dim],
+        cos,
+        sin,
+    )
+    return torch.cat((rotated, tensor[..., rotary_dim:]), dim=-1)
+
+
+def _gemma_rmsnorm(
+    tensor: torch.Tensor, weight: torch.Tensor, eps: float
+) -> torch.Tensor:
+    normalized = tensor.float() * torch.rsqrt(
+        tensor.float().pow(2).mean(dim=-1, keepdim=True) + eps
+    )
+    return (normalized * (1.0 + weight.float())).to(tensor.dtype)
+
+
+def _supports_fused_pre_indexer(
+    rotary_emb: nn.Module,
+    head_dim: int,
+    num_kv_heads: int,
+    compress_ratio: int,
+) -> bool:
+    rotary_dim = int(rotary_emb.rotary_dim)
+    mrope_section = getattr(rotary_emb, "mrope_section", None)
+    return (
+        bool(getattr(rotary_emb, "is_neox_style", False))
+        and (
+            not mrope_section
+            or (
+                len(mrope_section) == 3
+                and sum(mrope_section) == rotary_dim // 2
+                and bool(getattr(rotary_emb, "mrope_interleaved", False))
+            )
+        )
+        and head_dim == 128
+        and rotary_dim == 64
+        and num_kv_heads == 1
+        and compress_ratio > 1
+        and compress_ratio & (compress_ratio - 1) == 0
+    )
+
+
+class QSAIndexer(nn.Module):
+    """Replicated Q/K projection plus paged, weight-free QSA selection.
+
+    ``prefix`` must be the checkpoint's indexer prefix, normally
+    ``model.layers.N.self_attn.indexer``.  Consequently the trainable names are
+    ``index_qk_proj``, ``q_layernorm`` and ``k_layernorm`` under that prefix.
+    """
+
+    def __init__(
+        self,
+        *,
+        vllm_config: VllmConfig,
+        config: Qwen4ExpTextConfig,
+        layer_id: int,
+        rotary_emb: nn.Module,
+        quant_config: QuantizationConfig | None = None,
+        prefix: str = "",
+    ) -> None:
+        super().__init__()
+        if vllm_config.cache_config is None:
+            raise ValueError("QSA requires a paged KV cache")
+        if vllm_config.model_config.dtype != torch.bfloat16:
+            raise NotImplementedError("Qwen4Exp QSA currently requires BF16")
+
+        self.layer_id = int(layer_id)
+        self.index_n_heads = int(config.indexer_n_heads)
+        self.index_kv_heads = int(config.indexer_kv_heads)
+        self.index_head_dim = int(config.indexer_head_dim)
+        self.token_topk = int(config.indexer_budget)
+        self.compress_ratio = int(config.indexer_compress_ratio)
+        self.rotary_emb = rotary_emb
+        self.use_fused_pre_indexer = _supports_fused_pre_indexer(
+            rotary_emb,
+            self.index_head_dim,
+            self.index_kv_heads,
+            self.compress_ratio,
+        ) and not envs.VLLM_ASCEND_FORCE_QSA_REFERENCE
+        self.prefix = prefix
+        # MTP step 0 selects the target-aligned rows; later steps reuse them
+        # while continuing to update the QSA side cache.
+        self.skip_topk = False
+
+        self.index_qk_proj = ReplicatedLinear(
+            int(config.hidden_size),
+            (self.index_n_heads + self.index_kv_heads) * self.index_head_dim,
+            bias=False,
+            quant_config=quant_config,
+            prefix=f"{prefix}.index_qk_proj" if prefix else "index_qk_proj",
+        )
+        self.q_layernorm = GemmaRMSNorm(
+            self.index_head_dim,
+            eps=float(getattr(config, "rms_norm_eps", 1e-6)),
+        )
+        self.k_layernorm = GemmaRMSNorm(
+            self.index_head_dim,
+            eps=float(getattr(config, "rms_norm_eps", 1e-6)),
+        )
+
+        cache_config = vllm_config.cache_config
+        cache_prefix = f"{prefix}." if prefix else ""
+        self.raw_key_cache = QSAKeyStateCache(
+            head_size=self.index_head_dim,
+            dtype=torch.bfloat16,
+            cache_rope_positions=vllm_config.model_config.uses_mrope,
+            prefix=f"{cache_prefix}raw_key_cache",
+            cache_config=cache_config,
+            compress_ratio=self.compress_ratio,
+            vllm_config=vllm_config,
+        )
+        self.compressed_key_cache = QSACompressedKeyCache(
+            head_size=self.index_head_dim,
+            dtype=torch.bfloat16,
+            compress_ratio=self.compress_ratio,
+            prefix=f"{cache_prefix}compressed_key_cache",
+            cache_config=cache_config,
+            vllm_config=vllm_config,
+        )
+
+    @property
+    def output_width(self) -> int:
+        return self.token_topk + self.compress_ratio - 1
+
+    def _metadata(
+        self,
+    ) -> tuple[QSAForwardMetadata, QSAForwardMetadata] | None:
+        metadata = get_forward_context().attn_metadata
+        if isinstance(metadata, list):
+            metadata = metadata[0]
+        if not isinstance(metadata, dict):
+            return None
+        raw = cast(QSAForwardMetadata, metadata[self.raw_key_cache.prefix])
+        compressed = cast(
+            QSAForwardMetadata, metadata[self.compressed_key_cache.prefix]
+        )
+        if raw.num_actual_tokens != compressed.num_actual_tokens:
+            raise RuntimeError("QSA side-cache metadata token counts disagree")
+        if not raw.logical_positions.is_cuda and (
+            not torch.equal(raw.logical_positions, compressed.logical_positions)
+        ):
+            raise RuntimeError("QSA side-cache metadata positions disagree")
+        return raw, compressed
+
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+        positions: torch.Tensor,
+        out: torch.Tensor | None = None,
+    ) -> torch.Tensor:
+        """Return fixed-width request-relative token indices padded with ``-1``."""
+
+        metadata = self._metadata()
+        if metadata is None:
+            # Preserve step-0 indices when later MTP steps reuse the buffer.
+            if self.skip_topk and out is not None:
+                return out
+            result = torch.full(
+                (hidden_states.shape[0], self.output_width),
+                -1,
+                dtype=torch.int32,
+                device=hidden_states.device,
+            )
+            if out is not None:
+                out.copy_(result)
+                return out
+            return result
+
+        from .ops.qsa import (
+            qsa_compress_groups_with_ratio,
+            qsa_select_paged_tokens,
+            qsa_store_cache_rows,
+        )
+
+        raw_metadata, compressed_metadata = metadata
+        num_tokens = raw_metadata.num_actual_tokens
+        hidden_states = hidden_states[:num_tokens]
+        positions = positions[..., :num_tokens]
+
+        # Q/K projection
+        projected_qk, _ = self.index_qk_proj(hidden_states)
+        projected_q, raw_keys = projected_qk.split(
+            (
+                self.index_n_heads * self.index_head_dim,
+                self.index_kv_heads * self.index_head_dim,
+            ),
+            dim=-1,
+        )
+        raw_key_state_cache = self.raw_key_cache
+        compressed_key_cache = self.compressed_key_cache.kv_cache
+
+        if self.use_fused_pre_indexer:
+            q = projected_q.new_empty(
+                num_tokens,
+                self.index_n_heads,
+                self.index_head_dim,
+            )
+            qsa_pre_indexer(
+                projected_q,
+                raw_keys,
+                positions,
+                self.rotary_emb.cos_sin_cache,
+                self.q_layernorm.weight,
+                self.k_layernorm.weight,
+                self.q_layernorm.variance_epsilon,
+                q,
+                raw_key_state_cache.kv_cache,
+                raw_metadata.slot_mapping,
+                raw_metadata.block_table,
+                raw_metadata.query_start_loc,
+                raw_metadata.logical_positions,
+                compressed_key_cache,
+                compressed_metadata.slot_mapping,
+                compressed_metadata.k_work_metadata,
+                compress_ratio=self.compress_ratio,
+                mrope_section=getattr(self.rotary_emb, "mrope_section", None),
+                rope_pos_offset=(
+                    raw_key_state_cache.rope_position_offset
+                    if raw_key_state_cache.rope_position_cache is not None
+                    else None
+                ),
+            )
+        else:
+            # Unfused reference path
+            q = projected_q.reshape(-1, self.index_n_heads, self.index_head_dim)
+            q = _gemma_rmsnorm(
+                q.reshape(-1, self.index_head_dim),
+                self.q_layernorm.weight,
+                self.q_layernorm.variance_epsilon,
+            ).reshape_as(q)
+            q = apply_qsa_rope(self.rotary_emb, positions, q)
+
+            raw_key_cache = raw_key_state_cache.key_cache
+            rope_position_cache = raw_key_state_cache.rope_position_cache
+            if rope_position_cache is None:
+                position_rows = raw_metadata.logical_positions.view(-1, 1, 1).expand(
+                    -1, 1, 3
+                )
+            else:
+                position_rows = canonical_qsa_rope_positions(positions).to(
+                    device=raw_key_cache.device
+                )
+            pooled, first_positions = qsa_compress_groups_with_ratio(
+                raw_keys.reshape(-1, 1, self.index_head_dim),
+                position_rows,
+                raw_key_cache,
+                raw_metadata.block_table,
+                raw_metadata.token_to_req,
+                raw_metadata.query_start_loc,
+                raw_metadata.logical_positions,
+                compressed_metadata.slot_mapping,
+                self.compress_ratio,
+                rope_position_cache,
+            )
+            compressed_keys = _gemma_rmsnorm(
+                pooled.reshape(-1, self.index_head_dim),
+                self.k_layernorm.weight,
+                self.k_layernorm.variance_epsilon,
+            ).reshape(-1, 1, self.index_head_dim)
+            if getattr(self.rotary_emb, "mrope_section", None):
+                first_positions = first_positions.transpose(0, 1)
+            else:
+                first_positions = first_positions[:, 0]
+            compressed_keys = apply_qsa_rope(
+                self.rotary_emb,
+                first_positions,
+                compressed_keys,
+            )
+            qsa_store_cache_rows(
+                compressed_key_cache,
+                compressed_metadata.slot_mapping,
+                compressed_keys,
+            )
+            qsa_store_cache_rows(
+                raw_key_cache,
+                raw_metadata.slot_mapping,
+                raw_keys,
+            )
+            if rope_position_cache is not None:
+                qsa_store_cache_rows(
+                    rope_position_cache,
+                    raw_metadata.slot_mapping,
+                    position_rows,
+                )
+
+        if self.skip_topk:
+            if out is None:
+                raise RuntimeError("QSA top-k reuse requires an output buffer")
+            return out
+
+        # Score compressed keys, select blocks, then expand them to token indices.
+        return qsa_select_paged_tokens(
+            q,
+            compressed_key_cache,
+            compressed_metadata.block_table,
+            compressed_metadata.token_to_req,
+            compressed_metadata.logical_positions,
+            compressed_metadata.seq_lens,
+            self.token_topk,
+            self.compress_ratio,
+            out,
+        )
+
+
+__all__ = ["QSAIndexer", "apply_qsa_rope"]

--- a/vllm_ascend/models/qwen4_exp/nvidia/low_latency_gemm.py
+++ b/vllm_ascend/models/qwen4_exp/nvidia/low_latency_gemm.py
@@ -1,0 +1,184 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Qwen4Exp decode GEMM selection on Blackwell.
+
+Dispatch follows Kimi-K3 and uses the local ``(N, K)`` shape and token count.
+Plans contain measured CUDA graph capture sizes; other token counts use the
+standard linear implementation.
+"""
+
+import torch
+import vllm.envs as envs
+from torch import nn
+from vllm.model_executor.kernels.linear.cute_dsl.skinny_gemm import (
+    SkinnyGemmConfig,
+    shape_dynamic_skinny_gemm,
+)
+from vllm.model_executor.layers.linear import LinearBase, UnquantizedLinearMethod
+from vllm.model_executor.layers.vocab_parallel_embedding import (
+    ParallelLMHead,
+    UnquantizedEmbeddingMethod,
+)
+from vllm.platforms import current_platform
+from vllm.utils.torch_utils import direct_register_custom_op
+
+QWEN4_EXP_GEMM_PLANS: dict[tuple[int, int], dict[int, SkinnyGemmConfig]] = {
+    # GDN fused QKVZ projection, TP=4.
+    (4096, 2560): {
+        1: SkinnyGemmConfig(1, 64, 4, k_unroll=4),
+        2: SkinnyGemmConfig(2, 64, 4, k_unroll=4),
+    },
+    # GDN and QSA output projections, TP=4.
+    (2560, 1536): {
+        1: SkinnyGemmConfig(1, 128, 2, k_unroll=2, vector_width=4),
+        2: SkinnyGemmConfig(2, 128, 2, k_unroll=2, vector_width=4),
+        4: SkinnyGemmConfig(4, 64, 2, k_unroll=2),
+    },
+    # GDN fused B/A projection, TP=4.
+    (24, 2560): {
+        1: SkinnyGemmConfig(1, 128, 2, k_unroll=4, vector_width=4),
+        2: SkinnyGemmConfig(2, 128, 2, k_unroll=4, vector_width=4),
+        4: SkinnyGemmConfig(4, 128, 2, k_unroll=4, vector_width=4),
+        8: SkinnyGemmConfig(8, 128, 1, k_unroll=4, vector_width=4),
+        16: SkinnyGemmConfig(16, 128, 1, k_unroll=4, vector_width=4),
+    },
+    # QSA fused QKV/gate projection, TP=4.
+    (3584, 2560): {
+        1: SkinnyGemmConfig(1, 128, 4, k_unroll=4, vector_width=4),
+        2: SkinnyGemmConfig(2, 64, 2, k_unroll=2),
+        4: SkinnyGemmConfig(4, 64, 2, k_unroll=2),
+    },
+    # QSA indexer Q/K projection, replicated in a TP=4 deployment.
+    (640, 2560): {
+        1: SkinnyGemmConfig(1, 128, 1, k_unroll=4, vector_width=4),
+        2: SkinnyGemmConfig(2, 128, 1, k_unroll=4, vector_width=4),
+        4: SkinnyGemmConfig(4, 128, 1, k_unroll=4, vector_width=4),
+        8: SkinnyGemmConfig(8, 128, 1, k_unroll=4, vector_width=4),
+    },
+    # Shared-expert fused gate/up projection, TP=4.
+    (320, 2560): {
+        1: SkinnyGemmConfig(1, 128, 2, k_unroll=4, vector_width=4),
+        2: SkinnyGemmConfig(2, 128, 2, k_unroll=4, vector_width=4),
+        4: SkinnyGemmConfig(4, 128, 2, k_unroll=4, vector_width=4),
+        8: SkinnyGemmConfig(8, 64, 1, k_unroll=4),
+        16: SkinnyGemmConfig(16, 128, 2, k_unroll=4, vector_width=4),
+    },
+    # LM head, TP=4.
+    (62080, 2560): {
+        1: SkinnyGemmConfig(1, 64, 4, k_unroll=2),
+        2: SkinnyGemmConfig(2, 32, 4, k_unroll=2),
+    },
+    # HC merged down/injection projection, replicated in a TP=4 deployment.
+    (336, 10240): {
+        1: SkinnyGemmConfig(1, 128, 1, static_k=10240),
+        2: SkinnyGemmConfig(2, 128, 1, static_k=10240),
+        4: SkinnyGemmConfig(4, 128, 2, static_k=10240),
+        8: SkinnyGemmConfig(8, 128, 1, k_unroll=4),
+    },
+}
+
+
+def _is_sm103() -> bool:
+    return current_platform.is_device_capability((10, 3))
+
+
+def _is_packed_row_major(tensor: torch.Tensor) -> bool:
+    return tensor.dim() == 2 and tensor.stride() == (tensor.shape[1], 1)
+
+
+def _runtime_ok(x: torch.Tensor, weight: torch.Tensor) -> bool:
+    return (
+        not envs.VLLM_BATCH_INVARIANT
+        and _is_packed_row_major(x)
+        and _is_packed_row_major(weight)
+        and x.dtype == torch.bfloat16
+        and weight.dtype == torch.bfloat16
+        and x.is_cuda
+        and weight.is_cuda
+        and x.device == weight.device
+        and x.shape[1] == weight.shape[1]
+    )
+
+
+class _Qwen4ExpLowLatencyApply:
+    def apply(
+        self,
+        layer: nn.Module,
+        x: torch.Tensor,
+        bias: torch.Tensor | None = None,
+    ) -> torch.Tensor:
+        if bias is None and not envs.VLLM_BATCH_INVARIANT:
+            return torch.ops.vllm.qwen4_exp_low_latency_gemm(x, layer.weight)
+        return super().apply(layer, x, bias)  # type: ignore[misc]
+
+
+class Qwen4ExpLowLatencyLinearMethod(_Qwen4ExpLowLatencyApply, UnquantizedLinearMethod):
+    pass
+
+
+class Qwen4ExpLowLatencyEmbeddingMethod(
+    _Qwen4ExpLowLatencyApply, UnquantizedEmbeddingMethod
+):
+    pass
+
+
+def _qwen4_exp_low_latency_gemm(x: torch.Tensor, weight: torch.Tensor) -> torch.Tensor:
+    plan = QWEN4_EXP_GEMM_PLANS.get((weight.shape[0], weight.shape[1]))
+    config = None if plan is None else plan.get(x.shape[0])
+    if (
+        config is not None
+        and _runtime_ok(x, weight)
+        and shape_dynamic_skinny_gemm.is_available()
+    ):
+        return shape_dynamic_skinny_gemm(x, weight, config)
+    return torch.nn.functional.linear(x, weight)
+
+
+def _qwen4_exp_low_latency_gemm_fake(
+    x: torch.Tensor, weight: torch.Tensor
+) -> torch.Tensor:
+    return x.new_empty((*x.shape[:-1], weight.shape[0]))
+
+
+direct_register_custom_op(
+    op_name="qwen4_exp_low_latency_gemm",
+    op_func=_qwen4_exp_low_latency_gemm,
+    fake_impl=_qwen4_exp_low_latency_gemm_fake,
+)
+
+
+def enable_qwen4_exp_low_latency_gemm(
+    module: nn.Module,
+    dtype: torch.dtype,
+) -> None:
+    if dtype != torch.bfloat16 or not _is_sm103():
+        return
+    if not shape_dynamic_skinny_gemm.is_available():
+        return
+
+    warmup_configs: set[SkinnyGemmConfig] = set()
+    for child in module.modules():
+        is_linear = (
+            isinstance(child, LinearBase)
+            and type(child.quant_method) is UnquantizedLinearMethod
+        )
+        is_head = (
+            isinstance(child, ParallelLMHead)
+            and type(child.quant_method) is UnquantizedEmbeddingMethod
+        )
+        if not (is_linear or is_head):
+            continue
+        weight = getattr(child, "weight", None)
+        if weight is None or weight.dim() != 2:
+            continue
+        plan = QWEN4_EXP_GEMM_PLANS.get((weight.shape[0], weight.shape[1]))
+        if plan is None:
+            continue
+        if is_linear:
+            child.quant_method = Qwen4ExpLowLatencyLinearMethod()
+        else:
+            child.quant_method = Qwen4ExpLowLatencyEmbeddingMethod()
+        warmup_configs.update(plan.values())
+
+    if warmup_configs:
+        shape_dynamic_skinny_gemm.request_warmup_configs(dtype, warmup_configs)

--- a/vllm_ascend/models/qwen4_exp/nvidia/model.py
+++ b/vllm_ascend/models/qwen4_exp/nvidia/model.py
@@ -1,0 +1,1052 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Inference-only Qwen4Exp model."""
+
+from collections.abc import Iterable
+from itertools import islice
+
+import torch
+import vllm.model_executor.models.qwen3_next as _qwen3_next
+from torch import nn
+from vllm.compilation.decorators import support_torch_compile
+from vllm.config import VllmConfig
+from vllm.distributed import get_pp_group
+from vllm.model_executor.layers.logits_processor import LogitsProcessor
+from vllm.model_executor.layers.mamba.gdn.qwen_gdn_linear_attn import (
+    QwenGatedDeltaNetAttention,
+)
+from vllm.model_executor.layers.mamba.mamba_utils import (
+    MambaStateCopyFunc,
+    MambaStateCopyFuncCalculator,
+    MambaStateDtypeCalculator,
+    MambaStateShapeCalculator,
+)
+from vllm.model_executor.layers.quantization import QuantizationConfig
+from vllm.model_executor.layers.vocab_parallel_embedding import (
+    ParallelLMHead,
+    VocabParallelEmbedding,
+)
+from vllm.model_executor.models.interfaces import (
+    HasInnerState,
+    IsHybrid,
+    MixtureOfExperts,
+    MultiModalEmbeddings,
+    SupportsLoRA,
+    SupportsMRoPE,
+    SupportsPP,
+    _require_is_multimodal,
+)
+from vllm.model_executor.models.qwen3_5 import (
+    Qwen3_5ForConditionalGeneration,
+    Qwen3_5Model,
+)
+from vllm.model_executor.models.qwen3_next import (
+    Qwen3NextAttention,
+    Qwen3NextMLP,
+    Qwen3NextSparseMoeBlock,
+)
+from vllm.model_executor.models.qwen3_vl import (
+    Qwen3_VisionTransformer,
+    Qwen3VLDummyInputsBuilder,
+    Qwen3VLMultiModalProcessor,
+    Qwen3VLProcessingInfo,
+)
+from vllm.model_executor.models.utils import (
+    AutoWeightsLoader,
+    StageMissingLayer,
+    WeightsMapper,
+    _merge_multimodal_embeddings,
+    extract_layer_index,
+    make_empty_intermediate_tensors_factory,
+    make_layers,
+    maybe_fuse_shared_experts,
+    maybe_prefix,
+)
+from vllm.multimodal import MULTIMODAL_REGISTRY
+from vllm.multimodal.inputs import MultiModalFeatureSpec
+from vllm.sequence import IntermediateTensors
+from vllm.tokenizers.registry import cached_tokenizer_from_config
+from vllm.v1.attention.backends.registry import MambaAttentionBackendEnum
+from vllm.v1.kv_cache_interface import MambaSpec
+
+from vllm_ascend.models.qwen4_exp.config import (
+    Qwen4ExpTextConfig,
+)
+from vllm_ascend.patch.platform.patch_fused_moe import _ascend_FusedMoE
+
+from ..config import Qwen4ExpConfig
+from .hyperconnection import GatedResidual, HyperConnectionConfig
+from .low_latency_gemm import enable_qwen4_exp_low_latency_gemm
+from .ple_layer import Qwen4ExpPLELayer
+from .qsa import Qwen4ExpQSAAttention
+
+_qwen3_next.FusedMoE = _ascend_FusedMoE
+
+
+def without_modelopt_fp4(
+    quant_config: QuantizationConfig | None,
+) -> QuantizationConfig | None:
+    """Return ``None`` for weights excluded from Qwen4Exp ModelOpt-FP4."""
+
+    if quant_config is not None and quant_config.get_name() == "modelopt_fp4":
+        return None
+    return quant_config
+
+
+def _remap_qsa_cache_scale_name(
+    name: str,
+    qsa_layer_ids: frozenset[int],
+) -> str:
+    """Map serialized main-cache scales onto the merged QSA owner.
+
+    Regular attention keeps cache scales below its ``attn`` child. QSA owns
+    that cache directly, so only QSA layers need the final path component
+    moved to the owner's persistent ``_k_scale``/``_v_scale`` buffers.
+    """
+
+    scale_suffixes = {
+        "k_proj.k_scale": "_k_scale",
+        "k_proj.output_scale": "_k_scale",
+        "attn.k_scale": "_k_scale",
+        "attn._k_scale": "_k_scale",
+        "k_scale": "_k_scale",
+        "_k_scale": "_k_scale",
+        "v_proj.v_scale": "_v_scale",
+        "v_proj.output_scale": "_v_scale",
+        "attn.v_scale": "_v_scale",
+        "attn._v_scale": "_v_scale",
+        "v_scale": "_v_scale",
+        "_v_scale": "_v_scale",
+    }
+    for layer_id in qsa_layer_ids:
+        marker = f"layers.{layer_id}.self_attn."
+        marker_start = name.find(marker)
+        if marker_start < 0 or (marker_start > 0 and name[marker_start - 1] != "."):
+            continue
+        suffix = name[marker_start + len(marker) :]
+        mapped_suffix = scale_suffixes.get(suffix)
+        if mapped_suffix is not None:
+            return f"{name[: marker_start + len(marker)]}{mapped_suffix}"
+    return name
+
+
+_QWEN4_EXP_IGNORED_MISSING_SUFFIXES = [
+    ".bias",
+    "_bias",
+    ".k_scale",
+    "_k_scale",
+    ".v_scale",
+    "_v_scale",
+    "_weight_scale",
+    "_input_scale",
+]
+
+# The checkpoint keeps down and injection projections separate; runtime packs
+# them into adjacent logical shards of one MergedColumnParallelLinear.
+_HC_WEIGHTS_MAPPER = WeightsMapper(
+    orig_to_new_stacked={
+        "hyper_connection.input_mix_weight_down.weight": (
+            "hyper_connection.input_mix_weight_down_block_inject.weight",
+            0,
+        ),
+        "hyper_connection.block_inject_weight.weight": (
+            "hyper_connection.input_mix_weight_down_block_inject.weight",
+            1,
+        ),
+    }
+)
+
+
+class Qwen4ExpSparseMoeBlock(Qwen3NextSparseMoeBlock):
+    """Qwen3Next MoE with Qwen4Exp HC validation."""
+
+    def __init__(self, vllm_config: VllmConfig, prefix: str = "") -> None:
+        parallel_config = vllm_config.parallel_config
+        if parallel_config.use_sequence_parallel_moe:
+            raise NotImplementedError(
+                "Qwen4Exp HC does not support sequence-parallel MoE"
+            )
+        super().__init__(vllm_config=vllm_config, prefix=prefix)
+        config = vllm_config.model_config.hf_text_config
+        self.n_shared_experts = int(config.shared_expert_intermediate_size > 0)
+
+
+class Qwen4ExpDecoderLayer(nn.Module):
+    def __init__(
+        self,
+        vllm_config: VllmConfig,
+        layer_type: str,
+        prefix: str = "",
+    ) -> None:
+        super().__init__()
+        config: Qwen4ExpTextConfig = vllm_config.model_config.hf_text_config
+        model_config = vllm_config.model_config
+        cache_config = vllm_config.cache_config
+        quant_config = vllm_config.quant_config
+
+        self.config = config
+        self.layer_type = layer_type
+        self.layer_idx = extract_layer_index(prefix)
+        if vllm_config.parallel_config.use_sequence_parallel_moe:
+            raise NotImplementedError(
+                "Qwen4Exp HC does not support sequence-parallel MoE"
+            )
+        self.ple: Qwen4ExpPLELayer | None = None
+        ple_layer_ids = config.ple_layer_ids
+        if (self.layer_idx + 1) in ple_layer_ids:
+            ple_layer_ids_sorted = sorted(set(ple_layer_ids))
+            ple_dense_layer_id_map = {
+                abs_id: idx for idx, abs_id in enumerate(ple_layer_ids_sorted)
+            }
+            ple_dense_layer_id = ple_dense_layer_id_map[self.layer_idx + 1]
+            self.ple = Qwen4ExpPLELayer(
+                config,
+                vllm_config=vllm_config,
+                layer_idx=self.layer_idx,
+                ple_dense_layer_id=ple_dense_layer_id,
+                prefix=f"{prefix}.ple",
+            )
+
+        if layer_type == "linear_attention":
+            self.linear_attn = QwenGatedDeltaNetAttention(
+                config,
+                vllm_config=vllm_config,
+                prefix=f"{prefix}.linear_attn",
+                gqa_interleaved_layout=False,
+            )
+        elif layer_type == "full_attention":
+            use_qsa = getattr(config, "indexer_n_heads", None) is not None
+            if not use_qsa:
+                self.self_attn = Qwen3NextAttention(
+                    config,
+                    model_config=model_config,
+                    cache_config=cache_config,
+                    quant_config=quant_config,
+                    prefix=f"{prefix}.self_attn",
+                )
+            else:
+                self.self_attn = Qwen4ExpQSAAttention(
+                    vllm_config=vllm_config,
+                    config=config,
+                    layer_id=self.layer_idx,
+                    quant_config=quant_config,
+                    prefix=f"{prefix}.self_attn",
+                )
+        else:
+            raise ValueError(f"Invalid layer_type {layer_type}")
+
+        mlp_only_layers = getattr(config, "mlp_only_layers", [])
+        num_experts = getattr(config, "num_experts", 0) or 0
+        absolute_layer_id = self.layer_idx + 1
+        is_moe_layer = self.layer_idx not in mlp_only_layers and (
+            num_experts > 0 and absolute_layer_id % config.decoder_sparse_step == 0
+        )
+        if is_moe_layer:
+            self.mlp = Qwen4ExpSparseMoeBlock(
+                vllm_config=vllm_config, prefix=f"{prefix}.mlp"
+            )
+        else:
+            self.mlp = Qwen3NextMLP(
+                hidden_size=config.hidden_size,
+                intermediate_size=config.intermediate_size,
+                hidden_act=config.hidden_act,
+                quant_config=quant_config,
+                prefix=f"{prefix}.mlp",
+            )
+
+        hc_config = HyperConnectionConfig(
+            hc_count=config.hc_count,
+            hidden_size=config.hidden_size,
+            params_dtype=torch.bfloat16,
+            hc_lowrank=config.hc_lowrank,
+            rms_norm_eps=config.rms_norm_eps,
+            hc_per_branch_norm=True,
+        )
+        self.attn_hyper_connection = GatedResidual(
+            hc_config,
+            prefix=maybe_prefix(prefix, "attn_hyper_connection"),
+        )
+        self.mlp_hyper_connection = GatedResidual(
+            hc_config,
+            prefix=maybe_prefix(prefix, "mlp_hyper_connection"),
+        )
+
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+        prev_block_output: torch.Tensor | None,
+        prev_injection: torch.Tensor | None,
+        positions: torch.Tensor,
+        *,
+        input_ids: torch.Tensor | None,
+        query_start_loc: torch.Tensor | None,
+        ngram_context: torch.Tensor | None,
+    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+        attn_hc = self.attn_hyper_connection
+        if self.ple is not None:
+            # PLE adds directly to the multi-stream state, so pending HC state
+            # must be materialized before the addition.
+            if prev_block_output is not None and prev_injection is not None:
+                hidden_states = attn_hc.combine(
+                    hidden_states, prev_block_output, prev_injection
+                )
+                prev_block_output = prev_injection = None
+
+            if input_ids is None or query_start_loc is None or ngram_context is None:
+                raise RuntimeError("PLE inputs were not prepared")
+            hidden_states = hidden_states + self.ple(
+                hidden_states,
+                input_ids,
+                query_start_loc,
+                ngram_context,
+            )
+
+        # Fuse a pending combine with this HC module's mix when possible.
+        if prev_block_output is not None and prev_injection is not None:
+            hidden_states, block_input, injection = attn_hc.combine_and_mix(
+                hidden_states, prev_block_output, prev_injection
+            )
+        else:
+            hidden_states, block_input, injection = attn_hc.mix(hidden_states)
+
+        if self.layer_type == "linear_attention":
+            attn_out = self.linear_attn(hidden_states=block_input)
+        elif self.layer_type == "full_attention":
+            attn_out = self.self_attn(
+                hidden_states=block_input,
+                positions=positions,
+            )
+        else:
+            raise ValueError("Invalid layer_type")
+
+        mlp_hc = self.mlp_hyper_connection
+        hidden_states, block_input, injection = mlp_hc.combine_and_mix(
+            hidden_states, attn_out, injection
+        )
+        mlp_out = self.mlp(block_input)
+        return hidden_states, mlp_out, injection
+
+
+class Qwen4ExpMixtureOfExperts(MixtureOfExperts):
+    """Expose Qwen4Exp routed experts through vLLM's EPLB protocol."""
+
+    def set_moe_parameters(self, layers: Iterable[nn.Module]) -> None:
+        self.moe_layers = []
+        self.moe_mlp_layers = []
+        example_moe = None
+        for layer in layers:
+            if isinstance(layer, Qwen4ExpDecoderLayer) and isinstance(
+                layer.mlp, Qwen4ExpSparseMoeBlock
+            ):
+                example_moe = layer.mlp
+                self.moe_mlp_layers.append(layer.mlp)
+                self.moe_layers.append(layer.mlp.experts)
+
+        self.num_moe_layers = len(self.moe_layers)
+        if example_moe is None:
+            self.num_expert_groups = 0
+            self.num_shared_experts = 0
+            self.num_logical_experts = 0
+            self.num_physical_experts = 0
+            self.num_local_physical_experts = 0
+            self.num_routed_experts = 0
+            self.num_redundant_experts = 0
+            return
+
+        self.num_expert_groups = 1
+        self.num_shared_experts = example_moe.n_shared_experts
+        self.num_logical_experts = example_moe.n_logical_experts
+        self.num_physical_experts = example_moe.n_physical_experts
+        self.num_local_physical_experts = example_moe.n_local_physical_experts
+        self.num_routed_experts = example_moe.n_routed_experts
+        self.num_redundant_experts = example_moe.n_redundant_experts
+
+    def update_physical_experts_metadata(
+        self,
+        num_physical_experts: int,
+        num_local_physical_experts: int,
+    ) -> None:
+        assert self.num_local_physical_experts == num_local_physical_experts
+        self.num_physical_experts = num_physical_experts
+        self.num_local_physical_experts = num_local_physical_experts
+        self.num_redundant_experts = num_physical_experts - self.num_logical_experts
+        for moe in self.moe_mlp_layers:
+            moe.n_physical_experts = num_physical_experts
+            moe.n_local_physical_experts = num_local_physical_experts
+            moe.n_redundant_experts = self.num_redundant_experts
+            moe.experts.update_expert_map()
+
+
+@support_torch_compile(
+    dynamic_arg_dims={
+        "input_ids": 0,
+        "positions": -1,
+        "intermediate_tensors": 0,
+        "inputs_embeds": 0,
+        "query_start_loc": 0,
+        "ngram_context": 0,
+        "deepstack_input_embeds": 0,
+    }
+)
+class Qwen4ExpModel(nn.Module):
+    hf_to_vllm_mapper = Qwen3_5Model.hf_to_vllm_mapper | _HC_WEIGHTS_MAPPER
+
+    def __init__(self, *, vllm_config: VllmConfig, prefix: str = "") -> None:
+        super().__init__()
+        config: Qwen4ExpTextConfig = vllm_config.model_config.hf_text_config
+        self.config = config
+        self.num_redundant_experts = (
+            vllm_config.parallel_config.eplb_config.num_redundant_experts
+        )
+        self.vocab_size = config.vocab_size
+        self._qsa_layer_ids = frozenset(
+            layer_idx
+            for layer_idx, layer_type in enumerate(config.layer_types)
+            if layer_type == "full_attention"
+            and getattr(config, "indexer_n_heads", None) is not None
+        )
+        self.embed_tokens = VocabParallelEmbedding(self.vocab_size, config.hidden_size)
+
+        def get_layer(prefix: str) -> Qwen4ExpDecoderLayer:
+            layer_idx = extract_layer_index(prefix)
+            return Qwen4ExpDecoderLayer(
+                vllm_config,
+                layer_type=config.layer_types[layer_idx],
+                prefix=prefix,
+            )
+
+        self.start_layer, self.end_layer, self.layers = make_layers(
+            config.num_hidden_layers, get_layer, prefix=f"{prefix}.layers"
+        )
+        intermediate_size = config.hidden_size * config.hc_count
+        self.make_empty_intermediate_tensors = make_empty_intermediate_tensors_factory(
+            ["hidden_states"], intermediate_size
+        )
+
+        self.hyper_connection_mixer: GatedResidual | None
+        if get_pp_group().is_last_rank:
+            hc_config = HyperConnectionConfig(
+                hc_count=config.hc_count,
+                hidden_size=config.hidden_size,
+                params_dtype=torch.bfloat16,
+                hc_lowrank=config.hc_lowrank,
+                rms_norm_eps=config.rms_norm_eps,
+                hc_per_branch_norm=True,
+            )
+            self.hyper_connection_mixer = GatedResidual(
+                hc_config,
+                use_combine=False,
+                prefix=maybe_prefix(prefix, "hyper_connection_mixer"),
+            )
+        else:
+            self.hyper_connection_mixer = None
+
+        spec_config = vllm_config.speculative_config
+        # MTP HC multi-stream outputs: when speculative method=="mtp" and the
+        # model uses HC with hc_count>1, retain the pre-final-mixer multi-stream
+        # hidden state [T, hc_count*H] so the MTP drafter can feed a real
+        # multi-stream backbone hidden on its first step (scheme A). Derived
+        # purely from config (NOT node identity) so P/D nodes stay consistent.
+        needs_mtp_hidden = (
+            spec_config is not None
+            and getattr(spec_config, "method", None) == "mtp"
+            and get_pp_group().is_last_rank
+        )
+        if needs_mtp_hidden:
+            self._mtp_hidden_buffer = torch.empty(
+                vllm_config.scheduler_config.max_num_batched_tokens,
+                config.hc_count * config.hidden_size,
+                dtype=vllm_config.model_config.dtype,
+            )
+        else:
+            self._mtp_hidden_buffer = None
+
+    def embed_input_ids(self, input_ids: torch.Tensor) -> torch.Tensor:
+        return self.embed_tokens(input_ids)
+
+    def forward(
+        self,
+        input_ids: torch.Tensor | None,
+        positions: torch.Tensor,
+        intermediate_tensors: IntermediateTensors | None = None,
+        inputs_embeds: torch.Tensor | None = None,
+        query_start_loc: torch.Tensor | None = None,
+        ngram_context: torch.Tensor | None = None,
+        deepstack_input_embeds: IntermediateTensors | None = None,
+    ) -> torch.Tensor | IntermediateTensors:
+        if get_pp_group().is_first_rank:
+            if inputs_embeds is not None:
+                hidden_states = inputs_embeds
+            else:
+                if input_ids is None:
+                    raise ValueError("input_ids or inputs_embeds is required")
+                hidden_states = self.embed_input_ids(input_ids)
+            hidden_states = hidden_states.repeat(1, self.config.hc_count)
+        else:
+            if intermediate_tensors is None:
+                raise ValueError("pipeline stage requires intermediate tensors")
+            hidden_states = intermediate_tensors["hidden_states"]
+
+        block_output = None
+        injection = None
+        last_layer = None
+        for layer_idx, layer in islice(
+            enumerate(self.layers), self.start_layer, self.end_layer
+        ):
+            last_layer = layer
+            hidden_states, block_output, injection = layer(
+                hidden_states=hidden_states,
+                prev_block_output=block_output,
+                prev_injection=injection,
+                positions=positions,
+                input_ids=input_ids,
+                query_start_loc=query_start_loc,
+                ngram_context=ngram_context,
+            )
+            if deepstack_input_embeds is not None and layer_idx < len(
+                deepstack_input_embeds
+            ):
+                deepstack_embed = deepstack_input_embeds[
+                    f"deepstack_input_embeds_{layer_idx}"
+                ]
+                deepstack_embed = (
+                    deepstack_embed.unsqueeze(-2)
+                    .expand(
+                        *deepstack_embed.shape[:-1],
+                        self.config.hc_count,
+                        self.config.hidden_size,
+                    )
+                    .flatten(-2)
+                )
+                # Deepstack is an external addition to the materialized
+                # multi-stream state and therefore terminates delayed combine.
+                hidden_states = layer.mlp_hyper_connection.combine(
+                    hidden_states, block_output, injection
+                )
+                block_output = None
+                injection = None
+                hidden_states = hidden_states + deepstack_embed
+
+        if not get_pp_group().is_last_rank:
+            # PP transports one tensor, not the delayed HC tuple. Materialize
+            # with the HC module that produced the pending injection.
+            if last_layer is not None and block_output is not None:
+                hidden_states = last_layer.mlp_hyper_connection.combine(
+                    hidden_states, block_output, injection
+                )
+            return IntermediateTensors({"hidden_states": hidden_states})
+
+        # The final mixer consumes the last pending combine and returns both
+        # the sampled single stream and the materialized multi-stream state.
+        final_mixer = self.hyper_connection_mixer
+        assert final_mixer is not None
+        multi_hidden, sample_hidden_states, _ = final_mixer.combine_and_mix(
+            hidden_states, block_output, injection
+        )
+        if self._mtp_hidden_buffer is not None:
+            # Capture the pre-final-mixer multi-stream hidden state
+            # [T, hc_count*H] for the MTP drafter (zero extra compute:
+            # this tensor is needed by the final mixer regardless).
+            num_tokens = multi_hidden.shape[0]
+            self._mtp_hidden_buffer[:num_tokens].copy_(multi_hidden)
+        return sample_hidden_states
+
+    def load_weights(self, weights: Iterable[tuple[str, torch.Tensor]]) -> set[str]:
+        weights = (
+            (
+                _remap_qsa_cache_scale_name(name, self._qsa_layer_ids),
+                weight,
+            )
+            for name, weight in weights
+        )
+        weights = maybe_fuse_shared_experts(
+            weights,
+            n_routed_experts=getattr(self.config, "num_experts", 0) or 0,
+            n_shared_experts=1,
+            ckpt_prefix="mlp.shared_expert",
+        )
+        # Non-persistent PLE state rebuilt in __init__; skip any ckpt
+        # column for them.
+        skip_substrs = [
+            "hashstats_",
+            "token_lookup",
+            "hyper_connection_mixer.block_inject_weight",
+        ]
+        loader = AutoWeightsLoader(
+            self,
+            skip_prefixes=(
+                ["hyper_connection_mixer."]
+                if not get_pp_group().is_last_rank
+                else None
+            ),
+            skip_substrs=skip_substrs,
+            ignore_unexpected_suffixes=_QWEN4_EXP_IGNORED_MISSING_SUFFIXES.copy(),
+        )
+        loaded = loader.load_weights(
+            weights,
+            mapper=self.hf_to_vllm_mapper,
+        )
+        return loaded
+
+
+class Qwen4ExpForCausalLM(
+    nn.Module,
+    HasInnerState,
+    SupportsLoRA,
+    SupportsMRoPE,
+    SupportsPP,
+    Qwen4ExpMixtureOfExperts,
+    IsHybrid,
+):
+    packed_modules_mapping = {
+        "qkv_proj": ["q_proj", "k_proj", "v_proj"],
+        "gate_up_proj": ["gate_proj", "up_proj"],
+        "in_proj_qkvz": ["in_proj_qkv", "in_proj_z"],
+        "in_proj_ba": ["in_proj_b", "in_proj_a"],
+        "input_mix_weight_down_block_inject": [
+            "input_mix_weight_down",
+            "block_inject_weight",
+            "_input_mix_padding",
+        ],
+    }
+    hf_to_vllm_mapper = WeightsMapper(
+        orig_to_new_prefix={"model.language_model.": "model."}
+    )
+    requires_raw_input_tokens = True
+
+    def __init__(self, *, vllm_config: VllmConfig, prefix: str = "") -> None:
+        super().__init__()
+        config: Qwen4ExpTextConfig = vllm_config.model_config.hf_text_config
+        self.vllm_config = vllm_config
+        self.model_config = vllm_config.model_config
+        self.quant_config = vllm_config.quant_config
+        self.config = config
+        self.scheduler_config = vllm_config.scheduler_config
+        if vllm_config.cache_config.mamba_cache_mode == "all":
+            raise NotImplementedError(
+                "Qwen4Exp currently does not support 'all' prefix caching, "
+                "please use '--mamba-cache-mode=align' instead"
+            )
+        self.model = Qwen4ExpModel(
+            vllm_config=vllm_config, prefix=maybe_prefix(prefix, "model")
+        )
+        self.lm_head = ParallelLMHead(
+            config.vocab_size,
+            config.hidden_size,
+            prefix=maybe_prefix(prefix, "lm_head"),
+        )
+        self.logits_processor = LogitsProcessor(config.vocab_size)
+        self.make_empty_intermediate_tensors = (
+            self.model.make_empty_intermediate_tensors
+        )
+        self.set_moe_parameters(self.model.layers)
+        enable_qwen4_exp_low_latency_gemm(self, self.model_config.dtype)
+
+    @staticmethod
+    def get_model_state_cls():
+        from .model_state import Qwen4ExpModelState
+
+        return Qwen4ExpModelState
+
+    def forward(
+        self,
+        input_ids: torch.Tensor | None,
+        positions: torch.Tensor,
+        intermediate_tensors: IntermediateTensors | None = None,
+        inputs_embeds: torch.Tensor | None = None,
+        **kwargs: object,
+    ) -> torch.Tensor | IntermediateTensors:
+        # Forward kwargs unchanged so the runner's _maybe_add_ngram_kwargs
+        # path (query_start_loc / ngram_context) reaches Qwen4ExpModel.
+        ple_input_ids = kwargs.pop("ple_input_ids", input_ids)
+        return self.model(
+            ple_input_ids,
+            positions,
+            intermediate_tensors,
+            inputs_embeds,
+            **kwargs,
+        )
+
+    def embed_input_ids(self, input_ids: torch.Tensor) -> torch.Tensor:
+        return self.model.embed_input_ids(input_ids)
+
+    @classmethod
+    def get_ple_mamba_state_dtype_from_config(
+        cls,
+        vllm_config: VllmConfig,
+    ) -> tuple[torch.dtype, ...]:
+        return MambaStateDtypeCalculator.short_conv_state_dtype(
+            vllm_config.model_config.dtype,
+            vllm_config.cache_config.mamba_cache_dtype,
+        )
+
+    @classmethod
+    def get_ple_mamba_state_shape_from_config(
+        cls, vllm_config: VllmConfig
+    ) -> tuple[tuple[int, int]]:
+        hf_config = vllm_config.model_config.hf_text_config
+        conv_kernel_size = hf_config.ple_conv_kernel_size
+        short_conv_dilation = hf_config.ngram_size
+        conv_state_len = (conv_kernel_size - 1) * short_conv_dilation
+        hc_count = hf_config.hc_count
+        hc_hidden_size = hf_config.hidden_size * hc_count
+        return MambaStateShapeCalculator.short_conv_state_shape(
+            tp_world_size=1,
+            intermediate_size=hc_hidden_size,
+            conv_kernel=conv_state_len + 1,
+        )
+
+    @classmethod
+    def get_gdn_mamba_state_dtype_from_config(
+        cls, vllm_config: VllmConfig
+    ) -> tuple[torch.dtype, torch.dtype]:
+        return MambaStateDtypeCalculator.gated_delta_net_state_dtype(
+            vllm_config.model_config.dtype,
+            vllm_config.cache_config.mamba_cache_dtype,
+            vllm_config.cache_config.mamba_ssm_cache_dtype,
+        )
+
+    @classmethod
+    def get_gdn_mamba_state_shape_from_config(
+        cls, vllm_config: VllmConfig
+    ) -> tuple[tuple[int, int], tuple[int, int]]:
+        parallel_config = vllm_config.parallel_config
+        hf_config = vllm_config.model_config.hf_text_config
+        tp_size = parallel_config.tensor_parallel_size
+        num_spec = (
+            vllm_config.speculative_config.num_speculative_tokens
+            if vllm_config.speculative_config
+            else 0
+        )
+        return MambaStateShapeCalculator.gated_delta_net_state_shape(
+            tp_size,
+            hf_config.linear_num_key_heads,
+            hf_config.linear_num_value_heads,
+            hf_config.linear_key_head_dim,
+            hf_config.linear_value_head_dim,
+            hf_config.linear_conv_kernel_dim,
+            num_spec,
+        )
+
+    @classmethod
+    def get_mamba_state_dtype_from_config(
+        cls,
+        vllm_config: VllmConfig,
+    ) -> tuple[torch.dtype, torch.dtype]:
+        return cls.get_gdn_mamba_state_dtype_from_config(vllm_config)
+
+    @classmethod
+    def get_mamba_state_shape_from_config(
+        cls, vllm_config: VllmConfig
+    ) -> tuple[tuple[int, int], tuple[int, int]]:
+        return cls.get_gdn_mamba_state_shape_from_config(vllm_config)
+
+    @classmethod
+    def get_mamba_state_copy_func(
+        cls,
+    ) -> tuple[MambaStateCopyFunc, MambaStateCopyFunc]:
+        return MambaStateCopyFuncCalculator.gated_delta_net_state_copy_func()
+
+    @classmethod
+    def get_mamba_state_copy_funcs(
+        cls,
+        mamba_types: set[MambaAttentionBackendEnum],
+    ) -> dict[MambaAttentionBackendEnum, tuple[MambaStateCopyFunc, ...]]:
+        copy_funcs_by_type = {
+            MambaAttentionBackendEnum.GDN_ATTN: cls.get_mamba_state_copy_func(),
+            MambaAttentionBackendEnum.SHORT_CONV: (
+                MambaStateCopyFuncCalculator.short_conv_state_copy_func()
+            ),
+        }
+        missing_types = mamba_types - copy_funcs_by_type.keys()
+        assert not missing_types, f"missing state copy funcs for {missing_types}"
+        return {
+            mamba_type: copy_funcs_by_type[mamba_type] for mamba_type in mamba_types
+        }
+
+    @classmethod
+    def get_mamba_specs_from_config(
+        cls, vllm_config: VllmConfig
+    ) -> tuple[MambaSpec, ...]:
+        """Return all MambaSpecs for this model (GDN layers + PLE layer).
+
+        The PLE layer uses a separate short_conv MambaSpec whose page_size_bytes
+        may exceed the GDN spec; callers should take the maximum.
+        """
+        return (
+            MambaSpec(
+                shapes=cls.get_gdn_mamba_state_shape_from_config(vllm_config),
+                dtypes=cls.get_gdn_mamba_state_dtype_from_config(vllm_config),
+                block_size=-1,
+            ),
+            MambaSpec(
+                shapes=cls.get_ple_mamba_state_shape_from_config(vllm_config),
+                dtypes=cls.get_ple_mamba_state_dtype_from_config(vllm_config),
+                block_size=-1,
+            ),
+        )
+
+    def compute_logits(self, hidden_states: torch.Tensor) -> torch.Tensor | None:
+        return self.logits_processor(self.lm_head, hidden_states)
+
+    def get_mtp_target_hidden_states(self) -> torch.Tensor | None:
+        return self.model._mtp_hidden_buffer
+
+    def get_mrope_input_positions(
+        self,
+        input_tokens: list[int],
+        mm_features: list[MultiModalFeatureSpec],
+    ) -> tuple[torch.Tensor, int]:
+        positions = torch.arange(len(input_tokens), dtype=torch.long)
+        return positions.unsqueeze(0).expand(3, -1), 0
+
+    def load_weights(self, weights: Iterable[tuple[str, torch.Tensor]]) -> set[str]:
+        loader = AutoWeightsLoader(
+            self,
+            skip_substrs=["mtp."],
+            ignore_unexpected_suffixes=_QWEN4_EXP_IGNORED_MISSING_SUFFIXES.copy(),
+        )
+        return loader.load_weights(weights, mapper=self.hf_to_vllm_mapper)
+
+
+class Qwen4ExpProcessingInfo(Qwen3VLProcessingInfo):
+    def get_hf_config(self) -> Qwen4ExpConfig:
+        return self.ctx.get_hf_config(Qwen4ExpConfig)
+
+
+@MULTIMODAL_REGISTRY.register_processor(
+    Qwen3VLMultiModalProcessor,
+    info=Qwen4ExpProcessingInfo,
+    dummy_inputs=Qwen3VLDummyInputsBuilder,
+)
+class Qwen4ExpForConditionalGeneration(
+    Qwen3_5ForConditionalGeneration,
+    HasInnerState,
+    Qwen4ExpMixtureOfExperts,
+):
+    """Qwen3-VL vision tower backed by the Qwen4Exp language model."""
+
+    requires_raw_input_tokens = True
+
+    packed_modules_mapping = Qwen3_5ForConditionalGeneration.packed_modules_mapping | {
+        "input_mix_weight_down_block_inject": [
+            "input_mix_weight_down",
+            "block_inject_weight",
+            "_input_mix_padding",
+        ]
+    }
+
+    @staticmethod
+    def get_model_state_cls():
+        from .model_state import Qwen4ExpModelState
+
+        return Qwen4ExpModelState
+
+    def _init_video_pruning(self, multimodal_config) -> None:
+        """Keep compatibility with the Qwen3.5 base in vLLM 0.26.0."""
+        del multimodal_config
+        self.is_multimodal_pruning_enabled = False
+        self.video_pruning_method = None
+        self.video_pruning_rate = 0.0
+
+    def __init__(self, *, vllm_config: VllmConfig, prefix: str = "model") -> None:
+        nn.Module.__init__(self)
+        config: Qwen4ExpConfig = vllm_config.model_config.hf_config
+        quant_config = vllm_config.quant_config
+        multimodal_config = vllm_config.model_config.multimodal_config
+        if multimodal_config is None:
+            raise ValueError(
+                "Qwen4ExpForConditionalGeneration requires multimodal_config"
+            )
+
+        self.config = config
+        self.model_config = vllm_config.model_config
+        self.multimodal_config = multimodal_config
+        self.language_model_only = multimodal_config.language_model_only
+        if self.language_model_only:
+            self.use_data_parallel = False
+            self.is_multimodal_pruning_enabled = False
+            self.video_pruning_method = None
+            self.video_pruning_rate = 0.0
+            self._tokenizer = None
+            self.visual = StageMissingLayer("vision_tower")
+            self._tower_model_names = []
+        else:
+            self.use_data_parallel = multimodal_config.mm_encoder_tp_mode == "data"
+            self._init_video_pruning(multimodal_config)
+            self._tokenizer = cached_tokenizer_from_config(vllm_config.model_config)
+
+            with self._mark_tower_model(vllm_config, {"image", "video"}):
+                self.visual = Qwen3_VisionTransformer(
+                    config.vision_config,
+                    norm_eps=config.text_config.rms_norm_eps,
+                    quant_config=quant_config,
+                    prefix=maybe_prefix(prefix, "visual"),
+                )
+
+        self.use_deepstack = (
+            not self.language_model_only
+            and bool(config.vision_config.deepstack_visual_indexes)
+            and not isinstance(self.visual, StageMissingLayer)
+        )
+        self.deepstack_num_level = (
+            len(config.vision_config.deepstack_visual_indexes)
+            if self.use_deepstack
+            else 0
+        )
+        self.visual_dim = config.vision_config.out_hidden_size
+        self.multiscale_dim = self.visual_dim * self.deepstack_num_level
+
+        if self.use_deepstack:
+            self.deepstack_input_embeds = [
+                torch.zeros(
+                    vllm_config.scheduler_config.max_num_batched_tokens,
+                    config.text_config.hidden_size,
+                )
+                for _ in range(self.deepstack_num_level)
+            ]
+            self.deepstack_input_embeds_num_tokens = 0
+
+        with self._mark_language_model(vllm_config):
+            self.language_model = Qwen4ExpForCausalLM(
+                vllm_config=vllm_config,
+                prefix=maybe_prefix(prefix, "language_model"),
+            )
+
+        self.make_empty_intermediate_tensors = (
+            self.language_model.make_empty_intermediate_tensors
+        )
+        if not get_pp_group().is_first_rank and self.use_deepstack:
+            assert self.language_model.model.start_layer >= len(
+                config.vision_config.deepstack_visual_indexes
+            ), (
+                "start_layer should be greater than or equal to "
+                "len(deepstack_visual_indexes)"
+            )
+        self.set_moe_parameters(self.language_model.model.layers)
+
+    def embed_input_ids(
+        self,
+        input_ids: torch.Tensor,
+        multimodal_embeddings: MultiModalEmbeddings | None = None,
+        *,
+        is_multimodal: torch.Tensor | None = None,
+    ) -> torch.Tensor:
+        inputs_embeds = self._embed_text_input_ids(
+            input_ids,
+            self.language_model.embed_input_ids,
+            is_multimodal=is_multimodal,
+        )
+        if multimodal_embeddings is None or len(multimodal_embeddings) == 0:
+            return inputs_embeds
+        if self.language_model_only:
+            raise ValueError(
+                "Qwen4Exp language_model_only does not accept multimodal embeddings"
+            )
+
+        is_multimodal = _require_is_multimodal(is_multimodal)
+        if self.use_deepstack:
+            deepstack_input_embeds, multimodal_embeddings = (
+                self._compute_deepstack_embeds(
+                    inputs_embeds=inputs_embeds,
+                    multimodal_embeddings=multimodal_embeddings,
+                    is_multimodal=is_multimodal,
+                )
+            )
+        else:
+            deepstack_input_embeds = None
+
+        inputs_embeds = _merge_multimodal_embeddings(
+            inputs_embeds=inputs_embeds,
+            multimodal_embeddings=multimodal_embeddings,
+            is_multimodal=is_multimodal,
+        )
+        if deepstack_input_embeds is not None:
+            self._set_deepstack_input_embeds(deepstack_input_embeds)
+        return inputs_embeds
+
+    def get_mtp_target_hidden_states(self) -> torch.Tensor | None:
+        return self.language_model.get_mtp_target_hidden_states()
+
+    def forward(
+        self,
+        input_ids: torch.Tensor | None,
+        positions: torch.Tensor,
+        intermediate_tensors: IntermediateTensors | None = None,
+        inputs_embeds: torch.Tensor | None = None,
+        **kwargs: object,
+    ) -> torch.Tensor | IntermediateTensors:
+        if intermediate_tensors is not None:
+            inputs_embeds = None
+        if inputs_embeds is not None and get_pp_group().is_first_rank:
+            deepstack_input_embeds = self._get_deepstack_input_embeds(
+                inputs_embeds.size(0)
+            )
+        else:
+            deepstack_input_embeds = None
+
+        ple_input_ids = kwargs.get("ple_input_ids", input_ids)
+        hidden_states = self.language_model.model(
+            input_ids=ple_input_ids,
+            positions=positions,
+            intermediate_tensors=intermediate_tensors,
+            inputs_embeds=inputs_embeds,
+            query_start_loc=kwargs.get("query_start_loc"),
+            ngram_context=kwargs.get("ngram_context"),
+            deepstack_input_embeds=deepstack_input_embeds,
+        )
+        if inputs_embeds is not None and get_pp_group().is_first_rank:
+            self._clear_deepstack_input_embeds(inputs_embeds.size(0))
+        return hidden_states
+
+    def load_weights(self, weights: Iterable[tuple[str, torch.Tensor]]) -> set[str]:
+        loader = AutoWeightsLoader(
+            self,
+            skip_prefixes=["visual."] if self.language_model_only else None,
+            skip_substrs=["mtp."],
+            ignore_unexpected_suffixes=_QWEN4_EXP_IGNORED_MISSING_SUFFIXES.copy(),
+        )
+        return loader.load_weights(weights, mapper=self.hf_to_vllm_mapper)
+
+    @classmethod
+    def get_mamba_state_dtype_from_config(
+        cls,
+        vllm_config: VllmConfig,
+    ) -> tuple[torch.dtype, torch.dtype]:
+        return Qwen4ExpForCausalLM.get_mamba_state_dtype_from_config(vllm_config)
+
+    @classmethod
+    def get_mamba_state_shape_from_config(
+        cls,
+        vllm_config: VllmConfig,
+    ) -> tuple[tuple[int, int], tuple[int, int]]:
+        return Qwen4ExpForCausalLM.get_mamba_state_shape_from_config(vllm_config)
+
+    @classmethod
+    def get_mamba_state_copy_func(
+        cls,
+    ) -> tuple[MambaStateCopyFunc, MambaStateCopyFunc]:
+        return Qwen4ExpForCausalLM.get_mamba_state_copy_func()
+
+    @classmethod
+    def get_mamba_state_copy_funcs(
+        cls,
+        mamba_types: set[MambaAttentionBackendEnum],
+    ) -> dict[MambaAttentionBackendEnum, tuple[MambaStateCopyFunc, ...]]:
+        return Qwen4ExpForCausalLM.get_mamba_state_copy_funcs(mamba_types)
+
+    @classmethod
+    def get_mamba_specs_from_config(
+        cls, vllm_config: VllmConfig
+    ) -> tuple[MambaSpec, ...]:
+        return Qwen4ExpForCausalLM.get_mamba_specs_from_config(vllm_config)
+
+
+__all__ = [
+    "Qwen4ExpDecoderLayer",
+    "Qwen4ExpForCausalLM",
+    "Qwen4ExpForConditionalGeneration",
+    "Qwen4ExpMixtureOfExperts",
+    "Qwen4ExpModel",
+    "Qwen4ExpSparseMoeBlock",
+]

--- a/vllm_ascend/models/qwen4_exp/nvidia/model.py
+++ b/vllm_ascend/models/qwen4_exp/nvidia/model.py
@@ -383,7 +383,6 @@ class Qwen4ExpMixtureOfExperts(MixtureOfExperts):
         "positions": -1,
         "intermediate_tensors": 0,
         "inputs_embeds": 0,
-        "query_start_loc": 0,
         "ngram_context": 0,
         "deepstack_input_embeds": 0,
     }
@@ -687,7 +686,10 @@ class Qwen4ExpForCausalLM(
         hf_config = vllm_config.model_config.hf_text_config
         conv_kernel_size = hf_config.ple_conv_kernel_size
         short_conv_dilation = hf_config.ngram_size
-        conv_state_len = (conv_kernel_size - 1) * short_conv_dilation
+        conv_state_len = (
+            (conv_kernel_size - 1) * short_conv_dilation
+            + vllm_config.num_speculative_tokens
+        )
         hc_count = hf_config.hc_count
         hc_hidden_size = hf_config.hidden_size * hc_count
         return MambaStateShapeCalculator.short_conv_state_shape(

--- a/vllm_ascend/models/qwen4_exp/nvidia/model_state.py
+++ b/vllm_ascend/models/qwen4_exp/nvidia/model_state.py
@@ -1,0 +1,142 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Model-runner state for Qwen4Exp PLE inputs."""
+
+from typing import Any
+
+import torch
+import torch.nn as nn
+from vllm.config import VllmConfig
+from vllm.v1.worker.gpu.input_batch import InputBatch
+from vllm.v1.worker.gpu.mm.encoder_cache import EncoderCache
+from vllm.v1.worker.gpu.model_states.mamba_hybrid import MambaHybridModelState
+from vllm.v1.worker.gpu.states import RequestState
+
+
+class Qwen4ExpModelState(MambaHybridModelState):
+    """Add rollback-safe PLE n-gram context to the model inputs."""
+
+    def __init__(
+        self,
+        vllm_config: VllmConfig,
+        model: nn.Module,
+        encoder_cache: EncoderCache | None,
+        device: torch.device,
+    ) -> None:
+        super().__init__(vllm_config, model, encoder_cache, device)
+        config = self.model_config.hf_text_config
+        self.uses_ngram_embedding = bool(config.ple_layer_ids)
+        if not self.uses_ngram_embedding:
+            self.ngram_context_len = 0
+            self.ngram_eos_token_id = 0
+            return
+
+        if vllm_config.parallel_config.pipeline_parallel_size > 1:
+            raise RuntimeError(
+                "N-gram PLE embedding currently requires "
+                "pipeline_parallel_size=1 because non-first pipeline ranks do "
+                "not receive the raw input_ids required by PLE. Please run "
+                "with PP=1."
+            )
+
+        self.ngram_context_len = int(config.ngram_size) - 1
+        if self.ngram_context_len <= 0:
+            raise ValueError("N-gram embedding requires context length >= 1.")
+        self.ngram_eos_token_id = int(config.eos_token_id)
+        self.ngram_context = torch.full(
+            (self.max_num_reqs, self.ngram_context_len),
+            self.ngram_eos_token_id,
+            dtype=torch.int32,
+            device=self.device,
+        )
+        self.ngram_context_offsets = torch.arange(
+            -self.ngram_context_len,
+            0,
+            dtype=torch.int64,
+            device=self.device,
+        )
+        self.ple_query_start_loc = torch.zeros(
+            self.max_num_reqs + 1,
+            dtype=torch.int32,
+            device=self.device,
+        )
+
+    def _prepare_ngram_context(
+        self,
+        input_batch: InputBatch,
+        req_states: RequestState,
+    ) -> torch.Tensor:
+        num_reqs = input_batch.num_reqs
+        num_reqs_padded = input_batch.num_reqs_after_padding
+        context = self.ngram_context[:num_reqs_padded]
+        context.fill_(self.ngram_eos_token_id)
+        if num_reqs == 0:
+            return context
+
+        request_indices = input_batch.idx_mapping[:num_reqs].long()
+        context_end = req_states.num_computed_tokens.gpu[request_indices].long()
+        token_indices = context_end.unsqueeze(1) + self.ngram_context_offsets
+        valid_tokens = token_indices >= 0
+        token_indices.clamp_min_(0)
+        context_tokens = req_states.all_token_ids.gpu[
+            request_indices.unsqueeze(1), token_indices
+        ]
+        context[:num_reqs].copy_(
+            torch.where(
+                valid_tokens,
+                context_tokens,
+                context_tokens.new_full((), self.ngram_eos_token_id),
+            )
+        )
+        return context
+
+    def prepare_inputs(
+        self,
+        input_batch: InputBatch,
+        req_states: RequestState,
+    ) -> dict[str, Any]:
+        model_inputs = super().prepare_inputs(input_batch, req_states)
+        if not self.uses_ngram_embedding:
+            return model_inputs
+
+        num_reqs_padded = input_batch.num_reqs_after_padding
+        query_start_loc = self.ple_query_start_loc[: num_reqs_padded + 1]
+        query_start_loc.copy_(input_batch.query_start_loc[: num_reqs_padded + 1])
+        model_inputs.update(
+            query_start_loc=query_start_loc,
+            ngram_context=self._prepare_ngram_context(input_batch, req_states),
+        )
+        return model_inputs
+
+    def prepare_dummy_inputs(
+        self,
+        num_reqs: int,
+        num_tokens: int,
+    ) -> dict[str, Any]:
+        model_inputs = super().prepare_dummy_inputs(num_reqs, num_tokens)
+        if not self.uses_ngram_embedding:
+            return model_inputs
+
+        query_start_loc = self.ple_query_start_loc[: num_reqs + 1]
+        query_start_loc[0] = 0
+        tokens_per_req, num_extra_tokens = divmod(num_tokens, num_reqs)
+        query_lens = torch.full(
+            (num_reqs,),
+            tokens_per_req,
+            dtype=query_start_loc.dtype,
+            device=query_start_loc.device,
+        )
+        if num_extra_tokens > 0:
+            query_lens[-num_extra_tokens:] += 1
+        torch.cumsum(query_lens, dim=0, out=query_start_loc[1:])
+
+        ngram_context = self.ngram_context[:num_reqs]
+        ngram_context.fill_(self.ngram_eos_token_id)
+        model_inputs.update(
+            query_start_loc=query_start_loc,
+            ngram_context=ngram_context,
+        )
+        return model_inputs
+
+
+__all__ = ["Qwen4ExpModelState"]

--- a/vllm_ascend/models/qwen4_exp/nvidia/mtp.py
+++ b/vllm_ascend/models/qwen4_exp/nvidia/mtp.py
@@ -1,0 +1,447 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Inference-only Qwen4Exp MTP (Multi-Token Predictor) model.
+
+The MTP draft model reuses the Qwen4Exp backbone (PLE/HC/MoE) but:
+  - drops all multi-modal handling (text-only),
+  - forces PLE off while keeping the main model's HC stream count,
+  - fuses the backbone hidden and the new-token embedding via
+    ``residual_linear_shared`` (fc_embedding + shared fc_hidden) instead of
+    the ``Linear(2H, H)`` + repeat used by other MTP variants,
+  - emits TWO hidden streams per step (scheme A): a single stream [T, H]
+    (final-mixer collapsed, fed to the LM head) and a pre-final-mixer
+    multi stream [T, hc_count*H] (fed to the next draft step).
+"""
+
+from collections.abc import Iterable
+
+import regex as re
+import torch
+from torch import nn
+from vllm.compilation.decorators import support_torch_compile
+from vllm.config import VllmConfig, replace, set_current_vllm_config
+from vllm.distributed import get_pp_group
+from vllm.model_executor.layers.layernorm import GemmaRMSNorm
+from vllm.model_executor.layers.linear import ColumnParallelLinear
+from vllm.model_executor.layers.logits_processor import LogitsProcessor
+from vllm.model_executor.layers.vocab_parallel_embedding import (
+    ParallelLMHead,
+    VocabParallelEmbedding,
+)
+from vllm.model_executor.model_loader.utils import configure_quant_config
+from vllm.model_executor.models.interfaces import SupportsPP
+from vllm.model_executor.models.qwen3_5 import Qwen3_5Model
+from vllm.model_executor.models.utils import (
+    AutoWeightsLoader,
+    PPMissingLayer,
+    get_draft_quant_config,
+    make_empty_intermediate_tensors_factory,
+    maybe_fuse_shared_experts,
+    maybe_prefix,
+)
+from vllm.sequence import IntermediateTensors
+
+from vllm_ascend.models.qwen4_exp.config import (
+    Qwen4ExpTextConfig,
+)
+
+from .hyperconnection import GatedResidual, HyperConnectionConfig
+from .low_latency_gemm import enable_qwen4_exp_low_latency_gemm
+from .model import (
+    _HC_WEIGHTS_MAPPER,
+    _QWEN4_EXP_IGNORED_MISSING_SUFFIXES,
+    Qwen4ExpDecoderLayer,
+    Qwen4ExpMixtureOfExperts,
+)
+
+
+def _remap_ignored_layers(
+    ignored_layers: list[str],
+    mtp_start_layer_idx: int,
+) -> list[str]:
+    remapped: list[str] = []
+    for name in ignored_layers:
+        if name.startswith("mtp."):
+            new_name = re.sub(
+                r"(?<=\.layers\.)\d+",
+                lambda m: str(mtp_start_layer_idx + int(m.group(0))),
+                name,
+            )
+            remapped.append(new_name)
+        else:
+            remapped.append(name)
+    return remapped
+
+
+def _remap_mtp_weight_name(name: str) -> str | None:
+    """Map Qwen4Exp checkpoint paths into the standalone draft model."""
+
+    for checkpoint_prefix in (
+        "model.language_model.",
+        "language_model.",
+    ):
+        if name.startswith(checkpoint_prefix):
+            name = name.removeprefix(checkpoint_prefix)
+            break
+
+    if name.startswith("embed_tokens."):
+        name = f"model.{name}"
+    if name.startswith("model.mtp."):
+        name = name.removeprefix("model.")
+    if name.startswith("mtp.shared_head.head."):
+        return name.replace("mtp.shared_head.head.", "lm_head.", 1)
+    if name.startswith("model.shared_head.head."):
+        return name.replace("model.shared_head.head.", "lm_head.", 1)
+    if name.startswith("shared_head.head."):
+        return name.replace("shared_head.head.", "lm_head.", 1)
+    if name.startswith("model.lm_head."):
+        return name.removeprefix("model.")
+    if name.startswith("mtp."):
+        return name.replace("mtp.", "model.", 1)
+    if name.startswith("model.embed_tokens.") or name.startswith("lm_head."):
+        return name
+    return None
+
+
+def _make_draft_vllm_config(
+    vllm_config: VllmConfig,
+    mtp_start_layer_idx: int,
+) -> VllmConfig:
+    """Ensure that the draft model config is set in the vLLM config."""
+    speculative_config = vllm_config.speculative_config
+    if speculative_config is None or speculative_config.draft_model_config is None:
+        raise ValueError("speculative_config.draft_model_config must be set")
+
+    draft_quant_config = get_draft_quant_config(vllm_config)
+
+    # inject packed and ignored modules to the quantization config of draft model
+    if draft_quant_config is not None:
+        configure_quant_config(draft_quant_config, Qwen4ExpMTP)
+        ignored_layers = getattr(draft_quant_config, "ignored_layers", None)
+        if ignored_layers:
+            setattr(  # noqa: B010
+                draft_quant_config,
+                "ignored_layers",
+                _remap_ignored_layers(ignored_layers, mtp_start_layer_idx),
+            )
+        exclude_modules = getattr(draft_quant_config, "exclude_modules", None)
+        if exclude_modules:
+            setattr(  # noqa: B010
+                draft_quant_config,
+                "exclude_modules",
+                _remap_ignored_layers(exclude_modules, mtp_start_layer_idx),
+            )
+
+    draft_vllm_config = replace(
+        vllm_config,
+        model_config=speculative_config.draft_model_config,
+    )
+    # VllmConfig post-init derives the target quant config, so restore the
+    # independently resolved draft quant config after replacement.
+    draft_vllm_config.quant_config = draft_quant_config
+    return draft_vllm_config
+
+
+@support_torch_compile(
+    dynamic_arg_dims={
+        "input_ids": 0,
+        "positions": -1,
+        "intermediate_tensors": 0,
+        "inputs_embeds": 0,
+        "hidden_states": 0,
+    }
+)
+class Qwen4ExpMultiTokenPredictor(nn.Module):
+    hf_to_vllm_mapper = Qwen3_5Model.hf_to_vllm_mapper | _HC_WEIGHTS_MAPPER
+
+    def __init__(self, *, vllm_config: VllmConfig, prefix: str = "") -> None:
+        super().__init__()
+
+        model_config = vllm_config.model_config
+        config: Qwen4ExpTextConfig = model_config.hf_text_config
+
+        self.config = config
+        self.vocab_size = config.vocab_size
+
+        self.mtp_start_layer_idx = config.num_hidden_layers
+        self.num_mtp_layers = getattr(config, "mtp_num_hidden_layers", 1)
+
+        self.hidden_size = config.hidden_size
+        self.hc_count = config.hc_count
+
+        self.embed_tokens = VocabParallelEmbedding(self.vocab_size, self.hidden_size)
+        draft_vllm_config = _make_draft_vllm_config(
+            vllm_config,
+            self.mtp_start_layer_idx,
+        )
+        with set_current_vllm_config(draft_vllm_config, prefix=prefix):
+            # residual_linear_shared fusion: fc_embedding projects the token
+            # embedding, fc_hidden (shared across HC branches) projects the
+            # backbone hidden; the embedding is added as a residual to every
+            # branch (see mtp_residual_linear_shared.md).
+            self.fc_embedding = ColumnParallelLinear(
+                self.hidden_size,
+                self.hidden_size,
+                gather_output=True,
+                bias=False,
+                return_bias=False,
+                quant_config=draft_vllm_config.quant_config,
+                prefix=f"{prefix}.fc_embedding",
+            )
+            self.fc_hidden = ColumnParallelLinear(
+                self.hidden_size,
+                self.hidden_size,
+                gather_output=True,
+                bias=False,
+                return_bias=False,
+                quant_config=draft_vllm_config.quant_config,
+                prefix=f"{prefix}.fc_hidden",
+            )
+            self.layers = nn.ModuleList(
+                Qwen4ExpDecoderLayer(
+                    draft_vllm_config,
+                    layer_type="full_attention",
+                    prefix=f"{prefix}.layers.{self.mtp_start_layer_idx + idx}",
+                )
+                for idx in range(self.num_mtp_layers)
+            )
+
+        self.pre_fc_norm_embedding = GemmaRMSNorm(
+            self.hidden_size, eps=config.rms_norm_eps
+        )
+        self.pre_fc_norm_hidden = GemmaRMSNorm(
+            self.hidden_size * self.hc_count, eps=config.rms_norm_eps
+        )
+        # HC final mixer collapses the multi stream into [T, H] for the LM head.
+        hc_config = HyperConnectionConfig(
+            hc_count=config.hc_count,
+            hidden_size=config.hidden_size,
+            params_dtype=torch.bfloat16,
+            hc_lowrank=config.hc_lowrank,
+            rms_norm_eps=config.rms_norm_eps,
+            hc_per_branch_norm=True,
+        )
+        self.hyper_connection_mixer = GatedResidual(
+            hc_config,
+            use_combine=False,
+            prefix=maybe_prefix(prefix, "hyper_connection_mixer"),
+        )
+        self.make_empty_intermediate_tensors = make_empty_intermediate_tensors_factory(
+            ["hidden_states"], self.hidden_size * self.hc_count
+        )
+
+    def _iter_qsa_attentions(self):
+        """Yield MTP attention modules that own a QSA indexer."""
+
+        for layer in self.layers:
+            attention = getattr(layer, "self_attn", None)
+            if (
+                attention is not None
+                and getattr(attention, "indexer", None) is not None
+            ):
+                yield attention
+
+    def set_skip_topk(self, skip: bool) -> None:
+        """Select on MTP step 0 and reuse its QSA indices on later steps."""
+
+        for attention in self._iter_qsa_attentions():
+            attention.indexer.skip_topk = skip
+
+    def compact_topk_indices(self, row_indices: torch.Tensor) -> None:
+        """Keep each request's target-aligned step-0 sparse-index row."""
+
+        num_rows = row_indices.numel()
+        for attention in self._iter_qsa_attentions():
+            buffer = attention.topk_indices_buffer
+            selected = buffer.index_select(0, row_indices)
+            buffer[:num_rows].copy_(selected)
+
+    def embed_input_ids(self, input_ids: torch.Tensor) -> torch.Tensor:
+        return self.embed_tokens(input_ids)
+
+    def forward(
+        self,
+        input_ids: torch.Tensor | None,
+        positions: torch.Tensor,
+        hidden_states: torch.Tensor | None = None,
+        intermediate_tensors: IntermediateTensors | None = None,
+        inputs_embeds: torch.Tensor | None = None,
+        spec_step_idx: int = 0,
+    ) -> torch.Tensor | tuple[torch.Tensor, torch.Tensor] | IntermediateTensors:
+        hc_count = self.hc_count
+        hidden_size = self.hidden_size
+
+        if get_pp_group().is_first_rank:
+            assert hidden_states is not None
+            if inputs_embeds is None:
+                assert input_ids is not None
+                inputs_embeds = self.embed_input_ids(input_ids)
+            # Embedding branch: pre-norm -> fc_embedding -> [T, H].
+            inputs_embeds = self.pre_fc_norm_embedding(inputs_embeds)
+            inputs_embeds = self.fc_embedding(inputs_embeds)
+
+            # Backbone hidden is multi-stream [T, hc_count*H] (scheme A:
+            # the main model truly emits the pre-final-mixer multi stream
+            # on the first step; subsequent steps reuse the prior draft
+            # step's multi stream).
+            num_tokens = hidden_states.shape[0]
+            hidden_states = hidden_states.view(num_tokens, hc_count, hidden_size)
+            hidden_states = self.pre_fc_norm_hidden(hidden_states.flatten(-2)).view(
+                num_tokens, hc_count, hidden_size
+            )
+            hidden_states = self.fc_hidden(hidden_states)
+            # Add the embedding residual to every branch, then fold back
+            # to [T, hc_count*H] (HC outer, HS inner) for the HC decoder.
+            hidden_states = inputs_embeds.unsqueeze(-2) + hidden_states
+            hidden_states = hidden_states.flatten(-2)
+        else:
+            assert intermediate_tensors is not None
+            hidden_states = intermediate_tensors["hidden_states"]
+
+        current_step_idx = spec_step_idx % self.num_mtp_layers
+        layer = self.layers[current_step_idx]
+        hidden_states, block_output, injection = layer(
+            hidden_states=hidden_states,
+            prev_block_output=None,
+            prev_injection=None,
+            positions=positions,
+            input_ids=None,
+            query_start_loc=None,
+            ngram_context=None,
+        )
+        if not get_pp_group().is_last_rank:
+            # As in the target model, PP carries a materialized tensor rather
+            # than the delayed hidden/output/injection tuple.
+            hidden_states = layer.mlp_hyper_connection.combine(
+                hidden_states, block_output, injection
+            )
+            return IntermediateTensors({"hidden_states": hidden_states})
+
+        # Last PP rank finalize. Keep both:
+        #   (A) sample_hidden_states [T, H]  -> single stream for the LM head
+        #   (B) multi_hidden [T, hc_count*H] -> pre-final-mixer multi stream
+        #       for the next draft step (zero extra compute, just kept).
+        multi_hidden, sample_hidden_states, _ = (
+            self.hyper_connection_mixer.combine_and_mix(
+                hidden_states, block_output, injection
+            )
+        )
+        return sample_hidden_states, multi_hidden
+
+    def load_weights(self, weights: Iterable[tuple[str, torch.Tensor]]) -> set[str]:
+        weights = maybe_fuse_shared_experts(
+            weights,
+            n_routed_experts=getattr(self.config, "num_experts", 0) or 0,
+            n_shared_experts=1,
+            ckpt_prefix="mlp.shared_expert",
+        )
+        loader = AutoWeightsLoader(
+            self,
+            skip_substrs=["hyper_connection_mixer.block_inject_weight"],
+            ignore_unexpected_suffixes=_QWEN4_EXP_IGNORED_MISSING_SUFFIXES.copy(),
+        )
+        return loader.load_weights(weights, mapper=self.hf_to_vllm_mapper)
+
+
+@support_torch_compile(
+    dynamic_arg_dims={
+        "input_ids": 0,
+        "positions": -1,
+        "intermediate_tensors": 0,
+        "inputs_embeds": 0,
+        "hidden_states": 0,
+    }
+)
+class Qwen4ExpMTP(nn.Module, SupportsPP, Qwen4ExpMixtureOfExperts):
+    packed_modules_mapping = {
+        "qkv_proj": ["q_proj", "k_proj", "v_proj"],
+        "gate_up_proj": ["gate_proj", "up_proj"],
+        "in_proj_qkvz": ["in_proj_qkv", "in_proj_z"],
+        "in_proj_ba": ["in_proj_b", "in_proj_a"],
+        "input_mix_weight_down_block_inject": [
+            "input_mix_weight_down",
+            "block_inject_weight",
+            "_input_mix_padding",
+        ],
+    }
+
+    def __init__(self, *, vllm_config: VllmConfig, prefix: str = "") -> None:
+        config: Qwen4ExpTextConfig = vllm_config.model_config.hf_text_config
+        self.vllm_config = vllm_config
+        cache_config = vllm_config.cache_config
+        if cache_config.mamba_cache_mode == "all":
+            raise NotImplementedError(
+                "Qwen4ExpMTP currently does not support 'all' prefix caching, "
+                "please use '--mamba-cache-mode=align' instead"
+            )
+
+        self.quant_config = vllm_config.quant_config
+
+        super().__init__()
+        self.config = config
+        self.model = Qwen4ExpMultiTokenPredictor(
+            vllm_config=vllm_config,
+            prefix=maybe_prefix(prefix, "mtp"),
+        )
+
+        if get_pp_group().is_last_rank:
+            if config.tie_word_embeddings:
+                self.lm_head = self.model.embed_tokens
+            else:
+                self.lm_head = ParallelLMHead(
+                    config.vocab_size,
+                    config.hidden_size,
+                    prefix=maybe_prefix(prefix, "lm_head"),
+                )
+        else:
+            self.lm_head = PPMissingLayer()
+
+        self.logits_processor = LogitsProcessor(config.vocab_size)
+        self.make_empty_intermediate_tensors = (
+            self.model.make_empty_intermediate_tensors
+        )
+        self.set_moe_parameters(self.model.layers)
+        enable_qwen4_exp_low_latency_gemm(self, vllm_config.model_config.dtype)
+
+    def embed_input_ids(self, input_ids: torch.Tensor) -> torch.Tensor:
+        return self.model.embed_input_ids(input_ids)
+
+    def forward(
+        self,
+        input_ids: torch.Tensor | None,
+        positions: torch.Tensor,
+        hidden_states: torch.Tensor | None = None,
+        intermediate_tensors: IntermediateTensors | None = None,
+        inputs_embeds: torch.Tensor | None = None,
+        spec_step_idx: int = 0,
+    ) -> torch.Tensor | tuple[torch.Tensor, torch.Tensor] | IntermediateTensors:
+        return self.model(
+            input_ids,
+            positions,
+            hidden_states,
+            intermediate_tensors,
+            inputs_embeds,
+            spec_step_idx=spec_step_idx,
+        )
+
+    def compute_logits(
+        self, hidden_states: torch.Tensor, spec_step_idx: int = 0
+    ) -> torch.Tensor | None:
+        return self.logits_processor(self.lm_head, hidden_states)
+
+    def load_weights(self, weights: Iterable[tuple[str, torch.Tensor]]) -> set[str]:
+        def remap_weight_names():
+            for name, weight in weights:
+                remapped_name = _remap_mtp_weight_name(name)
+                if remapped_name is not None:
+                    yield remapped_name, weight
+
+        loader = AutoWeightsLoader(
+            self,
+            skip_substrs=["hyper_connection_mixer.block_inject_weight"],
+            ignore_unexpected_suffixes=_QWEN4_EXP_IGNORED_MISSING_SUFFIXES.copy(),
+        )
+        return loader.load_weights(remap_weight_names())
+
+
+__all__ = ["Qwen4ExpMTP", "Qwen4ExpMultiTokenPredictor"]

--- a/vllm_ascend/models/qwen4_exp/nvidia/ops/__init__.py
+++ b/vllm_ascend/models/qwen4_exp/nvidia/ops/__init__.py
@@ -1,0 +1,3 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""NVIDIA-only Qwen4Exp kernels; import leaf modules directly."""

--- a/vllm_ascend/models/qwen4_exp/nvidia/ops/hc.py
+++ b/vllm_ascend/models/qwen4_exp/nvidia/ops/hc.py
@@ -1,0 +1,486 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""NVIDIA HyperConnection kernels for Qwen4Exp."""
+
+import torch
+from vllm.platforms import current_platform
+from vllm.triton_utils import tl, triton
+from vllm.utils.torch_utils import direct_register_custom_op
+
+
+@triton.jit
+def _grouped_gemma_rmsnorm_kernel(
+    x_ptr,
+    w_ptr,
+    y_ptr,
+    stride_x,
+    stride_y,
+    DIM: tl.constexpr,
+    NUM_GROUPS: tl.constexpr,
+    W_SHARED: tl.constexpr,
+    EPS: tl.constexpr,
+    launch_pdl: tl.constexpr,
+) -> None:
+    GROUP_DIM: tl.constexpr = DIM // NUM_GROUPS
+    BLOCK_SIZE: tl.constexpr = triton.next_power_of_2(GROUP_DIM)
+
+    pid = tl.program_id(0)
+    group_id = pid % NUM_GROUPS
+    row = pid // NUM_GROUPS
+
+    offs_g = tl.arange(0, BLOCK_SIZE)
+    offsets = group_id * GROUP_DIM + offs_g
+    mask = offs_g < GROUP_DIM
+    # A [GROUP_DIM] affine is shared; a [DIM] affine follows the grouped
+    # checkpoint layout.
+    w_offs = offs_g if W_SHARED else offsets
+
+    if launch_pdl:
+        tl.extra.cuda.gdc_wait()
+
+    x = tl.load(x_ptr + row * stride_x + offsets, mask, other=0.0).to(tl.float32)
+    w = tl.load(w_ptr + w_offs, mask, other=0.0)
+
+    rrms = tl.rsqrt(tl.sum(x * x) / GROUP_DIM + EPS)
+    # Gemma's (1 + w) affine is written this way to lower to an FMA.
+    y = x * rrms
+    y += y * w.to(tl.float32)
+
+    if launch_pdl:
+        tl.extra.cuda.gdc_launch_dependents()
+    tl.store(y_ptr + row * stride_y + offsets, y, mask)
+
+
+def _grouped_gemma_rmsnorm(
+    x: torch.Tensor, weight: torch.Tensor, eps: float, num_groups: int
+) -> torch.Tensor:
+    N, DIM = x.shape
+    assert x.stride(1) == 1, "grouped Gemma RMSNorm requires unit inner stride"
+    assert weight.is_contiguous(), "grouped Gemma RMSNorm weight must be contiguous"
+    assert DIM % num_groups == 0
+    group_dim = DIM // num_groups
+    assert weight.numel() in (group_dim, DIM)
+
+    y = x.new_empty(x.shape)
+    _grouped_gemma_rmsnorm_kernel[(N * num_groups,)](
+        x,
+        weight,
+        y,
+        x.stride(0),
+        y.stride(0),
+        DIM,
+        num_groups,
+        W_SHARED=weight.numel() == group_dim,
+        EPS=eps,
+        launch_pdl=current_platform.is_arch_support_pdl(),
+    )
+    return y
+
+
+@triton.jit
+def _hc_silu_kernel(
+    x_ptr,
+    y_ptr,
+    stride_x,
+    stride_y,
+    DIM: tl.constexpr,
+    HC: tl.constexpr,
+    launch_pdl: tl.constexpr,
+) -> None:
+    BLOCK_SIZE: tl.constexpr = triton.next_power_of_2(DIM)
+
+    row = tl.program_id(0)
+    offs = tl.arange(0, BLOCK_SIZE)
+    mask = offs < DIM
+
+    if launch_pdl:
+        tl.extra.cuda.gdc_wait()
+
+    x = tl.load(x_ptr + row * stride_x + offs, mask).to(tl.float32) / HC
+    y = x * tl.sigmoid(x)
+
+    if launch_pdl:
+        tl.extra.cuda.gdc_launch_dependents()
+    tl.store(y_ptr + row * stride_y + offs, y, mask)
+
+
+def _hc_silu(x: torch.Tensor, hc_count: int) -> torch.Tensor:
+    num_tokens, DIM = x.shape
+    assert x.stride(1) == 1
+
+    output = x.new_empty(x.shape)
+    _hc_silu_kernel[(num_tokens,)](
+        x,
+        output,
+        x.stride(0),
+        output.stride(0),
+        DIM=DIM,
+        HC=hc_count,
+        launch_pdl=current_platform.is_arch_support_pdl(),
+    )
+    return output
+
+
+@triton.jit
+def _hc_gate_mix_kernel(
+    x_ptr,
+    g_ptr,
+    y_ptr,
+    stride_x,
+    stride_g,
+    stride_y,
+    DIM: tl.constexpr,
+    HC: tl.constexpr,
+    BLOCK_SIZE: tl.constexpr,
+    launch_pdl: tl.constexpr,
+) -> None:
+    HC_DIM: tl.constexpr = DIM // HC
+
+    row = tl.program_id(0)
+    tile_id = tl.program_id(1)
+    offs_inner = tile_id * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
+    mask = offs_inner < HC_DIM
+
+    if launch_pdl:
+        tl.extra.cuda.gdc_wait()
+
+    # The constexpr loop is unrolled and keeps one stream live at a time.
+    # Materializing [HC, BLOCK_SIZE] more than doubles latency at large M.
+    acc = tl.zeros([BLOCK_SIZE], dtype=tl.float32)
+    for stream in tl.static_range(HC):
+        offsets = stream * HC_DIM + offs_inner
+        g = tl.load(g_ptr + row * stride_g + offsets, mask, other=0.0)
+        x = tl.load(x_ptr + row * stride_x + offsets, mask, other=0.0)
+        acc += tl.sigmoid(g.to(tl.float32)) * x.to(tl.float32)
+    acc /= HC
+
+    if launch_pdl:
+        tl.extra.cuda.gdc_launch_dependents()
+    tl.store(y_ptr + row * stride_y + offs_inner, acc, mask)
+
+
+def _hc_gate_mix(x: torch.Tensor, gate: torch.Tensor, hc_count: int) -> torch.Tensor:
+    N, DIM = gate.shape
+    assert x.shape == gate.shape
+    assert DIM % hc_count == 0
+    assert x.stride(1) == 1
+    assert gate.stride(1) == 1
+
+    HC_DIM = DIM // hc_count
+    out = x.new_empty(N, HC_DIM)
+    BLOCK_SIZE = 512
+    _hc_gate_mix_kernel[(N, triton.cdiv(HC_DIM, BLOCK_SIZE))](
+        x,
+        gate,
+        out,
+        x.stride(0),
+        gate.stride(0),
+        out.stride(0),
+        DIM,
+        hc_count,
+        BLOCK_SIZE,
+        launch_pdl=current_platform.is_arch_support_pdl(),
+    )
+    return out
+
+
+@triton.jit
+def _hc_combine_kernel(
+    block_ptr,
+    res_ptr,
+    inj_ptr,
+    out_ptr,
+    stride_block,
+    stride_res,
+    stride_inj,
+    stride_out,
+    HC_DIM: tl.constexpr,
+    HC: tl.constexpr,
+    BLOCK_SIZE: tl.constexpr,
+    launch_pdl: tl.constexpr,
+) -> None:
+    HC_PAD: tl.constexpr = triton.next_power_of_2(HC)
+
+    row = tl.program_id(0)
+    tile_id = tl.program_id(1)
+
+    offs_inner = tile_id * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
+    mask_inner = offs_inner < HC_DIM
+    offs_hc = tl.arange(0, HC_PAD)
+    mask_hc = offs_hc < HC
+    offs = offs_hc[:, None] * HC_DIM + offs_inner[None, :]
+    mask = mask_hc[:, None] & mask_inner[None, :]
+
+    if launch_pdl:
+        tl.extra.cuda.gdc_wait()
+
+    inj = tl.load(inj_ptr + row * stride_inj + offs_hc, mask_hc, other=0.0)
+    block = tl.load(block_ptr + row * stride_block + offs_inner, mask_inner, other=0.0)
+    res = tl.load(res_ptr + row * stride_res + offs, mask, other=0.0)
+
+    # Keeping HC as a broadcast dimension is faster here than four separate
+    # residual load/store sequences.
+    inj = 2.0 * tl.sigmoid(inj.to(tl.float32) / HC)
+    out = res.to(tl.float32) + block.to(tl.float32)[None, :] * inj[:, None]
+
+    if launch_pdl:
+        tl.extra.cuda.gdc_launch_dependents()
+    tl.store(out_ptr + row * stride_out + offs, out, mask=mask)
+
+
+def _hc_combine(
+    residual: torch.Tensor,
+    block_output: torch.Tensor,
+    injection_logits: torch.Tensor,
+    hc_count: int,
+) -> torch.Tensor:
+    N, DIM = residual.shape
+    assert DIM % hc_count == 0
+    hc_dim = DIM // hc_count
+    assert block_output.shape == (N, hc_dim)
+    assert injection_logits.shape == (N, hc_count)
+    assert residual.stride(1) == 1
+    assert block_output.stride(1) == 1
+    assert injection_logits.stride(1) == 1
+
+    out = residual.new_empty(residual.shape)
+    BLOCK_SIZE = 512
+    _hc_combine_kernel[(N, triton.cdiv(hc_dim, BLOCK_SIZE))](
+        block_output,
+        residual,
+        injection_logits,
+        out,
+        block_output.stride(0),
+        residual.stride(0),
+        injection_logits.stride(0),
+        out.stride(0),
+        hc_dim,
+        hc_count,
+        BLOCK_SIZE,
+        launch_pdl=current_platform.is_arch_support_pdl(),
+    )
+    return out
+
+
+@triton.jit
+def _hc_combine_norm_kernel(
+    block_ptr,
+    res_ptr,
+    inj_ptr,
+    w_ptr,
+    out_ptr,
+    y_ptr,
+    stride_block,
+    stride_res,
+    stride_inj,
+    stride_out,
+    stride_y,
+    HC_DIM: tl.constexpr,
+    HC: tl.constexpr,
+    W_SHARED: tl.constexpr,
+    EPS: tl.constexpr,
+    BLOCK_SIZE: tl.constexpr,
+    launch_pdl: tl.constexpr,
+) -> None:
+    HC_PAD: tl.constexpr = triton.next_power_of_2(HC)
+    NUM_TILES: tl.constexpr = triton.cdiv(HC_DIM, BLOCK_SIZE)
+    NUM_TILES_PAD: tl.constexpr = triton.next_power_of_2(NUM_TILES)
+
+    row = tl.program_id(0)
+    stream = tl.program_id(1)
+    offs_hc = tl.arange(0, HC_PAD)
+    mask_hc = offs_hc < HC
+    tile_ids = tl.arange(0, NUM_TILES_PAD)
+    offs_inner = tile_ids[:, None] * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)[None, :]
+    mask_inner = offs_inner < HC_DIM
+    offs = stream * HC_DIM + offs_inner
+    # Shared norm weights repeat across streams; per-branch weights use the
+    # same flattened HC layout as the residual.
+    w_offs = offs_inner if W_SHARED else offs
+
+    if launch_pdl:
+        tl.extra.cuda.gdc_wait()
+
+    # Start the uncached residual load first, then issue the other combine
+    # loads before consuming any of them.
+    res = tl.load(res_ptr + row * stride_res + offs, mask_inner, other=0.0)
+    inj = tl.load(inj_ptr + row * stride_inj + offs_hc, mask_hc, other=0.0)
+    block = tl.load(block_ptr + row * stride_block + offs_inner, mask_inner, other=0.0)
+    inj = 2.0 * tl.sigmoid(inj.to(tl.float32) / HC)
+    inj = tl.sum(tl.where(offs_hc == stream, inj, 0.0))
+    # Round the materialized combine result before normalization. This matches
+    # the unfused combine -> RMSNorm boundary.
+    out = (res.to(tl.float32) + block.to(tl.float32) * inj).to(out_ptr.dtype.element_ty)
+    tl.store(out_ptr + row * stride_out + offs, out, mask=mask_inner)
+
+    out = out.to(tl.float32)
+    # Keep the two-axis reduction: flattening the padded tile is ~40% slower
+    # at decode sizes.
+    sum_sq = tl.sum(tl.sum(out * out, axis=1), axis=0)
+    rrms = tl.rsqrt(sum_sq / HC_DIM + EPS)
+
+    if launch_pdl:
+        tl.extra.cuda.gdc_launch_dependents()
+
+    # Loading the weight earlier helps decode but keeps the tile live across
+    # the reduction and regresses larger batches, so defer it to the norm.
+    w = tl.load(w_ptr + w_offs, mask_inner, other=0.0)
+    y = out * rrms
+    y += y * w.to(tl.float32)
+    tl.store(y_ptr + row * stride_y + offs, y, mask_inner)
+
+
+def _hc_combine_norm(
+    residual: torch.Tensor,
+    block_output: torch.Tensor,
+    injection_logits: torch.Tensor,
+    norm_weight: torch.Tensor,
+    eps: float,
+    hc_count: int,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    N, DIM = residual.shape
+    assert DIM % hc_count == 0
+    hc_dim = DIM // hc_count
+    assert block_output.shape == (N, hc_dim)
+    assert injection_logits.shape == (N, hc_count)
+    assert residual.stride(1) == 1
+    assert block_output.stride(1) == 1
+    assert injection_logits.stride(1) == 1
+    assert norm_weight.is_contiguous()
+    assert norm_weight.numel() in (hc_dim, DIM)
+
+    out = residual.new_empty(residual.shape)
+    y = residual.new_empty(residual.shape)
+    BLOCK_SIZE = 512
+    _hc_combine_norm_kernel[(N, hc_count)](
+        block_output,
+        residual,
+        injection_logits,
+        norm_weight,
+        out,
+        y,
+        block_output.stride(0),
+        residual.stride(0),
+        injection_logits.stride(0),
+        out.stride(0),
+        y.stride(0),
+        hc_dim,
+        hc_count,
+        W_SHARED=norm_weight.numel() == hc_dim,
+        EPS=eps,
+        BLOCK_SIZE=BLOCK_SIZE,
+        launch_pdl=current_platform.is_arch_support_pdl(),
+    )
+    return out, y
+
+
+def _same_shape_fake(x: torch.Tensor, *args) -> torch.Tensor:
+    return x.new_empty(x.shape)
+
+
+def _hc_gate_mix_fake(
+    x: torch.Tensor, gate: torch.Tensor, hc_count: int
+) -> torch.Tensor:
+    del gate
+    return x.new_empty((x.shape[0], x.shape[1] // hc_count))
+
+
+def _hc_combine_fake(
+    residual: torch.Tensor,
+    block_output: torch.Tensor,
+    injection_logits: torch.Tensor,
+    hc_count: int,
+) -> torch.Tensor:
+    del block_output, injection_logits, hc_count
+    return residual.new_empty(residual.shape)
+
+
+def _hc_combine_norm_fake(
+    residual: torch.Tensor,
+    block_output: torch.Tensor,
+    injection_logits: torch.Tensor,
+    norm_weight: torch.Tensor,
+    eps: float,
+    hc_count: int,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    del block_output, injection_logits, norm_weight, eps, hc_count
+    return residual.new_empty(residual.shape), residual.new_empty(residual.shape)
+
+
+direct_register_custom_op(
+    op_name="qwen4_exp_grouped_gemma_rmsnorm",
+    op_func=_grouped_gemma_rmsnorm,
+    fake_impl=_same_shape_fake,
+)
+direct_register_custom_op(
+    op_name="qwen4_exp_hc_silu",
+    op_func=_hc_silu,
+    fake_impl=_same_shape_fake,
+)
+direct_register_custom_op(
+    op_name="qwen4_exp_hc_gate_mix",
+    op_func=_hc_gate_mix,
+    fake_impl=_hc_gate_mix_fake,
+)
+direct_register_custom_op(
+    op_name="qwen4_exp_hc_combine",
+    op_func=_hc_combine,
+    fake_impl=_hc_combine_fake,
+)
+direct_register_custom_op(
+    op_name="qwen4_exp_hc_combine_norm",
+    op_func=_hc_combine_norm,
+    fake_impl=_hc_combine_norm_fake,
+)
+
+
+def grouped_gemma_rmsnorm(
+    x: torch.Tensor, weight: torch.Tensor, eps: float, num_groups: int
+) -> torch.Tensor:
+    return torch.ops.vllm.qwen4_exp_grouped_gemma_rmsnorm(x, weight, eps, num_groups)
+
+
+def hc_silu(x: torch.Tensor, hc_count: int) -> torch.Tensor:
+    return torch.ops.vllm.qwen4_exp_hc_silu(x, hc_count)
+
+
+def hc_gate_mix(x: torch.Tensor, gate: torch.Tensor, hc_count: int) -> torch.Tensor:
+    return torch.ops.vllm.qwen4_exp_hc_gate_mix(x, gate, hc_count)
+
+
+def hc_combine(
+    residual: torch.Tensor,
+    block_output: torch.Tensor,
+    injection_logits: torch.Tensor,
+    hc_count: int,
+) -> torch.Tensor:
+    return torch.ops.vllm.qwen4_exp_hc_combine(
+        residual, block_output, injection_logits, hc_count
+    )
+
+
+def hc_combine_norm(
+    residual: torch.Tensor,
+    block_output: torch.Tensor,
+    injection_logits: torch.Tensor,
+    norm_weight: torch.Tensor,
+    eps: float,
+    hc_count: int,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    return torch.ops.vllm.qwen4_exp_hc_combine_norm(
+        residual,
+        block_output,
+        injection_logits,
+        norm_weight,
+        eps,
+        hc_count,
+    )
+
+
+__all__ = [
+    "grouped_gemma_rmsnorm",
+    "hc_combine",
+    "hc_combine_norm",
+    "hc_gate_mix",
+    "hc_silu",
+]

--- a/vllm_ascend/models/qwen4_exp/nvidia/ops/qsa.py
+++ b/vllm_ascend/models/qwen4_exp/nvidia/ops/qsa.py
@@ -1,0 +1,1114 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Triton kernels for the Qwen4Exp weight-free QSA path."""
+
+from __future__ import annotations
+
+import math
+
+import torch
+from vllm.platforms import current_platform
+from vllm.triton_utils import HAS_TRITON, tl, triton
+
+_LOGITS_WORKSPACE_BYTES = 128 * 1024 * 1024
+_TOPK_WORKSPACE_BYTES = 1024 * 1024
+
+
+@triton.jit
+def _qsa_mqa_paged_kernel(
+    q_ptr,
+    k_cache_ptr,
+    page_table_ptr,
+    token_to_req_ptr,
+    query_positions_ptr,
+    sequence_lengths_ptr,
+    visible_blocks_ptr,
+    logits_ptr,
+    stride_q_row,
+    stride_q_head,
+    stride_q_dim,
+    stride_cache_block,
+    stride_cache_token,
+    stride_cache_dim,
+    stride_table_req,
+    stride_table_page,
+    stride_logits_row,
+    num_rows,
+    num_columns,
+    num_pages,
+    num_requests,
+    score_divisor,
+    PAGE_SIZE: tl.constexpr,
+    PAGE_TABLE_WIDTH: tl.constexpr,
+    NUM_HEADS: tl.constexpr,
+    HEAD_DIM: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+    BLOCK_D: tl.constexpr,
+    TILES_PER_PROG: tl.constexpr,
+    STAGES: tl.constexpr,
+    MAX_N: tl.constexpr,
+    COMPRESS_RATIO: tl.constexpr,
+) -> None:
+    row = tl.program_id(0)
+    dims = tl.arange(0, BLOCK_D)
+    heads = tl.arange(0, MAX_N)
+    request = tl.load(token_to_req_ptr + row)
+    safe_request = tl.minimum(tl.maximum(request, 0), num_requests - 1)
+    query_position = tl.load(query_positions_ptr + row)
+    sequence_length = tl.load(
+        sequence_lengths_ptr + safe_request,
+        mask=(request >= 0) & (request < num_requests),
+        other=0,
+    )
+    visible = tl.minimum(
+        (query_position + 1) // COMPRESS_RATIO,
+        sequence_length // COMPRESS_RATIO,
+    )
+    if tl.program_id(1) == 0:
+        tl.store(visible_blocks_ptr + row, visible)
+    tile_start = tl.program_id(1) * TILES_PER_PROG
+    # Top-k is bounded by visible_blocks, so columns beyond it need no value.
+    if tile_start * BLOCK_N >= visible:
+        return
+    tile_end = tl.minimum(tile_start + TILES_PER_PROG, tl.cdiv(visible, BLOCK_N))
+    tile_end = tl.minimum(tile_end, tl.cdiv(num_columns, BLOCK_N))
+
+    # Pad the small head axis to a tensor-core-compatible N dimension.
+    query = tl.load(
+        q_ptr
+        + row * stride_q_row
+        + heads[None, :] * stride_q_head
+        + dims[:, None] * stride_q_dim,
+        mask=(heads[None, :] < NUM_HEADS) & (dims[:, None] < HEAD_DIM),
+        other=0.0,
+    )
+    column_offsets = tl.arange(0, BLOCK_N)
+    for tile in tl.range(tile_start, tile_end, num_stages=STAGES):
+        columns = tile * BLOCK_N + column_offsets
+        live = columns < visible
+        logical_page = tl.minimum(columns // PAGE_SIZE, PAGE_TABLE_WIDTH - 1)
+        page_offset = columns % PAGE_SIZE
+        physical_page = tl.load(
+            page_table_ptr
+            + safe_request * stride_table_req
+            + logical_page * stride_table_page,
+            mask=live,
+            other=-1,
+        )
+        page_valid = live & (physical_page >= 0) & (physical_page < num_pages)
+        # physical_page * block stride can overflow int32 for large caches.
+        safe_physical_page = tl.maximum(physical_page, 0).to(tl.int64)
+        keys = tl.load(
+            k_cache_ptr
+            + safe_physical_page[:, None] * stride_cache_block
+            + page_offset[:, None] * stride_cache_token
+            + dims[None, :] * stride_cache_dim,
+            mask=page_valid[:, None] & (dims[None, :] < HEAD_DIM),
+            other=0.0,
+            eviction_policy="evict_first",
+        )
+        scores = tl.dot(keys, query, out_dtype=tl.float32)
+        scores = tl.where(heads[None, :] < NUM_HEADS, tl.maximum(scores, 0.0), 0.0)
+        score = tl.sum(scores, axis=1) / score_divisor
+        tl.store(
+            logits_ptr + row * stride_logits_row + columns,
+            tl.where(page_valid, score, -float("inf")),
+            mask=live & (columns < num_columns),
+        )
+
+
+@triton.jit
+def _expand_qsa_indices_kernel(
+    block_indices_ptr,
+    query_positions_ptr,
+    sequence_lengths_ptr,
+    token_to_req_ptr,
+    output_ptr,
+    stride_blocks_row,
+    stride_blocks_column,
+    stride_output_row,
+    stride_output_column,
+    rows,
+    num_requests,
+    BLOCK_TOPK: tl.constexpr,
+    COMPRESS_RATIO: tl.constexpr,
+    TOKEN_TOPK: tl.constexpr,
+    OUTPUT_WIDTH: tl.constexpr,
+    COLUMN_BLOCK: tl.constexpr,
+) -> None:
+    row = tl.program_id(0)
+    columns = tl.program_id(1) * COLUMN_BLOCK + tl.arange(0, COLUMN_BLOCK)
+    query_position = tl.load(query_positions_ptr + row)
+    request = tl.load(token_to_req_ptr + row)
+    safe_request = tl.minimum(tl.maximum(request, 0), num_requests - 1)
+    sequence_length = tl.load(
+        sequence_lengths_ptr + safe_request,
+        mask=(request >= 0) & (request < num_requests),
+        other=0,
+    )
+    complete_blocks = tl.minimum(
+        tl.minimum(
+            (query_position + 1) // COMPRESS_RATIO,
+            sequence_length // COMPRESS_RATIO,
+        ),
+        BLOCK_TOPK,
+    )
+    expanded_count = complete_blocks * COMPRESS_RATIO
+    tail_start = ((query_position + 1) // COMPRESS_RATIO) * COMPRESS_RATIO
+    tail_count = (query_position + 1) - tail_start
+
+    is_expanded = columns < expanded_count
+    block_rank = columns // COMPRESS_RATIO
+    offset = columns % COMPRESS_RATIO
+    safe_rank = tl.minimum(block_rank, BLOCK_TOPK - 1)
+    block = tl.load(
+        block_indices_ptr + row * stride_blocks_row + safe_rank * stride_blocks_column,
+        mask=(row < rows) & is_expanded,
+        other=-1,
+    )
+    expanded = block * COMPRESS_RATIO + offset
+    tail_offset = columns - expanded_count
+    is_tail = (
+        (columns >= expanded_count)
+        & (tail_offset < tail_count)
+        & (tail_offset < COMPRESS_RATIO - 1)
+    )
+    token = tl.where(is_expanded, expanded, tail_start + tail_offset)
+    valid = (
+        (row < rows)
+        & (columns < OUTPUT_WIDTH)
+        & (is_expanded | is_tail)
+        & (token >= 0)
+        & (token < sequence_length)
+    )
+    tl.store(
+        output_ptr + row * stride_output_row + columns * stride_output_column,
+        tl.where(valid, token, -1),
+        mask=(row < rows) & (columns < OUTPUT_WIDTH),
+    )
+
+
+@triton.jit
+def _qsa_sparse_paged_gqa_splitk_kernel(
+    q_ptr,
+    k_cache_ptr,
+    v_cache_ptr,
+    indices_ptr,
+    block_table_ptr,
+    token_to_req_ptr,
+    partial_output_ptr,
+    partial_lse_ptr,
+    output_ptr,
+    stride_q_row,
+    stride_q_head,
+    stride_k_block,
+    stride_k_token,
+    stride_k_head,
+    stride_v_block,
+    stride_v_token,
+    stride_v_head,
+    stride_indices_row,
+    stride_table_req,
+    stride_output_row,
+    stride_output_head,
+    num_rows,
+    num_cache_blocks,
+    num_requests,
+    TOPK: tl.constexpr,
+    PAGE_SIZE: tl.constexpr,
+    PAGE_TABLE_WIDTH: tl.constexpr,
+    GROUP_SIZE: tl.constexpr,
+    HEAD_DIM: tl.constexpr,
+    NUM_QUERY_HEADS: tl.constexpr,
+    NUM_SPLITS: tl.constexpr,
+    NUM_TILES: tl.constexpr,
+    BLOCK_M: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+) -> None:
+    row = tl.program_id(0)
+    kv_head = tl.program_id(1)
+    split_id = tl.program_id(2)
+    request = tl.load(token_to_req_ptr + row)
+    safe_request = tl.minimum(tl.maximum(request, 0), num_requests - 1)
+
+    head_offsets = tl.arange(0, BLOCK_M)
+    dim_offsets = tl.arange(0, HEAD_DIM)
+    column_offsets = tl.arange(0, BLOCK_N)
+    first_head = kv_head * GROUP_SIZE
+    query = tl.load(
+        q_ptr
+        + row * stride_q_row
+        + (first_head + head_offsets[:, None]) * stride_q_head
+        + dim_offsets[None, :],
+        mask=head_offsets[:, None] < GROUP_SIZE,
+        other=0.0,
+    )
+
+    max_value = tl.full((BLOCK_M,), -1.0e20, dtype=tl.float32)
+    normalizer = tl.zeros((BLOCK_M,), dtype=tl.float32)
+    accumulator = tl.zeros((BLOCK_M, HEAD_DIM), dtype=tl.float32)
+    softmax_scale_log2: tl.constexpr = (HEAD_DIM**-0.5) * 1.4426950408889634
+
+    # Dynamic bounds avoid padded main-loop iterations for uneven splits.
+    split_tile_start = split_id * NUM_TILES // NUM_SPLITS
+    split_tile_end = (split_id + 1) * NUM_TILES // NUM_SPLITS
+    for tile in range(split_tile_start, split_tile_end):
+        columns = tile * BLOCK_N + column_offsets
+        logical_token = tl.load(
+            indices_ptr + row * stride_indices_row + columns,
+            mask=columns < TOPK,
+            other=-1,
+        )
+        safe_token = tl.maximum(logical_token, 0)
+        logical_page = safe_token // PAGE_SIZE
+        page_offset = safe_token % PAGE_SIZE
+        valid = (
+            (request >= 0)
+            & (request < num_requests)
+            & (logical_token >= 0)
+            & (logical_page < PAGE_TABLE_WIDTH)
+        )
+        physical_page = tl.load(
+            block_table_ptr
+            + safe_request * stride_table_req
+            + tl.minimum(logical_page, PAGE_TABLE_WIDTH - 1),
+            mask=valid,
+            other=-1,
+        )
+        valid &= (physical_page >= 0) & (physical_page < num_cache_blocks)
+        # physical_page * block stride can overflow int32 for large caches.
+        safe_page = tl.maximum(physical_page, 0).to(tl.int64)
+        keys = tl.load(
+            k_cache_ptr
+            + safe_page[None, :] * stride_k_block
+            + page_offset[None, :] * stride_k_token
+            + kv_head * stride_k_head
+            + dim_offsets[:, None],
+            mask=valid[None, :],
+            other=0.0,
+        )
+        values = tl.load(
+            v_cache_ptr
+            + safe_page[:, None] * stride_v_block
+            + page_offset[:, None] * stride_v_token
+            + kv_head * stride_v_head
+            + dim_offsets[None, :],
+            mask=valid[:, None],
+            other=0.0,
+        )
+        scores = tl.dot(query, keys)
+        # Scaling scores avoids re-quantizing a scaled query to BF16.
+        scores *= softmax_scale_log2
+        scores = tl.where(valid[None, :], scores, -1.0e20)
+        next_max = tl.maximum(max_value, tl.max(scores, axis=1))
+        alpha = tl.math.exp2(max_value - next_max)
+        probabilities = tl.where(
+            valid[None, :], tl.math.exp2(scores - next_max[:, None]), 0.0
+        )
+        accumulator = tl.dot(
+            probabilities.to(values.dtype),
+            values,
+            acc=accumulator * alpha[:, None],
+        )
+        normalizer = normalizer * alpha + tl.sum(probabilities, axis=1)
+        max_value = next_max
+
+    has_values = normalizer > 0
+    normalized_output = tl.where(
+        has_values[:, None],
+        accumulator / tl.maximum(normalizer[:, None], 1.0e-20),
+        0.0,
+    )
+    output_mask = head_offsets[:, None] < GROUP_SIZE
+    if NUM_SPLITS == 1:
+        tl.store(
+            output_ptr
+            + row * stride_output_row
+            + (first_head + head_offsets[:, None]) * stride_output_head
+            + dim_offsets[None, :],
+            normalized_output,
+            mask=output_mask,
+        )
+    else:
+        partial_lse = tl.where(
+            has_values,
+            max_value + tl.math.log2(tl.maximum(normalizer, 1.0e-20)),
+            -float("inf"),
+        )
+        tl.store(
+            partial_output_ptr
+            + (
+                (split_id * num_rows + row) * NUM_QUERY_HEADS
+                + first_head
+                + head_offsets[:, None]
+            )
+            * HEAD_DIM
+            + dim_offsets[None, :],
+            normalized_output,
+            mask=output_mask,
+        )
+        tl.store(
+            partial_lse_ptr
+            + (split_id * num_rows + row) * NUM_QUERY_HEADS
+            + first_head
+            + head_offsets,
+            partial_lse,
+            mask=head_offsets < GROUP_SIZE,
+        )
+
+
+@triton.jit
+def _qsa_merge_splitk_kernel(
+    partial_output_ptr,
+    partial_lse_ptr,
+    output_ptr,
+    stride_output_row,
+    stride_output_head,
+    num_rows,
+    HEAD_DIM: tl.constexpr,
+    NUM_QUERY_HEADS: tl.constexpr,
+    NUM_SPLITS: tl.constexpr,
+    BLOCK_SPLITS: tl.constexpr,
+) -> None:
+    row = tl.program_id(0)
+    head = tl.program_id(1)
+    split_offsets = tl.arange(0, BLOCK_SPLITS)
+    dim_offsets = tl.arange(0, HEAD_DIM)
+    split_mask = split_offsets < NUM_SPLITS
+    lse = tl.load(
+        partial_lse_ptr + (split_offsets * num_rows + row) * NUM_QUERY_HEADS + head,
+        mask=split_mask,
+        other=-float("inf"),
+    )
+    lse_max = tl.max(lse, axis=0)
+    has_values = lse_max > -float("inf")
+    shifted = tl.where(split_mask & has_values, lse - lse_max, -float("inf"))
+    weights = tl.math.exp2(shifted)
+    denominator = tl.sum(weights, axis=0)
+    partial_output = tl.load(
+        partial_output_ptr
+        + ((split_offsets[:, None] * num_rows + row) * NUM_QUERY_HEADS + head)
+        * HEAD_DIM
+        + dim_offsets[None, :],
+        mask=split_mask[:, None],
+        other=0.0,
+    )
+    merged = tl.sum(partial_output * weights[:, None], axis=0)
+    merged = tl.where(denominator > 0, merged / denominator, 0.0)
+    tl.store(
+        output_ptr + row * stride_output_row + head * stride_output_head + dim_offsets,
+        merged,
+    )
+
+
+@triton.jit
+def _store_qsa_rows_kernel(
+    cache_ptr,
+    slots_ptr,
+    rows_ptr,
+    stride_cache_block,
+    stride_cache_token,
+    stride_cache_dim,
+    stride_rows_row,
+    stride_rows_dim,
+    num_rows,
+    num_blocks,
+    PAGE_SIZE: tl.constexpr,
+    WIDTH: tl.constexpr,
+    BLOCK_D: tl.constexpr,
+) -> None:
+    row = tl.program_id(0)
+    dims = tl.arange(0, BLOCK_D)
+    slot = tl.load(slots_ptr + row)
+    valid = (row < num_rows) & (slot >= 0) & (slot < num_blocks * PAGE_SIZE)
+    block = tl.maximum(slot, 0) // PAGE_SIZE
+    token = tl.maximum(slot, 0) % PAGE_SIZE
+    values = tl.load(
+        rows_ptr + row * stride_rows_row + dims * stride_rows_dim,
+        mask=valid & (dims < WIDTH),
+        other=0,
+    )
+    tl.store(
+        cache_ptr
+        + block * stride_cache_block
+        + token * stride_cache_token
+        + dims * stride_cache_dim,
+        values,
+        mask=valid & (dims < WIDTH),
+    )
+
+
+@triton.jit
+def _compress_qsa_groups_kernel(
+    raw_keys_ptr,  # this step's raw key rows, straight from activations
+    raw_positions_ptr,  # this step's per-token positions
+    compressor_state_cache_ptr,  # per-request ring of previous raw keys
+    rope_cache_ptr,  # packed RoPE position tail of the ring
+    compressor_state_table_ptr,
+    token_to_req_ptr,
+    query_start_loc_ptr,
+    logical_positions_ptr,
+    compressed_slots_ptr,
+    pooled_ptr,
+    first_positions_ptr,
+    stride_raw_row,
+    stride_raw_dim,
+    stride_raw_positions_row,
+    stride_raw_positions_dim,
+    stride_compressor_state_block,
+    stride_compressor_state_token,
+    stride_compressor_state_dim,
+    stride_rope_block,
+    stride_rope_token,
+    stride_rope_dim,
+    stride_compressor_state_table_req,
+    stride_pooled_row,
+    stride_pooled_dim,
+    stride_positions_row,
+    stride_positions_dim,
+    num_rows,
+    num_compressor_state_blocks,
+    num_requests,
+    COMPRESSOR_STATE_SIZE: tl.constexpr,
+    COMPRESS_RATIO: tl.constexpr,
+    HEAD_DIM: tl.constexpr,
+    BLOCK_D: tl.constexpr,
+    LOAD_ROPE_POSITIONS: tl.constexpr,
+) -> None:
+    row = tl.program_id(0)
+    dims = tl.arange(0, BLOCK_D)
+    request = tl.load(token_to_req_ptr + row)
+    end_position = tl.load(logical_positions_ptr + row)
+    compressed_slot = tl.load(compressed_slots_ptr + row)
+    valid_request = (request >= 0) & (request < num_requests)
+    safe_request = tl.minimum(tl.maximum(request, 0), num_requests - 1)
+    query_row_start = tl.load(
+        query_start_loc_ptr + safe_request, mask=valid_request, other=0
+    )
+    query_row_end = tl.load(
+        query_start_loc_ptr + safe_request + 1, mask=valid_request, other=0
+    )
+    chunk_start_position = end_position - (row - query_row_start)
+    compressor_state_block = tl.load(
+        compressor_state_table_ptr + safe_request * stride_compressor_state_table_req,
+        mask=valid_request,
+        other=-1,
+    )
+    valid_compressor_state_block = (compressor_state_block >= 0) & (
+        compressor_state_block < num_compressor_state_blocks
+    )
+    valid_row = (
+        (row < num_rows)
+        & valid_request
+        & (row >= query_row_start)
+        & (row < query_row_end)
+        & (end_position >= COMPRESS_RATIO - 1)
+        & (compressed_slot >= 0)
+    )
+    accumulator = tl.zeros((BLOCK_D,), dtype=tl.float32)
+
+    # A group can span the compressor-state ring (older members) and this
+    # step's raw rows (members at positions >= chunk_start_position).
+    for group_offset in tl.range(0, COMPRESS_RATIO):
+        position = end_position - (COMPRESS_RATIO - 1 - group_offset)
+        use_raw = position >= chunk_start_position
+        raw_row = query_row_start + position - chunk_start_position
+        raw_values = tl.load(
+            raw_keys_ptr + raw_row * stride_raw_row + dims * stride_raw_dim,
+            mask=valid_row
+            & use_raw
+            & (raw_row >= query_row_start)
+            & (raw_row < query_row_end)
+            & (raw_row < num_rows)
+            & (dims < HEAD_DIM),
+            other=0.0,
+        ).to(tl.float32)
+        compressor_state_values = tl.load(
+            compressor_state_cache_ptr
+            + tl.maximum(compressor_state_block, 0).to(tl.int64)
+            * stride_compressor_state_block
+            + (position % COMPRESSOR_STATE_SIZE) * stride_compressor_state_token
+            + dims * stride_compressor_state_dim,
+            mask=valid_row
+            & ~use_raw
+            & valid_compressor_state_block
+            & (dims < HEAD_DIM),
+            other=0.0,
+        ).to(tl.float32)
+        accumulator += tl.where(use_raw, raw_values, compressor_state_values)
+
+    tl.store(
+        pooled_ptr + row * stride_pooled_row + dims * stride_pooled_dim,
+        accumulator / COMPRESS_RATIO,
+        mask=(row < num_rows) & (dims < HEAD_DIM),
+    )
+
+    position_dims = tl.arange(0, 4)
+    first_position = end_position - COMPRESS_RATIO + 1
+    if LOAD_ROPE_POSITIONS:
+        first_from_raw = first_position >= chunk_start_position
+        raw_first_row = query_row_start + first_position - chunk_start_position
+        raw_position_values = tl.load(
+            raw_positions_ptr
+            + raw_first_row * stride_raw_positions_row
+            + position_dims * stride_raw_positions_dim,
+            mask=valid_row
+            & first_from_raw
+            & (raw_first_row >= query_row_start)
+            & (raw_first_row < query_row_end)
+            & (raw_first_row < num_rows)
+            & (position_dims < 3),
+            other=0,
+        )
+        compressor_state_position_values = tl.load(
+            rope_cache_ptr
+            + tl.maximum(compressor_state_block, 0).to(tl.int64) * stride_rope_block
+            + (first_position % COMPRESSOR_STATE_SIZE) * stride_rope_token
+            + position_dims * stride_rope_dim,
+            mask=valid_row
+            & ~first_from_raw
+            & valid_compressor_state_block
+            & (position_dims < 3),
+            other=0,
+        )
+        position_values = tl.where(
+            first_from_raw,
+            raw_position_values,
+            compressor_state_position_values,
+        )
+    else:
+        position_values = tl.where(valid_row, first_position, 0)
+    tl.store(
+        first_positions_ptr
+        + row * stride_positions_row
+        + position_dims * stride_positions_dim,
+        position_values,
+        mask=(row < num_rows) & (position_dims < 3),
+    )
+
+
+def _validate_mqa(q: torch.Tensor) -> None:
+    if q.ndim != 3 or q.shape[1] <= 0 or q.shape[2] <= 0:
+        raise ValueError("QSA query must be [rows, heads, head_dim]")
+
+
+def qsa_mqa_paged(
+    q: torch.Tensor,
+    k_cache: torch.Tensor,
+    page_table: torch.Tensor,
+    token_to_req: torch.Tensor,
+    query_positions: torch.Tensor,
+    sequence_lengths: torch.Tensor,
+    compress_ratio: int,
+    num_columns: int | None = None,
+    score_scale: float | None = None,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Compute QSA scores directly from a paged compressed-key cache."""
+
+    _validate_mqa(q)
+    if not q.is_cuda or not HAS_TRITON:
+        raise RuntimeError("paged QSA scoring requires CUDA and Triton")
+    if k_cache.ndim != 4 or k_cache.shape[2] != 1:
+        raise ValueError("QSA cache must be [pages, page_size, 1, head_dim]")
+    if k_cache.shape[3] != q.shape[2]:
+        raise ValueError("QSA query and cache dimensions must match")
+    if page_table.ndim != 2:
+        raise ValueError("QSA page table must be two-dimensional")
+    if q.shape[0] and (not all(k_cache.shape[:2]) or not all(page_table.shape)):
+        raise ValueError("QSA paged scoring cache and page table must be nonempty")
+    if token_to_req.shape != (q.shape[0],):
+        raise ValueError("QSA request mapping must match query rows")
+    if query_positions.shape != (q.shape[0],):
+        raise ValueError("QSA query positions must match query rows")
+    if sequence_lengths.shape != (page_table.shape[0],):
+        raise ValueError("QSA sequence lengths must match page-table requests")
+    if compress_ratio <= 0:
+        raise ValueError("QSA compression ratio must be positive")
+    score_divisor = math.sqrt(q.shape[2]) if score_scale is None else score_scale
+    if score_divisor <= 0:
+        raise ValueError("QSA score scale must be positive")
+
+    capacity = page_table.shape[1] * k_cache.shape[1]
+    columns = capacity if num_columns is None else num_columns
+    if columns < 0:
+        raise ValueError("QSA score width must be non-negative")
+    logits = torch.empty((q.shape[0], columns), dtype=torch.float32, device=q.device)
+    visible_blocks = torch.empty(q.shape[0], dtype=torch.int32, device=q.device)
+    if not q.shape[0] or not columns:
+        return logits, visible_blocks
+    BLOCK_N = 64
+    BLOCK_D = max(16, triton.next_power_of_2(q.shape[2]))
+    MAX_N = max(16, triton.next_power_of_2(q.shape[1]))
+    # Tuned on GB300: larger row batches provide enough parallelism to reuse Q.
+    tiles_per_program = 1 if q.shape[0] <= 32 else 8
+    _qsa_mqa_paged_kernel[
+        (q.shape[0], triton.cdiv(columns, BLOCK_N * tiles_per_program))
+    ](
+        q,
+        k_cache,
+        page_table,
+        token_to_req,
+        query_positions,
+        sequence_lengths,
+        visible_blocks,
+        logits,
+        q.stride(0),
+        q.stride(1),
+        q.stride(2),
+        k_cache.stride(0),
+        k_cache.stride(1),
+        k_cache.stride(3),
+        page_table.stride(0),
+        page_table.stride(1),
+        logits.stride(0),
+        q.shape[0],
+        columns,
+        k_cache.shape[0],
+        page_table.shape[0],
+        float(score_divisor),
+        PAGE_SIZE=k_cache.shape[1],
+        PAGE_TABLE_WIDTH=page_table.shape[1],
+        NUM_HEADS=q.shape[1],
+        HEAD_DIM=q.shape[2],
+        BLOCK_N=BLOCK_N,
+        BLOCK_D=BLOCK_D,
+        TILES_PER_PROG=tiles_per_program,
+        STAGES=2,
+        MAX_N=MAX_N,
+        COMPRESS_RATIO=compress_ratio,
+        num_warps=2,
+    )
+    return logits, visible_blocks
+
+
+def expand_qsa_block_indices_cuda(
+    block_indices: torch.Tensor,
+    query_positions: torch.Tensor,
+    sequence_lengths: torch.Tensor,
+    token_to_req: torch.Tensor,
+    compress_ratio: int,
+    token_topk: int,
+    out: torch.Tensor | None = None,
+) -> torch.Tensor:
+    """Expand compressed blocks and compact the causal tail of the open group."""
+
+    if not block_indices.is_cuda or not HAS_TRITON:
+        raise RuntimeError("QSA CUDA expansion requires Triton")
+    if token_topk % compress_ratio:
+        raise ValueError("QSA token top-k must be divisible by compression ratio")
+    block_topk = token_topk // compress_ratio
+    output_width = token_topk + compress_ratio - 1
+    if block_indices.shape != (query_positions.numel(), block_topk):
+        raise ValueError("QSA compressed top-k has an invalid shape")
+    if token_to_req.shape != query_positions.shape:
+        raise ValueError("QSA request mapping must match query positions")
+    if sequence_lengths.ndim != 1 or not sequence_lengths.shape[0]:
+        raise ValueError("QSA request sequence lengths must be nonempty")
+    if out is None:
+        out = torch.empty(
+            (block_indices.shape[0], output_width),
+            dtype=torch.int32,
+            device=block_indices.device,
+        )
+    elif out.shape != (block_indices.shape[0], output_width):
+        raise ValueError("QSA expansion output has an invalid shape")
+    if not block_indices.shape[0]:
+        return out
+    column_block = 256
+    _expand_qsa_indices_kernel[
+        (block_indices.shape[0], triton.cdiv(output_width, column_block))
+    ](
+        block_indices,
+        query_positions,
+        sequence_lengths,
+        token_to_req,
+        out,
+        block_indices.stride(0),
+        block_indices.stride(1),
+        out.stride(0),
+        out.stride(1),
+        block_indices.shape[0],
+        sequence_lengths.shape[0],
+        BLOCK_TOPK=block_topk,
+        COMPRESS_RATIO=compress_ratio,
+        TOKEN_TOPK=token_topk,
+        OUTPUT_WIDTH=output_width,
+        COLUMN_BLOCK=column_block,
+        num_warps=4,
+    )
+    return out
+
+
+def qsa_select_paged_tokens(
+    q: torch.Tensor,
+    k_cache: torch.Tensor,
+    page_table: torch.Tensor,
+    token_to_req: torch.Tensor,
+    query_positions: torch.Tensor,
+    sequence_lengths: torch.Tensor,
+    token_topk: int,
+    compress_ratio: int,
+    out: torch.Tensor | None = None,
+) -> torch.Tensor:
+    """Score, select, and expand QSA indices without host synchronization."""
+
+    rows = q.shape[0]
+    output_width = token_topk + compress_ratio - 1
+    if out is None:
+        out = torch.empty((rows, output_width), dtype=torch.int32, device=q.device)
+    if out.shape != (rows, output_width):
+        raise ValueError("QSA selection output has an invalid shape")
+    if not rows:
+        return out
+
+    columns = page_table.shape[1] * k_cache.shape[1]
+    block_topk = token_topk // compress_ratio
+    rows_per_chunk = max(1, _LOGITS_WORKSPACE_BYTES // max(columns * 4, 1))
+    chunk_rows = min(rows, rows_per_chunk)
+    blocks_buffer = torch.empty(
+        (chunk_rows, block_topk), dtype=torch.int32, device=q.device
+    )
+    topk_workspace = torch.empty(
+        (_TOPK_WORKSPACE_BYTES,), dtype=torch.uint8, device=q.device
+    )
+    for row_start in range(0, rows, rows_per_chunk):
+        row_end = min(row_start + rows_per_chunk, rows)
+        row_slice = slice(row_start, row_end)
+        logits, visible_blocks = qsa_mqa_paged(
+            q[row_slice],
+            k_cache,
+            page_table,
+            token_to_req[row_slice],
+            query_positions[row_slice],
+            sequence_lengths,
+            compress_ratio,
+        )
+        blocks = blocks_buffer[: row_end - row_start]
+        use_cooperative_topk = (
+            blocks.shape[0] <= 32
+            and logits.stride(0) % 4 == 0
+            and current_platform.has_device_capability(90)
+            and not current_platform.is_device_capability_family(120)
+        )
+        topk_op = (
+            torch.ops._C.cooperative_topk
+            if use_cooperative_topk
+            else torch.ops._C.persistent_topk
+        )
+        topk_op(logits, visible_blocks, blocks, topk_workspace, block_topk, columns)
+        expand_qsa_block_indices_cuda(
+            blocks,
+            query_positions[row_slice],
+            sequence_lengths,
+            token_to_req[row_slice],
+            compress_ratio,
+            token_topk,
+            out[row_slice],
+        )
+    return out
+
+
+def qsa_sparse_paged_attention(
+    q: torch.Tensor,
+    k_cache: torch.Tensor,
+    v_cache: torch.Tensor,
+    logical_indices: torch.Tensor,
+    block_table: torch.Tensor,
+    token_to_req: torch.Tensor,
+    out: torch.Tensor | None = None,
+) -> torch.Tensor:
+    """Run sparse GQA directly over paged BF16 K/V caches."""
+
+    if not q.is_cuda or not HAS_TRITON:
+        raise RuntimeError("paged QSA sparse attention requires CUDA and Triton")
+    if q.ndim != 3 or k_cache.ndim != 4 or v_cache.shape != k_cache.shape:
+        raise ValueError("QSA sparse attention received invalid Q/K/V shapes")
+    if logical_indices.ndim != 2 or logical_indices.shape[0] != q.shape[0]:
+        raise ValueError("QSA indices must have one row per query")
+    if token_to_req.shape != (q.shape[0],) or block_table.ndim != 2:
+        raise ValueError("QSA sparse attention metadata has invalid shapes")
+    if not all(k_cache.shape[:3]) or not all(block_table.shape):
+        raise ValueError("QSA sparse attention cache and block table must be nonempty")
+    if logical_indices.shape[1] <= 0:
+        raise ValueError("QSA sparse attention requires a positive selection width")
+    if q.shape[2] != k_cache.shape[3] or q.shape[1] % k_cache.shape[2]:
+        raise ValueError("QSA sparse attention requires valid grouped-query heads")
+    head_dim = q.shape[2]
+    assert head_dim >= 16 and (head_dim & (head_dim - 1)) == 0
+    assert q.dtype == k_cache.dtype == v_cache.dtype == torch.bfloat16
+    assert logical_indices.dtype == block_table.dtype == torch.int32
+    assert token_to_req.dtype == torch.int32
+    assert q.device == k_cache.device == v_cache.device
+    assert q.device == logical_indices.device == block_table.device
+    assert q.device == token_to_req.device
+    assert q.stride(2) == k_cache.stride(3) == v_cache.stride(3) == 1
+    assert logical_indices.stride(1) == block_table.stride(1) == 1
+    assert token_to_req.stride(0) == 1
+    if out is None:
+        out = torch.empty_like(q)
+    if out.shape != q.shape:
+        raise ValueError("QSA sparse output must match its query")
+    assert out.dtype == q.dtype and out.device == q.device
+    assert out.stride(2) == 1
+    if not q.shape[0]:
+        return out
+
+    group_size = q.shape[1] // k_cache.shape[2]
+    block_m = triton.next_power_of_2(group_size)
+    base_programs = q.shape[0] * k_cache.shape[2]
+    small_profile_limit = 8 if block_m <= 8 else 4
+
+    # Tuned on GB300 for the Qwen-Air TP1, TP2, and TP4 attention shapes.
+    # Narrow tiles favor decode; wide tiles improve throughput for prefill.
+    if base_programs <= small_profile_limit:
+        block_n, target_splits, partial_warps = 16, 64, 4
+    elif base_programs < 32:
+        block_n, target_splits, partial_warps = 16, 32, 4
+    elif base_programs <= 256:
+        block_n, target_splits, partial_warps = 64, 8, 2
+    elif base_programs <= 512:
+        block_n, target_splits, partial_warps = 64, 4, 2
+    else:
+        block_n, target_splits, partial_warps = 64, 1, 2
+
+    num_tiles = triton.cdiv(logical_indices.shape[1], block_n)
+    # Avoid empty splits when the selection width is smaller than the profile.
+    max_useful_splits = 1 << (num_tiles.bit_length() - 1)
+    num_splits = min(max_useful_splits, target_splits)
+
+    # Split=1 writes output directly and compiles out all workspace accesses.
+    if num_splits == 1:
+        partial_output = out
+        partial_lse = out
+    else:
+        # FP32 partials preserve accuracy when merging independently normalized
+        # splits.
+        partial_output = torch.empty(
+            (num_splits, *q.shape), dtype=torch.float32, device=q.device
+        )
+        partial_lse = torch.empty(
+            (num_splits, q.shape[0], q.shape[1]),
+            dtype=torch.float32,
+            device=q.device,
+        )
+
+    partial_grid = (q.shape[0], k_cache.shape[2], num_splits)
+    _qsa_sparse_paged_gqa_splitk_kernel[partial_grid](
+        q,
+        k_cache,
+        v_cache,
+        logical_indices,
+        block_table,
+        token_to_req,
+        partial_output,
+        partial_lse,
+        out,
+        q.stride(0),
+        q.stride(1),
+        k_cache.stride(0),
+        k_cache.stride(1),
+        k_cache.stride(2),
+        v_cache.stride(0),
+        v_cache.stride(1),
+        v_cache.stride(2),
+        logical_indices.stride(0),
+        block_table.stride(0),
+        out.stride(0),
+        out.stride(1),
+        q.shape[0],
+        k_cache.shape[0],
+        block_table.shape[0],
+        TOPK=logical_indices.shape[1],
+        PAGE_SIZE=k_cache.shape[1],
+        PAGE_TABLE_WIDTH=block_table.shape[1],
+        GROUP_SIZE=group_size,
+        HEAD_DIM=q.shape[2],
+        NUM_QUERY_HEADS=q.shape[1],
+        NUM_SPLITS=num_splits,
+        NUM_TILES=num_tiles,
+        BLOCK_M=block_m,
+        BLOCK_N=block_n,
+        num_warps=partial_warps,
+        num_stages=2,
+    )
+    if num_splits == 1:
+        return out
+
+    _qsa_merge_splitk_kernel[(q.shape[0], q.shape[1])](
+        partial_output,
+        partial_lse,
+        out,
+        out.stride(0),
+        out.stride(1),
+        q.shape[0],
+        HEAD_DIM=q.shape[2],
+        NUM_QUERY_HEADS=q.shape[1],
+        NUM_SPLITS=num_splits,
+        BLOCK_SPLITS=triton.next_power_of_2(num_splits),
+        num_warps=2,
+        num_stages=1,
+    )
+    return out
+
+
+def qsa_store_cache_rows(
+    cache: torch.Tensor,
+    slot_mapping: torch.Tensor,
+    rows: torch.Tensor,
+) -> None:
+    """Store fixed-width rows in a QSA cache without boolean indexing."""
+
+    if not cache.is_cuda or not HAS_TRITON:
+        raise RuntimeError("QSA CUDA cache stores require Triton")
+    if cache.ndim != 4 or cache.shape[2] != 1:
+        raise ValueError("QSA cache must be [pages, page_size, 1, width]")
+    if not all(cache.shape):
+        raise ValueError("QSA cache dimensions must be nonzero")
+    if rows.ndim == 3:
+        if rows.shape[1] != 1:
+            raise ValueError("QSA cache rows must have one head")
+        rows = rows[:, 0]
+    if rows.shape != (slot_mapping.numel(), cache.shape[3]):
+        raise ValueError("QSA cache rows and slots have incompatible shapes")
+    if not rows.shape[0]:
+        return
+    _store_qsa_rows_kernel[(rows.shape[0],)](
+        cache,
+        slot_mapping,
+        rows,
+        cache.stride(0),
+        cache.stride(1),
+        cache.stride(3),
+        rows.stride(0),
+        rows.stride(1),
+        rows.shape[0],
+        cache.shape[0],
+        PAGE_SIZE=cache.shape[1],
+        WIDTH=cache.shape[3],
+        BLOCK_D=triton.next_power_of_2(cache.shape[3]),
+        num_warps=4,
+    )
+
+
+def qsa_compress_groups_with_ratio(
+    raw_keys: torch.Tensor,  # this step's raw key rows [rows, 1, head_size]
+    raw_positions: torch.Tensor,  # this step's positions [rows, 1, 3] int64
+    compressor_state_cache: torch.Tensor,
+    compressor_state_block_table: torch.Tensor,
+    token_to_req: torch.Tensor,
+    query_start_loc: torch.Tensor,
+    logical_positions: torch.Tensor,
+    compressed_slots: torch.Tensor,
+    compress_ratio: int,
+    rope_cache: torch.Tensor | None = None,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Pool completed groups from the compressor-state ring and raw token rows."""
+
+    if not raw_keys.is_cuda or not HAS_TRITON:
+        raise RuntimeError("QSA CUDA compression requires Triton")
+    rows = token_to_req.numel()
+    if compress_ratio <= 0:
+        raise ValueError("QSA compression ratio must be positive")
+    if raw_keys.ndim != 3 or raw_keys.shape[:2] != (rows, 1):
+        raise ValueError("QSA raw keys must be [rows, 1, head_size]")
+    if raw_positions.shape != (rows, 1, 3) or raw_positions.dtype != torch.int64:
+        raise ValueError("QSA raw positions must be [rows, 1, 3] int64")
+    if logical_positions.shape != (rows,) or compressed_slots.shape != (rows,):
+        raise ValueError("QSA compression metadata must match token rows")
+    if compressor_state_cache.ndim != 4 or compressor_state_cache.shape[2] != 1:
+        raise ValueError("QSA compressor-state cache has an invalid shape")
+    if (
+        # The ring is wider than one group so speculative rows cannot alias
+        # onto the committed keys of the group still being collected.
+        compressor_state_cache.shape[1] < compress_ratio
+        or compressor_state_cache.shape[3] != raw_keys.shape[2]
+        or compressor_state_cache.dtype != raw_keys.dtype
+    ):
+        raise ValueError(
+            "QSA compressor-state cache does not match the compression layout"
+        )
+    if (
+        compressor_state_block_table.ndim != 2
+        or compressor_state_block_table.shape[1] < 1
+    ):
+        raise ValueError(
+            "QSA compressor-state block table must contain one block per request"
+        )
+    if query_start_loc.ndim != 1 or query_start_loc.shape[0] < 2:
+        raise ValueError("QSA query starts must contain a terminal offset")
+    num_requests = query_start_loc.shape[0] - 1
+    if compressor_state_block_table.shape[0] < num_requests:
+        raise ValueError("QSA compressor-state block table has too few request rows")
+    if rope_cache is not None and (
+        rope_cache.ndim != 4
+        or rope_cache.shape[:3] != compressor_state_cache.shape[:3]
+        or rope_cache.shape[3] != 3
+        or rope_cache.dtype != torch.int64
+    ):
+        raise ValueError("QSA packed position view has an invalid shape or dtype")
+    if rows and (
+        not all(compressor_state_cache.shape)
+        or not all(compressor_state_block_table.shape)
+    ):
+        raise ValueError("QSA compressor-state cache and block table must be nonempty")
+    pooled = torch.empty(
+        (rows, 1, raw_keys.shape[2]),
+        dtype=raw_keys.dtype,
+        device=raw_keys.device,
+    )
+    first_positions = torch.empty((rows, 3), dtype=torch.int64, device=raw_keys.device)
+    if not rows:
+        return pooled, first_positions
+    if rope_cache is None:
+        rope_cache = compressor_state_cache
+        load_rope_positions = False
+    else:
+        load_rope_positions = True
+    _compress_qsa_groups_kernel[(rows,)](
+        raw_keys,
+        raw_positions,
+        compressor_state_cache,
+        rope_cache,
+        compressor_state_block_table,
+        token_to_req,
+        query_start_loc,
+        logical_positions,
+        compressed_slots,
+        pooled,
+        first_positions,
+        raw_keys.stride(0),
+        raw_keys.stride(2),
+        raw_positions.stride(0),
+        raw_positions.stride(2),
+        compressor_state_cache.stride(0),
+        compressor_state_cache.stride(1),
+        compressor_state_cache.stride(3),
+        rope_cache.stride(0),
+        rope_cache.stride(1),
+        rope_cache.stride(3),
+        compressor_state_block_table.stride(0),
+        pooled.stride(0),
+        pooled.stride(2),
+        first_positions.stride(0),
+        first_positions.stride(1),
+        rows,
+        compressor_state_cache.shape[0],
+        num_requests,
+        COMPRESSOR_STATE_SIZE=compressor_state_cache.shape[1],
+        COMPRESS_RATIO=compress_ratio,
+        HEAD_DIM=raw_keys.shape[2],
+        LOAD_ROPE_POSITIONS=load_rope_positions,
+        BLOCK_D=triton.next_power_of_2(raw_keys.shape[2]),
+        num_warps=4,
+    )
+    return pooled, first_positions
+
+
+__all__ = [
+    "expand_qsa_block_indices_cuda",
+    "qsa_compress_groups_with_ratio",
+    "qsa_mqa_paged",
+    "qsa_select_paged_tokens",
+    "qsa_sparse_paged_attention",
+    "qsa_store_cache_rows",
+]

--- a/vllm_ascend/models/qwen4_exp/nvidia/ops/qsa_pre_indexer.py
+++ b/vllm_ascend/models/qwen4_exp/nvidia/ops/qsa_pre_indexer.py
@@ -1,0 +1,522 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Fused QSA pre-indexer kernel for Qwen4Exp."""
+
+import torch
+from vllm.triton_utils import tl, triton
+
+
+@triton.jit
+def _norm_rope(
+    x,
+    pos_t,
+    pos_h,
+    pos_w,
+    cos_sin_ptr,
+    cos_sin_stride,
+    norm_weight_ptr,
+    eps,
+    IS_MROPE: tl.constexpr,
+    MROPE_H: tl.constexpr,
+    MROPE_W: tl.constexpr,
+):
+    """Apply Gemma RMSNorm and selected-axis NeoX RoPE to register rows."""
+    TILE_T: tl.constexpr = x.shape[0]
+    TILE_H: tl.constexpr = x.shape[1]
+    D: tl.constexpr = x.shape[2]
+    ROWS: tl.constexpr = TILE_T * TILE_H
+    HALF: tl.constexpr = D // 2
+    QUARTER: tl.constexpr = D // 4
+    pairs = tl.arange(0, QUARTER)
+    if IS_MROPE:
+        # Qwen interleaves temporal, height, and width rotary pairs. Each axis
+        # still indexes the same position-major cos/sin table.
+        h_mask = ((pairs % 3) == 1) & (pairs <= 3 * MROPE_H)
+        w_mask = ((pairs % 3) == 2) & (pairs <= 3 * MROPE_W)
+        t_mask = ~(h_mask | w_mask)
+        base = cos_sin_ptr + pairs[None, :]
+        cos = tl.load(
+            base + pos_t[:, None] * cos_sin_stride,
+            mask=t_mask[None, :],
+            other=0,
+        )
+        cos += tl.load(
+            base + pos_h[:, None] * cos_sin_stride,
+            mask=h_mask[None, :],
+            other=0,
+        )
+        cos += tl.load(
+            base + pos_w[:, None] * cos_sin_stride,
+            mask=w_mask[None, :],
+            other=0,
+        )
+        sin = tl.load(
+            base + pos_t[:, None] * cos_sin_stride + QUARTER,
+            mask=t_mask[None, :],
+            other=0,
+        )
+        sin += tl.load(
+            base + pos_h[:, None] * cos_sin_stride + QUARTER,
+            mask=h_mask[None, :],
+            other=0,
+        )
+        sin += tl.load(
+            base + pos_w[:, None] * cos_sin_stride + QUARTER,
+            mask=w_mask[None, :],
+            other=0,
+        )
+    else:
+        cos = tl.load(cos_sin_ptr + pos_t[:, None] * cos_sin_stride + pairs[None, :])
+        sin = tl.load(
+            cos_sin_ptr + pos_t[:, None] * cos_sin_stride + QUARTER + pairs[None, :]
+        )
+
+    cos = tl.reshape(
+        tl.broadcast_to(cos[:, None, :], (TILE_T, TILE_H, QUARTER)),
+        (ROWS, QUARTER),
+    )
+    sin = tl.reshape(
+        tl.broadcast_to(sin[:, None, :], (TILE_T, TILE_H, QUARTER)),
+        (ROWS, QUARTER),
+    )
+    x = tl.reshape(x, (ROWS, D)).to(tl.float32)
+    weight = tl.load(norm_weight_ptr + tl.arange(0, D)).to(tl.float32) + 1.0
+    rrms = tl.rsqrt(tl.sum(x * x, axis=1) / D + eps)
+    y = (x * rrms[:, None] * weight[None, :]).to(cos.dtype)
+    rotated, passthrough = tl.split(
+        tl.permute(tl.reshape(y, (ROWS, 2, HALF)), (0, 2, 1))
+    )
+    r0, r1 = tl.split(tl.permute(tl.reshape(rotated, (ROWS, 2, QUARTER)), (0, 2, 1)))
+    out0 = r0 * cos - r1 * sin
+    out1 = r1 * cos + r0 * sin
+    rotated = tl.reshape(tl.permute(tl.join(out0, out1), (0, 2, 1)), (ROWS, HALF))
+    result = tl.reshape(tl.permute(tl.join(rotated, passthrough), (0, 2, 1)), (ROWS, D))
+    return tl.reshape(result, (TILE_T, TILE_H, D))
+
+
+@triton.jit(
+    do_not_specialize=[
+        "num_tokens",
+        "num_state_blocks",
+        "num_compressed_blocks",
+        "num_k_work",
+    ]
+)
+def _qsa_pre_indexer_kernel(
+    q_ptr,
+    q_stride_token,
+    k_ptr,
+    k_stride_token,
+    pos_ptr,
+    pos_stride_axis,
+    pos_stride_token,
+    cos_sin_ptr,
+    q_norm_weight_ptr,
+    k_norm_weight_ptr,
+    eps,
+    q_out_ptr,
+    q_out_stride_token,
+    q_out_stride_head,
+    state_cache_ptr,
+    state_cache_stride_block,
+    state_cache_stride_token,
+    state_slots_ptr,
+    state_table_ptr,
+    state_table_stride_req,
+    query_start_loc_ptr,
+    logical_positions_ptr,
+    compressed_slots_ptr,
+    k_work_metadata_ptr,
+    compressed_cache_ptr,
+    compressed_cache_stride_block,
+    compressed_cache_stride_token,
+    num_tokens,
+    num_state_blocks,
+    num_compressed_blocks,
+    num_k_work,
+    HQ: tl.constexpr,
+    D: tl.constexpr,
+    TILE_T_Q: tl.constexpr,
+    TILE_H_Q: tl.constexpr,
+    COMPRESS_RATIO: tl.constexpr,
+    STATE_SIZE: tl.constexpr,
+    COMP_PAGE_SIZE: tl.constexpr,
+    IS_2D_POSITIONS: tl.constexpr,
+    IS_K_MROPE: tl.constexpr,
+    CACHE_HAS_ROPE_POS: tl.constexpr,
+    MROPE_H: tl.constexpr,
+    MROPE_W: tl.constexpr,
+):
+    pid = tl.program_id(0)
+    # K work occupies the first programs; the remaining programs tile Q. This
+    # keeps both paths in one launch while leaving their register shapes
+    # independent.
+    if pid >= num_k_work:
+        q_pid = pid - num_k_work
+        num_head_tiles: tl.constexpr = tl.cdiv(HQ, TILE_H_Q)
+        token_tile = q_pid // num_head_tiles
+        head_tile = q_pid % num_head_tiles
+        tokens = token_tile * TILE_T_Q + tl.arange(0, TILE_T_Q)
+        heads = head_tile * TILE_H_Q + tl.arange(0, TILE_H_Q)
+        valid_tokens = tokens < num_tokens
+        valid_heads = heads < HQ
+        dims = tl.arange(0, D)
+        mask = valid_tokens[:, None, None] & valid_heads[None, :, None]
+        x = tl.load(
+            q_ptr
+            + tokens[:, None, None] * q_stride_token
+            + heads[None, :, None] * D
+            + dims[None, None, :],
+            mask=mask,
+            other=0.0,
+        )
+        pos_t = tl.load(pos_ptr + tokens * pos_stride_token, mask=valid_tokens, other=0)
+        if IS_2D_POSITIONS:
+            pos_h = tl.load(
+                pos_ptr + pos_stride_axis + tokens * pos_stride_token,
+                mask=valid_tokens,
+                other=0,
+            )
+            pos_w = tl.load(
+                pos_ptr + 2 * pos_stride_axis + tokens * pos_stride_token,
+                mask=valid_tokens,
+                other=0,
+            )
+        else:
+            pos_h = pos_t
+            pos_w = pos_t
+        y = _norm_rope(
+            x,
+            pos_t,
+            pos_h,
+            pos_w,
+            cos_sin_ptr,
+            D // 2,
+            q_norm_weight_ptr,
+            eps,
+            IS_2D_POSITIONS,
+            MROPE_H,
+            MROPE_W,
+        )
+        tl.store(
+            q_out_ptr
+            + tokens[:, None, None] * q_out_stride_token
+            + heads[None, :, None] * q_out_stride_head
+            + dims[None, None, :],
+            y,
+            mask=mask,
+        )
+
+    if pid < num_k_work:
+        # One work item owns one completed compression group. Work item zero
+        # additionally commits the request's current raw-K suffix below.
+        work_metadata = tl.load(k_work_metadata_ptr + pid * 2 + tl.arange(0, 2))
+        request, work_in_request = tl.split(work_metadata)
+        if request < 0:
+            return
+
+        query_start = tl.load(query_start_loc_ptr + request)
+        query_end = tl.load(query_start_loc_ptr + request + 1)
+        query_len = query_end - query_start
+        chunk_end = tl.load(logical_positions_ptr + query_end - 1)
+        chunk_start = chunk_end - query_len + 1
+        num_groups = (chunk_end + 1) // COMPRESS_RATIO - chunk_start // COMPRESS_RATIO
+        dims = tl.arange(0, D)
+
+        if work_in_request < num_groups:
+            first_boundary = (
+                (chunk_start + COMPRESS_RATIO) // COMPRESS_RATIO
+            ) * COMPRESS_RATIO - 1
+            end_position = first_boundary + work_in_request * COMPRESS_RATIO
+            boundary_token = query_start + end_position - chunk_start
+            valid_token = (
+                (boundary_token >= query_start)
+                & (boundary_token < query_end)
+                & (boundary_token < num_tokens)
+            )
+            compressed_slot = tl.load(
+                compressed_slots_ptr + boundary_token,
+                mask=valid_token,
+                other=-1,
+            )
+            valid = (
+                valid_token
+                & (compressed_slot >= 0)
+                & (compressed_slot < num_compressed_blocks * COMP_PAGE_SIZE)
+            )
+            state_block = tl.load(state_table_ptr + request * state_table_stride_req)
+            state_block_valid = (state_block >= 0) & (state_block < num_state_blocks)
+            safe_state_block = tl.maximum(state_block, 0).to(tl.int64)
+            group_offsets = tl.arange(0, COMPRESS_RATIO)
+            source_positions = end_position - (COMPRESS_RATIO - 1) + group_offsets
+            source_in_chunk = source_positions >= chunk_start
+            source_tokens = query_start + source_positions - chunk_start
+            source_tokens_valid = (
+                (source_tokens >= query_start)
+                & (source_tokens < query_end)
+                & (source_tokens < num_tokens)
+            )
+            current_base = (
+                k_ptr + tl.maximum(source_tokens, 0)[:, None] * k_stride_token
+            )
+            cached_base = (
+                state_cache_ptr
+                + safe_state_block * state_cache_stride_block
+                + (source_positions % STATE_SIZE)[:, None] * state_cache_stride_token
+            )
+            # Only the first completed group can cross the chunk boundary. Select
+            # historical rows from the ring without issuing two masked loads.
+            source_base = tl.where(source_in_chunk[:, None], current_base, cached_base)
+            # Pointer selection obscures alignment from Triton's analysis.
+            source_base = tl.multiple_of(source_base, (8, 8))
+            source_valid = tl.where(
+                source_in_chunk, source_tokens_valid, state_block_valid
+            )
+            source = tl.load(
+                source_base + dims[None, :],
+                mask=valid & source_valid[:, None],
+                other=0.0,
+            ).to(tl.float32)
+            # Match the unfused path's BF16 pooled tensor before RMSNorm.
+            pooled = (
+                (tl.sum(source, axis=0) / COMPRESS_RATIO).to(tl.bfloat16).to(tl.float32)
+            )
+
+            first_position = end_position - (COMPRESS_RATIO - 1)
+            if CACHE_HAS_ROPE_POS:
+                # RoPE uses the first token in the pooled group. Its exact MRoPE
+                # coordinates may live in this chunk or the raw-state ring.
+                first_in_chunk = first_position >= chunk_start
+                first_token = query_start + first_position - chunk_start
+                first_token_valid = (
+                    (first_token >= query_start)
+                    & (first_token < query_end)
+                    & (first_token < num_tokens)
+                )
+                safe_first_token = tl.maximum(first_token, 0)
+                load_current_position = first_in_chunk & first_token_valid
+                first_pos_t = tl.load(
+                    pos_ptr + safe_first_token * pos_stride_token,
+                    mask=load_current_position,
+                    other=0,
+                )
+                if IS_2D_POSITIONS:
+                    first_pos_h = tl.load(
+                        pos_ptr + pos_stride_axis + safe_first_token * pos_stride_token,
+                        mask=load_current_position,
+                        other=0,
+                    )
+                    first_pos_w = tl.load(
+                        pos_ptr
+                        + 2 * pos_stride_axis
+                        + safe_first_token * pos_stride_token,
+                        mask=load_current_position,
+                        other=0,
+                    )
+                else:
+                    first_pos_h = first_pos_t
+                    first_pos_w = first_pos_t
+                tail = (
+                    state_cache_ptr
+                    + safe_state_block * state_cache_stride_block
+                    + (first_position % STATE_SIZE) * state_cache_stride_token
+                    + D
+                ).to(tl.pointer_type(tl.int64))
+                load_cached_position = ~first_in_chunk & state_block_valid
+                cached_pos_t = tl.load(tail, mask=load_cached_position, other=0)
+                cached_pos_h = tl.load(tail + 1, mask=load_cached_position, other=0)
+                cached_pos_w = tl.load(tail + 2, mask=load_cached_position, other=0)
+                pos_t = tl.where(first_in_chunk, first_pos_t.to(tl.int64), cached_pos_t)
+                pos_h = tl.where(first_in_chunk, first_pos_h.to(tl.int64), cached_pos_h)
+                pos_w = tl.where(first_in_chunk, first_pos_w.to(tl.int64), cached_pos_w)
+            else:
+                pos_t = first_position
+                pos_h = first_position
+                pos_w = first_position
+            y = _norm_rope(
+                tl.reshape(pooled, (1, 1, D)),
+                pos_t + tl.arange(0, 1),
+                pos_h + tl.arange(0, 1),
+                pos_w + tl.arange(0, 1),
+                cos_sin_ptr,
+                D // 2,
+                k_norm_weight_ptr,
+                eps,
+                IS_K_MROPE,
+                MROPE_H,
+                MROPE_W,
+            )
+            compressed_block = (compressed_slot // COMP_PAGE_SIZE).to(tl.int64)
+            compressed_row = compressed_slot % COMP_PAGE_SIZE
+            tl.store(
+                compressed_cache_ptr
+                + compressed_block * compressed_cache_stride_block
+                + compressed_row * compressed_cache_stride_token
+                + dims,
+                tl.reshape(y, (D,)),
+                mask=valid,
+            )
+
+        if work_in_request == 0:
+            # This CTA may have just read historical rows from the circular buffer.
+            # Keep every lane past those loads before overwriting the same ring.
+            tl.debug_barrier()
+            # One CTA per request commits only the suffix retained by the ring.
+            num_state_rows = tl.minimum(query_len, STATE_SIZE)
+            for state_offset in tl.range(0, num_state_rows):
+                token = query_end - num_state_rows + state_offset
+                valid_token = (
+                    (token >= query_start) & (token < query_end) & (token < num_tokens)
+                )
+                slot = tl.load(state_slots_ptr + token, mask=valid_token, other=-1)
+                valid_slot = (
+                    valid_token & (slot >= 0) & (slot < num_state_blocks * STATE_SIZE)
+                )
+                safe_slot = tl.maximum(slot, 0)
+                state_row = (
+                    state_cache_ptr
+                    + (safe_slot // STATE_SIZE).to(tl.int64) * state_cache_stride_block
+                    + (safe_slot % STATE_SIZE) * state_cache_stride_token
+                )
+                k = tl.load(
+                    k_ptr + tl.maximum(token, 0) * k_stride_token + dims,
+                    mask=valid_slot,
+                    other=0.0,
+                )
+                tl.store(state_row + dims, k, mask=valid_slot)
+                if CACHE_HAS_ROPE_POS:
+                    pos_t = tl.load(
+                        pos_ptr + tl.maximum(token, 0) * pos_stride_token,
+                        mask=valid_slot,
+                        other=0,
+                    )
+                    if IS_2D_POSITIONS:
+                        pos_h = tl.load(
+                            pos_ptr
+                            + pos_stride_axis
+                            + tl.maximum(token, 0) * pos_stride_token,
+                            mask=valid_slot,
+                            other=0,
+                        )
+                        pos_w = tl.load(
+                            pos_ptr
+                            + 2 * pos_stride_axis
+                            + tl.maximum(token, 0) * pos_stride_token,
+                            mask=valid_slot,
+                            other=0,
+                        )
+                    else:
+                        pos_h = pos_t
+                        pos_w = pos_t
+                    tail = (state_row + D).to(tl.pointer_type(tl.int64))
+                    tl.store(tail, pos_t.to(tl.int64), mask=valid_slot)
+                    tl.store(tail + 1, pos_h.to(tl.int64), mask=valid_slot)
+                    tl.store(tail + 2, pos_w.to(tl.int64), mask=valid_slot)
+
+
+def qsa_pre_indexer(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    positions: torch.Tensor,
+    cos_sin_cache: torch.Tensor,
+    q_norm_weight: torch.Tensor,
+    k_norm_weight: torch.Tensor,
+    eps: float,
+    q_out: torch.Tensor,
+    state_cache: torch.Tensor,
+    state_slots: torch.Tensor,
+    state_block_table: torch.Tensor,
+    query_start_loc: torch.Tensor,
+    logical_positions: torch.Tensor,
+    compressed_cache: torch.Tensor,
+    compressed_slots: torch.Tensor,
+    k_work_metadata: torch.Tensor,
+    *,
+    compress_ratio: int,
+    mrope_section: tuple[int, int, int] | None,
+    rope_pos_offset: int | None,
+) -> None:
+    """Normalize Q, compress K, then update the circular raw state."""
+    num_tokens = q.shape[0]
+    if num_tokens == 0:
+        return
+    num_q_heads, head_dim = q_out.shape[1:]
+    assert cos_sin_cache.shape[-1] * 2 == head_dim
+    assert q.shape == (num_tokens, num_q_heads * head_dim)
+    assert k.shape == (num_tokens, head_dim)
+    assert q.stride(-1) == 1
+    assert k.stride(-1) == 1
+    assert q_out.stride(-1) == 1
+    assert cos_sin_cache.is_contiguous()
+    assert state_cache.stride(-1) == 1
+    assert compressed_cache.stride(-1) == 1
+    assert k_work_metadata.ndim == 2 and k_work_metadata.shape[1] == 2
+    is_2d_positions = positions.ndim == 2
+    is_k_mrope = bool(mrope_section)
+    cache_has_rope_pos = rope_pos_offset is not None
+    assert rope_pos_offset is None or rope_pos_offset == head_dim
+    if is_2d_positions:
+        assert positions.shape == (3, num_tokens)
+        assert is_k_mrope
+        pos_stride_axis, pos_stride_token = positions.stride()
+    else:
+        assert positions.shape == (num_tokens,)
+        pos_stride_axis, pos_stride_token = 0, positions.stride(0)
+    section = mrope_section if mrope_section is not None else (0, 0, 0)
+    assert len(section) == 3
+
+    if num_tokens <= 4096:
+        TILE_T_Q, TILE_H_Q = 2, 2
+    else:
+        TILE_T_Q, TILE_H_Q = 2, 4
+    num_k_work = k_work_metadata.shape[0]
+    num_q_work = triton.cdiv(num_tokens, TILE_T_Q) * triton.cdiv(num_q_heads, TILE_H_Q)
+    _qsa_pre_indexer_kernel[(num_k_work + num_q_work,)](
+        q,
+        q.stride(0),
+        k,
+        k.stride(0),
+        positions,
+        pos_stride_axis,
+        pos_stride_token,
+        cos_sin_cache,
+        q_norm_weight,
+        k_norm_weight,
+        eps,
+        q_out,
+        q_out.stride(0),
+        q_out.stride(1),
+        state_cache,
+        state_cache.stride(0),
+        state_cache.stride(1),
+        state_slots,
+        state_block_table,
+        state_block_table.stride(0),
+        query_start_loc,
+        logical_positions,
+        compressed_slots,
+        k_work_metadata,
+        compressed_cache,
+        compressed_cache.stride(0),
+        compressed_cache.stride(1),
+        num_tokens,
+        state_cache.shape[0],
+        compressed_cache.shape[0],
+        num_k_work,
+        HQ=num_q_heads,
+        D=head_dim,
+        TILE_T_Q=TILE_T_Q,
+        TILE_H_Q=TILE_H_Q,
+        COMPRESS_RATIO=compress_ratio,
+        STATE_SIZE=state_cache.shape[1],
+        COMP_PAGE_SIZE=compressed_cache.shape[1],
+        IS_2D_POSITIONS=is_2d_positions,
+        IS_K_MROPE=is_k_mrope,
+        CACHE_HAS_ROPE_POS=cache_has_rope_pos,
+        MROPE_H=section[1],
+        MROPE_W=section[2],
+        num_warps=1,
+    )
+
+
+__all__ = ["qsa_pre_indexer"]

--- a/vllm_ascend/models/qwen4_exp/nvidia/ple_layer.py
+++ b/vllm_ascend/models/qwen4_exp/nvidia/ple_layer.py
@@ -1,0 +1,1243 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""GPU-resident Qwen4Exp position-learning enhancement layers."""
+
+import math
+from collections.abc import Iterable, Sequence
+
+import torch
+import torch.nn.functional as F
+from torch import nn
+from vllm.config import CacheConfig, ModelConfig, VllmConfig, get_current_vllm_config
+from vllm.forward_context import get_forward_context
+from vllm.model_executor.layers.linear import ReplicatedLinear
+from vllm.model_executor.layers.mamba.abstract import MambaBase
+from vllm.model_executor.layers.mamba.mamba_utils import (
+    MambaStateDtypeCalculator,
+    MambaStateShapeCalculator,
+    is_conv_state_dim_first,
+)
+from vllm.model_executor.layers.quantization.base_config import (
+    QuantizationConfig,
+    QuantizeMethodBase,
+)
+from vllm.model_executor.layers.quantization.fp8 import Fp8Config
+from vllm.model_executor.layers.quantization.utils.fp8_utils import (
+    create_fp8_scale_parameter,
+    create_fp8_weight_parameter,
+    is_fp8,
+)
+from vllm.model_executor.layers.quantization.utils.quant_utils import (
+    is_layer_skipped,
+)
+from vllm.model_executor.models.utils import AutoWeightsLoader
+from vllm.model_executor.parameter import PerTensorScaleParameter
+from vllm.utils.torch_utils import direct_register_custom_op
+from vllm.v1.attention.backends.registry import MambaAttentionBackendEnum
+from vllm.v1.attention.backends.utils import NULL_BLOCK_ID
+
+from vllm_ascend.models.qwen4_exp.config import (
+    Qwen4ExpTextConfig,
+)
+from vllm_ascend.models.qwen4_exp.ple_offload_layer import (
+    PLE_CPU_OFFLOAD,
+    PleOffloadLayer,
+    is_offload_process,
+)
+from vllm_ascend.models.qwen4_exp.short_conv_attn import (
+    PleShortConvAttentionBackend,
+    PleShortConvAttentionMetadata,
+)
+from vllm_ascend.models.qwen4_exp.vocab_parallel_embedding import (
+    VocabParallelEmbedding,
+)
+
+from ..common.ple import copy_ple_embedding_shard_
+
+_MASK64 = (1 << 64) - 1
+_SPLITMIX_GAMMA = 0x9E3779B97F4A7C15
+_SPLITMIX_M1 = 0xBF58476D1CE4E5B9
+_SPLITMIX_M2 = 0x94D049BB133111EB
+_PLE_LAYER_PRIME = 10007
+
+
+def _splitmix64(value: int) -> int:
+    value = (value + _SPLITMIX_GAMMA) & _MASK64
+    value = ((value ^ (value >> 30)) * _SPLITMIX_M1) & _MASK64
+    value = ((value ^ (value >> 27)) * _SPLITMIX_M2) & _MASK64
+    return (value ^ (value >> 31)) & _MASK64
+
+
+def _is_prime_64(value: int) -> bool:
+    if value < 2:
+        return False
+    for prime in (2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37):
+        if value % prime == 0:
+            return value == prime
+    exponent = value - 1
+    shifts = 0
+    while exponent % 2 == 0:
+        exponent //= 2
+        shifts += 1
+    for base in (2, 325, 9375, 28178, 450775, 9780504, 1795265022):
+        if base % value == 0:
+            continue
+        witness = pow(base, exponent, value)
+        if witness in (1, value - 1):
+            continue
+        for _ in range(shifts - 1):
+            witness = pow(witness, 2, value)
+            if witness == value - 1:
+                break
+        else:
+            return False
+    return True
+
+
+def _nth_prime_after(start: int, count: int) -> int:
+    prime = int(start)
+    for _ in range(count):
+        candidate = prime + 1
+        if candidate <= 2:
+            prime = 2
+            continue
+        if candidate % 2 == 0:
+            candidate += 1
+        while not _is_prime_64(candidate):
+            candidate += 2
+        prime = candidate
+    return prime
+
+
+class Qwen4ExpPLEGroupedNorm(nn.Module):
+    def __init__(
+        self,
+        hidden_size: int,
+        eps: float,
+        group_size: int | None,
+        dtype: torch.dtype | None,
+    ) -> None:
+        super().__init__()
+        if group_size is not None and hidden_size % group_size:
+            raise ValueError(
+                f"hidden_size ({hidden_size}) must be divisible by "
+                f"group_size ({group_size})"
+            )
+        self.eps = eps
+        self.group_size = group_size
+        self.weight = nn.Parameter(torch.zeros(hidden_size, dtype=dtype))
+
+    def forward(self, hidden_states: torch.Tensor) -> torch.Tensor:
+        input_dtype = hidden_states.dtype
+        hidden_states = hidden_states.float()
+        if self.group_size is None:
+            variance = hidden_states.square().mean(dim=-1, keepdim=True)
+            normalized = hidden_states * torch.rsqrt(variance + self.eps)
+        else:
+            grouped = hidden_states.unflatten(
+                -1, (hidden_states.shape[-1] // self.group_size, self.group_size)
+            )
+            variance = grouped.square().mean(dim=-1, keepdim=True)
+            normalized = (grouped * torch.rsqrt(variance + self.eps)).flatten(-2)
+        return (normalized * (1.0 + self.weight.float())).to(input_dtype)
+
+
+class Qwen4ExpPLEFp8EmbeddingMethod(QuantizeMethodBase):
+    """FP8 PLE embedding with one global checkpoint scale."""
+
+    def create_weights(
+        self,
+        layer: nn.Module,
+        input_size_per_partition: int,
+        output_partition_sizes: list[int],
+        input_size: int,
+        output_size: int,
+        params_dtype: torch.dtype,
+        **extra_weight_attrs,
+    ) -> None:
+        del input_size, output_size, params_dtype
+        weight_loader = extra_weight_attrs.get("weight_loader")
+        weight = create_fp8_weight_parameter(
+            sum(output_partition_sizes), input_size_per_partition, weight_loader
+        )
+        layer.register_parameter("weight", weight)
+
+        weight_scale = create_fp8_scale_parameter(
+            PerTensorScaleParameter,
+            output_partition_sizes,
+            input_size_per_partition,
+            None,
+            weight_loader,
+            scale_dtype=torch.bfloat16,
+        )
+        layer.register_parameter("weight_scale", weight_scale)
+
+    def apply(
+        self,
+        layer: nn.Module,
+        x: torch.Tensor,
+        bias: torch.Tensor | None = None,
+    ) -> torch.Tensor:
+        raise NotImplementedError("PLE FP8 weights only support embedding lookup")
+
+    def embedding(self, layer: nn.Module, input_: torch.Tensor) -> torch.Tensor:
+        return F.embedding(input_, layer.weight)
+
+
+def _get_ple_embedding_quant_method(
+    quant_config: QuantizationConfig | None,
+    prefix: str,
+) -> QuantizeMethodBase | None:
+    """Select global-scale FP8 only for quantized PLE checkpoint shards."""
+
+    if not isinstance(quant_config, Fp8Config):
+        return None
+    if not quant_config.is_checkpoint_fp8_serialized:
+        return None
+
+    ignored_layers = quant_config.ignored_layers
+    if is_layer_skipped(
+        prefix,
+        ignored_layers,
+        quant_config.packed_modules_mapping,
+        match_mode=quant_config.ignored_layers_match_mode,
+    ):
+        return None
+    # PLE checkpoint shards form one runtime embedding parameter.
+    shard_prefix = f"{prefix}.shard_"
+    if any(name.startswith(shard_prefix) for name in ignored_layers):
+        return None
+    return Qwen4ExpPLEFp8EmbeddingMethod()
+
+
+class Qwen4ExpNGramEmbedding(PleOffloadLayer):
+    def __init__(
+        self,
+        config: Qwen4ExpTextConfig,
+        embedding_dim: int,
+        ple_dense_layer_id: int,
+        max_total_tokens: int,
+        max_num_reqs: int,
+        prefix: str,
+        quant_config: QuantizationConfig | None = None,
+        params_dtype: torch.dtype | None = None,
+    ) -> None:
+        super().__init__()
+        self.embedding_dim = embedding_dim
+        self.ngram_size = int(config.ngram_size)
+        self.heads_per_ngram = int(config.heads_per_ngram)
+        self.ngram_heads = (self.ngram_size - 1) * self.heads_per_ngram
+        if self.ngram_size < 2:
+            raise ValueError(f"ngram_size must be >= 2, got {self.ngram_size}")
+        if self.heads_per_ngram <= 0:
+            raise ValueError(f"heads_per_ngram must be > 0, got {self.heads_per_ngram}")
+        if embedding_dim % self.ngram_heads:
+            raise ValueError(
+                "ple_embed_dim must be divisible by total ngram heads: "
+                f"{embedding_dim} % {self.ngram_heads} != 0"
+            )
+        self.head_dim = embedding_dim // self.ngram_heads
+        self.eos_token_id = int(config.eos_token_id)
+        self.unigram_vocab_size = int(config.vocab_size)
+        self.split_ngram_parts = int(getattr(config, "split_ngram_parts", 512))
+        if self.split_ngram_parts <= 0:
+            raise ValueError("split_ngram_parts must be positive")
+
+        max_multiplier = ((1 << 63) - 1) // self.unigram_vocab_size
+        half_bound = max(1, max_multiplier // 2)
+        seed = int(getattr(config, "seed", 1234))
+        base_seed = seed + _PLE_LAYER_PRIME * ple_dense_layer_id
+        multipliers = []
+        for index in range(self.ngram_size):
+            value = base_seed + _SPLITMIX_GAMMA * (index + 1)
+            multipliers.append(2 * (_splitmix64(value) % half_bound) + 1)
+        self.register_buffer(
+            "layer_multipliers",
+            torch.tensor(multipliers, dtype=torch.long),
+            persistent=True,
+        )
+
+        ngram_vocab_size_base = int(config.ngram_vocab_size_base)
+        sizes: list[int] = []
+        offsets: list[int] = []
+        offset = 0
+        for local_head in range(self.ngram_heads):
+            global_head = ple_dense_layer_id * self.ngram_heads + local_head
+            size = _nth_prime_after(ngram_vocab_size_base - 1, global_head + 1)
+            sizes.append(size)
+            offsets.append(offset)
+            offset += size
+        self.register_buffer(
+            "ngram_heads_vocab_sizes",
+            torch.tensor(sizes, dtype=torch.long),
+            persistent=True,
+        )
+        self.register_buffer(
+            "ngram_heads_offsets",
+            torch.tensor(offsets, dtype=torch.long),
+            persistent=True,
+        )
+        divisor = int(config.make_ngram_vocab_size_divisible_by)
+        padded_vocab_size = ((offset + divisor - 1) // divisor) * divisor
+        self.ngram_embedding = VocabParallelEmbedding(
+            padded_vocab_size,
+            self.head_dim,
+            params_dtype=params_dtype,
+            padding_size=divisor,
+            prefix=f"{prefix}.ngram_embedding",
+            quant_method=_get_ple_embedding_quant_method(
+                quant_config, f"{prefix}.ngram_embedding"
+            ),
+        )
+        self.register_buffer(
+            "positions_buffer",
+            torch.arange(max_total_tokens, dtype=torch.int64),
+            persistent=False,
+        )
+        self.register_buffer(
+            "padded_buffer",
+            torch.full(
+                (max_num_reqs, max_total_tokens),
+                self.eos_token_id,
+                dtype=torch.int64,
+            ),
+            persistent=False,
+        )
+
+    @staticmethod
+    def _shift_precompute(
+        tokens: torch.Tensor, eos_token_id: int
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        if tokens.dim() != 2:
+            raise ValueError("tokens must be a 2D tensor")
+        batch_size, seq_len = tokens.shape
+        positions = torch.arange(seq_len, device=tokens.device, dtype=torch.int64)
+        eos_positions = torch.where(tokens == eos_token_id, positions, -1)
+        previous_eos_inclusive = torch.cummax(eos_positions, dim=1).values
+        previous_eos = torch.cat(
+            [
+                eos_positions.new_full((batch_size, 1), -1),
+                previous_eos_inclusive[:, :-1],
+            ],
+            dim=1,
+        )
+        return positions, positions.unsqueeze(0) - previous_eos - 1
+
+    @staticmethod
+    def _shift_apply(
+        tokens: torch.Tensor,
+        positions: torch.Tensor,
+        position_in_segment: torch.Tensor,
+        shift: int,
+        eos_token_id: int,
+    ) -> torch.Tensor:
+        if shift == 0:
+            return tokens
+        source = positions - shift
+        gather_indices = source.clamp_min(0).unsqueeze(0).expand(tokens.shape[0], -1)
+        shifted = tokens.gather(1, gather_indices)
+        valid = (source.unsqueeze(0) >= 0) & (position_in_segment >= shift)
+        return torch.where(valid, shifted, tokens.new_full((), eos_token_id))
+
+    def forward_impl(  # type: ignore[override]
+        self,
+        hidden_states: torch.Tensor,
+        input_ids: torch.Tensor,
+        query_start_loc: torch.Tensor,
+        ngram_context: torch.Tensor,
+        output_buffer: torch.Tensor | None = None,
+    ) -> torch.Tensor:
+        del hidden_states
+        input_ids = input_ids.reshape(-1).long()
+        query_start_loc = query_start_loc.long()
+        num_reqs = query_start_loc.numel() - 1
+        num_tokens = input_ids.shape[0]
+        if num_tokens > self.positions_buffer.numel():
+            raise ValueError(
+                f"PLE received {num_tokens} tokens, but its workspace supports "
+                f"at most {self.positions_buffer.numel()}"
+            )
+        if num_reqs > self.padded_buffer.shape[0]:
+            raise ValueError(
+                f"PLE received {num_reqs} requests, but its workspace supports "
+                f"at most {self.padded_buffer.shape[0]}"
+            )
+
+        # The CPU-offload subprocess is never captured by a CUDA Graph, so its
+        # pack workspace can narrow to the actual maximum sequence length. The
+        # regular GPU path retains the static maximum-width buffer for capture.
+        if is_offload_process():
+            if num_reqs <= 0:
+                raise ValueError("PLE CPU offload requires at least one request")
+            max_seq_len = max(
+                1,
+                int((query_start_loc[1:] - query_start_loc[:-1]).max().item()),
+            )
+            # The model runner sends the CUDA-graph padded token count together
+            # with an unpadded query_start_loc. Stale padding must not enter the
+            # scatter: its clamped indices would overwrite the last real token.
+            num_valid_tokens = min(int(query_start_loc[-1].item()), num_tokens)
+        else:
+            max_seq_len = self.padded_buffer.shape[1]
+            num_valid_tokens = num_tokens
+
+        positions = self.positions_buffer[:num_tokens]
+        packed = self.padded_buffer[:num_reqs, :max_seq_len]
+        packed.fill_(self.eos_token_id)
+        request_indices = torch.searchsorted(query_start_loc, positions, right=True) - 1
+        request_indices.clamp_(max=num_reqs - 1)
+        columns = (positions - query_start_loc[request_indices]).clamp(
+            0, packed.shape[1] - 1
+        )
+        packed[request_indices[:num_valid_tokens], columns[:num_valid_tokens]] = (
+            input_ids[:num_valid_tokens]
+        )
+        ngram_context = ngram_context[:num_reqs].to(
+            device=input_ids.device, dtype=torch.long
+        )
+
+        context = torch.cat([ngram_context, packed], dim=-1)
+        positions_2d, position_in_segment = self._shift_precompute(
+            context, self.eos_token_id
+        )
+        shifted = [context]
+        for shift in range(1, self.ngram_size):
+            shifted.append(
+                self._shift_apply(
+                    context,
+                    positions_2d,
+                    position_in_segment,
+                    shift,
+                    self.eos_token_id,
+                )
+            )
+        adjusted_columns = columns + self.ngram_size - 1
+        id_blocks = []
+        for ngram in range(2, self.ngram_size + 1):
+            start = (ngram - 2) * self.heads_per_ngram
+            end = start + self.heads_per_ngram
+            mixed = shifted[0] * self.layer_multipliers[0]
+            for index in range(1, ngram):
+                mixed = torch.bitwise_xor(
+                    mixed, shifted[index] * self.layer_multipliers[index]
+                )
+            sizes = self.ngram_heads_vocab_sizes[start:end]
+            offsets = self.ngram_heads_offsets[start:end]
+            ids = torch.remainder(mixed.unsqueeze(-1), sizes) + offsets
+            id_blocks.append(ids[request_indices, adjusted_columns])
+        ngram_ids = torch.cat(id_blocks, dim=-1)
+        if output_buffer is not None:
+            output = output_buffer[:num_tokens, : self.embedding_dim]
+            torch.index_select(
+                self.ngram_embedding.weight,
+                0,
+                ngram_ids.reshape(-1),
+                out=output.reshape(-1, self.head_dim),
+            )
+            return output
+        return self.ngram_embedding(ngram_ids).flatten(-2)
+
+    def get_offload_output_dtype(self, default_dtype: torch.dtype) -> torch.dtype:
+        """Keep quantized lookup results in their embedding storage dtype."""
+        embedding = getattr(self, "ngram_embedding", None)
+        weight = getattr(embedding, "weight", None)
+        if weight is not None:
+            return weight.dtype
+        if hasattr(self, "_offload_weight_scale"):
+            return torch.float8_e4m3fn
+        return default_dtype
+
+    def load_weights(self, weights: Iterable[tuple[str, torch.Tensor]]) -> set[str]:
+        """Load hash buffers and checkpoint-split embedding rows."""
+
+        # GPU workers retain only the global FP8 scale. The CPU process owns the
+        # embedding weight and returns its quantized lookup output unchanged.
+        if PLE_CPU_OFFLOAD and not is_offload_process():
+            retained: set[str] = set()
+            for name, loaded_weight in weights:
+                if name != "ngram_embedding.weight_scale":
+                    continue
+                self.register_buffer(
+                    "_offload_weight_scale",
+                    loaded_weight.to(device=torch.accelerator.current_accelerator()),
+                    persistent=False,
+                )
+                retained.add(name)
+            return retained
+
+        persistent_buffers = {
+            "layer_multipliers": self.layer_multipliers,
+            "ngram_heads_offsets": self.ngram_heads_offsets,
+            "ngram_heads_vocab_sizes": self.ngram_heads_vocab_sizes,
+        }
+        loaded: set[str] = set()
+        regular_weights: list[tuple[str, torch.Tensor]] = []
+        shard_prefix = "ngram_embedding.shard_"
+
+        for name, loaded_weight in weights:
+            leaf_name = name.rsplit(".", 1)[-1]
+            if leaf_name.startswith("hashstats_") or leaf_name == "token_lookup":
+                continue
+            if name in persistent_buffers:
+                buffer = persistent_buffers[name]
+                if buffer.shape != loaded_weight.shape:
+                    raise ValueError(
+                        f"Shape mismatch for {name}: expected "
+                        f"{tuple(buffer.shape)}, got {tuple(loaded_weight.shape)}"
+                    )
+                buffer.copy_(loaded_weight.to(device=buffer.device, dtype=buffer.dtype))
+                loaded.add(name)
+                continue
+            if name.startswith(shard_prefix) and name.endswith(".weight"):
+                shard_text = name[len(shard_prefix) : -len(".weight")]
+                if not shard_text.isdigit():
+                    regular_weights.append((name, loaded_weight))
+                    continue
+                shard_index = int(shard_text)
+                if shard_index >= self.split_ngram_parts:
+                    raise ValueError(
+                        f"PLE embedding shard index {shard_index} exceeds "
+                        f"split_ngram_parts={self.split_ngram_parts}"
+                    )
+                embedding = self.ngram_embedding
+                shard_size = (
+                    embedding.org_vocab_size + self.split_ngram_parts - 1
+                ) // self.split_ngram_parts
+                checkpoint_start = shard_index * shard_size
+                expected_rows = max(
+                    0,
+                    min(shard_size, embedding.org_vocab_size - checkpoint_start),
+                )
+                expected_shape = (expected_rows, embedding.embedding_dim)
+                if tuple(loaded_weight.shape) != expected_shape:
+                    raise ValueError(
+                        f"Shape mismatch for PLE embedding shard {shard_index}: "
+                        f"expected {expected_shape}, got "
+                        f"{tuple(loaded_weight.shape)}"
+                    )
+                copy_ple_embedding_shard_(
+                    embedding.weight.data,
+                    loaded_weight,
+                    checkpoint_start=checkpoint_start,
+                    tp_start=embedding.shard_indices.org_vocab_start_index,
+                    tp_end=embedding.shard_indices.org_vocab_end_index,
+                )
+                loaded.add("ngram_embedding.weight")
+                continue
+            regular_weights.append((name, loaded_weight))
+
+        if regular_weights:
+            loaded.update(AutoWeightsLoader(self).load_weights(regular_weights))
+        return loaded
+
+
+class Qwen4ExpPLELayer(nn.Module, MambaBase):
+    def __init__(
+        self,
+        config: Qwen4ExpTextConfig,
+        vllm_config: VllmConfig,
+        layer_idx: int = 0,
+        ple_dense_layer_id: int | None = None,
+        prefix: str = "",
+    ) -> None:
+        super().__init__()
+        model_config = vllm_config.model_config
+        cache_config = vllm_config.cache_config
+        quant_config = vllm_config.quant_config
+        self.model_config: ModelConfig = model_config
+        self.cache_config: CacheConfig = cache_config
+        self.layer_idx = layer_idx
+        self.ple_dense_layer_id = (
+            int(ple_dense_layer_id)
+            if ple_dense_layer_id is not None
+            else int(layer_idx)
+        )
+        self.prefix = prefix
+        self.hidden_size = int(config.hidden_size)
+        self.hc_count = config.hc_count
+        self.hc_hidden_size = self.hidden_size * self.hc_count
+        self.conv_kernel_size = int(config.ple_conv_kernel_size)
+        self.short_conv_dilation = int(config.ngram_size)
+        self.conv_state_len = (self.conv_kernel_size - 1) * self.short_conv_dilation
+        self.num_spec_tokens = vllm_config.num_speculative_tokens
+        self.activation = "silu"
+        # The offload process builds the surrounding model on meta while
+        # this subtree must own real CPU storage. GPU workers skip the
+        # subclass constructor and retain only an empty IPC placeholder.
+        with torch.device(PleOffloadLayer.get_target_device()):
+            self.ple_embedding: nn.Module = Qwen4ExpNGramEmbedding(
+                config,
+                int(config.ple_embed_dim),
+                self.ple_dense_layer_id,
+                vllm_config.scheduler_config.max_num_batched_tokens,
+                vllm_config.scheduler_config.max_num_seqs,
+                f"{prefix}.ple_embedding",
+                quant_config=quant_config,
+                params_dtype=model_config.dtype,
+            )
+        self.key_proj = ReplicatedLinear(
+            int(config.ple_embed_dim),
+            self.hc_hidden_size,
+            bias=False,
+            quant_config=quant_config,
+            prefix=f"{prefix}.key_proj",
+        )
+        self.value_proj = ReplicatedLinear(
+            int(config.ple_embed_dim),
+            self.hidden_size,
+            bias=False,
+            quant_config=quant_config,
+            prefix=f"{prefix}.value_proj",
+        )
+        norm_args = (
+            self.hc_hidden_size,
+            config.rms_norm_eps,
+            self.hidden_size,
+            model_config.dtype,
+        )
+        self.norm_key = Qwen4ExpPLEGroupedNorm(*norm_args)
+        self.norm_query = Qwen4ExpPLEGroupedNorm(*norm_args)
+        self.norm_conv = Qwen4ExpPLEGroupedNorm(*norm_args)
+        self.conv1d = nn.Conv1d(
+            self.hc_hidden_size,
+            self.hc_hidden_size,
+            self.conv_kernel_size,
+            groups=self.hc_hidden_size,
+            padding=self.conv_state_len,
+            dilation=self.short_conv_dilation,
+            bias=False,
+            dtype=model_config.dtype,
+        )
+        nn.init.zeros_(self.conv1d.weight)
+        self.conv1d.weight._no_reinit = True
+        self.kv_cache = (torch.tensor([]),)
+        compilation_config = get_current_vllm_config().compilation_config
+        if prefix in compilation_config.static_forward_context:
+            raise ValueError(f"Duplicate layer name: {prefix}")
+        compilation_config.static_forward_context[prefix] = self
+
+    def _get_embedding_weight_scale(self) -> torch.Tensor | None:
+        embedding = getattr(self.ple_embedding, "ngram_embedding", None)
+        weight_scale = getattr(embedding, "weight_scale", None)
+        if weight_scale is not None:
+            return weight_scale
+        return getattr(self.ple_embedding, "_offload_weight_scale", None)
+
+    def _dequantize_embeddings(
+        self,
+        embeddings: torch.Tensor,
+        output_dtype: torch.dtype,
+    ) -> torch.Tensor:
+        """Dequantize PLE lookup output."""
+
+        if not is_fp8(embeddings):
+            return embeddings
+        weight_scale = self._get_embedding_weight_scale()
+        if weight_scale is None:
+            raise RuntimeError("FP8 PLE embedding is missing its global scale")
+        if weight_scale.device != embeddings.device:
+            raise RuntimeError("FP8 PLE embedding scale must be on the output device")
+        return embeddings.to(output_dtype) * weight_scale.to(output_dtype)
+
+    @property
+    def mamba_type(self) -> MambaAttentionBackendEnum:
+        return MambaAttentionBackendEnum.SHORT_CONV
+
+    @property
+    def is_kv_cache_tp_replicated(self) -> bool:
+        return True
+
+    def get_attn_backend(self) -> type[PleShortConvAttentionBackend]:
+        return PleShortConvAttentionBackend
+
+    def get_state_dtype(self) -> tuple[torch.dtype, ...]:
+        return MambaStateDtypeCalculator.short_conv_state_dtype(
+            self.model_config.dtype, self.cache_config.mamba_cache_dtype
+        )
+
+    def get_state_shape(self) -> Sequence[tuple[int, ...]]:
+        return MambaStateShapeCalculator.short_conv_state_shape(
+            tp_world_size=1,
+            intermediate_size=self.hc_hidden_size,
+            conv_kernel=self.conv_state_len + 1,
+        )
+
+    def _apply_norm(
+        self, norm: Qwen4ExpPLEGroupedNorm, hidden_states: torch.Tensor
+    ) -> torch.Tensor:
+        shape = hidden_states.shape
+        return norm(hidden_states.flatten(-2)).reshape(shape)
+
+    def _short_conv_fallback(self, inputs: torch.Tensor) -> torch.Tensor:
+        # Profiling / CUDA graph capture only; conv state is not updated.
+        inputs_t = inputs.transpose(0, 1).unsqueeze(0)
+        output = self.conv1d(inputs_t)[..., : inputs_t.size(-1)]
+        return F.silu(output).squeeze(0).transpose(0, 1)
+
+    def _short_conv_dilated_decode_batched(
+        self,
+        x_d: torch.Tensor,
+        conv_state: torch.Tensor,
+        conv_weights: torch.Tensor,
+        state_indices_tensor_d: torch.Tensor,
+        has_initial_states_d: torch.Tensor | None,
+    ) -> torch.Tensor:
+        state_indices = state_indices_tensor_d.to(
+            device=conv_state.device, dtype=torch.int64
+        )
+        # TODO: need double-check
+        # FULL cudagraph padded decode rows use NULL_BLOCK_ID. Remap them to
+        # slot 0 for a safe gather, then zero output and skip write-back.
+        valid_state = state_indices != NULL_BLOCK_ID
+        state_indices = torch.where(
+            valid_state, state_indices, torch.zeros_like(state_indices)
+        )
+        if has_initial_states_d is None:
+            has_initial_state = valid_state
+        else:
+            if has_initial_states_d.numel() < state_indices_tensor_d.numel():
+                raise ValueError(
+                    "has_initial_states_d size mismatch: "
+                    f"got {has_initial_states_d.numel()}, "
+                    f"need >= {state_indices_tensor_d.numel()}."
+                )
+            has_initial_state = has_initial_states_d[
+                : state_indices_tensor_d.numel()
+            ].to(device=conv_state.device, dtype=torch.bool)
+            has_initial_state = has_initial_state & valid_state
+
+        cached_state = conv_state.index_select(0, state_indices)
+        state = cached_state[..., : self.conv_state_len].to(x_d.dtype)
+        if self.conv_state_len > 0:
+            initial_state = torch.where(
+                has_initial_state.view(-1, 1, 1),
+                state,
+                torch.zeros_like(state),
+            )
+            history = torch.cat((initial_state, x_d.unsqueeze(-1)), dim=-1)
+        else:
+            history = x_d.unsqueeze(-1)
+
+        conv_output = F.conv1d(
+            history,
+            conv_weights.unsqueeze(1).contiguous(),
+            groups=history.size(1),
+            dilation=self.short_conv_dilation,
+        ).squeeze(-1)
+        output = F.silu(conv_output)
+        output = output * valid_state.view(-1, 1).to(output.dtype)
+
+        if self.conv_state_len > 0:
+            next_state = history[..., -self.conv_state_len :]
+            # Padded rows are remapped to the reserved null slot. Preserve its
+            # existing value while writing the new states for valid rows.
+            existing_base_state = cached_state[..., : self.conv_state_len]
+            safe_next_state = torch.where(
+                valid_state.view(-1, 1, 1),
+                next_state.to(conv_state.dtype),
+                existing_base_state,
+            )
+            cached_state[..., : self.conv_state_len] = safe_next_state
+            conv_state.index_copy_(0, state_indices, cached_state)
+
+        return output
+
+    def _short_conv_dilated_prefill_batched(
+        self,
+        x_p: torch.Tensor,
+        metadata: PleShortConvAttentionMetadata,
+        conv_state: torch.Tensor,
+        conv_weights: torch.Tensor,
+        state_indices_tensor_p: torch.Tensor,
+        num_prefills: int,
+        num_decode_tokens: int,
+        num_prefill_tokens: int,
+    ) -> torch.Tensor:
+        # ``non_spec_query_start_loc`` covers the non-spec (decode + prefill)
+        # requests and equals ``query_start_loc`` when spec-decode is inactive.
+        non_spec_query_start_loc = metadata.non_spec_query_start_loc
+        if non_spec_query_start_loc is None:
+            raise ValueError("query_start_loc is required for prefill short-conv")
+        query_start_loc_p = (
+            non_spec_query_start_loc[-num_prefills - 1 :] - num_decode_tokens
+        )
+        # The metadata builder guarantees that the prefill query offsets start
+        # at 0 and end at num_prefill_tokens. Avoid reading those values here,
+        # since doing so would force a device-to-host synchronization.
+        has_initial_states_p = metadata.has_initial_states_p
+        if has_initial_states_p is None:
+            raise ValueError("has_initial_states_p is required for prefill short-conv")
+
+        output = torch.empty_like(x_p)
+        q_starts = query_start_loc_p.to(torch.int64)
+        if state_indices_tensor_p.numel() < num_prefills:
+            raise ValueError(
+                "state_indices_tensor_p size mismatch: "
+                f"got {state_indices_tensor_p.numel()}, "
+                f"need >= {num_prefills}."
+            )
+        if has_initial_states_p.numel() < num_prefills:
+            raise ValueError(
+                "has_initial_states_p size mismatch: "
+                f"got {has_initial_states_p.numel()}, "
+                f"need >= {num_prefills}."
+            )
+        if num_prefills == 0 or x_p.numel() == 0:
+            return output
+        lengths = q_starts[1:] - q_starts[:-1]
+        # Use the CPU-computed packing width from the metadata builder instead
+        # of synchronizing on lengths.max().
+        max_len = metadata.max_prefill_query_len
+        if max_len <= 0:
+            return output
+
+        hidden_size = x_p.shape[1]
+        positions = torch.arange(
+            num_prefill_tokens, device=x_p.device, dtype=torch.int64
+        )
+        req_indices = torch.searchsorted(q_starts[1:], positions, right=True)
+        col_indices = positions - q_starts[req_indices]
+
+        packed_tokens = x_p.new_zeros((num_prefills, max_len, hidden_size))
+        packed_tokens[req_indices, col_indices] = x_p
+        packed_tokens = packed_tokens.transpose(1, 2).contiguous()
+
+        state_indices = state_indices_tensor_p[:num_prefills].to(
+            device=conv_state.device, dtype=torch.int64
+        )
+        valid_state = state_indices != NULL_BLOCK_ID
+        state_indices = torch.where(
+            valid_state, state_indices, torch.zeros_like(state_indices)
+        )
+        has_initial = has_initial_states_p[:num_prefills].to(
+            device=conv_state.device, dtype=torch.bool
+        )
+        if self.conv_state_len > 0:
+            if conv_state.shape[0] == 0:
+                state = conv_state.new_zeros(
+                    (num_prefills, hidden_size, self.conv_state_len),
+                    dtype=x_p.dtype,
+                )
+            else:
+                state = conv_state.index_select(0, state_indices)[
+                    ..., : self.conv_state_len
+                ].to(x_p.dtype)
+            use_initial_mask = (valid_state & has_initial).view(num_prefills, 1, 1)
+            initial_state = torch.where(
+                use_initial_mask,
+                state,
+                torch.zeros_like(state),
+            )
+            history = torch.cat((initial_state, packed_tokens), dim=-1)
+        else:
+            history = packed_tokens
+
+        conv_output = F.conv1d(
+            history,
+            conv_weights.unsqueeze(1).contiguous(),
+            groups=history.size(1),
+            dilation=self.short_conv_dilation,
+        )
+        conv_output = F.silu(conv_output).transpose(1, 2).contiguous()
+
+        token_positions = torch.arange(max_len, device=x_p.device, dtype=torch.int64)
+        valid_tokens = token_positions.view(1, max_len) < lengths.view(num_prefills, 1)
+        valid_output_mask = valid_tokens & valid_state.to(device=x_p.device).view(
+            num_prefills, 1
+        )
+        conv_output.masked_fill_(~valid_output_mask.unsqueeze(-1), 0)
+        output.copy_(conv_output[req_indices, col_indices])
+
+        if self.conv_state_len > 0 and conv_state.shape[0] > 0:
+            state_starts = lengths.to(device=history.device, dtype=torch.int64).view(
+                num_prefills, 1, 1
+            )
+            state_offsets = torch.arange(
+                self.conv_state_len, device=history.device, dtype=torch.int64
+            ).view(1, 1, self.conv_state_len)
+            next_state = history.gather(
+                dim=2,
+                index=(state_starts + state_offsets).expand(-1, history.size(1), -1),
+            )
+            # Write back without a host synchronization. Valid, non-empty rows
+            # receive their new state; padding and zero-length rows keep the
+            # current cache value.
+            existing_state = conv_state.index_select(0, state_indices)
+            existing_base_state = existing_state[..., : self.conv_state_len]
+            update_mask = valid_state & (lengths.to(device=conv_state.device) > 0)
+            safe_next_state = torch.where(
+                update_mask.view(num_prefills, 1, 1),
+                next_state.to(conv_state.dtype),
+                existing_base_state,
+            )
+            existing_state[..., : self.conv_state_len] = safe_next_state
+            conv_state.index_copy_(0, state_indices, existing_state)
+        return output
+
+    def _short_conv_dilated_spec_batched(
+        self,
+        x_spec: torch.Tensor,
+        conv_state: torch.Tensor,
+        conv_weights: torch.Tensor,
+        spec_state_indices_tensor: torch.Tensor,
+        spec_query_start_loc: torch.Tensor,
+        num_accepted_tokens: torch.Tensor,
+        spec_query_len: int,
+    ) -> torch.Tensor:
+        """Dilated short-conv for speculative-decode (MTP) requests.
+
+        Each spec request feeds multiple (draft + 1) query tokens. The conv
+        outputs are computed causally after rolling back the previous draft
+        state by ``num_accepted_tokens - 1``. The current candidate inputs stay
+        in the extended cache for the next forward, matching
+        ``causal_conv1d_update``.
+
+        ``spec_query_len`` (== num_speculative_tokens + 1) is the maximum query
+        length and is a Python int, so no host synchronization is needed; this
+        keeps the path safe for full CUDA-graph capture/replay where the buffers
+        are padded at the request level.
+        """
+        num_reqs = spec_state_indices_tensor.numel()
+        hidden_size = x_spec.size(-1)
+        # Use a fixed packing width instead of synchronizing on lengths.max().
+        max_len = spec_query_len
+        # Full CUDA graphs can pad these buffers. Only the first num_reqs
+        # accepted-token counts belong to actual speculative requests.
+        num_accepted_tokens = num_accepted_tokens[:num_reqs]
+        q_starts = spec_query_start_loc[: num_reqs + 1].to(torch.int64)
+        # Keep the number of real speculative tokens on the device.
+        total_real_tokens = q_starts[num_reqs]
+
+        state_indices = spec_state_indices_tensor.to(
+            device=conv_state.device, dtype=torch.int64
+        )
+        valid_state = state_indices != NULL_BLOCK_ID
+        state_indices = torch.where(
+            valid_state, state_indices, torch.zeros_like(state_indices)
+        )
+        positions = torch.arange(
+            x_spec.size(0), device=x_spec.device, dtype=torch.int64
+        )
+        # Route graph-padded token rows to the discarded dummy request so that
+        # they cannot overwrite real packed data.
+        req_indices = torch.searchsorted(q_starts[1:], positions, right=True)
+        valid_tokens = (positions < total_real_tokens) & (req_indices < num_reqs)
+        clamped_req_indices = req_indices.clamp_max(max(num_reqs - 1, 0))
+        col_indices = (positions - q_starts[clamped_req_indices]).clamp_(0, max_len - 1)
+        pack_req_indices = torch.where(
+            valid_tokens,
+            clamped_req_indices,
+            torch.full_like(req_indices, num_reqs),
+        )
+        pack_col_indices = torch.where(
+            valid_tokens, col_indices, torch.zeros_like(col_indices)
+        )
+
+        # The last request row is the dummy sink for graph padding.
+        packed = x_spec.new_zeros((num_reqs + 1, max_len, hidden_size))
+        packed[pack_req_indices, pack_col_indices] = x_spec
+        packed = packed.transpose(1, 2).contiguous()
+
+        if self.conv_state_len > 0:
+            cached_state = conv_state.index_select(0, state_indices)
+            rollback_offsets = num_accepted_tokens.to(
+                device=conv_state.device, dtype=torch.int64
+            ).sub(1)
+            rollback_offsets = torch.where(
+                valid_state,
+                rollback_offsets.clamp_(0, max_len - 1),
+                torch.zeros_like(rollback_offsets),
+            )
+            state_offsets = torch.arange(
+                self.conv_state_len, device=conv_state.device, dtype=torch.int64
+            ).view(1, 1, self.conv_state_len)
+            rollback_indices = rollback_offsets.view(-1, 1, 1) + state_offsets
+            state = cached_state.gather(
+                2, rollback_indices.expand(-1, hidden_size, -1)
+            ).to(x_spec.dtype)
+            state = torch.where(
+                valid_state.view(num_reqs, 1, 1),
+                state,
+                torch.zeros_like(state),
+            )
+            # Append a zeroed dummy-row state to match the [num_reqs + 1] pack.
+            dummy_state = state.new_zeros((1, hidden_size, self.conv_state_len))
+            state_full = torch.cat((state, dummy_state), dim=0)
+            history = torch.cat((state_full, packed), dim=-1)
+        else:
+            history = packed
+
+        conv_output = F.conv1d(
+            history,
+            conv_weights.unsqueeze(1).contiguous(),
+            groups=history.size(1),
+            dilation=self.short_conv_dilation,
+        )
+        conv_output = F.silu(conv_output).transpose(1, 2).contiguous()
+
+        output = conv_output[pack_req_indices, pack_col_indices]
+        output = output * valid_tokens.view(-1, 1).to(output.dtype)
+
+        # Keep all current candidate inputs in the extended state. On the next
+        # target forward, ``num_accepted_tokens - 1`` selects the rollback
+        # window before processing the newly scheduled tokens.
+        if self.conv_state_len > 0:
+            state_capacity = self.conv_state_len + max_len - 1
+            if conv_state.size(-1) < state_capacity:
+                raise RuntimeError(
+                    "PLE short-conv cache cannot retain speculative tokens: "
+                    f"got {conv_state.size(-1)}, need {state_capacity}."
+                )
+            candidate_state = history[:num_reqs, :, 1 : state_capacity + 1]
+            query_lengths = q_starts[1:] - q_starts[:-1]
+            state_positions = torch.arange(
+                state_capacity, device=history.device, dtype=torch.int64
+            ).view(1, 1, state_capacity)
+            update_lengths = (self.conv_state_len + query_lengths - 1).view(
+                num_reqs, 1, 1
+            )
+            update_mask = valid_state.view(num_reqs, 1, 1) & (
+                state_positions < update_lengths
+            )
+            existing_state = cached_state[..., :state_capacity]
+            next_state = torch.where(
+                update_mask,
+                candidate_state.to(conv_state.dtype),
+                existing_state,
+            )
+            cached_state[..., :state_capacity] = next_state
+            conv_state.index_copy_(0, state_indices, cached_state)
+
+        return output
+
+    def _short_conv_dilated_dispatch(
+        self,
+        inputs: torch.Tensor,
+        metadata: PleShortConvAttentionMetadata,
+        conv_state: torch.Tensor,
+        conv_weights: torch.Tensor,
+    ) -> torch.Tensor:
+        num_prefills = metadata.num_prefills
+        num_decodes = metadata.num_decodes
+        num_decode_tokens = metadata.num_decode_tokens
+        num_prefill_tokens = metadata.num_prefill_tokens
+        has_prefill = num_prefills > 0
+        has_decode = num_decodes > 0
+        has_spec = metadata.spec_sequence_masks is not None
+        x = inputs[: metadata.num_actual_tokens]
+
+        # Split spec / non-spec tokens.
+        if has_spec:
+            if has_prefill or has_decode:
+                assert metadata.spec_token_indx is not None
+                assert metadata.non_spec_token_indx is not None
+                x_spec = x.index_select(0, metadata.spec_token_indx.long())
+                x_non_spec = x.index_select(0, metadata.non_spec_token_indx.long())
+            else:
+                x_spec = x
+                x_non_spec = None
+        else:
+            x_spec = None
+            x_non_spec = x
+
+        spec_output = None
+        # 1. Run the multi-query speculative-decode part.
+        if has_spec:
+            assert metadata.spec_state_indices_tensor is not None
+            assert metadata.spec_query_start_loc is not None
+            assert metadata.num_accepted_tokens is not None
+            spec_output = self._short_conv_dilated_spec_batched(
+                x_spec=x_spec,
+                conv_state=conv_state,
+                conv_weights=conv_weights,
+                spec_state_indices_tensor=metadata.spec_state_indices_tensor[
+                    : metadata.num_spec_decodes
+                ],
+                spec_query_start_loc=metadata.spec_query_start_loc,
+                num_accepted_tokens=metadata.num_accepted_tokens,
+                spec_query_len=metadata.spec_query_len,
+            )
+
+        # 2. Run regular decode and prefill requests.
+        conv_out_non_spec = None
+        state_indices_tensor = metadata.state_indices_tensor
+        if x_non_spec is not None:
+            assert state_indices_tensor is not None
+            if has_prefill:
+                state_indices_tensor_d, state_indices_tensor_p = torch.split(
+                    state_indices_tensor,
+                    [num_decodes, num_prefills],
+                    dim=0,
+                )
+                x_d, x_p = torch.split(
+                    x_non_spec,
+                    [num_decode_tokens, num_prefill_tokens],
+                    dim=0,
+                )
+                non_spec_parts: list[torch.Tensor] = []
+                if has_decode:
+                    non_spec_parts.append(
+                        self._short_conv_dilated_decode_batched(
+                            x_d=x_d,
+                            conv_state=conv_state,
+                            conv_weights=conv_weights,
+                            state_indices_tensor_d=state_indices_tensor_d,
+                            has_initial_states_d=metadata.has_initial_states_d,
+                        )
+                    )
+                non_spec_parts.append(
+                    self._short_conv_dilated_prefill_batched(
+                        x_p=x_p,
+                        metadata=metadata,
+                        conv_state=conv_state,
+                        conv_weights=conv_weights,
+                        state_indices_tensor_p=state_indices_tensor_p,
+                        num_prefills=num_prefills,
+                        num_decode_tokens=num_decode_tokens,
+                        num_prefill_tokens=num_prefill_tokens,
+                    )
+                )
+                conv_out_non_spec = torch.vstack(non_spec_parts)
+            else:
+                conv_out_non_spec = self._short_conv_dilated_decode_batched(
+                    x_d=x_non_spec,
+                    conv_state=conv_state,
+                    conv_weights=conv_weights,
+                    state_indices_tensor_d=state_indices_tensor[: x_non_spec.size(0)],
+                    has_initial_states_d=metadata.has_initial_states_d,
+                )
+
+        # 3. Merge both parts back into the original token order.
+        if has_spec and conv_out_non_spec is not None:
+            assert metadata.spec_token_indx is not None
+            assert metadata.non_spec_token_indx is not None
+            assert spec_output is not None
+            output = x.new_empty((metadata.num_actual_tokens, x.size(-1)))
+            output.index_copy_(0, metadata.spec_token_indx, spec_output)
+            output.index_copy_(0, metadata.non_spec_token_indx, conv_out_non_spec)
+            return output
+        elif has_spec:
+            assert spec_output is not None
+            return spec_output
+        if conv_out_non_spec is None:
+            return x
+        return conv_out_non_spec
+
+    def _short_conv(self, inputs: torch.Tensor) -> torch.Tensor:
+        forward_context = get_forward_context()
+        attn_metadata = forward_context.attn_metadata
+        if attn_metadata is None:
+            return self._short_conv_fallback(inputs)
+
+        if not isinstance(attn_metadata, dict):
+            raise RuntimeError(
+                "PLE short-conv expects per-layer attention metadata dict "
+                f"during inference, got {type(attn_metadata).__name__}."
+            )
+
+        layer_attn_metadata = attn_metadata.get(self.prefix)
+        if layer_attn_metadata is None:
+            raise RuntimeError(
+                f"Missing short-conv metadata for layer '{self.prefix}'. "
+                "This would bypass conv-state updates and is not allowed."
+            )
+        if not isinstance(layer_attn_metadata, PleShortConvAttentionMetadata):
+            raise TypeError(
+                "Expected PleShortConvAttentionMetadata for layer "
+                f"'{self.prefix}', got "
+                f"{type(layer_attn_metadata).__name__}."
+            )
+
+        conv_state = self.kv_cache[0]
+        if not is_conv_state_dim_first():
+            conv_state = conv_state.transpose(-1, -2)
+        conv_weights = self.conv1d.weight.squeeze(1)
+
+        state_capacity = self.conv_state_len + self.num_spec_tokens
+        if state_capacity > 0:
+            if conv_state.size(-1) < state_capacity:
+                raise RuntimeError(
+                    "PLE short-conv cache is smaller than expected for "
+                    f"dilated convolution: got {conv_state.size(-1)}, "
+                    f"expect at least {state_capacity}."
+                )
+            conv_state = conv_state[..., -state_capacity:]
+        return self._short_conv_dilated_dispatch(
+            inputs,
+            layer_attn_metadata,
+            conv_state,
+            conv_weights.to(dtype=inputs.dtype),
+        )
+
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+        input_ids: torch.Tensor,
+        query_start_loc: torch.Tensor,
+        ngram_context: torch.Tensor,
+    ) -> torch.Tensor:
+        input_ids = input_ids.reshape(-1)
+        if input_ids.shape[0] != hidden_states.shape[0]:
+            raise ValueError(
+                "PLE expects input_ids and hidden_states to have the same "
+                f"token length, got {input_ids.shape[0]} and "
+                f"{hidden_states.shape[0]}"
+            )
+        embeddings = self.ple_embedding(
+            hidden_states,
+            input_ids,
+            query_start_loc,
+            ngram_context,
+        )
+        embeddings = self._dequantize_embeddings(embeddings, hidden_states.dtype)
+        key, _ = self.key_proj(embeddings)
+        value, _ = self.value_proj(embeddings)
+        token_count = hidden_states.shape[0]
+        key = key.reshape(token_count, self.hc_count, self.hidden_size)
+        query = hidden_states.reshape(token_count, self.hc_count, self.hidden_size)
+        key = self._apply_norm(self.norm_key, key)
+        query = self._apply_norm(self.norm_query, query)
+        gate = (key * query).sum(dim=-1, keepdim=True) / math.sqrt(self.hidden_size)
+        gate = torch.sigmoid(gate.sign() * gate.abs().clamp_min(1e-6).sqrt())
+        gated_value = gate * value.unsqueeze(-2)
+        normalized = self._apply_norm(self.norm_conv, gated_value).flatten(-2)
+        conv_output = torch.zeros_like(normalized)
+        torch.ops.vllm.qwen4_exp_ple_short_conv(
+            normalized,
+            conv_output,
+            self.prefix,
+        )
+        return gated_value.flatten(-2) + conv_output
+
+
+def qwen4_exp_ple_short_conv(
+    inputs: torch.Tensor,
+    output: torch.Tensor,
+    layer_name: str,
+) -> None:
+    layer = get_forward_context().no_compile_layers[layer_name]
+    result = layer._short_conv(inputs)
+    output[: result.shape[0]].copy_(result)
+
+
+def qwen4_exp_ple_short_conv_fake(
+    inputs: torch.Tensor,
+    output: torch.Tensor,
+    layer_name: str,
+) -> None:
+    return
+
+
+direct_register_custom_op(
+    op_name="qwen4_exp_ple_short_conv",
+    op_func=qwen4_exp_ple_short_conv,
+    mutates_args=["output"],
+    fake_impl=qwen4_exp_ple_short_conv_fake,
+)
+
+
+__all__ = [
+    "Qwen4ExpNGramEmbedding",
+    "Qwen4ExpPLEGroupedNorm",
+    "Qwen4ExpPLELayer",
+]

--- a/vllm_ascend/models/qwen4_exp/nvidia/ple_layer.py
+++ b/vllm_ascend/models/qwen4_exp/nvidia/ple_layer.py
@@ -659,7 +659,7 @@ class Qwen4ExpPLELayer(nn.Module, MambaBase):
         return MambaStateShapeCalculator.short_conv_state_shape(
             tp_world_size=1,
             intermediate_size=self.hc_hidden_size,
-            conv_kernel=self.conv_state_len + 1,
+            conv_kernel=self.conv_state_len + self.num_spec_tokens + 1,
         )
 
     def _apply_norm(
@@ -673,6 +673,76 @@ class Qwen4ExpPLELayer(nn.Module, MambaBase):
         inputs_t = inputs.transpose(0, 1).unsqueeze(0)
         output = self.conv1d(inputs_t)[..., : inputs_t.size(-1)]
         return F.silu(output).squeeze(0).transpose(0, 1)
+
+    @staticmethod
+    def _gather_conv_state_rows(
+        conv_state: torch.Tensor, state_indices: torch.Tensor
+    ) -> torch.Tensor:
+        """Select request rows before transposing the large short-conv cache."""
+        storage_layout = conv_state.transpose(-1, -2)
+        if storage_layout.is_contiguous():
+            selected = storage_layout.index_select(0, state_indices)
+            return selected.transpose(-1, -2)
+        return conv_state.index_select(0, state_indices)
+
+    @staticmethod
+    def _scatter_conv_state_rows(
+        conv_state: torch.Tensor,
+        state_indices: torch.Tensor,
+        selected_state: torch.Tensor,
+    ) -> None:
+        """Write request rows through the contiguous short-conv cache layout."""
+        storage_layout = conv_state.transpose(-1, -2)
+        if storage_layout.is_contiguous():
+            storage_layout.index_copy_(
+                0, state_indices, selected_state.transpose(-1, -2)
+            )
+            return
+        conv_state.index_copy_(0, state_indices, selected_state)
+
+    @staticmethod
+    def _short_conv_cross_correlation(
+        history: torch.Tensor,
+        conv_weights: torch.Tensor,
+        dilation: int,
+    ) -> torch.Tensor:
+        """Depthwise 1-D cross-correlation without Conv2D or unfold views.
+
+        ``Tensor.unfold`` represents its windows with overlapping as-strided
+        metadata. That metadata can be captured with temporary graph-pool
+        addresses on Ascend and then fault on the first graph replay. The
+        kernel is tiny, so explicitly accumulate its fixed-offset slices.
+        """
+        kernel_size = conv_weights.size(-1)
+        history_len = history.size(-1)
+        effective_kernel_size = dilation * (kernel_size - 1) + 1
+        output_len = history_len - effective_kernel_size + 1
+        if output_len == 1:
+            # Ordinary decode has exactly one output position. Materialize
+            # the dilated kernel samples so graph replay never observes the
+            # stepped slice's dynamic stride metadata.
+            dilated_history = history[..., 0:history_len:dilation].contiguous()
+            return (
+                dilated_history.float()
+                * conv_weights.float().view(1, history.size(1), kernel_size)
+            ).sum(dim=-1, keepdim=True).to(history.dtype)
+
+        # Prefill/speculative paths can have multiple output positions. Each
+        # slice is a normal contiguous-range view; stack immediately owns a
+        # dense copy and no view stride survives into the multiply kernel.
+        windows = torch.stack(
+            [
+                history[
+                    ..., kernel_idx * dilation : kernel_idx * dilation + output_len
+                ]
+                for kernel_idx in range(kernel_size)
+            ],
+            dim=-1,
+        ).contiguous()
+        return (
+            windows.float()
+            * conv_weights.float().view(1, history.size(1), 1, kernel_size)
+        ).sum(dim=-1).to(history.dtype)
 
     def _short_conv_dilated_decode_batched(
         self,
@@ -706,7 +776,9 @@ class Qwen4ExpPLELayer(nn.Module, MambaBase):
             ].to(device=conv_state.device, dtype=torch.bool)
             has_initial_state = has_initial_state & valid_state
 
-        cached_state = conv_state.index_select(0, state_indices)
+        state_capacity = self.conv_state_len + self.num_spec_tokens
+        cached_state_full = self._gather_conv_state_rows(conv_state, state_indices)
+        cached_state = cached_state_full[..., -state_capacity:]
         state = cached_state[..., : self.conv_state_len].to(x_d.dtype)
         if self.conv_state_len > 0:
             initial_state = torch.where(
@@ -718,11 +790,12 @@ class Qwen4ExpPLELayer(nn.Module, MambaBase):
         else:
             history = x_d.unsqueeze(-1)
 
-        conv_output = F.conv1d(
-            history,
-            conv_weights.unsqueeze(1).contiguous(),
-            groups=history.size(1),
-            dilation=self.short_conv_dilation,
+        # ``F.conv1d`` lowers this tiny depthwise convolution to the legacy
+        # ACLop Conv2D path on Ascend, which cannot be captured by an NPU
+        # graph. Express the same cross-correlation with tensor operations so
+        # the ordinary decode path remains graph-capturable.
+        conv_output = self._short_conv_cross_correlation(
+            history, conv_weights, self.short_conv_dilation
         ).squeeze(-1)
         output = F.silu(conv_output)
         output = output * valid_state.view(-1, 1).to(output.dtype)
@@ -738,7 +811,9 @@ class Qwen4ExpPLELayer(nn.Module, MambaBase):
                 existing_base_state,
             )
             cached_state[..., : self.conv_state_len] = safe_next_state
-            conv_state.index_copy_(0, state_indices, cached_state)
+            self._scatter_conv_state_rows(
+                conv_state, state_indices, cached_state_full
+            )
 
         return output
 
@@ -819,9 +894,10 @@ class Qwen4ExpPLELayer(nn.Module, MambaBase):
                     dtype=x_p.dtype,
                 )
             else:
-                state = conv_state.index_select(0, state_indices)[
-                    ..., : self.conv_state_len
-                ].to(x_p.dtype)
+                state_capacity = self.conv_state_len + self.num_spec_tokens
+                state = self._gather_conv_state_rows(conv_state, state_indices)[
+                    ..., -state_capacity:
+                ][..., : self.conv_state_len].to(x_p.dtype)
             use_initial_mask = (valid_state & has_initial).view(num_prefills, 1, 1)
             initial_state = torch.where(
                 use_initial_mask,
@@ -832,11 +908,12 @@ class Qwen4ExpPLELayer(nn.Module, MambaBase):
         else:
             history = packed_tokens
 
-        conv_output = F.conv1d(
-            history,
-            conv_weights.unsqueeze(1).contiguous(),
-            groups=history.size(1),
-            dilation=self.short_conv_dilation,
+        # ``F.conv1d`` lowers this tiny depthwise convolution to the legacy
+        # ACLop Conv2D path on Ascend, which cannot be captured by an NPU
+        # graph. Express the same cross-correlation with tensor operations so
+        # the speculative decode path remains graph-capturable.
+        conv_output = self._short_conv_cross_correlation(
+            history, conv_weights, self.short_conv_dilation
         )
         conv_output = F.silu(conv_output).transpose(1, 2).contiguous()
 
@@ -862,7 +939,11 @@ class Qwen4ExpPLELayer(nn.Module, MambaBase):
             # Write back without a host synchronization. Valid, non-empty rows
             # receive their new state; padding and zero-length rows keep the
             # current cache value.
-            existing_state = conv_state.index_select(0, state_indices)
+            state_capacity = self.conv_state_len + self.num_spec_tokens
+            existing_state_full = self._gather_conv_state_rows(
+                conv_state, state_indices
+            )
+            existing_state = existing_state_full[..., -state_capacity:]
             existing_base_state = existing_state[..., : self.conv_state_len]
             update_mask = valid_state & (lengths.to(device=conv_state.device) > 0)
             safe_next_state = torch.where(
@@ -871,7 +952,9 @@ class Qwen4ExpPLELayer(nn.Module, MambaBase):
                 existing_base_state,
             )
             existing_state[..., : self.conv_state_len] = safe_next_state
-            conv_state.index_copy_(0, state_indices, existing_state)
+            self._scatter_conv_state_rows(
+                conv_state, state_indices, existing_state_full
+            )
         return output
 
     def _short_conv_dilated_spec_batched(
@@ -939,7 +1022,9 @@ class Qwen4ExpPLELayer(nn.Module, MambaBase):
         packed = packed.transpose(1, 2).contiguous()
 
         if self.conv_state_len > 0:
-            cached_state = conv_state.index_select(0, state_indices)
+            state_capacity = self.conv_state_len + self.num_spec_tokens
+            cached_state_full = self._gather_conv_state_rows(conv_state, state_indices)
+            cached_state = cached_state_full[..., -state_capacity:]
             rollback_offsets = num_accepted_tokens.to(
                 device=conv_state.device, dtype=torch.int64
             ).sub(1)
@@ -967,11 +1052,10 @@ class Qwen4ExpPLELayer(nn.Module, MambaBase):
         else:
             history = packed
 
-        conv_output = F.conv1d(
-            history,
-            conv_weights.unsqueeze(1).contiguous(),
-            groups=history.size(1),
-            dilation=self.short_conv_dilation,
+        # Avoid the legacy ACLop Conv2D lowering of depthwise ``F.conv1d``;
+        # ACLop operators cannot run while the MTP decode graph is captured.
+        conv_output = self._short_conv_cross_correlation(
+            history, conv_weights, self.short_conv_dilation
         )
         conv_output = F.silu(conv_output).transpose(1, 2).contiguous()
 
@@ -1006,7 +1090,9 @@ class Qwen4ExpPLELayer(nn.Module, MambaBase):
                 existing_state,
             )
             cached_state[..., :state_capacity] = next_state
-            conv_state.index_copy_(0, state_indices, cached_state)
+            self._scatter_conv_state_rows(
+                conv_state, state_indices, cached_state_full
+            )
 
         return output
 
@@ -1161,7 +1247,10 @@ class Qwen4ExpPLELayer(nn.Module, MambaBase):
                     f"dilated convolution: got {conv_state.size(-1)}, "
                     f"expect at least {state_capacity}."
                 )
-            conv_state = conv_state[..., -state_capacity:]
+            # Keep the full cache contiguous here. Slicing the last state
+            # columns before index_select creates a strided view whose Ascend
+            # kernel materializes the entire cache. Gather the request rows
+            # first, then slice the much smaller gathered tensor instead.
         return self._short_conv_dilated_dispatch(
             inputs,
             layer_attn_metadata,

--- a/vllm_ascend/models/qwen4_exp/nvidia/qsa.py
+++ b/vllm_ascend/models/qwen4_exp/nvidia/qsa.py
@@ -1,0 +1,481 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""NVIDIA QSA owner with Triton kernels."""
+
+from __future__ import annotations
+
+from typing import ClassVar, cast
+
+import torch
+from torch import nn
+from vllm.config import VllmConfig
+from vllm.config.cache import CacheDType
+from vllm.distributed import get_tensor_model_parallel_world_size
+from vllm.forward_context import get_forward_context
+from vllm.model_executor.layers.attention.attention import (
+    set_default_quant_scales,
+)
+from vllm.model_executor.layers.attention_layer_base import AttentionLayerBase
+from vllm.model_executor.layers.layernorm import GemmaRMSNorm
+from vllm.model_executor.layers.linear import QKVParallelLinear, RowParallelLinear
+from vllm.model_executor.layers.quantization import QuantizationConfig
+from vllm.model_executor.layers.rotary_embedding import MRotaryEmbedding, get_rope
+from vllm.model_executor.models.qwen3_next import Qwen3NextAttention
+from vllm.platforms import current_platform
+from vllm.utils.torch_utils import (
+    LayerNameType,
+    _encode_layer_name,
+    _resolve_layer_name,
+    canonicalize_singleton_dim_strides,
+    direct_register_custom_op,
+    kv_cache_dtype_str_to_dtype,
+)
+from vllm.v1.attention.backend import (
+    AttentionBackend,
+    AttentionCGSupport,
+    AttentionType,
+)
+from vllm.v1.attention.backends.fa_utils import is_flash_attn_varlen_func_available
+from vllm.v1.attention.backends.flash_attn import (
+    FlashAttentionBackend,
+    FlashAttentionImpl,
+    FlashAttentionMetadata,
+    FlashAttentionMetadataBuilder,
+)
+from vllm.v1.kv_cache_interface import (
+    FullAttentionSpec,
+    KVCacheSpec,
+    get_kv_quant_mode,
+)
+
+from vllm_ascend.models.qwen4_exp.config import (
+    Qwen4ExpTextConfig,
+)
+
+from ..common.qsa_cache import QSAForwardMetadata
+from . import model
+from .indexer_qsa import QSAIndexer
+
+
+class Qwen4ExpQSAMetadataBuilder(FlashAttentionMetadataBuilder):
+    """Flash metadata supporting uniform decode and target-verify graphs."""
+
+    _cudagraph_support: ClassVar[AttentionCGSupport] = AttentionCGSupport.UNIFORM_BATCH
+
+
+class Qwen4ExpQSAFlashAttentionBackend(FlashAttentionBackend):
+    """FullAttentionSpec backend used by the merged QSA owner."""
+
+    supported_dtypes: ClassVar[list[torch.dtype]] = [torch.bfloat16]
+    supported_kv_cache_dtypes: ClassVar[list[CacheDType]] = ["auto", "bfloat16"]
+
+    @staticmethod
+    def get_name() -> str:
+        return "QWEN4_EXP_QSA_TRITON"
+
+    @staticmethod
+    def get_impl_cls() -> type[Qwen4ExpQSAFlashAttentionImpl]:
+        return Qwen4ExpQSAFlashAttentionImpl
+
+    @staticmethod
+    def get_builder_cls() -> type[Qwen4ExpQSAMetadataBuilder]:
+        return Qwen4ExpQSAMetadataBuilder
+
+    @classmethod
+    def is_sparse(cls) -> bool:
+        return True
+
+    @classmethod
+    def supports_kv_connector(cls) -> bool:
+        return False
+
+
+class Qwen4ExpQSAFlashAttentionImpl(FlashAttentionImpl):
+    """Run paged sparse GQA with the QSA Triton kernel."""
+
+    supports_dcp: bool = False
+    supports_pcp: bool = False
+
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
+        if not is_flash_attn_varlen_func_available():
+            raise NotImplementedError("Qwen4Exp QSA requires FlashAttention")
+        if self.dcp_world_size != 1:
+            raise NotImplementedError(
+                "Qwen4Exp QSA does not support decode context parallelism"
+            )
+        if self.kv_cache_dtype not in ("auto", "bfloat16"):
+            raise NotImplementedError("Qwen4Exp QSA requires a BF16 main KV cache")
+        self.supports_quant_query_input = False
+
+    def forward_qsa(
+        self,
+        layer: torch.nn.Module,
+        query: torch.Tensor,
+        key: torch.Tensor,
+        value: torch.Tensor,
+        kv_cache: torch.Tensor,
+        attn_metadata: FlashAttentionMetadata,
+        output: torch.Tensor,
+        token_to_req: torch.Tensor,
+        output_scale: torch.Tensor | None = None,
+        output_block_scale: torch.Tensor | None = None,
+    ) -> torch.Tensor:
+        del key, value
+        if output_scale is not None or output_block_scale is not None:
+            raise NotImplementedError("QSA does not support fused output quantization")
+        if self.alibi_slopes is not None or self.sinks is not None:
+            raise NotImplementedError("QSA does not support ALiBi or attention sinks")
+        if self.sliding_window != (-1, -1):
+            raise NotImplementedError("QSA does not support sliding-window attention")
+
+        num_tokens = attn_metadata.num_actual_tokens
+        output.zero_()
+        if num_tokens == 0:
+            return output
+
+        topk_buffer = getattr(layer, "topk_indices_buffer", None)
+        if topk_buffer is None:
+            raise RuntimeError("QSA owner did not provide its top-k buffer")
+        logical_indices = topk_buffer[:num_tokens]
+        token_to_req = token_to_req[:num_tokens]
+        key_cache, value_cache = kv_cache.transpose(1, 2).split(self.head_size, dim=-1)
+        key_cache = canonicalize_singleton_dim_strides(key_cache)
+        value_cache = canonicalize_singleton_dim_strides(value_cache)
+        if key_cache.dtype != torch.bfloat16 or query.dtype != torch.bfloat16:
+            raise NotImplementedError("Qwen4Exp QSA requires BF16 Q/K/V")
+
+        from .ops.qsa import qsa_sparse_paged_attention
+
+        qsa_sparse_paged_attention(
+            query[:num_tokens],
+            key_cache,
+            value_cache,
+            logical_indices,
+            attn_metadata.block_table,
+            token_to_req,
+            output[:num_tokens],
+        )
+        return output
+
+
+class Qwen4ExpQSAAttention(Qwen3NextAttention, AttentionLayerBase):
+    """Merged Qwen full-attention owner with a QSA index side branch."""
+
+    supports_dcp = False
+
+    def __init__(
+        self,
+        *,
+        vllm_config: VllmConfig,
+        config: Qwen4ExpTextConfig,
+        layer_id: int,
+        quant_config: QuantizationConfig | None = None,
+        reduce_results: bool = True,
+        prefix: str = "",
+    ) -> None:
+        nn.Module.__init__(self)
+        cache_config = vllm_config.cache_config
+        model_config = vllm_config.model_config
+        if cache_config is None:
+            raise ValueError("Qwen4Exp QSA requires a paged KV cache")
+        if model_config.dtype != torch.bfloat16:
+            raise NotImplementedError("Qwen4Exp QSA currently requires BF16")
+        if cache_config.cache_dtype not in ("auto", "bfloat16"):
+            raise NotImplementedError("Qwen4Exp QSA requires a BF16 main KV cache")
+        if getattr(quant_config, "kv_cache_scheme", None) is not None:
+            raise NotImplementedError("Qwen4Exp QSA does not support KV quantization")
+        parallel_config = vllm_config.parallel_config
+        if (
+            parallel_config.prefill_context_parallel_size > 1
+            or parallel_config.decode_context_parallel_size > 1
+        ):
+            raise NotImplementedError(
+                "Qwen4Exp QSA does not support context parallelism"
+            )
+        if not getattr(config, "is_causal", True):
+            raise NotImplementedError("Qwen4Exp QSA requires causal decoder attention")
+
+        self.config = config
+        self.hidden_size = int(config.hidden_size)
+        tp_size = get_tensor_model_parallel_world_size()
+        self.total_num_heads = int(config.num_attention_heads)
+        if self.total_num_heads % tp_size:
+            raise ValueError("QSA attention heads must be divisible by TP size")
+        self.num_heads = self.total_num_heads // tp_size
+        self.total_num_kv_heads = int(config.num_key_value_heads)
+        if self.total_num_kv_heads >= tp_size:
+            if self.total_num_kv_heads % tp_size:
+                raise ValueError("QSA KV heads must be divisible by TP size")
+        elif tp_size % self.total_num_kv_heads:
+            raise ValueError("TP size must be divisible by replicated QSA KV heads")
+        self.num_kv_heads = max(1, self.total_num_kv_heads // tp_size)
+        self.head_dim = int(config.head_dim or self.hidden_size // self.num_heads)
+        self.q_size = self.num_heads * self.head_dim
+        self.kv_size = self.num_kv_heads * self.head_dim
+        self.scaling = self.head_dim**-0.5
+        self.dual_chunk_attention_config = getattr(
+            config, "dual_chunk_attention_config", None
+        )
+        if self.dual_chunk_attention_config is not None:
+            raise NotImplementedError("Qwen4Exp QSA does not support dual-chunk RoPE")
+        # Qwen4Exp full-attention checkpoints always pack a sigmoid output
+        # gate next to Q, even when an inherited config default says otherwise.
+        self.attn_output_gate = True
+
+        self.qkv_proj = QKVParallelLinear(
+            self.hidden_size,
+            self.head_dim,
+            self.total_num_heads * (1 + self.attn_output_gate),
+            self.total_num_kv_heads,
+            bias=False,
+            quant_config=model.without_modelopt_fp4(quant_config),
+            prefix=f"{prefix}.qkv_proj",
+        )
+        self.o_proj = RowParallelLinear(
+            self.total_num_heads * self.head_dim,
+            self.hidden_size,
+            bias=False,
+            reduce_results=reduce_results,
+            quant_config=quant_config,
+            prefix=f"{prefix}.o_proj",
+        )
+        self.rotary_emb = get_rope(
+            head_size=self.head_dim,
+            max_position=config.max_position_embeddings,
+            rope_parameters=config.rope_parameters,
+        )
+        self.q_norm = GemmaRMSNorm(self.head_dim, eps=config.rms_norm_eps)
+        self.k_norm = GemmaRMSNorm(self.head_dim, eps=config.rms_norm_eps)
+
+        mm_config = model_config.multimodal_config
+        text_only = mm_config is None or mm_config.language_model_only
+        mrope_section = getattr(self.rotary_emb, "mrope_section", None)
+        supports_mrope = bool(
+            type(self.rotary_emb) is MRotaryEmbedding
+            and mrope_section
+            and len(mrope_section) == 3
+            and sum(mrope_section) == self.rotary_emb.rotary_dim // 2
+            and getattr(self.rotary_emb, "mrope_interleaved", False)
+        )
+        supports_dtype = getattr(self.rotary_emb, "dtype", None) in (
+            torch.float16,
+            torch.bfloat16,
+        )
+        self.use_fused_qk_norm_rope_gate = (
+            self.attn_output_gate
+            and getattr(self.rotary_emb, "is_neox_style", False)
+            and current_platform.is_cuda()
+            and supports_dtype
+            and (text_only or supports_mrope)
+        )
+
+        self.layer_name = f"{prefix}.attn"
+        self.attn_type = AttentionType.DECODER
+        self.kv_cache_dtype = cache_config.cache_dtype
+        self.kv_cache_torch_dtype = kv_cache_dtype_str_to_dtype(
+            self.kv_cache_dtype, model_config
+        )
+        if self.kv_cache_torch_dtype != torch.bfloat16:
+            raise NotImplementedError("Qwen4Exp QSA requires BF16 cache storage")
+        self.kv_sharing_target_layer_name = None
+        self.kv_cache = torch.tensor([])
+        set_default_quant_scales(self, register_buffer=True)
+
+        self.attn_backend = Qwen4ExpQSAFlashAttentionBackend
+        self.impl = Qwen4ExpQSAFlashAttentionImpl(
+            self.num_heads,
+            self.head_dim,
+            self.scaling,
+            self.num_kv_heads,
+            None,
+            None,
+            self.kv_cache_dtype,
+            None,
+            AttentionType.DECODER,
+            None,
+        )
+        self.indexer = QSAIndexer(
+            vllm_config=vllm_config,
+            config=config,
+            layer_id=layer_id,
+            rotary_emb=self.rotary_emb,
+            quant_config=quant_config,
+            prefix=f"{prefix}.indexer",
+        )
+        max_tokens = vllm_config.scheduler_config.max_num_batched_tokens
+        self.register_buffer(
+            "topk_indices_buffer",
+            torch.empty(
+                max_tokens,
+                self.indexer.output_width,
+                dtype=torch.int32,
+            ),
+            persistent=False,
+        )
+
+        static_context = vllm_config.compilation_config.static_forward_context
+        if self.layer_name in static_context:
+            raise ValueError(f"Duplicate layer name: {self.layer_name}")
+        static_context[self.layer_name] = self
+
+    def get_attn_backend(self) -> type[AttentionBackend]:
+        return self.attn_backend
+
+    def get_kv_cache_spec(self, vllm_config: VllmConfig) -> KVCacheSpec:
+        return FullAttentionSpec(
+            block_size=vllm_config.cache_config.block_size,
+            num_kv_heads=self.num_kv_heads,
+            head_size=self.head_dim,
+            head_size_v=self.head_dim,
+            dtype=self.kv_cache_torch_dtype,
+            kv_quant_mode=get_kv_quant_mode(self.kv_cache_dtype),
+        )
+
+    def _run_qsa(
+        self,
+        hidden_states: torch.Tensor,
+        positions: torch.Tensor,
+        query: torch.Tensor,
+        key: torch.Tensor,
+        value: torch.Tensor,
+        output: torch.Tensor,
+    ) -> None:
+        metadata = get_forward_context().attn_metadata
+        if isinstance(metadata, list):
+            metadata = metadata[0]
+        if not isinstance(metadata, dict):
+            output.zero_()
+            return
+        main_metadata = cast(FlashAttentionMetadata, metadata[self.layer_name])
+        if self.kv_cache.numel() == 0:
+            raise RuntimeError("QSA main K/V cache is not bound")
+
+        num_tokens = main_metadata.num_actual_tokens
+        side_metadata = cast(
+            QSAForwardMetadata,
+            metadata[self.indexer.raw_key_cache.prefix],
+        )
+        if side_metadata.num_actual_tokens != num_tokens:
+            raise RuntimeError("QSA main and side metadata token counts disagree")
+        selected = self.indexer(
+            hidden_states,
+            positions,
+            self.topk_indices_buffer[:num_tokens],
+        )
+        if selected.shape != (
+            num_tokens,
+            self.indexer.output_width,
+        ):
+            raise RuntimeError("QSA indexer returned an invalid selection shape")
+        impl = cast(Qwen4ExpQSAFlashAttentionImpl, self.impl)
+        impl.do_kv_cache_update(
+            self,
+            key,
+            value,
+            self.kv_cache,
+            main_metadata.slot_mapping,
+        )
+        impl.forward_qsa(
+            self,
+            query,
+            key,
+            value,
+            self.kv_cache,
+            main_metadata,
+            output,
+            token_to_req=side_metadata.token_to_req,
+        )
+
+    def forward(
+        self,
+        positions: torch.Tensor,
+        hidden_states: torch.Tensor,
+    ) -> torch.Tensor:
+        qkv, _ = self.qkv_proj(hidden_states)
+        q, k, v, gate = self._project_qkv_gate(qkv, positions)
+        num_tokens = hidden_states.shape[0]
+        query = q.view(num_tokens, self.num_heads, self.head_dim)
+        key = k.view(num_tokens, self.num_kv_heads, self.head_dim)
+        value = v.view(num_tokens, self.num_kv_heads, self.head_dim)
+        attn_output = torch.empty_like(query)
+        encoded_layer_name = _encode_layer_name(self.layer_name)
+        if current_platform.opaque_attention_op():
+            torch.ops.vllm.qwen4_exp_qsa_with_output(
+                hidden_states,
+                positions,
+                query,
+                key,
+                value,
+                attn_output,
+                encoded_layer_name,
+            )
+        else:
+            qwen4_exp_qsa_with_output(
+                hidden_states,
+                positions,
+                query,
+                key,
+                value,
+                attn_output,
+                encoded_layer_name,
+            )
+        flat_output = attn_output.view(num_tokens, -1)
+        if gate is not None:
+            flat_output = flat_output * torch.sigmoid(gate)
+        output, _ = self.o_proj(flat_output)
+        return output
+
+
+def qwen4_exp_qsa_with_output(
+    hidden_states: torch.Tensor,
+    positions: torch.Tensor,
+    query: torch.Tensor,
+    key: torch.Tensor,
+    value: torch.Tensor,
+    output: torch.Tensor,
+    layer_name: LayerNameType,
+) -> None:
+    """Run the complete QSA state/update/attend transaction."""
+
+    layer_name = _resolve_layer_name(layer_name)
+    layer = get_forward_context().no_compile_layers[layer_name]
+    if not isinstance(layer, Qwen4ExpQSAAttention):
+        raise TypeError(f"{layer_name} is not a Qwen4Exp QSA owner")
+    layer._run_qsa(
+        hidden_states,
+        positions,
+        query,
+        key,
+        value,
+        output,
+    )
+
+
+def qwen4_exp_qsa_with_output_fake(
+    hidden_states: torch.Tensor,
+    positions: torch.Tensor,
+    query: torch.Tensor,
+    key: torch.Tensor,
+    value: torch.Tensor,
+    output: torch.Tensor,
+    layer_name: LayerNameType,
+) -> None:
+    del hidden_states, positions, query, key, value, output, layer_name
+
+
+direct_register_custom_op(
+    op_name="qwen4_exp_qsa_with_output",
+    op_func=qwen4_exp_qsa_with_output,
+    mutates_args=["output"],
+    fake_impl=qwen4_exp_qsa_with_output_fake,
+)
+
+
+__all__ = [
+    "QSAIndexer",
+    "Qwen4ExpQSAAttention",
+    "Qwen4ExpQSAFlashAttentionBackend",
+    "Qwen4ExpQSAFlashAttentionImpl",
+    "qwen4_exp_qsa_with_output",
+]

--- a/vllm_ascend/models/qwen4_exp/ops.py
+++ b/vllm_ascend/models/qwen4_exp/ops.py
@@ -1,0 +1,314 @@
+# Copyright (c) 2026 Huawei Technologies Co., Ltd. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Portable Ascend fallbacks for Qwen3.8-Flash-Next platform operators."""
+
+import math
+
+import torch
+import torch.nn.functional as F
+
+
+def grouped_gemma_rmsnorm(
+    hidden_states: torch.Tensor,
+    weight: torch.Tensor,
+    eps: float,
+    num_groups: int,
+) -> torch.Tensor:
+    """Apply Gemma RMSNorm independently to each HyperConnection stream."""
+    if hidden_states.shape[-1] % num_groups:
+        raise ValueError("hidden size must be divisible by the HC stream count")
+    group_dim = hidden_states.shape[-1] // num_groups
+    grouped = hidden_states.unflatten(-1, (num_groups, group_dim)).float()
+    variance = grouped.square().mean(dim=-1, keepdim=True)
+    normalized = grouped * torch.rsqrt(variance + eps)
+    if weight.numel() == group_dim:
+        affine = weight.reshape(1, 1, group_dim)
+    elif weight.numel() == hidden_states.shape[-1]:
+        affine = weight.reshape(1, num_groups, group_dim)
+    else:
+        raise ValueError("HC norm weight has an incompatible shape")
+    return (normalized * (1.0 + affine.float())).flatten(-2).to(hidden_states.dtype)
+
+
+def hc_silu(hidden_states: torch.Tensor, hc_count: int) -> torch.Tensor:
+    return F.silu(hidden_states.float() / hc_count).to(hidden_states.dtype)
+
+
+def hc_gate_mix(
+    hidden_states: torch.Tensor,
+    gate: torch.Tensor,
+    hc_count: int,
+) -> torch.Tensor:
+    if hidden_states.shape != gate.shape:
+        raise ValueError("HC input and gate shapes must match")
+    group_dim = hidden_states.shape[-1] // hc_count
+    hidden_states = hidden_states.unflatten(-1, (hc_count, group_dim))
+    gate = torch.sigmoid(gate.float()).unflatten(-1, (hc_count, group_dim))
+    return (hidden_states.float() * gate).mean(dim=-2).to(hidden_states.dtype)
+
+
+def hc_combine(
+    residual: torch.Tensor,
+    block_output: torch.Tensor,
+    injection_logits: torch.Tensor,
+    hc_count: int,
+) -> torch.Tensor:
+    group_dim = residual.shape[-1] // hc_count
+    residual_grouped = residual.unflatten(-1, (hc_count, group_dim))
+    injection = 2.0 * torch.sigmoid(injection_logits.float() / hc_count)
+    output = residual_grouped.float() + block_output.float().unsqueeze(-2) * injection.unsqueeze(-1)
+    return output.flatten(-2).to(residual.dtype)
+
+
+def hc_combine_norm(
+    residual: torch.Tensor,
+    block_output: torch.Tensor,
+    injection_logits: torch.Tensor,
+    norm_weight: torch.Tensor,
+    eps: float,
+    hc_count: int,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    output = hc_combine(residual, block_output, injection_logits, hc_count)
+    normalized = grouped_gemma_rmsnorm(output, norm_weight, eps, hc_count)
+    return output, normalized
+
+
+def qsa_store_cache_rows(
+    cache: torch.Tensor,
+    slot_mapping: torch.Tensor,
+    rows: torch.Tensor,
+) -> None:
+    """Store QSA rows using device-native indexed writes."""
+    if cache.ndim != 4 or cache.shape[2] <= 0:
+        raise ValueError("QSA cache must be [blocks, block_size, heads, width]")
+    if rows.ndim == 2:
+        rows = rows.unsqueeze(1)
+    if rows.ndim != 3 or rows.shape[1:] != cache.shape[2:]:
+        raise ValueError("QSA cache rows have an incompatible shape")
+    slots = slot_mapping.reshape(-1).long()
+    cache_capacity = cache.shape[0] * cache.shape[1]
+    valid = (slots >= 0) & (slots < cache_capacity)
+    safe_slots = slots.masked_select(valid)
+    safe_rows = rows[: slots.shape[0]][valid]
+    physical_blocks = torch.div(safe_slots, cache.shape[1], rounding_mode="floor")
+    block_offsets = safe_slots.remainder(cache.shape[1])
+    # Do not flatten the cache here. With an HND cache, ``cache`` is a
+    # non-contiguous logical [block, token, head, dim] view and reshape may
+    # silently materialize a copy. Two-dimensional indexed assignment keeps
+    # writes attached to the original KV-cache allocation for both layouts.
+    cache[physical_blocks, block_offsets] = safe_rows.to(cache.dtype)
+
+
+def qsa_compress_groups_with_ratio(
+    raw_keys: torch.Tensor,
+    raw_positions: torch.Tensor,
+    compressor_state_cache: torch.Tensor,
+    compressor_state_block_table: torch.Tensor,
+    token_to_req: torch.Tensor,
+    query_start_loc: torch.Tensor,
+    logical_positions: torch.Tensor,
+    compressed_slots: torch.Tensor,
+    compress_ratio: int,
+    rope_cache: torch.Tensor | None = None,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Pool completed QSA groups from current rows and the per-request ring."""
+    if compress_ratio <= 0:
+        raise ValueError("QSA compression ratio must be positive")
+    rows = token_to_req.numel()
+    if raw_keys.shape[:2] != (rows, 1):
+        raise ValueError("QSA raw keys must be [rows, 1, head_size]")
+    if rows == 0:
+        return raw_keys.new_empty(raw_keys.shape), raw_positions.new_empty((0, 3))
+    row_ids = torch.arange(rows, device=raw_keys.device)
+    requests = token_to_req.long()
+    request_count = query_start_loc.numel() - 1
+    safe_requests = requests.clamp(0, max(request_count - 1, 0))
+    query_starts = query_start_loc.index_select(0, safe_requests).long()
+    chunk_starts = logical_positions.long() - (row_ids - query_starts)
+
+    group_offsets = torch.arange(compress_ratio, device=raw_keys.device)
+    member_positions = logical_positions.long().unsqueeze(1) - (compress_ratio - 1 - group_offsets)
+    use_raw = member_positions >= chunk_starts.unsqueeze(1)
+    raw_row_ids = query_starts.unsqueeze(1) + member_positions - chunk_starts.unsqueeze(1)
+    raw_row_ids = raw_row_ids.clamp(0, max(rows - 1, 0))
+    current_members = raw_keys[:, 0].index_select(0, raw_row_ids.reshape(-1)).reshape(rows, compress_ratio, -1)
+
+    state_blocks = compressor_state_block_table[safe_requests, 0].long()
+    safe_state_blocks = state_blocks.clamp(0, max(compressor_state_cache.shape[0] - 1, 0))
+    state_offsets = member_positions.remainder(compressor_state_cache.shape[1])
+    state_members = compressor_state_cache[safe_state_blocks.unsqueeze(1), state_offsets, 0]
+    members = torch.where(use_raw.unsqueeze(-1), current_members, state_members)
+    pooled = members.float().mean(dim=1, keepdim=True).to(raw_keys.dtype)
+
+    valid = (
+        (requests >= 0)
+        & (requests < request_count)
+        & (state_blocks >= 0)
+        & (logical_positions >= compress_ratio - 1)
+        & (compressed_slots >= 0)
+    )
+    pooled = torch.where(valid.reshape(-1, 1, 1), pooled, torch.zeros_like(pooled))
+
+    first_positions = member_positions[:, 0]
+    if rope_cache is None:
+        first_rope_positions = first_positions.unsqueeze(1).expand(-1, 3)
+    else:
+        raw_first_rows = raw_row_ids[:, 0]
+        raw_first_positions = raw_positions[:, 0].index_select(0, raw_first_rows)
+        state_first_positions = rope_cache[safe_state_blocks, first_positions.remainder(rope_cache.shape[1]), 0]
+        first_rope_positions = torch.where(use_raw[:, :1], raw_first_positions, state_first_positions)
+    first_rope_positions = torch.where(valid.unsqueeze(1), first_rope_positions, torch.zeros_like(first_rope_positions))
+    return pooled, first_rope_positions
+
+
+def _paged_cache_rows(
+    cache: torch.Tensor,
+    block_table: torch.Tensor,
+    request_ids: torch.Tensor,
+    logical_positions: torch.Tensor,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    page_size = cache.shape[1]
+    logical_pages = torch.div(logical_positions.clamp_min(0), page_size, rounding_mode="floor")
+    valid = (
+        (request_ids >= 0)
+        & (request_ids < block_table.shape[0])
+        & (logical_positions >= 0)
+        & (logical_pages < block_table.shape[1])
+    )
+    safe_requests = request_ids.clamp(0, max(block_table.shape[0] - 1, 0))
+    safe_pages = logical_pages.clamp(0, max(block_table.shape[1] - 1, 0))
+    physical_pages = block_table[safe_requests, safe_pages].long()
+    valid &= (physical_pages >= 0) & (physical_pages < cache.shape[0])
+    safe_physical_pages = physical_pages.clamp(0, max(cache.shape[0] - 1, 0))
+    page_offsets = logical_positions.remainder(page_size)
+    rows = cache[safe_physical_pages, page_offsets]
+    return rows, valid
+
+
+def qsa_select_paged_tokens(
+    query: torch.Tensor,
+    compressed_key_cache: torch.Tensor,
+    block_table: torch.Tensor,
+    token_to_req: torch.Tensor,
+    query_positions: torch.Tensor,
+    sequence_lengths: torch.Tensor,
+    token_topk: int,
+    compress_ratio: int,
+    out: torch.Tensor | None = None,
+) -> torch.Tensor:
+    """Select QSA token indices with portable Torch operators."""
+    if token_topk % compress_ratio:
+        raise ValueError("QSA token top-k must be divisible by compression ratio")
+    row_count = query.shape[0]
+    output_width = token_topk + compress_ratio - 1
+    if out is None:
+        out = torch.empty((row_count, output_width), dtype=torch.int32, device=query.device)
+    compressed_capacity = block_table.shape[1] * compressed_key_cache.shape[1]
+    block_topk = token_topk // compress_ratio
+    if block_topk > compressed_capacity:
+        raise ValueError("QSA top-k exceeds the compressed cache capacity")
+
+    columns = torch.arange(compressed_capacity, device=query.device)
+    # Advanced paged indexing materializes one cache row. Bound the complete
+    # key-and-score working set rather than only the score tensor; at the
+    # 262k context limit a single compressed key row is already tens of MiB.
+    bytes_per_row = compressed_capacity * (
+        compressed_key_cache.shape[2] * compressed_key_cache.shape[3] * compressed_key_cache.element_size()
+        + query.shape[1] * 4
+    )
+    rows_per_chunk = max(1, (128 * 1024 * 1024) // max(bytes_per_row, 1))
+    for row_start in range(0, row_count, rows_per_chunk):
+        row_end = min(row_count, row_start + rows_per_chunk)
+        row_slice = slice(row_start, row_end)
+        request_ids = token_to_req[row_slice].long()
+        logical = columns.unsqueeze(0).expand(row_end - row_start, -1)
+        requests = request_ids.unsqueeze(1).expand_as(logical)
+        keys, valid_cache = _paged_cache_rows(compressed_key_cache, block_table, requests, logical)
+        keys = keys[..., 0, :]
+        scores = torch.einsum("rhd,rcd->rhc", query[row_slice].float(), keys.float())
+        scores = scores.clamp_min_(0).sum(dim=1) / math.sqrt(query.shape[-1])
+        safe_requests = request_ids.clamp(0, max(sequence_lengths.shape[0] - 1, 0))
+        visible = torch.minimum(
+            (query_positions[row_slice].long() + 1) // compress_ratio,
+            sequence_lengths.index_select(0, safe_requests).long() // compress_ratio,
+        )
+        visible_mask = columns.unsqueeze(0) < visible.unsqueeze(1)
+        scores.masked_fill_(~(visible_mask & valid_cache), -torch.inf)
+        selected_blocks = torch.topk(scores, block_topk, dim=-1).indices
+
+        output_columns = torch.arange(output_width, device=query.device)
+        block_rank = torch.div(output_columns, compress_ratio, rounding_mode="floor")
+        offsets = output_columns.remainder(compress_ratio)
+        safe_rank = block_rank.clamp_max(block_topk - 1)
+        expanded = selected_blocks[:, safe_rank] * compress_ratio + offsets
+        complete_blocks = visible.clamp_max(block_topk)
+        expanded_count = complete_blocks * compress_ratio
+        tail_start = ((query_positions[row_slice].long() + 1) // compress_ratio) * compress_ratio
+        tail_offset = output_columns.unsqueeze(0) - expanded_count.unsqueeze(1)
+        tail_count = query_positions[row_slice].long() + 1 - tail_start
+        is_expanded = output_columns.unsqueeze(0) < expanded_count.unsqueeze(1)
+        is_tail = (tail_offset >= 0) & (tail_offset < tail_count.unsqueeze(1)) & (tail_offset < compress_ratio - 1)
+        tokens = torch.where(is_expanded, expanded, tail_start.unsqueeze(1) + tail_offset)
+        request_lengths = sequence_lengths.index_select(0, safe_requests).long()
+        valid_tokens = (is_expanded | is_tail) & (tokens < request_lengths.unsqueeze(1))
+        out[row_slice].copy_(torch.where(valid_tokens, tokens, -1).to(torch.int32))
+    return out
+
+
+def qsa_sparse_paged_attention(
+    query: torch.Tensor,
+    key_cache: torch.Tensor,
+    value_cache: torch.Tensor,
+    logical_indices: torch.Tensor,
+    block_table: torch.Tensor,
+    token_to_req: torch.Tensor,
+    out: torch.Tensor | None = None,
+) -> torch.Tensor:
+    """Run sparse paged GQA without CUDA-only kernels."""
+    if out is None:
+        out = torch.empty_like(query)
+    row_count, num_query_heads, head_dim = query.shape
+    num_kv_heads = key_cache.shape[2]
+    if num_query_heads % num_kv_heads:
+        raise ValueError("QSA query heads must be divisible by KV heads")
+    group_size = num_query_heads // num_kv_heads
+    rows_per_chunk = 8
+    for row_start in range(0, row_count, rows_per_chunk):
+        row_end = min(row_count, row_start + rows_per_chunk)
+        row_slice = slice(row_start, row_end)
+        logical = logical_indices[row_slice].long()
+        request_ids = token_to_req[row_slice].long().unsqueeze(1).expand_as(logical)
+        keys, valid = _paged_cache_rows(key_cache, block_table, request_ids, logical)
+        values, _ = _paged_cache_rows(value_cache, block_table, request_ids, logical)
+        q = query[row_slice].reshape(row_end - row_start, num_kv_heads, group_size, head_dim)
+        logits = torch.einsum("rhgd,rkhd->rhgk", q.float(), keys.float())
+        logits.mul_(head_dim**-0.5).masked_fill_(~valid[:, None, None, :], -torch.inf)
+        probabilities = torch.softmax(logits, dim=-1)
+        probabilities = torch.nan_to_num(probabilities)
+        result = torch.einsum("rhgk,rkhd->rhgd", probabilities, values.float())
+        out[row_slice].copy_(result.reshape(row_end - row_start, num_query_heads, head_dim).to(out.dtype))
+    return out
+
+
+def reshape_and_cache_qsa(
+    key: torch.Tensor,
+    value: torch.Tensor,
+    kv_cache: torch.Tensor,
+    slot_mapping: torch.Tensor,
+    head_dim: int,
+) -> None:
+    key_cache, value_cache = kv_cache.transpose(1, 2).split(head_dim, dim=-1)
+    qsa_store_cache_rows(key_cache, slot_mapping, key)
+    qsa_store_cache_rows(value_cache, slot_mapping, value)

--- a/vllm_ascend/models/qwen4_exp/ops.py
+++ b/vllm_ascend/models/qwen4_exp/ops.py
@@ -91,24 +91,43 @@ def qsa_store_cache_rows(
     rows: torch.Tensor,
 ) -> None:
     """Store QSA rows using device-native indexed writes."""
-    if cache.ndim != 4 or cache.shape[2] <= 0:
+    if (
+        cache.ndim != 4
+        or cache.shape[0] <= 0
+        or cache.shape[1] <= 0
+        or cache.shape[2] <= 0
+    ):
         raise ValueError("QSA cache must be [blocks, block_size, heads, width]")
     if rows.ndim == 2:
         rows = rows.unsqueeze(1)
     if rows.ndim != 3 or rows.shape[1:] != cache.shape[2:]:
         raise ValueError("QSA cache rows have an incompatible shape")
     slots = slot_mapping.reshape(-1).long()
+    # Target prefill can have more padded slots than rows, while a draft pass
+    # can have more rows than active slots. Only the aligned prefix represents
+    # cache updates; the remainder is capacity padding.
+    num_updates = min(slots.shape[0], rows.shape[0])
+    slots = slots[:num_updates]
     cache_capacity = cache.shape[0] * cache.shape[1]
     valid = (slots >= 0) & (slots < cache_capacity)
-    safe_slots = slots.masked_select(valid)
-    safe_rows = rows[: slots.shape[0]][valid]
+    # Keep the update width static for NPU graph capture. ``masked_select``
+    # creates a data-dependent output shape. Invalid rows map to slot 0 but
+    # contribute a zero delta, so they cannot overwrite a real row there.
+    safe_slots = slots.clamp(0, cache_capacity - 1)
     physical_blocks = torch.div(safe_slots, cache.shape[1], rounding_mode="floor")
     block_offsets = safe_slots.remainder(cache.shape[1])
     # Do not flatten the cache here. With an HND cache, ``cache`` is a
     # non-contiguous logical [block, token, head, dim] view and reshape may
     # silently materialize a copy. Two-dimensional indexed assignment keeps
     # writes attached to the original KV-cache allocation for both layouts.
-    cache[physical_blocks, block_offsets] = safe_rows.to(cache.dtype)
+    current_rows = cache[physical_blocks, block_offsets]
+    update_rows = rows[:num_updates].to(cache.dtype)
+    deltas = (update_rows - current_rows) * valid.view(-1, 1, 1).to(cache.dtype)
+    cache.index_put_(
+        (physical_blocks, block_offsets),
+        deltas,
+        accumulate=True,
+    )
 
 
 def qsa_compress_groups_with_ratio(

--- a/vllm_ascend/models/qwen4_exp/ple_offload_layer.py
+++ b/vllm_ascend/models/qwen4_exp/ple_offload_layer.py
@@ -1,0 +1,53 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM-Ascend project
+"""Ascend-local PLE layer contract.
+
+The CUDA implementation added by vLLM PR #53899 uses CUDA IPC and driver
+semaphores.  Qwen4Exp still needs the common layer contract when CPU offload
+is disabled, so the plugin owns this device-resident implementation instead
+of modifying vLLM 0.26.0.
+"""
+
+from abc import ABC, abstractmethod
+
+import torch
+from torch import nn
+
+PLE_CPU_OFFLOAD = False
+
+
+def is_offload_process() -> bool:
+    return False
+
+
+class PleOffloadLayer(nn.Module, ABC):
+    """Base class for device-resident PLE layers on Ascend."""
+
+    @classmethod
+    def get_target_device(cls) -> torch.device:
+        return torch.device("npu", torch.npu.current_device())
+
+    @abstractmethod
+    def forward_impl(
+        self,
+        hidden_states: torch.Tensor,
+        input_ids: torch.Tensor,
+        *args: object,
+        **kwargs: object,
+    ) -> torch.Tensor:
+        raise NotImplementedError
+
+    def get_offload_output_dtype(self, default_dtype: torch.dtype) -> torch.dtype:
+        return default_dtype
+
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+        input_ids: torch.Tensor,
+        *args: object,
+        **kwargs: object,
+    ) -> torch.Tensor:
+        return self.forward_impl(hidden_states, input_ids, *args, **kwargs)
+
+    def release_offloaded_output(self, stream: object | None = None) -> None:
+        del stream

--- a/vllm_ascend/models/qwen4_exp/qsa.py
+++ b/vllm_ascend/models/qwen4_exp/qsa.py
@@ -38,15 +38,144 @@ def apply_qsa_rope(
     positions: torch.Tensor,
     tensor: torch.Tensor,
 ) -> torch.Tensor:
-    """Use the Ascend-patched vLLM rotary module for 1D RoPE and MRoPE."""
-    original_shape = tensor.shape
-    flattened = tensor.flatten(1)
-    rotated, _ = rotary_emb(positions, flattened, flattened)
-    return rotated.reshape(original_shape)
+    """Apply RoPE using the QSA head width rather than the main Q/K width."""
+    rotary_dim = int(rotary_emb.rotary_dim)
+    cache = rotary_emb._match_cos_sin_cache_dtype(tensor)  # noqa: SLF001
+    cos_sin = cache[positions]
+    cos, sin = cos_sin.chunk(2, dim=-1)
+
+    if positions.ndim == 2:
+        sections = list(rotary_emb.mrope_section)
+        if getattr(rotary_emb, "mrope_interleaved", False):
+            merged_cos = cos[0].clone()
+            merged_sin = sin[0].clone()
+            merged_cos[..., 1 : sections[1] * 3 : 3] = cos[
+                1, ..., 1 : sections[1] * 3 : 3
+            ]
+            merged_cos[..., 2 : sections[2] * 3 : 3] = cos[
+                2, ..., 2 : sections[2] * 3 : 3
+            ]
+            merged_sin[..., 1 : sections[1] * 3 : 3] = sin[
+                1, ..., 1 : sections[1] * 3 : 3
+            ]
+            merged_sin[..., 2 : sections[2] * 3 : 3] = sin[
+                2, ..., 2 : sections[2] * 3 : 3
+            ]
+            cos, sin = merged_cos, merged_sin
+        else:
+            cos = torch.cat(
+                [part[i] for i, part in enumerate(cos.split(sections, dim=-1))],
+                dim=-1,
+            )
+            sin = torch.cat(
+                [part[i] for i, part in enumerate(sin.split(sections, dim=-1))],
+                dim=-1,
+            )
+
+    cos = cos.unsqueeze(1)
+    sin = sin.unsqueeze(1)
+    rotary = tensor[..., :rotary_dim]
+    if getattr(rotary_emb, "is_neox_style", False):
+        first, second = rotary.chunk(2, dim=-1)
+        rotated = torch.cat(
+            (first * cos - second * sin, second * cos + first * sin),
+            dim=-1,
+        )
+    else:
+        even = rotary[..., ::2]
+        odd = rotary[..., 1::2]
+        rotated = torch.stack(
+            (even * cos - odd * sin, odd * cos + even * sin),
+            dim=-1,
+        ).flatten(-2)
+    return torch.cat((rotated, tensor[..., rotary_dim:]), dim=-1)
 
 
 class AscendQSAIndexer(upstream_indexer.QSAIndexer):
     """QSA indexer using NPU-compatible cache, RoPE and top-k operators."""
+
+    def _metadata(
+        self,
+    ) -> tuple[QSAForwardMetadata, QSAForwardMetadata] | None:
+        """Read paired QSA metadata without a graph-breaking host sync."""
+        metadata = get_forward_context().attn_metadata
+        if isinstance(metadata, list):
+            metadata = metadata[0]
+        if not isinstance(metadata, dict):
+            return None
+        raw = cast(QSAForwardMetadata, metadata[self.raw_key_cache.prefix])
+        compressed = cast(
+            QSAForwardMetadata,
+            metadata[self.compressed_key_cache.prefix],
+        )
+        if raw.num_actual_tokens != compressed.num_actual_tokens:
+            raise RuntimeError("QSA side-cache metadata token counts disagree")
+        # The common Ascend builder creates the paired logical positions
+        # together. Avoid torch.equal here because checking an NPU tensor on
+        # the host would synchronize the stream during FULL graph capture.
+        return raw, compressed
+
+    def normalize_compressed_keys(
+        self,
+        pooled: torch.Tensor,
+        first_positions: torch.Tensor,
+    ) -> torch.Tensor:
+        """Apply the reference K normalization and RoPE to compressed keys."""
+        compressed_keys = upstream_indexer._gemma_rmsnorm(
+            pooled.reshape(-1, self.index_head_dim),
+            self.k_layernorm.weight,
+            self.k_layernorm.variance_epsilon,
+        ).reshape(-1, 1, self.index_head_dim)
+        if getattr(self.rotary_emb, "mrope_section", None):
+            first_positions = first_positions.transpose(0, 1)
+        else:
+            first_positions = first_positions[:, 0]
+        return apply_qsa_rope(
+            self.rotary_emb,
+            first_positions,
+            compressed_keys,
+        )
+
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+        positions: torch.Tensor,
+        out: torch.Tensor | None = None,
+    ) -> torch.Tensor:
+        """Run the portable Ascend path instead of upstream Triton kernels."""
+        metadata = self._metadata()
+        if metadata is None:
+            # Preserve step-0 indices when later MTP steps reuse the buffer.
+            if self.skip_topk and out is not None:
+                return out
+            result = torch.full(
+                (hidden_states.shape[0], self.output_width),
+                -1,
+                dtype=torch.int32,
+                device=hidden_states.device,
+            )
+            if out is not None:
+                out.copy_(result)
+                return out
+            return result
+
+        raw_metadata, compressed_metadata = metadata
+        num_tokens = raw_metadata.num_actual_tokens
+        hidden_states = hidden_states[:num_tokens]
+        positions = positions[..., :num_tokens]
+        query, token_k = self.project_qk(hidden_states, positions)
+        self._update_and_compress(
+            token_k,
+            positions,
+            raw_metadata,
+            compressed_metadata,
+        )
+
+        if self.skip_topk:
+            if out is None:
+                raise RuntimeError("QSA top-k reuse requires an output buffer")
+            return out
+        return self._select(query, compressed_metadata, out)
 
     def project_qk(
         self,

--- a/vllm_ascend/models/qwen4_exp/qsa.py
+++ b/vllm_ascend/models/qwen4_exp/qsa.py
@@ -1,0 +1,269 @@
+# Copyright (c) 2026 Huawei Technologies Co., Ltd. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Ascend QSA owner for Qwen3.8-Flash-Next."""
+
+from typing import cast
+
+import torch
+from vllm.forward_context import get_forward_context
+from vllm.utils.torch_utils import canonicalize_singleton_dim_strides
+
+from .common import qsa_cache
+from .common.qsa_cache import QSAForwardMetadata
+from .nvidia import indexer_qsa as upstream_indexer
+from .nvidia import qsa as upstream_qsa
+from .ops import (
+    qsa_compress_groups_with_ratio,
+    qsa_select_paged_tokens,
+    qsa_sparse_paged_attention,
+    qsa_store_cache_rows,
+    reshape_and_cache_qsa,
+)
+
+
+def apply_qsa_rope(
+    rotary_emb: torch.nn.Module,
+    positions: torch.Tensor,
+    tensor: torch.Tensor,
+) -> torch.Tensor:
+    """Use the Ascend-patched vLLM rotary module for 1D RoPE and MRoPE."""
+    original_shape = tensor.shape
+    flattened = tensor.flatten(1)
+    rotated, _ = rotary_emb(positions, flattened, flattened)
+    return rotated.reshape(original_shape)
+
+
+class AscendQSAIndexer(upstream_indexer.QSAIndexer):
+    """QSA indexer using NPU-compatible cache, RoPE and top-k operators."""
+
+    def project_qk(
+        self,
+        hidden_states: torch.Tensor,
+        positions: torch.Tensor,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        qk, _ = self.index_qk_proj(hidden_states)
+        q_raw, token_k = qk.split(
+            (
+                self.index_n_heads * self.index_head_dim,
+                self.index_kv_heads * self.index_head_dim,
+            ),
+            dim=-1,
+        )
+        q = q_raw.reshape(-1, self.index_n_heads, self.index_head_dim)
+        q = self.q_layernorm(q.reshape(-1, self.index_head_dim)).reshape_as(q)
+        q = apply_qsa_rope(self.rotary_emb, positions, q)
+        return q, token_k.reshape(-1, 1, self.index_head_dim)
+
+    def _update_and_compress(
+        self,
+        token_k: torch.Tensor,
+        positions: torch.Tensor,
+        raw_metadata: QSAForwardMetadata,
+        compressed_metadata: QSAForwardMetadata,
+    ) -> None:
+        num_tokens = raw_metadata.num_actual_tokens
+        raw_key_cache = self.raw_key_cache.key_cache
+        rope_position_cache = self.raw_key_cache.rope_position_cache
+        if rope_position_cache is None:
+            position_rows = raw_metadata.logical_positions.view(-1, 1, 1).expand(-1, 1, 3)
+        else:
+            position_rows = qsa_cache.canonical_qsa_rope_positions(positions)[:num_tokens].to(
+                device=raw_key_cache.device
+            )
+        pooled, first_positions = qsa_compress_groups_with_ratio(
+            token_k[:num_tokens],
+            position_rows,
+            raw_key_cache,
+            raw_metadata.block_table,
+            raw_metadata.token_to_req,
+            raw_metadata.query_start_loc,
+            raw_metadata.logical_positions,
+            compressed_metadata.slot_mapping,
+            self.compress_ratio,
+            rope_position_cache,
+        )
+        normalized = self.normalize_compressed_keys(pooled, first_positions)
+        qsa_store_cache_rows(
+            self.compressed_key_cache.kv_cache,
+            compressed_metadata.slot_mapping,
+            normalized,
+        )
+        qsa_store_cache_rows(raw_key_cache, raw_metadata.slot_mapping, token_k[:num_tokens])
+        if rope_position_cache is not None:
+            qsa_store_cache_rows(
+                rope_position_cache,
+                raw_metadata.slot_mapping,
+                position_rows,
+            )
+
+    def _select(
+        self,
+        query: torch.Tensor,
+        metadata: QSAForwardMetadata,
+        out: torch.Tensor | None,
+    ) -> torch.Tensor:
+        return qsa_select_paged_tokens(
+            query,
+            self.compressed_key_cache.kv_cache,
+            metadata.block_table,
+            metadata.token_to_req,
+            metadata.logical_positions,
+            metadata.seq_lens,
+            self.token_topk,
+            self.compress_ratio,
+            out,
+        )
+
+
+class AscendQSAImpl:
+    """Minimal QSA attention implementation independent of FlashAttention."""
+
+    supports_dcp = False
+    supports_pcp = False
+
+    def __init__(self, *args: object, **kwargs: object) -> None:
+        del kwargs
+        self.num_heads = cast(int, args[0])
+        self.head_size = cast(int, args[1])
+        self.scale = cast(float, args[2])
+        self.num_kv_heads = cast(int, args[3])
+        self.kv_cache_dtype = cast(str, args[6])
+        self.attn_type = args[8]
+        self.alibi_slopes = None
+        self.sinks = None
+        self.sliding_window = (-1, -1)
+        self.supports_quant_query_input = False
+
+    def do_kv_cache_update(
+        self,
+        layer: torch.nn.Module,
+        key: torch.Tensor,
+        value: torch.Tensor,
+        kv_cache: torch.Tensor,
+        slot_mapping: torch.Tensor,
+    ) -> None:
+        del layer
+        reshape_and_cache_qsa(key, value, kv_cache, slot_mapping, self.head_size)
+
+    def forward_qsa(
+        self,
+        layer: torch.nn.Module,
+        query: torch.Tensor,
+        key: torch.Tensor,
+        value: torch.Tensor,
+        kv_cache: torch.Tensor,
+        attn_metadata: object,
+        output: torch.Tensor,
+        token_to_req: torch.Tensor,
+        output_scale: torch.Tensor | None = None,
+        output_block_scale: torch.Tensor | None = None,
+    ) -> torch.Tensor:
+        del key, value
+        if output_scale is not None or output_block_scale is not None:
+            raise NotImplementedError("QSA output quantization is not supported on Ascend")
+        num_tokens = attn_metadata.num_actual_tokens
+        output.zero_()
+        if num_tokens == 0:
+            return output
+        logical_indices = layer.topk_indices_buffer[:num_tokens]
+        key_cache, value_cache = kv_cache.transpose(1, 2).split(self.head_size, dim=-1)
+        key_cache = canonicalize_singleton_dim_strides(key_cache)
+        value_cache = canonicalize_singleton_dim_strides(value_cache)
+        return qsa_sparse_paged_attention(
+            query[:num_tokens],
+            key_cache,
+            value_cache,
+            logical_indices,
+            attn_metadata.block_table,
+            token_to_req[:num_tokens],
+            output[:num_tokens],
+        )
+
+
+class AscendQSABackend(upstream_qsa.Qwen4ExpQSAFlashAttentionBackend):
+    @staticmethod
+    def get_name() -> str:
+        return "QWEN4_EXP_QSA_ASCEND"
+
+    @staticmethod
+    def get_impl_cls() -> type[AscendQSAImpl]:
+        return AscendQSAImpl
+
+
+# The upstream owner resolves these names from its module globals during
+# construction. Replace only the platform-specific components, leaving model
+# structure, cache specifications and weight mapping in upstream vLLM.
+upstream_indexer.apply_qsa_rope = apply_qsa_rope
+upstream_qsa.QSAIndexer = AscendQSAIndexer
+upstream_qsa.Qwen4ExpQSAFlashAttentionImpl = AscendQSAImpl
+upstream_qsa.Qwen4ExpQSAFlashAttentionBackend = AscendQSABackend
+
+# qsa_cache selects its Triton metadata builder at import time. The upstream
+# kernel uses CUDA PDL intrinsics, so Ascend must use the equivalent Torch path.
+qsa_cache.build_qsa_metadata = qsa_cache._build_qsa_metadata_torch
+
+
+class AscendQwen4ExpQSAAttention(upstream_qsa.Qwen4ExpQSAAttention):
+    """Qwen4Exp QSA owner bound to the Ascend implementation."""
+
+    def _run_qsa(
+        self,
+        hidden_states: torch.Tensor,
+        positions: torch.Tensor,
+        query: torch.Tensor,
+        key: torch.Tensor,
+        value: torch.Tensor,
+        output: torch.Tensor,
+    ) -> None:
+        metadata = get_forward_context().attn_metadata
+        if isinstance(metadata, list):
+            metadata = metadata[0]
+        if not isinstance(metadata, dict):
+            output.zero_()
+            return
+        main_metadata = metadata[self.layer_name]
+        if self.kv_cache.numel() == 0:
+            raise RuntimeError("QSA main K/V cache is not bound")
+        num_tokens = main_metadata.num_actual_tokens
+        side_metadata = metadata[self.indexer.raw_key_cache.prefix]
+        if side_metadata.num_actual_tokens != num_tokens:
+            raise RuntimeError("QSA main and side metadata token counts disagree")
+        selected = self.indexer(
+            hidden_states,
+            positions,
+            self.topk_indices_buffer[:num_tokens],
+        )
+        if selected.shape != (num_tokens, self.indexer.output_width):
+            raise RuntimeError("QSA indexer returned an invalid selection shape")
+        self.impl.do_kv_cache_update(
+            self,
+            key,
+            value,
+            self.kv_cache,
+            main_metadata.slot_mapping,
+        )
+        self.impl.forward_qsa(
+            self,
+            query,
+            key,
+            value,
+            self.kv_cache,
+            main_metadata,
+            output,
+            token_to_req=side_metadata.token_to_req,
+        )
+
+
+__all__ = ["AscendQSAIndexer", "AscendQwen4ExpQSAAttention"]

--- a/vllm_ascend/models/qwen4_exp/short_conv_attn.py
+++ b/vllm_ascend/models/qwen4_exp/short_conv_attn.py
@@ -1,0 +1,558 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+from dataclasses import dataclass, replace
+from typing import Any
+
+import torch
+from vllm.config import VllmConfig
+from vllm.utils.torch_utils import async_tensor_h2d
+from vllm.v1.attention.backend import (
+    AttentionBackend,
+    AttentionCGSupport,
+    CommonAttentionMetadata,
+)
+from vllm.v1.attention.backends.mamba_attn import (
+    BaseMambaAttentionMetadata,
+    BaseMambaAttentionMetadataBuilder,
+)
+from vllm.v1.attention.backends.utils import (
+    NULL_BLOCK_ID,
+    compute_causal_conv1d_metadata,
+    mamba_get_block_table_tensor,
+)
+from vllm.v1.kv_cache_interface import MambaSpec
+
+
+class ShortConvAttentionBackend(AttentionBackend):
+    @staticmethod
+    def get_name() -> str:
+        return "SHORT_CONV_ATTN"
+
+    @staticmethod
+    def get_builder_cls() -> type["ShortConvAttentionMetadataBuilder"]:
+        return ShortConvAttentionMetadataBuilder
+
+    @classmethod
+    def is_ssm(cls) -> bool:
+        return True
+
+
+@dataclass
+class ShortConvAttentionMetadata(BaseMambaAttentionMetadata):
+    pass
+
+
+class ShortConvAttentionMetadataBuilder(
+    BaseMambaAttentionMetadataBuilder[ShortConvAttentionMetadata]
+):
+    metadata_cls = ShortConvAttentionMetadata
+
+
+@dataclass
+class PleShortConvAttentionMetadata(ShortConvAttentionMetadata):
+    # Number of speculative-decode (multi-query / MTP) requests and the total
+    # number of tokens they contribute. These are 0 when spec-decode is off.
+    num_spec_decodes: int = 0
+    num_spec_decode_tokens: int = 0
+    num_actual_tokens: int = 0
+
+    # Max query length among spec-decode requests (== num_speculative_tokens + 1).
+    # Used as ``max_query_len`` for the varlen spec causal_conv1d_update.
+    spec_query_len: int = 1
+
+    # Max query length among the non-spec *prefill* requests, precomputed
+    # CPU-side in the builder. The dilated PLE short-conv uses it to size its
+    # packing buffer without a device->host sync (``lengths.max().item()``).
+    # 0 when there are no prefill requests.
+    max_prefill_query_len: int = 0
+    query_start_loc: torch.Tensor | None = None
+
+    # ``state_indices_tensor`` keeps the historical (non-spec) layout used by
+    # all existing short-conv consumers: the conv-state slot for each regular
+    # decode followed by each prefill request. When spec-decode is active this
+    # only covers the non-spec requests.
+    state_indices_tensor: torch.Tensor | None = None
+    has_initial_states_d: torch.Tensor | None = None
+
+    # ``non_spec_query_start_loc`` is the varlen cumulative token offset over
+    # the non-spec requests only (decodes then prefills). It equals
+    # ``query_start_loc`` when there are no spec-decode requests.
+    non_spec_query_start_loc: torch.Tensor | None = None
+
+    # Speculative-decode (MTP) conv metadata. Only column 0 of the block table
+    # is needed for the convolution state, so these tensors are 1-D over the
+    # spec-decode requests.
+    spec_query_start_loc: torch.Tensor | None = None  # [num_spec_decodes + 1]
+    spec_state_indices_tensor: torch.Tensor | None = None  # [num_spec_decodes]
+    spec_sequence_masks: torch.Tensor | None = None  # [batch]
+    spec_token_indx: torch.Tensor | None = None
+    non_spec_token_indx: torch.Tensor | None = None
+    num_decode_draft_tokens_cpu: torch.Tensor | None = None
+
+
+class PleShortConvAttentionBackend(ShortConvAttentionBackend):
+    @staticmethod
+    def get_name() -> str:
+        return "PLE_SHORT_CONV_ATTN"
+
+    @staticmethod
+    def get_builder_cls() -> type["PleShortConvAttentionMetadataBuilder"]:
+        return PleShortConvAttentionMetadataBuilder
+
+
+class PleShortConvAttentionMetadataBuilder(ShortConvAttentionMetadataBuilder):
+    metadata_cls = PleShortConvAttentionMetadata
+    # Spec-decode requires a uniform (multi-token) decode batch for full
+    # CUDA graph capture, matching the GDN backend.
+    _cudagraph_support = AttentionCGSupport.UNIFORM_BATCH
+    reorder_batch_threshold: int = 1
+    supports_update_block_table = False
+
+    def __init__(
+        self,
+        kv_cache_spec: MambaSpec,
+        layer_names: list[str],
+        vllm_config: VllmConfig,
+        device: torch.device,
+    ) -> None:
+        super().__init__(kv_cache_spec, layer_names, vllm_config, device)
+        self.num_spec = self.num_spec_tokens
+        self.use_full_cuda_graph = (
+            self.compilation_config.cudagraph_mode.has_full_cudagraphs()
+        )
+
+        max_num_seqs = vllm_config.scheduler_config.max_num_seqs
+        max_capture_size = self.compilation_config.max_cudagraph_capture_size
+        self.decode_cudagraph_max_bs = max_num_seqs
+        self.decode_cudagraph_max_tokens = max_num_seqs * (self.num_spec + 1)
+        if max_capture_size is not None:
+            self.decode_cudagraph_max_bs = min(
+                self.decode_cudagraph_max_bs, max_capture_size
+            )
+            self.decode_cudagraph_max_tokens = min(
+                self.decode_cudagraph_max_tokens, max_capture_size
+            )
+
+        # Persistent buffers reused during full CUDA graph capture and replay.
+        self.spec_state_indices_tensor = torch.empty(
+            (self.decode_cudagraph_max_bs,), dtype=torch.int32, device=device
+        )
+        self.spec_sequence_masks = torch.empty(
+            (self.decode_cudagraph_max_bs,), dtype=torch.bool, device=device
+        )
+        self.spec_token_indx = torch.empty(
+            (self.decode_cudagraph_max_tokens,), dtype=torch.int32, device=device
+        )
+        self.non_spec_token_indx = torch.empty(
+            (self.decode_cudagraph_max_tokens,), dtype=torch.int32, device=device
+        )
+        self.spec_query_start_loc = torch.empty(
+            (self.decode_cudagraph_max_bs + 1,), dtype=torch.int32, device=device
+        )
+        self.num_accepted_tokens = torch.empty(
+            (self.decode_cudagraph_max_bs,), dtype=torch.int32, device=device
+        )
+        self.has_initial_states_d = torch.empty(
+            (self.decode_cudagraph_max_bs,), dtype=torch.bool, device=device
+        )
+
+    def _build_non_spec_metadata(
+        self,
+        common_prefix_len: int,
+        common_attn_metadata: CommonAttentionMetadata,
+        fast_build: bool,
+        num_decode_draft_tokens_cpu: torch.Tensor | None,
+        **kwargs: Any,
+    ) -> PleShortConvAttentionMetadata:
+        metadata = super().build(
+            common_prefix_len,
+            common_attn_metadata,
+            fast_build,
+            num_accepted_tokens=None,
+            **kwargs,
+        )
+        assert isinstance(metadata, PleShortConvAttentionMetadata)
+
+        state_indices_d = metadata.state_indices_tensor_d
+        if state_indices_d is not None and state_indices_d.dim() > 1:
+            state_indices_d = state_indices_d[:, 0]
+        state_indices_p = metadata.state_indices_tensor_p
+        if metadata.num_prefills == 0:
+            assert state_indices_d is not None
+            # BaseMambaAttentionMetadataBuilder pads decode state indices into
+            # a persistent tensor for full CUDA graphs. Keep those rows so the
+            # PLE decode receives one cache slot per graph-padded token.
+            state_indices_tensor = state_indices_d
+        elif metadata.num_decodes == 0:
+            assert state_indices_p is not None
+            state_indices_tensor = state_indices_p[: metadata.num_prefills]
+        else:
+            assert state_indices_d is not None
+            assert state_indices_p is not None
+            state_indices_tensor = torch.cat(
+                (state_indices_d, state_indices_p[: metadata.num_prefills])
+            )
+
+        has_initial_states_d = None
+        if metadata.num_decodes > 0:
+            num_computed_tokens = common_attn_metadata.compute_num_computed_tokens()
+            has_initial_states_d = num_computed_tokens[: metadata.num_decodes] > 0
+            if (
+                self.use_full_cuda_graph
+                and metadata.num_prefills == 0
+                and metadata.num_decodes <= self.decode_cudagraph_max_bs
+            ):
+                assert state_indices_d is not None
+                # Prepare tensors for CUDA graph replay. Padded rows have no
+                # initial state and use NULL_BLOCK_ID in state_indices_d.
+                num_decode_rows = state_indices_d.numel()
+                self.has_initial_states_d[: metadata.num_decodes].copy_(
+                    has_initial_states_d, non_blocking=True
+                )
+                self.has_initial_states_d[metadata.num_decodes : num_decode_rows].fill_(
+                    False
+                )
+                has_initial_states_d = self.has_initial_states_d[:num_decode_rows]
+
+        max_prefill_query_len = 0
+        if metadata.num_prefills > 0:
+            query_lens_cpu = torch.diff(common_attn_metadata.query_start_loc_cpu)
+            max_prefill_query_len = int(
+                query_lens_cpu[
+                    metadata.num_decodes : (
+                        metadata.num_decodes + metadata.num_prefills
+                    )
+                ]
+                .max()
+                .item()
+            )
+
+        return replace(
+            metadata,
+            num_actual_tokens=common_attn_metadata.num_actual_tokens,
+            spec_query_len=self.num_spec + 1,
+            max_prefill_query_len=max_prefill_query_len,
+            query_start_loc=common_attn_metadata.query_start_loc,
+            state_indices_tensor=state_indices_tensor,
+            has_initial_states_d=has_initial_states_d,
+            non_spec_query_start_loc=common_attn_metadata.query_start_loc,
+            num_decode_draft_tokens_cpu=num_decode_draft_tokens_cpu,
+        )
+
+    def build(  # type: ignore[override]
+        self,
+        common_prefix_len: int,
+        common_attn_metadata: CommonAttentionMetadata,
+        fast_build: bool = False,
+        *,
+        num_accepted_tokens: torch.Tensor | None = None,
+        num_decode_draft_tokens_cpu: torch.Tensor | None = None,
+        **kwargs: Any,
+    ) -> PleShortConvAttentionMetadata:
+        m = common_attn_metadata
+        spec_sequence_masks_cpu: torch.Tensor | None = None
+        # Detect speculative-decode requests. We use -1 to mark prefill and
+        # plain-decode requests, so any value >= 0 is a (multi-query)
+        # spec-decode request.
+        if self.use_spec_decode and num_decode_draft_tokens_cpu is not None:
+            candidate_mask = num_decode_draft_tokens_cpu[: m.num_reqs] >= 0
+            if bool(candidate_mask.any().item()):
+                spec_sequence_masks_cpu = candidate_mask
+
+        if spec_sequence_masks_cpu is None:
+            return self._build_non_spec_metadata(
+                common_prefix_len,
+                common_attn_metadata,
+                fast_build,
+                num_decode_draft_tokens_cpu,
+                **kwargs,
+            )
+
+        del common_prefix_len, fast_build, kwargs
+        query_start_loc = m.query_start_loc
+        query_start_loc_cpu = m.query_start_loc_cpu
+        query_lens_cpu = torch.diff(query_start_loc_cpu)
+        block_table_tensor = mamba_get_block_table_tensor(
+            m.block_table_tensor,
+            m.seq_lens,
+            self.kv_cache_spec,
+            self.vllm_config.cache_config.mamba_cache_mode,
+        )
+
+        if query_start_loc.device.type == "cpu":
+            spec_sequence_masks = spec_sequence_masks_cpu
+        else:
+            spec_sequence_masks = async_tensor_h2d(
+                spec_sequence_masks_cpu, device=query_start_loc.device
+            )
+
+        # For causal_conv1d (non-spec prefill Triton kernel metadata).
+        nums_dict = None
+        batch_ptr = None
+        token_chunk_offset_ptr = None
+        has_initial_states_p = None
+        has_initial_states_d = None
+        num_computed_tokens_p = None
+        # Original request indices of the non-spec requests, ordered
+        # [decodes, prefills]. Used to gather per-request data consistently.
+        non_spec_req_idx_cpu: torch.Tensor | None = None
+
+        query_lens = torch.diff(query_start_loc)
+        # Per-request classification by mask, NOT by position. With
+        # spec-decode, the front decode group can contain both spec-decode
+        # requests and plain non-spec single-token decodes. Spec requests are
+        # therefore not guaranteed to occupy the first num_spec_decodes slots.
+        non_spec_mask_cpu = ~spec_sequence_masks_cpu
+        decode_mask_cpu = non_spec_mask_cpu & (query_lens_cpu == 1)
+        prefill_mask_cpu = non_spec_mask_cpu & (query_lens_cpu > 1)
+
+        num_spec_decodes = int(spec_sequence_masks_cpu.sum().item())
+        num_decodes = int(decode_mask_cpu.sum().item())
+        num_prefills = int(prefill_mask_cpu.sum().item())
+        num_decode_tokens = num_decodes
+        num_prefill_tokens = int(query_lens_cpu[prefill_mask_cpu].sum().item())
+        num_spec_decode_tokens = int(
+            query_lens_cpu[spec_sequence_masks_cpu].sum().item()
+        )
+        # Max prefill query length, CPU-side (no device-to-host sync) for the
+        # PLE dilated short-conv packing buffer.
+        max_prefill_query_len = (
+            int(query_lens_cpu[prefill_mask_cpu].max().item())
+            if num_prefills > 0
+            else 0
+        )
+
+        # Original request indices grouped as
+        # [spec | non-spec decode | non-spec prefill]; each group keeps the
+        # original (already reordered) relative order via a stable nonzero.
+        spec_req_idx_cpu = spec_sequence_masks_cpu.nonzero(as_tuple=True)[0]
+        decode_req_idx_cpu = decode_mask_cpu.nonzero(as_tuple=True)[0]
+        prefill_req_idx_cpu = prefill_mask_cpu.nonzero(as_tuple=True)[0]
+        non_spec_req_idx_cpu = torch.cat((decode_req_idx_cpu, prefill_req_idx_cpu))
+        spec_req_idx = spec_req_idx_cpu.to(query_start_loc.device)
+        non_spec_req_idx = non_spec_req_idx_cpu.to(query_start_loc.device)
+
+        if num_decodes == 0 and num_prefills == 0:
+            # Pure speculative-decode batch: all real tokens are spec tokens.
+            spec_token_indx = torch.arange(
+                num_spec_decode_tokens,
+                dtype=torch.int32,
+                device=query_start_loc.device,
+            )
+            non_spec_token_indx = torch.empty(
+                0, dtype=torch.int32, device=query_start_loc.device
+            )
+            spec_state_indices_tensor = block_table_tensor[spec_req_idx, 0]
+            non_spec_state_indices_tensor = None
+            spec_query_start_loc = query_start_loc[: num_spec_decodes + 1]
+            non_spec_query_start_loc = None
+            non_spec_query_start_loc_cpu = None
+        else:
+            # Mixed batch: build a per-token group key consistent with the
+            # request grouping above (spec=0 | decode=1 | prefill=2) and a
+            # stable sort, so tokens of each request stay contiguous and in
+            # request order. This yields spec tokens first, then the non-spec
+            # [decode, prefill] tokens.
+            req_group = torch.full(
+                (m.num_reqs,),
+                2,
+                dtype=torch.int64,
+                device=query_start_loc.device,
+            )
+            req_group[spec_req_idx] = 0
+            req_group[decode_req_idx_cpu.to(query_start_loc.device)] = 1
+            token_group = torch.repeat_interleave(req_group, query_lens)
+            token_perm = torch.argsort(token_group, stable=True)
+            spec_token_indx = token_perm[:num_spec_decode_tokens]
+            non_spec_token_indx = token_perm[num_spec_decode_tokens:]
+
+            spec_state_indices_tensor = block_table_tensor[spec_req_idx, 0]
+            non_spec_state_indices_tensor = block_table_tensor[non_spec_req_idx, 0]
+            spec_query_start_loc = torch.zeros(
+                num_spec_decodes + 1,
+                dtype=torch.int32,
+                device=query_start_loc.device,
+            )
+            torch.cumsum(query_lens[spec_req_idx], dim=0, out=spec_query_start_loc[1:])
+            non_spec_query_start_loc = torch.zeros(
+                num_decodes + num_prefills + 1,
+                dtype=torch.int32,
+                device=query_start_loc.device,
+            )
+            torch.cumsum(
+                query_lens[non_spec_req_idx],
+                dim=0,
+                out=non_spec_query_start_loc[1:],
+            )
+            non_spec_query_start_loc_cpu = torch.zeros(
+                num_decodes + num_prefills + 1, dtype=torch.int32
+            )
+            torch.cumsum(
+                query_lens_cpu[non_spec_req_idx_cpu],
+                dim=0,
+                out=non_spec_query_start_loc_cpu[1:],
+            )
+
+        assert num_accepted_tokens is not None
+        # Accepted-token counts must follow the same request order as the
+        # speculative state indices.
+        num_accepted_tokens = num_accepted_tokens[
+            spec_req_idx_cpu.to(num_accepted_tokens.device)
+        ]
+
+        # Compute the conv-state slots for the non-spec decode/prefill split,
+        # plus the initial-state masks and Triton causal_conv1d metadata.
+        if non_spec_state_indices_tensor is None:
+            state_indices_tensor = block_table_tensor[:0, 0]
+        else:
+            state_indices_tensor = non_spec_state_indices_tensor
+
+        # Build the regular decode/prefill state metadata inherited from the
+        # generic short-conv metadata contract.
+        query_start_loc_p = None
+        query_start_loc_d = None
+        state_indices_tensor_p = None
+        state_indices_tensor_d = None
+        if num_decodes > 0 or num_prefills > 0:
+            num_computed_tokens = m.compute_num_computed_tokens()
+            if non_spec_req_idx_cpu is not None:
+                non_spec_req_idx = non_spec_req_idx_cpu.to(num_computed_tokens.device)
+                num_computed_tokens = num_computed_tokens[non_spec_req_idx]
+
+            state_indices_tensor_d = state_indices_tensor[:num_decodes]
+            state_indices_tensor_p = state_indices_tensor[
+                num_decodes : num_decodes + num_prefills
+            ]
+            if num_decodes > 0:
+                has_initial_states_d = num_computed_tokens[:num_decodes] > 0
+                assert non_spec_query_start_loc is not None
+                query_start_loc_d = non_spec_query_start_loc[: num_decodes + 1]
+            if num_prefills > 0:
+                num_computed_tokens_p = num_computed_tokens[
+                    num_decodes : num_decodes + num_prefills
+                ]
+                has_initial_states_p = num_computed_tokens_p > 0
+                assert non_spec_query_start_loc is not None
+                assert non_spec_query_start_loc_cpu is not None
+                query_start_loc_p = (
+                    non_spec_query_start_loc[num_decodes:] - num_decode_tokens
+                )
+                query_start_loc_p_cpu = (
+                    non_spec_query_start_loc_cpu[num_decodes:] - num_decode_tokens
+                )
+                if query_start_loc.device.type != "cpu":
+                    nums_dict, batch_ptr, token_chunk_offset_ptr = (
+                        compute_causal_conv1d_metadata(
+                            query_start_loc_p_cpu,
+                            device=query_start_loc.device,
+                        )
+                    )
+
+        # Prepare persistent tensors for CUDA graph capture and replay.
+        # ``m.num_actual_tokens`` is already padded by the model runner.
+        # Request-level buffers use ``m.num_reqs`` while token-level buffers
+        # use their independently bounded token count.
+        batch_size = m.num_reqs
+        if (
+            self.use_full_cuda_graph
+            and num_prefills == 0
+            and num_decodes == 0
+            and spec_sequence_masks is not None
+            and num_spec_decodes <= self.decode_cudagraph_max_bs
+            and num_spec_decode_tokens <= self.decode_cudagraph_max_tokens
+        ):
+            assert spec_state_indices_tensor is not None
+            self.spec_state_indices_tensor[:num_spec_decodes].copy_(
+                spec_state_indices_tensor, non_blocking=True
+            )
+            spec_state_indices_tensor = self.spec_state_indices_tensor[:batch_size]
+            spec_state_indices_tensor[num_spec_decodes:].fill_(NULL_BLOCK_ID)
+
+            self.spec_sequence_masks[:batch_size].copy_(
+                spec_sequence_masks[:batch_size], non_blocking=True
+            )
+            spec_sequence_masks = self.spec_sequence_masks[:batch_size]
+
+            assert spec_query_start_loc is not None
+            self.spec_query_start_loc[: num_spec_decodes + 1].copy_(
+                spec_query_start_loc, non_blocking=True
+            )
+            spec_num_query_tokens = spec_query_start_loc[-1]
+            spec_query_start_loc = self.spec_query_start_loc[: batch_size + 1]
+            spec_query_start_loc[num_spec_decodes + 1 :].fill_(spec_num_query_tokens)
+
+            assert num_accepted_tokens is not None
+            self.num_accepted_tokens[:num_spec_decodes].copy_(
+                num_accepted_tokens, non_blocking=True
+            )
+            num_accepted_tokens = self.num_accepted_tokens[:batch_size]
+            num_accepted_tokens[num_spec_decodes:].fill_(1)
+
+        return PleShortConvAttentionMetadata(
+            num_prefills=num_prefills,
+            num_prefill_tokens=num_prefill_tokens,
+            num_decodes=num_decodes,
+            num_decode_tokens=num_decode_tokens,
+            num_reqs=m.num_reqs,
+            num_spec_decodes=num_spec_decodes,
+            num_spec_decode_tokens=num_spec_decode_tokens,
+            num_actual_tokens=m.num_actual_tokens,
+            spec_query_len=self.num_spec + 1,
+            max_prefill_query_len=max_prefill_query_len,
+            query_start_loc=query_start_loc,
+            state_indices_tensor=state_indices_tensor,
+            has_initial_states_p=has_initial_states_p,
+            has_initial_states_d=has_initial_states_d,
+            non_spec_query_start_loc=non_spec_query_start_loc,
+            spec_query_start_loc=spec_query_start_loc,
+            spec_state_indices_tensor=spec_state_indices_tensor,
+            spec_sequence_masks=spec_sequence_masks,
+            spec_token_indx=spec_token_indx,
+            non_spec_token_indx=non_spec_token_indx,
+            num_accepted_tokens=num_accepted_tokens,
+            num_decode_draft_tokens_cpu=num_decode_draft_tokens_cpu,
+            nums_dict=nums_dict,
+            batch_ptr=batch_ptr,
+            token_chunk_offset_ptr=token_chunk_offset_ptr,
+            query_start_loc_p=query_start_loc_p,
+            query_start_loc_d=query_start_loc_d,
+            state_indices_tensor_p=state_indices_tensor_p,
+            state_indices_tensor_d=state_indices_tensor_d,
+            num_computed_tokens_p=num_computed_tokens_p,
+            block_idx_last_scheduled_token=None,
+            block_idx_first_scheduled_token_p=None,
+            block_idx_last_computed_token=None,
+            block_idx_last_scheduled_token_prev_step=None,
+            seq_lens=m.seq_lens,
+        )
+
+    def build_for_cudagraph_capture(
+        self, common_attn_metadata: CommonAttentionMetadata
+    ) -> PleShortConvAttentionMetadata:
+        """Build metadata for full CUDA graph capture.
+
+        Currently, only decode is supported for full CUDA graphs with
+        short-conv.
+        """
+        m = common_attn_metadata
+        assert (
+            m.num_reqs <= self.decode_cudagraph_max_bs
+            and m.num_actual_tokens <= self.decode_cudagraph_max_tokens
+        ), (
+            "ShortConv only supports decode-only full CUDAGraph capture. "
+            f"Make sure batch size ({m.num_reqs}) <= "
+            f"cudagraph capture size ({self.decode_cudagraph_max_bs}) and "
+            f"number of tokens ({m.num_actual_tokens}) <= "
+            f"token capture size ({self.decode_cudagraph_max_tokens})."
+        )
+
+        if self.use_spec_decode:
+            num_accepted_tokens = torch.diff(m.query_start_loc)
+            num_decode_draft_tokens_cpu = (num_accepted_tokens - 1).cpu()
+            return self.build(
+                0,
+                m,
+                num_accepted_tokens=num_accepted_tokens,
+                num_decode_draft_tokens_cpu=num_decode_draft_tokens_cpu,
+            )
+        return self.build(0, m)

--- a/vllm_ascend/models/qwen4_exp/vllm_config.py
+++ b/vllm_ascend/models/qwen4_exp/vllm_config.py
@@ -1,0 +1,58 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM-Ascend project
+"""vLLM configuration hooks for the plugin-owned Qwen4Exp model."""
+
+from vllm.model_executor.models import config as model_config_module
+from vllm.model_executor.models.config import Qwen3_5ForConditionalGenerationConfig
+
+
+def _strip_mrope(model_config: object) -> None:
+    hf_config = getattr(model_config, "hf_config", None)
+    text_config = getattr(model_config, "hf_text_config", None)
+    for config in {id(item): item for item in (hf_config, text_config) if item is not None}.values():
+        rope_parameters = getattr(config, "rope_parameters", None)
+        if rope_parameters is not None:
+            rope_parameters.pop("mrope_section", None)
+            rope_parameters.pop("mrope_interleaved", None)
+
+
+class Qwen4ExpForConditionalGenerationConfig(Qwen3_5ForConditionalGenerationConfig):
+    @staticmethod
+    def verify_and_update_config(vllm_config: object) -> None:
+        Qwen3_5ForConditionalGenerationConfig.verify_and_update_config(vllm_config)
+        text_config = vllm_config.model_config.hf_text_config
+        if text_config.hc_count <= 1:
+            raise ValueError("Qwen4Exp requires hc_count > 1")
+        parallel_config = vllm_config.parallel_config
+        if (text_config.ple_layer_ids or getattr(text_config, "indexer_n_heads", None) is not None) and (
+            parallel_config.enable_dbo or parallel_config.ubatch_size > 1
+        ):
+            raise NotImplementedError("Qwen4Exp PLE/QSA does not support DBO or microbatching")
+        multimodal_config = vllm_config.model_config.multimodal_config
+        if multimodal_config is not None and multimodal_config.language_model_only:
+            _strip_mrope(vllm_config.model_config)
+
+
+class Qwen4ExpForCausalLMConfig(Qwen4ExpForConditionalGenerationConfig):
+    @staticmethod
+    def verify_and_update_config(vllm_config: object) -> None:
+        Qwen4ExpForConditionalGenerationConfig.verify_and_update_config(vllm_config)
+        _strip_mrope(vllm_config.model_config)
+
+
+class Qwen4ExpMTPConfig(Qwen4ExpForConditionalGenerationConfig):
+    @staticmethod
+    def verify_and_update_config(vllm_config: object) -> None:
+        Qwen4ExpForConditionalGenerationConfig.verify_and_update_config(vllm_config)
+        if not hasattr(vllm_config.model_config.hf_config, "vision_config"):
+            _strip_mrope(vllm_config.model_config)
+
+
+def register_qwen4_exp_vllm_config() -> None:
+    model_config_module.MODELS_CONFIG_MAP.update(
+        {
+            "Qwen4ExpForCausalLM": Qwen4ExpForCausalLMConfig,
+            "Qwen4ExpForConditionalGeneration": Qwen4ExpForConditionalGenerationConfig,
+            "Qwen4ExpMTP": Qwen4ExpMTPConfig,
+        }
+    )

--- a/vllm_ascend/models/qwen4_exp/vocab_parallel_embedding.py
+++ b/vllm_ascend/models/qwen4_exp/vocab_parallel_embedding.py
@@ -1,0 +1,568 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from collections.abc import Sequence
+from dataclasses import dataclass
+
+import torch
+import torch.nn.functional as F
+import vllm.envs as envs
+from torch.nn.parameter import Parameter
+from vllm.distributed import (
+    divide,
+    get_tensor_model_parallel_rank,
+    get_tensor_model_parallel_world_size,
+    tensor_model_parallel_all_reduce,
+)
+from vllm.model_executor.layers.batch_invariant import (
+    linear_batch_invariant,
+)
+from vllm.model_executor.layers.quantization.base_config import (
+    QuantizationConfig,
+    QuantizeMethodBase,
+    method_has_implemented_embedding,
+)
+from vllm.model_executor.layers.utils import dispatch_unquantized_gemm
+from vllm.model_executor.parameter import BasevLLMParameter
+from vllm.model_executor.utils import set_weight_attrs
+from vllm.platforms import current_platform
+
+DEFAULT_VOCAB_PADDING_SIZE = 64
+
+
+class UnquantizedEmbeddingMethod(QuantizeMethodBase):
+    """Unquantized method for embeddings."""
+
+    def create_weights(
+        self,
+        layer: torch.nn.Module,
+        input_size_per_partition: int,
+        output_partition_sizes: list[int],
+        input_size: int,
+        output_size: int,
+        params_dtype: torch.dtype,
+        **extra_weight_attrs,
+    ):
+        """Create weights for embedding layer."""
+        weight = Parameter(
+            torch.empty(
+                sum(output_partition_sizes),
+                input_size_per_partition,
+                dtype=params_dtype,
+            ),
+            requires_grad=False,
+        )
+        set_weight_attrs(weight, {"input_dim": 1, "output_dim": 0})
+        layer.register_parameter("weight", weight)
+        set_weight_attrs(weight, extra_weight_attrs)
+
+    def process_weights_after_loading(self, layer: torch.nn.Module) -> None:
+        if current_platform.is_cpu():
+            from vllm.model_executor.layers.utils import dispatch_cpu_unquantized_gemm
+
+            dispatch_cpu_unquantized_gemm(layer, remove_weight=False)
+
+    def apply(
+        self,
+        layer: torch.nn.Module,
+        x: torch.Tensor,
+        bias: torch.Tensor | None = None,
+    ) -> torch.Tensor:
+        if envs.VLLM_BATCH_INVARIANT and current_platform.is_cuda_alike():
+            return linear_batch_invariant(x, layer.weight, bias)
+        return dispatch_unquantized_gemm()(layer, x, layer.weight, bias)
+
+    def embedding(self, layer: torch.nn.Module, input_: torch.Tensor) -> torch.Tensor:
+        return F.embedding(input_, layer.weight)
+
+    def tie_weights(
+        self, layer: torch.nn.Module, embed_tokens: "VocabParallelEmbedding"
+    ):
+        layer.weight = embed_tokens.weight
+        return layer
+
+
+def pad_vocab_size(vocab_size: int, pad_to: int = DEFAULT_VOCAB_PADDING_SIZE) -> int:
+    """Pad the vocab size to the given value."""
+    return ((vocab_size + pad_to - 1) // pad_to) * pad_to
+
+
+def vocab_range_from_per_partition_vocab_size(
+    per_partition_vocab_size: int, rank: int, offset: int = 0
+) -> Sequence[int]:
+    index_f = rank * per_partition_vocab_size
+    index_l = index_f + per_partition_vocab_size
+    return index_f + offset, index_l + offset
+
+
+def vocab_range_from_global_vocab_size(
+    global_vocab_size: int, rank: int, world_size: int, offset: int = 0
+) -> Sequence[int]:
+    per_partition_vocab_size = divide(global_vocab_size, world_size)
+    return vocab_range_from_per_partition_vocab_size(
+        per_partition_vocab_size, rank, offset=offset
+    )
+
+
+@dataclass
+class VocabParallelEmbeddingShardIndices:
+    """Indices for a shard of a vocab parallel embedding."""
+
+    padded_org_vocab_start_index: int
+    padded_org_vocab_end_index: int
+    padded_added_vocab_start_index: int
+    padded_added_vocab_end_index: int
+
+    org_vocab_start_index: int
+    org_vocab_end_index: int
+    added_vocab_start_index: int
+    added_vocab_end_index: int
+
+    @property
+    def num_org_elements(self) -> int:
+        return self.org_vocab_end_index - self.org_vocab_start_index
+
+    @property
+    def num_added_elements(self) -> int:
+        return self.added_vocab_end_index - self.added_vocab_start_index
+
+    @property
+    def num_org_elements_padded(self) -> int:
+        return self.padded_org_vocab_end_index - self.padded_org_vocab_start_index
+
+    @property
+    def num_added_elements_padded(self) -> int:
+        return self.padded_added_vocab_end_index - self.padded_added_vocab_start_index
+
+    @property
+    def num_org_vocab_padding(self) -> int:
+        return self.num_org_elements_padded - self.num_org_elements
+
+    @property
+    def num_added_vocab_padding(self) -> int:
+        return self.num_added_elements_padded - self.num_added_elements
+
+    @property
+    def num_elements_padded(self) -> int:
+        return self.num_org_elements_padded + self.num_added_elements_padded
+
+    def __post_init__(self):
+        # sanity checks
+        assert self.padded_org_vocab_start_index <= self.padded_org_vocab_end_index
+        assert self.padded_added_vocab_start_index <= self.padded_added_vocab_end_index
+
+        assert self.org_vocab_start_index <= self.org_vocab_end_index
+        assert self.added_vocab_start_index <= self.added_vocab_end_index
+
+        assert self.org_vocab_start_index <= self.padded_org_vocab_start_index
+        assert self.added_vocab_start_index <= self.padded_added_vocab_start_index
+        assert self.org_vocab_end_index <= self.padded_org_vocab_end_index
+        assert self.added_vocab_end_index <= self.padded_added_vocab_end_index
+
+        assert self.num_org_elements <= self.num_org_elements_padded
+        assert self.num_added_elements <= self.num_added_elements_padded
+
+
+@torch.compile(dynamic=True, backend=current_platform.simple_compile_backend)
+def get_masked_input_and_mask(
+    input_: torch.Tensor,
+    org_vocab_start_index: int,
+    org_vocab_end_index: int,
+    num_org_vocab_padding: int,
+    added_vocab_start_index: int,
+    added_vocab_end_index: int,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    # torch.compile will fuse all of the pointwise ops below
+    # into a single kernel, making it very fast
+    org_vocab_mask = (input_ >= org_vocab_start_index) & (input_ < org_vocab_end_index)
+    added_vocab_mask = (input_ >= added_vocab_start_index) & (
+        input_ < added_vocab_end_index
+    )
+    added_offset = (
+        added_vocab_start_index
+        - (org_vocab_end_index - org_vocab_start_index)
+        - num_org_vocab_padding
+    )
+    valid_offset = (org_vocab_start_index * org_vocab_mask) + (
+        added_offset * added_vocab_mask
+    )
+    vocab_mask = org_vocab_mask | added_vocab_mask
+    input_ = vocab_mask * (input_ - valid_offset)
+    return input_, ~vocab_mask
+
+
+# --8<-- [start:vocab_parallel_embedding]
+class VocabParallelEmbedding(torch.nn.Module):
+    """Embedding parallelized in the vocabulary dimension.
+
+    Adapted from torch.nn.Embedding, note that we pad the vocabulary size to
+    make sure it is divisible by the number of model parallel GPUs.
+
+    In order to support various loading methods, we ensure that LoRA-added
+    embeddings are always at the end of TP-sharded tensors. In other words,
+    we shard base embeddings and LoRA embeddings separately (both padded),
+    and place them in the same tensor.
+    In this example, we will have the original vocab size = 1010,
+    added vocab size = 16 and padding to 64. Therefore, the total
+    vocab size with padding will be 1088 (because we first pad 1010 to
+    1024, add 16, and then pad to 1088).
+    Therefore, the tensor format looks like the following:
+    TP1, rank 0 (no sharding):
+                            |< --------BASE-------- >|< -BASE PADDING-- >|< -----LORA------ >|< -LORA PADDING-- >|
+    corresponding token_id: |  0  |  1  | ... | 1009 |  -1  | ... |  -1  | 1010 | ... | 1025 |  -1  | ... |  -1  |
+                     index: |  0  |  1  | ... | 1009 | 1010 | ... | 1023 | 1024 | ... | 1039 | 1040 | ... | 1087 |
+
+    TP2, rank 0:
+                            |< --------------------BASE--------------------- >|< -----LORA------ >|< -LORA PADDING- >|
+    corresponding token_id: |  0  |  1  |  2  | ... | 497  | 498 | ...  | 511 | 1010 | ... | 1025 |  -1  | ... |  -1 |
+                     index: |  0  |  1  |  2  | ... | 497  | 498 | ...  | 511 | 512  | ... | 527  |  528 | ... | 543 |
+    TP2, rank 1:
+                            |< -----------BASE----------- >|< -BASE PADDING- >|< -----------LORA PADDING----------- >|
+    corresponding token_id: | 512 | 513 | 514 | ... | 1009 | -1  | ...  | -1  |  -1  | ... |  -1  | -1  | ... |   -1 |
+                     index: |  0  |  1  |  2  | ... | 497  | 498 | ...  | 511 | 512  | ... | 527  | 528 | ... |  543 |
+
+    Args:
+        num_embeddings: vocabulary size.
+        embedding_dim: size of hidden state.
+        params_dtype: type of the parameters.
+        org_num_embeddings: original vocabulary size (without LoRA).
+        padding_size: padding size for the vocabulary.
+        quant_config: quant config for the layer
+        prefix: full name of the layer in the state dict
+    """  # noqa: E501
+
+    # --8<-- [end:vocab_parallel_embedding]
+
+    def __init__(
+        self,
+        num_embeddings: int,
+        embedding_dim: int,
+        params_dtype: torch.dtype | None = None,
+        org_num_embeddings: int | None = None,
+        padding_size: int = DEFAULT_VOCAB_PADDING_SIZE,
+        quant_config: QuantizationConfig | None = None,
+        prefix: str = "",
+        quant_method: QuantizeMethodBase | None = None,
+    ):
+        super().__init__()
+
+        # Keep the input dimensions.
+        tp_rank = get_tensor_model_parallel_rank()
+        self.tp_size = get_tensor_model_parallel_world_size()
+        self.num_embeddings = num_embeddings
+        self.padding_size = padding_size
+        self.org_vocab_size = org_num_embeddings or num_embeddings
+        num_added_embeddings = num_embeddings - self.org_vocab_size
+        self.org_vocab_size_padded = pad_vocab_size(
+            self.org_vocab_size, self.padding_size
+        )
+        self.num_embeddings_padded = pad_vocab_size(
+            self.org_vocab_size_padded + num_added_embeddings, self.padding_size
+        )
+        assert self.org_vocab_size_padded <= self.num_embeddings_padded
+
+        self.shard_indices = self._get_indices(
+            self.num_embeddings_padded,
+            self.org_vocab_size_padded,
+            self.num_embeddings,
+            self.org_vocab_size,
+            tp_rank,
+            self.tp_size,
+        )
+        self.embedding_dim = embedding_dim
+
+        # Avoid overriding a preselected model-specific method with generic
+        # config-based dispatch.
+        if quant_method is None and quant_config is not None:
+            quant_method = quant_config.get_quant_method(self, prefix=prefix)
+        if quant_method is None:
+            quant_method = UnquantizedEmbeddingMethod()
+
+        # If we are making an embedding layer, then our quantization linear
+        # method must implement the embedding operation. If we are another
+        # layer type like ParallelLMHead, this is not important.
+        is_embedding_layer = type(self) is VocabParallelEmbedding
+        quant_method_implements_embedding = method_has_implemented_embedding(
+            type(quant_method)
+        )
+        if is_embedding_layer and not quant_method_implements_embedding:
+            raise NotImplementedError(
+                f"The class {type(quant_method).__name__} must implement "
+                "the 'embedding' method, see UnquantizedEmbeddingMethod."
+            )
+
+        self.quant_method: QuantizeMethodBase = quant_method
+
+        if params_dtype is None:
+            params_dtype = torch.get_default_dtype()
+        self.params_dtype = params_dtype
+        # Divide the weight matrix along the vocabulary dimension.
+        self.num_added_embeddings = self.num_embeddings - self.org_vocab_size
+        self.num_embeddings_per_partition = divide(
+            self.num_embeddings_padded, self.tp_size
+        )
+        assert (
+            self.shard_indices.num_elements_padded == self.num_embeddings_per_partition
+        )
+        self.num_org_embeddings_per_partition = (
+            self.shard_indices.org_vocab_end_index
+            - self.shard_indices.org_vocab_start_index
+        )
+        self.num_added_embeddings_per_partition = (
+            self.shard_indices.added_vocab_end_index
+            - self.shard_indices.added_vocab_start_index
+        )
+
+        self.quant_method.create_weights(
+            self,
+            self.embedding_dim,
+            [self.num_embeddings_per_partition],
+            self.embedding_dim,
+            self.num_embeddings_padded,
+            params_dtype=params_dtype,
+            weight_loader=self.weight_loader,
+        )
+
+    @classmethod
+    def _get_indices(
+        cls,
+        vocab_size_padded: int,
+        org_vocab_size_padded: int,
+        vocab_size: int,
+        org_vocab_size: int,
+        tp_rank: int,
+        tp_size: int,
+    ) -> VocabParallelEmbeddingShardIndices:
+        """Get start and end indices for vocab parallel embedding, following the
+        layout outlined in the class docstring, based on the given tp_rank and
+        tp_size."""
+        num_added_embeddings_padded = vocab_size_padded - org_vocab_size_padded
+        padded_org_vocab_start_index, padded_org_vocab_end_index = (
+            vocab_range_from_global_vocab_size(org_vocab_size_padded, tp_rank, tp_size)
+        )
+        padded_added_vocab_start_index, padded_added_vocab_end_index = (
+            vocab_range_from_global_vocab_size(
+                num_added_embeddings_padded, tp_rank, tp_size, offset=org_vocab_size
+            )
+        )
+        # remove padding
+        org_vocab_start_index = min(padded_org_vocab_start_index, org_vocab_size)
+        org_vocab_end_index = min(padded_org_vocab_end_index, org_vocab_size)
+        added_vocab_start_index = min(padded_added_vocab_start_index, vocab_size)
+        added_vocab_end_index = min(padded_added_vocab_end_index, vocab_size)
+        return VocabParallelEmbeddingShardIndices(
+            padded_org_vocab_start_index,
+            padded_org_vocab_end_index,
+            padded_added_vocab_start_index,
+            padded_added_vocab_end_index,
+            org_vocab_start_index,
+            org_vocab_end_index,
+            added_vocab_start_index,
+            added_vocab_end_index,
+        )
+
+    def get_sharded_to_full_mapping(self) -> list[int] | None:
+        """Get a mapping that can be used to reindex the gathered
+        logits for sampling.
+
+        During sampling, we gather logits from all ranks. The relationship
+        of index->token_id will follow the same format as outlined in the class
+        docstring. However, after the gather, we want to reindex the final
+        logits tensor to map index->token_id one-to-one (the index is always
+        equal the token_id it corresponds to). The indices returned by this
+        method allow us to do that.
+        """
+        if self.tp_size < 2:
+            return None
+
+        base_embeddings: list[int] = []
+        added_embeddings: list[int] = []
+        padding: list[int] = []
+        for tp_rank in range(self.tp_size):
+            shard_indices = self._get_indices(
+                self.num_embeddings_padded,
+                self.org_vocab_size_padded,
+                self.num_embeddings,
+                self.org_vocab_size,
+                tp_rank,
+                self.tp_size,
+            )
+            range_start = self.num_embeddings_per_partition * tp_rank
+            range_end = self.num_embeddings_per_partition * (tp_rank + 1)
+            base_embeddings.extend(
+                range(range_start, range_start + shard_indices.num_org_elements)
+            )
+            padding.extend(
+                range(
+                    range_start + shard_indices.num_org_elements,
+                    range_start + shard_indices.num_org_elements_padded,
+                )
+            )
+            added_embeddings.extend(
+                range(
+                    range_start + shard_indices.num_org_elements_padded,
+                    range_start
+                    + shard_indices.num_org_elements_padded
+                    + shard_indices.num_added_elements,
+                )
+            )
+            padding.extend(
+                range(
+                    range_start
+                    + shard_indices.num_org_elements_padded
+                    + shard_indices.num_added_elements,
+                    range_start
+                    + shard_indices.num_org_elements_padded
+                    + shard_indices.num_added_elements_padded,
+                )
+            )
+            assert (
+                range_start
+                + shard_indices.num_org_elements_padded
+                + shard_indices.num_added_elements_padded
+                == range_end
+            )
+        ret = base_embeddings + added_embeddings + padding
+        assert len(ret) == self.num_embeddings_padded
+        return ret
+
+    def weight_loader(self, param: Parameter, loaded_weight: torch.Tensor):
+        output_dim = getattr(param, "output_dim", None)
+        packed_dim = getattr(param, "packed_dim", None)
+
+        # If parameter does not have output dim, then it should
+        # be copied onto all gpus (e.g. g_idx for act_order gptq).
+        if output_dim is None:
+            if (
+                loaded_weight.ndim == 0
+                and param.data.ndim == 1
+                and param.data.numel() == 1
+            ):
+                loaded_weight = loaded_weight.reshape(1)
+            assert param.data.shape == loaded_weight.shape
+            param.data.copy_(loaded_weight)
+            return
+
+        # Shard indexes for loading the weight
+        start_idx = self.shard_indices.org_vocab_start_index
+        shard_size = self.shard_indices.org_vocab_end_index - start_idx
+
+        # If param packed on the same dim we are sharding on, then
+        # need to adjust offsets of loaded weight by pack_factor.
+        if packed_dim is not None and packed_dim == output_dim:
+            packed_factor = (
+                param.packed_factor
+                if isinstance(param, BasevLLMParameter)
+                else param.pack_factor
+            )
+            assert loaded_weight.shape[output_dim] == (
+                self.org_vocab_size // param.packed_factor
+            )
+            start_idx = start_idx // packed_factor
+            shard_size = shard_size // packed_factor
+        else:
+            assert loaded_weight.shape[output_dim] == self.org_vocab_size
+
+        # Copy the data. Select chunk corresponding to current shard.
+        loaded_weight = loaded_weight.narrow(output_dim, start_idx, shard_size)
+        param[: loaded_weight.shape[0]].data.copy_(loaded_weight)
+        param[loaded_weight.shape[0] :].data.fill_(0)
+
+    def forward(self, input_):
+        if self.tp_size > 1:
+            # Build the mask.
+            masked_input, input_mask = get_masked_input_and_mask(
+                input_,
+                self.shard_indices.org_vocab_start_index,
+                self.shard_indices.org_vocab_end_index,
+                self.shard_indices.num_org_vocab_padding,
+                self.shard_indices.added_vocab_start_index,
+                self.shard_indices.added_vocab_end_index,
+            )
+        else:
+            masked_input = input_
+        # Get the embeddings.
+        output_parallel = self.quant_method.embedding(self, masked_input.long())
+        # Mask the output embedding.
+        if self.tp_size > 1:
+            if output_parallel.dtype in (
+                torch.float8_e4m3fn,
+                torch.float8_e5m2,
+            ):
+                comm_output = output_parallel.view(torch.int8)
+                comm_output.masked_fill_(input_mask.unsqueeze(-1), 0)
+                return tensor_model_parallel_all_reduce(comm_output).view(
+                    output_parallel.dtype
+                )
+            output_parallel.masked_fill_(input_mask.unsqueeze(-1), 0)
+        # Reduce across all the model parallel GPUs.
+        output = tensor_model_parallel_all_reduce(output_parallel)
+        return output
+
+    def extra_repr(self) -> str:
+        s = f"num_embeddings={self.num_embeddings_per_partition}"
+        s += f", embedding_dim={self.embedding_dim}"
+        s += f", org_vocab_size={self.org_vocab_size}"
+        s += f", num_embeddings_padded={self.num_embeddings_padded}"
+        s += f", tp_size={self.tp_size}"
+        return s
+
+
+# --8<-- [start:parallel_lm_head]
+class ParallelLMHead(VocabParallelEmbedding):
+    """Parallelized LM head.
+
+    Output logits weight matrices used in the Sampler. The weight and bias
+    tensors are padded to make sure they are divisible by the number of
+    model parallel GPUs.
+
+    Args:
+        num_embeddings: vocabulary size.
+        embedding_dim: size of hidden state.
+        bias: whether to use bias.
+        params_dtype: type of the parameters.
+        org_num_embeddings: original vocabulary size (without LoRA).
+        padding_size: padding size for the vocabulary.
+    """
+
+    # --8<-- [end:parallel_lm_head]
+
+    def __init__(
+        self,
+        num_embeddings: int,
+        embedding_dim: int,
+        bias: bool = False,
+        params_dtype: torch.dtype | None = None,
+        org_num_embeddings: int | None = None,
+        padding_size: int = DEFAULT_VOCAB_PADDING_SIZE,
+        quant_config: QuantizationConfig | None = None,
+        prefix: str = "",
+    ):
+        super().__init__(
+            num_embeddings,
+            embedding_dim,
+            params_dtype,
+            org_num_embeddings,
+            padding_size,
+            quant_config,
+            prefix,
+        )
+        self.quant_config = quant_config
+        if bias:
+            self._register_bias()
+        else:
+            self.register_parameter("bias", None)
+
+    def _register_bias(self):
+        data = torch.empty(self.num_embeddings_per_partition, dtype=self.params_dtype)
+        self.bias = Parameter(data, requires_grad=False)
+        weight_attrs = dict(output_dim=0, weight_loader=self.weight_loader)
+        set_weight_attrs(weight=self.bias, weight_attrs=weight_attrs)
+
+    def tie_weights(self, embed_tokens: VocabParallelEmbedding):
+        """Tie the weights with word embeddings."""
+        return self.quant_method.tie_weights(self, embed_tokens)
+
+    def forward(self, input_):
+        del input_
+        raise RuntimeError("LMHead's weights should be used in the sampler.")

--- a/vllm_ascend/models/qwen4_exp_model_state.py
+++ b/vllm_ascend/models/qwen4_exp_model_state.py
@@ -1,0 +1,141 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Model-runner state for Qwen4Exp PLE inputs."""
+
+from typing import Any
+
+import torch
+import torch.nn as nn
+from vllm.config import VllmConfig
+from vllm.v1.worker.gpu.input_batch import InputBatch
+from vllm.v1.worker.gpu.mm.encoder_cache import EncoderCache
+from vllm.v1.worker.gpu.states import RequestState
+
+from vllm_ascend.worker.v2.model_states.mamba_hybrid import AscendMambaHybridModelState
+
+
+class AscendQwen4ExpModelState(AscendMambaHybridModelState):
+    """Add rollback-safe PLE n-gram context to the model inputs."""
+
+    def __init__(
+        self,
+        vllm_config: VllmConfig,
+        model: nn.Module,
+        encoder_cache: EncoderCache | None,
+        device: torch.device,
+    ) -> None:
+        super().__init__(vllm_config, model, encoder_cache, device)
+        config = self.model_config.hf_text_config
+        self.uses_ngram_embedding = bool(config.ple_layer_ids)
+        if not self.uses_ngram_embedding:
+            self.ngram_context_len = 0
+            self.ngram_eos_token_id = 0
+            return
+
+        if vllm_config.parallel_config.pipeline_parallel_size > 1:
+            raise RuntimeError(
+                "N-gram PLE embedding currently requires "
+                "pipeline_parallel_size=1 because non-first pipeline ranks do "
+                "not receive the raw input_ids required by PLE. Please run "
+                "with PP=1."
+            )
+
+        self.ngram_context_len = int(config.ngram_size) - 1
+        if self.ngram_context_len <= 0:
+            raise ValueError("N-gram embedding requires context length >= 1.")
+        self.ngram_eos_token_id = int(config.eos_token_id)
+        self.ngram_context = torch.full(
+            (self.max_num_reqs, self.ngram_context_len),
+            self.ngram_eos_token_id,
+            dtype=torch.int32,
+            device=self.device,
+        )
+        self.ngram_context_offsets = torch.arange(
+            -self.ngram_context_len,
+            0,
+            dtype=torch.int64,
+            device=self.device,
+        )
+        self.ple_query_start_loc = torch.zeros(
+            self.max_num_reqs + 1,
+            dtype=torch.int32,
+            device=self.device,
+        )
+
+    def _prepare_ngram_context(
+        self,
+        input_batch: InputBatch,
+        req_states: RequestState,
+    ) -> torch.Tensor:
+        num_reqs = input_batch.num_reqs
+        num_reqs_padded = input_batch.num_reqs_after_padding
+        context = self.ngram_context[:num_reqs_padded]
+        context.fill_(self.ngram_eos_token_id)
+        if num_reqs == 0:
+            return context
+
+        request_indices = input_batch.idx_mapping[:num_reqs].long()
+        context_end = req_states.num_computed_tokens.gpu[request_indices].long()
+        token_indices = context_end.unsqueeze(1) + self.ngram_context_offsets
+        valid_tokens = token_indices >= 0
+        token_indices.clamp_min_(0)
+        context_tokens = req_states.all_token_ids.gpu[request_indices.unsqueeze(1), token_indices]
+        context[:num_reqs].copy_(
+            torch.where(
+                valid_tokens,
+                context_tokens,
+                context_tokens.new_full((), self.ngram_eos_token_id),
+            )
+        )
+        return context
+
+    def prepare_inputs(
+        self,
+        input_batch: InputBatch,
+        req_states: RequestState,
+    ) -> dict[str, Any]:
+        model_inputs = super().prepare_inputs(input_batch, req_states)
+        if not self.uses_ngram_embedding:
+            return model_inputs
+
+        num_reqs_padded = input_batch.num_reqs_after_padding
+        query_start_loc = self.ple_query_start_loc[: num_reqs_padded + 1]
+        query_start_loc.copy_(input_batch.query_start_loc[: num_reqs_padded + 1])
+        model_inputs.update(
+            query_start_loc=query_start_loc,
+            ngram_context=self._prepare_ngram_context(input_batch, req_states),
+        )
+        return model_inputs
+
+    def prepare_dummy_inputs(
+        self,
+        num_reqs: int,
+        num_tokens: int,
+    ) -> dict[str, Any]:
+        model_inputs = super().prepare_dummy_inputs(num_reqs, num_tokens)
+        if not self.uses_ngram_embedding:
+            return model_inputs
+
+        query_start_loc = self.ple_query_start_loc[: num_reqs + 1]
+        query_start_loc[0] = 0
+        tokens_per_req, num_extra_tokens = divmod(num_tokens, num_reqs)
+        query_lens = torch.full(
+            (num_reqs,),
+            tokens_per_req,
+            dtype=query_start_loc.dtype,
+            device=query_start_loc.device,
+        )
+        if num_extra_tokens > 0:
+            query_lens[-num_extra_tokens:] += 1
+        torch.cumsum(query_lens, dim=0, out=query_start_loc[1:])
+
+        ngram_context = self.ngram_context[:num_reqs]
+        ngram_context.fill_(self.ngram_eos_token_id)
+        model_inputs.update(
+            query_start_loc=query_start_loc,
+            ngram_context=ngram_context,
+        )
+        return model_inputs
+
+
+__all__ = ["AscendQwen4ExpModelState"]

--- a/vllm_ascend/ops/gdn.py
+++ b/vllm_ascend/ops/gdn.py
@@ -27,6 +27,9 @@ from vllm.v1.attention.backend import AttentionBackend, AttentionMetadata  # typ
 from vllm.v1.attention.backends.gdn_attn import GDNAttentionMetadata
 from vllm.v1.attention.backends.utils import PAD_SLOT_ID
 
+from vllm_ascend._310p.ops.causal_conv1d import (
+    causal_conv1d_update as causal_conv1d_update_fallback,
+)
 from vllm_ascend.attention.utils import maybe_save_kv_layer_to_connector
 from vllm_ascend.device.device_op import DeviceOperator
 from vllm_ascend.ops.gdn_attn_builder import AscendGDNAttentionBackend
@@ -34,6 +37,53 @@ from vllm_ascend.ops.triton.fla.chunk import chunk_gated_delta_rule
 from vllm_ascend.ops.triton.fla.fused_qkvzba_split_reshape import fused_qkvzba_split_reshape_cat
 from vllm_ascend.ops.triton.fla.utils import clear_ssm_states
 from vllm_ascend.ops.triton.mamba.causal_conv1d import extract_last_width
+
+
+def _causal_conv1d_custom_with_fallback(
+    output: torch.Tensor,
+    x: torch.Tensor,
+    weight: torch.Tensor,
+    *,
+    conv_state: torch.Tensor,
+    bias_opt: torch.Tensor | None,
+    query_start_loc_opt: torch.Tensor | None,
+    cache_indices_opt: torch.Tensor | None,
+    initial_state_mode_opt: torch.Tensor | None,
+    num_accepted_tokens_opt: torch.Tensor | None,
+    activation_mode: int,
+    pad_slot_id: int,
+    run_mode: int,
+) -> None:
+    try:
+        torch.ops._C_ascend.npu_causal_conv1d_custom(
+            output,
+            x,
+            weight,
+            conv_state=conv_state,
+            bias_opt=bias_opt,
+            query_start_loc_opt=query_start_loc_opt,
+            cache_indices_opt=cache_indices_opt,
+            initial_state_mode_opt=initial_state_mode_opt,
+            num_accepted_tokens_opt=num_accepted_tokens_opt,
+            activation_mode=activation_mode,
+            pad_slot_id=pad_slot_id,
+            run_mode=run_mode,
+        )
+    except RuntimeError as exc:
+        if "aclnnCausalConv1d" not in str(exc):
+            raise
+        fallback_output = causal_conv1d_update_fallback(
+            x,
+            conv_state,
+            weight,
+            bias_opt,
+            activation=bool(activation_mode),
+            conv_state_indices=cache_indices_opt,
+            num_accepted_tokens=num_accepted_tokens_opt,
+            query_start_loc=query_start_loc_opt,
+            pad_slot_id=pad_slot_id,
+        )
+        output.copy_(fallback_output)
 
 
 class AscendGatedDeltaNetAttention(GatedDeltaNetAttention):
@@ -199,7 +249,7 @@ class AscendGatedDeltaNetAttention(GatedDeltaNetAttention):
             spec_causal_conv1d_meta = attn_metadata.spec_decode_metadata.spec_causal_conv1d
             spec_query_start_loc_device = spec_causal_conv1d_meta.query_start_loc
             output_spec = torch.empty_like(mixed_qkv_spec)
-            torch.ops._C_ascend.npu_causal_conv1d_custom(
+            _causal_conv1d_custom_with_fallback(
                 output_spec,
                 mixed_qkv_spec,
                 conv_weights_T,
@@ -246,7 +296,7 @@ class AscendGatedDeltaNetAttention(GatedDeltaNetAttention):
                             pcp_rank - 1, ...
                         ].transpose(-1, -2)
                     mixed_qkv_non_spec_output = torch.empty_like(mixed_qkv_non_spec)
-                    torch.ops._C_ascend.npu_causal_conv1d_custom(
+                    _causal_conv1d_custom_with_fallback(
                         mixed_qkv_non_spec_output,
                         mixed_qkv_non_spec,
                         conv_weights_T,
@@ -269,7 +319,7 @@ class AscendGatedDeltaNetAttention(GatedDeltaNetAttention):
                     conv_weights_T = conv_weights.transpose(0, 1)
                     activation_num = 1 if self.activation else 0
                     mixed_qkv_non_spec_output = torch.empty_like(mixed_qkv_non_spec)
-                    torch.ops._C_ascend.npu_causal_conv1d_custom(
+                    _causal_conv1d_custom_with_fallback(
                         mixed_qkv_non_spec_output,
                         mixed_qkv_non_spec,
                         conv_weights_T,
@@ -290,7 +340,7 @@ class AscendGatedDeltaNetAttention(GatedDeltaNetAttention):
             non_spec_causal_conv1d_meta = attn_metadata.non_spec_decode_metadata.causal_conv1d
             non_spec_query_start_loc_device = non_spec_causal_conv1d_meta.query_start_loc
             output_non_spec = torch.empty_like(mixed_qkv_non_spec)
-            torch.ops._C_ascend.npu_causal_conv1d_custom(
+            _causal_conv1d_custom_with_fallback(
                 output_non_spec,
                 mixed_qkv_non_spec,
                 conv_weights_T,

--- a/vllm_ascend/ops/triton/fla/chunk.py
+++ b/vllm_ascend/ops/triton/fla/chunk.py
@@ -16,6 +16,8 @@ from vllm.distributed import get_pcp_group
 from vllm.forward_context import get_forward_context
 from vllm.third_party.flash_linear_attention.ops.utils import SUPPRESS_LEVEL
 
+from vllm_ascend import envs
+
 from .chunk_delta_h import chunk_gated_delta_rule_fwd_h  # noqa: F401
 from .chunk_delta_hupdate import chunk_gated_delta_rule_fwd_hupdate
 from .chunk_o import chunk_fwd_o  # noqa: F401
@@ -25,6 +27,64 @@ from .l2norm import l2norm_fwd
 from .solve_tril import solve_tril
 from .utils import input_guard, prepare_final_chunk_indices
 from .wy_fast import recompute_w_u_fwd
+
+
+def _torch_gated_delta_rule_fwd(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    g: torch.Tensor,
+    beta: torch.Tensor,
+    scale: float,
+    initial_state: torch.Tensor,
+    cu_seqlens: torch.LongTensor | None,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Portable recurrence for images without the AscendC GDN kernels.
+
+    This path intentionally favors compatibility over performance.  It is used
+    only when the runtime reports that ``aclnnChunkGatedDeltaRuleFwdH`` is not
+    installed; current images continue to use the fused AscendC implementation.
+    """
+    batch, seq_len, num_heads, value_dim = v.shape
+    output = torch.empty(
+        (batch, seq_len, num_heads, value_dim), dtype=v.dtype, device=v.device
+    )
+    if cu_seqlens is None:
+        boundaries = tuple(range(0, (batch + 1) * seq_len, seq_len))
+    else:
+        boundaries = tuple(int(offset) for offset in cu_seqlens.tolist())
+
+    final_states = []
+    for sequence_idx, (start, end) in enumerate(zip(boundaries, boundaries[1:])):
+        state = initial_state[sequence_idx].float()
+        state_heads = state.shape[0]
+        for flat_idx in range(start, end):
+            batch_idx, token_idx = divmod(flat_idx, seq_len)
+            q_t = q[batch_idx, token_idx].float()
+            k_t = k[batch_idx, token_idx].float()
+            v_t = v[batch_idx, token_idx].float()
+            decay_t = g[batch_idx, token_idx].float().exp()
+            beta_t = beta[batch_idx, token_idx].float()
+
+            def expand_kv_heads(tensor: torch.Tensor) -> torch.Tensor:
+                if tensor.shape[0] == state_heads:
+                    return tensor
+                assert state_heads % tensor.shape[0] == 0
+                return tensor.repeat_interleave(state_heads // tensor.shape[0], dim=0)
+
+            q_t = expand_kv_heads(q_t)
+            k_t = expand_kv_heads(k_t)
+            decay_t = expand_kv_heads(decay_t)
+            beta_t = expand_kv_heads(beta_t)
+
+            state = state * decay_t[:, None, None]
+            residual = v_t - torch.einsum("hkv,hk->hv", state, k_t)
+            state = state + torch.einsum("hk,hv->hkv", k_t, beta_t[:, None] * residual)
+            output[batch_idx, token_idx] = (
+                torch.einsum("hkv,hk->hv", state, q_t) * scale
+            ).to(v.dtype)
+        final_states.append(state.to(initial_state.dtype))
+    return output, torch.stack(final_states)
 
 
 def chunk_gated_delta_rule_fwd(
@@ -39,13 +99,37 @@ def chunk_gated_delta_rule_fwd(
     cu_seqlens: torch.LongTensor | None = None,
     prebuilt_meta=None,
 ):
+    if envs.VLLM_ASCEND_FORCE_GDN_TORCH_FALLBACK:
+        o, final_state = _torch_gated_delta_rule_fwd(
+            q=q,
+            k=k,
+            v=v,
+            g=g,
+            beta=beta,
+            scale=scale,
+            initial_state=initial_state,
+            cu_seqlens=cu_seqlens,
+        )
+        placeholder = q.new_empty(0)
+        return g, o, placeholder, final_state, None, None, None
+
     forward_context = get_forward_context()
     num_decodes = 0
-    attn_metadata = forward_context.attn_metadata
-    if attn_metadata is not None and isinstance(attn_metadata, dict):
-        attn_metadata = next(iter(attn_metadata.values()), None)
-    if attn_metadata is not None:
-        num_decodes = attn_metadata.num_decodes
+    if prebuilt_meta is not None:
+        num_decodes = prebuilt_meta.num_decodes
+    else:
+        attn_metadata = forward_context.attn_metadata
+        if isinstance(attn_metadata, dict):
+            attn_metadata = next(
+                (
+                    metadata
+                    for metadata in attn_metadata.values()
+                    if hasattr(metadata, "num_decodes")
+                ),
+                None,
+            )
+        if attn_metadata is not None:
+            num_decodes = attn_metadata.num_decodes
     chunk_size = 64
     block_indices_cumsum = None if prebuilt_meta is None else prebuilt_meta.block_indices_cumsum
     cu_seqlens_host = None if prebuilt_meta is None else prebuilt_meta.cu_seqlens_host
@@ -55,6 +139,7 @@ def chunk_gated_delta_rule_fwd(
     update_chunk_offsets_chunk64 = None if prebuilt_meta is None else prebuilt_meta.update_chunk_offsets_chunk64
     final_chunk_indices_chunk64 = None if prebuilt_meta is None else prebuilt_meta.final_chunk_indices_chunk64
     chunk_indices_large_block = None if prebuilt_meta is None else prebuilt_meta.chunk_indices_large_block
+    g_raw = g
     g = chunk_local_cumsum(
         g,
         chunk_size=chunk_size,
@@ -112,21 +197,37 @@ def chunk_gated_delta_rule_fwd(
     else:
         cu_seqlens_kern, initial_state_kern = cu_seqlens_host, initial_state
         keep_meta = None
-    h, v_new, final_state = torch.ops._C_ascend.chunk_gated_delta_rule_fwd_h(
-        k_ascendc,
-        w_ascendc,
-        u_ascendc,
-        g=g_ascendc,
-        gk=None,
-        initial_state=initial_state_kern,
-        output_final_state=True,
-        chunk_size=64,
-        save_new_value=True,
-        cu_seqlens=cu_seqlens_kern,
-        chunk_indices=chunk_indices_chunk64_host,
-        use_exp2=False,
-        transpose_state_layout=False,
-    )
+    used_triton_h = False
+    try:
+        h, v_new, final_state = torch.ops._C_ascend.chunk_gated_delta_rule_fwd_h(
+            k_ascendc,
+            w_ascendc,
+            u_ascendc,
+            g=g_ascendc,
+            gk=None,
+            initial_state=initial_state_kern,
+            output_final_state=True,
+            chunk_size=64,
+            save_new_value=True,
+            cu_seqlens=cu_seqlens_kern,
+            chunk_indices=chunk_indices_chunk64_host,
+            use_exp2=False,
+            transpose_state_layout=False,
+        )
+    except RuntimeError as exc:
+        if "aclnnChunkGatedDeltaRuleFwdH" not in str(exc):
+            raise
+        o, final_state = _torch_gated_delta_rule_fwd(
+            q=q,
+            k=k,
+            v=v,
+            g=g_raw,
+            beta=beta,
+            scale=scale,
+            initial_state=initial_state,
+            cu_seqlens=cu_seqlens,
+        )
+        return g, o, A, final_state, None, None, None
     if keep_meta is not None:
         # Scatter the compacted final_state back to the original [N, H, K, V]
         # layout the PCP state recursion expects; empty segments keep their
@@ -194,23 +295,47 @@ def chunk_gated_delta_rule_fwd(
             h = h.transpose(1, 2).contiguous()
             v_new = v_new.transpose(1, 2).contiguous()
 
-    o_ascendc = torch.ops._C_ascend.chunk_fwd_o(
-        q_ascendc,
-        k_ascendc,
-        v_new,
-        h,
-        scale,
-        g=g_ascendc,
-        g_gamma=None,
-        cu_seqlens=cu_seqlens_host,
-        chunk_indices=chunk_indices_chunk64_host,
-        chunk_size=64,
-        transpose_state_layout=False,
-    )
+    used_triton_o = False
+    try:
+        o_ascendc = torch.ops._C_ascend.chunk_fwd_o(
+            q_ascendc,
+            k_ascendc,
+            v_new,
+            h,
+            scale,
+            g=g_ascendc,
+            g_gamma=None,
+            cu_seqlens=cu_seqlens_host,
+            chunk_indices=chunk_indices_chunk64_host,
+            chunk_size=64,
+            transpose_state_layout=False,
+        )
+    except RuntimeError as exc:
+        if "aclnnChunkFwdO" not in str(exc):
+            raise
+        h_triton = h if used_triton_h else h.transpose(1, 2).contiguous()
+        v_new_triton = (
+            v_new if used_triton_h else v_new.transpose(1, 2).contiguous()
+        )
+        o = chunk_fwd_o(
+            q=q,
+            k=k,
+            v=v_new_triton,
+            h=h_triton,
+            g=g,
+            scale=scale,
+            cu_seqlens=cu_seqlens,
+            chunk_size=64,
+            chunk_offsets=chunk_offsets_chunk64,
+        )
+        h = h_triton
+        v_new = v_new_triton
+        used_triton_o = True
 
-    o = o_ascendc.to(torch.bfloat16).transpose(1, 2).contiguous()
-    v_new = v_new.to(torch.bfloat16).transpose(1, 2).contiguous()
-    h = h.to(torch.bfloat16).transpose(1, 2).contiguous()
+    if not used_triton_o:
+        o = o_ascendc.to(torch.bfloat16).transpose(1, 2).contiguous()
+        v_new = v_new.to(torch.bfloat16).transpose(1, 2).contiguous()
+        h = h.to(torch.bfloat16).transpose(1, 2).contiguous()
 
     if SUPPRESS_LEVEL < 3:
         return g, o, A, final_state, None, None, None

--- a/vllm_ascend/ops/triton/qwen4_exp/__init__.py
+++ b/vllm_ascend/ops/triton/qwen4_exp/__init__.py
@@ -1,0 +1,1 @@
+"""Ascend kernels used by the experimental Qwen3.8 Flash-Next model."""

--- a/vllm_ascend/ops/triton/qwen4_exp/hc.py
+++ b/vllm_ascend/ops/triton/qwen4_exp/hc.py
@@ -1,0 +1,81 @@
+"""Torch implementations of the Qwen4Exp HyperConnection glue operations.
+
+The CUDA implementation uses PDL-enabled Triton kernels.  Keeping these
+small elementwise operations in PyTorch lets torch-npu compile them into the
+surrounding graph without importing CUDA-only ``tl.extra.cuda`` primitives.
+"""
+
+import torch
+import torch.nn.functional as F
+
+
+def grouped_gemma_rmsnorm(
+    x: torch.Tensor,
+    weight: torch.Tensor,
+    eps: float,
+    num_groups: int,
+) -> torch.Tensor:
+    rows, dim = x.shape
+    if dim % num_groups:
+        raise ValueError(f"hidden dimension {dim} is not divisible by {num_groups}")
+    group_dim = dim // num_groups
+    grouped = x.float().view(rows, num_groups, group_dim)
+    normalized = grouped * torch.rsqrt(grouped.square().mean(-1, keepdim=True) + eps)
+    if weight.numel() == group_dim:
+        affine = weight.float().view(1, 1, group_dim)
+    elif weight.numel() == dim:
+        affine = weight.float().view(1, num_groups, group_dim)
+    else:
+        raise ValueError(f"expected {group_dim} or {dim} norm weights, got {weight.numel()}")
+    return (normalized * (1 + affine)).to(x.dtype).view_as(x)
+
+
+def hc_silu(x: torch.Tensor, hc_count: int) -> torch.Tensor:
+    return F.silu(x.float() / hc_count).to(x.dtype)
+
+
+def hc_gate_mix(
+    x: torch.Tensor,
+    gate: torch.Tensor,
+    hc_count: int,
+) -> torch.Tensor:
+    if x.shape != gate.shape:
+        raise ValueError("HyperConnection input and gate shapes must match")
+    group_dim = x.shape[-1] // hc_count
+    mixed = torch.sigmoid(gate.float()) * x.float()
+    return mixed.view(-1, hc_count, group_dim).mean(1).to(x.dtype)
+
+
+def hc_combine(
+    residual: torch.Tensor,
+    block_output: torch.Tensor,
+    injection_logits: torch.Tensor,
+    hc_count: int,
+) -> torch.Tensor:
+    group_dim = residual.shape[-1] // hc_count
+    injection = 2 * torch.sigmoid(injection_logits.float() / hc_count)
+    combined = residual.float().view(-1, hc_count, group_dim)
+    combined = combined + block_output.float().unsqueeze(1) * injection.unsqueeze(-1)
+    return combined.to(residual.dtype).view_as(residual)
+
+
+def hc_combine_norm(
+    residual: torch.Tensor,
+    block_output: torch.Tensor,
+    injection_logits: torch.Tensor,
+    norm_weight: torch.Tensor,
+    eps: float,
+    hc_count: int,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    combined = hc_combine(residual, block_output, injection_logits, hc_count)
+    normalized = grouped_gemma_rmsnorm(combined, norm_weight, eps, hc_count)
+    return combined, normalized
+
+
+__all__ = [
+    "grouped_gemma_rmsnorm",
+    "hc_combine",
+    "hc_combine_norm",
+    "hc_gate_mix",
+    "hc_silu",
+]

--- a/vllm_ascend/ops/triton/qwen4_exp/qsa.py
+++ b/vllm_ascend/ops/triton/qwen4_exp/qsa.py
@@ -1,0 +1,1036 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Triton kernels for the Qwen4Exp weight-free QSA path.
+
+Adapted from ``vllm/models/qwen4_exp/nvidia/ops/qsa.py``.  The kernels are
+shared with upstream; device validation and top-k dispatch are specialized
+for triton-ascend and torch-npu.
+"""
+
+from __future__ import annotations
+
+import math
+
+import torch
+from vllm.triton_utils import HAS_TRITON, tl, triton
+
+_LOGITS_WORKSPACE_BYTES = 128 * 1024 * 1024
+
+
+@triton.jit
+def _qsa_mqa_paged_kernel(
+    q_ptr,
+    k_cache_ptr,
+    page_table_ptr,
+    token_to_req_ptr,
+    query_positions_ptr,
+    sequence_lengths_ptr,
+    visible_blocks_ptr,
+    logits_ptr,
+    stride_q_row,
+    stride_q_head,
+    stride_q_dim,
+    stride_cache_block,
+    stride_cache_token,
+    stride_cache_dim,
+    stride_table_req,
+    stride_table_page,
+    stride_logits_row,
+    num_rows,
+    num_columns,
+    num_pages,
+    num_requests,
+    score_divisor,
+    PAGE_SIZE: tl.constexpr,
+    PAGE_TABLE_WIDTH: tl.constexpr,
+    NUM_HEADS: tl.constexpr,
+    HEAD_DIM: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+    BLOCK_D: tl.constexpr,
+    TILES_PER_PROG: tl.constexpr,
+    STAGES: tl.constexpr,
+    MAX_N: tl.constexpr,
+    COMPRESS_RATIO: tl.constexpr,
+) -> None:
+    row = tl.program_id(0)
+    dims = tl.arange(0, BLOCK_D)
+    heads = tl.arange(0, MAX_N)
+    request = tl.load(token_to_req_ptr + row)
+    safe_request = tl.minimum(tl.maximum(request, 0), num_requests - 1)
+    query_position = tl.load(query_positions_ptr + row)
+    sequence_length = tl.load(
+        sequence_lengths_ptr + safe_request,
+        mask=(request >= 0) & (request < num_requests),
+        other=0,
+    )
+    visible = tl.minimum(
+        (query_position + 1) // COMPRESS_RATIO,
+        sequence_length // COMPRESS_RATIO,
+    )
+    if tl.program_id(1) == 0:
+        tl.store(visible_blocks_ptr + row, visible)
+    tile_start = tl.program_id(1) * TILES_PER_PROG
+    # Top-k is bounded by visible_blocks, so columns beyond it need no value.
+    if tile_start * BLOCK_N >= visible:
+        return
+    tile_end = tl.minimum(tile_start + TILES_PER_PROG, tl.cdiv(visible, BLOCK_N))
+    tile_end = tl.minimum(tile_end, tl.cdiv(num_columns, BLOCK_N))
+
+    # Pad the small head axis to a tensor-core-compatible N dimension.
+    query = tl.load(
+        q_ptr + row * stride_q_row + heads[None, :] * stride_q_head + dims[:, None] * stride_q_dim,
+        mask=(heads[None, :] < NUM_HEADS) & (dims[:, None] < HEAD_DIM),
+        other=0.0,
+    )
+    column_offsets = tl.arange(0, BLOCK_N)
+    for tile in tl.range(tile_start, tile_end, num_stages=STAGES):
+        columns = tile * BLOCK_N + column_offsets
+        live = columns < visible
+        logical_page = tl.minimum(columns // PAGE_SIZE, PAGE_TABLE_WIDTH - 1)
+        page_offset = columns % PAGE_SIZE
+        physical_page = tl.load(
+            page_table_ptr + safe_request * stride_table_req + logical_page * stride_table_page,
+            mask=live,
+            other=-1,
+        )
+        page_valid = live & (physical_page >= 0) & (physical_page < num_pages)
+        # physical_page * block stride can overflow int32 for large caches.
+        safe_physical_page = tl.maximum(physical_page, 0).to(tl.int64)
+        keys = tl.load(
+            k_cache_ptr
+            + safe_physical_page[:, None] * stride_cache_block
+            + page_offset[:, None] * stride_cache_token
+            + dims[None, :] * stride_cache_dim,
+            mask=page_valid[:, None] & (dims[None, :] < HEAD_DIM),
+            other=0.0,
+            eviction_policy="evict_first",
+        )
+        scores = tl.dot(keys, query, out_dtype=tl.float32)
+        scores = tl.where(heads[None, :] < NUM_HEADS, tl.maximum(scores, 0.0), 0.0)
+        score = tl.sum(scores, axis=1) / score_divisor
+        tl.store(
+            logits_ptr + row * stride_logits_row + columns,
+            tl.where(page_valid, score, -float("inf")),
+            mask=live & (columns < num_columns),
+        )
+
+
+@triton.jit
+def _expand_qsa_indices_kernel(
+    block_indices_ptr,
+    query_positions_ptr,
+    sequence_lengths_ptr,
+    token_to_req_ptr,
+    output_ptr,
+    stride_blocks_row,
+    stride_blocks_column,
+    stride_output_row,
+    stride_output_column,
+    rows,
+    num_requests,
+    BLOCK_TOPK: tl.constexpr,
+    COMPRESS_RATIO: tl.constexpr,
+    TOKEN_TOPK: tl.constexpr,
+    OUTPUT_WIDTH: tl.constexpr,
+    COLUMN_BLOCK: tl.constexpr,
+) -> None:
+    row = tl.program_id(0)
+    columns = tl.program_id(1) * COLUMN_BLOCK + tl.arange(0, COLUMN_BLOCK)
+    query_position = tl.load(query_positions_ptr + row)
+    request = tl.load(token_to_req_ptr + row)
+    safe_request = tl.minimum(tl.maximum(request, 0), num_requests - 1)
+    sequence_length = tl.load(
+        sequence_lengths_ptr + safe_request,
+        mask=(request >= 0) & (request < num_requests),
+        other=0,
+    )
+    complete_blocks = tl.minimum(
+        tl.minimum(
+            (query_position + 1) // COMPRESS_RATIO,
+            sequence_length // COMPRESS_RATIO,
+        ),
+        BLOCK_TOPK,
+    )
+    expanded_count = complete_blocks * COMPRESS_RATIO
+    tail_start = ((query_position + 1) // COMPRESS_RATIO) * COMPRESS_RATIO
+    tail_count = (query_position + 1) - tail_start
+
+    is_expanded = columns < expanded_count
+    block_rank = columns // COMPRESS_RATIO
+    offset = columns % COMPRESS_RATIO
+    safe_rank = tl.minimum(block_rank, BLOCK_TOPK - 1)
+    block = tl.load(
+        block_indices_ptr + row * stride_blocks_row + safe_rank * stride_blocks_column,
+        mask=(row < rows) & is_expanded,
+        other=-1,
+    )
+    expanded = block * COMPRESS_RATIO + offset
+    tail_offset = columns - expanded_count
+    is_tail = (columns >= expanded_count) & (tail_offset < tail_count) & (tail_offset < COMPRESS_RATIO - 1)
+    token = tl.where(is_expanded, expanded, tail_start + tail_offset)
+    valid = (row < rows) & (columns < OUTPUT_WIDTH) & (is_expanded | is_tail) & (token >= 0) & (token < sequence_length)
+    tl.store(
+        output_ptr + row * stride_output_row + columns * stride_output_column,
+        tl.where(valid, token, -1),
+        mask=(row < rows) & (columns < OUTPUT_WIDTH),
+    )
+
+
+@triton.jit
+def _qsa_sparse_paged_gqa_splitk_kernel(
+    q_ptr,
+    k_cache_ptr,
+    v_cache_ptr,
+    indices_ptr,
+    block_table_ptr,
+    token_to_req_ptr,
+    partial_output_ptr,
+    partial_lse_ptr,
+    output_ptr,
+    stride_q_row,
+    stride_q_head,
+    stride_k_block,
+    stride_k_token,
+    stride_k_head,
+    stride_v_block,
+    stride_v_token,
+    stride_v_head,
+    stride_indices_row,
+    stride_table_req,
+    stride_output_row,
+    stride_output_head,
+    num_rows,
+    num_cache_blocks,
+    num_requests,
+    TOPK: tl.constexpr,
+    PAGE_SIZE: tl.constexpr,
+    PAGE_TABLE_WIDTH: tl.constexpr,
+    GROUP_SIZE: tl.constexpr,
+    HEAD_DIM: tl.constexpr,
+    NUM_QUERY_HEADS: tl.constexpr,
+    NUM_SPLITS: tl.constexpr,
+    NUM_TILES: tl.constexpr,
+    BLOCK_M: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+) -> None:
+    row = tl.program_id(0)
+    kv_head = tl.program_id(1)
+    split_id = tl.program_id(2)
+    request = tl.load(token_to_req_ptr + row)
+    safe_request = tl.minimum(tl.maximum(request, 0), num_requests - 1)
+
+    head_offsets = tl.arange(0, BLOCK_M)
+    dim_offsets = tl.arange(0, HEAD_DIM)
+    column_offsets = tl.arange(0, BLOCK_N)
+    first_head = kv_head * GROUP_SIZE
+    query = tl.load(
+        q_ptr + row * stride_q_row + (first_head + head_offsets[:, None]) * stride_q_head + dim_offsets[None, :],
+        mask=head_offsets[:, None] < GROUP_SIZE,
+        other=0.0,
+    )
+
+    max_value = tl.full((BLOCK_M,), -1.0e20, dtype=tl.float32)
+    normalizer = tl.zeros((BLOCK_M,), dtype=tl.float32)
+    accumulator = tl.zeros((BLOCK_M, HEAD_DIM), dtype=tl.float32)
+    softmax_scale_log2: tl.constexpr = (HEAD_DIM**-0.5) * 1.4426950408889634
+
+    # Dynamic bounds avoid padded main-loop iterations for uneven splits.
+    split_tile_start = split_id * NUM_TILES // NUM_SPLITS
+    split_tile_end = (split_id + 1) * NUM_TILES // NUM_SPLITS
+    for tile in range(split_tile_start, split_tile_end):
+        columns = tile * BLOCK_N + column_offsets
+        logical_token = tl.load(
+            indices_ptr + row * stride_indices_row + columns,
+            mask=columns < TOPK,
+            other=-1,
+        )
+        safe_token = tl.maximum(logical_token, 0)
+        logical_page = safe_token // PAGE_SIZE
+        page_offset = safe_token % PAGE_SIZE
+        valid = (request >= 0) & (request < num_requests) & (logical_token >= 0) & (logical_page < PAGE_TABLE_WIDTH)
+        physical_page = tl.load(
+            block_table_ptr + safe_request * stride_table_req + tl.minimum(logical_page, PAGE_TABLE_WIDTH - 1),
+            mask=valid,
+            other=-1,
+        )
+        valid &= (physical_page >= 0) & (physical_page < num_cache_blocks)
+        # physical_page * block stride can overflow int32 for large caches.
+        safe_page = tl.maximum(physical_page, 0).to(tl.int64)
+        keys = tl.load(
+            k_cache_ptr
+            + safe_page[None, :] * stride_k_block
+            + page_offset[None, :] * stride_k_token
+            + kv_head * stride_k_head
+            + dim_offsets[:, None],
+            mask=valid[None, :],
+            other=0.0,
+        )
+        values = tl.load(
+            v_cache_ptr
+            + safe_page[:, None] * stride_v_block
+            + page_offset[:, None] * stride_v_token
+            + kv_head * stride_v_head
+            + dim_offsets[None, :],
+            mask=valid[:, None],
+            other=0.0,
+        )
+        scores = tl.dot(query, keys)
+        # Scaling scores avoids re-quantizing a scaled query to BF16.
+        scores *= softmax_scale_log2
+        scores = tl.where(valid[None, :], scores, -1.0e20)
+        next_max = tl.maximum(max_value, tl.max(scores, axis=1))
+        alpha = tl.math.exp2(max_value - next_max)
+        probabilities = tl.where(valid[None, :], tl.math.exp2(scores - next_max[:, None]), 0.0)
+        accumulator = tl.dot(
+            probabilities.to(values.dtype),
+            values,
+            acc=accumulator * alpha[:, None],
+        )
+        normalizer = normalizer * alpha + tl.sum(probabilities, axis=1)
+        max_value = next_max
+
+    has_values = normalizer > 0
+    normalized_output = tl.where(
+        has_values[:, None],
+        accumulator / tl.maximum(normalizer[:, None], 1.0e-20),
+        0.0,
+    )
+    output_mask = head_offsets[:, None] < GROUP_SIZE
+    if NUM_SPLITS == 1:
+        tl.store(
+            output_ptr
+            + row * stride_output_row
+            + (first_head + head_offsets[:, None]) * stride_output_head
+            + dim_offsets[None, :],
+            normalized_output,
+            mask=output_mask,
+        )
+    else:
+        partial_lse = tl.where(
+            has_values,
+            max_value + tl.math.log2(tl.maximum(normalizer, 1.0e-20)),
+            -float("inf"),
+        )
+        tl.store(
+            partial_output_ptr
+            + ((split_id * num_rows + row) * NUM_QUERY_HEADS + first_head + head_offsets[:, None]) * HEAD_DIM
+            + dim_offsets[None, :],
+            normalized_output,
+            mask=output_mask,
+        )
+        tl.store(
+            partial_lse_ptr + (split_id * num_rows + row) * NUM_QUERY_HEADS + first_head + head_offsets,
+            partial_lse,
+            mask=head_offsets < GROUP_SIZE,
+        )
+
+
+@triton.jit
+def _qsa_merge_splitk_kernel(
+    partial_output_ptr,
+    partial_lse_ptr,
+    output_ptr,
+    stride_output_row,
+    stride_output_head,
+    num_rows,
+    HEAD_DIM: tl.constexpr,
+    NUM_QUERY_HEADS: tl.constexpr,
+    NUM_SPLITS: tl.constexpr,
+    BLOCK_SPLITS: tl.constexpr,
+) -> None:
+    row = tl.program_id(0)
+    head = tl.program_id(1)
+    split_offsets = tl.arange(0, BLOCK_SPLITS)
+    dim_offsets = tl.arange(0, HEAD_DIM)
+    split_mask = split_offsets < NUM_SPLITS
+    lse = tl.load(
+        partial_lse_ptr + (split_offsets * num_rows + row) * NUM_QUERY_HEADS + head,
+        mask=split_mask,
+        other=-float("inf"),
+    )
+    lse_max = tl.max(lse, axis=0)
+    has_values = lse_max > -float("inf")
+    shifted = tl.where(split_mask & has_values, lse - lse_max, -float("inf"))
+    weights = tl.math.exp2(shifted)
+    denominator = tl.sum(weights, axis=0)
+    partial_output = tl.load(
+        partial_output_ptr
+        + ((split_offsets[:, None] * num_rows + row) * NUM_QUERY_HEADS + head) * HEAD_DIM
+        + dim_offsets[None, :],
+        mask=split_mask[:, None],
+        other=0.0,
+    )
+    merged = tl.sum(partial_output * weights[:, None], axis=0)
+    merged = tl.where(denominator > 0, merged / denominator, 0.0)
+    tl.store(
+        output_ptr + row * stride_output_row + head * stride_output_head + dim_offsets,
+        merged,
+    )
+
+
+@triton.jit
+def _store_qsa_rows_kernel(
+    cache_ptr,
+    slots_ptr,
+    rows_ptr,
+    stride_cache_block,
+    stride_cache_token,
+    stride_cache_dim,
+    stride_rows_row,
+    stride_rows_dim,
+    num_rows,
+    num_blocks,
+    PAGE_SIZE: tl.constexpr,
+    WIDTH: tl.constexpr,
+    BLOCK_D: tl.constexpr,
+) -> None:
+    row = tl.program_id(0)
+    dims = tl.arange(0, BLOCK_D)
+    slot = tl.load(slots_ptr + row)
+    valid = (row < num_rows) & (slot >= 0) & (slot < num_blocks * PAGE_SIZE)
+    block = tl.maximum(slot, 0) // PAGE_SIZE
+    token = tl.maximum(slot, 0) % PAGE_SIZE
+    values = tl.load(
+        rows_ptr + row * stride_rows_row + dims * stride_rows_dim,
+        mask=valid & (dims < WIDTH),
+        other=0,
+    )
+    tl.store(
+        cache_ptr + block * stride_cache_block + token * stride_cache_token + dims * stride_cache_dim,
+        values,
+        mask=valid & (dims < WIDTH),
+    )
+
+
+@triton.jit
+def _compress_qsa_groups_kernel(
+    raw_keys_ptr,  # this step's raw key rows, straight from activations
+    raw_positions_ptr,  # this step's per-token positions
+    compressor_state_cache_ptr,  # per-request ring of previous raw keys
+    rope_cache_ptr,  # packed RoPE position tail of the ring
+    compressor_state_table_ptr,
+    token_to_req_ptr,
+    query_start_loc_ptr,
+    logical_positions_ptr,
+    compressed_slots_ptr,
+    pooled_ptr,
+    first_positions_ptr,
+    stride_raw_row,
+    stride_raw_dim,
+    stride_raw_positions_row,
+    stride_raw_positions_dim,
+    stride_compressor_state_block,
+    stride_compressor_state_token,
+    stride_compressor_state_dim,
+    stride_rope_block,
+    stride_rope_token,
+    stride_rope_dim,
+    stride_compressor_state_table_req,
+    stride_pooled_row,
+    stride_pooled_dim,
+    stride_positions_row,
+    stride_positions_dim,
+    num_rows,
+    num_compressor_state_blocks,
+    num_requests,
+    COMPRESSOR_STATE_SIZE: tl.constexpr,
+    COMPRESS_RATIO: tl.constexpr,
+    HEAD_DIM: tl.constexpr,
+    BLOCK_D: tl.constexpr,
+    LOAD_ROPE_POSITIONS: tl.constexpr,
+) -> None:
+    row = tl.program_id(0)
+    dims = tl.arange(0, BLOCK_D)
+    request = tl.load(token_to_req_ptr + row)
+    end_position = tl.load(logical_positions_ptr + row)
+    compressed_slot = tl.load(compressed_slots_ptr + row)
+    valid_request = (request >= 0) & (request < num_requests)
+    safe_request = tl.minimum(tl.maximum(request, 0), num_requests - 1)
+    query_row_start = tl.load(query_start_loc_ptr + safe_request, mask=valid_request, other=0)
+    query_row_end = tl.load(query_start_loc_ptr + safe_request + 1, mask=valid_request, other=0)
+    chunk_start_position = end_position - (row - query_row_start)
+    compressor_state_block = tl.load(
+        compressor_state_table_ptr + safe_request * stride_compressor_state_table_req,
+        mask=valid_request,
+        other=-1,
+    )
+    valid_compressor_state_block = (compressor_state_block >= 0) & (
+        compressor_state_block < num_compressor_state_blocks
+    )
+    valid_row = (
+        (row < num_rows)
+        & valid_request
+        & (row >= query_row_start)
+        & (row < query_row_end)
+        & (end_position >= COMPRESS_RATIO - 1)
+        & (compressed_slot >= 0)
+    )
+    accumulator = tl.zeros((BLOCK_D,), dtype=tl.float32)
+
+    # A group can span the compressor-state ring (older members) and this
+    # step's raw rows (members at positions >= chunk_start_position).
+    for group_offset in tl.range(0, COMPRESS_RATIO):
+        position = end_position - (COMPRESS_RATIO - 1 - group_offset)
+        use_raw = position >= chunk_start_position
+        raw_row = query_row_start + position - chunk_start_position
+        raw_values = tl.load(
+            raw_keys_ptr + raw_row * stride_raw_row + dims * stride_raw_dim,
+            mask=valid_row
+            & use_raw
+            & (raw_row >= query_row_start)
+            & (raw_row < query_row_end)
+            & (raw_row < num_rows)
+            & (dims < HEAD_DIM),
+            other=0.0,
+        ).to(tl.float32)
+        compressor_state_values = tl.load(
+            compressor_state_cache_ptr
+            + tl.maximum(compressor_state_block, 0).to(tl.int64) * stride_compressor_state_block
+            + (position % COMPRESSOR_STATE_SIZE) * stride_compressor_state_token
+            + dims * stride_compressor_state_dim,
+            mask=valid_row & ~use_raw & valid_compressor_state_block & (dims < HEAD_DIM),
+            other=0.0,
+        ).to(tl.float32)
+        accumulator += tl.where(use_raw, raw_values, compressor_state_values)
+
+    tl.store(
+        pooled_ptr + row * stride_pooled_row + dims * stride_pooled_dim,
+        accumulator / COMPRESS_RATIO,
+        mask=(row < num_rows) & (dims < HEAD_DIM),
+    )
+
+    position_dims = tl.arange(0, 4)
+    first_position = end_position - COMPRESS_RATIO + 1
+    if LOAD_ROPE_POSITIONS:
+        first_from_raw = first_position >= chunk_start_position
+        raw_first_row = query_row_start + first_position - chunk_start_position
+        raw_position_values = tl.load(
+            raw_positions_ptr + raw_first_row * stride_raw_positions_row + position_dims * stride_raw_positions_dim,
+            mask=valid_row
+            & first_from_raw
+            & (raw_first_row >= query_row_start)
+            & (raw_first_row < query_row_end)
+            & (raw_first_row < num_rows)
+            & (position_dims < 3),
+            other=0,
+        )
+        compressor_state_position_values = tl.load(
+            rope_cache_ptr
+            + tl.maximum(compressor_state_block, 0).to(tl.int64) * stride_rope_block
+            + (first_position % COMPRESSOR_STATE_SIZE) * stride_rope_token
+            + position_dims * stride_rope_dim,
+            mask=valid_row & ~first_from_raw & valid_compressor_state_block & (position_dims < 3),
+            other=0,
+        )
+        position_values = tl.where(
+            first_from_raw,
+            raw_position_values,
+            compressor_state_position_values,
+        )
+    else:
+        position_values = tl.where(valid_row, first_position, 0)
+    tl.store(
+        first_positions_ptr + row * stride_positions_row + position_dims * stride_positions_dim,
+        position_values,
+        mask=(row < num_rows) & (position_dims < 3),
+    )
+
+
+def _validate_mqa(q: torch.Tensor) -> None:
+    if q.ndim != 3 or q.shape[1] <= 0 or q.shape[2] <= 0:
+        raise ValueError("QSA query must be [rows, heads, head_dim]")
+
+
+def qsa_mqa_paged(
+    q: torch.Tensor,
+    k_cache: torch.Tensor,
+    page_table: torch.Tensor,
+    token_to_req: torch.Tensor,
+    query_positions: torch.Tensor,
+    sequence_lengths: torch.Tensor,
+    compress_ratio: int,
+    num_columns: int | None = None,
+    score_scale: float | None = None,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Compute QSA scores directly from a paged compressed-key cache."""
+
+    _validate_mqa(q)
+    if q.device.type != "npu" or not HAS_TRITON:
+        raise RuntimeError("paged QSA scoring requires NPU and Triton")
+    if k_cache.ndim != 4 or k_cache.shape[2] != 1:
+        raise ValueError("QSA cache must be [pages, page_size, 1, head_dim]")
+    if k_cache.shape[3] != q.shape[2]:
+        raise ValueError("QSA query and cache dimensions must match")
+    if page_table.ndim != 2:
+        raise ValueError("QSA page table must be two-dimensional")
+    if q.shape[0] and (not all(k_cache.shape[:2]) or not all(page_table.shape)):
+        raise ValueError("QSA paged scoring cache and page table must be nonempty")
+    if token_to_req.shape != (q.shape[0],):
+        raise ValueError("QSA request mapping must match query rows")
+    if query_positions.shape != (q.shape[0],):
+        raise ValueError("QSA query positions must match query rows")
+    if sequence_lengths.shape != (page_table.shape[0],):
+        raise ValueError("QSA sequence lengths must match page-table requests")
+    if compress_ratio <= 0:
+        raise ValueError("QSA compression ratio must be positive")
+    score_divisor = math.sqrt(q.shape[2]) if score_scale is None else score_scale
+    if score_divisor <= 0:
+        raise ValueError("QSA score scale must be positive")
+
+    capacity = page_table.shape[1] * k_cache.shape[1]
+    columns = capacity if num_columns is None else num_columns
+    if columns < 0:
+        raise ValueError("QSA score width must be non-negative")
+    logits = torch.empty((q.shape[0], columns), dtype=torch.float32, device=q.device)
+    visible_blocks = torch.empty(q.shape[0], dtype=torch.int32, device=q.device)
+    if not q.shape[0] or not columns:
+        return logits, visible_blocks
+    BLOCK_N = 64
+    BLOCK_D = max(16, triton.next_power_of_2(q.shape[2]))
+    MAX_N = max(16, triton.next_power_of_2(q.shape[1]))
+    # Tuned on GB300: larger row batches provide enough parallelism to reuse Q.
+    tiles_per_program = 1 if q.shape[0] <= 32 else 8
+    _qsa_mqa_paged_kernel[(q.shape[0], triton.cdiv(columns, BLOCK_N * tiles_per_program))](
+        q,
+        k_cache,
+        page_table,
+        token_to_req,
+        query_positions,
+        sequence_lengths,
+        visible_blocks,
+        logits,
+        q.stride(0),
+        q.stride(1),
+        q.stride(2),
+        k_cache.stride(0),
+        k_cache.stride(1),
+        k_cache.stride(3),
+        page_table.stride(0),
+        page_table.stride(1),
+        logits.stride(0),
+        q.shape[0],
+        columns,
+        k_cache.shape[0],
+        page_table.shape[0],
+        float(score_divisor),
+        PAGE_SIZE=k_cache.shape[1],
+        PAGE_TABLE_WIDTH=page_table.shape[1],
+        NUM_HEADS=q.shape[1],
+        HEAD_DIM=q.shape[2],
+        BLOCK_N=BLOCK_N,
+        BLOCK_D=BLOCK_D,
+        TILES_PER_PROG=tiles_per_program,
+        STAGES=2,
+        MAX_N=MAX_N,
+        COMPRESS_RATIO=compress_ratio,
+        num_warps=2,
+    )
+    return logits, visible_blocks
+
+
+def expand_qsa_block_indices_npu(
+    block_indices: torch.Tensor,
+    query_positions: torch.Tensor,
+    sequence_lengths: torch.Tensor,
+    token_to_req: torch.Tensor,
+    compress_ratio: int,
+    token_topk: int,
+    out: torch.Tensor | None = None,
+) -> torch.Tensor:
+    """Expand compressed blocks and compact the causal tail of the open group."""
+
+    if block_indices.device.type != "npu" or not HAS_TRITON:
+        raise RuntimeError("QSA NPU expansion requires Triton")
+    if token_topk % compress_ratio:
+        raise ValueError("QSA token top-k must be divisible by compression ratio")
+    block_topk = token_topk // compress_ratio
+    output_width = token_topk + compress_ratio - 1
+    if block_indices.shape != (query_positions.numel(), block_topk):
+        raise ValueError("QSA compressed top-k has an invalid shape")
+    if token_to_req.shape != query_positions.shape:
+        raise ValueError("QSA request mapping must match query positions")
+    if sequence_lengths.ndim != 1 or not sequence_lengths.shape[0]:
+        raise ValueError("QSA request sequence lengths must be nonempty")
+    if out is None:
+        out = torch.empty(
+            (block_indices.shape[0], output_width),
+            dtype=torch.int32,
+            device=block_indices.device,
+        )
+    elif out.shape != (block_indices.shape[0], output_width):
+        raise ValueError("QSA expansion output has an invalid shape")
+    if not block_indices.shape[0]:
+        return out
+    column_block = 256
+    _expand_qsa_indices_kernel[(block_indices.shape[0], triton.cdiv(output_width, column_block))](
+        block_indices,
+        query_positions,
+        sequence_lengths,
+        token_to_req,
+        out,
+        block_indices.stride(0),
+        block_indices.stride(1),
+        out.stride(0),
+        out.stride(1),
+        block_indices.shape[0],
+        sequence_lengths.shape[0],
+        BLOCK_TOPK=block_topk,
+        COMPRESS_RATIO=compress_ratio,
+        TOKEN_TOPK=token_topk,
+        OUTPUT_WIDTH=output_width,
+        COLUMN_BLOCK=column_block,
+        num_warps=4,
+    )
+    return out
+
+
+def qsa_select_paged_tokens(
+    q: torch.Tensor,
+    k_cache: torch.Tensor,
+    page_table: torch.Tensor,
+    token_to_req: torch.Tensor,
+    query_positions: torch.Tensor,
+    sequence_lengths: torch.Tensor,
+    token_topk: int,
+    compress_ratio: int,
+    out: torch.Tensor | None = None,
+) -> torch.Tensor:
+    """Score, select, and expand QSA indices without host synchronization."""
+
+    rows = q.shape[0]
+    output_width = token_topk + compress_ratio - 1
+    if out is None:
+        out = torch.empty((rows, output_width), dtype=torch.int32, device=q.device)
+    if out.shape != (rows, output_width):
+        raise ValueError("QSA selection output has an invalid shape")
+    if not rows:
+        return out
+
+    columns = page_table.shape[1] * k_cache.shape[1]
+    block_topk = token_topk // compress_ratio
+    rows_per_chunk = max(1, _LOGITS_WORKSPACE_BYTES // max(columns * 4, 1))
+    chunk_rows = min(rows, rows_per_chunk)
+    blocks_buffer = torch.empty((chunk_rows, block_topk), dtype=torch.int32, device=q.device)
+    for row_start in range(0, rows, rows_per_chunk):
+        row_end = min(row_start + rows_per_chunk, rows)
+        row_slice = slice(row_start, row_end)
+        logits, visible_blocks = qsa_mqa_paged(
+            q[row_slice],
+            k_cache,
+            page_table,
+            token_to_req[row_slice],
+            query_positions[row_slice],
+            sequence_lengths,
+            compress_ratio,
+        )
+        blocks = blocks_buffer[: row_end - row_start]
+        blocks.copy_(torch.topk(logits, block_topk, dim=-1).indices.to(torch.int32))
+        topk_rank = torch.arange(block_topk, device=q.device)
+        blocks.masked_fill_(
+            topk_rank.unsqueeze(0) >= visible_blocks.unsqueeze(1),
+            -1,
+        )
+        expand_qsa_block_indices_npu(
+            blocks,
+            query_positions[row_slice],
+            sequence_lengths,
+            token_to_req[row_slice],
+            compress_ratio,
+            token_topk,
+            out[row_slice],
+        )
+    return out
+
+
+def qsa_sparse_paged_attention(
+    q: torch.Tensor,
+    k_cache: torch.Tensor,
+    v_cache: torch.Tensor,
+    logical_indices: torch.Tensor,
+    block_table: torch.Tensor,
+    token_to_req: torch.Tensor,
+    out: torch.Tensor | None = None,
+) -> torch.Tensor:
+    """Run sparse GQA directly over paged BF16 K/V caches."""
+
+    if q.device.type != "npu" or not HAS_TRITON:
+        raise RuntimeError("paged QSA sparse attention requires NPU and Triton")
+    if q.ndim != 3 or k_cache.ndim != 4 or v_cache.shape != k_cache.shape:
+        raise ValueError("QSA sparse attention received invalid Q/K/V shapes")
+    if logical_indices.ndim != 2 or logical_indices.shape[0] != q.shape[0]:
+        raise ValueError("QSA indices must have one row per query")
+    if token_to_req.shape != (q.shape[0],) or block_table.ndim != 2:
+        raise ValueError("QSA sparse attention metadata has invalid shapes")
+    if not all(k_cache.shape[:3]) or not all(block_table.shape):
+        raise ValueError("QSA sparse attention cache and block table must be nonempty")
+    if logical_indices.shape[1] <= 0:
+        raise ValueError("QSA sparse attention requires a positive selection width")
+    if q.shape[2] != k_cache.shape[3] or q.shape[1] % k_cache.shape[2]:
+        raise ValueError("QSA sparse attention requires valid grouped-query heads")
+    head_dim = q.shape[2]
+    assert head_dim >= 16 and (head_dim & (head_dim - 1)) == 0
+    assert q.dtype == k_cache.dtype == v_cache.dtype == torch.bfloat16
+    assert logical_indices.dtype == block_table.dtype == torch.int32
+    assert token_to_req.dtype == torch.int32
+    assert q.device == k_cache.device == v_cache.device
+    assert q.device == logical_indices.device == block_table.device
+    assert q.device == token_to_req.device
+    assert q.stride(2) == k_cache.stride(3) == v_cache.stride(3) == 1
+    assert logical_indices.stride(1) == block_table.stride(1) == 1
+    assert token_to_req.stride(0) == 1
+    if out is None:
+        out = torch.empty_like(q)
+    if out.shape != q.shape:
+        raise ValueError("QSA sparse output must match its query")
+    assert out.dtype == q.dtype and out.device == q.device
+    assert out.stride(2) == 1
+    if not q.shape[0]:
+        return out
+
+    group_size = q.shape[1] // k_cache.shape[2]
+    block_m = triton.next_power_of_2(group_size)
+    base_programs = q.shape[0] * k_cache.shape[2]
+    small_profile_limit = 8 if block_m <= 8 else 4
+
+    # Tuned on GB300 for the Qwen-Air TP1, TP2, and TP4 attention shapes.
+    # Narrow tiles favor decode; wide tiles improve throughput for prefill.
+    if base_programs <= small_profile_limit:
+        block_n, target_splits, partial_warps = 16, 64, 4
+    elif base_programs < 32:
+        block_n, target_splits, partial_warps = 16, 32, 4
+    elif base_programs <= 256:
+        block_n, target_splits, partial_warps = 64, 8, 2
+    elif base_programs <= 512:
+        block_n, target_splits, partial_warps = 64, 4, 2
+    else:
+        block_n, target_splits, partial_warps = 64, 1, 2
+
+    num_tiles = triton.cdiv(logical_indices.shape[1], block_n)
+    # Avoid empty splits when the selection width is smaller than the profile.
+    max_useful_splits = 1 << (num_tiles.bit_length() - 1)
+    num_splits = min(max_useful_splits, target_splits)
+
+    # Split=1 writes output directly and compiles out all workspace accesses.
+    if num_splits == 1:
+        partial_output = out
+        partial_lse = out
+    else:
+        # FP32 partials preserve accuracy when merging independently normalized
+        # splits.
+        partial_output = torch.empty((num_splits, *q.shape), dtype=torch.float32, device=q.device)
+        partial_lse = torch.empty(
+            (num_splits, q.shape[0], q.shape[1]),
+            dtype=torch.float32,
+            device=q.device,
+        )
+
+    partial_grid = (q.shape[0], k_cache.shape[2], num_splits)
+    _qsa_sparse_paged_gqa_splitk_kernel[partial_grid](
+        q,
+        k_cache,
+        v_cache,
+        logical_indices,
+        block_table,
+        token_to_req,
+        partial_output,
+        partial_lse,
+        out,
+        q.stride(0),
+        q.stride(1),
+        k_cache.stride(0),
+        k_cache.stride(1),
+        k_cache.stride(2),
+        v_cache.stride(0),
+        v_cache.stride(1),
+        v_cache.stride(2),
+        logical_indices.stride(0),
+        block_table.stride(0),
+        out.stride(0),
+        out.stride(1),
+        q.shape[0],
+        k_cache.shape[0],
+        block_table.shape[0],
+        TOPK=logical_indices.shape[1],
+        PAGE_SIZE=k_cache.shape[1],
+        PAGE_TABLE_WIDTH=block_table.shape[1],
+        GROUP_SIZE=group_size,
+        HEAD_DIM=q.shape[2],
+        NUM_QUERY_HEADS=q.shape[1],
+        NUM_SPLITS=num_splits,
+        NUM_TILES=num_tiles,
+        BLOCK_M=block_m,
+        BLOCK_N=block_n,
+        num_warps=partial_warps,
+        num_stages=2,
+    )
+    if num_splits == 1:
+        return out
+
+    _qsa_merge_splitk_kernel[(q.shape[0], q.shape[1])](
+        partial_output,
+        partial_lse,
+        out,
+        out.stride(0),
+        out.stride(1),
+        q.shape[0],
+        HEAD_DIM=q.shape[2],
+        NUM_QUERY_HEADS=q.shape[1],
+        NUM_SPLITS=num_splits,
+        BLOCK_SPLITS=triton.next_power_of_2(num_splits),
+        num_warps=2,
+        num_stages=1,
+    )
+    return out
+
+
+def qsa_store_cache_rows(
+    cache: torch.Tensor,
+    slot_mapping: torch.Tensor,
+    rows: torch.Tensor,
+) -> None:
+    """Store fixed-width rows in a QSA cache without boolean indexing."""
+
+    if cache.device.type != "npu" or not HAS_TRITON:
+        raise RuntimeError("QSA NPU cache stores require Triton")
+    if cache.ndim != 4 or cache.shape[2] != 1:
+        raise ValueError("QSA cache must be [pages, page_size, 1, width]")
+    if not all(cache.shape):
+        raise ValueError("QSA cache dimensions must be nonzero")
+    if rows.ndim == 3:
+        if rows.shape[1] != 1:
+            raise ValueError("QSA cache rows must have one head")
+        rows = rows[:, 0]
+    if rows.shape != (slot_mapping.numel(), cache.shape[3]):
+        raise ValueError("QSA cache rows and slots have incompatible shapes")
+    if not rows.shape[0]:
+        return
+    _store_qsa_rows_kernel[(rows.shape[0],)](
+        cache,
+        slot_mapping,
+        rows,
+        cache.stride(0),
+        cache.stride(1),
+        cache.stride(3),
+        rows.stride(0),
+        rows.stride(1),
+        rows.shape[0],
+        cache.shape[0],
+        PAGE_SIZE=cache.shape[1],
+        WIDTH=cache.shape[3],
+        BLOCK_D=triton.next_power_of_2(cache.shape[3]),
+        num_warps=4,
+    )
+
+
+def qsa_compress_groups_with_ratio(
+    raw_keys: torch.Tensor,  # this step's raw key rows [rows, 1, head_size]
+    raw_positions: torch.Tensor,  # this step's positions [rows, 1, 3] int64
+    compressor_state_cache: torch.Tensor,
+    compressor_state_block_table: torch.Tensor,
+    token_to_req: torch.Tensor,
+    query_start_loc: torch.Tensor,
+    logical_positions: torch.Tensor,
+    compressed_slots: torch.Tensor,
+    compress_ratio: int,
+    rope_cache: torch.Tensor | None = None,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Pool completed groups from the compressor-state ring and raw token rows."""
+
+    if raw_keys.device.type != "npu" or not HAS_TRITON:
+        raise RuntimeError("QSA NPU compression requires Triton")
+    rows = token_to_req.numel()
+    if compress_ratio <= 0:
+        raise ValueError("QSA compression ratio must be positive")
+    if raw_keys.ndim != 3 or raw_keys.shape[:2] != (rows, 1):
+        raise ValueError("QSA raw keys must be [rows, 1, head_size]")
+    if raw_positions.shape != (rows, 1, 3) or raw_positions.dtype != torch.int64:
+        raise ValueError("QSA raw positions must be [rows, 1, 3] int64")
+    if logical_positions.shape != (rows,) or compressed_slots.shape != (rows,):
+        raise ValueError("QSA compression metadata must match token rows")
+    if compressor_state_cache.ndim != 4 or compressor_state_cache.shape[2] != 1:
+        raise ValueError("QSA compressor-state cache has an invalid shape")
+    if (
+        # The ring is wider than one group so speculative rows cannot alias
+        # onto the committed keys of the group still being collected.
+        compressor_state_cache.shape[1] < compress_ratio
+        or compressor_state_cache.shape[3] != raw_keys.shape[2]
+        or compressor_state_cache.dtype != raw_keys.dtype
+    ):
+        raise ValueError("QSA compressor-state cache does not match the compression layout")
+    if compressor_state_block_table.ndim != 2 or compressor_state_block_table.shape[1] < 1:
+        raise ValueError("QSA compressor-state block table must contain one block per request")
+    if query_start_loc.ndim != 1 or query_start_loc.shape[0] < 2:
+        raise ValueError("QSA query starts must contain a terminal offset")
+    num_requests = query_start_loc.shape[0] - 1
+    if compressor_state_block_table.shape[0] < num_requests:
+        raise ValueError("QSA compressor-state block table has too few request rows")
+    if rope_cache is not None and (
+        rope_cache.ndim != 4
+        or rope_cache.shape[:3] != compressor_state_cache.shape[:3]
+        or rope_cache.shape[3] != 3
+        or rope_cache.dtype != torch.int64
+    ):
+        raise ValueError("QSA packed position view has an invalid shape or dtype")
+    if rows and (not all(compressor_state_cache.shape) or not all(compressor_state_block_table.shape)):
+        raise ValueError("QSA compressor-state cache and block table must be nonempty")
+    pooled = torch.empty(
+        (rows, 1, raw_keys.shape[2]),
+        dtype=raw_keys.dtype,
+        device=raw_keys.device,
+    )
+    first_positions = torch.empty((rows, 3), dtype=torch.int64, device=raw_keys.device)
+    if not rows:
+        return pooled, first_positions
+    if rope_cache is None:
+        rope_cache = compressor_state_cache
+        load_rope_positions = False
+    else:
+        load_rope_positions = True
+    _compress_qsa_groups_kernel[(rows,)](
+        raw_keys,
+        raw_positions,
+        compressor_state_cache,
+        rope_cache,
+        compressor_state_block_table,
+        token_to_req,
+        query_start_loc,
+        logical_positions,
+        compressed_slots,
+        pooled,
+        first_positions,
+        raw_keys.stride(0),
+        raw_keys.stride(2),
+        raw_positions.stride(0),
+        raw_positions.stride(2),
+        compressor_state_cache.stride(0),
+        compressor_state_cache.stride(1),
+        compressor_state_cache.stride(3),
+        rope_cache.stride(0),
+        rope_cache.stride(1),
+        rope_cache.stride(3),
+        compressor_state_block_table.stride(0),
+        pooled.stride(0),
+        pooled.stride(2),
+        first_positions.stride(0),
+        first_positions.stride(1),
+        rows,
+        compressor_state_cache.shape[0],
+        num_requests,
+        COMPRESSOR_STATE_SIZE=compressor_state_cache.shape[1],
+        COMPRESS_RATIO=compress_ratio,
+        HEAD_DIM=raw_keys.shape[2],
+        LOAD_ROPE_POSITIONS=load_rope_positions,
+        BLOCK_D=triton.next_power_of_2(raw_keys.shape[2]),
+        num_warps=4,
+    )
+    return pooled, first_positions
+
+
+__all__ = [
+    "expand_qsa_block_indices_npu",
+    "qsa_compress_groups_with_ratio",
+    "qsa_mqa_paged",
+    "qsa_select_paged_tokens",
+    "qsa_sparse_paged_attention",
+    "qsa_store_cache_rows",
+]

--- a/vllm_ascend/patch/platform/patch_kv_cache_utils.py
+++ b/vllm_ascend/patch/platform/patch_kv_cache_utils.py
@@ -14,6 +14,7 @@ from vllm.v1.kv_cache_interface import (
     KVCacheGroupSpec,
     KVCacheSpec,
     KVCacheTensor,
+    MambaSpec,
     MLAAttentionSpec,
     SlidingWindowMLASpec,
     SlidingWindowSpec,
@@ -23,6 +24,9 @@ from vllm.v1.kv_cache_interface import (
 _orig_resolve_kv_cache_block_sizes = vllm.v1.core.kv_cache_utils.resolve_kv_cache_block_sizes
 
 _orig_get_kv_cache_groups = vllm.v1.core.kv_cache_utils.get_kv_cache_groups
+_orig_get_kv_cache_config_from_groups = (
+    vllm.v1.core.kv_cache_utils.get_kv_cache_config_from_groups
+)
 
 
 def _ascend_resolve_kv_cache_block_sizes(
@@ -128,6 +132,90 @@ def get_kv_cache_groups(vllm_config: VllmConfig, kv_cache_spec: dict[str, KVCach
                 f"{spec_summary}."
             ) from exc
         return fallback_groups
+
+
+def _group_member_specs(group: KVCacheGroupSpec) -> dict[str, KVCacheSpec]:
+    if isinstance(group.kv_cache_spec, UniformTypeKVCacheSpecs):
+        return group.kv_cache_spec.kv_cache_specs
+    return {name: group.kv_cache_spec for name in group.layer_names}
+
+
+def _get_qwen4_exp_kv_cache_config(
+    vllm_config: VllmConfig,
+    kv_cache_groups: list[KVCacheGroupSpec],
+    available_memory: int,
+) -> KVCacheConfig | None:
+    """Build the packed QSA/linear-cache layout without a vLLM source patch."""
+    from vllm_ascend.core.kv_cache_interface import AscendCircularBufferSpec
+
+    members = {
+        name: spec
+        for group in kv_cache_groups
+        for name, spec in _group_member_specs(group).items()
+    }
+    if not any(isinstance(spec, AscendCircularBufferSpec) for spec in members.values()):
+        return None
+
+    main = [(name, spec) for name, spec in members.items() if type(spec) is FullAttentionSpec]
+    compressed = [(name, spec) for name, spec in members.items() if type(spec) is MLAAttentionSpec]
+    compressor_state = [
+        (name, spec) for name, spec in members.items() if isinstance(spec, AscendCircularBufferSpec)
+    ]
+    mamba_groups = [group for group in kv_cache_groups if isinstance(group.kv_cache_spec, MambaSpec)]
+    if not main or not compressed or len(compressed) != len(compressor_state):
+        raise ValueError("Qwen4Exp QSA cache owners have an inconsistent packed layout")
+
+    main_page_size = max(spec.page_size_bytes for _, spec in main)
+    compressed_page_size = max(
+        spec.page_size_bytes for _, spec in (*compressed, *compressor_state)
+    )
+    bytes_per_block = len(main) * main_page_size + len(compressed) * compressed_page_size
+    num_blocks = may_override_num_blocks(vllm_config, available_memory // bytes_per_block)
+    total_size = bytes_per_block * num_blocks
+    compressed_offset = len(main) * main_page_size
+
+    def packed_tensor(layer_name: str, offset: int) -> KVCacheTensor:
+        return KVCacheTensor(
+            size=total_size,
+            shared_by=[layer_name],
+            offset=offset,
+            block_stride=bytes_per_block,
+        )
+
+    tensors = [
+        packed_tensor(name, index * main_page_size)
+        for index, (name, _) in enumerate(main)
+    ]
+    for owners in (compressed, compressor_state):
+        tensors.extend(
+            packed_tensor(name, compressed_offset + index * compressed_page_size)
+            for index, (name, _) in enumerate(owners)
+        )
+    for group in mamba_groups:
+        tensors.extend(
+            packed_tensor(name, index * main_page_size)
+            for index, name in enumerate(group.layer_names)
+        )
+    return KVCacheConfig(
+        num_blocks=num_blocks,
+        kv_cache_tensors=tensors,
+        kv_cache_groups=kv_cache_groups,
+    )
+
+
+def get_kv_cache_config_from_groups(
+    vllm_config: VllmConfig,
+    kv_cache_groups: list[KVCacheGroupSpec],
+    available_memory: int,
+) -> KVCacheConfig:
+    qwen_config = _get_qwen4_exp_kv_cache_config(
+        vllm_config, kv_cache_groups, available_memory
+    )
+    if qwen_config is not None:
+        return qwen_config
+    return _orig_get_kv_cache_config_from_groups(
+        vllm_config, kv_cache_groups, available_memory
+    )
 
 
 def group_and_unify_kv_cache_specs(
@@ -321,6 +409,9 @@ def _get_kv_cache_config_deepseek_v4(
 
 vllm.v1.core.kv_cache_utils.resolve_kv_cache_block_sizes = _ascend_resolve_kv_cache_block_sizes
 vllm.v1.core.kv_cache_utils.get_kv_cache_groups = get_kv_cache_groups
+vllm.v1.core.kv_cache_utils.get_kv_cache_config_from_groups = (
+    get_kv_cache_config_from_groups
+)
 vllm.v1.core.kv_cache_utils.group_and_unify_kv_cache_specs = group_and_unify_kv_cache_specs
 vllm.v1.core.kv_cache_utils._get_kv_cache_groups_uniform_groups = _get_kv_cache_groups_uniform_groups
 # vLLM v0.24.0 renamed _get_kv_cache_config_deepseek_v4 to _get_kv_cache_config_packed and

--- a/vllm_ascend/patch/platform/patch_speculative_config.py
+++ b/vllm_ascend/patch/platform/patch_speculative_config.py
@@ -161,6 +161,20 @@ def hf_config_override(hf_config: PretrainedConfig) -> PretrainedConfig:
                 "architectures": ["Qwen3_5MoeMTP" if is_moe else "Qwen3_5MTP"],
             }
         )
+    if hf_config.model_type in ("qwen4_exp", "qwen4_exp_text"):
+        text_config = getattr(hf_config, "text_config", hf_config)
+        text_config.model_type = "qwen4_exp_mtp"
+        n_predict = getattr(text_config, "mtp_num_hidden_layers", 1)
+        text_config.update(
+            {
+                "n_predict": n_predict,
+                "architectures": ["Qwen4ExpMTP"],
+                "index_share_for_mtp_iteration": getattr(
+                    text_config, "index_share_for_mtp_iteration", False
+                ),
+            }
+        )
+        hf_config = text_config
     if hf_config.model_type in ("longcat_flash", "longcat_flash_ngram"):
         hf_config.model_type = "longcat_flash_mtp"
         n_predict = getattr(hf_config, "num_nextn_predict_layers", 1)

--- a/vllm_ascend/patch/platform/patch_speculative_config.py
+++ b/vllm_ascend/patch/platform/patch_speculative_config.py
@@ -1,5 +1,6 @@
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Literal, get_args
 
+import vllm.config.speculative as vllm_speculative
 from vllm.config.speculative import SpeculativeConfig
 from vllm.transformers_utils.configs.speculators import algos as speculator_algos
 from vllm.utils.import_utils import LazyLoader
@@ -10,6 +11,13 @@ from vllm_ascend.transformers_utils.configs.kimi_k3 import (
 )
 
 _orig_post_init = SpeculativeConfig.__post_init__
+
+# vLLM 0.26 predates Qwen4Exp MTP. Extend its runtime validation list before
+# SpeculativeConfig normalizes the draft model returned by hf_config_override.
+if "qwen4_exp_mtp" not in get_args(vllm_speculative.MTPModelTypes):
+    vllm_speculative.MTPModelTypes = Literal.__getitem__(
+        get_args(vllm_speculative.MTPModelTypes) + ("qwen4_exp_mtp",)
+    )
 
 if TYPE_CHECKING:
     import vllm.model_executor.layers.quantization as me_quant

--- a/vllm_ascend/spec_decode/__init__.py
+++ b/vllm_ascend/spec_decode/__init__.py
@@ -21,7 +21,10 @@
 from vllm_ascend.spec_decode.dflash_proposer import AscendDflashProposer
 from vllm_ascend.spec_decode.draft_proposer import AscendDraftModelProposer
 from vllm_ascend.spec_decode.dspark_proposer import AscendDSparkProposer
-from vllm_ascend.spec_decode.eagle_proposer import AscendEagleProposer
+from vllm_ascend.spec_decode.eagle_proposer import (
+    AscendEagleProposer,
+    AscendQwen4ExpMTPProposer,
+)
 from vllm_ascend.spec_decode.extract_hidden_states_proposer import (
     AscendExtractHiddenStatesProposer,
 )
@@ -30,6 +33,20 @@ from vllm_ascend.spec_decode.ngram_proposer import AscendNgramProposer
 from vllm_ascend.spec_decode.ngram_proposer_npu import AscendNgramProposerNPU
 from vllm_ascend.spec_decode.step3p5 import AscendStep3p5MTPProposer
 from vllm_ascend.spec_decode.suffix_proposer import AscendSuffixDecodingProposer
+
+
+def _use_qwen4_exp_mtp(speculative_config) -> bool:
+    checker = getattr(speculative_config, "use_qwen4_exp_mtp", None)
+    if checker is not None and checker():
+        return True
+    draft_model_config = getattr(speculative_config, "draft_model_config", None)
+    text_config = getattr(draft_model_config, "hf_text_config", None)
+    if text_config is None:
+        return False
+    architectures = getattr(text_config, "architectures", ()) or ()
+    return getattr(text_config, "model_type", None) == "qwen4_exp_mtp" or (
+        "Qwen4ExpMTP" in architectures
+    )
 
 
 def get_spec_decode_method(method, vllm_config, device, runner):
@@ -47,6 +64,10 @@ def get_spec_decode_method(method, vllm_config, device, runner):
         speculative_config = vllm_config.speculative_config
         if speculative_config is not None and speculative_config.use_step3p5_mtp():
             return AscendStep3p5MTPProposer(vllm_config, device, runner)
+        if speculative_config is not None and _use_qwen4_exp_mtp(
+            speculative_config
+        ):
+            return AscendQwen4ExpMTPProposer(vllm_config, device, runner)
         return AscendEagleProposer(vllm_config, device, runner)
     elif method == "dflash":
         return AscendDflashProposer(vllm_config, device, runner)

--- a/vllm_ascend/spec_decode/eagle_proposer.py
+++ b/vllm_ascend/spec_decode/eagle_proposer.py
@@ -5,8 +5,23 @@ from vllm.config import VllmConfig
 from vllm.v1.spec_decode.eagle import EagleProposer
 
 from vllm_ascend.spec_decode.llm_base_proposer import AscendSpecDecodeBaseProposer
+from vllm_ascend.spec_decode.qwen4_exp import Qwen4ExpMTPProposer
 
 
 class AscendEagleProposer(EagleProposer, AscendSpecDecodeBaseProposer):
     def __init__(self, vllm_config: VllmConfig, device: torch.device, runner=None):
         AscendSpecDecodeBaseProposer.__init__(self, vllm_config, device, True, runner=runner)
+
+
+class AscendQwen4ExpMTPProposer(Qwen4ExpMTPProposer, AscendSpecDecodeBaseProposer):
+    """Ascend proposer for Qwen4Exp multi-stream MTP."""
+
+    def __init__(self, vllm_config: VllmConfig, device: torch.device, runner=None):
+        AscendSpecDecodeBaseProposer.__init__(self, vllm_config, device, True, runner=runner)
+        self._per_group_block_tables: dict[int, torch.Tensor] = {}
+
+    def _get_hidden_size(self) -> int:
+        # ModelConfig.get_hidden_size() resolves the multimodal outer width for
+        # Qwen3.8-Flash-Next. The MTP feedback is the text backbone's HC stream.
+        text_config = self.draft_model_config.hf_text_config
+        return int(text_config.hidden_size * text_config.hc_count)

--- a/vllm_ascend/spec_decode/eagle_proposer.py
+++ b/vllm_ascend/spec_decode/eagle_proposer.py
@@ -18,6 +18,18 @@ class AscendQwen4ExpMTPProposer(Qwen4ExpMTPProposer, AscendSpecDecodeBasePropose
 
     def __init__(self, vllm_config: VllmConfig, device: torch.device, runner=None):
         AscendSpecDecodeBaseProposer.__init__(self, vllm_config, device, True, runner=runner)
+
+        # vLLM allocates the base proposer buffer from ModelConfig directly and
+        # no longer calls this proposer's _get_hidden_size() hook. Qwen4Exp MTP
+        # consumes the full HC stream, so replace a single-stream allocation.
+        qwen_hidden_size = self._get_hidden_size()
+        if self.hidden_size != qwen_hidden_size:
+            self.hidden_size = qwen_hidden_size
+            self.hidden_states = torch.zeros(
+                (self.max_num_tokens, self.hidden_size),
+                dtype=self.dtype,
+                device=device,
+            )
         self._per_group_block_tables: dict[int, torch.Tensor] = {}
 
     def _get_hidden_size(self) -> int:

--- a/vllm_ascend/spec_decode/eagle_proposer.py
+++ b/vllm_ascend/spec_decode/eagle_proposer.py
@@ -25,3 +25,12 @@ class AscendQwen4ExpMTPProposer(Qwen4ExpMTPProposer, AscendSpecDecodeBasePropose
         # Qwen3.8-Flash-Next. The MTP feedback is the text backbone's HC stream.
         text_config = self.draft_model_config.hf_text_config
         return int(text_config.hidden_size * text_config.hc_count)
+
+    def maybe_pad_and_reduce(self, hidden_states, positions):
+        # Qwen4Exp target and draft share the same TP group and HC width.
+        return hidden_states, positions
+
+    def maybe_all_gather_and_unpad(
+        self, last_hidden_states, positions, hidden_states=None
+    ):
+        return last_hidden_states, positions, hidden_states

--- a/vllm_ascend/spec_decode/llm_base_proposer.py
+++ b/vllm_ascend/spec_decode/llm_base_proposer.py
@@ -22,6 +22,7 @@ from vllm.model_executor.layers.attention_layer_base import AttentionLayerBase
 from vllm.model_executor.model_loader import get_model
 from vllm.model_executor.models import supports_multimodal
 from vllm.model_executor.models.deepseek_eagle3 import Eagle3DeepseekV2ForCausalLM
+from vllm.v1.attention.backend import MultipleOf
 from vllm.model_executor.models.deepseek_v2 import DeepseekV32IndexerCache
 from vllm.model_executor.models.llama_eagle3 import Eagle3LlamaForCausalLM
 from vllm.model_executor.models.qwen3_dflash import DFlashQwen3ForCausalLM
@@ -481,8 +482,16 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
         self.attn_layer_names = list(sorted(self._draft_attn_layer_names))
         draft_attn_layers_dict = get_layers_from_vllm_config(self.vllm_config, AttentionLayerBase)
         # initialized for mamba models
-        self.kernel_block_size = (
+        kernel_block_size = (
             draft_attn_layers_dict[self.attn_layer_names[0]].get_attn_backend().get_supported_kernel_block_sizes()[0]
+        )
+        # Some backends advertise a block-size constraint rather than a
+        # concrete integer. Slot-mapping arithmetic needs the constraint's
+        # integer base, matching the model runner's normalization.
+        self.kernel_block_size = (
+            kernel_block_size.base
+            if isinstance(kernel_block_size, MultipleOf)
+            else kernel_block_size
         )
 
         # Sliding-window draft attention adapter.

--- a/vllm_ascend/spec_decode/qwen4_exp.py
+++ b/vllm_ascend/spec_decode/qwen4_exp.py
@@ -152,10 +152,13 @@ class Qwen4ExpMTPProposer(EagleProposer):
             for layer_name in group.layer_names:
                 if layer_name not in self._draft_attn_layer_names:
                     continue
-                assert isinstance(group_spec, UniformTypeKVCacheSpecs), (
-                    "Qwen draft cache owners require packed KV cache groups"
-                )
-                spec = group_spec.kv_cache_specs.get(layer_name)
+                if isinstance(group_spec, UniformTypeKVCacheSpecs):
+                    spec = group_spec.kv_cache_specs.get(layer_name)
+                else:
+                    # vLLM 0.26 hybrid KV grouping may emit a direct
+                    # homogeneous KVCacheSpec alongside packed UniformType
+                    # groups. The group spec is then the per-layer spec.
+                    spec = group_spec
                 assert spec is not None, (
                     f"Qwen draft cache group {gid} has no spec for {layer_name}"
                 )

--- a/vllm_ascend/spec_decode/qwen4_exp.py
+++ b/vllm_ascend/spec_decode/qwen4_exp.py
@@ -1,0 +1,172 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Qwen4Exp MTP proposer backported for the vLLM 0.26 release stack."""
+
+from copy import copy
+
+import torch
+from vllm.config import VllmConfig, get_layers_from_vllm_config
+from vllm.model_executor.layers.attention_layer_base import AttentionLayerBase
+from vllm.v1.attention.backend import CommonAttentionMetadata
+from vllm.v1.kv_cache_interface import (
+    FullAttentionSpec,
+    KVCacheConfig,
+    KVCacheSpec,
+    UniformTypeKVCacheSpecs,
+)
+from vllm.v1.spec_decode.eagle import EagleProposer
+from vllm.v1.worker.utils import AttentionGroup
+
+
+class Qwen4ExpMTPProposer(EagleProposer):
+    """Speculative decoding proposer for the vendored Qwen4Exp MTP."""
+
+    def __init__(
+        self,
+        vllm_config: VllmConfig,
+        device: torch.device,
+        runner=None,
+    ) -> None:
+        super().__init__(vllm_config, device, runner)
+        self._per_group_block_tables: dict[int, torch.Tensor] = {}
+
+    def _get_hidden_size(self) -> int:
+        text_config = self.draft_model_config.hf_text_config
+        return int(text_config.hidden_size * text_config.hc_count)
+
+    def model_returns_tuple(self) -> bool:
+        return True
+
+    def set_per_group_block_table(
+        self,
+        gid: int,
+        block_table: torch.Tensor,
+    ) -> None:
+        self._per_group_block_tables[gid] = block_table
+
+    def build_per_group_and_layer_attn_metadata(
+        self,
+        common_attn_metadata: CommonAttentionMetadata,
+        draft_index: int = 0,
+    ) -> tuple[list[object], dict[str, object]]:
+        per_group_attn_metadata: list[object] = []
+        per_layer_attn_metadata: dict[str, object] = {}
+        common_by_gid: dict[int, CommonAttentionMetadata] = {}
+        num_reqs = common_attn_metadata.num_reqs
+
+        for attn_group in self.draft_attn_groups:
+            gid = attn_group.kv_cache_group_id
+            group_common = common_by_gid.get(gid)
+            if group_common is None:
+                if gid == self.kv_cache_gid:
+                    group_common = common_attn_metadata
+                else:
+                    block_table = self._per_group_block_tables.get(gid)
+                    assert block_table is not None, (
+                        f"Missing Qwen draft block table for KV cache group {gid}"
+                    )
+                    group_common = copy(common_attn_metadata)
+                    group_common.block_table_tensor = block_table[:num_reqs]
+                common_by_gid[gid] = group_common
+
+            attn_metadata = attn_group.get_metadata_builder().build_for_drafting(
+                common_attn_metadata=group_common,
+                draft_index=draft_index,
+            )
+            per_group_attn_metadata.append(attn_metadata)
+            for layer_name in attn_group.layer_names:
+                per_layer_attn_metadata[layer_name] = attn_metadata
+
+        return per_group_attn_metadata, per_layer_attn_metadata
+
+    def initialize_attn_backend(
+        self,
+        kv_cache_config: KVCacheConfig,
+        kernel_block_sizes: list[int] | None = None,
+    ) -> None:
+        num_mtp_layers = self.draft_model_config.hf_text_config.mtp_num_hidden_layers
+        if num_mtp_layers != 1:
+            raise NotImplementedError(
+                "Qwen4Exp MTP proposer only supports one MTP layer"
+            )
+        assert kernel_block_sizes is not None, (
+            "Qwen MTP requires resolved kernel block sizes"
+        )
+        assert len(kernel_block_sizes) == len(kv_cache_config.kv_cache_groups), (
+            "Qwen MTP requires one kernel block size per KV cache group"
+        )
+
+        all_attn_layers = get_layers_from_vllm_config(
+            self.vllm_config,
+            AttentionLayerBase,  # type: ignore[type-abstract]
+        )
+        layer_to_gid, layer_to_spec = self._map_draft_layers_to_groups(
+            kv_cache_config
+        )
+        main_layers = [
+            name
+            for name, spec in layer_to_spec.items()
+            if type(spec) is FullAttentionSpec
+        ]
+        assert len(main_layers) == 1, (
+            "Qwen4Exp MTP requires exactly one main cache owner"
+        )
+        self.kv_cache_gid = layer_to_gid[main_layers[0]]
+
+        attention_groups: list[AttentionGroup] = []
+        for layer_name in sorted(self._draft_attn_layer_names):
+            attn_layer = all_attn_layers[layer_name]
+            gid = layer_to_gid[layer_name]
+            attn_group = AttentionGroup(
+                backend=attn_layer.get_attn_backend(),
+                layer_names=[layer_name],
+                kv_cache_spec=layer_to_spec[layer_name],
+                kv_cache_group_id=gid,
+            )
+            attn_group.create_metadata_builders(
+                self.vllm_config,
+                self.device,
+                kernel_block_size=kernel_block_sizes[gid],
+            )
+            attention_groups.append(attn_group)
+
+        self.draft_attn_groups = sorted(
+            attention_groups,
+            key=lambda group: (
+                group.kv_cache_group_id != self.kv_cache_gid,
+                group.kv_cache_group_id,
+                group.backend.full_cls_name(),
+                group.layer_names[0],
+            ),
+        )
+        self.block_size = kernel_block_sizes[self.kv_cache_gid]
+
+    def _map_draft_layers_to_groups(
+        self,
+        kv_cache_config: KVCacheConfig,
+    ) -> tuple[dict[str, int], dict[str, KVCacheSpec]]:
+        layer_to_gid: dict[str, int] = {}
+        layer_to_spec: dict[str, KVCacheSpec] = {}
+        for gid, group in enumerate(kv_cache_config.kv_cache_groups):
+            group_spec = group.kv_cache_spec
+            for layer_name in group.layer_names:
+                if layer_name not in self._draft_attn_layer_names:
+                    continue
+                assert isinstance(group_spec, UniformTypeKVCacheSpecs), (
+                    "Qwen draft cache owners require packed KV cache groups"
+                )
+                spec = group_spec.kv_cache_specs.get(layer_name)
+                assert spec is not None, (
+                    f"Qwen draft cache group {gid} has no spec for {layer_name}"
+                )
+                layer_to_gid[layer_name] = gid
+                layer_to_spec[layer_name] = spec
+
+        assert layer_to_spec.keys() == self._draft_attn_layer_names, (
+            "Qwen draft KV cache configuration is missing layers: "
+            f"{sorted(self._draft_attn_layer_names - layer_to_spec.keys())}"
+        )
+        return layer_to_gid, layer_to_spec
+
+
+__all__ = ["Qwen4ExpMTPProposer"]

--- a/vllm_ascend/worker/model_runner_v1.py
+++ b/vllm_ascend/worker/model_runner_v1.py
@@ -36,7 +36,13 @@ import torch.distributed as dist
 import torch.nn as nn
 from vllm._aiter_ops import rocm_aiter_ops
 from vllm.compilation.cuda_graph import CUDAGraphStat
-from vllm.config import CompilationMode, CUDAGraphMode, VllmConfig, get_layers_from_vllm_config
+from vllm.config import (
+    CompilationMode,
+    CUDAGraphMode,
+    VllmConfig,
+    get_layers_from_vllm_config,
+    set_current_vllm_config,
+)
 from vllm.distributed import (
     get_tensor_model_parallel_rank,
     get_tensor_model_parallel_world_size,
@@ -560,6 +566,10 @@ class NPUModelRunner(GPUModelRunner):
             ),
             cp_kv_cache_interleave_size=self.parallel_config.cp_kv_cache_interleave_size,
         )
+        # PLE's ngram context is an ACL-graph input. Keep one backing allocation
+        # for the runner lifetime so graph replay always sees a valid address;
+        # _maybe_add_qwen4_exp_ple_inputs refreshes its contents every step.
+        self._qwen4_exp_ngram_context_buffer: torch.Tensor | None = None
         self.num_draft_tokens = self._make_buffer(self.max_num_reqs, dtype=torch.int32)
         # here we use int32
         self.sampled_token_ids_pinned_cpu = torch.empty(
@@ -2666,14 +2676,19 @@ class NPUModelRunner(GPUModelRunner):
             if self.enable_enpu:
                 torch.npu.current_stream().synchronize()
 
-            update_full_graph_params(
-                self.attn_backend,
-                self.update_stream,
-                forward_context,
-                num_tokens_padded,
-                self.vllm_config,
-                self.speculative_config,
-            )
+            # Async DP can enter this path through execute_dummy_batch, which
+            # does not inherit the worker's normal current-config context.
+            # Attention backend selection consults that context while updating
+            # FULL graph parameters, so establish it explicitly here.
+            with set_current_vllm_config(self.vllm_config):
+                update_full_graph_params(
+                    self.attn_backend,
+                    self.update_stream,
+                    forward_context,
+                    num_tokens_padded,
+                    self.vllm_config,
+                    self.speculative_config,
+                )
 
     def _model_forward(
         self,
@@ -2728,30 +2743,74 @@ class NPUModelRunner(GPUModelRunner):
             "query_start_loc",
             self.query_start_loc.gpu[: num_reqs_padded + 1],
         )
-        if "ngram_context" in model_kwargs:
-            return
-
         context_len = int(text_config.ngram_size) - 1
-        eos_token_id = int(text_config.eos_token_id)
-        context_cpu = np.full(
-            (num_reqs_padded, context_len),
-            eos_token_id,
-            dtype=np.int32,
-        )
-        if not is_dummy:
-            for req_idx in range(num_reqs):
-                context_end = int(
-                    self.input_batch.num_computed_tokens_cpu[req_idx]
-                )
-                context_start = max(0, context_end - context_len)
-                tokens = self.input_batch.token_ids_cpu[
-                    req_idx, context_start:context_end
-                ]
-                if len(tokens) > 0:
-                    context_cpu[req_idx, -len(tokens) :] = tokens
-        model_kwargs["ngram_context"] = torch.from_numpy(context_cpu).to(
-            self.device
-        )
+        if not 0 < num_reqs_padded <= self.max_num_reqs:
+            raise ValueError(
+                "Qwen4Exp PLE num_reqs_padded must be in "
+                f"[1, {self.max_num_reqs}], got {num_reqs_padded}"
+            )
+
+        runtime_context = model_kwargs.get("ngram_context")
+        if runtime_context is None:
+            eos_token_id = int(text_config.eos_token_id)
+            context_cpu = np.full(
+                (num_reqs_padded, context_len),
+                eos_token_id,
+                dtype=np.int32,
+            )
+            if not is_dummy:
+                for req_idx in range(num_reqs):
+                    context_end = int(
+                        self.input_batch.num_computed_tokens_cpu[req_idx]
+                    )
+                    context_start = max(0, context_end - context_len)
+                    tokens = self.input_batch.token_ids_cpu[
+                        req_idx, context_start:context_end
+                    ]
+                    if len(tokens) > 0:
+                        context_cpu[req_idx, -len(tokens) :] = tokens
+            runtime_context = torch.from_numpy(context_cpu)
+        elif (
+            runtime_context.shape != (num_reqs_padded, context_len)
+            or runtime_context.dtype != torch.int32
+        ):
+            raise ValueError(
+                "Qwen4Exp PLE ngram_context must have shape "
+                f"({num_reqs_padded}, {context_len}) and dtype torch.int32, "
+                f"got shape={tuple(runtime_context.shape)}, "
+                f"dtype={runtime_context.dtype}"
+            )
+
+        buffer = self._qwen4_exp_ngram_context_buffer
+        expected_buffer_shape = (self.max_num_reqs, context_len)
+        if buffer is None:
+            buffer = torch.empty(
+                expected_buffer_shape,
+                dtype=torch.int32,
+                device=self.device,
+            )
+            self._qwen4_exp_ngram_context_buffer = buffer
+        elif (
+            buffer.shape != expected_buffer_shape
+            or buffer.dtype != torch.int32
+            or buffer.device != self.device
+        ):
+            raise RuntimeError(
+                "Qwen4Exp PLE persistent ngram_context buffer changed "
+                f"unexpectedly: shape={tuple(buffer.shape)}, "
+                f"dtype={buffer.dtype}, device={buffer.device}"
+            )
+
+        static_context = buffer[:num_reqs_padded]
+        if (
+            runtime_context.device != static_context.device
+            or runtime_context.data_ptr() != static_context.data_ptr()
+        ):
+            # Blocking copy is intentional: runtime_context can be a temporary
+            # CPU tensor, while static_context must contain fresh request data
+            # before the captured model graph is replayed.
+            static_context.copy_(runtime_context, non_blocking=False)
+        model_kwargs["ngram_context"] = static_context
 
     def _pad_for_sequence_parallelism(self, num_scheduled_tokens: int) -> int:
         # Pad tokens to multiple of tensor_parallel_size when

--- a/vllm_ascend/worker/model_runner_v1.py
+++ b/vllm_ascend/worker/model_runner_v1.py
@@ -4095,6 +4095,12 @@ class NPUModelRunner(GPUModelRunner):
         """
         # init kv cache tensors
         kv_cache_raw_tensors: dict[str, torch.Tensor | tuple[torch.Tensor, ...]] = {}
+        # Packed descriptors are logical views into one physical allocation.
+        # Each descriptor carries the full backing size together with its own
+        # offset and block stride, so allocating once per descriptor would
+        # multiply the actual HBM usage without increasing cache capacity.
+        packed_backing: torch.Tensor | None = None
+        packed_hidden_backing: torch.Tensor | None = None
         # prefill disaggregation need the addr of cache tensor be aligned with 2M
         alignment = 2 * 1024 * 1024
         layer_kv_cache_spec = self._get_layer_kv_cache_specs(kv_cache_config)
@@ -4136,7 +4142,15 @@ class NPUModelRunner(GPUModelRunner):
                         is_hidden_state_cache_spec(layer_kv_cache_spec.get(ln))
                         for ln in kv_cache_tensor.shared_by
                     )
-                    if self.vllm_config.kv_transfer_config is None:
+                    if kv_cache_tensor.block_stride:
+                        if packed_backing is None:
+                            packed_backing = torch.zeros(
+                                kv_cache_tensor.size,
+                                dtype=torch.int8,
+                                device=self.device,
+                            )
+                        tensor = packed_backing
+                    elif self.vllm_config.kv_transfer_config is None:
                         tensor = torch.zeros(kv_cache_tensor.size, dtype=torch.int8, device=self.device)
                     else:
                         cache_size_aligned = kv_cache_tensor.size + alignment
@@ -4146,7 +4160,15 @@ class NPUModelRunner(GPUModelRunner):
                     if has_mamba and has_hidden:
                         # Allocate separate tensor for HiddenStateCacheSpec layers
                         # so ssm_state writes don't corrupt hidden-states data
-                        if self.vllm_config.kv_transfer_config is None:
+                        if kv_cache_tensor.block_stride:
+                            if packed_hidden_backing is None:
+                                packed_hidden_backing = torch.zeros(
+                                    kv_cache_tensor.size,
+                                    dtype=torch.int8,
+                                    device=self.device,
+                                )
+                            tensor_hs = packed_hidden_backing
+                        elif self.vllm_config.kv_transfer_config is None:
                             tensor_hs = torch.zeros(kv_cache_tensor.size, dtype=torch.int8, device=self.device)
                         else:
                             cache_size_aligned = kv_cache_tensor.size + alignment

--- a/vllm_ascend/worker/model_runner_v1.py
+++ b/vllm_ascend/worker/model_runner_v1.py
@@ -162,7 +162,10 @@ from vllm_ascend.spec_decode import get_spec_decode_method
 from vllm_ascend.spec_decode.dflash_proposer import AscendDflashProposer
 from vllm_ascend.spec_decode.draft_proposer import AscendDraftModelProposer
 from vllm_ascend.spec_decode.dspark_proposer import AscendDSparkProposer
-from vllm_ascend.spec_decode.eagle_proposer import AscendEagleProposer
+from vllm_ascend.spec_decode.eagle_proposer import (
+    AscendEagleProposer,
+    AscendQwen4ExpMTPProposer,
+)
 from vllm_ascend.spec_decode.extract_hidden_states_proposer import (
     AscendExtractHiddenStatesProposer,
 )
@@ -3271,9 +3274,24 @@ class NPUModelRunner(GPUModelRunner):
                 # build per-step attention metadata for the active MTP layer.
                 self.drafter.set_per_group_attn_metadata(
                     kv_cache_gid, cm.block_table_tensor, cm.slot_mapping)
+            if self.speculative_config and isinstance(
+                self.drafter, AscendQwen4ExpMTPProposer
+            ):
+                # Qwen4Exp MTP has attention layers in multiple hybrid-cache
+                # groups. Preserve each group's block table so the drafter can
+                # build metadata against the matching cache group.
+                self.drafter.set_per_group_block_table(
+                    kv_cache_gid, cm.block_table_tensor
+                )
             if self.speculative_config and spec_decode_common_attn_metadata is None:
-                if isinstance(self.drafter, AscendEagleProposer | AscendDraftModelProposer | AscendDflashProposer 
-                    | AscendDSparkProposer):
+                if isinstance(
+                    self.drafter,
+                    AscendEagleProposer
+                    | AscendQwen4ExpMTPProposer
+                    | AscendDraftModelProposer
+                    | AscendDflashProposer
+                    | AscendDSparkProposer,
+                ):
                     if self.drafter.attn_layer_names[0] in kv_cache_group.layer_names:
                         spec_decode_common_attn_metadata = cm
                 elif isinstance(self.drafter, AscendExtractHiddenStatesProposer):
@@ -3903,7 +3921,11 @@ class NPUModelRunner(GPUModelRunner):
         ):
             assert isinstance(
                 self.drafter,
-                AscendEagleProposer | AscendDflashProposer | AscendDSparkProposer | AscendDraftModelProposer,
+                AscendEagleProposer
+                | AscendQwen4ExpMTPProposer
+                | AscendDflashProposer
+                | AscendDSparkProposer
+                | AscendDraftModelProposer,
             )
             if isinstance(self.kernel_block_sizes, list):
                 draft_kernel_block_sizes = [
@@ -5277,7 +5299,10 @@ class NPUModelRunner(GPUModelRunner):
         ):
             assert isinstance(
                 self.drafter,
-                AscendEagleProposer | AscendDflashProposer | AscendExtractHiddenStatesProposer,
+                AscendEagleProposer
+                | AscendQwen4ExpMTPProposer
+                | AscendDflashProposer
+                | AscendExtractHiddenStatesProposer,
             )
             self.drafter.initialize_cudagraph_keys(cudagraph_mode)
 

--- a/vllm_ascend/worker/model_runner_v1.py
+++ b/vllm_ascend/worker/model_runner_v1.py
@@ -215,6 +215,7 @@ else:
 from vllm.model_executor.layers.attention import Attention, MLAAttention
 
 from vllm_ascend.core.kv_cache_interface import (
+    AscendCircularBufferSpec,
     AscendMLAAttentionSpec,
     AscendSFAIndexerCacheSpec,
     AscendSlidingWindowMLASpec,
@@ -2093,6 +2094,12 @@ class NPUModelRunner(GPUModelRunner):
                 num_tokens_padded,
                 intermediate_tensors,
             )
+            self._maybe_add_qwen4_exp_ple_inputs(
+                model_kwargs,
+                num_tokens=num_tokens_padded,
+                num_reqs=num_reqs,
+                num_reqs_padded=num_reqs_padded,
+            )
 
             # update global cos, sin
             update_cos_sin(positions)
@@ -2702,6 +2709,50 @@ class NPUModelRunner(GPUModelRunner):
             hidden_states = self._all_gather_hidden_states_and_aux(hidden_states)
         return hidden_states
 
+    def _maybe_add_qwen4_exp_ple_inputs(
+        self,
+        model_kwargs: dict[str, Any],
+        *,
+        num_tokens: int,
+        num_reqs: int,
+        num_reqs_padded: int,
+        is_dummy: bool = False,
+    ) -> None:
+        """Backport the Qwen4Exp PLE inputs missing from vLLM 0.26.0."""
+        text_config = self.model_config.hf_text_config
+        if not getattr(text_config, "ple_layer_ids", None):
+            return
+
+        model_kwargs.setdefault("ple_input_ids", self.input_ids.gpu[:num_tokens])
+        model_kwargs.setdefault(
+            "query_start_loc",
+            self.query_start_loc.gpu[: num_reqs_padded + 1],
+        )
+        if "ngram_context" in model_kwargs:
+            return
+
+        context_len = int(text_config.ngram_size) - 1
+        eos_token_id = int(text_config.eos_token_id)
+        context_cpu = np.full(
+            (num_reqs_padded, context_len),
+            eos_token_id,
+            dtype=np.int32,
+        )
+        if not is_dummy:
+            for req_idx in range(num_reqs):
+                context_end = int(
+                    self.input_batch.num_computed_tokens_cpu[req_idx]
+                )
+                context_start = max(0, context_end - context_len)
+                tokens = self.input_batch.token_ids_cpu[
+                    req_idx, context_start:context_end
+                ]
+                if len(tokens) > 0:
+                    context_cpu[req_idx, -len(tokens) :] = tokens
+        model_kwargs["ngram_context"] = torch.from_numpy(context_cpu).to(
+            self.device
+        )
+
     def _pad_for_sequence_parallelism(self, num_scheduled_tokens: int) -> int:
         # Pad tokens to multiple of tensor_parallel_size when
         # enabled collective fusion for SP
@@ -3144,7 +3195,7 @@ class NPUModelRunner(GPUModelRunner):
             # But gdn needs an unpadded one.
             # gdn_query_start_loc is an unpadded version of query_start_loc.
             # TODO delete it if fia's check is removed.
-            if self._has_gdn:
+            if self._has_gdn and self.attn_groups[kv_cache_gid]:
                 attn_group = self.attn_groups[kv_cache_gid][0]
                 builder = attn_group.get_metadata_builder(0)
                 if isinstance(builder, GDNAttentionMetadataBuilder):
@@ -3500,8 +3551,21 @@ class NPUModelRunner(GPUModelRunner):
                 input_ids=input_ids,
                 eplb_heat_collection_status=self.eplb_heat_collection_status if self.dynamic_eplb else False,
             ):
+                model_kwargs: dict[str, Any] = {}
+                self._maybe_add_qwen4_exp_ple_inputs(
+                    model_kwargs,
+                    num_tokens=num_tokens_padded,
+                    num_reqs=num_reqs,
+                    num_reqs_padded=num_reqs_padded,
+                    is_dummy=True,
+                )
                 outputs = self._model_forward(
-                    num_tokens_padded, input_ids, positions, intermediate_tensors, inputs_embeds
+                    num_tokens_padded,
+                    input_ids,
+                    positions,
+                    intermediate_tensors,
+                    inputs_embeds,
+                    **model_kwargs,
                 )
             if self.use_aux_hidden_state_outputs:
                 hidden_states, _ = outputs
@@ -3756,7 +3820,9 @@ class NPUModelRunner(GPUModelRunner):
         self.use_hybrid_blocks = len(self.attn_groups) > 1
         # NOTE: Currently, we determine whether we need `num_accepted_tokens` through `MambaSpec`.
         self.need_accepted_tokens = any(
-            [isinstance(attn_group[0].kv_cache_spec, MambaSpec) for attn_group in self.attn_groups]
+            attn_group
+            and isinstance(attn_group[0].kv_cache_spec, MambaSpec)
+            for attn_group in self.attn_groups
         )
 
         self.may_reinitialize_input_batch(kv_cache_config)
@@ -3866,6 +3932,13 @@ class NPUModelRunner(GPUModelRunner):
                 self.kv_caches,
                 num_attn_module,
             )
+            for layer_name, kv_cache in kv_caches.items():
+                layer = self.compilation_config.static_forward_context.get(
+                    layer_name
+                )
+                bind_layer_kv_cache = getattr(layer, "bind_kv_cache", None)
+                if bind_layer_kv_cache is not None:
+                    bind_layer_kv_cache(kv_cache)
 
         return kv_caches
 
@@ -3911,6 +3984,16 @@ class NPUModelRunner(GPUModelRunner):
 
         head_size_v = kv_cache_spec.head_size_v if hasattr(kv_cache_spec, "head_size_v") else kv_cache_spec.head_size
         return kv_cache_spec.head_size, head_size_v
+
+    def _is_qsa_state_cache(self, layer_name: str) -> bool:
+        attn_layer = self.vllm_config.compilation_config.static_forward_context.get(
+            layer_name
+        )
+        return (
+            isinstance(attn_layer, AttentionLayerBase)
+            and attn_layer.get_attn_backend().get_name()
+            == "QWEN4_EXP_EXP_QSA_STATE"
+        )
 
     @staticmethod
     def _align_up(value: int, alignment: int) -> int:
@@ -4031,7 +4114,12 @@ class NPUModelRunner(GPUModelRunner):
                 layer_name = kv_cache_tensor.shared_by[idx]
                 # Single tensor path for: mamba, hybrid attn-mamba, or cache_only_layers
                 if (
-                    "linear_attn" in layer_name
+                    isinstance(
+                        layer_kv_cache_spec[layer_name],
+                        (MambaSpec, AscendCircularBufferSpec),
+                    )
+                    or self._is_qsa_state_cache(layer_name)
+                    or kv_cache_tensor.block_stride
                     or self.hybrid_with_attn_and_mamba
                     or "cache_only_layers" in layer_name
                     or is_hidden_state_cache_spec(layer_kv_cache_spec.get(layer_name))
@@ -4198,7 +4286,12 @@ class NPUModelRunner(GPUModelRunner):
                 if layer_name in self.runner_only_attn_layers:
                     continue
                 layer_names.add(layer_name)
-        assert layer_names == set(kv_cache_raw_tensors.keys()), "Some layers are not correctly initialized"
+        initialized_layer_names = set(kv_cache_raw_tensors)
+        assert layer_names == initialized_layer_names, (
+            "Some layers are not correctly initialized: "
+            f"missing={sorted(layer_names - initialized_layer_names)}, "
+            f"extra={sorted(initialized_layer_names - layer_names)}"
+        )
 
         return kv_cache_raw_tensors
 
@@ -4364,6 +4457,93 @@ class NPUModelRunner(GPUModelRunner):
                     current_sparse_sfa_c8 = self.use_sparse and kv_cache_spec_uses_sparse_sfa_c8(
                         current_kv_cache_spec
                     )
+                    cache_tensor = next(
+                        tensor
+                        for tensor in kv_cache_config.kv_cache_tensors
+                        if layer_name in tensor.shared_by
+                    )
+                    if (
+                        cache_tensor.block_stride
+                        and not self._is_qsa_state_cache(layer_name)
+                    ):
+                        raw_cache = kv_cache_raw_tensors[layer_name]
+                        assert isinstance(raw_cache, torch.Tensor)
+                        dtype_size = get_dtype_size(current_kv_cache_spec.dtype)
+                        assert cache_tensor.offset % dtype_size == 0
+                        assert cache_tensor.block_stride % dtype_size == 0
+                        packed_num_blocks = (
+                            (
+                                raw_cache.numel()
+                                - cache_tensor.offset
+                                - current_kv_cache_spec.page_size_bytes
+                            )
+                            // cache_tensor.block_stride
+                            + 1
+                        )
+                        packed_shape = attn_backend.get_kv_cache_shape(
+                            packed_num_blocks,
+                            current_kv_cache_spec.block_size,
+                            current_kv_cache_spec.num_kv_heads,
+                            current_kv_cache_spec.head_size,
+                        )
+                        k_shape = (
+                            packed_shape[1:]
+                            if packed_shape[0] == 2
+                            else packed_shape
+                        )
+                        head_size_v = getattr(
+                            current_kv_cache_spec,
+                            "head_size_v",
+                            current_kv_cache_spec.head_size,
+                        )
+                        v_shape = (*k_shape[:-1], head_size_v)
+                        if attn_backend.get_name() == "QWEN4_EXP_QSA_TRITON":
+                            merged_shape = (
+                                *k_shape[:-1],
+                                current_kv_cache_spec.head_size + head_size_v,
+                            )
+                            merged_strides = [1] * len(merged_shape)
+                            for dim_idx in range(len(merged_shape) - 2, 0, -1):
+                                merged_strides[dim_idx] = (
+                                    merged_strides[dim_idx + 1]
+                                    * merged_shape[dim_idx + 1]
+                                )
+                            merged_strides[0] = (
+                                cache_tensor.block_stride // dtype_size
+                            )
+                            raw_cache = raw_cache.view(
+                                current_kv_cache_spec.dtype
+                            )
+                            kv_caches[layer_name] = torch.as_strided(
+                                raw_cache,
+                                size=merged_shape,
+                                stride=tuple(merged_strides),
+                                storage_offset=cache_tensor.offset // dtype_size,
+                            )
+                            continue
+                        strides = [1] * len(k_shape)
+                        for dim_idx in range(len(k_shape) - 2, 0, -1):
+                            strides[dim_idx] = (
+                                strides[dim_idx + 1] * k_shape[dim_idx + 1]
+                            )
+                        strides[0] = cache_tensor.block_stride // dtype_size
+                        raw_cache = raw_cache.view(current_kv_cache_spec.dtype)
+                        storage_offset = cache_tensor.offset // dtype_size
+                        k_cache = torch.as_strided(
+                            raw_cache,
+                            size=k_shape,
+                            stride=tuple(strides),
+                            storage_offset=storage_offset,
+                        )
+                        k_block_numel = int(np.prod(k_shape[1:]))
+                        v_cache = torch.as_strided(
+                            raw_cache,
+                            size=v_shape,
+                            stride=tuple(strides),
+                            storage_offset=storage_offset + k_block_numel,
+                        )
+                        kv_caches[layer_name] = (k_cache, v_cache)
+                        continue
                     if self.sparse_kv_offload_enabled:
                         assert self.use_sparse, "Sparse KV offload only support sparse attention."
                         assert not current_sparse_sfa_c8, "Sparse KV offload do not support sparse SFA C8."
@@ -4387,6 +4567,11 @@ class NPUModelRunner(GPUModelRunner):
                         else:
                             raw_k_tensor, raw_v_tensor = raw_cache
                             sum_page_size_bytes = raw_k_tensor.numel() + raw_v_tensor.numel()
+                    elif self._is_qsa_state_cache(layer_name):
+                        raw_k_tensor = kv_cache_raw_tensors[layer_name]
+                        assert isinstance(raw_k_tensor, torch.Tensor)
+                        raw_v_tensor = None
+                        sum_page_size_bytes = raw_k_tensor.numel()
                     elif (
                         self.use_hybrid_blocks
                         and self.hybrid_with_attn_and_mamba
@@ -4443,6 +4628,8 @@ class NPUModelRunner(GPUModelRunner):
                     assert raw_k_tensor is not None
                     assert sum_page_size_bytes % current_kv_cache_spec.page_size_bytes == 0
                     num_blocks = sum_page_size_bytes // current_kv_cache_spec.page_size_bytes
+                    if isinstance(current_kv_cache_spec, AscendCircularBufferSpec):
+                        num_blocks = kv_cache_config.num_blocks
 
                     # `num_blocks` is the number of blocks the model runner can use.
                     # `kv_cache_config.num_blocks` is the number of blocks that
@@ -4455,6 +4642,8 @@ class NPUModelRunner(GPUModelRunner):
 
                     if hasattr(attn_backend, "get_supported_kernel_block_sizes") and self.use_hybrid_blocks:
                         block_size = attn_backend.get_supported_kernel_block_sizes()[0]
+                        if isinstance(block_size, MultipleOf):
+                            block_size = block_size.base
 
                         block_size_chunk = current_kv_cache_spec.block_size // block_size
                         kv_cache_shape = attn_backend.get_kv_cache_shape(
@@ -4491,6 +4680,49 @@ class NPUModelRunner(GPUModelRunner):
                             current_kv_cache_spec.num_kv_heads,
                             current_kv_cache_spec.head_size,
                         )
+                    if self._is_qsa_state_cache(layer_name):
+                        cache_tensor = next(
+                            tensor
+                            for tensor in kv_cache_config.kv_cache_tensors
+                            if layer_name in tensor.shared_by
+                        )
+                        raw_k_cache = raw_k_tensor.view(current_kv_cache_spec.dtype)
+                        if cache_tensor.block_stride:
+                            dtype_size = get_dtype_size(current_kv_cache_spec.dtype)
+                            assert cache_tensor.offset % dtype_size == 0
+                            assert cache_tensor.block_stride % dtype_size == 0
+                            packed_num_blocks = (
+                                (
+                                    raw_k_tensor.numel()
+                                    - cache_tensor.offset
+                                    - current_kv_cache_spec.real_page_size_bytes
+                                )
+                                // cache_tensor.block_stride
+                                + 1
+                            )
+                            kv_cache_shape = attn_backend.get_kv_cache_shape(
+                                packed_num_blocks,
+                                current_kv_cache_spec.block_size,
+                                current_kv_cache_spec.num_kv_heads,
+                                current_kv_cache_spec.head_size,
+                            )
+                            strides = [1] * len(kv_cache_shape)
+                            for dim_idx in range(len(kv_cache_shape) - 2, 0, -1):
+                                strides[dim_idx] = (
+                                    strides[dim_idx + 1]
+                                    * kv_cache_shape[dim_idx + 1]
+                                )
+                            strides[0] = cache_tensor.block_stride // dtype_size
+                            k_cache = torch.as_strided(
+                                raw_k_cache,
+                                size=kv_cache_shape,
+                                stride=tuple(strides),
+                                storage_offset=cache_tensor.offset // dtype_size,
+                            )
+                        else:
+                            k_cache = raw_k_cache.view(kv_cache_shape)
+                        kv_caches[layer_name] = k_cache
+                        continue
                     if not isinstance(current_kv_cache_spec, AscendMLAAttentionSpec):
                         k_shape = kv_cache_shape[1:]
                         if hasattr(current_kv_cache_spec, "head_size_v"):

--- a/vllm_ascend/worker/model_runner_v1.py
+++ b/vllm_ascend/worker/model_runner_v1.py
@@ -4600,7 +4600,10 @@ class NPUModelRunner(GPUModelRunner):
                             current_kv_cache_spec.head_size,
                         )
                         v_shape = (*k_shape[:-1], head_size_v)
-                        if attn_backend.get_name() == "QWEN4_EXP_QSA_TRITON":
+                        if attn_backend.get_name() in (
+                            "QWEN4_EXP_QSA_TRITON",
+                            "QWEN4_EXP_QSA_ASCEND",
+                        ):
                             merged_shape = (
                                 *k_shape[:-1],
                                 current_kv_cache_spec.head_size + head_size_v,


### PR DESCRIPTION
# Problem

Qwen3.8 Flash-Next could not complete profile, `FULL_DECODE_ONLY` capture, and
replay on Ascend A3 when using the hybrid QSA/PLE cache layout. The failures
were independent but surfaced sequentially:

- packed KV-cache descriptors were allocated as independent physical buffers,
  multiplying profile-run HBM usage;
- a non-contiguous PLE cache row selection materialized almost the entire
  convolution cache, and the short depthwise convolution was not graph-safe;
- PLE n-gram context used a temporary device address, causing invalid-GM replay
  failures (holding the captured tensor alone would instead replay stale data);
- the QSA Triton pre-indexer and dynamic cache-update path were not portable to
  this graph/compiler path;
- Qwen4Exp MTP did not handle both vLLM hybrid-cache group representations or
  the model's full hyper-connection hidden width.

# Baseline

- Target repository/base: `vllm-project/vllm-ascend:releases/v0.26.0rc`
- Original audited A snapshot:
  `85625bd772f27a4a13bc8e548f131af5ce3ff734`
- Live base head at PR creation:
  `9c01df962a245346c904c9d224c5ad77e1212b0a` (the release branch advanced by
  the unrelated #15113 after the original audit)
- Prerequisite B: #15072, head
  `5d5bf084323cec9a4bc47d6dca1dfbfe0928ec58`
- GitHub test merge for #15072:
  `10c7bc0c433118b82991b85a7e0aba199615097b`

#15072 is not yet merged into the target release branch, so the GitHub PR diff
necessarily contains B + C. The commits and diffstat under "C-only commits"
below are the self-contained increment of this PR measured from an exact local
live-base + B merge (`15aae5d5e7cff3358ff4dd3a62760f31da075242`).
This PR does not duplicate or rewrite #15072.
All C commits carry the required DCO sign-off. The two prerequisite commits are
preserved byte-for-byte; their existing DCO findings must be resolved in
#15072 rather than by rewriting another author's commits here.

# Changes (C only)

1. Reuse one physical backing allocation for packed KV-cache descriptors while
   retaining a separate hidden-state backing for mixed Mamba/hidden owners.
   Logical offsets, views, and cache-sizing metadata remain unchanged.
2. Make PLE state access and convolution graph-safe:
   - gather/scatter through the contiguous storage layout;
   - replace the tiny dilated convolution with explicit contiguous slices;
   - reserve speculative state capacity and remove the runtime-owned
     `query_start_loc` from model dynamic arguments.
3. Keep PLE n-gram input address-stable and value-fresh with a runner-lifetime
   int32 buffer updated by a blocking per-step copy. Also install the current
   vLLM config while preparing async-DP full-graph metadata.
4. Replace only the QSA pre-indexer with the portable
   `project_qk -> update_and_compress -> select` chain. Avoid host-sync equality
   checks and data-dependent `masked_select` cache writes; keep the main QSA
   attention backend unchanged.
5. Support Qwen4Exp MTP hybrid cache groups in both direct and uniform forms,
   forward every group block table, allocate the full hyper-connection hidden
   buffer, and normalize `MultipleOf` block-size constraints.
6. Add focused allocator, PLE, QSA, and MTP regression tests.

# Why FULL_DECODE_ONLY main graph + MTP eager previously failed

The main runner needs stable graph inputs and graph-compatible PLE/QSA cache
updates. At the same time, the speculative runner must honor
`enforce_eager=true` without inheriting the main runner's graph capture, while
still receiving all Qwen4Exp hybrid cache groups and the full HC hidden state.
Before these changes, the main graph could fail during capture/replay and the
MTP proposer had incomplete cache/hidden metadata. The changes isolate those
two execution modes: the main runner remains `FULL_DECODE_ONLY`; MTP stays out
of `ACLGraphWrapper` and runs eager.

# Validation

Historical A3 functional validation used dummy weights with DP2 x TP8 x EP16,
16 workers, 128K maximum context, `gpu_memory_utilization=0.95`, and no block
override.

- Main graph without MTP: 1 frontend, 2 EngineCore processes, 16 workers and
  all 16 EP ranks; `torch.compile` completed; FULL decode graph capture was
  `1/1` (about 13.32 s and 0.66 GiB graph memory); `/v1/models` became ready;
  a short request returned HTTP 200 and 8 non-empty tokens; all workers entered
  graph replay.
- Main `FULL_DECODE_ONLY` + MTP eager: only the speculative configuration was
  enabled (`qwen3_5_mtp`, 3 draft tokens, `enforce_eager=true`); main capture
  completed (about 14.23 s); source/config/log evidence confirmed MTP did not
  enter `ACLGraphWrapper`; API became ready and a short request returned HTTP
  200 and 8 non-empty tokens with EngineCore/worker replay evidence.
- Isolated historical A3 checks covered PLE convolution equivalence, persistent
  n-gram address plus cross-request value refresh, QSA eager equivalence, and
  two QSA NPU graph replays.
- Repository checks in this checkout: `git diff --check`, conflict-marker scan,
  120-column scan, Git connectivity, and bounded secret/debug-artifact scans
  pass.

All completion text above came from dummy weights. It proves functional request
execution only and is not semantic or accuracy validation. The newly added
Python unit tests were not executed locally because this checkout has no usable
Python interpreter; they are included for CI and a later target-container run.

# Limitations / pending real BF16 validation

- The intended BF16 checkpoint has not been authenticated and validated in the
  target environment.
- No real-weight semantic/accuracy claim is made.
- A deterministic real-BF16 request and GPQA Diamond remain pending.
- A5 MXFP/W8A8 experiments, transfer/launch scripts, logs, response artifacts,
  credentials, environment-specific diagnostics, and vLLM-main changes are
  intentionally excluded.

# C-only commits

- `da4cb3b355b589afa9ebc7b1a30fd5b5abfd7728` - reuse packed KV-cache backing
- `cc66df1a311f6862e3c29164dd2aa6b438450721` - make Qwen4Exp PLE graph-safe
- `73f9a70c29e360fba8fc005ac0e01c92a32e4ac6` - support Qwen4Exp hybrid MTP caches
- `1110ffe51b6fae3b3bd24cf8114b1dd75aa816b9` - use graph-safe Ascend QSA indexer fallback

# Exact C-only diffstat (relative to A + #15072)

```text
15 files changed, 840 insertions(+), 84 deletions(-)
```
