### PR TITLE
[v0.26.0rc][Performance] Move AscendStore lookup to the scheduler

### DIFF
--- a/tests/ut/distributed/ascend_store/test_ascend_store_connector.py
+++ b/tests/ut/distributed/ascend_store/test_ascend_store_connector.py
@@ -156,7 +156,7 @@ class TestAscendStoreConnector(unittest.TestCase):
 
     @patch("vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.ascend_store_connector.LookupKeyServer")
     @patch("vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.ascend_store_connector.KVPoolWorker")
-    def test_init_worker_role(self, mock_worker_cls, mock_lookup_cls):
+    def test_worker_skips_lookup_server_for_scheduler_client_backend(self, mock_worker_cls, mock_lookup_cls):
         config = self._make_vllm_config()
         from vllm.distributed.kv_transfer.kv_connector.v1.base import KVConnectorRole
 
@@ -165,6 +165,21 @@ class TestAscendStoreConnector(unittest.TestCase):
             role=KVConnectorRole.WORKER,
             kv_cache_config=None,
         )
+        mock_worker_cls.assert_called_once()
+        mock_lookup_cls.assert_not_called()
+
+    @patch("vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.ascend_store_connector.LookupKeyServer")
+    @patch("vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.ascend_store_connector.KVPoolWorker")
+    def test_worker_keeps_lookup_server_for_yuanrong(self, mock_worker_cls, mock_lookup_cls):
+        config = self._make_vllm_config(extra_config={"backend": "yuanrong"})
+        from vllm.distributed.kv_transfer.kv_connector.v1.base import KVConnectorRole
+
+        AscendStoreConnector(
+            vllm_config=config,
+            role=KVConnectorRole.WORKER,
+            kv_cache_config=None,
+        )
+
         mock_worker_cls.assert_called_once()
         mock_lookup_cls.assert_called_once()
 

--- a/tests/ut/distributed/ascend_store/test_backend.py
+++ b/tests/ut/distributed/ascend_store/test_backend.py
@@ -24,6 +24,7 @@ from unittest.mock import MagicMock, patch
 import tests.ut.distributed.ascend_store._mock_deps  # noqa: F401, E402
 from vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.backend.backend import Backend
 from vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.backend.mooncake_backend import (
+    MooncakeBackend,
     MooncakeStoreConfig,
     _convert_to_bytes,
     _parse_global_segment_size,
@@ -343,8 +344,6 @@ class TestYuanrongHelper(unittest.TestCase):
 # =========================================================================
 class TestMooncakeBackendMethods(unittest.TestCase):
     def _make_backend(self):
-        from vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.backend.mooncake_backend import MooncakeBackend
-
         with (
             patch.dict(os.environ, {"MOONCAKE_CONFIG_PATH": "/dev/null"}),
             patch.object(MooncakeBackend, "__init__", lambda self, pc: None),
@@ -354,11 +353,69 @@ class TestMooncakeBackendMethods(unittest.TestCase):
             backend.config = MagicMock()
             backend.local_seg = "127.0.0.1:1234"
             backend._lazy_init = False
+            backend._lookup_only = False
             backend._store_initialized = True
             backend._use_fabric_mem = False
             backend._store_init_lock = MagicMock()
             backend.local_seg = None
             return backend
+
+    @patch("vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.backend.mooncake_backend.global_te")
+    @patch(
+        "vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.backend.mooncake_backend.get_ip",
+        return_value="10.0.0.1",
+    )
+    def test_lookup_only_setup_uses_rpc_protocol(self, _mock_get_ip, mock_global_te):
+        backend = MooncakeBackend.__new__(MooncakeBackend)
+        backend.config = _make_mooncake_store_config(
+            metadata_server="meta:2379",
+            master_server_address="master:50051",
+        )
+        backend._lookup_only = True
+
+        with patch("mooncake.store.MooncakeDistributedStore") as store_cls:
+            store_cls.return_value.setup.return_value = 0
+            result = backend._setup_store()
+
+        self.assertIs(result, store_cls.return_value)
+        store_cls.return_value.setup.assert_called_once_with(
+            local_hostname="10.0.0.1",
+            metadata_server="meta:2379",
+            global_segment_size=0,
+            local_buffer_size=0,
+            protocol="rpc_only",
+            rdma_devices="",
+            master_server_addr="master:50051",
+        )
+        mock_global_te.get_transfer_engine.assert_not_called()
+
+    def test_lookup_only_setup_failure_is_fatal(self):
+        backend = MooncakeBackend.__new__(MooncakeBackend)
+        backend.config = _make_mooncake_store_config()
+        backend._lookup_only = True
+
+        with (
+            patch("mooncake.store.MooncakeDistributedStore") as store_cls,
+            patch(
+                "vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.backend.mooncake_backend.get_ip",
+                return_value="10.0.0.1",
+            ),
+        ):
+            store_cls.return_value.setup.return_value = -1
+            with self.assertRaisesRegex(RuntimeError, "lookup client failed"):
+                backend._setup_store()
+
+    def test_create_scheduler_client_is_lookup_only(self):
+        parallel_config = MagicMock()
+        with patch.object(MooncakeBackend, "__init__", return_value=None) as mock_init:
+            client = MooncakeBackend.create_scheduler_client(parallel_config)
+
+        self.assertIsInstance(client, MooncakeBackend)
+        mock_init.assert_called_once_with(
+            parallel_config,
+            contribute_memory=False,
+            lookup_only=True,
+        )
 
     def test_exists(self):
         b = self._make_backend()

--- a/tests/ut/distributed/ascend_store/test_config_data.py
+++ b/tests/ut/distributed/ascend_store/test_config_data.py
@@ -16,7 +16,8 @@
 #
 
 import unittest
-from unittest.mock import MagicMock
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
 
 import tests.ut.distributed.ascend_store._mock_deps  # noqa: F401, E402
 from vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.config_data import (
@@ -30,7 +31,36 @@ from vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.config_data import
     ReqMeta,
     RequestTracker,
     get_block_hashes,
+    get_kv_pool_lookup_tp_size,
+    infer_group_cache_families,
 )
+
+
+class TestLookupKeyMetadata(unittest.TestCase):
+    def test_lookup_tp_size_matches_worker_key_sharding(self):
+        self.assertEqual(get_kv_pool_lookup_tp_size(8, 4, False, False), 4)
+        self.assertEqual(get_kv_pool_lookup_tp_size(8, 4, True, False), 1)
+        self.assertEqual(get_kv_pool_lookup_tp_size(8, 4, False, True), 1)
+        self.assertEqual(get_kv_pool_lookup_tp_size(8, 4, True, False, use_align_state=True), 8)
+        self.assertEqual(get_kv_pool_lookup_tp_size(8, 4, False, False, effective_tp_size=16), 16)
+
+    def test_sparse_group_uses_mixed_cache_family(self):
+        group = SimpleNamespace(
+            kv_cache_spec=SimpleNamespace(compress_ratio=None),
+            layer_names=[],
+        )
+        self.assertEqual(infer_group_cache_families([group], None, use_sparse=True), ["mixed"])
+
+    def test_missing_spec_ratio_falls_back_to_model_ratio(self):
+        group = SimpleNamespace(
+            kv_cache_spec=SimpleNamespace(compress_ratio=None),
+            layer_names=["model.layers.0.self_attn"],
+        )
+        with patch(
+            "vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.config_data._get_layer_compress_ratio",
+            return_value=4,
+        ):
+            self.assertEqual(infer_group_cache_families([group], [4]), ["c4"])
 
 
 class TestKeyMetadata(unittest.TestCase):

--- a/tests/ut/distributed/ascend_store/test_pool_scheduler.py
+++ b/tests/ut/distributed/ascend_store/test_pool_scheduler.py
@@ -75,7 +75,10 @@ class TestKVPoolScheduler(unittest.TestCase):
     def _make_config(self, kv_role="kv_producer", extra_config=None, block_size=16):
         config = MagicMock()
         config.kv_transfer_config.kv_role = kv_role
-        config.kv_transfer_config.kv_connector_extra_config = extra_config or {}
+        config.kv_transfer_config.kv_connector_extra_config = {
+            "backend": "yuanrong",
+            **(extra_config or {}),
+        }
         config.kv_transfer_config.get_from_extra_config.return_value = True
         config.parallel_config.data_parallel_rank = 0
         config.parallel_config.prefill_context_parallel_size = 1
@@ -191,6 +194,39 @@ class TestKVPoolScheduler(unittest.TestCase):
 
         self.assertEqual(scheduler.get_num_new_matched_tokens(request, 64), (0, False))
         mock_client_cls.return_value.lookup.assert_not_called()
+
+    @patch("vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.pool_scheduler.LookupKeyClient")
+    def test_scheduler_client_lookup_for_mooncake_and_memcache(self, mock_client_cls):
+        for backend_name in ("mooncake", "memcache"):
+            with self.subTest(backend=backend_name):
+                scheduler = KVPoolScheduler(
+                    self._make_config(extra_config={"backend": backend_name}),
+                    use_layerwise=False,
+                )
+                scheduler.store_scheduler.batch_is_exist.return_value = [1, 1, 0]
+                request = MagicMock()
+                request.prompt_token_ids = list(range(64))
+                request.num_tokens = 64
+                request.request_id = f"r-{backend_name}"
+                request.block_hashes = [bytes([index]) * 32 for index in range(4)]
+
+                self.assertEqual(scheduler.get_num_new_matched_tokens(request, 16), (32, False))
+                scheduler.store_scheduler.batch_is_exist.assert_called_once()
+                mock_client_cls.assert_not_called()
+
+    def test_scheduler_client_full_hbm_hit_skips_store_lookup(self):
+        scheduler = KVPoolScheduler(
+            self._make_config(extra_config={"backend": "mooncake"}),
+            use_layerwise=False,
+        )
+        request = MagicMock()
+        request.prompt_token_ids = list(range(64))
+        request.num_tokens = 64
+        request.request_id = "r1"
+        request.block_hashes = [bytes([index]) * 32 for index in range(4)]
+
+        self.assertEqual(scheduler.get_num_new_matched_tokens(request, 64), (0, False))
+        scheduler.store_scheduler.batch_is_exist.assert_not_called()
 
     @patch("vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.pool_scheduler.LookupKeyClient")
     def test_get_num_new_matched_tokens_less_than_computed(self, mock_client_cls):
@@ -706,6 +742,7 @@ class TestKVPoolSchedulerStoreQueryKeys(unittest.TestCase):
     def test_generate_store_query_keys_multi_tp(self):
         scheduler = self._make_scheduler()
         scheduler.tp_size = 2
+        scheduler.num_kv_head = 2
         scheduler.put_step = 1
         result = scheduler._generate_store_query_keys([b"\xaa\xbb"])
         # 1 block * 2 tp_ranks * 1 pp * 1 pcp * 1 dcp = 2 keys
@@ -778,6 +815,76 @@ class TestKVPoolSchedulerGetStoreLookupHitTokens(unittest.TestCase):
         request.block_hashes = [b"\xaa"] * 4
         result = scheduler._get_store_lookup_hit_tokens(request, 64, 32)
         self.assertEqual(result, 64)
+
+    def test_align_state_uses_latest_aligned_hit(self):
+        scheduler = self._make_scheduler()
+        scheduler.group_uses_align_state = [True]
+        scheduler.cache_transfer_granularity = 32
+        scheduler.store_scheduler.batch_is_exist.return_value = [0, 1, 0, 1]
+        request = MagicMock()
+        request.block_hashes = [b"\xaa"] * 4
+
+        result = scheduler._get_store_lookup_hit_tokens(request, 64, 0)
+
+        self.assertEqual(result, 64)
+
+
+class TestKVPoolSchedulerCoordinatedLookup(unittest.TestCase):
+    def _make_scheduler(self):
+        scheduler = KVPoolScheduler.__new__(KVPoolScheduler)
+        scheduler.cache_coordinator = MagicMock()
+        scheduler.cache_coordinator.lcm_block_size = 32
+        scheduler.cache_coordinator.lookup_mask.return_value = (None, None)
+        scheduler.cache_coordinator.find_longest_cache_hit.return_value = ((), 64)
+        scheduler.kv_cache_group_ids = [0, 1]
+        scheduler.grouped_block_size = [16, 32]
+        scheduler.kv_cache_group_families = ["c1", "c1"]
+        scheduler.hash_block_size = 16
+        scheduler.model_name = "model"
+        scheduler.pcp_size = 1
+        scheduler.dcp_size = 1
+        scheduler.tp_size = 1
+        scheduler.pp_size = 1
+        scheduler.num_kv_head = 1
+        scheduler.use_mla = False
+        scheduler.use_sparse = False
+        scheduler.group_uses_align_state = [False, False]
+        scheduler.tp_mismatch = False
+        scheduler.effective_tp_size = 1
+        scheduler.store_scheduler = MagicMock()
+        scheduler.store_scheduler.batch_is_exist.side_effect = lambda keys: [1] * len(keys)
+        return scheduler
+
+    def test_queries_each_group_and_delegates_hit_resolution(self):
+        scheduler = self._make_scheduler()
+        request = MagicMock()
+        request.request_id = "r1"
+        request.block_hashes = [bytes([index]) * 32 for index in range(4)]
+
+        hit_tokens = scheduler._get_coordinated_lookup_hit_tokens(request, 64, 16)
+
+        self.assertEqual(hit_tokens, 64)
+        self.assertEqual(scheduler.store_scheduler.batch_is_exist.call_count, 2)
+        group0_keys = scheduler.store_scheduler.batch_is_exist.call_args_list[0].args[0]
+        group1_keys = scheduler.store_scheduler.batch_is_exist.call_args_list[1].args[0]
+        self.assertEqual(len(group0_keys), 3)
+        self.assertEqual(len(group1_keys), 2)
+        self.assertTrue(all("@group:0@" in key for key in group0_keys))
+        self.assertTrue(all("@group:1@" in key for key in group1_keys))
+        scheduler.cache_coordinator.find_longest_cache_hit.assert_called_once()
+
+    def test_lookup_prefixes_cover_all_parallel_ranks(self):
+        scheduler = self._make_scheduler()
+        scheduler.pcp_size = 2
+        scheduler.dcp_size = 2
+        scheduler.tp_size = 4
+        scheduler.pp_size = 2
+        scheduler.num_kv_head = 4
+
+        prefixes = scheduler._get_lookup_key_prefixes(0)
+
+        self.assertEqual(len(prefixes), 32)
+        self.assertIn("@pcp1@dcp1@head_or_tp_rank:3@pp_rank:1@", prefixes[-1])
 
 
 class TestKVPoolSchedulerStaticMethods(unittest.TestCase):

--- a/tests/ut/distributed/ascend_store/test_pool_worker.py
+++ b/tests/ut/distributed/ascend_store/test_pool_worker.py
@@ -1037,7 +1037,12 @@ class TestKVPoolWorkerGetGroupTpSize(unittest.TestCase):
         worker = self._make_worker()
         worker.use_mla = True
         worker.group_uses_align_state = [False]
-        # _get_group_num_kv_heads returns 1 for MLA
+        self.assertEqual(worker.get_group_tp_size(0), 1)
+
+    def test_get_group_tp_size_sparse(self):
+        worker = self._make_worker()
+        worker.use_sparse = True
+        worker.group_uses_align_state = [False]
         self.assertEqual(worker.get_group_tp_size(0), 1)
 
 

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/ascend_store_connector.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/ascend_store_connector.py
@@ -30,6 +30,7 @@ from vllm.v1.request import Request
 from vllm.v1.serial_utils import MsgpackDecoder
 
 from vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.config_data import (
+    SCHEDULER_LOOKUP_BACKENDS,
     AscendStoreKVConnectorWorkerMetadata,
     block_hash_to_bytes,
 )
@@ -99,6 +100,7 @@ class AscendStoreConnector(KVConnectorBase_V1, SupportsHMA):
         backend_name = vllm_config.kv_transfer_config.kv_connector_extra_config.get("backend", "mooncake")
         self.backend_name = backend_name.lower()
         self.use_gva_layerwise = self.use_layerwise and self.backend_name == "memcache"
+        self.use_scheduler_client_for_lookup = not self.use_layerwise and self.backend_name in SCHEDULER_LOOKUP_BACKENDS
         self.consumer_is_to_put = vllm_config.kv_transfer_config.kv_connector_extra_config.get(
             "consumer_is_to_put", False
         )
@@ -128,7 +130,11 @@ class AscendStoreConnector(KVConnectorBase_V1, SupportsHMA):
                 kv_cache_config,
             )
             assert self.connector_worker is not None
-            if not self.use_layerwise and vllm_config.parallel_config.rank == 0:
+            if (
+                not self.use_layerwise
+                and not self.use_scheduler_client_for_lookup
+                and vllm_config.parallel_config.rank == 0
+            ):
                 self.lookup_server = LookupKeyServer(self.connector_worker, vllm_config)
 
     ############################################################

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/backend/mooncake_backend.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/backend/mooncake_backend.py
@@ -60,16 +60,23 @@ def _ssd_setup_kwargs(config: "MooncakeStoreConfig") -> dict[str, object]:
 
 
 class MooncakeBackend(Backend):
-    def __init__(self, parallel_config: ParallelConfig, lazy_init: bool = False, contribute_memory: bool = True):
+    def __init__(
+        self,
+        parallel_config: ParallelConfig,
+        lazy_init: bool = False,
+        contribute_memory: bool = True,
+        lookup_only: bool = False,
+    ):
         self.parallel_config = parallel_config
         self.config = MooncakeStoreConfig.load_from_env()
-        if self.config.protocol != "ascend":
+        if not lookup_only and self.config.protocol != "ascend":
             raise NotImplementedError(f"MooncakeBackend does not support protocol {self.config.protocol!r}.")
 
         self.store: Any | None = None
         self.local_seg: str | None = None
         self._use_fabric_mem = os.getenv("ASCEND_ENABLE_USE_FABRIC_MEM", "0") == "1"
-        self._lazy_init = lazy_init and self._use_fabric_mem
+        self._lookup_only = lookup_only
+        self._lazy_init = lazy_init and self._use_fabric_mem and not lookup_only
         self._contribute_memory = contribute_memory
         self._store_initialized = False
         self._store_init_lock = threading.Lock()
@@ -102,6 +109,20 @@ class MooncakeBackend(Backend):
 
         store = MooncakeDistributedStore()
         local_hostname = get_ip()
+        if self._lookup_only:
+            ret = store.setup(
+                local_hostname=local_hostname,
+                metadata_server=self.config.metadata_server,
+                global_segment_size=0,
+                local_buffer_size=0,
+                protocol="rpc_only",
+                rdma_devices="",
+                master_server_addr=self.config.master_server_address,
+            )
+            if ret != 0:
+                raise RuntimeError(f"Initialize Mooncake lookup client failed with return code {ret}.")
+            return store
+
         ssd_kwargs = _ssd_setup_kwargs(self.config)
         # Each rank that contributes memory to the pool uses its own SSD
         # directory to avoid bucket file collisions. Key by the globally unique
@@ -162,8 +183,7 @@ class MooncakeBackend(Backend):
 
     @classmethod
     def create_scheduler_client(cls, parallel_config: ParallelConfig):
-        torch.npu.set_device(0)
-        return cls(parallel_config, contribute_memory=False)
+        return cls(parallel_config, contribute_memory=False, lookup_only=True)
 
     def set_device(self):
         local_rank = get_world_group().local_rank
@@ -171,6 +191,8 @@ class MooncakeBackend(Backend):
         torch.npu.set_device(device)
 
     def register_buffer(self, ptrs: list[int], lengths: list[int]):
+        if self._lookup_only:
+            return
         if not self._use_fabric_mem:
             local_hostname = get_ip()
             global_te.get_transfer_engine(local_hostname, device_name=None)

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/config_data.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/config_data.py
@@ -14,6 +14,8 @@ from vllm.v1.core.sched.output import NewRequestData
 
 from vllm_ascend.memcache_comm_fence import AttentionComputeStartGate
 
+SCHEDULER_LOOKUP_BACKENDS = frozenset({"memcache", "mooncake"})
+
 
 @dataclass(frozen=True)
 class TPMismatchInfo:
@@ -67,6 +69,21 @@ def infer_tp_mismatch_info(
         effective_heads_per_rank=effective_heads_per_rank,
         num_sub_keys=num_sub_keys,
     )
+
+
+def get_kv_pool_lookup_tp_size(
+    tp_size: int,
+    num_kv_heads: int,
+    use_mla: bool,
+    use_sparse: bool,
+    use_align_state: bool = False,
+    effective_tp_size: int | None = None,
+) -> int:
+    if effective_tp_size is not None:
+        return effective_tp_size
+    if use_align_state:
+        return tp_size
+    return min(tp_size, 1 if use_mla or use_sparse else num_kv_heads)
 
 
 # Parameters related to the key
@@ -220,14 +237,18 @@ def infer_group_cache_families(
     kv_cache_groups: Sequence[object] | None,
     compress_ratios: Sequence[int] | None,
     hf_config: Any | None = None,
+    use_sparse: bool = False,
 ) -> list[str]:
     if kv_cache_groups is None:
-        return ["default"]
+        return ["mixed" if use_sparse else "default"]
 
     families: list[str] = []
     for group in kv_cache_groups:
+        if use_sparse:
+            families.append("mixed")
+            continue
         spec_ratios = _get_group_spec_ratios(group)
-        if len(spec_ratios) == 1:
+        if len(spec_ratios) == 1 and spec_ratios != {None}:
             families.append(infer_cache_family_from_ratio(next(iter(spec_ratios))))
             continue
         if len(spec_ratios) > 1:

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/pool_scheduler.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/pool_scheduler.py
@@ -28,6 +28,7 @@ from vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.backend import (
     backend_map,
 )
 from vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.config_data import (
+    SCHEDULER_LOOKUP_BACKENDS,
     AscendConnectorMetadata,
     AscendStoreKVConnectorWorkerMetadata,
     KeyMetadata,
@@ -35,13 +36,19 @@ from vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.config_data import
     PoolKey,
     ReqMeta,
     RequestTracker,
+    block_hash_to_bytes,
     block_hash_to_str,
     get_block_hashes,
     get_cache_family_granularity,
+    get_kv_pool_lookup_tp_size,
     infer_cache_family_ratio,
     infer_group_cache_families,
     infer_tp_mismatch_info,
     normalize_block_ids_by_group,
+)
+from vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.coordinator import (
+    AscendStoreCoordinator,
+    ExternalCachedBlockPool,
 )
 from vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.layerwise_cache_layout import (
     build_layerwise_cache_layout,
@@ -72,6 +79,7 @@ class KVPoolScheduler:
         if self.compress_ratios is None:
             self.compress_ratios = getattr(hf_config, "compress_ratios", None)
         self.use_compress = self.compress_ratios is not None
+        self.use_sparse = hasattr(vllm_config.model_config.hf_text_config, "index_topk")
         self.use_hybrid = self._uses_hybrid_kv_cache(vllm_config, kv_cache_config)
         self.kv_cache_group_ids = (
             list(range(len(kv_cache_config.kv_cache_groups)))
@@ -109,6 +117,7 @@ class KVPoolScheduler:
         self.dcp_size = getattr(vllm_config.parallel_config, "decode_context_parallel_size", 1)
 
         self.mamba_group_ids = self._infer_mamba_groups()
+        self.group_uses_align_state = self._infer_group_uses_align_state()
         self.num_speculative_blocks = (
             vllm_config.speculative_config.num_speculative_tokens if vllm_config.speculative_config else 0
         )
@@ -163,12 +172,14 @@ class KVPoolScheduler:
             use_hybrid=self.use_hybrid,
         )
         self.tp_mismatch = tp_mismatch_info.enabled
+        self.effective_tp_size = tp_mismatch_info.effective_tp_size
 
         self.page_size_bytes = page_size_bytes
         logger.info("KV pool page_size_bytes: %d", page_size_bytes)
         backend_name = vllm_config.kv_transfer_config.kv_connector_extra_config.get("backend", "mooncake")
         self.backend_name = backend_name.lower()
         self.use_gva_layerwise = self.use_layerwise and self.backend_name == "memcache"
+        self.use_scheduler_client_for_lookup = not self.use_layerwise and self.backend_name in SCHEDULER_LOOKUP_BACKENDS
         backend = backend_map.get(self.backend_name)
         if backend is None:
             raise ValueError(f"Unsupported KV pool backend: {backend_name}")
@@ -216,6 +227,7 @@ class KVPoolScheduler:
                     vllm_config.kv_transfer_config.kv_connector_extra_config,
                 ).has_layer_reuse
         self.model_name = model_config.model.split("/")[-1]
+        self.cache_coordinator = self._build_cache_coordinator()
 
         # Keep this in sync with pool_worker.py because it affects GVA allocation size.
         num_layer_keys = self.num_layers if self.use_gva_layerwise else 1
@@ -253,7 +265,7 @@ class KVPoolScheduler:
         include_layers: bool = False,
         kv_cache_group_id: int = 0,
     ) -> list[list[str]]:
-        head_or_tp_ranks = self.tp_size // self.put_step
+        head_or_tp_ranks = self.get_group_tp_size(kv_cache_group_id)
         cache_family = self._get_group_family(self.kv_cache_group_families, kv_cache_group_id)
         keys_by_block = []
         for block_hash in block_hashes:
@@ -285,6 +297,35 @@ class KVPoolScheduler:
             keys_by_block.append(block_keys)
         return keys_by_block
 
+    def get_group_tp_size(self, group_id: int) -> int:
+        use_align_state = group_id < len(self.group_uses_align_state) and self.group_uses_align_state[group_id]
+        return get_kv_pool_lookup_tp_size(
+            self.tp_size,
+            self.num_kv_head,
+            self.use_mla,
+            self.use_sparse,
+            use_align_state,
+            self.effective_tp_size if self.tp_mismatch else None,
+        )
+
+    def _get_lookup_key_prefixes(self, group_id: int) -> list[str]:
+        cache_family = self._get_group_family(self.kv_cache_group_families, group_id)
+        return [
+            (
+                f"{self.model_name}"
+                f"@pcp{pcp_rank}@dcp{dcp_rank}"
+                f"@head_or_tp_rank:{head_or_tp_rank}"
+                f"@pp_rank:{pp_rank}"
+                f"@group:{group_id}"
+                f"@cache_role:kv"
+                f"@cache_family:{cache_family}@"
+            )
+            for pcp_rank in range(self.pcp_size)
+            for dcp_rank in range(self.dcp_size)
+            for head_or_tp_rank in range(self.get_group_tp_size(group_id))
+            for pp_rank in range(self.pp_size)
+        ]
+
     def _get_store_lookup_hit_tokens(
         self,
         request: "Request",
@@ -313,20 +354,107 @@ class KVPoolScheduler:
                 f"expected={len(query_keys)}, actual={len(exists_states)}"
             )
 
-        num_queried_hit_blocks = 0
+        block_hits: list[bool] = []
         offset = 0
         for block_keys in query_keys_by_block:
             block_states = exists_states[offset : offset + len(block_keys)]
             offset += len(block_keys)
             if all(exists == 1 for exists in block_states):
-                num_queried_hit_blocks += 1
+                block_hits.append(True)
                 continue
             if any(exists == 0 for exists in block_states):
-                break
+                block_hits.append(False)
+                continue
             raise RuntimeError(f"KV pool exists check failed for request {request.request_id}: states={exists_states}")
+
+        if self.group_uses_align_state[0]:
+            for index in range(len(block_hits) - 1, -1, -1):
+                hit_end = (query_start_block + index + 1) * self._block_size
+                if block_hits[index] and hit_end % self.cache_transfer_granularity == 0:
+                    return hit_end
+            return 0
+
+        num_queried_hit_blocks = 0
+        for is_hit in block_hits:
+            if not is_hit:
+                break
+            num_queried_hit_blocks += 1
 
         num_hit_blocks = query_start_block + num_queried_hit_blocks
         return num_hit_blocks * self._block_size
+
+    def _get_coordinated_lookup_hit_tokens(
+        self,
+        request: "Request",
+        token_len: int,
+        hbm_hit_tokens: int,
+    ) -> int:
+        assert self.cache_coordinator is not None
+        block_hashes = request.block_hashes
+        exists: set[tuple[int, bytes]] = set()
+        aligned_len = cdiv(token_len, self.cache_coordinator.lcm_block_size) * self.cache_coordinator.lcm_block_size
+        lookup_masks = self.cache_coordinator.lookup_mask(aligned_len)
+
+        for group_id in self.kv_cache_group_ids:
+            effective_block_size = self._get_effective_group_block_size(group_id)
+            grouped_hashes = get_block_hashes(block_hashes, effective_block_size, self.hash_block_size)
+            num_chunks = min(len(grouped_hashes), cdiv(token_len, effective_block_size))
+            hbm_hit_chunks = min(hbm_hit_tokens // effective_block_size, num_chunks)
+            for chunk_index in range(hbm_hit_chunks):
+                exists.add((group_id, block_hash_to_bytes(grouped_hashes[chunk_index])))
+
+            prefixes = self._get_lookup_key_prefixes(group_id)
+            variant_count = len(prefixes)
+            lookup_mask = lookup_masks[group_id] if group_id < len(lookup_masks) else None
+            queried_hashes = []
+            query_keys = []
+            for chunk_index in range(hbm_hit_chunks, num_chunks):
+                if lookup_mask is not None and (chunk_index >= len(lookup_mask) or not lookup_mask[chunk_index]):
+                    continue
+                chunk_hash = grouped_hashes[chunk_index]
+                hash_string = block_hash_to_str(chunk_hash)
+                query_keys.extend(prefix + hash_string for prefix in prefixes)
+                queried_hashes.append(chunk_hash)
+
+            if not query_keys:
+                continue
+            exists_states = self.store_scheduler.batch_is_exist(query_keys)
+            if len(exists_states) != len(query_keys):
+                raise RuntimeError(
+                    "KV pool exists check returned unexpected number of states "
+                    f"for request {request.request_id}: expected={len(query_keys)}, actual={len(exists_states)}"
+                )
+            for chunk_index, chunk_hash in enumerate(queried_hashes):
+                offset = chunk_index * variant_count
+                if all(exists_states[index] == 1 for index in range(offset, offset + variant_count)):
+                    exists.add((group_id, block_hash_to_bytes(chunk_hash)))
+
+        _, hit_length = self.cache_coordinator.find_longest_cache_hit(
+            block_hashes,
+            token_len,
+            ExternalCachedBlockPool(self.hash_block_size, exists),
+            apply_eagle=False,
+        )
+        return hit_length
+
+    def _get_scheduler_lookup_hit_tokens(
+        self,
+        request: "Request",
+        token_len: int,
+        hbm_hit_tokens: int,
+    ) -> int:
+        try:
+            if self.cache_coordinator is not None:
+                return self._get_coordinated_lookup_hit_tokens(request, token_len, hbm_hit_tokens)
+            return self._get_store_lookup_hit_tokens(request, token_len, hbm_hit_tokens)
+        except Exception as e:
+            logger.error(
+                "Remote connection failed in scheduler KV pool lookup. "
+                "type=%s, error=%s. Check network and remote store.",
+                type(e).__name__,
+                e,
+            )
+            return 0
 
     def _make_layerwise_gva_keys_for_hit_check(self, group_id: int, block_hash_hex: str) -> list[str]:
         """Generate all-rank GVA keys for scheduler-side hit check.
@@ -412,7 +540,25 @@ class KVPoolScheduler:
 
     def _infer_group_families(self) -> list[str]:
         kv_cache_groups = self.kv_cache_config.kv_cache_groups if self.kv_cache_config is not None else None
-        return infer_group_cache_families(kv_cache_groups, self.compress_ratios, self.hf_config)
+        return infer_group_cache_families(
+            kv_cache_groups,
+            self.compress_ratios,
+            self.hf_config,
+            use_sparse=self.use_sparse and not self.use_compress and not self.use_hybrid,
+        )
+
+    def _build_cache_coordinator(self) -> AscendStoreCoordinator | None:
+        if self.use_layerwise or self.kv_cache_config is None or not self.use_hybrid:
+            return None
+        return AscendStoreCoordinator(
+            self.kv_cache_config.kv_cache_groups,
+            scheduler_block_size=self.cache_transfer_granularity,
+            hash_block_size=self.hash_block_size,
+            group_block_sizes=self.grouped_block_size,
+            group_cache_families=self.kv_cache_group_families,
+            use_eagle=self.use_eagle,
+            retention_interval=self.retention_interval,
+        )
 
     def _infer_group_block_sizes(
         self,
@@ -479,6 +625,23 @@ class KVPoolScheduler:
             if isinstance(kv_cache_spec, MambaSpec):
                 mamba_group_ids.append(group_id)
         return mamba_group_ids
+
+    def _infer_group_uses_align_state(self) -> list[bool]:
+        if self.kv_cache_config is None:
+            return [False]
+        group_uses_align_state = []
+        for group in self.kv_cache_config.kv_cache_groups:
+            kv_cache_spec = group.kv_cache_spec
+            if isinstance(kv_cache_spec, UniformTypeKVCacheSpecs):
+                specs = [kv_cache_spec.kv_cache_specs[layer_name] for layer_name in group.layer_names]
+            else:
+                specs = [kv_cache_spec]
+            group_uses_align_state.append(
+                any(
+                    isinstance(spec, MambaSpec) and getattr(spec, "mamba_cache_mode", None) == "align" for spec in specs
+                )
+            )
+        return group_uses_align_state
 
     def _infer_swa_blocks(self) -> list[int]:
         if self.kv_cache_config is None:
@@ -558,13 +721,20 @@ class KVPoolScheduler:
             if token_len < self.cache_transfer_granularity:
                 return 0, False
 
+            if not self.use_layerwise and num_computed_tokens >= token_len:
+                return 0, False
+
             if self.use_layerwise:
                 num_external_hit_tokens = self._get_store_lookup_hit_tokens(
                     request, token_len, num_computed_tokens, include_layers=True
                 )
+            elif self.use_scheduler_client_for_lookup:
+                num_external_hit_tokens = self._get_scheduler_lookup_hit_tokens(
+                    request,
+                    token_len,
+                    num_computed_tokens,
+                )
             else:
-                if num_computed_tokens >= token_len:
-                    return 0, False
                 if self.client is None:
                     self.client = LookupKeyClient(self.vllm_config)
                 num_external_hit_tokens = self.client.lookup(

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/pool_worker.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/pool_worker.py
@@ -43,6 +43,7 @@ from vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.config_data import
     block_hash_to_str,
     get_block_hashes,
     get_cache_family_granularity,
+    get_kv_pool_lookup_tp_size,
     infer_cache_family_ratio,
     infer_group_cache_families,
     infer_tp_mismatch_info,
@@ -606,7 +607,12 @@ class KVPoolWorker:
 
     def _infer_group_families(self) -> list[str]:
         kv_cache_groups = self.kv_cache_config.kv_cache_groups if self.kv_cache_config is not None else None
-        return infer_group_cache_families(kv_cache_groups, self.compress_ratios, self.hf_config)
+        return infer_group_cache_families(
+            kv_cache_groups,
+            self.compress_ratios,
+            self.hf_config,
+            use_sparse=self.use_sparse and not self.use_compress and not self.use_hybrid,
+        )
 
     def _infer_group_block_sizes(
         self,
@@ -2211,19 +2217,15 @@ class KVPoolWorker:
             return 0
         return min(hits) if hits else 0
 
-    def _get_group_num_kv_heads(self, group_id: int) -> int:
-        if self.use_mla or self.use_sparse:
-            return 1
-        if group_id < len(self.group_uses_align_state) and self.group_uses_align_state[group_id]:
-            return 1
-        return self.num_kv_head
-
     def get_group_tp_size(self, kv_cache_group_id: int):
-        if self.tp_mismatch:
-            return self.effective_tp_size
-        if self.group_uses_align_state[kv_cache_group_id]:
-            return self.tp_size
-        return min(self.tp_size, self._get_group_num_kv_heads(kv_cache_group_id))
+        return get_kv_pool_lookup_tp_size(
+            self.tp_size,
+            self.num_kv_head,
+            self.use_mla,
+            self.use_sparse,
+            self.group_uses_align_state[kv_cache_group_id],
+            self.effective_tp_size if self.tp_mismatch else None,
+        )
 
     @staticmethod
     def _replace_key_field(key: str, field: str, value: int) -> str:


### PR DESCRIPTION
### What this PR does / why we need it?

Move non-layerwise Mooncake and Memcache AscendStore lookup into the scheduler process, following the scheduler-client direction in lijiahang226/vllm-ascend#8.

- The scheduler calls the backend metadata client directly instead of using the scheduler -> ZMQ -> rank-0 worker lookup path.
- Worker-side `LookupKeyServer` creation is skipped for Mooncake and Memcache; Yuanrong keeps the existing fallback path.
- Mooncake creates a metadata-only client with the community `rpc_only` protocol, zero contributed memory, and no Transfer Engine or NPU device initialization.
- Scheduler key generation covers PCP, DCP, TP/head, and PP variants and shares TP-key-count logic with the worker.
- Hybrid/compressed KV cache groups use the AscendStore coordinator, including HBM-hit seeding and reachable lookup masks. Aligned state-cache and TP-mismatch behavior are also preserved.
- Layerwise lookup remains unchanged.

This removes the worker RPC hop and keeps metadata lookup off the model worker's Python hot path.

### Does this PR introduce _any_ user-facing change?

Yes. Non-layerwise Mooncake and Memcache lookup automatically runs in the scheduler process. No new configuration is required. Yuanrong and layerwise paths retain their current behavior.

### How was this patch tested?

- All pre-commit hooks passed for the changed files.
- Scheduler/config/backend/connector AscendStore unit tests: `236 passed`.
- Worker TP-key parity tests: `5 passed`.
- A broader local AscendStore run completed `338 passed`; its only failure is an existing CPU-only environment limitation where an unrelated test directly calls `torch.npu.Event`.

The added tests cover Mooncake `rpc_only` setup, Memcache/Mooncake direct scheduler lookup, removal of their worker lookup server, Yuanrong fallback, all-rank key generation, hybrid coordinator lookup, aligned state-cache lookup, sparse/MLA/TP-mismatch key counts, and full-HBM lookup bypass. NPU end-to-end testing was not run in the local environment.

- vLLM main: https://github.com/vllm-project/vllm/commit/d02df748bf9efd99022f1a062597dc3cb3808485
