### PR TITLE
[BugFix][Sleep] Keep a dedicated 1 MiB HCCL lifecycle anchor

### DIFF
--- a/tests/ut/device_allocator/test_sleep_mem_optimized.py
+++ b/tests/ut/device_allocator/test_sleep_mem_optimized.py
@@ -17,12 +17,18 @@
 
 from contextlib import nullcontext
 from dataclasses import dataclass
+from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 from vllm_ascend.device_allocator.sleep_mem_optimized import (
     AclGraphSleepWakeupManager,
     HcclSleepWakeupManager,
     SleepWakeupManager,
+)
+from vllm_ascend.utils import (
+    SLEEP_LIFECYCLE_ANCHOR_BUFFER_SIZE,
+    SLEEP_LIFECYCLE_ANCHOR_GROUP_NAME,
+    get_hccl_config_for_pg_options,
 )
 
 
@@ -105,3 +111,215 @@ def test_hccl_wakeup_restores_and_refreshes_moe_groups():
 
     mock_restore.assert_called_once_with()
     mock_refresh.assert_called_once_with()
+
+
+def test_hccl_lifecycle_anchor_uses_minimum_supported_buffer_size():
+    assert get_hccl_config_for_pg_options(SLEEP_LIFECYCLE_ANCHOR_GROUP_NAME) == {
+        "hccl_buffer_size": SLEEP_LIFECYCLE_ANCHOR_BUFFER_SIZE
+    }
+    assert SLEEP_LIFECYCLE_ANCHOR_BUFFER_SIZE == 1
+
+
+def test_hccl_lifecycle_anchor_is_physically_initialized_once_and_reused():
+    manager = HcclSleepWakeupManager(MagicMock(), MagicMock())
+    device_group = object()
+    anchor_group = SimpleNamespace(device_group=device_group)
+
+    with (
+        patch(
+            "vllm_ascend.device_allocator.sleep_mem_optimized.torch.distributed.get_world_size",
+            return_value=4,
+        ),
+        patch(
+            "vllm_ascend.device_allocator.sleep_mem_optimized.get_world_group",
+            return_value=SimpleNamespace(local_rank=2),
+        ),
+        patch(
+            "vllm_ascend.device_allocator.sleep_mem_optimized.init_model_parallel_group",
+            return_value=anchor_group,
+        ) as mock_init_group,
+        patch(
+            "vllm_ascend.device_allocator.sleep_mem_optimized.torch.npu.current_device",
+            return_value=2,
+        ),
+        patch("vllm_ascend.device_allocator.sleep_mem_optimized.torch.distributed.barrier") as mock_barrier,
+    ):
+        assert manager._ensure_lifecycle_anchor() is True
+        assert manager._ensure_lifecycle_anchor() is True
+
+    mock_init_group.assert_called_once_with(
+        [[0, 1, 2, 3]],
+        2,
+        "hccl",
+        use_device_communicator=False,
+        group_name=SLEEP_LIFECYCLE_ANCHOR_GROUP_NAME,
+    )
+    assert mock_barrier.call_count == 2
+    mock_barrier.assert_called_with(group=device_group, device_ids=[2])
+
+
+def test_hccl_lifecycle_anchor_skipped_for_single_rank():
+    manager = HcclSleepWakeupManager(MagicMock(), MagicMock())
+    tp_group = MagicMock(group_name="tp")
+
+    with (
+        patch(
+            "vllm_ascend.device_allocator.sleep_mem_optimized.torch.distributed.get_world_size",
+            return_value=1,
+        ),
+        patch(
+            "vllm_ascend.device_allocator.sleep_mem_optimized.init_model_parallel_group",
+        ) as mock_init_group,
+        patch.object(manager, "iter_alive_group_coordinators", return_value=[tp_group]),
+    ):
+        assert manager._ensure_lifecycle_anchor() is False
+        assert manager.destroy_hccl() == 0
+
+    mock_init_group.assert_not_called()
+    tp_group.destroy_hccl.assert_not_called()
+    assert manager._lifecycle_anchor_group is None
+    assert manager._skip_hccl_cleanup_for_cycle
+
+
+def test_hccl_lifecycle_anchor_restores_existing_coordinator_for_next_cycle():
+    manager = HcclSleepWakeupManager(MagicMock(), MagicMock())
+    device_group = object()
+    anchor_group = SimpleNamespace(device_group=None)
+
+    def restore_hccl():
+        anchor_group.device_group = device_group
+        return True
+
+    anchor_group.restore_hccl = MagicMock(side_effect=restore_hccl)
+    manager._lifecycle_anchor_group = anchor_group
+
+    with (
+        patch(
+            "vllm_ascend.device_allocator.sleep_mem_optimized.torch.distributed.get_world_size",
+            return_value=4,
+        ),
+        patch(
+            "vllm_ascend.device_allocator.sleep_mem_optimized.torch.npu.current_device",
+            return_value=1,
+        ),
+        patch("vllm_ascend.device_allocator.sleep_mem_optimized.torch.distributed.barrier") as mock_barrier,
+    ):
+        assert manager._ensure_lifecycle_anchor() is True
+
+    anchor_group.restore_hccl.assert_called_once_with()
+    mock_barrier.assert_called_once_with(group=device_group, device_ids=[1])
+
+
+def test_hccl_lifecycle_anchor_released_after_recovery():
+    manager = HcclSleepWakeupManager(MagicMock(), MagicMock())
+    device_group = object()
+    anchor_group = MagicMock(device_group=device_group)
+    anchor_group.destroy_hccl.return_value = True
+    manager._lifecycle_anchor_group = anchor_group
+
+    with (
+        patch(
+            "vllm_ascend.device_allocator.sleep_mem_optimized.torch.npu.current_device",
+            return_value=3,
+        ),
+        patch("vllm_ascend.device_allocator.sleep_mem_optimized.torch.distributed.barrier") as mock_barrier,
+    ):
+        assert manager.release_lifecycle_anchor() is True
+
+    mock_barrier.assert_called_once_with(group=device_group, device_ids=[3])
+    anchor_group.destroy_hccl.assert_called_once_with()
+
+
+def test_hccl_lifecycle_anchor_initialization_failure_is_safe():
+    manager = HcclSleepWakeupManager(MagicMock(), MagicMock())
+
+    with (
+        patch(
+            "vllm_ascend.device_allocator.sleep_mem_optimized.torch.distributed.get_world_size",
+            return_value=4,
+        ),
+        patch(
+            "vllm_ascend.device_allocator.sleep_mem_optimized.get_world_group",
+            return_value=SimpleNamespace(local_rank=0),
+        ),
+        patch(
+            "vllm_ascend.device_allocator.sleep_mem_optimized.init_model_parallel_group",
+            side_effect=RuntimeError("new_group failed"),
+        ),
+        patch("vllm_ascend.device_allocator.sleep_mem_optimized.logger.exception") as mock_log,
+    ):
+        assert manager._ensure_lifecycle_anchor() is False
+
+    assert manager._lifecycle_anchor_group is None
+    mock_log.assert_called_once()
+
+
+def test_hccl_sleep_preserves_anchor_and_manages_business_groups():
+    manager = HcclSleepWakeupManager(MagicMock(), MagicMock())
+    anchor_group = MagicMock(group_name=SLEEP_LIFECYCLE_ANCHOR_GROUP_NAME)
+    tp_group = MagicMock(group_name="tp")
+    ep_group = MagicMock(group_name="ep")
+    manager._lifecycle_anchor_group = anchor_group
+    tp_group.destroy_hccl.return_value = True
+    ep_group.destroy_hccl.return_value = True
+    tp_group.restore_hccl.return_value = True
+    ep_group.restore_hccl.return_value = True
+    groups = [anchor_group, tp_group, ep_group]
+
+    with (
+        patch.object(manager, "_ensure_lifecycle_anchor", return_value=True),
+        patch.object(manager, "iter_alive_group_coordinators", return_value=groups),
+    ):
+        assert manager.destroy_hccl() == 2
+    with patch.object(manager, "iter_alive_group_coordinators", return_value=groups):
+        assert manager.restore_hccl() == 2
+
+    anchor_group.destroy_hccl.assert_not_called()
+    anchor_group.restore_hccl.assert_not_called()
+    tp_group.destroy_hccl.assert_called_once_with()
+    ep_group.destroy_hccl.assert_called_once_with()
+    tp_group.restore_hccl.assert_called_once_with()
+    ep_group.restore_hccl.assert_called_once_with()
+
+
+def test_hccl_sleep_skips_teardown_when_anchor_initialization_fails():
+    manager = HcclSleepWakeupManager(MagicMock(), MagicMock())
+    business_group = MagicMock(group_name="tp")
+
+    with (
+        patch.object(manager, "_ensure_lifecycle_anchor", return_value=False),
+        patch.object(manager, "iter_alive_group_coordinators", return_value=[business_group]),
+    ):
+        assert manager.destroy_hccl() == 0
+    with patch.object(manager, "iter_alive_group_coordinators", return_value=[business_group]):
+        assert manager.restore_hccl() == 0
+
+    business_group.destroy_hccl.assert_not_called()
+    business_group.restore_hccl.assert_not_called()
+
+
+def test_sleep_wakeup_releases_anchor_after_aclgraph_recapture():
+    model_runner = MagicMock(use_aclgraph=True)
+    manager = SleepWakeupManager(MagicMock(), MagicMock(), lambda: model_runner)
+    calls: list[str] = []
+    manager.hccl.wakeup = MagicMock(side_effect=lambda: calls.append("hccl"))
+    manager.acl_graph.wakeup = MagicMock(side_effect=lambda tags: calls.append("acl"))
+    manager.hccl.release_lifecycle_anchor = MagicMock(side_effect=lambda: calls.append("release"))
+
+    manager.wakeup()
+
+    assert calls == ["hccl", "acl", "release"]
+
+
+def test_staged_wakeup_keeps_anchor_until_kv_cache_recapture():
+    model_runner = MagicMock(use_aclgraph=True)
+    manager = SleepWakeupManager(MagicMock(), MagicMock(), lambda: model_runner)
+    manager.hccl.wakeup = MagicMock()
+    manager.acl_graph.wakeup = MagicMock()
+    manager.hccl.release_lifecycle_anchor = MagicMock()
+
+    manager.wakeup(tags=["weights"])
+    manager.hccl.release_lifecycle_anchor.assert_not_called()
+
+    manager.wakeup(tags=["kv_cache"])
+    manager.hccl.release_lifecycle_anchor.assert_called_once_with()

--- a/tests/ut/device_allocator/test_sleep_mem_optimized.py
+++ b/tests/ut/device_allocator/test_sleep_mem_optimized.py
@@ -268,6 +268,7 @@ def test_hccl_sleep_preserves_anchor_and_manages_business_groups():
 
     with (
         patch.object(manager, "_ensure_lifecycle_anchor", return_value=True),
+        patch.object(manager, "prepare_moe_hccl_teardown", return_value=True) as mock_prepare_moe,
         patch.object(manager, "iter_alive_group_coordinators", return_value=groups),
     ):
         assert manager.destroy_hccl() == 2
@@ -276,6 +277,7 @@ def test_hccl_sleep_preserves_anchor_and_manages_business_groups():
 
     anchor_group.destroy_hccl.assert_not_called()
     anchor_group.restore_hccl.assert_not_called()
+    mock_prepare_moe.assert_called_once_with()
     tp_group.destroy_hccl.assert_called_once_with()
     ep_group.destroy_hccl.assert_called_once_with()
     tp_group.restore_hccl.assert_called_once_with()
@@ -296,6 +298,87 @@ def test_hccl_sleep_skips_teardown_when_anchor_initialization_fails():
 
     business_group.destroy_hccl.assert_not_called()
     business_group.restore_hccl.assert_not_called()
+
+
+def test_hccl_sleep_prepares_moe_state_before_business_group_teardown():
+    manager = HcclSleepWakeupManager(MagicMock(), MagicMock())
+    business_group = MagicMock(group_name="mc2")
+    business_group.destroy_hccl.return_value = True
+    calls: list[str] = []
+
+    def record_prepare() -> bool:
+        calls.append("prepare")
+        return True
+
+    def record_destroy() -> bool:
+        calls.append("destroy")
+        return True
+
+    with (
+        patch.object(manager, "_ensure_lifecycle_anchor", return_value=True),
+        patch.object(manager, "prepare_moe_hccl_teardown", side_effect=record_prepare),
+        patch.object(manager, "iter_alive_group_coordinators", return_value=[business_group]),
+    ):
+        business_group.destroy_hccl.side_effect = record_destroy
+        assert manager.destroy_hccl() == 1
+
+    assert calls == ["prepare", "destroy"]
+
+
+def test_hccl_wakeup_refreshes_dispatcher_then_moe_runtime_state():
+    manager = HcclSleepWakeupManager(MagicMock(), MagicMock())
+    calls: list[str] = []
+
+    def record_restore() -> int:
+        calls.append("restore")
+        return 2
+
+    def record_dispatcher() -> None:
+        calls.append("dispatcher")
+
+    def record_runtime() -> None:
+        calls.append("runtime")
+
+    with (
+        patch.object(manager, "restore_hccl", side_effect=record_restore),
+        patch.object(manager, "refresh_moe_hccl_groups", side_effect=record_dispatcher),
+        patch.object(manager, "refresh_moe_hccl_runtime_state", side_effect=record_runtime),
+        patch(
+            "vllm_ascend.device_allocator.sleep_mem_optimized.set_current_vllm_config",
+            return_value=nullcontext(),
+        ),
+    ):
+        manager.wakeup()
+
+    assert calls == ["restore", "dispatcher", "runtime"]
+
+
+def test_hccl_prepare_calls_moe_communicator_lifecycle_hooks():
+    manager = HcclSleepWakeupManager(MagicMock(), MagicMock())
+    prepareable = MagicMock()
+    unrelated = object()
+
+    with patch(
+        "vllm_ascend.ops.fused_moe.moe_comm_method._MoECommMethods",
+        {"fused": prepareable, "other": unrelated},
+    ):
+        assert manager.prepare_moe_hccl_teardown() is True
+
+    prepareable.prepare_hccl_teardown.assert_called_once_with()
+
+
+def test_hccl_runtime_refresh_calls_moe_communicator_hooks():
+    manager = HcclSleepWakeupManager(MagicMock(), MagicMock())
+    refreshable = MagicMock()
+    unrelated = object()
+
+    with patch(
+        "vllm_ascend.ops.fused_moe.moe_comm_method._MoECommMethods",
+        {"fused": refreshable, "other": unrelated},
+    ):
+        manager.refresh_moe_hccl_runtime_state()
+
+    refreshable.refresh_hccl_runtime_state.assert_called_once_with()
 
 
 def test_sleep_wakeup_releases_anchor_after_aclgraph_recapture():

--- a/tests/ut/ops/test_fused_mc2_sleep_state.py
+++ b/tests/ut/ops/test_fused_mc2_sleep_state.py
@@ -1,0 +1,106 @@
+# Copyright (c) 2026 Huawei Technologies Co., Ltd. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+import torch
+
+from vllm_ascend.ops.fused_moe.moe_comm_method import FusedMC2CommImpl
+
+
+def _new_comm_impl(symm_buffer=None):
+    comm_impl = FusedMC2CommImpl.__new__(FusedMC2CommImpl)
+    comm_impl.mega_moe_symm_buffer = symm_buffer
+    comm_impl._mega_moe_hccl_state_stale = False
+    return comm_impl
+
+
+def test_fused_mc2_hccl_lifecycle_is_noop_before_buffer_initialization():
+    comm_impl = _new_comm_impl()
+
+    assert comm_impl.prepare_hccl_teardown()
+    assert comm_impl.refresh_hccl_runtime_state()
+    assert not comm_impl._mega_moe_hccl_state_stale
+
+
+def test_fused_mc2_prepare_marks_existing_context_stale_without_destroying_buffer():
+    context_manager = MagicMock()
+    symm_buffer = SimpleNamespace(_ctx_manager=context_manager)
+    comm_impl = _new_comm_impl(symm_buffer)
+
+    assert comm_impl.prepare_hccl_teardown()
+
+    assert comm_impl.mega_moe_symm_buffer is symm_buffer
+    assert comm_impl._mega_moe_hccl_state_stale
+    context_manager.update_group.assert_not_called()
+
+
+def test_fused_mc2_prepare_refuses_teardown_without_update_group_api():
+    comm_impl = _new_comm_impl(SimpleNamespace(_ctx_manager=object()))
+
+    with pytest.raises(RuntimeError, match="update_group"):
+        comm_impl.prepare_hccl_teardown()
+
+    assert not comm_impl._mega_moe_hccl_state_stale
+
+
+def test_fused_mc2_refreshes_existing_context_against_restored_group():
+    context_manager = MagicMock(ccl_buffer_size=4096)
+    inference_modes: list[bool] = []
+    context_manager.update_group.side_effect = lambda *_: inference_modes.append(torch.is_inference_mode_enabled())
+    context = MagicMock()
+    symm_buffer = SimpleNamespace(
+        _ctx_manager=context_manager,
+        context=context,
+        group="old-group",
+        group_name="old-name",
+        rank_id=7,
+        ep_world_size=1,
+        ccl_buffer_size=1,
+    )
+    comm_impl = _new_comm_impl(symm_buffer)
+    comm_impl._mega_moe_hccl_state_stale = True
+    new_group = MagicMock()
+    backend = MagicMock()
+    backend.get_hccl_comm_name.return_value = "new-name"
+    new_group._get_backend.return_value = backend
+
+    with (
+        patch(
+            "vllm_ascend.ops.fused_moe.moe_comm_method.get_mc2_group",
+            return_value=SimpleNamespace(device_group=new_group),
+        ),
+        patch.object(torch.distributed, "get_rank", return_value=3),
+        patch.object(torch.distributed, "get_world_size", return_value=8),
+        patch.object(torch.distributed, "barrier") as mock_barrier,
+        patch.object(torch.npu, "current_device", return_value=4),
+    ):
+        assert comm_impl.refresh_hccl_runtime_state()
+
+    new_group._get_backend.assert_called_once_with(torch.device("npu"))
+    backend.get_hccl_comm_name.assert_called_once_with(3)
+    context_manager.update_group.assert_called_once_with("new-name", context)
+    assert inference_modes == [True]
+    assert symm_buffer.group is new_group
+    assert symm_buffer.group_name == "new-name"
+    assert symm_buffer.rank_id == 3
+    assert symm_buffer.ep_world_size == 8
+    assert symm_buffer.ccl_buffer_size == 4096
+    mock_barrier.assert_called_once_with(group=new_group, device_ids=[4])
+    assert not comm_impl._mega_moe_hccl_state_stale
+
+
+def test_fused_mc2_refresh_is_noop_when_context_was_not_invalidated():
+    context_manager = MagicMock()
+    comm_impl = _new_comm_impl(SimpleNamespace(_ctx_manager=context_manager))
+
+    assert comm_impl.refresh_hccl_runtime_state()
+
+    context_manager.update_group.assert_not_called()

--- a/vllm_ascend/device_allocator/sleep_mem_optimized.py
+++ b/vllm_ascend/device_allocator/sleep_mem_optimized.py
@@ -24,11 +24,12 @@ from typing import Any
 
 import torch
 from vllm.config import VllmConfig, set_current_vllm_config
-from vllm.distributed.parallel_state import _groups
+from vllm.distributed.parallel_state import _groups, get_world_group, init_model_parallel_group
 from vllm.logger import logger
 from vllm.utils.mem_constants import GiB_bytes
 
 from vllm_ascend.compilation import acl_graph
+from vllm_ascend.utils import SLEEP_LIFECYCLE_ANCHOR_GROUP_NAME
 
 
 class SleepWakeupManager:
@@ -62,6 +63,11 @@ class SleepWakeupManager:
         model_runner = self._model_runner_getter()
         if model_runner.use_aclgraph:
             self.acl_graph.wakeup(tags)
+        if tags is None or "kv_cache" in tags:
+            # Keep the anchor alive until graph recapture is complete. For
+            # staged level-2 wakeup, weights are restored first and recapture
+            # happens only after the KV cache is restored.
+            self.hccl.release_lifecycle_anchor()
 
 
 class AclGraphSleepWakeupManager:
@@ -132,6 +138,8 @@ class HcclSleepWakeupManager:
     def __init__(self, vllm_config: VllmConfig, worker: Any):
         self.vllm_config = vllm_config
         self.worker = worker
+        self._lifecycle_anchor_group: Any | None = None
+        self._skip_hccl_cleanup_for_cycle = False
 
     @staticmethod
     def iter_alive_group_coordinators():
@@ -143,18 +151,94 @@ class HcclSleepWakeupManager:
             seen.add(id(group))
             yield group
 
-    @classmethod
-    def destroy_hccl(cls) -> int:
+    def _ensure_lifecycle_anchor(self) -> bool:
+        """Create and physically initialize the HCCL sleep anchor.
+
+        HCCL process-group creation can be lazy. Running a device barrier is
+        therefore required before treating the group as a lifecycle anchor.
+        The coordinator is registered with vLLM's normal distributed
+        lifecycle. Its HCCL communicator is restored once per sleep cycle and
+        released after business groups and ACL graphs are restored. Single-rank
+        processes skip the anchor: there is no multi-rank HCCL control plane
+        to keep alive.
+        """
+        try:
+            if torch.distributed.get_world_size() <= 1:
+                return False
+            if self._lifecycle_anchor_group is None:
+                world_size = torch.distributed.get_world_size()
+                ranks = list(range(world_size))
+                self._lifecycle_anchor_group = init_model_parallel_group(
+                    [ranks],
+                    get_world_group().local_rank,
+                    "hccl",
+                    use_device_communicator=False,
+                    group_name=SLEEP_LIFECYCLE_ANCHOR_GROUP_NAME,
+                )
+
+            device_group = getattr(self._lifecycle_anchor_group, "device_group", None)
+            if device_group is None:
+                if not self._lifecycle_anchor_group.restore_hccl():
+                    raise RuntimeError("failed to restore the HCCL lifecycle anchor")
+                device_group = getattr(self._lifecycle_anchor_group, "device_group", None)
+
+            torch.distributed.barrier(
+                group=device_group,
+                device_ids=[torch.npu.current_device()],
+            )
+            return True
+        except Exception:
+            logger.exception(
+                "Failed to initialize the HCCL sleep lifecycle anchor; sleep_hccl_policy=skip for this sleep cycle."
+            )
+            return False
+
+    def release_lifecycle_anchor(self) -> bool:
+        """Release the temporary anchor after business groups and graphs recover."""
+        anchor_group = self._lifecycle_anchor_group
+        device_group = getattr(anchor_group, "device_group", None)
+        if anchor_group is None or device_group is None:
+            return False
+
+        # All ranks must finish recapture before the collective anchor is
+        # destroyed. The coordinator remains registered and is restored on the
+        # next sleep cycle instead of creating another group with the same name.
+        torch.distributed.barrier(
+            group=device_group,
+            device_ids=[torch.npu.current_device()],
+        )
+        destroyed = anchor_group.destroy_hccl()
+        if destroyed:
+            logger.info(
+                "Released HCCL sleep lifecycle anchor '%s' after wake-up recovery.",
+                SLEEP_LIFECYCLE_ANCHOR_GROUP_NAME,
+            )
+        return destroyed
+
+    def destroy_hccl(self) -> int:
+        groups = list(self.iter_alive_group_coordinators())
+        self._skip_hccl_cleanup_for_cycle = False
+        if not self._ensure_lifecycle_anchor():
+            self._skip_hccl_cleanup_for_cycle = True
+            return 0
+
         num_destroyed = 0
-        for group in cls.iter_alive_group_coordinators():
+        for group in groups:
+            if group is self._lifecycle_anchor_group:
+                continue
             if group.destroy_hccl():
                 num_destroyed += 1
         return num_destroyed
 
-    @classmethod
-    def restore_hccl(cls) -> int:
+    def restore_hccl(self) -> int:
+        if self._skip_hccl_cleanup_for_cycle:
+            self._skip_hccl_cleanup_for_cycle = False
+            return 0
+
         num_restored = 0
-        for group in cls.iter_alive_group_coordinators():
+        for group in self.iter_alive_group_coordinators():
+            if group is self._lifecycle_anchor_group:
+                continue
             if group.restore_hccl():
                 num_restored += 1
         return num_restored

--- a/vllm_ascend/device_allocator/sleep_mem_optimized.py
+++ b/vllm_ascend/device_allocator/sleep_mem_optimized.py
@@ -222,6 +222,10 @@ class HcclSleepWakeupManager:
             self._skip_hccl_cleanup_for_cycle = True
             return 0
 
+        if not self.prepare_moe_hccl_teardown():
+            self._skip_hccl_cleanup_for_cycle = True
+            return 0
+
         num_destroyed = 0
         for group in groups:
             if group is self._lifecycle_anchor_group:
@@ -253,6 +257,33 @@ class HcclSleepWakeupManager:
             if callable(refresh_fn):
                 refresh_fn()
 
+    @staticmethod
+    def prepare_moe_hccl_teardown() -> bool:
+        """Prepare MoE resources before their HCCL groups are destroyed."""
+        from vllm_ascend.ops.fused_moe.moe_comm_method import _MoECommMethods
+
+        try:
+            for comm_method in _MoECommMethods.values():
+                prepare_fn = getattr(comm_method, "prepare_hccl_teardown", None)
+                if callable(prepare_fn):
+                    prepare_fn()
+            return True
+        except Exception:
+            logger.exception(
+                "Failed to prepare MoE state for HCCL teardown; skipping HCCL cleanup for this sleep cycle."
+            )
+            return False
+
+    @staticmethod
+    def refresh_moe_hccl_runtime_state() -> None:
+        """Refresh MoE runtime resources after HCCL groups are restored."""
+        from vllm_ascend.ops.fused_moe.moe_comm_method import _MoECommMethods
+
+        for comm_method in _MoECommMethods.values():
+            refresh_fn = getattr(comm_method, "refresh_hccl_runtime_state", None)
+            if callable(refresh_fn):
+                refresh_fn()
+
     def sleep(self) -> None:
         if torch.distributed.is_available() and torch.distributed.is_initialized():
             for handle in getattr(self.worker, "_pp_send_work", []):
@@ -267,4 +298,5 @@ class HcclSleepWakeupManager:
         with set_current_vllm_config(self.vllm_config):
             num_restored = self.restore_hccl()
             self.refresh_moe_hccl_groups()
+            self.refresh_moe_hccl_runtime_state()
         logger.info("Restored %d HCCL process groups after sleep mode.", num_restored)

--- a/vllm_ascend/ops/fused_moe/moe_comm_method.py
+++ b/vllm_ascend/ops/fused_moe/moe_comm_method.py
@@ -267,6 +267,7 @@ class FusedMC2CommImpl(MoECommMethod):
 
     def __init__(self, moe_config):
         super().__init__(moe_config)
+        self._mega_moe_hccl_state_stale = False
         self.enable_fused_mc2 = get_ascend_config().enable_fused_mc2
         if self.enable_fused_mc2 == 1 and is_mega_moe_supported():
             self.mega_moe_symm_buffer = None
@@ -288,6 +289,57 @@ class FusedMC2CommImpl(MoECommMethod):
 
     def _get_prepare_finalize(self):
         return PrepareAndFinalizeWithMC2(self.moe_config)
+
+    def prepare_hccl_teardown(self) -> bool:
+        """Invalidate the MegaMoe context before its MC2 group is destroyed."""
+        symm_buffer = getattr(self, "mega_moe_symm_buffer", None)
+        if symm_buffer is None:
+            return True
+
+        context_manager = getattr(symm_buffer, "_ctx_manager", None)
+        update_group = getattr(context_manager, "update_group", None)
+        if not callable(update_group):
+            raise RuntimeError(
+                "The installed cann_ops_transformer MegaMoe context manager "
+                "does not expose update_group(); refusing to tear down its HCCL group."
+            )
+
+        self._mega_moe_hccl_state_stale = True
+        logger.info("Marked MegaMoe HCCL runtime context stale before MC2 group teardown.")
+        return True
+
+    def refresh_hccl_runtime_state(self) -> bool:
+        """Rebind a stale MegaMoe context to the restored MC2 communicator."""
+        symm_buffer = getattr(self, "mega_moe_symm_buffer", None)
+        if symm_buffer is None or not self._mega_moe_hccl_state_stale:
+            return True
+
+        device_group = get_mc2_group().device_group
+        local_rank = torch.distributed.get_rank(group=device_group)
+        backend = device_group._get_backend(torch.device("npu"))
+        group_name = backend.get_hccl_comm_name(local_rank)
+        context_manager = symm_buffer._ctx_manager
+
+        # The context tensor was created under inference mode during model
+        # initialization. CANN updates it in place, so preserve that mode here.
+        with torch.inference_mode():
+            context_manager.update_group(group_name, symm_buffer.context)
+        symm_buffer.group = device_group
+        symm_buffer.rank_id = local_rank
+        symm_buffer.group_name = group_name
+        symm_buffer.ep_world_size = torch.distributed.get_world_size(group=device_group)
+        symm_buffer.ccl_buffer_size = context_manager.ccl_buffer_size
+        torch.distributed.barrier(
+            group=device_group,
+            device_ids=[torch.npu.current_device()],
+        )
+        self._mega_moe_hccl_state_stale = False
+        logger.info(
+            "Refreshed MegaMoe HCCL runtime context after MC2 group restore: rank=%d, world_size=%d.",
+            local_rank,
+            symm_buffer.ep_world_size,
+        )
+        return True
 
     def _init_mega_moe_symm_buffer(
         self,

--- a/vllm_ascend/utils.py
+++ b/vllm_ascend/utils.py
@@ -73,6 +73,8 @@ _CP_CHUNKEDPREFILL_COMM_STREAM = None
 _ASCEND_CUSTOMOP_IS_REIGISTERED = False
 _DEFAULT_BUFFER_SIZE = 200
 _MIN_DP_BUFFER_SIZE = 50
+SLEEP_LIFECYCLE_ANCHOR_GROUP_NAME = "sleep_lifecycle_anchor"
+SLEEP_LIFECYCLE_ANCHOR_BUFFER_SIZE = 1
 _DYNAMIC_EPLB_BUFFER_SIZE = 100
 _IS_MOE_MODEL = None
 _IS_DRAFTER_MOE_MODEL = None
@@ -1047,6 +1049,8 @@ def get_hccl_config_for_pg_options(group_name: str) -> dict | None:
     # result in memory misalignment problems.
     if group_name and "mc2" in group_name:
         return None
+    if group_name == SLEEP_LIFECYCLE_ANCHOR_GROUP_NAME:
+        return {"hccl_buffer_size": SLEEP_LIFECYCLE_ANCHOR_BUFFER_SIZE}
     hccl_config_map = {
         "dp": {"hccl_buffer_size": calculate_dp_buffer_size()},
         "dynamic_eplb": {"hccl_buffer_size": _DYNAMIC_EPLB_BUFFER_SIZE},


### PR DESCRIPTION
### What this PR does / why we need it?

`rl_config.sleep_mode_extra_cleanup` destroys HCCL process groups during sleep so EP/MC2 windows can be returned to the trainer. Destroying every multi-rank communicator can tear down shared CANN HCCP/AICPU state. After restore, the first DSA metadata op (`SparseAttnSharedkvMetadata`) then fails and `wake_up` returns 500.

This PR does not keep a business group (TP/DP/EP/world). Before teardown it creates a dedicated world-size HCCL group named `sleep_lifecycle_anchor` with a **1 MiB** buffer, initializes it with a device `barrier`, and uses that group as a temporary lifecycle nail:

1. Sleep creates the coordinator on the first cycle, or `restore_hccl()` on later cycles if the communicator was released after the previous wake-up.
2. A device barrier physically initializes the nail (HCCL `new_group` can be lazy).
3. All other HCCL groups are destroyed. If the nail cannot be established, teardown is skipped for that cycle.
4. Wake-up restores business groups and refreshes MoE/MC2 metadata. The nail stays up through ACL Graph recapture.
5. After recapture (or after the `kv_cache` stage of level-2 wake-up), all ranks barrier on the nail and `destroy_hccl()` it. The Python coordinator is kept (`device_group=None`) and reused next sleep, so the same group name is not registered twice.

`get_hccl_config_for_pg_options` returns the 1 MiB size for `sleep_lifecycle_anchor` **before** building the normal config map, so sleep-time creation does not call `calculate_dp_buffer_size()` / `get_current_vllm_config()`.

### Does this PR introduce _any_ user-facing change?

Yes. Extra-cleanup creates one temporary 1 MiB world-size HCCL group for each sleep/wake cycle and releases it after graph recapture. There is no new environment variable or `rl_config` key.

### How was this patch tested?

- Unit tests in `tests/ut/device_allocator/test_sleep_mem_optimized.py`:
  - first-cycle create + reuse / restore of the existing coordinator
  - destroy/restore business groups while skipping the nail
  - skip all HCCL teardown when nail init fails
  - release after recapture; keep the nail across staged `tags=["weights"]` wake-up


- vLLM main: https://github.com/vllm-project/vllm/commit/84030bbe3d74d99bad477a3d2e37a973ccd8865c
