### PR TITLE
[Performance][KV Pool] Avoid prompt token copies when KV events are disabled

### DIFF
--- a/tests/ut/distributed/ascend_store/test_pool_scheduler.py
+++ b/tests/ut/distributed/ascend_store/test_pool_scheduler.py
@@ -48,6 +48,7 @@ def _patch_pool_scheduler_importlib():
 
 def make_config(kv_role="kv_producer", extra_config=None, block_size=16):
     config = MagicMock()
+    config.kv_events_config = None
     config.kv_transfer_config.kv_role = kv_role
     config.kv_transfer_config.kv_connector_extra_config = extra_config or {}
     config.kv_transfer_config.get_from_extra_config.return_value = True
@@ -287,6 +288,7 @@ class TestKVPoolScheduler(unittest.TestCase):
 class TestKVPoolSchedulerBuildMeta(unittest.TestCase):
     def _make_config(self, kv_role="kv_producer", block_size=16, extra_config=None, num_layers=2):
         config = MagicMock()
+        config.kv_events_config = None
         config.kv_transfer_config.kv_role = kv_role
         config.kv_transfer_config.kv_connector_extra_config = extra_config or {}
         config.kv_transfer_config.get_from_extra_config.return_value = True
@@ -369,6 +371,41 @@ class TestKVPoolSchedulerBuildMeta(unittest.TestCase):
 
         meta = scheduler.build_connector_meta(sched_output)
         self.assertTrue(len(meta.requests) >= 1)
+        self.assertIsNone(meta.requests[0].token_ids)
+
+    @patch("vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.pool_scheduler.LookupKeyClient")
+    def test_build_connector_meta_new_req_with_kv_events(self, mock_client_cls):
+        config = self._make_config()
+        config.kv_events_config = MagicMock(enable_kv_cache_events=True)
+        scheduler = KVPoolScheduler(config, use_layerwise=False)
+
+        request = MagicMock()
+        request.request_id = "r1"
+        request.prompt_token_ids = list(range(32))
+        request.num_tokens = 32
+        request.num_computed_tokens = 0
+        request.block_hashes = [b"h0", b"h1"]
+        request.all_token_ids = list(range(32))
+        blocks = MagicMock()
+        blocks.get_block_ids.return_value = [[0, 1]]
+        scheduler.update_state_after_alloc(request, blocks, 0)
+
+        new_req_data = MagicMock()
+        new_req_data.req_id = "r1"
+        new_req_data.num_computed_tokens = 0
+        new_req_data.block_ids = [0, 1]
+        new_req_data.prompt_token_ids = list(range(32))
+
+        sched_output = MagicMock()
+        sched_output.finished_req_ids = set()
+        sched_output.preempted_req_ids = set()
+        sched_output.scheduled_new_reqs = [new_req_data]
+        sched_output.num_scheduled_tokens = {"r1": 32}
+        sched_output.scheduled_cached_reqs = MagicMock()
+        sched_output.scheduled_cached_reqs.req_ids = []
+
+        meta = scheduler.build_connector_meta(sched_output)
+        self.assertEqual(meta.requests[0].token_ids, list(range(32)))
 
     @patch("vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.pool_scheduler.LookupKeyClient")
     def test_running_chunk_reloads_prefix_with_layer_reuse(self, mock_client_cls):

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/pool_scheduler.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/pool_scheduler.py
@@ -95,6 +95,8 @@ class KVPoolScheduler:
             "consumer_is_to_put", False
         )
         self.load_async = vllm_config.kv_transfer_config.kv_connector_extra_config.get("load_async", False)
+        kv_event_config = vllm_config.kv_events_config
+        self.enable_kv_events = bool(kv_event_config and kv_event_config.enable_kv_cache_events)
         retention_interval = getattr(envs, "VLLM_PREFIX_CACHE_RETENTION_INTERVAL", None)
         self.retention_interval = retention_interval if isinstance(retention_interval, int) else None
         self.save_decode_cache = vllm_config.kv_transfer_config.kv_connector_extra_config.get(
@@ -654,7 +656,7 @@ class KVPoolScheduler:
             token_len=num_tokens_to_compute,
             allocated_block_ids_by_group=block_ids_by_group,
             num_saved_tokens=0,
-            token_ids=request.prompt_token_ids[:num_tokens_to_compute].copy(),
+            token_ids=(request.prompt_token_ids[:num_tokens_to_compute].copy() if self.enable_kv_events else None),
             num_prompt_tokens=len(request.prompt_token_ids),
             block_gvas=(previous_tracker.block_gvas.copy() if previous_tracker else []),
             gva_block_offset=(previous_tracker.gva_block_offset if previous_tracker else 0),
@@ -696,7 +698,7 @@ class KVPoolScheduler:
             token_len=num_tokens_to_compute,
             allocated_block_ids_by_group=new_block_ids_by_group,
             num_saved_tokens=0,
-            token_ids=request_real.prompt_token_ids[:num_tokens_to_compute].copy(),
+            token_ids=(request_real.prompt_token_ids[:num_tokens_to_compute].copy() if self.enable_kv_events else None),
             num_prompt_tokens=len(request_real.prompt_token_ids),
             block_gvas=(previous_tracker.block_gvas.copy() if previous_tracker else []),
             gva_block_offset=(previous_tracker.gva_block_offset if previous_tracker else 0),


### PR DESCRIPTION
### What this PR does / why we need it?

Avoid prompt-sized token list copies in AscendStore when KV cache events are disabled, which is the default path. Prompt token IDs are now retained in request metadata only when `enable_kv_cache_events` is enabled; event payload behavior remains unchanged.

This follows the behavior prototyped in lijiahang226/vllm-ascend@85fc2384061594c0f73a47a39a99d473a7fa2bbd. The redundant async-scheduling `deepcopy` from lijiahang226/vllm-ascend@ffdacc6b82cd28ae7d1154fb2155c0d825bc33c2 is already removed on `main` by #14643, so it is not duplicated here.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

- Added unit coverage for both event-disabled and event-enabled connector metadata.
- `uvx ruff check tests/ut/distributed/ascend_store/test_pool_scheduler.py vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/pool_scheduler.py`
- `uvx ruff format --check tests/ut/distributed/ascend_store/test_pool_scheduler.py vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/pool_scheduler.py`
- `python -m py_compile tests/ut/distributed/ascend_store/test_pool_scheduler.py vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/pool_scheduler.py`
- The pytest suite was not run locally because pytest is not installed in the current Windows environment; CI is required for runtime verification.

- vLLM main: https://github.com/vllm-project/vllm/commit/ba07e4a48fc951300d97eb506217dd530583dea3
