### PR TITLE
[Feature][MRV2] Support o_proj TP in model runner v2

### DIFF
--- a/tests/ut/test_ascend_config.py
+++ b/tests/ut/test_ascend_config.py
@@ -877,7 +877,9 @@ class TestSubconfigPydanticTypeValidation(TestBase):
 
         def vllm_config(cudagraph_mode):
             return SimpleNamespace(
-                parallel_config=SimpleNamespace(tensor_parallel_size=1, data_parallel_size=8),
+                parallel_config=SimpleNamespace(
+                    tensor_parallel_size=1, data_parallel_size=8, prefill_context_parallel_size=1
+                ),
                 compilation_config=SimpleNamespace(cudagraph_mode=cudagraph_mode),
                 kv_transfer_config=SimpleNamespace(is_kv_consumer=True),
                 model_config=SimpleNamespace(is_moe=True),
@@ -889,6 +891,26 @@ class TestSubconfigPydanticTypeValidation(TestBase):
         with self.assertRaisesRegex(AssertionError, "only supported in graph mode"):
             config._validate_preconditions(vllm_config(CUDAGraphMode.NONE))
         config._validate_preconditions(vllm_config(CUDAGraphMode.FULL_DECODE_ONLY))
+
+    def test_oproj_tp_rejects_pcp(self):
+        from vllm.config.compilation import CUDAGraphMode
+
+        def vllm_config(pcp_size):
+            return SimpleNamespace(
+                parallel_config=SimpleNamespace(
+                    tensor_parallel_size=1, data_parallel_size=8, prefill_context_parallel_size=pcp_size
+                ),
+                compilation_config=SimpleNamespace(cudagraph_mode=CUDAGraphMode.FULL_DECODE_ONLY),
+                kv_transfer_config=SimpleNamespace(is_kv_consumer=True),
+                model_config=SimpleNamespace(is_moe=True),
+            )
+
+        config = FinegrainedTPConfig(oproj_tensor_parallel_size=2)
+        # PCP's dispatch recomputes the token count per rank, dropping the
+        # DP-padded count; eager steps would hang the cross-DP collectives.
+        with self.assertRaisesRegex(AssertionError, "not supported with prefill_context_parallel_size"):
+            config._validate_preconditions(vllm_config(2))
+        config._validate_preconditions(vllm_config(1))
 
     def test_eplb_config_int_field_lax(self):
         cfg = EplbConfig(eplb_policy_type="2")

--- a/tests/ut/test_ascend_config.py
+++ b/tests/ut/test_ascend_config.py
@@ -872,6 +872,24 @@ class TestSubconfigPydanticTypeValidation(TestBase):
         with self.assertRaisesRegex(ValueError, "lmhead_tensor_parallel_size must be non-negative"):
             FinegrainedTPConfig(lmhead_tensor_parallel_size=-1)
 
+    def test_oproj_tp_requires_graph_mode(self):
+        from vllm.config.compilation import CUDAGraphMode
+
+        def vllm_config(cudagraph_mode):
+            return SimpleNamespace(
+                parallel_config=SimpleNamespace(tensor_parallel_size=1, data_parallel_size=8),
+                compilation_config=SimpleNamespace(cudagraph_mode=cudagraph_mode),
+                kv_transfer_config=SimpleNamespace(is_kv_consumer=True),
+                model_config=SimpleNamespace(is_moe=True),
+            )
+
+        config = FinegrainedTPConfig(oproj_tensor_parallel_size=2)
+        # VllmConfig.__post_init__ normalizes enforce_eager into NONE, so this
+        # single check covers both spellings of "no graph mode".
+        with self.assertRaisesRegex(AssertionError, "only supported in graph mode"):
+            config._validate_preconditions(vllm_config(CUDAGraphMode.NONE))
+        config._validate_preconditions(vllm_config(CUDAGraphMode.FULL_DECODE_ONLY))
+
     def test_eplb_config_int_field_lax(self):
         cfg = EplbConfig(eplb_policy_type="2")
         self.assertEqual(cfg.eplb_policy_type, 2)

--- a/tests/ut/worker/test_model_runner_v2_finegrained_tp.py
+++ b/tests/ut/worker/test_model_runner_v2_finegrained_tp.py
@@ -265,9 +265,8 @@ def _make_batch_req_state(num_tokens):
     "enabled,dummy_run,is_profile,total,expected_calls",
     [
         (True, False, False, 5, 1),  # real step with work: agree the group max
-        # A real step with nothing scheduled returns from the parent before
-        # dispatch without posting any DP collective, so an all_reduce here
-        # would desync the gloo op stream against busy/dummy steps.
+        # Zero-token steps return before dispatch without any DP collective; an
+        # all_reduce here would desync the gloo op stream against busy/dummy steps.
         (True, False, False, 0, 0),
         (True, True, False, 0, 1),  # dummy step (idle rank): report zero
         (True, False, True, 5, 0),  # profile run
@@ -308,7 +307,6 @@ def test_dp_padding_dummy_step_forwards_group_max():
     forwarded = super_execute.call_args.args[0]
     assert forwarded.total_num_scheduled_tokens == 4
     # decode_query_len-sized requests keep the dummy decode-graph matchable
-    # (given a capture size that covers the group max)
     assert list(forwarded.num_scheduled_tokens.values()) == [2, 2]
     assert forwarded.finished_req_ids == {"done-r0"}
 
@@ -319,14 +317,12 @@ def test_dp_padded_dummy_output_keeps_decode_shape():
     assert list(out.num_scheduled_tokens.values()) == [2, 2]
     assert out.total_num_scheduled_tokens == 4
 
-    # A remainder keeps the total exact; the batch is non-uniform, so no decode
-    # graph matches regardless of the dummy's shape.
+    # A remainder keeps the total exact; the batch is non-uniform so no decode graph matches.
     out = make_dp_padded_dummy_output(_make_scheduler_output(0), group_max=5, decode_query_len=2, max_num_reqs=8)
     assert list(out.num_scheduled_tokens.values()) == [2, 2, 1]
     assert out.total_num_scheduled_tokens == 5
 
-    # Past max_num_reqs the decode graphs cannot match either; fall back to
-    # _dummy_run's bounded even split, keeping the total exact.
+    # Past max_num_reqs the decode graphs cannot match either; use _dummy_run's bounded even split.
     out = make_dp_padded_dummy_output(_make_scheduler_output(0), group_max=9, decode_query_len=2, max_num_reqs=3)
     assert list(out.num_scheduled_tokens.values()) == [3, 3, 3]
     assert out.total_num_scheduled_tokens == 9

--- a/tests/ut/worker/test_model_runner_v2_finegrained_tp.py
+++ b/tests/ut/worker/test_model_runner_v2_finegrained_tp.py
@@ -353,8 +353,8 @@ def test_prepare_inputs_restores_real_extent_wiring():
         n for n in ast.walk(tree) if isinstance(n, ast.If) and "_dp_padding_aligned_tokens" in ast.unparse(n.test)
     ]
     assert len(restore) == 1
-    assert "_dp_padding_original_tokens" in ast.unparse(restore[0].body)
-    assert "batch_req_state.num_tokens" in ast.unparse(restore[0].orelse)
+    assert "_dp_padding_original_tokens" in ast.unparse(ast.Module(body=restore[0].body, type_ignores=[]))
+    assert "batch_req_state.num_tokens" in ast.unparse(ast.Module(body=restore[0].orelse, type_ignores=[]))
     # the padded row count still derives from the restored value
     assert "max(num_tokens, batch_desc.num_tokens)" in ast.unparse(tree)
     fills = [

--- a/tests/ut/worker/test_model_runner_v2_finegrained_tp.py
+++ b/tests/ut/worker/test_model_runner_v2_finegrained_tp.py
@@ -19,7 +19,7 @@ from vllm.v1.worker.gpu.sample.sampler import Sampler
 from vllm.v1.worker.gpu.spec_decode.rejection_sampler import RejectionSampler
 from vllm.v1.worker.gpu.structured_outputs import StructuredOutputsWorker
 
-from vllm_ascend.worker.v2.eager_dp_padding import sync_dp_group_max_tokens
+from vllm_ascend.worker.v2.eager_dp_padding import make_dp_padded_dummy_output, sync_dp_group_max_tokens
 from vllm_ascend.worker.v2.model_runner import NPUModelRunner
 
 
@@ -225,6 +225,7 @@ def _make_dp_padding_runner(enabled=True, aligned_tokens=0):
     runner._dp_padding_original_tokens = 0
     runner.dp_size = 8
     runner.dp_rank = 3
+    runner.decode_query_len = 2
     # need_timing=False keeps both profiling helpers pure no-ops (no NPU sync).
     runner.ascend_config = SimpleNamespace(
         scheduler_config=SimpleNamespace(profiling_chunk_config=SimpleNamespace(need_timing=False))
@@ -305,8 +306,21 @@ def test_dp_padding_dummy_step_forwards_group_max():
 
     forwarded = super_execute.call_args.args[0]
     assert forwarded.total_num_scheduled_tokens == 4
-    assert forwarded.num_scheduled_tokens == {"_dummy_dp_padding": 4}
+    # decode_query_len-sized requests keep the dummy graph-matchable
+    assert list(forwarded.num_scheduled_tokens.values()) == [2, 2]
     assert forwarded.finished_req_ids == {"done-r0"}
+
+
+def test_dp_padded_dummy_output_keeps_decode_shape():
+    """The rewrite must stay uniform-decode shaped (graph match) with an exact total."""
+    out = make_dp_padded_dummy_output(_make_scheduler_output(0), group_max=4, decode_query_len=2)
+    assert list(out.num_scheduled_tokens.values()) == [2, 2]
+    assert out.total_num_scheduled_tokens == 4
+
+    # A remainder keeps the eager row count exact; the step is non-uniform anyway.
+    out = make_dp_padded_dummy_output(_make_scheduler_output(0), group_max=5, decode_query_len=2)
+    assert list(out.num_scheduled_tokens.values()) == [2, 2, 1]
+    assert out.total_num_scheduled_tokens == 5
 
 
 @pytest.mark.parametrize(

--- a/tests/ut/worker/test_model_runner_v2_finegrained_tp.py
+++ b/tests/ut/worker/test_model_runner_v2_finegrained_tp.py
@@ -307,7 +307,8 @@ def test_dp_padding_dummy_step_forwards_group_max():
 
     forwarded = super_execute.call_args.args[0]
     assert forwarded.total_num_scheduled_tokens == 4
-    # decode_query_len-sized requests keep the dummy graph-matchable
+    # decode_query_len-sized requests keep the dummy decode-graph matchable
+    # (given a capture size that covers the group max)
     assert list(forwarded.num_scheduled_tokens.values()) == [2, 2]
     assert forwarded.finished_req_ids == {"done-r0"}
 
@@ -329,6 +330,47 @@ def test_dp_padded_dummy_output_keeps_decode_shape():
     out = make_dp_padded_dummy_output(_make_scheduler_output(0), group_max=9, decode_query_len=2, max_num_reqs=3)
     assert list(out.num_scheduled_tokens.values()) == [3, 3, 3]
     assert out.total_num_scheduled_tokens == 9
+
+    # The fallback also covers a non-divisible total.
+    out = make_dp_padded_dummy_output(_make_scheduler_output(0), group_max=10, decode_query_len=2, max_num_reqs=3)
+    assert list(out.num_scheduled_tokens.values()) == [3, 3, 4]
+    assert out.total_num_scheduled_tokens == 10
+
+    # decode_query_len == 1: one request per token, still decode-shaped.
+    out = make_dp_padded_dummy_output(_make_scheduler_output(0), group_max=4, decode_query_len=1, max_num_reqs=8)
+    assert list(out.num_scheduled_tokens.values()) == [1, 1, 1, 1]
+    assert out.total_num_scheduled_tokens == 4
+
+
+def test_prepare_inputs_restores_real_extent_wiring():
+    """The restore branch in prepare_inputs must read the recorded real extent.
+
+    Full behavioral coverage lands with the UT rework; this pins the wiring so a
+    refactor cannot silently drop it.
+    """
+    import ast
+    import inspect
+    import textwrap
+
+    tree = ast.parse(textwrap.dedent(inspect.getsource(NPUModelRunner.prepare_inputs)))
+    restore = [
+        n for n in ast.walk(tree) if isinstance(n, ast.If) and "_dp_padding_aligned_tokens" in ast.unparse(n.test)
+    ]
+    assert len(restore) == 1
+    assert "_dp_padding_original_tokens" in ast.unparse(restore[0].body)
+    assert "batch_req_state.num_tokens" in ast.unparse(restore[0].orelse)
+    # the padded row count still derives from the restored value
+    assert "max(num_tokens, batch_desc.num_tokens)" in ast.unparse(tree)
+    fills = [
+        n
+        for n in ast.walk(tree)
+        if isinstance(n, ast.Assign)
+        and isinstance(n.targets[0], ast.Subscript)
+        and ast.unparse(n.targets[0]).startswith("query_start_loc_np[num_reqs")
+        and isinstance(n.value, ast.Name)
+        and n.value.id == "num_tokens"
+    ]
+    assert fills, "the trailing query_start_loc fill must use the restored num_tokens"
 
 
 @pytest.mark.parametrize(

--- a/tests/ut/worker/test_model_runner_v2_finegrained_tp.py
+++ b/tests/ut/worker/test_model_runner_v2_finegrained_tp.py
@@ -226,6 +226,7 @@ def _make_dp_padding_runner(enabled=True, aligned_tokens=0):
     runner.dp_size = 8
     runner.dp_rank = 3
     runner.decode_query_len = 2
+    runner.max_num_reqs = 8
     # need_timing=False keeps both profiling helpers pure no-ops (no NPU sync).
     runner.ascend_config = SimpleNamespace(
         scheduler_config=SimpleNamespace(profiling_chunk_config=SimpleNamespace(need_timing=False))
@@ -313,14 +314,21 @@ def test_dp_padding_dummy_step_forwards_group_max():
 
 def test_dp_padded_dummy_output_keeps_decode_shape():
     """The rewrite must stay uniform-decode shaped (graph match) with an exact total."""
-    out = make_dp_padded_dummy_output(_make_scheduler_output(0), group_max=4, decode_query_len=2)
+    out = make_dp_padded_dummy_output(_make_scheduler_output(0), group_max=4, decode_query_len=2, max_num_reqs=8)
     assert list(out.num_scheduled_tokens.values()) == [2, 2]
     assert out.total_num_scheduled_tokens == 4
 
-    # A remainder keeps the eager row count exact; the step is non-uniform anyway.
-    out = make_dp_padded_dummy_output(_make_scheduler_output(0), group_max=5, decode_query_len=2)
+    # A remainder keeps the total exact; the batch is non-uniform, so no decode
+    # graph matches regardless of the dummy's shape.
+    out = make_dp_padded_dummy_output(_make_scheduler_output(0), group_max=5, decode_query_len=2, max_num_reqs=8)
     assert list(out.num_scheduled_tokens.values()) == [2, 2, 1]
     assert out.total_num_scheduled_tokens == 5
+
+    # Past max_num_reqs the decode graphs cannot match either; fall back to
+    # _dummy_run's bounded even split, keeping the total exact.
+    out = make_dp_padded_dummy_output(_make_scheduler_output(0), group_max=9, decode_query_len=2, max_num_reqs=3)
+    assert list(out.num_scheduled_tokens.values()) == [3, 3, 3]
+    assert out.total_num_scheduled_tokens == 9
 
 
 @pytest.mark.parametrize(

--- a/tests/ut/worker/test_model_runner_v2_finegrained_tp.py
+++ b/tests/ut/worker/test_model_runner_v2_finegrained_tp.py
@@ -1,21 +1,25 @@
-"""Unit tests for lmhead TP support in the Ascend V2 model runner.
+"""Unit tests for fine-grained TP support in the Ascend V2 model runner.
 
 Pure-mock tests (CPU tensors, no NPU): they lock the runner-side pad/trim
 contract of sample()/_dummy_run and guard the copied dispatch tail with a
-canary that compares it call-by-call against upstream GPUModelRunner.sample.
-Collective behavior of the LM head itself is validated on real hardware.
+canary that compares it call-by-call against upstream GPUModelRunner.sample,
+plus the eager DP padding contract of o_proj TP. Collective behavior of the
+LM head and the OTP exchange itself is validated on real hardware.
 """
 
 from types import SimpleNamespace
 from unittest.mock import MagicMock, create_autospec, patch
 
+import numpy as np
 import pytest
 import torch
-from vllm.v1.worker.gpu.model_runner import GPUModelRunner
+from vllm.v1.core.sched.output import SchedulerOutput
+from vllm.v1.worker.gpu.model_runner import BatchReqState, GPUModelRunner
 from vllm.v1.worker.gpu.sample.sampler import Sampler
 from vllm.v1.worker.gpu.spec_decode.rejection_sampler import RejectionSampler
 from vllm.v1.worker.gpu.structured_outputs import StructuredOutputsWorker
 
+from vllm_ascend.worker.v2.eager_dp_padding import sync_dp_group_max_tokens
 from vllm_ascend.worker.v2.model_runner import NPUModelRunner
 
 
@@ -211,6 +215,142 @@ def test_dummy_run_joins_lmhead_collectives_at_capacity():
     torch.testing.assert_close(dummy_input, hidden_states[torch.zeros(16, dtype=torch.long)])
     # return contract is a pure passthrough of the parent's values
     assert result == (hidden_states, sample_hidden)
+
+
+def _make_dp_padding_runner(enabled=True, aligned_tokens=0):
+    """Bare runner carrying only the eager-DP-padding state."""
+    runner = object.__new__(NPUModelRunner)
+    runner._dp_padding_enabled = enabled
+    runner._dp_padding_aligned_tokens = aligned_tokens
+    runner._dp_padding_original_tokens = 0
+    runner.dp_size = 8
+    runner.dp_rank = 3
+    # need_timing=False keeps both profiling helpers pure no-ops (no NPU sync).
+    runner.ascend_config = SimpleNamespace(
+        scheduler_config=SimpleNamespace(profiling_chunk_config=SimpleNamespace(need_timing=False))
+    )
+    return runner
+
+
+def _make_scheduler_output(total, num_scheduled_tokens=None):
+    return SchedulerOutput(
+        scheduled_new_reqs=[],
+        scheduled_cached_reqs=MagicMock(),
+        num_scheduled_tokens=dict(num_scheduled_tokens or {}),
+        total_num_scheduled_tokens=total,
+        scheduled_spec_decode_tokens={},
+        scheduled_encoder_inputs={},
+        num_common_prefix_blocks=[],
+        finished_req_ids={"done-r0"},
+        free_encoder_mm_hashes=[],
+    )
+
+
+def _make_batch_req_state(num_tokens):
+    return BatchReqState(
+        req_ids=["r0"],
+        num_scheduled_tokens=np.array([num_tokens], dtype=np.int32),
+        num_tokens=num_tokens,
+        idx_mapping_np=np.array([0], dtype=np.intp),
+        prefill_len_np=np.array([0], dtype=np.int32),
+        num_computed_prefill_tokens_np=np.array([0], dtype=np.int32),
+        is_prefilling_np=np.array([False]),
+        has_prefill=False,
+    )
+
+
+@pytest.mark.parametrize(
+    "enabled,dummy_run,is_profile,total,expected_calls",
+    [
+        (True, False, False, 5, 1),  # real step with work: agree the group max
+        # A real step with nothing scheduled returns from the parent before
+        # dispatch without posting any DP collective, so an all_reduce here
+        # would desync the gloo op stream against busy/dummy steps.
+        (True, False, False, 0, 0),
+        (True, True, False, 0, 1),  # dummy step (idle rank): report zero
+        (True, False, True, 5, 0),  # profile run
+        (False, False, False, 5, 0),  # feature off
+    ],
+)
+def test_dp_padding_execute_model_gate(enabled, dummy_run, is_profile, total, expected_calls):
+    runner = _make_dp_padding_runner(enabled=enabled)
+    scheduler_output = _make_scheduler_output(total, {"r0": total} if total else {})
+
+    with (
+        patch("vllm_ascend.worker.v2.model_runner.sync_dp_group_max_tokens", return_value=0) as sync,
+        patch("vllm_ascend.worker.v2.model_runner.make_dp_padded_dummy_output") as make_dummy,
+        patch.object(NPUModelRunner.__bases__[0], "execute_model", return_value="out") as super_execute,
+    ):
+        assert runner.execute_model(scheduler_output, dummy_run=dummy_run, is_profile=is_profile) == "out"
+
+    assert sync.call_count == expected_calls
+    if expected_calls:
+        # dummy ranks report zero, so only real work raises the group max
+        assert sync.call_args.args == (0 if dummy_run else total, 8, 3)
+    make_dummy.assert_not_called()
+    assert super_execute.call_args.args[0] is scheduler_output
+
+
+def test_dp_padding_dummy_step_forwards_group_max():
+    """An idle rank must run its dummy batch at the group's agreed size, and the
+    rewrite must leave the rest of the synthetic output intact."""
+    runner = _make_dp_padding_runner()
+    scheduler_output = _make_scheduler_output(0)
+
+    with (
+        patch("vllm_ascend.worker.v2.model_runner.sync_dp_group_max_tokens", return_value=4),
+        patch.object(NPUModelRunner.__bases__[0], "execute_model", return_value="out") as super_execute,
+    ):
+        runner.execute_model(scheduler_output, dummy_run=True)
+
+    forwarded = super_execute.call_args.args[0]
+    assert forwarded.total_num_scheduled_tokens == 4
+    assert forwarded.num_scheduled_tokens == {"_dummy_dp_padding": 4}
+    assert forwarded.finished_req_ids == {"done-r0"}
+
+
+@pytest.mark.parametrize(
+    "aligned,parent_tokens,expected_reported,expected_original",
+    [
+        (8, 5, 8, 5),  # dispatch sees the group max, the real extent stays recoverable
+        (8, 8, 8, 8),  # this rank already is the group max
+        (0, 5, 5, 5),  # padding inactive
+        (8, None, None, 0),  # dummy step: no parent state to pad or record
+    ],
+)
+def test_dp_padding_gather_reports_group_max(aligned, parent_tokens, expected_reported, expected_original):
+    runner = _make_dp_padding_runner(aligned_tokens=aligned)
+    dummy_run = parent_tokens is None
+    parent = (None, 4) if dummy_run else (_make_batch_req_state(parent_tokens), None)
+
+    with patch.object(NPUModelRunner.__bases__[0], "gather_batch_req_state", return_value=parent):
+        # the scheduler output still reports the untrimmed total
+        batch_req_state, uniform_tok_count = runner.gather_batch_req_state(_make_scheduler_output(8), dummy_run)
+
+    assert (None if batch_req_state is None else batch_req_state.num_tokens) == expected_reported
+    assert runner._dp_padding_original_tokens == expected_original
+    assert uniform_tok_count == (4 if dummy_run else None)
+
+
+def test_dp_padding_sync_is_one_hot_then_max():
+    """The agreement mirrors dp_utils.sync_cudagraph_and_dp_padding: only this
+    rank's slot carries a count, and the returned value is the vector max."""
+    seen = {}
+
+    def fake_all_reduce(tensor, group=None):
+        seen["sent"] = tensor.clone()
+        seen["group"] = group
+        tensor[2] = 5  # some rank in the group reported 5 tokens
+
+    with (
+        patch("vllm_ascend.worker.v2.eager_dp_padding.get_dp_group", return_value=SimpleNamespace(cpu_group="dp-cpu")),
+        patch("vllm_ascend.worker.v2.eager_dp_padding.dist.all_reduce", fake_all_reduce),
+    ):
+        group_max = sync_dp_group_max_tokens(3, dp_size=4, dp_rank=1)
+
+    assert seen["sent"].tolist() == [0, 3, 0, 0]
+    assert seen["group"] == "dp-cpu"
+    assert group_max == 5
 
 
 def test_dummy_run_lmhead_disabled_or_profile_skips_collectives():

--- a/vllm_ascend/ascend_config.py
+++ b/vllm_ascend/ascend_config.py
@@ -1013,8 +1013,8 @@ class FinegrainedTPConfig:
                     "tensor_parallel_size == 1, got "
                     f"{vc.parallel_config.tensor_parallel_size}."
                 )
-            # The DSA exchange's address-stable buffers are sized to get_potential_max_tokens (decode scale);
-            # larger eager steps fail fast there. NONE also covers enforce_eager (normalized in VllmConfig).
+            # The DP padding is only validated with a graph mode (V1 rejects eager for this knob too); the DSA
+            # path additionally fails fast on oversized eager steps (decode-scale buffers). NONE covers enforce_eager.
             if vc.compilation_config.cudagraph_mode == CUDAGraphMode.NONE:
                 raise AssertionError("oproj_tensor_parallel_size is only supported in graph mode")
             if vc.kv_transfer_config is None or not vc.kv_transfer_config.is_kv_consumer:

--- a/vllm_ascend/ascend_config.py
+++ b/vllm_ascend/ascend_config.py
@@ -1013,7 +1013,8 @@ class FinegrainedTPConfig:
                     "tensor_parallel_size == 1, got "
                     f"{vc.parallel_config.tensor_parallel_size}."
                 )
-            # The DSA exchange needs ACL graph capture; NONE also covers enforce_eager (normalized in VllmConfig).
+            # Address-stable DSA buffers are sized at decode scale (get_potential_max_tokens); eager prefill overflows.
+            # Checking NONE also covers enforce_eager, which VllmConfig normalizes to NONE.
             if vc.compilation_config.cudagraph_mode == CUDAGraphMode.NONE:
                 raise AssertionError("oproj_tensor_parallel_size is only supported in graph mode")
             if vc.kv_transfer_config is None or not vc.kv_transfer_config.is_kv_consumer:

--- a/vllm_ascend/ascend_config.py
+++ b/vllm_ascend/ascend_config.py
@@ -1005,34 +1005,22 @@ class FinegrainedTPConfig:
         enabled_configs = []
         if self.oproj_tensor_parallel_size > 0:
             enabled_configs.append(f"oproj_tensor_parallel_size={self.oproj_tensor_parallel_size}")
-            # wo_a/wo_b are sharded solely by the OTP group (which splits DP,
-            # orthogonal to the standard TP group), but _forward_o_proj reshapes
-            # the attention output with n_local_groups = n_groups // tp_size
-            # (standard TP). When tp_size > 1 the weight-shard and input-shard
-            # operate on different axes of the rank grid and no longer align,
-            # so oproj TP currently requires standard tp_size == 1.
+            # _forward_o_proj reshapes with n_local_groups = n_groups // tp_size (standard TP),
+            # which misaligns with the OTP weight shard (DP axis) when tp_size > 1.
             if vc.parallel_config.tensor_parallel_size > 1:
                 raise AssertionError(
                     "oproj_tensor_parallel_size currently requires "
                     "tensor_parallel_size == 1, got "
                     f"{vc.parallel_config.tensor_parallel_size}."
                 )
-            # The DSA o_proj exchange runs on address-stable buffers sized at decode
-            # scale (`get_potential_max_tokens`, overflow fails fast) and shaped for
-            # ACL graph replay — eager prefill chunks can exceed the capacity. V1
-            # also rejects `enforce_eager` for this knob. VllmConfig.__post_init__
-            # maps enforce_eager to cudagraph_mode=NONE, so checking the mode
-            # covers both.
+            # The DSA exchange needs ACL graph capture; NONE also covers enforce_eager (normalized in VllmConfig).
             if vc.compilation_config.cudagraph_mode == CUDAGraphMode.NONE:
                 raise AssertionError("oproj_tensor_parallel_size is only supported in graph mode")
             if vc.kv_transfer_config is None or not vc.kv_transfer_config.is_kv_consumer:
                 raise AssertionError(
                     "oproj_tensor_parallel_size is only supported in pd scenario and can only be used in D node."
                 )
-            # With PCP on, the upstream dispatch recomputes num_tokens from
-            # per-request num_scheduled_tokens, dropping the DP-padded count
-            # gather_batch_req_state reports — eager steps fall back to
-            # per-rank counts and the cross-DP collectives would hang.
+            # PCP's dispatch recomputes num_tokens per rank, dropping the DP-padded count.
             if vc.parallel_config.prefill_context_parallel_size > 1:
                 raise AssertionError(
                     "oproj_tensor_parallel_size is not supported with prefill_context_parallel_size > 1."

--- a/vllm_ascend/ascend_config.py
+++ b/vllm_ascend/ascend_config.py
@@ -1029,6 +1029,14 @@ class FinegrainedTPConfig:
                 raise AssertionError(
                     "oproj_tensor_parallel_size is only supported in pd scenario and can only be used in D node."
                 )
+            # With PCP on, the upstream dispatch recomputes num_tokens from
+            # per-request num_scheduled_tokens, dropping the DP-padded count
+            # gather_batch_req_state reports — eager steps fall back to
+            # per-rank counts and the cross-DP collectives would hang.
+            if vc.parallel_config.prefill_context_parallel_size > 1:
+                raise AssertionError(
+                    "oproj_tensor_parallel_size is not supported with prefill_context_parallel_size > 1."
+                )
         if self.lmhead_tensor_parallel_size > 0:
             enabled_configs.append(f"lmhead_tensor_parallel_size={self.lmhead_tensor_parallel_size}")
         if self.embedding_tensor_parallel_size > 0:

--- a/vllm_ascend/ascend_config.py
+++ b/vllm_ascend/ascend_config.py
@@ -1017,10 +1017,12 @@ class FinegrainedTPConfig:
                     "tensor_parallel_size == 1, got "
                     f"{vc.parallel_config.tensor_parallel_size}."
                 )
-            # The o_proj exchange requires ACL graph capture (buffers sized
-            # for graph replay; eager dummy runs skip the attention module).
-            # VllmConfig.__post_init__ maps enforce_eager to
-            # cudagraph_mode=NONE, so checking the mode covers both.
+            # The DSA o_proj exchange runs on address-stable buffers sized at decode
+            # scale (`get_potential_max_tokens`, overflow fails fast) and shaped for
+            # ACL graph replay — eager prefill chunks can exceed the capacity. V1
+            # also rejects `enforce_eager` for this knob. VllmConfig.__post_init__
+            # maps enforce_eager to cudagraph_mode=NONE, so checking the mode
+            # covers both.
             if vc.compilation_config.cudagraph_mode == CUDAGraphMode.NONE:
                 raise AssertionError("oproj_tensor_parallel_size is only supported in graph mode")
             if vc.kv_transfer_config is None or not vc.kv_transfer_config.is_kv_consumer:

--- a/vllm_ascend/ascend_config.py
+++ b/vllm_ascend/ascend_config.py
@@ -1013,8 +1013,8 @@ class FinegrainedTPConfig:
                     "tensor_parallel_size == 1, got "
                     f"{vc.parallel_config.tensor_parallel_size}."
                 )
-            # Address-stable DSA buffers are sized at decode scale (get_potential_max_tokens); eager prefill overflows.
-            # Checking NONE also covers enforce_eager, which VllmConfig normalizes to NONE.
+            # The DSA exchange's address-stable buffers are sized to get_potential_max_tokens (decode scale);
+            # larger eager steps fail fast there. NONE also covers enforce_eager (normalized in VllmConfig).
             if vc.compilation_config.cudagraph_mode == CUDAGraphMode.NONE:
                 raise AssertionError("oproj_tensor_parallel_size is only supported in graph mode")
             if vc.kv_transfer_config is None or not vc.kv_transfer_config.is_kv_consumer:

--- a/vllm_ascend/ascend_config.py
+++ b/vllm_ascend/ascend_config.py
@@ -998,6 +998,9 @@ class FinegrainedTPConfig:
         return self
 
     def _validate_preconditions(self, vllm_config: Any):
+        # Local import to avoid a circular import during platform resolution.
+        from vllm.config.compilation import CUDAGraphMode
+
         vc = vllm_config
         enabled_configs = []
         if self.oproj_tensor_parallel_size > 0:
@@ -1014,11 +1017,11 @@ class FinegrainedTPConfig:
                     "tensor_parallel_size == 1, got "
                     f"{vc.parallel_config.tensor_parallel_size}."
                 )
-            # The static all_to_all / reduce_scatter exchange buffers used by
-            # _forward_o_proj are sized for graph replay and require ACL graph
-            # capture; dummy_run does not run the entire attention module in
-            # eager mode, so o_proj tp split can only be used in graph mode.
-            if vc.model_config and vc.model_config.enforce_eager:
+            # The o_proj exchange requires ACL graph capture (buffers sized
+            # for graph replay; eager dummy runs skip the attention module).
+            # VllmConfig.__post_init__ maps enforce_eager to
+            # cudagraph_mode=NONE, so checking the mode covers both.
+            if vc.compilation_config.cudagraph_mode == CUDAGraphMode.NONE:
                 raise AssertionError("oproj_tensor_parallel_size is only supported in graph mode")
             if vc.kv_transfer_config is None or not vc.kv_transfer_config.is_kv_consumer:
                 raise AssertionError(

--- a/vllm_ascend/worker/v2/eager_dp_padding.py
+++ b/vllm_ascend/worker/v2/eager_dp_padding.py
@@ -51,7 +51,8 @@ def make_dp_padded_dummy_output(
     Rewrite a dummy scheduler output to forward exactly `group_max` tokens. The output
     is synthetic, so rewriting it is safe.
     """
-    # decode_query_len-sized requests stay decode-graph matchable; past max_num_reqs use _dummy_run's even split.
+    # decode_query_len-sized requests stay decode-graph matchable when a capture size covers G;
+    # a remainder or a max_num_reqs overflow breaks that match, so the total must stay exact.
     num_full, remainder = divmod(group_max, decode_query_len)
     per_request = [decode_query_len] * num_full
     if remainder:

--- a/vllm_ascend/worker/v2/eager_dp_padding.py
+++ b/vllm_ascend/worker/v2/eager_dp_padding.py
@@ -45,7 +45,7 @@ def sync_dp_group_max_tokens(num_tokens: int, dp_size: int, dp_rank: int) -> int
 
 
 def make_dp_padded_dummy_output(
-    scheduler_output: SchedulerOutput, group_max: int, decode_query_len: int
+    scheduler_output: SchedulerOutput, group_max: int, decode_query_len: int, max_num_reqs: int
 ) -> SchedulerOutput:
     """
     Rewrite a dummy scheduler output to forward exactly `group_max` tokens. The output
@@ -53,13 +53,18 @@ def make_dp_padded_dummy_output(
     """
     # decode_query_len-sized requests keep the dummy uniform-decode shaped, so it
     # still matches the captured decode graphs; one group_max-token request would
-    # drag the whole DP group to eager via the cg_mode min. A trailing remainder
-    # keeps the total exact; then the group-max rank is itself non-uniform and
-    # the step runs eager regardless.
+    # drag the step off them via the cg_mode min (to eager under FULL_DECODE_ONLY,
+    # to the mixed/piecewise graphs under the other modes). A trailing remainder
+    # keeps the total exact — the batch is non-uniform then, so no decode graph
+    # matches regardless of the dummy's shape. Past max_num_reqs the decode graphs
+    # cannot match either, so reuse _dummy_run's bounded even split there.
     num_full, remainder = divmod(group_max, decode_query_len)
     per_request = [decode_query_len] * num_full
     if remainder:
         per_request.append(remainder)
+    if len(per_request) > max_num_reqs:
+        num_reqs = min(group_max, max_num_reqs)
+        per_request = [group_max // num_reqs + (i >= num_reqs - group_max % num_reqs) for i in range(num_reqs)]
     return replace(
         scheduler_output,
         num_scheduled_tokens={f"_dummy_dp_padding_{i}": n for i, n in enumerate(per_request)},

--- a/vllm_ascend/worker/v2/eager_dp_padding.py
+++ b/vllm_ascend/worker/v2/eager_dp_padding.py
@@ -17,9 +17,9 @@
 #
 """DP padding for fine-grained TP eager steps.
 
-Cross-DP collectives (o_proj TP, mlp TP) need every rank to forward the same
-token count per step. Cudagraph dispatch pads natively, eager dispatch would
-hang, so `NPUModelRunner` aligns eager steps to the group max.
+Cross-DP collectives (o_proj TP) need every rank to forward the same token
+count per step. Cudagraph dispatch pads natively, eager dispatch would hang,
+so `NPUModelRunner` aligns eager steps to the group max.
 """
 
 from __future__ import annotations
@@ -52,12 +52,13 @@ def make_dp_padded_dummy_output(
     is synthetic, so rewriting it is safe.
     """
     # decode_query_len-sized requests keep the dummy uniform-decode shaped, so it
-    # still matches the captured decode graphs; one group_max-token request would
-    # drag the step off them via the cg_mode min (to eager under FULL_DECODE_ONLY,
-    # to the mixed/piecewise graphs under the other modes). A trailing remainder
-    # keeps the total exact — the batch is non-uniform then, so no decode graph
-    # matches regardless of the dummy's shape. Past max_num_reqs the decode graphs
-    # cannot match either, so reuse _dummy_run's bounded even split there.
+    # can still match the captured decode graphs when a capture size covers
+    # group_max; one group_max-token request would drag the step off them via the
+    # cg_mode min (to eager under FULL_DECODE_ONLY, to the mixed/piecewise graphs
+    # under the other modes). A trailing remainder keeps the total exact — the
+    # batch is non-uniform then, so no decode graph matches regardless of the
+    # dummy's shape. Past max_num_reqs the decode graphs cannot match either, so
+    # reuse _dummy_run's bounded even split there.
     num_full, remainder = divmod(group_max, decode_query_len)
     per_request = [decode_query_len] * num_full
     if remainder:

--- a/vllm_ascend/worker/v2/eager_dp_padding.py
+++ b/vllm_ascend/worker/v2/eager_dp_padding.py
@@ -51,14 +51,7 @@ def make_dp_padded_dummy_output(
     Rewrite a dummy scheduler output to forward exactly `group_max` tokens. The output
     is synthetic, so rewriting it is safe.
     """
-    # decode_query_len-sized requests keep the dummy uniform-decode shaped, so it
-    # can still match the captured decode graphs when a capture size covers
-    # group_max; one group_max-token request would drag the step off them via the
-    # cg_mode min (to eager under FULL_DECODE_ONLY, to the mixed/piecewise graphs
-    # under the other modes). A trailing remainder keeps the total exact — the
-    # batch is non-uniform then, so no decode graph matches regardless of the
-    # dummy's shape. Past max_num_reqs the decode graphs cannot match either, so
-    # reuse _dummy_run's bounded even split there.
+    # decode_query_len-sized requests stay decode-graph matchable; past max_num_reqs use _dummy_run's even split.
     num_full, remainder = divmod(group_max, decode_query_len)
     per_request = [decode_query_len] * num_full
     if remainder:

--- a/vllm_ascend/worker/v2/eager_dp_padding.py
+++ b/vllm_ascend/worker/v2/eager_dp_padding.py
@@ -51,8 +51,8 @@ def make_dp_padded_dummy_output(
     Rewrite a dummy scheduler output to forward exactly `group_max` tokens. The output
     is synthetic, so rewriting it is safe.
     """
-    # decode_query_len-sized requests stay decode-graph matchable when a capture size covers G;
-    # a remainder or a max_num_reqs overflow breaks that match, so the total must stay exact.
+    # Requests of decode_query_len tokens keep the uniform-decode graph match when a capture size covers G;
+    # a remainder or an overflow fallback loses that match — eager via the cg_mode min only under FULL_DECODE_ONLY.
     num_full, remainder = divmod(group_max, decode_query_len)
     per_request = [decode_query_len] * num_full
     if remainder:

--- a/vllm_ascend/worker/v2/eager_dp_padding.py
+++ b/vllm_ascend/worker/v2/eager_dp_padding.py
@@ -44,13 +44,24 @@ def sync_dp_group_max_tokens(num_tokens: int, dp_size: int, dp_rank: int) -> int
     return int(counts.max().item())
 
 
-def make_dp_padded_dummy_output(scheduler_output: SchedulerOutput, group_max: int) -> SchedulerOutput:
+def make_dp_padded_dummy_output(
+    scheduler_output: SchedulerOutput, group_max: int, decode_query_len: int
+) -> SchedulerOutput:
     """
     Rewrite a dummy scheduler output to forward exactly `group_max` tokens. The output
     is synthetic, so rewriting it is safe.
     """
+    # decode_query_len-sized requests keep the dummy uniform-decode shaped, so it
+    # still matches the captured decode graphs; one group_max-token request would
+    # drag the whole DP group to eager via the cg_mode min. A trailing remainder
+    # keeps the total exact; then the group-max rank is itself non-uniform and
+    # the step runs eager regardless.
+    num_full, remainder = divmod(group_max, decode_query_len)
+    per_request = [decode_query_len] * num_full
+    if remainder:
+        per_request.append(remainder)
     return replace(
         scheduler_output,
-        num_scheduled_tokens={"_dummy_dp_padding": group_max},
+        num_scheduled_tokens={f"_dummy_dp_padding_{i}": n for i, n in enumerate(per_request)},
         total_num_scheduled_tokens=group_max,
     )

--- a/vllm_ascend/worker/v2/eager_dp_padding.py
+++ b/vllm_ascend/worker/v2/eager_dp_padding.py
@@ -1,0 +1,86 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+# Copyright (c) 2025 Huawei Technologies Co., Ltd. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# This file is a part of the vllm-ascend project.
+#
+"""DP padding for fine-grained TP eager steps.
+
+Fine-grained TP features whose collectives cross DP ranks (o_proj TP & mlp TP)
+require every rank of the group to forward the same number of tokens per step.
+Cudagraph dispatch guarantees that natively: the DP sync agrees one group-wide
+token count and pads every rank to it. A step that degrades to eager keeps
+per-rank token counts and the cross-DP collectives would hang.
+
+Instead of rejecting eager steps, keep them DP-aligned with four pieces in
+NPUModelRunner, without replacing any upstream binding:
+
+1. `execute_model` agrees the step's DP-group token max G with one CPU
+   all_reduce before dispatch (real steps report their token count, dummy
+   steps report zero) — the same technique model runner v1's
+   `_sync_metadata_across_dp` applied on every step.
+2. `gather_batch_req_state` reports G as the batch's token count, so the
+   dispatch input already carries the padded size. The eager branch then
+   hands every rank a descriptor at G AND publishes counts[dp_rank] == G,
+   keeping the forward-context invariant (counts[dp_rank] equals the padded
+   forward row count) intact without touching the dispatch result.
+3. `prepare_inputs` restores the real token extent for everything that
+   treats num_tokens as real work (query_start_loc trailing fill,
+   `InputBatch.num_tokens`); padded rows keep flowing through the
+   cudagraph-padding machinery (PAD_SLOT_ID slot mappings, sampler reads
+   only real request rows).
+4. Dummy steps rewrite their synthetic scheduler output to G, so an idle
+   rank's dummy batch forwards exactly G rows and joins the collectives at
+   the same shape.
+"""
+
+from __future__ import annotations
+
+from dataclasses import replace
+
+import torch
+import torch.distributed as dist
+from vllm.distributed.parallel_state import get_dp_group
+from vllm.v1.core.sched.output import SchedulerOutput
+
+
+def sync_dp_group_max_tokens(num_tokens: int, dp_size: int, dp_rank: int) -> int:
+    """Agree the DP-group token-count max with one CPU all_reduce.
+
+    Mirrors the one-hot reduce `dp_utils.sync_cudagraph_and_dp_padding`
+    performs: every rank writes its own count into its slot, the sum
+    all_reduce yields the full per-rank vector, and the max of that vector
+    is identical on every rank. Dummy steps report zero so only real work
+    raises the bar.
+    """
+    cpu_group = get_dp_group().cpu_group
+    counts = torch.zeros(dp_size, dtype=torch.int32)
+    counts[dp_rank] = num_tokens
+    dist.all_reduce(counts, group=cpu_group)
+    return int(counts.max().item())
+
+
+def make_dp_padded_dummy_output(scheduler_output: SchedulerOutput, group_max: int) -> SchedulerOutput:
+    """Rewrite a dummy scheduler output to forward exactly group_max tokens.
+
+    The dummy output is synthetic (built by `_dummy_run`), so replacing
+    its token accounting is safe. One synthetic request keeps the dummy
+    uniform-decode shape gather_batch_req_state derives from it, and makes
+    the eager dispatch report exactly group_max for this rank.
+    """
+    return replace(
+        scheduler_output,
+        num_scheduled_tokens={"_dummy_dp_padding": group_max},
+        total_num_scheduled_tokens=group_max,
+    )

--- a/vllm_ascend/worker/v2/eager_dp_padding.py
+++ b/vllm_ascend/worker/v2/eager_dp_padding.py
@@ -17,32 +17,9 @@
 #
 """DP padding for fine-grained TP eager steps.
 
-Fine-grained TP features whose collectives cross DP ranks (o_proj TP & mlp TP)
-require every rank of the group to forward the same number of tokens per step.
-Cudagraph dispatch guarantees that natively: the DP sync agrees one group-wide
-token count and pads every rank to it. A step that degrades to eager keeps
-per-rank token counts and the cross-DP collectives would hang.
-
-Instead of rejecting eager steps, keep them DP-aligned with four pieces in
-NPUModelRunner, without replacing any upstream binding:
-
-1. `execute_model` agrees the step's DP-group token max G with one CPU
-   all_reduce before dispatch (real steps report their token count, dummy
-   steps report zero) — the same technique model runner v1's
-   `_sync_metadata_across_dp` applied on every step.
-2. `gather_batch_req_state` reports G as the batch's token count, so the
-   dispatch input already carries the padded size. The eager branch then
-   hands every rank a descriptor at G AND publishes counts[dp_rank] == G,
-   keeping the forward-context invariant (counts[dp_rank] equals the padded
-   forward row count) intact without touching the dispatch result.
-3. `prepare_inputs` restores the real token extent for everything that
-   treats num_tokens as real work (query_start_loc trailing fill,
-   `InputBatch.num_tokens`); padded rows keep flowing through the
-   cudagraph-padding machinery (PAD_SLOT_ID slot mappings, sampler reads
-   only real request rows).
-4. Dummy steps rewrite their synthetic scheduler output to G, so an idle
-   rank's dummy batch forwards exactly G rows and joins the collectives at
-   the same shape.
+Cross-DP collectives (o_proj TP, mlp TP) need every rank to forward the same
+token count per step. Cudagraph dispatch pads natively, eager dispatch would
+hang, so `NPUModelRunner` aligns eager steps to the group max.
 """
 
 from __future__ import annotations
@@ -56,13 +33,9 @@ from vllm.v1.core.sched.output import SchedulerOutput
 
 
 def sync_dp_group_max_tokens(num_tokens: int, dp_size: int, dp_rank: int) -> int:
-    """Agree the DP-group token-count max with one CPU all_reduce.
-
-    Mirrors the one-hot reduce `dp_utils.sync_cudagraph_and_dp_padding`
-    performs: every rank writes its own count into its slot, the sum
-    all_reduce yields the full per-rank vector, and the max of that vector
-    is identical on every rank. Dummy steps report zero so only real work
-    raises the bar.
+    """
+    Agree the DP-group token-count max with one CPU all_reduce. Mirrors the one-hot
+    reduce in `dp_utils.sync_cudagraph_and_dp_padding`.
     """
     cpu_group = get_dp_group().cpu_group
     counts = torch.zeros(dp_size, dtype=torch.int32)
@@ -72,12 +45,9 @@ def sync_dp_group_max_tokens(num_tokens: int, dp_size: int, dp_rank: int) -> int
 
 
 def make_dp_padded_dummy_output(scheduler_output: SchedulerOutput, group_max: int) -> SchedulerOutput:
-    """Rewrite a dummy scheduler output to forward exactly group_max tokens.
-
-    The dummy output is synthetic (built by `_dummy_run`), so replacing
-    its token accounting is safe. One synthetic request keeps the dummy
-    uniform-decode shape gather_batch_req_state derives from it, and makes
-    the eager dispatch report exactly group_max for this rank.
+    """
+    Rewrite a dummy scheduler output to forward exactly `group_max` tokens. The output
+    is synthetic, so rewriting it is safe.
     """
     return replace(
         scheduler_output,

--- a/vllm_ascend/worker/v2/model_runner.py
+++ b/vllm_ascend/worker/v2/model_runner.py
@@ -110,8 +110,9 @@ class NPUModelRunner(GPUModelRunner):
         if spec_pp_support is not None and spec_pp_support.needs_aux_hidden_states:
             self.use_aux_hidden_state_outputs = True
 
-        # Fine-grained TP features with cross-DP collectives (o_proj TP, mlp TP) need every DP rank to
-        # forward the same token count per step; eager steps are aligned by `eager_dp_padding`.
+        # o_proj TP's cross-DP collectives need every DP rank to forward the same
+        # token count per step; eager steps are aligned by `eager_dp_padding`.
+        # (mlp/embedding TP share the constraint and are out of scope here.)
         finegrained_tp_config = self.ascend_config.finegrained_tp_config
         self._dp_padding_enabled = finegrained_tp_config.oproj_tensor_parallel_size > 0 and self.dp_size > 1
         self._dp_padding_aligned_tokens = 0

--- a/vllm_ascend/worker/v2/model_runner.py
+++ b/vllm_ascend/worker/v2/model_runner.py
@@ -110,9 +110,7 @@ class NPUModelRunner(GPUModelRunner):
         if spec_pp_support is not None and spec_pp_support.needs_aux_hidden_states:
             self.use_aux_hidden_state_outputs = True
 
-        # o_proj TP's cross-DP collectives need every DP rank to forward the same
-        # token count per step; eager steps are aligned by `eager_dp_padding`.
-        # (mlp/embedding TP share the constraint and are out of scope here.)
+        # o_proj TP needs every DP rank at the same token count; eager steps are aligned by `eager_dp_padding`.
         finegrained_tp_config = self.ascend_config.finegrained_tp_config
         self._dp_padding_enabled = finegrained_tp_config.oproj_tensor_parallel_size > 0 and self.dp_size > 1
         self._dp_padding_aligned_tokens = 0

--- a/vllm_ascend/worker/v2/model_runner.py
+++ b/vllm_ascend/worker/v2/model_runner.py
@@ -284,7 +284,9 @@ class NPUModelRunner(GPUModelRunner):
                 0 if dummy_run else scheduler_output.total_num_scheduled_tokens, self.dp_size, self.dp_rank
             )
             if dummy_run and self._dp_padding_aligned_tokens > 0:
-                scheduler_output = make_dp_padded_dummy_output(scheduler_output, self._dp_padding_aligned_tokens)
+                scheduler_output = make_dp_padded_dummy_output(
+                    scheduler_output, self._dp_padding_aligned_tokens, self.decode_query_len
+                )
         profiling_config = self.ascend_config.scheduler_config.profiling_chunk_config
         execution_start_time = _start_profiling_chunk_timing(
             profiling_config,

--- a/vllm_ascend/worker/v2/model_runner.py
+++ b/vllm_ascend/worker/v2/model_runner.py
@@ -285,7 +285,10 @@ class NPUModelRunner(GPUModelRunner):
             )
             if dummy_run and self._dp_padding_aligned_tokens > 0:
                 scheduler_output = make_dp_padded_dummy_output(
-                    scheduler_output, self._dp_padding_aligned_tokens, self.decode_query_len
+                    scheduler_output,
+                    self._dp_padding_aligned_tokens,
+                    self.decode_query_len,
+                    self.max_num_reqs,
                 )
         profiling_config = self.ascend_config.scheduler_config.profiling_chunk_config
         execution_start_time = _start_profiling_chunk_timing(

--- a/vllm_ascend/worker/v2/model_runner.py
+++ b/vllm_ascend/worker/v2/model_runner.py
@@ -110,14 +110,12 @@ class NPUModelRunner(GPUModelRunner):
         if spec_pp_support is not None and spec_pp_support.needs_aux_hidden_states:
             self.use_aux_hidden_state_outputs = True
 
-        # Fine-grained TP features with cross-DP collectives (o_proj TP today,
-        # mlp TP when it lands) need every DP rank to forward the same token
-        # count per step; eager steps are aligned by `eager_dp_padding`.
-        self._dp_padding_enabled = (
-            self.ascend_config.finegrained_tp_config.oproj_tensor_parallel_size > 0 and self.dp_size > 1
-        )
-        self._dp_padding_group_max = 0
-        self._dp_padding_real_tokens = 0
+        # Fine-grained TP features with cross-DP collectives (o_proj TP, mlp TP) need every DP rank to
+        # forward the same token count per step; eager steps are aligned by `eager_dp_padding`.
+        finegrained_tp_config = self.ascend_config.finegrained_tp_config
+        self._dp_padding_enabled = finegrained_tp_config.oproj_tensor_parallel_size > 0 and self.dp_size > 1
+        self._dp_padding_aligned_tokens = 0
+        self._dp_padding_original_tokens = 0
 
         self.use_aclgraph = (
             self.compilation_config.cudagraph_mode != CUDAGraphMode.NONE
@@ -275,26 +273,18 @@ class NPUModelRunner(GPUModelRunner):
         context_len: int = 0,
     ):
         self._cpp_execution_time_ms = None
-        self._dp_padding_group_max = 0
-        self._dp_padding_real_tokens = 0
-        # _dp_padding_enabled is set in __init__; bare mock runners built via
-        # object.__new__ in upstream tests lack it, hence the default.
-        # PCP and adaptive verification rewrite the dispatched token count
-        # after this point and are skipped until validated.
+        self._dp_padding_aligned_tokens = 0
+        self._dp_padding_original_tokens = 0
         if (
             getattr(self, "_dp_padding_enabled", False)
             and not is_profile
-            and getattr(self, "pcp_manager", None) is None
-            and getattr(self, "adaptive_verification", None) is None
-            # Zero-token real steps return from the parent before dispatch
-            # (posting ours there would hang it against busy/dummy steps).
             and (dummy_run or scheduler_output.total_num_scheduled_tokens > 0)
         ):
-            intent = 0 if dummy_run else scheduler_output.total_num_scheduled_tokens
-            self._dp_padding_group_max = sync_dp_group_max_tokens(intent, self.dp_size, self.dp_rank)
-            self._dp_padding_real_tokens = intent
-            if dummy_run and self._dp_padding_group_max > 0:
-                scheduler_output = make_dp_padded_dummy_output(scheduler_output, self._dp_padding_group_max)
+            self._dp_padding_aligned_tokens = sync_dp_group_max_tokens(
+                0 if dummy_run else scheduler_output.total_num_scheduled_tokens, self.dp_size, self.dp_rank
+            )
+            if dummy_run and self._dp_padding_aligned_tokens > 0:
+                scheduler_output = make_dp_padded_dummy_output(scheduler_output, self._dp_padding_aligned_tokens)
         profiling_config = self.ascend_config.scheduler_config.profiling_chunk_config
         execution_start_time = _start_profiling_chunk_timing(
             profiling_config,
@@ -338,12 +328,13 @@ class NPUModelRunner(GPUModelRunner):
 
     def gather_batch_req_state(self, scheduler_output, dummy_run):
         batch_req_state, uniform_tok_count = super().gather_batch_req_state(scheduler_output, dummy_run)
-        # DP padding: report the agreed group max so the dispatch input
-        # already carries the padded size (the eager branch publishes it
-        # both as the descriptor and as this rank's counts entry, keeping
-        # the forward-context counts[dp_rank] == batch size invariant).
-        if batch_req_state is not None and self._dp_padding_group_max > batch_req_state.num_tokens:
-            batch_req_state = batch_req_state._replace(num_tokens=self._dp_padding_group_max)
+        if batch_req_state is None:
+            return batch_req_state, uniform_tok_count
+        # Keep the real token count before the DP-aligned one replaces it below.
+        self._dp_padding_original_tokens = batch_req_state.num_tokens
+        # Report the agreed group max so eager dispatch steps are DP-padded.
+        if self._dp_padding_aligned_tokens > batch_req_state.num_tokens:
+            batch_req_state = batch_req_state._replace(num_tokens=self._dp_padding_aligned_tokens)
         return batch_req_state, uniform_tok_count
 
     def prepare_inputs(  # type: ignore[misc]
@@ -356,11 +347,9 @@ class NPUModelRunner(GPUModelRunner):
         npu attention backends need seq_lens_cpu to work.
         so we need to prepare seq_lens_cpu here.
         """
-        # DP padding: gather reported the padded size, so restore the real
-        # extent for everything that treats num_tokens as real work
-        # (query_start_loc trailing fill, InputBatch.num_tokens).
-        if self._dp_padding_group_max > 0:
-            num_tokens = self._dp_padding_real_tokens
+        # Restore the real token extent; gather reported the padded size.
+        if self._dp_padding_aligned_tokens > 0:
+            num_tokens = self._dp_padding_original_tokens
         else:
             num_tokens = batch_req_state.num_tokens
         num_tokens_after_padding = max(num_tokens, batch_desc.num_tokens)

--- a/vllm_ascend/worker/v2/model_runner.py
+++ b/vllm_ascend/worker/v2/model_runner.py
@@ -61,6 +61,10 @@ from vllm_ascend.utils import lmhead_tp_enable, set_potential_max_tokens, vllm_v
 from vllm_ascend.worker.utils import disable_compilation
 from vllm_ascend.worker.v2.aclgraph_utils import ModelAclGraphManager
 from vllm_ascend.worker.v2.attn_utils import build_attn_state
+from vllm_ascend.worker.v2.eager_dp_padding import (
+    make_dp_padded_dummy_output,
+    sync_dp_group_max_tokens,
+)
 from vllm_ascend.worker.v2.eplb import AscendEPLBController
 from vllm_ascend.worker.v2.input_batch import AscendInputBatch, AscendInputBuffers
 from vllm_ascend.worker.v2.pcp_manager import AscendPCPManager
@@ -105,6 +109,15 @@ class NPUModelRunner(GPUModelRunner):
         # These draft heads consume target aux states collected across PP ranks.
         if spec_pp_support is not None and spec_pp_support.needs_aux_hidden_states:
             self.use_aux_hidden_state_outputs = True
+
+        # Fine-grained TP features with cross-DP collectives (o_proj TP today,
+        # mlp TP when it lands) need every DP rank to forward the same token
+        # count per step; eager steps are aligned by `eager_dp_padding`.
+        self._dp_padding_enabled = (
+            self.ascend_config.finegrained_tp_config.oproj_tensor_parallel_size > 0 and self.dp_size > 1
+        )
+        self._dp_padding_group_max = 0
+        self._dp_padding_real_tokens = 0
 
         self.use_aclgraph = (
             self.compilation_config.cudagraph_mode != CUDAGraphMode.NONE
@@ -262,6 +275,26 @@ class NPUModelRunner(GPUModelRunner):
         context_len: int = 0,
     ):
         self._cpp_execution_time_ms = None
+        self._dp_padding_group_max = 0
+        self._dp_padding_real_tokens = 0
+        # _dp_padding_enabled is set in __init__; bare mock runners built via
+        # object.__new__ in upstream tests lack it, hence the default.
+        # PCP and adaptive verification rewrite the dispatched token count
+        # after this point and are skipped until validated.
+        if (
+            getattr(self, "_dp_padding_enabled", False)
+            and not is_profile
+            and getattr(self, "pcp_manager", None) is None
+            and getattr(self, "adaptive_verification", None) is None
+            # Zero-token real steps return from the parent before dispatch
+            # (posting ours there would hang it against busy/dummy steps).
+            and (dummy_run or scheduler_output.total_num_scheduled_tokens > 0)
+        ):
+            intent = 0 if dummy_run else scheduler_output.total_num_scheduled_tokens
+            self._dp_padding_group_max = sync_dp_group_max_tokens(intent, self.dp_size, self.dp_rank)
+            self._dp_padding_real_tokens = intent
+            if dummy_run and self._dp_padding_group_max > 0:
+                scheduler_output = make_dp_padded_dummy_output(scheduler_output, self._dp_padding_group_max)
         profiling_config = self.ascend_config.scheduler_config.profiling_chunk_config
         execution_start_time = _start_profiling_chunk_timing(
             profiling_config,
@@ -303,6 +336,16 @@ class NPUModelRunner(GPUModelRunner):
                     self._dummy_run(mc2_tokens_capacity, skip_attn=True, skip_eplb=True, is_profile=True)
             super().profile_run()
 
+    def gather_batch_req_state(self, scheduler_output, dummy_run):
+        batch_req_state, uniform_tok_count = super().gather_batch_req_state(scheduler_output, dummy_run)
+        # DP padding: report the agreed group max so the dispatch input
+        # already carries the padded size (the eager branch publishes it
+        # both as the descriptor and as this rank's counts entry, keeping
+        # the forward-context counts[dp_rank] == batch size invariant).
+        if batch_req_state is not None and self._dp_padding_group_max > batch_req_state.num_tokens:
+            batch_req_state = batch_req_state._replace(num_tokens=self._dp_padding_group_max)
+        return batch_req_state, uniform_tok_count
+
     def prepare_inputs(  # type: ignore[misc]
         self,
         scheduler_output: SchedulerOutput,
@@ -313,7 +356,13 @@ class NPUModelRunner(GPUModelRunner):
         npu attention backends need seq_lens_cpu to work.
         so we need to prepare seq_lens_cpu here.
         """
-        num_tokens = batch_req_state.num_tokens
+        # DP padding: gather reported the padded size, so restore the real
+        # extent for everything that treats num_tokens as real work
+        # (query_start_loc trailing fill, InputBatch.num_tokens).
+        if self._dp_padding_group_max > 0:
+            num_tokens = self._dp_padding_real_tokens
+        else:
+            num_tokens = batch_req_state.num_tokens
         num_tokens_after_padding = max(num_tokens, batch_desc.num_tokens)
         assert num_tokens > 0
 


### PR DESCRIPTION
### What this PR does / why we need it?

Enables the `oproj_tensor_parallel_size` knob of fine-grained TP on model runner v2; it previously only worked on the V1 runner — on V2, graph-dispatched steps ran, but an eagerly dispatched step had no cross-DP alignment and would desynchronize the collectives.

o_proj TP shards the attention output projection along the **DP axis** (`vllm_ascend/distributed/parallel_state.py`). The exchange runs `all_to_all` → partial GEMM → `reduce_scatter` across that group on every attention forward, so every rank of the group must forward the **same number of tokens per step** — otherwise the generic exchange's HCCL collectives hang without an error.

With a graph mode active this invariant is native on V2: the upstream cudagraph dispatch (`sync_cudagraph_and_dp_padding` in `vllm/v1/worker/gpu/dp_utils.py`) agrees one group-wide token count and dispatches every rank to the same captured size. Idle DP ranks join through the engine-level dummy batch, which takes part in the same synchronization and runs the full forward — the o_proj exchange sits inside the forward, so unlike lmhead TP (#14668) no dummy collective call is needed. `_EXTRA_CTX.num_tokens` (consumed by the DSA/MLA o_proj exchange) is populated by the platform hook (`set_additional_forward_context`) with the same padded value V1 set explicitly. The exchange implementation, OTP group setup and static buffer sizing are runner-independent and carry over unchanged. The config validation is shared between the runners as well, and this PR tightens it rather than carrying it over (graph-mode criterion, PCP rejection — both under user-facing changes below).

The one gap is a step that degrades to **eager** — a mixed batch (eager only under `FULL_DECODE_ONLY`; under `FULL` it matches a mixed full graph and under `FULL_AND_PIECEWISE` a piecewise graph), a batch beyond the largest captured size (eager in every mode), or a request's boundary-recompute step on a PD decode node (the uniform-decode classifier treats it as prefill work, vLLM #51865, landed in v0.28.0). The eager branch of the DP sync keeps per-rank token counts, so the cross-DP collectives would hang. Rather than reject such steps, they are kept DP-aligned on the eager path too, with four small pieces and **no upstream binding replaced by this PR** (`vllm_ascend/worker/v2/eager_dp_padding.py` plus hooks in `vllm_ascend/worker/v2/model_runner.py`; the `dispatch_cg_and_sync_dp` rebinding further down that file is upstream PCP code, untouched here):

1. `execute_model` agrees the step's DP-group token max G with one CPU all_reduce before dispatch — real steps report their token count, dummy steps report zero. (V1's `_sync_metadata_across_dp` skips both the reduce and the padding wherever its MC2 path allows — dense models, or MoE with MC2 decode plus the recompute scheduler this knob requires — leaving per-step uniformity to the scheduler; when it cannot skip it still reduces and pads to the group max — with fine-grained TP on, which this knob implies, that pad condition always holds. The V2 eager branch pads nothing, so this hook agrees G explicitly.) Steps with zero scheduled tokens post nothing, matching the upstream early return;
2. `gather_batch_req_state` reports G as the batch's token count, so the dispatch input already carries the padded size and the eager branch hands every rank a descriptor at G *and* publishes `counts[dp_rank] == G`, keeping the forward-context invariant intact without touching the dispatch result;
3. `prepare_inputs` restores the real token extent for everything that treats `num_tokens` as real work (`query_start_loc` trailing fill, `InputBatch.num_tokens`); padded rows get `PAD_SLOT_ID` slot mappings (upstream `prepare_attn` → `compute_slot_mappings`, shared by the Ascend runner) and are never sampled (logits indices cover the real request rows only);
4. dummy steps rewrite their synthetic scheduler output to G, split into `decode_query_len`-sized requests so the dummy keeps the uniform-decode graph match when a capture size covers G — a single G-token request, a remainder request (non-uniform batch), or the over-`max_num_reqs` fallback (per-request counts at or above `decode_query_len`, non-uniform) each lose it, dragging the step to eager under `FULL_DECODE_ONLY` (the other modes still match their mixed/piecewise graphs). An idle rank's dummy batch then joins the collectives at the same shape.

The mechanism is installed only when o_proj TP runs with `dp_size > 1`; with the feature off, behavior is unchanged. That gate covers o_proj TP alone — mlp and embedding TP share the cross-DP constraint (same DP-axis exchange) and stay ungated here, to be covered by follow-up work with their own guards.

### Does this PR introduce _any_ user-facing change?

Yes. `oproj_tensor_parallel_size` now works on the V2 runner, functionally matching V1 for the supported PD deployment on the generic exchange (decode TPOT is currently ~2.7× worse than V1 at oproj=2; cause open, tracked under Performance): eager steps — mixed batches, oversized recompute chunks, request-arrival steps (i.e., the boundary-recompute step) on a PD decode node — are DP-padded and run instead of hanging the cross-DP collectives (mechanism UT-covered; the inflated case's e2e rerun is scheduled — see Testing). As before, the knob requires the PD decode-node deployment with `recompute_scheduler_enable=true`. As on V1, `enforce_eager` / `cudagraph_mode=NONE` are still rejected at config load; that precondition now tests `cudagraph_mode == NONE` instead of `model_config.enforce_eager`, so an explicit `cudagraph_mode=none` is caught as well (previously only `enforce_eager` was) — and since the validation is shared, the tightened criterion applies to the V1 runner too. An all-eager deployment stays out of scope — V1 rejects it for this knob as well; on the DSA path the static exchange buffers are sized at decode scale so oversized eager steps fail fast there, while the generic exchange has no capacity check of its own — an all-eager deployment of either exchange is rejected at config load. Spec decode combined with o_proj TP is unvalidated on either runner (see the testing notes). PCP (`prefill_context_parallel_size > 1`) is rejected alongside o_proj TP: its dispatch path recomputes the token count per rank, which would drop the DP padding and hang the cross-DP collectives on eager steps. That rejection is unconditional (fail rather than gamble on graph-only steps), and PCP is only reachable on the V2 runner on Ascend (the platform rejects it otherwise), so it is a new V2-specific limitation, not a parity regression.

### How was this patch tested?

Both e2e testbeds below exercise the generic `OProjRowParallelOp` exchange (MiniMax-M2.7, a GQA model, and the 4-layer dummy); the DSA path's static exchange is unchanged by this PR and runner-independent by construction, but unvalidated here (no e2e coverage).

- **UT** (CPU, pure mock): `tests/ut/worker/test_model_runner_v2_finegrained_tp.py` covers the DP-padding contract — the `execute_model` gate (feature on/off, dummy, profile, and the zero-token skip), group-max agreement, batch-state reporting at the group max with the real extent recorded, and the dummy-output rewrite (decode-shaped, exact total, capped at `max_num_reqs`); the `prepare_inputs` restore is pinned by a structural canary rather than behavioral coverage; `tests/ut/test_ascend_config.py` covers the config-level rejections (graph mode, PCP). The suite runs in CI cpu-ut, which builds against the main-verified vllm pin.
- **Single-A3 PD smoke** (decode node dp8×tp1, FULL_DECODE_ONLY + recompute scheduler, Mooncake connector, 4-layer dummy-weight model): continuous request arrival (KV transfer + boundary recompute) runs with the eager-padding hooks active — the eager branch executes without collective desync, and outputs are token-identical to the `oproj=0` baseline. The sampled steps carried at most one request per rank, so the gather-level inflation never fired (idle ranks' dummy batches do forward a row); that branch has UT coverage only, and no end-to-end run with real collectives exercises it yet.
- **2×A3 e2e** (MiniMax-M2.7-W8A8, PD tp8×dp2 / dp16×tp1, requests through the load-balance proxy): service up, sanity prompts normal, 640 requests at cc1–cc64 clean. That matrix predates the eager-padding mechanism — no eager step was observed across its 640 requests, so the padded path itself was never exercised and still needs a rerun.
- **Memory (net accounting)**: on the prior 2×A3 matrix (MiniMax-M2.7, tp8×dp2), enabling oproj=2 saved ~0.55 GiB of weights per rank and cost ~0.4–0.5 GiB of non-torch HCCL buffers for the OTP group (present on V1 as well; 0.48 GiB on that matrix, 0.42 GiB on a 4-layer dummy-weight single-A3 bed); oproj=4 measured ~0.82 GiB saved per rank on the same matrix, and larger splits were not measured. Net KV capacity is positive only for deep models (+256–384 KV tokens/rank at oproj=2 in that matrix, +1,536 at oproj=4; graph capture costs ~0.05 GiB); shallow models or small splits can be net negative.
- **Performance**: decode TPOT with the feature enabled is higher on V2 than on V1: on the single-A3 PD bed (dp8×tp1, n=8, engine-side) oproj=2 raised V2 from 6.17 to 16.76 ms (+10.6 ms, 2.7×) while V1 stayed flat (5.41→5.40 ms). Steady-state decode forwards one token per rank (no padding rows; each rank's log shows at least one num_tokens=1 full-graph replay), but the bed predates the dummy-rewrite fix and does not isolate the per-step CPU all_reduce the hooks add — whether the gap is in-graph OTP communication serialization, the extra per-step CPU reduce, or the prior-generation single-request dummy rewrite is open, tracked as follow-up work that also covers closing it.

The scenarios the runs above do not cover:

- the inflation itself (the group max above some rank's real count) under continuous request arrival in `FULL_DECODE_ONLY`, and with a deliberately undersized capture size so that ordinary steps overflow the largest captured graph — scheduled on the same test bed.
- spec decode: the drafter's main forward reuses the target's DP sync (`dp_sync` passthrough in `dispatch_cg_and_sync_dp`, no extra collective), which this padding aligns as well; its self-dispatched per-step decode runs its own sync. The combination is untested in this PR — there is no config guard for it either — and it is tracked as follow-up work.

- vLLM main: https://github.com/vllm-project/vllm/commit/b2f685834a6456197e7033966fdef52a23f1abcd
