### PR TITLE
[BugFix][GDN] Skip recurrent state updates for idle DP dummy runs

### DIFF
--- a/tests/ut/worker/a2/test_model_runner_v1.py
+++ b/tests/ut/worker/a2/test_model_runner_v1.py
@@ -1337,7 +1337,10 @@ class TestNPUModelRunnerDebugger(unittest.TestCase):
 
         runner.execute_model(scheduler_output)
 
-        runner._dummy_run.assert_called_once_with(1)
+        runner._dummy_run.assert_called_once_with(
+            1,
+            skip_gdn_state_update=True,
+        )
         runner._start_dump_data.assert_not_called()
 
     @patch("vllm_ascend.worker.model_runner_v1.has_kv_transfer_group", return_value=False)

--- a/tests/ut/worker/a2/test_model_runner_v1.py
+++ b/tests/ut/worker/a2/test_model_runner_v1.py
@@ -1330,6 +1330,7 @@ class TestNPUModelRunnerDebugger(unittest.TestCase):
         runner.synchronize_input_prep = nullcontext
         runner._update_states = MagicMock(return_value=None)
         runner.parallel_config = SimpleNamespace(distributed_executor_backend="external_launcher", data_parallel_size=2)
+        runner.uniform_decode_query_len = 8
         runner._dummy_run = MagicMock()
         runner._start_dump_data = MagicMock()
         runner.requests = {}
@@ -1338,7 +1339,8 @@ class TestNPUModelRunnerDebugger(unittest.TestCase):
         runner.execute_model(scheduler_output)
 
         runner._dummy_run.assert_called_once_with(
-            1,
+            8,
+            uniform_decode=True,
             skip_gdn_state_update=True,
         )
         runner._start_dump_data.assert_not_called()

--- a/tests/ut/worker/a2/test_worker_v1.py
+++ b/tests/ut/worker/a2/test_worker_v1.py
@@ -764,7 +764,11 @@ class TestNPUWorker(TestBase):
             worker.execute_dummy_batch()
 
             # Verify call
-            mock_model_runner._dummy_run.assert_called_once_with(mock_uniform_decode_query_len, uniform_decode=True)
+            mock_model_runner._dummy_run.assert_called_once_with(
+                mock_uniform_decode_query_len,
+                uniform_decode=True,
+                skip_gdn_state_update=True,
+            )
 
     @patch("vllm_ascend.worker.worker.plan_sparse_kv_offload_memory")
     @patch("vllm_ascend.worker.worker.get_ascend_config")

--- a/vllm_ascend/_310p/model_runner_310p.py
+++ b/vllm_ascend/_310p/model_runner_310p.py
@@ -583,6 +583,7 @@ class NPUModelRunner310(NPUModelRunner):
         is_graph_capturing: bool = False,
         num_active_loras: int = 0,
         profile_seq_lens: int | None = None,
+        skip_gdn_state_update: bool = False,
     ):
         temporary_context = self.temporary_modify_uniform_decode_query_len() if uniform_decode else nullcontext()
         # All the spec decoding cases has to run splitfuse op on 310P.
@@ -609,6 +610,7 @@ class NPUModelRunner310(NPUModelRunner):
                     is_graph_capturing=is_graph_capturing,
                     num_active_loras=num_active_loras,
                     profile_seq_lens=profile_seq_lens,
+                    skip_gdn_state_update=skip_gdn_state_update,
                 )
             finally:
                 self._spec_dummy_capture = False

--- a/vllm_ascend/worker/model_runner_v1.py
+++ b/vllm_ascend/worker/model_runner_v1.py
@@ -2139,8 +2139,14 @@ class NPUModelRunner(GPUModelRunner):
                         # 0, and has_unfinished_requests in the outer loop
                         # returns True. before returning early here we call
                         # dummy run to ensure coordinate_batch_across_dp
-                        # is called into to avoid out of sync issues.
-                        self._dummy_run(1, skip_gdn_state_update=True)
+                        # is called into to avoid out of sync issues. Match the
+                        # active decode descriptor so an idle rank does not
+                        # downgrade graph mode across the DP group.
+                        self._dummy_run(
+                            self.uniform_decode_query_len,
+                            uniform_decode=True,
+                            skip_gdn_state_update=True,
+                        )
                     if not has_kv_transfer_group():
                         # Return empty ModelRunnerOutput if no work to do.
                         return EMPTY_MODEL_RUNNER_OUTPUT

--- a/vllm_ascend/worker/model_runner_v1.py
+++ b/vllm_ascend/worker/model_runner_v1.py
@@ -3247,17 +3247,22 @@ class NPUModelRunner(GPUModelRunner):
                 GDNAttentionMetadataBuilder,
             )
             if is_gdn_noop:
-                assert num_reqs_padded is not None
-                # An idle DP dummy has a real tensor shape for model and
-                # collective execution, but no GDN tokens. Keep both captured
-                # recurrent branches inert instead of advancing cached state.
+                # Dummy-run callers coalesce this; fall back to the unpadded
+                # batch size instead of asserting in the execute path.
+                gdn_num_reqs = (
+                    num_reqs if num_reqs_padded is None else num_reqs_padded
+                )
+                # Idle DP dummy: keep captured GDN tensor ranks for graph
+                # replay/collectives. num_actual_tokens=0 is the kernel no-op
+                # (ops slice mixed_qkv[:0]); query_start_loc is a zero-filled
+                # prefix sized to the graph, not a real token schedule.
                 common_attn_metadata = replace(
                     common_attn_metadata,
                     query_start_loc=self.gdn_query_start_loc.gpu[
-                        : num_reqs_padded + 1
+                        : gdn_num_reqs + 1
                     ],
                     query_start_loc_cpu=self.gdn_query_start_loc.cpu[
-                        : num_reqs_padded + 1
+                        : gdn_num_reqs + 1
                     ],
                     num_actual_tokens=0,
                     max_query_len=0,

--- a/vllm_ascend/worker/model_runner_v1.py
+++ b/vllm_ascend/worker/model_runner_v1.py
@@ -2140,7 +2140,7 @@ class NPUModelRunner(GPUModelRunner):
                         # returns True. before returning early here we call
                         # dummy run to ensure coordinate_batch_across_dp
                         # is called into to avoid out of sync issues.
-                        self._dummy_run(1)
+                        self._dummy_run(1, skip_gdn_state_update=True)
                     if not has_kv_transfer_group():
                         # Return empty ModelRunnerOutput if no work to do.
                         return EMPTY_MODEL_RUNNER_OUTPUT
@@ -3077,6 +3077,7 @@ class NPUModelRunner(GPUModelRunner):
         num_scheduled_tokens: dict[str, int] | None = None,
         num_scheduled_tokens_np: np.ndarray | None = None,
         cascade_attn_prefix_lens: list[list[int]] | None = None,
+        skip_gdn_state_update: bool = False,
     ) -> tuple[PerLayerAttnMetadata, CommonAttentionMetadata | None]:
         """
         :return: tuple[attn_metadata, spec_decode_common_attn_metadata]
@@ -3241,12 +3242,40 @@ class NPUModelRunner(GPUModelRunner):
         ) -> None:
             attn_group = self.attn_groups[kv_cache_gid][attn_gid]
             builder = attn_group.get_metadata_builder(ubid or 0)
+            is_gdn_noop = skip_gdn_state_update and isinstance(
+                builder,
+                GDNAttentionMetadataBuilder,
+            )
+            if is_gdn_noop:
+                assert num_reqs_padded is not None
+                # An idle DP dummy has a real tensor shape for model and
+                # collective execution, but no GDN tokens. Keep both captured
+                # recurrent branches inert instead of advancing cached state.
+                common_attn_metadata = common_attn_metadata.replace(
+                    query_start_loc=self.gdn_query_start_loc.gpu[
+                        : num_reqs_padded + 1
+                    ],
+                    query_start_loc_cpu=self.gdn_query_start_loc.cpu[
+                        : num_reqs_padded + 1
+                    ],
+                    num_actual_tokens=0,
+                    max_query_len=0,
+                    is_prefilling=(
+                        torch.zeros_like(common_attn_metadata.is_prefilling)
+                        if common_attn_metadata.is_prefilling is not None
+                        else None
+                    ),
+                )
             cascade_attn_prefix_len = (
                 cascade_attn_prefix_lens[kv_cache_gid][attn_gid] if cascade_attn_prefix_lens else 0
             )
 
             extra_attn_metadata_args = {}
-            if use_spec_decode and isinstance(builder, GDNAttentionMetadataBuilder):
+            if (
+                use_spec_decode
+                and isinstance(builder, GDNAttentionMetadataBuilder)
+                and not is_gdn_noop
+            ):
                 assert ubid is None, "UBatching not supported with GDN yet"
                 extra_attn_metadata_args = dict(
                     num_accepted_tokens=self.num_accepted_tokens.gpu[:num_reqs_padded],
@@ -3405,6 +3434,7 @@ class NPUModelRunner(GPUModelRunner):
         num_active_loras: int = 0,
         profile_seq_lens: int | None = None,
         profile_cpp: bool = False,
+        skip_gdn_state_update: bool = False,
     ) -> tuple[torch.Tensor, torch.Tensor]:
         # only support eager mode and piecewise graph now
         assert cudagraph_runtime_mode is None or cudagraph_runtime_mode.valid_runtime_modes()
@@ -3543,7 +3573,12 @@ class NPUModelRunner(GPUModelRunner):
                 self.query_start_loc.np[1 : num_reqs_padded + 1] = cum_num_tokens
                 self.query_start_loc.copy_to_gpu()
                 if self._has_gdn:
-                    self.gdn_query_start_loc.np[1 : num_reqs_padded + 1] = cum_num_tokens
+                    if skip_gdn_state_update:
+                        self.gdn_query_start_loc.np.fill(0)
+                    else:
+                        self.gdn_query_start_loc.np[
+                            1 : num_reqs_padded + 1
+                        ] = cum_num_tokens
                     self.gdn_query_start_loc.copy_to_gpu()
 
                 if not profile_cpp:
@@ -3575,6 +3610,7 @@ class NPUModelRunner(GPUModelRunner):
                     ubatch_slices=ubatch_slices_padded if pad_attn else ubatch_slices,
                     for_cudagraph_capture=is_graph_capturing,
                     num_scheduled_tokens_np=num_scheduled_tokens,
+                    skip_gdn_state_update=skip_gdn_state_update,
                 )
                 if not is_graph_capturing:
                     for kv_cache_gid in range(len(self.kv_cache_config.kv_cache_groups)):

--- a/vllm_ascend/worker/model_runner_v1.py
+++ b/vllm_ascend/worker/model_runner_v1.py
@@ -3251,7 +3251,8 @@ class NPUModelRunner(GPUModelRunner):
                 # An idle DP dummy has a real tensor shape for model and
                 # collective execution, but no GDN tokens. Keep both captured
                 # recurrent branches inert instead of advancing cached state.
-                common_attn_metadata = common_attn_metadata.replace(
+                common_attn_metadata = replace(
+                    common_attn_metadata,
                     query_start_loc=self.gdn_query_start_loc.gpu[
                         : num_reqs_padded + 1
                     ],

--- a/vllm_ascend/worker/worker.py
+++ b/vllm_ascend/worker/worker.py
@@ -1085,7 +1085,11 @@ class NPUWorker(WorkerBase):
     def execute_dummy_batch(self) -> None:
         self.log_memory_stats()
         num_tokens = getattr(self.model_runner, "uniform_decode_query_len", 1)
-        self.model_runner._dummy_run(num_tokens, uniform_decode=True)
+        self.model_runner._dummy_run(
+            num_tokens,
+            uniform_decode=True,
+            skip_gdn_state_update=True,
+        )
 
     def _init_worker_distributed_environment(self) -> None:
         """Initialize the distributed environment."""


### PR DESCRIPTION
## What this PR does / why we need it

Data-parallel ranks with no scheduled requests still execute a one-token dummy batch to participate in graph replay and collectives. For GDN/Mamba layers, treating that synchronization-only token as a real decode token can advance causal-conv and KDA recurrent state through block-table entries left by an earlier request.

This PR keeps the model/collective dummy shape unchanged, but builds zero-length GDN metadata for idle DP dummies. Both captured recurrent branches become no-ops while other layers and distributed communication continue to execute normally.

The change restores the behavior previously validated on the v0.26 Kimi K3 path. It adds no device-wide synchronization and does not change GDN kernels.

## Does this PR introduce any user-facing change?

No API change. Multi-node GDN/Mamba inference no longer depends on whether another DP rank was idle between requests.

## How was this patch tested?

- `python -m compileall` for the changed runtime files
- `git diff --check`
- Existing unit expectations updated for both idle-dummy entry points; the existing GDN builder regression covers zero-length recurrent metadata
- Real-weight A/B on two A3 nodes, TP16 x DP2 / EP32, Kimi K3 GQA DSpark, async scheduling, prefix cache, FULL_DECODE_ONLY graph, 131072-input + 1024-output:
  - before: a cache-hit repeat diverged from token 0 and collapsed into a repeated `1.1.1...` output while speculative acceptance remained 80.55%
  - after: no corrupted output in five cold/warm repeats; the last four cold/warm pairs were token-for-token identical, with per-token acceptance between 95.81% and 97.49%
- Real-weight four-node smoke on TP16 x DP4 / EP64 with full QuaRot weights and the same 128K-to-1K case:
  - repetition 1: aggregate acceptance 85.40%, mean accepted length 6.98, per-DP acceptance 88.11% / 89.03% / 85.91% / 79.16%
  - repetition 2: aggregate acceptance 87.00%, mean accepted length 7.09, per-DP acceptance 87.40% / 84.08% / 87.09% / 89.56%
  - both repetitions reported a 94.63% prefix-cache hit rate and completed without the cross-DP rotating collapse seen before the fix
  - repetition 3 was not counted: the DP2 EngineCore exited concurrently with an external Docker exec ending with status 137. The host reported no OOM or device fault, but the initiating command was not captured, so this is recorded as an interrupted run rather than attributed to the patch. The shared nodes were reclaimed and no restart was performed.

- vLLM main: https://github.com/vllm-project/vllm/commit/ba07e4a48fc951300d97eb506217dd530583dea3
