### PR TITLE
[CI][v0.26.0rc] Update A3 runner labels for 800T runners

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -6,9 +6,9 @@ self-hosted-runner:
     - linux-aarch64-310p-2
     - linux-aarch64-310p-4
     - linux-aarch64-a3-1
-    - linux-aarch64-a3-2
-    - linux-aarch64-a3-4
-    - linux-aarch64-a3-8
+    - linux-aarch64-a3-800t-2
+    - linux-aarch64-a3-800t-4
+    - linux-aarch64-a3-800t-8
     - linux-aarch64-a3-0
     - linux-aarch64-a3-0-cn12-001
     - linux-amd64-cpu-2-hk

--- a/.github/workflows/configs/weekly_config.yaml
+++ b/.github/workflows/configs/weekly_config.yaml
@@ -84,7 +84,7 @@ a3:
     test_config:
       # pytest-driven tests
       - name: engine-func-tests
-        os: linux-aarch64-a3-4
+        os: linux-aarch64-a3-800t-4
         tests: tests/e2e/weekly/single_node/engine_func_test_robot
       - name: deepseek-v3-2-w8a8
         os: linux-aarch64-a3-16
@@ -99,7 +99,7 @@ a3:
         os: linux-aarch64-a3-16
         config_file_path: Qwen3.5-397B-A17B-W8A8-mtp-A3_weekly.yaml
       - name: Qwen3.5-27B-w8a8-A3
-        os: linux-aarch64-a3-2
+        os: linux-aarch64-a3-800t-2
         config_file_path: Qwen3.5-27B-w8a8-A3.yaml
       - name: Qwen3.5-122B-A10B-W8A8-A3
         os: linux-aarch64-a3-16
@@ -111,7 +111,7 @@ a3:
         os: linux-aarch64-a3-16
         config_file_path: GLM-5.yaml
       - name: qwen2-5-vl-7b-epd
-        os: linux-aarch64-a3-4
+        os: linux-aarch64-a3-800t-4
         config_file_path: Qwen2.5-VL-7B-Instruct-EPD.yaml
       - name: MiniMax-M2.5-w8a8
         os: linux-aarch64-a3-16

--- a/.github/workflows/scripts/runner_label.json
+++ b/.github/workflows/scripts/runner_label.json
@@ -17,19 +17,19 @@
         "image_tag": "9.1.0-310p-ubuntu22.04-py3.12",
         "csrc_cache_target": "310p-arm64-ubuntu"
     },
-    "linux-aarch64-a3-2": {
+    "linux-aarch64-a3-800t-2": {
         "chip": "a3",
         "npu_num": 2,
         "image_tag": "9.1.0-a3-ubuntu22.04-py3.12",
         "csrc_cache_target": "a3-arm64-ubuntu"
     },
-    "linux-aarch64-a3-4": {
+    "linux-aarch64-a3-800t-4": {
         "chip": "a3",
         "npu_num": 4,
         "image_tag": "9.1.0-a3-ubuntu22.04-py3.12",
         "csrc_cache_target": "a3-arm64-ubuntu"
     },
-    "linux-aarch64-a3-8": {
+    "linux-aarch64-a3-800t-8": {
         "chip": "a3",
         "npu_num": 8,
         "image_tag": "9.1.0-a3-ubuntu22.04-py3.12",

--- a/docs/source/developer_guide/contribution/e2e_ci_test.md
+++ b/docs/source/developer_guide/contribution/e2e_ci_test.md
@@ -70,8 +70,8 @@ on path patterns:
 
 | Path pattern | Hardware | Runner |
 |---|---|---|
-| `two_card` in path | two_card A3 NPU | `linux-aarch64-a3-2` |
-| `four_card` in path | four_card A3 NPU | `linux-aarch64-a3-4` |
+| `two_card` in path | two_card A3 NPU | `linux-aarch64-a3-800t-2` |
+| `four_card` in path | four_card A3 NPU | `linux-aarch64-a3-800t-4` |
 | `_310p` in filename under one/two_card | Ascend 310P x1 | `linux-aarch64-310p-*` |
 | `_310p` in filename under four_card | Ascend 310P x4 | `linux-aarch64-310p-*` |
 | All other paths | one_card A2 NPU | `linux-aarch64-a2b3-1` |

--- a/docs/source/locale/zh_CN/LC_MESSAGES/developer_guide/contribution/e2e_ci_test.po
+++ b/docs/source/locale/zh_CN/LC_MESSAGES/developer_guide/contribution/e2e_ci_test.po
@@ -222,11 +222,11 @@ msgstr ""
 "| `/e2e tests/e2e/pull_request/one_card/test_foo.py::test_case` | 运行指定的测试用例 "
 "|"
 
-msgid "| `two_card` in path | two_card A3 NPU | `linux-aarch64-a3-2` |"
-msgstr "| 路径中包含 `two_card` | two_card A3 NPU | `linux-aarch64-a3-2` |"
+msgid "| `two_card` in path | two_card A3 NPU | `linux-aarch64-a3-800t-2` |"
+msgstr "| 路径中包含 `two_card` | two_card A3 NPU | `linux-aarch64-a3-800t-2` |"
 
-msgid "| `four_card` in path | four_card A3 NPU | `linux-aarch64-a3-4` |"
-msgstr "| 路径中包含 `four_card` | four_card A3 NPU | `linux-aarch64-a3-4` |"
+msgid "| `four_card` in path | four_card A3 NPU | `linux-aarch64-a3-800t-4` |"
+msgstr "| 路径中包含 `four_card` | four_card A3 NPU | `linux-aarch64-a3-800t-4` |"
 
 msgid ""
 "| `_310p` in filename under one/two_card | Ascend 310P x1 | `linux-"


### PR DESCRIPTION
### What this PR does / why we need it?
The existing A3 runner labels are no longer applicable to the current 800T runners.

This PR renames the A3 runner labels as follows:

- `linux-aarch64-a3-2` → `linux-aarch64-a3-800t-2`
- `linux-aarch64-a3-4` → `linux-aarch64-a3-800t-4`
- `linux-aarch64-a3-8` → `linux-aarch64-a3-800t-8`

All corresponding CI configurations, actionlint settings, and documentation references are updated accordingly.

### Does this PR introduce _any_ user-facing change?

### How was this patch tested?

- vLLM main: https://github.com/vllm-project/vllm/commit/d02df748bf9efd99022f1a062597dc3cb3808485
