### PR TITLE
[BugFix][Frontend] Handle DeepSeek V4 trailing system messages

### DIFF
--- a/tests/ut/patch/platform/test_deepseek_v4_thinking.py
+++ b/tests/ut/patch/platform/test_deepseek_v4_thinking.py
@@ -23,7 +23,7 @@ class FakeTokenizer:
 
 
 def _mock_checkpoint_config(monkeypatch, *, post_preview: bool) -> None:
-    config = {"dspark_block_size": 5} if post_preview else {"model_type": "deepseek_v4"}
+    config: dict[str, object] = {"dspark_block_size": 5} if post_preview else {"model_type": "deepseek_v4"}
     monkeypatch.setattr(
         patch_deepseek_v4_frontend,
         "get_hf_file_to_dict",

--- a/tests/ut/patch/platform/test_deepseek_v4_thinking.py
+++ b/tests/ut/patch/platform/test_deepseek_v4_thinking.py
@@ -1,6 +1,8 @@
 # SPDX-License-Identifier: Apache-2.0
 
+import pytest
 from vllm.entrypoints.openai.chat_completion.protocol import ChatCompletionRequest
+from vllm.parser.deepseek_v4 import DeepSeekV4Parser
 from vllm.tokenizers import deepseek_v4
 
 from vllm_ascend.utils import vllm_version_is
@@ -11,6 +13,9 @@ class FakeTokenizer:
 
     def get_added_vocab(self):
         return {}
+
+    def get_vocab(self):
+        return {"<think>": 1, "</think>": 2}
 
     def encode(self, text, add_special_tokens=False, **kwargs):
         return text
@@ -94,3 +99,74 @@ def test_deepseek_v4_tokenizer_maps_latest_reasoning_effort_values(monkeypatch):
         )
         assert captured_kwargs[-1]["thinking_mode"] == expected_mode
         assert captured_kwargs[-1]["reasoning_effort"] == expected_effort
+
+
+def test_deepseek_v4_tokenizer_attaches_tools_to_existing_system(monkeypatch):
+    captured_messages = []
+
+    def fake_encode_messages(messages, **kwargs):
+        captured_messages.append(messages)
+        return "prompt"
+
+    monkeypatch.setattr(deepseek_v4, "encode_messages", fake_encode_messages)
+    tokenizer = deepseek_v4.get_deepseek_v4_tokenizer(FakeTokenizer())
+    messages = [
+        {"role": "system", "content": "system prompt"},
+        {"role": "user", "content": "hi"},
+    ]
+    tools = [{"type": "function", "function": {"name": "get_weather"}}]
+    original_messages = [message.copy() for message in messages]
+
+    tokenizer.apply_chat_template(messages, tools=tools, tokenize=False)
+
+    assert captured_messages[-1] == [
+        {"role": "system", "content": "system prompt", "tools": tools},
+        {"role": "user", "content": "hi"},
+    ]
+    assert messages == original_messages
+
+
+def test_deepseek_v4_tokenizer_adds_system_for_tools_when_missing(monkeypatch):
+    captured_messages = []
+
+    def fake_encode_messages(messages, **kwargs):
+        captured_messages.append(messages)
+        return "prompt"
+
+    monkeypatch.setattr(deepseek_v4, "encode_messages", fake_encode_messages)
+    tokenizer = deepseek_v4.get_deepseek_v4_tokenizer(FakeTokenizer())
+    messages = [{"role": "user", "content": "hi"}]
+    tools = [{"type": "function", "function": {"name": "get_weather"}}]
+    original_messages = [message.copy() for message in messages]
+
+    tokenizer.apply_chat_template(messages, tools=tools, tokenize=False)
+
+    assert captured_messages[-1] == [
+        {"role": "system", "tools": tools},
+        {"role": "user", "content": "hi"},
+    ]
+    assert messages == original_messages
+
+
+@pytest.mark.parametrize(
+    ("chat_template_kwargs", "expected_state"),
+    [
+        ({}, "REASONING"),
+        ({"thinking": True}, "REASONING"),
+        ({"enable_thinking": True}, "REASONING"),
+        ({"reasoning_effort": "high"}, "REASONING"),
+        ({"thinking": False}, "CONTENT"),
+        ({"enable_thinking": False}, "CONTENT"),
+        ({"enable_thinking": True, "reasoning_effort": "none"}, "CONTENT"),
+    ],
+)
+def test_parser_thinking_mode_matches_tokenizer_default(
+    chat_template_kwargs,
+    expected_state,
+):
+    parser = DeepSeekV4Parser(
+        FakeTokenizer(),
+        chat_template_kwargs=chat_template_kwargs,
+    )
+
+    assert parser.parser_engine_config.initial_state.name == expected_state

--- a/tests/ut/patch/platform/test_deepseek_v4_thinking.py
+++ b/tests/ut/patch/platform/test_deepseek_v4_thinking.py
@@ -1,7 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
 
-import pickle
-
 import pytest
 from vllm.entrypoints.openai.chat_completion.protocol import ChatCompletionRequest
 from vllm.parser.deepseek_v4 import DeepSeekV4Parser
@@ -248,20 +246,6 @@ def test_rewrapping_tokenizer_binds_method_to_new_instance(monkeypatch):
 
     assert first.apply_chat_template.__self__ is first
     assert second.apply_chat_template.__self__ is second
-
-
-def test_tokenizer_pickle_rebuilds_through_patched_factory(monkeypatch):
-    _mock_checkpoint_config(monkeypatch, post_preview=True)
-    tokenizer = deepseek_v4.get_deepseek_v4_tokenizer(FakeTokenizer())
-
-    restored = pickle.loads(pickle.dumps(tokenizer))
-
-    assert restored.apply_chat_template.__self__ is restored
-    prompt = restored.apply_chat_template(
-        [{"role": "user", "content": "hi"}],
-        tokenize=False,
-    )
-    assert "Reasoning Effort: Absolute maximum" in prompt
 
 
 @pytest.mark.parametrize(

--- a/tests/ut/patch/platform/test_deepseek_v4_thinking.py
+++ b/tests/ut/patch/platform/test_deepseek_v4_thinking.py
@@ -1,15 +1,18 @@
 # SPDX-License-Identifier: Apache-2.0
 
+import pickle
+
 import pytest
 from vllm.entrypoints.openai.chat_completion.protocol import ChatCompletionRequest
 from vllm.parser.deepseek_v4 import DeepSeekV4Parser
-from vllm.tokenizers import deepseek_v4
+from vllm.tokenizers import deepseek_v4, deepseek_v4_encoding
 
-from vllm_ascend.utils import vllm_version_is
+from vllm_ascend.patch.platform import patch_deepseek_v4_frontend
 
 
 class FakeTokenizer:
     vocab_size = 1
+    name_or_path = "deepseek-v4"
 
     def get_added_vocab(self):
         return {}
@@ -19,6 +22,15 @@ class FakeTokenizer:
 
     def encode(self, text, add_special_tokens=False, **kwargs):
         return text
+
+
+def _mock_checkpoint_config(monkeypatch, *, post_preview: bool) -> None:
+    config = {"dspark_block_size": 5} if post_preview else {"model_type": "deepseek_v4"}
+    monkeypatch.setattr(
+        patch_deepseek_v4_frontend,
+        "get_hf_file_to_dict",
+        lambda *args, **kwargs: config,
+    )
 
 
 def test_deepseek_v4_reasoning_effort_accepts_latest_values():
@@ -58,56 +70,99 @@ def test_reasoning_effort_enables_thinking_unless_user_overrides():
     assert params.chat_template_kwargs["enable_thinking"] is False
 
 
-def test_deepseek_v4_tokenizer_maps_latest_reasoning_effort_values(monkeypatch):
+@pytest.mark.parametrize(
+    ("kwargs", "expected_mode", "expected_effort"),
+    [
+        ({}, "thinking", "high"),
+        ({"enable_thinking": True}, "thinking", "high"),
+        ({"enable_thinking": False}, "chat", None),
+        ({"thinking": False}, "chat", None),
+        ({"reasoning_effort": "none"}, "chat", None),
+        ({"reasoning_effort": "minimal"}, "thinking", "low"),
+        ({"reasoning_effort": "low"}, "thinking", "low"),
+        ({"reasoning_effort": "medium"}, "thinking", "low"),
+        ({"reasoning_effort": "high"}, "thinking", "high"),
+        ({"reasoning_effort": "xhigh"}, "thinking", "high"),
+        ({"reasoning_effort": "max"}, "thinking", "max"),
+        ({"reasoning_effort": "unexpected"}, "thinking", "high"),
+        ({"enable_thinking": False, "reasoning_effort": "max"}, "chat", "max"),
+    ],
+)
+def test_post_preview_reasoning_effort_mapping(
+    monkeypatch,
+    kwargs,
+    expected_mode,
+    expected_effort,
+):
     captured_kwargs = []
 
     def fake_encode_messages(messages, **kwargs):
         captured_kwargs.append(kwargs)
         return "prompt"
 
+    _mock_checkpoint_config(monkeypatch, post_preview=True)
     monkeypatch.setattr(deepseek_v4, "encode_messages", fake_encode_messages)
     tokenizer = deepseek_v4.get_deepseek_v4_tokenizer(FakeTokenizer())
+    tokenizer.apply_chat_template(
+        [{"role": "user", "content": "hi"}],
+        tokenize=False,
+        **kwargs,
+    )
 
-    if vllm_version_is("0.27.1"):
-        cases = [
-            ("none", "chat", None),
-            ("minimal", "thinking", "high"),
-            ("low", "thinking", "high"),
-            ("medium", "thinking", "high"),
-            ("high", "thinking", "high"),
-            ("xhigh", "thinking", "max"),
-            ("max", "thinking", "max"),
-            ("unexpected", "thinking", "high"),
-        ]
-    else:
-        cases = [
-            ("none", "chat", None),
-            ("minimal", "thinking", "low"),
-            ("low", "thinking", "low"),
-            ("medium", "thinking", "low"),
-            ("high", "thinking", "high"),
-            ("xhigh", "thinking", "high"),
-            ("max", "thinking", "max"),
-            ("unexpected", "thinking", "high"),
-        ]
-    for reasoning_effort, expected_mode, expected_effort in cases:
-        tokenizer.apply_chat_template(
-            [{"role": "user", "content": "hi"}],
-            tokenize=False,
-            enable_thinking=True,
-            reasoning_effort=reasoning_effort,
-        )
-        assert captured_kwargs[-1]["thinking_mode"] == expected_mode
-        assert captured_kwargs[-1]["reasoning_effort"] == expected_effort
+    assert captured_kwargs[-1]["thinking_mode"] == expected_mode
+    assert captured_kwargs[-1]["reasoning_effort"] == expected_effort
 
 
-def test_deepseek_v4_tokenizer_attaches_tools_to_existing_system(monkeypatch):
+@pytest.mark.parametrize(
+    ("kwargs", "expected_mode", "expected_effort"),
+    [
+        ({}, "thinking", "low"),
+        ({"enable_thinking": True}, "thinking", "low"),
+        ({"enable_thinking": False}, "chat", None),
+        ({"reasoning_effort": "none"}, "chat", None),
+        ({"reasoning_effort": "minimal"}, "thinking", "low"),
+        ({"reasoning_effort": "low"}, "thinking", "low"),
+        ({"reasoning_effort": "medium"}, "thinking", "low"),
+        ({"reasoning_effort": "high"}, "thinking", "low"),
+        ({"reasoning_effort": "xhigh"}, "thinking", "high"),
+        ({"reasoning_effort": "max"}, "thinking", "high"),
+        ({"reasoning_effort": "unexpected"}, "thinking", "low"),
+        ({"enable_thinking": False, "reasoning_effort": "max"}, "chat", "high"),
+    ],
+)
+def test_preview_reasoning_effort_mapping(
+    monkeypatch,
+    kwargs,
+    expected_mode,
+    expected_effort,
+):
+    captured_kwargs = []
+
+    def fake_encode_messages(messages, **kwargs):
+        captured_kwargs.append(kwargs)
+        return "prompt"
+
+    _mock_checkpoint_config(monkeypatch, post_preview=False)
+    monkeypatch.setattr(deepseek_v4, "encode_messages", fake_encode_messages)
+    tokenizer = deepseek_v4.get_deepseek_v4_tokenizer(FakeTokenizer())
+    tokenizer.apply_chat_template(
+        [{"role": "user", "content": "hi"}],
+        tokenize=False,
+        **kwargs,
+    )
+
+    assert captured_kwargs[-1]["thinking_mode"] == expected_mode
+    assert captured_kwargs[-1]["reasoning_effort"] == expected_effort
+
+
+def test_tools_are_attached_to_existing_system_without_mutation(monkeypatch):
     captured_messages = []
 
     def fake_encode_messages(messages, **kwargs):
         captured_messages.append(messages)
         return "prompt"
 
+    _mock_checkpoint_config(monkeypatch, post_preview=True)
     monkeypatch.setattr(deepseek_v4, "encode_messages", fake_encode_messages)
     tokenizer = deepseek_v4.get_deepseek_v4_tokenizer(FakeTokenizer())
     messages = [
@@ -126,18 +181,18 @@ def test_deepseek_v4_tokenizer_attaches_tools_to_existing_system(monkeypatch):
     assert messages == original_messages
 
 
-def test_deepseek_v4_tokenizer_adds_system_for_tools_when_missing(monkeypatch):
+def test_tools_add_system_when_missing(monkeypatch):
     captured_messages = []
 
     def fake_encode_messages(messages, **kwargs):
         captured_messages.append(messages)
         return "prompt"
 
+    _mock_checkpoint_config(monkeypatch, post_preview=True)
     monkeypatch.setattr(deepseek_v4, "encode_messages", fake_encode_messages)
     tokenizer = deepseek_v4.get_deepseek_v4_tokenizer(FakeTokenizer())
     messages = [{"role": "user", "content": "hi"}]
     tools = [{"type": "function", "function": {"name": "get_weather"}}]
-    original_messages = [message.copy() for message in messages]
 
     tokenizer.apply_chat_template(messages, tools=tools, tokenize=False)
 
@@ -145,7 +200,68 @@ def test_deepseek_v4_tokenizer_adds_system_for_tools_when_missing(monkeypatch):
         {"role": "system", "tools": tools},
         {"role": "user", "content": "hi"},
     ]
-    assert messages == original_messages
+    assert messages == [{"role": "user", "content": "hi"}]
+
+
+def test_conversation_keyword_is_bound_once(monkeypatch):
+    captured_messages = []
+
+    def fake_encode_messages(messages, **kwargs):
+        captured_messages.append(messages)
+        return "prompt"
+
+    _mock_checkpoint_config(monkeypatch, post_preview=True)
+    monkeypatch.setattr(deepseek_v4, "encode_messages", fake_encode_messages)
+    tokenizer = deepseek_v4.get_deepseek_v4_tokenizer(FakeTokenizer())
+    messages = [{"role": "user", "content": "ignored"}]
+    conversation = [{"role": "user", "content": "used"}]
+    tools = [{"type": "function", "function": {"name": "get_weather"}}]
+
+    tokenizer.apply_chat_template(
+        messages,
+        conversation=conversation,
+        tools=tools,
+        tokenize=False,
+    )
+
+    assert captured_messages[-1] == [
+        {"role": "system", "tools": tools},
+        {"role": "user", "content": "used"},
+    ]
+
+
+def test_tokenizer_instances_do_not_modify_generated_class(monkeypatch):
+    _mock_checkpoint_config(monkeypatch, post_preview=True)
+    first = deepseek_v4.get_deepseek_v4_tokenizer(FakeTokenizer())
+    first_class_apply = type(first).apply_chat_template
+    second = deepseek_v4.get_deepseek_v4_tokenizer(FakeTokenizer())
+
+    assert type(first).apply_chat_template is first_class_apply
+    assert "apply_chat_template" in first.__dict__
+    assert "apply_chat_template" in second.__dict__
+
+
+def test_rewrapping_tokenizer_binds_method_to_new_instance(monkeypatch):
+    _mock_checkpoint_config(monkeypatch, post_preview=True)
+    first = deepseek_v4.get_deepseek_v4_tokenizer(FakeTokenizer())
+    second = deepseek_v4.get_deepseek_v4_tokenizer(first)
+
+    assert first.apply_chat_template.__self__ is first
+    assert second.apply_chat_template.__self__ is second
+
+
+def test_tokenizer_pickle_rebuilds_through_patched_factory(monkeypatch):
+    _mock_checkpoint_config(monkeypatch, post_preview=True)
+    tokenizer = deepseek_v4.get_deepseek_v4_tokenizer(FakeTokenizer())
+
+    restored = pickle.loads(pickle.dumps(tokenizer))
+
+    assert restored.apply_chat_template.__self__ is restored
+    prompt = restored.apply_chat_template(
+        [{"role": "user", "content": "hi"}],
+        tokenize=False,
+    )
+    assert "Reasoning Effort: Absolute maximum" in prompt
 
 
 @pytest.mark.parametrize(
@@ -168,5 +284,72 @@ def test_parser_thinking_mode_matches_tokenizer_default(
         FakeTokenizer(),
         chat_template_kwargs=chat_template_kwargs,
     )
-
     assert parser.parser_engine_config.initial_state.name == expected_state
+
+
+@pytest.mark.parametrize(
+    ("post_preview", "reasoning_effort", "expected_prefix"),
+    [
+        (False, None, "<｜begin▁of▁sentence｜><｜User｜>hi"),
+        (False, "high", "<｜begin▁of▁sentence｜><｜User｜>hi"),
+        (
+            False,
+            "max",
+            "<｜begin▁of▁sentence｜>Reasoning Effort: Absolute maximum",
+        ),
+        (
+            True,
+            "high",
+            "<｜begin▁of▁sentence｜>Reasoning Effort: Absolute maximum",
+        ),
+        (
+            True,
+            "max",
+            "<｜begin▁of▁sentence｜>Reasoning Effort: Beyond maximum",
+        ),
+    ],
+)
+def test_checkpoint_specific_reasoning_prompts(
+    monkeypatch,
+    post_preview,
+    reasoning_effort,
+    expected_prefix,
+):
+    _mock_checkpoint_config(monkeypatch, post_preview=post_preview)
+    tokenizer = deepseek_v4.get_deepseek_v4_tokenizer(FakeTokenizer())
+    kwargs = {} if reasoning_effort is None else {"reasoning_effort": reasoning_effort}
+    prompt = tokenizer.apply_chat_template(
+        [{"role": "user", "content": "hi"}],
+        tokenize=False,
+        **kwargs,
+    )
+    assert prompt.startswith(expected_prefix)
+    assert prompt.endswith("<｜Assistant｜><think>")
+
+
+def test_checkpoint_config_failure_uses_preview_mapping(monkeypatch):
+    def unavailable_config(*args, **kwargs):
+        raise OSError("config unavailable")
+
+    monkeypatch.setattr(
+        patch_deepseek_v4_frontend,
+        "get_hf_file_to_dict",
+        unavailable_config,
+    )
+    tokenizer = deepseek_v4.get_deepseek_v4_tokenizer(FakeTokenizer())
+    prompt = tokenizer.apply_chat_template(
+        [{"role": "user", "content": "hi"}],
+        tokenize=False,
+    )
+
+    assert prompt.startswith("<｜begin▁of▁sentence｜><｜User｜>hi")
+
+
+def test_deepseek_v4_rejects_invalid_renderer_reasoning_effort():
+    with pytest.raises((AssertionError, ValueError), match="Invalid reasoning effort"):
+        deepseek_v4_encoding.render_message(
+            0,
+            [{"role": "user", "content": "hi"}],
+            thinking_mode="thinking",
+            reasoning_effort="unexpected",
+        )

--- a/tests/ut/patch/platform/test_deepseek_v4_tool_streaming.py
+++ b/tests/ut/patch/platform/test_deepseek_v4_tool_streaming.py
@@ -1,0 +1,258 @@
+# SPDX-License-Identifier: Apache-2.0
+
+import json
+from unittest.mock import MagicMock
+
+import pytest
+from vllm.entrypoints.openai.chat_completion.protocol import (
+    ChatCompletionToolsParam,
+    FunctionDefinition,
+)
+from vllm.parser.deepseek_v4 import DeepSeekV4Parser
+from vllm.tool_parsers.deepseekv4_engine_tool_parser import (
+    DeepSeekV4EngineToolParser,
+)
+
+TOOL_START = "<｜DSML｜tool_calls>\n"
+INVOKE_START = '<｜DSML｜invoke name="emit_text">\n'
+INVOKE_END = "</｜DSML｜invoke>\n"
+TOOL_END = "</｜DSML｜tool_calls>"
+PARAM_CLOSE = "</｜DSML｜parameter>"
+
+
+class FakeTokenizer:
+    def get_vocab(self):
+        return {}
+
+
+def _param_open(name: str, is_string: bool) -> str:
+    string_attr = "true" if is_string else "false"
+    return f'<｜DSML｜parameter name="{name}" string="{string_attr}">'
+
+
+def _make_parser(properties: dict, parser_cls=DeepSeekV4Parser):
+    tool = ChatCompletionToolsParam(
+        type="function",
+        function=FunctionDefinition(
+            name="emit_text",
+            parameters={
+                "type": "object",
+                "properties": properties,
+                "required": list(properties),
+            },
+        ),
+    )
+    request = MagicMock(tools=[tool], tool_choice="auto")
+    parser = parser_cls(
+        FakeTokenizer(),
+        tools=[tool],
+        chat_template_kwargs={"enable_thinking": False},
+    )
+    return parser, request
+
+
+def _arguments_from_delta(delta) -> list[str]:
+    arguments = []
+    if delta and delta.tool_calls:
+        for tool_call in delta.tool_calls:
+            if tool_call.function and tool_call.function.arguments:
+                arguments.append(tool_call.function.arguments)
+    return arguments
+
+
+def _stream_chunks(parser, request, chunks: list[str], *, finish: bool = False):
+    previous_text = ""
+    argument_deltas: list[tuple[int, str]] = []
+    for index, delta_text in enumerate(chunks):
+        current_text = previous_text + delta_text
+        delta = parser.extract_tool_calls_streaming(
+            previous_text=previous_text,
+            current_text=current_text,
+            delta_text=delta_text,
+            previous_token_ids=[],
+            current_token_ids=[],
+            delta_token_ids=[index + 1],
+            request=request,
+        )
+        previous_text = current_text
+        argument_deltas.extend((index, arguments) for arguments in _arguments_from_delta(delta))
+
+    if finish:
+        argument_deltas.extend(
+            (len(chunks), arguments) for arguments in _arguments_from_delta(parser.finish_streaming())
+        )
+    return argument_deltas
+
+
+def _long_string_chunks(body: str, chunk_size: int = 32) -> list[str]:
+    chunks = [TOOL_START + INVOKE_START + _param_open("text", True)]
+    chunks.extend(body[i : i + chunk_size] for i in range(0, len(body), chunk_size))
+    chunks.append(PARAM_CLOSE + "\n" + INVOKE_END + TOOL_END)
+    return chunks
+
+
+def _joined_arguments(argument_deltas: list[tuple[int, str]]) -> str:
+    return "".join(value for _, value in argument_deltas)
+
+
+def test_long_string_streams_before_parameter_close():
+    body = "A" * 4096
+    parser, request = _make_parser(
+        {"text": {"type": "string"}},
+        parser_cls=DeepSeekV4EngineToolParser,
+    )
+    chunks = _long_string_chunks(body)
+    argument_deltas = _stream_chunks(parser, request, chunks)
+
+    body_deltas = [value for index, value in argument_deltas if 0 < index < len(chunks) - 1]
+
+    assert len(body_deltas) > 1
+    assert json.loads(_joined_arguments(argument_deltas)) == {"text": body}
+
+
+def test_string_escaping_and_unicode_reconstruct_exactly():
+    body = 'quote=" slash=\\ newline=\n tab=\t nul=\x00 angle=> unicode=杭州'
+    parser, request = _make_parser({"text": {"type": "string"}})
+    argument_deltas = _stream_chunks(
+        parser,
+        request,
+        _long_string_chunks(body, chunk_size=3),
+    )
+
+    assert json.loads(_joined_arguments(argument_deltas)) == {"text": body}
+
+
+def test_split_parameter_close_does_not_leak_into_arguments():
+    parser, request = _make_parser({"text": {"type": "string"}})
+    chunks = [
+        TOOL_START + INVOKE_START + _param_open("text", True),
+        "alpha",
+        "</｜DSML｜para",
+        "meter>\n" + INVOKE_END + TOOL_END,
+    ]
+    argument_deltas = _stream_chunks(parser, request, chunks)
+
+    assert all("｜DSML｜" not in value for _, value in argument_deltas)
+    assert json.loads(_joined_arguments(argument_deltas)) == {"text": "alpha"}
+
+
+def test_string_numeric_and_second_string_keep_types_and_streaming():
+    properties = {
+        "text": {"type": "string"},
+        "count": {"type": "integer"},
+        "suffix": {"type": "string"},
+    }
+    parser, request = _make_parser(properties)
+    chunks = [
+        TOOL_START + INVOKE_START + _param_open("text", True),
+        "alpha",
+        PARAM_CLOSE + "\n" + _param_open("count", False),
+        "42",
+        PARAM_CLOSE + "\n" + _param_open("suffix", True),
+        "omega",
+        PARAM_CLOSE + "\n" + INVOKE_END + TOOL_END,
+    ]
+    argument_deltas = _stream_chunks(parser, request, chunks)
+
+    assert any(index == 1 and "alpha" in value for index, value in argument_deltas)
+    assert not any(index == 3 for index, _ in argument_deltas)
+    assert any(index == 5 and "omega" in value for index, value in argument_deltas)
+    assert json.loads(_joined_arguments(argument_deltas)) == {
+        "text": "alpha",
+        "count": 42,
+        "suffix": "omega",
+    }
+
+
+def test_split_next_parameter_header_does_not_leak_into_previous_string():
+    properties = {
+        "text": {"type": "string"},
+        "suffix": {"type": "string"},
+    }
+    parser, request = _make_parser(properties)
+    chunks = [
+        TOOL_START + INVOKE_START + _param_open("text", True),
+        "alpha",
+        PARAM_CLOSE + '\n<｜DSML｜parameter name="suf',
+        'fix" string="true">',
+        "omega",
+        PARAM_CLOSE + "\n" + INVOKE_END + TOOL_END,
+    ]
+    argument_deltas = _stream_chunks(parser, request, chunks)
+
+    arguments = _joined_arguments(argument_deltas)
+    assert "｜DSML｜" not in arguments
+    assert json.loads(arguments) == {"text": "alpha", "suffix": "omega"}
+
+
+def test_nullable_string_remains_buffered_until_stable():
+    body = "not-null" * 128
+    parser, request = _make_parser(
+        {
+            "text": {
+                "anyOf": [
+                    {"type": "string"},
+                    {"type": "null"},
+                ]
+            }
+        }
+    )
+    chunks = _long_string_chunks(body)
+    argument_deltas = _stream_chunks(parser, request, chunks)
+
+    assert not any(0 < index < len(chunks) - 1 for index, _ in argument_deltas)
+    assert json.loads(_joined_arguments(argument_deltas)) == {"text": body}
+
+
+def test_escaped_parameter_name_remains_buffered_until_stable():
+    parameter_name = "text\\key"
+    body = "value" * 128
+    parser, request = _make_parser({parameter_name: {"type": "string"}})
+    chunks = [TOOL_START + INVOKE_START + _param_open(parameter_name, True)]
+    chunks.extend(body[i : i + 32] for i in range(0, len(body), 32))
+    chunks.append(PARAM_CLOSE + "\n" + INVOKE_END + TOOL_END)
+    argument_deltas = _stream_chunks(parser, request, chunks)
+
+    assert not any(0 < index < len(chunks) - 1 for index, _ in argument_deltas)
+    assert json.loads(_joined_arguments(argument_deltas)) == {parameter_name: body}
+
+
+def test_truncated_string_remains_invalid_json():
+    parser, request = _make_parser({"text": {"type": "string"}})
+    chunks = [
+        TOOL_START + INVOKE_START + _param_open("text", True),
+        "unfinished ",
+        "body",
+    ]
+    argument_deltas = _stream_chunks(parser, request, chunks, finish=True)
+
+    with pytest.raises(json.JSONDecodeError):
+        json.loads(_joined_arguments(argument_deltas))
+
+
+def test_long_body_does_not_repeatedly_call_converter():
+    body = "A" * 4096
+    parser, request = _make_parser({"text": {"type": "string"}})
+    original_converter = parser._arg_converter
+    converter_calls = 0
+
+    def counting_converter(raw_args: str, partial: bool) -> str:
+        nonlocal converter_calls
+        converter_calls += 1
+        return original_converter(raw_args, partial)
+
+    parser._arg_converter = counting_converter
+    argument_deltas = _stream_chunks(parser, request, _long_string_chunks(body))
+
+    assert converter_calls <= 4
+    assert json.loads(_joined_arguments(argument_deltas)) == {"text": body}
+
+
+def test_parser_reuse_clears_direct_streaming_state():
+    parser, request = _make_parser({"text": {"type": "string"}})
+    first = _stream_chunks(parser, request, _long_string_chunks("first"))
+    parser._reset()
+    second = _stream_chunks(parser, request, _long_string_chunks("second"))
+
+    assert json.loads(_joined_arguments(first)) == {"text": "first"}
+    assert json.loads(_joined_arguments(second)) == {"text": "second"}

--- a/tests/ut/patch/platform/test_deepseek_v4_tool_streaming.py
+++ b/tests/ut/patch/platform/test_deepseek_v4_tool_streaming.py
@@ -24,6 +24,9 @@ class FakeTokenizer:
     def get_vocab(self):
         return {}
 
+    def decode(self, token_ids):
+        return ""
+
 
 def _param_open(name: str, is_string: bool) -> str:
     string_attr = "true" if is_string else "false"

--- a/tests/ut/patch/platform/test_deepseek_v4_trailing_system.py
+++ b/tests/ut/patch/platform/test_deepseek_v4_trailing_system.py
@@ -1,0 +1,55 @@
+# SPDX-License-Identifier: Apache-2.0
+
+from vllm.tokenizers import deepseek_v4_encoding
+
+import vllm_ascend.patch.platform.patch_deepseek_v4_trailing_system  # noqa: F401
+
+
+def test_trailing_system_appends_assistant_transition():
+    messages = [
+        {"role": "system", "content": "rules"},
+        {"role": "user", "content": "question"},
+        {"role": "system", "content": "final rules"},
+    ]
+
+    chat_prompt = deepseek_v4_encoding.encode_messages(messages, thinking_mode="chat")
+    thinking_prompt = deepseek_v4_encoding.encode_messages(
+        messages,
+        thinking_mode="thinking",
+    )
+
+    prefix = "<｜begin▁of▁sentence｜>rules<｜User｜>questionfinal rules"
+    assert chat_prompt == prefix + "<｜Assistant｜></think>"
+    assert thinking_prompt == prefix + "<｜Assistant｜><think>"
+
+
+def test_system_to_assistant_appends_transition():
+    messages = [
+        {"role": "system", "content": "rules"},
+        {"role": "assistant", "reasoning": "reason", "content": "answer"},
+    ]
+
+    chat_prompt = deepseek_v4_encoding.encode_messages(messages, thinking_mode="chat")
+    thinking_prompt = deepseek_v4_encoding.encode_messages(
+        messages,
+        thinking_mode="thinking",
+    )
+
+    assert chat_prompt == ("<｜begin▁of▁sentence｜>rules<｜Assistant｜></think>answer<｜end▁of▁sentence｜>")
+    assert thinking_prompt == (
+        "<｜begin▁of▁sentence｜>rules<｜Assistant｜><think>reason</think>answer<｜end▁of▁sentence｜>"
+    )
+
+
+def test_mid_conversation_system_does_not_append_transition():
+    messages = [
+        {"role": "user", "content": "first"},
+        {"role": "assistant", "content": "answer"},
+        {"role": "system", "content": "new rules"},
+        {"role": "user", "content": "second"},
+    ]
+
+    prompt = deepseek_v4_encoding.encode_messages(messages, thinking_mode="chat")
+
+    assert "new rules<｜User｜>second" in prompt
+    assert "new rules<｜Assistant｜>" not in prompt

--- a/tests/ut/patch/platform/test_deepseek_v4_trailing_system.py
+++ b/tests/ut/patch/platform/test_deepseek_v4_trailing_system.py
@@ -1,8 +1,10 @@
 # SPDX-License-Identifier: Apache-2.0
 
+import inspect
+
 from vllm.tokenizers import deepseek_v4_encoding
 
-import vllm_ascend.patch.platform.patch_deepseek_v4_trailing_system  # noqa: F401
+import vllm_ascend.patch.platform.patch_deepseek_v4_trailing_system as trailing_system_patch
 
 
 def test_trailing_system_appends_assistant_transition():
@@ -53,3 +55,18 @@ def test_mid_conversation_system_does_not_append_transition():
 
     assert "new rules<｜User｜>second" in prompt
     assert "new rules<｜Assistant｜>" not in prompt
+
+
+def test_probe_skips_incompatible_signature(monkeypatch):
+    def render_message(index, messages, thinking_mode, required):
+        del index, messages, thinking_mode, required
+        return ""
+
+    monkeypatch.setattr(
+        trailing_system_patch,
+        "_render_message_signature",
+        inspect.signature(render_message),
+    )
+    monkeypatch.setattr(trailing_system_patch, "_original_render_message", render_message)
+
+    assert not trailing_system_patch._needs_trailing_system_patch()

--- a/vllm_ascend/patch/__init__.py
+++ b/vllm_ascend/patch/__init__.py
@@ -90,6 +90,23 @@
 #    Future Plan:
 #       Remove this patch once the supported vLLM version contains PR #52865.
 #
+# ** 4. File: platform/patch_deepseek_v4_trailing_system.py**
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+#   1. `vllm.tokenizers.deepseek_v4_encoding.render_message`
+#    Why:
+#       The supported vLLM version does not append the assistant transition
+#       after a trailing DeepSeek V4 system message. Generation then starts at
+#       an invalid prompt boundary and can return empty content or raw tags.
+#    How:
+#       Append the existing assistant/thinking transition after a trailing
+#       system message or before an assistant history turn. A system message
+#       followed by a user or latest-reminder message remains unchanged. The
+#       patch is skipped when a behavior probe detects the upstream fix.
+#    Related PR (if no, explain why):
+#       https://github.com/vllm-project/vllm/pull/51262
+#    Future Plan:
+#       Remove this patch once the supported vLLM version contains PR #51262.
+#
 # ** 2. File: platform/patch_deepseek_v4_vision.py**
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 #   1. `vllm.transformers_utils.model_arch_config_convertor.MODEL_ARCH_CONFIG_CONVERTORS`

--- a/vllm_ascend/patch/__init__.py
+++ b/vllm_ascend/patch/__init__.py
@@ -51,21 +51,25 @@
 # ** 2. File: platform/patch_deepseek_v4_frontend.py**
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 #   1. `vllm.tokenizers.deepseek_v4.get_deepseek_v4_tokenizer`
-#      `vllm.parser.deepseek_v4.DeepSeekV4Parser.__init__`
+#      `vllm.parser.deepseek_v4.DeepSeekV4Parser.__init__` (legacy vLLM only)
 #    Why:
-#       The supported vLLM inserts request tools before an existing system
-#       message and initializes the parser in content mode when thinking
-#       controls are omitted. Both differ from the DeepSeek V4 tokenizer
-#       default and checkpoint renderer.
+#       vLLM v0.27.1 inserts request tools before an existing system message,
+#       defaults the parser to content mode, and does not expose the current
+#       reasoning-effort prompt mapping. The pre-0731 checkpoint and post-0731
+#       (dspark_*) checkpoint use different effort mappings.
 #    How:
-#       Attach tools to a shallow copy of the first system message, or insert
-#       a system message only when one is absent. Default the parser to
-#       thinking only when neither thinking control is present.
+#       Bind one wrapper to each returned tokenizer instance, attach tools to a
+#       shallow copy of the first system message (or insert one when absent),
+#       and use inspect-based behavior detection for legacy renderer/parser
+#       compatibility. Checkpoints without dspark_* use the Preview mapping:
+#       default/high have no prefix and max/xhigh use Absolute maximum. The
+#       dspark_* mapping keeps the post-Preview low/high/max behavior.
 #    Related PR (if no, explain why):
 #       https://github.com/vllm-project/vllm/issues/51829
 #       https://github.com/vllm-project/vllm/pull/51856
 #       https://github.com/vllm-project/vllm/pull/52255
 #       https://github.com/vllm-project/vllm/pull/51296
+#       https://github.com/vllm-project/vllm-ascend/pull/14952
 #    Future Plan:
 #       Remove this patch once both behaviors are in the supported vLLM.
 #

--- a/vllm_ascend/patch/__init__.py
+++ b/vllm_ascend/patch/__init__.py
@@ -48,6 +48,44 @@
 #    Future Plan:
 #       Remove this patch when vLLM merge the PR.
 #
+# ** 2. File: platform/patch_deepseek_v4_frontend.py**
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+#   1. `vllm.tokenizers.deepseek_v4.get_deepseek_v4_tokenizer`
+#      `vllm.parser.deepseek_v4.DeepSeekV4Parser.__init__`
+#    Why:
+#       The supported vLLM inserts request tools before an existing system
+#       message and initializes the parser in content mode when thinking
+#       controls are omitted. Both differ from the DeepSeek V4 tokenizer
+#       default and checkpoint renderer.
+#    How:
+#       Attach tools to a shallow copy of the first system message, or insert
+#       a system message only when one is absent. Default the parser to
+#       thinking only when neither thinking control is present.
+#    Related PR (if no, explain why):
+#       https://github.com/vllm-project/vllm/issues/51829
+#       https://github.com/vllm-project/vllm/pull/51856
+#       https://github.com/vllm-project/vllm/pull/52255
+#       https://github.com/vllm-project/vllm/pull/51296
+#    Future Plan:
+#       Remove this patch once both behaviors are in the supported vLLM.
+#
+# ** 3. File: platform/patch_deepseek_v4_tool_streaming.py**
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+#   1. `vllm.parser.deepseek_v4.DeepSeekV4Parser._compute_arg_delta`
+#    Why:
+#       The supported vLLM skips argument conversion for DeepSeek V4 parameter-body
+#       deltas without `>`. A long string is consequently emitted only when
+#       `</parameter>` arrives instead of streaming incrementally.
+#    How:
+#       After the original converter confirms an in-progress, schema-stable
+#       string parameter, JSON-escape and emit plain body deltas directly.
+#       Structural deltas and final conversion remain on the original path.
+#       Skip installation once upstream removes the structural-character filter.
+#    Related PR (if no, explain why):
+#       https://github.com/vllm-project/vllm/pull/52865
+#    Future Plan:
+#       Remove this patch once the supported vLLM version contains PR #52865.
+#
 # ** 2. File: platform/patch_deepseek_v4_vision.py**
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 #   1. `vllm.transformers_utils.model_arch_config_convertor.MODEL_ARCH_CONFIG_CONVERTORS`

--- a/vllm_ascend/patch/platform/__init__.py
+++ b/vllm_ascend/patch/platform/__init__.py
@@ -16,6 +16,8 @@
 
 import os
 
+import vllm_ascend.patch.platform.patch_deepseek_v4_frontend  # noqa
+import vllm_ascend.patch.platform.patch_deepseek_v4_tool_streaming  # noqa
 import vllm_ascend.patch.platform.patch_deepseek_v4_vision  # noqa
 import vllm_ascend.patch.platform.patch_distributed  # noqa
 import vllm_ascend.patch.platform.patch_kv_cache_utils  # noqa

--- a/vllm_ascend/patch/platform/__init__.py
+++ b/vllm_ascend/patch/platform/__init__.py
@@ -18,6 +18,7 @@ import os
 
 import vllm_ascend.patch.platform.patch_deepseek_v4_frontend  # noqa
 import vllm_ascend.patch.platform.patch_deepseek_v4_tool_streaming  # noqa
+import vllm_ascend.patch.platform.patch_deepseek_v4_trailing_system  # noqa
 import vllm_ascend.patch.platform.patch_deepseek_v4_vision  # noqa
 import vllm_ascend.patch.platform.patch_distributed  # noqa
 import vllm_ascend.patch.platform.patch_kv_cache_utils  # noqa

--- a/vllm_ascend/patch/platform/patch_deepseek_v4_frontend.py
+++ b/vllm_ascend/patch/platform/patch_deepseek_v4_frontend.py
@@ -1,0 +1,62 @@
+# SPDX-License-Identifier: Apache-2.0
+
+from functools import wraps
+from typing import Any
+
+from vllm.parser.deepseek_v4 import DeepSeekV4Parser
+from vllm.tokenizers import deepseek_v4
+
+_original_get_deepseek_v4_tokenizer = deepseek_v4.get_deepseek_v4_tokenizer
+_original_deepseek_v4_parser_init = DeepSeekV4Parser.__init__
+
+
+@wraps(_original_get_deepseek_v4_tokenizer)
+def _patched_get_deepseek_v4_tokenizer(tokenizer: deepseek_v4.HfTokenizer):
+    dsv4_tokenizer = _original_get_deepseek_v4_tokenizer(tokenizer)
+    tokenizer_cls = type(dsv4_tokenizer)
+    original_apply_chat_template = tokenizer_cls.apply_chat_template
+
+    @wraps(original_apply_chat_template)
+    def apply_chat_template(
+        self,
+        messages,
+        tools=None,
+        **kwargs,
+    ):
+        if tools:
+            conversation = kwargs.get("conversation", messages).copy()
+            system_index = next(
+                (index for index, message in enumerate(conversation) if message.get("role") == "system"),
+                None,
+            )
+            if system_index is None:
+                conversation.insert(0, {"role": "system", "tools": tools})
+            else:
+                system_message = conversation[system_index].copy()
+                system_message["tools"] = tools
+                conversation[system_index] = system_message
+            kwargs["conversation"] = conversation
+            tools = None
+        return original_apply_chat_template(self, messages, tools=tools, **kwargs)
+
+    tokenizer_cls.apply_chat_template = apply_chat_template
+    return dsv4_tokenizer
+
+
+@wraps(_original_deepseek_v4_parser_init)
+def _patched_deepseek_v4_parser_init(
+    self: DeepSeekV4Parser,
+    *args: Any,
+    **kwargs: Any,
+) -> None:
+    chat_kwargs = kwargs.get("chat_template_kwargs") or {}
+    if "thinking" not in chat_kwargs and "enable_thinking" not in chat_kwargs:
+        chat_kwargs = dict(chat_kwargs)
+        chat_kwargs["enable_thinking"] = True
+        kwargs["chat_template_kwargs"] = chat_kwargs
+
+    _original_deepseek_v4_parser_init(self, *args, **kwargs)
+
+
+deepseek_v4.get_deepseek_v4_tokenizer = _patched_get_deepseek_v4_tokenizer
+DeepSeekV4Parser.__init__ = _patched_deepseek_v4_parser_init

--- a/vllm_ascend/patch/platform/patch_deepseek_v4_frontend.py
+++ b/vllm_ascend/patch/platform/patch_deepseek_v4_frontend.py
@@ -1,62 +1,207 @@
 # SPDX-License-Identifier: Apache-2.0
 
+import inspect
 from functools import wraps
+from types import MethodType
 from typing import Any
 
 from vllm.parser.deepseek_v4 import DeepSeekV4Parser
-from vllm.tokenizers import deepseek_v4
+from vllm.tokenizers import deepseek_v4, deepseek_v4_encoding
+from vllm.transformers_utils.repo_utils import get_hf_file_to_dict
+
+REASONING_EFFORT_PROMPTS = {
+    "low": "",
+    "high": (
+        "Reasoning Effort: Absolute maximum with no shortcuts permitted.\n"
+        "You MUST be very thorough in your thinking and comprehensively "
+        "decompose the problem to resolve the root cause, rigorously "
+        "stress-testing your logic against all potential paths, edge cases, "
+        "and adversarial scenarios.\n"
+        "Explicitly write out your entire deliberation process, documenting "
+        "every intermediate step, considered alternative, and rejected "
+        "hypothesis to ensure absolutely no assumption is left unchecked.\n\n"
+    ),
+    "max": (
+        "Reasoning Effort: Beyond maximum — exhaustive, relentless, and "
+        "uncompromising.\n"
+        "You MUST reason with the utmost depth and rigor, leaving absolutely "
+        "nothing to chance: exhaustively decompose the problem into its most "
+        "fundamental components, trace every causal chain to its root, and "
+        "resolve the underlying cause rather than any surface symptom.\n"
+        "Do not stop reasoning until you have independently verified the "
+        "solution from multiple angles and are certain that no assumption "
+        "remains unchecked and no error remains undiscovered.\n\n"
+    ),
+}
 
 _original_get_deepseek_v4_tokenizer = deepseek_v4.get_deepseek_v4_tokenizer
-_original_deepseek_v4_parser_init = DeepSeekV4Parser.__init__
+_original_parser_init = DeepSeekV4Parser.__init__
+_original_parser_init_signature = inspect.signature(_original_parser_init)
 
 
-@wraps(_original_get_deepseek_v4_tokenizer)
+def _uses_preview_reasoning_effort_mapping(tokenizer: Any) -> bool:
+    """The pre-0731 checkpoint has no ``dspark_*`` config fields."""
+    model_name_or_path = getattr(tokenizer, "name_or_path", None)
+    if not model_name_or_path:
+        return True
+    try:
+        config = get_hf_file_to_dict("config.json", model_name_or_path)
+    except Exception:
+        return True
+    return not (config and any(key.startswith("dspark_") for key in config))
+
+
+def _needs_legacy_renderer_patch() -> bool:
+    """v0.27.1 exposes only ``REASONING_EFFORT_MAX``."""
+    return not hasattr(deepseek_v4_encoding, "REASONING_EFFORT_PROMPTS")
+
+
+def _needs_legacy_parser_patch() -> bool:
+    """Detect the old parser default without keying the patch to a version."""
+
+    class _ProbeTokenizer:
+        def get_vocab(self) -> dict[str, int]:
+            return {}
+
+    parser = DeepSeekV4Parser(
+        _ProbeTokenizer(),
+        chat_template_kwargs={},
+    )
+    return parser.parser_engine_config.initial_state.name != "REASONING"
+
+
+_USES_LEGACY_RENDERER = _needs_legacy_renderer_patch()
+_USES_LEGACY_PARSER = _needs_legacy_parser_patch()
+
+
+def _patched_render_message(
+    index: int,
+    messages: list[dict[str, Any]],
+    thinking_mode: str,
+    drop_thinking: bool = True,
+    reasoning_effort: str | None = None,
+) -> str:
+    reasoning_effort = reasoning_effort or "low"
+    if reasoning_effort not in REASONING_EFFORT_PROMPTS:
+        raise ValueError(
+            f"Invalid reasoning effort: {reasoning_effort}, expected one of {list(REASONING_EFFORT_PROMPTS)}"
+        )
+    prompt = _original_render_message(
+        index,
+        messages,
+        thinking_mode,
+        drop_thinking,
+        reasoning_effort="high",
+    )
+    if index == 0 and thinking_mode == "thinking":
+        return REASONING_EFFORT_PROMPTS[reasoning_effort] + prompt
+    return prompt
+
+
+def _normalize_reasoning_effort(
+    reasoning_effort: Any,
+    thinking_enabled: bool,
+    uses_preview_mapping: bool,
+) -> tuple[str, str | None]:
+    thinking_mode = "thinking" if thinking_enabled else "chat"
+    if not isinstance(reasoning_effort, str):
+        canonical = "low" if uses_preview_mapping else "high"
+        return thinking_mode, canonical if thinking_enabled else None
+    if reasoning_effort == "none":
+        return "chat", None
+    if uses_preview_mapping:
+        canonical = "high" if reasoning_effort in ("max", "xhigh") else "low"
+    elif reasoning_effort == "max":
+        canonical = "max"
+    elif reasoning_effort in ("low", "minimal", "medium"):
+        canonical = "low"
+    else:
+        canonical = "high"
+    return thinking_mode, canonical
+
+
+def _attach_tools(messages: Any, tools: list[dict[str, Any]] | None) -> Any:
+    if not tools:
+        return messages
+    conversation = list(messages)
+    system_index = next(
+        (index for index, message in enumerate(conversation) if message.get("role") == "system"),
+        None,
+    )
+    if system_index is None:
+        conversation.insert(0, {"role": "system", "tools": tools})
+    else:
+        system_message = conversation[system_index].copy()
+        system_message["tools"] = tools
+        conversation[system_index] = system_message
+    return conversation
+
+
 def _patched_get_deepseek_v4_tokenizer(tokenizer: deepseek_v4.HfTokenizer):
     dsv4_tokenizer = _original_get_deepseek_v4_tokenizer(tokenizer)
-    tokenizer_cls = type(dsv4_tokenizer)
-    original_apply_chat_template = tokenizer_cls.apply_chat_template
+    uses_preview_mapping = _uses_preview_reasoning_effort_mapping(tokenizer)
+    original_apply = type(dsv4_tokenizer).apply_chat_template
 
-    @wraps(original_apply_chat_template)
+    @wraps(original_apply)
     def apply_chat_template(
-        self,
-        messages,
-        tools=None,
-        **kwargs,
-    ):
-        if tools:
-            conversation = kwargs.get("conversation", messages).copy()
-            system_index = next(
-                (index for index, message in enumerate(conversation) if message.get("role") == "system"),
-                None,
-            )
-            if system_index is None:
-                conversation.insert(0, {"role": "system", "tools": tools})
-            else:
-                system_message = conversation[system_index].copy()
-                system_message["tools"] = tools
-                conversation[system_index] = system_message
-            kwargs["conversation"] = conversation
-            tools = None
-        return original_apply_chat_template(self, messages, tools=tools, **kwargs)
+        self: Any,
+        messages: Any,
+        tools: list[dict[str, Any]] | None = None,
+        **kwargs: Any,
+    ) -> str | list[int]:
+        conversation = kwargs.get("conversation", messages)
+        adjusted_messages = _attach_tools(conversation, tools)
+        thinking = kwargs.get("thinking")
+        enable_thinking = kwargs.get("enable_thinking")
+        thinking_enabled = bool(thinking) or bool(enable_thinking)
+        if "thinking" not in kwargs and "enable_thinking" not in kwargs:
+            thinking_enabled = True
 
-    tokenizer_cls.apply_chat_template = apply_chat_template
+        thinking_mode, canonical_effort = _normalize_reasoning_effort(
+            kwargs.get("reasoning_effort"),
+            thinking_enabled,
+            uses_preview_mapping,
+        )
+        prompt = deepseek_v4.encode_messages(
+            adjusted_messages,
+            thinking_mode=thinking_mode,
+            drop_thinking=kwargs.get("drop_thinking", True),
+            reasoning_effort=canonical_effort,
+        )
+        if kwargs.get("tokenize", True):
+            tokenizer_kwargs = {key: kwargs[key] for key in ("truncation", "max_length") if key in kwargs}
+            return self.encode(
+                prompt,
+                add_special_tokens=False,
+                **tokenizer_kwargs,
+            )
+        return prompt
+
+    dsv4_tokenizer.apply_chat_template = MethodType(
+        apply_chat_template,
+        dsv4_tokenizer,
+    )
     return dsv4_tokenizer
 
 
-@wraps(_original_deepseek_v4_parser_init)
-def _patched_deepseek_v4_parser_init(
-    self: DeepSeekV4Parser,
-    *args: Any,
-    **kwargs: Any,
-) -> None:
-    chat_kwargs = kwargs.get("chat_template_kwargs") or {}
+@wraps(_original_parser_init)
+def _patched_parser_init(self: DeepSeekV4Parser, *args: Any, **kwargs: Any) -> None:
+    bound = _original_parser_init_signature.bind(self, *args, **kwargs)
+    extra_kwargs = bound.arguments.get("kwargs", {})
+    chat_kwargs = extra_kwargs.get("chat_template_kwargs") or {}
     if "thinking" not in chat_kwargs and "enable_thinking" not in chat_kwargs:
-        chat_kwargs = dict(chat_kwargs)
-        chat_kwargs["enable_thinking"] = True
-        kwargs["chat_template_kwargs"] = chat_kwargs
+        extra_kwargs["chat_template_kwargs"] = {
+            **chat_kwargs,
+            "enable_thinking": True,
+        }
+    _original_parser_init(*bound.args, **bound.kwargs)
 
-    _original_deepseek_v4_parser_init(self, *args, **kwargs)
 
+if _USES_LEGACY_RENDERER:
+    _original_render_message = deepseek_v4_encoding.render_message
+    deepseek_v4_encoding.REASONING_EFFORT_PROMPTS = REASONING_EFFORT_PROMPTS
+    deepseek_v4_encoding.render_message = _patched_render_message
 
 deepseek_v4.get_deepseek_v4_tokenizer = _patched_get_deepseek_v4_tokenizer
-DeepSeekV4Parser.__init__ = _patched_deepseek_v4_parser_init
+if _USES_LEGACY_PARSER:
+    DeepSeekV4Parser.__init__ = _patched_parser_init

--- a/vllm_ascend/patch/platform/patch_deepseek_v4_tool_streaming.py
+++ b/vllm_ascend/patch/platform/patch_deepseek_v4_tool_streaming.py
@@ -1,0 +1,122 @@
+#
+# Copyright (c) 2026 Huawei Technologies Co., Ltd. All Rights Reserved.
+# This file is a part of the vllm-ascend project.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import json
+from functools import wraps
+from typing import Any
+
+from vllm.parser.deepseek_v4 import (
+    _PARAM_RE,
+    _PARTIAL_PARAM_RE,
+    DeepSeekV4Parser,
+    deepseek_v4_config,
+)
+
+_DIRECT_STRING_SLOTS_ATTR = "_ascend_direct_string_slots"
+_PATCHED_ATTR = "_ascend_tool_streaming_patched"
+_UPSTREAM_STRUCTURAL_CHARS = deepseek_v4_config().arg_structural_chars
+
+_original_reset = DeepSeekV4Parser._reset
+_original_compute_arg_delta = DeepSeekV4Parser._compute_arg_delta
+
+
+@wraps(_original_reset)
+def _patched_reset(
+    self: DeepSeekV4Parser,
+    *args: Any,
+    **kwargs: Any,
+) -> None:
+    _original_reset(self, *args, **kwargs)
+    setattr(self, _DIRECT_STRING_SLOTS_ATTR, set())
+
+
+def _in_progress_string_key(raw_args: str) -> str | None:
+    last_complete_end = 0
+    for match in _PARAM_RE.finditer(raw_args):
+        last_complete_end = match.end()
+
+    match = _PARTIAL_PARAM_RE.search(raw_args, last_complete_end)
+    if match is None or match.group(2) != "true":
+        return None
+    return match.group(1)
+
+
+def _ends_in_open_json_string(json_prefix: str) -> bool:
+    in_string = False
+    escaped = False
+    for char in json_prefix:
+        if escaped:
+            escaped = False
+        elif char == "\\" and in_string:
+            escaped = True
+        elif char == '"':
+            in_string = not in_string
+    return in_string
+
+
+@wraps(_original_compute_arg_delta)
+def _patched_compute_arg_delta(
+    self: DeepSeekV4Parser,
+    idx: int,
+    raw_delta: str,
+) -> str | None:
+    direct_string_slots: set[int] = getattr(
+        self,
+        _DIRECT_STRING_SLOTS_ATTR,
+        set(),
+    )
+    setattr(self, _DIRECT_STRING_SLOTS_ATTR, direct_string_slots)
+
+    structural = self._arg_structural_chars
+    is_plain_delta = structural is not None and structural.isdisjoint(raw_delta)
+    # The lexer holds split closing tags, so a plain event here is committed
+    # string body text and can be JSON-escaped without rescanning slot.args.
+    if idx in direct_string_slots and is_plain_delta and self._arg_converter is not None and self._stream_arg_deltas:
+        escaped_delta = json.dumps(raw_delta, ensure_ascii=False)[1:-1]
+        if escaped_delta:
+            self._tool_slots[idx].streamed_json += escaped_delta
+            return escaped_delta
+        return None
+
+    direct_string_slots.discard(idx)
+    arg_delta = _original_compute_arg_delta(self, idx, raw_delta)
+    if not arg_delta:
+        return arg_delta
+
+    # Structural events always return to the converter. Re-arm direct streaming
+    # only while the raw DSML still ends in a schema-stable string parameter.
+    slot = self._tool_slots[idx]
+    string_key = _in_progress_string_key(slot.args)
+    if (
+        string_key is not None
+        and (slot.string_keys is None or string_key in slot.string_keys)
+        and _ends_in_open_json_string(slot.streamed_json)
+    ):
+        direct_string_slots.add(idx)
+    return arg_delta
+
+
+if frozenset(">") == _UPSTREAM_STRUCTURAL_CHARS:
+    if not getattr(DeepSeekV4Parser, _PATCHED_ATTR, False):
+        DeepSeekV4Parser._reset = _patched_reset
+        DeepSeekV4Parser._compute_arg_delta = _patched_compute_arg_delta
+        setattr(DeepSeekV4Parser, _PATCHED_ATTR, True)
+elif _UPSTREAM_STRUCTURAL_CHARS is not None:
+    raise RuntimeError(
+        "DeepSeek V4 tool streaming patch requires upstream "
+        "arg_structural_chars to be frozenset('>') or None, got "
+        f"{_UPSTREAM_STRUCTURAL_CHARS!r}"
+    )

--- a/vllm_ascend/patch/platform/patch_deepseek_v4_trailing_system.py
+++ b/vllm_ascend/patch/platform/patch_deepseek_v4_trailing_system.py
@@ -24,13 +24,18 @@ _original_render_message = deepseek_v4_encoding.render_message
 _render_message_signature = inspect.signature(_original_render_message)
 
 
-def _upstream_handles_trailing_system() -> bool:
-    prompt = _original_render_message(
-        0,
-        [{"role": "system", "content": ""}],
-        thinking_mode="chat",
-    )
-    return prompt.endswith(deepseek_v4_encoding.ASSISTANT_SP_TOKEN + deepseek_v4_encoding.thinking_end_token)
+def _needs_trailing_system_patch() -> bool:
+    try:
+        bound_args = _render_message_signature.bind(
+            index=0,
+            messages=[{"role": "system", "content": ""}],
+            thinking_mode="chat",
+        )
+    except TypeError:
+        return False
+    bound_args.apply_defaults()
+    prompt = _original_render_message(*bound_args.args, **bound_args.kwargs)
+    return not prompt.endswith(deepseek_v4_encoding.ASSISTANT_SP_TOKEN + deepseek_v4_encoding.thinking_end_token)
 
 
 @wraps(_original_render_message)
@@ -41,7 +46,7 @@ def _patched_render_message(*args: Any, **kwargs: Any) -> str:
     index = bound_args.arguments["index"]
     messages = bound_args.arguments["messages"]
     thinking_mode = bound_args.arguments["thinking_mode"]
-    drop_thinking = bound_args.arguments["drop_thinking"]
+    drop_thinking = bound_args.arguments.get("drop_thinking", True)
     message = messages[index]
     if message.get("role") != "system" or message.get("task") is not None:
         return prompt
@@ -59,5 +64,5 @@ def _patched_render_message(*args: Any, **kwargs: Any) -> str:
     return prompt
 
 
-if not _upstream_handles_trailing_system():
+if _needs_trailing_system_patch():
     deepseek_v4_encoding.render_message = _patched_render_message

--- a/vllm_ascend/patch/platform/patch_deepseek_v4_trailing_system.py
+++ b/vllm_ascend/patch/platform/patch_deepseek_v4_trailing_system.py
@@ -14,12 +14,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import inspect
 from functools import wraps
 from typing import Any
 
 from vllm.tokenizers import deepseek_v4_encoding
 
 _original_render_message = deepseek_v4_encoding.render_message
+_render_message_signature = inspect.signature(_original_render_message)
 
 
 def _upstream_handles_trailing_system() -> bool:
@@ -34,13 +36,12 @@ def _upstream_handles_trailing_system() -> bool:
 @wraps(_original_render_message)
 def _patched_render_message(*args: Any, **kwargs: Any) -> str:
     prompt = _original_render_message(*args, **kwargs)
-    index = kwargs["index"] if "index" in kwargs else args[0]
-    messages = kwargs["messages"] if "messages" in kwargs else args[1]
-    thinking_mode = kwargs["thinking_mode"] if "thinking_mode" in kwargs else args[2]
-    drop_thinking = kwargs.get(
-        "drop_thinking",
-        args[3] if len(args) > 3 else True,
-    )
+    bound_args = _render_message_signature.bind(*args, **kwargs)
+    bound_args.apply_defaults()
+    index = bound_args.arguments["index"]
+    messages = bound_args.arguments["messages"]
+    thinking_mode = bound_args.arguments["thinking_mode"]
+    drop_thinking = bound_args.arguments["drop_thinking"]
     message = messages[index]
     if message.get("role") != "system" or message.get("task") is not None:
         return prompt
@@ -48,10 +49,7 @@ def _patched_render_message(*args: Any, **kwargs: Any) -> str:
         return prompt
 
     prompt += deepseek_v4_encoding.ASSISTANT_SP_TOKEN
-    last_user_idx = kwargs.get(
-        "last_user_idx",
-        args[5] if len(args) > 5 else None,
-    )
+    last_user_idx = bound_args.arguments.get("last_user_idx")
     if last_user_idx is None:
         last_user_idx = deepseek_v4_encoding.find_last_user_index(messages)
     if thinking_mode == "thinking" and (not drop_thinking or index >= last_user_idx):

--- a/vllm_ascend/patch/platform/patch_deepseek_v4_trailing_system.py
+++ b/vllm_ascend/patch/platform/patch_deepseek_v4_trailing_system.py
@@ -1,0 +1,65 @@
+#
+# Copyright (c) 2026 Huawei Technologies Co., Ltd. All Rights Reserved.
+# This file is a part of the vllm-ascend project.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from functools import wraps
+from typing import Any
+
+from vllm.tokenizers import deepseek_v4_encoding
+
+_original_render_message = deepseek_v4_encoding.render_message
+
+
+def _upstream_handles_trailing_system() -> bool:
+    prompt = _original_render_message(
+        0,
+        [{"role": "system", "content": ""}],
+        thinking_mode="chat",
+    )
+    return prompt.endswith(deepseek_v4_encoding.ASSISTANT_SP_TOKEN + deepseek_v4_encoding.thinking_end_token)
+
+
+@wraps(_original_render_message)
+def _patched_render_message(*args: Any, **kwargs: Any) -> str:
+    prompt = _original_render_message(*args, **kwargs)
+    index = kwargs["index"] if "index" in kwargs else args[0]
+    messages = kwargs["messages"] if "messages" in kwargs else args[1]
+    thinking_mode = kwargs["thinking_mode"] if "thinking_mode" in kwargs else args[2]
+    drop_thinking = kwargs.get(
+        "drop_thinking",
+        args[3] if len(args) > 3 else True,
+    )
+    message = messages[index]
+    if message.get("role") != "system" or message.get("task") is not None:
+        return prompt
+    if index + 1 < len(messages) and messages[index + 1].get("role") != "assistant":
+        return prompt
+
+    prompt += deepseek_v4_encoding.ASSISTANT_SP_TOKEN
+    last_user_idx = kwargs.get(
+        "last_user_idx",
+        args[5] if len(args) > 5 else None,
+    )
+    if last_user_idx is None:
+        last_user_idx = deepseek_v4_encoding.find_last_user_index(messages)
+    if thinking_mode == "thinking" and (not drop_thinking or index >= last_user_idx):
+        prompt += deepseek_v4_encoding.thinking_start_token
+    else:
+        prompt += deepseek_v4_encoding.thinking_end_token
+    return prompt
+
+
+if not _upstream_handles_trailing_system():
+    deepseek_v4_encoding.render_message = _patched_render_message


### PR DESCRIPTION
### What this PR does / why we need it?

Backport the DeepSeek V4 trailing-system prompt-rendering fix from https://github.com/vllm-project/vllm/pull/51262 for the vLLM version currently supported by vLLM-Ascend.

For a message sequence such as `system -> user -> system`, the existing renderer leaves the prompt at a bare system-message boundary. This patch appends the existing assistant/thinking transition after a trailing system message or before an assistant history turn, while preserving `system -> user` and `system -> latest_reminder` behavior.

The platform monkey patch uses a behavior probe and is skipped automatically once the supported vLLM version contains the upstream fix.

Fixes #11951

Depends on #14632

### Does this PR introduce _any_ user-facing change?

Yes. DeepSeek V4 requests ending in a system message now start generation from the correct assistant boundary instead of potentially returning empty content or raw tags.

### How was this patch tested?

Regression tests cover trailing system messages in chat and thinking modes, `system -> assistant`, and a non-trailing mid-conversation system message.

```bash
VLLM_PLUGINS="" PYTHONPATH=/path/to/vllm:/path/to/vllm-ascend \
pytest -q -p no:cacheprovider --confcutdir=tests/ut/patch/platform --noconftest \
  tests/ut/patch/platform/test_deepseek_v4_trailing_system.py
```

- Supported release (`v0.27.1`): `4 passed`
- Verified source (`ba07e4a`): `4 passed`
- Current vLLM source containing upstream #51262: behavior probe kept the monkey patch disabled and both chat/thinking prompts rendered correctly
- `ruff check`: passed
- `ruff format --check`: passed
- `git diff --check`: passed

No additional NPU inference run was performed for this frontend-only monkey patch. The upstream PR reports 12/12 production-router requests passing after applying the same renderer behavior.

- vLLM main: https://github.com/vllm-project/vllm/commit/ba07e4a48fc951300d97eb506217dd530583dea3
