### PR TITLE
[BugFix][MRV2] Isolate Eagle draft parallel config

### DIFF
--- a/vllm_ascend/worker/v2/spec_decode/eagle/speculator.py
+++ b/vllm_ascend/worker/v2/spec_decode/eagle/speculator.py
@@ -16,13 +16,28 @@
 # limitations under the License.
 # This file is a part of the vllm-ascend project.
 #
+from vllm.config import VllmConfig, replace
 from vllm.v1.worker.gpu.spec_decode.eagle.speculator import EagleSpeculator
 
-from vllm_ascend.worker.v2.spec_decode.autoregressive.speculator import AscendAutoRegressiveSpeculator
+from vllm_ascend.worker.v2.spec_decode.autoregressive.speculator import (
+    AscendAutoRegressiveSpeculator,
+)
 
 
 class AscendEagleSpeculator(AscendAutoRegressiveSpeculator, EagleSpeculator):
     """Ascend Eagle speculator: the NPU loop from AscendAutoRegressiveSpeculator
     layered on upstream EagleSpeculator (flat/GQA attention)."""
 
-    pass
+    def _create_draft_vllm_config(self) -> VllmConfig:
+        # EAGLE draft models are dense even when the target is an MoE model.
+        # Reusing the target's EP/EPLB flags makes VllmConfig validate the
+        # draft as an expert model and fail because the draft has no experts.
+        return replace(
+            self.vllm_config,
+            model_config=self.draft_model_config,
+            parallel_config=replace(
+                self.vllm_config.parallel_config,
+                enable_expert_parallel=False,
+                enable_eplb=False,
+            ),
+        )


### PR DESCRIPTION
### What this PR does / why we need it?

ModelRunner V2 builds the EAGLE draft runtime config from the target model's `VllmConfig`. When an MoE target enables expert parallelism, those parallel flags are inherited by the dense EAGLE draft model. `VllmConfig` then validates the draft as an expert model and fails because the draft has no experts:

```text
Value error, Number of experts in the model must be greater than 0 when expert parallelism is enabled.
```

This change overrides the EAGLE draft runtime config to disable EP and EPLB only for the draft model. The target model keeps its original EP/EPLB configuration. A source comment documents why these flags must not be inherited.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Clean A/B startup validation with MiniMax-M3 BF16 + EAGLE3, TP16/DP1 and target EP enabled:

- Before: startup fails while validating the dense draft model with inherited expert parallelism.
- After: the target and draft weights load and the service starts successfully in both `FULL_DECODE_ONLY` and `PIECEWISE` graph modes.

Also verified with `git diff --check`.

- vLLM main: https://github.com/vllm-project/vllm/commit/ba07e4a48fc951300d97eb506217dd530583dea3
