### PR TITLE
[BugFix][Scheduler] Restore pre-#51113 Mamba chunk splitting

### DIFF
--- a/tests/ut/patch/platform/test_patch_mamba_block_aligned_split.py
+++ b/tests/ut/patch/platform/test_patch_mamba_block_aligned_split.py
@@ -1,0 +1,37 @@
+from types import SimpleNamespace
+
+from vllm.v1.core.sched.scheduler import Scheduler
+
+import vllm_ascend.patch.platform.patch_mamba_block_aligned_split  # noqa: F401
+
+
+def _scheduler_stub() -> SimpleNamespace:
+    return SimpleNamespace(
+        cache_config=SimpleNamespace(block_size=1600),
+        use_eagle=True,
+        max_num_scheduled_tokens=16384,
+        scheduler_config=SimpleNamespace(long_prefill_token_threshold=0),
+        mamba_partial_cache_hit=False,
+        hash_block_size=16,
+    )
+
+
+def _request_stub(num_computed_tokens: int) -> SimpleNamespace:
+    return SimpleNamespace(
+        num_computed_tokens=num_computed_tokens,
+        num_prompt_tokens=2002,
+        num_tokens=2002,
+        shared_prefix_boundary=0,
+    )
+
+
+def test_fragmented_chunk_past_last_cache_position_is_not_forced_to_align():
+    num_scheduled = Scheduler._mamba_block_aligned_split(_scheduler_stub(), _request_stub(0), 364)
+
+    assert num_scheduled == 364
+
+
+def test_mid_block_chunk_past_last_cache_position_is_not_forced_to_realign():
+    num_scheduled = Scheduler._mamba_block_aligned_split(_scheduler_stub(), _request_stub(331), 1000)
+
+    assert num_scheduled == 1000

--- a/vllm_ascend/patch/platform/__init__.py
+++ b/vllm_ascend/patch/platform/__init__.py
@@ -25,6 +25,7 @@ from vllm_ascend.utils import is_310p
 
 if not is_310p():
     import vllm_ascend.patch.platform.patch_mamba_config  # noqa
+    import vllm_ascend.patch.platform.patch_mamba_block_aligned_split  # noqa
 else:
     import vllm_ascend.patch.platform.patch_mamba_config_310  # noqa
 import vllm_ascend.patch.platform.patch_minimax_m2_config  # noqa

--- a/vllm_ascend/patch/platform/patch_mamba_block_aligned_split.py
+++ b/vllm_ascend/patch/platform/patch_mamba_block_aligned_split.py
@@ -1,0 +1,88 @@
+# Copyright (c) 2026 Huawei Technologies Co., Ltd. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Ascend compatibility patch for vLLM PR #51113.
+
+PR #51113 changed Mamba align-mode chunk splitting for every non-final
+prefill chunk. Kimi-K3 P/D deployments need the previous behavior while the
+upstream change is being investigated with externally supplied KV state.
+"""
+
+import inspect
+
+from vllm.logger import logger
+from vllm.v1.core.sched.scheduler import Scheduler
+from vllm.v1.request import Request
+
+_EXPECTED_PARAMETERS = (
+    "self",
+    "request",
+    "num_new_tokens",
+    "num_new_local_computed_tokens",
+    "num_external_computed_tokens",
+)
+
+
+def _mamba_block_aligned_split_before_vllm_pr_51113(
+    self: Scheduler,
+    request: Request,
+    num_new_tokens: int,
+    num_new_local_computed_tokens: int = 0,
+    num_external_computed_tokens: int = 0,
+) -> int:
+    """Use the Mamba align splitting behavior from before vLLM PR #51113."""
+    start = request.num_computed_tokens + num_new_local_computed_tokens + num_external_computed_tokens
+    if start >= max(request.num_prompt_tokens, request.num_tokens - 1):
+        return num_new_tokens
+
+    block_size = self.cache_config.block_size
+    last_cache_position = request.num_tokens - request.num_tokens % block_size
+    if self.use_eagle:
+        last_cache_position = max(last_cache_position - block_size, 0)
+
+    end = start + num_new_tokens
+    if end < last_cache_position:
+        max_prefill_tokens = self.max_num_scheduled_tokens
+        long_prefill_threshold = self.scheduler_config.long_prefill_token_threshold
+        if long_prefill_threshold > 0:
+            max_prefill_tokens = min(max_prefill_tokens, long_prefill_threshold)
+        aligned_end = end // block_size * block_size
+        if aligned_end > start or block_size <= max_prefill_tokens:
+            end = aligned_end
+
+    next_block_boundary = (start // block_size + 1) * block_size
+    tail_boundary = (
+        request.num_prompt_tokens // self.hash_block_size * self.hash_block_size if self.mamba_partial_cache_hit else 0
+    )
+    stops = (
+        next_block_boundary if start % block_size != 0 and next_block_boundary <= last_cache_position else 0,
+        last_cache_position,
+        tail_boundary if last_cache_position < tail_boundary < request.num_prompt_tokens else 0,
+        start + (request.shared_prefix_boundary - start) // block_size * block_size
+        if start < request.shared_prefix_boundary < end
+        else 0,
+    )
+    end = min((stop for stop in stops if start < stop < end), default=end)
+    return max(end - start, 0)
+
+
+current_parameters = tuple(inspect.signature(Scheduler._mamba_block_aligned_split).parameters)
+if current_parameters != _EXPECTED_PARAMETERS:
+    raise RuntimeError(
+        "Cannot apply the vLLM PR #51113 compatibility patch: unexpected "
+        f"Scheduler._mamba_block_aligned_split signature {current_parameters}"
+    )
+
+Scheduler._mamba_block_aligned_split = _mamba_block_aligned_split_before_vllm_pr_51113
+logger.warning("Applied Ascend compatibility patch reverting vLLM PR #51113 Mamba align-mode chunk splitting behavior.")


### PR DESCRIPTION
### What this PR does / why we need it?

vLLM PR [#51113](https://github.com/vllm-project/vllm/pull/51113) changed `Scheduler._mamba_block_aligned_split` so align-mode prefill chunks remain block-aligned past `last_cache_position` until the end of prefill.

For Ascend Kimi-K3 P/D deployments with externally supplied KV state, that behavior can shorten the local request slice while speculative rejection metadata still describes the full draft-token window. This patch restores the pre-#51113 splitting behavior through the vLLM-Ascend platform patch mechanism:

- only align a chunk while `end < last_cache_position`;
- only stop at `next_block_boundary` when that boundary does not exceed `last_cache_position`;
- fail fast if the upstream scheduler method signature changes;
- apply the patch on non-310P platforms alongside the existing Mamba configuration patch.

The scheduler function body is AST-identical to the patch already validated in the reporter's eight-node P/D environment. The only source-level adjustment is using the current vLLM-Ascend shared logger required by the repository's logger check.

### Does this PR introduce _any_ user-facing change?

Yes. Affected Ascend Mamba P/D deployments use the pre-vLLM-#51113 chunk splitting boundaries. Other scheduling modes are unchanged because the patched method is only called when Mamba block-aligned splitting is enabled.

### How was this patch tested?

- Added two regression tests covering chunks that extend past the last cacheable Mamba position and must not be forced to align or re-align.
- `ruff check` and `ruff format --check` with the repository-pinned Ruff 0.14.0: passed.
- `codespell`: passed.
- Forbidden-import, logger-pattern, long-function, `compileall`, and `git diff --check` checks: passed.
- Isolated semantic checks for both regression cases and the five-parameter upstream signature: 3 passed.
- The core function AST was compared with the patch deployed on all eight reporter nodes: identical.
- No live service restart or mutation was performed while preparing this PR, so the reporter's running vLLM service was not affected.

- vLLM main: https://github.com/vllm-project/vllm/commit/ba07e4a48fc951300d97eb506217dd530583dea3
