### PR TITLE
[CI] Skip DSV4 DSpark e2e

### DIFF
--- a/tests/e2e/pull_request/four_card/spec_decode/test_dspark_deepseekv4.py
+++ b/tests/e2e/pull_request/four_card/spec_decode/test_dspark_deepseekv4.py
@@ -45,6 +45,7 @@ DSPARK_DYNAMIC_SPEC_CONFIG = {
 }
 
 
+@pytest.mark.skip(reason="Unstable e2e test, will fix it soon.")
 @pytest.mark.parametrize("model_name", MODELS)
 @pytest.mark.parametrize(
     ("golden", "num_speculative_tokens", "additional_config"),


### PR DESCRIPTION
### What this PR does / why we need it?
Skip unstable DeepSeek-V4 DSpark E2E test.

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?

- vLLM version: v0.27.1
- vLLM main: https://github.com/vllm-project/vllm/commit/ba07e4a48fc951300d97eb506217dd530583dea3
