### PR TITLE
[Add][Kernel] expose fused GroupedMatmulSituQuant via torch.vllm_ascendC

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -58,11 +58,13 @@ set(VLLM_ASCEND_CUSTOM_OP
     ${KERNEL_FILES}
     ${CMAKE_CURRENT_SOURCE_DIR}/csrc/mla_preprocess/op_kernel/mla_preprocess_kernel.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/csrc/batch_matmul_transpose/op_kernel/batch_matmul_transpose_kernel.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/csrc/gmsq_situ_quant/op_kernel/grouped_matmul_situ_quant_kernel.cpp
 )
 
 set(VLLM_ASCEND_CUSTOM_OP_EXCLUDE_ASCEND950
     ${CMAKE_CURRENT_SOURCE_DIR}/csrc/mla_preprocess/op_kernel/mla_preprocess_kernel.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/csrc/batch_matmul_transpose/op_kernel/batch_matmul_transpose_kernel.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/csrc/gmsq_situ_quant/op_kernel/grouped_matmul_situ_quant_kernel.cpp
 )
 
 if(SOC_VERSION MATCHES "ascend950")
@@ -76,6 +78,12 @@ if(SOC_VERSION MATCHES "ascend310p.*|ascend950")
 else()
     ascendc_library(vllm_ascend_kernels SHARED
         ${VLLM_ASCEND_CUSTOM_OP}
+    )
+    # CANN experiment headers pulled in transitively by AscendC adv_api includes
+    ascendc_include_directories(vllm_ascend_kernels PRIVATE
+        ${ASCEND_CANN_PACKAGE_PATH}/include
+        ${ASCEND_CANN_PACKAGE_PATH}/include/experiment/runtime
+        ${ASCEND_CANN_PACKAGE_PATH}/include/experiment/msprof
     )
 endif()
 
@@ -200,5 +208,22 @@ target_link_options(vllm_ascend_C PRIVATE "-Wl,-rpath,$ORIGIN:$ORIGIN/lib:$ORIGI
 if(SOC_VERSION MATCHES "ascend310p.*|ascend950")
   install(TARGETS vllm_ascend_C DESTINATION ${VLLM_ASCEND_INSTALL_PATH})
 else()
-  install(TARGETS vllm_ascend_C vllm_ascend_kernels DESTINATION ${VLLM_ASCEND_INSTALL_PATH})
+  # Direct pybind exposure of the fused GMSQ operator: torch.vllm_ascendC.*
+  # (no dispatcher registration; see csrc/gmsq_situ_quant/vllm_ascendC_binding.cpp)
+  pybind11_add_module(vllm_ascendC
+    ${CMAKE_CURRENT_SOURCE_DIR}/csrc/gmsq_situ_quant/grouped_matmul_situ_quant.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/csrc/gmsq_situ_quant/vllm_ascendC_binding.cpp
+  )
+  target_include_directories(vllm_ascendC PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/csrc/gmsq_situ_quant)
+  target_link_directories(vllm_ascendC PRIVATE
+    ${TORCH_LIBRARY_DIRS}
+    ${TORCH_NPU_PATH}/lib/
+    ${ASCEND_HOME_PATH}/lib64
+  )
+  target_link_libraries(vllm_ascendC PUBLIC
+    vllm_ascend_kernels
+    ${VLLM_ASCEND_C_COMMON_LIBS}
+  )
+  target_link_options(vllm_ascendC PRIVATE "-Wl,-rpath,$ORIGIN:$ORIGIN/lib:$ORIGIN/_cann_ops_custom/vendors/custom_transformer/op_api/lib")
+  install(TARGETS vllm_ascend_C vllm_ascendC vllm_ascend_kernels DESTINATION ${VLLM_ASCEND_INSTALL_PATH})
 endif()

--- a/csrc/gmsq_situ_quant/grouped_matmul_situ_quant.cpp
+++ b/csrc/gmsq_situ_quant/grouped_matmul_situ_quant.cpp
@@ -1,0 +1,381 @@
+/*
+ * Copyright (c) 2026 Huawei Technologies Co., Ltd.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ */
+
+// GroupedMatmulSituQuant op_host.
+// Fused GMM1 (fake-A8W8) + SiTU + per-token INT8 quant, single operator.
+//
+// DEVICE-SIDE group_list parsing (this revision):
+//   The fused single-launch path performs NO host-side group_list parse. The
+//   group_list device tensor is passed straight to the kernel, which parses it
+//   on-device every forward (mE / startRow / mPadOff / sumMPad / MValid are
+//   derived in-kernel from GM). This makes the operator correct for DYNAMIC
+//   production MoE group_list (new tensor per forward OR in-place value update)
+//   while keeping the host call path zero-copy / zero-sync on cache hit.
+//
+//   The persistent FusedMetaCache key is ONLY the static weight configuration:
+//   (full weight/scale pointer set, K, N, C, group_list_type). group_list
+//   identity/values are NOT part of the key — any group_list change is handled
+//   by the on-device parse each forward.
+//
+//   The P34 expanded-w8 cache covers ALL E experts ([E,K,N] int8). On cache miss
+//   the kernel's AIV stage fills the whole cache (unpack all experts), then the
+//   AIC GEMM reads the active experts' w8 — so any group_list's active set is
+//   always covered. skipUnpack=1 (cache hit) reuses the persistent expanded w8.
+//
+//   All mechanisms preserved: column-blocked w8, single-launch 3-stage pipeline,
+//   NZ (FRACTAL_NZ) input, stacked/TensorList, capacity-padded x, gl_type 0/1.
+
+#include <algorithm>
+#include <cstdint>
+#include <optional>
+#include <tuple>
+#include <vector>
+
+#include <torch/extension.h>
+#include <torch/library.h>
+
+#include "tiling/platform/platform_ascendc.h"
+#include "torch_npu/csrc/core/npu/NPUFormat.h"
+
+#include "acl/acl_rt.h"
+#include "torch_npu/csrc/core/npu/NPUStream.h"
+#include "torch_npu/csrc/framework/OpCommand.h"
+
+#include "grouped_matmul_situ_quant.h"
+
+namespace vllm_ascend {
+
+// Device kernel launcher exported by libvllm_ascend_kernels (ccec-compiled TU
+// owns the kernel entry and the tripple-chevron launch; see op_kernel/).
+void gmsq_fused_256_impl(uint32_t blockDim, void *stream, void *x, void *wPtrTbl, void *scPtrTbl,
+                          void *w8, void *acc, void *scaleF32, void *xScale, void *y, void *yScale,
+                          void *groupList, int32_t E, int32_t kNum, int32_t nNum, int32_t nBlock,
+                          int32_t NP, int32_t N, int32_t N2, int32_t K, int32_t C, int32_t glType,
+                          float beta, float invBeta, int32_t hasLinear, float linBeta,
+                          float invLinBeta, int32_t skipUnpack);
+
+constexpr int32_t GMSQ_BM = 128;
+constexpr int32_t GMSQ_BN = 128;
+constexpr int32_t GMSQ_BK = 64;
+constexpr int32_t GMSQ_EPI_M = 32;
+
+// ACL tensor format ids (see acl_base.h / torch_npu Format enum).
+constexpr int64_t ACL_FMT_ND = 2;
+constexpr int64_t ACL_FMT_FRACTAL_NZ = 29;
+
+// ---------------------------------------------------------------------------
+// Persistent device-side metadata cache for the FUSED single-launch path.
+// Key = static weight configuration ONLY (weights are static during inference):
+//   fullWPtrs/fullSPtrs — data_ptr of every expert's weight / weight_scale
+//   K, N, C            — tensor shapes
+//   glType             — group_list interpretation mode (0 cumsum / 1 count)
+// group_list identity is deliberately NOT in the key (it changes every forward
+// in production MoE; the kernel parses it on-device each forward).
+// ---------------------------------------------------------------------------
+struct FusedMetaCache {
+    // key
+    std::vector<uintptr_t> fullWPtrs;
+    std::vector<uintptr_t> fullSPtrs;
+    int64_t K = 0;
+    int64_t N = 0;
+    int64_t C = 0;
+    int64_t glType = 0;
+    // NZ -> ND one-time converted tensors (all E, kept alive).
+    bool srcIsNz = false;
+    std::vector<at::Tensor> ndWeights;
+    std::vector<at::Tensor> ndScales;
+    // Strong refs to ORIGINAL weight/weight_scale tensors (all E) so the
+    // allocator cannot reuse their data_ptr while this cache is alive.
+    std::vector<at::Tensor> weightRefs;
+    std::vector<at::Tensor> scaleRefs;
+    // device tensors (static per weight config)
+    at::Tensor tbl;     // int32 [4*E] = wPtrV(2E) + scPtrV(2E)
+    at::Tensor wsFlat;  // workspace (accWs + scaleF32)
+    int64_t scOff = 0;
+    int64_t accOffWs = 0;
+    int64_t scOffWs = 0;
+    int64_t accBytes = 0;
+    int64_t scBytes = 0;
+    int32_t kNum = 0;
+    int32_t nNum256 = 0;
+    int32_t gemmNBlock = 1024;  // P54: MTE2 load-balance N-block, computed ONCE per
+                                // cache build (removed from steady-state launch path)
+    int64_t wBytes = 0;   // E*K*N
+    int64_t accRows = 0;  // C + 128*E (max padded rows)
+    bool valid = false;
+};
+static FusedMetaCache g_fusedCache;
+
+// P34: expanded-w8 persistent cache, ALL experts [E,K,N] int8. Keyed on the
+// full weight pointer set + shapes (static). A hit lets the kernel skip the
+// whole unpack phase; a miss triggers a one-time in-kernel cache fill.
+static std::vector<uintptr_t> g_cachedWPtrs;
+static int64_t g_cachedK = 0;
+static int64_t g_cachedN = 0;
+static at::Tensor g_cachedW8;
+
+// Return an ND tensor for `t` (original if already ND, else FRACTAL_NZ -> ND).
+static at::Tensor EnsureNd(const at::Tensor &t, std::vector<at::Tensor> &converted)
+{
+    if (at_npu::native::get_npu_format(t) == ACL_FMT_ND) {
+        return t;
+    }
+    at::Tensor nd = at_npu::native::npu_format_cast(t, ACL_FMT_ND);
+    converted.push_back(nd);
+    return nd;
+}
+
+static std::vector<int32_t> BuildPtrVec(const std::vector<uintptr_t> &ptrs)
+{
+    std::vector<int32_t> v;
+    v.reserve(ptrs.size() * 2);
+    for (uintptr_t p : ptrs) {
+        v.push_back(static_cast<int32_t>(static_cast<uint32_t>(p & 0xFFFFFFFFu)));
+        v.push_back(static_cast<int32_t>(p >> 32));
+    }
+    return v;
+}
+
+std::tuple<at::Tensor, at::Tensor> grouped_matmul_situ_quant(
+    const at::Tensor &x, at::TensorList weight, at::TensorList weight_scale,
+    const at::Tensor &x_scale, const at::Tensor &group_list, at::TensorList weight_assist_matrix,
+    double beta, std::optional<double> linear_beta, int64_t group_list_type)
+{
+    TORCH_CHECK(x.dim() == 2, "x must be [M, K]");
+    TORCH_CHECK(x.scalar_type() == at::kChar, "x must be int8");
+    TORCH_CHECK(x.is_contiguous(), "x must be contiguous");
+    TORCH_CHECK(x_scale.scalar_type() == at::kFloat, "x_scale must be float32");
+    TORCH_CHECK(!weight.empty(), "weight list must be non-empty");
+    TORCH_CHECK(weight.size() == weight_scale.size(), "weight/weight_scale size mismatch");
+    TORCH_CHECK(weight_assist_matrix.empty() || weight_assist_matrix.size() == weight.size(),
+                "weight_assist_matrix size mismatch");
+    TORCH_CHECK(group_list_type == 0 || group_list_type == 1, "group_list_type must be 0 or 1");
+
+    auto ascendcPlatform = platform_ascendc::PlatformAscendCManager::GetInstance();
+    int32_t aivCoreNum = static_cast<int32_t>(ascendcPlatform->GetCoreNumAiv());
+    int32_t aicCoreNum = static_cast<int32_t>(ascendcPlatform->GetCoreNumAic());
+    TORCH_CHECK(aivCoreNum > 0 && aicCoreNum > 0, "failed to query core numbers");
+
+    int64_t C = x.sizes()[0];      // x rows (capacity, >= M_valid)
+    int64_t K = x.sizes()[1];
+    int64_t experts = static_cast<int64_t>(weight.size());
+    int64_t NP = weight[0].sizes()[1];  // packed N/8 per row
+    int64_t N = NP * 8;
+    int64_t N2 = N / 2;
+    TORCH_CHECK(K % GMSQ_BK == 0, "K must be a multiple of 64");
+    TORCH_CHECK(N % GMSQ_BN == 0, "N must be a multiple of 128");
+    TORCH_CHECK(N2 % GMSQ_BN == 0, "N/2 must be a multiple of 128");
+    TORCH_CHECK(weight[0].scalar_type() == at::kInt, "weight must be int32 packed");
+    TORCH_CHECK(weight_scale[0].scalar_type() == at::kLong, "weight_scale must be int64 carrier");
+
+    auto devOptI8 = at::device(at::kPrivateUse1).dtype(at::kChar);
+    auto devOptI32 = at::device(at::kPrivateUse1).dtype(at::kInt);
+    auto devOptF32 = at::device(at::kPrivateUse1).dtype(at::kFloat);
+
+    // outputs: y [C, N2] int8, y_scale [C] fp32 (only first M_valid rows meaningful)
+    at::Tensor y = at::empty({C, N2}, devOptI8);
+    at::Tensor y_scale = at::empty({C}, devOptF32);
+
+    // EP empty rank (M_valid == 0): x may be [0, K] with an all-zero group_list
+    // (short requests under TP8+EP leave some ranks without routed tokens). All
+    // parameter validation is done above and the outputs are already empty with
+    // the right shapes — return without building caches, reading group_list or
+    // launching the kernel. A C > 0 input whose device-side group_list is all
+    // zero stays on the normal launch path; the kernel tolerates
+    // sum(group_list) == 0 (the P54 waveBatch clamp keeps batches at 0, so no
+    // tile is scheduled and no cross-core flag pair is exercised).
+    if (C == 0) {
+        return {y, y_scale};
+    }
+
+    float betaF = static_cast<float>(beta);
+    float invBeta = 1.0f / betaF;
+    int32_t hasLinear = linear_beta.has_value() ? 1 : 0;
+    float lbF = hasLinear ? static_cast<float>(*linear_beta) : 1.0f;
+    float invLb = hasLinear ? 1.0f / lbF : 1.0f;
+
+    // ---- FUSED single-launch path (device-side group_list parse) ----
+    int32_t nNum256 = static_cast<int32_t>(N / 256);
+    bool fusedEligible = (N % 256 == 0) && (nNum256 <= 128) && (experts > 0);
+    if (fusedEligible) {
+        // Cheap host-side key (no H2D/D2H, no sync): full pointer sets + shapes +
+        // gl_type. group_list is deliberately NOT in the key.
+        std::vector<uintptr_t> fullWPtrs(static_cast<size_t>(experts));
+        std::vector<uintptr_t> fullSPtrs(static_cast<size_t>(experts));
+        bool ptrsOk = true;
+        for (int64_t e = 0; e < experts; e++) {
+            if (weight[e].data_ptr() == nullptr || weight_scale[e].data_ptr() == nullptr) {
+                ptrsOk = false;
+                break;
+            }
+            fullWPtrs[static_cast<size_t>(e)] = reinterpret_cast<uintptr_t>(weight[e].data_ptr());
+            fullSPtrs[static_cast<size_t>(e)] = reinterpret_cast<uintptr_t>(weight_scale[e].data_ptr());
+            int64_t wfmt = at_npu::native::get_npu_format(weight[e]);
+            if (wfmt != ACL_FMT_ND && wfmt != ACL_FMT_FRACTAL_NZ) {
+                ptrsOk = false;
+            }
+        }
+
+        FusedMetaCache &fc = g_fusedCache;
+        bool hit = ptrsOk && fc.valid && (fc.K == K) && (fc.N == N) && (fc.C == C) &&
+                   (fc.glType == group_list_type) && (fc.fullWPtrs == fullWPtrs) &&
+                   (fc.fullSPtrs == fullSPtrs) && fc.tbl.defined() && fc.wsFlat.defined();
+
+        if (!hit) {
+            // ---- CACHE MISS: build static pointer tables + workspace (no D2H) ----
+            fc.ndWeights.clear();
+            fc.ndScales.clear();
+            fc.weightRefs.clear();
+            fc.scaleRefs.clear();
+            // pointer tables for ALL experts (expert index = table index)
+            std::vector<uintptr_t> wPtrsAll;
+            std::vector<uintptr_t> scPtrsAll;
+            wPtrsAll.reserve(static_cast<size_t>(experts));
+            scPtrsAll.reserve(static_cast<size_t>(experts));
+            for (int64_t e = 0; e < experts; e++) {
+                at::Tensor wNd = EnsureNd(weight[static_cast<size_t>(e)], fc.ndWeights);
+                at::Tensor sNd = EnsureNd(weight_scale[static_cast<size_t>(e)], fc.ndScales);
+                fc.weightRefs.push_back(weight[static_cast<size_t>(e)]);
+                fc.scaleRefs.push_back(weight_scale[static_cast<size_t>(e)]);
+                TORCH_CHECK(wNd.is_contiguous(), "weight[e] must be contiguous (ND)");
+                TORCH_CHECK(sNd.is_contiguous(), "weight_scale[e] must be contiguous (ND)");
+                wPtrsAll.push_back(reinterpret_cast<uintptr_t>(wNd.data_ptr()));
+                scPtrsAll.push_back(reinterpret_cast<uintptr_t>(sNd.data_ptr()));
+            }
+            std::vector<int32_t> wPtrV = BuildPtrVec(wPtrsAll);
+            std::vector<int32_t> scPtrV = BuildPtrVec(scPtrsAll);
+            int64_t wPtrLen = static_cast<int64_t>(wPtrV.size());
+            int64_t scOff = wPtrLen;
+            int64_t tblLen = wPtrLen + static_cast<int64_t>(scPtrV.size());
+            std::vector<int32_t> tblV;
+            tblV.reserve(static_cast<size_t>(tblLen));
+            tblV.insert(tblV.end(), wPtrV.begin(), wPtrV.end());
+            tblV.insert(tblV.end(), scPtrV.begin(), scPtrV.end());
+            at::Tensor tblCpu = at::from_blob(
+                tblV.data(), {tblLen}, [](void *) {}, at::TensorOptions().dtype(at::kInt));
+            at::Tensor tbl = at::empty({tblLen}, devOptI32);
+            tbl.copy_(tblCpu, /*non_blocking=*/false);  // H2D — one-time per weight config
+
+            // workspace with MAX bounds (device-side group_list parse determines the
+            // actual active rows; we allocate the worst case C + 64*E padded rows).
+            auto align64 = [](int64_t v) { return (v + 63) / 64 * 64; };
+            int64_t wBytes = experts * K * N;
+            int64_t accRows = C + 128 * experts;  // max sumMPad (BM=128)
+            // P49: accumulator is now half (epilogue dequant int32->half), halving
+            // the GM intermediate traffic vs. the int32 baseline.
+            int64_t accBytes = accRows * N * static_cast<int64_t>(sizeof(at::Half));
+            int64_t scBytes = experts * 2 * N2 * static_cast<int64_t>(sizeof(float));
+            int64_t accOffWs = align64(wBytes);
+            int64_t scOffWs = align64(accOffWs + accBytes);
+            int64_t wsTotal = scOffWs + scBytes;
+            at::Tensor wsFlat = at::empty({wsTotal}, devOptI8);
+
+            fc.fullWPtrs = std::move(fullWPtrs);
+            fc.fullSPtrs = std::move(fullSPtrs);
+            fc.K = K; fc.N = N; fc.C = C; fc.glType = group_list_type;
+            fc.tbl = tbl;
+            fc.scOff = scOff;
+            fc.accOffWs = accOffWs; fc.scOffWs = scOffWs;
+            fc.accBytes = accBytes; fc.scBytes = scBytes;
+            fc.kNum = static_cast<int32_t>(K / GMSQ_BK);
+            fc.nNum256 = nNum256;
+            fc.wBytes = wBytes;
+            fc.accRows = accRows;
+            fc.wsFlat = wsFlat;  // plain copy (refcount) — avoids move-reorder hazards
+            fc.valid = true;
+
+            // P54: MTE2 load-balance N-block scheduling computed ONCE per weight
+            // config (cache build), removing the per-call scalar scheduling loop
+            // from the steady-state launch path. Same first-principles rule as the
+            // original per-call loop: critB = waves*blk minimized, largest blk on
+            // ties to minimize A re-fetch / per-tile scalar overhead.
+            {
+                int32_t cores = aicCoreNum;
+                int64_t bestCritB = INT64_MAX;
+                int32_t gblock = 1024;
+                for (int32_t blk = 1024; blk >= 256; blk -= 256) {
+                    if (N % blk != 0) {
+                        continue;  // clean tiling only (N is a multiple of 256)
+                    }
+                    int64_t tiles = experts * (N / blk);
+                    int32_t waves = static_cast<int32_t>((tiles + cores - 1) / cores);
+                    int64_t critB = static_cast<int64_t>(waves) * blk;
+                    if (critB < bestCritB) {
+                        bestCritB = critB;
+                        gblock = blk;
+                    }
+                }
+                fc.gemmNBlock = gblock;
+            }
+        }
+
+        // ---- STEADY STATE (cache hit): pure kernel launch below ----
+        at::Tensor wPtrTf = fc.tbl.narrow(0, 0, static_cast<int64_t>(experts * 2));
+        at::Tensor scPtrTf = fc.tbl.narrow(0, fc.scOff, static_cast<int64_t>(experts * 2));
+        at::Tensor accWs = fc.wsFlat.narrow(0, fc.accOffWs, fc.accBytes).view(at::kHalf);
+        at::Tensor scaleF32 = fc.wsFlat.narrow(0, fc.scOffWs, fc.scBytes).view(at::kFloat);
+
+        // P34 expanded-w8 cache (ALL experts, static key).
+        bool w8Hit = (g_cachedK == fc.K) && (g_cachedN == fc.N) &&
+                     (g_cachedWPtrs == fc.fullWPtrs) && g_cachedW8.defined() &&
+                     (g_cachedW8.numel() == fc.wBytes);
+        if (!w8Hit) {
+            g_cachedWPtrs = fc.fullWPtrs;
+            g_cachedK = fc.K;
+            g_cachedN = fc.N;
+            g_cachedW8 = at::empty({fc.wBytes}, devOptI8);
+        }
+        at::Tensor wInt8 = g_cachedW8;
+        int32_t skipUnpack = w8Hit ? 1 : 0;
+
+        int32_t E32f = static_cast<int32_t>(experts);
+        int32_t NP32f = static_cast<int32_t>(NP);
+        int32_t N32f = static_cast<int32_t>(N);
+        int32_t N232f = static_cast<int32_t>(N2);
+        int32_t K32f = static_cast<int32_t>(K);
+        int32_t C32f = static_cast<int32_t>(C);
+        int32_t glType32 = static_cast<int32_t>(group_list_type);
+
+        // P54: N-block scheduling was computed once per cache build (see the
+        // cache-miss path above); the steady-state launch path just reads it.
+        int32_t gemmNBlock = fc.gemmNBlock;
+
+        int32_t kNumV = fc.kNum;
+        int32_t nNum256V = fc.nNum256;
+        uint32_t fusedBlockDim = static_cast<uint32_t>(aicCoreNum);
+        aclrtStream gmsqStream = c10_npu::getCurrentNPUStream().stream();
+        at_npu::native::OpCommand opCmd;
+        opCmd.Name("grouped_matmul_situ_quant");
+        opCmd.SetCustomHandler(
+            [gmsqStream, fusedBlockDim, x, wPtrTf, scPtrTf, wInt8, accWs, scaleF32, x_scale, y,
+             y_scale, group_list, E32f, kNumV, nNum256V, gemmNBlock, NP32f, N32f, N232f, K32f,
+             C32f, glType32, betaF, invBeta, hasLinear, lbF, invLb, skipUnpack]() -> int {
+                gmsq_fused_256_impl(fusedBlockDim, gmsqStream, x.data_ptr(), wPtrTf.data_ptr(),
+                                     scPtrTf.data_ptr(), wInt8.data_ptr(), accWs.data_ptr(),
+                                     scaleF32.data_ptr(), x_scale.data_ptr(), y.data_ptr(),
+                                     y_scale.data_ptr(), group_list.data_ptr(), E32f, kNumV,
+                                     nNum256V, gemmNBlock, NP32f, N32f, N232f, K32f, C32f,
+                                     glType32, betaF, invBeta, hasLinear, lbF, invLb,
+                                     skipUnpack);
+                return 0;
+            });
+        opCmd.Run();
+        return {y, y_scale};
+    }
+
+    // The fused single-launch path is the only path: TORCH_CHECK(N2 %% GMSQ_BN == 0)
+    // above (GMSQ_BN=128) forces N %% 256 == 0, and fusedEligible gates nNum256 <= 128.
+    // No 4-kernel fallback exists in this MMImplType delivery.
+    TORCH_CHECK(fusedEligible,
+                "unsupported shape for fused kernel: N must be a multiple of 256 and N/256 <= 128");
+    return {y, y_scale};
+}
+
+}  // namespace vllm_ascend

--- a/csrc/gmsq_situ_quant/grouped_matmul_situ_quant.h
+++ b/csrc/gmsq_situ_quant/grouped_matmul_situ_quant.h
@@ -1,0 +1,31 @@
+/* Copyright (c) 2026 Huawei Technologies Co., Ltd.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ */
+
+// Fused grouped matmul (fake-A8W8) + SiTU + per-token INT8 quant, single launch
+// (GroupedMatmulSituQuant). Vendored from the A3 fused-operator delivery and
+// adapted to the vllm-ascend extension build.
+#ifndef VLLM_ASCEND_GMSQ_SITU_QUANT_H_
+#define VLLM_ASCEND_GMSQ_SITU_QUANT_H_
+
+#include <optional>
+#include <tuple>
+#include <vector>
+
+#include <ATen/ATen.h>
+
+namespace vllm_ascend {
+
+std::tuple<at::Tensor, at::Tensor> grouped_matmul_situ_quant(
+    const at::Tensor &x, at::TensorList weight, at::TensorList weight_scale,
+    const at::Tensor &x_scale, const at::Tensor &group_list, at::TensorList weight_assist_matrix,
+    double beta, std::optional<double> linear_beta, int64_t group_list_type);
+
+}  // namespace vllm_ascend
+
+#endif  // VLLM_ASCEND_GMSQ_SITU_QUANT_H_

--- a/csrc/gmsq_situ_quant/op_kernel/grouped_matmul_situ_quant_kernel.cpp
+++ b/csrc/gmsq_situ_quant/op_kernel/grouped_matmul_situ_quant_kernel.cpp
@@ -1,0 +1,919 @@
+/*
+ * Copyright (c) 2026 Huawei Technologies Co., Ltd.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ */
+
+// AscendC fused kernel for GMM1 (fake-A8W8) + SiTU + per-token INT8 quant.
+//
+// Production-base fusion (this revision): the GEMM engine is the CANN
+// production static-tiling MatmulImpl<A int8 ND, B int8 NZ, C int32 ND> path --
+// the same mechanism as production aclnnGroupedMatmulWeightNz fake-A8W8. The
+// static tiling is built with GetMatmulApiTiling over the production GenGmmConf
+// field set (basicM=128/basicN=256/basicK=128, singleCoreM=128/singleCoreN=1024/
+// singleCoreK=8192, enVecND2NZ, INNER_PRODUCT) plus the production 8 static
+// tiling overrides (depthA1/B1=8, stepM/N=1, stepKa/Kb=4, dbL0A/B=2, dbL0C=1).
+//
+// Weight path: the AIV stage expands packed INT4-in-INT32 -> INT8 directly into
+// FRACTAL_NZ layout (16 DataCopyPad [16,32] blocks per [32,256] strip), so the
+// AIC feeds MatmulImpl a production-compatible NZ B tensor. On a P34 cache hit
+// the whole [E,K,N] NZ workspace is reused (skipUnpack=1).
+//
+// AIC GEMM tiles (expert, M-tile, N-tile) with BM=128 / BN=256, sync
+// IterateAll<true>, writing int32 acc [sumMPad, N] into GM before the wave
+// handshake (FLAG_WAVE_READY) releases the AIV SiTU+quant epilogue.
+//
+// All capabilities preserved (regression must pass): FusedMetaCache
+// persistent host meta, no per-call H2D / stream sync on host (NPUGraph /
+// torch.compile usable), device-side group_list parse (AIC GM-direct read, AIV
+// UB parse), ND/NZ weight input (host converts ND->NZ), stacked/TensorList dual
+// organization, capacity pruning, group_list_type 0/1, P34 persistent
+// expanded-w8 cache (skipUnpack).
+//
+// Rewritten by mechanism from the CANN Open Software License sources
+// (ops_transformer/ascendc/grouped_matmul/*), not copied verbatim.
+
+#include "kernel_operator.h"
+#include "adv_api/matmul_intf.h"
+
+using AscendC::DataCopyExtParams;
+using AscendC::DataCopyPadExtParams;
+using AscendC::GlobalTensor;
+using AscendC::LocalTensor;
+using AscendC::TBuf;
+using AscendC::TQue;
+using AscendC::TPipe;
+
+namespace {
+
+constexpr int32_t BM = 128;               // GEMM M tile (production baseM)
+constexpr int32_t BN = 256;               // GEMM N tile (production baseN / L0B tile)
+                                           // (runtime N-block nBlock, multiple of 256, is host-chosen
+                                           // for MTE2 B-fetch load balance; default 1024 = singleCoreN)
+constexpr int32_t UNPACK_BK = 64;         // unpack K rows per strip
+constexpr int32_t UNPACK_SUB_K = 32;      // unpack rows per AIV sub-block
+constexpr int32_t FUSED_UNPACK_BN = 256;  // unpack strip width (== BN)
+constexpr int32_t FUSED_UNPACK_BNP = 32;  // int32 carriers per strip row
+constexpr int32_t ACT_RED_CHUNK = 1024;   // ReduceMax chunk width
+constexpr int32_t SCALE_SUB = 256;        // fp32 outputs per de-interleave chunk
+constexpr uint16_t FLAG_WAVE_READY = 8;   // AIC -> AIV (PIPE_FIX): wave-batch tiles in GM
+constexpr int32_t SYNC_THROTTLE = 14;     // max unconsumed cross-core sets
+constexpr int32_t P54_SMALL_M = 64;       // P54 header-opt: mValid <= 64 collapses the
+                                           // per-wave cross-core handshake into ONE sync
+
+// ---------------------------------------------------------------------------
+// Production MMImplType GEMM types (fake-A8W8: int8 ND x int8 NZ -> half ND).
+// C=half enables the MatmulImpl epilogue dequant (int32 L0C * fp32 channel
+// scale -> half, VDEQF16 fixpipe) which halves the GM accumulator traffic.
+// ---------------------------------------------------------------------------
+using AType = AscendC::MatmulType<AscendC::TPosition::GM, CubeFormat::ND, int8_t, false>;
+using BType = AscendC::MatmulType<AscendC::TPosition::GM, CubeFormat::NZ, int8_t, false>;
+using CType = AscendC::MatmulType<AscendC::TPosition::GM, CubeFormat::ND, half, false>;
+using BiasType = AscendC::MatmulType<AscendC::TPosition::GM, CubeFormat::ND, half, false>;
+
+// Production GenGmmConf(isND2NZ=true) field set, rebuilt by field assignment
+// (C++17-safe; no designated initializers). Every field whose value differs
+// from its default member initializer is set explicitly; the rest keep the
+// struct defaults, which match the production designated-initializer list.
+// MatmulConfig / CubeFormat / BatchMode / IterateMode / IterateOrder /
+// ScheduleType are declared at GLOBAL scope in matmul_config.h (no namespace).
+__aicore__ inline constexpr MatmulConfig MakeGmmConf()
+{
+    MatmulConfig conf{};
+    conf.doMultiDataLoad = true;
+    conf.basicM = 128;
+    conf.basicN = 256;
+    conf.basicK = 128;
+    conf.enVecND2NZ = true;
+    conf.singleCoreM = 128;
+    conf.singleCoreN = 1024;
+    conf.singleCoreK = 8192;
+    conf.enUnitFlag = true;
+    conf.enableInit = false;
+    conf.batchMode = BatchMode::NONE;
+    conf.enableEnd = true;
+    conf.enableGetTensorC = true;
+    conf.enableSetOrgShape = true;
+    conf.enableSetBias = false;
+    conf.enableSetTail = true;
+    conf.enableQuantVector = true;
+    conf.enableSetDefineData = false;
+    conf.iterateMode = IterateMode::ITERATE_MODE_DEFAULT;
+    conf.enableReuse = true;
+    conf.enableUBReuse = true;
+    conf.iterateOrder = IterateOrder::UNDEF;
+    conf.scheduleType = ScheduleType::INNER_PRODUCT;
+    conf.isBiasBatch = true;
+    return conf;
+}
+
+// Production GetGmmMatmulApiTiling(isWeightNZ=true, transB=false) + the 8
+// static-tiling overrides applied to the returned MatmulApiStaticTiling.
+__aicore__ inline constexpr auto MakeGmmStaticTiling()
+{
+    auto tiling =
+        AscendC::GetMatmulApiTiling<AType, BType, CType, BiasType>(MakeGmmConf());
+    tiling.depthA1 = 8;
+    tiling.depthB1 = 8;
+    tiling.stepM = 1;
+    tiling.stepN = 1;
+    tiling.stepKa = 4;
+    tiling.stepKb = 4;
+    tiling.dbL0A = 2;
+    tiling.dbL0B = 2;
+    // dbL0C must stay 1: the L0C accumulator is STILL int32 (GetMmDstType<int8>),
+    // because the int32->half dequant runs in the fixpipe only during the
+    // L0C->GM copy-out. baseM(128)*baseN(256)*sizeof(int32) = 128KB already fills
+    // the L0C, so dbL0C=2 remains impossible even with a half C output. The C=half
+    // win is the halved GM accumulator traffic, not L0C double buffering.
+    tiling.dbL0C = 1;
+    return tiling;
+}
+constexpr static auto staticCFG = MakeGmmStaticTiling();
+
+// The production MatmulImpl<A, B, C, Bias, staticCFG> type (MMImplType::MT).
+using GmmMt = AscendC::MatmulImpl<AType, BType, CType, BiasType, staticCFG>;
+
+__aicore__ inline float Int32BitsToFloat(int32_t v)
+{
+    union {
+        int32_t i;
+        float f;
+    } u;
+    u.i = v;
+    return u.f;
+}
+
+__aicore__ inline int32_t AivCoreIdx()
+{
+    return AscendC::GetBlockIdx() / AscendC::GetSubBlockNum();
+}
+
+__aicore__ inline int32_t AivSubIdx()
+{
+    return AscendC::GetBlockIdx() % AscendC::GetSubBlockNum();
+}
+
+__aicore__ inline int32_t AivCoreNum()
+{
+    int32_t n = AscendC::GetBlockNum() / AscendC::GetSubBlockNum();
+    return n > 0 ? n : 1;
+}
+
+__aicore__ inline int32_t AivSlotIdx()
+{
+    return AscendC::GetBlockIdx();
+}
+
+__aicore__ inline int32_t AivSlotNum()
+{
+    int32_t n = AscendC::GetBlockNum() * AscendC::GetSubBlockNum();
+    return n > 0 ? n : 1;
+}
+
+// Read a 64-bit GM address stored as two int32 lanes (lo, hi).
+__aicore__ inline int64_t ReadGmPtr(const GlobalTensor<int32_t> &tbl, int32_t compactIdx)
+{
+    uint32_t lo = static_cast<uint32_t>(tbl.GetValue(static_cast<uint64_t>(2 * compactIdx)));
+    int32_t hi = tbl.GetValue(static_cast<uint64_t>(2 * compactIdx + 1));
+    return (static_cast<int64_t>(hi) << 32) | static_cast<int64_t>(lo);
+}
+
+// On-device group_list accessor for the AIC (cube) core. The AIC must NOT touch
+// VECCALC UB (scalar SetValue/GetValue on a vector-calc TBuf hangs on the cube
+// core), so this variant reads group_list directly from GM on each accessor
+// call. E <= 128 -> the per-tile scan is small; the AIV stage does the
+// heavyweight on-device parse into local UB.
+// Layout follows group_list GM: [E] int64, glType 0 (cumsum) / 1 (count).
+class DeviceGlMetaGm {
+public:
+    static constexpr int32_t MAX_E = 128;     // matches host "E <= 128" assumption
+    static constexpr int32_t MAX_MBLK = 256;  // C/128 + E <= 256 (eval max ~21)
+
+    __aicore__ inline DeviceGlMetaGm() {}
+
+    // Per-expert M dynamic split: precompute the whole (expert, padded-row,
+    // start-row) mapping ONCE per forward (O(E + M_blocks) GM scalar reads),
+    // then resolve each GEMM tile in O(1) local lookups instead of three O(E)
+    // GM scalar scans (FindExpert / PadOff / Start) per tile. For decode's 120
+    // tiles x ~20 GM reads -> ~2400 GM reads become a single ~35-read pass.
+    __aicore__ inline void Init(const GlobalTensor<int64_t> &glGM, int32_t E, int32_t glType)
+    {
+        E_ = E; glType_ = glType; glGM_ = glGM;
+        int64_t prev = 0;
+        int32_t sumM = 0;
+        int32_t sumP = 0;
+        for (int32_t e = 0; e < E_; e++) {
+            int64_t gv = glGM_.GetValue(e);
+            int32_t cnt = (glType_ == 1) ? static_cast<int32_t>(gv)
+                                         : static_cast<int32_t>(gv - prev);
+            prev = gv;
+            count_[e] = cnt;
+            start_[e] = sumM;
+            padOff_[e] = sumP;
+            sumM += cnt;
+            sumP += ((cnt + BM - 1) / BM) * BM;
+        }
+        padOff_[E_] = sumP;
+        sumMPad_ = sumP;
+        sumM_ = sumM;
+        numMBlocks_ = sumP / BM;
+        int32_t e = 0;
+        for (int32_t b = 0; b < numMBlocks_; b++) {
+            int32_t rowW = b * BM;
+            while (e + 1 < E_ && rowW >= padOff_[e + 1]) {
+                ++e;
+            }
+            expertOfBlock_[b] = e;
+        }
+    }
+
+    __aicore__ inline int32_t Count(int32_t e) const { return count_[e]; }
+    __aicore__ inline int32_t Start(int32_t e) const { return start_[e]; }
+    __aicore__ inline int32_t PadOff(int32_t e) const { return padOff_[e]; }
+    __aicore__ inline int32_t SumMPad() const { return sumMPad_; }
+    // P54: real token count (M_valid) for the small-M single-sync decision.
+    __aicore__ inline int32_t SumM() const { return sumM_; }
+    __aicore__ inline int32_t ExpertOfBlock(int32_t bmG) const { return expertOfBlock_[bmG]; }
+
+private:
+    GlobalTensor<int64_t> glGM_;
+    int32_t count_[MAX_E];
+    int32_t start_[MAX_E];
+    int32_t padOff_[MAX_E + 1];
+    int32_t expertOfBlock_[MAX_MBLK];
+    int32_t E_;
+    int32_t glType_;
+    int32_t sumMPad_;
+    int32_t sumM_;
+    int32_t numMBlocks_;
+};
+
+// On-device group_list parser + accessor (device-side group_list parsing).
+// The AIV stage parses the device group_list tensor into a LOCAL UB meta buffer
+// every forward, so the meta is correct for the CURRENT (possibly dynamic)
+// production MoE group_list -- no host D2H, no glPtr in any cache key.
+// Local layout (E = expert count):
+//   [0..E)      mE        : real token count of expert e
+//   [E..2E)     startRow  : first real row of expert e inside x / y
+//   [2E..3E+1)  mPadOff   : prefix sum of padded rows (mPadOff[E] = sumMPad)
+//   [3E+1]      sumMPad
+//   [3E+2]      MValid
+class DeviceGlMeta {
+public:
+    __aicore__ inline DeviceGlMeta() {}
+
+    __aicore__ inline void Init(const GlobalTensor<int64_t> &glGM, int32_t E,
+                                int32_t glType, TPipe *pipe)
+    {
+        E_ = E;
+        glGM_ = glGM;
+        pipe->InitBuffer(metaBuf_, (3 * E + 4) * static_cast<uint32_t>(sizeof(int32_t)));
+        Parse(glType);
+    }
+
+    __aicore__ inline void Parse(int32_t glType)
+    {
+        LocalTensor<int32_t> meta = metaBuf_.Get<int32_t>();
+        int64_t prev = 0;
+        int32_t sumM = 0;
+        int32_t sumP = 0;
+        for (int32_t e = 0; e < E_; e++) {
+            int64_t gv = glGM_.GetValue(e);
+            int32_t cnt = (glType == 1) ? static_cast<int32_t>(gv)
+                                        : static_cast<int32_t>(gv - prev);
+            prev = gv;
+            meta.SetValue(e, cnt);           // mE[e]
+            meta.SetValue(E_ + e, sumM);     // startRow[e]
+            meta.SetValue(2 * E_ + e, sumP); // mPadOff[e]
+            int32_t mPad = ((cnt + BM - 1) / BM) * BM;
+            sumP += mPad;
+            sumM += cnt;
+        }
+        meta.SetValue(2 * E_ + E_, sumP);    // mPadOff[E]
+        meta.SetValue(3 * E_ + 1, sumP);     // sumMPad
+        meta.SetValue(3 * E_ + 2, sumM);     // MValid
+        AscendC::PipeBarrier<PIPE_ALL>();
+    }
+
+    __aicore__ inline int32_t PadOff(int32_t e)
+    {
+        return metaBuf_.Get<int32_t>().GetValue(2 * E_ + e);
+    }
+
+    __aicore__ inline int32_t Start(int32_t e)
+    {
+        return metaBuf_.Get<int32_t>().GetValue(E_ + e);
+    }
+
+    __aicore__ inline int32_t Count(int32_t e)
+    {
+        return metaBuf_.Get<int32_t>().GetValue(e);
+    }
+
+    __aicore__ inline int32_t SumMPad()
+    {
+        return metaBuf_.Get<int32_t>().GetValue(3 * E_ + 1);
+    }
+
+    __aicore__ inline int32_t MValid()
+    {
+        return metaBuf_.Get<int32_t>().GetValue(3 * E_ + 2);
+    }
+
+    // Owning expert of a global padded row. Empty experts have
+    // mPadOff[e] == mPadOff[e+1], so the scan steps over them.
+    __aicore__ inline int32_t FindExpert(int32_t rowW)
+    {
+        LocalTensor<int32_t> meta = metaBuf_.Get<int32_t>();
+        int32_t e = 0;
+        while (e + 1 < E_ + 1 && rowW >= meta.GetValue(2 * E_ + e + 1)) {
+            ++e;
+        }
+        return e < E_ ? e : E_ - 1;
+    }
+
+    // Owning expert of a global REAL row g (0 <= g < MValid). Empty experts
+    // have startRow[e] == startRow[e+1], so the scan steps over them.
+    __aicore__ inline int32_t FindExpertReal(int32_t g)
+    {
+        LocalTensor<int32_t> meta = metaBuf_.Get<int32_t>();
+        int32_t e = 0;
+        while (e + 1 < E_ && g >= meta.GetValue(E_ + e + 1)) {
+            ++e;
+        }
+        return e < E_ ? e : E_ - 1;
+    }
+
+private:
+    GlobalTensor<int64_t> glGM_;
+    TBuf<AscendC::TPosition::VECCALC> metaBuf_;
+    int32_t E_;
+};
+
+// ---------------------------------------------------------------------------
+// Fused GEMM (AIC): production MatmulImpl int8 ND x int8 NZ -> int32 ND.
+// Tiles are (expert, M-tile, N-tile) with BM=128 / BN=256; the acc is written
+// to [sumMPad, N] int32 GM (cross-expert padded rows). Wave-major tile order
+// (t = w*cores + core) with a wave handshake to the local AIV pair.
+// ---------------------------------------------------------------------------
+class GmsqGemmKernel256 {
+public:
+    __aicore__ inline GmsqGemmKernel256() {}
+
+    __aicore__ inline void Init(GM_ADDR x, GM_ADDR w, GM_ADDR acc, GM_ADDR scPtrTbl,
+                                const GlobalTensor<int64_t> &glGM, int32_t E, int32_t glType,
+                                int32_t K, int32_t N, int32_t nBlock, TPipe *pipe)
+    {
+        K_ = K;
+        N_ = N;
+        // Runtime N-block size (host-chosen multiple of baseN=256, <= singleCoreN
+        // 1024) for MTE2 B-fetch load balance. The MatmulImpl iterates
+        // nBlock/baseN internal baseN=256 N-tiles and REUSES A across them in
+        // L0A, instead of reloading A per 256-wide tile.
+        nBlock_ = nBlock;
+        nNum_ = (N + nBlock_ - 1) / nBlock_;
+        xGM_.SetGlobalBuffer(reinterpret_cast<__gm__ int8_t *>(x));
+        wGM_.SetGlobalBuffer(reinterpret_cast<__gm__ int8_t *>(w));
+        accGM_.SetGlobalBuffer(reinterpret_cast<__gm__ half *>(acc));
+        scPtrTblGM_.SetGlobalBuffer(reinterpret_cast<__gm__ int32_t *>(scPtrTbl));
+        // AIC: GM-direct group_list access (no VECCALC UB on the cube core).
+        meta_.Init(glGM, E, glType);
+        sumMPad_ = meta_.SumMPad();
+        totalTiles_ = (sumMPad_ / BM) * nNum_;
+        mm_.SetSubBlockIdx(0);
+        mm_.Init(static_cast<TCubeTiling *>(nullptr), pipe);
+    }
+
+    __aicore__ inline void ProcessFused(int32_t skipUnpack)
+    {
+        int32_t core = AscendC::GetBlockIdx();
+        int32_t cores = AscendC::GetBlockNum();
+        // On a P34 cache MISS the AIV stage fills the whole [E,K,N] NZ workspace
+        // first; the AIC waits on the grid-wide barrier so it reads the freshly
+        // written NZ weight. On a HIT the persistent NZ workspace is already valid.
+        if (skipUnpack == 0) {
+            AscendC::SyncAll<false>();
+        }
+        int32_t totalWaves = (totalTiles_ + cores - 1) / cores;
+        // P54 header-opt: small-M (decode/cap, mValid<=64) collapses the per-wave
+        // handshake into ONE cross-core sync (decode = 5 waves -> 5 syncs before,
+        // 1 now), removing the fixed per-wave sync/launch overhead that dominates
+        // small-M. Formula MUST match GmsqFusedAivKernel256::ActPhase (same
+        // threshold P54_SMALL_M and same expression).
+        int32_t mValid = meta_.SumM();
+        int32_t waveBatch = (mValid <= P54_SMALL_M)
+                                ? totalWaves
+                                : (totalWaves + SYNC_THROTTLE - 1) / SYNC_THROTTLE;
+        if (waveBatch < 1) {
+            waveBatch = 1;
+        }
+        for (int32_t w = 0; w < totalWaves; w++) {
+            int32_t t = w * cores + core;
+            if (t < totalTiles_) {
+                int32_t bmG = t / nNum_;
+                int32_t bn = t - bmG * nNum_;
+                int32_t rowW = bmG * BM;
+                // Per-expert M dynamic split: expert is resolved O(1) from the
+                // precomputed per-M-block map (no O(E) GM FindExpert scan).
+                int32_t e = meta_.ExpertOfBlock(bmG);
+                int32_t lr0 = rowW - meta_.PadOff(e);
+                int32_t aRow = meta_.Start(e) + lr0;
+                int32_t rowsAvail = meta_.Count(e) - lr0;
+                int32_t curM = rowsAvail < BM ? rowsAvail : BM;
+                if (curM > 0) {
+                    int32_t tailN = bn * nBlock_;
+                    int32_t curBN = N_ - tailN < nBlock_ ? N_ - tailN : nBlock_;
+                    // NZ B-tile base for expert e, N-offset tailN (non-transpose
+                    // SetWOffset == tailN * AlignUp16(K) == tailN * K, K mult 16).
+                    int64_t wBase = (int64_t)e * K_ * N_ + (int64_t)tailN * K_;
+                    mm_.SetOrgShape(meta_.Count(e), N_, K_);
+                    mm_.SetSingleShape(curM, curBN, K_);
+                    mm_.SetTensorA(xGM_[(int64_t)aRow * K_], false);
+                    mm_.SetTensorB(wGM_[wBase], false);
+                    // P49 epilogue dequant: int32 L0C -> half C with the per-channel
+                    // fp32 channel scale (fp32 bits encoded in the low 32 bits of the
+                    // ND int64 weight_scale carrier, reinterpreted as uint64). Offset
+                    // the scale base by tailN so the fixpipe reads scale[tailN + col].
+                    deqScale_.SetGlobalBuffer(
+                        reinterpret_cast<__gm__ uint64_t *>(ReadGmPtr(scPtrTblGM_, e)), N_);
+                    mm_.SetQuantVector(deqScale_[tailN]);
+                    mm_.IterateAll<true>(accGM_[(int64_t)rowW * N_ + tailN], 0);
+                }
+            }
+            if (((w + 1) % waveBatch == 0) || (w + 1 == totalWaves)) {
+                AscendC::CrossCoreSetFlag<0x2, PIPE_FIX>(FLAG_WAVE_READY);
+            }
+        }
+    }
+
+private:
+    GlobalTensor<int8_t> xGM_;
+    GlobalTensor<int8_t> wGM_;
+    GlobalTensor<half> accGM_;
+    GlobalTensor<int32_t> scPtrTblGM_;
+    GlobalTensor<uint64_t> deqScale_;
+    DeviceGlMetaGm meta_;
+    GmmMt mm_;
+    int32_t K_;
+    int32_t N_;
+    int32_t nBlock_;
+    int32_t nNum_;
+    int32_t totalTiles_;
+    int32_t sumMPad_;
+};
+
+// ---------------------------------------------------------------------------
+// Fused AIV stage: strip-ordered NZ unpack producer + wave-driven act/quant
+// consumer on every AI Core's AIV pair.
+//   Phase 0: channel-scale de-interleave (int64 carriers -> contiguous fp32),
+//     striped over all AIV slots; wave-0 SyncAll guarantees visibility.
+//   Phase 1 (P34 cache miss only): unpack the whole [E,K,N] cache into FRACTAL_NZ
+//     layout for ALL experts (any future group_list's active set is covered),
+//     then grid-sync so the AIC GEMM sees the fresh NZ weight.
+//   Phase 2: per wave batch: wait FLAG_WAVE_READY + SyncAll, then act+quant the
+//     row-blocks completed by this batch. Rows striped over all slots.
+// ---------------------------------------------------------------------------
+class GmsqFusedAivKernel256 {
+public:
+    __aicore__ inline GmsqFusedAivKernel256() {}
+
+    __aicore__ inline void Init(GM_ADDR wPtrTbl, GM_ADDR scPtrTbl, GM_ADDR w8, GM_ADDR acc,
+                                GM_ADDR scaleF32, GM_ADDR xScale, GM_ADDR y, GM_ADDR yScale,
+                                const GlobalTensor<int64_t> &glGM, int32_t E, int32_t glType,
+                                int32_t kNum, int32_t nNum, int32_t NP, int32_t N, int32_t N2,
+                                int32_t K, int32_t C, float beta, float invBeta,
+                                int32_t hasLinear, float linBeta, float invLinBeta,
+                                int32_t nBlock, TPipe *pipe, int32_t skipUnpack)
+    {
+        skipUnpack_ = skipUnpack;
+        E_ = E;
+        kNum_ = kNum;
+        nNum_ = nNum;
+        NP_ = NP;
+        N_ = N;
+        N2_ = N2;
+        K_ = K;
+        M_ = C;  // xs buffer sized to capacity C (M_valid parsed on-device <= C)
+        beta_ = beta;
+        invBeta2_ = 2.0f * invBeta;
+        hasLinear_ = hasLinear;
+        linBeta_ = linBeta;
+        invLinBeta2_ = 2.0f * invLinBeta;
+        // device-side group_list parse -> local UB meta
+        meta_.Init(glGM, E, glType, pipe);
+        // N-block count for the GEMM wave (must MATCH the AIC's nNum_ which now
+        // uses the runtime nBlock, not the 256-wide unpack strip count nNum_).
+        nBlock_ = nBlock;
+        nBlockNum_ = (N + nBlock_ - 1) / nBlock_;
+        gemmTiles_ = (meta_.SumMPad() / BM) * nBlockNum_;
+
+        ptrTblGM_.SetGlobalBuffer(reinterpret_cast<__gm__ int32_t *>(wPtrTbl));
+        scPtrTblGM_.SetGlobalBuffer(reinterpret_cast<__gm__ int32_t *>(scPtrTbl));
+        w8GM_.SetGlobalBuffer(reinterpret_cast<__gm__ int8_t *>(w8));
+        accGM_.SetGlobalBuffer(reinterpret_cast<__gm__ half *>(acc));
+        xsGM_.SetGlobalBuffer(reinterpret_cast<__gm__ float *>(xScale));
+        yGM_.SetGlobalBuffer(reinterpret_cast<__gm__ int8_t *>(y));
+        ysGM_.SetGlobalBuffer(reinterpret_cast<__gm__ float *>(yScale));
+
+        pipe->InitBuffer(inQueue_, 2, UNPACK_SUB_K * FUSED_UNPACK_BNP * sizeof(int32_t));
+        pipe->InitBuffer(upkH16Buf_, UNPACK_SUB_K * FUSED_UNPACK_BN * sizeof(half));
+        pipe->InitBuffer(outQueue_, 2, UNPACK_SUB_K * FUSED_UNPACK_BN * sizeof(int8_t));
+        uint32_t rowF32 = (uint32_t)(N2 * sizeof(float));
+        uint32_t rowH16 = (uint32_t)(N2 * sizeof(half));
+        pipe->InitBuffer(accGQueue_, 1, rowH16);
+        pipe->InitBuffer(accUQueue_, 1, rowH16);
+        pipe->InitBuffer(xsQueue_, 1, (uint32_t)(M_ * sizeof(float)));
+        pipe->InitBuffer(gBuf_, rowF32);
+        pipe->InitBuffer(uBuf_, rowF32);
+        pipe->InitBuffer(tBuf_, rowF32);
+        pipe->InitBuffer(aBuf_, rowF32);
+        pipe->InitBuffer(actH16Buf_, (uint32_t)(N2 * sizeof(half)));
+        pipe->InitBuffer(yQueue_, 1, (uint32_t)(N2 * sizeof(int8_t)));
+        pipe->InitBuffer(ysQueue_, 1, 8 * sizeof(float));
+        pipe->InitBuffer(redWorkBuf_, ACT_RED_CHUNK * sizeof(float));
+        pipe->InitBuffer(chunkMaxBuf_, 8 * sizeof(float));
+    }
+
+    __aicore__ inline void Process()
+    {
+        int32_t coreIdx = AivCoreIdx();
+        int32_t subIdx = AivSubIdx();
+        int32_t slot = AivSlotIdx();
+        int32_t slots = AivSlotNum();
+        int32_t cores = AscendC::GetBlockNum();
+        int32_t totalWaves = (gemmTiles_ + cores - 1) / cores;
+
+        // Phase 1 (P34 cache miss only): fill the whole [E,K,N] NZ cache (all
+        // experts), then grid-sync so the AIC GEMM sees the fresh NZ weight.
+        if (skipUnpack_ == 0) {
+            CacheFillUnpackAll(coreIdx, subIdx, cores);
+            AscendC::SyncAll<false>();
+        }
+        // Phase 2: wave-driven fused act+quant (expert index; no strip gating).
+        ActPhase(slot, slots, cores, totalWaves);
+    }
+
+private:
+    // Phase 1 (P34 cache miss only): fill the whole [E,K,N] FRACTAL_NZ cache
+    // for ALL experts. Distribution: (expert, bn) strips across AIV cores; both
+    // sub-blocks of a block split the K rows via subIdx.
+    __aicore__ inline void CacheFillUnpackAll(int32_t coreIdx, int32_t subIdx, int32_t cores)
+    {
+        int32_t totalStrips = E_ * nNum_;
+        for (int32_t idx = coreIdx; idx < totalStrips; idx += cores) {
+            int32_t e = idx / nNum_;
+            int32_t bn = idx % nNum_;
+            packedGM_.SetGlobalBuffer(
+                reinterpret_cast<__gm__ int32_t *>(ReadGmPtr(ptrTblGM_, e)));
+            for (int32_t bk = 0; bk < kNum_; bk++) {
+                UnpackTile(e, bn, bk, subIdx);
+            }
+        }
+    }
+
+    // One unpack tile: 32 rows x 32 int32 carriers -> 32 x 256 int8, written
+    // into FRACTAL_NZ layout. The [32,256] ND tile is 2 K-blocks x 8 N-blocks
+    // of [16,32]; each [16,32] block is scattered to its NZ position via one
+    // DataCopyPad (16 total). NZ offset for int8 (C0=32, K16=AlignUp16(K)=K):
+    //   off(k,n) = (n/32)*K*32 + (k/16)*512 + (k%16)*32 + (n%32).
+    __aicore__ inline void UnpackTile(int32_t e, int32_t bn, int32_t bk, int32_t subIdx)
+    {
+        int32_t row0 = bk * UNPACK_BK + subIdx * UNPACK_SUB_K;
+        LocalTensor<int32_t> pk = inQueue_.AllocTensor<int32_t>();
+        DataCopyExtParams cp{(uint16_t)UNPACK_SUB_K, (uint32_t)(FUSED_UNPACK_BNP * sizeof(int32_t)),
+                             (uint32_t)((NP_ - FUSED_UNPACK_BNP) * sizeof(int32_t)), 0, 0};
+        DataCopyPadExtParams<int32_t> pp{false, 0, 0, 0};
+        AscendC::DataCopyPad(pk, packedGM_[(int64_t)row0 * NP_ + bn * FUSED_UNPACK_BNP], cp, pp);
+        inQueue_.EnQue(pk);
+
+        LocalTensor<half> h16 = upkH16Buf_.Get<half>();
+        LocalTensor<int32_t> pkl = inQueue_.DeQue<int32_t>();
+        LocalTensor<AscendC::int4b_t> p4 = pkl.ReinterpretCast<AscendC::int4b_t>();
+        AscendC::Cast(h16, p4, AscendC::RoundMode::CAST_NONE, UNPACK_SUB_K * FUSED_UNPACK_BN);
+        AscendC::PipeBarrier<PIPE_V>();
+        LocalTensor<int8_t> out = outQueue_.AllocTensor<int8_t>();
+        AscendC::Cast(out, h16, AscendC::RoundMode::CAST_NONE, UNPACK_SUB_K * FUSED_UNPACK_BN);
+        inQueue_.FreeTensor(pkl);
+        outQueue_.EnQue(out);
+
+        LocalTensor<int8_t> outl = outQueue_.DeQue<int8_t>();
+        // Scatter the ND [32,256] tile into the NZ workspace: 16 [16,32] blocks.
+        // DataCopyExtParams in the UB->GM direction: blockLen is BYTES, the
+        // srcStride is the UB-side gap in 32-BYTE BLOCKS, and dstStride is the
+        // GM-side gap in BYTES (see MOV_UB_TO_OUT_ALIGN: burst_src_stride =
+        // ceil32(lenBurst)*32 + srcGap*32; burst_dst_stride = lenBurst + dstGap).
+        // Source rows sit at 256B stride (32B written, gap 224B == 7 blocks);
+        // NZ destination rows are contiguous 32B (gap 0B).
+        int64_t eBase = (int64_t)e * K_ * N_;
+        int32_t rowK = row0 / 16;  // K-block base index (16-row blocks)
+        DataCopyExtParams nzcp{static_cast<uint16_t>(16), static_cast<uint32_t>(32),
+                               static_cast<uint32_t>(7), 0, 0};
+        for (int32_t kblk = 0; kblk < 2; kblk++) {
+            int32_t srcRowBase = kblk * 16 * FUSED_UNPACK_BN;
+            int64_t dstKBase = eBase + (int64_t)(rowK + kblk) * 512;
+            for (int32_t nblk = 0; nblk < 8; nblk++) {
+                int32_t srcOff = srcRowBase + nblk * 32;
+                int64_t dstOff = dstKBase + (int64_t)(bn * 8 + nblk) * K_ * 32;
+                AscendC::DataCopyPad(w8GM_[dstOff], outl[srcOff], nzcp);
+            }
+        }
+        outQueue_.FreeTensor(outl);
+    }
+
+    // Phase 2: wave-driven fused act+quant.
+    __aicore__ inline void ActPhase(int32_t slot, int32_t slots, int32_t cores,
+                                    int32_t totalWaves)
+    {
+        LocalTensor<float> xs = xsQueue_.AllocTensor<float>();
+        DataCopyExtParams xcp{1, (uint32_t)(M_ * sizeof(float)), 0, 0, 0};
+        DataCopyPadExtParams<float> xpp{false, 0, 0, 0};
+        AscendC::DataCopyPad(xs, xsGM_[0], xcp, xpp);
+        xsQueue_.EnQue(xs);
+        LocalTensor<float> xsl = xsQueue_.DeQue<float>();
+
+        g_ = gBuf_.Get<float>();
+        u_ = uBuf_.Get<float>();
+        t_ = tBuf_.Get<float>();
+        a_ = aBuf_.Get<float>();
+        h16_ = actH16Buf_.Get<half>();
+        redWork_ = redWorkBuf_.Get<float>();
+        chunkMax_ = chunkMaxBuf_.Get<float>();
+
+        // P54 header-opt: match GmsqGemmKernel256::ProcessFused (identical
+        // P54_SMALL_M threshold and expression) so the AIC flag emission and the
+        // AIV flag wait collapse to a single cross-core sync for small M.
+        int32_t mValid = meta_.MValid();
+        int32_t waveBatch = (mValid <= P54_SMALL_M)
+                                ? totalWaves
+                                : (totalWaves + SYNC_THROTTLE - 1) / SYNC_THROTTLE;
+        if (waveBatch < 1) {
+            waveBatch = 1;
+        }
+        int32_t batches = (totalWaves + waveBatch - 1) / waveBatch;
+        // P54 merge-writes: a single sync means every accumulator is visible
+        // before the epilogue, so a tiny M (decode/cap: 1-2 rows per expert) no
+        // longer needs to be serialized row-block by row-block under BM=128
+        // padding. Stripe the REAL rows globally over all slots instead.
+        bool globalStripe = (batches == 1);
+        int32_t prevRB = 0;
+        for (int32_t b = 0; b < batches; b++) {
+            AscendC::CrossCoreWaitFlag(FLAG_WAVE_READY);
+            AscendC::SyncAll<true>();
+            int32_t completed = (b + 1) * waveBatch * cores;
+            if (completed > gemmTiles_) {
+                completed = gemmTiles_;
+            }
+            int32_t rbDone = completed / nBlockNum_;
+            if (globalStripe) {
+                ActPhaseGlobal(slot, slots, xsl, mValid);
+            } else {
+                for (int32_t rb = prevRB; rb < rbDone; rb++) {
+                    ActRowBlock(rb, slot, slots, xsl);
+                }
+            }
+            prevRB = rbDone;
+        }
+
+        xsQueue_.FreeTensor(xsl);
+    }
+
+    // Act+quant ALL real rows in one global stripe (single-sync path). For a
+    // tiny M each expert has 1-2 rows, so the per-row-block stripe would
+    // serialize ~E blocks; this spreads the MValid real rows across all slots.
+    // accRow mapping is IDENTICAL to ActRowBlock: accRow = PadOff(e) + (g-Start(e)).
+    __aicore__ inline void ActPhaseGlobal(int32_t slot, int32_t slots,
+                                          const LocalTensor<float> &xsl,
+                                          int32_t mValid)
+    {
+        for (int32_t g = slot; g < mValid; g += slots) {
+            int32_t e = meta_.FindExpertReal(g);
+            int32_t lr = g - meta_.Start(e);
+            int32_t accRow = meta_.PadOff(e) + lr;
+            ActRow(accRow, g, xsl.GetValue(g));
+        }
+    }
+
+    // Act+quant all real rows of padded row-block rb (striped over slots).
+    __aicore__ inline void ActRowBlock(int32_t rb, int32_t slot, int32_t slots,
+                                       const LocalTensor<float> &xsl)
+    {
+        int32_t rowW = rb * BM;
+        int32_t e = meta_.FindExpert(rowW);
+        int32_t lr0 = rowW - meta_.PadOff(e);
+        int32_t valid = meta_.Count(e) - lr0;
+        if (valid > BM) {
+            valid = BM;
+        }
+        if (valid <= 0) {
+            return;
+        }
+        int32_t outRow0 = meta_.Start(e) + lr0;
+        for (int32_t r = slot; r < valid; r += slots) {
+            ActRow(rowW + r, outRow0 + r, xsl.GetValue(outRow0 + r));
+        }
+    }
+
+    // Per-row act+quant. The channel scale (sgl/sul) is now applied in the AIC
+    // epilogue dequant (int32 acc * fp32 channel scale -> half), so the AIV only
+    // reads the half accumulator, casts to float, and applies the x scale.
+    __aicore__ inline void ActRow(int32_t accRow, int32_t row, float xsi)
+    {
+        LocalTensor<half> accG = accGQueue_.AllocTensor<half>();
+        AscendC::DataCopy(accG, accGM_[(int64_t)accRow * N_], N2_);
+        accGQueue_.EnQue(accG);
+        LocalTensor<half> accU = accUQueue_.AllocTensor<half>();
+        AscendC::DataCopy(accU, accGM_[(int64_t)accRow * N_ + N2_], N2_);
+        accUQueue_.EnQue(accU);
+
+        LocalTensor<half> accGl = accGQueue_.DeQue<half>();
+        AscendC::Cast(g_, accGl, AscendC::RoundMode::CAST_NONE, N2_);
+        accGQueue_.FreeTensor(accGl);
+        LocalTensor<half> accUl = accUQueue_.DeQue<half>();
+        AscendC::Cast(u_, accUl, AscendC::RoundMode::CAST_NONE, N2_);
+        accUQueue_.FreeTensor(accUl);
+        AscendC::PipeBarrier<PIPE_V>();
+        AscendC::Muls(g_, g_, xsi, N2_);
+        AscendC::Muls(u_, u_, xsi, N2_);
+        AscendC::PipeBarrier<PIPE_V>();
+
+        // SiTU: gate = beta*tanh(g/beta)*sigmoid(g); tanh(z)=2*sig(2z)-1
+        AscendC::Muls(t_, g_, invBeta2_, N2_);
+        AscendC::PipeBarrier<PIPE_V>();
+        AscendC::Sigmoid(t_, t_, N2_);
+        AscendC::PipeBarrier<PIPE_V>();
+        AscendC::Sigmoid(g_, g_, N2_);
+        AscendC::PipeBarrier<PIPE_V>();
+        AscendC::Muls(t_, t_, 2.0f, N2_);
+        AscendC::Adds(t_, t_, -1.0f, N2_);
+        AscendC::PipeBarrier<PIPE_V>();
+        AscendC::Mul(t_, t_, g_, N2_);
+        AscendC::PipeBarrier<PIPE_V>();
+        AscendC::Muls(t_, t_, beta_, N2_);
+        AscendC::PipeBarrier<PIPE_V>();
+        if (hasLinear_ != 0) {
+            AscendC::Muls(u_, u_, invLinBeta2_, N2_);
+            AscendC::PipeBarrier<PIPE_V>();
+            AscendC::Sigmoid(u_, u_, N2_);
+            AscendC::PipeBarrier<PIPE_V>();
+            AscendC::Muls(u_, u_, 2.0f, N2_);
+            AscendC::Adds(u_, u_, -1.0f, N2_);
+            AscendC::PipeBarrier<PIPE_V>();
+            AscendC::Muls(u_, u_, linBeta_, N2_);
+            AscendC::PipeBarrier<PIPE_V>();
+        }
+        AscendC::Mul(t_, t_, u_, N2_);  // act row in t
+        AscendC::PipeBarrier<PIPE_V>();
+
+        // rowmax(|act|) via safe ReduceMax API (chunked, barrier-free fire-and-collect)
+        AscendC::Abs(a_, t_, N2_);
+        AscendC::PipeBarrier<PIPE_V>();
+        float rowMax = 0.0f;
+        int32_t chunks = (N2_ + ACT_RED_CHUNK - 1) / ACT_RED_CHUNK;
+        for (int32_t ch = 0; ch < N2_; ch += ACT_RED_CHUNK) {
+            int32_t idx = ch / ACT_RED_CHUNK;
+            int32_t len = N2_ - ch < ACT_RED_CHUNK ? N2_ - ch : ACT_RED_CHUNK;
+            AscendC::ReduceMax(chunkMax_[idx], a_[ch], redWork_, len);
+        }
+        AscendC::PipeBarrier<PIPE_V>();
+        for (int32_t idx = 0; idx < chunks; idx++) {
+            float v = chunkMax_.GetValue(idx);
+            rowMax = rowMax > v ? rowMax : v;
+        }
+
+        // y_scale + safe inverse (zero rows: inv=0 -> y=0 exactly)
+        float yScale = rowMax / 127.0f;
+        float inv = rowMax > 0.0f ? 127.0f / rowMax : 0.0f;
+
+        // y = rint(act * inv) -> int8
+        AscendC::Muls(t_, t_, inv, N2_);
+        AscendC::PipeBarrier<PIPE_V>();
+        AscendC::Cast(h16_, t_, AscendC::RoundMode::CAST_RINT, N2_);
+        AscendC::PipeBarrier<PIPE_V>();
+        LocalTensor<int8_t> y8 = yQueue_.AllocTensor<int8_t>();
+        AscendC::Cast(y8, h16_, AscendC::RoundMode::CAST_NONE, N2_);
+        yQueue_.EnQue(y8);
+        LocalTensor<int8_t> y8l = yQueue_.DeQue<int8_t>();
+        AscendC::DataCopy(yGM_[(int64_t)row * N2_], y8l, N2_);
+        yQueue_.FreeTensor(y8l);
+
+        LocalTensor<float> ys = ysQueue_.AllocTensor<float>();
+        ys.SetValue(0, yScale);
+        AscendC::PipeBarrier<PIPE_ALL>();
+        ysQueue_.EnQue(ys);
+        LocalTensor<float> ysl = ysQueue_.DeQue<float>();
+        DataCopyExtParams ycp{1, (uint32_t)sizeof(float), 0, 0, 0};
+        AscendC::DataCopyPad(ysGM_[row], ysl, ycp);
+        ysQueue_.FreeTensor(ysl);
+    }
+
+    GlobalTensor<int32_t> ptrTblGM_;
+    GlobalTensor<int32_t> scPtrTblGM_;
+    GlobalTensor<int32_t> packedGM_;
+    GlobalTensor<int8_t> w8GM_;
+    GlobalTensor<half> accGM_;
+    GlobalTensor<float> xsGM_;
+    GlobalTensor<int8_t> yGM_;
+    GlobalTensor<float> ysGM_;
+    DeviceGlMeta meta_;
+    TQue<AscendC::TPosition::VECIN, 1> inQueue_;
+    TQue<AscendC::TPosition::VECOUT, 1> outQueue_;
+    TBuf<AscendC::TPosition::VECCALC> upkH16Buf_;
+    TQue<AscendC::TPosition::VECIN, 1> accGQueue_;
+    TQue<AscendC::TPosition::VECIN, 1> accUQueue_;
+    TQue<AscendC::TPosition::VECIN, 1> xsQueue_;
+    TQue<AscendC::TPosition::VECOUT, 1> yQueue_;
+    TQue<AscendC::TPosition::VECOUT, 1> ysQueue_;
+    TBuf<AscendC::TPosition::VECCALC> gBuf_;
+    TBuf<AscendC::TPosition::VECCALC> uBuf_;
+    TBuf<AscendC::TPosition::VECCALC> tBuf_;
+    TBuf<AscendC::TPosition::VECCALC> aBuf_;
+    TBuf<AscendC::TPosition::VECCALC> actH16Buf_;
+    TBuf<AscendC::TPosition::VECCALC> redWorkBuf_;
+    TBuf<AscendC::TPosition::VECCALC> chunkMaxBuf_;
+    LocalTensor<float> g_;
+    LocalTensor<float> u_;
+    LocalTensor<float> t_;
+    LocalTensor<float> a_;
+    LocalTensor<half> h16_;
+    LocalTensor<float> redWork_;
+    LocalTensor<float> chunkMax_;
+    int32_t E_;
+    int32_t skipUnpack_;
+    int32_t kNum_;
+    int32_t nNum_;
+    int32_t nBlock_;
+    int32_t nBlockNum_;
+    int32_t gemmTiles_;
+    int32_t NP_;
+    int32_t N_;
+    int32_t N2_;
+    int32_t K_;
+    int32_t M_;
+    float beta_;
+    float invBeta2_;
+    int32_t hasLinear_;
+    float linBeta_;
+    float invLinBeta2_;
+};
+
+}  // namespace
+
+// Device-side group_list parse fused single launch (production MatmulImpl GEMM),
+// ported to the fused interface. The group_list device tensor is parsed on-device
+// every forward, so the operator is correct for DYNAMIC production MoE
+// group_list (new tensor or in-place update) with zero host D2H and no glPtr in
+// any cache key.
+extern "C" __global__ __aicore__ void gmsq_fused_256(GM_ADDR x, GM_ADDR wPtrTbl, GM_ADDR scPtrTbl,
+                                                      GM_ADDR w8, GM_ADDR acc, GM_ADDR scaleF32,
+                                                      GM_ADDR xScale, GM_ADDR y, GM_ADDR yScale,
+                                                      GM_ADDR groupList, int32_t E, int32_t kNum,
+                                                      int32_t nNum, int32_t nBlock, int32_t NP,
+                                                      int32_t N, int32_t N2, int32_t K, int32_t C,
+                                                      int32_t glType, float beta, float invBeta,
+                                                      int32_t hasLinear, float linBeta,
+                                                      float invLinBeta, int32_t skipUnpack)
+{
+    KERNEL_TASK_TYPE_DEFAULT(KERNEL_TYPE_MIX_AIC_1_2);
+    GlobalTensor<int64_t> glGM;
+    glGM.SetGlobalBuffer(reinterpret_cast<__gm__ int64_t *>(groupList));
+    if ASCEND_IS_AIC {
+        AscendC::AscendCUtils::SetOverflow(1);
+        TPipe pipe;
+        GmsqGemmKernel256 kernel;
+        kernel.Init(x, w8, acc, scPtrTbl, glGM, E, glType, K, N, nBlock, &pipe);
+        kernel.ProcessFused(skipUnpack);
+    }
+    if ASCEND_IS_AIV {
+        TPipe pipe;
+        GmsqFusedAivKernel256 kernel;
+        kernel.Init(wPtrTbl, scPtrTbl, w8, acc, scaleF32, xScale, y, yScale, glGM, E, glType,
+                    kNum, nNum, NP, N, N2, K, C, beta, invBeta, hasLinear, linBeta, invLinBeta,
+                    nBlock, &pipe, skipUnpack);
+        kernel.Process();
+    }
+}
+
+
+namespace vllm_ascend {
+// Host-side launcher exported to the vllm_ascend_C extension (bgmv/sgmv
+// style): this ccec-compiled TU owns the kernel entry, so the tripple-chevron
+// launch is resolved inside libvllm_ascend_kernels and only this symbol is
+// linked out to the host extension.
+void gmsq_fused_256_impl(uint32_t blockDim, void *stream, void *x, void *wPtrTbl, void *scPtrTbl,
+                          void *w8, void *acc, void *scaleF32, void *xScale, void *y, void *yScale,
+                          void *groupList, int32_t E, int32_t kNum, int32_t nNum, int32_t nBlock,
+                          int32_t NP, int32_t N, int32_t N2, int32_t K, int32_t C, int32_t glType,
+                          float beta, float invBeta, int32_t hasLinear, float linBeta,
+                          float invLinBeta, int32_t skipUnpack)
+{
+    gmsq_fused_256<<<blockDim, nullptr, stream>>>(x, wPtrTbl, scPtrTbl, w8, acc, scaleF32, xScale,
+                                                   y, yScale, groupList, E, kNum, nNum, nBlock, NP,
+                                                   N, N2, K, C, glType, beta, invBeta, hasLinear,
+                                                   linBeta, invLinBeta, skipUnpack);
+}
+}  // namespace vllm_ascend

--- a/csrc/gmsq_situ_quant/vllm_ascendC_binding.cpp
+++ b/csrc/gmsq_situ_quant/vllm_ascendC_binding.cpp
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2026 Huawei Technologies Co., Ltd.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ */
+
+// Direct pybind11 exposure of the fused GroupedMatmulSituQuant AscendC
+// operator (fake-A8W8 grouped GMM1 + SiTU + per-token INT8 quant, single
+// launch). Importing this extension attaches the module to the `torch`
+// namespace, so callers can use
+//   torch.vllm_ascendC.grouped_matmul_situ_quant(...)
+// without going through the torch dispatcher (no TORCH_LIBRARY registration
+// on this branch — see the torch.ops._C_ascend variant branch for that exposure).
+
+#include <optional>
+#include <tuple>
+#include <vector>
+
+#include <torch/extension.h>
+#include <pybind11/stl.h>
+
+#include "grouped_matmul_situ_quant.h"
+
+namespace py = pybind11;
+
+PYBIND11_MODULE(vllm_ascendC, m)
+{
+    m.doc() = "vllm-ascend direct AscendC operator bindings (torch.vllm_ascendC.*)";
+
+    m.def(
+        "grouped_matmul_situ_quant",
+        [](const at::Tensor &x, std::vector<at::Tensor> weight,
+           std::vector<at::Tensor> weight_scale, const at::Tensor &x_scale,
+           const at::Tensor &group_list, std::vector<at::Tensor> weight_assist_matrix, double beta,
+           std::optional<double> linear_beta, int64_t group_list_type) {
+            return vllm_ascend::grouped_matmul_situ_quant(x, weight, weight_scale, x_scale,
+                                                             group_list, weight_assist_matrix, beta,
+                                                             linear_beta, group_list_type);
+        },
+        "Fused grouped matmul (fake-A8W8) + SiTU + per-token INT8 quant (single launch).",
+        py::arg("x"), py::arg("weight"), py::arg("weight_scale"), py::arg("x_scale"),
+        py::arg("group_list"), py::arg("weight_assist_matrix"), py::arg("beta") = 1.0,
+        py::arg("linear_beta") = py::none(), py::arg("group_list_type") = 1);
+
+    // Attach as a `torch` attribute: importing vllm_ascend.vllm_ascendC makes
+    // torch.vllm_ascendC.grouped_matmul_situ_quant available on the torch
+    // module itself.
+    py::module_ torch_mod = py::module_::import("torch");
+    if (!py::hasattr(torch_mod, "vllm_ascendC")) {
+        torch_mod.attr("vllm_ascendC") = m;
+    }
+}


### PR DESCRIPTION
Vendor the A3 fused operator GroupedMatmulSituQuant (fake-A8W8 grouped GMM1 + SiTU + per-token INT8 dynamic quant, single MIX_AIC_1_2 launch) under csrc/gmsq_situ_quant/ and expose it through a dedicated pybind11 module instead of the torch dispatcher:

- op_kernel/grouped_matmul_situ_quant_kernel.cpp: ccec-compiled device kernel, added to the vllm_ascend_kernels ascendc_library target
- grouped_matmul_situ_quant.cpp: host wrapper (FusedMetaCache + P34 expanded-w8 cache, NZ->ND EnsureNd, device-side group_list parse, M_valid==0 empty-rank early return)
- vllm_ascendC_binding.cpp: new vllm_ascendC pybind module; importing vllm_ascend.vllm_ascendC attaches itself to the torch namespace, so torch.vllm_ascendC.grouped_matmul_situ_quant(...) is callable
- CMakeLists.txt: build vllm_ascendC alongside vllm_ascend_C (non-310p/950), linking vllm_ascend_kernels

Usage: import vllm_ascend.vllm_ascendC, then
       torch.vllm_ascendC.grouped_matmul_situ_quant(x, weight, ...)
Model / MoE / DeviceOperator code paths are untouched; no TORCH_LIBRARY registration on this branch (see the torch.ops._C_ascend variant branch for the dispatcher exposure).

Verified on Ascend910_9382: build + load + 5/5 functional smoke cases.

### What this PR does / why we need it?

### Does this PR introduce _any_ user-facing change?

### How was this patch tested?

- vLLM main: https://github.com/vllm-project/vllm/commit/d02df748bf9efd99022f1a062597dc3cb3808485
