### PR TITLE
[Refactor][Attention] Unify MRV2 PCP MLA metadata and implementation

### DIFF
--- a/tests/ut/attention/test_mla_v1.py
+++ b/tests/ut/attention/test_mla_v1.py
@@ -15,9 +15,6 @@ from vllm_ascend.attention.mla_v1 import (
     AscendMLAImpl,
     AscendMLAMetadata,
     AscendMLAMetadataBuilder,
-    AscendMLAPCPImpl,
-    AscendMLAPCPMetadata,
-    AscendMLAPCPMetadataBuilder,
     AscendMLAPrefillMetadata,
     ChunkedContextMetadata,
     DecodeMLAPreprocessResult,
@@ -48,30 +45,27 @@ class TestAscendMLABackend(TestBase):
         )
         self.mla_config_patcher.start()
 
-        from vllm_ascend.attention.utils import enable_dcp
+        from vllm_ascend.attention.utils import enable_dcp, enable_pcp
 
         enable_dcp.cache_clear()
+        enable_pcp.cache_clear()
 
     def test_get_name(self):
         self.assertEqual(AscendMLABackend.get_name(), "ASCEND_MLA")
 
-    @patch("vllm_ascend.attention.mla_v1.enable_pcp")
-    def test_get_builder_cls(self, mock_enable_pcp):
-        mock_enable_pcp.return_value = False
+    def test_get_builder_cls(self):
         self.assertEqual(AscendMLABackend.get_builder_cls(), AscendMLAMetadataBuilder)
-        mock_enable_pcp.return_value = True
-        self.assertIs(AscendMLABackend.get_builder_cls(), AscendMLAPCPMetadataBuilder)
+        self.mock_parallel_config.prefill_context_parallel_size = 2
+        self.assertIs(AscendMLABackend.get_builder_cls(), AscendMLAMetadataBuilder)
 
     def test_get_kv_cache_shape(self):
         result = AscendMLABackend.get_kv_cache_shape(2, 4, 8, 128)
         self.assertEqual(result, (2, 4, 8, 128))
 
-    @patch("vllm_ascend.attention.mla_v1.enable_pcp")
-    def test_get_impl_cls(self, mock_enable_pcp):
-        mock_enable_pcp.return_value = False
+    def test_get_impl_cls(self):
         self.assertEqual(AscendMLABackend.get_impl_cls(), AscendMLAImpl)
-        mock_enable_pcp.return_value = True
-        self.assertIs(AscendMLABackend.get_impl_cls(), AscendMLAPCPImpl)
+        self.mock_parallel_config.prefill_context_parallel_size = 2
+        self.assertIs(AscendMLABackend.get_impl_cls(), AscendMLAImpl)
 
     def test_get_supported_kernel_block_sizes(self):
         result = AscendMLABackend.get_supported_kernel_block_sizes()
@@ -106,8 +100,23 @@ def _make_pcp_metadata(
     num_actual_tokens: int,
     num_decode_tokens: int,
     attn_state: AscendAttentionState = AscendAttentionState.ChunkedPrefill,
-) -> AscendMLAPCPMetadata:
-    return AscendMLAPCPMetadata(
+) -> AscendMLAMetadata:
+    num_prefills = int(num_actual_tokens > num_decode_tokens)
+    prefill_metadata = None
+    if num_prefills > 0:
+        prefill_metadata = AscendMLAPrefillMetadata(
+            attn_mask=torch.empty(0),
+            query_lens=torch.empty(0, dtype=torch.int32),
+            seq_lens=[],
+            context_lens=torch.empty(0, dtype=torch.int32),
+            input_positions=torch.empty(0, dtype=torch.int64),
+            query_start_loc=torch.tensor([0], dtype=torch.int32),
+            block_table=torch.empty(0, 0, dtype=torch.int32),
+            max_query_len=0,
+            max_seq_lens=0,
+        )
+
+    return AscendMLAMetadata(
         num_actual_tokens=num_actual_tokens,
         slot_mapping=torch.empty(0, dtype=torch.int64),
         query_start_loc=torch.tensor([0, num_actual_tokens], dtype=torch.int32),
@@ -116,8 +125,9 @@ def _make_pcp_metadata(
         block_tables=torch.zeros(1, 1, dtype=torch.int32),
         num_decodes=int(num_decode_tokens > 0),
         num_decode_tokens=num_decode_tokens,
-        num_prefills=int(num_actual_tokens > num_decode_tokens),
+        num_prefills=num_prefills,
         attn_state=attn_state,
+        prefill=prefill_metadata,
     )
 
 
@@ -126,28 +136,28 @@ def test_mla_pcp_metadata_keeps_expanded_slot_mapping() -> None:
         [5, 10, 11, -1, -1, 20, 21, -1],
         dtype=torch.int64,
     )
-    common_metadata = SimpleNamespace(slot_mapping=expanded_slots)
     metadata = _make_pcp_metadata(
         num_actual_tokens=3,
         num_decode_tokens=1,
         attn_state=AscendAttentionState.PrefillCacheHit,
     )
-    builder = AscendMLAPCPMetadataBuilder.__new__(AscendMLAPCPMetadataBuilder)
+    builder = AscendMLAMetadataBuilder.__new__(AscendMLAMetadataBuilder)
     builder.pcp_size = 2
     builder.pcp_rank = 1
 
-    with patch.object(AscendMLAMetadataBuilder, "build", return_value=metadata):
-        result = builder.build(0, common_metadata)
+    builder._finalize_pcp_metadata(metadata, expanded_slots)
 
-    assert result.slot_mapping is expanded_slots
-    assert result.pcp_local_num_input_tokens == 4
-    assert result.pcp_local_prefill_start == 3
-    assert result.pcp_local_prefill_end == 5
-    assert result.attn_state == AscendAttentionState.ChunkedPrefill
+    assert metadata.slot_mapping is expanded_slots
+    prefill_metadata = metadata.prefill
+    assert prefill_metadata is not None
+    assert prefill_metadata.pcp_local_num_input_tokens == 4
+    assert prefill_metadata.pcp_local_prefill_start == 3
+    assert prefill_metadata.pcp_local_prefill_end == 5
+    assert metadata.attn_state == AscendAttentionState.ChunkedPrefill
 
 
 def test_mla_pcp_prefill_gathers_padded_cache_inputs() -> None:
-    impl = AscendMLAPCPImpl.__new__(AscendMLAPCPImpl)
+    impl = AscendMLAImpl.__new__(AscendMLAImpl)
     captured: dict[str, torch.Tensor] = {}
 
     def fake_gather(tensors, slot_mapping, num_decode_tokens):
@@ -160,10 +170,10 @@ def test_mla_pcp_prefill_gathers_padded_cache_inputs() -> None:
             slot_mapping,
         )
 
-    def fake_exec_kv_prefill(self, kv, cos, sin, kv_cache, slots):
+    def fake_kv_cache(kv, _weight, cos, _sin, slots, *_args, **_kwargs):
         captured["gathered_kv"] = kv
         captured["cache_slots"] = slots
-        return cos, kv[:, :2]
+        return None, None, cos, kv.view(kv.shape[0], -1)[:, :2]
 
     pcp_group = SimpleNamespace(world_size=2, rank_in_group=1)
     metadata = _make_pcp_metadata(num_actual_tokens=3, num_decode_tokens=1)
@@ -171,9 +181,21 @@ def test_mla_pcp_prefill_gathers_padded_cache_inputs() -> None:
         [5, 10, 11, -1, -1, 20, 21, -1],
         dtype=torch.int64,
     )
-    metadata.pcp_local_num_input_tokens = 4
-    metadata.pcp_local_prefill_start = 3
-    metadata.pcp_local_prefill_end = 5
+    prefill_metadata = metadata.prefill
+    assert prefill_metadata is not None
+    prefill_metadata.pcp_local_num_input_tokens = 4
+    prefill_metadata.pcp_local_prefill_start = 3
+    prefill_metadata.pcp_local_prefill_end = 5
+    impl.pcp_enabled = True
+    impl.use_mla_rope = True
+    impl.kv_a_layernorm = SimpleNamespace(
+        weight=torch.empty(0),
+        variance_epsilon=1e-6,
+    )
+    impl.num_kv_heads = 1
+    impl.kv_lora_rank = 2
+    impl.qk_rope_head_dim = 1
+    impl.fa_quant_layer = False
     kv = torch.arange(9, dtype=torch.float32).view(3, 3)
     cos = torch.tensor([[1.0], [2.0], [1.0]])
     sin = torch.tensor([[3.0], [4.0], [0.0]])
@@ -187,10 +209,13 @@ def test_mla_pcp_prefill_gathers_padded_cache_inputs() -> None:
             "vllm_ascend.attention.mla_v1._gather_prefill_cache_inputs",
             side_effect=fake_gather,
         ),
-        patch.object(
-            AscendMLAImpl,
-            "exec_kv_prefill",
-            fake_exec_kv_prefill,
+        patch(
+            "vllm_ascend.attention.mla_v1.torch_npu.npu_kv_rmsnorm_rope_cache",
+            side_effect=fake_kv_cache,
+        ),
+        patch(
+            "vllm_ascend.attention.mla_v1.get_ascend_device_type",
+            return_value=None,
         ),
     ):
         k_pe, k_nope = impl.exec_kv_prefill(
@@ -202,6 +227,7 @@ def test_mla_pcp_prefill_gathers_padded_cache_inputs() -> None:
             attn_metadata=metadata,
         )
 
+    assert impl._get_num_prefill_kv_tokens(metadata) == 3
     expected_slots = torch.tensor([10, 11, -1, 20, 21, -1])
     torch.testing.assert_close(captured["slots"], expected_slots)
     assert captured["local_kv"] is kv
@@ -462,6 +488,7 @@ class TestAscendMLAMetadataBuilder(TestBase):
 
     def test_ascend_mla_metadata_builder_default(self):
         mock_vllm_config = MagicMock()
+        mock_vllm_config.parallel_config.prefill_context_parallel_size = 1
         mock_vllm_config.model_config.max_model_len = 1024
         mock_vllm_config.model_config.get_head_size.return_value = 64
         mock_vllm_config.model_config.dtype = torch.float16
@@ -489,6 +516,7 @@ class TestAscendMLAMetadataBuilder(TestBase):
         mock_vllm_config.cache_config.block_size = 16
         mock_vllm_config.scheduler_config.max_num_seqs = 4
         mock_vllm_config.scheduler_config.enable_chunked_prefill = False
+        mock_vllm_config.parallel_config.prefill_context_parallel_size = 1
         mock_vllm_config.speculative_config = None
 
         for layer_uses_rope in (True, False):
@@ -544,6 +572,7 @@ class TestAscendMLAMetadataBuilder(TestBase):
 
     def test_ascend_mla_metadata_builder_spec_decode(self):
         mock_vllm_config = MagicMock()
+        mock_vllm_config.parallel_config.prefill_context_parallel_size = 1
         mock_vllm_config.model_config.max_model_len = 1024
         mock_vllm_config.model_config.get_head_size.return_value = 64
         mock_vllm_config.model_config.dtype = torch.float16
@@ -611,6 +640,7 @@ class TestAscendMLAMetadataBuilder(TestBase):
         ascend_config = MagicMock()
 
         mock_vllm_config = MagicMock()
+        mock_vllm_config.parallel_config.prefill_context_parallel_size = 1
         mock_vllm_config.model_config.max_model_len = 1024
         mock_vllm_config.model_config.get_head_size.return_value = 64
         mock_vllm_config.model_config.dtype = torch.float16
@@ -663,6 +693,7 @@ class TestAscendMLAMetadataBuilder(TestBase):
 
     def test_set_num_actual_tokens(self):
         mock_vllm_config = MagicMock()
+        mock_vllm_config.parallel_config.prefill_context_parallel_size = 1
         mock_vllm_config.model_config.max_model_len = 1024
         mock_vllm_config.model_config.get_head_size.return_value = 64
         mock_vllm_config.model_config.dtype = torch.float16
@@ -683,6 +714,7 @@ class TestAscendMLAMetadataBuilder(TestBase):
 
     def test_pad_actual_seq_lens_q_mtp_disable_pad(self):
         mock_vllm_config = MagicMock()
+        mock_vllm_config.parallel_config.prefill_context_parallel_size = 1
         mock_vllm_config.model_config.max_model_len = 1024
         mock_vllm_config.model_config.get_head_size.return_value = 64
         mock_vllm_config.model_config.dtype = torch.float16
@@ -704,6 +736,7 @@ class TestAscendMLAMetadataBuilder(TestBase):
 
     def test_pad_actual_seq_lens_q_mtp_enable_pad(self):
         mock_vllm_config = MagicMock()
+        mock_vllm_config.parallel_config.prefill_context_parallel_size = 1
         mock_vllm_config.model_config.max_model_len = 1024
         mock_vllm_config.model_config.get_head_size.return_value = 64
         mock_vllm_config.model_config.dtype = torch.float16
@@ -730,6 +763,7 @@ class TestAscendMLAMetadataBuilder(TestBase):
 
     def test_pad_actual_seq_lens_q_mtp_enable_pad_with_padding(self):
         mock_vllm_config = MagicMock()
+        mock_vllm_config.parallel_config.prefill_context_parallel_size = 1
         mock_vllm_config.model_config.max_model_len = 1024
         mock_vllm_config.model_config.get_head_size.return_value = 64
         mock_vllm_config.model_config.dtype = torch.float16
@@ -807,6 +841,29 @@ class TestAscendMLAMetadataBuilderBuild(TestBase):
 
     def tearDown(self):
         self.parent_init_patcher.stop()
+
+    @patch("vllm_ascend.attention.mla_v1.get_pcp_group")
+    def test_pcp_mode_is_initialized_from_config(self, mock_get_pcp_group):
+        builder = AscendMLAMetadataBuilder(
+            self.kv_cache_spec,
+            ["layer_0"],
+            self.mock_vllm_config,
+            self.mock_device,
+        )
+        self.assertFalse(builder.pcp_enabled)
+        self.assertIs(builder.metadata_cls, AscendMLAMetadata)
+
+        self.mock_vllm_config.parallel_config.prefill_context_parallel_size = 2
+        mock_get_pcp_group.return_value.rank_in_group = 1
+        pcp_builder = AscendMLAMetadataBuilder(
+            self.kv_cache_spec,
+            ["layer_0"],
+            self.mock_vllm_config,
+            self.mock_device,
+        )
+        self.assertTrue(pcp_builder.pcp_enabled)
+        self.assertIs(pcp_builder.metadata_cls, AscendMLAMetadata)
+        self.assertEqual(pcp_builder.pcp_rank, 1)
 
     @patch("vllm_ascend.attention.mla_v1.get_cos_and_sin_mla")
     @patch("vllm_ascend.attention.mla_v1.torch.zeros", wraps=torch.zeros)
@@ -1217,6 +1274,7 @@ class TestAscendMLAImpl(TestBase):
         self.assertEqual(self.impl.scale, 0.1)
         self.assertEqual(self.impl.num_kv_heads, 8)
         self.assertEqual(self.impl.kv_cache_dtype, "auto")
+        self.assertFalse(self.impl.pcp_enabled)
         self.assertEqual(self.impl.kv_lora_rank, 32)
         self.assertEqual(self.impl.qk_nope_head_dim, 64)
         self.assertEqual(self.impl.qk_rope_head_dim, 32)
@@ -1236,6 +1294,7 @@ class TestAscendMLAImpl(TestBase):
     def test_init_head_padding_for_non_power_of_two(self, mock_get_current_vllm_config):
         """Test head padding computation for num_heads that are not power of 2 (e.g. GLM-4.7-Flash with 20 heads)."""
         mock_get_current_vllm_config.return_value = MagicMock()
+        mock_get_current_vllm_config.return_value.parallel_config.prefill_context_parallel_size = 1
         kwargs = {
             "kv_lora_rank": 32,
             "qk_nope_head_dim": 64,
@@ -1683,6 +1742,7 @@ class TestAscendMLAImpl(TestBase):
     def test_forward_prefill_non_power_of_two_heads(self, mock_fia, mock_device_operator, mock_get_current_vllm_config):
         """Test prefill with non-power-of-2 heads uses concat instead of query_rope/key_rope kwargs."""
         mock_get_current_vllm_config.return_value = MagicMock()
+        mock_get_current_vllm_config.return_value.parallel_config.prefill_context_parallel_size = 1
         num_heads = 20
         kwargs = {
             "kv_lora_rank": 32,
@@ -2028,6 +2088,7 @@ class TestAscendMLAImpl(TestBase):
     ):
         """Test prefill context with non-power-of-2 heads uses concat for query and key."""
         mock_get_current_vllm_config.return_value = MagicMock()
+        mock_get_current_vllm_config.return_value.parallel_config.prefill_context_parallel_size = 1
         num_heads = 20
         kwargs = {
             "kv_lora_rank": 32,
@@ -2354,6 +2415,7 @@ class TestAscendMLAImpl(TestBase):
     ):
         """Test decode with non-power-of-2 heads pads to next power of 2 and slices output."""
         mock_get_current_vllm_config.return_value = MagicMock()
+        mock_get_current_vllm_config.return_value.parallel_config.prefill_context_parallel_size = 1
         num_heads = 20
         kwargs = {
             "kv_lora_rank": 256,
@@ -2430,6 +2492,7 @@ class TestAscendMLAImpl(TestBase):
     ):
         """Test normal decode (BNSD_NBSD) with non-power-of-2 heads pads q and slices output."""
         mock_get_current_vllm_config.return_value = MagicMock()
+        mock_get_current_vllm_config.return_value.parallel_config.prefill_context_parallel_size = 1
         num_heads = 20
         kwargs = {
             "kv_lora_rank": 256,

--- a/tests/ut/attention/test_mla_v1.py
+++ b/tests/ut/attention/test_mla_v1.py
@@ -83,7 +83,6 @@ class TestAscendMLABackend(TestBase):
         self.assertIsNotNone(impl_cls)
 
 
-
 def _make_pcp_metadata(
     *,
     num_actual_tokens: int,

--- a/tests/ut/attention/test_mla_v1.py
+++ b/tests/ut/attention/test_mla_v1.py
@@ -196,6 +196,7 @@ def test_mla_pcp_prefill_gathers_padded_cache_inputs() -> None:
     impl.kv_lora_rank = 2
     impl.qk_rope_head_dim = 1
     impl.fa_quant_layer = False
+    impl.support_fp8_attention = False
     kv = torch.arange(9, dtype=torch.float32).view(3, 3)
     cos = torch.tensor([[1.0], [2.0], [1.0]])
     sin = torch.tensor([[3.0], [4.0], [0.0]])
@@ -212,10 +213,6 @@ def test_mla_pcp_prefill_gathers_padded_cache_inputs() -> None:
         patch(
             "vllm_ascend.attention.mla_v1.torch_npu.npu_kv_rmsnorm_rope_cache",
             side_effect=fake_kv_cache,
-        ),
-        patch(
-            "vllm_ascend.attention.mla_v1.get_ascend_device_type",
-            return_value=None,
         ),
     ):
         k_pe, k_nope = impl.exec_kv_prefill(

--- a/tests/ut/attention/test_mla_v1.py
+++ b/tests/ut/attention/test_mla_v1.py
@@ -223,6 +223,62 @@ def test_mla_pcp_prefill_gathers_padded_cache_inputs() -> None:
     torch.testing.assert_close(k_nope, kv[:2, :2])
 
 
+def test_mla_pcp_nope_prefill_trims_gathered_outputs() -> None:
+    impl = AscendMLAImpl.__new__(AscendMLAImpl)
+
+    def fake_gather(tensors, slot_mapping, num_decode_tokens):
+        assert num_decode_tokens == 0
+        return (
+            tuple(torch.cat((tensor + 100, tensor), dim=0) for tensor in tensors),
+            slot_mapping,
+        )
+
+    pcp_group = SimpleNamespace(world_size=2, rank_in_group=1)
+    metadata = _make_pcp_metadata(num_actual_tokens=3, num_decode_tokens=1)
+    metadata.slot_mapping = torch.tensor(
+        [5, 10, 11, -1, -1, 20, 21, -1],
+        dtype=torch.int64,
+    )
+    prefill_metadata = metadata.prefill
+    assert prefill_metadata is not None
+    prefill_metadata.pcp_local_num_input_tokens = 4
+    prefill_metadata.pcp_local_prefill_start = 3
+    prefill_metadata.pcp_local_prefill_end = 5
+
+    impl.pcp_enabled = True
+    impl.use_mla_rope = True
+    impl.kv_a_layernorm = object()
+    impl.num_kv_heads = 1
+    impl.kv_lora_rank = 2
+    impl.qk_rope_head_dim = 0
+
+    gathered_k_pe = torch.empty(6, 1, 1, 0)
+    gathered_k_nope = torch.arange(12, dtype=torch.float32).view(6, 1, 1, 2)
+    impl._exec_kv_mla_nope = MagicMock(return_value=(gathered_k_pe, gathered_k_nope))
+
+    with (
+        patch(
+            "vllm_ascend.attention.mla_v1.get_pcp_group",
+            return_value=pcp_group,
+        ),
+        patch(
+            "vllm_ascend.attention.mla_v1._gather_prefill_cache_inputs",
+            side_effect=fake_gather,
+        ),
+    ):
+        k_pe, k_nope = impl.exec_kv_prefill(
+            torch.arange(6, dtype=torch.float32).view(3, 2),
+            torch.empty(3, 0),
+            torch.empty(3, 0),
+            (torch.empty(0), torch.empty(0)),
+            torch.empty(0, dtype=torch.int64),
+            attn_metadata=metadata,
+        )
+
+    assert k_pe.shape == (2, 1, 1, 0)
+    torch.testing.assert_close(k_nope, gathered_k_nope[3:5])
+
+
 class TestDecodeMLAPreprocessResult(TestBase):
     def test_decode_mla_preprocess_result_default(self):
         result = DecodeMLAPreprocessResult()
@@ -528,6 +584,7 @@ class TestAscendMLAMetadataBuilder(TestBase):
         mock_vllm_config.scheduler_config.max_num_seqs = 4
         mock_vllm_config.scheduler_config.enable_chunked_prefill = False
         mock_vllm_config.speculative_config = None
+        mock_vllm_config.parallel_config.prefill_context_parallel_size = 1
 
         for qk_rope_head_dim, expected in ((64, None), (0, {})):
             with self.subTest(qk_rope_head_dim=qk_rope_head_dim):

--- a/tests/ut/attention/test_mla_v1.py
+++ b/tests/ut/attention/test_mla_v1.py
@@ -45,10 +45,9 @@ class TestAscendMLABackend(TestBase):
         )
         self.mla_config_patcher.start()
 
-        from vllm_ascend.attention.utils import enable_dcp, enable_pcp
+        from vllm_ascend.attention.utils import enable_dcp
 
         enable_dcp.cache_clear()
-        enable_pcp.cache_clear()
 
     def test_get_name(self):
         self.assertEqual(AscendMLABackend.get_name(), "ASCEND_MLA")
@@ -83,16 +82,6 @@ class TestAscendMLABackend(TestBase):
         impl_cls = AscendMLABackend.get_impl_cls()
         self.assertIsNotNone(impl_cls)
 
-    @patch("vllm_ascend.attention.mla_v1.enable_dcp")
-    @patch("vllm_ascend.attention.mla_v1.enable_pcp")
-    def test_pcp_and_dcp_are_rejected(self, mock_enable_pcp, mock_enable_dcp):
-        mock_enable_dcp.return_value = True
-        mock_enable_pcp.return_value = True
-
-        with self.assertRaisesRegex(NotImplementedError, "does not support PCP and DCP"):
-            AscendMLABackend.get_builder_cls()
-        with self.assertRaisesRegex(NotImplementedError, "does not support PCP and DCP"):
-            AscendMLABackend.get_impl_cls()
 
 
 def _make_pcp_metadata(

--- a/vllm_ascend/attention/mla_v1.py
+++ b/vllm_ascend/attention/mla_v1.py
@@ -553,9 +553,10 @@ class AscendMLAMetadataBuilder(MLACommonMetadataBuilder[AscendMLAMetadata]):
             prefill_metadata = metadata.prefill
             assert prefill_metadata is not None
             prefill_metadata.pcp_local_num_input_tokens = local_num_input_tokens
-            prefill_metadata.pcp_local_prefill_start = self.pcp_rank * local_prefill_capacity
+            local_prefill_start = self.pcp_rank * local_prefill_capacity
+            prefill_metadata.pcp_local_prefill_start = local_prefill_start
             prefill_metadata.pcp_local_prefill_end = (
-                prefill_metadata.pcp_local_prefill_start + metadata.num_actual_tokens - metadata.num_decode_tokens
+                local_prefill_start + metadata.num_actual_tokens - metadata.num_decode_tokens
             )
             # PCP partitions prefill tokens into rank-local chunks, including
             # continued prefills whose uncached suffix contains only one token.

--- a/vllm_ascend/attention/mla_v1.py
+++ b/vllm_ascend/attention/mla_v1.py
@@ -91,15 +91,12 @@ class AscendMLABackend(AttentionBackend):
     @staticmethod
     def get_builder_cls():
         dcp_enabled = enable_dcp()
-        pcp_enabled = enable_pcp()
-        if dcp_enabled and pcp_enabled:
-            raise NotImplementedError("Ascend MRV2 MLA does not support PCP and DCP simultaneously yet.")
         if dcp_enabled:
+            if enable_pcp():
+                raise NotImplementedError("Ascend MRV2 MLA does not support PCP and DCP simultaneously yet.")
             from vllm_ascend.attention.context_parallel.mla_cp import AscendMlaDCPMetadataBuilder
 
             return AscendMlaDCPMetadataBuilder
-        if pcp_enabled:
-            return AscendMLAPCPMetadataBuilder
         return AscendMLAMetadataBuilder
 
     @staticmethod
@@ -115,15 +112,12 @@ class AscendMLABackend(AttentionBackend):
     @staticmethod
     def get_impl_cls() -> type["MLAAttentionImpl"]:
         dcp_enabled = enable_dcp()
-        pcp_enabled = enable_pcp()
-        if dcp_enabled and pcp_enabled:
-            raise NotImplementedError("Ascend MRV2 MLA does not support PCP and DCP simultaneously yet.")
         if dcp_enabled:
+            if enable_pcp():
+                raise NotImplementedError("Ascend MRV2 MLA does not support PCP and DCP simultaneously yet.")
             from vllm_ascend.attention.context_parallel.mla_cp import AscendMlaDCPImpl
 
             return AscendMlaDCPImpl
-        if pcp_enabled:
-            return AscendMLAPCPImpl
         return AscendMLAImpl
 
     @staticmethod
@@ -166,6 +160,9 @@ class AscendMLAPrefillMetadata:
     sin: torch.Tensor = None
     cos: torch.Tensor = None
     actual_seq_lengths_q: list[int] | None = None
+    pcp_local_num_input_tokens: int | None = None
+    pcp_local_prefill_start: int | None = None
+    pcp_local_prefill_end: int | None = None
 
 
 @dataclass
@@ -242,15 +239,6 @@ class AscendMLAMetadata:
         #         f"received {self.head_dim}.")
 
 
-@dataclass
-class AscendMLAPCPMetadata(AscendMLAMetadata):
-    """MLA metadata needed to write the complete PCP prefill KV cache."""
-
-    pcp_local_num_input_tokens: int = 0
-    pcp_local_prefill_start: int = 0
-    pcp_local_prefill_end: int = 0
-
-
 M = TypeVar("M", bound=AscendMLAMetadata)
 
 
@@ -279,6 +267,11 @@ class AscendMLAMetadataBuilder(MLACommonMetadataBuilder[AscendMLAMetadata]):
             metadata_cls if metadata_cls is not None else AscendMLAMetadata,
             supports_dcp_with_varlen,
         )
+        self.pcp_size = vllm_config.parallel_config.prefill_context_parallel_size
+        self.pcp_enabled = self.pcp_size > 1
+        self.pcp_rank = 0
+        if self.pcp_enabled:
+            self.pcp_rank = get_pcp_group().rank_in_group
 
         scheduler_config = vllm_config.scheduler_config
 
@@ -468,6 +461,7 @@ class AscendMLAMetadataBuilder(MLACommonMetadataBuilder[AscendMLAMetadata]):
         common_attn_metadata: AscendCommonAttentionMetadata,
         fast_build: bool = False,
     ) -> AscendMLAMetadata:
+        expanded_slot_mapping = common_attn_metadata.slot_mapping if self.pcp_enabled else None
         num_reqs = common_attn_metadata.num_reqs
         query_start_loc = common_attn_metadata.query_start_loc
         query_start_loc_cpu = common_attn_metadata.query_start_loc_cpu
@@ -478,8 +472,7 @@ class AscendMLAMetadataBuilder(MLACommonMetadataBuilder[AscendMLAMetadata]):
                 common_attn_metadata,
                 decode_threshold=self.decode_threshold,
                 treat_short_extends_as_decodes=not (
-                    parallel_config.prefill_context_parallel_size > 1
-                    or parallel_config.decode_context_parallel_size > 1
+                    self.pcp_enabled or parallel_config.decode_context_parallel_size > 1
                 ),
             )
         )
@@ -512,7 +505,7 @@ class AscendMLAMetadataBuilder(MLACommonMetadataBuilder[AscendMLAMetadata]):
         decode_metadata = None
         if self.num_decodes > 0:
             decode_metadata = self.build_decode_metadata(common_prefix_len, common_attn_metadata)
-        return self.metadata_cls(  # type: ignore
+        metadata = self.metadata_cls(  # type: ignore
             num_input_tokens=common_attn_metadata.num_input_tokens,
             num_actual_tokens=self.num_actual_tokens,
             query_lens=self.query_lens.tolist(),
@@ -531,6 +524,44 @@ class AscendMLAMetadataBuilder(MLACommonMetadataBuilder[AscendMLAMetadata]):
             seq_lens=self.seq_lens,
             seq_lens_cpu=self.seq_lens,
         )
+        if self.pcp_enabled:
+            assert expanded_slot_mapping is not None
+            self._finalize_pcp_metadata(metadata, expanded_slot_mapping)
+        return metadata
+
+    def _finalize_pcp_metadata(
+        self,
+        metadata: AscendMLAMetadata,
+        expanded_slot_mapping: torch.Tensor,
+    ) -> None:
+        if expanded_slot_mapping.numel() % self.pcp_size != 0:
+            raise RuntimeError(
+                "PCP slot mapping size must be divisible by the PCP world size: "
+                f"{expanded_slot_mapping.numel()} % {self.pcp_size} != 0."
+            )
+
+        local_num_input_tokens = expanded_slot_mapping.numel() // self.pcp_size
+        if metadata.num_actual_tokens > local_num_input_tokens:
+            raise RuntimeError(
+                "PCP actual token count exceeds the rank-local padded token count: "
+                f"{metadata.num_actual_tokens} > {local_num_input_tokens}."
+            )
+
+        local_prefill_capacity = local_num_input_tokens - metadata.num_decode_tokens
+        metadata.slot_mapping = expanded_slot_mapping
+        if metadata.num_prefills > 0:
+            prefill_metadata = metadata.prefill
+            assert prefill_metadata is not None
+            prefill_metadata.pcp_local_num_input_tokens = local_num_input_tokens
+            prefill_metadata.pcp_local_prefill_start = self.pcp_rank * local_prefill_capacity
+            prefill_metadata.pcp_local_prefill_end = (
+                prefill_metadata.pcp_local_prefill_start + metadata.num_actual_tokens - metadata.num_decode_tokens
+            )
+            # PCP partitions prefill tokens into rank-local chunks, including
+            # continued prefills whose uncached suffix contains only one token.
+            # Keep decode-only batches on their graph path, but route every batch
+            # containing prefill work through the chunked-prefill implementation.
+            metadata.attn_state = AscendAttentionState.ChunkedPrefill
 
     def build_chunked_metadata(
         self,
@@ -734,71 +765,6 @@ class AscendMLAMetadataBuilder(MLACommonMetadataBuilder[AscendMLAMetadata]):
         return attn_metadata
 
 
-class AscendMLAPCPMetadataBuilder(AscendMLAMetadataBuilder):
-    """Build rank-local MLA metadata while retaining PCP cache-write slots."""
-
-    def __init__(
-        self,
-        kv_cache_spec: AscendMLAAttentionSpec,
-        layer_names: list[str],
-        vllm_config: VllmConfig,
-        device: torch.device,
-        metadata_cls: type[AscendMLAMetadata] | None = None,
-        supports_dcp_with_varlen: bool = False,
-    ) -> None:
-        super().__init__(
-            kv_cache_spec,
-            layer_names,
-            vllm_config,
-            device,
-            metadata_cls or AscendMLAPCPMetadata,
-            supports_dcp_with_varlen,
-        )
-        self.pcp_size = vllm_config.parallel_config.prefill_context_parallel_size
-        self.pcp_rank = get_pcp_group().rank_in_group
-
-    def build(
-        self,
-        common_prefix_len: int,
-        common_attn_metadata: AscendCommonAttentionMetadata,
-        fast_build: bool = False,
-    ) -> AscendMLAPCPMetadata:
-        expanded_slot_mapping = common_attn_metadata.slot_mapping
-        metadata = super().build(
-            common_prefix_len,
-            common_attn_metadata,
-            fast_build,
-        )
-        assert isinstance(metadata, AscendMLAPCPMetadata)
-        if expanded_slot_mapping.numel() % self.pcp_size != 0:
-            raise RuntimeError(
-                "PCP slot mapping size must be divisible by the PCP world size: "
-                f"{expanded_slot_mapping.numel()} % {self.pcp_size} != 0."
-            )
-
-        local_num_input_tokens = expanded_slot_mapping.numel() // self.pcp_size
-        if metadata.num_actual_tokens > local_num_input_tokens:
-            raise RuntimeError(
-                "PCP actual token count exceeds the rank-local padded token count: "
-                f"{metadata.num_actual_tokens} > {local_num_input_tokens}."
-            )
-
-        local_prefill_capacity = local_num_input_tokens - metadata.num_decode_tokens
-        metadata.slot_mapping = expanded_slot_mapping
-        metadata.pcp_local_num_input_tokens = local_num_input_tokens
-        metadata.pcp_local_prefill_start = self.pcp_rank * local_prefill_capacity
-        metadata.pcp_local_prefill_end = (
-            metadata.pcp_local_prefill_start + metadata.num_actual_tokens - metadata.num_decode_tokens
-        )
-        # PCP partitions prefill tokens into rank-local chunks, including
-        # continued prefills whose uncached suffix contains only one token.
-        # Keep decode-only batches on their graph path, but route every batch
-        # containing prefill work through the chunked-prefill implementation.
-        if metadata.num_prefills > 0:
-            metadata.attn_state = AscendAttentionState.ChunkedPrefill
-        return metadata
-
-
 class DecodeMLAPreprocessResult(NamedTuple):
     ql_nope: torch.Tensor | None = None
     q_pe: torch.Tensor | None = None
@@ -860,6 +826,7 @@ class AscendMLAImpl(MLAAttentionImpl):
         self.use_output_gate = self.g_proj is not None
         self.use_mla_rope = kwargs.get("use_mla_rope", True)
         self.vllm_config = get_current_vllm_config()
+        self.pcp_enabled = self.vllm_config.parallel_config.prefill_context_parallel_size > 1
         self.kv_a_proj_with_mqa = kwargs.get("kv_a_proj_with_mqa")
         self.kv_a_layernorm = kwargs.get("kv_a_layernorm")
         self.q_a_layernorm = kwargs.get("q_a_layernorm")
@@ -1516,6 +1483,41 @@ class AscendMLAImpl(MLAAttentionImpl):
         if not self.use_mla_rope:
             return self._exec_kv_no_rope(kv_no_split, kv_cache, slots)
 
+        pcp_prefill_range = None
+        if self.pcp_enabled:
+            assert attn_metadata is not None
+            prefill_metadata = attn_metadata.prefill
+            assert prefill_metadata is not None
+            local_num_input_tokens = prefill_metadata.pcp_local_num_input_tokens
+            local_prefill_start = prefill_metadata.pcp_local_prefill_start
+            local_prefill_end = prefill_metadata.pcp_local_prefill_end
+            assert (
+                local_num_input_tokens is not None and local_prefill_start is not None and local_prefill_end is not None
+            ), "PCP MLA metadata must be finalized before execution."
+
+            num_decode_tokens = attn_metadata.num_decode_tokens
+            local_prefill_capacity = local_num_input_tokens - num_decode_tokens
+            if not (kv_no_split.shape[0] == cos.shape[0] == sin.shape[0] == local_prefill_capacity):
+                raise RuntimeError(
+                    "PCP MLA prefill input length mismatch: "
+                    f"kv={kv_no_split.shape[0]}, cos={cos.shape[0]}, "
+                    f"sin={sin.shape[0]}, expected={local_prefill_capacity}."
+                )
+
+            pcp_group = get_pcp_group()
+            rank_slot_mappings = attn_metadata.slot_mapping.view(
+                pcp_group.world_size,
+                local_num_input_tokens,
+            )
+            # Remove the decoding area and flatten it.
+            expanded_prefill_slots = rank_slot_mappings[:, num_decode_tokens:].flatten()
+            (kv_no_split, cos, sin), slots = _gather_prefill_cache_inputs(
+                (kv_no_split, cos, sin),
+                expanded_prefill_slots,
+                num_decode_tokens=0,
+            )
+            pcp_prefill_range = (local_prefill_start, local_prefill_end)
+
         assert self.kv_a_layernorm is not None
         B = kv_no_split.shape[0]
         N = self.num_kv_heads
@@ -1523,24 +1525,31 @@ class AscendMLAImpl(MLAAttentionImpl):
         # npu_kv_rmsnorm_rope_cache needs [B, N, S, D]
         kv_no_split = kv_no_split.view(B, N, S, self.kv_lora_rank + self.qk_rope_head_dim)
         if self.qk_rope_head_dim == 0:
-            return self._exec_kv_mla_nope(kv_no_split, kv_cache, slots, is_prefill=True)
-        cache_mode = "PA"
-        c_kv_scale = None
-        if self.support_fp8_attention and self.fa_quant_layer:
-            c_kv_scale = self.fak_descale_reciprocal
-        _, _, k_pe, k_nope = torch_npu.npu_kv_rmsnorm_rope_cache(
-            kv_no_split,
-            self.kv_a_layernorm.weight,  # type: ignore[union-attr]
-            cos,
-            sin,
-            slots.to(torch.int64),
-            kv_cache[1],
-            kv_cache[0],
-            c_kv_scale=c_kv_scale,
-            epsilon=self.kv_a_layernorm.variance_epsilon,  # type: ignore[union-attr]
-            cache_mode=cache_mode,
-            is_output_kv=True,
-        )
+            k_pe, k_nope = self._exec_kv_mla_nope(kv_no_split, kv_cache, slots, is_prefill=True)
+        else:
+            cache_mode = "PA"
+            c_kv_scale = None
+            if self.support_fp8_attention and self.fa_quant_layer:
+                c_kv_scale = self.fak_descale_reciprocal
+            _, _, k_pe, k_nope = torch_npu.npu_kv_rmsnorm_rope_cache(
+                kv_no_split,
+                self.kv_a_layernorm.weight,  # type: ignore[union-attr]
+                cos,
+                sin,
+                slots.to(torch.int64),
+                kv_cache[1],
+                kv_cache[0],
+                c_kv_scale=c_kv_scale,
+                epsilon=self.kv_a_layernorm.variance_epsilon,  # type: ignore[union-attr]
+                cache_mode=cache_mode,
+                is_output_kv=True,
+            )
+        if pcp_prefill_range is not None:
+            # Due to the fused RMSNorm/RoPE/cache operator, KV normalization is
+            # repeated after gather; trim outputs back to this rank's real range.
+            local_start, local_end = pcp_prefill_range
+            k_pe = k_pe[local_start:local_end]
+            k_nope = k_nope[local_start:local_end]
         return k_pe, k_nope
 
     def rope_single(
@@ -1892,6 +1901,14 @@ class AscendMLAImpl(MLAAttentionImpl):
         self,
         attn_metadata: AscendMLAMetadata,
     ) -> int:
+        if self.pcp_enabled:
+            prefill_metadata = attn_metadata.prefill
+            assert prefill_metadata is not None
+            local_num_input_tokens = prefill_metadata.pcp_local_num_input_tokens
+            assert local_num_input_tokens is not None, "PCP MLA metadata must be finalized before execution."
+            # Keep the PCP-padded prefill length so every rank processes the
+            # same number of KV tokens; exec_kv_prefill trims gathered outputs.
+            return local_num_input_tokens - attn_metadata.num_decode_tokens
         return attn_metadata.num_actual_tokens - attn_metadata.num_decode_tokens
 
     def mla_preprocess_prefill(self, q_c, kv_no_split, kv_cache, attn_metadata):
@@ -2101,73 +2118,6 @@ class AscendMLAImpl(MLAAttentionImpl):
         del o_proj_input
         maybe_save_kv_layer_to_connector(layer_name, list(kv_cache))
         return output_padded
-
-
-class AscendMLAPCPImpl(AscendMLAImpl):
-    """MRV2 MLA implementation for Prefill Context Parallelism."""
-
-    def _get_num_prefill_kv_tokens(
-        self,
-        attn_metadata: AscendMLAMetadata,
-    ) -> int:
-        if not isinstance(attn_metadata, AscendMLAPCPMetadata):
-            raise RuntimeError("PCP MLA prefill requires AscendMLAPCPMetadata.")
-        # Keep the PCP-padded prefill length so every PCP rank processes the
-        # same number of KV tokens. exec_kv_prefill trims the gathered tensors
-        # back to this rank's actual prefill range.
-        return attn_metadata.pcp_local_num_input_tokens - attn_metadata.num_decode_tokens
-
-    def exec_kv_prefill(
-        self,
-        kv_no_split: torch.Tensor,
-        cos: torch.Tensor,
-        sin: torch.Tensor,
-        kv_cache: tuple[torch.Tensor, ...],
-        slots: torch.Tensor,
-        *,
-        attn_metadata: AscendMLAMetadata | None = None,
-    ):
-        if not isinstance(attn_metadata, AscendMLAPCPMetadata):
-            raise RuntimeError("PCP MLA prefill requires AscendMLAPCPMetadata.")
-
-        num_decode_tokens = attn_metadata.num_decode_tokens
-        local_num_input_tokens = attn_metadata.pcp_local_num_input_tokens
-        local_prefill_capacity = local_num_input_tokens - num_decode_tokens
-        if not (kv_no_split.shape[0] == cos.shape[0] == sin.shape[0] == local_prefill_capacity):
-            raise RuntimeError(
-                "PCP MLA prefill input length mismatch: "
-                f"kv={kv_no_split.shape[0]}, cos={cos.shape[0]}, "
-                f"sin={sin.shape[0]}, expected={local_prefill_capacity}."
-            )
-
-        pcp_group = get_pcp_group()
-        rank_slot_mappings = attn_metadata.slot_mapping.view(
-            pcp_group.world_size,
-            local_num_input_tokens,
-        )
-        # Remove the decoding area and flatten it.
-        expanded_prefill_slots = rank_slot_mappings[:, num_decode_tokens:].flatten()
-        (gathered_kv, gathered_cos, gathered_sin), gathered_prefill_slots = _gather_prefill_cache_inputs(
-            (kv_no_split, cos, sin),
-            expanded_prefill_slots,
-            num_decode_tokens=0,
-        )
-        # TODO Due to the npu_kv_rmsnorm_rope_cache fusion operator, the RMSNorm rope of the KV layer
-        # involves repeated calculations, leaving room for optimization.
-        gathered_k_pe, gathered_k_c_normed = super().exec_kv_prefill(
-            gathered_kv,
-            gathered_cos,
-            gathered_sin,
-            kv_cache,
-            gathered_prefill_slots,
-        )
-        # Unpad the gathered KV tensors to this PCP rank's actual prefill range.
-        prefill_k_pe = gathered_k_pe[attn_metadata.pcp_local_prefill_start : attn_metadata.pcp_local_prefill_end]
-        prefill_k_c_normed = gathered_k_c_normed[
-            attn_metadata.pcp_local_prefill_start : attn_metadata.pcp_local_prefill_end
-        ]
-
-        return prefill_k_pe, prefill_k_c_normed
 
 
 # mla_nope_zero_rope_cache: the paged key_rope operand is cache-sized

--- a/vllm_ascend/attention/mla_v1.py
+++ b/vllm_ascend/attention/mla_v1.py
@@ -29,7 +29,6 @@ from vllm_ascend.attention.utils import (
     AscendCommonAttentionMetadata,
     ascend_chunked_prefill_workspace_size,
     enable_dcp,
-    enable_pcp,
     enabling_mlapo,
     maybe_save_kv_layer_to_connector,
     notify_kv_cache_written,
@@ -92,8 +91,6 @@ class AscendMLABackend(AttentionBackend):
     def get_builder_cls():
         dcp_enabled = enable_dcp()
         if dcp_enabled:
-            if enable_pcp():
-                raise NotImplementedError("Ascend MRV2 MLA does not support PCP and DCP simultaneously yet.")
             from vllm_ascend.attention.context_parallel.mla_cp import AscendMlaDCPMetadataBuilder
 
             return AscendMlaDCPMetadataBuilder
@@ -113,8 +110,6 @@ class AscendMLABackend(AttentionBackend):
     def get_impl_cls() -> type["MLAAttentionImpl"]:
         dcp_enabled = enable_dcp()
         if dcp_enabled:
-            if enable_pcp():
-                raise NotImplementedError("Ascend MRV2 MLA does not support PCP and DCP simultaneously yet.")
             from vllm_ascend.attention.context_parallel.mla_cp import AscendMlaDCPImpl
 
             return AscendMlaDCPImpl


### PR DESCRIPTION
### What this PR does / why we need it?

This PR extracts the MLA portion of #14960 into an independently reviewable prerequisite.

- Fold the MRV2 PCP-specific MLA metadata builder and attention implementation into the standard MLA path.
- Keep PCP state in the regular metadata types, with prefill-only fields owned by `AscendMLAPrefillMetadata`.
- Preserve expanded slot mappings, cross-rank KV cache gathering, and rank-local prefill output trimming.
- Remove the separate `AscendMLAPCPMetadata`, `AscendMLAPCPMetadataBuilder`, and `AscendMLAPCPImpl` classes.

This PR does not include speculative decoding, draft-model graph, ModelRunner, or PCP manager changes. It is a prerequisite for #14960.

### Does this PR introduce _any_ user-facing change?

No. This is an internal refactor of the existing MRV2 MLA PCP implementation.

### How was this patch tested?

- `python -m py_compile vllm_ascend/attention/mla_v1.py tests/ut/attention/a2/test_mla_v1.py`
- `python -m pytest -q tests/ut/attention/a2/test_mla_v1.py` (`77 passed`)
- `git diff --check`

- vLLM main: https://github.com/vllm-project/vllm/commit/ba07e4a48fc951300d97eb506217dd530583dea3
