### PR TITLE
[BugFix][Kernel] Fix missing V-to-S synchronization in MLA preprocess

### DIFF
--- a/csrc/mla_preprocess/op_kernel/mla_preprocess_mix_bf16.hpp
+++ b/csrc/mla_preprocess/op_kernel/mla_preprocess_mix_bf16.hpp
@@ -513,6 +513,8 @@ public:
                 AscendC::PipeBarrier<PIPE_V>();
                 ReduceMaxCustom(max, abs, work, num_col_ - input_stride_);
                 AscendC::PipeBarrier<PIPE_V>();
+                SET_FLAG(V, S, EVENT_ID0);
+                WAIT_FLAG(V, S, EVENT_ID0);
                 float scaleOut = max.GetValue(0) / 127;
                 SET_FLAG(S, V, EVENT_ID0);
                 WAIT_FLAG(S, V, EVENT_ID0);
@@ -817,6 +819,8 @@ public:
                 AscendC::PipeBarrier<PIPE_V>();
                 ReduceMaxCustom(max, abs, work, num_col_ - input_stride_);
                 AscendC::PipeBarrier<PIPE_V>();
+                SET_FLAG(V, S, EVENT_ID0);
+                WAIT_FLAG(V, S, EVENT_ID0);
                 float scaleOut = max.GetValue(0) / 127;
                 SET_FLAG(S, V, EVENT_ID0);
                 WAIT_FLAG(S, V, EVENT_ID0);

--- a/csrc/mla_preprocess/op_kernel/mla_preprocess_mix_bf16_qdown.hpp
+++ b/csrc/mla_preprocess/op_kernel/mla_preprocess_mix_bf16_qdown.hpp
@@ -512,6 +512,8 @@ public:
                 AscendC::PipeBarrier<PIPE_V>();
                 ReduceMaxCustom(max, abs, work, num_col_ - input_stride_);
                 AscendC::PipeBarrier<PIPE_V>();
+                SET_FLAG(V, S, EVENT_ID0);
+                WAIT_FLAG(V, S, EVENT_ID0);
                 float scaleOut = max.GetValue(0) / 127;
                 SET_FLAG(S, V, EVENT_ID0);
                 WAIT_FLAG(S, V, EVENT_ID0);
@@ -835,6 +837,8 @@ public:
                 AscendC::PipeBarrier<PIPE_V>();
                 ReduceMaxCustom(max, abs, work, num_col_ - input_stride_);
                 AscendC::PipeBarrier<PIPE_V>();
+                SET_FLAG(V, S, EVENT_ID0);
+                WAIT_FLAG(V, S, EVENT_ID0);
                 float scaleOut = max.GetValue(0) / 127;
                 SET_FLAG(S, V, EVENT_ID0);
                 WAIT_FLAG(S, V, EVENT_ID0);


### PR DESCRIPTION
### What this PR does / why we need it?

The BF16 `PER_TOKEN_SYMM_QUANT` paths compute the per-token maximum with `ReduceMaxCustom` on the Vector pipeline and then read `max.GetValue(0)` on the Scalar pipeline. `PipeBarrier<PIPE_V>()` only orders operations within the Vector pipeline; it does not establish visibility from Vector to Scalar. The raw launcher timing could mask this race, while validation through the standard ACLNN launch path exposed stale and nondeterministic Quant1 results.

This PR adds an explicit `SET_FLAG(V, S, EVENT_ID0)` / `WAIT_FLAG(V, S, EVENT_ID0)` pair before each of the four Scalar reads in the normal and qdown BF16 templates.

The patch does not change the quantization formula, tensor shapes, tiling, launch configuration, supported modes, or public Torch API. It is the correctness prerequisite for a separate MLA ACLNN/NPU Graph refactor.

Refs #14347.

### Does this PR introduce _any_ user-facing change?

Yes. It prevents stale or nondeterministic output in the existing per-token symmetric quantization path. There is no public API or supported-mode change.

### How was this patch tested?

Current commit: `2a9a5780ff1a505bf8b8a53eac8427f421c40e1b`, rebased onto upstream `main` at `2617fb6abf541145ea7f12d1dd39c757f1180b66`.

NPU correctness validation was performed on pre-rebase commit `6554393787f02f1a85f02b311da4158337009618`. Its stable patch ID is identical to the current commit, so the rebase changed commit ancestry but not the two-file, eight-line kernel patch.

Environment: Ascend 910B4, CANN 9.1.0, Python 3.11.10, and torch-npu 2.10.0.post4.

- `bash format.sh ci` passed all hooks on a clean worktree at the current commit.
- The existing `tests/e2e/nightly/single_node/ops/singlecard_ops/test_mla_preprocess.py` suite passed on the patch-equivalent pre-rebase commit: `13 passed, 32 warnings in 19.52s`. Torch-NPU internal formats were enabled by the external test launcher, matching the vLLM-Ascend model runner configuration.
- An external instrumented A/B probe confirmed that all 24,576 bytes entering Quant1 were identical before the affected reduction. Without the V-to-S event, repeated output comparisons mismatched 24,575, 22,648, and 22,516 of 24,576 bytes. With only this synchronization change, all 24,576 bytes matched in each of three runs.
- External fixed-input checks for both normal and qdown paths matched the raw launcher's stable hot-state output in three of three runs each.
- `git diff --check upstream/main...HEAD` passed after the rebase; the PR still changes only the two intended kernel files.
- GitHub [E2E run 33148586547](https://github.com/vllm-project/vllm-ascend/actions/runs/33148586547) passed pre-commit, coverage recommendation, and test selection. The selected tests did not start because this Ready PR does not yet have the maintainer-controlled `ready-precise` or `ready-all` label; the resulting `ci-gate` failure is the expected missing-label gate rather than a source or test failure.

No test files are added or modified. The deterministic A/B probe requires an instrumented NPU build and is kept as external validation rather than a timing-sensitive CI assertion. The full repository test suite was not run.

- vLLM version: v0.27.1
- vLLM main: https://github.com/vllm-project/vllm/commit/ba07e4a48fc951300d97eb506217dd530583dea3
