### PR TITLE
[Feature][Quantization] Support compressed-tensors MXFP4 for GLM-5.2 and DeepSeek-V4

### DIFF
--- a/examples/quantization/llm-compressor/mixed_mxfp4_mxfp8_dynamic_moe.py
+++ b/examples/quantization/llm-compressor/mixed_mxfp4_mxfp8_dynamic_moe.py
@@ -11,62 +11,68 @@ from transformers.models.deepseek_v4.modeling_deepseek_v4 import (
     DeepseekV4PreTrainedModel,
 )
 
-# DeepSeek-V4 expects these modules to remain in the model dtype during
-# loading instead of being forced to FP32.
-DeepseekV4PreTrainedModel._keep_in_fp32_modules_strict = set()
 
-MODEL_ID = "RedHatAI/DeepSeek-V4-Flash-BF16"
+def main():
+    model_id = "RedHatAI/DeepSeek-V4-Flash-BF16"
 
-# Load the model with llm-compressor offloading support.
-with load_context():
-    model = AutoModelForCausalLM.from_pretrained(
-        MODEL_ID,
-        device_map="auto_offload",
+    # DeepSeek-V4 expects these modules to remain in the model dtype during
+    # loading instead of being forced to FP32.
+    DeepseekV4PreTrainedModel._keep_in_fp32_modules_strict = set()
+
+    # Load the model with llm-compressor offloading support.
+    with load_context():
+        model = AutoModelForCausalLM.from_pretrained(
+            model_id,
+            device_map="auto_offload",
+        )
+
+    tokenizer = AutoTokenizer.from_pretrained(model_id)
+
+    # Mixed MXFP quantization:
+    #
+    #   Attention       -> MXFP8 weights + dynamic MXFP8 activations
+    #   Shared experts  -> MXFP8 weights + dynamic MXFP8 activations
+    #   Routed experts  -> MXFP4 weights + dynamic MXFP4 activations
+    #
+    # Shared experts intentionally remain in MXFP8. Only routed experts
+    # are quantized to MXFP4.
+    recipe = QuantizationModifier(
+        config_groups={
+            "attention_shared_experts": QuantizationScheme(
+                targets=[
+                    r"re:.*attn\.(q_a_proj|q_b_proj|kv_proj|o_a_proj|o_b_proj)$",
+                    r"re:.*attn\.compressor\.indexer\.q_b_proj$",
+                    r"re:.*mlp\.shared_experts\.(gate|up|down)_proj$",
+                ],
+                **MXFP8,
+            ),
+            "routed_experts": QuantizationScheme(
+                targets=[
+                    r"re:.*mlp\.experts\..*(gate|up|down)_proj$",
+                ],
+                **MXFP4,
+            ),
+        },
+        ignore=[],
     )
 
-tokenizer = AutoTokenizer.from_pretrained(MODEL_ID)
+    # MXFP4/MXFP8 quantization is data-free, so no calibration dataset is
+    # required.
+    oneshot(
+        model=model,
+        recipe=recipe,
+        pipeline="datafree",
+    )
 
-# Mixed MXFP quantization:
-#
-#   Attention       -> MXFP8 weights + dynamic MXFP8 activations
-#   Shared experts  -> MXFP8 weights + dynamic MXFP8 activations
-#   Routed experts  -> MXFP4 weights + dynamic MXFP4 activations
-#
-# Shared experts intentionally remain in MXFP8. Only routed experts
-# are quantized to MXFP4.
-recipe = QuantizationModifier(
-    config_groups={
-        "attention_shared_experts": QuantizationScheme(
-            targets=[
-                r"re:.*attn\.(q_a_proj|q_b_proj|kv_proj|o_a_proj|o_b_proj)$",
-                r"re:.*attn\.compressor\.indexer\.q_b_proj$",
-                r"re:.*mlp\.shared_experts\.(gate|up|down)_proj$",
-            ],
-            **MXFP8,
-        ),
-        "routed_experts": QuantizationScheme(
-            targets=[
-                r"re:.*mlp\.experts\..*(gate|up|down)_proj$",
-            ],
-            **MXFP4,
-        ),
-    },
-    ignore=[],
-)
+    # Save the model in compressed-tensors format.
+    save_dir = model_id.rstrip("/").split("/")[-1] + "-Mixed-MXFP4-MXFP8"
+    model.save_pretrained(
+        save_dir,
+        save_compressed=True,
+        max_shard_size="5GB",
+    )
+    tokenizer.save_pretrained(save_dir)
 
-# MXFP4/MXFP8 quantization is data-free, so no calibration dataset is
-# required.
-oneshot(
-    model=model,
-    recipe=recipe,
-    pipeline="datafree",
-)
 
-# Save the model in compressed-tensors format.
-SAVE_DIR = MODEL_ID.rstrip("/").split("/")[-1] + "-Mixed-MXFP4-MXFP8"
-model.save_pretrained(
-    SAVE_DIR,
-    save_compressed=True,
-    max_shard_size="5GB",
-)
-tokenizer.save_pretrained(SAVE_DIR)
+if __name__ == "__main__":
+    main()

--- a/examples/quantization/llm-compressor/mixed_mxfp4_mxfp8_dynamic_moe.py
+++ b/examples/quantization/llm-compressor/mixed_mxfp4_mxfp8_dynamic_moe.py
@@ -1,0 +1,72 @@
+from compressed_tensors.quantization.quant_scheme import (
+    MXFP4,
+    MXFP8,
+    QuantizationScheme,
+)
+from llmcompressor import oneshot
+from llmcompressor.modifiers.quantization import QuantizationModifier
+from llmcompressor.utils import load_context
+from transformers import AutoModelForCausalLM, AutoTokenizer
+from transformers.models.deepseek_v4.modeling_deepseek_v4 import (
+    DeepseekV4PreTrainedModel,
+)
+
+# DeepSeek-V4 expects these modules to remain in the model dtype during
+# loading instead of being forced to FP32.
+DeepseekV4PreTrainedModel._keep_in_fp32_modules_strict = set()
+
+MODEL_ID = "RedHatAI/DeepSeek-V4-Flash-BF16"
+
+# Load the model with llm-compressor offloading support.
+with load_context():
+    model = AutoModelForCausalLM.from_pretrained(
+        MODEL_ID,
+        device_map="auto_offload",
+    )
+
+tokenizer = AutoTokenizer.from_pretrained(MODEL_ID)
+
+# Mixed MXFP quantization:
+#
+#   Attention       -> MXFP8 weights + dynamic MXFP8 activations
+#   Shared experts  -> MXFP8 weights + dynamic MXFP8 activations
+#   Routed experts  -> MXFP4 weights + dynamic MXFP4 activations
+#
+# Shared experts intentionally remain in MXFP8. Only routed experts
+# are quantized to MXFP4.
+recipe = QuantizationModifier(
+    config_groups={
+        "attention_shared_experts": QuantizationScheme(
+            targets=[
+                r"re:.*attn\.(q_a_proj|q_b_proj|kv_proj|o_a_proj|o_b_proj)$",
+                r"re:.*attn\.compressor\.indexer\.q_b_proj$",
+                r"re:.*mlp\.shared_experts\.(gate|up|down)_proj$",
+            ],
+            **MXFP8,
+        ),
+        "routed_experts": QuantizationScheme(
+            targets=[
+                r"re:.*mlp\.experts\..*(gate|up|down)_proj$",
+            ],
+            **MXFP4,
+        ),
+    },
+    ignore=[],
+)
+
+# MXFP4/MXFP8 quantization is data-free, so no calibration dataset is
+# required.
+oneshot(
+    model=model,
+    recipe=recipe,
+    pipeline="datafree",
+)
+
+# Save the model in compressed-tensors format.
+SAVE_DIR = MODEL_ID.rstrip("/").split("/")[-1] + "-Mixed-MXFP4-MXFP8"
+model.save_pretrained(
+    SAVE_DIR,
+    save_compressed=True,
+    max_shard_size="5GB",
+)
+tokenizer.save_pretrained(SAVE_DIR)

--- a/tests/ut/quantization/methods/test_w4a4_mxfp4.py
+++ b/tests/ut/quantization/methods/test_w4a4_mxfp4.py
@@ -8,7 +8,9 @@ from tests.ut.quantization.conftest_quantization import create_mock_ascend_confi
 from vllm_ascend.quantization.methods.w4a4.w4a4_mxfp4 import (
     AscendW4A4MXFP4DynamicFusedMoEMethod,
     AscendW4A4MXFP4DynamicLinearMethod,
+    _rename_packed_weight_parameter,
 )
+from vllm_ascend.utils import COMPRESSED_TENSORS_METHOD
 
 
 class TestAscendW4A4MXFP4LinearMethod(TestBase):
@@ -17,11 +19,28 @@ class TestAscendW4A4MXFP4LinearMethod(TestBase):
         mock_vllm.return_value = create_mock_vllm_config()
         self.scheme = AscendW4A4MXFP4DynamicLinearMethod()
 
-    def test_get_weight_various_input_sizes(self):
+    @patch("vllm_ascend.quantization.methods.w4a4.w4a4_mxfp4.get_current_vllm_config")
+    def test_get_weight_various_input_sizes(self, mock_vllm):
+        mock_vllm.return_value = create_mock_vllm_config()
         for input_size in [64, 128, 256, 512]:
             result = self.scheme.get_weight(input_size, 128, torch.bfloat16)
             self.assertEqual(result["weight"].shape, (128, input_size // 2))
             self.assertEqual(result["weight"].dtype, torch.uint8)
+
+    @patch("vllm_ascend.quantization.methods.w4a4.w4a4_mxfp4.get_current_vllm_config")
+    def test_get_weight_compressed_tensors(self, mock_vllm):
+        mock_vllm.return_value = create_mock_vllm_config()
+        mock_vllm.return_value.quant_config.get_name.return_value = COMPRESSED_TENSORS_METHOD
+        result = self.scheme.get_weight(128, 128, torch.bfloat16)
+        self.assertIn("weight_packed", result)
+        self.assertNotIn("weight", result)
+
+    def test_rename_packed_weight_parameter(self):
+        layer = nn.Module()
+        layer.weight_packed = nn.Parameter(torch.empty(2, 2), requires_grad=False)
+        _rename_packed_weight_parameter(layer, "weight")
+        self.assertTrue(hasattr(layer, "weight"))
+        self.assertFalse(hasattr(layer, "weight_packed"))
 
     def test_get_pergroup_param_based_on_group_size(self):
         group_sizes = [16, 32, 64]
@@ -67,7 +86,9 @@ class TestAscendW4A4MXFP4MoEMethod(TestBase):
         mock_ascend.return_value = create_mock_ascend_config()
         self.scheme = AscendW4A4MXFP4DynamicFusedMoEMethod()
 
-    def test_get_weight_static_method(self):
+    @patch("vllm_ascend.quantization.methods.w4a4.w4a4_mxfp4.get_current_vllm_config")
+    def test_get_weight_static_method(self, mock_vllm):
+        mock_vllm.return_value = create_mock_vllm_config()
         result = self.scheme.get_weight(self.num_experts, self.intermediate_size, self.hidden_size, torch.bfloat16)
         self.assertEqual(result["w13_weight"].dtype, torch.uint8)
         self.assertEqual(result["w2_weight"].dtype, torch.uint8)
@@ -75,6 +96,16 @@ class TestAscendW4A4MXFP4MoEMethod(TestBase):
             result["w13_weight"].shape, (self.num_experts, 2 * self.intermediate_size, self.hidden_size // 2)
         )
         self.assertEqual(result["w2_weight"].shape, (self.num_experts, self.hidden_size, self.intermediate_size // 2))
+
+    @patch("vllm_ascend.quantization.methods.w4a4.w4a4_mxfp4.get_current_vllm_config")
+    def test_get_weight_compressed_tensors(self, mock_vllm):
+        mock_vllm.return_value = create_mock_vllm_config()
+        mock_vllm.return_value.quant_config.get_name.return_value = COMPRESSED_TENSORS_METHOD
+        result = self.scheme.get_weight(self.num_experts, self.intermediate_size, self.hidden_size, torch.bfloat16)
+        self.assertIn("w13_weight_packed", result)
+        self.assertIn("w2_weight_packed", result)
+        self.assertNotIn("w13_weight", result)
+        self.assertNotIn("w2_weight", result)
 
     def test_get_dynamic_quant_param_based_on_group_size(self):
         group_sizes = [16, 32, 64]

--- a/tests/ut/quantization/test_compressed_tensors_config.py
+++ b/tests/ut/quantization/test_compressed_tensors_config.py
@@ -38,6 +38,18 @@ class TestAscendCompressedTensorsQuanType(TestBase):
         mock.symmetric = symmetric
         return mock
 
+    def _make_mx_quant(self, num_bits=4, dynamic=False):
+        from compressed_tensors.quantization import QuantizationType
+
+        mock = MagicMock()
+        mock.num_bits = num_bits
+        mock.type = QuantizationType.FLOAT
+        mock.strategy = "group"
+        mock.dynamic = dynamic
+        mock.symmetric = True
+        mock.group_size = 32
+        return mock
+
     def test_detect_w8a8_static(self):
         weight = self._make_weight_quant(num_bits=8, strategy="channel", dynamic=False, symmetric=True)
         input_q = self._make_input_quant(num_bits=8, strategy="tensor", dynamic=False, symmetric=True)
@@ -66,6 +78,34 @@ class TestAscendCompressedTensorsQuanType(TestBase):
         weight.type = QuantizationType.INT
         result = self.config._detect_quant_type(weight, None, None)
         self.assertEqual(result, "W4A16")
+
+    def test_detect_mxfp4_dynamic(self):
+        weight = self._make_mx_quant(num_bits=4, dynamic=False)
+        input_q = self._make_mx_quant(num_bits=4, dynamic=True)
+        result = self.config._detect_quant_type(weight, input_q, "mxfp4-pack-quantized")
+        self.assertEqual(result, "W4A4_MXFP4")
+
+    def test_detect_mxfp8_dynamic(self):
+        weight = self._make_mx_quant(num_bits=8, dynamic=False)
+        input_q = self._make_mx_quant(num_bits=8, dynamic=True)
+        result = self.config._detect_quant_type(weight, input_q, "mxfp8-quantized")
+        self.assertEqual(result, "W8A8_MXFP8")
+
+    def test_mixed_precision_preserves_input_activations(self):
+        from compressed_tensors.quantization.quant_scheme import MXFP4
+
+        config = {
+            "format": "mixed-precision",
+            "config_groups": {
+                "group_0": {
+                    "format": "mxfp4-pack-quantized",
+                    "targets": ["Linear"],
+                    **MXFP4,
+                }
+            },
+        }
+        scheme_map = self.config._quantization_scheme_map_from_config(config)
+        self.assertIsNotNone(scheme_map["Linear"]["input_activations"])
 
     def test_detect_unsupported_raises(self):
         weight = self._make_weight_quant(num_bits=2, strategy="channel", dynamic=False, symmetric=True)

--- a/vllm_ascend/quantization/configs/compressed_tensors_config.py
+++ b/vllm_ascend/quantization/configs/compressed_tensors_config.py
@@ -20,6 +20,7 @@
 from typing import Any, Optional, cast
 
 import torch
+from compressed_tensors.config import CompressionFormat
 from compressed_tensors.quantization import QuantizationArgs, QuantizationStrategy, QuantizationType
 from vllm.logger import logger
 from vllm.model_executor.layers.linear import LinearBase
@@ -130,11 +131,11 @@ class AscendCompressedTensorsConfig(QuantizationConfig):
                     if format is not None
                     else is_activation_quantization_format(quant_format)
                 )
+                mixed_precision_format = quant_format == CompressionFormat.mixed_precision.value
+
                 input_activations = quant_config.get("input_activations")
-                if act_quant_format and input_activations is not None:
-                    target_scheme_map[target]["input_activations"] = QuantizationArgs.model_validate(
-                        quant_config.get("input_activations")
-                    )
+                if (act_quant_format or mixed_precision_format) and input_activations is not None:
+                    target_scheme_map[target]["input_activations"] = QuantizationArgs.model_validate(input_activations)
         return target_scheme_map
 
     def get_quant_method(
@@ -342,6 +343,26 @@ class AscendCompressedTensorsConfig(QuantizationConfig):
         format = format if format is not None else self.quant_format
         act_quant_format = is_activation_quantization_format(format)
 
+        # MXFP8: static FP8 group-wise weights + dynamic FP8 group-wise activations.
+        if format == CompressionFormat.mxfp8_quantized.value and self._is_dynamic_group_mx(
+            weight_quant=weight_quant,
+            input_quant=input_quant,
+            num_bits=8,
+        ):
+            assert self.quant_description is not None
+            self.quant_description["group_size"] = weight_quant.group_size or 32
+            return "W8A8_MXFP8"
+
+        # MXFP4: static packed FP4 group-wise weights + dynamic FP4 group-wise activations.
+        if format == CompressionFormat.mxfp4_pack_quantized.value and self._is_dynamic_group_mx(
+            weight_quant=weight_quant,
+            input_quant=input_quant,
+            num_bits=4,
+        ):
+            assert self.quant_description is not None
+            self.quant_description["group_size"] = weight_quant.group_size or 32
+            return "W4A4_MXFP4"
+
         if act_quant_format and input_quant is not None:
             if self._is_static_tensor_w8a8(weight_quant, input_quant):
                 return "W8A8"
@@ -359,6 +380,25 @@ class AscendCompressedTensorsConfig(QuantizationConfig):
             return "W4A16"
 
         raise NotImplementedError("No compressed-tensors compatible quantization type was found.")
+
+    def _is_dynamic_group_mx(
+        self, weight_quant: "QuantizationArgs", input_quant: Optional["QuantizationArgs"], num_bits: int
+    ) -> bool:
+        """Detect MXFP group-wise weight and dynamic activation quantization."""
+        if input_quant is None:
+            return False
+
+        is_float = weight_quant.type == input_quant.type == QuantizationType.FLOAT
+        is_expected_bits = weight_quant.num_bits == input_quant.num_bits == num_bits
+        is_group = (
+            weight_quant.strategy == QuantizationStrategy.GROUP.value
+            and input_quant.strategy == QuantizationStrategy.GROUP.value
+        )
+        is_dynamic = not weight_quant.dynamic and input_quant.dynamic
+        is_symmetric = weight_quant.symmetric and input_quant.symmetric
+        is_group_size_32 = weight_quant.group_size == input_quant.group_size == 32
+
+        return is_float and is_expected_bits and is_group and is_dynamic and is_symmetric and is_group_size_32
 
     def _is_static_tensor_w8a8(self, weight_quant: "QuantizationArgs", input_quant: "QuantizationArgs") -> bool:
         is_8_bits = weight_quant.num_bits == input_quant.num_bits == 8

--- a/vllm_ascend/quantization/methods/w4a4/w4a4_mxfp4.py
+++ b/vllm_ascend/quantization/methods/w4a4/w4a4_mxfp4.py
@@ -29,7 +29,7 @@ from vllm_ascend.ops.fused_moe.dataclass.fused_experts import build_fused_expert
 from vllm_ascend.ops.fused_moe.dataclass.moe_mlp import MoEMlpComputeInput
 from vllm_ascend.ops.fused_moe.moe_utils import cumsum_group_list, maybe_normalize_mxfp_scale_layout
 from vllm_ascend.ops.fused_moe.routed_experts import AscendRoutedExperts  # noqa: F401
-from vllm_ascend.utils import dispose_tensor
+from vllm_ascend.utils import COMPRESSED_TENSORS_METHOD, dispose_tensor
 
 from ..base import (
     AscendLinearScheme,
@@ -38,6 +38,35 @@ from ..base import (
     TPWeightGatherSpec,
 )
 from ..registry import register_scheme
+
+
+# Select checkpoint parameter names for packed compressed-tensors weights.
+def _use_packed_mxfp4_weight_names() -> bool:
+    quant_config = get_current_vllm_config().quant_config
+    if quant_config is None:
+        return False
+
+    get_name = getattr(quant_config, "get_name", None)
+    return callable(get_name) and get_name() == COMPRESSED_TENSORS_METHOD
+
+
+def _rename_packed_weight_parameter(
+    layer: torch.nn.Module,
+    weight_name: str,
+) -> None:
+    packed_weight_name = f"{weight_name}_packed"
+    if not hasattr(layer, packed_weight_name):
+        return
+
+    setattr(
+        layer,
+        weight_name,
+        torch.nn.Parameter(
+            getattr(layer, packed_weight_name).data,
+            requires_grad=False,
+        ),
+    )
+    delattr(layer, packed_weight_name)
 
 
 @register_scheme("W4A4_MXFP4", "linear")
@@ -65,7 +94,8 @@ class AscendW4A4MXFP4DynamicLinearMethod(AscendLinearScheme):
         self.group_size = vllm_config.quant_config.quant_description.get("group_size", 32)
 
     def get_weight(self, input_size: int, output_size: int, params_dtype: torch.dtype) -> dict[str, Any]:
-        params_dict = {"weight": torch.empty(output_size, input_size // 2, dtype=torch.uint8)}
+        weight_name = "weight_packed" if _use_packed_mxfp4_weight_names() else "weight"
+        params_dict = {weight_name: torch.empty(output_size, input_size // 2, dtype=torch.uint8)}
         return params_dict
 
     def get_pergroup_param(
@@ -121,6 +151,8 @@ class AscendW4A4MXFP4DynamicLinearMethod(AscendLinearScheme):
         - weight_scale: (n_dim, k_dim) -> (k_dim//2, n_dim, 2)
         """
 
+        _rename_packed_weight_parameter(layer, "weight")
+
         n_dim, k_dim = layer.weight_scale.data.shape
         # Shape should be padded if it cannot be divided by 2
         if k_dim % 2 != 0:
@@ -153,10 +185,11 @@ class AscendW4A4MXFP4DynamicFusedMoEMethod(AscendMoEScheme):
         num_experts: int, intermediate_size_per_partition: int, hidden_sizes: int, params_dtype: torch.dtype
     ) -> dict[str, Any]:
         param_dict = {}
-        param_dict["w13_weight"] = torch.empty(
+        suffix = "_packed" if _use_packed_mxfp4_weight_names() else ""
+        param_dict[f"w13_weight{suffix}"] = torch.empty(
             num_experts, 2 * intermediate_size_per_partition, hidden_sizes // 2, dtype=torch.uint8
         )
-        param_dict["w2_weight"] = torch.empty(
+        param_dict[f"w2_weight{suffix}"] = torch.empty(
             num_experts, hidden_sizes, intermediate_size_per_partition // 2, dtype=torch.uint8
         )
         return param_dict
@@ -220,6 +253,9 @@ class AscendW4A4MXFP4DynamicFusedMoEMethod(AscendMoEScheme):
         ]
 
     def process_weights_after_loading(self, layer):
+        _rename_packed_weight_parameter(layer, "w13_weight")
+        _rename_packed_weight_parameter(layer, "w2_weight")
+
         g_num, n_size, k_size = layer.w13_weight_scale.shape
         layer.w13_weight_scale.data = layer.w13_weight_scale.data.reshape(g_num, n_size, k_size // 2, 2)
         g_num, n_size, k_size = layer.w2_weight_scale.shape

--- a/vllm_ascend/quantization/methods/w4a4/w4a4_mxfp4.py
+++ b/vllm_ascend/quantization/methods/w4a4/w4a4_mxfp4.py
@@ -41,7 +41,7 @@ from ..registry import register_scheme
 
 
 # Select checkpoint parameter names for packed compressed-tensors weights.
-def _use_packed_mxfp4_weight_names() -> bool:
+def _use_compressed_tensors_mxfp4_weight_names() -> bool:
     quant_config = get_current_vllm_config().quant_config
     if quant_config is None:
         return False
@@ -50,10 +50,7 @@ def _use_packed_mxfp4_weight_names() -> bool:
     return callable(get_name) and get_name() == COMPRESSED_TENSORS_METHOD
 
 
-def _rename_packed_weight_parameter(
-    layer: torch.nn.Module,
-    weight_name: str,
-) -> None:
+def _rename_packed_weight_parameter(layer: torch.nn.Module, weight_name: str) -> None:
     packed_weight_name = f"{weight_name}_packed"
     if not hasattr(layer, packed_weight_name):
         return
@@ -94,7 +91,7 @@ class AscendW4A4MXFP4DynamicLinearMethod(AscendLinearScheme):
         self.group_size = vllm_config.quant_config.quant_description.get("group_size", 32)
 
     def get_weight(self, input_size: int, output_size: int, params_dtype: torch.dtype) -> dict[str, Any]:
-        weight_name = "weight_packed" if _use_packed_mxfp4_weight_names() else "weight"
+        weight_name = "weight_packed" if _use_compressed_tensors_mxfp4_weight_names() else "weight"
         params_dict = {weight_name: torch.empty(output_size, input_size // 2, dtype=torch.uint8)}
         return params_dict
 
@@ -185,7 +182,7 @@ class AscendW4A4MXFP4DynamicFusedMoEMethod(AscendMoEScheme):
         num_experts: int, intermediate_size_per_partition: int, hidden_sizes: int, params_dtype: torch.dtype
     ) -> dict[str, Any]:
         param_dict = {}
-        suffix = "_packed" if _use_packed_mxfp4_weight_names() else ""
+        suffix = "_packed" if _use_compressed_tensors_mxfp4_weight_names() else ""
         param_dict[f"w13_weight{suffix}"] = torch.empty(
             num_experts, 2 * intermediate_size_per_partition, hidden_sizes // 2, dtype=torch.uint8
         )


### PR DESCRIPTION
### What this PR does / why we need it?

This PR adds compressed-tensors mixed MXFP4/MXFP8 support for vLLM Ascend, including the configuration parsing and packed MXFP4 checkpoint loading required by models such as GLM-5.2 and DeepSeek-V4.

It includes three parts:

1. Support mixed-precision compressed-tensors configurations, preserve per-group activation quantization arguments, and detect MXFP8/MXFP4 quantization schemes from per-group formats.
2. Support packed MXFP4 checkpoint weight names for compressed-tensors while preserving the existing non-compressed-tensors loading path.
3. Add an LLM-Compressor mixed MXFP4/MXFP8 MoE quantization example, with attention and shared experts using MXFP8 and routed experts using MXFP4.

For compressed-tensors checkpoints, packed weights are loaded using `weight_packed`, `w13_weight_packed`, and `w2_weight_packed`, then restored to the existing runtime weight names during `process_weights_after_loading()`.

This keeps the checkpoint-format adaptation in the quantization layer without introducing model-specific branches or changing the existing runtime weight layout.

### Does this PR introduce any user-facing change?

Yes. This enables compressed-tensors mixed MXFP4/MXFP8 configurations to be recognized and MXFP4 packed checkpoint weights to be loaded by vLLM Ascend.

No new environment variable, CLI option, or user configuration item is introduced.

### How was this patch tested?

* Added unit tests for mixed-precision compressed-tensors configuration parsing and MXFP4/MXFP8 quantization type detection.
* Added unit tests for compressed-tensors packed MXFP4 Linear/MoE weight names and packed-parameter renaming.
* Verified the existing non-compressed-tensors MXFP4 weight path remains covered by the existing tests.
* The MXFP4 loading path has been validated with GLM-5.2 and DeepSeek-V4 compressed-tensors checkpoints.
* Verified the modified unit tests with Ruff and `git diff --check`; the targeted unit tests pass.

- vLLM main: https://github.com/vllm-project/vllm/commit/ba07e4a48fc951300d97eb506217dd530583dea3
