### PR TITLE
[Feature][Spec Decode] Support DSpark ACL graph replay

### DIFF
--- a/tests/ut/spec_decode/test_dspark_proposer.py
+++ b/tests/ut/spec_decode/test_dspark_proposer.py
@@ -25,6 +25,7 @@ from unittest.mock import MagicMock, patch
 import numpy as np
 import pytest
 import torch
+from vllm.config import CUDAGraphMode
 from vllm.v1.kv_cache_interface import (
     FullAttentionSpec,
     MLAAttentionSpec,
@@ -34,6 +35,7 @@ from vllm.v1.worker.utils import AttentionGroup
 
 from vllm_ascend.attention.attention_v1 import AscendAttentionState
 from vllm_ascend.spec_decode.dspark_proposer import AscendDSparkProposer
+from vllm_ascend.spec_decode.llm_base_proposer import AscendSpecDecodeBaseProposer
 
 # 0 = single-DP (no padding); >0 = multi-DP where num_input_tokens >
 # num_query_total, the out-of-bounds regime.
@@ -406,6 +408,60 @@ def test_pad_query_start_loc_matches_graph_capture_layout(
     assert num_metadata_reqs == len(expected) - 1
     assert query_start_loc.np[: len(expected)].tolist() == expected
     query_start_loc.copy_to_gpu.assert_called_once_with()
+
+
+def test_graph_dispatch_uses_target_verification_width(monkeypatch):
+    """Seven draft queries still require an eight-token target graph slot."""
+    proposer = AscendSpecDecodeBaseProposer.__new__(AscendSpecDecodeBaseProposer)
+    proposer.method = "dspark"
+    proposer.model = SimpleNamespace(combine_hidden_states=lambda hidden_states: hidden_states)
+    proposer.hidden_size = _HIDDEN_SIZE
+    proposer.use_cuda_graph = True
+    proposer.set_inputs_first_pass = MagicMock()
+
+    batch_size = 16
+    num_speculative_tokens = 7
+    num_draft_tokens = batch_size * num_speculative_tokens
+    common_attn_metadata = MagicMock()
+    common_attn_metadata.batch_size.return_value = batch_size
+    proposer.set_inputs_first_pass.return_value = (
+        num_draft_tokens,
+        torch.arange(num_draft_tokens, dtype=torch.int32),
+        common_attn_metadata,
+        None,
+    )
+
+    proposer.runner = MagicMock()
+    proposer.runner.dcp_manager = None
+    proposer.runner.input_batch.lora_id_to_lora_request = {}
+    proposer.runner.cudagraph_dispatcher.dispatch.return_value = (
+        CUDAGraphMode.FULL,
+        SimpleNamespace(num_tokens=128, num_reqs=batch_size),
+    )
+    proposer.runner._sync_metadata_across_dp.side_effect = RuntimeError("stop after first dispatch")
+    monkeypatch.setattr(
+        "vllm_ascend.spec_decode.llm_base_proposer._HIDDEN_STATE_DRAFTER_TYPES",
+        (object,),
+    )
+
+    with pytest.raises(RuntimeError, match="stop after first dispatch"):
+        proposer._propose(
+            num_speculative_tokens=num_speculative_tokens,
+            target_token_ids=torch.zeros(num_draft_tokens, dtype=torch.int64),
+            target_positions=torch.zeros(num_draft_tokens, dtype=torch.int32),
+            target_hidden_states=torch.zeros(num_draft_tokens, _HIDDEN_SIZE),
+            next_token_ids=torch.zeros(batch_size, dtype=torch.int64),
+            token_indices_to_sample=torch.arange(num_draft_tokens, dtype=torch.int32),
+            common_attn_metadata=common_attn_metadata,
+            target_model_batch_desc=SimpleNamespace(uniform=True),
+            sampling_metadata=MagicMock(),
+        )
+
+    proposer.runner.cudagraph_dispatcher.dispatch.assert_called_once_with(
+        num_tokens=batch_size * (1 + num_speculative_tokens),
+        uniform_decode=True,
+        has_lora=False,
+    )
 
 
 class TestSetInputsFirstPassOutputs(_DSparkProposerTestBase):

--- a/tests/ut/spec_decode/test_dspark_proposer.py
+++ b/tests/ut/spec_decode/test_dspark_proposer.py
@@ -81,6 +81,7 @@ class _DSparkProposerTestBase:
         hf_config: SimpleNamespace | None = None,
         draft_attn_causal: bool | None = None,
         draft_sample_method: str = "greedy",
+        use_cuda_graph: bool = False,
     ):
         device = torch.device("cpu")
         vllm_config = cls._make_vllm_config(hf_config or SimpleNamespace(), draft_sample_method)
@@ -99,6 +100,7 @@ class _DSparkProposerTestBase:
             proposer.dtype = torch.float32
             proposer.device = device
             proposer.hidden_size = _HIDDEN_SIZE
+            proposer.use_cuda_graph = use_cuda_graph
             proposer.hidden_states = torch.empty(0)
             proposer._dflash_hidden_states = torch.empty(0)
             proposer.model = (
@@ -339,11 +341,71 @@ class TestDSparkInitialization(_DSparkProposerTestBase):
             hf_config=hf_config,
             draft_sample_method=draft_sample_method,
         )
-        expected_max_query_tokens = _MAX_BATCH_SIZE * expected_num_query_per_req
+        expected_max_query_tokens = _MAX_BATCH_SIZE * (1 + _NUM_SPECULATIVE_TOKENS)
         assert proposer.sample_from_anchor is expected_sample_from_anchor
         assert proposer.num_query_per_req == expected_num_query_per_req
         assert proposer.max_query_tokens == expected_max_query_tokens
         assert proposer._dspark_draft_buffer.shape == (_MAX_BATCH_SIZE, 1 + _NUM_SPECULATIVE_TOKENS)
+
+    def test_static_config_preserves_parent_graph_mode(self):
+        proposer = self._make_proposer(
+            max_num_tokens=64,
+            num_reqs=2,
+            block_size=5,
+            use_cuda_graph=True,
+        )
+
+        assert proposer.use_cuda_graph is True
+
+    def test_block_table_buffer_keeps_graph_padding_rows(self):
+        proposer = self._make_proposer(
+            max_num_tokens=128,
+            num_reqs=16,
+            block_size=5,
+        )
+        block_table = torch.arange(8 * 4, dtype=torch.int32).reshape(8, 4)
+        slot_mapping = torch.arange(40, dtype=torch.int32)
+
+        proposer.set_per_group_attn_metadata(0, block_table, slot_mapping)
+
+        buffer = proposer._per_group_block_table_buffers[0]
+        assert buffer.shape == (16, 4)
+        assert torch.equal(buffer[:8], block_table)
+        assert torch.count_nonzero(buffer[8:]) == 0
+
+
+@pytest.mark.parametrize(
+    ("query_width", "real_num_reqs", "graph_num_reqs", "num_input_tokens", "expected"),
+    [
+        (7, 1, 2, 16, [0, 7, 14, 16]),
+        (5, 2, 8, 48, [0, 5, 10, 15, 20, 25, 30, 35, 40, 48]),
+    ],
+)
+def test_pad_query_start_loc_matches_graph_capture_layout(
+    query_width,
+    real_num_reqs,
+    graph_num_reqs,
+    num_input_tokens,
+    expected,
+):
+    proposer = AscendDSparkProposer.__new__(AscendDSparkProposer)
+    proposer.num_query_per_req = query_width
+    query_start_loc = SimpleNamespace(
+        np=np.zeros(graph_num_reqs + 2, dtype=np.int32),
+        copy_to_gpu=MagicMock(),
+    )
+    query_start_loc.np[: real_num_reqs + 1] = np.arange(real_num_reqs + 1) * query_width
+
+    num_metadata_reqs = proposer.pad_query_start_loc_for_graph(
+        query_start_loc,
+        num_input_tokens,
+        real_num_reqs,
+        graph_num_reqs,
+    )
+
+    assert num_metadata_reqs == len(expected) - 1
+    assert query_start_loc.np[: len(expected)].tolist() == expected
+    query_start_loc.copy_to_gpu.assert_called_once_with()
 
 
 class TestSetInputsFirstPassOutputs(_DSparkProposerTestBase):

--- a/tests/ut/test_ascend_config.py
+++ b/tests/ut/test_ascend_config.py
@@ -995,11 +995,14 @@ class TestTopLevelSwitchTypeValidation(TestBase):
     @patch("vllm_ascend.ascend_config._MEGA_MOE_SUPPORTED", True)
     @patch.object(AscendConfig, "_is_megamoe_supported_by_config", return_value=False)
     @patch("vllm_ascend.platform.NPUPlatform.check_and_update_config")
-    def test_fused_mc2_is_disabled_for_unsupported_megamoe_config(self, mock_fix, mock_megamoe_supported):
+    def test_fused_mc2_mode_1_keeps_switch_for_unsupported_megamoe_config(self, mock_fix, mock_megamoe_supported):
+        # enable_fused_mc2=1 rolls MegaMoe back to dispatch_ffn_combine and
+        # forces _MEGA_MOE_SUPPORTED=False, so derive_and_validate does not
+        # zero the switch even when the model config cannot use MegaMoe.
         vc = VllmConfig()
         vc.additional_config = {"enable_fused_mc2": 1}
 
-        self.assertEqual(init_ascend_config(vc).enable_fused_mc2, 0)
+        self.assertEqual(init_ascend_config(vc).enable_fused_mc2, 1)
 
     @_clean_up
     @patch("vllm_ascend.platform.NPUPlatform.check_and_update_config")

--- a/tests/ut/worker/a2/test_model_runner_v1.py
+++ b/tests/ut/worker/a2/test_model_runner_v1.py
@@ -1337,7 +1337,10 @@ class TestNPUModelRunnerDebugger(unittest.TestCase):
 
         runner.execute_model(scheduler_output)
 
-        runner._dummy_run.assert_called_once_with(1)
+        runner._dummy_run.assert_called_once_with(
+            1,
+            skip_gdn_state_update=True,
+        )
         runner._start_dump_data.assert_not_called()
 
     @patch("vllm_ascend.worker.model_runner_v1.has_kv_transfer_group", return_value=False)

--- a/tests/ut/worker/a2/test_worker_v1.py
+++ b/tests/ut/worker/a2/test_worker_v1.py
@@ -764,7 +764,11 @@ class TestNPUWorker(TestBase):
             worker.execute_dummy_batch()
 
             # Verify call
-            mock_model_runner._dummy_run.assert_called_once_with(mock_uniform_decode_query_len, uniform_decode=True)
+            mock_model_runner._dummy_run.assert_called_once_with(
+                mock_uniform_decode_query_len,
+                uniform_decode=True,
+                skip_gdn_state_update=True,
+            )
 
     @patch("vllm_ascend.worker.worker.plan_sparse_kv_offload_memory")
     @patch("vllm_ascend.worker.worker.get_ascend_config")

--- a/vllm_ascend/_310p/model_runner_310p.py
+++ b/vllm_ascend/_310p/model_runner_310p.py
@@ -583,6 +583,7 @@ class NPUModelRunner310(NPUModelRunner):
         is_graph_capturing: bool = False,
         num_active_loras: int = 0,
         profile_seq_lens: int | None = None,
+        skip_gdn_state_update: bool = False,
     ):
         temporary_context = self.temporary_modify_uniform_decode_query_len() if uniform_decode else nullcontext()
         # All the spec decoding cases has to run splitfuse op on 310P.
@@ -609,6 +610,7 @@ class NPUModelRunner310(NPUModelRunner):
                     is_graph_capturing=is_graph_capturing,
                     num_active_loras=num_active_loras,
                     profile_seq_lens=profile_seq_lens,
+                    skip_gdn_state_update=skip_gdn_state_update,
                 )
             finally:
                 self._spec_dummy_capture = False

--- a/vllm_ascend/spec_decode/dspark_proposer.py
+++ b/vllm_ascend/spec_decode/dspark_proposer.py
@@ -5,14 +5,17 @@ from typing import Any
 
 import torch
 from vllm.config import CUDAGraphMode, VllmConfig, get_layers_from_vllm_config
+from vllm.forward_context import get_forward_context
+from vllm.logger import logger
 from vllm.model_executor.layers.attention_layer_base import AttentionLayerBase
 from vllm.v1.attention.backends.utils import CommonAttentionMetadata
 from vllm.v1.kv_cache_interface import UniformTypeKVCacheSpecs
 from vllm.v1.worker.utils import AttentionGroup
 
 from vllm_ascend.ascend_config import get_ascend_config
-from vllm_ascend.ascend_forward_context import set_ascend_forward_context
+from vllm_ascend.ascend_forward_context import _EXTRA_CTX, set_ascend_forward_context
 from vllm_ascend.attention.attention_v1 import AscendAttentionState
+from vllm_ascend.attention.utils import AscendCommonAttentionMetadata
 from vllm_ascend.ops.triton.spec_decode.utils import copy_and_expand_dflash_and_dspark_inputs_kernel
 from vllm_ascend.spec_decode.dflash_proposer import AscendDflashProposer, _compute_num_programs
 from vllm_ascend.spec_decode.utils import DynamicSpecScheduler
@@ -67,10 +70,16 @@ class AscendDSparkProposer(AscendDflashProposer):
                 num_speculative_tokens=self.num_speculative_tokens,
                 device=device,
             )
-        # DSpark runs eager only (Ascend cudagraph unsupported on this path).
-        self.use_cuda_graph = False
-        # Max query tokens depend on whether sampling from anchor or not.
-        self.max_query_tokens = self.max_batch_size * self.num_query_per_req
+            if self.use_cuda_graph:
+                logger.warning(
+                    "DSpark dynamic verify length is incompatible with ACLGraph; "
+                    "the draft model will run in eager mode."
+                )
+                self.use_cuda_graph = False
+        # The inherited DFlash capacity uses the target verification width
+        # (1 + N). Anchor-first DSpark has N real query tokens per request, and
+        # uses the extra capacity for graph padding.
+        self.max_query_tokens = self.max_batch_size * (1 + self.num_speculative_tokens)
         # Position ids for the draft query block [max_query_tokens].
         # Overrides dflash:49; v2 uses input_buffers.positions.
         self.positions = torch.zeros(
@@ -205,6 +214,14 @@ class AscendDSparkProposer(AscendDflashProposer):
     ) -> None:
         self._per_group_block_tables[gid] = block_table
         self._per_group_slot_mappings[gid] = slot_mapping
+        buffer = self._per_group_block_table_buffers.get(gid)
+        buffer_shape = (self.max_batch_size, *block_table.shape[1:])
+        if buffer is None or buffer.shape != buffer_shape:
+            buffer = block_table.new_zeros(buffer_shape)
+            self._per_group_block_table_buffers[gid] = buffer
+        num_rows = block_table.shape[0]
+        buffer[:num_rows].copy_(block_table)
+        buffer[num_rows:].zero_()
 
     def set_inputs_first_pass(
         self,
@@ -229,10 +246,6 @@ class AscendDSparkProposer(AscendDflashProposer):
         num_sample_total = batch_size * self.num_speculative_tokens
         has_num_rejected = num_rejected_tokens_gpu is not None
         primary_gid = getattr(self, "kv_cache_gid", 0)
-        self._per_group_block_table_buffers = {
-            attn_group.kv_cache_group_id: self._per_group_block_tables[attn_group.kv_cache_group_id]
-            for attn_group in self.draft_attn_groups
-        }
         self._context_slot_mapping_buffers = None
         self._dflash_num_context = int(cad.query_start_loc_cpu[batch_size])
         self._dflash_hidden_states[: self._dflash_num_context] = target_hidden_states[: self._dflash_num_context]
@@ -326,6 +339,29 @@ class AscendDSparkProposer(AscendDflashProposer):
 
         return num_query_total, token_indices_to_sample, cad, None
 
+    def pad_query_start_loc_for_graph(
+        self,
+        query_start_loc,
+        num_input_tokens: int,
+        real_num_reqs: int,
+        graph_num_reqs: int,
+    ) -> int:
+        """Match DSpark's N-token queries to target (1 + N) graph buckets."""
+        last_loc = int(query_start_loc.np[real_num_reqs])
+        num_metadata_reqs = real_num_reqs
+
+        for req_idx in range(real_num_reqs, graph_num_reqs):
+            last_loc += self.num_query_per_req
+            query_start_loc.np[req_idx + 1] = last_loc
+            num_metadata_reqs += 1
+
+        if last_loc < num_input_tokens:
+            query_start_loc.np[num_metadata_reqs + 1] = num_input_tokens
+            num_metadata_reqs += 1
+
+        query_start_loc.copy_to_gpu()
+        return num_metadata_reqs
+
     @torch.inference_mode()
     def dummy_run(
         self,
@@ -339,7 +375,10 @@ class AscendDSparkProposer(AscendDflashProposer):
         **kwargs,
     ) -> None:
         num_query_total = num_reqs * self.num_query_per_req
-        num_query_tokens = min(num_query_total if num_reqs > 0 else num_tokens, self.max_query_tokens)
+        num_query_tokens = num_query_total if num_reqs > 0 else num_tokens
+        if aclgraph_runtime_mode == CUDAGraphMode.FULL and batch_descriptor is not None:
+            num_query_tokens = batch_descriptor.num_tokens
+        num_query_tokens = min(num_query_tokens, self.max_query_tokens)
 
         (
             num_input_tokens,
@@ -356,8 +395,58 @@ class AscendDSparkProposer(AscendDflashProposer):
         self.token_indices_to_sample.fill_(0)
         self._pad_draft_buffers(num_query_total, num_input_tokens)
 
+        multi_steps_attn_metadata = []
+        if aclgraph_runtime_mode == CUDAGraphMode.FULL and self.draft_attn_groups:
+            query_start_loc_cpu = (
+                torch.from_numpy(self.token_arange_np[: num_reqs + 1]).clone() * self.num_query_per_req
+            )
+            if num_input_tokens > num_query_total:
+                query_start_loc_cpu = torch.cat(
+                    (query_start_loc_cpu, query_start_loc_cpu.new_tensor([num_input_tokens]))
+                )
+            num_metadata_reqs = query_start_loc_cpu.shape[0] - 1
+            query_start_loc = query_start_loc_cpu.to(self.device)
+            causal = self.model.get_draft_attn_causal()[0]
+            per_layer_attn_metadata: dict[str, Any] = {}
+            for attn_group in self.draft_attn_groups:
+                gid = attn_group.kv_cache_group_id
+                common_attn_metadata = AscendCommonAttentionMetadata(
+                    query_start_loc=query_start_loc,
+                    query_start_loc_cpu=query_start_loc_cpu,
+                    seq_lens_cpu=self.runner.optimistic_seq_lens_cpu[:num_metadata_reqs],
+                    _seq_lens_cpu=self.runner.optimistic_seq_lens_cpu[:num_metadata_reqs],
+                    seq_lens_cpu_upper_bound=self.runner.optimistic_seq_lens_cpu[:num_metadata_reqs],
+                    seq_lens=self.runner.seq_lens[:num_metadata_reqs],
+                    num_reqs=num_metadata_reqs,
+                    # FULL graph capture must materialize the complete graph
+                    # bucket. The tail slots are already padded with -1, so
+                    # treating them as graph tokens keeps attention tensor
+                    # shapes and graph-parameter keys fixed at
+                    # ``num_input_tokens``.
+                    num_actual_tokens=num_input_tokens,
+                    num_input_tokens=num_input_tokens,
+                    max_query_len=self.num_query_per_req,
+                    max_seq_len=0,
+                    slot_mapping=self._per_group_query_slot_mapping_buffers[gid][:num_input_tokens],
+                    positions=self.positions,
+                    attn_state=AscendAttentionState.SpecDecoding,
+                    causal=causal,
+                    is_prefilling=torch.zeros(num_metadata_reqs, dtype=torch.bool),
+                    block_table_tensor=self._per_group_block_table_buffers[gid][:num_metadata_reqs],
+                )
+                metadata = attn_group.get_metadata_builder().build_for_graph_capture(
+                    common_attn_metadata,
+                    AscendAttentionState.SpecDecoding,
+                )
+                if hasattr(metadata, "attn_mask") and not causal:
+                    metadata.attn_mask = None
+                metadata.attn_state = AscendAttentionState.SpecDecoding
+                for layer_name in attn_group.layer_names:
+                    per_layer_attn_metadata[layer_name] = metadata
+            multi_steps_attn_metadata.append(per_layer_attn_metadata)
+
         with set_ascend_forward_context(
-            None,
+            multi_steps_attn_metadata[0] if multi_steps_attn_metadata else None,
             self.vllm_config,
             num_tokens=num_input_tokens,
             num_tokens_across_dp=num_tokens_across_dp,
@@ -366,7 +455,7 @@ class AscendDSparkProposer(AscendDflashProposer):
             batch_descriptor=batch_descriptor,
             aclgraph_runtime_mode=aclgraph_runtime_mode,
             is_draft_model=True,
-            draft_attn_metadatas=[],
+            draft_attn_metadatas=multi_steps_attn_metadata,
         ):
             if is_profile:
                 self.model.precompute_and_store_context_kv(context_states, context_positions)
@@ -384,6 +473,10 @@ class AscendDSparkProposer(AscendDflashProposer):
                     token_indices_to_sample=self.token_indices_to_sample[: num_reqs * self.num_speculative_tokens],
                     target_positions=self._get_positions(num_input_tokens),
                     inputs_embeds=None,
-                    multi_steps_attn_metadata=[],
+                    multi_steps_attn_metadata=multi_steps_attn_metadata,
                     num_tokens=num_input_tokens,
                 )
+
+            forward_context = get_forward_context()
+            if forward_context.cudagraph_runtime_mode == CUDAGraphMode.FULL and not _EXTRA_CTX.capturing:
+                self._update_full_graph_params(forward_context, num_input_tokens, multi_steps_attn_metadata)

--- a/vllm_ascend/spec_decode/dspark_proposer.py
+++ b/vllm_ascend/spec_decode/dspark_proposer.py
@@ -418,12 +418,10 @@ class AscendDSparkProposer(AscendDflashProposer):
                     seq_lens_cpu_upper_bound=self.runner.optimistic_seq_lens_cpu[:num_metadata_reqs],
                     seq_lens=self.runner.seq_lens[:num_metadata_reqs],
                     num_reqs=num_metadata_reqs,
-                    # FULL graph capture must materialize the complete graph
-                    # bucket. The tail slots are already padded with -1, so
-                    # treating them as graph tokens keeps attention tensor
-                    # shapes and graph-parameter keys fixed at
-                    # ``num_input_tokens``.
-                    num_actual_tokens=num_input_tokens,
+                    # Keep cache writes limited to real draft queries. The
+                    # graph still executes ``num_input_tokens`` rows; padding
+                    # rows have -1 slot mappings and are discarded.
+                    num_actual_tokens=num_query_total,
                     num_input_tokens=num_input_tokens,
                     max_query_len=self.num_query_per_req,
                     max_seq_len=0,
@@ -450,7 +448,7 @@ class AscendDSparkProposer(AscendDflashProposer):
             self.vllm_config,
             num_tokens=num_input_tokens,
             num_tokens_across_dp=num_tokens_across_dp,
-            num_actual_tokens=num_input_tokens,
+            num_actual_tokens=num_query_total,
             in_profile_run=is_profile,
             batch_descriptor=batch_descriptor,
             aclgraph_runtime_mode=aclgraph_runtime_mode,

--- a/vllm_ascend/spec_decode/llm_base_proposer.py
+++ b/vllm_ascend/spec_decode/llm_base_proposer.py
@@ -878,17 +878,41 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
             num_reqs = common_attn_metadata.query_start_loc.shape[0]
             self.query_start_loc.gpu[:num_reqs].copy_(common_attn_metadata.query_start_loc)
             self.query_start_loc.cpu[:num_reqs].copy_(common_attn_metadata.query_start_loc_cpu)
-            num_reqs_padded = self.runner._pad_query_start_loc_for_fia(
-                self.query_start_loc,
-                num_input_tokens,
-                batch_descriptor.num_reqs if batch_descriptor.num_reqs is not None else common_attn_metadata.num_reqs,
-                common_attn_metadata.num_reqs,
-                aclgraph_runtime_mode,
-                batch_descriptor.num_reqs,
-            )
+            if self.method == "dspark":
+                graph_num_reqs = (
+                    batch_descriptor.num_reqs
+                    if batch_descriptor.num_reqs is not None
+                    else common_attn_metadata.num_reqs
+                )
+                num_reqs_padded = self.pad_query_start_loc_for_graph(
+                    self.query_start_loc,
+                    num_input_tokens,
+                    common_attn_metadata.num_reqs,
+                    graph_num_reqs,
+                )
+            else:
+                num_reqs_padded = self.runner._pad_query_start_loc_for_fia(
+                    self.query_start_loc,
+                    num_input_tokens,
+                    (
+                        batch_descriptor.num_reqs
+                        if batch_descriptor.num_reqs is not None
+                        else common_attn_metadata.num_reqs
+                    ),
+                    common_attn_metadata.num_reqs,
+                    aclgraph_runtime_mode,
+                    batch_descriptor.num_reqs,
+                )
             common_attn_metadata.num_reqs = num_reqs_padded
             common_attn_metadata.query_start_loc = self.query_start_loc.gpu[: num_reqs_padded + 1]
             common_attn_metadata.query_start_loc_cpu = self.query_start_loc.cpu[: num_reqs_padded + 1]
+            if self.method == "dspark":
+                # DSpark has N real query tokens per request while the target
+                # graph bucket is sized for 1 + N. Include the padded tail in
+                # attention tensor shapes so capture and replay use the same
+                # graph key; its slot mapping remains -1 and its outputs are
+                # discarded.
+                common_attn_metadata.num_actual_tokens = num_input_tokens
             slicing_length = num_reqs_padded * self.decode_threshold if self.dcp_size > 1 else num_reqs_padded
             common_attn_metadata.block_table_tensor = self._adjust_tensor(
                 common_attn_metadata.block_table_tensor, slicing_length
@@ -1043,6 +1067,11 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
         self.token_indices_to_sample[:token_indices_to_sample_len].copy_(token_indices_to_sample)
         self.token_indices_to_sample[token_indices_to_sample_len:].fill_(0)
 
+        # DSpark context K/V has a request-dependent shape. Update it eagerly;
+        # the fixed query block remains inside the captured graph.
+        if self.method == "dspark":
+            self.build_model_inputs_first_pass(num_input_tokens, self._context_slot_mapping_buffers)
+
         with set_ascend_forward_context(
             multi_steps_attn_metadata[0],
             self.vllm_config,
@@ -1164,9 +1193,9 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
         model_positions = self._get_positions(num_input_tokens)
         model_kwargs = {"input_ids": model_input_ids, "positions": model_positions, "inputs_embeds": inputs_embeds}
 
-        if self.method in ("dflash", "dspark"):
+        if self.method == "dflash":
             self.build_model_inputs_first_pass(num_input_tokens, self._context_slot_mapping_buffers)
-        else:
+        elif self.method != "dspark":
             if self.pass_hidden_states_to_model:
                 model_hidden_states = self.hidden_states[:num_input_tokens]
                 model_hidden_states, model_positions = self.maybe_pad_and_reduce(model_hidden_states, model_positions)

--- a/vllm_ascend/spec_decode/llm_base_proposer.py
+++ b/vllm_ascend/spec_decode/llm_base_proposer.py
@@ -847,8 +847,17 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
         uniform_decode = target_model_batch_desc.uniform
 
         if self.use_cuda_graph:
+            graph_dispatch_tokens = num_tokens
+            if self.method == "dspark":
+                # DSpark may run N anchor-first draft queries per request,
+                # while the target graph verifies 1 + N tokens. Graph batch
+                # descriptors use the target width, so dispatch with that
+                # width and retain ``num_tokens`` as the real draft count.
+                graph_dispatch_tokens = batch_size * (1 + self.num_speculative_tokens)
             _, batch_descriptor = self.runner.cudagraph_dispatcher.dispatch(
-                num_tokens=num_tokens, uniform_decode=uniform_decode, has_lora=has_lora
+                num_tokens=graph_dispatch_tokens,
+                uniform_decode=uniform_decode,
+                has_lora=has_lora,
             )
             num_input_tokens = batch_descriptor.num_tokens
         else:
@@ -906,13 +915,6 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
             common_attn_metadata.num_reqs = num_reqs_padded
             common_attn_metadata.query_start_loc = self.query_start_loc.gpu[: num_reqs_padded + 1]
             common_attn_metadata.query_start_loc_cpu = self.query_start_loc.cpu[: num_reqs_padded + 1]
-            if self.method == "dspark":
-                # DSpark has N real query tokens per request while the target
-                # graph bucket is sized for 1 + N. Include the padded tail in
-                # attention tensor shapes so capture and replay use the same
-                # graph key; its slot mapping remains -1 and its outputs are
-                # discarded.
-                common_attn_metadata.num_actual_tokens = num_input_tokens
             slicing_length = num_reqs_padded * self.decode_threshold if self.dcp_size > 1 else num_reqs_padded
             common_attn_metadata.block_table_tensor = self._adjust_tensor(
                 common_attn_metadata.block_table_tensor, slicing_length

--- a/vllm_ascend/worker/model_runner_v1.py
+++ b/vllm_ascend/worker/model_runner_v1.py
@@ -3247,17 +3247,22 @@ class NPUModelRunner(GPUModelRunner):
                 GDNAttentionMetadataBuilder,
             )
             if is_gdn_noop:
-                assert num_reqs_padded is not None
-                # An idle DP dummy has a real tensor shape for model and
-                # collective execution, but no GDN tokens. Keep both captured
-                # recurrent branches inert instead of advancing cached state.
+                # Dummy-run callers coalesce this; fall back to the unpadded
+                # batch size instead of asserting in the execute path.
+                gdn_num_reqs = (
+                    num_reqs if num_reqs_padded is None else num_reqs_padded
+                )
+                # Idle DP dummy: keep captured GDN tensor ranks for graph
+                # replay/collectives. num_actual_tokens=0 is the kernel no-op
+                # (ops slice mixed_qkv[:0]); query_start_loc is a zero-filled
+                # prefix sized to the graph, not a real token schedule.
                 common_attn_metadata = replace(
                     common_attn_metadata,
                     query_start_loc=self.gdn_query_start_loc.gpu[
-                        : num_reqs_padded + 1
+                        : gdn_num_reqs + 1
                     ],
                     query_start_loc_cpu=self.gdn_query_start_loc.cpu[
-                        : num_reqs_padded + 1
+                        : gdn_num_reqs + 1
                     ],
                     num_actual_tokens=0,
                     max_query_len=0,

--- a/vllm_ascend/worker/model_runner_v1.py
+++ b/vllm_ascend/worker/model_runner_v1.py
@@ -2140,7 +2140,7 @@ class NPUModelRunner(GPUModelRunner):
                         # returns True. before returning early here we call
                         # dummy run to ensure coordinate_batch_across_dp
                         # is called into to avoid out of sync issues.
-                        self._dummy_run(1)
+                        self._dummy_run(1, skip_gdn_state_update=True)
                     if not has_kv_transfer_group():
                         # Return empty ModelRunnerOutput if no work to do.
                         return EMPTY_MODEL_RUNNER_OUTPUT
@@ -3077,6 +3077,7 @@ class NPUModelRunner(GPUModelRunner):
         num_scheduled_tokens: dict[str, int] | None = None,
         num_scheduled_tokens_np: np.ndarray | None = None,
         cascade_attn_prefix_lens: list[list[int]] | None = None,
+        skip_gdn_state_update: bool = False,
     ) -> tuple[PerLayerAttnMetadata, CommonAttentionMetadata | None]:
         """
         :return: tuple[attn_metadata, spec_decode_common_attn_metadata]
@@ -3241,12 +3242,40 @@ class NPUModelRunner(GPUModelRunner):
         ) -> None:
             attn_group = self.attn_groups[kv_cache_gid][attn_gid]
             builder = attn_group.get_metadata_builder(ubid or 0)
+            is_gdn_noop = skip_gdn_state_update and isinstance(
+                builder,
+                GDNAttentionMetadataBuilder,
+            )
+            if is_gdn_noop:
+                assert num_reqs_padded is not None
+                # An idle DP dummy has a real tensor shape for model and
+                # collective execution, but no GDN tokens. Keep both captured
+                # recurrent branches inert instead of advancing cached state.
+                common_attn_metadata = common_attn_metadata.replace(
+                    query_start_loc=self.gdn_query_start_loc.gpu[
+                        : num_reqs_padded + 1
+                    ],
+                    query_start_loc_cpu=self.gdn_query_start_loc.cpu[
+                        : num_reqs_padded + 1
+                    ],
+                    num_actual_tokens=0,
+                    max_query_len=0,
+                    is_prefilling=(
+                        torch.zeros_like(common_attn_metadata.is_prefilling)
+                        if common_attn_metadata.is_prefilling is not None
+                        else None
+                    ),
+                )
             cascade_attn_prefix_len = (
                 cascade_attn_prefix_lens[kv_cache_gid][attn_gid] if cascade_attn_prefix_lens else 0
             )
 
             extra_attn_metadata_args = {}
-            if use_spec_decode and isinstance(builder, GDNAttentionMetadataBuilder):
+            if (
+                use_spec_decode
+                and isinstance(builder, GDNAttentionMetadataBuilder)
+                and not is_gdn_noop
+            ):
                 assert ubid is None, "UBatching not supported with GDN yet"
                 extra_attn_metadata_args = dict(
                     num_accepted_tokens=self.num_accepted_tokens.gpu[:num_reqs_padded],
@@ -3405,6 +3434,7 @@ class NPUModelRunner(GPUModelRunner):
         num_active_loras: int = 0,
         profile_seq_lens: int | None = None,
         profile_cpp: bool = False,
+        skip_gdn_state_update: bool = False,
     ) -> tuple[torch.Tensor, torch.Tensor]:
         # only support eager mode and piecewise graph now
         assert cudagraph_runtime_mode is None or cudagraph_runtime_mode.valid_runtime_modes()
@@ -3543,7 +3573,12 @@ class NPUModelRunner(GPUModelRunner):
                 self.query_start_loc.np[1 : num_reqs_padded + 1] = cum_num_tokens
                 self.query_start_loc.copy_to_gpu()
                 if self._has_gdn:
-                    self.gdn_query_start_loc.np[1 : num_reqs_padded + 1] = cum_num_tokens
+                    if skip_gdn_state_update:
+                        self.gdn_query_start_loc.np.fill(0)
+                    else:
+                        self.gdn_query_start_loc.np[
+                            1 : num_reqs_padded + 1
+                        ] = cum_num_tokens
                     self.gdn_query_start_loc.copy_to_gpu()
 
                 if not profile_cpp:
@@ -3575,6 +3610,7 @@ class NPUModelRunner(GPUModelRunner):
                     ubatch_slices=ubatch_slices_padded if pad_attn else ubatch_slices,
                     for_cudagraph_capture=is_graph_capturing,
                     num_scheduled_tokens_np=num_scheduled_tokens,
+                    skip_gdn_state_update=skip_gdn_state_update,
                 )
                 if not is_graph_capturing:
                     for kv_cache_gid in range(len(self.kv_cache_config.kv_cache_groups)):

--- a/vllm_ascend/worker/model_runner_v1.py
+++ b/vllm_ascend/worker/model_runner_v1.py
@@ -3251,7 +3251,8 @@ class NPUModelRunner(GPUModelRunner):
                 # An idle DP dummy has a real tensor shape for model and
                 # collective execution, but no GDN tokens. Keep both captured
                 # recurrent branches inert instead of advancing cached state.
-                common_attn_metadata = common_attn_metadata.replace(
+                common_attn_metadata = replace(
+                    common_attn_metadata,
                     query_start_loc=self.gdn_query_start_loc.gpu[
                         : num_reqs_padded + 1
                     ],

--- a/vllm_ascend/worker/worker.py
+++ b/vllm_ascend/worker/worker.py
@@ -1085,7 +1085,11 @@ class NPUWorker(WorkerBase):
     def execute_dummy_batch(self) -> None:
         self.log_memory_stats()
         num_tokens = getattr(self.model_runner, "uniform_decode_query_len", 1)
-        self.model_runner._dummy_run(num_tokens, uniform_decode=True)
+        self.model_runner._dummy_run(
+            num_tokens,
+            uniform_decode=True,
+            skip_gdn_state_update=True,
+        )
 
     def _init_worker_distributed_environment(self) -> None:
         """Initialize the distributed environment."""


### PR DESCRIPTION
### What this PR does / why we need it?

Enable ACLGraph capture and replay for static-length DSpark speculative decoding.

- Keep request-shaped DSpark context K/V preparation eager while capturing the fixed query block.
- Pad anchor-first DSpark query metadata from `N` real draft tokens to the target `1 + N` graph bucket.
- Preserve per-KV-group block tables and zeroed virtual-request rows for graph replay.
- Support both Kimi-K3 GQA DSpark (7 draft tokens) and MLA-Block5 DSpark (5 draft tokens).
- Keep dynamic verification-length DSpark on the existing eager path.
- Include the idle-DP GDN state fix from #15253 so dummy synchronization batches do not update recurrent state.

### Does this PR introduce _any_ user-facing change?

Yes. Static-length DSpark draft models can use Ascend ACLGraph with `FULL_DECODE_ONLY` instead of always running the draft path eagerly.

### How was this patch tested?

- Unit tests: 51 passed across the DSpark proposer/base proposer and the focused #15253 regressions.
- Ruff lint and format checks passed for all changed files; `git diff --check` passed.
- Single-node, TP16, 16-expert QuaRot target:
  - GQA DSpark: graph bucket `[16]`, capture and replay passed.
  - MLA-Block5 DSpark: graph bucket `[48]`, capture and replay passed.
- Four-node, DP4/TP16/EP64, full QuaRot target:
  - GQA DSpark: all four DP engines replayed the graph; short and repeated 9.6K-prefix requests completed without runtime errors or `None` output.
  - MLA-Block5 DSpark: all four DP engines replayed the graph; short and repeated 9.6K-prefix requests completed without runtime errors or `None` output.

- vLLM main: https://github.com/vllm-project/vllm/commit/ba07e4a48fc951300d97eb506217dd530583dea3
