### PR TITLE
[Attention][BugFix] Restore use_gva_layerwise dropped by #14465

### DIFF
--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/ascend_store_connector.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/ascend_store_connector.py
@@ -88,6 +88,8 @@ class AscendStoreConnector(KVConnectorBase_V1, SupportsHMA):
 
         extra_config = vllm_config.kv_transfer_config.kv_connector_extra_config
         self.use_layerwise = extra_config.get("use_layerwise", False)
+        backend_name = str(extra_config.get("backend", "mooncake")).lower()
+        self.use_gva_layerwise = self.use_layerwise and backend_name == "memcache"
         self.consumer_is_to_put = extra_config.get("consumer_is_to_put", False)
 
         connector_name = vllm_config.kv_transfer_config.kv_connector


### PR DESCRIPTION

### What this PR does / why we need it?
When #14465 simplified AscendStoreConnector.__init__, it accidentally dropped self.use_gva_layerwise, which set_external_slot_release_waiter() still references → MultiConnector (PD disaggregation) crashes at init. This PR restores it with the same semantics as KVPoolWorker: use_gva_layerwise = use_layerwise and backend == 'memcache'.

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
PD disaggregation (MultiConnector, proxy 9004): 400/400 requests succeed; external hit rate 89.95% (prefill) / 99.99% (decode) on GSM8K.

- vLLM main: https://github.com/vllm-project/vllm/commit/ba07e4a48fc951300d97eb506217dd530583dea3
