### PR TITLE
[BugFix][Model] Reuse DeepSeek-V4 compressor tail workspace

### DIFF
--- a/csrc/attention/compressor/README.md
+++ b/csrc/attention/compressor/README.md
@@ -70,6 +70,7 @@
 | coff | 可选属性 | 默认值1，支持1/2。当coff=1时，无需进行overlap数据重排。当coff=2时，需要进行overlap数据重排。  | INT32          | -         |
 | norm\_eps | 可选属性 | 表示RmsNorm计算的权重系数。默认值1e-6。 | FLOAT32          | -         |
 | rotary\_mode | 可选属性 | 表示Rop计算的模式。默认值1，支持1/2。rotary\_mode为1时，代表half模式。rotary\_mode为2时，代表interleave模式。 | INT32          | -         |
+| cache\_mode | 可选属性 | 状态缓存模式。1为按绝对token连续分页；2为persistent tail循环分页，当前chunk中间结果使用算子workspace。默认值1。 | INT32          | -         |
 | enabled\_grad | 可选属性 | 训练场景使用，表示是否参与反向更新。默认值false，支持false/true。**目前暂不支持输入true**。 | BOOL          | -         |
 | cmp\_kv | 输出 | 表示压缩后的数据。 | FLOAT16、BFLOAT16         | ND          |
 | wkv\_proj | 可选输出 | 训练反向使用，表示wkv权重Matmul的计算结果，**目前暂不支持返回wkv\_proj**。 | FLOAT16、BFLOAT16         | ND          |
@@ -151,6 +152,12 @@
         - C4Li: D=128, coff=2, cmp_ratio=4；
         - C128A: D=512, coff=1, cmp_ratio=128。
     - 支持rotary_mode为2，Rope计算模式为interleave。
+    - `cache_mode=2`时，每个batch的block table行前
+      `ceil(coff * cmp_ratio / block_size)`项组成tail ring。绝对token位置先对
+      `coff * cmp_ratio`取模，再映射到ring block和block内offset。C4A/C4Li在
+      `block_size=8`时使用1个block，C128A在`block_size=32`时使用4个block。
+      该模式只保存跨chunk所需tail，当前chunk的FP32 partial states保存在算子
+      workspace中。
 
 ## Atlas A3 推理系列产品 调用说明
 

--- a/csrc/attention/compressor/op_host/arch32/compressor_tiling.cpp
+++ b/csrc/attention/compressor/op_host/arch32/compressor_tiling.cpp
@@ -165,10 +165,13 @@ ge::graphStatus CompressorTiling::SetPageAttentionInfo()
 {
     pageAttentionParams_->blockNum = context_->stateCache.shape->GetStorageShape().GetDim(COMPRESSOR_DIM_INDEX_0);
     pageAttentionParams_->blockSize = context_->stateCache.shape->GetStorageShape().GetDim(COMPRESSOR_DIM_INDEX_1);
-    if (static_cast<uint8_t>(*context_->cacheMode) == static_cast<uint8_t>(CACHE_MODE::CONTINUOUS)) {
-        pageAttentionParams_->maxBlockNumPerBatch =
-            context_->stateBlockTable.shape->GetStorageShape().GetDim(COMPRESSOR_DIM_INDEX_1);
-    }
+    // Both CONTINUOUS and CYCLE use a 2-D block table. In CYCLE mode this is
+    // the row stride; only the first ceil(coff * ratio / blockSize) entries
+    // contain the persistent tail ring.
+    const auto &blockTableShape = context_->stateBlockTable.shape->GetStorageShape();
+    pageAttentionParams_->maxBlockNumPerBatch = blockTableShape.GetDimNum() == 1 ?
+                                                    1 :
+                                                    blockTableShape.GetDim(COMPRESSOR_DIM_INDEX_1);
 
     return ge::GRAPH_SUCCESS;
 }
@@ -801,6 +804,25 @@ ge::graphStatus CompressorTiling::CheckFeature() const
                 OP_LOGE(context_->opName, "blockSize should not be less than 1, but got %u",
                         pageAttentionParams_->blockSize),
                 return ge::GRAPH_FAILED);
+    if (static_cast<uint8_t>(*context_->cacheMode) == static_cast<uint8_t>(CACHE_MODE::CYCLE)) {
+        const uint32_t tailTokens = coff * baseParams_->cmpRatio;
+        const uint32_t ringBlocks =
+            (tailTokens + pageAttentionParams_->blockSize - 1) / pageAttentionParams_->blockSize;
+        OP_CHECK_IF(pageAttentionParams_->maxBlockNumPerBatch < ringBlocks,
+                    OP_LOGE(context_->opName,
+                            "when cacheMode is %u, block-table row width should not be less than ringBlocks(%u), "
+                            "but got %u",
+                            static_cast<uint8_t>(CACHE_MODE::CYCLE), ringBlocks,
+                            pageAttentionParams_->maxBlockNumPerBatch),
+                    return ge::GRAPH_FAILED);
+        OP_CHECK_IF(pageAttentionParams_->blockNum < baseParams_->batchSize * ringBlocks,
+                    OP_LOGE(context_->opName,
+                            "when cacheMode is %u, blockNum should not be less than batchSize(%u) * "
+                            "ringBlocks(%u), but got %u",
+                            static_cast<uint8_t>(CACHE_MODE::CYCLE), baseParams_->batchSize, ringBlocks,
+                            pageAttentionParams_->blockNum),
+                    return ge::GRAPH_FAILED);
+    }
     return ge::GRAPH_SUCCESS;
 }
 

--- a/csrc/attention/compressor/op_host/arch32/compressor_tiling.h
+++ b/csrc/attention/compressor/op_host/arch32/compressor_tiling.h
@@ -231,7 +231,7 @@ const std::vector<int> CMP_RATIO {2, 4, 8, 16, 32, 64, 128};
 const std::vector<int> ROTARY_MODE {1, 2};
 #endif
 const std::vector<uint32_t> HEAD_DIM {128, 512};
-const std::vector<int> CACHE_MODE {1};
+const std::vector<int> CACHE_MODE {1, 2};
 
 enum class ROTARY_MODE:uint8_t {
     HALF = 1,

--- a/csrc/attention/compressor/op_host/arch35/compressor_tiling.cpp
+++ b/csrc/attention/compressor/op_host/arch35/compressor_tiling.cpp
@@ -165,10 +165,13 @@ ge::graphStatus CompressorTiling::SetPageAttentionInfo()
 {
     pageAttentionParams_->blockNum = context_->stateCache.shape->GetStorageShape().GetDim(COMPRESSOR_DIM_INDEX_0);
     pageAttentionParams_->blockSize = context_->stateCache.shape->GetStorageShape().GetDim(COMPRESSOR_DIM_INDEX_1);
-    if (static_cast<uint8_t>(*context_->cacheMode) == static_cast<uint8_t>(CACHE_MODE::CONTINUOUS)) {
-        pageAttentionParams_->maxBlockNumPerBatch =
-            context_->stateBlockTable.shape->GetStorageShape().GetDim(COMPRESSOR_DIM_INDEX_1);
-    }
+    // Both CONTINUOUS and CYCLE use a 2-D block table. In CYCLE mode this is
+    // the row stride; only the first ceil(coff * ratio / blockSize) entries
+    // contain the persistent tail ring.
+    const auto &blockTableShape = context_->stateBlockTable.shape->GetStorageShape();
+    pageAttentionParams_->maxBlockNumPerBatch = blockTableShape.GetDimNum() == 1 ?
+                                                    1 :
+                                                    blockTableShape.GetDim(COMPRESSOR_DIM_INDEX_1);
 
     return ge::GRAPH_SUCCESS;
 }
@@ -836,11 +839,22 @@ ge::graphStatus CompressorTiling::CheckFeature() const
         OP_LOGE(context_->opName, "blockSize should not be less than 1, but got %u", pageAttentionParams_->blockSize),
         return ge::GRAPH_FAILED);
     if (static_cast<uint8_t>(*context_->cacheMode) == static_cast<uint8_t>(CACHE_MODE::CYCLE)) {
-        OP_CHECK_IF(pageAttentionParams_->blockNum < baseParams_->batchSize,
+        const uint32_t tailTokens = coff * baseParams_->cmpRatio;
+        const uint32_t ringBlocks =
+            (tailTokens + pageAttentionParams_->blockSize - 1) / pageAttentionParams_->blockSize;
+        OP_CHECK_IF(pageAttentionParams_->maxBlockNumPerBatch < ringBlocks,
                     OP_LOGE(context_->opName,
-                            "when cacheMode is %u, blockNum should not be less than batchSize(%u), but got %u",
-                            static_cast<uint8_t>(CACHE_MODE::CYCLE), baseParams_->batchSize,
-                            pageAttentionParams_->blockSize),
+                            "when cacheMode is %u, block-table row width should not be less than ringBlocks(%u), "
+                            "but got %u",
+                            static_cast<uint8_t>(CACHE_MODE::CYCLE), ringBlocks,
+                            pageAttentionParams_->maxBlockNumPerBatch),
+                    return ge::GRAPH_FAILED);
+        OP_CHECK_IF(pageAttentionParams_->blockNum < baseParams_->batchSize * ringBlocks,
+                    OP_LOGE(context_->opName,
+                            "when cacheMode is %u, blockNum should not be less than batchSize(%u) * "
+                            "ringBlocks(%u), but got %u",
+                            static_cast<uint8_t>(CACHE_MODE::CYCLE), baseParams_->batchSize, ringBlocks,
+                            pageAttentionParams_->blockNum),
                     return ge::GRAPH_FAILED);
     }
     return ge::GRAPH_SUCCESS;

--- a/csrc/attention/compressor/op_kernel/arch32/compressor_block_vec_perf.h
+++ b/csrc/attention/compressor/op_kernel/arch32/compressor_block_vec_perf.h
@@ -809,10 +809,18 @@ __aicore__ inline void CompressorBlockVectorPerf<COMP>::ReadFromCacheState(
     uint32_t copyFinishRowCnt = 0;
     uint32_t seqCnt = endSeqIdx - startSeqIdx;
     while (copyFinishRowCnt < seqCnt) {
-        uint64_t blockIdOffset = curSeqIdx / constInfo_.blockSize;
-        uint64_t remainRowCnt = curSeqIdx % constInfo_.blockSize;
+        uint32_t cacheSeqIdx = curSeqIdx;
+        uint32_t ringTokenCount = coff_ * constInfo_.cmpRatio;
+        if constexpr (COMP::cacheMode == CACHE_MODE::CYCLE) {
+            cacheSeqIdx %= ringTokenCount;
+        }
+        uint32_t blockIdOffset = cacheSeqIdx / constInfo_.blockSize;
+        uint32_t remainRowCnt = cacheSeqIdx % constInfo_.blockSize;
         uint64_t idInBlockTable = blockTableGm.GetValue(blockTablebaseOffset + blockIdOffset);
         uint32_t copyRowCount = constInfo_.blockSize - remainRowCnt;
+        if constexpr (COMP::cacheMode == CACHE_MODE::CYCLE) {
+            copyRowCount = min(copyRowCount, ringTokenCount - cacheSeqIdx);
+        }
         if (copyFinishRowCnt + copyRowCount > seqCnt) {
             copyRowCount = seqCnt - copyFinishRowCnt;
         }
@@ -837,10 +845,18 @@ __aicore__ inline void CompressorBlockVectorPerf<COMP>::WriteToCacheState(
     uint32_t copyFinishRowCnt = 0;
     uint32_t seqCnt = endSeqIdx - startSeqIdx;
     while (copyFinishRowCnt < seqCnt) {
-        uint64_t blockIdOffset = curSeqIdx / constInfo_.blockSize;
-        uint64_t remainRowCnt = curSeqIdx % constInfo_.blockSize;
+        uint32_t cacheSeqIdx = curSeqIdx;
+        uint32_t ringTokenCount = coff_ * constInfo_.cmpRatio;
+        if constexpr (COMP::cacheMode == CACHE_MODE::CYCLE) {
+            cacheSeqIdx %= ringTokenCount;
+        }
+        uint32_t blockIdOffset = cacheSeqIdx / constInfo_.blockSize;
+        uint32_t remainRowCnt = cacheSeqIdx % constInfo_.blockSize;
         uint64_t idInBlockTable = blockTableGm.GetValue(blockTablebaseOffset + blockIdOffset);
         uint32_t copyRowCount = constInfo_.blockSize - remainRowCnt;
+        if constexpr (COMP::cacheMode == CACHE_MODE::CYCLE) {
+            copyRowCount = min(copyRowCount, ringTokenCount - cacheSeqIdx);
+        }
         if (copyFinishRowCnt + copyRowCount > seqCnt) {
             copyRowCount = seqCnt - copyFinishRowCnt;
         }
@@ -866,6 +882,17 @@ CompressorBlockVectorPerf<COMP>::SaveState(const LocalTensor<T> &srcLocal, const
     uint32_t startSeqIdx = sliceInfo.bStartPos + sliceInfo.sIdx;
     uint32_t endSeqIdx = startSeqIdx + sliceInfo.validSeqCnt;
     uint64_t srcBaseOffset = sliceInfo.dealedSeqCnt * coff_ * dDealSize;
+
+    if constexpr (COMP::cacheMode == CACHE_MODE::CYCLE) {
+        uint32_t compressSeqIdx = Trunc(sliceInfo.bStartPos + sliceInfo.bSeqUsed, constInfo_.cmpRatio);
+        uint32_t writeSeqStartIdx = compressSeqIdx > (coff_ - 1) * constInfo_.cmpRatio ?
+                                    compressSeqIdx - (coff_ - 1) * constInfo_.cmpRatio : 0;
+        if (endSeqIdx <= writeSeqStartIdx) {
+            return;
+        }
+        srcBaseOffset += (max(startSeqIdx, writeSeqStartIdx) - startSeqIdx) * coff_ * dDealSize;
+        startSeqIdx = max(startSeqIdx, writeSeqStartIdx);
+    }
 
     if constexpr (COMP::coff == COFF::OVERLAP) {
         WriteToCacheState(stateGm, blockTableGm, srcLocal[srcBaseOffset], sliceInfo.bIdx, startSeqIdx, endSeqIdx,

--- a/csrc/attention/compressor/op_kernel/arch32/compressor_comm.h
+++ b/csrc/attention/compressor/op_kernel/arch32/compressor_comm.h
@@ -104,13 +104,15 @@ enum class TEMPLATE_ID : uint8_t {
     PERF = 2
 };
 
-template <X_LAYOUT X_L, X_DTYPE X_T, ROPE_DTYPE R_T, COFF C, ROTARY_MODE Rotary_Mode, typename... Args>
+template <X_LAYOUT X_L, X_DTYPE X_T, ROPE_DTYPE R_T, COFF C, ROTARY_MODE Rotary_Mode, CACHE_MODE Cache_Mode,
+          typename... Args>
 struct COMPType {
     static constexpr X_LAYOUT xLayout = X_L;
     static constexpr X_DTYPE xDtype = X_T;
     static constexpr ROPE_DTYPE ropeDtype = R_T;
     static constexpr COFF coff = C;
     static constexpr ROTARY_MODE rotaryMode = Rotary_Mode;
+    static constexpr CACHE_MODE cacheMode = Cache_Mode;
 };
 
 struct ConstInfo {

--- a/csrc/attention/compressor/op_kernel/arch35/compressor_block_vec.h
+++ b/csrc/attention/compressor/op_kernel/arch35/compressor_block_vec.h
@@ -755,10 +755,15 @@ CompressorBlockVector<COMP>::ReadFromCacheState(const LocalTensor<T> &output, co
         uint32_t curSeqIdx = startSeqIdx;
         uint32_t copyFinishRowCnt = 0;
         uint32_t seqCnt = endSeqIdx - startSeqIdx;
-        uint64_t idInBlockTable = blockTableGm.GetValue(batchIdx);
+        uint64_t blockTablebaseOffset = batchIdx * constInfo_.maxBlockNumPerBatch;
+        uint32_t ringTokenCount = coff_ * cmpRatio_;
         while (copyFinishRowCnt < seqCnt) {
-            uint64_t remainRowCnt = curSeqIdx % constInfo_.blockSize;
-            uint32_t copyRowCount = constInfo_.blockSize - remainRowCnt;
+            uint32_t ringTokenIdx = curSeqIdx % ringTokenCount;
+            uint32_t blockIdOffset = ringTokenIdx / constInfo_.blockSize;
+            uint32_t remainRowCnt = ringTokenIdx % constInfo_.blockSize;
+            uint64_t idInBlockTable = blockTableGm.GetValue(blockTablebaseOffset + blockIdOffset);
+            uint32_t copyRowCount = min(constInfo_.blockSize - remainRowCnt,
+                                        ringTokenCount - ringTokenIdx);
             if (copyFinishRowCnt + copyRowCount > seqCnt) {
                 copyRowCount = seqCnt - copyFinishRowCnt;
             }
@@ -809,10 +814,15 @@ CompressorBlockVector<COMP>::WriteToCacheState(const GlobalTensor<T> &state, con
         uint32_t curSeqIdx = startSeqIdx;
         uint32_t copyFinishRowCnt = 0;
         uint32_t seqCnt = endSeqIdx - startSeqIdx;
-        uint64_t idInBlockTable = blockTableGm.GetValue(batchIdx);
+        uint64_t blockTablebaseOffset = batchIdx * constInfo_.maxBlockNumPerBatch;
+        uint32_t ringTokenCount = coff_ * cmpRatio_;
         while (copyFinishRowCnt < seqCnt) {
-            uint64_t remainRowCnt = curSeqIdx % constInfo_.blockSize;
-            uint32_t copyRowCount = constInfo_.blockSize - remainRowCnt;
+            uint32_t ringTokenIdx = curSeqIdx % ringTokenCount;
+            uint32_t blockIdOffset = ringTokenIdx / constInfo_.blockSize;
+            uint32_t remainRowCnt = ringTokenIdx % constInfo_.blockSize;
+            uint64_t idInBlockTable = blockTableGm.GetValue(blockTablebaseOffset + blockIdOffset);
+            uint32_t copyRowCount = min(constInfo_.blockSize - remainRowCnt,
+                                        ringTokenCount - ringTokenIdx);
             if (copyFinishRowCnt + copyRowCount > seqCnt) {
                 copyRowCount = seqCnt - copyFinishRowCnt;
             }

--- a/csrc/attention/compressor/op_kernel/arch35/compressor_block_vec_full_load.h
+++ b/csrc/attention/compressor/op_kernel/arch35/compressor_block_vec_full_load.h
@@ -691,10 +691,15 @@ __aicore__ inline void CompressorBlockVectorFullLoad<COMP>::WriteToCacheState(co
         uint32_t curSeqIdx = startSeqIdx;
         uint32_t copyFinishRowCnt = 0;
         uint32_t seqCnt = endSeqIdx - startSeqIdx;
-        uint64_t idInBlockTable = blockTableGm.GetValue(batchIdx);
+        uint64_t blockTablebaseOffset = batchIdx * constInfo_.maxBlockNumPerBatch;
+        uint32_t ringTokenCount = coff_ * cmpRatio_;
         while (copyFinishRowCnt < seqCnt) {
-            uint64_t remainRowCnt = curSeqIdx % constInfo_.blockSize;
-            uint32_t copyRowCount = constInfo_.blockSize - remainRowCnt;
+            uint32_t ringTokenIdx = curSeqIdx % ringTokenCount;
+            uint32_t blockIdOffset = ringTokenIdx / constInfo_.blockSize;
+            uint32_t remainRowCnt = ringTokenIdx % constInfo_.blockSize;
+            uint64_t idInBlockTable = blockTableGm.GetValue(blockTablebaseOffset + blockIdOffset);
+            uint32_t copyRowCount = min(constInfo_.blockSize - remainRowCnt,
+                                        ringTokenCount - ringTokenIdx);
             if (copyFinishRowCnt + copyRowCount > seqCnt) {
                 copyRowCount = seqCnt - copyFinishRowCnt;
             }
@@ -744,10 +749,15 @@ CompressorBlockVectorFullLoad<COMP>::ReadFromCacheState(const LocalTensor<T> &ou
         uint32_t curSeqIdx = startSeqIdx;
         uint32_t copyFinishRowCnt = 0;
         uint32_t seqCnt = endSeqIdx - startSeqIdx;
-        uint64_t idInBlockTable = blockTableGm.GetValue(batchIdx);
+        uint64_t blockTablebaseOffset = batchIdx * constInfo_.maxBlockNumPerBatch;
+        uint32_t ringTokenCount = coff_ * cmpRatio_;
         while (copyFinishRowCnt < seqCnt) {
-            uint64_t remainRowCnt = curSeqIdx % constInfo_.blockSize;
-            uint32_t copyRowCount = constInfo_.blockSize - remainRowCnt;
+            uint32_t ringTokenIdx = curSeqIdx % ringTokenCount;
+            uint32_t blockIdOffset = ringTokenIdx / constInfo_.blockSize;
+            uint32_t remainRowCnt = ringTokenIdx % constInfo_.blockSize;
+            uint64_t idInBlockTable = blockTableGm.GetValue(blockTablebaseOffset + blockIdOffset);
+            uint32_t copyRowCount = min(constInfo_.blockSize - remainRowCnt,
+                                        ringTokenCount - ringTokenIdx);
             if (copyFinishRowCnt + copyRowCount > seqCnt) {
                 copyRowCount = seqCnt - copyFinishRowCnt;
             }

--- a/csrc/attention/compressor/op_kernel/compressor.cpp
+++ b/csrc/attention/compressor/op_kernel/compressor.cpp
@@ -68,14 +68,13 @@ __global__ __aicore__ void compressor(
 #endif
     constexpr auto coff = static_cast<COFF>(Coff);
     constexpr auto rotaryMode = static_cast<ROTARY_MODE>(RotaryMode);
-#if (__CCE_AICORE__ != 220)
     constexpr auto cacheMode = static_cast<CACHE_MODE>(CacheMode);
-#endif
 #if (__CCE_AICORE__ == 220)
     if constexpr (static_cast<TEMPLATE_ID>(TemplateId) == TEMPLATE_ID::PERF) {
-        INVOKE_COMPRESSOR_GENERAL_OP_IMPL(CompressorKernelPerf, xLayout, xDtype, ropeDtype, coff, rotaryMode);
+        INVOKE_COMPRESSOR_GENERAL_OP_IMPL(CompressorKernelPerf, xLayout, xDtype, ropeDtype, coff, rotaryMode,
+                                          cacheMode);
     } else {
-        INVOKE_COMPRESSOR_GENERAL_OP_IMPL(CompressorKernel, xLayout, xDtype, ropeDtype, coff, rotaryMode);
+        INVOKE_COMPRESSOR_GENERAL_OP_IMPL(CompressorKernel, xLayout, xDtype, ropeDtype, coff, rotaryMode, cacheMode);
     }
 #else
     if constexpr (static_cast<TEMPLATE_ID>(TemplateId) == TEMPLATE_ID::FULL_LOAD) {

--- a/tests/ut/core/test_compressor_tail_manager.py
+++ b/tests/ut/core/test_compressor_tail_manager.py
@@ -1,0 +1,358 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM-Ascend project
+
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+import torch
+from vllm.v1.kv_cache_interface import UniformTypeKVCacheSpecs
+from vllm.v1.kv_cache_spec_registry import KVCacheSpecRegistry
+
+from vllm_ascend.ascend_config import (
+    get_dsv4_shared_compressor_workspace_fallback_reasons,
+)
+from vllm_ascend.core.kv_cache_interface import AscendCompressorTailSpec
+from vllm_ascend.core.single_type_kv_cache_manager import (
+    CompressorTailManager,
+    get_manager_for_kv_cache_spec,
+)
+
+pytestmark = pytest.mark.cpu_test
+
+
+class _FakeBlockPool:
+    def __init__(self) -> None:
+        self.null_block = object()
+        self.next_block_id = 1
+        self.freed_blocks = []
+
+    def get_new_blocks(self, num_blocks: int):
+        blocks = [
+            SimpleNamespace(block_id=block_id)
+            for block_id in range(
+                self.next_block_id,
+                self.next_block_id + num_blocks,
+            )
+        ]
+        self.next_block_id += num_blocks
+        return blocks
+
+    def free_blocks(self, blocks) -> None:
+        self.freed_blocks.extend(blocks)
+
+
+def _tail_spec(*, ratio: int, block_size: int, state_dim: int):
+    tail_tokens = ratio * (2 if ratio == 4 else 1)
+    return AscendCompressorTailSpec(
+        block_size=block_size,
+        num_kv_heads=1,
+        head_size=state_dim,
+        dtype=torch.float32,
+        sliding_window=tail_tokens,
+        compress_ratio=ratio,
+        model_version="deepseek_v4",
+        tail_tokens=tail_tokens,
+        ring_blocks_per_request=(tail_tokens + block_size - 1) // block_size,
+        state_dim=state_dim,
+    )
+
+
+@pytest.mark.parametrize(
+    ("ratio", "block_size", "state_dim", "expected_blocks"),
+    [
+        pytest.param(4, 8, 2048, 1, id="c4"),
+        pytest.param(128, 32, 1024, 4, id="c128"),
+    ],
+)
+def test_tail_spec_has_constant_per_request_capacity(
+    ratio: int,
+    block_size: int,
+    state_dim: int,
+    expected_blocks: int,
+) -> None:
+    spec = _tail_spec(
+        ratio=ratio,
+        block_size=block_size,
+        state_dim=state_dim,
+    )
+
+    assert spec.ring_blocks_per_request == expected_blocks
+    assert spec.max_admission_blocks_per_request(16_384, 65_536) == expected_blocks
+    assert spec.max_memory_usage_bytes(SimpleNamespace()) == (
+        expected_blocks * spec.page_size_bytes
+    )
+    assert spec.max_num_blocks_per_req(SimpleNamespace(), 65_536) == expected_blocks
+
+
+@pytest.mark.parametrize(
+    ("ratio", "block_size", "state_dim", "expected_blocks"),
+    [
+        pytest.param(4, 8, 2048, 1, id="c4"),
+        pytest.param(128, 32, 1024, 4, id="c128"),
+    ],
+)
+def test_tail_manager_does_not_grow_with_chunk_length(
+    ratio: int,
+    block_size: int,
+    state_dim: int,
+    expected_blocks: int,
+) -> None:
+    pool = _FakeBlockPool()
+    manager = CompressorTailManager(
+        _tail_spec(
+            ratio=ratio,
+            block_size=block_size,
+            state_dim=state_dim,
+        ),
+        block_pool=pool,
+        enable_caching=False,
+        kv_cache_group_id=0,
+        scheduler_block_size=128,
+    )
+
+    for num_tokens in (1, ratio - 1, ratio, 4096, 16_384, 65_536):
+        needed = manager.get_num_blocks_to_allocate(
+            "request",
+            num_tokens,
+            (),
+            total_computed_tokens=0,
+            num_local_computed_tokens=0,
+            num_tokens_main_model=num_tokens,
+        )
+        if not manager.req_to_blocks["request"]:
+            assert needed == expected_blocks
+            manager.allocate_new_blocks("request", num_tokens, num_tokens)
+        else:
+            assert needed == 0
+        assert len(manager.req_to_blocks["request"]) == expected_blocks
+
+    manager.free("request")
+    assert len(pool.freed_blocks) == expected_blocks
+    assert "request" not in manager.req_to_blocks
+
+    # A preempted request releases its ring and gets exactly the same fixed
+    # reservation when scheduled again; sequence length never affects it.
+    assert (
+        manager.get_num_blocks_to_allocate(
+            "request",
+            65_536,
+            (),
+            total_computed_tokens=0,
+            num_local_computed_tokens=0,
+            num_tokens_main_model=65_536,
+        )
+        == expected_blocks
+    )
+
+
+@pytest.mark.parametrize(
+    ("tail_tokens", "block_size", "positions", "expected"),
+    [
+        pytest.param(8, 8, (0, 7, 8, 15), ((0, 0), (0, 7), (0, 0), (0, 7)), id="c4"),
+        pytest.param(
+            128,
+            32,
+            (0, 31, 32, 127, 128, 159),
+            ((0, 0), (0, 31), (1, 0), (3, 31), (0, 0), (0, 31)),
+            id="c128",
+        ),
+    ],
+)
+def test_absolute_position_maps_to_tail_ring(
+    tail_tokens: int,
+    block_size: int,
+    positions: tuple[int, ...],
+    expected: tuple[tuple[int, int], ...],
+) -> None:
+    actual = tuple(
+        (
+            (position % tail_tokens) // block_size,
+            (position % tail_tokens) % block_size,
+        )
+        for position in positions
+    )
+    assert actual == expected
+
+
+def test_all_compressor_call_sites_use_feature_gated_cache_mode() -> None:
+    repo_root = Path(__file__).resolve().parents[3]
+    model_source = (repo_root / "vllm_ascend/models/deepseek_v4.py").read_text(
+        encoding="utf-8"
+    )
+    assert "from vllm.utils.math_utils import cdiv" in model_source
+
+    expected_call_counts = {
+        repo_root / "vllm_ascend/attention/dsa_v1.py": 4,
+        repo_root / "vllm_ascend/attention/context_parallel/dsa_cp.py": 2,
+    }
+    for source_path, expected_count in expected_call_counts.items():
+        source = source_path.read_text(encoding="utf-8")
+        assert source.count("cache_mode=_compressor_cache_mode()") == expected_count
+
+
+def test_arch35_cycle_kernel_uses_multi_block_tail_ring() -> None:
+    repo_root = Path(__file__).resolve().parents[3]
+    kernel_paths = (
+        repo_root / "csrc/attention/compressor/op_kernel/arch35/compressor_block_vec.h",
+        repo_root
+        / "csrc/attention/compressor/op_kernel/arch35/compressor_block_vec_full_load.h",
+    )
+    for kernel_path in kernel_paths:
+        source = kernel_path.read_text(encoding="utf-8")
+        # Both read and write variants must index the request row, select a
+        # physical ring block, and stop copies at the ring boundary.
+        assert source.count("batchIdx * constInfo_.maxBlockNumPerBatch") == 4
+        assert source.count("ringTokenIdx / constInfo_.blockSize") == 2
+        assert source.count("ringTokenCount - ringTokenIdx") == 2
+
+    tiling_source = (
+        repo_root / "csrc/attention/compressor/op_host/arch35/compressor_tiling.cpp"
+    ).read_text(encoding="utf-8")
+    assert "blockTableShape.GetDimNum() == 1" in tiling_source
+    assert "maxBlockNumPerBatch < ringBlocks" in tiling_source
+    assert "blockNum < baseParams_->batchSize * ringBlocks" in tiling_source
+
+
+def test_a3_arch32_cycle_kernel_uses_multi_block_tail_ring() -> None:
+    repo_root = Path(__file__).resolve().parents[3]
+    kernel_source = (
+        repo_root
+        / "csrc/attention/compressor/op_kernel/arch32/compressor_block_vec_perf.h"
+    ).read_text(encoding="utf-8")
+    # PERF is the implementation selected on __CCE_AICORE__ == 220. Lock both
+    # state read/write mappings and the fixed-tail SaveState branch.
+    assert kernel_source.count("batchIdx * constInfo_.maxBlockNumPerBatch") == 2
+    assert kernel_source.count("cacheSeqIdx %= ringTokenCount") == 2
+    assert kernel_source.count("ringTokenCount - cacheSeqIdx") == 2
+    assert "if constexpr (COMP::cacheMode == CACHE_MODE::CYCLE)" in kernel_source
+    assert "writeSeqStartIdx" in kernel_source
+
+    tiling_header = (
+        repo_root / "csrc/attention/compressor/op_host/arch32/compressor_tiling.h"
+    ).read_text(encoding="utf-8")
+    assert "const std::vector<int> CACHE_MODE {1, 2};" in tiling_header
+
+    tiling_source = (
+        repo_root / "csrc/attention/compressor/op_host/arch32/compressor_tiling.cpp"
+    ).read_text(encoding="utf-8")
+    assert "blockTableShape.GetDimNum() == 1" in tiling_source
+    assert "maxBlockNumPerBatch < ringBlocks" in tiling_source
+    assert "blockNum < baseParams_->batchSize * ringBlocks" in tiling_source
+
+
+def test_a3_build_route_passes_cache_mode_to_arch32_comp_type() -> None:
+    repo_root = Path(__file__).resolve().parents[3]
+    entry_source = (
+        repo_root / "csrc/attention/compressor/op_kernel/compressor.cpp"
+    ).read_text(encoding="utf-8")
+    assert '#include "arch32/compressor_kernel_perf.h"' in entry_source
+    assert "__CCE_AICORE__ == 220" in entry_source
+    assert (
+        "CompressorKernelPerf, xLayout, xDtype, ropeDtype, coff, rotaryMode,\n"
+        "                                          cacheMode"
+    ) in entry_source
+
+    comm_source = (
+        repo_root / "csrc/attention/compressor/op_kernel/arch32/compressor_comm.h"
+    ).read_text(encoding="utf-8")
+    assert "ROTARY_MODE Rotary_Mode, CACHE_MODE Cache_Mode" in comm_source
+    assert "static constexpr CACHE_MODE cacheMode = Cache_Mode;" in comm_source
+
+
+def test_uniform_tail_group_selects_tail_manager() -> None:
+    spec = _tail_spec(ratio=128, block_size=32, state_dim=1024)
+    uniform_spec = UniformTypeKVCacheSpecs(
+        block_size=spec.block_size,
+        kv_cache_specs={"layer.0": spec, "layer.1": spec},
+    )
+    pool = _FakeBlockPool()
+
+    with patch.object(
+        KVCacheSpecRegistry,
+        "get_manager_class",
+        return_value=CompressorTailManager,
+    ):
+        manager = get_manager_for_kv_cache_spec(
+            uniform_spec,
+            max_in_flight_tokens=16_384,
+            max_model_len=65_536,
+            block_pool=pool,
+            enable_caching=False,
+            kv_cache_group_id=0,
+            scheduler_block_size=128,
+        )
+
+    assert isinstance(manager, CompressorTailManager)
+    assert manager.kv_cache_spec is spec
+    assert manager.ring_blocks_per_request == 4
+
+
+def _stage1_config(**overrides):
+    config = SimpleNamespace(
+        model_config=SimpleNamespace(
+            hf_text_config=SimpleNamespace(model_type="deepseek_v4"),
+            enforce_eager=True,
+        ),
+        cache_config=SimpleNamespace(enable_prefix_caching=False),
+        kv_transfer_config=None,
+        speculative_config=None,
+        parallel_config=SimpleNamespace(
+            decode_context_parallel_size=1,
+            prefill_context_parallel_size=1,
+        ),
+    )
+    for dotted_name, value in overrides.items():
+        owner_name, field_name = dotted_name.split("__", maxsplit=1)
+        setattr(getattr(config, owner_name), field_name, value)
+    return config
+
+
+def test_stage1_feature_gate_accepts_target_configuration() -> None:
+    reasons = get_dsv4_shared_compressor_workspace_fallback_reasons(
+        _stage1_config(),
+        is_a3=True,
+        multistream_dsv4_dsa_overlap=False,
+    )
+    assert reasons == []
+
+
+@pytest.mark.parametrize(
+    ("config", "is_a3", "multistream", "expected_reason"),
+    [
+        pytest.param(
+            _stage1_config(cache_config__enable_prefix_caching=True),
+            True,
+            False,
+            "prefix caching is enabled",
+            id="prefix-cache",
+        ),
+        pytest.param(
+            _stage1_config(),
+            True,
+            True,
+            "multistream_dsv4_dsa_overlap is enabled",
+            id="multistream",
+        ),
+        pytest.param(
+            _stage1_config(),
+            False,
+            False,
+            "device is not A3",
+            id="device",
+        ),
+    ],
+)
+def test_stage1_feature_gate_falls_back(
+    config,
+    is_a3: bool,
+    multistream: bool,
+    expected_reason: str,
+) -> None:
+    reasons = get_dsv4_shared_compressor_workspace_fallback_reasons(
+        config,
+        is_a3=is_a3,
+        multistream_dsv4_dsa_overlap=multistream,
+    )
+    assert expected_reason in reasons

--- a/tests/ut/device_allocator/test_cpu_binding.py
+++ b/tests/ut/device_allocator/test_cpu_binding.py
@@ -27,6 +27,7 @@ from vllm_ascend.utils import AscendDeviceType
 def make_cpu_alloc(rank_id=0):
     cpu_alloc = object.__new__(CpuAlloc)
     cpu_alloc.rank_id = rank_id
+    cpu_alloc.current_npu = 0
     cpu_alloc.device_info = SimpleNamespace(
         running_npu_list=[0],
         all_logic_npus=[0],
@@ -302,7 +303,15 @@ class TestCpuAlloc(unittest.TestCase):
             ("| NPU Chip | Process id |\n| 0 0 | 1234 | vllm | 56000 |\n| 1 0 | 1235 | vllm | 56000 |", 0),
             ("", 0),
         ]
-        self.cpu_alloc = CpuAlloc(0)
+        self.cpu_alloc = CpuAlloc(0, npu_id=0)
+
+    @patch("vllm_ascend.cpu_binding.DeviceInfo")
+    def test_explicit_npu_id_overrides_running_npu_order(self, mock_device_info):
+        mock_device_info.return_value.running_npu_list = [1, 3]
+
+        cpu_alloc = CpuAlloc(rank_id=0, npu_id=3)
+
+        self.assertEqual(cpu_alloc.current_npu, 3)
 
     def test_average_distribute(self):
         self.cpu_alloc.npu_cpu_pool = {0: [10, 11, 12, 13], 1: [10, 11, 12, 13]}
@@ -542,6 +551,7 @@ class TestCpuAlloc(unittest.TestCase):
         mock_execute_command.return_value = ("PCIe Bus Info 0000:03:00.0", 0)
         self.cpu_alloc.rank_id = 0
         self.cpu_alloc.device_info.running_npu_list = [3]
+        self.cpu_alloc.current_npu = 3
         self.cpu_alloc.npu_cpu_pool = {3: [0, 1, 2, 3, 4]}
 
         self.cpu_alloc.bind_npu_irq()
@@ -888,6 +898,7 @@ class TestCpuBindingSupplemental(unittest.TestCase):
     def test_print_plan_handles_empty_release_assignment(self, mock_logger_info, _mock_get_device_type):
         cpu_alloc = make_cpu_alloc()
         cpu_alloc.device_info.running_npu_list = [1]
+        cpu_alloc.current_npu = 1
         cpu_alloc.rank_id = 0
         cpu_alloc.assign_main = {1: [2, 3]}
         cpu_alloc.assign_acl = {1: [4]}
@@ -902,6 +913,7 @@ class TestCpuBindingSupplemental(unittest.TestCase):
     def test_print_plan_uses_ascend_950_worker_log(self, mock_logger_info, _mock_get_device_type):
         cpu_alloc = make_cpu_alloc()
         cpu_alloc.device_info.running_npu_list = [1]
+        cpu_alloc.current_npu = 1
         cpu_alloc.rank_id = 0
         cpu_alloc.assign_main = {1: [2, 3]}
         cpu_alloc.assign_acl = {1: []}
@@ -922,6 +934,7 @@ class TestCpuBindingSupplemental(unittest.TestCase):
     def test_print_plan_handles_non_empty_release_assignment(self, mock_logger_info, _mock_get_device_type):
         cpu_alloc = make_cpu_alloc()
         cpu_alloc.device_info.running_npu_list = [1]
+        cpu_alloc.current_npu = 1
         cpu_alloc.rank_id = 0
         cpu_alloc.assign_main = {1: [2, 3]}
         cpu_alloc.assign_acl = {1: [4]}
@@ -1238,15 +1251,15 @@ class TestBindingSwitch(unittest.TestCase):
     @patch("vllm_ascend.cpu_binding.is_arm_cpu")
     def test_bind_cpus_skip_non_arm(self, mock_is_arm_cpu, mock_cpu_alloc):
         mock_is_arm_cpu.return_value = False
-        bind_cpus(0)
+        bind_cpus(0, npu_id=0)
         mock_cpu_alloc.assert_not_called()
 
     @patch("vllm_ascend.cpu_binding.CpuAlloc")
     @patch("vllm_ascend.cpu_binding.is_arm_cpu", return_value=True)
     def test_bind_cpus_runs_allocator_on_arm(self, _mock_is_arm_cpu, mock_cpu_alloc):
-        bind_cpus(1)
+        bind_cpus(1, npu_id=3)
 
-        mock_cpu_alloc.assert_called_once_with(1)
+        mock_cpu_alloc.assert_called_once_with(1, npu_id=3)
         mock_cpu_alloc.return_value.run_all.assert_called_once_with()
 
 

--- a/tests/ut/worker/test_compressor_tail_block_table.py
+++ b/tests/ut/worker/test_compressor_tail_block_table.py
@@ -1,0 +1,176 @@
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# This file is a part of the vllm-ascend project.
+#
+
+import unittest
+from unittest.mock import MagicMock, patch
+
+import numpy as np
+import torch
+from vllm.distributed.parallel_state import GroupCoordinator
+from vllm.v1.kv_cache_interface import KVCacheGroupSpec, UniformTypeKVCacheSpecs
+
+from tests.ut.base import TestBase
+
+
+def _make_compressor_tail_spec(block_size=8, tail_tokens=8, compress_ratio=4):
+    from vllm_ascend.core.kv_cache_interface import AscendCompressorTailSpec
+
+    return AscendCompressorTailSpec(
+        block_size=block_size,
+        num_kv_heads=1,
+        head_size=2048,
+        dtype=torch.float32,
+        sliding_window=tail_tokens,
+        compress_ratio=compress_ratio,
+        model_version="deepseek_v4",
+        tail_tokens=tail_tokens,
+        ring_blocks_per_request=(tail_tokens + block_size - 1) // block_size,
+        state_dim=2048,
+    )
+
+
+class TestCompressorTailBlockTable(TestBase):
+    """Regression tests for the compressor-tail slot-mapping out-of-bounds bug.
+
+    The compressor-tail block table keeps only ``ring_blocks_per_request``
+    columns per row, but the generic slot-mapping path indexes rows by
+    absolute position (``pos // block_size``) without ring modulo. Any
+    position beyond the tail therefore reads outside the request's own row.
+    Tail groups must be skipped like mamba groups: the compressor operator
+    addresses the ring internally via ``compressor_metadata``.
+    """
+
+    def setUp(self):
+        self.max_num_reqs = 4
+        self.max_num_batched_tokens = 512
+        self.device = torch.device("cpu")
+
+    def _create_multi_group_block_table(self, block_sizes, max_num_blocks, kernel_sizes, kv_cache_groups):
+        with patch("vllm_ascend.worker.block_table.get_dcp_group") as mock_get_dcp_group:
+            mock_dcp_group = MagicMock(spec=GroupCoordinator)
+            mock_dcp_group.world_size = 1
+            mock_dcp_group.rank_in_group = 0
+            mock_get_dcp_group.return_value = mock_dcp_group
+
+            from vllm_ascend.worker.block_table import MultiGroupBlockTable
+
+            return MultiGroupBlockTable(
+                max_num_reqs=self.max_num_reqs,
+                max_model_len=4096,
+                max_num_batched_tokens=self.max_num_batched_tokens,
+                pin_memory=False,
+                device=self.device,
+                block_sizes=block_sizes,
+                max_num_blocks=max_num_blocks,
+                kernel_sizes=kernel_sizes,
+                cp_kv_cache_interleave_size=1,
+                kv_cache_groups=kv_cache_groups,
+            )
+
+    def test_tail_group_detected_without_row_shrink(self):
+        """Tail group keeps ring-sized rows (no compress_ratio shrink)."""
+        tail_spec = _make_compressor_tail_spec(block_size=8, tail_tokens=8)
+        multi = self._create_multi_group_block_table(
+            block_sizes=[8],
+            max_num_blocks=[1],
+            kernel_sizes=[[8]],
+            kv_cache_groups=[KVCacheGroupSpec(["layer0"], tail_spec)],
+        )
+        tail_table = multi.block_tables[0]
+        self.assertTrue(tail_table.is_compressor_tail_group)
+        self.assertFalse(tail_table.is_mamba_group)
+        self.assertEqual(tail_table.max_num_blocks_per_req, 1)
+        self.assertEqual(tail_table.block_table.np.shape, (self.max_num_reqs, 1))
+
+    def test_tail_group_detected_through_uniform_type_wrapper(self):
+        """Runtime packs DSV4 groups in UniformTypeKVCacheSpecs; detection must unwrap."""
+        tail_spec = _make_compressor_tail_spec(block_size=32, tail_tokens=128, compress_ratio=128)
+        uniform_spec = UniformTypeKVCacheSpecs(kv_cache_specs={"layer0": tail_spec})
+        multi = self._create_multi_group_block_table(
+            block_sizes=[32],
+            max_num_blocks=[4],
+            kernel_sizes=[[32]],
+            kv_cache_groups=[KVCacheGroupSpec(["layer0"], uniform_spec)],
+        )
+        tail_table = multi.block_tables[0]
+        self.assertTrue(tail_table.is_compressor_tail_group)
+        self.assertEqual(tail_table.max_num_blocks_per_req, 4)
+
+    def test_compute_slot_mapping_skips_tail_group(self):
+        """Generic slot mapping must not run for tail groups.
+
+        Before the fix this either raised (CPU: no usable triton backend) or
+        silently computed out-of-row slots (NPU). After the fix the tail
+        group's slot mapping must remain untouched.
+        """
+        tail_spec = _make_compressor_tail_spec(block_size=8, tail_tokens=8)
+        multi = self._create_multi_group_block_table(
+            block_sizes=[8],
+            max_num_blocks=[1],
+            kernel_sizes=[[8]],
+            kv_cache_groups=[KVCacheGroupSpec(["layer0"], tail_spec)],
+        )
+        multi.add_row(([11],), 0)
+        multi.add_row(([13],), 1)
+
+        before = multi.block_tables[0].slot_mapping.np.copy()
+        query_start_loc = torch.tensor([0, 2, 4], dtype=torch.int32)
+        # Positions 8..11 exceed the 8-token tail ring: the buggy kernel
+        # indexed block_table rows at pos // 8 >= 1 (out of row).
+        positions = torch.tensor([8, 9, 10, 11], dtype=torch.int64)
+
+        multi.compute_slot_mapping(2, query_start_loc, positions)
+
+        np.testing.assert_array_equal(multi.block_tables[0].slot_mapping.np, before)
+
+    def test_compute_slot_mapping_draft_skips_tail_group_but_not_normal_group(self):
+        """Draft path: normal group still maps, tail group is skipped.
+
+        With ring=1 block per row and max_num_reqs=4, request row 3 at
+        absolute position 8 made the buggy numpy draft path read flat index
+        3 * 1 + 8 // 8 = 4 in a 4-element table -> IndexError (or a silent
+        cross-row read for smaller indices). After the fix only the normal
+        group consumes the mapping.
+        """
+        tail_spec = _make_compressor_tail_spec(block_size=8, tail_tokens=8)
+        multi = self._create_multi_group_block_table(
+            block_sizes=[128, 8],
+            max_num_blocks=[4, 1],
+            kernel_sizes=[[128], [8]],
+            kv_cache_groups=[None, KVCacheGroupSpec(["layer0"], tail_spec)],
+        )
+        normal_table, tail_table = multi.block_tables
+        normal_table.add_row([5], 0)
+        normal_table.add_row([9], 3)
+        tail_table.add_row([11], 0)
+        tail_table.add_row([13], 3)
+
+        tail_before = tail_table.slot_mapping.np.copy()
+        req_indices = np.array([0, 3], dtype=np.int64)
+        positions = np.array([0, 8], dtype=np.int64)
+
+        multi.compute_slot_mapping_draft(req_indices, positions)
+
+        # Normal group: slot = block_id * block_size + pos % block_size.
+        np.testing.assert_array_equal(
+            normal_table.slot_mapping.np[:2],
+            np.array([5 * 128 + 0, 9 * 128 + 8], dtype=np.int32),
+        )
+        # Tail group: untouched.
+        np.testing.assert_array_equal(tail_table.slot_mapping.np, tail_before)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/vllm_ascend/ascend_config.py
+++ b/vllm_ascend/ascend_config.py
@@ -24,6 +24,40 @@ if TYPE_CHECKING:
     from vllm.config import VllmConfig
 
 
+def get_dsv4_shared_compressor_workspace_fallback_reasons(
+    vllm_config: "VllmConfig",
+    *,
+    is_a3: bool,
+    multistream_dsv4_dsa_overlap: bool,
+) -> list[str]:
+    """Return Stage-1 incompatibilities without mutating user features."""
+    reasons = []
+    model_type = getattr(
+        getattr(vllm_config.model_config, "hf_text_config", None),
+        "model_type",
+        None,
+    )
+    if model_type != "deepseek_v4":
+        reasons.append("model is not DeepSeek-V4")
+    if not is_a3:
+        reasons.append("device is not A3")
+    if not vllm_config.model_config.enforce_eager:
+        reasons.append("ACL graph is enabled")
+    if multistream_dsv4_dsa_overlap:
+        reasons.append("multistream_dsv4_dsa_overlap is enabled")
+    if vllm_config.cache_config.enable_prefix_caching:
+        reasons.append("prefix caching is enabled")
+    if vllm_config.kv_transfer_config is not None:
+        reasons.append("KV transfer/P-D is enabled")
+    if vllm_config.speculative_config is not None:
+        reasons.append("speculative decoding is enabled")
+    if vllm_config.parallel_config.decode_context_parallel_size != 1:
+        reasons.append("decode context parallelism is enabled")
+    if vllm_config.parallel_config.prefill_context_parallel_size != 1:
+        reasons.append("prefill context parallelism is enabled")
+    return reasons
+
+
 class AscendConfig:
     """
     Configuration Object for additional_config from vllm.configs.
@@ -144,6 +178,37 @@ class AscendConfig:
         self.enable_cpu_binding = additional_config.get("enable_cpu_binding", True)
         self.enable_sleep_mode_extra_cleanup = additional_config.get("enable_sleep_mode_extra_cleanup", False)
         self.multistream_dsv4_dsa_overlap = additional_config.get("multistream_dsv4_dsa_overlap", True)
+        shared_compressor_workspace_requested = bool(
+            additional_config.get("enable_dsv4_shared_compressor_workspace", False)
+        )
+        shared_compressor_workspace_fallback_reasons = []
+        if shared_compressor_workspace_requested:
+            from vllm_ascend.utils import AscendDeviceType, get_ascend_device_type
+
+            shared_compressor_workspace_fallback_reasons = (
+                get_dsv4_shared_compressor_workspace_fallback_reasons(
+                    vllm_config,
+                    is_a3=get_ascend_device_type() == AscendDeviceType.A3,
+                    multistream_dsv4_dsa_overlap=self.multistream_dsv4_dsa_overlap,
+                )
+            )
+        self.enable_dsv4_shared_compressor_workspace = (
+            shared_compressor_workspace_requested
+            and not shared_compressor_workspace_fallback_reasons
+        )
+        if shared_compressor_workspace_requested:
+            if shared_compressor_workspace_fallback_reasons:
+                logger.info_once(
+                    "DeepSeek-V4 shared compressor workspace requested but "
+                    "unsupported for this configuration (%s); falling back "
+                    "to the CONTINUOUS state-cache path.",
+                    ", ".join(shared_compressor_workspace_fallback_reasons),
+                )
+            else:
+                logger.info_once(
+                    "Enabled DeepSeek-V4 persistent compressor tails and "
+                    "cross-layer transient workspace reuse."
+                )
         self.enable_prefill_mc2 = bool(additional_config.get("enable_prefill_mc2", False))
 
         self.enable_fused_mc2 = self._get_config_value(

--- a/vllm_ascend/attention/context_parallel/dsa_cp.py
+++ b/vllm_ascend/attention/context_parallel/dsa_cp.py
@@ -12,6 +12,7 @@ from vllm.triton_utils import HAS_TRITON, triton
 from vllm.v1.attention.backend import AttentionCGSupport, AttentionMetadataBuilder
 from vllm.v1.kv_cache_interface import AttentionSpec
 
+from vllm_ascend.ascend_config import get_ascend_config
 from vllm_ascend.attention.abstract import DSAAttentionImpl
 from vllm_ascend.attention.attention_v1 import AscendAttentionState
 from vllm_ascend.attention.utils import (
@@ -35,6 +36,10 @@ from vllm_ascend.utils import (
     get_ascend_device_type,
     olora_tp_enable,
 )
+
+
+def _compressor_cache_mode() -> int:
+    return 2 if get_ascend_config().enable_dsv4_shared_compressor_workspace else 1
 
 
 def hadamard_transform_ref(
@@ -1514,7 +1519,7 @@ class AscendDSACPImpl(DSAAttentionImpl):
                 coff=coff,
                 norm_eps=self.compressor_norm_eps,
                 rotary_mode=2,
-                cache_mode=1,
+                cache_mode=_compressor_cache_mode(),
             )
 
             if compressed_kv.numel() == 0:
@@ -1655,7 +1660,7 @@ class AscendDSACPImpl(DSAAttentionImpl):
             coff=coff,
             norm_eps=self.compressor_norm_eps,
             rotary_mode=2,
-            cache_mode=1,
+            cache_mode=_compressor_cache_mode(),
         )
 
         if kv.numel() == 0:

--- a/vllm_ascend/attention/dsa_v1.py
+++ b/vllm_ascend/attention/dsa_v1.py
@@ -59,6 +59,12 @@ BUILD_METADATA_STEP_DECODE = 1
 _DSV4_DSA_OVERLAP_STREAM = None
 
 
+def _compressor_cache_mode() -> int:
+    # CYCLE keeps only the persistent per-request tail in paged cache; the
+    # current chunk's partial states stay in the CANN operator workspace.
+    return 2 if get_ascend_config().enable_dsv4_shared_compressor_workspace else 1
+
+
 def dsv4_dsa_overlap_stream() -> torch.npu.Stream:
     global _DSV4_DSA_OVERLAP_STREAM
     if _DSV4_DSA_OVERLAP_STREAM is None:
@@ -2132,7 +2138,7 @@ class AscendDSAImpl(DSAAttentionImpl):
                 coff=coff,
                 norm_eps=self.compressor_norm_eps,
                 rotary_mode=2,
-                cache_mode=1,
+                cache_mode=_compressor_cache_mode(),
             )
 
             # For multistream_dsv4_dsa_overlap with compress_ratio=4:
@@ -2430,7 +2436,7 @@ class AscendDSAImpl(DSAAttentionImpl):
                 coff=coff,
                 norm_eps=self.compressor_norm_eps,
                 rotary_mode=2,
-                cache_mode=1,
+                cache_mode=_compressor_cache_mode(),
             )
 
             # For multistream_dsv4_dsa_overlap with compress_ratio=4:
@@ -2642,7 +2648,7 @@ class AscendDSAImpl(DSAAttentionImpl):
             coff=coff,
             norm_eps=self.compressor_norm_eps,
             rotary_mode=2,
-            cache_mode=1,
+            cache_mode=_compressor_cache_mode(),
         )
 
         if kv.numel() == 0:
@@ -2868,7 +2874,7 @@ class AscendDSAImpl(DSAAttentionImpl):
             coff=coff,
             norm_eps=self.compressor_norm_eps,
             rotary_mode=2,
-            cache_mode=1,
+            cache_mode=_compressor_cache_mode(),
         )
 
         if kv.numel() == 0:

--- a/vllm_ascend/core/kv_cache_interface.py
+++ b/vllm_ascend/core/kv_cache_interface.py
@@ -12,7 +12,10 @@ from vllm.v1.core.single_type_kv_cache_manager import FullAttentionManager, Slid
 from vllm.v1.kv_cache_interface import FullAttentionSpec, MLAAttentionSpec, SlidingWindowMLASpec
 from vllm.v1.kv_cache_spec_registry import KVCacheSpecRegistry
 
-from vllm_ascend.core.single_type_kv_cache_manager import CompressAttentionManager
+from vllm_ascend.core.single_type_kv_cache_manager import (
+    CompressorTailManager,
+    CompressAttentionManager,
+)
 
 
 @dataclass(frozen=True, kw_only=True)
@@ -211,6 +214,75 @@ class AscendSlidingWindowMLASpec(SlidingWindowMLASpec):
         )
 
 
+@dataclass(frozen=True, kw_only=True)
+class AscendCompressorTailSpec(AscendSlidingWindowMLASpec):
+    """Persistent DeepSeek-V4 compressor tail stored as a page ring.
+
+    The compressor operator materializes current-chunk partial states in its
+    CANN workspace. Only the incomplete compression group (and the previous
+    group for C4 overlap) must survive across forwards, so scheduler-managed
+    pages are constant per request rather than proportional to chunk length.
+    """
+
+    tail_tokens: int
+    ring_blocks_per_request: int
+    state_dim: int
+
+    def max_admission_blocks_per_request(
+        self,
+        max_in_flight_tokens: int,
+        max_model_len: int,
+    ) -> int:
+        del max_in_flight_tokens, max_model_len
+        return self.ring_blocks_per_request
+
+    def max_memory_usage_bytes(self, vllm_config: VllmConfig) -> int:
+        del vllm_config
+        return self.ring_blocks_per_request * self.page_size_bytes
+
+    def max_num_blocks_per_req(self, vllm_config: VllmConfig, max_len: int) -> int:
+        del vllm_config, max_len
+        return self.ring_blocks_per_request
+
+    @classmethod
+    def merge(cls, specs: list[Self]) -> Self:
+        assert all(isinstance(spec, cls) for spec in specs), (
+            "All layers in a compressor-tail group must use "
+            "AscendCompressorTailSpec."
+        )
+        first = specs[0]
+        assert all(
+            (
+                spec.block_size,
+                spec.num_kv_heads,
+                spec.head_size,
+                spec.dtype,
+                spec.page_size_padded,
+                spec.sliding_window,
+                spec.compress_ratio,
+                spec.model_version,
+                spec.tail_tokens,
+                spec.ring_blocks_per_request,
+                spec.state_dim,
+            )
+            == (
+                first.block_size,
+                first.num_kv_heads,
+                first.head_size,
+                first.dtype,
+                first.page_size_padded,
+                first.sliding_window,
+                first.compress_ratio,
+                first.model_version,
+                first.tail_tokens,
+                first.ring_blocks_per_request,
+                first.state_dim,
+            )
+            for spec in specs[1:]
+        ), "All layers in a compressor-tail group must use the same layout."
+        return first
+
+
 def register_ascend_kv_cache_specs() -> None:
     KVCacheSpecRegistry.register(
         kvcache_spec_cls=AscendMLAAttentionSpec,
@@ -225,5 +297,10 @@ def register_ascend_kv_cache_specs() -> None:
     KVCacheSpecRegistry.register(
         kvcache_spec_cls=AscendSlidingWindowMLASpec,
         manager_class=SlidingWindowManager,
+        uniform_type_base_spec=SlidingWindowMLASpec,
+    )
+    KVCacheSpecRegistry.register(
+        kvcache_spec_cls=AscendCompressorTailSpec,
+        manager_class=CompressorTailManager,
         uniform_type_base_spec=SlidingWindowMLASpec,
     )

--- a/vllm_ascend/core/single_type_kv_cache_manager.py
+++ b/vllm_ascend/core/single_type_kv_cache_manager.py
@@ -14,17 +14,90 @@ from vllm.v1.core.kv_cache_utils import (
 from vllm.v1.core.single_type_kv_cache_manager import (
     FullAttentionManager,
     SingleTypeKVCacheManager,
+    SlidingWindowManager,
 )
 from vllm.v1.kv_cache_interface import (
     ChunkedLocalAttentionSpec,
     FullAttentionSpec,
     KVCacheSpec,
     SlidingWindowSpec,
+    UniformTypeKVCacheSpecs,
 )
 from vllm.v1.request import Request
 
 if TYPE_CHECKING:
-    from vllm_ascend.core.kv_cache_interface import AscendMLAAttentionSpec
+    from vllm_ascend.core.kv_cache_interface import (
+        AscendCompressorTailSpec,
+        AscendMLAAttentionSpec,
+    )
+
+
+class CompressorTailManager(SlidingWindowManager):
+    """Allocate a fixed persistent compressor-state ring per request."""
+
+    def __init__(self, kv_cache_spec: "AscendCompressorTailSpec", **kwargs) -> None:
+        super().__init__(kv_cache_spec, **kwargs)
+        self.ring_blocks_per_request = kv_cache_spec.ring_blocks_per_request
+
+    def get_num_blocks_to_allocate(
+        self,
+        request_id: str,
+        num_tokens: int,
+        new_computed_blocks: Sequence[KVCacheBlock],
+        total_computed_tokens: int,
+        num_local_computed_tokens: int | None = None,
+        num_tokens_main_model: int | None = None,
+        apply_admission_cap: bool = False,
+    ) -> int:
+        del (
+            num_tokens,
+            total_computed_tokens,
+            num_local_computed_tokens,
+            num_tokens_main_model,
+            apply_admission_cap,
+        )
+        assert not new_computed_blocks, (
+            "Compressor-tail prefix hits are unsupported; the feature gate "
+            "must fall back before cache allocation."
+        )
+        allocated = len(self.req_to_blocks.get(request_id, ()))
+        return max(self.ring_blocks_per_request - allocated, 0)
+
+    def allocate_new_blocks(
+        self,
+        request_id: str,
+        num_tokens: int,
+        num_tokens_main_model: int,
+    ) -> list[KVCacheBlock]:
+        del num_tokens, num_tokens_main_model
+        req_blocks = self.req_to_blocks[request_id]
+        num_new_blocks = self.ring_blocks_per_request - len(req_blocks)
+        if num_new_blocks <= 0:
+            return []
+        new_blocks = self.block_pool.get_new_blocks(num_new_blocks)
+        req_blocks.extend(new_blocks)
+        return new_blocks
+
+    def remove_skipped_blocks(
+        self,
+        request_id: str,
+        processed_computed_tokens: int,
+        num_prompt_tokens: int | None = None,
+    ) -> None:
+        del request_id, processed_computed_tokens, num_prompt_tokens
+
+    def cache_blocks(
+        self,
+        request: Request,
+        num_tokens: int,
+        retention_interval: int | None = None,
+        **kwargs,
+    ) -> None:
+        del request, num_tokens, retention_interval, kwargs
+
+    def get_num_common_prefix_blocks(self, running_request_id: str) -> int:
+        del running_request_id
+        return 0
 
 
 class CompressAttentionManager(FullAttentionManager):
@@ -298,17 +371,33 @@ def get_manager_for_kv_cache_spec(
 
     from vllm_ascend.core.kv_cache_interface import AscendMLAAttentionSpec
 
-    manager_class = KVCacheSpecRegistry.get_manager_class(kv_cache_spec)
+    # DeepSeek-V4 cache groups retain per-layer layouts in a
+    # UniformTypeKVCacheSpecs wrapper. Manager semantics are uniform within a
+    # group, so use one contained spec for manager selection and allocation.
+    # The physical per-layer page sizes remain on the wrapper in KVCacheConfig.
+    manager_spec = kv_cache_spec
+    if isinstance(kv_cache_spec, UniformTypeKVCacheSpecs):
+        nested_specs = list(kv_cache_spec.kv_cache_specs.values())
+        assert nested_specs, "UniformTypeKVCacheSpecs must contain at least one spec"
+        manager_spec = nested_specs[0]
+        manager_classes = {
+            KVCacheSpecRegistry.get_manager_class(spec) for spec in nested_specs
+        }
+        assert len(manager_classes) == 1, (
+            "All specs in one uniform KV cache group must use the same manager"
+        )
+
+    manager_class = KVCacheSpecRegistry.get_manager_class(manager_spec)
     assert manager_class is not None, f"No KV cache manager registered for {type(kv_cache_spec).__name__}"
-    if isinstance(kv_cache_spec, AscendMLAAttentionSpec) and kv_cache_spec.compress_ratio > 1:
+    if isinstance(manager_spec, AscendMLAAttentionSpec) and manager_spec.compress_ratio > 1:
         manager_class = CompressAttentionManager
         if max_model_len is not None:
             # Compressed-MLA peak in blocks: ceil(max_model_len/compress/block).
-            compress_ratio = kv_cache_spec.compress_ratio
-            block_size = kv_cache_spec.block_size
+            compress_ratio = manager_spec.compress_ratio
+            block_size = manager_spec.block_size
             max_compressed_tokens = max_model_len // compress_ratio
             kwargs["max_admission_blocks_per_request"] = cdiv(max_compressed_tokens, block_size) + 1
-    elif isinstance(kv_cache_spec, (SlidingWindowSpec, ChunkedLocalAttentionSpec)):
+    elif isinstance(manager_spec, (SlidingWindowSpec, ChunkedLocalAttentionSpec)):
         # Replicate the upstream PR #40946 cap setting for recycling specs.
         # We override the vLLM factory above, so the upstream block that does
         # this lives in dead code (never reached); without re-applying it here
@@ -318,9 +407,9 @@ def get_manager_for_kv_cache_spec(
         # at cc>=2 on DSv4 (see vLLM issue #40863).
         token_budget = max_in_flight_tokens
         if token_budget is not None and max_model_len is not None:
-            kwargs["max_admission_blocks_per_request"] = kv_cache_spec.max_admission_blocks_per_request(
+            kwargs["max_admission_blocks_per_request"] = manager_spec.max_admission_blocks_per_request(
                 max_in_flight_tokens=token_budget,
                 max_model_len=max_model_len,
             )
-    manager = manager_class(kv_cache_spec, **kwargs)
+    manager = manager_class(manager_spec, **kwargs)
     return manager

--- a/vllm_ascend/cpu_binding.py
+++ b/vllm_ascend/cpu_binding.py
@@ -205,9 +205,10 @@ class DeviceInfo:
 
 
 class CpuAlloc:
-    def __init__(self, rank_id: int):
+    def __init__(self, rank_id: int, npu_id: int):
         self.rank_id = rank_id
         self.device_info: DeviceInfo = DeviceInfo()
+        self.current_npu = npu_id
         self.cpu_node: dict[int, int] = {}
         self.numa_to_cpu_map: dict[int, list[int]] = defaultdict(list)
         self.npu_cpu_pool: dict[int, list[int]] = {}
@@ -624,11 +625,10 @@ class CpuAlloc:
 
     def print_plan(self) -> None:
         logger.info("The CPU allocation plan is as follows:")
-        current_npu = self.device_info.running_npu_list[self.rank_id]
         if self._is_ascend_950():
-            self._print_ascend_950_plan(current_npu)
+            self._print_ascend_950_plan(self.current_npu)
             return
-        self._print_default_plan(current_npu)
+        self._print_default_plan(self.current_npu)
 
     def _print_ascend_950_plan(self, current_npu: int) -> None:
         main = " ".join(map(str, self.assign_main[current_npu]))
@@ -684,20 +684,18 @@ class CpuAlloc:
         thread_message, _ = execute_command(["ps", "-Te"])
         threads_map = self.get_threads_map(thread_message)
         main_pid = str(psutil.Process().pid)
-        current_npu = self.device_info.running_npu_list[self.rank_id]
-        self.bind(main_pid, self.assign_main[current_npu], True)
+        self.bind(main_pid, self.assign_main[self.current_npu], True)
         for thread_id in threads_map.get(main_pid, {}).get("acl_thread", []):
-            self.bind(thread_id, self.assign_acl[current_npu], False)
+            self.bind(thread_id, self.assign_acl[self.current_npu], False)
         for thread_id in threads_map.get(main_pid, {}).get("release_thread", []):
-            self.bind(thread_id, self.assign_rel[current_npu], False)
+            self.bind(thread_id, self.assign_rel[self.current_npu], False)
         # Migrate memory once for the whole process, after all threads are pinned.
-        self.bind_memory(main_pid, current_npu)
+        self.bind_memory(main_pid, self.current_npu)
 
     def bind_ascend_950_threads(self) -> None:
         main_pid = str(psutil.Process().pid)
-        current_npu = self.device_info.running_npu_list[self.rank_id]
-        self.bind(main_pid, self.assign_main[current_npu], True)
-        self.bind_memory(main_pid, current_npu)
+        self.bind(main_pid, self.assign_main[self.current_npu], True)
+        self.bind_memory(main_pid, self.current_npu)
 
     def bind_npu_irq(self) -> None:
         if not self._reserve_irq_cpus():
@@ -708,9 +706,8 @@ class CpuAlloc:
             return
 
         # Only bind IRQ for current rank's NPU to avoid multi-process overwrite.
-        current_npu = self.device_info.running_npu_list[self.rank_id]
-        if current_npu not in self.npu_cpu_pool:
-            logger.warning("[irq] NPU has no CPU pool. rank=%s, npu=%s. ", self.rank_id, current_npu)
+        if self.current_npu not in self.npu_cpu_pool:
+            logger.warning("[irq] NPU has no CPU pool. rank=%s, npu=%s. ", self.rank_id, self.current_npu)
             return
 
         if shutil.which("systemctl"):
@@ -731,7 +728,7 @@ class CpuAlloc:
                     irq = line.split(":")[0].strip()
                     sq_irqs.append(irq)
 
-        npu = current_npu
+        npu = self.current_npu
         cpus = self.npu_cpu_pool[npu]
         if len(cpus) < 2:
             logger.warning("[irq] CPU pool too small. npu=%s, cpu_count=%d, min_required=2. ", npu, len(cpus))
@@ -798,9 +795,9 @@ class CpuAlloc:
         self.bind_npu_irq()
 
 
-def bind_cpus(rank_id: int) -> None:
+def bind_cpus(rank_id: int, npu_id: int) -> None:
     if not is_arm_cpu():
         logger.info("CPU binding skipped: non-ARM CPU detected.")
         return
-    binder = CpuAlloc(rank_id)
+    binder = CpuAlloc(rank_id, npu_id=npu_id)
     binder.run_all()

--- a/vllm_ascend/models/deepseek_v4.py
+++ b/vllm_ascend/models/deepseek_v4.py
@@ -75,11 +75,15 @@ from vllm.models.deepseek_v4.compressor import CompressorStateCache  # type: ign
 from vllm.platforms import current_platform
 from vllm.sequence import IntermediateTensors
 from vllm.transformers_utils.configs.deepseek_v4 import DeepseekV4Config
+from vllm.utils.math_utils import cdiv
 from vllm.v1.attention.backends.mla.sparse_swa import DeepseekV4SWACache as VllmDeepseekV4SWACache
 from vllm.v1.kv_cache_interface import KVCacheSpec
 
 from vllm_ascend.ascend_config import get_ascend_config
-from vllm_ascend.core.kv_cache_interface import AscendSlidingWindowMLASpec
+from vllm_ascend.core.kv_cache_interface import (
+    AscendCompressorTailSpec,
+    AscendSlidingWindowMLASpec,
+)
 from vllm_ascend.ops.dsa import AscendDeepseekSparseAttention, DSAModules
 from vllm_ascend.ops.rope_dsv4 import ComplexExpRotaryEmbedding
 from vllm_ascend.ops.triton.mul_add import muls_add_triton
@@ -123,6 +127,25 @@ class AscendCompressorStateCache(CompressorStateCache):
     def get_kv_cache_spec(self, vllm_config: VllmConfig) -> KVCacheSpec:
         pads = _dsv4_block_sizes()[vllm_config.cache_config.block_size][1]
         page_size_padded = pads[0] if self.state_dim == 2 * 256 and self.compress_ratio == 4 else pads[1]
+
+        if get_ascend_config().enable_dsv4_shared_compressor_workspace:
+            return AscendCompressorTailSpec(
+                block_size=self.block_size,
+                num_kv_heads=1,
+                head_size=self.state_dim,
+                dtype=self.dtype,
+                sliding_window=self.sliding_window,
+                alignment=None,
+                page_size_padded=page_size_padded,
+                compress_ratio=self.compress_ratio,
+                model_version="deepseek_v4",
+                tail_tokens=self.sliding_window,
+                ring_blocks_per_request=cdiv(
+                    self.sliding_window,
+                    self.block_size,
+                ),
+                state_dim=self.state_dim,
+            )
 
         return AscendSlidingWindowMLASpec(
             block_size=self.block_size,

--- a/vllm_ascend/worker/block_table.py
+++ b/vllm_ascend/worker/block_table.py
@@ -28,14 +28,24 @@ class BlockTable:
         self.dcp_world_size = get_dcp_group().world_size
         self.dcp_rank = get_dcp_group().rank_in_group
         compress_ratio = 1
+        is_compressor_tail_group = False
         if (
             kv_cache_group is not None
             and hasattr(kv_cache_group, "kv_cache_spec")
             and isinstance(kv_cache_group.kv_cache_spec, UniformTypeKVCacheSpecs)
         ):
-            kv_cache_spec = next(iter(kv_cache_group.kv_cache_spec.kv_cache_specs.values()), None)
+            nested_specs = tuple(kv_cache_group.kv_cache_spec.kv_cache_specs.values())
+            kv_cache_spec = next(iter(nested_specs), None)
             if kv_cache_spec is not None and hasattr(kv_cache_spec, "compress_ratio"):
                 compress_ratio = kv_cache_spec.compress_ratio
+            is_compressor_tail_group = bool(nested_specs) and all(
+                hasattr(spec, "ring_blocks_per_request") for spec in nested_specs
+            )
+        elif kv_cache_group is not None and hasattr(
+            kv_cache_group.kv_cache_spec,
+            "ring_blocks_per_request",
+        ):
+            is_compressor_tail_group = True
         if (
             kv_cache_group is not None
             and hasattr(kv_cache_group, "kv_cache_spec")
@@ -43,7 +53,9 @@ class BlockTable:
             and isinstance(kv_cache_group.kv_cache_spec, MambaSpec)
         ):
             max_num_blocks_per_req = max_num_blocks_per_req * self.dcp_world_size
-        max_num_blocks_per_req = max(cdiv(max_num_blocks_per_req, compress_ratio), 1)
+        if not is_compressor_tail_group:
+            max_num_blocks_per_req = cdiv(max_num_blocks_per_req, compress_ratio)
+        max_num_blocks_per_req = max(max_num_blocks_per_req, 1)
         self.max_num_blocks_per_req = max_num_blocks_per_req
         self.max_num_batched_tokens = max_num_batched_tokens
         self.pin_memory = pin_memory

--- a/vllm_ascend/worker/block_table.py
+++ b/vllm_ascend/worker/block_table.py
@@ -61,6 +61,11 @@ class BlockTable:
         self.pin_memory = pin_memory
         self.device = device
         self.physical_block_size = block_size
+        # Compressor-tail groups keep only a fixed per-request ring of
+        # persistent state blocks. Like mamba groups they have no per-token
+        # slot mapping: the compressor operator addresses the ring by
+        # absolute position modulo ring size inside its own kernel.
+        self.is_compressor_tail_group = is_compressor_tail_group
         self.is_mamba_group = (
             kv_cache_group is not None
             and hasattr(kv_cache_group, "kv_cache_spec")
@@ -435,7 +440,7 @@ class MultiGroupBlockTable:
         req_indices_compressed_list: list[np.ndarray] | None = None,
     ) -> None:
         for i, block_table in enumerate(self.block_tables):
-            if block_table.is_mamba_group:
+            if block_table.is_mamba_group or block_table.is_compressor_tail_group:
                 continue
             if positions_compressed_list and req_indices_compressed_list:
                 block_table.compute_slot_mapping_draft(req_indices_compressed_list[i], positions_compressed_list[i])
@@ -450,7 +455,7 @@ class MultiGroupBlockTable:
         req_indices_compressed_list: list[np.ndarray] | None = None,
     ) -> None:
         for i, block_table in enumerate(self.block_tables):
-            if block_table.is_mamba_group:
+            if block_table.is_mamba_group or block_table.is_compressor_tail_group:
                 continue
             if positions_compressed_list and req_indices_compressed_list:
                 block_table.compute_slot_mapping_draft(req_indices_compressed_list[i], positions_compressed_list[i])

--- a/vllm_ascend/worker/model_runner_v1.py
+++ b/vllm_ascend/worker/model_runner_v1.py
@@ -121,7 +121,6 @@ from vllm_ascend.compilation.acl_graph import (
     set_graph_params,
     update_full_graph_params,
 )
-from vllm_ascend.distributed.utils import get_decode_context_model_parallel_world_size
 from vllm_ascend.eplb.adaptor.vllm_adaptor import VllmEplbAdaptor
 from vllm_ascend.eplb.core.eplb_device_transfer_loader import D2DExpertWeightLoader
 from vllm_ascend.eplb.core.eplb_worker import EplbProcess
@@ -4392,10 +4391,17 @@ class NPUModelRunner(GPUModelRunner):
         for i, kv_cache_group in enumerate(kv_cache_config.kv_cache_groups):
             if isinstance(kv_cache_group.kv_cache_spec, EncoderOnlyAttentionSpec):
                 continue
-            max_num_blocks_per_req = cdiv(
-                max_model_len,
-                block_sizes[i] * get_decode_context_model_parallel_world_size(),
-            )
+            kv_cache_spec = kv_cache_group.kv_cache_spec
+            if isinstance(kv_cache_spec, UniformTypeKVCacheSpecs):
+                max_num_blocks_per_req = max(
+                    spec.max_num_blocks_per_req(self.vllm_config, max_model_len)
+                    for spec in kv_cache_spec.kv_cache_specs.values()
+                )
+            else:
+                max_num_blocks_per_req = kv_cache_spec.max_num_blocks_per_req(
+                    self.vllm_config,
+                    max_model_len,
+                )
             if isinstance(kv_cache_group.kv_cache_spec, MambaSpec):
                 mamba_blocks_per_req = (
                     max_num_blocks_per_req if self.cache_config.enable_prefix_caching else 1

--- a/vllm_ascend/worker/worker.py
+++ b/vllm_ascend/worker/worker.py
@@ -762,7 +762,10 @@ class NPUWorker(WorkerBase):
         # worker process before migratepages/taskset run.
         if get_ascend_config().enable_cpu_binding:
             try:
-                bind_cpus(self.local_rank)
+                bind_cpus(
+                    self.local_rank,
+                    npu_id=current_platform.device_id_to_physical_device_id(self.local_rank),
+                )
             except Exception as e:
                 logger.warning("Bind cpus failed in rank%s: %s Skip binding cpu.", self.local_rank, e)
 


### PR DESCRIPTION
### What this PR does / why we need it?

DeepSeek-V4 compressor partial states are currently represented as token-indexed paged KV cache. For a large prefill chunk, the scheduler reserves state pages for the full in-flight chunk across every compressor layer, although only a small incomplete compression tail must survive across forwards.

This PR:

- adds `AscendCompressorTailSpec` and `CompressorTailManager` so scheduler-managed compressor state remains constant per request;
- reserves one C4 tail block and four C128 tail blocks per request on the A3 block layout;
- enables compressor `cache_mode=2` (`CYCLE`), mapping absolute token positions into a persistent multi-block ring;
- keeps transient current-chunk partial states in the existing CANN operator workspace;
- extends the arch32 and arch35 kernels and tiling validation for the multi-block C128 ring;
- keeps the existing `CONTINUOUS` path as a gated fallback.

For a 4096-token in-flight chunk, compressor-state reservations change from 512 to 1 C4 block and from 128 to 4 C128 blocks per request. This removes the `chunk size x compressor layers` contribution from compressor-state block occupancy.

#### Current limitations

The optimized path is opt-in and disabled by default. Stage 1 is enabled only when all of the following are true:

- the model is DeepSeek-V4;
- the device is Atlas A3;
- eager mode is enforced; ACL graph capture/replay is not supported yet;
- `multistream_dsv4_dsa_overlap` is disabled;
- prefix caching is disabled;
- KV transfer and prefill/decode disaggregation are disabled;
- speculative decoding is disabled;
- decode and prefill context parallel sizes are both 1.

Unsupported configurations are not silently changed. They log the incompatibility and fall back to the existing `cache_mode=1` continuous state-cache path.

Prefix-cache tail checkpoints, P/D tail transfer, multistream synchronization, ACL graph support, and A5 support are follow-up work.

### Does this PR introduce _any_ user-facing change?

Yes. It adds the opt-in `additional_config.enable_dsv4_shared_compressor_workspace` configuration. The default remains `false`, and existing behavior is unchanged unless explicitly enabled on a supported configuration.

### How was this patch tested?

- Added `tests/ut/core/test_compressor_tail_manager.py` covering fixed C4/C128 capacity, chunk-length independence, ring address mapping, manager registration, block-table sizing, kernel source invariants, and feature-gate fallback reasons.
- Added host-side CANN validation for ring width and physical block capacity.
- Rebased onto the current `releases/v0.26.0rc` head and passed `git diff --check`.
- The targeted UT was not run in the PR preparation environment because `pytest` is unavailable; CI validation is pending.
- Full A3 NPU accuracy, peak-memory, and performance validation is pending and should be completed before merge.

- vLLM main: https://github.com/vllm-project/vllm/commit/d02df748bf9efd99022f1a062597dc3cb3808485
