### PR TITLE
[BugFix][SpecDecode] Handle partial DSpark verification windows

### DIFF
--- a/tests/e2e/nightly/single_node/ops/singlecard_ops/triton/test_copy_and_expand_dflash_dspark.py
+++ b/tests/e2e/nightly/single_node/ops/singlecard_ops/triton/test_copy_and_expand_dflash_dspark.py
@@ -24,6 +24,7 @@ def copy_and_expand_dflash_dspark_ref(
     query_start_loc,
     seq_lens,
     num_rejected_tokens,
+    valid_sampled_tokens_count,
     num_query_per_req,
     num_speculative_tokens,
     sample_from_anchor,
@@ -51,13 +52,19 @@ def copy_and_expand_dflash_dspark_ref(
 
         if num_rejected_tokens is not None:
             num_rejected = num_rejected_tokens[req_idx].item()
-            valid_ctx_end = ctx_end - num_rejected
         else:
             num_rejected = 0
+        if valid_sampled_tokens_count is not None and num_rejected > 0:
+            valid_ctx_end = ctx_start + valid_sampled_tokens_count[req_idx].item()
+        else:
             valid_ctx_end = ctx_end
+            valid_ctx_end -= num_rejected
 
         seq_len = seq_lens[req_idx].item()
-        effective_seq_len = seq_len - num_rejected
+        current_window_rejected = num_rejected
+        if valid_sampled_tokens_count is not None and num_rejected > 0:
+            current_window_rejected = ctx_end - ctx_start - valid_sampled_tokens_count[req_idx].item()
+        effective_seq_len = seq_len - current_window_rejected
         last_pos = target_positions[valid_ctx_end - 1].item()
 
         for q_idx in range(num_query_per_req):
@@ -94,22 +101,39 @@ def copy_and_expand_dflash_dspark_ref(
     }
 
 
-# (batch_size, ctx_lens, num_spec, sample_from_anchor, has_num_rejected)
+# (batch_size, ctx_lens, num_spec, sample_from_anchor,
+#  has_num_rejected, has_valid_sampled_count, partial_window)
 CONFIGS = [
-    (1, [4], 3, False, False),
-    (64, [4] * 64, 3, False, False),
-    (256, [4] * 256, 3, False, False),
-    (1, [2048], 3, False, False),
-    (4, [1024] * 4, 3, False, False),
-    (8, [512] * 8, 3, False, False),
-    (64, [4] * 64, 3, True, False),
-    (64, [4] * 64, 3, False, True),
-    (8, [512] * 8, 3, True, True),
+    (1, [4], 3, False, False, False, False),
+    (64, [4] * 64, 3, False, False, False, False),
+    (256, [4] * 256, 3, False, False, False, False),
+    (1, [2048], 3, False, False, False, False),
+    (4, [1024] * 4, 3, False, False, False, False),
+    (8, [512] * 8, 3, False, False, False, False),
+    (64, [4] * 64, 3, True, False, False, False),
+    (64, [4] * 64, 3, False, True, False, False),
+    (8, [512] * 8, 3, True, True, False, False),
+    # PR #51113 Mamba boundary case: the current chunk can be shorter than
+    # the real rejection count from the previous complete DSpark window.
+    (2, [5, 8], 7, True, True, True, True),
+    # A valid-count tensor must not move the anchor on a reject-free row.
+    (1, [5], 7, True, False, True, False),
 ]
 
 
-@pytest.mark.parametrize("batch_size,ctx_lens,num_spec,sample_from_anchor,has_num_rejected", CONFIGS)
-def test_copy_and_expand_dflash_dspark(batch_size, ctx_lens, num_spec, sample_from_anchor, has_num_rejected):
+@pytest.mark.parametrize(
+    "batch_size,ctx_lens,num_spec,sample_from_anchor,has_num_rejected,has_valid_sampled_count,partial_window",
+    CONFIGS,
+)
+def test_copy_and_expand_dflash_dspark(
+    batch_size,
+    ctx_lens,
+    num_spec,
+    sample_from_anchor,
+    has_num_rejected,
+    has_valid_sampled_count,
+    partial_window,
+):
     init_device_properties_triton()
     device = "npu"
     torch.manual_seed(0)
@@ -125,6 +149,8 @@ def test_copy_and_expand_dflash_dspark(batch_size, ctx_lens, num_spec, sample_fr
 
     history = torch.randint(0, 100, (batch_size,), dtype=torch.int32, device=device)
     seq_lens = ctx + history
+    if partial_window:
+        seq_lens = ctx + 379
     target_positions = torch.cat(
         [
             torch.arange(
@@ -137,15 +163,34 @@ def test_copy_and_expand_dflash_dspark(batch_size, ctx_lens, num_spec, sample_fr
         ]
     )
     max_blocks = int((seq_lens.max() + num_query_per_req + KV_BLOCK_SIZE) // KV_BLOCK_SIZE) + 2
-    block_table = torch.randint(1, 10000, (batch_size, max_blocks), dtype=torch.int32, device=device)
+    if partial_window:
+        # Consecutive, request-distinct block IDs make the expected physical
+        # slots below direct constants rather than another copy of the kernel
+        # formula.
+        block_table = torch.stack(
+            [torch.arange(100 + 100 * i, 100 + 100 * i + max_blocks) for i in range(batch_size)]
+        ).to(dtype=torch.int32, device=device)
+    else:
+        block_table = torch.randint(1, 10000, (batch_size, max_blocks), dtype=torch.int32, device=device)
 
     if has_num_rejected:
-        num_rejected_tokens = torch.minimum(
-            torch.randint(0, num_spec + 1, (batch_size,), dtype=torch.int32, device=device),
-            ctx - 1,
-        ).clamp(min=0)
+        if partial_window:
+            num_rejected_tokens = torch.full((batch_size,), num_spec, dtype=torch.int32, device=device)
+        else:
+            num_rejected_tokens = torch.minimum(
+                torch.randint(0, num_spec + 1, (batch_size,), dtype=torch.int32, device=device),
+                ctx - 1,
+            ).clamp(min=0)
     else:
         num_rejected_tokens = None
+    valid_sampled_tokens_count = None
+    if has_valid_sampled_count:
+        if partial_window:
+            valid_sampled_tokens_count = torch.ones(batch_size, dtype=torch.int32, device=device)
+        elif num_rejected_tokens is not None:
+            valid_sampled_tokens_count = ctx - num_rejected_tokens
+        else:
+            valid_sampled_tokens_count = ctx.clone()
 
     next_token_ids = torch.randint(0, 150000, (batch_size,), dtype=torch.int32, device=device)
     context_slot_mapping = torch.randint(0, 1 << 30, (total_ctx,), dtype=torch.int32, device=device)
@@ -159,6 +204,7 @@ def test_copy_and_expand_dflash_dspark(batch_size, ctx_lens, num_spec, sample_fr
         query_start_loc,
         seq_lens,
         num_rejected_tokens,
+        valid_sampled_tokens_count,
         num_query_per_req,
         num_spec,
         sample_from_anchor,
@@ -189,6 +235,9 @@ def test_copy_and_expand_dflash_dspark(batch_size, ctx_lens, num_spec, sample_fr
         query_start_loc_ptr=query_start_loc,
         seq_lens_ptr=seq_lens,
         num_rejected_tokens_ptr=(num_rejected_tokens if num_rejected_tokens is not None else 0),
+        valid_sampled_tokens_count_ptr=(
+            valid_sampled_tokens_count if valid_sampled_tokens_count is not None else 0
+        ),
         parallel_drafting_token_id=PARALLEL_DRAFTING_TOKEN_ID,
         block_size=KV_BLOCK_SIZE,
         num_query_per_req=num_query_per_req,
@@ -196,6 +245,7 @@ def test_copy_and_expand_dflash_dspark(batch_size, ctx_lens, num_spec, sample_fr
         total_input_tokens=total_ctx,
         batch_size=batch_size,
         HAS_NUM_REJECTED=has_num_rejected,
+        HAS_VALID_SAMPLED_COUNT=has_valid_sampled_count,
         SAMPLE_FROM_ANCHOR=sample_from_anchor,
         TILE_SIZE=_COPY_EXPAND_TILE_SIZE,
     )
@@ -206,6 +256,25 @@ def test_copy_and_expand_dflash_dspark(batch_size, ctx_lens, num_spec, sample_fr
     torch.testing.assert_close(out_context_slot_mapping, ref["out_context_slot_mapping"])
     torch.testing.assert_close(out_query_slot_mapping, ref["out_query_slot_mapping"])
     torch.testing.assert_close(out_token_indices, ref["out_token_indices"])
+
+    if partial_window:
+        # ctx=5/rejected=7/valid=1 anchors at position 379, then expands the
+        # fixed K=7 DSpark query at positions and physical slots 380..386.
+        # The second request deliberately has ctx=8 to prove row-local anchor
+        # semantics in a mixed batch.
+        expected_positions = torch.tensor(
+            [380, 381, 382, 383, 384, 385, 386] * 2,
+            dtype=torch.int32,
+            device=device,
+        )
+        expected_slots = torch.tensor(
+            [13180, 13181, 13182, 13183, 13184, 13185, 13186,
+             25980, 25981, 25982, 25983, 25984, 25985, 25986],
+            dtype=torch.int32,
+            device=device,
+        )
+        torch.testing.assert_close(out_query_positions, expected_positions)
+        torch.testing.assert_close(out_query_slot_mapping, expected_slots)
 
     gc.collect()
     torch.npu.empty_cache()

--- a/tests/ut/spec_decode/test_dspark_proposer.py
+++ b/tests/ut/spec_decode/test_dspark_proposer.py
@@ -33,7 +33,10 @@ from vllm.v1.kv_cache_interface import (
 from vllm.v1.worker.utils import AttentionGroup
 
 from vllm_ascend.attention.attention_v1 import AscendAttentionState
-from vllm_ascend.spec_decode.dspark_proposer import AscendDSparkProposer
+from vllm_ascend.spec_decode.dspark_proposer import (
+    AscendDSparkProposer,
+    _derive_current_window_rejected_tokens,
+)
 
 # 0 = single-DP (no padding); >0 = multi-DP where num_input_tokens >
 # num_query_total, the out-of-bounds regime.
@@ -163,6 +166,7 @@ class _DSparkProposerTestBase:
         async_metadata=False,
         context=None,
         num_rejected=None,
+        valid_sampled_count=None,
         with_optional_attrs=False,
     ):
         """Drive ``set_inputs_first_pass`` with a configurable cad.
@@ -200,6 +204,7 @@ class _DSparkProposerTestBase:
             token_indices_to_sample=None,
             cad=cad,
             num_rejected_tokens_gpu=num_rejected,
+            valid_sampled_tokens_count_gpu=valid_sampled_count,
         )
         return num_query_total, token_indices, cad, extra, next_token_ids, target_hidden_states
 
@@ -509,7 +514,142 @@ class TestSetInputsFirstPassRejectedTokens(_DSparkProposerTestBase):
         kwargs = sub.call_args.kwargs
         assert kwargs["HAS_NUM_REJECTED"] is True
         assert kwargs["num_rejected_tokens_ptr"] is rejected
+        assert kwargs["HAS_VALID_SAMPLED_COUNT"] is False
+        assert kwargs["valid_sampled_tokens_count_ptr"] == 0
         assert kwargs["SAMPLE_FROM_ANCHOR"] is True
+
+    def test_kernel_receives_current_window_valid_counts(self, monkeypatch):
+        kernel = MagicMock()
+        monkeypatch.setattr(
+            "vllm_ascend.spec_decode.dspark_proposer.copy_and_expand_dflash_and_dspark_inputs_kernel",
+            kernel,
+        )
+        num_reqs, block_size, max_num_tokens = 2, 7, 64
+        proposer = self._make_proposer(max_num_tokens=max_num_tokens, num_reqs=num_reqs, block_size=block_size)
+        rejected = torch.full((num_reqs,), 7, dtype=torch.int32)
+        valid_count = torch.ones(num_reqs, dtype=torch.int64)
+
+        self._invoke_set_inputs_first_pass(
+            proposer,
+            num_reqs=num_reqs,
+            block_size=block_size,
+            num_rejected=rejected,
+            valid_sampled_count=valid_count,
+        )
+
+        kwargs = kernel[1,].call_args.kwargs
+        assert kwargs["HAS_NUM_REJECTED"] is True
+        assert kwargs["HAS_VALID_SAMPLED_COUNT"] is True
+        assert kwargs["num_rejected_tokens_ptr"] is rejected
+        forwarded = kwargs["valid_sampled_tokens_count_ptr"]
+        assert forwarded.dtype == torch.int32
+        assert torch.equal(forwarded, valid_count.to(torch.int32))
+
+    def test_partial_window_without_valid_count_fails_before_kernel(self, monkeypatch):
+        kernel = MagicMock()
+        monkeypatch.setattr(
+            "vllm_ascend.spec_decode.dspark_proposer.copy_and_expand_dflash_and_dspark_inputs_kernel",
+            kernel,
+        )
+
+        def _assert_async(condition, message):
+            if not bool(condition.item()):
+                raise AssertionError(message)
+
+        monkeypatch.setattr(torch, "_assert_async", _assert_async)
+        num_reqs, block_size, max_num_tokens = 2, 7, 64
+        proposer = self._make_proposer(max_num_tokens=max_num_tokens, num_reqs=num_reqs, block_size=block_size)
+        rejected = torch.full((num_reqs,), 7, dtype=torch.int32)
+
+        with pytest.raises(AssertionError, match="target-only fallback"):
+            self._invoke_set_inputs_first_pass(
+                proposer,
+                num_reqs=num_reqs,
+                block_size=block_size,
+                num_rejected=rejected,
+            )
+
+        assert not kernel.mock_calls
+
+
+class TestCurrentWindowAnchorValidation:
+    """The physical current-window reject count must never replace the real
+    speculative rollback count or permit a cross-request anchor."""
+
+    @staticmethod
+    def _raise_on_false_async_assert(monkeypatch):
+        def _assert_async(condition, message):
+            if not bool(condition.item()):
+                raise AssertionError(message)
+
+        monkeypatch.setattr(torch, "_assert_async", _assert_async)
+
+    @pytest.mark.parametrize("valid_dtype", [torch.int32, torch.int64])
+    def test_partial_window_derives_physical_rejects_without_clamping_real_rejects(
+        self, monkeypatch, valid_dtype
+    ):
+        self._raise_on_false_async_assert(monkeypatch)
+        query_start_loc = torch.tensor([0, 5, 13], dtype=torch.int32)
+        real_rejected = torch.tensor([7, 0], dtype=torch.int32)
+        valid_count = torch.tensor([1, 8], dtype=valid_dtype)
+
+        current_rejected, normalized_valid_count = _derive_current_window_rejected_tokens(
+            query_start_loc,
+            real_rejected,
+            valid_count,
+        )
+
+        assert torch.equal(real_rejected, torch.tensor([7, 0], dtype=torch.int32))
+        assert torch.equal(current_rejected, torch.tensor([4, 0], dtype=torch.int32))
+        assert normalized_valid_count is not None
+        assert normalized_valid_count.dtype == query_start_loc.dtype
+        assert torch.equal(normalized_valid_count, torch.tensor([1, 8], dtype=torch.int32))
+
+    @pytest.mark.parametrize("invalid_valid_count", [0, 6])
+    def test_invalid_request_local_anchor_fails_fast(self, monkeypatch, invalid_valid_count):
+        self._raise_on_false_async_assert(monkeypatch)
+        with pytest.raises(AssertionError, match="target-only fallback"):
+            _derive_current_window_rejected_tokens(
+                torch.tensor([0, 5], dtype=torch.int32),
+                torch.tensor([7], dtype=torch.int32),
+                torch.tensor([invalid_valid_count], dtype=torch.int64),
+            )
+
+    def test_missing_valid_count_fails_fast_only_for_partial_window(self, monkeypatch):
+        self._raise_on_false_async_assert(monkeypatch)
+        complete_rejected, normalized = _derive_current_window_rejected_tokens(
+            torch.tensor([0, 8], dtype=torch.int32),
+            torch.tensor([7], dtype=torch.int32),
+            None,
+        )
+        assert torch.equal(complete_rejected, torch.tensor([7], dtype=torch.int32))
+        assert normalized is None
+
+        with pytest.raises(AssertionError, match="target-only fallback"):
+            _derive_current_window_rejected_tokens(
+                torch.tensor([0, 5], dtype=torch.int32),
+                torch.tensor([7], dtype=torch.int32),
+                None,
+            )
+
+    def test_negative_real_rejection_fails_fast(self, monkeypatch):
+        self._raise_on_false_async_assert(monkeypatch)
+        with pytest.raises(AssertionError, match="target-only fallback"):
+            _derive_current_window_rejected_tokens(
+                torch.tensor([0, 5], dtype=torch.int32),
+                torch.tensor([-1], dtype=torch.int32),
+                None,
+            )
+
+    @pytest.mark.parametrize("invalid_dtype", [torch.float16, torch.float32])
+    def test_valid_count_requires_integer_dtype(self, monkeypatch, invalid_dtype):
+        self._raise_on_false_async_assert(monkeypatch)
+        with pytest.raises(TypeError, match="integer dtype"):
+            _derive_current_window_rejected_tokens(
+                torch.tensor([0, 5], dtype=torch.int32),
+                torch.tensor([7], dtype=torch.int32),
+                torch.tensor([1], dtype=invalid_dtype),
+            )
 
 
 class TestInitializeAttnBackend(_DSparkProposerTestBase):

--- a/vllm_ascend/ops/triton/spec_decode/utils.py
+++ b/vllm_ascend/ops/triton/spec_decode/utils.py
@@ -85,6 +85,7 @@ def copy_and_expand_dflash_and_dspark_inputs_kernel(
     query_start_loc_ptr,  # [num_reqs + 1]
     seq_lens_ptr,  # [num_reqs]
     num_rejected_tokens_ptr,  # [num_reqs] or null (0) when not padded
+    valid_sampled_tokens_count_ptr,  # [num_reqs] or null (0) when unavailable
     # Scalars
     parallel_drafting_token_id,  # tl.int32
     block_size,  # tl.int32
@@ -93,6 +94,7 @@ def copy_and_expand_dflash_and_dspark_inputs_kernel(
     total_input_tokens,  # tl.int32
     batch_size,  # tl.int32
     HAS_NUM_REJECTED: tl.constexpr = False,
+    HAS_VALID_SAMPLED_COUNT: tl.constexpr = False,
     SAMPLE_FROM_ANCHOR: tl.constexpr = False,
     TILE_SIZE: tl.constexpr = 256,
 ):
@@ -131,21 +133,54 @@ def copy_and_expand_dflash_and_dspark_inputs_kernel(
         req_idx = offs // num_query_per_req
         q_idx = offs % num_query_per_req
 
+        ctx_start = tl.load(query_start_loc_ptr + req_idx, mask=mask, other=0)
         ctx_end = tl.load(query_start_loc_ptr + req_idx + 1, mask=mask, other=0)
+        num_ctx = ctx_end - ctx_start
         if HAS_NUM_REJECTED:
             num_rejected = tl.load(num_rejected_tokens_ptr + req_idx, mask=mask, other=0)
         else:
             num_rejected = tl.zeros([TILE_SIZE], dtype=tl.int32)
-        valid_ctx_end = ctx_end - num_rejected
+        # num_rejected belongs to the previous complete speculative window and
+        # remains the rollback distance below. A Mamba-aligned scheduler chunk
+        # can be shorter than that window, so verification rows must locate
+        # their anchor from the accepted-token count in the current request.
+        if HAS_VALID_SAMPLED_COUNT:
+            valid_count = tl.load(valid_sampled_tokens_count_ptr + req_idx, mask=mask, other=0)
+            use_valid_anchor = num_rejected > 0
+            valid_ctx_end = tl.where(
+                use_valid_anchor,
+                ctx_start + valid_count,
+                ctx_end - num_rejected,
+            )
+            anchor_count_valid = tl.where(
+                use_valid_anchor,
+                (valid_count > 0) & (valid_count <= num_ctx),
+                (num_rejected >= 0) & (num_rejected < num_ctx),
+            )
+            current_window_rejected = tl.where(
+                use_valid_anchor,
+                num_ctx - valid_count,
+                num_rejected,
+            )
+        else:
+            valid_ctx_end = ctx_end - num_rejected
+            anchor_count_valid = (num_rejected >= 0) & (num_rejected < num_ctx)
+            current_window_rejected = num_rejected
 
+        # The proposer validates the same predicate with an asynchronous
+        # device assertion before launching this kernel.  Keep it in the
+        # kernel mask as a second line of defence so an invalid request-local
+        # anchor can never issue an out-of-range target-position or block-table
+        # load while that assertion is being reported.
+        query_mask = mask & anchor_count_valid
         seq_len = tl.load(seq_lens_ptr + req_idx, mask=mask, other=0)
-        effective_seq_len = seq_len - num_rejected
-        last_pos = tl.load(target_positions_ptr + valid_ctx_end - 1, mask=mask, other=0)
+        effective_seq_len = seq_len - current_window_rejected
+        last_pos = tl.load(target_positions_ptr + valid_ctx_end - 1, mask=query_mask, other=0)
 
         # RoPE position id of the query token, derived from the last context
         # token's position. Written to out_query_positions for position embeddings.
         query_pos = last_pos + 1 + q_idx
-        tl.store(out_query_positions_ptr + offs, query_pos, mask=mask)
+        tl.store(out_query_positions_ptr + offs, query_pos, mask=query_mask)
 
         # Linear KV-cache token index used to look up the physical slot via the
         # block_table. This is kept separate from query_pos for multimodal
@@ -156,21 +191,23 @@ def copy_and_expand_dflash_and_dspark_inputs_kernel(
         # identical, so this only changes behaviour for multimodal inputs.
         query_kv_slot_pos = effective_seq_len + q_idx
         block_num_q = query_kv_slot_pos // block_size
-        block_id_q = tl.load(block_table_ptr + req_idx * block_table_stride + block_num_q, mask=mask, other=0).to(
-            tl.int64
-        )
+        block_id_q = tl.load(
+            block_table_ptr + req_idx * block_table_stride + block_num_q,
+            mask=query_mask,
+            other=0,
+        ).to(tl.int64)
         slot_q = block_id_q * block_size + (query_kv_slot_pos % block_size)
-        tl.store(out_query_slot_mapping_ptr + offs, slot_q, mask=mask)
+        tl.store(out_query_slot_mapping_ptr + offs, slot_q, mask=query_mask)
 
-        bonus = tl.load(next_token_ids_ptr + req_idx, mask=mask, other=0)
+        bonus = tl.load(next_token_ids_ptr + req_idx, mask=query_mask, other=0)
         in_id = tl.where(q_idx == 0, bonus, parallel_drafting_token_id)
-        tl.store(out_input_ids_ptr + offs, in_id, mask=mask)
+        tl.store(out_input_ids_ptr + offs, in_id, mask=query_mask)
 
         if SAMPLE_FROM_ANCHOR:
             sample_out_idx = req_idx * num_speculative_tokens + q_idx
-            tl.store(out_token_indices_ptr + sample_out_idx, offs, mask=mask)
+            tl.store(out_token_indices_ptr + sample_out_idx, offs, mask=query_mask)
         else:
-            sample_mask = mask & (q_idx > 0)
+            sample_mask = query_mask & (q_idx > 0)
             sample_out_idx = req_idx * num_speculative_tokens + (q_idx - 1)
             tl.store(out_token_indices_ptr + sample_out_idx, offs, mask=sample_mask)
 

--- a/vllm_ascend/spec_decode/dflash_proposer.py
+++ b/vllm_ascend/spec_decode/dflash_proposer.py
@@ -148,6 +148,7 @@ class AscendDflashProposer(AscendEagleProposer):
             query_start_loc_ptr=cad.query_start_loc,
             seq_lens_ptr=cad.seq_lens,
             num_rejected_tokens_ptr=(num_rejected_tokens_gpu if has_num_rejected else 0),
+            valid_sampled_tokens_count_ptr=0,
             # Scalars
             parallel_drafting_token_id=self.parallel_drafting_token_id,
             block_size=self.kernel_block_size,
@@ -156,6 +157,7 @@ class AscendDflashProposer(AscendEagleProposer):
             total_input_tokens=num_context,
             batch_size=batch_size,
             HAS_NUM_REJECTED=has_num_rejected,
+            HAS_VALID_SAMPLED_COUNT=False,
         )
 
         query_slot_mapping = self._slot_mapping_buffer[:num_query_total]

--- a/vllm_ascend/spec_decode/dspark_proposer.py
+++ b/vllm_ascend/spec_decode/dspark_proposer.py
@@ -18,6 +18,74 @@ from vllm_ascend.spec_decode.dflash_proposer import AscendDflashProposer, _compu
 from vllm_ascend.spec_decode.utils import DynamicSpecScheduler
 
 
+_INVALID_CURRENT_WINDOW_ANCHOR = (
+    "DSpark current-window anchor is invalid. A partial Mamba-aligned "
+    "window requires one valid sampled-token count per rejected request; "
+    "route the affected request through the target-only fallback."
+)
+
+
+def _derive_current_window_rejected_tokens(
+    query_start_loc: torch.Tensor,
+    real_rejected_tokens: torch.Tensor,
+    valid_sampled_tokens_count: torch.Tensor | None,
+) -> tuple[torch.Tensor, torch.Tensor | None]:
+    """Validate DSpark anchors and derive physical, current-window rejects.
+
+    ``real_rejected_tokens`` describes the logical rollback of the previous
+    complete speculative window and must remain unchanged.  A Mamba-aligned
+    scheduler chunk can be shorter than that rollback distance, so proposal
+    positions and slots instead discard only the invalid tokens physically
+    present in the current context.
+
+    The assertion is intentionally asynchronous: all inputs already live on
+    the accelerator and a host read here would serialize the decode hot path.
+    Invalid rows cannot be repaired by clamping because there is no trustworthy
+    request-local anchor; the caller must use the request-level target-only
+    fallback instead.
+    """
+    if query_start_loc.ndim != 1 or real_rejected_tokens.ndim != 1:
+        raise ValueError("DSpark anchor metadata must use one-dimensional tensors")
+    if query_start_loc.shape[0] != real_rejected_tokens.shape[0] + 1:
+        raise ValueError("query_start_loc must contain one more element than real_rejected_tokens")
+    if real_rejected_tokens.dtype not in (torch.int32, torch.int64):
+        raise TypeError("real_rejected_tokens must use an integer dtype")
+
+    num_ctx = query_start_loc[1:] - query_start_loc[:-1]
+    real_rejected = real_rejected_tokens.to(dtype=num_ctx.dtype)
+    legacy_anchor_valid = (real_rejected >= 0) & (real_rejected < num_ctx)
+
+    if valid_sampled_tokens_count is None:
+        # The legacy anchor ``ctx_end - rejected`` remains valid for complete
+        # windows.  It is explicitly rejected for a partial window instead of
+        # silently indexing before this request's context.
+        torch._assert_async(torch.all(legacy_anchor_valid), _INVALID_CURRENT_WINDOW_ANCHOR)
+        return real_rejected, None
+
+    if valid_sampled_tokens_count.ndim != 1:
+        raise ValueError("valid_sampled_tokens_count must be one-dimensional")
+    if valid_sampled_tokens_count.shape[0] != real_rejected_tokens.shape[0]:
+        raise ValueError("valid_sampled_tokens_count must contain one value per request")
+    if valid_sampled_tokens_count.dtype not in (torch.int32, torch.int64):
+        raise TypeError("valid_sampled_tokens_count must use an integer dtype")
+
+    valid_count = valid_sampled_tokens_count.to(dtype=num_ctx.dtype)
+    use_current_window_anchor = real_rejected > 0
+    anchor_valid = torch.where(
+        use_current_window_anchor,
+        (valid_count > 0) & (valid_count <= num_ctx),
+        legacy_anchor_valid,
+    )
+    torch._assert_async(torch.all(anchor_valid), _INVALID_CURRENT_WINDOW_ANCHOR)
+
+    current_window_rejected = torch.where(
+        use_current_window_anchor,
+        num_ctx - valid_count,
+        real_rejected,
+    )
+    return current_window_rejected, valid_count
+
+
 class AscendDSparkProposer(AscendDflashProposer):
     """DSpark block proposer.
 
@@ -215,6 +283,7 @@ class AscendDSparkProposer(AscendDflashProposer):
         token_indices_to_sample: torch.Tensor | None,
         cad: CommonAttentionMetadata,
         num_rejected_tokens_gpu: torch.Tensor | None,
+        valid_sampled_tokens_count_gpu: torch.Tensor | None = None,
         req_scheduled_tokens=None,
         long_seq_metadata=None,
         num_prefill_reqs=0,
@@ -228,6 +297,17 @@ class AscendDSparkProposer(AscendDflashProposer):
         num_query_total = batch_size * self.num_query_per_req
         num_sample_total = batch_size * self.num_speculative_tokens
         has_num_rejected = num_rejected_tokens_gpu is not None
+        has_valid_sampled_count = valid_sampled_tokens_count_gpu is not None
+        current_window_rejected_tokens = None
+        if has_num_rejected:
+            assert num_rejected_tokens_gpu is not None
+            current_window_rejected_tokens, valid_sampled_tokens_count_gpu = (
+                _derive_current_window_rejected_tokens(
+                    cad.query_start_loc,
+                    num_rejected_tokens_gpu,
+                    valid_sampled_tokens_count_gpu,
+                )
+            )
         primary_gid = getattr(self, "kv_cache_gid", 0)
         self._per_group_block_table_buffers = {
             attn_group.kv_cache_group_id: self._per_group_block_tables[attn_group.kv_cache_group_id]
@@ -271,6 +351,9 @@ class AscendDSparkProposer(AscendDflashProposer):
                 query_start_loc_ptr=cad.query_start_loc,
                 seq_lens_ptr=cad.seq_lens,
                 num_rejected_tokens_ptr=num_rejected_tokens_gpu,
+                valid_sampled_tokens_count_ptr=(
+                    valid_sampled_tokens_count_gpu if has_valid_sampled_count else 0
+                ),
                 # Scalars
                 parallel_drafting_token_id=self.parallel_drafting_token_id,
                 block_size=kernel_block_size,
@@ -279,6 +362,7 @@ class AscendDSparkProposer(AscendDflashProposer):
                 total_input_tokens=self._dflash_num_context,
                 batch_size=batch_size,
                 HAS_NUM_REJECTED=has_num_rejected,
+                HAS_VALID_SAMPLED_COUNT=has_valid_sampled_count,
                 SAMPLE_FROM_ANCHOR=self.sample_from_anchor,
             )
         # to compute self._context_slot_mapping_buffers from dict to list
@@ -288,7 +372,8 @@ class AscendDSparkProposer(AscendDflashProposer):
 
         effective_seq_lens = cad.seq_lens
         if has_num_rejected:
-            effective_seq_lens = effective_seq_lens - num_rejected_tokens_gpu
+            assert current_window_rejected_tokens is not None
+            effective_seq_lens = effective_seq_lens - current_window_rejected_tokens
 
         cad.query_start_loc = self.arange_dflash[: batch_size + 1] * self.num_query_per_req
         cad.seq_lens = effective_seq_lens + self.num_query_per_req

--- a/vllm_ascend/spec_decode/llm_base_proposer.py
+++ b/vllm_ascend/spec_decode/llm_base_proposer.py
@@ -789,6 +789,7 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
         scheduler_output: SchedulerOutput = None,
         num_scheduled_tokens: int = 0,
         num_rejected_tokens_gpu: torch.Tensor | None = None,
+        valid_sampled_tokens_count_gpu: torch.Tensor | None = None,
     ) -> torch.Tensor:
         batch_size = common_attn_metadata.batch_size()
 
@@ -824,6 +825,11 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
             target_hidden_states = model.combine_hidden_states(target_hidden_states)
             assert target_hidden_states.shape[-1] == self.hidden_size
 
+        dspark_first_pass_kwargs = (
+            {"valid_sampled_tokens_count_gpu": valid_sampled_tokens_count_gpu}
+            if self.method == "dspark"
+            else {}
+        )
         num_tokens, token_indices_to_sample, common_attn_metadata, long_seq_args = self.set_inputs_first_pass(
             target_token_ids=target_token_ids,
             next_token_ids=next_token_ids,
@@ -836,6 +842,7 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
             long_seq_metadata=long_seq_metadata,
             num_prefill_reqs=num_prefill_reqs,
             num_decode_reqs=num_decode_reqs,
+            **dspark_first_pass_kwargs,
         )
         assert self.runner is not None
         dcp_manager = getattr(self.runner, "dcp_manager", None)

--- a/vllm_ascend/worker/model_runner_v1.py
+++ b/vllm_ascend/worker/model_runner_v1.py
@@ -1815,6 +1815,7 @@ class NPUModelRunner(GPUModelRunner):
         elif self.speculative_config.use_eagle() or self.speculative_config.uses_draft_model():
             common_attn_metadata = spec_decode_common_attn_metadata
             sampled_token_ids = valid_sampled_token_ids
+            valid_sampled_tokens_count = None
 
             if self.vllm_config.speculative_config.disable_padded_drafter_batch:
                 # When padded-batch is disabled, the sampled_token_ids should be
@@ -1896,6 +1897,11 @@ class NPUModelRunner(GPUModelRunner):
                 else:
                     target_hidden_states = hidden_states[token_indices]
             assert self.drafter is not None
+            dspark_propose_kwargs = (
+                {"valid_sampled_tokens_count_gpu": valid_sampled_tokens_count}
+                if isinstance(self.drafter, AscendDSparkProposer)
+                else {}
+            )
             # Dynamic SD: pass the scheduled per-step K explicitly, unified with
             # the other proposers (ngram/suffix/medusa/extract) and matching
             # vLLM's ``propose(num_speculative_tokens=...)``. ``_propose`` sets
@@ -1918,6 +1924,7 @@ class NPUModelRunner(GPUModelRunner):
                 scheduler_output=scheduler_output,
                 num_scheduled_tokens=num_scheduled_tokens,
                 num_rejected_tokens_gpu=num_rejected_tokens_gpu,
+                **dspark_propose_kwargs,
             )
             if hasattr(self.drafter, "take_last_draft_probs"):
                 draft_probs = self.drafter.take_last_draft_probs()


### PR DESCRIPTION
### What this PR does / why we need it?

This is proposal A for a DSpark/Mamba incompatibility observed on a PD-disaggregated decode node.

After remote prefill, Mamba alignment can expose a physical verification chunk that is shorter than the previous complete `1 + K` speculative window. `real_rejected_tokens` still describes the logical rollback of that complete window, while DSpark previously used it to locate an anchor inside only the current physical chunk. For example, a logical reject count of 7 with only 5 current context rows makes `ctx_end - rejected` point outside the request-local context.

This change:

- preserves `real_rejected_tokens` for the logical rejection/rollback semantics;
- derives the physical current-window rollback from `valid_sampled_tokens_count` and the current request context;
- threads that accepted-token count only through the DSpark proposer path;
- masks invalid anchors in the Triton expansion kernel before any position, block-table, slot, input or sample access;
- uses a device-side asynchronous assertion instead of a hot-path `.item()` synchronization.

It does not change Mamba alignment, KV cache group topology, group IDs, or DFlash behavior.

This is one of two mutually exclusive draft approaches. The companion proposal applies a scheduler phase fence instead; NPU comparison is pending.

### Does this PR introduce _any_ user-facing change?

Yes. It prevents invalid DSpark positions/slots and metadata-shape failures when a PD decode node verifies a partial Mamba-aligned transition window.

### How was this patch tested?

Added/updated regression coverage:

- `tests/ut/spec_decode/test_dspark_proposer.py`
- `tests/e2e/nightly/single_node/ops/singlecard_ops/triton/test_copy_and_expand_dflash_dspark.py`

Completed locally:

- `git diff --check`
- Python syntax compilation for all changed Python files

Pending while this PR remains Draft:

- Targeted pytest collection is blocked on the current Windows host by PyTorch `c10.dll` initialization (`WinError 1114`), before test collection.
- Ascend NPU tests and the four-node PD/DSpark/Mooncake/prefix-cache regression are pending an idle hardware window.

Companion draft: #15338.
- vLLM main: https://github.com/vllm-project/vllm/commit/ba07e4a48fc951300d97eb506217dd530583dea3
