### PR TITLE
[BugFix] Keep the torch profiler lifecycle on the client-registering thread

### DIFF
--- a/tests/ut/test_platform.py
+++ b/tests/ut/test_platform.py
@@ -281,6 +281,9 @@ class TestNPUPlatform(TestBase):
         ):
             _validate_eplb_config(vllm_config)
         self.assertEqual(NPUPlatform.dispatch_key, "PrivateUse1")
+        # torch_npu's Kineto client is bound to its registering thread, so the
+        # profiler lifecycle must not be dispatched to a worker thread.
+        self.assertTrue(NPUPlatform.profiler_needs_client_thread)
         self.assertEqual(NPUPlatform.supported_quantization, [ASCEND_QUANTIZATION_METHOD, COMPRESSED_TENSORS_METHOD])
 
     def test_get_recompute_scheduler_cls(self):

--- a/vllm_ascend/platform.py
+++ b/vllm_ascend/platform.py
@@ -89,6 +89,9 @@ class NPUPlatform(Platform):
         "RAY_EXPERIMENTAL_NOSET_ASCEND_RT_VISIBLE_DEVICES",
     ]
     dispatch_key: str = "PrivateUse1"
+    # torch_npu's Kineto client is bound to the thread that registered it, so
+    # the profiler lifecycle must not be dispatched to a worker thread.
+    profiler_needs_client_thread: bool = True
 
     supported_quantization: list[str] = [
         ASCEND_QUANTIZATION_METHOD,


### PR DESCRIPTION
### What this PR does / why we need it?

Refs #14974. **Blocked on vllm-project/vllm#54322** — that PR adds the flag this one sets;
without it this is an inert class attribute. Draft until it lands.

`AsyncLLM.start_profile` / `stop_profile` dispatch the frontend profiler lifecycle with
`asyncio.to_thread`. torch_npu's Kineto client is bound to the thread that registered it, so
`POST /start_profile` is rejected:

```
ERROR: External init callback must run in same thread as registerClient (1088942336 != -1328559392)
```

and the frontend profiler is left in a broken state. #14974 and vllm-project/vllm#39603
both report the serving process crashing on `stop_profile` afterwards.

The upstream PR adds `Platform.profiler_needs_client_thread`, defaulting to `False` so CUDA
keeps running the lifecycle off the event loop — `profiler.stop()` exports the trace inline
and costs ~4.5 µs per recorded span, so inlining it everywhere would stall the API server.
This PR is the Ascend half: set the flag to `True` on `NPUPlatform`.

### Does this PR introduce _any_ user-facing change?

Yes, once the upstream change lands: `POST /start_profile` and `POST /stop_profile` work on
NPU instead of corrupting the profiler.

### How was this patch tested?

Atlas A3 (`Ascend910_9392`), CANN 9.0.1, torch_npu 2.10, `vllm serve Qwen3-0.6B
--profiler-config '{"profiler":"torch","torch_profiler_dir":...}'`, then `POST /start_profile`
→ traffic → `POST /stop_profile`, with both this change and vllm-project/vllm#54322 applied:

| | `same thread as registerClient` errors in the server log |
|---|---|
| before | 1 |
| after | **0** |

Traces are written in both cases.

`tests/ut/test_platform.py` extends the existing `test_class_variables` assertions, since
that test already pins the platform's class attributes one by one: 52 passed, 1 skipped.
Deleting the attribute makes it fail, so it is a real guard rather than a restatement.
(That file needs `TORCH_DEVICE_BACKEND_AUTOLOAD=0` to run in my container; it fails the same
way on unmodified `main` there, so that is an environment quirk and not from this change.)

Two things I would rather state than overclaim:

- I could **not** reproduce the hard segfault #14974 describes. On my stack the server stayed
  alive and both endpoints returned 200; the reporter was on Atlas A2 with CANN 9.1.0 and
  vLLM 0.23.0. What is demonstrably fixed here is the thread violation that the issue
  identifies as the root cause.
- A separate `Incorrect schedule: Stop profiler while current state is RECORD` warning comes
  from the **EngineCore** process. It appears identically before and after, so it is a
  different problem and out of scope.

vLLM version: v0.27.1
vLLM main: https://github.com/vllm-project/vllm/commit/ba07e4a48fc951300d97eb506217dd530583dea3

- vLLM main: https://github.com/vllm-project/vllm/commit/ba07e4a48fc951300d97eb506217dd530583dea3
