### PR TITLE
[BugFix][Graph] Keep idle DP ranks on the decode graph

### DIFF
--- a/tests/ut/test_ascend_config.py
+++ b/tests/ut/test_ascend_config.py
@@ -995,11 +995,14 @@ class TestTopLevelSwitchTypeValidation(TestBase):
     @patch("vllm_ascend.ascend_config._MEGA_MOE_SUPPORTED", True)
     @patch.object(AscendConfig, "_is_megamoe_supported_by_config", return_value=False)
     @patch("vllm_ascend.platform.NPUPlatform.check_and_update_config")
-    def test_fused_mc2_is_disabled_for_unsupported_megamoe_config(self, mock_fix, mock_megamoe_supported):
+    def test_fused_mc2_mode_1_keeps_switch_for_unsupported_megamoe_config(self, mock_fix, mock_megamoe_supported):
+        # enable_fused_mc2=1 rolls MegaMoe back to dispatch_ffn_combine and
+        # forces _MEGA_MOE_SUPPORTED=False, so derive_and_validate does not
+        # zero the switch even when the model config cannot use MegaMoe.
         vc = VllmConfig()
         vc.additional_config = {"enable_fused_mc2": 1}
 
-        self.assertEqual(init_ascend_config(vc).enable_fused_mc2, 0)
+        self.assertEqual(init_ascend_config(vc).enable_fused_mc2, 1)
 
     @_clean_up
     @patch("vllm_ascend.platform.NPUPlatform.check_and_update_config")

--- a/tests/ut/worker/a2/test_model_runner_v1.py
+++ b/tests/ut/worker/a2/test_model_runner_v1.py
@@ -1337,7 +1337,10 @@ class TestNPUModelRunnerDebugger(unittest.TestCase):
 
         runner.execute_model(scheduler_output)
 
-        runner._dummy_run.assert_called_once_with(1)
+        runner._dummy_run.assert_called_once_with(
+            1,
+            skip_gdn_state_update=True,
+        )
         runner._start_dump_data.assert_not_called()
 
     @patch("vllm_ascend.worker.model_runner_v1.has_kv_transfer_group", return_value=False)

--- a/tests/ut/worker/a2/test_model_runner_v1.py
+++ b/tests/ut/worker/a2/test_model_runner_v1.py
@@ -1330,6 +1330,7 @@ class TestNPUModelRunnerDebugger(unittest.TestCase):
         runner.synchronize_input_prep = nullcontext
         runner._update_states = MagicMock(return_value=None)
         runner.parallel_config = SimpleNamespace(distributed_executor_backend="external_launcher", data_parallel_size=2)
+        runner.uniform_decode_query_len = 8
         runner._dummy_run = MagicMock()
         runner._start_dump_data = MagicMock()
         runner.requests = {}
@@ -1338,7 +1339,8 @@ class TestNPUModelRunnerDebugger(unittest.TestCase):
         runner.execute_model(scheduler_output)
 
         runner._dummy_run.assert_called_once_with(
-            1,
+            8,
+            uniform_decode=True,
             skip_gdn_state_update=True,
         )
         runner._start_dump_data.assert_not_called()

--- a/tests/ut/worker/a2/test_worker_v1.py
+++ b/tests/ut/worker/a2/test_worker_v1.py
@@ -764,7 +764,11 @@ class TestNPUWorker(TestBase):
             worker.execute_dummy_batch()
 
             # Verify call
-            mock_model_runner._dummy_run.assert_called_once_with(mock_uniform_decode_query_len, uniform_decode=True)
+            mock_model_runner._dummy_run.assert_called_once_with(
+                mock_uniform_decode_query_len,
+                uniform_decode=True,
+                skip_gdn_state_update=True,
+            )
 
     @patch("vllm_ascend.worker.worker.plan_sparse_kv_offload_memory")
     @patch("vllm_ascend.worker.worker.get_ascend_config")

--- a/vllm_ascend/_310p/model_runner_310p.py
+++ b/vllm_ascend/_310p/model_runner_310p.py
@@ -583,6 +583,7 @@ class NPUModelRunner310(NPUModelRunner):
         is_graph_capturing: bool = False,
         num_active_loras: int = 0,
         profile_seq_lens: int | None = None,
+        skip_gdn_state_update: bool = False,
     ):
         temporary_context = self.temporary_modify_uniform_decode_query_len() if uniform_decode else nullcontext()
         # All the spec decoding cases has to run splitfuse op on 310P.
@@ -609,6 +610,7 @@ class NPUModelRunner310(NPUModelRunner):
                     is_graph_capturing=is_graph_capturing,
                     num_active_loras=num_active_loras,
                     profile_seq_lens=profile_seq_lens,
+                    skip_gdn_state_update=skip_gdn_state_update,
                 )
             finally:
                 self._spec_dummy_capture = False

--- a/vllm_ascend/worker/model_runner_v1.py
+++ b/vllm_ascend/worker/model_runner_v1.py
@@ -2139,8 +2139,14 @@ class NPUModelRunner(GPUModelRunner):
                         # 0, and has_unfinished_requests in the outer loop
                         # returns True. before returning early here we call
                         # dummy run to ensure coordinate_batch_across_dp
-                        # is called into to avoid out of sync issues.
-                        self._dummy_run(1, skip_gdn_state_update=True)
+                        # is called into to avoid out of sync issues. Match the
+                        # active decode descriptor so an idle rank does not
+                        # downgrade graph mode across the DP group.
+                        self._dummy_run(
+                            self.uniform_decode_query_len,
+                            uniform_decode=True,
+                            skip_gdn_state_update=True,
+                        )
                     if not has_kv_transfer_group():
                         # Return empty ModelRunnerOutput if no work to do.
                         return EMPTY_MODEL_RUNNER_OUTPUT

--- a/vllm_ascend/worker/model_runner_v1.py
+++ b/vllm_ascend/worker/model_runner_v1.py
@@ -3247,17 +3247,22 @@ class NPUModelRunner(GPUModelRunner):
                 GDNAttentionMetadataBuilder,
             )
             if is_gdn_noop:
-                assert num_reqs_padded is not None
-                # An idle DP dummy has a real tensor shape for model and
-                # collective execution, but no GDN tokens. Keep both captured
-                # recurrent branches inert instead of advancing cached state.
+                # Dummy-run callers coalesce this; fall back to the unpadded
+                # batch size instead of asserting in the execute path.
+                gdn_num_reqs = (
+                    num_reqs if num_reqs_padded is None else num_reqs_padded
+                )
+                # Idle DP dummy: keep captured GDN tensor ranks for graph
+                # replay/collectives. num_actual_tokens=0 is the kernel no-op
+                # (ops slice mixed_qkv[:0]); query_start_loc is a zero-filled
+                # prefix sized to the graph, not a real token schedule.
                 common_attn_metadata = replace(
                     common_attn_metadata,
                     query_start_loc=self.gdn_query_start_loc.gpu[
-                        : num_reqs_padded + 1
+                        : gdn_num_reqs + 1
                     ],
                     query_start_loc_cpu=self.gdn_query_start_loc.cpu[
-                        : num_reqs_padded + 1
+                        : gdn_num_reqs + 1
                     ],
                     num_actual_tokens=0,
                     max_query_len=0,

--- a/vllm_ascend/worker/model_runner_v1.py
+++ b/vllm_ascend/worker/model_runner_v1.py
@@ -2140,7 +2140,7 @@ class NPUModelRunner(GPUModelRunner):
                         # returns True. before returning early here we call
                         # dummy run to ensure coordinate_batch_across_dp
                         # is called into to avoid out of sync issues.
-                        self._dummy_run(1)
+                        self._dummy_run(1, skip_gdn_state_update=True)
                     if not has_kv_transfer_group():
                         # Return empty ModelRunnerOutput if no work to do.
                         return EMPTY_MODEL_RUNNER_OUTPUT
@@ -3077,6 +3077,7 @@ class NPUModelRunner(GPUModelRunner):
         num_scheduled_tokens: dict[str, int] | None = None,
         num_scheduled_tokens_np: np.ndarray | None = None,
         cascade_attn_prefix_lens: list[list[int]] | None = None,
+        skip_gdn_state_update: bool = False,
     ) -> tuple[PerLayerAttnMetadata, CommonAttentionMetadata | None]:
         """
         :return: tuple[attn_metadata, spec_decode_common_attn_metadata]
@@ -3241,12 +3242,40 @@ class NPUModelRunner(GPUModelRunner):
         ) -> None:
             attn_group = self.attn_groups[kv_cache_gid][attn_gid]
             builder = attn_group.get_metadata_builder(ubid or 0)
+            is_gdn_noop = skip_gdn_state_update and isinstance(
+                builder,
+                GDNAttentionMetadataBuilder,
+            )
+            if is_gdn_noop:
+                assert num_reqs_padded is not None
+                # An idle DP dummy has a real tensor shape for model and
+                # collective execution, but no GDN tokens. Keep both captured
+                # recurrent branches inert instead of advancing cached state.
+                common_attn_metadata = common_attn_metadata.replace(
+                    query_start_loc=self.gdn_query_start_loc.gpu[
+                        : num_reqs_padded + 1
+                    ],
+                    query_start_loc_cpu=self.gdn_query_start_loc.cpu[
+                        : num_reqs_padded + 1
+                    ],
+                    num_actual_tokens=0,
+                    max_query_len=0,
+                    is_prefilling=(
+                        torch.zeros_like(common_attn_metadata.is_prefilling)
+                        if common_attn_metadata.is_prefilling is not None
+                        else None
+                    ),
+                )
             cascade_attn_prefix_len = (
                 cascade_attn_prefix_lens[kv_cache_gid][attn_gid] if cascade_attn_prefix_lens else 0
             )
 
             extra_attn_metadata_args = {}
-            if use_spec_decode and isinstance(builder, GDNAttentionMetadataBuilder):
+            if (
+                use_spec_decode
+                and isinstance(builder, GDNAttentionMetadataBuilder)
+                and not is_gdn_noop
+            ):
                 assert ubid is None, "UBatching not supported with GDN yet"
                 extra_attn_metadata_args = dict(
                     num_accepted_tokens=self.num_accepted_tokens.gpu[:num_reqs_padded],
@@ -3405,6 +3434,7 @@ class NPUModelRunner(GPUModelRunner):
         num_active_loras: int = 0,
         profile_seq_lens: int | None = None,
         profile_cpp: bool = False,
+        skip_gdn_state_update: bool = False,
     ) -> tuple[torch.Tensor, torch.Tensor]:
         # only support eager mode and piecewise graph now
         assert cudagraph_runtime_mode is None or cudagraph_runtime_mode.valid_runtime_modes()
@@ -3543,7 +3573,12 @@ class NPUModelRunner(GPUModelRunner):
                 self.query_start_loc.np[1 : num_reqs_padded + 1] = cum_num_tokens
                 self.query_start_loc.copy_to_gpu()
                 if self._has_gdn:
-                    self.gdn_query_start_loc.np[1 : num_reqs_padded + 1] = cum_num_tokens
+                    if skip_gdn_state_update:
+                        self.gdn_query_start_loc.np.fill(0)
+                    else:
+                        self.gdn_query_start_loc.np[
+                            1 : num_reqs_padded + 1
+                        ] = cum_num_tokens
                     self.gdn_query_start_loc.copy_to_gpu()
 
                 if not profile_cpp:
@@ -3575,6 +3610,7 @@ class NPUModelRunner(GPUModelRunner):
                     ubatch_slices=ubatch_slices_padded if pad_attn else ubatch_slices,
                     for_cudagraph_capture=is_graph_capturing,
                     num_scheduled_tokens_np=num_scheduled_tokens,
+                    skip_gdn_state_update=skip_gdn_state_update,
                 )
                 if not is_graph_capturing:
                     for kv_cache_gid in range(len(self.kv_cache_config.kv_cache_groups)):

--- a/vllm_ascend/worker/model_runner_v1.py
+++ b/vllm_ascend/worker/model_runner_v1.py
@@ -3251,7 +3251,8 @@ class NPUModelRunner(GPUModelRunner):
                 # An idle DP dummy has a real tensor shape for model and
                 # collective execution, but no GDN tokens. Keep both captured
                 # recurrent branches inert instead of advancing cached state.
-                common_attn_metadata = common_attn_metadata.replace(
+                common_attn_metadata = replace(
+                    common_attn_metadata,
                     query_start_loc=self.gdn_query_start_loc.gpu[
                         : num_reqs_padded + 1
                     ],

--- a/vllm_ascend/worker/worker.py
+++ b/vllm_ascend/worker/worker.py
@@ -1085,7 +1085,11 @@ class NPUWorker(WorkerBase):
     def execute_dummy_batch(self) -> None:
         self.log_memory_stats()
         num_tokens = getattr(self.model_runner, "uniform_decode_query_len", 1)
-        self.model_runner._dummy_run(num_tokens, uniform_decode=True)
+        self.model_runner._dummy_run(
+            num_tokens,
+            uniform_decode=True,
+            skip_gdn_state_update=True,
+        )
 
     def _init_worker_distributed_environment(self) -> None:
         """Initialize the distributed environment."""


### PR DESCRIPTION
### What this PR does / why we need it?

In the external-launcher data-parallel path, an idle rank currently executes a one-token dummy run when the DP group still has unfinished work. With speculative decoding, active decode ranks use a uniform query length of `1 + num_speculative_tokens` while the idle rank reports a non-uniform one-token descriptor.

For `FULL_DECODE_ONLY`, graph mode is synchronized across the DP group by taking the minimum mode. One idle rank returning `NONE` therefore downgrades active ranks to a full eager target-model iteration.

This PR makes the idle DP dummy use the same decode descriptor as active ranks:

```python
self._dummy_run(
    self.uniform_decode_query_len,
    uniform_decode=True,
    skip_gdn_state_update=True,
)
```

The existing unit test now verifies the eight-token descriptor used by a `1 + 7` speculative decode configuration.

### Dependency

Depends on #15253, which introduces `skip_gdn_state_update=True` for synchronization-only dummy runs. This branch is stacked on the approved, CI-passing #15253 head and targets `main`.

Please merge #15253 first. Once it lands, this PR should contain only commit `83dd6f2a3bf0b84ba88ab8afe7e9425f5e78adce` and the two-file graph-descriptor change.

### Does this PR introduce _any_ user-facing change?

No API or configuration change.

Runtime impact is intentionally narrow:

- Applies only when `distributed_executor_backend == "external_launcher"`, data parallel size is greater than one, and the local rank has zero scheduled tokens.
- With seven speculative tokens, idle dummy work changes from one token to eight tokens so it matches the captured decode graph.
- Without speculative decoding, `uniform_decode_query_len == 1`, so token count remains unchanged.
- Active decode, prefill, and genuine mixed prefill/decode batches keep their existing graph-selection behavior. This does not force mixed batches onto a graph.
- `skip_gdn_state_update=True` remains enabled, so the larger synchronization dummy does not advance GDN/KDA/Conv recurrent state.
- Idle-rank dummy compute may increase by the speculative window size. The expected net effect is positive when the batch is graph-eligible because it avoids downgrading all active DP ranks to a full eager iteration.

### How was this patch tested?

- Updated `test_execute_model_skips_dump_start_for_dp_dummy_run` to assert:
  - `uniform_decode_query_len=8`;
  - `uniform_decode=True`;
  - `skip_gdn_state_update=True`.
- Repository-pinned Ruff check and format: passed.
- Codespell: passed.
- `python -m compileall`, long-function check, and `git diff --check`: passed.
- Dependency PR #15253 E2E workflow: passed.
- No live NPU service was restarted or mutated while preparing this PR. Live multi-node graph/profile validation remains to be run after #15253 is merged.

- vLLM main: https://github.com/vllm-project/vllm/commit/ba07e4a48fc951300d97eb506217dd530583dea3
