### PR TITLE
[BugFix][SpecDecode] Fence DSpark padding at Mamba boundaries

### DIFF
--- a/tests/ut/patch/platform/test_patch_dspark_mamba_phase_fence.py
+++ b/tests/ut/patch/platform/test_patch_dspark_mamba_phase_fence.py
@@ -1,0 +1,138 @@
+from types import SimpleNamespace
+
+import pytest
+
+from vllm_ascend.patch.platform.patch_dspark_mamba_phase_fence import (
+    _DEFERRED_REQUEST_IDS_ATTR,
+    _is_padded_transition_window,
+    _make_cached_request_data_wrapper,
+    _make_mamba_split_wrapper,
+)
+
+
+def _make_scheduler(*, method="dspark", role="kv_consumer", num_spec_tokens=7):
+    kv_transfer_config = SimpleNamespace(
+        kv_role=role,
+        is_kv_consumer=role == "kv_consumer",
+        is_kv_producer=role == "kv_producer",
+    )
+    return SimpleNamespace(
+        vllm_config=SimpleNamespace(
+            speculative_config=SimpleNamespace(method=method),
+            kv_transfer_config=kv_transfer_config,
+        ),
+        num_spec_tokens=num_spec_tokens,
+    )
+
+
+def _make_request(*, num_computed_tokens=0, num_tokens=380):
+    return SimpleNamespace(
+        request_id="request-0",
+        num_computed_tokens=num_computed_tokens,
+        num_tokens=num_tokens,
+    )
+
+
+def test_partial_padded_window_runs_target_only():
+    calls = []
+
+    def original(_scheduler, _request, num_new_tokens, *_args):
+        calls.append(num_new_tokens)
+        return 4 if num_new_tokens == 8 else num_new_tokens
+
+    scheduler = _make_scheduler()
+    request = _make_request()
+    wrapped = _make_mamba_split_wrapper(original)
+
+    assert wrapped(
+        scheduler,
+        request,
+        8,
+        128,
+        251,
+    ) == 1
+    assert calls == [8, 1]
+    assert getattr(scheduler, _DEFERRED_REQUEST_IDS_ATTR) == {request.request_id}
+
+
+@pytest.mark.parametrize(
+    ("scheduler", "request", "num_new_tokens"),
+    [
+        (_make_scheduler(method="eagle"), _make_request(num_computed_tokens=379), 8),
+        (_make_scheduler(role="kv_producer"), _make_request(num_computed_tokens=379), 8),
+        (_make_scheduler(), _make_request(num_computed_tokens=379, num_tokens=381), 8),
+        (_make_scheduler(), _make_request(num_computed_tokens=379), 7),
+    ],
+)
+def test_transition_detection_is_strictly_scoped(
+    scheduler,
+    request,
+    num_new_tokens,
+):
+    assert not _is_padded_transition_window(
+        scheduler,
+        request,
+        num_new_tokens,
+        0,
+        0,
+    )
+
+
+def test_complete_padded_window_is_unchanged():
+    def original(_scheduler, _request, num_new_tokens, *_args):
+        return num_new_tokens
+
+    scheduler = _make_scheduler()
+    request = _make_request(num_computed_tokens=379)
+    wrapped = _make_mamba_split_wrapper(original)
+
+    assert wrapped(scheduler, request, 8) == 8
+    assert not hasattr(scheduler, _DEFERRED_REQUEST_IDS_ATTR)
+
+
+def test_cached_request_data_drops_only_synthetic_drafts():
+    captured = {}
+
+    def original(
+        _scheduler,
+        running_reqs,
+        resumed_reqs,
+        num_scheduled_tokens,
+        spec_decode_tokens,
+        req_to_new_blocks,
+    ):
+        captured["spec_decode_tokens"] = dict(spec_decode_tokens)
+        return "cached-request-data"
+
+    scheduler = _make_scheduler()
+    setattr(
+        scheduler,
+        _DEFERRED_REQUEST_IDS_ATTR,
+        {"request-0", "request-with-real-drafts"},
+    )
+    spec_decode_tokens = {
+        "request-0": [-1] * 7,
+        "request-with-real-drafts": [11, 12],
+        "other-request": [-1] * 7,
+    }
+    wrapped = _make_cached_request_data_wrapper(original)
+
+    result = wrapped(
+        scheduler,
+        [],
+        [],
+        {
+            "request-0": 1,
+            "request-with-real-drafts": 1,
+            "other-request": 8,
+        },
+        spec_decode_tokens,
+        {},
+    )
+
+    assert result == "cached-request-data"
+    assert captured["spec_decode_tokens"] == {
+        "request-with-real-drafts": [11, 12],
+        "other-request": [-1] * 7,
+    }
+    assert getattr(scheduler, _DEFERRED_REQUEST_IDS_ATTR) == set()

--- a/vllm_ascend/patch/platform/__init__.py
+++ b/vllm_ascend/patch/platform/__init__.py
@@ -17,6 +17,7 @@
 import os
 
 import vllm_ascend.patch.platform.patch_distributed  # noqa
+import vllm_ascend.patch.platform.patch_dspark_mamba_phase_fence  # noqa
 import vllm_ascend.patch.platform.patch_kv_cache_utils  # noqa
 import vllm_ascend.patch.platform.patch_mla_prefill_backend  # noqa
 import vllm_ascend.patch.platform.patch_pp_mtp  # noqa

--- a/vllm_ascend/patch/platform/patch_dspark_mamba_phase_fence.py
+++ b/vllm_ascend/patch/platform/patch_dspark_mamba_phase_fence.py
@@ -1,0 +1,194 @@
+#
+# Copyright (c) 2026 Huawei Technologies Co., Ltd. All Rights Reserved.
+# This file is a part of the vllm-ascend project.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+"""Fence DSpark padding at a partial Mamba verification boundary.
+
+On a PD decode node, the first locally scheduled token can be the one-token
+tail reconstructed after remote prefill. vLLM pads that token to ``1 + K`` for
+speculative verification before Mamba alignment is applied. If alignment
+clips the padded width, downstream DSpark metadata still describes all K
+placeholder drafts while the model runner only sees the clipped physical
+chunk.
+
+Keep the upstream Mamba boundary rule intact. When this exact transition is
+detected, schedule the real target token only and remove its synthetic draft
+placeholders before request data and connector metadata are constructed. The
+next scheduler iteration can then form a complete ``1 + K`` decode window.
+"""
+
+from __future__ import annotations
+
+from functools import wraps
+from typing import Any, Callable
+
+from vllm.logger import logger
+
+_DEFERRED_REQUEST_IDS_ATTR = "_vllm_ascend_dspark_deferred_padding_request_ids"
+
+
+def _is_pd_decode_dspark(scheduler: Any) -> bool:
+    vllm_config = getattr(scheduler, "vllm_config", None)
+    if vllm_config is None:
+        return False
+
+    speculative_config = getattr(vllm_config, "speculative_config", None)
+    if getattr(speculative_config, "method", None) != "dspark":
+        return False
+
+    kv_transfer_config = getattr(vllm_config, "kv_transfer_config", None)
+    if kv_transfer_config is None:
+        return False
+
+    kv_role = getattr(kv_transfer_config, "kv_role", None)
+    if kv_role is not None:
+        return kv_role == "kv_consumer"
+
+    return bool(getattr(kv_transfer_config, "is_kv_consumer", False)) and not bool(
+        getattr(kv_transfer_config, "is_kv_producer", False)
+    )
+
+
+def _is_padded_transition_window(
+    scheduler: Any,
+    request: Any,
+    num_new_tokens: int,
+    num_new_local_computed_tokens: int,
+    num_external_computed_tokens: int,
+) -> bool:
+    if not _is_pd_decode_dspark(scheduler):
+        return False
+
+    num_spec_tokens = int(getattr(scheduler, "num_spec_tokens", 0))
+    if num_spec_tokens <= 0 or num_new_tokens != 1 + num_spec_tokens:
+        return False
+
+    start = (
+        request.num_computed_tokens
+        + num_new_local_computed_tokens
+        + num_external_computed_tokens
+    )
+    return request.num_tokens - start == 1
+
+
+def _make_mamba_split_wrapper(original: Callable[..., int]) -> Callable[..., int]:
+    @wraps(original)
+    def _patched_mamba_block_aligned_split(
+        self,
+        request,
+        num_new_tokens: int,
+        num_new_local_computed_tokens: int = 0,
+        num_external_computed_tokens: int = 0,
+    ) -> int:
+        clipped_tokens = original(
+            self,
+            request,
+            num_new_tokens,
+            num_new_local_computed_tokens,
+            num_external_computed_tokens,
+        )
+        if clipped_tokens == num_new_tokens or not _is_padded_transition_window(
+            self,
+            request,
+            num_new_tokens,
+            num_new_local_computed_tokens,
+            num_external_computed_tokens,
+        ):
+            return clipped_tokens
+
+        target_tokens = original(
+            self,
+            request,
+            1,
+            num_new_local_computed_tokens,
+            num_external_computed_tokens,
+        )
+        if target_tokens != 1:
+            return target_tokens
+
+        deferred_request_ids = getattr(self, _DEFERRED_REQUEST_IDS_ATTR, None)
+        if deferred_request_ids is None:
+            deferred_request_ids = set()
+            setattr(self, _DEFERRED_REQUEST_IDS_ATTR, deferred_request_ids)
+        deferred_request_ids.add(request.request_id)
+        logger.debug(
+            "Deferring DSpark padding for request %s: Mamba alignment clipped "
+            "the %d-token window to %d; scheduling the target token first",
+            request.request_id,
+            num_new_tokens,
+            clipped_tokens,
+        )
+        return target_tokens
+
+    _patched_mamba_block_aligned_split._vllm_ascend_dspark_phase_fence = True  # type: ignore[attr-defined]
+    return _patched_mamba_block_aligned_split
+
+
+def _make_cached_request_data_wrapper(original: Callable[..., Any]) -> Callable[..., Any]:
+    @wraps(original)
+    def _patched_make_cached_request_data(
+        self,
+        running_reqs,
+        resumed_reqs,
+        num_scheduled_tokens,
+        spec_decode_tokens,
+        req_to_new_blocks,
+    ):
+        deferred_request_ids = getattr(self, _DEFERRED_REQUEST_IDS_ATTR, None)
+        if deferred_request_ids:
+            try:
+                for request_id in deferred_request_ids:
+                    placeholder_tokens = spec_decode_tokens.get(request_id)
+                    if (
+                        num_scheduled_tokens.get(request_id) == 1
+                        and placeholder_tokens
+                        and all(token_id == -1 for token_id in placeholder_tokens)
+                    ):
+                        spec_decode_tokens.pop(request_id)
+            finally:
+                deferred_request_ids.clear()
+
+        return original(
+            self,
+            running_reqs,
+            resumed_reqs,
+            num_scheduled_tokens,
+            spec_decode_tokens,
+            req_to_new_blocks,
+        )
+
+    _patched_make_cached_request_data._vllm_ascend_dspark_phase_fence = True  # type: ignore[attr-defined]
+    return _patched_make_cached_request_data
+
+
+def _apply_patch() -> None:
+    from vllm.v1.core.sched.scheduler import Scheduler
+
+    mamba_split = Scheduler._mamba_block_aligned_split
+    if not getattr(mamba_split, "_vllm_ascend_dspark_phase_fence", False):
+        Scheduler._mamba_block_aligned_split = _make_mamba_split_wrapper(mamba_split)
+
+    make_cached_request_data = Scheduler._make_cached_request_data
+    if not getattr(
+        make_cached_request_data,
+        "_vllm_ascend_dspark_phase_fence",
+        False,
+    ):
+        Scheduler._make_cached_request_data = _make_cached_request_data_wrapper(
+            make_cached_request_data
+        )
+
+
+_apply_patch()


### PR DESCRIPTION
### What this PR does / why we need it?

This is proposal B for a DSpark/Mamba incompatibility observed on a PD-disaggregated decode node.

vLLM can pad a real one-token prefill-to-decode transition to a synthetic `1 + K` DSpark verification width before applying Mamba alignment. If Mamba clips that padded width at the next cacheable boundary, the physical model-runner chunk no longer matches the K placeholder drafts recorded in scheduler metadata.

This change keeps the upstream Mamba boundary invariant and adds a narrowly scoped Ascend platform phase fence. It activates only when all of the following are true:

- the node is a PD KV consumer;
- speculative method is DSpark;
- the request has exactly one real token remaining at the local/remote computed boundary;
- the scheduler requested exactly `1 + K` tokens;
- Mamba alignment actually clipped that synthetic window.

For that transition iteration it schedules only the real target token and removes only that request's synthetic `-1` draft placeholders before cached-request and connector metadata are constructed. The next iteration can form a complete `1 + K` verification window.

It does not restore the pre-PR51113 `last_cache_position` condition, bypass Mamba boundary protection, alter KV group topology, or change normal prefill/pure decode behavior.

This is one of two mutually exclusive draft approaches. The companion proposal makes DSpark consume explicit current-window anchor semantics instead; NPU comparison is pending. A long-term follow-up should move the exact-width speculative-padding rule into upstream vLLM scheduler logic.

### Does this PR introduce _any_ user-facing change?

Yes. On the affected PD decode transition, one target-only iteration is used instead of dispatching a truncated speculative verification shape. Normal full `1 + K` DSpark decoding resumes on the next iteration.

### How was this patch tested?

Added regression coverage:

- `tests/ut/patch/platform/test_patch_dspark_mamba_phase_fence.py`

Completed locally:

- `git diff --check`
- 120-column check and Python syntax compilation
- isolated wrapper test reproducing `real remaining=1`, `padded width=8`, `Mamba clipped width=4`, and verifying target-only width 1 plus removal of only the seven synthetic placeholders

Pending while this PR remains Draft:

- Targeted pytest collection is blocked on the current Windows host by PyTorch `c10.dll` initialization (`WinError 1114`), before test collection.
- Ascend NPU tests and the four-node PD/DSpark/Mooncake/prefix-cache regression are pending an idle hardware window.

Companion draft: #15337.
- vLLM main: https://github.com/vllm-project/vllm/commit/ba07e4a48fc951300d97eb506217dd530583dea3
