### PR TITLE
[Feature][MRV2] Support DSA PCP with ACLGraph

### DIFF
--- a/.github/workflows/scripts/test_config.yaml
+++ b/.github/workflows/scripts/test_config.yaml
@@ -187,7 +187,7 @@ estimated_times:
   tests/e2e/pull_request/four_card/_310p/test_moe_model_310p.py: 800
   tests/e2e/pull_request/four_card/_310p/test_vl_model_310p.py: 370
   tests/e2e/pull_request/four_card/context_parallel/test_accuracy.py: 880
-  tests/e2e/pull_request/four_card/context_parallel/test_accuracy_v2.py: 590
+  tests/e2e/pull_request/four_card/context_parallel/test_accuracy_v2.py: 900
   tests/e2e/pull_request/four_card/context_parallel/test_prefix_caching_cp.py: 210
   tests/e2e/pull_request/four_card/model_runner_v2/test_deepseek_v4.py: 520
   tests/e2e/pull_request/four_card/rlhf/consistency/test_batch_invariant_tp4.py: 210

--- a/docs/source/user_guide/feature_guide/context_parallel.md
+++ b/docs/source/user_guide/feature_guide/context_parallel.md
@@ -19,14 +19,14 @@ PCP support is experimental and available only with ModelRunner V2. The followin
 
 | Attention Backend | Basic PCP | Prefix Caching + PCP | Chunked Prefill + PCP | MLAPO + PCP | Speculative Decoding + PCP | P/D Disaggregation + PCP | Sequence Parallelism (SP) + PCP |
 | --- | --- | --- | --- | --- | --- | --- | --- |
-| MLA | ❌ No compatibility | ❌ No compatibility | ❌ No compatibility | ❌ No compatibility | ❌ No compatibility | ❌ No compatibility | ❌ No compatibility |
-| GQA | 🟠 Partial compatibility (eager) | ✅ Full compatibility | ✅ Full compatibility | — Not applicable | ❌ No compatibility | ❌ No compatibility | ❌ No compatibility |
-| SFA | ❌ No compatibility | ❌ No compatibility | ❌ No compatibility | ❌ No compatibility | ❌ No compatibility | ❌ No compatibility | ❌ No compatibility |
-| DSA | 🟠 Partial compatibility (eager) | ✅ Full compatibility | ✅ Full compatibility | — Not applicable | ❌ No compatibility | ❌ No compatibility | ❌ No compatibility |
+| MLA | ✅ Full compatibility | ✅ Full compatibility | ✅ Full compatibility | ✅ Full compatibility | ❌ No compatibility | ❌ No compatibility | ❌ No compatibility |
+| GQA | ✅ Full compatibility | ✅ Full compatibility | ✅ Full compatibility | — Not applicable | ❌ No compatibility | ❌ No compatibility | ❌ No compatibility |
+| SFA | ✅ Full compatibility | ✅ Full compatibility | ✅ Full compatibility | ❌ No compatibility | ❌ No compatibility | ❌ No compatibility | ❌ No compatibility |
+| DSA | ✅ Full compatibility | ✅ Full compatibility | ✅ Full compatibility | — Not applicable | ❌ No compatibility | ❌ No compatibility | ❌ No compatibility |
 
 - ✅ **Full compatibility**: The basic path or feature combination is supported.
 - 🟠 **Partial compatibility**: The basic path or feature combination is supported with the stated limitations.
-- ❌ **No compatibility**: The backend or feature combination is not supported by the initial MRV2 PCP implementation.
+- ❌ **No compatibility**: The backend or feature combination is not supported by the current MRV2 PCP implementation.
 - **Not applicable**: The feature does not apply to the attention backend.
 
 ### Decode Context Parallel

--- a/tests/e2e/coverage_taxonomy.py
+++ b/tests/e2e/coverage_taxonomy.py
@@ -48,6 +48,7 @@ ALLOWED_VALUES: dict[str, set[str]] = {
         "eagle3",
         "sfa_dsa",
         "sfa_pcp",
+        "dsa_pcp",
         "dsa_cp",
         "prefix_caching",
         "chunked_prefill",

--- a/tests/e2e/pull_request/four_card/context_parallel/test_accuracy_v2.py
+++ b/tests/e2e/pull_request/four_card/context_parallel/test_accuracy_v2.py
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-"""Model Runner V2 SFA DCP and PCP accuracy guards.
+"""Model Runner V2 context-parallel accuracy guards.
 
 Run `pytest tests/e2e/pull_request/four_card/context_parallel/test_accuracy_v2.py`.
 """
@@ -30,19 +30,18 @@ import pytest
 from tests.e2e.conftest import DPVllmRunner, VllmRunner, wait_until_npu_memory_free
 
 MAX_NUM_SEQS = 4
-
 FULL_DECODE_GRAPH = {
     "cudagraph_mode": "FULL_DECODE_ONLY",
     "cudagraph_capture_sizes": [MAX_NUM_SEQS],
 }
 
-COMMON_PROMPTS = [
+DSV3_2_MODEL = "vllm-ascend/DeepSeek-V3.2-W8A8-Pruning"
+DSV3_2_PROMPTS = [
     "The capital of France is",
     "Hello, my name is Tom, I am",
     "The president of United States is",
 ]
-
-DSV3_2_DCP_GOLDENS = (
+DSV3_2_SFA_DCP_GOLDENS = (
     [
         "The capital of France isoint054 Rund compasses",
         "Hello, my name is Tom, I am" + "ERIC slicpacelike挂",
@@ -64,14 +63,21 @@ DSV3_2_DCP_GOLDENS = (
         "The president of United States is平行于我 charm与技术oi",
     ],
 )
-
-DSV3_2_PCP_GOLDEN = [
+DSV3_2_SFA_PCP_GOLDENS = [
     "The capital of France isoint054 Rund compasses",
     "Hello, my name is Tom, I am" + "ERIC slicpacelike\u6302",
     "The president of United States isoint054 Rund959arki",
 ]
 
-MODEL = "vllm-ascend/DeepSeek-V3.2-W8A8-Pruning"
+DSV4_MODEL = "gdydems/DeepSeek-V4-Flash-w4a8-mtp"
+DSV4_PROMPTS = [
+    "Hello, my name is",
+    "What is the meaning of life?",
+]
+DSV4_DSA_PCP_GOLDENS = [
+    "Hello, my name is {name} and I",
+    'What is the meaning of life?",\n    "What is',
+]
 
 
 @dataclass(frozen=True)
@@ -84,11 +90,11 @@ class AccuracyCase:
     runner_kwargs: dict[str, Any]
 
 
-def match_outputs_with_goldens(outputs: list[tuple[list[int], str]], goldens: Sequence[str]) -> None:
+def _match_outputs_with_goldens(outputs: list[tuple[list[int], str]], goldens: Sequence[str]) -> None:
     """Helper function to compare output with golden output, ignoring whitespace differences."""
     outputs_str: Sequence[str] = [output[1] for output in outputs]
     assert len(outputs_str) == len(goldens)
-    for index, (output, golden) in enumerate(zip(outputs_str, goldens)):
+    for output, golden in zip(outputs_str, goldens):
         assert isinstance(output, str) and isinstance(golden, str), "Both output and golden must be strings"
         assert output and golden, "Output and golden should not be empty"
         assert output.strip() == golden.strip()
@@ -101,14 +107,14 @@ def _run_accuracy_case(case: AccuracyCase) -> None:
 
     if isinstance(case.expected_outputs[0], str):
         expected_outputs = cast(Sequence[str], case.expected_outputs)
-        match_outputs_with_goldens(outputs, expected_outputs)
+        _match_outputs_with_goldens(outputs, expected_outputs)
     else:
         # If multiple expected output sets are provided, the output is considered correct if it matches any of the sets.
         multi_expected_outputs = cast(Sequence[Sequence[str]], case.expected_outputs)
         tries = []
         for expected in multi_expected_outputs:
             try:
-                match_outputs_with_goldens(outputs, expected)
+                _match_outputs_with_goldens(outputs, expected)
             except AssertionError as exc:
                 tries.append(f"Output did not match expected set:\n{exc}")
             else:
@@ -118,11 +124,11 @@ def _run_accuracy_case(case: AccuracyCase) -> None:
             raise AssertionError(f"Output did not match any of the expected output sets:\n{failure_details}")
 
 
-FULL_FEATURE_MODEL_CASES = AccuracyCase(
+DSV3_2_SFA_DCP_CASE = AccuracyCase(
     name="dsv3_2_sfa_dcp_replicated_indexer_mrv2_tp2_dcp2",
-    model=MODEL,
-    prompts=COMMON_PROMPTS,
-    expected_outputs=DSV3_2_DCP_GOLDENS,
+    model=DSV3_2_MODEL,
+    prompts=DSV3_2_PROMPTS,
+    expected_outputs=DSV3_2_SFA_DCP_GOLDENS,
     max_tokens=5,
     runner_kwargs={
         "max_model_len": 1024,
@@ -146,11 +152,11 @@ FULL_FEATURE_MODEL_CASES = AccuracyCase(
     },
 )
 
-PCP_MODEL_CASE = AccuracyCase(
+DSV3_2_SFA_PCP_CASE = AccuracyCase(
     name="dsv3_2_sfa_pcp_mrv2_full_decode_only",
-    model=MODEL,
-    prompts=COMMON_PROMPTS,
-    expected_outputs=DSV3_2_PCP_GOLDEN,
+    model=DSV3_2_MODEL,
+    prompts=DSV3_2_PROMPTS,
+    expected_outputs=DSV3_2_SFA_PCP_GOLDENS,
     max_tokens=5,
     runner_kwargs={
         "max_model_len": 1024,
@@ -169,6 +175,32 @@ PCP_MODEL_CASE = AccuracyCase(
     },
 )
 
+DSV4_DSA_PCP_CASE = AccuracyCase(
+    name="dsv4_dsa_pcp_mrv2_full_decode_only",
+    model=DSV4_MODEL,
+    prompts=DSV4_PROMPTS,
+    expected_outputs=DSV4_DSA_PCP_GOLDENS,
+    max_tokens=5,
+    runner_kwargs={
+        "max_model_len": 1024,
+        "max_num_seqs": MAX_NUM_SEQS,
+        "max_num_batched_tokens": 1024,
+        "dtype": "auto",
+        "tensor_parallel_size": 2,
+        "prefill_context_parallel_size": 2,
+        "enable_expert_parallel": True,
+        "gpu_memory_utilization": 0.9,
+        "block_size": 128,
+        "quantization": "ascend",
+        "tokenizer_mode": "deepseek_v4",
+        "compilation_config": FULL_DECODE_GRAPH,
+        "additional_config": {
+            "enable_dsa_cp": False,
+            "enable_prefill_mc2": True,
+        },
+    },
+)
+
 
 @patch.dict(
     os.environ,
@@ -182,10 +214,10 @@ PCP_MODEL_CASE = AccuracyCase(
 @wait_until_npu_memory_free(target_free_percentage=0.8)
 def test_dsv3_2_sfa_dcp_tp2_dcp2_model_runner_v2_accuracy() -> None:
     """Guard MRV2 accuracy."""
-    _run_accuracy_case(FULL_FEATURE_MODEL_CASES)
+    _run_accuracy_case(DSV3_2_SFA_DCP_CASE)
 
 
-@pytest.mark.e2e_model(MODEL)
+@pytest.mark.e2e_model(DSV3_2_MODEL)
 @pytest.mark.e2e_coverage(
     arch="moe",
     feature="sfa_pcp",
@@ -208,4 +240,30 @@ def test_dsv3_2_sfa_dcp_tp2_dcp2_model_runner_v2_accuracy() -> None:
 @wait_until_npu_memory_free(target_free_percentage=0.8)
 def test_dsv3_2_sfa_pcp_model_runner_v2_graph_accuracy() -> None:
     """Guard MRV2 SFA PCP full-decode-only graph accuracy."""
-    _run_accuracy_case(PCP_MODEL_CASE)
+    _run_accuracy_case(DSV3_2_SFA_PCP_CASE)
+
+
+@pytest.mark.e2e_model(DSV4_MODEL)
+@pytest.mark.e2e_coverage(
+    arch="moe",
+    feature="dsa_pcp",
+    parallel="TP,EP,PCP",
+    deploy="pd_mix",
+    hardware="A3",
+    quantization="W4A8",
+    graph_mode="full_decode_only",
+)
+@patch.dict(
+    os.environ,
+    {
+        "VLLM_USE_V2_MODEL_RUNNER": "1",
+        "VLLM_BATCH_INVARIANT": "1",
+        "VLLM_WORKER_MULTIPROC_METHOD": "spawn",
+        "HCCL_BUFFSIZE": "2560",
+        "PYTORCH_NPU_ALLOC_CONF": "expandable_segments:True",
+    },
+)
+@wait_until_npu_memory_free(target_free_percentage=0.8)
+def test_dsv4_dsa_pcp_model_runner_v2_graph_accuracy() -> None:
+    """Guard MRV2 DSA PCP full-decode-only graph accuracy."""
+    _run_accuracy_case(DSV4_DSA_PCP_CASE)

--- a/tests/ut/attention/test_dsa_v1.py
+++ b/tests/ut/attention/test_dsa_v1.py
@@ -20,6 +20,7 @@ from unittest.mock import MagicMock, patch
 import numpy as np
 import pytest
 import torch
+from vllm.v1.attention.backend import AttentionCGSupport
 
 from vllm_ascend.attention.context_parallel.dsa_cp import (
     AscendDSAPCPImpl,
@@ -35,13 +36,17 @@ from vllm_ascend.attention.dsa_v1 import (
     AscendDSAMetadataBuilder,
     AscendDSAReqMetadata,
 )
+from vllm_ascend.attention.utils import AscendCommonAttentionMetadata
 from vllm_ascend.device.device_op import DeviceOperator
 from vllm_ascend.models.deepseek_v4.compressor import AscendCompressorMetadata
 from vllm_ascend.models.deepseek_v4.indexer import (
     AscendIndexerMetadata,
     IndexerOverlapPlan,
 )
-from vllm_ascend.worker.v2.pcp_manager import AscendPCPManager
+from vllm_ascend.worker.v2.pcp_manager import (
+    AscendPCPAttentionContext,
+    AscendPCPManager,
+)
 
 
 def _mock_dsa_kv_plan(**method_returns) -> MagicMock:
@@ -1105,6 +1110,13 @@ def test_dsa_backend_selects_pcp_and_rejects_legacy_cp():
     ):
         assert AscendDSABackend.get_builder_cls() is AscendDSAPCPMetadataBuilder
         assert AscendDSABackend.get_impl_cls() is AscendDSAPCPImpl
+        assert (
+            AscendDSAPCPMetadataBuilder.get_cudagraph_support(
+                cast(Any, None),
+                cast(Any, None),
+            )
+            is AttentionCGSupport.UNIFORM_BATCH
+        )
 
     with (
         patch("vllm_ascend.attention.dsa_v1.enable_pcp", return_value=True),
@@ -1123,6 +1135,7 @@ def test_pcp_metadata_builds_from_manager_global_view():
     builder = AscendDSAPCPMetadataBuilder.__new__(AscendDSAPCPMetadataBuilder)
     builder._pcp_world_size = 2
     builder._pcp_rank = 1
+    builder._hidden_restore_idx_buffer = torch.empty(8, dtype=torch.int64)
     builder.model_config = SimpleNamespace(get_head_size=lambda: 512)
 
     raw_slot_mapping = torch.arange(6, dtype=torch.int64)
@@ -1130,6 +1143,7 @@ def test_pcp_metadata_builds_from_manager_global_view():
     global_batch = SimpleNamespace(
         num_reqs=2,
         num_tokens=5,
+        num_tokens_after_padding=5,
         query_start_loc=torch.tensor([0, 2, 5], dtype=torch.int32),
         query_start_loc_np=np.array([0, 2, 5], dtype=np.int32),
         seq_lens=torch.tensor([4, 7], dtype=torch.int32),
@@ -1140,6 +1154,7 @@ def test_pcp_metadata_builds_from_manager_global_view():
         dcp_local_seq_lens=None,
         positions=torch.arange(5, dtype=torch.int64),
         attn_state=object(),
+        is_dummy=False,
         is_prefilling_np=np.array([True, True]),
         idx_mapping=torch.tensor([0, 1], dtype=torch.int32),
         num_reqs_after_padding=2,
@@ -1151,10 +1166,14 @@ def test_pcp_metadata_builds_from_manager_global_view():
     local_common = SimpleNamespace(
         attn_state="local",
         num_actual_tokens=2,
+        num_input_tokens=3,
+        num_reqs=2,
     )
     common_attn_metadata = SimpleNamespace(
         num_actual_tokens=2,
+        num_input_tokens=3,
         slot_mapping=raw_slot_mapping,
+        block_table_tensor=torch.tensor([[3]], dtype=torch.int32),
         max_seq_len=8,
         causal=True,
         replace=MagicMock(return_value=local_common),
@@ -1167,11 +1186,7 @@ def test_pcp_metadata_builds_from_manager_global_view():
     )
     pcp_manager._global_batch_slot_mappings = global_slot_mappings
     pcp_manager._hidden_restore_idx = hidden_restore_idx
-    pcp_context = pcp_manager.build_attention_context(
-        SimpleNamespace(is_dummy=False, num_tokens_after_padding=3),
-        (),
-        torch.empty(0),
-    )
+    pcp_context = pcp_manager.build_attention_context()
     global_metadata = AscendDSAMetadata(
         num_actual_tokens=5,
         num_decodes=0,
@@ -1200,13 +1215,13 @@ def test_pcp_metadata_builds_from_manager_global_view():
             pcp_context=pcp_context,
             pcp_cache_group_idx=1,
             common_ratio_to_sas_metadata={"local": True},
-            num_actual_reqs=7,
+            num_actual_reqs=2,
         )
 
     assert isinstance(actual, AscendDSAPCPMetadata)
     assert actual.num_actual_tokens == local_metadata.num_actual_tokens
     assert actual.global_dsa_metadata is global_metadata
-    assert actual.hidden_restore_idx is hidden_restore_idx
+    assert torch.equal(actual.hidden_restore_idx, hidden_restore_idx)
     assert actual.local_num_tokens_after_padding == 3
     gather_block_tables.assert_called_once_with(
         global_batch.idx_mapping,
@@ -1215,7 +1230,7 @@ def test_pcp_metadata_builds_from_manager_global_view():
     common_attn_metadata.replace.assert_called_once()
     replace_kwargs = common_attn_metadata.replace.call_args.kwargs
     assert torch.equal(replace_kwargs["slot_mapping"], raw_slot_mapping.view(2, 3)[1])
-    assert replace_kwargs["num_input_tokens"] == 3
+    assert "block_table_tensor" not in replace_kwargs
     global_call = builder._global_metadata_builder.build.call_args
     global_common = global_call.args[1]
     assert global_common.num_actual_tokens == global_batch.num_tokens
@@ -1225,7 +1240,156 @@ def test_pcp_metadata_builds_from_manager_global_view():
     assert global_call.kwargs["num_actual_reqs"] == global_batch.num_reqs
     assert global_call.kwargs["common_ratio_to_sas_metadata"] == {}
     assert build_local.call_args.args[2] is local_common
-    assert build_local.call_args.kwargs["num_actual_reqs"] == 7
+    assert build_local.call_args.kwargs["num_actual_reqs"] == 2
+
+
+@pytest.mark.parametrize("is_dummy", [True, False], ids=["capture", "replay"])
+def test_pcp_graph_metadata_builds_fixed_decode_shape(is_dummy: bool):
+    """Cover the fixed graph metadata contract during capture and replay."""
+    graph_size = 4
+    num_actual_reqs = graph_size if is_dummy else 2
+    num_actual_tokens = num_actual_reqs
+    query_start_loc = (
+        torch.arange(graph_size + 1, dtype=torch.int32)
+        if is_dummy
+        else torch.tensor([0, 1, 2, 2, 2], dtype=torch.int32)
+    )
+    expected_query_start_loc = torch.arange(graph_size + 1, dtype=torch.int32)
+    seq_lens = torch.ones(graph_size, dtype=torch.int32) if is_dummy else torch.tensor([8, 9, 0, 0], dtype=torch.int32)
+
+    builder = AscendDSAPCPMetadataBuilder.__new__(AscendDSAPCPMetadataBuilder)
+    builder._pcp_world_size = 2
+    builder._pcp_rank = 1
+    builder._hidden_restore_idx_buffer = torch.empty(8, dtype=torch.int64)
+    builder.model_config = SimpleNamespace(get_head_size=lambda: 512)
+
+    global_slot_mappings = (
+        torch.tensor([[10, 11, 12, 13]], dtype=torch.int64)
+        if is_dummy
+        else torch.tensor([[10, 11, -1, -1]], dtype=torch.int64)
+    )
+    global_batch = SimpleNamespace(
+        num_reqs=num_actual_reqs,
+        num_reqs_after_padding=graph_size,
+        num_tokens=num_actual_tokens,
+        num_tokens_after_padding=graph_size,
+        query_start_loc=query_start_loc.clone(),
+        query_start_loc_np=query_start_loc.numpy().copy(),
+        seq_lens=seq_lens.clone(),
+        seq_lens_np=seq_lens.numpy().copy(),
+        seq_lens_cpu_upper_bound=seq_lens.clone(),
+        num_computed_tokens_np=np.arange(num_actual_reqs, dtype=np.int32),
+        num_scheduled_tokens=np.ones(num_actual_reqs, dtype=np.int32),
+        dcp_local_seq_lens=None,
+        positions=torch.arange(graph_size, dtype=torch.int64),
+        attn_state="global",
+        is_dummy=is_dummy,
+        is_prefilling_np=np.zeros(num_actual_reqs, dtype=np.bool_),
+    )
+    original_hidden_restore_idx = (
+        torch.tensor([3, 1, 2, 0], dtype=torch.int64) if is_dummy else torch.tensor([1, 0, 7, 6], dtype=torch.int64)
+    )
+    pcp_context = AscendPCPAttentionContext(
+        global_batch=global_batch,
+        global_block_tables=(torch.arange(graph_size, dtype=torch.int32).view(-1, 1),),
+        global_slot_mappings=global_slot_mappings,
+        hidden_restore_idx=original_hidden_restore_idx,
+    )
+
+    local_slot_mapping = (
+        torch.arange(20, 20 + 2 * graph_size, dtype=torch.int64)
+        if is_dummy
+        else torch.tensor([20, 21, -1, -1, 30, 31, -1, -1], dtype=torch.int64)
+    )
+    local_common = AscendCommonAttentionMetadata(
+        query_start_loc=query_start_loc.clone(),
+        query_start_loc_cpu=query_start_loc.clone(),
+        seq_lens=seq_lens.clone(),
+        seq_lens_cpu=seq_lens.clone(),
+        seq_lens_cpu_upper_bound=seq_lens.clone(),
+        num_reqs=graph_size,
+        num_actual_tokens=num_actual_tokens,
+        max_query_len=1,
+        max_seq_len=16,
+        block_table_tensor=torch.zeros((graph_size, 1), dtype=torch.int32),
+        slot_mapping=local_slot_mapping,
+        positions=torch.arange(graph_size, dtype=torch.int64),
+        attn_state="local",
+        num_input_tokens=graph_size,
+        is_prefilling=torch.zeros(graph_size, dtype=torch.bool),
+    )
+    global_metadata = AscendDSAMetadata(
+        num_actual_tokens=num_actual_tokens,
+        num_decodes=graph_size,
+        num_decode_tokens=num_actual_tokens,
+        num_prefills=0,
+    )
+    local_metadata = AscendDSAMetadata(
+        num_actual_tokens=num_actual_tokens,
+        num_decodes=graph_size,
+        num_decode_tokens=num_actual_tokens,
+        num_prefills=0,
+    )
+    builder._global_metadata_builder = SimpleNamespace(
+        build=MagicMock(return_value=global_metadata),
+    )
+    shared_local_metadata = {"local": True}
+
+    with patch.object(
+        AscendDSAMetadataBuilder,
+        "build",
+        autospec=True,
+        return_value=local_metadata,
+    ) as build_local:
+        actual = builder.build(
+            0,
+            local_common,
+            pcp_context=pcp_context,
+            pcp_cache_group_idx=0,
+            num_actual_reqs=num_actual_reqs,
+            common_ratio_to_sas_metadata=shared_local_metadata,
+        )
+
+    expected_global_slots = (
+        torch.full((1, graph_size), -1, dtype=torch.int64)
+        if is_dummy
+        else torch.tensor([[10, 11, -1, -1]], dtype=torch.int64)
+    )
+    expected_local_slots = (
+        torch.full((graph_size,), -1, dtype=torch.int64)
+        if is_dummy
+        else torch.tensor([30, 31, -1, -1], dtype=torch.int64)
+    )
+    expected_restore_idx = original_hidden_restore_idx if is_dummy else torch.tensor([1, 0, 0, 0], dtype=torch.int64)
+
+    assert actual.global_dsa_metadata is global_metadata
+    assert actual.local_num_tokens_after_padding == graph_size
+    assert torch.equal(actual.hidden_restore_idx, expected_restore_idx)
+    assert actual.hidden_restore_idx.data_ptr() == builder._hidden_restore_idx_buffer.data_ptr()
+
+    global_call = builder._global_metadata_builder.build.call_args
+    global_common = global_call.args[1]
+    assert global_common.num_reqs == graph_size
+    assert global_common.num_actual_tokens == num_actual_tokens
+    assert global_common.num_input_tokens == graph_size
+    assert torch.equal(global_common.query_start_loc, expected_query_start_loc)
+    assert torch.equal(global_common.query_start_loc_cpu, expected_query_start_loc)
+    assert torch.equal(global_common.seq_lens, seq_lens)
+    assert torch.equal(global_common.slot_mapping, expected_global_slots[0])
+    assert global_call.kwargs["num_actual_reqs"] == num_actual_reqs
+    assert global_call.kwargs["common_ratio_to_sas_metadata"] == {}
+
+    local_call = build_local.call_args
+    built_local_common = local_call.args[2]
+    assert built_local_common.num_reqs == graph_size
+    assert built_local_common.num_actual_tokens == num_actual_tokens
+    assert built_local_common.num_input_tokens == graph_size
+    assert torch.equal(built_local_common.query_start_loc, expected_query_start_loc)
+    assert torch.equal(built_local_common.query_start_loc_cpu, expected_query_start_loc)
+    assert torch.equal(built_local_common.seq_lens, seq_lens)
+    assert torch.equal(built_local_common.slot_mapping, expected_local_slots)
+    assert local_call.kwargs["num_actual_reqs"] == num_actual_reqs
+    assert local_call.kwargs["common_ratio_to_sas_metadata"] is shared_local_metadata
 
 
 @pytest.mark.parametrize("local_num_actual_tokens", [2, 0], ids=["local_tokens", "empty_rank"])

--- a/tests/ut/worker/test_attn_utils_v2.py
+++ b/tests/ut/worker/test_attn_utils_v2.py
@@ -1,5 +1,6 @@
 from types import SimpleNamespace
 from typing import Any, cast
+from unittest.mock import MagicMock
 
 import numpy as np
 import pytest
@@ -225,6 +226,18 @@ def test_mrv2_initializes_dsv4_cache_only_layer(
 class _RecordingDSAMetadataBuilder(AscendDSAMetadataBuilder):
     def __init__(self, calls: list[dict[str, Any]]):
         self.calls = calls
+        self.for_cudagraph_capture = False
+
+    def build_for_cudagraph_capture(
+        self,
+        common_attn_metadata,
+        **kwargs,
+    ):
+        self.for_cudagraph_capture = True
+        return super().build_for_cudagraph_capture(
+            common_attn_metadata,
+            **kwargs,
+        )
 
     def build(
         self,
@@ -238,6 +251,10 @@ class _RecordingDSAMetadataBuilder(AscendDSAMetadataBuilder):
         call = {
             "common_attn_metadata": common_attn_metadata,
             "common_ratio_to_sas_metadata": self.common_ratio_to_sas_metadata,
+            "for_cudagraph_capture": self.for_cudagraph_capture,
+            "num_actual_reqs": kwargs["num_actual_reqs"],
+            "pcp_context": kwargs.get("pcp_context"),
+            "pcp_cache_group_idx": kwargs.get("pcp_cache_group_idx"),
         }
         assert "block_size" not in kwargs
         self.calls.append(call)
@@ -360,16 +377,25 @@ def test_dsv4_backends_declare_role_specific_logical_sizes(
 
 
 @pytest.mark.parametrize(
-    ("caller", "cudagraph_mode", "expected_input_tokens"),
+    (
+        "caller",
+        "cudagraph_mode",
+        "for_capture",
+        "pcp_size",
+        "expected_input_tokens",
+    ),
     [
-        ("default", None, 5),
-        ("model_state", CUDAGraphMode.NONE, 5),
-        ("model_state", CUDAGraphMode.FULL, 8),
+        ("default", None, False, 1, 5),
+        ("model_state", CUDAGraphMode.NONE, False, 1, 5),
+        ("model_state", CUDAGraphMode.FULL, False, 1, 8),
+        ("pcp_capture", CUDAGraphMode.NONE, True, 2, 8),
     ],
 )
 def test_mrv2_builds_shared_dsa_metadata_for_each_execution_mode(
     caller,
     cudagraph_mode,
+    for_capture,
+    pcp_size,
     expected_input_tokens,
 ):
     layer_names, specs, calls, attn_groups, kv_cache_config = _make_dsa_metadata_groups()
@@ -381,6 +407,14 @@ def test_mrv2_builds_shared_dsa_metadata_for_each_execution_mode(
     dcp_local_seq_lens = torch.tensor(
         [2, 1, 0, 0],
         dtype=torch.int32,
+    )
+    pcp_context = object() if caller == "pcp_capture" else None
+    pcp_manager = (
+        SimpleNamespace(
+            build_attention_context=MagicMock(return_value=pcp_context),
+        )
+        if pcp_context is not None
+        else None
     )
 
     if caller == "default":
@@ -403,7 +437,12 @@ def test_mrv2_builds_shared_dsa_metadata_for_each_execution_mode(
     else:
         model_state = AscendModelState.__new__(AscendModelState)
         model_state.max_model_len = 8
-        model_state.vllm_config = SimpleNamespace(parallel_config=SimpleNamespace(prefill_context_parallel_size=1))
+        model_state.vllm_config = SimpleNamespace(
+            parallel_config=SimpleNamespace(
+                prefill_context_parallel_size=pcp_size,
+            ),
+        )
+        model_state.pcp_manager = pcp_manager
         input_batch = SimpleNamespace(
             num_reqs=2,
             num_reqs_after_padding=4,
@@ -426,6 +465,7 @@ def test_mrv2_builds_shared_dsa_metadata_for_each_execution_mode(
             slot_mappings=slot_mappings,
             attn_groups=attn_groups,
             kv_cache_config=kv_cache_config,
+            for_capture=for_capture,
         )
 
     assert set(metadata) == set(layer_names)
@@ -434,6 +474,9 @@ def test_mrv2_builds_shared_dsa_metadata_for_each_execution_mode(
         common_metadata = call["common_attn_metadata"]
         assert common_metadata.num_actual_tokens == 5
         assert common_metadata.num_input_tokens == expected_input_tokens
+        assert call["for_cudagraph_capture"] is for_capture
+        assert call["num_actual_reqs"] == 2
+        assert call["pcp_context"] is pcp_context
         if caller != "default":
             assert torch.equal(
                 common_metadata.is_prefilling,
@@ -444,6 +487,12 @@ def test_mrv2_builds_shared_dsa_metadata_for_each_execution_mode(
     cache_name = "common_ratio_to_sas_metadata"
     assert calls[0][cache_name] is calls[1][cache_name]
     assert calls[1][cache_name]["first_group"] is True
+    if pcp_context is not None:
+        assert [call["pcp_cache_group_idx"] for call in calls] == [0, 1]
+        assert pcp_manager is not None
+        pcp_manager.build_attention_context.assert_called_once_with()
+    else:
+        assert all(call["pcp_cache_group_idx"] is None for call in calls)
 
 
 class _PrefillStateBuilder:

--- a/tests/ut/worker/test_pcp_manager_v2.py
+++ b/tests/ut/worker/test_pcp_manager_v2.py
@@ -17,7 +17,7 @@
 # This file is a part of the vllm-ascend project.
 #
 from types import SimpleNamespace
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import numpy as np
 import pytest
@@ -246,45 +246,40 @@ def test_partition_batch_refreshes_local_ascend_input_batch_metadata():
     np.testing.assert_array_equal(args[4], result.num_scheduled_tokens)
 
 
-def test_dummy_attention_context_uses_rank_local_identity_view():
+def test_attention_context_collects_global_pcp_data():
     manager = AscendPCPManager.__new__(AscendPCPManager)
-    manager.pcp_world_size = 2
-    manager.pcp_rank = 1
-    manager.device = torch.device("cpu")
     input_batch = _make_local_pcp_batch()
-    input_batch.is_dummy = True
     block_tables = (
         torch.tensor([[1]], dtype=torch.int32),
         torch.tensor([[2]], dtype=torch.int32),
     )
-    slot_mappings = torch.arange(
-        len(block_tables) * manager.pcp_world_size * input_batch.num_tokens,
+    slot_mapping_capacity = input_batch.num_tokens_after_padding + 3
+    global_slot_mappings = torch.arange(
+        len(block_tables) * slot_mapping_capacity,
         dtype=torch.int64,
-    ).view(len(block_tables), -1)
-
-    actual = manager.build_attention_context(
-        input_batch,
-        block_tables,
-        slot_mappings,
+    ).view(len(block_tables), slot_mapping_capacity)
+    gather_block_tables = MagicMock(return_value=block_tables)
+    manager._global_batch = input_batch
+    manager._block_tables = SimpleNamespace(
+        gather_block_tables=gather_block_tables,
     )
+    manager._global_batch_slot_mappings = global_slot_mappings
+    hidden_restore_idx = torch.arange(input_batch.num_tokens, dtype=torch.int64)
+    manager._hidden_restore_idx = hidden_restore_idx
 
-    expected_slot_mappings = slot_mappings.view(
-        len(block_tables),
-        manager.pcp_world_size,
-        input_batch.num_tokens,
-    )[:, manager.pcp_rank]
-    restore_start = manager.pcp_rank * input_batch.num_tokens
+    actual = manager.build_attention_context()
+
     assert actual.global_batch is input_batch
     assert actual.global_block_tables is block_tables
-    assert torch.equal(actual.global_slot_mappings, expected_slot_mappings)
     assert torch.equal(
-        actual.hidden_restore_idx,
-        torch.arange(
-            restore_start,
-            restore_start + input_batch.num_tokens,
-        ),
+        actual.global_slot_mappings,
+        global_slot_mappings[:, : input_batch.num_tokens_after_padding],
     )
-    assert actual.local_num_tokens_after_padding == input_batch.num_tokens
+    assert actual.hidden_restore_idx is hidden_restore_idx
+    gather_block_tables.assert_called_once_with(
+        input_batch.idx_mapping,
+        input_batch.num_reqs_after_padding,
+    )
 
 
 def test_prepare_slot_mappings_pads_each_pcp_rank_for_full_decode_graph() -> None:

--- a/vllm_ascend/attention/context_parallel/dsa_cp.py
+++ b/vllm_ascend/attention/context_parallel/dsa_cp.py
@@ -2042,20 +2042,20 @@ class AscendDSAPCPMetadataBuilder(dsa_v1.AscendDSAMetadataBuilder):
         common_prefix_len: int,
         local_common_attn_metadata: AscendCommonAttentionMetadata,
         fast_build: bool,
-        **kwargs,
+        num_actual_reqs: int | None,
+        common_ratio_to_sas_metadata: dict[Any, Any],
     ) -> dsa_v1.AscendDSAMetadata:
         if local_common_attn_metadata.num_actual_tokens > 0:
             return super().build(
                 common_prefix_len,
                 local_common_attn_metadata,
                 fast_build,
-                **kwargs,
+                num_actual_reqs=num_actual_reqs,
+                common_ratio_to_sas_metadata=common_ratio_to_sas_metadata,
             )
 
         # Empty ranks still participate in the global cache update collectives.
-        self.common_ratio_to_sas_metadata = kwargs.get(
-            "common_ratio_to_sas_metadata",
-        )
+        self.common_ratio_to_sas_metadata = common_ratio_to_sas_metadata
         return self.metadata_cls(  # type: ignore[call-arg]
             num_actual_tokens=0,
             head_dim=self.model_config.get_head_size(),
@@ -2067,25 +2067,6 @@ class AscendDSAPCPMetadataBuilder(dsa_v1.AscendDSAMetadataBuilder):
             hadamard=dsa_v1.AscendDSAMetadataBuilder.hadamard,
         )
 
-    def _build_global_dsa_metadata(
-        self,
-        common_prefix_len: int,
-        global_common_attn_metadata: AscendCommonAttentionMetadata,
-        fast_build: bool,
-        **kwargs,
-    ) -> dsa_v1.AscendDSAMetadata:
-        global_build_kwargs = {
-            **kwargs,
-            "common_ratio_to_sas_metadata": {},
-            "num_actual_reqs": global_common_attn_metadata.num_reqs,
-        }
-        return self._global_metadata_builder.build(
-            common_prefix_len,
-            global_common_attn_metadata,
-            fast_build,
-            **global_build_kwargs,
-        )
-
     def build(
         self,
         common_prefix_len: int,
@@ -2093,20 +2074,24 @@ class AscendDSAPCPMetadataBuilder(dsa_v1.AscendDSAMetadataBuilder):
         fast_build: bool = False,
         pcp_context: "AscendPCPAttentionContext | None" = None,
         pcp_cache_group_idx: int | None = None,
-        **kwargs,
+        num_actual_reqs: int | None = None,
+        common_ratio_to_sas_metadata: dict[Any, Any] | None = None,
+        **kwargs: Any,
     ) -> AscendDSAPCPMetadata:
         assert pcp_context is not None
         assert pcp_cache_group_idx is not None
+        assert common_ratio_to_sas_metadata is not None
         global_common_attn_metadata = self._build_global_common_attn_metadata(
             pcp_context,
             pcp_cache_group_idx,
             common_attn_metadata,
         )
-        global_dsa_metadata = self._build_global_dsa_metadata(
+        global_dsa_metadata = self._global_metadata_builder.build(
             common_prefix_len,
             global_common_attn_metadata,
             fast_build,
-            **kwargs,
+            num_actual_reqs=global_common_attn_metadata.num_reqs,
+            common_ratio_to_sas_metadata={},
         )
         local_common_attn_metadata = self._build_local_common_attn_metadata(
             pcp_context,
@@ -2116,7 +2101,8 @@ class AscendDSAPCPMetadataBuilder(dsa_v1.AscendDSAMetadataBuilder):
             common_prefix_len,
             local_common_attn_metadata,
             fast_build,
-            **kwargs,
+            num_actual_reqs=num_actual_reqs,
+            common_ratio_to_sas_metadata=common_ratio_to_sas_metadata,
         )
         return AscendDSAPCPMetadata.from_local_metadata(
             local_dsa_metadata,

--- a/vllm_ascend/attention/context_parallel/dsa_cp.py
+++ b/vllm_ascend/attention/context_parallel/dsa_cp.py
@@ -1,5 +1,5 @@
 import math
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from typing import TYPE_CHECKING, Any, ClassVar, TypeAlias
 
 import torch
@@ -1983,6 +1983,11 @@ class AscendDSAPCPMetadataBuilder(dsa_v1.AscendDSAMetadataBuilder):
         )
         self._pcp_world_size = vllm_config.parallel_config.prefill_context_parallel_size
         self._pcp_rank = get_pcp_group().rank_in_group
+        self._hidden_restore_idx_buffer = torch.empty(
+            vllm_config.scheduler_config.max_num_batched_tokens,
+            dtype=torch.int64,
+            device=device,
+        )
 
     @classmethod
     def get_cudagraph_support(
@@ -1990,7 +1995,94 @@ class AscendDSAPCPMetadataBuilder(dsa_v1.AscendDSAMetadataBuilder):
         vllm_config: VllmConfig,
         kv_cache_spec: AttentionSpec,
     ) -> AttentionCGSupport:
-        return AttentionCGSupport.NEVER
+        return AttentionCGSupport.UNIFORM_BATCH
+
+    def _prepare_graph_pcp_context(
+        self,
+        pcp_context: "AscendPCPAttentionContext",
+    ) -> "AscendPCPAttentionContext":
+        """Prepare graph-stable DSA tensors without changing the PCP batch layout."""
+        global_batch = pcp_context.global_batch
+        num_actual_tokens = global_batch.num_tokens
+
+        # Use the preallocated buffer to keep the address fixed for graph replay.
+        hidden_restore_idx = self._hidden_restore_idx_buffer[: global_batch.num_tokens_after_padding]
+        hidden_restore_idx[:num_actual_tokens].copy_(pcp_context.hidden_restore_idx[:num_actual_tokens])
+        hidden_restore_idx[num_actual_tokens:].zero_()
+
+        # The upstream dummy path only invalidates gathered slot mappings.
+        # DSA also consumes the scheduler-global mapping, so clear it here.
+        if global_batch.is_dummy:
+            pcp_context.global_slot_mappings.fill_(-1)
+
+        return replace(
+            pcp_context,
+            hidden_restore_idx=hidden_restore_idx,
+        )
+
+    @staticmethod
+    def _build_graph_common_attn_metadata(
+        common_attn_metadata: AscendCommonAttentionMetadata,
+        num_actual_reqs: int | None,
+    ) -> AscendCommonAttentionMetadata:
+        """Restore DSA graph request metadata after PCP partitioning.
+
+        PCP preserves the fixed graph token shape, but represents the padded
+        local rows as zero-token requests. DSA requires the query offsets to
+        cover every decode graph token, so expand the padded query offsets in
+        both the NPU and CPU metadata views. Padded slot mappings are
+        invalidated separately.
+
+        Example: 2 actual requests in a graph batch padded to 4::
+
+            After PCP partition:
+                query_start_loc = [0, 1, 2, 2, 2]
+
+            After DSA restoration:
+                query_start_loc = [0, 1, 2, 3, 4]
+
+        ``num_actual_reqs`` remains 2, and the two padded slot mappings remain
+        invalid.
+        """
+        if num_actual_reqs is None:
+            return common_attn_metadata
+        num_reqs = common_attn_metadata.num_reqs
+        if num_reqs <= num_actual_reqs:
+            return common_attn_metadata
+
+        is_prefilling = common_attn_metadata.is_prefilling
+        if is_prefilling is not None and bool(is_prefilling.any()):
+            return common_attn_metadata
+        if common_attn_metadata.num_input_tokens != num_reqs:
+            raise RuntimeError("DSA PCP full-decode graph requires one input token per request.")
+
+        # Expand NPU and CPU query offsets to cover padded graph tokens.
+        query_start_loc = common_attn_metadata.query_start_loc[: num_reqs + 1]
+        torch.arange(
+            common_attn_metadata.num_actual_tokens + 1,
+            common_attn_metadata.num_input_tokens + 1,
+            dtype=query_start_loc.dtype,
+            device=query_start_loc.device,
+            out=query_start_loc[num_actual_reqs + 1 : num_reqs + 1],
+        )
+        query_start_loc_cpu = torch.empty(
+            num_reqs + 1,
+            dtype=common_attn_metadata.query_start_loc_cpu.dtype,
+        )
+        query_start_loc_cpu[: num_actual_reqs + 1].copy_(
+            common_attn_metadata.query_start_loc_cpu[: num_actual_reqs + 1]
+        )
+        torch.arange(
+            common_attn_metadata.num_actual_tokens + 1,
+            common_attn_metadata.num_input_tokens + 1,
+            dtype=query_start_loc_cpu.dtype,
+            out=query_start_loc_cpu[num_actual_reqs + 1 : num_reqs + 1],
+        )
+
+        return common_attn_metadata.replace(
+            query_start_loc=query_start_loc,
+            query_start_loc_cpu=query_start_loc_cpu,
+        )
 
     @staticmethod
     def _build_global_common_attn_metadata(
@@ -1999,7 +2091,7 @@ class AscendDSAPCPMetadataBuilder(dsa_v1.AscendDSAMetadataBuilder):
         local_common_attn_metadata: AscendCommonAttentionMetadata,
     ) -> AscendCommonAttentionMetadata:
         global_batch = pcp_context.global_batch
-        num_reqs = global_batch.num_reqs
+        num_reqs = global_batch.num_reqs_after_padding
         return AscendCommonAttentionMetadata(
             query_start_loc=global_batch.query_start_loc,
             query_start_loc_cpu=torch.from_numpy(global_batch.query_start_loc_np),
@@ -2017,7 +2109,7 @@ class AscendDSAPCPMetadataBuilder(dsa_v1.AscendDSAMetadataBuilder):
             dcp_local_seq_lens=global_batch.dcp_local_seq_lens,
             positions=global_batch.positions,
             attn_state=global_batch.attn_state,
-            num_input_tokens=global_batch.num_tokens,
+            num_input_tokens=global_batch.num_tokens_after_padding,
             is_prefilling=torch.from_numpy(global_batch.is_prefilling_np),
         )
 
@@ -2026,15 +2118,16 @@ class AscendDSAPCPMetadataBuilder(dsa_v1.AscendDSAMetadataBuilder):
         pcp_context: "AscendPCPAttentionContext",
         common_attn_metadata: AscendCommonAttentionMetadata,
     ) -> AscendCommonAttentionMetadata:
-        num_local_padded_tokens = pcp_context.local_num_tokens_after_padding
+        num_local_padded_tokens = common_attn_metadata.num_input_tokens
         gathered_slot_mapping = common_attn_metadata.slot_mapping
+        if pcp_context.global_batch.is_dummy:
+            gathered_slot_mapping.fill_(-1)
         local_slot_mapping = gathered_slot_mapping.view(
             self._pcp_world_size,
             num_local_padded_tokens,
         )[self._pcp_rank]
         return common_attn_metadata.replace(
             slot_mapping=local_slot_mapping,
-            num_input_tokens=num_local_padded_tokens,
         )
 
     def _build_local_dsa_metadata(
@@ -2081,21 +2174,30 @@ class AscendDSAPCPMetadataBuilder(dsa_v1.AscendDSAMetadataBuilder):
         assert pcp_context is not None
         assert pcp_cache_group_idx is not None
         assert common_ratio_to_sas_metadata is not None
+        pcp_context = self._prepare_graph_pcp_context(pcp_context)
         global_common_attn_metadata = self._build_global_common_attn_metadata(
             pcp_context,
             pcp_cache_group_idx,
             common_attn_metadata,
         )
+        global_common_attn_metadata = self._build_graph_common_attn_metadata(
+            global_common_attn_metadata,
+            pcp_context.global_batch.num_reqs,
+        )
         global_dsa_metadata = self._global_metadata_builder.build(
             common_prefix_len,
             global_common_attn_metadata,
             fast_build,
-            num_actual_reqs=global_common_attn_metadata.num_reqs,
+            num_actual_reqs=pcp_context.global_batch.num_reqs,
             common_ratio_to_sas_metadata={},
         )
         local_common_attn_metadata = self._build_local_common_attn_metadata(
             pcp_context,
             common_attn_metadata,
+        )
+        local_common_attn_metadata = self._build_graph_common_attn_metadata(
+            local_common_attn_metadata,
+            num_actual_reqs,
         )
         local_dsa_metadata = self._build_local_dsa_metadata(
             common_prefix_len,
@@ -2106,7 +2208,7 @@ class AscendDSAPCPMetadataBuilder(dsa_v1.AscendDSAMetadataBuilder):
         )
         return AscendDSAPCPMetadata.from_local_metadata(
             local_dsa_metadata,
-            pcp_context.local_num_tokens_after_padding,
+            local_common_attn_metadata.num_input_tokens,
             pcp_context.hidden_restore_idx,
             global_dsa_metadata,
         )

--- a/vllm_ascend/attention/dsa_v1.py
+++ b/vllm_ascend/attention/dsa_v1.py
@@ -519,13 +519,15 @@ class AscendDSAMetadataBuilder(AttentionMetadataBuilder[AscendDSAMetadata]):
         num_tokens = self.num_actual_tokens
         return min(num_tokens, num_tokens // self.compressor_ratio + num_reqs)
 
-    def build_for_cudagraph_capture(self, common_attn_metadata: AscendCommonAttentionMetadata) -> AscendDSAMetadata:
-        """Delegate to build() because DSA needs shared request metadata."""
+    def build_for_cudagraph_capture(
+        self,
+        common_attn_metadata: AscendCommonAttentionMetadata,
+        **kwargs,
+    ) -> AscendDSAMetadata:
         return self.build(
             common_prefix_len=0,
             common_attn_metadata=common_attn_metadata,
-            num_actual_reqs=common_attn_metadata.num_reqs,
-            common_ratio_to_sas_metadata={},
+            **kwargs,
         )
 
     def build(

--- a/vllm_ascend/worker/v2/attn_utils.py
+++ b/vllm_ascend/worker/v2/attn_utils.py
@@ -269,39 +269,42 @@ def build_attn_metadata(
 
         for attn_group in attn_groups[i]:
             attn_metadata_builder = attn_group.get_metadata_builder(0)
-            if for_cudagraph_capture:
-                # All backends use the capture wrapper; DSA overrides it internally.
-                metadata = attn_metadata_builder.build_for_cudagraph_capture(common_attn_metadata)
-            else:
-                is_dsa_builder = isinstance(attn_metadata_builder, AscendDSAMetadataBuilder)
-                attn_metadata_extra_kwargs = (
-                    model_specific_attn_metadata.get_extra_attn_kwargs(
-                        attn_metadata_builder,
-                        num_reqs,
-                    )
-                    if model_specific_attn_metadata is not None
-                    else {}
+            is_dsa_builder = isinstance(attn_metadata_builder, AscendDSAMetadataBuilder)
+            attn_metadata_extra_kwargs = (
+                model_specific_attn_metadata.get_extra_attn_kwargs(
+                    attn_metadata_builder,
+                    num_reqs,
                 )
-                if is_dsa_builder:
-                    # DSA cache groups share request-level metadata during replay.
+                if not for_cudagraph_capture and model_specific_attn_metadata is not None
+                else {}
+            )
+            if is_dsa_builder:
+                # DSA cache groups share request-level metadata during replay.
+                attn_metadata_extra_kwargs.update(
+                    num_actual_reqs=num_actual_reqs,
+                    common_ratio_to_sas_metadata=common_ratio_to_sas_metadata,
+                )
+                if pcp_context is not None:
                     attn_metadata_extra_kwargs.update(
-                        num_actual_reqs=num_actual_reqs,
-                        common_ratio_to_sas_metadata=common_ratio_to_sas_metadata,
+                        pcp_context=pcp_context,
+                        pcp_cache_group_idx=i,
                     )
-                    if pcp_context is not None:
-                        attn_metadata_extra_kwargs.update(
-                            pcp_context=pcp_context,
-                            pcp_cache_group_idx=i,
-                        )
+
+            if for_cudagraph_capture:
+                metadata = attn_metadata_builder.build_for_cudagraph_capture(
+                    common_attn_metadata,
+                    **attn_metadata_extra_kwargs,
+                )
+            else:
                 metadata = attn_metadata_builder.build(
                     common_prefix_len=0,
                     common_attn_metadata=common_attn_metadata,
                     **attn_metadata_extra_kwargs,
                 )
-                if is_dsa_builder:
-                    # Preserve sharing even if a builder replaces one of the
-                    # dictionaries while constructing its metadata.
-                    common_ratio_to_sas_metadata = attn_metadata_builder.common_ratio_to_sas_metadata  # type: ignore[assignment]
+            if is_dsa_builder:
+                # Preserve sharing even if a builder replaces one of the
+                # dictionaries while constructing its metadata.
+                common_ratio_to_sas_metadata = attn_metadata_builder.common_ratio_to_sas_metadata  # type: ignore[assignment]
             for layer_name in attn_group.layer_names:
                 attn_metadata[layer_name] = metadata
     return attn_metadata

--- a/vllm_ascend/worker/v2/model_states/default.py
+++ b/vllm_ascend/worker/v2/model_states/default.py
@@ -68,15 +68,7 @@ class AscendModelState(DefaultModelState):
         query_start_loc_cpu = torch.from_numpy(input_batch.query_start_loc_np)
         is_prefilling = torch.from_numpy(input_batch.is_prefilling_np)
         max_query_len = input_batch.num_scheduled_tokens.max().item()
-        pcp_context = (
-            self.pcp_manager.build_attention_context(
-                input_batch,
-                block_tables,
-                slot_mappings,
-            )
-            if self.pcp_manager is not None
-            else None
-        )
+        pcp_context = self.pcp_manager.build_attention_context() if self.pcp_manager is not None else None
         # attn_metadata is needed when update_full_graph_params, but no way can get it now.
         # Temporarily store it in model_state.
         self.attn_metadata = build_attn_metadata(

--- a/vllm_ascend/worker/v2/pcp_manager.py
+++ b/vllm_ascend/worker/v2/pcp_manager.py
@@ -36,7 +36,6 @@ class AscendPCPAttentionContext:
     global_block_tables: tuple[torch.Tensor, ...]
     global_slot_mappings: torch.Tensor
     hidden_restore_idx: torch.Tensor
-    local_num_tokens_after_padding: int
 
 
 class AscendPCPManager(PCPManager):
@@ -179,40 +178,20 @@ class AscendPCPManager(PCPManager):
             graph_slot_mappings[:, target_start + local_num_tokens : target_start + graph_num_tokens].fill_(-1)
         return graph_slot_mappings
 
-    def build_attention_context(
-        self,
-        input_batch: AscendInputBatch,
-        block_tables: tuple[torch.Tensor, ...],
-        slot_mappings: torch.Tensor,
-    ) -> AscendPCPAttentionContext:
+    def build_attention_context(self) -> AscendPCPAttentionContext:
         """Build the PCP context consumed by attention metadata builders."""
-        if input_batch.is_dummy:
-            local_num_tokens_after_padding = input_batch.num_tokens
-            restore_start = self.pcp_rank * local_num_tokens_after_padding
-            return AscendPCPAttentionContext(
-                global_batch=input_batch,
-                global_block_tables=block_tables,
-                global_slot_mappings=slot_mappings.view(
-                    slot_mappings.shape[0],
-                    self.pcp_world_size,
-                    local_num_tokens_after_padding,
-                )[:, self.pcp_rank],
-                hidden_restore_idx=torch.arange(
-                    restore_start,
-                    restore_start + local_num_tokens_after_padding,
-                    device=self.device,
-                ),
-                local_num_tokens_after_padding=local_num_tokens_after_padding,
-            )
-
         global_batch = self._global_batch
+        hidden_restore_idx = self._hidden_restore_idx
+        assert global_batch is not None
+        assert self._block_tables is not None
+        assert self._global_batch_slot_mappings is not None
+        assert hidden_restore_idx is not None
         return AscendPCPAttentionContext(
             global_batch=global_batch,
             global_block_tables=self._block_tables.gather_block_tables(
                 global_batch.idx_mapping,
                 global_batch.num_reqs_after_padding,
             ),
-            global_slot_mappings=self._global_batch_slot_mappings[:, : global_batch.num_tokens],
-            hidden_restore_idx=self._hidden_restore_idx,
-            local_num_tokens_after_padding=input_batch.num_tokens_after_padding,
+            global_slot_mappings=self._global_batch_slot_mappings[:, : global_batch.num_tokens_after_padding],
+            hidden_restore_idx=hidden_restore_idx,
         )


### PR DESCRIPTION
### What this PR does / why we need it?

This PR enables `FULL_DECODE_ONLY` ACLGraph execution for DSA PCP in Model Runner V2.

- Builds canonical scheduler-global DSA metadata and rank-local PCP metadata with graph-stable request and token shapes.
- Restores graph-padded `query_start_loc` after PCP partition while preserving zero-length padding requests in `seq_lens`.
- Carries the PCP attention context and shared DSA metadata cache through graph capture and replay.
- Keeps the PCP manager generic and concentrates DSA-specific graph handling in the DSA PCP metadata builder.
- Adds focused unit coverage for PCP context construction, DSA graph metadata lifecycle, and MRV2 graph-capture dispatch.
- Updates the context-parallel compatibility documentation.

### Does this PR introduce _any_ user-facing change?

Yes. Model Runner V2 DSA PCP can now run decode with `FULL_DECODE_ONLY` ACLGraph instead of requiring eager execution.

### How was this patch tested?

Accuracy: GPQA Diamond first 100, concurrency 100, request_rate=0, 0-shot CoT chat, temperature=0, seed=0, max_out_len=3072; five rounds per graph configuration.

| Configuration | Run 1 | Run 2 | Run 3 | Run 4 | Run 5 | Median | Range |
| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| Single graph (TP8, PCP1) | 75.00% | 75.00% | 77.00% | 77.00% | 74.00% | 75.00% | 74.00–77.00% |
| PCP + graph (TP4, PCP2) | 75.00% | 76.00% | 80.00% | 78.00% | 75.00% | 76.00% | 75.00–80.00% |

Performance: 100 requests at concurrency 100, 256-token input content, 256 output tokens, ignore_eos=True; one warmup followed by three formal rounds, reporting formal-round medians.

| Configuration | Request throughput (req/s) | Output throughput (tok/s) | Total throughput (tok/s) | Median TTFT (ms) | Median TPOT (ms) | Median E2EL (ms) |
| --- | ---: | ---: | ---: | ---: | ---: | ---: |
| Single graph (TP8, PCP1) | 1.6178 | 414.1636 | 834.7985 | 6610.7 | 210.0 | 60172.0 |
| PCP eager (TP4, PCP2) | 1.3660 | 349.7022 | 704.8684 | 6897.2 | 224.9 | 63705.1 |
| PCP + graph (TP4, PCP2) | 1.6268 | 416.4667 | 839.4406 | 6547.4 | 208.4 | 59697.1 |

- vLLM main: https://github.com/vllm-project/vllm/commit/ba07e4a48fc951300d97eb506217dd530583dea3
