### PR TITLE
[BugFix][SFA] Fence the lightning indexer before the shared index cache is reused

### DIFF
--- a/.github/workflows/scripts/test_config.yaml
+++ b/.github/workflows/scripts/test_config.yaml
@@ -107,6 +107,7 @@
   base: attention_common
   source_file_dependencies:
     - vllm_ascend/attention/indexer.py
+    - vllm_ascend/attention/indexer_sync.py
     - vllm_ascend/attention/sfa_v1.py
     - vllm_ascend/attention/sfa_kv_offload.py
   tests:

--- a/tests/ut/attention/test_indexer_sync.py
+++ b/tests/ut/attention/test_indexer_sync.py
@@ -1,0 +1,41 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM Ascend project
+
+import unittest
+
+from vllm_ascend.attention.indexer_sync import synchronize_long_indexer_if_needed
+
+
+class TestIndexerSync(unittest.TestCase):
+    def test_synchronizes_for_a_long_prefill_that_publishes_the_shared_cache(self):
+        calls = []
+
+        synchronized = synchronize_long_indexer_if_needed(
+            seq_len=1_000_000,
+            num_query_tokens=65,
+            pp_world_size=4,
+            use_index_cache=True,
+            synchronize=lambda: calls.append("sync"),
+        )
+
+        self.assertTrue(synchronized)
+        self.assertEqual(calls, ["sync"])
+
+    def test_every_other_case_keeps_its_current_behaviour(self):
+        calls = []
+
+        for kwargs in (
+            {"seq_len": 999_999, "num_query_tokens": 65, "pp_world_size": 4, "use_index_cache": True},
+            {"seq_len": 1_000_000, "num_query_tokens": 64, "pp_world_size": 4, "use_index_cache": True},
+            {"seq_len": 1_000_000, "num_query_tokens": 65, "pp_world_size": 1, "use_index_cache": True},
+            {"seq_len": 1_000_000, "num_query_tokens": 65, "pp_world_size": 4, "use_index_cache": False},
+        ):
+            self.assertFalse(
+                synchronize_long_indexer_if_needed(**kwargs, synchronize=lambda: calls.append("unexpected"))
+            )
+
+        self.assertEqual(calls, [])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/vllm_ascend/attention/indexer_sync.py
+++ b/vllm_ascend/attention/indexer_sync.py
@@ -1,0 +1,32 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM Ascend project
+
+from collections.abc import Callable
+
+# At ~1M-token prefills the lightning indexer can return before its result is
+# visible to the stage that publishes the shared index cache. Shorter prefills
+# finish before the cache consumer catches up; long ones do not, and the layers
+# that reuse the cached top-k then read a partially written buffer.
+_LONG_INDEXER_SYNC_TOKENS = 1_000_000
+
+
+def synchronize_long_indexer_if_needed(
+    *,
+    seq_len: int,
+    num_query_tokens: int,
+    pp_world_size: int,
+    use_index_cache: bool,
+    synchronize: Callable[[], None],
+) -> bool:
+    """Fence the indexer before the shared index cache is published.
+
+    Only the reproduced case is fenced - a ~1M prefill chunk on a pipeline
+    parallel deployment that reuses the cached top-k - so decode steps and
+    short prefills keep their current behaviour.
+    """
+    should_synchronize = (
+        seq_len >= _LONG_INDEXER_SYNC_TOKENS and num_query_tokens > 64 and pp_world_size > 1 and use_index_cache
+    )
+    if should_synchronize:
+        synchronize()
+    return should_synchronize

--- a/vllm_ascend/attention/sfa_v1.py
+++ b/vllm_ascend/attention/sfa_v1.py
@@ -7,7 +7,7 @@ import scipy  # type: ignore
 import torch
 import torch_npu
 from vllm.config import VllmConfig, get_current_vllm_config
-from vllm.distributed import get_tensor_model_parallel_world_size
+from vllm.distributed import get_pp_group, get_tensor_model_parallel_world_size
 from vllm.logger import logger
 from vllm.model_executor.layers.attention.mla_attention import MLACommonMetadataBuilder
 from vllm.model_executor.layers.linear import UnquantizedLinearMethod
@@ -23,6 +23,7 @@ from vllm.v1.worker.utils import select_common_block_size
 from vllm_ascend.ascend_config import get_ascend_config
 from vllm_ascend.attention.attention_mask import AttentionMaskBuilder
 from vllm_ascend.attention.attention_v1 import AscendAttentionState
+from vllm_ascend.attention.indexer_sync import synchronize_long_indexer_if_needed
 from vllm_ascend.attention.mla_v1 import MLAPO_MAX_SUPPORTED_TOKENS
 from vllm_ascend.attention.utils import (
     SFA_QSFA_TILE_SIZE,
@@ -1649,6 +1650,15 @@ class AscendSFAImpl(MLAAttentionImpl):
                 sin=sin,
                 actual_seq_lengths_query=actual_seq_lengths_query,
                 actual_seq_lengths_key=actual_seq_lengths_key,
+            )
+            # The indexer result has to be visible before the layers that skip
+            # the indexer read it back from the shared cache.
+            synchronize_long_indexer_if_needed(
+                seq_len=int(attn_metadata.seq_lens_cpu.max()),
+                num_query_tokens=attn_metadata.num_actual_tokens,
+                pp_world_size=get_pp_group().world_size,
+                use_index_cache=self.use_index_cache,
+                synchronize=torch.npu.synchronize,
             )
             if self.use_index_cache:
                 self._update_indexcache_topk_indices(topk_indices)


### PR DESCRIPTION
### What this PR does / why we need it?

With the shared index cache enabled, one SFA layer runs the lightning
indexer and publishes its top-k indices, and the layers that have no indexer
read them back from `topk_indices_buffer`. At ~1M-token prefill chunks on a
pipeline parallel deployment the consumer can read a partially written
buffer: the request comes back with content taken from the wrong positions,
while short-context requests on the same server stay correct and the same
request at a shorter length is always correct. Shorter prefills happen to
finish before the consumer catches up; long ones do not.

This PR adds an explicit fence for exactly that case - sequence length
>= 1M, more than 64 query tokens, PP > 1, index cache in use - so decode
steps and short prefills keep their current behaviour and pay nothing.

The fence is deliberately coarse: a `torch.npu.synchronize()` behind a
narrow gate, placed where the reproduction pointed. If an event recorded on
the indexer stream is preferred, or a fix inside the cache publication path
itself, the gate can stay as it is and only the callback changes - happy to
rework it that way.

Related but different: #14984 (index_cache with dspark speculative decoding
on a prefix cache hit).

### Does this PR introduce _any_ user-facing change?

No interface or configuration change. Long-context requests on PP
deployments that use the shared index cache stop reading a partially
published top-k buffer; every other shape keeps the current code path.

### How was this patch tested?

- New unit test `tests/ut/attention/test_indexer_sync.py`: the gate fires
  for a long prefill chunk that publishes the shared cache and for nothing
  else (shorter sequence, <= 64 query tokens, PP = 1, cache disabled).
- Reproduced on Atlas 800I A2 with PP4xTP4 and chunked prefill at ~1.04M
  prompt tokens: retrieval from the long prompt was intermittently wrong
  before the fence and correct after it, over three distinct prompts, with
  short-context and high-concurrency requests unchanged on the same server.

- vLLM version: v0.27.1
- vLLM main: https://github.com/vllm-project/vllm/commit/ba07e4a48fc951300d97eb506217dd530583dea3
