### PR TITLE
[Test][MRV2] Move SFA PCP graph accuracy test to four cards

### DIFF
--- a/.github/workflows/scripts/test_config.yaml
+++ b/.github/workflows/scripts/test_config.yaml
@@ -139,7 +139,7 @@ estimated_times:
   tests/e2e/pull_request/four_card/_310p/test_moe_model_310p.py: 800
   tests/e2e/pull_request/four_card/_310p/test_vl_model_310p.py: 370
   tests/e2e/pull_request/four_card/context_parallel/test_accuracy.py: 880
-  tests/e2e/pull_request/four_card/context_parallel/test_accuracy_v2.py: 380
+  tests/e2e/pull_request/four_card/context_parallel/test_accuracy_v2.py: 590
   tests/e2e/pull_request/four_card/context_parallel/test_prefix_caching_cp.py: 210
   tests/e2e/pull_request/four_card/model_runner_v2/test_deepseek_v4.py: 520
   tests/e2e/pull_request/four_card/rlhf/consistency/test_batch_invariant_tp4.py: 210

--- a/tests/e2e/pull_request/eight_card/model_runner_v2/test_glm5_2.py
+++ b/tests/e2e/pull_request/eight_card/model_runner_v2/test_glm5_2.py
@@ -18,10 +18,9 @@ import os
 from unittest.mock import patch
 
 import pytest
-from vllm import SamplingParams
 from vllm.config import CompilationConfig
 
-from tests.e2e.conftest import VllmRunner, wait_until_npu_memory_free
+from tests.e2e.conftest import wait_until_npu_memory_free
 from tests.e2e.pull_request.utils import _run_speculative_decoding
 
 MODEL = "Eco-Tech/GLM-5.2-w4a8"
@@ -64,53 +63,6 @@ def test_glm5_2_mtp_full_decode_only() -> None:
             "compilation_config": CompilationConfig(cudagraph_mode="FULL_DECODE_ONLY"),
         },
     )
-
-
-@pytest.mark.e2e_model(MODEL)
-@pytest.mark.e2e_coverage(
-    arch="moe",
-    feature="sfa_pcp",
-    parallel="TP,EP,PCP",
-    deploy="pd_mix",
-    hardware="A3",
-    quantization="W4A8",
-    graph_mode="full_decode_only",
-)
-@patch.dict(
-    os.environ,
-    {
-        "VLLM_USE_V2_MODEL_RUNNER": "1",
-        "VLLM_WORKER_MULTIPROC_METHOD": "spawn",
-        "PYTORCH_NPU_ALLOC_CONF": "expandable_segments:True",
-    },
-)
-@wait_until_npu_memory_free()
-def test_glm5_2_sfa_pcp_full_decode_only() -> None:
-    """Exercise MRV2 SFA PCP prefill and full-decode-only graph replay without C8 SFA."""
-    long_prompt = (
-        "You are validating a distributed language-model runtime. Explain how "
-        "prefill, KV-cache reuse, decode graph replay, and attention outputs "
-        "work together when serving a request with a long context. "
-    ) * 4
-    prompts = [f"{long_prompt} Request identifier: {request_id}." for request_id in range(4)]
-    sampling_params = SamplingParams(max_tokens=2, temperature=0.0)
-
-    with VllmRunner(
-        MODEL,
-        quantization="ascend",
-        tensor_parallel_size=4,
-        prefill_context_parallel_size=2,
-        max_model_len=8192,
-        max_num_seqs=16,
-        max_num_batched_tokens=1024,
-        enable_expert_parallel=True,
-        disable_log_stats=False,
-        compilation_config={"cudagraph_mode": "FULL_DECODE_ONLY"},
-    ) as runner:
-        outputs = runner.model.generate(prompts, sampling_params)
-
-    assert len(outputs) == len(prompts)
-    assert all(output.outputs[0].token_ids for output in outputs)
 
 
 @pytest.mark.e2e_model(MODEL)

--- a/tests/e2e/pull_request/four_card/context_parallel/test_accuracy_v2.py
+++ b/tests/e2e/pull_request/four_card/context_parallel/test_accuracy_v2.py
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-"""Model Runner V2 SFA DCP accuracy guard.
+"""Model Runner V2 SFA DCP and PCP accuracy guards.
 
 Run `pytest tests/e2e/pull_request/four_card/context_parallel/test_accuracy_v2.py`.
 """
@@ -64,6 +64,12 @@ DSV3_2_DCP_GOLDENS = (
         "The president of United States is平行于我 charm与技术oi",
     ],
 )
+
+DSV3_2_PCP_GOLDEN = [
+    "The capital of France isoint054 Rund compasses",
+    "Hello, my name is Tom, I am" + "ERIC slicpacelike\u6302",
+    "The president of United States isoint054 Rund959arki",
+]
 
 MODEL = "vllm-ascend/DeepSeek-V3.2-W8A8-Pruning"
 
@@ -140,6 +146,29 @@ FULL_FEATURE_MODEL_CASES = AccuracyCase(
     },
 )
 
+PCP_MODEL_CASE = AccuracyCase(
+    name="dsv3_2_sfa_pcp_mrv2_full_decode_only",
+    model=MODEL,
+    prompts=COMMON_PROMPTS,
+    expected_outputs=DSV3_2_PCP_GOLDEN,
+    max_tokens=5,
+    runner_kwargs={
+        "max_model_len": 1024,
+        "max_num_seqs": MAX_NUM_SEQS,
+        "max_num_batched_tokens": 1024,
+        "tensor_parallel_size": 2,
+        "prefill_context_parallel_size": 2,
+        "enable_expert_parallel": True,
+        "enable_chunked_prefill": True,
+        "enable_prefix_caching": True,
+        "gpu_memory_utilization": 0.8,
+        "cp_kv_cache_interleave_size": 128,
+        "block_size": 128,
+        "quantization": "ascend",
+        "compilation_config": FULL_DECODE_GRAPH,
+    },
+)
+
 
 @pytest.mark.skip("The use case is unstable and temporarily taken offline.")
 @patch.dict(
@@ -155,3 +184,29 @@ FULL_FEATURE_MODEL_CASES = AccuracyCase(
 def test_dsv3_2_sfa_dcp_tp2_dcp2_model_runner_v2_accuracy() -> None:
     """Guard MRV2 accuracy."""
     _run_accuracy_case(FULL_FEATURE_MODEL_CASES)
+
+
+@pytest.mark.e2e_model(MODEL)
+@pytest.mark.e2e_coverage(
+    arch="moe",
+    feature="sfa_pcp",
+    parallel="TP,EP,PCP",
+    deploy="pd_mix",
+    hardware="A3",
+    quantization="W8A8",
+    graph_mode="full_decode_only",
+)
+@patch.dict(
+    os.environ,
+    {
+        "VLLM_USE_V2_MODEL_RUNNER": "1",
+        "VLLM_BATCH_INVARIANT": "1",
+        "VLLM_WORKER_MULTIPROC_METHOD": "spawn",
+        "HCCL_BUFFSIZE": "768",
+        "PYTORCH_NPU_ALLOC_CONF": "expandable_segments:True",
+    },
+)
+@wait_until_npu_memory_free(target_free_percentage=0.8)
+def test_dsv3_2_sfa_pcp_model_runner_v2_graph_accuracy() -> None:
+    """Guard MRV2 SFA PCP full-decode-only graph accuracy."""
+    _run_accuracy_case(PCP_MODEL_CASE)


### PR DESCRIPTION
### What this PR does / why we need it?
Test Migration: Removed the SFA PCP graph accuracy test from the eight-card test suite.
New Test Implementation: Added a new, dedicated accuracy test for SFA PCP graph mode configured for four-card execution.
### Does this PR introduce _any_ user-facing change?
No
### How was this patch tested?


- vLLM main: https://github.com/vllm-project/vllm/commit/ba07e4a48fc951300d97eb506217dd530583dea3
