### PR TITLE
[BugFix][Worker] Invalidate dummy slots before attention metadata build

### DIFF
--- a/tests/ut/worker/test_model_runner_v1.py
+++ b/tests/ut/worker/test_model_runner_v1.py
@@ -1,5 +1,6 @@
 import unittest
 from collections import deque
+from contextlib import nullcontext
 from types import SimpleNamespace
 from unittest.mock import MagicMock, call, patch
 
@@ -27,6 +28,51 @@ from vllm_ascend.core.kv_cache_interface import AscendMLAAttentionSpec, AscendSF
 from vllm_ascend.device.hardware_profile import get_hardware_profile
 from vllm_ascend.utils import AscendDeviceType
 from vllm_ascend.worker.model_runner_v1 import NPUModelRunner
+
+
+class TestDummyRunSlotInvalidation(unittest.TestCase):
+    def test_backend_metadata_sees_invalidated_dummy_slots(self):
+        runner = NPUModelRunner.__new__(NPUModelRunner)
+        runner.uniform_decode_query_len = 1
+        runner.scheduler_config = SimpleNamespace(max_num_batched_tokens=8, max_num_seqs=8)
+        runner.dynamic_eplb = False
+        runner.use_dcp = False
+        runner.speculative_config = None
+        runner.use_compress = True
+        runner._has_gdn = False
+
+        runner._determine_batch_execution_and_padding = MagicMock(
+            return_value=(CUDAGraphMode.NONE, SimpleNamespace(num_tokens=1, num_reqs=1), None, None, None)
+        )
+        runner._should_build_dummy_attn_metadata = MagicMock(return_value=True)
+        runner.synchronize_input_prep = MagicMock(return_value=nullcontext())
+        runner._get_cumsum_and_arange = MagicMock(return_value=np.array([1], dtype=np.int32))
+        runner._pad_query_start_loc_for_fia = MagicMock(return_value=1)
+
+        runner.optimistic_seq_lens_cpu = torch.zeros(8, dtype=torch.int32)
+        runner.seq_lens = MagicMock()
+        runner.query_pos = SimpleNamespace(np=np.zeros(8, dtype=np.int32))
+        runner.query_start_loc = SimpleNamespace(np=np.zeros(9, dtype=np.int32), copy_to_gpu=MagicMock())
+        runner.positions = MagicMock()
+        runner._dsa_positions_cpu_buf = MagicMock()
+
+        slot_mappings = [torch.tensor([3]), torch.tensor([7])]
+        block_tables = MagicMock()
+        block_tables.__getitem__.side_effect = lambda index: SimpleNamespace(
+            slot_mapping=SimpleNamespace(gpu=slot_mappings[index])
+        )
+        runner.input_batch = SimpleNamespace(block_table=block_tables)
+        runner.kv_cache_config = SimpleNamespace(kv_cache_groups=[object(), object()])
+
+        def check_slots_before_build(**_kwargs):
+            for slot_mapping in slot_mappings:
+                torch.testing.assert_close(slot_mapping, torch.full_like(slot_mapping, -1))
+            raise RuntimeError("metadata checked")
+
+        runner._build_attention_metadata = check_slots_before_build
+
+        with self.assertRaisesRegex(RuntimeError, "metadata checked"):
+            runner._dummy_run(1)
 
 
 class TestDSparkAuxCaptureMode(unittest.TestCase):

--- a/tests/ut/worker/test_model_runner_v1.py
+++ b/tests/ut/worker/test_model_runner_v1.py
@@ -36,7 +36,8 @@ class TestDummyRunSlotInvalidation(unittest.TestCase):
         runner.uniform_decode_query_len = 1
         runner.scheduler_config = SimpleNamespace(max_num_batched_tokens=8, max_num_seqs=8)
         runner.dynamic_eplb = False
-        runner.use_dcp = False
+        # use_dcp is a read-only property derived from dcp_size.
+        runner.dcp_size = 1
         runner.speculative_config = None
         runner.use_compress = True
         runner._has_gdn = False

--- a/vllm_ascend/worker/model_runner_v1.py
+++ b/vllm_ascend/worker/model_runner_v1.py
@@ -3560,6 +3560,13 @@ class NPUModelRunner(GPUModelRunner):
                 # rows as well so device-side metadata does not see stale block ids.
                 self.input_batch.block_table.commit_block_table(num_reqs_padded)
 
+                # Invalidate real-request slots before attention backends derive
+                # or copy their backend-specific metadata for dummy execution.
+                if not is_graph_capturing:
+                    for kv_cache_gid in range(len(self.kv_cache_config.kv_cache_groups)):
+                        blk_table = self.input_batch.block_table[kv_cache_gid]
+                        blk_table.slot_mapping.gpu.fill_(-1)
+
                 pad_attn = cudagraph_runtime_mode == CUDAGraphMode.FULL
                 # check how to build dummy
                 if self.use_compress:
@@ -3575,11 +3582,6 @@ class NPUModelRunner(GPUModelRunner):
                     for_cudagraph_capture=is_graph_capturing,
                     num_scheduled_tokens_np=num_scheduled_tokens,
                 )
-                if not is_graph_capturing:
-                    for kv_cache_gid in range(len(self.kv_cache_config.kv_cache_groups)):
-                        blk_table = self.input_batch.block_table[kv_cache_gid]
-                        blk_table.slot_mapping.gpu.fill_(-1)
-
         with self.maybe_dummy_run_with_lora(
             self.lora_config,
             num_scheduled_tokens,


### PR DESCRIPTION
### What this PR does / why we need it?

This PR fixes stale KV slot metadata in `NPUModelRunner._dummy_run()`.

A DP rank with no real requests can still execute a dummy batch for DP alignment. The previous order invalidated the generic `slot_mapping` only after `_build_attention_metadata()`. Attention backends such as DSA may derive or copy backend-specific slot metadata during that build, so the later `fill_(-1)` cannot invalidate the already-built metadata. Dummy graph execution can then write through slots left by a completed request into logical KV blocks that have already been released and may be assigned to a new request.

The fix moves the existing per-KV-group `slot_mapping.gpu.fill_(-1)` before attention metadata construction. It adds no new synchronization, NPU operator, allocation, or mathematical operation.

A production one-shot probe captured the causal transition inside one `_dummy_run` on DP2 in FULL graph mode:

- stale source slots before metadata build: `1498..1505`;
- corresponding persistent SWA KV rows: block 11, offsets 90..97;
- before dummy forward: 4,096/4,096 finite BF16 values and 0 NaNs;
- after the same dummy forward: 0 finite values and 4,096 NaNs;
- the generic slot buffer was already `-1` after the late clear, proving that the clear happened after backend metadata had consumed the stale slots.

The previous `record_stream` changes and tests have been removed from the final diff because the captured corruption is logical KV-block reuse inside a persistent KV cache tensor, not caching-allocator reuse of a temporary tensor.

AI assistance was used during investigation, instrumentation, branch adaptation, test development, and PR preparation. Every changed line, the captured evidence, and the final causal explanation were manually reviewed by the submitter.

### Does this PR introduce _any_ user-facing change?

No API or configuration change. It prevents dummy execution from corrupting released logical KV blocks.

### How was this patch tested?

- Added `TestDummyRunSlotInvalidation::test_backend_metadata_sees_invalidated_dummy_slots` in `tests/ut/worker/a2/test_model_runner_v1.py`. It initializes two KV cache groups with stale slots and asserts that both mappings are `-1` when `_build_attention_metadata()` is entered.
- `python -m py_compile vllm_ascend/worker/model_runner_v1.py tests/ut/worker/a2/test_model_runner_v1.py` — passed.
- `git diff --check` — passed.
- Focused pytest collection in the local Windows checkout is blocked because a matching vLLM environment and `cbor2` are not installed; branch CI remains required.
- On the original v0.25.1 Ascend PD-separated workload, the minimal ordering fix passed 70 rounds / 17,920 requests with 0 request failures and 0 NaN signals.
- The additional stress run completed 100/100 rounds and 25,600/25,600 successful requests with 0 failures, 0 NaN signals, and 0 stop conditions. Combined minimal-fix validation is 170 rounds / 43,520 requests.

- vLLM main: https://github.com/vllm-project/vllm/commit/ba07e4a48fc951300d97eb506217dd530583dea3
