### PR TITLE
[CI] Fix shallow vLLM range recovery

### DIFF
--- a/tests/e2e/vllm_interface/vllm_interface_contracts/vllm_ci.py
+++ b/tests/e2e/vllm_interface/vllm_interface_contracts/vllm_ci.py
@@ -24,6 +24,10 @@ VLLM_REPOSITORY_URL = "https://github.com/vllm-project/vllm.git"
 VLLM_BASE_BRANCH = "main"
 
 
+class GitCommandError(RuntimeError):
+    """Raised when a Git command cannot complete successfully."""
+
+
 def _git(root: Path, *args: str) -> str:
     command = ["git", "-C", str(root), *args]
     try:
@@ -46,7 +50,7 @@ def _git(root: Path, *args: str) -> str:
             details.extend(("stderr:", stderr))
         if not stdout and not stderr:
             details.append("The Git command produced no output.")
-        raise RuntimeError("\n".join(details)) from None
+        raise GitCommandError("\n".join(details)) from None
 
 
 def resolve_vllm_range(
@@ -65,7 +69,7 @@ def resolve_vllm_range(
     _git(vllm_root, "fetch", "--no-tags", repository_url, base_branch)
     try:
         old_sha = _git(vllm_root, "merge-base", new_sha, "FETCH_HEAD")
-    except subprocess.CalledProcessError:
+    except GitCommandError:
         if _git(vllm_root, "rev-parse", "--is-shallow-repository") != "true":
             raise
         _git(vllm_root, "fetch", "--no-tags", "--unshallow", repository_url, base_branch)


### PR DESCRIPTION
### What this PR does / why we need it?

This follow-up fixes the shallow-checkout range resolution failure observed after #14560 was merged.

In [vLLM Buildkite build #86104](https://buildkite.com/vllm/ci/builds/86104/list?sid=01a04bab-e537-447f-b487-3d9f8eca4f1f&tab=output), the new interface test was invoked successfully but stopped before source indexing:

```text
Git command failed with exit code 1:
git -C /workspace/vllm merge-base d4d035ccef298dda06e0f490234b76381f8b859f FETCH_HEAD
The Git command produced no output.
```

The detailed Git diagnostics added before #14560 was merged converted `subprocess.CalledProcessError` into `RuntimeError`. However, `resolve_vllm_range()` still caught `subprocess.CalledProcessError`, so the existing shallow-repository recovery path could no longer run.

This PR introduces a narrow `GitCommandError` type and uses it consistently:

```text
_git() failure
  -> raise GitCommandError with command/stdout/stderr
  -> resolve_vllm_range() catches GitCommandError
  -> verify the checkout is shallow
  -> fetch --unshallow
  -> retry merge-base
```

The change retains the actionable pytest diagnostics while restoring the intended `--unshallow` retry. Other `RuntimeError` instances are not caught.

### Does this PR introduce _any_ user-facing change?

No. Runtime inference behavior and public APIs are unchanged. This only fixes vLLM PR CI range resolution.

### How was this patch tested?

A local bare Git remote was used to create this history:

```text
        B  main tip
       /
A  merge base
       \
        P  PR head
```

Two independent `--depth 1` clones of the PR branch were created. Both implementations executed real Git commands; the harness only recorded the command arguments.

| Result | Before this fix | After this fix |
| --- | --- | --- |
| Initial shallow state | `true` | `true` |
| Initial `merge-base` | failed | failed |
| `fetch --unshallow` observed | no | yes |
| Range resolution | failed with the Buildkite error | passed |
| Final shallow state | `true` | `false` |
| Base/head SHAs | not returned | both matched exactly |

Additional checks:

```bash
python -m ruff check tests/e2e/vllm_interface/vllm_interface_contracts/vllm_ci.py
python -m ruff format --check tests/e2e/vllm_interface/vllm_interface_contracts/vllm_ci.py
python -m mypy --follow-imports skip --check-untyped-defs --python-version 3.10 tests/e2e/vllm_interface/vllm_interface_contracts/vllm_ci.py
python -m mypy --follow-imports skip --check-untyped-defs --python-version 3.11 tests/e2e/vllm_interface/vllm_interface_contracts/vllm_ci.py
python -m mypy --follow-imports skip --check-untyped-defs --python-version 3.12 tests/e2e/vllm_interface/vllm_interface_contracts/vllm_ci.py
python -m compileall -q tests/e2e/vllm_interface/vllm_interface_contracts/vllm_ci.py
git diff --check origin/main..HEAD
```

All checks passed.
- vLLM main: https://github.com/vllm-project/vllm/commit/ba07e4a48fc951300d97eb506217dd530583dea3
