### PR TITLE
[BugFix] Fix DSpark draft attn_sink loading under DSA-CP with TP>1

### DIFF
--- a/vllm_ascend/models/deepseek_v4/dspark.py
+++ b/vllm_ascend/models/deepseek_v4/dspark.py
@@ -44,6 +44,7 @@ from vllm_ascend.models.deepseek_v4.model import (
     DeepseekV4MoE,
 )
 from vllm_ascend.ops.rope_dsv4 import get_cos_and_sin_dsa
+from vllm_ascend.utils import enable_dsa_cp
 
 
 def _apply_dsv4_rope(
@@ -490,9 +491,12 @@ class DSparkDeepseekV4ForCausalLM(nn.Module, DeepseekV2MixtureOfExperts, Support
                 break
             else:
                 if "attn_sink" in name:
-                    narrow = loaded_weight[head_start:head_end]
+                    if enable_dsa_cp():
+                        narrow = loaded_weight
+                    else:
+                        narrow = loaded_weight[head_start:head_end]
                     with torch.no_grad():
-                        params_dict[name][: narrow.shape[0]].copy_(narrow)
+                        params_dict[name].copy_(narrow)
                     loaded_params.add(name)
                     continue
                 param = params_dict[name]


### PR DESCRIPTION
### What this PR does / why we need it?
In the scenario with tp=1 and dp=4, the DSPark acceptance rates are 0.905, 0.788, 0.671, 0.561, 0.450, 0.341, and 0.228. However, when tp=4, dp=1, and DSA-CP is enabled, the acceptance rates drop to 0.836, 0.654, 0.484, 0.338, 0.207, 0.105, and 0.045. The main issue is that when loading the draft model, the attn_sink parameter is not adapted for DSA-CP with full-weight loading. This PR addresses and resolves this issue.
### Does this PR introduce _any_ user-facing change?
no
### How was this patch tested?
gsm8k tp=4, dp=1, and DSA-CP is enabled   
**3.67: [0.836, 0.654, 0.484, 0.338, 0.207, 0.105, and 0.045] => 4.92: [0.904, 0.784, 0.664, 0.552, 0.444, 0.339, 0.229]**

- vLLM main: https://github.com/vllm-project/vllm/commit/ba07e4a48fc951300d97eb506217dd530583dea3
