### PR TITLE
[Feature] Add customized ops "npu_fused_infer_attention_score_v2_sink…

### DIFF
--- a/tests/ut/attention/a2/test_attention_v1_fia_v2_sink.py
+++ b/tests/ut/attention/a2/test_attention_v1_fia_v2_sink.py
@@ -1,0 +1,215 @@
+#
+# Copyright (c) 2025 Huawei Technologies Co., Ltd. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# This file is a part of the vllm-ascend project.
+#
+"""Unit tests for the FIA v2 sink integration in attention_v1 (phase A).
+
+Phase A only wires the routing and guards behind two default-off switches;
+these tests exercise exactly that wiring on CPU mocks. No operator execution,
+no model run, no NPU side effects — runtime correctness stays unproven until
+the phase B experiments (docs/13 §4 S4/S5).
+
+Guard philosophy mirrors the DSpark integration's delegation pattern: static
+layer facts are resolved once in __init__ (_fia_v2_sink_layer_ok) and input
+validity beyond those (head topology, dtype, layout) is delegated to the
+operators, which receive them as inputs.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import torch
+
+import vllm_ascend.attention.attention_v1 as attn_module
+from tests.ut.base import TestBase
+from vllm.v1.attention.backend import AttentionType
+from vllm_ascend.attention.attention_v1 import AscendAttentionBackendImpl, AscendAttentionState
+from vllm_ascend.attention.utils import needs_layer_aware_fia_graph_replay
+
+
+def _make_impl(**kwargs):
+    """Build an impl on CPU mocks.
+
+    Supported extra kwargs: quant=True emulates a c8-quant config;
+    sink_enabled/graph_enabled patch the module-level switches (read at impl
+    __init__) so the routing gate becomes reachable.
+    """
+    quant = kwargs.pop("quant", False)
+    sink_enabled = kwargs.pop("sink_enabled", False)
+    graph_enabled = kwargs.pop("graph_enabled", False)
+    mock_config = MagicMock()
+    mock_config.quant_config = MagicMock() if quant else None
+    mock_config.kv_transfer_config = None
+    with (
+        patch("vllm_ascend.attention.attention_v1.get_current_vllm_config", return_value=mock_config),
+        patch("vllm_ascend.attention.utils.get_current_vllm_config", return_value=mock_config),
+        patch.object(attn_module, "_FIA_V2_SINK_ENABLED", sink_enabled),
+        patch.object(attn_module, "_FIA_V2_SINK_GRAPH_ENABLED", graph_enabled),
+    ):
+        needs_layer_aware_fia_graph_replay.cache_clear()
+        defaults = dict(
+            num_heads=8,
+            head_size=128,
+            scale=0.08838834764831845,
+            num_kv_heads=4,
+            alibi_slopes=None,
+            sliding_window=None,
+            kv_cache_dtype="bfloat16",
+            logits_soft_cap=None,
+            attn_type=AttentionType.DECODER,
+            kv_sharing_target_layer_name=None,
+        )
+        defaults.update(kwargs)
+        return AscendAttentionBackendImpl(**defaults)
+
+
+def _make_metadata(num_reqs=3, state=AscendAttentionState.DecodeOnly):
+    meta = MagicMock()
+    meta.attn_state = state
+    meta.actual_seq_lengths_q = [2, 5, 9][:num_reqs]
+    meta.seq_lens = torch.arange(10, 10 + num_reqs)
+    meta.query_start_loc = torch.tensor([0, 2, 5, 9][: num_reqs + 1])
+    meta.block_tables = torch.zeros((num_reqs, 8), dtype=torch.int32)
+    return meta
+
+
+class TestFiaV2SinkSwitchDefaults(TestBase):
+    def test_switches_default_off(self):
+        self.assertFalse(attn_module._FIA_V2_SINK_ENABLED)
+        self.assertFalse(attn_module._FIA_V2_SINK_GRAPH_ENABLED)
+
+    def test_required_op_names(self):
+        self.assertEqual(
+            attn_module._FIA_V2_SINK_REQUIRED_OPS,
+            (
+                "_npu_fused_infer_attention_score_v2_sink_metadata",
+                "npu_fused_infer_attention_score_v2_sink",
+            ),
+        )
+
+    def test_init_is_inert_when_switches_off(self):
+        impl = _make_impl()
+        self.assertFalse(impl._fia_v2_sink_requested)
+        self.assertFalse(impl._fia_v2_sink_layer_ok)
+
+
+class TestFiaV2SinkLayerGate(TestBase):
+    """Static per-layer facts are resolved once at __init__."""
+
+    def test_clean_layer_passes(self):
+        impl = _make_impl(sink_enabled=True)
+        self.assertTrue(impl._fia_v2_sink_requested)
+        self.assertTrue(impl._fia_v2_sink_layer_ok)
+
+    def test_sliding_window_layer(self):
+        impl = _make_impl(sliding_window=4096)
+        self.assertFalse(impl._fia_v2_sink_layer_ok)
+        self.assertFalse(impl._use_fia_v2_sink(_make_metadata()))
+
+    def test_sinks_layer(self):
+        # sinks reach the impl through the ctor (`sinks=`), before the gate.
+        impl = _make_impl(sinks=torch.randn(1))
+        self.assertFalse(impl._fia_v2_sink_layer_ok)
+        self.assertFalse(impl._use_fia_v2_sink(_make_metadata()))
+
+    def test_c8_quant_variant(self):
+        impl = _make_impl(quant=True)
+        self.assertTrue(impl.enable_c8_quant)
+        self.assertFalse(impl._fia_v2_sink_layer_ok)
+
+    def test_encoder_decoder(self):
+        impl = _make_impl(attn_type=AttentionType.ENCODER_DECODER)
+        self.assertFalse(impl._fia_v2_sink_layer_ok)
+
+
+class TestUseFiaV2SinkRouting(TestBase):
+    """Runtime/batch conditions; any mismatch falls back to the official path."""
+
+    def setUp(self):
+        self.impl = _make_impl(sink_enabled=True)
+
+    def test_none_metadata(self):
+        self.assertFalse(self.impl._use_fia_v2_sink(None))
+
+    def test_prefill_no_cache_state(self):
+        self.assertFalse(self.impl._use_fia_v2_sink(_make_metadata(state=AscendAttentionState.PrefillNoCache)))
+
+    def test_seq_lens_shorter_than_batch(self):
+        meta = _make_metadata()
+        meta.seq_lens = torch.arange(10, dtype=torch.int64)[:1]
+        self.assertFalse(self.impl._use_fia_v2_sink(meta))
+
+    def test_query_start_loc_shorter_than_batch(self):
+        meta = _make_metadata()
+        meta.query_start_loc = torch.tensor([0, 2])
+        self.assertFalse(self.impl._use_fia_v2_sink(meta))
+
+    def test_block_table_shorter_than_batch(self):
+        meta = _make_metadata()
+        meta.block_tables = torch.zeros((1, 8), dtype=torch.int32)
+        self.assertFalse(self.impl._use_fia_v2_sink(meta))
+
+    def test_valid_decode_batch(self):
+        self.assertTrue(self.impl._use_fia_v2_sink(_make_metadata()))
+
+
+class TestBuildFiaV2SinkSeqTensors(TestBase):
+    def test_uniform_fallback_without_npu_query_start_loc(self):
+        # query_start_loc not on NPU -> DSpark uniform arange derivation.
+        seq_lens = torch.tensor([904, 1180, 1024, 1290])
+        q_loc = torch.tensor([0, 4, 8, 12, 16])
+        qlen, kvlen = attn_module._build_fia_v2_sink_seq_tensors(16, 4, seq_lens, q_loc)
+        self.assertEqual(qlen.tolist(), [4, 8, 12, 16])
+        self.assertEqual(kvlen.tolist(), [904, 1180, 1024, 1290])
+        self.assertEqual(qlen.dtype, torch.int64)
+        self.assertEqual(kvlen.dtype, torch.int64)
+
+    def test_kv_clamp_keeps_lengths_strictly_positive(self):
+        seq_lens = torch.tensor([7, 0, 0])  # padded dummy requests carry 0
+        qlen, kvlen = attn_module._build_fia_v2_sink_seq_tensors(9, 3, seq_lens, None)
+        self.assertEqual(qlen.tolist(), [3, 6, 9])
+        self.assertEqual(kvlen.tolist(), [7, 1, 1])
+        self.assertEqual(kvlen.dtype, torch.int64)
+
+    def test_uniform_fallback_rejects_uneven_batch(self):
+        seq_lens = torch.tensor([900, 1100])
+        with self.assertRaises(RuntimeError):
+            attn_module._build_fia_v2_sink_seq_tensors(7, 2, seq_lens, None)
+
+
+class TestGetOrComputeCache(TestBase):
+    def test_computes_once_per_signature(self):
+        # A plain attribute holder mimicking ForwardContext (MagicMock would
+        # auto-create a non-container attribute and defeat the dict cache).
+        holder = type("ForwardContextStub", (), {})()
+
+        def fake_get_forward_context():
+            return holder
+
+        calls = []
+
+        def compute():
+            # Distinct object per invocation (avoid constant-folded tuples).
+            calls.append(1)
+            marker = object()
+            return marker, "kvlen", "meta"
+
+        with patch.object(attn_module, "get_forward_context", fake_get_forward_context):
+            first = attn_module._get_or_compute_fia_v2_sink_inputs(("k", 1), compute)
+            second = attn_module._get_or_compute_fia_v2_sink_inputs(("k", 1), compute)
+            other = attn_module._get_or_compute_fia_v2_sink_inputs(("k", 2), compute)
+
+        self.assertEqual(len(calls), 2)
+        self.assertIs(first, second)
+        self.assertIsNot(first[0], other[0])

--- a/vllm_ascend/attention/attention_v1.py
+++ b/vllm_ascend/attention/attention_v1.py
@@ -15,6 +15,8 @@
 # This file is a part of the vllm-ascend project.
 #
 
+import importlib
+from collections.abc import Callable
 from dataclasses import dataclass
 from enum import Enum
 from typing import Any
@@ -23,6 +25,7 @@ import torch
 import torch_npu
 from vllm.config import VllmConfig, get_current_vllm_config
 from vllm.distributed import get_tensor_model_parallel_rank, get_tensor_model_parallel_world_size
+from vllm.forward_context import get_forward_context
 from vllm.utils.math_utils import cdiv
 from vllm.v1.attention.backend import (  # type: ignore
     AttentionBackend,
@@ -39,6 +42,7 @@ from vllm.v1.attention.backends.registry import (  # type: ignore
 from vllm.v1.core.sched.output import SchedulerOutput
 from vllm.v1.kv_cache_interface import AttentionSpec, CrossAttentionSpec
 
+from vllm_ascend import envs
 from vllm_ascend.ascend_forward_context import _EXTRA_CTX
 from vllm_ascend.attention.attention_mask import AttentionMaskBuilder
 from vllm_ascend.attention.utils import (
@@ -72,6 +76,112 @@ else:
 # default max value of sliding window size
 SWA_INT_MAX = 2147483647
 _ATTN_KEYS_BUFFER = None
+
+# ---------------------------------------------------------------------------
+# FIA v2 sink integration (fia_v2_sink_ops, phase A: eager + graph routing).
+# Copied from the DSpark omni-sink integration with the §2.1 renames applied:
+# omni_custom_ops -> fia_v2_sink_ops and the two op names below. Both switches
+# default to 0 (registered in vllm_ascend/envs.py); the graph-mode switch
+# guards an UNVERIFIED aclgraph path (see F1 note at the capture branch).
+# Following the DSpark integration's delegation principle: the framework only
+# routes and checks op registration; input validity (head topology, head dim,
+# dtype, layout) is validated by the sink operators themselves.
+# ---------------------------------------------------------------------------
+_FIA_V2_SINK_META_CACHE_ATTR = "_ascend_fia_v2_sink_meta_cache"
+_FIA_V2_SINK_REQUIRED_OPS = (
+    "_npu_fused_infer_attention_score_v2_sink_metadata",
+    "npu_fused_infer_attention_score_v2_sink",
+)
+_FIA_V2_SINK_ENABLED = bool(envs.VLLM_ASCEND_ENABLE_FIA_V2_SINK)
+_FIA_V2_SINK_GRAPH_ENABLED = bool(envs.VLLM_ASCEND_ENABLE_FIA_V2_SINK_GRAPH)
+_fia_v2_sink_ops_registered = False
+
+
+def _ensure_fia_v2_sink_ops_registered() -> None:
+    """Load fia_v2_sink_ops and fail early when its sink ops are unavailable."""
+    global _fia_v2_sink_ops_registered
+    if _fia_v2_sink_ops_registered:
+        return
+
+    try:
+        importlib.import_module("fia_v2_sink_ops")
+    except (ImportError, OSError) as exc:
+        raise RuntimeError(
+            "VLLM_ASCEND_ENABLE_FIA_V2_SINK=1 requires the fia_v2_sink_ops "
+            "wheel. Install it and set ASCEND_CUSTOM_OPP_PATH to both custom "
+            "OPP entries of the delivery kit."
+        ) from exc
+
+    missing_ops = [name for name in _FIA_V2_SINK_REQUIRED_OPS if not hasattr(torch.ops.custom, name)]
+    if missing_ops:
+        raise RuntimeError(
+            "fia_v2_sink_ops was imported but the required FIA v2 sink operators "
+            f"were not registered: {', '.join(missing_ops)}. Check that "
+            "ASCEND_CUSTOM_OPP_PATH points at both delivered OPP entries."
+        )
+    _fia_v2_sink_ops_registered = True
+
+
+def _get_or_compute_fia_v2_sink_inputs(
+    cache_key: tuple[int | bool | None, ...],
+    compute: Callable[[], tuple[torch.Tensor, torch.Tensor, torch.Tensor]],
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    """Compute device seq tensors and metadata once per forward/signature.
+
+    During aclgraph capture the first layer records the conversion, metadata and
+    sink dependency. Later layers reuse the same tensors. Graph replay therefore
+    reruns one metadata op per signature while keeping all captured addresses
+    stable. Eager forwards get a fresh context-local cache on every step.
+    """
+    forward_context = get_forward_context()
+    cache = getattr(forward_context, _FIA_V2_SINK_META_CACHE_ATTR, None)
+    if cache is None:
+        cache = {}
+        setattr(forward_context, _FIA_V2_SINK_META_CACHE_ATTR, cache)
+    if cache_key not in cache:
+        cache[cache_key] = compute()
+    return cache[cache_key]
+
+
+def _build_fia_v2_sink_seq_tensors(
+    num_tokens: int,
+    num_reqs: int,
+    seq_lens: torch.Tensor,
+    query_start_loc: torch.Tensor | None,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Build legal device-side TND lengths without host synchronization.
+
+    Main-model query blocks are not uniform (mixed prefill), so cumulative Q
+    lengths come from the device-side query_start_loc tensor whenever it is
+    available; the uniform-block arange derivation below is kept verbatim from
+    the DSpark integration as fallback for producers without that tensor.
+    KV lengths map to int64 on the same device; padded dummy requests keep a
+    strictly positive length because FIA sink rejects non-positive values.
+    """
+    if (
+        query_start_loc is not None
+        and query_start_loc.device.type == "npu"
+        and query_start_loc.numel() == num_reqs + 1
+    ):
+        actual_seq_qlen = query_start_loc[1 : num_reqs + 1].to(torch.int64)
+    else:
+        # DSpark原文路径：均匀块直接 arange×每req token 数得累积和。
+        if num_reqs <= 0 or num_tokens % num_reqs != 0:
+            raise RuntimeError(
+                "FIA v2 sink requires a non-empty uniform query batch when no "
+                "device-side query_start_loc is available: "
+                f"num_tokens={num_tokens}, num_reqs={num_reqs}"
+            )
+        device = query_start_loc.device if query_start_loc is not None else seq_lens.device
+        actual_seq_qlen = torch.arange(1, num_reqs + 1, dtype=torch.int64, device=device) * (
+            num_tokens // num_reqs
+        )
+    # Eager metadata may keep seq_lens host-resident while query_start_loc is
+    # on device; the [B]-element H2D stays asynchronous and sync-free.
+    if seq_lens.device != actual_seq_qlen.device:
+        seq_lens = seq_lens.to(device=actual_seq_qlen.device, non_blocking=True)
+    actual_seq_kvlen = seq_lens[:num_reqs].to(torch.int64).clamp_min(1)
+    return actual_seq_qlen, actual_seq_kvlen
 
 
 @register_backend(AttentionBackendEnum.CUSTOM, "ASCEND")
@@ -538,6 +648,25 @@ class AscendAttentionBackendImpl(AttentionImpl):
         # attn_metadata during graph replay. Record the captured layer name only
         # for that path.
         self._layer_name: str | None = None
+        # FIA v2 sink (phase A): fail fast at engine start when a switch is
+        # explicitly enabled but the wheel/OPP package is half-deployed, so it
+        # cannot silently fall back or route nowhere mid-serving.
+        self._fia_v2_sink_requested = _FIA_V2_SINK_ENABLED or _FIA_V2_SINK_GRAPH_ENABLED
+        if self._fia_v2_sink_requested:
+            _ensure_fia_v2_sink_ops_registered()
+        # Static per-layer facts are resolved once here instead of per step,
+        # so the hot path reads a single routing conclusion. Only facts the
+        # sink operators cannot see live in this gate: head topology, head
+        # dim, dtype and layout are passed to the ops as inputs and validated
+        # by the ops themselves (delegation principle of the DSpark
+        # integration), so the framework must not duplicate their capability
+        # tables.
+        self._fia_v2_sink_layer_ok = self._fia_v2_sink_requested and (
+            self.sliding_window is None
+            and self.sinks is None
+            and self.attn_type != AttentionType.ENCODER_DECODER
+            and not self.enable_c8_quant
+        )
 
     def _graph_metadata_layer_name(self, layer: AttentionLayer | None = None) -> str | None:
         layer_name = layer.layer_name if layer is not None else self._layer_name
@@ -1344,6 +1473,158 @@ class AscendAttentionBackendImpl(AttentionImpl):
             actual_seq_lengths_kv = attn_metadata.seq_lens_list
         return key, value, block_size, block_table, actual_seq_lengths_kv
 
+    def _use_fia_v2_sink(self, attn_metadata: AscendMetadata) -> bool:
+        """Whether this layer/batch may be dispatched to the FIA v2 sink ops.
+
+        Static layer facts were resolved once in __init__
+        (_fia_v2_sink_layer_ok); input validity beyond those (head topology,
+        head dim, dtype, layout) is delegated to the sink operators, which
+        receive them as inputs. Routing keeps only conditions the operators
+        cannot judge: the batch must be paged (PrefillNoCache runs on inline
+        KV) and the seq/block_table tensors must cover the query batch —
+        any mismatch falls back to the official path because the AICPU
+        metadata op fails with a process-level crash on illegal inputs
+        (plans/10 §5.5-L2), not with a catchable error.
+        """
+        if not self._fia_v2_sink_layer_ok or attn_metadata is None:
+            return False
+        num_reqs = len(attn_metadata.actual_seq_lengths_q)
+        return (
+            attn_metadata.attn_state != AscendAttentionState.PrefillNoCache
+            and num_reqs > 0
+            and attn_metadata.seq_lens is not None
+            and attn_metadata.query_start_loc is not None
+            and attn_metadata.seq_lens.shape[0] >= num_reqs
+            and attn_metadata.query_start_loc.numel() >= num_reqs + 1
+            and attn_metadata.block_tables.shape[0] >= num_reqs
+        )
+
+    def _forward_fia_v2_sink(
+        self,
+        query: torch.Tensor,
+        key: torch.Tensor,
+        value: torch.Tensor,
+        attn_metadata: AscendMetadata,
+        output: torch.Tensor,
+        kv_cache=None,
+    ) -> torch.Tensor:
+        """Main-model attention via the two-stage FIA v2 sink operators.
+
+        Copied from the DSpark integration (_forward_fia_sink) with three
+        deltas per docs/13 §2: (1) op names / wheel swapped to fia_v2_sink_ops;
+        (2) return_softmax_lse=True keeps the (out, lse) tuple contract of the
+        delivered schema (omni returned it unconditionally); (3) sparse_mode /
+        atten_mask are forwarded instead of hardcoded non-causal DSpark
+        semantics, because this path serves causal main models — sliding-window
+        (sparse_mode=4) layers never reach here (guarded in _use_fia_v2_sink).
+        Both seq tensors stay on device: the metadata stage reads them on AICPU
+        and no seq_lens.tolist()/item() host sync happens in this forward.
+        """
+        if self.key_cache is None and kv_cache is not None:
+            if (
+                isinstance(kv_cache, torch.Tensor)
+                and kv_cache.dim() > 0
+                and kv_cache.shape[0] == 2
+                or isinstance(kv_cache, (list, tuple))
+                and len(kv_cache) >= 2
+            ):
+                self.key_cache, self.value_cache = kv_cache[0], kv_cache[1]
+        if self.key_cache is None:
+            raise RuntimeError("key_cache is None in _forward_fia_v2_sink")
+
+        num_block, block_size, _, _ = self.key_cache.shape
+        key = self.key_cache.view(num_block, block_size, -1)
+        value = self.value_cache.view(num_block, block_size, -1)
+        block_table = attn_metadata.block_tables
+
+        num_tokens = attn_metadata.actual_seq_lengths_q[-1]
+        query = query[:num_tokens]
+
+        num_reqs = len(attn_metadata.actual_seq_lengths_q)
+        if block_table.shape[0] < num_reqs:
+            raise RuntimeError(
+                "FIA v2 sink block table has fewer rows than requests: "
+                f"rows={block_table.shape[0]}, num_reqs={num_reqs}"
+            )
+        block_table = block_table[:num_reqs]
+
+        sparse_mode = 3 if attn_metadata.causal else 0
+        atten_mask = attn_metadata.attn_mask if sparse_mode == 3 else None
+
+        cache_key = (
+            attn_metadata.query_start_loc.data_ptr(),
+            attn_metadata.seq_lens.data_ptr(),
+            num_tokens,
+            num_reqs,
+            sparse_mode,
+            atten_mask is not None,
+            self.num_heads,
+            self.num_kv_heads,
+            self.head_size,
+            block_size,
+        )
+
+        def compute_sink_inputs() -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+            actual_seq_qlen, actual_seq_kvlen = _build_fia_v2_sink_seq_tensors(
+                num_tokens,
+                num_reqs,
+                attn_metadata.seq_lens,
+                attn_metadata.query_start_loc,
+            )
+            # Explicit aic/aiv counts: the schema defaults (24/48) do not match
+            # this SoC, and get_stream_limit is the omni/vllm convention the
+            # delivered wheel was validated with.
+            stream_limit = torch.npu.get_stream_limit(torch.npu.current_stream())
+            meta_data = torch.ops.custom._npu_fused_infer_attention_score_v2_sink_metadata(
+                self.num_heads,
+                self.num_kv_heads,
+                self.head_size,
+                self.head_size,
+                actual_seq_lengths=actual_seq_qlen,
+                actual_seq_lengths_kv=actual_seq_kvlen,
+                batch_size=num_reqs,
+                sparse_mode=sparse_mode,
+                pre_tokens=SWA_INT_MAX,
+                next_tokens=SWA_INT_MAX,
+                input_layout="TND",
+                input_layout_kv="BnBsH",
+                sink_num=0,
+                block_size=block_size,
+                aic_core_num=stream_limit["cube_core_num"],
+                aiv_core_num=stream_limit["vector_core_num"],
+            )
+            return actual_seq_qlen, actual_seq_kvlen, meta_data
+
+        actual_seq_qlen, actual_seq_kvlen, meta_data = _get_or_compute_fia_v2_sink_inputs(
+            cache_key,
+            compute_sink_inputs,
+        )
+
+        attn_output, _ = torch.ops.custom.npu_fused_infer_attention_score_v2_sink(
+            query,
+            key,
+            value,
+            query_rope=None,
+            key_rope=None,
+            atten_mask=atten_mask,
+            actual_seq_qlen=actual_seq_qlen,
+            actual_seq_kvlen=actual_seq_kvlen,
+            block_table=block_table,
+            meta_data=meta_data,
+            num_query_heads=self.num_heads,
+            num_key_value_heads=self.num_kv_heads,
+            softmax_scale=self.scale,
+            input_layout="TND",
+            sparse_mode=sparse_mode,
+            block_size=block_size,
+            pre_tokens=SWA_INT_MAX,
+            next_tokens=SWA_INT_MAX,
+            return_softmax_lse=True,
+        )
+        attn_output = attn_output.view(num_tokens, self.num_heads, self.head_size)
+        output[:num_tokens] = attn_output[:num_tokens]
+        return output
+
     def forward_fused_infer_attention(
         self,
         query: torch.Tensor,
@@ -1357,6 +1638,16 @@ class AscendAttentionBackendImpl(AttentionImpl):
         # runner v2, there is not capturing attribute in forward_context,
         # just use getattr to avoid attribute error.
         if _EXTRA_CTX.capturing:
+            if _FIA_V2_SINK_GRAPH_ENABLED and self._use_fia_v2_sink(attn_metadata):
+                # ⚠️ F1 未证路径（docs/13 §0，运行验证前一律视为未证）：
+                # 私有仓模板 docstring 声称 aclgraph capture 后 replay 会重执行
+                # metadata op；但 9.1/9.2 双环境的决定性探针实测相反——含
+                # DNN_VM_AICPU 自定义节点的图重放不刷新 AICPU 输出，metadata
+                # 内容固化在捕获时刻，主算子随图烘焙捕获时的分核计划。本分支
+                # 照抄模板 inline 捕获结构，因此继承同一风险。阶段B 开启前必须
+                # 先独立跑通 tests/aclgraph_decisive_replay_probe.py 并留证；
+                # 默认由子开关 VLLM_ASCEND_ENABLE_FIA_V2_SINK_GRAPH 关闭。
+                return self._forward_fia_v2_sink(query, key, value, attn_metadata, output, kv_cache)
             if self.sinks is not None:
                 attn_output, num_tokens = self.full_graph_fia_v2(query, key, value, attn_metadata, output)
                 output[:num_tokens] = attn_output[:num_tokens]
@@ -1365,6 +1656,11 @@ class AscendAttentionBackendImpl(AttentionImpl):
                 attn_output, num_tokens = self.full_graph_fia(query, key, value, attn_metadata, output)
                 output[:num_tokens] = attn_output[:num_tokens]
                 return output
+        elif _FIA_V2_SINK_ENABLED and self._use_fia_v2_sink(attn_metadata):
+            # Eager dispatch（主开关 VLLM_ASCEND_ENABLE_FIA_V2_SINK）：
+            # seq 张量全程驻留 device，AICPU metadata 每步按真值分核，
+            # 动态 batch 形态合法，eager 路径不受 F1 影响。
+            return self._forward_fia_v2_sink(query, key, value, attn_metadata, output, kv_cache)
         passed_value = value
         key, value, block_size, block_table, actual_seq_lengths_kv = self._get_fia_params(
             key, value, attn_metadata, kv_cache

--- a/vllm_ascend/envs.py
+++ b/vllm_ascend/envs.py
@@ -83,6 +83,24 @@ env_variables: dict[str, Callable[[], Any]] = {
     # Control the aclrtMemcpyBatchAsync compile path for KV cache offloading.
     # "1": force enable, "0": force disable, None: auto-detect from CANN headers.
     "VLLM_ASCEND_ENABLE_BATCH_MEMCPY": lambda: os.getenv("VLLM_ASCEND_ENABLE_BATCH_MEMCPY", None),
+    # Whether to dispatch eager GQA attention to the pre-built FIA v2 sink
+    # operators (fia_v2_sink_ops wheel + custom OPP package). Requires
+    # ASCEND_CUSTOM_OPP_PATH to contain both delivered custom OPP entries and
+    # the wheel to be installed; when enabled but not deployed this fails fast
+    # at engine start. Layers with sliding_window or sinks never route here.
+    # 0: disable (official FIA path only), 1: enable. Default 0 (off).
+    # NOT run-verified yet (phase A: code-ready only).
+    "VLLM_ASCEND_ENABLE_FIA_V2_SINK": lambda: bool(int(os.getenv("VLLM_ASCEND_ENABLE_FIA_V2_SINK", "0"))),
+    # Whether the FIA v2 sink dispatch may also apply while capturing/replaying
+    # aclgraph. KNOWN RISK (F1): AICPU nodes captured inside a graph are not
+    # re-executed at replay on CANN 9.1/9.2, so the captured split-core
+    # metadata goes stale while shapes change. Keep 0 until
+    # tests/aclgraph_decisive_replay_probe.py passes independently.
+    # 0: disable, 1: enable. Default 0 (off).
+    # UNVERIFIED path — do not enable outside controlled experiments.
+    "VLLM_ASCEND_ENABLE_FIA_V2_SINK_GRAPH": lambda: bool(
+        int(os.getenv("VLLM_ASCEND_ENABLE_FIA_V2_SINK_GRAPH", "0"))
+    ),
 }
 
 # end-env-vars-definition


### PR DESCRIPTION
<!--  Thanks for sending a pull request!

BEFORE SUBMITTING, PLEASE READ https://docs.vllm.ai/en/latest/contributing/overview.html

-->
### What this PR does / why we need it?
<!--
- Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue.
If possible, please consider writing useful notes for better and faster reviews in your PR.

- Please clarify why the changes are needed. For instance, the use case and bug description.

- Fixes #
-->

Add 2 customized ops "npu_fused_infer_attention_score_v2_sink" and "npu_fused_infer_attention_score_v2_sink_metadata" to support GQA tiling sink

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as API, interface or other behavior changes.
Documentation-only updates are not considered user-facing changes.
-->

Yes, two env variables are added for testing the customized ops, the ops is registrated as "torch.ops.custom._npu_fused_infer_attention_score_v2_sink_metadata" and "torch.ops.custom.npu_fused_infer_attention_score_v2_sink";  we shall move the source codes of the ops to /vllm-ascend/csrc to automatically compile it later

### How was this patch tested?
<!--
CI passed with new added/existing test.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->

```
#!/bin/bash
export HCCL_OP_EXPANSION_MODE="AIV"
export OMP_PROC_BIND=false
export OMP_NUM_THREADS=1
export HCCL_BUFFSIZE=512
export HCCL_CONNECT_TIMEOUT=3600
export PYTORCH_NPU_ALLOC_CONF=expandable_segments:True
export VLLM_ASCEND_BALANCE_SCHEDULING=0
export TRITON_DEBUG=0
export ASCEND_RT_VISIBLE_DEVICES=8,9,10,11,12,13,14,15
export VLLM_ASCEND_ENABLE_FIA_V2_SINK=1 # enable fia tiling sink
export ASCEND_CUSTOM_OPP_PATH= /ops_dir/ # path to fia_sink ops

LOG_FILE="/home/t00886357/fia_sink/logs/test_glm5.log"
> "$LOG_FILE"

mkdir -p /tmp/glm5-run && cd /tmp/glm5-run

vllm serve /dir/GLM-5.2-w4a8 \
    --served-model-name glm-52 \
    --host 0.0.0.0 \
    --port 8078 \
    --tensor-parallel-size 8 \
    --data-parallel-size 1 \
    --enable-expert-parallel \
    --speculative-config '{"method":"dspark","model":"/dir/GLM5.2_dspark","num_speculative_tokens":7, "enforce_eager":true}' \
    --compilation-config '{"cudagraph_capture_sizes":[8, 16, 24, 32], "cudagraph_mode": "FULL_DECODE_ONLY"}' \
    --seed 1024 \
    --max-num-seqs 4 \
    --max-model-len 32096 \
    --trust-remote-code \
    --gpu-memory-utilization 0.92 \
    --hf-overrides '{"use_index_cache": true}' \
    --quantization ascend \
    --async-scheduling \
    &>> "$LOG_FILE" &

echo "vLLM (GLM-5.2) started in background, PID: $!"
echo "Log file: $LOG_FILE"
```

vllm-ascend: main@23c8bf712c5c2963e12c8488551bcc7837f7fca7
vllm: v0.27.1