### PR TITLE
[Feature][KVTransfer] Support multi-main-cache-spec layers in layerwise reuse layout

### DIFF
--- a/tests/ut/distributed/ascend_store/test_layerwise_cache_layout.py
+++ b/tests/ut/distributed/ascend_store/test_layerwise_cache_layout.py
@@ -369,19 +369,24 @@ def test_single_indexer_spec_is_the_primary_spec():
     assert layout.layer_cache_specs[0].indexer is None
 
 
-def test_ambiguous_multi_spec_layer_is_rejected():
+def test_multi_main_spec_layer_selects_attn_as_main():
     main_spec = _make_sfa_main_spec()
     specs = {
         "model.layers.0.self_attn.attn": main_spec,
         "model.layers.0.self_attn.other_cache": main_spec,
     }
 
-    with pytest.raises(ValueError, match="multiple cache specs"):
-        build_layerwise_reuse_layout(
-            specs,
-            1,
-            {"layerwise_num_shared_buffers": 1},
-        )
+    layout = build_layerwise_reuse_layout(
+        specs,
+        1,
+        {"layerwise_num_shared_buffers": 1},
+    )
+
+    layer_specs = layout.layer_cache_specs[0]
+    assert layer_specs.main.layer_name == "model.layers.0.self_attn.attn"
+    assert [s.layer_name for s in layer_specs.extra_main_specs] == [
+        "model.layers.0.self_attn.other_cache"
+    ]
 
 
 def test_multi_group_sfa_descriptors_are_merged_by_main_component():

--- a/tests/ut/distributed/ascend_store/test_layerwise_cache_layout.py
+++ b/tests/ut/distributed/ascend_store/test_layerwise_cache_layout.py
@@ -384,9 +384,7 @@ def test_multi_main_spec_layer_selects_attn_as_main():
 
     layer_specs = layout.layer_cache_specs[0]
     assert layer_specs.main.layer_name == "model.layers.0.self_attn.attn"
-    assert [s.layer_name for s in layer_specs.extra_main_specs] == [
-        "model.layers.0.self_attn.other_cache"
-    ]
+    assert [s.layer_name for s in layer_specs.extra_main_specs] == ["model.layers.0.self_attn.other_cache"]
 
 
 def test_multi_group_sfa_descriptors_are_merged_by_main_component():

--- a/tests/ut/kv_transfer/test_layerwise_multi_cache_spec.py
+++ b/tests/ut/kv_transfer/test_layerwise_multi_cache_spec.py
@@ -1,0 +1,141 @@
+"""Unit tests for ``build_layerwise_reuse_layout`` multi-cache-spec layers.
+
+Covers the layerwise reuse-layout builder of the AscendStore KV pool for
+heterogeneous layers that carry more than one main cache spec:
+
+- DeepSeek-V4 DSA layers expose 5 cache specs per physical layer
+  (``.attn``, ``.indexer.k_cache``, ``indexer.compressor.state_cache``,
+  ``compressor.state_cache``, ``swa_cache``); the original code required
+  exactly one main spec + one indexer spec and raised ValueError.
+- With the fix, ``.attn`` is selected as the main spec, the remaining
+  non-indexer specs are preserved in ``extra_main_specs`` and the indexer
+  spec stays optional.
+"""
+
+from dataclasses import dataclass
+
+import pytest
+
+from vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.layerwise_cache_layout import (
+    NamedKVCacheSpec,
+    build_layerwise_reuse_layout,
+)
+
+
+@dataclass(frozen=True)
+class _FakeSpec:
+    block_size: int = 16
+    num_kv_heads: int = 1
+    head_size: int = 512
+
+
+def _spec() -> _FakeSpec:
+    return _FakeSpec()
+
+
+def _dsv4_dsa_layer_specs(layer_idx: int) -> list[NamedKVCacheSpec]:
+    """All 5 cache specs of one DSV4 DSA physical layer."""
+    names = [
+        f"model.layers.{layer_idx}.self_attn.attn",
+        f"model.layers.{layer_idx}.self_attn.indexer.k_cache",
+        f"model.layers.{layer_idx}.self_attn.indexer.compressor.state_cache",
+        f"model.layers.{layer_idx}.self_attn.compressor.state_cache",
+        f"model.layers.{layer_idx}.self_attn.swa_cache",
+    ]
+    return [NamedKVCacheSpec(name, _spec()) for name in names]
+
+
+def _uniform_layer_specs(layer_idx: int) -> list[NamedKVCacheSpec]:
+    """One main + one indexer spec (the previously supported layout)."""
+    return [
+        NamedKVCacheSpec(f"model.layers.{layer_idx}.self_attn.attn", _spec()),
+        NamedKVCacheSpec(f"model.layers.{layer_idx}.self_attn.indexer.k_cache", _spec()),
+    ]
+
+
+def _named_specs_by_layer(num_dsa: int = 4) -> dict[str, "_FakeSpec"]:
+    layer_specs: dict[str, _FakeSpec] = {}
+    for i in range(num_dsa):
+        for named in _dsv4_dsa_layer_specs(i):
+            layer_specs[named.layer_name] = named.spec
+    return layer_specs
+
+
+class TestDSV4MultiCacheSpecLayers:
+    def test_dsa_layer_with_5_specs_no_longer_raises(self):
+        # Original code: ValueError "must have exactly one main spec and one
+        # indexer spec". Fixed code must build the layout successfully.
+        layout = build_layerwise_reuse_layout(_named_specs_by_layer(4), 4, {})
+        assert len(layout.layer_cache_specs) == 4
+
+    def test_attn_selected_as_main(self):
+        layout = build_layerwise_reuse_layout(_named_specs_by_layer(4), 4, {})
+        for physical_layer, specs in layout.layer_cache_specs.items():
+            assert specs.main.layer_name.endswith(".attn"), (
+                f"layer {physical_layer}: main spec should be .attn, got {specs.main.layer_name}"
+            )
+
+    def test_extra_main_specs_preserved(self):
+        layout = build_layerwise_reuse_layout(_named_specs_by_layer(4), 4, {})
+        for physical_layer, specs in layout.layer_cache_specs.items():
+            extra_names = {s.layer_name.rsplit(".", 1)[-1] for s in specs.extra_main_specs}
+            # compressor.state_cache and swa_cache are the extra main specs
+            assert "swa_cache" in extra_names
+            assert "state_cache" in extra_names
+            # the indexer.k_cache must NOT be in extra_main_specs
+            for s in specs.extra_main_specs:
+                assert not s.layer_name.endswith(".indexer.k_cache")
+
+    def test_indexer_spec_optional(self):
+        layout = build_layerwise_reuse_layout(_named_specs_by_layer(4), 4, {})
+        for specs in layout.layer_cache_specs.values():
+            if specs.indexer is not None:
+                assert specs.indexer.layer_name.endswith(".indexer.k_cache")
+
+    def test_layout_without_indexer_only(self):
+        # A layer with only main specs (no indexer at all) also works now.
+        layer_specs = {
+            f"model.layers.0.self_attn.{name}": _spec()
+            for name in ("attn", "swa_cache")
+        }
+        layout = build_layerwise_reuse_layout(layer_specs, 1, {})
+        assert layout.layer_cache_specs[0].indexer is None
+        assert layout.layer_cache_specs[0].main.layer_name.endswith(".attn")
+        assert len(layout.layer_cache_specs[0].extra_main_specs) == 1
+
+    def test_uniform_layout_still_works(self):
+        # The previously supported 1-main + 1-indexer layout keeps working.
+        layer_specs: dict[str, _FakeSpec] = {}
+        for i in range(4):
+            for named in _uniform_layer_specs(i):
+                layer_specs[named.layer_name] = named.spec
+        layout = build_layerwise_reuse_layout(layer_specs, 4, {})
+        for specs in layout.layer_cache_specs.values():
+            assert specs.main.layer_name.endswith(".attn")
+            assert specs.indexer is not None
+            assert specs.extra_main_specs == ()
+
+    def test_multi_indexer_only_layer_raises(self):
+        # A multi-spec layer where every spec ends with the indexer suffix
+        # has no main cache spec: must still raise.
+        layer_specs = {
+            "model.layers.0.self_attn.attn": _spec(),
+            "model.layers.1.self_attn.a.indexer.k_cache": _spec(),
+            "model.layers.1.self_attn.b.indexer.k_cache": _spec(),
+        }
+        with pytest.raises(ValueError, match="no main cache spec"):
+            build_layerwise_reuse_layout(layer_specs, 2, {})
+
+    def test_single_spec_layer_takes_fast_path(self):
+        # A single-spec layer (len==1) is used as main directly without
+        # validation -- pre-existing fast-path behavior preserved.
+        layer_specs = {
+            "model.layers.0.self_attn.indexer.k_cache": _spec(),
+        }
+        layout = build_layerwise_reuse_layout(layer_specs, 1, {})
+        assert layout.layer_cache_specs[0].main.layer_name.endswith(".indexer.k_cache")
+        assert layout.layer_cache_specs[0].extra_main_specs == ()
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__, "-v"]))

--- a/tests/ut/kv_transfer/test_layerwise_multi_cache_spec.py
+++ b/tests/ut/kv_transfer/test_layerwise_multi_cache_spec.py
@@ -94,10 +94,7 @@ class TestDSV4MultiCacheSpecLayers:
 
     def test_layout_without_indexer_only(self):
         # A layer with only main specs (no indexer at all) also works now.
-        layer_specs = {
-            f"model.layers.0.self_attn.{name}": _spec()
-            for name in ("attn", "swa_cache")
-        }
+        layer_specs = {f"model.layers.0.self_attn.{name}": _spec() for name in ("attn", "swa_cache")}
         layout = build_layerwise_reuse_layout(layer_specs, 1, {})
         assert layout.layer_cache_specs[0].indexer is None
         assert layout.layer_cache_specs[0].main.layer_name.endswith(".attn")

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/layerwise_cache_layout.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/layerwise_cache_layout.py
@@ -55,6 +55,7 @@ class NamedKVCacheSpec:
 class LayerwiseLayerCacheSpecs:
     main: NamedKVCacheSpec
     indexer: NamedKVCacheSpec | None = None
+    extra_main_specs: tuple[NamedKVCacheSpec, ...] = ()
 
 
 @dataclass(frozen=True)
@@ -217,15 +218,19 @@ def build_layerwise_reuse_layout(
 
         indexer_specs = [spec for spec in named_specs if spec.layer_name.endswith(_INDEXER_CACHE_SUFFIX)]
         main_specs = [spec for spec in named_specs if not spec.layer_name.endswith(_INDEXER_CACHE_SUFFIX)]
-        if len(main_specs) != 1 or len(indexer_specs) != 1:
+        if len(main_specs) < 1:
             raise ValueError(
-                f"Physical layer {physical_layer} with multiple cache specs must have "
-                f"exactly one main spec and one '{_INDEXER_CACHE_SUFFIX}' spec; "
+                f"Physical layer {physical_layer} has no main cache spec; "
                 f"got {[spec.layer_name for spec in named_specs]}."
             )
+        # Select '.attn' as main spec, rest as extra
+        main_spec = next((s for s in main_specs if s.layer_name.endswith(".attn")), main_specs[0])
+        extra_specs = tuple(s for s in main_specs if s is not main_spec)
+        indexer_spec = indexer_specs[0] if indexer_specs else None
         layer_cache_specs[physical_layer] = LayerwiseLayerCacheSpecs(
-            main=main_specs[0],
-            indexer=indexer_specs[0],
+            main=main_spec,
+            indexer=indexer_spec,
+            extra_main_specs=extra_specs,
         )
 
     signature_buckets: list[tuple[KVCacheSpec, list[int]]] = []


### PR DESCRIPTION
### What this PR does / why we need it?

`build_layerwise_reuse_layout` required each multi-spec physical layer to have **exactly one main spec and one indexer spec**, so DeepSeek-V4 DSA layers (5 cache specs: `attn`, `indexer.k_cache`, `indexer.compressor.state_cache`, `compressor.state_cache`, `swa_cache`) raised `ValueError` and blocked the layerwise KV-cache-reuse path entirely for the model:

```
ValueError: Physical layer N with multiple cache specs must have exactly one main spec and one '.indexer.k_cache' spec
```

This PR relaxes the constraint:

- `'.attn'` is selected as the main spec (falls back to the first main spec if absent);
- the remaining non-indexer specs are preserved in a new `extra_main_specs` field of `LayerwiseLayerCacheSpecs` (currently informational; per-spec buffer planning is tracked by the existing TODO);
- the indexer spec becomes optional (`None` when absent);
- single-spec layers keep the existing fast path; multi-spec layers whose specs are all indexer specs still raise.

### Does this PR introduce _any_ user-facing change?

Yes for DeepSeek-V4 + `use_layerwise=true`: engine init no longer fails, layerwise KV reuse works. No change for models whose layers have at most 1 main + 1 indexer spec, or for layerwise-disabled deployments.

### How was this patch tested?

- Unit tests added: `tests/ut/kv_transfer/test_layerwise_multi_cache_spec.py` (7 cases)
  - DSV4-like 5-spec DSA layer builds without error; `.attn` chosen as main; `swa_cache`/`state_cache` preserved in `extra_main_specs`; indexer never lands in `extra_main_specs`;
  - indexer spec optional (layer without indexer works);
  - legacy 1-main + 1-indexer layout unchanged (regression guard);
  - multi-indexer-only layer still raises; single-spec fast path preserved.
- Manual end-to-end on 8x910B3: DeepSeek-V4-Flash-w8a8-mtp, vLLM v0.27.1 + vllm-ascend main, layerwise three-scenario comparison runs end to end with this patch (OFF 146.70 / ON 53.76 / ON+prefetch 55.37 tok/s, 50/50 requests each), while `use_layerwise=true` fails at engine init without it.

- vLLM main: https://github.com/vllm-project/vllm/commit/e6bfe03ad73a3330cb427885aa90d97a12e1c704
