### PR TITLE
[Doc][v0.23.0] Fix pip and uv-wheelnext indexes for installation

### DIFF
--- a/docs/source/installation.md
+++ b/docs/source/installation.md
@@ -168,6 +168,8 @@ Then you can install `vllm` and `vllm-ascend` from a **pre-built wheel** using o
 ::::{tab-item} Original installation
 :sync: original
 
+Currently, this installation method supports only A2. For A3, Atlas 300I DUO, Atlas 200I Pro, or 950DT, use a pre-built image, uv-wheelnext, or source installation.
+
 ```{code-block} bash
    :substitutions:
 
@@ -176,7 +178,6 @@ pip install vllm==|pip_vllm_version|
 
 # Install vllm-project/vllm-ascend.
 pip install \
---extra-index-url https://mirrors.huaweicloud.com/ascend/repos/pypi/variant \
 --extra-index-url https://mirrors.huaweicloud.com/ascend/repos/pypi \
 vllm-ascend==|pip_vllm_ascend_version|
 
@@ -204,7 +205,7 @@ pip install vllm==|pip_vllm_version|
 # Install vllm-project/vllm-ascend from wheelnext index.
 uv pip install --system \
 --extra-index-url https://mirrors.huaweicloud.com/ascend/repos/pypi/variant \
---extra-index-url https://mirrors.huaweicloud.com/ascend/repos/pypi \
+--find-links https://mirrors.huaweicloud.com/ascend/repos/pypi/triton-ascend/ \
 --index-url https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple \
 vllm-ascend==|pip_vllm_ascend_version|
 


### PR DESCRIPTION
### What this PR does / why we need it?

This PR updates the pip and uv-wheelnext installation commands for vLLM Ascend.

- Use the standard Ascend package index for pip installation.
- Clarify that the standard pip wheel currently supports only A2.
- Keep the WheelNext variant index for uv-wheelnext installation.
- Remove the general Ascend package index from the uv-wheelnext command.
- Add the Triton Ascend wheel directory through `--find-links`.

uv uses the [`first-index` strategy](https://docs.astral.sh/uv/concepts/indexes/#searching-across-multiple-indexes) by default. The general Ascend package index can expose the `torch-npu` package without containing the exact version required by the selected WheelNext build. Once uv finds the package name on that index, it limits candidate versions to that index and fails dependency resolution instead of continuing to a lower-priority index.

The general Ascend package index is therefore removed from the uv-wheelnext command. The following option provides the required Triton Ascend wheels directly without reintroducing the incomplete `torch-npu` candidates from the broader index:

```bash
--find-links https://mirrors.huaweicloud.com/ascend/repos/pypi/triton-ascend/
```

No other installation instructions are changed.

### Does this PR introduce _any_ user-facing change?

### How was this patch tested?

- vLLM main: https://github.com/vllm-project/vllm/commit/ee0da84ab9e04ac7610e28580af62c365e898389
