### PR TITLE
[CI][Docker] Build vLLM Rust frontend in official images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -35,7 +35,7 @@ RUN if [ -n "$APTMIRROR" ]; then \
         sed -Ei "s@(ports|archive).ubuntu.com@${APTMIRROR#http://}@g" /etc/apt/sources.list; \
     fi && \
     apt-get update -y && \
-    apt-get install -y git vim wget net-tools gcc g++ cmake numactl libnuma-dev libibverbs-dev libjemalloc2 libhiredis-dev clang-15 && \
+    apt-get install -y git vim wget curl protobuf-compiler net-tools gcc g++ cmake numactl libnuma-dev libibverbs-dev libjemalloc2 libhiredis-dev clang-15 && \
     update-alternatives --install /usr/bin/clang clang /usr/bin/clang-15 20 && \
     update-alternatives --install /usr/bin/clang++ clang++ /usr/bin/clang++-15 20 && \
     source /usr/local/Ascend/ascend-toolkit/set_env.sh && \
@@ -84,6 +84,13 @@ RUN export PIP_EXTRA_INDEX_URL="${ASCEND_INDEX_URL}" && \
     python3 -m pip install triton-ascend==3.2.2 --extra-index-url ${ASCEND_INDEX_URL} && \
     python3 -m pip install concurrent-log-handler && \
     python3 -m pip cache purge
+
+# Install _rust_tool_parser for the Rust frontend.
+RUN cd /vllm-workspace/vllm && \
+    python3 -m pip install setuptools-rust && \
+    ./build_rust.sh && \
+    python3 -m pip cache purge && \
+    rm -rf rust/target ~/.cargo ~/.rustup
 
 # Append `libascend_hal.so` path (devlib) to LD_LIBRARY_PATH
 RUN echo "export LD_PRELOAD=/usr/lib/$(uname -m)-linux-gnu/libjemalloc.so.2:$LD_PRELOAD" >> ~/.bashrc

--- a/Dockerfile.310p
+++ b/Dockerfile.310p
@@ -34,7 +34,7 @@ RUN if [ -n "$APTMIRROR" ]; then \
         sed -Ei "s@(ports|archive).ubuntu.com@${APTMIRROR#http://}@g" /etc/apt/sources.list; \
     fi && \
     apt-get update -y && \
-    apt-get install -y python3-pip git vim wget net-tools gcc g++ cmake numactl libnuma-dev libjemalloc2 pciutils && \
+    apt-get install -y python3-pip git vim wget curl protobuf-compiler net-tools gcc g++ cmake numactl libnuma-dev libjemalloc2 pciutils && \
     rm -rf /var/cache/apt/* && \
     rm -rf /var/lib/apt/lists/*
 
@@ -76,6 +76,13 @@ RUN export PIP_EXTRA_INDEX_URL="${ASCEND_INDEX_URL}" && \
     python3 -m pip install --timeout 1200 -e /vllm-workspace/vllm-ascend/ --extra-index-url ${PYTORCH_INDEX_URL} && \
     python3 -m pip uninstall -y triton-ascend triton && \
     python3 -m pip cache purge
+
+# Install _rust_tool_parser for the Rust frontend.
+RUN cd /vllm-workspace/vllm && \
+    python3 -m pip install setuptools-rust && \
+    ./build_rust.sh && \
+    python3 -m pip cache purge && \
+    rm -rf rust/target ~/.cargo ~/.rustup
 
 # Append `libascend_hal.so` path (devlib) to LD_LIBRARY_PATH
 RUN echo "export LD_PRELOAD=/usr/lib/$(uname -m)-linux-gnu/libjemalloc.so.2:$LD_PRELOAD" >> ~/.bashrc

--- a/Dockerfile.310p.openEuler
+++ b/Dockerfile.310p.openEuler
@@ -31,7 +31,7 @@ ARG PIP_TRUSTED_HOST=""
 WORKDIR /workspace
 
 RUN yum update -y && \
-    yum install -y python3-pip git vim wget net-tools gcc gcc-c++ make cmake numactl numactl-devel jemalloc patch && \
+    yum install -y python3-pip git vim wget protobuf-compiler curl net-tools gcc gcc-c++ make cmake numactl numactl-devel jemalloc patch && \
     rm -rf /var/cache/yum
 
 # Install modelscope (for fast download) and ray (for multinode)
@@ -71,6 +71,13 @@ RUN export PIP_EXTRA_INDEX_URL="${ASCEND_INDEX_URL}" && \
     python3 -m pip install --timeout 1200 -e /vllm-workspace/vllm-ascend/ --extra-index-url ${PYTORCH_INDEX_URL} && \
     python3 -m pip uninstall -y triton-ascend triton && \
     python3 -m pip cache purge
+
+# Install _rust_tool_parser for the Rust frontend.
+RUN cd /vllm-workspace/vllm && \
+    python3 -m pip install setuptools-rust && \
+    ./build_rust.sh && \
+    python3 -m pip cache purge && \
+    rm -rf rust/target ~/.cargo ~/.rustup
 
 RUN echo "export LD_PRELOAD=/usr/lib64/libjemalloc.so.2:$LD_PRELOAD" >> ~/.bashrc
 RUN echo "export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/local/lib" >> ~/.bashrc

--- a/Dockerfile.a3
+++ b/Dockerfile.a3
@@ -38,7 +38,7 @@ RUN if [ -n "$APTMIRROR" ]; then \
         sed -Ei "s@(ports|archive).ubuntu.com@${APTMIRROR#http://}@g" /etc/apt/sources.list; \
     fi && \
     apt-get update -y && \
-    apt-get install -y git vim wget net-tools gcc g++ cmake numactl libnuma-dev libibverbs-dev libjemalloc2 libhiredis-dev clang-15 && \
+    apt-get install -y git vim wget curl protobuf-compiler net-tools gcc g++ cmake numactl libnuma-dev libibverbs-dev libjemalloc2 libhiredis-dev clang-15 && \
     update-alternatives --install /usr/bin/clang clang /usr/bin/clang-15 20 && \
     update-alternatives --install /usr/bin/clang++ clang++ /usr/bin/clang++-15 20 && \
     source /usr/local/Ascend/ascend-toolkit/set_env.sh && \
@@ -87,6 +87,13 @@ RUN export PIP_EXTRA_INDEX_URL="${ASCEND_INDEX_URL}" && \
     python3 -m pip install triton-ascend==3.2.2 --extra-index-url ${ASCEND_INDEX_URL} && \
     python3 -m pip install concurrent-log-handler && \
     python3 -m pip cache purge
+
+# Install _rust_tool_parser for the Rust frontend.
+RUN cd /vllm-workspace/vllm && \
+    python3 -m pip install setuptools-rust && \
+    ./build_rust.sh && \
+    python3 -m pip cache purge && \
+    rm -rf rust/target ~/.cargo ~/.rustup
 
 # Append `libascend_hal.so` path (devlib) to LD_LIBRARY_PATH
 RUN echo "export LD_PRELOAD=/usr/lib/$(uname -m)-linux-gnu/libjemalloc.so.2:$LD_PRELOAD" >> ~/.bashrc

--- a/Dockerfile.a3.openEuler
+++ b/Dockerfile.a3.openEuler
@@ -35,7 +35,7 @@ SHELL ["/bin/bash", "-c"]
 # Install clang (for triton-ascend) and Mooncake
 ARG MOONCAKE_TAG=0.3.11.post1
 RUN yum update -y && \
-    yum install -y git vim wget net-tools gcc gcc-c++ make cmake numactl numactl-devel libibverbs-devel jemalloc hiredis-devel clang patch && \
+    yum install -y git vim wget curl protobuf-compiler net-tools gcc gcc-c++ make cmake numactl numactl-devel libibverbs-devel jemalloc hiredis-devel clang patch && \
     source /usr/local/Ascend/ascend-toolkit/set_env.sh && \
     python3 -m pip install mooncake-transfer-engine-npu==${MOONCAKE_TAG} --extra-index-url ${MOONCAKE_INDEX_URL} && \
     rm -rf /var/cache/yum/*
@@ -80,6 +80,13 @@ RUN export PIP_EXTRA_INDEX_URL="${ASCEND_INDEX_URL}" && \
     python3 -m pip install triton-ascend==3.2.2 --extra-index-url ${ASCEND_INDEX_URL} && \
     python3 -m pip install concurrent-log-handler && \
     python3 -m pip cache purge
+
+# Install _rust_tool_parser for the Rust frontend.
+RUN cd /vllm-workspace/vllm && \
+    python3 -m pip install setuptools-rust && \
+    ./build_rust.sh && \
+    python3 -m pip cache purge && \
+    rm -rf rust/target ~/.cargo ~/.rustup
 
 RUN echo "export LD_PRELOAD=/usr/lib64/libjemalloc.so.2:$LD_PRELOAD" >> ~/.bashrc
 RUN echo "export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/local/lib" >> ~/.bashrc

--- a/Dockerfile.a5
+++ b/Dockerfile.a5
@@ -38,7 +38,7 @@ RUN if [ -n "$APTMIRROR" ]; then \
         sed -Ei "s@(ports|archive).ubuntu.com@${APTMIRROR#http://}@g" /etc/apt/sources.list; \
     fi && \
     apt-get update -y && \
-    apt-get install -y git vim wget net-tools gcc g++ cmake numactl libnuma-dev libibverbs-dev libjemalloc2 libhiredis-dev clang-15 && \
+    apt-get install -y git vim wget curl protobuf-compiler net-tools gcc g++ cmake numactl libnuma-dev libibverbs-dev libjemalloc2 libhiredis-dev clang-15 && \
     update-alternatives --install /usr/bin/clang clang /usr/bin/clang-15 20 && \
     update-alternatives --install /usr/bin/clang++ clang++ /usr/bin/clang++-15 20 && \
     source /usr/local/Ascend/ascend-toolkit/set_env.sh && \
@@ -79,6 +79,13 @@ RUN export PIP_EXTRA_INDEX_URL="${ASCEND_INDEX_URL}" && \
     python3 -m pip install triton-ascend==3.2.2 --extra-index-url ${ASCEND_INDEX_URL} && \
     python3 -m pip install concurrent-log-handler && \
     python3 -m pip cache purge
+
+# Install _rust_tool_parser for the Rust frontend.
+RUN cd /vllm-workspace/vllm && \
+    python3 -m pip install setuptools-rust && \
+    ./build_rust.sh && \
+    python3 -m pip cache purge && \
+    rm -rf rust/target ~/.cargo ~/.rustup
 
 # Append `libascend_hal.so` path (devlib) to LD_LIBRARY_PATH
 RUN echo "export LD_PRELOAD=/usr/lib/$(uname -m)-linux-gnu/libjemalloc.so.2:$LD_PRELOAD" >> ~/.bashrc

--- a/Dockerfile.a5.openEuler
+++ b/Dockerfile.a5.openEuler
@@ -35,7 +35,7 @@ SHELL ["/bin/bash", "-c"]
 # Install clang (for triton-ascend) and Mooncake
 ARG MOONCAKE_TAG=0.3.11.post1
 RUN yum update -y && \
-    yum install -y git vim wget net-tools gcc gcc-c++ make cmake numactl numactl-devel libibverbs-devel jemalloc hiredis-devel clang patch && \
+    yum install -y git vim wget curl protobuf-compiler net-tools gcc gcc-c++ make cmake numactl numactl-devel libibverbs-devel jemalloc hiredis-devel clang patch && \
     source /usr/local/Ascend/ascend-toolkit/set_env.sh && \
     python3 -m pip install mooncake-transfer-engine-npu==${MOONCAKE_TAG} --extra-index-url ${MOONCAKE_INDEX_URL} && \
     rm -rf /var/cache/yum/*
@@ -72,6 +72,13 @@ RUN export PIP_EXTRA_INDEX_URL="${ASCEND_INDEX_URL}" && \
     python3 -m pip install triton-ascend==3.2.2 --extra-index-url ${ASCEND_INDEX_URL} && \
     python3 -m pip install concurrent-log-handler && \
     python3 -m pip cache purge
+
+# Install _rust_tool_parser for the Rust frontend.
+RUN cd /vllm-workspace/vllm && \
+    python3 -m pip install setuptools-rust && \
+    ./build_rust.sh && \
+    python3 -m pip cache purge && \
+    rm -rf rust/target ~/.cargo ~/.rustup
 
 RUN echo "export LD_PRELOAD=/usr/lib64/libjemalloc.so.2:$LD_PRELOAD" >> ~/.bashrc
 RUN echo "export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/local/lib" >> ~/.bashrc

--- a/Dockerfile.openEuler
+++ b/Dockerfile.openEuler
@@ -35,7 +35,7 @@ SHELL ["/bin/bash", "-c"]
 # Install clang (for triton-ascend) and Mooncake
 ARG MOONCAKE_TAG=0.3.11.post1
 RUN yum update -y && \
-    yum install -y git vim wget net-tools gcc gcc-c++ make cmake numactl numactl-devel libibverbs-devel jemalloc hiredis-devel clang patch && \
+    yum install -y git vim wget curl protobuf-compiler net-tools gcc gcc-c++ make cmake numactl numactl-devel libibverbs-devel jemalloc hiredis-devel clang patch && \
     source /usr/local/Ascend/ascend-toolkit/set_env.sh && \
     python3 -m pip install mooncake-transfer-engine-npu==${MOONCAKE_TAG} --extra-index-url ${MOONCAKE_INDEX_URL} && \
     rm -rf /var/cache/yum/*
@@ -80,6 +80,13 @@ RUN export PIP_EXTRA_INDEX_URL="${ASCEND_INDEX_URL}" && \
     python3 -m pip install triton-ascend==3.2.2 --extra-index-url ${ASCEND_INDEX_URL} && \
     python3 -m pip install concurrent-log-handler && \
     python3 -m pip cache purge
+
+# Install _rust_tool_parser for the Rust frontend.
+RUN cd /vllm-workspace/vllm && \
+    python3 -m pip install setuptools-rust && \
+    ./build_rust.sh && \
+    python3 -m pip cache purge && \
+    rm -rf rust/target ~/.cargo ~/.rustup
 
 RUN echo "export LD_PRELOAD=/usr/lib64/libjemalloc.so.2:$LD_PRELOAD" >> ~/.bashrc
 RUN echo "export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/local/lib" >> ~/.bashrc


### PR DESCRIPTION
### What this PR does / why we need it?

MiniMax-M3 tool calling needs `vllm._rust_tool_parser`. Official images currently require users to run `build_rust.sh` inside the container after start.

This PR builds the Rust frontend while making the image:

- Install `protobuf-compiler` and `curl` (needed by `protoc` / rustup during the rust build).
- Run `./build_rust.sh` **after** `pip install -e vllm-ascend`, so custom-kernel compilation stays on the existing image path.
- Purge pip cache and remove `rust/target`, `~/.cargo`, and `~/.rustup` in the same `RUN` to avoid multi-GB image bloat.

### Does this PR introduce _any_ user-facing change?

Yes. Official Docker images include the prebuilt rust tool parser (`vllm-rs` / `_rust_tool_parser`). Users no longer need to run `pip install setuptools-rust && ./build_rust.sh` after `docker run` for MiniMax-M3 tool calling.

### How was this patch tested?

- Dockerfile changes are limited to the eight official image files.
- Image rebuild on NPU hosts still required for full verification; CI image build should cover the new rust layer.


- vLLM version: v0.27.1
- vLLM main: https://github.com/vllm-project/vllm/commit/ba07e4a48fc951300d97eb506217dd530583dea3
