### PR TITLE
[CI] Fix wheel build OOM and disable scheduled release

### DIFF
--- a/.github/workflows/dockerfiles/Dockerfile.buildwheel.a5
+++ b/.github/workflows/dockerfiles/Dockerfile.buildwheel.a5
@@ -18,10 +18,13 @@ ARG PY_VERSION=3.12
 FROM quay.io/ascend/manylinux:9.1.0-950-manylinux_2_34-py${PY_VERSION}
 
 ARG SOC_VERSION="ascend950dt_9582"
+ARG MAX_JOBS=2
 
 # Define environments
 ENV DEBIAN_FRONTEND=noninteractive
 ENV SOC_VERSION=$SOC_VERSION
+ENV MAX_JOBS=$MAX_JOBS
+ENV CMAKE_BUILD_PARALLEL_LEVEL=$MAX_JOBS
 RUN yum update -y && \
     yum install -y python3-pip git vim wget net-tools gcc gcc-c++ make cmake numactl-devel && \
     rm -rf /var/cache/yum

--- a/.github/workflows/schedule_release_code_and_wheel.yml
+++ b/.github/workflows/schedule_release_code_and_wheel.yml
@@ -30,6 +30,7 @@ on:
         type: choice
         options:
           - main
+          - v0.26.0rc1
           - v0.23.0
           - v0.23.0rc1
           - v0.22.1rc1

--- a/.github/workflows/schedule_release_code_and_wheel.yml
+++ b/.github/workflows/schedule_release_code_and_wheel.yml
@@ -18,9 +18,6 @@
 name: Release Code and Wheel
 
 on:
-  schedule:
-    # UTC+8: 10am, 16pm
-    - cron: '0 2,8 * * *'
   push:
     tags:
       - 'v*'
@@ -373,6 +370,7 @@ jobs:
           ls
           docker build -f ./.github/workflows/dockerfiles/Dockerfile.buildwheel.a5 \
           --build-arg PY_VERSION=${{ matrix.python-version }} \
+          --build-arg MAX_JOBS=2 \
           -t wheel-a5:v1 .
           docker run --rm \
           -u "$(id -u):$(id -g)" \


### PR DESCRIPTION
### What this PR does / why we need it?

1. **Remove scheduled trigger** — The `schedule` event pushed wheels to PyPI twice daily without a tag, which is unnecessary and error-prone. The workflow now only runs on `v*` tag pushes or `workflow_dispatch`.

2. **Limit parallel compilation jobs** — The Docker build for A5 wheels had no cap on parallel compile jobs, frequently causing OOM on CI runners with large core counts. This change:
   - Adds `MAX_JOBS` and `CMAKE_BUILD_PARALLEL_LEVEL` env vars to the Dockerfile (default: 2)
   

### Does this PR introduce _any_ user-facing change?

### How was this patch tested?


- vLLM main: https://github.com/vllm-project/vllm/commit/ba07e4a48fc951300d97eb506217dd530583dea3
