### PR TITLE
[BugFix][MoE] Skip mega_moe JIT load when fused MC2 is disabled

### DIFF
--- a/tests/ut/ops/test_moe_comm_method.py
+++ b/tests/ut/ops/test_moe_comm_method.py
@@ -12,6 +12,7 @@ from vllm_ascend.ops.fused_moe.dataclass.token_dispatcher import MoEAllGatherCom
 from vllm_ascend.ops.fused_moe.moe_comm_method import (
     AllGatherCommImpl,
     AlltoAllCommImpl,
+    FusedMC2CommImpl,
     MC2CommImpl,
 )
 from vllm_ascend.quantization.methods.base import QuantType
@@ -279,3 +280,87 @@ class TestMoECommMethod(TestBase):
             hidden_states=mock_unified_apply_mlp.return_value[0],
             combine_metadata=mock_td_instance.token_dispatch.return_value.combine_metadata,
         )
+
+    @patch("vllm_ascend.ops.fused_moe.moe_comm_method.moe_utils.load_cann_mega_moe_ops")
+    @patch("vllm_ascend.ops.fused_moe.moe_comm_method.is_mega_moe_supported", return_value=True)
+    @patch("vllm_ascend.ops.fused_moe.moe_comm_method.PrepareAndFinalizeWithMC2")
+    @patch("vllm_ascend.ops.fused_moe.moe_comm_method.TokenDispatcherWithMC2")
+    def test_fused_mc2_init_skips_mega_moe_load_when_fused_mc2_disabled(
+        self,
+        mock_token_dispatcher,
+        mock_prepare_finalize,
+        mock_is_mega_moe_supported,
+        mock_load_cann_mega_moe_ops,
+    ):
+        # EP>1 always constructs FusedMC2CommImpl. Default enable_fused_mc2=0
+        # must not JIT-import cann_ops_transformer even if the package exists.
+        self.mock_ascend_config.enable_fused_mc2 = 0
+        self.moe_config.swiglu_limit = None
+        self.moe_config.swiglu_alpha = None
+        self.moe_config.swiglu_beta = None
+        mock_token_dispatcher.return_value = MagicMock()
+        mock_prepare_finalize.return_value = MagicMock()
+
+        comm_impl = FusedMC2CommImpl(self.moe_config)
+
+        mock_load_cann_mega_moe_ops.assert_not_called()
+        self.assertIsNone(comm_impl.expert_token_nums)
+        self.assertFalse(hasattr(comm_impl, "mega_moe"))
+
+    @patch("torch.zeros")
+    @patch("vllm_ascend.ops.fused_moe.moe_comm_method.moe_utils.load_cann_mega_moe_ops")
+    @patch("vllm_ascend.ops.fused_moe.moe_comm_method.is_mega_moe_supported", return_value=True)
+    @patch("vllm_ascend.ops.fused_moe.moe_comm_method.PrepareAndFinalizeWithMC2")
+    @patch("vllm_ascend.ops.fused_moe.moe_comm_method.TokenDispatcherWithMC2")
+    def test_fused_mc2_init_loads_mega_moe_when_fused_mc2_enabled_and_supported(
+        self,
+        mock_token_dispatcher,
+        mock_prepare_finalize,
+        mock_is_mega_moe_supported,
+        mock_load_cann_mega_moe_ops,
+        mock_zeros,
+    ):
+        # enable_fused_mc2=2 remaps to 1 while keeping mega_moe supported.
+        self.mock_ascend_config.enable_fused_mc2 = 1
+        self.moe_config.swiglu_limit = None
+        self.moe_config.swiglu_alpha = None
+        self.moe_config.swiglu_beta = None
+        mock_token_dispatcher.return_value = MagicMock()
+        mock_prepare_finalize.return_value = MagicMock()
+        mock_get_symm_buffer = MagicMock()
+        mock_mega_moe = MagicMock()
+        mock_load_cann_mega_moe_ops.return_value = (mock_get_symm_buffer, mock_mega_moe)
+        mock_zeros.return_value = MagicMock()
+
+        comm_impl = FusedMC2CommImpl(self.moe_config)
+
+        mock_load_cann_mega_moe_ops.assert_called_once()
+        self.assertIs(comm_impl.get_symm_buffer_for_mega_moe, mock_get_symm_buffer)
+        self.assertIs(comm_impl.mega_moe, mock_mega_moe)
+
+    @patch("torch.zeros")
+    @patch("vllm_ascend.ops.fused_moe.moe_comm_method.moe_utils.load_cann_mega_moe_ops")
+    @patch("vllm_ascend.ops.fused_moe.moe_comm_method.is_mega_moe_supported", return_value=False)
+    @patch("vllm_ascend.ops.fused_moe.moe_comm_method.PrepareAndFinalizeWithMC2")
+    @patch("vllm_ascend.ops.fused_moe.moe_comm_method.TokenDispatcherWithMC2")
+    def test_fused_mc2_init_skips_mega_moe_load_when_rolled_back(
+        self,
+        mock_token_dispatcher,
+        mock_prepare_finalize,
+        mock_is_mega_moe_supported,
+        mock_load_cann_mega_moe_ops,
+        mock_zeros,
+    ):
+        # enable_fused_mc2=1 rolls mega_moe back to dispatch_ffn_combine.
+        self.mock_ascend_config.enable_fused_mc2 = 1
+        self.moe_config.swiglu_limit = None
+        self.moe_config.swiglu_alpha = None
+        self.moe_config.swiglu_beta = None
+        mock_token_dispatcher.return_value = MagicMock()
+        mock_prepare_finalize.return_value = MagicMock()
+        mock_zeros.return_value = MagicMock()
+
+        comm_impl = FusedMC2CommImpl(self.moe_config)
+
+        mock_load_cann_mega_moe_ops.assert_not_called()
+        self.assertFalse(hasattr(comm_impl, "mega_moe"))

--- a/vllm_ascend/ops/fused_moe/moe_comm_method.py
+++ b/vllm_ascend/ops/fused_moe/moe_comm_method.py
@@ -259,10 +259,15 @@ class FusedMC2CommImpl(MoECommMethod):
 
     def __init__(self, moe_config):
         super().__init__(moe_config)
-        if is_mega_moe_supported():
+        # FusedMC2CommImpl is constructed whenever ep_size > 1, even if fused
+        # MC2 is disabled. cann_ops_transformer JIT-loads npu_mega_moe.so on
+        # import, so only load it when fused MC2 will actually use mega_moe
+        # (enable_fused_mc2=2 remaps to 1 and keeps is_mega_moe_supported()).
+        ascend_config = get_ascend_config()
+        if ascend_config.enable_fused_mc2 == 1 and is_mega_moe_supported():
             self.mega_moe_symm_buffer = None
             self.get_symm_buffer_for_mega_moe, self.mega_moe = moe_utils.load_cann_mega_moe_ops()
-        if get_ascend_config().enable_fused_mc2 == 1:
+        if ascend_config.enable_fused_mc2 == 1:
             self.expert_token_nums = torch.zeros([self.moe_config.num_local_experts], dtype=torch.int32, device="npu")
         else:
             self.expert_token_nums = None


### PR DESCRIPTION
### What this PR does / why we need it?

`setup_moe_comm_method()` constructs `FusedMC2CommImpl` whenever `ep_size > 1`, even if `enable_fused_mc2` is the default `0`. `FusedMC2CommImpl.__init__` previously JIT-imported `cann_ops_transformer` whenever `is_mega_moe_supported()` was true, which loads `npu_mega_moe.so`.

Nightly accuracy tests (Qwen3-Next-80B-A3B-Instruct, Qwen3-Omni, Qwen3-30B-A3B, etc.) enable EP but not fused MC2. The engine then crashes at model load with:

```
ImportError: .../npu_mega_moe.so: cannot open shared object file: No such file or directory
```

`#15267` / `#15303` only skip mega_moe when `enable_fused_mc2=1`. This PR also requires `enable_fused_mc2==1` before loading the op, so the default path no longer depends on that `.so`.

### Does this PR introduce _any_ user-facing change?

Yes. Default EP serving (`enable_fused_mc2=0`) no longer imports `cann_ops_transformer` / JIT-loads `npu_mega_moe.so` during `FusedMC2CommImpl` construction. Runtime communication selection is unchanged.

### How was this patch tested?

- Unit tests added in `tests/ut/ops/test_moe_comm_method.py`:
  - skip load when `enable_fused_mc2=0` even if mega_moe is marked supported
  - load when `enable_fused_mc2=1` and mega_moe is supported (`enable_fused_mc2=2` remap path)
  - skip load when `enable_fused_mc2=1` after mega_moe rollback
- CI unit tests for the new cases

- vLLM main: https://github.com/vllm-project/vllm/commit/ba07e4a48fc951300d97eb506217dd530583dea3
