### PR TITLE
[CI]Add filtering to remove invalid noise：Filter out def and import noise when generating test_case_map.json

### DIFF
--- a/.github/workflows/scripts/test_selector.py
+++ b/.github/workflows/scripts/test_selector.py
@@ -164,6 +164,7 @@ class CoverageSelector:
         self.coverage_data_dir = Path(coverage_data_dir) if coverage_data_dir else None
         self.source_dir = Path(source_dir) if source_dir else None
         self.test_case_map = {}  # test_case_name -> {files: {filepath: {lines}}}
+        self._noise_lines_cache = {}  # filepath -> set of noise lines (import + def)
 
     def scan_test_cases(self) -> list[str]:
         """Scan all test case directories"""
@@ -240,6 +241,68 @@ class CoverageSelector:
             print(f"  Warning: Error reading {cov_file}: {e}")
         return files
 
+    def _get_function_def_lines(self, filepath: str) -> set[int]:
+        """
+        Get function definition line numbers (def line only, not function body).
+
+        Args:
+            filepath: Source file path
+
+        Returns:
+            Set of line numbers where function definitions occur
+        """
+        def_lines = set()
+        try:
+            with open(filepath, encoding="utf-8") as f:
+                tree = ast.parse(f.read(), filename=filepath)
+            for node in ast.walk(tree):
+                if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                    def_lines.add(node.lineno)
+        except Exception:
+            pass
+        return def_lines
+
+    def _filter_noise_lines(self, filepath: str, lines: set[int]) -> set[int]:
+        """
+        Filter out invalid noise lines from coverage data:
+        1. import/from...import statement lines
+        2. Function definition lines (def line only)
+
+        Args:
+            filepath: Source file path
+            lines: Original set of covered line numbers
+
+        Returns:
+            Filtered set with noise lines removed
+        """
+        if not lines:
+            return lines
+
+        # Use cache to avoid re-parsing the same file multiple times
+        if filepath not in self._noise_lines_cache:
+            import_lines = FunctionParser._get_import_lines(filepath)
+            # Get function definition lines
+            def_lines = self._get_function_def_lines(filepath)
+            self._noise_lines_cache[filepath] = import_lines | def_lines
+
+        return lines - self._noise_lines_cache[filepath]
+
+    def _resolve_source_file(self, filename: str) -> Path | None:
+        """
+        Resolve source file path from relative filename.
+
+        Args:
+            filename: Relative file path (e.g., 'vllm_ascend/core/worker.py')
+
+        Returns:
+            Path object if found, None otherwise
+        """
+        if not self.source_dir:
+            return None
+
+        source_path = self.source_dir / REPO_NAME / filename
+        return source_path if source_path.exists() else None
+
     def build_test_case_map(self) -> dict:
         """Build test case -> covered files mapping (with line numbers)"""
         print("Scanning test cases...")
@@ -258,6 +321,11 @@ class CoverageSelector:
                 for filename in covered_files:
                     lines = self.get_covered_lines_from_file(str(cov_file), filename)
                     if lines:
+                        # Filter noise lines if source_dir is available
+                        if self.source_dir:
+                            source_file = self._resolve_source_file(filename)
+                            if source_file and source_file.exists():
+                                lines = self._filter_noise_lines(str(source_file), lines)
                         file_lines_map[filename].update(lines)
 
             normalized_name = self.normalize_test_name(test_case)


### PR DESCRIPTION
### What this PR does / why we need it?
Add filtering to remove invalid noise from recommendations

### Does this PR introduce _any_ user-facing change?
No. This PR does not introduce any user-facing changes.

### How was this patch tested?
This patch was tested through the following approaches:
Verify the difference between the data before and after noise filtering. The removed noise data should only consist of definitions (def) and import statements, while all other code elements should be preserved.


- vLLM main: https://github.com/vllm-project/vllm/commit/ba07e4a48fc951300d97eb506217dd530583dea3
