### PR TITLE
feat(model): add Kimi K3 reduced layer loading

### DIFF
--- a/tests/ut/models/test_kimi_k3_adapter.py
+++ b/tests/ut/models/test_kimi_k3_adapter.py
@@ -4,6 +4,7 @@
 from types import MethodType, SimpleNamespace
 from unittest.mock import patch
 
+import pytest
 import torch
 from safetensors.torch import save_file
 from torch import nn
@@ -12,10 +13,82 @@ from vllm_ascend.models import kimi_k3
 from vllm_ascend.models.kimi_k3 import (
     AscendKimiK3MultiModalProjector,
     AscendKimiLinearModel,
+    _get_decoder_layer_idx_from_weight_name,
+    _get_kimi_k3_num_loaded_layers,
 )
 from vllm_ascend.models.kimi_k3_dspark import (
     AscendK3DSparkForCausalLM,
 )
+
+
+@pytest.mark.parametrize(
+    ("env_value", "expected"),
+    [("0", 4), ("3", 3)],
+)
+def test_kimi_k3_layer_reduction_config(
+    monkeypatch: pytest.MonkeyPatch,
+    env_value: str,
+    expected: int,
+):
+    monkeypatch.setenv("VLLM_ASCEND_KIMI_K3_MAX_LOADED_LAYERS", env_value)
+
+    assert _get_kimi_k3_num_loaded_layers(4) == expected
+
+
+@pytest.mark.parametrize("env_value", ["-1", "5", "True", "3.0"])
+def test_kimi_k3_layer_reduction_config_rejects_invalid_values(
+    monkeypatch: pytest.MonkeyPatch,
+    env_value: str,
+):
+    monkeypatch.setenv("VLLM_ASCEND_KIMI_K3_MAX_LOADED_LAYERS", env_value)
+
+    with pytest.raises(ValueError, match="VLLM_ASCEND_KIMI_K3_MAX_LOADED_LAYERS"):
+        _get_kimi_k3_num_loaded_layers(4)
+
+
+@pytest.mark.parametrize(
+    ("weight_name", "expected_layer"),
+    [
+        ("model.layers.2.mlp.gate_proj.weight", 2),
+        ("layers.3.self_attn.q_proj.weight", 3),
+        ("language_model.model.layers.4.mlp.up_proj.weight", 4),
+        ("model.layers.invalid.mlp.gate_proj.weight", None),
+        ("model.embed_tokens.weight", None),
+    ],
+)
+def test_kimi_k3_layer_reduction_parses_loader_prefixes(
+    weight_name: str,
+    expected_layer: int | None,
+):
+    assert _get_decoder_layer_idx_from_weight_name(weight_name) == expected_layer
+
+
+def test_kimi_k3_layer_reduction_skips_weights_for_omitted_layers(monkeypatch):
+    model = AscendKimiLinearModel.__new__(AscendKimiLinearModel)
+    nn.Module.__init__(model)
+    model.num_loaded_layers = 2
+    loaded_names = []
+
+    def fake_upstream_load_weights(_self, weights):
+        loaded_names.extend(name for name, *_ in weights)
+        return set(loaded_names)
+
+    monkeypatch.setattr(
+        kimi_k3.UpstreamKimiLinearModel,
+        "load_weights",
+        fake_upstream_load_weights,
+    )
+    loaded = model.load_weights(
+        iter(
+            [
+                ("layers.1.router.weight", torch.tensor([1.0])),
+                ("layers.2.router.weight", torch.tensor([2.0])),
+            ]
+        )
+    )
+
+    assert loaded_names == ["layers.1.router.weight"]
+    assert loaded == {"layers.1.router.weight"}
 
 
 def test_ascend_attn_res_matches_canonical_k3_math():

--- a/vllm_ascend/envs.py
+++ b/vllm_ascend/envs.py
@@ -71,6 +71,11 @@ env_variables: dict[str, Callable[[], Any]] = {
     # Control the aclrtMemcpyBatchAsync compile path for KV cache offloading.
     # "1": force enable, "0": force disable, None: auto-detect from CANN headers.
     "VLLM_ASCEND_ENABLE_BATCH_MEMCPY": lambda: os.getenv("VLLM_ASCEND_ENABLE_BATCH_MEMCPY", None),
+    # Number of Kimi K3 decoder layers to instantiate and load for debugging.
+    # 0 (the default) loads the complete model.
+    "VLLM_ASCEND_KIMI_K3_MAX_LOADED_LAYERS": lambda: os.getenv(
+        "VLLM_ASCEND_KIMI_K3_MAX_LOADED_LAYERS", "0"
+    ),
 }
 
 # end-env-vars-definition

--- a/vllm_ascend/models/kimi_k3.py
+++ b/vllm_ascend/models/kimi_k3.py
@@ -19,6 +19,7 @@ from vllm.distributed import (
     get_tensor_model_parallel_world_size,
 )
 from vllm.forward_context import get_forward_context, is_forward_context_available
+from vllm.logger import logger
 from vllm.model_executor.layers.fused_moe import FusedMoEFactory
 from vllm.model_executor.layers.fused_moe.router.gate_linear import GateLinear
 from vllm.model_executor.layers.layernorm import RMSNorm
@@ -78,6 +79,7 @@ from vllm.sequence import IntermediateTensors
 from vllm.triton_utils import HAS_TRITON
 from vllm.utils.math_utils import cdiv
 
+from vllm_ascend import envs as envs_ascend
 from vllm_ascend.models.llama_eagle3 import get_rotation_path
 from vllm_ascend.ops.kimi_kda import AscendKimiK3DeltaAttention  # type: ignore[import-untyped]
 
@@ -87,6 +89,43 @@ if HAS_TRITON:
     )
 else:
     apply_attn_res = None  # type: ignore[assignment]
+
+
+KIMI_K3_MAX_LOADED_LAYERS_ENV = "VLLM_ASCEND_KIMI_K3_MAX_LOADED_LAYERS"
+
+
+def _get_kimi_k3_num_loaded_layers(total_num_layers: int) -> int:
+    """Return the requested K3 decoder-layer count for debug loading."""
+    requested_num_layers_raw = getattr(envs_ascend, KIMI_K3_MAX_LOADED_LAYERS_ENV)
+    try:
+        requested_num_layers = int(requested_num_layers_raw)
+    except (TypeError, ValueError) as exc:
+        raise ValueError(
+            f"{KIMI_K3_MAX_LOADED_LAYERS_ENV} must be an integer in "
+            f"[0, {total_num_layers}], got {requested_num_layers_raw!r}"
+        ) from exc
+    if requested_num_layers == 0:
+        return total_num_layers
+    if not 1 <= requested_num_layers <= total_num_layers:
+        raise ValueError(
+            f"{KIMI_K3_MAX_LOADED_LAYERS_ENV} must be in "
+            f"[0, {total_num_layers}], got {requested_num_layers}"
+        )
+    return requested_num_layers
+
+
+def _get_decoder_layer_idx_from_weight_name(weight_name: str) -> int | None:
+    """Extract a K3 decoder-layer index from an inner or VL checkpoint key."""
+    layer_prefix = "layers."
+    prefix_idx = weight_name.find(layer_prefix)
+    if prefix_idx < 0:
+        return None
+    layer_idx_start = prefix_idx + len(layer_prefix)
+    layer_idx_end = weight_name.find(".", layer_idx_start)
+    if layer_idx_end < 0:
+        return None
+    layer_idx_text = weight_name[layer_idx_start:layer_idx_end]
+    return int(layer_idx_text) if layer_idx_text.isdecimal() else None
 
 
 def _apply_ascend_attn_res(
@@ -535,6 +574,17 @@ class AscendKimiLinearModel(UpstreamKimiLinearModel):
         config = vllm_config.model_config.hf_text_config
         self.config = config
         self.vocab_size = config.vocab_size
+        self.num_loaded_layers = _get_kimi_k3_num_loaded_layers(
+            config.num_hidden_layers
+        )
+        if self.num_loaded_layers != config.num_hidden_layers:
+            logger.warning_once(
+                "Kimi K3 layer-reduced debug mode is enabled: loading and "
+                "executing decoder layers [0, %d) out of %d. Generated "
+                "results are not model-quality valid.",
+                self.num_loaded_layers,
+                config.num_hidden_layers,
+            )
         parallel_config = vllm_config.parallel_config
         # vLLM's generic MoE SP switch currently requires DP > 1. K3 also
         # needs the same rank-local token layout for the TP/EP, DP=1 topology
@@ -563,7 +613,7 @@ class AscendKimiLinearModel(UpstreamKimiLinearModel):
             )
 
         self.start_layer, self.end_layer, self.layers = make_layers(
-            config.num_hidden_layers,
+            self.num_loaded_layers,
             get_layer,
             prefix=f"{prefix}.layers",
         )
@@ -603,6 +653,11 @@ class AscendKimiLinearModel(UpstreamKimiLinearModel):
         def remap_mixed_gate_weights():
             for args in weights:
                 name, loaded_weight = args[:2]
+                layer_idx = _get_decoder_layer_idx_from_weight_name(name)
+                if layer_idx is not None and layer_idx >= getattr(
+                    self, "num_loaded_layers", float("inf")
+                ):
+                    continue
                 for source, target, shard_id in gate_mapping:
                     if source not in name:
                         continue


### PR DESCRIPTION
### What this PR does / why we need it?

Adds a debug-only Kimi K3 reduced-layer loading mode controlled by `VLLM_ASCEND_KIMI_K3_MAX_LOADED_LAYERS`.

- Default `0` preserves the complete model.
- A value in `[1, num_hidden_layers]` instantiates only decoder layers `[0, N)`.
- Checkpoint weights belonging to omitted decoder layers are skipped during loading, avoiding missing-parameter failures.
- Invalid values fail fast with a clear `ValueError`.

### Does this PR introduce _any_ user-facing change?

Yes. It introduces the optional debug environment variable `VLLM_ASCEND_KIMI_K3_MAX_LOADED_LAYERS`; its default behavior is unchanged.

### How was this patch tested?

- Added unit coverage in `tests/ut/models/test_kimi_k3_adapter.py` for configuration parsing, layer-key parsing, and skipping omitted-layer weights.
- Tests were not run during this PR preparation; runtime validation will be performed separately on Ascend hardware.

- vLLM main: https://github.com/vllm-project/vllm/commit/ba07e4a48fc951300d97eb506217dd530583dea3
