### PR TITLE
[CI] The DCP use case is temporarily taken offline

### DIFF
--- a/tests/e2e/pull_request/four_card/context_parallel/test_accuracy_v2.py
+++ b/tests/e2e/pull_request/four_card/context_parallel/test_accuracy_v2.py
@@ -139,6 +139,7 @@ FULL_FEATURE_MODEL_CASES = AccuracyCase(
 )
 
 
+@pytest.mark.skip("The use case is unstable and temporarily taken offline.")
 @patch.dict(
     os.environ,
     {

--- a/tests/e2e/pull_request/four_card/context_parallel/test_accuracy_v2.py
+++ b/tests/e2e/pull_request/four_card/context_parallel/test_accuracy_v2.py
@@ -25,6 +25,8 @@ from dataclasses import dataclass
 from typing import Any, cast
 from unittest.mock import patch
 
+import pytest
+
 from tests.e2e.conftest import DPVllmRunner, VllmRunner, wait_until_npu_memory_free
 
 MAX_NUM_SEQS = 4


### PR DESCRIPTION
### What this PR does / why we need it?
The DCP test cases are unstable, and the output is inaccurate. Therefore, the DCP is temporarily brought offline.

### Does this PR introduce _any_ user-facing change?
no

### How was this patch tested?

- vLLM main: https://github.com/vllm-project/vllm/commit/ba07e4a48fc951300d97eb506217dd530583dea3
