### PR TITLE
[CI][Triton] Add SwiGLU quant operator test

### DIFF
--- a/.github/workflows/configs/nightly_config.yaml
+++ b/.github/workflows/configs/nightly_config.yaml
@@ -39,9 +39,6 @@ a2:
       - name: rejection-sample
         os: linux-aarch64-a2b3-1
         tests: tests/e2e/nightly/single_node/ops/singlecard_ops/triton/test_rejection_sample.py
-      - name: swiglu-quant
-        os: linux-aarch64-a2b3-1
-        tests: tests/e2e/nightly/single_node/ops/singlecard_ops/triton/test_swiglu_quant.py
   multi_node:
     test_config:
       - name: multi-node-qwen3-235b-dp

--- a/.github/workflows/configs/nightly_config.yaml
+++ b/.github/workflows/configs/nightly_config.yaml
@@ -39,6 +39,9 @@ a2:
       - name: rejection-sample
         os: linux-aarch64-a2b3-1
         tests: tests/e2e/nightly/single_node/ops/singlecard_ops/triton/test_rejection_sample.py
+      - name: swiglu-quant
+        os: linux-aarch64-a2b3-1
+        tests: tests/e2e/nightly/single_node/ops/singlecard_ops/triton/test_swiglu_quant.py
   multi_node:
     test_config:
       - name: multi-node-qwen3-235b-dp

--- a/tests/e2e/nightly/single_node/ops/singlecard_ops/triton/test_swiglu_quant.py
+++ b/tests/e2e/nightly/single_node/ops/singlecard_ops/triton/test_swiglu_quant.py
@@ -47,13 +47,16 @@ def _dynamic_quant_reference(x: torch.Tensor) -> tuple[torch.Tensor, torch.Tenso
         ),
     ],
 )
+@pytest.mark.parametrize("group_list_type", [0, 1], ids=["cumsum", "count"])
 @torch.inference_mode()
-def test_swiglu_quant_correctness(shape, dtype, group_counts, group_list_dtype):
+def test_swiglu_quant_correctness(shape, dtype, group_counts, group_list_dtype, group_list_type):
     torch.manual_seed(42)
     x = torch.randn(shape, dtype=dtype, device=DEVICE)
     group_list = torch.tensor(group_counts, dtype=group_list_dtype, device=DEVICE)
+    if group_list_type == 0:
+        group_list = group_list.cumsum(dim=0)
 
-    actual, actual_scale = swiglu_quant(x, group_list, group_list_type=1)
+    actual, actual_scale = swiglu_quant(x, group_list, group_list_type=group_list_type)
     swiglu_ref = _swiglu_reference(x)
     expected, expected_scale = _dynamic_quant_reference(swiglu_ref)
     scale_rtol, scale_atol = SCALE_TOLERANCES[dtype]

--- a/tests/e2e/nightly/single_node/ops/singlecard_ops/triton/test_swiglu_quant.py
+++ b/tests/e2e/nightly/single_node/ops/singlecard_ops/triton/test_swiglu_quant.py
@@ -1,0 +1,100 @@
+import pytest
+import torch
+import torch.nn.functional as F
+
+from vllm_ascend.ops.triton.activation.swiglu_quant import swiglu_quant
+from vllm_ascend.ops.triton.triton_utils import init_device_properties_triton
+
+DEVICE = "npu"
+INT8_MAX = 127
+TOLERANCES = {
+    torch.float16: (5e-3, 5e-3),
+    torch.bfloat16: (2e-2, 2e-2),
+}
+SCALE_TOLERANCES = {
+    torch.float16: (5e-3, 1e-5),
+    torch.bfloat16: (2e-2, 1e-4),
+}
+
+
+@pytest.fixture(scope="module", autouse=True)
+def init_triton_device_properties():
+    init_device_properties_triton()
+
+
+def _swiglu_reference(x: torch.Tensor) -> torch.Tensor:
+    x_fp32 = x.cpu().float()
+    gate, up = x_fp32.chunk(2, dim=-1)
+    return F.silu(gate) * up
+
+
+def _dynamic_quant_reference(x: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
+    scale = x.abs().amax(dim=-1) / INT8_MAX
+    quantized = torch.round(x / scale.unsqueeze(-1)).clamp(-INT8_MAX, INT8_MAX).to(torch.int8)
+    return quantized, scale
+
+
+@pytest.mark.parametrize(
+    ("shape", "dtype", "group_counts", "group_list_dtype"),
+    [
+        pytest.param((1, 4096), torch.float16, [1], torch.int32, id="single-token-fp16"),
+        pytest.param(
+            (65, 14336),
+            torch.bfloat16,
+            [0, 17, 1, 0, 31, 16],
+            torch.int64,
+            id="multi-core-bf16-empty-experts",
+        ),
+    ],
+)
+@torch.inference_mode()
+def test_swiglu_quant_correctness(shape, dtype, group_counts, group_list_dtype):
+    torch.manual_seed(42)
+    x = torch.randn(shape, dtype=dtype, device=DEVICE)
+    group_list = torch.tensor(group_counts, dtype=group_list_dtype, device=DEVICE)
+
+    actual, actual_scale = swiglu_quant(x, group_list, group_list_type=1)
+    swiglu_ref = _swiglu_reference(x)
+    expected, expected_scale = _dynamic_quant_reference(swiglu_ref)
+    scale_rtol, scale_atol = SCALE_TOLERANCES[dtype]
+
+    assert actual.shape == swiglu_ref.shape
+    assert actual.dtype == torch.int8
+    assert actual_scale.shape == (shape[0],)
+    assert actual_scale.dtype == torch.float32
+    torch.testing.assert_close(actual_scale.cpu(), expected_scale, rtol=scale_rtol, atol=scale_atol)
+    # The kernel casts through the input dtype before converting to int8.
+    # Permit one quantization bin of error relative to the FP32 reference.
+    torch.testing.assert_close(actual.cpu().float(), expected.float(), rtol=0, atol=1)
+
+
+@pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16])
+@torch.inference_mode()
+def test_swiglu_quant_without_quantization(dtype):
+    torch.manual_seed(42)
+    x = torch.randn((9, 4096), dtype=dtype, device=DEVICE)
+    group_list = torch.tensor([2, 0, 7], dtype=torch.int64, device=DEVICE)
+
+    actual, _ = swiglu_quant(x, group_list, group_list_type=1, need_quant=False)
+    expected = _swiglu_reference(x)
+    rtol, atol = TOLERANCES[dtype]
+
+    assert actual.shape == expected.shape
+    assert actual.dtype == dtype
+    torch.testing.assert_close(actual.cpu().float(), expected, rtol=rtol, atol=atol)
+
+
+def test_swiglu_quant_rejects_invalid_group_list_type():
+    x = torch.empty((1, 4096), dtype=torch.float16, device=DEVICE)
+    group_list = torch.tensor([1], dtype=torch.int32, device=DEVICE)
+
+    with pytest.raises(ValueError, match="group_list_type must be 0 or 1"):
+        swiglu_quant(x, group_list, group_list_type=2)
+
+
+def test_swiglu_quant_rejects_invalid_group_list_dtype():
+    x = torch.empty((1, 4096), dtype=torch.float16, device=DEVICE)
+    group_list = torch.tensor([1], dtype=torch.float32, device=DEVICE)
+
+    with pytest.raises(ValueError, match="group_list dtype must be torch.int32 or torch.int64"):
+        swiglu_quant(x, group_list, group_list_type=1)

--- a/vllm_ascend/ops/triton/activation/swiglu_quant.py
+++ b/vllm_ascend/ops/triton/activation/swiglu_quant.py
@@ -22,7 +22,7 @@ def _swiglu_quant_kernel(
 ):
     # calc real total_rows
     if GROUP_LIST_TYPE == 0:  # cusum
-        total_rows = tl.load(group_list_ptr + NUM_EXPERTS).to(tl.int32)
+        total_rows = tl.load(group_list_ptr + NUM_EXPERTS - 1).to(tl.int32)
     else:
         gl_offsets = tl.arange(0, NUM_EXPERTS_ALGIN)
         gl_mask = gl_offsets < NUM_EXPERTS


### PR DESCRIPTION
### What this PR does / why we need it?

Adds single-card NPU CI coverage for `swiglu_quant`, the Triton fallback used by quantized MoE MLP paths when GMM+SwiGLU+Quant fusion is disabled.

The test compares the kernel with an independent FP32 PyTorch reference and covers:

- INT8 output and per-token dynamic scales
- the `need_quant=False` path
- FP16 and BF16 inputs
- single-token and multi-core token counts
- empty experts and int32/int64 count-mode group lists
- invalid group-list type and dtype validation

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

- `python -m py_compile tests/e2e/nightly/single_node/ops/singlecard_ops/triton/test_swiglu_quant.py`
- `uvx ruff format --check tests/e2e/nightly/single_node/ops/singlecard_ops/triton/test_swiglu_quant.py`
- `uvx ruff check tests/e2e/nightly/single_node/ops/singlecard_ops/triton/test_swiglu_quant.py`
- `git diff --cached --check`

The NPU test was not run on the local Windows host; it is intended to run in Ascend CI.

- vLLM main: https://github.com/vllm-project/vllm/commit/ba07e4a48fc951300d97eb506217dd530583dea3
