### PR TITLE
[Refactor][layerwise offload] Generalize layerwise KV cache offload for multi-component layouts

### DIFF
--- a/tests/ut/distributed/ascend_store/_mock_deps.py
+++ b/tests/ut/distributed/ascend_store/_mock_deps.py
@@ -45,13 +45,17 @@ if "torch" not in sys.modules and importlib.util.find_spec("torch") is None:
     _torch.sum = MagicMock(return_value=0)  # type: ignore[attr-defined]
     _torch.device = MagicMock()  # type: ignore[attr-defined]
     _torch.distributed = MagicMock()  # type: ignore[attr-defined]
+    sys.modules["torch"] = _torch
+    sys.modules["torch.distributed"] = _torch.distributed  # type: ignore[attr-defined]
+else:
+    _torch = importlib.import_module("torch")
+
+if not hasattr(_torch, "npu"):
     _npu = MagicMock()
     _npu.Event = MagicMock
     _npu.current_device = MagicMock(return_value=0)
     _npu.set_device = MagicMock()
     _torch.npu = _npu  # type: ignore[attr-defined]
-    sys.modules["torch"] = _torch
-    sys.modules["torch.distributed"] = _torch.distributed  # type: ignore[attr-defined]
 
 if "torch_npu" not in sys.modules:
     sys.modules["torch_npu"] = MagicMock()
@@ -84,6 +88,7 @@ _vllm_mock_modules = [
     "vllm.utils.hashing",
     "vllm.utils.math_utils",
     "vllm.utils.network_utils",
+    "vllm.utils.torch_utils",
     "vllm.v1",
     "vllm.v1.attention",
     "vllm.v1.attention.backend",
@@ -107,6 +112,7 @@ if _MOCK_VLLM_DEPS:
 
 if _MOCK_VLLM_DEPS:
     sys.modules["vllm.utils.math_utils"].cdiv = lambda a, b: -(-a // b)  # type: ignore[attr-defined]
+    sys.modules["vllm.utils.torch_utils"].get_dtype_size = lambda dtype: dtype.itemsize  # type: ignore[attr-defined]
     sys.modules["vllm.logger"].logger = logging.getLogger("vllm")  # type: ignore[attr-defined]
 
 _base_mod: Any = (
@@ -160,6 +166,9 @@ class _FakeKVCacheSpec:
     def __eq__(self, other):
         return type(self) is type(other) and self.__dict__ == getattr(other, "__dict__", {})
 
+    def __hash__(self):
+        return hash((type(self), tuple(sorted(self.__dict__.items()))))
+
     def copy_with_new_block_size(self, block_size):
         kwargs = self.__dict__.copy()
         kwargs["block_size"] = block_size
@@ -184,6 +193,10 @@ class _FakeFullAttentionSpec(_FakeAttentionSpec):
     pass
 
 
+class _FakeMLAAttentionSpec(_FakeAttentionSpec):
+    pass
+
+
 class _FakeSlidingWindowSpec(_FakeKVCacheSpec):
     def __init__(self, block_size=16, sliding_window=32, **kwargs):
         super().__init__(block_size=block_size, sliding_window=sliding_window, **kwargs)
@@ -193,6 +206,10 @@ class _FakeMambaSpec(_FakeKVCacheSpec):
     def __init__(self, block_size=16, **kwargs):
         super().__init__(block_size=block_size, **kwargs)
         self.num_speculative_blocks = getattr(self, "num_speculative_blocks", 0)
+
+
+class _FakeSlidingWindowMLASpec(_FakeMLAAttentionSpec):
+    pass
 
 
 class _FakeUniformTypeKVCacheSpecs(_FakeKVCacheSpec):
@@ -328,7 +345,9 @@ _kv_interface_mod: Any = sys.modules["vllm.v1.kv_cache_interface"] if _MOCK_VLLM
 _kv_interface_mod.KVCacheSpec = _FakeKVCacheSpec  # type: ignore[attr-defined]
 _kv_interface_mod.AttentionSpec = _FakeAttentionSpec  # type: ignore[attr-defined]
 _kv_interface_mod.FullAttentionSpec = _FakeFullAttentionSpec  # type: ignore[attr-defined]
+_kv_interface_mod.MLAAttentionSpec = _FakeMLAAttentionSpec  # type: ignore[attr-defined]
 _kv_interface_mod.SlidingWindowSpec = _FakeSlidingWindowSpec  # type: ignore[attr-defined]
+_kv_interface_mod.SlidingWindowMLASpec = _FakeSlidingWindowMLASpec  # type: ignore[attr-defined]
 _kv_interface_mod.MambaSpec = _FakeMambaSpec  # type: ignore[attr-defined]
 _kv_interface_mod.UniformTypeKVCacheSpecs = _FakeUniformTypeKVCacheSpecs  # type: ignore[attr-defined]
 _kv_interface_mod.KVCacheGroupSpec = _FakeKVCacheGroupSpec  # type: ignore[attr-defined]

--- a/tests/ut/distributed/ascend_store/test_layerwise_cache_layout.py
+++ b/tests/ut/distributed/ascend_store/test_layerwise_cache_layout.py
@@ -17,6 +17,7 @@ from vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.layerwise_cache_la
     build_layerwise_reuse_layout,
     get_gva_layerwise_config,
     get_layerwise_physical_layer_index,
+    get_raw_cache_components,
 )
 
 
@@ -34,9 +35,19 @@ def _make_full_attention_spec(
     )
 
 
-def _make_vllm_config(num_layers: int, num_shared_buffers: int):
+def _make_vllm_config(
+    num_layers: int,
+    num_shared_buffers: int,
+    total_num_layers: int | None = None,
+    layer_start: int = 0,
+):
     model_config = MagicMock()
     model_config.get_num_layers.return_value = num_layers
+    model_config.get_total_num_hidden_layers.return_value = num_layers if total_num_layers is None else total_num_layers
+    model_config.get_layers_start_end_indices.return_value = (
+        layer_start,
+        layer_start + num_layers,
+    )
     return SimpleNamespace(
         kv_transfer_config=SimpleNamespace(
             kv_connector="AscendStoreConnector",
@@ -64,6 +75,7 @@ def test_no_reuse_skips_topology_validation():
     ]
     layer_names = [tensor.shared_by[0] for tensor in original_tensors]
     kv_cache_config = SimpleNamespace(
+        num_blocks=1,
         kv_cache_tensors=original_tensors.copy(),
         kv_cache_groups=[
             SimpleNamespace(
@@ -76,16 +88,56 @@ def test_no_reuse_skips_topology_validation():
         ],
     )
 
-    apply_layerwise_kv_cache_plan(kv_cache_config, _make_vllm_config(2, 2))
+    assert apply_layerwise_kv_cache_plan(kv_cache_config, _make_vllm_config(2, 2)) is False
 
     assert kv_cache_config.kv_cache_tensors == original_tensors
 
 
-def test_base_layers_are_merged_into_shared_slots():
-    original_tensors = [KVCacheTensor(size=16, shared_by=[f"model.layers.{layer}.self_attn"]) for layer in range(6)]
-    layer_names = [tensor.shared_by[0] for tensor in original_tensors]
-    spec = _make_full_attention_spec()
+def test_no_reuse_skips_multi_component_layer_validation():
+    spec = MambaSpec(
+        block_size=2,
+        shapes=((1,),),
+        dtypes=(torch.int8,),
+    )
+    suffixes = (
+        "compressor.state_cache",
+        "indexer.k_cache",
+        "indexer.compressor.state_cache",
+        "swa_cache",
+        "attn",
+    )
+    layer_names = [f"model.layers.{layer}.self_attn.{suffix}" for layer in range(2) for suffix in suffixes]
+    original_tensors = [KVCacheTensor(size=16, shared_by=[layer_name]) for layer_name in layer_names]
     kv_cache_config = SimpleNamespace(
+        num_blocks=1,
+        kv_cache_tensors=original_tensors.copy(),
+        kv_cache_groups=[
+            SimpleNamespace(
+                layer_names=layer_names,
+                kv_cache_spec=UniformTypeKVCacheSpecs(
+                    block_size=2,
+                    kv_cache_specs=dict.fromkeys(layer_names, spec),
+                ),
+            )
+        ],
+    )
+
+    assert apply_layerwise_kv_cache_plan(kv_cache_config, _make_vllm_config(2, 2)) is False
+    assert kv_cache_config.kv_cache_tensors == original_tensors
+
+
+def test_base_layers_are_merged_into_shared_slots():
+    spec = _make_full_attention_spec()
+    original_tensors = [
+        KVCacheTensor(
+            size=spec.page_size_bytes,
+            shared_by=[f"model.layers.{layer}.self_attn"],
+        )
+        for layer in range(6)
+    ]
+    layer_names = [tensor.shared_by[0] for tensor in original_tensors]
+    kv_cache_config = SimpleNamespace(
+        num_blocks=1,
         kv_cache_tensors=original_tensors,
         kv_cache_groups=[
             SimpleNamespace(
@@ -207,7 +259,11 @@ def test_incompatible_cache_specs_use_separate_slots():
     layer_specs = {layer_name: first_spec for layer_name in layer_names}
     layer_specs[layer_names[2]] = incompatible_spec
     kv_cache_config = SimpleNamespace(
-        kv_cache_tensors=[KVCacheTensor(size=32, shared_by=[layer_name]) for layer_name in layer_names],
+        num_blocks=1,
+        kv_cache_tensors=[
+            KVCacheTensor(size=layer_specs[layer_name].page_size_bytes, shared_by=[layer_name])
+            for layer_name in layer_names
+        ],
         kv_cache_groups=[
             SimpleNamespace(
                 layer_names=layer_names,
@@ -236,6 +292,7 @@ def test_partial_layout_skips_tensor_merge():
     original_tensors = [KVCacheTensor(size=16, shared_by=[layer_name]) for layer_name in layer_names]
     spec = _make_full_attention_spec()
     kv_cache_config = SimpleNamespace(
+        num_blocks=1,
         kv_cache_tensors=original_tensors.copy(),
         kv_cache_groups=[
             SimpleNamespace(
@@ -252,6 +309,75 @@ def test_partial_layout_skips_tensor_merge():
 
     apply_layerwise_kv_cache_plan(kv_cache_config, vllm_config)
 
+    assert kv_cache_config.kv_cache_tensors == original_tensors
+
+
+def test_mtp_layer_does_not_hide_missing_base_layer():
+    layer_names = [
+        "model.layers.0.self_attn",
+        "model.layers.1.self_attn",
+        "model.layers.2.self_attn",
+        "model.mtp.0.self_attn",
+    ]
+    original_tensors = [KVCacheTensor(size=16, shared_by=[layer_name]) for layer_name in layer_names]
+    spec = _make_full_attention_spec()
+    kv_cache_config = SimpleNamespace(
+        num_blocks=1,
+        kv_cache_tensors=original_tensors.copy(),
+        kv_cache_groups=[
+            SimpleNamespace(
+                layer_names=layer_names,
+                kv_cache_spec=UniformTypeKVCacheSpecs(
+                    block_size=2,
+                    kv_cache_specs=dict.fromkeys(layer_names, spec),
+                ),
+            )
+        ],
+    )
+    vllm_config = _make_vllm_config(4, 1)
+    vllm_config.kv_transfer_config.kv_connector_extra_config["layerwise_independent_layers"] = []
+
+    assert apply_layerwise_kv_cache_plan(kv_cache_config, vllm_config) is False
+    assert kv_cache_config.kv_cache_tensors == original_tensors
+
+
+def test_wrong_pp_base_layers_do_not_enable_tensor_merge():
+    spec = _make_full_attention_spec()
+    layer_names = [
+        "model.layers.0.self_attn",
+        "model.layers.2.self_attn",
+        "model.layers.3.self_attn",
+        "model.mtp.0.self_attn",
+    ]
+    original_tensors = [
+        KVCacheTensor(
+            size=spec.page_size_bytes,
+            shared_by=[layer_name],
+        )
+        for layer_name in layer_names
+    ]
+    kv_cache_config = SimpleNamespace(
+        num_blocks=1,
+        kv_cache_tensors=original_tensors.copy(),
+        kv_cache_groups=[
+            SimpleNamespace(
+                layer_names=layer_names,
+                kv_cache_spec=UniformTypeKVCacheSpecs(
+                    block_size=2,
+                    kv_cache_specs=dict.fromkeys(layer_names, spec),
+                ),
+            )
+        ],
+    )
+    vllm_config = _make_vllm_config(
+        num_layers=2,
+        num_shared_buffers=1,
+        total_num_layers=4,
+        layer_start=2,
+    )
+    vllm_config.kv_transfer_config.kv_connector_extra_config["layerwise_independent_layers"] = []
+
+    assert apply_layerwise_kv_cache_plan(kv_cache_config, vllm_config) is False
     assert kv_cache_config.kv_cache_tensors == original_tensors
 
 
@@ -289,7 +415,50 @@ def test_physical_layer_index_supports_mtp_names(
     assert get_layerwise_physical_layer_index(layer_name, 4) == expected
 
 
-def test_main_spec_controls_reuse_regardless_of_indexer():
+def test_mtp_offset_uses_total_layers_with_pipeline_parallelism():
+    spec = _make_full_attention_spec()
+    layer_names = [
+        "model.layers.2.self_attn.attn",
+        "model.layers.3.self_attn.attn",
+        "model.mtp.0.self_attn.attn",
+    ]
+    kv_cache_config = SimpleNamespace(
+        num_blocks=1,
+        kv_cache_tensors=[KVCacheTensor(size=spec.page_size_bytes, shared_by=[name]) for name in layer_names],
+        kv_cache_groups=[
+            SimpleNamespace(
+                layer_names=layer_names,
+                kv_cache_spec=UniformTypeKVCacheSpecs(
+                    block_size=2,
+                    kv_cache_specs=dict.fromkeys(layer_names, spec),
+                ),
+            )
+        ],
+    )
+    vllm_config = _make_vllm_config(
+        num_layers=2,
+        num_shared_buffers=1,
+        total_num_layers=4,
+        layer_start=2,
+    )
+    vllm_config.kv_transfer_config.kv_connector_extra_config["layerwise_independent_layers"] = []
+
+    layout = build_layerwise_reuse_layout(
+        dict.fromkeys(layer_names, spec),
+        4,
+        vllm_config.kv_transfer_config.kv_connector_extra_config,
+    )
+
+    assert apply_layerwise_kv_cache_plan(kv_cache_config, vllm_config) is True
+    assert kv_cache_config.kv_cache_tensors[0].shared_by == layer_names
+    assert get_layerwise_physical_layer_index(layer_names[0], 4) == 2
+    assert get_layerwise_physical_layer_index(layer_names[2], 4) == 4
+    assert sorted(layout.layer_cache_specs) == [0, 1, 2]
+    assert layout.buffer_slots == ((0, 1, 2),)
+    assert layout.prefetch_layer_map == {1: 0, 2: 1}
+
+
+def test_scheduler_slot_controls_reuse_for_each_present_component():
     main_spec = AscendMLAAttentionSpec(
         block_size=2,
         num_kv_heads=1,
@@ -320,16 +489,25 @@ def test_main_spec_controls_reuse_regardless_of_indexer():
         },
     )
 
-    # Identical main specs put every layer in one buffer; the indexer subset rides along.
+    # The scheduler puts every layer in one slot. Each component role then gets
+    # its own lane and the indexer lane only binds the layers that own it.
     assert layout.buffer_slots == ((0, 1, 2, 3, 4, 5),)
-    assert tuple(layer for layer in layout.buffer_slots[0] if layout.layer_cache_specs[layer].indexer is not None) == (
+    assert sorted(len(components) for components in layout.component_lanes.values()) == [
+        3,
+        6,
+    ]
+    assert tuple(
+        layer
+        for layer in layout.buffer_slots[0]
+        if any(".indexer." in named_spec.layer_name for named_spec in layout.layer_cache_specs[layer])
+    ) == (
         1,
         3,
         5,
     )
     assert layout.prefetch_layer_map == {1: 0, 2: 1, 3: 2, 4: 3, 5: 4}
-    assert layout.layer_cache_specs[0].indexer is None
-    assert layout.layer_cache_specs[1].indexer is not None
+    assert len(layout.layer_cache_specs[0]) == 1
+    assert len(layout.layer_cache_specs[1]) == 2
 
 
 def test_cache_spec_roles_do_not_depend_on_order():
@@ -352,9 +530,10 @@ def test_cache_spec_roles_do_not_depend_on_order():
         },
     )
 
-    assert layout.layer_cache_specs[0].main.layer_name == main_name
-    assert layout.layer_cache_specs[0].indexer is not None
-    assert layout.layer_cache_specs[0].indexer.layer_name == indexer_name
+    assert [named_spec.layer_name for named_spec in layout.layer_cache_specs[0]] == [
+        main_name,
+        indexer_name,
+    ]
 
 
 def test_single_indexer_spec_is_the_primary_spec():
@@ -365,23 +544,160 @@ def test_single_indexer_spec_is_the_primary_spec():
         {"layerwise_num_shared_buffers": 1},
     )
 
-    assert layout.layer_cache_specs[0].main.layer_name == indexer_name
-    assert layout.layer_cache_specs[0].indexer is None
+    assert [named_spec.layer_name for named_spec in layout.layer_cache_specs[0]] == [indexer_name]
 
 
-def test_ambiguous_multi_spec_layer_is_rejected():
-    main_spec = _make_sfa_main_spec()
-    specs = {
-        "model.layers.0.self_attn.attn": main_spec,
-        "model.layers.0.self_attn.other_cache": main_spec,
+def test_arbitrary_components_are_planned_independently_per_slot():
+    spec = _make_full_attention_spec()
+    component_names = {
+        layer: [
+            f"model.layers.{layer}.self_attn.component0",
+            f"model.layers.{layer}.self_attn.component1",
+        ]
+        for layer in range(4)
     }
+    component_names[3].append("model.layers.3.self_attn.component3")
+    layer_names = [name for names in component_names.values() for name in names]
+    kv_cache_config = SimpleNamespace(
+        num_blocks=1,
+        kv_cache_tensors=[KVCacheTensor(size=spec.page_size_bytes, shared_by=[name]) for name in layer_names],
+        kv_cache_groups=[
+            SimpleNamespace(
+                layer_names=layer_names,
+                kv_cache_spec=UniformTypeKVCacheSpecs(
+                    block_size=2,
+                    kv_cache_specs=dict.fromkeys(layer_names, spec),
+                ),
+            )
+        ],
+    )
+    vllm_config = _make_vllm_config(4, 2)
+    vllm_config.kv_transfer_config.kv_connector_extra_config["layerwise_independent_layers"] = []
 
-    with pytest.raises(ValueError, match="multiple cache specs"):
-        build_layerwise_reuse_layout(
-            specs,
-            1,
-            {"layerwise_num_shared_buffers": 1},
-        )
+    assert apply_layerwise_kv_cache_plan(kv_cache_config, vllm_config) is True
+
+    assert [tensor.shared_by for tensor in kv_cache_config.kv_cache_tensors] == [
+        [component_names[0][0], component_names[2][0]],
+        [component_names[0][1], component_names[2][1]],
+        [component_names[1][0], component_names[3][0]],
+        [component_names[1][1], component_names[3][1]],
+        [component_names[3][2]],
+    ]
+
+
+def test_multi_layer_slot_without_compatible_components_has_no_reuse():
+    first_spec = _make_full_attention_spec()
+    second_spec = _make_full_attention_spec(num_kv_heads=2, head_size=4)
+    layout = build_layerwise_reuse_layout(
+        {
+            "model.layers.0.self_attn.attn": first_spec,
+            "model.layers.1.self_attn.attn": second_spec,
+        },
+        2,
+        {
+            "layerwise_num_shared_buffers": 1,
+            "layerwise_independent_layers": [],
+        },
+    )
+
+    assert layout.buffer_slots == ((0, 1),)
+    assert layout.has_layer_reuse is False
+    assert layout.prefetch_layer_map == {}
+    assert layout.independent_layers == [0, 1]
+
+
+def test_raw_component_layout_is_stable_and_linear_in_num_blocks():
+    spec = _make_sfa_indexer_spec()
+    layer_name = "model.layers.0.self_attn.indexer.k_cache"
+    (page_component,) = get_raw_cache_components(layer_name, spec, num_blocks=1)
+    (actual_component,) = get_raw_cache_components(layer_name, spec, num_blocks=3)
+
+    assert actual_component.reuse_key == page_component.reuse_key
+    assert actual_component.alignment == page_component.alignment
+    assert actual_component.size_bytes == page_component.size_bytes * 3
+    assert len(actual_component.views) == len(page_component.views)
+
+
+def test_actual_tensor_cannot_have_fewer_than_configured_blocks():
+    spec = _make_full_attention_spec()
+    layer_names = [f"model.layers.{layer}.self_attn.attn" for layer in range(2)]
+    kv_cache_config = SimpleNamespace(
+        num_blocks=2,
+        kv_cache_tensors=[KVCacheTensor(size=spec.page_size_bytes, shared_by=[name]) for name in layer_names],
+        kv_cache_groups=[
+            SimpleNamespace(
+                layer_names=layer_names,
+                kv_cache_spec=UniformTypeKVCacheSpecs(
+                    block_size=2,
+                    kv_cache_specs=dict.fromkeys(layer_names, spec),
+                ),
+            )
+        ],
+    )
+    vllm_config = _make_vllm_config(2, 1)
+    vllm_config.kv_transfer_config.kv_connector_extra_config["layerwise_independent_layers"] = []
+
+    with pytest.raises(ValueError, match="fewer than the configured minimum"):
+        apply_layerwise_kv_cache_plan(kv_cache_config, vllm_config)
+
+
+def test_actual_tensors_can_have_different_extra_block_counts():
+    spec = _make_full_attention_spec()
+    layer_names = [f"model.layers.{layer}.self_attn.attn" for layer in range(2)]
+    configured_num_blocks = 2
+    actual_num_blocks = [3, 4]
+    kv_cache_config = SimpleNamespace(
+        num_blocks=configured_num_blocks,
+        kv_cache_tensors=[
+            KVCacheTensor(
+                size=spec.page_size_bytes * num_blocks,
+                shared_by=[name],
+            )
+            for name, num_blocks in zip(layer_names, actual_num_blocks, strict=True)
+        ],
+        kv_cache_groups=[
+            SimpleNamespace(
+                layer_names=layer_names,
+                kv_cache_spec=UniformTypeKVCacheSpecs(
+                    block_size=2,
+                    kv_cache_specs=dict.fromkeys(layer_names, spec),
+                ),
+            )
+        ],
+    )
+    vllm_config = _make_vllm_config(2, 1)
+    vllm_config.kv_transfer_config.kv_connector_extra_config["layerwise_independent_layers"] = []
+
+    assert apply_layerwise_kv_cache_plan(kv_cache_config, vllm_config) is True
+    assert len(kv_cache_config.kv_cache_tensors) == 1
+    assert kv_cache_config.kv_cache_tensors[0].size == spec.page_size_bytes * configured_num_blocks
+
+
+def test_compatible_mixed_indexer_components_bind_one_raw_lane():
+    layer_name = "model.layers.0.self_attn.indexer.k_cache"
+    (bf16_component,) = get_raw_cache_components(
+        layer_name,
+        _make_unquantized_sfa_indexer_spec(),
+        num_blocks=2,
+    )
+    (c8_component,) = get_raw_cache_components(
+        "model.layers.1.self_attn.indexer.k_cache",
+        _make_sfa_indexer_spec(),
+        num_blocks=2,
+    )
+    raw = torch.zeros(
+        max(bf16_component.size_bytes, c8_component.size_bytes),
+        dtype=torch.int8,
+    )
+
+    bf16_views = bf16_component.bind(raw)
+    c8_views = c8_component.bind(raw)
+
+    assert bf16_component.reuse_key == c8_component.reuse_key
+    assert len(bf16_views) == 1
+    assert len(c8_views) == 2
+    assert bf16_views[0].untyped_storage().data_ptr() == c8_views[0].untyped_storage().data_ptr()
+    assert c8_views[0].untyped_storage().data_ptr() == c8_views[1].untyped_storage().data_ptr()
 
 
 def test_multi_group_sfa_descriptors_are_merged_by_main_component():
@@ -405,6 +721,7 @@ def test_multi_group_sfa_descriptors_are_merged_by_main_component():
         scale_dtype=torch.float16,
     )
     kv_cache_config = SimpleNamespace(
+        num_blocks=1,
         kv_cache_tensors=[
             *(KVCacheTensor(size=main_spec.page_size_bytes, shared_by=[name]) for name in main_names),
             *(KVCacheTensor(size=indexer_spec.page_size_bytes, shared_by=[name]) for name in indexer_names),
@@ -463,6 +780,76 @@ def _make_sfa_indexer_spec() -> AscendSFAIndexerCacheSpec:
     )
 
 
+def _make_unquantized_sfa_indexer_spec() -> AscendSFAIndexerCacheSpec:
+    return AscendSFAIndexerCacheSpec(
+        block_size=2,
+        num_kv_heads=1,
+        head_size=4,
+        dtype=torch.bfloat16,
+        cache_sparse_li_c8=False,
+    )
+
+
+def test_mixed_li_c8_indexers_share_one_buffer_per_main_slot():
+    main_spec = _make_sfa_main_spec()
+    c8_spec = _make_sfa_indexer_spec()
+    bf16_spec = _make_unquantized_sfa_indexer_spec()
+    main_by_layer = {layer: f"model.layers.{layer}.self_attn.attn" for layer in range(6)}
+    indexer_by_layer = {layer: f"model.layers.{layer}.self_attn.indexer.k_cache" for layer in range(6)}
+    indexer_specs = {indexer_by_layer[layer]: c8_spec if layer % 2 == 0 else bf16_spec for layer in range(6)}
+    num_blocks = 2
+    kv_cache_config = SimpleNamespace(
+        num_blocks=num_blocks,
+        kv_cache_tensors=[
+            *(
+                KVCacheTensor(size=main_spec.page_size_bytes * num_blocks, shared_by=[name])
+                for name in main_by_layer.values()
+            ),
+            *(
+                KVCacheTensor(size=spec.page_size_bytes * num_blocks, shared_by=[name])
+                for name, spec in indexer_specs.items()
+            ),
+        ],
+        kv_cache_groups=[
+            SimpleNamespace(
+                layer_names=list(main_by_layer.values()),
+                kv_cache_spec=UniformTypeKVCacheSpecs(
+                    block_size=2,
+                    kv_cache_specs=dict.fromkeys(main_by_layer.values(), main_spec),
+                ),
+            ),
+            SimpleNamespace(
+                layer_names=list(indexer_by_layer.values()),
+                kv_cache_spec=UniformTypeKVCacheSpecs(
+                    block_size=2,
+                    kv_cache_specs=indexer_specs,
+                ),
+            ),
+        ],
+    )
+    vllm_config = _make_vllm_config(6, 3)
+    vllm_config.kv_transfer_config.kv_connector_extra_config["layerwise_independent_layers"] = []
+
+    apply_layerwise_kv_cache_plan(kv_cache_config, vllm_config)
+
+    main_tensors = [
+        tensor
+        for tensor in kv_cache_config.kv_cache_tensors
+        if not any(".indexer." in name for name in tensor.shared_by)
+    ]
+    indexer_tensors = [
+        tensor for tensor in kv_cache_config.kv_cache_tensors if any(".indexer." in name for name in tensor.shared_by)
+    ]
+    assert len(main_tensors) == 3
+    assert len(indexer_tensors) == 3
+    assert [tensor.shared_by for tensor in indexer_tensors] == [
+        [indexer_by_layer[0], indexer_by_layer[3]],
+        [indexer_by_layer[1], indexer_by_layer[4]],
+        [indexer_by_layer[2], indexer_by_layer[5]],
+    ]
+    assert all(tensor.size == bf16_spec.page_size_bytes * num_blocks for tensor in indexer_tensors)
+
+
 def test_component_sharing_merges_main_across_a_and_b_layers():
     # GLM5.2/SFA: A-class layers own main + indexer, B-class layers own main only. Every
     # main spec is identical, so one buffer's main tensor is shared by all layers in the
@@ -479,6 +866,7 @@ def test_component_sharing_merges_main_across_a_and_b_layers():
     }
     indexer_by_layer = {layer: f"model.layers.{layer}.self_attn.indexer.k_cache" for layer in a_layers}
     kv_cache_config = SimpleNamespace(
+        num_blocks=1,
         kv_cache_tensors=[
             *(KVCacheTensor(size=main_spec.page_size_bytes, shared_by=[name]) for name in main_by_layer.values()),
             *(KVCacheTensor(size=indexer_spec.page_size_bytes, shared_by=[name]) for name in indexer_by_layer.values()),
@@ -547,6 +935,7 @@ def test_packed_cache_tensor_descriptors_are_rejected():
     ]
     spec = _make_full_attention_spec()
     kv_cache_config = SimpleNamespace(
+        num_blocks=1,
         kv_cache_tensors=[
             KVCacheTensor(
                 size=16,

--- a/tests/ut/distributed/ascend_store/test_pool_scheduler.py
+++ b/tests/ut/distributed/ascend_store/test_pool_scheduler.py
@@ -65,6 +65,8 @@ def make_config(kv_role="kv_producer", extra_config=None, block_size=16):
     config.model_config.hf_text_config = MagicMock(spec=[])
     config.model_config.get_total_num_kv_heads.return_value = 1
     config.model_config.get_num_layers.return_value = 2
+    config.model_config.get_total_num_hidden_layers.return_value = 2
+    config.model_config.get_layers_start_end_indices.return_value = (0, 2)
     return config
 
 
@@ -306,6 +308,8 @@ class TestKVPoolSchedulerBuildMeta(unittest.TestCase):
         config.model_config.hf_text_config = MagicMock(spec=[])
         config.model_config.get_total_num_kv_heads.return_value = 1
         config.model_config.get_num_layers.return_value = num_layers
+        config.model_config.get_total_num_hidden_layers.return_value = num_layers
+        config.model_config.get_layers_start_end_indices.return_value = (0, num_layers)
         return config
 
     def _set_running_chunk(self, scheduler):
@@ -324,6 +328,108 @@ class TestKVPoolSchedulerBuildMeta(unittest.TestCase):
             token_ids=list(range(16)),
             num_prompt_tokens=64,
         )
+
+    @patch("vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.pool_scheduler.LookupKeyClient")
+    def test_pp_layerwise_scheduler_uses_local_layer_count(self, mock_client_cls):
+        from types import SimpleNamespace
+
+        import torch
+        from vllm.v1.kv_cache_interface import FullAttentionSpec
+
+        config = self._make_config(
+            extra_config={
+                "backend": "memcache",
+                "use_layerwise": True,
+                "layerwise_num_shared_buffers": 1,
+                "layerwise_independent_layers": [],
+            },
+            num_layers=2,
+        )
+        config.kv_transfer_config.kv_connector = "AscendStoreConnector"
+        config.parallel_config.pipeline_parallel_size = 2
+        config.parallel_config.rank = 1
+        config.parallel_config.world_size = 2
+        config.model_config.get_total_num_hidden_layers.return_value = 4
+        config.model_config.get_layers_start_end_indices.return_value = (2, 4)
+        spec = FullAttentionSpec(
+            block_size=2,
+            num_kv_heads=1,
+            head_size=8,
+            dtype=torch.bfloat16,
+        )
+        layer_names = [
+            "model.layers.2.self_attn.attn",
+            "model.layers.3.self_attn.attn",
+            "model.mtp.0.self_attn.attn",
+        ]
+        kv_cache_config = SimpleNamespace(
+            kv_cache_groups=[
+                SimpleNamespace(
+                    layer_names=layer_names,
+                    kv_cache_spec=spec,
+                )
+            ]
+        )
+
+        scheduler = KVPoolScheduler(
+            config,
+            use_layerwise=True,
+            kv_cache_config=kv_cache_config,
+        )
+
+        self.assertEqual(scheduler.num_layers, 3)
+        self.assertTrue(scheduler.layerwise_offload)
+
+    @patch("vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.pool_scheduler.LookupKeyClient")
+    def test_wrong_pp_base_layers_do_not_enable_reuse(self, mock_client_cls):
+        from types import SimpleNamespace
+
+        import torch
+        from vllm.v1.kv_cache_interface import FullAttentionSpec
+
+        config = self._make_config(
+            extra_config={
+                "backend": "memcache",
+                "use_layerwise": True,
+                "layerwise_num_shared_buffers": 1,
+                "layerwise_independent_layers": [],
+            },
+            num_layers=2,
+        )
+        config.kv_transfer_config.kv_connector = "AscendStoreConnector"
+        config.parallel_config.pipeline_parallel_size = 2
+        config.parallel_config.rank = 1
+        config.parallel_config.world_size = 2
+        config.model_config.get_total_num_hidden_layers.return_value = 4
+        config.model_config.get_layers_start_end_indices.return_value = (2, 4)
+        spec = FullAttentionSpec(
+            block_size=2,
+            num_kv_heads=1,
+            head_size=8,
+            dtype=torch.bfloat16,
+        )
+        layer_names = [
+            "model.layers.0.self_attn.attn",
+            "model.layers.2.self_attn.attn",
+            "model.layers.3.self_attn.attn",
+            "model.mtp.0.self_attn.attn",
+        ]
+        kv_cache_config = SimpleNamespace(
+            kv_cache_groups=[
+                SimpleNamespace(
+                    layer_names=layer_names,
+                    kv_cache_spec=spec,
+                )
+            ]
+        )
+
+        scheduler = KVPoolScheduler(
+            config,
+            use_layerwise=True,
+            kv_cache_config=kv_cache_config,
+        )
+
+        self.assertFalse(scheduler.layerwise_offload)
 
     def _make_running_chunk_output(self, new_block_ids):
         sched_output = MagicMock()
@@ -786,6 +892,7 @@ class TestKVPoolSchedulerInferMambaGroups(unittest.TestCase):
         config.model_config.hf_text_config = MagicMock(spec=[])
         config.model_config.get_total_num_kv_heads.return_value = 1
         config.model_config.get_num_layers.return_value = 2
+        config.model_config.get_total_num_hidden_layers.return_value = 2
         scheduler = KVPoolScheduler(config, use_layerwise=False)
         self.assertEqual(scheduler._infer_mamba_groups(), [])
 

--- a/tests/ut/distributed/ascend_store/test_pool_worker.py
+++ b/tests/ut/distributed/ascend_store/test_pool_worker.py
@@ -70,6 +70,7 @@ def make_worker(
     if num_hidden_layers is not None:
         config.model_config.hf_text_config.num_hidden_layers = num_hidden_layers
     config.model_config.get_num_layers.return_value = num_layers
+    config.model_config.get_layers_start_end_indices.return_value = (0, num_layers)
     config.model_config.get_total_num_kv_heads.return_value = num_kv_heads
     config.parallel_config.data_parallel_rank = 0
     config.parallel_config.rank = 0
@@ -251,6 +252,8 @@ class TestKVPoolWorkerHelpers(unittest.TestCase):
         cls = self._make_worker_class()
         worker = object.__new__(cls)
         worker.num_layers = 4
+        worker.base_layer_start = 0
+        worker.base_layer_end = 4
         worker.num_kv_cache_groups = 2
         worker.hf_config = SimpleNamespace(num_hidden_layers=4)
         worker.use_gva_layerwise = True
@@ -293,6 +296,169 @@ class TestKVPoolWorkerHelpers(unittest.TestCase):
         self.assertEqual(worker.independent_layers, [0])
         self.assertEqual(len(worker.layer_load_tasks), 5)
         self.assertEqual(len(worker.layer_save_tasks), 5)
+
+    def test_pp_layerwise_layout_uses_local_execution_indices(self):
+        import torch
+        from vllm.v1.kv_cache_interface import FullAttentionSpec
+
+        cls = self._make_worker_class()
+        worker = object.__new__(cls)
+        worker.num_layers = 2
+        worker.base_layer_start = 2
+        worker.base_layer_end = 4
+        worker.num_kv_cache_groups = 2
+        worker.hf_config = SimpleNamespace(num_hidden_layers=4)
+        worker.use_gva_layerwise = True
+        worker._extra_config = {
+            "layerwise_num_shared_buffers": 1,
+            "layerwise_independent_layers": [],
+        }
+        spec = FullAttentionSpec(
+            block_size=2,
+            num_kv_heads=1,
+            head_size=8,
+            dtype=torch.float16,
+        )
+        main_names = [
+            "model.layers.2.self_attn.attn",
+            "model.layers.3.self_attn.attn",
+            "model.mtp.0.self_attn.attn",
+        ]
+        indexer_names = [
+            "model.layers.2.self_attn.indexer.k_cache",
+            "model.layers.3.self_attn.indexer.k_cache",
+        ]
+        worker.kv_cache_config = SimpleNamespace(
+            kv_cache_groups=[
+                SimpleNamespace(layer_names=main_names, kv_cache_spec=spec),
+                SimpleNamespace(layer_names=indexer_names, kv_cache_spec=spec),
+            ]
+        )
+
+        worker._init_layerwise_config()
+
+        self.assertEqual(worker.num_layers, 3)
+        self.assertEqual(worker.prefetch_layer_map, {1: 0, 2: 1})
+        self.assertEqual(worker.independent_layers, [])
+        self.assertEqual(
+            worker.physical_layer_to_group_layers,
+            {
+                0: [(0, 0), (1, 0)],
+                1: [(0, 1), (1, 1)],
+                2: [(0, 2)],
+            },
+        )
+
+    def test_pp_cache_group_metadata_keeps_global_physical_layers(self):
+        import torch
+
+        cls = self._make_worker_class()
+        worker = object.__new__(cls)
+        worker.num_layers = 3
+        worker.num_kv_cache_groups = 2
+        worker.num_blocks = 2
+        worker.hf_config = SimpleNamespace(num_hidden_layers=4)
+        layer_names = [
+            "model.layers.2.self_attn.attn",
+            "model.layers.3.self_attn.attn",
+            "model.mtp.0.self_attn.attn",
+        ]
+        worker.kv_caches = {layer_name: torch.zeros((2, 1), dtype=torch.uint8) for layer_name in layer_names}
+        worker.group_kv_caches_base_addr = {}
+        worker.group_block_len = {}
+        worker.group_block_stride = {}
+        worker.group_layer_cache_entry_offsets = {}
+        worker.group_num_layers = {}
+
+        worker._infer_cache_group_metadata(0, layer_names)
+
+        self.assertEqual(worker.group_num_layers[0], 3)
+        self.assertEqual(worker.group_layer_cache_entry_offsets[0], [0, 1, 2, 3])
+        self.assertEqual(len(worker.group_kv_caches_base_addr[0]), 3)
+
+    def test_concrete_no_reuse_layout_is_not_reenabled_from_model_layer_count(self):
+        import torch
+        from vllm.v1.kv_cache_interface import FullAttentionSpec
+
+        cls = self._make_worker_class()
+        worker = object.__new__(cls)
+        worker.num_layers = 4
+        worker.base_layer_start = 0
+        worker.base_layer_end = 4
+        worker.num_kv_cache_groups = 1
+        worker.hf_config = SimpleNamespace(num_hidden_layers=4)
+        worker.use_gva_layerwise = True
+        worker._extra_config = {
+            "layerwise_num_shared_buffers": 2,
+            "layerwise_independent_layers": [],
+        }
+        spec = FullAttentionSpec(
+            block_size=2,
+            num_kv_heads=1,
+            head_size=8,
+            dtype=torch.float16,
+        )
+        worker.kv_cache_config = SimpleNamespace(
+            kv_cache_groups=[
+                SimpleNamespace(
+                    layer_names=[
+                        "model.layers.0.self_attn.attn",
+                        "model.layers.1.self_attn.attn",
+                    ],
+                    kv_cache_spec=spec,
+                )
+            ]
+        )
+
+        worker._init_layerwise_config()
+
+        self.assertIsNone(worker._layerwise_reuse_layout)
+        self.assertFalse(worker.layerwise_offload)
+        self.assertEqual(worker.prefetch_layer_map, {})
+        self.assertEqual(worker.independent_layers, [])
+
+    def test_wrong_pp_base_layers_do_not_enable_reuse(self):
+        import torch
+        from vllm.v1.kv_cache_interface import FullAttentionSpec
+
+        cls = self._make_worker_class()
+        worker = object.__new__(cls)
+        worker.num_layers = 2
+        worker.base_layer_start = 2
+        worker.base_layer_end = 4
+        worker.num_kv_cache_groups = 1
+        worker.hf_config = SimpleNamespace(num_hidden_layers=4)
+        worker.use_gva_layerwise = True
+        worker._extra_config = {
+            "layerwise_num_shared_buffers": 1,
+            "layerwise_independent_layers": [],
+        }
+        spec = FullAttentionSpec(
+            block_size=2,
+            num_kv_heads=1,
+            head_size=8,
+            dtype=torch.float16,
+        )
+        layer_names = [
+            "model.layers.0.self_attn.attn",
+            "model.layers.2.self_attn.attn",
+            "model.layers.3.self_attn.attn",
+            "model.mtp.0.self_attn.attn",
+        ]
+        worker.kv_cache_config = SimpleNamespace(
+            kv_cache_groups=[
+                SimpleNamespace(
+                    layer_names=layer_names,
+                    kv_cache_spec=spec,
+                )
+            ]
+        )
+
+        worker._init_layerwise_config()
+
+        self.assertIsNone(worker._layerwise_reuse_layout)
+        self.assertFalse(worker.layerwise_offload)
+        self.assertEqual(worker.prefetch_layer_map, {})
 
 
 class TestKVPoolWorkerInit(unittest.TestCase):
@@ -554,6 +720,7 @@ class TestKVPoolWorkerRegisterAndTransfer(unittest.TestCase):
         config.model_config.hf_text_config = MagicMock(spec=[])
         config.model_config.max_model_len = 1024
         config.model_config.get_num_layers.return_value = 2
+        config.model_config.get_layers_start_end_indices.return_value = (0, 2)
         config.model_config.get_total_num_kv_heads.return_value = 1
         config.parallel_config.data_parallel_rank = 0
         config.parallel_config.rank = 0

--- a/tests/ut/worker/test_model_runner_v1.py
+++ b/tests/ut/worker/test_model_runner_v1.py
@@ -761,6 +761,113 @@ class TestNPUModelRunnerKVCache(unittest.TestCase):
         self.assertEqual(indexer_spec.page_size_bytes, 2 * 16 * (128 + 2))
         self.assertFalse(hasattr(main_spec, "sfa_dcp_replicated_indexer_size"))
 
+    def test_mixed_li_c8_indexers_follow_descriptor_sharing(self):
+        """Mixed indexers share storage exactly when their descriptor does."""
+        runner = self._build_runner()
+        runner.vllm_config.kv_transfer_config = SimpleNamespace(
+            kv_connector="AscendStoreConnector",
+            kv_connector_extra_config={
+                "backend": "memcache",
+                "use_layerwise": True,
+            },
+        )
+        bf16_name = "model.layers.1.self_attn.indexer.k_cache"
+        c8_name = "model.layers.4.self_attn.indexer.k_cache"
+        bf16_spec = AscendSFAIndexerCacheSpec(
+            block_size=16,
+            num_kv_heads=1,
+            head_size=128,
+            dtype=torch.bfloat16,
+            cache_sparse_li_c8=False,
+        )
+        c8_spec = AscendSFAIndexerCacheSpec(
+            block_size=16,
+            num_kv_heads=1,
+            head_size=128,
+            dtype=torch.int8,
+            scale_dim=1,
+            scale_dtype=torch.float16,
+            cache_sparse_li_c8=True,
+        )
+        num_blocks = 2
+        group_spec = UniformTypeKVCacheSpecs(
+            block_size=16,
+            kv_cache_specs={bf16_name: bf16_spec, c8_name: c8_spec},
+        )
+        separate_config = KVCacheConfig(
+            num_blocks=num_blocks,
+            kv_cache_tensors=[
+                KVCacheTensor(
+                    size=bf16_spec.page_size_bytes * num_blocks,
+                    shared_by=[bf16_name],
+                ),
+                KVCacheTensor(
+                    size=c8_spec.page_size_bytes * num_blocks,
+                    shared_by=[c8_name],
+                ),
+            ],
+            kv_cache_groups=[
+                KVCacheGroupSpec(
+                    layer_names=[c8_name, bf16_name],
+                    kv_cache_spec=group_spec,
+                )
+            ],
+        )
+        backend = MagicMock()
+        backend.get_kv_cache_shape.side_effect = lambda num_blocks, block_size, num_kv_heads, head_size: (
+            num_blocks,
+            block_size,
+            num_kv_heads,
+            head_size,
+        )
+        runner._kv_cache_spec_attn_group_iterator = MagicMock(
+            return_value=[
+                SimpleNamespace(
+                    kv_cache_spec=bf16_spec,
+                    backend=backend,
+                    layer_names=[bf16_name],
+                ),
+                SimpleNamespace(
+                    kv_cache_spec=c8_spec,
+                    backend=backend,
+                    layer_names=[c8_name],
+                ),
+            ]
+        )
+        shared_config = KVCacheConfig(
+            num_blocks=num_blocks,
+            kv_cache_tensors=[
+                KVCacheTensor(
+                    size=bf16_spec.page_size_bytes * num_blocks,
+                    shared_by=[c8_name, bf16_name],
+                )
+            ],
+            kv_cache_groups=separate_config.kv_cache_groups,
+        )
+
+        separate_raw_caches = runner._allocate_kv_cache_tensors(separate_config)
+        self.assertNotEqual(
+            separate_raw_caches[bf16_name][0].untyped_storage().data_ptr(),
+            separate_raw_caches[c8_name][0].untyped_storage().data_ptr(),
+        )
+
+        raw_caches = runner._allocate_kv_cache_tensors(shared_config)
+        bf16_raw = raw_caches[bf16_name]
+        c8_raw = raw_caches[c8_name]
+        storage_ptr = bf16_raw[0].untyped_storage().data_ptr()
+        self.assertEqual(storage_ptr, c8_raw[0].untyped_storage().data_ptr())
+        self.assertEqual(storage_ptr, c8_raw[1].untyped_storage().data_ptr())
+
+        caches = runner._reshape_kv_cache_tensors(shared_config, raw_caches)
+        self.assertEqual(len(caches[bf16_name]), 1)
+        self.assertEqual(caches[bf16_name][0].dtype, torch.bfloat16)
+        self.assertEqual(caches[bf16_name][0].shape, (2, 16, 1, 128))
+        self.assertEqual(len(caches[c8_name]), 2)
+        self.assertEqual(caches[c8_name][0].dtype, torch.int8)
+        self.assertEqual(caches[c8_name][0].shape, (2, 16, 1, 128))
+        self.assertEqual(caches[c8_name][1].dtype, torch.float16)
+        self.assertEqual(caches[c8_name][1].shape, (2, 16, 1, 1))
+
     def test_sparse_sfa_and_li_c8_allocate_and_reshape_independently(self):
         runner = self._build_runner()
         runner.use_sparse = True

--- a/tests/ut/worker/test_worker_v1.py
+++ b/tests/ut/worker/test_worker_v1.py
@@ -5,7 +5,7 @@ from unittest.mock import MagicMock, patch
 
 import torch
 from vllm.config import CacheConfig, ModelConfig, ParallelConfig, ProfilerConfig, VllmConfig
-from vllm.v1.kv_cache_interface import FullAttentionSpec
+from vllm.v1.kv_cache_interface import FullAttentionSpec, HiddenStateCacheSpec
 
 from tests.ut.base import TestBase
 from vllm_ascend.device.hardware import AscendDeviceType
@@ -59,7 +59,7 @@ class TestNPUWorker(TestBase):
         self.distributed_init_method = "tcp://localhost:12345"
         self.is_driver_worker = False
 
-    def test_layer_reuse_memory_factor_merges_main_components(self):
+    def test_layer_reuse_memory_plan_merges_main_components(self):
         from vllm_ascend.core.kv_cache_interface import (
             AscendMLAAttentionSpec,
             AscendSFAIndexerCacheSpec,
@@ -70,6 +70,8 @@ class TestNPUWorker(TestBase):
         worker.model_config = MagicMock()
         worker.parallel_config = MagicMock()
         worker.model_config.get_num_layers.return_value = 6
+        worker.model_config.get_total_num_hidden_layers.return_value = 6
+        worker.model_config.get_layers_start_end_indices.return_value = (0, 6)
         main_spec = AscendMLAAttentionSpec(
             block_size=2,
             num_kv_heads=1,
@@ -91,7 +93,7 @@ class TestNPUWorker(TestBase):
             **{f"model.layers.{layer}.self_attn.indexer.k_cache": indexer_spec for layer in (1, 2, 4)},
         }
 
-        num_layers, num_slots, factor = worker._get_layerwise_kv_cache_memory_info(
+        memory_info = worker._get_layerwise_kv_cache_memory_info(
             specs,
             {"layerwise_num_shared_buffers": 2},
         )
@@ -99,10 +101,13 @@ class TestNPUWorker(TestBase):
         expected_logical_bytes = 6 * main_spec.page_size_bytes + 3 * indexer_spec.page_size_bytes
         # Both reused slots contain indexer layers; the independent slot does not.
         expected_physical_bytes = 3 * main_spec.page_size_bytes + 2 * indexer_spec.page_size_bytes
-        self.assertEqual((num_layers, num_slots), (6, 3))
-        self.assertEqual(factor, expected_logical_bytes / expected_physical_bytes)
+        alignment = 2 * 1024 * 1024
+        self.assertEqual(
+            memory_info,
+            (6, 5, expected_logical_bytes, expected_physical_bytes, 5 * alignment),
+        )
 
-    def test_layer_reuse_memory_factor_counts_components_per_buffer(self):
+    def test_layer_reuse_memory_plan_counts_components_per_buffer(self):
         from vllm_ascend.core.kv_cache_interface import (
             AscendMLAAttentionSpec,
             AscendSFAIndexerCacheSpec,
@@ -113,6 +118,8 @@ class TestNPUWorker(TestBase):
         worker.model_config = MagicMock()
         worker.parallel_config = MagicMock()
         worker.model_config.get_num_layers.return_value = 6
+        worker.model_config.get_total_num_hidden_layers.return_value = 6
+        worker.model_config.get_layers_start_end_indices.return_value = (0, 6)
         main_spec = AscendMLAAttentionSpec(
             block_size=2,
             num_kv_heads=1,
@@ -137,7 +144,7 @@ class TestNPUWorker(TestBase):
             "model.mtp.0.self_attn.attn": main_spec,
         }
 
-        num_layers, num_slots, factor = worker._get_layerwise_kv_cache_memory_info(
+        memory_info = worker._get_layerwise_kv_cache_memory_info(
             specs,
             {"layerwise_num_shared_buffers": 2},
         )
@@ -147,8 +154,113 @@ class TestNPUWorker(TestBase):
         # counted once per buffer: independent + both reused == 3 indexer slots.
         expected_logical_bytes = 7 * main_spec.page_size_bytes + 3 * indexer_spec.page_size_bytes
         expected_physical_bytes = 3 * main_spec.page_size_bytes + 3 * indexer_spec.page_size_bytes
-        self.assertEqual((num_layers, num_slots), (7, 3))
-        self.assertEqual(factor, expected_logical_bytes / expected_physical_bytes)
+        alignment = 2 * 1024 * 1024
+        self.assertEqual(
+            memory_info,
+            (7, 6, expected_logical_bytes, expected_physical_bytes, 6 * alignment),
+        )
+
+    def test_layer_reuse_memory_plan_uses_largest_mixed_indexer(self):
+        from vllm_ascend.core.kv_cache_interface import (
+            AscendMLAAttentionSpec,
+            AscendSFAIndexerCacheSpec,
+        )
+        from vllm_ascend.worker.worker import NPUWorker
+
+        worker = NPUWorker.__new__(NPUWorker)
+        worker.model_config = MagicMock()
+        worker.parallel_config = MagicMock()
+        worker.model_config.get_num_layers.return_value = 2
+        worker.model_config.get_total_num_hidden_layers.return_value = 2
+        worker.model_config.get_layers_start_end_indices.return_value = (0, 2)
+        main_spec = AscendMLAAttentionSpec(
+            block_size=2,
+            num_kv_heads=1,
+            head_size=8,
+            dtype=torch.bfloat16,
+        )
+        bf16_indexer_spec = AscendSFAIndexerCacheSpec(
+            block_size=2,
+            num_kv_heads=1,
+            head_size=4,
+            dtype=torch.bfloat16,
+            cache_sparse_li_c8=False,
+        )
+        c8_indexer_spec = AscendSFAIndexerCacheSpec(
+            block_size=2,
+            num_kv_heads=1,
+            head_size=4,
+            dtype=torch.int8,
+            scale_dim=1,
+            scale_dtype=torch.float16,
+            cache_sparse_li_c8=True,
+        )
+        specs = {
+            "model.layers.0.self_attn.attn": main_spec,
+            "model.layers.1.self_attn.attn": main_spec,
+            "model.layers.0.self_attn.indexer.k_cache": bf16_indexer_spec,
+            "model.layers.1.self_attn.indexer.k_cache": c8_indexer_spec,
+        }
+
+        memory_info = worker._get_layerwise_kv_cache_memory_info(
+            specs,
+            {
+                "layerwise_num_shared_buffers": 1,
+                "layerwise_independent_layers": [],
+            },
+        )
+
+        expected_logical_bytes = (
+            2 * main_spec.page_size_bytes + bf16_indexer_spec.page_size_bytes + c8_indexer_spec.page_size_bytes
+        )
+        expected_physical_bytes = main_spec.page_size_bytes + bf16_indexer_spec.page_size_bytes
+        alignment = 2 * 1024 * 1024
+        self.assertEqual(
+            memory_info,
+            (2, 2, expected_logical_bytes, expected_physical_bytes, 3 * alignment),
+        )
+
+    def test_layer_reuse_memory_plan_counts_single_tensor_attention_lanes_once(self):
+        from vllm_ascend.worker.worker import NPUWorker
+
+        worker = NPUWorker.__new__(NPUWorker)
+        worker.model_config = MagicMock()
+        worker.parallel_config = MagicMock()
+        worker.model_config.get_num_layers.return_value = 2
+        worker.model_config.get_total_num_hidden_layers.return_value = 2
+        worker.model_config.get_layers_start_end_indices.return_value = (0, 2)
+        cache_only_spec = FullAttentionSpec(
+            block_size=2,
+            num_kv_heads=1,
+            head_size=8,
+            dtype=torch.bfloat16,
+        )
+        hidden_state_spec = HiddenStateCacheSpec(
+            block_size=2,
+            num_kv_heads=1,
+            head_size=8,
+            dtype=torch.bfloat16,
+        )
+        specs = {
+            **{f"model.layers.{layer}.cache_only_layers.attn": cache_only_spec for layer in range(2)},
+            **{f"model.layers.{layer}.hidden_state.attn": hidden_state_spec for layer in range(2)},
+        }
+
+        memory_info = worker._get_layerwise_kv_cache_memory_info(
+            specs,
+            {
+                "layerwise_num_shared_buffers": 1,
+                "layerwise_independent_layers": [],
+            },
+        )
+
+        expected_logical_bytes = 2 * (cache_only_spec.page_size_bytes + hidden_state_spec.page_size_bytes)
+        expected_physical_bytes = cache_only_spec.page_size_bytes + hidden_state_spec.page_size_bytes
+        alignment = 2 * 1024 * 1024
+        self.assertEqual(
+            memory_info,
+            (2, 2, expected_logical_bytes, expected_physical_bytes, 2 * alignment),
+        )
 
     def test_incomplete_layer_layout_does_not_scale_memory_budget(self):
         from vllm_ascend.worker.worker import NPUWorker
@@ -157,6 +269,8 @@ class TestNPUWorker(TestBase):
         worker.model_config = MagicMock()
         worker.parallel_config = MagicMock()
         worker.model_config.get_num_layers.return_value = 4
+        worker.model_config.get_total_num_hidden_layers.return_value = 4
+        worker.model_config.get_layers_start_end_indices.return_value = (0, 4)
         specs = {
             "model.layers.0.self_attn.attn": MagicMock(),
             "model.layers.1.self_attn.attn": MagicMock(),
@@ -170,7 +284,40 @@ class TestNPUWorker(TestBase):
             },
         )
 
-        self.assertEqual(memory_info, (2, 2, 1.0))
+        self.assertEqual(memory_info, (2, 2, 0, 0, 0))
+
+    def test_wrong_pp_base_layers_do_not_scale_memory_budget(self):
+        from vllm_ascend.worker.worker import NPUWorker
+
+        worker = NPUWorker.__new__(NPUWorker)
+        worker.model_config = MagicMock()
+        worker.parallel_config = MagicMock()
+        worker.model_config.get_num_layers.return_value = 2
+        worker.model_config.get_total_num_hidden_layers.return_value = 4
+        worker.model_config.get_layers_start_end_indices.return_value = (2, 4)
+        spec = FullAttentionSpec(
+            block_size=2,
+            num_kv_heads=1,
+            head_size=8,
+            head_size_v=8,
+            dtype=torch.int8,
+        )
+        specs = {
+            "model.layers.0.self_attn.attn": spec,
+            "model.layers.2.self_attn.attn": spec,
+            "model.layers.3.self_attn.attn": spec,
+            "model.mtp.0.self_attn.attn": spec,
+        }
+
+        memory_info = worker._get_layerwise_kv_cache_memory_info(
+            specs,
+            {
+                "layerwise_num_shared_buffers": 1,
+                "layerwise_independent_layers": [],
+            },
+        )
+
+        self.assertEqual(memory_info, (4, 4, 0, 0, 0))
 
     def test_no_reuse_does_not_scale_layerwise_memory_layout(self):
         from vllm_ascend.worker.worker import NPUWorker
@@ -179,6 +326,8 @@ class TestNPUWorker(TestBase):
         worker.model_config = MagicMock()
         worker.parallel_config = MagicMock()
         worker.model_config.get_num_layers.return_value = 2
+        worker.model_config.get_total_num_hidden_layers.return_value = 2
+        worker.model_config.get_layers_start_end_indices.return_value = (0, 2)
         spec = FullAttentionSpec(
             block_size=2,
             num_kv_heads=1,
@@ -197,7 +346,32 @@ class TestNPUWorker(TestBase):
             {"layerwise_num_shared_buffers": 3},
         )
 
-        self.assertEqual(memory_info, (3, 3, 1.0))
+        self.assertEqual(memory_info, (3, 3, 0, 0, 0))
+
+    def test_no_reuse_does_not_validate_multi_component_layers(self):
+        from vllm_ascend.worker.worker import NPUWorker
+
+        worker = NPUWorker.__new__(NPUWorker)
+        worker.model_config = MagicMock()
+        worker.parallel_config = MagicMock()
+        worker.model_config.get_num_layers.return_value = 2
+        worker.model_config.get_total_num_hidden_layers.return_value = 2
+        worker.model_config.get_layers_start_end_indices.return_value = (0, 2)
+        suffixes = (
+            "compressor.state_cache",
+            "indexer.k_cache",
+            "indexer.compressor.state_cache",
+            "swa_cache",
+            "attn",
+        )
+        specs = {f"model.layers.{layer}.self_attn.{suffix}": MagicMock() for layer in range(2) for suffix in suffixes}
+
+        memory_info = worker._get_layerwise_kv_cache_memory_info(
+            specs,
+            {"layerwise_num_shared_buffers": 2},
+        )
+
+        self.assertEqual(memory_info, (2, 2, 0, 0, 0))
 
     @patch("vllm_ascend.utils.adapt_patch")
     @patch("vllm_ascend.ops")

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/layerwise_cache_layout.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/layerwise_cache_layout.py
@@ -1,11 +1,14 @@
 from __future__ import annotations
 
+from collections.abc import Hashable
 from dataclasses import dataclass
 from typing import Any
 
 import regex as re
+import torch
 from vllm.config import VllmConfig
 from vllm.logger import logger
+from vllm.utils.torch_utils import get_dtype_size
 from vllm.v1.kv_cache_interface import (
     AttentionSpec,
     KVCacheConfig,
@@ -14,25 +17,32 @@ from vllm.v1.kv_cache_interface import (
     UniformTypeKVCacheSpecs,
 )
 
+from vllm_ascend.core.kv_cache_interface import AscendSFAIndexerCacheSpec
+
 _NUM_SHARED_BUFFERS = "layerwise_num_shared_buffers"
 _PREFETCH_LAYERS = "layerwise_prefetch_layers"
 _INDEPENDENT_LAYERS = "layerwise_independent_layers"
 _DEFAULT_MAX_PREFETCH_LAYERS = 8
-_INDEXER_CACHE_SUFFIX = ".indexer.k_cache"
+KV_CACHE_TENSOR_ALIGNMENT = 2 * 1024 * 1024
 
 
-def get_layerwise_physical_layer_index(layer_name: str, base_layers: int) -> int:
+def get_layerwise_physical_layer_index(layer_name: str, total_base_layers: int) -> int:
     match = re.search(
         r"(?:^|\.)mtp(?:\.layers)?\.(\d+)(?:\.|$)",
         layer_name,
     )
     if match:
-        return base_layers + int(match.group(1))
+        return total_base_layers + int(match.group(1))
     match = re.search(r"layers\.(\d+)", layer_name)
     if match:
         return int(match.group(1))
     match = re.search(r"(\d+)", layer_name)
     return int(match.group(1)) if match else 0
+
+
+def get_layerwise_base_layers(physical_layers: set[int], total_base_layers: int) -> set[int]:
+    """Return base-model layers, excluding MTP/spec-decode layers."""
+    return {layer for layer in physical_layers if 0 <= layer < total_base_layers}
 
 
 @dataclass(frozen=True)
@@ -52,19 +62,118 @@ class NamedKVCacheSpec:
 
 
 @dataclass(frozen=True)
-class LayerwiseLayerCacheSpecs:
-    main: NamedKVCacheSpec
-    indexer: NamedKVCacheSpec | None = None
+class RawCacheComponent:
+    """One named cache component that can reuse an aligned raw allocation."""
+
+    layer_name: str
+    reuse_key: Hashable
+    size_bytes: int
+    alignment: int
+    # Each view is (dtype, offset_bytes, size_bytes, shape). The current model
+    # runner binds byte views here and creates backend-specific typed views in
+    # its existing reshape path.
+    views: tuple[tuple[torch.dtype, int, int, tuple[int, ...]], ...]
+
+    def __post_init__(self) -> None:
+        if self.size_bytes <= 0 or self.alignment <= 0:
+            raise ValueError("Raw cache component size and alignment must be positive.")
+        hash(self.reuse_key)
+        for dtype, offset, size, shape in self.views:
+            dtype_size = get_dtype_size(dtype)
+            if (
+                offset < 0
+                or size <= 0
+                or offset + size > self.size_bytes
+                or offset % dtype_size
+                or size % dtype_size
+                or torch.Size(shape).numel() * dtype_size != size
+            ):
+                raise ValueError(f"Invalid raw cache view for {self.layer_name}.")
+
+    def bind(self, raw: torch.Tensor) -> tuple[torch.Tensor, ...]:
+        if raw.numel() < self.size_bytes:
+            raise ValueError(
+                f"Raw cache component {self.layer_name} needs {self.size_bytes} bytes, "
+                f"but its lane has {raw.numel()} bytes."
+            )
+        return tuple(raw[offset : offset + size].view(dtype).view(shape) for dtype, offset, size, shape in self.views)
 
 
 @dataclass(frozen=True)
 class LayerwiseReuseLayout:
-    layer_cache_specs: dict[int, LayerwiseLayerCacheSpecs]
+    layer_cache_specs: dict[int, tuple[NamedKVCacheSpec, ...]]
     buffer_slots: tuple[tuple[int, ...], ...]
+    component_lanes: dict[tuple[int, Hashable], tuple[RawCacheComponent, ...]]
     prefetch_layer_map: dict[int, int]
     independent_layers: list[int]
     num_prefetch_layers: int
     has_layer_reuse: bool
+
+
+def get_raw_cache_components(
+    layer_name: str,
+    spec: KVCacheSpec,
+    num_blocks: int,
+) -> tuple[RawCacheComponent, ...]:
+    """Normalize one named cache spec into its raw allocation component."""
+    if num_blocks < 1:
+        raise ValueError("num_blocks must be at least 1")
+
+    layer_match = re.search(r"(?:^|\.)mtp(?:\.layers)?\.\d+(?:\.|$)", layer_name)
+    if layer_match is None:
+        layer_match = re.search(r"(?:^|\.)layers\.\d+(?:\.|$)", layer_name)
+    role = layer_name[layer_match.end() :] if layer_match is not None else layer_name
+    role = role.lstrip(".")
+    size_bytes = spec.page_size_bytes * num_blocks
+
+    if isinstance(spec, AscendSFAIndexerCacheSpec):
+        reuse_key: Hashable = (
+            role,
+            "sfa_indexer",
+            spec.block_size,
+            spec.num_kv_heads,
+            spec.head_size,
+            spec.sfa_dcp_replicated_indexer_size,
+        )
+        k_size = (
+            num_blocks
+            * spec.sfa_dcp_replicated_indexer_size
+            * spec.block_size
+            * spec.num_kv_heads
+            * spec.head_size
+            * get_dtype_size(spec.dtype)
+        )
+        views: list[tuple[torch.dtype, int, int, tuple[int, ...]]] = [
+            (torch.int8, 0, k_size, (k_size,)),
+        ]
+        if spec.scale_dim:
+            scale_size = (
+                num_blocks
+                * spec.sfa_dcp_replicated_indexer_size
+                * spec.block_size
+                * spec.num_kv_heads
+                * spec.scale_dim
+                * get_dtype_size(spec.scale_dtype)
+            )
+            scale_dtype_size = get_dtype_size(spec.scale_dtype)
+            scale_offset = (k_size + scale_dtype_size - 1) // scale_dtype_size * scale_dtype_size
+            views.append((torch.int8, scale_offset, scale_size, (scale_size,)))
+    else:
+        # Non-indexer specs are deliberately conservative in the first
+        # version: only equal specs with the same semantic role share storage.
+        hash(spec)
+        reuse_key = (role, type(spec), spec)
+        views = [(torch.int8, 0, size_bytes, (size_bytes,))]
+
+    return (
+        RawCacheComponent(
+            layer_name=layer_name,
+            reuse_key=reuse_key,
+            size_bytes=size_bytes,
+            alignment=KV_CACHE_TENSOR_ALIGNMENT,
+            views=tuple(views),
+        ),
+    )
 
 
 def get_gva_layerwise_config(kv_transfer_config: Any) -> dict[str, Any] | None:
@@ -195,163 +304,280 @@ def get_layerwise_kv_cache_specs(
 
 def build_layerwise_reuse_layout(
     layer_specs: dict[str, KVCacheSpec],
-    base_layers: int,
+    total_base_layers: int,
     extra_config: dict[str, Any],
+    num_blocks: int = 1,
 ) -> LayerwiseReuseLayout:
-    """Build reusable physical-layer slots by grouping layers on their main cache spec."""
+    """Build component lanes inside the configured physical-layer slots.
+
+    ``num_blocks`` controls the component sizes stored in the returned layout.
+    Memory planning callers use the default single-block layout, while the
+    descriptor rewrite passes the globally usable block count.
+    """
+    # Running example legend:
+    #   L=local layer, C=component, K=reuse key, A/B=buffer slot.
+    #   L1..L4 correspond to local layer indices 0..3.
+    #   The example uses one PP rank, so physical and local indices are equal.
+    # Example input layer_specs keys:
+    #   L1.C0, L1.C1, L2.C0, L2.C1,
+    #   L3.C0, L3.C1, L4.C0, L4.C1, L4.C3
     named_specs_by_layer: dict[int, list[NamedKVCacheSpec]] = {}
     for layer_name, layer_spec in layer_specs.items():
-        physical_layer = get_layerwise_physical_layer_index(layer_name, base_layers)
+        physical_layer = get_layerwise_physical_layer_index(layer_name, total_base_layers)
         named_specs_by_layer.setdefault(physical_layer, []).append(NamedKVCacheSpec(layer_name, layer_spec))
+    # Example output named_specs_by_layer:
+    #   L1=(C0, C1), L2=(C0, C1),
+    #   L3=(C0, C1), L4=(C0, C1, C3)
 
     physical_layers = sorted(named_specs_by_layer)
-    base_layout = build_layerwise_cache_layout(len(physical_layers), extra_config)
-    independent_layers = [physical_layers[index] for index in base_layout.independent_layers]
-    independent_layer_set = set(independent_layers)
-
-    layer_cache_specs: dict[int, LayerwiseLayerCacheSpecs] = {}
-    for physical_layer, named_specs in named_specs_by_layer.items():
-        if len(named_specs) == 1:
-            layer_cache_specs[physical_layer] = LayerwiseLayerCacheSpecs(main=named_specs[0])
-            continue
-
-        indexer_specs = [spec for spec in named_specs if spec.layer_name.endswith(_INDEXER_CACHE_SUFFIX)]
-        main_specs = [spec for spec in named_specs if not spec.layer_name.endswith(_INDEXER_CACHE_SUFFIX)]
-        if len(main_specs) != 1 or len(indexer_specs) != 1:
-            raise ValueError(
-                f"Physical layer {physical_layer} with multiple cache specs must have "
-                f"exactly one main spec and one '{_INDEXER_CACHE_SUFFIX}' spec; "
-                f"got {[spec.layer_name for spec in named_specs]}."
+    # Layerwise execution is local to one PP rank. Keep the global physical
+    # indices only for sorting/grouping layer names, then expose contiguous
+    # local execution indices to the scheduler and pool worker.
+    # Example: global physical layers [2, 3, 4] map to PP-local layers
+    # [0, 1, 2], where global layer 4 may be MTP layer 0.
+    layer_cache_specs = {
+        local_layer: tuple(
+            sorted(
+                named_specs_by_layer[physical_layer],
+                key=lambda named_spec: named_spec.layer_name,
             )
-        layer_cache_specs[physical_layer] = LayerwiseLayerCacheSpecs(
-            main=main_specs[0],
-            indexer=indexer_specs[0],
+        )
+        for local_layer, physical_layer in enumerate(physical_layers)
+    }
+    if not layer_cache_specs:
+        return LayerwiseReuseLayout(
+            layer_cache_specs={},
+            buffer_slots=(),
+            component_lanes={},
+            prefetch_layer_map={},
+            independent_layers=[],
+            num_prefetch_layers=0,
+            has_layer_reuse=False,
         )
 
-    signature_buckets: list[tuple[KVCacheSpec, list[int]]] = []
-    for physical_layer in physical_layers:
-        if physical_layer in independent_layer_set:
+    # Example input: 4 layers, two shared buffers, no independent layers.
+    # Example output: storage_indices=[[0, 2], [1, 3]], i.e.
+    #   slot A=(L1, L3), slot B=(L2, L4).
+    base_layout = build_layerwise_cache_layout(len(layer_cache_specs), extra_config)
+    buffer_slots = tuple(tuple(slot) for slot in base_layout.storage_indices)
+    if not base_layout.has_layer_reuse:
+        return LayerwiseReuseLayout(
+            layer_cache_specs=layer_cache_specs,
+            buffer_slots=buffer_slots,
+            component_lanes={},
+            prefetch_layer_map={},
+            independent_layers=list(range(len(physical_layers))),
+            num_prefetch_layers=base_layout.num_prefetch_layers,
+            has_layer_reuse=False,
+        )
+
+    # Example input: the slots and layer components above.
+    # K0/K1/K3 are the reuse keys of components C0/C1/C3.
+    # A/K0 denotes the K0 lane in buffer slot A.
+    # Example output after grouping by (slot_id, reuse_key):
+    #   A/K0=(L1.C0, L3.C0), A/K1=(L1.C1, L3.C1)
+    #   B/K0=(L2.C0, L4.C0), B/K1=(L2.C1, L4.C1)
+    #   B/K3=(L4.C3,)
+    lane_components: dict[tuple[int, Hashable], list[RawCacheComponent]] = {}
+    for slot_id, layers in enumerate(buffer_slots):
+        for layer in layers:
+            seen_keys: set[Hashable] = set()
+            for named_spec in layer_cache_specs[layer]:
+                # TODO: Support specs with multiple independently allocated
+                # components (for example, MLA nope/rope) end to end so each
+                # component can participate in a separate reuse lane.
+                (component,) = get_raw_cache_components(
+                    named_spec.layer_name,
+                    named_spec.spec,
+                    num_blocks=num_blocks,
+                )
+                if component.reuse_key in seen_keys:
+                    raise ValueError(
+                        f"Physical layer {layer} contains duplicate component reuse key {component.reuse_key!r}."
+                    )
+                seen_keys.add(component.reuse_key)
+                lane_components.setdefault(
+                    (slot_id, component.reuse_key),
+                    [],
+                ).append(component)
+    # Freeze the collected lane members. In the example, four lanes have two
+    # members, while B/K3 contains only L4.C3.
+    component_lanes = {lane_key: tuple(components) for lane_key, components in lane_components.items()}
+    # A slot is only a reuse candidate. Reuse is actually applied only when at
+    # least one component lane has multiple members. The example returns True.
+    has_layer_reuse = any(len(components) > 1 for components in component_lanes.values())
+
+    # Validate only lanes that really share storage. Singleton lanes such as
+    # B/K3 do not need cross-layer reuse support. Currently, shared lanes must
+    # contain AttentionSpec components.
+    # TODO: Keep unsupported shared lanes as independently allocated singleton
+    # lanes, while preserving reuse for supported AttentionSpec lanes.
+    for components in component_lanes.values():
+        if len(components) < 2:
             continue
-        # TODO(lf): Plan shared buffers independently for every cache spec.
-        # Slots are grouped by main spec. Indexer specs are validated separately.
-        signature = layer_cache_specs[physical_layer].main.spec
-        for bucket_signature, bucket_layers in signature_buckets:
-            if signature == bucket_signature:
-                bucket_layers.append(physical_layer)
-                break
-        else:
-            signature_buckets.append((signature, [physical_layer]))
-
-    buffer_slots: list[tuple[int, ...]] = [(layer,) for layer in independent_layers]
-    prefetch_layer_map: dict[int, int] = {}
-    for _, bucket_layers in signature_buckets:
-        num_shared_buffers = min(base_layout.num_shared_buffers, len(bucket_layers))
-        for buffer_index in range(num_shared_buffers):
-            layers_sharing_buffer = tuple(bucket_layers[buffer_index::num_shared_buffers])
-            buffer_slots.append(layers_sharing_buffer)
-            for owner_index in range(1, len(layers_sharing_buffer)):
-                prefetch_layer_map[layers_sharing_buffer[owner_index]] = layers_sharing_buffer[owner_index - 1]
-
-    if prefetch_layer_map:
-        unsupported_specs = [
-            named_spec
-            for named_specs in named_specs_by_layer.values()
-            for named_spec in named_specs
-            if not isinstance(named_spec.spec, AttentionSpec)
-        ]
-        if unsupported_specs:
-            named_spec = unsupported_specs[0]
+        unsupported = next(
+            (
+                component
+                for component in components
+                if not isinstance(
+                    layer_specs[component.layer_name],
+                    AttentionSpec,
+                )
+            ),
+            None,
+        )
+        if unsupported is not None:
+            spec = layer_specs[unsupported.layer_name]
             raise NotImplementedError(
                 "Layerwise KV cache reuse supports attention cache specs only; "
-                f"{named_spec.layer_name} uses {type(named_spec.spec).__name__}."
+                f"{unsupported.layer_name} uses {type(spec).__name__}."
             )
+
+    # Convert component-level reuse back to slot-level runtime dependencies.
+    # The example has shared lanes in both A and B, so shared_slot_ids={0, 1}.
+    shared_slot_ids = {lane_key[0] for lane_key, components in component_lanes.items() if len(components) > 1}
+    prefetch_layer_map: dict[int, int] = {}
+    independent_layers = set(base_layout.independent_layers)
+    for slot_id, slot in enumerate(buffer_slots):
+        # If none of a slot's component lanes are shared, all its layers remain
+        # independent and require no wait-for-previous-owner dependency.
+        if slot_id not in shared_slot_ids:
+            independent_layers.update(slot)
+            continue
+        # Chain the owners of a shared slot. For A=(L1, L3) and B=(L2, L4),
+        # the example output is {L3: L1, L4: L2}, or {2: 0, 3: 1} locally.
+        for owner_index in range(1, len(slot)):
+            prefetch_layer_map[slot[owner_index]] = slot[owner_index - 1]
 
     return LayerwiseReuseLayout(
         layer_cache_specs=layer_cache_specs,
-        buffer_slots=tuple(buffer_slots),
+        buffer_slots=buffer_slots,
+        component_lanes=component_lanes,
         prefetch_layer_map=prefetch_layer_map,
-        independent_layers=independent_layers,
+        independent_layers=sorted(independent_layers),
         num_prefetch_layers=base_layout.num_prefetch_layers,
-        has_layer_reuse=bool(prefetch_layer_map),
+        has_layer_reuse=has_layer_reuse,
     )
 
 
 def apply_layerwise_kv_cache_plan(
     kv_cache_config: KVCacheConfig,
     vllm_config: VllmConfig,
-) -> None:
-    """Rewrite logical layer tensors to use shared physical KV buffers."""
+) -> bool:
+    """Replace per-component descriptors with one descriptor per component lane.
+
+    Return True and update ``kv_cache_config.kv_cache_tensors`` in place when
+    reuse is applied. Return False without changing the descriptors otherwise.
+    """
     extra_config = get_gva_layerwise_config(vllm_config.kv_transfer_config)
     if extra_config is None:
-        return
+        return False
 
+    # Using the running example from build_layerwise_reuse_layout(), the input
+    # descriptor shared_by values have one owner each:
+    #   (L1.C0,), (L1.C1,), (L2.C0,), (L2.C1,),
+    #   (L3.C0,), (L3.C1,), (L4.C0,), (L4.C1,), (L4.C3,)
     old_tensors = kv_cache_config.kv_cache_tensors
     if len(old_tensors) <= 1:
-        return
+        return False
 
-    base_layers = vllm_config.model_config.get_num_layers(vllm_config.parallel_config)
+    # Retrieve and validate the base layers assigned to the current PP rank
+    # while allowing additional MTP/spec-decode layers.
+    # Example: total_base_layers=8, PP=2. On PP rank 1,
+    # local_base_layers=4, (base_layer_start, base_layer_end)=(4, 8),
+    # expected_base_layers={4, 5, 6, 7}, and MTP0 makes physical_layers={4, 5, 6, 7, 8}.
+    local_base_layers = vllm_config.model_config.get_num_layers(vllm_config.parallel_config)
+    total_base_layers = vllm_config.model_config.get_total_num_hidden_layers()
     layer_specs = get_layerwise_kv_cache_specs(kv_cache_config)
+    physical_layers = {get_layerwise_physical_layer_index(layer_name, total_base_layers) for layer_name in layer_specs}
+    base_layer_start, base_layer_end = vllm_config.model_config.get_layers_start_end_indices(
+        vllm_config.parallel_config
+    )
+    expected_base_layers = set(range(base_layer_start, base_layer_end))
+    actual_base_layers = get_layerwise_base_layers(physical_layers, total_base_layers)
+    # MTP/spec-decode layers participate in the plan, but cannot hide a missing
+    # base layer or introduce a base layer owned by another PP rank.
+    if actual_base_layers != expected_base_layers:
+        missing_base_layers = sorted(expected_base_layers - actual_base_layers)
+        unexpected_base_layers = sorted(actual_base_layers - expected_base_layers)
+        logger.warning(
+            "Layer reuse has missing base layers %s and unexpected base layers %s; skip tensor merge.",
+            missing_base_layers,
+            unexpected_base_layers,
+        )
+        return False
+    # Build the layerwise KV cache reuse plan and count the physical layers participating in it.
     reuse_layout = build_layerwise_reuse_layout(
         layer_specs,
-        base_layers,
+        total_base_layers,
         extra_config,
+        num_blocks=kv_cache_config.num_blocks,
     )
     actual_layers = len(reuse_layout.layer_cache_specs)
     if not reuse_layout.has_layer_reuse:
-        return
+        return False
+    # The rewrite starts from one unpacked descriptor per named component. It
+    # cannot safely merge descriptors that already share or slice storage.
     if any(len(tensor.shared_by) != 1 or tensor.offset != 0 or tensor.block_stride != 0 for tensor in old_tensors):
         raise NotImplementedError(
             "Layerwise KV cache reuse does not support pre-shared or packed KV cache tensor descriptors."
         )
 
-    if actual_layers < base_layers:
-        logger.warning(
-            "Layer reuse expected at least %d layers, got %d; skip tensor merge.",
-            base_layers,
-            actual_layers,
-        )
-        return
-    if actual_layers > base_layers:
+    if actual_layers > local_base_layers:
         logger.info(
             "Layer reuse includes %d base and %d MTP/spec-decode layer(s).",
-            base_layers,
-            actual_layers - base_layers,
+            local_base_layers,
+            actual_layers - local_base_layers,
         )
 
+    # Index the input descriptors by their sole owner, then verify that the
+    # planned owner names match the input descriptor names.
     tensors_by_name = {tensor.shared_by[0]: tensor for tensor in old_tensors}
+    planned_names = {
+        component.layer_name for components in reuse_layout.component_lanes.values() for component in components
+    }
+    if planned_names != set(tensors_by_name):
+        raise ValueError("Layerwise component plan does not match the KV cache tensor descriptors.")
 
-    def _merge_specs(named_specs: list[NamedKVCacheSpec]) -> None:
-        shared_by = [named_spec.layer_name for named_spec in named_specs]
+    new_tensors: list[KVCacheTensor] = []
+    # Each lane becomes one output descriptor. For example, lane A/K0 produces
+    # shared_by=(L1.C0, L3.C0), while singleton B/K3 produces (L4.C3,).
+    for components in reuse_layout.component_lanes.values():
+        shared_by = [component.layer_name for component in components]
         cache_tensors = [tensors_by_name[layer_name] for layer_name in shared_by]
-        tensor_sizes = {tensor.size for tensor in cache_tensors}
-        if len(tensor_sizes) != 1:
-            raise ValueError("Layers sharing layerwise KV buffers must have equal tensor sizes for every cache spec.")
-        reference_spec = layer_specs[shared_by[0]]
-        if any(layer_specs[layer_name] != reference_spec for layer_name in shared_by[1:]):
-            raise ValueError(
-                "Layers sharing layerwise KV buffers must have identical cache specs for every named cache spec."
-            )
+        for component, cache_tensor in zip(components, cache_tensors, strict=True):
+            page_size_bytes = layer_specs[component.layer_name].page_size_bytes
+            if cache_tensor.size % page_size_bytes:
+                raise ValueError(
+                    f"Layerwise tensor size {cache_tensor.size} for {component.layer_name} "
+                    f"is not divisible by its page size {page_size_bytes}."
+                )
+            component_num_blocks = cache_tensor.size // page_size_bytes
+            if component_num_blocks < kv_cache_config.num_blocks:
+                raise ValueError(
+                    f"Layerwise tensor for {component.layer_name} has "
+                    f"{component_num_blocks} blocks, fewer than the configured "
+                    f"minimum {kv_cache_config.num_blocks}."
+                )
+
+        # Discard per-rank surplus capacity: KVCacheManager can only use the
+        # globally configured block count. Mixed layouts reserve enough bytes
+        # for the largest lane member at that common block count.
         new_tensors.append(
             KVCacheTensor(
                 shared_by=shared_by,
-                size=cache_tensors[0].size,
+                size=max(component.size_bytes for component in components),
             )
         )
-
-    new_tensors: list[KVCacheTensor] = []
-    for slot in reuse_layout.buffer_slots:
-        _merge_specs([reuse_layout.layer_cache_specs[layer].main for layer in slot])
-        indexer_specs: list[NamedKVCacheSpec] = []
-        for layer in slot:
-            indexer = reuse_layout.layer_cache_specs[layer].indexer
-            if indexer is not None:
-                indexer_specs.append(indexer)
-        if indexer_specs:
-            _merge_specs(indexer_specs)
+    # Example output descriptor shared_by values, one per component lane:
+    #   (L1.C0, L3.C0), (L1.C1, L3.C1)
+    #   (L2.C0, L4.C0), (L2.C1, L4.C1), (L4.C3)
+    # Each descriptor size is the maximum size of its listed components.
     kv_cache_config.kv_cache_tensors = new_tensors
     logger.info(
-        "Layerwise KV cache reuse merged %d descriptors into %d descriptors using %d buffer assignments.",
+        "Layerwise KV cache reuse merged %d descriptors into %d component lanes across %d layer slots.",
         len(old_tensors),
         len(new_tensors),
         len(reuse_layout.buffer_slots),
     )
+    return True

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/pool_scheduler.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/pool_scheduler.py
@@ -30,7 +30,9 @@ from vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.layerwise_cache_la
     build_layerwise_cache_layout,
     build_layerwise_reuse_layout,
     get_gva_layerwise_config,
+    get_layerwise_base_layers,
     get_layerwise_kv_cache_specs,
+    get_layerwise_physical_layer_index,
 )
 from vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.metadata import (
     AscendConnectorMetadata,
@@ -188,22 +190,29 @@ class KVPoolScheduler:
             self.put_step = self.tp_size // self.num_kv_head
         else:
             self.put_step = 1
-        self.num_layers = vllm_config.model_config.get_num_layers(vllm_config.parallel_config)
+        local_base_layers = vllm_config.model_config.get_num_layers(vllm_config.parallel_config)
+        self.num_layers = local_base_layers
         self.layerwise_offload = False
         if self.use_gva_layerwise:
+            base_layer_start, base_layer_end = model_config.get_layers_start_end_indices(vllm_config.parallel_config)
+            expected_base_layers = set(range(base_layer_start, base_layer_end))
             extra_config = get_gva_layerwise_config(vllm_config.kv_transfer_config)
             if kv_cache_config is not None and extra_config is not None:
-                reuse_layout = build_layerwise_reuse_layout(
-                    get_layerwise_kv_cache_specs(kv_cache_config),
-                    self.num_layers,
-                    extra_config,
-                )
-                if reuse_layout.layer_cache_specs:
-                    self.num_layers = max(
-                        self.num_layers,
-                        max(reuse_layout.layer_cache_specs) + 1,
+                layer_specs = get_layerwise_kv_cache_specs(kv_cache_config)
+                total_base_layers = model_config.get_total_num_hidden_layers()
+                physical_layers = {
+                    get_layerwise_physical_layer_index(layer_name, total_base_layers) for layer_name in layer_specs
+                }
+                if physical_layers:
+                    self.num_layers = max(self.num_layers, len(physical_layers))
+                actual_base_layers = get_layerwise_base_layers(physical_layers, total_base_layers)
+                if actual_base_layers == expected_base_layers:
+                    reuse_layout = build_layerwise_reuse_layout(
+                        layer_specs,
+                        total_base_layers,
+                        extra_config,
                     )
-                self.layerwise_offload = reuse_layout.has_layer_reuse
+                    self.layerwise_offload = reuse_layout.has_layer_reuse
             else:
                 self.layerwise_offload = build_layerwise_cache_layout(
                     self.num_layers,

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/pool_worker.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/pool_worker.py
@@ -52,6 +52,7 @@ from vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.layerwise_cache_la
     LayerwiseReuseLayout,
     build_layerwise_cache_layout,
     build_layerwise_reuse_layout,
+    get_layerwise_base_layers,
     get_layerwise_kv_cache_specs,
     get_layerwise_physical_layer_index,
 )
@@ -196,6 +197,10 @@ class KVPoolWorker:
     def _init_key_head_config(self, model_config, parallel_config) -> None:
         self.current_layer = 0
         self.num_layers = model_config.get_num_layers(parallel_config)
+        self.base_layer_start = 0
+        self.base_layer_end = self.num_layers
+        if self.use_gva_layerwise:
+            self.base_layer_start, self.base_layer_end = model_config.get_layers_start_end_indices(parallel_config)
 
         if self.use_mla:
             self.num_kv_head = 1
@@ -346,15 +351,17 @@ class KVPoolWorker:
         self._allocated_gvas: dict[str, int] = {}
 
     def _init_layerwise_config(self) -> None:
-        # Build mapping: physical_layer -> [(group_id, layer_idx_in_group), ...]
+        # Build mapping: local execution layer ->
+        # [(group_id, layer_idx_in_group), ...]
         # layer_idx_in_group is the index of the physical layer within the
         # group (not the index in layer_names). Multiple cache names at the
         # same physical layer are treated as entries of one layer.
         self.physical_layer_to_group_layers: dict[int, list[tuple[int, int]]] = {}
         self._layerwise_reuse_layout: LayerwiseReuseLayout | None = None
+        local_layer_by_physical: dict[int, int] = {}
 
         if self.kv_cache_config is not None:
-            base_layers = getattr(
+            total_base_layers = getattr(
                 self.hf_config,
                 "num_hidden_layers",
                 self.num_layers,
@@ -365,7 +372,12 @@ class KVPoolWorker:
                 for layer_name in group_spec.layer_names
             }
             if physical_layers:
-                effective_num_layers = max(self.num_layers, max(physical_layers) + 1)
+                # Example: global physical layers [2, 3, 4] map to
+                # PP-local execution layers [0, 1, 2].
+                local_layer_by_physical = {
+                    physical_layer: local_layer for local_layer, physical_layer in enumerate(sorted(physical_layers))
+                }
+                effective_num_layers = max(self.num_layers, len(physical_layers))
                 if effective_num_layers != self.num_layers:
                     logger.info(
                         "KVPoolWorker: updated num_layers %d -> %d from cache group layout.",
@@ -374,19 +386,23 @@ class KVPoolWorker:
                     )
                     self.num_layers = effective_num_layers
             if self.use_gva_layerwise:
-                self._layerwise_reuse_layout = build_layerwise_reuse_layout(
-                    get_layerwise_kv_cache_specs(self.kv_cache_config),
-                    base_layers,
-                    self._extra_config,
-                )
+                layer_specs = get_layerwise_kv_cache_specs(self.kv_cache_config)
+                expected_base_layers = set(range(self.base_layer_start, self.base_layer_end))
+                actual_base_layers = get_layerwise_base_layers(physical_layers, total_base_layers)
+                if actual_base_layers == expected_base_layers:
+                    reuse_layout = build_layerwise_reuse_layout(
+                        layer_specs,
+                        total_base_layers,
+                        self._extra_config,
+                    )
+                    if reuse_layout.has_layer_reuse:
+                        self._layerwise_reuse_layout = reuse_layout
 
         if self.kv_cache_config is not None and self.num_kv_cache_groups > 1:
             for group_id, group_spec in enumerate(self.kv_cache_config.kv_cache_groups):
                 physical_layers = set()
                 for layer_name in group_spec.layer_names:
                     physical_layer = self._extract_physical_layer_index(layer_name)
-                    if physical_layer >= self.num_layers:
-                        continue
                     physical_layers.add(physical_layer)
                 phys_to_layer_idx = {
                     physical_layer: layer_index for layer_index, physical_layer in enumerate(sorted(physical_layers))
@@ -394,7 +410,8 @@ class KVPoolWorker:
 
                 # Add one entry per unique physical layer (no duplicates)
                 for physical_layer, layer_idx_in_group in phys_to_layer_idx.items():
-                    existing = self.physical_layer_to_group_layers.setdefault(physical_layer, [])
+                    local_layer = local_layer_by_physical[physical_layer]
+                    existing = self.physical_layer_to_group_layers.setdefault(local_layer, [])
                     entry = (group_id, layer_idx_in_group)
                     if entry not in existing:
                         existing.append(entry)
@@ -421,10 +438,11 @@ class KVPoolWorker:
                     self.num_layers,
                     self._extra_config,
                 )
-                self.layerwise_offload = cache_layout.has_layer_reuse
-                self.independent_layers = cache_layout.independent_layers
-                self.prefetch_layer_map = cache_layout.prefetch_layer_map
                 self.num_prefetch_layers = cache_layout.num_prefetch_layers
+                if self.kv_cache_config is None:
+                    self.layerwise_offload = cache_layout.has_layer_reuse
+                    self.independent_layers = cache_layout.independent_layers
+                    self.prefetch_layer_map = cache_layout.prefetch_layer_map
             else:
                 self.layerwise_offload = self._layerwise_reuse_layout.has_layer_reuse
                 self.independent_layers = self._layerwise_reuse_layout.independent_layers
@@ -651,12 +669,12 @@ class KVPoolWorker:
             return cache.storage().data_ptr()
 
     def _extract_physical_layer_index(self, layer_name: str) -> int:
-        base_layers = getattr(
+        total_base_layers = getattr(
             self.hf_config,
             "num_hidden_layers",
             self.num_layers,
         )
-        return get_layerwise_physical_layer_index(layer_name, base_layers)
+        return get_layerwise_physical_layer_index(layer_name, total_base_layers)
 
     def _infer_cache_group_metadata(self, group_id: int, layer_names: list[str]):
         group_addrs: list[int] = []
@@ -665,8 +683,6 @@ class KVPoolWorker:
         layer_names_by_physical: dict[int, list[str]] = {}
         for layer_name in layer_names:
             phys = self._extract_physical_layer_index(layer_name)
-            if phys >= self.num_layers and self.num_kv_cache_groups > 1:
-                continue
             layer_names_by_physical.setdefault(phys, []).append(layer_name)
 
         layer_cache_entry_offsets = [0]

--- a/vllm_ascend/worker/model_runner_v1.py
+++ b/vllm_ascend/worker/model_runner_v1.py
@@ -80,6 +80,7 @@ from vllm.v1.kv_cache_interface import (
     KVCacheConfig,
     KVCacheGroupSpec,
     KVCacheSpec,
+    KVCacheTensor,
     MambaSpec,
     UniformTypeKVCacheSpecs,
 )
@@ -135,7 +136,10 @@ from vllm_ascend.compilation.acl_graph import (
 from vllm_ascend.compilation.breakable_aclgraph import BreakableACLGraphWrapper
 from vllm_ascend.device.hardware_profile import HardwareCapability, get_current_hardware_profile
 from vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.layerwise_cache_layout import (
+    KV_CACHE_TENSOR_ALIGNMENT,
+    RawCacheComponent,
     apply_layerwise_kv_cache_plan,
+    get_raw_cache_components,
 )
 from vllm_ascend.distributed.kv_transfer.sparse_kv_offload.sparse_kv_offload_manager import (
     allocate_kv_cache_tensors_for_sparse_kv_offload,
@@ -3920,7 +3924,10 @@ class NPUModelRunner(GPUModelRunner):
         self._mamba_bufs = None
         self._mamba_copy_bufs = None
         self.may_add_encoder_only_layers_to_kv_cache_config()
-        apply_layerwise_kv_cache_plan(kv_cache_config, self.vllm_config)
+        apply_layerwise_kv_cache_plan(
+            kv_cache_config,
+            self.vllm_config,
+        )
         self.maybe_add_kv_sharing_layers_to_kv_cache_groups(kv_cache_config)
         # NOTE(cmq): initialize_attn_backend must before using self.attn_groups
         self.initialize_attn_backend(kv_cache_config)
@@ -4155,6 +4162,26 @@ class NPUModelRunner(GPUModelRunner):
 
         return dsa_k_tensor, dsa_k_scale_tensor
 
+    def _allocate_raw_cache_components(
+        self,
+        kv_cache_tensor: KVCacheTensor,
+        components: list[RawCacheComponent],
+        alignment: int,
+    ) -> dict[str, tuple[torch.Tensor, ...]]:
+        """Allocate and bind components that share one normalized lane key."""
+        expected_size = max(component.size_bytes for component in components)
+        if kv_cache_tensor.size != expected_size:
+            raise ValueError(
+                "Shared component descriptor has an unexpected size: "
+                f"expected {expected_size}, got {kv_cache_tensor.size}."
+            )
+        raw_buffer = self._allocate_int8_cache_tensor(kv_cache_tensor.size, alignment)
+
+        raw_caches: dict[str, tuple[torch.Tensor, ...]] = {}
+        for component in components:
+            raw_caches[component.layer_name] = component.bind(raw_buffer)
+        return raw_caches
+
     def _allocate_kv_cache_tensors(self, kv_cache_config: KVCacheConfig) -> dict[str, torch.Tensor]:
         """
         Initializes the KV cache buffer with the correct size. The buffer needs
@@ -4174,7 +4201,7 @@ class NPUModelRunner(GPUModelRunner):
         # init kv cache tensors
         kv_cache_raw_tensors: dict[str, torch.Tensor | tuple[torch.Tensor, ...]] = {}
         # prefill disaggregation need the addr of cache tensor be aligned with 2M
-        alignment = 2 * 1024 * 1024
+        alignment = KV_CACHE_TENSOR_ALIGNMENT
         layer_kv_cache_spec = self._get_layer_kv_cache_specs(kv_cache_config)
         # If some tensors are shared by linear layers and attention layers,
         # the same tensor format must be maintained even if some layers
@@ -4188,6 +4215,28 @@ class NPUModelRunner(GPUModelRunner):
                 if isinstance(layer_kv_cache_spec[layer_name], AttentionSpec):
                     use_attn = True
             self.hybrid_with_attn_and_mamba = self.hybrid_with_attn_and_mamba or (use_mamba and use_attn)
+            shared_specs = [layer_kv_cache_spec[layer_name] for layer_name in kv_cache_tensor.shared_by]
+            shared_components = [
+                get_raw_cache_components(
+                    layer_name,
+                    spec,
+                    kv_cache_config.num_blocks,
+                )[0]
+                for layer_name, spec in zip(kv_cache_tensor.shared_by, shared_specs, strict=True)
+            ]
+            if (
+                len(shared_specs) > 1
+                and any(spec != shared_specs[0] for spec in shared_specs[1:])
+                and len({component.reuse_key for component in shared_components}) == 1
+            ):
+                kv_cache_raw_tensors.update(
+                    self._allocate_raw_cache_components(
+                        kv_cache_tensor,
+                        shared_components,
+                        alignment,
+                    )
+                )
+                continue
             for idx in range(len(kv_cache_tensor.shared_by)):
                 layer_name = kv_cache_tensor.shared_by[idx]
                 # Single tensor path for: mamba, hybrid attn-mamba, or cache_only_layers

--- a/vllm_ascend/worker/worker.py
+++ b/vllm_ascend/worker/worker.py
@@ -49,7 +49,7 @@ from vllm.utils.mem_constants import GiB_bytes
 from vllm.utils.mem_utils import MemorySnapshot, format_gib, memory_profiling
 from vllm.utils.torch_utils import STR_DTYPE_TO_TORCH_DTYPE
 from vllm.v1.core.sched.output import GrammarOutput, SchedulerOutput
-from vllm.v1.kv_cache_interface import KVCacheConfig, KVCacheSpec
+from vllm.v1.kv_cache_interface import AttentionSpec, KVCacheConfig, KVCacheSpec
 from vllm.v1.outputs import EMPTY_MODEL_RUNNER_OUTPUT, AsyncModelRunnerOutput, DraftTokenIds, ModelRunnerOutput
 from vllm.v1.utils import report_usage_stats
 from vllm.v1.worker.gpu_worker import AsyncIntermediateTensors
@@ -59,6 +59,7 @@ from vllm.v1.worker.workspace import init_workspace_manager
 import vllm_ascend.envs as envs_ascend
 from vllm_ascend.ascend_config import get_ascend_config, init_ascend_config
 from vllm_ascend.batch_invariant import init_batch_invariance
+from vllm_ascend.core.kv_cache_interface import AscendSFAIndexerCacheSpec
 from vllm_ascend.core.profiling_chunk_predictor import (
     _attach_profiling_chunk_execution_time,
 )
@@ -70,6 +71,7 @@ from vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.layerwise_cache_la
     build_layerwise_cache_layout,
     build_layerwise_reuse_layout,
     get_gva_layerwise_config,
+    get_layerwise_base_layers,
     get_layerwise_physical_layer_index,
 )
 from vllm_ascend.distributed.kv_transfer.sparse_kv_offload.sparse_kv_offload_manager import (
@@ -81,6 +83,7 @@ from vllm_ascend.profiler.torch_npu_profiler import TorchNPUProfilerWrapper
 from vllm_ascend.utils import (
     check_ascend_device_type,
     enable_sp,
+    is_hidden_state_cache_spec,
     register_ascend_customop,
     setup_ascend_local_comm_res,
 )
@@ -606,13 +609,30 @@ class NPUWorker(WorkerBase):
                 layout = build_layerwise_cache_layout(num_layers, extra_config)
                 num_buffer_assignments = len(layout.storage_indices)
                 factor = num_layers / num_buffer_assignments if layout.has_layer_reuse else 1.0
+                if factor != 1.0:
+                    self.available_kv_cache_memory_bytes = int(self.available_kv_cache_memory_bytes * factor)
             else:
-                num_layers, num_buffer_assignments, factor = memory_info
+                (
+                    num_layers,
+                    num_buffer_assignments,
+                    logical_page_bytes,
+                    physical_page_bytes,
+                    alignment_reserve_bytes,
+                ) = memory_info
+                if physical_page_bytes:
+                    payload_budget = max(
+                        0,
+                        self.available_kv_cache_memory_bytes - alignment_reserve_bytes,
+                    )
+                    num_blocks = payload_budget // physical_page_bytes
+                    self.available_kv_cache_memory_bytes = num_blocks * logical_page_bytes
+                    factor = logical_page_bytes / physical_page_bytes
+                else:
+                    factor = 1.0
             if factor != 1.0:
-                self.available_kv_cache_memory_bytes = int(self.available_kv_cache_memory_bytes * factor)
                 logger.info(
-                    "Layerwise KV cache reuse maps %d layers onto %d buffer assignments; "
-                    "scale logical KV budget by %.3f.",
+                    "Layerwise KV cache reuse maps %d layers onto %d component lanes; "
+                    "logical/physical page ratio %.3f.",
                     num_layers,
                     num_buffer_assignments,
                     factor,
@@ -951,33 +971,56 @@ class NPUWorker(WorkerBase):
         self,
         kv_cache_spec: dict[str, KVCacheSpec],
         extra_config: dict[str, Any],
-    ) -> tuple[int, int, float]:
+    ) -> tuple[int, int, int, int, int]:
         if not kv_cache_spec:
-            return 0, 0, 1.0
-        base_layers = self.model_config.get_num_layers(self.parallel_config)
-        physical_layers = {get_layerwise_physical_layer_index(layer_name, base_layers) for layer_name in kv_cache_spec}
+            return 0, 0, 0, 0, 0
+        total_base_layers = self.model_config.get_total_num_hidden_layers()
+        physical_layers = {
+            get_layerwise_physical_layer_index(layer_name, total_base_layers) for layer_name in kv_cache_spec
+        }
         num_layers = len(physical_layers)
-        if num_layers < base_layers:
-            return num_layers, num_layers, 1.0
+        base_layer_start, base_layer_end = self.model_config.get_layers_start_end_indices(self.parallel_config)
+        expected_base_layers = set(range(base_layer_start, base_layer_end))
+        actual_base_layers = get_layerwise_base_layers(physical_layers, total_base_layers)
+        if actual_base_layers != expected_base_layers:
+            return num_layers, num_layers, 0, 0, 0
         reuse_layout = build_layerwise_reuse_layout(
             kv_cache_spec,
-            base_layers,
+            total_base_layers,
             extra_config,
         )
         if not reuse_layout.has_layer_reuse:
-            return num_layers, num_layers, 1.0
-        num_buffer_assignments = len(reuse_layout.buffer_slots)
+            return num_layers, num_layers, 0, 0, 0
+        num_buffer_assignments = len(reuse_layout.component_lanes)
 
         logical_page_bytes = sum(spec.page_size_bytes for spec in kv_cache_spec.values())
-        physical_page_bytes = 0
-        for slot in reuse_layout.buffer_slots:
-            physical_page_bytes += reuse_layout.layer_cache_specs[slot[0]].main.spec.page_size_bytes
-            for layer in slot:
-                indexer = reuse_layout.layer_cache_specs[layer].indexer
-                if indexer is not None:
-                    physical_page_bytes += indexer.spec.page_size_bytes
-                    break
-        return num_layers, num_buffer_assignments, logical_page_bytes / physical_page_bytes
+        physical_page_bytes = sum(
+            max(component.size_bytes for component in components)
+            for components in reuse_layout.component_lanes.values()
+        )
+
+        alignment_reserve_bytes = 0
+        for components in reuse_layout.component_lanes.values():
+            alignment = max(component.alignment for component in components)
+            num_raw_allocations = max(
+                2
+                if isinstance(kv_cache_spec[component.layer_name], AttentionSpec)
+                and not isinstance(kv_cache_spec[component.layer_name], AscendSFAIndexerCacheSpec)
+                and not getattr(kv_cache_spec[component.layer_name], "cache_sparse_sfa_c8", False)
+                and getattr(kv_cache_spec[component.layer_name], "compress_ratio", 1) == 1
+                and "cache_only_layers" not in component.layer_name
+                and not is_hidden_state_cache_spec(kv_cache_spec[component.layer_name])
+                else 1
+                for component in components
+            )
+            alignment_reserve_bytes += alignment * num_raw_allocations
+        return (
+            num_layers,
+            num_buffer_assignments,
+            logical_page_bytes,
+            physical_page_bytes,
+            alignment_reserve_bytes,
+        )
 
     def get_kv_cache_spec(self) -> dict[str, KVCacheSpec]:
         kv_cache_spec = self.model_runner.get_kv_cache_spec()


### PR DESCRIPTION
### What this PR does / why we need it?

This PR generalizes GVA layerwise KV cache reuse from the mixed SFA
indexer special case to component-level cache layouts.

- Normalize each named KV cache spec into a raw cache component.
- Group compatible components by `(layerwise slot, reuse key)` and represent the resulting sharing relationship through `KVCacheTensor.shared_by`.
- Allow compatible components with different tensor views or sizes to reuse storage, allocating the largest component size in each lane.
- Preserve singleton descriptors when no compatible component exists in the same slot.
- Keep model runner allocation, scheduler dependencies, pool worker state, and KV cache memory accounting consistent with the concrete component reuse plan.
- Include MTP/spec-decode layers in the reuse plan while validating the exact base-layer range assigned to the current pipeline-parallel rank.
- Account for raw tensor alignment overhead when calculating the available logical KV cache memory.


### Does this PR introduce _any_ user-facing change?

Yes. It fixes KV cache allocation and memory accounting for multi-component layerwise KV cache layouts, including mixed C8 and unquantized SFA indexer caches. There is no API or configuration change.

### How was this patch tested?

- `pytest -q --confcutdir=tests/ut/distributed/ascend_store tests/ut/distributed/ascend_store/test_layerwise_cache_layout.py tests/ut/distributed/ascend_store/test_pool_scheduler.py tests/ut/distributed/ascend_store/test_pool_worker.py`
  (`154 passed, 62 subtests passed`)
- `bash format.sh ci`
- Python compile checks on all changed runtime and test files
- NPU-dependent model-runner and worker validation is left to CI.

- vLLM main: https://github.com/vllm-project/vllm/commit/ba07e4a48fc951300d97eb506217dd530583dea3
