### PR TITLE
[Refactor] (kv_pool): converge layerwise GVA protocol into backend/gva_protocol

### DIFF
--- a/tests/ut/distributed/ascend_store/_mock_deps.py
+++ b/tests/ut/distributed/ascend_store/_mock_deps.py
@@ -450,24 +450,23 @@ _backend_pkg = _make_pkg(
 )
 sys.modules["vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.backend"] = _backend_pkg
 
-# Mirror the real backend/__init__.py entry points. The scheduler/worker resolve
-# the backend class dynamically via ``importlib.import_module(path)``; tests that
-# exercise those paths patch ``<module>.importlib`` locally (see
-# test_pool_scheduler.py / test_pool_worker.py) so the backend resolves to a
-# MagicMock. Do NOT register the backends in sys.modules or globally wrap
-# import_module here: test_backend.py imports the real backend classes and also
-# relies on ``mock.patch`` (which itself calls importlib.import_module) resolving
+# Execute the real backend/__init__.py inside the stub package so that
+# backend_map and the capability helpers (backend_supports /
+# use_gva_layerwise) always stay in sync with the source of truth. The stub
+# package shadows the real package for these tests; without this, any
+# ``from ...backend import use_gva_layerwise`` in the real modules would fail
+# with ImportError under the stub.
+# The scheduler/worker resolve the backend class dynamically via
+# ``importlib.import_module(path)``; tests that exercise those paths patch
+# ``<module>.importlib`` locally (see test_pool_scheduler.py /
+# test_pool_worker.py) so the backend resolves to a MagicMock. Do NOT
+# register the backends in sys.modules or globally wrap import_module here:
+# test_backend.py imports the real backend classes and also relies on
+# ``mock.patch`` (which itself calls importlib.import_module) resolving
 # those real modules.
-_backend_module_paths = {
-    "mooncake": "vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.backend.mooncake_backend",
-    "memcache": "vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.backend.memcache_backend",
-    "yuanrong": "vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.backend.yuanrong_backend",
-}
-_backend_pkg.backend_map = {  # type: ignore[attr-defined]
-    "mooncake": {"name": "MooncakeBackend", "path": _backend_module_paths["mooncake"]},
-    "memcache": {"name": "MemcacheBackend", "path": _backend_module_paths["memcache"]},
-    "yuanrong": {"name": "YuanrongBackend", "path": _backend_module_paths["yuanrong"]},
-}
+_backend_init_path = os.path.join(_backend_pkg.__path__[0], "__init__.py")  # type: ignore[attr-defined]
+with open(_backend_init_path, encoding="utf-8") as _backend_init_file:
+    exec(compile(_backend_init_file.read(), _backend_init_path, "exec"), vars(_backend_pkg))  # type: ignore[arg-type]
 
 if "vllm_ascend.utils" not in sys.modules or not hasattr(sys.modules["vllm_ascend.utils"], "AscendDeviceType"):
     _ascend_utils = MagicMock()

--- a/tests/ut/distributed/ascend_store/test_ascend_store_connector.py
+++ b/tests/ut/distributed/ascend_store/test_ascend_store_connector.py
@@ -359,6 +359,40 @@ class TestAscendStoreConnectorLayerwise(unittest.TestCase):
                     expected,
                 )
 
+    def test_use_gva_layerwise_derived_in_init(self):
+        """Regression test: the connector must derive use_gva_layerwise in
+        __init__ (a #14465-era cleanup deleted the derivation while
+        set_external_slot_release_waiter still read the attribute, so plain
+        connector construction crashed with AttributeError).
+        """
+        from vllm.distributed.kv_transfer.kv_connector.v1.base import KVConnectorRole
+
+        cases = [
+            ({"use_layerwise": True, "backend": "memcache"}, True),
+            ({"use_layerwise": True, "backend": "Memcache"}, True),
+            ({"use_layerwise": True}, False),  # default backend mooncake
+            ({"use_layerwise": True, "backend": "mooncake"}, False),
+            ({}, False),
+        ]
+        for extra_config, expected in cases:
+            with (
+                self.subTest(extra_config=extra_config),
+                patch.object(self.connector_mod, "KVPoolWorker") as _mock_worker_cls,
+                patch.object(self.connector_mod, "LookupKeyServer") as _mock_lookup_cls,
+            ):
+                config = MagicMock()
+                config.kv_transfer_config.kv_role = "kv_producer"
+                config.kv_transfer_config.kv_connector = "AscendStoreConnector"
+                config.kv_transfer_config.kv_connector_extra_config = extra_config
+                config.parallel_config.rank = 0
+
+                connector = self.connector_mod.AscendStoreConnector(
+                    vllm_config=config,
+                    role=KVConnectorRole.WORKER,
+                    kv_cache_config=None,
+                )
+                self.assertIs(connector.use_gva_layerwise, expected)
+
     def test_layerwise_worker_paths(self):
         from vllm.distributed.kv_transfer.kv_connector.v1.base import KVConnectorRole
 

--- a/tests/ut/distributed/ascend_store/test_backend.py
+++ b/tests/ut/distributed/ascend_store/test_backend.py
@@ -19,6 +19,7 @@ import json
 import os
 import sys
 import tempfile
+import threading
 import unittest
 from unittest.mock import MagicMock, patch
 
@@ -29,7 +30,10 @@ from vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.backend import (
     backend_supports,
     use_gva_layerwise,
 )
-from vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.backend.base import Backend
+from vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.backend.base import (
+    Backend,
+    GVALayerwiseCapable,
+)
 from vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.backend.mooncake_backend import (
     DEFAULT_TENANT_ID,
     MooncakeBackend,
@@ -88,6 +92,86 @@ class TestBackendCapabilities(unittest.TestCase):
         for backend_name in backend_map:
             with self.subTest(backend_name=backend_name):
                 self.assertIn(backend_name, _BACKEND_CAPABILITIES)
+
+    def test_capability_table_matches_gva_interface(self):
+        # The capability registry and the GVALayerwiseCapable class hierarchy
+        # must agree: a backend advertises "gva_layerwise" if and only if
+        # its class implements the interface.
+        for backend_name, entry in backend_map.items():
+            with self.subTest(backend_name=backend_name):
+                module = __import__(entry["path"], fromlist=[entry["name"]])
+                backend_cls = getattr(module, entry["name"])
+                self.assertEqual(
+                    backend_supports(backend_name, "gva_layerwise"),
+                    issubclass(backend_cls, GVALayerwiseCapable),
+                )
+
+
+# =========================================================================
+# on_worker_ready lifecycle hook
+# =========================================================================
+class TestOnWorkerReady(unittest.TestCase):
+    def _make_memcache(self, lazy_init: bool, store_initialized: bool):
+        from vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.backend.memcache_backend import (
+            MemcacheBackend,
+        )
+
+        backend = MemcacheBackend.__new__(MemcacheBackend)
+        backend._lazy_init = lazy_init
+        backend._store_initialized = store_initialized
+        backend._store_init_lock = threading.Lock()
+        backend._pending_buffers = None
+        backend.local_rank = 0
+        return backend
+
+    def test_default_is_noop_for_plain_backends(self):
+        # mooncake / yuanrong inherit the Backend default and must not raise
+        # even without any internal state set up.
+        with patch.object(MooncakeBackend, "__init__", lambda self, pc: None):
+            mooncake = MooncakeBackend.__new__(MooncakeBackend)
+        from vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.backend.yuanrong_backend import (
+            YuanrongBackend,
+        )
+
+        with patch.object(YuanrongBackend, "__init__", lambda self, pc: None):
+            yuanrong = YuanrongBackend.__new__(YuanrongBackend)
+        mooncake.on_worker_ready()
+        yuanrong.on_worker_ready()
+
+    def test_lazy_init_skips_eager_initialization(self):
+        # UT 1: lazy_init (compress + device_sdma) must keep deferring store
+        # setup — exists/batch_get_key_info rely on the "uninitialized means
+        # all-miss" short circuit, so an eager init here would break it.
+        from vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.backend.memcache_backend import (
+            MemcacheBackend,
+        )
+
+        backend = self._make_memcache(lazy_init=True, store_initialized=False)
+        with patch.object(MemcacheBackend, "_setup_store") as mock_setup:
+            backend.on_worker_ready()
+        mock_setup.assert_not_called()
+        self.assertFalse(backend._store_initialized)
+
+    def test_non_lazy_ensures_initialization(self):
+        from vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.backend.memcache_backend import (
+            MemcacheBackend,
+        )
+
+        backend = self._make_memcache(lazy_init=False, store_initialized=False)
+        with patch.object(MemcacheBackend, "_setup_store", return_value=object()) as mock_setup:
+            backend.on_worker_ready()
+        mock_setup.assert_called_once()
+        self.assertTrue(backend._store_initialized)
+
+    def test_already_initialized_is_idempotent(self):
+        from vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.backend.memcache_backend import (
+            MemcacheBackend,
+        )
+
+        backend = self._make_memcache(lazy_init=False, store_initialized=True)
+        with patch.object(MemcacheBackend, "_setup_store") as mock_setup:
+            backend.on_worker_ready()
+        mock_setup.assert_not_called()
 
 
 def _make_mooncake_store_config(**overrides) -> MooncakeStoreConfig:
@@ -654,6 +738,21 @@ class TestMemcacheBackendMethods(unittest.TestCase):
         b = self._make_backend()
         b.store.batch_is_exist.return_value = [1]
         self.assertEqual(b.exists(["k1"]), [1])
+
+    def test_exists_short_circuits_all_miss_when_lazy_uninitialized(self):
+        # UT 3: under lazy_init the uninitialized store must report every key
+        # as missing instead of touching self.store (which is None at that
+        # point). This short circuit is the load-path degradation contract —
+        # do not "fix" it into an eager init.
+        from vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.backend.memcache_backend import (
+            MemcacheBackend,
+        )
+
+        b = MemcacheBackend.__new__(MemcacheBackend)
+        b._lazy_init = True
+        b._store_initialized = False
+        b.store = None
+        self.assertEqual(b.exists(["k1", "k2", "k3"]), [0, 0, 0])
 
     def test_register_buffer(self):
         b = self._make_backend()

--- a/tests/ut/distributed/ascend_store/test_backend.py
+++ b/tests/ut/distributed/ascend_store/test_backend.py
@@ -23,6 +23,12 @@ import unittest
 from unittest.mock import MagicMock, patch
 
 import tests.ut.distributed.ascend_store._mock_deps  # noqa: F401, E402
+from vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.backend import (
+    _BACKEND_CAPABILITIES,
+    backend_map,
+    backend_supports,
+    use_gva_layerwise,
+)
 from vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.backend.base import Backend
 from vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.backend.mooncake_backend import (
     DEFAULT_TENANT_ID,
@@ -49,6 +55,39 @@ class TestBackendABC(unittest.TestCase):
     def test_cannot_instantiate(self):
         with self.assertRaises(TypeError):
             Backend(MagicMock())  # type: ignore[abstract]
+
+
+# =========================================================================
+# Backend capability registry
+# =========================================================================
+class TestBackendCapabilities(unittest.TestCase):
+    def test_use_gva_layerwise_truth_table(self):
+        cases = [
+            (True, "memcache", True),
+            (False, "memcache", False),
+            (True, "mooncake", False),
+            (True, "yuanrong", False),
+            (True, "unknown", False),
+            (True, "Memcache", False),
+        ]
+        for use_layerwise, backend_name, expected in cases:
+            with self.subTest(use_layerwise=use_layerwise, backend_name=backend_name):
+                self.assertEqual(use_gva_layerwise(use_layerwise, backend_name), expected)
+
+    def test_backend_supports(self):
+        self.assertTrue(backend_supports("memcache", "gva_layerwise"))
+        self.assertFalse(backend_supports("mooncake", "gva_layerwise"))
+        self.assertFalse(backend_supports("yuanrong", "gva_layerwise"))
+        self.assertFalse(backend_supports("memcache", "nonexistent_capability"))
+        self.assertFalse(backend_supports("unknown", "gva_layerwise"))
+
+    def test_every_registered_backend_has_capabilities_entry(self):
+        # Every backend in backend_map must have an explicit capabilities
+        # entry so that adding a new backend without updating the registry
+        # is caught here instead of silently degrading to "no capabilities".
+        for backend_name in backend_map:
+            with self.subTest(backend_name=backend_name):
+                self.assertIn(backend_name, _BACKEND_CAPABILITIES)
 
 
 def _make_mooncake_store_config(**overrides) -> MooncakeStoreConfig:

--- a/tests/ut/distributed/ascend_store/test_gva_protocol.py
+++ b/tests/ut/distributed/ascend_store/test_gva_protocol.py
@@ -1,0 +1,479 @@
+#
+# Copyright (c) 2026 Huawei Technologies Co., Ltd. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# This file is a part of the vllm-ascend project.
+#
+
+import unittest
+from unittest.mock import MagicMock
+
+import numpy as np
+
+import tests.ut.distributed.ascend_store._mock_deps  # noqa: F401, E402
+from vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.backend.gva_protocol import (
+    GVAHitChecker,
+    GVAKeyFactory,
+    GVASession,
+)
+from vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.metadata import (
+    LoadSpec,
+    ReqMeta,
+    get_partial_block_index,
+)
+
+_BLOCK_HASH_HEX = "ab" * 32
+
+
+class _FakeKeyInfo:
+    def __init__(self, size, gva=777):
+        self._size = size
+        self._gva = gva
+
+    def size(self):
+        return self._size
+
+    def gva_list(self):
+        return [self._gva]
+
+
+class _FakeStore:
+    """Minimal stand-in for the memcache backend surface used by GVASession."""
+
+    def __init__(self):
+        self.calls: list[str] = []
+        self.ensure_initialized = MagicMock(side_effect=lambda: self.calls.append("ensure_initialized"))
+        self.batch_is_exist = MagicMock(side_effect=lambda keys: [1] * len(keys))
+        self.batch_get_key_info = MagicMock(return_value=[])
+        self.batch_alloc = MagicMock(side_effect=lambda keys, sizes: [100 + i for i in range(len(keys))])
+        self.batch_add_lease = MagicMock(side_effect=lambda keys, ttl=0: [0] * len(keys))
+        self.batch_remove_lease = MagicMock(return_value=0)
+
+
+def _make_session(
+    store=None,
+    num_kv_cache_groups=1,
+    grouped_block_size=None,
+    hash_block_size=16,
+    layerwise_offload=False,
+    use_eagle=False,
+    kv_role="kv_producer",
+    consumer_is_to_put=False,
+    tp_rank=0,
+    put_step=1,
+    head_or_tp_rank=0,
+    on_invalid_blocks=None,
+):
+    invalid_calls: list[list[int]] = []
+    if on_invalid_blocks is None:
+        on_invalid_blocks = invalid_calls.append
+    session = GVASession(
+        store=store or _FakeStore(),
+        model_name="test-model",
+        head_or_tp_rank=head_or_tp_rank,
+        tp_rank=tp_rank,
+        put_step=put_step,
+        num_kv_cache_groups=num_kv_cache_groups,
+        grouped_block_size=grouped_block_size or [16],
+        hash_block_size=hash_block_size,
+        layerwise_offload=layerwise_offload,
+        use_eagle=use_eagle,
+        kv_role=kv_role,
+        consumer_is_to_put=consumer_is_to_put,
+        on_invalid_blocks=on_invalid_blocks,
+    )
+    session.bind_layout({0: [4096]}, 65536)
+    return session
+
+
+def _make_req(
+    req_id="req-1",
+    target_token_len=32,
+    save_start_token=0,
+    num_hashes=2,
+    can_save=True,
+    load_spec=None,
+    block_ids_np=None,
+    block_hashes=None,
+):
+    return ReqMeta(
+        req_id=req_id,
+        token_len_chunk=target_token_len,
+        block_ids_by_group=[[i + 1 for i in range(num_hashes)]],
+        block_hashes=block_hashes if block_hashes is not None else [bytes([i]) * 32 for i in range(num_hashes)],
+        can_save=can_save,
+        load_spec=load_spec,
+        save_start_token=save_start_token,
+        target_token_len=target_token_len,
+        block_ids_np=block_ids_np if block_ids_np is not None else np.asarray([i + 1 for i in range(num_hashes)]),
+    )
+
+
+# =========================================================================
+# GVAKeyFactory — byte-level key format snapshots
+# =========================================================================
+class TestGVAKeyFactory(unittest.TestCase):
+    def test_full_key_single_group_snapshot(self):
+        # PR #11585 compat format: model@hash@rank
+        key = GVAKeyFactory.full_key("m", 0, _BLOCK_HASH_HEX, 3, num_groups=1)
+        self.assertEqual(key, f"m@{_BLOCK_HASH_HEX}@3")
+
+    def test_full_key_multi_group_snapshot(self):
+        key = GVAKeyFactory.full_key("m", 2, _BLOCK_HASH_HEX, 3, num_groups=2)
+        self.assertEqual(key, f"m@2@{_BLOCK_HASH_HEX}@3")
+
+    def test_partial_key_snapshot(self):
+        key = GVAKeyFactory.partial_key("m", "req-9", 1, 4, 128, 3)
+        self.assertEqual(key, "m@partial@req-9@1@4@128@3")
+
+    def test_hit_check_keys_single_group_snapshot(self):
+        keys = GVAKeyFactory.hit_check_keys("m", 0, _BLOCK_HASH_HEX, num_ranks=2, num_groups=1)
+        self.assertEqual(keys, [f"m@{_BLOCK_HASH_HEX}@0", f"m@{_BLOCK_HASH_HEX}@1"])
+
+    def test_hit_check_keys_multi_group_snapshot(self):
+        keys = GVAKeyFactory.hit_check_keys("m", 1, _BLOCK_HASH_HEX, num_ranks=2, num_groups=2)
+        self.assertEqual(keys, [f"m@1@{_BLOCK_HASH_HEX}@0", f"m@1@{_BLOCK_HASH_HEX}@1"])
+
+
+# =========================================================================
+# get_partial_block_index
+# =========================================================================
+class TestGetPartialBlockIndex(unittest.TestCase):
+    def test_disabled_or_nonpositive(self):
+        self.assertIsNone(get_partial_block_index(10, 16, 2, enabled=False))
+        self.assertIsNone(get_partial_block_index(0, 16, 2, enabled=True))
+        self.assertIsNone(get_partial_block_index(-1, 16, 2, enabled=True))
+
+    def test_exact_alignment(self):
+        # 32 tokens / block 16 = 2 full blocks, no remainder
+        self.assertIsNone(get_partial_block_index(32, 16, 4, enabled=True))
+
+    def test_exact_alignment_beyond_hash_count(self):
+        # full_blocks (4) > hash_count (2) -> last full block is partial
+        self.assertEqual(get_partial_block_index(64, 16, 2, enabled=True), 3)
+
+    def test_trailing_partial_block(self):
+        self.assertEqual(get_partial_block_index(33, 16, 4, enabled=True), 2)
+
+
+# =========================================================================
+# GVASession construction (UT 2 — LIFE self-ensure)
+# =========================================================================
+class TestGVASessionConstruction(unittest.TestCase):
+    def test_construction_triggers_ensure_initialized(self):
+        store = _FakeStore()
+        _make_session(store=store)
+        store.ensure_initialized.assert_called_once_with()
+
+    def test_construction_calls_ensure_before_any_store_use(self):
+        store = _FakeStore()
+        _make_session(store=store)
+        # ensure_initialized must be the first store interaction
+        self.assertEqual(store.calls[0], "ensure_initialized")
+
+
+# =========================================================================
+# GVASession.alloc_gvas_for_save
+# =========================================================================
+class TestAllocGVAsForSave(unittest.TestCase):
+    def test_role_gate_consumer_not_to_put(self):
+        session = _make_session(kv_role="kv_consumer", consumer_is_to_put=False)
+        req = _make_req()
+        session.alloc_gvas_for_save([req])
+        session._store.batch_alloc.assert_not_called()
+
+    def test_tp_rank_gate(self):
+        session = _make_session(tp_rank=1, put_step=2)
+        req = _make_req()
+        session.alloc_gvas_for_save([req])
+        session._store.batch_alloc.assert_not_called()
+
+    def test_can_save_gate(self):
+        session = _make_session()
+        req = _make_req(can_save=False)
+        session.alloc_gvas_for_save([req])
+        session._store.batch_alloc.assert_not_called()
+
+    def test_allocates_new_keys_and_writes_reqmeta(self):
+        session = _make_session()
+        req = _make_req(target_token_len=32, num_hashes=2)
+        session.alloc_gvas_for_save([req])
+
+        self.assertEqual(len(session._store.batch_alloc.call_args_list), 1)
+        keys, sizes = session._store.batch_alloc.call_args_list[0].args
+        # alloc_size falls back to sum(group_block_len) = sum({0: [4096]})
+        self.assertEqual(sizes, [4096, 4096])
+        self.assertEqual(len(keys), 2)
+        # ReqMeta field writes are part of the protocol contract
+        self.assertEqual(req.block_gvas_np.tolist(), [100, 101])
+        self.assertEqual(req.block_ids_by_group_np[0].tolist(), [1, 2])
+        self.assertEqual(req.save_keys, keys)
+        self.assertEqual(req.gva_block_offset, 0)
+
+    def test_skips_blocks_still_in_memcache(self):
+        # Block already allocated in a previous step -> save range starts
+        # after it, so the cached block is neither re-allocated nor
+        # re-published in save_keys
+        session = _make_session()
+        req = _make_req(target_token_len=32, num_hashes=2)
+        first_key = GVAKeyFactory.full_key("test-model", 0, req.block_hashes[0].hex(), 0, 1)
+        session._allocated_gvas[first_key] = 555
+        session._store.batch_is_exist.side_effect = lambda keys: [1] * len(keys)
+
+        session.alloc_gvas_for_save([req])
+        keys, _ = session._store.batch_alloc.call_args_list[0].args
+        # Only the second block needs a fresh allocation
+        self.assertEqual(len(keys), 1)
+        second_key = GVAKeyFactory.full_key("test-model", 0, req.block_hashes[1].hex(), 0, 1)
+        self.assertEqual(keys, [second_key])
+        # Blocks before save_start_block stay 0 (already saved previously)
+        self.assertEqual(req.block_gvas_np.tolist(), [0, 100])
+        self.assertEqual(req.save_keys, [second_key])
+
+    def test_evicted_allocated_gva_is_reallocated(self):
+        # batch_is_exist reports 0 -> cached entry dropped and re-allocated
+        session = _make_session()
+        req = _make_req(target_token_len=32, num_hashes=2)
+        first_key = GVAKeyFactory.full_key("test-model", 0, req.block_hashes[0].hex(), 0, 1)
+        session._allocated_gvas[first_key] = 555
+        session._store.batch_is_exist.side_effect = lambda keys: [0] + [1] * (len(keys) - 1)
+
+        session.alloc_gvas_for_save([req])
+        keys, _ = session._store.batch_alloc.call_args_list[0].args
+        self.assertEqual(len(keys), 2)
+        self.assertEqual(req.block_gvas_np.tolist(), [100, 101])
+
+    def test_partial_allocation_failure_logs_and_zero(self):
+        session = _make_session(layerwise_offload=True)
+        # 33 tokens / block 16 -> partial block index 2, beyond num_hashes=2
+        # so use num_hashes=3 to make the partial block indexable
+        req = _make_req(target_token_len=33, num_hashes=3)
+        # batch_alloc: first call allocates 3 full keys, second call (partial)
+        # returns 0 -> failure branch
+        session._store.batch_alloc.side_effect = [
+            [100, 101, 102],
+            [0],
+        ]
+        session.alloc_gvas_for_save([req])
+        self.assertEqual(req.partial_save_gva_per_group, [0])
+        # Partial keys must not be retained
+        self.assertFalse(any("partial" in k for k in session._allocated_gvas))
+
+    def test_partial_allocation_success(self):
+        session = _make_session(layerwise_offload=True)
+        req = _make_req(target_token_len=33, num_hashes=3)
+        session._store.batch_alloc.side_effect = [
+            [100, 101, 102],
+            [200],
+        ]
+        session.alloc_gvas_for_save([req])
+        self.assertEqual(req.partial_save_gva_per_group, [200])
+        # Request-scoped partial key is popped after publishing
+        self.assertFalse(any("partial" in k for k in session._allocated_gvas))
+        self.assertIn("partial", req.save_keys[-1])
+
+
+# =========================================================================
+# GVASession.prepare_load_gvas
+# =========================================================================
+class TestPrepareLoadGVAs(unittest.TestCase):
+    def _make_load_req(self, cached_tokens=32, vllm_cached_tokens=0, num_hashes=2, use_eagle=False):
+        load_spec = LoadSpec(
+            vllm_cached_tokens=vllm_cached_tokens,
+            kvpool_cached_tokens=cached_tokens,
+            can_load=True,
+        )
+        return _make_req(target_token_len=cached_tokens, num_hashes=num_hashes, load_spec=load_spec)
+
+    def test_load_gvas_written_to_reqmeta(self):
+        session = _make_session()
+        req = self._make_load_req()
+        session._store.batch_get_key_info.return_value = [
+            _FakeKeyInfo(1, gva=100),
+            _FakeKeyInfo(1, gva=101),
+        ]
+        session.prepare_load_gvas([req])
+
+        keys = session._store.batch_get_key_info.call_args_list[0].args[0]
+        self.assertEqual(len(keys), 2)
+        self.assertEqual(req.load_block_gvas_np.tolist(), [100, 101])
+        self.assertEqual(req.load_keys, keys)
+        self.assertEqual(req.load_gva_block_offset, 0)
+
+    def test_invalid_gva_reports_block(self):
+        # size-0 key infos mark the block invalid (single-group path
+        # reports via callback)
+        reported: list[list[int]] = []
+        session = _make_session(on_invalid_blocks=reported.append)
+        req = self._make_load_req()
+        session._store.batch_get_key_info.return_value = [
+            _FakeKeyInfo(1, gva=100),
+            _FakeKeyInfo(0),
+        ]
+        session.prepare_load_gvas([req])
+        self.assertEqual(reported, [[2]])
+        # Invalid block's GVA stays 0 in the padded array
+        self.assertEqual(req.load_block_gvas_np.tolist(), [100, 0])
+
+    def test_empty_key_info_return_writes_zero_gvas(self):
+        # UT 4 golden: an uninitialized (lazy) store returns [] from
+        # batch_get_key_info; the protocol must not raise and silently
+        # writes all-zero GVAs with no lease and no failure report.
+        # This locks the CURRENT contract (documented silent-degradation
+        # behavior of the lazy-init path) so any future change to it is
+        # deliberate and visible.
+        reported: list[list[int]] = []
+        session = _make_session(on_invalid_blocks=reported.append)
+        req = self._make_load_req()
+        session._store.batch_get_key_info.return_value = []
+
+        session.prepare_load_gvas([req])
+
+        self.assertEqual(req.load_block_gvas_np.tolist(), [0, 0])
+        self.assertEqual(req.load_keys, [])
+        session._store.batch_add_lease.assert_not_called()
+        session._store.batch_remove_lease.assert_not_called()
+        self.assertEqual(reported, [])
+
+    def test_multi_group_failure_raises_and_releases_leases(self):
+        session = _make_session(num_kv_cache_groups=2, grouped_block_size=[16, 16])
+        session.bind_layout({0: [4096], 1: [4096]}, 65536)
+        req = self._make_load_req()
+        req.block_ids_by_group_np = None
+        # First key valid+leased, second invalid -> multi-group path raises
+        # and releases the lease acquired for the valid key
+        session._store.batch_get_key_info.return_value = [
+            _FakeKeyInfo(1, gva=100),
+            _FakeKeyInfo(0),
+        ]
+        with self.assertRaises(RuntimeError):
+            session.prepare_load_gvas([req])
+        session._store.batch_remove_lease.assert_called_once()
+
+    def test_lease_failure_zeroes_gva_and_reports(self):
+        reported: list[list[int]] = []
+        session = _make_session(on_invalid_blocks=reported.append)
+        req = self._make_load_req()
+        session._store.batch_get_key_info.return_value = [
+            _FakeKeyInfo(1, gva=100),
+            _FakeKeyInfo(1, gva=101),
+        ]
+        session._store.batch_add_lease.side_effect = lambda keys, ttl=0: [0, 1]  # second lease fails
+        session.prepare_load_gvas([req])
+        self.assertEqual(reported, [[2]])
+        self.assertEqual(req.load_block_gvas_np.tolist(), [100, 0])
+
+    def test_no_requests_with_load_spec(self):
+        session = _make_session()
+        req = _make_req(load_spec=None)
+        session.prepare_load_gvas([req])
+        session._store.batch_get_key_info.assert_not_called()
+
+
+# =========================================================================
+# GVAHitChecker
+# =========================================================================
+class TestGVAHitChecker(unittest.TestCase):
+    def _make_checker(self, store=None, grouped_block_size=None, hash_block_size=16, use_layerwise=True):
+        return GVAHitChecker(
+            store=store or _FakeStore(),
+            model_name="test-model",
+            head_or_tp_ranks=2,
+            grouped_block_size=grouped_block_size or [16],
+            hash_block_size=hash_block_size,
+            num_groups=1,
+            use_layerwise=use_layerwise,
+        )
+
+    def _make_request(self, num_hashes, request_id="req-1"):
+        request = MagicMock()
+        request.request_id = request_id
+        request.block_hashes = [bytes([i]) * 32 for i in range(num_hashes)]
+        return request
+
+    def test_all_ranks_hit_blocks(self):
+        store = _FakeStore()
+        checker = self._make_checker(store=store)
+        request = self._make_request(2)
+        # 2 blocks x 2 ranks = 4 key infos, all valid
+        store.batch_get_key_info.return_value = [_FakeKeyInfo(1)] * 4
+        hit = checker.hit_tokens(request, token_len=32, num_computed_tokens=0)
+        self.assertEqual(hit, 32)
+        # Key layout: all-rank keys, block-major
+        keys = store.batch_get_key_info.call_args_list[0].args[0]
+        self.assertEqual(len(keys), 4)
+        self.assertEqual(keys[0], f"test-model@{request.block_hashes[0].hex()}@0")
+        self.assertEqual(keys[1], f"test-model@{request.block_hashes[0].hex()}@1")
+        self.assertEqual(keys[2], f"test-model@{request.block_hashes[1].hex()}@0")
+        self.assertEqual(keys[3], f"test-model@{request.block_hashes[1].hex()}@1")
+
+    def test_partial_hit_stops_at_first_miss(self):
+        store = _FakeStore()
+        checker = self._make_checker(store=store)
+        request = self._make_request(2)
+        # Block 0: both ranks valid; block 1: rank 0 invalid -> stop
+        store.batch_get_key_info.return_value = [
+            _FakeKeyInfo(1),
+            _FakeKeyInfo(1),
+            _FakeKeyInfo(0),
+            _FakeKeyInfo(1),
+        ]
+        hit = checker.hit_tokens(request, token_len=32, num_computed_tokens=0)
+        self.assertEqual(hit, 16)
+
+    def test_all_groups_hit_takes_min(self):
+        store = _FakeStore()
+        checker = self._make_checker(store=store, grouped_block_size=[16, 32])
+        request = self._make_request(4)
+
+        def key_info(keys):
+            if len(keys) == 8:
+                # Group 0 (bs 16): 4 blocks, all ranks valid -> 64 tokens
+                return [_FakeKeyInfo(1)] * 8
+            # Group 1 (bs 32): block 0 fully valid, block 1 rank 0 invalid
+            # -> 1 hit block -> 32 tokens
+            return [
+                _FakeKeyInfo(1),
+                _FakeKeyInfo(1),
+                _FakeKeyInfo(0),
+                _FakeKeyInfo(1),
+            ]
+
+        store.batch_get_key_info.side_effect = key_info
+        hit = checker.hit_tokens(request, token_len=64, num_computed_tokens=0)
+        self.assertEqual(hit, 32)
+
+    def test_mismatched_key_info_count_returns_zero_for_group(self):
+        store = _FakeStore()
+        checker = self._make_checker(store=store)
+        request = self._make_request(2)
+        store.batch_get_key_info.return_value = [_FakeKeyInfo(1)]  # expected 4
+        hit = checker.hit_tokens(request, token_len=32, num_computed_tokens=0)
+        self.assertEqual(hit, 0)
+
+    def test_query_start_block_respects_use_layerwise(self):
+        # use_layerwise=True always queries from block 0; False starts at
+        # num_computed_tokens // block_size
+        store = _FakeStore()
+        checker = self._make_checker(store=store, use_layerwise=False)
+        request = self._make_request(4)
+        store.batch_get_key_info.return_value = [_FakeKeyInfo(1)] * 4
+        hit = checker.hit_tokens(request, token_len=64, num_computed_tokens=32)
+        # Queries blocks [2, 4): 2 blocks hit, plus query_start 2 -> 4 blocks
+        keys = store.batch_get_key_info.call_args_list[0].args[0]
+        self.assertEqual(len(keys), 4)
+        self.assertEqual(hit, 64)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/ut/distributed/ascend_store/test_kv_transfer.py
+++ b/tests/ut/distributed/ascend_store/test_kv_transfer.py
@@ -24,6 +24,10 @@ import numpy as np
 # isort: off
 import tests.ut.distributed.ascend_store._mock_deps  # noqa: F401, E402
 from vllm.distributed.kv_events import BlockStored
+from vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.backend.base import (
+    Backend,
+    GVALayerwiseCapable,
+)
 from vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.metadata import (
     ChunkedTokenDatabase,
     KeyMetadata,
@@ -45,6 +49,11 @@ from vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.kv_transfer import
     KVTransferThread,
     LayerBatchBuilder,
 )
+
+
+class _DualSpecStore(Backend, GVALayerwiseCapable):
+    """Concrete double-inheritance stand-in so MagicMock spec passes the
+    isinstance asserts on the GVA layer transfer threads."""
 
 
 class FakeStore:
@@ -219,7 +228,7 @@ class TestKVTransferThread(unittest.TestCase):
 
 class TestGVALayerTransferFailures(unittest.TestCase):
     def _make_sending_thread(self):
-        store = MagicMock()
+        store = MagicMock(spec=_DualSpecStore)
         store.store.batch_copy.return_value = 0
         store.batch_write_finish.return_value = [0]
         builder = MagicMock()
@@ -283,7 +292,7 @@ class TestGVALayerTransferFailures(unittest.TestCase):
 
 class TestGVALayerReceivingTaskOwnership(unittest.TestCase):
     def _make_thread(self, external_slot_release_waiter=None, save_failure_checker=None):
-        store = MagicMock()
+        store = MagicMock(spec=_DualSpecStore)
         store.store.batch_copy.return_value = 0
         load_finished = [threading.Event(), threading.Event()]
         save_finished = [threading.Event(), threading.Event()]

--- a/tests/ut/distributed/ascend_store/test_pool_scheduler.py
+++ b/tests/ut/distributed/ascend_store/test_pool_scheduler.py
@@ -21,6 +21,9 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 import tests.ut.distributed.ascend_store._mock_deps  # noqa: F401, E402
+from vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.backend.gva_protocol import (
+    GVAHitChecker,
+)
 from vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.metadata import (
     LoadSpec,
     RequestTracker,
@@ -142,7 +145,8 @@ class TestKVPoolScheduler(unittest.TestCase):
         scheduler.use_gva_layerwise = True
         scheduler.use_eagle = True
         scheduler.cache_transfer_granularity = 16
-        scheduler._get_layerwise_gva_hit_tokens = MagicMock(return_value=64)
+        scheduler._gva_hit_checker = MagicMock()
+        scheduler._gva_hit_checker.hit_tokens.return_value = 64
 
         request = MagicMock()
         request.prompt_token_ids = list(range(64))
@@ -158,6 +162,8 @@ class TestKVPoolScheduler(unittest.TestCase):
         self.assertEqual(load_spec.kvpool_cached_tokens, 48)
         self.assertEqual(load_spec.kvpool_store_skip_tokens, 64)
         self.assertTrue(load_spec.can_load)
+        # The GVA hit-check delegation must keep creating the request tracker.
+        self.assertIn("r1", scheduler._request_trackers)
         scheduler.update_state_after_alloc(request, MagicMock(), 0)
         self.assertTrue(load_spec.can_load)
 
@@ -791,7 +797,7 @@ class TestKVPoolSchedulerInferMambaGroups(unittest.TestCase):
 
 
 class TestKVPoolSchedulerGetLayerwiseGvaHitTokens(unittest.TestCase):
-    """Test _get_layerwise_gva_hit_tokens."""
+    """Test GVAHitChecker.hit_tokens through the scheduler's store client."""
 
     @patch("vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.pool_scheduler.LookupKeyClient")
     def _make_scheduler(self, mock_client_cls):
@@ -815,9 +821,18 @@ class TestKVPoolSchedulerGetLayerwiseGvaHitTokens(unittest.TestCase):
                         info.gva_list.return_value = [0x1000]
                     key_infos.append(info)
                 scheduler.store_scheduler.batch_get_key_info.return_value = key_infos
+                checker = GVAHitChecker(
+                    store=scheduler.store_scheduler,
+                    model_name=scheduler.model_name,
+                    head_or_tp_ranks=scheduler.tp_size // scheduler.put_step,
+                    grouped_block_size=scheduler.grouped_block_size,
+                    hash_block_size=scheduler.hash_block_size,
+                    num_groups=len(scheduler.kv_cache_group_ids),
+                    use_layerwise=scheduler.use_layerwise,
+                )
                 request = MagicMock()
                 request.block_hashes = [b"\xaa"] * hash_count
-                result = scheduler._get_layerwise_gva_hit_tokens(request, token_count, computed_tokens)
+                result = checker.hit_tokens(request, token_count, computed_tokens)
                 self.assertEqual(result, expected)
 
 

--- a/tests/ut/distributed/ascend_store/test_pool_worker.py
+++ b/tests/ut/distributed/ascend_store/test_pool_worker.py
@@ -23,12 +23,16 @@ from unittest.mock import MagicMock, patch
 import numpy as np
 
 import tests.ut.distributed.ascend_store._mock_deps  # noqa: F401, E402
+from vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.backend.gva_protocol import (
+    GVASession,
+)
 from vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.metadata import (
     AscendConnectorMetadata,
     LayerTransferTask,
     LoadSpec,
     ReqMeta,
     SharedBlockData,
+    get_partial_block_index,
 )
 
 
@@ -180,12 +184,10 @@ class TestKVPoolWorkerHelpers(unittest.TestCase):
         self.assertEqual(result, [48])
 
     def test_partial_prefill_block_index_boundaries(self):
-        cls = self._make_worker_class()
-
-        self.assertEqual(cls._get_partial_block_index(20, 16, 1, True), 1)
-        self.assertEqual(cls._get_partial_block_index(32, 16, 1, True), 1)
-        self.assertIsNone(cls._get_partial_block_index(32, 16, 2, True))
-        self.assertIsNone(cls._get_partial_block_index(20, 16, 1, False))
+        self.assertEqual(get_partial_block_index(20, 16, 1, True), 1)
+        self.assertEqual(get_partial_block_index(32, 16, 1, True), 1)
+        self.assertIsNone(get_partial_block_index(32, 16, 2, True))
+        self.assertIsNone(get_partial_block_index(20, 16, 1, False))
 
     def test_find_all_discontinuous_hit_positions_all_tp_hits_with_limits(self):
         cls = self._make_worker_class()
@@ -255,6 +257,17 @@ class TestKVPoolWorkerHelpers(unittest.TestCase):
         worker.hf_config = SimpleNamespace(num_hidden_layers=4)
         worker.use_gva_layerwise = True
         worker._extra_config = {"layerwise_num_shared_buffers": 2}
+        # GVASession is constructed at the end of _init_layerwise_config.
+        worker.m_store = MagicMock()
+        worker.model_name = "llama-7b"
+        worker.head_or_tp_rank = 0
+        worker.tp_rank = 0
+        worker.put_step = 1
+        worker.grouped_block_size = [16, 16]
+        worker.hash_block_size = 16
+        worker.use_eagle = False
+        worker.kv_role = "kv_producer"
+        worker.consumer_is_to_put = False
         main_spec = FullAttentionSpec(
             block_size=2,
             num_kv_heads=1,
@@ -962,10 +975,11 @@ class TestKVPoolWorkerProcessLayerData(unittest.TestCase):
     def _make_worker(self):
         return make_worker(self)
 
-    def _make_gva_worker(self, num_groups=1):
+    def _make_gva_worker(self, num_groups=1, use_eagle=False):
         worker = self._make_worker()
         worker.use_gva_layerwise = True
         worker.layerwise_offload = True
+        worker.use_eagle = use_eagle
         worker.num_kv_cache_groups = num_groups
         worker.grouped_block_size = [16] * num_groups
         worker.kv_cache_group_families = ["default"] * num_groups
@@ -975,6 +989,22 @@ class TestKVPoolWorkerProcessLayerData(unittest.TestCase):
         worker.page_size_bytes = 64
         worker.head_or_tp_rank = 0
         worker.m_store = MagicMock()
+        worker._gva_session = GVASession(
+            store=worker.m_store,
+            model_name=worker.model_name,
+            head_or_tp_rank=worker.head_or_tp_rank,
+            tp_rank=worker.tp_rank,
+            put_step=worker.put_step,
+            num_kv_cache_groups=num_groups,
+            grouped_block_size=worker.grouped_block_size,
+            hash_block_size=worker.hash_block_size,
+            layerwise_offload=worker.layerwise_offload,
+            use_eagle=worker.use_eagle,
+            kv_role=worker.kv_role,
+            consumer_is_to_put=worker.consumer_is_to_put,
+            on_invalid_blocks=worker._report_invalid_blocks,
+        )
+        worker._gva_session.bind_layout(worker.group_block_len, worker.page_size_bytes)
         return worker
 
     @staticmethod
@@ -1019,8 +1049,9 @@ class TestKVPoolWorkerProcessLayerData(unittest.TestCase):
         worker = self._make_worker()
         worker.num_layers = 0
         call_order = []
-        worker._prepare_load_gvas = MagicMock(side_effect=lambda requests: call_order.append("load"))
-        worker._alloc_gvas_for_save = MagicMock(side_effect=lambda requests: call_order.append("save"))
+        worker._gva_session = MagicMock()
+        worker._gva_session.prepare_load_gvas.side_effect = lambda requests: call_order.append("load")
+        worker._gva_session.alloc_gvas_for_save.side_effect = lambda requests: call_order.append("save")
         worker._build_shared_save_data = MagicMock()
         worker._build_shared_load_data = MagicMock()
 
@@ -1040,8 +1071,7 @@ class TestKVPoolWorkerProcessLayerData(unittest.TestCase):
         worker._process_load_for_layer_batch = MagicMock(
             side_effect=lambda _requests, layer_id, *_args: worker.layer_load_tasks[layer_id].append(load_marker)
         )
-        worker._prepare_load_gvas = MagicMock()
-        worker._alloc_gvas_for_save = MagicMock()
+        worker._gva_session = MagicMock()
         worker._build_shared_save_data = MagicMock()
         worker._build_shared_load_data = MagicMock()
 
@@ -1164,8 +1194,9 @@ class TestKVPoolWorkerProcessLayerData(unittest.TestCase):
         self.assertEqual(worker.layer_load_tasks[1], [])
 
     def test_mtp_gva_prepare_uses_safe_extent_not_store_skip_extent(self):
-        worker = self._make_gva_worker()
-        worker.use_eagle = True
+        # use_eagle must be set before GVASession construction: the session
+        # captures it at init time (production sets it in _init_kv_transfer_config).
+        worker = self._make_gva_worker(use_eagle=True)
         key_info = MagicMock()
         key_info.size.return_value = 64
         key_info.gva_list.return_value = [201]
@@ -1185,7 +1216,7 @@ class TestKVPoolWorkerProcessLayerData(unittest.TestCase):
             ),
         )
 
-        worker._prepare_load_gvas([request])
+        worker._gva_session.prepare_load_gvas([request])
 
         queried_keys = worker.m_store.batch_get_key_info.call_args.args[0]
         self.assertEqual(len(queried_keys), 1)
@@ -1208,8 +1239,8 @@ class TestKVPoolWorkerProcessLayerData(unittest.TestCase):
             can_save=True,
         )
 
-        worker._prepare_load_gvas([request])
-        worker._alloc_gvas_for_save([request])
+        worker._gva_session.prepare_load_gvas([request])
+        worker._gva_session.alloc_gvas_for_save([request])
         worker._process_load_for_layer_batch([request], 1)
         worker._process_save_for_layer_batch([request], 1)
 
@@ -1228,20 +1259,8 @@ class TestKVPoolWorkerProcessLayerData(unittest.TestCase):
         )
 
         self.assertIsNotNone(_pool_worker)
-        worker = self._make_worker()
-        worker.use_gva_layerwise = True
-        worker.layerwise_offload = True
+        worker = self._make_gva_worker()
         worker.independent_layers = [0]
-        worker.num_kv_cache_groups = 1
-        worker.grouped_block_size = [16]
-        worker.kv_cache_group_families = ["default"]
-        worker.group_block_len = {0: [64]}
-        worker.group_num_layers = {0: 1}
-        worker.hash_block_size = 16
-        worker.page_size_bytes = 64
-        worker.head_or_tp_rank = 0
-        worker._allocated_gvas = {}
-        worker.m_store = MagicMock()
         worker.m_store.batch_alloc.return_value = [101]
 
         save_request = ReqMeta(
@@ -1257,7 +1276,7 @@ class TestKVPoolWorkerProcessLayerData(unittest.TestCase):
             block_ids_np=np.asarray([0, 1], dtype=np.int64),
             block_ids_by_group_np=[np.asarray([0, 1], dtype=np.int64)],
         )
-        worker._alloc_gvas_for_save([save_request])
+        worker._gva_session.alloc_gvas_for_save([save_request])
         worker._process_save_for_layer_batch([save_request], 1)
 
         self.assertIsNotNone(save_request.save_keys)
@@ -1295,13 +1314,13 @@ class TestKVPoolWorkerProcessLayerData(unittest.TestCase):
             block_ids_np=np.asarray([0, 1], dtype=np.int64),
             block_ids_by_group_np=[np.asarray([0, 1], dtype=np.int64)],
         )
-        worker._prepare_load_gvas([load_request])
+        worker._gva_session.prepare_load_gvas([load_request])
         worker._process_load_for_layer_batch([load_request], 0)
         worker._process_load_for_layer_batch([load_request], 1)
 
         queried_keys = worker.m_store.batch_get_key_info.call_args.args[0]
         self.assertIn(partial_key, queried_keys)
-        self.assertNotIn(partial_key, worker._allocated_gvas)
+        self.assertNotIn(partial_key, worker._gva_session._allocated_gvas)
         self.assertEqual(load_request.partial_load_gva_per_group, [202])
         self.assertEqual(worker.layer_load_tasks[0], [])
         block_range = worker.layer_load_tasks[1][0].block_ranges[0]
@@ -1329,7 +1348,7 @@ class TestKVPoolWorkerProcessLayerData(unittest.TestCase):
             ),
         )
 
-        worker._prepare_load_gvas([request])
+        worker._gva_session.prepare_load_gvas([request])
 
         self.assertEqual(request.load_block_gvas_by_group_np[0].tolist(), [0])
         self.assertEqual(request.load_keys, [])
@@ -1366,16 +1385,16 @@ class TestKVPoolWorkerProcessLayerData(unittest.TestCase):
             block_ids_by_group_np=[np.asarray([7, 8], dtype=np.int64)],
         )
 
-        with patch("vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.pool_worker.time.sleep") as sleep:
-            worker._prepare_load_gvas([request])
+        with patch("vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.backend.gva_protocol.time.sleep") as sleep:
+            worker._gva_session.prepare_load_gvas([request])
 
-        partial_key = worker._make_layerwise_partial_key(request, 0, 1, 20)
+        partial_key = worker._gva_session._make_partial_key(request, 0, 1, 20)
         self.assertEqual(
             worker.m_store.batch_add_lease.call_args_list[1].args[0],
             [partial_key],
         )
         sleep.assert_called_once()
-        self.assertEqual(request.load_keys, [worker._make_layerwise_gva_key(0, "h0"), partial_key])
+        self.assertEqual(request.load_keys, [worker._gva_session._make_gva_key(0, "h0"), partial_key])
         self.assertEqual(request.partial_load_gva_per_group, [202])
         self.assertEqual(worker.get_block_ids_with_load_errors(), set())
 
@@ -1405,9 +1424,9 @@ class TestKVPoolWorkerProcessLayerData(unittest.TestCase):
             RuntimeError,
             "multi-group KV load failed",
         ):
-            worker._prepare_load_gvas([request])
+            worker._gva_session.prepare_load_gvas([request])
 
-        group0_key = worker._make_layerwise_gva_key(0, "h0")
+        group0_key = worker._gva_session._make_gva_key(0, "h0")
         worker.m_store.batch_remove_lease.assert_called_once_with([group0_key])
 
     def test_worker_physical_layer_index_supports_mtp_layers_namespace(self):
@@ -1422,16 +1441,16 @@ class TestKVPoolWorkerProcessLayerData(unittest.TestCase):
 
     def test_evicted_allocated_gva_is_reallocated(self):
         worker = self._make_gva_worker()
-        key = worker._make_layerwise_gva_key(0, "h0")
-        worker._allocated_gvas[key] = 101
+        key = worker._gva_session._make_gva_key(0, "h0")
+        worker._gva_session._allocated_gvas[key] = 101
         worker.m_store.batch_is_exist.return_value = [0]
         worker.m_store.batch_alloc.return_value = [202]
         request = self._make_gva_request(can_save=True)
 
-        worker._alloc_gvas_for_save([request])
+        worker._gva_session.alloc_gvas_for_save([request])
 
         worker.m_store.batch_alloc.assert_called_once_with([key], [64])
-        self.assertEqual(worker._allocated_gvas[key], 202)
+        self.assertEqual(worker._gva_session._allocated_gvas[key], 202)
         self.assertEqual(request.block_gvas_by_group_np[0].tolist(), [202])
 
     def test_partial_decode_is_saved_and_loaded_for_reused_layer(self):

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/ascend_store_connector.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/ascend_store_connector.py
@@ -28,6 +28,9 @@ from vllm.v1.outputs import KVConnectorOutput
 from vllm.v1.request import Request
 from vllm.v1.serial_utils import MsgpackDecoder
 
+from vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.backend import (
+    use_gva_layerwise,
+)
 from vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.metadata import AscendStoreKVConnectorWorkerMetadata
 from vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.pool_scheduler import (
     KVPoolScheduler,
@@ -88,6 +91,9 @@ class AscendStoreConnector(KVConnectorBase_V1, SupportsHMA):
 
         extra_config = vllm_config.kv_transfer_config.kv_connector_extra_config
         self.use_layerwise = extra_config.get("use_layerwise", False)
+        self.use_gva_layerwise = use_gva_layerwise(
+            self.use_layerwise, str(extra_config.get("backend", "mooncake")).lower()
+        )
         self.consumer_is_to_put = extra_config.get("consumer_is_to_put", False)
 
         connector_name = vllm_config.kv_transfer_config.kv_connector

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/backend/__init__.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/backend/__init__.py
@@ -28,3 +28,33 @@ backend_map = {
         "path": "vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.backend.yuanrong_backend",
     },
 }
+
+# Optional protocol families implemented by each backend. This table is the
+# single source of truth for backend-specific feature gating in the generic
+# layers; keep it in sync with the backend classes in backend_map
+# (tests/ut/distributed/ascend_store/test_backend.py asserts the consistency
+# between this table and GVALayerwiseCapable subclasses).
+_BACKEND_CAPABILITIES: dict[str, frozenset[str]] = {
+    "mooncake": frozenset(),
+    "memcache": frozenset({"gva_layerwise"}),
+    "yuanrong": frozenset(),
+}
+
+
+def backend_supports(backend_name: str, capability: str) -> bool:
+    """Return True if the backend registered under ``backend_name``
+    implements the given optional capability (e.g. ``"gva_layerwise"``).
+    """
+    return capability in _BACKEND_CAPABILITIES.get(backend_name, frozenset())
+
+
+def use_gva_layerwise(use_layerwise: bool, backend_name: str) -> bool:
+    """Single derivation point for the GVA layerwise transfer mode.
+
+    The layerwise GVA fast path is a memcache-specific protocol, so every
+    call site must derive the flag from here instead of re-spelling the
+    backend string comparison. Duplicated derivations have already caused a
+    live regression: #14465 deleted one copy as dead code while a reader
+    still consumed it.
+    """
+    return use_layerwise and backend_supports(backend_name, "gva_layerwise")

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/backend/base.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/backend/base.py
@@ -6,6 +6,36 @@ from typing import Any
 from vllm.config import ParallelConfig
 
 
+class GVALayerwiseCapable(ABC):
+    """Optional protocol family for backends that support the layerwise GVA
+    transfer mode (batch key-info lookup, allocation, and leases).
+
+    The generic layers must gate these calls behind
+    ``backend_supports(backend_name, "gva_layerwise")`` instead of calling
+    them unconditionally on a plain :class:`Backend`.
+    """
+
+    @abstractmethod
+    def batch_get_key_info(self, keys: list[str]) -> list[Any]:
+        pass
+
+    @abstractmethod
+    def batch_alloc(self, keys: list[str], sizes: list[int]) -> list[int]:
+        pass
+
+    @abstractmethod
+    def batch_add_lease(self, keys: list[str], lease_ttl_ms: int = 0) -> list[int]:
+        pass
+
+    @abstractmethod
+    def batch_remove_lease(self, keys: list[str]) -> int:
+        pass
+
+    @abstractmethod
+    def batch_write_finish(self, keys: list[str], results: list[int]) -> list[int]:
+        pass
+
+
 class Backend(ABC):
     store: Any | None = None
 
@@ -32,20 +62,10 @@ class Backend(ABC):
     def batch_is_exist(self, keys: list[str]) -> list[int]:
         return self.exists(keys)
 
-    def batch_get_key_info(self, keys: list[str]):
-        raise NotImplementedError(f"{type(self).__name__} does not support batch_get_key_info")
-
-    def batch_alloc(self, keys: list[str], sizes: list[int]) -> list[int]:
-        raise NotImplementedError(f"{type(self).__name__} does not support batch_alloc")
-
-    def batch_add_lease(self, keys: list[str], lease_ttl_ms: int = 0) -> list[int]:
-        raise NotImplementedError(f"{type(self).__name__} does not support batch_add_lease")
-
-    def batch_remove_lease(self, keys: list[str]) -> int:
-        raise NotImplementedError(f"{type(self).__name__} does not support batch_remove_lease")
-
-    def batch_write_finish(self, keys: list[str], results: list[int]) -> list[int]:
-        raise NotImplementedError(f"{type(self).__name__} does not support batch_write_finish")
+    def on_worker_ready(self) -> None:  # noqa: B027 (optional lifecycle hook)
+        """Called after kv caches are registered and before transfer threads
+        start. Backends that need eager initialization override this.
+        """
 
     @abstractmethod
     def put(self, keys: list[str], addrs: list[list[int]], sizes: list[list[int]]):

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/backend/gva_protocol.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/backend/gva_protocol.py
@@ -1,0 +1,667 @@
+#
+# Copyright (c) 2026 Huawei Technologies Co., Ltd. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# This file is a part of the vllm-ascend project.
+#
+"""Layerwise GVA transfer protocol (memcache backend).
+
+This module centralizes the GVA key/allocation/lease protocol that used to
+live inside ``KVPoolWorker`` and ``KVPoolScheduler``. It is a
+behavior-preserving relocation: key formats, log messages, and the
+prepare-load -> alloc-save ordering are kept byte-for-byte.
+
+Ownership:
+- :class:`GVAKeyFactory`: string formats of full/partial/hit-check keys.
+- :class:`GVASession`: worker-side allocation, load preparation, and leases.
+- :class:`GVAHitChecker`: scheduler-side prefix hit computation over the
+  all-rank keys.
+"""
+
+from __future__ import annotations
+
+import time
+from collections.abc import Callable
+from typing import TYPE_CHECKING, Any, Protocol
+
+import numpy as np
+from vllm.logger import logger
+
+from vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.metadata import (
+    ReqMeta,
+    block_hash_to_str,
+    get_block_hashes,
+    get_group_block_size,
+    get_partial_block_index,
+)
+
+if TYPE_CHECKING:
+    from vllm.v1.request import Request
+
+# Read lease TTL (ms) for the layerwise load path. batch_add_lease acquires a
+# read lease before batch_copy(G2L); the lease must cover the asynchronous
+# multi-layer load time.
+LAYERWISE_READ_LEASE_TTL_MS = 5 * 60 * 1000
+
+# A partial snapshot can be visible to readers before the rank responsible for
+# saving it has published its final layer.
+MEMCACHE_UNMATCHED_STATE = -3101
+PARTIAL_LEASE_RETRY_COUNT = 10
+PARTIAL_LEASE_RETRY_INTERVAL_S = 0.001
+
+
+class GVAStore(Protocol):
+    """Structural type of the backend surface the GVA protocol needs."""
+
+    def ensure_initialized(self) -> None: ...
+
+    def batch_is_exist(self, keys: list[str]) -> list[int]: ...
+
+    def batch_get_key_info(self, keys: list[str]) -> list[Any]: ...
+
+    def batch_alloc(self, keys: list[str], sizes: list[int]) -> list[int]: ...
+
+    def batch_add_lease(self, keys: list[str], lease_ttl_ms: int = 0) -> list[int]: ...
+
+    def batch_remove_lease(self, keys: list[str]) -> int: ...
+
+
+class GVAKeyFactory:
+    """String formats for the layerwise GVA keys.
+
+    Single-group models use the PR #11585 format (model@hash@rank) for
+    backward compatibility. Multi-group models include group_id
+    (model@group_id@hash@rank) to distinguish groups.
+    """
+
+    @staticmethod
+    def full_key(
+        model_name: str,
+        group_id: int,
+        block_hash_hex: str,
+        head_or_tp_rank: int,
+        num_groups: int,
+    ) -> str:
+        if num_groups > 1:
+            return f"{model_name}@{group_id}@{block_hash_hex}@{head_or_tp_rank}"
+        else:
+            return f"{model_name}@{block_hash_hex}@{head_or_tp_rank}"
+
+    @staticmethod
+    def partial_key(
+        model_name: str,
+        req_id: str,
+        group_id: int,
+        block_index: int,
+        end_token: int,
+        head_or_tp_rank: int,
+    ) -> str:
+        return f"{model_name}@partial@{req_id}@{group_id}@{block_index}@{end_token}@{head_or_tp_rank}"
+
+    @staticmethod
+    def hit_check_keys(
+        model_name: str,
+        group_id: int,
+        block_hash_hex: str,
+        num_ranks: int,
+        num_groups: int,
+    ) -> list[str]:
+        """All-rank GVA keys for scheduler-side hit check.
+
+        Returns one key per head_or_tp_rank (ranks in the same put_step
+        group share one key for MLA).
+        """
+        if num_groups > 1:
+            return [f"{model_name}@{group_id}@{block_hash_hex}@{h}" for h in range(num_ranks)]
+        else:
+            return [f"{model_name}@{block_hash_hex}@{h}" for h in range(num_ranks)]
+
+
+class GVASession:
+    """Worker-side GVA lifecycle: allocation for save, preparation for load.
+
+    Constructed only when ``use_gva_layerwise`` is true. Layout-dependent
+    parameters (group_block_len / page_size_bytes) arrive later via
+    :meth:`bind_layout`, once ``register_kv_caches`` has measured them.
+
+    Invalid-block reporting is injected as the ``on_invalid_blocks``
+    callback so the protocol never touches worker state directly.
+    """
+
+    def __init__(
+        self,
+        store: GVAStore,
+        model_name: str,
+        head_or_tp_rank: int,
+        tp_rank: int,
+        put_step: int,
+        num_kv_cache_groups: int,
+        grouped_block_size: list[int],
+        hash_block_size: int,
+        layerwise_offload: bool,
+        use_eagle: bool,
+        kv_role: str,
+        consumer_is_to_put: bool,
+        on_invalid_blocks: Callable[[list[int]], None],
+    ) -> None:
+        # Self-ensure (LIFE): a session must never run against an
+        # uninitialized store, even when the worker skips the eager
+        # on_worker_ready path (lazy_init mode relies on this too).
+        store.ensure_initialized()
+        self._store = store
+        self._model_name = model_name
+        self._head_or_tp_rank = head_or_tp_rank
+        self._tp_rank = tp_rank
+        self._put_step = put_step
+        self._num_kv_cache_groups = num_kv_cache_groups
+        self._grouped_block_size = grouped_block_size
+        self._hash_block_size = hash_block_size
+        self._layerwise_offload = layerwise_offload
+        self._use_eagle = use_eagle
+        self._kv_role = kv_role
+        self._consumer_is_to_put = consumer_is_to_put
+        self._on_invalid_blocks = on_invalid_blocks
+        self._group_block_len: dict[int, list[int]] = {}
+        self._page_size_bytes = 0
+        self._allocated_gvas: dict[str, int] = {}
+
+    def bind_layout(self, group_block_len: dict[int, list[int]], page_size_bytes: int) -> None:
+        """Bind the layout-dependent parameters measured by register_kv_caches."""
+        self._group_block_len = group_block_len
+        self._page_size_bytes = page_size_bytes
+
+    def _make_gva_key(self, group_id: int, block_hash_hex: str) -> str:
+        return GVAKeyFactory.full_key(
+            self._model_name,
+            group_id,
+            block_hash_hex,
+            self._head_or_tp_rank,
+            self._num_kv_cache_groups,
+        )
+
+    def _make_partial_key(self, request: ReqMeta, group_id: int, block_index: int, end_token: int) -> str:
+        return GVAKeyFactory.partial_key(
+            self._model_name,
+            request.req_id,
+            group_id,
+            block_index,
+            end_token,
+            self._head_or_tp_rank,
+        )
+
+    def _refresh_allocated_gvas(self, keys: list[str]) -> None:
+        """Drop local GVA entries whose MemCache blobs were evicted."""
+        cached_keys = list(dict.fromkeys(key for key in keys if key in self._allocated_gvas))
+        if not cached_keys:
+            return
+        exists_states = self._store.batch_is_exist(cached_keys)
+        if len(exists_states) != len(cached_keys):
+            raise RuntimeError(
+                "MemCache exists check returned unexpected number of states: "
+                f"expected={len(cached_keys)}, actual={len(exists_states)}"
+            )
+        for key, exists in zip(cached_keys, exists_states):
+            if exists == 0:
+                self._allocated_gvas.pop(key, None)
+            elif exists != 1:
+                raise RuntimeError(f"MemCache exists check failed for {key}: state={exists}")
+
+    def alloc_gvas_for_save(self, requests: list[ReqMeta]) -> None:
+        """Allocate per-group GVA on the worker side right before batch_copy.
+
+        For multi-group models, iterates all KV cache groups and allocates
+        per-group GVAs. Key format: model@group_id@hash@head_or_tp_rank
+        (multi-group) or model@hash@head_or_tp_rank (single-group, backward
+        compat with PR #11585).
+        """
+        if self._kv_role == "kv_consumer" and not self._consumer_is_to_put:
+            return
+        if self._tp_rank % self._put_step != 0:
+            return
+        for request in requests:
+            if request.can_save is None or not request.can_save:
+                continue
+            block_hashes = request.block_hashes
+
+            all_group_gvas: list[np.ndarray] = []
+            all_group_block_ids: list[np.ndarray] = []
+            all_group_save_keys: list[str] = []
+            request.partial_save_gva_per_group = [0] * self._num_kv_cache_groups
+            for group_id in range(self._num_kv_cache_groups):
+                group_block_size = self._grouped_block_size[group_id]
+                effective_block_size = group_block_size
+                group_block_len = self._group_block_len.get(group_id, self._group_block_len.get(0, []))
+                alloc_size = sum(group_block_len) if group_block_len else self._page_size_bytes
+
+                group_block_hashes = get_block_hashes(block_hashes, effective_block_size, self._hash_block_size)
+                block_ids_by_group = (
+                    request.block_ids_by_group_np[group_id]
+                    if (request.block_ids_by_group_np is not None and group_id < len(request.block_ids_by_group_np))
+                    else request.block_ids_np
+                )
+                if block_ids_by_group is None:
+                    raise RuntimeError(f"Block IDs are not initialized for request {request.req_id}")
+
+                save_start_block = request.save_start_token // effective_block_size
+                save_end_block = request.save_end_token // effective_block_size
+                if request.load_spec is not None and request.load_spec.can_load:
+                    pool_hit_tokens = (
+                        request.load_spec.kvpool_store_skip_tokens
+                        if request.load_spec.kvpool_store_skip_tokens is not None
+                        else request.load_spec.kvpool_cached_tokens
+                    )
+                    hit_full_blocks = pool_hit_tokens // effective_block_size
+                    save_start_block = max(save_start_block, hit_full_blocks)
+                candidate_keys = [
+                    self._make_gva_key(
+                        group_id,
+                        block_hash_to_str(group_block_hashes[block_idx]),
+                    )
+                    for block_idx in range(
+                        save_start_block,
+                        min(save_end_block, len(group_block_hashes)),
+                    )
+                ]
+                self._refresh_allocated_gvas(candidate_keys)
+                # Skip blocks that are still present and readable in MemCache.
+                while save_start_block < save_end_block and save_start_block < len(group_block_hashes):
+                    key = self._make_gva_key(group_id, block_hash_to_str(group_block_hashes[save_start_block]))
+                    if key in self._allocated_gvas:
+                        save_start_block += 1
+                    else:
+                        break
+
+                block_gvas: list[int] = []
+                new_keys: list[str] = []
+                new_positions: list[int] = []
+                for blk_idx in range(save_start_block, min(save_end_block, len(group_block_hashes))):
+                    key = self._make_gva_key(group_id, block_hash_to_str(group_block_hashes[blk_idx]))
+                    cached = self._allocated_gvas.get(key)
+                    if cached is not None:
+                        block_gvas.append(cached)
+                    else:
+                        new_keys.append(key)
+                        new_positions.append(len(block_gvas))
+                        block_gvas.append(0)
+
+                if new_keys:
+                    new_gvas = self._store.batch_alloc(new_keys, [alloc_size] * len(new_keys))
+                    if any(gva <= 0 for gva in new_gvas):
+                        logger.error(
+                            "alloc_gvas FAIL: req=%s group=%d alloc_size=%d new_keys=%d gvas_sample=%s zero_count=%d",
+                            request.req_id,
+                            group_id,
+                            alloc_size,
+                            len(new_keys),
+                            new_gvas[:5],
+                            sum(1 for g in new_gvas if g <= 0),
+                        )
+                    for pos, key, gva in zip(new_positions, new_keys, new_gvas):
+                        if gva > 0:
+                            block_gvas[pos] = gva
+                            self._allocated_gvas[key] = gva
+                            all_group_save_keys.append(key)
+
+                partial_block_index = get_partial_block_index(
+                    request.target_token_len,
+                    effective_block_size,
+                    len(group_block_hashes),
+                    self._layerwise_offload,
+                )
+                if partial_block_index is not None and partial_block_index < len(block_ids_by_group):
+                    partial_key = self._make_partial_key(
+                        request,
+                        group_id,
+                        partial_block_index,
+                        request.target_token_len,
+                    )
+                    partial_gva = self._allocated_gvas.get(partial_key)
+                    if partial_gva is None:
+                        allocated = self._store.batch_alloc(
+                            [partial_key],
+                            [alloc_size],
+                        )
+                        partial_gva = allocated[0] if allocated else 0
+                        if partial_gva > 0:
+                            self._allocated_gvas[partial_key] = partial_gva
+                            all_group_save_keys.append(partial_key)
+                        else:
+                            logger.error(
+                                "alloc_gvas: partial allocation failed req=%s group=%d block=%d gva=%d",
+                                request.req_id,
+                                group_id,
+                                partial_block_index,
+                                partial_gva,
+                            )
+                    # Partial keys are request-scoped; do not retain them forever.
+                    self._allocated_gvas.pop(partial_key, None)
+                    request.partial_save_gva_per_group[group_id] = partial_gva
+
+                logger.debug(
+                    "alloc_gvas: req=%s group=%d eff_bs=%d save_blocks=[%d,%d) "
+                    "new_keys=%d cached_keys=%d alloc_size=%d",
+                    request.req_id,
+                    group_id,
+                    effective_block_size,
+                    save_start_block,
+                    save_end_block,
+                    len(new_keys),
+                    len(block_gvas) - len(new_keys),
+                    alloc_size,
+                )
+
+                # Pad block_gvas to match block_ids length (fill 0 for blocks before save_start)
+                full_gvas = [0] * len(block_ids_by_group)
+                for i, gva in enumerate(block_gvas):
+                    if save_start_block + i < len(full_gvas):
+                        full_gvas[save_start_block + i] = gva
+
+                all_group_gvas.append(np.asarray(full_gvas, dtype=np.int64))
+                all_group_block_ids.append(np.asarray(block_ids_by_group, dtype=np.int64))
+
+            if all_group_gvas:
+                request.save_keys = all_group_save_keys
+                request.block_gvas_by_group_np = all_group_gvas
+                request.block_ids_by_group_np = all_group_block_ids
+                request.block_gvas_np = all_group_gvas[0]
+                request.gva_block_offset = 0
+
+    def prepare_load_gvas(self, requests: list[ReqMeta]) -> None:
+        """Fetch per-rank GVA and acquire read lease for the load path.
+
+        memcache requires batch_copy (read) to find the blob in the per-process
+        gvaBlobTracker with a valid lease. The scheduler only checks existence
+        (batch_is_exist) to decide the load range; before batch_copy(G2L) the
+        worker must, for its own per-rank keys:
+          1. batch_get_key_info to fetch the GVA (fills block_gvas_np)
+          2. batch_add_lease to register the blob locally + acquire a read lease
+        """
+        for request in requests:
+            if request.load_spec is None or not request.load_spec.can_load:
+                continue
+            cached_tokens = request.load_spec.kvpool_cached_tokens
+            if not self._use_eagle and request.load_spec.kvpool_store_skip_tokens is not None:
+                cached_tokens = request.load_spec.kvpool_store_skip_tokens
+            block_hashes = request.block_hashes
+
+            all_group_load_gvas: list[np.ndarray] = []
+            all_group_load_keys: list[str] = []
+            request.partial_load_gva_per_group = [0] * self._num_kv_cache_groups
+            for group_id in range(self._num_kv_cache_groups):
+                group_block_size = self._grouped_block_size[group_id]
+                effective_block_size = group_block_size
+
+                group_block_hashes = get_block_hashes(block_hashes, effective_block_size, self._hash_block_size)
+                load_start_block = (
+                    0 if self._layerwise_offload else request.load_spec.vllm_cached_tokens // effective_block_size
+                )
+                cached_full_blocks = cached_tokens // effective_block_size
+                full_blocks = min(cached_full_blocks, len(group_block_hashes))
+
+                block_ids_by_group = (
+                    request.block_ids_by_group_np[group_id]
+                    if (request.block_ids_by_group_np is not None and group_id < len(request.block_ids_by_group_np))
+                    else request.block_ids_np
+                )
+                if block_ids_by_group is None:
+                    all_group_load_gvas.append(np.zeros(0, dtype=np.int64))
+                    continue
+                full_len = len(block_ids_by_group)
+
+                partial_block_index = get_partial_block_index(
+                    cached_tokens,
+                    effective_block_size,
+                    len(group_block_hashes),
+                    self._layerwise_offload,
+                )
+                if partial_block_index is not None and (
+                    partial_block_index < load_start_block or partial_block_index >= full_len
+                ):
+                    partial_block_index = None
+
+                if load_start_block >= full_blocks and partial_block_index is None:
+                    all_group_load_gvas.append(np.zeros(full_len, dtype=np.int64))
+                    continue
+
+                keys = [
+                    self._make_gva_key(group_id, block_hash_to_str(group_block_hashes[i]))
+                    for i in range(load_start_block, full_blocks)
+                ]
+                block_indices = list(range(load_start_block, full_blocks))
+                if partial_block_index is not None:
+                    keys.append(
+                        self._make_partial_key(
+                            request,
+                            group_id,
+                            partial_block_index,
+                            cached_tokens,
+                        )
+                    )
+                    block_indices.append(partial_block_index)
+                if not keys:
+                    all_group_load_gvas.append(np.zeros(full_len, dtype=np.int64))
+                    continue
+
+                key_infos = self._store.batch_get_key_info(keys)
+                gvas = []
+                valid_gva_indices = []
+                invalid_block_ids: list[int] = []
+                for ki, key, block_idx in zip(key_infos, keys, block_indices):
+                    sizes = ki.size()
+                    gva = ki.gva_list()[0] if sizes and sizes > 0 else 0
+                    gvas.append(gva)
+                    if gva > 0:
+                        valid_gva_indices.append(len(gvas) - 1)
+                    else:
+                        if block_idx < len(block_ids_by_group):
+                            invalid_block_ids.append(int(block_ids_by_group[block_idx]))
+                        logger.warning(
+                            "load_gvas: req=%s group=%d got invalid gva=%d (size=%d), block_id=%s load failed",
+                            request.req_id,
+                            group_id,
+                            gva,
+                            sizes if sizes else 0,
+                            int(block_ids_by_group[block_idx]) if block_idx < len(block_ids_by_group) else "N/A",
+                        )
+
+                # Only call batch_add_lease for keys with valid size
+                valid_keys = [keys[index] for index in valid_gva_indices]
+                if valid_keys:
+                    lease_results = self._store.batch_add_lease(valid_keys, LAYERWISE_READ_LEASE_TTL_MS)
+                    if len(lease_results) != len(valid_keys):
+                        raise RuntimeError(
+                            "MemCache lease returned unexpected number of results: "
+                            f"expected={len(valid_keys)}, actual={len(lease_results)}"
+                        )
+                    leased_keys = []
+                    for gva_index, lease_res in zip(valid_gva_indices, lease_results):
+                        block_idx = block_indices[gva_index]
+                        if lease_res == MEMCACHE_UNMATCHED_STATE and block_idx == partial_block_index:
+                            partial_key = keys[gva_index]
+                            for retry in range(1, PARTIAL_LEASE_RETRY_COUNT + 1):
+                                time.sleep(PARTIAL_LEASE_RETRY_INTERVAL_S)
+                                retry_results = self._store.batch_add_lease(
+                                    [partial_key],
+                                    LAYERWISE_READ_LEASE_TTL_MS,
+                                )
+                                if len(retry_results) != 1:
+                                    raise RuntimeError(
+                                        "MemCache partial lease retry returned "
+                                        f"unexpected number of results: {len(retry_results)}"
+                                    )
+                                lease_res = retry_results[0]
+                                if lease_res != MEMCACHE_UNMATCHED_STATE:
+                                    break
+                        block_id = int(block_ids_by_group[block_idx]) if block_idx < len(block_ids_by_group) else None
+                        if lease_res == 0:
+                            leased_keys.append(keys[gva_index])
+                        else:
+                            gvas[gva_index] = 0
+                            if block_id is not None:
+                                invalid_block_ids.append(block_id)
+                            logger.warning(
+                                "load_gvas: req=%s group=%d lease failed result=%d, block_id=%s load failed",
+                                request.req_id,
+                                group_id,
+                                lease_res,
+                                block_id,
+                            )
+                else:
+                    lease_results = []
+                    leased_keys = []
+
+                # Report invalid blocks to scheduler for recompute.
+                # Single-group models can safely report individual block IDs.
+                # Multi-group (hybrid) models must not report partial group
+                # failures, as the scheduler cannot handle inconsistent KV
+                # cache state across groups (see PR #9701 for rationale).
+                if invalid_block_ids:
+                    if self._num_kv_cache_groups == 1:
+                        self._on_invalid_blocks(invalid_block_ids)
+                    else:
+                        leased_keys_to_release = list(
+                            dict.fromkeys(
+                                [
+                                    *all_group_load_keys,
+                                    *leased_keys,
+                                ]
+                            )
+                        )
+                        if leased_keys_to_release:
+                            self._store.batch_remove_lease(leased_keys_to_release)
+                        raise RuntimeError(
+                            "Layerwise multi-group KV load failed and cannot "
+                            "safely fall back to per-block recomputation: "
+                            f"request={request.req_id}, "
+                            f"failed_blocks={invalid_block_ids}"
+                        )
+                all_group_load_keys.extend(leased_keys)
+
+                logger.debug(
+                    "load_gvas: req=%s group=%d eff_bs=%d load_blocks=[%d,%d) keys=%d valid_gvas=%d lease_fail=%d",
+                    request.req_id,
+                    group_id,
+                    effective_block_size,
+                    load_start_block,
+                    full_blocks,
+                    len(keys),
+                    sum(1 for g in gvas if g > 0),
+                    sum(1 for r in lease_results if r != 0),
+                )
+
+                # Pad to match block_ids_by_group length, with 0s before load_start_block
+                full_gvas = [0] * full_len
+                normal_gva_count = full_blocks - load_start_block
+                for i, gva in enumerate(gvas[:normal_gva_count]):
+                    if load_start_block + i < len(full_gvas):
+                        full_gvas[load_start_block + i] = gva
+                all_group_load_gvas.append(np.asarray(full_gvas, dtype=np.int64))
+                if partial_block_index is not None and len(gvas) > normal_gva_count:
+                    request.partial_load_gva_per_group[group_id] = gvas[normal_gva_count]
+
+            if all_group_load_gvas:
+                request.load_keys = all_group_load_keys
+                request.load_block_gvas_by_group_np = all_group_load_gvas
+                request.load_block_gvas_np = all_group_load_gvas[0]
+                request.load_gva_block_offset = 0
+
+
+class GVAHitChecker:
+    """Scheduler-side GVA prefix hit computation."""
+
+    def __init__(
+        self,
+        store: GVAStore,
+        model_name: str,
+        head_or_tp_ranks: int,
+        grouped_block_size: list[int],
+        hash_block_size: int,
+        num_groups: int,
+        use_layerwise: bool,
+    ) -> None:
+        self._store = store
+        self._model_name = model_name
+        self._head_or_tp_ranks = head_or_tp_ranks
+        self._grouped_block_size = grouped_block_size
+        self._hash_block_size = hash_block_size
+        self._num_groups = num_groups
+        self._use_layerwise = use_layerwise
+
+    def _make_hit_check_keys(self, group_id: int, block_hash_hex: str) -> list[str]:
+        return GVAKeyFactory.hit_check_keys(
+            self._model_name,
+            group_id,
+            block_hash_hex,
+            self._head_or_tp_ranks,
+            self._num_groups,
+        )
+
+    def hit_tokens(self, request: Request, token_len: int, num_computed_tokens: int) -> int:
+        # In layerwise mode, always query from block 0 because the remote
+        # pool stores per-layer data that may not match local prefix cache.
+        num_hash_blocks = token_len // self._hash_block_size
+        block_hashes_to_check = request.block_hashes[:num_hash_blocks]
+        hits_per_group: list[int] = []
+
+        for group_id in range(len(self._grouped_block_size)):
+            effective_block_size = get_group_block_size(self._grouped_block_size, group_id)
+            group_block_hashes = get_block_hashes(block_hashes_to_check, effective_block_size, self._hash_block_size)
+            query_start_block = (
+                0 if self._use_layerwise else min(num_computed_tokens // effective_block_size, len(group_block_hashes))
+            )
+            group_block_hashes = group_block_hashes[query_start_block:]
+            # Generate all-rank keys for each block hash
+            keys_by_block = [self._make_hit_check_keys(group_id, block_hash_to_str(bh)) for bh in group_block_hashes]
+            all_keys = [key for block_keys in keys_by_block for key in block_keys]
+            if not all_keys:
+                continue
+
+            key_infos = self._store.batch_get_key_info(all_keys)
+            if len(key_infos) != len(all_keys):
+                logger.error(
+                    "KV pool batch_get_key_info returned unexpected number of results: expected=%d, actual=%d",
+                    len(all_keys),
+                    len(key_infos),
+                )
+                hits_per_group.append(0)
+                continue
+
+            # A block is hit only when ALL ranks' keys return valid GVA
+            num_hit_blocks = 0
+            offset = 0
+            for block_keys in keys_by_block:
+                block_infos = key_infos[offset : offset + len(block_keys)]
+                offset += len(block_keys)
+                if all(ki.size() and ki.size() > 0 for ki in block_infos):
+                    num_hit_blocks += 1
+                else:
+                    break
+
+            hits_per_group.append((query_start_block + num_hit_blocks) * effective_block_size)
+
+        if not hits_per_group:
+            logger.debug(
+                "hit_check: req=%s token_len=%d no participating groups (all skipped)",
+                request.request_id,
+                token_len,
+            )
+            return 0
+        hit_tokens = min(hits_per_group)
+        logger.debug(
+            "hit_check: req=%s token_len=%d hits_per_group=%s hit_tokens=%d",
+            request.request_id,
+            token_len,
+            hits_per_group,
+            hit_tokens,
+        )
+        return hit_tokens

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/backend/memcache_backend.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/backend/memcache_backend.py
@@ -10,7 +10,7 @@ from vllm.config import ParallelConfig
 from vllm.distributed.parallel_state import get_world_group
 from vllm.logger import logger
 
-from vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.backend.base import Backend
+from vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.backend.base import Backend, GVALayerwiseCapable
 
 
 def _is_device_sdma() -> bool:
@@ -38,7 +38,7 @@ class MmcDirect(Enum):
     COPY_H2G = 3
 
 
-class MemcacheBackend(Backend):
+class MemcacheBackend(Backend, GVALayerwiseCapable):
     def __init__(
         self,
         parallel_config: ParallelConfig,
@@ -58,6 +58,15 @@ class MemcacheBackend(Backend):
         if not self._lazy_init:
             self.store = self._setup_store()
             self._store_initialized = True
+
+    def on_worker_ready(self) -> None:
+        # lazy_init (compress + device_sdma) intentionally defers store
+        # setup: exists/batch_get_key_info rely on the "uninitialized means
+        # all-miss" short circuit, so an unconditional eager init here would
+        # break that contract.
+        if self._lazy_init:
+            return
+        self.ensure_initialized()
 
     def ensure_initialized(self):
         if self._store_initialized:

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/kv_transfer.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/kv_transfer.py
@@ -14,7 +14,10 @@ from vllm.distributed.kv_events import BlockStored
 from vllm.logger import logger
 from vllm.v1.core.kv_cache_utils import maybe_convert_block_hash
 
-from vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.backend.base import Backend
+from vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.backend.base import (
+    Backend,
+    GVALayerwiseCapable,
+)
 
 # isort: off
 from vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.metadata import (
@@ -1377,6 +1380,7 @@ class KVCacheStoreLayerSendingThread(KVTransferThread):
             if write_finish_keys:
                 finish_keys = list(dict.fromkeys(write_finish_keys))
                 results = [self.write_results.pop(key) for key in finish_keys]
+                assert isinstance(self.m_store, GVALayerwiseCapable)
                 finish_results = self.m_store.batch_write_finish(finish_keys, results)
                 if len(finish_results) != len(finish_keys) or any(result != 0 for result in finish_results):
                     raise RuntimeError(
@@ -1578,6 +1582,7 @@ class KVCacheStoreLayerRecvingThread(KVTransferThread):
 
         if layer_id == self.final_layer_id and all_load_keys:
             unique_load_keys = list(dict.fromkeys(all_load_keys))
+            assert isinstance(self.m_store, GVALayerwiseCapable)
             self.m_store.batch_remove_lease(unique_load_keys)
             logger.debug(
                 "[KVPOOL] load_thread released %d leases after final layer %d",

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/layerwise_cache_layout.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/layerwise_cache_layout.py
@@ -14,6 +14,10 @@ from vllm.v1.kv_cache_interface import (
     UniformTypeKVCacheSpecs,
 )
 
+from vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.backend import (
+    backend_supports,
+)
+
 _NUM_SHARED_BUFFERS = "layerwise_num_shared_buffers"
 _PREFETCH_LAYERS = "layerwise_prefetch_layers"
 _INDEPENDENT_LAYERS = "layerwise_independent_layers"
@@ -95,7 +99,7 @@ def get_gva_layerwise_config(kv_transfer_config: Any) -> dict[str, Any] | None:
         ):
             continue
         extra_config = connector_config.get("kv_connector_extra_config") or {}
-        if str(extra_config.get("backend", "mooncake")).lower() == "memcache" and extra_config.get(
+        if backend_supports(str(extra_config.get("backend", "mooncake")).lower(), "gva_layerwise") and extra_config.get(
             "use_layerwise", False
         ):
             return extra_config

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/metadata.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/metadata.py
@@ -702,6 +702,27 @@ def block_hash_to_bytes(block_hash: BlockHash | str) -> bytes:
     return bytes(block_hash)
 
 
+def get_partial_block_index(
+    token_count: int,
+    block_size: int,
+    hash_count: int,
+    enabled: bool,
+) -> int | None:
+    """Index of the trailing partial block to transfer, if any.
+
+    Returns None when disabled, when the request carries no tokens, or when
+    the token count aligns exactly with completed hash blocks.
+    """
+    if not enabled or token_count <= 0:
+        return None
+    full_blocks, remainder = divmod(token_count, block_size)
+    if remainder:
+        return full_blocks
+    if full_blocks > hash_count:
+        return full_blocks - 1
+    return None
+
+
 # Parameters related to the connector metadata
 @dataclass
 class LoadSpec:

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/pool_scheduler.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/pool_scheduler.py
@@ -402,6 +402,7 @@ class KVPoolScheduler:
         if self.use_gva_layerwise:
             token_len = prompt_token_len
             self._get_or_create_request_tracker(request.request_id)
+            assert self._gva_hit_checker is not None
             num_external_hit_tokens = self._gva_hit_checker.hit_tokens(request, token_len, num_computed_tokens)
         else:
             if self._discard_partial_chunks:

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/pool_scheduler.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/pool_scheduler.py
@@ -25,6 +25,7 @@ from vllm.v1.serial_utils import MsgpackEncoder
 
 from vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.backend import (
     backend_map,
+    use_gva_layerwise,
 )
 from vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.layerwise_cache_layout import (
     build_layerwise_cache_layout,
@@ -160,7 +161,7 @@ class KVPoolScheduler:
 
         backend_name = vllm_config.kv_transfer_config.kv_connector_extra_config.get("backend", "mooncake")
         self.backend_name = backend_name.lower()
-        self.use_gva_layerwise = self.use_layerwise and self.backend_name == "memcache"
+        self.use_gva_layerwise = use_gva_layerwise(self.use_layerwise, self.backend_name)
         backend = backend_map.get(self.backend_name)
         if backend is None:
             raise ValueError(f"Unsupported KV pool backend: {backend_name}")

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/pool_scheduler.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/pool_scheduler.py
@@ -27,6 +27,9 @@ from vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.backend import (
     backend_map,
     use_gva_layerwise,
 )
+from vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.backend.gva_protocol import (
+    GVAHitChecker,
+)
 from vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.layerwise_cache_layout import (
     build_layerwise_cache_layout,
     build_layerwise_reuse_layout,
@@ -41,9 +44,6 @@ from vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.metadata import (
     PoolKey,
     ReqMeta,
     RequestTracker,
-    block_hash_to_str,
-    get_block_hashes,
-    get_group_block_size,
     get_group_cache_family,
     infer_cache_transfer_granularity,
     infer_group_block_sizes,
@@ -212,6 +212,22 @@ class KVPoolScheduler:
 
         self.client: LookupKeyClient | None = None
 
+        # Scheduler-side GVA hit computation (all-rank key probing, group-wise
+        # min). Only constructed for the GVA layerwise mode.
+        self._gva_hit_checker: GVAHitChecker | None = (
+            GVAHitChecker(
+                store=self.store_scheduler,
+                model_name=self.model_name,
+                head_or_tp_ranks=self.tp_size // self.put_step,
+                grouped_block_size=self.grouped_block_size,
+                hash_block_size=self.hash_block_size,
+                num_groups=len(self.kv_cache_group_ids),
+                use_layerwise=self.use_layerwise,
+            )
+            if self.use_gva_layerwise
+            else None
+        )
+
     def _get_or_create_request_tracker(self, req_id: str) -> RequestTracker:
         tracker = self._request_trackers.get(req_id)
         if tracker is None:
@@ -304,88 +320,6 @@ class KVPoolScheduler:
         num_hit_blocks = query_start_block + num_queried_hit_blocks
         return num_hit_blocks * self._block_size
 
-    def _make_layerwise_gva_keys_for_hit_check(self, group_id: int, block_hash_hex: str) -> list[str]:
-        """Generate all-rank GVA keys for scheduler-side hit check.
-
-        Single-group uses PR #11585 format; multi-group includes group_id.
-        Returns one key per head_or_tp_rank (ranks in the same put_step
-        group share one key for MLA).
-        """
-        head_or_tp_ranks = self.tp_size // self.put_step
-        if len(self.kv_cache_group_ids) > 1:
-            return [f"{self.model_name}@{group_id}@{block_hash_hex}@{h}" for h in range(head_or_tp_ranks)]
-        else:
-            return [f"{self.model_name}@{block_hash_hex}@{h}" for h in range(head_or_tp_ranks)]
-
-    def _get_layerwise_gva_hit_tokens(
-        self,
-        request: "Request",
-        token_len: int,
-        num_computed_tokens: int,
-    ) -> int:
-        # In layerwise mode, always query from block 0 because the remote
-        # pool stores per-layer data that may not match local prefix cache.
-        num_hash_blocks = token_len // self.hash_block_size
-        block_hashes_to_check = request.block_hashes[:num_hash_blocks]
-        hits_per_group: list[int] = []
-        self._get_or_create_request_tracker(request.request_id)
-
-        for group_id in range(len(self.grouped_block_size)):
-            effective_block_size = get_group_block_size(self.grouped_block_size, group_id)
-            group_block_hashes = get_block_hashes(block_hashes_to_check, effective_block_size, self.hash_block_size)
-            query_start_block = (
-                0 if self.use_layerwise else min(num_computed_tokens // effective_block_size, len(group_block_hashes))
-            )
-            group_block_hashes = group_block_hashes[query_start_block:]
-            # Generate all-rank keys for each block hash
-            keys_by_block = [
-                self._make_layerwise_gva_keys_for_hit_check(group_id, block_hash_to_str(bh))
-                for bh in group_block_hashes
-            ]
-            all_keys = [key for block_keys in keys_by_block for key in block_keys]
-            if not all_keys:
-                continue
-
-            key_infos = self.store_scheduler.batch_get_key_info(all_keys)
-            if len(key_infos) != len(all_keys):
-                logger.error(
-                    "KV pool batch_get_key_info returned unexpected number of results: expected=%d, actual=%d",
-                    len(all_keys),
-                    len(key_infos),
-                )
-                hits_per_group.append(0)
-                continue
-
-            # A block is hit only when ALL ranks' keys return valid GVA
-            num_hit_blocks = 0
-            offset = 0
-            for block_keys in keys_by_block:
-                block_infos = key_infos[offset : offset + len(block_keys)]
-                offset += len(block_keys)
-                if all(ki.size() and ki.size() > 0 for ki in block_infos):
-                    num_hit_blocks += 1
-                else:
-                    break
-
-            hits_per_group.append((query_start_block + num_hit_blocks) * effective_block_size)
-
-        if not hits_per_group:
-            logger.debug(
-                "hit_check: req=%s token_len=%d no participating groups (all skipped)",
-                request.request_id,
-                token_len,
-            )
-            return 0
-        hit_tokens = min(hits_per_group)
-        logger.debug(
-            "hit_check: req=%s token_len=%d hits_per_group=%s hit_tokens=%d",
-            request.request_id,
-            token_len,
-            hits_per_group,
-            hit_tokens,
-        )
-        return hit_tokens
-
     def _floor_to_cache_transfer_granularity(self, token_len: int) -> int:
         return token_len // self.cache_transfer_granularity * self.cache_transfer_granularity
 
@@ -467,7 +401,8 @@ class KVPoolScheduler:
 
         if self.use_gva_layerwise:
             token_len = prompt_token_len
-            num_external_hit_tokens = self._get_layerwise_gva_hit_tokens(request, token_len, num_computed_tokens)
+            self._get_or_create_request_tracker(request.request_id)
+            num_external_hit_tokens = self._gva_hit_checker.hit_tokens(request, token_len, num_computed_tokens)
         else:
             if self._discard_partial_chunks:
                 token_len = self._floor_to_cache_transfer_granularity(prompt_token_len)

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/pool_worker.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/pool_worker.py
@@ -3,11 +3,9 @@ from __future__ import annotations
 import importlib
 import math
 import threading
-import time
 from collections.abc import Callable, Generator
 from typing import Any
 
-import numpy as np
 import torch
 import vllm.envs as envs
 from vllm.config import VllmConfig
@@ -32,6 +30,9 @@ from vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.attention_fence im
 from vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.backend import (
     backend_map,
     use_gva_layerwise,
+)
+from vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.backend.gva_protocol import (
+    GVASession,
 )
 from vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.coordinator import (
     AscendStoreCoordinator,
@@ -67,10 +68,10 @@ from vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.metadata import (
     LayerTransferTask,
     ReqMeta,
     block_hash_to_bytes,
-    block_hash_to_str,
     get_block_hashes,
     get_group_block_size,
     get_group_cache_family,
+    get_partial_block_index,
     infer_cache_transfer_granularity,
     infer_group_block_sizes,
     infer_group_cache_families,
@@ -81,17 +82,6 @@ from vllm_ascend.distributed.utils import (
     get_decode_context_model_parallel_rank,
     get_decode_context_model_parallel_world_size,
 )
-
-# Read lease TTL (ms) for the layerwise load path. batch_add_lease acquires a
-# read lease before batch_copy(G2L); the lease must cover the asynchronous
-# multi-layer load time.
-LAYERWISE_READ_LEASE_TTL_MS = 5 * 60 * 1000
-
-# A partial snapshot can be visible to readers before the rank responsible for
-# saving it has published its final layer.
-MEMCACHE_UNMATCHED_STATE = -3101
-PARTIAL_LEASE_RETRY_COUNT = 10
-PARTIAL_LEASE_RETRY_INTERVAL_S = 0.001
 
 
 class KVPoolWorker:
@@ -339,12 +329,6 @@ class KVPoolWorker:
         self.kv_recv_thread: KVTransferThread | None = None
         self._transfer_threads_started = False
         self.external_slot_release_waiter: Callable[[int], None] | None = None
-        # Per-rank GVA cache: maps per-rank store key to its allocated GVA.
-        # batch_alloc is non-idempotent (returns MMC_DUPLICATED_OBJECT for an
-        # existing key without registering the blob), so the worker must track
-        # which keys it has already allocated and reuse those GVAs instead of
-        # re-allocating them on every save step.
-        self._allocated_gvas: dict[str, int] = {}
 
     def _init_layerwise_config(self) -> None:
         # Build mapping: physical_layer -> [(group_id, layer_idx_in_group), ...]
@@ -434,6 +418,31 @@ class KVPoolWorker:
         else:
             self.num_prefetch_layers = int(self._extra_config.get("layerwise_prefetch_layers", 1))
         self.sync_save_events: list[torch.npu.Event] | None = None
+
+        # The GVA session owns the worker-side layerwise GVA protocol
+        # (allocation for save, lease acquisition for load). Construction
+        # self-ensures the store is initialized (LIFE). Layout-dependent
+        # parameters (group_block_len / page_size_bytes) are bound later by
+        # register_kv_caches via bind_layout.
+        self._gva_session: GVASession | None = (
+            GVASession(
+                store=self.m_store,
+                model_name=self.model_name,
+                head_or_tp_rank=self.head_or_tp_rank,
+                tp_rank=self.tp_rank,
+                put_step=self.put_step,
+                num_kv_cache_groups=self.num_kv_cache_groups,
+                grouped_block_size=self.grouped_block_size,
+                hash_block_size=self.hash_block_size,
+                layerwise_offload=self.layerwise_offload,
+                use_eagle=self.use_eagle,
+                kv_role=self.kv_role,
+                consumer_is_to_put=self.consumer_is_to_put,
+                on_invalid_blocks=self._report_invalid_blocks,
+            )
+            if self.use_gva_layerwise
+            else None
+        )
 
         logger.info(
             "layerwise config: num_layers=%d num_groups=%d physical_layer_to_group_layers_sample=%s",
@@ -789,6 +798,8 @@ class KVPoolWorker:
             self.layer_save_tasks = [[] for _ in range(self.num_layers)]
 
         self.page_size_bytes = sum(self.block_len)
+        if self._gva_session is not None:
+            self._gva_session.bind_layout(self.group_block_len, self.page_size_bytes)
         self.token_database.set_group_buffers(
             self.group_kv_caches_base_addr,
             self.group_block_len,
@@ -814,8 +825,9 @@ class KVPoolWorker:
 
         # Initialize store, register buffers, and start transfer threads
         # directly here (like main) — no separate init_backend handshake.
-        if self.use_gva_layerwise:
-            self.m_store.ensure_initialized()
+        # The GVA path is already covered by the GVASession construction
+        # self-ensure; lazy backends keep their deferred short-circuit.
+        self.m_store.on_worker_ready()
         self.m_store.register_buffer(ptrs, lengths)
         self._start_kv_transfer_threads()
 
@@ -992,7 +1004,7 @@ class KVPoolWorker:
                 block_size,
                 self.hash_block_size,
             )
-            partial_block_index = self._get_partial_block_index(
+            partial_block_index = get_partial_block_index(
                 request.target_token_len,
                 block_size,
                 len(group_block_hashes),
@@ -1058,7 +1070,7 @@ class KVPoolWorker:
             )
             cached_full_blocks = cached_tokens // block_size
             full_blocks = min(cached_full_blocks, len(group_block_hashes))
-            partial_block_index = self._get_partial_block_index(
+            partial_block_index = get_partial_block_index(
                 cached_tokens,
                 block_size,
                 len(group_block_hashes),
@@ -1094,426 +1106,6 @@ class KVPoolWorker:
                     layer_idx_in_group=layer_idx_in_group,
                 )
             )
-
-    @staticmethod
-    def _get_partial_block_index(
-        token_count: int,
-        block_size: int,
-        hash_count: int,
-        enabled: bool,
-    ) -> int | None:
-        if not enabled or token_count <= 0:
-            return None
-        full_blocks, remainder = divmod(token_count, block_size)
-        if remainder:
-            return full_blocks
-        if full_blocks > hash_count:
-            return full_blocks - 1
-        return None
-
-    def _make_layerwise_gva_key(self, group_id: int, block_hash_hex: str) -> str:
-        """Generate GVA key for layerwise transfer.
-
-        Single-group models use the PR #11585 format (model@hash@rank) for
-        backward compatibility. Multi-group models include group_id
-        (model@group_id@hash@rank) to distinguish groups.
-        """
-        if self.num_kv_cache_groups > 1:
-            return f"{self.model_name}@{group_id}@{block_hash_hex}@{self.head_or_tp_rank}"
-        else:
-            return f"{self.model_name}@{block_hash_hex}@{self.head_or_tp_rank}"
-
-    def _make_layerwise_partial_key(
-        self,
-        request: ReqMeta,
-        group_id: int,
-        block_index: int,
-        end_token: int,
-    ) -> str:
-        return f"{self.model_name}@partial@{request.req_id}@{group_id}@{block_index}@{end_token}@{self.head_or_tp_rank}"
-
-    def _refresh_allocated_gvas(self, keys: list[str]) -> None:
-        """Drop local GVA entries whose MemCache blobs were evicted."""
-        cached_keys = list(dict.fromkeys(key for key in keys if key in self._allocated_gvas))
-        if not cached_keys:
-            return
-        exists_states = self.m_store.batch_is_exist(cached_keys)
-        if len(exists_states) != len(cached_keys):
-            raise RuntimeError(
-                "MemCache exists check returned unexpected number of states: "
-                f"expected={len(cached_keys)}, actual={len(exists_states)}"
-            )
-        for key, exists in zip(cached_keys, exists_states):
-            if exists == 0:
-                self._allocated_gvas.pop(key, None)
-            elif exists != 1:
-                raise RuntimeError(f"MemCache exists check failed for {key}: state={exists}")
-
-    def _alloc_gvas_for_save(self, requests: list[ReqMeta]) -> None:
-        """Allocate per-group GVA on the worker side right before batch_copy.
-
-        For multi-group models, iterates all KV cache groups and allocates
-        per-group GVAs. Key format: model@group_id@hash@head_or_tp_rank
-        (multi-group) or model@hash@head_or_tp_rank (single-group, backward
-        compat with PR #11585).
-        """
-        if not self.use_gva_layerwise:
-            return
-        if self.kv_role == "kv_consumer" and not self.consumer_is_to_put:
-            return
-        if self.tp_rank % self.put_step != 0:
-            return
-        for request in requests:
-            if request.can_save is None or not request.can_save:
-                continue
-            block_hashes = request.block_hashes
-
-            all_group_gvas: list[np.ndarray] = []
-            all_group_block_ids: list[np.ndarray] = []
-            all_group_save_keys: list[str] = []
-            request.partial_save_gva_per_group = [0] * self.num_kv_cache_groups
-            for group_id in range(self.num_kv_cache_groups):
-                group_block_size = self.grouped_block_size[group_id]
-                effective_block_size = group_block_size
-                group_block_len = self.group_block_len.get(group_id, self.group_block_len.get(0, []))
-                alloc_size = sum(group_block_len) if group_block_len else self.page_size_bytes
-
-                group_block_hashes = get_block_hashes(block_hashes, effective_block_size, self.hash_block_size)
-                block_ids_by_group = (
-                    request.block_ids_by_group_np[group_id]
-                    if (request.block_ids_by_group_np is not None and group_id < len(request.block_ids_by_group_np))
-                    else request.block_ids_np
-                )
-                if block_ids_by_group is None:
-                    raise RuntimeError(f"Block IDs are not initialized for request {request.req_id}")
-
-                save_start_block = request.save_start_token // effective_block_size
-                save_end_block = request.save_end_token // effective_block_size
-                if request.load_spec is not None and request.load_spec.can_load:
-                    pool_hit_tokens = (
-                        request.load_spec.kvpool_store_skip_tokens
-                        if request.load_spec.kvpool_store_skip_tokens is not None
-                        else request.load_spec.kvpool_cached_tokens
-                    )
-                    hit_full_blocks = pool_hit_tokens // effective_block_size
-                    save_start_block = max(save_start_block, hit_full_blocks)
-                candidate_keys = [
-                    self._make_layerwise_gva_key(
-                        group_id,
-                        block_hash_to_str(group_block_hashes[block_idx]),
-                    )
-                    for block_idx in range(
-                        save_start_block,
-                        min(save_end_block, len(group_block_hashes)),
-                    )
-                ]
-                self._refresh_allocated_gvas(candidate_keys)
-                # Skip blocks that are still present and readable in MemCache.
-                while save_start_block < save_end_block and save_start_block < len(group_block_hashes):
-                    key = self._make_layerwise_gva_key(
-                        group_id, block_hash_to_str(group_block_hashes[save_start_block])
-                    )
-                    if key in self._allocated_gvas:
-                        save_start_block += 1
-                    else:
-                        break
-
-                block_gvas: list[int] = []
-                new_keys: list[str] = []
-                new_positions: list[int] = []
-                for blk_idx in range(save_start_block, min(save_end_block, len(group_block_hashes))):
-                    key = self._make_layerwise_gva_key(group_id, block_hash_to_str(group_block_hashes[blk_idx]))
-                    cached = self._allocated_gvas.get(key)
-                    if cached is not None:
-                        block_gvas.append(cached)
-                    else:
-                        new_keys.append(key)
-                        new_positions.append(len(block_gvas))
-                        block_gvas.append(0)
-
-                if new_keys:
-                    new_gvas = self.m_store.batch_alloc(new_keys, [alloc_size] * len(new_keys))
-                    if any(gva <= 0 for gva in new_gvas):
-                        logger.error(
-                            "alloc_gvas FAIL: req=%s group=%d alloc_size=%d new_keys=%d gvas_sample=%s zero_count=%d",
-                            request.req_id,
-                            group_id,
-                            alloc_size,
-                            len(new_keys),
-                            new_gvas[:5],
-                            sum(1 for g in new_gvas if g <= 0),
-                        )
-                    for pos, key, gva in zip(new_positions, new_keys, new_gvas):
-                        if gva > 0:
-                            block_gvas[pos] = gva
-                            self._allocated_gvas[key] = gva
-                            all_group_save_keys.append(key)
-
-                partial_block_index = self._get_partial_block_index(
-                    request.target_token_len,
-                    effective_block_size,
-                    len(group_block_hashes),
-                    self.layerwise_offload,
-                )
-                if partial_block_index is not None and partial_block_index < len(block_ids_by_group):
-                    partial_key = self._make_layerwise_partial_key(
-                        request,
-                        group_id,
-                        partial_block_index,
-                        request.target_token_len,
-                    )
-                    partial_gva = self._allocated_gvas.get(partial_key)
-                    if partial_gva is None:
-                        allocated = self.m_store.batch_alloc(
-                            [partial_key],
-                            [alloc_size],
-                        )
-                        partial_gva = allocated[0] if allocated else 0
-                        if partial_gva > 0:
-                            self._allocated_gvas[partial_key] = partial_gva
-                            all_group_save_keys.append(partial_key)
-                        else:
-                            logger.error(
-                                "alloc_gvas: partial allocation failed req=%s group=%d block=%d gva=%d",
-                                request.req_id,
-                                group_id,
-                                partial_block_index,
-                                partial_gva,
-                            )
-                    # Partial keys are request-scoped; do not retain them forever.
-                    self._allocated_gvas.pop(partial_key, None)
-                    request.partial_save_gva_per_group[group_id] = partial_gva
-
-                logger.debug(
-                    "alloc_gvas: req=%s group=%d eff_bs=%d save_blocks=[%d,%d) "
-                    "new_keys=%d cached_keys=%d alloc_size=%d",
-                    request.req_id,
-                    group_id,
-                    effective_block_size,
-                    save_start_block,
-                    save_end_block,
-                    len(new_keys),
-                    len(block_gvas) - len(new_keys),
-                    alloc_size,
-                )
-
-                # Pad block_gvas to match block_ids length (fill 0 for blocks before save_start)
-                full_gvas = [0] * len(block_ids_by_group)
-                for i, gva in enumerate(block_gvas):
-                    if save_start_block + i < len(full_gvas):
-                        full_gvas[save_start_block + i] = gva
-
-                all_group_gvas.append(np.asarray(full_gvas, dtype=np.int64))
-                all_group_block_ids.append(np.asarray(block_ids_by_group, dtype=np.int64))
-
-            if all_group_gvas:
-                request.save_keys = all_group_save_keys
-                request.block_gvas_by_group_np = all_group_gvas
-                request.block_ids_by_group_np = all_group_block_ids
-                request.block_gvas_np = all_group_gvas[0]
-                request.gva_block_offset = 0
-
-    def _prepare_load_gvas(self, requests: list[ReqMeta]) -> None:
-        """Fetch per-rank GVA and acquire read lease for the load path.
-
-        memcache requires batch_copy (read) to find the blob in the per-process
-        gvaBlobTracker with a valid lease. The scheduler only checks existence
-        (batch_is_exist) to decide the load range; before batch_copy(G2L) the
-        worker must, for its own per-rank keys:
-          1. batch_get_key_info to fetch the GVA (fills block_gvas_np)
-          2. batch_add_lease to register the blob locally + acquire a read lease
-        """
-        if not self.use_gva_layerwise:
-            return
-        for request in requests:
-            if request.load_spec is None or not request.load_spec.can_load:
-                continue
-            cached_tokens = request.load_spec.kvpool_cached_tokens
-            if not getattr(self, "use_eagle", False) and request.load_spec.kvpool_store_skip_tokens is not None:
-                cached_tokens = request.load_spec.kvpool_store_skip_tokens
-            block_hashes = request.block_hashes
-
-            all_group_load_gvas: list[np.ndarray] = []
-            all_group_load_keys: list[str] = []
-            request.partial_load_gva_per_group = [0] * self.num_kv_cache_groups
-            for group_id in range(self.num_kv_cache_groups):
-                group_block_size = self.grouped_block_size[group_id]
-                effective_block_size = group_block_size
-
-                group_block_hashes = get_block_hashes(block_hashes, effective_block_size, self.hash_block_size)
-                load_start_block = (
-                    0 if self.layerwise_offload else request.load_spec.vllm_cached_tokens // effective_block_size
-                )
-                cached_full_blocks = cached_tokens // effective_block_size
-                full_blocks = min(cached_full_blocks, len(group_block_hashes))
-
-                block_ids_by_group = (
-                    request.block_ids_by_group_np[group_id]
-                    if (request.block_ids_by_group_np is not None and group_id < len(request.block_ids_by_group_np))
-                    else request.block_ids_np
-                )
-                if block_ids_by_group is None:
-                    all_group_load_gvas.append(np.zeros(0, dtype=np.int64))
-                    continue
-                full_len = len(block_ids_by_group)
-
-                partial_block_index = self._get_partial_block_index(
-                    cached_tokens,
-                    effective_block_size,
-                    len(group_block_hashes),
-                    self.layerwise_offload,
-                )
-                if partial_block_index is not None and (
-                    partial_block_index < load_start_block or partial_block_index >= full_len
-                ):
-                    partial_block_index = None
-
-                if load_start_block >= full_blocks and partial_block_index is None:
-                    all_group_load_gvas.append(np.zeros(full_len, dtype=np.int64))
-                    continue
-
-                keys = [
-                    self._make_layerwise_gva_key(group_id, block_hash_to_str(group_block_hashes[i]))
-                    for i in range(load_start_block, full_blocks)
-                ]
-                block_indices = list(range(load_start_block, full_blocks))
-                if partial_block_index is not None:
-                    keys.append(
-                        self._make_layerwise_partial_key(
-                            request,
-                            group_id,
-                            partial_block_index,
-                            cached_tokens,
-                        )
-                    )
-                    block_indices.append(partial_block_index)
-                if not keys:
-                    all_group_load_gvas.append(np.zeros(full_len, dtype=np.int64))
-                    continue
-
-                key_infos = self.m_store.batch_get_key_info(keys)
-                gvas = []
-                valid_gva_indices = []
-                invalid_block_ids: list[int] = []
-                for ki, key, block_idx in zip(key_infos, keys, block_indices):
-                    sizes = ki.size()
-                    gva = ki.gva_list()[0] if sizes and sizes > 0 else 0
-                    gvas.append(gva)
-                    if gva > 0:
-                        valid_gva_indices.append(len(gvas) - 1)
-                    else:
-                        if block_idx < len(block_ids_by_group):
-                            invalid_block_ids.append(int(block_ids_by_group[block_idx]))
-                        logger.warning(
-                            "load_gvas: req=%s group=%d got invalid gva=%d (size=%d), block_id=%s load failed",
-                            request.req_id,
-                            group_id,
-                            gva,
-                            sizes if sizes else 0,
-                            int(block_ids_by_group[block_idx]) if block_idx < len(block_ids_by_group) else "N/A",
-                        )
-
-                # Only call batch_add_lease for keys with valid size
-                valid_keys = [keys[index] for index in valid_gva_indices]
-                if valid_keys:
-                    lease_results = self.m_store.batch_add_lease(valid_keys, LAYERWISE_READ_LEASE_TTL_MS)
-                    if len(lease_results) != len(valid_keys):
-                        raise RuntimeError(
-                            "MemCache lease returned unexpected number of results: "
-                            f"expected={len(valid_keys)}, actual={len(lease_results)}"
-                        )
-                    leased_keys = []
-                    for gva_index, lease_res in zip(valid_gva_indices, lease_results):
-                        block_idx = block_indices[gva_index]
-                        if lease_res == MEMCACHE_UNMATCHED_STATE and block_idx == partial_block_index:
-                            partial_key = keys[gva_index]
-                            for retry in range(1, PARTIAL_LEASE_RETRY_COUNT + 1):
-                                time.sleep(PARTIAL_LEASE_RETRY_INTERVAL_S)
-                                retry_results = self.m_store.batch_add_lease(
-                                    [partial_key],
-                                    LAYERWISE_READ_LEASE_TTL_MS,
-                                )
-                                if len(retry_results) != 1:
-                                    raise RuntimeError(
-                                        "MemCache partial lease retry returned "
-                                        f"unexpected number of results: {len(retry_results)}"
-                                    )
-                                lease_res = retry_results[0]
-                                if lease_res != MEMCACHE_UNMATCHED_STATE:
-                                    break
-                        block_id = int(block_ids_by_group[block_idx]) if block_idx < len(block_ids_by_group) else None
-                        if lease_res == 0:
-                            leased_keys.append(keys[gva_index])
-                        else:
-                            gvas[gva_index] = 0
-                            if block_id is not None:
-                                invalid_block_ids.append(block_id)
-                            logger.warning(
-                                "load_gvas: req=%s group=%d lease failed result=%d, block_id=%s load failed",
-                                request.req_id,
-                                group_id,
-                                lease_res,
-                                block_id,
-                            )
-                else:
-                    lease_results = []
-                    leased_keys = []
-
-                # Report invalid blocks to scheduler for recompute.
-                # Single-group models can safely report individual block IDs.
-                # Multi-group (hybrid) models must not report partial group
-                # failures, as the scheduler cannot handle inconsistent KV
-                # cache state across groups (see PR #9701 for rationale).
-                if invalid_block_ids:
-                    if self.num_kv_cache_groups == 1:
-                        with self._invalid_block_ids_lock:
-                            self._invalid_block_ids.update(invalid_block_ids)
-                    else:
-                        leased_keys_to_release = list(
-                            dict.fromkeys(
-                                [
-                                    *all_group_load_keys,
-                                    *leased_keys,
-                                ]
-                            )
-                        )
-                        if leased_keys_to_release:
-                            self.m_store.batch_remove_lease(leased_keys_to_release)
-                        raise RuntimeError(
-                            "Layerwise multi-group KV load failed and cannot "
-                            "safely fall back to per-block recomputation: "
-                            f"request={request.req_id}, "
-                            f"failed_blocks={invalid_block_ids}"
-                        )
-                all_group_load_keys.extend(leased_keys)
-
-                logger.debug(
-                    "load_gvas: req=%s group=%d eff_bs=%d load_blocks=[%d,%d) keys=%d valid_gvas=%d lease_fail=%d",
-                    request.req_id,
-                    group_id,
-                    effective_block_size,
-                    load_start_block,
-                    full_blocks,
-                    len(keys),
-                    sum(1 for g in gvas if g > 0),
-                    sum(1 for r in lease_results if r != 0),
-                )
-
-                # Pad to match block_ids_by_group length, with 0s before load_start_block
-                full_gvas = [0] * full_len
-                normal_gva_count = full_blocks - load_start_block
-                for i, gva in enumerate(gvas[:normal_gva_count]):
-                    if load_start_block + i < len(full_gvas):
-                        full_gvas[load_start_block + i] = gva
-                all_group_load_gvas.append(np.asarray(full_gvas, dtype=np.int64))
-                if partial_block_index is not None and len(gvas) > normal_gva_count:
-                    request.partial_load_gva_per_group[group_id] = gvas[normal_gva_count]
-
-            if all_group_load_gvas:
-                request.load_keys = all_group_load_keys
-                request.load_block_gvas_by_group_np = all_group_load_gvas
-                request.load_block_gvas_np = all_group_load_gvas[0]
-                request.load_gva_block_offset = 0
 
     def _build_shared_save_data(self) -> None:
         """Build shared block data once and attach to all layer save tasks.
@@ -1607,8 +1199,9 @@ class KVPoolWorker:
             for group_id, layer_idx_in_group in group_layers:
                 self._process_save_for_layer_batch(requests, physical_layer, group_id, layer_idx_in_group)
         # Protect the previous partial before allocating the next snapshot.
-        self._prepare_load_gvas(requests)
-        self._alloc_gvas_for_save(requests)
+        if self._gva_session is not None:
+            self._gva_session.prepare_load_gvas(requests)
+            self._gva_session.alloc_gvas_for_save(requests)
         self._build_shared_save_data()
         for physical_layer in range(self.num_layers):
             group_layers = self.physical_layer_to_group_layers.get(physical_layer, [(0, physical_layer)])
@@ -1663,6 +1256,10 @@ class KVPoolWorker:
             self.kv_recv_thread.raise_if_failed()
             logger.info("Layerwise %d load not done, keep waiting", self.current_layer)
         self.layer_load_finished_events[self.current_layer].clear()
+
+    def _report_invalid_blocks(self, invalid_block_ids: list[int]) -> None:
+        with self._invalid_block_ids_lock:
+            self._invalid_block_ids.update(invalid_block_ids)
 
     def get_block_ids_with_load_errors(self) -> set[int]:
         with self._invalid_block_ids_lock:

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/pool_worker.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/pool_worker.py
@@ -31,6 +31,7 @@ from vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.attention_fence im
 )
 from vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.backend import (
     backend_map,
+    use_gva_layerwise,
 )
 from vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.coordinator import (
     AscendStoreCoordinator,
@@ -154,7 +155,7 @@ class KVPoolWorker:
         self.consumer_is_to_put = extra_config.get("consumer_is_to_put", False)
         self.backend = extra_config.get("backend", "mooncake")
         self.backend_name = self.backend.lower()
-        self.use_gva_layerwise = self.use_layerwise and self.backend_name == "memcache"
+        self.use_gva_layerwise = use_gva_layerwise(self.use_layerwise, self.backend_name)
         kv_cache_groups = kv_cache_config.kv_cache_groups if kv_cache_config is not None else None
         self.use_hybrid = uses_hybrid_kv_cache(vllm_config.scheduler_config, kv_cache_groups)
         self.use_mamba = self._uses_mamba_kv_cache(self.use_hybrid, kv_cache_config)


### PR DESCRIPTION
### What this PR does / why we need it?
Behavior-preserving re-encapsulation of the memcache layerwise GVA protocol in the ascend_store KV pool. The protocol logic (key formats, allocation, leases, scheduler-side hit computation) is scattered inside KVPoolWorker/KVPoolScheduler in the generic layer and base.Backend carries memcache-specific NotImplementedError stubs. This PR:

Consolidates the protocol into a dedicated backend/gva_protocol.py (GVAKeyFactory / GVASession / GVAHitChecker).
Declares it as an optional capability via a backend registry (backend_supports / single use_gva_layerwise() derivation).
Extracts the memcache interface into GVALayerwiseCapable(ABC) and adds an on_worker_ready() lifecycle hook.
Fixes a live main regression (#14465 deleted the use_gva_layerwise derivation while set_external_slot_release_waiter still reads it, crashing connector construction).

### Does this PR introduce _any_ user-facing change?
No. Pure internal refactoring with an optional-fix; no config, API, or behavior change for users.

### How was this patch tested?
ascend_store UT suite: 309 passed / 2 failed (both pre-existing test_coordinator stub issues on the branch base, unrelated to this PR).
grep assertions: removed method names have zero residual in the repo.


- vLLM main: https://github.com/vllm-project/vllm/commit/ba07e4a48fc951300d97eb506217dd530583dea3
