### PR TITLE
[CI] Add static kernel test for Qwen3-0.6B

### DIFF
--- a/.github/workflows/configs/weekly_config.yaml
+++ b/.github/workflows/configs/weekly_config.yaml
@@ -295,6 +295,9 @@ a3:
       - name: MiniMax-M2.5-w8a8
         os: linux-aarch64-nightly-a3-16
         config_file_path: MiniMax-M2.5-W8A8-A3.yaml
+      - name: Qwen3-0.6B-static-kernel
+        os: linux-aarch64-a3-16
+        config_file_path: Qwen3-0.6B-static-kernel.yaml
       - name: Qwen3.6-35B-A3B-w8a8-A3-accuracy
         os: linux-aarch64-nightly-a3-2
         config_file_path: Qwen3.6-35B-A3B-w8a8-A3-accuracy.yaml

--- a/tests/e2e/weekly/single_node/configs/Qwen3-0.6B-static-kernel.yaml
+++ b/tests/e2e/weekly/single_node/configs/Qwen3-0.6B-static-kernel.yaml
@@ -1,0 +1,52 @@
+# ==========================================
+# ACTUAL TEST CASES
+# ==========================================
+
+test_cases:
+  - name: "Qwen3-0.6B-static-kernel"
+    model: "Qwen/Qwen3-0.6B"
+    envs:
+      TASK_QUEUE_ENABLE: "1"
+      OMP_PROC_BIND: "false"
+      HCCL_OP_EXPANSION_MODE: "AIV"
+      PAGED_ATTENTION_MASK_LEN: "5500"
+      SERVER_PORT: "DEFAULT_PORT"
+    server_cmd:
+      - "--no-enable-prefix-caching"
+      - "--port"
+      - "$SERVER_PORT"
+      - "--max-model-len"
+      - "40960"
+      - "--max-num-batched-tokens"
+      - "25600"
+      - "--block-size"
+      - "128"
+      - "--trust-remote-code"
+      - "--gpu-memory-utilization"
+      - "0.9"
+      - "--compilation-config"
+      - '{"cudagraph_capture_sizes": [32], "cudagraph_mode": "FULL_DECODE_ONLY"}'
+      - "--additional-config"
+      - '{"enable_cpu_binding": true, "ascend_compilation_config": {"enable_static_kernel": true}, "weight_nz_mode": 1}'
+    benchmarks:
+      acc:
+        case_type: accuracy
+        dataset_path: vllm-ascend/gsm8k
+        request_conf: vllm_api_general_chat
+        dataset_conf: gsm8k/gsm8k_gen_0_shot_cot_chat_prompt
+        max_out_len: 512
+        num_prompts: 32
+        batch_size: 32
+        baseline: 55
+        threshold: 5
+      perf:
+        case_type: performance
+        dataset_path: vllm-ascend/GSM8K-in3500-bs400
+        request_conf: vllm_api_stream_chat
+        dataset_conf: gsm8k/gsm8k_gen_0_shot_cot_str_perf
+        num_prompts: 80
+        max_out_len: 512
+        batch_size: 32
+        request_rate: 0
+        baseline: 1
+        threshold: 0.97


### PR DESCRIPTION
**What this PR does / why we need it?**
Adds a new test to guard the `enable_static_kernel=True` scenario.

**Does this PR introduce any user-facing change?**
No.

**How was this patch tested?**
CI test.

- vLLM main: https://github.com/vllm-project/vllm/commit/b2f685834a6456197e7033966fdef52a23f1abcd
