### PR TITLE
[BugFix][MRV2] Sync num_computed_tokens on non-last PP ranks with MTP

### DIFF
--- a/tests/ut/worker/v2/test_spec_pp_state_sync.py
+++ b/tests/ut/worker/v2/test_spec_pp_state_sync.py
@@ -1,0 +1,78 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM Ascend project
+
+import unittest
+from types import SimpleNamespace
+
+import numpy as np
+
+from vllm_ascend.patch.worker.patch_v2.patch_spec_pp import (
+    sync_spec_pp_num_computed_tokens_cpu,
+)
+
+
+class FakeEvent:
+    def __init__(self):
+        self.sync_count = 0
+
+    def synchronize(self):
+        self.sync_count += 1
+
+
+def make_runner(num_computed_tokens_np, prefill_len_np, device_copy_np):
+    req_states = SimpleNamespace(
+        req_id_to_index={"prefill": 0, "decode": 1},
+        num_computed_tokens_np=np.array(num_computed_tokens_np, dtype=np.int32),
+        prefill_len=SimpleNamespace(np=np.array(prefill_len_np, dtype=np.int32)),
+        num_computed_tokens_cpu=np.zeros(2, dtype=np.int32),
+    )
+    return SimpleNamespace(
+        req_states=req_states,
+        num_computed_tokens_cpu=np.array(device_copy_np, dtype=np.int32),
+        num_computed_tokens_event=FakeEvent(),
+    )
+
+
+def make_scheduler_output(*req_ids):
+    return SimpleNamespace(scheduled_cached_reqs=SimpleNamespace(req_ids=list(req_ids)))
+
+
+class TestSpecPPNumComputedTokensSync(unittest.TestCase):
+    def test_sampled_requests_read_the_device_copy_and_prefills_the_scheduler_value(self):
+        # "decode" was sampled and had a draft token rejected, so only the D2H
+        # copy holds its reverted length; "prefill" is inside a prefill chunk.
+        runner = make_runner([4096, 123], [4425, 100], [7, 120])
+
+        sync_spec_pp_num_computed_tokens_cpu(runner, make_scheduler_output("prefill", "decode"))
+
+        np.testing.assert_array_equal(
+            runner.req_states.num_computed_tokens_cpu,
+            np.array([4096, 120], dtype=np.int32),
+        )
+        self.assertEqual(runner.num_computed_tokens_event.sync_count, 1)
+
+    def test_fully_prefilling_batch_does_not_wait_on_the_copy_event(self):
+        runner = make_runner([4096, 2048], [4425, 8192], [7, 9])
+
+        sync_spec_pp_num_computed_tokens_cpu(runner, make_scheduler_output("prefill", "decode"))
+
+        np.testing.assert_array_equal(
+            runner.req_states.num_computed_tokens_cpu,
+            np.array([4096, 2048], dtype=np.int32),
+        )
+        self.assertEqual(runner.num_computed_tokens_event.sync_count, 0)
+
+    def test_empty_batch_is_a_noop(self):
+        runner = make_runner([1, 2], [8, 8], [3, 4])
+
+        sync_spec_pp_num_computed_tokens_cpu(runner, make_scheduler_output())
+
+        np.testing.assert_array_equal(
+            runner.req_states.num_computed_tokens_cpu,
+            np.zeros(2, dtype=np.int32),
+        )
+        self.assertEqual(runner.num_computed_tokens_event.sync_count, 0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/vllm_ascend/patch/__init__.py
+++ b/vllm_ascend/patch/__init__.py
@@ -1064,6 +1064,19 @@
 #       No, this enables the Ascend MRV2 implementation.
 #    Future Plan:
 #       Remove when vLLM natively transports draft tokens through PP.
+#   2. `sync_spec_pp_num_computed_tokens_cpu`
+#    Why:
+#       With MTP the reverted `num_computed_tokens` of a rejection only exists
+#       on the device, so `seq_lens_cpu` has to come from the D2H copy. Non-last
+#       PP ranks hold no speculator and would otherwise fall back to the
+#       scheduler value, and requests inside a non-final prefill chunk are not
+#       sampled at all and must not wait on the copy event.
+#    How:
+#       Pick the authoritative source per request when speculative PP is on.
+#    Related PR (if no, explain why):
+#       No, this belongs to the Ascend MRV2 speculative PP implementation.
+#    Future Plan:
+#       Remove when vLLM natively transports draft tokens through PP.
 #
 # ** 28. File: worker/patch_v2/patch_triton.py**
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/vllm_ascend/patch/worker/patch_v2/patch_spec_pp.py
+++ b/vllm_ascend/patch/worker/patch_v2/patch_spec_pp.py
@@ -8,6 +8,32 @@ from vllm.v1.worker.gpu.buffer_utils import async_copy_to_gpu
 _BROADCAST_PATCHED = "_vllm_ascend_spec_pp_broadcast_patched"
 
 
+def sync_spec_pp_num_computed_tokens_cpu(runner, scheduler_output) -> None:
+    """Refresh ``num_computed_tokens_cpu`` for MTP with PP.
+
+    MTP reverts ``num_computed_tokens`` on rejection, and only the device value
+    (and therefore the D2H copy issued by ``postprocess_sampled``) sees that
+    revert, so requests that were sampled must read the copy. Requests inside a
+    non-final prefill chunk were not sampled this step: their scheduler-side
+    value is the authoritative one, and a fully prefilling batch does not have
+    to wait on the copy event at all.
+    """
+    req_ids = scheduler_output.scheduled_cached_reqs.req_ids
+    if not req_ids:
+        return
+
+    req_indices = [runner.req_states.req_id_to_index[req_id] for req_id in req_ids]
+    is_prefilling = (
+        runner.req_states.num_computed_tokens_np[req_indices] < runner.req_states.prefill_len.np[req_indices]
+    )
+    if not is_prefilling.all():
+        runner.num_computed_tokens_event.synchronize()
+
+    for req_index, req_is_prefilling in zip(req_indices, is_prefilling, strict=True):
+        source = runner.req_states.num_computed_tokens_np if req_is_prefilling else runner.num_computed_tokens_cpu
+        runner.req_states.num_computed_tokens_cpu[req_index] = source[req_index]
+
+
 def install_spec_pp_token_broadcast(pp_handler, req_states) -> None:
     """Send accepted and next-draft tokens through the same V2 PP slot."""
     if getattr(pp_handler, _BROADCAST_PATCHED, False):

--- a/vllm_ascend/worker/v2/model_runner.py
+++ b/vllm_ascend/worker/v2/model_runner.py
@@ -811,7 +811,9 @@ class NPUModelRunner(GPUModelRunner):
 
         # Skip D2H copy without MTP: num_computed_tokens_cpu is synced
         # from num_computed_tokens_np in _update_seq_lens_cpu instead.
-        if self.speculator is not None:
+        # Non-last PP ranks run MTP without holding a speculator, so the copy
+        # is selected by use_spec_pp there.
+        if self.speculator is not None or self.use_spec_pp:
             self._copy_num_computed_tokens_to_cpu()
 
     def _copy_num_computed_tokens_to_cpu(self):
@@ -837,7 +839,16 @@ class NPUModelRunner(GPUModelRunner):
 
         # MTP needs D2H copy to get reverted num_computed_tokens after rejection.
         # Without MTP, num_computed_tokens_np is already correct from update_requests.
-        if self.speculator is not None:
+        if self.use_spec_pp:
+            # Same requirement on every PP rank, but non-last ranks have no
+            # speculator and requests inside a non-final prefill chunk keep the
+            # scheduler value.
+            from vllm_ascend.patch.worker.patch_v2.patch_spec_pp import (
+                sync_spec_pp_num_computed_tokens_cpu,
+            )
+
+            sync_spec_pp_num_computed_tokens_cpu(self, scheduler_output)
+        elif self.speculator is not None:
             self.num_computed_tokens_event.synchronize()
             for req_id in scheduler_output.scheduled_cached_reqs.req_ids:
                 req_index = self.req_states.req_id_to_index[req_id]


### PR DESCRIPTION
### What this PR does / why we need it?

`NPUModelRunner._update_seq_lens_cpu()` picks the source of
`num_computed_tokens_cpu` with `self.speculator is not None`:

```python
# MTP needs D2H copy to get reverted num_computed_tokens after rejection.
# Without MTP, num_computed_tokens_np is already correct from update_requests.
if self.speculator is not None:
    self.num_computed_tokens_event.synchronize()
    ...
else:
    ... = self.req_states.num_computed_tokens_np[req_index]
```

Since #14184 the speculator is built on the last PP rank only
(`if self.speculative_config is not None and (not self.use_spec_pp or self.is_last_pp_rank)`),
so with PP + MTP every other rank takes the `else` branch - the branch that
the comment above it says is only correct *without* MTP. The same condition
gates the D2H copy in `postprocess_sampled()`, so that copy is skipped on
those ranks as well. Non-last PP ranks therefore build `seq_lens_cpu`, the
value the NPU attention backends consume, from a length that was never
reverted after a rejected draft token.

This PR selects both by `use_spec_pp` as well, and picks the authoritative
source per request: requests inside a non-final prefill chunk were not
sampled this step, so the scheduler value is the correct one for them, and a
fully prefilling batch does not have to wait on the copy event at all.

Builds on #14184 (MTP with PP in MRV2).

### Does this PR introduce _any_ user-facing change?

No interface or configuration change. Deployments that combine pipeline
parallelism with MTP speculative decoding stop feeding a stale sequence
length to the attention backend on non-last PP ranks.

### How was this patch tested?

- New unit test `tests/ut/worker/v2/test_spec_pp_state_sync.py`: a mixed
  prefill/decode batch reads the device copy for the sampled request and the
  scheduler value for the prefilling one, a fully prefilling batch does not
  wait on the copy event, and an empty batch is a no-op.
- Exercised on Atlas 800I A2 with PP4xTP4, MTP3 and chunked prefill, both
  for short requests and for prefills that span several chunks.

- vLLM version: v0.27.1
- vLLM main: https://github.com/vllm-project/vllm/commit/ba07e4a48fc951300d97eb506217dd530583dea3
