### PR TITLE
[Draft][KV Offload] Prepare DeepSeek V4 c4 cache routing

### DIFF
--- a/tests/ut/distributed/kv_transfer/sparse_kv_offload/test_sparse_kv_offload_manager.py
+++ b/tests/ut/distributed/kv_transfer/sparse_kv_offload/test_sparse_kv_offload_manager.py
@@ -158,18 +158,6 @@ class TestSparseKVOffloadMemoryPlanning(unittest.TestCase):
         invalid_cases = (
             ({"device.0": specs["device.0"]}, "at least one host"),
             ({"host.0": specs["host.0"]}, "at least one device"),
-            (
-                {
-                    **specs,
-                    "device.1": _FakeKVCacheSpec(
-                        page_size_bytes=512,
-                        max_blocks_per_request=100,
-                        store_on_host=False,
-                        block_size=64,
-                    ),
-                },
-                "one shared block size",
-            ),
         )
 
         for invalid_specs, message in invalid_cases:
@@ -181,6 +169,25 @@ class TestSparseKVOffloadMemoryPlanning(unittest.TestCase):
                     dram_limit_bytes=alignment_reserve + 1000 * 2048,
                     keep_device_kv_cache=False,
                 )
+
+    def test_memory_plan_supports_hybrid_block_sizes(self):
+        specs, vllm_config, alignment_reserve = _make_memory_plan_inputs()
+        specs["host.0"].block_size = 512
+        specs["host.1"].block_size = 512
+        specs["device.0"].block_size = 64
+
+        budget = plan_sparse_kv_offload_memory(
+            kv_cache_spec=specs,
+            vllm_config=vllm_config,
+            available_device_memory_bytes=1000 * 512,
+            dram_limit_bytes=alignment_reserve + 1000 * 2048,
+            keep_device_kv_cache=False,
+        )
+
+        self.assertEqual(budget.npu_limit_blocks, 1000)
+        self.assertEqual(budget.dram_limit_blocks, 1000)
+        self.assertEqual(budget.workload_limit_blocks, 201)
+        self.assertEqual(budget.final_num_blocks, 201)
 
     def test_cpu_pool_size_includes_per_layer_alignment_reserve(self):
         specs, _, alignment_reserve = _make_memory_plan_inputs()

--- a/tests/ut/worker/a2/test_model_runner_v1.py
+++ b/tests/ut/worker/a2/test_model_runner_v1.py
@@ -25,7 +25,10 @@ from vllm_ascend.attention.mla_v1 import AscendMLABackend
 from vllm_ascend.attention.utils import get_sfa_qsfa_packed_head_dim
 from vllm_ascend.core.kv_cache_interface import AscendMLAAttentionSpec, AscendSFAIndexerCacheSpec
 from vllm_ascend.utils import AscendDeviceType
-from vllm_ascend.worker.model_runner_v1 import NPUModelRunner
+from vllm_ascend.worker.model_runner_v1 import (
+    NPUModelRunner,
+    _mark_dsv4_c4_main_cache_for_offload,
+)
 
 
 class TestDSparkAuxCaptureMode(unittest.TestCase):
@@ -73,6 +76,53 @@ class TestDSparkAuxCaptureMode(unittest.TestCase):
 
         self.assertFalse(runner._draft_uses_qwen3_gqa_dspark())
 
+
+class TestDeepSeekV4KVOffloadSpecRouting(unittest.TestCase):
+    @staticmethod
+    def _spec(compress_ratio: int, model_version: str = "deepseek_v4"):
+        return AscendMLAAttentionSpec(
+            block_size=512,
+            num_kv_heads=1,
+            head_size=256,
+            dtype=torch.bfloat16,
+            model_version=model_version,
+            compress_ratio=compress_ratio,
+        )
+
+    def test_marks_only_c4_main_attention_cache(self):
+        c4 = self._spec(4)
+        marked = _mark_dsv4_c4_main_cache_for_offload(
+            "model.layers.2.self_attn.attn",
+            c4,
+            True,
+        )
+
+        self.assertTrue(marked.store_on_host)
+        self.assertFalse(c4.store_on_host)
+
+    def test_keeps_other_dsv4_cache_components_on_device(self):
+        cases = (
+            ("model.layers.2.self_attn.attn", self._spec(128)),
+            ("model.layers.2.self_attn.indexer.k_cache", self._spec(4)),
+            ("model.layers.2.self_attn.compressor.state_cache", self._spec(4)),
+            ("model.layers.2.self_attn.attn", self._spec(4, "deepseek_v3")),
+        )
+
+        for layer_name, spec in cases:
+            with self.subTest(layer_name=layer_name, ratio=spec.compress_ratio):
+                routed = _mark_dsv4_c4_main_cache_for_offload(layer_name, spec, True)
+                self.assertIs(routed, spec)
+                self.assertFalse(routed.store_on_host)
+
+    def test_disabled_offload_does_not_rewrite_spec(self):
+        spec = self._spec(4)
+        routed = _mark_dsv4_c4_main_cache_for_offload(
+            "model.layers.2.self_attn.attn",
+            spec,
+            False,
+        )
+
+        self.assertIs(routed, spec)
 
 class TestAcceptedTokenSnapshot(unittest.TestCase):
     def _build_runner(self):

--- a/vllm_ascend/distributed/kv_transfer/sparse_kv_offload/sparse_kv_offload_manager.py
+++ b/vllm_ascend/distributed/kv_transfer/sparse_kv_offload/sparse_kv_offload_manager.py
@@ -172,9 +172,6 @@ def _split_host_device_kv_specs(
         raise ValueError("Sparse KV offload requires at least one host KV cache spec")
     if not device_specs:
         raise ValueError("Sparse KV offload requires at least one device KV cache spec")
-    block_sizes = {spec.block_size for spec in host_specs + device_specs}
-    if len(block_sizes) != 1:
-        raise ValueError(f"Sparse KV offload memory planning requires one shared block size, got {sorted(block_sizes)}")
     return host_specs, device_specs
 
 

--- a/vllm_ascend/worker/model_runner_v1.py
+++ b/vllm_ascend/worker/model_runner_v1.py
@@ -224,6 +224,29 @@ from vllm_ascend.core.kv_cache_interface import (
     AscendSlidingWindowMLASpec,
 )
 
+
+def _mark_dsv4_c4_main_cache_for_offload(
+    layer_name: str,
+    spec: KVCacheSpec,
+    enabled: bool,
+) -> KVCacheSpec:
+    """Mark only DeepSeek-V4 c4 attention data as host-resident.
+
+    DeepSeek-V4 exposes several MLA-shaped cache specs. The c4 attention
+    payload is the sparse-attention data plane; the indexer, compressor state,
+    c128 cache, and SWA cache must remain device-resident.
+    """
+    if (
+        enabled
+        and isinstance(spec, AscendMLAAttentionSpec)
+        and layer_name.endswith(".attn")
+        and spec.model_version == "deepseek_v4"
+        and spec.compress_ratio == 4
+    ):
+        return replace(spec, store_on_host=True)
+    return spec
+
+
 # if true, allow tensor initialization and casting with internal format (e.g., NZ)
 torch.npu.config.allow_internal_format = True
 
@@ -4979,7 +5002,11 @@ class NPUModelRunner(GPUModelRunner):
             elif self.use_compress:
                 # Skip modules that don't need KV cache (eg encoder-only attention)
                 if spec := attn_module.get_kv_cache_spec(self.vllm_config):
-                    kv_cache_spec[layer_name] = spec
+                    kv_cache_spec[layer_name] = _mark_dsv4_c4_main_cache_for_offload(
+                        layer_name,
+                        spec,
+                        self.sparse_kv_offload_enabled,
+                    )
             elif isinstance(attn_module, Attention):
                 if spec := attn_module.get_kv_cache_spec(self.vllm_config):
                     kv_cache_spec[layer_name] = spec


### PR DESCRIPTION
## Summary

This is the first implementation slice for DeepSeek V4 sparse KV cache offload on Ascend.

- route only DeepSeek V4 c4 main attention cache specs to host residency
- keep c128, SWA, compressor state, and indexer caches device-resident
- allow sparse-offload memory planning across hybrid cache specs with different block sizes
- add regression coverage for DSV4 cache selection and hybrid memory budgets

## Why a draft

The control-plane/spec-routing foundation is ready and tested. The DSV4 packed single-plane data path is not wired to the resident H2D manager and DSA attention kernel yet, so the existing compressed-model precondition remains in place. Follow-up commits on this PR will add packed CPU allocation, resident buffer remapping, and the DSA decode integration without changing the existing GLM SFA K/V-pair path.

## Validation

- A3 container rebuilt from current vLLM/vllm-ascend sources
- import + NPU tensor smoke passed
- pytest -q tests/ut/distributed/kv_transfer/sparse_kv_offload/test_sparse_kv_offload_manager.py tests/ut/worker/a2/test_model_runner_v1.py
  - 53 passed
- git diff --check passed
- ruff was not available in the fresh runtime image

## Model used for development

/mnt/share/weights/DeepSeek-V4-Flash-bf16-4layers (model_type=deepseek_v4, index_topk=512)
- vLLM main: https://github.com/vllm-project/vllm/commit/ba07e4a48fc951300d97eb506217dd530583dea3
