### PR TITLE
[CI] update baseline for nightly single-node case: Kimi-K2-Thinking.yaml

### DIFF
--- a/tests/e2e/nightly/single_node/models/configs/Kimi-K2-Thinking.yaml
+++ b/tests/e2e/nightly/single_node/models/configs/Kimi-K2-Thinking.yaml
@@ -48,5 +48,5 @@ test_cases:
         batch_size: 64
         trust_remote_code: true
         request_rate: 11.2
-        baseline: 43.3429
+        baseline: 41.86
         threshold: 0.97


### PR DESCRIPTION
### What this PR does / why we need it?
update baseline for nightly single-node case: Kimi-K2-Thinking.yaml

### Does this PR introduce _any_ user-facing change?
no

### How was this patch tested?
run the case nightly

- vLLM main: https://github.com/vllm-project/vllm/commit/ba07e4a48fc951300d97eb506217dd530583dea3
