### PR TITLE
[Performance] Optimize slot mapping kernel paths

### DIFF
--- a/vllm_ascend/ops/triton/compute_slot_mapping.py
+++ b/vllm_ascend/ops/triton/compute_slot_mapping.py
@@ -82,3 +82,328 @@ def _compute_slot_mapping_kernel(
         if TOTAL_CP_WORLD_SIZE != 1:
             slot_ids = tl.where(is_local, slot_ids, PAD_ID)
         tl.store(slot_mapping_ptr + offsets, slot_ids, mask=mask)
+
+
+@triton.jit
+def _compute_slot_mapping_request(
+    start_idx,
+    end_idx,
+    req_idx,
+    positions_ptr,
+    block_table_ptr,
+    block_table_stride,
+    block_size,
+    slot_mapping_ptr,
+    KV_CACHE_BLOCK_SIZE: tl.constexpr,
+    BLOCKS_PER_KV_BLOCK: tl.constexpr,
+    TOTAL_CP_WORLD_SIZE: tl.constexpr,
+    TOTAL_CP_RANK: tl.constexpr,
+    CP_KV_CACHE_INTERLEAVE_SIZE: tl.constexpr,
+    PAD_ID: tl.constexpr,
+    TILE_BLOCK_SIZE: tl.constexpr,
+    BLOCK_TABLE_WINDOW_SIZE: tl.constexpr,
+):
+    row_offset = req_idx * block_table_stride
+    block_table_offsets = tl.arange(0, BLOCK_TABLE_WINDOW_SIZE)
+    for i in range(start_idx, end_idx, TILE_BLOCK_SIZE):
+        offsets = i + tl.arange(0, TILE_BLOCK_SIZE)
+        mask = offsets < end_idx
+        pos = tl.load(positions_ptr + offsets, mask=mask, other=0).to(tl.int32)
+        if TOTAL_CP_WORLD_SIZE == 1:
+            block_indices = pos // block_size
+            slot_offsets = pos - block_indices * block_size
+        else:
+            virtual_block_size = KV_CACHE_BLOCK_SIZE * TOTAL_CP_WORLD_SIZE
+            virtual_block_indices = pos // virtual_block_size
+            virtual_block_offsets = pos - virtual_block_indices * virtual_block_size
+            is_local = (virtual_block_offsets // CP_KV_CACHE_INTERLEAVE_SIZE) % TOTAL_CP_WORLD_SIZE == TOTAL_CP_RANK
+            local_block_offsets = (
+                virtual_block_offsets // (TOTAL_CP_WORLD_SIZE * CP_KV_CACHE_INTERLEAVE_SIZE)
+            ) * CP_KV_CACHE_INTERLEAVE_SIZE + (virtual_block_offsets % CP_KV_CACHE_INTERLEAVE_SIZE)
+
+            block_indices = virtual_block_indices * BLOCKS_PER_KV_BLOCK + local_block_offsets // block_size
+            slot_offsets = local_block_offsets % block_size
+
+        INT32_MAX = 2147483647
+        valid_block_indices = tl.where(mask, block_indices, INT32_MAX)
+        block_idx_base = tl.min(valid_block_indices, axis=0)
+        block_table_window_offsets = block_idx_base + block_table_offsets
+        block_table_window = tl.load(
+            block_table_ptr + row_offset + block_table_window_offsets,
+            mask=block_table_window_offsets < block_table_stride,
+            other=0,
+        ).to(tl.float32)
+        if TOTAL_CP_WORLD_SIZE == 1:
+            relative_block_indices = tl.where(mask, block_indices - block_idx_base, 0)
+        else:
+            relative_block_indices = tl.where(mask & is_local, block_indices - block_idx_base, 0)
+        block_numbers = tl.gather(block_table_window, relative_block_indices, 0).to(tl.int32)
+        slot_ids = block_numbers * block_size + slot_offsets
+        if TOTAL_CP_WORLD_SIZE != 1:
+            slot_ids = tl.where(is_local, slot_ids, PAD_ID)
+        tl.store(slot_mapping_ptr + offsets, slot_ids, mask=mask)
+
+
+@triton.jit(do_not_specialize=["num_tokens", "max_num_tokens"])
+def _compute_slot_mapping_adaptive_kernel(
+    num_tokens,
+    max_num_tokens,
+    query_start_loc_ptr,
+    positions_ptr,
+    block_table_ptr,
+    block_table_stride,
+    block_size,
+    slot_mapping_ptr,
+    KV_CACHE_BLOCK_SIZE: tl.constexpr,
+    BLOCKS_PER_KV_BLOCK: tl.constexpr,
+    TOTAL_CP_WORLD_SIZE: tl.constexpr,
+    TOTAL_CP_RANK: tl.constexpr,
+    CP_KV_CACHE_INTERLEAVE_SIZE: tl.constexpr,
+    PAD_ID: tl.constexpr,
+    SMALL_TILE_BLOCK_SIZE: tl.constexpr,
+    SMALL_BLOCK_TABLE_WINDOW_SIZE: tl.constexpr,
+    LARGE_BLOCK_TABLE_WINDOW_SIZE: tl.constexpr,
+):
+    req_idx = tl.program_id(0)
+
+    if req_idx == tl.num_programs(0) - 1:
+        for i in range(num_tokens, max_num_tokens, 1024):
+            offsets = i + tl.arange(0, 1024)
+            tl.store(
+                slot_mapping_ptr + offsets,
+                PAD_ID,
+                mask=offsets < max_num_tokens,
+            )
+        return
+
+    start_idx = tl.load(query_start_loc_ptr + req_idx).to(tl.int64)
+    end_idx = tl.load(query_start_loc_ptr + req_idx + 1).to(tl.int64)
+    request_tokens = end_idx - start_idx
+    if request_tokens <= SMALL_TILE_BLOCK_SIZE:
+        _compute_slot_mapping_request(
+            start_idx,
+            end_idx,
+            req_idx,
+            positions_ptr,
+            block_table_ptr,
+            block_table_stride,
+            block_size,
+            slot_mapping_ptr,
+            KV_CACHE_BLOCK_SIZE,
+            BLOCKS_PER_KV_BLOCK,
+            TOTAL_CP_WORLD_SIZE,
+            TOTAL_CP_RANK,
+            CP_KV_CACHE_INTERLEAVE_SIZE,
+            PAD_ID,
+            SMALL_TILE_BLOCK_SIZE,
+            SMALL_BLOCK_TABLE_WINDOW_SIZE,
+        )
+    else:
+        _compute_slot_mapping_request(
+            start_idx,
+            end_idx,
+            req_idx,
+            positions_ptr,
+            block_table_ptr,
+            block_table_stride,
+            block_size,
+            slot_mapping_ptr,
+            KV_CACHE_BLOCK_SIZE,
+            BLOCKS_PER_KV_BLOCK,
+            TOTAL_CP_WORLD_SIZE,
+            TOTAL_CP_RANK,
+            CP_KV_CACHE_INTERLEAVE_SIZE,
+            PAD_ID,
+            1024,
+            LARGE_BLOCK_TABLE_WINDOW_SIZE,
+        )
+
+
+@triton.jit(do_not_specialize=["num_tokens", "max_num_tokens"])
+def _compute_slot_mapping_parallel_kernel(
+    num_tokens,
+    max_num_tokens,
+    query_start_loc_ptr,
+    positions_ptr,
+    block_table_ptr,
+    block_table_stride,
+    block_size,
+    slot_mapping_ptr,
+    KV_CACHE_BLOCK_SIZE: tl.constexpr,
+    BLOCKS_PER_KV_BLOCK: tl.constexpr,
+    TOTAL_CP_WORLD_SIZE: tl.constexpr,
+    TOTAL_CP_RANK: tl.constexpr,
+    CP_KV_CACHE_INTERLEAVE_SIZE: tl.constexpr,
+    PAD_ID: tl.constexpr,
+    TILE_BLOCK_SIZE: tl.constexpr,
+    PARALLEL_TILES: tl.constexpr,
+    BLOCK_TABLE_WINDOW_SIZE: tl.constexpr,
+):
+    program_idx = tl.program_id(0)
+
+    if program_idx == tl.num_programs(0) - 1:
+        for i in range(num_tokens, max_num_tokens, 1024):
+            offsets = i + tl.arange(0, 1024)
+            tl.store(
+                slot_mapping_ptr + offsets,
+                PAD_ID,
+                mask=offsets < max_num_tokens,
+            )
+        return
+
+    req_idx = program_idx // PARALLEL_TILES
+    tile_idx = program_idx - req_idx * PARALLEL_TILES
+    start_idx = tl.load(query_start_loc_ptr + req_idx).to(tl.int64)
+    end_idx = tl.load(query_start_loc_ptr + req_idx + 1).to(tl.int64)
+
+    row_offset = req_idx * block_table_stride
+    block_table_offsets = tl.arange(0, BLOCK_TABLE_WINDOW_SIZE)
+    for i in range(
+        start_idx + tile_idx * TILE_BLOCK_SIZE,
+        end_idx,
+        TILE_BLOCK_SIZE * PARALLEL_TILES,
+    ):
+        offsets = i + tl.arange(0, TILE_BLOCK_SIZE)
+        mask = offsets < end_idx
+        pos = tl.load(positions_ptr + offsets, mask=mask, other=0).to(tl.int32)
+        if TOTAL_CP_WORLD_SIZE == 1:
+            block_indices = pos // block_size
+            slot_offsets = pos - block_indices * block_size
+        else:
+            virtual_block_size = KV_CACHE_BLOCK_SIZE * TOTAL_CP_WORLD_SIZE
+            virtual_block_indices = pos // virtual_block_size
+            virtual_block_offsets = pos - virtual_block_indices * virtual_block_size
+            is_local = (virtual_block_offsets // CP_KV_CACHE_INTERLEAVE_SIZE) % TOTAL_CP_WORLD_SIZE == TOTAL_CP_RANK
+            local_block_offsets = (
+                virtual_block_offsets // (TOTAL_CP_WORLD_SIZE * CP_KV_CACHE_INTERLEAVE_SIZE)
+            ) * CP_KV_CACHE_INTERLEAVE_SIZE + (virtual_block_offsets % CP_KV_CACHE_INTERLEAVE_SIZE)
+
+            block_indices = virtual_block_indices * BLOCKS_PER_KV_BLOCK + local_block_offsets // block_size
+            slot_offsets = local_block_offsets % block_size
+
+        INT32_MAX = 2147483647
+        valid_block_indices = tl.where(mask, block_indices, INT32_MAX)
+        block_idx_base = tl.min(valid_block_indices, axis=0)
+        block_table_window_offsets = block_idx_base + block_table_offsets
+        block_table_window = tl.load(
+            block_table_ptr + row_offset + block_table_window_offsets,
+            mask=block_table_window_offsets < block_table_stride,
+            other=0,
+        ).to(tl.float32)
+        if TOTAL_CP_WORLD_SIZE == 1:
+            relative_block_indices = tl.where(mask, block_indices - block_idx_base, 0)
+        else:
+            relative_block_indices = tl.where(mask & is_local, block_indices - block_idx_base, 0)
+        block_numbers = tl.gather(block_table_window, relative_block_indices, 0).to(tl.int32)
+        slot_ids = block_numbers * block_size + slot_offsets
+        if TOTAL_CP_WORLD_SIZE != 1:
+            slot_ids = tl.where(is_local, slot_ids, PAD_ID)
+        tl.store(slot_mapping_ptr + offsets, slot_ids, mask=mask)
+
+
+def _select_slot_mapping_launch_config(
+    num_reqs: int,
+    num_tokens: int,
+    max_tile_block_size: int = 1024,
+) -> tuple[int, int]:
+    tile_block_size = max_tile_block_size
+    if num_reqs > 1:
+        tokens_per_req = (num_tokens + num_reqs - 1) // num_reqs
+        tokens_per_req = 1 if tokens_per_req < 1 else tokens_per_req
+        request_tile = _next_power_of_2(tokens_per_req)
+        request_tile = 16 if request_tile < 16 else request_tile
+        tile_block_size = request_tile if request_tile < max_tile_block_size else max_tile_block_size
+
+    parallel_tiles = (num_tokens + tile_block_size - 1) // tile_block_size
+    parallel_tiles = 4 if parallel_tiles > 4 else parallel_tiles
+    if num_reqs == 1:
+        parallel_tiles = parallel_tiles if num_tokens >= 2 * tile_block_size else 1
+    elif num_reqs == 2 and num_tokens >= 4 * tile_block_size:
+        parallel_tiles = 2
+    else:
+        parallel_tiles = 1
+    return tile_block_size, parallel_tiles
+
+
+def compute_slot_mapping(
+    num_reqs,
+    num_tokens,
+    max_num_tokens,
+    query_start_loc_ptr,
+    positions_ptr,
+    block_table_ptr,
+    block_table_stride,
+    block_size,
+    slot_mapping_ptr,
+    *,
+    kv_cache_block_size,
+    blocks_per_kv_block,
+    total_cp_world_size,
+    total_cp_rank,
+    cp_kv_cache_interleave_size,
+    pad_id,
+    max_tile_block_size=1024,
+    large_block_table_window_size=None,
+):
+    tile_block_size, parallel_tiles = _select_slot_mapping_launch_config(
+        num_reqs,
+        num_tokens,
+        max_tile_block_size,
+    )
+    common_kernel_kwargs = {
+        "KV_CACHE_BLOCK_SIZE": kv_cache_block_size,
+        "BLOCKS_PER_KV_BLOCK": blocks_per_kv_block,
+        "TOTAL_CP_WORLD_SIZE": total_cp_world_size,
+        "TOTAL_CP_RANK": total_cp_rank,
+        "CP_KV_CACHE_INTERLEAVE_SIZE": cp_kv_cache_interleave_size,
+        "PAD_ID": pad_id,
+    }
+    block_table_window_size = _next_power_of_2((tile_block_size + block_size - 1) // block_size + 1)
+    if large_block_table_window_size is None:
+        large_block_table_window_size = _next_power_of_2((1024 + block_size - 1) // block_size + 1)
+
+    if num_reqs > 1 and tile_block_size < 1024:
+        _compute_slot_mapping_adaptive_kernel[(num_reqs + 1,)](
+            num_tokens,
+            max_num_tokens,
+            query_start_loc_ptr,
+            positions_ptr,
+            block_table_ptr,
+            block_table_stride,
+            block_size,
+            slot_mapping_ptr,
+            SMALL_TILE_BLOCK_SIZE=tile_block_size,
+            SMALL_BLOCK_TABLE_WINDOW_SIZE=block_table_window_size,
+            LARGE_BLOCK_TABLE_WINDOW_SIZE=large_block_table_window_size,
+            **common_kernel_kwargs,
+        )
+    elif parallel_tiles > 1:
+        _compute_slot_mapping_parallel_kernel[(num_reqs * parallel_tiles + 1,)](
+            num_tokens,
+            max_num_tokens,
+            query_start_loc_ptr,
+            positions_ptr,
+            block_table_ptr,
+            block_table_stride,
+            block_size,
+            slot_mapping_ptr,
+            TILE_BLOCK_SIZE=tile_block_size,
+            PARALLEL_TILES=parallel_tiles,
+            BLOCK_TABLE_WINDOW_SIZE=block_table_window_size,
+            **common_kernel_kwargs,
+        )
+    else:
+        _compute_slot_mapping_kernel[(num_reqs + 1,)](
+            num_tokens,
+            max_num_tokens,
+            query_start_loc_ptr,
+            positions_ptr,
+            block_table_ptr,
+            block_table_stride,
+            block_size,
+            slot_mapping_ptr,
+            TILE_BLOCK_SIZE=tile_block_size,
+            BLOCK_TABLE_WINDOW_SIZE=block_table_window_size,
+            **common_kernel_kwargs,
+        )
+    return slot_mapping_ptr

--- a/vllm_ascend/worker/block_table.py
+++ b/vllm_ascend/worker/block_table.py
@@ -11,10 +11,7 @@ from vllm.v1.kv_cache_interface import (
 from vllm.v1.utils import CpuGpuBuffer
 
 from vllm_ascend.distributed.utils import get_decode_context_model_parallel_world_size
-from vllm_ascend.ops.triton.compute_slot_mapping import (
-    _compute_slot_mapping_kernel,
-    _next_power_of_2,
-)
+from vllm_ascend.ops.triton.compute_slot_mapping import compute_slot_mapping
 
 
 class BlockTable:
@@ -154,19 +151,8 @@ class BlockTable:
             )
             self._compute_dcp_slot_mapping(req_indices, positions)
         else:
-            TILE_BLOCK_SIZE = 1024
-            kernel_kwargs = {
-                "KV_CACHE_BLOCK_SIZE": self.physical_block_size,
-                "BLOCKS_PER_KV_BLOCK": self.blocks_per_phys_block,
-                "TOTAL_CP_WORLD_SIZE": total_cp_world_size,
-                "TOTAL_CP_RANK": total_cp_rank,
-                "CP_KV_CACHE_INTERLEAVE_SIZE": self.cp_kv_cache_interleave_size,
-                "PAD_ID": PAD_SLOT_ID,
-                "TILE_BLOCK_SIZE": TILE_BLOCK_SIZE,
-                "BLOCK_TABLE_WINDOW_SIZE": _next_power_of_2(cdiv(TILE_BLOCK_SIZE, self.block_size) + 1),
-            }
-
-            _compute_slot_mapping_kernel[(num_reqs + 1,)](
+            compute_slot_mapping(
+                num_reqs,
                 num_tokens,
                 self.max_num_batched_tokens,
                 query_start_loc,
@@ -175,7 +161,12 @@ class BlockTable:
                 self.block_table.gpu.stride(0),
                 self.block_size,
                 self.slot_mapping.gpu,
-                **kernel_kwargs,
+                kv_cache_block_size=self.physical_block_size,
+                blocks_per_kv_block=self.blocks_per_phys_block,
+                total_cp_world_size=total_cp_world_size,
+                total_cp_rank=total_cp_rank,
+                cp_kv_cache_interleave_size=self.cp_kv_cache_interleave_size,
+                pad_id=PAD_SLOT_ID,
             )
 
     def compute_slot_mapping_draft(


### PR DESCRIPTION
### What this PR does / why we need it?

This PR optimizes the single-group `compute_slot_mapping` Triton dispatch for different request shapes.

- Split long single-request work across up to four Triton programs.
- Select a power-of-two tile for multi-request batches and adapt each request's tile to its runtime token count.
- Split two long requests across two programs per request to improve physical-core utilization.
- Centralize fixed, adaptive, and parallel kernel selection in `vllm_ascend/ops/triton/compute_slot_mapping.py`; `block_table.py` delegates to one launcher.

This is the kernel-path portion split from #15289. Multi-group DSV4 launch fusion remains in #15289.

### Performance

Measurements were collected on one Ascend A3 device at 1850 MHz with CANN 9.1.0. Each shape used `msprof op` kernel replay with 20 warmups and 20 recorded replays per state.

#### Long single request

| Case | Original median (us) | Optimized median (us) | Improvement |
| --- | ---: | ---: | ---: |
| 1 request, 4096 tokens, position start 64 | 6.590 | 4.130 | 37.3% |
| 1 request, 4096 tokens, position start 2048 | 6.590 | 4.460 | 32.3% |
| 1 request, 4096 tokens, position start 8192 | 6.500 | 4.450 | 31.5% |
| 1 request, 4096 tokens, position start 65536 | 6.080 | 4.400 | 27.6% |
| 1 request, 4096 tokens, position start 131072 | 6.010 | 4.420 | 26.5% |
| Hybrid profile-derived case | 6.170 | 4.460 | 27.7% |

The weighted improvement across these profile-derived cases is **30.8%**.

#### Multi request within one group

| Case | Original median (us) | Optimized median (us) | Improvement |
| --- | ---: | ---: | ---: |
| 2 x 2048 tokens | 3.760 | 2.760 | 36.2% |
| 2 requests, 0 + 4096 tokens | 5.760 | 3.740 | 54.0% |
| 4 x 1024 tokens | 2.870 | 2.870 | 0.0% |
| 8 x 512 tokens | 3.330 | 2.930 | 13.7% |
| 16 x 256 tokens | 3.890 | 3.420 | 13.7% |
| 32 x 128 tokens | 5.060 | 4.530 | 11.7% |
| 64 x 64 tokens | 7.880 | 6.690 | 17.8% |
| 8-request uneven distribution | 3.620 | 3.590 | 0.8% |
| 32 requests, 1 x 4096 + 31 x 0 | 6.100 | 5.990 | 1.8% |
| 8 x 1024 prefill | 3.140 | 3.150 | -0.3% |
| 64-request decode | 7.810 | 6.390 | 22.2% |

The weighted nine-case primary matrix improves **12.4%**. On 2 x 2048, the grid grows from three to five programs including padding, kernel median falls from 3.710 us to 2.760 us, compute-program AIV time falls from 3.095 us to 2.136 us, and Scalar wait time falls from 1.307 us to 0.592 us.

### Does this PR introduce _any_ user-facing change?

No API or configuration change. This is an internal Triton-kernel dispatch optimization.

### How was this patch tested?

- Split-branch A3 reference comparison: 24/24 eager cases passed exactly.
- Split-branch multi-request ACL Graph capture/replay: 11/11 cases passed exactly.
- The matrix covers long single request, balanced and uneven multi-request, decode, padding, hybrid KV-cache, non-monotonic positions, and tile boundaries.
- Ruff, Python syntax, and `git diff --check` passed.

Evidence scope: kernel-level correctness, ACL Graph capture/replay, latency, and pipeline attribution on Ascend A3.

- vLLM main: https://github.com/vllm-project/vllm/commit/ba07e4a48fc951300d97eb506217dd530583dea3
