### PR TITLE
[Doc][Misc] Align Kimi-K3 tutorial with the deployment template

### DIFF
--- a/docs/hooks/nav_titles.py
+++ b/docs/hooks/nav_titles.py
@@ -123,6 +123,7 @@ TITLES = {
     "tutorials/models/Kimi-K2-Thinking.md": {"en": "Kimi-K2-Thinking", "zh": "Kimi-K2-Thinking"},
     "tutorials/models/Kimi-K2.5.md": {"en": "Kimi-K2.5", "zh": "Kimi-K2.5"},
     "tutorials/models/Kimi-K2.6.md": {"en": "Kimi-K2.6", "zh": "Kimi-K2.6"},
+    "tutorials/models/Kimi-K3.md": {"en": "Kimi-K3", "zh": "Kimi-K3"},
     "tutorials/models/LLaVA-OneVision-Qwen2-0.5B-OV.md": {
         "en": "LLaVA-OneVision-Qwen2-0.5B-OV",
         "zh": "LLaVA-OneVision-Qwen2-0.5B-OV",

--- a/docs/source/tutorials/models/Kimi-K3.md
+++ b/docs/source/tutorials/models/Kimi-K3.md
@@ -26,8 +26,10 @@ This guide covers A3 W4A8 text and multimodal serving, TP/DP/EP, Prefix Cache,
 
 | Model | Purpose | Requirements |
 | --- | --- | --- |
-| [Kimi-K3-W4A8](https://www.modelscope.cn/models/sgl-npu/Kimi-K3-W4A8) | Full 93-layer, 896-expert target | About 1.49 TB of weight storage; the reference deployment uses four Atlas 800 A3 nodes with 16 logical NPUs per node (DP4/TP16/EP64) |
-| [Kimi-K3-DSpark](https://huggingface.co/RadixArk/Kimi-K3-DSpark) | Optional GQA draft for speculative decoding | Download separately; use a draft compatible with the target checkpoint and TP size |
+| [Eco-Tech/Kimi-K3-w4a8](https://www.modelscope.cn/models/Eco-Tech/Kimi-K3-w4a8) | Full 93-layer, 896-expert W4A8 target | About 1.49 TB of weight storage; the reference deployment uses four Atlas 800 A3 nodes with 16 logical NPUs per node (DP4/TP16/EP64) |
+| [RadixArk/Kimi-K3-DSpark](https://huggingface.co/RadixArk/Kimi-K3-DSpark) | Optional GQA draft | Set `num_speculative_tokens` to `7` |
+| [Inferact/Kimi-K3-DSpark](https://huggingface.co/Inferact/Kimi-K3-DSpark) | Optional MLA draft | Set `num_speculative_tokens` to `7` |
+| [Inferact/Kimi-K3-DSpark-Block5](https://huggingface.co/Inferact/Kimi-K3-DSpark-Block5) | Optional MLA draft with five-token blocks | Set `num_speculative_tokens` to `5` |
 
 Download weights, tokenizer, and processor files before starting the service.
 Mount them at identical paths on every node, for example under `/path/to/models`.
@@ -242,16 +244,20 @@ running the request in Section 6. For general startup issues, see the
 
 ### 5.2 Speculative Decoding with DSpark
 
-For the GQA path, a public draft checkpoint is
-[`RadixArk/Kimi-K3-DSpark`](https://huggingface.co/RadixArk/Kimi-K3-DSpark).
-For the MLA path, use a matching Kimi K3 MLA draft checkpoint. Add the same
-speculative configuration to the Node 0 and headless worker commands:
+Choose a GQA or MLA draft from the [model weights](#31-model-weights-and-hardware)
+listed in Section 3.1 and download it to the same path on every node.
+The following configuration uses seven speculative tokens for
+`RadixArk/Kimi-K3-DSpark` or `Inferact/Kimi-K3-DSpark`. For
+`Inferact/Kimi-K3-DSpark-Block5`, select that checkpoint's path and change
+`num_speculative_tokens` to `5`.
+
+Add the same speculative configuration to the Node 0 and headless worker commands:
 
 ```shell
 --speculative-config \
 '{
   "method": "dspark",
-  "model": "<MATCHING_GQA_OR_MLA_DRAFT_PATH>",
+  "model": "<DSPARK_DRAFT_PATH>",
   "num_speculative_tokens": 7,
   "draft_tensor_parallel_size": 16,
   "max_model_len": 4096,
@@ -345,9 +351,10 @@ not a claim of optimal throughput or latency for every workload.
 | --- | ---: | ---: | ---: | --- | ---: | ---: | ---: | --- |
 | Full W4A8, mixed prefill/decode | 4 A3 | 64 | 16 | 4 / 64 | 16 | 8192 | 133120 | `FULL_DECODE_ONLY` |
 
-Optional DSpark uses draft TP16, seven speculative tokens, and draft
-`max_model_len=4096`, as shown in Section 5.2. Account for its extra memory
-before enabling it.
+Optional DSpark uses draft TP16 and draft `max_model_len=4096`, as shown in
+Section 5.2. Use seven speculative tokens for the RadixArk GQA draft or the
+Inferact seven-token MLA draft, and five for `Inferact/Kimi-K3-DSpark-Block5`.
+Account for its extra memory before enabling it.
 
 ### 9.2 Tuning Guidelines
 
@@ -370,6 +377,7 @@ the [Public FAQ](../../faqs.md). This section covers K3-specific questions.
 ### Which checkpoint should I use with DSpark?
 
 Use a draft that matches the target architecture, tokenizer, and quantization
-variant. The public GQA draft is linked in Section 3.1; an MLA draft must be
-matched separately. For QuaRot checkpoints, retain the checkpoint's
-quantization metadata and bundled rotation tensors on every node.
+variant. Section 3.1 lists the RadixArk GQA draft and both Inferact MLA drafts,
+together with their `num_speculative_tokens` values. For QuaRot checkpoints,
+retain the checkpoint's quantization metadata and bundled rotation tensors on
+every node.

--- a/docs/source/tutorials/models/Kimi-K3.md
+++ b/docs/source/tutorials/models/Kimi-K3.md
@@ -2,14 +2,14 @@
 
 ## 1 Introduction
 
-Kimi K3 is a multimodal mixture-of-experts model that combines Kimi Delta
+Kimi-K3 is a multimodal mixture-of-experts model that combines Kimi Delta
 Attention (KDA), gated Multi-head Latent Attention (MLA), attention residuals,
 SiTU activations, and latent MoE layers.
 
 This tutorial covers model preparation, installation, online serving, and
 accuracy and performance evaluation for the full W4A8 checkpoint on Atlas A3.
 This tutorial is based on **vLLM-Ascend main with vLLM 0.27.1**. Use a
-main-branch build with Kimi K3 support and its matching vLLM revision.
+main-branch build with Kimi-K3 support and its matching vLLM revision.
 
 ## 2 Supported Features
 
@@ -24,12 +24,12 @@ This guide covers A3 W4A8 text and multimodal serving, TP/DP/EP, Prefix Cache,
 
 ### 3.1 Model Weights and Hardware
 
-| Model | Purpose | Requirements |
-| --- | --- | --- |
-| [Eco-Tech/Kimi-K3-w4a8](https://www.modelscope.cn/models/Eco-Tech/Kimi-K3-w4a8) | Full 93-layer, 896-expert W4A8 target | About 1.49 TB of weight storage; the reference deployment uses four Atlas 800 A3 nodes with 16 logical NPUs per node (DP4/TP16/EP64) |
-| [RadixArk/Kimi-K3-DSpark](https://huggingface.co/RadixArk/Kimi-K3-DSpark) | Optional GQA draft | Set `num_speculative_tokens` to `7` |
-| [Inferact/Kimi-K3-DSpark](https://huggingface.co/Inferact/Kimi-K3-DSpark) | Optional MLA draft | Set `num_speculative_tokens` to `7` |
-| [Inferact/Kimi-K3-DSpark-Block5](https://huggingface.co/Inferact/Kimi-K3-DSpark-Block5) | Optional MLA draft with five-token blocks | Set `num_speculative_tokens` to `5` |
+| Model | Download | Purpose | Requirements |
+| --- | --- | --- | --- |
+| Eco-Tech/Kimi-K3-w4a8 | [ModelScope](https://www.modelscope.cn/models/Eco-Tech/Kimi-K3-w4a8) | Full 93-layer, 896-expert W4A8 target | About 1.49 TB of weight storage; the reference deployment uses four Atlas 800 A3 nodes with 16 logical NPUs per node (DP4/TP16/EP64) |
+| RadixArk/Kimi-K3-DSpark | [ModelScope](https://www.modelscope.cn/models/RadixArk/Kimi-K3-DSpark) / [Hugging Face](https://huggingface.co/RadixArk/Kimi-K3-DSpark) | Optional GQA draft | Set `num_speculative_tokens` to `7` |
+| Inferact/Kimi-K3-DSpark | [ModelScope](https://www.modelscope.cn/models/Inferact/Kimi-K3-DSpark) / [Hugging Face](https://huggingface.co/Inferact/Kimi-K3-DSpark) | Optional MLA draft | Set `num_speculative_tokens` to `7` |
+| Inferact/Kimi-K3-DSpark-Block5 | [ModelScope](https://www.modelscope.cn/models/Inferact/Kimi-K3-DSpark-Block5) / [Hugging Face](https://huggingface.co/Inferact/Kimi-K3-DSpark-Block5) | Optional MLA draft with five-token blocks | Set `num_speculative_tokens` to `5` |
 
 Download weights, tokenizer, and processor files before starting the service.
 Mount them at identical paths on every node, for example under `/path/to/models`.
@@ -46,13 +46,16 @@ All nodes must use the same model revision and compatible software stack.
 
 ## 4 Installation
 
+The Kimi-K3 installation and deployment instructions in this tutorial apply
+only to the Atlas A3 series.
+
 ### 4.1 Docker Image Installation
 
 Follow the [installation requirements](../../installation.md#requirements) for
 the host driver and firmware. Start the A3 container below on every node.
 
 The example uses the main-branch nightly image for the vLLM 0.27-based stack.
-Check that the image includes Kimi K3 support and the matching vLLM version.
+Check that the image includes Kimi-K3 support and the matching vLLM version.
 Pin its digest for reproducible deployments.
 To build an image from the selected source revision, follow Section 4.2.
 
@@ -233,7 +236,7 @@ Key parameter descriptions:
   budget. Check capacity with the actual checkpoint before increasing sequence
   length, concurrency, or adding a draft.
 - `--tokenizer-mode kimi_k3`, `--reasoning-parser kimi_k3`, and
-  `--tool-call-parser kimi_k3` select the K3 request/response format.
+  `--tool-call-parser kimi_k3` select the Kimi-K3 request/response format.
   `--enable-auto-tool-choice` enables automatic tool selection.
 - `FULL_DECODE_ONLY` captures decode execution; `--enable-prefix-caching`
   enables reuse of cached prefixes.
@@ -330,9 +333,49 @@ comparing results across backends.
 
 ## 8 Performance Evaluation
 
-Use [AISBench performance evaluation](../../developer_guide/evaluation/using_ais_bench.md#execute-performance-evaluation)
-or the [vLLM benchmark tools](https://docs.vllm.ai/en/latest/benchmarking/)
-from a load generator in the serving network.
+### Using AISBench
+
+Refer to [AISBench performance evaluation](../../developer_guide/evaluation/using_ais_bench.md#execute-performance-evaluation)
+for configuration and execution instructions.
+
+### Using vLLM Benchmark
+
+After the service in Section 5.1 is ready, run the following from a load generator
+in the serving network with the same vLLM version and tokenizer files. Set
+`NODE0_IP` and `TOKENIZER_PATH` to the service address and local tokenizer path.
+
+```shell
+export NODE0_IP="<NODE0_IP>"
+export TOKENIZER_PATH="<KIMI_K3_TOKENIZER_PATH>"
+
+vllm bench serve \
+  --backend openai-chat \
+  --base-url "http://$NODE0_IP:8000" \
+  --endpoint /v1/chat/completions \
+  --model kimi-k3 \
+  --tokenizer "$TOKENIZER_PATH" \
+  --tokenizer-mode kimi_k3 \
+  --dataset-name random \
+  --random-input-len 1024 \
+  --random-output-len 128 \
+  --random-range-ratio 0.0 \
+  --num-prompts 100 \
+  --max-concurrency 4 \
+  --request-rate inf \
+  --ignore-eos \
+  --save-result \
+  --result-dir ./benchmark-results
+```
+
+This example measures 100 requests with at most four in flight, using random
+1024-token inputs and 128-token outputs. The chat format can add input tokens;
+`--ignore-eos` prevents early EOS from shortening the requested output length.
+`--request-rate inf` sends requests as soon as concurrency slots are available.
+Check that all 100 measured requests succeed and review throughput, TTFT, and
+TPOT in the console and saved JSON results. Adjust lengths and concurrency for
+the intended workload; this example is not a peak-performance configuration.
+See the [vLLM benchmark tools](https://docs.vllm.ai/en/latest/benchmarking/)
+for additional options.
 
 Record the checkpoint revision, topology, graph mode, Prefix Cache setting,
 input/output lengths, concurrency, completed requests, and error count together
@@ -372,7 +415,7 @@ general tuning methods.
 ## 10 FAQ
 
 For common environment, installation, and general parameter issues, refer to
-the [Public FAQ](../../faqs.md). This section covers K3-specific questions.
+the [Public FAQ](../../faqs.md). This section covers Kimi-K3-specific questions.
 
 ### Which checkpoint should I use with DSpark?
 

--- a/docs/source/tutorials/models/Kimi-K3.md
+++ b/docs/source/tutorials/models/Kimi-K3.md
@@ -1,80 +1,62 @@
-# Kimi K3
+# Kimi-K3
 
 ## 1 Introduction
 
 Kimi K3 is a multimodal mixture-of-experts model that combines Kimi Delta
 Attention (KDA), gated Multi-head Latent Attention (MLA), attention residuals,
-SiTU activations, and latent MoE layers. This guide describes the W4A8
-deployment validated by the Kimi K3 integration for the vLLM 0.27-based
-vLLM-Ascend branch.
+SiTU activations, and latent MoE layers.
 
-The full W4A8 checkpoint is approximately 1.49 TB. Download it from
-[ModelScope](https://www.modelscope.cn/models/sgl-npu/Kimi-K3-W4A8), or make it
-available from shared storage at the same path on every serving node.
+This tutorial covers model preparation, installation, online serving, and
+accuracy and performance evaluation for the full W4A8 checkpoint on Atlas A3.
+This tutorial is based on **vLLM-Ascend main with vLLM 0.27.1**. Use a
+main-branch build with Kimi K3 support and its matching vLLM revision.
 
-## 2 Supported and Validated Features
+## 2 Supported Features
 
-The integration contains the following model paths. The table distinguishes
-runtime validation from implementation-only coverage.
+Refer to the [Supported Models](../../user_guide/support_matrix/supported_models.md)
+for the model support matrix and the
+[Feature Guide](../../user_guide/feature_guide/index.md) for feature configuration.
 
-| Capability | Status in this integration |
-| --- | --- |
-| Text and multimodal serving | Validated on Atlas A3 |
-| TP16 with expert parallelism | Validated on one and multiple nodes |
-| `FULL_DECODE_ONLY` ACL Graph | Validated |
-| Prefix Cache and hybrid KDA/MLA state | Validated |
-| Prefill-Decode disaggregation | Validated on two nodes |
-| GQA and MLA DSpark adapters | Supported with a matching draft checkpoint; see Section 6 |
-| MTP adapter | Implemented; validate the target and draft checkpoint pair separately |
-| Atlas A5 SiTU MX quantization | Cross-built; target-hardware execution is still required |
+This guide covers A3 W4A8 text and multimodal serving, TP/DP/EP, Prefix Cache,
+`FULL_DECODE_ONLY` ACL Graph, and DSpark with a matching draft checkpoint.
 
-Refer to the [supported features](../../user_guide/support_matrix/supported_features.md)
-for the project-wide feature matrix.
+## 3 Prerequisites
 
-## 3 Choosing a Checkpoint
+### 3.1 Model Weights and Hardware
 
-Kimi K3 checkpoints serve different validation purposes. A reduced
-checkpoint must not be used to report GPQA or other semantic accuracy.
+| Model | Purpose | Requirements |
+| --- | --- | --- |
+| [Kimi-K3-W4A8](https://www.modelscope.cn/models/sgl-npu/Kimi-K3-W4A8) | Full 93-layer, 896-expert target | About 1.49 TB of weight storage; the reference deployment uses four Atlas 800 A3 nodes with 16 logical NPUs per node (DP4/TP16/EP64) |
+| [Kimi-K3-DSpark](https://huggingface.co/RadixArk/Kimi-K3-DSpark) | Optional GQA draft for speculative decoding | Download separately; use a draft compatible with the target checkpoint and TP size |
 
-| Checkpoint | Typical storage | What it can validate | What it cannot validate |
-| --- | ---: | --- | --- |
-| Full 93-layer, 896-expert W4A8 | About 1.49 TB | Deployment and benchmark accuracy | Not applicable |
-| Full 93-layer, 16-expert derivative | About 113 GB | Single-node integration and long-context execution | Full-model semantics and full expert routing |
-| Five-layer, 16-expert W4A8 derivative | About 12.1 GiB | Real quantized loading, KDA/MLA/MoE execution, graph and cache parity | Full-depth behavior and benchmark accuracy |
+Download weights, tokenizer, and processor files before starting the service.
+Mount them at identical paths on every node, for example under `/path/to/models`.
+The weight size is a storage requirement, not an estimate of runtime NPU memory;
+KV cache, activations, communication buffers, and the optional draft also need
+memory.
 
-For a storage-limited real-weight validation checkpoint, derive the five-layer,
-16-expert checkpoint from the W4A8 checkpoint as follows:
+### 3.2 Verify Multi-Node Communication
 
-1. Keep tokenizer and configuration metadata.
-1. Keep all non-expert tensors needed by the first five layers.
-1. Keep routed experts 0 through 15 in those layers and rewrite the Safetensors
-   index without renaming tensors.
-1. Set `num_hidden_layers`, `num_experts`, and `num_experts_per_token` to 5,
-   16, and 16 respectively. Keep KDA layers 1, 2, 3, and 5, and MLA layer 4.
-1. Load the result with `--quantization ascend` and record deterministic token
-   and log-probability parity. Do not create a task-accuracy baseline from it.
-
-:::{note}
-The reduced checkpoint is a validation artifact, not a model release. Keep the source
-checkpoint revision and a manifest of retained tensors with the artifact so
-that it can be reproduced when the quantized weights change.
-:::
+Before launching the four-node service, follow
+[Verify Multi-Node Communication](../../installation.md#verify-multi-node-communication).
+Use a reachable address and the correct communication interface on each node.
+All nodes must use the same model revision and compatible software stack.
 
 ## 4 Installation
 
-Use an Atlas A3 image containing the vLLM version pinned by this release and
-the matching vLLM-Ascend build. Mount the checkpoint at the same path on all
-nodes.
+### 4.1 Docker Image Installation
 
-For multi-node serving, first follow the
-[multi-node communication check](../../installation.md#verify-multi-node-communication).
-The commands below cover the A3 configurations validated for this integration.
-The A2 deployment from the vLLM-Ascend 0.23 guide is not carried forward as a
-validated main-branch configuration until it is rerun with the current runtime.
+Follow the [installation requirements](../../installation.md#requirements) for
+the host driver and firmware. Start the A3 container below on every node.
+
+The example uses the main-branch nightly image for the vLLM 0.27-based stack.
+Check that the image includes Kimi K3 support and the matching vLLM version.
+Pin its digest for reproducible deployments.
+To build an image from the selected source revision, follow Section 4.2.
 
 ```shell
-export IMAGE=<VLLM_ASCEND_A3_IMAGE>
-export MODEL_ROOT=<HOST_MODEL_ROOT>
+export IMAGE=quay.io/ascend/vllm-ascend:nightly-main-a3
+export MODEL_ROOT="/path/to/models"
 
 docker run --rm -it \
   --name vllm-kimi-k3 \
@@ -101,6 +83,8 @@ docker run --rm -it \
   --device /dev/hisi_hdc \
   -v /usr/local/dcmi:/usr/local/dcmi \
   -v /usr/local/Ascend/driver:/usr/local/Ascend/driver \
+  -v /usr/local/bin/npu-smi:/usr/local/bin/npu-smi \
+  -v /etc/ascend_install.info:/etc/ascend_install.info \
   -v "$MODEL_ROOT:$MODEL_ROOT" \
   "$IMAGE" bash
 ```
@@ -108,50 +92,36 @@ docker run --rm -it \
 Verify the installed revisions before starting the service:
 
 ```shell
-python -c "import vllm, vllm_ascend; print(vllm.__version__, vllm_ascend.__version__)"
+python -m pip show vllm vllm-ascend
 ```
 
-## 5 Single-Node Functional Deployment
+### 4.2 Source Code Installation
 
-Use a full-depth 16-expert derivative for single-node functional testing. It
-preserves every transformer layer but is not semantically equivalent to the
-full 896-expert checkpoint.
+To build the A3 image from source, run the following on an A3 build host.
+The Dockerfile installs the matching CANN/PyTorch/TorchNPU stack and compiles
+the Ascend operators; `VLLM_COMMIT` selects the upstream revision verified for
+the chosen vLLM-Ascend checkout.
 
 ```shell
-export MODEL_PATH=<KIMI_K3_93_LAYER_16_EXPERT_PATH>
-export TOKENIZER_PATH=<KIMI_K3_TOKENIZER_PATH>
-export ASCEND_RT_VISIBLE_DEVICES=0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15
-export PYTORCH_NPU_ALLOC_CONF=expandable_segments:True
-export HCCL_OP_EXPANSION_MODE=AIV
-export HCCL_BUFFSIZE=1024
-export HCCL_BUFFSIZE_EP=2048
-export OMP_PROC_BIND=false
-export OPENBLAS_NUM_THREADS=1
-
-vllm serve "$MODEL_PATH" \
-  --host 0.0.0.0 \
-  --port 8000 \
-  --served-model-name kimi-k3 \
-  --tokenizer "$TOKENIZER_PATH" \
-  --quantization ascend \
-  --safetensors-load-strategy lazy \
-  --tensor-parallel-size 16 \
-  --enable-expert-parallel \
-  --enable-prefix-caching \
-  --max-model-len 133120 \
-  --max-num-seqs 16 \
-  --max-num-batched-tokens 8192 \
-  --gpu-memory-utilization 0.85 \
-  --reasoning-parser kimi_k3 \
-  --tool-call-parser kimi_k3 \
-  --compilation-config '{"cudagraph_mode":"FULL_DECODE_ONLY"}'
+git clone --branch main https://github.com/vllm-project/vllm-ascend.git
+cd vllm-ascend
+git submodule update --init --recursive
+docker build -f Dockerfile.a3 \
+  --build-arg VLLM_COMMIT="$(cat .github/vllm-main-verified.commit)" \
+  -t vllm-ascend-kimi-k3:main .
+export IMAGE=vllm-ascend-kimi-k3:main
 ```
 
-Lower `--max-model-len` and `--max-num-batched-tokens` for a short smoke test.
-The larger values above require a capacity check with the exact checkpoint and
-runner memory configuration.
+Use the resulting image on every node with the container command in Section 4.1,
+replacing its `IMAGE` value. Record the source revision and image digest.
+For an installation outside Docker, follow the
+[source installation guide](../../installation.md#set-up-using-python), using
+the selected main checkout and its verified vLLM commit instead of the older
+release versions in the generic examples.
 
-## 6 Four-Node Full-Checkpoint Deployment
+## 5 Online Service Deployment
+
+### 5.1 Four-Node Online Deployment
 
 The full checkpoint uses four Atlas 800 A3 nodes in a DP4/TP16/EP64 mixed
 deployment. Start Node 0 first. Each worker owns one global DP rank and joins
@@ -160,11 +130,11 @@ Node 0 through the DP RPC address.
 Set these variables on every node:
 
 ```shell
-export MODEL_PATH=<KIMI_K3_FULL_W4A8_PATH>
-export TOKENIZER_PATH=<KIMI_K3_TOKENIZER_PATH>
-export LOCAL_IP=<CURRENT_NODE_IP>
-export NODE0_IP=<NODE0_IP>
-export NIC_NAME=<CURRENT_NODE_NIC>
+export MODEL_PATH="<KIMI_K3_FULL_W4A8_PATH>"
+export TOKENIZER_PATH="<KIMI_K3_TOKENIZER_PATH>"
+export LOCAL_IP="<CURRENT_NODE_IP>"
+export NODE0_IP="<NODE0_IP>"
+export NIC_NAME="<CURRENT_NODE_NIC>"
 export SERVICE_PORT=8000
 export RPC_PORT=13345
 export DP_SIZE=4
@@ -195,6 +165,7 @@ vllm serve "$MODEL_PATH" \
   --port $SERVICE_PORT \
   --served-model-name kimi-k3 \
   --tokenizer "$TOKENIZER_PATH" \
+  --tokenizer-mode kimi_k3 \
   --quantization ascend \
   --safetensors-load-strategy lazy \
   --tensor-parallel-size $TP_SIZE \
@@ -210,13 +181,14 @@ vllm serve "$MODEL_PATH" \
   --gpu-memory-utilization 0.85 \
   --reasoning-parser kimi_k3 \
   --tool-call-parser kimi_k3 \
+  --enable-auto-tool-choice \
   --compilation-config '{"cudagraph_mode":"FULL_DECODE_ONLY"}'
 ```
 
 Run on Nodes 1 through 3. Set `DP_START_RANK` to 1, 2, or 3 respectively:
 
 ```shell
-export DP_START_RANK=<1_OR_2_OR_3>
+export DP_START_RANK="<1_OR_2_OR_3>"
 
 vllm serve "$MODEL_PATH" \
   --headless \
@@ -224,6 +196,7 @@ vllm serve "$MODEL_PATH" \
   --port $SERVICE_PORT \
   --served-model-name kimi-k3 \
   --tokenizer "$TOKENIZER_PATH" \
+  --tokenizer-mode kimi_k3 \
   --quantization ascend \
   --safetensors-load-strategy lazy \
   --tensor-parallel-size $TP_SIZE \
@@ -240,10 +213,34 @@ vllm serve "$MODEL_PATH" \
   --gpu-memory-utilization 0.85 \
   --reasoning-parser kimi_k3 \
   --tool-call-parser kimi_k3 \
+  --enable-auto-tool-choice \
   --compilation-config '{"cudagraph_mode":"FULL_DECODE_ONLY"}'
 ```
 
-### 6.1 Enabling DSpark
+Key parameter descriptions:
+
+- `--data-parallel-size 4` and `--data-parallel-size-local 1` create one DP
+  rank per node. `--tensor-parallel-size 16` uses all 16 local logical NPUs;
+  `--enable-expert-parallel` distributes experts across the 64-rank EP group.
+- `--data-parallel-start-rank` identifies each worker's global DP rank.
+  `--headless` workers join Node 0 without serving a separate HTTP endpoint.
+- `--max-model-len` bounds input plus output tokens;
+  `--max-num-batched-tokens` bounds tokens scheduled per iteration, and
+  `--max-num-seqs` bounds concurrent sequences per engine.
+- `--gpu-memory-utilization` controls the model executor's device-memory
+  budget. Check capacity with the actual checkpoint before increasing sequence
+  length, concurrency, or adding a draft.
+- `--tokenizer-mode kimi_k3`, `--reasoning-parser kimi_k3`, and
+  `--tool-call-parser kimi_k3` select the K3 request/response format.
+  `--enable-auto-tool-choice` enables automatic tool selection.
+- `FULL_DECODE_ONLY` captures decode execution; `--enable-prefix-caching`
+  enables reuse of cached prefixes.
+
+Wait for all ranks to finish weight loading and graph compilation before
+running the request in Section 6. For general startup issues, see the
+[Public FAQ](../../faqs.md).
+
+### 5.2 Speculative Decoding with DSpark
 
 For the GQA path, a public draft checkpoint is
 [`RadixArk/Kimi-K3-DSpark`](https://huggingface.co/RadixArk/Kimi-K3-DSpark).
@@ -263,98 +260,17 @@ speculative configuration to the Node 0 and headless worker commands:
 }'
 ```
 
-The example uses seven draft tokens, so each proposal cycle contains seven
-draft steps followed by one target-model verification step. Set
-`draft_tensor_parallel_size` to the topology used to shard the draft model.
+The example proposes seven draft tokens in one query block, followed by
+target-model verification.
+Set `draft_tensor_parallel_size` to the topology used to shard the draft model.
 
-K3 cache grouping is derived from the target and draft layer layouts rather
-than a hard-coded TP16 layout. The grouping contracts cover TP8 and TP16, but
-the full-checkpoint deployment documented above was validated with TP16. For a
-different TP size, first verify that both checkpoints' head and hidden
-dimensions are divisible by that TP size, then rerun the functional and
-accuracy checks in Sections 8 and 9.
+## 6 Functional Verification
 
-## 7 Two-Node Prefill-Decode Deployment
-
-The functional Prefill-Decode (P/D) check uses one 16-NPU A3 Prefill node and
-one 16-NPU A3 Decode node. Both engines use TP16/EP and the same checkpoint,
-tokenizer, KDA/MLA cache layout, and model revision. Install Mooncake and check
-the data-plane network as described in the
-[multi-node Mooncake guide](../features/pd_disaggregation_mooncake_multi_node.md).
-
-Use these K3-specific settings in addition to the common model and environment
-arguments from Section 5:
-
-| Setting | Prefill | Decode |
-| --- | --- | --- |
-| Parallelism | TP16/EP | TP16/EP |
-| Execution mode | `--enforce-eager` | `FULL_DECODE_ONLY` |
-| Hybrid state layout | `--mamba-cache-mode align` | `--mamba-cache-mode align` |
-| KV role | `kv_producer` | `kv_consumer` |
-| Prefix Cache | Enabled | Enabled |
-
-Add the following arguments to the Prefill service. Select a `kv_port` outside
-Mooncake's reserved AscendDirectTransport range; for a 16-NPU node, use a port
-of at least 36000.
+Once all four nodes have completed model loading and graph compilation, send
+a request to the Node 0 service from a host in the serving network.
 
 ```shell
---enforce-eager \
---mamba-cache-mode align \
---kv-transfer-config \
-'{
-  "kv_connector": "MooncakeConnectorV1",
-  "kv_role": "kv_producer",
-  "kv_port": "<PREFILL_KV_PORT>",
-  "kv_connector_extra_config": {
-    "prefill": {"dp_size": 1, "tp_size": 16},
-    "decode": {"dp_size": 1, "tp_size": 16}
-  }
-}'
-```
-
-Add the following arguments to the Decode service:
-
-```shell
---mamba-cache-mode align \
---compilation-config '{"cudagraph_mode":"FULL_DECODE_ONLY"}' \
---kv-transfer-config \
-'{
-  "kv_connector": "MooncakeConnectorV1",
-  "kv_role": "kv_consumer",
-  "kv_port": "<DECODE_KV_PORT>",
-  "kv_connector_extra_config": {
-    "prefill": {"dp_size": 1, "tp_size": 16},
-    "decode": {"dp_size": 1, "tp_size": 16}
-  }
-}'
-```
-
-Start the standard Mooncake proxy with the Prefill and Decode endpoints, then
-send requests to the proxy rather than directly to an engine:
-
-```shell
-python examples/disaggregated_prefill_v1/load_balance_proxy_server_example.py \
-  --host 0.0.0.0 \
-  --port 9000 \
-  --prefiller-hosts <PREFILL_HOST> \
-  --prefiller-ports <PREFILL_SERVICE_PORT> \
-  --decoder-hosts <DECODE_HOST> \
-  --decoder-ports <DECODE_SERVICE_PORT>
-```
-
-The proxy CLI may evolve with the shared P/D implementation. Treat the linked
-Mooncake guide and `--help` output from the checked-out revision as
-authoritative for proxy-only arguments. Do not change the K3 model, tokenizer,
-TP size, or hybrid cache mode between the two engines.
-
-## 8 Functional Verification
-
-Run request generation inside the serving environment or its trusted service
-network. Avoid sending a large benchmark load across a developer workstation
-or VPN.
-
-```shell
-curl http://<NODE0_IP>:8000/v1/chat/completions \
+curl "http://$NODE0_IP:8000/v1/chat/completions" \
   -H 'Content-Type: application/json' \
   -d '{
     "model": "kimi-k3",
@@ -362,15 +278,13 @@ curl http://<NODE0_IP>:8000/v1/chat/completions \
       {"role": "user", "content": "Explain why prefix caching helps repeated long prompts."}
     ],
     "temperature": 0,
-    "max_tokens": 128,
-    "logprobs": true
+    "max_tokens": 128
   }'
 ```
 
-The response must be HTTP 200, contain one non-null choice, and contain the
-requested number of finite token log probabilities unless generation reaches a
-configured stop token. Repeat an identical prompt and confirm that Prefix Cache
-metrics increase without changing deterministic output tokens.
+Expected result: HTTP 200 with a JSON response containing a non-null choice and
+generated text. Generation may stop before `max_tokens` when a stop token is
+reached.
 
 For a multimodal smoke test, replace the message content with an image and a
 text instruction:
@@ -385,61 +299,77 @@ text instruction:
 }
 ```
 
-Run concurrency and benchmark requests from a host inside the trusted serving
-network. A developer workstation or VPN should be used only for bounded smoke
-requests.
+For automatic tool selection, keep `--enable-auto-tool-choice` and
+`--tool-call-parser kimi_k3` in the startup command and include `tools` and
+`tool_choice: "auto"` in the chat request.
 
-## 9 Accuracy Validation
+## 7 Accuracy Evaluation
 
-Use the following validation ladder:
+Use the full 93-layer, 896-expert checkpoint with the four-node service in
+Section 5.1.
 
-1. Use a reduced W4A8 checkpoint for execution validation. Compare cold
-   prefill, a Prefix Cache hit that leaves exactly one token to prefill, and
-   a post-reset cold run. Check deterministic output tokens, close and finite
-   chosen-token log probabilities, complete outputs, and `FULL_DECODE_ONLY`
-   replay.
-1. Run GPQA with the full 93-layer, 896-expert checkpoint on the four-node
-   deployment. This is the semantic accuracy gate and cannot be replaced by
-   a reduced checkpoint.
+### Using AISBench
 
-Keep the model revision, tokenizer, chat rendering, reasoning mode, sampling
-parameters, dataset revision, and evaluator revision fixed when comparing
-GPQA results. Record completed, failed, missing, and unparsed samples in
-addition to the final score. Refer to [AISBench](../../developer_guide/evaluation/using_ais_bench.md)
-or [lm_eval](../../developer_guide/evaluation/using_lm_eval.md) for evaluator
-setup.
+Follow [Using AISBench](../../developer_guide/evaluation/using_ais_bench.md) to
+configure the `kimi-k3` chat-completions endpoint and run GPQA. Keep the model
+and tokenizer revisions, chat rendering, reasoning mode, sampling parameters,
+dataset, and evaluator revisions fixed when comparing results. Record completed,
+failed, missing, and unparsed samples alongside the score.
 
-## 10 Performance Evaluation
+### Using Language Model Evaluation Harness
 
-Use [AISBench](../../developer_guide/evaluation/using_ais_bench.md) or the
-[vLLM benchmark tools](https://docs.vllm.ai/en/latest/benchmarking/) from a
-server-side load-generator environment. Record the checkpoint revision,
-topology, graph mode, Prefix Cache setting, input/output lengths, concurrency,
-completed requests, and error count together with throughput and latency.
+See [Using lm_eval](../../developer_guide/evaluation/using_lm_eval.md) for
+evaluator setup. Use the same full checkpoint and serving configuration when
+comparing results across backends.
 
-Reduced checkpoints are useful for execution and scaling comparisons, but
-their throughput is not representative of the full 896-expert model.
+## 8 Performance Evaluation
 
-## 11 FAQ
+Use [AISBench performance evaluation](../../developer_guide/evaluation/using_ais_bench.md#execute-performance-evaluation)
+or the [vLLM benchmark tools](https://docs.vllm.ai/en/latest/benchmarking/)
+from a load generator in the serving network.
 
-### The service returns an incomplete or null choice
+Record the checkpoint revision, topology, graph mode, Prefix Cache setting,
+input/output lengths, concurrency, completed requests, and error count together
+with throughput and latency. Report cold-prefix and prefix-hit workloads
+separately. With DSpark, also record the draft checkpoint and speculative-token
+count.
 
-First check every rank log for a worker abort, a non-finite tensor, or a graph
-replay failure. Then repeat the same deterministic request with log
-probabilities and verify that every generated token has a finite chosen-token
-log probability. An HTTP 200 response alone is not a sufficient pass condition.
+## 9 Performance Tuning
 
-### A Prefix Cache hit fails only at block-size plus one token
+### 9.1 Reference Configuration
 
-Use a prompt that leaves exactly one uncached token after a full cached block.
-Compare its output tokens and chosen-token log probabilities against a cold
-prefill and a post-reset cold run in the same model instance. This exercises
-the one-token prefill classification without conflating it with decode.
+The following is the configuration used by the full-checkpoint commands above,
+not a claim of optimal throughput or latency for every workload.
 
-### P/D starts but requests hang
+| Deployment | Nodes | Total logical NPUs | TP per DP rank | Global DP / EP | Max Num Seqs per Engine | Max Num Batched Tokens | Max Model Len | Graph Mode |
+| --- | ---: | ---: | ---: | --- | ---: | ---: | ---: | --- |
+| Full W4A8, mixed prefill/decode | 4 A3 | 64 | 16 | 4 / 64 | 16 | 8192 | 133120 | `FULL_DECODE_ONLY` |
 
-Verify that both engines use `--mamba-cache-mode align`, the same model
-revision and TP size, complementary Mooncake roles, reachable non-overlapping
-KV ports, and topology values matching the actual Prefill and Decode groups.
-Check both engine logs and the proxy response; engine health alone does not
-prove hybrid KDA/MLA state transfer.
+Optional DSpark uses draft TP16, seven speculative tokens, and draft
+`max_model_len=4096`, as shown in Section 5.2. Account for its extra memory
+before enabling it.
+
+### 9.2 Tuning Guidelines
+
+| Goal | Parameters to evaluate | Check before adopting a change |
+| --- | --- | --- |
+| Higher throughput | Increase `--max-num-seqs` or `--max-num-batched-tokens` gradually | Memory headroom, completed requests, and tail latency |
+| Lower latency | Compare the baseline with a matching DSpark draft | End-to-end latency, draft acceptance, and accuracy on the same workload |
+| Longer context | Adjust `--max-model-len` together with concurrency and the token budget | Target/draft compatibility and available hybrid KV-cache capacity |
+| Repeated prompts | Enable Prefix Cache and compare cold and cached requests separately | Cache-hit metrics and output correctness |
+
+Refer to the [public performance tuning guide](../../developer_guide/performance_and_debug/optimization_and_tuning.md)
+and [feature matrix](../../user_guide/support_matrix/feature_matrix.md) for
+general tuning methods.
+
+## 10 FAQ
+
+For common environment, installation, and general parameter issues, refer to
+the [Public FAQ](../../faqs.md). This section covers K3-specific questions.
+
+### Which checkpoint should I use with DSpark?
+
+Use a draft that matches the target architecture, tokenizer, and quantization
+variant. The public GQA draft is linked in Section 3.1; an MLA draft must be
+matched separately. For QuaRot checkpoints, retain the checkpoint's
+quantization metadata and bundled rotation tensors on every node.

--- a/docs/source/tutorials/models/index.md
+++ b/docs/source/tutorials/models/index.md
@@ -1,5 +1,3 @@
 # Model Tutorials
 
 This section provides tutorials for different models of vLLM Ascend.
-
-- [Kimi K3](Kimi-K3.md)

--- a/docs/source/user_guide/support_matrix/supported_models.md
+++ b/docs/source/user_guide/support_matrix/supported_models.md
@@ -132,6 +132,7 @@ Get the latest info here: <https://github.com/vllm-project/vllm-ascend/issues/16
     | Qwen3.6-35B-A3B                     | 🔵      |      | ✅  | A2/A3              | ✅ | ✅ | ✅ |  | 🔵 | ✅ | ✅ |  | ✅ | ✅ | ❌ | ✅ | ✅ | 262144 | [Qwen3.6-35B-A3B](../../tutorials/models/Qwen3.6-35B-A3B.md) |
     | Qwen3-Omni-30B-A3B-Thinking         | 🔵      |      |      | A2/A3              |  |  |  |  |  |  | ✅ |  | ✅ |  |  |  |  |  | [Qwen3-Omni-30B-A3B-Thinking](../../tutorials/models/Qwen3-Omni-30B-A3B-Thinking.md) |
     | Kimi-K2.5/Kimi-K2.6                 | 🔵      |      |      | A2/A3              |  | ✅ | ✅ |  | ✅ | ✅ | ✅ |  | ✅ | ✅ | ✅ | ✅ | ✅ | 262144 | [Kimi-K2.5](../../tutorials/models/Kimi-K2.5.md)/[Kimi-K2.6](../../tutorials/models/Kimi-K2.6.md) |
+    | Kimi-K3                             | 🔵      | W4A8; DSpark; FULL_DECODE_ONLY |      | A3 |  |  | ✅ |  | ✅ |  | ✅ |  | ✅ | ✅ |  |  | ✅ |  | [Kimi-K3](../../tutorials/models/Kimi-K3.md) |
     | MiniMax-M3                          | 🔵      | Text, image, video, and ViT DP | ✅ | A2/A3 | ✅ | ✅ | ✅ | ❌ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ❌ | ❌ | ✅ | 1M | [MiniMax-M3](../../tutorials/models/MiniMax-M3.md) |
     | Cohere Transcribe                  | 🔵      | 2B Conformer encoder-decoder ASR, 14 languages (03-2026 & arabic-07-2026) | ✅ | A2/A3 | ❌ |  |  | ❌ | ❌ |  | 🟡 |  |  |  | ❌ | 🟡 | 🟡 |  | [Cohere-Transcribe](../../tutorials/models/Cohere-Transcribe.md) |
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -214,6 +214,7 @@ nav:
         - tutorials/models/Kimi-K2-Thinking.md
         - tutorials/models/Kimi-K2.5.md
         - tutorials/models/Kimi-K2.6.md
+        - tutorials/models/Kimi-K3.md
         - tutorials/models/PaddleOCR-VL.md
         - tutorials/models/MiniMax-M2.md
         - tutorials/models/MiniMax-M3.md


### PR DESCRIPTION
### What this PR does / why we need it?

Follow up on #14454 to align the Kimi-K3 documentation with the model deployment tutorial template and the existing Kimi, DeepSeek, and Qwen tutorials.

- Add Kimi-K3 to the MkDocs model navigation and bilingual title mapping, and restore the generic model tutorial overview.
- Add a conservative A3 W4A8 entry to the supported-model matrix and link the tutorial to the shared model/feature guides.
- Organize the tutorial into the standard ten sections, including prerequisites, installation, full-checkpoint deployment, functional verification, accuracy/performance evaluation, tuning, and FAQ.
- Document the Atlas A3-only installation scope, main-branch A3 image, and source-build path using the verified upstream vLLM revision; add key serving-parameter explanations and a reference configuration table.
- Provide ModelScope links for the Eco-Tech W4A8 target, RadixArk GQA draft, and both Inferact MLA drafts. Retain the draft Hugging Face links and their respective seven- or five-token settings.
- Correct the DSpark block-drafting explanation and include the Kimi-K3 tokenizer mode and automatic tool-selection option in the serving examples.
- Add a `vllm bench serve` command for the configured chat endpoint, with explicit tokenizer, input/output lengths, request count, concurrency, and saved results. Keep the tutorial limited to the standard deployment-template sections.

### Does this PR introduce _any_ user-facing change?

No runtime behavior changes. This is a documentation-only update.

### How was this patch tested?

- `bash format.sh ci`: all hooks passed.
- `bash tools/rtd_build.sh`: full English MkDocs build passed in strict mode.
- `PYTHONPATH=. python -m pytest --noconftest -o addopts= -q tests/ut/test_dependency_documentation.py tests/ut/_tools/test_docs_codegen.py tests/ut/_tools/test_generate_zh_docs.py`: 25 tests and 19 subtests passed. These documentation-only tests do not require the shared NPU test setup.
- Checked the rendered tutorial's ten section headings, navigation order, supported-model table columns, and 199 local links/anchors. Parsed all nine shell blocks with `bash -n` and all five embedded JSON payloads.
- Verified that all 16 benchmark flags exist in the pinned vLLM command-line parser. The benchmark itself was not run against an NPU service.
- Verified the three draft ModelScope repositories are accessible, their configs match the Hugging Face versions, and the published weight SHA256 values and sizes match.
- `git diff --check`: passed.

No NPU serving, model accuracy, or performance tests were run for this documentation-only change. The hardware topology and capacity settings are retained from the existing full-checkpoint example; the tuning table does not claim a new performance result.

- vLLM main: https://github.com/vllm-project/vllm/commit/ba07e4a48fc951300d97eb506217dd530583dea3
