### PR TITLE
[BugFix] Fix DSV3.1 nightly weight load error

### DIFF
--- a/vllm_ascend/models/__init__.py
+++ b/vllm_ascend/models/__init__.py
@@ -48,6 +48,7 @@ def register_model():
         "DFlash2DraftModel",
         "vllm_ascend.models.qwen3_dflash2:DFlash2Qwen3ForCausalLM",
     )
+    ModelRegistry.register_model("DeepSeekMTPModel", "vllm_ascend.models.deepseek_mtp:AscendDeepSeekMTP")
     ModelRegistry.register_model("DeepseekV32MTPModel", "vllm_ascend.models.deepseek_mtp:AscendDeepSeekMTP")
     ModelRegistry.register_model("GlmMoeDsaForCausalLM", "vllm_ascend.models.deepseek_mtp:AscendGlmMoeDsaForCausalLM")
     ModelRegistry.register_model(


### PR DESCRIPTION
### What this PR does / why we need it?
vLLM moved DeepSeek-V3.2 codes to `vllm/models`, and changed the class name of MTP from `DeepSeekMTPModel` to `DeepseekV32MTPModel`, but DeepSeek-V3.1 MTP still uses `DeepSeekMTPModel` class, so it should not be deleted.

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?

- vLLM main: https://github.com/vllm-project/vllm/commit/ba07e4a48fc951300d97eb506217dd530583dea3
