### PR TITLE
[BugFix][Worker] Enable Kimi K3 hybrid caches in MRV2

### DIFF
--- a/docs/source/tutorials/models/Kimi-K3.md
+++ b/docs/source/tutorials/models/Kimi-K3.md
@@ -151,6 +151,31 @@ Lower `--max-model-len` and `--max-num-batched-tokens` for a short smoke test.
 The larger values above require a capacity check with the exact checkpoint and
 runner memory configuration.
 
+### Model Runner V2
+
+Enable MRV2 before starting the single-node deployment:
+
+```shell
+export VLLM_USE_V2_MODEL_RUNNER=1
+```
+
+For generation without a draft model, omit `--speculative-config` from the
+launch command. The bounded functional configuration uses
+`--max-model-len 4096`, `--max-num-seqs 4`, `--max-num-batched-tokens 512`,
+and `--mamba-cache-mode align`.
+Use `--enforce-eager` for eager execution, or
+`--compilation-config '{"cudagraph_mode":"FULL_DECODE_ONLY"}'` for ACL Graph.
+The model, parallelism, and KV cache layout settings remain unchanged.
+
+The validated MRV2 scope is bounded single-node text generation without a
+draft model, including prefix caching, chunked prefill, and ACL Graph.
+This does not establish full-checkpoint accuracy, long-context capacity,
+multi-node, or P/D support.
+
+DSpark under MRV2 is experimental and has a known warm-prefix token-consistency
+issue. Use MRV1 (`VLLM_USE_V2_MODEL_RUNNER=0`) for DSpark workloads that require
+prefix-cache consistency.
+
 ## 6 Four-Node Full-Checkpoint Deployment
 
 The full checkpoint uses four Atlas 800 A3 nodes in a DP4/TP16/EP64 mixed

--- a/tests/e2e/pull_request/sixteen_card/test_kimi_k3.py
+++ b/tests/e2e/pull_request/sixteen_card/test_kimi_k3.py
@@ -304,8 +304,8 @@ def k3_models(tmp_path_factory: pytest.TempPathFactory) -> dict[str, str]:
 
 
 @pytest.fixture(autouse=True)
-def k3_runtime(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setenv("VLLM_USE_V2_MODEL_RUNNER", "0")
+def k3_runtime(monkeypatch: pytest.MonkeyPatch, request: pytest.FixtureRequest) -> None:
+    monkeypatch.setenv("VLLM_USE_V2_MODEL_RUNNER", getattr(request, "param", "0"))
     monkeypatch.setenv("VLLM_WORKER_MULTIPROC_METHOD", "spawn")
     monkeypatch.setenv("HCCL_OP_EXPANSION_MODE", "AIV")
     monkeypatch.setenv("HCCL_BUFFSIZE", "512")
@@ -374,6 +374,7 @@ def _generate(llm, prompts: list[dict]):
     return outputs
 
 
+@pytest.mark.parametrize("k3_runtime", ["0", "1"], indirect=True, ids=["mrv1", "mrv2"])
 def test_k3_mla_block5_tp16(k3_models: dict[str, str]) -> None:
     args = _engine_args(k3_models, "mla_block5")
     with VllmRunner(k3_models["target"], **args) as runner:
@@ -397,6 +398,29 @@ def test_k3_mla_block5_tp16(k3_models: dict[str, str]) -> None:
         drafts = [m for m in llm.get_metrics() if m.name == "vllm:spec_decode_num_drafts"]
         assert drafts and all(isinstance(m, Counter) for m in drafts)
         assert sum(m.value for m in drafts) > 0, "Requests bypassed speculative decoding"
+
+
+@pytest.mark.parametrize("k3_runtime", ["1"], indirect=True, ids=["mrv2"])
+@pytest.mark.parametrize("enforce_eager", [True, False], ids=["eager", "aclgraph"])
+def test_k3_mrv2_without_draft(k3_models: dict[str, str], enforce_eager: bool) -> None:
+    args = _engine_args(k3_models, "mla_block5")
+    del args["speculative_config"]
+    args["enforce_eager"] = enforce_eager
+    args["compilation_config"] = {"cudagraph_mode": "FULL_DECODE_ONLY", "cudagraph_capture_sizes": [1, 2, 4]}
+    with VllmRunner(k3_models["target"], **args) as runner:
+        llm = runner.model
+        _generate(llm, [_prompt(length, salt=i * 137) for i, length in enumerate((127, 128, 129, 769))])
+        prefix = _prompt(1153, salt=421)
+        assert llm.reset_prefix_cache()
+        cold = _generate(llm, [prefix])[0]
+        warm = _generate(llm, [prefix])[0]
+        assert cold.num_cached_tokens == 0
+        assert warm.num_cached_tokens > 0
+        assert cold.outputs[0].token_ids == warm.outputs[0].token_ids
+        assert llm.reset_prefix_cache()
+        reset = _generate(llm, [prefix])[0]
+        assert reset.num_cached_tokens == 0
+        assert cold.outputs[0].token_ids == reset.outputs[0].token_ids
 
 
 def _serve_args(args: dict) -> list[str]:

--- a/tests/ut/worker/a2/test_kv_block_zeroer_npu.py
+++ b/tests/ut/worker/a2/test_kv_block_zeroer_npu.py
@@ -1,0 +1,79 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from types import SimpleNamespace
+
+import pytest
+import torch
+from vllm.v1.kv_cache_interface import FullAttentionSpec
+
+from vllm_ascend.core.kv_cache_interface import AscendMLAAttentionSpec
+from vllm_ascend.ops.triton.triton_utils import init_device_properties_triton
+from vllm_ascend.worker.utils import AscendKVBlockZeroer
+
+
+@pytest.mark.parametrize("ratio", [1, 3])
+@pytest.mark.parametrize("padded", [False, True])
+def test_zero_split_kv_blocks_preserves_other_blocks_and_padding(ratio, padded):
+    device = torch.device("npu")
+    init_device_properties_triton()
+    num_blocks, kernel_bs = 4, 128
+    spec = FullAttentionSpec(block_size=kernel_bs * ratio, num_kv_heads=1, head_size=64, dtype=torch.bfloat16)
+    caches = []
+    expected_caches = []
+    raw_buffers = []
+    expected_buffers = []
+    for width, dtype in ((512, torch.bfloat16), (64, torch.bfloat16), (32, torch.int8)):
+        payload = kernel_bs * width
+        stride = payload + (128 if padded else 0)
+        raw = torch.full((128 + num_blocks * ratio * stride,), 7, dtype=dtype, device=device)
+        expected = raw.clone()
+        shape, strides = (num_blocks * ratio, kernel_bs, 1, width), (stride, width, width, 1)
+        caches.append(torch.as_strided(raw, shape, strides, storage_offset=128))
+        expected_caches.append(torch.as_strided(expected, shape, strides, storage_offset=128))
+        raw_buffers.append(raw)
+        expected_buffers.append(expected)
+    caches.append(torch.empty(num_blocks * ratio, kernel_bs, 1, 0, dtype=torch.bfloat16, device=device))
+    group = SimpleNamespace(kv_cache_spec=spec, kv_cache_group_id=0, layer_names=["attn", "shared"])
+    zeroer = AscendKVBlockZeroer(device, pin_memory=True)
+    zeroer.init_meta(
+        [group],
+        [[kernel_bs]],
+        "auto",
+        set(),
+        {name: SimpleNamespace(kv_cache=tuple(caches)) for name in group.layer_names},
+    )
+    for block_ids in ([0], [1, 3]):
+        zeroer.zero_block_ids(block_ids)
+        for cache in expected_caches:
+            for block_id in block_ids:
+                cache[block_id * ratio : (block_id + 1) * ratio].zero_()
+        torch.npu.synchronize()
+        for actual, expected in zip(raw_buffers, expected_buffers):
+            torch.testing.assert_close(actual, expected, rtol=0, atol=0)
+
+
+def test_zero_hybrid_split_views_sharing_one_allocation():
+    device = torch.device("npu")
+    init_device_properties_triton()
+    num_blocks, block_size = 4, 128
+    state_elements = 1024
+    key_elements, value_elements = num_blocks * block_size * 512, num_blocks * block_size * 64
+    raw = torch.full((state_elements + key_elements + value_elements,), 7, dtype=torch.bfloat16, device=device)
+    expected = raw.clone()
+
+    def views(buffer):
+        k = buffer[state_elements : state_elements + key_elements].view(num_blocks, block_size, 1, 512)
+        v = buffer[state_elements + key_elements :].view(num_blocks, block_size, 1, 64)
+        return k, v
+
+    spec = AscendMLAAttentionSpec(block_size=block_size, num_kv_heads=1, head_size=576, dtype=torch.bfloat16)
+    group = SimpleNamespace(kv_cache_spec=spec, kv_cache_group_id=0, layer_names=["attn"])
+    zeroer = AscendKVBlockZeroer(device, pin_memory=True)
+    zeroer.init_meta([group], [[block_size]], "auto", set(), {"attn": SimpleNamespace(kv_cache=views(raw))})
+    zeroer.zero_block_ids([1, 3])
+    for cache in views(expected):
+        cache[1].zero_()
+        cache[3].zero_()
+    torch.npu.synchronize()
+    torch.testing.assert_close(raw, expected, rtol=0, atol=0)

--- a/tests/ut/worker/test_kv_block_zeroer.py
+++ b/tests/ut/worker/test_kv_block_zeroer.py
@@ -1,0 +1,176 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+import torch
+from vllm.v1.core.block_pool import BlockPool
+from vllm.v1.core.single_type_kv_cache_manager import get_manager_for_kv_cache_spec
+from vllm.v1.kv_cache_interface import FullAttentionSpec, MambaSpec
+
+from vllm_ascend.attention.mla_v1 import AscendMLABackend
+from vllm_ascend.core.kv_cache_interface import (
+    AscendMLAAttentionSpec,
+    AscendSFAIndexerCacheSpec,
+    register_ascend_kv_cache_specs,
+)
+from vllm_ascend.worker.utils import AscendKVBlockZeroer
+from vllm_ascend.worker.v2.model_runner import NPUModelRunner
+
+
+def _group(spec, names, group_id=0):
+    return SimpleNamespace(kv_cache_spec=spec, layer_names=names, kv_cache_group_id=group_id)
+
+
+def _init_zeroer(groups, caches, kernel_sizes, excluded=None):
+    zeroer = AscendKVBlockZeroer(torch.device("cpu"), pin_memory=False)
+    zeroer.init_meta(
+        groups,
+        kernel_sizes,
+        "auto",
+        set() if excluded is None else excluded,
+        {name: SimpleNamespace(kv_cache=cache) for name, cache in caches.items()},
+    )
+    return zeroer
+
+
+def test_mla_backend_accepts_upstream_cache_dtype_keyword():
+    assert AscendMLABackend.get_kv_cache_block_dim(128, 1, 576, cache_dtype_str="auto") == 0
+    assert AscendMLABackend.get_kv_cache_shape(2, 128, 1, 576, cache_dtype_str="auto") == (2, 128, 1, 576)
+
+
+@pytest.mark.parametrize("spec_cls", [AscendMLAAttentionSpec, AscendSFAIndexerCacheSpec])
+@pytest.mark.parametrize("needs_zeroing", [False, True])
+def test_ascend_attention_managers_record_new_blocks_for_zeroing(spec_cls, needs_zeroing):
+    register_ascend_kv_cache_specs()
+    spec = spec_cls(block_size=384, num_kv_heads=1, head_size=64, dtype=torch.bfloat16)
+    manager = get_manager_for_kv_cache_spec(
+        spec,
+        max_in_flight_tokens=512,
+        max_model_len=4096,
+        block_pool=BlockPool(16, enable_caching=False, hash_block_size=384),
+        enable_caching=False,
+        kv_cache_group_id=0,
+        scheduler_block_size=384,
+        needs_kv_cache_zeroing=needs_zeroing,
+    )
+    blocks = manager.allocate_new_blocks("request", 385, 385)
+    assert len(blocks) == 2
+    assert manager.take_new_block_ids() == ([block.block_id for block in blocks] if needs_zeroing else [])
+    assert manager.take_new_block_ids() == []
+
+
+def test_mixed_mla_gqa_pages_skip_empty_shared_and_mamba_views():
+    mla_spec = AscendMLAAttentionSpec(block_size=384, num_kv_heads=1, head_size=576, dtype=torch.bfloat16)
+    gqa_spec = FullAttentionSpec(block_size=128, num_kv_heads=2, head_size=64, dtype=torch.bfloat16)
+    mamba_spec = MambaSpec(block_size=384, shapes=((2, 4),), dtypes=(torch.float32,))
+    k = torch.empty(6, 128, 1, 512, dtype=torch.bfloat16)
+    rope = torch.empty(6, 128, 1, 64, dtype=torch.bfloat16)
+    gqa_k = torch.empty(2, 128, 2, 64, dtype=torch.int8)
+    gqa_v = torch.empty(2, 128, 2, 64, dtype=torch.bfloat16)
+    groups = [
+        _group(mla_spec, ["mla", "shared", "excluded", "no_rope"]),
+        _group(gqa_spec, ["gqa"], 1),
+        _group(mamba_spec, ["mamba"], 2),
+        _group(gqa_spec, ["unallocated"], 3),
+    ]
+    zeroer = _init_zeroer(
+        groups,
+        {
+            "mla": (k, rope),
+            "shared": (k, rope),
+            "no_rope": (k, torch.empty(6, 128, 1, 0)),
+            "gqa": (gqa_k, gqa_v),
+        },
+        [[128], [128], [384]],
+        excluded={"excluded"},
+    )
+    addrs, sizes, strides, max_chunks, chunk_size, num_segments = zeroer._meta
+    assert addrs.tolist() == [cache.data_ptr() for cache in (k, rope, gqa_k, gqa_v)]
+    assert sizes.tolist() == [384 * 512 // 2, 384 * 64 // 2, 128 * 2 * 64 // 4, 128 * 2 * 64 // 2]
+    assert torch.equal(sizes, strides)
+    assert num_segments == 4
+    assert max_chunks * chunk_size == max(sizes.tolist())
+
+
+@pytest.mark.parametrize("ratio", [1, 3])
+def test_strided_views_keep_payload_separate_from_scheduler_stride(ratio):
+    spec = FullAttentionSpec(block_size=4 * ratio, num_kv_heads=1, head_size=2, dtype=torch.float32)
+    raw = torch.empty(2 * ratio * 24 + 4, dtype=torch.float32)
+    # Distinct components share storage, with a leading offset and guard holes.
+    k = torch.as_strided(raw, (2 * ratio, 4, 1, 2), (24, 2, 2, 1), storage_offset=4)
+    v = torch.as_strided(raw, (2 * ratio, 4, 1, 2), (24, 2, 2, 1), storage_offset=12)
+    zeroer = _init_zeroer([_group(spec, ["attn"])], {"attn": (k, v)}, [[4]])
+    addrs, sizes, strides, _, _, num_segments = zeroer._meta
+    assert addrs.tolist() == [cache.data_ptr() + i * 24 * 4 for cache in (k, v) for i in range(ratio)]
+    assert sizes.tolist() == [8] * (2 * ratio)
+    assert strides.tolist() == [24 * ratio] * (2 * ratio)
+    assert num_segments == 2 * ratio
+
+
+def test_compressed_cache_uses_physical_block_size():
+    spec = AscendMLAAttentionSpec(block_size=128, num_kv_heads=1, head_size=8, dtype=torch.bfloat16, compress_ratio=4)
+    cache = torch.empty(2, 32, 1, 8, dtype=torch.bfloat16)
+    zeroer = _init_zeroer([_group(spec, ["attn"])], {"attn": (cache,)}, [[128]])
+    assert zeroer._meta[1].tolist() == [32 * 8 // 2]
+
+
+def test_zeroer_empty_cache_is_noop():
+    zeroer = _init_zeroer([], {}, [])
+    assert zeroer._meta is None
+    with patch("vllm_ascend.worker.utils._zero_kv_blocks_kernel") as kernel:
+        zeroer.zero_block_ids([0])
+        zeroer.zero_block_ids([])
+        kernel.__getitem__.assert_not_called()
+
+
+@pytest.mark.parametrize(
+    "cache",
+    [torch.empty(2, 1, 1, 1, dtype=torch.int8), torch.empty(2, 4, 2, 2).transpose(1, 2)],
+    ids=["unaligned-payload", "noncontiguous-inner-dimensions"],
+)
+def test_zeroer_rejects_unsupported_component_layout(cache):
+    spec = FullAttentionSpec(block_size=4, num_kv_heads=1, head_size=2, dtype=torch.float32)
+    with pytest.raises(AssertionError):
+        _init_zeroer([_group(spec, ["attn"])], {"attn": (cache,)}, [[4]])
+
+
+def test_zeroer_reuses_block_id_buffers_and_dispatches_all_segments():
+    spec = FullAttentionSpec(block_size=4, num_kv_heads=1, head_size=2, dtype=torch.float32)
+    k, v = torch.empty(3, 4, 1, 2), torch.empty(3, 4, 1, 2)
+    zeroer = _init_zeroer([_group(spec, ["attn"])], {"attn": (k, v)}, [[4]])
+    ids = zeroer._ids_gpu
+    with (
+        patch("vllm_ascend.worker.utils._zero_kv_blocks_kernel") as kernel,
+        patch("vllm_ascend.worker.utils.get_vectorcore_num", return_value=8),
+    ):
+        zeroer.zero_block_ids([])
+        kernel.__getitem__.assert_not_called()
+        zeroer.warmup(3)
+        zeroer.zero_block_ids([1, 2])
+        assert zeroer._ids_gpu is ids
+        assert ids[:2].tolist() == [1, 2]
+        args, kwargs = kernel.__getitem__.return_value.call_args
+        assert args[4] == 2
+        assert kwargs["N_SEGS"] == 2
+        assert kwargs["MAX_CHUNKS"] == 1
+
+
+def test_mrv2_initializes_ascend_zeroer_on_the_upstream_attribute():
+    group = object()
+    runner = SimpleNamespace(
+        device=torch.device("cpu"),
+        attn_groups=[[group]],
+        kernel_block_sizes=[128],
+        cache_config=SimpleNamespace(cache_dtype="auto"),
+        compilation_config=SimpleNamespace(static_forward_context={}),
+    )
+    with patch("vllm_ascend.worker.v2.model_runner.AscendKVBlockZeroer") as zeroer_cls:
+        NPUModelRunner._init_kv_zero_meta(runner)
+    assert runner.kv_block_zeroer is zeroer_cls.return_value
+    kwargs = runner.kv_block_zeroer.init_meta.call_args.kwargs
+    assert list(kwargs["attn_groups_iter"]) == [group]
+    assert kwargs["kernel_block_sizes"] == [[128]]
+    assert kwargs["static_forward_context"] is runner.compilation_config.static_forward_context

--- a/tests/ut/worker/test_model_runner_v2_mamba.py
+++ b/tests/ut/worker/test_model_runner_v2_mamba.py
@@ -1,8 +1,10 @@
 import ast
+from contextlib import nullcontext
 from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
+import pytest
 import torch
 from vllm.v1.kv_cache_interface import (
     FullAttentionSpec,
@@ -10,6 +12,7 @@ from vllm.v1.kv_cache_interface import (
     KVCacheGroupSpec,
     KVCacheTensor,
     MambaSpec,
+    UniformTypeKVCacheSpecs,
 )
 from vllm.v1.worker.gpu.model_states.mamba_hybrid import MambaHybridModelState
 
@@ -18,7 +21,9 @@ from vllm_ascend.worker.v2.attn_utils import (
     _allocate_kv_cache,
     _reshape_kv_cache_v2,
     get_kv_cache_spec,
+    normalize_mamba_kv_cache_config,
 )
+from vllm_ascend.worker.v2.model_runner import NPUModelRunner
 from vllm_ascend.worker.v2.model_states import init_asecnd_model_state
 from vllm_ascend.worker.v2.model_states.mamba_hybrid import (
     AscendMambaHybridModelState,
@@ -67,6 +72,86 @@ def test_mamba_model_state_inherits_upstream_state_management():
     assert issubclass(AscendMambaHybridModelState, MambaHybridModelState)
     assert AscendMambaHybridModelState.preprocess_state is MambaHybridModelState.preprocess_state
     assert AscendMambaHybridModelState.postprocess_state is MambaHybridModelState.postprocess_state
+    assert AscendMambaHybridModelState._get_mamba_group_info is MambaHybridModelState._get_mamba_group_info
+
+
+@pytest.mark.parametrize("wrapped", [False, True])
+@pytest.mark.parametrize("prefix_caching", [False, True])
+def test_mamba_worker_groups_reserve_speculative_block_table_entries(wrapped, prefix_caching):
+    spec = MambaSpec(
+        block_size=384,
+        shapes=((10, 6), (2, 2)),
+        dtypes=(torch.float16, torch.float32),
+        num_speculative_blocks=7,
+        mamba_cache_mode="align",
+    )
+    attention_specs = {
+        name: FullAttentionSpec(block_size=384, num_kv_heads=1, head_size=head_size, dtype=torch.float16)
+        for name, head_size in (("target", 8), ("draft", 16))
+    }
+    attention_spec = UniformTypeKVCacheSpecs.from_specs(attention_specs)
+    assert attention_spec is not None
+    groups = [KVCacheGroupSpec(layer_names=list(attention_specs), kv_cache_spec=attention_spec)]
+    for group_id in range(2):
+        layer_names = [f"mamba.{group_id}.{layer_id}" for layer_id in range(2)]
+        group_spec = UniformTypeKVCacheSpecs.from_specs(dict.fromkeys(layer_names, spec)) if wrapped else spec
+        assert group_spec is not None
+        groups.append(KVCacheGroupSpec(layer_names=layer_names, kv_cache_spec=group_spec))
+    config = KVCacheConfig(num_blocks=3, kv_cache_tensors=[], kv_cache_groups=groups)
+    runner = object.__new__(NPUModelRunner)
+    runner.max_model_len = 4096
+    runner.is_encoder_decoder = False
+    runner.dcp_size = 1
+    runner.dcp_rank = 0
+    runner.cp_interleave = 1
+    runner.max_num_reqs = 4
+    runner.max_num_tokens = 512
+    runner.device = torch.device("cpu")
+    runner.cache_config = SimpleNamespace(enable_prefix_caching=prefix_caching)
+    runner.vllm_config = SimpleNamespace()
+    runner.model_state = MagicMock()
+    runner.model_state.get_additional_cg_support.return_value = []
+
+    class BlockTablesReached(Exception):
+        pass
+
+    with (
+        patch("vllm_ascend.worker.v2.model_runner.graph_manager_wrapper", return_value=nullcontext()),
+        patch("vllm.v1.worker.gpu.model_runner.init_attn_backend", return_value=([], MagicMock(), [128, 384, 384])),
+        patch("vllm.v1.worker.gpu.model_runner.BlockTables", side_effect=BlockTablesReached) as block_tables,
+        pytest.raises(BlockTablesReached),
+    ):
+        runner.initialize_kv_cache(config)
+
+    # Exercise upstream sizing, not a reimplementation of its arithmetic.
+    expected_mamba_width = (11 if prefix_caching else 1) + spec.num_speculative_blocks
+    assert block_tables.call_args.kwargs["max_num_blocks_per_group"] == [11, expected_mamba_width, expected_mamba_width]
+    worker_groups = runner.kv_cache_config.kv_cache_groups
+    assert worker_groups[0].kv_cache_spec == attention_spec
+    assert worker_groups[1].kv_cache_spec == worker_groups[2].kv_cache_spec == spec
+    # No mutation of the config shared with the scheduler/other workers.
+    assert isinstance(config.kv_cache_groups[1].kv_cache_spec, UniformTypeKVCacheSpecs) == wrapped
+    state = object.__new__(AscendMambaHybridModelState)
+    state._mamba_spec = None
+    state._mamba_group_ids = []
+    assert state._get_mamba_group_info(runner.kv_cache_config) == ([1, 2], spec)
+    assert state._get_mamba_group_info(runner.kv_cache_config) == ([1, 2], spec)
+
+
+def test_mamba_normalization_preserves_distinct_per_layer_state_layouts():
+    specs = {
+        "first": _mamba_spec(),
+        "second": MambaSpec(block_size=16, shapes=((4, 3), (2, 2)), dtypes=(torch.float16, torch.float32)),
+    }
+    group_spec = UniformTypeKVCacheSpecs.from_specs(specs)
+    assert group_spec is not None
+    config = KVCacheConfig(
+        num_blocks=3,
+        kv_cache_tensors=[],
+        kv_cache_groups=[KVCacheGroupSpec(layer_names=list(specs), kv_cache_spec=group_spec)],
+    )
+    normalized = normalize_mamba_kv_cache_config(config)
+    assert normalized.kv_cache_groups[0].kv_cache_spec is group_spec
 
 
 def test_prepare_inputs_propagates_padded_request_count():

--- a/vllm_ascend/attention/mla_v1.py
+++ b/vllm_ascend/attention/mla_v1.py
@@ -110,7 +110,7 @@ class AscendMLABackend(AttentionBackend):
         block_size: int,
         num_kv_heads: int,
         head_size: int,
-        cache_type: str = "",
+        cache_dtype_str: str = "auto",
     ) -> tuple[int, ...]:
         return num_blocks, block_size, num_kv_heads, head_size
 

--- a/vllm_ascend/core/kv_cache_interface.py
+++ b/vllm_ascend/core/kv_cache_interface.py
@@ -224,15 +224,25 @@ class AscendSlidingWindowMLASpec(SlidingWindowMLASpec):
         )
 
 
+class AscendFullAttentionManager(FullAttentionManager):
+    """Keep Ascend full-attention specs in the scheduler's zeroing lifecycle."""
+
+    def __init__(self, kv_cache_spec: KVCacheSpec, **kwargs) -> None:
+        super().__init__(kv_cache_spec, **kwargs)
+        # Upstream's exact-type whitelist omits custom MLA/indexer specs.
+        # The Ascend zeroer supports both; retain the config-level opt-in.
+        self._record_new_block_ids = kwargs.get("needs_kv_cache_zeroing", False)
+
+
 def register_ascend_kv_cache_specs() -> None:
     KVCacheSpecRegistry.register(
         kvcache_spec_cls=AscendMLAAttentionSpec,
-        manager_class=FullAttentionManager,
+        manager_class=AscendFullAttentionManager,
         uniform_type_base_spec=FullAttentionSpec,
     )
     KVCacheSpecRegistry.register(
         kvcache_spec_cls=AscendSFAIndexerCacheSpec,
-        manager_class=FullAttentionManager,
+        manager_class=AscendFullAttentionManager,
         uniform_type_base_spec=FullAttentionSpec,
     )
     KVCacheSpecRegistry.register(

--- a/vllm_ascend/worker/utils.py
+++ b/vllm_ascend/worker/utils.py
@@ -1,5 +1,5 @@
 from collections.abc import Iterable
-from itertools import product as iprod
+from math import prod
 from typing import Any
 
 import torch
@@ -8,25 +8,29 @@ from vllm.utils.math_utils import largest_power_of_2_divisor
 from vllm.v1.kv_cache_interface import FullAttentionSpec
 from vllm.v1.worker.utils import AttentionGroup, KVBlockZeroer
 
+from vllm_ascend.core.kv_cache_interface import get_storage_block_size
 from vllm_ascend.ops.triton.triton_utils import get_vectorcore_num
+
+ZERO_BLOCK_SIZE = 8192
+INITIAL_BLOCK_ID_CAPACITY = 8192
 
 
 @triton.jit
 def _zero_kv_blocks_kernel(
     seg_addrs_ptr,
+    seg_page_sizes_ptr,
+    seg_page_strides_ptr,
     block_ids_ptr,
     n_blocks,
     N_SEGS: tl.constexpr,
-    PAGE_SIZE_EL: tl.constexpr,
+    MAX_CHUNKS: tl.constexpr,
     BLOCK_SIZE: tl.constexpr,
     GRID_SIZE: tl.constexpr,
 ):
     """Zero KV cache blocks across all segments in a single launch.
 
-    Each segment is a contiguous region of one block's data.  For backends
-    where blocks are outermost (block_dim=0) there is one segment per
-    buffer.  For backends where K/V is outermost (block_dim=1) there are
-    two segments per buffer (one for K, one for V).
+    Each segment is a contiguous region of one scheduler block's data.
+    Separate sizes and strides preserve padding and other hybrid cache views.
 
     seg_addrs_ptr holds absolute byte addresses (int64) for each segment,
     allowing segments to live in different CUDA allocations.
@@ -34,20 +38,21 @@ def _zero_kv_blocks_kernel(
     Programs are mapped as (block_index, seg_index, chunk_index).
     """
     pid = tl.program_id(0)
-    chunks = PAGE_SIZE_EL // BLOCK_SIZE
-    work_per_block = N_SEGS * chunks
+    work_per_block = N_SEGS * MAX_CHUNKS
     total_work = n_blocks * work_per_block
     for work_idx in range(pid, total_work, GRID_SIZE):
         block_index = work_idx // work_per_block
         remainder = work_idx % work_per_block
-        seg_index = remainder // chunks
-        chunk_index = remainder % chunks
+        seg_index = remainder // MAX_CHUNKS
+        chunk_index = remainder % MAX_CHUNKS
         block_id = tl.load(block_ids_ptr + block_index)
         seg_addr = tl.load(seg_addrs_ptr + seg_index)
+        page_size_el = tl.load(seg_page_sizes_ptr + seg_index)
+        page_stride_el = tl.load(seg_page_strides_ptr + seg_index)
         ptr = tl.cast(seg_addr, tl.pointer_type(tl.int32))
-        offset = block_id.to(tl.int64) * PAGE_SIZE_EL + chunk_index.to(tl.int64) * BLOCK_SIZE
-        cols = tl.arange(0, BLOCK_SIZE).to(tl.int64)
-        tl.store(ptr + offset + cols, tl.zeros([BLOCK_SIZE], dtype=tl.int32))
+        offset = block_id.to(tl.int64) * page_stride_el
+        cols = chunk_index.to(tl.int64) * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE).to(tl.int64)
+        tl.store(ptr + offset + cols, tl.zeros([BLOCK_SIZE], dtype=tl.int32), mask=cols < page_size_el)
 
 
 class AscendKVBlockZeroer(KVBlockZeroer):
@@ -61,7 +66,7 @@ class AscendKVBlockZeroer(KVBlockZeroer):
     def __init__(self, device: torch.device, pin_memory: bool) -> None:
         self.device = device
         self.pin_memory = pin_memory
-        self._meta: tuple[torch.Tensor, int, int, int] | None = None
+        self._meta: tuple[torch.Tensor, torch.Tensor, torch.Tensor, int, int, int] | None = None
         self._id_cap: int = 0
         self._ids_pinned: torch.Tensor | None = None
         self._ids_gpu: torch.Tensor | None = None
@@ -82,14 +87,15 @@ class AscendKVBlockZeroer(KVBlockZeroer):
 
         Block IDs from the scheduler reference logical blocks whose size
         may differ from the kernel block size (virtual block splitting).
-        PAGE_SIZE_EL accounts for this ratio so that
-        ``block_id * PAGE_SIZE_EL`` lands at the correct offset.
+        Per-segment page strides account for this ratio. The payload size
+        excludes padding, which may belong to another hybrid cache view.
 
         Only AttentionSpec layers are processed; Mamba layers are skipped.
         """
         seen_ptrs: set[int] = set()
         seg_addrs: list[int] = []
-        page_size_el: int | None = None
+        seg_page_sizes: list[int] = []
+        seg_page_strides: list[int] = []
 
         for group in attn_groups_iter:
             spec = group.kv_cache_spec
@@ -98,45 +104,50 @@ class AscendKVBlockZeroer(KVBlockZeroer):
             if group.kv_cache_group_id >= len(kernel_block_sizes):
                 continue
             kernel_bs = kernel_block_sizes[group.kv_cache_group_id][0]
-            ratio = spec.block_size // kernel_bs
-            block_dim = 0
+            storage_bs = get_storage_block_size(spec)
+            # Compressed caches are reshaped with one physical block per
+            # scheduler block, rather than the uncompressed kernel size.
+            if storage_bs != spec.block_size:
+                kernel_bs = storage_bs
+            assert storage_bs % kernel_bs == 0
+            ratio = storage_bs // kernel_bs
 
             for layer_name in group.layer_names:
                 if layer_name in runner_only_attn_layers:
                     continue
                 kv_tuple = static_forward_context[layer_name].kv_cache
-                assert len(kv_tuple) == 2, "K and V are not stored separately"
                 for kv in kv_tuple:
-                    block_dim = 0
+                    # No-RoPE MLA can expose an empty second component.
+                    if kv.numel() == 0:
+                        continue
                     dp = kv.data_ptr()
                     if dp in seen_ptrs:
                         continue
                     seen_ptrs.add(dp)
 
-                    el = kv.element_size()
-                    cur_bytes = kv.stride(block_dim) * el
-                    assert cur_bytes % 4 == 0
-                    kernel_block_el = cur_bytes // 4
-                    cur_page_el = kernel_block_el * ratio
-                    if page_size_el is None:
-                        page_size_el = cur_page_el
+                    assert kv[0].is_contiguous(), "KV blocks must have contiguous inner dimensions"
+                    stride_bytes = kv.stride(0) * kv.element_size()
+                    payload_bytes = prod(kv.shape[1:]) * kv.element_size()
+                    assert stride_bytes >= payload_bytes
+                    assert stride_bytes % 4 == 0 and payload_bytes % 4 == 0 and dp % 4 == 0
+                    if stride_bytes == payload_bytes:
+                        # Coalesce contiguous virtual blocks into one segment.
+                        seg_addrs.append(dp)
+                        seg_page_sizes.append(payload_bytes * ratio // 4)
+                        seg_page_strides.append(stride_bytes * ratio // 4)
                     else:
-                        assert page_size_el == cur_page_el, f"Non-uniform page sizes: {page_size_el} vs {cur_page_el}"
+                        for sub_block in range(ratio):
+                            seg_addrs.append(dp + sub_block * stride_bytes)
+                            seg_page_sizes.append(payload_bytes // 4)
+                            seg_page_strides.append(stride_bytes * ratio // 4)
 
-                    block_stride_bytes = cur_bytes
-                    outer_dims = [d for d in range(block_dim) if kv.stride(d) * el > block_stride_bytes]
-                    outer_strides = [kv.stride(d) * el for d in outer_dims]
-                    for outer in iprod(*(range(kv.shape[d]) for d in outer_dims)):
-                        off_bytes = sum(i * s for i, s in zip(outer, outer_strides))
-                        seg_addrs.append(dp + off_bytes)
-
-        if not seg_addrs or page_size_el is None:
+        if not seg_addrs:
             self._meta = None
             return
 
-        # _zero_kv_blocks_kernel will use int64 zeros, to meet the UB size, we use blk_size=64B/8B=8192
-        blk_size = min(largest_power_of_2_divisor(page_size_el), 8192)
-        self._id_cap = 8192
+        # Bound each int32 store to 32 KiB of UB space.
+        blk_size = min(min(largest_power_of_2_divisor(size) for size in seg_page_sizes), ZERO_BLOCK_SIZE)
+        self._id_cap = INITIAL_BLOCK_ID_CAPACITY
         self._ids_pinned = torch.empty(
             self._id_cap,
             dtype=torch.int64,
@@ -145,7 +156,9 @@ class AscendKVBlockZeroer(KVBlockZeroer):
         self._ids_gpu = torch.empty(self._id_cap, dtype=torch.int64, device=self.device)
         self._meta = (
             torch.tensor(seg_addrs, dtype=torch.uint64, device=self.device),
-            page_size_el,
+            torch.tensor(seg_page_sizes, dtype=torch.int64, device=self.device),
+            torch.tensor(seg_page_strides, dtype=torch.int64, device=self.device),
+            max(seg_page_sizes) // blk_size,
             blk_size,
             len(seg_addrs),
         )
@@ -154,7 +167,7 @@ class AscendKVBlockZeroer(KVBlockZeroer):
         """Zero the KV cache memory for the given block IDs."""
         if not block_ids or self._meta is None:
             return
-        seg_addrs, page_size_el, blk_size, n_segs = self._meta
+        seg_addrs, seg_page_sizes, seg_page_strides, max_chunks, blk_size, n_segs = self._meta
         n_blocks = len(block_ids)
         if n_blocks > self._id_cap:
             self._id_cap = n_blocks * 2
@@ -168,17 +181,18 @@ class AscendKVBlockZeroer(KVBlockZeroer):
         self._ids_pinned[:n_blocks].numpy()[:] = block_ids
         idx = self._ids_gpu[:n_blocks]
         idx.copy_(self._ids_pinned[:n_blocks], non_blocking=True)
-        chunks = page_size_el // blk_size
-        total_work = n_blocks * n_segs * chunks
+        total_work = n_blocks * n_segs * max_chunks
         grid = min(total_work, get_vectorcore_num()) if total_work > 0 else 0
         if grid == 0:
             return
         _zero_kv_blocks_kernel[(grid,)](
             seg_addrs,
+            seg_page_sizes,
+            seg_page_strides,
             idx,
             n_blocks,
             N_SEGS=n_segs,
-            PAGE_SIZE_EL=page_size_el,
+            MAX_CHUNKS=max_chunks,
             BLOCK_SIZE=blk_size,
             GRID_SIZE=grid,
         )

--- a/vllm_ascend/worker/v2/attn_utils.py
+++ b/vllm_ascend/worker/v2/attn_utils.py
@@ -61,6 +61,24 @@ if TYPE_CHECKING:
     from vllm_ascend.worker.v2.pcp_manager import AscendPCPAttentionContext
 
 
+def normalize_mamba_kv_cache_config(kv_cache_config: KVCacheConfig) -> KVCacheConfig:
+    """Expose identical Mamba specs to upstream MRV2 sizing and state handling."""
+    groups = []
+    for group in kv_cache_config.kv_cache_groups:
+        spec = group.kv_cache_spec
+        if isinstance(spec, UniformTypeKVCacheSpecs):
+            inner_specs = list(spec.kv_cache_specs.values())
+            if (
+                inner_specs
+                and isinstance(inner_specs[0], MambaSpec)
+                and all(inner == inner_specs[0] for inner in inner_specs)
+            ):
+                group = replace(group, kv_cache_spec=inner_specs[0])
+        groups.append(group)
+    # Preserve per-layer attention layouts and the caller's worker config.
+    return replace(kv_cache_config, kv_cache_groups=groups)
+
+
 def get_kv_cache_spec(vllm_config: VllmConfig) -> dict[str, KVCacheSpec]:
     """Build Ascend-specific KV cache specs for v2 worker patching."""
     from vllm.model_executor.models.deepseek_v2 import DeepseekV32IndexerCache

--- a/vllm_ascend/worker/v2/model_runner.py
+++ b/vllm_ascend/worker/v2/model_runner.py
@@ -57,12 +57,13 @@ from vllm_ascend.core.profiling_chunk_predictor import (
 )
 from vllm_ascend.ops.rotary_embedding import set_cos_and_sin, update_cos_sin
 from vllm_ascend.utils import lmhead_tp_enable, set_potential_max_tokens, vllm_version_is
+from vllm_ascend.worker.utils import AscendKVBlockZeroer
 
 if not vllm_version_is("0.27.1"):
     from vllm.v1.worker.gpu.model_runner import BatchReqState
 
 from vllm_ascend.worker.v2.aclgraph_utils import ModelAclGraphManager
-from vllm_ascend.worker.v2.attn_utils import build_attn_state
+from vllm_ascend.worker.v2.attn_utils import build_attn_state, normalize_mamba_kv_cache_config
 from vllm_ascend.worker.v2.eplb import AscendEPLBController
 from vllm_ascend.worker.v2.input_batch import AscendInputBatch, AscendInputBuffers
 from vllm_ascend.worker.v2.pcp_manager import AscendPCPManager
@@ -214,6 +215,9 @@ class NPUModelRunner(GPUModelRunner):
         return output
 
     def initialize_kv_cache(self, kv_cache_config: KVCacheConfig) -> None:
+        # Upstream sizes speculative Mamba block tables using the bare spec.
+        # K3 DSpark worker configs retain uniform per-layer group wrappers.
+        kv_cache_config = normalize_mamba_kv_cache_config(kv_cache_config)
         with graph_manager_wrapper(self), _use_ascend_pcp_manager_for_vllm_0271():
             super().initialize_kv_cache(kv_cache_config)
             if self.pcp_manager is not None:
@@ -222,6 +226,18 @@ class NPUModelRunner(GPUModelRunner):
                 self.model_state.pcp_manager = self.pcp_manager
         if self.model_config.enable_return_routed_experts:
             self.init_routed_experts_capturer()
+
+    def _init_kv_zero_meta(self) -> None:
+        # The upstream zeroer only handles a single tensor per layer. Ascend
+        # binds separate K/V views, including unequal MLA cache components.
+        self.kv_block_zeroer = AscendKVBlockZeroer(self.device, pin_memory=True)
+        self.kv_block_zeroer.init_meta(
+            attn_groups_iter=(group for groups in self.attn_groups for group in groups),
+            kernel_block_sizes=[[block_size] for block_size in self.kernel_block_sizes],
+            cache_dtype=self.cache_config.cache_dtype,
+            runner_only_attn_layers=set(),
+            static_forward_context=self.compilation_config.static_forward_context,
+        )
 
     @torch.inference_mode()
     def execute_model(


### PR DESCRIPTION
### What this PR does / why we need it?

Enable Kimi K3 hybrid-cache initialization and zeroing in Model Runner V2:

- Align the MLA cache-shape API with the upstream `cache_dtype_str` contract.
- Wire split-KV zeroing through MRV2 and the Ascend attention managers, including unequal components, virtual blocks, and padded/shared storage.
- Normalize identical Mamba group specs before initialization so speculative state slots are sized correctly.
- Add CPU/NPU regressions and opt-in MRV2 K3 e2e coverage.

KV layouts and Mamba preprocess/postprocess remain unchanged.

### Does this PR introduce _any_ user-facing change?

Yes. Enable MRV2 with `VLLM_USE_V2_MODEL_RUNNER=1`. The validated functional scope is single-node text generation without a draft model, including prefix caching, chunked prefill, and `FULL_DECODE_ONLY` ACL Graph.

DSpark under MRV2 has a known warm-prefix token-consistency issue. Use MRV1 for DSpark workloads requiring prefix consistency. Full-checkpoint accuracy, long-context capacity, multi-node, and P/D support are not established by these tests.

### How was this patch tested?

- CPU/metadata: **70 passed**, including Mamba sizing, scheduler zeroing, and PCP coverage.
- NPU zeroer: **5 passed**, covering split views, virtual blocks, padding, and shared storage.
- TP16/DP1/EP16 no-draft ACLGraph: **17 functional requests passed** with a 93-layer, 16-expert reduced K3 W4A8 QuaRot checkpoint on Ascend A3 / CANN 9.1. Prefix cold/hit/reset token IDs matched; block boundaries and four concurrent requests were covered.
- MRV2 e2e: **3 cases collected; execution pending**.
- `bash format.sh ci`: passed.
- Zeroer microbenchmark: approximately **3–5 us additional dispatch time** for 48 segments; no end-to-end performance claim.

The NPU results cover the cache implementation, not a full hardware validation of the current main integration. That integration still needs an NPU rerun. The reduced-expert checkpoint is functional evidence, not full-model accuracy evidence.

- vLLM version: v0.27.1
- vLLM main: https://github.com/vllm-project/vllm/commit/ba07e4a48fc951300d97eb506217dd530583dea3
