### PR TITLE
[Test][Doc] Add numerical tests and operator doc for the MRV2 resample kernels

### DIFF
--- a/tests/e2e/nightly/single_node/ops/singlecard_ops/triton/test_resample.py
+++ b/tests/e2e/nightly/single_node/ops/singlecard_ops/triton/test_resample.py
@@ -1,26 +1,25 @@
 # SPDX-License-Identifier: Apache-2.0
-# Numerical test for vllm_ascend.worker.v2.spec_decode.rejection_sampler_utils
-# (`_resample_kernel` and the `_npu_gumbel_block_argmax` device function it
-# calls) against a plain PyTorch fp32 reference.
+# Numerical test for `_resample_kernel` in
+# vllm_ascend.worker.v2.spec_decode.rejection_sampler_utils, against a plain
+# PyTorch fp32 reference.
 # Requires NPU and Triton-Ascend.
 #
 # See vllm_ascend/ops/triton/docs/resample.md for the operator spec.
 #
 # Regression scope: #9155 (main2main import of the MRV2 rejection sampler) and
 # #13470 (probabilistic rejection sampling enabled on NPU) -- neither PR shipped
-# any numerical coverage for these two kernels.
+# any numerical coverage for this kernel.
 #
-# `_npu_gumbel_block_argmax` is a `@triton.jit` *device* function: it cannot be
-# launched from host.  It is exercised two ways here:
-#   * directly, through the thin probe kernel `_gumbel_probe_kernel` below,
-#     which mirrors the real call site in `_resample_kernel`;
-#   * indirectly, through `_resample_kernel` itself.
+# `_npu_gumbel_block_argmax` is a `@triton.jit` device function inlined into
+# `_resample_kernel`, not a separate operator: it has no `tl.program_id` and
+# cannot be launched on its own.  It is covered here only through
+# `_resample_kernel`, which is the sole caller.
+#
 # The Gumbel noise it draws comes from Triton's philox, which has no PyTorch
 # equivalent, so `_gumbel_noise_probe_kernel` re-draws the *same* stream and the
-# reference consumes it.  That pins down everything except the RNG itself
-# (temperature scaling, processed-logits store, masking, the -inf branch, the
-# block-local argmax); the RNG is covered separately and statistically by
-# `test_gumbel_argmax_follows_softmax_distribution`.
+# reference consumes it.  That copy shares a blind spot with the code under
+# test, so the RNG is additionally pinned from the other side, without the probe,
+# by `test_resample_argmax_follows_softmax_distribution`.
 
 import gc
 
@@ -30,11 +29,7 @@ import torch_npu  # noqa: F401  # registers the npu backend / torch.npu namespac
 from vllm.triton_utils import tl, triton
 
 from vllm_ascend.ops.triton.triton_utils import init_device_properties_triton
-from vllm_ascend.worker.v2.spec_decode.rejection_sampler_utils import (
-    _npu_gumbel_block_argmax,
-    _resample_kernel,
-    rejection_sample,
-)
+from vllm_ascend.worker.v2.spec_decode.rejection_sampler_utils import _resample_kernel, rejection_sample
 
 DEVICE = "npu"
 
@@ -63,100 +58,8 @@ def _npu_env():
 
 
 # ---------------------------------------------------------------------------
-# Probe kernels (test-only harness)
+# Probe kernel (test-only harness)
 # ---------------------------------------------------------------------------
-
-
-@triton.jit
-def _gumbel_probe_kernel(
-    out_value_ptr,
-    out_value_stride,
-    out_idx_ptr,
-    out_idx_stride,
-    logits_ptr,
-    logits_stride,
-    expanded_idx_mapping_ptr,
-    temp_ptr,
-    seeds_ptr,
-    pos_ptr,
-    processed_logits_ptr,
-    processed_logits_stride,
-    processed_logits_col_ptr,
-    vocab_size,
-    BLOCK_SIZE: tl.constexpr,
-    APPLY_TEMPERATURE: tl.constexpr,
-    # 0 = no processed_logits (mirrors the real call site in _resample_kernel)
-    # 1 = processed_logits, implicit column 0
-    # 2 = processed_logits, column read from processed_logits_col_ptr
-    PROCESSED_MODE: tl.constexpr,
-):
-    """Thin host-launchable wrapper around the `_npu_gumbel_block_argmax` device function.
-
-    The three `PROCESSED_MODE` variants pass literal `None`s rather than relying
-    on `None` surviving a kernel-argument boundary, so each variant compiles the
-    same way the production call site does.
-    """
-    token_idx = tl.program_id(0)
-    block_idx = tl.program_id(1)
-    block = block_idx * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
-    mask = block < vocab_size
-    logits = tl.load(
-        logits_ptr + token_idx * logits_stride + block,
-        mask=mask,
-        other=float("-inf"),
-    ).to(tl.float32)
-
-    if PROCESSED_MODE == 0:
-        value, idx = _npu_gumbel_block_argmax(
-            logits,
-            block,
-            mask,
-            token_idx,
-            expanded_idx_mapping_ptr,
-            temp_ptr,
-            seeds_ptr,
-            pos_ptr,
-            None,
-            0,
-            None,
-            vocab_size,
-            APPLY_TEMPERATURE=APPLY_TEMPERATURE,
-        )
-    elif PROCESSED_MODE == 1:
-        value, idx = _npu_gumbel_block_argmax(
-            logits,
-            block,
-            mask,
-            token_idx,
-            expanded_idx_mapping_ptr,
-            temp_ptr,
-            seeds_ptr,
-            pos_ptr,
-            processed_logits_ptr,
-            processed_logits_stride,
-            None,
-            vocab_size,
-            APPLY_TEMPERATURE=APPLY_TEMPERATURE,
-        )
-    else:
-        value, idx = _npu_gumbel_block_argmax(
-            logits,
-            block,
-            mask,
-            token_idx,
-            expanded_idx_mapping_ptr,
-            temp_ptr,
-            seeds_ptr,
-            pos_ptr,
-            processed_logits_ptr,
-            processed_logits_stride,
-            processed_logits_col_ptr,
-            vocab_size,
-            APPLY_TEMPERATURE=APPLY_TEMPERATURE,
-        )
-
-    tl.store(out_value_ptr + token_idx * out_value_stride + block_idx, value)
-    tl.store(out_idx_ptr + token_idx * out_idx_stride + block_idx, block_idx * BLOCK_SIZE + idx)
 
 
 @triton.jit
@@ -356,300 +259,6 @@ def _ref_residual_from_draft(target, draft, target_lse_val, draft_lse_val):
     return torch.where(ratio < 1.0, residual, torch.full_like(residual, float("-inf")))
 
 
-# ---------------------------------------------------------------------------
-# _npu_gumbel_block_argmax
-# ---------------------------------------------------------------------------
-
-
-def _gumbel_setup(num_tokens, vocab_size, max_num_reqs, temps, seed=1234, shuffle_rows=True):
-    torch.manual_seed(seed)
-    logits = torch.randn(num_tokens, vocab_size, dtype=torch.float32, device=DEVICE)
-    if shuffle_rows:
-        # req_state rows deliberately not equal to the token index, so mixing up
-        # `token_idx` and `req_state_idx` cannot pass by accident.
-        rows = torch.randperm(max_num_reqs)[:num_tokens].to(torch.int32)
-    else:
-        rows = torch.zeros(num_tokens, dtype=torch.int32)
-    expanded_idx_mapping = rows.to(DEVICE)
-    temperature = torch.zeros(max_num_reqs, dtype=torch.float32, device=DEVICE)
-    for i, t in enumerate(temps):
-        temperature[int(rows[i])] = t
-    seeds = torch.randint(1, 2**30, (max_num_reqs,), dtype=torch.int64, device=DEVICE)
-    pos = torch.arange(num_tokens, dtype=torch.int64, device=DEVICE) * 7 + 3
-    return logits, expanded_idx_mapping, temperature, seeds, pos
-
-
-@torch.inference_mode()
-def test_gumbel_greedy_is_plain_block_argmax():
-    """temp == 0 disables the noise entirely -- the only fully deterministic path.
-
-    This is the branch `_resample_kernel` takes for greedy bonus tokens, and the
-    one the whole greedy spec-decode path depends on, so it is checked exactly
-    rather than through the noise probe.  `vocab_size` is deliberately not a
-    multiple of BLOCK_SIZE so the padded tail (`other=-inf`) is exercised.
-    """
-    num_tokens, vocab_size, max_num_reqs = 6, 3 * RESAMPLE_BLOCK_SIZE + 37, 11
-    logits, mapping, temperature, seeds, pos = _gumbel_setup(num_tokens, vocab_size, max_num_reqs, [0.0] * num_tokens)
-    num_blocks = triton.cdiv(vocab_size, RESAMPLE_BLOCK_SIZE)
-
-    values = torch.empty(num_tokens, num_blocks, dtype=torch.float32, device=DEVICE)
-    idxs = torch.empty(num_tokens, num_blocks, dtype=torch.int64, device=DEVICE)
-    dummy = torch.empty(1, dtype=torch.float32, device=DEVICE)
-    dummy_col = torch.zeros(1, dtype=torch.int32, device=DEVICE)
-    _gumbel_probe_kernel[(num_tokens, num_blocks)](
-        values,
-        values.stride(0),
-        idxs,
-        idxs.stride(0),
-        logits,
-        logits.stride(0),
-        mapping,
-        temperature,
-        seeds,
-        pos,
-        dummy,
-        0,
-        dummy_col,
-        vocab_size,
-        BLOCK_SIZE=RESAMPLE_BLOCK_SIZE,
-        APPLY_TEMPERATURE=False,
-        PROCESSED_MODE=0,
-    )
-    torch.npu.synchronize()
-
-    ref_val, ref_idx = _ref_block_argmax(logits, vocab_size, RESAMPLE_BLOCK_SIZE)
-    torch.testing.assert_close(values, ref_val, rtol=_RTOL, atol=_ATOL)
-    assert torch.equal(idxs, ref_idx)
-    # The tail block must never point past the vocabulary.
-    assert int(idxs.max()) < vocab_size
-
-
-@pytest.mark.parametrize("apply_temperature", [True, False])
-@torch.inference_mode()
-def test_gumbel_matches_reference_with_noise(apply_temperature):
-    """temp != 0: noise on, and `APPLY_TEMPERATURE` toggled on both sides.
-
-    The `APPLY_TEMPERATURE=True` half is unreachable from `_resample_kernel`
-    (which hardcodes False) but is part of the device function's contract and is
-    what the upstream sampler uses, so both sides of the constexpr are pinned.
-    """
-    num_tokens, vocab_size, max_num_reqs = 5, 2 * RESAMPLE_BLOCK_SIZE + 11, 9
-    temps = [0.5, 1.0, 2.0, 0.7, 1.3]
-    logits, mapping, temperature, seeds, pos = _gumbel_setup(num_tokens, vocab_size, max_num_reqs, temps)
-    num_blocks = triton.cdiv(vocab_size, RESAMPLE_BLOCK_SIZE)
-
-    values = torch.empty(num_tokens, num_blocks, dtype=torch.float32, device=DEVICE)
-    idxs = torch.empty(num_tokens, num_blocks, dtype=torch.int64, device=DEVICE)
-    dummy = torch.empty(1, dtype=torch.float32, device=DEVICE)
-    dummy_col = torch.zeros(1, dtype=torch.int32, device=DEVICE)
-    _gumbel_probe_kernel[(num_tokens, num_blocks)](
-        values,
-        values.stride(0),
-        idxs,
-        idxs.stride(0),
-        logits,
-        logits.stride(0),
-        mapping,
-        temperature,
-        seeds,
-        pos,
-        dummy,
-        0,
-        dummy_col,
-        vocab_size,
-        BLOCK_SIZE=RESAMPLE_BLOCK_SIZE,
-        APPLY_TEMPERATURE=apply_temperature,
-        PROCESSED_MODE=0,
-    )
-    torch.npu.synchronize()
-
-    noise = _draw_noise(num_tokens, vocab_size, mapping, seeds, pos, RESAMPLE_BLOCK_SIZE)
-    # Guard the guard: a degenerate (constant / all-zero) noise draw would make
-    # this test collapse into the greedy one above.
-    assert float(noise.std()) > 0.1, "gumbel noise probe no longer produces a spread of values"
-
-    scaled = logits.float()
-    if apply_temperature:
-        per_token_temp = temperature[mapping.long()].unsqueeze(1)
-        scaled = scaled / per_token_temp
-    ref_val, ref_idx = _ref_block_argmax(scaled, vocab_size, RESAMPLE_BLOCK_SIZE, noise=noise)
-
-    _assert_block_argmax_close(idxs, values, ref_idx, ref_val, scaled + noise, RESAMPLE_BLOCK_SIZE)
-
-    # Guard the guard: the noise must actually move at least one winner, else
-    # this case proves nothing beyond the greedy path.
-    _, greedy_idx = _ref_block_argmax(scaled, vocab_size, RESAMPLE_BLOCK_SIZE)
-    assert bool((greedy_idx != ref_idx).any()), "noise no longer changes any block winner"
-
-
-@pytest.mark.parametrize("processed_mode", [1, 2], ids=["implicit-col-0", "explicit-col"])
-@torch.inference_mode()
-def test_gumbel_stores_processed_logits(processed_mode):
-    """The `processed_logits` side output: written before the noise, after the temperature.
-
-    Both column modes are covered: `processed_logits_col_ptr is None` (column 0)
-    and an explicit column, which is the branch that makes the write land at
-    `req_state_idx * stride + col * vocab_size`.  Note the row index is
-    `req_state_idx`, *not* `token_idx` -- getting that wrong is silent.
-    """
-    num_tokens, vocab_size, max_num_reqs = 4, RESAMPLE_BLOCK_SIZE + 5, 7
-    num_cols = 3
-    col = 2 if processed_mode == 2 else 0
-    temps = [0.0, 0.5, 2.0, 1.0]
-    logits, mapping, temperature, seeds, pos = _gumbel_setup(num_tokens, vocab_size, max_num_reqs, temps)
-    num_blocks = triton.cdiv(vocab_size, RESAMPLE_BLOCK_SIZE)
-
-    processed = torch.full((max_num_reqs, num_cols * vocab_size), float("nan"), dtype=torch.float32, device=DEVICE)
-    col_tensor = torch.tensor([col], dtype=torch.int32, device=DEVICE)
-    values = torch.empty(num_tokens, num_blocks, dtype=torch.float32, device=DEVICE)
-    idxs = torch.empty(num_tokens, num_blocks, dtype=torch.int64, device=DEVICE)
-    _gumbel_probe_kernel[(num_tokens, num_blocks)](
-        values,
-        values.stride(0),
-        idxs,
-        idxs.stride(0),
-        logits,
-        logits.stride(0),
-        mapping,
-        temperature,
-        seeds,
-        pos,
-        processed,
-        processed.stride(0),
-        col_tensor,
-        vocab_size,
-        BLOCK_SIZE=RESAMPLE_BLOCK_SIZE,
-        APPLY_TEMPERATURE=True,
-        PROCESSED_MODE=processed_mode,
-    )
-    torch.npu.synchronize()
-
-    for token_idx in range(num_tokens):
-        row = int(mapping[token_idx])
-        temp = float(temperature[row])
-        expected = logits[token_idx].float()
-        if temp != 0.0:
-            expected = expected / temp
-        actual = processed[row, col * vocab_size : col * vocab_size + vocab_size]
-        torch.testing.assert_close(actual, expected, rtol=_RTOL, atol=_ATOL)
-
-    # Rows/columns nobody wrote must still be untouched: the store is masked to
-    # `block < vocab_size`, so no neighbouring column may be clobbered.
-    written_rows = {int(r) for r in mapping}
-    for row in range(max_num_reqs):
-        for c in range(num_cols):
-            if row in written_rows and c == col:
-                continue
-            chunk = processed[row, c * vocab_size : c * vocab_size + vocab_size]
-            assert bool(torch.isnan(chunk).all()), f"row {row} col {c} was overwritten"
-
-
-@torch.inference_mode()
-def test_gumbel_argmax_follows_softmax_distribution():
-    """Gumbel-max must sample proportionally to softmax(logits).
-
-    This is the one check that does *not* reuse the kernel's own RNG, so it is
-    the only thing standing between a broken philox call (wrong seed mixing,
-    a constant draw, a sign error in `-log(-log(u))`) and a silently biased
-    sampler.  8 categories in a single block, 16384 draws, one distinct `pos`
-    per draw.
-    """
-    num_tokens, vocab_size, max_num_reqs = 16384, 8, 1
-    torch.manual_seed(7)
-    row_logits = torch.tensor([2.0, 1.0, 0.5, 0.0, -0.5, -1.0, -1.5, -2.0], dtype=torch.float32)
-    logits = row_logits.to(DEVICE).repeat(num_tokens, 1).contiguous()
-    mapping = torch.zeros(num_tokens, dtype=torch.int32, device=DEVICE)
-    temperature = torch.ones(max_num_reqs, dtype=torch.float32, device=DEVICE)
-    seeds = torch.full((max_num_reqs,), 20260827, dtype=torch.int64, device=DEVICE)
-    pos = torch.arange(num_tokens, dtype=torch.int64, device=DEVICE)
-
-    values = torch.empty(num_tokens, 1, dtype=torch.float32, device=DEVICE)
-    idxs = torch.empty(num_tokens, 1, dtype=torch.int64, device=DEVICE)
-    dummy = torch.empty(1, dtype=torch.float32, device=DEVICE)
-    dummy_col = torch.zeros(1, dtype=torch.int32, device=DEVICE)
-    _gumbel_probe_kernel[(num_tokens, 1)](
-        values,
-        values.stride(0),
-        idxs,
-        idxs.stride(0),
-        logits,
-        logits.stride(0),
-        mapping,
-        temperature,
-        seeds,
-        pos,
-        dummy,
-        0,
-        dummy_col,
-        vocab_size,
-        BLOCK_SIZE=vocab_size,
-        APPLY_TEMPERATURE=False,
-        PROCESSED_MODE=0,
-    )
-    torch.npu.synchronize()
-
-    counts = torch.bincount(idxs.flatten().cpu(), minlength=vocab_size).float()
-    empirical = counts / num_tokens
-    expected = torch.softmax(row_logits, dim=0)
-    # 16384 draws => per-category std <= 0.004; 0.02 is ~5 sigma and leaves room
-    # for the coarse fp32 tail of `-log(-log(u))` (see the operator doc).
-    assert torch.allclose(empirical, expected, atol=0.02), (
-        f"argmax frequencies {empirical.tolist()} deviate from softmax {expected.tolist()}"
-    )
-
-
-@torch.inference_mode()
-def test_gumbel_is_deterministic_in_seed_and_pos():
-    """Same (seed, pos) must give the same token; a different pos must not.
-
-    Reproducibility across two runs of the same request is a user-visible
-    property (`SamplingParams.seed`), and it is what makes the noise-probe
-    oracle in the tests above legitimate.
-    """
-    num_tokens, vocab_size, max_num_reqs = 8, RESAMPLE_BLOCK_SIZE, 8
-    logits, mapping, temperature, seeds, pos = _gumbel_setup(num_tokens, vocab_size, max_num_reqs, [1.0] * num_tokens)
-
-    def _run(pos_tensor):
-        values = torch.empty(num_tokens, 1, dtype=torch.float32, device=DEVICE)
-        idxs = torch.empty(num_tokens, 1, dtype=torch.int64, device=DEVICE)
-        dummy = torch.empty(1, dtype=torch.float32, device=DEVICE)
-        dummy_col = torch.zeros(1, dtype=torch.int32, device=DEVICE)
-        _gumbel_probe_kernel[(num_tokens, 1)](
-            values,
-            values.stride(0),
-            idxs,
-            idxs.stride(0),
-            logits,
-            logits.stride(0),
-            mapping,
-            temperature,
-            seeds,
-            pos_tensor,
-            dummy,
-            0,
-            dummy_col,
-            vocab_size,
-            BLOCK_SIZE=RESAMPLE_BLOCK_SIZE,
-            APPLY_TEMPERATURE=False,
-            PROCESSED_MODE=0,
-        )
-        torch.npu.synchronize()
-        return values, idxs
-
-    v1, i1 = _run(pos)
-    v2, i2 = _run(pos)
-    assert torch.equal(i1, i2)
-    torch.testing.assert_close(v1, v2, rtol=0.0, atol=0.0)
-
-    v3, i3 = _run(pos + 1)
-    assert bool((i3 != i1).any()), "shifting pos no longer changes the draw"
-
-
-# ---------------------------------------------------------------------------
-# _resample_kernel
-# ---------------------------------------------------------------------------
-
-
 def _make_batch(num_logits_per_req, vocab_size, max_num_reqs, temps, seed=99):
     """Build a resample batch.
 
@@ -690,6 +299,11 @@ def _make_batch(num_logits_per_req, vocab_size, max_num_reqs, temps, seed=99):
         "pos": pos,
         "num_logits": num_logits,
     }
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
 
 
 @torch.inference_mode()
@@ -1043,6 +657,62 @@ def test_resample_is_deterministic():
     a2, m2 = _run_resample(**kwargs)
     assert torch.equal(a1, a2)
     torch.testing.assert_close(m1, m2, rtol=0.0, atol=0.0)
+
+
+@torch.inference_mode()
+def test_resample_argmax_follows_softmax_distribution():
+    """The resampled token must follow softmax(residual), not merely "some token".
+
+    Every other sampling case here compares against a reference that consumes
+    the kernel's own Gumbel noise, so a broken philox call -- wrong seed mixing,
+    a constant draw, a sign error in `-log(-log(u))` -- would be reproduced by
+    the reference and compared against itself.  This case closes that blind spot
+    from the other side, using only the mathematical property of Gumbel-max:
+    adding independent Gumbel noise and taking the argmax samples exactly from
+    `softmax(logits)`.  It reads nothing from the noise probe.
+
+    Driven through the bonus branch (residual == target logits) so the expected
+    distribution is the target softmax itself.  One request per draw, each with
+    a distinct `pos`, since the noise is keyed on (seed, pos).
+    """
+    num_draws, vocab_size, max_num_reqs = 16384, 8, 1
+    torch.manual_seed(7)
+    row_logits = torch.tensor([2.0, 1.0, 0.5, 0.0, -0.5, -1.0, -1.5, -2.0], dtype=torch.float32)
+    target_logits = row_logits.to(DEVICE).repeat(num_draws, 1).contiguous()
+
+    # One logit per request => resample_token_idx == end_idx - 1 => bonus branch.
+    cu_num_logits = torch.arange(num_draws + 1, dtype=torch.int32, device=DEVICE)
+    expanded_idx_mapping = torch.zeros(num_draws, dtype=torch.int32, device=DEVICE)
+    rejected_step = torch.zeros(num_draws, dtype=torch.int32, device=DEVICE)
+    draft_sampled = torch.zeros(num_draws, dtype=torch.int32, device=DEVICE)
+    temperature = torch.ones(max_num_reqs, dtype=torch.float32, device=DEVICE)
+    seeds = torch.full((max_num_reqs,), 20260827, dtype=torch.int64, device=DEVICE)
+    pos = torch.arange(num_draws, dtype=torch.int64, device=DEVICE)
+    lse = torch.zeros(num_draws, dtype=torch.float32, device=DEVICE)
+
+    argmax, _ = _run_resample(
+        target_logits=target_logits,
+        draft_logits=None,
+        draft_sampled=draft_sampled,
+        cu_num_logits=cu_num_logits,
+        expanded_idx_mapping=expanded_idx_mapping,
+        rejected_step=rejected_step,
+        temperature=temperature,
+        seeds=seeds,
+        pos=pos,
+        target_lse=lse,
+        draft_lse=lse,
+        block_size=vocab_size,
+    )
+
+    counts = torch.bincount(argmax.flatten().cpu(), minlength=vocab_size).float()
+    empirical = counts / num_draws
+    expected = torch.softmax(row_logits, dim=0)
+    # 16384 draws => per-category std <= 0.004; 0.02 is ~5 sigma and leaves room
+    # for the coarse fp32 tail of `-log(-log(u))` (see the operator doc).
+    assert torch.allclose(empirical, expected, atol=0.02), (
+        f"argmax frequencies {empirical.tolist()} deviate from softmax {expected.tolist()}"
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/tests/e2e/nightly/single_node/ops/singlecard_ops/triton/test_resample.py
+++ b/tests/e2e/nightly/single_node/ops/singlecard_ops/triton/test_resample.py
@@ -14,19 +14,13 @@
 # `_resample_kernel`, not a separate operator: it has no `tl.program_id` and
 # cannot be launched on its own.  It is covered here only through
 # `_resample_kernel`, which is the sole caller.
-#
-# The Gumbel noise it draws comes from Triton's philox, which has no PyTorch
-# equivalent, so `_gumbel_noise_probe_kernel` re-draws the *same* stream and the
-# reference consumes it.  That copy shares a blind spot with the code under
-# test, so the RNG is additionally pinned from the other side, without the probe,
-# by `test_resample_argmax_follows_softmax_distribution`.
 
 import gc
 
 import pytest
 import torch
 import torch_npu  # noqa: F401  # registers the npu backend / torch.npu namespace
-from vllm.triton_utils import tl, triton
+from vllm.triton_utils import triton
 
 from vllm_ascend.ops.triton.triton_utils import init_device_properties_triton
 from vllm_ascend.worker.v2.spec_decode.rejection_sampler_utils import _resample_kernel, rejection_sample
@@ -58,71 +52,15 @@ def _npu_env():
 
 
 # ---------------------------------------------------------------------------
-# Probe kernel (test-only harness)
-# ---------------------------------------------------------------------------
-
-
-@triton.jit
-def _gumbel_noise_probe_kernel(
-    noise_ptr,
-    noise_stride,
-    expanded_idx_mapping_ptr,
-    seeds_ptr,
-    pos_ptr,
-    vocab_size,
-    BLOCK_SIZE: tl.constexpr,
-):
-    """Re-draw the exact Gumbel noise `_npu_gumbel_block_argmax` uses.
-
-    Line-for-line copy of the RNG block of the device function.  It only
-    reproduces the noise; it says nothing about how the noise is combined with
-    the logits, which is what the tests using it check.
-    """
-    token_idx = tl.program_id(0)
-    block_idx = tl.program_id(1)
-    block = block_idx * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
-    mask = block < vocab_size
-
-    req_state_idx = tl.load(expanded_idx_mapping_ptr + token_idx)
-    seed = tl.load(seeds_ptr + req_state_idx)
-    pos = tl.load(pos_ptr + token_idx).to(tl.int32)
-    gumbel_seed = tl.randint(seed, pos)
-    r = tl.rand(gumbel_seed, block).to(tl.float32)
-    gumbel_noise = -tl.log(-tl.log(r + 1e-20) + 1e-20)
-    tl.store(noise_ptr + token_idx * noise_stride + block, gumbel_noise, mask=mask)
-
-
-# ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
 
 
-def _draw_noise(num_tokens, vocab_size, expanded_idx_mapping, seeds, pos, block_size):
-    """Materialise [num_tokens, vocab_size] of the kernel's own Gumbel noise."""
-    num_blocks = triton.cdiv(vocab_size, block_size)
-    noise = torch.zeros(num_tokens, vocab_size, dtype=torch.float32, device=DEVICE)
-    _gumbel_noise_probe_kernel[(num_tokens, num_blocks)](
-        noise,
-        noise.stride(0),
-        expanded_idx_mapping,
-        seeds,
-        pos,
-        vocab_size,
-        BLOCK_SIZE=block_size,
-    )
-    torch.npu.synchronize()
-    return noise
+def _ref_block_argmax(logits, vocab_size, block_size):
+    """Plain PyTorch per-block max/argmax over fp32 logits.
 
-
-def _ref_block_argmax(logits, vocab_size, block_size, noise=None):
-    """Per-block max/argmax over `logits`, fp32, deliberately loop-free but
-    written straight from the kernel's semantics:
-
-      * positions >= vocab_size are -inf (the kernel's `other=-inf` load plus
-        the `tl.where(mask, ...)` re-mask), so they can never win a block;
-      * noise is added only when the caller says so, and -inf + noise stays -inf,
-        which is what keeps excluded tokens out of the argmax;
-      * the returned index is *global* (`block_idx * BLOCK_SIZE + idx`).
+    Positions beyond `vocab_size` are padded with -inf, and the returned indices
+    are global vocabulary indices rather than offsets within each block.
 
     Returns (values [T, num_blocks] fp32, indices [T, num_blocks] int64).
     """
@@ -134,43 +72,24 @@ def _ref_block_argmax(logits, vocab_size, block_size, noise=None):
         dtype=torch.float32,
         device=logits.device,
     )
-    scored = logits.float() if noise is None else logits.float() + noise.float()
-    # -inf entries (masked-out / excluded tokens) must stay -inf even after the
-    # noise add; float arithmetic already does that, but nan would not, so guard.
-    scored = torch.where(torch.isneginf(logits.float()), logits.float(), scored)
-    padded[:, :vocab_size] = scored
+    padded[:, :vocab_size] = logits.float()
     padded = padded.view(num_tokens, num_blocks, block_size)
     values, idx = padded.max(dim=-1)
     offsets = torch.arange(num_blocks, device=logits.device, dtype=torch.int64) * block_size
     return values, idx.to(torch.int64) + offsets
 
 
-def _assert_block_argmax_close(actual_idx, actual_val, ref_idx, ref_val, ref_scores, block_size):
-    """Compare (value, index) pairs, tolerating an exact-tie index swap.
-
-    The kernel and the reference both reduce in fp32 but not necessarily in the
-    same order, so two near-equal candidates inside one block can swap.  A wrong
-    index is only a real failure when the value it points at is *worse* than the
-    reference maximum.
-    """
-    torch.testing.assert_close(actual_val.float(), ref_val.float(), rtol=_RTOL, atol=_ATOL)
-    mismatch = actual_idx != ref_idx
-    if not bool(mismatch.any()):
-        return
-    rows, blocks = torch.nonzero(mismatch, as_tuple=True)
-    for r, b in zip(rows.tolist(), blocks.tolist()):
-        chosen = int(actual_idx[r, b])
-        assert b * block_size <= chosen < (b + 1) * block_size, (
-            f"token {r} block {b}: index {chosen} escaped its own block"
-        )
-        assert chosen < ref_scores.shape[1], (
-            f"token {r} block {b}: index {chosen} points into the padded tail past the vocabulary"
-        )
-        got = float(ref_scores[r, chosen])
-        want = float(ref_val[r, b])
-        assert abs(got - want) <= _ATOL + _RTOL * abs(want), (
-            f"token {r} block {b}: kernel picked index {chosen} (score {got}) "
-            f"but the reference maximum is {want} at index {int(ref_idx[r, b])}"
+def _assert_valid_block_outputs(argmax, local_max, vocab_size, block_size):
+    """Check that every launched block writes a finite, in-range winner."""
+    num_blocks = triton.cdiv(vocab_size, block_size)
+    assert argmax.shape[1] == num_blocks
+    assert bool(torch.isfinite(local_max).all()), "resample produced a non-finite block maximum"
+    for block_idx in range(num_blocks):
+        block_start = block_idx * block_size
+        block_end = min(block_start + block_size, vocab_size)
+        chosen = argmax[:, block_idx]
+        assert bool(((chosen >= block_start) & (chosen < block_end)).all()), (
+            f"block {block_idx} returned an index outside [{block_start}, {block_end})"
         )
 
 
@@ -231,34 +150,6 @@ def _run_resample(
     return argmax, local_max
 
 
-def _ref_residual_one_hot(target_logits, draft_sampled, resample_token_idx):
-    """The `HAS_DRAFT_LOGITS=False` residual: the target row with one token removed.
-
-    Mirrors the detail that is easy to get wrong -- the token read is
-    `draft_sampled[resample_token_idx + 1]`, i.e. the *next* slot, because
-    `draft_sampled` is the input-id stream and sits one position ahead of the
-    logits it was drafted from.
-    """
-    out = target_logits[resample_token_idx].float().clone()
-    out[int(draft_sampled[resample_token_idx + 1])] = float("-inf")
-    return out
-
-
-def _ref_residual_from_draft(target, draft, target_lse_val, draft_lse_val):
-    """The `HAS_DRAFT_LOGITS=True` residual: `ratio < 1 ? log p + log(1 - ratio) : -inf`.
-
-    fp32 throughout, and written in the kernel's own order (subtract the two
-    logsumexps first, exponentiate the difference) rather than the algebraically
-    equivalent `log(p - q)`, so the comparison is not testing a different
-    formula's rounding.
-    """
-    target_log_probs = target.float() - target_lse_val
-    draft_log_probs = draft.float() - draft_lse_val
-    ratio = torch.exp(draft_log_probs - target_log_probs)
-    residual = target_log_probs + torch.log(1.0 - ratio)
-    return torch.where(ratio < 1.0, residual, torch.full_like(residual, float("-inf")))
-
-
 def _make_batch(num_logits_per_req, vocab_size, max_num_reqs, temps, seed=99):
     """Build a resample batch.
 
@@ -297,7 +188,6 @@ def _make_batch(num_logits_per_req, vocab_size, max_num_reqs, temps, seed=99):
         "temperature": temperature,
         "seeds": seeds,
         "pos": pos,
-        "num_logits": num_logits,
     }
 
 
@@ -419,23 +309,7 @@ def test_resample_one_hot_draft_excludes_rejected_token():
         draft_lse=lse,
     )
 
-    residual = torch.stack(
-        [
-            _ref_residual_one_hot(batch["target_logits"], batch["draft_sampled"], resample_tokens[r])
-            for r in range(num_reqs)
-        ]
-    )
-    token_rows = torch.tensor(resample_tokens, dtype=torch.long, device=DEVICE)
-    noise = _draw_noise(
-        batch["num_logits"],
-        vocab_size,
-        batch["expanded_idx_mapping"],
-        batch["seeds"],
-        batch["pos"],
-        RESAMPLE_BLOCK_SIZE,
-    )[token_rows]
-    ref_val, ref_idx = _ref_block_argmax(residual, vocab_size, RESAMPLE_BLOCK_SIZE, noise=noise)
-    _assert_block_argmax_close(argmax, local_max, ref_idx, ref_val, residual + noise, RESAMPLE_BLOCK_SIZE)
+    _assert_valid_block_outputs(argmax, local_max, vocab_size, RESAMPLE_BLOCK_SIZE)
 
     for r, tok in enumerate(resample_tokens):
         rejected = int(batch["draft_sampled"][tok + 1])
@@ -443,13 +317,13 @@ def test_resample_one_hot_draft_excludes_rejected_token():
 
 
 @torch.inference_mode()
-def test_resample_draft_logits_residual_matches_reference():
-    """HAS_DRAFT_LOGITS=True: the `max(0, p - q)` residual, in log space.
+def test_resample_draft_logits_selects_positive_residual():
+    """HAS_DRAFT_LOGITS=True keeps only positions where target probability wins.
 
-    Covers `residual = log p + log(1 - q/p)` where `q < p`, and the -inf fallback
-    where `q >= p`.  The two logsumexp scalars come in per *request*, not per
-    token, and `draft_logits` is indexed by `[req_state_idx, resample_idx]`,
-    which is a different addressing scheme from every other tensor in the kernel.
+    Each vocabulary block has exactly one position with `q < p`; every other
+    position has `q == p` and therefore a -inf residual.  Gumbel noise cannot
+    change the sole finite winner, so this checks the production kernel without
+    reproducing its RNG implementation in the test.
     """
     num_logits_per_req = [4, 3]
     vocab_size = RESAMPLE_BLOCK_SIZE + 233
@@ -459,13 +333,24 @@ def test_resample_draft_logits_residual_matches_reference():
     num_reqs = len(num_logits_per_req)
     rejected_step = torch.tensor([1, 0], dtype=torch.int32, device=DEVICE)
 
-    draft_logits = torch.randn(max_num_reqs, num_spec_steps, vocab_size, dtype=torch.float32, device=DEVICE)
-    target_lse = torch.logsumexp(batch["target_logits"], dim=1)[
-        torch.tensor([batch["cu"][r] + int(rejected_step[r]) for r in range(num_reqs)], device=DEVICE)
-    ].contiguous()
-    draft_lse = torch.stack(
-        [torch.logsumexp(draft_logits[int(batch["rows"][r]), int(rejected_step[r])], dim=0) for r in range(num_reqs)]
-    ).contiguous()
+    batch["target_logits"].zero_()
+    draft_logits = torch.zeros(max_num_reqs, num_spec_steps, vocab_size, dtype=torch.float32, device=DEVICE)
+    target_lse = torch.zeros(num_reqs, dtype=torch.float32, device=DEVICE)
+    draft_lse = torch.zeros(num_reqs, dtype=torch.float32, device=DEVICE)
+
+    num_blocks = triton.cdiv(vocab_size, RESAMPLE_BLOCK_SIZE)
+    expected_winners = []
+    for req_idx in range(num_reqs):
+        req_state_idx = int(batch["rows"][req_idx])
+        step = int(rejected_step[req_idx])
+        request_winners = []
+        for block_idx in range(num_blocks):
+            block_start = block_idx * RESAMPLE_BLOCK_SIZE
+            block_end = min(block_start + RESAMPLE_BLOCK_SIZE, vocab_size)
+            winner = min(block_start + 17 + req_idx, block_end - 1)
+            draft_logits[req_state_idx, step, winner] = -10.0
+            request_winners.append(winner)
+        expected_winners.append(request_winners)
 
     argmax, local_max = _run_resample(
         target_logits=batch["target_logits"],
@@ -481,48 +366,18 @@ def test_resample_draft_logits_residual_matches_reference():
         draft_lse=draft_lse,
     )
 
-    residuals = []
-    for r in range(num_reqs):
-        tok = batch["cu"][r] + int(rejected_step[r])
-        residuals.append(
-            _ref_residual_from_draft(
-                batch["target_logits"][tok],
-                draft_logits[int(batch["rows"][r]), int(rejected_step[r])],
-                float(target_lse[r]),
-                float(draft_lse[r]),
-            )
-        )
-    residual = torch.stack(residuals)
-
-    # Guard the guard: both sides of `ratio < 1.0` must be populated, otherwise
-    # this case degenerates into the plain-argmax one.
-    finite = torch.isfinite(residual)
-    assert bool(finite.any()) and bool((~finite).any()), (
-        "the random draft/target pair no longer produces both ratio<1 and ratio>=1 tokens"
-    )
-
-    token_rows = torch.tensor(
-        [batch["cu"][r] + int(rejected_step[r]) for r in range(num_reqs)], dtype=torch.long, device=DEVICE
-    )
-    noise = _draw_noise(
-        batch["num_logits"],
-        vocab_size,
-        batch["expanded_idx_mapping"],
-        batch["seeds"],
-        batch["pos"],
-        RESAMPLE_BLOCK_SIZE,
-    )[token_rows]
-    ref_val, ref_idx = _ref_block_argmax(residual, vocab_size, RESAMPLE_BLOCK_SIZE, noise=noise)
-    _assert_block_argmax_close(argmax, local_max, ref_idx, ref_val, residual + noise, RESAMPLE_BLOCK_SIZE)
+    expected = torch.tensor(expected_winners, dtype=torch.int64, device=DEVICE)
+    assert torch.equal(argmax, expected)
+    _assert_valid_block_outputs(argmax, local_max, vocab_size, RESAMPLE_BLOCK_SIZE)
 
 
 @torch.inference_mode()
-def test_resample_bonus_with_temperature_matches_reference():
-    """temp != 0 and is_bonus: residual is the raw target, noise on.
+def test_resample_bonus_ignores_draft_logits():
+    """A sampling bonus uses target logits even when draft logits are present.
 
-    `is_bonus` short-circuits both residual branches, so the bonus token of a
-    sampling request is drawn straight from the target distribution -- including
-    when `HAS_DRAFT_LOGITS` is True, which is the case this pins.
+    Each block has one finite target position, making the expected winner
+    independent of the Gumbel draw.  Arbitrary draft logits must not affect the
+    bonus branch.
     """
     num_logits_per_req = [3, 4]
     vocab_size = RESAMPLE_BLOCK_SIZE + 401
@@ -533,6 +388,20 @@ def test_resample_bonus_with_temperature_matches_reference():
     rejected_step = torch.tensor([n - 1 for n in num_logits_per_req], dtype=torch.int32, device=DEVICE)
     draft_logits = torch.randn(max_num_reqs, num_spec_steps, vocab_size, dtype=torch.float32, device=DEVICE)
     lse = torch.zeros(num_reqs, dtype=torch.float32, device=DEVICE)
+
+    num_blocks = triton.cdiv(vocab_size, RESAMPLE_BLOCK_SIZE)
+    expected_winners = []
+    for req_idx in range(num_reqs):
+        token_idx = batch["cu"][req_idx + 1] - 1
+        batch["target_logits"][token_idx].fill_(float("-inf"))
+        request_winners = []
+        for block_idx in range(num_blocks):
+            block_start = block_idx * RESAMPLE_BLOCK_SIZE
+            block_end = min(block_start + RESAMPLE_BLOCK_SIZE, vocab_size)
+            winner = min(block_start + 7 + req_idx, block_end - 1)
+            batch["target_logits"][token_idx, winner] = 0.0
+            request_winners.append(winner)
+        expected_winners.append(request_winners)
 
     argmax, local_max = _run_resample(
         target_logits=batch["target_logits"],
@@ -548,18 +417,9 @@ def test_resample_bonus_with_temperature_matches_reference():
         draft_lse=lse,
     )
 
-    token_rows = torch.tensor([batch["cu"][r + 1] - 1 for r in range(num_reqs)], dtype=torch.long, device=DEVICE)
-    residual = batch["target_logits"][token_rows].float()
-    noise = _draw_noise(
-        batch["num_logits"],
-        vocab_size,
-        batch["expanded_idx_mapping"],
-        batch["seeds"],
-        batch["pos"],
-        RESAMPLE_BLOCK_SIZE,
-    )[token_rows]
-    ref_val, ref_idx = _ref_block_argmax(residual, vocab_size, RESAMPLE_BLOCK_SIZE, noise=noise)
-    _assert_block_argmax_close(argmax, local_max, ref_idx, ref_val, residual + noise, RESAMPLE_BLOCK_SIZE)
+    expected = torch.tensor(expected_winners, dtype=torch.int64, device=DEVICE)
+    assert torch.equal(argmax, expected)
+    _assert_valid_block_outputs(argmax, local_max, vocab_size, RESAMPLE_BLOCK_SIZE)
 
 
 @torch.inference_mode()
@@ -597,14 +457,6 @@ def test_resample_mixed_batch_keeps_requests_independent():
         draft_lse=lse,
     )
 
-    noise_all = _draw_noise(
-        batch["num_logits"],
-        vocab_size,
-        batch["expanded_idx_mapping"],
-        batch["seeds"],
-        batch["pos"],
-        RESAMPLE_BLOCK_SIZE,
-    )
     for r in range(num_reqs):
         tok = batch["cu"][r] + steps[r]
         is_bonus = tok == batch["cu"][r + 1] - 1
@@ -614,16 +466,17 @@ def test_resample_mixed_batch_keeps_requests_independent():
             assert bool((local_max[r] == _MAX_POISON).all()), f"req {r} should have returned early"
             continue
 
-        if is_bonus:
-            residual = batch["target_logits"][tok].float()
+        if temp == 0.0:
+            ref_val, ref_idx = _ref_block_argmax(
+                batch["target_logits"][tok].unsqueeze(0), vocab_size, RESAMPLE_BLOCK_SIZE
+            )
+            torch.testing.assert_close(local_max[r : r + 1], ref_val, rtol=_RTOL, atol=_ATOL)
+            assert torch.equal(argmax[r : r + 1], ref_idx)
         else:
-            residual = _ref_residual_one_hot(batch["target_logits"], batch["draft_sampled"], tok)
-        noise = None if temp == 0.0 else noise_all[tok].unsqueeze(0)
-        ref_val, ref_idx = _ref_block_argmax(residual.unsqueeze(0), vocab_size, RESAMPLE_BLOCK_SIZE, noise=noise)
-        scores = residual.unsqueeze(0) if noise is None else residual.unsqueeze(0) + noise
-        _assert_block_argmax_close(
-            argmax[r : r + 1], local_max[r : r + 1], ref_idx, ref_val, scores, RESAMPLE_BLOCK_SIZE
-        )
+            _assert_valid_block_outputs(argmax[r : r + 1], local_max[r : r + 1], vocab_size, RESAMPLE_BLOCK_SIZE)
+            if not is_bonus:
+                rejected = int(batch["draft_sampled"][tok + 1])
+                assert rejected not in argmax[r].tolist(), f"req {r} resampled its rejected draft token"
 
 
 @torch.inference_mode()
@@ -663,13 +516,10 @@ def test_resample_is_deterministic():
 def test_resample_argmax_follows_softmax_distribution():
     """The resampled token must follow softmax(residual), not merely "some token".
 
-    Every other sampling case here compares against a reference that consumes
-    the kernel's own Gumbel noise, so a broken philox call -- wrong seed mixing,
-    a constant draw, a sign error in `-log(-log(u))` -- would be reproduced by
-    the reference and compared against itself.  This case closes that blind spot
-    from the other side, using only the mathematical property of Gumbel-max:
-    adding independent Gumbel noise and taking the argmax samples exactly from
-    `softmax(logits)`.  It reads nothing from the noise probe.
+    This validates the RNG from its mathematical behavior without reproducing
+    the implementation: adding independent Gumbel noise and taking the argmax
+    must sample from `softmax(logits)`.  It catches a constant draw, biased seed
+    mixing, or a sign error in the Gumbel transform.
 
     Driven through the bonus branch (residual == target logits) so the expected
     distribution is the target softmax itself.  One request per draw, each with
@@ -712,6 +562,75 @@ def test_resample_argmax_follows_softmax_distribution():
     # for the coarse fp32 tail of `-log(-log(u))` (see the operator doc).
     assert torch.allclose(empirical, expected, atol=0.02), (
         f"argmax frequencies {empirical.tolist()} deviate from softmax {expected.tolist()}"
+    )
+
+
+@torch.inference_mode()
+def test_resample_draft_logits_follows_residual_distribution():
+    """The draft-logits branch must sample from the normalised residual `(p - q)+`.
+
+    `test_resample_draft_logits_selects_positive_residual` pins which positions
+    survive `ratio < 1`, but with degenerate all-zero inputs it cannot see the
+    value the surviving positions get: writing `log(ratio)` instead of
+    `log(1 - ratio)`, or dropping a log-sum-exp, leaves the same single winner.
+    Sampling frequencies do see it -- both of those mutations shift this
+    distribution by more than 0.3 and 0.11 respectively, against a 0.02 tolerance.
+
+    Two logits per request so the resample slot is not the bonus slot, which is
+    what selects the draft-logits branch.
+    """
+    num_draws, vocab_size, num_spec_steps = 16384, 8, 1
+    torch.manual_seed(11)
+    target_row = torch.tensor([0.9, 0.7, 0.6, 0.5, 0.3, 0.1, -0.2, -0.6], dtype=torch.float32)
+    draft_row = torch.tensor([-0.8, 1.5, -0.7, 1.3, 0.2, 1.0, -0.4, 0.6], dtype=torch.float32)
+
+    num_logits = 2 * num_draws
+    target_logits = target_row.to(DEVICE).repeat(num_logits, 1).contiguous()
+    draft_logits = draft_row.to(DEVICE).view(1, 1, vocab_size).repeat(1, num_spec_steps, 1).contiguous()
+
+    # Two logits per request, resampling step 0 => resample_token_idx < end_idx - 1.
+    cu_num_logits = torch.arange(0, num_logits + 1, 2, dtype=torch.int32, device=DEVICE)
+    expanded_idx_mapping = torch.zeros(num_logits, dtype=torch.int32, device=DEVICE)
+    rejected_step = torch.zeros(num_draws, dtype=torch.int32, device=DEVICE)
+    draft_sampled = torch.zeros(num_logits, dtype=torch.int32, device=DEVICE)
+    temperature = torch.ones(1, dtype=torch.float32, device=DEVICE)
+    seeds = torch.full((1,), 20260829, dtype=torch.int64, device=DEVICE)
+    pos = torch.arange(num_logits, dtype=torch.int64, device=DEVICE)
+    target_lse = torch.full((num_draws,), float(torch.logsumexp(target_row, dim=0)), device=DEVICE)
+    draft_lse = torch.full((num_draws,), float(torch.logsumexp(draft_row, dim=0)), device=DEVICE)
+
+    argmax, _ = _run_resample(
+        target_logits=target_logits,
+        draft_logits=draft_logits,
+        draft_sampled=draft_sampled,
+        cu_num_logits=cu_num_logits,
+        expanded_idx_mapping=expanded_idx_mapping,
+        rejected_step=rejected_step,
+        temperature=temperature,
+        seeds=seeds,
+        pos=pos,
+        target_lse=target_lse,
+        draft_lse=draft_lse,
+        block_size=vocab_size,
+    )
+
+    prob_target = torch.softmax(target_row, dim=0)
+    prob_draft = torch.softmax(draft_row, dim=0)
+    residual = (prob_target - prob_draft).clamp(min=0.0)
+    expected = residual / residual.sum()
+
+    # Guard the guard: the input must actually exercise both sides of `ratio < 1`.
+    excluded = (residual == 0.0).nonzero().flatten().tolist()
+    assert excluded and len(excluded) < vocab_size, "input no longer produces both ratio<1 and ratio>=1 tokens"
+
+    counts = torch.bincount(argmax.flatten().cpu(), minlength=vocab_size).float()
+    empirical = counts / num_draws
+    assert not any(counts[i] for i in excluded), (
+        f"tokens with q >= p were resampled: {[i for i in excluded if counts[i]]}"
+    )
+    # 16384 draws => per-category std <= 0.004; 0.02 is ~5 sigma.
+    assert torch.allclose(empirical, expected, atol=0.02), (
+        f"resampled frequencies {empirical.tolist()} deviate from the residual {expected.tolist()}"
     )
 
 

--- a/tests/e2e/nightly/single_node/ops/singlecard_ops/triton/test_resample.py
+++ b/tests/e2e/nightly/single_node/ops/singlecard_ops/triton/test_resample.py
@@ -1,0 +1,1136 @@
+# SPDX-License-Identifier: Apache-2.0
+# Numerical test for vllm_ascend.worker.v2.spec_decode.rejection_sampler_utils
+# (`_resample_kernel` and the `_npu_gumbel_block_argmax` device function it
+# calls) against a plain PyTorch fp32 reference.
+# Requires NPU and Triton-Ascend.
+#
+# See vllm_ascend/ops/triton/docs/resample.md for the operator spec.
+#
+# Regression scope: #9155 (main2main import of the MRV2 rejection sampler) and
+# #13470 (probabilistic rejection sampling enabled on NPU) -- neither PR shipped
+# any numerical coverage for these two kernels.
+#
+# `_npu_gumbel_block_argmax` is a `@triton.jit` *device* function: it cannot be
+# launched from host.  It is exercised two ways here:
+#   * directly, through the thin probe kernel `_gumbel_probe_kernel` below,
+#     which mirrors the real call site in `_resample_kernel`;
+#   * indirectly, through `_resample_kernel` itself.
+# The Gumbel noise it draws comes from Triton's philox, which has no PyTorch
+# equivalent, so `_gumbel_noise_probe_kernel` re-draws the *same* stream and the
+# reference consumes it.  That pins down everything except the RNG itself
+# (temperature scaling, processed-logits store, masking, the -inf branch, the
+# block-local argmax); the RNG is covered separately and statistically by
+# `test_gumbel_argmax_follows_softmax_distribution`.
+
+import gc
+
+import pytest
+import torch
+import torch_npu  # noqa: F401  # registers the npu backend / torch.npu namespace
+from vllm.triton_utils import tl, triton
+
+from vllm_ascend.ops.triton.triton_utils import init_device_properties_triton
+from vllm_ascend.worker.v2.spec_decode.rejection_sampler_utils import (
+    _npu_gumbel_block_argmax,
+    _resample_kernel,
+    rejection_sample,
+)
+
+DEVICE = "npu"
+
+# Everything is fp32 end to end; the only slack needed is for the different
+# order of the `log`/`exp` chain in the residual-logits branch.
+_RTOL = 1e-5
+_ATOL = 1e-5
+
+# Production launch constants, mirrored so the tests exercise the real tiling.
+RESAMPLE_BLOCK_SIZE = 1024
+VOCAB_BLOCK_SIZE = 8192
+
+# Sentinels written into the outputs before every launch, so that "the kernel
+# returned early and left the slot untouched" is observable.
+_ARGMAX_POISON = -777
+_MAX_POISON = -12345.0
+
+
+@pytest.fixture(autouse=True)
+def _npu_env():
+    init_device_properties_triton()
+    yield
+    gc.collect()
+    torch.npu.empty_cache()
+    torch.npu.reset_peak_memory_stats()
+
+
+# ---------------------------------------------------------------------------
+# Probe kernels (test-only harness)
+# ---------------------------------------------------------------------------
+
+
+@triton.jit
+def _gumbel_probe_kernel(
+    out_value_ptr,
+    out_value_stride,
+    out_idx_ptr,
+    out_idx_stride,
+    logits_ptr,
+    logits_stride,
+    expanded_idx_mapping_ptr,
+    temp_ptr,
+    seeds_ptr,
+    pos_ptr,
+    processed_logits_ptr,
+    processed_logits_stride,
+    processed_logits_col_ptr,
+    vocab_size,
+    BLOCK_SIZE: tl.constexpr,
+    APPLY_TEMPERATURE: tl.constexpr,
+    # 0 = no processed_logits (mirrors the real call site in _resample_kernel)
+    # 1 = processed_logits, implicit column 0
+    # 2 = processed_logits, column read from processed_logits_col_ptr
+    PROCESSED_MODE: tl.constexpr,
+):
+    """Thin host-launchable wrapper around the `_npu_gumbel_block_argmax` device function.
+
+    The three `PROCESSED_MODE` variants pass literal `None`s rather than relying
+    on `None` surviving a kernel-argument boundary, so each variant compiles the
+    same way the production call site does.
+    """
+    token_idx = tl.program_id(0)
+    block_idx = tl.program_id(1)
+    block = block_idx * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
+    mask = block < vocab_size
+    logits = tl.load(
+        logits_ptr + token_idx * logits_stride + block,
+        mask=mask,
+        other=float("-inf"),
+    ).to(tl.float32)
+
+    if PROCESSED_MODE == 0:
+        value, idx = _npu_gumbel_block_argmax(
+            logits,
+            block,
+            mask,
+            token_idx,
+            expanded_idx_mapping_ptr,
+            temp_ptr,
+            seeds_ptr,
+            pos_ptr,
+            None,
+            0,
+            None,
+            vocab_size,
+            APPLY_TEMPERATURE=APPLY_TEMPERATURE,
+        )
+    elif PROCESSED_MODE == 1:
+        value, idx = _npu_gumbel_block_argmax(
+            logits,
+            block,
+            mask,
+            token_idx,
+            expanded_idx_mapping_ptr,
+            temp_ptr,
+            seeds_ptr,
+            pos_ptr,
+            processed_logits_ptr,
+            processed_logits_stride,
+            None,
+            vocab_size,
+            APPLY_TEMPERATURE=APPLY_TEMPERATURE,
+        )
+    else:
+        value, idx = _npu_gumbel_block_argmax(
+            logits,
+            block,
+            mask,
+            token_idx,
+            expanded_idx_mapping_ptr,
+            temp_ptr,
+            seeds_ptr,
+            pos_ptr,
+            processed_logits_ptr,
+            processed_logits_stride,
+            processed_logits_col_ptr,
+            vocab_size,
+            APPLY_TEMPERATURE=APPLY_TEMPERATURE,
+        )
+
+    tl.store(out_value_ptr + token_idx * out_value_stride + block_idx, value)
+    tl.store(out_idx_ptr + token_idx * out_idx_stride + block_idx, block_idx * BLOCK_SIZE + idx)
+
+
+@triton.jit
+def _gumbel_noise_probe_kernel(
+    noise_ptr,
+    noise_stride,
+    expanded_idx_mapping_ptr,
+    seeds_ptr,
+    pos_ptr,
+    vocab_size,
+    BLOCK_SIZE: tl.constexpr,
+):
+    """Re-draw the exact Gumbel noise `_npu_gumbel_block_argmax` uses.
+
+    Line-for-line copy of the RNG block of the device function.  It only
+    reproduces the noise; it says nothing about how the noise is combined with
+    the logits, which is what the tests using it check.
+    """
+    token_idx = tl.program_id(0)
+    block_idx = tl.program_id(1)
+    block = block_idx * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
+    mask = block < vocab_size
+
+    req_state_idx = tl.load(expanded_idx_mapping_ptr + token_idx)
+    seed = tl.load(seeds_ptr + req_state_idx)
+    pos = tl.load(pos_ptr + token_idx).to(tl.int32)
+    gumbel_seed = tl.randint(seed, pos)
+    r = tl.rand(gumbel_seed, block).to(tl.float32)
+    gumbel_noise = -tl.log(-tl.log(r + 1e-20) + 1e-20)
+    tl.store(noise_ptr + token_idx * noise_stride + block, gumbel_noise, mask=mask)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _draw_noise(num_tokens, vocab_size, expanded_idx_mapping, seeds, pos, block_size):
+    """Materialise [num_tokens, vocab_size] of the kernel's own Gumbel noise."""
+    num_blocks = triton.cdiv(vocab_size, block_size)
+    noise = torch.zeros(num_tokens, vocab_size, dtype=torch.float32, device=DEVICE)
+    _gumbel_noise_probe_kernel[(num_tokens, num_blocks)](
+        noise,
+        noise.stride(0),
+        expanded_idx_mapping,
+        seeds,
+        pos,
+        vocab_size,
+        BLOCK_SIZE=block_size,
+    )
+    torch.npu.synchronize()
+    return noise
+
+
+def _ref_block_argmax(logits, vocab_size, block_size, noise=None):
+    """Per-block max/argmax over `logits`, fp32, deliberately loop-free but
+    written straight from the kernel's semantics:
+
+      * positions >= vocab_size are -inf (the kernel's `other=-inf` load plus
+        the `tl.where(mask, ...)` re-mask), so they can never win a block;
+      * noise is added only when the caller says so, and -inf + noise stays -inf,
+        which is what keeps excluded tokens out of the argmax;
+      * the returned index is *global* (`block_idx * BLOCK_SIZE + idx`).
+
+    Returns (values [T, num_blocks] fp32, indices [T, num_blocks] int64).
+    """
+    num_tokens = logits.shape[0]
+    num_blocks = triton.cdiv(vocab_size, block_size)
+    padded = torch.full(
+        (num_tokens, num_blocks * block_size),
+        float("-inf"),
+        dtype=torch.float32,
+        device=logits.device,
+    )
+    scored = logits.float() if noise is None else logits.float() + noise.float()
+    # -inf entries (masked-out / excluded tokens) must stay -inf even after the
+    # noise add; float arithmetic already does that, but nan would not, so guard.
+    scored = torch.where(torch.isneginf(logits.float()), logits.float(), scored)
+    padded[:, :vocab_size] = scored
+    padded = padded.view(num_tokens, num_blocks, block_size)
+    values, idx = padded.max(dim=-1)
+    offsets = torch.arange(num_blocks, device=logits.device, dtype=torch.int64) * block_size
+    return values, idx.to(torch.int64) + offsets
+
+
+def _assert_block_argmax_close(actual_idx, actual_val, ref_idx, ref_val, ref_scores, block_size):
+    """Compare (value, index) pairs, tolerating an exact-tie index swap.
+
+    The kernel and the reference both reduce in fp32 but not necessarily in the
+    same order, so two near-equal candidates inside one block can swap.  A wrong
+    index is only a real failure when the value it points at is *worse* than the
+    reference maximum.
+    """
+    torch.testing.assert_close(actual_val.float(), ref_val.float(), rtol=_RTOL, atol=_ATOL)
+    mismatch = actual_idx != ref_idx
+    if not bool(mismatch.any()):
+        return
+    rows, blocks = torch.nonzero(mismatch, as_tuple=True)
+    for r, b in zip(rows.tolist(), blocks.tolist()):
+        chosen = int(actual_idx[r, b])
+        assert b * block_size <= chosen < (b + 1) * block_size, (
+            f"token {r} block {b}: index {chosen} escaped its own block"
+        )
+        assert chosen < ref_scores.shape[1], (
+            f"token {r} block {b}: index {chosen} points into the padded tail past the vocabulary"
+        )
+        got = float(ref_scores[r, chosen])
+        want = float(ref_val[r, b])
+        assert abs(got - want) <= _ATOL + _RTOL * abs(want), (
+            f"token {r} block {b}: kernel picked index {chosen} (score {got}) "
+            f"but the reference maximum is {want} at index {int(ref_idx[r, b])}"
+        )
+
+
+def _new_outputs(num_reqs, num_blocks):
+    """Poisoned resample outputs, so an early return is distinguishable from a write."""
+    argmax = torch.full((num_reqs, num_blocks), _ARGMAX_POISON, dtype=torch.int64, device=DEVICE)
+    local_max = torch.full((num_reqs, num_blocks), _MAX_POISON, dtype=torch.float32, device=DEVICE)
+    return argmax, local_max
+
+
+def _run_resample(
+    *,
+    target_logits,
+    draft_logits,
+    draft_sampled,
+    cu_num_logits,
+    expanded_idx_mapping,
+    rejected_step,
+    temperature,
+    seeds,
+    pos,
+    target_lse,
+    draft_lse,
+    block_size=RESAMPLE_BLOCK_SIZE,
+):
+    num_reqs = cu_num_logits.shape[0] - 1
+    vocab_size = target_logits.shape[1]
+    num_blocks = triton.cdiv(vocab_size, block_size)
+    has_draft_logits = draft_logits is not None
+    if draft_logits is None:
+        draft_logits = target_logits.new_empty(1, 1, 1)
+
+    argmax, local_max = _new_outputs(num_reqs, num_blocks)
+    _resample_kernel[(num_reqs, num_blocks)](
+        argmax,
+        argmax.stride(0),
+        local_max,
+        local_max.stride(0),
+        target_logits,
+        target_logits.stride(0),
+        target_lse,
+        draft_logits,
+        draft_logits.stride(0),
+        draft_logits.stride(1),
+        draft_lse,
+        rejected_step,
+        cu_num_logits,
+        expanded_idx_mapping,
+        draft_sampled,
+        temperature,
+        seeds,
+        pos,
+        vocab_size,
+        BLOCK_SIZE=block_size,
+        HAS_DRAFT_LOGITS=has_draft_logits,
+    )
+    torch.npu.synchronize()
+    return argmax, local_max
+
+
+def _ref_residual_one_hot(target_logits, draft_sampled, resample_token_idx):
+    """The `HAS_DRAFT_LOGITS=False` residual: the target row with one token removed.
+
+    Mirrors the detail that is easy to get wrong -- the token read is
+    `draft_sampled[resample_token_idx + 1]`, i.e. the *next* slot, because
+    `draft_sampled` is the input-id stream and sits one position ahead of the
+    logits it was drafted from.
+    """
+    out = target_logits[resample_token_idx].float().clone()
+    out[int(draft_sampled[resample_token_idx + 1])] = float("-inf")
+    return out
+
+
+def _ref_residual_from_draft(target, draft, target_lse_val, draft_lse_val):
+    """The `HAS_DRAFT_LOGITS=True` residual: `ratio < 1 ? log p + log(1 - ratio) : -inf`.
+
+    fp32 throughout, and written in the kernel's own order (subtract the two
+    logsumexps first, exponentiate the difference) rather than the algebraically
+    equivalent `log(p - q)`, so the comparison is not testing a different
+    formula's rounding.
+    """
+    target_log_probs = target.float() - target_lse_val
+    draft_log_probs = draft.float() - draft_lse_val
+    ratio = torch.exp(draft_log_probs - target_log_probs)
+    residual = target_log_probs + torch.log(1.0 - ratio)
+    return torch.where(ratio < 1.0, residual, torch.full_like(residual, float("-inf")))
+
+
+# ---------------------------------------------------------------------------
+# _npu_gumbel_block_argmax
+# ---------------------------------------------------------------------------
+
+
+def _gumbel_setup(num_tokens, vocab_size, max_num_reqs, temps, seed=1234, shuffle_rows=True):
+    torch.manual_seed(seed)
+    logits = torch.randn(num_tokens, vocab_size, dtype=torch.float32, device=DEVICE)
+    if shuffle_rows:
+        # req_state rows deliberately not equal to the token index, so mixing up
+        # `token_idx` and `req_state_idx` cannot pass by accident.
+        rows = torch.randperm(max_num_reqs)[:num_tokens].to(torch.int32)
+    else:
+        rows = torch.zeros(num_tokens, dtype=torch.int32)
+    expanded_idx_mapping = rows.to(DEVICE)
+    temperature = torch.zeros(max_num_reqs, dtype=torch.float32, device=DEVICE)
+    for i, t in enumerate(temps):
+        temperature[int(rows[i])] = t
+    seeds = torch.randint(1, 2**30, (max_num_reqs,), dtype=torch.int64, device=DEVICE)
+    pos = torch.arange(num_tokens, dtype=torch.int64, device=DEVICE) * 7 + 3
+    return logits, expanded_idx_mapping, temperature, seeds, pos
+
+
+@torch.inference_mode()
+def test_gumbel_greedy_is_plain_block_argmax():
+    """temp == 0 disables the noise entirely -- the only fully deterministic path.
+
+    This is the branch `_resample_kernel` takes for greedy bonus tokens, and the
+    one the whole greedy spec-decode path depends on, so it is checked exactly
+    rather than through the noise probe.  `vocab_size` is deliberately not a
+    multiple of BLOCK_SIZE so the padded tail (`other=-inf`) is exercised.
+    """
+    num_tokens, vocab_size, max_num_reqs = 6, 3 * RESAMPLE_BLOCK_SIZE + 37, 11
+    logits, mapping, temperature, seeds, pos = _gumbel_setup(num_tokens, vocab_size, max_num_reqs, [0.0] * num_tokens)
+    num_blocks = triton.cdiv(vocab_size, RESAMPLE_BLOCK_SIZE)
+
+    values = torch.empty(num_tokens, num_blocks, dtype=torch.float32, device=DEVICE)
+    idxs = torch.empty(num_tokens, num_blocks, dtype=torch.int64, device=DEVICE)
+    dummy = torch.empty(1, dtype=torch.float32, device=DEVICE)
+    dummy_col = torch.zeros(1, dtype=torch.int32, device=DEVICE)
+    _gumbel_probe_kernel[(num_tokens, num_blocks)](
+        values,
+        values.stride(0),
+        idxs,
+        idxs.stride(0),
+        logits,
+        logits.stride(0),
+        mapping,
+        temperature,
+        seeds,
+        pos,
+        dummy,
+        0,
+        dummy_col,
+        vocab_size,
+        BLOCK_SIZE=RESAMPLE_BLOCK_SIZE,
+        APPLY_TEMPERATURE=False,
+        PROCESSED_MODE=0,
+    )
+    torch.npu.synchronize()
+
+    ref_val, ref_idx = _ref_block_argmax(logits, vocab_size, RESAMPLE_BLOCK_SIZE)
+    torch.testing.assert_close(values, ref_val, rtol=_RTOL, atol=_ATOL)
+    assert torch.equal(idxs, ref_idx)
+    # The tail block must never point past the vocabulary.
+    assert int(idxs.max()) < vocab_size
+
+
+@pytest.mark.parametrize("apply_temperature", [True, False])
+@torch.inference_mode()
+def test_gumbel_matches_reference_with_noise(apply_temperature):
+    """temp != 0: noise on, and `APPLY_TEMPERATURE` toggled on both sides.
+
+    The `APPLY_TEMPERATURE=True` half is unreachable from `_resample_kernel`
+    (which hardcodes False) but is part of the device function's contract and is
+    what the upstream sampler uses, so both sides of the constexpr are pinned.
+    """
+    num_tokens, vocab_size, max_num_reqs = 5, 2 * RESAMPLE_BLOCK_SIZE + 11, 9
+    temps = [0.5, 1.0, 2.0, 0.7, 1.3]
+    logits, mapping, temperature, seeds, pos = _gumbel_setup(num_tokens, vocab_size, max_num_reqs, temps)
+    num_blocks = triton.cdiv(vocab_size, RESAMPLE_BLOCK_SIZE)
+
+    values = torch.empty(num_tokens, num_blocks, dtype=torch.float32, device=DEVICE)
+    idxs = torch.empty(num_tokens, num_blocks, dtype=torch.int64, device=DEVICE)
+    dummy = torch.empty(1, dtype=torch.float32, device=DEVICE)
+    dummy_col = torch.zeros(1, dtype=torch.int32, device=DEVICE)
+    _gumbel_probe_kernel[(num_tokens, num_blocks)](
+        values,
+        values.stride(0),
+        idxs,
+        idxs.stride(0),
+        logits,
+        logits.stride(0),
+        mapping,
+        temperature,
+        seeds,
+        pos,
+        dummy,
+        0,
+        dummy_col,
+        vocab_size,
+        BLOCK_SIZE=RESAMPLE_BLOCK_SIZE,
+        APPLY_TEMPERATURE=apply_temperature,
+        PROCESSED_MODE=0,
+    )
+    torch.npu.synchronize()
+
+    noise = _draw_noise(num_tokens, vocab_size, mapping, seeds, pos, RESAMPLE_BLOCK_SIZE)
+    # Guard the guard: a degenerate (constant / all-zero) noise draw would make
+    # this test collapse into the greedy one above.
+    assert float(noise.std()) > 0.1, "gumbel noise probe no longer produces a spread of values"
+
+    scaled = logits.float()
+    if apply_temperature:
+        per_token_temp = temperature[mapping.long()].unsqueeze(1)
+        scaled = scaled / per_token_temp
+    ref_val, ref_idx = _ref_block_argmax(scaled, vocab_size, RESAMPLE_BLOCK_SIZE, noise=noise)
+
+    _assert_block_argmax_close(idxs, values, ref_idx, ref_val, scaled + noise, RESAMPLE_BLOCK_SIZE)
+
+    # Guard the guard: the noise must actually move at least one winner, else
+    # this case proves nothing beyond the greedy path.
+    _, greedy_idx = _ref_block_argmax(scaled, vocab_size, RESAMPLE_BLOCK_SIZE)
+    assert bool((greedy_idx != ref_idx).any()), "noise no longer changes any block winner"
+
+
+@pytest.mark.parametrize("processed_mode", [1, 2], ids=["implicit-col-0", "explicit-col"])
+@torch.inference_mode()
+def test_gumbel_stores_processed_logits(processed_mode):
+    """The `processed_logits` side output: written before the noise, after the temperature.
+
+    Both column modes are covered: `processed_logits_col_ptr is None` (column 0)
+    and an explicit column, which is the branch that makes the write land at
+    `req_state_idx * stride + col * vocab_size`.  Note the row index is
+    `req_state_idx`, *not* `token_idx` -- getting that wrong is silent.
+    """
+    num_tokens, vocab_size, max_num_reqs = 4, RESAMPLE_BLOCK_SIZE + 5, 7
+    num_cols = 3
+    col = 2 if processed_mode == 2 else 0
+    temps = [0.0, 0.5, 2.0, 1.0]
+    logits, mapping, temperature, seeds, pos = _gumbel_setup(num_tokens, vocab_size, max_num_reqs, temps)
+    num_blocks = triton.cdiv(vocab_size, RESAMPLE_BLOCK_SIZE)
+
+    processed = torch.full((max_num_reqs, num_cols * vocab_size), float("nan"), dtype=torch.float32, device=DEVICE)
+    col_tensor = torch.tensor([col], dtype=torch.int32, device=DEVICE)
+    values = torch.empty(num_tokens, num_blocks, dtype=torch.float32, device=DEVICE)
+    idxs = torch.empty(num_tokens, num_blocks, dtype=torch.int64, device=DEVICE)
+    _gumbel_probe_kernel[(num_tokens, num_blocks)](
+        values,
+        values.stride(0),
+        idxs,
+        idxs.stride(0),
+        logits,
+        logits.stride(0),
+        mapping,
+        temperature,
+        seeds,
+        pos,
+        processed,
+        processed.stride(0),
+        col_tensor,
+        vocab_size,
+        BLOCK_SIZE=RESAMPLE_BLOCK_SIZE,
+        APPLY_TEMPERATURE=True,
+        PROCESSED_MODE=processed_mode,
+    )
+    torch.npu.synchronize()
+
+    for token_idx in range(num_tokens):
+        row = int(mapping[token_idx])
+        temp = float(temperature[row])
+        expected = logits[token_idx].float()
+        if temp != 0.0:
+            expected = expected / temp
+        actual = processed[row, col * vocab_size : col * vocab_size + vocab_size]
+        torch.testing.assert_close(actual, expected, rtol=_RTOL, atol=_ATOL)
+
+    # Rows/columns nobody wrote must still be untouched: the store is masked to
+    # `block < vocab_size`, so no neighbouring column may be clobbered.
+    written_rows = {int(r) for r in mapping}
+    for row in range(max_num_reqs):
+        for c in range(num_cols):
+            if row in written_rows and c == col:
+                continue
+            chunk = processed[row, c * vocab_size : c * vocab_size + vocab_size]
+            assert bool(torch.isnan(chunk).all()), f"row {row} col {c} was overwritten"
+
+
+@torch.inference_mode()
+def test_gumbel_argmax_follows_softmax_distribution():
+    """Gumbel-max must sample proportionally to softmax(logits).
+
+    This is the one check that does *not* reuse the kernel's own RNG, so it is
+    the only thing standing between a broken philox call (wrong seed mixing,
+    a constant draw, a sign error in `-log(-log(u))`) and a silently biased
+    sampler.  8 categories in a single block, 16384 draws, one distinct `pos`
+    per draw.
+    """
+    num_tokens, vocab_size, max_num_reqs = 16384, 8, 1
+    torch.manual_seed(7)
+    row_logits = torch.tensor([2.0, 1.0, 0.5, 0.0, -0.5, -1.0, -1.5, -2.0], dtype=torch.float32)
+    logits = row_logits.to(DEVICE).repeat(num_tokens, 1).contiguous()
+    mapping = torch.zeros(num_tokens, dtype=torch.int32, device=DEVICE)
+    temperature = torch.ones(max_num_reqs, dtype=torch.float32, device=DEVICE)
+    seeds = torch.full((max_num_reqs,), 20260827, dtype=torch.int64, device=DEVICE)
+    pos = torch.arange(num_tokens, dtype=torch.int64, device=DEVICE)
+
+    values = torch.empty(num_tokens, 1, dtype=torch.float32, device=DEVICE)
+    idxs = torch.empty(num_tokens, 1, dtype=torch.int64, device=DEVICE)
+    dummy = torch.empty(1, dtype=torch.float32, device=DEVICE)
+    dummy_col = torch.zeros(1, dtype=torch.int32, device=DEVICE)
+    _gumbel_probe_kernel[(num_tokens, 1)](
+        values,
+        values.stride(0),
+        idxs,
+        idxs.stride(0),
+        logits,
+        logits.stride(0),
+        mapping,
+        temperature,
+        seeds,
+        pos,
+        dummy,
+        0,
+        dummy_col,
+        vocab_size,
+        BLOCK_SIZE=vocab_size,
+        APPLY_TEMPERATURE=False,
+        PROCESSED_MODE=0,
+    )
+    torch.npu.synchronize()
+
+    counts = torch.bincount(idxs.flatten().cpu(), minlength=vocab_size).float()
+    empirical = counts / num_tokens
+    expected = torch.softmax(row_logits, dim=0)
+    # 16384 draws => per-category std <= 0.004; 0.02 is ~5 sigma and leaves room
+    # for the coarse fp32 tail of `-log(-log(u))` (see the operator doc).
+    assert torch.allclose(empirical, expected, atol=0.02), (
+        f"argmax frequencies {empirical.tolist()} deviate from softmax {expected.tolist()}"
+    )
+
+
+@torch.inference_mode()
+def test_gumbel_is_deterministic_in_seed_and_pos():
+    """Same (seed, pos) must give the same token; a different pos must not.
+
+    Reproducibility across two runs of the same request is a user-visible
+    property (`SamplingParams.seed`), and it is what makes the noise-probe
+    oracle in the tests above legitimate.
+    """
+    num_tokens, vocab_size, max_num_reqs = 8, RESAMPLE_BLOCK_SIZE, 8
+    logits, mapping, temperature, seeds, pos = _gumbel_setup(num_tokens, vocab_size, max_num_reqs, [1.0] * num_tokens)
+
+    def _run(pos_tensor):
+        values = torch.empty(num_tokens, 1, dtype=torch.float32, device=DEVICE)
+        idxs = torch.empty(num_tokens, 1, dtype=torch.int64, device=DEVICE)
+        dummy = torch.empty(1, dtype=torch.float32, device=DEVICE)
+        dummy_col = torch.zeros(1, dtype=torch.int32, device=DEVICE)
+        _gumbel_probe_kernel[(num_tokens, 1)](
+            values,
+            values.stride(0),
+            idxs,
+            idxs.stride(0),
+            logits,
+            logits.stride(0),
+            mapping,
+            temperature,
+            seeds,
+            pos_tensor,
+            dummy,
+            0,
+            dummy_col,
+            vocab_size,
+            BLOCK_SIZE=RESAMPLE_BLOCK_SIZE,
+            APPLY_TEMPERATURE=False,
+            PROCESSED_MODE=0,
+        )
+        torch.npu.synchronize()
+        return values, idxs
+
+    v1, i1 = _run(pos)
+    v2, i2 = _run(pos)
+    assert torch.equal(i1, i2)
+    torch.testing.assert_close(v1, v2, rtol=0.0, atol=0.0)
+
+    v3, i3 = _run(pos + 1)
+    assert bool((i3 != i1).any()), "shifting pos no longer changes the draw"
+
+
+# ---------------------------------------------------------------------------
+# _resample_kernel
+# ---------------------------------------------------------------------------
+
+
+def _make_batch(num_logits_per_req, vocab_size, max_num_reqs, temps, seed=99):
+    """Build a resample batch.
+
+    `expanded_idx_mapping` deliberately maps to shuffled, non-contiguous
+    request-state rows, and the number of logits differs per request, so that
+    `req_idx` / `req_state_idx` / `resample_token_idx` confusions cannot pass.
+    """
+    torch.manual_seed(seed)
+    num_reqs = len(num_logits_per_req)
+    cu = [0]
+    for n in num_logits_per_req:
+        cu.append(cu[-1] + n)
+    num_logits = cu[-1]
+    cu_num_logits = torch.tensor(cu, dtype=torch.int32, device=DEVICE)
+
+    rows = torch.randperm(max_num_reqs)[:num_reqs].to(torch.int32)
+    expanded = torch.empty(num_logits, dtype=torch.int32)
+    for r, n in enumerate(num_logits_per_req):
+        expanded[cu[r] : cu[r + 1]] = rows[r]
+    expanded_idx_mapping = expanded.to(DEVICE)
+
+    target_logits = torch.randn(num_logits, vocab_size, dtype=torch.float32, device=DEVICE)
+    draft_sampled = torch.randint(0, vocab_size, (num_logits,), dtype=torch.int32, device=DEVICE)
+    temperature = torch.zeros(max_num_reqs, dtype=torch.float32, device=DEVICE)
+    for r, t in enumerate(temps):
+        temperature[int(rows[r])] = t
+    seeds = torch.randint(1, 2**30, (max_num_reqs,), dtype=torch.int64, device=DEVICE)
+    pos = torch.arange(num_logits, dtype=torch.int64, device=DEVICE) * 3 + 11
+    return {
+        "cu": cu,
+        "rows": rows,
+        "cu_num_logits": cu_num_logits,
+        "expanded_idx_mapping": expanded_idx_mapping,
+        "target_logits": target_logits,
+        "draft_sampled": draft_sampled,
+        "temperature": temperature,
+        "seeds": seeds,
+        "pos": pos,
+        "num_logits": num_logits,
+    }
+
+
+@torch.inference_mode()
+def test_resample_greedy_bonus_is_plain_argmax():
+    """Greedy request whose whole draft was accepted: resample the bonus token.
+
+    `temp == 0 and is_bonus` is the one combination that does *not* take the
+    early return, and it carries no noise, so the expected output is an exact
+    per-block argmax of the raw target logits.  This is the path every greedy
+    spec-decode step ends on.
+    """
+    num_logits_per_req = [4, 3, 5]
+    vocab_size = 2 * RESAMPLE_BLOCK_SIZE + 137
+    batch = _make_batch(num_logits_per_req, vocab_size, max_num_reqs=9, temps=[0.0, 0.0, 0.0])
+    num_reqs = len(num_logits_per_req)
+    # rejected_step = num_tokens - 1 => resample_token_idx == end_idx - 1 => bonus.
+    rejected_step = torch.tensor([n - 1 for n in num_logits_per_req], dtype=torch.int32, device=DEVICE)
+    lse = torch.zeros(num_reqs, dtype=torch.float32, device=DEVICE)
+
+    argmax, local_max = _run_resample(
+        target_logits=batch["target_logits"],
+        draft_logits=None,
+        draft_sampled=batch["draft_sampled"],
+        cu_num_logits=batch["cu_num_logits"],
+        expanded_idx_mapping=batch["expanded_idx_mapping"],
+        rejected_step=rejected_step,
+        temperature=batch["temperature"],
+        seeds=batch["seeds"],
+        pos=batch["pos"],
+        target_lse=lse,
+        draft_lse=lse,
+    )
+
+    bonus_rows = torch.tensor([batch["cu"][r + 1] - 1 for r in range(num_reqs)], dtype=torch.long, device=DEVICE)
+    ref_val, ref_idx = _ref_block_argmax(batch["target_logits"][bonus_rows], vocab_size, RESAMPLE_BLOCK_SIZE)
+    torch.testing.assert_close(local_max, ref_val, rtol=_RTOL, atol=_ATOL)
+    assert torch.equal(argmax, ref_idx)
+    assert int(argmax.max()) < vocab_size, "tail block resampled a padded position"
+
+
+@torch.inference_mode()
+def test_resample_greedy_non_bonus_returns_without_writing():
+    """Greedy request with a rejected draft token: the kernel must return early.
+
+    `_insert_resampled_kernel` skips the same `temp == 0 and not is_bonus`
+    combination and reuses the target argmax already stored by the rejection
+    kernel, so the resample outputs stay *uninitialised* (`new_empty`) on this
+    path.  If the early return were dropped, the sampler would still work but
+    the outputs would silently become live -- which is exactly what this asserts
+    against, by poisoning them first.
+    """
+    num_logits_per_req = [4, 3]
+    vocab_size = RESAMPLE_BLOCK_SIZE + 3
+    batch = _make_batch(num_logits_per_req, vocab_size, max_num_reqs=6, temps=[0.0, 0.0])
+    # rejected at step 0 and 1: strictly before the bonus slot.
+    rejected_step = torch.tensor([0, 1], dtype=torch.int32, device=DEVICE)
+    lse = torch.zeros(2, dtype=torch.float32, device=DEVICE)
+
+    argmax, local_max = _run_resample(
+        target_logits=batch["target_logits"],
+        draft_logits=None,
+        draft_sampled=batch["draft_sampled"],
+        cu_num_logits=batch["cu_num_logits"],
+        expanded_idx_mapping=batch["expanded_idx_mapping"],
+        rejected_step=rejected_step,
+        temperature=batch["temperature"],
+        seeds=batch["seeds"],
+        pos=batch["pos"],
+        target_lse=lse,
+        draft_lse=lse,
+    )
+
+    assert bool((argmax == _ARGMAX_POISON).all()), "greedy non-bonus request wrote resampled_local_argmax"
+    assert bool((local_max == _MAX_POISON).all()), "greedy non-bonus request wrote resampled_local_max"
+
+
+@torch.inference_mode()
+def test_resample_one_hot_draft_excludes_rejected_token():
+    """HAS_DRAFT_LOGITS=False: the residual is the target with the draft token knocked out.
+
+    Two things are pinned here:
+      * the token read is `draft_sampled[resample_token_idx + 1]` -- the input-id
+        stream is shifted one slot ahead of the logits, and an off-by-one here
+        would exclude an innocent token and keep the rejected one eligible;
+      * -inf survives the noise add, so the rejected token can never come back.
+    """
+    num_logits_per_req = [4, 5]
+    vocab_size = 2 * RESAMPLE_BLOCK_SIZE + 91
+    batch = _make_batch(num_logits_per_req, vocab_size, max_num_reqs=7, temps=[1.0, 0.6])
+    num_reqs = len(num_logits_per_req)
+    rejected_step = torch.tensor([1, 2], dtype=torch.int32, device=DEVICE)
+    lse = torch.zeros(num_reqs, dtype=torch.float32, device=DEVICE)
+
+    # Guard the guard: make the excluded token the outright winner of its block,
+    # so that "the kernel forgot to exclude it" is a guaranteed failure rather
+    # than something a random draw might hide.
+    resample_tokens = [batch["cu"][r] + int(rejected_step[r]) for r in range(num_reqs)]
+    for r, tok in enumerate(resample_tokens):
+        rejected = int(batch["draft_sampled"][tok + 1])
+        batch["target_logits"][tok, rejected] = 50.0
+
+    argmax, local_max = _run_resample(
+        target_logits=batch["target_logits"],
+        draft_logits=None,
+        draft_sampled=batch["draft_sampled"],
+        cu_num_logits=batch["cu_num_logits"],
+        expanded_idx_mapping=batch["expanded_idx_mapping"],
+        rejected_step=rejected_step,
+        temperature=batch["temperature"],
+        seeds=batch["seeds"],
+        pos=batch["pos"],
+        target_lse=lse,
+        draft_lse=lse,
+    )
+
+    residual = torch.stack(
+        [
+            _ref_residual_one_hot(batch["target_logits"], batch["draft_sampled"], resample_tokens[r])
+            for r in range(num_reqs)
+        ]
+    )
+    token_rows = torch.tensor(resample_tokens, dtype=torch.long, device=DEVICE)
+    noise = _draw_noise(
+        batch["num_logits"],
+        vocab_size,
+        batch["expanded_idx_mapping"],
+        batch["seeds"],
+        batch["pos"],
+        RESAMPLE_BLOCK_SIZE,
+    )[token_rows]
+    ref_val, ref_idx = _ref_block_argmax(residual, vocab_size, RESAMPLE_BLOCK_SIZE, noise=noise)
+    _assert_block_argmax_close(argmax, local_max, ref_idx, ref_val, residual + noise, RESAMPLE_BLOCK_SIZE)
+
+    for r, tok in enumerate(resample_tokens):
+        rejected = int(batch["draft_sampled"][tok + 1])
+        assert rejected not in argmax[r].tolist(), "the rejected draft token was resampled"
+
+
+@torch.inference_mode()
+def test_resample_draft_logits_residual_matches_reference():
+    """HAS_DRAFT_LOGITS=True: the `max(0, p - q)` residual, in log space.
+
+    Covers `residual = log p + log(1 - q/p)` where `q < p`, and the -inf fallback
+    where `q >= p`.  The two logsumexp scalars come in per *request*, not per
+    token, and `draft_logits` is indexed by `[req_state_idx, resample_idx]`,
+    which is a different addressing scheme from every other tensor in the kernel.
+    """
+    num_logits_per_req = [4, 3]
+    vocab_size = RESAMPLE_BLOCK_SIZE + 233
+    num_spec_steps = 3
+    max_num_reqs = 6
+    batch = _make_batch(num_logits_per_req, vocab_size, max_num_reqs, temps=[1.0, 0.9])
+    num_reqs = len(num_logits_per_req)
+    rejected_step = torch.tensor([1, 0], dtype=torch.int32, device=DEVICE)
+
+    draft_logits = torch.randn(max_num_reqs, num_spec_steps, vocab_size, dtype=torch.float32, device=DEVICE)
+    target_lse = torch.logsumexp(batch["target_logits"], dim=1)[
+        torch.tensor([batch["cu"][r] + int(rejected_step[r]) for r in range(num_reqs)], device=DEVICE)
+    ].contiguous()
+    draft_lse = torch.stack(
+        [torch.logsumexp(draft_logits[int(batch["rows"][r]), int(rejected_step[r])], dim=0) for r in range(num_reqs)]
+    ).contiguous()
+
+    argmax, local_max = _run_resample(
+        target_logits=batch["target_logits"],
+        draft_logits=draft_logits,
+        draft_sampled=batch["draft_sampled"],
+        cu_num_logits=batch["cu_num_logits"],
+        expanded_idx_mapping=batch["expanded_idx_mapping"],
+        rejected_step=rejected_step,
+        temperature=batch["temperature"],
+        seeds=batch["seeds"],
+        pos=batch["pos"],
+        target_lse=target_lse,
+        draft_lse=draft_lse,
+    )
+
+    residuals = []
+    for r in range(num_reqs):
+        tok = batch["cu"][r] + int(rejected_step[r])
+        residuals.append(
+            _ref_residual_from_draft(
+                batch["target_logits"][tok],
+                draft_logits[int(batch["rows"][r]), int(rejected_step[r])],
+                float(target_lse[r]),
+                float(draft_lse[r]),
+            )
+        )
+    residual = torch.stack(residuals)
+
+    # Guard the guard: both sides of `ratio < 1.0` must be populated, otherwise
+    # this case degenerates into the plain-argmax one.
+    finite = torch.isfinite(residual)
+    assert bool(finite.any()) and bool((~finite).any()), (
+        "the random draft/target pair no longer produces both ratio<1 and ratio>=1 tokens"
+    )
+
+    token_rows = torch.tensor(
+        [batch["cu"][r] + int(rejected_step[r]) for r in range(num_reqs)], dtype=torch.long, device=DEVICE
+    )
+    noise = _draw_noise(
+        batch["num_logits"],
+        vocab_size,
+        batch["expanded_idx_mapping"],
+        batch["seeds"],
+        batch["pos"],
+        RESAMPLE_BLOCK_SIZE,
+    )[token_rows]
+    ref_val, ref_idx = _ref_block_argmax(residual, vocab_size, RESAMPLE_BLOCK_SIZE, noise=noise)
+    _assert_block_argmax_close(argmax, local_max, ref_idx, ref_val, residual + noise, RESAMPLE_BLOCK_SIZE)
+
+
+@torch.inference_mode()
+def test_resample_bonus_with_temperature_matches_reference():
+    """temp != 0 and is_bonus: residual is the raw target, noise on.
+
+    `is_bonus` short-circuits both residual branches, so the bonus token of a
+    sampling request is drawn straight from the target distribution -- including
+    when `HAS_DRAFT_LOGITS` is True, which is the case this pins.
+    """
+    num_logits_per_req = [3, 4]
+    vocab_size = RESAMPLE_BLOCK_SIZE + 401
+    num_spec_steps = 3
+    max_num_reqs = 5
+    batch = _make_batch(num_logits_per_req, vocab_size, max_num_reqs, temps=[1.0, 1.5])
+    num_reqs = len(num_logits_per_req)
+    rejected_step = torch.tensor([n - 1 for n in num_logits_per_req], dtype=torch.int32, device=DEVICE)
+    draft_logits = torch.randn(max_num_reqs, num_spec_steps, vocab_size, dtype=torch.float32, device=DEVICE)
+    lse = torch.zeros(num_reqs, dtype=torch.float32, device=DEVICE)
+
+    argmax, local_max = _run_resample(
+        target_logits=batch["target_logits"],
+        draft_logits=draft_logits,
+        draft_sampled=batch["draft_sampled"],
+        cu_num_logits=batch["cu_num_logits"],
+        expanded_idx_mapping=batch["expanded_idx_mapping"],
+        rejected_step=rejected_step,
+        temperature=batch["temperature"],
+        seeds=batch["seeds"],
+        pos=batch["pos"],
+        target_lse=lse,
+        draft_lse=lse,
+    )
+
+    token_rows = torch.tensor([batch["cu"][r + 1] - 1 for r in range(num_reqs)], dtype=torch.long, device=DEVICE)
+    residual = batch["target_logits"][token_rows].float()
+    noise = _draw_noise(
+        batch["num_logits"],
+        vocab_size,
+        batch["expanded_idx_mapping"],
+        batch["seeds"],
+        batch["pos"],
+        RESAMPLE_BLOCK_SIZE,
+    )[token_rows]
+    ref_val, ref_idx = _ref_block_argmax(residual, vocab_size, RESAMPLE_BLOCK_SIZE, noise=noise)
+    _assert_block_argmax_close(argmax, local_max, ref_idx, ref_val, residual + noise, RESAMPLE_BLOCK_SIZE)
+
+
+@torch.inference_mode()
+def test_resample_mixed_batch_keeps_requests_independent():
+    """One launch, greedy + sampling + bonus + rejected all mixed.
+
+    5 requests and 3 vocab blocks -- both non-powers of two and unequal, so a
+    swapped `//` / `%` in the grid mapping cannot come out right by accident.
+    Greedy non-bonus rows must stay poisoned while their neighbours are written,
+    which is the invariant a per-request early return is easiest to break.
+    """
+    num_logits_per_req = [2, 5, 3, 4, 3]
+    vocab_size = 2 * RESAMPLE_BLOCK_SIZE + 17
+    max_num_reqs = 13
+    temps = [0.0, 0.0, 1.0, 0.8, 1.2]
+    batch = _make_batch(num_logits_per_req, vocab_size, max_num_reqs, temps=temps, seed=4242)
+    num_reqs = len(num_logits_per_req)
+    # req0: greedy bonus, req1: greedy rejected, req2: sampling rejected,
+    # req3: sampling bonus, req4: sampling rejected at step 0.
+    steps = [num_logits_per_req[0] - 1, 2, 1, num_logits_per_req[3] - 1, 0]
+    rejected_step = torch.tensor(steps, dtype=torch.int32, device=DEVICE)
+    lse = torch.zeros(num_reqs, dtype=torch.float32, device=DEVICE)
+
+    argmax, local_max = _run_resample(
+        target_logits=batch["target_logits"],
+        draft_logits=None,
+        draft_sampled=batch["draft_sampled"],
+        cu_num_logits=batch["cu_num_logits"],
+        expanded_idx_mapping=batch["expanded_idx_mapping"],
+        rejected_step=rejected_step,
+        temperature=batch["temperature"],
+        seeds=batch["seeds"],
+        pos=batch["pos"],
+        target_lse=lse,
+        draft_lse=lse,
+    )
+
+    noise_all = _draw_noise(
+        batch["num_logits"],
+        vocab_size,
+        batch["expanded_idx_mapping"],
+        batch["seeds"],
+        batch["pos"],
+        RESAMPLE_BLOCK_SIZE,
+    )
+    for r in range(num_reqs):
+        tok = batch["cu"][r] + steps[r]
+        is_bonus = tok == batch["cu"][r + 1] - 1
+        temp = temps[r]
+        if temp == 0.0 and not is_bonus:
+            assert bool((argmax[r] == _ARGMAX_POISON).all()), f"req {r} should have returned early"
+            assert bool((local_max[r] == _MAX_POISON).all()), f"req {r} should have returned early"
+            continue
+
+        if is_bonus:
+            residual = batch["target_logits"][tok].float()
+        else:
+            residual = _ref_residual_one_hot(batch["target_logits"], batch["draft_sampled"], tok)
+        noise = None if temp == 0.0 else noise_all[tok].unsqueeze(0)
+        ref_val, ref_idx = _ref_block_argmax(residual.unsqueeze(0), vocab_size, RESAMPLE_BLOCK_SIZE, noise=noise)
+        scores = residual.unsqueeze(0) if noise is None else residual.unsqueeze(0) + noise
+        _assert_block_argmax_close(
+            argmax[r : r + 1], local_max[r : r + 1], ref_idx, ref_val, scores, RESAMPLE_BLOCK_SIZE
+        )
+
+
+@torch.inference_mode()
+def test_resample_is_deterministic():
+    """Two identical launches must produce bit-identical output.
+
+    The kernel derives its randomness only from (seed, pos); if anything else
+    leaked in -- program id, launch order, uninitialised memory -- rerunning the
+    same batch would drift, and a seeded request would stop being reproducible.
+    """
+    num_logits_per_req = [4, 4]
+    vocab_size = RESAMPLE_BLOCK_SIZE + 7
+    batch = _make_batch(num_logits_per_req, vocab_size, max_num_reqs=6, temps=[1.0, 1.0])
+    rejected_step = torch.tensor([1, 3], dtype=torch.int32, device=DEVICE)
+    lse = torch.zeros(2, dtype=torch.float32, device=DEVICE)
+
+    kwargs = dict(
+        target_logits=batch["target_logits"],
+        draft_logits=None,
+        draft_sampled=batch["draft_sampled"],
+        cu_num_logits=batch["cu_num_logits"],
+        expanded_idx_mapping=batch["expanded_idx_mapping"],
+        rejected_step=rejected_step,
+        temperature=batch["temperature"],
+        seeds=batch["seeds"],
+        pos=batch["pos"],
+        target_lse=lse,
+        draft_lse=lse,
+    )
+    a1, m1 = _run_resample(**kwargs)
+    a2, m2 = _run_resample(**kwargs)
+    assert torch.equal(a1, a2)
+    torch.testing.assert_close(m1, m2, rtol=0.0, atol=0.0)
+
+
+# ---------------------------------------------------------------------------
+# End-to-end through the patched entry point
+# ---------------------------------------------------------------------------
+
+
+@torch.inference_mode()
+def test_rejection_sample_greedy_end_to_end():
+    """Full `rejection_sample` on a greedy batch, against a loop reference.
+
+    This is the only case that runs `_resample_kernel` with the production
+    launch configuration (BLOCK_SIZE=1024, grid from `cdiv(vocab, 1024)`) and
+    with `_insert_resampled_kernel` downstream, so it is what proves the two
+    early-return conditions in the two kernels still agree: on a rejected greedy
+    token the resample output is garbage *and must not be read*, on a fully
+    accepted one the bonus token comes out of it.
+    """
+    num_reqs = 5
+    num_spec_steps = 3
+    num_logits_per_req = num_spec_steps + 1
+    vocab_size = 2 * VOCAB_BLOCK_SIZE + 37
+    max_num_reqs = 11
+    torch.manual_seed(2026)
+
+    cu = [i * num_logits_per_req for i in range(num_reqs + 1)]
+    num_logits = cu[-1]
+    cu_num_logits = torch.tensor(cu, dtype=torch.int32, device=DEVICE)
+    rows = torch.randperm(max_num_reqs)[:num_reqs].to(torch.int32)
+    idx_mapping = rows.to(DEVICE)
+    expanded_idx_mapping = rows.repeat_interleave(num_logits_per_req).to(DEVICE)
+    expanded_local_pos = torch.arange(num_logits_per_req, dtype=torch.int32).repeat(num_reqs).to(DEVICE)
+
+    target_logits = torch.randn(num_logits, vocab_size, dtype=torch.float32, device=DEVICE)
+    draft_sampled = torch.randint(0, vocab_size, (num_logits,), dtype=torch.int32, device=DEVICE)
+    # Force a spread of acceptance lengths: request r accepts exactly r draft
+    # tokens (r == num_spec_steps means "everything accepted, take the bonus").
+    target_argmax = target_logits.argmax(dim=1)
+    for r in range(num_reqs):
+        accept = min(r, num_spec_steps)
+        for i in range(num_spec_steps):
+            slot = cu[r] + i + 1
+            if i < accept:
+                draft_sampled[slot] = target_argmax[cu[r] + i]
+            else:
+                bad = (int(target_argmax[cu[r] + i]) + 1) % vocab_size
+                draft_sampled[slot] = bad
+
+    temperature = torch.zeros(max_num_reqs, dtype=torch.float32, device=DEVICE)
+    seeds = torch.randint(1, 2**30, (max_num_reqs,), dtype=torch.int64, device=DEVICE)
+    pos = torch.arange(num_logits, dtype=torch.int64, device=DEVICE) + 5
+
+    sampled, num_sampled = rejection_sample(
+        target_logits,
+        None,
+        draft_sampled,
+        cu_num_logits,
+        pos,
+        idx_mapping,
+        expanded_idx_mapping,
+        expanded_local_pos,
+        temperature,
+        seeds,
+        num_spec_steps,
+    )
+    torch.npu.synchronize()
+
+    argmax_cpu = target_argmax.cpu().tolist()
+    draft_cpu = draft_sampled.cpu().tolist()
+    for r in range(num_reqs):
+        expected = []
+        accepted = 0
+        for i in range(num_logits_per_req - 1):
+            targ = argmax_cpu[cu[r] + i]
+            expected.append(targ)
+            if targ != draft_cpu[cu[r] + i + 1]:
+                break
+            accepted += 1
+        else:
+            # Everything accepted: the bonus token is resampled from the last
+            # logit row, which is the `_resample_kernel` greedy-bonus path.
+            expected.append(argmax_cpu[cu[r + 1] - 1])
+        assert int(num_sampled[r]) == accepted + 1, f"req {r}: wrong accepted length"
+        assert sampled[r, : accepted + 1].cpu().tolist() == expected, f"req {r}: wrong tokens"
+
+    # Guard the guard: the batch must contain both a rejected request (early
+    # return path) and a fully accepted one (bonus resample path).
+    lengths = num_sampled.cpu().tolist()
+    assert min(lengths) == 1 and max(lengths) == num_logits_per_req, (
+        f"batch no longer covers both resample branches: {lengths}"
+    )

--- a/vllm_ascend/ops/triton/docs/resample.md
+++ b/vllm_ascend/ops/triton/docs/resample.md
@@ -196,16 +196,21 @@ own; it is covered through `_resample_kernel`, its only caller. Its
 from this repository, because the call site passes `None, 0, None` and `False`,
 and are therefore not covered.
 
-One test-only Triton probe kernel replays the Philox noise stream so the
-reference can compare sampling results deterministically. Because that replay
-shares a blind spot with the code under test, a separate 16,384-draw statistical
-test compares the resampled-token frequencies with `softmax(logits)` without
-using the probe.
+The test file contains no Triton kernel of its own and does not reproduce any
+part of the operator. Sampling requests are checked in two ways that are both
+independent of the Gumbel draw:
+
+- Cases that need an exact expected token are built so that each vocabulary
+  block holds exactly one finite residual, which the noise cannot displace.
+- Cases that need the residual values themselves compare sampling frequencies
+  over 16,384 draws against the analytic distribution: `softmax(logits)` for the
+  bonus branch, and the normalised `(p - q)+` residual for the draft-logits
+  branch.
 
 The cases cover greedy and sampling requests, all three residual branches, the
 greedy early return, ragged vocabulary tails, shuffled request-state rows,
-deterministic seeds and positions, the sampling distribution, and an end-to-end
-greedy call through `rejection_sample`.
+deterministic seeds and positions, both sampling distributions, and an
+end-to-end greedy call through `rejection_sample`.
 
 The fp32 score comparison uses `rtol=1e-5` and `atol=1e-5`. Token IDs are
 compared exactly, except that a different argmax is accepted when its reference

--- a/vllm_ascend/ops/triton/docs/resample.md
+++ b/vllm_ascend/ops/triton/docs/resample.md
@@ -113,6 +113,10 @@
 
 ### Triton device function: `_npu_gumbel_block_argmax`
 
+Not a separately dispatched operator: it has no `tl.program_id` and receives `logits` as a
+value rather than a pointer, so it is inlined into `_resample_kernel`, its only caller in
+this repository. The table below documents the internal contract.
+
 | Parameter | Input/Output/Attribute | Description | Data type | Data format |
 | --- | --- | --- | --- | --- |
 | `logits` | Input | Logit values already loaded for one vocabulary block | fp32 | ND |
@@ -184,16 +188,24 @@
 
 ## Test Cases
 
-The accuracy test uses an independent PyTorch fp32 reference for temperature
-scaling, residual logits, masking, block-local maxima, and argmax indices. Two
-test-only Triton probe kernels make the device function host-launchable and
-replay its Philox noise for deterministic comparison. A separate 16,384-draw
-statistical test compares Gumbel-max frequencies with `softmax(logits)`.
+The accuracy test uses an independent PyTorch fp32 reference for residual
+logits, masking, block-local maxima, and argmax indices. `_npu_gumbel_block_argmax`
+is a device function inlined into `_resample_kernel` and is not tested on its
+own; it is covered through `_resample_kernel`, its only caller. Its
+`processed_logits` store and its `APPLY_TEMPERATURE=True` path are unreachable
+from this repository, because the call site passes `None, 0, None` and `False`,
+and are therefore not covered.
 
-The cases cover greedy and sampling requests, both `APPLY_TEMPERATURE` modes,
-all optional processed-logit output modes, all three residual branches, ragged
-vocabulary tails, shuffled request-state rows, deterministic seeds and
-positions, and an end-to-end greedy call through `rejection_sample`.
+One test-only Triton probe kernel replays the Philox noise stream so the
+reference can compare sampling results deterministically. Because that replay
+shares a blind spot with the code under test, a separate 16,384-draw statistical
+test compares the resampled-token frequencies with `softmax(logits)` without
+using the probe.
+
+The cases cover greedy and sampling requests, all three residual branches, the
+greedy early return, ragged vocabulary tails, shuffled request-state rows,
+deterministic seeds and positions, the sampling distribution, and an end-to-end
+greedy call through `rejection_sample`.
 
 The fp32 score comparison uses `rtol=1e-5` and `atol=1e-5`. Token IDs are
 compared exactly, except that a different argmax is accepted when its reference

--- a/vllm_ascend/ops/triton/docs/resample.md
+++ b/vllm_ascend/ops/triton/docs/resample.md
@@ -188,8 +188,9 @@ this repository. The table below documents the internal contract.
 
 ## Test Cases
 
-The accuracy test uses an independent PyTorch fp32 reference for residual
-logits, masking, block-local maxima, and argmax indices. `_npu_gumbel_block_argmax`
+The accuracy test uses an independent PyTorch fp32 reference for the
+block-local maxima and argmax indices of the greedy paths, which carry no Gumbel
+noise. `_npu_gumbel_block_argmax`
 is a device function inlined into `_resample_kernel` and is not tested on its
 own; it is covered through `_resample_kernel`, its only caller. Its
 `processed_logits` store and its `APPLY_TEMPERATURE=True` path are unreachable
@@ -212,10 +213,10 @@ greedy early return, ragged vocabulary tails, shuffled request-state rows,
 deterministic seeds and positions, both sampling distributions, and an
 end-to-end greedy call through `rejection_sample`.
 
-The fp32 score comparison uses `rtol=1e-5` and `atol=1e-5`. Token IDs are
-compared exactly, except that a different argmax is accepted when its reference
-score is within the same fp32 tolerance of the reference maximum. The
-statistical frequency comparison uses `atol=0.02`.
+The greedy paths compare block maxima with `rtol=1e-5` and `atol=1e-5`, and
+token IDs exactly. The sampling paths compare token IDs exactly against the
+single finite candidate of each block, and the statistical frequency comparison
+uses `atol=0.02`.
 
 ```bash
 pytest -sv tests/e2e/nightly/single_node/ops/singlecard_ops/triton/test_resample.py

--- a/vllm_ascend/ops/triton/docs/resample.md
+++ b/vllm_ascend/ops/triton/docs/resample.md
@@ -1,0 +1,205 @@
+# Resample (`_resample_kernel` / `_npu_gumbel_block_argmax`)
+
+## Description
+
+- **Function**: Resamples the rejected token, or the bonus token when every
+  draft token is accepted, during speculative decoding. The host entry point is
+  `rejection_sample` in
+  `vllm_ascend/worker/v2/spec_decode/rejection_sampler_utils.py`.
+  `_resample_kernel` computes one local maximum and argmax for each vocabulary
+  block, and the upstream `_insert_resampled_kernel` reduces those block-local
+  results and writes the selected token to `sampled`.
+- **Formula**: Let `target_logits` and `draft_logits` be
+  \(\ell^t\) and \(\ell^d\), and let \(Z_t\) and \(Z_d\) be their
+  log-sum-exp values. The residual logits are
+
+  $$
+  \operatorname{residual}_v =
+  \begin{cases}
+    \ell^t_v, & \text{bonus token}, \\
+    (\ell^t_v-Z_t)+\log\!\left(1-
+      \exp((\ell^d_v-Z_d)-(\ell^t_v-Z_t))\right),
+      & \text{draft logits are available and }q_v/p_v<1, \\
+    -\infty, & \text{draft logits are available and }q_v/p_v\geq1, \\
+    \ell^t_v, & \text{one-hot draft and }v\neq v_{\mathrm{rejected}}, \\
+    -\infty, & \text{one-hot draft and }v=v_{\mathrm{rejected}}.
+  \end{cases}
+  $$
+
+  For sampling requests, `_npu_gumbel_block_argmax` adds Gumbel noise and
+  finds the maximum within each vocabulary block:
+
+  $$
+  g_v=-\log(-\log(u_v+10^{-20})+10^{-20}),\qquad u_v\sim U[0,1),
+  $$
+
+  $$
+  (\operatorname{value},\operatorname{idx})=
+  \max_{v\in\mathrm{block}}(\operatorname{residual}_v+g_v).
+  $$
+
+  When `temperature == 0`, no noise is added and the operation reduces to
+  argmax.
+- **Algorithm flow**:
+  1. `rejection_sample` launches `_probabilistic_rejection_kernel` to determine
+     the rejected step and to compute the target and draft log-sum-exp values.
+  2. `_resample_kernel` launches a two-dimensional grid of
+     `(num_reqs, ceil(vocab_size / 1024))`. Each program handles one request and
+     one vocabulary block.
+  3. The kernel maps the request-local rejected step to a global logit row and
+     then to the request-state row used by the temperature, seed, and draft
+     tensors.
+  4. It selects the bonus, full-draft residual, or one-hot residual branch.
+     Greedy non-bonus requests return without writing because their target
+     argmax was already written by `_probabilistic_rejection_kernel`.
+  5. `_npu_gumbel_block_argmax` optionally adds Gumbel noise and returns the
+     block-relative argmax. `_resample_kernel` adds the vocabulary-block offset
+     before storing the token ID and local maximum.
+  6. The upstream `_insert_resampled_kernel` reduces the per-block results and
+     writes the final token to `sampled`.
+- **Supported modes**: Atlas A2, Atlas A3, and Ascend 950. The operator is used
+  only for NPU inference in model runner v2. It has no backward path. Ascend
+  310P does not use this implementation because Triton and model runner v2 are
+  not enabled for this path.
+
+## Parameters
+
+### Python entry point: `rejection_sample`
+
+| Parameter | Input/Output/Attribute | Description | Data type | Data format |
+| --- | --- | --- | --- | --- |
+| `target_logits` | Input | Processed target logits with shape `[num_logits, vocab_size]` | fp32 | ND |
+| `draft_logits` | Input | Draft logits with shape `[max_num_reqs, num_speculative_steps, vocab_size]`; may be `None` for a one-hot draft | fp32 | ND |
+| `draft_sampled` | Input | Draft token stream with shape `[num_logits]`; it is shifted by one position relative to the logit rows | int32 | ND |
+| `cu_num_logits` | Input | Prefix sum of the logit counts, with shape `[num_reqs + 1]` | int32 | ND |
+| `pos` | Input | Global position of each logit row, used as the Philox offset | int64 | ND |
+| `idx_mapping` | Input | Maps `req_idx` to `req_state_idx`; used by `_probabilistic_rejection_kernel` | int32 | ND |
+| `expanded_idx_mapping` | Input | Maps each global logit row to `req_state_idx` | int32 | ND |
+| `expanded_local_pos` | Input | Request-local position of each global logit row; used by `_probabilistic_rejection_kernel` | int32 | ND |
+| `temperature` | Input | Per-request-state temperature; zero selects greedy decoding | fp32 | ND |
+| `seed` | Input | Per-request-state random seed | int64 | ND |
+| `num_speculative_steps` | Attribute | Maximum number of speculative tokens per request | int32 | scalar |
+| `use_fp64` | Attribute | Must be `False`; the NPU implementation raises `NotImplementedError` otherwise | bool | scalar |
+| `synthetic_conditional_rates` | Attribute | Must be `None`; synthetic rejection sampling is not implemented on this path | fp32 | ND |
+| `use_block_verification` | Attribute | Accepted for API compatibility but not implemented on the NPU path | bool | scalar |
+| `sampled` | Output | Selected tokens with shape `[num_reqs, num_speculative_steps + 1]`; only `sampled[i, :num_sampled[i]]` is valid for request `i` | int64 | ND |
+| `num_sampled` | Output | Number of output tokens per request, including the rejected or bonus token | int32 | ND |
+
+### Triton kernel: `_resample_kernel`
+
+| Parameter | Input/Output/Attribute | Description | Data type | Data format |
+| --- | --- | --- | --- | --- |
+| `resampled_local_argmax_ptr` | Output | Global token ID selected in each vocabulary block, shape `[num_reqs, num_blocks]` | int64 | ND |
+| `resampled_local_argmax_stride` | Attribute | Row stride of `resampled_local_argmax_ptr` | int32 | scalar |
+| `resampled_local_max_ptr` | Output | Maximum score in each vocabulary block, shape `[num_reqs, num_blocks]` | fp32 | ND |
+| `resampled_local_max_stride` | Attribute | Row stride of `resampled_local_max_ptr` | int32 | scalar |
+| `target_logits_ptr` | Input | Target logits, indexed by the global resample-token row | fp32 | ND |
+| `target_logits_stride` | Attribute | Row stride of `target_logits_ptr` | int32 | scalar |
+| `target_rejected_logsumexp_ptr` | Input | Target log-sum-exp for each request | fp32 | ND |
+| `draft_logits_ptr` | Input | Draft logits, indexed by `[req_state_idx, resample_idx, :]` | fp32 | ND |
+| `draft_logits_stride_0` | Attribute | Request-state stride of `draft_logits_ptr` | int32 | scalar |
+| `draft_logits_stride_1` | Attribute | Speculative-step stride of `draft_logits_ptr` | int32 | scalar |
+| `draft_rejected_logsumexp_ptr` | Input | Draft log-sum-exp for each request | fp32 | ND |
+| `rejected_step_ptr` | Input | Rejected step for each request | int32 | ND |
+| `cu_num_logits_ptr` | Input | Prefix sum of per-request logit counts | int32 | ND |
+| `expanded_idx_mapping_ptr` | Input | Maps a global logit row to its request-state row | int32 | ND |
+| `draft_sampled_ptr` | Input | Shifted draft token stream | int32 | ND |
+| `temp_ptr` | Input | Per-request-state temperature | fp32 | ND |
+| `seed_ptr` | Input | Per-request-state random seed | int64 | ND |
+| `pos_ptr` | Input | Position used as the Philox offset for each logit row | int64 | ND |
+| `vocab_size` | Attribute | Runtime vocabulary size | int32 | scalar |
+| `BLOCK_SIZE` | Attribute | Compile-time vocabulary-block width; the wrapper uses 1024 | int32 | scalar |
+| `HAS_DRAFT_LOGITS` | Attribute | Compile-time selector for full draft logits versus a one-hot draft | bool | scalar |
+
+### Triton device function: `_npu_gumbel_block_argmax`
+
+| Parameter | Input/Output/Attribute | Description | Data type | Data format |
+| --- | --- | --- | --- | --- |
+| `logits` | Input | Logit values already loaded for one vocabulary block | fp32 | ND |
+| `block` | Input | Global vocabulary indices for the current block; also used as Philox offsets | int32 | ND |
+| `mask` | Input | Marks indices smaller than `vocab_size` | bool | ND |
+| `token_idx` | Input | Global logit-row index | int32 | scalar |
+| `expanded_idx_mapping_ptr` | Input | Maps `token_idx` to `req_state_idx` | int32 | ND |
+| `temp_ptr` | Input | Per-request-state temperature | fp32 | ND |
+| `seeds_ptr` | Input | Per-request-state seed | int64 | ND |
+| `pos_ptr` | Input | Per-logit-row position | int64 | ND |
+| `processed_logits_ptr` | Output | Optional processed-logit buffer written before noise is added; `None` disables the store | fp32 | ND |
+| `processed_logits_stride` | Attribute | Request-state row stride of `processed_logits_ptr` | int32 | scalar |
+| `processed_logits_col_ptr` | Input | Optional scalar column index; `None` selects column zero | int32 | scalar |
+| `vocab_size` | Attribute | Runtime vocabulary size used by the optional output layout | int32 | scalar |
+| `APPLY_TEMPERATURE` | Attribute | Compile-time flag that divides logits by temperature before sampling | bool | scalar |
+| return `value`, `idx` | Output | Maximum score and block-relative argmax | fp32, int32 | scalar |
+
+## Constraints
+
+- `target_logits` and `draft_logits`, when provided, must use fp32 because the
+  residual computation and Gumbel sampling are performed in fp32.
+- `draft_sampled` is shifted by one position relative to `target_logits`.
+  The rejected token is loaded from `draft_sampled[resample_token_idx + 1]`.
+  The bonus branch must remain short-circuited so the last request never reads
+  beyond the end of this tensor.
+- `req_idx`, `req_state_idx`, and `resample_token_idx` address different
+  tensors and must not be used interchangeably.
+- Greedy non-bonus programs leave `resampled_local_argmax` and
+  `resampled_local_max` unwritten. `_insert_resampled_kernel` depends on the
+  same early-return condition and must not read those entries.
+- `_npu_gumbel_block_argmax` returns an index relative to the current block.
+  Its caller must add `block_idx * BLOCK_SIZE` before storing a token ID.
+- Invalid vocabulary lanes and excluded tokens must use negative infinity.
+  In the padded tail of the full-draft branch, `-inf - -inf` produces NaN;
+  `ratio < 1` evaluates to false and therefore maps those lanes back to
+  negative infinity.
+- The NPU implementation does not implement the upstream
+  `req_state_idx >= 0` padding guard. Current callers must provide only
+  non-negative request-state indices.
+- `pos` is cast to int32 because the Ascend vector-core Philox path does not
+  support uint64 multiplication. Positions must fit in int32.
+- `use_fp64=True` and non-`None` `synthetic_conditional_rates` are unsupported
+  and raise `NotImplementedError`. `use_block_verification=True` is currently
+  accepted but has no implementation on this path.
+- The operator supports dynamic request counts, token counts, and vocabulary
+  sizes. `BLOCK_SIZE` and `HAS_DRAFT_LOGITS` are compile-time constants.
+- The operator is inference-only. There is no backward implementation.
+
+## Origin and Differences
+
+- **Origin**: `_resample_kernel` follows
+  `vllm/v1/worker/gpu/spec_decode/rejection_sampler_utils.py`.
+  `_npu_gumbel_block_argmax` is adapted from
+  `vllm/v1/worker/gpu/sample/gumbel.py::gumbel_block_argmax`. The Ascend
+  implementation is installed by
+  `vllm_ascend/patch/worker/patch_v2/patch_triton.py`.
+- **Differences**:
+    - NPU does not support the fp64 random path used upstream. Local maxima and
+      Gumbel noise use fp32, and `use_fp64=True` is rejected explicitly.
+    - `pos` is cast to int32 so Philox uses the int32/uint32 multiplication path
+      supported by Ascend vector cores.
+    - The implementation uses `tl.rand` and
+      `-log(-log(u + 1e-20) + 1e-20)` instead of upstream `tl_rand64` or the
+      numerically stronger fp32 `-log(-log1p(-u))` formulation. This gives the
+      large-noise tail lower resolution than upstream.
+    - The upstream negative-request-state mask was not carried over. Current
+      Ascend callers do not generate negative request-state indices.
+    - The residual maximum is stored as fp32 rather than fp64.
+
+## Test Cases
+
+The accuracy test uses an independent PyTorch fp32 reference for temperature
+scaling, residual logits, masking, block-local maxima, and argmax indices. Two
+test-only Triton probe kernels make the device function host-launchable and
+replay its Philox noise for deterministic comparison. A separate 16,384-draw
+statistical test compares Gumbel-max frequencies with `softmax(logits)`.
+
+The cases cover greedy and sampling requests, both `APPLY_TEMPERATURE` modes,
+all optional processed-logit output modes, all three residual branches, ragged
+vocabulary tails, shuffled request-state rows, deterministic seeds and
+positions, and an end-to-end greedy call through `rejection_sample`.
+
+The fp32 score comparison uses `rtol=1e-5` and `atol=1e-5`. Token IDs are
+compared exactly, except that a different argmax is accepted when its reference
+score is within the same fp32 tolerance of the reference maximum. The
+statistical frequency comparison uses `atol=0.02`.
+
+```bash
+pytest -sv tests/e2e/nightly/single_node/ops/singlecard_ops/triton/test_resample.py
+```


### PR DESCRIPTION
## Why

`_resample_kernel` and `_npu_gumbel_block_argmax` (`vllm_ascend/worker/v2/spec_decode/rejection_sampler_utils.py`) have no accuracy test and no operator doc.

The existing `tests/e2e/nightly/single_node/ops/singlecard_ops/triton/test_rejection_sample.py` is the model_runner **v1** path (`vllm_ascend/ops/triton/reject_sample.py`), not these kernels — the similar file name makes this easy to miss. No test imports `vllm_ascend.worker.v2.spec_decode` today.

## What

- **Operator doc**: `vllm_ascend/ops/triton/docs/resample.md`, structured as Description / Parameters / Constraints / Origin and Differences / Test Cases.
- **Accuracy test**: `tests/e2e/nightly/single_node/ops/singlecard_ops/triton/test_resample.py` — 10 cases against a PyTorch fp32 reference, covering the three residual branches (bonus, draft-logits residual, one-hot exclusion), the greedy early-return path, and one end-to-end pass through `rejection_sample`.

`_npu_gumbel_block_argmax` is a `@triton.jit` device function inlined into `_resample_kernel`, not a separately dispatched operator, so it is covered through `_resample_kernel` rather than tested on its own. The test file defines no Triton kernel and reproduces no part of the operator: cases that need an exact expected token are constructed so each vocabulary block holds a single finite residual, which the Gumbel noise cannot displace, and cases that need the residual values compare sampling frequencies over 16,384 draws against the analytic distribution.

## Notes

- Verified on Atlas A2, Python 3.11, torch_npu 2.10 — all 10 cases pass:

```bash
pytest -sv tests/e2e/nightly/single_node/ops/singlecard_ops/triton/test_resample.py
```

- Documentation and tests only; no operator behaviour is changed.
- Constraints worth flagging from the doc: `draft_sampled` is read at `resample_token_idx + 1` (the input-id stream sits one slot ahead of the logits); the `temp == 0 and not is_bonus` early return is a contract with the upstream `_insert_resampled_kernel`, which skips on the identical condition and reuses the target argmax already written.

- vLLM main: https://github.com/vllm-project/vllm/commit/ba07e4a48fc951300d97eb506217dd530583dea3
