### PR TITLE
[v0.23.0][Bugfix][P/D] Backport rejected-request KV cleanup

### DIFF
--- a/examples/disaggregated_prefill_v1/load_balance_proxy_server_example.py
+++ b/examples/disaggregated_prefill_v1/load_balance_proxy_server_example.py
@@ -816,23 +816,24 @@ async def send_request_to_service(
 ):
     req_data = build_prefill_request(req_data)
     headers = auth_headers(request_id)
-    last_exc = None
-    for attempt in range(1, max_retries + 1):
+    max_attempts = max(1, max_retries)
+    for attempt in range(1, max_attempts + 1):
         try:
             response = await client.post(endpoint, json=req_data, headers=headers)
             response.raise_for_status()
             return response
-        except (httpx.RequestError, httpx.HTTPStatusError) as exc:
+        except httpx.HTTPStatusError as exc:
+            if exc.response.status_code == 400 or attempt == max_attempts:
+                raise
             logger.warning("Attempt %s failed for %s: %s", attempt, endpoint, exc)
-            last_exc = exc
-            if attempt < max_retries:
-                await asyncio.sleep(base_delay * (2 ** (attempt - 1)))
-            else:
-                logger.error("All %s attempts failed for %s.", max_retries, endpoint)
-                raise last_exc
+        except httpx.RequestError as exc:
+            if attempt == max_attempts:
+                raise
+            logger.warning("Attempt %s failed for %s: %s", attempt, endpoint, exc)
+        await asyncio.sleep(base_delay * (2 ** (attempt - 1)))
 
 
-async def stream_service_response_with_retry(
+async def stream_service_response(
     client: httpx.AsyncClient,
     endpoint: str,
     req_data: dict,
@@ -841,32 +842,35 @@ async def stream_service_response_with_retry(
     base_delay: float = 0.2,
 ):
     headers = auth_headers(request_id)
-    for attempt in range(1, max_retries + 1):
+    max_attempts = max(1, max_retries)
+    for attempt in range(1, max_attempts + 1):
+        first_chunk_sent = False
         try:
             async with client.stream("POST", endpoint, json=req_data, headers=headers) as response:
                 response.raise_for_status()
-                first_chunk_sent = False
                 async for chunk in response.aiter_bytes():
                     first_chunk_sent = True
                     yield chunk
                 return
-        except (httpx.RequestError, httpx.HTTPStatusError) as exc:
-            if attempt < max_retries:
-                logger.warning("Attempt %s failed for streaming %s: %s", attempt, endpoint, exc)
-                await asyncio.sleep(base_delay * (2 ** (attempt - 1)))
-            else:
-                logger.error("All %s attempts failed for streaming %s.", max_retries, endpoint)
-                raise exc
-        except Exception as exc:
-            if "first_chunk_sent" in locals() and first_chunk_sent:
+        except httpx.HTTPStatusError as exc:
+            if exc.response.status_code == 400 or attempt == max_attempts:
+                raise
+            logger.warning("Attempt %s failed for streaming %s: %s", attempt, endpoint, exc)
+        except httpx.RequestError as exc:
+            if first_chunk_sent:
                 logger.error("Streaming to client interrupted after response started: %s", exc)
                 return
-            if attempt < max_retries:
-                logger.warning("Attempt %s failed for streaming %s: %s", attempt, endpoint, exc)
-                await asyncio.sleep(base_delay * (2 ** (attempt - 1)))
-            else:
-                logger.error("All %s attempts failed for streaming %s.", max_retries, endpoint)
-                raise exc
+            if attempt == max_attempts:
+                raise
+            logger.warning("Attempt %s failed for streaming %s: %s", attempt, endpoint, exc)
+        except Exception as exc:
+            if first_chunk_sent:
+                logger.error("Streaming to client interrupted after response started: %s", exc)
+                return
+            if attempt == max_attempts:
+                raise
+            logger.warning("Attempt %s failed for streaming %s: %s", attempt, endpoint, exc)
+        await asyncio.sleep(base_delay * (2 ** (attempt - 1)))
 
 
 async def _abort_prefill_selection(
@@ -1000,7 +1004,7 @@ async def handle_completions_impl(api: str, request: Request):
                 while retry:
                     retry = False
                     decoder_client = await runtime.get_client(ServerRole.DECODE, instance_info.decoder_key)
-                    async for chunk in stream_service_response_with_retry(
+                    async for chunk in stream_service_response(
                         decoder_client,
                         api,
                         req_data,

--- a/tests/ut/kv_offload/test_mooncake_connector.py
+++ b/tests/ut/kv_offload/test_mooncake_connector.py
@@ -888,6 +888,21 @@ class TestCoreFunctionality(unittest.TestCase):
         cast(Any, self.thread.task_tracker).update_done_task_count.assert_called_once_with("req1")
         self.mock_queue.task_done.assert_called_once()
 
+    @patch.object(KVCacheRecvingThread, "_send_done_signal_to_free_remote_port")
+    @patch.object(KVCacheRecvingThread, "_send_done_recv_signal")
+    def test_handle_empty_transfer_sends_done(self, mock_send_done, mock_free_remote_port):
+        req = dict(self.test_req)
+        req["local_block_ids"] = ([],)
+        req["remote_block_ids"] = ([3, 4],)
+
+        self.thread._handle_request(req)
+
+        self.engine.batch_transfer_sync_read.assert_not_called()
+        mock_free_remote_port.assert_called_once_with("req1", "localhost", {6666: 1})
+        mock_send_done.assert_called_once_with("req1", "localhost", 6666, {6666: 1})
+        cast(Any, self.thread.task_tracker).update_done_task_count.assert_called_once_with("req1")
+        self.mock_queue.task_done.assert_called_once()
+
     @patch.object(KVCacheRecvingThread, "_get_remote_metadata")
     def test_transfer_kv_cache(self, mock_get_meta):
         with patch("vllm_ascend.distributed.kv_transfer.kv_p2p.mooncake_connector.get_ascend_config") as mock_config:
@@ -1639,6 +1654,33 @@ class TestMooncakeConnectorScheduler(unittest.TestCase):
         delay_free, params = self.scheduler.request_finished(request, [1, 2, 3])
         self.assertFalse(delay_free)
         self.assertIsNone(params)
+
+    def test_request_finished_rejected_remote_prefill_enqueues_empty_recv(self):
+        request = MockRequest(
+            "req1",
+            kv_transfer_params={
+                "do_remote_prefill": True,
+                "do_remote_decode": False,
+                "remote_block_ids": ([1, 2, 3],),
+                "remote_engine_id": "remote",
+                "remote_request_id": "remote_req1",
+                "remote_host": "localhost",
+                "remote_port": 5000,
+            },
+            status=RequestStatus.FINISHED_ABORTED,
+        )
+
+        delay_free, params = self.scheduler.request_finished(request, ([],))
+
+        self.assertFalse(delay_free)
+        self.assertIsNone(params)
+        self.assertFalse(request.kv_transfer_params["do_remote_prefill"])
+        self.assertEqual(self.scheduler._reqs_need_recv["req1"], (request, ([],), ([],), 0))
+
+        metadata = self.scheduler.build_connector_meta(MockSchedulerOutput())
+        self.assertEqual(metadata.requests["req1"].local_block_ids, ([],))
+        self.assertEqual(metadata.requests["req1"].num_external_tokens, 0)
+        self.assertEqual(metadata.requests["req1"].remote_request_id, "remote_req1")
 
     def test_get_transfer_block_ids_trims_attention_mtp_blocks(self):
         self.scheduler.group_transfer_info = [

--- a/vllm_ascend/distributed/kv_transfer/kv_p2p/mooncake_connector.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_p2p/mooncake_connector.py
@@ -1894,11 +1894,27 @@ class MooncakeConnectorScheduler:
             "MooncakeConnector request_finished, request_status=%s, kv_transfer_params=%s", request.status, params
         )
 
-        if (
-            params is None
-            or not params.get("do_remote_decode")
-            or request.status != RequestStatus.FINISHED_LENGTH_CAPPED
-        ):
+        if params is None:
+            return False, None
+
+        # A remote-prefill request can be rejected before scheduler admission
+        # (for example, when prompt + max_tokens exceeds max_model_len). In
+        # that case update_state_after_alloc() never gets a chance to schedule
+        # the receive, so explicitly enqueue an empty receive. The worker skips
+        # the data transfer for empty block IDs but still sends the completion
+        # signal to the P node, allowing it to release the stranded KV blocks.
+        if params.get("do_remote_prefill"):
+            empty_block_ids: BlockIds = tuple([] for _ in self.kv_cache_groups)
+            self._reqs_need_recv[request.request_id] = (
+                request,
+                empty_block_ids,
+                empty_block_ids,
+                0,
+            )
+            params["do_remote_prefill"] = False
+            return False, None
+
+        if not params.get("do_remote_decode") or request.status != RequestStatus.FINISHED_LENGTH_CAPPED:
             return False, None
 
         num_prompt_blocks = math.ceil(len(request.prompt_token_ids) / self.block_size)


### PR DESCRIPTION
## What this PR does

Backports #14142 (`1ba7ee4e0319e5a0333ed0e50042b91823f49c26`) to `releases/v0.23.0`.

- Enqueue an empty Mooncake receive task when a remote-prefill request is rejected or aborted before scheduler admission, so the D worker still sends `DONE_RECVING_MSG` and the P node can release delayed KV blocks.
- Do not retry HTTP 400 responses from P/D backends.
- Retry transport errors and non-400 HTTP failures with exponential backoff.
- Treat non-positive `max_retries` as one attempt.
- Do not replay a streaming request after response bytes have already been emitted.

## Why

On v0.23.0, an immediate D-side cancellation can finish a request before `update_state_after_alloc()` creates the KV receive task. The Mooncake connector then returns from `request_finished()` without notifying P, leaving P-side KV blocks in delayed-free until forced timeout cleanup.

The empty receive task performs no KV read; it only follows the normal worker completion path and sends the cleanup signal. Duplicate or late completion signals are guarded by the P-side request tracker.

## Validation

- `git diff --check upstream/releases/v0.23.0...HEAD`
- `python -m py_compile examples/disaggregated_prefill_v1/load_balance_proxy_server_example.py tests/ut/kv_offload/test_mooncake_connector.py vllm_ascend/distributed/kv_transfer/kv_p2p/mooncake_connector.py`
- Backported the original unit coverage for rejected-request cleanup and empty-transfer completion.

Ascend runtime tests were not run locally.

- vLLM main: https://github.com/vllm-project/vllm/commit/ee0da84ab9e04ac7610e28580af62c365e898389
