### PR TITLE
[CI] Move `MiniMax-M3-W8A8-A3` from nightly to weekly.

### DIFF
--- a/.github/workflows/configs/nightly_config.yaml
+++ b/.github/workflows/configs/nightly_config.yaml
@@ -177,9 +177,6 @@ a3:
       - name: MiniMax-M3-BF16-A3
         os: linux-aarch64-nightly-a3-16
         config_file_path: MiniMax-M3-BF16-A3.yaml
-      - name: MiniMax-M3-W8A8-A3
-        os: linux-aarch64-nightly-a3-16
-        config_file_path: MiniMax-M3-W8A8-A3.yaml
       - name: DeepSeek-V4-Flash-W8A8-A3
         os: linux-aarch64-nightly-a3-16
         config_file_path: DeepSeek-V4-Flash-W8A8-A3.yaml

--- a/.github/workflows/configs/weekly_config.yaml
+++ b/.github/workflows/configs/weekly_config.yaml
@@ -327,6 +327,9 @@ a3:
       - name: MiniMax-M2.5-w8a8
         os: linux-aarch64-a3-16
         config_file_path: MiniMax-M2.5-W8A8-A3.yaml
+      - name: MiniMax-M3-W8A8-A3
+        os: linux-aarch64-a3-16
+        config_file_path: MiniMax-M3-W8A8-A3.yaml
       - name: Qwen3-235B-A22B-W8A8_piecewise_fullgraph_A3
         os: linux-aarch64-a3-16
         config_file_path: Qwen3-235B-A22B-W8A8_piecewise_fullgraph_A3.yaml

--- a/.github/workflows/configs/weekly_config.yaml
+++ b/.github/workflows/configs/weekly_config.yaml
@@ -327,7 +327,7 @@ a3:
       - name: MiniMax-M2.5-w8a8
         os: linux-aarch64-a3-16
         config_file_path: MiniMax-M2.5-W8A8-A3.yaml
-      - name: MiniMax-M3-W8A8-A3
+      - name: MiniMax-M3-W8A8
         os: linux-aarch64-a3-16
         config_file_path: MiniMax-M3-W8A8-A3.yaml
       - name: Qwen3-235B-A22B-W8A8_piecewise_fullgraph_A3

--- a/tests/e2e/weekly/single_node/configs/MiniMax-M3-W8A8-A3.yaml
+++ b/tests/e2e/weekly/single_node/configs/MiniMax-M3-W8A8-A3.yaml
@@ -41,7 +41,7 @@ test_cases:
       - "--long-prefill-token-threshold"
       - "2048"
       - "--max-num-seqs"
-      - "16"
+      - "64"
       - "--distributed-executor-backend"
       - "mp"
       - "--reasoning-parser"
@@ -49,15 +49,11 @@ test_cases:
       - "--limit-mm-per-prompt"
       - '{"image":1}'
       - "--compilation-config"
-      - '{"cudagraph_mode": "FULL_DECODE_ONLY"}'
+      - '{"cudagraph_capture_sizes": [256], "cudagraph_mode": "FULL_DECODE_ONLY"}'
+      - "--speculative-config"
+      - '{"model": "Inferact/MiniMax-M3-EAGLE3-GQA", "method": "eagle3", "num_speculative_tokens": 3}'
       - "--additional-config"
-      - '{"enable_cpu_binding":true,"ascend_compilation_config":{"enable_static_kernel":false,"fuse_norm_quant":false},"multistream_overlap_shared_expert":true,"weight_nz_mode":2,"enable_shared_expert_dp": true,"enable_reduce_sample": true}'
-    test_content:
-      - chat_completion
-    api_keyword_args:
-      max_tokens: 10
-      chat_template_kwargs:
-        thinking_mode: disabled
+      - '{"enable_cpu_binding":true,"ascend_compilation_config":{"enable_static_kernel":true,"fuse_norm_quant":false},"multistream_overlap_shared_expert":true,"weight_nz_mode":2,"enable_shared_expert_dp": true,"enable_reduce_sample": true}'
     benchmarks:
       acc_gpqa:
         case_type: accuracy

--- a/tests/e2e/weekly/single_node/configs/MiniMax-M3-W8A8-A3.yaml
+++ b/tests/e2e/weekly/single_node/configs/MiniMax-M3-W8A8-A3.yaml
@@ -3,7 +3,7 @@
 # ==========================================
 
 test_cases:
-  - name: "MiniMax-M3-W8A8-A3"
+  - name: "MiniMax-M3-W8A8"
     model: "Eco-Tech/MiniMax-M3-w8a8-0626"
     envs:
       VLLM_NIXL_ABORT_REQUEST_TIMEOUT: "30000"


### PR DESCRIPTION
**What this PR does / why we need it?**
Moves `MiniMax-M3-W8A8-A3` from nightly to weekly.

This test enables `enable_static_kernel` and takes too long to run, significantly increasing nightly CI duration. Moving it to weekly reduces nightly CI overhead while keeping regular A3 coverage.

**Does this PR introduce any user-facing change?**
No.

**How was this patch tested?**
Verified it runs correctly under the weekly schedule.


- vLLM main: https://github.com/vllm-project/vllm/commit/ba07e4a48fc951300d97eb506217dd530583dea3
