### PR TITLE
[Feature][DCP] Support parallel drafting and K3 DSpark on main

### DIFF
--- a/tests/e2e/nightly/single_node/ops/singlecard_ops/triton/test_copy_and_expand_dflash_dspark.py
+++ b/tests/e2e/nightly/single_node/ops/singlecard_ops/triton/test_copy_and_expand_dflash_dspark.py
@@ -27,6 +27,10 @@ def copy_and_expand_dflash_dspark_ref(
     num_query_per_req,
     num_speculative_tokens,
     sample_from_anchor,
+    total_cp_world_size=1,
+    current_cp_rank=0,
+    cp_kv_cache_interleave_size=1,
+    pad_id=-1,
 ):
     """Pure-PyTorch reference of the serial kernel logic (golden)."""
     batch_size = next_token_ids.shape[0]
@@ -67,9 +71,15 @@ def copy_and_expand_dflash_dspark_ref(
             out_query_positions[query_out_idx] = query_pos
 
             query_cache_pos = effective_seq_len + q_idx
-            block_num_q = query_cache_pos // KV_BLOCK_SIZE
+            virtual_block = KV_BLOCK_SIZE * total_cp_world_size
+            virtual_offset = query_cache_pos % virtual_block
+            owner = (virtual_offset // cp_kv_cache_interleave_size) % total_cp_world_size
+            local_offset = (
+                virtual_offset // (total_cp_world_size * cp_kv_cache_interleave_size)
+            ) * cp_kv_cache_interleave_size + virtual_offset % cp_kv_cache_interleave_size
+            block_num_q = query_cache_pos // virtual_block + local_offset // KV_BLOCK_SIZE
             block_id_q = block_table[req_idx, block_num_q].to(torch.int64).item()
-            slot_q = block_id_q * KV_BLOCK_SIZE + (query_cache_pos % KV_BLOCK_SIZE)
+            slot_q = block_id_q * KV_BLOCK_SIZE + local_offset % KV_BLOCK_SIZE if owner == current_cp_rank else pad_id
             out_query_slot_mapping[query_out_idx] = slot_q
 
             if q_idx == 0:
@@ -94,22 +104,39 @@ def copy_and_expand_dflash_dspark_ref(
     }
 
 
-# (batch_size, ctx_lens, num_spec, sample_from_anchor, has_num_rejected)
+# (batch_size, ctx_lens, num_spec, sample_from_anchor, has_num_rejected,
+#  total_cp_world_size, current_cp_rank, cp_kv_cache_interleave_size)
 CONFIGS = [
-    (1, [4], 3, False, False),
-    (64, [4] * 64, 3, False, False),
-    (256, [4] * 256, 3, False, False),
-    (1, [2048], 3, False, False),
-    (4, [1024] * 4, 3, False, False),
-    (8, [512] * 8, 3, False, False),
-    (64, [4] * 64, 3, True, False),
-    (64, [4] * 64, 3, False, True),
-    (8, [512] * 8, 3, True, True),
+    (1, [4], 3, False, False, 1, 0, 1),
+    (64, [4] * 64, 3, False, False, 1, 0, 1),
+    (256, [4] * 256, 3, False, False, 1, 0, 1),
+    (1, [2048], 3, False, False, 1, 0, 1),
+    (4, [1024] * 4, 3, False, False, 1, 0, 1),
+    (8, [512] * 8, 3, False, False, 1, 0, 1),
+    (64, [4] * 64, 3, True, False, 1, 0, 1),
+    (64, [4] * 64, 3, False, True, 1, 0, 1),
+    (8, [512] * 8, 3, True, True, 1, 0, 1),
+    (4, [32] * 4, 3, True, False, 8, 0, 1),
+    (4, [32] * 4, 3, True, False, 8, 3, 1),
+    (4, [32] * 4, 3, True, False, 8, 7, 1),
 ]
 
 
-@pytest.mark.parametrize("batch_size,ctx_lens,num_spec,sample_from_anchor,has_num_rejected", CONFIGS)
-def test_copy_and_expand_dflash_dspark(batch_size, ctx_lens, num_spec, sample_from_anchor, has_num_rejected):
+@pytest.mark.parametrize(
+    "batch_size,ctx_lens,num_spec,sample_from_anchor,has_num_rejected,"
+    "total_cp_world_size,current_cp_rank,cp_kv_cache_interleave_size",
+    CONFIGS,
+)
+def test_copy_and_expand_dflash_dspark(
+    batch_size,
+    ctx_lens,
+    num_spec,
+    sample_from_anchor,
+    has_num_rejected,
+    total_cp_world_size,
+    current_cp_rank,
+    cp_kv_cache_interleave_size,
+):
     init_device_properties_triton()
     device = "npu"
     torch.manual_seed(0)
@@ -162,6 +189,9 @@ def test_copy_and_expand_dflash_dspark(batch_size, ctx_lens, num_spec, sample_fr
         num_query_per_req,
         num_spec,
         sample_from_anchor,
+        total_cp_world_size,
+        current_cp_rank,
+        cp_kv_cache_interleave_size,
     )
 
     # Run Triton kernel
@@ -197,6 +227,10 @@ def test_copy_and_expand_dflash_dspark(batch_size, ctx_lens, num_spec, sample_fr
         batch_size=batch_size,
         HAS_NUM_REJECTED=has_num_rejected,
         SAMPLE_FROM_ANCHOR=sample_from_anchor,
+        total_cp_world_size=total_cp_world_size,
+        current_cp_rank=current_cp_rank,
+        cp_kv_cache_interleave_size=cp_kv_cache_interleave_size,
+        PAD_ID=-1,
         TILE_SIZE=_COPY_EXPAND_TILE_SIZE,
     )
 

--- a/tests/ut/attention/test_attention_cp.py
+++ b/tests/ut/attention/test_attention_cp.py
@@ -1,0 +1,176 @@
+#
+# Copyright (c) 2026 Huawei Technologies Co., Ltd. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for the non-uniform BSND helpers used by GQA decode DCP.
+
+``pad_decode_query_to_bsnd`` and ``_compact_bsnd_out`` are the two halves of
+the non-uniform speculative-decode path in
+``AscendAttentionDCPImpl._forward_decode_dcp``: the first converts a packed
+TND query into the BSND layout ``npu_fused_infer_attention_score`` expects,
+the second strips the padding back out of the kernel output.  Both are pure
+tensor bookkeeping, so they run on CPU without an NPU.
+"""
+
+import torch
+
+from vllm_ascend.attention.context_parallel.attention_cp import (
+    _compact_bsnd_out,
+    pad_decode_query_to_bsnd,
+)
+
+NUM_HEADS = 2
+HEAD_SIZE = 4
+
+
+def _packed_query(
+    query_lens: list[int],
+    dtype: torch.dtype = torch.float32,
+) -> torch.Tensor:
+    """Build a TND query whose every element is unique and non-zero.
+
+    Values start at 1 so that "this slot is padding" can be asserted as
+    "this slot is exactly 0".
+    """
+    num_tokens = sum(query_lens)
+    return torch.arange(
+        1,
+        num_tokens * NUM_HEADS * HEAD_SIZE + 1,
+        dtype=dtype,
+    ).reshape(num_tokens, NUM_HEADS, HEAD_SIZE)
+
+
+def _flat_bsnd(num_decodes: int, max_q: int, last_dim: int) -> torch.Tensor:
+    """Build a ``(num_decodes * max_q, NUM_HEADS, last_dim)`` kernel output."""
+    num_rows = num_decodes * max_q
+    return torch.arange(
+        1,
+        num_rows * NUM_HEADS * last_dim + 1,
+        dtype=torch.float32,
+    ).reshape(num_rows, NUM_HEADS, last_dim)
+
+
+def test_pad_decode_query_keeps_shape_and_per_request_content() -> None:
+    query_lens = [3, 1, 2]
+    query = _packed_query(query_lens)
+
+    padded = pad_decode_query_to_bsnd(query, query_lens, max_q=3)
+
+    assert padded.shape == (3, 3, NUM_HEADS, HEAD_SIZE)
+    offset = 0
+    for i, query_len in enumerate(query_lens):
+        torch.testing.assert_close(padded[i, :query_len], query[offset : offset + query_len])
+        offset += query_len
+
+
+def test_pad_decode_query_zero_fills_padding_slots() -> None:
+    query_lens = [3, 1, 2]
+    query = _packed_query(query_lens)
+
+    padded = pad_decode_query_to_bsnd(query, query_lens, max_q=3)
+
+    for i, query_len in enumerate(query_lens):
+        tail = padded[i, query_len:]
+        torch.testing.assert_close(tail, torch.zeros_like(tail))
+
+
+def test_pad_decode_query_skips_requests_without_tokens() -> None:
+    """A zero-length request occupies a row but consumes no input token."""
+    query_lens = [2, 0, 3]
+    query = _packed_query(query_lens)
+
+    padded = pad_decode_query_to_bsnd(query, query_lens, max_q=3)
+
+    torch.testing.assert_close(padded[0, :2], query[:2])
+    torch.testing.assert_close(padded[1], torch.zeros_like(padded[1]))
+    torch.testing.assert_close(padded[2, :3], query[2:5])
+
+
+def test_compact_bsnd_out_selects_valid_rows() -> None:
+    decode_q_lens = [3, 1, 2]
+    max_q = 3
+    attn_out = _flat_bsnd(len(decode_q_lens), max_q, HEAD_SIZE)
+    attn_lse = _flat_bsnd(len(decode_q_lens), max_q, 1)
+
+    out, lse = _compact_bsnd_out(attn_out, attn_lse, decode_q_lens, max_q)
+
+    valid_rows = torch.tensor([0, 1, 2, 3, 6, 7])
+    assert out.shape == (6, NUM_HEADS, HEAD_SIZE)
+    assert lse.shape == (6, NUM_HEADS, 1)
+    torch.testing.assert_close(out, attn_out[valid_rows])
+    torch.testing.assert_close(lse, attn_lse[valid_rows])
+
+
+def test_compact_bsnd_out_drops_padding_garbage() -> None:
+    """Padding slots are never written by the kernel and must not leak out."""
+    decode_q_lens = [3, 1, 2]
+    max_q = 3
+    attn_out = _flat_bsnd(len(decode_q_lens), max_q, HEAD_SIZE)
+    attn_lse = _flat_bsnd(len(decode_q_lens), max_q, 1)
+    padding_rows = torch.tensor([4, 5, 8])
+    attn_out[padding_rows] = torch.nan
+    attn_lse[padding_rows] = torch.inf
+
+    out, lse = _compact_bsnd_out(attn_out, attn_lse, decode_q_lens, max_q)
+
+    assert torch.isfinite(out).all()
+    assert torch.isfinite(lse).all()
+
+
+def test_compact_bsnd_out_follows_forward_layout_transform() -> None:
+    """Reproduce the reshapes ``_forward_decode_dcp`` applies before compacting.
+
+    The kernel returns ``out`` as ``(B, S, N, D)`` but ``lse`` as
+    ``(B, N, S, 1)``; the caller transposes the latter so that both are
+    row-indexed by ``batch * max_q + step`` before compaction.  This test pins
+    that ordering down: dropping the transpose swaps the head and step axes
+    and silently corrupts the DCP lse merge.
+    """
+    decode_q_lens = [2, 1]
+    max_q = 2
+    num_decodes = len(decode_q_lens)
+    kernel_out = torch.arange(
+        num_decodes * max_q * NUM_HEADS * HEAD_SIZE,
+        dtype=torch.float32,
+    ).reshape(num_decodes, max_q, NUM_HEADS, HEAD_SIZE)
+    kernel_lse = torch.arange(
+        num_decodes * NUM_HEADS * max_q,
+        dtype=torch.float32,
+    ).reshape(num_decodes, NUM_HEADS, max_q, 1)
+
+    flat_out = kernel_out.view(-1, kernel_out.shape[2], kernel_out.shape[3])
+    flat_lse = kernel_lse.transpose(1, 2).reshape(-1, kernel_lse.shape[1], 1)
+    out, lse = _compact_bsnd_out(flat_out, flat_lse, decode_q_lens, max_q)
+
+    expected_out = torch.cat([kernel_out[0, :2], kernel_out[1, :1]], dim=0)
+    expected_lse = torch.cat(
+        [kernel_lse[0, :, :2].transpose(0, 1), kernel_lse[1, :, :1].transpose(0, 1)],
+        dim=0,
+    )
+    torch.testing.assert_close(out, expected_out)
+    torch.testing.assert_close(lse, expected_lse)
+
+
+def test_pad_then_compact_round_trip() -> None:
+    """Padding and compaction are inverses for an identity "attention"."""
+    query_lens = [3, 1, 2]
+    max_q = 3
+    query = _packed_query(query_lens)
+
+    padded = pad_decode_query_to_bsnd(query, query_lens, max_q)
+    flat = padded.view(-1, NUM_HEADS, HEAD_SIZE)
+    flat_lse = torch.zeros(flat.shape[0], NUM_HEADS, 1)
+    out, _ = _compact_bsnd_out(flat, flat_lse, query_lens, max_q)
+
+    torch.testing.assert_close(out, query)

--- a/tests/ut/kv_offload/test_mooncake_connector.py
+++ b/tests/ut/kv_offload/test_mooncake_connector.py
@@ -2062,6 +2062,33 @@ class TestMooncakeConnectorScheduler(unittest.TestCase):
         self.assertFalse(delay_free)
         self.assertIsNone(params)
 
+    def test_request_finished_advertises_decode_dcp_size(self):
+        self.scheduler.vllm_config.kv_transfer_config.get_from_extra_config.side_effect = lambda key, default: (
+            {"dcp_size": 8} if key == "decode" else default
+        )
+        request = self._make_remote_decode_request(prompt_len=33, request_id="req_remote_dcp")
+
+        delay_free, params = self.scheduler.request_finished(request, ([10, 11, 12],))
+
+        self.assertTrue(delay_free)
+        self.assertIsNotNone(params)
+        assert params is not None
+        self.assertEqual(params["remote_dcp_size"], 8)
+
+    def test_request_finished_falls_back_when_decode_topology_is_none(self):
+        self.scheduler.dcp_size = 4
+        self.scheduler.vllm_config.kv_transfer_config.get_from_extra_config.side_effect = lambda key, default: (
+            None if key == "decode" else default
+        )
+        request = self._make_remote_decode_request(prompt_len=33, request_id="req_remote_dcp_fallback")
+
+        delay_free, params = self.scheduler.request_finished(request, ([10, 11, 12],))
+
+        self.assertTrue(delay_free)
+        self.assertIsNotNone(params)
+        assert params is not None
+        self.assertEqual(params["remote_dcp_size"], 4)
+
     def test_request_finished_rejected_remote_prefill_enqueues_empty_recv(self):
         request = MockRequest(
             "req1",

--- a/tests/ut/patch/platform/test_prefix_cache_cp_patches.py
+++ b/tests/ut/patch/platform/test_prefix_cache_cp_patches.py
@@ -3,7 +3,7 @@
 import math
 from dataclasses import replace
 from types import SimpleNamespace
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 import pytest
 import torch
@@ -11,6 +11,7 @@ from vllm.v1.core.block_pool import BlockPool
 from vllm.v1.core.kv_cache_utils import generate_scheduler_kv_cache_config
 from vllm.v1.core.single_type_kv_cache_manager import (
     FullAttentionManager,
+    MambaManager,
     SlidingWindowManager,
 )
 from vllm.v1.kv_cache_interface import (
@@ -690,6 +691,25 @@ def test_ascend_mamba_manager_uses_logical_block_size_with_prefix_caching() -> N
     manager = AscendMambaManager(**manager_kwargs)
 
     assert manager.block_size == mamba_spec.block_size
+
+
+def test_ascend_mamba_cache_hit_treats_dcp_state_as_replicated() -> None:
+    expected = ([],)
+
+    with patch.object(MambaManager, "find_longest_cache_hit", return_value=expected) as find_cache_hit:
+        result = AscendMambaManager.find_longest_cache_hit(
+            block_hashes=MagicMock(),
+            max_length=128,
+            kv_cache_group_ids=[0],
+            block_pool=MagicMock(),
+            kv_cache_spec=MagicMock(),
+            alignment_tokens=16,
+            dcp_world_size=8,
+            pcp_world_size=1,
+        )
+
+    assert result == expected
+    assert find_cache_hit.call_args.kwargs["dcp_world_size"] == 1
 
 
 def test_swa_reachable_block_mask_sparse_with_lcm_alignment() -> None:

--- a/tests/ut/spec_decode/test_dspark_proposer.py
+++ b/tests/ut/spec_decode/test_dspark_proposer.py
@@ -68,7 +68,8 @@ class _DSparkProposerTestBase:
             speculative_config=SimpleNamespace(
                 draft_sample_method=draft_sample_method,
                 draft_model_config=draft_model_config,
-            )
+            ),
+            parallel_config=SimpleNamespace(cp_kv_cache_interleave_size=1),
         )
 
     @classmethod
@@ -92,6 +93,7 @@ class _DSparkProposerTestBase:
             runner: object | None = None,
         ) -> None:
             del runner
+            proposer.vllm_config = vllm_config
             proposer.draft_model_config = vllm_config.speculative_config.draft_model_config
             proposer.num_speculative_tokens = block_size
             proposer.max_batch_size = num_reqs
@@ -106,6 +108,8 @@ class _DSparkProposerTestBase:
                 if draft_attn_causal is not None
                 else SimpleNamespace()
             )
+            proposer.dcp_size = 1
+            proposer.dcp_rank = 0
 
         dynamic_spec_config = SimpleNamespace(method="", method_params={})
         with (
@@ -464,6 +468,52 @@ class TestSetInputsFirstPassOutputs(_DSparkProposerTestBase):
         assert torch.equal(cad.seq_lens, expected)
         assert torch.equal(cad._seq_lens_cpu, expected)
         assert torch.equal(cad.seq_lens_cpu, expected)
+
+    def test_dcp_populates_parallel_drafting_metadata(self, monkeypatch):
+        kernel = MagicMock()
+        monkeypatch.setattr(
+            "vllm_ascend.spec_decode.dspark_proposer.copy_and_expand_dflash_and_dspark_inputs_kernel",
+            kernel,
+        )
+        num_reqs, block_size, max_num_tokens = 2, 3, 64
+        proposer = self._make_proposer(
+            max_num_tokens=max_num_tokens,
+            num_reqs=num_reqs,
+            block_size=block_size,
+        )
+        proposer.dcp_size = 8
+        proposer.dcp_rank = 3
+        proposer.vllm_config.parallel_config.cp_kv_cache_interleave_size = 1
+        local_seq_lens = torch.arange(num_reqs * proposer.dcp_size, dtype=torch.int32).reshape(
+            num_reqs, proposer.dcp_size
+        )
+
+        with patch(
+            "vllm_ascend.spec_decode.dspark_proposer.get_dcp_local_seq_lens",
+            return_value=local_seq_lens,
+        ) as get_local_seq_lens:
+            _num_query_total, _token_indices, cad, long_seq_args = self._invoke_set_inputs_first_pass(
+                proposer,
+                num_reqs=num_reqs,
+                block_size=block_size,
+            )[:4]
+
+        get_local_seq_lens.assert_called_once_with(
+            cad._seq_lens_cpu,
+            proposer.dcp_size,
+            proposer.vllm_config.parallel_config.cp_kv_cache_interleave_size,
+        )
+        assert long_seq_args == (None, None)
+        assert np.array_equal(cad.context_parallel_metadata.num_computed_tokens_of_dcp, local_seq_lens.numpy())
+        assert torch.equal(
+            cad.context_parallel_metadata.query_lens_cpu,
+            torch.full((num_reqs,), block_size, dtype=torch.int32),
+        )
+        kwargs = kernel[1,].call_args.kwargs
+        assert kwargs["total_cp_world_size"] == 8
+        assert kwargs["current_cp_rank"] == 3
+        assert kwargs["cp_kv_cache_interleave_size"] == 1
+        assert kwargs["PAD_ID"] == -1
 
 
 class TestSetInputsFirstPassRejectedTokens(_DSparkProposerTestBase):

--- a/vllm_ascend/attention/attention_v1.py
+++ b/vllm_ascend/attention/attention_v1.py
@@ -340,7 +340,7 @@ class AscendAttentionMetadataBuilder(AttentionMetadataBuilder[AscendMetadata]):
             seq_lens = common_attn_metadata.seq_lens
             slot_mapping = common_attn_metadata.slot_mapping.to(torch.int32)
         elif self.speculative_config and self.speculative_config.parallel_drafting:
-            seq_lens = common_attn_metadata.seq_lens
+            seq_lens = common_attn_metadata.seq_lens.to("cpu")
 
         attn_state = common_attn_metadata.attn_state
 

--- a/vllm_ascend/attention/context_parallel/attention_cp.py
+++ b/vllm_ascend/attention/context_parallel/attention_cp.py
@@ -76,6 +76,7 @@ class AscendMetadataForDecode:
     num_computed_tokens_of_dcp: list[list[int]] | None = None
     block_tables: torch.Tensor = None
     dcp_mtp_attn_mask: torch.Tensor = None
+    query_lens: list[int] | None = None
 
 
 @dataclass
@@ -121,6 +122,12 @@ class AscendAttentionDCPMetadataBuilder(
         num_prefills: int,
     ) -> dict[str, object]:
         dcp_metadata = self._require_dcp_metadata(common_attn_metadata)
+        dcp_query_lens = dcp_metadata.query_lens_cpu
+        if dcp_query_lens is not None:
+            query_lens = dcp_query_lens[: num_decodes + num_prefills].to(
+                device=query_lens.device,
+                dtype=query_lens.dtype,
+            )
         prefill_metadata = None
         if num_prefills > 0:
             prefill_query_lens = query_lens[num_decodes:]
@@ -162,12 +169,43 @@ class AscendAttentionDCPMetadataBuilder(
                 num_computed_tokens_of_dcp=np.asarray(dcp_metadata.num_computed_tokens_of_dcp)[:num_decodes],
                 block_tables=block_table[:num_decodes],
                 dcp_mtp_attn_mask=dcp_metadata.dcp_mtp_attn_mask,
+                query_lens=query_lens[:num_decodes].tolist(),
             )
 
         return {
             "prefill": prefill_metadata,
             "decode_meta": decode_metadata,
         }
+
+
+def pad_decode_query_to_bsnd(
+    query: torch.Tensor,
+    query_lens: list[int],
+    max_q: int,
+) -> torch.Tensor:
+    num_decodes = len(query_lens)
+    num_heads, head_size = query.shape[1], query.shape[-1]
+    out = query.new_zeros((num_decodes, max_q, num_heads, head_size))
+    offset = 0
+    for i, qlen in enumerate(query_lens):
+        if qlen > 0:
+            out[i, :qlen] = query[offset : offset + qlen]
+            offset += qlen
+    return out
+
+
+def _compact_bsnd_out(
+    attn_out: torch.Tensor,
+    attn_lse: torch.Tensor,
+    decode_q_lens: list[int],
+    max_q: int,
+):
+    num_decodes = len(decode_q_lens)
+    out_q = attn_out.view(num_decodes, max_q, *attn_out.shape[1:])
+    out_l = attn_lse.view(num_decodes, max_q, *attn_lse.shape[1:])
+    lens = torch.as_tensor(decode_q_lens, device=attn_out.device).unsqueeze(1)
+    valid = torch.arange(max_q, device=attn_out.device).unsqueeze(0) < lens
+    return out_q[valid], out_l[valid]
 
 
 class AscendAttentionDCPImpl(DCPImplMixin, AscendAttentionBackendImpl):
@@ -221,17 +259,25 @@ class AscendAttentionDCPImpl(DCPImplMixin, AscendAttentionBackendImpl):
                     attn_mask,
                 ) = param
 
+                actual_seq_lengths_q_is_cumulative = False
                 if _EXTRA_CTX.is_draft_model:
                     draft_step = attn_count // num_layers
-                    actual_seq_lengths_kv = attn_metadata[draft_step][key].decode_meta.num_computed_tokens_of_dcp[
-                        :, dcp_rank
-                    ]
+                    draft_attn_metadata = attn_metadata[draft_step][key]
+                    draft_decode_meta = draft_attn_metadata.decode_meta
+                    actual_seq_lengths_kv = (
+                        draft_decode_meta.num_computed_tokens_of_dcp[:, dcp_rank]
+                        if draft_decode_meta is not None
+                        else np.zeros(num_tokens, dtype=np.int32)
+                    )
                     pad_length = num_tokens - len(actual_seq_lengths_kv)
                     if pad_length > 0:
                         pad_tensor = np.zeros(pad_length, dtype=actual_seq_lengths_kv.dtype)
                         actual_seq_lengths_kv = np.concatenate([actual_seq_lengths_kv, pad_tensor])
 
-                    actual_seq_lengths_q = attn_metadata[draft_step][key].actual_seq_lengths_q
+                    actual_seq_lengths_q = draft_decode_meta.query_lens if draft_decode_meta is not None else None
+                    if actual_seq_lengths_q is None:
+                        actual_seq_lengths_q = draft_attn_metadata.actual_seq_lengths_q
+                        actual_seq_lengths_q_is_cumulative = True
                     attn_count = attn_count + 1
                 else:
                     actual_seq_lengths_kv = attn_metadata[key].decode_meta.num_computed_tokens_of_dcp[:, dcp_rank]
@@ -248,9 +294,17 @@ class AscendAttentionDCPImpl(DCPImplMixin, AscendAttentionBackendImpl):
                 torch.npu.graph_task_update_begin(update_stream, handle)
 
                 input_layout = "TND"
-                if speculative_config is not None:
+                if _EXTRA_CTX.is_draft_model and speculative_config is not None:
                     input_layout = "BSND"
-                    actual_seq_lengths_q = [actual_seq_lengths_q[0] for _ in range(len(actual_seq_lengths_q))]
+                    if (
+                        actual_seq_lengths_q_is_cumulative
+                        and isinstance(actual_seq_lengths_q, list)
+                        and actual_seq_lengths_q
+                    ):
+                        actual_seq_lengths_q = [actual_seq_lengths_q[0]] + [
+                            actual_seq_lengths_q[i] - actual_seq_lengths_q[i - 1]
+                            for i in range(1, len(actual_seq_lengths_q))
+                        ]
 
                 torch_npu.npu_fused_infer_attention_score.out(
                     q_nope,
@@ -295,15 +349,26 @@ class AscendAttentionDCPImpl(DCPImplMixin, AscendAttentionBackendImpl):
         attn_mask = None
         input_layerout = "TND"
         actual_seq_lengths_q = attn_metadata.actual_seq_lengths_q[: attn_metadata.num_decodes]
-        if self.vllm_config.speculative_config is not None:
+        is_uniform = True
+        decode_q_lens: list[int] | None = None
+        max_q = 0
+        if _EXTRA_CTX.is_draft_model and self.vllm_config.speculative_config is not None:
             input_layerout = "BSND"
             num_decodes = attn_metadata.num_decodes
             if attn_metadata.decode_meta.dcp_mtp_attn_mask is not None:
                 attn_mask = attn_metadata.decode_meta.dcp_mtp_attn_mask
             else:
                 attn_mask = None
-            query = query.view(num_decodes, -1, query.shape[1], query.shape[-1])
-            actual_seq_lengths_q = [actual_seq_lengths_q[0] for _ in range(len(actual_seq_lengths_q))]
+            decode_q_lens = attn_metadata.decode_meta.query_lens
+            assert decode_q_lens is not None
+            spec = self.vllm_config.speculative_config
+            max_q = 1 + (spec.num_speculative_tokens if spec is not None else 0)
+            is_uniform = attn_metadata.num_decode_tokens == num_decodes * max_q
+            if is_uniform:
+                query = query.view(num_decodes, max_q, query.shape[1], query.shape[-1])
+            else:
+                query = pad_decode_query_to_bsnd(query, decode_q_lens, max_q)
+            actual_seq_lengths_q = decode_q_lens
 
         common_kwargs = {
             "num_heads": num_heads,
@@ -386,6 +451,13 @@ class AscendAttentionDCPImpl(DCPImplMixin, AscendAttentionBackendImpl):
         if input_layerout == "BSND":
             attn_out = attn_out.view(-1, attn_out.shape[2], attn_out.shape[3])
             attn_lse = attn_lse.transpose(1, 2).reshape(-1, attn_lse.shape[1], 1)
+            if not is_uniform:
+                attn_out, attn_lse = _compact_bsnd_out(
+                    attn_out,
+                    attn_lse,
+                    decode_q_lens,
+                    max_q,
+                )
         return self._merge_dcp_attention_output(
             attn_out,
             attn_lse,

--- a/vllm_ascend/distributed/kv_transfer/kv_p2p/mooncake_connector.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_p2p/mooncake_connector.py
@@ -2030,6 +2030,10 @@ class MooncakeConnectorScheduler:
             logger.info("Delaying free of %d blocks for request %s", sum(computed_block_lens), request.request_id)
             self._reqs_need_send[request.request_id] = time.time()
 
+        decode_topology = self.vllm_config.kv_transfer_config.get_from_extra_config("decode", {}) or {}
+        configured_dcp_size = decode_topology.get("dcp_size")
+        advertised_remote_dcp_size = int(configured_dcp_size) if configured_dcp_size is not None else self.dcp_size
+
         return delay_free_blocks, dict(
             do_remote_prefill=True,
             do_remote_decode=False,
@@ -2039,7 +2043,7 @@ class MooncakeConnectorScheduler:
             remote_host=self.side_channel_host,
             remote_port=self.side_channel_port,
             remote_pcp_size=self.pcp_size,
-            remote_dcp_size=self.dcp_size,
+            remote_dcp_size=advertised_remote_dcp_size,
             remote_ptp_size=self.tp_size,
             last_token_id=request.output_token_ids[-1],
             remote_multi_nodes_meta_mapping=self.multi_nodes_meta_mapping,

--- a/vllm_ascend/ops/triton/spec_decode/utils.py
+++ b/vllm_ascend/ops/triton/spec_decode/utils.py
@@ -94,6 +94,10 @@ def copy_and_expand_dflash_and_dspark_inputs_kernel(
     batch_size,  # tl.int32
     HAS_NUM_REJECTED: tl.constexpr = False,
     SAMPLE_FROM_ANCHOR: tl.constexpr = False,
+    total_cp_world_size: tl.constexpr = 1,
+    current_cp_rank: tl.constexpr = 0,
+    cp_kv_cache_interleave_size: tl.constexpr = 1,
+    PAD_ID: tl.constexpr = -1,
     TILE_SIZE: tl.constexpr = 256,
 ):
     # Grid-stride kernel: launch grid is capped at the vector-core count by
@@ -104,6 +108,7 @@ def copy_and_expand_dflash_and_dspark_inputs_kernel(
     pid = tl.program_id(axis=0)
     num_programs = tl.num_programs(axis=0)
     block_start_step = num_programs * TILE_SIZE
+    virtual_block = block_size * total_cp_world_size
 
     # --- Part 1: context positions / slot_mapping copy ---
     # query_start_loc is a contiguous partition of [0, total_input_tokens),
@@ -155,11 +160,31 @@ def copy_and_expand_dflash_and_dspark_inputs_kernel(
         # rather than from query_pos. For text-only inputs the two values are
         # identical, so this only changes behaviour for multimodal inputs.
         query_kv_slot_pos = effective_seq_len + q_idx
-        block_num_q = query_kv_slot_pos // block_size
-        block_id_q = tl.load(block_table_ptr + req_idx * block_table_stride + block_num_q, mask=mask, other=0).to(
-            tl.int64
-        )
-        slot_q = block_id_q * block_size + (query_kv_slot_pos % block_size)
+        if total_cp_world_size > 1:
+            virtual_offset = query_kv_slot_pos % virtual_block
+            owner = (virtual_offset // cp_kv_cache_interleave_size) % total_cp_world_size
+            local_offset = (
+                virtual_offset // (total_cp_world_size * cp_kv_cache_interleave_size)
+            ) * cp_kv_cache_interleave_size + (virtual_offset % cp_kv_cache_interleave_size)
+            block_num_q = query_kv_slot_pos // virtual_block + local_offset // block_size
+            block_id_q = tl.load(
+                block_table_ptr + req_idx * block_table_stride + block_num_q,
+                mask=mask,
+                other=0,
+            ).to(tl.int64)
+            slot_q = tl.where(
+                owner == current_cp_rank,
+                block_id_q * block_size + local_offset % block_size,
+                PAD_ID,
+            )
+        else:
+            block_num_q = query_kv_slot_pos // block_size
+            block_id_q = tl.load(
+                block_table_ptr + req_idx * block_table_stride + block_num_q,
+                mask=mask,
+                other=0,
+            ).to(tl.int64)
+            slot_q = block_id_q * block_size + query_kv_slot_pos % block_size
         tl.store(out_query_slot_mapping_ptr + offs, slot_q, mask=mask)
 
         bonus = tl.load(next_token_ids_ptr + req_idx, mask=mask, other=0)

--- a/vllm_ascend/patch/platform/patch_mamba_manager.py
+++ b/vllm_ascend/patch/platform/patch_mamba_manager.py
@@ -42,7 +42,9 @@ class AscendMambaManager(MambaManager):
             block_pool=block_pool,
             kv_cache_spec=kv_cache_spec,
             alignment_tokens=alignment_tokens,
-            dcp_world_size=dcp_world_size,
+            # Mamba recurrent state is replicated rather than sharded across
+            # DCP ranks, so its prefix-cache lookup remains single-rank.
+            dcp_world_size=1,
             pcp_world_size=pcp_world_size,
             drop_eagle_block=drop_eagle_block,
         )

--- a/vllm_ascend/spec_decode/dflash_proposer.py
+++ b/vllm_ascend/spec_decode/dflash_proposer.py
@@ -5,11 +5,13 @@ from vllm.config import CUDAGraphMode, VllmConfig
 from vllm.forward_context import get_forward_context
 from vllm.triton_utils import triton
 from vllm.v1.attention.backends.utils import CommonAttentionMetadata
+from vllm.v1.spec_decode.utils import PADDING_SLOT_ID
 
 from vllm_ascend.ascend_config import get_ascend_config
 from vllm_ascend.ascend_forward_context import _EXTRA_CTX, set_ascend_forward_context
 from vllm_ascend.attention.attention_v1 import AscendAttentionState
-from vllm_ascend.attention.utils import AscendCommonAttentionMetadata
+from vllm_ascend.attention.context_parallel.common_cp import get_dcp_local_seq_lens
+from vllm_ascend.attention.utils import AscendCommonAttentionMetadata, AscendDCPMetadata
 from vllm_ascend.ops.triton.spec_decode.utils import copy_and_expand_dflash_and_dspark_inputs_kernel
 from vllm_ascend.ops.triton.triton_utils import get_vectorcore_num, init_device_properties_triton
 from vllm_ascend.spec_decode.eagle_proposer import AscendEagleProposer
@@ -128,6 +130,9 @@ class AscendDflashProposer(AscendEagleProposer):
         )
 
         has_num_rejected = num_rejected_tokens_gpu is not None
+        total_cp_world_size = self.dcp_size
+        current_cp_rank = self.dcp_rank
+        cp_kv_cache_interleave_size = self.vllm_config.parallel_config.cp_kv_cache_interleave_size
 
         copy_and_expand_dflash_and_dspark_inputs_kernel[(_compute_num_programs(num_context, num_query_total),)](
             # Inputs
@@ -156,6 +161,10 @@ class AscendDflashProposer(AscendEagleProposer):
             total_input_tokens=num_context,
             batch_size=batch_size,
             HAS_NUM_REJECTED=has_num_rejected,
+            total_cp_world_size=total_cp_world_size,
+            current_cp_rank=current_cp_rank,
+            cp_kv_cache_interleave_size=cp_kv_cache_interleave_size,
+            PAD_ID=PADDING_SLOT_ID,
         )
 
         query_slot_mapping = self._slot_mapping_buffer[:num_query_total]
@@ -184,7 +193,30 @@ class AscendDflashProposer(AscendEagleProposer):
         cad.attn_mask = None
         cad.attn_state = AscendAttentionState.ChunkedPrefill
 
-        return num_query_total, token_indices_to_sample, cad, None
+        if getattr(cad, "is_prefilling", None) is not None:
+            cad.is_prefilling = torch.zeros_like(cad.is_prefilling)
+        long_seq_args = None
+        if self.dcp_size > 1:
+            seq_lens_cpu = cad.seq_lens.cpu()
+            if hasattr(cad, "seq_lens_cpu"):
+                cad.seq_lens_cpu = seq_lens_cpu
+            if getattr(cad, "_seq_lens_cpu", None) is not None:
+                cad._seq_lens_cpu = seq_lens_cpu
+            cad.max_seq_len = int(seq_lens_cpu.max().item())
+            local_seq_lens = get_dcp_local_seq_lens(
+                seq_lens_cpu,
+                self.dcp_size,
+                self.vllm_config.parallel_config.cp_kv_cache_interleave_size,
+            )
+            cad.context_parallel_metadata = AscendDCPMetadata(
+                num_computed_tokens_of_dcp=local_seq_lens.numpy(),
+                query_lens_cpu=None,
+                max_query_len=0,
+                dcp_mtp_attn_mask=None,
+            )
+            long_seq_args = (None, None)
+
+        return num_query_total, token_indices_to_sample, cad, long_seq_args
 
     @torch.inference_mode()
     def dummy_run(
@@ -198,7 +230,9 @@ class AscendDflashProposer(AscendEagleProposer):
         is_profile=False,
         **kwargs,
     ) -> None:
-        num_query_tokens = min(num_tokens, self.max_query_tokens)
+        num_query_per_req = 1 + self.num_speculative_tokens
+        num_query_total = num_reqs * num_query_per_req if num_reqs > 0 else min(num_tokens, self.max_query_tokens)
+        num_query_tokens = num_query_total
 
         (
             num_input_tokens,
@@ -208,8 +242,16 @@ class AscendDflashProposer(AscendEagleProposer):
 
         if not self.use_cuda_graph:
             aclgraph_runtime_mode = CUDAGraphMode.NONE
-        num_query_per_req = 1 + self.num_speculative_tokens
-        num_query_total = num_reqs * num_query_per_req
+        if self.dcp_size > 1 and self.use_cuda_graph and not is_profile and self.block_table_tensor_clone is None:
+            self.block_table_tensor_clone = torch.zeros(
+                (
+                    self.runner.max_num_tokens + 2 * self.runner.max_num_reqs,
+                    self.runner.input_batch.block_table[0].get_device_tensor().shape[1],
+                ),
+                dtype=torch.int32,
+                device=self.device,
+                pin_memory=self.runner.pin_memory,
+            )
 
         context_positions = self._context_positions_buffer[:num_input_tokens]
         context_states = self.hidden_states[:num_input_tokens]
@@ -217,6 +259,23 @@ class AscendDflashProposer(AscendEagleProposer):
         multi_steps_attn_metadata = []
         if aclgraph_runtime_mode == CUDAGraphMode.FULL and len(self.runner.attn_groups) > 0:
             builder = self.draft_attn_groups[0].get_metadata_builder()
+            cp_metadata = None
+            if self.dcp_size > 1:
+                query_lens_cpu = torch.full(
+                    (num_reqs,),
+                    num_query_per_req,
+                    dtype=torch.int32,
+                )
+                local_seq_lens = get_dcp_local_seq_lens(
+                    self.runner.optimistic_seq_lens[:num_reqs],
+                    self.dcp_size,
+                    self.vllm_config.parallel_config.cp_kv_cache_interleave_size,
+                )
+                cp_metadata = AscendDCPMetadata(
+                    num_computed_tokens_of_dcp=local_seq_lens.numpy(),
+                    query_lens_cpu=query_lens_cpu,
+                    max_query_len=num_query_per_req,
+                )
             common_attn_metadata = AscendCommonAttentionMetadata(
                 query_start_loc=self.arange_dflash[: num_reqs + 1] * num_query_per_req,
                 query_start_loc_cpu=torch.from_numpy(self.token_arange_np[: num_reqs + 1]).clone() * num_query_per_req,
@@ -234,6 +293,7 @@ class AscendDflashProposer(AscendEagleProposer):
                 block_table_tensor=self.runner.input_batch.block_table[self.kv_cache_gid].get_device_tensor()[
                     :num_reqs
                 ],
+                context_parallel_metadata=cp_metadata,
             )
 
             attn_metadata_dflash = builder.build_for_graph_capture(
@@ -285,7 +345,7 @@ class AscendDflashProposer(AscendEagleProposer):
 
             forward_context = get_forward_context()
             if forward_context.cudagraph_runtime_mode == CUDAGraphMode.FULL and not _EXTRA_CTX.capturing:
-                self._update_full_graph_params(forward_context, num_tokens, multi_steps_attn_metadata)
+                self._update_full_graph_params(forward_context, num_input_tokens, multi_steps_attn_metadata)
 
     def build_model_inputs_first_pass(
         self,

--- a/vllm_ascend/spec_decode/dspark_proposer.py
+++ b/vllm_ascend/spec_decode/dspark_proposer.py
@@ -8,11 +8,14 @@ from vllm.config import CUDAGraphMode, VllmConfig, get_layers_from_vllm_config
 from vllm.model_executor.layers.attention_layer_base import AttentionLayerBase
 from vllm.v1.attention.backends.utils import CommonAttentionMetadata
 from vllm.v1.kv_cache_interface import UniformTypeKVCacheSpecs
+from vllm.v1.spec_decode.utils import PADDING_SLOT_ID
 from vllm.v1.worker.utils import AttentionGroup
 
 from vllm_ascend.ascend_config import get_ascend_config
 from vllm_ascend.ascend_forward_context import set_ascend_forward_context
 from vllm_ascend.attention.attention_v1 import AscendAttentionState
+from vllm_ascend.attention.context_parallel.common_cp import get_dcp_local_seq_lens
+from vllm_ascend.attention.utils import AscendDCPMetadata
 from vllm_ascend.ops.triton.spec_decode.utils import copy_and_expand_dflash_and_dspark_inputs_kernel
 from vllm_ascend.spec_decode.dflash_proposer import AscendDflashProposer, _compute_num_programs
 from vllm_ascend.spec_decode.utils import DynamicSpecScheduler
@@ -242,6 +245,11 @@ class AscendDSparkProposer(AscendDflashProposer):
             dtype=torch.int32,
             device=self.device,
         )
+        dcp_size = getattr(self, "dcp_size", 1)
+        dcp_rank = getattr(self, "dcp_rank", 0)
+        cp_kv_cache_interleave_size = (
+            self.vllm_config.parallel_config.cp_kv_cache_interleave_size if dcp_size > 1 else 1
+        )
 
         # Query block: reuse the DFlash inputs kernel logic (host-side ref)
         # per kv-cache-group to fill positions / input_ids / query slot_mapping
@@ -280,6 +288,10 @@ class AscendDSparkProposer(AscendDflashProposer):
                 batch_size=batch_size,
                 HAS_NUM_REJECTED=has_num_rejected,
                 SAMPLE_FROM_ANCHOR=self.sample_from_anchor,
+                total_cp_world_size=dcp_size,
+                current_cp_rank=dcp_rank,
+                cp_kv_cache_interleave_size=cp_kv_cache_interleave_size,
+                PAD_ID=PADDING_SLOT_ID,
             )
         # to compute self._context_slot_mapping_buffers from dict to list
         self._context_slot_mapping_buffers = [
@@ -324,7 +336,29 @@ class AscendDSparkProposer(AscendDflashProposer):
         cad.attn_mask = None
         cad.attn_state = AscendAttentionState.ChunkedPrefill
 
-        return num_query_total, token_indices_to_sample, cad, None
+        long_seq_args = None
+        if dcp_size > 1:
+            seq_lens_cpu = getattr(cad, "_seq_lens_cpu", None)
+            if seq_lens_cpu is None:
+                seq_lens_cpu = cad.seq_lens.cpu()
+            local_seq_lens = get_dcp_local_seq_lens(
+                seq_lens_cpu,
+                dcp_size,
+                cp_kv_cache_interleave_size,
+            )
+            cad.context_parallel_metadata = AscendDCPMetadata(
+                num_computed_tokens_of_dcp=local_seq_lens.numpy(),
+                query_lens_cpu=torch.full(
+                    (batch_size,),
+                    self.num_query_per_req,
+                    dtype=torch.int32,
+                ),
+                max_query_len=self.num_query_per_req,
+                dcp_mtp_attn_mask=None,
+            )
+            long_seq_args = (None, None)
+
+        return num_query_total, token_indices_to_sample, cad, long_seq_args
 
     @torch.inference_mode()
     def dummy_run(

--- a/vllm_ascend/spec_decode/llm_base_proposer.py
+++ b/vllm_ascend/spec_decode/llm_base_proposer.py
@@ -161,6 +161,7 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
         self.use_sequence_parallel_moe = enable_sp(vllm_config)
 
         self.dcp_size = self.runner.dcp_size
+        self.dcp_rank = self.runner.dcp_rank
 
         self.use_sparse = hasattr(vllm_config.model_config.hf_text_config, "index_topk")
 
@@ -839,7 +840,7 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
         )
         assert self.runner is not None
         dcp_manager = getattr(self.runner, "dcp_manager", None)
-        if dcp_manager is not None:
+        if dcp_manager is not None and not self.parallel_drafting:
             assert long_seq_args is not None
             _, ori_token_indices_to_sample = long_seq_args
 
@@ -1001,7 +1002,7 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
             "slot_indices": None,
             "mtp_slot_mapping": None,
         }
-        if dcp_manager is not None:
+        if dcp_manager is not None and not self.parallel_drafting:
             dcp_mtp_inputs = dcp_manager.prepare_spec_decode_mtp_drafting_inputs(
                 common_attn_metadata=common_attn_metadata,
                 attn_metadata=attn_metadata_i,


### PR DESCRIPTION
### What this PR does / why we need it?

This is the `main`-branch port of #14812 and carries the current-main equivalent of the production changes from #14744.

It enables DCP for parallel speculative drafting and the Kimi K3 DSpark path by:

- supporting non-uniform speculative query lengths in the DCP BSND attention path;
- mapping draft KV slots to their owning DCP rank in the Triton copy/expand kernel;
- excluding parallel drafting from the MTP-only DCP manager preparation path;
- populating DCP-aware sequence and attention metadata in the DSpark proposer;
- advertising the configured decode-side DCP size in Mooncake P/D transfer metadata, with a safe fallback for missing or null values;
- treating Mamba recurrent state as replicated during Prefix Cache lookup instead of applying attention-KV DCP sharding rules.

The first commit retains attribution to the original #14744 implementation. Review feedback from #14812 is incorporated: Mooncake handles null topology values, draft graph metadata tolerates missing decode metadata, and optional Ascend metadata attributes are guarded.

Refs #14744
Refs #14812

### Does this PR introduce _any_ user-facing change?

Yes. DFlash/DSpark parallel drafting can be combined with decode context parallelism, including a P DCP1 to D DCP8 Mooncake topology. There is no new API; the existing `decode.dcp_size` topology field is honored.

### How was this patch tested?

Added or updated regression coverage for:

- non-uniform BSND padding and output compaction;
- DCP slot ownership in the Triton copy/expand kernel;
- DSpark DCP metadata and kernel arguments;
- Mooncake remote DCP advertisement and null fallback;
- replicated Mamba Prefix Cache lookup under DCP.

Completed locally:

- `python -m py_compile` for all 13 changed Python files
- `python -m ruff check` for all changed files
- `python -m ruff format --check` for all changed files
- `git diff --check upstream/main..HEAD`

The target pytest suite could not be executed on the local workstation because its Python environment does not contain `vllm` (`ModuleNotFoundError` while loading `tests/ut/conftest.py`). This PR is therefore opened as a draft for CI and NPU validation.

On the v0.26 release-path environment, a full 93-layer Kimi K3 service with DSpark3, Prefix Cache and DCP8 completed model loading, Triton warmup, graph capture and API startup. The first real request exposed the parallel-drafting DCP-manager and replicated-Mamba issues fixed here. A final end-to-end rerun was not completed because the four validation hosts became occupied by another job.

- vLLM version: v0.27.1
- vLLM main: https://github.com/vllm-project/vllm/commit/ba07e4a48fc951300d97eb506217dd530583dea3
