### PR TITLE
[BugFix][KV Pool] Take _invalid_block_ids_lock in the sync load path

### DIFF
--- a/tests/ut/distributed/ascend_store/test_pool_worker.py
+++ b/tests/ut/distributed/ascend_store/test_pool_worker.py
@@ -15,6 +15,7 @@
 # This file is a part of the vllm-ascend project.
 #
 
+import queue
 import threading
 import unittest
 from types import SimpleNamespace
@@ -717,6 +718,109 @@ class TestKVPoolWorkerRegisterAndTransfer(unittest.TestCase):
         )
         kwargs["invalid_block_ids"].add(7)
         self.assertEqual(worker.get_block_ids_with_load_errors(), {7})
+
+    def test_sync_load_failure_records_invalid_blocks_under_lock(self):
+        # The synchronous load path in start_load_kv() updated _invalid_block_ids
+        # without holding _invalid_block_ids_lock, unlike every other mutation site.
+        worker = self._make_worker()
+        worker.token_database.set_group_buffers({0: [1000, 2000]}, {0: [160]})
+        worker.m_store.get = MagicMock(return_value=[1])
+
+        lock = worker._invalid_block_ids_lock
+        lock_held_on_update: list[bool] = []
+
+        class LockObservingSet(set):
+            def update(self, *args, **kwargs):
+                lock_held_on_update.append(lock.locked())
+                return super().update(*args, **kwargs)
+
+        worker._invalid_block_ids = LockObservingSet()
+
+        req = ReqMeta(
+            req_id="r1",
+            token_len_chunk=16,
+            block_ids=[3],
+            block_hashes=["h0"],
+            load_spec=LoadSpec(0, 16, can_load=True, token_len=16),
+        )
+        meta = AscendConnectorMetadata(set())
+        meta.add_request(req)
+        worker.start_load_kv(meta)
+
+        self.assertTrue(lock_held_on_update, "sync load failure did not record any invalid block")
+        self.assertTrue(all(lock_held_on_update), "invalid blocks were recorded outside the lock")
+        self.assertEqual(worker.get_block_ids_with_load_errors(), {3})
+
+    @patch(
+        "vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.pool_worker.KVCacheStoreRecvingThread.start",
+        autospec=True,
+    )
+    def test_concurrent_load_failures_and_queries_stay_consistent(self, start_thread):
+        # Concurrent load failures reported from receiving threads while the main
+        # thread drains, driven through the real start_load_kv() -> queue ->
+        # _handle_request() -> get_block_ids_with_load_errors() path.
+        num_requests = 200
+        worker = self._make_worker(kv_role="kv_consumer", extra_config={"load_async": True})
+        worker.token_database.set_group_buffers({0: [1000]}, {0: [160]})
+        worker.m_store.get = MagicMock(return_value=[1])
+        start_thread.side_effect = lambda thread: thread.ready_event.set()
+        worker._start_kv_transfer_threads()
+        recv_thread = worker.kv_recv_thread
+
+        meta = AscendConnectorMetadata(set())
+        for block_id in range(num_requests):
+            meta.add_request(
+                ReqMeta(
+                    req_id=f"r{block_id}",
+                    token_len_chunk=16,
+                    block_ids=[block_id],
+                    block_hashes=[f"h{block_id}"],
+                    load_spec=LoadSpec(0, 16, can_load=True, token_len=16),
+                )
+            )
+        worker.start_load_kv(meta)
+
+        errors: list[BaseException] = []
+        drained_batches: list[set[int]] = []
+        stop = threading.Event()
+
+        def consume() -> None:
+            # Mirrors KVTransferThread.run(): pull one request, handle it.
+            while True:
+                try:
+                    request = recv_thread.request_queue.get_nowait()
+                except queue.Empty:
+                    return
+                try:
+                    recv_thread._handle_request(request)
+                except BaseException as exc:  # noqa: BLE001 - reported below
+                    errors.append(exc)
+                    return
+
+        def drain() -> None:
+            while not stop.is_set():
+                batch = worker.get_block_ids_with_load_errors()
+                if batch:
+                    drained_batches.append(batch)
+
+        reader = threading.Thread(target=drain)
+        reader.start()
+        consumers = [threading.Thread(target=consume) for _ in range(4)]
+        for consumer in consumers:
+            consumer.start()
+        for consumer in consumers:
+            consumer.join()
+        stop.set()
+        reader.join()
+        tail = worker.get_block_ids_with_load_errors()
+        if tail:
+            drained_batches.append(tail)
+
+        self.assertEqual(errors, [])
+        drained = [block_id for batch in drained_batches for block_id in batch]
+        self.assertEqual(len(drained), len(set(drained)), "a block id was reported more than once")
+        self.assertEqual(set(drained), set(range(num_requests)), "a block id was lost")
+        self.assertEqual(worker.get_block_ids_with_load_errors(), set())
 
     def test_wait_for_save_waits_for_save(self):
         worker = self._make_worker()

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/pool_worker.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/pool_worker.py
@@ -934,7 +934,8 @@ class KVPoolWorker:
                     ret,
                 )
                 if len(request.block_ids_by_group) == 1:
-                    self._invalid_block_ids.update(missing_block_ids)
+                    with self._invalid_block_ids_lock:
+                        self._invalid_block_ids.update(missing_block_ids)
                 elif missing_block_ids:
                     logger.error(
                         "KV load failed for hybrid request %s. "
@@ -949,7 +950,8 @@ class KVPoolWorker:
                     [1] * len(block_id_list_c),
                 )
                 if len(request.block_ids_by_group) == 1:
-                    self._invalid_block_ids.update(missing_block_ids)
+                    with self._invalid_block_ids_lock:
+                        self._invalid_block_ids.update(missing_block_ids)
                 elif missing_block_ids:
                     logger.error(
                         "KV load failed for hybrid request %s. "


### PR DESCRIPTION
### What this PR does / why we need it?

Closes #14150 (task #9 of #9079).

`_invalid_block_ids` is shared between `KVPoolWorker` and the receiving
thread. An audit found that the two synchronous `start_load_kv()` failure
paths updated it without `_invalid_block_ids_lock`; all other reads and writes
were already protected.

This PR adds the missing lock at those two sites only (`+4/-2` in production
code). No other production path is changed.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Added two focused tests:

- `test_sync_load_failure_records_invalid_blocks_under_lock` exercises the
  synchronous failure path and fails on unmodified `main`.
- `test_concurrent_load_failures_and_queries_stay_consistent` exercises the
  real request queue, receiving-thread handler, and concurrent drain path.

Run on an Ascend 910B1 host:

```bash
pytest tests/ut/distributed/ascend_store/ \
  tests/ut/distributed/kv_transfer/test_kv_transfer_failures.py \
  -q --noconftest \
  --ignore=tests/ut/distributed/ascend_store/test_backend.py \
  --ignore=tests/ut/distributed/ascend_store/test_layerwise_cache_layout.py
```

- Baseline: 236 passed, 2 pre-existing failures.
- This PR: 238 passed, the same 2 pre-existing failures.
- `ruff check` and `ruff format --check`: passed.

No E2E test was added because this is host-side Python locking with no
NPU-specific behavior. Tests requiring a full matching vLLM environment are
left to selected-test CI, which is currently waiting for a ready label.

AI assistance was used for code review and test drafting.

- vLLM version: v0.27.1
- vLLM main: https://github.com/vllm-project/vllm/commit/ba07e4a48fc951300d97eb506217dd530583dea3
