### PR TITLE
[bugfix] remove env HCCL_INTRA_PCIE_ENABLE & HCCL_INTRA_ROCE_ENABLE in e2e

### DIFF
--- a/tests/e2e/nightly/multi_node/internal_dp/config/DeepSeek-V3.1-BF16.yaml
+++ b/tests/e2e/nightly/multi_node/internal_dp/config/DeepSeek-V3.1-BF16.yaml
@@ -9,8 +9,6 @@ env_common: &env_common
   OMP_PROC_BIND: false
   PYTORCH_NPU_ALLOC_CONF: expandable_segments:True
   OMP_NUM_THREADS: 1
-  HCCL_INTRA_PCIE_ENABLE: 1
-  HCCL_INTRA_ROCE_ENABLE: 0
   VLLM_ENGINE_READY_TIMEOUT_S: "3000"
 
 deployment:

--- a/tests/e2e/nightly/multi_node/internal_dp/config/Kimi-K2_5-W4A8-A2-dual-nodes.yaml
+++ b/tests/e2e/nightly/multi_node/internal_dp/config/Kimi-K2_5-W4A8-A2-dual-nodes.yaml
@@ -5,8 +5,6 @@ npu_per_node: 8
 
 env_common: &env_common
   HCCL_OP_EXPANSION_MODE: AIV
-  HCCL_INTRA_PCIE_ENABLE: 1
-  HCCL_INTRA_ROCE_ENABLE: 0
   PYTORCH_NPU_ALLOC_CONF: expandable_segments:True
   OMP_PROC_BIND: false
   OMP_NUM_THREADS: 1
@@ -44,7 +42,7 @@ deployment:
         --mm-processor-cache-gb 0
         --mm-encoder-tp-mode data
 
-      --additional-config '{"enable_mlapo":true}'
+      --additional-config '{"enable_mlapo":true, "mc2_comm_alg": "hierarchy"}'
 
   - 
     envs:
@@ -75,7 +73,7 @@ deployment:
         --mm-processor-cache-gb 0
         --mm-encoder-tp-mode data
 
-      --additional-config '{"enable_mlapo":true}'
+      --additional-config '{"enable_mlapo":true, "mc2_comm_alg": "hierarchy"}'
 
 benchmarks:
   perf:


### PR DESCRIPTION
### What this PR does / why we need it?

related to https://github.com/vllm-project/vllm-ascend/pull/15094
Now env HCCL_INTRA_PCIE_ENABLE & HCCL_INTRA_ROCE_ENABLE will not control dispatch/combine op's input param in A2, we need to set --additional_config '{"mc2_comm_alg": "hierarchy"}' to replace these two envs.

When in A3, these two envs are only effective in kv pooling case, so remove these two envs when kv pooling is not open.

### Does this PR introduce _any_ user-facing change?

### How was this patch tested?

- vLLM main: https://github.com/vllm-project/vllm/commit/ba07e4a48fc951300d97eb506217dd530583dea3
