### PR TITLE
[Bugfix][MRV2] Fix full-graph param updates for mixed-attention models under PP

### DIFF
--- a/tests/ut/models/minimax_m3/test_msa_m3.py
+++ b/tests/ut/models/minimax_m3/test_msa_m3.py
@@ -1559,3 +1559,30 @@ def test_sparse_attn_decode_npu_forwards_runtime_metadata(
     assert kwargs["block_size"] == 128
     assert kwargs["top_k"] == 2
     assert torch.equal(output, torch.ones_like(output))
+
+
+def test_m3_impls_provide_update_graph_params_protocol():
+    """Both M3 impls must satisfy the update_graph_params protocol.
+
+    The implementations are no-ops (replay parameters are refreshed by the
+    metadata builders), but the method must exist so the full-graph
+    parameter-update backend selection treats them uniformly.
+    """
+    from vllm_ascend.models.minimax_m3.msa_m3 import (
+        AscendMiniMaxM3IndexerImpl,
+        AscendMiniMaxM3SparseImpl,
+    )
+
+    for impl_cls in (AscendMiniMaxM3IndexerImpl, AscendMiniMaxM3SparseImpl):
+        method = getattr(impl_cls, "update_graph_params", None)
+        assert callable(method)
+        # Signature parity with AscendAttentionBackendImpl.update_graph_params.
+        params = inspect.signature(method).parameters
+        assert list(params)[:5] == [
+            "update_stream",
+            "forward_context",
+            "num_tokens",
+            "vllm_config",
+            "speculative_config",
+        ]
+        assert params["speculative_config"].default is None

--- a/vllm_ascend/models/minimax_m3/msa_m3.py
+++ b/vllm_ascend/models/minimax_m3/msa_m3.py
@@ -594,6 +594,24 @@ class AscendMiniMaxM3IndexerImpl(nn.Module):
                 )
         return decode_topk, prefill_topk
 
+    @staticmethod
+    def update_graph_params(
+        update_stream,
+        forward_context,
+        num_tokens,
+        vllm_config,
+        speculative_config=None,
+        draft_attn_metadatas=None,
+    ):
+        """No-op: indexer replay parameters are owned by its metadata builder,
+        not by the full-graph parameter-update channel.
+
+        Selection note: _get_graph_update_backend picks the first executable
+        backend, so correct updates for mixed-attention models rely on the
+        full-attention (GQA) group being scanned first — M3's full-attention
+        layers are the first layers registered, which holds today.
+        """
+
 
 class AscendMiniMaxM3Indexer(nn.Module):
     def __init__(
@@ -891,6 +909,24 @@ class AscendMiniMaxM3SparseImpl(AttentionImplBase[AscendMiniMaxM3SparseMetadata]
                 block_size=self.block_size,
             )
         return output
+
+    @staticmethod
+    def update_graph_params(
+        update_stream,
+        forward_context,
+        num_tokens,
+        vllm_config,
+        speculative_config=None,
+        draft_attn_metadatas=None,
+    ):
+        """No-op: sparse-attention replay parameters are owned by its metadata
+        builder, not by the full-graph parameter-update channel.
+
+        Selection note: _get_graph_update_backend picks the first executable
+        backend, so correct updates for mixed-attention models rely on the
+        full-attention (GQA) group being scanned first — M3's full-attention
+        layers are the first layers registered, which holds today.
+        """
 
 
 class AscendMiniMaxM3QKVParallelLinearWithIndexer(QKVParallelLinear):


### PR DESCRIPTION
### What this PR does / why we need it?

MiniMax-M3 is mixed-attention: layers 0-2 are full attention (global `AscendAttentionBackend`) while layers 3-59 are block-sparse with a lightning indexer. The sparse/indexer impls did not implement the `update_graph_params` protocol, so when `_get_graph_update_backend()` selected one of them — e.g. on a pipeline stage whose layers are all sparse/indexer — full-graph replay crashed with:

```
(Worker_PP1_TP0_EP0) AttributeError: type object 'AscendMiniMaxM3IndexerImpl'
                    has no attribute 'update_graph_params'
```

Without PP the GQA group happens to be ordered first and things work by luck; with PP>1 the second stage (layers 30-59) has no full-attention layer at all.

Their replay parameters are refreshed by their own metadata builders, so a **no-op `update_graph_params` documenting that is the correct protocol implementation** — no change to the selection logic is needed. Selection-order note: on stages that do contain full-attention layers, the GQA group is scanned first (M3's full-attention layers are the first registered), so the real update implementation still wins; this ordering dependency is recorded in the no-op docstrings.

Root-cause analysis and the selection-condition idea originate from #14822.

### Does this PR introduce _any_ user-facing change?

Yes: MiniMax-M3 with pipeline parallelism no longer crashes in FULL / FULL_DECODE_ONLY cudagraph mode on stages without full-attention layers.

### How was this patch tested?

8x Ascend 910B (A3), MRV2, `--cudagraph-mode FULL_DECODE_ONLY`, GSM8K single-case:

- MiniMax-M3 BF16, TP4xPP2: crashes on main with the AttributeError above; passes with this PR (answer=71, matches eager baseline)
- MiniMax-M3-W8A8 (quantization=ascend): TP8+EP and TP8xPP2 both pass (answer=71)
- Cross-family spot checks unaffected (single-backend selection resolves identically): Qwen3-235B-A22B W8A8 (GQA), DeepSeek-V3.2-Exp W4A8 (SFA/MLA), DeepSeek-V4-Flash W8A8 (DSA)
- New UT: `test_m3_impls_provide_update_graph_params_protocol` (both impls expose the method with signature parity); existing M3/worker/spec_decode UT suites green

- vLLM main: https://github.com/vllm-project/vllm/commit/ba07e4a48fc951300d97eb506217dd530583dea3
