### PR TITLE
[BugFix][MRV2] Fix expert transfers with pipeline parallelism

### DIFF
--- a/tests/ut/distributed/eplb/test_communicator.py
+++ b/tests/ut/distributed/eplb/test_communicator.py
@@ -1,9 +1,10 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM Ascend project
 
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, call
 
 import pytest
+import torch
 from vllm.distributed.eplb.eplb_communicator import (
     EplbCommunicator,
     TorchDistGlooStagedEplbCommunicator,
@@ -21,3 +22,33 @@ def communicator(monkeypatch):
 def test_communicator_reuses_upstream_gloo_staging(communicator):
     assert isinstance(communicator, TorchDistGlooStagedEplbCommunicator)
     assert communicator.needs_profile_buffer_reservation is False
+
+
+def test_send_and_recv_translate_group_local_peer_ranks(communicator, monkeypatch):
+    communicator._cpu_group.size.return_value = 2
+    get_global_rank = MagicMock(side_effect=[3, 2])
+    monkeypatch.setattr(
+        "vllm_ascend.distributed.eplb.communicator.dist.get_global_rank",
+        get_global_rank,
+    )
+    send_tensor = torch.arange(2)
+    recv_tensor = torch.zeros(2)
+
+    communicator.add_send([send_tensor], dst_rank=1, expert_id=3)
+    communicator.add_recv([recv_tensor], src_rank=0, expert_id=3)
+
+    assert communicator._ops == [
+        ("send", send_tensor, 3),
+        ("recv", recv_tensor, 2),
+    ]
+    assert get_global_rank.call_args_list == [
+        call(communicator._cpu_group, 1),
+        call(communicator._cpu_group, 0),
+    ]
+
+
+def test_peer_group_rank_must_be_in_range(communicator):
+    communicator._cpu_group.size.return_value = 2
+
+    with pytest.raises(ValueError, match=r"group rank 2.*\[0, 2\)"):
+        communicator.add_send([torch.zeros(1)], dst_rank=2, expert_id=3)

--- a/vllm_ascend/distributed/eplb/communicator.py
+++ b/vllm_ascend/distributed/eplb/communicator.py
@@ -17,7 +17,15 @@ class AscendGlooEplbCommunicator(TorchDistGlooStagedEplbCommunicator):
     """
 
     def _to_global_peer_rank(self, peer_group_rank: int) -> int:
-        """Translate an EPLB group-local peer rank for torch.distributed."""
+        """Translate an EPLB group-local peer rank to a global rank.
+
+        The EPLB transfer planner addresses peers relative to the EPLB process
+        group. The upstream Gloo communicator, however, passes that value as
+        the positional ``peer`` argument of ``torch.distributed.P2POp``, which
+        is interpreted as a global rank. The two rank spaces differ when a
+        non-zero pipeline stage owns an EPLB group, for example group ranks
+        ``[0, 1]`` may correspond to global ranks ``[2, 3]``.
+        """
         group_size = self._cpu_group.size()
         if not 0 <= peer_group_rank < group_size:
             raise ValueError(f"EPLB peer group rank {peer_group_rank} is outside the valid range [0, {group_size}).")
@@ -29,6 +37,8 @@ class AscendGlooEplbCommunicator(TorchDistGlooStagedEplbCommunicator):
         dst_rank: int,
         expert_id: int,
     ) -> None:
+        # ``dst_rank`` is local to the EPLB group, while the parent class
+        # ultimately supplies it as P2POp.peer, which requires a global rank.
         super().add_send(tensors, self._to_global_peer_rank(dst_rank), expert_id)
 
     def add_recv(
@@ -37,6 +47,8 @@ class AscendGlooEplbCommunicator(TorchDistGlooStagedEplbCommunicator):
         src_rank: int,
         expert_id: int,
     ) -> None:
+        # Keep receive peers in the same global-rank space expected by the
+        # parent's positional P2POp.peer argument.
         super().add_recv(tensors, self._to_global_peer_rank(src_rank), expert_id)
 
     @property

--- a/vllm_ascend/distributed/eplb/communicator.py
+++ b/vllm_ascend/distributed/eplb/communicator.py
@@ -1,6 +1,8 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM Ascend project
 
+import torch
+import torch.distributed as dist
 from vllm.distributed.eplb.eplb_communicator import TorchDistGlooStagedEplbCommunicator
 
 
@@ -13,6 +15,29 @@ class AscendGlooEplbCommunicator(TorchDistGlooStagedEplbCommunicator):
     which does not implement the __torch_function__ protocol for
     distributed collectives.
     """
+
+    def _to_global_peer_rank(self, peer_group_rank: int) -> int:
+        """Translate an EPLB group-local peer rank for torch.distributed."""
+        group_size = self._cpu_group.size()
+        if not 0 <= peer_group_rank < group_size:
+            raise ValueError(f"EPLB peer group rank {peer_group_rank} is outside the valid range [0, {group_size}).")
+        return dist.get_global_rank(self._cpu_group, peer_group_rank)
+
+    def add_send(
+        self,
+        tensors: list[torch.Tensor],
+        dst_rank: int,
+        expert_id: int,
+    ) -> None:
+        super().add_send(tensors, self._to_global_peer_rank(dst_rank), expert_id)
+
+    def add_recv(
+        self,
+        tensors: list[torch.Tensor],
+        src_rank: int,
+        expert_id: int,
+    ) -> None:
+        super().add_recv(tensors, self._to_global_peer_rank(src_rank), expert_id)
 
     @property
     def needs_profile_buffer_reservation(self) -> bool:


### PR DESCRIPTION
### What this PR does / why we need it?
Fixes EPLB expert weight transfers when pipeline parallelism is enabled.
EPLB produces EP group-local peer ranks, while the upstream P2POp.peer parameter expects global ranks. This mismatch causes asynchronous EPLB transfers on non-zero PP stages to fail with Global rank ... is not part of group.
This PR converts group-local peer ranks to global ranks in the Ascend EPLB communicator before enqueueing send/receive operations and adds corresponding unit tests.
### Does this PR introduce _any_ user-facing change?
No
### How was this patch tested?


- vLLM main: https://github.com/vllm-project/vllm/commit/ba07e4a48fc951300d97eb506217dd530583dea3
