### PR TITLE
[BugFix] Backport structured output fixes for vLLM 0.26

### DIFF
--- a/tests/ut/patch/platform/test_patch_structured_output.py
+++ b/tests/ut/patch/platform/test_patch_structured_output.py
@@ -269,9 +269,12 @@ def test_should_advance_uses_exact_speculative_window():
 
 def test_should_advance_preserves_legacy_delta_window():
     seen_deltas = []
-    reasoner = SimpleNamespace(
-        is_reasoning_end_streaming=lambda _all_ids, delta_ids: seen_deltas.append(list(delta_ids)) or False
-    )
+
+    def record_delta(_all_ids, delta_ids):
+        seen_deltas.append(list(delta_ids))
+        return False
+
+    reasoner = SimpleNamespace(is_reasoning_end_streaming=record_delta)
     manager = object.__new__(StructuredOutputManager)
     manager.enable_in_reasoning = False
     manager._get_reasoner = lambda _request: reasoner

--- a/tests/ut/patch/platform/test_patch_structured_output.py
+++ b/tests/ut/patch/platform/test_patch_structured_output.py
@@ -317,6 +317,7 @@ def test_grammar_bitmask_validates_post_reasoning_drafts_before_accepting():
     grammar = FakeGrammar()
     reasoner = SimpleNamespace(is_reasoning_end_streaming=lambda _all_ids, delta_ids: list(delta_ids) == [marker])
     manager = object.__new__(StructuredOutputManager)
+    manager.enable_in_reasoning = False
     manager.vllm_config = SimpleNamespace(
         num_speculative_tokens=3,
         scheduler_config=SimpleNamespace(max_num_seqs=1),

--- a/tests/ut/patch/platform/test_patch_structured_output.py
+++ b/tests/ut/patch/platform/test_patch_structured_output.py
@@ -33,6 +33,33 @@ class FakeGuidanceBackend(FakeBackend):
     pass
 
 
+class FakeMaskRow:
+    def __init__(self):
+        self.value = None
+
+    def fill_(self, value):
+        self.value = value
+
+
+class FakeMask:
+    def __init__(self, size):
+        self.rows = [FakeMaskRow() for _ in range(size)]
+
+    @property
+    def shape(self):
+        return (len(self.rows),)
+
+    def __getitem__(self, index):
+        if isinstance(index, slice):
+            result = FakeMask(0)
+            result.rows = self.rows[index]
+            return result
+        return self.rows[index]
+
+    def numpy(self):
+        return [row.value for row in self.rows]
+
+
 def make_manager() -> StructuredOutputManager:
     manager = object.__new__(StructuredOutputManager)
     manager.backend = None
@@ -213,3 +240,155 @@ def test_failed_first_backend_does_not_lock_manager(monkeypatch):
 
     assert isinstance(manager.backend, FakeXgrammarBackend)
     assert getattr(manager, patch_structured_output._BACKEND_ATTR) == "xgrammar"
+
+
+def test_should_advance_uses_exact_speculative_window():
+    marker = 9
+    reasoner = SimpleNamespace(is_reasoning_end_streaming=lambda _all_ids, delta_ids: marker in list(delta_ids))
+    manager = object.__new__(StructuredOutputManager)
+    manager.enable_in_reasoning = False
+    manager._get_reasoner = lambda _request: reasoner
+
+    structured_request = SimpleNamespace(
+        reasoning_ended=False,
+        reasoning_end_token_index=None,
+    )
+    request = SimpleNamespace(
+        use_structured_output=True,
+        structured_output_request=structured_request,
+        all_token_ids=[1, 2, marker, 7],
+        num_computed_tokens=4,
+        num_output_placeholders=1,
+    )
+
+    assert manager.should_advance(request, new_token_ids=[marker, 7])
+    assert structured_request.reasoning_ended is True
+    assert structured_request.reasoning_end_token_index == 2
+    assert manager.trim_reasoning_for_advance(request, [marker, 7]) == [7]
+
+
+def test_should_advance_preserves_legacy_delta_window():
+    seen_deltas = []
+    reasoner = SimpleNamespace(
+        is_reasoning_end_streaming=lambda _all_ids, delta_ids: seen_deltas.append(list(delta_ids)) or False
+    )
+    manager = object.__new__(StructuredOutputManager)
+    manager.enable_in_reasoning = False
+    manager._get_reasoner = lambda _request: reasoner
+    request = SimpleNamespace(
+        use_structured_output=True,
+        structured_output_request=SimpleNamespace(reasoning_ended=False),
+        all_token_ids=[1, 2, 3, 4, 5],
+        num_computed_tokens=5,
+        num_output_placeholders=2,
+    )
+
+    assert manager.should_advance(request) is False
+    assert seen_deltas == [[4, 5]]
+
+
+def test_grammar_bitmask_validates_post_reasoning_drafts_before_accepting():
+    marker = 9
+
+    class FakeGrammar:
+        def __init__(self):
+            self.accepted = []
+            self.rolled_back = None
+
+        def fill_bitmask(self, bitmask, index):
+            bitmask[index].fill_(index)
+
+        def is_terminated(self):
+            return False
+
+        def validate_tokens(self, token_ids):
+            return token_ids if token_ids != [7] else []
+
+        def accept_tokens(self, _request_id, token_ids):
+            self.accepted.extend(token_ids)
+            return True
+
+        def rollback(self, count):
+            self.rolled_back = count
+
+    grammar = FakeGrammar()
+    reasoner = SimpleNamespace(is_reasoning_end_streaming=lambda _all_ids, delta_ids: list(delta_ids) == [marker])
+    manager = object.__new__(StructuredOutputManager)
+    manager.vllm_config = SimpleNamespace(
+        num_speculative_tokens=3,
+        scheduler_config=SimpleNamespace(max_num_seqs=1),
+        model_config=SimpleNamespace(is_diffusion=False),
+    )
+    manager.backend = SimpleNamespace(allocate_token_bitmask=FakeMask)
+    manager._grammar_bitmask = None
+    manager._full_mask = -1
+    manager.fill_bitmask_parallel_threshold = 100
+    manager.should_fill_bitmask = lambda _request: False
+    manager._get_reasoner = lambda _request: reasoner
+
+    request = SimpleNamespace(
+        all_token_ids=[1, 2],
+        structured_output_request=SimpleNamespace(grammar=grammar),
+    )
+    result = manager.grammar_bitmask(
+        {"req": request},
+        ["req"],
+        {"req": [marker, 7, 8]},
+    )
+
+    assert len(result) == 4
+    assert grammar.accepted == [8]
+    assert grammar.rolled_back == 1
+
+
+def test_grammar_bitmask_preserves_normal_fsm_advance_path():
+    class FakeGrammar:
+        def __init__(self):
+            self.accepted = []
+            self.validate_calls = []
+
+        def fill_bitmask(self, bitmask, index):
+            bitmask[index].fill_(index)
+
+        def is_terminated(self):
+            return False
+
+        def validate_tokens(self, token_ids):
+            self.validate_calls.append(token_ids)
+            return token_ids
+
+        def accept_tokens(self, _request_id, token_ids):
+            self.accepted.extend(token_ids)
+            return True
+
+        def rollback(self, _count):
+            pass
+
+    grammar = FakeGrammar()
+    reasoner_lookups = []
+    manager = object.__new__(StructuredOutputManager)
+    manager.vllm_config = SimpleNamespace(
+        num_speculative_tokens=1,
+        scheduler_config=SimpleNamespace(max_num_seqs=1),
+        model_config=SimpleNamespace(is_diffusion=False),
+    )
+    manager.backend = SimpleNamespace(allocate_token_bitmask=FakeMask)
+    manager._grammar_bitmask = None
+    manager._full_mask = -1
+    manager.fill_bitmask_parallel_threshold = 100
+    manager.should_fill_bitmask = lambda _request: True
+    manager._get_reasoner = lambda request: reasoner_lookups.append(request)
+
+    request = SimpleNamespace(
+        all_token_ids=[1, 2],
+        structured_output_request=SimpleNamespace(grammar=grammar),
+    )
+    manager.grammar_bitmask({"req": request}, ["req"], {"req": [8]})
+
+    assert reasoner_lookups == [request]
+    assert grammar.accepted == [8]
+    assert grammar.validate_calls == []
+
+
+def test_vllm_release_already_has_structured_output_logger():
+    assert structured_output.logger is not None

--- a/vllm_ascend/core/recompute_scheduler.py
+++ b/vllm_ascend/core/recompute_scheduler.py
@@ -1057,7 +1057,7 @@ class RecomputeScheduler(Scheduler):
                 request.status = RequestStatus.FINISHED_STOPPED
                 stopped = True
 
-            if new_token_ids and self.structured_output_manager.should_advance(request):
+            if new_token_ids and self.structured_output_manager.should_advance(request, new_token_ids=new_token_ids):
                 struct_output_request = request.structured_output_request
                 assert struct_output_request is not None
                 grammar = struct_output_request.grammar

--- a/vllm_ascend/patch/__init__.py
+++ b/vllm_ascend/patch/__init__.py
@@ -663,6 +663,8 @@
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 #   1. `vllm.sampling_params.SamplingParams._validate_structured_outputs`
 #      `vllm.v1.structured_output.StructuredOutputManager.grammar_init`
+#      `vllm.v1.structured_output.StructuredOutputManager.grammar_bitmask`
+#      `vllm.v1.structured_output.StructuredOutputManager.should_advance`
 #    Why:
 #       V1 structured outputs use one engine-level backend, while `backend=auto`
 #       resolves the backend per request. After one request initializes
@@ -672,10 +674,16 @@
 #       Record the first resolved backend on the structured-output config and
 #       reject later requests that resolve to a different backend. Also guard
 #       `grammar_init` so requests that bypass API-side validation fail before
-#       backend grammar compilation.
+#       backend grammar compilation. On vLLM v0.26.0 only, backport the
+#       reasoning-boundary fixes so the exact accepted speculative window
+#       advances the FSM, and validate post-boundary draft tokens before
+#       accepting them into the grammar.
 #    Related PR (if no, explain why):
 #       https://github.com/vllm-project/vllm/issues/43920
 #       https://github.com/vllm-project/vllm/pull/44401
+#       https://github.com/vllm-project/vllm/pull/44993
+#       https://github.com/vllm-project/vllm/pull/49626
+#       https://github.com/vllm-project/vllm/pull/53046
 #    Future Plan:
 #       Remove this patch once upstream vLLM either enforces backend consistency
 #       before grammar compilation or safely handles mixed-backend grammar

--- a/vllm_ascend/patch/platform/patch_kv_delivery_preemption.py
+++ b/vllm_ascend/patch/platform/patch_kv_delivery_preemption.py
@@ -971,7 +971,7 @@ class KVDeliveryScheduler(Scheduler):
                 request.status = RequestStatus.FINISHED_STOPPED
                 stopped = True
 
-            if new_token_ids and self.structured_output_manager.should_advance(request):
+            if new_token_ids and self.structured_output_manager.should_advance(request, new_token_ids=new_token_ids):
                 struct_output_request = request.structured_output_request
                 assert struct_output_request is not None
                 grammar = struct_output_request.grammar

--- a/vllm_ascend/patch/platform/patch_structured_output.py
+++ b/vllm_ascend/patch/platform/patch_structured_output.py
@@ -4,15 +4,22 @@
 
 from __future__ import annotations
 
+import itertools
+from collections.abc import Iterable
 from inspect import Signature, signature
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from vllm.exceptions import VLLMValidationError
 from vllm.sampling_params import SamplingParams
 from vllm.v1.structured_output import StructuredOutputManager
+from vllm.v1.structured_output.backend_types import StructuredOutputGrammar
+
+from vllm_ascend.utils import vllm_version_is
 
 _BACKEND_ATTR = "_vllm_ascend_structured_output_backend"
+_ORIGINAL_GRAMMAR_BITMASK_ATTR = "_vllm_ascend_original_grammar_bitmask"
 _ORIGINAL_GRAMMAR_INIT_ATTR = "_vllm_ascend_original_grammar_init"
+_ORIGINAL_SHOULD_ADVANCE_ATTR = "_vllm_ascend_original_should_advance"
 _ORIGINAL_VALIDATE_ATTR = "_vllm_ascend_original_validate_structured_outputs"
 
 
@@ -105,8 +112,144 @@ def _patch_sampling_params_validation() -> None:
 
 
 def _patch_structured_output_manager() -> None:
+    install_reasoning_boundary_backports = vllm_version_is("0.26.0")
     original_grammar_init = StructuredOutputManager.grammar_init
     setattr(StructuredOutputManager, _ORIGINAL_GRAMMAR_INIT_ATTR, original_grammar_init)
+
+    def grammar_bitmask(
+        self: StructuredOutputManager,
+        requests: dict[str, Any],
+        structured_output_request_ids: list[str],
+        scheduled_spec_decode_tokens: dict[str, list[int]],
+    ) -> Any:
+        if not structured_output_request_ids:
+            return None
+
+        max_num_spec_tokens = self.vllm_config.num_speculative_tokens
+        if self._grammar_bitmask is None:
+            assert self.backend is not None
+            max_batch_size = self.vllm_config.scheduler_config.max_num_seqs
+            self._grammar_bitmask = self.backend.allocate_token_bitmask(max_batch_size * (1 + max_num_spec_tokens))
+
+        cumulative_index = 0
+        if len(structured_output_request_ids) > self.fill_bitmask_parallel_threshold and max_num_spec_tokens == 0:
+            promises = []
+            batch = []
+            for req_id in structured_output_request_ids:
+                request = requests[req_id]
+                structured_output_request = request.structured_output_request
+                if TYPE_CHECKING:
+                    assert structured_output_request is not None
+                grammar = structured_output_request.grammar
+                if TYPE_CHECKING:
+                    assert isinstance(grammar, StructuredOutputGrammar)
+
+                apply_bitmask = self.should_fill_bitmask(request)
+                batch.append((grammar, cumulative_index, apply_bitmask))
+                if len(batch) == self.fill_bitmask_parallel_batch_size:
+                    promises.append(self._async_submit_fill_bitmask(batch))
+                    batch = []
+                cumulative_index += 1
+            if batch:
+                promises.append(self._async_submit_fill_bitmask(batch))
+            for promise in promises:
+                promise.result()
+        else:
+            for req_id in structured_output_request_ids:
+                request = requests[req_id]
+                structured_output_request = request.structured_output_request
+                if TYPE_CHECKING:
+                    assert structured_output_request is not None
+                grammar = structured_output_request.grammar
+                if TYPE_CHECKING:
+                    assert isinstance(grammar, StructuredOutputGrammar)
+                apply_bitmask = self.should_fill_bitmask(request)
+
+                reasoner = self._get_reasoner(request)
+                detect_reasoning_end = not apply_bitmask and reasoner is not None and not self.enable_in_reasoning
+                simulated_buf: list[int] | None = None
+                history_len = 0
+                state_advancements = 0
+                post_reasoning_end_in_window = False
+                req_tokens = scheduled_spec_decode_tokens.get(req_id, ())
+                for i, token in enumerate(req_tokens):
+                    self._fill_bitmasks(((grammar, cumulative_index, apply_bitmask),))
+                    advance_grammar = apply_bitmask
+                    if token == -1:
+                        apply_bitmask = False
+                        advance_grammar = False
+                    elif detect_reasoning_end and reasoner is not None and not apply_bitmask:
+                        if simulated_buf is None:
+                            history = list(request.all_token_ids)
+                            history_len = len(history)
+                            simulated_buf = history + list(req_tokens)
+                        simulated = simulated_buf[: history_len + i + 1]
+                        if reasoner.is_reasoning_end_streaming(simulated, [token]):
+                            apply_bitmask = True
+                            advance_grammar = False
+                            post_reasoning_end_in_window = True
+                    if advance_grammar and not grammar.is_terminated():
+                        if post_reasoning_end_in_window:
+                            accepted = bool(grammar.validate_tokens([token]))
+                            if accepted:
+                                accepted = grammar.accept_tokens(req_id, [token])
+                        else:
+                            accepted = grammar.accept_tokens(req_id, [token])
+                        if accepted:
+                            state_advancements += 1
+                        elif not post_reasoning_end_in_window:
+                            raise AssertionError((token, req_id, scheduled_spec_decode_tokens))
+                    cumulative_index += 1
+
+                if not (self.vllm_config.model_config.is_diffusion and req_tokens):
+                    bonus_apply = self.should_fill_bitmask(request) or apply_bitmask
+                    self._fill_bitmasks(((grammar, cumulative_index, bonus_apply),))
+                    cumulative_index += 1
+                if state_advancements > 0:
+                    grammar.rollback(state_advancements)
+
+        bitmask_tensor = self._grammar_bitmask
+        if cumulative_index < bitmask_tensor.shape[0]:
+            bitmask_tensor = bitmask_tensor[:cumulative_index]
+        return bitmask_tensor.numpy()
+
+    def should_advance(
+        self: StructuredOutputManager,
+        request: Any,
+        new_token_ids: list[int] | None = None,
+    ) -> bool:
+        if not request.use_structured_output:
+            return False
+
+        if TYPE_CHECKING:
+            assert request.structured_output_request is not None
+            assert request.structured_output_request.grammar is not None
+
+        reasoner = self._get_reasoner(request)
+        if reasoner is None:
+            return True
+
+        if self.enable_in_reasoning:
+            return True
+
+        structured_req = request.structured_output_request
+        if structured_req.reasoning_ended:
+            return True
+
+        all_token_ids = request.all_token_ids
+        if new_token_ids:
+            start = len(all_token_ids) - len(new_token_ids)
+            delta_ids: Iterable[int] = new_token_ids
+        else:
+            delta_from = request.num_computed_tokens - request.num_output_placeholders
+            start = delta_from if delta_from >= 0 else max(len(all_token_ids) + delta_from, 0)
+            delta_ids = itertools.islice(all_token_ids, start, None)
+
+        if reasoner.is_reasoning_end_streaming(all_token_ids, delta_ids):
+            structured_req.reasoning_ended = True
+            structured_req.reasoning_end_token_index = self._find_reasoning_end_index(reasoner, all_token_ids, start)
+            return True
+        return False
 
     def grammar_init(self: StructuredOutputManager, request: Any) -> None:
         request_backend = _request_backend(request)
@@ -128,6 +271,19 @@ def _patch_structured_output_manager() -> None:
         return result
 
     StructuredOutputManager.grammar_init = grammar_init
+    if install_reasoning_boundary_backports:
+        setattr(
+            StructuredOutputManager,
+            _ORIGINAL_GRAMMAR_BITMASK_ATTR,
+            StructuredOutputManager.grammar_bitmask,
+        )
+        setattr(
+            StructuredOutputManager,
+            _ORIGINAL_SHOULD_ADVANCE_ATTR,
+            StructuredOutputManager.should_advance,
+        )
+        StructuredOutputManager.grammar_bitmask = grammar_bitmask
+        StructuredOutputManager.should_advance = should_advance
 
 
 _patch_sampling_params_validation()


### PR DESCRIPTION
### What this PR does / why we need it?
Backport the upstream reasoning-boundary and speculative grammar fixes while keeping the pinned vLLM source unchanged.

This PR ports the fixes from the following upstream vLLM PRs through the vLLM Ascend patch layer:

* vLLM #44993: advance the structured-output FSM using the exact accepted speculative token window and record the reasoning-end boundary.
* vLLM #53046: validate draft tokens before advancing the grammar when reasoning ends in the middle of a speculative window.
* vLLM #49626: preserve structured-output logger initialization required by the patched error path. The pinned vLLM v0.26.0 source already contains the logger initialization, so no additional source modification is needed.

### Does this PR introduce _any_ user-facing change?
N/A

### How was this patch tested?
by ci


- vLLM main: https://github.com/vllm-project/vllm/commit/d02df748bf9efd99022f1a062597dc3cb3808485
