### PR TITLE
[Doc][Misc] Add docs for matmul_bias_persistent, linear_persistent, mean and _rms_norm operators

### DIFF
--- a/vllm_ascend/ops/triton/docs/linear_persistent.md
+++ b/vllm_ascend/ops/triton/docs/linear_persistent.md
@@ -1,0 +1,48 @@
+# linear_persistent
+
+## Description
+
+- **Location**: `vllm_ascend/ops/triton/batch_invariant/matmul.py` — `linear_persistent_kernel`, 1:1 wrapper `linear_persistent`, convenience wrapper `linear_batch_invariant`
+- **Function**: Batch-invariant `x @ y^T` — the core GEMM of `F.linear`, where the weight `y` is stored as `[N, K]`. Part of the batch-invariant Triton family for NPU. In batch-invariant mode (`--additional-config '{"enable_batch_invariant": true}'` → `VLLM_BATCH_INVARIANT=1`, initialized by `vllm_ascend/worker/worker.py::init_batch_invariance`), the facade registers `linear_batch_invariant` for `aten::linear` on the NPU dispatch key — but only when the AscendC `batch_invariant_ops` package is absent, since AscendC's matmul path gives better performance (upstream vllm instead serves `aten::linear` through its generic `matmul_persistent`).
+- **Formula** (per output element, fp32 accumulator):
+    - `c[m, n] = Σ_k x[m, k] · y[n, k]` — `y` is used in its natural `[N, K]` layout; the transpose happens in-register via `tl.trans`, so no transposed copy of the weight is materialized.
+- **Algorithm flow** (true persistent 1D grid):
+  1. `grid_size = num_vectorcore // 2` fixed programs; every program strides over all output tiles: `for block_index in range(pid, NUM_BLOCKS_M * NUM_BLOCKS_N, GRID_SIZE)`.
+  2. Per output tile (`BLOCK_M × BLOCK_N`): loop `K` in `BLOCK_K` chunks; load the `a` block `[BLOCK_M, BLOCK_K]` and the `b` block `[BLOCK_N, BLOCK_K]` with boundary masks, transpose `b` in-register, accumulate `tl.dot` into an fp32 tile.
+  3. Store the tile cast to the input dtype with `(m < M) & (n < N)` masks.
+  4. Block sizes are selected host-side by shape heuristics: `BLOCK_K = 256` (halved for fp32), and `BLOCK_M`/`BLOCK_N` picked from `M`/`N` regimes (e.g. `M < 256` vs. `M ≥ 1024`, `grid_size`-proportional splits) so the tile count roughly saturates the fixed grid.
+- **Supported modes**: Atlas A2 and Atlas A3. Serves every `torch.nn.functional.linear` call in batch-invariant mode when the AscendC ops are absent; works in both eager and graph-capture modes.
+
+## Parameters
+
+> [!NOTE]
+> All parameters are required.
+
+| Parameter | Input/Output/Attribute | Description | Data type | Data format |
+| --- | --- | --- | --- | --- |
+| `x` | Input | activations `[M, K]` (the wrapper `linear_batch_invariant` flattens any leading dims to `M`) | fp16 / bf16 / fp32 | ND |
+| `y` | Input | linear weight in PyTorch layout `[N, K]` (output features × input features; **not** transposed) | fp16 / bf16 / fp32 | ND |
+| `output` | Output | `x @ y^T` `[M, N]`, same dtype as `x` | fp16 / bf16 / fp32 | ND |
+
+## Constraints
+
+- `x` and `y` must be 2D with matching `K` (`x.shape[1] == y.shape[1]`, asserted).
+- `M == 0 or N == 0` is legal (empty output; wrapper picks fixed `128/256/256` blocks).
+- Accumulation is fp32; the output dtype equals the input dtype; the output is zero-initialized by the wrapper.
+- Block sizes are compile-time `constexpr` including `NUM_BLOCKS_M/N` and `GRID_SIZE`, so each distinct heuristic configuration triggers its own Triton compilation.
+- Only for inference on NPU with batch-invariant mode enabled.
+
+## Origin and Differences
+
+- **Origin**: Developed in vllm-ascend within the batch-invariant framework (#5517); there is no direct upstream counterpart — upstream vllm's `linear_batch_invariant` computes `x @ weight.T` through the generic `matmul_persistent` GEMM. The file carries the "Adapt from `vllm/model_executor/layers/batch_invariant.py`" header.
+- **Differences**:
+    - NPU adaptation for performance: dedicated `x @ y^T` kernel with in-register `tl.trans` (avoids materializing `y^T`) and a true persistent 1D grid pinned to half the vector-core count, each program looping over multiple output tiles — program count is independent of the problem size;
+    - Modified for a specific vllm-ascend logic or different input parameters: host-side block-size heuristics keyed on `M`/`N`/`grid_size` (several shape regimes) instead of upstream's autotuner; bias is **not** fused — `linear_batch_invariant` adds it as a separate elementwise op after the GEMM.
+
+## Test Cases
+
+The test guards the 1:1 wrapper against an fp32 CPU golden across fp16/bf16/fp32 and shapes exercising the small, medium, and large-`M` heuristic regimes (`(m, k, n) = (7, 63, 129)`, `(257, 257, 131)`, `(1025, 65, 257)`), with unified tolerances (`rtol=2e-3, atol=2e-2` for fp16; `2e-2, 5e-2` for bf16; `1e-4, 1e-4` for fp32). The sibling `test_linear_batch_invariant_nd_precision` covers the convenience wrapper on 2D/3D/4D activations.
+
+```bash
+pytest -sv tests/e2e/nightly/single_node/ops/singlecard_ops/triton/test_batch_invariant_ops.py -k linear_persistent
+```

--- a/vllm_ascend/ops/triton/docs/matmul_bias_persistent.md
+++ b/vllm_ascend/ops/triton/docs/matmul_bias_persistent.md
@@ -1,0 +1,50 @@
+# matmul_bias_persistent
+
+## Description
+
+- **Location**: `vllm_ascend/ops/triton/batch_invariant/matmul.py` — `matmul_bias_persistent_kernel`, 1:1 wrapper `matmul_persistent`, convenience wrappers `mm_batch_invariant` / `bmm_batch_invariant` / `addmm_batch_invariant` / `matmul_batch_invariant`
+- **Function**: Batch-invariant GEMM `x @ y (+ bias)` with fp32 accumulation and TF32 disabled, so the result is deterministic and independent of batch composition. It is one of the four Triton kernels of the batch-invariant family adapted from vllm for NPU. In batch-invariant mode the vllm-ascend facade (`vllm_ascend/batch_invariant.py::enable_batch_invariant_mode`) registers it as an `aten` implementation on the NPU dispatch key: `aten::addmm` and `aten::bmm` whenever Triton is available, plus `aten::mm` and `aten::matmul` when the AscendC `batch_invariant_ops` package is absent (the AscendC ops take priority when present). Mode activation: `--additional-config '{"enable_batch_invariant": true}'` (sets `VLLM_BATCH_INVARIANT=1`), initialized per rank in `vllm_ascend/worker/worker.py` (`init_batch_invariance`).
+- **Formula** (per output element, computed in fp32):
+    - `out[m, n] = Σ_k x[m, k] · y[k, n] + bias[n]` (bias term only when `bias` is given)
+    - Inputs are cast to fp32 on load; `tl.dot(..., allow_tf32=False)` accumulates into an fp32 register tile; the result is stored in the input dtype.
+- **Algorithm flow** (one output tile per program):
+  1. Grid `(ceil(M / BLOCK_M), ceil(N / BLOCK_N))` with fixed `BLOCK_M=128, BLOCK_N=128, BLOCK_K=64`.
+  2. Per output tile: loop over `K` in `BLOCK_K` chunks; load the `x` row-block and `y` column-block with boundary masks (`other=0.0`), cast to fp32, accumulate `tl.dot` into `acc`.
+  3. If `has_bias`: load the `bias[n]` slice (row-broadcast) and add it to `acc`.
+  4. Store `acc` cast to the input dtype with an `(m < M) & (n < N)` mask, so arbitrary (non-aligned) `M`/`N`/`K` are handled without padding.
+- **Supported modes**: Atlas A2 and Atlas A3. Used by every model layer that goes through `torch.mm` / `torch.addmm` / `torch.bmm` / `torch.matmul` while batch-invariant mode is enabled (e.g. linear layers, attention score/value projections); works in both eager and graph-capture modes.
+
+## Parameters
+
+> [!NOTE]
+> All parameters are required.
+
+| Parameter | Input/Output/Attribute | Description | Data type | Data format |
+| --- | --- | --- | --- | --- |
+| `x` | Input | LHS matrix `[M, K]`; made contiguous by the wrapper | fp16 / bf16 / fp32 | ND |
+| `y` | Input | RHS matrix `[K, N]`; made contiguous by the wrapper | fp16 / bf16 / fp32 | ND |
+| `bias` | Input | Optional addend `[N]`; pass `None` to skip (kernel flag `has_bias=False`) | fp16 / bf16 / fp32 | ND |
+| `output` | Output | `x @ y (+ bias)` `[M, N]`, same dtype as `x` | fp16 / bf16 / fp32 | ND |
+
+## Constraints
+
+- `x` and `y` must be 2D with `x.shape[1] == y.shape[0]`; `bias` must be 1D with `bias.shape[0] == N` (asserted by the wrapper).
+- Only 2D × 2D is implemented in the kernel; batched/higher-rank cases are handled by the convenience wrappers (`bmm` loops over the batch dim, `matmul` reshapes 3D/4D combos, `addmm` falls back to `matmul + scale` unless `alpha == beta == 1` with a 1D `input`).
+- Tiling is fixed at compile time (`BLOCK_M/N/K = 128/128/64`); non-aligned shapes are masked, not padded.
+- Accumulation is always fp32 with `allow_tf32=False`; the output dtype equals the input dtype.
+- Only for inference on NPU with batch-invariant mode enabled.
+
+## Origin and Differences
+
+- **Origin**: Adapted from vllm's `model_executor/layers/batch_invariant.py` (`matmul_kernel_persistent` / `matmul_persistent`); the NPU port first landed with the batch-invariant framework in #5517.
+- **Differences**:
+    - NPU adaptation for performance: replaces upstream's persistent 1D grid with `_compute_pid` L2-grouped tile ordering and autotuned block sizes by a plain 2D block grid with fixed `128/128/64` tiles and boundary masks, sized for the NPU vector cores;
+    - Modified for a specific vllm-ascend logic or different input parameters: adds the fused optional bias (`has_bias` constexpr + broadcast add) so `aten::addmm` can be served by a single launch, and forces fp32 loads plus `allow_tf32=False` for strict batch invariance.
+
+## Test Cases
+
+The test guards the 1:1 wrapper against an fp32 CPU golden, across fp16/bf16, `bias` on/off, and shapes covering a single row, non-aligned sizes, and multi-block tiling (`(m, k, n) = (1, 64, 128)`, `(17, 65, 129)`, `(129, 257, 131)`), with unified tolerances (`rtol=2e-3, atol=2e-2` for fp16; `2e-2, 5e-2` for bf16). Wrapper-level cases for `mm`/`bmm`/`addmm`/`matmul` shape combinations and the `out=` parameter are covered by the sibling tests in the same file.
+
+```bash
+pytest -sv tests/e2e/nightly/single_node/ops/singlecard_ops/triton/test_batch_invariant_ops.py -k matmul_bias_persistent
+```

--- a/vllm_ascend/ops/triton/docs/mean.md
+++ b/vllm_ascend/ops/triton/docs/mean.md
@@ -1,0 +1,49 @@
+# mean
+
+## Description
+
+- **Location**: `vllm_ascend/ops/triton/batch_invariant/mean.py` — `mean_kernel`, 1:1 wrapper `mean_dim`, convenience wrapper `mean_batch_invariant`
+- **Function**: Batch-invariant mean along a single dimension: reduces the input viewed as `(M, N, K)` over the middle (reduced) dimension `N` with a running scalar accumulator. Part of the batch-invariant Triton family adapted from vllm for NPU.
+- **Formula** (per output element, computed independently):
+    - `out[m, k] = (1 / N) · Σ_n x[m, n, k]` where the input is reshaped to `(M, N, K)` with `N` the reduced dimension (`M`/`K` are the products of the dims before/after it).
+- **Algorithm flow** (one program per output element):
+  1. Grid `(M * K,)`; program `pid` decodes `(m_idx, k_idx) = (pid // K, pid % K)` with a bounds check.
+  2. Strided loop over the reduction dimension in `BLOCK_SIZE = 1024` chunks with a tail mask (`other=0.0`), accumulating `tl.sum` of each chunk into a running scalar.
+  3. Divide by `N` and store the single output element.
+- **Supported modes**: Atlas A2 and Atlas A3. Intended for the batch-invariant reduction path.
+
+## Parameters
+
+> [!NOTE]
+> All parameters are required.
+
+| Parameter | Input/Output/Attribute | Description | Data type | Data format |
+| --- | --- | --- | --- | --- |
+| `input_` | Input | Tensor of arbitrary rank; the dim before/after `dim` are folded into `M`/`K` | fp16 / bf16 / fp32 (integers are promoted to fp32 when `dtype=None`) | ND |
+| `dim` | Input | Single dimension to reduce; negative values normalized by the wrapper | int32 | scalar |
+| `keepdim` | Input | Whether the reduced dim is kept as size 1 (default `False`) | bool | scalar |
+| `dtype` | Input | Compute/output dtype (default `torch.float16`); the input is cast to it first — unlike `torch.mean`, this changes the reduction dtype, not only the output dtype | torch.dtype | attribute |
+| `output` | Output | Mean over `dim`, shape `input.shape` with `dim` removed (or size 1 if `keepdim`) | same as `dtype` | ND |
+
+## Constraints
+
+- Single-dimension reduction only; `mean_batch_invariant` handles multi-dim `dim` lists by falling back to `torch.sum(..., dtype=fp32) / n_elems`, and asserts `dtype is None or fp32`.
+- The `dtype` cast happens before the reduction (`input_.to(dtype)`), so a `None`-default fp32 reduction requires passing `dtype=torch.float32` explicitly (the wrapper default is fp16).
+- The convenience wrapper's `dtype` assert applies to its own path only; the 1-dim case delegates to `mean_dim` with the wrapper's own default dtype.
+- `BLOCK_SIZE = 1024` is fixed; arbitrary `N` handled by masking.
+- Only for inference on NPU.
+
+## Origin and Differences
+
+- **Origin**: Adapted from vllm's `model_executor/layers/batch_invariant.py` (`mean_kernel` / `mean_dim`, registered upstream as the `aten::mean.dim` batch-invariant implementation); the kernel body and `(M, N, K)` view are carried over essentially unchanged (#5517).
+- **Differences**:
+    - NPU adaptation for performance: none required in the kernel body — it is a direct port; the grid `(M*K,)` of one-program-per-output-element maps naturally onto the vector cores;
+    - Modified for a specific vllm-ascend logic or different input parameters: the wrapper default `dtype` is `torch.float16` instead of upstream's `None` (input dtype), and upstream's `aten::mean.dim` registration is not wired on the NPU facade (reductions use the AscendC `npu_reduce_sum_batch_invariant` op instead).
+
+## Test Cases
+
+The test guards the 1:1 wrapper against `torch.mean` on fp32 CPU, across fp16/bf16/fp32, dimensions exercising multi-block reduction tails, negative `dim`, and `keepdim` (`(3, 1031, 17)` dim 1, `(5, 7, 2051)` dim -1 keepdim, `(2051, 3)` dim 0 keepdim), with unified tolerances (`rtol=2e-3, atol=2e-2` for fp16; `2e-2, 5e-2` for bf16; `1e-4, 1e-4` for fp32). The sibling `test_mean_batch_invariant_multiple_dims` covers the convenience wrapper's multi-dim fallback.
+
+```bash
+pytest -sv tests/e2e/nightly/single_node/ops/singlecard_ops/triton/test_batch_invariant_ops.py -k mean_kernel
+```

--- a/vllm_ascend/ops/triton/docs/rms_norm.md
+++ b/vllm_ascend/ops/triton/docs/rms_norm.md
@@ -1,0 +1,48 @@
+# rms_norm
+
+## Description
+
+- **Location**: `vllm_ascend/ops/triton/batch_invariant/rmsnorm.py` — `_rms_norm_kernel`, 1:1 wrapper `rms_norm`, convenience wrapper `rms_norm_batch_invariant`.
+- **Function**: Batch-invariant RMS normalization along the last dimension with all arithmetic in fp32. Part of the batch-invariant Triton family adapted from vllm for NPU.
+- **Formula** (per row, computed in fp32):
+    - `inv_rms = 1 / sqrt(mean(x²) + eps)` with `mean(x²) = (1/n_cols) · Σ_j x[j]²`
+    - `y[j] = x[j] · inv_rms · weight[j]`, stored in the input dtype
+- **Algorithm flow** (rows share programs):
+  1. Input is flattened to 2D `[n_rows, n_cols]`; grid is `min(n_rows, num_vectorcore)` programs.
+  2. Each program owns `ceil(n_rows / n_programs)` consecutive rows; per row it makes two passes over the columns in `BLOCK_SIZE = 1024` chunks with tail masks: pass 1 accumulates the sum of squares in fp32, pass 2 normalizes, scales by `weight`, and stores in the input dtype.
+- **Supported modes**: Atlas A2 and Atlas A3. Intended for the batch-invariant normalization path.
+
+## Parameters
+
+> [!NOTE]
+> All parameters are required.
+
+| Parameter | Input/Output/Attribute | Description | Data type | Data format |
+| --- | --- | --- | --- | --- |
+| `input_` | Input | Activations `[..., hidden_size]`; leading dims are flattened to rows, made contiguous by the wrapper | fp16 / bf16 / fp32 | ND |
+| `weight` | Input | Per-channel scale `[hidden_size]` (**required**, unlike upstream's optional weight); made contiguous by the wrapper | fp16 / bf16 / fp32 | ND |
+| `eps` | Input | Numerical-stability constant added to the mean square (default `1e-6`) | fp32 | scalar |
+| `output` | Output | Normalized tensor with the input's original shape and dtype | fp16 / bf16 / fp32 | ND |
+
+## Constraints
+
+- `weight` must be 1D with `weight.shape[0] == input_.shape[-1]` (asserted).
+- `BLOCK_SIZE = 1024` is fixed; arbitrary `hidden_size` handled by masking (tested at 1025 and 4096).
+- All arithmetic is fp32 (loads cast, stores cast back); the output dtype equals the input dtype.
+- The grid is capped at the vector-core count with rows block-scheduled per program, so program count stays independent of the token count.
+- Only for inference on NPU.
+
+## Origin and Differences
+
+- **Origin**: Adapted from vllm's `model_executor/layers/batch_invariant.py` (`_rms_norm_kernel` / `rms_norm_batch_invariant`); the three-pass math (sum of squares → inv_rms → normalize+scale) is carried over unchanged (#5517).
+- **Differences**:
+    - NPU adaptation for performance: replaces upstream's one-row-per-program grid (`grid = (n_rows,)`) with a capped grid of `min(n_rows, num_vectorcore)` programs, each owning a contiguous block of rows — fewer programs with more work each on the NPU vector cores; fixed `BLOCK_SIZE=1024` instead of upstream's autotuned meta-parameters;
+    - Modified for a specific vllm-ascend logic or different input parameters: `weight` is mandatory (upstream has a `HAS_WEIGHT` constexpr for the optional-weight case), and upstream's `aten` registration is not wired on the NPU facade (the fused add+rmsnorm path uses `torch_npu.npu_rms_norm` instead).
+
+## Test Cases
+
+The test guards the 1:1 wrapper against an fp32 CPU golden (`x · rsqrt(mean(x²) + eps) · w`) across fp16/bf16/fp32, a non-power-of-two hidden size (1025) and a multi-program/multi-block shape (2×65×4096), `eps = 1e-6 / 1e-5`, with unified tolerances (`rtol=2e-3, atol=2e-2` for fp16; `2e-2, 5e-2` for bf16; `1e-4, 1e-4` for fp32).
+
+```bash
+pytest -sv tests/e2e/nightly/single_node/ops/singlecard_ops/triton/test_batch_invariant_ops.py -k rms_norm_kernel
+```


### PR DESCRIPTION
### What this PR does / why we need it?
Add triton operator docs for matmul_bias_persistent_kernel, linear_persistent_kernel, mean_kernel and _rms_norm_kernel following the triton operator doc template (#14966).

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
Documentation-only changes, no runtime code changes.

- vLLM main: https://github.com/vllm-project/vllm/commit/ba07e4a48fc951300d97eb506217dd530583dea3
