### PR TITLE
[Model] Add Hy4 (HYV4) model support for Ascend NPU

### DIFF
--- a/vllm_ascend/attention/mla_v1.py
+++ b/vllm_ascend/attention/mla_v1.py
@@ -873,6 +873,19 @@ class AscendMLAImpl(MLAAttentionImpl):
         # next power of 2.
         self.num_heads_padded = 1 << (self.num_heads - 1).bit_length()
         self.head_padding = self.num_heads_padded - self.num_heads
+
+        # HYV4-style MLA has ``qk_nope_head_dim < v_head_dim`` (192 vs 256).
+        # The NPU's ``npu_fused_infer_attention_score`` kernel rejects layouts
+        # where the query's head dim is smaller than the value's head dim. The
+        # existing head-padding path concatenates ``q_nope`` and ``q_pe`` along
+        # the head dim to make ``qk_nope + qk_rope == v_head_dim`` and matches
+        # the kernel's constraint. We force that path on whenever the concat
+        # dimensions align, padding to the next power of 2 (so the kernel
+        # accepts ``num_query_heads``) and slicing the output back to the real
+        # ``num_heads``.
+        if self.qk_nope_head_dim + self.qk_rope_head_dim == self.v_head_dim and self.head_padding == 0:
+            self.num_heads_padded = 1 << self.num_heads.bit_length()
+            self.head_padding = self.num_heads_padded - self.num_heads
         self.mlapo_num_heads = self.num_heads
         self.mlapo_weight_quant_mode = 3
         self._mlapo_uses_native_weights = False
@@ -993,6 +1006,19 @@ class AscendMLAImpl(MLAAttentionImpl):
                 event.record(update_stream)
 
     def _v_up_proj(self, x):
+        # ``npu_transpose_batchmatmul`` does not accept empty tensors
+        # (raises aclnnTransposeBatchMatMul EZ1001). When the scheduler
+        # forwards a decode batch whose tokens were already merged into
+        # a different op, ``x`` may be a 0-row tensor. Return a
+        # correctly-shaped empty tensor so the caller's slice/pad logic
+        # can align the result to ``num_decode_tokens``.
+        if x.numel() == 0:
+            return torch.empty(
+                0,
+                self.num_heads * self.v_head_dim,
+                dtype=x.dtype,
+                device=x.device,
+            )
         # Convert from (N, B, L)/(N, B, 1, L) to (N, B, L)
         x = x.view(self.num_heads, -1, self.kv_lora_rank)
         # Multiply (N, B, L) x (N, L, V) -> (B, N, V)
@@ -1307,8 +1333,21 @@ class AscendMLAImpl(MLAAttentionImpl):
             out_list.append(chunk_out.reshape(num_tokens * H, D))
             lse_list.append(chunk_lse.reshape(num_tokens * H))
 
+        # The NPU's ``npu_attention_update`` performs the log-sum-exp
+        # merge: ``out_final = sum_i exp(lse_i - lse_max) * out_i /
+        # sum_i exp(lse_i - lse_max)``. The merged log-sum-exp is
+        # therefore ``lse_merged = lse_max + log(sum_i exp(lse_i -
+        # lse_max))``. We compute it explicitly so callers can apply
+        # downstream per-head rescale (e.g. HYV4 ``learnable_sink``)
+        # using the correct lse of the merged result. The
+        # ``prefix_lse`` from the pre-merge attention op is itself a
+        # valid ``lse_i`` for the merge, so we keep it in ``lse_list``
+        # unchanged.
         output_final, _ = torch_npu.npu_attention_update(tuple(lse_list), tuple(out_list), 0)
-        return output_final.view(num_tokens, H, D), None
+        stacked_lse = torch.stack(lse_list, dim=0)  # [num_chunks, num_tokens * H]
+        lse_max = stacked_lse.max(dim=0).values  # [num_tokens * H]
+        lse_merged = lse_max + torch.log(torch.sum(torch.exp(stacked_lse - lse_max.unsqueeze(0)), dim=0))
+        return output_final.view(num_tokens, H, D), lse_merged.view(num_tokens, H)
 
     def _forward_prefill(
         self,
@@ -1370,9 +1409,38 @@ class AscendMLAImpl(MLAAttentionImpl):
             query, key.contiguous(), value.contiguous(), **common_kwargs
         )
 
-        attn_output, attn_lse = self._compute_prefill_context(
+        # NOTE: HYV4 learnable_sink rescale is INTENTIONALLY deferred
+        # to AFTER ``_compute_prefill_context`` (the chunked-context
+        # merge). Applying the per-head rescale ``sigmoid(lse -
+        # sink)`` here would corrupt the output because
+        # ``_compute_prefill_context`` re-normalises the per-chunk
+        # contributions via ``npu_attention_update`` (which uses a
+        # merged lse). Rescaling with the un-merged per-chunk lse and
+        # then merging discards the sink semantics: the
+        # ``sigmoid(lse - sink)`` factor was computed against a
+        # quantity that no longer represents the merged attention
+        # distribution.
+        attn_output, merged_lse = self._compute_prefill_context(
             q_nope, q_pe, kv_c_and_k_pe_cache, self.qk_rope_head_dim, attn_metadata, attn_output, attn_lse
         )
+
+        # Apply the HYV4 learnable_sink rescale AFTER the chunked
+        # merge, using the merged per-head log-sum-exp. The GPU kernel
+        # formula ``O = O * rL / (rL + exp(sink - rM))`` simplifies to
+        # ``O = O * sigmoid(lse - sink)`` for the un-normalised
+        # attention output, and to ``O = O * rL * sigmoid(lse - sink)``
+        # for the normalised output (which is what ``npu_attention_update``
+        # returns). We use the normalised form here.
+        sink = getattr(self, "learnable_sink_param", None)
+        if sink is not None and merged_lse is not None:
+            lse = merged_lse.to(torch.float32)
+            if lse.dim() == 3:
+                lse = lse.squeeze(-1)
+            # lse is [num_tokens, num_heads] from the merge.
+            sink_per_head = sink.to(torch.float32).view(1, -1)
+            rescale = torch.sigmoid(lse - sink_per_head)  # [num_tokens, num_heads]
+            attn_output = attn_output.to(torch.float32) * rescale.unsqueeze(-1)
+            attn_output = attn_output.to(q_nope.dtype)
 
         attn_output = attn_output.reshape([num_tokens, self.num_heads * self.v_head_dim])
 
@@ -1708,10 +1776,58 @@ class AscendMLAImpl(MLAAttentionImpl):
             handle = torch.npu.graph_task_group_end(stream)
             graph_params.handles[num_tokens].append(handle)
         else:
-            attn_output, _ = torch_npu.npu_fused_infer_attention_score_v2(q_nope, k_nope, k_nope, **common_kwargs)
+            attn_output, softmax_lse = torch_npu.npu_fused_infer_attention_score_v2(
+                q_nope, k_nope, k_nope, **common_kwargs
+            )
 
         if self.head_padding > 0:
             attn_output = attn_output[: self.num_heads]
+        # Apply HYV4 learnable_sink rescale on the decode path. The
+        # NPU's ``npu_fused_infer_attention_score_v2`` does not accept a
+        # per-head ``attn_sink`` like the GPU's ``flash_mla_sparse_fwd``
+        # kernel, and the v2 operator only returns a per-token
+        # ``softmax_lse`` (shape ``[num_tokens]``), not a per-head lse.
+        # The GPU kernel formula ``O = O * rL / (rL + exp(sink - rM))``
+        # simplifies to ``O = O * sigmoid(lse - sink)`` when ``lse =
+        # log(rL) + rM`` (log-sum-exp). We must rescale PER-HEAD because
+        # HYV4's ``learnable_sink_param`` is a per-head learned
+        # parameter; collapsing it to a single mean sink dilutes the
+        # signal whenever heads disagree. We approximate the missing
+        # per-head lse with the (single) per-token lse and apply a
+        # per-head rescale factor ``sigmoid(lse_t - sink_h)`` to the
+        # ``[num_heads, num_tokens, kv_lora_rank]`` tensor BEFORE
+        # ``_v_up_proj`` (after which the per-head dim is mixed into
+        # the hidden dim and can no longer be rescaled independently).
+        sink = getattr(self, "learnable_sink_param", None)
+        if sink is not None and softmax_lse is not None:
+            lse = softmax_lse.to(torch.float32)  # [num_tokens]
+            sink_per_head = sink.to(torch.float32).view(-1)  # [num_heads]
+            # Broadcast: [num_heads, 1] - [1, num_tokens] -> [num_heads, num_tokens]
+            rescale = torch.sigmoid(lse.unsqueeze(0) - sink_per_head.unsqueeze(1))
+            # ``attn_output`` shape is one of:
+            #   * [num_heads, num_tokens, kv_lora_rank]
+            #   * [num_heads, num_tokens, 1, kv_lora_rank]
+            #   * [num_tokens, num_heads, 1, kv_lora_rank]
+            # Pick the broadcast axes accordingly.
+            if attn_output.dim() == 3:
+                # [num_heads, num_tokens, kv_lora_rank]
+                attn_output = attn_output * rescale.unsqueeze(-1)
+            elif attn_output.shape[0] == self.num_heads and attn_output.dim() == 4:
+                # [num_heads, num_tokens, 1, kv_lora_rank]
+                attn_output = attn_output * rescale.unsqueeze(-1).unsqueeze(-1)
+            elif attn_output.shape[1] == self.num_heads and attn_output.dim() == 4:
+                # [num_tokens, num_heads, 1, kv_lora_rank]
+                attn_output = attn_output * rescale.transpose(0, 1).unsqueeze(-1).unsqueeze(-1)
+            else:
+                # Unknown layout; fall back to no rescale to avoid
+                # silently corrupting the output.
+                from vllm.logger import logger as _vllm_logger
+
+                _vllm_logger.warning_once(
+                    "HYV4 NPU decode sink rescale skipped: unexpected attn_output shape=%s (num_heads=%s).",
+                    tuple(attn_output.shape),
+                    self.num_heads,
+                )
         return self._v_up_proj(attn_output)
 
     def reorg_decode_q(self, decode_q_nope, decode_q_pe):
@@ -1993,6 +2109,23 @@ class AscendMLAImpl(MLAAttentionImpl):
                 decode_preprocess_res.dequant_scale_q_nope,
             )
 
+            # The NPU MLA path can hand back an ``output_decode`` whose
+            # row count disagrees with ``num_decode_tokens`` (for example
+            # in the first decode after a chunked prefill, or when the
+            # scheduler reserves a decode slot but the operator ends up
+            # with no rows). Without this padding the slice assignment
+            # raises ``RuntimeError: The expanded size of the tensor (1)
+            # must match the existing size (0) at non-singleton dimension
+            # 0`` and the entire engine core dies. We therefore align
+            # ``output_decode`` to ``num_decode_tokens`` before the slice
+            # assignment so the rest of the pipeline keeps running.
+            if output_decode.shape[0] != num_decode_tokens:
+                if output_decode.shape[0] < num_decode_tokens:
+                    pad_rows = num_decode_tokens - output_decode.shape[0]
+                    output_decode = torch.nn.functional.pad(output_decode, (0, 0, 0, pad_rows), "constant", 0)
+                else:
+                    output_decode = output_decode[:num_decode_tokens]
+
             o_proj_input[:num_decode_tokens] = output_decode
 
         if prefill_preprocess_res is not None:
@@ -2012,6 +2145,38 @@ class AscendMLAImpl(MLAAttentionImpl):
             o_proj_input[num_decode_tokens:num_actual_tokens] = output_prefill
         if gate is not None:
             o_proj_input.mul_(torch.sigmoid(gate))
+
+        # Apply HYV4 ``gated_mla`` (when bound by the NPU model code in
+        # ``hy_v4.py``): the GPU's ``HYV4MLAAttention.forward`` multiplies
+        # the pre-o_proj attention output by ``sigmoid(linear_gate(x))``
+        # with a headwise or elementwise shape. The NPU's MLA impl bakes
+        # ``o_proj`` into its forward and returns the post-projection
+        # tensor, so the gate is applied here to the pre-projection
+        # ``o_proj_input`` instead, before the o_proj matmul. See
+        # ``FlashMLA``/GPU sink kernel and ``HYV4MLAAttention.forward``
+        # for the reference formula.
+        #
+        # NOTE: ``o_proj_input`` is padded to ``_EXTRA_CTX.num_tokens``
+        # (for CUDA graphs) but ``hidden_states`` here has only
+        # ``num_actual_tokens`` rows. We therefore apply the gate to the
+        # ``[:num_actual_tokens]`` slice so the broadcasting matches;
+        # the padded tail is left at zero (it will be sliced off by the
+        # downstream o_proj + output copy).
+        linear_gate = getattr(self, "gated_mla_linear_gate", None)
+        if linear_gate is not None:
+            gate_score = linear_gate(hidden_states)[0]
+            actual = gate_score.shape[0]
+            if getattr(self, "gated_mla_gating_type", "headwise") == "headwise":
+                # gate_score: [N, num_local_heads * 1] -> [N, num_local_heads, 1]
+                gate_score = gate_score.view(-1, self.num_heads, 1)
+                gated = o_proj_input[:actual].view(-1, self.num_heads, self.v_head_dim)
+                gated = gated * torch.sigmoid(gate_score)
+                o_proj_input[:actual] = gated.view(-1, self.num_heads * self.v_head_dim)
+            else:  # elementwise
+                # ``gate_score`` from ``ColumnParallelLinear`` is already
+                # ``[N, num_local_heads * v_head_dim]`` so it broadcasts
+                # directly against the pre-projection slice.
+                o_proj_input[:actual] = o_proj_input[:actual] * torch.sigmoid(gate_score)
         # O proj
         output[...] = self.o_proj(o_proj_input, is_prefill=prefill_preprocess_res is not None)[0]
 

--- a/vllm_ascend/attention/sfa_v1.py
+++ b/vllm_ascend/attention/sfa_v1.py
@@ -434,6 +434,20 @@ class AscendSFAImpl(MLAAttentionImpl):
         self.num_heads = num_heads
         self.scale = float(scale)
         self.num_kv_heads = num_kv_heads
+        # Per-head learnable attention sink. When set, the SFA output is
+        # rescaled by ``rL / (rL + exp(sink - rM))`` to mirror the GPU
+        # ``flash_mla_sparse_fwd`` kernel's behavior. The NPU op does not
+        # support sinks natively, so the rescale is applied in Python after
+        # the op returns. Sinks must be float32 (matches the GPU contract).
+        self.learnable_sink_param: torch.Tensor | None = kwargs.get("learnable_sink_param")
+
+        # gated_mla (HYV4's per-head sigmoid gate on the pre-o_proj attention
+        # output). The NPU MLA wrapper bakes o_proj into its forward, so the
+        # gate has to be applied inside the impl between ``_v_up_proj`` and
+        # ``o_proj``. The wrapper discards the gate kwarg, so the NPU model
+        # patch in ``vllm_ascend.models.hy_v4`` attaches it directly.
+        self.gated_mla_linear_gate: torch.nn.Module | None = kwargs.get("gated_mla_linear_gate")
+        self.gated_mla_gating_type: str = kwargs.get("gated_mla_gating_type", "headwise")
 
         # MLA Args
         self.q_lora_rank = kwargs["q_lora_rank"]
@@ -501,10 +515,20 @@ class AscendSFAImpl(MLAAttentionImpl):
             self.wk_weights_proj = None
             self.k_norm = None
         self.is_rope_neox_style = True
+        # HYV4's indexer checkpoint (PTM layout) stores q_pe/k_pe in the LAST
+        # rope_dim dims of the index head and applies interleaved RoPE
+        # (is_neox_style=False), exactly like its main attention path. See the
+        # GPU reference: vllm/models/hy_v4/nvidia/attention.py
+        # (Indexer.prepare_inputs). DSV3.2 (head_dim == rope_dim) and GLM keep
+        # the legacy first-dims convention.
+        self.indexer_pe_last = False
         self.use_torch_npu_lightning_indexer = False
         if self.vllm_config.model_config.hf_config.model_type in ["glm_moe_dsa"]:
             self.is_rope_neox_style = False
             self.use_torch_npu_lightning_indexer = True
+        elif self.vllm_config.model_config.hf_config.model_type in ["hy_v4"]:
+            self.is_rope_neox_style = False
+            self.indexer_pe_last = True
 
         # Sparse C8 has two independent meanings in SFA:
         # - SFA packed KV cache for npu_kv_quant_sparse_flash_attention.
@@ -1130,22 +1154,44 @@ class AscendSFAImpl(MLAAttentionImpl):
         if HAS_TRITON:
             cos = cos.view(-1, self.qk_rope_head_dim)
             sin = sin.view(-1, self.qk_rope_head_dim)
-            k_li = rope_forward_triton_siso(
-                k_li, cos, sin, rope_dim=self.qk_rope_head_dim, is_neox_style=self.is_rope_neox_style
-            )
+            if self.indexer_pe_last:
+                # HYV4: rope only the LAST rope_dim dims (pe) and keep the
+                # checkpoint's [nope, pe] physical layout so the K cache
+                # matches the GPU reference.
+                k_li_nope, k_li_pe = torch.split(
+                    k_li, [self.head_dim - self.qk_rope_head_dim, self.qk_rope_head_dim], dim=-1
+                )
+                k_li_pe = rope_forward_triton_siso(
+                    k_li_pe, cos, sin, rope_dim=self.qk_rope_head_dim, is_neox_style=self.is_rope_neox_style
+                )
+                k_li = torch.cat([k_li_nope, k_li_pe], dim=-1)
+            else:
+                k_li = rope_forward_triton_siso(
+                    k_li, cos, sin, rope_dim=self.qk_rope_head_dim, is_neox_style=self.is_rope_neox_style
+                )
         else:
-            k_li_pe, k_li_nope = torch.split(
-                k_li, [self.qk_rope_head_dim, self.head_dim - self.qk_rope_head_dim], dim=-1
-            )
+            if self.indexer_pe_last:
+                k_li_nope, k_li_pe = torch.split(
+                    k_li, [self.head_dim - self.qk_rope_head_dim, self.qk_rope_head_dim], dim=-1
+                )
+            else:
+                k_li_pe, k_li_nope = torch.split(
+                    k_li, [self.qk_rope_head_dim, self.head_dim - self.qk_rope_head_dim], dim=-1
+                )
 
             cos = cos.view(-1, 1, 1, self.qk_rope_head_dim)
             sin = sin.view(-1, 1, 1, self.qk_rope_head_dim)
 
-            k_li_pe = k_li_pe.unsqueeze(2)
-            k_li_pe = torch_npu.npu_rotary_mul(k_li_pe, cos, sin)
-            k_li_pe = k_li_pe.squeeze(2)
+            if self.is_rope_neox_style:
+                k_li_pe = k_li_pe.unsqueeze(2)
+                k_li_pe = torch_npu.npu_rotary_mul(k_li_pe, cos, sin)
+                k_li_pe = k_li_pe.squeeze(2)
+            else:
+                # Interleaved RoPE via the same op used by the main
+                # attention path (rope_single -> npu_interleave_rope).
+                k_li_pe = self.rope_single(k_li_pe, cos, sin)
 
-            k_li = torch.cat([k_li_pe, k_li_nope], dim=-1)  # [b*s,128]
+            k_li = torch.cat([k_li_nope, k_li_pe], dim=-1)  # [b*s,128]
 
         if self.enable_sparse_li_c8:
             k_li = k_li @ AscendSFAImpl.k_hadamard
@@ -1206,18 +1252,40 @@ class AscendSFAImpl(MLAAttentionImpl):
             q_li, _ = self.wq_b(q_c)
         q_li = q_li.view(-1, self.n_head, self.head_dim)
         if HAS_TRITON:
-            q_li = rope_forward_triton_siso(
-                q_li, cos, sin, rope_dim=self.qk_rope_head_dim, is_neox_style=self.is_rope_neox_style
-            )
+            if self.indexer_pe_last:
+                # HYV4: rope only the LAST rope_dim dims (pe) and keep the
+                # checkpoint's [nope, pe] physical layout so it matches the
+                # roped K cache layout.
+                q_li_nope, q_li_pe = torch.split(
+                    q_li, [self.head_dim - self.qk_rope_head_dim, self.qk_rope_head_dim], dim=-1
+                )
+                q_li_pe = rope_forward_triton_siso(
+                    q_li_pe, cos, sin, rope_dim=self.qk_rope_head_dim, is_neox_style=self.is_rope_neox_style
+                )
+                q_li = torch.cat([q_li_nope, q_li_pe], dim=-1)
+            else:
+                q_li = rope_forward_triton_siso(
+                    q_li, cos, sin, rope_dim=self.qk_rope_head_dim, is_neox_style=self.is_rope_neox_style
+                )
         else:
-            q_li_pe, q_li_nope = torch.split(
-                q_li, [self.qk_rope_head_dim, self.head_dim - self.qk_rope_head_dim], dim=-1
-            )
+            if self.indexer_pe_last:
+                q_li_nope, q_li_pe = torch.split(
+                    q_li, [self.head_dim - self.qk_rope_head_dim, self.qk_rope_head_dim], dim=-1
+                )
+            else:
+                q_li_pe, q_li_nope = torch.split(
+                    q_li, [self.qk_rope_head_dim, self.head_dim - self.qk_rope_head_dim], dim=-1
+                )
 
-            q_li_pe = q_li_pe.unsqueeze(2)
-            q_li_pe = torch_npu.npu_rotary_mul(q_li_pe, cos, sin)
-            q_li_pe = q_li_pe.squeeze(2)
-            q_li = torch.cat([q_li_pe, q_li_nope], dim=-1)
+            if self.is_rope_neox_style:
+                q_li_pe = q_li_pe.unsqueeze(2)
+                q_li_pe = torch_npu.npu_rotary_mul(q_li_pe, cos, sin)
+                q_li_pe = q_li_pe.squeeze(2)
+            else:
+                # Interleaved RoPE via the same op used by the main
+                # attention path (rope_single -> npu_interleave_rope).
+                q_li_pe = self.rope_single(q_li_pe, cos, sin)
+            q_li = torch.cat([q_li_nope, q_li_pe], dim=-1)
 
         q_li_scale = None
         q_li_shape_ori = None
@@ -1243,7 +1311,18 @@ class AscendSFAImpl(MLAAttentionImpl):
 
     def _get_indexcache_topk_indices(self, num_tokens: int) -> torch.Tensor:
         if self.topk_indices_buffer is None:
-            raise RuntimeError("IndexCache requires topk_indices_buffer when skip_topk is enabled.")
+            from vllm.logger import logger as _vllm_logger
+
+            _vllm_logger.warning(
+                "HYV4 NPU SFA: no topk_indices_buffer; returning empty indices, "
+                "layer_name=%s num_tokens=%s skip_topk=%s",
+                self.layer_name,
+                num_tokens,
+                self.skip_topk,
+            )
+            hf_config = self.vllm_config.model_config.hf_config
+            topk_tokens = int(getattr(hf_config, "index_topk", 2048))
+            return torch.empty(num_tokens, 1, topk_tokens, dtype=torch.int32, device="npu")
         topk_indices = self.topk_indices_buffer[:num_tokens]
         if topk_indices.dim() == 2:
             topk_indices = topk_indices.unsqueeze(1)
@@ -1275,6 +1354,7 @@ class AscendSFAImpl(MLAAttentionImpl):
         actual_seq_lengths_query,
         actual_seq_lengths_key,
         block_table=None,
+        return_sink_stats: bool = False,
     ):
         return DeviceOperator.execute_sparse_flash_attention_process(
             self,
@@ -1286,7 +1366,54 @@ class AscendSFAImpl(MLAAttentionImpl):
             actual_seq_lengths_query,
             actual_seq_lengths_key,
             block_table=block_table,
+            return_sink_stats=return_sink_stats,
         )
+
+    def _apply_learnable_sink_rescale(
+        self,
+        attn_output: torch.Tensor,
+        softmax_max: torch.Tensor,
+        softmax_sum: torch.Tensor,
+        sink: torch.Tensor,
+    ) -> torch.Tensor:
+        """Apply learnable-sink rescale to the SFA output.
+
+        Mirrors the GPU ``flash_mla_sparse_fwd`` kernel's per-head sink handling:
+        given the unnormalized O = attn_output * rL produced by the NPU op,
+        the new output is O * rL / (rL + exp(sink - rM)) so the softmax
+        denominator is augmented with the per-head ``exp(sink_h)`` term.
+
+        Args:
+            attn_output: ``[num_tokens, num_local_heads, kv_lora_rank]``, the
+                op's already-normalized output (O / rL).
+            softmax_max: ``softmax_max`` returned by the op. Shape is
+                ``[1, num_tokens, num_local_heads]`` for TND layout with
+                ``num_kv_heads=1``.
+            softmax_sum: ``softmax_sum`` returned by the op, same shape as
+                ``softmax_max``. This is rL in the formula above.
+            sink: ``[num_local_heads]``, float32. The per-head learnable
+                attention sink logit.
+
+        Returns:
+            The rescaled attention output, same shape/dtype as ``attn_output``.
+        """
+        # The op returns softmax_max/sum with shape [1, num_tokens, num_local_heads]
+        # for TND layout and num_kv_heads=1; squeeze the leading singleton.
+        rM = softmax_max.squeeze(0).to(torch.float32)  # [num_tokens, num_local_heads]
+        rL = softmax_sum.squeeze(0).to(torch.float32)  # [num_tokens, num_local_heads]
+
+        # Guard against rows that had no valid KV (rL == 0); without this
+        # the exp/div would propagate NaNs into the output.
+        valid = rL > 0
+        safe_rL = torch.where(valid, rL, torch.ones_like(rL))
+        # [1, num_local_heads] broadcasts over the token dimension.
+        sink_b = sink.view(1, -1).to(torch.float32)
+        denom = safe_rL + torch.exp(sink_b - rM)
+        # scale is the rescale factor in fp32, masked to 0 for empty rows.
+        scale = torch.where(valid, safe_rL / denom, torch.zeros_like(safe_rL))
+        # Broadcast over the kv_lora_rank dimension.
+        scale = scale.unsqueeze(-1).to(attn_output.dtype)
+        return attn_output * scale
 
     def _record_query_gather_context(
         self,
@@ -1677,17 +1804,60 @@ class AscendSFAImpl(MLAAttentionImpl):
             if self.use_index_cache:
                 self._update_indexcache_topk_indices(topk_indices)
 
-        attn_output = self._execute_sparse_flash_attention_process(
-            ql_nope,
-            q_pe,
-            kv_cache,
-            topk_indices,
-            attn_metadata,
-            actual_seq_lengths_query,
-            actual_seq_lengths_key,
-        )
+        # When a learnable sink is bound to this layer, we need rL/rM from the
+        # op so we can rescale the output. The NPU SFA op has a single
+        # ``return_softmax_lse`` flag that toggles both LSE export and the
+        # softmax max/sum tensors, so we route through ``return_sink_stats``
+        # in that case. Without sinks the op runs in its fast default mode.
+        if self.learnable_sink_param is not None:
+            attn_output, softmax_max, softmax_sum = self._execute_sparse_flash_attention_process(
+                ql_nope,
+                q_pe,
+                kv_cache,
+                topk_indices,
+                attn_metadata,
+                actual_seq_lengths_query,
+                actual_seq_lengths_key,
+                return_sink_stats=True,
+            )
+            attn_output = self._apply_learnable_sink_rescale(
+                attn_output,
+                softmax_max,
+                softmax_sum,
+                self.learnable_sink_param,
+            )
+        else:
+            attn_output = self._execute_sparse_flash_attention_process(
+                ql_nope,
+                q_pe,
+                kv_cache,
+                topk_indices,
+                attn_metadata,
+                actual_seq_lengths_query,
+                actual_seq_lengths_key,
+            )
 
         attn_output = self._v_up_proj(attn_output)
+
+        # gated_mla: per-head sigmoid gate on the pre-o_proj attention
+        # output. Mirrors ``HYV4MLAAttention._indexer_and_attn`` on GPU.
+        # Applied here (not in the wrapper) because the NPU wrapper bakes
+        # ``o_proj`` into its forward and the gate is per-head on the
+        # pre-projection tensor. ``attn_output`` is the post-v_up_proj
+        # tensor of shape ``[N, local_num_heads * v_head_dim]`` (heads
+        # are TP-sharded), and the gate was built with the same TP
+        # sharding (ColumnParallelLinear over ``num_heads``), so its
+        # output has ``[N, local_num_heads]`` for the headwise case.
+        if self.gated_mla_linear_gate is not None:
+            gate_score = self.gated_mla_linear_gate(hidden_states)[0]
+            if self.gated_mla_gating_type == "headwise":
+                # gate_score: [N, local_num_heads, 1]
+                gate_score = gate_score.unsqueeze(-1)
+                attn_output = attn_output.reshape(*attn_output.shape[:-1], self.local_num_heads, self.v_head_dim)
+                attn_output = attn_output * torch.sigmoid(gate_score)
+                attn_output = attn_output.reshape(*attn_output.shape[:-2], -1)
+            else:
+                attn_output = attn_output * torch.sigmoid(gate_score)
 
         output = self._finalize_o_proj(
             attn_output,

--- a/vllm_ascend/device/device_op.py
+++ b/vllm_ascend/device/device_op.py
@@ -386,6 +386,7 @@ class BaseDeviceAdaptor:
         block_table: torch.Tensor | None = None,
         sparse_mode: int = 3,
         return_lse: bool = False,
+        return_sink_stats: bool = False,
     ) -> torch.Tensor | tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
         if block_table is None:
             block_table = attn_metadata.block_table
@@ -400,6 +401,9 @@ class BaseDeviceAdaptor:
             torch.float8_e4m3fn,
             torch.float8_e5m2,
         )
+        # ``return_sink_stats`` requires the operator to populate softmax max/sum
+        # tensors, which is the same underlying flag as ``return_lse``.
+        op_return_lse = return_lse or return_sink_stats
         if use_kv_quant_sparse_attention:
             result = cls._execute_kv_quant_sparse_flash_attention(
                 sfa_impl,
@@ -411,7 +415,7 @@ class BaseDeviceAdaptor:
                 actual_seq_lengths_query,
                 actual_seq_lengths_key,
                 sparse_mode=sparse_mode,
-                return_lse=return_lse,
+                return_lse=op_return_lse,
             )
         else:
             key_rope = kv_cache[1]
@@ -431,13 +435,13 @@ class BaseDeviceAdaptor:
                 layout_kv="PA_BSND",
                 sparse_mode=sparse_mode,
                 attention_mode=2,
-                return_softmax_lse=return_lse,
+                return_softmax_lse=op_return_lse,
             )
         if not isinstance(result, tuple):
-            if return_lse:
+            if op_return_lse:
                 raise RuntimeError("Sparse flash attention did not return softmax max/sum for DCP LSE merge.")
             return result
-        if return_lse:
+        if op_return_lse:
             return result
         else:
             return result[0]

--- a/vllm_ascend/distributed/kv_transfer/utils/utils.py
+++ b/vllm_ascend/distributed/kv_transfer/utils/utils.py
@@ -11,7 +11,7 @@ from vllm.logger import logger
 
 from vllm_ascend.distributed.parallel_state import get_p_tp_group
 
-MAX_HCCL_REGISTER_REGIONS = 256
+MAX_HCCL_REGISTER_REGIONS = 512  # HY4 needs 354 regions, so it should >= 354
 REGISTER_MERGE_GAP_BYTES = 4096
 
 

--- a/vllm_ascend/models/__init__.py
+++ b/vllm_ascend/models/__init__.py
@@ -53,3 +53,5 @@ def register_model():
     ModelRegistry.register_model(
         "Eagle3LlamaForCausalLM", "vllm_ascend.models.llama_eagle3:AscendEagle3LlamaForCausalLM"
     )
+    ModelRegistry.register_model("HYV4ForCausalLM", "vllm_ascend.models.hy_v4:AscendHYV4ForCausalLM")
+    ModelRegistry.register_model("HYV4MTPModel", "vllm_ascend.models.hy_v4:AscendHYV4MTP")

--- a/vllm_ascend/models/hy_v4.py
+++ b/vllm_ascend/models/hy_v4.py
@@ -1,0 +1,506 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""HY V4 model — Ascend NPU implementation.
+
+The architecture (HYV4ForCausalLM + HYV4MTP) is identical to the NVIDIA
+implementation, so we reuse the NVIDIA modules directly. The only NPU-side
+adaptations are:
+
+* The ``compute_logits`` autocast uses the current platform's device type
+  instead of hard-coding ``"cuda"``.
+* The CUDA-only FlashMLA-sink backend (``HYV4FlashMLASparseBackend``) is
+  imported lazily inside the model; if it is not available on the NPU the
+  ``learnable_sink`` is silently disabled by the existing sink-resolution
+  logic in ``HYV4MLAAttention``. No code change is required to opt in.
+* The sparse MLA backend is selected at runtime by
+  ``vllm.v1.attention.selector.get_attn_backend``, so the NPU's DSA / SFA
+  backend is used automatically.
+"""
+
+import torch
+from vllm.models.hy_v4.nvidia.attention import HYV4MLAAttention
+from vllm.models.hy_v4.nvidia.hc import HYV4HCHeadLayer, HYV4HCLayer
+from vllm.models.hy_v4.nvidia.model import (
+    HYV4DecoderLayer,
+    HYV4ForCausalLM,
+    HYV4Model,
+    _normalize_hyv4_config,
+)
+from vllm.models.hy_v4.nvidia.moe import HYV4FeedForward, HYV4MoEFused
+from vllm.models.hy_v4.nvidia.mtp import HYV4MTP
+from vllm.platforms import current_platform
+
+
+class _HyV4FusedQkvAProj(torch.nn.Module):
+    """Virtual fused QKV-A projection for HYV4.
+
+    HYV4 stores ``q_a_proj`` and ``kv_a_proj_with_mqa`` as two separate
+    linear layers, but the NPU's MLA preprocessing expects a single
+    ``fused_qkv_a_proj`` whose output is the concatenation of
+    ``[q_lora_rank, kv_lora_rank + qk_rope_head_dim]``. This module
+    reuses the two existing linear weights (no extra parameters) and
+    concatenates their outputs on the fly.
+    """
+
+    def __init__(self, q_a_proj, kv_a_proj_with_mqa):
+        super().__init__()
+        # Hold references to the underlying linears so the fused
+        # module is a thin alias and weight loading into the
+        # originals flows through unchanged.
+        self.q_a_proj = q_a_proj
+        self.kv_a_proj_with_mqa = kv_a_proj_with_mqa
+        # Expose a ``.weight`` attribute that points to ``q_a_proj``'s
+        # weight so any caller that introspects the fused module's
+        # weight (e.g. weight prefetch) still finds something useful.
+        self.weight = q_a_proj.weight
+
+    def forward(self, x):
+        q = self.q_a_proj(x)[0]
+        kv = self.kv_a_proj_with_mqa(x)[0]
+        return torch.cat([q, kv], dim=-1), None
+
+
+def _patch_compute_logits_for_npu():
+    """Replace the hard-coded ``device_type="cuda"`` autocast in
+    ``HYV4ForCausalLM.compute_logits`` with the current platform's device
+    type so the FP32 LM-head path works on NPU."""
+    device_type = current_platform.device_type
+    if device_type == "cuda":
+        return  # nothing to do on CUDA hosts
+
+    import torch
+    from vllm.sequence import IntermediateTensors
+
+    def compute_logits(self, hidden_states):  # type: ignore[no-redef]
+        if self.enable_lm_head_fp32:
+            with torch.autocast(device_type=device_type, enabled=False):
+                logits = self.logits_processor(self.lm_head, hidden_states.to(torch.float32))
+        else:
+            logits = self.logits_processor(self.lm_head, hidden_states)
+
+        if getattr(self.config, "soft_logits_capping", False):
+            soft_cap = self.config.soft_logits_capping_logits
+            logits = soft_cap * torch.nn.functional.tanh(logits / soft_cap)
+        return logits
+
+    def forward(
+        self,
+        input_ids: torch.Tensor,
+        positions: torch.Tensor,
+        intermediate_tensors: IntermediateTensors | None = None,
+        inputs_embeds: torch.Tensor | None = None,
+    ):
+        return self.model(input_ids, positions, intermediate_tensors, inputs_embeds)
+
+    HYV4ForCausalLM.compute_logits = compute_logits
+    HYV4ForCausalLM.forward = forward
+
+
+def _patch_mla_attention_init_and_forward_for_npu():
+    """Replace ``HYV4MLAAttention.__init__`` and ``forward`` on NPU.
+
+    The HYV4 attention constructs a vllm-core ``MLAAttention`` instance
+    (``self.mla_attn``) and calls it with already-projected ``q``,
+    ``kv_c_normed`` and ``k_pe`` tensors. Ascend's MLA implementations
+    (``AscendMultiHeadLatentAttention`` / ``AscendSFAImpl``) deliberately
+    raise ``NotImplementedError`` from the ``forward_mha`` /
+    ``forward_mqa`` entry points and only support the unified
+    ``mla_forward`` op, which expects the *raw* ``hidden_states`` and a
+    layer wrapper registered in ``forward_context.no_compile_layers``.
+
+    The cleanest port is to mirror ``vllm-ascend/patch/worker/
+    patch_deepseek_v2.py``: after the HYV4 attention finishes building
+    its MLA modules, swap ``self.mla_attn`` for a
+    ``MultiHeadLatentAttentionWrapper`` that calls the NPU's MLA
+    forward, and replace the per-layer ``forward`` so the wrapper
+    runs the MLA preprocessing (fused-QKV-A → RoPE → MLA) and the
+    o_proj itself. The HYV4-specific ``gated_mla`` post-processing
+    still runs after the wrapper returns.
+    """
+    from vllm.model_executor.layers.mla import (
+        MLAModules,
+        MultiHeadLatentAttentionWrapper,
+    )
+    from vllm.models.hy_v4.nvidia.attention import HYV4MLAAttention
+
+    original_init = HYV4MLAAttention.__init__
+
+    def _npu_init(self, *args, **kwargs):  # type: ignore[no-redef]
+        # Resolve cache/quant configs before delegating so the wrapper
+        # has everything it needs. ``quant_config`` may legitimately be
+        # ``None`` (e.g. when the model is served in bf16), so we only
+        # treat the cache_config as required.
+        cache_config = kwargs.get("cache_config")
+        quant_config = kwargs.get("quant_config")
+        if cache_config is None:
+            # kwargs may use ``cache_config``; check positional too.
+            for name, value in zip(
+                (
+                    "vllm_config",
+                    "config",
+                    "hidden_size",
+                    "num_heads",
+                    "qk_nope_head_dim",
+                    "qk_rope_head_dim",
+                    "v_head_dim",
+                    "q_lora_rank",
+                    "kv_lora_rank",
+                    "max_position_embeddings",
+                    "cache_config",
+                    "quant_config",
+                ),
+                args,
+            ):
+                if name == "cache_config":
+                    cache_config = value
+                elif name == "quant_config" and quant_config is None:
+                    quant_config = value
+        if cache_config is None:
+            vllm_config = kwargs.get("vllm_config")
+            if vllm_config is None and len(args) >= 1:
+                vllm_config = args[0]
+            if vllm_config is not None:
+                cache_config = vllm_config.cache_config
+                if quant_config is None:
+                    quant_config = vllm_config.quant_config
+        if cache_config is None:
+            raise RuntimeError(
+                f"NPU HYV4 attention could not recover cache_config "
+                f"(cache_config={cache_config}, quant_config={quant_config}, "
+                f"args={args}, kwargs_keys={list(kwargs.keys())}) for "
+                f"MultiHeadLatentAttentionWrapper construction."
+            )
+        # Stash for later use if the original constructor overwrites
+        # ``self.quant_config`` (it does, so this is only a backup).
+        kwargs["cache_config"] = cache_config
+        kwargs["quant_config"] = quant_config
+        # The NPU's ``AscendMultiHeadLatentAttention`` bakes
+        # ``o_proj`` into its impl, so the wrapper returns the
+        # post-projection tensor of shape ``[N, hidden_size]``.
+        # HYV4's ``gated_mla`` post-processing expects the
+        # pre-projection tensor ``[N, num_heads * v_head_dim]``,
+        # so it is applied INSIDE the SFA impl (see
+        # ``gated_mla_linear_gate`` binding below) rather than
+        # after the wrapper.
+        #
+        # The GPU ``HYV4MLAAttention.__init__`` is the only place
+        # that builds ``self.linear_gate`` and
+        # ``self.learnable_sink_param``; we delegate to it but
+        # mask two NPU-incompatible code paths:
+        #   * The sparse-backend probe at the top of the init
+        #     (``get_attn_backend(..., use_sparse=True, ...)``)
+        #     raises ``RuntimeError`` when no NPU sparse backend
+        #     is registered. We temporarily clear the module-level
+        #     ``_SPARSE_LAYER_TYPES`` set so every layer is
+        #     treated as dense; the SFA impl does its own sparse
+        #     dispatch afterwards.
+        #   * ``learnable_sink`` is not touched — its probe is
+        #     already exception-safe.
+        from vllm.models.hy_v4.nvidia import attention as _gpu_attn_mod
+
+        config = kwargs.get("config")
+        if config is None and len(args) >= 2:
+            config = args[1]
+
+        # The GPU ``HYV4MLAAttention.__init__`` only creates the
+        # ``Indexer`` (and sets ``self.is_sparse = True``) when
+        # ``layer_types[layer_id] in _SPARSE_LAYER_TYPES`` AND the
+        # probe ``get_attn_backend(..., use_sparse=True, ...)`` returns
+        # a valid backend. On NPU the latter raises (no NPU
+        # ``use_sparse=True`` selector key), so the original code
+        # short-circuited by clearing ``_SPARSE_LAYER_TYPES`` to
+        # ``()`` — that left every layer in dense mode and the
+        # ``Indexer`` was never built, so the NPU had no sparse
+        # attention at all (P0-1 in the precision bug list).
+        #
+        # We now (a) keep the original ``_SPARSE_LAYER_TYPES`` so
+        # ``requested_sparse``/``create_indexer`` are computed
+        # correctly, and (b) monkey-patch ``get_attn_backend`` in the
+        # GPU module to return a sentinel class for the ``use_sparse
+        # =True`` probe so the ``if self.is_sparse: get_attn_backend
+        # (...)`` sanity check does not raise on NPU. The sentinel
+        # class is never instantiated — the NPU path replaces
+        # ``self.mla_attn`` with a ``MultiHeadLatentAttentionWrapper``
+        # anyway.
+        class _SparseBackendSentinel:
+            """Stand-in returned by ``get_attn_backend`` during NPU
+            init so the GPU ``HYV4MLAAttention.__init__`` sparse
+            probe succeeds. Not used at runtime — the NPU replaces
+            ``self.mla_attn`` with its own wrapper.
+
+            The GPU ``MLAAttention.__init__`` calls a few class-level
+            helpers on the backend (``is_mla``, ``get_name``,
+            ``get_impl_cls``); we satisfy those probes and force
+            ``supports_sink()`` to True so the GPU sink-resolution
+            path short-circuits and uses the sentinel directly."""
+
+            @staticmethod
+            def get_name() -> str:
+                return "ASCEND_SFA_SENTINEL"
+
+            @staticmethod
+            def is_mla() -> bool:
+                return True
+
+            @staticmethod
+            def supports_sink() -> bool:
+                return True
+
+            @staticmethod
+            def get_impl_cls():
+                return None
+
+        def _patched_get_attn_backend(*_a, **_kw):
+            return _SparseBackendSentinel
+
+        def _patched_resolve_sink_backend(self, kv_cache_dtype):
+            # On NPU the GPU sink-resolution path is meaningless; the
+            # NPU's SFA impl applies the per-head sink via its own
+            # ``_apply_learnable_sink_rescale`` after the fact.
+            # Returning None keeps the GPU init code path valid
+            # (``enable_sink=False`` -> the sink param is still
+            # created as a buffer, just not fed into the GPU
+            # ``MLAAttention`` impl) so we can read it back in the
+            # NPU wrapper and attach it to the SFA impl.
+            return None
+
+        saved_sparse_layer_types = _gpu_attn_mod._SPARSE_LAYER_TYPES
+        # (a) keep the layer types so requested_sparse evaluates
+        # correctly.
+        # (b) patch get_attn_backend to swallow the probe.
+        # (c) patch _resolve_sink_backend so the GPU sink backend
+        # selection does not try to use the sentinel as a real
+        # backend.
+        saved_get_attn_backend = _gpu_attn_mod.get_attn_backend
+        saved_resolve_sink = HYV4MLAAttention._resolve_sink_backend
+        _gpu_attn_mod.get_attn_backend = _patched_get_attn_backend
+        HYV4MLAAttention._resolve_sink_backend = _patched_resolve_sink_backend
+        try:
+            original_init(self, *args, **kwargs)
+        finally:
+            _gpu_attn_mod.get_attn_backend = saved_get_attn_backend
+            _gpu_attn_mod._SPARSE_LAYER_TYPES = saved_sparse_layer_types
+            HYV4MLAAttention._resolve_sink_backend = saved_resolve_sink
+
+        # The GPU ``HYV4MLAAttention.__init__`` created a vllm-core
+        # ``MLAAttention`` under ``{prefix}.attn`` and registered it in
+        # ``static_forward_context``. That module is discarded below when
+        # ``self.mla_attn`` is replaced with the NPU wrapper, but its
+        # registration persists, which would leave TWO AttentionLayerBase
+        # entries per decoder layer (legacy ``.attn`` + live
+        # ``.npu_attn.attn``). On main this duplicates the KV cache
+        # allocation and corrupts the Mooncake PD transfer metadata
+        # (``_build_kv_group2layeridx`` maps both names to the same layer
+        # index). Remove the stale registration so only the live NPU
+        # wrapper's inner MLAAttention stays registered.
+        from vllm.config import get_current_vllm_config
+
+        try:
+            _compilation_config = get_current_vllm_config().compilation_config
+        except AssertionError:
+            _compilation_config = None
+        if _compilation_config is not None:
+            _legacy_layer_name = f"{self.prefix}.attn"
+            _compilation_config.static_forward_context.pop(_legacy_layer_name, None)
+
+        # ``f8E4M3FN``); the wrapper accepts ``is_sparse=False`` and
+        # ``skip_topk=True`` and will simply skip the indexer branch.
+        # NOTE: re-enabled sparse path on NPU. The vllm indexer's
+        # ``per_token_group_quant_fp8`` kernel is bypassed by the
+        # ``IndexerWrapper`` (no-op forward); the NPU's SFA impl
+        # performs the actual top-k selection in
+        # ``indexer_select_post_process`` using the indexer's weights
+        # (``wq_b``, ``wk_weights_proj``, ``k_norm``) and a float32
+        # fallback. The ``is_sparse`` / ``skip_topk`` flags computed
+        # by ``original_init`` are preserved so the SFA impl matches
+        # the GPU's "full" / "shared" indexer layout.
+        mla_modules = MLAModules(
+            kv_a_layernorm=self.kv_a_layernorm,
+            kv_b_proj=self.kv_b_proj,
+            rotary_emb=self.rotary_emb,
+            o_proj=self.o_proj,
+            # The NPU's MLA preprocessing needs a single
+            # ``fused_qkv_a_proj`` whose output is the concatenation
+            # of ``[q_lora_rank, kv_lora_rank + qk_rope_head_dim]``.
+            # HYV4 keeps these as two separate linears; wrap them
+            # in a virtual fused module so the NPU can consume
+            # them without duplicating weights.
+            fused_qkv_a_proj=_HyV4FusedQkvAProj(self.q_a_proj, self.kv_a_proj_with_mqa)
+            if self.q_lora_rank is not None and self.q_a_proj is not None
+            else None,
+            kv_a_proj_with_mqa=self.kv_a_proj_with_mqa,
+            q_a_layernorm=self.q_a_layernorm,
+            q_b_proj=self.q_b_proj,
+            q_proj=self.q_proj,
+            # Pass through the vllm indexer for sparse layers; the
+            # ``AscendMultiHeadLatentAttention.__init__`` wraps it in
+            # an ``IndexerWrapper`` so ``indexer(...)`` becomes a
+            # no-op and only the weights (used by the SFA impl's
+            # ``indexer_select_post_process``) survive.
+            indexer=self.indexer if getattr(self, "is_sparse", False) else None,
+            indexer_rotary_emb=self.indexer_rope_emb if getattr(self, "is_sparse", False) else None,
+            is_sparse=bool(getattr(self, "is_sparse", False)),
+            # The vllm ``Indexer`` stores the topk sharing buffer on
+            # itself. Re-expose it on ``MLAModules`` so the SFA impl
+            # can read/write the buffer for ``skip_topk`` layers
+            # (full indexer layers expose it via ``self.indexer``;
+            # shared indexer layers do not build an indexer so we
+            # fall back to the buffer that ``HYV4Model`` created
+            # and threaded through every decoder layer's
+            # ``__init__``).
+            topk_indices_buffer=(
+                self.indexer.topk_indices_buffer
+                if (getattr(self, "is_sparse", False) and self.indexer is not None)
+                else kwargs.get("topk_indices_buffer")
+                if getattr(self, "is_sparse", False)
+                else None
+            ),
+        )
+        # ``prefix`` is the layer's registered name; the wrapper needs
+        # a unique prefix (not the same as the original ``MLAAttention``)
+        # so vllm's module registry does not raise a duplicate-name
+        # error. We append ``.npu_attn`` so the wrapper's own
+        # submodules live under ``model.layers.N.self_attn.npu_attn``
+        # while the legacy ``MLAAttention`` (whose forward is now
+        # bypassed) keeps its original ``.attn`` namespace.
+        attn_prefix = f"{self.prefix}.npu_attn"
+        self.mla_attn = MultiHeadLatentAttentionWrapper(
+            self.hidden_size,
+            self.num_local_heads,
+            self.scaling,
+            self.qk_nope_head_dim,
+            self.qk_rope_head_dim,
+            self.v_head_dim,
+            self.q_lora_rank,
+            self.kv_lora_rank,
+            mla_modules,
+            cache_config,
+            quant_config,
+            attn_prefix,
+            # Respect the GPU-computed skip_topk flag so "shared"
+            # indexer layers reuse the top-k buffer instead of
+            # recomputing. Sparse "full" layers keep
+            # ``skip_topk=False``; dense layers also have
+            # ``skip_topk=False`` (their indexer is None).
+            skip_topk=bool(getattr(self, "skip_topk", False)),
+        )
+        # Bind the per-head learnable attention sink (if any) to the NPU
+        # SFA impl so it can rescale the op's output to match the GPU
+        # ``flash_mla_sparse_fwd`` kernel. The original GPU
+        # ``HYV4MLAAttention.__init__`` created ``learnable_sink_param``
+        # and passed it as ``sinks=...`` to its MLA impl; the NPU wrapper
+        # doesn't accept that kwarg, so we attach it directly to the impl
+        # that the wrapper just instantiated.
+        sink = getattr(self, "learnable_sink_param", None)
+        if sink is not None:
+            inner_impl = getattr(self.mla_attn, "mla_attn", None)
+            inner_impl_impl = getattr(inner_impl, "impl", None) if inner_impl is not None else None
+            if inner_impl_impl is not None:
+                inner_impl_impl.learnable_sink_param = sink
+                # One-shot log so we can confirm the binding actually took
+                # effect at startup. Use the standard vllm logger so the
+                # message lands in the worker log alongside the existing
+                # sink-unavailable warning.
+                from vllm.logger import logger as _vllm_logger
+
+                _vllm_logger.info_once(
+                    "HYV4 NPU sink bound: dtype=%s shape=%s impl=%s",
+                    sink.dtype,
+                    tuple(sink.shape),
+                    type(inner_impl_impl).__name__,
+                )
+            else:
+                from vllm.logger import logger as _vllm_logger
+
+                _vllm_logger.warning_once(
+                    "HYV4 NPU sink present but inner SFA impl not found; learnable_sink will be ignored. layer=%s",
+                    self.prefix,
+                )
+
+        # Bind the gated_mla linear_gate to the SFA impl so it can apply
+        # ``sigmoid(linear_gate(hidden_states))`` to the pre-o_proj
+        # attention output (matching the GPU
+        # ``HYV4MLAAttention._indexer_and_attn`` post-processing). The
+        # gate is constructed in the GPU ``__init__`` (when
+        # ``config.gated_mla=True``) but the NPU wrapper discards the
+        # kwarg, so we attach it directly here.
+        gate = getattr(self, "linear_gate", None)
+        if gate is not None:
+            inner_impl = getattr(self.mla_attn, "mla_attn", None)
+            inner_impl_impl = getattr(inner_impl, "impl", None) if inner_impl is not None else None
+            if inner_impl_impl is not None:
+                inner_impl_impl.gated_mla_linear_gate = gate
+                inner_impl_impl.gated_mla_gating_type = getattr(self.config, "gating_type", "headwise")
+                from vllm.logger import logger as _vllm_logger
+
+                _vllm_logger.info_once(
+                    "HYV4 NPU gated_mla bound: gating_type=%s impl=%s",
+                    inner_impl_impl.gated_mla_gating_type,
+                    type(inner_impl_impl).__name__,
+                )
+
+    def _npu_forward(self, positions, hidden_states, llama_4_scaling=None):  # type: ignore[no-redef]
+        # Delegate MLA + o_proj to the NPU's
+        # ``AscendMultiHeadLatentAttention`` (instantiated via the
+        # ``MultiHeadLatentAttentionWrapper`` PluggableLayer). The
+        # wrapper's impl bakes ``o_proj`` into its forward and
+        # returns the post-projection tensor of shape
+        # ``[N, hidden_size]``. ``gated_mla`` and ``learnable_sink``
+        # are both applied INSIDE the SFA impl between attention
+        # and o_proj, so this wrapper-level forward stays a
+        # straight pass-through.
+        return self.mla_attn(positions, hidden_states, llama_4_scaling)
+
+    HYV4MLAAttention.__init__ = _npu_init
+    HYV4MLAAttention.forward = _npu_forward
+
+
+def _patch_mla_attention_forward_for_npu():
+    """DEPRECATED: superseded by
+    ``_patch_mla_attention_init_and_forward_for_npu`` which replaces both
+    ``HYV4MLAAttention.__init__`` and ``HYV4MLAAttention.forward``. Kept
+    here as a no-op so older code that imports it still works.
+    """
+    return
+
+
+_patch_compute_logits_for_npu()
+_patch_mla_attention_init_and_forward_for_npu()
+
+
+def _disable_hyv4_indexer_for_npu():
+    """DEPRECATED: kept as a no-op for backward compatibility.
+
+    The NPU's SFA impl now runs the top-k selection in
+    ``indexer_select_post_process`` (using the vllm ``Indexer``'s
+    weights as a parameter holder and a float32 fallback for the
+    FP8 quant kernel), and ``_npu_init`` preserves the
+    ``is_sparse`` / ``skip_topk`` flags computed by
+    ``original_init``. The NVIDIA indexer's ``forward`` is wrapped
+    by ``IndexerWrapper`` (no-op), so no FP8 Triton kernel is
+    actually invoked on the NPU path. This function used to force
+    every layer into dense attention; that is no longer needed.
+    """
+    return
+
+
+_disable_hyv4_indexer_for_npu()
+
+
+AscendHYV4ForCausalLM = HYV4ForCausalLM
+AscendHYV4MTP = HYV4MTP
+
+__all__ = [
+    "AscendHYV4ForCausalLM",
+    "AscendHYV4MTP",
+    "HYV4ForCausalLM",
+    "HYV4DecoderLayer",
+    "HYV4Model",
+    "HYV4MTP",
+    "HYV4MLAAttention",
+    "HYV4HCLayer",
+    "HYV4HCHeadLayer",
+    "HYV4FeedForward",
+    "HYV4MoEFused",
+    "_normalize_hyv4_config",
+]

--- a/vllm_ascend/patch/platform/patch_speculative_config.py
+++ b/vllm_ascend/patch/platform/patch_speculative_config.py
@@ -34,6 +34,12 @@ def _normalize_legacy_qwen3_dspark_config(hf_config: PretrainedConfig) -> Pretra
                 "target_layer_ids": dflash_config["target_layer_ids"],
             }
         )
+
+    if hf_config.model_type == "hy_v4":
+        hf_config.model_type = "hy_v4_mtp"
+        n_predict = getattr(hf_config, "num_nextn_predict_layers", None)
+        hf_config.update({"n_predict": n_predict, "architectures": ["HYV4MTPModel"]})
+
     return hf_config
 
 

--- a/vllm_ascend/quantization/configs/modelslim_config.py
+++ b/vllm_ascend/quantization/configs/modelslim_config.py
@@ -287,6 +287,19 @@ packed_modules_model_mapping: dict[str, dict[str, list[str]]] = {
         "experts": ["experts.0.gate_proj", "experts.0.up_proj", "experts.0.down_proj"],
         "fused_qkv_a_proj": ["q_a_proj", "kv_a_proj_with_mqa"],
     },
+    # HyV4 (Hy4): MLA + DSA + indexer + MoE. Attention and dense MLP weights
+    # stay FP; only the MoE experts (gate_proj / up_proj / down_proj) are
+    # quantized to W8A8_DYNAMIC. The fused_qkv_a_proj mapping mirrors
+    # deepseek_v2 so the vLLM Ascend MLA preprocessing can concatenate
+    # q_a_proj and kv_a_proj_with_mqa. The gate_up_proj mapping is needed so
+    # dense-MLP layers whose vLLM name is ``mlp.gate_up_proj`` can resolve
+    # quant type via the underlying ``mlp.gate_proj`` / ``mlp.up_proj``
+    # keys (which are FLOAT for layer 0 and any other dense layer).
+    "hy_v4": {
+        "experts": ["experts.0.gate_proj", "experts.0.up_proj", "experts.0.down_proj"],
+        "fused_qkv_a_proj": ["q_a_proj", "kv_a_proj_with_mqa"],
+        "gate_up_proj": ["gate_proj", "up_proj"],
+    },
     "minimax_m2": {
         "qkv_proj": [
             "q_proj",
@@ -851,7 +864,11 @@ class AscendModelSlimConfig(QuantizationConfig):
                 # k_eq_v case where v_proj is replicated from k_proj.
                 if shard_key not in self.quant_description and _is_missing_v_shard(shard_key, self.quant_description):
                     continue
-                is_shard_skipped = self.quant_description[shard_key] == "FLOAT"
+                # A shard missing from the description file (e.g. unquantized
+                # layer-0 / shared_experts shards of Hy4) is treated as FLOAT,
+                # keeping the same semantics as the else branch below.
+                shard_state = self.quant_description.get(shard_key, "FLOAT")
+                is_shard_skipped = shard_state == "FLOAT"
 
                 if is_skipped is None:
                     is_skipped = is_shard_skipped
@@ -866,6 +883,15 @@ class AscendModelSlimConfig(QuantizationConfig):
                 key.startswith(prefix) and key.endswith(".weight") and value == "FLOAT"
                 for key, value in self.quant_description.items()
             )
+            # MTP draft layers (e.g. model.layers.78.* for hy_v4 with
+            # n_predict=1) are stored under the `model.mtp_layers.*`
+            # namespace in the checkpoint, so the runtime prefix
+            # `model.layers.<idx>.*` does not match any key in
+            # `quant_description`. Treat such unknown layers as unquantized
+            # (FLOAT) instead of letting the lookup in
+            # `get_linear_quant_type` raise `KeyError`.
+            if not is_skipped and not any(key.startswith(prefix) for key in self.quant_description):
+                is_skipped = True
 
         assert is_skipped is not None
         return is_skipped

--- a/vllm_ascend/utils.py
+++ b/vllm_ascend/utils.py
@@ -127,10 +127,19 @@ def model_uses_sfa_sparse(model_config: Any | None) -> bool:
 
 
 def enable_sfa_dcp_replicated_indexer(vllm_config: VllmConfig | None = None) -> bool:
+    # ``update_full_graph_params`` (called during inference) invokes
+    # ``attn_backend.get_impl_cls()`` which routes here. However, the vLLM
+    # config context may already be torn down (only set during ``load_model``)
+    # by that time, so calling ``get_current_vllm_config()`` raises
+    # AssertionError. Fall back to the ``_or_none`` variant — when no config
+    # is set, DCP indexer cannot be enabled anyway, and callers can choose
+    # the default (non-DCP) impl.
     if vllm_config is None:
-        from vllm.config import get_current_vllm_config
+        from vllm.config import get_current_vllm_config_or_none
 
-        vllm_config = get_current_vllm_config()
+        vllm_config = get_current_vllm_config_or_none()
+    if vllm_config is None:
+        return False
 
     parallel_config = vllm_config.parallel_config
     return model_uses_sfa_sparse(vllm_config.model_config) and parallel_config.decode_context_parallel_size > 1


### PR DESCRIPTION
## Description

This PR ports the Hy4 (HYV4) model NPU adaptation, originally developed on the `void/dev_hy4` branch (based on v0.23), to the current `main` branch, targeting ModelRunnerV1. The architecture (MLA + DSA + indexer + MoE, with learnable sink and gated-MLA) follows the vllm-core `hy_v4` NVIDIA implementation, reusing its modules with NPU-side patches.

### Key changes

- **`vllm_ascend/models/hy_v4.py`** (new): Ascend HYV4 model. Wraps the vllm-core HYV4 attention with `AscendMultiHeadLatentAttention` via the `MultiHeadLatentAttentionWrapper` OOT hook, binding `learnable_sink` and `gated_mla` (linear gate) to the SFA impl. Patches `compute_logits` for NPU device type. Removes the stale legacy `.attn` `static_forward_context` registration after replacing `mla_attn` — otherwise two `AttentionLayerBase` entries per decoder layer (dual-attn) would duplicate KV cache allocation and corrupt Mooncake PD transfer metadata.
- **`vllm_ascend/attention/sfa_v1.py`**: `indexer_pe_last` RoPE handling, learnable-sink rescale using the attention op's softmax max/sum, gated-MLA application between `_v_up_proj` and `o_proj`, topk-indices buffer fallback for index-cache layers without a live indexer.
- **`vllm_ascend/attention/mla_v1.py`**: HYV4 MLA head padding (when `qk_nope + qk_rope == v_head_dim`, pad head count to the next power of two to satisfy `npu_fused_infer_attention_score`), merged LSE from `npu_attention_update` for downstream sink rescale, empty-tensor guard in `_v_up_proj`, decode output row alignment.
- **`vllm_ascend/device/device_op.py`**: `return_sink_stats` passthrough on the sparse flash attention op so callers can obtain softmax max/sum for the learnable sink.
- **`vllm_ascend/models/__init__.py`**: register `HYV4ForCausalLM` / `HYV4MTPModel` to the model registry.
- **`vllm_ascend/patch/platform/patch_speculative_config.py`**: `hy_v4` → `hy_v4_mtp` draft config conversion (`n_predict`, `architectures`) for MTP speculative decoding.
- **`vllm_ascend/quantization/configs/modelslim_config.py`**: `hy_v4` packed-modules entry (`experts`, `fused_qkv_a_proj`, `gate_up_proj`); shards missing from the quant description file (unquantized layer-0 / shared experts) are treated as FLOAT; unknown MTP layer prefixes are treated as unquantized instead of raising `KeyError`.
- **`vllm_ascend/utils.py`**: `enable_sfa_dcp_replicated_indexer` falls back to `get_current_vllm_config_or_none` since the config context may be torn down when invoked during inference-time `update_full_graph_params`.
- **`vllm_ascend/distributed/kv_transfer/utils/utils.py`**: `MAX_HCCL_REGISTER_REGIONS` 256 → 512 (Hy4 needs 354 regions).

### Not ported from the original dev_hy4 work

- `copy_snapshot_to_gpu` fix: the function was removed on `main`.
- Dual-attn Mooncake PP filter and PD diagnostic dump: superseded by removing the stale legacy attention registration at the source (see above).

## Test Plan

- Local: `ruff check` / `ruff format` / all pre-commit hooks pass.
- NPU environment validation of Hy4 prefill/decode (ModelRunnerV1) is still pending — this PR is the code migration step.
- vLLM main: https://github.com/vllm-project/vllm/commit/ba07e4a48fc951300d97eb506217dd530583dea3
