### PR TITLE
[Doc][Ops] Add standard, multimodal, and TP QKV RMSNorm RoPE operator descriptions

### DIFF
--- a/vllm_ascend/ops/triton/docs/split_qkv_rmsnorm_mrope.md
+++ b/vllm_ascend/ops/triton/docs/split_qkv_rmsnorm_mrope.md
@@ -1,0 +1,75 @@
+# split_qkv_rmsnorm_mrope
+
+## Description
+
+- **Function**: Fuses QKV splitting, per-head Q/K RMSNorm, multimodal rotary position embedding, and optional attention-gate extraction. It supports both chunked and T/H/W-interleaved MRoPE frequency layouts through `torch.ops.vllm.triton_split_qkv_rmsnorm_mrope`.
+- **Formula**: Let `T` be the token count, `D` the head size, `Q = Hq * D`, `K = Hkv * D`, and `R` the rotary dimension. Without a gate, split the input as `[Q | K | V]`. With a gate, each Q head is stored as `[q_head(D) | gate_head(D)]`, followed by K and V. Q and K use
+
+  $$
+  z = x \cdot \operatorname{rsqrt}\left(\operatorname{mean}(x^2) + \epsilon\right) \cdot w + b.
+  $$
+
+  For every half-frequency index, select cos/sin from the temporal, height, or width plane according to `mrope_section` and `is_interleaved`. Repeat the selected half-vector across both halves and apply NeoX rotation:
+
+  $$
+  y_{0:R/2} = z_{0:R/2}c - z_{R/2:R}s,
+  \qquad
+  y_{R/2:R} = z_{R/2:R}c + z_{0:R/2}s.
+  $$
+
+  Dimensions `R:D` remain unchanged for partial RoPE. V and the optional gate are copied unchanged.
+- **Algorithm flow** (processed row by row, independently):
+  1. Derive Q/K widths, optional gate width, token distribution, and rotary mode in the wrapper.
+  2. Partition tokens contiguously across at most the available vector cores. Front cores process `ceil(T / core_count)` rows and tail cores process `floor(T / core_count)` rows.
+  3. For each token, load Q, K, V, and the optional per-head-interleaved gate; compute per-head Q/K RMSNorm and affine transforms in fp32.
+  4. Select T/H/W cos and sin values using either contiguous sections or the interleaved pattern, rotate Q and K, and store Q, K, V, and the optional gate.
+- **Supported modes**: Atlas A2 and Atlas A3 for Qwen3.5 and Qwen3-VL multimodal inference, in eager and graph-captured execution. The current direct single-operator test has been verified on Atlas A2; Ascend 950 verification is not claimed by the current test evidence.
+
+## Parameters
+
+| Parameter | Input/Output/Attribute | Description | Data type | Data format |
+| --- | --- | --- | --- | --- |
+| `qkv` | Input | Fused QKV input; Q, K, V without a gate, or per-Q-head q/gate pairs followed by K and V when gated | fp16 / bf16 | Contiguous 2-D, `[T, Q + 2 * K]` or `[T, 2 * Q + 2 * K]` |
+| `q_weight` | Input | RMSNorm weight shared by all Q heads | fp16 / bf16 | Contiguous 1-D, `[D]` |
+| `k_weight` | Input | RMSNorm weight shared by all K heads | fp16 / bf16 | Contiguous 1-D, `[D]` |
+| `cos_sin` | Input | T/H/W cache planes, each row containing a cos half followed by a sin half | same as `qkv` | Contiguous 3-D, `[3, T, R]` |
+| `num_q_heads` | Input (attribute) | Number of local Q heads `Hq` | int32 | Scalar |
+| `num_kv_heads` | Input (attribute) | Number of local K/V heads `Hkv` | int32 | Scalar |
+| `head_size` | Input (attribute) | Per-head feature size `D` | int32 | Scalar |
+| `eps` | Input (attribute) | Positive RMSNorm epsilon | fp32 | Scalar |
+| `mrope_section` | Input (attribute) | Half-dimension counts `[temporal, height, width]` | list of three int32 values | 1-D attribute |
+| `is_interleaved` | Input (attribute) | Selects T/H/W-interleaved frequency-source assignment instead of contiguous sections | bool | Scalar |
+| `rope_dim` | Optional input (attribute) | Rotary dimension `R`; defaults to `head_size` | int32 | Scalar |
+| `q_bias` | Optional input | Bias shared by all normalized Q heads | fp16 / bf16 | Contiguous 1-D, `[D]` |
+| `k_bias` | Optional input | Bias shared by all normalized K heads | fp16 / bf16 | Contiguous 1-D, `[D]` |
+| `has_gate` | Input (attribute) | Indicates whether each Q head contains an adjacent gate vector | bool | Scalar |
+| `q_output` | Output | Normalized and MRoPE-rotated Q | same as `qkv` | Contiguous 2-D, `[T, Q]` |
+| `k_output` | Output | Normalized and MRoPE-rotated K | same as `qkv` | Contiguous 2-D, `[T, K]` |
+| `v_output` | Output | V copied from the fused input | same as `qkv` | Contiguous 2-D, `[T, K]` |
+| `gate_output` | Output | Extracted gate, or a zero-width tensor when gating is disabled | same as `qkv` | Contiguous 2-D, `[T, Q]` or `[T, 0]` |
+
+## Constraints
+
+- `Q = num_q_heads * head_size` and `K = num_kv_heads * head_size`; the input width must exactly match the selected gated or non-gated layout.
+- `rope_dim` must be positive, even, and no greater than `head_size`. `sum(mrope_section)` must equal `rope_dim / 2`, and all three section lengths must be non-negative.
+- `cos_sin` must have the exact contiguous shape `[3, T, rope_dim]`; plane 0 is temporal, plane 1 is height, and plane 2 is width.
+- `q_weight` and `k_weight` must each contain `head_size` elements. `q_bias` and `k_bias` must either both be present or both be absent.
+- All tensors must be contiguous because the kernel uses flat pointer arithmetic and does not accept strides.
+- `T` must be positive. The wrapper does not provide a zero-token fast path before calculating the launch size.
+- `is_interleaved` changes which modality supplies each frequency; the rotary pairing itself remains NeoX half-style.
+- The registered fake implementation supports Dynamo/AOT tracing. The optional bias branch is implemented but not covered by the current single-operator test.
+
+## Origin and Differences
+
+- **Origin**: Developed as a vLLM-Ascend-native fused Triton operator in PR #6730 for the Qwen3.5 and Qwen3-VL multimodal attention paths.
+- **Differences**:
+    - NPU adaptation for performance: combines QKV/gate extraction, Q/K RMSNorm, modality-frequency selection, partial MRoPE, and output stores in one vector-core launch;
+    - Modified for a specific vllm-ascend logic or different input parameters: accepts cache rows already indexed by three-dimensional multimodal positions, supports both chunked and interleaved `mrope_section` layouts, and extracts the Qwen3.5 per-head attention gate when present.
+
+## Test Cases
+
+The direct custom-op test covers `T={1,4096}`, `(Hq,Hkv)={(2,1),(16,2)}`, `D={128,256}`, `mrope_section={[11,11,10],[24,20,20]}`, interleaved and non-interleaved layouts, gate enabled and disabled, and both fp16 and bf16. It produces 128 parameter combinations and compares Q, K, V, and the enabled gate with a PyTorch reference using `rtol=1e-2, atol=1e-2`. The optional bias path remains uncovered.
+
+```bash
+pytest -sv tests/e2e/nightly/single_node/ops/singlecard_ops/triton/test_split_qkv_rmsnorm_mrope.py
+```

--- a/vllm_ascend/ops/triton/docs/split_qkv_rmsnorm_rope.md
+++ b/vllm_ascend/ops/triton/docs/split_qkv_rmsnorm_rope.md
@@ -1,0 +1,76 @@
+# split_qkv_rmsnorm_rope
+
+## Description
+
+- **Function**: Fuses QKV splitting, per-head Q/K RMSNorm, optional affine bias, and NeoX-style rotary position embedding into one Triton operator. V is copied without arithmetic. The public custom operator is `torch.ops.vllm.qkv_rmsnorm_rope`.
+- **Formula**: Let `T` be the token count, `D` the head dimension, `Hq` and `Hkv` the Q and KV head counts, `Q = Hq * D`, `K = Hkv * D`, and `R` the rotary dimension. Split
+
+  $$
+  [q_0, k_0, v] = \operatorname{split}(\operatorname{input}, [Q, K, K]).
+  $$
+
+  For each token and head, compute in fp32
+
+  $$
+  \operatorname{norm}(x) = x \cdot \operatorname{rsqrt}\left(\operatorname{mean}(x^2) + \epsilon\right),
+  $$
+
+  followed by `zq = norm(q0) * q_weight + q_bias` and `zk = norm(k0) * k_weight + k_bias`, with the bias terms omitted when disabled. For cache row `positions[t]`, let `c` and `s` be the first and second `R / 2` elements. NeoX half rotation produces
+
+  $$
+  y_{0:R/2} = z_{0:R/2}c - z_{R/2:R}s,
+  \qquad
+  y_{R/2:R} = z_{R/2:R}c + z_{0:R/2}s.
+  $$
+
+  Dimensions `R:D` are preserved for partial RoPE.
+- **Algorithm flow** (processed row by row, independently):
+  1. Derive `Hq`, `Hkv`, the rotary mode, and UB-aware token tile sizes in the wrapper.
+  2. Launch one program per available vector core. Each `program_id(0)` owns a contiguous interval of `ceil(T / num_vector_cores)` token rows.
+  3. Load a Q+K token tile, reshape it to `[tile, Hq + Hkv, D]`, compute per-head fp32 RMSNorm, apply shared per-head weights and optional biases, and round the affine result to bf16.
+  4. Gather the selected cos/sin cache rows, rotate Q and K, and store them with token-tail masks. A separate UB-tiled loop copies V unchanged.
+- **Supported modes**: Atlas A2 and Atlas A3 for this kernel, in eager and graph-fused inference. On Ascend 950, `DeviceOperator` dispatches the same public semantics to the separate SIMT implementation instead of this kernel.
+
+## Parameters
+
+| Parameter | Input/Output/Attribute | Description | Data type | Data format |
+| --- | --- | --- | --- | --- |
+| `input` | Input | Fused QKV projection laid out as Q followed by K and V | bf16 | Contiguous 2-D, `[T, Q + 2 * K]` |
+| `cos_sin_cache` | Input | Position cache; each row contains `R / 2` cos values followed by `R / 2` sin values | bf16 | Contiguous 2-D, `[max_position, R]` |
+| `positions` | Input | Cache-row index for every token | int64 | Contiguous 1-D, `[T]` |
+| `q_weight` | Input | RMSNorm weight shared by all Q heads | bf16 | Contiguous 1-D, `[D]` |
+| `k_weight` | Input | RMSNorm weight shared by all K heads | bf16 | Contiguous 1-D, `[D]` |
+| `q_hidden_size` | Input (attribute) | Local flattened Q width `Q` | int32 | Scalar |
+| `kv_hidden_size` | Input (attribute) | Local flattened K and V width `K` | int32 | Scalar |
+| `head_dim` | Input (attribute) | Per-head feature size `D` | int32 | Scalar |
+| `eps` | Input (attribute) | Positive RMSNorm epsilon | fp32 | Scalar |
+| `q_bias` | Optional input | Bias shared by all normalized Q heads | bf16 | Contiguous 1-D, `[D]` |
+| `k_bias` | Optional input | Bias shared by all normalized K heads | bf16 | Contiguous 1-D, `[D]` |
+| `q_output` | Output | Normalized and rotated Q | bf16 | Contiguous 2-D, `[T, Q]` |
+| `k_output` | Output | Normalized and rotated K | bf16 | Contiguous 2-D, `[T, K]` |
+| `v_output` | Output | V copied from the fused input | bf16 | Contiguous 2-D, `[T, K]` |
+
+## Constraints
+
+- `input.shape[1]` must equal `q_hidden_size + 2 * kv_hidden_size`; `q_hidden_size` and `kv_hidden_size` must both be divisible by `head_dim`.
+- This implementation is a bf16 kernel: the tested and production fusion path uses bf16, and the Q/K affine intermediate is explicitly converted to bf16 before RoPE.
+- `R = cos_sin_cache.shape[-1]` must be positive, even, and no greater than `head_dim`. The rotation uses NeoX half splitting, not interleaved GPT-J pairing.
+- Every `positions[t]` must satisfy `0 <= positions[t] < cos_sin_cache.shape[0]`.
+- `q_weight` and `k_weight` must each contain exactly `head_dim` elements. `q_bias` and `k_bias` must either both be present or both be absent.
+- All tensors must use the contiguous layouts listed above because the kernel does not consume tensor strides.
+- The registered custom operator provides a fake implementation for Dynamo/AOT tracing. The normal A2/A3 kernel and the Ascend 950 SIMT kernel are separate implementations and should be tested on their respective hardware routes.
+
+## Origin and Differences
+
+- **Origin**: Developed in vLLM-Ascend PR #4711 as a native NPU fusion of QKV split, Q/K RMSNorm, and RoPE. A direct nightly accuracy test was added in PR #5267; indexed cos/sin-cache access and partial-RoPE support were added in later optimizations.
+- **Differences**:
+    - NPU adaptation for performance: performs Q/K normalization, affine transform, rotary embedding, and V extraction in one vector-core launch with UB-aware row tiling;
+    - Modified for a specific vllm-ascend logic or different input parameters: registered as `torch.ops.vllm.qkv_rmsnorm_rope` and used by the Ascend QK-Norm/RoPE graph-fusion pass and direct model patches. The A2/A3 kernel consumes a compact `[cos_base | sin_base]` cache selected by `positions`.
+
+## Test Cases
+
+The test runs through `DeviceOperator.split_qkv_rmsnorm_rope` on the A2/A3 route and compares Q, K, and V with a PyTorch fp32 reference. It covers `T={1,16,1024,10240}`, `(Hq,Hkv)={(12,1),(64,4)}`, `D=128`, full and partial RoPE with `R={128,64}`, bias enabled and disabled, bf16 input, and a maximum position of 262144. The tolerance is `rtol=5e-3, atol=5e-2`.
+
+```bash
+pytest -sv tests/e2e/nightly/single_node/ops/singlecard_ops/triton/test_split_qkv_rmsnorm_rope.py
+```

--- a/vllm_ascend/ops/triton/docs/split_qkv_tp_rmsnorm_rope.md
+++ b/vllm_ascend/ops/triton/docs/split_qkv_tp_rmsnorm_rope.md
@@ -1,0 +1,80 @@
+# split_qkv_tp_rmsnorm_rope
+
+## Description
+
+- **Function**: Implements the two-stage Tensor Parallel QKV split, global Q/K RMSNorm, and NeoX-style RoPE pipeline used by MiniMax-M2 attention. The public operator contains `_split_qkv_and_compute_local_qk_var_kernel`, a TP all-reduce, and `_apply_global_rmsnorm_kernel`; the two kernels therefore form one semantic operator.
+- **Formula**: On TP rank `r`, let local Q and K widths be `Q` and `K`, and let `W = tp_world`. The first kernel computes local means
+
+  $$
+  \mu_{q,r}=\frac{1}{Q}\sum_{j=0}^{Q-1}q_{r,j}^2,
+  \qquad
+  \mu_{k,r}=\frac{1}{K}\sum_{j=0}^{K-1}k_{r,j}^2.
+  $$
+
+  The wrapper all-reduces these values and the second kernel computes
+
+  $$
+  \mu_q=\frac{1}{W}\sum_{r=0}^{W-1}\mu_{q,r},
+  \qquad
+  z_{q,r,j}=q_{r,j}\operatorname{rsqrt}(\mu_q+\epsilon)w_{q,r,j},
+  $$
+
+  with the same equations for K. For equal-width TP shards, this is the mean over the global sharded Q or K vector. Q and K are then reshaped into local heads and rotated over their first `R` dimensions:
+
+  $$
+  y_{0:R/2}=z_{0:R/2}c-z_{R/2:R}s,
+  \qquad
+  y_{R/2:R}=z_{R/2:R}c+z_{0:R/2}s.
+  $$
+
+  V is copied unchanged.
+- **Algorithm flow** (processed token by token):
+  1. Flatten the local `[Q | K | V]` input and launch `min(T, num_vector_cores)` programs.
+  2. `_split_qkv_and_compute_local_qk_var_kernel` grid-strides over token tiles, loads power-of-two-padded feature blocks with masks, copies Q/K/V, and writes fp32 local Q/K means to `[T, 2]`.
+  3. If `tp_world > 1`, all-reduce the local means across the initialized tensor-parallel group.
+  4. `_apply_global_rmsnorm_kernel` assigns each program a contiguous token range, applies the global scale and per-feature local weights, performs partial or full NeoX RoPE, and stores Q/K in place.
+- **Supported modes**: Atlas A2 and Atlas A3 for MiniMax-M2/M2.5 Tensor Parallel inference, with a registered fake implementation for graph tracing. The current single-card accuracy test has been verified on Atlas A2; multi-rank and Ascend 950 accuracy are not claimed by the current test evidence.
+
+## Parameters
+
+| Parameter | Input/Output/Attribute | Description | Data type | Data format |
+| --- | --- | --- | --- | --- |
+| `input` | Input | Local TP shard of the fused projection, laid out as Q followed by K and V | bf16 | Contiguous 2-D, `[T, Q + 2 * K]` |
+| `q_weight` | Input | Per-feature RMSNorm weight for the local Q shard | fp32 | Contiguous 1-D, `[Q]` |
+| `k_weight` | Input | Per-feature RMSNorm weight for the local K shard | fp32 | Contiguous 1-D, `[K]` |
+| `q_hidden_size` | Input (attribute) | Local flattened Q width `Q` | int32 | Scalar |
+| `kv_hidden_size` | Input (attribute) | Local flattened K and V width `K` | int32 | Scalar |
+| `head_dim` | Input (attribute) | Per-head feature size `D` | int32 | Scalar |
+| `rotary_dim` | Input (attribute) | Number of leading dimensions per head transformed by RoPE | int32 | Scalar |
+| `eps` | Input (attribute) | Positive global RMSNorm epsilon | fp32 | Scalar |
+| `tp_world` | Input (attribute) | Number of equal-width tensor-parallel shards participating in the mean | int32 | Scalar |
+| `cos` | Input | Cosine cache; the kernel reads the first `rotary_dim / 2` values of each token row | bf16 | Contiguous and viewable as `[T, C]`, where `C >= rotary_dim / 2` |
+| `sin` | Input | Sine cache; the kernel reads the first `rotary_dim / 2` values of each token row | bf16 | Contiguous and viewable as `[T, C]`, where `C >= rotary_dim / 2` |
+| `q_output` | Output | Globally normalized and rotated local Q shard | bf16 | Contiguous 2-D, `[T, Q]` |
+| `k_output` | Output | Globally normalized and rotated local K shard | bf16 | Contiguous 2-D, `[T, K]` |
+| `v_output` | Output | Local V shard copied from the input | bf16 | Contiguous 2-D, `[T, K]` |
+
+## Constraints
+
+- `input.shape[1]` must equal `q_hidden_size + 2 * kv_hidden_size`; both hidden sizes must be divisible by `head_dim`.
+- `rotary_dim` must be positive, even, and no greater than `head_dim`. `cos` and `sin` must be viewable as token-major rows with at least `rotary_dim / 2` values and compatible row strides. The direct test uses compact `[T, rotary_dim / 2]` rows; the MiniMax production cache may use repeated full-width `[1, T, 1, rotary_dim]` rows, of which the kernel reads the first half.
+- `q_weight.numel()` must equal the local `q_hidden_size`; `k_weight.numel()` must equal the local `kv_hidden_size`. This operator uses per-feature shard weights, not a single `[head_dim]` weight shared across heads.
+- `tp_world` must be positive. When `tp_world > 1`, it must match the initialized tensor-model-parallel process group, and every rank must use equal Q/K shard widths and identical token ordering and count. `tp_world=1` does not enter a collective.
+- `input` must be dense contiguous with row stride exactly `q_hidden_size + 2 * kv_hidden_size`; the first kernel hard-codes this stride. The first kernel pads feature loads to powers of two and masks the padded columns.
+- `T` must be positive. Although the wrapper contains an empty-output return, it first evaluates `input.view(T, -1)`, so a zero-element input is not accepted by the current implementation.
+- The distributed all-reduce is part of the operator semantics. The current test uses only `tp_world=1`, so multi-rank numerical behavior remains a documented test gap.
+
+## Origin and Differences
+
+- **Origin**: Developed in vLLM-Ascend PR #7376 as a native fused TP operator for the MiniMax-M2/M2.5 attention path. Later changes optimized the apply stage and added grid-stride batched loading for the local-statistics stage.
+- **Differences**:
+    - NPU adaptation for performance: fuses local QKV splitting and fp32 statistics, reduces only two scalars per token across TP ranks, and applies global RMSNorm and RoPE in a second vector-core kernel;
+    - Modified for a specific vllm-ascend logic or different input parameters: computes RMSNorm across the globally TP-sharded flattened Q/K vectors, consumes per-feature local weights, and is inserted directly into the patched MiniMax-M2 attention forward path.
+
+## Test Cases
+
+The direct custom-op test covers `T={1,8,32}`, `(Hq,Hkv)={(6,1),(8,2)}`, `D=128`, full and partial RoPE with `R={128,64}`, bf16 QKV/cos/sin, fp32 per-feature weights, and `tp_world=1`. Q, K, and V are compared with a PyTorch reference using `rtol=5e-3, atol=5e-2`. The test executes both Triton kernels but deliberately does not enter the multi-rank all-reduce path.
+
+```bash
+pytest -sv tests/e2e/nightly/single_node/ops/singlecard_ops/triton/test_split_qkv_tp_rmsnorm_rope.py
+```


### PR DESCRIPTION
### What this PR does / why we need it?

This PR adds three related Triton operator documents under
`vllm_ascend/ops/triton/docs/`:

- `split_qkv_rmsnorm_rope.md` documents the fused QKV split, Q/K RMSNorm,
  optional bias, and NeoX-style RoPE operator;
- `split_qkv_rmsnorm_mrope.md` documents the multimodal RoPE variant, including
  the optional attention-gate extraction and interleaved MRoPE layout;
- `split_qkv_tp_rmsnorm_rope.md` documents the two-stage Tensor Parallel
  pipeline formed by `_split_qkv_and_compute_local_qk_var_kernel`, the TP
  all-reduce, and `_apply_global_rmsnorm_kernel`.

The documents describe the formulas, fused execution flows, parameter layouts,
hardware routing, constraints, production call paths, and existing accuracy
test coverage.

They also record the current test-coverage boundaries: the MRoPE optional-bias
branch is not covered, and the TP test executes both kernels with `tp_world=1`
but does not exercise a multi-rank all-reduce.

Documentation only; no operator source or test file is modified.

### Does this PR introduce _any_ user-facing change?

No. This PR only adds documentation for internal Triton operators and does not
change any API, interface, numerical result, or runtime behavior.

### How was this patch tested?

The repository pre-commit workflow was run in the `zrr_dev` Linux container on
the exact PR commit, and all hooks passed:

```bash
bash format.sh ci
```

A non-empty Gitleaks scan of the PR commit range also reported no leaks.

The documents reference the existing accuracy tests below. The tests themselves
are not modified, and no NPU test was rerun for this documentation-only patch:

```bash
pytest -sv tests/e2e/nightly/single_node/ops/singlecard_ops/triton/test_split_qkv_rmsnorm_rope.py
pytest -sv tests/e2e/nightly/single_node/ops/singlecard_ops/triton/test_split_qkv_rmsnorm_mrope.py
pytest -sv tests/e2e/nightly/single_node/ops/singlecard_ops/triton/test_split_qkv_tp_rmsnorm_rope.py
```

- vLLM main: https://github.com/vllm-project/vllm/commit/ba07e4a48fc951300d97eb506217dd530583dea3
