### PR TITLE
[BugFix][Quantization] Propagate auto-detected quantization to MTP draft

### DIFF
--- a/tests/ut/quantization/test_utils.py
+++ b/tests/ut/quantization/test_utils.py
@@ -199,6 +199,51 @@ class TestMaybeAutoDetectQuantization(TestBase):
         self.assertIn(ASCEND_QUANTIZATION_METHOD, call_args)
         self.assertIn("/fake/quant_model", call_args)
 
+    @patch("vllm.config.VllmConfig._get_quantization_config", return_value=MagicMock())
+    @patch("vllm_ascend.quantization.utils.detect_quantization_method", return_value=ASCEND_QUANTIZATION_METHOD)
+    def test_auto_detect_sets_quantization_on_same_checkpoint_mtp(self, mock_detect, mock_get_quant_config):
+        vllm_config = self._make_vllm_config(model_path="/fake/glm5", quantization=None)
+        draft_model_config = SimpleNamespace(model="/fake/glm5", quantization=None)
+        vllm_config.speculative_config = SimpleNamespace(
+            method="mtp",
+            draft_model_config=draft_model_config,
+        )
+
+        maybe_auto_detect_quantization(vllm_config)
+
+        self.assertEqual(draft_model_config.quantization, ASCEND_QUANTIZATION_METHOD)
+
+    @patch("vllm.config.VllmConfig._get_quantization_config", return_value=MagicMock())
+    @patch("vllm_ascend.quantization.utils.detect_quantization_method", return_value=ASCEND_QUANTIZATION_METHOD)
+    def test_auto_detect_does_not_update_independent_mtp(self, mock_detect, mock_get_quant_config):
+        vllm_config = self._make_vllm_config(model_path="/fake/glm5", quantization=None)
+        draft_model_config = SimpleNamespace(model="/fake/speculator", quantization=None)
+        vllm_config.speculative_config = SimpleNamespace(
+            method="mtp",
+            draft_model_config=draft_model_config,
+        )
+
+        maybe_auto_detect_quantization(vllm_config)
+
+        self.assertIsNone(draft_model_config.quantization)
+
+    @patch("vllm.config.VllmConfig._get_quantization_config", return_value=MagicMock())
+    @patch("vllm_ascend.quantization.utils.detect_quantization_method", return_value=ASCEND_QUANTIZATION_METHOD)
+    def test_auto_detect_preserves_explicit_mtp_quantization(self, mock_detect, mock_get_quant_config):
+        vllm_config = self._make_vllm_config(model_path="/fake/glm5", quantization=None)
+        draft_model_config = SimpleNamespace(
+            model="/fake/glm5",
+            quantization=COMPRESSED_TENSORS_METHOD,
+        )
+        vllm_config.speculative_config = SimpleNamespace(
+            method="mtp",
+            draft_model_config=draft_model_config,
+        )
+
+        maybe_auto_detect_quantization(vllm_config)
+
+        self.assertEqual(draft_model_config.quantization, COMPRESSED_TENSORS_METHOD)
+
     @patch("vllm_ascend.quantization.utils.detect_quantization_method", return_value=ASCEND_QUANTIZATION_METHOD)
     def test_user_mismatch_logs_warning(self, mock_detect):
         """When user specifies a different method than auto-detected,

--- a/vllm_ascend/quantization/utils.py
+++ b/vllm_ascend/quantization/utils.py
@@ -188,6 +188,30 @@ def detect_quantization_method(model: str, revision: str | None = None) -> str |
     return None
 
 
+def _sync_quantization_to_same_checkpoint_mtp(vllm_config, detected: str) -> None:
+    """Propagate auto-detected quantization to an in-checkpoint MTP draft.
+
+    ``SpeculativeConfig`` is initialized before the platform hook that performs
+    quantization auto-detection. Therefore an MTP draft created from the target
+    checkpoint may retain ``quantization=None`` even after the target config is
+    updated. Keep independent draft models and explicitly configured drafts
+    unchanged.
+    """
+    speculative_config = getattr(vllm_config, "speculative_config", None)
+    if speculative_config is None or getattr(speculative_config, "method", None) != "mtp":
+        return
+
+    draft_model_config = getattr(speculative_config, "draft_model_config", None)
+    if draft_model_config is None:
+        return
+
+    target_model_config = vllm_config.model_config
+    if draft_model_config.model != target_model_config.model or draft_model_config.quantization is not None:
+        return
+
+    draft_model_config.quantization = detected
+
+
 def maybe_auto_detect_quantization(vllm_config) -> None:
     """Auto-detect and apply the quantization method on *vllm_config*.
 
@@ -204,6 +228,9 @@ def maybe_auto_detect_quantization(vllm_config) -> None:
     2. Recreate ``vllm_config.quant_config`` so that the quantization
        pipeline (``get_quant_config`` → ``QuantizationConfig`` →
        ``get_quant_method`` for every layer) is properly initialised.
+    3. Propagate the detected method to an MTP draft that shares the target
+       checkpoint. ``SpeculativeConfig`` was initialized before this hook, so
+       the draft cannot inherit a method that was only detected here.
 
     Rules:
         * If the user explicitly set ``--quantization``, that value is
@@ -262,6 +289,7 @@ def maybe_auto_detect_quantization(vllm_config) -> None:
     from vllm.config import VllmConfig as _VllmConfig
 
     vllm_config.quant_config = _VllmConfig._get_quantization_config(model_config, vllm_config.load_config)
+    _sync_quantization_to_same_checkpoint_mtp(vllm_config, detected)
 
 
 def enable_fa_quant(vllm_config, layer_name=None) -> bool:


### PR DESCRIPTION
### What this PR does / why we need it?

Quantization auto-detection runs from the Ascend platform hook after SpeculativeConfig has already created its MTP draft ModelConfig. For ModelSlim checkpoints started without an explicit --quantization ascend argument, the target config is updated to ascend but the same-checkpoint MTP draft remains unquantized. Quantized GLM-5 MTP weights then fail to load because the draft layers were constructed without their quantization parameters.

This change propagates the auto-detected method to an MTP draft only when it shares the target checkpoint and has no explicit quantization method. Independent or explicitly configured drafts remain unchanged. It also adds regression coverage for all three cases.

### Does this PR introduce _any_ user-facing change?

Yes. Quantized GLM-5-style same-checkpoint MTP models can rely on quantization auto-detection and no longer need --quantization ascend solely to load their MTP weights correctly.

### How was this patch tested?

- python -m pre_commit run ruff-check --files vllm_ascend/quantization/utils.py tests/ut/quantization/test_utils.py
- python -m pre_commit run ruff-format --files vllm_ascend/quantization/utils.py tests/ut/quantization/test_utils.py
- python -m pre_commit run codespell --files vllm_ascend/quantization/utils.py tests/ut/quantization/test_utils.py
- python -m compileall -q vllm_ascend/quantization/utils.py tests/ut/quantization/test_utils.py
- The focused pytest suite was not run locally because this Windows environment does not provide torch or torch_npu; the added unit tests are included for CI execution.

- vLLM main: https://github.com/vllm-project/vllm/commit/ba07e4a48fc951300d97eb506217dd530583dea3
