### PR TITLE
[Performance][MRV2] Remove atomic_or from the bincount prompt bitmask

### DIFF
--- a/tests/e2e/nightly/single_node/ops/singlecard_ops/triton/test_bincount.py
+++ b/tests/e2e/nightly/single_node/ops/singlecard_ops/triton/test_bincount.py
@@ -1,8 +1,10 @@
 import pytest
 import torch
-from vllm.triton_utils import triton
 
-from vllm_ascend.worker.v2.sample.penalties import _bincount_kernel
+from vllm_ascend.worker.v2.sample.penalties import bincount
+
+VOCAB_SIZE = 151936
+MAX_NUM_REQS = 64
 
 
 def torch_bincount(
@@ -36,70 +38,50 @@ def torch_bincount(
             output_bin_counts[req_idx, token] += 1
 
 
-@pytest.mark.skip(reason="atomic_or operator hangs in current npu_ir version")
-def test_bincount_kernel():
-    """
-    Compute the prompt binary mask and token bincount using the Triton kernel.
-
-    Args:
-        expanded_idx_mapping: Tensor containing the indices of requests to process.
-        all_token_ids: Batch of input token IDs for all requests.
-        prompt_len: Tensor storing the prompt length for each request.
-        prefill_len: Tensor storing the prefill length for each request.
-        prompt_bin_mask: Output binary mask tensor to mark prompt tokens.
-        output_bin_counts: Output tensor to store token frequency counts.
-        max_prefill_len: Maximum prefill length to limit kernel processing.
-    """
-
+@pytest.mark.parametrize(
+    "num_reqs, prompt_tokens, output_tokens",
+    [
+        # Single short request: the common case when one request is admitted.
+        (1, 8, 4),
+        # Prompt spanning several BLOCK_SIZE=1024 blocks.
+        (1, 4096, 16),
+        # Several requests admitted in the same step.
+        (4, 2048, 32),
+        # No generated tokens yet, so output_bin_counts must stay all zero.
+        (2, 1024, 0),
+    ],
+)
+def test_bincount(num_reqs, prompt_tokens, output_tokens):
+    """The packed prompt bitmask and the output token counts must match torch."""
     torch.manual_seed(42)
 
-    expanded_idx_mapping = torch.tensor([63], dtype=torch.int32).npu()
+    max_model_len = prompt_tokens + output_tokens + 1
+    expanded_idx_mapping = torch.arange(num_reqs, dtype=torch.int32).npu()
     all_token_ids = torch.randint(
         low=0,
-        high=10,
-        size=(64, 40960),
+        high=VOCAB_SIZE,
+        size=(MAX_NUM_REQS, max_model_len),
         dtype=torch.int32,
     ).npu()
 
-    prompt_len = torch.randint(
-        low=0,
-        high=10,
-        size=(64,),
-        dtype=torch.int32,
-    ).npu()
+    prompt_len = torch.full((MAX_NUM_REQS,), prompt_tokens, dtype=torch.int32).npu()
+    prefill_len = torch.full((MAX_NUM_REQS,), prompt_tokens + output_tokens, dtype=torch.int32).npu()
 
-    prefill_len = torch.randint(
-        low=0,
-        high=10,
-        size=(64,),
-        dtype=torch.int32,
-    ).npu()
+    num_words = (VOCAB_SIZE + 31) // 32
+    prompt_bin_mask = torch.zeros(size=(MAX_NUM_REQS, num_words), dtype=torch.int32).npu()
+    output_bin_counts = torch.zeros(size=(MAX_NUM_REQS, VOCAB_SIZE), dtype=torch.int32).npu()
 
-    prompt_bin_mask = torch.zeros(size=(64, 4748), dtype=torch.int32).npu()
-    output_bin_counts = torch.zeros(size=(64, 151936), dtype=torch.int32).npu()
+    ref_prompt_bin_mask = torch.zeros(size=(MAX_NUM_REQS, num_words), dtype=torch.int32).npu()
+    ref_output_bin_counts = torch.zeros(size=(MAX_NUM_REQS, VOCAB_SIZE), dtype=torch.int32).npu()
 
-    ref_prompt_bin_mask = torch.zeros(size=(64, 4748), dtype=torch.int32).npu()
-    ref_output_bin_counts = torch.zeros(size=(64, 151936), dtype=torch.int32).npu()
-
-    max_prefill_len = 10
-
-    prompt_bin_mask[expanded_idx_mapping] = 0
-    output_bin_counts[expanded_idx_mapping] = 0
-    num_tokens = expanded_idx_mapping.shape[0]
-    BLOCK_SIZE = 1024
-    num_blocks = triton.cdiv(max_prefill_len, BLOCK_SIZE)
-
-    _bincount_kernel[(num_tokens, num_blocks)](
+    bincount(
         expanded_idx_mapping,
         all_token_ids,
-        all_token_ids.stride(0),
         prompt_len,
         prefill_len,
         prompt_bin_mask,
-        prompt_bin_mask.stride(0),
         output_bin_counts,
-        output_bin_counts.stride(0),
-        BLOCK_SIZE=BLOCK_SIZE,
+        prompt_tokens + output_tokens,
     )
 
     torch_bincount(
@@ -113,13 +95,11 @@ def test_bincount_kernel():
 
     # ========== Verify results ==========
     assert torch.equal(prompt_bin_mask, ref_prompt_bin_mask), (
-        f"prompt_bin_mask triton output differs from torch reference.\n"
-        f"Max diff: {torch.max(torch.abs(prompt_bin_mask - ref_prompt_bin_mask))}\n"
-        f"Mean diff: {torch.mean(torch.abs(prompt_bin_mask - ref_prompt_bin_mask))}"
+        "prompt_bin_mask triton output differs from torch reference at "
+        f"rows {torch.nonzero((prompt_bin_mask != ref_prompt_bin_mask).any(dim=1)).flatten().tolist()[:8]}"
     )
 
     assert torch.equal(output_bin_counts, ref_output_bin_counts), (
-        f"output_bin_counts triton output differs from torch reference.\n"
-        f"Max diff: {torch.max(torch.abs(output_bin_counts - ref_output_bin_counts))}\n"
-        f"Mean diff: {torch.mean(torch.abs(output_bin_counts - ref_output_bin_counts))}"
+        "output_bin_counts triton output differs from torch reference at "
+        f"rows {torch.nonzero((output_bin_counts != ref_output_bin_counts).any(dim=1)).flatten().tolist()[:8]}"
     )

--- a/tests/e2e/nightly/single_node/ops/singlecard_ops/triton/test_bincount.py
+++ b/tests/e2e/nightly/single_node/ops/singlecard_ops/triton/test_bincount.py
@@ -1,9 +1,8 @@
 import pytest
 import torch
 
-from vllm_ascend.worker.v2.sample.penalties import bincount
+from vllm_ascend.worker.v2.sample.penalties import apply_penalties, bincount
 
-VOCAB_SIZE = 151936
 MAX_NUM_REQS = 64
 
 
@@ -38,41 +37,57 @@ def torch_bincount(
             output_bin_counts[req_idx, token] += 1
 
 
-@pytest.mark.parametrize(
-    "num_reqs, prompt_tokens, output_tokens",
-    [
-        # Single short request: the common case when one request is admitted.
-        (1, 8, 4),
-        # Prompt spanning several BLOCK_SIZE=1024 blocks.
-        (1, 4096, 16),
-        # Several requests admitted in the same step.
-        (4, 2048, 32),
-        # No generated tokens yet, so output_bin_counts must stay all zero.
-        (2, 1024, 0),
-    ],
-)
-def test_bincount(num_reqs, prompt_tokens, output_tokens):
-    """The packed prompt bitmask and the output token counts must match torch."""
-    torch.manual_seed(42)
-
+def _make_inputs(idx_mapping, prompt_tokens, output_tokens, vocab_size, seed=42):
+    """Build kernel inputs; token ids are drawn over the whole vocabulary."""
+    torch.manual_seed(seed)
     max_model_len = prompt_tokens + output_tokens + 1
-    expanded_idx_mapping = torch.arange(num_reqs, dtype=torch.int32).npu()
+    expanded_idx_mapping = torch.tensor(idx_mapping, dtype=torch.int32).npu()
     all_token_ids = torch.randint(
         low=0,
-        high=VOCAB_SIZE,
+        high=vocab_size,
         size=(MAX_NUM_REQS, max_model_len),
         dtype=torch.int32,
     ).npu()
-
     prompt_len = torch.full((MAX_NUM_REQS,), prompt_tokens, dtype=torch.int32).npu()
     prefill_len = torch.full((MAX_NUM_REQS,), prompt_tokens + output_tokens, dtype=torch.int32).npu()
+    num_words = (vocab_size + 31) // 32
+    return expanded_idx_mapping, all_token_ids, prompt_len, prefill_len, num_words
 
-    num_words = (VOCAB_SIZE + 31) // 32
-    prompt_bin_mask = torch.zeros(size=(MAX_NUM_REQS, num_words), dtype=torch.int32).npu()
-    output_bin_counts = torch.zeros(size=(MAX_NUM_REQS, VOCAB_SIZE), dtype=torch.int32).npu()
 
-    ref_prompt_bin_mask = torch.zeros(size=(MAX_NUM_REQS, num_words), dtype=torch.int32).npu()
-    ref_output_bin_counts = torch.zeros(size=(MAX_NUM_REQS, VOCAB_SIZE), dtype=torch.int32).npu()
+@pytest.mark.parametrize(
+    "idx_mapping, prompt_tokens, output_tokens",
+    [
+        # Single request placed at the end of the batch: token_idx 0 must not be
+        # confused with req_state_idx 63 anywhere in the kernels.
+        ([63], 8, 4),
+        # Several requests in a scrambled, non-contiguous order.
+        ([63, 7, 31, 2], 2048, 32),
+        # Prompt spanning several BLOCK_SIZE=1024 blocks.
+        ([17], 4096, 16),
+        # No generated tokens yet, so output_bin_counts must stay all zero.
+        ([40, 9], 1024, 0),
+    ],
+)
+@pytest.mark.parametrize(
+    "vocab_size",
+    [
+        151936,  # divisible by 32
+        151000,  # not divisible by 32: exercises the tail-word masking
+        5121,  # small and not divisible by 32
+    ],
+)
+def test_bincount(idx_mapping, prompt_tokens, output_tokens, vocab_size):
+    """The packed prompt bitmask and the output token counts must match torch."""
+    expanded_idx_mapping, all_token_ids, prompt_len, prefill_len, num_words = _make_inputs(
+        idx_mapping, prompt_tokens, output_tokens, vocab_size
+    )
+
+    # Poison the outputs so a row or word that is never written is caught
+    # instead of silently matching a zero-initialised reference.
+    prompt_bin_mask = torch.full((MAX_NUM_REQS, num_words), -1, dtype=torch.int32).npu()
+    output_bin_counts = torch.full((MAX_NUM_REQS, vocab_size), -1, dtype=torch.int32).npu()
+    ref_prompt_bin_mask = torch.full((MAX_NUM_REQS, num_words), -1, dtype=torch.int32).npu()
+    ref_output_bin_counts = torch.full((MAX_NUM_REQS, vocab_size), -1, dtype=torch.int32).npu()
 
     bincount(
         expanded_idx_mapping,
@@ -93,13 +108,115 @@ def test_bincount(num_reqs, prompt_tokens, output_tokens):
         ref_output_bin_counts,
     )
 
-    # ========== Verify results ==========
-    assert torch.equal(prompt_bin_mask, ref_prompt_bin_mask), (
-        "prompt_bin_mask triton output differs from torch reference at "
-        f"rows {torch.nonzero((prompt_bin_mask != ref_prompt_bin_mask).any(dim=1)).flatten().tolist()[:8]}"
+    touched = expanded_idx_mapping.long()
+    assert torch.equal(prompt_bin_mask[touched], ref_prompt_bin_mask[touched]), (
+        f"prompt_bin_mask differs from torch reference for rows {idx_mapping} at vocab_size={vocab_size}"
+    )
+    assert torch.equal(output_bin_counts[touched], ref_output_bin_counts[touched]), (
+        f"output_bin_counts differs from torch reference for rows {idx_mapping}"
+    )
+    # Rows outside expanded_idx_mapping must be left untouched.
+    untouched = torch.ones(MAX_NUM_REQS, dtype=torch.bool)
+    untouched[torch.tensor(idx_mapping)] = False
+    untouched = untouched.npu()
+    assert torch.all(prompt_bin_mask[untouched] == -1), "bincount wrote outside expanded_idx_mapping"
+    assert torch.all(output_bin_counts[untouched] == -1), "bincount wrote outside expanded_idx_mapping"
+
+
+def torch_apply_penalties(
+    logits: torch.Tensor,
+    expanded_idx_mapping: torch.Tensor,
+    repetition_penalty: torch.Tensor,
+    frequency_penalty: torch.Tensor,
+    presence_penalty: torch.Tensor,
+    prompt_bin_mask: torch.Tensor,
+    output_bin_counts: torch.Tensor,
+):
+    vocab_size = logits.shape[1]
+    bit_index = torch.arange(vocab_size, device=logits.device)
+    for token_idx in range(expanded_idx_mapping.shape[0]):
+        req = expanded_idx_mapping[token_idx].item()
+        rep = repetition_penalty[req].item()
+        freq = frequency_penalty[req].item()
+        presence = presence_penalty[req].item()
+        if rep == 1.0 and freq == 0.0 and presence == 0.0:
+            continue
+        counts = output_bin_counts[req].to(torch.float32)
+        out_mask = counts != 0
+        row = logits[token_idx].to(torch.float32)
+        if rep != 1.0:
+            words = prompt_bin_mask[req][bit_index // 32]
+            prompt_mask = ((words >> (bit_index % 32)) & 1) != 0
+            scale = torch.where(prompt_mask | out_mask, rep, 1.0)
+            row = row * torch.where(row > 0, 1.0 / scale, scale)
+        row = row - freq * counts
+        row = row - presence * out_mask.to(torch.float32)
+        logits[token_idx] = row
+
+
+@pytest.mark.parametrize("vocab_size", [5121, 151936])
+def test_bincount_then_apply_penalties(vocab_size):
+    """bincount feeds apply_penalties: check the chained result, not just bincount."""
+    idx_mapping = [63, 7, 31, 2]
+    prompt_tokens, output_tokens = 512, 24
+    expanded_idx_mapping, all_token_ids, prompt_len, prefill_len, num_words = _make_inputs(
+        idx_mapping, prompt_tokens, output_tokens, vocab_size, seed=7
     )
 
-    assert torch.equal(output_bin_counts, ref_output_bin_counts), (
-        "output_bin_counts triton output differs from torch reference at "
-        f"rows {torch.nonzero((output_bin_counts != ref_output_bin_counts).any(dim=1)).flatten().tolist()[:8]}"
+    prompt_bin_mask = torch.full((MAX_NUM_REQS, num_words), -1, dtype=torch.int32).npu()
+    output_bin_counts = torch.full((MAX_NUM_REQS, vocab_size), -1, dtype=torch.int32).npu()
+    ref_prompt_bin_mask = torch.full((MAX_NUM_REQS, num_words), -1, dtype=torch.int32).npu()
+    ref_output_bin_counts = torch.full((MAX_NUM_REQS, vocab_size), -1, dtype=torch.int32).npu()
+
+    bincount(
+        expanded_idx_mapping,
+        all_token_ids,
+        prompt_len,
+        prefill_len,
+        prompt_bin_mask,
+        output_bin_counts,
+        prompt_tokens + output_tokens,
     )
+    torch_bincount(
+        expanded_idx_mapping,
+        all_token_ids,
+        prompt_len,
+        prefill_len,
+        ref_prompt_bin_mask,
+        ref_output_bin_counts,
+    )
+
+    num_tokens = len(idx_mapping)
+    torch.manual_seed(11)
+    logits = torch.randn(num_tokens, vocab_size, dtype=torch.float32).npu()
+    ref_logits = logits.clone()
+    # No draft tokens, so every logits row is the last position of its request.
+    expanded_local_pos = torch.zeros(num_tokens, dtype=torch.int32).npu()
+    token_ids = all_token_ids[expanded_idx_mapping.long()]
+
+    repetition_penalty = torch.full((MAX_NUM_REQS,), 1.3, dtype=torch.float32).npu()
+    frequency_penalty = torch.full((MAX_NUM_REQS,), 0.4, dtype=torch.float32).npu()
+    presence_penalty = torch.full((MAX_NUM_REQS,), 0.2, dtype=torch.float32).npu()
+
+    apply_penalties(
+        logits,
+        expanded_idx_mapping,
+        token_ids,
+        expanded_local_pos,
+        repetition_penalty,
+        frequency_penalty,
+        presence_penalty,
+        prompt_bin_mask,
+        output_bin_counts,
+    )
+    torch_apply_penalties(
+        ref_logits,
+        expanded_idx_mapping,
+        repetition_penalty,
+        frequency_penalty,
+        presence_penalty,
+        ref_prompt_bin_mask,
+        ref_output_bin_counts,
+    )
+
+    torch.testing.assert_close(logits, ref_logits, rtol=1e-5, atol=1e-5)

--- a/vllm_ascend/worker/v2/sample/penalties.py
+++ b/vllm_ascend/worker/v2/sample/penalties.py
@@ -21,6 +21,9 @@
 import torch
 from vllm.triton_utils import tl, triton
 
+# Vocabulary words packed per program in _pack_prompt_bin_mask_kernel.
+WORDS_PER_BLOCK = 128
+
 
 @triton.jit
 def _penalties_kernel(
@@ -156,8 +159,8 @@ def _bincount_kernel(
     all_token_ids_stride,
     prompt_len_ptr,
     prefill_len_ptr,
-    prompt_bin_mask_ptr,
-    prompt_bin_mask_stride,
+    prompt_flag_ptr,
+    prompt_flag_stride,
     output_bin_counts_ptr,
     output_bin_counts_stride,
     BLOCK_SIZE: tl.constexpr,
@@ -175,14 +178,12 @@ def _bincount_kernel(
     if block_idx * BLOCK_SIZE < prompt_len:
         mask = block < prompt_len
         prompt_tokens = tl.load(all_token_ids_ptr + req_state_idx * all_token_ids_stride + block, mask=mask)
-        idx = prompt_tokens // 32
-
-        bit_idx = prompt_tokens % 32
-        bit = tl.full((BLOCK_SIZE,), 1, tl.int32) << bit_idx
-
-        tl.atomic_or(
-            prompt_bin_mask_ptr + req_state_idx * prompt_bin_mask_stride + idx,
-            bit,
+        # One byte per vocabulary entry instead of a packed bit, so colliding
+        # tokens need no read-modify-write: every lane stores the same value.
+        # The packed mask is built by _pack_prompt_bin_mask_kernel below.
+        tl.store(
+            prompt_flag_ptr + token_idx * prompt_flag_stride + prompt_tokens,
+            tl.full((BLOCK_SIZE,), 1, tl.int8),
             mask=mask,
         )
 
@@ -197,6 +198,33 @@ def _bincount_kernel(
         )
 
 
+@triton.jit
+def _pack_prompt_bin_mask_kernel(
+    expanded_idx_mapping_ptr,
+    prompt_flag_ptr,
+    prompt_flag_stride,
+    prompt_bin_mask_ptr,
+    prompt_bin_mask_stride,
+    num_words,
+    vocab_size,
+    WORDS_PER_BLOCK: tl.constexpr,
+):
+    token_idx = tl.program_id(0)
+    word_block_idx = tl.program_id(1)
+    req_state_idx = tl.load(expanded_idx_mapping_ptr + token_idx)
+
+    words = word_block_idx * WORDS_PER_BLOCK + tl.arange(0, WORDS_PER_BLOCK)
+    word_mask = words < num_words
+    bits = tl.arange(0, 32)
+    flat = words[:, None] * 32 + bits[None, :]
+    # The final word runs past vocab_size, so mask per element, not per word.
+    elem_mask = word_mask[:, None] & (flat < vocab_size)
+    flags = tl.load(prompt_flag_ptr + token_idx * prompt_flag_stride + flat, mask=elem_mask, other=0).to(tl.int32)
+    # Each bit is contributed by exactly one lane, so the sum equals an OR.
+    packed = tl.sum(flags << bits[None, :], axis=1)
+    tl.store(prompt_bin_mask_ptr + req_state_idx * prompt_bin_mask_stride + words, packed, mask=word_mask)
+
+
 def bincount(
     expanded_idx_mapping: torch.Tensor,
     all_token_ids: torch.Tensor,
@@ -206,20 +234,41 @@ def bincount(
     output_bin_counts: torch.Tensor,
     max_prefill_len: int,
 ) -> None:
-    prompt_bin_mask[expanded_idx_mapping] = 0
     output_bin_counts[expanded_idx_mapping] = 0
     num_tokens = expanded_idx_mapping.shape[0]
+    num_words = prompt_bin_mask.shape[1]
+    vocab_size = output_bin_counts.shape[1]
     BLOCK_SIZE = 1024
     num_blocks = triton.cdiv(max_prefill_len, BLOCK_SIZE)
+    # Scratch flags for the prompt bitmask, one byte per vocabulary entry per
+    # request being counted. Freed on return; num_tokens is the number of newly
+    # added penalty requests, so this stays small.
+    prompt_flag = torch.zeros(
+        num_tokens,
+        num_words * 32,
+        dtype=torch.int8,
+        device=prompt_bin_mask.device,
+    )
     _bincount_kernel[(num_tokens, num_blocks)](
         expanded_idx_mapping,
         all_token_ids,
         all_token_ids.stride(0),
         prompt_len,
         prefill_len,
-        prompt_bin_mask,
-        prompt_bin_mask.stride(0),
+        prompt_flag,
+        prompt_flag.stride(0),
         output_bin_counts,
         output_bin_counts.stride(0),
         BLOCK_SIZE=BLOCK_SIZE,
+    )
+    # Writes every word of each row, so prompt_bin_mask needs no pre-zeroing.
+    _pack_prompt_bin_mask_kernel[(num_tokens, triton.cdiv(num_words, WORDS_PER_BLOCK))](
+        expanded_idx_mapping,
+        prompt_flag,
+        prompt_flag.stride(0),
+        prompt_bin_mask,
+        prompt_bin_mask.stride(0),
+        num_words,
+        vocab_size,
+        WORDS_PER_BLOCK=WORDS_PER_BLOCK,
     )


### PR DESCRIPTION
### What this PR does / why we need it?

Closes #14158 (MRV2 task of #9079).

Ascend `_bincount_kernel` uses `tl.atomic_or` to build `prompt_bin_mask`. On A2/A3,
this operation serializes and dominates the kernel; replacing it with a plain store in a
measurement-only kernel makes the prompt path 6.5x-33.2x faster, while removing
`atomic_add` improves the output-count path by only 1.24x-1.50x.

This PR removes `atomic_or` with two passes:

1. Write one byte per prompt vocabulary entry to a zero-initialized scratch row. Duplicate
   tokens safely write the same value.
2. Pack the byte flags into the existing int32 bitmask without atomics.

`output_bin_counts` keeps `tl.atomic_add`. The pack pass overwrites every target word, so
the old `prompt_bin_mask` row zeroing is removed. Scratch usage is
`new_penalty_requests x padded_vocab` bytes: about 0.1 MiB for one request and 9.3 MiB for
64 requests at vocab size 151936.

### Does this PR introduce _any_ user-facing change?

No. `prompt_bin_mask`, `output_bin_counts`, and penalty-adjusted logits remain numerically
equivalent to the current implementation and the vLLM-core GPU baseline.

### How was this patch tested?

#### Correctness tests

```bash
pytest -q tests/e2e/nightly/single_node/ops/singlecard_ops/triton/test_bincount.py
# 14 passed on A3

ruff check vllm_ascend/worker/v2/sample/penalties.py \
  tests/e2e/nightly/single_node/ops/singlecard_ops/triton/test_bincount.py
ruff format --check vllm_ascend/worker/v2/sample/penalties.py \
  tests/e2e/nightly/single_node/ops/singlecard_ops/triton/test_bincount.py
```

The test now exercises the public `bincount()` path and covers:

- scrambled, non-contiguous request mappings: `[63]`, `[63, 7, 31, 2]`, `[17]`,
  and `[40, 9]`;
- vocab sizes 151936, 151000, and 5121, including non-32-multiple tail words;
- short, multi-block, multi-request, and zero-output-token inputs;
- poisoned outputs and verification that unmapped rows remain untouched;
- `bincount -> apply_penalties` logits against a PyTorch reference.

The same inputs were run through vLLM-core `bincount` on an NVIDIA H20 with vLLM 0.27.1.
All three comparison cases matched byte for byte:

| case | vocab | request rows | prompt mask | output counts |
|---|---:|---|---|---|
| scrambled mapping | 5121 | `[63, 7, 31, 2]` | MATCH | MATCH |
| tail word | 151000 | `[63]` | MATCH | MATCH |
| full vocab, multi-block | 151936 | `[17, 40]` | MATCH | MATCH |

#### Single-operator performance

`vocab_size=151936`; times are per `bincount()` call.

| new requests | prompt | output | A2 current / PR | A2 speedup | A3 current / PR | A3 speedup |
|---:|---:|---:|---:|---:|---:|---:|
| 1 | 8 | 4 | 0.621 / 0.662 ms | 0.94x | 0.310 / 0.368 ms | 0.84x |
| 1 | 1024 | 256 | 0.867 / 0.662 ms | 1.31x | 0.572 / 0.438 ms | 1.30x |
| 1 | 65280 | 256 | 21.730 / 0.841 ms | 25.8x | 20.387 / 0.587 ms | 34.8x |
| 16 | 16384 | 256 | 86.532 / 2.461 ms | 35.2x | 82.021 / 2.223 ms | 36.9x |
| 64 | 4096 | 256 | 87.231 / 5.915 ms | 14.8x | 82.590 / 5.689 ms | 14.5x |

The extra pack launch costs at most 0.06 ms for very short prompts. Break-even is about 200
prompt tokens on both A2 and A3. `bincount()` runs only when a penalty-using request is
admitted, not on every decode step. `WORDS_PER_BLOCK=128` was retained after a sweep: 64
and 128 tie, 256 is slower, and 512 or above exceeds UB capacity.

#### NPU profiler

`torch_npu.profiler` on A3, 4 new requests x 16384 prompt tokens, 5 iterations:

| device-side total | current | this PR |
|---|---:|---:|
| `_bincount_kernel` | 92059.8 us | 1363.3 us |
| `_pack_prompt_bin_mask_kernel` | - | 1897.9 us |
| row zeroing | 335.0 us | 291.8 us |
| all measured work | 92444.9 us | 3601.3 us (**25.7x**) |

#### End-to-end, penalties enabled

Qwen3-0.6B on one A3, MRV2 with `VLLM_USE_V2_MODEL_RUNNER=1` and `--enforce-eager`;
32 requests, concurrency 8, 23230 prompt tokens, `max_tokens=16`. Requests use
`top_p=1.0, top_k=-1` to avoid an unrelated top-k/top-p Triton compile failure in the test
image. All 32 requests succeeded in every configuration.

| build | penalties | mean TTFT run 1 | mean TTFT run 2 |
|---|---|---:|---:|
| baseline | on | 1656.7 ms | 1689.9 ms |
| baseline | off | 1510.8 ms | 1569.4 ms |
| this PR | on | **1505.1 ms** | **1522.1 ms** |
| this PR | off | 1508.4 ms | 1519.1 ms |

The cost of enabling penalties changes from +145.9/+120.5 ms on baseline to
-3.3/+3.0 ms with this PR. Penalties-on TTFT improves by 9.2% and 9.9%; penalties-off is
the control for changes outside the optimized path.

#### CI and environments

- CI: pre-commit, mypy, coverage recommendation, test selection, main, and DCO pass.
  Selected NPU CI is pending a `ready-precise` or `ready-all` label.
- NPU: Atlas A2 910B1, CANN 9.0.0/9.1.0; Atlas A3 Ascend910_9392, CANN 9.0.1;
  triton_ascend 3.2.1; torch 2.10.0.
- GPU baseline: NVIDIA H20; torch 2.13.0+cu130; vLLM 0.27.1.

AI assistance was used during implementation and test drafting. The author reviewed every
changed line and ran the reported hardware tests.

- vLLM version: v0.27.1
- vLLM main: https://github.com/vllm-project/vllm/commit/ba07e4a48fc951300d97eb506217dd530583dea3
