### PR TITLE
[BugFix] Fix parent block hash chain in AscendStore tp-mismatch KV events

### DIFF
--- a/tests/ut/distributed/ascend_store/test_pool_worker.py
+++ b/tests/ut/distributed/ascend_store/test_pool_worker.py
@@ -1696,6 +1696,79 @@ class TestKVPoolWorkerTpMismatch(unittest.TestCase):
                     self.assertEqual(len(worker.m_store.put.call_args.args[0]), 1)
                 send_thread.dec_stored_request.assert_called_once_with("r1")
 
+    def _make_event_worker(self, hash_block_size):
+        worker = self._make_strided_worker()
+        worker.token_database.hash_block_size = hash_block_size
+        worker.enable_kv_events = True
+        worker.m_store = MagicMock()
+        send_thread = MagicMock()
+        send_thread.is_stored_request.return_value = True
+        worker.kv_send_thread = send_thread
+        return worker, send_thread
+
+    def test_store_kv_tp_mismatch_event_chain_uses_grouped_hashes(self):
+        # Regression test for issue #12002: request hashes may be finer than
+        # the transfer granularity. Events must carry the grouped (terminal)
+        # hash of each chunk and link parents across the grouped chain, so
+        # the Conductor can walk the prefix even when only some blocks are
+        # newly stored.
+        worker, send_thread = self._make_event_worker(hash_block_size=2)
+        # 4 fine-grained hashes (2 tokens each) over 8 tokens -> 2 chunks of
+        # 4 tokens; grouped hashes are [h1, h3].
+        send_thread.lookup.return_value = [False, False, True, True]
+        req = ReqMeta(
+            req_id="r1",
+            token_len_chunk=8,
+            block_ids_by_group=[[5, 6]],
+            block_hashes=[b"h0", b"h1", b"h2", b"h3"],
+            current_event=None,
+            token_ids=list(range(8)),
+            original_block_size=16,
+        )
+
+        worker._store_kv_tp_mismatch(req)
+
+        # Only the missing chunk's sub-keys are put.
+        self.assertEqual(len(worker.m_store.put.call_args.args[0]), 2)
+        send_thread.update_kv_event.assert_called_once()
+        events = send_thread.update_kv_event.call_args.args[0]
+        self.assertEqual(len(events), 2)
+        self.assertEqual(events[0].block_hashes, [b"h1"])
+        self.assertIsNone(events[0].parent_block_hash)
+        self.assertEqual(events[0].token_ids, [0, 1, 2, 3])
+        self.assertEqual(events[1].block_hashes, [b"h3"])
+        self.assertEqual(events[1].parent_block_hash, b"h1")
+        self.assertEqual(events[1].token_ids, [4, 5, 6, 7])
+        send_thread.dec_stored_request.assert_called_once_with("r1")
+
+    def test_store_kv_tp_mismatch_event_chain_equal_granularity(self):
+        # With hash granularity equal to the transfer block size the chain
+        # follows the raw block hashes in sequence order.
+        worker, send_thread = self._make_event_worker(hash_block_size=4)
+        send_thread.lookup.return_value = [False] * 6
+        req = ReqMeta(
+            req_id="r1",
+            token_len_chunk=12,
+            block_ids_by_group=[[5, 6, 7]],
+            block_hashes=[b"a", b"b", b"c"],
+            current_event=None,
+            token_ids=list(range(12)),
+            original_block_size=16,
+        )
+
+        worker._store_kv_tp_mismatch(req)
+
+        send_thread.update_kv_event.assert_called_once()
+        events = send_thread.update_kv_event.call_args.args[0]
+        self.assertEqual(len(events), 3)
+        self.assertEqual(events[0].block_hashes, [b"a"])
+        self.assertIsNone(events[0].parent_block_hash)
+        self.assertEqual(events[1].block_hashes, [b"b"])
+        self.assertEqual(events[1].parent_block_hash, b"a")
+        self.assertEqual(events[2].block_hashes, [b"c"])
+        self.assertEqual(events[2].parent_block_hash, b"b")
+        send_thread.dec_stored_request.assert_called_once_with("r1")
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/pool_worker.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/pool_worker.py
@@ -1997,19 +1997,23 @@ class KVPoolWorker:
                     if isinstance(req_meta.original_block_size, list)
                     else req_meta.original_block_size
                 )
+                group_block_size = self.token_database.get_block_size(0)
+                group_block_hashes = get_block_hashes(
+                    req_meta.block_hashes,
+                    group_block_size,
+                    getattr(self.token_database, "hash_block_size", group_block_size),
+                )
+                all_hashes = [maybe_convert_block_hash(bh) for bh in group_block_hashes]
                 stored_events: list[BlockStored] = []
-                prev_key = None
-                for idx, (start, end, _base_key) in enumerate(
-                    self.token_database.process_tokens(token_len, req_meta.block_hashes)
-                ):
-                    if idx >= len(req_meta.block_hashes):
-                        break
-                    block_hash = maybe_convert_block_hash(req_meta.block_hashes[idx])
+                for start, end, _base_key in self.token_database.process_tokens(token_len, req_meta.block_hashes):
+                    block_idx = start // group_block_size
+                    if block_idx >= len(all_hashes):
+                        continue
                     token_ids = req_meta.token_ids[start:end] if req_meta.token_ids is not None else None
                     stored_events.append(
                         BlockStored(
-                            block_hashes=[block_hash],
-                            parent_block_hash=prev_key,
+                            block_hashes=[all_hashes[block_idx]],
+                            parent_block_hash=all_hashes[block_idx - 1] if block_idx > 0 else None,
                             token_ids=token_ids,
                             block_size=event_block_size,
                             lora_id=None,
@@ -2017,7 +2021,6 @@ class KVPoolWorker:
                             lora_name=None,
                         )
                     )
-                    prev_key = block_hash
                 if stored_events:
                     send_thread.update_kv_event(stored_events)  # type: ignore[attr-defined]
         finally:


### PR DESCRIPTION
### What this PR does / why we need it?

Fixes #12002 (tp-mismatch store path, not covered by the earlier fix #12012 for the main store path).

Issue #12002 reports that the Mooncake Conductor's `longest_matched` stalls at exactly one block (e.g. 128 tokens) even when the KV Pool holds a much longer cached prefix, because AscendStore emits an incorrect `parent_block_hash` when some blocks already exist and only the missing blocks are stored.

PR #12012 fixed this for the main store path in `kv_transfer.py` by deriving the parent hash from `all_hashes[block_idx - 1]`. However, the tp-mismatch path (`_store_kv_tp_mismatch` in `pool_worker.py`, introduced in #11582) still uses the old `prev_key` pattern and additionally indexes `req_meta.block_hashes` with the enumerate position over `process_tokens` chunks. Since request hashes may be finer than the transfer block granularity (see `from_request_tracker`), the emitted events carry hashes from wrong positions and a parent chain over the wrong hash domain, so the Conductor cannot link the blocks.

This PR mirrors the #12012 fix for the tp-mismatch path:
- Precompute grouped hashes via `get_block_hashes` so event hashes match the stored block granularity
- Derive each event's hash and `parent_block_hash` from `block_idx = start // group_block_size` instead of tracking `prev_key` across the loop

### Does this PR introduce _any_ user-facing change?

No. This is an internal bugfix for KV event chain tracking with AscendStore TP-mismatch pooling.

### How was this patch tested?

- New regression tests in `tests/ut/distributed/ascend_store/test_pool_worker.py`:
  - `test_store_kv_tp_mismatch_event_chain_uses_grouped_hashes` (fails on the pre-fix code, passes after)
  - `test_store_kv_tp_mismatch_event_chain_equal_granularity`
- `python -m unittest tests.ut.distributed.ascend_store.test_pool_worker.TestKVPoolWorkerTpMismatch` -> 11 passed
- `python -m unittest tests.ut.distributed.ascend_store.test_kv_transfer tests.ut.distributed.ascend_store.test_metadata` -> 86 passed
- `ruff check` on both changed files -> clean

## AI Assistance

This PR was prepared with AI assistance; every changed line has been reviewed and tested by the submitter.


- vLLM main: https://github.com/vllm-project/vllm/commit/ba07e4a48fc951300d97eb506217dd530583dea3
