### PR TITLE
[Doc][BugFix] Prevent Traditional Chinese characters in zh_CN translations

### DIFF
--- a/.github/workflows/scripts/po_translate.py
+++ b/.github/workflows/scripts/po_translate.py
@@ -25,18 +25,19 @@ import time
 from pathlib import Path
 
 import regex as re
+import zhconv
 from openai import AsyncOpenAI
 from polib import POEntry, pofile
 
 SYSTEM_PROMPT = (
     "You are a professional technical documentation translator specializing in "
-    "translating MkDocs markdown documentation from English to Chinese. "
+    "translating MkDocs markdown documentation from English to Simplified Chinese (简体中文). "
     "You produce accurate, consistent translations of all gettext PO file entries "
     "without skipping any. You never add explanations, markdown fences, or extra text "
     "outside the PO file content."
 )
 
-TRANSLATION_PROMPT = """Translate these PO file entries (gettext format) from English to Chinese.
+TRANSLATION_PROMPT = """Translate these PO file entries (gettext format) from English to Simplified Chinese (简体中文).
 
 You are given a list of msgid/msgstr pairs where every msgstr is empty ("").
 For each msgid, fill in the Chinese translation in the corresponding msgstr.
@@ -137,6 +138,18 @@ def _normalize_msgid(text: str) -> str:
     while lines and not lines[-1]:
         lines.pop()
     return "\n".join(lines)
+
+
+def _convert_po_to_simplified(po):
+    """Convert all msgstr values in a PO file from Traditional to Simplified Chinese.
+
+    This is a safety net to catch any Traditional Chinese characters that the
+    translation model may have produced despite the prompt requesting Simplified
+    Chinese only.
+    """
+    for entry in po:
+        if entry.msgstr:
+            entry.msgstr = zhconv.convert(entry.msgstr, "zh-cn")
 
 
 class POTranslator:
@@ -243,6 +256,7 @@ class POTranslator:
                 print("FAILED (merge)")
                 return False
 
+            _convert_po_to_simplified(po)
             po.save(str(path))
             if merged < len(untranslated):
                 print(f"OK ({merged}/{len(untranslated)} merged)")

--- a/docs/requirements-docs.txt
+++ b/docs/requirements-docs.txt
@@ -6,3 +6,4 @@ mkdocs-macros-plugin
 polib
 regex
 openai
+zhconv


### PR DESCRIPTION
### What this PR does / why we need it?
The auto doc translation workflow occasionally mixes Traditional Chinese characters (繁體字) into Simplified Chinese (zh_CN) PO files, e.g. '環境变量' instead of '环境变量' (see PR #15231 review).

This PR applies two fixes:

1. **Prompt improvement** — Both SYSTEM_PROMPT and TRANSLATION_PROMPT now explicitly request 'Simplified Chinese (简体中文)' as the target language.

2. **Post-processing safety net** — A new _convert_po_to_simplified() function uses zhconv to convert all msgstr values from Traditional to Simplified Chinese before saving, catching any remaining Traditional characters the model may still produce.

### Does this PR introduce _any_ user-facing change?

### How was this patch tested?

- vLLM main: https://github.com/vllm-project/vllm/commit/ba07e4a48fc951300d97eb506217dd530583dea3
