### PR TITLE
[CI] Add scheduled workflow to run all e2e tests

### DIFF
--- a/.github/workflows/pr_test.yaml
+++ b/.github/workflows/pr_test.yaml
@@ -532,7 +532,6 @@ jobs:
       matrix:
         vllm_version:
           - ${{ needs.pre-commit.outputs.main_commit }}
-          - ${{ needs.pre-commit.outputs.release_tag }}
     uses: ./.github/workflows/_selected_tests.yaml
     with:
       vllm: ${{ matrix.vllm_version }}
@@ -560,7 +559,6 @@ jobs:
       matrix:
         vllm_version:
           - ${{ needs.pre-commit.outputs.main_commit }}
-          - ${{ needs.pre-commit.outputs.release_tag }}
     uses: ./.github/workflows/_selected_tests_upstream.yaml
     with:
       vllm: ${{ matrix.vllm_version }}
@@ -585,7 +583,6 @@ jobs:
       matrix:
         vllm_version:
           - ${{ needs.pre-commit.outputs.main_commit }}
-          - ${{ needs.pre-commit.outputs.release_tag }}
     uses: ./.github/workflows/_selected_tests.yaml
     with:
       vllm: ${{ matrix.vllm_version }}

--- a/.github/workflows/schedule_all_e2e_test.yaml
+++ b/.github/workflows/schedule_all_e2e_test.yaml
@@ -1,0 +1,174 @@
+#
+# Copyright (c) 2026 Huawei Technologies Co., Ltd. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# This file is a part of the vllm-ascend project.
+#
+
+name: Schedule All E2E Tests
+
+on:
+  workflow_dispatch:
+    inputs:
+      vllm_ascend_branch:
+        description: 'Branch, tag, or SHA to test'
+        required: false
+        default: 'main'
+        type: string
+
+# Bash shells do not use ~/.profile or ~/.bashrc so these shells need to be explicitly
+# declared as "shell: bash -el {0}" on steps that need to be properly activated.
+# It's used to activate ascend-toolkit environment variables.
+defaults:
+  run:
+    shell: bash -el {0}
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  select-all-tests:
+    runs-on: linux-amd64-cpu-8-hk
+    container:
+      image: quay.io/ascend-ci/vllm-ascend:lint
+    outputs:
+      has_tests: ${{ steps.full-scope.outputs.has_tests }}
+      test_groups: ${{ steps.full-scope.outputs.test_groups }}
+      matched_modules: ${{ steps.full-scope.outputs.matched_modules }}
+      csrc_cache_target_ids: ${{ steps.full-scope.outputs.csrc_cache_target_ids }}
+      vllm_ascend_ref: ${{ steps.resolve-refs.outputs.vllm_ascend_ref }}
+      base_sha: ${{ steps.resolve-refs.outputs.base_sha }}
+      base_ref: ${{ steps.resolve-refs.outputs.base_ref }}
+      main_commit: ${{ steps.resolve-refs.outputs.main_commit }}
+      release_tag: ${{ steps.resolve-refs.outputs.release_tag }}
+      has_tests_a5: ${{ steps.scope-a5.outputs.has_tests }}
+      test_groups_a5: ${{ steps.scope-a5.outputs.test_groups }}
+    steps:
+      - name: Checkout vllm-project/vllm-ascend repo
+        uses: actions/checkout@v7
+        with:
+          ref: >-
+            ${{
+              github.event_name == 'workflow_dispatch' && inputs.vllm_ascend_branch || ''
+            }}
+          fetch-depth: 0
+
+      - name: Resolve refs
+        id: resolve-refs
+        env:
+          WD_BRANCH: ${{ github.event_name == 'workflow_dispatch' && inputs.vllm_ascend_branch || '' }}
+        run: |
+          git config --global --add safe.directory "$GITHUB_WORKSPACE"
+          cd "$GITHUB_WORKSPACE"
+          TARGET_BRANCH="${WD_BRANCH:-$GITHUB_REF_NAME}"
+          git fetch origin "$TARGET_BRANCH"
+          {
+            echo "vllm_ascend_ref=$(git rev-parse HEAD)"
+            echo "base_sha=$(git rev-parse FETCH_HEAD)"
+            echo "base_ref=${TARGET_BRANCH}"
+          } >> "$GITHUB_OUTPUT"
+          main_commit="$(tr -d '[:space:]' < .github/vllm-main-verified.commit)"
+          release_tag="$(tr -d '[:space:]' < .github/vllm-release-tag.commit)"
+          [[ "${main_commit}" =~ ^[0-9a-f]{7,40}$ ]] || {
+            echo "::error file=.github/vllm-main-verified.commit::invalid vLLM main commit: ${main_commit}"
+            exit 1
+          }
+          [[ "${release_tag}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+([.-].*)?$ ]] || {
+            echo "::error file=.github/vllm-release-tag.commit::invalid vLLM release tag: ${release_tag}"
+            exit 1
+          }
+          {
+            echo "main_commit=${main_commit}"
+            echo "release_tag=${release_tag}"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Select all tests
+        id: full-scope
+        run: |
+          pip install regex pyyaml
+          git config --global --add safe.directory "$GITHUB_WORKSPACE"
+          python3 .github/workflows/scripts/select_tests.py \
+            --changed-files vllm_ascend/dummy.py \
+            --run-all-modules
+
+      - name: Select A5 tests
+        id: scope-a5
+        run: |
+          pip install regex pyyaml
+          git config --global --add safe.directory "$GITHUB_WORKSPACE"
+          python3 .github/workflows/scripts/select_tests.py \
+            --changed-files vllm_ascend/dummy.py \
+            --modules a5 \
+            --runner-label-override linux-aarch64-a5-4
+
+  ensure-csrc-cache:
+    needs: select-all-tests
+    if: ${{ needs.select-all-tests.outputs.has_tests == 'true' }}
+    uses: ./.github/workflows/_ensure_csrc_cache.yaml
+    with:
+      target_ids: ${{ needs.select-all-tests.outputs.csrc_cache_target_ids }}
+      source_ref: ${{ needs.select-all-tests.outputs.vllm_ascend_ref }}
+      base_ref: ${{ needs.select-all-tests.outputs.base_ref }}
+      base_sha: ${{ needs.select-all-tests.outputs.base_sha }}
+
+  run-all-tests:
+    needs: [select-all-tests, ensure-csrc-cache]
+    if: ${{ needs.select-all-tests.outputs.has_tests == 'true' }}
+    strategy:
+      fail-fast: false
+      matrix:
+        vllm_version:
+          - ${{ needs.select-all-tests.outputs.main_commit }}
+          - ${{ needs.select-all-tests.outputs.release_tag }}
+    uses: ./.github/workflows/_selected_tests.yaml
+    with:
+      vllm: ${{ matrix.vllm_version }}
+      ref: ${{ needs.select-all-tests.outputs.vllm_ascend_ref }}
+      base_ref: ${{ needs.select-all-tests.outputs.base_ref }}
+      base_sha: ${{ needs.select-all-tests.outputs.base_sha }}
+      test_groups: ${{ needs.select-all-tests.outputs.test_groups }}
+
+  run-all-tests-upstream:
+    needs: [select-all-tests, ensure-csrc-cache]
+    if: ${{ needs.select-all-tests.outputs.has_tests == 'true' }}
+    strategy:
+      fail-fast: false
+      matrix:
+        vllm_version:
+          - ${{ needs.select-all-tests.outputs.main_commit }}
+          - ${{ needs.select-all-tests.outputs.release_tag }}
+    uses: ./.github/workflows/_selected_tests_upstream.yaml
+    with:
+      vllm: ${{ matrix.vllm_version }}
+      ref: ${{ needs.select-all-tests.outputs.vllm_ascend_ref }}
+      base_ref: ${{ needs.select-all-tests.outputs.base_ref }}
+      base_sha: ${{ needs.select-all-tests.outputs.base_sha }}
+      test_groups: ${{ needs.select-all-tests.outputs.test_groups }}
+
+  run-all-tests-a5:
+    needs: [select-all-tests, ensure-csrc-cache]
+    if: ${{ needs.select-all-tests.outputs.has_tests_a5 == 'true' }}
+    strategy:
+      fail-fast: false
+      matrix:
+        vllm_version:
+          - ${{ needs.select-all-tests.outputs.main_commit }}
+          - ${{ needs.select-all-tests.outputs.release_tag }}
+    uses: ./.github/workflows/_selected_tests.yaml
+    with:
+      vllm: ${{ matrix.vllm_version }}
+      ref: ${{ needs.select-all-tests.outputs.vllm_ascend_ref }}
+      base_ref: ${{ needs.select-all-tests.outputs.base_ref }}
+      base_sha: ${{ needs.select-all-tests.outputs.base_sha }}
+      test_groups: ${{ needs.select-all-tests.outputs.test_groups_a5 }}


### PR DESCRIPTION

### What this PR does / why we need it?

- pr_test only tests against the vLLM main commit
- Add schedule_all_e2e_test.yaml triggered by cron (Beijing 08/12/16/20), pull_request (verification only), and workflow_dispatch (third-party scheduler)
- Select all test modules via select_tests.py --run-all-modules, running the full e2e and upstream suites against both vLLM main commit and release tag
- Make the workflow branch-aware: workflow_dispatch accepts a vllm_ascend_branch input so future branch switches (e.g. releases/*) can be tested as-is

### Does this PR introduce _any_ user-facing change?

### How was this patch tested?


- vLLM version: v0.27.1
- vLLM main: https://github.com/vllm-project/vllm/commit/ba07e4a48fc951300d97eb506217dd530583dea3
