### PR TITLE
[Perf] Revert ND PA KV cache write to _npu_reshape_and_cache for A3/A2

### DIFF
--- a/vllm_ascend/device/device_op.py
+++ b/vllm_ascend/device/device_op.py
@@ -40,13 +40,14 @@ else:
 class BaseDeviceAdaptor:
     @classmethod
     def reshape_and_cache(cls, key, value, key_cache, value_cache, slot_mapping):
-        torch_npu.npu_scatter_pa_kv_cache(
-            key=key.contiguous(),
-            value=value.contiguous(),
+        # npu_scatter_pa_kv_cache (#11713) adds host-side overhead that costs
+        # ~9% end-to-end throughput on Atlas A3; see commit message for data.
+        torch_npu._npu_reshape_and_cache(
+            key=key,
+            value=value,
             key_cache=key_cache,
             value_cache=value_cache,
-            slot_mapping=slot_mapping.contiguous(),
-            cache_mode="Norm",
+            slot_indices=slot_mapping,
         )
 
     @classmethod


### PR DESCRIPTION
PR #11713 (af672dd6e) replaced the ND page-attention KV cache write in BaseDeviceAdaptor.reshape_and_cache with
torch_npu.npu_scatter_pa_kv_cache(cache_mode='Norm'). On Atlas A3 this new op adds significant host-side overhead: profiling Qwen3-32B-W8A8- QuaRot + EAGLE3 (TP2, gsm8k, 80 prompts / concurrency 20) shows the ScatterPaKvCache host API alone consuming ~139 ms per 3.3 s window, EVENT_WAIT growing ~6x, aclrtSynchronizeEvent latency rising from 134 us to 3.6 ms per call, and per-step engine wall time going from 167 ms to 187 ms, while NPU kernel composition and per-kernel cost are unchanged - a pure host-bound regression.

Reverting this single function to _npu_reshape_and_cache (still used by the Ascend310P adaptor) recovers the v0.23.0 baseline on the same machine and chips:

  v0.23.0 (old op)                418.02 tok/s
  v0.26 (scatter op, #11713)      382.03 tok/s   (-8.6%)
  v0.26 + this revert (run 1)     404.62 tok/s
  v0.26 + this revert (run 2)     428.88 tok/s

All runs 80/80 requests succeeded.

### What this PR does / why we need it?

### Does this PR introduce _any_ user-facing change?

### How was this patch tested?

- vLLM main: https://github.com/vllm-project/vllm/commit/ba07e4a48fc951300d97eb506217dd530583dea3
