### PR TITLE
[Test] Remove redundant ascend_compilation_config from Minimax M2.7 nightly config

### DIFF
--- a/tests/e2e/nightly/single_node/models/configs/Minimax_m2.7_w8a8_A3.yaml
+++ b/tests/e2e/nightly/single_node/models/configs/Minimax_m2.7_w8a8_A3.yaml
@@ -39,7 +39,7 @@ _server_cmd: &server_cmd
   - "--compilation-config"
   - '{"cudagraph_mode": "FULL_DECODE_ONLY"}'
   - "--additional-config"
-  - '{"enable_cpu_binding": true, "ascend_compilation_config": {"enable_npugraph_ex": true, "enable_static_kernel": false}, "enable_fused_mc2": true, "weight_nz_mode": 1, "enable_flashcomm1": true}'
+  - '{"enable_cpu_binding": true, "enable_fused_mc2": true, "weight_nz_mode": 1, "enable_flashcomm1": true}'
 
 _benchmarks_3500: &benchmarks_3500
   perf_50:


### PR DESCRIPTION
### Description
Removes the explicit `ascend_compilation_config` (`enable_npugraph_ex: true`, `enable_static_kernel: false`) override from `Minimax_m2.7_w8a8_A3.yaml`.

These values are already the defaults in `AscendCompilationConfig` (`vllm_ascend/ascend_config.py`: `enable_npugraph_ex: bool = True`, `enable_static_kernel: bool = False`), so the override is redundant.

### Test
Nightly e2e config only; please trigger the nightly workflow to validate.

- vLLM version: v0.27.1
- vLLM main: https://github.com/vllm-project/vllm/commit/ba07e4a48fc951300d97eb506217dd530583dea3
