### PR TITLE
[BugFix][Platform] Explore divergent P/D Mamba cache blocks

### DIFF
--- a/tests/ut/patch/platform/test_prefix_cache_cp_patches.py
+++ b/tests/ut/patch/platform/test_prefix_cache_cp_patches.py
@@ -263,6 +263,27 @@ def test_resolve_kv_cache_block_sizes_with_cp_hybrid_groups(
     assert hash_block_size == expected_hash_block_size
 
 
+def test_resolve_divergent_mamba_hash_granularity_for_pd_consumer() -> None:
+    kv_cache_config = _make_hybrid_kv_cache_config(
+        full_block_size=384,
+        mamba_block_size=133248,
+    )
+    vllm_config = _make_vllm_config(
+        enable_prefix_caching=True,
+        dcp=1,
+        block_size=384,
+    )
+    vllm_config.kv_transfer_config = SimpleNamespace(is_kv_consumer=True)
+
+    scheduler_block_size, hash_block_size = _ascend_resolve_kv_cache_block_sizes(
+        kv_cache_config,
+        vllm_config,
+    )
+
+    assert scheduler_block_size == 133248
+    assert hash_block_size == 384
+
+
 def test_deepseek_v4_groups_use_logical_sizes_and_full_attention_manager() -> None:
     c128_spec = MLAAttentionSpec(
         block_size=128 * 128,

--- a/vllm_ascend/patch/platform/patch_kv_cache_utils.py
+++ b/vllm_ascend/patch/platform/patch_kv_cache_utils.py
@@ -81,6 +81,23 @@ def _ascend_resolve_kv_cache_block_sizes(
         hash_block_size = math.gcd(*group_block_sizes)
         return scheduler_block_size, hash_block_size
 
+    # In Mamba "none" mode, the recurrent group owns one full-sequence
+    # block while attention groups retain the regular cache block size. The
+    # upstream fallback uses the LCM for both scheduling and hashing, which
+    # makes the hash block larger than an attention block and violates the
+    # coordinator's divisibility invariant. Keep the LCM for scheduling, but
+    # hash at the GCD shared by every group.
+    connector_enabled = vllm_config.kv_transfer_config is not None
+    if cache_config.enable_prefix_caching or connector_enabled:
+        group_block_sizes = [g.kv_cache_spec.block_size for g in groups]
+        has_divergent_mamba_group = any(
+            isinstance(g.kv_cache_spec, MambaSpec)
+            and g.kv_cache_spec.block_size != cache_config.block_size
+            for g in groups
+        )
+        if has_divergent_mamba_group:
+            return math.lcm(*group_block_sizes), math.gcd(*group_block_sizes)
+
     return _orig_resolve_kv_cache_block_sizes(kv_cache_config, vllm_config)
 
 

--- a/vllm_ascend/patch/platform/patch_mamba_config.py
+++ b/vllm_ascend/patch/platform/patch_mamba_config.py
@@ -140,10 +140,18 @@ def verify_and_update_config(cls, vllm_config) -> None:
             assert cache_config.mamba_cache_mode == "align", (
                 "mamba_cache_mode only support 'align' when kv_transfer enabled now!"
             )
+    if (
+        vllm_config.kv_transfer_config
+        and vllm_config.kv_transfer_config.is_kv_consumer
+    ):
+        cache_config.mamba_cache_mode = "none"
     if cache_config.enable_prefix_caching and cache_config.mamba_cache_mode == "align":
         cache_config.mamba_block_size = cache_config.block_size
     else:
-        cache_config.mamba_block_size = model_config.max_model_len
+        cache_config.mamba_block_size = (
+            cdiv(model_config.max_model_len, cache_config.block_size)
+            * cache_config.block_size
+        )
 
 
 vllm.model_executor.models.config.HybridAttentionMambaModelConfig.verify_and_update_config = verify_and_update_config


### PR DESCRIPTION
### What this PR does / why we need it?

This is an **experimental Draft PR** extracted from a four-node Kimi K3 P/D investigation. It is intentionally separate from the reduced-layer PR #15103.

The experiment makes KV consumers use full-sequence Mamba blocks instead of the aligned Mamba block layout, then:

- rounds the full-sequence Mamba block to the attention block granularity;
- keeps the LCM of heterogeneous group block sizes as the scheduler block size;
- uses their GCD as the prefix-hash block size;
- adds regression coverage for the observed `attention=384`, `mamba=133248` layout.

This resolves the D-side startup assertion:

```text
AssertionError: block_size must be divisible by hash_block_size
```

For the reproduced configuration, the resolved values become:

```text
scheduler_block_size = 133248
hash_block_size      = 384
```

### Known limitation: not a complete runtime fix

This PR is **not ready for production use**.

The P side remains on Mamba `align` and exports three Mooncake manager groups, while the D-side consumer in Mamba `none` mode builds eight local manager groups. The first end-to-end request therefore fails in:

```text
mooncake_connector.py::_get_kernel_block_ids
IndexError: list index out of range
```

The root request on D rank 0 contained eight local block-id groups but only three producer remote block-id groups. D rank 1 then exited through the expected Gloo peer-disconnect cascade.

A complete fix requires an explicit producer-to-consumer KV-group mapping or a topology-preserving solution to the original DSpark/Mamba boundary problem. Silently skipping unmatched groups is not safe.

### Does this PR introduce _any_ user-facing change?

Yes. Hybrid-model KV consumers use Mamba `none` mode and a full-sequence recurrent block. Because this changes cache topology and is known to be incompatible with the current Mooncake group metadata, this PR remains Draft.

### How was this patch tested?

Per request, pytest and NPU tests were not run while preparing this PR.

Available runtime evidence from the four-node DP2/TP16 deployment:

- D ranks completed startup after the block-size changes;
- both D endpoints reached HTTP 200;
- all eight `FULL_DECODE_ONLY` graph tiers were captured;
- the first P/D smoke request reproduced the separate Mooncake 3-group versus 8-group mismatch described above.

Code preparation checks:

- based on upstream main `a1affe4d3218f292c2c79c6d7666877efe526cbb`;
- `git diff --check` passed;
- one regression test was added but not executed;
- final scope is three files and one signed-off commit.

- vLLM main: https://github.com/vllm-project/vllm/commit/ba07e4a48fc951300d97eb506217dd530583dea3
