### PR TITLE
[Feature]kv pool supports Qos control

### DIFF
--- a/docs/source/user_guide/feature_guide/kv_pool.md
+++ b/docs/source/user_guide/feature_guide/kv_pool.md
@@ -178,6 +178,8 @@ curl -s "http://<master_host>:9003/api/v1/tenant_quotas?tenant_id=tenant-a"
 
 Using `MultiConnector` to simultaneously utilize both `MooncakeConnectorV1` and `AscendStoreConnector`. `MooncakeConnectorV1` performs kv_transfer, while `AscendStoreConnector` serves as the prefix-cache node.
 
+For A3 and Ascend 950 Products Store/PD traffic separation, set `ASCEND_GLOBAL_RESOURCE_CONFIG` on both the prefill and decode nodes and use **CANN >= 9.1.0**. The top-level resource configuration controls `MooncakeConnectorV1` PD traffic, and the `store` section controls `AscendStoreConnector` Mooncake Store traffic.
+
 **run_prefill.sh/run_decode.sh:**
 
 ```shell
@@ -1358,3 +1360,30 @@ Ensure `free -h` **available** on the host exceeds this sum plus vLLM overhead. 
 
 For the temporary DSv4 known issue, see:
 <https://github.com/vllm-project/vllm-ascend/issues/9975>
+
+### 5.6. ASCEND_GLOBAL_RESOURCE_CONFIG
+
+`ASCEND_GLOBAL_RESOURCE_CONFIG` is a JSON string passed to HIXL. Common fields are:
+
+| Field | Description |
+| :--- | :--- |
+| `comm_resource_config.protocol_desc` | Protocol descriptor for the top-level Mooncake transfer engine. In PD disaggregation, this controls the `MooncakeConnectorV1` PD transfer path. Example values include `["hccs:device"]` and `["roce:device"]`. |
+| `store.comm_resource_config.protocol_desc` | Protocol descriptor for Mooncake Store traffic used by `AscendStoreConnector`. On A3, this can be set to `["roce:device"]` while PD transfer uses HCCS. |
+| `store.comm_resource_config.qos` | Transfer QoS for Mooncake Store traffic used by `AscendStoreConnector`. The valid range is **0-4 (integers only)**; the **default value is 0**, and a larger value means a higher transfer priority. Invalid values cause startup to fail fast with a validation error. See [QoS Configuration](#561-qos-configuration). |
+| `comm_resource_config.listen_port` | One-sided communication listen port. The HIXL default is `16666`; use a different port for standalone `mooncake_client` processes to avoid conflicts with embedded clients. |
+| `fabric_memory.max_capacity` | Fabric memory quota in GB per process. Use it only when the fabric memory budget is too small; see [Fabric memory size alignment](#5322-fabric-memory-size-alignment-a3--ascend_enable_use_fabric_mem1). |
+
+Store/PD traffic separation requires **CANN >= 9.1.0**. It is intended for A3 and Ascend 950 Products deployments where PD transfer traffic can use HCCS and Mooncake Store traffic can use ROCE, so the two traffic classes do not compete on the same physical link. For more HIXL deployment patterns, see the [Mooncake + HIXL pooling overview](https://gitcode.com/cann/hixl/wiki/Mooncake%20+%20HIXL%20%E6%B1%A0%E5%8C%96%E6%96%B9%E6%A1%88%E6%80%BB%E8%A7%88%EF%BC%88A2%20-%20A3%EF%BC%89.md).
+
+#### 5.7. QoS Configuration
+
+Both the Mooncake and Memcache backends support configuring the transfer
+QoS. The valid range is **0-4 (integers only)**, and the **default value is 0**
+when not configured. A larger value means a higher transfer priority. Invalid
+values (non-integer, out of range) cause startup to fail fast with a
+validation error.
+
+| Backend | Configuration Method | Example |
+| :--- | :--- | :--- |
+| Mooncake | `store.comm_resource_config.qos` field in `ASCEND_GLOBAL_RESOURCE_CONFIG` | `export ASCEND_GLOBAL_RESOURCE_CONFIG='{"store":{"comm_resource_config":{"qos":3}}}'` |
+| Memcache | `MF_DEVICE_UB_QOS` environment variable | `export MF_DEVICE_UB_QOS=3` |

--- a/tests/ut/distributed/ascend_store/_mock_deps.py
+++ b/tests/ut/distributed/ascend_store/_mock_deps.py
@@ -402,6 +402,15 @@ _distributed_utils.get_decode_context_model_parallel_world_size = MagicMock(  # 
 )
 sys.modules["vllm_ascend.distributed.utils"] = _distributed_utils
 
+# mooncake_backend imports get_global_rank from the real
+# vllm_ascend.distributed.parallel_state, whose import chain pulls in vllm.
+# Only mock it when vllm is absent; otherwise keep the real module so the
+# mock does not leak into other UTs collected in the same process.
+if _MOCK_VLLM_DEPS:
+    _ascend_parallel_state = _make_pkg("vllm_ascend.distributed.parallel_state")
+    _ascend_parallel_state.get_global_rank = MagicMock(return_value=0)  # type: ignore[attr-defined]
+    sys.modules["vllm_ascend.distributed.parallel_state"] = _ascend_parallel_state
+
 _kv_transfer_real_path = os.path.join(_vllm_ascend_real_path, "distributed", "kv_transfer")
 if _MOCK_VLLM_DEPS:
     _kv_transfer_init = _make_pkg("vllm_ascend.distributed.kv_transfer", _kv_transfer_real_path)

--- a/tests/ut/distributed/ascend_store/test_backend.py
+++ b/tests/ut/distributed/ascend_store/test_backend.py
@@ -20,6 +20,7 @@ import os
 import sys
 import tempfile
 import unittest
+from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 import tests.ut.distributed.ascend_store._mock_deps  # noqa: F401, E402
@@ -29,6 +30,8 @@ from vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.backend import (
 )
 from vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.backend.base import Backend
 from vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.backend.memcache_backend import (
+    MemcacheBackend,
+    _validate_device_ub_qos,
     extract_layout_config,
     make_full_key,
     make_hit_check_keys,
@@ -41,6 +44,7 @@ from vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.backend.mooncake_b
     _convert_to_bytes,
     _parse_global_segment_size,
     _ssd_setup_kwargs,
+    _validate_store_qos,
 )
 from vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.backend.yuanrong_backend import (
     YuanrongConfig,
@@ -293,6 +297,7 @@ class TestMooncakeBackendSetup(unittest.TestCase):
         backend.config = config
         backend.local_seg = None
         backend._use_fabric_mem = use_fabric_mem
+        backend._use_store_independent_te = False
         backend._contribute_memory = contribute_memory
         return backend
 
@@ -417,6 +422,7 @@ class TestMooncakeBackendMethods(unittest.TestCase):
             backend._lazy_init = False
             backend._store_initialized = True
             backend._use_fabric_mem = False
+            backend._use_store_independent_te = False
             backend._store_init_lock = MagicMock()
             backend.local_seg = None
             return backend
@@ -457,6 +463,133 @@ class TestMooncakeBackendMethods(unittest.TestCase):
         ):
             b.register_buffer([100], [200])
             mock_te.register_buffer.assert_called_once()
+
+    def test_register_buffer_with_store_independent_te(self):
+        b = self._make_backend()
+        b._use_store_independent_te = True
+        b.store.register_buffer.return_value = 0
+        with patch(
+            "vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.backend.mooncake_backend.global_te"
+        ) as mock_te:
+            b.register_buffer([100, 101], [200, 201])
+            b.store.register_buffer.assert_any_call(100, 200)
+            b.store.register_buffer.assert_any_call(101, 201)
+            self.assertEqual(b.store.register_buffer.call_count, 2)
+            mock_te.register_buffer.assert_not_called()
+
+    def test_register_buffer_skips_fabric_mem(self):
+        b = self._make_backend()
+        b._use_fabric_mem = True
+        b.register_buffer([100], [200])
+        b.store.register_buffer.assert_not_called()
+
+    def test_setup_store_with_store_independent_te(self):
+        b = self._make_backend()
+        b._use_store_independent_te = True
+        b._contribute_memory = True
+        b.config = SimpleNamespace(
+            metadata_server="P2PHANDSHAKE",
+            global_segment_size=1024,
+            local_buffer_size=2048,
+            protocol="ascend",
+            device_name="",
+            master_server_address="127.0.0.1:50088",
+            enable_ssd_offload=False,
+            tenant_id="default",
+        )
+        with (
+            patch.object(sys.modules["mooncake.store"], "MooncakeDistributedStore", create=True) as mock_store_cls,
+            patch(
+                "vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.backend.mooncake_backend.global_te"
+            ) as mock_te,
+            patch(
+                "vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.backend.mooncake_backend.get_ip",
+                return_value="127.0.0.1",
+            ),
+        ):
+            mock_store = mock_store_cls.return_value
+            mock_store.setup.return_value = 0
+            self.assertIs(b._setup_store(), mock_store)
+            mock_te.get_transfer_engine.assert_not_called()
+            mock_store.setup.assert_called_once()
+            setup_kwargs = mock_store.setup.call_args.kwargs
+            self.assertEqual(setup_kwargs["local_hostname"], "127.0.0.1")
+            self.assertEqual(setup_kwargs["local_buffer_size"], 0)
+            self.assertNotIn("engine", setup_kwargs)
+
+
+# =========================================================================
+# MooncakeBackend store QoS validation (ASCEND_GLOBAL_RESOURCE_CONFIG)
+# =========================================================================
+class TestMooncakeStoreQosValidation(unittest.TestCase):
+    _ENV = "ASCEND_GLOBAL_RESOURCE_CONFIG"
+
+    @staticmethod
+    def _store_qos_env(qos) -> dict:
+        return {"ASCEND_GLOBAL_RESOURCE_CONFIG": json.dumps({"store": {"comm_resource_config": {"qos": qos}}})}
+
+    def test_unset_env_passes(self):
+        with patch.dict(os.environ, {}, clear=True):
+            _validate_store_qos()
+
+    def test_valid_qos_values_pass(self):
+        for qos in (0, 1, 2, 3, 4):
+            with self.subTest(qos=qos), patch.dict(os.environ, self._store_qos_env(qos)):
+                _validate_store_qos()
+
+    def test_out_of_range_qos_rejected(self):
+        for qos in (5, 6, 7, -1):
+            with (
+                self.subTest(qos=qos),
+                patch.dict(os.environ, self._store_qos_env(qos)),
+                self.assertRaisesRegex(ValueError, r"\[0, 4\]"),
+            ):
+                _validate_store_qos()
+
+    def test_non_integer_qos_rejected(self):
+        for qos in ("3", 2.5, True, None, [3]):
+            with (
+                self.subTest(qos=qos),
+                patch.dict(os.environ, self._store_qos_env(qos)),
+                self.assertRaisesRegex(ValueError, "QoS must be an integer"),
+            ):
+                _validate_store_qos()
+
+    def test_malformed_json_rejected(self):
+        with patch.dict(os.environ, {self._ENV: "not-json"}), self.assertRaisesRegex(ValueError, "not valid JSON"):
+            _validate_store_qos()
+
+    def test_missing_store_qos_passes(self):
+        # The top-level comm_resource_config.qos is not used by the KV pool and
+        # must not be validated here.
+        configs: tuple[dict, ...] = (
+            {},
+            {"comm_resource_config": {"qos": 7}},
+            {"store": {}},
+            {"store": {"comm_resource_config": {}}},
+            {"fabric_memory": {"max_capacity": 32}},
+        )
+        for config in configs:
+            with self.subTest(config=config), patch.dict(os.environ, {self._ENV: json.dumps(config)}):
+                _validate_store_qos()
+
+    def test_init_rejects_invalid_store_qos(self):
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as f:
+            json.dump({"metadata_server": "192.168.0.1:2379"}, f)
+            path = f.name
+        try:
+            env = {
+                "MOONCAKE_CONFIG_PATH": path,
+                "ASCEND_GLOBAL_RESOURCE_CONFIG": json.dumps({"store": {"comm_resource_config": {"qos": 6}}}),
+            }
+            with (
+                patch.dict(os.environ, env),
+                patch.object(MooncakeBackend, "_setup_store"),
+                self.assertRaisesRegex(ValueError, r"\[0, 4\]"),
+            ):
+                MooncakeBackend(MagicMock())
+        finally:
+            os.unlink(path)
 
 
 # =========================================================================
@@ -829,6 +962,46 @@ class TestMemcacheBackendMethods(unittest.TestCase):
         error_log = _format_log_call(mock_logger.error.call_args)
         self.assertIn("RuntimeError", error_log)
         self.assertIn("backend fail", error_log)
+
+
+# =========================================================================
+# MemcacheBackend QoS validation (MF_DEVICE_UB_QOS)
+# =========================================================================
+class TestMemcacheQosValidation(unittest.TestCase):
+    _ENV = "MF_DEVICE_UB_QOS"
+
+    def test_unset_or_empty_env_passes(self):
+        with patch.dict(os.environ, {}, clear=True):
+            _validate_device_ub_qos()
+        with patch.dict(os.environ, {self._ENV: ""}):
+            _validate_device_ub_qos()
+
+    def test_valid_qos_values_pass(self):
+        for qos in ("0", "1", "2", "3", "4", " 3 "):
+            with self.subTest(qos=qos), patch.dict(os.environ, {self._ENV: qos}):
+                _validate_device_ub_qos()
+
+    def test_out_of_range_qos_rejected(self):
+        for qos in ("5", "7", "-1", "100"):
+            with (
+                self.subTest(qos=qos),
+                patch.dict(os.environ, {self._ENV: qos}),
+                self.assertRaisesRegex(ValueError, r"\[0, 4\]"),
+            ):
+                _validate_device_ub_qos()
+
+    def test_non_integer_qos_rejected(self):
+        for qos in ("abc", "3.5", "0x3"):
+            with (
+                self.subTest(qos=qos),
+                patch.dict(os.environ, {self._ENV: qos}),
+                self.assertRaisesRegex(ValueError, "QoS must be an integer"),
+            ):
+                _validate_device_ub_qos()
+
+    def test_init_rejects_invalid_qos(self):
+        with patch.dict(os.environ, {self._ENV: "7"}), self.assertRaisesRegex(ValueError, r"\[0, 4\]"):
+            MemcacheBackend(MagicMock())
 
 
 if __name__ == "__main__":

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/backend/base.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/backend/base.py
@@ -5,6 +5,11 @@ from typing import Any
 
 from vllm.config import ParallelConfig
 
+# QoS range supported by the pooled KV store backends. A larger value
+# means a higher transfer priority.
+QOS_VALUE_MIN = 0
+QOS_VALUE_MAX = 4
+
 
 class Backend(ABC):
     store: Any | None = None

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/backend/memcache_backend.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/backend/memcache_backend.py
@@ -10,7 +10,11 @@ from vllm.config import ParallelConfig
 from vllm.distributed.parallel_state import get_world_group
 from vllm.logger import logger
 
-from vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.backend.base import Backend
+from vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.backend.base import (
+    QOS_VALUE_MAX,
+    QOS_VALUE_MIN,
+    Backend,
+)
 
 
 def _is_device_sdma() -> bool:
@@ -29,6 +33,28 @@ def _is_device_sdma() -> bool:
 
 
 MEMCACHE_THREAD_START_WAIT_S = 0.1
+
+
+def _validate_device_ub_qos() -> None:
+    """Validate MF_DEVICE_UB_QOS used by the MemCache store transfers.
+
+    Only integers in [QOS_VALUE_MIN, QOS_VALUE_MAX] are supported; MemCache
+    silently falls back to its default QoS on invalid values, so fail fast
+    with a clear error instead.
+    """
+    qos_str = os.getenv("MF_DEVICE_UB_QOS")
+    if qos_str is None or not qos_str.strip():
+        return
+    try:
+        qos = int(qos_str)
+    except ValueError as e:
+        raise ValueError(
+            f"Invalid MF_DEVICE_UB_QOS value {qos_str!r}: QoS must be an integer in [{QOS_VALUE_MIN}, {QOS_VALUE_MAX}]."
+        ) from e
+    if not (QOS_VALUE_MIN <= qos <= QOS_VALUE_MAX):
+        raise ValueError(
+            f"Invalid MF_DEVICE_UB_QOS value {qos}: QoS must be an integer in [{QOS_VALUE_MIN}, {QOS_VALUE_MAX}]."
+        )
 
 
 class MmcDirect(Enum):
@@ -119,6 +145,7 @@ class MemcacheBackend(Backend):
         init_bm: bool = True,
         lazy_init: bool = False,
     ):
+        _validate_device_ub_qos()
         self.local_rank = local_rank if local_rank is not None else get_world_group().local_rank
         self._init_bm = init_bm
         self._lazy_init = lazy_init and _is_device_sdma()

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/backend/mooncake_backend.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/backend/mooncake_backend.py
@@ -16,7 +16,11 @@ from vllm.distributed.parallel_state import get_world_group
 from vllm.logger import logger
 from vllm.utils.network_utils import get_ip
 
-from vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.backend.base import Backend
+from vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.backend.base import (
+    QOS_VALUE_MAX,
+    QOS_VALUE_MIN,
+    Backend,
+)
 from vllm_ascend.distributed.kv_transfer.utils.mooncake_transfer_engine import global_te
 from vllm_ascend.distributed.parallel_state import get_global_rank
 
@@ -60,16 +64,58 @@ def _ssd_setup_kwargs(config: "MooncakeStoreConfig") -> dict[str, object]:
     }
 
 
+def _validate_store_qos() -> None:
+    """Validate the store QoS configured via ASCEND_GLOBAL_RESOURCE_CONFIG.
+
+    KV pool transfers go through the Mooncake store, whose HIXL QoS comes from
+    the ``store.comm_resource_config.qos`` field. The top-level
+    ``comm_resource_config.qos`` belongs to other HIXL users and is not
+    validated here. Only integers in [QOS_VALUE_MIN, QOS_VALUE_MAX] are
+    supported; an invalid value fails fast with a clear error instead of an
+    obscure failure inside the transfer engine.
+    """
+    config_str = os.getenv("ASCEND_GLOBAL_RESOURCE_CONFIG")
+    if not config_str:
+        return
+    try:
+        config = json.loads(config_str)
+    except json.JSONDecodeError as e:
+        raise ValueError(
+            f"ASCEND_GLOBAL_RESOURCE_CONFIG is not valid JSON: {e}. "
+            'Expected e.g. \'{"store": {"comm_resource_config": {"qos": 3}}}\'.'
+        ) from e
+    if not isinstance(config, dict):
+        return
+    store_config = config.get("store")
+    if not isinstance(store_config, dict):
+        return
+    comm_resource_config = store_config.get("comm_resource_config")
+    if not isinstance(comm_resource_config, dict) or "qos" not in comm_resource_config:
+        return
+    qos = comm_resource_config["qos"]
+    if isinstance(qos, bool) or not isinstance(qos, int) or not (QOS_VALUE_MIN <= qos <= QOS_VALUE_MAX):
+        raise ValueError(
+            f"Invalid store QoS {qos!r} in ASCEND_GLOBAL_RESOURCE_CONFIG "
+            f"(store.comm_resource_config.qos): QoS must be an integer in "
+            f"[{QOS_VALUE_MIN}, {QOS_VALUE_MAX}]."
+        )
+
+
 class MooncakeBackend(Backend):
     def __init__(self, parallel_config: ParallelConfig, lazy_init: bool = False, contribute_memory: bool = True):
         self.parallel_config = parallel_config
         self.config = MooncakeStoreConfig.load_from_env()
         if self.config.protocol != "ascend":
             raise NotImplementedError(f"MooncakeBackend does not support protocol {self.config.protocol!r}.")
+        _validate_store_qos()
 
         self.store: Any | None = None
         self.local_seg: str | None = None
         self._use_fabric_mem = os.getenv("ASCEND_ENABLE_USE_FABRIC_MEM", "0") == "1"
+        # ASCEND_GLOBAL_RESOURCE_CONFIG: dual-protocol / RoCE Store path where the store
+        # operates independently of the global transfer engine; setup goes through store
+        # and buffers are registered via store.register_buffer() instead of global_te.
+        self._use_store_independent_te = bool(os.getenv("ASCEND_GLOBAL_RESOURCE_CONFIG")) and not self._use_fabric_mem
         self._lazy_init = lazy_init and self._use_fabric_mem
         self._contribute_memory = contribute_memory
         self._store_initialized = False
@@ -122,7 +168,8 @@ class MooncakeBackend(Backend):
         # ASCEND_ENABLE_USE_FABRIC_MEM: Enable unified memory address direct transmission scheme
         # and only can be used for 800 I/T A3 series.
         # Required supporting hardware versions are as follows:
-        if not self._use_fabric_mem:
+        # ASCEND_GLOBAL_RESOURCE_CONFIG takes the same store-independent-TE setup path as fabric-mem.
+        if not self._use_fabric_mem and not self._use_store_independent_te:
             transfer_engine = global_te.get_transfer_engine(local_hostname, device_name=None)
             self.local_seg = local_hostname + ":" + str(transfer_engine.get_rpc_port())
             ret = store.setup(
@@ -176,7 +223,18 @@ class MooncakeBackend(Backend):
         torch.npu.set_device(device)
 
     def register_buffer(self, ptrs: list[int], lengths: list[int]):
-        if not self._use_fabric_mem:
+        if self._use_store_independent_te:
+            assert self.store is not None
+            for ptr, length in zip(ptrs, lengths):
+                ret = self.store.register_buffer(ptr, length)
+                if ret != 0:
+                    logger.error(
+                        "Failed to register buffer via store: ptr=%s, length=%s, ret=%s",
+                        ptr,
+                        length,
+                        ret,
+                    )
+        elif not self._use_fabric_mem:
             local_hostname = get_ip()
             global_te.get_transfer_engine(local_hostname, device_name=None)
             global_te.register_buffer(ptrs, lengths)


### PR DESCRIPTION
### What this PR does / why we need it?
[RFC](https://github.com/vllm-project/vllm-ascend/issues/15483)
In scenarios with high traffic congestion, in order to avoid affecting high-priority operations such as operator distribution and aggregate communication, kv pool needs to support configuring QoS to lower its priority.

### Does this PR introduce _any_ user-facing change?
NA

### How was this patch tested?

1. Configure the Ascend_GLOBAL_RESOURCE_CONFIG environment variable in the mooncake scene.
```
export ASCEND_GLOBAL_RESOURCE_CONFIG='{
    "comm_resource_config": {"qos": 4},
    "store": {"comm_resource_config": {"qos": 2}}
}'
```
2. Configure the MF_DEVICE_UB_QOS environment variable in the memcache scenario.
```
export MF_DEVICE_UB_QOS=3
```


- vLLM main: https://github.com/vllm-project/vllm/commit/ba07e4a48fc951300d97eb506217dd530583dea3
