### PR TITLE
[BugFix] Align hybrid cache block size for Qwen3.5

### DIFF
--- a/tests/ut/patch/platform/test_patch_mamba_config.py
+++ b/tests/ut/patch/platform/test_patch_mamba_config.py
@@ -1,0 +1,66 @@
+# SPDX-License-Identifier: Apache-2.0
+
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+from vllm_ascend.patch.platform.patch_mamba_config import verify_and_update_config
+
+
+class _FakeHybridModel:
+    @staticmethod
+    def get_mamba_state_shape_from_config(_vllm_config):
+        # Qwen3.5-style conv and SSM states.
+        return ((3, 6144), (16, 128, 128))
+
+    @staticmethod
+    def get_mamba_state_dtype_from_config(_vllm_config):
+        return (torch.bfloat16, torch.float32)
+
+
+@pytest.mark.parametrize("requested_block_size", [512, 1024, 2048])
+def test_block_size_is_aligned_for_hybrid_cache(monkeypatch, requested_block_size):
+    model_config = SimpleNamespace(
+        architecture="FakeHybridModel",
+        dtype=torch.bfloat16,
+        use_mla=False,
+        max_model_len=16384,
+        get_num_kv_heads=lambda _parallel_config: 2,
+        get_head_size=lambda: 256,
+    )
+
+    cache_config = SimpleNamespace(
+        cache_dtype="auto",
+        block_size=requested_block_size,
+        mamba_page_size_padded=None,
+        mamba_cache_mode="none",
+        enable_prefix_caching=False,
+    )
+
+    vllm_config = SimpleNamespace(
+        cache_config=cache_config,
+        model_config=model_config,
+        parallel_config=SimpleNamespace(),
+        scheduler_config=SimpleNamespace(
+            disable_hybrid_kv_cache_manager=False,
+        ),
+        kv_transfer_config=None,
+        speculative_config=None,
+    )
+
+    monkeypatch.setattr(
+        "vllm_ascend.patch.platform.patch_mamba_config.MambaModelConfig.verify_and_update_config",
+        lambda _config: None,
+    )
+    monkeypatch.setattr(
+        "vllm_ascend.patch.platform.patch_mamba_config.ModelRegistry.resolve_model_cls",
+        lambda *_args, **_kwargs: (_FakeHybridModel, None),
+    )
+
+    verify_and_update_config.__func__(None, vllm_config)
+
+    # The Qwen3.5-style layout above requires a 1024-token attention block:
+    # 1024 tokens * 2 KV heads * 256 head size * 2 bytes = 1 MiB,
+    # exactly matching one SSM state block.
+    assert cache_config.block_size == 1024

--- a/vllm_ascend/patch/platform/patch_mamba_config.py
+++ b/vllm_ascend/patch/platform/patch_mamba_config.py
@@ -30,11 +30,10 @@ def _using_kv_store(vllm_config) -> bool:
 @classmethod
 def verify_and_update_config(cls, vllm_config) -> None:
     """
-    Ensure that page size of attention layers is greater than or
-    equal to the mamba layers. If not, automatically set the attention
-    block size to ensure that it is. If the attention page size is
-    strictly greater than the mamba page size, we pad the mamba page size
-    to make them equal.
+    Ensure that the attention K block page size exactly matches the
+    Mamba SSM block page size, as required by the contiguous hybrid cache
+    layout. Adjust the attention block size when necessary and pad the
+    Mamba page size to account for the convolution state.
 
     Args:
         vllm_config: vLLM Config
@@ -96,13 +95,12 @@ def verify_and_update_config(cls, vllm_config) -> None:
         "Cannot align ssm_page_size and attn_page_size."
     )
 
-    # override attention block size if either (a) the
-    # user has not set it or (b) the user has set it
-    # too small.
-    if cache_config.block_size is None or cache_config.block_size < attn_block_size:
+    # The contiguous hybrid cache layout requires the attention K block
+    # and SSM block to have exactly the same page size.
+    if cache_config.block_size != attn_block_size:
         cache_config.block_size = attn_block_size
         logger.info(
-            "Setting attention block size to %d tokens to ensure that attention page size is >= mamba page size.",
+            "Setting attention block size to %d tokens to ensure that attention page size matches mamba page size.",
             attn_block_size,
         )
 


### PR DESCRIPTION
### What this PR does / why we need it?

Fixes #13853.

Qwen3.5 inference can produce corrupted output when using a larger attention block size such as `--block-size 2048`.

The hybrid attention + Mamba cache uses a contiguous shared allocation. For this layout, the attention K block page size must exactly match the Mamba SSM block page size.

The existing logic already computes the aligned attention block size, but it only overrides the configured block size when it is unset or smaller than the required value:

```python
if cache_config.block_size is None or cache_config.block_size < attn_block_size:
```

This means a larger incompatible value such as `2048` is kept, even though it violates the layout requirement.

For the Qwen3.5-0.8B configuration used in #13853:

- Mamba SSM state per block:
  `(16, 128, 128) * fp32 = 1,048,576 bytes`
- Attention K bytes per token:
  `2 KV heads * 256 head size * bf16 = 1,024 bytes`
- Required aligned attention block size:
  `1,048,576 / 1,024 = 1024 tokens`

With block size 2048, the attention scatter offset for slot 2048 is:

```text
2048 * 1024 = 2,097,152 bytes
```

which overlaps the start of the corresponding Mamba SSM state in the shared allocation. The attention KV scatter therefore overwrites the recurrent state, causing corrupted decode output.

This PR changes the condition so that any block size that does not match the calculated aligned size is normalized to the required value:

```python
if cache_config.block_size != attn_block_size:
```

It also adds unit coverage for smaller, already-aligned, and larger requested block sizes:

```text
512  -> 1024
1024 -> 1024
2048 -> 1024
```

### Does this PR introduce _any_ user-facing change?

Yes.

For hybrid attention + Mamba models using this cache layout, an explicitly configured attention block size that is incompatible with the required page alignment will now be automatically adjusted to the aligned block size.

For the Qwen3.5-0.8B configuration reproduced in #13853, specifying:

```text
--block-size 2048
```

results in an effective attention block size of:

```text
1024
```

This prevents the attention KV cache from overlapping the Mamba SSM state.

### How was this patch tested?

Added a unit test for the hybrid-cache block-size alignment logic:

```bash
pytest -q tests/ut/patch/platform/test_patch_mamba_config.py
```

Result:

```text
3 passed
```

The test covers:

```text
requested 512  -> aligned 1024
requested 1024 -> aligned 1024
requested 2048 -> aligned 1024
```

Lint and formatting checks:

```bash
ruff check \
  vllm_ascend/patch/platform/patch_mamba_config.py \
  tests/ut/patch/platform/test_patch_mamba_config.py

ruff format --check \
  vllm_ascend/patch/platform/patch_mamba_config.py \
  tests/ut/patch/platform/test_patch_mamba_config.py
```

Both passed.

Also ran the surrounding platform patch tests:

```bash
pytest -q tests/ut/patch/platform
```

Result:

```text
64 passed, 1 unrelated failure
```

The unrelated failure is:

```text
tests/ut/patch/platform/test_patch_balance_schedule.py::
test_schedule_body_matches_pinned_release_tag
```

and is caused by schedule-body drift against the pinned vLLM v0.26.0 release.

Finally, the original issue was reproduced end-to-end with Qwen3.5-0.8B using:

```bash
ASCEND_RT_VISIBLE_DEVICES=0 vllm serve /workspace/models/Qwen3.5-0.8B \
  --served-model-name qwen35 \
  --tensor-parallel-size 1 \
  --block-size 2048 \
  --max-model-len 16384 \
  --enforce-eager \
  --host 0.0.0.0 \
  --port 8000
```

and:

```bash
curl http://127.0.0.1:8000/v1/completions \
  -H "Content-Type: application/json" \
  -d '{
    "model": "qwen35",
    "prompt": "1+1=2, 1+2=3, 1+3=4, 1+4=5, 1+5=6, 1+6=7, 1+7=8, 1+8=9, 1+9=10, 1+10=11, 1+11=12, 1+12=13, 1+13=14, 1+14=?",
    "max_tokens": 32,
    "temperature": 0
  }'
```

Before the fix, the `2048` configuration produced corrupted repeated `!` output.

After the fix, the same request produced normal output:

```text
A. 15
B. 16
C. 17
D. 18
E. 19
<think>
```

- vLLM main: https://github.com/vllm-project/vllm/commit/ba07e4a48fc951300d97eb506217dd530583dea3
