### PR TITLE
[BugFix][Config] Ignore unknown additional_config keys in init_ascend_config

### DIFF
--- a/vllm_ascend/ascend_config.py
+++ b/vllm_ascend/ascend_config.py
@@ -1385,7 +1385,14 @@ def init_ascend_config(vllm_config):
         "profiling_chunk_config",
         "batch_job_sched_config",
     }
-    kwargs = {k: v for k, v in additional_config.items() if k not in _NON_USER_INPUT_KEYS}
+
+    # NOTE: do not splat all additional_config keys into AscendConfig;
+    # unknown keys (not AscendConfig fields) break downstream like vllm-omni.
+    kwargs = {
+        k: v
+        for k, v in additional_config.items()
+        if k not in _NON_USER_INPUT_KEYS and k in AscendConfig.__dataclass_fields__
+    }
 
     new_config = AscendConfig(  # type: ignore[call-arg]
         scheduler_config=sched,


### PR DESCRIPTION
### What this PR does / why we need it?

`init_ascend_config` previously splatted every `additional_config` key that was not in `_NON_USER_INPUT_KEYS` into `AscendConfig`. Because `AscendConfig` is a `@config` pydantic dataclass with `extra="forbid"`, any key that is not a declared field raised a `ValidationError`, which breaks downstream consumers (e.g. vllm-omni) that place extra keys in `additional_config`.

This PR filters the splat to only keys that are declared `AscendConfig` fields (`k in AscendConfig.__dataclass_fields__`), so unknown keys are ignored instead of rejected. Direct `AscendConfig` construction is unchanged and still forbids unknown keys via `extra="forbid"`.

### Does this PR introduce _any_ user-facing change?

Yes, behaviorally: top-level `additional_config` keys that are not declared `AscendConfig` fields are no longer rejected; they are silently ignored. Typo'd keys that were previously caught by `extra="forbid"` will now be silently dropped. The accompanying test was updated to reflect this behavior (`test_unknown_top_level_key_is_ignored`).

### How was this patch tested?

- Unit test updated: `tests/ut/test_ascend_config.py` — `test_unknown_top_level_key_is_ignored` verifies that unknown top-level `additional_config` keys are dropped while valid keys still apply.
- `ruff check` passes on the changed files.
- Verified via a standalone repro against `config_utils.config` (pydantic dataclass) that `__dataclass_fields__` filters unknown keys and `extra="forbid"` rejects them on direct construction.
- CI (NPU/Linux UT runner with a constructible `VllmConfig`) runs the full `tests/ut/test_ascend_config.py` suite.

- vLLM main: https://github.com/vllm-project/vllm/commit/ba07e4a48fc951300d97eb506217dd530583dea3
