### PR TITLE
[Refactor][Attention] Select Ascend CP backends from selector config

### DIFF
--- a/tests/ut/attention/a2/test_attention_v1.py
+++ b/tests/ut/attention/a2/test_attention_v1.py
@@ -8,7 +8,9 @@ from tests.ut.base import TestBase
 from vllm_ascend.attention.attention_v1 import (
     AscendAttentionBackend,
     AscendAttentionBackendImpl,
+    AscendAttentionDCPBackend,
     AscendAttentionMetadataBuilder,
+    AscendAttentionPCPBackend,
     AscendAttentionPCPImpl,
     AscendAttentionPCPMetadata,
     AscendAttentionPCPMetadataBuilder,
@@ -56,28 +58,6 @@ class TestAttentionGraphHelpers(TestBase):
 
 
 class TestAscendAttentionBackend(TestBase):
-    def setUp(self):
-        self.mock_config = MagicMock()
-
-        mock_parallel_config = MagicMock()
-        mock_parallel_config.prefill_context_parallel_size = 1
-        mock_parallel_config.decode_context_parallel_size = 1
-
-        self.mock_config.parallel_config = mock_parallel_config
-
-        self.utils_patcher = patch("vllm_ascend.attention.utils.get_current_vllm_config", return_value=self.mock_config)
-        self.utils_patcher.start()
-
-        from vllm_ascend.attention.utils import enable_dcp, enable_pcp
-
-        self.enable_dcp = enable_dcp
-        self.enable_pcp = enable_pcp
-        enable_dcp.cache_clear()
-        enable_pcp.cache_clear()
-        self.addCleanup(self.utils_patcher.stop)
-        self.addCleanup(enable_dcp.cache_clear)
-        self.addCleanup(enable_pcp.cache_clear)
-
     def test_get_name(self):
         self.assertEqual(AscendAttentionBackend.get_name(), "CUSTOM")
 
@@ -88,33 +68,25 @@ class TestAscendAttentionBackend(TestBase):
         self.assertEqual(AscendAttentionBackend.get_builder_cls(), AscendAttentionMetadataBuilder)
 
     def test_get_impl_cls_with_pcp(self):
-        self.mock_config.parallel_config.prefill_context_parallel_size = 2
-        self.enable_pcp.cache_clear()
-
         self.assertIs(
-            AscendAttentionBackend.get_impl_cls(),
+            AscendAttentionPCPBackend.get_impl_cls(),
             AscendAttentionPCPImpl,
         )
 
     def test_get_builder_cls_with_pcp(self):
-        self.mock_config.parallel_config.prefill_context_parallel_size = 2
-        self.enable_pcp.cache_clear()
-
         self.assertIs(
-            AscendAttentionBackend.get_builder_cls(),
+            AscendAttentionPCPBackend.get_builder_cls(),
             AscendAttentionPCPMetadataBuilder,
         )
 
-    def test_pcp_and_dcp_are_rejected_together(self):
-        self.mock_config.parallel_config.prefill_context_parallel_size = 2
-        self.mock_config.parallel_config.decode_context_parallel_size = 2
-        self.enable_pcp.cache_clear()
-        self.enable_dcp.cache_clear()
+    def test_dcp_backend_uses_dcp_classes(self):
+        from vllm_ascend.attention.context_parallel.attention_cp import (
+            AscendAttentionDCPImpl,
+            AscendAttentionDCPMetadataBuilder,
+        )
 
-        with self.assertRaisesRegex(NotImplementedError, "PCP and DCP"):
-            AscendAttentionBackend.get_impl_cls()
-        with self.assertRaisesRegex(NotImplementedError, "PCP and DCP"):
-            AscendAttentionBackend.get_builder_cls()
+        self.assertIs(AscendAttentionDCPBackend.get_impl_cls(), AscendAttentionDCPImpl)
+        self.assertIs(AscendAttentionDCPBackend.get_builder_cls(), AscendAttentionDCPMetadataBuilder)
 
     def test_get_kv_cache_shape_not(self):
         result = AscendAttentionBackend.get_kv_cache_shape(10, 20, 30, 40)

--- a/tests/ut/attention/a2/test_mla_v1.py
+++ b/tests/ut/attention/a2/test_mla_v1.py
@@ -12,10 +12,12 @@ from vllm_ascend.ascend_config import init_ascend_config
 from vllm_ascend.attention.attention_v1 import AscendAttentionState
 from vllm_ascend.attention.mla_v1 import (
     AscendMLABackend,
+    AscendMLADCPBackend,
     AscendMLADecodeMetadata,
     AscendMLAImpl,
     AscendMLAMetadata,
     AscendMLAMetadataBuilder,
+    AscendMLAPCPBackend,
     AscendMLAPCPImpl,
     AscendMLAPCPMetadata,
     AscendMLAPCPMetadataBuilder,
@@ -28,75 +30,32 @@ from vllm_ascend.attention.utils import AscendCommonAttentionMetadata
 
 
 class TestAscendMLABackend(TestBase):
-    def setUp(self):
-        self.mock_config = MagicMock()
-
-        mock_parallel_config = MagicMock()
-        mock_parallel_config.prefill_context_parallel_size = 1
-        mock_parallel_config.decode_context_parallel_size = 1
-        self.mock_parallel_config = mock_parallel_config
-
-        self.mock_config.parallel_config = mock_parallel_config
-
-        self.utils_patcher = patch("vllm_ascend.attention.utils.get_current_vllm_config", return_value=self.mock_config)
-        self.utils_patcher.start()
-        self.mla_config_patcher = patch(
-            "vllm_ascend.attention.mla_v1.get_current_vllm_config",
-            return_value=self.mock_config,
-        )
-        self.mla_config_patcher.start()
-
-        from vllm_ascend.attention.utils import enable_dcp
-
-        enable_dcp.cache_clear()
-
     def test_get_name(self):
         self.assertEqual(AscendMLABackend.get_name(), "ASCEND_MLA")
 
-    @patch("vllm_ascend.attention.mla_v1.enable_pcp")
-    def test_get_builder_cls(self, mock_enable_pcp):
-        mock_enable_pcp.return_value = False
+    def test_get_builder_cls(self):
         self.assertEqual(AscendMLABackend.get_builder_cls(), AscendMLAMetadataBuilder)
-        mock_enable_pcp.return_value = True
-        self.assertIs(AscendMLABackend.get_builder_cls(), AscendMLAPCPMetadataBuilder)
+        self.assertIs(AscendMLAPCPBackend.get_builder_cls(), AscendMLAPCPMetadataBuilder)
 
     def test_get_kv_cache_shape(self):
         result = AscendMLABackend.get_kv_cache_shape(2, 4, 8, 128)
         self.assertEqual(result, (2, 4, 8, 128))
 
-    @patch("vllm_ascend.attention.mla_v1.enable_pcp")
-    def test_get_impl_cls(self, mock_enable_pcp):
-        mock_enable_pcp.return_value = False
+    def test_get_impl_cls(self):
         self.assertEqual(AscendMLABackend.get_impl_cls(), AscendMLAImpl)
-        mock_enable_pcp.return_value = True
-        self.assertIs(AscendMLABackend.get_impl_cls(), AscendMLAPCPImpl)
+        self.assertIs(AscendMLAPCPBackend.get_impl_cls(), AscendMLAPCPImpl)
 
     def test_get_supported_kernel_block_sizes(self):
         result = AscendMLABackend.get_supported_kernel_block_sizes()
         self.assertEqual(result, [128])
 
-    @patch("vllm_ascend.attention.mla_v1.enable_dcp")
-    def test_get_builder_cls_with_dcp(self, mock_enable_dcp):
-        mock_enable_dcp.return_value = True
-        builder_cls = AscendMLABackend.get_builder_cls()
+    def test_get_builder_cls_with_dcp(self):
+        builder_cls = AscendMLADCPBackend.get_builder_cls()
         self.assertIsNotNone(builder_cls)
 
-    @patch("vllm_ascend.attention.mla_v1.enable_dcp")
-    def test_get_impl_cls_with_dcp(self, mock_enable_dcp):
-        mock_enable_dcp.return_value = True
-        impl_cls = AscendMLABackend.get_impl_cls()
+    def test_get_impl_cls_with_dcp(self):
+        impl_cls = AscendMLADCPBackend.get_impl_cls()
         self.assertIsNotNone(impl_cls)
-
-    @patch("vllm_ascend.attention.mla_v1.enable_dcp")
-    @patch("vllm_ascend.attention.mla_v1.enable_pcp")
-    def test_pcp_and_dcp_are_rejected(self, mock_enable_pcp, mock_enable_dcp):
-        mock_enable_dcp.return_value = True
-        mock_enable_pcp.return_value = True
-
-        with self.assertRaisesRegex(NotImplementedError, "does not support PCP and DCP"):
-            AscendMLABackend.get_builder_cls()
-        with self.assertRaisesRegex(NotImplementedError, "does not support PCP and DCP"):
-            AscendMLABackend.get_impl_cls()
 
 
 def _make_pcp_metadata(

--- a/tests/ut/attention/a2/test_sfa_v1.py
+++ b/tests/ut/attention/a2/test_sfa_v1.py
@@ -22,6 +22,7 @@ from vllm_ascend.attention.sfa_kv_offload import (
 )
 from vllm_ascend.attention.sfa_v1 import (
     AscendSFABackend,
+    AscendSFADCPBackend,
     AscendSFAImpl,
     AscendSFAMetadata,
     AscendSFAMetadataBuilder,
@@ -81,20 +82,16 @@ class TestAscendSFABackend(TestBase):
         result = AscendSFABackend.get_impl_cls()
         self.assertEqual(result, AscendSFAImpl)
 
-    @patch("vllm_ascend.attention.context_parallel.sfa_cp.enable_sfa_dcp_replicated_indexer")
     @patch("vllm_ascend.attention.sfa_v1.get_ascend_config")
-    def test_get_builder_cls_with_dcp(self, mock_get_ascend_config, mock_enable_dcp):
-        mock_enable_dcp.return_value = True
+    def test_get_builder_cls_with_dcp(self, mock_get_ascend_config):
         mock_get_ascend_config.return_value.sparse_kv_offload_config.enabled = False
-        builder_cls = AscendSFABackend.get_builder_cls()
+        builder_cls = AscendSFADCPBackend.get_builder_cls()
         self.assertIsNotNone(builder_cls)
 
-    @patch("vllm_ascend.attention.context_parallel.sfa_cp.enable_sfa_dcp_replicated_indexer")
     @patch("vllm_ascend.attention.sfa_v1.get_ascend_config")
-    def test_get_impl_cls_with_dcp(self, mock_get_ascend_config, mock_enable_dcp):
-        mock_enable_dcp.return_value = True
+    def test_get_impl_cls_with_dcp(self, mock_get_ascend_config):
         mock_get_ascend_config.return_value.sparse_kv_offload_config.enabled = False
-        impl_cls = AscendSFABackend.get_impl_cls()
+        impl_cls = AscendSFADCPBackend.get_impl_cls()
         self.assertIsNotNone(impl_cls)
 
     @patch("vllm_ascend.attention.sfa_v1.get_ascend_config")

--- a/tests/ut/attention/test_dsa_v1.py
+++ b/tests/ut/attention/test_dsa_v1.py
@@ -33,7 +33,9 @@ from vllm_ascend.attention.dsa_v1 import (
     AscendDSALayerMetadata,
     AscendDSAMetadata,
     AscendDSAMetadataBuilder,
+    AscendDSAPCPBackend,
     AscendDSAReqMetadata,
+    select_dsa_backend,
 )
 from vllm_ascend.device.device_op import DeviceOperator
 from vllm_ascend.models.deepseek_v4.compressor import AscendCompressorMetadata
@@ -1090,23 +1092,17 @@ def test_prepared_cache_rejects_multistream_before_cache_access():
 
 
 def test_dsa_backend_selects_pcp_and_rejects_legacy_cp():
-    with (
-        patch("vllm_ascend.attention.dsa_v1.enable_pcp", return_value=True),
-        patch("vllm_ascend.utils.enable_dsa_cp", return_value=False),
-    ):
-        assert AscendDSABackend.get_builder_cls() is AscendDSAPCPMetadataBuilder
-        assert AscendDSABackend.get_impl_cls() is AscendDSAPCPImpl
+    with patch("vllm_ascend.utils.enable_dsa_cp", return_value=False):
+        backend = select_dsa_backend(AscendDSABackend, use_pcp=True)
+        assert backend is AscendDSAPCPBackend
+        assert backend.get_builder_cls() is AscendDSAPCPMetadataBuilder
+        assert backend.get_impl_cls() is AscendDSAPCPImpl
 
     with (
-        patch("vllm_ascend.attention.dsa_v1.enable_pcp", return_value=True),
         patch("vllm_ascend.utils.enable_dsa_cp", return_value=True),
+        pytest.raises(ValueError, match="cannot be enabled at the same time"),
     ):
-        for get_backend_cls in (
-            AscendDSABackend.get_builder_cls,
-            AscendDSABackend.get_impl_cls,
-        ):
-            with pytest.raises(ValueError, match="cannot be enabled at the same time"):
-                get_backend_cls()
+        select_dsa_backend(AscendDSABackend, use_pcp=True)
 
 
 def test_pcp_metadata_builds_from_manager_global_view():

--- a/tests/ut/attention/test_sfa_cp.py
+++ b/tests/ut/attention/test_sfa_cp.py
@@ -56,15 +56,9 @@ def test_sfa_cp_four_mode_resolution() -> None:
         (True, True): (AscendSFADSADCPMetadataBuilder, AscendSFADSADCPImpl),
     }
     for flags, classes in expected.items():
-        with (
-            patch("vllm_ascend.attention.context_parallel.sfa_cp.enable_dsa_cp", return_value=flags[0]),
-            patch(
-                "vllm_ascend.attention.context_parallel.sfa_cp.enable_sfa_dcp_replicated_indexer",
-                return_value=flags[1],
-            ),
-        ):
-            assert resolve_sfa_metadata_builder() is classes[0]
-            assert resolve_sfa_impl() is classes[1]
+        with patch("vllm_ascend.attention.context_parallel.sfa_cp.enable_dsa_cp", return_value=flags[0]):
+            assert resolve_sfa_metadata_builder(dcp_enabled=flags[1]) is classes[0]
+            assert resolve_sfa_impl(dcp_enabled=flags[1]) is classes[1]
 
 
 def test_sfa_cp_query_gather_axis_follows_composed_layout() -> None:

--- a/tests/ut/spec_decode/test_speculators_vwn_eagle3.py
+++ b/tests/ut/spec_decode/test_speculators_vwn_eagle3.py
@@ -154,16 +154,7 @@ def _mock_npu_env():
             side_effect=_cpu_add_rms_norm_bias,
             create=True,
         ),
-        # These tests do not exercise context parallelism. Short-circuit the
-        # backend routing checks so their mocked config stays scoped to VWN.
-        patch("vllm_ascend.attention.attention_v1.enable_pcp", return_value=False),
-        patch("vllm_ascend.attention.attention_v1.enable_dcp", return_value=False),
-        patch(
-            "vllm_ascend.attention.context_parallel.sfa_cp.enable_sfa_dcp_replicated_indexer",
-            return_value=False,
-        ),
         patch("vllm_ascend.attention.context_parallel.sfa_cp.enable_dsa_cp", return_value=False),
-        patch("vllm_ascend.attention.mla_v1.enable_dcp", return_value=False),
     ):
         yield
 

--- a/tests/ut/test_platform.py
+++ b/tests/ut/test_platform.py
@@ -1539,6 +1539,61 @@ class TestNPUPlatform(TestBase):
         result = self.platform.get_attn_backend_cls("ascend", attn_selector_config)
         self.assertEqual(result, "vllm_ascend.attention.attention_v1.AscendAttentionBackend")
 
+    @patch("vllm_ascend.platform.get_ascend_config")
+    def test_get_attn_backend_cls_selects_context_parallel_variants(self, mock_get_ascend_config):
+        mock_get_ascend_config.return_value.rl_config.enabled = False
+        mock_get_ascend_config.return_value.rl_config.enable_training_consistency = False
+        cases = [
+            (
+                dict(use_mla=False, use_sparse=False, use_pcp=True),
+                "vllm_ascend.attention.attention_v1.AscendAttentionPCPBackend",
+            ),
+            (
+                dict(use_mla=True, use_sparse=False, use_pcp=True),
+                "vllm_ascend.attention.mla_v1.AscendMLAPCPBackend",
+            ),
+            (
+                dict(use_mla=False, use_sparse=False, use_dcp=True),
+                "vllm_ascend.attention.attention_v1.AscendAttentionDCPBackend",
+            ),
+            (
+                dict(use_mla=True, use_sparse=False, use_dcp=True),
+                "vllm_ascend.attention.mla_v1.AscendMLADCPBackend",
+            ),
+            (
+                dict(use_mla=True, use_sparse=True, use_dcp=True),
+                "vllm_ascend.attention.sfa_v1.AscendSFADCPBackend",
+            ),
+        ]
+
+        for selector_overrides, expected in cases:
+            with self.subTest(selector_overrides=selector_overrides):
+                attn_selector_config = AttentionSelectorConfig(
+                    dtype=torch.float16,
+                    head_size=0,
+                    kv_cache_dtype=None,
+                    block_size=128,
+                    **selector_overrides,
+                )
+                result = self.platform.get_attn_backend_cls("ascend", attn_selector_config)
+                self.assertEqual(result, expected)
+
+    @patch("vllm_ascend.platform.get_ascend_config")
+    def test_get_attn_backend_cls_rejects_combined_pcp_dcp(self, mock_get_ascend_config):
+        mock_get_ascend_config.return_value.rl_config.enabled = False
+        mock_get_ascend_config.return_value.rl_config.enable_training_consistency = False
+        attn_selector_config = AttentionSelectorConfig(
+            dtype=torch.float16,
+            head_size=0,
+            kv_cache_dtype=None,
+            block_size=128,
+            use_pcp=True,
+            use_dcp=True,
+        )
+
+        with self.assertRaisesRegex(NotImplementedError, "PCP and DCP"):
+            self.platform.get_attn_backend_cls("ascend", attn_selector_config)
+
     @patch("vllm_ascend.platform.import_module")
     @patch("vllm_ascend.platform.util.find_spec", return_value=object())
     @patch("vllm_ascend.platform.get_ascend_config")

--- a/vllm_ascend/attention/attention_v1.py
+++ b/vllm_ascend/attention/attention_v1.py
@@ -45,8 +45,6 @@ from vllm_ascend.attention.utils import (
     AscendCommonAttentionMetadata,
     PagedAttentionGraphParam,
     cache_graph_workspace,
-    enable_dcp,
-    enable_pcp,
     needs_layer_aware_fia_graph_replay,
     notify_kv_cache_written,
     split_decodes_and_prefills,
@@ -84,30 +82,10 @@ class AscendAttentionBackend(AttentionBackend):
 
     @staticmethod
     def get_impl_cls() -> type["AscendAttentionBackendImpl"]:
-        pcp_enabled = enable_pcp()
-        dcp_enabled = enable_dcp()
-        if pcp_enabled and dcp_enabled:
-            raise NotImplementedError("Ascend MRV2 GQA does not support PCP and DCP simultaneously yet.")
-        if pcp_enabled:
-            return AscendAttentionPCPImpl
-        if dcp_enabled:
-            from vllm_ascend.attention.context_parallel.attention_cp import AscendAttentionDCPImpl
-
-            return AscendAttentionDCPImpl
         return AscendAttentionBackendImpl
 
     @staticmethod
     def get_builder_cls() -> type["AscendAttentionMetadataBuilder"]:
-        pcp_enabled = enable_pcp()
-        dcp_enabled = enable_dcp()
-        if pcp_enabled and dcp_enabled:
-            raise NotImplementedError("Ascend MRV2 GQA does not support PCP and DCP simultaneously yet.")
-        if pcp_enabled:
-            return AscendAttentionPCPMetadataBuilder
-        if dcp_enabled:
-            from vllm_ascend.attention.context_parallel.attention_cp import AscendAttentionDCPMetadataBuilder
-
-            return AscendAttentionDCPMetadataBuilder
         return AscendAttentionMetadataBuilder
 
     @staticmethod
@@ -151,6 +129,34 @@ class AscendAttentionBackend(AttentionBackend):
     @staticmethod
     def get_supported_kernel_block_sizes() -> list[int]:
         return [128]
+
+
+class AscendAttentionPCPBackend(AscendAttentionBackend):
+    """GQA backend selected when prefill context parallelism is enabled."""
+
+    @staticmethod
+    def get_impl_cls() -> type["AscendAttentionPCPImpl"]:
+        return AscendAttentionPCPImpl
+
+    @staticmethod
+    def get_builder_cls() -> type["AscendAttentionPCPMetadataBuilder"]:
+        return AscendAttentionPCPMetadataBuilder
+
+
+class AscendAttentionDCPBackend(AscendAttentionBackend):
+    """GQA backend selected when decode context parallelism is enabled."""
+
+    @staticmethod
+    def get_impl_cls():
+        from vllm_ascend.attention.context_parallel.attention_cp import AscendAttentionDCPImpl
+
+        return AscendAttentionDCPImpl
+
+    @staticmethod
+    def get_builder_cls():
+        from vllm_ascend.attention.context_parallel.attention_cp import AscendAttentionDCPMetadataBuilder
+
+        return AscendAttentionDCPMetadataBuilder
 
 
 class AscendAttentionState(Enum):

--- a/vllm_ascend/attention/context_parallel/sfa_cp.py
+++ b/vllm_ascend/attention/context_parallel/sfa_cp.py
@@ -31,7 +31,6 @@ from vllm_ascend.utils import (
     _round_up,
     enable_dsa_cp,
     enable_dsa_cp_with_o_proj_tp,
-    enable_sfa_dcp_replicated_indexer,
 )
 
 M = TypeVar("M", bound=AscendSFAMetadata)
@@ -1249,10 +1248,9 @@ class AscendSFADSADCPImpl(AscendSFADCPImpl, AscendSFADSACPImpl):
     """Composes DCP collectives around the DSA-CP SFA implementation."""
 
 
-def resolve_sfa_metadata_builder() -> type[AscendSFAMetadataBuilder]:
+def resolve_sfa_metadata_builder(*, dcp_enabled: bool) -> type[AscendSFAMetadataBuilder]:
     """Resolve one SFA metadata builder from the two independent CP switches."""
     dsa_cp_enabled = enable_dsa_cp()
-    dcp_enabled = enable_sfa_dcp_replicated_indexer()
     if dsa_cp_enabled and dcp_enabled:
         return AscendSFADSADCPMetadataBuilder
     if dsa_cp_enabled:
@@ -1262,10 +1260,9 @@ def resolve_sfa_metadata_builder() -> type[AscendSFAMetadataBuilder]:
     return AscendSFAMetadataBuilder
 
 
-def resolve_sfa_impl() -> type[AscendSFAImpl]:
+def resolve_sfa_impl(*, dcp_enabled: bool) -> type[AscendSFAImpl]:
     """Resolve one SFA implementation from the two independent CP switches."""
     dsa_cp_enabled = enable_dsa_cp()
-    dcp_enabled = enable_sfa_dcp_replicated_indexer()
     if dsa_cp_enabled and dcp_enabled:
         return AscendSFADSADCPImpl
     if dsa_cp_enabled:

--- a/vllm_ascend/attention/dsa_v1.py
+++ b/vllm_ascend/attention/dsa_v1.py
@@ -21,7 +21,6 @@ from vllm_ascend.ascend_forward_context import _EXTRA_CTX
 from vllm_ascend.attention.attention_v1 import AscendAttentionState
 from vllm_ascend.attention.utils import (
     AscendCommonAttentionMetadata,
-    enable_pcp,
     get_or_register_attention_buffer,
     maybe_save_kv_layer_to_connector,
     notify_kv_cache_written,
@@ -93,17 +92,10 @@ class AscendDSABackend(AttentionBackend):
         from vllm_ascend.utils import enable_dsa_cp
 
         use_dsa_cp = enable_dsa_cp()
-        use_pcp = enable_pcp()
-        if use_dsa_cp and use_pcp:
-            raise ValueError("Legacy DSACP and PCP cannot be enabled at the same time.")
         if use_dsa_cp:
             from vllm_ascend.attention.context_parallel.dsa_cp import AscendDSACPMetadataBuilder
 
             return AscendDSACPMetadataBuilder
-        if use_pcp:
-            from vllm_ascend.attention.context_parallel.dsa_cp import AscendDSAPCPMetadataBuilder
-
-            return AscendDSAPCPMetadataBuilder
         return AscendDSAMetadataBuilder
 
     @staticmethod
@@ -125,22 +117,31 @@ class AscendDSABackend(AttentionBackend):
         from vllm_ascend.utils import enable_dsa_cp
 
         use_dsa_cp = enable_dsa_cp()
-        use_pcp = enable_pcp()
-        if use_dsa_cp and use_pcp:
-            raise ValueError("Legacy DSACP and PCP cannot be enabled at the same time.")
         if use_dsa_cp:
             from vllm_ascend.attention.context_parallel.dsa_cp import AscendDSACPImpl
 
             return AscendDSACPImpl
-        if use_pcp:
-            from vllm_ascend.attention.context_parallel.dsa_cp import AscendDSAPCPImpl
-
-            return AscendDSAPCPImpl
         return AscendDSAImpl
 
     @staticmethod
     def get_supported_kernel_block_sizes() -> list[int]:
         return [2, 4, 8, 16, 32, 64, 128]
+
+
+class AscendDSAPCPBackend(AscendDSABackend):
+    """DSA backend selected when prefill context parallelism is enabled."""
+
+    @staticmethod
+    def get_builder_cls():
+        from vllm_ascend.attention.context_parallel.dsa_cp import AscendDSAPCPMetadataBuilder
+
+        return AscendDSAPCPMetadataBuilder
+
+    @staticmethod
+    def get_impl_cls() -> type[AttentionImplBase[Any]]:
+        from vllm_ascend.attention.context_parallel.dsa_cp import AscendDSAPCPImpl
+
+        return AscendDSAPCPImpl
 
 
 class AscendDSAC4Backend(AscendDSABackend):
@@ -197,6 +198,52 @@ class AscendDSAC128StateBackend(AscendDSABackend):
         if get_ascend_device_type() == AscendDeviceType.A5:
             return [4, 8, 16]
         return [8, 16, 32]
+
+
+class AscendDSAC4PCPBackend(AscendDSAPCPBackend, AscendDSAC4Backend):
+    pass
+
+
+class AscendDSAC128PCPBackend(AscendDSAPCPBackend, AscendDSAC128Backend):
+    pass
+
+
+class AscendDSASWAPCPBackend(AscendDSAPCPBackend, AscendDSASWABackend):
+    pass
+
+
+class AscendDSAC4StatePCPBackend(AscendDSAPCPBackend, AscendDSAC4StateBackend):
+    pass
+
+
+class AscendDSAC128StatePCPBackend(AscendDSAPCPBackend, AscendDSAC128StateBackend):
+    pass
+
+
+_DSA_PCP_BACKENDS: dict[type[AscendDSABackend], type[AscendDSABackend]] = {
+    AscendDSABackend: AscendDSAPCPBackend,
+    AscendDSAC4Backend: AscendDSAC4PCPBackend,
+    AscendDSAC128Backend: AscendDSAC128PCPBackend,
+    AscendDSASWABackend: AscendDSASWAPCPBackend,
+    AscendDSAC4StateBackend: AscendDSAC4StatePCPBackend,
+    AscendDSAC128StateBackend: AscendDSAC128StatePCPBackend,
+}
+
+
+def select_dsa_backend(
+    backend: type[AscendDSABackend],
+    *,
+    use_pcp: bool,
+) -> type[AscendDSABackend]:
+    """Resolve an explicitly attached DSA backend without global config reads."""
+    if not use_pcp:
+        return backend
+
+    from vllm_ascend.utils import enable_dsa_cp
+
+    if enable_dsa_cp():
+        raise ValueError("Legacy DSACP and PCP cannot be enabled at the same time.")
+    return _DSA_PCP_BACKENDS[backend]
 
 
 @dataclass

--- a/vllm_ascend/attention/mla_v1.py
+++ b/vllm_ascend/attention/mla_v1.py
@@ -28,8 +28,6 @@ from vllm_ascend.attention.attention_v1 import AscendAttentionState
 from vllm_ascend.attention.utils import (
     AscendCommonAttentionMetadata,
     ascend_chunked_prefill_workspace_size,
-    enable_dcp,
-    enable_pcp,
     enabling_mlapo,
     maybe_save_kv_layer_to_connector,
     notify_kv_cache_written,
@@ -92,16 +90,6 @@ class AscendMLABackend(AttentionBackend):
 
     @staticmethod
     def get_builder_cls():
-        dcp_enabled = enable_dcp()
-        pcp_enabled = enable_pcp()
-        if dcp_enabled and pcp_enabled:
-            raise NotImplementedError("Ascend MRV2 MLA does not support PCP and DCP simultaneously yet.")
-        if dcp_enabled:
-            from vllm_ascend.attention.context_parallel.mla_cp import AscendMlaDCPMetadataBuilder
-
-            return AscendMlaDCPMetadataBuilder
-        if pcp_enabled:
-            return AscendMLAPCPMetadataBuilder
         return AscendMLAMetadataBuilder
 
     @staticmethod
@@ -116,21 +104,39 @@ class AscendMLABackend(AttentionBackend):
 
     @staticmethod
     def get_impl_cls() -> type["MLAAttentionImpl"]:
-        dcp_enabled = enable_dcp()
-        pcp_enabled = enable_pcp()
-        if dcp_enabled and pcp_enabled:
-            raise NotImplementedError("Ascend MRV2 MLA does not support PCP and DCP simultaneously yet.")
-        if dcp_enabled:
-            from vllm_ascend.attention.context_parallel.mla_cp import AscendMlaDCPImpl
-
-            return AscendMlaDCPImpl
-        if pcp_enabled:
-            return AscendMLAPCPImpl
         return AscendMLAImpl
 
     @staticmethod
     def get_supported_kernel_block_sizes() -> list[int]:
         return [128]
+
+
+class AscendMLAPCPBackend(AscendMLABackend):
+    """MLA backend selected when prefill context parallelism is enabled."""
+
+    @staticmethod
+    def get_builder_cls():
+        return AscendMLAPCPMetadataBuilder
+
+    @staticmethod
+    def get_impl_cls() -> type["MLAAttentionImpl"]:
+        return AscendMLAPCPImpl
+
+
+class AscendMLADCPBackend(AscendMLABackend):
+    """MLA backend selected when decode context parallelism is enabled."""
+
+    @staticmethod
+    def get_builder_cls():
+        from vllm_ascend.attention.context_parallel.mla_cp import AscendMlaDCPMetadataBuilder
+
+        return AscendMlaDCPMetadataBuilder
+
+    @staticmethod
+    def get_impl_cls() -> type["MLAAttentionImpl"]:
+        from vllm_ascend.attention.context_parallel.mla_cp import AscendMlaDCPImpl
+
+        return AscendMlaDCPImpl
 
 
 @dataclass

--- a/vllm_ascend/attention/sfa_v1.py
+++ b/vllm_ascend/attention/sfa_v1.py
@@ -115,7 +115,7 @@ class AscendSFABackend(AttentionBackend):
             return AscendSFAKVOffloadMetadataBuilder
         from vllm_ascend.attention.context_parallel.sfa_cp import resolve_sfa_metadata_builder
 
-        return resolve_sfa_metadata_builder()
+        return resolve_sfa_metadata_builder(dcp_enabled=False)
 
     @staticmethod
     def get_kv_cache_shape(
@@ -135,11 +135,35 @@ class AscendSFABackend(AttentionBackend):
             return AscendSFAKVOffloadImpl
         from vllm_ascend.attention.context_parallel.sfa_cp import resolve_sfa_impl
 
-        return resolve_sfa_impl()
+        return resolve_sfa_impl(dcp_enabled=False)
 
     @staticmethod
     def get_supported_kernel_block_sizes() -> list[int]:
         return [128]
+
+
+class AscendSFADCPBackend(AscendSFABackend):
+    """SFA backend selected when decode context parallelism is enabled."""
+
+    @staticmethod
+    def get_builder_cls():
+        if get_ascend_config().sparse_kv_offload_config.enabled:
+            from vllm_ascend.attention.sfa_kv_offload import AscendSFAKVOffloadMetadataBuilder
+
+            return AscendSFAKVOffloadMetadataBuilder
+        from vllm_ascend.attention.context_parallel.sfa_cp import resolve_sfa_metadata_builder
+
+        return resolve_sfa_metadata_builder(dcp_enabled=True)
+
+    @staticmethod
+    def get_impl_cls() -> type["AscendSFAImpl"]:
+        if get_ascend_config().sparse_kv_offload_config.enabled:
+            from vllm_ascend.attention.sfa_kv_offload import AscendSFAKVOffloadImpl
+
+            return AscendSFAKVOffloadImpl
+        from vllm_ascend.attention.context_parallel.sfa_cp import resolve_sfa_impl
+
+        return resolve_sfa_impl(dcp_enabled=True)
 
 
 @dataclass

--- a/vllm_ascend/attention/utils.py
+++ b/vllm_ascend/attention/utils.py
@@ -222,18 +222,6 @@ def using_paged_attention(runtime_shape: int, vllm_config: VllmConfig, head_size
     return runtime_shape in get_ascend_config().pa_shape_list
 
 
-@lru_cache(maxsize=1)
-def enable_dcp():
-    parallel_config = get_current_vllm_config().parallel_config
-    return parallel_config.decode_context_parallel_size > 1
-
-
-@lru_cache(maxsize=1)
-def enable_pcp():
-    parallel_config = get_current_vllm_config().parallel_config
-    return parallel_config.prefill_context_parallel_size > 1
-
-
 @dataclass
 class AscendDCPMetadata:
     """Per-batch metadata required by decode context parallelism."""

--- a/vllm_ascend/models/deepseek_v4/compressor.py
+++ b/vllm_ascend/models/deepseek_v4/compressor.py
@@ -53,8 +53,10 @@ class AscendCompressorStateCache(CompressorStateCache):
         super().__init__(state_dim, dtype, compress_ratio, prefix)
         self.compress_ratio = compress_ratio
         self.block_size = block_size
+        self._use_pcp = False
 
     def get_kv_cache_spec(self, vllm_config: VllmConfig) -> KVCacheSpec:
+        self._use_pcp = vllm_config.parallel_config.prefill_context_parallel_size > 1
         from vllm_ascend.models.layer.attention.layer import DSV4_BLOCK_SIZES
 
         pads = DSV4_BLOCK_SIZES[vllm_config.cache_config.block_size][1]
@@ -75,13 +77,13 @@ class AscendCompressorStateCache(CompressorStateCache):
     def get_attn_backend(self):
         # Keep these imports lazy to avoid a model-inspection circular import.
         if self.compress_ratio == 4:
-            from vllm_ascend.attention.dsa_v1 import AscendDSAC4StateBackend
+            from vllm_ascend.attention.dsa_v1 import AscendDSAC4StateBackend, select_dsa_backend
 
-            return AscendDSAC4StateBackend
+            return select_dsa_backend(AscendDSAC4StateBackend, use_pcp=getattr(self, "_use_pcp", False))
         if self.compress_ratio == 128:
-            from vllm_ascend.attention.dsa_v1 import AscendDSAC128StateBackend
+            from vllm_ascend.attention.dsa_v1 import AscendDSAC128StateBackend, select_dsa_backend
 
-            return AscendDSAC128StateBackend
+            return select_dsa_backend(AscendDSAC128StateBackend, use_pcp=getattr(self, "_use_pcp", False))
         raise ValueError(f"Unsupported DeepSeek V4 state-cache compression ratio: {self.compress_ratio}")
 
 

--- a/vllm_ascend/models/deepseek_v4/indexer.py
+++ b/vllm_ascend/models/deepseek_v4/indexer.py
@@ -90,8 +90,10 @@ class AscendDeepseekV4IndexerCache(DeepseekV4IndexerCache):
         compress_ratio: int = 1,
     ):
         super().__init__(head_dim, dtype, prefix, cache_config, compress_ratio)
+        self._use_pcp = False
 
     def get_kv_cache_spec(self, vllm_config: VllmConfig) -> KVCacheSpec:
+        self._use_pcp = vllm_config.parallel_config.prefill_context_parallel_size > 1
         if get_ascend_device_type() in {AscendDeviceType.A5}:
             self.dtype = torch.float8_e4m3fn
             vllm_config.cache_config.cache_dtype = "float8_e4m3fn"
@@ -117,13 +119,13 @@ class AscendDeepseekV4IndexerCache(DeepseekV4IndexerCache):
     def get_attn_backend(self):
         # Keep these imports lazy to avoid a model-inspection circular import.
         if self.compress_ratio == 4:
-            from vllm_ascend.attention.dsa_v1 import AscendDSAC4Backend
+            from vllm_ascend.attention.dsa_v1 import AscendDSAC4Backend, select_dsa_backend
 
-            return AscendDSAC4Backend
+            return select_dsa_backend(AscendDSAC4Backend, use_pcp=getattr(self, "_use_pcp", False))
         if self.compress_ratio == 128:
-            from vllm_ascend.attention.dsa_v1 import AscendDSAC128Backend
+            from vllm_ascend.attention.dsa_v1 import AscendDSAC128Backend, select_dsa_backend
 
-            return AscendDSAC128Backend
+            return select_dsa_backend(AscendDSAC128Backend, use_pcp=getattr(self, "_use_pcp", False))
         raise ValueError(f"Unsupported DeepSeek V4 indexer compression ratio: {self.compress_ratio}")
 
 

--- a/vllm_ascend/models/deepseek_v4/model.py
+++ b/vllm_ascend/models/deepseek_v4/model.py
@@ -104,10 +104,12 @@ class AscendDeepseekV4SWACache(VllmDeepseekV4SWACache):
         from vllm_ascend.models.layer.attention.layer import DSV4_BLOCK_SIZES
 
         self.dtype = dtype
+        self._use_pcp = False
 
         self.block_size = DSV4_BLOCK_SIZES[cache_config.block_size][0][1]
 
     def get_kv_cache_spec(self, vllm_config: VllmConfig) -> KVCacheSpec:
+        self._use_pcp = vllm_config.parallel_config.prefill_context_parallel_size > 1
         if get_ascend_device_type() in {AscendDeviceType.A5}:
             self.dtype = torch.float8_e4m3fn
             vllm_config.cache_config.cache_dtype = "float8_e4m3fn"
@@ -126,9 +128,9 @@ class AscendDeepseekV4SWACache(VllmDeepseekV4SWACache):
     def forward(self): ...
 
     def get_attn_backend(self):
-        from vllm_ascend.attention.dsa_v1 import AscendDSASWABackend
+        from vllm_ascend.attention.dsa_v1 import AscendDSASWABackend, select_dsa_backend
 
-        return AscendDSASWABackend
+        return select_dsa_backend(AscendDSASWABackend, use_pcp=getattr(self, "_use_pcp", False))
 
 
 def precompute_freqs_cis_cpu(dim, seqlen, original_seq_len, base, factor, beta_fast, beta_slow) -> torch.Tensor:

--- a/vllm_ascend/models/layer/attention/layer.py
+++ b/vllm_ascend/models/layer/attention/layer.py
@@ -23,6 +23,7 @@ from vllm_ascend.attention.dsa_v1 import (
     AscendDSAC4Backend,
     AscendDSAC128Backend,
     AscendDSASWABackend,
+    select_dsa_backend,
 )
 from vllm_ascend.core.kv_cache_interface import AscendMLAAttentionSpec
 from vllm_ascend.utils import (
@@ -111,12 +112,14 @@ class DSAAttention(nn.Module, AttentionLayerBase):
         # Initialize KV cache quantization attributes
         _init_kv_cache_quant(self, quant_config, prefix)
 
+        use_pcp = get_current_vllm_config().parallel_config.prefill_context_parallel_size > 1
         if self.compress_ratio == 4:
             self.attn_backend = AscendDSAC4Backend
         elif self.compress_ratio == 128:
             self.attn_backend = AscendDSAC128Backend
         else:
             self.attn_backend = AscendDSASWABackend
+        self.attn_backend = select_dsa_backend(self.attn_backend, use_pcp=use_pcp)
 
         # NOTE(zxr): vllm_is_batch_invariant is delete during updating to v0.20.1
         if (

--- a/vllm_ascend/platform.py
+++ b/vllm_ascend/platform.py
@@ -218,6 +218,9 @@ class NPUPlatform(Platform):
         use_compress = getattr(attn_selector_config, "use_compress", False)
         key = (attn_selector_config.use_mla, attn_selector_config.use_sparse)
 
+        if attn_selector_config.use_pcp and attn_selector_config.use_dcp:
+            raise NotImplementedError("Ascend MRV2 does not support PCP and DCP simultaneously yet.")
+
         if _validate_fa3_backend(key, attn_selector_config):
             return "vllm_ascend.attention.fa3_v1.AscendFABackend"
 
@@ -240,7 +243,26 @@ class NPUPlatform(Platform):
         if is_310p():
             return backend_map_310.get(key, backend_map_310[(False, False)])
 
-        return backend_map[(attn_selector_config.use_mla, attn_selector_config.use_sparse, use_compress)]
+        backend_key = (attn_selector_config.use_mla, attn_selector_config.use_sparse, use_compress)
+        if attn_selector_config.use_pcp:
+            pcp_backend_map = {
+                (True, False, False): "vllm_ascend.attention.mla_v1.AscendMLAPCPBackend",
+                (False, False, False): "vllm_ascend.attention.attention_v1.AscendAttentionPCPBackend",
+                (True, False, True): "vllm_ascend.attention.dsa_v1.AscendDSAPCPBackend",
+            }
+            if backend_key in pcp_backend_map:
+                return pcp_backend_map[backend_key]
+
+        if attn_selector_config.use_dcp:
+            dcp_backend_map = {
+                (True, False, False): "vllm_ascend.attention.mla_v1.AscendMLADCPBackend",
+                (False, False, False): "vllm_ascend.attention.attention_v1.AscendAttentionDCPBackend",
+                (True, True, False): "vllm_ascend.attention.sfa_v1.AscendSFADCPBackend",
+            }
+            if backend_key in dcp_backend_map:
+                return dcp_backend_map[backend_key]
+
+        return backend_map[backend_key]
 
     @classmethod
     def import_kernels(cls) -> None:

--- a/vllm_ascend/worker/model_runner_v1.py
+++ b/vllm_ascend/worker/model_runner_v1.py
@@ -424,7 +424,7 @@ class NPUModelRunner(GPUModelRunner):
                 self.use_sparse,
             )
         self.sfa_dcp_replicated_indexer_size = 1
-        if enable_sfa_dcp_replicated_indexer():
+        if enable_sfa_dcp_replicated_indexer(self.vllm_config):
             self.sfa_dcp_replicated_indexer_size = self.dcp_size
 
         # Create a CPU numpy buffer for positions computation when


### PR DESCRIPTION
## What this PR does

- Select GQA, MLA, and SFA context-parallel backend variants from `AttentionSelectorConfig`.
- Keep attention implementation and metadata-builder classes stable across model and KV-cache initialization.
- Preserve DSA backend roles through explicit PCP variants.
- Pass SFA DCP state explicitly through backend resolution.

## Why

Attention backend class factories can be queried at multiple lifecycle phases. Selecting a concrete backend class from selector configuration makes implementation and metadata-builder resolution deterministic, including when multiple configurations coexist in one process.

## Validation

- Targeted Ruff checks for all modified Python files.
- Python byte-compilation for all modified Python files.
- `git diff --check`.

## Test coverage note

Ascend NPU unit tests were not run because a healthy isolated remote session was not available for safe current-tree synchronization.

- vLLM version: v0.27.1
- vLLM main: https://github.com/vllm-project/vllm/commit/ba07e4a48fc951300d97eb506217dd530583dea3
