### PR TITLE
[Feature] GLM5.2 rotation v2 Dspark support

### DIFF
--- a/tests/e2e/coverage_taxonomy.py
+++ b/tests/e2e/coverage_taxonomy.py
@@ -44,6 +44,7 @@ ALLOWED_VALUES: dict[str, set[str]] = {
         "fully_sharded_lora",
         "spec_decode",
         "mtp",
+        "dspark",
         "eagle3",
         "sfa_dsa",
         "sfa_pcp",

--- a/tests/e2e/pull_request/eight_card/model_runner_v2/test_glm5_2.py
+++ b/tests/e2e/pull_request/eight_card/model_runner_v2/test_glm5_2.py
@@ -152,4 +152,5 @@ def test_glm5_2_dspark_eager() -> None:
             "enable_prefix_caching": False,
             "async_scheduling": False,
         },
+        acceptance_length_rtol=0.1,
     )

--- a/tests/e2e/pull_request/eight_card/model_runner_v2/test_glm5_2.py
+++ b/tests/e2e/pull_request/eight_card/model_runner_v2/test_glm5_2.py
@@ -26,7 +26,7 @@ from tests.e2e.pull_request.utils import _run_speculative_decoding
 
 MODEL = "Eco-Tech/GLM-5.2-w4a8"
 DRAFT_MODEL = "/RedHatAI/GLM-5.2-speculator.dspark"
-EXPECTED_ACCEPTANCE_LENGTH = 10
+EXPECTED_ACCEPTANCE_LENGTH = 3.0
 DSPARK_EXPECTED_ACCEPTANCE_LENGTH = 3.5
 
 

--- a/tests/e2e/pull_request/eight_card/model_runner_v2/test_glm5_2.py
+++ b/tests/e2e/pull_request/eight_card/model_runner_v2/test_glm5_2.py
@@ -19,15 +19,15 @@ from unittest.mock import patch
 
 import pytest
 from vllm import SamplingParams
-from vllm.v1.metrics.reader import Counter, Vector
 
-from tests.e2e.pull_request.utils import _run_speculative_decoding
 from tests.e2e.conftest import VllmRunner, wait_until_npu_memory_free
+from tests.e2e.pull_request.utils import _run_speculative_decoding
 
 MODEL = "Eco-Tech/GLM-5.2-w4a8"
 DRAFT_MODEL = "/RedHatAI/GLM-5.2-speculator.dspark"
 EXPECTED_ACCEPTANCE_LENGTH = 10
 DSPARK_EXPECTED_ACCEPTANCE_LENGTH = 3.5
+
 
 @pytest.mark.e2e_model(MODEL)
 @pytest.mark.e2e_coverage(
@@ -147,9 +147,9 @@ def test_glm5_2_dspark_eager() -> None:
             "quantization": "ascend",
             "tensor_parallel_size": 8,
             "max_model_len": 4096,
-            "max_num_batched_tokens":2048,
+            "max_num_batched_tokens": 2048,
             "enforce_eager": True,
-            "enable_prefix_caching":False,
-            "async_scheduling":False,
+            "enable_prefix_caching": False,
+            "async_scheduling": False,
         },
     )

--- a/tests/e2e/pull_request/eight_card/model_runner_v2/test_glm5_2.py
+++ b/tests/e2e/pull_request/eight_card/model_runner_v2/test_glm5_2.py
@@ -19,6 +19,7 @@ from unittest.mock import patch
 
 import pytest
 from vllm import SamplingParams
+from vllm.config import CompilationConfig
 
 from tests.e2e.conftest import VllmRunner, wait_until_npu_memory_free
 from tests.e2e.pull_request.utils import _run_speculative_decoding

--- a/tests/e2e/pull_request/eight_card/model_runner_v2/test_glm5_2.py
+++ b/tests/e2e/pull_request/eight_card/model_runner_v2/test_glm5_2.py
@@ -25,7 +25,7 @@ from tests.e2e.conftest import VllmRunner, wait_until_npu_memory_free
 from tests.e2e.pull_request.utils import _run_speculative_decoding
 
 MODEL = "Eco-Tech/GLM-5.2-w4a8"
-DRAFT_MODEL = "/RedHatAI/GLM-5.2-speculator.dspark"
+DRAFT_MODEL = "RedHatAI/GLM-5.2-speculator.dspark"
 EXPECTED_ACCEPTANCE_LENGTH = 3.0
 DSPARK_EXPECTED_ACCEPTANCE_LENGTH = 3.5
 

--- a/tests/e2e/pull_request/eight_card/model_runner_v2/test_glm5_2.py
+++ b/tests/e2e/pull_request/eight_card/model_runner_v2/test_glm5_2.py
@@ -60,7 +60,6 @@ def test_glm5_2_mtp_full_decode_only() -> None:
         runner_kwargs={
             "quantization": "ascend",
             "tensor_parallel_size": 8,
-            "enable_expert_parallel": True,
             "max_model_len": 8192,
             "compilation_config": CompilationConfig(cudagraph_mode="FULL_DECODE_ONLY"),
         },

--- a/tests/e2e/pull_request/eight_card/model_runner_v2/test_glm5_2.py
+++ b/tests/e2e/pull_request/eight_card/model_runner_v2/test_glm5_2.py
@@ -21,10 +21,13 @@ import pytest
 from vllm import SamplingParams
 from vllm.v1.metrics.reader import Counter, Vector
 
+from tests.e2e.pull_request.utils import _run_speculative_decoding
 from tests.e2e.conftest import VllmRunner, wait_until_npu_memory_free
 
 MODEL = "Eco-Tech/GLM-5.2-w4a8"
-
+DRAFT_MODEL = "/RedHatAI/GLM-5.2-speculator.dspark"
+EXPECTED_ACCEPTANCE_LENGTH = 10
+DSPARK_EXPECTED_ACCEPTANCE_LENGTH = 3.5
 
 @pytest.mark.e2e_model(MODEL)
 @pytest.mark.e2e_coverage(
@@ -46,51 +49,21 @@ MODEL = "Eco-Tech/GLM-5.2-w4a8"
 )
 @wait_until_npu_memory_free()
 def test_glm5_2_mtp_full_decode_only() -> None:
-    prompts = [
-        "Hello, my name is",
-        "The president of the United States is",
-        "The capital of France is",
-        "The future of AI is",
-    ]
-    num_speculative_tokens = 3
-    sampling_params = SamplingParams(max_tokens=1024, temperature=0.0)
-
-    with VllmRunner(
-        MODEL,
-        quantization="ascend",
-        tensor_parallel_size=8,
-        max_model_len=8192,
-        max_num_seqs=16,
-        enable_expert_parallel=True,
-        disable_log_stats=False,
-        compilation_config={"cudagraph_mode": "FULL_DECODE_ONLY"},
+    _run_speculative_decoding(
+        model_name=MODEL,
         speculative_config={
             "method": "mtp",
-            "num_speculative_tokens": num_speculative_tokens,
+            "num_speculative_tokens": 3,
         },
-    ) as runner:
-        outputs = runner.model.generate(prompts, sampling_params)
-        metrics = runner.model.get_metrics()
-
-    assert len(outputs) == len(prompts)
-    assert all(output.outputs[0].token_ids for output in outputs)
-
-    num_drafts = 0
-    num_accepted_tokens_per_pos = [0] * num_speculative_tokens
-    for metric in metrics:
-        if metric.name == "vllm:spec_decode_num_drafts":
-            assert isinstance(metric, Counter)
-            num_drafts += metric.value
-        elif metric.name == "vllm:spec_decode_num_accepted_tokens_per_pos":
-            assert isinstance(metric, Vector)
-            assert len(metric.values) == num_speculative_tokens
-            for pos, value in enumerate(metric.values):
-                num_accepted_tokens_per_pos[pos] += value
-
-    assert num_drafts > 0, "Speculative decoding did not generate any draft tokens"
-    acceptance_per_pos = [accepted / num_drafts for accepted in num_accepted_tokens_per_pos]
-    assert any(acceptance_per_pos)
-    assert all(0 <= acceptance <= 1 for acceptance in acceptance_per_pos)
+        expected_acceptance_length=EXPECTED_ACCEPTANCE_LENGTH,
+        runner_kwargs={
+            "quantization": "ascend",
+            "tensor_parallel_size": 8,
+            "enable_expert_parallel": True,
+            "max_model_len": 8192,
+            "compilation_config": CompilationConfig(cudagraph_mode="FULL_DECODE_ONLY"),
+        },
+    )
 
 
 @pytest.mark.e2e_model(MODEL)
@@ -138,3 +111,45 @@ def test_glm5_2_sfa_pcp_full_decode_only() -> None:
 
     assert len(outputs) == len(prompts)
     assert all(output.outputs[0].token_ids for output in outputs)
+
+
+@pytest.mark.e2e_model(MODEL)
+@pytest.mark.e2e_coverage(
+    arch="moe",
+    feature="dspark",
+    parallel="TP,EP",
+    deploy="pd_mix",
+    hardware="A3",
+    quantization="W4A8",
+    graph_mode="eager",
+)
+@patch.dict(
+    os.environ,
+    {
+        "VLLM_USE_V2_MODEL_RUNNER": "1",
+        "VLLM_WORKER_MULTIPROC_METHOD": "spawn",
+        "PYTORCH_NPU_ALLOC_CONF": "expandable_segments:True",
+        "HCCL_BUFFSIZE": "1024",
+    },
+)
+@wait_until_npu_memory_free()
+def test_glm5_2_dspark_eager() -> None:
+    _run_speculative_decoding(
+        model_name=MODEL,
+        speculative_config={
+            "method": "dspark",
+            "model": DRAFT_MODEL,
+            "num_speculative_tokens": 7,
+            "enforce_eager": True,
+        },
+        expected_acceptance_length=DSPARK_EXPECTED_ACCEPTANCE_LENGTH,
+        runner_kwargs={
+            "quantization": "ascend",
+            "tensor_parallel_size": 8,
+            "max_model_len": 4096,
+            "max_num_batched_tokens":2048,
+            "enforce_eager": True,
+            "enable_prefix_caching":False,
+            "async_scheduling":False,
+        },
+    )

--- a/tests/ut/quantization/test_modelslim_config.py
+++ b/tests/ut/quantization/test_modelslim_config.py
@@ -13,7 +13,6 @@ from vllm.model_executor.layers.linear import LinearBase
 from vllm.model_executor.models.utils import WeightsMapper
 
 from tests.ut.base import TestBase
-from vllm_ascend.utils import get_rotation_path
 from vllm_ascend.ops.linear import AscendUnquantizedLinearMethod
 from vllm_ascend.quantization.modelslim_config import (
     MODELSLIM_CONFIG_FILENAME,
@@ -22,7 +21,7 @@ from vllm_ascend.quantization.modelslim_config import (
     get_linear_quant_type,
     get_packed_modules_mapping,
 )
-from vllm_ascend.utils import ASCEND_QUANTIZATION_METHOD
+from vllm_ascend.utils import ASCEND_QUANTIZATION_METHOD, get_rotation_path
 
 
 class TestAscendModelSlimConfig(TestBase):

--- a/tests/ut/quantization/test_modelslim_config.py
+++ b/tests/ut/quantization/test_modelslim_config.py
@@ -13,7 +13,7 @@ from vllm.model_executor.layers.linear import LinearBase
 from vllm.model_executor.models.utils import WeightsMapper
 
 from tests.ut.base import TestBase
-from vllm_ascend.models.llama_eagle3 import get_rotation_path
+from vllm_ascend.utils import get_rotation_path
 from vllm_ascend.ops.linear import AscendUnquantizedLinearMethod
 from vllm_ascend.quantization.modelslim_config import (
     MODELSLIM_CONFIG_FILENAME,

--- a/tests/ut/spec_decode/test_dspark_speculator.py
+++ b/tests/ut/spec_decode/test_dspark_speculator.py
@@ -15,22 +15,10 @@
 # limitations under the License.
 # This file is a part of the vllm-ascend project.
 #
-"""Unit tests for ``AscendDSparkSpeculator.load_draft_model``.
-
-The override rotates the drafter's ``fc`` projection after load so it matches a
-QuaRot-quantized target's rotated aux hidden states: upstream
-``load_dspark_model`` overrides the drafter's ``quant_config`` with
-``get_draft_quant_config`` (None for a bf16 drafter), so the drafter's
-``__init__`` derives ``rotation_path=None`` and ``fc`` is loaded unrotated. The
-speculator still holds the target's ``vllm_config`` (``quant_config=QuaRot``),
-so the override recomputes ``rotation_path`` from it and rotates ``fc`` in
-place. These tests pin that behaviour and the CPU-side matmul that avoids a
-cross-device (NPU vs CPU) ``torch.matmul``.
-"""
+"""Unit tests for ``AscendDSparkSpeculator.load_draft_model`` fc rotation."""
 
 from __future__ import annotations
 
-import inspect
 from types import SimpleNamespace
 from unittest.mock import MagicMock
 
@@ -42,172 +30,76 @@ from vllm_ascend.worker.v2.spec_decode.dspark.speculator import (
     AscendDSparkSpeculator,
 )
 
-# Small shapes that mirror the real layout (fc is [hidden, num_aux * hidden]
-# for the concatenated aux hidden states) but keep the CPU matmul trivial.
-_HIDDEN_SIZE = 8
-_NUM_AUX_LAYERS = 5
-_FC_IN = _NUM_AUX_LAYERS * _HIDDEN_SIZE
-
-# The speculator module binds get_rotation_matrix at import time; patch it there
-# so load_draft_model sees the stub instead of reading a rotation file.
-_ROTATION_MATRIX_ATTR = (
+_HIDDEN = 8
+_FC_IN = 5 * _HIDDEN  # concatenated aux hidden states
+# Patch where load_draft_model looks it up (the speculator module binding).
+_ROT_MATRIX = (
     "vllm_ascend.worker.v2.spec_decode.dspark.speculator.get_rotation_matrix"
 )
 
 
-def _quarot_vllm_config() -> SimpleNamespace:
-    """A vllm_config whose quant_config exposes a QuaRot global_rotation, so
-    the real ``get_rotation_path`` returns a non-None path. The matrix itself
-    is stubbed per-test, so no rotation file is read from disk."""
-    quant_config = SimpleNamespace(
-        quant_description={
-            "optional": {
-                "quarot": {
-                    "rotation_map": {
-                        "global_rotation": "optional/quarot.safetensors"
-                    }
-                }
-            }
-        }
-    )
-    return SimpleNamespace(
-        quant_config=quant_config,
-        model_config=SimpleNamespace(model="/fake/target"),
-    )
-
-
-def _bf16_vllm_config() -> SimpleNamespace:
-    """A bf16 target: ``quant_config`` is None, so ``get_rotation_path``
-    returns None immediately (the no-op path)."""
-    return SimpleNamespace(quant_config=None, model_config=SimpleNamespace())
-
-
-def _non_quarot_vllm_config() -> SimpleNamespace:
-    """A quantized-but-not-QuaRot target: ``quant_config`` is set but its
-    description has no ``quarot.rotation_map``, so ``get_rotation_path``
-    returns None via KeyError (the other no-op path)."""
-    quant_config = SimpleNamespace(quant_description={"optional": {}})
-    return SimpleNamespace(
-        quant_config=quant_config,
-        model_config=SimpleNamespace(model="/fake/target"),
-    )
-
-
-def _make_speculator(vllm_config: SimpleNamespace) -> AscendDSparkSpeculator:
-    """Bypass the heavy ``DSparkSpeculator.__init__``; ``load_draft_model``
-    only reads ``self.vllm_config`` and the (patched) parent call."""
+def _spec(vllm_config: SimpleNamespace) -> AscendDSparkSpeculator:
+    """Bypass the heavy ``__init__``; ``load_draft_model`` only reads
+    ``self.vllm_config`` and the patched parent call."""
     spec = AscendDSparkSpeculator.__new__(AscendDSparkSpeculator)
     spec.vllm_config = vllm_config
     return spec
 
 
-def _fake_draft_model() -> SimpleNamespace:
-    """A draft model exposing ``model.fc`` as a non-sharded ``nn.Linear`` whose
-    ``weight.data`` ``load_draft_model`` can rotate in place, mirroring the
-    real ``DFlashQwen3Model.fc`` ``ReplicatedLinear``."""
-    fc = torch.nn.Linear(_FC_IN, _HIDDEN_SIZE, bias=False)
+def _fake_draft() -> SimpleNamespace:
+    fc = torch.nn.Linear(_FC_IN, _HIDDEN, bias=False)
     with torch.no_grad():
         fc.weight.copy_(torch.randn_like(fc.weight))
     return SimpleNamespace(model=SimpleNamespace(fc=fc))
 
 
-class _LoadDraftModelTestBase:
-    """Shared fixtures for ``load_draft_model`` rotation tests."""
+def _quarot_config() -> SimpleNamespace:
+    quarot = {"rotation_map": {"global_rotation": "x.safetensors"}}
+    return SimpleNamespace(
+        quant_config=SimpleNamespace(
+            quant_description={"optional": {"quarot": quarot}}
+        ),
+        model_config=SimpleNamespace(model="/fake"),
+    )
+
+
+def _bf16_config() -> SimpleNamespace:
+    return SimpleNamespace(quant_config=None, model_config=SimpleNamespace())
+
+
+def _no_call(*args, **kwargs):
+    raise AssertionError(
+        "get_rotation_matrix must not be called without a rotation path")
+
+
+class TestLoadDraftModel:
+    """``load_draft_model`` rotates fc for a QuaRot target and is a no-op otherwise."""
 
     @pytest.fixture
-    def stub_parent_load(self, monkeypatch):
-        """Replace the heavy parent ``load_draft_model`` (which builds/loads a
-        real drafter via ``load_dspark_model``) with one returning a fresh fake
-        draft model, and snapshot its ``fc`` weight before the override can
-        mutate it in place."""
+    def captured(self, monkeypatch):
+        """Stub the heavy parent ``load_draft_model`` to return a fake draft and
+        snapshot its fc weight before the override mutates it in place."""
+        out: dict = {}
 
-        captured: dict = {}
-
-        def _fake_load(
-            self, target_model, target_attn_layer_names
-        ) -> SimpleNamespace:
-            draft = _fake_draft_model()
-            captured["fc_before"] = draft.model.fc.weight.data.clone()
-            captured["draft"] = draft
+        def _load(self, target_model, target_attn_layer_names):
+            draft = _fake_draft()
+            out["before"] = draft.model.fc.weight.data.clone()
+            out["draft"] = draft
             return draft
 
-        monkeypatch.setattr(DSparkSpeculator, "load_draft_model", _fake_load)
-        return captured
+        monkeypatch.setattr(DSparkSpeculator, "load_draft_model", _load)
+        return out
 
+    def test_rotates_fc_for_quarot_target(self, captured, monkeypatch):
+        # R = 2*I -> W @ R == 2*W, an expectation independent of process_weight.
+        monkeypatch.setattr(_ROT_MATRIX, lambda path: torch.eye(_HIDDEN) * 2.0)
+        draft = _spec(_quarot_config()).load_draft_model(MagicMock(), set())
+        before = captured["before"]
+        assert draft is captured["draft"]
+        assert torch.allclose(draft.model.fc.weight.data, 2.0 * before, atol=1e-6)
+        assert not torch.allclose(draft.model.fc.weight.data, before)
 
-# fmt: off
-class TestLoadDraftModelRotatesFC(_LoadDraftModelTestBase):
-    """``load_draft_model`` rotates the drafter's ``fc`` projection to match a
-    QuaRot-quantized target's rotated aux hidden states, and is a no-op for
-    bf16 / non-QuaRot targets (``get_rotation_path`` returns None)."""
-
-    def test_rotates_fc_for_quarot_target(self, stub_parent_load, monkeypatch):
-        """QuaRot target: ``fc.weight`` is overwritten with ``W @ R`` and the
-        returned model is the same object the parent loaded."""
-        spec = _make_speculator(_quarot_vllm_config())
-        # diag(2): W @ (2*I) == 2 * W, an expected value that is independent of
-        # process_weight's internal chunked matmul.
-        rotation = torch.eye(_HIDDEN_SIZE, dtype=torch.float32) * 2.0
-        monkeypatch.setattr(_ROTATION_MATRIX_ATTR, lambda rotation_path: rotation)
-
-        draft = spec.load_draft_model(
-            target_model=MagicMock(), target_attn_layer_names=set()
-        )
-
-        assert draft is stub_parent_load["draft"]
-        rotated = draft.model.fc.weight.data
-        assert rotated.shape == (_HIDDEN_SIZE, _FC_IN)
-        fc_before = stub_parent_load["fc_before"]
-        assert torch.allclose(rotated, 2.0 * fc_before, atol=1e-6)
-        # the weight actually changed (R is not the identity).
-        assert not torch.allclose(rotated, fc_before)
-
-    def test_noop_for_bf16_target(self, stub_parent_load, monkeypatch):
-        """bf16 target (``quant_config=None``): ``get_rotation_path`` is None,
-        so ``fc`` is left exactly as loaded and the matrix is never read."""
-        spec = _make_speculator(_bf16_vllm_config())
-
-        def _fail(*args, **kwargs):
-            raise AssertionError(
-                "get_rotation_matrix must not be called for a bf16 target"
-            )
-
-        monkeypatch.setattr(_ROTATION_MATRIX_ATTR, _fail)
-
-        draft = spec.load_draft_model(
-            target_model=MagicMock(), target_attn_layer_names=set()
-        )
-
-        fc_before = stub_parent_load["fc_before"]
-        assert torch.equal(draft.model.fc.weight.data, fc_before)
-
-    def test_noop_for_non_quarot_quant(self, stub_parent_load, monkeypatch):
-        """Quantized-but-not-QuaRot target (no ``quarot.rotation_map``):
-        ``get_rotation_path`` returns None via KeyError, so ``fc`` is untouched
-        and the matrix is never read."""
-        spec = _make_speculator(_non_quarot_vllm_config())
-
-        def _fail(*args, **kwargs):
-            raise AssertionError(
-                "get_rotation_matrix must not be called for a non-QuaRot target"
-            )
-
-        monkeypatch.setattr(_ROTATION_MATRIX_ATTR, _fail)
-
-        draft = spec.load_draft_model(
-            target_model=MagicMock(), target_attn_layer_names=set()
-        )
-
-        fc_before = stub_parent_load["fc_before"]
-        assert torch.equal(draft.model.fc.weight.data, fc_before)
-
-    def test_rotation_runs_on_cpu(self):
-        """The drafter is already on device after load while the rotation
-        matrix is loaded from disk to CPU, so the matmul must take ``fc`` on CPU
-        (``fc.weight.data.cpu()``) and derive ``rotation_path`` from the
-        target's ``vllm_config``. A refactor that drops the ``.cpu()`` regresses
-        the cross-device matmul, so fail loudly here rather than silently."""
-        src = inspect.getsource(AscendDSparkSpeculator.load_draft_model)
-        assert "process_weight(fc.weight.data.cpu()" in src
-        assert "get_rotation_path(self.vllm_config)" in src
-# fmt: on
+    def test_noop_for_bf16_target(self, captured, monkeypatch):
+        monkeypatch.setattr(_ROT_MATRIX, _no_call)
+        draft = _spec(_bf16_config()).load_draft_model(MagicMock(), set())
+        assert torch.equal(draft.model.fc.weight.data, captured["before"])

--- a/tests/ut/spec_decode/test_dspark_speculator.py
+++ b/tests/ut/spec_decode/test_dspark_speculator.py
@@ -1,0 +1,213 @@
+#
+# Copyright (c) 2026 Huawei Technologies Co., Ltd. All Rights Reserved.
+# Copyright 2023 The vLLM team.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# This file is a part of the vllm-ascend project.
+#
+"""Unit tests for ``AscendDSparkSpeculator.load_draft_model``.
+
+The override rotates the drafter's ``fc`` projection after load so it matches a
+QuaRot-quantized target's rotated aux hidden states: upstream
+``load_dspark_model`` overrides the drafter's ``quant_config`` with
+``get_draft_quant_config`` (None for a bf16 drafter), so the drafter's
+``__init__`` derives ``rotation_path=None`` and ``fc`` is loaded unrotated. The
+speculator still holds the target's ``vllm_config`` (``quant_config=QuaRot``),
+so the override recomputes ``rotation_path`` from it and rotates ``fc`` in
+place. These tests pin that behaviour and the CPU-side matmul that avoids a
+cross-device (NPU vs CPU) ``torch.matmul``.
+"""
+
+from __future__ import annotations
+
+import inspect
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+import torch
+
+from vllm.v1.worker.gpu.spec_decode.dspark.speculator import DSparkSpeculator
+from vllm_ascend.worker.v2.spec_decode.dspark.speculator import (
+    AscendDSparkSpeculator,
+)
+
+# Small shapes that mirror the real layout (fc is [hidden, num_aux * hidden]
+# for the concatenated aux hidden states) but keep the CPU matmul trivial.
+_HIDDEN_SIZE = 8
+_NUM_AUX_LAYERS = 5
+_FC_IN = _NUM_AUX_LAYERS * _HIDDEN_SIZE
+
+# The speculator module binds get_rotation_matrix at import time; patch it there
+# so load_draft_model sees the stub instead of reading a rotation file.
+_ROTATION_MATRIX_ATTR = (
+    "vllm_ascend.worker.v2.spec_decode.dspark.speculator.get_rotation_matrix"
+)
+
+
+def _quarot_vllm_config() -> SimpleNamespace:
+    """A vllm_config whose quant_config exposes a QuaRot global_rotation, so
+    the real ``get_rotation_path`` returns a non-None path. The matrix itself
+    is stubbed per-test, so no rotation file is read from disk."""
+    quant_config = SimpleNamespace(
+        quant_description={
+            "optional": {
+                "quarot": {
+                    "rotation_map": {
+                        "global_rotation": "optional/quarot.safetensors"
+                    }
+                }
+            }
+        }
+    )
+    return SimpleNamespace(
+        quant_config=quant_config,
+        model_config=SimpleNamespace(model="/fake/target"),
+    )
+
+
+def _bf16_vllm_config() -> SimpleNamespace:
+    """A bf16 target: ``quant_config`` is None, so ``get_rotation_path``
+    returns None immediately (the no-op path)."""
+    return SimpleNamespace(quant_config=None, model_config=SimpleNamespace())
+
+
+def _non_quarot_vllm_config() -> SimpleNamespace:
+    """A quantized-but-not-QuaRot target: ``quant_config`` is set but its
+    description has no ``quarot.rotation_map``, so ``get_rotation_path``
+    returns None via KeyError (the other no-op path)."""
+    quant_config = SimpleNamespace(quant_description={"optional": {}})
+    return SimpleNamespace(
+        quant_config=quant_config,
+        model_config=SimpleNamespace(model="/fake/target"),
+    )
+
+
+def _make_speculator(vllm_config: SimpleNamespace) -> AscendDSparkSpeculator:
+    """Bypass the heavy ``DSparkSpeculator.__init__``; ``load_draft_model``
+    only reads ``self.vllm_config`` and the (patched) parent call."""
+    spec = AscendDSparkSpeculator.__new__(AscendDSparkSpeculator)
+    spec.vllm_config = vllm_config
+    return spec
+
+
+def _fake_draft_model() -> SimpleNamespace:
+    """A draft model exposing ``model.fc`` as a non-sharded ``nn.Linear`` whose
+    ``weight.data`` ``load_draft_model`` can rotate in place, mirroring the
+    real ``DFlashQwen3Model.fc`` ``ReplicatedLinear``."""
+    fc = torch.nn.Linear(_FC_IN, _HIDDEN_SIZE, bias=False)
+    with torch.no_grad():
+        fc.weight.copy_(torch.randn_like(fc.weight))
+    return SimpleNamespace(model=SimpleNamespace(fc=fc))
+
+
+class _LoadDraftModelTestBase:
+    """Shared fixtures for ``load_draft_model`` rotation tests."""
+
+    @pytest.fixture
+    def stub_parent_load(self, monkeypatch):
+        """Replace the heavy parent ``load_draft_model`` (which builds/loads a
+        real drafter via ``load_dspark_model``) with one returning a fresh fake
+        draft model, and snapshot its ``fc`` weight before the override can
+        mutate it in place."""
+
+        captured: dict = {}
+
+        def _fake_load(
+            self, target_model, target_attn_layer_names
+        ) -> SimpleNamespace:
+            draft = _fake_draft_model()
+            captured["fc_before"] = draft.model.fc.weight.data.clone()
+            captured["draft"] = draft
+            return draft
+
+        monkeypatch.setattr(DSparkSpeculator, "load_draft_model", _fake_load)
+        return captured
+
+
+# fmt: off
+class TestLoadDraftModelRotatesFC(_LoadDraftModelTestBase):
+    """``load_draft_model`` rotates the drafter's ``fc`` projection to match a
+    QuaRot-quantized target's rotated aux hidden states, and is a no-op for
+    bf16 / non-QuaRot targets (``get_rotation_path`` returns None)."""
+
+    def test_rotates_fc_for_quarot_target(self, stub_parent_load, monkeypatch):
+        """QuaRot target: ``fc.weight`` is overwritten with ``W @ R`` and the
+        returned model is the same object the parent loaded."""
+        spec = _make_speculator(_quarot_vllm_config())
+        # diag(2): W @ (2*I) == 2 * W, an expected value that is independent of
+        # process_weight's internal chunked matmul.
+        rotation = torch.eye(_HIDDEN_SIZE, dtype=torch.float32) * 2.0
+        monkeypatch.setattr(_ROTATION_MATRIX_ATTR, lambda rotation_path: rotation)
+
+        draft = spec.load_draft_model(
+            target_model=MagicMock(), target_attn_layer_names=set()
+        )
+
+        assert draft is stub_parent_load["draft"]
+        rotated = draft.model.fc.weight.data
+        assert rotated.shape == (_HIDDEN_SIZE, _FC_IN)
+        fc_before = stub_parent_load["fc_before"]
+        assert torch.allclose(rotated, 2.0 * fc_before, atol=1e-6)
+        # the weight actually changed (R is not the identity).
+        assert not torch.allclose(rotated, fc_before)
+
+    def test_noop_for_bf16_target(self, stub_parent_load, monkeypatch):
+        """bf16 target (``quant_config=None``): ``get_rotation_path`` is None,
+        so ``fc`` is left exactly as loaded and the matrix is never read."""
+        spec = _make_speculator(_bf16_vllm_config())
+
+        def _fail(*args, **kwargs):
+            raise AssertionError(
+                "get_rotation_matrix must not be called for a bf16 target"
+            )
+
+        monkeypatch.setattr(_ROTATION_MATRIX_ATTR, _fail)
+
+        draft = spec.load_draft_model(
+            target_model=MagicMock(), target_attn_layer_names=set()
+        )
+
+        fc_before = stub_parent_load["fc_before"]
+        assert torch.equal(draft.model.fc.weight.data, fc_before)
+
+    def test_noop_for_non_quarot_quant(self, stub_parent_load, monkeypatch):
+        """Quantized-but-not-QuaRot target (no ``quarot.rotation_map``):
+        ``get_rotation_path`` returns None via KeyError, so ``fc`` is untouched
+        and the matrix is never read."""
+        spec = _make_speculator(_non_quarot_vllm_config())
+
+        def _fail(*args, **kwargs):
+            raise AssertionError(
+                "get_rotation_matrix must not be called for a non-QuaRot target"
+            )
+
+        monkeypatch.setattr(_ROTATION_MATRIX_ATTR, _fail)
+
+        draft = spec.load_draft_model(
+            target_model=MagicMock(), target_attn_layer_names=set()
+        )
+
+        fc_before = stub_parent_load["fc_before"]
+        assert torch.equal(draft.model.fc.weight.data, fc_before)
+
+    def test_rotation_runs_on_cpu(self):
+        """The drafter is already on device after load while the rotation
+        matrix is loaded from disk to CPU, so the matmul must take ``fc`` on CPU
+        (``fc.weight.data.cpu()``) and derive ``rotation_path`` from the
+        target's ``vllm_config``. A refactor that drops the ``.cpu()`` regresses
+        the cross-device matmul, so fail loudly here rather than silently."""
+        src = inspect.getsource(AscendDSparkSpeculator.load_draft_model)
+        assert "process_weight(fc.weight.data.cpu()" in src
+        assert "get_rotation_path(self.vllm_config)" in src
+# fmt: on

--- a/tests/ut/spec_decode/test_dspark_speculator.py
+++ b/tests/ut/spec_decode/test_dspark_speculator.py
@@ -24,8 +24,8 @@ from unittest.mock import MagicMock
 
 import pytest
 import torch
-
 from vllm.v1.worker.gpu.spec_decode.dspark.speculator import DSparkSpeculator
+
 from vllm_ascend.worker.v2.spec_decode.dspark.speculator import (
     AscendDSparkSpeculator,
 )
@@ -33,9 +33,7 @@ from vllm_ascend.worker.v2.spec_decode.dspark.speculator import (
 _HIDDEN = 8
 _FC_IN = 5 * _HIDDEN  # concatenated aux hidden states
 # Patch where load_draft_model looks it up (the speculator module binding).
-_ROT_MATRIX = (
-    "vllm_ascend.worker.v2.spec_decode.dspark.speculator.get_rotation_matrix"
-)
+_ROT_MATRIX = "vllm_ascend.worker.v2.spec_decode.dspark.speculator.get_rotation_matrix"
 
 
 def _spec(vllm_config: SimpleNamespace) -> AscendDSparkSpeculator:
@@ -56,9 +54,7 @@ def _fake_draft() -> SimpleNamespace:
 def _quarot_config() -> SimpleNamespace:
     quarot = {"rotation_map": {"global_rotation": "x.safetensors"}}
     return SimpleNamespace(
-        quant_config=SimpleNamespace(
-            quant_description={"optional": {"quarot": quarot}}
-        ),
+        quant_config=SimpleNamespace(quant_description={"optional": {"quarot": quarot}}),
         model_config=SimpleNamespace(model="/fake"),
     )
 
@@ -68,8 +64,7 @@ def _bf16_config() -> SimpleNamespace:
 
 
 def _no_call(*args, **kwargs):
-    raise AssertionError(
-        "get_rotation_matrix must not be called without a rotation path")
+    raise AssertionError("get_rotation_matrix must not be called without a rotation path")
 
 
 class TestLoadDraftModel:

--- a/vllm_ascend/models/deepseek_v4/dspark.py
+++ b/vllm_ascend/models/deepseek_v4/dspark.py
@@ -312,7 +312,7 @@ class DSparkDeepseekV4ForCausalLM(nn.Module, DeepseekV2MixtureOfExperts, Support
         self.config = vllm_config.speculative_config.draft_model_config.hf_config
 
         # check if quant config exist
-        from vllm_ascend.models.llama_eagle3 import get_rotation_path
+        from vllm_ascend.utils import get_rotation_path
 
         self.rotation_path = get_rotation_path(vllm_config) if vllm_config.quant_config is not None else None
 

--- a/vllm_ascend/models/kimi_k3.py
+++ b/vllm_ascend/models/kimi_k3.py
@@ -78,7 +78,7 @@ from vllm.sequence import IntermediateTensors
 from vllm.triton_utils import HAS_TRITON
 from vllm.utils.math_utils import cdiv
 
-from vllm_ascend.models.llama_eagle3 import get_rotation_path
+from vllm_ascend.utils import get_rotation_path
 from vllm_ascend.ops.kimi_kda import AscendKimiK3DeltaAttention  # type: ignore[import-untyped]
 
 if HAS_TRITON:

--- a/vllm_ascend/models/kimi_k3.py
+++ b/vllm_ascend/models/kimi_k3.py
@@ -78,8 +78,8 @@ from vllm.sequence import IntermediateTensors
 from vllm.triton_utils import HAS_TRITON
 from vllm.utils.math_utils import cdiv
 
-from vllm_ascend.utils import get_rotation_path
 from vllm_ascend.ops.kimi_kda import AscendKimiK3DeltaAttention  # type: ignore[import-untyped]
+from vllm_ascend.utils import get_rotation_path
 
 if HAS_TRITON:
     from vllm_ascend.ops.triton.kimi_k3.attention_residual import (  # type: ignore[import-untyped]

--- a/vllm_ascend/models/kimi_k3_dspark.py
+++ b/vllm_ascend/models/kimi_k3_dspark.py
@@ -37,17 +37,17 @@ from vllm_ascend.models.kimi_k3 import (
     AscendKimiMLAAttention,
 )
 from vllm_ascend.models.llama_eagle3 import load_quarot_target_layer
-from vllm_ascend.utils import (
-    get_rotation_matrix,
-    get_rotation_path,
-)
 from vllm_ascend.models.qwen3_dspark import (
     TARGET_EMBED_WEIGHT_NAMES,
     TARGET_LM_HEAD_WEIGHT_NAMES,
     process_weight,
 )
 from vllm_ascend.ops.rotary_embedding import get_cos_and_sin_mla
-from vllm_ascend.utils import vllm_version_is
+from vllm_ascend.utils import (
+    get_rotation_matrix,
+    get_rotation_path,
+    vllm_version_is,
+)
 
 
 def _uses_causal_draft_attention(config) -> bool:

--- a/vllm_ascend/models/kimi_k3_dspark.py
+++ b/vllm_ascend/models/kimi_k3_dspark.py
@@ -36,10 +36,10 @@ from vllm.models.kimi_k3.nvidia.dspark_mla import (
 from vllm_ascend.models.kimi_k3 import (
     AscendKimiMLAAttention,
 )
-from vllm_ascend.models.llama_eagle3 import (
+from vllm_ascend.models.llama_eagle3 import load_quarot_target_layer
+from vllm_ascend.utils import (
     get_rotation_matrix,
     get_rotation_path,
-    load_quarot_target_layer,
 )
 from vllm_ascend.models.qwen3_dspark import (
     TARGET_EMBED_WEIGHT_NAMES,

--- a/vllm_ascend/models/llama_eagle3.py
+++ b/vllm_ascend/models/llama_eagle3.py
@@ -10,6 +10,10 @@ from safetensors.torch import load_file
 from torch import nn
 from vllm.config import VllmConfig
 from vllm.model_executor.models.llama_eagle3 import Eagle3LlamaForCausalLM
+from vllm_ascend.utils import (
+    get_rotation_matrix,
+    get_rotation_path,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -26,33 +30,6 @@ def get_embedding_tensor(directory_path):
                 if "embed" in key.lower():
                     return tensor
     return None
-
-
-def get_rotation_path(vllm_config: VllmConfig) -> Path | None:
-    quant_config = vllm_config.quant_config
-    if quant_config is None:
-        return None
-    target_model_path = vllm_config.model_config.model
-    try:
-        quant_description = quant_config.quant_description
-        rotation_relative_path = quant_description["optional"]["quarot"]["rotation_map"]["global_rotation"]
-    except KeyError:
-        return None
-    return Path(target_model_path) / rotation_relative_path
-
-
-def get_rotation_matrix(rotation_path: Path | None) -> torch.Tensor:
-    """Load the global rotation matrix."""
-    try:
-        safetensor_data = load_file(rotation_path)
-        Q = safetensor_data["global_rotation"]
-        return Q
-    except Exception as e:
-        logger.error(
-            "Failed to load rotation weight from '%s'. If you want to use quarot model with eagle3, take a check.",
-            rotation_path,
-        )
-        raise e
 
 
 def _find_safetensors_weight(

--- a/vllm_ascend/models/llama_eagle3.py
+++ b/vllm_ascend/models/llama_eagle3.py
@@ -10,6 +10,7 @@ from safetensors.torch import load_file
 from torch import nn
 from vllm.config import VllmConfig
 from vllm.model_executor.models.llama_eagle3 import Eagle3LlamaForCausalLM
+
 from vllm_ascend.utils import (
     get_rotation_matrix,
     get_rotation_path,

--- a/vllm_ascend/models/qwen3_dspark.py
+++ b/vllm_ascend/models/qwen3_dspark.py
@@ -12,9 +12,8 @@ from vllm_ascend.models.llama_eagle3 import load_quarot_target_layer
 from vllm_ascend.utils import (
     get_rotation_matrix,
     get_rotation_path,
+    vllm_version_is,
 )
-
-from vllm_ascend.utils import vllm_version_is
 
 TARGET_EMBED_WEIGHT_NAMES = (
     "language_model.model.embed_tokens.weight",

--- a/vllm_ascend/models/qwen3_dspark.py
+++ b/vllm_ascend/models/qwen3_dspark.py
@@ -8,11 +8,12 @@ from vllm.model_executor.layers.linear import ReplicatedLinear
 from vllm.model_executor.models.qwen3_dspark import Qwen3DSparkForCausalLM
 from vllm.model_executor.models.utils import AutoWeightsLoader, maybe_prefix
 
-from vllm_ascend.models.llama_eagle3 import (
+from vllm_ascend.models.llama_eagle3 import load_quarot_target_layer
+from vllm_ascend.utils import (
     get_rotation_matrix,
     get_rotation_path,
-    load_quarot_target_layer,
 )
+
 from vllm_ascend.utils import vllm_version_is
 
 TARGET_EMBED_WEIGHT_NAMES = (

--- a/vllm_ascend/utils.py
+++ b/vllm_ascend/utils.py
@@ -30,10 +30,10 @@ from typing import TYPE_CHECKING, Any
 
 import numpy as np
 import regex as re
-from safetensors.torch import load_file
 import torch
 import torch_npu  # noqa: F401
 from packaging.version import InvalidVersion, Version
+from safetensors.torch import load_file
 from vllm.logger import logger
 from vllm.sequence import IntermediateTensors
 

--- a/vllm_ascend/utils.py
+++ b/vllm_ascend/utils.py
@@ -25,10 +25,12 @@ import math
 import os
 from contextlib import nullcontext
 from functools import lru_cache
+from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 import numpy as np
 import regex as re
+from safetensors.torch import load_file
 import torch
 import torch_npu  # noqa: F401
 from packaging.version import InvalidVersion, Version
@@ -1528,3 +1530,30 @@ def enable_sfa(vllm_config) -> bool:
     if hf_text_config is None:
         return False
     return hasattr(hf_text_config, "index_topk") and not hasattr(hf_text_config, "compress_ratios")
+
+
+def get_rotation_path(vllm_config: VllmConfig) -> Path | None:
+    quant_config = vllm_config.quant_config
+    if quant_config is None:
+        return None
+    target_model_path = vllm_config.model_config.model
+    try:
+        quant_description = quant_config.quant_description
+        rotation_relative_path = quant_description["optional"]["quarot"]["rotation_map"]["global_rotation"]
+    except KeyError:
+        return None
+    return Path(target_model_path) / rotation_relative_path
+
+
+def get_rotation_matrix(rotation_path: Path | None) -> torch.Tensor:
+    """Load the global rotation matrix."""
+    try:
+        safetensor_data = load_file(rotation_path)
+        Q = safetensor_data["global_rotation"]
+        return Q
+    except Exception as e:
+        logger.error(
+            "Failed to load rotation weight from '%s'. If you want to use quarot model with eagle3, take a check.",
+            rotation_path,
+        )
+        raise e

--- a/vllm_ascend/worker/v2/spec_decode/dspark/speculator.py
+++ b/vllm_ascend/worker/v2/spec_decode/dspark/speculator.py
@@ -26,11 +26,12 @@ from vllm.v1.worker.gpu.input_batch import InputBatch
 from vllm.v1.worker.gpu.spec_decode.dspark.speculator import (
     DSparkSpeculator,
 )
+
+from vllm_ascend.models.qwen3_dspark import process_weight
 from vllm_ascend.utils import (
     get_rotation_matrix,
     get_rotation_path,
 )
-from vllm_ascend.models.qwen3_dspark import process_weight
 from vllm_ascend.worker.v2.attn_utils import (
     build_attn_metadata_wrapper,
     build_draft_attn_metadata_factory,
@@ -61,8 +62,7 @@ class AscendDSparkSpeculator(DSparkSpeculator):
             rotation_weight = get_rotation_matrix(rotation_path)
             fc = model.model.fc
             with torch.no_grad():
-                fc.weight.data.copy_(
-                    process_weight(fc.weight.data.cpu(), rotation_weight))
+                fc.weight.data.copy_(process_weight(fc.weight.data.cpu(), rotation_weight))
         return model
 
     def init_cudagraph_manager(self, cudagraph_mode: CUDAGraphMode) -> None:

--- a/vllm_ascend/worker/v2/spec_decode/dspark/speculator.py
+++ b/vllm_ascend/worker/v2/spec_decode/dspark/speculator.py
@@ -58,7 +58,7 @@ class AscendDSparkSpeculator(DSparkSpeculator):
         # feeds the drafter are in rotated space; fc must be rotated (W @ R) to
         # project them back to model space.
         rotation_path = get_rotation_path(self.vllm_config)
-        if rotation_path is not None:
+        if rotation_path is not None and hasattr(model.model, "fc"):
             rotation_weight = get_rotation_matrix(rotation_path)
             fc = model.model.fc
             with torch.no_grad():

--- a/vllm_ascend/worker/v2/spec_decode/dspark/speculator.py
+++ b/vllm_ascend/worker/v2/spec_decode/dspark/speculator.py
@@ -26,7 +26,7 @@ from vllm.v1.worker.gpu.input_batch import InputBatch
 from vllm.v1.worker.gpu.spec_decode.dspark.speculator import (
     DSparkSpeculator,
 )
-from vllm_ascend.models.llama_eagle3 import (
+from vllm_ascend.utils import (
     get_rotation_matrix,
     get_rotation_path,
 )

--- a/vllm_ascend/worker/v2/spec_decode/dspark/speculator.py
+++ b/vllm_ascend/worker/v2/spec_decode/dspark/speculator.py
@@ -26,7 +26,11 @@ from vllm.v1.worker.gpu.input_batch import InputBatch
 from vllm.v1.worker.gpu.spec_decode.dspark.speculator import (
     DSparkSpeculator,
 )
-
+from vllm_ascend.models.llama_eagle3 import (
+    get_rotation_matrix,
+    get_rotation_path,
+)
+from vllm_ascend.models.qwen3_dspark import process_weight
 from vllm_ascend.worker.v2.attn_utils import (
     build_attn_metadata_wrapper,
     build_draft_attn_metadata_factory,
@@ -39,6 +43,27 @@ class AscendDSparkSpeculator(DSparkSpeculator):
     def __init__(self, vllm_config: VllmConfig, device: torch.device):
         super().__init__(vllm_config, device)
         self.input_batch: InputBatch | None = None
+
+    def load_draft_model(
+        self,
+        target_model: torch.nn.Module,
+        target_attn_layer_names: set[str],
+    ) -> torch.nn.Module:
+        model = super().load_draft_model(target_model, target_attn_layer_names)
+        # Upstream load_dspark_model overrides the drafter's quant_config with
+        # get_draft_quant_config (None for a bf16 drafter), so the drafter's
+        # __init__ derives rotation_path=None and its fc projection is loaded
+        # unrotated. The target is QuaRot-quantized, so the aux hidden states it
+        # feeds the drafter are in rotated space; fc must be rotated (W @ R) to
+        # project them back to model space.
+        rotation_path = get_rotation_path(self.vllm_config)
+        if rotation_path is not None:
+            rotation_weight = get_rotation_matrix(rotation_path)
+            fc = model.model.fc
+            with torch.no_grad():
+                fc.weight.data.copy_(
+                    process_weight(fc.weight.data.cpu(), rotation_weight))
+        return model
 
     def init_cudagraph_manager(self, cudagraph_mode: CUDAGraphMode) -> None:
         super().init_cudagraph_manager(cudagraph_mode)


### PR DESCRIPTION
### What this PR does / why we need it?
Override the function load_draft_model for adding rotation fc.
Make glm5.2 QuaRot model support dspark in v2

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
tests and ut

- vLLM main: https://github.com/vllm-project/vllm/commit/ba07e4a48fc951300d97eb506217dd530583dea3
