### PR TITLE
[Perf][Graph] Env-gated ACL-graph step decomposition probe + capture seq_len override

### DIFF
--- a/vllm_ascend/compilation/acl_graph.py
+++ b/vllm_ascend/compilation/acl_graph.py
@@ -2,6 +2,8 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
 import dataclasses
+import os
+import time
 import weakref
 from collections.abc import Callable
 from contextlib import ExitStack
@@ -31,6 +33,41 @@ _STREAM_RESOURCE_ERROR_MARKERS = (
     "stream resources are insufficient",
 )
 _OLD_HDK_CAPTURE_ERROR_MARKERS = ("alloc sq cq fail",)
+
+
+# GLM53 graph-mode step decomposition probe: on FULL-graph replay steps,
+# `sync` host wall time equals the device drain of the previous replay (the
+# current stream only holds the previous replay), `update_host` is the host
+# cost of re-issuing the per-layer FIA task updates, `replay_host` is the
+# enqueue cost. Log a running average every 200 replays. Env-gated, zero
+# overhead when off.
+_GRAPH_TIMING = os.environ.get("GLM53_GRAPH_TIMING", "0") == "1"
+_graph_timing_acc: dict[str, float] = {"sync": 0.0, "update_host": 0.0, "replay_host": 0.0, "n": 0.0}
+_GRAPH_TIMING_LOG_EVERY = 200
+
+
+def acc_graph_timing(key: str, dt: float) -> None:
+    """Accumulate one timed section; called from model_runner for update_host."""
+    if not _GRAPH_TIMING:
+        return
+    _graph_timing_acc[key] += dt
+
+
+def graph_timing_enabled() -> bool:
+    return _GRAPH_TIMING
+
+
+def _graph_timing_tick() -> None:
+    _graph_timing_acc["n"] += 1
+    n = _graph_timing_acc["n"]
+    if n % _GRAPH_TIMING_LOG_EVERY == 0:
+        logger.info(
+            "[graph-timing] n=%d sync=%.1fms update_host=%.1fms replay_host=%.1fms (avg/step)",
+            n,
+            _graph_timing_acc["sync"] / n * 1e3,
+            _graph_timing_acc["update_host"] / n * 1e3,
+            _graph_timing_acc["replay_host"] / n * 1e3,
+        )
 
 
 def _is_stream_resource_capture_error(exc: RuntimeError) -> bool:
@@ -262,8 +299,17 @@ class ACLGraphWrapper:
         is_draft_eagle = _EXTRA_CTX.is_draft_model and self.use_eagle
         need_sync = self.runtime_mode == CUDAGraphMode.FULL and not is_draft_eagle
         if not self.enable_enpu and need_sync:
+            if _GRAPH_TIMING:
+                _t_sync = time.perf_counter()
             torch.npu.current_stream().synchronize()
+            if _GRAPH_TIMING:
+                acc_graph_timing("sync", time.perf_counter() - _t_sync)
+        if _GRAPH_TIMING:
+            _t_replay = time.perf_counter()
         entry.aclgraph.replay()
+        if _GRAPH_TIMING:
+            acc_graph_timing("replay_host", time.perf_counter() - _t_replay)
+            _graph_timing_tick()
         return entry.output
 
 

--- a/vllm_ascend/worker/model_runner_v1.py
+++ b/vllm_ascend/worker/model_runner_v1.py
@@ -19,6 +19,7 @@
 
 import logging
 import math
+import os
 import sys
 import time
 from collections import defaultdict, deque
@@ -128,6 +129,8 @@ from vllm_ascend.attention.utils import (
 # yapf: disable
 from vllm_ascend.compilation.acl_graph import (
     ACLGraphWrapper,
+    acc_graph_timing,
+    graph_timing_enabled,
     set_draft_graph_params,
     set_graph_params,
     update_full_graph_params,
@@ -231,7 +234,10 @@ AttnMetadataDict: TypeAlias = dict[str, AttentionMetadata]
 # list when ubatching is enabled
 PerLayerAttnMetadata: TypeAlias = list[AttnMetadataDict] | AttnMetadataDict
 
-SEQ_LEN_WITH_MAX_PA_WORKSPACE = 6144
+# Workspace-probe seq_len baked into the captured FIA calls. GLM53_GRAPH_CAPTURE_SEQLEN
+# overrides it for the graph-mode negative-optimization investigation (tiling for a
+# giant KV len may be the 4x device-time inflation); 6144 is the upstream default.
+SEQ_LEN_WITH_MAX_PA_WORKSPACE = int(os.environ.get("GLM53_GRAPH_CAPTURE_SEQLEN", "6144"))
 
 
 @dataclass
@@ -2868,6 +2874,8 @@ class NPUModelRunner(GPUModelRunner):
             if self.enable_enpu:
                 torch.npu.current_stream().synchronize()
 
+            if graph_timing_enabled():
+                _t_upd = time.perf_counter()
             update_full_graph_params(
                 self.attn_backend,
                 self.update_stream,
@@ -2876,6 +2884,8 @@ class NPUModelRunner(GPUModelRunner):
                 self.vllm_config,
                 self.speculative_config,
             )
+            if graph_timing_enabled():
+                acc_graph_timing("update_host", time.perf_counter() - _t_upd)
 
     def _model_forward(
         self,


### PR DESCRIPTION
## What

Two investigation knobs for FULL/FULL_DECODE_ONLY graph-mode step-time analysis, both env-gated with zero overhead when off:

1. `GLM53_GRAPH_TIMING=1` — accumulate host wall time of the pre-replay `synchronize()` (== device drain of the previous replay), the per-step FIA task-update issue cost, and the replay enqueue; log a running average every 200 replays.
2. `GLM53_GRAPH_CAPTURE_SEQLEN` — override `SEQ_LEN_WITH_MAX_PA_WORKSPACE` (default 6144) for capture-tiling experiments.

## Why

While tuning GLM-5.3-Flash (34 KDA + 11 sparse-MLA layers) we needed to attribute graph-mode step time between host update / sync wait / replay. Measured on this stack: sync=0.1ms, update_host=2.4ms, replay_host=0.1ms — i.e. the per-layer FIA task update is cheap here (~2.4ms for 11 ops), which retired the "per-layer update is the graph-mode bottleneck" hypothesis for this model class and pointed the investigation at state-writeback instead (fixed separately).

Also documents a measurement trap: the pre-replay sync reads ~0.1ms whenever an earlier host-side event sync already drained the stream, so it must not be read as "device is idle".

🤖 Generated with [Claude Code](https://claude.com/claude-code)
- vLLM main: https://github.com/vllm-project/vllm/commit/ba07e4a48fc951300d97eb506217dd530583dea3
