### PR TITLE
[Feat][Quantization] Add DeepSeek-V4 offline W8A8/W4A8 quantization script

### DIFF
--- a/examples/quantization/deepseek_v4/README.md
+++ b/examples/quantization/deepseek_v4/README.md
@@ -1,0 +1,229 @@
+# DeepSeek-V4 Quantization
+
+Convert DeepSeek-V4 native FP8 weights to W8A8 or W4A8 quantized weights in ModelSlim format, loadable by vllm-ascend on Ascend NPU without `--quantization` flag.
+
+## Supported Models
+
+| Model | Config File | Quant Scheme | Auto-detected? |
+|-------|------------|--------------|----------------|
+| **DeepSeek-V4-Flash** | `quantize_config.yaml` | W8A8 (all Linear) | Yes (default) |
+| **DeepSeek-V4-Pro** | `quantize_config_pro_w4a8.yaml` | W4A8 (routed experts) + W8A8 (attn, shared_experts, MTP) | No — must pass `--config` |
+| **DeepSeek-V4-Flash-DSpark** | `quantize_config_dspark.yaml` | W8A8 (all Linear) | Yes (`dspark_block_size` in config.json) |
+| **DeepSeek-V4-Pro-DSpark** | `quantize_config_dspark.yaml` | W8A8 (all Linear) | Yes (`dspark_block_size` in config.json) |
+
+> Regardless of auto-detection, **always pass `--config` explicitly** for clarity. See Usage below.
+
+**Key differences between variants**:
+- **Flash**: 1 MTP layer, uses `e_proj`/`h_proj` for MTP projection
+- **Pro**: 1 MTP layer, uses `e_proj`/`h_proj` for MTP projection; routed experts go W4A8 (4-bit) for smaller checkpoint size
+- **DSpark** (Flash-DSpark + Pro-DSpark): 3 MTP draft layers, uses `main_proj` for MTP projection; draft `wo_a` kept as FP8 (vllm-ascend has dedicated dequant path)
+
+## Prerequisites
+
+- **Hardware**: Ascend NPU (Atlas 800I A2 / Atlas A3 Inference series) — optional, see `--device` below
+- **Software**:
+  - PyTorch (required)
+  - torch_npu (optional, only needed for `--device npu`)
+  - vllm-ascend (for loading the quantized weights)
+- **Input**: DeepSeek-V4 FP8 HF weights:
+  - [DeepSeek-V4-Flash](https://huggingface.co/deepseek-ai/DeepSeek-V4-Flash)
+  - [DeepSeek-V4-Pro](https://huggingface.co/deepseek-ai/DeepSeek-V4-Pro)
+  - [DeepSeek-V4-Flash-DSpark](https://huggingface.co/deepseek-ai/DeepSeek-V4-Flash-DSpark)
+  - [DeepSeek-V4-Pro-DSpark](https://huggingface.co/deepseek-ai/DeepSeek-V4-Pro-DSpark)
+
+## Usage
+
+> **Always pass `--config` explicitly.** Each model variant needs its own YAML config file. If omitted, the script auto-selects based on `config.json`'s `dspark_block_size` field (DSpark → `quantize_config_dspark.yaml`, otherwise → `quantize_config.yaml`), but passing it explicitly avoids ambiguity — especially for Pro, which is NOT auto-detected and must use `quantize_config_pro_w4a8.yaml`.
+
+### DeepSeek-V4-Flash (W8A8)
+
+```bash
+python examples/quantization/deepseek_v4/quantize.py \
+    --input_fp8_hf_path /path/to/DeepSeek-V4-Flash \
+    --output_hf_path /path/to/DeepSeek-V4-Flash-w8a8 \
+    --config examples/quantization/deepseek_v4/quantize_config.yaml
+```
+
+Serve:
+```bash
+vllm serve /path/to/DeepSeek-V4-Flash-w8a8
+```
+
+### DeepSeek-V4-Pro (W4A8 + W8A8 mixed)
+
+```bash
+python examples/quantization/deepseek_v4/quantize.py \
+    --input_fp8_hf_path /path/to/DeepSeek-V4-Pro \
+    --output_hf_path /path/to/DeepSeek-V4-Pro-w4a8 \
+    --config examples/quantization/deepseek_v4/quantize_config_pro_w4a8.yaml
+```
+
+Serve:
+```bash
+vllm serve /path/to/DeepSeek-V4-Pro-w4a8
+```
+
+### DeepSeek-V4-Flash-DSpark (W8A8)
+
+```bash
+python examples/quantization/deepseek_v4/quantize.py \
+    --input_fp8_hf_path /path/to/DeepSeek-V4-Flash-DSpark \
+    --output_hf_path /path/to/DeepSeek-V4-Flash-DSpark-w8a8 \
+    --config examples/quantization/deepseek_v4/quantize_config_dspark.yaml
+```
+
+Serve with speculative config:
+```bash
+vllm serve /path/to/DeepSeek-V4-Flash-DSpark-w8a8 \
+    --speculative-config '{"method":"dspark","num_speculative_tokens":7,"draft_sample_method":"greedy"}'
+```
+
+### DeepSeek-V4-Pro-DSpark (W8A8)
+
+```bash
+python examples/quantization/deepseek_v4/quantize.py \
+    --input_fp8_hf_path /path/to/DeepSeek-V4-Pro-DSpark \
+    --output_hf_path /path/to/DeepSeek-V4-Pro-DSpark-w8a8 \
+    --config examples/quantization/deepseek_v4/quantize_config_dspark.yaml
+```
+
+Serve with speculative config:
+```bash
+vllm serve /path/to/DeepSeek-V4-Pro-DSpark-w8a8 \
+    --speculative-config '{"method":"dspark","num_speculative_tokens":7,"draft_sample_method":"greedy"}'
+```
+
+> **Note**: Pro-DSpark uses W8A8 (not W4A8) for all layers. The W4A8 config is only for non-DSpark Pro.
+
+### Device Selection (`--device`)
+
+The script can run quantization compute on either CPU or NPU. The bottleneck is disk I/O and FP8 dequantization (always CPU), not the quantization compute itself — so CPU mode is only ~1 min slower for Flash-scale models.
+
+```bash
+# Auto-detect: uses NPU if torch_npu is installed and NPU is available, otherwise CPU (default)
+python examples/quantization/deepseek_v4/quantize.py \
+    --input_fp8_hf_path /path/to/model \
+    --output_hf_path /path/to/output \
+    --config examples/quantization/deepseek_v4/quantize_config_pro_w4a8.yaml
+
+# Force CPU (no NPU dependency, works on any machine)
+python examples/quantization/deepseek_v4/quantize.py \
+    --input_fp8_hf_path /path/to/model \
+    --output_hf_path /path/to/output \
+    --device cpu
+
+# Force NPU
+python examples/quantization/deepseek_v4/quantize.py \
+    --input_fp8_hf_path /path/to/model \
+    --output_hf_path /path/to/output \
+    --device npu
+```
+
+| Device | Quant compute | Total time (Flash) | Requirements |
+|--------|--------------|-------------------|--------------|
+| `auto` (default) | NPU if available, else CPU | ~10 min (NPU) / ~13 min (CPU) | torch_npu for NPU |
+| `cpu` | CPU | ~13 min | PyTorch only |
+| `npu` | NPU | ~10 min | torch_npu + NPU hardware |
+
+## Output Format
+
+The output directory contains ModelSlim-format quantized weights:
+
+| File | Description |
+|------|-------------|
+| `quant_model_weights-{N:05d}-of-{M:05d}.safetensors` | Sharded quantized weights (~4GB per shard) |
+| `quant_model_weights.safetensors.index.json` | Shard index with `weight_map` and `total_size` |
+| `quant_model_description.json` | Per-weight quant type (`W8A8_DYNAMIC`, `W4A8_DYNAMIC`, or `FLOAT`) |
+| `config.json` | Model config with `quantization_config` removed |
+| `*.py`, `*.json`, `*.jinja` | Copied from input (tokenizer, modeling code, etc.) |
+
+### How vllm-ascend Loads the Output
+
+1. `config.json` has no `quant_method` field
+2. vllm-ascend's `AscendModelSlimConfig.override_quantization_method()` detects this on NPU and auto-selects the ascend path
+3. `maybe_update_config()` loads `quant_model_description.json` to determine per-layer quantization scheme
+4. No `--quantization` flag needed when serving
+
+## Quantization Config (YAML)
+
+### DeepSeek-V4-Flash (`quantize_config.yaml`)
+
+W8A8 for all Linear layers:
+
+- **`*attn*`** (exclude `wq_a`, `wkv`, `wo_a`, compressor, indexer) — quantize `wq_b`, `wo_b`
+- **`*ffn*`** (exclude `*gate`) — quantize expert and shared_expert weights
+- **`*e_proj`, `*h_proj`** — quantize MTP projection layers
+
+Each quantized weight produces three tensors:
+- `.weight` (int8) — quantized weight
+- `.weight_scale` (float32) — per-channel scale
+- `.weight_offset` (float32) — per-channel offset (zeros for symmetric quant)
+
+### DeepSeek-V4-Pro (`quantize_config_pro_w4a8.yaml`)
+
+Mixed W4A8 + W8A8 — routed experts use W4A8 (4-bit) for smaller checkpoint, everything else stays W8A8:
+
+- **Rule 1: attn** → W8A8 (exclude `wq_a`, `wkv`, `wo_a`, compressor, indexer)
+- **Rule 2: ffn routed experts** → W4A8 (routed experts only, exclude `*gate` and `shared_experts`)
+- **Rule 3: shared_experts** → W8A8 (every token executes, precision-sensitive)
+- **Rule 4: MTP projections** → W8A8 (`e_proj`, `h_proj` — Pro uses same MTP structure as Flash)
+
+W4A8 quantized weights produce four tensors per layer:
+- `.weight` (int8, packed int4) — two 4-bit values packed per int8 element, shape `[output//2, input]`
+- `.weight_scale` (float32) — per-channel scale
+- `.weight_offset` (float32) — per-channel offset (zeros for symmetric quant)
+- `.scale_bias` (float32) — precomputed `(quant_weight * scale).sum(dim=1) * 8`
+
+W4A8 algorithm aligns with msmodelslim:
+- Per-channel symmetric quantization (minmax, Q_MAX=7, Q_MIN=-8)
+- int4 packing: transpose → pack along output dim (`high<<4 | low&0x0F`) → transpose back
+- `scale_bias` calculated from quantized integer values (not original weights)
+
+### DeepSeek-V4-DSpark (`quantize_config_dspark.yaml`)
+
+W8A8 for all Linear layers. DSpark has 3 MTP draft layers (vs Flash's 1), uses `main_proj` instead of `e_proj`/`h_proj`, and has `markov_head`/`confidence_head` (not quantized):
+
+- **`*attn*`** (exclude `wq_a`, `wkv`, `wo_a`, compressor, indexer) — quantize `wq_b`, `wo_b` (both main + draft)
+- **`*ffn*`** (exclude `*gate`) — quantize expert and shared_expert weights (both main + draft)
+- **`*main_proj`** — quantize DSpark MTP main projection (replaces `e_proj`/`h_proj`)
+
+**Draft wo_a special handling**: DSpark draft model `wo_a` (`mtp.N.attn.wo_a`) is kept as FP8 + `.scale` (not dequantized, not quantized). vllm-ascend's dspark `load_weights` has a dedicated FP8→BF16 dequant path for draft wo_a. Main model `wo_a` is dequantized to BF16 and marked `FLOAT` (same as Flash).
+
+## How It Works
+
+```
+FP8 weight + .scale ──decode_fp8──▶ BF16 weight
+                                          │
+                              YAML match + dim==2?
+                                    ├── W8A8 rule ── weight_quant_sym_perchannel ──▶ int8 + scale + offset (W8A8_DYNAMIC)
+                                    ├── W4A8 rule ── weight_quant_w4a8_perchannel ──▶ packed int4 + scale + offset + scale_bias (W4A8_DYNAMIC)
+                                    └── No match  ── keep original (FLOAT)
+
+DSpark draft wo_a (mtp.N.attn.wo_a): skip dequant/quant, output FP8 + .scale as-is
+```
+
+Quantization logic references [msmodelslim](https://gitee.com/ascend/msit/tree/master/msmodelslim):
+- FP8 dequant: `decode_fp8` / `decode_fp4` (128×128 block)
+- W8A8 weight quant: per-channel symmetric (`clamp([-128, 127])`)
+- W4A8 weight quant: per-channel symmetric minmax (Q_MAX=7), int4 packed in int8, scale_bias precomputed
+- Output sharding: 4GB per shard (BufferedSafetensorsWriter)
+
+## Crash Recovery (Checkpoint/Resume)
+
+Quantizing large models (e.g. DeepSeek-V4-Pro-DSpark ~1.6T) can take hours. The script automatically saves a checkpoint after each input shard is processed, so if the process crashes (OOM, disk full, killed), re-running the same command resumes from the last completed shard — no progress is lost.
+
+**Usage**: no extra flags needed. Just re-run the same command:
+
+```bash
+# If the previous run crashed, simply re-run:
+python examples/quantization/deepseek_v4/quantize.py \
+    --input_fp8_hf_path /path/to/DeepSeek-V4-Pro-DSpark \
+    --output_hf_path /path/to/output
+```
+
+The script detects the checkpoint file (`.quantize_checkpoint.json` in the output directory), restores progress, skips already-completed input shards, and continues. The checkpoint is automatically deleted after `writer.close()` succeeds (all shards processed, index.json and quant_model_description.json written).
+
+**What happens on crash**:
+- Each input shard is force-flushed to disk + checkpoint written atomically (temp file + rename)
+- On resume: stale temporary shard files (from a crash between flush and checkpoint) are cleaned up, completed shards are skipped
+- On successful completion: checkpoint file is deleted, output is identical to a non-interrupted run

--- a/examples/quantization/deepseek_v4/quantize.py
+++ b/examples/quantization/deepseek_v4/quantize.py
@@ -1,0 +1,691 @@
+"""DeepSeek-V4 W8A8 quantization script.
+
+Converts native FP8 weights to W8A8 quantized weights in ModelSlim format,
+loadable by vllm-ascend without --quantization flag (auto-detected on NPU).
+
+Supports both DeepSeek-V4-Flash and DeepSeek-V4-DSpark (Flash + Pro) variants.
+DSpark is auto-detected via config.json's dspark_block_size field.
+
+Quantization logic references msmodelslim:
+- FP8 dequant: msmodelslim/model/deepseek_v4/convert_fp8_to_bf16.py
+- W8A8 weight quant: msmodelslim/pytorch/llm_ptq/llm_ptq_tools/flat_quant/components/quantizer.py
+- Output format: msmodelslim/pytorch/llm_ptq/llm_ptq_tools/save/
+
+Script form (argparse, shard reading, memory management) references:
+- cann-recipes-infer/models/deepseek_v4/utils/convert_model.py
+"""
+
+import argparse
+import fnmatch
+import json
+import os
+import shutil
+from glob import glob
+
+import torch
+import yaml
+from safetensors.torch import load_file, save_file
+from tqdm import tqdm
+
+# torch_npu is optional: only needed when --device npu (or auto with NPU present).
+# Importing it registers the NPU backend so tensor.to("npu") works.
+try:
+    import torch_npu  # noqa: F401  required for tensor.to("npu")
+
+    HAS_TORCH_NPU = True
+except ImportError:
+    HAS_TORCH_NPU = False
+
+# W8A8 symmetric per-channel quantization constants
+NUM_BITS = 8
+Q_MAX = 2 ** (NUM_BITS - 1) - 1  # 127
+Q_MIN = -(2 ** (NUM_BITS - 1))  # -128
+# Epsilon to prevent division by zero when the input is all zeros
+QUANT_EPSILON = 1e-5
+
+# FP8 block size for dequantization (DeepSeek-V4 uses 128x128 blocks)
+FP8_BLOCK_SIZE = 128
+# MXFP4 block size: 32 FP4 elements (packed into 16 uint8) share 1 block scale
+MXFP4_BLOCK_SIZE = 32
+
+# Output shard size (GB), matches YAML save.ascendv1_saver.part_file_size
+OUTPUT_SHARD_GB = 4
+ONE_GB_BYTES = 1073741824
+
+# Max number of input safetensors shards to keep in memory simultaneously.
+# FP8 weight and its scale may land in adjacent shards, so a window of 2 is
+# sufficient for the common case; get_tensor() may pull in extra scale shards
+# which are evicted by the while-loop after each iteration.
+MAX_CACHED_SHARDS = 2
+
+# Quant type strings for quant_model_description.json
+QUANT_TYPE_W8A8_DYNAMIC = "W8A8_DYNAMIC"
+QUANT_TYPE_W4A8_DYNAMIC = "W4A8_DYNAMIC"
+QUANT_TYPE_FLOAT = "FLOAT"
+
+# W4A8 symmetric per-channel quantization constants (4-bit signed: [-8, 7])
+W4_NUM_BITS = 4
+W4_Q_MAX = 2 ** (W4_NUM_BITS - 1) - 1  # 7
+W4_Q_MIN = -(2 ** (W4_NUM_BITS - 1))  # -8
+# Bit mask for extracting low 4 bits: (1 << W4_NUM_BITS) - 1
+W4_BIT_MASK = (1 << W4_NUM_BITS) - 1  # 0x0F
+# scale_bias factor: 2 ** (W4_NUM_BITS - 1), from msmodelslim process_scale formula
+W4_SCALE_BIAS_FACTOR = 2 ** (W4_NUM_BITS - 1)  # 8
+
+# DSpark has 3 MTP draft layers (vs Flash's 1); used for post-quantization assertions
+DSPARK_MTP_LAYERS = 3
+
+# Checkpoint filename for crash recovery (stored in output directory)
+CHECKPOINT_FILENAME = ".quantize_checkpoint.json"
+
+
+def decode_fp8(weight: torch.Tensor, scale: torch.Tensor) -> torch.Tensor:
+    """Dequantize FP8 e4m3 weight to bfloat16.
+
+    References: msmodelslim/model/deepseek_v4/convert_fp8_to_bf16.py:decode_fp8
+    """
+    weight = weight.unflatten(0, (-1, FP8_BLOCK_SIZE)).unflatten(-1, (-1, FP8_BLOCK_SIZE)).float()
+    weight = weight * scale[:, None, :, None].float()
+    return weight.flatten(2, 3).flatten(0, 1).bfloat16()
+
+
+def decode_fp4(packed_fp4_data: torch.Tensor, block_scales: torch.Tensor) -> torch.Tensor:
+    """Dequantize MXFP4 packed weight to bfloat16.
+
+    References: msmodelslim/model/deepseek_v4/convert_fp8_to_bf16.py:decode_fp4
+    """
+    lut = torch.tensor(
+        [0.0, 0.5, 1.0, 1.5, 2.0, 3.0, 4.0, 6.0],
+        device=packed_fp4_data.device,
+        dtype=torch.float32,
+    )
+
+    uint8 = packed_fp4_data.view(torch.uint8)
+    low = uint8 & 0x0F
+    high = (uint8 >> 4) & 0x0F
+    indices = torch.stack([low, high], dim=-1).flatten(-2)
+
+    sign = 1.0 - 2.0 * ((indices >> 3) & 1).float()
+    abs_idx = indices & 0x07
+    values = sign * lut[abs_idx.long()]
+
+    # MXFP4: 32 FP4 elements share 1 block scale, so repeat_interleave(32)
+    # expands block_scales to match the unpacked weight dimension
+    scales_expanded = block_scales.to(torch.float32).repeat_interleave(MXFP4_BLOCK_SIZE, dim=-1)
+    return (values * scales_expanded).to(torch.bfloat16)
+
+
+def weight_quant_sym_perchannel(
+    tensor: torch.Tensor, device: str = "cpu"
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    """Per-channel symmetric W8A8 weight quantization.
+
+    Returns (quant_weight[int8], weight_scale[fp32], weight_offset[fp32 zeros]).
+
+    References: msmodelslim WeightQuantizer.find_params(sym=True) + sym_quant()
+    """
+    x = tensor.to(device)
+    if x.dim() > 2:
+        x = x.flatten(1)
+
+    tmp = torch.zeros(x.shape[0], device=x.device)
+    xmin = torch.minimum(x.min(1)[0], tmp)
+    xmax = torch.maximum(x.max(1)[0], tmp)
+
+    # symmetric: take max of abs(xmin) and xmax, clamp to avoid div-by-zero
+    xmax = torch.maximum(torch.abs(xmin), xmax).clamp(min=QUANT_EPSILON)
+    scale = (xmax / Q_MAX).unsqueeze(-1)  # (M, 1) for broadcasting with x (M, N)
+    zero = torch.zeros_like(scale)
+
+    quant_weight = torch.clamp(torch.round(x / scale), Q_MIN, Q_MAX).to(torch.int8)
+    return quant_weight.cpu(), scale.cpu().to(torch.float32), zero.cpu().to(torch.float32)
+
+
+def w4a8_pack_int4(weight: torch.Tensor) -> torch.Tensor:
+    """Pack int4 weight to int8 (two 4-bit values per int8 element).
+
+    Aligns with msmodelslim ``format/common/pack.py:w4a8_pack_int4``:
+    transpose → pack along output dim → transpose back.
+    Input shape [output, input] → output shape [output // 2, input].
+    """
+    assert weight.dim() == 2, f"Expected 2D tensor, got {weight.dim()}D"
+    output_size, input_size = weight.shape
+    assert output_size % 2 == 0, f"Output dimension must be even for int4 packing, got {output_size}"
+
+    weight = weight.transpose(0, 1).contiguous()  # [input, output]
+    weight = weight.reshape(-1, 2)  # [input * output//2, 2]
+    high = torch.bitwise_left_shift(weight[:, 1:], W4_NUM_BITS)
+    low = weight[:, :1] & W4_BIT_MASK
+    packed = torch.bitwise_or(high, low)
+    packed = packed.reshape(input_size, output_size // 2)  # [input, output//2]
+    packed = packed.transpose(0, 1).contiguous()  # [output//2, input]
+    return packed.to(torch.int8)
+
+
+def weight_quant_w4a8_perchannel(
+    tensor: torch.Tensor, device: str = "cpu"
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+    """Per-channel symmetric W4A8 weight quantization with int4 packing.
+
+    Returns (packed_weight[int8], weight_scale[fp32], weight_offset[fp32 zeros],
+    scale_bias[fp32]).
+
+    Aligns with msmodelslim WeightQuantizer.find_params(bits=4, sym=True) +
+    ascendv1.py:on_w4a8_dynamic save format.
+    """
+    x = tensor.to(device)
+    if x.dim() > 2:
+        x = x.flatten(1)
+
+    tmp = torch.zeros(x.shape[0], device=x.device)
+    xmin = torch.minimum(x.min(1)[0], tmp)
+    xmax = torch.maximum(x.max(1)[0], tmp)
+
+    xmax = torch.maximum(torch.abs(xmin), xmax).clamp(min=QUANT_EPSILON)
+    scale = (xmax / W4_Q_MAX).unsqueeze(-1)  # (M, 1)
+    zero = torch.zeros_like(scale)
+
+    quant_weight = torch.clamp(torch.round(x / scale), W4_Q_MIN, W4_Q_MAX).to(torch.int8)
+    packed_weight = w4a8_pack_int4(quant_weight)
+
+    # scale_bias: (weight * scale).sum(dim=1) * W4_SCALE_BIAS_FACTOR
+    # Aligns with msmodelslim process_scale (column-parallel formula).
+    scale_bias = (quant_weight.to(torch.float32) * scale).sum(dim=1, keepdim=True) * W4_SCALE_BIAS_FACTOR
+
+    return (
+        packed_weight.cpu(),
+        scale.cpu().to(torch.float32),
+        zero.cpu().to(torch.float32),
+        scale_bias.cpu().to(torch.float32),
+    )
+
+
+def match_yaml_rules(weight_name: str, yaml_rules: list) -> dict | None:
+    """Check if weight_name matches any linear_quant rule in YAML config.
+
+    A rule matches if weight_name matches any include pattern AND does not
+    match any exclude pattern. Only `linear_quant` type rules are considered.
+
+    Returns the matched rule dict (including qconfig) or None.
+    """
+    for rule in yaml_rules:
+        if rule.get("type") != "linear_quant":
+            continue
+        includes = rule.get("include", [])
+        excludes = rule.get("exclude", [])
+        if any(fnmatch.fnmatch(weight_name, pat) for pat in includes):
+            if not any(fnmatch.fnmatch(weight_name, pat) for pat in excludes):
+                return rule
+    return None
+
+
+class BufferedSafetensorsWriter:
+    """Buffered safetensors writer with 4GB shard flushing.
+
+    Simplified from msmodelslim BufferedSafetensorsWriter.
+    Accumulates tensors in memory; flushes to a new shard when exceeding
+    OUTPUT_SHARD_GB. On close, renames shards to {N:05d}-of-{M:05d} format
+    and writes the index.json.
+    """
+
+    def __init__(
+        self,
+        save_directory: str,
+        save_prefix: str = "quant_model_weights",
+        resume_state: dict | None = None,
+    ):
+        self.save_directory = save_directory
+        self.save_prefix = save_prefix
+        self.max_size = OUTPUT_SHARD_GB * ONE_GB_BYTES
+        self.wait_save_keys: dict[str, torch.Tensor] = {}
+        self.saved_keys_map: dict[str, str] = {}
+        self.quant_description: dict[str, str] = {
+            "version": "1.0.0",
+            "model_quant_type": QUANT_TYPE_W8A8_DYNAMIC,
+            "group_size": 0,
+            "metadata": {},
+        }
+        self.total_size = 0
+        self._wait_save_size = 0
+        self._save_count = 0
+
+        # Resume from checkpoint: restore previously flushed state so that
+        # close() can rename the correct number of shards and write a complete
+        # index.json/quant_model_description.json.
+        if resume_state is not None:
+            self._save_count = resume_state.get("save_count", 0)
+            self.saved_keys_map = resume_state.get("saved_keys_map", {})
+            self.quant_description.update(resume_state.get("quant_description", {}))
+            self.total_size = resume_state.get("total_size", 0)
+
+    def write(self, name: str, tensor: torch.Tensor, quant_type: str) -> None:
+        """Write a tensor and record its quant type in description."""
+        tensor = tensor.detach().cpu().contiguous()
+        tensor_size = tensor.numel() * tensor.element_size()
+
+        if self._wait_save_size + tensor_size >= self.max_size:
+            self._flush()
+
+        self.wait_save_keys[name] = tensor
+        self.quant_description[name] = quant_type
+        self.total_size += tensor_size
+        self._wait_save_size += tensor_size
+
+    def _flush(self) -> None:
+        if not self.wait_save_keys:
+            return
+        self._save_count += 1
+        file_name = f"{self.save_prefix}-{self._save_count:05d}-of-00000.safetensors"
+        file_path = os.path.join(self.save_directory, file_name)
+        save_file(self.wait_save_keys, file_path, metadata={"format": "pt"})
+        self.saved_keys_map.update({k: file_name for k in self.wait_save_keys})
+        self.wait_save_keys.clear()
+        self._wait_save_size = 0
+
+    def close(self) -> None:
+        """Flush remaining, rename shards, write index.json and description."""
+        self._flush()
+
+        # Rename shards: -of-00000 -> -of-{M:05d}
+        # Idempotent: if a previous close() already renamed some/all shards
+        # (crash between close() and checkpoint deletion), skip the rename
+        # for those shards instead of raising FileNotFoundError.
+        for i in range(self._save_count):
+            shard_idx = i + 1
+            src_name = f"{self.save_prefix}-{shard_idx:05d}-of-00000.safetensors"
+            src = os.path.join(self.save_directory, src_name)
+            dst_name = f"{self.save_prefix}-{shard_idx:05d}-of-{self._save_count:05d}.safetensors"
+            dst = os.path.join(self.save_directory, dst_name)
+            if os.path.exists(dst):
+                # Already renamed by a previous close() call
+                pass
+            elif os.path.exists(src):
+                shutil.move(src, dst)
+            else:
+                raise FileNotFoundError(
+                    f"Shard {shard_idx} not found as either {src_name} or {dst_name} "
+                    f"in {self.save_directory}. Output may be corrupted."
+                )
+            # Update weight_map: replace src_name with dst_name for keys in this shard
+            for key in self.saved_keys_map:
+                if self.saved_keys_map[key] == src_name:
+                    self.saved_keys_map[key] = dst_name
+
+        # Write index.json
+        index = {
+            "metadata": {"total_size": self.total_size},
+            "weight_map": self.saved_keys_map,
+        }
+        index_path = os.path.join(self.save_directory, f"{self.save_prefix}.safetensors.index.json")
+        with open(index_path, "w") as f:
+            json.dump(index, f, indent=2)
+
+        # Write quant_model_description.json
+        desc_path = os.path.join(self.save_directory, "quant_model_description.json")
+        with open(desc_path, "w") as f:
+            json.dump(self.quant_description, f, indent=2)
+
+    def get_state(self) -> dict:
+        """Return a serializable snapshot of flushed state for checkpointing.
+
+        Only includes already-flushed state (saved_keys_map, quant_description,
+        total_size, _save_count). The in-memory buffer (wait_save_keys) is
+        excluded — caller must _flush() before calling get_state().
+        """
+        return {
+            "save_count": self._save_count,
+            "saved_keys_map": dict(self.saved_keys_map),
+            "quant_description": dict(self.quant_description),
+            "total_size": self.total_size,
+        }
+
+
+def load_yaml_rules(config_path: str) -> list:
+    """Load linear_quant rules from YAML config."""
+    with open(config_path) as f:
+        cfg = yaml.safe_load(f)
+    return cfg.get("spec", {}).get("process", [])
+
+
+def main(input_fp8_hf_path: str, output_hf_path: str, config_path: str, device: str = "cpu") -> None:
+    """Convert FP8 weights to W8A8 quantized weights in ModelSlim format.
+
+    Args:
+        input_fp8_hf_path: Path to HF directory containing FP8 safetensors.
+        output_hf_path: Path to output directory for quantized weights.
+        config_path: Path to YAML quantization config.
+        device: "cpu" or "npu" — where to run W8A8 quantization compute.
+    """
+    if device == "npu":
+        assert HAS_TORCH_NPU, "torch_npu not installed; cannot use NPU. Use --device cpu."
+        assert torch.npu.is_available(), "NPU not available. Use --device cpu."
+
+    os.makedirs(output_hf_path, exist_ok=True)
+
+    # Read model index and config
+    with open(os.path.join(input_fp8_hf_path, "model.safetensors.index.json")) as f:
+        model_index = json.load(f)
+    with open(os.path.join(input_fp8_hf_path, "config.json")) as f:
+        config = json.load(f)
+
+    # Detect DSpark variant: dspark_block_size field is present in DSpark config.json
+    is_dspark = "dspark_block_size" in config
+
+    weight_map = model_index["weight_map"]
+    yaml_rules = load_yaml_rules(config_path)
+
+    # Remove quantization_config so vllm-ascend auto-detects via override_quantization_method
+    config.pop("quantization_config", None)
+
+    # --- Checkpoint / resume logic ---
+    checkpoint_path = os.path.join(output_hf_path, CHECKPOINT_FILENAME)
+    resume_state = None
+    completed_shards: set[str] = set()
+
+    if os.path.exists(checkpoint_path):
+        with open(checkpoint_path) as f:
+            ckpt = json.load(f)
+        resume_state = ckpt.get("writer_state")
+        completed_shards = set(ckpt.get("completed_shards", []))
+        print(f"Resuming from checkpoint: {len(completed_shards)} shards already done")
+
+        # Crash recovery: delete half-finished temporary shard files
+        # (-of-00000.safetensors) left by a crash between _flush() and
+        # checkpoint write. Only delete orphans NOT referenced by
+        # saved_keys_map — the referenced ones are valid checkpoint state.
+        saved_files = set(resume_state.get("saved_keys_map", {}).values()) if resume_state else set()
+        for stale in glob(os.path.join(output_hf_path, "*-of-00000.safetensors")):
+            if os.path.basename(stale) not in saved_files:
+                os.remove(stale)
+                print(f"  Removed stale shard: {os.path.basename(stale)}")
+
+    writer = BufferedSafetensorsWriter(output_hf_path, resume_state=resume_state)
+
+    # Cache for loaded safetensors files (keep last 2 to limit memory)
+    loaded_files: dict[str, dict[str, torch.Tensor]] = {}
+
+    def get_tensor(name: str) -> torch.Tensor:
+        file_name = weight_map[name]
+        if file_name not in loaded_files:
+            loaded_files[file_name] = load_file(os.path.join(input_fp8_hf_path, file_name), device="cpu")
+        return loaded_files[file_name][name]
+
+    safetensor_files = sorted(glob(os.path.join(input_fp8_hf_path, "*.safetensors")))
+
+    for safetensor_file in tqdm(safetensor_files, desc="Quantizing shards"):
+        file_name = os.path.basename(safetensor_file)
+
+        # Skip already-completed shards when resuming
+        if file_name in completed_shards:
+            continue
+
+        current_state_dict = load_file(safetensor_file, device="cpu")
+        loaded_files[file_name] = current_state_dict
+
+        for weight_name, weight in current_state_dict.items():
+            # Skip FP8 scale files - consumed during dequantization or passed
+            # through for draft wo_a (DSpark) below.
+            if weight_name.endswith(".scale"):
+                continue
+
+            # DSpark draft model wo_a: keep FP8 + .scale as-is.
+            # vllm-ascend dspark load_weights has a dedicated FP8->BF16
+            # dequant path for draft wo_a (detects .self_attn.wo_a.scale).
+            # If we dequantize/quantize it here, that path breaks. Main model
+            # wo_a (layers.N.*) is NOT affected — only mtp.N.* prefix matches.
+            if (
+                is_dspark
+                and weight_name.startswith("mtp.")
+                and weight_name.endswith(".attn.wo_a.weight")
+                and weight.element_size() == 1
+            ):
+                # Output wo_a.weight as-is (FP8) + wo_a.scale as-is
+                writer.write(weight_name, weight, QUANT_TYPE_FLOAT)
+                scale_name = weight_name.replace(".weight", ".scale")
+                try:
+                    wo_a_scale = get_tensor(scale_name)
+                    writer.write(scale_name, wo_a_scale, QUANT_TYPE_FLOAT)
+                except KeyError:
+                    print(f"Warning: Missing scale tensor for draft wo_a {weight_name}")
+                continue
+
+            # Dequantize FP8 weights to BF16 first
+            if weight.element_size() == 1:
+                scale_name = weight_name.replace(".weight", ".scale")
+                try:
+                    scale_inv = get_tensor(scale_name)
+                    if weight.dtype == torch.float8_e4m3fn:
+                        weight = decode_fp8(weight, scale_inv)
+                    elif weight.dtype in (torch.int8, torch.uint8):
+                        # MXFP4 packed as int8/uint8
+                        weight = decode_fp4(weight, scale_inv)
+                    else:
+                        raise ValueError(
+                            f"Unexpected 1-byte dtype {weight.dtype} for {weight_name}; "
+                            "expected float8_e4m3fn (FP8) or int8/uint8 (MXFP4 packed)."
+                        )
+                except KeyError:
+                    print(f"Warning: Missing scale tensor for {weight_name}, keeping original")
+                    writer.write(weight_name, weight, QUANT_TYPE_FLOAT)
+                    continue
+
+            # Determine quantization: YAML match + 2D tensor (Linear weights)
+            base_name = weight_name.rsplit(".", 1)[0] if weight_name.endswith(".weight") else None
+            matched_rule = (
+                match_yaml_rules(base_name, yaml_rules) if base_name is not None and weight.dim() == 2 else None
+            )
+
+            if matched_rule is not None:
+                weight_dtype = matched_rule.get("qconfig", {}).get("weight", {}).get("dtype", "int8")
+                if weight_dtype == "int4":
+                    # W4A8: int4 weight + int8 activation, packed int4 in int8
+                    quant_weight, weight_scale, weight_offset, scale_bias = weight_quant_w4a8_perchannel(weight, device)
+                    writer.write(weight_name, quant_weight, QUANT_TYPE_W4A8_DYNAMIC)
+                    writer.write(
+                        weight_name.replace(".weight", ".weight_scale"),
+                        weight_scale,
+                        QUANT_TYPE_W4A8_DYNAMIC,
+                    )
+                    writer.write(
+                        weight_name.replace(".weight", ".weight_offset"),
+                        weight_offset,
+                        QUANT_TYPE_W4A8_DYNAMIC,
+                    )
+                    writer.write(
+                        weight_name.replace(".weight", ".scale_bias"),
+                        scale_bias,
+                        QUANT_TYPE_W4A8_DYNAMIC,
+                    )
+                else:
+                    # W8A8: int8 weight + int8 activation (default path)
+                    quant_weight, weight_scale, weight_offset = weight_quant_sym_perchannel(weight, device)
+                    writer.write(weight_name, quant_weight, QUANT_TYPE_W8A8_DYNAMIC)
+                    writer.write(
+                        weight_name.replace(".weight", ".weight_scale"),
+                        weight_scale,
+                        QUANT_TYPE_W8A8_DYNAMIC,
+                    )
+                    writer.write(
+                        weight_name.replace(".weight", ".weight_offset"),
+                        weight_offset,
+                        QUANT_TYPE_W8A8_DYNAMIC,
+                    )
+            else:
+                writer.write(weight_name, weight, QUANT_TYPE_FLOAT)
+
+            # MTP shared weights: vLLM loads MTP as a separate model instance that
+            # only accepts weights with "mtp.0." prefix. The embedding and head
+            # are shared with the main model in training (tie_weight), but at
+            # deployment each model instance needs its own copy in the safetensors
+            # file. FP8 path auto-renames these in vLLM; W8A8 path does not, so
+            # we duplicate them here (matches msmodelslim warp_mtp_model behavior).
+            # clone() is required because safetensors rejects tensors sharing the
+            # same storage in the same shard.
+            #
+            # DSpark: load_weights explicitly skips embed/head (line 929 of
+            # deepseek_v4_dspark.py), so no copy is needed.
+            if not is_dspark:
+                if weight_name == "embed.weight":
+                    writer.write("mtp.0.emb.tok_emb.weight", weight.clone(), QUANT_TYPE_FLOAT)
+                elif weight_name == "head.weight":
+                    writer.write("mtp.0.head.weight", weight.clone(), QUANT_TYPE_FLOAT)
+
+        # Memory management: keep only the most recently used shards.
+        # Use while (not if) because get_tensor() may pull in multiple scale
+        # shards beyond the current one, so we evict until we're back at the limit.
+        while len(loaded_files) > MAX_CACHED_SHARDS:
+            oldest = next(iter(loaded_files))
+            del loaded_files[oldest]
+
+        # Checkpoint: force flush + write checkpoint after each input shard.
+        # This ensures a crash only loses the current in-progress shard.
+        writer._flush()
+        completed_shards.add(file_name)
+        ckpt = {
+            "completed_shards": sorted(completed_shards),
+            "writer_state": writer.get_state(),
+        }
+        # Atomic write: temp file + rename to avoid partial JSON on crash
+        tmp_path = checkpoint_path + ".tmp"
+        with open(tmp_path, "w") as f:
+            json.dump(ckpt, f)
+        os.replace(tmp_path, checkpoint_path)
+
+    writer.close()
+
+    # Checkpoint no longer needed — all shards processed and close() succeeded
+    if os.path.exists(checkpoint_path):
+        os.remove(checkpoint_path)
+
+    # Post-quantization sanity checks (design.md risk 1: YAML glob matching)
+    # Only count weight entries (exclude top-level metadata like model_quant_type)
+    w8a8_weight_suffixes = (".weight", ".weight_scale", ".weight_offset")
+    w8a8_count = sum(
+        1
+        for k, v in writer.quant_description.items()
+        if v == QUANT_TYPE_W8A8_DYNAMIC and k.endswith(w8a8_weight_suffixes)
+    )
+    assert w8a8_count > 0, "No weights were quantized — check YAML config include patterns"
+    assert w8a8_count % 3 == 0, (
+        f"W8A8_DYNAMIC weight entry count ({w8a8_count}) must be a multiple of 3 "
+        "(weight + weight_scale + weight_offset per quantized layer)"
+    )
+
+    # W4A8 count check: each W4A8 layer produces 4 tensors
+    # (weight + weight_scale + weight_offset + scale_bias)
+    w4a8_weight_suffixes = (".weight", ".weight_scale", ".weight_offset", ".scale_bias")
+    w4a8_count = sum(
+        1
+        for k, v in writer.quant_description.items()
+        if v == QUANT_TYPE_W4A8_DYNAMIC and k.endswith(w4a8_weight_suffixes)
+    )
+    if w4a8_count > 0:
+        assert w4a8_count % 4 == 0, (
+            f"W4A8_DYNAMIC weight entry count ({w4a8_count}) must be a multiple of 4 "
+            "(weight + weight_scale + weight_offset + scale_bias per quantized layer)"
+        )
+
+    # DSpark-specific check: draft wo_a must be preserved as FP8+scale.
+    # DSpark has 3 MTP layers, each with one wo_a → 3 wo_a.weight + 3 wo_a.scale.
+    if is_dspark:
+        draft_wo_a_weights = [
+            k for k in writer.quant_description if k.startswith("mtp.") and k.endswith(".attn.wo_a.weight")
+        ]
+        assert len(draft_wo_a_weights) == DSPARK_MTP_LAYERS, (
+            f"DSpark draft wo_a count ({len(draft_wo_a_weights)}) must be {DSPARK_MTP_LAYERS} "
+            "(one per MTP layer). Check that mtp.N.attn.wo_a weights exist in input."
+        )
+        draft_wo_a_scales = [
+            k for k in writer.quant_description if k.startswith("mtp.") and k.endswith(".attn.wo_a.scale")
+        ]
+        assert len(draft_wo_a_scales) == DSPARK_MTP_LAYERS, (
+            f"DSpark draft wo_a scale count ({len(draft_wo_a_scales)}) must be {DSPARK_MTP_LAYERS}. "
+            "Check that mtp.N.attn.wo_a.scale files exist in input."
+        )
+
+    # Write config.json (without quantization_config)
+    with open(os.path.join(output_hf_path, "config.json"), "w") as f:
+        json.dump(config, f, indent=2)
+
+    # Copy non-safetensors files (tokenizer, modeling code, etc.)
+    # Skip config.json (already written above) and model.safetensors.index.json
+    # (stale — references input FP8 shard names that don't exist in the output;
+    # vllm's filter_duplicate_safetensors_files would use it to filter out all
+    # quant_model_weights-*.safetensors, causing "Cannot find any model weights").
+    # The script writes quant_model_weights.safetensors.index.json via writer.close(),
+    # and vllm falls back to globbing *.safetensors when model.safetensors.index.json
+    # is absent.
+    skip_files = {"config.json", "model.safetensors.index.json"}
+    copy_extensions = (".py", ".json", ".jinja")
+    for root, _, files in os.walk(input_fp8_hf_path):
+        for file in files:
+            if file in skip_files:
+                continue
+            # .gitattributes is a hidden file with no extension, copy by name
+            if file.endswith(copy_extensions) or file == ".gitattributes":
+                src = os.path.join(root, file)
+                rel_dir = os.path.relpath(root, input_fp8_hf_path)
+                dst_dir = os.path.join(output_hf_path, rel_dir)
+                os.makedirs(dst_dir, exist_ok=True)
+                shutil.copy2(src, os.path.join(dst_dir, file))
+
+    print(f"\nQuantization complete. Output saved to: {output_hf_path}")
+    print(f"  - {writer._save_count} safetensors shards")
+    print(f"  - quant_model_description.json ({len(writer.quant_description)} entries)")
+    print("  - config.json (quantization_config removed)")
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+        description="Quantize DeepSeek-V4 FP8 weights (Flash/DSpark) to W8A8 for vllm-ascend."
+    )
+    parser.add_argument(
+        "--input_fp8_hf_path",
+        type=str,
+        required=True,
+        help="Path to HF directory containing DeepSeek-V4 FP8 weights (Flash, Flash-DSpark, or Pro-DSpark).",
+    )
+    parser.add_argument(
+        "--output_hf_path",
+        type=str,
+        required=True,
+        help="Path to output directory for W8A8 quantized weights.",
+    )
+    parser.add_argument(
+        "--config",
+        type=str,
+        default=None,
+        help="Path to YAML quantization config. Auto-selected based on model "
+        "variant: quantize_config_dspark.yaml for DSpark, quantize_config.yaml "
+        "otherwise.",
+    )
+    parser.add_argument(
+        "--device",
+        type=str,
+        choices=["auto", "cpu", "npu"],
+        default="auto",
+        help="Device for W8A8 quantization compute. 'auto' uses NPU if "
+        "torch_npu is installed and NPU is available, otherwise CPU. "
+        "CPU-only mode works everywhere and is only ~1 min slower for "
+        "Flash-scale models (quantization compute is not the bottleneck; "
+        "FP8 dequant + disk I/O dominate).",
+    )
+    args = parser.parse_args()
+
+    # Resolve 'auto' to concrete device
+    if args.device == "auto":
+        if HAS_TORCH_NPU and torch.npu.is_available():
+            args.device = "npu"
+        else:
+            args.device = "cpu"
+
+    if args.config is None:
+        # Auto-select YAML based on DSpark detection
+        with open(os.path.join(args.input_fp8_hf_path, "config.json")) as f:
+            hf_config = json.load(f)
+        if "dspark_block_size" in hf_config:
+            args.config = os.path.join(os.path.dirname(__file__), "quantize_config_dspark.yaml")
+        else:
+            args.config = os.path.join(os.path.dirname(__file__), "quantize_config.yaml")
+
+    main(args.input_fp8_hf_path, args.output_hf_path, args.config, args.device)

--- a/examples/quantization/deepseek_v4/quantize_config.yaml
+++ b/examples/quantization/deepseek_v4/quantize_config.yaml
@@ -1,0 +1,62 @@
+apiversion: modelslim_v1
+metadata:
+  config_id: deepseek_v4_flash_w8a8
+  score: 90
+  verified_model_types:
+    - DeepSeek-V4-Flash
+  verified_tags:
+    DeepSeek-V4-Flash:
+      - - vLLM-Ascend
+        - Atlas_A3_Inference
+  label:
+    w_bit: 8
+    a_bit: 8
+    is_sparse: False
+    kv_cache: False
+
+default_w8a8_dynamic: &default_w8a8_dynamic
+  act:
+    scope: "per_token"
+    dtype: "int8"
+    symmetric: True
+    method: "minmax"
+  weight:
+    scope: "per_channel"
+    dtype: "int8"
+    symmetric: True
+    method: "minmax"
+
+spec:
+  process:
+    # quaRot/smoothQuant are not executed in this script
+    - type: "linear_quant"
+      qconfig: *default_w8a8_dynamic
+      include:
+        - "*attn*"
+      exclude:
+        - "*attn.wq_a"
+        - "*attn.wkv"
+        - "*attn.wo_a"
+        - "*weights_proj"
+        - "*compressor.wgate"
+        - "*compressor.wkv"
+        - "*indexer.wkv"
+        - "*indexer.wgate"
+        - "*indexer.weights_proj"
+        - "*indexer.compressor.wgate"
+        - "*indexer.compressor.wkv"
+    - type: "linear_quant"
+      qconfig: *default_w8a8_dynamic
+      include:
+        - "*ffn*"
+      exclude:
+        - "*gate"
+    # MTP-specific projections
+    - type: "linear_quant"
+      qconfig: *default_w8a8_dynamic
+      include:
+        - "*e_proj"
+        - "*h_proj"
+  save:
+    - type: "ascendv1_saver"
+      part_file_size: 4

--- a/examples/quantization/deepseek_v4/quantize_config_dspark.yaml
+++ b/examples/quantization/deepseek_v4/quantize_config_dspark.yaml
@@ -1,0 +1,70 @@
+apiversion: modelslim_v1
+metadata:
+  config_id: deepseek_v4_dspark_w8a8
+  score: 90
+  verified_model_types:
+    - DeepSeek-V4-Flash-DSpark
+    - DeepSeek-V4-Pro-DSpark
+  verified_tags:
+    DeepSeek-V4-Flash-DSpark:
+      - - vLLM-Ascend
+        - Atlas_A3_Inference
+    DeepSeek-V4-Pro-DSpark:
+      - - vLLM-Ascend
+        - Atlas_A3_Inference
+  label:
+    w_bit: 8
+    a_bit: 8
+    is_sparse: False
+    kv_cache: False
+
+default_w8a8_dynamic: &default_w8a8_dynamic
+  act:
+    scope: "per_token"
+    dtype: "int8"
+    symmetric: True
+    method: "minmax"
+  weight:
+    scope: "per_channel"
+    dtype: "int8"
+    symmetric: True
+    method: "minmax"
+
+spec:
+  process:
+    # quaRot/smoothQuant are not executed in this script
+    # Rule 1: attention layers. wo_a is excluded from quantization for BOTH
+    # main model (kept as BF16 FLOAT) and draft model (kept as FP8+scale,
+    # because vllm-ascend dspark load_weights has a dedicated FP8->BF16
+    # dequant path for draft wo_a). wo_b is NOT excluded (draft model
+    # is_layer_skipped_ascend returns False, must be quantized).
+    - type: "linear_quant"
+      qconfig: *default_w8a8_dynamic
+      include:
+        - "*attn*"
+      exclude:
+        - "*attn.wq_a"
+        - "*attn.wkv"
+        - "*attn.wo_a"
+        - "*weights_proj"
+        - "*compressor.wgate"
+        - "*compressor.wkv"
+        - "*indexer.wkv"
+        - "*indexer.wgate"
+        - "*indexer.weights_proj"
+        - "*indexer.compressor.wgate"
+        - "*indexer.compressor.wkv"
+    - type: "linear_quant"
+      qconfig: *default_w8a8_dynamic
+      include:
+        - "*ffn*"
+      exclude:
+        - "*gate"
+    # DSpark MTP uses main_proj instead of e_proj/h_proj
+    - type: "linear_quant"
+      qconfig: *default_w8a8_dynamic
+      include:
+        - "*main_proj"
+  save:
+    - type: "ascendv1_saver"
+      part_file_size: 4

--- a/examples/quantization/deepseek_v4/quantize_config_pro_w4a8.yaml
+++ b/examples/quantization/deepseek_v4/quantize_config_pro_w4a8.yaml
@@ -1,0 +1,82 @@
+apiversion: modelslim_v1
+metadata:
+  config_id: deepseek_v4_pro_w4a8
+  score: 90
+  verified_model_types:
+    - DeepSeek-V4-Pro
+  verified_tags:
+    DeepSeek-V4-Pro:
+      - - vLLM-Ascend
+        - Atlas_A3_Inference
+  label:
+    w_bit: 4
+    a_bit: 8
+    is_sparse: False
+    kv_cache: False
+
+default_w4a8_dynamic: &default_w4a8_dynamic
+  act:
+    scope: "per_token"
+    dtype: "int8"
+    symmetric: True
+    method: "minmax"
+  weight:
+    scope: "per_channel"
+    dtype: "int4"
+    symmetric: True
+    method: "minmax"
+
+default_w8a8_dynamic: &default_w8a8_dynamic
+  act:
+    scope: "per_token"
+    dtype: "int8"
+    symmetric: True
+    method: "minmax"
+  weight:
+    scope: "per_channel"
+    dtype: "int8"
+    symmetric: True
+    method: "minmax"
+
+spec:
+  process:
+    # quaRot/smoothQuant are not executed in this script
+    # Rule 1: attention layers → W8A8 (same as Flash)
+    - type: "linear_quant"
+      qconfig: *default_w8a8_dynamic
+      include:
+        - "*attn*"
+      exclude:
+        - "*attn.wq_a"
+        - "*attn.wkv"
+        - "*attn.wo_a"
+        - "*weights_proj"
+        - "*compressor.wgate"
+        - "*compressor.wkv"
+        - "*indexer.wkv"
+        - "*indexer.wgate"
+        - "*indexer.weights_proj"
+        - "*indexer.compressor.wgate"
+        - "*indexer.compressor.wkv"
+    # Rule 2: routed experts → W4A8 (int4 weight)
+    - type: "linear_quant"
+      qconfig: *default_w4a8_dynamic
+      include:
+        - "*ffn*"
+      exclude:
+        - "*gate"
+        - "*shared_experts*"
+    # Rule 3: shared experts → W8A8 (int8 weight, every token executes)
+    - type: "linear_quant"
+      qconfig: *default_w8a8_dynamic
+      include:
+        - "*ffn.shared_experts*"
+    # Rule 4: MTP projections → W8A8 (Pro uses e_proj/h_proj, same as Flash)
+    - type: "linear_quant"
+      qconfig: *default_w8a8_dynamic
+      include:
+        - "*e_proj"
+        - "*h_proj"
+  save:
+    - type: "ascendv1_saver"
+      part_file_size: 4


### PR DESCRIPTION
# DeepSeek-V4 offline quantization script (W8A8 / W4A8)

### What this PR does / why we need it?

This PR adds a self-contained offline quantization toolset under `examples/quantization/deepseek_v4/` (one script + three YAML quantization configs + README). It converts DeepSeek-V4 native FP8 weights (Flash / Pro / Flash-DSpark / Pro-DSpark) into ModelSlim-format W8A8/W4A8 weights, which vllm-ascend auto-detects and loads on NPU **without the `--quantization` flag**.

**Why:**

- **Removes the msmodelslim dependency.** Previously, converting DeepSeek-V4 FP8 weights into vllm-ascend-loadable quantized weights required msmodelslim. This script re-implements the msmodelslim quantization algorithms and output format in pure PyTorch (torch_npu optional), so no extra package is needed.
- **Handles the DSpark draft `wo_a` format contract.** The DSpark `load_weights` path has a dedicated FP8→BF16 dequant route for draft-model `wo_a` (triggered by detecting `.wo_a.scale`). If the script dequantized or quantized this weight, that loading path would break. The script therefore passes draft `mtp.N.attn.wo_a` FP8 weights + `.scale` through as-is (documented in code comments).

**Key implementation points:**

1. **FP8/MXFP4 dequantization** — `decode_fp8` (e4m3, 128×128 blocks) and `decode_fp4` (MXFP4, 32 elements per block scale), aligned with msmodelslim `convert_fp8_to_bf16.py`.
2. **W8A8 quantization** — `weight_quant_sym_perchannel`: per-channel symmetric minmax (clamp [-128, 127]); each layer emits `.weight` (int8) + `.weight_scale` (fp32) + `.weight_offset` (fp32), matching the `W8A8_DYNAMIC` weight contract.
3. **W4A8 quantization (Pro)** — `weight_quant_w4a8_perchannel`: per-channel symmetric (Q_MAX=7) with two int4 values packed per int8 element (`w4a8_pack_int4`: transpose → pack along output dim → transpose back), plus `scale_bias = (quant_weight * scale).sum(dim=1) * 8` (computed value, not zeros — aligned with msmodelslim `process_scale`).
4. **YAML-driven rule matching** — `match_yaml_rules` uses include/exclude globs over weight names plus a `dim == 2` check for Linear weights; the `qconfig.weight.dtype` field dispatches int4 vs int8 paths.
5. **ModelSlim output format** — `BufferedSafetensorsWriter` flushes ~4GB shards (`quant_model_weights-{N:05d}-of-{M:05d}.safetensors`), writes `quant_model_weights.safetensors.index.json` and a per-weight `quant_model_description.json` (`W8A8_DYNAMIC` / `W4A8_DYNAMIC` / `FLOAT`); output `config.json` has `quantization_config` removed so `override_quantization_method()` auto-detects on NPU.
6. **DSpark support** — auto-detected via the `dspark_block_size` field in `config.json`; DSpark MTP uses `main_proj` (instead of `e_proj`/`h_proj`) which is quantized; non-DSpark embed/head → `mtp.0.*` duplication is skipped for DSpark (its `load_weights` handles this).
7. **Checkpoint-based crash recovery** — after each input shard: force flush + atomic checkpoint write (`.quantize_checkpoint.json`, temp file + rename). On restart: restore writer state, skip completed shards, clean up stale half-written shards; `close()` is idempotent across crashes; checkpoint deleted after successful completion.
8. **Device selection** — `--device auto/cpu/npu`; torch_npu is optional (only needed for NPU mode). FP8 dequantization always runs on CPU; NPU only accelerates the quantization compute.
9. **Post-quantization assertions** — W8A8 entry count must be a multiple of 3, W4A8 a multiple of 4; DSpark draft `wo_a` must be exactly 3 weight+scale pairs (3 MTP layers).

**Files changed:**

| File | Change |
|------|--------|
| `examples/quantization/deepseek_v4/README.md` | +229: usage doc (per-variant commands, serve commands, device selection, output format, crash recovery) |
| `examples/quantization/deepseek_v4/quantize.py` | +691: quantization script (dequant / W8A8 / W4A8 / sharded output / checkpoint resume / DSpark detection) |
| `examples/quantization/deepseek_v4/quantize_config.yaml` | +62: Flash W8A8 config |
| `examples/quantization/deepseek_v4/quantize_config_dspark.yaml` | +70: Flash-DSpark / Pro-DSpark W8A8 config |
| `examples/quantization/deepseek_v4/quantize_config_pro_w4a8.yaml` | +82: Pro mixed config — W4A8 (routed experts) + W8A8 (attn / shared_experts / MTP projections) |

**Known limitations:**

- The Pro (non-DSpark) variant cannot be auto-detected; `--config quantize_config_pro_w4a8.yaml` must be passed explicitly (noted in README). Pro-DSpark uses W8A8, not W4A8.
- No QuaRot / AWQ / SmoothQuant pre-processing — weight-only quantization (noted in the YAML configs).
- FP8 / MXFP4 inputs only; weights missing their scale tensor are kept as-is and marked `FLOAT` (with a warning).

### Does this PR introduce _any_ user-facing change?

Yes — a new example tool under `examples/quantization/deepseek_v4/`. No core code is modified, no API or behavior changes to existing functionality.

### How was this patch tested?

- `ruff check` and `ruff format` pass on the new files.
- YAML rule matching verified manually against real weight names: 20 DSV4 cases + 21 DSpark cases (covering `wo_a` / `wo_b` / `main_proj` / `markov_head` / `confidence_head` / `*gate` / `shared_experts` boundaries).
- W4A8 pack/unpack roundtrip verified (packed `[64, 256]`, unpacked values within `[-8, 7]`; odd output dim correctly rejected by assert; `scale_bias` non-zero and matching the formula).
- Small-scale end-to-end run: 2 input shards (4.4G) of DSV4 FP8 weights quantized successfully — 773 `W8A8_DYNAMIC` + 9 `FLOAT` entries in `quant_model_description.json`, `config.json` without `quantization_config`, correct shard/index output.
- Full-scale conversion + `vllm serve` smoke tests can be run with the copy-paste commands in `README.md` (requires the FP8 HF weights; DSpark variants serve with `--speculative-config '{"method":"dspark",...}'`).
- No unit tests added: examples/ scripts have no UT precedent in this repo (none of the 30+ existing example scripts carry tests), and the script includes built-in post-quantization assertions as a self-check. CI verification should suffice for the rest, since this PR touches examples only.

- vLLM main: https://github.com/vllm-project/vllm/commit/1f486d96a17303ce8db8e02be39545b2be338446
