### PR TITLE
[CI] offline dspark e2e

### DIFF
--- a/tests/e2e/pull_request/four_card/spec_decode/test_dspark_deepseekv4.py
+++ b/tests/e2e/pull_request/four_card/spec_decode/test_dspark_deepseekv4.py
@@ -73,6 +73,7 @@ DSPARK_DYNAMIC_SPEC_CONFIG = {
         ),
     ],
 )
+@pytest.mark.skip(reason="Temporarily brought offline. The cases of speculative decoding need to be rectified later.")
 @patch.dict(os.environ, {"HCCL_BUFFSIZE": "1024"})
 def test_deepseek_v4_dspark_acceptance_tp4(
     model_name,

--- a/tests/e2e/pull_request/four_card/spec_decode/test_dspark_deepseekv4.py
+++ b/tests/e2e/pull_request/four_card/spec_decode/test_dspark_deepseekv4.py
@@ -45,6 +45,7 @@ DSPARK_DYNAMIC_SPEC_CONFIG = {
 }
 
 
+@pytest.mark.skip(reason="Temporarily brought offline. The cases of speculative decoding need to be rectified later.")
 @pytest.mark.parametrize("model_name", MODELS)
 @pytest.mark.parametrize(
     ("golden", "num_speculative_tokens", "additional_config"),
@@ -73,7 +74,6 @@ DSPARK_DYNAMIC_SPEC_CONFIG = {
         ),
     ],
 )
-@pytest.mark.skip(reason="Temporarily brought offline. The cases of speculative decoding need to be rectified later.")
 @patch.dict(os.environ, {"HCCL_BUFFSIZE": "1024"})
 def test_deepseek_v4_dspark_acceptance_tp4(
     model_name,


### PR DESCRIPTION
### What this PR does / why we need it?
Temporarily brought offline. The cases of speculative decoding need to be rectified later.

### Does this PR introduce _any_ user-facing change?
no

### How was this patch tested?

- vLLM version: v0.27.1
- vLLM main: https://github.com/vllm-project/vllm/commit/ba07e4a48fc951300d97eb506217dd530583dea3
