### PR TITLE
[BugFix][Attention] Fix incorrect LoRA layer mapping in FULL graph replay

### DIFF
--- a/tests/ut/attention/test_attention_v1.py
+++ b/tests/ut/attention/test_attention_v1.py
@@ -807,7 +807,7 @@ class TestAscendAttentionBackendImpl(TestBase):
         mock_EXTRA_CTX.sinks = False
         mock_EXTRA_CTX.is_draft_model = False
 
-        param: list[MagicMock | None] = [MagicMock()] * 22
+        param: list[MagicMock | str | None] = [MagicMock()] * 22
         param[16] = None  # sliding_window
         param[17] = None  # c8_k_aq_scale
         param[21] = "model.layers.2.self_attn.attn"  # layer_name

--- a/tests/ut/attention/test_attention_v1.py
+++ b/tests/ut/attention/test_attention_v1.py
@@ -810,7 +810,7 @@ class TestAscendAttentionBackendImpl(TestBase):
         param: list[MagicMock | None] = [MagicMock()] * 22
         param[16] = None  # sliding_window
         param[17] = None  # c8_k_aq_scale
-        param[21] = None  # layer_name
+        param[21] = "model.layers.2.self_attn.attn"  # layer_name
 
         mock_get_graph_params.return_value.attn_params = {1: [tuple(param)] * 3}
         mock_get_graph_params.return_value.handles = {1: [MagicMock()] * 3}

--- a/vllm_ascend/attention/attention_v1.py
+++ b/vllm_ascend/attention/attention_v1.py
@@ -667,8 +667,7 @@ class AscendAttentionBackendImpl(AttentionImpl):
                     )
                     if captured_layer_name is None:
                         raise RuntimeError(
-                            "FULL_REPLAY_METADATA_KEY_MISSING: "
-                            "captured attention parameter has no layer name."
+                            "FULL_REPLAY_METADATA_KEY_MISSING: captured attention parameter has no layer name."
                         )
                     if captured_layer_name not in attn_metadata:
                         raise RuntimeError(
@@ -835,8 +834,7 @@ class AscendAttentionBackendImpl(AttentionImpl):
                     )
                     if captured_layer_name is None:
                         raise RuntimeError(
-                            "FULL_REPLAY_METADATA_KEY_MISSING: "
-                            "captured attention parameter has no layer name."
+                            "FULL_REPLAY_METADATA_KEY_MISSING: captured attention parameter has no layer name."
                         )
                     if captured_layer_name not in attn_metadata:
                         raise RuntimeError(

--- a/vllm_ascend/attention/attention_v1.py
+++ b/vllm_ascend/attention/attention_v1.py
@@ -637,13 +637,18 @@ class AscendAttentionBackendImpl(AttentionImpl):
             # TODO: We use a new variable `attn_keys` to ensure the loop count is
             # correct after get by `zip` because of the new structure of the attn_metadata
             # when running with the merged full eagle-graph. Should check it with Qwen3-next.
-            num_layers = len(attn_keys)
-            if num_layers == 0:
+            if not attn_keys:
                 return
             captured_attn_params = graph_params.attn_params[num_tokens]
             handles = graph_params.handles[num_tokens]
             events = graph_params.events[num_tokens]
             graph_param_count = len(captured_attn_params)
+            if graph_param_count != len(handles) or graph_param_count != len(events):
+                raise RuntimeError(
+                    "FULL_REPLAY_CAPTURE_LENGTH_MISMATCH: "
+                    f"params={graph_param_count}, handles={len(handles)}, "
+                    f"events={len(events)}"
+                )
             workspace = graph_params.workspaces.get(num_tokens)
             if _EXTRA_CTX.is_draft_model:
                 if graph_param_count > len(draft_attn_key_steps):
@@ -652,12 +657,26 @@ class AscendAttentionBackendImpl(AttentionImpl):
                 else:
                     draft_attn_key_steps = draft_attn_key_steps[:graph_param_count]
                 attn_keys = [key for _, key in draft_attn_key_steps]
-            elif use_layer_aware_replay:
-                # One graph size can contain captured FIA ops from all layers.
-                # Repeat attn keys to match the captured op count, then use the
-                # stored layer name in each op param to resolve the exact
-                # metadata entry during replay.
-                attn_keys = [attn_keys[index % num_layers] for index in range(graph_param_count)]
+            else:
+                replay_keys = []
+                for captured_param in captured_attn_params:
+                    captured_layer_name = (
+                        captured_param.layer_name
+                        if isinstance(captured_param, PagedAttentionGraphParam)
+                        else captured_param[-1]
+                    )
+                    if captured_layer_name is None:
+                        raise RuntimeError(
+                            "FULL_REPLAY_METADATA_KEY_MISSING: "
+                            "captured attention parameter has no layer name."
+                        )
+                    if captured_layer_name not in attn_metadata:
+                        raise RuntimeError(
+                            "FULL_REPLAY_METADATA_KEY_NOT_FOUND: "
+                            f"{captured_layer_name!r} is absent from runtime metadata."
+                        )
+                    replay_keys.append(captured_layer_name)
+                attn_keys = replay_keys
             attn_count = 0
             with torch.npu.stream(update_stream):
                 for key, param, handle, event in zip(
@@ -786,13 +805,18 @@ class AscendAttentionBackendImpl(AttentionImpl):
             # TODO: We use a new variable `attn_keys` to ensure the loop count is
             # correct after get by `zip` because of the new structure of the attn_metadata
             # when running with the merged full eagle-graph. Should check it with Qwen3-next.
-            num_layers = len(attn_keys)
-            if num_layers == 0:
+            if not attn_keys:
                 return
             captured_attn_params = graph_params.attn_params[num_tokens]
             handles = graph_params.handles[num_tokens]
             events = graph_params.events[num_tokens]
             graph_param_count = len(captured_attn_params)
+            if graph_param_count != len(handles) or graph_param_count != len(events):
+                raise RuntimeError(
+                    "FULL_REPLAY_CAPTURE_LENGTH_MISMATCH: "
+                    f"params={graph_param_count}, handles={len(handles)}, "
+                    f"events={len(events)}"
+                )
             workspace = graph_params.workspaces.get(num_tokens)
             if _EXTRA_CTX.is_draft_model:
                 if graph_param_count > len(draft_attn_key_steps):
@@ -801,11 +825,26 @@ class AscendAttentionBackendImpl(AttentionImpl):
                 else:
                     draft_attn_key_steps = draft_attn_key_steps[:graph_param_count]
                 attn_keys = [key for _, key in draft_attn_key_steps]
-            elif use_layer_aware_replay:
-                # Keep the replay loop length aligned with captured FIA ops;
-                # layer-specific metadata lookup below prevents global/sliding
-                # window layers from accidentally sharing the same metadata.
-                attn_keys = [attn_keys[index % num_layers] for index in range(graph_param_count)]
+            else:
+                replay_keys = []
+                for captured_param in captured_attn_params:
+                    captured_layer_name = (
+                        captured_param.layer_name
+                        if isinstance(captured_param, PagedAttentionGraphParam)
+                        else captured_param[-1]
+                    )
+                    if captured_layer_name is None:
+                        raise RuntimeError(
+                            "FULL_REPLAY_METADATA_KEY_MISSING: "
+                            "captured attention parameter has no layer name."
+                        )
+                    if captured_layer_name not in attn_metadata:
+                        raise RuntimeError(
+                            "FULL_REPLAY_METADATA_KEY_NOT_FOUND: "
+                            f"{captured_layer_name!r} is absent from runtime metadata."
+                        )
+                    replay_keys.append(captured_layer_name)
+                attn_keys = replay_keys
             attn_count = 0
             layer_count = 0
             with torch.npu.stream(update_stream):
@@ -1065,7 +1104,7 @@ class AscendAttentionBackendImpl(AttentionImpl):
             )  # type: ignore
         else:
             attn_params = attn_params + (None, None, None, None)  # type: ignore
-        layer_name = self._graph_metadata_layer_name(layer) if self._use_layer_aware_fia_graph_replay else None
+        layer_name = self._graph_metadata_layer_name(layer)
         attn_params = attn_params + (layer_name,)  # type: ignore
         graph_params.attn_params[num_tokens].append(attn_params)
 
@@ -1195,7 +1234,7 @@ class AscendAttentionBackendImpl(AttentionImpl):
                 self.sinks,
                 weak_ref_tensors(output),
                 weak_ref_tensors(softmax_lse),
-                self._graph_metadata_layer_name() if self._use_layer_aware_fia_graph_replay else None,
+                self._graph_metadata_layer_name(),
             )
         )
         torch.npu.graph_task_group_begin(stream)
@@ -1268,7 +1307,7 @@ class AscendAttentionBackendImpl(AttentionImpl):
                         attn_metadata.seq_lens,
                         weak_ref_tensors(output),
                     ),
-                    self._graph_metadata_layer_name() if self._use_layer_aware_fia_graph_replay else None,
+                    self._graph_metadata_layer_name(),
                 )
             )
 
@@ -1760,8 +1799,7 @@ class AscendAttentionBackendImpl(AttentionImpl):
             shape = [num_tokens, num_heads * head_size]
         """
         assert output is not None, "Output tensor must be provided."
-        if self._use_layer_aware_fia_graph_replay:
-            self._layer_name = layer.layer_name
+        self._layer_name = layer.layer_name
 
         if output_scale is not None or output_block_scale is not None:
             raise NotImplementedError("fused output quantization is not yet supported for AscendAttentionBackendImpl")
@@ -1830,8 +1868,7 @@ class AscendC8AttentionBackendImpl(AscendAttentionBackendImpl):
         output_block_scale: torch.Tensor | None = None,
     ) -> torch.Tensor:
         assert output is not None, "Output tensor must be provided."
-        if self._use_layer_aware_fia_graph_replay:
-            self._layer_name = layer.layer_name
+        self._layer_name = layer.layer_name
 
         if output_scale is not None or output_block_scale is not None:
             raise NotImplementedError("fused output quantization is not yet supported for AscendC8AttentionBackendImpl")


### PR DESCRIPTION
Map replay parameters using captured runtime layer metadata so active LoRA layers update the correct FULL graph entries.

### What this PR does / why we need it?

FULL graph replay previously reconstructed attention keys by repeating the current runtime layer keys. This could associate captured attention operations with the wrong layers when merged FULL Eagle graphs contained multiple FIA operations, causing active LoRA updates to target incorrect graph entries.

This PR:

- Records layer metadata for all captured FULL graph FIA, FIA v2, and paged-attention parameters.
- Maps replay parameters using the layer name captured at graph-capture time.
- Validates parameter, handle, and event counts before replay.
- Raises explicit errors when replay metadata is missing or inconsistent.
- Keeps draft-model replay behavior unchanged.

### Does this PR introduce _any_ user-facing change?

### How was this patch tested?

- vLLM main: https://github.com/vllm-project/vllm/commit/84030bbe3d74d99bad477a3d2e37a973ccd8865c
