### PR TITLE
[Test][310P] Cover unsupported sampler parameters

### DIFF
--- a/tests/ut/_310p/test_model_runner_v2_310p.py
+++ b/tests/ut/_310p/test_model_runner_v2_310p.py
@@ -390,27 +390,31 @@ def test_sampler_rejects_random_sampling_parameters() -> None:
 
 
 @pytest.mark.parametrize(
-    ("sampling_kwargs", "message"),
+    ("sampling_kwargs", "message", "temperature"),
     [
-        ({"top_p": 0.9}, "top_p"),
-        ({"top_k": 10}, "top_k"),
-        ({"min_p": 0.1}, "min_p"),
-        ({"repetition_penalty": 1.1}, "repetition_penalty"),
-        ({"presence_penalty": 0.1}, "presence/frequency penalty"),
-        ({"frequency_penalty": 0.1}, "presence/frequency penalty"),
+        # vLLM normalizes top_p/top_k/min_p to greedy defaults when
+        # temperature=0, so those cases must use temperature=1.0 to reach
+        # the sampler guard.
+        ({"top_p": 0.9}, "top_p", 1.0),
+        ({"top_k": 10}, "top_k", 1.0),
+        ({"min_p": 0.1}, "min_p", 1.0),
+        ({"repetition_penalty": 1.1}, "repetition_penalty", 0),
+        ({"presence_penalty": 0.1}, "presence/frequency penalty", 0),
+        ({"frequency_penalty": 0.1}, "presence/frequency penalty", 0),
         (
             {"presence_penalty": 0.1, "frequency_penalty": 0.1},
             "presence/frequency penalty",
+            0,
         ),
-        ({"logprobs": 1}, "logprobs"),
-        ({"prompt_logprobs": 1}, "logprobs"),
-        ({"logit_bias": {1: 0.1}}, "logits processors"),
+        ({"logprobs": 1}, "logprobs", 0),
+        ({"prompt_logprobs": 1}, "logprobs", 0),
+        ({"logit_bias": {1: 0.1}}, "logits processors", 0),
     ],
 )
-def test_sampler_rejects_unsupported_sampling_parameters(sampling_kwargs, message) -> None:
+def test_sampler_rejects_unsupported_sampling_parameters(sampling_kwargs, message, temperature) -> None:
     sampler = Ascend310PSampler()
     with pytest.raises(NotImplementedError, match=message):
-        sampler.add_request(0, 4, SamplingParams(temperature=0, **sampling_kwargs))
+        sampler.add_request(0, 4, SamplingParams(temperature=temperature, **sampling_kwargs))
 
 
 def test_block_tables_use_cpu_metadata_for_gather_and_slot_mapping() -> None:

--- a/tests/ut/_310p/test_model_runner_v2_310p.py
+++ b/tests/ut/_310p/test_model_runner_v2_310p.py
@@ -389,6 +389,30 @@ def test_sampler_rejects_random_sampling_parameters() -> None:
         sampler.add_request(1, 4, SamplingParams(temperature=1))
 
 
+@pytest.mark.parametrize(
+    ("sampling_kwargs", "message"),
+    [
+        ({"top_p": 0.9}, "top_p"),
+        ({"top_k": 10}, "top_k"),
+        ({"min_p": 0.1}, "min_p"),
+        ({"repetition_penalty": 1.1}, "repetition_penalty"),
+        ({"presence_penalty": 0.1}, "presence/frequency penalty"),
+        ({"frequency_penalty": 0.1}, "presence/frequency penalty"),
+        (
+            {"presence_penalty": 0.1, "frequency_penalty": 0.1},
+            "presence/frequency penalty",
+        ),
+        ({"logprobs": 1}, "logprobs"),
+        ({"prompt_logprobs": 1}, "logprobs"),
+        ({"logit_bias": {1: 0.1}}, "logits processors"),
+    ],
+)
+def test_sampler_rejects_unsupported_sampling_parameters(sampling_kwargs, message) -> None:
+    sampler = Ascend310PSampler()
+    with pytest.raises(NotImplementedError, match=message):
+        sampler.add_request(0, 4, SamplingParams(temperature=0, **sampling_kwargs))
+
+
 def test_block_tables_use_cpu_metadata_for_gather_and_slot_mapping() -> None:
     block_tables = Ascend310PBlockTables(
         block_sizes=[4],


### PR DESCRIPTION
### What this PR does / why we need it?

The Ascend310PSampler for 310P model runner v2 intentionally rejects unsupported sampling parameters, including repetition, presence, and frequency penalties. This PR adds focused unit coverage for each rejection path so future changes cannot silently broaden the supported parameter set.

The existing greedy and random-sampling checks remain covered, and the new cases exercise the three penalty fields independently plus the combined presence/frequency path.

Related: #15235

### Does this PR introduce _any_ user-facing change?

No. This change only adds unit tests for existing rejection behavior.

### How was this patch tested?

- `python -m py_compile tests/ut/_310p/test_model_runner_v2_310p.py vllm_ascend/_310p/worker/v2/sampler.py`
- `ruff check tests/ut/_310p/test_model_runner_v2_310p.py`
- `ruff format --check tests/ut/_310p/test_model_runner_v2_310p.py`
- `git diff --check`

The focused pytest invocation was attempted, but this host's installed vLLM/NPU environment did not complete test collection within 300 seconds. The test file and sampler module compile successfully; full pytest and 310P hardware validation should run in CI or on maintainer hardware.

Signed-off-by: UniversePeak <UniversePeak@users.noreply.github.com>

- vLLM main: https://github.com/vllm-project/vllm/commit/84030bbe3d74d99bad477a3d2e37a973ccd8865c
