### PR TITLE
[BugFix] Add hf_to_vllm_mapper to DeepSeekV4 model class

### DIFF
--- a/vllm_ascend/models/deepseek_v4/model.py
+++ b/vllm_ascend/models/deepseek_v4/model.py
@@ -1096,8 +1096,8 @@ class AscendDeepseekV4ForCausalLM(nn.Module, SupportsPP, DeepseekV2MixtureOfExpe
             if spec_layer is not None:
                 continue  # skip spec decode layers for main model
 
-            mapped = self.hf_to_vllm_mapper._map_name(name)
-            if mapped is None:
+            name = self.hf_to_vllm_mapper._map_name(name)
+            if name is None:
                 continue
 
             if "sink" in name:

--- a/vllm_ascend/models/deepseek_v4/model.py
+++ b/vllm_ascend/models/deepseek_v4/model.py
@@ -956,6 +956,7 @@ class AscendDeepseekV4ForCausalLM(nn.Module, SupportsPP, DeepseekV2MixtureOfExpe
     hf_to_vllm_mapper = WeightsMapper(
         orig_to_new_regex={
             re.compile(r"rotary_emb\.inv_freq"): None,
+            re.compile(r"(?<![\w])embed\.(?!tokens)"): "embed_tokens.",
             re.compile(r"^(?!model)"): "model.",
         },
         orig_to_new_substr={
@@ -964,7 +965,6 @@ class AscendDeepseekV4ForCausalLM(nn.Module, SupportsPP, DeepseekV2MixtureOfExpe
             ".w3.": ".up_proj.",
             "model.head.": "lm_head.",
             "model.lm_head.": "lm_head.",
-            "embed.": "embed_tokens.",
             ".attn.": ".self_attn.",
             ".ffn.": ".mlp.",
             ".ffn_norm.": ".post_attention_layernorm.",

--- a/vllm_ascend/models/deepseek_v4/model.py
+++ b/vllm_ascend/models/deepseek_v4/model.py
@@ -23,6 +23,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+import re
 import math
 import typing
 from collections.abc import Callable, Iterable
@@ -64,6 +65,7 @@ from vllm.model_executor.models.interfaces import (
 )
 from vllm.model_executor.models.utils import (
     PPMissingLayer,
+    WeightsMapper,
     is_pp_missing_parameter,
     make_layers,
     maybe_prefix,
@@ -951,6 +953,26 @@ class AscendDeepseekV4ForCausalLM(nn.Module, SupportsPP, DeepseekV2MixtureOfExpe
     packed_modules_mapping = {
         "gate_up_proj": ["gate_proj", "up_proj"],
     }
+    hf_to_vllm_mapper = WeightsMapper(
+        orig_to_new_regex={
+            re.compile(r"rotary_emb\.inv_freq"): None,
+            re.compile(r"^(?!model)"): "model.",
+        },
+        orig_to_new_substr={
+            ".w1.": ".gate_proj.",
+            ".w2.": ".down_proj.",
+            ".w3.": ".up_proj.",
+            "model.head.": "lm_head.",
+            "model.lm_head.": "lm_head.",
+            "embed.": "embed_tokens.",
+            ".attn.": ".self_attn.",
+            ".ffn.": ".mlp.",
+            ".ffn_norm.": ".post_attention_layernorm.",
+            ".attn_norm.": ".input_layernorm.",
+            ".gate.bias": ".gate.e_score_correction_bias",
+        },
+        orig_to_new_suffix={".scale": ".weight_scale"},
+    )
     model_cls = DeepseekV4Model
 
     def __init__(self, *, vllm_config: VllmConfig, prefix: str = ""):
@@ -1074,38 +1096,9 @@ class AscendDeepseekV4ForCausalLM(nn.Module, SupportsPP, DeepseekV2MixtureOfExpe
             if spec_layer is not None:
                 continue  # skip spec decode layers for main model
 
-            # TODO:
-            if not name.startswith("model"):
-                name = f"model.{name}"
-
-            if ".w1." in name:
-                name = name.replace(".w1.", ".gate_proj.")
-            if ".w2." in name:
-                name = name.replace(".w2.", ".down_proj.")
-            if ".w3." in name:
-                name = name.replace(".w3.", ".up_proj.")
-
-            if "model.head." in name and "model.lm_head." not in name:
-                name = name.replace("model.head.", "lm_head.")
-            if "model.lm_head." in name:
-                name = name.replace("model.lm_head.", "lm_head.")
-            if "embed." in name and "embed_token." not in name:
-                name = name.replace("embed.", "embed_tokens.")
-            if "attn" in name and "self_attn" not in name:
-                name = name.replace(".attn.", ".self_attn.")
-            if ".ffn." in name:
-                name = name.replace(".ffn.", ".mlp.")
-            if ".ffn_norm." in name:
-                name = name.replace(".ffn_norm.", ".post_attention_layernorm.")
-            if ".attn_norm." in name:
-                name = name.replace(".attn_norm.", ".input_layernorm.")
-            if name.endswith(".scale"):
-                name = name.replace(".scale", ".weight_scale")
-
-            if "rotary_emb.inv_freq" in name:
+            mapped = self.hf_to_vllm_mapper._map_name(name)
+            if mapped is None:
                 continue
-            if ".gate.bias" in name:
-                name = name.replace(".gate.bias", ".gate.e_score_correction_bias")
 
             if "sink" in name:
                 if is_pp_missing_parameter(name, self):


### PR DESCRIPTION
### What this PR does / why we need it?
This pull request refactors the weight loading logic in `AscendDeepseekV4ForCausalLM` to use the `WeightsMapper` utility instead of manual string replacements.

Normally model classes contain `hf_to_vllm_mapper` instance that renames modules on load to match vllm naming conventions. Current main `AscendDeepseekV4ForCausalLM` have `hf_to_vllm_mapper=None` and instead hard-codes this in load_weights function.

As a result, when a valid LoRa adapter in hf format is loaded, it falls with an error because renames do not apply and module names mismatch between adapter and the base model.

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
LoRa adapter in huggingface format that were falling with error now loads correctly

- vLLM main: https://github.com/vllm-project/vllm/commit/ba07e4a48fc951300d97eb506217dd530583dea3
