### PR TITLE
 [v0.26.0][Feature][Kimi K3 DSPark] Enable TP for context_proj

### DIFF
--- a/vllm_ascend/models/kimi_k3_dspark.py
+++ b/vllm_ascend/models/kimi_k3_dspark.py
@@ -33,7 +33,6 @@ from vllm.model_executor.layers.layernorm import RMSNorm
 from vllm.model_executor.layers.linear import (
     ColumnParallelLinear,
     MergedColumnParallelLinear,
-    ReplicatedLinear,
     RowParallelLinear,
 )
 from vllm.model_executor.layers.logits_processor import LogitsProcessor
@@ -328,13 +327,14 @@ class K3DSparkModel(nn.Module):
         # _maybe_share_embeddings (has_own_embed_tokens=False).
         self.embed_tokens: nn.Module | None = None
 
-        self.context_proj = ReplicatedLinear(
+        self.context_proj = ColumnParallelLinear(
             self.config.target_hidden_size * self.config.num_target_layers,
             self.config.hidden_size,
             bias=False,
             return_bias=False,
             quant_config=self.quant_config,
             prefix=maybe_prefix(prefix, "context_proj"),
+            gather_output=True,
         )
         self.context_norm = RMSNorm(self.config.hidden_size, eps=self.config.rms_norm_eps)
 


### PR DESCRIPTION
Switch context_proj from ReplicatedLinear to ColumnParallelLinear (gather_output=True) so the projection weight [7168, 35840] is sharded along the output dim (7168) across TP ranks instead of being replicated.

This is not just a memory saving. During decode the context_proj GEMM is memory-bandwidth bound: profiling shows aic_mte2_ratio ~94% vs aic_mac_ratio ~8% (weight-load bound, batch=8). With the weight replicated, every rank re-reads the full ~490MB weight each step and the cluster bandwidth is not distributed. Sharding the output dim cuts the per-rank HBM weight read by TPx and spreads the traffic across ranks. gather_output=True reassembles [8, 7168] for context_norm, leaving the combine_hidden_states caller unchanged. Numerically equivalent to the replicated path; checkpoint layout unchanged.

idea from ：https://github.com/vllm-project/vllm-ascend/pull/15144

### What this PR does / why we need it?

### Does this PR introduce _any_ user-facing change?

### How was this patch tested?


- vLLM main: https://github.com/vllm-project/vllm/commit/d02df748bf9efd99022f1a062597dc3cb3808485
