### PR TITLE
[v0.25.1rc][BugFix][Frontend] Handle DeepSeek V4 trailing system messages

### DIFF
--- a/tests/ut/patch/platform/test_deepseek_v4_trailing_system.py
+++ b/tests/ut/patch/platform/test_deepseek_v4_trailing_system.py
@@ -1,0 +1,55 @@
+# SPDX-License-Identifier: Apache-2.0
+
+from vllm.tokenizers import deepseek_v4_encoding
+
+import vllm_ascend.patch.platform.patch_deepseek_v4_trailing_system  # noqa: F401
+
+
+def test_trailing_system_appends_assistant_transition():
+    messages = [
+        {"role": "system", "content": "rules"},
+        {"role": "user", "content": "question"},
+        {"role": "system", "content": "final rules"},
+    ]
+
+    chat_prompt = deepseek_v4_encoding.encode_messages(messages, thinking_mode="chat")
+    thinking_prompt = deepseek_v4_encoding.encode_messages(
+        messages,
+        thinking_mode="thinking",
+    )
+
+    prefix = "<｜begin▁of▁sentence｜>rules<｜User｜>questionfinal rules"
+    assert chat_prompt == prefix + "<｜Assistant｜></think>"
+    assert thinking_prompt == prefix + "<｜Assistant｜><think>"
+
+
+def test_system_to_assistant_appends_transition():
+    messages = [
+        {"role": "system", "content": "rules"},
+        {"role": "assistant", "reasoning": "reason", "content": "answer"},
+    ]
+
+    chat_prompt = deepseek_v4_encoding.encode_messages(messages, thinking_mode="chat")
+    thinking_prompt = deepseek_v4_encoding.encode_messages(
+        messages,
+        thinking_mode="thinking",
+    )
+
+    assert chat_prompt == ("<｜begin▁of▁sentence｜>rules<｜Assistant｜></think>answer<｜end▁of▁sentence｜>")
+    assert thinking_prompt == (
+        "<｜begin▁of▁sentence｜>rules<｜Assistant｜><think>reason</think>answer<｜end▁of▁sentence｜>"
+    )
+
+
+def test_mid_conversation_system_does_not_append_transition():
+    messages = [
+        {"role": "user", "content": "first"},
+        {"role": "assistant", "content": "answer"},
+        {"role": "system", "content": "new rules"},
+        {"role": "user", "content": "second"},
+    ]
+
+    prompt = deepseek_v4_encoding.encode_messages(messages, thinking_mode="chat")
+
+    assert "new rules<｜User｜>second" in prompt
+    assert "new rules<｜Assistant｜>" not in prompt

--- a/vllm_ascend/patch/__init__.py
+++ b/vllm_ascend/patch/__init__.py
@@ -107,6 +107,23 @@
 #    Future Plan:
 #       Remove this patch once the supported vLLM version fixes issue #52846.
 #
+# ** 3b. File: platform/patch_deepseek_v4_trailing_system.py**
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+#   1. `vllm.tokenizers.deepseek_v4_encoding.render_message`
+#    Why:
+#       The supported vLLM version does not append the assistant transition
+#       after a trailing DeepSeek V4 system message. Generation then starts at
+#       an invalid prompt boundary and can return empty content or raw tags.
+#    How:
+#       Append the existing assistant/thinking transition after a trailing
+#       system message or before an assistant history turn. A system message
+#       followed by a user or latest-reminder message remains unchanged. The
+#       patch is skipped when a behavior probe detects the upstream fix.
+#    Related PR (if no, explain why):
+#       https://github.com/vllm-project/vllm/pull/51262
+#    Future Plan:
+#       Remove this patch once the supported vLLM version contains PR #51262.
+#
 # ** 4. File: platform/patch_distributed.py**
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 #   1. `torch.distributed.all_reduce`, `torch.distributed.broadcast`

--- a/vllm_ascend/patch/platform/__init__.py
+++ b/vllm_ascend/patch/platform/__init__.py
@@ -19,6 +19,7 @@ import os
 import vllm_ascend.patch.platform.patch_camem_allocator  # noqa
 import vllm_ascend.patch.platform.patch_deepseek_v4_thinking  # noqa
 import vllm_ascend.patch.platform.patch_deepseek_v4_tool_streaming  # noqa
+import vllm_ascend.patch.platform.patch_deepseek_v4_trailing_system  # noqa
 import vllm_ascend.patch.platform.patch_distributed  # noqa
 import vllm_ascend.patch.platform.patch_kv_cache_utils  # noqa
 import vllm_ascend.patch.platform.patch_mla_prefill_backend  # noqa

--- a/vllm_ascend/patch/platform/patch_deepseek_v4_trailing_system.py
+++ b/vllm_ascend/patch/platform/patch_deepseek_v4_trailing_system.py
@@ -14,12 +14,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import inspect
 from functools import wraps
 from typing import Any
 
 from vllm.tokenizers import deepseek_v4_encoding
 
 _original_render_message = deepseek_v4_encoding.render_message
+_render_message_signature = inspect.signature(_original_render_message)
 
 
 def _upstream_handles_trailing_system() -> bool:
@@ -34,13 +36,12 @@ def _upstream_handles_trailing_system() -> bool:
 @wraps(_original_render_message)
 def _patched_render_message(*args: Any, **kwargs: Any) -> str:
     prompt = _original_render_message(*args, **kwargs)
-    index = kwargs["index"] if "index" in kwargs else args[0]
-    messages = kwargs["messages"] if "messages" in kwargs else args[1]
-    thinking_mode = kwargs["thinking_mode"] if "thinking_mode" in kwargs else args[2]
-    drop_thinking = kwargs.get(
-        "drop_thinking",
-        args[3] if len(args) > 3 else True,
-    )
+    bound_args = _render_message_signature.bind(*args, **kwargs)
+    bound_args.apply_defaults()
+    index = bound_args.arguments["index"]
+    messages = bound_args.arguments["messages"]
+    thinking_mode = bound_args.arguments["thinking_mode"]
+    drop_thinking = bound_args.arguments["drop_thinking"]
     message = messages[index]
     if message.get("role") != "system" or message.get("task") is not None:
         return prompt
@@ -48,10 +49,7 @@ def _patched_render_message(*args: Any, **kwargs: Any) -> str:
         return prompt
 
     prompt += deepseek_v4_encoding.ASSISTANT_SP_TOKEN
-    last_user_idx = kwargs.get(
-        "last_user_idx",
-        args[5] if len(args) > 5 else None,
-    )
+    last_user_idx = bound_args.arguments.get("last_user_idx")
     if last_user_idx is None:
         last_user_idx = deepseek_v4_encoding.find_last_user_index(messages)
     if thinking_mode == "thinking" and (not drop_thinking or index >= last_user_idx):

--- a/vllm_ascend/patch/platform/patch_deepseek_v4_trailing_system.py
+++ b/vllm_ascend/patch/platform/patch_deepseek_v4_trailing_system.py
@@ -1,0 +1,65 @@
+#
+# Copyright (c) 2026 Huawei Technologies Co., Ltd. All Rights Reserved.
+# This file is a part of the vllm-ascend project.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from functools import wraps
+from typing import Any
+
+from vllm.tokenizers import deepseek_v4_encoding
+
+_original_render_message = deepseek_v4_encoding.render_message
+
+
+def _upstream_handles_trailing_system() -> bool:
+    prompt = _original_render_message(
+        0,
+        [{"role": "system", "content": ""}],
+        thinking_mode="chat",
+    )
+    return prompt.endswith(deepseek_v4_encoding.ASSISTANT_SP_TOKEN + deepseek_v4_encoding.thinking_end_token)
+
+
+@wraps(_original_render_message)
+def _patched_render_message(*args: Any, **kwargs: Any) -> str:
+    prompt = _original_render_message(*args, **kwargs)
+    index = kwargs["index"] if "index" in kwargs else args[0]
+    messages = kwargs["messages"] if "messages" in kwargs else args[1]
+    thinking_mode = kwargs["thinking_mode"] if "thinking_mode" in kwargs else args[2]
+    drop_thinking = kwargs.get(
+        "drop_thinking",
+        args[3] if len(args) > 3 else True,
+    )
+    message = messages[index]
+    if message.get("role") != "system" or message.get("task") is not None:
+        return prompt
+    if index + 1 < len(messages) and messages[index + 1].get("role") != "assistant":
+        return prompt
+
+    prompt += deepseek_v4_encoding.ASSISTANT_SP_TOKEN
+    last_user_idx = kwargs.get(
+        "last_user_idx",
+        args[5] if len(args) > 5 else None,
+    )
+    if last_user_idx is None:
+        last_user_idx = deepseek_v4_encoding.find_last_user_index(messages)
+    if thinking_mode == "thinking" and (not drop_thinking or index >= last_user_idx):
+        prompt += deepseek_v4_encoding.thinking_start_token
+    else:
+        prompt += deepseek_v4_encoding.thinking_end_token
+    return prompt
+
+
+if not _upstream_handles_trailing_system():
+    deepseek_v4_encoding.render_message = _patched_render_message


### PR DESCRIPTION
### What this PR does / why we need it?

Backport the DeepSeek V4 trailing-system renderer fix from #15317 to the v0.25.1rc release branch.

When a DeepSeek V4 request ends with a `system` message, the v0.25 renderer can leave the prompt at an invalid system-message boundary. Generation may then return empty content or raw DSML tags. This patch appends the assistant/thinking transition for trailing system messages while preserving mid-conversation system behavior.

Fixes #15070
Fixes #11951
Backport of #15317

### Does this PR introduce _any_ user-facing change?

Yes. DeepSeek V4 requests ending in a system message now start generation from the correct assistant boundary.

### How was this patch tested?

Focused DeepSeek V4 patch tests on the v0.25.1rc environment:

```bash
VLLM_PLUGINS="" PYTHONPATH=/vllm-workspace/vllm:$PWD \
python -m pytest -q -p no:cacheprovider \
  --confcutdir=tests/ut/patch/platform --noconftest \
  tests/ut/patch/platform/test_deepseek_v4_thinking.py \
  tests/ut/patch/platform/test_deepseek_v4_tool_streaming.py \
  tests/ut/patch/platform/test_deepseek_v4_trailing_system.py
```

Result: `48 passed`.

Ruff check, Ruff format check, and `git diff --check` also passed.

- vLLM main: https://github.com/vllm-project/vllm/commit/fe784ff22e630a31fd798f392b01e0a75c18f047
