### PR TITLE
[Refactor][Attention] Unify MRV2 PCP GQA metadata and implementation

### DIFF
--- a/tests/ut/_310p/attention/test_attention_v1_310.py
+++ b/tests/ut/_310p/attention/test_attention_v1_310.py
@@ -34,6 +34,7 @@ class TestAscendAttentionBackend310(TestBase):
         self.mock_config = MagicMock()
         self.utils_patcher = patch("vllm_ascend.attention.utils.get_current_vllm_config", return_value=self.mock_config)
         self.utils_patcher.start()
+        self.addCleanup(self.utils_patcher.stop)
 
     def test_get_impl_cls(self):
         self.assertEqual(AscendAttentionBackend310.get_impl_cls(), AscendAttentionBackendImpl310)
@@ -54,6 +55,11 @@ class TestAscendAttentionBackendImpl310(TestBase):
         self.attn_metadata = MagicMock()
         self.attn_metadata.return_value = "1"
         self.mock_vllm_config = MagicMock()
+        self.utils_patcher = patch(
+            "vllm_ascend.attention.utils.get_current_vllm_config", return_value=self.mock_vllm_config
+        )
+        self.utils_patcher.start()
+        self.addCleanup(self.utils_patcher.stop)
         self.layer_no_quant = MagicMock(spec=["layer_name", "_k_scale_float", "_v_scale_float"])
         self.layer_no_quant.layer_name = "test_layer"
         self.layer_no_quant._k_scale_float = 1.0
@@ -62,6 +68,7 @@ class TestAscendAttentionBackendImpl310(TestBase):
             "vllm_ascend.attention.attention_v1.get_current_vllm_config", return_value=self.mock_vllm_config
         )
         self.config_patcher.start()
+        self.addCleanup(self.config_patcher.stop)
         self.impl = AscendAttentionBackendImpl310(
             num_heads=8,
             head_size=128,

--- a/tests/ut/attention/test_attention_v1.py
+++ b/tests/ut/attention/test_attention_v1.py
@@ -13,6 +13,10 @@ from vllm_ascend.attention.attention_v1 import (
     AscendC8AttentionBackendImpl,
     AscendMetadata,
 )
+from vllm_ascend.attention.context_parallel.attention_cp import (
+    AscendAttentionDCPImpl,
+    AscendAttentionDCPMetadataBuilder,
+)
 from vllm_ascend.attention.utils import (
     AscendCommonAttentionMetadata,
     PagedAttentionGraphParam,
@@ -58,39 +62,20 @@ class TestAttentionGraphHelpers(TestBase):
 
 
 class TestAscendAttentionBackend(TestBase):
-    def setUp(self):
-        self.mock_config = MagicMock()
-
-        mock_parallel_config = MagicMock()
-        mock_parallel_config.prefill_context_parallel_size = 1
-        mock_parallel_config.decode_context_parallel_size = 1
-
-        self.mock_config.parallel_config = mock_parallel_config
-
-        self.utils_patcher = patch("vllm_ascend.attention.utils.get_current_vllm_config", return_value=self.mock_config)
-        self.utils_patcher.start()
-
-        from vllm_ascend.attention.utils import enable_dcp, enable_pcp
-
-        self.enable_dcp = enable_dcp
-        self.enable_pcp = enable_pcp
-        enable_dcp.cache_clear()
-        enable_pcp.cache_clear()
-        self.addCleanup(self.utils_patcher.stop)
-        self.addCleanup(enable_dcp.cache_clear)
-        self.addCleanup(enable_pcp.cache_clear)
-
     def test_get_name(self):
         self.assertEqual(AscendAttentionBackend.get_name(), "CUSTOM")
 
     def test_get_impl_cls(self):
-        self.assertEqual(AscendAttentionBackend.get_impl_cls(), AscendAttentionBackendImpl)
+        with patch("vllm_ascend.attention.attention_v1.enable_dcp", return_value=False):
+            self.assertEqual(AscendAttentionBackend.get_impl_cls(), AscendAttentionBackendImpl)
 
     def test_get_builder_cls(self):
-        self.assertEqual(AscendAttentionBackend.get_builder_cls(), AscendAttentionMetadataBuilder)
+        with patch("vllm_ascend.attention.attention_v1.enable_dcp", return_value=False):
+            self.assertEqual(AscendAttentionBackend.get_builder_cls(), AscendAttentionMetadataBuilder)
 
     def test_supports_pcp_only_for_main_implementation(self):
-        self.assertTrue(AscendAttentionBackend.supports_pcp())
+        with patch("vllm_ascend.attention.attention_v1.enable_dcp", return_value=False):
+            self.assertTrue(AscendAttentionBackend.supports_pcp())
 
         class OtherAttentionBackend(AscendAttentionBackend):
             @staticmethod
@@ -99,34 +84,19 @@ class TestAscendAttentionBackend(TestBase):
 
         self.assertFalse(OtherAttentionBackend.supports_pcp())
 
-    def test_get_impl_cls_with_pcp(self):
-        self.mock_config.parallel_config.prefill_context_parallel_size = 2
-        self.enable_pcp.cache_clear()
+    def test_get_impl_cls_with_dcp(self):
+        with patch("vllm_ascend.attention.attention_v1.enable_dcp", return_value=True):
+            self.assertIs(
+                AscendAttentionBackend.get_impl_cls(),
+                AscendAttentionDCPImpl,
+            )
 
-        self.assertIs(
-            AscendAttentionBackend.get_impl_cls(),
-            AscendAttentionBackendImpl,
-        )
-
-    def test_get_builder_cls_with_pcp(self):
-        self.mock_config.parallel_config.prefill_context_parallel_size = 2
-        self.enable_pcp.cache_clear()
-
-        self.assertIs(
-            AscendAttentionBackend.get_builder_cls(),
-            AscendAttentionMetadataBuilder,
-        )
-
-    def test_pcp_and_dcp_are_rejected_together(self):
-        self.mock_config.parallel_config.prefill_context_parallel_size = 2
-        self.mock_config.parallel_config.decode_context_parallel_size = 2
-        self.enable_pcp.cache_clear()
-        self.enable_dcp.cache_clear()
-
-        with self.assertRaisesRegex(NotImplementedError, "PCP and DCP"):
-            AscendAttentionBackend.get_impl_cls()
-        with self.assertRaisesRegex(NotImplementedError, "PCP and DCP"):
-            AscendAttentionBackend.get_builder_cls()
+    def test_get_builder_cls_with_dcp(self):
+        with patch("vllm_ascend.attention.attention_v1.enable_dcp", return_value=True):
+            self.assertIs(
+                AscendAttentionBackend.get_builder_cls(),
+                AscendAttentionDCPMetadataBuilder,
+            )
 
     def test_get_kv_cache_shape_not(self):
         result = AscendAttentionBackend.get_kv_cache_shape(10, 20, 30, 40)

--- a/tests/ut/attention/test_attention_v1.py
+++ b/tests/ut/attention/test_attention_v1.py
@@ -9,11 +9,9 @@ from vllm_ascend.attention.attention_v1 import (
     AscendAttentionBackend,
     AscendAttentionBackendImpl,
     AscendAttentionMetadataBuilder,
-    AscendAttentionPCPImpl,
-    AscendAttentionPCPMetadata,
-    AscendAttentionPCPMetadataBuilder,
     AscendAttentionState,
     AscendC8AttentionBackendImpl,
+    AscendMetadata,
 )
 from vllm_ascend.attention.utils import (
     AscendCommonAttentionMetadata,
@@ -91,13 +89,23 @@ class TestAscendAttentionBackend(TestBase):
     def test_get_builder_cls(self):
         self.assertEqual(AscendAttentionBackend.get_builder_cls(), AscendAttentionMetadataBuilder)
 
+    def test_supports_pcp_only_for_main_implementation(self):
+        self.assertTrue(AscendAttentionBackend.supports_pcp())
+
+        class OtherAttentionBackend(AscendAttentionBackend):
+            @staticmethod
+            def get_impl_cls():
+                return AscendC8AttentionBackendImpl
+
+        self.assertFalse(OtherAttentionBackend.supports_pcp())
+
     def test_get_impl_cls_with_pcp(self):
         self.mock_config.parallel_config.prefill_context_parallel_size = 2
         self.enable_pcp.cache_clear()
 
         self.assertIs(
             AscendAttentionBackend.get_impl_cls(),
-            AscendAttentionPCPImpl,
+            AscendAttentionBackendImpl,
         )
 
     def test_get_builder_cls_with_pcp(self):
@@ -106,7 +114,7 @@ class TestAscendAttentionBackend(TestBase):
 
         self.assertIs(
             AscendAttentionBackend.get_builder_cls(),
-            AscendAttentionPCPMetadataBuilder,
+            AscendAttentionMetadataBuilder,
         )
 
     def test_pcp_and_dcp_are_rejected_together(self):
@@ -144,6 +152,7 @@ class TestAscendAttentionMetadataBuilder(TestBase):
     def setUp(self):
         self.mock_vllm_config = MagicMock()
         self.mock_vllm_config.speculative_config = None
+        self.mock_vllm_config.parallel_config.prefill_context_parallel_size = 1
         self.mock_vllm_config.model_config.max_model_len = 640
         self.mock_vllm_config.model_config.hf_text_config.sliding_window = None
         self.mock_vllm_config.cache_config.block_size = 64
@@ -161,6 +170,16 @@ class TestAscendAttentionMetadataBuilder(TestBase):
         result = self.builder.reorder_batch(mock_input_batch, mock_scheduler_output)
 
         self.assertFalse(result)
+
+    def test_pcp_mode_is_initialized_from_config(self):
+        self.assertFalse(self.builder.pcp_enabled)
+        self.assertIs(self.builder.metadata_cls, AscendMetadata)
+
+        self.mock_vllm_config.parallel_config.prefill_context_parallel_size = 2
+        pcp_builder = AscendAttentionMetadataBuilder(None, None, self.mock_vllm_config, self.mock_device)
+
+        self.assertTrue(pcp_builder.pcp_enabled)
+        self.assertIs(pcp_builder.metadata_cls, AscendMetadata)
 
     def test_unpadded_preserves_internal_seq_lens_cpu(self):
         internal_seq_lens_cpu = torch.tensor([4, 5, 6], dtype=torch.int32)
@@ -213,35 +232,28 @@ class TestAscendAttentionMetadataBuilder(TestBase):
 
 
 def test_pcp_metadata_keeps_expanded_slot_mapping() -> None:
-    builder = AscendAttentionPCPMetadataBuilder.__new__(AscendAttentionPCPMetadataBuilder)
+    builder = AscendAttentionMetadataBuilder.__new__(AscendAttentionMetadataBuilder)
     builder.pcp_size = 2
-    common_metadata = SimpleNamespace(
-        slot_mapping=torch.tensor(
-            [10, 11, -1, -1, 20, 21, -1, -1],
-            dtype=torch.int64,
-        )
+    expanded_slot_mapping = torch.tensor(
+        [10, 11, -1, -1, 20, 21, -1, -1],
+        dtype=torch.int64,
     )
-    metadata = AscendAttentionPCPMetadata(
+    metadata = AscendMetadata(
         num_actual_tokens=3,
         num_decode_tokens=1,
         num_prefills=1,
         attn_state=AscendAttentionState.PrefillCacheHit,
     )
 
-    with patch.object(
-        AscendAttentionMetadataBuilder,
-        "build",
-        return_value=metadata,
-    ):
-        result = builder.build(0, common_metadata)
+    builder._finalize_pcp_metadata(metadata, expanded_slot_mapping)
 
-    assert result.slot_mapping is common_metadata.slot_mapping
-    assert result.pcp_local_num_input_tokens == 4
-    assert result.attn_state == AscendAttentionState.ChunkedPrefill
+    assert metadata.slot_mapping is expanded_slot_mapping
+    assert metadata.pcp_local_num_input_tokens == 4
+    assert metadata.attn_state == AscendAttentionState.ChunkedPrefill
 
 
 def test_pcp_cache_write_uses_gathered_inputs() -> None:
-    impl = AscendAttentionPCPImpl.__new__(AscendAttentionPCPImpl)
+    impl = AscendAttentionBackendImpl.__new__(AscendAttentionBackendImpl)
     impl.attn_type = attn_module.AttentionType.DECODER
     impl.key_cache = None
     impl.value_cache = None
@@ -256,7 +268,7 @@ def test_pcp_cache_write_uses_gathered_inputs() -> None:
     gathered_value = torch.arange(30, 37).reshape(7, 1, 1)
     gathered_slots = torch.tensor([10, 11, -1, -1, 21, -1, -1])
     slot_mapping = torch.tensor([10, 11, -1, -1, 20, 21, -1, -1])
-    metadata = AscendAttentionPCPMetadata(
+    metadata = AscendMetadata(
         num_actual_tokens=3,
         num_decode_tokens=1,
         pcp_local_num_input_tokens=4,
@@ -276,7 +288,7 @@ def test_pcp_cache_write_uses_gathered_inputs() -> None:
         patch("vllm_ascend.attention.attention_v1.DeviceOperator.reshape_and_cache") as reshape_and_cache,
         patch("vllm_ascend.attention.attention_v1.notify_kv_cache_written"),
     ):
-        result = impl.reshape_and_cache(
+        result = impl._reshape_and_cache_pcp(
             query,
             key,
             value,
@@ -304,8 +316,9 @@ def test_pcp_cache_write_uses_gathered_inputs() -> None:
 
 
 def test_pcp_builder_keeps_short_extend_in_prefill() -> None:
-    builder = AscendAttentionPCPMetadataBuilder.__new__(AscendAttentionPCPMetadataBuilder)
+    builder = AscendAttentionMetadataBuilder.__new__(AscendAttentionMetadataBuilder)
     builder.decode_threshold = 1
+    builder.pcp_enabled = True
     common_metadata = SimpleNamespace(
         context_parallel_metadata=None,
         max_query_len=4,
@@ -345,6 +358,7 @@ class TestAscendAttentionBackendImpl(TestBase):
         self.layer_no_quant._k_scale_float = 1.0
         self.layer_no_quant._v_scale_float = 1.0
         self.mock_vllm_config = MagicMock()
+        self.mock_vllm_config.parallel_config.prefill_context_parallel_size = 1
         self.config_patcher = patch(
             "vllm_ascend.attention.attention_v1.get_current_vllm_config", return_value=self.mock_vllm_config
         )

--- a/tests/ut/spec_decode/test_speculators_vwn_eagle3.py
+++ b/tests/ut/spec_decode/test_speculators_vwn_eagle3.py
@@ -156,7 +156,6 @@ def _mock_npu_env():
         ),
         # These tests do not exercise context parallelism. Short-circuit the
         # backend routing checks so their mocked config stays scoped to VWN.
-        patch("vllm_ascend.attention.attention_v1.enable_pcp", return_value=False),
         patch("vllm_ascend.attention.attention_v1.enable_dcp", return_value=False),
         patch(
             "vllm_ascend.attention.context_parallel.sfa_cp.enable_sfa_dcp_replicated_indexer",

--- a/tests/ut/test_platform.py
+++ b/tests/ut/test_platform.py
@@ -1675,6 +1675,76 @@ class TestNPUPlatform(TestBase):
         result = self.platform.get_attn_backend_cls("ascend", attn_selector_config)
         self.assertEqual(result, "vllm_ascend.attention.attention_v1.AscendAttentionBackend")
 
+    @patch("vllm_ascend.platform.get_ascend_config")
+    def test_get_attn_backend_cls_selects_cp_backend(self, mock_get_ascend_config):
+        mock_get_ascend_config.return_value.rl_config.enabled = False
+        mock_get_ascend_config.return_value.rl_config.enable_training_consistency = False
+        cases = (
+            (
+                True,
+                True,
+                False,
+                "vllm_ascend.attention.mla_v1.AscendMLABackend",
+            ),
+            (
+                False,
+                True,
+                False,
+                "vllm_ascend.attention.attention_v1.AscendAttentionBackend",
+            ),
+            (
+                True,
+                False,
+                True,
+                "vllm_ascend.attention.mla_v1.AscendMLABackend",
+            ),
+            (
+                False,
+                False,
+                True,
+                "vllm_ascend.attention.attention_v1.AscendAttentionBackend",
+            ),
+        )
+        for use_mla, use_pcp, use_dcp, expected_backend in cases:
+            with self.subTest(use_mla=use_mla, use_pcp=use_pcp, use_dcp=use_dcp):
+                attn_selector_config = AttentionSelectorConfig(
+                    dtype=torch.float16,
+                    head_size=0,
+                    kv_cache_dtype=None,
+                    block_size=128,
+                    use_mla=use_mla,
+                    use_sparse=False,
+                    use_pcp=use_pcp,
+                    use_dcp=use_dcp,
+                )
+                result = self.platform.get_attn_backend_cls("ascend", attn_selector_config)
+                self.assertEqual(result, expected_backend)
+
+    def test_get_attn_backend_cls_rejects_pcp_and_dcp(self):
+        attn_selector_config = AttentionSelectorConfig(
+            dtype=torch.float16,
+            head_size=0,
+            kv_cache_dtype=None,
+            block_size=128,
+            use_pcp=True,
+            use_dcp=True,
+        )
+        with self.assertRaisesRegex(NotImplementedError, "does not support PCP and DCP simultaneously"):
+            self.platform.get_attn_backend_cls("ascend", attn_selector_config)
+
+    def test_get_attn_backend_cls_rejects_unsupported_pcp_backend(self):
+        attn_selector_config = AttentionSelectorConfig(
+            dtype=torch.float16,
+            head_size=0,
+            kv_cache_dtype=None,
+            block_size=128,
+            use_mla=True,
+            use_sparse=True,
+            use_pcp=True,
+        )
+        with self.assertRaisesRegex(NotImplementedError, "PCP does not support attention backend"):
+            self.platform.get_attn_backend_cls("ascend", attn_selector_config)
+
     @patch("vllm_ascend.platform.import_module")
     @patch("vllm_ascend.platform.util.find_spec", return_value=object())
     @patch("vllm_ascend.platform.get_ascend_config")

--- a/tests/ut/test_platform.py
+++ b/tests/ut/test_platform.py
@@ -1732,13 +1732,26 @@ class TestNPUPlatform(TestBase):
         with self.assertRaisesRegex(NotImplementedError, "does not support PCP and DCP simultaneously"):
             self.platform.get_attn_backend_cls("ascend", attn_selector_config)
 
-    def test_get_attn_backend_cls_rejects_unsupported_pcp_backend(self):
+    def test_get_attn_backend_cls_selects_sfa_pcp_backend(self):
         attn_selector_config = AttentionSelectorConfig(
             dtype=torch.float16,
             head_size=0,
             kv_cache_dtype=None,
             block_size=128,
             use_mla=True,
+            use_sparse=True,
+            use_pcp=True,
+        )
+        result = self.platform.get_attn_backend_cls("ascend", attn_selector_config)
+        self.assertEqual(result, "vllm_ascend.attention.sfa_v1.AscendSFABackend")
+
+    def test_get_attn_backend_cls_rejects_unsupported_pcp_backend(self):
+        attn_selector_config = AttentionSelectorConfig(
+            dtype=torch.float16,
+            head_size=0,
+            kv_cache_dtype=None,
+            block_size=128,
+            use_mla=False,
             use_sparse=True,
             use_pcp=True,
         )

--- a/tests/ut/worker/test_pcp_manager_v2.py
+++ b/tests/ut/worker/test_pcp_manager_v2.py
@@ -77,6 +77,13 @@ def test_validate_config_allows_sparse_mla_full_decode_only():
     assert vllm_config.compilation_config.cudagraph_mode == CUDAGraphMode.FULL_DECODE_ONLY
 
 
+def test_validate_config_allows_gqa():
+    vllm_config = _make_pcp_config(CUDAGraphMode.NONE, sparse_mla=False)
+    vllm_config.model_config.use_mla = False
+
+    AscendPCPManager.validate_config(vllm_config, supports_mm_inputs=False)
+
+
 @pytest.mark.parametrize("cudagraph_mode", [CUDAGraphMode.PIECEWISE, CUDAGraphMode.FULL])
 def test_validate_config_rejects_unsupported_sparse_mla_graph_modes(cudagraph_mode):
     vllm_config = _make_pcp_config(cudagraph_mode)

--- a/vllm_ascend/attention/attention_v1.py
+++ b/vllm_ascend/attention/attention_v1.py
@@ -85,13 +85,10 @@ class AscendAttentionBackend(AttentionBackend):
 
     @staticmethod
     def get_impl_cls() -> type["AscendAttentionBackendImpl"]:
-        pcp_enabled = enable_pcp()
         dcp_enabled = enable_dcp()
-        if pcp_enabled and dcp_enabled:
-            raise NotImplementedError("Ascend MRV2 GQA does not support PCP and DCP simultaneously yet.")
-        if pcp_enabled:
-            return AscendAttentionPCPImpl
         if dcp_enabled:
+            if enable_pcp():
+                raise NotImplementedError("Ascend MRV2 GQA does not support PCP and DCP simultaneously yet.")
             from vllm_ascend.attention.context_parallel.attention_cp import AscendAttentionDCPImpl
 
             return AscendAttentionDCPImpl
@@ -99,17 +96,21 @@ class AscendAttentionBackend(AttentionBackend):
 
     @staticmethod
     def get_builder_cls() -> type["AscendAttentionMetadataBuilder"]:
-        pcp_enabled = enable_pcp()
         dcp_enabled = enable_dcp()
-        if pcp_enabled and dcp_enabled:
-            raise NotImplementedError("Ascend MRV2 GQA does not support PCP and DCP simultaneously yet.")
-        if pcp_enabled:
-            return AscendAttentionPCPMetadataBuilder
         if dcp_enabled:
+            if enable_pcp():
+                raise NotImplementedError("Ascend MRV2 GQA does not support PCP and DCP simultaneously yet.")
             from vllm_ascend.attention.context_parallel.attention_cp import AscendAttentionDCPMetadataBuilder
 
             return AscendAttentionDCPMetadataBuilder
         return AscendAttentionMetadataBuilder
+
+    @classmethod
+    def supports_pcp(cls) -> bool:
+        # vLLM checks this capability before any instance-level PCP dispatch.
+        # Only the main GQA implementation owns the PCP path; exact identity
+        # prevents backends such as 310P from inheriting unsupported capability.
+        return cls.get_impl_cls() is AscendAttentionBackendImpl
 
     @staticmethod
     def get_kv_cache_shape(
@@ -215,12 +216,7 @@ class AscendMetadata:
     # prefill reshape_and_cache event
     reshape_cache_event: torch.npu.Event = None
 
-
-@dataclass
-class AscendAttentionPCPMetadata(AscendMetadata):
-    """GQA metadata needed to write the complete PCP KV cache."""
-
-    pcp_local_num_input_tokens: int = 0
+    pcp_local_num_input_tokens: int | None = None
 
 
 class AscendAttentionMetadataBuilder(AttentionMetadataBuilder[AscendMetadata]):
@@ -246,6 +242,8 @@ class AscendAttentionMetadataBuilder(AttentionMetadataBuilder[AscendMetadata]):
     ):
         super().__init__(kv_cache_spec, layer_names, vllm_config, device)
         self.vllm_config = vllm_config
+        self.pcp_size = vllm_config.parallel_config.prefill_context_parallel_size
+        self.pcp_enabled = self.pcp_size > 1
         self.model_config = vllm_config.model_config
         self.compilation_config = vllm_config.compilation_config
         self.device = device
@@ -290,6 +288,7 @@ class AscendAttentionMetadataBuilder(AttentionMetadataBuilder[AscendMetadata]):
         return split_decodes_and_prefills(
             common_attn_metadata,
             decode_threshold=self.decode_threshold,
+            treat_short_extends_as_decodes=not self.pcp_enabled,
         )
 
     def _build_backend_metadata(
@@ -316,6 +315,7 @@ class AscendAttentionMetadataBuilder(AttentionMetadataBuilder[AscendMetadata]):
         common_attn_metadata: AscendCommonAttentionMetadata,
         fast_build: bool = False,
     ) -> AscendMetadata:
+        expanded_slot_mapping = common_attn_metadata.slot_mapping if self.pcp_enabled else None
         num_reqs = common_attn_metadata.num_reqs
         num_actual_tokens = common_attn_metadata.num_actual_tokens
         query_start_loc_cpu = common_attn_metadata.query_start_loc_cpu[: num_reqs + 1]
@@ -414,7 +414,33 @@ class AscendAttentionMetadataBuilder(AttentionMetadataBuilder[AscendMetadata]):
             model_runner_type=self.model_config.runner_type,
             **backend_metadata,
         )
+        if self.pcp_enabled:
+            assert expanded_slot_mapping is not None
+            self._finalize_pcp_metadata(attn_metadata, expanded_slot_mapping)
         return attn_metadata
+
+    def _finalize_pcp_metadata(
+        self,
+        metadata: AscendMetadata,
+        expanded_slot_mapping: torch.Tensor,
+    ) -> None:
+        if expanded_slot_mapping.numel() % self.pcp_size != 0:
+            raise RuntimeError(
+                "PCP slot mapping size must be divisible by the PCP world size: "
+                f"{expanded_slot_mapping.numel()} % {self.pcp_size} != 0."
+            )
+
+        local_num_input_tokens = expanded_slot_mapping.numel() // self.pcp_size
+        if metadata.num_actual_tokens > local_num_input_tokens:
+            raise RuntimeError(
+                "PCP actual token count exceeds the rank-local padded token count: "
+                f"{metadata.num_actual_tokens} > {local_num_input_tokens}."
+            )
+
+        metadata.slot_mapping = expanded_slot_mapping
+        metadata.pcp_local_num_input_tokens = local_num_input_tokens
+        if metadata.num_prefills > 0:
+            metadata.attn_state = AscendAttentionState.ChunkedPrefill
 
     def build_for_graph_capture(
         self,
@@ -439,58 +465,6 @@ class AscendAttentionMetadataBuilder(AttentionMetadataBuilder[AscendMetadata]):
         return attn_metadata
 
 
-class AscendAttentionPCPMetadataBuilder(AscendAttentionMetadataBuilder):
-    """Build GQA metadata while retaining expanded cache slots."""
-
-    metadata_cls = AscendAttentionPCPMetadata
-
-    def __init__(self, *args, **kwargs) -> None:
-        super().__init__(*args, **kwargs)
-        self.pcp_size = self.vllm_config.parallel_config.prefill_context_parallel_size
-
-    def _split_decodes_and_prefills(
-        self,
-        common_attn_metadata: AscendCommonAttentionMetadata,
-    ) -> tuple[int, int, int, int]:
-        return split_decodes_and_prefills(
-            common_attn_metadata,
-            decode_threshold=self.decode_threshold,
-            treat_short_extends_as_decodes=False,
-        )
-
-    def build(
-        self,
-        common_prefix_len: int,
-        common_attn_metadata: AscendCommonAttentionMetadata,
-        fast_build: bool = False,
-    ) -> AscendAttentionPCPMetadata:
-        expanded_slot_mapping = common_attn_metadata.slot_mapping
-        metadata = super().build(
-            common_prefix_len,
-            common_attn_metadata,
-            fast_build,
-        )
-        assert isinstance(metadata, AscendAttentionPCPMetadata)
-        if expanded_slot_mapping.numel() % self.pcp_size != 0:
-            raise RuntimeError(
-                "PCP slot mapping size must be divisible by the PCP world size: "
-                f"{expanded_slot_mapping.numel()} % {self.pcp_size} != 0."
-            )
-
-        local_num_input_tokens = expanded_slot_mapping.numel() // self.pcp_size
-        if metadata.num_actual_tokens > local_num_input_tokens:
-            raise RuntimeError(
-                "PCP actual token count exceeds the rank-local padded token count: "
-                f"{metadata.num_actual_tokens} > {local_num_input_tokens}."
-            )
-
-        metadata.slot_mapping = expanded_slot_mapping
-        metadata.pcp_local_num_input_tokens = local_num_input_tokens
-        if metadata.num_prefills > 0:
-            metadata.attn_state = AscendAttentionState.ChunkedPrefill
-        return metadata
-
-
 class AscendAttentionBackendImpl(AttentionImpl):
     def __init__(
         self,
@@ -508,6 +482,7 @@ class AscendAttentionBackendImpl(AttentionImpl):
         **kwargs,
     ) -> None:
         self.vllm_config = get_current_vllm_config()
+        self.pcp_enabled = self.vllm_config.parallel_config.prefill_context_parallel_size > 1
         self.num_heads = num_heads
         self.head_size = head_size
         self.scale = float(scale)
@@ -1658,6 +1633,48 @@ class AscendAttentionBackendImpl(AttentionImpl):
             notify_kv_cache_written()
         return query, key, value, output
 
+    # Keep PCP gathering outside reshape_and_cache: derived implementations
+    # such as C8 reuse that method but are outside this PCP feature matrix.
+    # Gathered inputs still flow through the canonical cache writer below.
+    def _reshape_and_cache_pcp(
+        self,
+        query: torch.Tensor,
+        key: torch.Tensor,
+        value: torch.Tensor,
+        kv_cache: tuple[torch.Tensor],
+        attn_metadata: AscendMetadata,
+        output: torch.Tensor,
+    ):
+        if len(kv_cache) <= 1:
+            return query, key, value, output
+
+        expanded_slot_mapping = attn_metadata.slot_mapping
+        local_num_input_tokens = attn_metadata.pcp_local_num_input_tokens
+        assert local_num_input_tokens is not None, "PCP GQA metadata must be finalized before execution."
+        if key.shape[0] < local_num_input_tokens:
+            raise RuntimeError(
+                f"PCP GQA input is shorter than the rank-local padded batch: {key.shape[0]} < {local_num_input_tokens}."
+            )
+
+        (cache_key, cache_value), cache_slot_mapping = _gather_prefill_cache_inputs(
+            (
+                key[:local_num_input_tokens],
+                value[:local_num_input_tokens],
+            ),
+            expanded_slot_mapping,
+            attn_metadata.num_decode_tokens,
+        )
+        local_num_actual_tokens = attn_metadata.num_actual_tokens
+        try:
+            attn_metadata.slot_mapping = cache_slot_mapping
+            attn_metadata.num_actual_tokens = cache_key.shape[0]
+            self.reshape_and_cache(query, cache_key, cache_value, kv_cache, attn_metadata, output)
+        finally:
+            attn_metadata.slot_mapping = expanded_slot_mapping
+            attn_metadata.num_actual_tokens = local_num_actual_tokens
+
+        return query, key, value, output
+
     def forward_impl(
         self,
         query: torch.Tensor,
@@ -1732,9 +1749,14 @@ class AscendAttentionBackendImpl(AttentionImpl):
         output_padded = None
         if key is not None and value is not None:
             output_padded = output
-            query, key, value, output_padded = self.reshape_and_cache(
-                query, key, value, kv_cache, attn_metadata, output
-            )
+            if self.pcp_enabled:
+                query, key, value, output_padded = self._reshape_and_cache_pcp(
+                    query, key, value, kv_cache, attn_metadata, output
+                )
+            else:
+                query, key, value, output_padded = self.reshape_and_cache(
+                    query, key, value, kv_cache, attn_metadata, output
+                )
         # pooling model branch
         if attn_metadata.model_runner_type == "pooling" and not attn_metadata.causal:
             attn_output = self._forward_encoder_attention(query, key, value, attn_metadata, output)
@@ -1746,49 +1768,6 @@ class AscendAttentionBackendImpl(AttentionImpl):
             attn_output = self.forward_impl(query, key, value, kv_cache, attn_metadata, output)
         output[:num_tokens] = attn_output[:num_tokens]
         return output
-
-
-class AscendAttentionPCPImpl(AscendAttentionBackendImpl):
-    """MRV2 GQA implementation for prefill context parallelism."""
-
-    supports_pcp = True
-
-    def reshape_and_cache(
-        self,
-        query: torch.Tensor,
-        key: torch.Tensor,
-        value: torch.Tensor,
-        kv_cache: tuple[torch.Tensor],
-        attn_metadata: AscendMetadata,
-        output: torch.Tensor,
-    ):
-        if len(kv_cache) <= 1:
-            return query, key, value, output
-        expanded_slot_mapping = attn_metadata.slot_mapping
-        local_num_input_tokens = attn_metadata.pcp_local_num_input_tokens
-        if key.shape[0] < local_num_input_tokens:
-            raise RuntimeError(
-                f"PCP GQA input is shorter than the rank-local padded batch: {key.shape[0]} < {local_num_input_tokens}."
-            )
-
-        (cache_key, cache_value), cache_slot_mapping = _gather_prefill_cache_inputs(
-            (
-                key[:local_num_input_tokens],
-                value[:local_num_input_tokens],
-            ),
-            expanded_slot_mapping,
-            attn_metadata.num_decode_tokens,
-        )
-        local_num_actual_tokens = attn_metadata.num_actual_tokens
-        try:
-            attn_metadata.slot_mapping = cache_slot_mapping
-            attn_metadata.num_actual_tokens = cache_key.shape[0]
-            super().reshape_and_cache(query, cache_key, cache_value, kv_cache, attn_metadata, output)
-        finally:
-            attn_metadata.slot_mapping = expanded_slot_mapping
-            attn_metadata.num_actual_tokens = local_num_actual_tokens
-
-        return query, key, value, output
 
 
 class AscendC8AttentionBackendImpl(AscendAttentionBackendImpl):

--- a/vllm_ascend/attention/attention_v1.py
+++ b/vllm_ascend/attention/attention_v1.py
@@ -475,7 +475,10 @@ class AscendAttentionBackendImpl(AttentionImpl):
         **kwargs,
     ) -> None:
         self.vllm_config = get_current_vllm_config()
-        self.pcp_enabled = self.vllm_config.parallel_config.prefill_context_parallel_size > 1
+        self.pcp_enabled = (
+            type(self) is AscendAttentionBackendImpl
+            and self.vllm_config.parallel_config.prefill_context_parallel_size > 1
+        )
         self.num_heads = num_heads
         self.head_size = head_size
         self.scale = float(scale)

--- a/vllm_ascend/attention/attention_v1.py
+++ b/vllm_ascend/attention/attention_v1.py
@@ -46,7 +46,6 @@ from vllm_ascend.attention.utils import (
     PagedAttentionGraphParam,
     cache_graph_workspace,
     enable_dcp,
-    enable_pcp,
     needs_layer_aware_fia_graph_replay,
     notify_kv_cache_written,
     split_decodes_and_prefills,
@@ -85,10 +84,7 @@ class AscendAttentionBackend(AttentionBackend):
 
     @staticmethod
     def get_impl_cls() -> type["AscendAttentionBackendImpl"]:
-        dcp_enabled = enable_dcp()
-        if dcp_enabled:
-            if enable_pcp():
-                raise NotImplementedError("Ascend MRV2 GQA does not support PCP and DCP simultaneously yet.")
+        if enable_dcp():
             from vllm_ascend.attention.context_parallel.attention_cp import AscendAttentionDCPImpl
 
             return AscendAttentionDCPImpl
@@ -96,10 +92,7 @@ class AscendAttentionBackend(AttentionBackend):
 
     @staticmethod
     def get_builder_cls() -> type["AscendAttentionMetadataBuilder"]:
-        dcp_enabled = enable_dcp()
-        if dcp_enabled:
-            if enable_pcp():
-                raise NotImplementedError("Ascend MRV2 GQA does not support PCP and DCP simultaneously yet.")
+        if enable_dcp():
             from vllm_ascend.attention.context_parallel.attention_cp import AscendAttentionDCPMetadataBuilder
 
             return AscendAttentionDCPMetadataBuilder

--- a/vllm_ascend/platform.py
+++ b/vllm_ascend/platform.py
@@ -221,8 +221,12 @@ class NPUPlatform(Platform):
     def get_attn_backend_cls(cls, selected_backend, attn_selector_config, num_heads: int | None = None):
         use_compress = getattr(attn_selector_config, "use_compress", False)
         key = (attn_selector_config.use_mla, attn_selector_config.use_sparse)
+        backend_key = (*key, use_compress)
 
-        if _validate_fa3_backend(key, attn_selector_config):
+        if attn_selector_config.use_pcp and attn_selector_config.use_dcp:
+            raise NotImplementedError("Ascend MRV2 does not support PCP and DCP simultaneously yet.")
+
+        if not attn_selector_config.use_pcp and _validate_fa3_backend(key, attn_selector_config):
             return "vllm_ascend.attention.fa3_v1.AscendFABackend"
 
         backend_map = {
@@ -244,7 +248,18 @@ class NPUPlatform(Platform):
         if get_current_hardware_profile().attention_backend_family is AttentionBackendFamily.COMPATIBILITY:
             return compatibility_backend_map.get(key, compatibility_backend_map[(False, False)])
 
-        return backend_map[(attn_selector_config.use_mla, attn_selector_config.use_sparse, use_compress)]
+        if attn_selector_config.use_pcp:
+            pcp_backend_map = {
+                (True, False, False): "vllm_ascend.attention.mla_v1.AscendMLABackend",
+                (False, False, False): "vllm_ascend.attention.attention_v1.AscendAttentionBackend",
+                (True, False, True): "vllm_ascend.attention.dsa_v1.AscendDSABackend",
+            }
+            pcp_backend = pcp_backend_map.get(backend_key)
+            if pcp_backend is None:
+                raise NotImplementedError(f"Ascend MRV2 PCP does not support attention backend {backend_key}.")
+            return pcp_backend
+
+        return backend_map[backend_key]
 
     @classmethod
     def import_kernels(cls) -> None:

--- a/vllm_ascend/platform.py
+++ b/vllm_ascend/platform.py
@@ -252,6 +252,7 @@ class NPUPlatform(Platform):
             pcp_backend_map = {
                 (True, False, False): "vllm_ascend.attention.mla_v1.AscendMLABackend",
                 (False, False, False): "vllm_ascend.attention.attention_v1.AscendAttentionBackend",
+                (True, True, False): "vllm_ascend.attention.sfa_v1.AscendSFABackend",
                 (True, False, True): "vllm_ascend.attention.dsa_v1.AscendDSABackend",
             }
             pcp_backend = pcp_backend_map.get(backend_key)

--- a/vllm_ascend/worker/v2/pcp_manager.py
+++ b/vllm_ascend/worker/v2/pcp_manager.py
@@ -56,8 +56,6 @@ class AscendPCPManager(PCPManager):
         if pcp_size <= 1:
             return
 
-        if not model_config.use_mla:
-            raise NotImplementedError("MRV2 PCP currently supports MLA models only.")
         if parallel_config.pipeline_parallel_size > 1:
             raise NotImplementedError("MRV2 PCP does not support PP yet.")
         if model_config.is_encoder_decoder:


### PR DESCRIPTION
### What this PR does / why we need it?

This PR extracts the GQA portion of #14960 into an independently reviewable prerequisite.

- Fold the MRV2 PCP-specific GQA metadata builder and cache-write implementation into the standard GQA path.
- Keep PCP state in the regular `AscendMetadata` type and select PCP behavior from the runtime parallel config.
- Preserve expanded slot mappings and cross-rank KV cache gathering.
- Advertise PCP support only for the main GQA implementation so derived backends such as C8 do not inherit unsupported capability.
- Remove the MLA-only MRV2 PCP validation restriction and add a GQA validation regression test.
- Remove the separate `AscendAttentionPCPMetadata`, `AscendAttentionPCPMetadataBuilder`, and `AscendAttentionPCPImpl` classes.

This PR does not include speculative decoding, draft-model graph, hidden-state restoration, or speculative batch partitioning changes. It is a prerequisite for #14960.

### Does this PR introduce _any_ user-facing change?

Yes. MRV2 PCP configuration validation now permits supported GQA models through the standard Ascend GQA backend.

### How was this patch tested?

- `python -m py_compile vllm_ascend/attention/attention_v1.py vllm_ascend/worker/v2/pcp_manager.py tests/ut/attention/a2/test_attention_v1.py tests/ut/worker/test_pcp_manager_v2.py`
- `python -m pytest -q tests/ut/attention/a2/test_attention_v1.py` (`34 passed`)
- `python -m pytest -q tests/ut/worker/test_pcp_manager_v2.py` (`9 passed`)
- `git diff --check`

- vLLM main: https://github.com/vllm-project/vllm/commit/ba07e4a48fc951300d97eb506217dd530583dea3
