### PR TITLE
[Feature][MRV2] Optimize ops topk_log_softmax

### DIFF
--- a/vllm_ascend/worker/v2/sample/logprob.py
+++ b/vllm_ascend/worker/v2/sample/logprob.py
@@ -25,62 +25,103 @@ from vllm.v1.outputs import LogprobsTensors
 from vllm_ascend.ops.triton.triton_utils import get_vectorcore_num
 
 
-@triton.jit
-def _topk_log_softmax_kernel(
-    output_ptr,
-    logits_ptr,
-    logits_stride,
-    topk_ids_ptr,
-    topk,
+@triton.jit 
+def _topk_log_softmax_kernel( 
+    output_ptr, 
+    logits_ptr, 
+    logits_stride, 
+    topk_ids_ptr, 
+    topk, 
     vocab_size,
-    BLOCK_SIZE: tl.constexpr,
-    PADDED_TOPK: tl.constexpr,
-):
-    req_idx = tl.program_id(0)
-    row_ptr = logits_ptr + req_idx * logits_stride
+    full_vocab_size,
+    BLOCK_SIZE: tl.constexpr, 
+    PADDED_TOPK: tl.constexpr, 
+): 
+    req_idx = tl.program_id(0) 
+    row_ptr = logits_ptr + req_idx * logits_stride 
+ 
+    running_max = float("-inf")
+    running_sum = 0.0
 
-    max_val = float("-inf")
-    for i in range(0, vocab_size, BLOCK_SIZE):
+    for i in range(0, full_vocab_size, BLOCK_SIZE):
         block = i + tl.arange(0, BLOCK_SIZE)
-        logits = tl.load(row_ptr + block, mask=block < vocab_size, other=float("-inf"))
-        max_val = tl.max(tl.maximum(logits, max_val, propagate_nan=tl.PropagateNan.ALL))
-    max_val = max_val.to(tl.float32)  # type: ignore
+        logits = tl.load(row_ptr + block)
 
-    se = 0.0
-    for i in range(0, vocab_size, BLOCK_SIZE):
-        block = i + tl.arange(0, BLOCK_SIZE)
-        logits = tl.load(row_ptr + block, mask=block < vocab_size, other=float("-inf"))
+        block_max = tl.max(logits)
+        block_max = block_max.to(tl.float32)  # type: ignore
+        new_max = tl.maximum(
+            block_max,
+            running_max,
+            propagate_nan=tl.PropagateNan.ALL,
+        )
+
         logits = logits.to(tl.float32)
-        e = tl.exp(logits - max_val)
-        se += tl.sum(e)
-    lse = tl.log(se)
+        old_scale = tl.exp(running_max - new_max)
+        block_sum = tl.sum(tl.exp(logits - new_max))
 
-    k_offset = tl.arange(0, PADDED_TOPK)
-    k_mask = k_offset < topk
-    topk_ids = tl.load(topk_ids_ptr + req_idx * topk + k_offset, mask=k_mask, other=0)
+        running_sum = running_sum * old_scale + block_sum
+        running_max = new_max
 
-    logits = tl.load(row_ptr + topk_ids, mask=k_mask)
-    logits = logits.to(tl.float32)
-    o = logits - lse - max_val
-    tl.store(output_ptr + req_idx * topk + k_offset, o, mask=k_mask)
-
-
-def compute_token_logprobs(logits: torch.Tensor, token_ids: torch.Tensor) -> torch.Tensor:
-    batch_size, vocab_size = logits.shape
-    token_ids = token_ids.to(torch.int64)
-    num_logprobs = token_ids.shape[1]
-    logprobs = logits.new_empty((batch_size, num_logprobs), dtype=torch.float32)
-    _topk_log_softmax_kernel[(batch_size,)](
-        logprobs,
-        logits,
-        logits.stride(0),
-        token_ids,
-        num_logprobs,
-        vocab_size,
-        BLOCK_SIZE=12944,
-        PADDED_TOPK=max(triton.next_power_of_2(num_logprobs), 2),
-        multibuffer=False,
+    block = full_vocab_size + tl.arange(0, BLOCK_SIZE)
+    logits = tl.load(
+        row_ptr + block,
+        mask=block < vocab_size,
+        other=float("-inf"),
     )
+
+    block_max = tl.max(logits)
+    block_max = block_max.to(tl.float32)  # type: ignore
+    new_max = tl.maximum(
+        block_max,
+        running_max,
+        propagate_nan=tl.PropagateNan.ALL,
+    )
+
+    logits = logits.to(tl.float32)
+    old_scale = tl.exp(running_max - new_max)
+    block_sum = tl.sum(tl.exp(logits - new_max))
+
+    running_sum = running_sum * old_scale + block_sum
+    running_max = new_max
+
+    lse = running_max + tl.log(running_sum)
+ 
+    k_offset = tl.arange(0, PADDED_TOPK) 
+    k_mask = k_offset < topk 
+    topk_ids = tl.load(
+        topk_ids_ptr + req_idx * topk + k_offset,
+        mask=k_mask,
+        other=0,
+    )
+ 
+    logits = tl.load(row_ptr + topk_ids, mask=k_mask) 
+    logits = logits.to(tl.float32) 
+    o = logits - lse
+    tl.store(output_ptr + req_idx * topk + k_offset, o, mask=k_mask) 
+ 
+ 
+def compute_token_logprobs(logits: torch.Tensor, token_ids: torch.Tensor) -> torch.Tensor: 
+    batch_size, vocab_size = logits.shape 
+    token_ids = token_ids.to(torch.int64) 
+    num_logprobs = token_ids.shape[1] 
+    logprobs = logits.new_empty((batch_size, num_logprobs), dtype=torch.float32)
+
+    full_vocab_size = (
+        vocab_size // (15 * 1024)
+    ) * (15 * 1024)
+
+    _topk_log_softmax_kernel[(batch_size,)]( 
+        logprobs, 
+        logits, 
+        logits.stride(0), 
+        token_ids, 
+        num_logprobs, 
+        vocab_size,
+        full_vocab_size,
+        BLOCK_SIZE=15 * 1024, 
+        PADDED_TOPK=max(triton.next_power_of_2(num_logprobs), 2), 
+        multibuffer=True, 
+    ) 
     return logprobs
 
 


### PR DESCRIPTION
### What this PR does / why we need it?
We apply 4 approaches on this triton op topk_log_softmax to gain a 1.37x speed up 
1. Better tiling config
2. online softmax
3. tailing mask
4. max logic changes
### Does this PR introduce _any_ user-facing change?

### How was this patch tested?

batch | vocab | topk | origin_us | opt_us | reduction | speedup
-- | -- | -- | -- | -- | -- | --
1 | 151936 | 5 | 31.959999 | 23.820000 | 25.47% | 1.342x
8 | 151936 | 5 | 31.900000 | 23.860001 | 25.20% | 1.337x
23 | 151936 | 5 | 32.660000 | 25.040001 | 23.33% | 1.304x
30 | 151936 | 5 | 33.720001 | 25.600000 | 24.08% | 1.317x
35 | 151936 | 5 | 34.419998 | 26.040001 | 24.35% | 1.322x
42 | 151936 | 5 | 62.720001 | 46.939999 | 25.16% | 1.336x
56 | 151936 | 5 | 64.260002 | 47.820000 | 25.58% | 1.344x
63 | 151936 | 5 | 64.699997 | 48.200001 | 25.50% | 1.342x
64 | 151936 | 5 | 65.500000 | 48.139999 | 26.50% | 1.361x
242 | 151936 | 6 | 216.740005 | 157.039993 | 27.54% | 1.380x
289 | 151936 | 6 | 247.559998 | 180.539993 | 27.07% | 1.371x
912 | 151936 | 6 | 705.099976 | 513.719971 | 27.14% | 1.373x
945 | 151936 | 6 | 734.200012 | 534.840027 | 27.15% | 1.373x
1024 | 151936 | 6 | 794.780029 |   |   |  

- vLLM version: v0.27.1
- vLLM main: https://github.com/vllm-project/vllm/commit/ba07e4a48fc951300d97eb506217dd530583dea3
