### PR TITLE
[BugFix] Handle non-PEP 440 CANN version strings in SFA prolog_v3 check

### DIFF
--- a/vllm_ascend/attention/sfa_v1.py
+++ b/vllm_ascend/attention/sfa_v1.py
@@ -683,9 +683,12 @@ class AscendSFAImpl(MLAAttentionImpl):
         # npu_mla_prolog_v3 depends on CANN 9.1 and is not available in the current community CANN 9.0.
         cann_version = getattr(torch.version, "cann", None)
         if cann_version is not None:
-            from packaging.version import Version
+            # CANN version strings (e.g. "9.2.T530") are not PEP 440 compliant and
+            # cannot be parsed by packaging.version. Compare leading major.minor numerically.
+            import regex as re
 
-            sfa_prolog_v3_supported = Version(cann_version) >= Version("9.1.0")
+            match = re.match(r"(\d+)\.(\d+)", cann_version)
+            sfa_prolog_v3_supported = match is not None and (int(match.group(1)), int(match.group(2))) >= (9, 1)
         else:
             sfa_prolog_v3_supported = False
         self.enable_sfa_prolog_v3 = (


### PR DESCRIPTION
## Problem

On machines with commercial CANN builds (e.g. `9.2.T530`), the engine fails to start with:

```
packaging.version.InvalidVersion: Invalid version: '9.2.T530'
```

at `vllm_ascend/attention/sfa_v1.py:688`:

```python
sfa_prolog_v3_supported = Version(cann_version) >= Version("9.1.0")
```

CANN commercial version strings carry a `T` suffix (e.g. `9.2.T530`) and are not PEP 440 compliant, so `packaging.version.Version` raises `InvalidVersion` during SFA attention initialization (triggered when `enable_sparse_sfa_c8` is enabled on decode nodes).

## Fix

Compare the leading `major.minor` of the CANN version numerically instead of parsing the full string with `packaging.version`:

```python
match = re.match(r"(\d+)\.(\d+)", cann_version)
sfa_prolog_v3_supported = bool(match) and (int(match.group(1)), int(match.group(2))) >= (9, 1)
```

`9.2.T530` → `(9, 2) >= (9, 1)` → `True`, behavior is preserved and the crash is gone.

## Test

- `Version("9.1.0")` → supported, unchanged behavior
- `Version("9.2.T530")` → supported, no crash
- malformed strings → `False`, no crash

- vLLM main: https://github.com/vllm-project/vllm/commit/ee0da84ab9e04ac7610e28580af62c365e898389
