### PR TITLE
[BugFix][SFA] Make the sparse attention walk order independent of block placement

### DIFF
--- a/tests/ut/attention/test_sfa_topk_order.py
+++ b/tests/ut/attention/test_sfa_topk_order.py
@@ -1,0 +1,58 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM Ascend project
+
+import os
+import unittest
+from unittest.mock import patch
+
+import torch
+
+from vllm_ascend.attention.sfa_v1 import canonicalize_topk_indices
+
+
+class TestCanonicalizeTopkIndices(unittest.TestCase):
+    def test_valid_indices_are_sorted_and_padding_stays_at_the_tail(self):
+        indices = torch.tensor([[[5, 2, -1, 9, -1, 0]]], dtype=torch.int32)
+
+        out = canonicalize_topk_indices(indices)
+
+        self.assertEqual(out.tolist(), [[[0, 2, 5, 9, -1, -1]]])
+        self.assertEqual(out.dtype, torch.int32)
+        self.assertEqual(out.shape, indices.shape)
+
+    def test_the_selected_set_is_preserved_for_every_row(self):
+        torch.manual_seed(0)
+        num_tokens, topk = 37, 64
+        rows = []
+        for token in range(num_tokens):
+            valid = min(topk, token + 1)
+            row = torch.randperm(token + 1, dtype=torch.int64)[:valid].to(torch.int32)
+            rows.append(torch.cat([row, torch.full((topk - valid,), -1, dtype=torch.int32)]))
+        indices = torch.stack(rows).unsqueeze(1)
+
+        out = canonicalize_topk_indices(indices)
+
+        for before, after in zip(indices.flatten(0, 1), out.flatten(0, 1)):
+            valid_after = after[after >= 0]
+            self.assertEqual(set(valid_after.tolist()), set(before[before >= 0].tolist()))
+            self.assertTrue(torch.equal(valid_after, valid_after.sort().values))
+            self.assertTrue(torch.all(after[valid_after.numel() :] == -1))
+
+    def test_large_positions_survive_the_float32_key(self):
+        indices = torch.tensor([[[1 << 23, 3, (1 << 23) - 1]]], dtype=torch.int32)
+
+        out = canonicalize_topk_indices(indices)
+
+        self.assertEqual(out.tolist(), [[[3, (1 << 23) - 1, 1 << 23]]])
+
+    def test_disabled_by_env_returns_the_indexer_order(self):
+        indices = torch.tensor([[[5, 2, -1, 9]]], dtype=torch.int32)
+
+        with patch.dict(os.environ, {"VLLM_ASCEND_SFA_SORT_TOPK": "0"}):
+            out = canonicalize_topk_indices(indices)
+
+        self.assertTrue(torch.equal(out, indices))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/vllm_ascend/attention/sfa_v1.py
+++ b/vllm_ascend/attention/sfa_v1.py
@@ -20,6 +20,7 @@ from vllm.v1.attention.backend import (
 from vllm.v1.kv_cache_interface import AttentionSpec
 from vllm.v1.worker.utils import select_common_block_size
 
+import vllm_ascend.envs as envs_ascend
 from vllm_ascend.ascend_config import get_ascend_config
 from vllm_ascend.attention.attention_mask import AttentionMaskBuilder
 from vllm_ascend.attention.attention_v1 import AscendAttentionState
@@ -68,6 +69,31 @@ if TYPE_CHECKING:
 
 # token count limits within bmm_transpose operator
 BMM_TRANS_MAX_SUPPORTED_TOKENS = 1024
+
+# Physical-page-order invariance for the sparse attention kernel.
+#
+# npu_sparse_flash_attention consumes the top-k indices as a set, but it walks
+# them in the given order, so its accumulation order - and with it the bf16
+# rounding - depends on the physical KV block layout whenever the indices are
+# not monotonic. The lightning indexer returns them sorted by score, so two
+# requests with identical content but different block placement produce
+# different bits. Sorting the valid indices ascending (-1 padding kept at the
+# tail, as the kernel requires) makes the walk order a pure function of the
+# logical positions.
+_TOPK_PAD_SENTINEL_F = 1.0e9
+
+
+def canonicalize_topk_indices(topk_indices: torch.Tensor) -> torch.Tensor:
+    if not envs_ascend.VLLM_ASCEND_SFA_SORT_TOPK:
+        return topk_indices
+    # NOTE: the int32 sort runs on AICPU on A2 (~30 ms for [1043, 2048]); the
+    # float32 sort is an AI Core kernel (~0.2 ms). Positions are below 2^24 and
+    # are therefore exact in float32.
+    keyed = topk_indices.to(torch.float32)
+    keyed = torch.where(keyed < 0, torch.full_like(keyed, _TOPK_PAD_SENTINEL_F), keyed)
+    sorted_keys = torch.sort(keyed, dim=-1).values
+    sorted_keys = torch.where(sorted_keys >= _TOPK_PAD_SENTINEL_F, torch.full_like(sorted_keys, -1.0), sorted_keys)
+    return sorted_keys.to(topk_indices.dtype)
 
 
 class PreprocessType(enum.Enum):
@@ -1650,6 +1676,10 @@ class AscendSFAImpl(MLAAttentionImpl):
                 actual_seq_lengths_query=actual_seq_lengths_query,
                 actual_seq_lengths_key=actual_seq_lengths_key,
             )
+            # Make the kernel walk order independent of the physical block
+            # layout. Applied before the cache is updated so that the layers
+            # reusing the cached top-k see the same order.
+            topk_indices = canonicalize_topk_indices(topk_indices)
             if self.use_index_cache:
                 self._update_indexcache_topk_indices(topk_indices)
 

--- a/vllm_ascend/envs.py
+++ b/vllm_ascend/envs.py
@@ -80,6 +80,12 @@ env_variables: dict[str, Callable[[], Any]] = {
     "VLLM_ASCEND_ENABLE_NZ": lambda: int(os.getenv("VLLM_ASCEND_ENABLE_NZ", 1)),
     # Whether to anbale dynamic EPLB
     "DYNAMIC_EPLB": lambda: os.getenv("DYNAMIC_EPLB", "false").lower(),
+    # Whether the sparse attention top-k indices are sorted into ascending
+    # order before they are used and cached. npu_sparse_flash_attention walks
+    # the indices in the given order, so without this the accumulation order -
+    # and the rounding that follows from it - depends on the physical KV block
+    # layout of the request. Set to 0 to restore the raw indexer order.
+    "VLLM_ASCEND_SFA_SORT_TOPK": lambda: bool(int(os.getenv("VLLM_ASCEND_SFA_SORT_TOPK", "1"))),
     # Control the aclrtMemcpyBatchAsync compile path for KV cache offloading.
     # "1": force enable, "0": force disable, None: auto-detect from CANN headers.
     "VLLM_ASCEND_ENABLE_BATCH_MEMCPY": lambda: os.getenv("VLLM_ASCEND_ENABLE_BATCH_MEMCPY", None),


### PR DESCRIPTION
### What this PR does / why we need it?

`npu_sparse_flash_attention` consumes the top-k indices as a set, but it
walks them in the given order, so its accumulation order - and with it the
bf16 rounding - depends on the physical KV block layout whenever the indices
are not monotonic. The lightning indexer returns them sorted by score, so
two requests with identical content but different block placement produce
different bits. On a W4A8 MoE model that difference is amplified by the
routing of every following layer: replaying the same request on an idle
server gives a different first token from run to run, and no bit-exactness
check is possible on this backend.

Measured on TP8 with one request replayed serially on an idle server:

| build | first token over replays |
|---|---|
| unpatched | 5 different logprobs in 5 replays, one of them a different token |
| this PR + `HCCL_DETERMINISTIC=true` | one logprob, 20/20 replays bit-identical |

This PR sorts the valid indices ascending (padding `-1` kept at the tail, as
the kernel requires) before they are used and before they are written to the
shared index cache, which makes the walk order a pure function of the
logical positions. The sort is done in float32 because the int32 sort falls
back to AICPU on A2; positions are below 2^24 and are therefore exact:

| `torch.sort` on `[T, 1, 2048]` | int32 | float32 |
|---|---:|---:|
| T = 1043 | 29.8 ms | 0.21 ms |
| T = 128 | 10.6 ms | 0.21 ms |

Cost, same configuration, cc96 x 128 output tokens, aggregate throughput of
two waves: this PR together with `HCCL_DETERMINISTIC=true` gives
265/273 tok/s against 277/285 tok/s for the unpatched baseline, about 4%.
`VLLM_ASCEND_SFA_SORT_TOPK=0` restores the raw indexer order.

Related, different scope: #14884 (same-request output instability under
concurrency with `VLLM_BATCH_INVARIANT=1`) is about batch invariance, which
this PR does not address - it removes the *block placement* source of drift,
not the batch-composition one.

This PR is independent of #15172; both touch the same two lines in
`AscendSFAImpl.forward`, so whichever lands second needs a trivial rebase.

### Does this PR introduce _any_ user-facing change?

Yes.

- Sparse attention now walks the top-k indices in ascending order, so output
  bits change for SFA models. The new order is the reproducible one: the
  same request on an idle server gives the same result across runs and
  across block placements.
- New environment variable `VLLM_ASCEND_SFA_SORT_TOPK` (default 1). Set it
  to 0 to keep the previous behaviour.

### How was this patch tested?

- New unit test `tests/ut/attention/test_sfa_topk_order.py`: valid indices
  sorted ascending with `-1` padding at the tail, the selected set preserved
  per row, positions up to 2^24 exact through the float32 key, and the env
  switch returning the indexer order unchanged.
- Replay and micro-benchmark numbers as tabulated above (single node, TP8).
- Exercised on Atlas 800I A2 with PP4xTP4 and long-context prefills: a
  96-prompt first-token panel is bit-identical across two runs, and
  throughput under 128 concurrent streams is unchanged within run-to-run
  spread.

- vLLM version: v0.27.1
- vLLM main: https://github.com/vllm-project/vllm/commit/ba07e4a48fc951300d97eb506217dd530583dea3
