### PR TITLE
[BugFix][Worker] Skip TP all-gather for already-global auxiliary hidden states

### DIFF
--- a/tests/ut/worker/a2/test_model_runner_v1.py
+++ b/tests/ut/worker/a2/test_model_runner_v1.py
@@ -56,6 +56,52 @@ class TestNPUModelRunnerProfileRun(unittest.TestCase):
         mock_disable_compilation.assert_called_once_with(runner.get_model.return_value)
 
 
+class TestNPUModelRunnerHiddenStateGather(unittest.TestCase):
+    @patch("vllm_ascend.worker.model_runner_v1.tensor_model_parallel_all_gather")
+    @patch("vllm_ascend.worker.model_runner_v1.get_forward_context")
+    def test_global_aux_hidden_state_is_not_gathered(self, mock_get_forward_context, mock_all_gather):
+        mock_get_forward_context.return_value = SimpleNamespace(
+            num_tokens=16,
+            pad_size=0,
+        )
+        hidden_states = torch.zeros((16, 8))
+
+        result = NPUModelRunner._all_gather_hidden_states(hidden_states)
+
+        self.assertIs(result, hidden_states)
+        mock_all_gather.assert_not_called()
+
+    @patch("vllm_ascend.worker.model_runner_v1.tensor_model_parallel_all_gather")
+    @patch("vllm_ascend.worker.model_runner_v1.get_forward_context")
+    def test_local_hidden_state_is_gathered(self, mock_get_forward_context, mock_all_gather):
+        mock_get_forward_context.return_value = SimpleNamespace(
+            num_tokens=16,
+            pad_size=0,
+        )
+        hidden_states = torch.zeros((4, 8))
+        gathered_hidden_states = torch.zeros((16, 8))
+        mock_all_gather.return_value = gathered_hidden_states
+
+        result = NPUModelRunner._all_gather_hidden_states(hidden_states)
+
+        self.assertIs(result, gathered_hidden_states)
+        mock_all_gather.assert_called_once_with(hidden_states, 0)
+
+    @patch("vllm_ascend.worker.model_runner_v1.tensor_model_parallel_all_gather")
+    @patch("vllm_ascend.worker.model_runner_v1.get_forward_context")
+    def test_global_aux_hidden_state_removes_padding(self, mock_get_forward_context, mock_all_gather):
+        mock_get_forward_context.return_value = SimpleNamespace(
+            num_tokens=15,
+            pad_size=1,
+        )
+        hidden_states = torch.zeros((16, 8))
+
+        result = NPUModelRunner._all_gather_hidden_states(hidden_states)
+
+        self.assertEqual(result.shape, (15, 8))
+        mock_all_gather.assert_not_called()
+
+
 class TestDSparkAuxCaptureMode(unittest.TestCase):
     def _build_runner(
         self,

--- a/tests/ut/worker/a2/test_model_runner_v1.py
+++ b/tests/ut/worker/a2/test_model_runner_v1.py
@@ -15,10 +15,45 @@ from vllm.v1.kv_cache_interface import (
     UniformTypeKVCacheSpecs,
 )
 
+from vllm_ascend.ascend_forward_context import MoECommType
 from vllm_ascend.attention.utils import get_sfa_qsfa_packed_head_dim
 from vllm_ascend.core.kv_cache_interface import AscendMLAAttentionSpec, AscendSFAIndexerCacheSpec
 from vllm_ascend.utils import AscendDeviceType
 from vllm_ascend.worker.model_runner_v1 import NPUModelRunner
+
+
+class TestNPUModelRunnerProfileRun(unittest.TestCase):
+    @patch("vllm_ascend.worker.model_runner_v1.disable_compilation")
+    @patch("vllm_ascend.worker.model_runner_v1.select_moe_comm_method", return_value=MoECommType.MC2)
+    @patch("vllm_ascend.worker.model_runner_v1.get_mc2_tokens_capacity", return_value=8)
+    @patch("vllm.v1.worker.gpu_model_runner.GPUModelRunner.profile_run", autospec=True)
+    def test_multimodal_profile_precedes_mc2_warmup(
+        self,
+        mock_base_profile,
+        mock_get_mc2_tokens_capacity,
+        mock_select_moe_comm_method,
+        mock_disable_compilation,
+    ):
+        runner = NPUModelRunner.__new__(NPUModelRunner)
+        runner.sparse_kv_offload_enabled = False
+        runner.max_num_tokens = 16
+        runner.vllm_config = MagicMock()
+        runner.eplb_warmup = MagicMock()
+        runner.get_model = MagicMock(return_value=MagicMock())
+        runner._dummy_run = MagicMock()
+
+        call_order = []
+        runner.eplb_warmup.side_effect = lambda: call_order.append("eplb")
+        mock_base_profile.side_effect = lambda _: call_order.append("multimodal")
+        runner._dummy_run.side_effect = lambda *args, **kwargs: call_order.append("mc2")
+
+        runner.profile_run()
+
+        self.assertEqual(call_order, ["eplb", "multimodal", "mc2"])
+        runner._dummy_run.assert_called_once_with(8, with_prefill=True, is_profile=True)
+        mock_get_mc2_tokens_capacity.assert_called_once_with()
+        mock_select_moe_comm_method.assert_called_once_with(8, runner.vllm_config)
+        mock_disable_compilation.assert_called_once_with(runner.get_model.return_value)
 
 
 class TestDSparkAuxCaptureMode(unittest.TestCase):

--- a/tests/ut/worker/a2/test_model_runner_v1.py
+++ b/tests/ut/worker/a2/test_model_runner_v1.py
@@ -15,45 +15,10 @@ from vllm.v1.kv_cache_interface import (
     UniformTypeKVCacheSpecs,
 )
 
-from vllm_ascend.ascend_forward_context import MoECommType
 from vllm_ascend.attention.utils import get_sfa_qsfa_packed_head_dim
 from vllm_ascend.core.kv_cache_interface import AscendMLAAttentionSpec, AscendSFAIndexerCacheSpec
 from vllm_ascend.utils import AscendDeviceType
 from vllm_ascend.worker.model_runner_v1 import NPUModelRunner
-
-
-class TestNPUModelRunnerProfileRun(unittest.TestCase):
-    @patch("vllm_ascend.worker.model_runner_v1.disable_compilation")
-    @patch("vllm_ascend.worker.model_runner_v1.select_moe_comm_method", return_value=MoECommType.MC2)
-    @patch("vllm_ascend.worker.model_runner_v1.get_mc2_tokens_capacity", return_value=8)
-    @patch("vllm.v1.worker.gpu_model_runner.GPUModelRunner.profile_run", autospec=True)
-    def test_multimodal_profile_precedes_mc2_warmup(
-        self,
-        mock_base_profile,
-        mock_get_mc2_tokens_capacity,
-        mock_select_moe_comm_method,
-        mock_disable_compilation,
-    ):
-        runner = NPUModelRunner.__new__(NPUModelRunner)
-        runner.sparse_kv_offload_enabled = False
-        runner.max_num_tokens = 16
-        runner.vllm_config = MagicMock()
-        runner.eplb_warmup = MagicMock()
-        runner.get_model = MagicMock(return_value=MagicMock())
-        runner._dummy_run = MagicMock()
-
-        call_order = []
-        runner.eplb_warmup.side_effect = lambda: call_order.append("eplb")
-        mock_base_profile.side_effect = lambda _: call_order.append("multimodal")
-        runner._dummy_run.side_effect = lambda *args, **kwargs: call_order.append("mc2")
-
-        runner.profile_run()
-
-        self.assertEqual(call_order, ["eplb", "multimodal", "mc2"])
-        runner._dummy_run.assert_called_once_with(8, with_prefill=True, is_profile=True)
-        mock_get_mc2_tokens_capacity.assert_called_once_with()
-        mock_select_moe_comm_method.assert_called_once_with(8, runner.vllm_config)
-        mock_disable_compilation.assert_called_once_with(runner.get_model.return_value)
 
 
 class TestNPUModelRunnerHiddenStateGather(unittest.TestCase):

--- a/vllm_ascend/worker/model_runner_v1.py
+++ b/vllm_ascend/worker/model_runner_v1.py
@@ -2624,8 +2624,24 @@ class NPUModelRunner(GPUModelRunner):
     # all-gather one hidden-states in sp scene
     @staticmethod
     def _all_gather_hidden_states(hidden_states):
+        forward_context = get_forward_context()
+        pad_size = forward_context.pad_size
+        num_tokens = forward_context.num_tokens
+        padded_num_tokens = getattr(
+            forward_context,
+            "padded_length",
+            num_tokens + pad_size,
+        )
+
+        # Multimodal inputs bypass the first sequence-parallel scatter. Eagle3
+        # auxiliary states captured before the first reduce-scatter therefore
+        # already contain the global token dimension. Gathering them again
+        # multiplies that dimension by TP (for example, 16K x TP16) and can
+        # allocate several GiB per auxiliary state.
+        if hidden_states.shape[0] == padded_num_tokens:
+            return hidden_states[:-pad_size] if pad_size > 0 else hidden_states
+
         hidden_states = tensor_model_parallel_all_gather(hidden_states, 0)
-        pad_size = get_forward_context().pad_size
         if pad_size > 0:
             hidden_states = hidden_states[:-pad_size, :]
 

--- a/vllm_ascend/worker/model_runner_v1.py
+++ b/vllm_ascend/worker/model_runner_v1.py
@@ -2638,10 +2638,8 @@ class NPUModelRunner(GPUModelRunner):
         # already contain the global token dimension. Gathering them again
         # multiplies that dimension by TP (for example, 16K x TP16) and can
         # allocate several GiB per auxiliary state.
-        if hidden_states.shape[0] == padded_num_tokens:
-            return hidden_states[:-pad_size] if pad_size > 0 else hidden_states
-
-        hidden_states = tensor_model_parallel_all_gather(hidden_states, 0)
+        if hidden_states.shape[0] != padded_num_tokens:
+            hidden_states = tensor_model_parallel_all_gather(hidden_states, 0)
         if pad_size > 0:
             hidden_states = hidden_states[:-pad_size, :]
 

--- a/vllm_ascend/worker/model_runner_v1.py
+++ b/vllm_ascend/worker/model_runner_v1.py
@@ -3575,12 +3575,6 @@ class NPUModelRunner(GPUModelRunner):
                 self.sparse_kv_offload_config,
             )
 
-        # Profile the multimodal encoder before the auxiliary MC2 warmup.
-        # The MC2 dummy run can initialize torch.compile state for both the
-        # target and draft models. Keeping that state alive while profiling
-        # maximum-sized multimodal inputs can exhaust device memory.
-        super().profile_run()
-
         mc2_tokens_capacity = get_mc2_tokens_capacity()
         if self.max_num_tokens > mc2_tokens_capacity and select_moe_comm_method(
             mc2_tokens_capacity, self.vllm_config
@@ -3588,6 +3582,7 @@ class NPUModelRunner(GPUModelRunner):
             # Use a call-scoped bypass because skip_compiled would require runner-specific ForwardContext plumbing.
             with disable_compilation(self.get_model()):
                 self._dummy_run(mc2_tokens_capacity, with_prefill=True, is_profile=True)
+        super().profile_run()
 
     def eplb_warmup(self):
         if self.dynamic_eplb and not self.is_eplb_warmuped:

--- a/vllm_ascend/worker/model_runner_v1.py
+++ b/vllm_ascend/worker/model_runner_v1.py
@@ -3559,6 +3559,12 @@ class NPUModelRunner(GPUModelRunner):
                 self.sparse_kv_offload_config,
             )
 
+        # Profile the multimodal encoder before the auxiliary MC2 warmup.
+        # The MC2 dummy run can initialize torch.compile state for both the
+        # target and draft models. Keeping that state alive while profiling
+        # maximum-sized multimodal inputs can exhaust device memory.
+        super().profile_run()
+
         mc2_tokens_capacity = get_mc2_tokens_capacity()
         if self.max_num_tokens > mc2_tokens_capacity and select_moe_comm_method(
             mc2_tokens_capacity, self.vllm_config
@@ -3566,7 +3572,6 @@ class NPUModelRunner(GPUModelRunner):
             # Use a call-scoped bypass because skip_compiled would require runner-specific ForwardContext plumbing.
             with disable_compilation(self.get_model()):
                 self._dummy_run(mc2_tokens_capacity, with_prefill=True, is_profile=True)
-        super().profile_run()
 
     def eplb_warmup(self):
         if self.dynamic_eplb and not self.is_eplb_warmuped:


### PR DESCRIPTION
### What this PR does / why we need it?
Kimi-K2.5/K2.6 W4A8 + dflash (TP16, `max-num-batched-tokens=16384`, `VLLM_ASCEND_ENABLE_FLASHCOMM1=1`) OOMs during startup dummy / profile:

The 3.50 GiB allocation is not the ViT dummy. It is a second TP all-gather of already-global last/aux hidden states:

`16384 × 7168 × 2 (BF16) × TP16 = 3.50 GiB`

`[16384, 7168]` is already the global token extent. `_all_gather_hidden_states()` (from the FlashComm v1 / Eagle3 SP path) always `all_gather`s dim 0, allocating `[262144, 7168]`.

Kimi uses the DeepseekV2 path, which already all-gathers aux / last hidden when `shape[0] != positions.shape[0]`, then slices back to `positions.shape[0]`. Multimodal / Eagle3 auxiliary states captured before the first sequence-parallel reduce-scatter also already have the global token dimension. Gathering them again multiplies that dimension by TP.

This PR skips `tensor_model_parallel_all_gather` when `hidden_states.shape[0]` already equals the padded global token count, and still strips `pad_size` if needed. Local (sharded) hidden states keep the original gather.

### Does this PR introduce _any_ user-facing change?
No API or config change. Kimi-K2.5/K2.6 + dflash + FlashComm v1 should no longer OOM on this second auxiliary all-gather during profile / dummy run.

### How was this patch tested?
- Unit tests added in `tests/ut/worker/a2/test_model_runner_v1.py`:
  - already-global aux hidden states are not gathered
  - local hidden states still all-gather
  - already-global padded states drop `pad_size` without gathering

- vLLM main: https://github.com/vllm-project/vllm/commit/d02df748bf9efd99022f1a062597dc3cb3808485
