### PR TITLE
[CI] Temporarily avoid the issue DTS2608260106811 by disabling the MC2 feature switch.

### DIFF
--- a/tests/e2e/nightly/multi_node/internal_dp/config/Qwen3-235B-disagg-pd.yaml
+++ b/tests/e2e/nightly/multi_node/internal_dp/config/Qwen3-235B-disagg-pd.yaml
@@ -39,7 +39,7 @@ deployment:
         --trust-remote-code
         --gpu-memory-utilization 0.9
         --no-enable-prefix-caching
-        --additional-config '{"enable_fused_mc2":1}'
+        --additional-config '{"enable_fused_mc2":0}'
         --kv-transfer-config
         '{"kv_connector": "MooncakeConnectorV1",
         "kv_role": "kv_producer",
@@ -78,7 +78,7 @@ deployment:
         --gpu-memory-utilization 0.9
         --no-enable-prefix-caching
         --compilation-config '{"cudagraph_mode":"FULL_DECODE_ONLY"}'
-        --additional-config '{"enable_fused_mc2":1}'
+        --additional-config '{"enable_fused_mc2":0}'
         --kv-transfer-config
         '{"kv_connector": "MooncakeConnectorV1",
         "kv_role": "kv_consumer",

--- a/tests/e2e/weekly/single_node/configs/Qwen3.5-397B-A17B-W8A8-mtp-A3_weekly.yaml
+++ b/tests/e2e/weekly/single_node/configs/Qwen3.5-397B-A17B-W8A8-mtp-A3_weekly.yaml
@@ -186,7 +186,7 @@ _benchmarks_bs16_in65536: &benchmarks_bs16_in65536
 _benchmarks_bs80: &benchmarks_bs80
   perf:
     case_type: performance
-    dataset_path: vllm-ascend/GSM8K-in131072-bs100-qwen3
+    dataset_path: vllm-ascend/GSM8K_prefix90_in131072_bs100_qwen
     request_conf: vllm_api_stream_chat
     dataset_conf: gsm8k/gsm8k_gen_0_shot_cot_str_perf
     num_prompts: 80
@@ -224,7 +224,7 @@ test_cases:
       <<: *envs
     server_cmd: *server_cmd
     server_cmd_extra:
-      - "--no-enable-prefix-caching"
+      - "--enable-prefix-caching"
       - "--speculative_config"
       - '{"method": "qwen3_5_mtp", "num_speculative_tokens": 5, "enforce_eager": true}'
       - "--compilation-config"

--- a/tests/e2e/weekly/single_node/configs/Qwen3.5-397B-A17B-W8A8-mtp-A3_weekly.yaml
+++ b/tests/e2e/weekly/single_node/configs/Qwen3.5-397B-A17B-W8A8-mtp-A3_weekly.yaml
@@ -186,7 +186,7 @@ _benchmarks_bs16_in65536: &benchmarks_bs16_in65536
 _benchmarks_bs80: &benchmarks_bs80
   perf:
     case_type: performance
-    dataset_path: vllm-ascend/GSM8K_prefix90_in131072_bs100_qwen
+    dataset_path: vllm-ascend/GSM8K-in131072-bs100-qwen3
     request_conf: vllm_api_stream_chat
     dataset_conf: gsm8k/gsm8k_gen_0_shot_cot_str_perf
     num_prompts: 80
@@ -224,7 +224,7 @@ test_cases:
       <<: *envs
     server_cmd: *server_cmd
     server_cmd_extra:
-      - "--enable-prefix-caching"
+      - "--no-enable-prefix-caching"
       - "--speculative_config"
       - '{"method": "qwen3_5_mtp", "num_speculative_tokens": 5, "enforce_eager": true}'
       - "--compilation-config"


### PR DESCRIPTION
### What this PR does / why we need it?
Temporarily avoid the issue DTS2608260106811 by disabling the MC2 feature switch.

### Does this PR introduce _any_ user-facing change?
no

### How was this patch tested?
run the cases nightly

- vLLM main: https://github.com/vllm-project/vllm/commit/ba07e4a48fc951300d97eb506217dd530583dea3
