### PR TITLE
[BugFix][Ops] Only use the custom add_rms_norm kernel when a norm bias was loaded

### DIFF
--- a/tests/ut/ops/test_layernorm.py
+++ b/tests/ut/ops/test_layernorm.py
@@ -1,3 +1,4 @@
+import os
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -6,7 +7,7 @@ from vllm.config import set_current_vllm_config
 from vllm.model_executor.layers.layernorm import RMSNorm
 from vllm.third_party.flash_linear_attention.ops.kda import FusedRMSNormGated
 
-from vllm_ascend.ops.layernorm import AscendFusedRMSNormGated
+from vllm_ascend.ops.layernorm import AscendFusedRMSNormGated, use_custom_add_rms_norm
 from vllm_ascend.utils import enable_custom_op
 from vllm_ascend.utils import is_310p as is_310p_hw
 
@@ -128,3 +129,34 @@ def test_RMSNorm_forward_310p(mock_add_rmsnorm, mock_rmsnorm, residual, dummy_te
         expected_out_x = dummy_tensor + 1
         mock_rmsnorm.assert_called_once()
         assert torch.allclose(out_x, expected_out_x)
+
+
+class TestAddRMSNormKernelSelection:
+    """The residual branch must pick its kernel from the checkpoint."""
+
+    @pytest.mark.parametrize(
+        "bias,bias_loaded",
+        [
+            (None, False),
+            (torch.zeros(8), False),
+        ],
+    )
+    def test_native_kernel_without_a_loaded_norm_bias(self, bias, bias_loaded):
+        with patch("vllm_ascend.ops.layernorm.enable_custom_op", return_value=True) as custom_op:
+            assert use_custom_add_rms_norm(bias, bias_loaded) is False
+        custom_op.assert_not_called()
+
+    def test_custom_kernel_once_a_norm_bias_was_loaded(self):
+        with patch("vllm_ascend.ops.layernorm.enable_custom_op", return_value=True):
+            assert use_custom_add_rms_norm(torch.ones(8), True) is True
+
+    def test_custom_kernel_is_still_gated_on_the_custom_op_library(self):
+        with patch("vllm_ascend.ops.layernorm.enable_custom_op", return_value=False):
+            assert use_custom_add_rms_norm(torch.ones(8), True) is False
+
+    def test_env_restores_the_previous_behaviour(self):
+        with (
+            patch.dict(os.environ, {"VLLM_ASCEND_NATIVE_ADD_RMS_NORM": "0"}),
+            patch("vllm_ascend.ops.layernorm.enable_custom_op", return_value=True),
+        ):
+            assert use_custom_add_rms_norm(None, False) is True

--- a/vllm_ascend/envs.py
+++ b/vllm_ascend/envs.py
@@ -80,6 +80,13 @@ env_variables: dict[str, Callable[[], Any]] = {
     "VLLM_ASCEND_ENABLE_NZ": lambda: int(os.getenv("VLLM_ASCEND_ENABLE_NZ", 1)),
     # Whether to anbale dynamic EPLB
     "DYNAMIC_EPLB": lambda: os.getenv("DYNAMIC_EPLB", "false").lower(),
+    # Whether AscendRMSNorm's residual branch uses the native torch_npu
+    # add_rms_norm kernel when the checkpoint carries no norm bias. The custom
+    # npu_add_rms_norm_bias kernel is only needed for anti-outlier norm biases,
+    # and selecting it otherwise makes the numerical path depend on whether the
+    # custom op library was importable when the graph was traced. Set to 0 to
+    # always use the custom kernel when it is available.
+    "VLLM_ASCEND_NATIVE_ADD_RMS_NORM": lambda: bool(int(os.getenv("VLLM_ASCEND_NATIVE_ADD_RMS_NORM", "1"))),
     # Control the aclrtMemcpyBatchAsync compile path for KV cache offloading.
     # "1": force enable, "0": force disable, None: auto-detect from CANN headers.
     "VLLM_ASCEND_ENABLE_BATCH_MEMCPY": lambda: os.getenv("VLLM_ASCEND_ENABLE_BATCH_MEMCPY", None),

--- a/vllm_ascend/ops/layernorm.py
+++ b/vllm_ascend/ops/layernorm.py
@@ -21,10 +21,30 @@ from vllm.config import get_current_vllm_config
 from vllm.model_executor.layers.layernorm import GemmaRMSNorm, RMSNorm, RMSNormGated
 from vllm.third_party.flash_linear_attention.ops.kda import FusedRMSNormGated
 
+import vllm_ascend.envs as envs_ascend
 from vllm_ascend.device.device_op import DeviceOperator
 from vllm_ascend.ops.triton.kda.kda import rms_norm_gated
 from vllm_ascend.ops.triton.layernorm_gated import layer_norm_fwd_npu
 from vllm_ascend.utils import enable_custom_op
+
+
+# Residual-add RMSNorm kernel selection.
+#
+# torch.ops._C_ascend.npu_add_rms_norm_bias and torch_npu.npu_add_rms_norm return
+# bitwise-identical tensors when called in isolation (also with a zero bias), but
+# inside the compiled model graph the two lead to different numerical paths for
+# the whole network: the backend can fuse the native op, while the custom op is
+# opaque to it. Both are legitimate rounding, so which one is taken must not
+# depend on whether the custom op library happened to be importable when the
+# graph was traced - a cached compilation artifact keeps whichever op it was
+# traced with. The custom op is only required when a norm bias was actually
+# loaded from the checkpoint (anti-outlier biases); the bias parameter that
+# AscendRMSNorm allocates whenever the quant description mentions "norm.bias"
+# stays zero for residual norms and must not select it.
+def use_custom_add_rms_norm(bias: torch.Tensor | None, bias_loaded: bool) -> bool:
+    if envs_ascend.VLLM_ASCEND_NATIVE_ADD_RMS_NORM and (bias is None or not bias_loaded):
+        return False
+    return enable_custom_op()
 
 
 class AscendRMSNorm(RMSNorm):
@@ -69,7 +89,7 @@ class AscendRMSNorm(RMSNorm):
         import torch_npu
 
         if residual is not None:
-            if enable_custom_op():
+            if use_custom_add_rms_norm(self.bias, self.bias_loaded):
                 x, _, residual = torch.ops._C_ascend.npu_add_rms_norm_bias(
                     x, residual, self.weight, self.bias, self.variance_epsilon
                 )
@@ -95,7 +115,7 @@ class AscendGemmaRMSNorm(GemmaRMSNorm):
         import torch_npu
 
         if residual is not None:
-            if enable_custom_op():
+            if use_custom_add_rms_norm(None, False):
                 x, _, residual = torch.ops._C_ascend.npu_add_rms_norm_bias(
                     x, residual, 1.0 + self.weight, None, self.variance_epsilon
                 )


### PR DESCRIPTION
### What this PR does / why we need it?

`AscendRMSNorm.forward_oot()` picks its residual-add kernel with
`enable_custom_op()`:

```python
if residual is not None:
    if enable_custom_op():
        x, _, residual = torch.ops._C_ascend.npu_add_rms_norm_bias(
            x, residual, self.weight, self.bias, self.variance_epsilon)
    else:
        x, _, residual = torch_npu.npu_add_rms_norm(x, residual, self.weight, self.variance_epsilon)
```

`torch.ops._C_ascend.npu_add_rms_norm_bias` and `torch_npu.npu_add_rms_norm`
return bitwise-identical tensors when called in isolation, with a zero bias
as well. Inside the compiled model graph they do not: the backend can fuse
the native op, while the custom op is opaque to it, so the two select
different numerical paths for the whole network. Both are legitimate
rounding, but on a W4A8 MoE model with sparse attention the difference is
amplified enough to change the answer of a long-context retrieval prompt.

That makes the branch a correctness-visible choice that today depends on
whether the custom op library was importable - and on *when*, since a cached
compilation artifact keeps whichever op it was traced with, so two servers
running the same source can end up executing different kernels.

The custom kernel is only needed when a norm bias was actually loaded from
the checkpoint (anti-outlier biases). The `bias` parameter that
`AscendRMSNorm` allocates whenever the quantization description mentions
`norm.bias` stays zero for residual norms, and passing that zero bias to the
custom op is what pulls the whole graph onto the other path for no benefit.
This PR selects the native op in that case, which makes the choice a
property of the checkpoint instead of the environment. Checkpoints that do
load norm biases keep the custom kernel, still gated on `enable_custom_op()`
as before.

Possibly also relevant to #9258, where the custom op is not available in
`libopapi.so`: checkpoints without a loaded norm bias no longer reach it.

### Does this PR introduce _any_ user-facing change?

Yes.

- On builds where the custom op library is available, models whose
  checkpoint carries no loaded norm bias now take the native
  `torch_npu.npu_add_rms_norm` path in the residual branch. The result is
  the same computation with different legitimate rounding, and it no longer
  depends on the build environment or on a cached compilation artifact.
- New environment variable `VLLM_ASCEND_NATIVE_ADD_RMS_NORM` (default 1).
  Set it to 0 to always use the custom kernel when it is available.

### How was this patch tested?

- New unit tests in `tests/ut/ops/test_layernorm.py`
  (`TestAddRMSNormKernelSelection`): the native op is selected when the bias
  is absent or was never loaded (without even calling `enable_custom_op()`),
  the custom op is selected once a bias was loaded, it stays gated on
  `enable_custom_op()`, and the env switch restores the previous behaviour.
- Exercised on Atlas 800I A2: with the selection pinned this way, one fixed
  prompt reproduces the same first-token logprob across server restarts,
  which is not the case when the branch is decided by the environment.

### Related

- #15188 - with `VLLM_USE_AOT_COMPILE`, a cached graph can be reused across two
  environments that disagree about `enable_custom_op()`, which is how the two
  kernels can end up mixed with the source that selects them. This PR makes the
  selection a property of the checkpoint; that issue is about the cache key.
