### PR TITLE
[BugFix][MTP] Fix embed_input_ids issue for MTP and graph mode

### DIFF
--- a/vllm_ascend/worker/v2/aclgraph_utils.py
+++ b/vllm_ascend/worker/v2/aclgraph_utils.py
@@ -288,6 +288,9 @@ class ModelWithContext(nn.Module):
     def map_draft_to_target(self, draft_ids: torch.Tensor):
         return self.original_model.map_draft_to_target(draft_ids)
 
+    def embed_input_ids(self, *args, **kwargs):
+        return self.original_model.embed_input_ids(*args, **kwargs)
+
 
 @contextmanager
 def model_capture_wrapper(speculator, is_draft_model_prefill):


### PR DESCRIPTION
### What this PR does / why we need it?
Resolve AttributeError
```
AttributeError: 'ModelWithContext' object has no attribute 'embed_input_ids'
```

When MTP speculative decoding and graph mode are enabled together, vLLM Ascend temporarily wraps the draft model with ModelWithContext during graph capture. The autoregressive speculator calls self.model.embed_input_ids(...) while preparing draft-model inputs.

Previously, no error occurred without graph mode because self.model remained the original MTP model, which implements embed_input_ids().
With graph mode enabled, the capture path temporarily replaces it:
```
speculator.capture()
→ model_capture_wrapper()
→ speculator.model = ModelWithContext(original_model)
→ speculator calls self.model.embed_input_ids()
```
Since ModelWithContext did not forward embed_input_ids(), the call failed. Without graph capture, this wrapper replacement never occurs.
This change preserves the wrapped model's embed_input_ids interface by forwarding the call to original_model.

### How was this patch tested?
Before this patch, graph capture failed when the speculator called embed_input_ids on ModelWithContext. After this patch, graph capture and service startup completed successfully.

- vLLM main: https://github.com/vllm-project/vllm/commit/ba07e4a48fc951300d97eb506217dd530583dea3
