### PR TITLE
[Doc][Attention] Correct misleading attention docstrings

### DIFF
--- a/vllm_ascend/attention/context_parallel/dsa_cp.py
+++ b/vllm_ascend/attention/context_parallel/dsa_cp.py
@@ -122,10 +122,7 @@ class AscendDSAReqMetadata:
 
 @dataclass
 class AscendDSAMetadata:
-    """Metadata for MLACommon.
-    NOTE: Please read the comment at the top of the file before trying to
-    understand this class
-    """
+    """Runtime metadata for context-parallel DeepSeek sparse attention."""
 
     num_actual_tokens: int  # Number of tokens excluding padding.
     query_start_loc: torch.Tensor
@@ -170,10 +167,7 @@ class AscendDSACPLayerMetadata:
 
 
 class AscendDSACPMetadataBuilder(AttentionMetadataBuilder[AscendDSAMetadata]):
-    """
-    NOTE: Please read the comment at the top of the file before trying to
-    understand this class
-    """
+    """Build runtime metadata for context-parallel DeepSeek sparse attention."""
 
     def __init__(
         self,
@@ -1053,10 +1047,7 @@ class AscendDSACPMetadataBuilder(AttentionMetadataBuilder[AscendDSAMetadata]):
 
 
 class AscendDSACPImpl(AttentionImplBase[Any]):
-    """
-    NOTE: Please read the comment at the top of the file before trying to
-    understand this class
-    """
+    """Context-parallel implementation of DeepSeek sparse attention."""
 
     o_proj_full_pools: ClassVar[dict[Any, torch.Tensor]] = {}
 

--- a/vllm_ascend/attention/context_parallel/mla_cp.py
+++ b/vllm_ascend/attention/context_parallel/mla_cp.py
@@ -160,10 +160,7 @@ class AscendMlaDCPMetadataBuilder(
 
 
 class AscendMlaDCPImpl(DCPImplMixin, AscendMLAImpl):
-    """
-    NOTE: Please read the comment at the top of the file before trying to
-    understand this class
-    """
+    """Ascend MLA implementation for decode context parallelism."""
 
     @staticmethod
     def update_graph_params(

--- a/vllm_ascend/attention/dsa_v1.py
+++ b/vllm_ascend/attention/dsa_v1.py
@@ -227,10 +227,7 @@ class AscendDSAReqMetadata:
 
 @dataclass
 class AscendDSAMetadata:
-    """Metadata for MLACommon.
-    NOTE: Please read the comment at the top of the file before trying to
-    understand this class
-    """
+    """Runtime metadata for Ascend DeepSeek sparse attention."""
 
     num_actual_tokens: int  # Number of tokens excluding padding.
     num_decodes: int
@@ -330,10 +327,7 @@ def build_dspark_swa_indices(
 
 
 class AscendDSAMetadataBuilder(AttentionMetadataBuilder[AscendDSAMetadata]):
-    """
-    NOTE: Please read the comment at the top of the file before trying to
-    understand this class
-    """
+    """Build runtime metadata for Ascend DeepSeek sparse attention."""
 
     def __init__(
         self,
@@ -972,10 +966,7 @@ class AscendDSAMetadataBuilder(AttentionMetadataBuilder[AscendDSAMetadata]):
 
 
 class AscendDSAImpl(AttentionImplBase[Any]):
-    """
-    NOTE: Please read the comment at the top of the file before trying to
-    understand this class
-    """
+    """Ascend implementation of DeepSeek sparse attention."""
 
     def __init__(
         self,

--- a/vllm_ascend/attention/mla_v1.py
+++ b/vllm_ascend/attention/mla_v1.py
@@ -188,10 +188,7 @@ class AscendMLADecodeMetadata:
 
 @dataclass
 class AscendMLAMetadata:
-    """Metadata for MLACommon.
-    NOTE: Please read the comment at the top of the file before trying to
-    understand this class
-    """
+    """Runtime metadata shared by Ascend MLA prefill and decode paths."""
 
     # NOTE(sang): Definition of context_len, query_len, and seq_len.
     # |---------- N-1 iteration --------|
@@ -252,10 +249,7 @@ M = TypeVar("M", bound=AscendMLAMetadata)
 
 
 class AscendMLAMetadataBuilder(MLACommonMetadataBuilder[AscendMLAMetadata]):
-    """
-    NOTE: Please read the comment at the top of the file before trying to
-    understand this class
-    """
+    """Build runtime metadata for Ascend multi-head latent attention."""
 
     decode_metadata_cls: type[AscendMLADecodeMetadata] = AscendMLADecodeMetadata
 
@@ -807,10 +801,7 @@ class PrefillMLAPreprocessResult(NamedTuple):
 
 
 class AscendMLAImpl(MLAAttentionImpl):
-    """
-    NOTE: Please read the comment at the top of the file before trying to
-    understand this class
-    """
+    """Ascend implementation of multi-head latent attention."""
 
     def __init__(
         self,

--- a/vllm_ascend/attention/sfa_v1.py
+++ b/vllm_ascend/attention/sfa_v1.py
@@ -144,11 +144,7 @@ class AscendSFABackend(AttentionBackend):
 
 @dataclass
 class AscendSFAMetadata:
-    """Metadata for MLACommon.
-
-    NOTE: Please read the comment at the top of the file before trying to
-    understand this class
-    """
+    """Runtime metadata for Ascend sparse flash attention."""
 
     # NOTE(sang): Definition of context_len, query_len, and seq_len.
     # |---------- N-1 iteration --------|
@@ -203,10 +199,7 @@ class SFAForwardContext:
 
 
 class AscendSFAMetadataBuilder(MLACommonMetadataBuilder[AscendSFAMetadata]):
-    """
-    NOTE: Please read the comment at the top of the file before trying to
-    understand this class
-    """
+    """Build runtime metadata for Ascend sparse flash attention."""
 
     def __init__(
         self,
@@ -408,10 +401,7 @@ class AscendSFAMetadataBuilder(MLACommonMetadataBuilder[AscendSFAMetadata]):
 
 
 class AscendSFAImpl(MLAAttentionImpl):
-    """
-    NOTE: Please read the comment at the top of the file before trying to
-    understand this class
-    """
+    """Ascend implementation of sparse flash attention."""
 
     # q_hadamard and k_hadamard tensor shared when dsa c8 enabled
     q_hadamard: torch.Tensor | None = None

--- a/vllm_ascend/models/layer/attention/layer.py
+++ b/vllm_ascend/models/layer/attention/layer.py
@@ -53,14 +53,11 @@ DSV4_BLOCK_SIZES = get_dsv4_block_sizes()
 
 
 class DSAAttention(nn.Module, AttentionLayerBase):
-    """Multi-Head Latent Attention layer.
+    """DeepSeek sparse attention layer for compressed KV caches.
 
-    This class takes query, and compressed key/value tensors as input.
-    The class does the following:
-
-    1. Store the input key and value tensors in the KV cache.
-    2. Perform (multi-head/multi-query/grouped-query) attention.
-    3. Return the output tensor.
+    This layer selects the backend and cache specification for DeepSeek V4's
+    C4, C128, and sliding-window attention variants. Execution is delegated to
+    the selected backend implementation.
     """
 
     def __init__(

--- a/vllm_ascend/ops/dsa.py
+++ b/vllm_ascend/ops/dsa.py
@@ -40,7 +40,7 @@ from vllm_ascend.utils import (
 
 @dataclass
 class DSAModules:
-    """Modules used in SFA V2."""
+    """Components required by the DeepSeek sparse attention wrapper."""
 
     wq_a: torch.nn.Module
     q_norm: torch.nn.Module


### PR DESCRIPTION
### What this PR does / why we need it?

Correct misleading and stale attention class docstrings:

- Describe `DSAAttention` as the DeepSeek sparse attention layer that selects the C4, C128, or sliding-window backend, instead of using the copied generic MLA description.
- Correct `DSAModules`, which was incorrectly documented as an SFA V2 container.
- Replace stale `MLACommon` and nonexistent file-level-comment references with concise descriptions for the MLA, SFA, DSA, and DSA-CP metadata, builders, and implementations.

No runtime behavior is changed.

### Does this PR introduce _any_ user-facing change?

No. This is a documentation-only correction.

### How was this patch tested?

- Targeted manual-stage pre-commit hooks passed for all seven changed Python files, including Ruff, formatting, codespell, typos, and repository-specific checks.
- `python3 -m compileall` passed for all changed files.
- `git diff --check` passed.
- No unit tests were added because the patch changes docstrings only.

The full `bash format.sh ci` run also passed Ruff, formatting, codespell, typos, clang-format, markdownlint, Actionlint, and repository-specific checks. Its gitleaks and shellcheck hooks could not run on this macOS host because the downloaded gitleaks binary was for x86-64 Linux and shellcheck was not installed.

https://github.com/vllm-project/vllm/commit/ba07e4a48fc951300d97eb506217dd530583dea3
- vLLM main: https://github.com/vllm-project/vllm/commit/ba07e4a48fc951300d97eb506217dd530583dea3
