### PR TITLE
[BugFix][CI] Fix vLLM rollback in bisect

### DIFF
--- a/tests/ut/tools/bisect/test_version_compat.py
+++ b/tests/ut/tools/bisect/test_version_compat.py
@@ -92,7 +92,7 @@ def test_adapter_switches_mismatched_vllm_and_torch_npu(
     monkeypatch.setattr(
         VersionAdapter,
         "_run",
-        staticmethod(lambda command, log_file, label: commands.append(command)),
+        staticmethod(lambda command, log_file, label, env=None: commands.append(command)),
     )
     options = BisectOptions(repo_dir=tmp_path, vllm_dir=tmp_path / "missing-vllm")
     adapter = VersionAdapter(options)
@@ -120,3 +120,28 @@ def test_adapter_switches_mismatched_vllm_and_torch_npu(
             "--disable-pip-version-check",
         ],
     ]
+
+
+def test_adapter_sets_empty_target_device_for_editable_vllm_install(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+):
+    runs: list[tuple[list[str], dict[str, str] | None]] = []
+    vllm_dir = tmp_path / "vllm"
+    vllm_dir.mkdir()
+    monkeypatch.setattr("tools.bisect.version_compat.installed_vllm_version", lambda: "0.24.0")
+    monkeypatch.setattr(git_ops, "resolve_commit", lambda repo, ref: "a" * 40)
+    monkeypatch.setattr(git_ops, "checkout", lambda repo, commit: None)
+    monkeypatch.setattr(
+        VersionAdapter,
+        "_run",
+        staticmethod(lambda command, log_file, label, env=None: runs.append((command, env))),
+    )
+    adapter = VersionAdapter(BisectOptions(repo_dir=tmp_path, vllm_dir=vllm_dir))
+
+    adapter.ensure_targets({"vllm": "v0.25.1"}, ("vllm",))
+
+    command, env = runs[0]
+    assert command[:4] == ["pip", "install", "-e", str(vllm_dir)]
+    assert env is not None
+    assert env["VLLM_TARGET_DEVICE"] == "empty"

--- a/tests/ut/tools/bisect/test_version_compat.py
+++ b/tests/ut/tools/bisect/test_version_compat.py
@@ -1,3 +1,6 @@
+import os
+import subprocess
+import sys
 from pathlib import Path
 
 import pytest
@@ -6,13 +9,18 @@ from tools.bisect import git_ops
 from tools.bisect.config import BisectOptions
 from tools.bisect.version_compat import (
     TORCH_NPU_REQUIREMENTS_FILE,
+    VLLM_PACKAGE,
     VLLM_TAG_FILE,
     PackageVersions,
     VersionAdapter,
     VersionPolicy,
     expected_versions,
+    installed_package_version,
     versions_equal,
 )
+
+VLLM_SOURCE_DIR = Path("/vllm-workspace/vllm")
+VLLM_ROLLBACK_TAG = "v0.25.1"
 
 
 def test_expected_versions_read_nightly_source_files(tmp_path: Path):
@@ -145,3 +153,62 @@ def test_adapter_sets_empty_target_device_for_editable_vllm_install(
     assert command[:4] == ["pip", "install", "-e", str(vllm_dir)]
     assert env is not None
     assert env["VLLM_TARGET_DEVICE"] == "empty"
+
+
+def _is_git_worktree_clean(repo: Path) -> bool:
+    result = subprocess.run(
+        ["git", "-C", str(repo), "status", "--porcelain"],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    return not result.stdout.strip()
+
+
+def _installed_vllm_version_from_test_interpreter() -> str:
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            "from importlib.metadata import version; print(version('vllm'))",
+        ],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    return result.stdout.strip()
+
+
+@pytest.mark.skipif(not VLLM_SOURCE_DIR.is_dir(), reason="requires the nightly vLLM source checkout")
+def test_adapter_switches_real_vllm_release_and_restores_source(tmp_path: Path):
+    if not _is_git_worktree_clean(VLLM_SOURCE_DIR):
+        pytest.skip("vLLM source checkout has uncommitted changes")
+
+    original_commit = git_ops.current_commit(VLLM_SOURCE_DIR)
+    original_version = installed_package_version(VLLM_PACKAGE)
+    original_vllm_version_env = os.environ.get("VLLM_VERSION")
+    target_commit = git_ops.resolve_commit(VLLM_SOURCE_DIR, VLLM_ROLLBACK_TAG)
+    if target_commit == original_commit:
+        pytest.skip(f"vLLM source is already at {VLLM_ROLLBACK_TAG}")
+
+    adapter = VersionAdapter(BisectOptions(repo_dir=tmp_path, vllm_dir=VLLM_SOURCE_DIR))
+    log_file = tmp_path / "vllm_switch.log"
+    try:
+        adapter._switch_vllm(VLLM_ROLLBACK_TAG, log_file)
+        assert git_ops.current_commit(VLLM_SOURCE_DIR) == target_commit
+        assert versions_equal(
+            _installed_vllm_version_from_test_interpreter(),
+            VLLM_ROLLBACK_TAG,
+        )
+    finally:
+        try:
+            adapter._switch_vllm(original_commit, log_file)
+        finally:
+            if original_vllm_version_env is None:
+                os.environ.pop("VLLM_VERSION", None)
+            else:
+                os.environ["VLLM_VERSION"] = original_vllm_version_env
+
+    assert git_ops.current_commit(VLLM_SOURCE_DIR) == original_commit
+    if original_version is not None:
+        assert versions_equal(_installed_vllm_version_from_test_interpreter(), original_version)

--- a/tools/bisect/version_compat.py
+++ b/tools/bisect/version_compat.py
@@ -256,6 +256,7 @@ class VersionAdapter:
                 "--no-input",
                 "--disable-pip-version-check",
             ]
+            install_env = {**os.environ, "VLLM_TARGET_DEVICE": "empty"}
         else:
             command = [
                 "pip",
@@ -264,7 +265,8 @@ class VersionAdapter:
                 "--no-input",
                 "--disable-pip-version-check",
             ]
-        self._run(command, log_file, f"install vllm {expected}")
+            install_env = None
+        self._run(command, log_file, f"install vllm {expected}", env=install_env)
         self._overrides[VLLM_PACKAGE] = expected
         os.environ["VLLM_VERSION"] = expected.lstrip("v")
 
@@ -283,15 +285,20 @@ class VersionAdapter:
         self._overrides[TORCH_NPU_PACKAGE] = expected
 
     @staticmethod
-    def _run(command: list[str], log_file: Path | None, label: str) -> None:
+    def _run(
+        command: list[str],
+        log_file: Path | None,
+        label: str,
+        env: dict[str, str] | None = None,
+    ) -> None:
         logger.info("[version] running: %s", " ".join(command))
         try:
             if log_file is not None:
                 with open(log_file, "a", encoding="utf-8") as out:
-                    proc = subprocess.run(command, stdout=out, stderr=subprocess.STDOUT, text=True)
+                    proc = subprocess.run(command, stdout=out, stderr=subprocess.STDOUT, text=True, env=env)
                 tail = "(see version adaptation log)"
             else:
-                proc = subprocess.run(command, capture_output=True, text=True)
+                proc = subprocess.run(command, capture_output=True, text=True, env=env)
                 tail = (proc.stdout or "")[-2000:]
         except OSError as exc:
             raise VersionAdaptationError(f"Failed to execute command {' '.join(command)}: {exc}") from exc


### PR DESCRIPTION
### What this PR does / why we need it?

Fixes vLLM version rollback during nightly bisect. The editable reinstall after checking out a vLLM release now explicitly sets `VLLM_TARGET_DEVICE=empty`, matching the Ascend image build and avoiding the default device build path.

Adds a regression test for the install environment and a real rollback-and-restore test for nightly vLLM source checkouts. The real test switches to `v0.25.1`, verifies the installed version from a separate Python process, and restores the original commit and installation in `finally`.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

- `tests/ut/tools/bisect`: 56 passed, 1 skipped.
- `ruff check tools/bisect tests/ut/tools/bisect`.
- `ruff format --check tools/bisect tests/ut/tools/bisect`.

The real rollback test is skipped outside the nightly image because this host does not contain `/vllm-workspace/vllm`; it executes in a nightly NPU checkout.

- vLLM main: https://github.com/vllm-project/vllm/commit/ba07e4a48fc951300d97eb506217dd530583dea3
