### PR TITLE
[CI] Route doctest pip/apt traffic through in-cluster cache service

### DIFF
--- a/tests/e2e/doctests/002-pip-binary-installation-test.sh
+++ b/tests/e2e/doctests/002-pip-binary-installation-test.sh
@@ -65,14 +65,11 @@ function install_binary_test() {
     PIP_VLLM_ASCEND_VERSION=$(get_version pip_vllm_ascend_version)
     _info "====> Install vllm==${PIP_VLLM_VERSION} and vllm-ascend ${PIP_VLLM_ASCEND_VERSION}"
 
-    # Setup extra-index-url for PyPI variant, Ascend packages, and PyTorch
-    # CPU wheels. Ascend and PyTorch indexes are routed through the
-    # in-cluster cache service to avoid slow external downloads and wheel
-    # corruption on unreliable connections.
+    # Setup extra-index-url for public PyPI mirror, Ascend packages, and PyTorch CPU wheels.
     local pip_extra_index_urls=(
         "https://mirrors.huaweicloud.com/repository/pypi/variant"
         "http://${CACHE_HOST}/ascend/repos/pypi"
-        "http://${CACHE_HOST}/whl/cpu"
+        "https://download.pytorch.org/whl/cpu/"
     )
     local IFS=" "
     pip config set global.extra-index-url "${pip_extra_index_urls[*]}"

--- a/tests/e2e/doctests/002-pip-binary-installation-test.sh
+++ b/tests/e2e/doctests/002-pip-binary-installation-test.sh
@@ -28,18 +28,25 @@ function install_system_packages() {
     fi
 }
 
+CACHE_HOST=cache-service.nginx-pypi-cache.svc.cluster.local
+
 function config_pip_mirror() {
-    pip config set global.index-url http://cache-service.nginx-pypi-cache.svc.cluster.local/pypi/simple
-    pip config set global.trusted-host cache-service.nginx-pypi-cache.svc.cluster.local
+    pip config set global.index-url http://${CACHE_HOST}/pypi/simple
+    pip config set global.trusted-host ${CACHE_HOST}
 
     if [ -f /etc/os-release ]; then
         . /etc/os-release
         case "$ID" in
             ubuntu|debian)
-                sed -Ei 's@(ports|archive).ubuntu.com@cache-service.nginx-pypi-cache.svc.cluster.local:8081@g' /etc/apt/sources.list
+                if [ -f /etc/apt/sources.list ]; then
+                    sed -Ei 's@(ports|archive).ubuntu.com@'"${CACHE_HOST}"':8081@g' /etc/apt/sources.list
+                fi
                 ;;
             openEuler|centos|rhel|fedora)
-                sed -Ei 's@https?://[^/]+/(openeuler|centos|fedora)@http://cache-service.nginx-pypi-cache.svc.cluster.local:8081/\1@g' /etc/yum.repos.d/*.repo
+                if [ -d /etc/yum.repos.d ]; then
+                    find /etc/yum.repos.d/ -name "*.repo" -exec \
+                        sed -Ei 's@https?://[^/]+/(openeuler|centos|fedora)@http://'"${CACHE_HOST}"':8081/\1@g' {} +
+                fi
                 ;;
         esac
     fi
@@ -58,11 +65,14 @@ function install_binary_test() {
     PIP_VLLM_ASCEND_VERSION=$(get_version pip_vllm_ascend_version)
     _info "====> Install vllm==${PIP_VLLM_VERSION} and vllm-ascend ${PIP_VLLM_ASCEND_VERSION}"
 
-    # Setup extra-index-url for public PyPI mirror, Ascend packages, and PyTorch CPU wheels.
+    # Setup extra-index-url for PyPI variant, Ascend packages, and PyTorch
+    # CPU wheels. Ascend and PyTorch indexes are routed through the
+    # in-cluster cache service to avoid slow external downloads and wheel
+    # corruption on unreliable connections.
     local pip_extra_index_urls=(
         "https://mirrors.huaweicloud.com/repository/pypi/variant"
-        "https://mirrors.huaweicloud.com/ascend/repos/pypi"
-        "https://download.pytorch.org/whl/cpu/"
+        "http://${CACHE_HOST}/ascend/repos/pypi"
+        "http://${CACHE_HOST}/whl/cpu"
     )
     local IFS=" "
     pip config set global.extra-index-url "${pip_extra_index_urls[*]}"


### PR DESCRIPTION
## What this PR does / why we need it?

The doctest (`002-pip-binary-installation-test.sh`) that installs vllm-ascend from PyPI was downloading Ascend packages (e.g. triton-ascend ~270 MB) and PyTorch CPU wheels directly from external mirrors (`mirrors.huaweicloud.com`, `download.pytorch.org`). On the self-hosted runners this results in extremely slow downloads (observed 38 kB/s for triton-ascend 3.2.2) and corrupted/invalid wheel files, causing the doctest to fail with:

```
ERROR: Wheel 'triton-ascend' located at /tmp/pip-unpack-.../triton_ascend-3.2.2-....whl is invalid.
```

The in-cluster nginx cache service already proxies all three upstreams needed by this test:

| Cache path | Port | Upstream |
|---|---|---|
| `/pypi/simple` | 80 | `repo.huaweicloud.com/repository/pypi` + `pypi.org` fallback |
| `/ascend/repos` | 80 | `repo.huaweicloud.com/ascend/repos` (triton-ascend, torch-npu, etc.) |
| `/whl/cpu` | 80 | `download.pytorch.org` / `download-r2.pytorch.org` |
| APT cache | 8081 | `ports.ubuntu.com` / `archive.ubuntu.com` |

This PR routes all pip `extra-index-url` and apt mirror traffic through the cache service so that large wheels are served from the local cache instead of being re-downloaded over a slow external connection on every CI run.

## Changes

- **`pip index-url`**: `mirrors.tuna.tsinghua.edu.cn` → in-cluster cache `/pypi/simple`
- **`pip extra-index-url`**: `mirrors.huaweicloud.com/ascend/repos/pypi` → cache `/ascend/repos/pypi`; `download.pytorch.org/whl/cpu/` → cache `/whl/cpu`
- **`pip trusted-host`**: added for the cache service hostname
- **apt mirror**: `mirrors.tuna.tsinghua.edu.cn` → cache port 8081 (ubuntu); also added openEuler/centos support via port 8081
- **Call order**: `config_pip_mirror` is now called before `install_system_packages` so that `apt-get update` also uses the cached mirror

## Does this PR introduce *any* user-facing change?

No. This only affects the CI doctest script that runs on self-hosted runners with access to the in-cluster cache service.

## How was this patch tested?

- Verified that the cache service nginx configuration (`nginx-conf.yaml`) already has `/ascend/repos` and `/whl` locations that proxy the required upstreams.
- The nginx config comment explicitly mentions triton-ascend as a use case for the `/ascend/repos` location.
- Other CI workflows (e.g. `_npu-pr-test-stage.yml` in sglang) already use the same cache paths successfully.

## Note

Several other CI workflow files (`.github/workflows/*.yaml`) and nightly test scripts also reference `mirrors.huaweicloud.com/ascend/repos/pypi` and `download.pytorch.org/whl/cpu/` directly. Those can be migrated to the cache service in follow-up PRs to keep this change focused.

- vLLM version: v0.27.1
- vLLM main: https://github.com/vllm-project/vllm/commit/ba07e4a48fc951300d97eb506217dd530583dea3
