### PR TITLE
[BugFix][Attention] Fix causal C8 multi-query verification and FULL replay tables

### DIFF
--- a/.github/workflows/scripts/test_config.yaml
+++ b/.github/workflows/scripts/test_config.yaml
@@ -127,6 +127,7 @@ estimated_times:
   tests/e2e/pull_request/one_card/pooling/test_classification.py: 270
   tests/e2e/pull_request/one_card/pooling/test_embedding.py: 580
   tests/e2e/pull_request/one_card/pooling/test_scoring.py: 740
+  tests/e2e/pull_request/one_card/spec_decode/test_c8_spec_decode_npu.py: 30
   tests/e2e/pull_request/one_card/spec_decode/test_dflash.py: 510
   tests/e2e/pull_request/one_card/spec_decode/test_dspark.py: 410
   tests/e2e/pull_request/one_card/spec_decode/test_dynamic.py: 420

--- a/tests/e2e/pull_request/one_card/spec_decode/test_c8_spec_decode_npu.py
+++ b/tests/e2e/pull_request/one_card/spec_decode/test_c8_spec_decode_npu.py
@@ -5,6 +5,7 @@
 
 The standard D128 kernel is intentional: these tests need neither a private
 quantized checkpoint nor the separate D256 custom operator used by Qwen3.8.
+Keep them in the one-card hardware suite; tests/ut is routed to CPU runners.
 """
 
 from types import SimpleNamespace

--- a/tests/ut/attention/test_attention_v1.py
+++ b/tests/ut/attention/test_attention_v1.py
@@ -204,7 +204,7 @@ class TestC8DecodeMetadata(TestBase):
         buffers = [torch.zeros(8, 2, dtype=torch.int32) for _ in names]
         captured = []
         for name, buffer in zip(names, buffers):
-            param = [None] * 23
+            param: list[object] = [None] * 23
             param[3] = buffer
             param[17] = torch.ones(1)
             param[21] = name

--- a/tests/ut/attention/test_attention_v1.py
+++ b/tests/ut/attention/test_attention_v1.py
@@ -12,6 +12,7 @@ from vllm_ascend.attention.attention_v1 import (
     AscendAttentionState,
     AscendC8AttentionBackendImpl,
     AscendMetadata,
+    _expand_c8_decode_metadata,
 )
 from vllm_ascend.attention.context_parallel.attention_cp import (
     AscendAttentionDCPImpl,
@@ -30,6 +31,213 @@ from vllm_ascend.device.utils import FIA_TND_LARGE_HEAD_FALLBACK_HEAD_SIZE
 from vllm_ascend.utils import AscendDeviceType
 
 LARGE_HEAD_PREFILL_PATH = "vllm_ascend.device.utils.npu_large_head_prefill_attention"
+
+
+class TestC8DecodeMetadata(TestBase):
+    @staticmethod
+    def _metadata(query_ends, kv_lens, tables, **kwargs):
+        return AscendMetadata(
+            actual_seq_lengths_q=query_ends,
+            seq_lens_list=kv_lens,
+            block_tables=tables,
+            num_actual_tokens=query_ends[-1],
+            num_decode_tokens=query_ends[-1],
+            num_decodes=len(query_ends),
+            **kwargs,
+        )
+
+    @staticmethod
+    def _impl():
+        impl = AscendC8AttentionBackendImpl.__new__(AscendC8AttentionBackendImpl)
+        impl.num_heads = 4
+        impl.num_kv_heads = 2
+        impl.head_size = 128
+        impl.scale = 128**-0.5
+        impl.key_cache = torch.zeros(4, 128, 2, 128, dtype=torch.int8)
+        impl.value_cache = torch.zeros_like(impl.key_cache)
+        impl.enable_c8_quant = True
+        impl.sliding_window = None
+        impl.kv_sharing_target_layer_name = None
+        impl._use_layer_aware_fia_graph_replay = False
+        impl._use_max_workspace_for_fia_graph = False
+        return impl
+
+    @staticmethod
+    def _layer(name="model.layers.0.self_attn.attn"):
+        return SimpleNamespace(
+            layer_name=name,
+            _c8_k_aq_scale_nz_bnsd=torch.ones(1, 2, 1, 128),
+            _c8_v_aq_scale_nz_bnsd=torch.ones(1, 2, 1, 128),
+        )
+
+    def test_verification_queries_only_see_their_causal_prefix(self):
+        tables = torch.tensor([[7, 11, 13]], dtype=torch.int32)
+        expanded, lengths = _expand_c8_decode_metadata(tables, [1008], [8], 1)
+        self.assertEqual(lengths, list(range(1001, 1009)))
+        torch.testing.assert_close(expanded, tables.repeat(8, 1))
+
+    def test_variable_query_lengths_do_not_repeat_the_final_kv_length(self):
+        tables = torch.tensor([[7, 8], [11, 12]], dtype=torch.int32)
+        expanded, lengths = _expand_c8_decode_metadata(tables, [100, 200], [1, 4], 2)
+        self.assertEqual(lengths, [100, 198, 199, 200])
+        torch.testing.assert_close(expanded, tables[[0, 1, 1, 1]])
+
+    def test_single_token_decode_keeps_the_original_storage(self):
+        tables = torch.tensor([[7, 8], [11, 12]], dtype=torch.int32)
+        expanded, lengths = _expand_c8_decode_metadata(tables, [100, 200], [1, 2], 2)
+        self.assertEqual(expanded.data_ptr(), tables.data_ptr())
+        self.assertEqual(lengths, [100, 200])
+
+    def test_noncausal_queries_keep_the_full_kv_length(self):
+        tables = torch.tensor([[7, 8]], dtype=torch.int32)
+        expanded, lengths = _expand_c8_decode_metadata(tables, [2], [3], 1, causal=False)
+        self.assertEqual(lengths, [2, 2, 2])
+        torch.testing.assert_close(expanded, tables.repeat(3, 1))
+
+    def test_padding_request_does_not_produce_negative_kv_lengths(self):
+        tables = torch.tensor([[7, 8], [0, 0]], dtype=torch.int32)
+        expanded, lengths = _expand_c8_decode_metadata(tables, [100, 1], [3, 8], 2, num_actual_tokens=3)
+        self.assertEqual(lengths, [98, 99, 100, 1, 1, 1, 1, 1])
+        torch.testing.assert_close(expanded[3:], torch.zeros(5, 2, dtype=torch.int32))
+
+    def test_capture_can_compute_lengths_without_expanding_a_device_table(self):
+        tables = torch.tensor([[7, 8]], dtype=torch.int32)
+        expanded, lengths = _expand_c8_decode_metadata(tables, [100], [3], 1, expand_tables=False)
+        self.assertEqual(expanded.data_ptr(), tables.data_ptr())
+        self.assertEqual(expanded.shape, tables.shape)
+        self.assertEqual(lengths, [98, 99, 100])
+
+    def test_invalid_metadata_is_rejected(self):
+        tables = torch.tensor([[7, 8]], dtype=torch.int32)
+        for kv_lens, query_ends, num_requests in (([2], [8], 1), ([8], [0], 1), ([], [], 0), ([8], [1], 2)):
+            with (
+                self.subTest(kv_lens=kv_lens, query_ends=query_ends, num_requests=num_requests),
+                self.assertRaises(ValueError),
+            ):
+                _expand_c8_decode_metadata(tables, kv_lens, query_ends, num_requests)
+
+    def test_graph_buffers_are_owned_per_layer_with_bounded_capture_storage(self):
+        first, second = self._impl(), self._impl()
+        table = torch.zeros(2, 3, dtype=torch.int32)
+        first.prepare_graph_block_tables(table, [4, 8])
+        second.prepare_graph_block_tables(table, [4, 8])
+        self.assertEqual(first._c8_graph_block_tables[4].shape, (4, 3))
+        self.assertEqual(first._c8_graph_block_tables[8].shape, (8, 3))
+        self.assertEqual(first._c8_graph_block_tables[4].data_ptr(), first._c8_graph_block_tables[8].data_ptr())
+        self.assertNotEqual(first._c8_graph_block_tables[8].data_ptr(), second._c8_graph_block_tables[8].data_ptr())
+        self.assertEqual(first._c8_graph_block_tables[4].untyped_storage().nbytes(), 8 * 3 * 4)
+        first._c8_graph_block_tables[8].fill_(9)
+        self.assertEqual(torch.count_nonzero(second._c8_graph_block_tables[8]), 0)
+
+    @patch("torch_npu.npu_fused_infer_attention_score")
+    def test_eager_decode_passes_one_block_row_and_length_per_query(self, mock_fia):
+        impl = self._impl()
+        tables = torch.tensor([[1, 2], [3, 0]], dtype=torch.int32)
+        metadata = self._metadata([1, 4], [100, 200], tables)
+        query = torch.zeros(4, 4, 128)
+        output = torch.empty_like(query)
+        mock_fia.return_value = (torch.zeros(4, 4, 1, 128), None)
+        impl._forward_c8_decode(query, metadata, output, self._layer())
+        args = mock_fia.call_args
+        self.assertEqual(args.args[0].shape, (4, 4, 1, 128))
+        self.assertEqual(args.kwargs["actual_seq_lengths"], [1] * 4)
+        self.assertEqual(args.kwargs["actual_seq_lengths_kv"], [100, 198, 199, 200])
+        torch.testing.assert_close(args.kwargs["block_table"], tables[[0, 1, 1, 1]])
+
+    @patch("torch_npu.npu_fused_infer_attention_score")
+    def test_chunked_prefill_only_expands_the_decode_part(self, mock_fia):
+        impl = self._impl()
+        tables = torch.tensor([[1, 2], [3, 0]], dtype=torch.int32)
+        metadata = self._metadata([3, 5], [100, 2], tables, num_prefills=1)
+        metadata.num_decodes = 1
+        metadata.num_decode_tokens = 3
+        query = torch.zeros(5, 4, 128)
+        mock_fia.side_effect = [(torch.zeros(3, 4, 1, 128), None), (torch.zeros(2, 4, 128), None)]
+        impl._forward_c8_chunked_prefill(query, query, query, metadata, torch.empty_like(query), self._layer())
+        decode, prefill = mock_fia.call_args_list
+        self.assertEqual(decode.kwargs["actual_seq_lengths_kv"], [98, 99, 100])
+        torch.testing.assert_close(decode.kwargs["block_table"], tables[:1].repeat(3, 1))
+        self.assertEqual(prefill.kwargs["input_layout"], "TND")
+        self.assertEqual(prefill.kwargs["actual_seq_lengths"], [2])
+        self.assertEqual(prefill.kwargs["actual_seq_lengths_kv"], [2])
+
+    @patch("torch.npu.graph_task_group_end")
+    @patch("torch.npu.graph_task_group_begin")
+    @patch("torch.npu.ExternalEvent")
+    @patch("torch_npu.npu.current_stream")
+    @patch("torch_npu.npu_fused_infer_attention_score")
+    @patch("vllm_ascend.attention.attention_v1.weak_ref_tensors", side_effect=lambda tensor: tensor)
+    @patch("vllm_ascend.attention.attention_v1.get_graph_params")
+    @patch("vllm_ascend.attention.attention_v1._EXTRA_CTX", is_draft_model=False)
+    def test_capture_uses_owned_buffer_without_copying_dummy_metadata(self, _ctx, get_params, _weak, fia, *_mocks):
+        impl = self._impl()
+        tables = torch.tensor([[1, 2]], dtype=torch.int32)
+        impl.prepare_graph_block_tables(tables, [8])
+        owned = impl._c8_graph_block_tables[8]
+        owned.fill_(17)
+        metadata = self._metadata([8], [1008], tables)
+        params = SimpleNamespace(events={8: []}, handles={8: []}, attn_params={8: []}, workspaces={8: torch.empty(1)})
+        get_params.return_value = params
+        impl._get_fia_params = lambda *args: (impl.key_cache, impl.value_cache, 128, tables, [1008])
+        query = torch.zeros(8, 4, 128)
+        with patch.object(torch.Tensor, "repeat_interleave", side_effect=AssertionError("captured dummy expansion")):
+            impl.full_graph_fia(query, query, query, metadata, torch.empty_like(query), self._layer())
+        args = fia.out.call_args.kwargs
+        self.assertEqual(args["block_table"].data_ptr(), owned.data_ptr())
+        self.assertTrue(torch.all(owned == 17))
+        self.assertEqual(args["actual_seq_lengths"], [1] * 8)
+        self.assertEqual(args["actual_seq_lengths_kv"], list(range(1001, 1009)))
+        self.assertEqual(params.attn_params[8][-1][-2], "model.layers.0.self_attn.attn")
+        self.assertTrue(params.attn_params[8][-1][-1])
+
+    @patch("torch.npu.stream")
+    @patch("torch.npu.graph_task_update_begin")
+    @patch("torch.npu.graph_task_update_end")
+    @patch("torch_npu.npu_fused_infer_attention_score")
+    @patch("vllm_ascend.attention.attention_v1.get_graph_params")
+    @patch("vllm_ascend.attention.attention_v1._EXTRA_CTX", sinks=False, is_draft_model=False)
+    @patch("vllm_ascend.attention.attention_v1.using_paged_attention", return_value=False)
+    @patch("vllm_ascend.attention.attention_v1.needs_layer_aware_fia_graph_replay", return_value=False)
+    @patch("vllm_ascend.attention.attention_v1._ATTN_KEYS_BUFFER", new=[])
+    def test_replay_uses_layer_names_and_persistent_addresses(self, _aware, _pa, _ctx, get_params, fia, *_mocks):
+        names = ["model.layers.0.self_attn.attn", "model.layers.4.self_attn.attn"]
+        buffers = [torch.zeros(8, 2, dtype=torch.int32) for _ in names]
+        captured = []
+        for name, buffer in zip(names, buffers):
+            param = [None] * 23
+            param[3] = buffer
+            param[17] = torch.ones(1)
+            param[21] = name
+            param[22] = True
+            captured.append(tuple(param))
+        get_params.return_value = SimpleNamespace(
+            events={8: [MagicMock(), MagicMock()]},
+            handles={8: [MagicMock(), MagicMock()]},
+            attn_params={8: captured},
+            workspaces={8: torch.empty(1)},
+        )
+        for iteration in range(3):
+            tables = [
+                torch.tensor([[iteration + 1, 5]], dtype=torch.int32),
+                torch.tensor([[9, iteration + 10]], dtype=torch.int32),
+            ]
+            metadata = {
+                names[1]: self._metadata([8], [2008 + iteration], tables[1]),
+                names[0]: self._metadata([8], [1008 + iteration], tables[0]),
+            }
+            fia.reset_mock()
+            AscendAttentionBackendImpl.update_graph_params(
+                MagicMock(), SimpleNamespace(attn_metadata=metadata), 8, MagicMock()
+            )
+            self.assertEqual(fia.out.call_count, 2)
+            for i, call in enumerate(fia.out.call_args_list):
+                args = call.kwargs
+                self.assertEqual(args["block_table"].data_ptr(), buffers[i].data_ptr())
+                self.assertNotEqual(args["block_table"].data_ptr(), tables[i].data_ptr())
+                torch.testing.assert_close(buffers[i], tables[i].repeat(8, 1))
+                end = (1008, 2008)[i] + iteration
+                self.assertEqual(args["actual_seq_lengths_kv"], list(range(end - 7, end + 1)))
+                self.assertEqual(args["actual_seq_lengths"], [1] * 8)
 
 
 class TestAttentionGraphHelpers(TestBase):
@@ -807,7 +1015,8 @@ class TestAscendAttentionBackendImpl(TestBase):
         mock_EXTRA_CTX.sinks = False
         mock_EXTRA_CTX.is_draft_model = False
 
-        param: list[MagicMock | None] = [MagicMock()] * 22
+        param: list[MagicMock | None | bool] = [MagicMock()] * 23
+        param[22] = False
         param[16] = None  # sliding_window
         param[17] = None  # c8_k_aq_scale
         param[21] = None  # layer_name

--- a/tests/ut/attention/test_attention_v1.py
+++ b/tests/ut/attention/test_attention_v1.py
@@ -521,6 +521,8 @@ class TestAscendAttentionBackendImpl(TestBase):
 
         self.event_patcher.start()
         self.stream_patcher.start()
+        self.addCleanup(self.event_patcher.stop)
+        self.addCleanup(self.stream_patcher.stop)
 
         self.layer = MagicMock()
         self.layer.layer_name = "test_layer"

--- a/tests/ut/attention/test_c8_spec_decode_npu.py
+++ b/tests/ut/attention/test_c8_spec_decode_npu.py
@@ -1,0 +1,185 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vllm-ascend project
+
+"""Model-free C8 numerical regressions using real FIA and ACL graph replay.
+
+The standard D128 kernel is intentional: these tests need neither a private
+quantized checkpoint nor the separate D256 custom operator used by Qwen3.8.
+"""
+
+from types import SimpleNamespace
+
+import pytest
+import torch
+from vllm.config import VllmConfig, set_current_vllm_config
+
+import vllm_ascend.attention.attention_v1 as attention_module
+import vllm_ascend.compilation.acl_graph as acl_graph
+from vllm_ascend.attention.attention_v1 import (
+    AscendAttentionBackendImpl,
+    AscendAttentionState,
+    AscendC8AttentionBackendImpl,
+    AscendMetadata,
+)
+
+pytestmark = pytest.mark.skipif(not torch.npu.is_available(), reason="Requires an Ascend NPU")
+
+BLOCK_SIZE = 128
+HEAD_SIZE = 128
+NUM_HEADS = 4
+NUM_KV_HEADS = 2
+
+
+def _pack_nz(tensor):
+    return (
+        tensor.reshape(8, BLOCK_SIZE, NUM_KV_HEADS, HEAD_SIZE // 32, 32)
+        .permute(0, 2, 3, 1, 4)
+        .contiguous()
+        .reshape(tensor.shape)
+        .npu()
+    )
+
+
+def _make_layer(seed, name):
+    generator = torch.Generator().manual_seed(seed)
+    key = torch.randint(-20, 21, (8, BLOCK_SIZE, NUM_KV_HEADS, HEAD_SIZE), generator=generator, dtype=torch.int8)
+    value = torch.randint(-20, 21, key.shape, generator=generator, dtype=torch.int8)
+    scale = torch.full((1, NUM_KV_HEADS, 1, HEAD_SIZE), 0.05, dtype=torch.bfloat16)
+
+    impl = AscendC8AttentionBackendImpl.__new__(AscendC8AttentionBackendImpl)
+    impl.num_heads = NUM_HEADS
+    impl.num_kv_heads = NUM_KV_HEADS
+    impl.head_size = HEAD_SIZE
+    impl.scale = HEAD_SIZE**-0.5
+    impl.key_cache = _pack_nz(key)
+    impl.value_cache = _pack_nz(value)
+    impl.enable_c8_quant = True
+    impl.sliding_window = None
+    impl.kv_sharing_target_layer_name = None
+    impl._use_layer_aware_fia_graph_replay = False
+    impl._use_max_workspace_for_fia_graph = False
+    layer = SimpleNamespace(
+        layer_name=name,
+        _c8_k_aq_scale_nz_bnsd=scale.squeeze(0).npu(),
+        _c8_v_aq_scale_nz_bnsd=scale.squeeze(0).npu(),
+    )
+    return impl, layer, key, value, scale
+
+
+def _metadata(query_lens, kv_lens, tables):
+    return AscendMetadata(
+        attn_state=AscendAttentionState.SpecDecoding,
+        actual_seq_lengths_q=torch.tensor(query_lens).cumsum(0).tolist(),
+        seq_lens_list=kv_lens,
+        block_tables=torch.tensor(tables, dtype=torch.int32, device="npu"),
+        num_actual_tokens=sum(query_lens),
+        num_decode_tokens=sum(query_lens),
+        num_decodes=len(query_lens),
+    )
+
+
+def _reference(query, key, value, scale, query_lens, kv_lens, tables):
+    result = []
+    start = 0
+    channel_scale = scale.reshape(NUM_KV_HEADS, HEAD_SIZE).float()
+    for q_len, kv_len, pages in zip(query_lens, kv_lens, tables):
+        keys = key[pages].reshape(-1, NUM_KV_HEADS, HEAD_SIZE).float() * channel_scale
+        values = value[pages].reshape(-1, NUM_KV_HEADS, HEAD_SIZE).float() * channel_scale
+        keys = keys.repeat_interleave(NUM_HEADS // NUM_KV_HEADS, dim=1)
+        values = values.repeat_interleave(NUM_HEADS // NUM_KV_HEADS, dim=1)
+        for index in range(q_len):
+            visible = kv_len - q_len + index + 1
+            scores = torch.einsum("hd,thd->ht", query[start + index].float(), keys[:visible]) * HEAD_SIZE**-0.5
+            result.append(torch.einsum("ht,thd->hd", scores.softmax(-1), values[:visible]))
+        start += q_len
+    return torch.stack(result)
+
+
+@pytest.mark.parametrize("query_lens,kv_lens", [([1], [130]), ([8], [136]), ([1, 3], [130, 250])])
+def test_c8_eager_matches_per_query_causal_reference(query_lens, kv_lens):
+    impl, layer, key, value, scale = _make_layer(42, "model.layers.0.self_attn.attn")
+    tables = [[4, 1], [6, 3]][: len(query_lens)]
+    generator = torch.Generator().manual_seed(24)
+    query = torch.randn(sum(query_lens), NUM_HEADS, HEAD_SIZE, generator=generator, dtype=torch.bfloat16)
+    metadata = _metadata(query_lens, kv_lens, tables)
+    result = impl._forward_c8_decode(query.npu(), metadata, torch.empty_like(query, device="npu"), layer)
+    expected = _reference(query, key, value, scale, query_lens, kv_lens, tables)
+    torch.testing.assert_close(result.cpu().float(), expected, atol=2e-3, rtol=2e-2)
+
+
+def test_c8_does_not_expose_unverified_future_values():
+    impl, layer, _, value, _ = _make_layer(42, "model.layers.0.self_attn.attn")
+    impl.key_cache.zero_()
+    value.zero_()
+    # Pages [4, 1], final length 136: the first query may see indices 0..128.
+    # Only the seven FUTURE values at logical indices 129..135 are nonzero.
+    value[1, 1:8] = 100
+    impl.value_cache.copy_(_pack_nz(value))
+    query = torch.zeros(8, NUM_HEADS, HEAD_SIZE, dtype=torch.bfloat16, device="npu")
+    metadata = _metadata([8], [136], [[4, 1]])
+    result = impl._forward_c8_decode(query, metadata, torch.empty_like(query), layer).cpu()
+    torch.testing.assert_close(result[0], torch.zeros_like(result[0]), atol=0, rtol=0)
+    assert result[-1].float().min() > 0.2
+
+
+def test_c8_full_replay_updates_two_layers_without_dummy_table_overwrite(monkeypatch):
+    """Replay several lengths/tables through the actual capture/update methods."""
+    config = VllmConfig()
+    # Select the FIA speculative path without loading a checkpoint.
+    config.speculative_config = SimpleNamespace(num_speculative_tokens=7)
+    capture_sizes = [4, 8]
+    graph_params = acl_graph.GraphParams(
+        {size: [] for size in capture_sizes},
+        {size: None for size in capture_sizes},
+        {size: [] for size in capture_sizes},
+        {size: [] for size in capture_sizes},
+    )
+    monkeypatch.setattr(acl_graph, "_graph_params", graph_params)
+    monkeypatch.setattr(attention_module, "_EXTRA_CTX", SimpleNamespace(is_draft_model=False, sinks=False))
+    layers = [_make_layer(42 + i, f"model.layers.{i}.self_attn.attn") for i in range(2)]
+    query = torch.zeros(max(capture_sizes), NUM_HEADS, HEAD_SIZE, dtype=torch.bfloat16, device="npu")
+    outputs = [torch.empty_like(query) for _ in layers]
+    dummy_metadata = {size: _metadata([size], [size], [[0, 0]]) for size in capture_sizes}
+    # Mixed FULL capture can use one token per dummy request, then replay a
+    # multi-query request of the same total size. Ownership must not depend on
+    # the dummy query lengths used at capture time.
+    dummy_metadata[8] = _metadata([1] * 8, [1] * 8, [[0, 0]] * 8)
+    for impl, *_ in layers:
+        impl.prepare_graph_block_tables(dummy_metadata[8].block_tables, capture_sizes)
+
+    capture_stream = torch.npu.Stream()
+    capture_stream.wait_stream(torch.npu.current_stream())
+    with set_current_vllm_config(config), torch.npu.stream(capture_stream):
+        # Warm up FIA independently; the capture below uses the implementation's
+        # real graph-task/event/workspace registration, not a mocked kernel.
+        for impl, layer, *_ in layers:
+            impl._forward_c8_decode(query, dummy_metadata[8], torch.empty_like(query), layer)
+        torch.npu.synchronize()
+        graphs = {}
+        for size in reversed(capture_sizes):
+            graph = torch.npu.NPUGraph()
+            with torch.npu.graph(graph, stream=capture_stream):
+                for (impl, layer, *_), output in zip(layers, outputs):
+                    impl.full_graph_fia(query[:size], None, None, dummy_metadata[size], output[:size], layer)
+            graphs[size] = graph
+
+    update_stream = torch.npu.Stream()
+    generator = torch.Generator().manual_seed(123)
+    with set_current_vllm_config(config):
+        for iteration, num_tokens in enumerate((8, 4, 8)):
+            query_cpu = torch.randn(query.shape, generator=generator, dtype=torch.bfloat16)
+            query.copy_(query_cpu)
+            tables = ([[4, 1]], [[6, 3]]) if iteration % 2 == 0 else ([[6, 3]], [[4, 1]])
+            kv_lens = ([136 + iteration], [248 - iteration])
+            # Reverse insertion order to exercise captured layer-name lookup.
+            metadata = {layers[i][1].layer_name: _metadata([num_tokens], kv_lens[i], tables[i]) for i in (1, 0)}
+            update_stream.wait_stream(torch.npu.current_stream())
+            AscendAttentionBackendImpl.update_graph_params(
+                update_stream, SimpleNamespace(attn_metadata=metadata), num_tokens, config
+            )
+            torch.npu.current_stream().wait_stream(update_stream)
+            graphs[num_tokens].replay()
+            torch.npu.synchronize()
+            for i, (_, _, key, value, scale) in enumerate(layers):
+                expected = _reference(query_cpu[:num_tokens], key, value, scale, [num_tokens], kv_lens[i], tables[i])
+                torch.testing.assert_close(outputs[i][:num_tokens].cpu().float(), expected, atol=2e-3, rtol=2e-2)

--- a/tests/ut/worker/test_model_runner_v1.py
+++ b/tests/ut/worker/test_model_runner_v1.py
@@ -24,6 +24,7 @@ from vllm.v1.utils import CpuGpuBuffer
 from vllm.v1.worker.gpu_input_batch import CachedRequestState, InputBatch
 from vllm.v1.worker.gpu_model_runner import GPUModelRunner
 
+from vllm_ascend.attention.attention_v1 import AscendC8AttentionBackendImpl
 from vllm_ascend.attention.mla_v1 import AscendMLABackend
 from vllm_ascend.attention.utils import get_sfa_qsfa_packed_head_dim
 from vllm_ascend.core.kv_cache_interface import AscendMLAAttentionSpec, AscendSFAIndexerCacheSpec
@@ -176,6 +177,45 @@ class TestDeviceMetadataFullGraphEvents(unittest.TestCase):
             runner._dummy_run(4, cudagraph_runtime_mode=CUDAGraphMode.FULL, is_graph_capturing=True)
 
         self.assertEqual(events, ["context_enter", "forward", "context_exit", "release"])
+
+
+class TestC8GraphBlockTables(unittest.TestCase):
+    def test_buffers_use_their_own_cache_group_and_only_c8_layers(self):
+        runner = NPUModelRunner.__new__(NPUModelRunner)
+        layers = {
+            name: SimpleNamespace(
+                impl=AscendC8AttentionBackendImpl.__new__(AscendC8AttentionBackendImpl),
+                kv_cache_torch_dtype=dtype,
+                _k_cache_scale=torch.ones(1),
+            )
+            for name, dtype in (("target.a", torch.int8), ("target.b", torch.int8), ("draft", torch.bfloat16))
+        }
+        runner.compilation_config = SimpleNamespace(
+            static_forward_context=layers, cudagraph_mode=CUDAGraphMode.FULL_DECODE_ONLY
+        )
+        runner.cudagraph_batch_sizes = [4, 8]
+        runner.speculative_config = object()
+        runner.max_num_reqs = 8
+        tables = [torch.zeros(8, 3, dtype=torch.int32), torch.zeros(8, 5, dtype=torch.int32)]
+        runner.input_batch = SimpleNamespace(
+            block_table=[SimpleNamespace(get_device_tensor=MagicMock(return_value=table)) for table in tables]
+        )
+        config = SimpleNamespace(
+            kv_cache_groups=[
+                SimpleNamespace(layer_names=["target.a", "draft"]),
+                SimpleNamespace(layer_names=["target.b"]),
+            ]
+        )
+        runner._prepare_c8_graph_block_tables(config)
+        self.assertEqual(layers["target.a"].impl._c8_graph_block_tables[8].shape, (8, 3))
+        self.assertEqual(layers["target.b"].impl._c8_graph_block_tables[8].shape, (8, 5))
+        self.assertFalse(hasattr(layers["draft"].impl, "_c8_graph_block_tables"))
+        runner.speculative_config = None
+        runner._prepare_c8_graph_block_tables(config)
+        self.assertEqual(layers["target.a"].impl._c8_graph_block_tables, {})
+        runner.compilation_config.cudagraph_mode = CUDAGraphMode.FULL
+        runner._prepare_c8_graph_block_tables(config)
+        self.assertEqual(set(layers["target.a"].impl._c8_graph_block_tables), {4, 8})
 
 
 class TestDSparkAuxCaptureMode(unittest.TestCase):

--- a/vllm_ascend/attention/attention_v1.py
+++ b/vllm_ascend/attention/attention_v1.py
@@ -75,6 +75,54 @@ SWA_INT_MAX = 2147483647
 _ATTN_KEYS_BUFFER = None
 
 
+def _expand_c8_decode_metadata(
+    block_tables: torch.Tensor,
+    seq_lens: list[int],
+    actual_seq_qlen: list[int],
+    num_requests: int,
+    *,
+    causal: bool = True,
+    num_actual_tokens: int | None = None,
+    expand_tables: bool = True,
+) -> tuple[torch.Tensor, list[int]]:
+    """Map flattened BNSD queries to paged rows and their visible KV lengths.
+
+    The C8 path uses S=1, including when a request verifies multiple tokens.
+    Repeating its final KV length would let earlier queries see future tokens.
+    Lengths are already host metadata; do not read device tensors here.
+    """
+    if not 0 < num_requests <= min(len(seq_lens), len(actual_seq_qlen), block_tables.shape[0]):
+        raise ValueError("C8 decode requires matching request metadata and block-table rows")
+    query_lens = []
+    expanded_seq_lens = []
+    previous_q_end = 0
+    for request_idx in range(num_requests):
+        q_end = int(actual_seq_qlen[request_idx])
+        query_len = q_end - previous_q_end
+        kv_len = int(seq_lens[request_idx])
+        is_padding = num_actual_tokens is not None and previous_q_end >= num_actual_tokens
+        if query_len <= 0 or (not is_padding and (kv_len <= 0 or (causal and kv_len < query_len))):
+            raise ValueError(f"Invalid C8 decode lengths: query={query_len}, kv={kv_len}")
+        query_lens.append(query_len)
+        if is_padding:
+            # The builder uses a null block row for the dummy padding request.
+            # Its output is discarded; avoid negative lengths for Q > KV = 1.
+            expanded_seq_lens.extend([1] * query_len)
+        elif causal:
+            expanded_seq_lens.extend(range(kv_len - query_len + 1, kv_len + 1))
+        else:
+            expanded_seq_lens.extend([kv_len] * query_len)
+        previous_q_end = q_end
+    tables = block_tables[:num_requests]
+    if not expand_tables or all(length == 1 for length in query_lens):
+        return tables, expanded_seq_lens
+    if len(set(query_lens)) == 1:
+        tables = tables.repeat_interleave(query_lens[0], dim=0)
+    else:
+        tables = torch.cat([tables[i : i + 1].expand(length, -1) for i, length in enumerate(query_lens)], dim=0)
+    return tables, expanded_seq_lens
+
+
 @register_backend(AttentionBackendEnum.CUSTOM, "ASCEND")
 class AscendAttentionBackend(AttentionBackend):
     accept_output_buffer: bool = True
@@ -858,8 +906,10 @@ class AscendAttentionBackendImpl(AttentionImpl):
                         c8_v_aq_scale,
                         c8_v_aq_offset,
                         layer_name,
+                        c8_block_table_is_persistent,
                     ) = param
 
+                    captured_block_tables = block_tables
                     if _EXTRA_CTX.is_draft_model:
                         draft_step, key = draft_attn_key_steps[attn_count]
                         metadata = attn_metadata[draft_step][key]
@@ -871,8 +921,9 @@ class AscendAttentionBackendImpl(AttentionImpl):
                             sparse_mode = 0
                     else:
                         metadata_key = layer_name if layer_name is not None and layer_name in attn_metadata else key
-                        seq_lens = attn_metadata[metadata_key].seq_lens_list
-                        actual_seq_lengths_q = attn_metadata[metadata_key].actual_seq_lengths_q
+                        metadata = attn_metadata[metadata_key]
+                        seq_lens = metadata.seq_lens_list
+                        actual_seq_lengths_q = metadata.actual_seq_lengths_q
                         # NOTE:
                         # For models with sliding-window attention on the FIA full-graph replay path,
                         # rebinding `block_tables` to the latest metadata tensor causes corrupted /
@@ -884,6 +935,27 @@ class AscendAttentionBackendImpl(AttentionImpl):
                         if not sliding_window:
                             block_tables = attn_metadata[metadata_key].block_tables
                     layer_count += 1
+
+                    if c8_k_aq_scale is not None:
+                        block_tables, seq_lens = _expand_c8_decode_metadata(
+                            metadata.block_tables,
+                            seq_lens,
+                            actual_seq_lengths_q,
+                            len(actual_seq_lengths_q),
+                            causal=metadata.causal,
+                            num_actual_tokens=metadata.num_actual_tokens,
+                        )
+                        if len(seq_lens) != num_tokens:
+                            raise ValueError("C8 replay query count must match the captured graph size")
+                        if c8_block_table_is_persistent:
+                            # graph_task_update keeps the input address, not ownership
+                            # of a temporary repeat_interleave/cat result. Each captured
+                            # layer/size owns a buffer initialized before graph capture.
+                            captured_block_tables.copy_(block_tables)
+                            block_tables = captured_block_tables
+                        elif num_tokens > len(actual_seq_lengths_q):
+                            raise ValueError("C8 multi-query replay requires a persistent captured block table")
+                        actual_seq_lengths_q = [1] * num_tokens
 
                     torch.npu.graph_task_update_begin(update_stream, handle)
                     input_layout = "TND"
@@ -953,6 +1025,7 @@ class AscendAttentionBackendImpl(AttentionImpl):
         next_tokens = 0 if self.sliding_window else SWA_INT_MAX
 
         extra_args = {}
+        c8_block_table_is_persistent = False
         if self.enable_c8_quant and layer is not None:
             extra_args = {
                 "key_antiquant_scale": layer._c8_k_aq_scale_nz_bnsd,
@@ -973,6 +1046,26 @@ class AscendAttentionBackendImpl(AttentionImpl):
             output = output.unsqueeze(2)
             attn_mask = None
             sparse_mode = 0
+            _, actual_seq_lengths_kv = _expand_c8_decode_metadata(
+                block_table,
+                attn_metadata.seq_lens_list,
+                actual_seq_lengths_q,
+                len(actual_seq_lengths_q),
+                causal=attn_metadata.causal,
+                num_actual_tokens=attn_metadata.num_actual_tokens,
+                expand_tables=False,
+            )
+            owned_tables = getattr(self, "_c8_graph_block_tables", {})
+            if num_tokens in owned_tables:
+                # Do not capture a copy/expansion from the dummy metadata: it
+                # would overwrite the real table installed before every replay.
+                # Mixed FULL capture can have one query per dummy request even
+                # when replay later verifies multiple queries for one request.
+                block_table = owned_tables[num_tokens]
+                c8_block_table_is_persistent = True
+            elif num_tokens > len(actual_seq_lengths_q):
+                raise ValueError("C8 multi-query FULL capture requires preallocated block tables")
+            actual_seq_lengths_q = [1] * num_tokens
         use_max_workspace = self._use_max_workspace_for_fia_graph
         workspace = graph_params.workspaces.get(num_tokens)
         should_update_workspace_cache = False
@@ -1065,8 +1158,12 @@ class AscendAttentionBackendImpl(AttentionImpl):
             )  # type: ignore
         else:
             attn_params = attn_params + (None, None, None, None)  # type: ignore
-        layer_name = self._graph_metadata_layer_name(layer) if self._use_layer_aware_fia_graph_replay else None
-        attn_params = attn_params + (layer_name,)  # type: ignore
+        layer_name = (
+            self._graph_metadata_layer_name(layer)
+            if self._use_layer_aware_fia_graph_replay or (self.enable_c8_quant and layer is not None)
+            else None
+        )
+        attn_params = attn_params + (layer_name, c8_block_table_is_persistent)  # type: ignore
         graph_params.attn_params[num_tokens].append(attn_params)
 
         torch.npu.graph_task_group_begin(stream)
@@ -1817,6 +1914,18 @@ class AscendC8AttentionBackendImpl(AscendAttentionBackendImpl):
     so that C8 attention layers automatically use this forward path.
     """
 
+    def prepare_graph_block_tables(self, block_table: torch.Tensor, capture_sizes: list[int]) -> None:
+        """Keep expanded PA input storage alive, without recording a graph write."""
+        if not capture_sizes:
+            self._c8_graph_block_tables = {}
+            return
+        # Capture sizes replay serially. Share storage across sizes, but never
+        # across layers: different captured FIA ops can need different tables.
+        buffer = torch.zeros(
+            (max(capture_sizes), block_table.shape[1]), dtype=block_table.dtype, device=block_table.device
+        )
+        self._c8_graph_block_tables = {size: buffer[:size] for size in capture_sizes}
+
     def forward(
         self,
         layer: AttentionLayer,
@@ -2029,7 +2138,15 @@ class AscendC8AttentionBackendImpl(AscendAttentionBackendImpl):
         """C8 decode via FIA V1 BNSD with native paged INT8 KV + perchannel antiquant."""
         num_block, block_size, _, _ = self.key_cache.shape  # type: ignore[attr-defined]
         assert block_size % 32 == 0, f"C8 INT8 KV cache requires block_size to be a multiple of 32, got {block_size}"
-        batch_size = len(attn_metadata.seq_lens_list)
+        block_tables, seq_lens = _expand_c8_decode_metadata(
+            attn_metadata.block_tables,
+            attn_metadata.seq_lens_list,
+            attn_metadata.actual_seq_lengths_q,
+            len(attn_metadata.actual_seq_lengths_q),
+            causal=attn_metadata.causal,
+            num_actual_tokens=attn_metadata.num_actual_tokens,
+        )
+        batch_size = len(seq_lens)
 
         key = self._nz_5d_view(self.key_cache, block_size)
         value = self._nz_5d_view(self.value_cache, block_size)
@@ -2040,8 +2157,9 @@ class AscendC8AttentionBackendImpl(AscendAttentionBackendImpl):
             value,
             key_antiquant_scale=layer._c8_k_aq_scale_nz_bnsd,
             value_antiquant_scale=layer._c8_v_aq_scale_nz_bnsd,
-            block_table=attn_metadata.block_tables,
-            actual_seq_lengths_kv=attn_metadata.seq_lens_list,
+            block_table=block_tables,
+            actual_seq_lengths=[1] * batch_size,
+            actual_seq_lengths_kv=seq_lens,
             num_heads=self.num_heads,
             num_key_value_heads=self.num_kv_heads,
             input_layout="BNSD",
@@ -2081,6 +2199,14 @@ class AscendC8AttentionBackendImpl(AscendAttentionBackendImpl):
             )
             kv_k = self._nz_5d_view(self.key_cache, block_size)
             kv_v = self._nz_5d_view(self.value_cache, block_size)
+            block_tables, seq_lens = _expand_c8_decode_metadata(
+                attn_metadata.block_tables,
+                attn_metadata.seq_lens_list,
+                actual_seq_qlen,
+                num_decodes,
+                causal=attn_metadata.causal,
+                num_actual_tokens=attn_metadata.num_actual_tokens,
+            )
 
             attn_out, _ = torch_npu.npu_fused_infer_attention_score(
                 query[:num_decode_tokens].unsqueeze(2),
@@ -2088,8 +2214,9 @@ class AscendC8AttentionBackendImpl(AscendAttentionBackendImpl):
                 kv_v,
                 key_antiquant_scale=layer._c8_k_aq_scale_nz_bnsd,
                 value_antiquant_scale=layer._c8_v_aq_scale_nz_bnsd,
-                block_table=attn_metadata.block_tables[:num_decodes],
-                actual_seq_lengths_kv=attn_metadata.seq_lens_list[:num_decodes],
+                block_table=block_tables,
+                actual_seq_lengths=[1] * num_decode_tokens,
+                actual_seq_lengths_kv=seq_lens,
                 num_heads=self.num_heads,
                 num_key_value_heads=self.num_kv_heads,
                 input_layout="BNSD",

--- a/vllm_ascend/worker/model_runner_v1.py
+++ b/vllm_ascend/worker/model_runner_v1.py
@@ -133,7 +133,11 @@ except ImportError:  # pragma: no cover - exercised on v0.28.0
 
 # yapf: enable
 from vllm_ascend.ascend_config import get_ascend_config, is_mega_moe_supported
-from vllm_ascend.attention.attention_v1 import AscendAttentionBackend, AscendAttentionState
+from vllm_ascend.attention.attention_v1 import (
+    AscendAttentionBackend,
+    AscendAttentionState,
+    AscendC8AttentionBackendImpl,
+)
 from vllm_ascend.attention.context_parallel.dsa_cp import AscendDSACPMetadataBuilder
 from vllm_ascend.attention.context_parallel.sfa_cp import AscendSFADCPMetadataBuilder
 from vllm_ascend.attention.dsa_v1 import AscendDSAMetadataBuilder
@@ -4203,6 +4207,8 @@ class NPUModelRunner(GPUModelRunner):
                 self.sparse_kv_offload_config,
             )
         kv_caches = self.initialize_kv_cache_tensors(kv_cache_config)
+        if self.compilation_config.cudagraph_mode.has_full_cudagraphs():
+            self._prepare_c8_graph_block_tables(kv_cache_config)
         # TODO: refactor the logic of attention
         if (
             self.speculative_config
@@ -4243,6 +4249,31 @@ class NPUModelRunner(GPUModelRunner):
 
         if self.model_config.enable_return_routed_experts:
             self.init_routed_experts_capturer()
+
+    def _prepare_c8_graph_block_tables(self, kv_cache_config: KVCacheConfig) -> None:
+        """Initialize per-layer C8 input buffers before any ACL graph is recorded."""
+        # Ordinary one-token decode already has a persistent row per query.
+        # Mixed FULL graphs can change their per-request query lengths between
+        # capture and replay, even without a speculative configuration.
+        capture_sizes = [
+            size
+            for size in self.cudagraph_batch_sizes
+            if size > 1
+            and (
+                self.speculative_config is not None
+                or self.compilation_config.cudagraph_mode == CUDAGraphMode.FULL
+                or size > self.max_num_reqs
+            )
+        ]
+        for group_id, group in enumerate(kv_cache_config.kv_cache_groups):
+            for layer_name in group.layer_names:
+                layer = self.compilation_config.static_forward_context[layer_name]
+                if (
+                    isinstance(getattr(layer, "impl", None), AscendC8AttentionBackendImpl)
+                    and getattr(layer, "kv_cache_torch_dtype", None) == torch.int8
+                ):
+                    block_table = self.input_batch.block_table[group_id].get_device_tensor()
+                    layer.impl.prepare_graph_block_tables(block_table, capture_sizes)
 
     def _align_memory(self, tensor: torch.Tensor, alignment: int) -> torch.Tensor:
         data_ptr = tensor.data_ptr()


### PR DESCRIPTION
### What this PR does / why we need it?

Fix the C8 FIA V1 BNSD path when one request verifies multiple query tokens.
This path flattens queries into the batch dimension with `S=1`, so it needs
one block-table row and one visible KV length per query, not per request.

For a causal request with final KV length `L` and `Q` verification queries,
the visible lengths must be `L-Q+1, ..., L`. Repeating `L` for every query
would allow earlier queries to attend to unverified future tokens.

The patch:

- Expands block-table rows and computes per-query causal lengths in C8 decode,
  the decode portion of chunked prefill, FULL capture, and FULL replay.
- Preserves full KV visibility for non-causal metadata and handles the dummy
  padding request without generating negative KV lengths.
- Allocates layer-owned expanded table buffers before Model Runner V1 graph
  capture. Replay copies current tables into these buffers before updating FIA
  tasks. A temporary expansion must not become an unowned graph input, and
  capture must not record a dummy-table copy that overwrites replay metadata.
- Records C8 layer names for replay metadata lookup instead of relying on
  dictionary insertion order. Graph sizes share one maximum-sized allocation
  per layer, while different layers retain independent storage.
- Retains explicit ownership when single-query dummy requests are captured
  but replay verifies multiple queries for one request at the same total size.
- Keeps ordinary single-query decode-only graphs without speculation on the
  existing table storage; mixed FULL graphs reserve expanded storage.

Related work: #10862 addresses C8/EAGLE length-list shape mismatches, and
#10399 explores C8/MTP GQA support. This PR is a focused alternative for the
existing flattened `BNSD, S=1` path, with causal and persistent-storage
regressions. It does not supersede or incorporate those unmerged PRs.

### Does this PR introduce _any_ user-facing change?

It corrects C8 multi-query attention metadata and Model Runner V1 FULL replay.
There are no new flags or configuration defaults, and the BF16 attention path
is unchanged.

This is **not** a complete W8A8C8 + DFlash2 support or performance claim.
Mixed INT8/BF16 KV allocation, checkpoint loading, D256 operator support,
Mamba prefix-cache correctness, Model Runner V2, and end-to-end long-context
model validation are outside this patch. The tests below use the native D128
kernel and require no model checkpoint or private custom operator.

### How was this patch tested?

Current validation (2026-09-10): rebased onto vllm-ascend
`6c30de40cdd0194e2bcc8a125f8a87cd3323a485`, with the verified vLLM main
`b2f685834a6456197e7033966fdef52a23f1abcd` (release reference: v0.28.0).
Patch head: `57fe622370e6833fb24b4a6900875fd626da371b`.

The rebased patch preserves upstream layer-aware FIA replay and workspace
handling. The native NPU regression now lives in the one-card hardware suite,
because upstream routes `tests/ut` to CPU runners. Its estimated runtime is
registered in `test_config.yaml`; the explicit CI selector selects the
`linux-aarch64-a2b3-1` runner with one NPU.

Runtime: Ascend 910B3 (one device), CANN 9.1.0, PyTorch 2.10.0+cpu,
torch-npu 2.10.0.post4. Isolated images install the complete verified vLLM
source and complete Ascend checkout (`COMPILE_CUSTOM_KERNELS=0`).
No model checkpoint, runtime source overlay, or private custom operator was used.

```bash
python3 -m pytest -q \
  tests/ut/attention/test_attention_v1.py \
  tests/ut/worker/test_model_runner_v1.py \
  tests/e2e/pull_request/one_card/spec_decode/test_c8_spec_decode_npu.py
```

- Combined run in one pytest process: **97 passed**, including all five real-NPU
  cases, without failures or skips.
- Separate CPU-only container, with no NPU devices and
  `TORCH_DEVICE_BACKEND_AUTOLOAD=0`: both UT modules **92 passed**.
- Full manual pre-commit checks, diff whitespace validation, and secret scan
  of all four commits: passed.
- Negative control: unpatched upstream `6c30de40` plus only the native test file,
  using the same runtime and `-k 'not full_replay'`: **1 passed, 3 failed,
  1 deselected**. Single-query decode passes; eight-query, variable-query,
  and future-value-isolation assertions fail numerically, not at import or
  kernel launch. FULL is excluded because it uses the new preparation API.
- The unpatched future-value sentinel returns `0.2578125` for the first query;
  the patched result is exactly zero, as required by the causal reference.

The model-free tests use native D128 FIA and a CPU per-query causal reference.
The FULL regression performs actual capture/update/replay for two layers,
reverses metadata insertion order, changes KV lengths and non-contiguous page
tables, and switches graph sizes 8 -> 4 -> 8. Size-8 capture uses eight
single-query dummy requests; replay verifies eight queries for one request.
The mocked UT fixtures restore streams/events so they do not leak into the
native graph test in the combined run.

Historical validation on vllm-ascend `6953f266922e3ec2c33a04db4febb00e15893cec`
and vLLM `ba07e4a48fc951300d97eb506217dd530583dea3` was **81 passed** on the
former test paths, with the same negative-control outcome. This historical
count is separate from the current 97-test run above.

These are focused regression results, not full-model inference or throughput
claims. Upstream hardware CI still requires a maintainer's `ready-precise` or
`ready-all` label; local validation does not replace that CI gate.

AI assistance: OpenAI Codex assisted with implementation, tests, and PR preparation.

- vLLM main: https://github.com/vllm-project/vllm/commit/b2f685834a6456197e7033966fdef52a23f1abcd
