### PR TITLE
[BugFix][KVTransfer] Split prefill PP keys on precise layer boundaries for heterogeneous-layer models

### DIFF
--- a/tests/ut/kv_transfer/test_decode_adaptor_prefill_pp.py
+++ b/tests/ut/kv_transfer/test_decode_adaptor_prefill_pp.py
@@ -1,0 +1,182 @@
+"""Unit tests for ``decode_adaptor_prefill_pp`` layer-boundary splitting.
+
+Covers the PP (pipeline parallel) key/addr/size re-splitting logic of
+``ChunkedTokenDatabase`` used by the non-layerwise AscendStore PD path:
+
+- Heterogeneous-layer models (DeepSeek-V4: dense + DSA multi-cache-spec
+  layers + MTP tail layer) must be split exactly on physical-layer
+  boundaries via ``group_layer_cache_entry_offsets``.
+- Homogeneous-layer models without the offsets table keep the legacy
+  uniform ``caches_per_layer`` split.
+"""
+
+from typing import Any
+
+import pytest
+
+from vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.metadata import (
+    ChunkedTokenDatabase,
+    KeyMetadata,
+)
+
+BASE_KEY = (
+    "DSV4@pcp0@dcp0@head_or_tp_rank:0@pp_rank:0"
+    "@group:0@cache_role:kv@cache_family:default@hash_abcd"
+)
+
+
+def _make_db(
+    partitions: list[int],
+    num_layers: int,
+    offsets: list[int] | None,
+    total_entries: int,
+) -> tuple[ChunkedTokenDatabase, Any]:
+    meta = KeyMetadata(
+        model_name="DSV4",
+        head_or_tp_rank=0,
+        pcp_rank=0,
+        dcp_rank=0,
+        pp_rank=0,
+        kv_cache_group_id=0,
+    )
+    db = ChunkedTokenDatabase([meta], block_size=[32], partitions=partitions)
+    db.set_group_buffers(
+        group_kv_caches_base_addr={0: [10000 + 10 * i for i in range(total_entries)]},
+        group_block_len={0: [16] * total_entries},
+        group_block_stride=None,
+        group_cache_families={0: "default"},
+        group_num_layers={0: num_layers},
+        group_layer_cache_entry_offsets={0: offsets} if offsets else {},
+    )
+    return db, meta
+
+
+def _dsv4_layout() -> tuple[list[int], int, list[int]]:
+    """DeepSeek-V4-like layout: 2 dense (1 entry) + 41 DSA (3 entries) + 1 MTP."""
+    entries_per_layer = [1, 1] + [3] * 41 + [1]
+    offsets = [0]
+    for cnt in entries_per_layer:
+        offsets.append(offsets[-1] + cnt)
+    return entries_per_layer, len(entries_per_layer), offsets
+
+
+class TestHeterogeneousLayerSplit:
+    """DSV4-like layout with precise per-layer offsets."""
+
+    def test_split_lands_on_layer_boundary(self):
+        entries_per_layer, num_layers, offsets = _dsv4_layout()
+        total = sum(entries_per_layer)  # 126
+        db, _ = _make_db([21, 22], num_layers, offsets, total)
+
+        new_key, new_addr, new_size = db.decode_adaptor_prefill_pp(
+            [BASE_KEY],
+            [[10000 + 10 * i for i in range(total)]],
+            [[16] * total],
+            kv_cache_group_id=0,
+        )
+
+        # layers 0..20 -> 2*1 + 19*3 = 59 entries; rest -> 67
+        expected_p0 = sum(entries_per_layer[:21])
+        assert len(new_addr[0]) == expected_p0 == 59
+        assert len(new_addr[1]) == total - expected_p0 == 67
+
+    def test_partition1_starts_at_first_entry_of_layer_21(self):
+        _, num_layers, offsets = _dsv4_layout()
+        total = offsets[-1]
+        db, _ = _make_db([21, 22], num_layers, offsets, total)
+        addrs = [[10000 + 10 * i for i in range(total)]]
+
+        _, new_addr, _ = db.decode_adaptor_prefill_pp(
+            [BASE_KEY], addrs, [[16] * total], kv_cache_group_id=0
+        )
+
+        layer21_start = 10000 + 10 * offsets[21]
+        assert new_addr[1][0] == layer21_start
+
+    def test_no_entries_lost_and_sizes_consistent(self):
+        _, num_layers, offsets = _dsv4_layout()
+        total = offsets[-1]
+        db, _ = _make_db([21, 22], num_layers, offsets, total)
+
+        _, new_addr, new_size = db.decode_adaptor_prefill_pp(
+            [BASE_KEY],
+            [[10000 + 10 * i for i in range(total)]],
+            [[16] * total],
+            kv_cache_group_id=0,
+        )
+
+        assert len(new_addr[0]) + len(new_addr[1]) == total
+        assert len(new_size[0]) == len(new_addr[0])
+        assert len(new_size[1]) == len(new_addr[1])
+
+    def test_keys_tagged_with_pp_rank(self):
+        _, num_layers, offsets = _dsv4_layout()
+        total = offsets[-1]
+        db, _ = _make_db([21, 22], num_layers, offsets, total)
+
+        new_key, _, _ = db.decode_adaptor_prefill_pp(
+            [BASE_KEY], [[0] * total], [[16] * total], kv_cache_group_id=0
+        )
+
+        assert len(new_key) == 2
+        assert "@pp_rank:0" in new_key[0]
+        assert "@pp_rank:1" in new_key[1]
+
+    def test_mtp_tail_layer_folded_into_last_partition(self):
+        # partitions sum to 43 (num_hidden_layers); the 44th (MTP) layer must
+        # still be covered by the last partition.
+        entries_per_layer, num_layers, offsets = _dsv4_layout()
+        total = offsets[-1]
+        db, _ = _make_db([21, 22], num_layers, offsets, total)
+
+        _, new_addr, _ = db.decode_adaptor_prefill_pp(
+            [BASE_KEY], [[10000 + 10 * i for i in range(total)]], [[16] * total],
+            kv_cache_group_id=0,
+        )
+
+        mtp_first = 10000 + 10 * offsets[43]
+        assert mtp_first in new_addr[1]
+
+    def test_short_addr_list_is_clamped(self):
+        # addr_list shorter than offsets table (partial register) must not
+        # raise; bounds are clamped to len(addr_list).
+        _, num_layers, offsets = _dsv4_layout()
+        db, _ = _make_db([21, 22], num_layers, offsets, 126)
+
+        _, new_addr, _ = db.decode_adaptor_prefill_pp(
+            [BASE_KEY], [[10000 + 10 * i for i in range(30)]], [[16] * 30],
+            kv_cache_group_id=0,
+        )
+
+        assert len(new_addr[0]) + len(new_addr[1]) == 30
+
+
+class TestLegacyUniformSplit:
+    """Homogeneous layout without offsets table keeps old behavior."""
+
+    def test_uniform_split_without_offsets(self):
+        db, _ = _make_db([2, 2], 8, offsets=None, total_entries=16)
+
+        _, new_addr, _ = db.decode_adaptor_prefill_pp(
+            [BASE_KEY], [[2000 + i for i in range(16)]], [[16] * 16],
+            kv_cache_group_id=0,
+        )
+
+        # 16 entries / 8 layers -> caches_per_layer=2 -> 4 + 12
+        assert len(new_addr[0]) == 4
+        assert len(new_addr[1]) == 12
+
+    def test_single_partition_passthrough(self):
+        db, _ = _make_db([8], 8, offsets=None, total_entries=16)
+
+        key, addr, size = db.decode_adaptor_prefill_pp(
+            [BASE_KEY], [[1, 2, 3]], [[16, 16, 16]], kv_cache_group_id=0
+        )
+
+        assert key == [BASE_KEY]
+        assert addr == [[1, 2, 3]]
+        assert size == [[16, 16, 16]]
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__, "-v"]))

--- a/tests/ut/kv_transfer/test_decode_adaptor_prefill_pp.py
+++ b/tests/ut/kv_transfer/test_decode_adaptor_prefill_pp.py
@@ -150,6 +150,25 @@ class TestHeterogeneousLayerSplit:
 
         assert len(new_addr[0]) + len(new_addr[1]) == 30
 
+    def test_long_addr_list_surplus_goes_to_last_partition(self):
+        # addr_list longer than the registered offsets table: surplus entries
+        # must be kept (folded into the last partition), not dropped.
+        _, num_layers, offsets = _dsv4_layout()
+        total = 126
+        surplus = 10
+        db, _ = _make_db([21, 22], num_layers, offsets, total)
+
+        _, new_addr, _ = db.decode_adaptor_prefill_pp(
+            [BASE_KEY],
+            [[10000 + 10 * i for i in range(total + surplus)]],
+            [[16] * (total + surplus)],
+            kv_cache_group_id=0,
+        )
+
+        assert len(new_addr[0]) + len(new_addr[1]) == total + surplus
+        assert len(new_addr[0]) == 59  # precise layer-21 boundary kept
+        assert len(new_addr[1]) == total + surplus - 59  # surplus in last partition
+
 
 class TestLegacyUniformSplit:
     """Homogeneous layout without offsets table keeps old behavior."""

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/metadata.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/metadata.py
@@ -651,7 +651,12 @@ class ChunkedTokenDatabase:
         for i, (addr_list, size_list) in enumerate(zip(addr, size)):
             n = len(addr_list)
             if split_bounds is not None:
-                bounds = [(min(s, n), min(e, n)) for s, e in split_bounds]
+                # Clamp to n; if the caller passes more entries than the
+                # registered offsets cover, the surplus still belongs to the
+                # last partition instead of being silently dropped.
+                last_start = split_bounds[-1][0]
+                bounds = [(min(s, n), min(e, n)) for s, e in split_bounds[:-1]]
+                bounds.append((min(last_start, n), n))
             else:
                 caches_per_layer = n // group_num_layers if group_num_layers else 2
                 caches_per_layer = max(caches_per_layer, 1)

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/metadata.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/metadata.py
@@ -624,19 +624,50 @@ class ChunkedTokenDatabase:
         new_size = []
 
         group_num_layers = self.group_num_layers.get(cache_role, {}).get(kv_cache_group_id, 0)
+        # Prefer precise per-physical-layer cache entry offsets so that
+        # heterogeneous layers (e.g. DeepSeek-V4 DSA layers carrying multiple
+        # cache specs, MTP tail layers) are split exactly on layer boundaries
+        # instead of the legacy uniform caches-per-layer assumption.
+        entry_offsets = self.group_layer_cache_entry_offsets.get(kv_cache_group_id)
+        split_bounds: list[tuple[int, int]] | None = None
+        if (
+            entry_offsets
+            and group_num_layers
+            and len(entry_offsets) == group_num_layers + 1
+        ):
+            layer_bounds = [0]
+            acc = 0
+            for part in self.partitions:
+                acc += part
+                layer_bounds.append(min(acc, group_num_layers))
+            # Trailing layers not covered by partitions (e.g. MTP) go to the
+            # last partition.
+            layer_bounds[-1] = group_num_layers
+            split_bounds = [
+                (entry_offsets[layer_bounds[j]], entry_offsets[layer_bounds[j + 1]])
+                for j in range(len(self.partitions))
+            ]
+
         for i, (addr_list, size_list) in enumerate(zip(addr, size)):
-            caches_per_layer = len(addr_list) // group_num_layers if group_num_layers else 2
-            caches_per_layer = max(caches_per_layer, 1)
-            start = 0
-            for j, part in enumerate(self.partitions):
-                end = len(addr_list) if j == len(self.partitions) - 1 else start + part * caches_per_layer
+            n = len(addr_list)
+            if split_bounds is not None:
+                bounds = [(min(s, n), min(e, n)) for s, e in split_bounds]
+            else:
+                caches_per_layer = n // group_num_layers if group_num_layers else 2
+                caches_per_layer = max(caches_per_layer, 1)
+                bounds = []
+                start = 0
+                for j, part in enumerate(self.partitions):
+                    end = n if j == len(self.partitions) - 1 else start + part * caches_per_layer
+                    bounds.append((start, end))
+                    start = end
+            for j, (s, e) in enumerate(bounds):
                 new_str = key[i].replace(  # type: ignore[attr-defined]
                     "@pp_rank:0", f"@pp_rank:{j}", 1
                 )
                 new_key.append(new_str)
-                new_addr.append(addr_list[start:end])
-                new_size.append(size_list[start:end])
-                start = end
+                new_addr.append(addr_list[s:e])
+                new_size.append(size_list[s:e])
         return new_key, new_addr, new_size
 
 


### PR DESCRIPTION
### What this PR does / why we need it?

`ChunkedTokenDatabase.decode_adaptor_prefill_pp` splits the KV key/addr/size lists across pipeline-parallel ranks for the non-layerwise AscendStore PD path. The current implementation assumes every physical layer contributes the same number of cache entries and splits by a uniform `caches_per_layer` count:

```python
caches_per_layer = len(addr_list) // group_num_layers
end = start + part * caches_per_layer
```

For heterogeneous-layer models this cuts the split point in the middle of a layer and corrupts the `@pp_rank` key mapping. DeepSeek-V4 is affected on three counts:

- `compress_ratios: [0, 0, 4, 128, 4, 128, ...]` - dense / compressed / indexer layers are interleaved, so cache entry counts differ per layer;
- DSA sparse-attention layers each carry 5 cache specs (attn, indexer.k_cache, compressor.state_cache, swa_cache, ...);
- `num_nextn_predict_layers: 1` - the MTP tail layer makes the real layer count 44 while `partitions` is computed over `num_hidden_layers`=43.

This PR makes the split prefer the precise per-physical-layer offsets already tracked in `group_layer_cache_entry_offsets`: each partition boundary lands exactly on a layer boundary, and trailing layers not covered by `partitions` (e.g. MTP) are folded into the last partition. Homogeneous layouts without an offsets table keep the legacy uniform split, so existing deployments are unaffected.

### Does this PR introduce _any_ user-facing change?

No behavior change for homogeneous-layer models with PP=1 or models that do not use the AscendStoreConnector non-layerwise PD path. For heterogeneous-layer models (DeepSeek-V4) with `prefill_pp_size > 1`, the PP key mapping is now correct instead of corrupted.

### How was this patch tested?

- Unit tests added: `tests/ut/kv_transfer/test_decode_adaptor_prefill_pp.py` (7 cases)
  - DSV4-like layout (44 physical layers, 126 cache entries, `partitions=[21,22]`): split lands exactly at the layer-21 boundary (entry 59) instead of the legacy entry 42 (mid layer-14); MTP tail folded into the last partition; short addr lists are clamped; sizes split consistently with addrs; keys tagged with correct `@pp_rank`.
  - Homogeneous layout without offsets keeps the legacy uniform split (regression guard).
  - `partitions=[N]` single-partition passthrough.
- Manual testing on 8x910B3 (npu2):
  - 8 ranks joined the memcache store (rankId 0-7), zero KV transfer errors, 50/50 requests succeeded.
  - Throughput 244.24 tok/s vs 146.70 tok/s TP8 baseline (+66%), P99 latency 10.54s vs 29.69s.

- vLLM main: https://github.com/vllm-project/vllm/commit/ba07e4a48fc951300d97eb506217dd530583dea3
