### PR TITLE
[Doc][Model] Update Qwen3, Qwen-VL, and DeepSeek OCR 2 deployment variables

### DIFF
--- a/docs/source/tutorials/models/DeepSeekOCR2.md
+++ b/docs/source/tutorials/models/DeepSeekOCR2.md
@@ -123,11 +123,7 @@ Run the following script to execute online inference.
 ```shell
 #!/bin/sh
 
-export VLLM_USE_V1=1
-export TOKENIZERS_PARALLELISM=false
 export PYTORCH_NPU_ALLOC_CONF="expandable_segments:True"
-export TASK_QUEUE_ENABLE=1
-export TOKENIZERS_PARALLELISM=false
 
 vllm serve /root/.cache/DeepSeek-OCR-2 \
     --served-model-name deepseekocr2 \

--- a/docs/source/tutorials/models/Qwen-VL-Dense.md
+++ b/docs/source/tutorials/models/Qwen-VL-Dense.md
@@ -209,11 +209,8 @@ Run docker container to start the vLLM server on single-NPU:
 
     ```bash
     export HCCL_OP_EXPANSION_MODE="AIV"
-    export PYTORCH_NPU_ALLOC_CONF=expandable_segments:True
-    export OMP_PROC_BIND=false
-    export OMP_NUM_THREADS=1
-    export TASK_QUEUE_ENABLE=1
     export ASCEND_RT_VISIBLE_DEVICES=$1
+    export PYTORCH_NPU_ALLOC_CONF=expandable_segments:True
 
     vllm serve Qwen/Qwen3-VL-8B-Instruct \
       --host 0.0.0.0 \
@@ -237,11 +234,8 @@ Run docker container to start the vLLM server on single-NPU:
 
     ```bash
     export HCCL_OP_EXPANSION_MODE="AIV"
-    export PYTORCH_NPU_ALLOC_CONF=expandable_segments:True
-    export OMP_PROC_BIND=false
-    export OMP_NUM_THREADS=1
-    export TASK_QUEUE_ENABLE=1
     export ASCEND_RT_VISIBLE_DEVICES=$1
+    export PYTORCH_NPU_ALLOC_CONF=expandable_segments:True
 
     vllm serve Qwen/Qwen3-VL-8B-Instruct \
     --host 0.0.0.0 \
@@ -266,11 +260,8 @@ Run docker container to start the vLLM server on single-NPU:
 
     ```bash
     export HCCL_OP_EXPANSION_MODE="AIV"
-    export PYTORCH_NPU_ALLOC_CONF=expandable_segments:True
-    export OMP_PROC_BIND=false
-    export OMP_NUM_THREADS=1
-    export TASK_QUEUE_ENABLE=1
     export ASCEND_RT_VISIBLE_DEVICES=$1
+    export PYTORCH_NPU_ALLOC_CONF=expandable_segments:True
 
     vllm serve Qwen/Qwen3-VL-8B-Instruct \
     --dtype float16 \

--- a/docs/source/tutorials/models/Qwen3-Omni-30B-A3B-Thinking.md
+++ b/docs/source/tutorials/models/Qwen3-Omni-30B-A3B-Thinking.md
@@ -211,11 +211,9 @@ Single-node deployment completes both Prefill and Decode within the same node, s
 **Atlas 800I A2/A3:**
 
 ```bash
-export ASCEND_RT_VISIBLE_DEVICES=0,1,2,3
-export HCCL_OP_EXPANSION_MODE="AIV"  # not needed on A2
 export HCCL_BUFFSIZE=1024
-export OMP_PROC_BIND=false
-export OMP_NUM_THREADS=1
+export HCCL_OP_EXPANSION_MODE="AIV"  # not needed on A2
+export ASCEND_RT_VISIBLE_DEVICES=0,1,2,3
 export PYTORCH_NPU_ALLOC_CONF=expandable_segments:True
 
 vllm serve your_model_path \
@@ -390,8 +388,8 @@ There are three `vllm bench` subcommands:
 Take the `serve` as an example. Run the code as follows.
 
 ```bash
-export VLLM_USE_MODELSCOPE=True
 export MODEL=Qwen/Qwen3-Omni-30B-A3B-Thinking
+export VLLM_USE_MODELSCOPE=True
 python3 -m vllm.entrypoints.openai.api_server --model $MODEL --tensor-parallel-size 2 --swap-space 16 --disable-log-stats --disable-log-request --load-format dummy
 
 pip config set global.index-url https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple
@@ -459,11 +457,9 @@ P99 ITL (ms):                            176.02
 **Low Latency Configuration:**
 
 ```shell
-export ASCEND_RT_VISIBLE_DEVICES=0,1,2,3
-export HCCL_OP_EXPANSION_MODE="AIV"
 export HCCL_BUFFSIZE=1024
-export OMP_PROC_BIND=false
-export OMP_NUM_THREADS=1
+export HCCL_OP_EXPANSION_MODE="AIV"
+export ASCEND_RT_VISIBLE_DEVICES=0,1,2,3
 export PYTORCH_NPU_ALLOC_CONF=expandable_segments:True
 
 vllm serve your_model_path \
@@ -495,11 +491,9 @@ vllm serve your_model_path \
 **High Throughput Configuration:**
 
 ```shell
-export ASCEND_RT_VISIBLE_DEVICES=0
-export HCCL_OP_EXPANSION_MODE="AIV"
 export HCCL_BUFFSIZE=1024
-export OMP_PROC_BIND=false
-export OMP_NUM_THREADS=1
+export HCCL_OP_EXPANSION_MODE="AIV"
+export ASCEND_RT_VISIBLE_DEVICES=0
 export PYTORCH_NPU_ALLOC_CONF=expandable_segments:True
 
 vllm serve your_model_path \
@@ -530,11 +524,9 @@ vllm serve your_model_path \
 **Long Context Configuration:**
 
 ```shell
-export ASCEND_RT_VISIBLE_DEVICES=0,1,2,3
-export HCCL_OP_EXPANSION_MODE="AIV"
 export HCCL_BUFFSIZE=1024
-export OMP_PROC_BIND=false
-export OMP_NUM_THREADS=1
+export HCCL_OP_EXPANSION_MODE="AIV"
+export ASCEND_RT_VISIBLE_DEVICES=0,1,2,3
 export PYTORCH_NPU_ALLOC_CONF=expandable_segments:True
 
 vllm serve your_model_path \

--- a/docs/source/tutorials/models/Qwen3-VL-235B-A22B-Instruct.md
+++ b/docs/source/tutorials/models/Qwen3-VL-235B-A22B-Instruct.md
@@ -210,15 +210,12 @@ Single-node deployment runs both Prefill and Decode on the same node. The W8A8 v
 
     # Load model from ModelScope to speed up download.
     export VLLM_USE_MODELSCOPE=True
-
-    # Reduce memory fragmentation and avoid out-of-memory errors.
+    export HCCL_BUFFSIZE=400
+    export HCCL_OP_EXPANSION_MODE="AIV"
     export PYTORCH_NPU_ALLOC_CONF=expandable_segments:True
 
-    export HCCL_OP_EXPANSION_MODE="AIV"
-    export HCCL_BUFFSIZE=400
-    export OMP_PROC_BIND=false
-    export OMP_NUM_THREADS=100
-    export TASK_QUEUE_ENABLE=1
+    # Reduce memory fragmentation and avoid out-of-memory errors.
+
 
     vllm serve Eco-Tech/Qwen3-VL-235B-A22B-Instruct-w8a8-mxfp8 \
       --host 0.0.0.0 \
@@ -251,16 +248,13 @@ Single-node deployment runs both Prefill and Decode on the same node. The W8A8 v
 
     # Load model from ModelScope to speed up download.
     export VLLM_USE_MODELSCOPE=True
-
-    # Reduce memory fragmentation and avoid out-of-memory errors.
+    export HCCL_BUFFSIZE=1536
+    export HCCL_OP_EXPANSION_MODE="AIV"
     export PYTORCH_NPU_ALLOC_CONF=expandable_segments:True
 
-    export HCCL_OP_EXPANSION_MODE="AIV"
-    export HCCL_BUFFSIZE=1536
-    export OMP_NUM_THREADS=1
-    export OMP_PROC_BIND=false
-    export TASK_QUEUE_ENABLE=1
-    vllm serve Eco-Tech/Qwen3-VL-235B-A22B-Instruct-w8a8-QuaRot --additional-config '{"enable_fused_mc2":1,"scheduler_config":{"enable_balance_scheduling":true}}' \
+    # Reduce memory fragmentation and avoid out-of-memory errors.
+
+    vllm serve Eco-Tech/Qwen3-VL-235B-A22B-Instruct-w8a8-QuaRot \
       --host 0.0.0.0 \
       --port 8000 \
       --served-model-name qwen3-vl-235b \
@@ -278,7 +272,8 @@ Single-node deployment runs both Prefill and Decode on the same node. The W8A8 v
       --mm-processor-cache-gb 0 \
       --limit-mm-per-prompt.image 1 \
       --limit-mm-per-prompt.video 0 \
-      --compilation-config '{"cudagraph_mode":"FULL_DECODE_ONLY","cudagraph_capture_sizes":[1,2,4,8,16,24,32]}'
+      --compilation-config '{"cudagraph_mode":"FULL_DECODE_ONLY","cudagraph_capture_sizes":[1,2,4,8,16,24,32]}' \
+      --additional-config '{"enable_fused_mc2": 1, "scheduler_config": {"enable_balance_scheduling": true}}'
     ```
 
 === "A2 series"
@@ -311,23 +306,19 @@ Run the following script on node 0.
 ```shell
 #!/bin/sh
 
-export VLLM_USE_MODELSCOPE=True
-export PYTORCH_NPU_ALLOC_CONF=expandable_segments:True
-
 # Get these values through ifconfig.
 # nic_name is the network interface name corresponding to local_ip.
 nic_name="xxxx"
 local_ip="xxxx"
 
-export HCCL_IF_IP=$local_ip
-export GLOO_SOCKET_IFNAME=$nic_name
-export TP_SOCKET_IFNAME=$nic_name
-export HCCL_SOCKET_IFNAME=$nic_name
-export OMP_PROC_BIND=false
-export OMP_NUM_THREADS=1
+export VLLM_USE_MODELSCOPE=True
 export HCCL_BUFFSIZE=1024
-export TASK_QUEUE_ENABLE=1
+export HCCL_IF_IP=$local_ip
 export HCCL_OP_EXPANSION_MODE="AIV"
+export HCCL_SOCKET_IFNAME=$nic_name
+export GLOO_SOCKET_IFNAME=$nic_name
+export PYTORCH_NPU_ALLOC_CONF=expandable_segments:True
+
 
 vllm serve Eco-Tech/Qwen3-VL-235B-A22B-Instruct-w8a8-QuaRot \
   --host 0.0.0.0 \
@@ -362,26 +353,22 @@ Run the following script on node 1.
 ```shell
 #!/bin/sh
 
-export VLLM_USE_MODELSCOPE=True
-export PYTORCH_NPU_ALLOC_CONF=expandable_segments:True
-
 # Get these values through ifconfig.
 # nic_name is the network interface name corresponding to local_ip.
 nic_name="xxxx"
 local_ip="xxxx"
 
+export VLLM_USE_MODELSCOPE=True
+export HCCL_BUFFSIZE=1024
+export HCCL_IF_IP=$local_ip
+export HCCL_OP_EXPANSION_MODE="AIV"
+export HCCL_SOCKET_IFNAME=$nic_name
+export GLOO_SOCKET_IFNAME=$nic_name
+export PYTORCH_NPU_ALLOC_CONF=expandable_segments:True
+
 # The value of node0_ip must be consistent with local_ip on node 0.
 node0_ip="xxxx"
 
-export HCCL_IF_IP=$local_ip
-export GLOO_SOCKET_IFNAME=$nic_name
-export TP_SOCKET_IFNAME=$nic_name
-export HCCL_SOCKET_IFNAME=$nic_name
-export OMP_PROC_BIND=false
-export OMP_NUM_THREADS=1
-export HCCL_BUFFSIZE=1024
-export TASK_QUEUE_ENABLE=1
-export HCCL_OP_EXPANSION_MODE="AIV"
 
 vllm serve Eco-Tech/Qwen3-VL-235B-A22B-Instruct-w8a8-QuaRot \
   --host 0.0.0.0 \
@@ -431,7 +418,7 @@ INFO:     Application startup complete.
 - `--api-server-count` controls how many API server processes are started on the master node.
 - `--headless` starts a worker node without exposing an API server. Use it on non-master nodes.
 - `--tensor-parallel-size 8` maps one TP group to the 8 NPUs on each A2 node.
-- `HCCL_IF_IP`, `GLOO_SOCKET_IFNAME`, `TP_SOCKET_IFNAME`, and `HCCL_SOCKET_IFNAME` bind HCCL, Gloo, and TP communication to the selected network.
+- `HCCL_IF_IP`, `GLOO_SOCKET_IFNAME`, and `HCCL_SOCKET_IFNAME` bind HCCL and Gloo communication to the selected network.
 
 ### 5.3 Multi-Node PD Separation Deployment
 
@@ -452,12 +439,9 @@ Create `run_p.sh` on the prefill node.
 #!/bin/bash
 
 export VLLM_USE_MODELSCOPE=True
-export PYTORCH_NPU_ALLOC_CONF=expandable_segments:True
 export HCCL_BUFFSIZE=1024
-export OMP_PROC_BIND=false
-export OMP_NUM_THREADS=1
 export HCCL_OP_EXPANSION_MODE="AIV"
-export TASK_QUEUE_ENABLE=1
+export PYTORCH_NPU_ALLOC_CONF=expandable_segments:True
 
 vllm serve Eco-Tech/Qwen3-VL-235B-A22B-Instruct-w8a8-QuaRot \
   --host 0.0.0.0 \
@@ -496,12 +480,9 @@ Create `run_d.sh` on the decode node.
 #!/bin/bash
 
 export VLLM_USE_MODELSCOPE=True
-export PYTORCH_NPU_ALLOC_CONF=expandable_segments:True
 export HCCL_BUFFSIZE=1024
-export OMP_PROC_BIND=false
-export OMP_NUM_THREADS=1
 export HCCL_OP_EXPANSION_MODE="AIV"
-export TASK_QUEUE_ENABLE=1
+export PYTORCH_NPU_ALLOC_CONF=expandable_segments:True
 
 vllm serve Eco-Tech/Qwen3-VL-235B-A22B-Instruct-w8a8-QuaRot \
   --host 0.0.0.0 \
@@ -687,6 +668,7 @@ Please refer to the [Feature Matrix](../../user_guide/support_matrix/feature_mat
 | Multimodal prompt limits | `--limit-mm-per-prompt.image`, `--limit-mm-per-prompt.video` | Avoids reserving memory for unused media types. | Disable video for image-only serving. |
 | Multimodal processor cache | `--mm-processor-cache-gb` | Caches processed media features when repeated media appears. | Set to 0 for memory-constrained validation. |
 | Full decode ACLGraph | `--compilation-config '{"cudagraph_mode":"FULL_DECODE_ONLY"}'` | Reduces operator dispatch overhead and stabilizes decode performance. | Recommended for decode-heavy serving. |
+| Fused MC2 | `--additional-config '{"enable_fused_mc2": 1}'` | Enables MoE fused operators to improve MoE efficiency. | Compare with disabled state if accuracy or performance regresses. |
 | Prefix caching | `--enable-prefix-caching` | Improves repeated-prefix workloads. | Validate HBM usage first. For PD, start with prefix caching disabled. |
 | PD disaggregation | `--kv-transfer-config` | Separates prefill and decode resources. | Ensure producer/consumer DP and TP sizes match the actual topology. |
 
@@ -708,7 +690,7 @@ For common environment, installation, and general parameter issues, refer to [Pu
 
 **Cause:** Network interface names, IP addresses, DP ranks, or RPC ports are inconsistent across nodes.
 
-**Solution:** Verify multi-node communication first. Ensure `HCCL_IF_IP`, `GLOO_SOCKET_IFNAME`, `TP_SOCKET_IFNAME`, and `HCCL_SOCKET_IFNAME` match the selected NIC. Ensure all nodes use the same `--data-parallel-rpc-port`, non-master nodes use `--headless`, and `--data-parallel-start-rank` does not overlap.
+**Solution:** Verify multi-node communication first. Ensure `HCCL_IF_IP`, `GLOO_SOCKET_IFNAME`, and `HCCL_SOCKET_IFNAME` match the selected NIC. Ensure all nodes use the same `--data-parallel-rpc-port`, non-master nodes use `--headless`, and `--data-parallel-start-rank` does not overlap.
 
 ### Q3: Why is video disabled in the image-only examples?
 

--- a/docs/source/tutorials/models/Qwen3-VL-30B-A3B-Instruct.md
+++ b/docs/source/tutorials/models/Qwen3-VL-30B-A3B-Instruct.md
@@ -205,15 +205,12 @@ Single-node deployment runs both Prefill and Decode on the same node. The follow
 
     # Load model from ModelScope to speed up download.
     export VLLM_USE_MODELSCOPE=True
-
-    # Reduce memory fragmentation and avoid out-of-memory errors.
+    export HCCL_BUFFSIZE=400
+    export HCCL_OP_EXPANSION_MODE="AIV"
     export PYTORCH_NPU_ALLOC_CONF=expandable_segments:True
 
-    export HCCL_OP_EXPANSION_MODE="AIV"
-    export HCCL_BUFFSIZE=400
-    export OMP_PROC_BIND=false
-    export OMP_NUM_THREADS=100
-    export TASK_QUEUE_ENABLE=1
+    # Reduce memory fragmentation and avoid out-of-memory errors.
+
 
     vllm serve Eco-Tech/Qwen3-VL-30B-A3B-Instruct-w8a8-mxfp8 \
       --host 0.0.0.0 \
@@ -246,15 +243,12 @@ Single-node deployment runs both Prefill and Decode on the same node. The follow
 
     # Load model from ModelScope to speed up download.
     export VLLM_USE_MODELSCOPE=True
-
-    # Reduce memory fragmentation and avoid out-of-memory errors.
+    export HCCL_BUFFSIZE=1024
+    export HCCL_OP_EXPANSION_MODE="AIV"
     export PYTORCH_NPU_ALLOC_CONF=expandable_segments:True
 
-    export HCCL_OP_EXPANSION_MODE="AIV"
-    export HCCL_BUFFSIZE=1024
-    export OMP_NUM_THREADS=1
-    export OMP_PROC_BIND=false
-    export TASK_QUEUE_ENABLE=1
+    # Reduce memory fragmentation and avoid out-of-memory errors.
+
 
     vllm serve Qwen/Qwen3-VL-30B-A3B-Instruct --additional-config '{"enable_fused_mc2":1}' \
       --host 0.0.0.0 \
@@ -272,7 +266,8 @@ Single-node deployment runs both Prefill and Decode on the same node. The follow
       --mm-processor-cache-gb 0 \
       --limit-mm-per-prompt.image 1 \
       --limit-mm-per-prompt.video 0 \
-      --compilation-config '{"cudagraph_mode":"FULL_DECODE_ONLY","cudagraph_capture_sizes":[1,2,4,8,16,24,32]}'
+      --compilation-config '{"cudagraph_mode":"FULL_DECODE_ONLY","cudagraph_capture_sizes":[1,2,4,8,16,24,32]}' \
+      --additional-config '{"enable_fused_mc2": 1}'
     ```
 
 === "A2 series"

--- a/docs/source/tutorials/models/Qwen3.5-27B-Qwen3.6-27B.md
+++ b/docs/source/tutorials/models/Qwen3.5-27B-Qwen3.6-27B.md
@@ -232,20 +232,14 @@ Both `Qwen3.5-27B` and `Qwen3.6-27B` share the same MTP head design, so the `qwe
         ```bash
         #!/bin/sh
         # Load model from ModelScope to speed up download
+        export MODEL_PATH=Eco-Tech/Qwen3.5-27B-w8a8-mtp
         export VLLM_USE_MODELSCOPE=True
-        # To reduce memory fragmentation and avoid out of memory
-        export PYTORCH_NPU_ALLOC_CONF=expandable_segments:True
-        # Size of the shared buffer (in MB) used by HCCL for NPU-to-NPU collective communication
         export HCCL_BUFFSIZE=512
-        # Whether OpenMP threads are bound to specific CPU cores
-        export OMP_PROC_BIND=false
-        # Number of OpenMP threads available for parallel regions
-        export OMP_NUM_THREADS=1
-        # Enables the Ascend task queue for asynchronous operator dispatch
-        export TASK_QUEUE_ENABLE=1
+        export PYTORCH_NPU_ALLOC_CONF=expandable_segments:True
+        # To reduce memory fragmentation and avoid out of memory
+        # Size of the shared buffer (in MB) used by HCCL for NPU-to-NPU collective communication
 
         # Model weight path; can be a ModelScope model id (e.g., Eco-Tech/Qwen3.5-27B-w8a8-mtp) or a local directory path
-        export MODEL_PATH=Eco-Tech/Qwen3.5-27B-w8a8-mtp
 
         vllm serve $MODEL_PATH \
             --host 0.0.0.0 \
@@ -273,20 +267,14 @@ Both `Qwen3.5-27B` and `Qwen3.6-27B` share the same MTP head design, so the `qwe
         ```bash
         #!/bin/sh
         # Load model from ModelScope to speed up download
+        export MODEL_PATH=Eco-Tech/Qwen3.6-27B-w8a8-310p
         export VLLM_USE_MODELSCOPE=True
-        # To reduce memory fragmentation and avoid out of memory
-        export PYTORCH_NPU_ALLOC_CONF=expandable_segments:True
-        # Size of the shared buffer (in MB) used by HCCL for NPU-to-NPU collective communication
         export HCCL_BUFFSIZE=512
-        # Whether OpenMP threads are bound to specific CPU cores
-        export OMP_PROC_BIND=false
-        # Number of OpenMP threads available for parallel regions
-        export OMP_NUM_THREADS=1
-        # Enables the Ascend task queue for asynchronous operator dispatch
-        export TASK_QUEUE_ENABLE=1
+        export PYTORCH_NPU_ALLOC_CONF=expandable_segments:True
+        # To reduce memory fragmentation and avoid out of memory
+        # Size of the shared buffer (in MB) used by HCCL for NPU-to-NPU collective communication
 
         # Model weight path; can be a ModelScope model id (e.g., Eco-Tech/Qwen3.6-27B-w8a8) or a local directory path
-        export MODEL_PATH=Eco-Tech/Qwen3.6-27B-w8a8
 
         vllm serve $MODEL_PATH \
             --host 0.0.0.0 \
@@ -335,10 +323,10 @@ Both `Qwen3.5-27B` and `Qwen3.6-27B` share the same MTP head design, so the `qwe
         ```bash
         #!/bin/sh
         # Load model from ModelScope to speed up download
+        export MODEL_PATH=Eco-Tech/Qwen3.5-27B-w8a8-mtp
         export VLLM_USE_MODELSCOPE=True
 
         # Model weight path; can be a ModelScope model id (e.g., Eco-Tech/Qwen3.5-27B-w8a8-mtp) or a local directory path
-        export MODEL_PATH=Eco-Tech/Qwen3.5-27B-w8a8-mtp
 
         vllm serve $MODEL_PATH \
             --host 127.0.0.1 \
@@ -363,10 +351,10 @@ Both `Qwen3.5-27B` and `Qwen3.6-27B` share the same MTP head design, so the `qwe
         ```bash
         #!/bin/sh
         # Load model from ModelScope to speed up download
+        export MODEL_PATH=Eco-Tech/Qwen3.6-27B-w8a8
         export VLLM_USE_MODELSCOPE=True
 
         # Model weight path; can be a ModelScope model id (e.g., Eco-Tech/Qwen3.6-27B-w8a8) or a local directory path
-        export MODEL_PATH=Eco-Tech/Qwen3.6-27B-w8a8-310p
 
         vllm serve $MODEL_PATH \
             --host 127.0.0.1 \
@@ -409,20 +397,14 @@ Both `Qwen3.5-27B` and `Qwen3.6-27B` share the same MTP head design, so the `qwe
         ```bash
         #!/bin/sh
         # Load model from ModelScope to speed up download
+        export MODEL_PATH=Eco-Tech/Qwen3.6-27B-w8a8-mxfp8
         export VLLM_USE_MODELSCOPE=True
-        # To reduce memory fragmentation and avoid out of memory
-        export PYTORCH_NPU_ALLOC_CONF=expandable_segments:True
-        # Size of the shared buffer (in MB) used by HCCL for NPU-to-NPU collective communication
         export HCCL_BUFFSIZE=512
-        # Whether OpenMP threads are bound to specific CPU cores
-        export OMP_PROC_BIND=false
-        # Number of OpenMP threads available for parallel regions
-        export OMP_NUM_THREADS=1
-        # Enables the Ascend task queue for asynchronous operator dispatch
-        export TASK_QUEUE_ENABLE=1
+        export PYTORCH_NPU_ALLOC_CONF=expandable_segments:True
+        # To reduce memory fragmentation and avoid out of memory
+        # Size of the shared buffer (in MB) used by HCCL for NPU-to-NPU collective communication
 
         # Model weight path; can be a ModelScope model id (e.g., Eco-Tech/Qwen3.6-27B-w8a8-mxfp8) or a local directory path
-        export MODEL_PATH=Eco-Tech/Qwen3.6-27B-w8a8-mxfp8
 
         vllm serve $MODEL_PATH \
             --host 0.0.0.0 \
@@ -525,24 +507,20 @@ To run the vllm-ascend Prefill-Decode Disaggregation service, you need to:
     nic_name="xxx"
     local_ip="192.xx.xx.1"
 
+    export HCCL_BUFFSIZE=1024
     export HCCL_IF_IP=$local_ip
-    export GLOO_SOCKET_IFNAME=$nic_name
-    export TP_SOCKET_IFNAME=$nic_name
+    export HCCL_OP_EXPANSION_MODE="AIV"
     export HCCL_SOCKET_IFNAME=$nic_name
+    export ASCEND_RT_VISIBLE_DEVICES=$1
+    export LD_LIBRARY_PATH=/usr/local/Ascend/ascend-toolkit/latest/python/site-packages/mooncake:$LD_LIBRARY_PATH
+    export GLOO_SOCKET_IFNAME=$nic_name
+    export PYTORCH_NPU_ALLOC_CONF=expandable_segments:True
 
     # [Optional] jemalloc
     # jemalloc is for better performance, if `libjemalloc.so` is installed on your machine, you can turn it on.
     # export LD_PRELOAD=/usr/lib/aarch64-linux-gnu/libjemalloc.so.2:$LD_PRELOAD
 
-    export HCCL_OP_EXPANSION_MODE="AIV"
-    export PYTORCH_NPU_ALLOC_CONF=expandable_segments:True
-    export OMP_PROC_BIND=false
-    export OMP_NUM_THREADS=1
-    export TASK_QUEUE_ENABLE=1
-    export LD_LIBRARY_PATH=/usr/local/Ascend/ascend-toolkit/latest/python/site-packages/mooncake:$LD_LIBRARY_PATH
 
-    export HCCL_BUFFSIZE=1024
-    export ASCEND_RT_VISIBLE_DEVICES=$1
 
     vllm serve Eco-Tech/Qwen3.5-27B-w8a8-mtp \
       --host 0.0.0.0 \
@@ -589,24 +567,20 @@ To run the vllm-ascend Prefill-Decode Disaggregation service, you need to:
     nic_name="xxx"
     local_ip="192.xx.xx.2"
 
+    export HCCL_BUFFSIZE=1024
     export HCCL_IF_IP=$local_ip
-    export GLOO_SOCKET_IFNAME=$nic_name
-    export TP_SOCKET_IFNAME=$nic_name
+    export HCCL_OP_EXPANSION_MODE="AIV"
     export HCCL_SOCKET_IFNAME=$nic_name
+    export ASCEND_RT_VISIBLE_DEVICES=$1
+    export LD_LIBRARY_PATH=/usr/local/Ascend/ascend-toolkit/latest/python/site-packages/mooncake:$LD_LIBRARY_PATH
+    export GLOO_SOCKET_IFNAME=$nic_name
+    export PYTORCH_NPU_ALLOC_CONF=expandable_segments:True
 
     # [Optional] jemalloc
     # jemalloc is for better performance, if `libjemalloc.so` is installed on your machine, you can turn it on.
     # export LD_PRELOAD=/usr/lib/aarch64-linux-gnu/libjemalloc.so.2:$LD_PRELOAD
 
-    export HCCL_OP_EXPANSION_MODE="AIV"
-    export PYTORCH_NPU_ALLOC_CONF=expandable_segments:True
-    export OMP_PROC_BIND=false
-    export OMP_NUM_THREADS=1
-    export TASK_QUEUE_ENABLE=1
-    export LD_LIBRARY_PATH=/usr/local/Ascend/ascend-toolkit/latest/python/site-packages/mooncake:$LD_LIBRARY_PATH
 
-    export HCCL_BUFFSIZE=1024
-    export ASCEND_RT_VISIBLE_DEVICES=$1
 
     vllm serve Eco-Tech/Qwen3.5-27B-w8a8-mtp \
       --host 0.0.0.0 \

--- a/docs/source/tutorials/models/Qwen3.5-397B-A17B.md
+++ b/docs/source/tutorials/models/Qwen3.5-397B-A17B.md
@@ -182,18 +182,14 @@ Single-node deployment runs both Prefill and Decode on the same node. It is suit
 
     # Load model from ModelScope to speed up download.
     export VLLM_USE_MODELSCOPE=True
+    export HCCL_BUFFSIZE=400
+    export HCCL_INTRA_ROCE_ENABLE=0
+    export HCCL_OP_EXPANSION_MODE="AIV"
+    export PYTORCH_NPU_ALLOC_CONF=expandable_segments:True
+    export VLLM_ASCEND_ENABLE_PREFETCH_MLP=1
 
     # Reduce memory fragmentation and avoid out-of-memory errors.
-    export PYTORCH_NPU_ALLOC_CONF=expandable_segments:True
 
-    export HCCL_OP_EXPANSION_MODE="AIV"
-    export HCCL_BUFFSIZE=400
-    export OMP_PROC_BIND=false
-    export OMP_NUM_THREADS=100
-    export TASK_QUEUE_ENABLE=1
-    export VLLM_ASCEND_ENABLE_PREFETCH_MLP=1
-    export HCCL_INTRA_PCIE_ENABLE=1
-    export HCCL_INTRA_ROCE_ENABLE=0
 
     vllm serve Eco-Tech/Qwen3.5-397B-A17B-w4a4-mxfp4 \
       --host 0.0.0.0 \
@@ -226,19 +222,17 @@ Single-node deployment runs both Prefill and Decode on the same node. It is suit
 
     # Load model from ModelScope to speed up download.
     export VLLM_USE_MODELSCOPE=True
-
-    # Reduce memory fragmentation and avoid out-of-memory errors.
+    export HCCL_BUFFSIZE=1024
+    export HCCL_OP_EXPANSION_MODE="AIV"
+    export LD_PRELOAD=/usr/lib/aarch64-linux-gnu/libjemalloc.so.2:$LD_PRELOAD
     export PYTORCH_NPU_ALLOC_CONF=expandable_segments:True
 
-    export HCCL_OP_EXPANSION_MODE="AIV"
-    export HCCL_BUFFSIZE=1024
-    export OMP_NUM_THREADS=1
-    export TASK_QUEUE_ENABLE=1
+    # Reduce memory fragmentation and avoid out-of-memory errors.
+
     echo performance | tee /sys/devices/system/cpu/cpu*/cpufreq/scaling_governor
     sysctl -w vm.swappiness=0
     sysctl -w kernel.numa_balancing=0
     sysctl kernel.sched_migration_cost_ns=50000
-    export LD_PRELOAD=/usr/lib/aarch64-linux-gnu/libjemalloc.so.2:$LD_PRELOAD
 
     vllm serve Eco-Tech/Qwen3.5-397B-A17B-w8a8-mtp \
       --host 0.0.0.0 \
@@ -291,22 +285,18 @@ Run the following script on node 0.
 ```shell
 #!/bin/sh
 
-export VLLM_USE_MODELSCOPE=True
-export PYTORCH_NPU_ALLOC_CONF=expandable_segments:True
-
 # Get these values through ifconfig.
 # nic_name is the network interface name corresponding to local_ip.
 nic_name="xxxx"
 local_ip="xxxx"
 
-export HCCL_IF_IP=$local_ip
-export GLOO_SOCKET_IFNAME=$nic_name
-export TP_SOCKET_IFNAME=$nic_name
-export HCCL_SOCKET_IFNAME=$nic_name
-export OMP_PROC_BIND=false
-export OMP_NUM_THREADS=1
+export VLLM_USE_MODELSCOPE=True
 export HCCL_BUFFSIZE=1024
-export TASK_QUEUE_ENABLE=1
+export HCCL_IF_IP=$local_ip
+export HCCL_SOCKET_IFNAME=$nic_name
+export GLOO_SOCKET_IFNAME=$nic_name
+export PYTORCH_NPU_ALLOC_CONF=expandable_segments:True
+
 
 vllm serve Eco-Tech/Qwen3.5-397B-A17B-w8a8-mtp \
   --host 0.0.0.0 \
@@ -339,25 +329,21 @@ Run the following script on node 1.
 ```shell
 #!/bin/sh
 
-export VLLM_USE_MODELSCOPE=True
-export PYTORCH_NPU_ALLOC_CONF=expandable_segments:True
-
 # Get these values through ifconfig.
 # nic_name is the network interface name corresponding to local_ip.
 nic_name="xxxx"
 local_ip="xxxx"
 
+export VLLM_USE_MODELSCOPE=True
+export HCCL_BUFFSIZE=1024
+export HCCL_IF_IP=$local_ip
+export HCCL_SOCKET_IFNAME=$nic_name
+export GLOO_SOCKET_IFNAME=$nic_name
+export PYTORCH_NPU_ALLOC_CONF=expandable_segments:True
+
 # The value of node0_ip must be consistent with local_ip on node 0.
 node0_ip="xxxx"
 
-export HCCL_IF_IP=$local_ip
-export GLOO_SOCKET_IFNAME=$nic_name
-export TP_SOCKET_IFNAME=$nic_name
-export HCCL_SOCKET_IFNAME=$nic_name
-export OMP_PROC_BIND=false
-export OMP_NUM_THREADS=1
-export HCCL_BUFFSIZE=1024
-export TASK_QUEUE_ENABLE=1
 
 vllm serve Eco-Tech/Qwen3.5-397B-A17B-w8a8-mtp \
   --host 0.0.0.0 \
@@ -407,7 +393,7 @@ INFO:     Application startup complete.
 - `--api-server-count` controls how many API server processes are started on the master node.
 - `--headless` starts a worker node without exposing an API server. Use it on non-master nodes.
 - `--tensor-parallel-size 8` maps one TP group to the 8 NPUs on each A2 node.
-- `HCCL_IF_IP`, `GLOO_SOCKET_IFNAME`, `TP_SOCKET_IFNAME`, and `HCCL_SOCKET_IFNAME` bind HCCL, Gloo, and TP communication to the selected network.
+- `HCCL_IF_IP`, `GLOO_SOCKET_IFNAME`, and `HCCL_SOCKET_IFNAME` bind HCCL and Gloo communication to the selected network.
 - `multistream_overlap_shared_expert` overlaps shared expert computation for better throughput on MoE workloads.
 
 ### 5.3 Multi-Node Deployment with Ray
@@ -445,22 +431,16 @@ unset http_proxy
 nic_name="xxxx"
 local_ip="xxxx"
 
-export VLLM_ENGINE_READY_TIMEOUT_S=30000
-export VLLM_MOONCAKE_ABORT_REQUEST_TIMEOUT=480
 export IP_ADDRESS=$local_ip
 export NETWORK_CARD_NAME=$nic_name
-export HCCL_IF_IP=$IP_ADDRESS
-export GLOO_SOCKET_IFNAME=$NETWORK_CARD_NAME
-export TP_SOCKET_IFNAME=$NETWORK_CARD_NAME
-export HCCL_SOCKET_IFNAME=$NETWORK_CARD_NAME
-export VLLM_USE_V1=1
 export HCCL_BUFFSIZE=1536
-export LD_LIBRARY_PATH=/usr/local/Ascend/ascend-toolkit/latest/python/site-packages:$LD_LIBRARY_PATH
-export PYTORCH_NPU_ALLOC_CONF="expandable_segments:True"
-export VLLM_TORCH_PROFILER_WITH_STACK=0
-export TASK_QUEUE_ENABLE=1
+export HCCL_IF_IP=$IP_ADDRESS
 export HCCL_OP_EXPANSION_MODE="AIV"
+export HCCL_SOCKET_IFNAME=$NETWORK_CARD_NAME
 export ASCEND_RT_VISIBLE_DEVICES=0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15
+export LD_LIBRARY_PATH=/usr/local/Ascend/ascend-toolkit/latest/python/site-packages:$LD_LIBRARY_PATH
+export GLOO_SOCKET_IFNAME=$NETWORK_CARD_NAME
+export PYTORCH_NPU_ALLOC_CONF="expandable_segments:True"
 
 vllm serve Eco-Tech/Qwen3.5-397B-A17B-w8a8-mtp \
   --host ${IP_ADDRESS} \
@@ -521,22 +501,16 @@ unset http_proxy
 nic_name="xxxx"
 local_ip="xxxx"
 
-export VLLM_ENGINE_READY_TIMEOUT_S=30000
-export VLLM_MOONCAKE_ABORT_REQUEST_TIMEOUT=480
 export IP_ADDRESS=$local_ip
 export NETWORK_CARD_NAME=$nic_name
-export HCCL_IF_IP=$IP_ADDRESS
-export GLOO_SOCKET_IFNAME=$NETWORK_CARD_NAME
-export TP_SOCKET_IFNAME=$NETWORK_CARD_NAME
-export HCCL_SOCKET_IFNAME=$NETWORK_CARD_NAME
-export VLLM_USE_V1=1
 export HCCL_BUFFSIZE=1536
-export LD_LIBRARY_PATH=/usr/local/Ascend/ascend-toolkit/latest/python/site-packages:$LD_LIBRARY_PATH
-export PYTORCH_NPU_ALLOC_CONF="expandable_segments:True"
-export VLLM_TORCH_PROFILER_WITH_STACK=0
-export TASK_QUEUE_ENABLE=1
+export HCCL_IF_IP=$IP_ADDRESS
 export HCCL_OP_EXPANSION_MODE="AIV"
+export HCCL_SOCKET_IFNAME=$NETWORK_CARD_NAME
 export ASCEND_RT_VISIBLE_DEVICES=0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15
+export LD_LIBRARY_PATH=/usr/local/Ascend/ascend-toolkit/latest/python/site-packages:$LD_LIBRARY_PATH
+export GLOO_SOCKET_IFNAME=$NETWORK_CARD_NAME
+export PYTORCH_NPU_ALLOC_CONF="expandable_segments:True"
 
 vllm serve Eco-Tech/Qwen3.5-397B-A17B-w8a8-mtp \
   --host ${IP_ADDRESS} \
@@ -593,7 +567,6 @@ Common Issues Tip: If the decode node fails to initialize, check that `--tensor-
 - `--kv-transfer-config` sets the Mooncake connector. `kv_role` is `kv_producer` on prefill and `kv_consumer` on decode.
 - `kv_connector_extra_config.prefill.dp_size/tp_size` and `decode.dp_size/tp_size` must match the actual global DP and TP layout.
 - `--no-enable-prefix-caching` disables prefix caching. For PD disaggregation, the D-node prefix-cache known issue is tracked in [#7944](https://github.com/vllm-project/vllm-ascend/issues/7944).
-- `VLLM_MOONCAKE_ABORT_REQUEST_TIMEOUT` is the timeout in seconds for automatically releasing the prefiller KV cache for a request.
 - `--compilation-config '{"cudagraph_mode": "FULL_DECODE_ONLY"}'` is recommended on the decode node to reduce decode dispatch overhead.
 
 ### 5.5 Prefill-Decode Disaggregation (Ascend 950DT series)
@@ -620,29 +593,22 @@ unset http_proxy
 
 source /root/.bashrc
 export PROMETHEUS_MULTIPROC_DIR=/dev/shm/vllm_metrics && mkdir -p $PROMETHEUS_MULTIPROC_DIR
-export HCCL_DFS_CONFIG="task_exception:off,inconsistent_check:off"
-
 # Get these values through ifconfig.
 # nic_name is the network interface name corresponding to local_ip.
 nic_name="xxx"
 local_ip="xxx"
 
-export HCCL_IF_IP=$local_ip
-export GLOO_SOCKET_IFNAME=$nic_name
-export TP_SOCKET_IFNAME=$nic_name
-export HCCL_SOCKET_IFNAME=$nic_name
-export HCCL_ALGO=level0:fullmesh
-export VLLM_RPC_TIMEOUT=3600000
 export VLLM_EXECUTE_MODEL_TIMEOUT_SECONDS=30000
-export HCCL_EXEC_TIMEOUT=204
-export HCCL_CONNECT_TIMEOUT=180
 export HCCL_BUFFSIZE=300
-export OMP_PROC_BIND=false
-export OMP_NUM_THREADS=10
-export PYTORCH_NPU_ALLOC_CONF=expandable_segments:True
-export TASK_QUEUE_ENABLE=1
+export HCCL_IF_IP=$local_ip
+export HCCL_SOCKET_IFNAME=$nic_name
 export ASCEND_RT_VISIBLE_DEVICES=0,1,2,3,4,5,6,7
 export DYNAMIC_EPLB="true"
+export GLOO_SOCKET_IFNAME=$nic_name
+export PYTORCH_NPU_ALLOC_CONF=expandable_segments:True
+export HCCL_DFS_CONFIG="task_exception:off,inconsistent_check:off"
+export HCCL_ALGO=level0:fullmesh
+
 
 vllm serve Eco-Tech/Qwen3.5-397B-A17B-w4a4-mxfp4 \
   --host 0.0.0.0 \
@@ -702,29 +668,22 @@ unset http_proxy
 
 source /root/.bashrc
 export PROMETHEUS_MULTIPROC_DIR=/dev/shm/vllm_metrics && mkdir -p $PROMETHEUS_MULTIPROC_DIR
-export HCCL_DFS_CONFIG="task_exception:off,inconsistent_check:off"
-
 # Get these values through ifconfig.
 # nic_name is the network interface name corresponding to local_ip.
 nic_name="xxx"
 local_ip="xxx"
 
-export HCCL_IF_IP=$local_ip
-export GLOO_SOCKET_IFNAME=$nic_name
-export TP_SOCKET_IFNAME=$nic_name
-export HCCL_SOCKET_IFNAME=$nic_name
-export HCCL_ALGO=level0:fullmesh
-export VLLM_RPC_TIMEOUT=3600000
 export VLLM_EXECUTE_MODEL_TIMEOUT_SECONDS=30000
-export HCCL_EXEC_TIMEOUT=200
-export HCCL_CONNECT_TIMEOUT=1800
 export HCCL_BUFFSIZE=1200
-export OMP_PROC_BIND=false
-export OMP_NUM_THREADS=10
-export PYTORCH_NPU_ALLOC_CONF=expandable_segments:True
-export TASK_QUEUE_ENABLE=1
+export HCCL_IF_IP=$local_ip
+export HCCL_SOCKET_IFNAME=$nic_name
 export ASCEND_RT_VISIBLE_DEVICES=0,1,2,3,4,5,6,7
 export DYNAMIC_EPLB="true"
+export GLOO_SOCKET_IFNAME=$nic_name
+export PYTORCH_NPU_ALLOC_CONF=expandable_segments:True
+export HCCL_DFS_CONFIG="task_exception:off,inconsistent_check:off"
+export HCCL_ALGO=level0:fullmesh
+
 
 vllm serve Eco-Tech/Qwen3.5-397B-A17B-w4a4-mxfp4 \
   --host 0.0.0.0 \
@@ -962,7 +921,7 @@ For common environment, installation, and general parameter issues, refer to [Pu
 
 **Cause:** Network interface names, IP addresses, DP ranks, or RPC ports are inconsistent across nodes.
 
-**Solution:** Verify multi-node communication first. Ensure `HCCL_IF_IP`, `GLOO_SOCKET_IFNAME`, `TP_SOCKET_IFNAME`, and `HCCL_SOCKET_IFNAME` match the selected NIC. Ensure all nodes use the same `--data-parallel-rpc-port`, non-master nodes use `--headless`, and `--data-parallel-start-rank` does not overlap.
+**Solution:** Verify multi-node communication first. Ensure `HCCL_IF_IP`, `GLOO_SOCKET_IFNAME`, and `HCCL_SOCKET_IFNAME` match the selected NIC. Ensure all nodes use the same `--data-parallel-rpc-port`, non-master nodes use `--headless`, and `--data-parallel-start-rank` does not overlap.
 
 ### Q3: Why is prefix caching disabled in the PD disaggregation examples?
 

--- a/docs/source/tutorials/models/Qwen3.6-35B-A3B.md
+++ b/docs/source/tutorials/models/Qwen3.6-35B-A3B.md
@@ -171,19 +171,17 @@ Single-node deployment runs both Prefill and Decode on the same node. `Qwen3.6-3
 
     # Load model from ModelScope to speed up download.
     export VLLM_USE_MODELSCOPE=True
-
-    # Reduce memory fragmentation and avoid out-of-memory errors.
+    export HCCL_BUFFSIZE=1024
+    export HCCL_OP_EXPANSION_MODE="AIV"
+    export LD_PRELOAD=/usr/lib/aarch64-linux-gnu/libjemalloc.so.2:$LD_PRELOAD
     export PYTORCH_NPU_ALLOC_CONF=expandable_segments:True
 
-    export HCCL_OP_EXPANSION_MODE="AIV"
-    export HCCL_BUFFSIZE=1024
-    export OMP_NUM_THREADS=1
-    export TASK_QUEUE_ENABLE=1
+    # Reduce memory fragmentation and avoid out-of-memory errors.
+
     echo performance | tee /sys/devices/system/cpu/cpu*/cpufreq/scaling_governor
     sysctl -w vm.swappiness=0
     sysctl -w kernel.numa_balancing=0
     sysctl kernel.sched_migration_cost_ns=50000
-    export LD_PRELOAD=/usr/lib/aarch64-linux-gnu/libjemalloc.so.2:$LD_PRELOAD
 
     vllm serve Eco-Tech/Qwen3.6-35B-A3B-w8a8 \
       --host 0.0.0.0 \

--- a/docs/source/tutorials/models/Qwen3.8-2.4T-A95B.md
+++ b/docs/source/tutorials/models/Qwen3.8-2.4T-A95B.md
@@ -196,9 +196,9 @@ Before starting the service:
         export DP_SIZE=4
         export TP_SIZE=16
 
+        export HCCL_BUFFSIZE_EP=2048
         export VLLM_EXECUTE_MODEL_TIMEOUT_SECONDS=3000
         export HCCL_BUFFSIZE=1024
-        export HCCL_BUFFSIZE_EP=2048
         export HCCL_IF_IP=$LOCAL_IP
         export HCCL_INTRA_ROCE_ENABLE=0
         export HCCL_OP_EXPANSION_MODE="AIV"
@@ -250,9 +250,9 @@ Before starting the service:
         export DP_START_RANK=<1_OR_2_OR_3>
         export TP_SIZE=16
 
+        export HCCL_BUFFSIZE_EP=2048
         export VLLM_EXECUTE_MODEL_TIMEOUT_SECONDS=3000
         export HCCL_BUFFSIZE=1024
-        export HCCL_BUFFSIZE_EP=2048
         export HCCL_IF_IP=$LOCAL_IP
         export HCCL_INTRA_ROCE_ENABLE=0
         export HCCL_OP_EXPANSION_MODE="AIV"

--- a/docs/source/tutorials/models/Qwen3.8-27B.md
+++ b/docs/source/tutorials/models/Qwen3.8-27B.md
@@ -218,14 +218,14 @@ Before starting the service:
     ```bash
     #!/bin/sh
     # Load model from ModelScope to speed up download
+    export MODEL_PATH=Eco-Tech/Qwen3.8-27B-w8a8-mxfp8
     export VLLM_USE_MODELSCOPE=True
-    # Size of the shared buffer (in MB) used by HCCL for NPU-to-NPU collective communication
     export HCCL_BUFFSIZE=512
-    # To reduce memory fragmentation and avoid out of memory
     export PYTORCH_NPU_ALLOC_CONF=expandable_segments:True
+    # Size of the shared buffer (in MB) used by HCCL for NPU-to-NPU collective communication
+    # To reduce memory fragmentation and avoid out of memory
 
     # Model weight path; can be a ModelScope model id (e.g., Eco-Tech/Qwen3.8-27B-w8a8-mxfp8) or a local directory path
-    export MODEL_PATH=Eco-Tech/Qwen3.8-27B-w8a8-mxfp8
 
     vllm serve $MODEL_PATH \
         --host 0.0.0.0 \
@@ -321,14 +321,14 @@ Before starting the service:
     ```bash
     #!/bin/sh
     # Load model from ModelScope to speed up download
+    export MODEL_PATH=Eco-Tech/Qwen3.8-27B-w8a8
     export VLLM_USE_MODELSCOPE=True
-    # Size of the shared buffer (in MB) used by HCCL for NPU-to-NPU collective communication
     export HCCL_BUFFSIZE=512
-    # To reduce memory fragmentation and avoid out of memory
     export PYTORCH_NPU_ALLOC_CONF=expandable_segments:True
+    # Size of the shared buffer (in MB) used by HCCL for NPU-to-NPU collective communication
+    # To reduce memory fragmentation and avoid out of memory
 
     # Model weight path; can be a ModelScope model id (e.g., Eco-Tech/Qwen3.8-27B-w8a8) or a local directory path
-    export MODEL_PATH=Eco-Tech/Qwen3.8-27B-w8a8
 
     vllm serve $MODEL_PATH \
         --host 0.0.0.0 \


### PR DESCRIPTION
### What this PR does / why we need it?

- Aligns serving commands in maintained model tutorials with the current environment-variable rectification guidance.
- Removes deprecated environment variables, migrates NZ and Fused MC2 settings to `--additional-config`, and orders retained variables by the required priority.
- Preserves runnable multi-node scripts by defining local IP and NIC variables before exports that reference them.

### Does this PR introduce _any_ user-facing change?

No. This is a documentation-only update.

### How was this patch tested?

- Audited the changed tutorial scripts against the latest environment variable specification requirements: no environment variables marked for deletion remain as active exports, and priority ordering has no inversions.
- Verified migrated `weight_nz_mode` and `enable_fused_mc2` entries in their `--additional-config` values.
- Ran `git diff --check` successfully.
- Attempted the required pre-commit formatting check. It could not complete locally because dependency installation stalled; CI will run the repository checks on the PR.

- vLLM main: https://github.com/vllm-project/vllm/commit/ba07e4a48fc951300d97eb506217dd530583dea3
