### PR TITLE
[Feature] Support Mistral4 on Ascend

### DIFF
--- a/tests/ut/models/test_mistral_compat.py
+++ b/tests/ut/models/test_mistral_compat.py
@@ -1,0 +1,134 @@
+# SPDX-License-Identifier: Apache-2.0
+
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+from vllm_ascend.models.mistral import (
+    _get_mistral3_text_architectures,
+    _get_mistral4_weights_mapper,
+    _prepare_llama4_scaling,
+    _prepare_mistral4_config,
+    _prepare_mistral4_weights,
+)
+
+
+def _config(**overrides: object) -> SimpleNamespace:
+    values: dict[str, object] = {
+        "model_type": "mistral4",
+        "rope_interleave": True,
+        "q_lora_rank": 4,
+        "kv_lora_rank": 2,
+        "qk_head_dim": 8,
+        "qk_nope_head_dim": 4,
+        "qk_rope_head_dim": 4,
+        "num_attention_heads": 2,
+        "v_head_dim": 4,
+        "hidden_size": 8,
+        "moe_intermediate_size": 4,
+        "rope_parameters": {
+            "rope_type": "yarn",
+            "factor": 2.0,
+            "partial_rotary_factor": 0.5,
+            "llama_4_scaling_beta": 0.1,
+            "original_max_position_embeddings": 16,
+        },
+    }
+    values.update(overrides)
+    return SimpleNamespace(**values)
+
+
+def test_nested_mistral4_architecture() -> None:
+    config = SimpleNamespace(model_type="mistral4")
+    assert _get_mistral3_text_architectures(config) == [
+        "Mistral4ForCausalLM"
+    ]
+
+
+def test_unknown_nested_architecture_is_rejected() -> None:
+    with pytest.raises(ValueError, match="Unsupported Mistral3 text_config"):
+        _get_mistral3_text_architectures(SimpleNamespace(model_type="unknown"))
+
+
+def test_mistral4_llama4_scaling_is_normalized() -> None:
+    config = SimpleNamespace(
+        rope_parameters={
+            "llama_4_scaling_beta": 0.1,
+            "original_max_position_embeddings": 16384,
+        }
+    )
+    _prepare_llama4_scaling(config)
+    assert config.llama_4_scaling == {
+        "beta": 0.1,
+        "original_max_position_embeddings": 16384,
+    }
+
+
+def test_mistral4_config_is_normalized_for_mla() -> None:
+    config = _config()
+    _prepare_mistral4_config(config)
+    assert "partial_rotary_factor" not in config.rope_parameters
+    assert config.llama_4_scaling["beta"] == 0.1
+
+
+def test_mistral4_explodes_packed_expert_weights() -> None:
+    config = _config(n_routed_experts=2)
+    gate_up = torch.arange(2 * 8 * 8).reshape(2, 8, 8)
+    down = torch.arange(2 * 8 * 4).reshape(2, 8, 4)
+    prepared = dict(
+        _prepare_mistral4_weights(
+            [
+                ("model.layers.0.mlp.experts.gate_up_proj", gate_up),
+                ("model.layers.0.mlp.experts.down_proj", down),
+            ],
+            config,
+            channelwise_fp8=True,
+        )
+    )
+    torch.testing.assert_close(
+        prepared["model.layers.0.mlp.experts.1.gate_proj.weight"],
+        gate_up[1, :4],
+    )
+    torch.testing.assert_close(
+        prepared["model.layers.0.mlp.experts.0.down_proj.weight"], down[0]
+    )
+
+
+def test_mistral4_expands_channelwise_scales() -> None:
+    config = _config()
+    prepared = dict(
+        _prepare_mistral4_weights(
+            [
+                (
+                    "model.layers.0.self_attn.q_a_proj.weight_scale_inv",
+                    torch.tensor(4.0),
+                ),
+                (
+                    "model.layers.0.self_attn.q_a_proj.activation_scale",
+                    torch.tensor(5.0),
+                ),
+            ],
+            config,
+            channelwise_fp8=True,
+        )
+    )
+    assert prepared[
+        "model.layers.0.self_attn.q_a_proj.weight_scale_inv"
+    ].shape == (4, 1)
+    assert not any(name.endswith("activation_scale") for name in prepared)
+
+
+def test_mistral4_selects_mapper_from_constructed_attention() -> None:
+    unfused = _get_mistral4_weights_mapper(
+        ["model.layers.0.self_attn.q_a_proj.weight"]
+    )
+    fused = _get_mistral4_weights_mapper(
+        ["model.layers.0.self_attn.fused_qkv_a_proj.weight"]
+    )
+    assert unfused._map_name(
+        "model.layers.0.self_attn.q_a_proj.weight"
+    ) == "model.layers.0.self_attn.q_a_proj.weight"
+    assert fused._map_name(
+        "model.layers.0.self_attn.q_a_proj.weight"
+    ) == "model.layers.0.self_attn.fused_qkv_a_proj.weight"

--- a/tests/ut/ops/test_fused_moe.py
+++ b/tests/ut/ops/test_fused_moe.py
@@ -1411,3 +1411,80 @@ def test_forward_impl_keeps_full_width_input_for_shared_experts(monkeypatch):
     )
     assert result[0] is shared_out
     assert result[1] is routed_out
+
+
+def test_forward_impl_applies_internal_router_without_shared_expert_wrapper(monkeypatch):
+    runner = AscendMoERunner.__new__(AscendMoERunner)
+    nn.Module.__init__(runner)
+    hidden_states = torch.randn(2, 4)
+    stale_router_logits = hidden_states.clone()
+    expected_router_logits = torch.randn(2, 3)
+    routed_out = torch.randn(2, 4)
+
+    gate = nn.Module()
+    gate.weight_fp32 = nn.Parameter(torch.randn(3, 4), requires_grad=False)
+    runner.gate = gate
+    runner.routed_experts = SimpleNamespace(
+        forward_impl=MagicMock(return_value=routed_out)
+    )
+    runner.ascend_shared_experts = None
+    runner._sequence_parallel_context = MagicMock(return_value=nullcontext())
+    monkeypatch.setattr(AscendMoERunner, "is_internal_router", property(lambda _: True))
+
+    with patch.object(
+        fused_moe_module.F,
+        "linear",
+        return_value=expected_router_logits,
+    ) as linear:
+        result = runner._forward_impl(
+            hidden_states,
+            stale_router_logits,
+            shared_experts_input=None,
+        )
+
+    linear.assert_called_once_with(hidden_states.float(), gate.weight_fp32)
+    runner.routed_experts.forward_impl.assert_called_once_with(
+        hidden_states=hidden_states,
+        router_logits=expected_router_logits,
+        input_ids=None,
+    )
+    assert result is routed_out
+
+def test_forward_impl_uses_gate_without_cached_fp32_weight(monkeypatch):
+    runner = AscendMoERunner.__new__(AscendMoERunner)
+    nn.Module.__init__(runner)
+    hidden_states = torch.randn(2, 4)
+    stale_router_logits = hidden_states.clone()
+    expected_router_logits = torch.randn(2, 3)
+    routed_out = torch.randn(2, 4)
+    shared_out = torch.randn(2, 4)
+    routed_events = FusedMoEEvents(
+        before_routed_experts=None,
+        after_routed_experts=None,
+        before_dispatch=None,
+        before_gmm2=None,
+        before_combine=None,
+    )
+    gate = nn.Module()
+    gate.forward = MagicMock(return_value=(expected_router_logits, None))
+    runner.gate = gate
+    runner.routed_experts = SimpleNamespace(
+        forward_impl=MagicMock(return_value=(routed_out, routed_events))
+    )
+    runner.ascend_shared_experts = None
+    runner._sequence_parallel_context = MagicMock(return_value=nullcontext())
+    monkeypatch.setattr(AscendMoERunner, "is_internal_router", property(lambda _: True))
+
+    result = runner._forward_impl(
+        hidden_states,
+        stale_router_logits,
+        shared_experts_input=None,
+    )
+
+    gate.forward.assert_called_once_with(hidden_states)
+    runner.routed_experts.forward_impl.assert_called_once_with(
+        hidden_states=hidden_states,
+        router_logits=expected_router_logits,
+        input_ids=None,
+    )
+    assert result[0] is routed_out

--- a/tests/ut/ops/test_layernorm.py
+++ b/tests/ut/ops/test_layernorm.py
@@ -6,7 +6,7 @@ from vllm.config import set_current_vllm_config
 from vllm.model_executor.layers.layernorm import RMSNorm
 from vllm.third_party.flash_linear_attention.ops.kda import FusedRMSNormGated
 
-from vllm_ascend.ops.layernorm import AscendFusedRMSNormGated
+from vllm_ascend.ops.layernorm import AscendFusedRMSNormGated, AscendRMSNorm
 from vllm_ascend.utils import enable_custom_op
 from vllm_ascend.utils import is_310p as is_310p_hw
 
@@ -128,3 +128,30 @@ def test_RMSNorm_forward_310p(mock_add_rmsnorm, mock_rmsnorm, residual, dummy_te
         expected_out_x = dummy_tensor + 1
         mock_rmsnorm.assert_called_once()
         assert torch.allclose(out_x, expected_out_x)
+
+
+@patch("torch_npu.npu_add_rms_norm", side_effect=mock_add_rms_norm)
+@patch("torch.ops._C_ascend.npu_add_rms_norm_bias", side_effect=mock_add_rms_norm_bias)
+def test_mistral4_uses_native_add_rms_norm(
+    mock_add_rms_norm_bias,
+    mock_add_rmsnorm,
+    dummy_tensor,
+):
+    mock_config = MagicMock()
+    mock_config.model_config.hf_config.model_type = "mistral3"
+    mock_config.model_config.hf_config.text_config.model_type = "mistral4"
+    mock_config.quant_config = None
+    mock_config.compilation_config.custom_ops = ["all"]
+    residual = torch.randn_like(dummy_tensor)
+
+    with (
+        set_current_vllm_config(mock_config),
+        patch("vllm_ascend.ops.layernorm.enable_custom_op", return_value=True),
+    ):
+        layer = AscendRMSNorm(hidden_size=8, eps=1e-5)
+        out_x, out_residual = layer.forward_oot(dummy_tensor, residual)
+
+    mock_add_rmsnorm.assert_called_once()
+    mock_add_rms_norm_bias.assert_not_called()
+    assert torch.allclose(out_x, 2 * dummy_tensor)
+    assert torch.allclose(out_residual, 2 * residual)

--- a/tests/ut/quantization/test_fp8_config.py
+++ b/tests/ut/quantization/test_fp8_config.py
@@ -9,6 +9,7 @@ from vllm.model_executor.layers.vocab_parallel_embedding import VocabParallelEmb
 from tests.ut.base import TestBase
 from vllm_ascend.ops.linear import AscendUnquantizedLinearMethod
 from vllm_ascend.quantization.configs.fp8_config import AscendDeepseekV4FP8Config, AscendFp8Config
+from vllm.model_executor.models import mistral3
 
 
 class TestAscendDeepseekV4FP8Config(TestBase):
@@ -253,3 +254,44 @@ class TestAscendFp8Config(TestBase):
 
 if __name__ == "__main__":
     unittest.main()
+
+
+def test_mistral4_fp8_config_maps_ignored_layers() -> None:
+    config = AscendFp8Config.from_config(
+        {
+            "activation_scheme": "static",
+            "modules_to_not_convert": [
+                "model.vision_tower",
+                "model.multi_modal_projector",
+                "lm_head",
+            ],
+            "quant_method": "fp8",
+            "weight_block_size": None,
+        }
+    )
+
+    mistral3_model = getattr(
+        mistral3,
+        "Mistral3For" "ConditionalGeneration",
+    )
+    config.apply_vllm_mapper(mistral3_model.hf_to_vllm_mapper)
+
+    assert config.is_per_tensor_fp8
+    assert not config.mistral4_dynamic_channelwise
+    assert config.ignored_layers == [
+        "vision_tower",
+        "multi_modal_projector",
+        "language_model.lm_head",
+    ]
+
+
+def test_block_fp8_keeps_non_mistral4_path() -> None:
+    config = AscendFp8Config.from_config(
+        {
+            "activation_scheme": "dynamic",
+            "quant_method": "fp8",
+            "weight_block_size": [128, 128],
+        }
+    )
+
+    assert not config.is_per_tensor_fp8

--- a/tests/ut/quantization/test_modelslim_config.py
+++ b/tests/ut/quantization/test_modelslim_config.py
@@ -717,6 +717,85 @@ class TestQuantPrefixMapper(TestBase):
 
         self.assertEqual(prefix, "model.layers.0.moe.experts")
 
+    def test_mistral3_packed_mapping_covers_outer_and_text_models(self):
+        expected_mapping = {
+            "qkv_proj": ["q_proj", "k_proj", "v_proj"],
+            "gate_up_proj": ["gate_proj", "up_proj"],
+            "experts": ["experts.0.gate_proj", "experts.0.up_proj", "experts.0.down_proj"],
+            "fused_qkv_a_proj": ["q_a_proj", "kv_a_proj_with_mqa"],
+        }
+
+        for model_type in ("mistral3", "mistral4"):
+            with self.subTest(model_type=model_type):
+                self.assertEqual(get_packed_modules_mapping(model_type), expected_mapping)
+
+    def test_mistral3_modelslim_quant_types_cover_fused_text_modules(self):
+        quant_description = {
+            "language_model.model.layers.0.self_attn.q_a_proj.weight": "W8A8_DYNAMIC",
+            "language_model.model.layers.0.self_attn.kv_a_proj_with_mqa.weight": "W8A8_DYNAMIC",
+            "language_model.model.layers.0.mlp.shared_experts.gate_proj.weight": "W8A8_DYNAMIC",
+            "language_model.model.layers.0.mlp.shared_experts.up_proj.weight": "W8A8_DYNAMIC",
+            "language_model.model.layers.0.mlp.experts.0.gate_proj.weight": "W8A8_DYNAMIC",
+            "language_model.model.layers.0.mlp.experts.0.up_proj.weight": "W8A8_DYNAMIC",
+            "language_model.model.layers.0.mlp.experts.0.down_proj.weight": "W8A8_DYNAMIC",
+        }
+        mapping = get_packed_modules_mapping("mistral4")
+
+        self.assertEqual(
+            get_linear_quant_type(
+                quant_description,
+                "language_model.model.layers.0.self_attn.fused_qkv_a_proj",
+                mapping,
+            ),
+            "W8A8_DYNAMIC",
+        )
+        self.assertEqual(
+            get_linear_quant_type(
+                quant_description,
+                "language_model.model.layers.0.mlp.shared_experts.gate_up_proj",
+                mapping,
+            ),
+            "W8A8_DYNAMIC",
+        )
+        self.assertEqual(
+            get_linear_quant_type(
+                quant_description,
+                "language_model.model.layers.0.mlp.experts",
+                mapping,
+            ),
+            "W8A8_DYNAMIC",
+        )
+
+    def test_mistral3_modelslim_keeps_multimodal_exceptions_float(self):
+        quant_description = {
+            "vision_tower.transformer.layers.0.attention.q_proj.weight": "FLOAT",
+            "vision_tower.transformer.layers.0.attention.k_proj.weight": "FLOAT",
+            "vision_tower.transformer.layers.0.attention.v_proj.weight": "FLOAT",
+            "multi_modal_projector.linear_1.weight": "FLOAT",
+            "language_model.lm_head.weight": "FLOAT",
+        }
+        config = AscendModelSlimConfig(quant_description)
+        mapping = get_packed_modules_mapping("mistral3")
+
+        self.assertTrue(
+            config.is_layer_skipped_ascend(
+                "vision_tower.transformer.layers.0.attention.qkv_proj",
+                mapping,
+            )
+        )
+        self.assertTrue(
+            config.is_layer_skipped_ascend(
+                "multi_modal_projector.linear_1",
+                mapping,
+            )
+        )
+        self.assertTrue(
+            config.is_layer_skipped_ascend(
+                "language_model.lm_head",
+                mapping,
+            )
+        )
+
 
 class TestGetKvQuantDtype(TestBase):
     def test_enable_fa_quant(self):

--- a/tests/ut/test_utils.py
+++ b/tests/ut/test_utils.py
@@ -125,6 +125,18 @@ class TestUtils(TestBase):
             mock_import_module.side_effect = ImportError("import error")
             self.assertFalse(utils.enable_custom_op())
 
+    def test_enable_custom_op_does_not_import_during_compile(self):
+        utils._CUSTOM_OP_ENABLED = None
+
+        with (
+            mock.patch("torch.compiler.is_compiling", return_value=True),
+            mock.patch.object(utils, "bootstrap_custom_op_env") as mock_bootstrap,
+        ):
+            self.assertFalse(utils.enable_custom_op())
+
+        self.assertIsNone(utils._CUSTOM_OP_ENABLED)
+        mock_bootstrap.assert_not_called()
+
     def test_find_hccl_library(self):
         with mock.patch.dict(os.environ, {"HCCL_SO_PATH": "/path/to/hccl/libhccl.so"}):
             self.assertEqual(utils.find_hccl_library(), "/path/to/hccl/libhccl.so")

--- a/tests/ut/worker/test_input_batch_v2.py
+++ b/tests/ut/worker/test_input_batch_v2.py
@@ -1,0 +1,13 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM Ascend project
+
+import inspect
+
+from vllm_ascend.worker.v2.input_batch import AscendInputBatch
+
+
+def test_ascend_input_batch_fields_are_keyword_only() -> None:
+    parameters = inspect.signature(AscendInputBatch).parameters
+
+    assert parameters["seq_lens_np"].kind is inspect.Parameter.KEYWORD_ONLY
+    assert parameters["attn_state"].kind is inspect.Parameter.KEYWORD_ONLY

--- a/tests/ut/worker/test_worker_v1.py
+++ b/tests/ut/worker/test_worker_v1.py
@@ -483,6 +483,7 @@ class TestNPUWorker(TestBase):
     @patch("vllm_ascend.worker.worker.MemorySnapshot")
     @patch("vllm_ascend.worker.worker.NPUWorker._init_worker_distributed_environment")
     @patch("vllm_ascend.worker.worker.init_device_properties_triton")
+    @patch("vllm_ascend.worker.worker.enable_custom_op")
     @patch("vllm_ascend.worker.worker.get_current_hardware_profile")
     @patch("vllm_ascend.worker.worker.torch.npu.set_device")
     @patch("vllm_ascend.worker.worker.torch.npu.empty_cache")
@@ -497,6 +498,7 @@ class TestNPUWorker(TestBase):
         mock_empty_cache,
         mock_set_device,
         mock_get_device_type,
+        mock_enable_custom_op,
         mock_init_triton,
         mock_init_dist_env,
         mock_snapshot_cls,
@@ -539,6 +541,7 @@ class TestNPUWorker(TestBase):
             result = worker._init_device()
 
             mock_init_dist_env.assert_called_once()
+            mock_enable_custom_op.assert_called_once_with()
             self.assertEqual(str(result), "npu:0")
             self.assertEqual(worker.init_snapshot, mock_snapshot)
             self.assertEqual(worker.requested_memory, 2000 * 0.5)

--- a/vllm_ascend/models/__init__.py
+++ b/vllm_ascend/models/__init__.py
@@ -2,6 +2,13 @@ from vllm import ModelRegistry
 
 
 def register_model():
+    from .mistral import patch_mistral3_text_model
+
+    patch_mistral3_text_model()
+    ModelRegistry.register_model(
+        "Mistral4ForCausalLM",
+        "vllm_ascend.models.mistral:Mistral4ForCausalLM",
+    )
     ModelRegistry.register_model(
         "KimiLinearForCausalLM",
         "vllm_ascend.models.kimi_k3:AscendKimiLinearForCausalLM",

--- a/vllm_ascend/models/mistral.py
+++ b/vllm_ascend/models/mistral.py
@@ -1,0 +1,340 @@
+# SPDX-License-Identifier: Apache-2.0
+
+import math
+from collections.abc import Iterable, Iterator
+from functools import wraps
+from typing import Any
+
+import torch
+
+from vllm.config import VllmConfig
+from vllm.model_executor.models.deepseek_v2 import DeepseekV3ForCausalLM
+from vllm.model_executor.models.utils import AutoWeightsLoader, WeightsMapper
+
+
+_MISTRAL3_TEXT_ARCHITECTURES = {
+    "mistral4": "Mistral4ForCausalLM",
+}
+
+_MISTRAL4_BASE_WEIGHTS_MAPPER = WeightsMapper(
+    orig_to_new_suffix={
+        ".activation_scale": ".input_scale",
+        ".weight_scale_inv": ".weight_scale",
+    },
+)
+_MISTRAL4_FUSED_QKV_A_WEIGHTS_MAPPER = WeightsMapper(
+    orig_to_new_stacked={
+        ".self_attn.q_a_proj.": (".self_attn.fused_qkv_a_proj.", 0),
+        ".self_attn.kv_a_proj_with_mqa.": (
+            ".self_attn.fused_qkv_a_proj.",
+            1,
+        ),
+    }
+) | _MISTRAL4_BASE_WEIGHTS_MAPPER
+
+
+def _get_mistral3_text_architectures(text_config: object) -> list[str]:
+    model_type = getattr(text_config, "model_type", None)
+    try:
+        return [_MISTRAL3_TEXT_ARCHITECTURES[model_type]]
+    except KeyError as exc:
+        supported = ", ".join(sorted(_MISTRAL3_TEXT_ARCHITECTURES))
+        raise ValueError(
+            "Unsupported Mistral3 text_config.model_type "
+            f"{model_type!r}; expected one of: {supported}"
+        ) from exc
+
+
+def _prepare_llama4_scaling(config: object) -> None:
+    if getattr(config, "llama_4_scaling", None) is not None:
+        return
+    rope_parameters = getattr(config, "rope_parameters", None)
+    if not isinstance(rope_parameters, dict):
+        return
+    scaling_beta = rope_parameters.get("llama_4_scaling_beta")
+    if scaling_beta is None:
+        return
+    original_max_position = rope_parameters.get(
+        "original_max_position_embeddings"
+    )
+    if original_max_position is None:
+        raise ValueError(
+            "llama_4_scaling_beta requires original_max_position_embeddings"
+        )
+    config.llama_4_scaling = {  # type: ignore[attr-defined]
+        "beta": scaling_beta,
+        "original_max_position_embeddings": original_max_position,
+    }
+
+
+def patch_mistral3_text_model() -> None:
+    """Resolve new nested Mistral text configs on the pinned vLLM baseline."""
+    import vllm.model_executor.models.mistral3 as mistral3
+
+    original = mistral3.init_vllm_registered_model
+    if getattr(original, "_vllm_ascend_mistral_compat", False):
+        return
+
+    @wraps(original)
+    def init_vllm_registered_model(
+        vllm_config: VllmConfig,
+        *,
+        prefix: str = "",
+        hf_config: Any | None = None,
+        architectures: list[str] | None = None,
+    ):
+        if hf_config is not None and architectures is None:
+            architectures = _get_mistral3_text_architectures(hf_config)
+            _prepare_llama4_scaling(hf_config)
+        return original(
+            vllm_config,
+            prefix=prefix,
+            hf_config=hf_config,
+            architectures=architectures,
+        )
+
+    init_vllm_registered_model._vllm_ascend_mistral_compat = True  # type: ignore[attr-defined]
+    mistral3.init_vllm_registered_model = init_vllm_registered_model
+
+
+def _prepare_mistral4_config(config: object) -> None:
+    if getattr(config, "model_type", None) != "mistral4":
+        raise ValueError("Mistral4ForCausalLM requires model_type='mistral4'")
+    if not getattr(config, "rope_interleave", False):
+        raise ValueError("Mistral4 requires interleaved RoPE")
+
+    qk_nope_head_dim = getattr(config, "qk_nope_head_dim")
+    qk_rope_head_dim = getattr(config, "qk_rope_head_dim")
+    qk_head_dim = getattr(config, "qk_head_dim")
+    if qk_nope_head_dim + qk_rope_head_dim != qk_head_dim:
+        raise ValueError(
+            "Mistral4 qk_head_dim must equal qk_nope_head_dim + "
+            "qk_rope_head_dim"
+        )
+
+    rope_parameters = dict(getattr(config, "rope_parameters"))
+    partial_rotary_factor = rope_parameters.pop("partial_rotary_factor", None)
+    expected_partial_factor = qk_rope_head_dim / qk_head_dim
+    if partial_rotary_factor is not None and not math.isclose(
+        float(partial_rotary_factor), float(expected_partial_factor)
+    ):
+        raise ValueError(
+            "Mistral4 partial_rotary_factor does not match the MLA rotary "
+            "head dimension"
+        )
+
+    # DeepseekV2Attention already receives the rotary-only MLA head dimension.
+    config.rope_parameters = rope_parameters  # type: ignore[attr-defined]
+    _prepare_llama4_scaling(config)
+
+
+def _mistral4_linear_scale_width(name: str, config: object) -> int | None:
+    if ".q_a_proj." in name:
+        return int(getattr(config, "q_lora_rank"))
+    if ".kv_a_proj_with_mqa." in name:
+        return int(getattr(config, "kv_lora_rank")) + int(
+            getattr(config, "qk_rope_head_dim")
+        )
+    if ".q_b_proj." in name:
+        return int(getattr(config, "num_attention_heads")) * int(
+            getattr(config, "qk_head_dim")
+        )
+    if ".kv_b_proj." in name:
+        return int(getattr(config, "num_attention_heads")) * (
+            int(getattr(config, "qk_nope_head_dim"))
+            + int(getattr(config, "v_head_dim"))
+        )
+    if ".self_attn.o_proj." in name:
+        return int(getattr(config, "hidden_size"))
+    if ".mlp.shared_experts.gate_proj." in name:
+        return int(getattr(config, "moe_intermediate_size")) * int(
+            getattr(config, "n_shared_experts", 1)
+        )
+    if ".mlp.shared_experts.up_proj." in name:
+        return int(getattr(config, "moe_intermediate_size")) * int(
+            getattr(config, "n_shared_experts", 1)
+        )
+    if ".mlp.shared_experts.down_proj." in name:
+        return int(getattr(config, "hidden_size"))
+    return None
+
+
+def _expand_packed_expert_scalar(
+    name: str,
+    value: torch.Tensor,
+    *,
+    suffix: str,
+    projection: str,
+    destination: str,
+    duplicate_gate_up: bool,
+    output_width: int | None = None,
+) -> Iterator[tuple[str, torch.Tensor]]:
+    values = value.reshape(value.shape[0], -1)
+    if values.shape[1] != 1:
+        raise ValueError(
+            f"Expected one scalar per Mistral4 expert for {name}, got "
+            f"shape {tuple(value.shape)}"
+        )
+    base = name[: -len(suffix)]
+    projections = ("gate_proj", "up_proj") if duplicate_gate_up else (projection,)
+    for expert_id, expert_value in enumerate(values[:, 0]):
+        if output_width is not None:
+            expert_value = expert_value.reshape(1, 1).expand(output_width, 1)
+            expert_value = expert_value.contiguous()
+        for target_projection in projections:
+            yield (
+                f"{base}{expert_id}.{target_projection}{destination}",
+                expert_value,
+            )
+
+
+def _explode_packed_expert_weight(
+    name: str,
+    value: torch.Tensor,
+    *,
+    projection: str,
+    config: object,
+) -> Iterator[tuple[str, torch.Tensor]]:
+    if value.ndim != 3:
+        raise ValueError(
+            f"Expected a 3D packed Mistral4 expert weight for {name}, got "
+            f"shape {tuple(value.shape)}"
+        )
+    expected_experts = int(getattr(config, "n_routed_experts"))
+    if value.shape[0] != expected_experts:
+        raise ValueError(
+            f"Expected {expected_experts} Mistral4 experts for {name}, got "
+            f"{value.shape[0]}"
+        )
+
+    base = name[: -len(projection)]
+    if projection == "gate_up_proj":
+        intermediate_size = int(getattr(config, "moe_intermediate_size"))
+        if value.shape[1] != 2 * intermediate_size:
+            raise ValueError(
+                f"Expected gate/up width {2 * intermediate_size} for {name}, "
+                f"got {value.shape[1]}"
+            )
+        for expert_id, expert_weight in enumerate(value.unbind(0)):
+            gate_weight, up_weight = expert_weight.split(intermediate_size, dim=0)
+            yield f"{base}{expert_id}.gate_proj.weight", gate_weight
+            yield f"{base}{expert_id}.up_proj.weight", up_weight
+        return
+    if projection == "down_proj":
+        for expert_id, expert_weight in enumerate(value.unbind(0)):
+            yield f"{base}{expert_id}.down_proj.weight", expert_weight
+        return
+    raise ValueError(f"Unsupported packed Mistral4 expert projection: {projection}")
+
+
+def _prepare_mistral4_weights(
+    weights: Iterable[tuple[str, torch.Tensor]],
+    config: object,
+    *,
+    channelwise_fp8: bool,
+) -> Iterator[tuple[str, torch.Tensor]]:
+    expert_widths = {
+        "gate_up_proj": 2 * int(getattr(config, "moe_intermediate_size")),
+        "down_proj": int(getattr(config, "hidden_size")),
+    }
+    expert_metadata = {
+        "gate_up_proj_scale_inv": ("gate_up_proj", ".weight_scale", True),
+        "down_proj_scale_inv": ("down_proj", ".weight_scale", False),
+        "gate_up_proj_activation_scale": ("gate_up_proj", ".input_scale", True),
+        "down_proj_activation_scale": ("down_proj", ".input_scale", False),
+    }
+
+    for name, loaded_weight in weights:
+        if ".mlp.experts." in name:
+            projection = next(
+                (
+                    item
+                    for item in ("gate_up_proj", "down_proj")
+                    if name.endswith(item)
+                ),
+                None,
+            )
+            if projection is not None:
+                yield from _explode_packed_expert_weight(
+                    name, loaded_weight, projection=projection, config=config
+                )
+                continue
+
+            matched = next(
+                (
+                    (suffix, metadata)
+                    for suffix, metadata in expert_metadata.items()
+                    if name.endswith(suffix)
+                ),
+                None,
+            )
+            if matched is not None:
+                suffix, (projection, destination, duplicate_gate_up) = matched
+                if channelwise_fp8:
+                    if destination == ".input_scale":
+                        continue
+                    output_width = expert_widths[projection]
+                    if duplicate_gate_up:
+                        output_width //= 2
+                    yield from _expand_packed_expert_scalar(
+                        name,
+                        loaded_weight,
+                        suffix=suffix,
+                        projection=projection,
+                        destination=destination,
+                        duplicate_gate_up=duplicate_gate_up,
+                        output_width=output_width,
+                    )
+                else:
+                    yield from _expand_packed_expert_scalar(
+                        name,
+                        loaded_weight,
+                        suffix=suffix,
+                        projection=projection,
+                        destination=destination,
+                        duplicate_gate_up=duplicate_gate_up,
+                    )
+                continue
+
+        if channelwise_fp8 and name.endswith((".activation_scale", ".input_scale")):
+            continue
+        if channelwise_fp8 and name.endswith((".weight_scale_inv", ".weight_scale")):
+            output_size = _mistral4_linear_scale_width(name, config)
+            if output_size is not None:
+                if loaded_weight.numel() != 1:
+                    raise ValueError(
+                        f"Expected a scalar Mistral4 linear scale for {name}, "
+                        f"got shape {tuple(loaded_weight.shape)}"
+                    )
+                loaded_weight = loaded_weight.reshape(1, 1).expand(output_size, 1)
+                loaded_weight = loaded_weight.contiguous()
+        yield name, loaded_weight
+
+
+def _get_mistral4_weights_mapper(parameter_names: Iterable[str]) -> WeightsMapper:
+    if any(".fused_qkv_a_proj." in name for name in parameter_names):
+        return _MISTRAL4_FUSED_QKV_A_WEIGHTS_MAPPER
+    return _MISTRAL4_BASE_WEIGHTS_MAPPER
+
+
+class Mistral4ForCausalLM(DeepseekV3ForCausalLM):
+    hf_to_vllm_mapper = _MISTRAL4_FUSED_QKV_A_WEIGHTS_MAPPER
+
+    def __init__(self, *, vllm_config: VllmConfig, prefix: str = "") -> None:
+        _prepare_mistral4_config(vllm_config.model_config.hf_config)
+        super().__init__(vllm_config=vllm_config, prefix=prefix)
+
+    def load_weights(
+        self, weights: Iterable[tuple[str, torch.Tensor]]
+    ) -> set[str]:
+        channelwise_fp8 = bool(
+            getattr(self.quant_config, "mistral4_dynamic_channelwise", False)
+        )
+        weights = _prepare_mistral4_weights(
+            weights, self.config, channelwise_fp8=channelwise_fp8
+        )
+        mapper = _get_mistral4_weights_mapper(
+            name for name, _ in self.named_parameters()
+        )
+        loader = AutoWeightsLoader(self)
+        return loader.load_weights(weights, mapper=mapper)

--- a/vllm_ascend/ops/fused_moe/fused_moe.py
+++ b/vllm_ascend/ops/fused_moe/fused_moe.py
@@ -225,6 +225,13 @@ class AscendMoERunner(MoERunner):  # type: ignore[no-redef]
             with self._sequence_parallel_context():
                 shared_hidden_states = shared_experts_input if shared_experts_input is not None else hidden_states
                 if self.ascend_shared_experts is None:
+                    if self.is_internal_router:
+                        gate = self.gate
+                        assert gate is not None
+                        if hasattr(gate, "weight_fp32"):
+                            router_logits = F.linear(hidden_states.float(), gate.weight_fp32)
+                        else:
+                            router_logits, _ = gate(hidden_states)
                     return self.routed_experts.forward_impl(
                         hidden_states=hidden_states,
                         router_logits=router_logits,
@@ -236,6 +243,22 @@ class AscendMoERunner(MoERunner):  # type: ignore[no-redef]
                 if self.is_internal_router:
                     gate = self.gate
                     assert gate is not None
+                    if not hasattr(gate, "weight_fp32"):
+                        router_logits, _ = gate(hidden_states)
+                        before_routed_experts = torch.npu.current_stream().record_event()
+                        after_routed_experts = torch.npu.current_stream().record_event()
+                        routed_out, fused_moe_events = self.routed_experts.forward_impl(
+                            hidden_states=hidden_states,
+                            router_logits=router_logits,
+                            input_ids=input_ids,
+                        )
+                        fused_moe_events.before_routed_experts = before_routed_experts
+                        fused_moe_events.after_routed_experts = after_routed_experts
+                        shared_out = self.ascend_shared_experts.forward(
+                            hidden_states,
+                            fused_moe_events,
+                        )
+                        return shared_out, routed_out
                     # NOTE(Angazenn): To make this cast explicitly, the hbm usage might
                     # increase with extra hidden states. We also assume that all gate
                     # linear is unquantized so that we the weight is pre-casted in

--- a/vllm_ascend/ops/layernorm.py
+++ b/vllm_ascend/ops/layernorm.py
@@ -40,6 +40,10 @@ class AscendRMSNorm(RMSNorm):
         vllm_config = get_current_vllm_config()
         self.bias = None
         self.bias_loaded = False
+        self.mistral_native_add_rms_norm = (
+            getattr(vllm_config.model_config.hf_config, "model_type", None)
+            in {"mistral3", "ministral3", "mistral4"}
+        )
 
         # quantization with anti_method m4 will generate none-zero norm bias
         quant_description = getattr(vllm_config.quant_config, "quant_description", None) or {}
@@ -69,7 +73,7 @@ class AscendRMSNorm(RMSNorm):
         import torch_npu
 
         if residual is not None:
-            if enable_custom_op():
+            if enable_custom_op() and not self.mistral_native_add_rms_norm:
                 x, _, residual = torch.ops._C_ascend.npu_add_rms_norm_bias(
                     x, residual, self.weight, self.bias, self.variance_epsilon
                 )

--- a/vllm_ascend/quantization/configs/fp8_config.py
+++ b/vllm_ascend/quantization/configs/fp8_config.py
@@ -3,6 +3,7 @@ from typing import Optional
 
 import torch
 from compressed_tensors.quantization import QuantizationArgs
+from vllm.config import get_current_vllm_config
 from vllm.logger import logger
 from vllm.model_executor.layers.linear import LinearBase
 from vllm.model_executor.layers.quantization import register_quantization_config
@@ -37,6 +38,8 @@ class AscendFp8Config(Fp8Config):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.quant_description = {}
+        self.is_per_tensor_fp8 = self.weight_block_size is None
+        self.mistral4_dynamic_channelwise = False
 
     @classmethod
     def get_min_capability(cls) -> int:
@@ -57,6 +60,20 @@ class AscendFp8Config(Fp8Config):
                 f"vLLM Ascend supports dynamic activation quantization for native FP8 checkpoints, "
                 f"but this one declares `activation_scheme: {self.activation_scheme}`."
             )
+
+    def apply_vllm_mapper(self, hf_to_vllm_mapper) -> None:
+        module_prefixes = [f"{name}." for name in self.ignored_layers]
+        mapped_prefixes = hf_to_vllm_mapper.apply_list(module_prefixes)
+        self.ignored_layers = [name.removesuffix(".") for name in mapped_prefixes]
+
+    @staticmethod
+    def _is_mistral4_model() -> bool:
+        try:
+            hf_config = get_current_vllm_config().model_config.hf_config
+        except Exception:
+            return False
+        text_config = getattr(hf_config, "text_config", hf_config)
+        return getattr(text_config, "model_type", None) == "mistral4"
 
     def get_quant_method(
         self,
@@ -90,6 +107,29 @@ class AscendFp8Config(Fp8Config):
             if is_linear:
                 return AscendUnquantizedLinearMethod()
             return AscendUnquantizedFusedMoEMethod(layer.moe_config, tid2eid)
+
+        if self.is_per_tensor_fp8 and self._is_mistral4_model():
+            if is_linear:
+                layer.ascend_quant_method = FP8_METHOD
+                scheme_class = get_scheme_class("W8A8FP8_DYNAMIC", "linear")
+                assert scheme_class is not None
+                logger.warning_once(
+                    "A2 per-tensor FP8 keeps serialized weights but uses dynamic "
+                    "activation quantization; checkpoint static activation scales "
+                    "are not consumed."
+                )
+                return AscendLinearMethod(scheme_class())
+
+            if is_moe:
+                layer.ascend_quant_method = FP8_METHOD
+                scheme_class = get_scheme_class("W8A8FP8_DYNAMIC", "moe")
+                assert scheme_class is not None
+                return AscendFusedMoEMethod(
+                    scheme_class(),
+                    layer.moe_config,
+                    tid2eid=tid2eid,
+                )
+            return None
 
         self._verify_block_quantization()
         logger.info_once("Using the vLLM Ascend block-wise fp8 Quantization now!")

--- a/vllm_ascend/quantization/configs/modelslim_config.py
+++ b/vllm_ascend/quantization/configs/modelslim_config.py
@@ -96,9 +96,18 @@ _MINIMAX_M3_PACKED_MODULES = {
     "experts": ["experts.0.w1", "experts.0.w2", "experts.0.w3"],
 }
 
+_MISTRAL3_PACKED_MODULES = {
+    "qkv_proj": ["q_proj", "k_proj", "v_proj"],
+    "gate_up_proj": ["gate_proj", "up_proj"],
+    "experts": ["experts.0.gate_proj", "experts.0.up_proj", "experts.0.down_proj"],
+    "fused_qkv_a_proj": ["q_a_proj", "kv_a_proj_with_mqa"],
+}
+
 packed_modules_model_mapping: dict[str, dict[str, list[str]]] = {
     "minimax_m3": _MINIMAX_M3_PACKED_MODULES,
     "minimax_m3_vl": _MINIMAX_M3_PACKED_MODULES,
+    "mistral3": _MISTRAL3_PACKED_MODULES,
+    "mistral4": _MISTRAL3_PACKED_MODULES,
     "qwen3_moe": {
         "qkv_proj": [
             "q_proj",

--- a/vllm_ascend/utils.py
+++ b/vllm_ascend/utils.py
@@ -402,12 +402,19 @@ def enable_custom_op():
     Enable lazy init for vllm_ascend_C to avoid early initialization of CANN's RTS component.
     Ensure that ASCEND_RT_VISIBLE_DEVICES can be dynamically modified before torch.npu.set_device().
     """
-    import vllm.envs as envs
-
     global _CUSTOM_OP_ENABLED
 
     if _CUSTOM_OP_ENABLED is not None:
         return _CUSTOM_OP_ENABLED
+
+    # Importing an extension while Dynamo is tracing is unsupported. Standard
+    # workers initialize this state after selecting the NPU and before the
+    # first profile run; keep this fallback uncached for other call paths so a
+    # later eager invocation can still discover the extension.
+    if torch.compiler.is_compiling():
+        return False
+
+    import vllm.envs as envs
 
     # There are some customed operators which aren't implemented
     # with batch invariant in vllm-ascend, we need to disable them.

--- a/vllm_ascend/worker/v2/input_batch.py
+++ b/vllm_ascend/worker/v2/input_batch.py
@@ -63,7 +63,7 @@ class AscendInputBuffers(InputBuffers):
         self.seq_lens_np: np.ndarray = self.seq_lens_cpu.numpy()
 
 
-@dataclass
+@dataclass(kw_only=True)
 class AscendInputBatch(InputBatch):
     """Input batch for Ascend NPUs."""
 

--- a/vllm_ascend/worker/worker.py
+++ b/vllm_ascend/worker/worker.py
@@ -80,6 +80,7 @@ from vllm_ascend.ops.triton.triton_utils import init_device_properties_triton
 from vllm_ascend.profiler.torch_npu_profiler import TorchNPUProfilerWrapper
 from vllm_ascend.utils import (
     check_ascend_device_type,
+    enable_custom_op,
     enable_sp,
     register_ascend_customop,
     setup_ascend_local_comm_res,
@@ -472,6 +473,10 @@ class NPUWorker(WorkerBase):
         set_random_seed(self.model_config.seed)
         # Initialize device properties used by triton kernels.
         init_device_properties_triton()
+        # Resolve extension availability before Dynamo traces model forwards.
+        # A missing extension is supported through torch-npu fallbacks, but
+        # probing it from inside a full graph raises an import failure.
+        enable_custom_op()
 
         return device
 


### PR DESCRIPTION
Add Mistral4 model support on Ascend.

Changes:
- Register the Mistral4 model implementation (`vllm_ascend/models/mistral.py`).
- Adapt the v2 worker/model runner, input batch, sampling and autoregressive speculator paths for Mistral4.
- Add unit tests for the v2 input batch.

- vLLM main: https://github.com/vllm-project/vllm/commit/ba07e4a48fc951300d97eb506217dd530583dea3
