### PR TITLE
[feature] reduce cases that required DP padding in mrv1

### DIFF
--- a/tests/e2e/pull_request/one_card/test_model_runner_v1_with_device.py
+++ b/tests/e2e/pull_request/one_card/test_model_runner_v1_with_device.py
@@ -440,10 +440,11 @@ def test_stateful_handoff_preserves_decode_graph(
         tensor_parallel_size=8,
         use_sequence_parallel_moe=True,
     )
+    cudagraph_capture_sizes = [8, 16, 24, 32]
     runner.compilation_config = SimpleNamespace(
         pass_config=SimpleNamespace(enable_sp=True),
         cudagraph_mode=CUDAGraphMode.FULL_DECODE_ONLY,
-        cudagraph_capture_sizes=[8, 16, 24, 32],
+        cudagraph_capture_sizes=cudagraph_capture_sizes,
         max_cudagraph_capture_size=32,
         compile_sizes=[],
     )
@@ -462,6 +463,9 @@ def test_stateful_handoff_preserves_decode_graph(
         num_prompt_tokens=np.array(prompts),
         lora_id_to_lora_request={},
     )
+    runner.ascend_config = SimpleNamespace(
+        get_mc2_comm_alg=lambda: "", finegrained_tp_config=SimpleNamespace(max_finegrained_tp_size=1)
+    )
     runner.cudagraph_dispatcher = CudagraphDispatcher(runner.vllm_config)
     runner.cudagraph_dispatcher.initialize_cudagraph_keys(
         CUDAGraphMode.FULL_DECODE_ONLY, runner.uniform_decode_query_len
@@ -476,8 +480,9 @@ def test_stateful_handoff_preserves_decode_graph(
     monkeypatch.setattr(f"{module}.should_skip_allreduce_across_dp_group", lambda *args: False)
     monkeypatch.setattr(f"{module}.get_dp_group", lambda: SimpleNamespace(cpu_group=None))
     monkeypatch.setattr(f"{module}.dist.all_reduce", all_reduce)
+    num_tokens = sum(scheduled)
     mode, descriptor, _, tokens_across_dp, _ = runner._determine_batch_execution_and_padding(
-        num_tokens=sum(scheduled),
+        num_tokens=num_tokens,
         num_reqs=len(scheduled),
         num_scheduled_tokens_np=np.array(scheduled, dtype=np.int32),
         max_num_scheduled_tokens=max(scheduled),
@@ -487,5 +492,12 @@ def test_stateful_handoff_preserves_decode_graph(
     assert mode == expected_mode
     assert descriptor.uniform == (expected_mode == CUDAGraphMode.FULL)
     if dp_size > 1:
-        assert descriptor.num_tokens == 32
-        torch.testing.assert_close(tokens_across_dp, torch.full((dp_size,), 32, dtype=torch.int32))
+        padded_num_tokens = num_tokens
+        for capture_size in cudagraph_capture_sizes:
+            if num_tokens <= capture_size:
+                padded_num_tokens = capture_size
+                break
+        assert descriptor.num_tokens == padded_num_tokens
+        expected_tokens_across_dp = torch.full((dp_size,), 32, dtype=torch.int32)
+        expected_tokens_across_dp[0] = padded_num_tokens
+        torch.testing.assert_close(tokens_across_dp, expected_tokens_across_dp)

--- a/tests/ut/ops/test_token_dispatcher.py
+++ b/tests/ut/ops/test_token_dispatcher.py
@@ -136,14 +136,15 @@ class TestTokenDispatcherWithMC2(TestBase):
 
         # Mock get_ascend_config()
         mock_ascend_config = MagicMock()
-        mock_ascend_config.mc2_comm_alg = ""
+        mock_ascend_config.get_mc2_comm_alg = MagicMock()
+        mock_ascend_config.get_mc2_comm_alg.return_value = ""
         mock_ascend_config.eplb_config = MagicMock()
         mock_ascend_config.eplb_config.dynamic_eplb = False
         mock_ascend_config.combine_quant_mode = 0
         self.ascend_config_patch = patch(
             "vllm_ascend.ops.fused_moe.token_dispatcher.get_ascend_config", return_value=mock_ascend_config
         )
-        self.ascend_config_patch.start()
+        self.mock_ascend_config = self.ascend_config_patch.start()
         self.ascend_config_utils_patch = patch("vllm_ascend.utils.get_ascend_config", return_value=mock_ascend_config)
         self.ascend_config_utils_patch.start()
         # Keep a handle so individual tests can set combine_quant_mode.
@@ -205,6 +206,8 @@ class TestTokenDispatcherWithMC2(TestBase):
         self.assertNotIn("x_active_mask", kwargs)
 
     def test_get_dispatch_mc2_kwargs_without_skip_allreduce_keeps_mc2_mask(self):
+        self.mock_skip_allreduce.return_value = False
+        dispatcher = TokenDispatcherWithMC2(with_quant=False, top_k=8, num_experts=128)
         hidden_states = torch.randn(10, 128)
         topk_ids = torch.randint(0, 8, (10, 1))
         topk_weights = torch.randn(10, 1)
@@ -218,7 +221,7 @@ class TestTokenDispatcherWithMC2(TestBase):
             mc2_mask=mc2_mask,
         )
 
-        kwargs = self.dispatcher.get_dispatch_mc2_kwargs(token_dispatch_input)
+        kwargs = dispatcher.get_dispatch_mc2_kwargs(token_dispatch_input)
 
         self.assertEqual(kwargs["global_bs"], 0)
         self.assertIs(kwargs["x_active_mask"], mc2_mask)

--- a/tests/ut/spec_decode/test_dspark_proposer.py
+++ b/tests/ut/spec_decode/test_dspark_proposer.py
@@ -130,7 +130,7 @@ def test_dspark_device_metadata_executor_forward_lifecycle(has_task: bool):
         device_metadata_executor=executor,
         dcp_manager=None,
         input_batch=SimpleNamespace(lora_id_to_lora_request={}),
-        _sync_metadata_across_dp=lambda num_tokens, **kwargs: (num_tokens, torch.tensor(1), None),
+        _sync_metadata_across_dp=lambda num_tokens, **kwargs: (num_tokens, None, None),
         dynamic_eplb=False,
         eplb_heat_collection_status=False,
     )
@@ -140,6 +140,7 @@ def test_dspark_device_metadata_executor_forward_lifecycle(has_task: bool):
     proposer.model = SimpleNamespace(combine_hidden_states=lambda hidden_states: hidden_states)
     proposer.hidden_size = 4
     proposer.use_cuda_graph = False
+    proposer.dp_rank = 0
     proposer.dcp_size = 1
     proposer.vllm_config = SimpleNamespace(model_config=SimpleNamespace(use_mla=True))
     proposer.draft_window_size = None

--- a/tests/ut/spec_decode/test_eagle_proposer.py
+++ b/tests/ut/spec_decode/test_eagle_proposer.py
@@ -1509,7 +1509,7 @@ class TestEagleProposerPropose:
         assert hasattr(RunnerCls, "_sync_metadata_across_dp")
         sig = inspect.signature(RunnerCls._sync_metadata_across_dp)
         sig_name = self.get_param_names(sig)
-        assert sig_name == ['self', 'num_tokens', 'is_draft_model', 'cudagraph_mode', 'allow_dp_padding']
+        assert sig_name == ['self', 'num_tokens', 'is_draft_model', 'cudagraph_mode']
 
         assert hasattr(RunnerCls, "_pad_query_start_loc_for_fia")
         sig = inspect.signature(RunnerCls._pad_query_start_loc_for_fia)

--- a/tests/ut/test_platform.py
+++ b/tests/ut/test_platform.py
@@ -73,7 +73,8 @@ class TestNPUPlatform(TestBase):
         mock_ascend_config.scheduler_config.recompute_scheduler_enable = False
         mock_ascend_config.scheduler_config.enable_balance_scheduling = False
         mock_ascend_config.scheduler_config.batch_job_sched_config.enabled = False
-        mock_ascend_config.mc2_comm_alg = ""
+        mock_ascend_config.get_mc2_comm_alg = MagicMock()
+        mock_ascend_config.get_mc2_comm_alg.return_value = ""
         mock_ascend_config.enable_fused_mc2 = False
         mock_ascend_config.enable_shared_expert_dp = False
         mock_ascend_config.scheduler_config.short_request_first_config.enabled = False

--- a/vllm_ascend/ascend_config.py
+++ b/vllm_ascend/ascend_config.py
@@ -965,10 +965,13 @@ class FinegrainedTPConfig:
             "mlp_tensor_parallel_size",
             "olora_tensor_parallel_size",
         )
+        self.max_finegrained_tp_size = 1
         for field_name in size_fields:
             value = getattr(self, field_name)
             if value < 0:
                 raise ValueError(f"finegrained_tp_config.{field_name} must be non-negative, got {value}")
+            self.max_finegrained_tp_size = max(self.max_finegrained_tp_size, value)
+
         return self
 
     def _validate_preconditions(self, vllm_config: Any):

--- a/vllm_ascend/ascend_forward_context.py
+++ b/vllm_ascend/ascend_forward_context.py
@@ -144,10 +144,7 @@ def set_ascend_forward_context(
         from vllm_ascend.ops.fused_moe.moe_comm_method import get_moe_comm_method
 
         max_num_tokens = int(num_tokens_across_dp.max().item()) if num_tokens_across_dp is not None else num_tokens
-        moe_comm_type = select_moe_comm_method(
-            max_num_tokens,
-            vllm_config,
-        )
+        moe_comm_type = select_moe_comm_method(max_num_tokens, vllm_config)
 
         forward_context.moe_comm_type = moe_comm_type
         forward_context.moe_comm_method = get_moe_comm_method(moe_comm_type)

--- a/vllm_ascend/ops/fused_moe/token_dispatcher.py
+++ b/vllm_ascend/ops/fused_moe/token_dispatcher.py
@@ -138,7 +138,7 @@ class TokenDispatcherWithMC2(MoETokenDispatcher[MoEMC2CombineMetadata]):
         _max_global_bs = num_tokens_per_tp_rank * self.ep_world_size
 
         # When allreduce across DP is not skipped, tokens are uniform across ranks:
-        # use global_bs=0 (uniform mode) and pass mc2_mask.
+        # use global_bs=0 (uniform mode) and pass mc2_mask to improve performance.
         # When allreduce is skipped, tokens may differ per rank:
         # use the real global_bs and do NOT pass mc2_mask.
         self.global_bs = _max_global_bs if should_skip_allreduce_across_dp_group(vllm_config) else 0

--- a/vllm_ascend/spec_decode/dflash_proposer.py
+++ b/vllm_ascend/spec_decode/dflash_proposer.py
@@ -205,6 +205,8 @@ class AscendDflashProposer(AscendEagleProposer):
             num_tokens_across_dp,
             _,
         ) = self.runner._sync_metadata_across_dp(num_query_tokens, is_draft_model=True)
+        if num_tokens_across_dp is not None:
+            num_input_tokens = int(num_tokens_across_dp[self.dp_rank].item())
 
         if not self.use_cuda_graph:
             aclgraph_runtime_mode = CUDAGraphMode.NONE

--- a/vllm_ascend/spec_decode/dspark_proposer.py
+++ b/vllm_ascend/spec_decode/dspark_proposer.py
@@ -358,6 +358,8 @@ class AscendDSparkProposer(AscendDflashProposer):
             num_tokens_across_dp,
             _,
         ) = self.runner._sync_metadata_across_dp(num_query_tokens, is_draft_model=True)
+        if num_tokens_across_dp is not None:
+            num_input_tokens = int(num_tokens_across_dp[self.dp_rank].item())
 
         if not self.use_cuda_graph:
             aclgraph_runtime_mode = CUDAGraphMode.NONE

--- a/vllm_ascend/spec_decode/extract_hidden_states_proposer.py
+++ b/vllm_ascend/spec_decode/extract_hidden_states_proposer.py
@@ -97,7 +97,6 @@ class AscendExtractHiddenStatesProposer(ExtractHiddenStatesProposer):
                 num_tokens=num_tokens_padded,
                 is_draft_model=True,
                 cudagraph_mode=cudagraph_mode,
-                allow_dp_padding=use_cudagraphs,
             )
 
             if num_tokens_across_dp is not None:
@@ -138,10 +137,12 @@ class AscendExtractHiddenStatesProposer(ExtractHiddenStatesProposer):
         # llm_base_proposer.dummy_run); otherwise the DP cpu_group collectives
         # desynchronize and the group deadlocks.
         (
-            num_tokens,
+            _,
             num_tokens_across_dp,
             _,
         ) = self.runner._sync_metadata_across_dp(num_tokens, is_draft_model=True)
+        if num_tokens_across_dp is not None:
+            num_tokens = int(num_tokens_across_dp[self.dp_rank].item())
 
         with set_forward_context(
             None,

--- a/vllm_ascend/spec_decode/llm_base_proposer.py
+++ b/vllm_ascend/spec_decode/llm_base_proposer.py
@@ -658,10 +658,12 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
         is_profile=False,
     ):
         (
-            num_tokens,
+            _,
             num_tokens_across_dp,
             _,
         ) = self.runner._sync_metadata_across_dp(num_tokens, is_draft_model=True)
+        if num_tokens_across_dp is not None:
+            num_tokens = int(num_tokens_across_dp[self.dp_rank].item())
         dcp_manager = getattr(self.runner, "dcp_manager", None)
 
         multi_steps_attn_metadata = []
@@ -931,10 +933,12 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
             num_input_tokens = num_tokens
 
         (
-            num_input_tokens,
+            _,
             num_tokens_across_dp,
             _,
         ) = self.runner._sync_metadata_across_dp(num_input_tokens, is_draft_model=True)
+        if num_tokens_across_dp is not None:
+            num_input_tokens = int(num_tokens_across_dp[self.dp_rank].item())
 
         if self.use_cuda_graph:
             aclgraph_runtime_mode, batch_descriptor = self.runner.cudagraph_dispatcher.dispatch(

--- a/vllm_ascend/spec_decode/step3p5.py
+++ b/vllm_ascend/spec_decode/step3p5.py
@@ -219,10 +219,12 @@ class AscendStep3p5MTPProposer(AscendEagleProposer):
         is_profile=False,
     ):
         (
-            num_tokens,
+            _,
             num_tokens_across_dp,
             _,
         ) = self.runner._sync_metadata_across_dp(num_tokens, is_draft_model=True)
+        if num_tokens_across_dp is not None:
+            num_tokens = int(num_tokens_across_dp[self.dp_rank].item())
 
         multi_steps_attn_metadata: list[dict[str, Any]] = []
         if not self.use_cuda_graph:
@@ -387,10 +389,12 @@ class AscendStep3p5MTPProposer(AscendEagleProposer):
             num_input_tokens = num_tokens
 
         (
-            num_input_tokens,
+            _,
             num_tokens_across_dp,
             _,
         ) = self.runner._sync_metadata_across_dp(num_input_tokens, is_draft_model=True)
+        if num_tokens_across_dp is not None:
+            num_input_tokens = int(num_tokens_across_dp[self.dp_rank].item())
 
         if self.use_cuda_graph:
             aclgraph_runtime_mode, batch_descriptor = self.runner.cudagraph_dispatcher.dispatch(

--- a/vllm_ascend/worker/model_runner_v1.py
+++ b/vllm_ascend/worker/model_runner_v1.py
@@ -176,7 +176,6 @@ from vllm_ascend.spec_decode.utils import (
 from vllm_ascend.utils import (
     calc_split_factor,
     check_gdn_layer,
-    embedding_tp_enable,
     enable_dsa_cp,
     enable_sfa,
     enable_sfa_dcp_replicated_indexer,
@@ -188,7 +187,6 @@ from vllm_ascend.utils import (
     is_score_encoder_cache_manager,
     kv_cache_spec_uses_sparse_sfa_c8,
     lmhead_tp_enable,
-    oproj_tp_enable,
     set_potential_max_tokens,
     should_skip_allreduce_across_dp_group,
     weak_ref_tensor,
@@ -735,7 +733,6 @@ class NPUModelRunner(GPUModelRunner):
         num_tokens: int,
         is_draft_model: bool = False,
         cudagraph_mode: CUDAGraphMode = CUDAGraphMode.NONE,
-        allow_dp_padding: bool = False,
     ) -> tuple[int, torch.Tensor | None, CUDAGraphMode]:
         # TODO: In vLLM, the only thing that needs to be synced is num_tokens, but in
         # our case, we still need to sync the other two flags as well. So we need to
@@ -761,7 +758,14 @@ class NPUModelRunner(GPUModelRunner):
         synced_cudagraph_mode = CUDAGraphMode(_post_process_cudagraph_mode(packed_tensor))
 
         # Create a tensor for num_tokens_after_padding
-        if allow_dp_padding or is_draft_model:
+        comm_method = select_moe_comm_method(max_tokens_across_dp, self.vllm_config)
+        is_finegrained_tp = self.ascend_config.finegrained_tp_config.max_finegrained_tp_size > 1
+        # There are three cases where padding between DPs is required:
+        # 1. comm_method == ALLGATHER, ensure the input tensor shape of allgather is consistent;
+        # 2. comm_method == MC2, reduce communication and computation through active_mask to enhance performance;
+        # 3. when finegrained_tp is open, we need to ensure num_tokens remains consistent within finegrained_tp_group.
+        #    TODO(zzzzwwjj): We can do dp padding in finegrained_tp_group, instead of world_group.
+        if comm_method in {MoECommType.ALLGATHER, MoECommType.MC2} or is_finegrained_tp:
             num_tokens_after_padding = torch.tensor(
                 [max_tokens_across_dp] * self.dp_size, device="cpu", dtype=torch.int32
             )
@@ -3106,10 +3110,6 @@ class NPUModelRunner(GPUModelRunner):
             _, num_tokens_across_dp, synced_cudagraph_mode = self._sync_metadata_across_dp(
                 num_tokens=num_tokens_padded,
                 cudagraph_mode=cudagraph_mode,
-                allow_dp_padding=((cudagraph_mode != CUDAGraphMode.NONE)
-                                  or enable_sp(self.vllm_config)
-                                  or oproj_tp_enable()
-                                  or embedding_tp_enable()),
             )
 
             # Extract DP padding if there is any
@@ -3650,7 +3650,7 @@ class NPUModelRunner(GPUModelRunner):
         num_reqs_padded = batch_desc.num_reqs if batch_desc.num_reqs is not None else num_reqs
         if num_tokens_across_dp is not None and num_tokens_padded != num_tokens:
             # pad is needed if the pad of `num_tokens` is triggered inside CudagraphDispatcher
-            num_tokens_across_dp[:] = num_tokens_padded
+            num_tokens_across_dp[self.dp_rank] = num_tokens_padded
             num_scheduled_tokens = num_scheduled_tokens.repeat(num_reqs_padded)
 
         if self.dynamic_eplb:


### PR DESCRIPTION
### What this PR does / why we need it?

Reducing the cases that required DP padding.

Before this pr, if one of the three cases is met, padding is required:
1. cudagraphmode != None;
2. enable_sp == True;
3. is_draft_model == True;

This is not reasonable, some cases do not require padding across dp.

And after this pr, there are three cases where padding between DPs is required:
1. comm_method == ALLGATHER;
2. comm_method == MC2, reduce communication and computation through active_mask to enhance performance;
3. when finegrained_tp is open, we need to ensure num_tokens remains consistent within finegrained_tp_group.

### Does this PR introduce _any_ user-facing change?

None

### How was this patch tested?

- vLLM main: https://github.com/vllm-project/vllm/commit/e6bfe03ad73a3330cb427885aa90d97a12e1c704
