### PR TITLE
[BugFix][310P] Avoid double-counting shared device memory

### DIFF
--- a/tests/ut/_310p/test_worker_310p.py
+++ b/tests/ut/_310p/test_worker_310p.py
@@ -44,8 +44,6 @@ def test_310p_non_rc_memory_does_not_charge_other_instance() -> None:
     with (
         patch("vllm_ascend._310p.worker_310p.is_rc_device", return_value=False),
         patch("vllm_ascend._310p.worker_310p.memory_profiling", return_value=context),
-        patch("vllm_ascend._310p.worker_310p.torch.npu.mem_get_info", return_value=(32 * GiB_bytes, 64 * GiB_bytes)),
-        patch("vllm_ascend._310p.worker_310p.torch.npu.memory_reserved", return_value=0),
     ):
         result = worker.determine_available_memory()
 

--- a/tests/ut/_310p/test_worker_310p.py
+++ b/tests/ut/_310p/test_worker_310p.py
@@ -1,0 +1,55 @@
+# Copyright (c) 2025 Huawei Technologies Co., Ltd. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+from vllm.utils.mem_constants import GiB_bytes
+
+
+def test_310p_non_rc_memory_does_not_charge_other_instance() -> None:
+    """Do not subtract device-global allocations from a second 310P instance."""
+    from vllm_ascend._310p.worker_310p import NPUWorker310
+
+    worker = object.__new__(NPUWorker310)
+    worker.init_snapshot = SimpleNamespace(
+        free_memory=32 * GiB_bytes,
+        total_memory=64 * GiB_bytes,
+    )
+    worker.requested_memory = int(64 * 0.4 * GiB_bytes)
+    worker.model_runner = MagicMock()
+    worker.model_runner.model_memory_usage = int(0.5 * GiB_bytes)
+
+    profile_result = MagicMock()
+    profile_result.after_profile.free_memory = worker.init_snapshot.free_memory - int(0.5 * GiB_bytes)
+    profile_result.non_kv_cache_memory = int(0.5 * GiB_bytes)
+    profile_result.non_torch_increase = 0
+    profile_result.torch_peak_increase = 0
+
+    context = MagicMock()
+    context.__enter__.return_value = profile_result
+    context.__exit__.return_value = False
+
+    with (
+        patch("vllm_ascend._310p.worker_310p.is_rc_device", return_value=False),
+        patch("vllm_ascend._310p.worker_310p.memory_profiling", return_value=context),
+        patch("vllm_ascend._310p.worker_310p.torch.npu.mem_get_info", return_value=(32 * GiB_bytes, 64 * GiB_bytes)),
+        patch("vllm_ascend._310p.worker_310p.torch.npu.memory_reserved", return_value=0),
+    ):
+        result = worker.determine_available_memory()
+
+    expected = (worker.requested_memory - profile_result.non_kv_cache_memory) // 2
+    assert result == expected
+    assert result > 0
+    worker.model_runner.profile_run.assert_called_once()

--- a/vllm_ascend/_310p/worker_310p.py
+++ b/vllm_ascend/_310p/worker_310p.py
@@ -87,17 +87,9 @@ class NPUWorker310(NPUWorker):
             weights_memory=int(self.model_runner.model_memory_usage),
         ) as profile_result:
             self.model_runner.profile_run()
-            free_memory, total_memory = torch.npu.mem_get_info()
-            # The host memory or device memory for RC devices refers to the available portion of memory
-            # which cannot be obtained via torch.npu.mem_get_info()
-            if is_rc_device():
-                free_memory = psutil.virtual_memory().available
-            torch_memory = torch.npu.memory_reserved()
-            non_torch_memory_before_empty_cache = total_memory - free_memory - torch_memory
 
         self.non_torch_memory = profile_result.non_torch_increase
         self.peak_activation_memory = profile_result.torch_peak_increase
-        non_torch_memory_cleared_by_empty_cache = non_torch_memory_before_empty_cache - self.non_torch_memory
 
         free_gpu_memory = profile_result.after_profile.free_memory
         assert self.init_snapshot.free_memory > free_gpu_memory, (
@@ -121,7 +113,7 @@ class NPUWorker310(NPUWorker):
             self.available_kv_cache_memory_bytes = (self.requested_memory - (vm.total - vm.available)) // 2
         else:
             self.available_kv_cache_memory_bytes = (
-                self.requested_memory - profile_result.non_kv_cache_memory - non_torch_memory_cleared_by_empty_cache
+                self.requested_memory - profile_result.non_kv_cache_memory
             ) // 2
 
         logger.debug(profile_result)

--- a/vllm_ascend/_310p/worker_310p.py
+++ b/vllm_ascend/_310p/worker_310p.py
@@ -112,9 +112,7 @@ class NPUWorker310(NPUWorker):
             vm = psutil.virtual_memory()
             self.available_kv_cache_memory_bytes = (self.requested_memory - (vm.total - vm.available)) // 2
         else:
-            self.available_kv_cache_memory_bytes = (
-                self.requested_memory - profile_result.non_kv_cache_memory
-            ) // 2
+            self.available_kv_cache_memory_bytes = (self.requested_memory - profile_result.non_kv_cache_memory) // 2
 
         logger.debug(profile_result)
         logger.info_once(


### PR DESCRIPTION
### What this PR does / why we need it?

Fix KV-cache memory accounting for non-RC Ascend 310P devices when multiple vLLM instances share one physical chip with device-share enabled.

`NPUWorker310.determine_available_memory()` currently derives `non_torch_memory_cleared_by_empty_cache` from device-global HBM usage. That includes allocations owned by another vLLM process, so the second instance charges the first instance's memory again and can calculate insufficient or zero KV-cache memory.

This change uses only the current profiling result's `profile_result.non_kv_cache_memory` for the non-RC 310P branch. The RC branch remains unchanged.

### How is this different from PR #7427?

PR #7427 fixes the analogous accounting issue in the generic Ascend worker and includes generic multi-instance coverage. Ascend 310P uses the specialized `NPUWorker310` implementation in `vllm_ascend/_310p/worker_310p.py`, which overrides `determine_available_memory()` and retained the stale calculation. This PR applies the corresponding correction to that 310P-specific override and adds a 310P-focused regression test.

Fixes #14274

### Validation

- Ascend 310P3, driver 25.5.1, vLLM Ascend 0.23.0.
- Device Share enabled on chip 0; both vLLM services share `/dev/davinci0`.
- Reranker: `max_model_len=32768`, KV cache 9.31 GiB, maximum concurrency 2.07x.
- Embedding: `max_model_len=40960`, KV cache 5.72 GiB, maximum concurrency 1.02x.
- Both services initialized successfully and passed batch HTTP inference tests.

### Does this PR introduce any user-facing change?

No API change. It allows the existing 310P device-share multi-instance configuration to reserve KV cache based on per-instance usage.

- vLLM main: https://github.com/vllm-project/vllm/commit/ba07e4a48fc951300d97eb506217dd530583dea3
