### PR TITLE
[Refactor][Kernel] Migrate MLA preprocess to ACLNN two-stage interface for NPU Graph

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -56,12 +56,10 @@ ${CMAKE_CURRENT_SOURCE_DIR}/csrc/kernels/*.cpp)
 
 set(VLLM_ASCEND_CUSTOM_OP
     ${KERNEL_FILES}
-    ${CMAKE_CURRENT_SOURCE_DIR}/csrc/mla_preprocess/op_kernel/mla_preprocess_kernel.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/csrc/batch_matmul_transpose/op_kernel/batch_matmul_transpose_kernel.cpp
 )
 
 set(VLLM_ASCEND_CUSTOM_OP_EXCLUDE_ASCEND950
-    ${CMAKE_CURRENT_SOURCE_DIR}/csrc/mla_preprocess/op_kernel/mla_preprocess_kernel.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/csrc/batch_matmul_transpose/op_kernel/batch_matmul_transpose_kernel.cpp
 )
 

--- a/csrc/build_aclnn.sh
+++ b/csrc/build_aclnn.sh
@@ -135,6 +135,7 @@ elif [[ "$SOC_VERSION" =~ ^ascend910b ]]; then
         "sparse_attention_score"
         "k2q_csr"
         "msa_index_score"
+        "mla_preprocess"
     )
 
     CUSTOM_OPS=$(IFS=';'; echo "${CUSTOM_OPS_ARRAY[*]}")
@@ -188,6 +189,7 @@ elif [[ "$SOC_VERSION" =~ ^ascend910_93 ]]; then
         "sparse_attention_score"
         "k2q_csr"
         "msa_index_score"
+        "mla_preprocess"
     )
     CUSTOM_OPS=$(IFS=';'; echo "${CUSTOM_OPS_ARRAY[*]}")
     SOC_ARG="ascend910_93"

--- a/csrc/cmake/func.cmake
+++ b/csrc/cmake/func.cmake
@@ -82,6 +82,7 @@ function(op_add_subdirectory OP_LIST OP_DIR_LIST)
         )
         if(BUILD_OPEN_PROJECT AND (NOT BUILD_OPS_RTY_KERNEL))
             file(GLOB CANNDEV_OPS_HOST_CMAKE_FILES
+                "${CMAKE_CURRENT_SOURCE_DIR}/mla_preprocess/CMakeLists.txt"
                 "${CMAKE_CURRENT_SOURCE_DIR}/posembedding/**/op_host/CMakeLists.txt"
                 "${CMAKE_CURRENT_SOURCE_DIR}/moe/**/op_host/CMakeLists.txt"
                 "${CMAKE_CURRENT_SOURCE_DIR}/ffn/**/op_host/CMakeLists.txt"

--- a/csrc/mla_preprocess/CMakeLists.txt
+++ b/csrc/mla_preprocess/CMakeLists.txt
@@ -1,0 +1,19 @@
+# -----------------------------------------------------------------------------------------------------------
+# Copyright (c) 2026 Huawei Technologies Co., Ltd.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+
+file(GLOB CURRENT_DIRS RELATIVE ${CMAKE_CURRENT_SOURCE_DIR} ${CMAKE_CURRENT_SOURCE_DIR}/*)
+if(NOT ENABLE_TEST AND NOT BENCHMARK)
+    list(REMOVE_ITEM CURRENT_DIRS tests)
+endif()
+foreach(SUB_DIR ${CURRENT_DIRS})
+    if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/${SUB_DIR}/CMakeLists.txt")
+        add_subdirectory(${SUB_DIR})
+    endif()
+endforeach()

--- a/csrc/mla_preprocess/mla_preprocess_torch_adpt.h
+++ b/csrc/mla_preprocess/mla_preprocess_torch_adpt.h
@@ -13,166 +13,183 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 #ifndef MLA_PREPROCESS_TORCH_ADPT_H
 #define MLA_PREPROCESS_TORCH_ADPT_H
 
-
-#include "op_host/mla_preprocess.h"
-
 namespace vllm_ascend {
-constexpr int64_t MLA_PREPROCESS_FULLY_SUPPORTED_KV_LORA_RANK = 512;
-constexpr int64_t MLA_PREPROCESS_FULLY_SUPPORTED_QK_ROPE_HEAD_DIM = 64;
+namespace mla_preprocess_detail {
+
+constexpr int64_t FULLY_SUPPORTED_KV_LORA_RANK = 512;
+constexpr int64_t FULLY_SUPPORTED_QK_ROPE_HEAD_DIM = 64;
+
+inline int64_t ParseCacheMode(c10::optional<c10::string_view> cacheMode)
+{
+    const c10::string_view mode = cacheMode.value_or("krope_ctkv");
+    if (mode == "kvcache") {
+        return 0;
+    }
+    if (mode == "krope_ctkv") {
+        return 1;
+    }
+    if (mode == "int8_nzcache") {
+        return 2;
+    }
+    if (mode == "nzcache") {
+        return 3;
+    }
+    TORCH_CHECK(false, "Unsupported cache_mode value: '", mode, "'");
+    return 0;
+}
+
+inline int64_t ParseQuantMode(c10::optional<c10::string_view> quantMode)
+{
+    const c10::string_view mode = quantMode.value_or("per_token_quant_symm");
+    if (mode == "per_tensor_quant_asymm") {
+        return 0;
+    }
+    if (mode == "per_token_quant_symm") {
+        return 1;
+    }
+    if (mode == "per_token_quant_asymm") {
+        return 2;
+    }
+    if (mode == "no_quant") {
+        return 3;
+    }
+    TORCH_CHECK(false, "Unsupported quant_mode value: '", mode, "'");
+    return 0;
+}
+
+// The kernel supports an enlarged dim0 stride for paged cache blocks. Every
+// inner axis must still use the compact layout expected by the selected mode.
+inline void ValidateCacheNonFirstAxisContiguous(const at::Tensor &cache, const char *tensorName)
+{
+    if (cache.dim() <= 1) {
+        return;
+    }
+    const auto sizes = cache.sizes();
+    const auto strides = cache.strides();
+    int64_t expectedStride = 1;
+    for (int64_t dim = cache.dim() - 1; dim >= 1; --dim) {
+        if (sizes[dim] == 1) {
+            continue;
+        }
+        TORCH_CHECK(strides[dim] == expectedStride,
+                    tensorName, " dim", dim, " is non-contiguous: actual stride=", strides[dim],
+                    ", expected contiguous stride=", expectedStride,
+                    ". Only dim0/blockNum may be non-contiguous.");
+        expectedStride *= sizes[dim];
+    }
+}
+
+inline int64_t GetStride0(const at::Tensor &cache, const char *tensorName)
+{
+    TORCH_CHECK(cache.dim() >= 1, tensorName, " must have at least one dimension.");
+    TORCH_CHECK(cache.stride(0) > 0, tensorName, " dim0 stride must be positive.");
+    return cache.stride(0);
+}
+
+inline bool IsPhysicalNzCache(const at::Tensor &cache, int64_t cacheMode)
+{
+    return (cacheMode == 2 || cacheMode == 3) && cache.dim() == 4 && cache.size(2) != 1;
+}
+
+inline int64_t GetRopeHeadDim(const at::Tensor &kvCacheRope, int64_t cacheMode)
+{
+    TORCH_CHECK(kvCacheRope.dim() >= 1, "kv_cache_rope must not be a scalar.");
+    if (IsPhysicalNzCache(kvCacheRope, cacheMode)) {
+        return kvCacheRope.size(1) * kvCacheRope.size(3);
+    }
+    return kvCacheRope.size(-1);
+}
+
+}  // namespace mla_preprocess_detail
 
 std::tuple<at::Tensor &, at::Tensor &, at::Tensor &, at::Tensor &, at::Tensor &> mla_preprocess(
     const at::Tensor &hiddenState, const at::Tensor &wdqkv,
-    const c10::optional<at::Tensor> &descale0, const at::Tensor &gamma1, const c10::optional<at::Tensor> &beta1, const at::Tensor &wuq,
+    const c10::optional<at::Tensor> &descale0, const at::Tensor &gamma1,
+    const c10::optional<at::Tensor> &beta1, const at::Tensor &wuq,
     const c10::optional<at::Tensor> &descale1, const at::Tensor &gamma2,
     const c10::optional<at::Tensor> &cos, const c10::optional<at::Tensor> &sin,
-    const at::Tensor &wuk, const at::Tensor &kv_cache, const at::Tensor &kv_cache_rope, const at::Tensor &slotmapping,
-    const c10::optional<at::Tensor> &quant_scale0, const c10::optional<at::Tensor> &quant_offset0, const c10::optional<at::Tensor> &bias0,
-    const c10::optional<at::Tensor> &quant_scale1, const c10::optional<at::Tensor> &quant_offset1, const c10::optional<at::Tensor> &bias1,
-    const c10::optional<at::Tensor> &ctkv_scale, const c10::optional<at::Tensor> &q_nope_scale,
-    c10::optional<c10::string_view> cache_mode, c10::optional<c10::string_view> quant_mode,
-    c10::optional<bool> enable_inner_out, at::Tensor &q_out0,
-    at::Tensor &kv_cache_out0, at::Tensor &q_out1, at::Tensor &kv_cache_out1, at::Tensor &inner_out)
+    const at::Tensor &wuk, const at::Tensor &kv_cache, const at::Tensor &kv_cache_rope,
+    const at::Tensor &slotmapping, const c10::optional<at::Tensor> &quant_scale0,
+    const c10::optional<at::Tensor> &quant_offset0, const c10::optional<at::Tensor> &bias0,
+    const c10::optional<at::Tensor> &quant_scale1, const c10::optional<at::Tensor> &quant_offset1,
+    const c10::optional<at::Tensor> &bias1, const c10::optional<at::Tensor> &ctkv_scale,
+    const c10::optional<at::Tensor> &q_nope_scale, c10::optional<c10::string_view> cache_mode,
+    c10::optional<c10::string_view> quant_mode, c10::optional<bool> enable_inner_out,
+    at::Tensor &q_out0, at::Tensor &kv_cache_out0, at::Tensor &q_out1,
+    at::Tensor &kv_cache_out1, at::Tensor &inner_out)
 {
-    at::Tensor Descale0 =
-        descale0.has_value()
-            ? descale0.value()
-            : at::empty({1}, at::TensorOptions().dtype(at::kHalf).device(hiddenState.options().device()));
-    at::Tensor Descale1 =
-        descale1.has_value()
-            ? descale1.value()
-            : at::empty({1}, at::TensorOptions().dtype(at::kHalf).device(hiddenState.options().device()));
-    at::Tensor Beta1 =
-        beta1.has_value()
-            ? beta1.value()
-            : at::empty({1}, at::TensorOptions().dtype(at::kHalf).device(hiddenState.options().device()));
-    at::Tensor Quant_scale0 =
-        quant_scale0.has_value()
-            ? quant_scale0.value()
-            : at::empty({1}, at::TensorOptions().dtype(at::kHalf).device(hiddenState.options().device()));
-    at::Tensor Quant_scale1 =
-        quant_scale1.has_value()
-            ? quant_scale1.value()
-            : at::empty({1}, at::TensorOptions().dtype(at::kHalf).device(hiddenState.options().device()));
-    at::Tensor Quant_offset0 =
-        quant_offset0.has_value()
-            ? quant_offset0.value()
-            : at::empty({1}, at::TensorOptions().dtype(at::kHalf).device(hiddenState.options().device()));
-    at::Tensor Quant_offset1 =
-        quant_offset1.has_value()
-            ? quant_offset1.value()
-            : at::empty({1}, at::TensorOptions().dtype(at::kHalf).device(hiddenState.options().device()));
-    at::Tensor Bias0 =
-        bias0.has_value()
-            ? bias0.value()
-            : at::empty({1}, at::TensorOptions().dtype(at::kHalf).device(hiddenState.options().device()));
-    at::Tensor Bias1 =
-        bias1.has_value()
-            ? bias1.value()
-            : at::empty({1}, at::TensorOptions().dtype(at::kHalf).device(hiddenState.options().device()));
-    at::Tensor CtkvScale =
-        ctkv_scale.has_value()
-            ? ctkv_scale.value()
-            : at::empty({1}, at::TensorOptions().dtype(at::kHalf).device(hiddenState.options().device()));
-    at::Tensor QnopeScale =
-        q_nope_scale.has_value()
-            ? q_nope_scale.value()
-            : at::empty({1}, at::TensorOptions().dtype(at::kHalf).device(hiddenState.options().device()));
-    bool enableInnerOut =
-        enable_inner_out.has_value()
-            ? enable_inner_out.value()
-            : false;
-    TORCH_CHECK(
-        cos.has_value() == sin.has_value(),
-        "mla_preprocess requires cos and sin to both be tensors or both be None.");
-    bool enableRope = cos.has_value();
-    // Use placeholder tensors because device kernels initialize RoPE input addresses unconditionally.
-    at::Tensor Cos =
-        cos.has_value()
-            ? cos.value()
-            : at::empty({1}, at::TensorOptions().dtype(at::kHalf).device(hiddenState.options().device()));
-    at::Tensor Sin =
-        sin.has_value()
-            ? sin.value()
-            : at::empty({1}, at::TensorOptions().dtype(at::kHalf).device(hiddenState.options().device()));
-    int64_t kvLoraRank = wuk.size(-1);
-    int64_t qkRopeHeadDim = kv_cache_rope.size(-1);
-    if (kvLoraRank != MLA_PREPROCESS_FULLY_SUPPORTED_KV_LORA_RANK ||
-        qkRopeHeadDim != MLA_PREPROCESS_FULLY_SUPPORTED_QK_ROPE_HEAD_DIM) {
+    TORCH_CHECK(cos.has_value() == sin.has_value(),
+                "mla_preprocess requires cos and sin to both be tensors or both be None.");
+
+    const int64_t cacheMode = mla_preprocess_detail::ParseCacheMode(cache_mode);
+    const int64_t quantMode = mla_preprocess_detail::ParseQuantMode(quant_mode);
+    const bool enableInnerOut = enable_inner_out.value_or(false);
+    const bool enableRope = cos.has_value();
+
+    mla_preprocess_detail::ValidateCacheNonFirstAxisContiguous(kv_cache, "kv_cache");
+    mla_preprocess_detail::ValidateCacheNonFirstAxisContiguous(kv_cache_rope, "kv_cache_rope");
+    const int64_t kvCacheStride0 = mla_preprocess_detail::GetStride0(kv_cache, "kv_cache");
+    const int64_t kvCacheRopeStride0 =
+        mla_preprocess_detail::GetStride0(kv_cache_rope, "kv_cache_rope");
+
+    const int64_t kvLoraRank = wuk.size(-1);
+    const int64_t qkRopeHeadDim = mla_preprocess_detail::GetRopeHeadDim(kv_cache_rope, cacheMode);
+    if (kvLoraRank != mla_preprocess_detail::FULLY_SUPPORTED_KV_LORA_RANK ||
+        qkRopeHeadDim != mla_preprocess_detail::FULLY_SUPPORTED_QK_ROPE_HEAD_DIM) {
         TORCH_WARN_ONCE(
             "mla_preprocess currently fully supports only kv_lora_rank=",
-            MLA_PREPROCESS_FULLY_SUPPORTED_KV_LORA_RANK,
-            " and qk_rope_head_dim=",
-            MLA_PREPROCESS_FULLY_SUPPORTED_QK_ROPE_HEAD_DIM,
-            ", but received kv_lora_rank=",
-            kvLoraRank,
-            " and qk_rope_head_dim=",
-            qkRopeHeadDim,
-             ". Inputs outside the fully supported configuration are allowed to continue, "
-             "but may produce accuracy issues.");
+            mla_preprocess_detail::FULLY_SUPPORTED_KV_LORA_RANK,
+            " and qk_rope_head_dim=", mla_preprocess_detail::FULLY_SUPPORTED_QK_ROPE_HEAD_DIM,
+            ", but received kv_lora_rank=", kvLoraRank,
+            " and qk_rope_head_dim=", qkRopeHeadDim,
+            ". Inputs outside the fully supported configuration are allowed to continue, "
+            "but may produce accuracy issues.");
     }
-    auto [workspace_tensor, tiling, block_dim] = mlapo::mla_preprocess_tiling(
+
+    EXEC_NPU_CMD(
+        aclnnMlaPreprocess,
         hiddenState,
+        quant_scale0,
+        quant_offset0,
         wdqkv,
-        wuk,
+        bias0,
         gamma1,
+        beta1,
+        quant_scale1,
+        quant_offset1,
+        gamma2,
+        sin,
+        cos,
+        sin,
+        cos,
         kv_cache,
-        kv_cache_rope,
-        cache_mode,
-        quant_mode,
+        slotmapping,
+        wuq,
+        bias1,
+        wuk,
+        descale0,
+        descale1,
+        ctkv_scale,
+        q_nope_scale,
+        cacheMode,
+        quantMode,
         enableInnerOut,
-        enableRope
-    );
+        enableRope,
+        kvCacheStride0,
+        kvCacheRopeStride0,
+        q_out0,
+        kv_cache_out0,
+        q_out1,
+        kv_cache_out1,
+        inner_out);
 
-    void *hidden_state_ptr = hiddenState.data_ptr();
-    void *quant_scale0_ptr = Quant_scale0.data_ptr();
-    void *quant_offset0_ptr = Quant_offset0.data_ptr();
-    void *wdqkv_ptr = wdqkv.data_ptr();
-    void *bias0_ptr = Bias0.data_ptr();
-    void *gamma1_ptr = gamma1.data_ptr();
-    void *beta1_ptr = Beta1.data_ptr();
-    void *quant_scale1_ptr = Quant_scale1.data_ptr();
-    void *quant_offset1_ptr = Quant_offset1.data_ptr();
-    void *gamma2_ptr = gamma2.data_ptr();
-    void *sin_ptr = Sin.data_ptr();
-    void *cos_ptr = Cos.data_ptr();
-    void *kv_cache_ptr = kv_cache.data_ptr();
-    void *slotmapping_ptr = slotmapping.data_ptr();
-    void *wuq_ptr = wuq.data_ptr();
-    void *bias1_ptr = Bias1.data_ptr();
-    void *wuk_ptr = wuk.data_ptr();
-    void *descale0_ptr = Descale0.data_ptr();
-    void *descale1_ptr = Descale1.data_ptr();
-    void *ctkv_scale_ptr = CtkvScale.data_ptr();
-    void *qnope_scale_ptr = QnopeScale.data_ptr();
-    void *q_out0_ptr = q_out0.data_ptr();
-    void *kv_cache_out0_ptr = kv_cache_out0.data_ptr();
-    void *q_out1_ptr = q_out1.data_ptr();
-    void *kv_cache_out1_ptr = kv_cache_out1.data_ptr();
-    void *inner_out_ptr = inner_out.data_ptr();
-    void *workspace_ptr = workspace_tensor.data_ptr();
-    void *tiling_ptr = tiling.data_ptr();
-
-    aclrtStream stream = c10_npu::getCurrentNPUStream().stream();
-    at_npu::native::OpCommand cmd;
-    cmd.Name("mla_preprocess");
-
-    cmd.SetCustomHandler([stream, hidden_state_ptr, quant_scale0_ptr, quant_offset0_ptr, wdqkv_ptr, bias0_ptr,
-                          gamma1_ptr, beta1_ptr, quant_scale1_ptr, quant_offset1_ptr, gamma2_ptr, sin_ptr, cos_ptr,
-                          kv_cache_ptr, slotmapping_ptr, wuq_ptr, bias1_ptr, wuk_ptr, descale0_ptr, descale1_ptr, ctkv_scale_ptr,
-                          qnope_scale_ptr, q_out0_ptr, kv_cache_out0_ptr, q_out1_ptr, kv_cache_out1_ptr, inner_out_ptr, workspace_ptr,
-                          tiling_ptr, block_dim]() -> int {
-        mla_preprocess_impl(stream, hidden_state_ptr, quant_scale0_ptr, quant_offset0_ptr, wdqkv_ptr, bias0_ptr,
-                            gamma1_ptr, beta1_ptr, quant_scale1_ptr, quant_offset1_ptr, gamma2_ptr, sin_ptr, cos_ptr, sin_ptr, cos_ptr,
-                            kv_cache_ptr, slotmapping_ptr, wuq_ptr, bias1_ptr, wuk_ptr, descale0_ptr, descale1_ptr, ctkv_scale_ptr,
-                            qnope_scale_ptr, q_out0_ptr, kv_cache_out0_ptr, q_out1_ptr, kv_cache_out1_ptr, inner_out_ptr, workspace_ptr,
-                            tiling_ptr, block_dim);
-        return 0;
-    });
-    cmd.Run();
     return std::forward_as_tuple(q_out0, kv_cache_out0, q_out1, kv_cache_out1, inner_out);
 }
-}
-#endif
+
+}  // namespace vllm_ascend
+
+#endif  // MLA_PREPROCESS_TORCH_ADPT_H

--- a/csrc/mla_preprocess/op_host/CMakeLists.txt
+++ b/csrc/mla_preprocess/op_host/CMakeLists.txt
@@ -1,0 +1,28 @@
+# -----------------------------------------------------------------------------------------------------------
+# Copyright (c) 2026 Huawei Technologies Co., Ltd.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+
+add_op_to_compiled_list()
+
+if(BUILD_OPEN_PROJECT)
+    target_sources(op_host_aclnn PRIVATE
+        mla_preprocess_def.cpp
+    )
+endif()
+
+add_ops_compile_options(
+    OP_NAME MlaPreprocess
+    OPTIONS
+        --cce-auto-sync=on
+        -Wno-deprecated-declarations
+)
+
+if(NOT BUILD_OPS_RTY_KERNEL)
+    add_modules_sources(OPTYPE mla_preprocess ACLNNTYPE aclnn)
+endif()

--- a/csrc/mla_preprocess/op_host/mla_preprocess_def.cpp
+++ b/csrc/mla_preprocess/op_host/mla_preprocess_def.cpp
@@ -1,0 +1,186 @@
+/*
+ * Copyright (c) Huawei Technologies Co., Ltd. 2026. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "register/op_def_registry.h"
+
+namespace ops {
+class MlaPreprocess : public OpDef {
+public:
+    explicit MlaPreprocess(const char *name) : OpDef(name)
+    {
+        this->Input("hiddenState")
+            .ParamType(REQUIRED)
+            .DataType({ge::DT_FLOAT16, ge::DT_BF16, ge::DT_BF16, ge::DT_BF16})
+            .FormatList({ge::FORMAT_ND})
+            .AutoContiguous();
+        this->Input("quantScale1")
+            .ParamType(OPTIONAL)
+            .DataType({ge::DT_FLOAT16, ge::DT_BF16, ge::DT_BF16, ge::DT_BF16})
+            .FormatList({ge::FORMAT_ND})
+            .AutoContiguous();
+        this->Input("quantOffset1")
+            .ParamType(OPTIONAL)
+            .DataTypeList({ge::DT_INT8})
+            .FormatList({ge::FORMAT_ND})
+            .AutoContiguous();
+        this->Input("wdqkv")
+            .ParamType(REQUIRED)
+            .DataType({ge::DT_INT8, ge::DT_INT8, ge::DT_INT8, ge::DT_BF16})
+            .Format({ge::FORMAT_FRACTAL_NZ, ge::FORMAT_FRACTAL_NZ,
+                     ge::FORMAT_FRACTAL_NZ, ge::FORMAT_FRACTAL_NZ})
+            .AutoContiguous();
+        this->Input("bias1")
+            .ParamType(OPTIONAL)
+            .DataTypeList({ge::DT_INT32})
+            .FormatList({ge::FORMAT_ND})
+            .AutoContiguous();
+        this->Input("gamma2")
+            .ParamType(REQUIRED)
+            .DataType({ge::DT_FLOAT16, ge::DT_BF16, ge::DT_BF16, ge::DT_BF16})
+            .FormatList({ge::FORMAT_ND})
+            .AutoContiguous();
+        this->Input("beta2")
+            .ParamType(OPTIONAL)
+            .DataType({ge::DT_FLOAT16, ge::DT_BF16, ge::DT_BF16, ge::DT_BF16})
+            .FormatList({ge::FORMAT_ND})
+            .AutoContiguous();
+        this->Input("quantScale2")
+            .ParamType(OPTIONAL)
+            .DataType({ge::DT_FLOAT16, ge::DT_BF16, ge::DT_BF16, ge::DT_BF16})
+            .FormatList({ge::FORMAT_ND})
+            .AutoContiguous();
+        this->Input("quantOffset2")
+            .ParamType(OPTIONAL)
+            .DataTypeList({ge::DT_INT8})
+            .FormatList({ge::FORMAT_ND})
+            .AutoContiguous();
+        this->Input("gamma3")
+            .ParamType(REQUIRED)
+            .DataType({ge::DT_FLOAT16, ge::DT_BF16, ge::DT_BF16, ge::DT_BF16})
+            .FormatList({ge::FORMAT_ND})
+            .AutoContiguous();
+        this->Input("sin1")
+            .ParamType(OPTIONAL)
+            .DataType({ge::DT_FLOAT16, ge::DT_BF16, ge::DT_BF16, ge::DT_BF16})
+            .FormatList({ge::FORMAT_ND})
+            .AutoContiguous();
+        this->Input("cos1")
+            .ParamType(OPTIONAL)
+            .DataType({ge::DT_FLOAT16, ge::DT_BF16, ge::DT_BF16, ge::DT_BF16})
+            .FormatList({ge::FORMAT_ND})
+            .AutoContiguous();
+        this->Input("sin2")
+            .ParamType(OPTIONAL)
+            .DataType({ge::DT_FLOAT16, ge::DT_BF16, ge::DT_BF16, ge::DT_BF16})
+            .FormatList({ge::FORMAT_ND})
+            .AutoContiguous();
+        this->Input("cos2")
+            .ParamType(OPTIONAL)
+            .DataType({ge::DT_FLOAT16, ge::DT_BF16, ge::DT_BF16, ge::DT_BF16})
+            .FormatList({ge::FORMAT_ND})
+            .AutoContiguous();
+        this->Input("keycache")
+            .ParamType(REQUIRED)
+            .DataType({ge::DT_FLOAT16, ge::DT_BF16, ge::DT_INT8, ge::DT_BF16})
+            .FormatList({ge::FORMAT_ND})
+            .IgnoreContiguous();
+        this->Input("slotMapping")
+            .ParamType(REQUIRED)
+            .DataTypeList({ge::DT_INT32})
+            .FormatList({ge::FORMAT_ND})
+            .AutoContiguous();
+        this->Input("wuq")
+            .ParamType(REQUIRED)
+            .DataType({ge::DT_INT8, ge::DT_INT8, ge::DT_INT8, ge::DT_BF16})
+            .Format({ge::FORMAT_FRACTAL_NZ, ge::FORMAT_FRACTAL_NZ,
+                     ge::FORMAT_FRACTAL_NZ, ge::FORMAT_FRACTAL_NZ})
+            .AutoContiguous();
+        this->Input("bias2")
+            .ParamType(OPTIONAL)
+            .DataTypeList({ge::DT_INT32})
+            .FormatList({ge::FORMAT_ND})
+            .AutoContiguous();
+        this->Input("wuk")
+            .ParamType(REQUIRED)
+            .DataType({ge::DT_FLOAT16, ge::DT_BF16, ge::DT_BF16, ge::DT_BF16})
+            .Format({ge::FORMAT_FRACTAL_NZ, ge::FORMAT_FRACTAL_NZ,
+                     ge::FORMAT_FRACTAL_NZ, ge::FORMAT_ND})
+            .AutoContiguous();
+        this->Input("descale1")
+            .ParamType(OPTIONAL)
+            .DataTypeList({ge::DT_FLOAT})
+            .FormatList({ge::FORMAT_ND})
+            .AutoContiguous();
+        this->Input("descale2")
+            .ParamType(OPTIONAL)
+            .DataTypeList({ge::DT_FLOAT})
+            .FormatList({ge::FORMAT_ND})
+            .AutoContiguous();
+        this->Input("ctkvScale")
+            .ParamType(OPTIONAL)
+            .DataType({ge::DT_FLOAT16, ge::DT_BF16, ge::DT_BF16, ge::DT_BF16})
+            .FormatList({ge::FORMAT_ND})
+            .AutoContiguous();
+        this->Input("qnopeScale")
+            .ParamType(OPTIONAL)
+            .DataType({ge::DT_FLOAT16, ge::DT_BF16, ge::DT_BF16, ge::DT_BF16})
+            .FormatList({ge::FORMAT_ND})
+            .AutoContiguous();
+
+        this->Output("q")
+            .ParamType(REQUIRED)
+            .DataType({ge::DT_FLOAT16, ge::DT_BF16, ge::DT_INT8, ge::DT_BF16})
+            .FormatList({ge::FORMAT_ND});
+        this->Output("keycacheOut")
+            .ParamType(REQUIRED)
+            .DataType({ge::DT_FLOAT16, ge::DT_BF16, ge::DT_INT8, ge::DT_BF16})
+            .FormatList({ge::FORMAT_ND});
+        this->Output("q2")
+            .ParamType(REQUIRED)
+            .DataType({ge::DT_FLOAT16, ge::DT_BF16, ge::DT_BF16, ge::DT_BF16})
+            .FormatList({ge::FORMAT_ND});
+        this->Output("keycacheOut2")
+            .ParamType(REQUIRED)
+            .DataType({ge::DT_FLOAT16, ge::DT_BF16, ge::DT_BF16, ge::DT_BF16})
+            .FormatList({ge::FORMAT_ND});
+        this->Output("innerOut")
+            .ParamType(REQUIRED)
+            .DataType({ge::DT_FLOAT16, ge::DT_BF16, ge::DT_BF16, ge::DT_BF16})
+            .FormatList({ge::FORMAT_ND});
+
+        this->Attr("cacheMode").AttrType(OPTIONAL).Int(1);
+        this->Attr("quantMode").AttrType(OPTIONAL).Int(1);
+        this->Attr("enableInnerOut").AttrType(OPTIONAL).Bool(false);
+        this->Attr("enableRope").AttrType(OPTIONAL).Bool(true);
+        this->Attr("kvCacheStride0").AttrType(REQUIRED).Int(0);
+        this->Attr("kvCacheRopeStride0").AttrType(REQUIRED).Int(0);
+
+        OpAICoreConfig aicoreConfig;
+        aicoreConfig.DynamicCompileStaticFlag(true)
+            .DynamicFormatFlag(true)
+            .DynamicRankSupportFlag(true)
+            .DynamicShapeSupportFlag(true)
+            .NeedCheckSupportFlag(false)
+            .PrecisionReduceFlag(true)
+            .ExtendCfgInfo("aclnnSupport.value", "support_aclnn")
+            .ExtendCfgInfo("opFile.value", "mla_preprocess");
+        this->AICore().AddConfig("ascend910b", aicoreConfig);
+        this->AICore().AddConfig("ascend910_93", aicoreConfig);
+    }
+};
+
+OP_ADD(MlaPreprocess);
+}  // namespace ops

--- a/csrc/mla_preprocess/op_host/mla_preprocess_tiling.cpp
+++ b/csrc/mla_preprocess/op_host/mla_preprocess_tiling.cpp
@@ -1,0 +1,248 @@
+/*
+ * Copyright (c) Huawei Technologies Co., Ltd. 2026. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <cstddef>
+#include <cstdint>
+#include <limits>
+
+#include "mla_preprocess_tiling.h"
+#include "register/op_def_registry.h"
+#include "tiling/platform/platform_ascendc.h"
+#include "tiling_base/error_log.h"
+
+namespace optiling {
+namespace {
+
+constexpr size_t INPUT_HIDDEN_STATE = 0;
+constexpr size_t INPUT_WDQKV = 3;
+constexpr size_t INPUT_GAMMA1 = 5;
+constexpr size_t INPUT_KV_CACHE = 14;
+constexpr size_t INPUT_WUK = 18;
+constexpr size_t OUTPUT_KV_CACHE_ROPE = 3;
+
+constexpr size_t ATTR_CACHE_MODE = 0;
+constexpr size_t ATTR_QUANT_MODE = 1;
+constexpr size_t ATTR_ENABLE_INNER_OUT = 2;
+constexpr size_t ATTR_ENABLE_ROPE = 3;
+constexpr size_t ATTR_KV_CACHE_STRIDE0 = 4;
+constexpr size_t ATTR_KV_CACHE_ROPE_STRIDE0 = 5;
+
+constexpr int64_t CACHE_MODE_MIN = 0;
+constexpr int64_t CACHE_MODE_MAX = 3;
+constexpr int64_t QUANT_MODE_MIN = 0;
+constexpr int64_t QUANT_MODE_MAX = 3;
+constexpr uint64_t GENERIC_KERNEL_TILING_KEY = 0;
+
+struct MlaPreprocessCompileInfo {};
+
+bool IsPositiveU32(int64_t value)
+{
+    return value > 0 && static_cast<uint64_t>(value) <= std::numeric_limits<uint32_t>::max();
+}
+
+bool IsPhysicalNzCache(const gert::Shape &shape, int64_t cacheMode)
+{
+    const bool isNzCache = cacheMode == 2 || cacheMode == 3;
+    return isNzCache && shape.GetDimNum() == 4 && shape.GetDim(2) != 1;
+}
+
+ge::graphStatus ParseShapesAndAttrs(gert::TilingContext *context, mlapo::OpParam &opParam)
+{
+    const gert::StorageShape *hiddenStorageShape = context->GetInputShape(INPUT_HIDDEN_STATE);
+    const gert::StorageShape *wdqkvStorageShape = context->GetInputShape(INPUT_WDQKV);
+    const gert::StorageShape *gamma1StorageShape = context->GetInputShape(INPUT_GAMMA1);
+    const gert::StorageShape *kvCacheStorageShape = context->GetInputShape(INPUT_KV_CACHE);
+    const gert::StorageShape *wukStorageShape = context->GetInputShape(INPUT_WUK);
+    const gert::StorageShape *kvCacheRopeStorageShape = context->GetOutputShape(OUTPUT_KV_CACHE_ROPE);
+    OP_CHECK_NULL_WITH_CONTEXT(context, hiddenStorageShape);
+    OP_CHECK_NULL_WITH_CONTEXT(context, wdqkvStorageShape);
+    OP_CHECK_NULL_WITH_CONTEXT(context, gamma1StorageShape);
+    OP_CHECK_NULL_WITH_CONTEXT(context, kvCacheStorageShape);
+    OP_CHECK_NULL_WITH_CONTEXT(context, wukStorageShape);
+    OP_CHECK_NULL_WITH_CONTEXT(context, kvCacheRopeStorageShape);
+
+    const gert::Shape &hiddenShape = hiddenStorageShape->GetOriginShape();
+    const gert::Shape &gamma1Shape = gamma1StorageShape->GetOriginShape();
+    const gert::Shape &kvCacheShape = kvCacheStorageShape->GetOriginShape();
+    const gert::Shape &wukShape = wukStorageShape->GetOriginShape();
+    const gert::Shape &kvCacheRopeShape = kvCacheRopeStorageShape->GetOriginShape();
+
+    OP_CHECK_IF(hiddenShape.GetDimNum() != 2,
+                OP_LOGE(context, "hiddenState must have rank 2, got %zu.", hiddenShape.GetDimNum()),
+                return ge::GRAPH_FAILED);
+    OP_CHECK_IF(gamma1Shape.GetDimNum() < 1,
+                OP_LOGE(context, "gamma1 must have at least one dimension."), return ge::GRAPH_FAILED);
+    OP_CHECK_IF(wukShape.GetDimNum() != 3,
+                OP_LOGE(context, "wuk must have logical rank 3, got %zu.", wukShape.GetDimNum()),
+                return ge::GRAPH_FAILED);
+    OP_CHECK_IF(kvCacheShape.GetDimNum() < 2,
+                OP_LOGE(context, "kv_cache must have at least two dimensions."), return ge::GRAPH_FAILED);
+    OP_CHECK_IF(kvCacheRopeShape.GetDimNum() < 1,
+                OP_LOGE(context, "kv_cache_rope must not be a scalar."), return ge::GRAPH_FAILED);
+
+    const auto *attrs = context->GetAttrs();
+    OP_CHECK_NULL_WITH_CONTEXT(context, attrs);
+    const int64_t *cacheModePtr = attrs->GetInt(ATTR_CACHE_MODE);
+    const int64_t *quantModePtr = attrs->GetInt(ATTR_QUANT_MODE);
+    const bool *enableInnerOutPtr = attrs->GetBool(ATTR_ENABLE_INNER_OUT);
+    const bool *enableRopePtr = attrs->GetBool(ATTR_ENABLE_ROPE);
+    const int64_t *kvCacheStride0Ptr = attrs->GetInt(ATTR_KV_CACHE_STRIDE0);
+    const int64_t *kvCacheRopeStride0Ptr = attrs->GetInt(ATTR_KV_CACHE_ROPE_STRIDE0);
+    OP_CHECK_NULL_WITH_CONTEXT(context, cacheModePtr);
+    OP_CHECK_NULL_WITH_CONTEXT(context, quantModePtr);
+    OP_CHECK_NULL_WITH_CONTEXT(context, enableInnerOutPtr);
+    OP_CHECK_NULL_WITH_CONTEXT(context, enableRopePtr);
+    OP_CHECK_NULL_WITH_CONTEXT(context, kvCacheStride0Ptr);
+    OP_CHECK_NULL_WITH_CONTEXT(context, kvCacheRopeStride0Ptr);
+
+    const int64_t cacheMode = *cacheModePtr;
+    const int64_t quantMode = *quantModePtr;
+    OP_CHECK_IF(cacheMode < CACHE_MODE_MIN || cacheMode > CACHE_MODE_MAX,
+                OP_LOGE(context, "cacheMode must be in [0, 3], got %ld.", cacheMode),
+                return ge::GRAPH_FAILED);
+    OP_CHECK_IF(quantMode < QUANT_MODE_MIN || quantMode > QUANT_MODE_MAX,
+                OP_LOGE(context, "quantMode must be in [0, 3], got %ld.", quantMode),
+                return ge::GRAPH_FAILED);
+    OP_CHECK_IF(*kvCacheStride0Ptr <= 0 || *kvCacheRopeStride0Ptr <= 0,
+                OP_LOGE(context, "cache dim0 strides must be positive."), return ge::GRAPH_FAILED);
+
+    const int64_t tokenNum = hiddenShape.GetDim(0);
+    const int64_t hiddenStateDim = hiddenShape.GetDim(1);
+    const int64_t headNum = wukShape.GetDim(0);
+    const int64_t qkNopeHeadDim = wukShape.GetDim(1);
+    const int64_t kvLoraRank = wukShape.GetDim(2);
+    const int64_t qLoraRank = gamma1Shape.GetDim(0);
+    OP_CHECK_IF(!IsPositiveU32(tokenNum) || !IsPositiveU32(hiddenStateDim) || !IsPositiveU32(headNum) ||
+                    !IsPositiveU32(qkNopeHeadDim) || !IsPositiveU32(kvLoraRank) || !IsPositiveU32(qLoraRank),
+                OP_LOGE(context, "MLA model and token dimensions must be positive uint32 values."),
+                return ge::GRAPH_FAILED);
+    OP_CHECK_IF(tokenNum > static_cast<int64_t>(mlapo::MAX_SUPPORT_TOKEN_NUMS),
+                OP_LOGE(context, "token count must be in [1, %u], got %ld.",
+                        mlapo::MAX_SUPPORT_TOKEN_NUMS, tokenNum),
+                return ge::GRAPH_FAILED);
+
+    const int64_t kvCacheBlockSize = IsPhysicalNzCache(kvCacheShape, cacheMode)
+                                         ? kvCacheShape.GetDim(2)
+                                         : kvCacheShape.GetDim(1);
+    int64_t qkRopeHeadDim = kvCacheRopeShape.GetDim(kvCacheRopeShape.GetDimNum() - 1);
+    if (IsPhysicalNzCache(kvCacheRopeShape, cacheMode)) {
+        qkRopeHeadDim = kvCacheRopeShape.GetDim(1) * kvCacheRopeShape.GetDim(3);
+    }
+    OP_CHECK_IF(!IsPositiveU32(kvCacheBlockSize) || !IsPositiveU32(qkRopeHeadDim),
+                OP_LOGE(context, "cache block size and RoPE head dimension must be positive uint32 values."),
+                return ge::GRAPH_FAILED);
+
+    const auto *hiddenDesc = context->GetInputDesc(INPUT_HIDDEN_STATE);
+    const auto *wdqkvDesc = context->GetInputDesc(INPUT_WDQKV);
+    OP_CHECK_NULL_WITH_CONTEXT(context, hiddenDesc);
+    OP_CHECK_NULL_WITH_CONTEXT(context, wdqkvDesc);
+    const ge::DataType hiddenDtype = hiddenDesc->GetDataType();
+    OP_CHECK_IF(hiddenDtype != ge::DT_FLOAT16 && hiddenDtype != ge::DT_BF16,
+                OP_LOGE(context, "hiddenState must be float16 or bfloat16."), return ge::GRAPH_FAILED);
+    OP_CHECK_IF(quantMode == static_cast<int64_t>(mlapo::QuantMode::PER_TOKEN_SYMM_QUANT) &&
+                    hiddenDtype != ge::DT_BF16,
+                OP_LOGE(context, "per_token_quant_symm supports only bfloat16 hiddenState."),
+                return ge::GRAPH_FAILED);
+
+    opParam.hiddenStateDim = static_cast<uint32_t>(hiddenStateDim);
+    opParam.N = static_cast<uint32_t>(tokenNum);
+    opParam.headNum = static_cast<uint32_t>(headNum);
+    opParam.cacheMode = static_cast<int32_t>(cacheMode);
+    opParam.quantMode = static_cast<mlapo::QuantMode>(quantMode);
+    opParam.inDtype = hiddenDtype == ge::DT_BF16 ? mlapo::OpParam::InputDtype::BFLOAT16
+                                                 : mlapo::OpParam::InputDtype::FLOAT16;
+    opParam.enableInnerOut = *enableInnerOutPtr;
+    opParam.enableRope = *enableRopePtr;
+    opParam.qLoraRank = static_cast<uint32_t>(qLoraRank);
+    opParam.qkNopeHeadDim = static_cast<uint32_t>(qkNopeHeadDim);
+    opParam.qkRopeHeadDim = static_cast<uint32_t>(qkRopeHeadDim);
+    opParam.kvLoraRank = static_cast<uint32_t>(kvLoraRank);
+    opParam.kvCacheBlockSize = static_cast<uint64_t>(kvCacheBlockSize);
+    opParam.kvCacheStride0 = static_cast<uint64_t>(*kvCacheStride0Ptr);
+    opParam.kvCacheRopeStride0 = static_cast<uint64_t>(*kvCacheRopeStride0Ptr);
+    const ge::DataType weightDtype = wdqkvDesc->GetDataType();
+    opParam.isWeightQuantized = weightDtype == ge::DT_FLOAT16 || weightDtype == ge::DT_BF16 ? 0U : 1U;
+    return ge::GRAPH_SUCCESS;
+}
+
+ge::graphStatus FillPlatformInfo(gert::TilingContext *context, mlapo::PlatformInfo &platformInfo,
+                                 uint64_t &systemWorkspaceSize)
+{
+    fe::PlatFormInfos *platform = context->GetPlatformInfo();
+    OP_CHECK_NULL_WITH_CONTEXT(context, platform);
+    const platform_ascendc::PlatformAscendC ascendcPlatform(platform);
+    platformInfo.coreNum = ascendcPlatform.GetCoreNum();
+    platformInfo.coreNumAic = ascendcPlatform.GetCoreNumAic();
+    platformInfo.coreNumAiv = ascendcPlatform.GetCoreNumAiv();
+    ascendcPlatform.GetCoreMemSize(platform_ascendc::CoreMemType::UB, platformInfo.ubSize);
+    ascendcPlatform.GetCoreMemSize(platform_ascendc::CoreMemType::L1, platformInfo.l1Size);
+    ascendcPlatform.GetCoreMemSize(platform_ascendc::CoreMemType::L2, platformInfo.l2Size);
+    ascendcPlatform.GetCoreMemSize(platform_ascendc::CoreMemType::L0_A, platformInfo.l0aSize);
+    ascendcPlatform.GetCoreMemSize(platform_ascendc::CoreMemType::L0_B, platformInfo.l0bSize);
+    ascendcPlatform.GetCoreMemSize(platform_ascendc::CoreMemType::L0_C, platformInfo.l0cSize);
+    systemWorkspaceSize = ascendcPlatform.GetLibApiWorkSpaceSize();
+    OP_CHECK_IF(platformInfo.coreNumAic == 0 || platformInfo.coreNumAiv == 0 || platformInfo.ubSize == 0 ||
+                    platformInfo.l0cSize == 0,
+                OP_LOGE(context, "invalid platform information for MLA preprocessing."),
+                return ge::GRAPH_FAILED);
+    return ge::GRAPH_SUCCESS;
+}
+
+ge::graphStatus TilingMlaPreprocess(gert::TilingContext *context)
+{
+    OP_CHECK_IF(context == nullptr, OP_LOGE("MlaPreprocess", "TilingContext is null."),
+                return ge::GRAPH_FAILED);
+
+    mlapo::OpParam opParam{};
+    OP_CHECK_IF(ParseShapesAndAttrs(context, opParam) != ge::GRAPH_SUCCESS,
+                OP_LOGE(context, "failed to parse MLA shapes, dtypes or attrs."),
+                return ge::GRAPH_FAILED);
+
+    mlapo::PlatformInfo platformInfo{};
+    uint64_t systemWorkspaceSize = 0;
+    OP_CHECK_IF(FillPlatformInfo(context, platformInfo, systemWorkspaceSize) != ge::GRAPH_SUCCESS,
+                OP_LOGE(context, "failed to query platform information."), return ge::GRAPH_FAILED);
+
+    MlaTilingData *tilingData = context->GetTilingData<MlaTilingData>();
+    OP_CHECK_NULL_WITH_CONTEXT(context, tilingData);
+    *tilingData = MlaTilingData{};
+    mlapo::MlaPreprocessTiling mlaTiling(platformInfo, opParam, tilingData);
+    mlaTiling.Init();
+
+    OP_CHECK_IF(tilingData->userWorkspaceSize > std::numeric_limits<uint64_t>::max() - systemWorkspaceSize,
+                OP_LOGE(context, "workspace size overflow."), return ge::GRAPH_FAILED);
+    size_t *workspaceSizes = context->GetWorkspaceSizes(1);
+    OP_CHECK_NULL_WITH_CONTEXT(context, workspaceSizes);
+    workspaceSizes[0] = static_cast<size_t>(systemWorkspaceSize + tilingData->userWorkspaceSize);
+    context->SetBlockDim(platformInfo.coreNumAic);
+    // The MLA dispatch key remains in MlaTilingData::tilingKey. The CANN key
+    // selects the single generic mixed AIC/AIV entry emitted by the kernel.
+    context->SetTilingKey(GENERIC_KERNEL_TILING_KEY);
+    return ge::GRAPH_SUCCESS;
+}
+
+ge::graphStatus TilingParseMlaPreprocess(gert::TilingParseContext *)
+{
+    return ge::GRAPH_SUCCESS;
+}
+
+}  // namespace
+
+IMPL_OP_OPTILING(MlaPreprocess)
+    .Tiling(TilingMlaPreprocess)
+    .TilingParse<MlaPreprocessCompileInfo>(TilingParseMlaPreprocess);
+
+}  // namespace optiling

--- a/csrc/mla_preprocess/op_host/mla_preprocess_tiling.h
+++ b/csrc/mla_preprocess/op_host/mla_preprocess_tiling.h
@@ -11,17 +11,13 @@
 // See LICENSE in the root of the software repository for the full text of the License.
 //
 
-#include <fstream>
-#include <iostream>
-#include <math.h>
-#include <stdexcept>
-#include "acl/acl.h"
-// #include "defines.h"
-// #include "torch_helper.h"
-#include "tiling/platform/platform_ascendc.h"
-#include "tiling/mla_preprocess_tiling.h"
+#include <algorithm>
+#include <cfloat>
+#include <climits>
+#include <cmath>
+#include <cstdint>
 
-// #include "aclrtlaunch_mla_preprocess.h"
+#include "../op_kernel/mla_preprocess_tiling_data.h"
 
 // namespace sglang {
 namespace mlapo {
@@ -121,13 +117,15 @@ struct PlatformInfo {
 };
 
 struct OpParam {
+    enum class InputDtype : uint32_t { FLOAT16 = 0, BFLOAT16 = 1 };
+
     uint32_t isWeightQuantized;
     uint32_t hiddenStateDim;
     uint32_t N;
     uint32_t headNum;
     int32_t cacheMode;
     QuantMode quantMode;
-    caffe2::TypeMeta inDtype;
+    InputDtype inDtype;
     bool enableInnerOut;
     bool enableRope;
     // MLA dimensions derived from tensor shapes
@@ -481,7 +479,8 @@ void MlaPreprocessTiling::EinSumQuantTiling()
     uint32_t esqHeadPerLoop = 0;  // The number of head rows per UB calculation
     uint32_t repeatMask = 0;
 
-    if (opParam.inDtype == at::kBFloat16 || opParam.quantMode == QuantMode::PER_TOKEN_SYMM_QUANT) {
+    if (opParam.inDtype == OpParam::InputDtype::BFLOAT16 ||
+        opParam.quantMode == QuantMode::PER_TOKEN_SYMM_QUANT) {
         // Move scales in at once, broadcast, and cache them all H * 32bytes
         uint32_t scaleUb = RoundUp(esqHeadNum) * CONST_32;
         // bf16 input [H', colNum](f16 + fp32 + int8), ub reuse
@@ -539,7 +538,8 @@ void MlaPreprocessTiling::SetMlapoWorkSpace()
 
     uint64_t userWorkspaceSize;
     if (opParam.isWeightQuantized == 1 &&
-        (opParam.inDtype == at::kBFloat16 || opParam.quantMode == QuantMode::PER_TOKEN_SYMM_QUANT)) {
+        (opParam.inDtype == OpParam::InputDtype::BFLOAT16 ||
+         opParam.quantMode == QuantMode::PER_TOKEN_SYMM_QUANT)) {
         userWorkspaceSize = 4 * maxWorkspaceSize + pertokenWorkspace;
     } else {
         userWorkspaceSize = 3 * maxWorkspaceSize;
@@ -556,7 +556,7 @@ void MlaPreprocessTiling::SetMlapoWorkSpace()
 void MlaPreprocessTiling::SetTilingKey()
 {
     uint64_t tilingKey = (static_cast<uint64_t>(opParam.enableInnerOut)) << 9;
-    tilingKey |= (static_cast<uint64_t>(opParam.inDtype == at::kBFloat16)) << 8;
+    tilingKey |= (static_cast<uint64_t>(opParam.inDtype == OpParam::InputDtype::BFLOAT16)) << 8;
 
     tilingKey |= static_cast<uint64_t>(opParam.cacheMode);
     tilingKey |= (static_cast<uint64_t>(opParam.quantMode) << 3);
@@ -573,7 +573,8 @@ void MlaPreprocessTiling::Init()
     tilingData->enableRope = static_cast<uint32_t>(opParam.enableRope);
     bool enDequant = (opParam.isWeightQuantized == 1);
     bool deqOnTheFly = false;
-    if (enDequant && (opParam.inDtype == at::kBFloat16 || opParam.quantMode == QuantMode::PER_TOKEN_SYMM_QUANT)) {
+    if (enDequant && (opParam.inDtype == OpParam::InputDtype::BFLOAT16 ||
+                      opParam.quantMode == QuantMode::PER_TOKEN_SYMM_QUANT)) {
         deqOnTheFly = true;
     }
 
@@ -641,199 +642,4 @@ void MlaPreprocessTiling::Init()
     return;
 }
 
-std::unordered_map<c10::string_view, uint16_t> cache_mode_map = {
-    {"kvcache", 0}, {"krope_ctkv", 1}, {"int8_nzcache", 2}, {"nzcache", 3}};
-
-std::unordered_map<c10::string_view, uint16_t> quant_mode_map = {
-    {"per_tensor_quant_asymm", 0},
-    {"per_token_quant_symm", 1},
-    {"per_token_quant_asymm", 2},
-    {"no_quant", 3}
-};
-
-template <typename MapType>
-inline int get_op_mode(const MapType &mode_map, c10::optional<c10::string_view> mode_opt, c10::string_view default_mode,
-                       const char *mode_name)
-{
-    c10::string_view mode_str = mode_opt.value_or(default_mode);
-    auto it = mode_map.find(mode_str);
-    TORCH_CHECK(it != mode_map.end(), "Unsupported ", mode_name, " value: '", mode_str, "'");
-    return it->second;
-}
-
-// Contiguous layout default for dim0: product(shape[1:]).
-inline uint64_t GetDefaultStride0FromSizes(at::IntArrayRef sizes)
-{
-    uint64_t stride = 1;
-    for (size_t dim = 1; dim < sizes.size(); ++dim) {
-        stride *= static_cast<uint64_t>(sizes[dim]);
-    }
-    return stride;
-}
-
-// Only dim0 may be non-contiguous; dims 1..N-1 must match contiguous strides.
-inline void ValidateCacheNonFirstAxisContiguous(const at::Tensor &cache, const char *tensorName)
-{
-    if (cache.dim() <= 1) {
-        return;
-    }
-    auto sizes = cache.sizes();
-    auto strides = cache.strides();
-    int64_t expectedStride = 1;
-    for (int64_t i = static_cast<int64_t>(sizes.size()) - 1; i >= 1; --i) {
-        // A size-1 axis is never traversed, so PyTorch is free to report any
-        // stride for it (unsqueeze, slicing, ...).
-        if (sizes[i] == 1) {
-            continue;
-        }
-        TORCH_CHECK(strides[i] == expectedStride,
-                    tensorName, " dim", i, " is non-contiguous: actual stride=", strides[i],
-                    ", expected contiguous stride=", expectedStride,
-                    ". Only the first axis (dim0/blockNum) may be non-contiguous.");
-        expectedStride *= sizes[i];
-    }
-}
-
-inline uint64_t GetTensorStride0(const at::Tensor &cache)
-{
-    if (cache.dim() < 1) {
-        return GetDefaultStride0FromSizes(cache.sizes());
-    }
-    return static_cast<uint64_t>(cache.stride(0));
-}
-
-// The NZ cache modes accept two equivalent spellings of the same bytes:
-//   - physical  [blockNum, C1, blockSize, C0], as the ATB/ST harnesses build it
-//   - logical   [blockNum, blockSize, numKvHeads=1, dim], as vLLM allocates it
-// Both describe a compact block of blockSize*dim elements, so only the shape
-// interpretation differs. dim2 is the only axis that tells them apart.
-inline bool IsPhysicalNzCache(const at::Tensor &cache, int32_t cacheMode)
-{
-    const bool isNzCache = (cacheMode == 2 || cacheMode == 3);
-    return isNzCache && cache.dim() == 4 && cache.size(2) != 1;
-}
-
-// blockSize: physical NZ → dim2; ND and logical NZ → dim1.
-inline uint64_t GetKvCacheBlockSize(const at::Tensor &kv_cache, int32_t cacheMode)
-{
-    auto sizes = kv_cache.sizes();
-    TORCH_CHECK(sizes.size() >= 2, "kv_cache must have at least 2 dims");
-    if (IsPhysicalNzCache(kv_cache, cacheMode)) {
-        return static_cast<uint64_t>(sizes[2]);
-    }
-    return static_cast<uint64_t>(sizes[1]);
-}
-
-// Physical NZ rope caches are [blockNum, ropeDim/16, blockSize, 16], so their
-// last axis is C0 rather than the rope dim; recover it from the C1/C0 pair.
-inline uint32_t GetRopeHeadDim(const at::Tensor &kv_cache_rope, int32_t cacheMode)
-{
-    auto sizes = kv_cache_rope.sizes();
-    TORCH_CHECK(!sizes.empty(), "kv_cache_rope must not be a scalar");
-    if (IsPhysicalNzCache(kv_cache_rope, cacheMode)) {
-        return static_cast<uint32_t>(sizes[1] * sizes[3]);
-    }
-    return static_cast<uint32_t>(sizes.back());
-}
-
-std::tuple<at::Tensor, at::Tensor, uint32_t> mla_preprocess_tiling(
-    const at::Tensor &hiddenState,
-    const at::Tensor &wdqkv,
-    const at::Tensor &wuk,
-    const at::Tensor &gamma1,
-    const at::Tensor &kv_cache,
-    const at::Tensor &kv_cache_rope,
-    c10::optional<c10::string_view> cache_mode,
-    c10::optional<c10::string_view> quant_mode,
-    bool enable_inner_out,
-    bool enable_rope
-)
-{
-    auto cacheMode = get_op_mode(cache_mode_map, cache_mode, "krope_ctkv", "cache_mode");
-    auto quantMode = get_op_mode(quant_mode_map, quant_mode, "per_token_quant_symm", "quant_mode");
-
-    platform_ascendc::PlatformAscendC *platformAscendC = platform_ascendc::PlatformAscendCManager::GetInstance();
-
-    struct PlatformInfo platformInfo;
-    platformInfo.coreNum = platformAscendC->GetCoreNum();
-    platformInfo.coreNumAic = platformAscendC->GetCoreNumAic();
-    platformInfo.coreNumAiv = platformAscendC->GetCoreNumAiv();
-    platformAscendC->GetCoreMemSize(platform_ascendc::CoreMemType::UB, platformInfo.ubSize);
-    platformAscendC->GetCoreMemSize(platform_ascendc::CoreMemType::L1, platformInfo.l1Size);
-    platformAscendC->GetCoreMemSize(platform_ascendc::CoreMemType::L2, platformInfo.l2Size);
-    platformAscendC->GetCoreMemSize(platform_ascendc::CoreMemType::L0_A, platformInfo.l0aSize);
-    platformAscendC->GetCoreMemSize(platform_ascendc::CoreMemType::L0_B, platformInfo.l0bSize);
-    platformAscendC->GetCoreMemSize(platform_ascendc::CoreMemType::L0_C, platformInfo.l0cSize);
-
-    int32_t N = hiddenState.sizes()[0];
-    int32_t headNum = wuk.sizes()[0];
-    uint32_t hiddenStateDim = hiddenState.sizes().back();
-
-    // Derive MLA dimensions from tensor shapes
-    uint32_t qkNopeHeadDim = wuk.sizes()[1];
-    uint32_t kvLoraRank = wuk.sizes()[2];
-    uint32_t qLoraRank = gamma1.sizes()[0];
-    uint32_t qkRopeHeadDim = GetRopeHeadDim(kv_cache_rope, static_cast<int32_t>(cacheMode));
-
-    ValidateCacheNonFirstAxisContiguous(kv_cache, "kv_cache");
-    ValidateCacheNonFirstAxisContiguous(kv_cache_rope, "kv_cache_rope");
-
-    OpParam opParam;
-    opParam.hiddenStateDim = hiddenStateDim;
-    opParam.N = N;
-    opParam.headNum = headNum;
-    opParam.cacheMode = static_cast<int32_t>(cacheMode);
-    opParam.quantMode = static_cast<QuantMode>(quantMode);
-    opParam.inDtype = hiddenState.options().dtype();
-    // PER_TOKEN_SYMM only has bf16 kernel instantiations (tilingKey bit8=1).
-    TORCH_CHECK(!(opParam.quantMode == QuantMode::PER_TOKEN_SYMM_QUANT && opParam.inDtype != at::kBFloat16),
-                "quant_mode=per_token_quant_symm only supports bf16 input, got ", opParam.inDtype);
-    opParam.enableInnerOut = enable_inner_out;
-    opParam.enableRope = enable_rope;
-    opParam.qLoraRank = qLoraRank;
-    opParam.qkNopeHeadDim = qkNopeHeadDim;
-    opParam.qkRopeHeadDim = qkRopeHeadDim;
-    opParam.kvLoraRank = kvLoraRank;
-    opParam.kvCacheBlockSize = GetKvCacheBlockSize(kv_cache, static_cast<int32_t>(cacheMode));
-    opParam.kvCacheStride0 = GetTensorStride0(kv_cache);
-    opParam.kvCacheRopeStride0 = GetTensorStride0(kv_cache_rope);
-    if (wdqkv.options().dtype() == at::kBFloat16 || wdqkv.options().dtype() == at::kHalf) {
-        opParam.isWeightQuantized = 0;
-    } else {
-        opParam.isWeightQuantized = 1;
-    }
-
-    MlaTilingData tilingData;
-    MlaPreprocessTiling mlaTiling(platformInfo, opParam, &tilingData);
-
-    mlaTiling.Init();
-    uint32_t blockDim = platformInfo.coreNumAic;
-
-    // workspace
-    uint64_t system_workspace_size = static_cast<uint64_t>(platformAscendC->GetLibApiWorkSpaceSize());
-    uint64_t workspace_size = system_workspace_size + tilingData.userWorkspaceSize;
-    auto options = at::TensorOptions().dtype(at::kByte).device(hiddenState.options().device());
-    auto workspace_tensor = at::empty({static_cast<int64_t>(workspace_size)}, options);
-
-    // tiling
-    int32_t bIndex = N - 1;
-    uint32_t tilingSize = sizeof(MlaTilingData);
-    static auto global_tiling_data =
-        at::empty({tilingSize * MAX_SUPPORT_TOKEN_NUMS},
-                  at::TensorOptions().dtype(at::kByte).device(hiddenState.options().device()));
-    if (bIndex >= 0 && bIndex < MAX_SUPPORT_TOKEN_NUMS) {
-        aclrtMemcpy(global_tiling_data.data_ptr<uint8_t>() + (tilingSize * bIndex), tilingSize, &tilingData, tilingSize,
-                    ACL_MEMCPY_HOST_TO_DEVICE);
-    } else {
-        // Handle the case where bIndex is out of range
-        TORCH_CHECK(false, "bIndex is out of range: ", bIndex);
-    }
-    at::Tensor tiling = at::from_blob(
-        global_tiling_data.data_ptr<uint8_t>() + (tilingSize * bIndex),
-        tilingSize,
-        at::kByte);
-
-    return std::make_tuple(workspace_tensor, tiling, blockDim);
-}
-
-}  // namespace npu_kernel
+}  // namespace mlapo

--- a/csrc/mla_preprocess/op_kernel/mla_preprocess.cpp
+++ b/csrc/mla_preprocess/op_kernel/mla_preprocess.cpp
@@ -11,14 +11,13 @@
 //
 
 #include "kernel_operator.h"
-#include "../../kernels/types.h"
 
 #include "mla_preprocess_mix_fp16.hpp"
 #include "mla_preprocess_mix_bf16.hpp"
 #include "mla_preprocess_mix_bf16_qdown.hpp"
 #include "mla_preprocess_mix_bf16_nq.hpp"
 
-#include "../op_host/tiling/mla_preprocess_tiling.h"
+#include "mla_preprocess_tiling_data.h"
 
 extern "C" __global__ __aicore__ void mla_preprocess(
     GM_ADDR hiddenState, GM_ADDR quantScale1, GM_ADDR quantOffset1, GM_ADDR wdqkv,
@@ -27,6 +26,8 @@ extern "C" __global__ __aicore__ void mla_preprocess(
     GM_ADDR bias2, GM_ADDR wuk, GM_ADDR descale1, GM_ADDR descale2, GM_ADDR ctkvScale, GM_ADDR qnopeScale, GM_ADDR q,
     GM_ADDR keycacheOut, GM_ADDR q2, GM_ADDR keycacheOut2, GM_ADDR innerOut, GM_ADDR workspace, GM_ADDR tiling)
 {
+    REGISTER_TILING_DEFAULT(MlaTilingData);
+    KERNEL_TASK_TYPE_DEFAULT(KERNEL_TYPE_MIX_AIC_1_2);
 #if defined(__CCE_KT_TEST__) || (__CCE_AICORE__ == 220)
     PRELOAD(2);
 #endif
@@ -38,125 +39,17 @@ extern "C" __global__ __aicore__ void mla_preprocess(
     SetNdpara(1, 0, 0);
 #endif
 
-    MlaTilingData mlaTilingData;
-    __gm__ MlaTilingData *tilingData = reinterpret_cast<__gm__ MlaTilingData *>(tiling);
+    GET_TILING_DATA_WITH_STRUCT(MlaTilingData, mlaTilingData, tiling);
 
-    mlaTilingData.tilingKey = tilingData->tilingKey;
-    mlaTilingData.n = tilingData->n;
-    mlaTilingData.hiddenStateDim = tilingData->hiddenStateDim;
-    mlaTilingData.enableRope = tilingData->enableRope;
-
-    mlaTilingData.mm1.numBatch = tilingData->mm1.numBatch;
-    mlaTilingData.mm1.m = tilingData->mm1.m;
-    mlaTilingData.mm1.k = tilingData->mm1.k;
-    mlaTilingData.mm1.n = tilingData->mm1.n;
-    mlaTilingData.mm1.m0 = tilingData->mm1.m0;
-    mlaTilingData.mm1.k0 = tilingData->mm1.k0;
-    mlaTilingData.mm1.n0 = tilingData->mm1.n0;
-    mlaTilingData.mm1.mLoop = tilingData->mm1.mLoop;
-    mlaTilingData.mm1.kLoop = tilingData->mm1.kLoop;
-    mlaTilingData.mm1.nLoop = tilingData->mm1.nLoop;
-    mlaTilingData.mm1.coreLoop = tilingData->mm1.coreLoop;
-    mlaTilingData.mm1.swizzleCount = tilingData->mm1.swizzleCount;
-    mlaTilingData.mm1.enShuffleK = tilingData->mm1.enShuffleK;
-    mlaTilingData.mm1.blockDim = tilingData->mm1.blockDim;
-    mlaTilingData.mm1.enLoadAllAmat = tilingData->mm1.enLoadAllAmat;
-    mlaTilingData.mm1.b0matPingPongBufferLen = tilingData->mm1.b0matPingPongBufferLen;
-
-    mlaTilingData.mm2.numBatch = tilingData->mm2.numBatch;
-    mlaTilingData.mm2.m = tilingData->mm2.m;
-    mlaTilingData.mm2.k = tilingData->mm2.k;
-    mlaTilingData.mm2.n = tilingData->mm2.n;
-    mlaTilingData.mm2.m0 = tilingData->mm2.m0;
-    mlaTilingData.mm2.k0 = tilingData->mm2.k0;
-    mlaTilingData.mm2.n0 = tilingData->mm2.n0;
-    mlaTilingData.mm2.mLoop = tilingData->mm2.mLoop;
-    mlaTilingData.mm2.kLoop = tilingData->mm2.kLoop;
-    mlaTilingData.mm2.nLoop = tilingData->mm2.nLoop;
-    mlaTilingData.mm2.coreLoop = tilingData->mm2.coreLoop;
-    mlaTilingData.mm2.swizzleCount = tilingData->mm2.swizzleCount;
-    mlaTilingData.mm2.enShuffleK = tilingData->mm2.enShuffleK;
-    mlaTilingData.mm2.blockDim = tilingData->mm2.blockDim;
-    mlaTilingData.mm2.enLoadAllAmat = tilingData->mm2.enLoadAllAmat;
-    mlaTilingData.mm2.b0matPingPongBufferLen = tilingData->mm2.b0matPingPongBufferLen;
-
-    mlaTilingData.mm3.numBatch = tilingData->mm3.numBatch;
-    mlaTilingData.mm3.m = tilingData->mm3.m;
-    mlaTilingData.mm3.k = tilingData->mm3.k;
-    mlaTilingData.mm3.n = tilingData->mm3.n;
-    mlaTilingData.mm3.m0 = tilingData->mm3.m0;
-    mlaTilingData.mm3.k0 = tilingData->mm3.k0;
-    mlaTilingData.mm3.n0 = tilingData->mm3.n0;
-    mlaTilingData.mm3.mLoop = tilingData->mm3.mLoop;
-    mlaTilingData.mm3.kLoop = tilingData->mm3.kLoop;
-    mlaTilingData.mm3.nLoop = tilingData->mm3.nLoop;
-    mlaTilingData.mm3.coreLoop = tilingData->mm3.coreLoop;
-    mlaTilingData.mm3.swizzleCount = tilingData->mm3.swizzleCount;
-    mlaTilingData.mm3.enShuffleK = tilingData->mm3.enShuffleK;
-    mlaTilingData.mm3.blockDim = tilingData->mm3.blockDim;
-
-    mlaTilingData.perTaskNum = tilingData->perTaskNum;
-    mlaTilingData.resTaskNum = tilingData->resTaskNum;
-    mlaTilingData.numCore = tilingData->numCore;
-
-    mlaTilingData.rmsNumCore1 = tilingData->rmsNumCore1;
-    mlaTilingData.rmsNumCol1 = tilingData->rmsNumCol1;
-    mlaTilingData.rmsNumCore2 = tilingData->rmsNumCore2;
-    mlaTilingData.rmsNumCol2 = tilingData->rmsNumCol2;
-
-    mlaTilingData.hiddenSizeQ = tilingData->hiddenSizeQ;
-    mlaTilingData.headNumQ = tilingData->headNumQ;
-    mlaTilingData.headDim = tilingData->headDim;
-    mlaTilingData.concatSize = tilingData->concatSize;
-    mlaTilingData.rotaryCoeff = tilingData->rotaryCoeff;
-    mlaTilingData.ntokens = tilingData->ntokens;
-    mlaTilingData.realCore = tilingData->realCore;
-    mlaTilingData.nlCoreRun = tilingData->nlCoreRun;
-    mlaTilingData.lCoreRun = tilingData->lCoreRun;
-    mlaTilingData.maxNPerLoopForUb = tilingData->maxNPerLoopForUb;
-    mlaTilingData.preCoreLoopTime = tilingData->preCoreLoopTime;
-    mlaTilingData.preCoreLoopNLast = tilingData->preCoreLoopNLast;
-    mlaTilingData.lastCoreLoopTime = tilingData->lastCoreLoopTime;
-    mlaTilingData.lastCoreLoopNLast = tilingData->lastCoreLoopNLast;
-
-    mlaTilingData.esqFrontCore = tilingData->esqFrontCore;
-    mlaTilingData.esqTailCore = tilingData->esqTailCore;
-    mlaTilingData.esqFrontCoreBatch = tilingData->esqFrontCoreBatch;
-    mlaTilingData.esqTailCoreBatch = tilingData->esqTailCoreBatch;
-    mlaTilingData.esqHeadNum = tilingData->esqHeadNum;
-    mlaTilingData.esqColNum = tilingData->esqColNum;
-    mlaTilingData.esqUbHeadLoop = tilingData->esqUbHeadLoop;
-    mlaTilingData.esqHeadPerLoop = tilingData->esqHeadPerLoop;
-    mlaTilingData.esqHeadTail = tilingData->esqHeadTail;
-    mlaTilingData.esqColLoop = tilingData->esqColLoop;
-    mlaTilingData.esqColTail = tilingData->esqColTail;
-
-    mlaTilingData.s1Offset = tilingData->s1Offset;
-    mlaTilingData.s2Offset = tilingData->s2Offset;
-    mlaTilingData.s3Offset = tilingData->s3Offset;
-    mlaTilingData.s4Offset = tilingData->s4Offset;
-    mlaTilingData.s5Offset = tilingData->s5Offset;
-
-    // Model-specific MLA dimensions
-    mlaTilingData.mm1OutSize = tilingData->mm1OutSize;
-    mlaTilingData.splitSizeOne = tilingData->splitSizeOne;
-    mlaTilingData.splitSizeTwo = tilingData->splitSizeTwo;
-    mlaTilingData.splitRmsNormSizeOne = tilingData->splitRmsNormSizeOne;
-    mlaTilingData.splitRmsNormSizeTwo = tilingData->splitRmsNormSizeTwo;
-    mlaTilingData.ropeSplitSizeOne = tilingData->ropeSplitSizeOne;
-    mlaTilingData.ropeSplitSizeTwo = tilingData->ropeSplitSizeTwo;
-    mlaTilingData.hiddenStrideRope = tilingData->hiddenStrideRope;
-    mlaTilingData.qkNopeHeadDim = tilingData->qkNopeHeadDim;
-    mlaTilingData.avgFactor = tilingData->avgFactor;
-    mlaTilingData.kvCacheBlockSize = tilingData->kvCacheBlockSize;
-    mlaTilingData.kvCacheStride0 = tilingData->kvCacheStride0;
-    mlaTilingData.kvCacheRopeStride0 = tilingData->kvCacheRopeStride0;
-
-    GM_ADDR s1 = workspace + static_cast<uint64_t>(mlaTilingData.s1Offset);
-    GM_ADDR s2 = workspace + static_cast<uint64_t>(mlaTilingData.s2Offset);
-    GM_ADDR s3 = workspace + static_cast<uint64_t>(mlaTilingData.s3Offset);
-    GM_ADDR s4 = workspace + static_cast<uint64_t>(mlaTilingData.s4Offset);
-    GM_ADDR s5 = workspace + static_cast<uint64_t>(mlaTilingData.s5Offset);
+    // ACLNN initializes the system-workspace state before entering the kernel.
+    // Do not overwrite it with the workspace argument; this operator's custom
+    // PpMatmul/FFTS path only uses the user portion.
+    GM_ADDR userWorkspace = AscendC::GetUserWorkspace(workspace);
+    GM_ADDR s1 = userWorkspace + static_cast<uint64_t>(mlaTilingData.s1Offset);
+    GM_ADDR s2 = userWorkspace + static_cast<uint64_t>(mlaTilingData.s2Offset);
+    GM_ADDR s3 = userWorkspace + static_cast<uint64_t>(mlaTilingData.s3Offset);
+    GM_ADDR s4 = userWorkspace + static_cast<uint64_t>(mlaTilingData.s4Offset);
+    GM_ADDR s5 = userWorkspace + static_cast<uint64_t>(mlaTilingData.s5Offset);
 
     switch (mlaTilingData.tilingKey) {
         case KEY_FP16_CACHEMODE_0_QUANTMODE_0: {
@@ -433,75 +326,4 @@ extern "C" __global__ __aicore__ void mla_preprocess(
         }
     }
     return;
-}
-
-namespace vllm_ascend {
-
-extern void mla_preprocess_impl(
-    void* stream,
-    void* hidden_state,
-    void* quant_scale1,
-    void* quant_offset1,
-    void* wdqkv,
-    void* bias1,
-    void* gamma2,
-    void* beta2,
-    void* quant_scale2,
-    void* quant_offset2,
-    void* gamma3,
-    void* sin1,
-    void* cos1,
-    void* sin2,
-    void* cos2,
-    void* keycache,
-    void* slot_mapping,
-    void* wuq,
-    void* bias2,
-    void* wuk,
-    void* descale1,
-    void* descale2,
-    void* ctkv_scale,
-    void* qnope_scale,
-    void* q,
-    void* keycache_out,
-    void* q2,
-    void* keycache_out2,
-    void* inner_out,
-    void* workspace,
-    void* tiling,
-    const uint32_t block_dim)
-{
-    mla_preprocess<<<block_dim, nullptr, stream>>>(
-        hidden_state,
-        quant_scale1,
-        quant_offset1,
-        wdqkv,
-        bias1,
-        gamma2,
-        beta2,
-        quant_scale2,
-        quant_offset2,
-        gamma3,
-        sin1,
-        cos1,
-        sin2,
-        cos2,
-        keycache,
-        slot_mapping,
-        wuq,
-        bias2,
-        wuk,
-        descale1,
-        descale2,
-        ctkv_scale,
-        qnope_scale,
-        q,
-        keycache_out,
-        q2,
-        keycache_out2,
-        inner_out,
-        workspace,
-        tiling);
-}
-
 }

--- a/csrc/mla_preprocess/op_kernel/mla_preprocess_mix_bf16.hpp
+++ b/csrc/mla_preprocess/op_kernel/mla_preprocess_mix_bf16.hpp
@@ -21,7 +21,7 @@
 #include "lib/matmul_intf.h"
 
 #include "mla_preprocess.h"
-#include "../op_host/tiling/mla_preprocess_tiling.h"
+#include "mla_preprocess_tiling_data.h"
 
 namespace MLAPO_BF16 {
 template <typename QkDtype, typename CosDtype, typename QOutDtype, int8_t CacheMode>

--- a/csrc/mla_preprocess/op_kernel/mla_preprocess_mix_bf16_nq.hpp
+++ b/csrc/mla_preprocess/op_kernel/mla_preprocess_mix_bf16_nq.hpp
@@ -21,7 +21,7 @@
 #include "lib/matmul_intf.h"
 
 #include "mla_preprocess.h"
-#include "../op_host/tiling/mla_preprocess_tiling.h"
+#include "mla_preprocess_tiling_data.h"
 
 namespace MLAPO_BF16_NQ {
 template <typename QkDtype, typename CosDtype, typename QOutDtype, int8_t CacheMode>
@@ -375,8 +375,8 @@ public:
 
         AscendC::DataCopy(gammaTensor, gammaGmTensor,
                           AscendC::DataCopyParams(1, (num_col_ - input_stride_) / BLOCK_SIZE_16, 0, 0));
-        AscendC::DataCopy(betaTensor, betaGmTensor,
-                          AscendC::DataCopyParams(1, (num_col_ - input_stride_) / BLOCK_SIZE_16, 0, 0));
+        // This no-quant RMSNorm path does not apply beta. beta2 is optional at
+        // the ACLNN boundary, so do not dereference it when the caller omits it.
         SET_FLAG(MTE2, V, EVENT_ID1);
 
         AscendC::SetFlag<HardEvent::S_V>(EVENT_ID0);

--- a/csrc/mla_preprocess/op_kernel/mla_preprocess_mix_bf16_qdown.hpp
+++ b/csrc/mla_preprocess/op_kernel/mla_preprocess_mix_bf16_qdown.hpp
@@ -21,7 +21,7 @@
 #include "lib/matmul_intf.h"
 
 #include "mla_preprocess.h"
-#include "../op_host/tiling/mla_preprocess_tiling.h"
+#include "mla_preprocess_tiling_data.h"
 
 namespace MLAPO_BF16_INNER {
 template <typename QkDtype, typename CosDtype, typename QOutDtype, int8_t CacheMode>

--- a/csrc/mla_preprocess/op_kernel/mla_preprocess_mix_fp16.hpp
+++ b/csrc/mla_preprocess/op_kernel/mla_preprocess_mix_fp16.hpp
@@ -21,7 +21,7 @@
 #include "lib/matmul_intf.h"
 
 #include "mla_preprocess.h"
-#include "../op_host/tiling/mla_preprocess_tiling.h"
+#include "mla_preprocess_tiling_data.h"
 
 namespace MLAPO_FP16 {
 

--- a/csrc/mla_preprocess/op_kernel/mla_preprocess_tiling_data.h
+++ b/csrc/mla_preprocess/op_kernel/mla_preprocess_tiling_data.h
@@ -10,8 +10,8 @@
 // See LICENSE in the root of the software repository for the full text of the License.
 //
 
-#ifndef MLAPREPROCESS_TILING_H
-#define MLAPREPROCESS_TILING_H
+#ifndef MLA_PREPROCESS_TILING_DATA_H
+#define MLA_PREPROCESS_TILING_DATA_H
 
 #include <cstdint>
 
@@ -116,4 +116,4 @@ struct MlaTilingData {
     uint64_t kvCacheRopeStride0{0};
 };
 
-#endif  // MLAPREPROCESS_TILING_H
+#endif  // MLA_PREPROCESS_TILING_DATA_H

--- a/csrc/ops.h
+++ b/csrc/ops.h
@@ -88,41 +88,6 @@ namespace vllm_ascend {
         uint32_t slice_offset,
         uint32_t output_full_dim);
 
-    extern void mla_preprocess_impl(
-        void* stream,
-        void* hidden_state,
-        void* quant_scale1,
-        void* quant_offset1,
-        void* wdqkv,
-        void* bias1,
-        void* gamma2,
-        void* beta2,
-        void* quant_scale2,
-        void* quant_offset2,
-        void* gamma3,
-        void* sin1,
-        void* cos1,
-        void* sin2,
-        void* cos2,
-        void* keycache,
-        void* slot_mapping,
-        void* wuq,
-        void* bias2,
-        void* wuk,
-        void* descale1,
-        void* descale2,
-        void* ctkv_scale,
-        void* qnope_scale,
-        void* q,
-        void* keycache_out,
-        void* q2,
-        void* keycache_out2,
-        void* inner_out,
-        void* workspace,
-        void* tiling,
-        const uint32_t block_dim
-    );
-
     extern void batch_matmul_transpose_impl(
         void* stream,
         void* gm_a,


### PR DESCRIPTION
### What this PR does / why we need it?

The existing MLA preprocess Torch adapter uses a raw custom-op launcher: it computes Host Tiling in the adapter, copies tiling data to device memory with synchronous `aclrtMemcpy`, and launches the kernel directly. During `torch.npu.graph` capture, that host-to-device copy is unsupported and reports runtime error `107030` in plog.

This PR migrates the existing operator to the repository's two-stage ACLNN path:

- the Torch adapter dispatches through `EXEC_NPU_CMD(aclnnMlaPreprocess, ...)`;
- an `OpDef` declares the existing inputs, outputs, attributes, dtypes, and formats;
- the Host Tiling callback supplies workspace size, block dimension, tiling key, and tiling data;
- Host and Device share one 488-byte `MlaTilingData` definition with a fixed binary layout; Host writes the CANN-owned tiling buffer through `TilingContext::GetTilingData<MlaTilingData>()`;
- `IMPL_OP_OPTILING(MlaPreprocess)` remains the Host Tiling function registration, so a second mirrored `REGISTER_TILING_DATA_CLASS` structure is unnecessary;
- the standard ACLNN build registration is enabled for the supported Ascend 910B/910_93 targets.

The ACLNN/NPU Graph runtime now owns the executor, workspace, tiling buffer, and launch resources across eager execution, capture, and replay. The public Torch schema, calling convention, supported cache/quant modes, tensor semantics, and output contract remain unchanged.

Related issue: #14347.

### Does this PR introduce _any_ user-facing change?

Yes. The existing `mla_preprocess` operator can be captured and replayed by NPU Graph without the unsupported synchronous Host Tiling copy. No public API or supported-mode change is introduced.

### How was this patch tested?

Tested commit: `3e14ab51dc07427f3528168c829502d019b0ae16`, based on upstream `main` at `fd5e534bcaf71c3a5e29bb3bea8a8c415e98f5e9`.

Environment: Ascend 910B4, CANN 9.1.0, Python 3.11.10, and torch-npu 2.10.0.post4.

- A clean `build.sh --pkg --ops=mla_preprocess --soc=ascend910b` build completed successfully. Package SHA256: `f5aff5ba75611479788a80789287141988f5646f8bb3189ccc1e78f6705a92e6`.
- `bash format.sh ci` passed all configured hooks, including Ruff, codespell, typos, clang-format, markdownlint, actionlint, Gitleaks, and shell lint.
- The existing `tests/e2e/nightly/single_node/ops/singlecard_ops/test_mla_preprocess.py` suite passed: `13 passed, 32 warnings in 20.26s`.
- The repository's `test_mla_preprocess_qdown.py` and `test_mla_preprocess_nq.py` collected six cases that remain skipped by their existing markers; they are not reported as passes.
- An external NPU Graph matrix covered all 10 combinations in the repository's `SUPPORTED_MODE_COMBOS`. Each case completed one capture, two consecutive replays, an in-place fixed-address input update, and an updated-input replay; all q/cache outputs matched the corresponding eager references.
- The external production-signature graph case (`krope_ctkv + per_tensor_quant_asymm + BF16 + enable_inner_out=True`) passed capture/replay, fixed-address input updates, and five-output comparison.
- Fixed-input byte-exact checks against the previously frozen raw hot-state golden passed three of three runs for both normal and qdown paths. Every output matched, including all 12,288 qdown `inner_out` elements.
- `git diff --check upstream/main...HEAD` passed. This PR adds or modifies no test file.

The full repository test suite was not run.

- vLLM main: https://github.com/vllm-project/vllm/commit/ba07e4a48fc951300d97eb506217dd530583dea3
