### PR TITLE
[MRV2][Performance][Kernel] Optimize V2 slot mappings on Ascend

### DIFF
--- a/tests/e2e/nightly/single_node/ops/singlecard_ops/triton/test_compute_slot_mapping.py
+++ b/tests/e2e/nightly/single_node/ops/singlecard_ops/triton/test_compute_slot_mapping.py
@@ -1,0 +1,125 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import pytest
+import torch
+from vllm.triton_utils import triton
+from vllm.v1.worker.gpu.block_table import (
+    _compute_slot_mappings_kernel as ref_compute_slot_mappings_kernel,
+)
+
+from vllm_ascend.ops.triton.v2.block_table.compute_slot_mappings import (
+    _compute_slot_mappings_kernel as ascend_compute_slot_mappings_kernel,
+)
+from vllm_ascend.worker.v2.block_table import (
+    AscendBlockTables,
+)
+
+
+@pytest.mark.parametrize(
+    ("cp_size", "cp_rank", "cp_interleave"),
+    [
+        pytest.param(1, 0, 1, id="cp1"),
+        pytest.param(2, 1, 2, id="cp2_interleaved"),
+        pytest.param(4, 2, 1, id="cp4_interleaved"),
+    ],
+)
+def test_compute_slot_mapping_npu_kernel_cp(cp_size: int, cp_rank: int, cp_interleave: int) -> None:
+    """Check the Ascend V2 kernel against the upstream kernel."""
+    device = "npu"
+    max_num_tokens = 8192
+    idx_mapping = torch.tensor([2, 0], dtype=torch.int32, device=device)
+    query_start_loc = torch.tensor([0, 5, 10], dtype=torch.int32, device=device)
+    positions = torch.tensor(
+        [0, 1, 63, 64, 127, 0, 2, 64, 128, 255],
+        dtype=torch.int64,
+        device=device,
+    )
+
+    num_groups = 2
+    block_tables = [torch.randint(0, 320, (3, 320), dtype=torch.int32, device=device) for _ in range(num_groups)]
+    block_table_ptrs = torch.tensor(
+        [table.data_ptr() for table in block_tables],
+        dtype=torch.uint64,
+        device=device,
+    )
+    block_table_strides = torch.tensor(
+        [table.stride(0) for table in block_tables],
+        dtype=torch.int64,
+        device=device,
+    )
+    block_sizes = torch.tensor([64, 128], dtype=torch.int32, device=device)
+    slot_mappings = torch.zeros((num_groups, max_num_tokens), dtype=torch.int32, device=device)
+    ref_slot_mappings = torch.zeros_like(slot_mappings)
+
+    kernel_args = (
+        max_num_tokens,
+        idx_mapping,
+        query_start_loc,
+        positions,
+        block_table_ptrs,
+        block_table_strides,
+        block_sizes,
+    )
+    grid = (num_groups, idx_mapping.shape[0] + 1)
+    kernel_kwargs = {
+        "CP_SIZE": cp_size,
+        "CP_INTERLEAVE": cp_interleave,
+        "PAD_ID": -1,
+        "TRITON_BLOCK_SIZE": 1024,
+    }
+    ascend_compute_slot_mappings_kernel[grid](
+        *kernel_args,
+        slot_mappings,
+        slot_mappings.stride(0),
+        cp_rank,
+        **kernel_kwargs,
+        BLOCK_TABLE_PAD_SIZE=triton.next_power_of_2(max(table.stride(0) for table in block_tables)),
+    )
+    ref_compute_slot_mappings_kernel[grid](
+        *kernel_args,
+        ref_slot_mappings,
+        ref_slot_mappings.stride(0),
+        cp_rank,
+        **kernel_kwargs,
+    )
+
+    torch.testing.assert_close(slot_mappings, ref_slot_mappings)
+
+
+def test_ascend_block_tables_compute_slot_mappings_out() -> None:
+    """Exercise the V2 override, including its current ``out`` argument."""
+    device = torch.device("npu")
+    block_table = torch.tensor(
+        [[10, 11, 0, 0], [20, 21, 0, 0], [30, 31, 0, 0]],
+        dtype=torch.int32,
+        device=device,
+    )
+    # This is a method-level test. Constructing BlockTables also exercises the
+    # unrelated UvaBuffer lifecycle, which is covered independently upstream.
+    block_tables = object.__new__(AscendBlockTables)
+    block_tables.num_kv_cache_groups = 1
+    block_tables.slot_mappings = torch.empty((1, 12), dtype=torch.int32, device=device)
+    block_tables.block_table_ptrs = torch.tensor([block_table.data_ptr()], dtype=torch.uint64, device=device)
+    block_tables.block_table_strides = torch.tensor([block_table.stride(0)], dtype=torch.int64, device=device)
+    block_tables.block_sizes_tensor = torch.tensor([4], dtype=torch.int32, device=device)
+    block_tables.cp_rank = 0
+    block_tables.cp_size = 1
+    block_tables.cp_interleave = 1
+    block_tables._block_table_pad_size = triton.next_power_of_2(block_table.stride(0))
+
+    out = torch.full((1, 12), 777, dtype=torch.int32, device=device)
+    result = block_tables.compute_slot_mappings(
+        torch.tensor([2, 0], dtype=torch.int32, device=device),
+        torch.tensor([0, 3, 6], dtype=torch.int32, device=device),
+        torch.tensor([0, 3, 4, 0, 4, 7], dtype=torch.int64, device=device),
+        num_tokens_padded=8,
+        out=out,
+    )
+
+    assert result.data_ptr() == out.data_ptr()
+    torch.testing.assert_close(
+        result.cpu(),
+        torch.tensor([[120, 123, 124, 40, 44, 47, -1, -1]], dtype=torch.int32),
+    )
+    torch.testing.assert_close(out[:, 8:].cpu(), torch.full((1, 4), -1, dtype=torch.int32))

--- a/vllm_ascend/ops/triton/v2/block_table/compute_slot_mappings.py
+++ b/vllm_ascend/ops/triton/v2/block_table/compute_slot_mappings.py
@@ -1,0 +1,74 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from vllm.triton_utils import tl, triton
+from vllm.v1.worker.gpu.block_table import _load_ptr
+
+
+@triton.jit
+def _compute_slot_mappings_kernel(
+    max_num_tokens,
+    idx_mapping,
+    query_start_loc,
+    pos,
+    block_table_ptrs,
+    block_table_strides,
+    block_sizes,
+    slot_mappings_ptr,
+    slot_mappings_stride,
+    cp_rank,
+    CP_SIZE: tl.constexpr,
+    CP_INTERLEAVE: tl.constexpr,
+    PAD_ID: tl.constexpr,
+    TRITON_BLOCK_SIZE: tl.constexpr,
+    BLOCK_TABLE_PAD_SIZE: tl.constexpr,
+):
+    group_id = tl.program_id(0)
+    batch_idx = tl.program_id(1)
+    slot_mapping_ptr = slot_mappings_ptr + group_id * slot_mappings_stride
+
+    if batch_idx == tl.num_programs(1) - 1:
+        actual_num_tokens = tl.load(query_start_loc + batch_idx)
+        for i in range(actual_num_tokens, max_num_tokens, TRITON_BLOCK_SIZE):
+            offset = i + tl.arange(0, TRITON_BLOCK_SIZE)
+            tl.store(slot_mapping_ptr + offset, PAD_ID, mask=offset < max_num_tokens)
+        return
+
+    block_table_ptr = _load_ptr(block_table_ptrs + group_id, tl.int32)
+    block_table_stride = tl.load(block_table_strides + group_id)
+    block_size = tl.load(block_sizes + group_id)
+    req_state_idx = tl.load(idx_mapping + batch_idx)
+    start_idx = tl.load(query_start_loc + batch_idx)
+    end_idx = tl.load(query_start_loc + batch_idx + 1)
+
+    lane_offsets = tl.arange(0, TRITON_BLOCK_SIZE)
+    # BLOCK_TABLE_PAD_SIZE is a compile-time upper bound for every group's row.
+    # The runtime stride mask keeps loads within the current group's row.
+    block_table_offsets = tl.arange(0, BLOCK_TABLE_PAD_SIZE)
+    block_table_values = tl.load(
+        block_table_ptr + req_state_idx * block_table_stride + block_table_offsets,
+        mask=block_table_offsets < block_table_stride,
+        other=0,
+    ).to(tl.float32)
+
+    for i in range(start_idx, end_idx, TRITON_BLOCK_SIZE):
+        offset = i + lane_offsets
+        valid = offset < end_idx
+        positions = tl.load(pos + offset, mask=valid, other=0).to(tl.int32)
+        block_indices = positions // (block_size * CP_SIZE)
+        # block_offset = positions % (block_size * CP_SIZE). Replacing the
+        # remainder with multiply/subtract avoids scalar fallback on Ascend.
+        block_offsets = positions - (block_size * CP_SIZE) * block_indices
+        block_numbers = tl.gather(block_table_values, block_indices, 0).to(tl.int32)
+
+        if CP_SIZE == 1:
+            slot_ids = block_numbers * block_size + block_offsets
+        else:
+            is_local = block_offsets // CP_INTERLEAVE % CP_SIZE == cp_rank
+            rounds = block_offsets // (CP_INTERLEAVE * CP_SIZE)
+            remainder = block_offsets % CP_INTERLEAVE
+            local_offsets = rounds * CP_INTERLEAVE + remainder
+            slot_ids = block_numbers * block_size + local_offsets
+            slot_ids = tl.where(is_local, slot_ids, PAD_ID)
+
+        tl.store(slot_mapping_ptr + offset, slot_ids, mask=valid)

--- a/vllm_ascend/ops/triton/v2/block_table/docs/compute_slot_mappings.md
+++ b/vllm_ascend/ops/triton/v2/block_table/docs/compute_slot_mappings.md
@@ -1,0 +1,133 @@
+# _compute_slot_mappings_kernel
+
+## Description
+
+- **Location**: `vllm_ascend/ops/triton/v2/block_table/compute_slot_mappings.py`
+  — `_compute_slot_mappings_kernel`, launched by
+  `AscendBlockTables.compute_slot_mappings`.
+- **Function**: Computes the physical KV-cache slot ID for every scheduled
+  token in MRV2. KV cache uses block-based physical storage, while each token
+  is identified by its logical position in a request. The request's
+  `block_table` maps the logical block index to a physical cache block; this
+  kernel combines that physical block number with the token's in-block offset
+  to produce the slot ID consumed by attention and cache-write operators. It
+  supports multiple KV-cache groups and context parallelism (CP), and fills
+  the unused tail of each output row with `PAD_ID`.
+- **Formula**: For a token at logical position `p`, let
+  `slice_size = block_size * CP_SIZE`,
+  `block_index = p // slice_size`, and
+  `block_offset = p % slice_size`. The physical block is read from the
+  request's block table. When `CP_SIZE == 1`, the output is
+  `physical_block * block_size + block_offset`. With CP enabled, only offsets
+  assigned to `cp_rank` are retained; their rank-local offset is
+  `(block_offset // (CP_INTERLEAVE * CP_SIZE)) * CP_INTERLEAVE +
+  block_offset % CP_INTERLEAVE`. Other ranks' offsets produce `PAD_ID`.
+- **Context-parallel mapping**: With `CP_SIZE > 1`, one virtual slice contains
+  `CP_SIZE` physical blocks and has size `block_size * CP_SIZE`. For a logical
+  position `p`:
+  1. `block_index = p // (block_size * CP_SIZE)` selects the virtual slice and
+     therefore the block-table entry.
+  2. `block_offset = p % (block_size * CP_SIZE)` selects a position inside the
+     virtual slice.
+  3. `(block_offset // CP_INTERLEAVE) % CP_SIZE` identifies the rank that owns
+     the position. Positions owned by another rank are represented by
+     `PAD_ID` on the current rank.
+  4. Complete interleave rounds and the remainder within one interleave segment
+     are combined into a contiguous rank-local offset. The final slot ID is
+     `physical_block * block_size + local_offset`.
+- **Algorithm flow**:
+  1. Launch a two-dimensional grid over KV-cache groups and requests, plus one
+     padding program per group.
+  2. Resolve the selected request through `idx_mapping`, then read its token
+     interval from `query_start_loc`.
+  3. Load the selected request's block-table row once with a contiguous GM
+     load, then process the interval in `TRITON_BLOCK_SIZE` tiles. Convert
+     positions to INT32, calculate block indices and offsets, and gather the
+     physical block number from the staged row.
+  4. Calculate slot IDs directly for non-CP execution. For CP execution,
+     convert virtual offsets to rank-local offsets and replace non-local slots
+     with `PAD_ID`.
+  5. The extra request program fills `[actual_num_tokens, max_num_tokens)` with
+     `PAD_ID` for each KV-cache group.
+- **Supported modes**: Atlas A2, Atlas A3, and Ascend 950. The kernel is used
+  by `AscendBlockTables.compute_slot_mappings` in the MRV2 model runner and
+  supports eager and graph-capture execution with a fixed grid and compile-time
+  CP attributes.
+
+## Parameters
+
+> [!NOTE]
+> All parameters are required.
+
+| Parameter | Input/Output/Attribute | Description | Data type | Data format |
+| --- | --- | --- | --- | --- |
+| `max_num_tokens` | Input | Number of allocated entries in each output row; entries after the actual token count are padded. | INT | scalar |
+| `idx_mapping` | Input | Maps each scheduled request index to a row in every group's block table; shape `[num_reqs]`. | INT32 | ND |
+| `query_start_loc` | Input | Prefix offsets delimiting each request's token interval; shape `[num_reqs + 1]`. The last value is the actual token count. | INT32 | ND |
+| `pos` | Input | Logical sequence position for every scheduled token; shape `[actual_num_tokens]`. Values are converted to INT32 inside the kernel. | INT64 | ND |
+| `block_table_ptrs` | Input | Device pointer table containing one INT32 block-table base address per KV-cache group; shape `[num_groups]`. | UINT64 | ND |
+| `block_table_strides` | Input | Row stride, in elements, of each group's block table; shape `[num_groups]`. | INT64 | ND |
+| `block_sizes` | Input | Physical KV-cache block size for each group; shape `[num_groups]`. | INT32 | ND |
+| `slot_mappings_ptr` | Output | Physical slot IDs, with one row per KV-cache group; shape `[num_groups, max_num_tokens]`. | INT32 | ND |
+| `slot_mappings_stride` | Input (attribute) | Row stride, in elements, of `slot_mappings_ptr`. | INT | scalar |
+| `cp_rank` | Input (attribute) | Rank of the current device in the context-parallel group. | INT | scalar |
+| `CP_SIZE` | Attribute | Number of ranks in the context-parallel group. | constexpr INT | scalar |
+| `CP_INTERLEAVE` | Attribute | Number of consecutive token positions assigned to one CP rank before interleaving to the next rank. | constexpr INT | scalar |
+| `PAD_ID` | Attribute | Value written for padding and token positions owned by another CP rank; production uses `PAD_SLOT_ID`. | constexpr INT | scalar |
+| `TRITON_BLOCK_SIZE` | Attribute | Number of token positions processed per loop tile; production uses 1024. | constexpr INT | scalar |
+| `BLOCK_TABLE_PAD_SIZE` | Attribute | Power-of-two upper bound for the allocated row stride. The load is masked by the runtime row stride. | constexpr INT | scalar |
+
+## Constraints
+
+- The launch grid must be `(num_groups, num_reqs + 1)`. The final program on
+  the request axis is reserved for output padding.
+- `idx_mapping` and `query_start_loc` must be INT32. `pos` is supplied as INT64
+  by MRV2, and every position must fit in INT32 because the optimized kernel
+  explicitly narrows it before index arithmetic.
+- Each `block_table_ptrs` entry must be a valid device address for an INT32
+  two-dimensional block table and must remain alive for the duration of the
+  launch. `block_table_strides` and `block_sizes` must describe the matching
+  group in the same order.
+- `query_start_loc` must be non-decreasing, start at zero, and end at a value no
+  greater than `max_num_tokens`. Every value in `idx_mapping` and every derived
+  block index must be within the corresponding block-table bounds.
+- `CP_SIZE >= 1`, `0 <= cp_rank < CP_SIZE`, and `CP_INTERLEAVE >= 1`.
+- `slot_mappings_ptr` must be INT32 with at least `max_num_tokens` entries per
+  group. `TRITON_BLOCK_SIZE` must be a positive compile-time constant.
+- Every derived block index must be smaller than its group's runtime row stride,
+  which in turn must not exceed `BLOCK_TABLE_PAD_SIZE`.
+- Graph capture requires the number of groups, request capacity, output
+  capacity, and compile-time CP attributes to remain compatible with the
+  captured launch.
+
+## Origin and Differences
+
+- **Origin**: Adapted from
+  `vllm.v1.worker.gpu.block_table._compute_slot_mappings_kernel`, the upstream
+  vLLM kernel used by the MRV2 block-table path.
+- **Differences**:
+    - Converts logical positions from INT64 to INT32 before block-index,
+    block-offset, and address calculations, reducing INT64 scalar arithmetic
+    on Ascend NPU.
+    - Stages one complete request row with a contiguous masked GM load and uses
+    `tl.gather` for token-to-block lookup, avoiding per-token non-contiguous GM
+    loads.
+    - Replaces the INT32 remainder used for the block offset with
+    multiply/subtract to avoid scalar fallback on Ascend.
+    - Preserves the upstream launch grid, CP mapping, padding behavior, and
+    optional `out` semantics.
+    - The kernel is launched by the Ascend-specific
+    `AscendBlockTables.compute_slot_mappings` override and writes to the
+    existing INT32 slot-mapping buffer required by the Ascend KV-cache path.
+
+## Test Cases
+
+The single-operator test compares the Ascend kernel bit-for-bit with the
+upstream MRV2 kernel for two KV-cache groups and CP configurations
+`(size, rank, interleave) = (1, 0, 1), (2, 1, 2), (4, 2, 1)`. It also exercises
+the `AscendBlockTables.compute_slot_mappings(..., out=...)` override and checks
+the returned view, physical slot IDs, and padded tail.
+
+```bash
+pytest -sv tests/e2e/nightly/single_node/ops/singlecard_ops/triton/test_compute_slot_mapping.py
+```

--- a/vllm_ascend/worker/v2/block_table.py
+++ b/vllm_ascend/worker/v2/block_table.py
@@ -17,7 +17,13 @@
 # This file is a part of the vllm-ascend project.
 #
 import torch
+from vllm.triton_utils import triton
+from vllm.v1.attention.backends.utils import PAD_SLOT_ID
 from vllm.v1.worker.gpu.block_table import BlockTables
+
+from vllm_ascend.ops.triton.v2.block_table.compute_slot_mappings import (
+    _compute_slot_mappings_kernel,
+)
 
 
 class AscendBlockTables(BlockTables):
@@ -48,6 +54,13 @@ class AscendBlockTables(BlockTables):
             cp_rank,
             cp_interleave,
         )
+        # The kernel block-table row can be wider than
+        # max_num_blocks_per_group when one KV block maps to multiple kernel
+        # blocks. Use the allocated row stride so the staged row is complete.
+        max_block_table_stride = max(block_table.gpu.stride(0) for block_table in self.block_tables)
+        # tl.arange needs a compile-time power-of-two size. This value is
+        # passed as a constexpr and covers every KV cache group's row.
+        self._block_table_pad_size = triton.next_power_of_2(max_block_table_stride)
         # because we will override these attribute, delete these attribute to
         # make sure it's collected by python gc immediately.
         del self.slot_mappings
@@ -59,3 +72,33 @@ class AscendBlockTables(BlockTables):
             dtype=torch.int32,
             device=self.device,
         )
+
+    def compute_slot_mappings(
+        self,
+        idx_mapping: torch.Tensor,
+        query_start_loc: torch.Tensor,
+        positions: torch.Tensor,
+        num_tokens_padded: int,
+        out: torch.Tensor | None = None,
+    ) -> torch.Tensor:
+        num_reqs = idx_mapping.shape[0]
+        num_groups = self.num_kv_cache_groups
+        slot_mappings = self.slot_mappings if out is None else out
+        _compute_slot_mappings_kernel[(num_groups, num_reqs + 1)](
+            slot_mappings.shape[1],
+            idx_mapping,
+            query_start_loc,
+            positions,
+            self.block_table_ptrs,
+            self.block_table_strides,
+            self.block_sizes_tensor,
+            slot_mappings,
+            slot_mappings.stride(0),
+            self.cp_rank,
+            CP_SIZE=self.cp_size,
+            CP_INTERLEAVE=self.cp_interleave,
+            PAD_ID=PAD_SLOT_ID,
+            TRITON_BLOCK_SIZE=1024,
+            BLOCK_TABLE_PAD_SIZE=self._block_table_pad_size,
+        )
+        return slot_mappings[:, :num_tokens_padded]


### PR DESCRIPTION
### What this PR does / why we need it?

MRv2 `AscendBlockTables` inherits the upstream slot-mapping algorithm. On
Ascend, its per-token indirect block-table loads and integer remainder
calculation cause high scalar overhead, especially as the number of request
programs or token tiles grows.

This PR keeps the existing V2 interface and moves the Ascend-specific Triton
kernel to `vllm_ascend/ops/triton/v2/block_table/compute_slot_mappings.py`.
`AscendBlockTables` remains responsible for deriving launch metadata and
launching the kernel. The kernel:

- use int32 position arithmetic;
- replace the int32 remainder with multiply/subtract;
- load each request's block-table row contiguously once and use `tl.gather`
  for token-to-block lookup; and
- derive a power-of-two compile-time row bound from the allocated block-table
  stride, while masking the runtime load by each group's actual stride.

The row bound uses the allocated stride rather than
`max_num_blocks_per_group`, because one KV block can map to multiple kernel
blocks.

### Does this PR introduce _any_ user-facing change?

No. This is an internal Ascend MRv2 kernel optimization.

### How was this patch tested?

- `bash format.sh`
- `bash format.sh ci`
- `SHELLCHECK_OPTS="--exclude=SC2046,SC2006,SC2086" pre-commit run --all-files --hook-stage manual --show-diff-on-failure`
- NPU test:

  ```bash
  /usr/local/python3.12.13/bin/python -m pytest -q -s \
    tests/e2e/nightly/single_node/ops/singlecard_ops/triton/test_compute_slot_mapping.py
  ```

  Result: `4 passed`, covering CP=1/2/4 numerical comparison with the
  upstream kernel and `AscendBlockTables.compute_slot_mappings(..., out=...)`.

- Direct-kernel performance on Ascend 910. Each implementation and case was
  profiled independently with `msprof op`; values are `Task Duration(us)`,
  not host-side Event timing. The baseline is the original vLLM kernel from
  `6e448d0ea9bf3d88d898b65449ca6dc2aec170ac`.

| Case | Request x tokens | Block-table width | Grid | Upstream (us) | Ascend (us) | Speedup |
| --- | --- | ---: | --- | ---: | ---: | ---: |
| `tile-1` | 1 x 1024 | 8 | 1 x 2 | 114.48 | 2.86 | 40.03x |
| `tile-64` | 64 x 1024 | 512 | 1 x 65 | 230.46 | 8.58 | 26.86x |
| `tile-1024` | 1024 x 1024 | 8192 | 1 x 1025 | 2944.54 | 78.62 | 37.45x |
| `long-64x8192` | 64 x 8192 | 4096 | 1 x 65 | 1574.28 | 13.10 | 120.17x |
| `long-64x32768` | 64 x 32768 | 16384 | 1 x 65 | 6183.24 | 36.12 | 171.19x |
| `cp2-tile-64-rank0` | 64 x 1024, CP=2 | 512 | 1 x 65 | 497.50 | 43.60 | 11.41x |
| `cp4-tile-64-rank2` | 64 x 1024, CP=4 | 512 | 1 x 65 | 492.56 | 43.74 | 11.26x |

Full CI was not run.

- vLLM main: https://github.com/vllm-project/vllm/commit/ba07e4a48fc951300d97eb506217dd530583dea3
