### PR TITLE
[v0.26.0rc][Performance] Reduce AscendStore lookup and transfer Python overhead

### DIFF
--- a/tests/ut/distributed/ascend_store/test_config_data.py
+++ b/tests/ut/distributed/ascend_store/test_config_data.py
@@ -16,9 +16,7 @@
 #
 
 import unittest
-from unittest.mock import MagicMock, patch
-
-import numpy as np
+from unittest.mock import MagicMock
 
 import tests.ut.distributed.ascend_store._mock_deps  # noqa: F401, E402
 from vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.config_data import (
@@ -296,24 +294,6 @@ class TestChunkedTokenDatabase(unittest.TestCase):
 
         self.assertEqual(addrs, [addr for addr, _ in expected])
         self.assertEqual(sizes, [size for _, size in expected])
-
-    def test_prepare_values_reuses_cached_layout_arrays(self):
-        with patch.object(np, "asarray", wraps=np.asarray) as asarray:
-            addrs, sizes = self.db.prepare_values([0, 16], [16, 24], [5, 9])
-
-        self.assertEqual(asarray.call_count, 3)
-        self.assertEqual(addrs, [[1800, 3600], [2440, 4880]])
-        self.assertEqual(sizes, [[160, 320], [80, 160]])
-
-    def test_set_group_buffers_refreshes_cached_layout_arrays(self):
-        old_layout = self.db._group_buffer_arrays[0]
-
-        self.db.set_group_buffers({0: [3000]}, {0: [640]}, {0: [1024]})
-        addrs, sizes = self.db.prepare_values([0], [16], [2])
-
-        self.assertIsNot(self.db._group_buffer_arrays[0], old_layout)
-        self.assertEqual(addrs, [[5048]])
-        self.assertEqual(sizes, [[640]])
 
     def test_prepare_values_matches_dsv4_compressed_groups(self):
         metadata = [KeyMetadata("dsv4", 0, 0, 0, 0, kv_cache_group_id=group_id) for group_id in range(3)]

--- a/tests/ut/distributed/ascend_store/test_config_data.py
+++ b/tests/ut/distributed/ascend_store/test_config_data.py
@@ -16,7 +16,9 @@
 #
 
 import unittest
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
+
+import numpy as np
 
 import tests.ut.distributed.ascend_store._mock_deps  # noqa: F401, E402
 from vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.config_data import (
@@ -294,6 +296,24 @@ class TestChunkedTokenDatabase(unittest.TestCase):
 
         self.assertEqual(addrs, [addr for addr, _ in expected])
         self.assertEqual(sizes, [size for _, size in expected])
+
+    def test_prepare_values_reuses_cached_layout_arrays(self):
+        with patch.object(np, "asarray", wraps=np.asarray) as asarray:
+            addrs, sizes = self.db.prepare_values([0, 16], [16, 24], [5, 9])
+
+        self.assertEqual(asarray.call_count, 3)
+        self.assertEqual(addrs, [[1800, 3600], [2440, 4880]])
+        self.assertEqual(sizes, [[160, 320], [80, 160]])
+
+    def test_set_group_buffers_refreshes_cached_layout_arrays(self):
+        old_layout = self.db._group_buffer_arrays[0]
+
+        self.db.set_group_buffers({0: [3000]}, {0: [640]}, {0: [1024]})
+        addrs, sizes = self.db.prepare_values([0], [16], [2])
+
+        self.assertIsNot(self.db._group_buffer_arrays[0], old_layout)
+        self.assertEqual(addrs, [[5048]])
+        self.assertEqual(sizes, [[640]])
 
     def test_prepare_values_matches_dsv4_compressed_groups(self):
         metadata = [KeyMetadata("dsv4", 0, 0, 0, 0, kv_cache_group_id=group_id) for group_id in range(3)]

--- a/tests/ut/distributed/ascend_store/test_config_data.py
+++ b/tests/ut/distributed/ascend_store/test_config_data.py
@@ -144,6 +144,20 @@ class TestChunkedTokenDatabase(unittest.TestCase):
         self.assertEqual(len(result), 2)
         self.assertEqual(result[0][0], 16)
 
+    def test_process_token_hashes_skips_key_construction(self):
+        hashes = ["a", "b", "c"]
+
+        result = list(self.db.process_token_hashes(48, hashes, mask_num=16))
+
+        self.assertEqual(result, [(16, 32, "b"), (32, 48, "c")])
+
+    def test_process_tokens_with_unaligned_mask_starts_at_next_chunk(self):
+        hashes = ["a", "b", "c"]
+
+        result = list(self.db.process_tokens(48, hashes, mask_num=17))
+
+        self.assertEqual([(start, end) for start, end, _ in result], [(32, 48)])
+
     def test_process_tokens_with_tail_clipped_block_ids_maps_tail_chunks(self):
         db = ChunkedTokenDatabase([self.meta], block_size=[128], partitions=None)
         hashes = [bytes([idx % 251]) * 32 for idx in range(128)]

--- a/tests/ut/distributed/ascend_store/test_config_data.py
+++ b/tests/ut/distributed/ascend_store/test_config_data.py
@@ -281,6 +281,67 @@ class TestChunkedTokenDatabase(unittest.TestCase):
         self.assertEqual(size[0], 160)
         self.assertEqual(size[1], 320)
 
+    def test_prepare_values_matches_scalar_results(self):
+        starts = [0, 16]
+        ends = [16, 24]
+        block_ids = [5, 9]
+
+        addrs, sizes = self.db.prepare_values(starts, ends, block_ids)
+        expected = [
+            self.db.prepare_value(start, end, [], block_id=block_id)[:2]
+            for start, end, block_id in zip(starts, ends, block_ids, strict=True)
+        ]
+
+        self.assertEqual(addrs, [addr for addr, _ in expected])
+        self.assertEqual(sizes, [size for _, size in expected])
+
+    def test_prepare_values_matches_dsv4_compressed_groups(self):
+        metadata = [KeyMetadata("dsv4", 0, 0, 0, 0, kv_cache_group_id=group_id) for group_id in range(3)]
+        db = ChunkedTokenDatabase(metadata, [128, 128, 128], None, hash_block_size=128)
+        db.set_group_buffers(
+            {0: [1000, 2000], 1: [3000], 2: [4000, 5000]},
+            {0: [256, 512], 1: [1024], 2: [2048, 4096]},
+            {0: [300, 600], 1: [1200], 2: [2400, 4800]},
+            group_cache_families={0: "c1", 1: "c4", 2: "c128"},
+        )
+        hashes = [f"h{index}" for index in range(1024)]
+        expected_chunks = [1024, 256, 8]
+
+        for group_id, chunk_count in enumerate(expected_chunks):
+            block_ids = list(range(chunk_count))
+            chunks = list(
+                db.process_token_key_strings_with_block_ids(
+                    128 * 1024,
+                    hashes,
+                    block_ids,
+                    kv_cache_group_id=group_id,
+                )
+            )
+            starts = [chunk[0] for chunk in chunks]
+            ends = [chunk[1] for chunk in chunks]
+            resolved_block_ids = [chunk[4] for chunk in chunks]
+            addrs, sizes = db.prepare_values(
+                starts,
+                ends,
+                resolved_block_ids,
+                kv_cache_group_id=group_id,
+            )
+            scalar = [
+                db.prepare_value(start, end, [], kv_cache_group_id=group_id, block_id=block_id)[:2]
+                for start, end, block_id in zip(starts, ends, resolved_block_ids, strict=True)
+            ]
+
+            self.assertEqual(len(chunks), chunk_count)
+            self.assertEqual(addrs, [addr for addr, _ in scalar])
+            self.assertEqual(sizes, [size for _, size in scalar])
+
+    def test_prepare_values_empty(self):
+        self.assertEqual(self.db.prepare_values([], [], []), ([], []))
+
+    def test_prepare_values_rejects_mismatched_inputs(self):
+        with self.assertRaisesRegex(ValueError, "must have the same length"):
+            self.db.prepare_values([0], [16], [])
+
     def test_prepare_value_layer(self):
         addr, size, block_id = self.db.prepare_value_layer(0, 16, [5, 6], layer_id=0)
         self.assertEqual(block_id, 5)

--- a/tests/ut/distributed/ascend_store/test_coordinator.py
+++ b/tests/ut/distributed/ascend_store/test_coordinator.py
@@ -161,6 +161,26 @@ class TestAscendStoreCoordinator(unittest.TestCase):
 
         self.assertEqual(hit_length, 0)
 
+    def test_hit_length_only_does_not_materialize_masks(self):
+        coord = AscendStoreCoordinator(
+            [KVCacheGroupSpec(["layer.0"], _full_spec(128))],
+            scheduler_block_size=128,
+            hash_block_size=128,
+            group_block_sizes=[128],
+            group_cache_families=["c1"],
+        )
+
+        with patch.object(coord, "_find_hit_blocks", return_value=(([],), 128)) as find_hit_blocks:
+            hit_length = coord.find_longest_cache_hit_length(
+                _hashes(1),
+                128,
+                ExternalCachedBlockPool(128),
+                apply_eagle=False,
+            )
+
+        self.assertEqual(hit_length, 128)
+        self.assertFalse(find_hit_blocks.call_args.kwargs["apply_eagle"])
+
     def test_store_mask_uses_manager_reachability(self):
         coord = AscendStoreCoordinator(
             [KVCacheGroupSpec(["layer.0"], _sliding_spec(block_size=128, sliding_window=256))],

--- a/tests/ut/distributed/ascend_store/test_kv_transfer.py
+++ b/tests/ut/distributed/ascend_store/test_kv_transfer.py
@@ -456,6 +456,7 @@ class TestKVCacheStoreSendingThread(unittest.TestCase):
 
     def test_handle_request_puts_missing_keys(self):
         t, store = self._make_thread([1, 0, 1, 0])
+        t.token_database.prepare_values = MagicMock(wraps=t.token_database.prepare_values)
         req = ReqMeta(
             req_id="r1",
             token_len_chunk=64,
@@ -467,8 +468,16 @@ class TestKVCacheStoreSendingThread(unittest.TestCase):
         t.request_queue.put(req)
         t._handle_request(req)
         self.assertEqual(len(store.put_calls), 1)
-        keys, _, _ = store.put_calls[0]
+        keys, addrs, sizes = store.put_calls[0]
         self.assertEqual(len(keys), 2)
+        self.assertEqual(addrs, [[1001], [1003]])
+        self.assertEqual(sizes, [[16], [16]])
+        t.token_database.prepare_values.assert_called_once_with(
+            [16, 48],
+            [32, 64],
+            [1, 3],
+            kv_cache_group_id=0,
+        )
 
     def test_handle_request_all_exist_no_put(self):
         t, store = self._make_thread([1, 1])
@@ -748,6 +757,54 @@ class TestKVCacheStoreRecvingThread(unittest.TestCase):
         t._handle_request(req)
         keys, _, _ = store.get_calls[0]
         self.assertEqual(len(keys), 1)
+
+    def test_handle_request_batches_values_per_group_in_order(self):
+        store = FakeStore()
+        db = ChunkedTokenDatabase(
+            [KeyMetadata("m", 0, 0, 0, 0), KeyMetadata("m", 0, 0, 0, 0, kv_cache_group_id=1)],
+            [16, 32],
+            None,
+            hash_block_size=16,
+        )
+        db.set_group_buffers(
+            {0: [1000], 1: [2000]},
+            {0: [16], 1: [32]},
+            {0: [16], 1: [32]},
+            group_num_layers={0: 1, 1: 1},
+        )
+        db.prepare_values = MagicMock(wraps=db.prepare_values)
+        t = KVCacheStoreRecvingThread(
+            m_store=store,
+            token_database=db,
+            block_size=[16, 32],
+            tp_rank=0,
+            dcp_size=1,
+            ready_event=threading.Event(),
+            invalid_block_ids=set(),
+            invalid_block_ids_lock=threading.Lock(),
+        )
+        load_spec = LoadSpec(vllm_cached_tokens=0, kvpool_cached_tokens=32, can_load=True, token_len=32)
+        req = ReqMeta(
+            req_id="r1",
+            token_len_chunk=32,
+            block_ids_by_group=[[1, 2], [3]],
+            block_hashes=[b"h0", b"h1"],  # type: ignore[arg-type]
+            load_spec=load_spec,
+            kv_cache_group_ids=[0, 1],
+        )
+
+        t.request_queue.put(req)
+        t._handle_request(req)
+
+        keys, addrs, sizes = store.get_calls[0]
+        self.assertEqual(len(keys), 3)
+        self.assertEqual(addrs, [[1016], [1032], [2096]])
+        self.assertEqual(sizes, [[16], [16], [32]])
+        self.assertEqual(db.prepare_values.call_count, 2)
+        self.assertEqual(
+            [call.kwargs["kv_cache_group_id"] for call in db.prepare_values.call_args_list],
+            [0, 1],
+        )
 
 
 @unittest.skip("LayerMultiBlockReqMeta API is deprecated, tests need update for LayerTransferTask")

--- a/tests/ut/distributed/ascend_store/test_kv_transfer.py
+++ b/tests/ut/distributed/ascend_store/test_kv_transfer.py
@@ -74,6 +74,16 @@ class FakeTokenDatabase(ChunkedTokenDatabase):
         self.set_group_buffers({0: [1000]}, {0: [block_size]}, {0: [1]}, group_num_layers={0: 1})
 
 
+class CountingBlockHash:
+    def __init__(self, value: int):
+        self.value = value
+        self.hex_calls = 0
+
+    def hex(self):
+        self.hex_calls += 1
+        return f"{self.value:064x}"
+
+
 class MaskedFakeTokenDatabase(FakeTokenDatabase):
     def __init__(self, block_size=16, masks=([True],)):
         super().__init__(block_size)
@@ -492,6 +502,61 @@ class TestKVCacheStoreSendingThread(unittest.TestCase):
         t.request_queue.put(req)
         t._handle_request(req)
         self.assertEqual(len(store.put_calls), 0)
+
+    def test_handle_request_reuses_serialized_hashes_across_cache_families(self):
+        metadata = [KeyMetadata("dsv4", 0, 0, 0, 0, kv_cache_group_id=group_id) for group_id in range(3)]
+        db = ChunkedTokenDatabase(metadata, [16, 16, 16], None, hash_block_size=16)
+        db.set_group_buffers(
+            {0: [1000], 1: [2000], 2: [3000]},
+            {0: [16], 1: [16], 2: [16]},
+            {0: [16], 1: [16], 2: [16]},
+            group_cache_families={0: "c1", 1: "c4", 2: "c128"},
+            group_num_layers={0: 1, 1: 1, 2: 1},
+        )
+        store = FakeStore()
+        thread = KVCacheStoreSendingThread(
+            m_store=store,
+            token_database=db,
+            block_size=[16, 16, 16],
+            tp_rank=0,
+            tp_size=4,
+            dcp_size=1,
+            put_step=1,
+            kv_role="kv_producer",
+            ready_event=threading.Event(),
+            group_uses_align_state=[False, False, False],
+        )
+        block_hashes = [CountingBlockHash(index) for index in range(128)]
+        req = ReqMeta(
+            req_id="r1",
+            token_len_chunk=128 * 16,
+            block_ids_by_group=[list(range(128)), list(range(32)), [0]],
+            block_hashes=block_hashes,  # type: ignore[arg-type]
+            kv_cache_group_ids=[0, 1, 2],
+        )
+        thread.add_stored_request(req.req_id)
+        thread.request_queue.put(req)
+
+        thread._handle_request(req)
+
+        self.assertEqual(len(store.put_calls), 3)
+        self.assertTrue(all(block_hash.hex_calls == 1 for block_hash in block_hashes))
+
+        late_hashes = [CountingBlockHash(index) for index in range(128)]
+        late_req = ReqMeta(
+            req_id="r2",
+            token_len_chunk=128 * 16,
+            save_start_token=120 * 16,
+            block_ids_by_group=[list(range(128)), list(range(32)), [0]],
+            block_hashes=late_hashes,  # type: ignore[arg-type]
+            kv_cache_group_ids=[0, 1, 2],
+        )
+        thread.add_stored_request(late_req.req_id)
+        thread.request_queue.put(late_req)
+
+        thread._handle_request(late_req)
+
+        self.assertTrue(all(block_hash.hex_calls == 0 for block_hash in late_hashes[:120]))
 
     def test_handle_request_starts_at_unsaved_watermark(self):
         t, store = self._make_thread([0, 0])

--- a/tests/ut/distributed/ascend_store/test_kv_transfer.py
+++ b/tests/ut/distributed/ascend_store/test_kv_transfer.py
@@ -74,16 +74,6 @@ class FakeTokenDatabase(ChunkedTokenDatabase):
         self.set_group_buffers({0: [1000]}, {0: [block_size]}, {0: [1]}, group_num_layers={0: 1})
 
 
-class CountingBlockHash:
-    def __init__(self, value: int):
-        self.value = value
-        self.hex_calls = 0
-
-    def hex(self):
-        self.hex_calls += 1
-        return f"{self.value:064x}"
-
-
 class MaskedFakeTokenDatabase(FakeTokenDatabase):
     def __init__(self, block_size=16, masks=([True],)):
         super().__init__(block_size)
@@ -502,61 +492,6 @@ class TestKVCacheStoreSendingThread(unittest.TestCase):
         t.request_queue.put(req)
         t._handle_request(req)
         self.assertEqual(len(store.put_calls), 0)
-
-    def test_handle_request_reuses_serialized_hashes_across_cache_families(self):
-        metadata = [KeyMetadata("dsv4", 0, 0, 0, 0, kv_cache_group_id=group_id) for group_id in range(3)]
-        db = ChunkedTokenDatabase(metadata, [16, 16, 16], None, hash_block_size=16)
-        db.set_group_buffers(
-            {0: [1000], 1: [2000], 2: [3000]},
-            {0: [16], 1: [16], 2: [16]},
-            {0: [16], 1: [16], 2: [16]},
-            group_cache_families={0: "c1", 1: "c4", 2: "c128"},
-            group_num_layers={0: 1, 1: 1, 2: 1},
-        )
-        store = FakeStore()
-        thread = KVCacheStoreSendingThread(
-            m_store=store,
-            token_database=db,
-            block_size=[16, 16, 16],
-            tp_rank=0,
-            tp_size=4,
-            dcp_size=1,
-            put_step=1,
-            kv_role="kv_producer",
-            ready_event=threading.Event(),
-            group_uses_align_state=[False, False, False],
-        )
-        block_hashes = [CountingBlockHash(index) for index in range(128)]
-        req = ReqMeta(
-            req_id="r1",
-            token_len_chunk=128 * 16,
-            block_ids_by_group=[list(range(128)), list(range(32)), [0]],
-            block_hashes=block_hashes,  # type: ignore[arg-type]
-            kv_cache_group_ids=[0, 1, 2],
-        )
-        thread.add_stored_request(req.req_id)
-        thread.request_queue.put(req)
-
-        thread._handle_request(req)
-
-        self.assertEqual(len(store.put_calls), 3)
-        self.assertTrue(all(block_hash.hex_calls == 1 for block_hash in block_hashes))
-
-        late_hashes = [CountingBlockHash(index) for index in range(128)]
-        late_req = ReqMeta(
-            req_id="r2",
-            token_len_chunk=128 * 16,
-            save_start_token=120 * 16,
-            block_ids_by_group=[list(range(128)), list(range(32)), [0]],
-            block_hashes=late_hashes,  # type: ignore[arg-type]
-            kv_cache_group_ids=[0, 1, 2],
-        )
-        thread.add_stored_request(late_req.req_id)
-        thread.request_queue.put(late_req)
-
-        thread._handle_request(late_req)
-
-        self.assertTrue(all(block_hash.hex_calls == 0 for block_hash in late_hashes[:120]))
 
     def test_handle_request_starts_at_unsaved_watermark(self):
         t, store = self._make_thread([0, 0])

--- a/tests/ut/distributed/ascend_store/test_kv_transfer.py
+++ b/tests/ut/distributed/ascend_store/test_kv_transfer.py
@@ -484,6 +484,48 @@ class TestKVCacheStoreSendingThread(unittest.TestCase):
         t._handle_request(req)
         self.assertEqual(len(store.put_calls), 0)
 
+    def test_handle_request_starts_at_unsaved_watermark(self):
+        t, store = self._make_thread([0, 0])
+        req = ReqMeta(
+            req_id="r1",
+            token_len_chunk=64,
+            save_start_token=32,
+            block_ids=[0, 1, 2, 3],
+            block_hashes=[b"h0", b"h1", b"h2", b"h3"],  # type: ignore[arg-type]
+            current_event=None,
+        )
+        t.add_stored_request("r1")
+        t.request_queue.put(req)
+
+        t._handle_request(req)
+
+        keys, addrs, _ = store.put_calls[0]
+        self.assertEqual(len(keys), 2)
+        self.assertTrue(keys[0].endswith("@6832"))
+        self.assertTrue(keys[1].endswith("@6833"))
+        self.assertEqual(addrs, [[1002], [1003]])
+
+    def test_handle_request_applies_raw_watermark_to_compressed_group(self):
+        t, store = self._make_thread([0])
+        t.token_database.group_cache_families["kv"][0] = "c4"
+        req = ReqMeta(
+            req_id="r1",
+            token_len_chunk=128,
+            save_start_token=64,
+            block_ids=[0, 1],
+            block_hashes=[f"h{i}" for i in range(8)],
+            current_event=None,
+        )
+        t.add_stored_request("r1")
+        t.request_queue.put(req)
+
+        t._handle_request(req)
+
+        keys, addrs, _ = store.put_calls[0]
+        self.assertEqual(len(keys), 1)
+        self.assertTrue(keys[0].endswith("@h7"))
+        self.assertEqual(addrs, [[1001]])
+
     def test_handle_request_not_in_stored(self):
         t, store = self._make_thread([0])
         req = ReqMeta(

--- a/tests/ut/distributed/ascend_store/test_pool_worker.py
+++ b/tests/ut/distributed/ascend_store/test_pool_worker.py
@@ -145,15 +145,16 @@ class TestKVPoolWorkerHelpers(unittest.TestCase):
         worker.cache_coordinator.lcm_block_size = 128
         worker.cache_coordinator.lookup_mask.return_value = ([True],)
         worker.cache_coordinator.store_mask.return_value = ([False],)
-        worker.cache_coordinator.find_longest_cache_hit.return_value = ((), 128)
+        worker.cache_coordinator.find_longest_cache_hit_length.return_value = 128
         worker.m_store = MagicMock()
         worker.m_store.exists.return_value = [1]
 
         worker.token_database = MagicMock()
         worker.token_database.get_block_size.return_value = 128
+        worker.token_database.get_key_prefix.return_value = "prefix@"
         worker.token_database.group_cache_families = {"kv": {0: "default"}}
-        worker.token_database.process_token_key_strings.side_effect = lambda *args, chunk_filter, **kwargs: (
-            [(0, 128, "key", "ab" * 32)] if chunk_filter(0) else []
+        worker.token_database.process_token_hashes.side_effect = lambda *args, chunk_filter, **kwargs: (
+            [(0, 128, "ab" * 32)] if chunk_filter(0) else []
         )
 
         hit = worker._lookup_with_coordinator(
@@ -167,10 +168,46 @@ class TestKVPoolWorkerHelpers(unittest.TestCase):
         self.assertEqual(hit, 128)
         worker.cache_coordinator.lookup_mask.assert_called_once_with(128)
         worker.cache_coordinator.store_mask.assert_not_called()
-        worker.m_store.exists.assert_called_once_with(["key"])
-        worker.cache_coordinator.find_longest_cache_hit.assert_called_once()
-        self.assertFalse(worker.cache_coordinator.find_longest_cache_hit.call_args.kwargs["apply_eagle"])
+        worker.m_store.exists.assert_called_once_with(["prefix@" + "ab" * 32])
+        worker.cache_coordinator.find_longest_cache_hit_length.assert_called_once()
+        self.assertFalse(worker.cache_coordinator.find_longest_cache_hit_length.call_args.kwargs["apply_eagle"])
         worker.token_database.process_tokens.assert_not_called()
+
+    def test_external_coordinator_lookup_expands_rank_prefix_once(self):
+        cls = self._make_worker_class()
+        worker = object.__new__(cls)
+        worker.hash_block_size = 128
+        worker.num_kv_cache_groups = 1
+        worker.cache_coordinator = MagicMock()
+        worker.cache_coordinator.lcm_block_size = 128
+        worker.cache_coordinator.lookup_mask.return_value = (None,)
+        worker.cache_coordinator.find_longest_cache_hit_length.return_value = 256
+        worker.m_store = MagicMock()
+        worker.m_store.exists.return_value = [1, 1, 1, 1]
+        worker._expand_lookup_keys_by_rank = MagicMock(return_value=["rank0@", "rank1@"])  # type: ignore[method-assign]
+
+        worker.token_database = MagicMock()
+        worker.token_database.get_block_size.return_value = 128
+        worker.token_database.get_key_prefix.return_value = "local@"
+        worker.token_database.group_cache_families = {"kv": {0: "default"}}
+        worker.token_database.process_token_hashes.return_value = [
+            (0, 128, "aa" * 32),
+            (128, 256, "bb" * 32),
+        ]
+
+        hit = worker._lookup_with_coordinator(
+            256,
+            [b"h0", b"h1"],
+            [0],
+            use_layerwise=False,
+            include_all_ranks=True,
+        )
+
+        self.assertEqual(hit, 256)
+        worker._expand_lookup_keys_by_rank.assert_called_once_with(["local@"], 0)
+        worker.m_store.exists.assert_called_once_with(
+            ["rank0@" + "aa" * 32, "rank1@" + "aa" * 32, "rank0@" + "bb" * 32, "rank1@" + "bb" * 32]
+        )
 
     def test_layerwise_multi_group_layout_includes_mtp(self):
         import torch

--- a/tests/ut/distributed/ascend_store/test_pool_worker.py
+++ b/tests/ut/distributed/ascend_store/test_pool_worker.py
@@ -136,6 +136,39 @@ class TestKVPoolWorkerHelpers(unittest.TestCase):
         hits = [[16, 32, 48], [32, 48], [16, 32], [32, 48, 64]]
         self.assertEqual(32, cls._max_intersection_hit_position(hits))
 
+    def test_build_lookup_keys_can_skip_starts(self):
+        cls = self._make_worker_class()
+        worker = object.__new__(cls)
+        worker.token_database = MagicMock()
+        worker.token_database.process_token_key_strings.return_value = [
+            (0, 16, "key0", "hash0"),
+            (16, 32, "key1", "hash1"),
+        ]
+
+        keys, starts, ends = worker._build_lookup_keys(32, ["hash0", "hash1"], 0, False, need_starts=False)
+
+        self.assertEqual(keys, ["key0", "key1"])
+        self.assertEqual(starts, [])
+        self.assertEqual(ends, [16, 32])
+
+    def test_expand_lookup_keys_by_rank_preserves_order(self):
+        cls = self._make_worker_class()
+        worker = object.__new__(cls)
+        worker.pp_size = 2
+        worker.get_group_tp_size = MagicMock(return_value=2)
+        keys = [
+            "model@pcp0@dcp0@head_or_tp_rank:0@pp_rank:0@group:0@cache_role:kv@cache_family:default@hash0",
+            "model@pcp0@dcp0@head_or_tp_rank:0@pp_rank:0@group:0@cache_role:kv@cache_family:default@hash1",
+        ]
+        expected = []
+        for pp_rank in range(2):
+            for tp_rank in range(2):
+                for key in keys:
+                    tp_key = cls._replace_key_field(key, "head_or_tp_rank", tp_rank)
+                    expected.append(cls._replace_key_field(tp_key, "pp_rank", pp_rank))
+
+        self.assertEqual(worker._expand_lookup_keys_by_rank(keys, 0), expected)
+
     def test_external_coordinator_lookup_uses_only_lookup_mask(self):
         cls = self._make_worker_class()
         worker = object.__new__(cls)
@@ -679,6 +712,7 @@ class TestKVPoolWorkerRegisterAndTransfer(unittest.TestCase):
         worker.m_store.get = MagicMock()
         # Setup token database
         worker.token_database.set_group_buffers({0: [1000, 2000]}, {0: [160]})
+        worker.token_database.prepare_values = MagicMock(wraps=worker.token_database.prepare_values)
 
         load_spec = LoadSpec(vllm_cached_tokens=0, kvpool_cached_tokens=16, can_load=True, token_len=16)
         req = ReqMeta(
@@ -692,6 +726,7 @@ class TestKVPoolWorkerRegisterAndTransfer(unittest.TestCase):
         meta.add_request(req)
         worker.start_load_kv(meta)
         worker.m_store.get.assert_called_once()
+        worker.token_database.prepare_values.assert_called_once_with([0], [16], [0], kv_cache_group_id=0)
 
     def test_start_load_kv_sync_uses_tail_block_id(self):
         worker = self._make_worker()

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/config_data.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/config_data.py
@@ -432,6 +432,38 @@ class ChunkedTokenDatabase:
             size_list.append(size)
         return addr_list, size_list, block_id
 
+    def prepare_values(
+        self,
+        starts: Sequence[int],
+        ends: Sequence[int],
+        block_ids: Sequence[int],
+        kv_cache_group_id: int = 0,
+        cache_role: str = "kv",
+    ) -> tuple[list[list[int]], list[list[int]]]:
+        """Prepare transfer addresses and sizes for a batch of cache blocks."""
+        if not (len(starts) == len(ends) == len(block_ids)):
+            raise ValueError("starts, ends and block_ids must have the same length")
+        if len(block_ids) == 0:
+            return [], []
+
+        group_addrs, group_block_len, group_block_stride = self._get_group_buffers(kv_cache_group_id, cache_role)
+        if not group_block_len:
+            return ([[] for _ in block_ids], [[] for _ in block_ids])
+
+        entry_indices = np.arange(len(group_addrs)) % len(group_block_len)
+        base_addrs = np.asarray(group_addrs, dtype=np.int64)
+        block_lens = np.asarray(group_block_len, dtype=np.int64)[entry_indices]
+        block_strides = (
+            np.asarray(group_block_stride, dtype=np.int64)[entry_indices] if group_block_stride else block_lens
+        )
+        block_ids_array = np.asarray(block_ids, dtype=np.int64)
+        token_spans = np.asarray(ends, dtype=np.int64) - np.asarray(starts, dtype=np.int64)
+        group_block_size = self.get_block_size(kv_cache_group_id)
+
+        addrs = base_addrs[None, :] + block_ids_array[:, None] * block_strides[None, :]
+        sizes = token_spans[:, None] * block_lens[None, :] // group_block_size
+        return addrs.tolist(), sizes.tolist()
+
     def prepare_block_info(self, start: int, end: int, block_ids: list[int]) -> tuple[int, list[int]]:
         block_size = self.block_size[0]
         block_id = block_ids[start // block_size]

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/config_data.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/config_data.py
@@ -266,7 +266,6 @@ class ChunkedTokenDatabase:
         self.group_kv_caches_base_addr: dict[int, list[int]] = {}
         self.group_block_len: dict[int, list[int]] = {}
         self.group_block_stride: dict[int, list[int]] = {}
-        self._group_buffer_arrays: dict[int, tuple[np.ndarray, np.ndarray, np.ndarray]] = {}
         self.group_layer_cache_entry_offsets: dict[int, list[int]] = {}
         self.group_cache_families: dict[str, dict[int, str]] = {
             "kv": {},
@@ -386,23 +385,6 @@ class ChunkedTokenDatabase:
             self.group_block_len = group_block_len
             self.group_block_stride = group_block_stride or {}
             self.group_layer_cache_entry_offsets = group_layer_cache_entry_offsets or {}
-            self._group_buffer_arrays = {}
-            for group_id, group_addrs in group_kv_caches_base_addr.items():
-                block_lens = group_block_len.get(group_id, [])
-                if not block_lens:
-                    continue
-                entry_indices = np.arange(len(group_addrs)) % len(block_lens)
-                base_addrs_array = np.asarray(group_addrs, dtype=np.int64)
-                block_lens_array = np.asarray(block_lens, dtype=np.int64)[entry_indices]
-                block_strides = self.group_block_stride.get(group_id)
-                block_strides_array = (
-                    np.asarray(block_strides, dtype=np.int64)[entry_indices] if block_strides else block_lens_array
-                )
-                self._group_buffer_arrays[group_id] = (
-                    base_addrs_array,
-                    block_lens_array,
-                    block_strides_array,
-                )
         if group_cache_families is not None:
             self.group_cache_families[cache_role] = group_cache_families.copy()
             self._key_prefix_cache.clear()
@@ -464,13 +446,16 @@ class ChunkedTokenDatabase:
         if len(block_ids) == 0:
             return [], []
 
-        if cache_role == "state":
-            return ([[] for _ in block_ids], [[] for _ in block_ids])
-        layout = self._group_buffer_arrays.get(kv_cache_group_id)
-        if layout is None:
+        group_addrs, group_block_len, group_block_stride = self._get_group_buffers(kv_cache_group_id, cache_role)
+        if not group_block_len:
             return ([[] for _ in block_ids], [[] for _ in block_ids])
 
-        base_addrs, block_lens, block_strides = layout
+        entry_indices = np.arange(len(group_addrs)) % len(group_block_len)
+        base_addrs = np.asarray(group_addrs, dtype=np.int64)
+        block_lens = np.asarray(group_block_len, dtype=np.int64)[entry_indices]
+        block_strides = (
+            np.asarray(group_block_stride, dtype=np.int64)[entry_indices] if group_block_stride else block_lens
+        )
         block_ids_array = np.asarray(block_ids, dtype=np.int64)
         token_spans = np.asarray(ends, dtype=np.int64) - np.asarray(starts, dtype=np.int64)
         group_block_size = self.get_block_size(kv_cache_group_id)
@@ -649,7 +634,6 @@ class ChunkedTokenDatabase:
     ) -> Iterable[tuple[int, int, str, BlockHash | str, int]]:
         """Yield cache key strings and resolved block ids without PoolKey allocation."""
         prefix = self.get_key_prefix(kv_cache_group_id)
-        hashes_are_strings = bool(block_hashes) and isinstance(block_hashes[0], str)
         for start, end, hash_val, block_id in self._iter_token_chunks(
             token_len,
             block_hashes,
@@ -662,8 +646,7 @@ class ChunkedTokenDatabase:
             shard_size=shard_size,
         ):
             assert block_id is not None
-            hash_string = hash_val if hashes_are_strings else block_hash_to_str(hash_val)
-            yield start, end, prefix + hash_string, hash_val, block_id
+            yield start, end, prefix + block_hash_to_str(hash_val), hash_val, block_id
 
     def decode_adaptor_prefill_pp(self, key, addr, size, kv_cache_group_id: int = 0, cache_role: str = "kv"):
         if self.partitions is None or len(self.partitions) == 1:

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/config_data.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/config_data.py
@@ -266,6 +266,7 @@ class ChunkedTokenDatabase:
         self.group_kv_caches_base_addr: dict[int, list[int]] = {}
         self.group_block_len: dict[int, list[int]] = {}
         self.group_block_stride: dict[int, list[int]] = {}
+        self._group_buffer_arrays: dict[int, tuple[np.ndarray, np.ndarray, np.ndarray]] = {}
         self.group_layer_cache_entry_offsets: dict[int, list[int]] = {}
         self.group_cache_families: dict[str, dict[int, str]] = {
             "kv": {},
@@ -385,6 +386,23 @@ class ChunkedTokenDatabase:
             self.group_block_len = group_block_len
             self.group_block_stride = group_block_stride or {}
             self.group_layer_cache_entry_offsets = group_layer_cache_entry_offsets or {}
+            self._group_buffer_arrays = {}
+            for group_id, group_addrs in group_kv_caches_base_addr.items():
+                block_lens = group_block_len.get(group_id, [])
+                if not block_lens:
+                    continue
+                entry_indices = np.arange(len(group_addrs)) % len(block_lens)
+                base_addrs_array = np.asarray(group_addrs, dtype=np.int64)
+                block_lens_array = np.asarray(block_lens, dtype=np.int64)[entry_indices]
+                block_strides = self.group_block_stride.get(group_id)
+                block_strides_array = (
+                    np.asarray(block_strides, dtype=np.int64)[entry_indices] if block_strides else block_lens_array
+                )
+                self._group_buffer_arrays[group_id] = (
+                    base_addrs_array,
+                    block_lens_array,
+                    block_strides_array,
+                )
         if group_cache_families is not None:
             self.group_cache_families[cache_role] = group_cache_families.copy()
             self._key_prefix_cache.clear()
@@ -446,16 +464,13 @@ class ChunkedTokenDatabase:
         if len(block_ids) == 0:
             return [], []
 
-        group_addrs, group_block_len, group_block_stride = self._get_group_buffers(kv_cache_group_id, cache_role)
-        if not group_block_len:
+        if cache_role == "state":
+            return ([[] for _ in block_ids], [[] for _ in block_ids])
+        layout = self._group_buffer_arrays.get(kv_cache_group_id)
+        if layout is None:
             return ([[] for _ in block_ids], [[] for _ in block_ids])
 
-        entry_indices = np.arange(len(group_addrs)) % len(group_block_len)
-        base_addrs = np.asarray(group_addrs, dtype=np.int64)
-        block_lens = np.asarray(group_block_len, dtype=np.int64)[entry_indices]
-        block_strides = (
-            np.asarray(group_block_stride, dtype=np.int64)[entry_indices] if group_block_stride else block_lens
-        )
+        base_addrs, block_lens, block_strides = layout
         block_ids_array = np.asarray(block_ids, dtype=np.int64)
         token_spans = np.asarray(ends, dtype=np.int64) - np.asarray(starts, dtype=np.int64)
         group_block_size = self.get_block_size(kv_cache_group_id)
@@ -634,6 +649,7 @@ class ChunkedTokenDatabase:
     ) -> Iterable[tuple[int, int, str, BlockHash | str, int]]:
         """Yield cache key strings and resolved block ids without PoolKey allocation."""
         prefix = self.get_key_prefix(kv_cache_group_id)
+        hashes_are_strings = bool(block_hashes) and isinstance(block_hashes[0], str)
         for start, end, hash_val, block_id in self._iter_token_chunks(
             token_len,
             block_hashes,
@@ -646,7 +662,8 @@ class ChunkedTokenDatabase:
             shard_size=shard_size,
         ):
             assert block_id is not None
-            yield start, end, prefix + block_hash_to_str(hash_val), hash_val, block_id
+            hash_string = hash_val if hashes_are_strings else block_hash_to_str(hash_val)
+            yield start, end, prefix + hash_string, hash_val, block_id
 
     def decode_adaptor_prefill_pp(self, key, addr, size, kv_cache_group_id: int = 0, cache_role: str = "kv"):
         if self.partitions is None or len(self.partitions) == 1:

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/config_data.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/config_data.py
@@ -281,7 +281,7 @@ class ChunkedTokenDatabase:
         self._key_prefix_cache: dict[tuple[int, str, str], str] = {}
         self.cache_coordinator: Any | None = None
 
-    def _get_key_prefix(
+    def get_key_prefix(
         self,
         kv_cache_group_id: int,
         cache_role: str = "kv",
@@ -492,12 +492,11 @@ class ChunkedTokenDatabase:
         num_logical_blocks = min(len(grouped_hashes), cdiv(token_len, effective_block_size)) if token_len > 0 else 0
         block_id_offset = max(num_logical_blocks - len(block_ids), 0) if block_ids is not None else 0
         candidate_index = 0
+        first_chunk_id = min(cdiv(mask_num, effective_block_size), num_logical_blocks) if mask_num > 0 else 0
 
-        for chunk_id in range(num_logical_blocks):
+        for chunk_id in range(first_chunk_id, num_logical_blocks):
             start_token = chunk_id * effective_block_size
             end_token = min(start_token + effective_block_size, token_len)
-            if start_token < mask_num:
-                continue
             start_idx = start_token // cache_family_ratio
             end_idx = end_token // cache_family_ratio
             if end_idx <= start_idx:
@@ -561,7 +560,25 @@ class ChunkedTokenDatabase:
         chunk_filter: Callable[[int], bool] | None = None,
     ) -> Iterable[tuple[int, int, str, BlockHash | str]]:
         """Yield cache key strings directly without materializing PoolKey objects."""
-        prefix = self._get_key_prefix(kv_cache_group_id)
+        prefix = self.get_key_prefix(kv_cache_group_id)
+        for start, end, hash_val in self.process_token_hashes(
+            token_len,
+            block_hashes,
+            mask_num,
+            kv_cache_group_id,
+            chunk_filter,
+        ):
+            yield start, end, prefix + block_hash_to_str(hash_val), hash_val
+
+    def process_token_hashes(
+        self,
+        token_len: int,
+        block_hashes: BlockHashList | list[str],
+        mask_num: int = 0,
+        kv_cache_group_id: int = 0,
+        chunk_filter: Callable[[int], bool] | None = None,
+    ) -> Iterable[tuple[int, int, BlockHash | str]]:
+        """Yield filtered chunks without constructing serialized cache keys."""
         for start, end, hash_val, _ in self._iter_token_chunks(
             token_len,
             block_hashes,
@@ -569,7 +586,7 @@ class ChunkedTokenDatabase:
             kv_cache_group_id,
             chunk_filter=chunk_filter,
         ):
-            yield start, end, prefix + block_hash_to_str(hash_val), hash_val
+            yield start, end, hash_val
 
     def process_token_key_strings_with_block_ids(
         self,
@@ -584,7 +601,7 @@ class ChunkedTokenDatabase:
         shard_size: int | None = None,
     ) -> Iterable[tuple[int, int, str, BlockHash | str, int]]:
         """Yield cache key strings and resolved block ids without PoolKey allocation."""
-        prefix = self._get_key_prefix(kv_cache_group_id)
+        prefix = self.get_key_prefix(kv_cache_group_id)
         for start, end, hash_val, block_id in self._iter_token_chunks(
             token_len,
             block_hashes,

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/coordinator.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/coordinator.py
@@ -158,6 +158,23 @@ class AscendStoreCoordinator:
         masks = tuple([block is not cached_block_pool.null_block for block in blocks] for blocks in blocks_per_group)
         return masks, hit_length
 
+    def find_longest_cache_hit_length(
+        self,
+        block_hashes: list[BlockHash],
+        max_length: int,
+        cached_block_pool: ExternalCachedBlockPool,
+        *,
+        apply_eagle: bool = True,
+    ) -> int:
+        """Return only the hit length for callers that do not consume masks."""
+        _, hit_length = self._find_hit_blocks(
+            block_hashes,
+            max_length,
+            cached_block_pool,
+            apply_eagle=apply_eagle,
+        )
+        return hit_length
+
     def load_mask(
         self,
         block_hashes: list[BlockHash],

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/kv_transfer.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/kv_transfer.py
@@ -27,6 +27,7 @@ from vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.config_data import
     LayerTransferTask,
     ReqMeta,
     SharedBlockData,
+    block_hash_to_str,
     get_block_hashes,
 )
 # isort: on
@@ -718,7 +719,37 @@ class KVCacheStoreSendingThread(KVTransferThread):
         def should_skip(start: int, end: int) -> bool:
             return skip_end > skip_start and start >= skip_start and end <= skip_end
 
-        for group_id in req_meta.kv_cache_group_ids or [0]:
+        group_ids = req_meta.kv_cache_group_ids or [0]
+        key_block_hashes = req_meta.block_hashes
+        # Serialize once only when a fine-grained group is guaranteed to visit
+        # every valid hash. Filtered or incremental saves keep lazy conversion.
+        if (
+            len(group_ids) > 1
+            and req_meta.save_start_token == 0
+            and store_masks is None
+            and skip_end <= skip_start
+            and self.put_step <= 1
+            and key_block_hashes
+            and not isinstance(key_block_hashes[0], str)
+        ):
+            hash_block_size = self.token_database.hash_block_size
+            valid_hash_count = min(len(key_block_hashes), (token_len + hash_block_size - 1) // hash_block_size)
+            covers_all_hashes = any(
+                self._get_block_size(group_id)
+                * infer_cache_family_ratio(self.token_database.group_cache_families["kv"].get(group_id))
+                == hash_block_size
+                and not self._skip_null_blocks(req_meta, group_id)
+                and group_id < len(req_meta.block_ids_by_group)
+                and len(req_meta.block_ids_by_group[group_id]) >= valid_hash_count
+                for group_id in group_ids
+            )
+            if covers_all_hashes:
+                key_block_hashes = list(key_block_hashes)
+                key_block_hashes[:valid_hash_count] = [
+                    block_hash_to_str(block_hash) for block_hash in key_block_hashes[:valid_hash_count]
+                ]
+
+        for group_id in group_ids:
             group_block_size = self._get_block_size(group_id)
             cache_family = self.token_database.group_cache_families["kv"].get(group_id)
             raw_group_block_size = group_block_size * infer_cache_family_ratio(cache_family)
@@ -768,7 +799,7 @@ class KVCacheStoreSendingThread(KVTransferThread):
             pre_shard = self.dcp_size <= 1 and not align_state_group
             iterator = self.token_database.process_token_key_strings_with_block_ids(
                 token_len,
-                req_meta.block_hashes,
+                key_block_hashes,
                 block_ids,
                 mask_num=req_meta.save_start_token,
                 kv_cache_group_id=group_id,
@@ -788,15 +819,16 @@ class KVCacheStoreSendingThread(KVTransferThread):
             if not keys:
                 continue
             exists_states = self.lookup(keys)
-            missing_indices = [index for index, exists in enumerate(exists_states) if not exists]
-            if not missing_indices:
-                continue
-            starts = [starts[index] for index in missing_indices]
-            ends = [ends[index] for index in missing_indices]
-            keys = [keys[index] for index in missing_indices]
-            if self.enable_kv_event:
-                block_hashes = [block_hashes[index] for index in missing_indices]
-            key_block_ids = [key_block_ids[index] for index in missing_indices]
+            if any(exists_states):
+                missing_indices = [index for index, exists in enumerate(exists_states) if not exists]
+                if not missing_indices:
+                    continue
+                starts = [starts[index] for index in missing_indices]
+                ends = [ends[index] for index in missing_indices]
+                keys = [keys[index] for index in missing_indices]
+                if self.enable_kv_event:
+                    block_hashes = [block_hashes[index] for index in missing_indices]
+                key_block_ids = [key_block_ids[index] for index in missing_indices]
 
             logger.debug(
                 "Storing KV cache for %d out of %d blocks for request %s in group %d",

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/kv_transfer.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/kv_transfer.py
@@ -791,6 +791,7 @@ class KVCacheStoreSendingThread(KVTransferThread):
                 token_len,
                 req_meta.block_hashes,
                 block_ids,
+                mask_num=req_meta.save_start_token,
                 kv_cache_group_id=group_id,
                 skip_null_blocks=skip_null_blocks,
                 chunk_filter=chunk_filter,

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/kv_transfer.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/kv_transfer.py
@@ -27,7 +27,6 @@ from vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.config_data import
     LayerTransferTask,
     ReqMeta,
     SharedBlockData,
-    block_hash_to_str,
     get_block_hashes,
 )
 # isort: on
@@ -719,37 +718,7 @@ class KVCacheStoreSendingThread(KVTransferThread):
         def should_skip(start: int, end: int) -> bool:
             return skip_end > skip_start and start >= skip_start and end <= skip_end
 
-        group_ids = req_meta.kv_cache_group_ids or [0]
-        key_block_hashes = req_meta.block_hashes
-        # Serialize once only when a fine-grained group is guaranteed to visit
-        # every valid hash. Filtered or incremental saves keep lazy conversion.
-        if (
-            len(group_ids) > 1
-            and req_meta.save_start_token == 0
-            and store_masks is None
-            and skip_end <= skip_start
-            and self.put_step <= 1
-            and key_block_hashes
-            and not isinstance(key_block_hashes[0], str)
-        ):
-            hash_block_size = self.token_database.hash_block_size
-            valid_hash_count = min(len(key_block_hashes), (token_len + hash_block_size - 1) // hash_block_size)
-            covers_all_hashes = any(
-                self._get_block_size(group_id)
-                * infer_cache_family_ratio(self.token_database.group_cache_families["kv"].get(group_id))
-                == hash_block_size
-                and not self._skip_null_blocks(req_meta, group_id)
-                and group_id < len(req_meta.block_ids_by_group)
-                and len(req_meta.block_ids_by_group[group_id]) >= valid_hash_count
-                for group_id in group_ids
-            )
-            if covers_all_hashes:
-                key_block_hashes = list(key_block_hashes)
-                key_block_hashes[:valid_hash_count] = [
-                    block_hash_to_str(block_hash) for block_hash in key_block_hashes[:valid_hash_count]
-                ]
-
-        for group_id in group_ids:
+        for group_id in req_meta.kv_cache_group_ids or [0]:
             group_block_size = self._get_block_size(group_id)
             cache_family = self.token_database.group_cache_families["kv"].get(group_id)
             raw_group_block_size = group_block_size * infer_cache_family_ratio(cache_family)
@@ -799,7 +768,7 @@ class KVCacheStoreSendingThread(KVTransferThread):
             pre_shard = self.dcp_size <= 1 and not align_state_group
             iterator = self.token_database.process_token_key_strings_with_block_ids(
                 token_len,
-                key_block_hashes,
+                req_meta.block_hashes,
                 block_ids,
                 mask_num=req_meta.save_start_token,
                 kv_cache_group_id=group_id,

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/kv_transfer.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/kv_transfer.py
@@ -564,27 +564,6 @@ class KVTransferThread(threading.Thread):
         skip_flags = req_meta.skip_null_blocks_by_group
         return group_id < len(skip_flags) and skip_flags[group_id] if skip_flags else False
 
-    def _prepare_value(
-        self,
-        start: int,
-        end: int,
-        block_ids: list[int],
-        kv_cache_group_id: int = 0,
-        cache_role: str = "kv",
-        block_id: int | None = None,
-    ):
-        try:
-            return self.token_database.prepare_value(
-                start,
-                end,
-                block_ids,
-                kv_cache_group_id=kv_cache_group_id,
-                cache_role=cache_role,
-                block_id=block_id,
-            )
-        except TypeError:
-            return self.token_database.prepare_value(start, end, block_ids)
-
     def _decode_adaptor_prefill_pp(
         self,
         keys: list[str],
@@ -826,8 +805,12 @@ class KVCacheStoreSendingThread(KVTransferThread):
                 req_id,
                 group_id,
             )
-            addrs = []
-            sizes = []
+            addrs, sizes = self.token_database.prepare_values(
+                starts,
+                ends,
+                key_block_ids,
+                kv_cache_group_id=group_id,
+            )
             stored_events: list[BlockStored] = []
             all_hashes = []
             if self.enable_kv_event:
@@ -846,15 +829,6 @@ class KVCacheStoreSendingThread(KVTransferThread):
                 keys[:3],
             )
             for index, start in enumerate(starts):
-                addr, size, _ = self._prepare_value(
-                    start,
-                    ends[index],
-                    block_ids,
-                    kv_cache_group_id=group_id,
-                    block_id=key_block_ids[index],
-                )
-                addrs.append(addr)
-                sizes.append(size)
                 if self.enable_kv_event:
                     token_ids = req_meta.token_ids[start : ends[index]] if req_meta.token_ids is not None else None
                     block_size = (
@@ -952,6 +926,10 @@ class KVCacheStoreRecvingThread(KVTransferThread):
             load_masks = self.token_database.load_mask(req_meta.block_hashes, token_len)
             for group_id in group_ids:
                 block_ids = req_meta.block_ids_by_group[group_id]
+                group_starts: list[int] = []
+                group_ends: list[int] = []
+                group_keys: list[str] = []
+                group_block_ids: list[int] = []
                 group_block_size = self._get_block_size(group_id)
                 mask_num = load_spec.vllm_cached_tokens // group_block_size * group_block_size
 
@@ -968,17 +946,21 @@ class KVCacheStoreRecvingThread(KVTransferThread):
                     chunk_filter=chunk_filter,
                 )
                 for start, end, key, _block_hash, block_id in token_iter:
-                    addr, size, block_id = self._prepare_value(
-                        start,
-                        end,
-                        block_ids,
-                        kv_cache_group_id=group_id,
-                        block_id=block_id,
-                    )
-                    key_list.append(key)
-                    addr_list.append(addr)
-                    size_list.append(size)
-                    block_id_list.append(block_id)
+                    group_starts.append(start)
+                    group_ends.append(end)
+                    group_keys.append(key)
+                    group_block_ids.append(block_id)
+
+                group_addrs, group_sizes = self.token_database.prepare_values(
+                    group_starts,
+                    group_ends,
+                    group_block_ids,
+                    kv_cache_group_id=group_id,
+                )
+                key_list.extend(group_keys)
+                addr_list.extend(group_addrs)
+                size_list.extend(group_sizes)
+                block_id_list.extend(group_block_ids)
             if not key_list:
                 self.set_finished_request(req_id)
                 return

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/pool_worker.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/pool_worker.py
@@ -938,6 +938,10 @@ class KVPoolWorker:
                 if group_id >= len(request.block_ids_by_group):
                     continue
                 block_ids = request.block_ids_by_group[group_id]
+                group_starts: list[int] = []
+                group_ends: list[int] = []
+                group_keys: list[str] = []
+                group_block_ids: list[int] = []
                 group_block_size = self.grouped_block_size[group_id]
                 mask_num = load_spec.vllm_cached_tokens // group_block_size * group_block_size
                 skip_null = group_id < len(self.group_uses_align_state) and self.group_uses_align_state[group_id]
@@ -960,17 +964,21 @@ class KVPoolWorker:
                     skip_null_blocks=skip_null,
                     chunk_filter=chunk_filter,
                 ):
-                    addr, size, block_id = self.token_database.prepare_value(
-                        start,
-                        end,
-                        block_ids,
-                        kv_cache_group_id=group_id,
-                        block_id=block_id,
-                    )
-                    key_list.append(key)
-                    addr_list.append(addr)
-                    size_list.append(size)
-                    block_id_list.append(block_id)
+                    group_starts.append(start)
+                    group_ends.append(end)
+                    group_keys.append(key)
+                    group_block_ids.append(block_id)
+
+                group_addrs, group_sizes = self.token_database.prepare_values(
+                    group_starts,
+                    group_ends,
+                    group_block_ids,
+                    kv_cache_group_id=group_id,
+                )
+                key_list.extend(group_keys)
+                addr_list.extend(group_addrs)
+                size_list.extend(group_sizes)
+                block_id_list.extend(group_block_ids)
             if not key_list:
                 continue
             key_list_c = _circular_shift(key_list, self.tp_rank % len(key_list))
@@ -2126,6 +2134,7 @@ class KVPoolWorker:
         block_hashes: list[BlockHash],
         group_id: int,
         use_layerwise: bool,
+        need_starts: bool = True,
     ) -> tuple[list[str], list[int], list[int]]:
         keys: list[str] = []
         starts: list[int] = []
@@ -2142,7 +2151,8 @@ class KVPoolWorker:
                 token_len, block_hashes, kv_cache_group_id=group_id
             ):
                 keys.append(key_string)
-                starts.append(start)
+                if need_starts:
+                    starts.append(start)
                 ends.append(end)
         return keys, starts, ends
 
@@ -2238,9 +2248,41 @@ class KVPoolWorker:
         return f"{key[:value_start]}{value}{key[value_end:]}"
 
     def _expand_lookup_keys_by_rank(self, keys: list[str], group_id: int) -> list[str]:
+        if not keys:
+            return []
+        group_tp_size = self.get_group_tp_size(group_id)
+
+        # Non-layerwise keys share the same metadata prefix and only differ in
+        # their trailing hash. Split that prefix once instead of scanning and
+        # rebuilding every key twice for every PP/TP rank.
+        key = keys[0]
+        tp_marker = "@head_or_tp_rank:"
+        pp_marker = "@pp_rank:"
+        tp_start = key.find(tp_marker)
+        tp_value_start = tp_start + len(tp_marker)
+        tp_end = key.find("@", tp_value_start)
+        pp_start = key.find(pp_marker, tp_end)
+        pp_value_start = pp_start + len(pp_marker)
+        pp_end = key.find("@", pp_value_start)
+
+        if tp_start >= 0 and tp_end >= 0 and pp_start >= 0:
+            if pp_end < 0:
+                pp_end = len(key)
+            prefix = key[:tp_value_start]
+            between_ranks = key[tp_end:pp_value_start]
+            suffixes = [key[pp_end:] for key in keys]
+            expanded: list[str] = []
+            for pp_rank in range(self.pp_size):
+                for tp_rank in range(group_tp_size):
+                    rank_prefix = f"{prefix}{tp_rank}{between_ranks}{pp_rank}"
+                    expanded.extend(rank_prefix + suffix for suffix in suffixes)
+            return expanded
+
+        # Layerwise keys do not contain pp_rank. Preserve their existing
+        # replacement and expansion behavior.
         expanded: list[str] = []
         for pp_rank in range(self.pp_size):
-            for tp_rank in range(self.get_group_tp_size(group_id)):
+            for tp_rank in range(group_tp_size):
                 for key in keys:
                     tp_key = self._replace_key_field(key, "head_or_tp_rank", tp_rank)
                     expanded.append(self._replace_key_field(tp_key, "pp_rank", pp_rank))
@@ -2371,7 +2413,13 @@ class KVPoolWorker:
             if coordinator_hit is not None:
                 return coordinator_hit
             for group_id in kv_cache_group_ids:
-                keys, starts, ends = self._build_lookup_keys(token_len, block_hashes, group_id, use_layerwise)
+                keys, _, ends = self._build_lookup_keys(
+                    token_len,
+                    block_hashes,
+                    group_id,
+                    use_layerwise,
+                    need_starts=False,
+                )
 
                 if not keys:
                     return 0

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/pool_worker.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/pool_worker.py
@@ -2280,13 +2280,13 @@ class KVPoolWorker:
 
         # Layerwise keys do not contain pp_rank. Preserve their existing
         # replacement and expansion behavior.
-        expanded: list[str] = []
+        fallback_expanded: list[str] = []
         for pp_rank in range(self.pp_size):
             for tp_rank in range(group_tp_size):
                 for key in keys:
                     tp_key = self._replace_key_field(key, "head_or_tp_rank", tp_rank)
-                    expanded.append(self._replace_key_field(tp_key, "pp_rank", pp_rank))
-        return expanded
+                    fallback_expanded.append(self._replace_key_field(tp_key, "pp_rank", pp_rank))
+        return fallback_expanded
 
     def _lookup_with_coordinator(
         self,

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/pool_worker.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/pool_worker.py
@@ -2246,11 +2246,6 @@ class KVPoolWorker:
                     expanded.append(self._replace_key_field(tp_key, "pp_rank", pp_rank))
         return expanded
 
-    def _expand_lookup_key_variants(self, key: str, group_id: int, include_all_ranks: bool) -> list[str]:
-        if not include_all_ranks:
-            return [key]
-        return self._expand_lookup_keys_by_rank([key], group_id)
-
     def _lookup_with_coordinator(
         self,
         token_len: int,
@@ -2276,18 +2271,23 @@ class KVPoolWorker:
         for group_id in kv_cache_group_ids:
             keys: list[str] = []
             chunk_hashes: list[BlockHash | str] = []
-            variant_counts: list[int] = []
             base_block_size = self.token_database.get_block_size(group_id)
             cache_family = self.token_database.group_cache_families.get("kv", {}).get(group_id, "default")
             effective_block_size = get_cache_family_granularity(base_block_size, cache_family)
+            key_prefix = self.token_database.get_key_prefix(group_id)
+            key_prefixes = (
+                self._expand_lookup_keys_by_rank([key_prefix], group_id) if include_all_ranks else [key_prefix]
+            )
+            variant_count = len(key_prefixes)
+            group_exists_count = 0
             if hbm_hit_tokens:
                 grouped_hashes = get_block_hashes(
                     block_hashes, effective_block_size, self.token_database.hash_block_size
                 )
-                exists.update(
-                    (group_id, block_hash_to_bytes(chunk_hash))
-                    for chunk_hash in grouped_hashes[: hbm_hit_tokens // effective_block_size]
-                )
+                local_hit_chunks = min(hbm_hit_tokens // effective_block_size, len(grouped_hashes))
+                for chunk_index in range(local_hit_chunks):
+                    exists.add((group_id, block_hash_to_bytes(grouped_hashes[chunk_index])))
+                group_exists_count = local_hit_chunks
             lookup_start = hbm_hit_tokens // effective_block_size * effective_block_size
             lookup_mask = lookup_masks[group_id] if lookup_masks is not None and group_id < len(lookup_masks) else None
 
@@ -2299,39 +2299,37 @@ class KVPoolWorker:
                 chunk_idx = start // base_block_size
                 return lookup_mask is None or (chunk_idx < len(lookup_mask) and lookup_mask[chunk_idx])
 
-            for _, _, key_string, chunk_hash in self.token_database.process_token_key_strings(
+            for _, _, chunk_hash in self.token_database.process_token_hashes(
                 token_len,
                 block_hashes,
                 mask_num=lookup_start,
                 kv_cache_group_id=group_id,
                 chunk_filter=chunk_filter,
             ):
-                variants = self._expand_lookup_key_variants(key_string, group_id, include_all_ranks)
-                keys.extend(variants)
+                chunk_hash_string = block_hash_to_str(chunk_hash)
+                keys.extend(prefix + chunk_hash_string for prefix in key_prefixes)
                 chunk_hashes.append(chunk_hash)
-                variant_counts.append(len(variants))
 
             if not keys:
                 continue
             res = self.m_store.exists(keys)  # type: ignore[assignment]
-            offset = 0
-            for chunk_hash, count in zip(chunk_hashes, variant_counts, strict=True):
-                values = res[offset : offset + count]  # type: ignore[index]
-                if values and all(value == 1 for value in values):
+            for chunk_index, chunk_hash in enumerate(chunk_hashes):
+                offset = chunk_index * variant_count
+                if all(res[index] == 1 for index in range(offset, offset + variant_count)):  # type: ignore[index]
                     exists.add((group_id, block_hash_to_bytes(chunk_hash)))
-                offset += count
+                    group_exists_count += 1
 
             logger.debug(
                 "KV pool coordinator lookup group=%d token_len=%d keys=%d exists_chunks=%d/%d sample_keys=%s",
                 group_id,
                 token_len,
                 len(keys),
-                sum(1 for group, _ in exists if group == group_id),
+                group_exists_count,
                 len(chunk_hashes),
                 keys[:3],
             )
 
-        _, hit_length = self.cache_coordinator.find_longest_cache_hit(
+        hit_length = self.cache_coordinator.find_longest_cache_hit_length(
             block_hashes,
             token_len,
             ExternalCachedBlockPool(self.hash_block_size, exists),


### PR DESCRIPTION
### What this PR does / why we need it?

vLLM block hashes are already reused in the 0.26 path, so this patch targets the Python work that remains after hashing:

- Start token-chunk iteration at the save watermark instead of scanning every earlier chunk and discarding it.
- Generate chunk hashes without constructing `PoolKey`/serialized key objects during coordinator lookup.
- Expand rank-specific key prefixes once per KV cache group, then append each reused vLLM block hash.
- Build fallback non-layerwise PP/TP lookup keys from a pre-split shared prefix instead of scanning and replacing rank fields for every key, and skip collecting unused start offsets.
- Avoid materializing coordinator hit masks when the lookup caller only needs the hit length.
- Pass `save_start_token` into non-layerwise save preparation so previously saved blocks are not rebuilt and queried again.
- Vectorize address and size preparation once per KV cache group for non-layerwise save, async load, and sync load paths.
- Keep the original key/range/block-id lists on cold all-miss saves instead of building missing indices and copying all four lists.
- Skip per-chunk Python mask callbacks when save, load, or coordinator-lookup masks allow every chunk; partial masks keep the original filtering semantics.
- Resolve the hash-to-string converter once per key batch and simplify compressed-family range and sharding arithmetic.
- Avoid copying all four async-load input lists when the circular-shift offset is zero.

This reduces the observed Python hotspots in coordinator lookup and non-layerwise save/load preparation without changing the external key format.

### Does this PR introduce _any_ user-facing change?

No. There is no new configuration or API. AscendStore keeps the same key format and cache-hit semantics.

### How was this patch tested?

- All pre-commit hooks passed for the changed files.
- Targeted CPU-mock unit tests covering token iteration, all-True and partial save/load masks, sync and async load preparation, and coordinator lookup: `99 passed`.
- AscendStore unit tests covering chunk iteration, non-layerwise save/load preparation, compressed groups, coordinator hit-length lookup, and rank-prefix expansion: `201 passed, 10 skipped, 1 deselected`.
  - The deselected test requires `torch.npu` in the local CPU-only environment and fails identically at the previous PR commit (`16a36cbd1`).
- Regression tests across `test_config_data` and `test_kv_transfer` using the CPU dependency mocks: `107 passed, 10 skipped`. Existing non-layerwise save tests cover the cold all-miss path.
- Synthetic Python microbenchmarks with 131,072 chunks:
  - Preparing only the final 64 chunks: 8.68 ms -> 0.018 ms average.
  - Isolated coordinator result handling when only hit length is consumed: 1.07 ms -> 0.003 ms average.
- Local 128K-token DSv4-Flash component benchmark using process CPU time medians on macOS arm64 / Python 3.12:
  - Geometry: block size 32; `c1`/`c4`/`c128` chunk counts 4096/1024/32; 43/42/20 registered cache entries; PP1/TP4. Store and NPU operations were replaced by no-ops to isolate Python preparation cost.
  - Batch address/size preparation: 26.07 ms -> 6.20 ms (`-76.2%`, `4.20x`).
  - Fallback non-layerwise rank-key expansion: 2.67 ms -> 0.30 ms (`-88.8%`, `8.90x`).
  - Production cold-save preparation path through `KVCacheStoreSendingThread._handle_request`: 28.22 ms -> 8.16 ms (`-71.1%`, `3.46x`).
  - To isolate the cold all-miss fast path after a future ndarray backend removes `.tolist()`, five serial runs of the same cold-save path with an array-returning backend stub changed from a 3.1825 ms median at `4771af1e2` to 2.9495 ms at `a3d29e5df` (`-7.3%`, `1.08x`).
  - Non-layerwise load key preparation with all-True masks: 2.43 ms -> 1.53 ms (`-37.2%`, `1.59x`).
  - Non-layerwise load key preparation with a partial c1 mask and all-True c4/c128 masks: 2.03 ms -> 1.40 ms (`-30.9%`, `1.45x`).
  - Async rank-0 circular-shift preparation: 0.18 ms -> 0.07 ms.

The rank-key result covers the scheduler fallback path. The normal DSv4 coordinator path already expands one shared prefix per group, so the incremental PR7-style benefit there is intentionally small. The coordinator's `load_mask` computation remains unchanged because it carries SWA/EAGLE reachability semantics and needs separate correctness validation before optimization.

This is a CPU component benchmark, not an NPU end-to-end latency result. NPU end-to-end testing was not run in the local environment.

- vLLM main: https://github.com/vllm-project/vllm/commit/d02df748bf9efd99022f1a062597dc3cb3808485
