### PR TITLE
[BugFix][Platform] Fix SP switch configuration

### DIFF
--- a/tests/e2e/nightly/multi_node/internal_dp/config/GLM5_1-W8A8-A2-dual-nodes.yaml
+++ b/tests/e2e/nightly/multi_node/internal_dp/config/GLM5_1-W8A8-A2-dual-nodes.yaml
@@ -12,6 +12,7 @@ env_common: &env_common
   VLLM_ENGINE_READY_TIMEOUT_S: 3000
   VLLM_RPC_TIMEOUT: 600
   SERVER_PORT: 8078
+  VLLM_ASCEND_ENABLE_FLASHCOMM1: 1
 
 # TODO: need to identify why TP and mtp+1 divisibility rules break on dual-node case
 

--- a/tests/e2e/nightly/multi_node/internal_dp/config/Qwen3-235B-A22B-A2.yaml
+++ b/tests/e2e/nightly/multi_node/internal_dp/config/Qwen3-235B-A22B-A2.yaml
@@ -11,6 +11,7 @@ env_common: &env_common
   NUMEXPR_MAX_THREADS: 128
   TASK_QUEUE_ENABLE: 1
   PYTORCH_NPU_ALLOC_CONF: expandable_segments:True
+  VLLM_ASCEND_ENABLE_FLASHCOMM1: 1
 
 deployment:
   -

--- a/vllm_ascend/platform.py
+++ b/vllm_ascend/platform.py
@@ -1111,11 +1111,15 @@ def _setup_compile_backend(
     # current max / size inputs after the mode adjustments above).
     compilation_config.cudagraph_num_of_warmups = 1
     vllm_config._set_cudagraph_sizes()
-    # Upstream MoE SP shards tokens before the MoE runner, independent shared-
-    # expert DP shards them inside AscendSharedExperts, and DSA-CP shards Q at
-    # its attention boundary. All three layouts require TP-aligned graph gears
-    # so every captured graph has a stable local token shape. Keep the layout
-    # constraint separate from the feature switches so none enables another.
+    additional_config = vllm_config.additional_config or {}
+    if (
+        not additional_config.get("enable_flashcomm1", False)
+        and int(os.getenv("VLLM_ASCEND_ENABLE_FLASHCOMM1", "0")) == 0
+    ):
+        vllm_config.parallel_config.all2all_backend = (
+            "flashinfer_all2allv"  # TODO: a tricky way to disable SP moe. Disable this when SP is supported.
+        )
+        logger.info_once("FlashComm1 is disabled. Using flashinfer_all2allv as the all2all backend.")
     requires_tp_aligned_capture_sizes = enable_sp(vllm_config) or enable_shared_expert_dp or enable_dsa_cp
     if (
         vllm_config.parallel_config.tensor_parallel_size > 1

--- a/vllm_ascend/platform.py
+++ b/vllm_ascend/platform.py
@@ -1201,8 +1201,14 @@ def _setup_worker_and_scheduler(
     parallel_config = vllm_config.parallel_config
     if parallel_config and parallel_config.worker_cls == "auto":
         additional_config = vllm_config.additional_config or {}
-        if ("enable_flashcomm1" not in additional_config) and (not os.getenv("VLLM_ASCEND_ENABLE_FLASHCOMM1")):
-            parallel_config.all2all_backend = "flashinfer_all2allv"  # a trikky way to disable SP moe.
+        if (
+            not additional_config.get("enable_flashcomm1", False)
+            and int(os.getenv("VLLM_ASCEND_ENABLE_FLASHCOMM1", "0")) == 0
+        ):
+            parallel_config.all2all_backend = (
+                "flashinfer_all2allv"  # TODO: a triky way to disable SP moe. Disable this when SP is supported.
+            )
+            logger.info_once("FlashComm1 is disabled. Using flashinfer_all2allv as the all2all backend.")
         hardware_profile = get_current_hardware_profile()
         if ascend_config.xlite_graph_config.enabled and hardware_profile.supports(
             HardwareCapability.STANDARD_WORKER_PATCHES

--- a/vllm_ascend/platform.py
+++ b/vllm_ascend/platform.py
@@ -1206,7 +1206,7 @@ def _setup_worker_and_scheduler(
             and int(os.getenv("VLLM_ASCEND_ENABLE_FLASHCOMM1", "0")) == 0
         ):
             parallel_config.all2all_backend = (
-                "flashinfer_all2allv"  # TODO: a triky way to disable SP moe. Disable this when SP is supported.
+                "flashinfer_all2allv"  # TODO: a tricky way to disable SP moe. Disable this when SP is supported.
             )
             logger.info_once("FlashComm1 is disabled. Using flashinfer_all2allv as the all2all backend.")
         hardware_profile = get_current_hardware_profile()


### PR DESCRIPTION
## Summary

- Honor the boolean value of `enable_flashcomm1` in `additional_config`.
- Parse `VLLM_ASCEND_ENABLE_FLASHCOMM1` as a numeric switch with `0` disabled by default.
- Keep the `flashinfer_all2allv` fallback when FlashComm1 is disabled and log the selected behavior.

## Motivation

The previous presence/truthiness checks treated `enable_flashcomm1: false` and `VLLM_ASCEND_ENABLE_FLASHCOMM1=0` as enabled paths, so users could not reliably control the SP-related backend selection. This change evaluates the configured values instead of only checking whether the keys or environment variable are present.

## Validation

- `ruff-check` passed.
- `ruff-format` passed.
- Local validation was completed before submission.

- vLLM main: https://github.com/vllm-project/vllm/commit/ba07e4a48fc951300d97eb506217dd530583dea3
