### PR TITLE
[Refactor][Device][6/N] Migrate model execution to hardware profiles

### DIFF
--- a/tests/ut/attention/test_dsa_attn_kv_plan.py
+++ b/tests/ut/attention/test_dsa_attn_kv_plan.py
@@ -17,6 +17,7 @@ from vllm_ascend.attention.dsa_attn_kv_plan import (
     resolve_dsv4_cache_dtype,
 )
 from vllm_ascend.attention.sparse_flash_mla import sparse_flash_mla
+from vllm_ascend.device.hardware_profile import get_hardware_profile
 from vllm_ascend.utils import AscendDeviceType
 
 _DSA_C_ASCEND_OPS = (
@@ -47,7 +48,10 @@ def _cache_config(cache_dtype: str = "auto"):
 
 
 def _on(device_type):
-    return mock.patch("vllm_ascend.attention.dsa_attn_kv_plan.get_ascend_device_type", return_value=device_type)
+    return mock.patch(
+        "vllm_ascend.attention.dsa_attn_kv_plan.get_current_hardware_profile",
+        return_value=get_hardware_profile(device_type),
+    )
 
 
 def test_get_dsa_attn_kv_plan_requires_vllm_config():
@@ -56,14 +60,14 @@ def test_get_dsa_attn_kv_plan_requires_vllm_config():
 
 
 def test_a5_fp8_plan_uses_flat_shared_kv():
-    with mock.patch("vllm_ascend.attention.dsa_attn_kv_plan.get_ascend_device_type", return_value=AscendDeviceType.A5):
+    with _on(AscendDeviceType.A5):
         plan = get_dsa_attn_kv_plan(_config(False))
         assert plan.get_dsa_compressor_slot_mapping_format() == DSA_COMPRESSOR_SLOT_MAPPING_FLAT
         assert plan.get_dsa_sparse_attn_metadata_kwargs("npu:0") == {"kv_quant_mode": 1}
 
 
 def test_a5_bf16_plan_uses_sparse_flash_mla():
-    with mock.patch("vllm_ascend.attention.dsa_attn_kv_plan.get_ascend_device_type", return_value=AscendDeviceType.A5):
+    with _on(AscendDeviceType.A5):
         plan = get_dsa_attn_kv_plan(_config(True))
         assert plan.get_dsa_sparse_attn_op() is sparse_flash_mla
         assert plan.get_dsa_compressor_slot_mapping_format() == DSA_COMPRESSOR_SLOT_MAPPING_BLOCK_OFFSET
@@ -74,7 +78,7 @@ def test_a5_bf16_plan_uses_sparse_flash_mla():
 
 
 def test_non_a5_plan_preserves_shared_kv_runtime_kwargs():
-    with mock.patch("vllm_ascend.attention.dsa_attn_kv_plan.get_ascend_device_type", return_value=AscendDeviceType.A3):
+    with _on(AscendDeviceType.A3):
         plan = get_dsa_attn_kv_plan(_config(True))
         assert plan.get_dsa_compressor_slot_mapping_format() == DSA_COMPRESSOR_SLOT_MAPPING_BLOCK_OFFSET
         kwargs: dict[str, Any] = {}
@@ -83,7 +87,7 @@ def test_non_a5_plan_preserves_shared_kv_runtime_kwargs():
 
 
 def test_scatter_skips_none_updates():
-    with mock.patch("vllm_ascend.attention.dsa_attn_kv_plan.get_ascend_device_type", return_value=AscendDeviceType.A5):
+    with _on(AscendDeviceType.A5):
         plan = get_dsa_attn_kv_plan(_config(False))
         cache = torch.zeros(2, 1, 4)
         with mock.patch.object(torch.ops._C_ascend, "kv_compress_epilog") as epilog:

--- a/tests/ut/device/test_hardware_profile.py
+++ b/tests/ut/device/test_hardware_profile.py
@@ -61,6 +61,7 @@ _EXPECTED_CAPABILITIES = {
             HardwareCapability.CLUSTER_CPU_TOPOLOGY,
             HardwareCapability.DSA_C128_STATE_SMALL_BLOCK_SIZES,
             HardwareCapability.DSA_O_PROJ_TP,
+            HardwareCapability.DSV4_COMPRESSED_CACHE,
             HardwareCapability.DYNAMIC_MX_QUANT_FUSION,
             HardwareCapability.DYNAMIC_MX_QUANT_SCALE_ALG_ONE,
             HardwareCapability.FP8_ATTENTION,

--- a/tests/ut/worker/a2/test_model_runner_v1.py
+++ b/tests/ut/worker/a2/test_model_runner_v1.py
@@ -24,6 +24,7 @@ from vllm.v1.worker.gpu_model_runner import GPUModelRunner
 from vllm_ascend.attention.mla_v1 import AscendMLABackend
 from vllm_ascend.attention.utils import get_sfa_qsfa_packed_head_dim
 from vllm_ascend.core.kv_cache_interface import AscendMLAAttentionSpec, AscendSFAIndexerCacheSpec
+from vllm_ascend.device.hardware_profile import get_hardware_profile
 from vllm_ascend.utils import AscendDeviceType
 from vllm_ascend.worker.model_runner_v1 import NPUModelRunner
 
@@ -827,7 +828,10 @@ class TestNPUModelRunnerKVCache(unittest.TestCase):
                     self.assertEqual(indexer_cache[1].shape, (2, 16, 1, 1))
                     self.assertEqual(indexer_cache[1].dtype, torch.float16)
 
-    @patch("vllm_ascend.worker.model_runner_v1.get_ascend_device_type", return_value=AscendDeviceType.A5)
+    @patch(
+        "vllm_ascend.worker.model_runner_v1.get_current_hardware_profile",
+        return_value=get_hardware_profile(AscendDeviceType.A5),
+    )
     @patch("vllm_ascend.worker.model_runner_v1.has_ec_transfer", return_value=False)
     @patch("vllm_ascend.worker.model_runner_v1.get_layers_from_vllm_config")
     def test_a5_sparse_c8_specs_keep_main_and_indexer_layouts_separate(

--- a/tests/ut/worker/test_attn_utils_v2.py
+++ b/tests/ut/worker/test_attn_utils_v2.py
@@ -68,7 +68,11 @@ def test_sfa_indexer_cache_spec_uses_dcp_replication(monkeypatch, replicated_ind
         "enable_sfa_dcp_replicated_indexer",
         lambda _config: replicated_indexer,
     )
-    monkeypatch.setattr(attn_utils, "get_ascend_device_type", lambda: AscendDeviceType.A2)
+    monkeypatch.setattr(
+        attn_utils,
+        "get_current_hardware_profile",
+        lambda: get_hardware_profile(AscendDeviceType.A2),
+    )
     monkeypatch.setattr(
         attn_utils,
         "get_ascend_config",

--- a/tests/ut/worker/test_attn_utils_v2.py
+++ b/tests/ut/worker/test_attn_utils_v2.py
@@ -133,13 +133,13 @@ def test_mrv2_initializes_dsv4_cache_only_layer(
 
     monkeypatch.setattr(
         deepseek_v4_indexer,
-        "get_ascend_device_type",
-        lambda: device_type,
+        "get_current_hardware_profile",
+        lambda: get_hardware_profile(device_type),
     )
     monkeypatch.setattr(
         attn_utils,
-        "get_ascend_device_type",
-        lambda: device_type,
+        "get_current_hardware_profile",
+        lambda: get_hardware_profile(device_type),
     )
     monkeypatch.setattr(
         attn_utils,

--- a/vllm_ascend/attention/dsa_attn_kv_plan.py
+++ b/vllm_ascend/attention/dsa_attn_kv_plan.py
@@ -10,9 +10,13 @@ import torch
 import torch_npu
 
 from vllm_ascend.attention.sparse_flash_mla import sparse_flash_mla, sparse_flash_mla_metadata
-from vllm_ascend.utils import AscendDeviceType, get_ascend_device_type
+from vllm_ascend.device.hardware_profile import HardwareCapability, get_current_hardware_profile
 
 _BF16_KV_CACHE_DTYPES = frozenset({"bfloat16", "bf16"})
+
+
+def _supports_dsv4_compressed_cache() -> bool:
+    return get_current_hardware_profile().supports(HardwareCapability.DSV4_COMPRESSED_CACHE)
 
 
 def resolve_dsv4_cache_dtype(cache_dtype, model_dtype: str) -> str:
@@ -24,7 +28,7 @@ def resolve_dsv4_cache_dtype(cache_dtype, model_dtype: str) -> str:
     collapsing every non-bfloat16 request to ``auto`` preserves the upstream
     values while keeping the mode recoverable.
     """
-    if get_ascend_device_type() != AscendDeviceType.A5:
+    if not _supports_dsv4_compressed_cache():
         return model_dtype
     return "bfloat16" if str(cache_dtype).lower() in _BF16_KV_CACHE_DTYPES else "auto"
 
@@ -36,7 +40,7 @@ def is_a5_bf16_kv_enabled(vllm_config) -> bool:
     process-global current config: that context is only set during
     ``load_model()`` and a missing lookup would silently pick the FP8 plan.
     """
-    if get_ascend_device_type() != AscendDeviceType.A5:
+    if not _supports_dsv4_compressed_cache():
         return False
     cache_config = getattr(vllm_config, "cache_config", None)
     if cache_config is None:
@@ -48,7 +52,7 @@ def get_dsv4_attn_kv_dtype(vllm_config) -> torch.dtype:
     """Return the attention KV dtype while preserving non-A5 behavior."""
     return (
         torch.bfloat16
-        if get_ascend_device_type() != AscendDeviceType.A5 or is_a5_bf16_kv_enabled(vllm_config)
+        if not _supports_dsv4_compressed_cache() or is_a5_bf16_kv_enabled(vllm_config)
         else torch.float8_e4m3fn
     )
 
@@ -133,7 +137,7 @@ class DsaAttnKvPlan:
 
 def get_dsa_attn_kv_plan(vllm_config) -> DsaAttnKvPlan:
     """Return the explicit A5 BF16 or upstream-compatible FP8 DSA plan."""
-    if get_ascend_device_type() != AscendDeviceType.A5:
+    if not _supports_dsv4_compressed_cache():
         return DsaAttnKvPlan(
             uses_sparse_flash_mla=False,
             uses_kv_compress_epilog=False,

--- a/vllm_ascend/device/hardware_profile.py
+++ b/vllm_ascend/device/hardware_profile.py
@@ -26,6 +26,7 @@ class HardwareCapability(Enum):
     DISTRIBUTED_COMMUNICATION_ADAPTATION = auto()
     DSA_C128_STATE_SMALL_BLOCK_SIZES = auto()
     DSA_O_PROJ_TP = auto()
+    DSV4_COMPRESSED_CACHE = auto()
     DYNAMIC_MX_QUANT_FUSION = auto()
     DYNAMIC_MX_QUANT_SCALE_ALG_ONE = auto()
     FP8_ATTENTION = auto()
@@ -193,6 +194,7 @@ _HARDWARE_PROFILES: Mapping[AscendDeviceType, HardwareProfile] = MappingProxyTyp
                     HardwareCapability.CLUSTER_CPU_TOPOLOGY,
                     HardwareCapability.DSA_C128_STATE_SMALL_BLOCK_SIZES,
                     HardwareCapability.DSA_O_PROJ_TP,
+                    HardwareCapability.DSV4_COMPRESSED_CACHE,
                     HardwareCapability.DYNAMIC_MX_QUANT_FUSION,
                     HardwareCapability.DYNAMIC_MX_QUANT_SCALE_ALG_ONE,
                     HardwareCapability.FP8_ATTENTION,

--- a/vllm_ascend/models/deepseek_v4/compressor.py
+++ b/vllm_ascend/models/deepseek_v4/compressor.py
@@ -38,7 +38,7 @@ from vllm.transformers_utils.configs.deepseek_v4 import DeepseekV4Config
 from vllm.v1.kv_cache_interface import KVCacheSpec
 
 from vllm_ascend.core.kv_cache_interface import AscendSlidingWindowMLASpec
-from vllm_ascend.utils import AscendDeviceType, get_ascend_device_type
+from vllm_ascend.device.hardware_profile import HardwareCapability, get_current_hardware_profile
 
 
 class AscendCompressorStateCache(CompressorStateCache):
@@ -126,7 +126,9 @@ class Compressor(nn.Module):
             self.dim,
             self.coff * self.head_dim,
             bias=False,
-            quant_config=None if get_ascend_device_type() in {AscendDeviceType.A5} else quant_config,
+            quant_config=None
+            if get_current_hardware_profile().supports(HardwareCapability.DSV4_COMPRESSED_CACHE)
+            else quant_config,
             prefix=f"{prefix}.wkv",
             return_bias=False,
         )
@@ -134,13 +136,17 @@ class Compressor(nn.Module):
             self.dim,
             self.coff * self.head_dim,
             bias=False,
-            quant_config=None if get_ascend_device_type() in {AscendDeviceType.A5} else quant_config,
+            quant_config=None
+            if get_current_hardware_profile().supports(HardwareCapability.DSV4_COMPRESSED_CACHE)
+            else quant_config,
             prefix=f"{prefix}.wgate",
             return_bias=False,
         )
 
         # A5 compressor kernel needs float for norm_weight input
-        norm_dtype = torch.float32 if get_ascend_device_type() == AscendDeviceType.A5 else None
+        norm_dtype = (
+            torch.float32 if get_current_hardware_profile().supports(HardwareCapability.DSV4_COMPRESSED_CACHE) else None
+        )
         self.norm = RMSNorm(self.head_dim, config.rms_norm_eps, dtype=norm_dtype)
 
         state_dtype = torch.float32

--- a/vllm_ascend/models/deepseek_v4/indexer.py
+++ b/vllm_ascend/models/deepseek_v4/indexer.py
@@ -45,11 +45,7 @@ from vllm_ascend.models.deepseek_v4.compressor import AscendCompressorMetadata, 
 from vllm_ascend.ops.cv_linear import CVLinearWrapper
 from vllm_ascend.ops.linear import AscendUnquantizedLinearMethod
 from vllm_ascend.quantization.methods import AscendW8A8DynamicLinearMethod
-from vllm_ascend.utils import (
-    AscendDeviceType,
-    get_ascend_device_type,
-    npu_stream_switch,
-)
+from vllm_ascend.utils import npu_stream_switch
 
 
 def hadamard_linear(x: torch.Tensor, hadamard: torch.Tensor) -> tuple[torch.Tensor, tuple[int, ...], int]:
@@ -94,7 +90,7 @@ class AscendDeepseekV4IndexerCache(DeepseekV4IndexerCache):
         super().__init__(head_dim, dtype, prefix, cache_config, compress_ratio)
 
     def get_kv_cache_spec(self, vllm_config: VllmConfig) -> KVCacheSpec:
-        if get_ascend_device_type() in {AscendDeviceType.A5}:
+        if get_current_hardware_profile().supports(HardwareCapability.DSV4_COMPRESSED_CACHE):
             self.dtype = torch.float8_e4m3fn
             if not is_a5_bf16_kv_enabled(vllm_config):
                 vllm_config.cache_config.cache_dtype = "float8_e4m3fn"
@@ -112,7 +108,9 @@ class AscendDeepseekV4IndexerCache(DeepseekV4IndexerCache):
             compress_ratio=self.compress_ratio,
             cache_dtype_str=self.cache_config.cache_dtype,
             scale_dim=1 if self.head_dim == 128 else 0,
-            scale_dtype=torch.float if get_ascend_device_type() in {AscendDeviceType.A5} else torch.float16,
+            scale_dtype=torch.float
+            if get_current_hardware_profile().supports(HardwareCapability.DSV4_COMPRESSED_CACHE)
+            else torch.float16,
         )
 
     def forward(self): ...
@@ -292,8 +290,11 @@ class DeepseekV4Indexer(nn.Module):
             prefix=f"{prefix}.weights_proj",
             return_bias=False,
         )
-        ascend_device_type = get_ascend_device_type()
-        k_dtype = torch.float8_e4m3fn if ascend_device_type == AscendDeviceType.A5 else torch.int8
+        k_dtype = (
+            torch.float8_e4m3fn
+            if get_current_hardware_profile().supports(HardwareCapability.DSV4_COMPRESSED_CACHE)
+            else torch.int8
+        )
 
         if self.compress_ratio == 4:
             # TODO(cmq): change the dtype of cache

--- a/vllm_ascend/models/layer/attention/layer.py
+++ b/vllm_ascend/models/layer/attention/layer.py
@@ -26,10 +26,7 @@ from vllm_ascend.attention.dsa_v1 import (
     AscendDSASWABackend,
 )
 from vllm_ascend.core.kv_cache_interface import AscendMLAAttentionSpec
-from vllm_ascend.utils import (
-    AscendDeviceType,
-    get_ascend_device_type,
-)
+from vllm_ascend.device.hardware_profile import HardwareCapability, get_current_hardware_profile
 
 
 def get_dsv4_block_sizes(use_a5_bf16_kv: bool = False):
@@ -39,7 +36,7 @@ def get_dsv4_block_sizes(use_a5_bf16_kv: bool = False):
         64: [[64, 64, 4, 16], [8320, 65536]],
         32: [[32, 32, 2, 8], [4160, 32768]],
     }
-    _DSV4_BLOCK_SIZES_A5 = {
+    _DSV4_COMPRESSED_BLOCK_SIZES = {
         128: [[128, 128, 8, 16], [16896, 81920]],
         64: [[64, 64, 4, 8], [8448, 40960]],
         32: [[32, 32, 2, 4], [4224, 20480]],
@@ -49,13 +46,11 @@ def get_dsv4_block_sizes(use_a5_bf16_kv: bool = False):
         64: [[64, 64, 4, 8], [8448, 65536]],
         32: [[32, 32, 2, 4], [4224, 32768]],
     }
-    if get_ascend_device_type() in {AscendDeviceType.A5}:
+    if get_current_hardware_profile().supports(HardwareCapability.DSV4_COMPRESSED_CACHE):
         if use_a5_bf16_kv:
             return _DSV4_BLOCK_SIZES_A5_BF16
-        else:
-            return _DSV4_BLOCK_SIZES_A5
-    else:
-        return _DSV4_BLOCK_SIZES
+        return _DSV4_COMPRESSED_BLOCK_SIZES
+    return _DSV4_BLOCK_SIZES
 
 
 DSV4_BLOCK_SIZES = get_dsv4_block_sizes()
@@ -197,17 +192,14 @@ class DSAAttention(nn.Module, AttentionLayerBase):
             return None
         kv_cache_dtype = kv_cache_dtype_str_to_dtype(self.kv_cache_dtype, vllm_config.model_config)
         use_bf16_kv = is_a5_bf16_kv_enabled(vllm_config)
+        has_compressed_cache = get_current_hardware_profile().supports(HardwareCapability.DSV4_COMPRESSED_CACHE)
         if use_bf16_kv:
             kv_cache_dtype = torch.bfloat16
-        elif get_ascend_device_type() in {AscendDeviceType.A5}:
+        elif has_compressed_cache:
             kv_cache_dtype = torch.float8_e4m3fn
             vllm_config.cache_config.cache_dtype = "float8_e4m3fn"
 
-        cached_head_size = (
-            self.head_size + 128
-            if not use_bf16_kv and get_ascend_device_type() == AscendDeviceType.A5
-            else self.head_size
-        )
+        cached_head_size = self.head_size + 128 if has_compressed_cache and not use_bf16_kv else self.head_size
         storage_block_size = dsv4_block_sizes(vllm_config)[vllm_config.cache_config.block_size][0][0]
         return AscendMLAAttentionSpec(
             # The scheduler operates in raw-token units. Ascend kernels keep

--- a/vllm_ascend/ops/dsa.py
+++ b/vllm_ascend/ops/dsa.py
@@ -31,11 +31,8 @@ from vllm.model_executor.layers.quantization import QuantizationConfig
 from vllm.utils.torch_utils import direct_register_custom_op
 from vllm.v1.attention.backend import AttentionMetadata
 
+from vllm_ascend.device.hardware_profile import HardwareCapability, get_current_hardware_profile
 from vllm_ascend.models.layer.attention.layer import DSAAttention
-from vllm_ascend.utils import (
-    AscendDeviceType,
-    get_ascend_device_type,
-)
 
 
 @dataclass
@@ -226,12 +223,12 @@ def _build_kv_cache(self, forward_context):
             compress_kv_cache = compress_kv_cache[virtual_engine]
     if self.compress_ratio == 4:
         indexer_state_cache = self.indexer.compressor.state_cache.kv_cache
-        if get_ascend_device_type() in {AscendDeviceType.A5}:
+        if get_current_hardware_profile().supports(HardwareCapability.DSV4_COMPRESSED_CACHE):
             indexer_k_cache, indexer_scale_cache, indexer_full_cache = unfold_kvcache(self.indexer.k_cache.kv_cache)
         else:
             indexer_k_cache, indexer_scale_cache = unfold_kvcache(self.indexer.k_cache.kv_cache)
 
-    if get_ascend_device_type() in {AscendDeviceType.A5}:
+    if get_current_hardware_profile().supports(HardwareCapability.DSV4_COMPRESSED_CACHE):
         kv_cache = tuple(
             [
                 unfold_kvcache(cache)

--- a/vllm_ascend/worker/model_runner_v1.py
+++ b/vllm_ascend/worker/model_runner_v1.py
@@ -133,6 +133,7 @@ from vllm_ascend.compilation.acl_graph import (
     update_full_graph_params,
 )
 from vllm_ascend.compilation.breakable_aclgraph import BreakableACLGraphWrapper
+from vllm_ascend.device.hardware_profile import HardwareCapability, get_current_hardware_profile
 from vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.layerwise_cache_layout import (
     apply_layerwise_kv_cache_plan,
 )
@@ -170,7 +171,6 @@ from vllm_ascend.spec_decode.utils import (
     update_num_computed_tokens_for_batch_change,
 )
 from vllm_ascend.utils import (
-    AscendDeviceType,
     calc_split_factor,
     check_gdn_layer,
     embedding_tp_enable,
@@ -178,7 +178,6 @@ from vllm_ascend.utils import (
     enable_sfa,
     enable_sfa_dcp_replicated_indexer,
     enable_sp,
-    get_ascend_device_type,
     get_c_env,
     global_stream,
     is_hidden_state_cache_spec,
@@ -380,7 +379,7 @@ class NPUModelRunner(GPUModelRunner):
         self.enable_sparse_sfa_c8 = self.ascend_config.enable_sparse_sfa_c8
         self.enable_sparse_li_c8 = self.ascend_config.enable_sparse_li_c8
         if self.enable_sparse_sfa_c8 or self.enable_sparse_li_c8:
-            if get_ascend_device_type() == AscendDeviceType.A5:
+            if get_current_hardware_profile().supports(HardwareCapability.FP8_ATTENTION):
                 self.c8_k_cache_dtype = torch.float8_e4m3fn
                 self.c8_k_scale_cache_dtype = torch.float32
             else:
@@ -4447,7 +4446,7 @@ class NPUModelRunner(GPUModelRunner):
                                                 current_kv_cache_spec.num_kv_heads,
                                                 current_kv_cache_spec.scale_dim
                                                 )
-                        if get_ascend_device_type() in {AscendDeviceType.A5}:
+                        if get_current_hardware_profile().supports(HardwareCapability.DSV4_COMPRESSED_CACHE):
                             indexer_full_shape = self.attn_backend.get_kv_cache_shape(
                                 num_blocks, current_kv_cache_spec.storage_block_size,
                                 current_kv_cache_spec.num_kv_heads,

--- a/vllm_ascend/worker/v2/attn_utils.py
+++ b/vllm_ascend/worker/v2/attn_utils.py
@@ -54,13 +54,12 @@ from vllm_ascend.core.kv_cache_interface import (
     AscendSFAIndexerCacheSpec,
     AscendSlidingWindowMLASpec,
 )
+from vllm_ascend.device.hardware_profile import HardwareCapability, get_current_hardware_profile
 from vllm_ascend.quantization.utils import enable_fa_quant
 from vllm_ascend.utils import (
-    AscendDeviceType,
     calc_split_factor,
     enable_sfa,
     enable_sfa_dcp_replicated_indexer,
-    get_ascend_device_type,
 )
 
 if TYPE_CHECKING:
@@ -82,7 +81,7 @@ def get_kv_cache_spec(vllm_config: VllmConfig) -> dict[str, KVCacheSpec]:
         else 1
     )
 
-    if get_ascend_device_type() == AscendDeviceType.A5:
+    if get_current_hardware_profile().supports(HardwareCapability.FP8_ATTENTION):
         c8_k_cache_dtype = torch.float8_e4m3fn
         c8_k_scale_cache_dtype = torch.float32
     else:
@@ -446,7 +445,7 @@ def _view_dsv4_cache(
         )
         cache_shapes.append(scale_shape)
         cache_dtypes.append(scale_dtype)
-        if get_ascend_device_type() in {AscendDeviceType.A5}:
+        if get_current_hardware_profile().supports(HardwareCapability.DSV4_COMPRESSED_CACHE):
             full_shape = attn_backend.get_kv_cache_shape(
                 num_blocks,
                 kv_cache_spec.storage_block_size,
@@ -871,7 +870,11 @@ def _reshape_kv_cache_v2(
 
             if sparse_sfa_c8:
                 raw_k_tensor = raw_cache
-                k_dtype = torch.float8_e4m3fn if get_ascend_device_type() == AscendDeviceType.A5 else torch.int8
+                k_dtype = (
+                    torch.float8_e4m3fn
+                    if get_current_hardware_profile().supports(HardwareCapability.FP8_ATTENTION)
+                    else torch.int8
+                )
                 k_cache = raw_k_tensor.view(k_dtype).view(k_shape)
                 kv_caches[layer_name] = (k_cache,)
             elif isinstance(raw_cache, tuple):


### PR DESCRIPTION
## What

- Add the A5-only `DSV4_COMPRESSED_CACHE` capability at its first real model-execution consumer.
- Replace device-identity branches in DeepSeek V4 compressor/indexer, DSA cache handling, and v1/v2 model-runner cache paths with hardware-profile capability checks.
- Integrate upstream #13716's new DSV4 attention-KV planner without restoring identity checks, while preserving its BF16/FP8 cache modes and block geometry.
- Preserve upstream #15155's new SFA DCP replicated-indexer path while keeping the overlapping FP8 cache selection capability-based.
- Update the exact capability matrix and focused unit-test mocks, including #15155's SFA DCP test.

## Why

This is PR 6/7 of the Device HAL / Hardware Profile refactor series, following merged PR #15376. It keeps hardware identity in detection/profile registration while shared model-execution code consumes an explicit hardware capability.

There is no user-visible behavior change; existing per-device behavior and the newly merged SparseFlashMla BF16/FP8 behavior are preserved.

## Validation

- Rebased onto `main@e8f47fc11c81f3eb3efeb9b40400db8b0fa6eef3`.
- `git range-diff`: original migrations remain patch-equivalent where their upstream consumers still exist; #15155's SFA DCP imports and replicated-indexer path are retained, and the overlapping A5 cache selection remains capability-based.
- Ruff check on all 12 changed Python files: passed.
- Ruff format check on all 12 changed Python files: passed.
- Python compileall on all 12 changed Python files: passed.
- `git diff --check upstream/main...HEAD`: passed.
- Added-device-identity check in changed production code: passed.
- Both commits retain `Signed-off-by`.
- E2E run `33461119015`: CPU exposed two parameterizations in #15155's new SFA DCP test still mocking the removed identity getter; signed follow-up `539315795` changes only that mock to the A2 hardware profile. A new CI run covers the fix.
- The development host has Python 3.10 but no pytest or mypy installation, so focused unit tests and the Python 3.10/3.11/3.12 mypy comparison are left to repository CI.

## Series

- 6/7: model runner / DeepSeek hardware-profile migration
- Depends on: #15376 (merged as `a8501e3d21d84e1cbf9087ab5a848531b9bdb0ae`)
- Next: MoE / compilation / sampler (submitted only after this PR merges)

- vLLM main: https://github.com/vllm-project/vllm/commit/ba07e4a48fc951300d97eb506217dd530583dea3
