### PR TITLE
[Feature][MRV1][MRV2] Support CPP and SRF composition

### DIFF
--- a/tests/e2e/pull_request/four_card/test_profiling_chunk_performance.py
+++ b/tests/e2e/pull_request/four_card/test_profiling_chunk_performance.py
@@ -1,8 +1,13 @@
 """Performance guard for profiling-based dynamic chunk sizing (PP scenario).
 
 Measures Time-To-First-Token (TTFT) on 64k-token prefill requests with
-profiling_chunk_config enabled.  The test runs against
-DeepSeek-V2-Lite-Chat served with PP=2, TP=2 (4 NPU cards total).
+profiling_chunk_config enabled. The test runs against Qwen3-30B-A3B
+served with PP=2, TP=2 (4 NPU cards total).
+
+The same scenario is executed with Model Runner V1 and Model Runner V2,
+both with Short Request First (SRF) disabled and enabled. Within each SRF
+mode, the only configuration difference between the two model-runner runs
+is VLLM_USE_V2_MODEL_RUNNER.
 
 Test flow:
   1. Create an LLM engine with profiling_chunk_config enabled.
@@ -17,7 +22,9 @@ import statistics
 import time
 from unittest.mock import patch
 
-from tests.e2e.conftest import VllmRunner
+import pytest
+
+from tests.e2e.conftest import VllmRunner, wait_until_npu_memory_free
 
 MODEL = "Qwen/Qwen3-30B-A3B"
 
@@ -33,6 +40,15 @@ NUM_TEST = 5
 BASELINE_TTFT_S = 5.45
 
 
+@pytest.mark.parametrize(
+    ("use_v2_model_runner", "enable_srf"),
+    [
+        pytest.param("0", False, id="MRV1"),
+        pytest.param("1", False, id="MRV2"),
+        pytest.param("0", True, id="MRV1-SRF"),
+        pytest.param("1", True, id="MRV2-SRF"),
+    ],
+)
 @patch.dict(
     os.environ,
     {
@@ -40,46 +56,60 @@ BASELINE_TTFT_S = 5.45
         "VLLM_ALLOW_LONG_MAX_MODEL_LEN": "1",
     },
 )
-def test_profiling_chunk_ttft_performance() -> None:
-    with VllmRunner(
-        MODEL,
-        max_model_len=70000,
-        tensor_parallel_size=2,
-        pipeline_parallel_size=2,
-        block_size=128,
-        enable_expert_parallel=True,
-        enable_prefix_caching=False,
-        gpu_memory_utilization=0.9,
-        max_num_batched_tokens=12288,
-        distributed_executor_backend="mp",
-        enforce_eager=True,
-        async_scheduling=False,
-        additional_config={
-            "scheduler_config": {
-                "profiling_chunk_config": {
-                    "enabled": True,
-                    "smooth_factor": 0.9,
+@wait_until_npu_memory_free()
+def test_profiling_chunk_ttft_performance(
+    use_v2_model_runner: str,
+    enable_srf: bool,
+) -> None:
+    runner_name = "MRV2" if use_v2_model_runner == "1" else "MRV1"
+    scenario_name = f"{runner_name}+SRF" if enable_srf else runner_name
+
+    # Keep all other runtime settings identical across cases.
+    with (
+        patch.dict(os.environ, {"VLLM_USE_V2_MODEL_RUNNER": use_v2_model_runner}),
+        VllmRunner(
+            MODEL,
+            max_model_len=70000,
+            tensor_parallel_size=2,
+            pipeline_parallel_size=2,
+            block_size=128,
+            enable_expert_parallel=True,
+            enable_prefix_caching=False,
+            gpu_memory_utilization=0.9,
+            max_num_batched_tokens=12288,
+            distributed_executor_backend="mp",
+            enforce_eager=True,
+            async_scheduling=False,
+            additional_config={
+                "scheduler_config": {
+                    "profiling_chunk_config": {
+                        "enabled": True,
+                        "smooth_factor": 0.9,
+                    },
+                    "short_request_first_config": {
+                        "enabled": enable_srf,
+                    },
                 },
+                "enable_cpu_binding": False,
             },
-            "enable_cpu_binding": False,
-        },
-        hf_overrides={
-            "rope_parameters": {
-                "rope_type": "yarn",
-                "rope_theta": 1000,
-                "factor": 5,
-                "original_max_position_embeddings": 262144,
-            }
-        },
-    ) as vllm_model:
+            hf_overrides={
+                "rope_parameters": {
+                    "rope_type": "yarn",
+                    "rope_theta": 1000,
+                    "factor": 5,
+                    "original_max_position_embeddings": 262144,
+                }
+            },
+        ) as vllm_model,
+    ):
         # With max_tokens=1, total latency ≈ prefill time ≈ TTFT
         prompts = [INPUT_64K_TOKENS]
 
-        # ── Warmup ──────────────────────────────────────────────────────────
+        # ── Warmup ──────────────────────────────────────────────────────
         for _ in range(NUM_WARMUP):
             vllm_model.generate_greedy(prompts, max_tokens=1)
 
-        # ── Measurement ─────────────────────────────────────────────────────
+        # ── Measurement ─────────────────────────────────────────────────
         ttfts: list[float] = []
         for _ in range(NUM_TEST):
             start = time.perf_counter()
@@ -89,13 +119,15 @@ def test_profiling_chunk_ttft_performance() -> None:
         median_ttft = statistics.median(ttfts)
         ttft_str = ", ".join(f"{t:.2f}s" for t in ttfts)
         print(
-            f"\n[profiling_chunk perf] TTFT per request: [{ttft_str}]"
-            f"\n[profiling_chunk perf] Median TTFT: {median_ttft:.2f}s  "
+            f"\n[profiling_chunk perf][{scenario_name}] "
+            f"TTFT per request: [{ttft_str}]"
+            f"\n[profiling_chunk perf][{scenario_name}] "
+            f"Median TTFT: {median_ttft:.2f}s  "
             f"(baseline: {BASELINE_TTFT_S}s)"
         )
 
         assert median_ttft <= BASELINE_TTFT_S, (
-            f"TTFT performance regression: median TTFT {median_ttft:.2f}s "
-            f"exceeds baseline {BASELINE_TTFT_S}s. "
-            f"Individual TTFTs: [{ttft_str}]"
+            f"[{scenario_name}] TTFT performance regression: "
+            f"median TTFT {median_ttft:.2f}s exceeds baseline "
+            f"{BASELINE_TTFT_S}s. Individual TTFTs: [{ttft_str}]"
         )

--- a/tests/ut/core/test_profiling_chunk.py
+++ b/tests/ut/core/test_profiling_chunk.py
@@ -31,6 +31,9 @@ from tests.ut.base import TestBase
 from vllm_ascend.ascend_config import ProfilingChunkConfig, clear_ascend_config, init_ascend_config
 from vllm_ascend.core.profiling_chunk_predictor import ChunkSizePredictor, ProfilingChunkManager
 from vllm_ascend.core.scheduler_profiling_chunk import ProfilingChunkScheduler
+from vllm_ascend.core.short_request_first_scheduler import (
+    ShortRequestFirstRequestQueue,
+)
 from vllm_ascend.utils import vllm_version_is
 
 MODEL = "Qwen/Qwen3-0.6B"
@@ -39,13 +42,13 @@ MAX_NUM_BATCHED_TOKENS = 8192
 MAX_NUM_SEQS = 16
 
 
-def create_requests(num_requests, num_tokens=10, max_tokens=16):
+def create_requests(num_requests, num_tokens=10, max_tokens=16, request_id_prefix=""):
     init_none_hash(sha256)
     sampling_params = SamplingParams(ignore_eos=False, max_tokens=max_tokens)
     requests = []
     for i in range(num_requests):
         request = Request(
-            request_id=f"{i}",
+            request_id=f"{request_id_prefix}{i}",
             prompt_token_ids=[i] * num_tokens,
             sampling_params=sampling_params,
             pooling_params=None,
@@ -282,12 +285,18 @@ class TestProfilingChunkScheduler(TestBase):
         mock_get_ascend_config,
         _mock_profiling_init_ascend_config,
         mock_balance_init_ascend_config,
+        srf_enabled=False,
     ):
         profiling_cfg = MagicMock()
         profiling_cfg.enabled = True
         profiling_cfg.smooth_factor = 0.8
         profiling_cfg.min_chunk = 256
         mock_get_ascend_config.return_value.scheduler_config.profiling_chunk_config = profiling_cfg
+        short_request_first_cfg = MagicMock()
+        short_request_first_cfg.enabled = srf_enabled
+        short_request_first_cfg.threshold = 256
+        short_request_first_cfg.long_max_wait_ms = 2000.0
+        mock_get_ascend_config.return_value.scheduler_config.short_request_first_config = short_request_first_cfg
         mock_balance_init_ascend_config.return_value.scheduler_config.short_request_first_config.enabled = False
 
         mock_hf_config = MagicMock()
@@ -376,6 +385,45 @@ class TestProfilingChunkScheduler(TestBase):
         scheduler = self.create_scheduler()
         self.assertIsNotNone(scheduler.profiling_chunk_manager)
         self.assertFalse(scheduler._profiling_initialized)
+        self.assertFalse(scheduler._short_request_first_enabled)
+        self.assertNotIsInstance(
+            scheduler.waiting,
+            ShortRequestFirstRequestQueue,
+        )
+
+    def test_scheduler_init_with_short_request_first(self):
+        scheduler = self.create_scheduler(srf_enabled=True)
+
+        self.assertIsInstance(
+            scheduler.waiting,
+            ShortRequestFirstRequestQueue,
+        )
+
+    def test_schedule_short_request_before_earlier_long_request(self):
+        scheduler = self.create_scheduler(srf_enabled=True)
+
+        long_request = create_requests(
+            num_requests=1,
+            num_tokens=512,
+            request_id_prefix="long-",
+        )[0]
+        short_request = create_requests(
+            num_requests=1,
+            num_tokens=64,
+            request_id_prefix="short-",
+        )[0]
+
+        # Simulate a long request arriving before a short request.
+        scheduler.add_request(long_request)
+        scheduler.add_request(short_request)
+
+        output = scheduler.schedule()
+
+        self.assertEqual(len(output.scheduled_new_reqs), 2)
+        self.assertEqual(
+            [request.request_id for request in scheduler.running],
+            ["short-0", "long-0"],
+        )
 
     def test_run_profiling_chunk_init_success(self):
         scheduler = self.create_scheduler()
@@ -386,6 +434,19 @@ class TestProfilingChunkScheduler(TestBase):
 
         self.assertTrue(scheduler._profiling_initialized)
         self.assertTrue(scheduler.profiling_chunk_manager.is_ready)
+        self.assertFalse(scheduler.profiling_chunk_manager._set_time_done)
+
+    def test_run_profiling_chunk_init_failure(self):
+        scheduler = self.create_scheduler()
+        mock_executor = MagicMock()
+        mock_executor.collective_rpc.return_value = []
+
+        scheduler.run_profiling_chunk_init(mock_executor)
+
+        self.assertTrue(scheduler._profiling_initialized)
+        self.assertFalse(scheduler.profiling_chunk_manager.is_ready)
+        self.assertIsNone(scheduler.profiling_chunk_manager.predictor.target_latency)
+        self.assertFalse(scheduler.profiling_chunk_manager._set_time_done)
 
     def test_run_profiling_chunk_init_skips_second_call(self):
         scheduler = self.create_scheduler()

--- a/tests/ut/test_platform.py
+++ b/tests/ut/test_platform.py
@@ -1210,11 +1210,6 @@ class TestNPUPlatform(TestBase):
                 "batch_job_sched_config",
             ),
             (
-                "profiling_chunk",
-                lambda config, ascend: setattr(ascend.scheduler_config.profiling_chunk_config, "enabled", True),
-                "profiling_chunk_config",
-            ),
-            (
                 "kv_consumer",
                 lambda config, ascend: setattr(
                     config, "kv_transfer_config", MagicMock(kv_role="kv_consumer", engine_id="engine0")
@@ -1237,6 +1232,79 @@ class TestNPUPlatform(TestBase):
                     patch.object(platform, "check_kv_extra_config"),
                 ):
                     self.platform.check_and_update_config(vllm_config)
+
+    @patch("vllm_ascend.quantization.utils.maybe_auto_detect_quantization")
+    @patch(
+        "vllm_ascend.device.hardware_profile.get_current_hardware_profile",
+        return_value=get_hardware_profile(AscendDeviceType.A3),
+    )
+    @patch("vllm_ascend.ascend_config.init_ascend_config")
+    def test_check_and_update_config_short_request_first_accepts_profiling_chunk(
+        self,
+        mock_init_ascend,
+        mock_soc_version,
+        mock_auto_detect,
+    ):
+        from vllm_ascend import platform
+
+        importlib.reload(platform)
+        self.platform = platform.NPUPlatform()
+
+        ascend_config = TestNPUPlatform.mock_vllm_ascend_config()
+        ascend_config.scheduler_config.short_request_first_config.enabled = True
+        ascend_config.scheduler_config.profiling_chunk_config.enabled = True
+        mock_init_ascend.return_value = ascend_config
+
+        vllm_config = TestNPUPlatform.mock_vllm_config()
+        vllm_config.kv_transfer_config = None
+        vllm_config.scheduler_config.async_scheduling = False
+
+        with (
+            patch.object(platform, "_fix_incompatible_config"),
+            patch.object(platform, "check_kv_extra_config"),
+        ):
+            self.platform.check_and_update_config(vllm_config)
+
+        self.assertEqual(
+            vllm_config.scheduler_config.scheduler_cls,
+            "vllm_ascend.core.scheduler_profiling_chunk.ProfilingChunkScheduler",
+        )
+
+    @patch("vllm_ascend.quantization.utils.maybe_auto_detect_quantization")
+    @patch(
+        "vllm_ascend.device.hardware_profile.get_current_hardware_profile",
+        return_value=get_hardware_profile(AscendDeviceType.A3),
+    )
+    @patch("vllm_ascend.ascend_config.init_ascend_config")
+    def test_check_and_update_config_short_request_first_rejects_async_profiling_chunk(
+        self,
+        mock_init_ascend,
+        mock_soc_version,
+        mock_auto_detect,
+    ):
+        from vllm_ascend import platform
+
+        importlib.reload(platform)
+        self.platform = platform.NPUPlatform()
+
+        ascend_config = TestNPUPlatform.mock_vllm_ascend_config()
+        ascend_config.scheduler_config.short_request_first_config.enabled = True
+        ascend_config.scheduler_config.profiling_chunk_config.enabled = True
+        mock_init_ascend.return_value = ascend_config
+
+        vllm_config = TestNPUPlatform.mock_vllm_config()
+        vllm_config.kv_transfer_config = None
+        vllm_config.scheduler_config.async_scheduling = True
+
+        with (
+            pytest.raises(
+                ValueError,
+                match="requires synchronous scheduling",
+            ),
+            patch.object(platform, "_fix_incompatible_config"),
+            patch.object(platform, "check_kv_extra_config"),
+        ):
+            self.platform.check_and_update_config(vllm_config)
 
     @patch("vllm_ascend.quantization.utils.maybe_auto_detect_quantization")
     @patch(

--- a/tests/ut/worker/test_model_runner_v1.py
+++ b/tests/ut/worker/test_model_runner_v1.py
@@ -1995,48 +1995,6 @@ class TestNPUModelRunnerDebugger(unittest.TestCase):
 
         runner._start_dump_data.assert_called_once_with(scheduled_tokens={"req0": 1})
 
-    @patch("vllm_ascend.worker.model_runner_v1.has_kv_transfer_group", return_value=False)
-    @patch("vllm_ascend.worker.model_runner_v1.has_ec_transfer", return_value=False)
-    @patch("vllm_ascend.worker.model_runner_v1.get_pp_group")
-    @patch("vllm_ascend.worker.model_runner_v1.record_function_or_nullcontext")
-    def test_execute_model_ignores_need_timing_when_profiling_chunk_is_disabled(
-        self, mock_record_function, mock_get_pp_group, _mock_has_ec_transfer, _mock_has_kv_transfer_group
-    ):
-        from contextlib import nullcontext
-
-        mock_record_function.return_value = nullcontext()
-        mock_get_pp_group.return_value = SimpleNamespace(world_size=1, is_first_rank=True, is_last_rank=True)
-        runner = self._build_runner(MagicMock(spec=["start", "stop", "step"]))
-        runner.vllm_config = MagicMock()
-        runner.vllm_config.model_config.enable_return_routed_experts = False
-        runner.ascend_config = SimpleNamespace(
-            scheduler_config=SimpleNamespace(profiling_chunk_config=SimpleNamespace(enabled=False, need_timing=True))
-        )
-        runner.execute_model_state = None
-        runner.speculative_config = None
-        runner.use_async_scheduling = False
-        runner.num_spec_tokens = 0
-        runner._draft_token_ids = None
-        runner.supports_mm_inputs = False
-        runner.model_config.is_encoder_decoder = False
-        runner.synchronize_input_prep = nullcontext
-        runner._update_states = MagicMock(return_value=None)
-        runner._sync_device = MagicMock()
-        runner.parallel_config = SimpleNamespace(
-            distributed_executor_backend="external_launcher", data_parallel_size=2, enable_dbo=False
-        )
-        runner.cache_config = SimpleNamespace(kv_sharing_fast_prefill=False)
-        runner.input_batch = SimpleNamespace(num_reqs=1, req_ids=["req0"], prev_req_id_to_index=None)
-        runner.requests = {}
-        runner._prepare_inputs = MagicMock(side_effect=RuntimeError("sentinel"))
-        scheduler_output = SimpleNamespace(total_num_scheduled_tokens=1, num_scheduled_tokens={"req0": 1})
-
-        with self.assertRaisesRegex(RuntimeError, "sentinel"):
-            runner.execute_model(scheduler_output)
-
-        runner._sync_device.assert_not_called()
-        self.assertFalse(hasattr(runner, "_execution_start_time"))
-
 
 class TestCorrectOptimisticSeqLensCpu(unittest.TestCase):
     """Regression tests for async spec-decode seq_lens correction.

--- a/tests/ut/worker/test_worker_v2.py
+++ b/tests/ut/worker/test_worker_v2.py
@@ -146,25 +146,3 @@ class TestNPUWorkerV2(TestBase):
             self.assertEqual(model_runner_output.execution_time_ms, 125.0)
             self.assertIsNone(model_runner._cpp_execution_time_ms)
             model_runner.sample_tokens.assert_called_once_with(grammar_output)
-
-    @patch(
-        "vllm_ascend.worker.worker._attach_profiling_chunk_execution_time",
-    )
-    def test_sample_tokens_v1_keeps_original_path(self, mock_attach):
-        from vllm_ascend.worker.worker import NPUWorker
-
-        with patch.object(NPUWorker, "__init__", lambda self, **kwargs: None):
-            worker = NPUWorker()
-            worker.use_v2_model_runner = False
-
-            model_runner = MagicMock()
-            output = SimpleNamespace()
-            model_runner.sample_tokens.return_value = output
-            worker.model_runner = model_runner
-
-            grammar_output = SimpleNamespace()
-            result = worker.sample_tokens(grammar_output)
-
-            self.assertIs(result, output)
-            mock_attach.assert_not_called()
-            model_runner.sample_tokens.assert_called_once_with(grammar_output)

--- a/vllm_ascend/core/scheduler_profiling_chunk.py
+++ b/vllm_ascend/core/scheduler_profiling_chunk.py
@@ -87,8 +87,24 @@ class ProfilingChunkScheduler(Scheduler):
         from vllm_ascend.ascend_config import get_ascend_config, init_ascend_config
 
         init_ascend_config(vllm_config)
-        profiling_cfg = get_ascend_config().scheduler_config.profiling_chunk_config
+        scheduler_extension_config = get_ascend_config().scheduler_config
+
+        profiling_cfg = scheduler_extension_config.profiling_chunk_config
         self.profiling_chunk_config = profiling_cfg
+
+        short_request_first_config = scheduler_extension_config.short_request_first_config
+        self._short_request_first_enabled = short_request_first_config.enabled
+
+        if self._short_request_first_enabled:
+            from vllm_ascend.core.short_request_first_scheduler import (
+                install_short_request_first_waiting_queue,
+            )
+
+            install_short_request_first_waiting_queue(
+                self,
+                threshold=short_request_first_config.threshold,
+                long_max_wait_ms=short_request_first_config.long_max_wait_ms,
+            )
         base_chunk = self.max_num_scheduled_tokens
 
         self.profiling_chunk_manager = ProfilingChunkManager(

--- a/vllm_ascend/platform.py
+++ b/vllm_ascend/platform.py
@@ -945,8 +945,8 @@ def _check_ascend_config(vllm_config: VllmConfig, ascend_config) -> None:
 
     _validate_kv_load_failure_policy(vllm_config)
 
-    # short_request_first_config: requires fcfs policy and excludes
-    # batch_job_sched_config / profiling_chunk_config / kv_consumer
+    # short_request_first_config requires FCFS, excludes batch-job and
+    # kv-consumer paths, and only supports profiling-chunk synchronously.
     if scheduler_extension_config.short_request_first_config.enabled:
         kv_transfer_config = vllm_config.kv_transfer_config
         kv_role = getattr(kv_transfer_config, "kv_role", None)
@@ -960,10 +960,10 @@ def _check_ascend_config(vllm_config: VllmConfig, ascend_config) -> None:
                 "ShortRequestFirst scheduling cannot be enabled with batch_job_sched_config. "
                 "Please disable one of them."
             )
-        if scheduler_extension_config.profiling_chunk_config.enabled:
+        if scheduler_extension_config.profiling_chunk_config.enabled and vllm_config.scheduler_config.async_scheduling:
             raise ValueError(
-                "ShortRequestFirst scheduling cannot be enabled with profiling_chunk_config. "
-                "Please disable one of them."
+                "ShortRequestFirst with profiling_chunk_config requires synchronous scheduling. "
+                "Please disable async scheduling."
             )
         if kv_role == "kv_consumer":
             raise ValueError(

--- a/vllm_ascend/worker/model_runner_v1.py
+++ b/vllm_ascend/worker/model_runner_v1.py
@@ -248,6 +248,10 @@ from vllm_ascend.core.kv_cache_interface import (
     AscendSlidingWindowMLASpec,
     get_kv_cache_compression_ratio,
 )
+from vllm_ascend.core.profiling_chunk_predictor import (
+    _finish_profiling_chunk_timing,
+    _start_profiling_chunk_timing,
+)
 
 # if true, allow tensor initialization and casting with internal format (e.g., NZ)
 torch.npu.config.allow_internal_format = True
@@ -2132,17 +2136,12 @@ class NPUModelRunner(GPUModelRunner):
         scheduler_output: "SchedulerOutput",
         intermediate_tensors: IntermediateTensors | None = None,
     ) -> ModelRunnerOutput | IntermediateTensors | None:
+        self._cpp_execution_time_ms = None
         profiling_chunk_config = self.ascend_config.scheduler_config.profiling_chunk_config
-        if profiling_chunk_config.enabled and profiling_chunk_config.need_timing:
-            # Check if the scheduler signaled that calibration is complete.
-            # This flag is set cross-process via scheduler_output because
-            # modifying the config singleton in the scheduler process does
-            # not affect this worker process.
-            if getattr(scheduler_output, "disable_profiling_timing", False):
-                profiling_chunk_config.need_timing = False
-            else:
-                self._sync_device()
-                self._execution_start_time = time.perf_counter()
+        execution_start_time = _start_profiling_chunk_timing(
+            profiling_chunk_config,
+            scheduler_output,
+        )
         if self.execute_model_state is not None:
             raise RuntimeError("State error: sample_tokens() must be called after execute_model() returns None.")
 
@@ -2489,6 +2488,10 @@ class NPUModelRunner(GPUModelRunner):
             hidden_states = self._model_forward(
                 num_tokens_padded, input_ids, positions, intermediate_tensors, inputs_embeds, **model_kwargs
             )
+            self._cpp_execution_time_ms = _finish_profiling_chunk_timing(
+                profiling_chunk_config,
+                execution_start_time,
+            )
             # Verify every scheduled layer executed its deferred copy.
             if self.cache_config.mamba_cache_mode == "align" and mamba_copy_connector is not None:
                 mamba_copy_connector.finish_mamba_state_copy()
@@ -2568,7 +2571,6 @@ class NPUModelRunner(GPUModelRunner):
     def sample_tokens(
         self, grammar_output: "GrammarOutput | None"
     ) -> ModelRunnerOutput | AsyncModelRunnerOutput | IntermediateTensors:
-        profiling_chunk_config = self.ascend_config.scheduler_config.profiling_chunk_config
         kv_connector_output = self.kv_connector_output
         self.kv_connector_output = None
         pp = get_pp_group()
@@ -2732,14 +2734,6 @@ class NPUModelRunner(GPUModelRunner):
             cudagraph_stats=cudagraph_stats,
             routed_experts=None,
         )
-        if (
-            profiling_chunk_config.enabled
-            and profiling_chunk_config.need_timing
-            and hasattr(self, "_execution_start_time")
-        ):
-            self._sync_device()
-            model_runner_output.execution_time_ms = (time.perf_counter() - self._execution_start_time) * 1000.0
-
         if self.dynamic_eplb:
             self.eplb_updator.forward_end(self.eplb_heat_collection_status)
 

--- a/vllm_ascend/worker/worker.py
+++ b/vllm_ascend/worker/worker.py
@@ -817,9 +817,6 @@ class NPUWorker(WorkerBase):
 
     @torch.inference_mode()
     def sample_tokens(self, grammar_output: "GrammarOutput") -> ModelRunnerOutput | AsyncModelRunnerOutput:
-        if not self.use_v2_model_runner:
-            return self.model_runner.sample_tokens(grammar_output)
-
         output = self.model_runner.sample_tokens(grammar_output)
         _attach_profiling_chunk_execution_time(
             self.model_runner.ascend_config.scheduler_config.profiling_chunk_config,


### PR DESCRIPTION
### What this PR does / why we need it?

This PR enables Profiling Chunk (CPP) scheduling to work with Short Request First (SRF) scheduling on both Model Runner V1 and Model Runner V2.

Previously, `short_request_first_config` and `profiling_chunk_config` were treated as mutually exclusive. This prevented SRF from prioritizing short requests while profiling-based chunk sizing was enabled.

This change:

- allows SRF and profiling-chunk scheduling to be enabled together in synchronous scheduling mode;
- keeps the unsupported asynchronous combination rejected with an explicit error;
- installs the standard SRF waiting queue in `ProfilingChunkScheduler` when SRF is enabled;
- aligns Model Runner V1 profiling-chunk timing with the Model Runner V2 timing path, measuring model-forward execution consistently and attaching the timing result through the shared worker path;
- adds unit coverage for configuration validation, SRF queue installation, and short-request ordering;
- extends the four-card profiling-chunk performance test to cover MRV1, MRV2, MRV1+SRF, and MRV2+SRF with otherwise identical runtime settings.

### Does this PR introduce _any_ user-facing change?

Yes.

Users can enable `short_request_first_config.enabled=true` together with `profiling_chunk_config.enabled=true` when synchronous scheduling is used. No new configuration field is introduced, and existing behavior is unchanged when SRF is disabled.

The SRF + profiling-chunk combination remains unsupported with `async_scheduling=true`.

### How was this patch tested?

After rebasing onto `vllm-project/vllm-ascend:main` at `e8f47fc11c81f3eb3efeb9b40400db8b0fa6eef3`:

- Static validation passed on all nine changed Python files:
  - `ruff check`
  - `ruff format --check`
  - `python -m py_compile`
  - `git diff --check upstream/main...HEAD`
- Targeted unit tests passed:
  ```text
  70 passed, 14 warnings in 1.84s
  ```
  The run covered `tests/ut/core/test_profiling_chunk.py`, the two new platform validation cases, `tests/ut/worker/a2/test_model_runner_v1.py`, and `tests/ut/worker/a2/test_worker_v2.py`.

Before the rebase, the complete four-scenario E2E test passed on server-27 with four Atlas A2 NPUs and local Qwen3-30B-A3B-W8A8 weights:

```text
MRV1 median TTFT:      4.56 s
MRV2 median TTFT:      4.61 s
MRV1 + SRF median:     4.56 s
MRV2 + SRF median:     4.57 s
Baseline:              5.45 s

4 passed, 14 warnings in 2106.03s
```

A complete E2E rerun on the rebased head was not completed; the targeted PR CI E2E should validate the rebased integration.

## AI Assistance

This PR was prepared with AI assistance. The submitter reviewed the changes, conflict resolution, and reported validation results.

- vLLM main: https://github.com/vllm-project/vllm/commit/b2f685834a6456197e7033966fdef52a23f1abcd
