### PR TITLE
[v0.26.0rc][BugFix] Release unused unquantized weights for fused MC2

### DIFF
--- a/tests/ut/ops/test_fused_moe.py
+++ b/tests/ut/ops/test_fused_moe.py
@@ -193,7 +193,11 @@ def test_unquantized_apply_builds_current_fused_experts_input(monkeypatch, moe_c
     monkeypatch.setattr(
         fused_moe_module,
         "_EXTRA_CTX",
-        SimpleNamespace(moe_comm_type=moe_comm_type, moe_comm_method=moe_comm_method),
+        SimpleNamespace(
+            moe_comm_type=moe_comm_type,
+            moe_comm_method=moe_comm_method,
+            use_megamoe=False,
+        ),
     )
     monkeypatch.setattr(fused_moe_module, "get_moe_num_logical_experts", lambda *args, **kwargs: 4)
     monkeypatch.setattr(fused_moe_module, "get_forward_context", lambda: SimpleNamespace(input_ids=None))

--- a/vllm_ascend/ops/fused_moe/fused_moe.py
+++ b/vllm_ascend/ops/fused_moe/fused_moe.py
@@ -146,19 +146,15 @@ class AscendUnquantizedFusedMoEMethod(UnquantizedFusedMoEMethod):
         # in their native format without explicit casting here.
         enable_fused_mc2 = get_ascend_config().enable_fused_mc2
         if enable_fused_mc2:
-            if _CANN_OPS_TRANSFORMER_AVAILABLE:
-                # MegaMoe bg16 Need to use ND format to support
-                layer.w13_weight_list = [weight.clone() for weight in layer.w13_weight.data.unbind(dim=0)]
-                layer.w2_weight_list = [weight.clone() for weight in layer.w2_weight.data.unbind(dim=0)]
-            else:
+            if not _CANN_OPS_TRANSFORMER_AVAILABLE:
                 layer.w13_weight.data = torch_npu.npu_format_cast(layer.w13_weight.data, ACL_FORMAT_FRACTAL_NZ)
                 layer.w2_weight.data = torch_npu.npu_format_cast(layer.w2_weight.data, ACL_FORMAT_FRACTAL_NZ)
-                if enable_fused_mc2 == 1 and self.dynamic_eplb:
-                    layer.w13_weight_list = [weight.clone() for weight in layer.w13_weight.data.unbind(dim=0)]
-                    layer.w2_weight_list = [weight.clone() for weight in layer.w2_weight.data.unbind(dim=0)]
-                    del layer.w13_weight
-                    del layer.w2_weight
-                    torch.npu.empty_cache()
+            if _CANN_OPS_TRANSFORMER_AVAILABLE or self.dynamic_eplb:
+                layer.w13_weight_list = [weight.clone() for weight in layer.w13_weight.data.unbind(dim=0)]
+                layer.w2_weight_list = [weight.clone() for weight in layer.w2_weight.data.unbind(dim=0)]
+                del layer.w13_weight
+                del layer.w2_weight
+                torch.npu.empty_cache()
         else:
             layer.w13_weight.data = maybe_trans_nz(layer.w13_weight.data)
             layer.w2_weight.data = maybe_trans_nz(layer.w2_weight.data)

--- a/vllm_ascend/ops/fused_moe/fused_moe.py
+++ b/vllm_ascend/ops/fused_moe/fused_moe.py
@@ -35,8 +35,8 @@ from vllm.model_executor.layers.fused_moe.layer import (
 )
 from vllm.model_executor.layers.fused_moe.unquantized_fused_moe_method import UnquantizedFusedMoEMethod
 
-from vllm_ascend.ascend_config import _CANN_OPS_TRANSFORMER_AVAILABLE, get_ascend_config
-from vllm_ascend.ascend_forward_context import _EXTRA_CTX, MoECommType
+from vllm_ascend.ascend_config import get_ascend_config
+from vllm_ascend.ascend_forward_context import _EXTRA_CTX, MoECommType, use_cann_megamoe
 from vllm_ascend.distributed.parallel_state import get_mc2_group
 from vllm_ascend.eplb.adaptor.vllm_adaptor import VllmEplbAdaptor
 from vllm_ascend.eplb.core.eplb_utils import init_eplb_config
@@ -146,10 +146,11 @@ class AscendUnquantizedFusedMoEMethod(UnquantizedFusedMoEMethod):
         # in their native format without explicit casting here.
         enable_fused_mc2 = get_ascend_config().enable_fused_mc2
         if enable_fused_mc2:
-            if not _CANN_OPS_TRANSFORMER_AVAILABLE:
+            use_megamoe = use_cann_megamoe(get_current_vllm_config())
+            if not use_megamoe:
                 layer.w13_weight.data = torch_npu.npu_format_cast(layer.w13_weight.data, ACL_FORMAT_FRACTAL_NZ)
                 layer.w2_weight.data = torch_npu.npu_format_cast(layer.w2_weight.data, ACL_FORMAT_FRACTAL_NZ)
-            if _CANN_OPS_TRANSFORMER_AVAILABLE or self.dynamic_eplb:
+            if use_megamoe or self.dynamic_eplb:
                 layer.w13_weight_list = [weight.clone() for weight in layer.w13_weight.data.unbind(dim=0)]
                 layer.w2_weight_list = [weight.clone() for weight in layer.w2_weight.data.unbind(dim=0)]
                 del layer.w13_weight
@@ -256,7 +257,7 @@ class AscendUnquantizedFusedMoEMethod(UnquantizedFusedMoEMethod):
         w2_weight_list = getattr(layer, "w2_weight_list", None)
         has_split_weight_lists = isinstance(w13_weight_list, list) and isinstance(w2_weight_list, list)
         if _EXTRA_CTX.moe_comm_type == MoECommType.FUSED_MC2:
-            if _CANN_OPS_TRANSFORMER_AVAILABLE:
+            if _EXTRA_CTX.use_megamoe:
                 w1 = w13_weight_list if isinstance(w13_weight_list, list) else [layer.w13_weight]
                 w2 = w2_weight_list if isinstance(w2_weight_list, list) else [layer.w2_weight]
                 w1_scale = None


### PR DESCRIPTION
### What this PR does / why we need it?

Backport of #15216 to `releases/v0.26.0rc`.

When fused MC2 uses CANN MegaMoe, unquantized expert weights are cloned into per-expert `w13_weight_list` and `w2_weight_list` tensors. The original fused `w13_weight` and `w2_weight` parameters remain registered even though the forward and dynamic EPLB paths consume the cloned lists, which keeps a redundant full copy of the local expert weights on the NPU.

This change:

- creates split expert-weight lists for CANN MegaMoe or dynamic EPLB through one shared path;
- removes the original fused parameters after independent clones are ready;
- releases cached NPU allocator blocks after removing unused parameters.

The execution tensors are unchanged: fused MC2 and dynamic EPLB continue to receive the same cloned per-expert weights.

For a BF16 example with 43 MoE layers, 4 local experts per rank, hidden size 4096, and expert intermediate size 2048, the calculated persistent saving per rank is:

`43 × 4 × 3 × 4096 × 2048 × 2 bytes = 8.0625 GiB`

This is a calculated weight-memory saving. No end-to-end throughput improvement is claimed.

### Does this PR introduce _any_ user-facing change?

No API or inference-output behavior changes. It reduces NPU memory usage for unquantized fused-MC2 deployments that materialize per-expert weight lists.

### How was this patch tested?

- `git diff --check github/releases/v0.26.0rc...HEAD`
- `python3 -m py_compile vllm_ascend/ops/fused_moe/fused_moe.py`
- Reviewed the fused-MC2 and dynamic-EPLB consumers to confirm they use `w13_weight_list` and `w2_weight_list` after split-list creation.

The focused pytest file was not run on the development control host because `pytest` is not installed there (`No module named pytest`).

- vLLM main: https://github.com/vllm-project/vllm/commit/d02df748bf9efd99022f1a062597dc3cb3808485
