### PR TITLE
[Performance][Attention] Avoid draft metadata device copies

### DIFF
--- a/tests/ut/attention/a2/test_attention_v1.py
+++ b/tests/ut/attention/a2/test_attention_v1.py
@@ -150,6 +150,43 @@ class TestAscendAttentionMetadataBuilder(TestBase):
         torch.Tensor.pin_memory = lambda x: x  # noqa
         self.builder = AscendAttentionMetadataBuilder(None, None, self.mock_vllm_config, self.mock_device)
 
+    def _build_common_metadata(
+        self,
+        *,
+        query_start_loc: torch.Tensor | None,
+        query_start_loc_cpu: torch.Tensor,
+        seq_lens: torch.Tensor,
+        internal_seq_lens_cpu: torch.Tensor | None,
+        public_seq_lens_cpu: torch.Tensor | None,
+    ) -> AscendCommonAttentionMetadata:
+        num_reqs = query_start_loc_cpu.numel() - 1
+        return AscendCommonAttentionMetadata(
+            query_start_loc=query_start_loc,
+            query_start_loc_cpu=query_start_loc_cpu,
+            seq_lens=seq_lens,
+            _seq_lens_cpu=internal_seq_lens_cpu,
+            seq_lens_cpu=public_seq_lens_cpu,
+            num_computed_tokens_cpu=None,
+            num_reqs=num_reqs,
+            num_actual_tokens=int(query_start_loc_cpu[-1]),
+            max_query_len=1,
+            block_table_tensor=torch.zeros((num_reqs, 1), dtype=torch.int32),
+            slot_mapping=torch.arange(int(query_start_loc_cpu[-1]), dtype=torch.int32),
+            causal=True,
+            actual_seq_lengths_q=query_start_loc_cpu[1:].tolist(),
+            positions=torch.arange(int(query_start_loc_cpu[-1])),
+            attn_state=AscendAttentionState.DecodeOnly,
+            max_seq_len=int(seq_lens.max()),
+        )
+
+    def _build_and_capture(self, common_attn_metadata: AscendCommonAttentionMetadata):
+        with patch.object(
+            AscendAttentionMetadataBuilder,
+            "metadata_cls",
+            side_effect=lambda **kwargs: SimpleNamespace(**kwargs),
+        ):
+            return self.builder.build(0, common_attn_metadata)
+
     def test_reorder_batch(self):
         mock_input_batch = MagicMock()
         mock_scheduler_output = MagicMock()
@@ -183,6 +220,147 @@ class TestAscendAttentionMetadataBuilder(TestBase):
 
         self.assertTrue(torch.equal(unpadded_metadata._seq_lens_cpu, internal_seq_lens_cpu[:2]))
         self.assertIsNone(unpadded_metadata.seq_lens_cpu)
+
+    def test_parallel_drafting_reuses_device_metadata_and_internal_cpu_mirror(self):
+        query_start_loc = torch.tensor([0, 1, 2, 3], dtype=torch.int32)
+        query_start_loc_cpu = query_start_loc.clone()
+        seq_lens = torch.tensor([17, 18, 19], dtype=torch.int32)
+        seq_lens_cpu = seq_lens.clone()
+        common_attn_metadata = self._build_common_metadata(
+            query_start_loc=query_start_loc,
+            query_start_loc_cpu=query_start_loc_cpu,
+            seq_lens=seq_lens,
+            internal_seq_lens_cpu=seq_lens_cpu,
+            public_seq_lens_cpu=None,
+        )
+        self.builder.speculative_config = SimpleNamespace(parallel_drafting=True)
+        to_sources: list[torch.Tensor] = []
+        tolist_sources: list[torch.Tensor] = []
+        original_to = torch.Tensor.to
+        original_tolist = torch.Tensor.tolist
+
+        def tracked_to(tensor, *args, **kwargs):
+            to_sources.append(tensor)
+            return original_to(tensor, *args, **kwargs)
+
+        def tracked_tolist(tensor, *args, **kwargs):
+            tolist_sources.append(tensor)
+            return original_tolist(tensor, *args, **kwargs)
+
+        with (
+            patch.object(torch.Tensor, "to", new=tracked_to),
+            patch.object(torch.Tensor, "tolist", new=tracked_tolist),
+        ):
+            metadata = self._build_and_capture(common_attn_metadata)
+
+        self.assertEqual(metadata.query_start_loc.data_ptr(), query_start_loc.data_ptr())
+        self.assertIs(metadata.seq_lens, seq_lens)
+        self.assertEqual(metadata.seq_lens_cpu.data_ptr(), seq_lens_cpu.data_ptr())
+        self.assertEqual(metadata.seq_lens_list, [17, 18, 19])
+        self.assertFalse(any(source is query_start_loc_cpu for source in to_sources))
+        self.assertFalse(any(source.data_ptr() == seq_lens.data_ptr() for source in tolist_sources))
+        self.assertTrue(any(source.data_ptr() == seq_lens_cpu.data_ptr() for source in tolist_sources))
+
+    def test_parallel_drafting_uses_public_cpu_mirror(self):
+        query_start_loc = torch.tensor([0, 1, 2], dtype=torch.int32)
+        seq_lens = torch.tensor([21, 22], dtype=torch.int32)
+        public_seq_lens_cpu = seq_lens.clone()
+        common_attn_metadata = self._build_common_metadata(
+            query_start_loc=query_start_loc,
+            query_start_loc_cpu=query_start_loc.clone(),
+            seq_lens=seq_lens,
+            internal_seq_lens_cpu=None,
+            public_seq_lens_cpu=public_seq_lens_cpu,
+        )
+        self.builder.speculative_config = SimpleNamespace(parallel_drafting=True)
+
+        metadata = self._build_and_capture(common_attn_metadata)
+
+        self.assertIs(metadata.seq_lens, seq_lens)
+        self.assertEqual(metadata.seq_lens_cpu.data_ptr(), public_seq_lens_cpu.data_ptr())
+        self.assertEqual(metadata.seq_lens_list, [21, 22])
+
+    def test_cross_attention_keeps_device_seq_lens_and_cpu_list(self):
+        class DummyCrossAttentionSpec:
+            pass
+
+        query_start_loc = torch.tensor([0, 1, 2], dtype=torch.int32)
+        seq_lens = torch.tensor([23, 24], dtype=torch.int32)
+        seq_lens_cpu = seq_lens.clone()
+        common_attn_metadata = self._build_common_metadata(
+            query_start_loc=query_start_loc,
+            query_start_loc_cpu=query_start_loc.clone(),
+            seq_lens=seq_lens,
+            internal_seq_lens_cpu=seq_lens_cpu,
+            public_seq_lens_cpu=None,
+        )
+        self.builder.kv_cache_spec = DummyCrossAttentionSpec()
+
+        with patch(
+            "vllm_ascend.attention.attention_v1.CrossAttentionSpec",
+            DummyCrossAttentionSpec,
+        ):
+            metadata = self._build_and_capture(common_attn_metadata)
+
+        self.assertIs(metadata.seq_lens, seq_lens)
+        self.assertEqual(metadata.seq_lens_cpu.data_ptr(), seq_lens_cpu.data_ptr())
+        self.assertEqual(metadata.seq_lens_list, [23, 24])
+        self.assertEqual(metadata.slot_mapping.dtype, torch.int32)
+
+    def test_regular_decode_reuses_device_query_start_loc(self):
+        query_start_loc = torch.tensor([0, 1, 2], dtype=torch.int32)
+        query_start_loc_cpu = query_start_loc.clone()
+        seq_lens_cpu = torch.tensor([9, 10], dtype=torch.int32)
+        common_attn_metadata = self._build_common_metadata(
+            query_start_loc=query_start_loc,
+            query_start_loc_cpu=query_start_loc_cpu,
+            seq_lens=seq_lens_cpu.clone(),
+            internal_seq_lens_cpu=seq_lens_cpu,
+            public_seq_lens_cpu=None,
+        )
+
+        metadata = self._build_and_capture(common_attn_metadata)
+
+        self.assertEqual(metadata.query_start_loc.data_ptr(), query_start_loc.data_ptr())
+        self.assertEqual(metadata.seq_lens.data_ptr(), seq_lens_cpu.data_ptr())
+        self.assertEqual(metadata.seq_lens_cpu.data_ptr(), seq_lens_cpu.data_ptr())
+
+    def test_missing_mirrors_keep_copy_fallbacks(self):
+        query_start_loc_cpu = torch.tensor([0, 1, 2], dtype=torch.int32)
+        seq_lens = torch.tensor([11, 12], dtype=torch.int32)
+        common_attn_metadata = self._build_common_metadata(
+            query_start_loc=None,
+            query_start_loc_cpu=query_start_loc_cpu,
+            seq_lens=seq_lens,
+            internal_seq_lens_cpu=None,
+            public_seq_lens_cpu=None,
+        )
+
+        metadata = self._build_and_capture(common_attn_metadata)
+
+        self.assertEqual(metadata.query_start_loc.tolist(), [0, 1, 2])
+        self.assertEqual(metadata.seq_lens_cpu.tolist(), [11, 12])
+        self.assertEqual(metadata.seq_lens_list, [11, 12])
+
+    def test_parallel_drafting_pads_device_and_cpu_seq_lens(self):
+        query_start_loc = torch.tensor([0, 1, 2, 3], dtype=torch.int32)
+        seq_lens = torch.tensor([31, 32], dtype=torch.int32)
+        seq_lens_cpu = seq_lens.clone()
+        common_attn_metadata = self._build_common_metadata(
+            query_start_loc=query_start_loc,
+            query_start_loc_cpu=query_start_loc.clone(),
+            seq_lens=seq_lens,
+            internal_seq_lens_cpu=seq_lens_cpu,
+            public_seq_lens_cpu=None,
+        )
+        self.builder.speculative_config = SimpleNamespace(parallel_drafting=True)
+
+        metadata = self._build_and_capture(common_attn_metadata)
+
+        self.assertEqual(metadata.seq_lens.tolist(), [31, 32, 1])
+        self.assertEqual(metadata.seq_lens_cpu.tolist(), [31, 32, 1])
+        self.assertEqual(metadata.seq_lens_list, [31, 32, 1])
+        self.assertEqual(metadata.block_tables.shape[0], 3)
 
     @patch.object(AscendAttentionMetadataBuilder, "metadata_cls")
     def test_build(self, mock_ascend_metadata):

--- a/vllm_ascend/attention/attention_v1.py
+++ b/vllm_ascend/attention/attention_v1.py
@@ -327,11 +327,14 @@ class AscendAttentionMetadataBuilder(AttentionMetadataBuilder[AscendMetadata]):
         # Prefer _seq_lens_cpu (always available, updated during draft
         # iterations) over seq_lens_cpu (None in async spec decode mode).
         if common_attn_metadata._seq_lens_cpu is not None:
-            seq_lens = common_attn_metadata._seq_lens_cpu[:num_reqs]
+            seq_lens_cpu = common_attn_metadata._seq_lens_cpu[:num_reqs]
         elif common_attn_metadata.seq_lens_cpu is not None:
-            seq_lens = common_attn_metadata.seq_lens_cpu[:num_reqs]
+            seq_lens_cpu = common_attn_metadata.seq_lens_cpu[:num_reqs]
         else:
-            seq_lens = common_attn_metadata.seq_lens[:num_reqs].to("cpu")
+            seq_lens_cpu = common_attn_metadata.seq_lens[:num_reqs].to("cpu")
+        # Some backends consume the device tensor below, while Python lists
+        # should always be derived from the maintained CPU mirror.
+        seq_lens = seq_lens_cpu
 
         slot_mapping = common_attn_metadata.slot_mapping[:num_actual_tokens]
         # this slot_mapping override doesn't work since vllm will override it again. We should fix it vllm.
@@ -347,11 +350,14 @@ class AscendAttentionMetadataBuilder(AttentionMetadataBuilder[AscendMetadata]):
         # Get attn_mask from singleton AttentionMaskBuilder
         attn_mask = self.attn_mask_builder.get_attention_mask(common_attn_metadata.causal, self.model_config)
 
-        # TODO: Yet another unnecessary H2D while we already have a query_start_loc on device
-        query_start_loc = query_start_loc_cpu.pin_memory().to(self.device, non_blocking=True)
+        if common_attn_metadata.query_start_loc is not None:
+            query_start_loc = common_attn_metadata.query_start_loc[: num_reqs + 1]
+        else:
+            # Keep compatibility with callers that only provide the CPU view.
+            query_start_loc = query_start_loc_cpu.pin_memory().to(self.device, non_blocking=True)
 
         actual_seq_lengths_q = query_start_loc_cpu[1:].tolist()
-        seq_lens_list = seq_lens.tolist()
+        seq_lens_list = seq_lens_cpu.tolist()
         # Sequence-parallel (or cudagraph) padding makes the model runner insert a
         # dummy padding request into query_start_loc to satisfy the FIA TND-layout
         # constraint (sum of q lengths == hidden_states.shape[0]), bumping the
@@ -376,7 +382,12 @@ class AscendAttentionMetadataBuilder(AttentionMetadataBuilder[AscendMetadata]):
         if len(seq_lens_list) < num_reqs_fia:
             padding_len = num_reqs_fia - len(seq_lens_list)
             seq_lens_list = seq_lens_list + [1] * padding_len
-            seq_lens = torch.cat([seq_lens, seq_lens.new_ones(padding_len)])
+            seq_lens_uses_cpu_mirror = seq_lens is seq_lens_cpu
+            seq_lens_cpu = torch.cat([seq_lens_cpu, seq_lens_cpu.new_ones(padding_len)])
+            if seq_lens_uses_cpu_mirror:
+                seq_lens = seq_lens_cpu
+            else:
+                seq_lens = torch.cat([seq_lens, seq_lens.new_ones(padding_len)])
         if block_table is not None and block_table.shape[0] < num_reqs_fia:
             block_table = torch.cat(
                 [
@@ -400,7 +411,7 @@ class AscendAttentionMetadataBuilder(AttentionMetadataBuilder[AscendMetadata]):
             block_tables=block_table,
             query_start_loc=query_start_loc,
             seq_lens=seq_lens,
-            seq_lens_cpu=seq_lens,
+            seq_lens_cpu=seq_lens_cpu,
             seq_lens_list=seq_lens_list,
             max_query_len=common_attn_metadata.max_query_len,
             actual_seq_lengths_q=actual_seq_lengths_q,


### PR DESCRIPTION
### What this PR does / why we need it?

Parallel drafting keeps `seq_lens` on device for attention, but the attention metadata builder also converted that device tensor to a Python list. This introduced a synchronous D2H copy in every draft metadata build. The builder additionally recreated `query_start_loc` on device even though the common metadata already maintains a device copy.

This patch:

- derives Python sequence-length lists from the maintained CPU mirror;
- reuses the existing device `query_start_loc`;
- preserves device `seq_lens` for parallel drafting and cross attention;
- pads both CPU and device sequence lengths for graph/FIA padding;
- retains the original copy fallbacks for callers without CPU/device mirrors.

### Does this PR introduce _any_ user-facing change?

No. This is an internal performance optimization and keeps compatibility fallbacks for legacy metadata producers.

### How was this patch tested?

- `ruff format --check vllm_ascend/attention/attention_v1.py tests/ut/attention/a2/test_attention_v1.py`
- `ruff check vllm_ascend/attention/attention_v1.py tests/ut/attention/a2/test_attention_v1.py`
- `python -m py_compile vllm_ascend/attention/attention_v1.py tests/ut/attention/a2/test_attention_v1.py`
- `pytest -q tests/ut/attention/a2/test_attention_v1.py tests/ut/spec_decode/test_dspark_proposer.py` (59 passed)
- `pytest -q tests/ut/spec_decode/test_llm_base_proposer.py` (23 passed)

Ascend NPU validation on a single-node DP1/TP8/PP1/EP8 Kimi-K3 service with DCP=1, main-model `FULL_DECODE_ONLY`, and eager DSpark speculative decoding:

- `/v1/models` returned HTTP 200 and all 8 ranks became ready;
- 3/3 deterministic precision requests returned HTTP 200 with non-empty valid content;
- rank-0 2-second Decode profiling parsed successfully offline;
- within `AscendAttentionMetadataBuilder.build`, 852 CPU `tolist` calls had a maximum duration of 8.63 us, with 0 `aten::_to_copy` and 0 `aten::copy_` events;
- the previous device `seq_lens.tolist()` path was about 2.1 ms per call.
- vLLM main: https://github.com/vllm-project/vllm/commit/ba07e4a48fc951300d97eb506217dd530583dea3
