### PR TITLE
[Feature] [MRV2] Refactor Host-Side Parameter Updates for ACL Graph Replay.

### DIFF
--- a/vllm_ascend/attention/attention_v1.py
+++ b/vllm_ascend/attention/attention_v1.py
@@ -60,6 +60,10 @@ from vllm_ascend.compilation.acl_graph import (
     update_draft_graph_params_workspaces,
     update_graph_params_workspaces,
 )
+from vllm_ascend.compilation.updatable_graph import (
+    get_capture_resource,
+    register_task,
+)
 from vllm_ascend.device.device_op import DeviceOperator
 from vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.attention_fence import record_attention_compute_start
 from vllm_ascend.utils import is_950, vllm_version_is, weak_ref_tensors
@@ -72,6 +76,7 @@ else:
 # default max value of sliding window size
 SWA_INT_MAX = 2147483647
 _ATTN_KEYS_BUFFER = None
+_FIA_WORKSPACE_KEY = "npu_fused_infer_attention_score.workspace"
 
 
 @register_backend(AttentionBackendEnum.CUSTOM, "ASCEND")
@@ -489,6 +494,17 @@ class AscendAttentionPCPMetadataBuilder(AscendAttentionMetadataBuilder):
             metadata.attn_state = AscendAttentionState.ChunkedPrefill
         return metadata
 
+
+@dataclass(frozen=True, slots=True)
+class FIAParamProvider:
+    layer_name: str
+
+    def resolve(self, attn_metadata) -> dict[str, Any]:
+        metadata = attn_metadata[self.layer_name]
+        return {
+            "actual_seq_lengths": metadata.actual_seq_lengths_q,
+            "actual_seq_lengths_kv": metadata.seq_lens_list,
+        }
 
 class AscendAttentionBackendImpl(AttentionImpl):
     def __init__(
@@ -946,7 +962,7 @@ class AscendAttentionBackendImpl(AttentionImpl):
         sparse_mode = 4 if self.sliding_window else 3 if attn_metadata.causal else 0
         pre_tokens = self.sliding_window or SWA_INT_MAX
         next_tokens = 0 if self.sliding_window else SWA_INT_MAX
-
+        output_view = output[: attn_metadata.num_actual_tokens]
         extra_args = {}
         if self.enable_c8_quant and layer is not None:
             extra_args = {
@@ -968,13 +984,10 @@ class AscendAttentionBackendImpl(AttentionImpl):
             output = output.unsqueeze(2)
             attn_mask = None
             sparse_mode = 0
-        use_max_workspace = self._use_max_workspace_for_fia_graph
-        workspace = graph_params.workspaces.get(num_tokens)
-        should_update_workspace_cache = False
-        if use_max_workspace:
-            # Some models mix attention layer shapes under the same graph size.
-            # During capture, keep the largest required workspace for that size.
-            candidate_workspace = torch_npu._npu_fused_infer_attention_score_get_max_workspace(
+        
+        workspace = get_capture_resource(
+            _FIA_WORKSPACE_KEY,
+            lambda: torch_npu._npu_fused_infer_attention_score_get_max_workspace(
                 query=query,
                 key=key,
                 value=value,
@@ -986,110 +999,36 @@ class AscendAttentionBackendImpl(AttentionImpl):
                 actual_seq_lengths_kv=actual_seq_lengths_kv,
                 num_key_value_heads=self.num_kv_heads,
                 num_heads=self.num_heads,
-                sparse_mode=sparse_mode,
                 pre_tokens=pre_tokens,
                 next_tokens=next_tokens,
                 scale=self.scale,
-                **extra_args,
-            )
-            workspace = cache_graph_workspace(
-                graph_params,
-                num_tokens,
-                candidate_workspace,
-                use_max_workspace=use_max_workspace,
-            )
-            should_update_workspace_cache = True
-        elif workspace is None:
-            workspace = torch_npu._npu_fused_infer_attention_score_get_max_workspace(
-                query=query,
-                key=key,
-                value=value,
-                atten_mask=attn_mask,
-                block_table=block_table,
-                input_layout=input_layout,
-                block_size=block_size,
-                actual_seq_lengths=actual_seq_lengths_q,
-                actual_seq_lengths_kv=actual_seq_lengths_kv,
-                num_key_value_heads=self.num_kv_heads,
-                num_heads=self.num_heads,
                 sparse_mode=sparse_mode,
-                pre_tokens=pre_tokens,
-                next_tokens=next_tokens,
-                scale=self.scale,
                 **extra_args,
-            )
-            should_update_workspace_cache = True
-        if should_update_workspace_cache:
-            if _EXTRA_CTX.is_draft_model:
-                update_draft_graph_params_workspaces(num_tokens, workspace)
-            else:
-                update_graph_params_workspaces(num_tokens, workspace)
-
-        # Handle graph capturing mode
-        stream = torch_npu.npu.current_stream()
-
-        event = torch.npu.ExternalEvent()
-        event.wait(stream)
-        event.reset(stream)
-        graph_params.events[num_tokens].append(event)
-        attn_params = (
-            weak_ref_tensors(query),
-            weak_ref_tensors(key),
-            weak_ref_tensors(value),
-            weak_ref_tensors(block_table),
-            weak_ref_tensors(attn_mask) if attn_mask is not None else None,
-            block_size,
-            actual_seq_lengths_kv,
-            actual_seq_lengths_q,
-            self.num_kv_heads,
-            self.num_heads,
-            self.scale,
-            weak_ref_tensors(output),
-            weak_ref_tensors(softmax_lse),
-            sparse_mode,
-            pre_tokens,
-            next_tokens,
-            self.sliding_window,
-        )
-        if self.enable_c8_quant and layer is not None:
-            attn_params = attn_params + (
-                weak_ref_tensors(layer._c8_k_aq_scale_nz_bnsd),
-                None,
-                weak_ref_tensors(layer._c8_v_aq_scale_nz_bnsd),
-                None,
-            )  # type: ignore
-        else:
-            attn_params = attn_params + (None, None, None, None)  # type: ignore
-        layer_name = self._graph_metadata_layer_name(layer) if self._use_layer_aware_fia_graph_replay else None
-        attn_params = attn_params + (layer_name,)  # type: ignore
-        graph_params.attn_params[num_tokens].append(attn_params)
-
-        torch.npu.graph_task_group_begin(stream)
-        torch_npu.npu_fused_infer_attention_score.out(
-            query=query,
-            key=key,
-            value=value,
-            atten_mask=attn_mask,
-            block_table=block_table,
-            input_layout=input_layout,
-            block_size=block_size,
-            actual_seq_lengths=actual_seq_lengths_q,
-            actual_seq_lengths_kv=actual_seq_lengths_kv,
-            num_key_value_heads=self.num_kv_heads,
-            num_heads=self.num_heads,
-            scale=self.scale,
-            sparse_mode=sparse_mode,
-            pre_tokens=pre_tokens,
-            next_tokens=next_tokens,
-            workspace=workspace,
-            out=[output, softmax_lse],
-            **extra_args,
-        )
-
-        output = output.view(num_tokens, self.num_heads, self.head_size)
-
-        handle = torch.npu.graph_task_group_end(stream)
-        graph_params.handles[num_tokens].append(handle)
+            ),
+        ) 
+        register_task(
+            torch_npu.npu_fused_infer_attention_score.out,
+            {
+                "query": query,
+                "key": key,
+                "value": value,
+                "atten_mask": attn_mask,
+                "block_table": block_table,
+                "input_layout": input_layout,
+                "block_size": block_size,
+                "actual_seq_lengths": actual_seq_lengths_q,
+                "actual_seq_lengths_kv": actual_seq_lengths_kv,
+                "num_key_value_heads": self.num_kv_heads,
+                "num_heads": self.num_heads,
+                "pre_tokens": pre_tokens,
+                "next_tokens": next_tokens,
+                "scale": self.scale,
+                "sparse_mode": sparse_mode,
+                "workspace": workspace,
+                "out": [output_view, softmax_lse],
+            },
+            FIAParamProvider(self._layer_name),
+        )        
         return output, num_tokens
 
     def full_graph_fia_v2(
@@ -1704,8 +1643,8 @@ class AscendAttentionBackendImpl(AttentionImpl):
             shape = [num_tokens, num_heads * head_size]
         """
         assert output is not None, "Output tensor must be provided."
-        if self._use_layer_aware_fia_graph_replay:
-            self._layer_name = layer.layer_name
+        # if self._use_layer_aware_fia_graph_replay:
+        self._layer_name = layer.layer_name
 
         if output_scale is not None or output_block_scale is not None:
             raise NotImplementedError("fused output quantization is not yet supported for AscendAttentionBackendImpl")

--- a/vllm_ascend/attention/attention_v1.py
+++ b/vllm_ascend/attention/attention_v1.py
@@ -948,13 +948,6 @@ class AscendAttentionBackendImpl(AttentionImpl):
         key, value, block_size, block_table, actual_seq_lengths_kv = self._get_fia_params(key, value, attn_metadata)
 
         num_tokens = attn_metadata.actual_seq_lengths_q[-1]
-        if _EXTRA_CTX.is_draft_model:
-            if _EXTRA_CTX.is_draft_model_prefill:
-                graph_params = get_draft_graph_prefill_params()
-            else:
-                graph_params = get_draft_graph_params()
-        else:
-            graph_params = get_graph_params()
         actual_seq_lengths_q = attn_metadata.actual_seq_lengths_q
         softmax_lse = torch.empty(1, dtype=query.dtype, device=query.device)
         input_layout = "TND"

--- a/vllm_ascend/compilation/acl_graph.py
+++ b/vllm_ascend/compilation/acl_graph.py
@@ -21,6 +21,11 @@ from vllm.logger import logger
 from vllm.platforms import current_platform
 
 from vllm_ascend.ascend_forward_context import _EXTRA_CTX
+from .updatable_graph import (
+    SharedSource,
+    ContextSource,
+    UpdatableGraph,
+)
 
 from ..utils import vllm_version_is, weak_ref_tensors
 
@@ -91,6 +96,7 @@ class ACLGraphWrapper:
         *,
         use_eagle: bool = False,
         enable_enpu: bool = False,
+        update_stream: torch.npu.Stream | None = None,
     ):
         self.runnable = runnable
         self.vllm_config = vllm_config
@@ -114,7 +120,15 @@ class ACLGraphWrapper:
         self.concrete_aclgraph_entries: dict[BatchDescriptor, ACLGraphEntry] = {}
         self.enable_enpu = enable_enpu
         self.use_eagle = use_eagle
+        self.update_stream = update_stream
+        self.draft_update_attn_metadata: list[dict[str, Any]] = []
         _acl_graph_wrappers.add(self)
+
+    def set_update_stream(self, update_stream):
+        self.update_stream = update_stream
+
+    def set_draft_update_attn_metadata(self, update_params: list[dict[str, Any]]):
+        self.draft_update_attn_metadata = update_params
 
     def __getattr__(self, key: str):
         # allow accessing the attributes of the runnable.
@@ -162,7 +176,7 @@ class ACLGraphWrapper:
 
             input_addresses = [x.data_ptr() for x in args if isinstance(x, torch.Tensor)]
             entry.input_addresses = input_addresses
-            aclgraph = torch.npu.NPUGraph()
+            aclgraph = UpdatableGraph()
 
             with ExitStack() as stack:
                 if self.aclgraph_options.gc_disable:
@@ -259,12 +273,35 @@ class ACLGraphWrapper:
         # we do not need to synchronize.
         # When enable_enpu is on, model_runner orders update vs replay; skip here.
         # When FULL + EAGLE draft (merge path), replay does not need this barrier.
+        if _EXTRA_CTX.is_draft_model:
+            resolved_tasks = entry.aclgraph.resolve_tasks(
+                SharedSource(self.draft_update_attn_metadata)
+            )
+        else:
+            resolved_tasks = entry.aclgraph.resolve_tasks(
+                ContextSource(forward_context.attn_metadata)
+            )
         is_draft_eagle = _EXTRA_CTX.is_draft_model and self.use_eagle
         need_sync = self.runtime_mode == CUDAGraphMode.FULL and not is_draft_eagle
-        if not self.enable_enpu and need_sync:
+        if self.enable_enpu or need_sync:
             torch.npu.current_stream().synchronize()
-        entry.aclgraph.replay()
+        if self.enable_enpu:
+            self._maybe_update_full_graph_params(entry.aclgraph, resolved_tasks)
+            entry.aclgraph.replay()
+        else:
+            entry.aclgraph.replay()
+            self._maybe_update_full_graph_params(entry.aclgraph, resolved_tasks)
         return entry.output
+
+    def _maybe_update_full_graph_params(
+        self,
+        graph: UpdatableGraph,
+        resolved_tasks: tuple[Any],
+    ) -> None:
+        if (
+            self.runtime_mode == CUDAGraphMode.FULL
+        ):
+            graph.update(self.update_stream, resolved_tasks)
 
 
 def weak_ref_workspaces(params):

--- a/vllm_ascend/compilation/updatable_graph.py
+++ b/vllm_ascend/compilation/updatable_graph.py
@@ -1,0 +1,176 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from collections.abc import Callable, Hashable, Sequence
+from contextvars import ContextVar, Token
+from dataclasses import dataclass, replace
+from typing import Any, Protocol
+
+import torch
+
+from vllm_ascend.utils import weak_ref_tensors
+
+
+Params = dict[str, Any]
+
+
+class ParamProvider(Protocol):
+    def resolve(self, context) -> Params: ...
+
+
+class ParamSource(Protocol):
+    def get(
+        self,
+        provider: ParamProvider,
+    ) -> Sequence[Params]: ...
+
+
+@dataclass(frozen=True, slots=True)
+class ContextSource:
+    context: Any
+
+    def get(
+        self,
+        provider: ParamProvider,
+    ) -> Sequence[Params]:
+        return (provider.resolve(self.context),)
+
+
+@dataclass(frozen=True, slots=True)
+class SharedSource:
+    params: Sequence[Params]
+
+    def get(
+        self,
+        _provider: ParamProvider,
+    ) -> Sequence[Params]:
+        return self.params
+
+
+_ACTIVE_GRAPH: ContextVar["UpdatableGraph | None"] = ContextVar(
+    "capturing_updatable_graph", default=None
+)
+
+
+@dataclass(frozen=True, slots=True)
+class GraphUpdateTask:
+    operation: Callable[..., Any]
+    kwargs: dict[str, Any]
+    provider: ParamProvider
+    provider_index: int
+    handle: Any
+    event: Any
+
+    def bind(self, params: Params) -> "GraphUpdateTask":
+        runtime_kwargs = {**self.kwargs, **params}
+        return replace(self, kwargs=runtime_kwargs)
+
+    def apply(self, update_stream) -> None:
+        torch.npu.graph_task_update_begin(update_stream, self.handle)
+        self.operation(**self.kwargs)
+        torch.npu.graph_task_update_end(update_stream)
+        self.event.record(update_stream)
+
+
+class UpdatableGraph(torch.npu.NPUGraph):
+    def __init__(self) -> None:
+        super().__init__()
+        self.tasks: list[GraphUpdateTask] = []
+        self.provider_sizes: dict[ParamProvider, int] = {}
+        self.capture_resources: dict[Hashable, Any] = {}
+        self.capture_token: Token[UpdatableGraph | None] | None = None
+
+    def capture_begin(self, pool=None, capture_error_mode: str = "global") -> None:
+        super().capture_begin(pool=pool, capture_error_mode=capture_error_mode)
+        assert self.capture_token is None
+        self.capture_token = _ACTIVE_GRAPH.set(self)
+
+    def capture_end(self) -> None:
+        try:
+            super().capture_end()
+        finally:
+            assert self.capture_token is not None
+            _ACTIVE_GRAPH.reset(self.capture_token)
+            self.capture_token = None
+            self.capture_resources = weak_ref_tensors(self.capture_resources)
+
+    def get_capture_resource(
+        self,
+        key: Hashable,
+        factory: Callable[[], Any],
+    ) -> Any:
+        if key not in self.capture_resources:
+            self.capture_resources[key] = factory()
+        return self.capture_resources[key]
+
+    def register_task(
+        self,
+        operation: Callable[..., Any],
+        kwargs: dict[str, Any],
+        provider: ParamProvider,
+    ) -> None:
+        stream = torch.npu.current_stream()
+        event = torch.npu.ExternalEvent()
+        event.wait(stream)
+        event.reset(stream)
+        torch.npu.graph_task_group_begin(stream)
+        operation(**kwargs)
+        handle = torch.npu.graph_task_group_end(stream)
+        weak_kwargs = weak_ref_tensors(kwargs)
+        provider_index = self.provider_sizes.get(provider, 0)
+        self.provider_sizes[provider] = provider_index + 1
+        self.tasks.append(
+            GraphUpdateTask(
+                operation,
+                weak_kwargs,
+                provider,
+                provider_index,
+                handle,
+                event,
+            )
+        )
+
+    def resolve_tasks(
+        self,
+        source: ParamSource,
+    ) -> tuple[GraphUpdateTask, ...]:
+        params_by_provider = {
+            provider: source.get(provider) for provider in self.provider_sizes
+        }
+        for provider, size in self.provider_sizes.items():
+            assert len(params_by_provider[provider]) == size
+        return tuple(
+            task.bind(params_by_provider[task.provider][task.provider_index])
+            for task in self.tasks
+        )
+
+    def update(
+        self,
+        update_stream,
+        resolved_tasks: tuple[GraphUpdateTask, ...],
+    ) -> None:
+        with torch.npu.stream(update_stream):
+            for task in resolved_tasks:
+                task.apply(update_stream)
+
+
+def register_task(
+    operation: Callable[..., Any],
+    kwargs: dict[str, Any],
+    provider: ParamProvider,
+) -> None:
+    graph = _ACTIVE_GRAPH.get()
+    if graph is None:
+        operation(**kwargs)
+    else:
+        graph.register_task(operation, kwargs, provider)
+
+
+def get_capture_resource(
+    key: Hashable,
+    factory: Callable[[], Any],
+) -> Any:
+    graph = _ACTIVE_GRAPH.get()
+    if graph is None:
+        return factory()
+    return graph.get_capture_resource(key, factory)

--- a/vllm_ascend/spec_decode/llm_base_proposer.py
+++ b/vllm_ascend/spec_decode/llm_base_proposer.py
@@ -45,7 +45,7 @@ from vllm_ascend.ascend_config import get_ascend_config
 from vllm_ascend.ascend_forward_context import _EXTRA_CTX, set_ascend_forward_context
 from vllm_ascend.attention.attention_v1 import AscendAttentionState
 from vllm_ascend.attention.utils import AscendCommonAttentionMetadata
-from vllm_ascend.compilation.acl_graph import ACLGraphWrapper, update_full_graph_params
+from vllm_ascend.compilation.acl_graph import ACLGraphWrapper
 from vllm_ascend.compilation.breakable_aclgraph import BreakableACLGraphWrapper
 from vllm_ascend.device.device_op import DeviceOperator
 from vllm_ascend.distributed.kv_transfer.sparse_kv_offload.sparse_kv_offload_manager import (
@@ -535,7 +535,6 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
                 self.use_eagle,
                 self.enable_enpu,
             )
-            self.update_stream = None
             self._runnable = ACLGraphWrapper(
                 self._run_merged_draft,
                 self.vllm_config,
@@ -543,6 +542,8 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
                 use_eagle=self.use_eagle,
                 enable_enpu=self.enable_enpu,
             )
+    def set_update_stream(self, update_stream):
+        self._runnable.set_update_stream(update_stream)
 
     def _maybe_share_topk_indices(self, target_language_model: nn.Module) -> None:
         if hasattr(target_language_model.model, "topk_indices_buffer"):
@@ -723,6 +724,14 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
 
         self.token_indices_to_sample.fill_(0)
 
+        update_params = []
+        for per_layer_metadata in multi_steps_attn_metadata:
+            metadata = next(iter(per_layer_metadata.values()))
+            update_params.append({
+                "actual_seq_lengths": metadata.actual_seq_lengths_q,
+                "actual_seq_lengths_kv": metadata.seq_lens_list,
+        })
+
         with set_ascend_forward_context(
             multi_steps_attn_metadata[0] if multi_steps_attn_metadata else None,
             self.vllm_config,
@@ -743,6 +752,9 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
             if forward_context is not None:
                 forward_context.moe_layer_index = 0
 
+            if forward_context.cudagraph_runtime_mode == CUDAGraphMode.FULL and not _EXTRA_CTX.capturing:
+                self._runnable.set_draft_update_attn_metadata(update_params)
+
             self._runnable(
                 num_input_tokens=num_tokens,
                 batch_size=batch_size,
@@ -753,18 +765,6 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
                 multi_steps_attn_metadata=multi_steps_attn_metadata,
                 num_tokens=num_tokens,
             )
-            forward_context = get_forward_context()
-            if forward_context.cudagraph_runtime_mode == CUDAGraphMode.FULL and not _EXTRA_CTX.capturing:
-                self._update_full_graph_params(forward_context, num_tokens, multi_steps_attn_metadata)
-
-    def _update_full_graph_params_if_needed(
-        self,
-        forward_context: ForwardContext,
-        num_input_tokens: int,
-        multi_steps_attn_metadata: list[dict[str, Any]],
-    ) -> None:
-        if forward_context.cudagraph_runtime_mode == CUDAGraphMode.FULL:
-            self._update_full_graph_params(forward_context, num_input_tokens, multi_steps_attn_metadata)
 
     def _propose(
         self,
@@ -1043,6 +1043,14 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
         self.token_indices_to_sample[:token_indices_to_sample_len].copy_(token_indices_to_sample)
         self.token_indices_to_sample[token_indices_to_sample_len:].fill_(0)
 
+        update_params = []
+        for per_layer_metadata in multi_steps_attn_metadata:
+            metadata = next(iter(per_layer_metadata.values()))
+            update_params.append({
+                "actual_seq_lengths": metadata.actual_seq_lengths_q,
+                "actual_seq_lengths_kv": metadata.seq_lens_list,
+        })       
+
         with set_ascend_forward_context(
             multi_steps_attn_metadata[0],
             self.vllm_config,
@@ -1073,15 +1081,11 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
                 "is_prefill": is_prefill_batch,
                 "sampling_metadata": sampling_metadata,
             }
+            if forward_context.cudagraph_runtime_mode == CUDAGraphMode.FULL:
+                self._runnable.set_draft_update_attn_metadata(update_params)
             runnable = cast(Callable[..., Any], self._runnable)
             run_draft: Callable[[], Any] = partial(runnable, **model_inputs)
-
-            if self.enable_enpu:
-                self._update_full_graph_params_if_needed(forward_context, num_input_tokens, multi_steps_attn_metadata)
-                draft_token_ids = run_draft()
-            else:
-                draft_token_ids = run_draft()
-                self._update_full_graph_params_if_needed(forward_context, num_input_tokens, multi_steps_attn_metadata)
+            draft_token_ids = run_draft()
         return draft_token_ids
 
     def _sample_draft_from_logits(
@@ -2199,20 +2203,6 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
         )
 
         return spec_common_attn_metadata, token_indices, token_indices_to_sample, num_rejected_tokens_gpu
-
-    # update full-graph params for one spec token
-    def _update_full_graph_params(self, forward_context, num_tokens, draft_attn_metadatas=None):
-        assert len(self.draft_attn_groups) > 0
-        attn_backend = self.draft_attn_groups[0].backend
-        update_full_graph_params(
-            attn_backend,
-            self.update_stream,
-            forward_context,
-            num_tokens,
-            self.vllm_config,
-            self.vllm_config.speculative_config,
-            draft_attn_metadatas=draft_attn_metadatas,
-        )
 
     # adjusting tensor into desired size
     def _adjust_tensor(self, tensor, desired_size):

--- a/vllm_ascend/utils.py
+++ b/vllm_ascend/utils.py
@@ -940,11 +940,13 @@ def weak_ref_tensors(
         return [weak_ref_tensor(t) for t in tensors]
     if isinstance(tensors, tuple):
         return tuple(weak_ref_tensor(t) for t in tensors)
-    # For IntermediateTensors used in pipeline parallelism
+    if isinstance(tensors, dict):
+        return {
+            key: weak_ref_tensors(tensor) for key, tensor in tensors.items()
+        }
     if isinstance(tensors, IntermediateTensors):
-        ret = IntermediateTensors({key: weak_ref_tensor(val) for key, val in tensors.tensors.items()})
-        return ret
-    raise ValueError("Invalid type for tensors")
+        return IntermediateTensors(weak_ref_tensors(tensors.tensors))
+    return tensors
 
 
 def npu_stream_switch(target_stream: torch.npu.Stream, *, enabled: bool = True):

--- a/vllm_ascend/worker/model_runner_v1.py
+++ b/vllm_ascend/worker/model_runner_v1.py
@@ -2179,7 +2179,7 @@ class NPUModelRunner(GPUModelRunner):
             if self.cache_config.mamba_cache_mode == "align":
                 mamba_utils.do_mamba_copy_block(preprocess_bufs)
             hidden_states = self._model_forward(
-                num_tokens_padded, input_ids, positions, intermediate_tensors, inputs_embeds, **model_kwargs
+                input_ids, positions, intermediate_tensors, inputs_embeds, **model_kwargs
             )
         with record_function_or_nullcontext("post process"):
             aux_hidden_states = None
@@ -3431,7 +3431,7 @@ class NPUModelRunner(GPUModelRunner):
                 eplb_heat_collection_status=self.eplb_heat_collection_status if self.dynamic_eplb else False,
             ):
                 outputs = self._model_forward(
-                    num_tokens_padded, input_ids, positions, intermediate_tensors, inputs_embeds
+                    input_ids, positions, intermediate_tensors, inputs_embeds
                 )
             if self.use_aux_hidden_state_outputs:
                 hidden_states, _ = outputs

--- a/vllm_ascend/worker/model_runner_v1.py
+++ b/vllm_ascend/worker/model_runner_v1.py
@@ -26,7 +26,6 @@ from collections.abc import Callable
 from contextlib import contextmanager, nullcontext
 from copy import copy, deepcopy
 from dataclasses import dataclass, replace
-from functools import partial
 from multiprocessing import Manager
 from typing import TYPE_CHECKING, Any, NamedTuple, TypeAlias
 
@@ -130,7 +129,6 @@ from vllm_ascend.compilation.acl_graph import (
     ACLGraphWrapper,
     set_draft_graph_params,
     set_graph_params,
-    update_full_graph_params,
 )
 from vllm_ascend.compilation.breakable_aclgraph import BreakableACLGraphWrapper
 from vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.layerwise_cache_layout import (
@@ -2659,31 +2657,8 @@ class NPUModelRunner(GPUModelRunner):
             invalid_req_indices,
         )
 
-    def _update_full_graph_params_if_needed(
-        self,
-        forward_context: ForwardContext,
-        num_tokens_padded: int,
-    ) -> None:
-        if (
-            forward_context.cudagraph_runtime_mode == CUDAGraphMode.FULL
-            and not forward_context.capturing
-            and not self.use_sparse and not self.use_compress
-        ):
-            if self.enable_enpu:
-                torch.npu.current_stream().synchronize()
-
-            update_full_graph_params(
-                self.attn_backend,
-                self.update_stream,
-                forward_context,
-                num_tokens_padded,
-                self.vllm_config,
-                self.speculative_config,
-            )
-
     def _model_forward(
         self,
-        num_tokens_padded: int,
         input_ids: torch.Tensor | None = None,
         positions: torch.Tensor | None = None,
         intermediate_tensors: IntermediateTensors | None = None,
@@ -2701,16 +2676,7 @@ class NPUModelRunner(GPUModelRunner):
             "inputs_embeds": inputs_embeds,
             **model_kwargs,
         }
-        run_model = partial(self.model, **model_inputs)
-
-        if self.enable_enpu:
-            # The soft segmentation scenario requires event.record first, then event.wait
-            self._update_full_graph_params_if_needed(forward_context, num_tokens_padded)
-            hidden_states = run_model()
-        else:
-            hidden_states = run_model()
-            self._update_full_graph_params_if_needed(forward_context, num_tokens_padded)
-
+        hidden_states = self.model(**model_inputs)
         return hidden_states
 
     def _pad_for_sequence_parallelism(self, num_scheduled_tokens: int) -> int:
@@ -3657,7 +3623,7 @@ class NPUModelRunner(GPUModelRunner):
             self.update_stream = torch.npu.Stream()
 
             if self.drafter is not None:
-                self.drafter.update_stream = self.update_stream
+                self.drafter.set_update_stream(self.update_stream)
 
         with _torch_cuda_wrapper():
             if (
@@ -3669,6 +3635,7 @@ class NPUModelRunner(GPUModelRunner):
                     self.vllm_config,
                     use_eagle=self.use_eagle,
                     enable_enpu=self.enable_enpu,
+                    update_stream=self.update_stream,
                 )
                 drafter = getattr(self, "drafter", None)
                 if drafter is not None and hasattr(drafter, "model"):
@@ -3677,6 +3644,7 @@ class NPUModelRunner(GPUModelRunner):
                         self.vllm_config,
                         use_eagle=self.use_eagle,
                         enable_enpu=self.enable_enpu,
+                        update_stream=self.update_stream,
                     )
             elif cudagraph_mode.has_full_cudagraphs():
                 self.model = ACLGraphWrapper(
@@ -3685,6 +3653,7 @@ class NPUModelRunner(GPUModelRunner):
                     runtime_mode=CUDAGraphMode.FULL,
                     use_eagle=self.use_eagle,
                     enable_enpu=self.enable_enpu,
+                    update_stream=self.update_stream,
                 )
 
         if self.compilation_config.cudagraph_mode != CUDAGraphMode.NONE:

--- a/vllm_ascend/worker/v2/aclgraph_utils.py
+++ b/vllm_ascend/worker/v2/aclgraph_utils.py
@@ -40,6 +40,10 @@ from vllm.v1.worker.utils import AttentionGroup
 from vllm_ascend.ascend_forward_context import _EXTRA_CTX
 from vllm_ascend.compilation.acl_graph import set_graph_params, update_full_graph_params
 from vllm_ascend.compilation.breakable_aclgraph import BreakableACLGraphWrapper
+from vllm_ascend.compilation.updatable_graph import (
+    ContextSource,
+    UpdatableGraph,
+)
 from vllm_ascend.utils import vllm_version_is
 from vllm_ascend.worker.v2.utils import communicator_switch
 
@@ -155,54 +159,29 @@ class ModelAclGraphManager(ModelCudaGraphManager):
             self.breakable_cg_runner: BreakableACLGraphWrapper | None = None
             self.model_runner = model_runner
             self.update_stream = self.model_runner.update_stream
-            self.capture_sizes = collect_sorted_captured_token_sizes(self._capture_descs)
-            if super().needs_capture():
-                set_graph_params(self.capture_sizes)
 
     def init_breakable_cg_runner(self, model: nn.Module) -> None:
         if self.breakable_cg_runner is None:
             self.breakable_cg_runner = BreakableACLGraphWrapper(model, self.vllm_config)
 
-    def run_fullgraph(self, desc: BatchExecutionDescriptor) -> torch.Tensor | tuple[torch.Tensor, list[torch.Tensor]]:
-        """Override run_fullgraph to update full graph params in run_fullgraph."""
+    def run_fullgraph(
+            self, desc: BatchExecutionDescriptor
+        ) -> torch.Tensor | tuple[torch.Tensor, list[torch.Tensor]] | IntermediateTensors:
+        """Replay a full graph and update its registered tasks."""
         num_tokens = desc.num_tokens
         logger.info_once("run_fullgraph with num_tokens=%s", num_tokens)
         assert self.update_stream is not None
+        
+        graph = self.graphs[desc]
+        assert isinstance(graph, UpdatableGraph)
+        # Resolve every provider before replay so a provider failure cannot
+        # leave the graph blocked on an update event that will never be recorded.
+        resolved_tasks = graph.resolve_tasks(
+            ContextSource(self.model_runner.model_state.attn_metadata)
+        )
         self.update_stream.wait_stream(torch.npu.current_stream())
         ret = super().run_fullgraph(desc)
-
-        # refer to vllm.v1.worker.gpu.dp_utils.sync_cudagraph_and_dp_padding to
-        # calculate num_tokens_across_dp.
-        num_tokens_across_dp = torch.full([self.model_runner.dp_size], num_tokens)
-        # sfa_v1.py:AscendSFABackend.get_impl_cls reaches
-        # sfa_cp.py:resolve_sfa_impl, whose SFA CP selector reads the current
-        # ModelConfig. Publish the target config because set_forward_context()
-        # does not update it.
-        # TODO: Remove this explicit current-config scope once ACL graph replay
-        # passes VllmConfig directly through the graph-update interfaces.
-        with (
-            set_current_vllm_config(self.vllm_config),
-            set_forward_context(
-                self.model_runner.model_state.attn_metadata,
-                self.vllm_config,
-                num_tokens=num_tokens,
-                cudagraph_runtime_mode=desc.cg_mode,
-                num_tokens_across_dp=num_tokens_across_dp,
-                batch_descriptor=None,  # Full graph model don't need batch_descriptor
-                slot_mapping=None,
-            ),
-        ):
-            forward_context = get_forward_context()
-            attn_backend = _get_graph_update_backend(self.model_runner.attn_groups)
-            update_full_graph_params(
-                # FIXME(Ronald1995): support hybrid attn backend
-                attn_backend,
-                self.update_stream,
-                forward_context,
-                num_tokens,
-                self.vllm_config,
-                self.model_runner.speculative_config,
-            )
+        graph.update(self.update_stream, resolved_tasks)
         return ret
 
     def capture(

--- a/vllm_ascend/worker/v2/aclgraph_utils.py
+++ b/vllm_ascend/worker/v2/aclgraph_utils.py
@@ -165,8 +165,6 @@ class ModelAclGraphManager(ModelCudaGraphManager):
             self, desc: BatchExecutionDescriptor
         ) -> torch.Tensor | tuple[torch.Tensor, list[torch.Tensor]] | IntermediateTensors:
         """Replay a full graph and update its registered tasks."""
-        num_tokens = desc.num_tokens
-        logger.info_once("run_fullgraph with num_tokens=%s", num_tokens)
         assert self.update_stream is not None
         
         graph = self.graphs[desc]

--- a/vllm_ascend/worker/v2/aclgraph_utils.py
+++ b/vllm_ascend/worker/v2/aclgraph_utils.py
@@ -23,9 +23,9 @@ from typing import Any
 
 import torch
 import torch.nn as nn
-from vllm.config import VllmConfig, set_current_vllm_config
+from vllm.config import VllmConfig
 from vllm.config.compilation import CUDAGraphMode
-from vllm.forward_context import get_forward_context, set_forward_context
+from vllm.forward_context import get_forward_context
 from vllm.logger import logger
 from vllm.sequence import IntermediateTensors
 from vllm.v1.attention.backend import AttentionBackend
@@ -38,7 +38,7 @@ from vllm.v1.worker.gpu.model_states.interface import ModelState
 from vllm.v1.worker.utils import AttentionGroup
 
 from vllm_ascend.ascend_forward_context import _EXTRA_CTX
-from vllm_ascend.compilation.acl_graph import set_graph_params, update_full_graph_params
+from vllm_ascend.compilation.acl_graph import set_graph_params
 from vllm_ascend.compilation.breakable_aclgraph import BreakableACLGraphWrapper
 from vllm_ascend.compilation.updatable_graph import (
     ContextSource,

--- a/vllm_ascend/worker/v2/aclgraph_utils.py
+++ b/vllm_ascend/worker/v2/aclgraph_utils.py
@@ -132,9 +132,6 @@ class ModelAclGraphManager(ModelCudaGraphManager):
             )
             self.model_runner = model_runner
             self.update_stream = self.model_runner.update_stream
-            self.capture_sizes = collect_sorted_captured_token_sizes(self._capture_descs)
-            if super().needs_capture():
-                set_graph_params(self.capture_sizes)
 
     else:
 

--- a/vllm_ascend/worker/v2/aclgraph_utils.py
+++ b/vllm_ascend/worker/v2/aclgraph_utils.py
@@ -262,6 +262,9 @@ class ModelWithContext(nn.Module):
     def map_draft_to_target(self, draft_ids: torch.Tensor):
         return self.original_model.map_draft_to_target(draft_ids)
 
+    def embed_input_ids(self, input_ids: torch.Tensor, *args, **kwargs) -> torch.Tensor:
+        return self.original_model.embed_input_ids(input_ids, *args, **kwargs)
+
 
 @contextmanager
 def model_capture_wrapper(speculator, is_draft_model_prefill):

--- a/vllm_ascend/worker/v2/spec_decode/autoregressive/aclgraph.py
+++ b/vllm_ascend/worker/v2/spec_decode/autoregressive/aclgraph.py
@@ -4,27 +4,22 @@ from collections.abc import Callable
 from typing import Any
 
 import torch
-from vllm.config import VllmConfig, set_current_vllm_config
+from vllm.config import VllmConfig
 from vllm.config.compilation import CUDAGraphMode
-from vllm.forward_context import get_forward_context, set_forward_context
 from vllm.logger import logger
 from vllm.v1.kv_cache_interface import KVCacheConfig
 from vllm.v1.worker.gpu.block_table import BlockTables
-from vllm.v1.worker.gpu.cudagraph_utils import (
-    BatchExecutionDescriptor,
-    CudaGraphManager,
-    prepare_inputs_to_capture,
-)
+from vllm.v1.worker.gpu.cudagraph_utils import BatchExecutionDescriptor
+
 from vllm.v1.worker.gpu.input_batch import InputBuffers
 from vllm.v1.worker.gpu.model_states.interface import ModelState
 from vllm.v1.worker.gpu.spec_decode.autoregressive.cudagraph_utils import SpeculatorCudaGraphManager
 from vllm.v1.worker.utils import AttentionGroup
 
 from vllm_ascend.ascend_forward_context import _EXTRA_CTX
-from vllm_ascend.compilation.acl_graph import (
-    set_draft_graph_params,
-    set_draft_graph_prefill_params,
-    update_full_graph_params,
+from vllm_ascend.compilation.updatable_graph import (
+    SharedSource,
+    UpdatableGraph,
 )
 from vllm_ascend.worker.v2.aclgraph_utils import (
     collect_sorted_captured_token_sizes,
@@ -64,11 +59,6 @@ class AutoRegressiveAclGraphManager(SpeculatorCudaGraphManager):
         # Upstream uses num_speculative_steps + 1 as the draft-prefill query
         # length and 1 for draft decode.
         self.is_draft_model_prefill = decode_query_len > 1
-        if super().needs_capture():
-            if self.is_draft_model_prefill:
-                set_draft_graph_prefill_params(self.capture_sizes)
-            else:
-                set_draft_graph_params(self.capture_sizes)
 
     def capture(
         self,
@@ -93,39 +83,11 @@ class AutoRegressiveAclGraphManager(SpeculatorCudaGraphManager):
                     kv_cache_config,
                     progress_bar_desc=progress_bar_desc,
                 )
-                return
 
-            def create_forward_fn(desc: BatchExecutionDescriptor, warmup: bool):
-                num_tokens = desc.num_tokens
-                num_reqs = desc.num_reqs or min(num_tokens, self.max_num_reqs)
-                num_tokens_across_dp = (
-                    torch.full((self.dp_size,), num_tokens, dtype=torch.int32, device="cpu")
-                    if self.dp_size > 1
-                    else None
-                )
-                prepare_inputs_to_capture(
-                    num_reqs,
-                    num_tokens,
-                    model_state,
-                    input_buffers,
-                    block_tables,
-                    attn_groups,
-                    kv_cache_config,
-                    full_cudagraph=(desc.cg_mode == CUDAGraphMode.FULL),
-                )
-                seq_lens_cpu_upper_bound = input_buffers.seq_lens_cpu[:num_reqs]
-                return lambda cg_mode: forward_fn(
-                    num_reqs,
-                    cg_mode == CUDAGraphMode.PIECEWISE,
-                    BatchExecutionDescriptor(cg_mode=cg_mode, num_tokens=num_tokens, num_reqs=num_reqs),
-                    num_tokens_across_dp,
-                    seq_lens_cpu_upper_bound,
-                )
-
-            CudaGraphManager.capture(self, create_forward_fn, progress_bar_desc=progress_bar_desc)
-
-    def run_fullgraph(self, desc: BatchExecutionDescriptor) -> torch.Tensor | tuple[torch.Tensor, list[torch.Tensor]]:
-        """Replay the draft ACL graph and update its attention parameters."""
+    def run_fullgraph(self, 
+        desc: BatchExecutionDescriptor
+    ) -> torch.Tensor | tuple[torch.Tensor, list[torch.Tensor]]:
+        """Override run_fullgraph to update full graph params in run_fullgraph."""
         num_tokens = desc.num_tokens
         if self.is_draft_model_prefill:
             logger.info_once(
@@ -134,46 +96,16 @@ class AutoRegressiveAclGraphManager(SpeculatorCudaGraphManager):
         else:
             logger.info_once("AutoRegressiveAclGraphManager: draft run_fullgraph with num_tokens=%s", num_tokens)
 
-        draft_attn_metadatas = self.speculator.build_draft_attn_metadatas(desc.num_reqs, self.is_draft_model_prefill)
+        graph = self.graphs[desc]
+        assert isinstance(graph, UpdatableGraph)
+        fia_params = self.speculator.build_fia_params(
+            desc.num_reqs,
+            self.is_draft_model_prefill,
+        )
+        resolved_tasks = graph.resolve_tasks(SharedSource(fia_params))
+
+        assert self.update_stream is not None
         self.update_stream.wait_stream(torch.npu.current_stream())
-        ret = super().run_fullgraph(desc)
-
-        # Mirror vLLM's DP graph-replay token-count metadata.
-        num_tokens_across_dp = torch.full([self.speculator.dp_size], num_tokens)
-        # sfa_v1.py:AscendSFABackend.get_impl_cls reaches
-        # sfa_cp.py:resolve_sfa_impl, whose SFA CP selector reads the current
-        # ModelConfig. Publish the draft config because set_forward_context()
-        # does not update it.
-        # TODO: Remove this explicit current-config scope once ACL graph replay
-        # passes VllmConfig directly through the graph-update interfaces.
-        draft_vllm_config = self.speculator.draft_vllm_config
-        with (
-            set_current_vllm_config(draft_vllm_config),
-            set_forward_context(
-                self.speculator.model_state.attn_metadata,
-                draft_vllm_config,
-                num_tokens=num_tokens,
-                cudagraph_runtime_mode=desc.cg_mode,
-                num_tokens_across_dp=num_tokens_across_dp,
-                batch_descriptor=None,  # Full graph model don't need batch_descriptor
-                slot_mapping=None,
-            ),
-        ):
-            # Select the draft prefill/decode graph-parameter pool.
-            _EXTRA_CTX.is_draft_model = True
-            _EXTRA_CTX.is_draft_model_prefill = self.is_draft_model_prefill
-
-            forward_context = get_forward_context()
-            attn_backend = self.speculator.attn_backend
-            assert attn_backend is not None, "Speculator attention backend is not initialized"
-            update_full_graph_params(
-                # FIXME(Ronald1995): support hybrid attn backend
-                attn_backend,
-                self.update_stream,
-                forward_context,
-                num_tokens,
-                draft_vllm_config,
-                self.speculator.speculative_config,
-                draft_attn_metadatas=draft_attn_metadatas,
-            )
-        return ret
+        output = super().run_fullgraph(desc)
+        graph.update(self.update_stream, resolved_tasks)
+        return output

--- a/vllm_ascend/worker/v2/spec_decode/autoregressive/speculator.py
+++ b/vllm_ascend/worker/v2/spec_decode/autoregressive/speculator.py
@@ -165,6 +165,33 @@ class AscendAutoRegressiveSpeculator(AutoRegressiveSpeculator):
             num_tokens_across_dp,
             seq_lens_cpu_upper_bound,
         )
+    
+    def _prefill(
+        self,
+        num_reqs: int,
+        num_tokens: int,
+        attn_metadata: dict[str, Any] | None,
+        slot_mappings: dict[str, torch.Tensor] | None,
+        num_tokens_across_dp: torch.Tensor | None,
+        cudagraph_runtime_mode: CUDAGraphMode = CUDAGraphMode.NONE,
+        mm_inputs: tuple[list[torch.Tensor], torch.Tensor] | None = None,
+    ) -> None:
+        # Draft prefill reuses target metadata, but the target metadata may
+        # also contain target-only attention layers (e.g. GDN layers).
+        if attn_metadata is not None and self.draft_attn_layer_names is not None:
+            attn_metadata = {
+                name: metadata for name, metadata in attn_metadata.items() if name in self.draft_attn_layer_names
+            }
+
+        super()._prefill(
+            num_reqs,
+            num_tokens,
+            attn_metadata,
+            slot_mappings,
+            num_tokens_across_dp,
+            cudagraph_runtime_mode,
+            mm_inputs,
+        )
 
     def build_fia_params(
         self,

--- a/vllm_ascend/worker/v2/spec_decode/autoregressive/speculator.py
+++ b/vllm_ascend/worker/v2/spec_decode/autoregressive/speculator.py
@@ -16,7 +16,6 @@
 # limitations under the License.
 # This file is a part of the vllm-ascend project.
 #
-import logging
 from contextlib import contextmanager
 from copy import copy
 from typing import Any
@@ -25,40 +24,26 @@ import torch
 from vllm.config import VllmConfig, replace
 from vllm.config.compilation import CUDAGraphMode
 from vllm.v1.attention.backend import AttentionBackend
-from vllm.v1.kv_cache_interface import KVCacheConfig
-from vllm.v1.worker.gpu.block_table import BlockTables
 from vllm.v1.worker.gpu.cudagraph_utils import BatchExecutionDescriptor
-from vllm.v1.worker.gpu.input_batch import InputBatch, InputBuffers
-from vllm.v1.worker.gpu.model_states.interface import ModelState
+from vllm.v1.worker.gpu.input_batch import InputBatch
 from vllm.v1.worker.gpu.spec_decode.autoregressive.speculator import AutoRegressiveSpeculator
-from vllm.v1.worker.utils import AttentionGroup
 
-from vllm_ascend.attention.attention_v1 import AscendAttentionBackend, AscendAttentionState
-from vllm_ascend.attention.dsa_v1 import AscendDSABackend
-from vllm_ascend.attention.indexer import AscendSFAIndexerBackend
-from vllm_ascend.attention.mla_v1 import AscendMLABackend
-from vllm_ascend.attention.sfa_v1 import AscendSFABackend
-from vllm_ascend.worker.v2.aclgraph_utils import _get_graph_update_backend
-from vllm_ascend.worker.v2.attn_utils import (
-    build_attn_metadata_wrapper,
-    build_draft_attn_metadata_factory,
-)
+from vllm_ascend.worker.v2.attn_utils import build_attn_metadata_wrapper
 from vllm_ascend.worker.v2.input_batch import AscendInputBuffers
-
-logger = logging.getLogger(__name__)
 
 
 class AscendAutoRegressiveSpeculator(AutoRegressiveSpeculator):
-    """Shared Ascend spec-decode loop for AscendEagle/AscendMTPSpeculator.
+    """
+    Shared Ascend spec-decode loop for AscendEagle/AscendMTPSpeculator.
 
-    GQA, MLA, DSA, and SFA draft decode state share one path. The current MTP path
+    GQA, MLA, and DSA draft decode state share one path. The current MTP path
     uses the draft attention backend recorded by ``set_attn``.
 
     MLA's per-step state lives in ``.decode`` (cloned per step, written via an
     alias), GQA's is top-level. MLA also rebuilds the base (live ``.decode`` is
     None/wrong-batch) and forwards rotary ``positions`` into
-    build_attn_metadata. DSA and SFA manage their draft state in their metadata
-    builders and skip the generic MLA/GQA init and update logic.
+    build_attn_metadata. DSA manages its draft state in its metadata builder
+    and skips the generic MLA/GQA init and update logic.
     """
 
     def __init__(self, vllm_config: VllmConfig, device: torch.device):
@@ -70,7 +55,6 @@ class AscendAutoRegressiveSpeculator(AutoRegressiveSpeculator):
         """
         super().__init__(vllm_config, device)
 
-        self.attn_architecture: str | None = None
         self.attn_backend: type[AttentionBackend] | None = None
         self.draft_vllm_config = self._create_draft_vllm_config()
 
@@ -82,14 +66,6 @@ class AscendAutoRegressiveSpeculator(AutoRegressiveSpeculator):
             max_num_tokens=self.max_num_tokens,
             device=device,
         )
-
-        # add more attributes for `input_buffers` in graph mode
-        cudagraph_mode = self.vllm_config.compilation_config.cudagraph_mode
-        if cudagraph_mode.decode_mode() == CUDAGraphMode.FULL:
-            self.input_buffers.draft_seq_lens_cpus = [
-                torch.zeros(self.max_num_reqs, dtype=torch.int32, device="cpu")
-                for _ in range(self.num_speculative_steps - 1)
-            ]
 
         # when in decode phase of eagle speculator, we need some value in
         # draft model's input_batch. so we keep a reference here.
@@ -104,6 +80,8 @@ class AscendAutoRegressiveSpeculator(AutoRegressiveSpeculator):
 
     def init_cudagraph_manager(self, cudagraph_mode: CUDAGraphMode) -> None:
         super().init_cudagraph_manager(cudagraph_mode)
+        assert self.prefill_cudagraph_manager is not None
+        assert self.decode_cudagraph_manager is not None
         # The Ascend graph managers are patched onto the upstream module and
         # created by super().init_cudagraph_manager without a speculator ref.
         # They need this speculator to update full-graph params, so set it here.
@@ -167,315 +145,63 @@ class AscendAutoRegressiveSpeculator(AutoRegressiveSpeculator):
                 is_profile=is_profile,
             )
 
-    def set_attn(
-        self,
-        model_state: ModelState,
-        kv_cache_config: KVCacheConfig,
-        block_tables: BlockTables,
-        target_input_buffers: InputBuffers,
-        target_attn_groups: list[list[AttentionGroup]],
-    ) -> None:
-        super().set_attn(
-            model_state,
-            kv_cache_config,
-            block_tables,
-            target_input_buffers,
-            target_attn_groups,
-        )
-
-        # Use the first executable draft attention layer as the architecture
-        # discriminator and cache it for ACL graph parameter updates.
-        self.attn_backend = _get_graph_update_backend(self.attn_groups)
-        if issubclass(self.attn_backend, AscendDSABackend):
-            self.attn_architecture = "DSA"
-        elif issubclass(self.attn_backend, AscendMLABackend):
-            self.attn_architecture = "MLA"
-        elif issubclass(self.attn_backend, (AscendSFABackend, AscendSFAIndexerBackend)):
-            self.attn_architecture = "SFA"
-        elif issubclass(self.attn_backend, AscendAttentionBackend):
-            self.attn_architecture = "GQA"
-        else:
-            raise ValueError(f"Unsupported attention backend: {self.attn_backend}")
-
-    def capture(self) -> None:
-        logger.info("Capturing model for speculator...")
-        # Reset indices to zeros to prevent stale values from prior
-        # dummy runs to cause out-of-bounds indexing during capture.
-        self.last_token_indices.zero_()
-
-        # Capture the prefill routine (model forward + compute_logits +
-        # sample).
-        # For FULL graphs, the entire routine is recorded as one graph.
-        # For PIECEWISE, only the model's compiled regions are captured
-        # and the rest (compute_logits, gumbel_sample) runs eagerly.
-        assert self.prefill_cudagraph_manager is not None
-        if self.prefill_cudagraph_manager.use_breakable_cg:
-            self.prefill_cudagraph_manager.init_breakable_cg_runner(self.model)
-        self.prefill_cudagraph_manager.capture(
-            self._prefill,
-            self.model_state,
-            self.target_input_buffers,
-            self.block_tables,
-            self.target_attn_groups,
-            self.kv_cache_config,
-            progress_bar_desc="Capturing prefill CUDA graphs",
-        )
-
-        if self.num_speculative_steps == 1:
-            return
-
-        # Capture all decode draft generation steps as a single graph.
-        assert self.decode_cudagraph_manager is not None
-        with build_attn_metadata_wrapper():
-            self.decode_cudagraph_manager.capture(
-                self._multi_step_decode,
-                self.model_state,
-                self.input_buffers,
-                self.block_tables,
-                self.attn_groups,
-                self.kv_cache_config,
-                progress_bar_desc="Capturing decode CUDA graphs",
-            )
-
-    @torch.inference_mode()
-    def _run_model(
-        self,
-        num_tokens: int,
-        attn_metadata: dict[str, Any] | None,
-        slot_mappings: dict[str, torch.Tensor] | None,
-        num_tokens_across_dp: torch.Tensor | None,
-        cudagraph_runtime_mode: CUDAGraphMode = CUDAGraphMode.NONE,
-        mm_inputs: tuple[list[torch.Tensor], torch.Tensor] | None = None,
-    ) -> tuple[torch.Tensor, torch.Tensor]:
-        """Override AutoRegressiveSpeculator._run_model for Ascend NPUs."""
-        last_hidden_states, hidden_states = super()._run_model(
-            num_tokens,
-            attn_metadata,
-            slot_mappings,
-            num_tokens_across_dp,
-            cudagraph_runtime_mode,
-            mm_inputs,
-        )
-        return last_hidden_states, hidden_states
-
-    def _generate_draft(
-        self,
-        num_reqs: int,
-        num_tokens_padded: int,
-        attn_metadata: dict[str, Any] | None,
-        slot_mappings: dict[str, torch.Tensor] | None,
-        num_tokens_across_dp: torch.Tensor | None,
-        cudagraph_runtime_mode: CUDAGraphMode = CUDAGraphMode.NONE,
-    ) -> None:
-        """Thin override: delegate to upstream single-step ``_generate_draft``,
-        then apply Ascend-specific attention-metadata updates required by the
-        FIA operator."""
-        super()._generate_draft(
-            num_reqs,
-            num_tokens_padded,
-            attn_metadata,
-            slot_mappings,
-            num_tokens_across_dp,
-            cudagraph_runtime_mode,
-        )
-        if attn_metadata is not None:
-            self._update_decode_attn_metadata(attn_metadata, 1, num_reqs)
-
-    def _multi_step_decode(  # type: ignore[misc]
+    def _fused_multi_step_decode(
         self,
         num_reqs: int,
         skip_attn: bool,
         batch_desc: BatchExecutionDescriptor,
         num_tokens_across_dp: torch.Tensor | None,
-        seq_lens_cpu_upper_bound: torch.Tensor | None = None,
+        seq_lens_cpu_upper_bound: torch.Tensor,
     ) -> None:
-        """Minimal override to handle the merged multi-step graph in FULL mode.
-
-        In FULL mode the captured graph already contains all speculative
-        steps, so ``run_fullgraph`` is called once instead of once per
-        step.  For PIECEWISE / NONE modes we delegate to the upstream
-        ``_multi_step_decode`` which iterates over steps and calls
-        ``_generate_draft`` per step.
-        """
-        if batch_desc.cg_mode == CUDAGraphMode.FULL:
-            assert self.decode_cudagraph_manager is not None
-            self.decode_cudagraph_manager.run_fullgraph(batch_desc)
-            return
-        super()._multi_step_decode(num_reqs, skip_attn, batch_desc, num_tokens_across_dp, seq_lens_cpu_upper_bound)
-
-    def _prefill(
-        self,
-        num_reqs: int,
-        num_tokens: int,
-        attn_metadata: dict[str, Any] | None,
-        slot_mappings: dict[str, torch.Tensor] | None,
-        num_tokens_across_dp: torch.Tensor | None,
-        cudagraph_runtime_mode: CUDAGraphMode = CUDAGraphMode.NONE,
-        mm_inputs: tuple[list[torch.Tensor], torch.Tensor] | None = None,
-    ) -> None:
-        # Draft prefill reuses target metadata, but the target metadata may
-        # also contain target-only attention layers (e.g. GDN layers).
-        if attn_metadata is not None and self.draft_attn_layer_names is not None:
-            attn_metadata = {
-                name: metadata for name, metadata in attn_metadata.items() if name in self.draft_attn_layer_names
-            }
-
-        super()._prefill(
+        assert skip_attn or batch_desc.cg_mode == CUDAGraphMode.FULL, (
+            "Ascend fused draft decode requires a captured FULL graph, but "
+            f"got {batch_desc.cg_mode.name}. Ensure cudagraph_capture_sizes "
+            "covers this draft decode batch size."
+        )
+        super()._fused_multi_step_decode(
             num_reqs,
-            num_tokens,
-            attn_metadata,
-            slot_mappings,
+            skip_attn,
+            batch_desc,
             num_tokens_across_dp,
-            cudagraph_runtime_mode,
-            mm_inputs,
+            seq_lens_cpu_upper_bound,
         )
 
-    def _build_draft_attn_metadata(  # type: ignore[misc]
+    def build_fia_params(
         self,
-        num_reqs: int,
         num_reqs_padded: int,
-        num_tokens_padded: int,
-        seq_lens_cpu_upper_bound: torch.Tensor,
-        step: int,
-        num_query_per_req: int = 1,
-        causal: bool = True,
-    ) -> dict[str, Any] | None:
-        assert self.input_batch is not None
-        with build_draft_attn_metadata_factory(
-            self.input_buffers.positions,
-            num_tokens_padded,
-            torch.from_numpy(self.input_batch.is_prefilling_np),
-        ):
-            attn_metadata = super()._build_draft_attn_metadata(
-                num_reqs,
-                num_reqs_padded,
-                num_tokens_padded,
-                seq_lens_cpu_upper_bound,
-                step,
-                num_query_per_req,
-                causal,
-            )
-        if attn_metadata is not None:
-            # Ascend-specific: force DecodeOnly attention state for the draft model.
-            for metadata in attn_metadata.values():
-                if metadata is None:
-                    continue
-                metadata.attn_state = AscendAttentionState.DecodeOnly
-        return attn_metadata
-
-    def build_draft_attn_metadatas(self, num_reqs_padded, is_draft_model_prefill):
-        """Build draft_attn_metadatas for partial-merged draft graph."""
-        attn_metadata = self.model_state.attn_metadata
-        attn_metadata = {
-            name: metadata for name, metadata in attn_metadata.items() if name in self.draft_attn_layer_names
-        }
-
+        is_draft_model_prefill: bool,
+    ) -> list[dict[str, Any]]:
         if is_draft_model_prefill:
-            return [attn_metadata]
-
-        draft_attn_metadatas = self._init_decode_draft_attn_metadatas(attn_metadata, num_reqs_padded)
-
-        for i, per_step_attn_metadata in enumerate(draft_attn_metadatas):
-            step = i + 1
-            assert self.input_batch is not None
-            self._update_decode_attn_metadata(per_step_attn_metadata, step, self.input_batch.num_reqs)
-
-        return draft_attn_metadatas
-
-    def _init_decode_draft_attn_metadatas(self, attn_metadata: dict[str, Any] | None, num_reqs_padded: int):
-        """Initialize per-step decode attention metadata for graph mode."""
-        if attn_metadata is None:
-            return
-
-        # DSA and SFA own their per-step sparse-attention state in their
-        # metadata builders and do not use draft graph metadata updates.
-        if self.attn_architecture in ("DSA", "SFA"):
-            return []
-
-        # TODO: _build_draft_attn_metadata pulls data (seq_lens, block_table,
-        # ...) from input_buffers internally; future may pass these as CPU
-        # params directly to build_attn_metadata, decoupling from input_buffers.
-        if self.attn_architecture == "MLA":
-            assert self.input_batch is not None
-            attn_metadata = self._build_draft_attn_metadata(  # type: ignore[call-arg]
-                num_reqs=self.input_batch.num_reqs,
-                num_reqs_padded=num_reqs_padded,
-                num_tokens_padded=num_reqs_padded,  # decode: 1 token/req
-                seq_lens_cpu_upper_bound=self.input_batch.seq_lens_cpu_upper_bound,
-                step=1,
+            metadata = next(
+                metadata
+                for layer_name, metadata in self.model_state.attn_metadata.items()
+                if layer_name in self.draft_attn_layer_names
             )
-            if attn_metadata is None:
-                return
+            return [
+                {
+                    "actual_seq_lengths": metadata.query_start_loc,
+                    "actual_seq_lengths_kv": metadata.seq_lens,
+                }
+            ]
 
-        attn_state = AscendAttentionState.DecodeOnly
-
-        draft_attn_metadatas = []
-        # attn_metadata is build in vllm's super class.
-        # We need to update attn_state for each layer's metadata.
-        for seq_lens_cpu in self.input_buffers.draft_seq_lens_cpus:
-            per_step_attn_metadata = {k: copy(v) for k, v in attn_metadata.items()}
-
-            seq_lens_cpu = seq_lens_cpu[:num_reqs_padded]
-            for metadata in per_step_attn_metadata.values():
-                metadata.attn_state = attn_state
-                metadata.seq_lens_cpu = seq_lens_cpu
-                if self.attn_architecture == "MLA":
-                    # clone .decode so per-step seq_lens_list writes don't alias.
-                    metadata.decode = copy(metadata.decode)
-            draft_attn_metadatas.append(per_step_attn_metadata)
-
-        return draft_attn_metadatas
-
-    def _update_decode_attn_metadata(
-        self, attn_metadata: dict[str, Any] | None, step: int, num_reqs: int | None = None
-    ):
-        """Update per-step decode attention metadata on Ascend."""
-        if attn_metadata is None:
-            return
-
-        if self.attn_architecture in ("DSA", "SFA"):
-            return
-
-        attn_meta = next(iter(attn_metadata.values()))
-        num_reqs_padded = attn_meta.seq_lens_cpu.shape[0]
-        seq_lens_cpu = self._get_seq_lens_cpu(num_reqs_padded)
-        if num_reqs is None:
-            num_reqs = num_reqs_padded
-        next_seq_lens_cpu = self._calc_next_seq_lens_cpu(seq_lens_cpu, num_reqs, num_reqs_padded, step)
-
-        query_lens_list = [i for i in range(1, num_reqs_padded + 1)]
-        seq_lens_list = next_seq_lens_cpu.tolist()
-        for metadata in attn_metadata.values():
-            if self.attn_architecture == "MLA":
-                decode_metadata = metadata.decode
-            else:
-                decode_metadata = metadata
-            decode_metadata.seq_lens_list = seq_lens_list
-            decode_metadata.actual_seq_lengths_q = query_lens_list
-            metadata.seq_lens_cpu.copy_(next_seq_lens_cpu)
-
-    def _calc_next_seq_lens_cpu(self, seq_lens_cpu, num_reqs, num_reqs_padded, step):
-        # NOTE(drslark) to achieve fully alignment with vllm, `num_rejected` should be subtracted from `seq_lens`
-        # to avoid extra sync overhead, `v2` is currently aligned with NPU `v1` only
-
-        # follows the logic in `prepare_eagle_decode` and `update_eagle_inputs`
-        next_seqs_cpu = torch.clamp(seq_lens_cpu[:num_reqs_padded] + step, max=self.max_model_len)
-        next_seqs_cpu[num_reqs:].fill_(0)
-        return next_seqs_cpu
-
-    def _get_seq_lens_cpu(self, num_reqs_padded: int) -> torch.Tensor:
-        """Return the target sequence lengths for the padded graph batch.
-
-        ``input_batch.seq_lens_np`` can contain only the active requests.
-        During full-graph capture the draft batch can be padded to a larger
-        graph batch, so using that compact view produces a tensor that is too
-        short for ``num_reqs_padded``. The target input buffer owns the same
-        sequence lengths and retains the storage required by the padded graph
-        batch.
-        """
-        assert isinstance(self.target_input_buffers, AscendInputBuffers)
-        return self.target_input_buffers.seq_lens_cpu[:num_reqs_padded]
-
+        assert self.input_batch is not None
+        num_reqs = self.input_batch.num_reqs
+        query_start_loc = list(range(1, num_reqs_padded + 1))
+        fia_params: list[dict[str, Any]] = []
+        for step in range(1, self.num_speculative_steps):
+            seq_lens = [
+                min(int(seq_len) + step, self.max_model_len)
+                for seq_len in self.input_batch.seq_lens_np[:num_reqs]
+            ]
+            seq_lens.extend([0] * (num_reqs_padded - num_reqs))
+            fia_params.append(
+                {
+                    "actual_seq_lengths": query_start_loc,
+                    "actual_seq_lengths_kv": seq_lens,
+                }
+            )
+        return fia_params
+ 
 
 # TODO Remove this patch when cann fix the gather bug.
 # NOTE(Ronald1995): torch.gather will pollute the cache such as self.input_buffers.positions

--- a/vllm_ascend/worker/v2/utils.py
+++ b/vllm_ascend/worker/v2/utils.py
@@ -5,6 +5,7 @@ from vllm.compilation import breakable_cudagraph
 from vllm.logger import logger
 
 from vllm_ascend.compilation.acl_graph import get_draft_graph_params, get_graph_params, weak_ref_workspaces
+from vllm_ascend.compilation.updatable_graph import UpdatableGraph
 from vllm_ascend.utils import weak_ref_tensor, weak_ref_tensors
 
 
@@ -17,7 +18,7 @@ def torch_cuda_wrapper():
         torch.cuda.default_stream = torch.npu.default_stream
         torch.cuda.current_stream = torch.npu.current_stream
         torch.cuda.graph_pool_handle = torch.npu.graph_pool_handle
-        torch.cuda.CUDAGraph = torch.npu.NPUGraph
+        torch.cuda.CUDAGraph = UpdatableGraph
         torch.cuda.graph = torch_npu_graph_wrapper
         torch.cuda.synchronize = torch.npu.synchronize
         torch.cuda.set_stream = torch.npu.set_stream


### PR DESCRIPTION
**What this PR does / why we need it?**
Implements the `UpdatableGraph` design discussed in https://github.com/vllm-project/vllm-ascend/issues/13058.
Refactors the `FIA` and `Speculative Decoding` to work with the new `UpdatableGraph` design.

Manually validated on A3 with the following scenarios:

- Qwen3-0.6B with MRV1 and MRV2
- Qwen3.5-27B with MRV1 and MRV2
- Qwen3.5-35B-A3B-w8a8-mtp with MRV1 and MRV2

**Does this PR introduce any user-facing change?**
No.

**How was this patch tested?**
Temporarily validated on some model.

- vLLM main: https://github.com/vllm-project/vllm/commit/ba07e4a48fc951300d97eb506217dd530583dea3
