### PR TITLE
[Bugfix] Add extra judgement about moe intermediate size

### DIFF
--- a/vllm_ascend/ascend_config.py
+++ b/vllm_ascend/ascend_config.py
@@ -739,6 +739,8 @@ class AscendConfig:
 
         moe_intermediate_size = getattr(hf_text_config, "moe_intermediate_size", None)
         if moe_intermediate_size is None:
+            moe_intermediate_size = getattr(hf_text_config, "intermediate_size", None)
+        if moe_intermediate_size is None:
             return False
         if moe_intermediate_size < 1024 or moe_intermediate_size > 3072 or moe_intermediate_size % 512 != 0:
             return False


### PR DESCRIPTION

### What this PR does / why we need it?
For some models like Minimax, it does not have moe_intermediate_size field. Instead, it only has intermediate_size in its config.json. This pr use intermediate_size if moe_intermediate_size is not found in config.json. In this way, it can support models without moe_intermediate_size field.

### Does this PR introduce _any_ user-facing change?

### How was this patch tested?

- vLLM main: https://github.com/vllm-project/vllm/commit/ba07e4a48fc951300d97eb506217dd530583dea3
