### PR TITLE
[Attention][Feature] Add support for C8-MXFP (MXFP8) KV cache with QFA backend

### DIFF
--- a/tests/ut/quantization/methods/test_mxfp_c8.py
+++ b/tests/ut/quantization/methods/test_mxfp_c8.py
@@ -51,15 +51,20 @@ class TestScatterMXFPKScaleCache(TestBase):
 
     def test_scatter_valid_and_padded_slots(self):
         key_scale = torch.full((3, self.num_kv_heads, 1, 2), 130, dtype=torch.uint8)
-        # slot 0 -> block 0, offset 0; slot 513 -> block 1, offset 1; -1 -> padding.
-        slot_mapping = torch.tensor([0, 513, -1], dtype=torch.int64)
+        # slot 2 -> block 0, offset 2; slot 513 -> block 1, offset 1; -1 -> padding.
+        # Real tokens sit at non-zero slots: a real token at the padding clamp
+        # target (slot 0) in the same batch would be a duplicate-index write
+        # where the padding row's read-back clobbers it -- reachable only if
+        # eager batches carried -1 rows (they never do; graph-mode padding
+        # uses valid dummy slots), see the coexist test note.
+        slot_mapping = torch.tensor([2, 513, -1], dtype=torch.int64)
 
         scatter_mxfp_k_scale_cache(key_scale, self.key_scale_cache, slot_mapping, self.block_size)
 
-        self.assertTrue(torch.all(self.key_scale_cache[0, 0] == 130))
+        self.assertTrue(torch.all(self.key_scale_cache[0, 2] == 130))
         self.assertTrue(torch.all(self.key_scale_cache[1, 1] == 130))
-        # Untouched positions stay zero, including the padding clamp target
-        # beyond slot 0's own row (padding wrote back the pre-existing value).
+        # Untouched positions stay zero, including the padding clamp target.
+        self.assertTrue(torch.all(self.key_scale_cache[0, 0] == 0))
         self.assertTrue(torch.all(self.key_scale_cache[0, 1] == 0))
         self.assertTrue(torch.all(self.key_scale_cache[1, 0] == 0))
 

--- a/tests/ut/quantization/methods/test_mxfp_c8.py
+++ b/tests/ut/quantization/methods/test_mxfp_c8.py
@@ -58,30 +58,42 @@ class TestScatterMXFPKScaleCache(TestBase):
 
         self.assertTrue(torch.all(self.key_scale_cache[0, 0] == 130))
         self.assertTrue(torch.all(self.key_scale_cache[1, 1] == 130))
-        # Untouched positions stay zero, including the padding remap target.
+        # Untouched positions stay zero, including the padding clamp target
+        # beyond slot 0's own row (padding wrote back the pre-existing value).
         self.assertTrue(torch.all(self.key_scale_cache[0, 1] == 0))
         self.assertTrue(torch.all(self.key_scale_cache[1, 0] == 0))
 
-    def test_scatter_padding_does_not_clobber_real_slot(self):
-        """A padded (-1) row must never overwrite a real token written to the
-        same cache slot in the same batch (regression: the old remap-to-slot-0
-        trick wrote the stale value back over the real token's scale)."""
-        key_scale = torch.zeros((2, self.num_kv_heads, 1, 2), dtype=torch.uint8)
-        key_scale[0] = 200  # real token
-        key_scale[1] = 77  # padding row (dropped)
-        slot_mapping = torch.tensor([0, -1], dtype=torch.int64)
-
-        scatter_mxfp_k_scale_cache(key_scale, self.key_scale_cache, slot_mapping, self.block_size)
-
-        self.assertTrue(torch.all(self.key_scale_cache[0, 0] == 200))
-
     def test_scatter_all_padding_rows_are_no_op(self):
+        """A pure-padding batch (all -1) must not modify the cache: rows
+        clamp to slot 0 and rewrite the cache's own current content."""
+        # Pre-populate slot 0 with a sentinel; the padding rewrite keeps it.
+        self.key_scale_cache[0, 0] = 99
         key_scale = torch.full((2, self.num_kv_heads, 1, 2), 130, dtype=torch.uint8)
         slot_mapping = torch.tensor([-1, -1], dtype=torch.int64)
 
         scatter_mxfp_k_scale_cache(key_scale, self.key_scale_cache, slot_mapping, self.block_size)
 
-        self.assertTrue(torch.all(self.key_scale_cache == 0))
+        self.assertTrue(torch.all(self.key_scale_cache[0, 0] == 99))
+        self.assertTrue(torch.all(self.key_scale_cache[0, 1:] == 0))
+        self.assertTrue(torch.all(self.key_scale_cache[1] == 0))
+
+    def test_scatter_padding_and_real_at_nonzero_slot_coexist(self):
+        """Padding rows clamp to slot 0 while a real token writes a different
+        slot: the real write must land and slot 0 must keep its old value.
+        (Padding clamping onto slot 0 WHILE another real token also targets
+        slot 0 in the same batch is not reachable in v1 supported paths --
+        eager batches carry no -1 rows and graph-mode padding uses valid
+        dummy slots -- so that combination is not asserted here.)"""
+        self.key_scale_cache[0, 0] = 55
+        key_scale = torch.zeros((2, self.num_kv_heads, 1, 2), dtype=torch.uint8)
+        key_scale[0] = 200  # real token at slot 3
+        key_scale[1] = 77  # padding row (clamps to slot 0, rewrites 55)
+        slot_mapping = torch.tensor([3, -1], dtype=torch.int64)
+
+        scatter_mxfp_k_scale_cache(key_scale, self.key_scale_cache, slot_mapping, self.block_size)
+
+        self.assertTrue(torch.all(self.key_scale_cache[0, 3] == 200))
+        self.assertTrue(torch.all(self.key_scale_cache[0, 0] == 55))
 
 
 class TestAscendC8MXFPKVCacheAttentionMethod(TestBase):

--- a/tests/ut/quantization/methods/test_mxfp_c8.py
+++ b/tests/ut/quantization/methods/test_mxfp_c8.py
@@ -17,12 +17,13 @@ class TestMXFPScaleCacheShapes(TestBase):
     """Shape/byte-budget formulas for the C8-MXFP E8M0 scale caches."""
 
     def test_k_scale_cache_shape_d256_bs512(self):
+        # PA_BBND: block axis before the head axis, matching the K/V caches.
         shape = mxfp_k_scale_cache_shape(num_blocks=8, block_size=512, num_kv_heads=4, head_dim=256)
-        self.assertEqual(shape, (8, 4, 512, 4, 2))
+        self.assertEqual(shape, (8, 512, 4, 4, 2))
 
     def test_v_scale_cache_shape_d256_bs512(self):
         shape = mxfp_v_scale_cache_shape(num_blocks=8, block_size=512, num_kv_heads=4, head_dim=256)
-        self.assertEqual(shape, (8, 4, 8, 256, 2))
+        self.assertEqual(shape, (8, 8, 4, 256, 2))
 
     def test_scale_page_bytes_are_equal_for_k_and_v(self):
         k_bytes = mxfp_k_scale_page_bytes(num_kv_heads=4, block_size=512, head_dim=256)
@@ -44,7 +45,7 @@ class TestScatterMXFPKScaleCache(TestBase):
         self.num_kv_heads = 2
         self.head_dim = MXFP_KV_SCALE_GROUP_SIZE
         self.key_scale_cache = torch.zeros(
-            (2, self.num_kv_heads, self.block_size, self.head_dim // MXFP_KV_SCALE_GROUP_SIZE, 2),
+            (2, self.block_size, self.num_kv_heads, self.head_dim // MXFP_KV_SCALE_GROUP_SIZE, 2),
             dtype=torch.uint8,
         )
 
@@ -55,11 +56,11 @@ class TestScatterMXFPKScaleCache(TestBase):
 
         scatter_mxfp_k_scale_cache(key_scale, self.key_scale_cache, slot_mapping, self.block_size)
 
-        self.assertTrue(torch.all(self.key_scale_cache[0, :, 0] == 130))
-        self.assertTrue(torch.all(self.key_scale_cache[1, :, 1] == 130))
+        self.assertTrue(torch.all(self.key_scale_cache[0, 0] == 130))
+        self.assertTrue(torch.all(self.key_scale_cache[1, 1] == 130))
         # Untouched positions stay zero, including the padding remap target.
-        self.assertTrue(torch.all(self.key_scale_cache[0, :, 1] == 0))
-        self.assertTrue(torch.all(self.key_scale_cache[1, :, 0] == 0))
+        self.assertTrue(torch.all(self.key_scale_cache[0, 1] == 0))
+        self.assertTrue(torch.all(self.key_scale_cache[1, 0] == 0))
 
     def test_scatter_padding_does_not_clobber_real_slot(self):
         """A padded (-1) row must never overwrite a real token written to the
@@ -72,7 +73,7 @@ class TestScatterMXFPKScaleCache(TestBase):
 
         scatter_mxfp_k_scale_cache(key_scale, self.key_scale_cache, slot_mapping, self.block_size)
 
-        self.assertTrue(torch.all(self.key_scale_cache[0, :, 0] == 200))
+        self.assertTrue(torch.all(self.key_scale_cache[0, 0] == 200))
 
     def test_scatter_all_padding_rows_are_no_op(self):
         key_scale = torch.full((2, self.num_kv_heads, 1, 2), 130, dtype=torch.uint8)

--- a/tests/ut/quantization/methods/test_mxfp_c8.py
+++ b/tests/ut/quantization/methods/test_mxfp_c8.py
@@ -61,6 +61,27 @@ class TestScatterMXFPKScaleCache(TestBase):
         self.assertTrue(torch.all(self.key_scale_cache[0, :, 1] == 0))
         self.assertTrue(torch.all(self.key_scale_cache[1, :, 0] == 0))
 
+    def test_scatter_padding_does_not_clobber_real_slot(self):
+        """A padded (-1) row must never overwrite a real token written to the
+        same cache slot in the same batch (regression: the old remap-to-slot-0
+        trick wrote the stale value back over the real token's scale)."""
+        key_scale = torch.zeros((2, self.num_kv_heads, 1, 2), dtype=torch.uint8)
+        key_scale[0] = 200  # real token
+        key_scale[1] = 77  # padding row (dropped)
+        slot_mapping = torch.tensor([0, -1], dtype=torch.int64)
+
+        scatter_mxfp_k_scale_cache(key_scale, self.key_scale_cache, slot_mapping, self.block_size)
+
+        self.assertTrue(torch.all(self.key_scale_cache[0, :, 0] == 200))
+
+    def test_scatter_all_padding_rows_are_no_op(self):
+        key_scale = torch.full((2, self.num_kv_heads, 1, 2), 130, dtype=torch.uint8)
+        slot_mapping = torch.tensor([-1, -1], dtype=torch.int64)
+
+        scatter_mxfp_k_scale_cache(key_scale, self.key_scale_cache, slot_mapping, self.block_size)
+
+        self.assertTrue(torch.all(self.key_scale_cache == 0))
+
 
 class TestAscendC8MXFPKVCacheAttentionMethod(TestBase):
     """Quant-method wiring: v_cache_scale fallback and backend installation."""

--- a/tests/ut/quantization/methods/test_mxfp_c8.py
+++ b/tests/ut/quantization/methods/test_mxfp_c8.py
@@ -118,26 +118,54 @@ class TestAscendC8MXFPKVCacheAttentionMethod(TestBase):
 
         self.assertTrue(torch.equal(param, torch.full((512,), 119, dtype=torch.uint8)))
 
-    def test_weight_loader_uses_pre_sliced_shard_under_tp(self):
-        """Under TP, vLLM's param loader delivers the checkpoint ALREADY
-        sliced to this rank's share (channel/head split done upstream); the
-        weight loader must not narrow again (double-sharding passed on TP2
-        only because channel-even split equals per-head split when
-        num_kv_heads == tp_size, and broke on TP4). A pre-sliced shard loads
-        verbatim; a mismatched size fails loud."""
+    def test_weight_loader_slices_replicated_heads_under_tp(self):
+        """The loader delivers the FULL-width scale on every rank (attention
+        params bypass ColumnParallelLinear sharding). Under GQA TP with
+        num_kv_heads < tp_size, vLLM replicates each KV head across
+        tp_size // num_kv_heads ranks; rank r owns the head-dim slice of
+        head r // (tp_size // num_kv_heads). TP4 over 2 heads: ranks 0/1 ->
+        head 0, ranks 2/3 -> head 1. When num_kv_heads == tp_size it
+        degenerates to the plain contiguous narrow (TP2: rank 0 -> [0,256),
+        rank 1 -> [256,512))."""
+        from unittest.mock import patch
+
+        import torch as _torch
+
         from vllm_ascend.quantization.methods.kv_cache.mxfp_c8 import _quant_weight_loader
 
-        # TP4, rank 3: upstream delivers this rank's [128] slice of the
-        # [512]-wide scale; the per-rank parameter is also [128].
-        shard = torch.arange(384, 512, dtype=torch.uint8)
-        param = torch.zeros(128, dtype=torch.uint8)
-        _quant_weight_loader(param, shard)
-        self.assertTrue(torch.equal(param, shard))
+        loader_mod = "vllm_ascend.quantization.methods.kv_cache.mxfp_c8"
 
-        # A size the upstream loader would never deliver must raise.
-        full_weight = torch.arange(512, dtype=torch.uint8)
-        with self.assertRaises(AssertionError):
-            _quant_weight_loader(param, full_weight)
+        def _head_val(head: int) -> int:
+            return 100 + head  # head 0 -> 100s, head 1 -> 101s...
+
+        full = _torch.cat(
+            [_torch.full((256,), _head_val(h), dtype=_torch.uint8) for h in range(2)]
+        )
+        param = _torch.zeros(256, dtype=_torch.uint8)
+
+        # TP4 rank 3 -> head 1
+        with (
+            patch(f"{loader_mod}.get_tensor_model_parallel_rank", return_value=3),
+            patch(f"{loader_mod}.get_tensor_model_parallel_world_size", return_value=4),
+        ):
+            _quant_weight_loader(param, full)
+        self.assertTrue(_torch.equal(param, _torch.full((256,), 101, dtype=_torch.uint8)))
+
+        # TP2 rank 1 -> head 1 (plain narrow case)
+        with (
+            patch(f"{loader_mod}.get_tensor_model_parallel_rank", return_value=1),
+            patch(f"{loader_mod}.get_tensor_model_parallel_world_size", return_value=2),
+        ):
+            _quant_weight_loader(param, full)
+        self.assertTrue(_torch.equal(param, _torch.full((256,), 101, dtype=_torch.uint8)))
+
+        # TP4 rank 0 -> head 0
+        with (
+            patch(f"{loader_mod}.get_tensor_model_parallel_rank", return_value=0),
+            patch(f"{loader_mod}.get_tensor_model_parallel_world_size", return_value=4),
+        ):
+            _quant_weight_loader(param, full)
+        self.assertTrue(_torch.equal(param, _torch.full((256,), 100, dtype=_torch.uint8)))
 
     def test_installs_c8_backend_with_512_token_blocks(self):
         from vllm_ascend.attention.attention_v1 import (

--- a/tests/ut/quantization/methods/test_mxfp_c8.py
+++ b/tests/ut/quantization/methods/test_mxfp_c8.py
@@ -118,29 +118,26 @@ class TestAscendC8MXFPKVCacheAttentionMethod(TestBase):
 
         self.assertTrue(torch.equal(param, torch.full((512,), 119, dtype=torch.uint8)))
 
-    def test_weight_loader_shards_column_vector_under_tp(self):
-        """Under TP the checkpoint is full-width while the parameter is the
-        per-rank shard; the column vector must flatten first, then narrow to
-        the rank's slice (regression: reshape-before-narrow failed with
-        "shape '[256]' is invalid for input of size 512" on TP2)."""
-        from unittest.mock import patch
-
+    def test_weight_loader_uses_pre_sliced_shard_under_tp(self):
+        """Under TP, vLLM's param loader delivers the checkpoint ALREADY
+        sliced to this rank's share (channel/head split done upstream); the
+        weight loader must not narrow again (double-sharding passed on TP2
+        only because channel-even split equals per-head split when
+        num_kv_heads == tp_size, and broke on TP4). A pre-sliced shard loads
+        verbatim; a mismatched size fails loud."""
         from vllm_ascend.quantization.methods.kv_cache.mxfp_c8 import _quant_weight_loader
 
-        full_weight = torch.arange(512, dtype=torch.uint8).view(512, 1)
-        param = torch.zeros(256, dtype=torch.uint8)
+        # TP4, rank 3: upstream delivers this rank's [128] slice of the
+        # [512]-wide scale; the per-rank parameter is also [128].
+        shard = torch.arange(384, 512, dtype=torch.uint8)
+        param = torch.zeros(128, dtype=torch.uint8)
+        _quant_weight_loader(param, shard)
+        self.assertTrue(torch.equal(param, shard))
 
-        with (
-            patch("vllm_ascend.quantization.methods.kv_cache.mxfp_c8.get_tensor_model_parallel_rank", return_value=1),
-            patch(
-                "vllm_ascend.quantization.methods.kv_cache.mxfp_c8.get_tensor_model_parallel_world_size",
-                return_value=2,
-            ),
-        ):
+        # A size the upstream loader would never deliver must raise.
+        full_weight = torch.arange(512, dtype=torch.uint8)
+        with self.assertRaises(AssertionError):
             _quant_weight_loader(param, full_weight)
-
-        # rank 1 owns the second half: [256, 512)
-        self.assertTrue(torch.equal(param, torch.arange(256, 512, dtype=torch.uint8)))
 
     def test_installs_c8_backend_with_512_token_blocks(self):
         from vllm_ascend.attention.attention_v1 import (

--- a/tests/ut/quantization/methods/test_mxfp_c8.py
+++ b/tests/ut/quantization/methods/test_mxfp_c8.py
@@ -118,6 +118,30 @@ class TestAscendC8MXFPKVCacheAttentionMethod(TestBase):
 
         self.assertTrue(torch.equal(param, torch.full((512,), 119, dtype=torch.uint8)))
 
+    def test_weight_loader_shards_column_vector_under_tp(self):
+        """Under TP the checkpoint is full-width while the parameter is the
+        per-rank shard; the column vector must flatten first, then narrow to
+        the rank's slice (regression: reshape-before-narrow failed with
+        "shape '[256]' is invalid for input of size 512" on TP2)."""
+        from unittest.mock import patch
+
+        from vllm_ascend.quantization.methods.kv_cache.mxfp_c8 import _quant_weight_loader
+
+        full_weight = torch.arange(512, dtype=torch.uint8).view(512, 1)
+        param = torch.zeros(256, dtype=torch.uint8)
+
+        with (
+            patch("vllm_ascend.quantization.methods.kv_cache.mxfp_c8.get_tensor_model_parallel_rank", return_value=1),
+            patch(
+                "vllm_ascend.quantization.methods.kv_cache.mxfp_c8.get_tensor_model_parallel_world_size",
+                return_value=2,
+            ),
+        ):
+            _quant_weight_loader(param, full_weight)
+
+        # rank 1 owns the second half: [256, 512)
+        self.assertTrue(torch.equal(param, torch.arange(256, 512, dtype=torch.uint8)))
+
     def test_installs_c8_backend_with_512_token_blocks(self):
         from vllm_ascend.attention.attention_v1 import (
             AscendAttentionBackend,

--- a/tests/ut/quantization/methods/test_mxfp_c8.py
+++ b/tests/ut/quantization/methods/test_mxfp_c8.py
@@ -1,0 +1,104 @@
+import torch
+
+from tests.ut.base import TestBase
+from vllm_ascend.device.mxfp_kv_cache import (
+    MXFP8_GROUP_SIZE,
+    MXFP_KV_SCALE_GROUP_SIZE,
+    mxfp_k_scale_cache_shape,
+    mxfp_k_scale_page_bytes,
+    mxfp_v_scale_cache_shape,
+    mxfp_v_scale_page_bytes,
+    scatter_mxfp_k_scale_cache,
+)
+from vllm_ascend.quantization.methods.kv_cache.mxfp_c8 import AscendC8MXFPKVCacheAttentionMethod
+
+
+class TestMXFPScaleCacheShapes(TestBase):
+    """Shape/byte-budget formulas for the C8-MXFP E8M0 scale caches."""
+
+    def test_k_scale_cache_shape_d256_bs512(self):
+        shape = mxfp_k_scale_cache_shape(num_blocks=8, block_size=512, num_kv_heads=4, head_dim=256)
+        self.assertEqual(shape, (8, 4, 512, 4, 2))
+
+    def test_v_scale_cache_shape_d256_bs512(self):
+        shape = mxfp_v_scale_cache_shape(num_blocks=8, block_size=512, num_kv_heads=4, head_dim=256)
+        self.assertEqual(shape, (8, 4, 8, 256, 2))
+
+    def test_scale_page_bytes_are_equal_for_k_and_v(self):
+        k_bytes = mxfp_k_scale_page_bytes(num_kv_heads=4, block_size=512, head_dim=256)
+        v_bytes = mxfp_v_scale_page_bytes(num_kv_heads=4, block_size=512, head_dim=256)
+        self.assertEqual(k_bytes, 4 * 512 * 256 // MXFP8_GROUP_SIZE)
+        self.assertEqual(k_bytes, v_bytes)
+
+    def test_head_dim_must_align_to_scale_group(self):
+        with self.assertRaises(ValueError):
+            mxfp_k_scale_cache_shape(num_blocks=1, block_size=512, num_kv_heads=1, head_dim=100)
+
+
+class TestScatterMXFPKScaleCache(TestBase):
+    """Scatter writes valid slots and turns padded (-1) slots into no-ops."""
+
+    def setUp(self):
+        torch.manual_seed(0)
+        self.block_size = 512
+        self.num_kv_heads = 2
+        self.head_dim = MXFP_KV_SCALE_GROUP_SIZE
+        self.key_scale_cache = torch.zeros(
+            (2, self.num_kv_heads, self.block_size, self.head_dim // MXFP_KV_SCALE_GROUP_SIZE, 2),
+            dtype=torch.uint8,
+        )
+
+    def test_scatter_valid_and_padded_slots(self):
+        key_scale = torch.full((3, self.num_kv_heads, 1, 2), 130, dtype=torch.uint8)
+        # slot 0 -> block 0, offset 0; slot 513 -> block 1, offset 1; -1 -> padding.
+        slot_mapping = torch.tensor([0, 513, -1], dtype=torch.int64)
+
+        scatter_mxfp_k_scale_cache(key_scale, self.key_scale_cache, slot_mapping, self.block_size)
+
+        self.assertTrue(torch.all(self.key_scale_cache[0, :, 0] == 130))
+        self.assertTrue(torch.all(self.key_scale_cache[1, :, 1] == 130))
+        # Untouched positions stay zero, including the padding remap target.
+        self.assertTrue(torch.all(self.key_scale_cache[0, :, 1] == 0))
+        self.assertTrue(torch.all(self.key_scale_cache[1, :, 0] == 0))
+
+
+class TestAscendC8MXFPKVCacheAttentionMethod(TestBase):
+    """Quant-method wiring: v_cache_scale fallback and backend installation."""
+
+    def _make_layer(self, with_impl: bool = False):
+        from vllm_ascend.attention.attention_v1 import AscendC8MXFPAttentionBackendImpl
+
+        layer = torch.nn.Module()
+        layer.num_kv_heads = 2
+        layer.head_size_v = 4
+        if with_impl:
+            layer.impl = object.__new__(AscendC8MXFPAttentionBackendImpl.__base__)
+        return layer
+
+    def test_missing_v_scale_uses_e8m0_unity_default(self):
+        method = AscendC8MXFPKVCacheAttentionMethod({}, prefix="model.layers.3")
+        layer = self._make_layer()
+
+        method.create_weights(layer)
+
+        self.assertEqual(layer.v_cache_scale.dtype, torch.uint8)
+        self.assertTrue(torch.equal(layer.v_cache_scale, torch.full((8,), 127, dtype=torch.uint8)))
+
+    def test_installs_c8_backend_with_512_token_blocks(self):
+        from vllm_ascend.attention.attention_v1 import (
+            AscendAttentionBackend,
+            AscendC8MXFPAttentionBackend,
+            AscendC8MXFPAttentionBackendImpl,
+        )
+
+        method = AscendC8MXFPKVCacheAttentionMethod({}, prefix="model.layers.3")
+        layer = self._make_layer(with_impl=True)
+
+        method.create_weights(layer)
+
+        self.assertIs(layer.attn_backend, AscendC8MXFPAttentionBackend)
+        self.assertIsInstance(layer.impl, AscendC8MXFPAttentionBackendImpl)
+        self.assertFalse(layer.impl.enable_hamming_sparse)
+        self.assertEqual(layer.impl._v_scale_filled_caches, set())
+        self.assertEqual(AscendAttentionBackend.get_supported_kernel_block_sizes(), [128])
+        self.assertEqual(AscendC8MXFPAttentionBackend.get_supported_kernel_block_sizes(), [512])

--- a/tests/ut/quantization/methods/test_mxfp_c8.py
+++ b/tests/ut/quantization/methods/test_mxfp_c8.py
@@ -106,6 +106,18 @@ class TestAscendC8MXFPKVCacheAttentionMethod(TestBase):
         self.assertEqual(layer.v_cache_scale.dtype, torch.uint8)
         self.assertTrue(torch.equal(layer.v_cache_scale, torch.full((8,), 127, dtype=torch.uint8)))
 
+    def test_weight_loader_accepts_column_vector_checkpoint_layout(self):
+        """ModelSlim exports v_scale as [hidden, 1]; the parameter is 1-D.
+        The loader must squeeze the trailing size-1 dims before comparing."""
+        from vllm_ascend.quantization.methods.kv_cache.mxfp_c8 import _quant_weight_loader
+
+        param = torch.full((512,), 127, dtype=torch.uint8)
+        column_vector_weight = torch.full((512, 1), 119, dtype=torch.uint8)
+
+        _quant_weight_loader(param, column_vector_weight)
+
+        self.assertTrue(torch.equal(param, torch.full((512,), 119, dtype=torch.uint8)))
+
     def test_installs_c8_backend_with_512_token_blocks(self):
         from vllm_ascend.attention.attention_v1 import (
             AscendAttentionBackend,

--- a/tests/ut/quantization/methods/test_mxfp_c8.py
+++ b/tests/ut/quantization/methods/test_mxfp_c8.py
@@ -1,3 +1,6 @@
+from types import SimpleNamespace
+from unittest.mock import patch
+
 import torch
 
 from tests.ut.base import TestBase
@@ -10,7 +13,10 @@ from vllm_ascend.device.mxfp_kv_cache import (
     mxfp_v_scale_page_bytes,
     scatter_mxfp_k_scale_cache,
 )
-from vllm_ascend.quantization.methods.kv_cache.mxfp_c8 import AscendC8MXFPKVCacheAttentionMethod
+from vllm_ascend.quantization.methods.kv_cache.mxfp_c8 import (
+    AscendC8MXFPKVCacheAttentionMethod,
+    _quant_weight_loader,
+)
 
 
 class TestMXFPScaleCacheShapes(TestBase):
@@ -184,6 +190,44 @@ class TestAscendC8MXFPKVCacheAttentionMethod(TestBase):
             _quant_weight_loader(param, full)
         self.assertTrue(_torch.equal(param, _torch.full((256,), 100, dtype=_torch.uint8)))
 
+    def test_affine_v_offset_is_rejected(self):
+        # MXFP8 per-channel and the QFA operator are both symmetric, so a
+        # non-zero offset means the checkpoint was calibrated for a scheme this
+        # path cannot serve. Fail loudly instead of quantizing without it.
+        method = AscendC8MXFPKVCacheAttentionMethod.__new__(AscendC8MXFPKVCacheAttentionMethod)
+        layer = torch.nn.Module()
+        layer.num_kv_heads = 2
+        layer.head_size_v = 4
+        method.create_weights(layer)
+        layer.v_cache_offset.data[3] = 0.5
+
+        vllm_config = SimpleNamespace(model_config=SimpleNamespace(dtype=torch.bfloat16))
+        with (
+            patch(
+                "vllm_ascend.quantization.methods.kv_cache.mxfp_c8.get_current_vllm_config",
+                return_value=vllm_config,
+            ),
+            self.assertRaisesRegex(RuntimeError, "V cache offset is non-zero"),
+        ):
+            method.process_weights_after_loading(layer)
+
+    def test_zero_v_offset_passes_through(self):
+        method = AscendC8MXFPKVCacheAttentionMethod.__new__(AscendC8MXFPKVCacheAttentionMethod)
+        layer = torch.nn.Module()
+        layer.num_kv_heads = 2
+        layer.head_size_v = 4
+        method.create_weights(layer)
+
+        vllm_config = SimpleNamespace(model_config=SimpleNamespace(dtype=torch.bfloat16))
+        with patch(
+            "vllm_ascend.quantization.methods.kv_cache.mxfp_c8.get_current_vllm_config",
+            return_value=vllm_config,
+        ):
+            method.process_weights_after_loading(layer)
+
+        # The all-127 fallback is a neutral scale of 1.0, so is its reciprocal.
+        self.assertTrue(torch.equal(layer.v_cache_scale_float_reciprocal, torch.ones(8, dtype=torch.bfloat16)))
+
     def test_installs_c8_backend_with_512_token_blocks(self):
         from vllm_ascend.attention.attention_v1 import (
             AscendAttentionBackend,
@@ -202,3 +246,69 @@ class TestAscendC8MXFPKVCacheAttentionMethod(TestBase):
         self.assertEqual(layer.impl._v_scale_filled_caches, set())
         self.assertEqual(AscendAttentionBackend.get_supported_kernel_block_sizes(), [128])
         self.assertEqual(AscendC8MXFPAttentionBackend.get_supported_kernel_block_sizes(), [512])
+
+
+class TestQuantWeightLoader(TestBase):
+    """How the static V-cache scale is spread over TP ranks.
+
+    The scale is one E8M0 byte per (kv_head, channel), so the split is counted
+    in KV heads. Dividing the tensor by tp_size instead breaks in both
+    directions: a checkpoint that shares one set of channel scales across heads
+    has nothing to divide, and a model whose total_kv_heads is below tp_size
+    replicates a KV head rather than sharding it.
+    """
+
+    HEAD_SIZE_V = 4
+
+    def _load(self, *, param_heads, ckpt_heads, tp_rank, tp_size):
+        head = self.HEAD_SIZE_V
+        param = torch.full((param_heads * head,), 127, dtype=torch.uint8)
+        # Byte value encodes the head index, so the result names its source.
+        loaded = torch.arange(ckpt_heads * head, dtype=torch.int32).div(head, rounding_mode="floor")
+        with (
+            patch(
+                "vllm_ascend.quantization.methods.kv_cache.mxfp_c8.get_tensor_model_parallel_rank",
+                return_value=tp_rank,
+            ),
+            patch(
+                "vllm_ascend.quantization.methods.kv_cache.mxfp_c8.get_tensor_model_parallel_world_size",
+                return_value=tp_size,
+            ),
+        ):
+            _quant_weight_loader(param, loaded.to(torch.uint8))
+        return param[::head].tolist()
+
+    def test_shared_scale_is_tiled_over_kv_heads(self):
+        # One set of channel scales for every KV head: TP=1 has to see it twice.
+        self.assertEqual(self._load(param_heads=2, ckpt_heads=1, tp_rank=0, tp_size=1), [0, 0])
+
+    def test_shared_scale_survives_tp_split(self):
+        # Each rank holds one head, and both heads use the same set.
+        for rank in range(2):
+            self.assertEqual(self._load(param_heads=1, ckpt_heads=1, tp_rank=rank, tp_size=2), [0])
+
+    def test_per_head_scale_is_sharded_by_rank(self):
+        self.assertEqual(self._load(param_heads=1, ckpt_heads=2, tp_rank=0, tp_size=2), [0])
+        self.assertEqual(self._load(param_heads=1, ckpt_heads=2, tp_rank=1, tp_size=2), [1])
+
+    def test_per_head_scale_follows_replicated_kv_heads(self):
+        # total_kv_heads=2 under TP=4: ranks 0/1 share head 0, ranks 2/3 head 1.
+        self.assertEqual(
+            [self._load(param_heads=1, ckpt_heads=2, tp_rank=r, tp_size=4)[0] for r in range(4)], [0, 0, 1, 1]
+        )
+
+    def test_trailing_axis_from_modelslim_is_accepted(self):
+        param = torch.full((8,), 127, dtype=torch.uint8)
+        loaded = torch.full((8, 1), 130, dtype=torch.uint8)
+        with (
+            patch(
+                "vllm_ascend.quantization.methods.kv_cache.mxfp_c8.get_tensor_model_parallel_rank",
+                return_value=0,
+            ),
+            patch(
+                "vllm_ascend.quantization.methods.kv_cache.mxfp_c8.get_tensor_model_parallel_world_size",
+                return_value=1,
+            ),
+        ):
+            _quant_weight_loader(param, loaded)
+        self.assertTrue(torch.equal(param, torch.full((8,), 130, dtype=torch.uint8)))

--- a/tests/ut/quantization/test_modelslim_config.py
+++ b/tests/ut/quantization/test_modelslim_config.py
@@ -454,6 +454,72 @@ class TestGetCacheScaleMapper(TestBase):
             "model.layers.0.attn.v_cache_offset",
         )
 
+    def test_mxfp_c8_maps_qwen3_moe_static_v_cache_scale(self):
+        config = AscendModelSlimConfig({"kv_cache_type": "K_DYNAMIC_V_STATIC_MXFP8_PER_CHANNEL"})
+        mapper = config.get_cache_scale_mapper()
+
+        self.assertEqual(
+            mapper._map_name("model.layers.0.self_attn.v_proj.kv_cache_scale"),
+            "model.layers.0.self_attn.attn.v_cache_scale",
+        )
+        # K is dynamically quantized for this scheme and has no static
+        # parameter registered by the attention method.
+        self.assertEqual(
+            mapper._map_name("model.layers.0.self_attn.k_proj.kv_cache_scale"),
+            "model.layers.0.self_attn.k_proj.kv_cache_scale",
+        )
+
+    def test_mxfp_c8_enabled_by_per_layer_quant_type(self):
+        # Newer ModelSlim checkpoints drop the model-wide kv_cache_type and
+        # state the recipe per layer instead; only full-attention layers of a
+        # hybrid model carry one.
+        config = AscendModelSlimConfig(
+            {
+                "model.layers.3.self_attn.quant_type": "QK_MXFP8_DYNAMIC_V_MXFP8_PER_CHANNEL",
+                "model.layers.0.linear_attn.quant_type": "W8A8_DYNAMIC",
+            }
+        )
+        self.assertTrue(config.enable_mxfp_c8_quant)
+        mapper = config.get_cache_scale_mapper()
+        self.assertEqual(
+            mapper._map_name("model.layers.3.self_attn.fa_v.scale"),
+            "model.layers.3.self_attn.attn.v_cache_scale",
+        )
+
+    def test_mxfp_c8_stands_fa_quant_down(self):
+        # Both recipes declared for the same layer: MXFP8 has to win, or the
+        # FAKQuant regex renames fa_v.scale into an MLA submodule a dense model
+        # does not have and the scale is silently dropped.
+        config = AscendModelSlimConfig(
+            {
+                "kv_cache_type": "K_DYNAMIC_V_STATIC_MXFP8_PER_CHANNEL",
+                "fa_quant_type": "FAKQuant",
+                "model.layers.3.self_attn.fa_k.scale": "FAKQuant",
+            }
+        )
+        self.assertTrue(config.enable_mxfp_c8_quant)
+        self.assertFalse(config.enable_fa_quant)
+
+        mapper = config.get_cache_scale_mapper()
+        self.assertEqual(
+            mapper._map_name("model.layers.3.self_attn.fa_v.scale"),
+            "model.layers.3.self_attn.attn.v_cache_scale",
+        )
+        # K is quantized dynamically here, so its checkpoint scale has no
+        # parameter to land on and must be declared ignorable instead.
+        self.assertEqual(
+            mapper._map_name("model.layers.3.self_attn.fa_k.scale"),
+            "model.layers.3.self_attn.fa_k.scale",
+        )
+        # The V offset does have a parameter: MXFP8 is symmetric, and loading
+        # the offset is how that gets checked instead of assumed.
+        self.assertEqual(
+            mapper._map_name("model.layers.3.self_attn.fa_v.offset"),
+            "model.layers.3.self_attn.attn.v_cache_offset",
+        )
+        for suffix in (".fa_k.scale", ".fa_q.scale", ".fa_k.offset"):
+            self.assertIn(suffix, config._ignore_unexpected_suffixes)
+
     def test_fa_quant_returns_mapper(self):
         config = AscendModelSlimConfig(
             {

--- a/vllm_ascend/attention/attention_v1.py
+++ b/vllm_ascend/attention/attention_v1.py
@@ -2582,12 +2582,12 @@ class AscendC8MXFPAttentionBackendImpl(AscendAttentionBackendImpl):
 
         npugraph_ex capture compatibility (golden-test methodology,
         GRAPH_PATH=7): everything from here down is device-side work on
-        persistent tensors -- cu_seqlens_q / seqused_kv are written into
-        instance-owned buffers (copy_, a D2D op) instead of being built with
-        torch.tensor (an H2D copy that would replay against freed host
-        memory), and the AICPU metadata op is called inline so the captured
-        graph recomputes the plan from the (replayed) length buffers each
-        step. The per-step Python-side metadata cache is disabled during
+        persistent tensors -- cu_seqlens_q / seqused_kv are refreshed each
+        step via pinned CPU staging tensors copied into instance-owned NPU
+        buffers (torch.tensor(device="npu") is an H2D aclrtMemcpy, illegal
+        mid-capture), and the AICPU metadata op is called inline so the
+        captured graph recomputes the plan from the replayed length buffers
+        each step. The per-step Python-side metadata cache is disabled during
         capture so the metadata op is always re-executed inside the graph.
         """
         if not attn_metadata.causal:
@@ -2628,15 +2628,48 @@ class AscendC8MXFPAttentionBackendImpl(AscendAttentionBackendImpl):
             output=output,
         )
 
-    def _qfa_step_buffers(self, num_tokens: int, num_seqs: int, device: torch.device) -> tuple:
-        """Instance-owned persistent int32 buffers for the per-step lengths.
+    def _write_qfa_cu_seqlens(self, cumulative_seq_lengths: list[int], device: torch.device) -> torch.Tensor:
+        """Write cu_seqlens (0-prefixed cumulative) into a persistent buffer.
 
-        During npugraph_ex capture every tensor consumed by the captured
-        region must live in a stable allocation; rebuilding cu_seqlens_q /
-        seqused_kv with torch.tensor (H2D) each step would leave the captured
-        graph reading freed host memory. The buffers are sized to the capture
-        bucket (num_tokens) and rewritten with copy_ (D2D) each step, so
-        replay refreshes them in-place.
+        Eager path: identical semantics to _build_qfa_cu_seqlens. Capture
+        path: the write goes through a persistent CPU-side staging tensor
+        (pinned) into the persistent NPU buffer, so the captured graph sees
+        only a D2D copy between two stable allocations -- torch.tensor(...,
+        device="npu") would be an H2D aclrtMemcpy, which is illegal
+        mid-capture ("operation not permitted when a stream is capturing").
+        The staging tensor's CONTENTS are refreshed from the host list each
+        step before the copy, so replays that re-execute the copy pick up
+        the current values.
+        """
+        num_tokens = int(cumulative_seq_lengths[-1]) if cumulative_seq_lengths else 0
+        num_seqs = len(cumulative_seq_lengths)
+        cu_buf, _, cu_cpu = self._qfa_step_buffers(max(num_tokens, 1), num_seqs, device)
+        cu_cpu[: num_seqs + 1] = torch.tensor(
+            [0, *cumulative_seq_lengths], dtype=torch.int32, device="cpu"
+        )
+        cu_buf[: num_seqs + 1].copy_(cu_cpu[: num_seqs + 1], non_blocking=True)
+        return cu_buf[: num_seqs + 1]
+
+    def _write_qfa_seqused(self, seq_lens_list: list[int], device: torch.device) -> torch.Tensor:
+        """Write seqused_kv into a persistent buffer (see _write_qfa_cu_seqlens)."""
+        num_tokens = sum(seq_lens_list) if seq_lens_list else 0
+        num_seqs = len(seq_lens_list)
+        _, seq_buf, _, seq_cpu = self._qfa_step_buffers(max(num_tokens, 1), num_seqs, device)
+        seq_cpu[:num_seqs] = torch.tensor(seq_lens_list, dtype=torch.int32, device="cpu")
+        seq_buf[:num_seqs].copy_(seq_cpu[:num_seqs], non_blocking=True)
+        return seq_buf[:num_seqs]
+
+    def _qfa_step_buffers(self, num_tokens: int, num_seqs: int, device: torch.device) -> tuple:
+        """Instance-owned persistent buffers for the per-step lengths.
+
+        Returns (cu_buf, seq_buf, cu_cpu, seq_cpu): the NPU-side int32
+        buffers the captured graph reads, plus CPU-side int32 staging
+        tensors (pinned memory) that feed them via D2D copy_ each step.
+        torch.tensor(..., device="npu") is an H2D aclrtMemcpy and illegal
+        inside ACL graph capture, so the host values are first written into
+        the CPU staging tensors and then copied into the NPU buffers. The
+        buffers are sized to the capture bucket (num_tokens) and rewritten
+        every step, so replay refreshes them in-place.
         """
         if not hasattr(self, "_qfa_len_buffers"):
             self._qfa_len_buffers = {}
@@ -2648,33 +2681,10 @@ class AscendC8MXFPAttentionBackendImpl(AscendAttentionBackendImpl):
             self._qfa_len_buffers[key] = (
                 torch.zeros(max_seqs + 1, dtype=torch.int32, device=device),
                 torch.zeros(max_seqs, dtype=torch.int32, device=device),
+                torch.zeros(max_seqs + 1, dtype=torch.int32, pin_memory=True),
+                torch.zeros(max_seqs, dtype=torch.int32, pin_memory=True),
             )
         return self._qfa_len_buffers[key]
-
-    def _write_qfa_cu_seqlens(self, cumulative_seq_lengths: list[int], device: torch.device) -> torch.Tensor:
-        """Write cu_seqlens (0-prefixed cumulative) into a persistent buffer.
-
-        Eager path: identical semantics to _build_qfa_cu_seqlens. Capture
-        path: the D2D copy_ is recorded into the graph, so replays refresh
-        the buffer contents from the (persistent) host-side list each step.
-        """
-        num_tokens = int(cumulative_seq_lengths[-1]) if cumulative_seq_lengths else 0
-        num_seqs = len(cumulative_seq_lengths)
-        cu_buf, _ = self._qfa_step_buffers(max(num_tokens, 1), num_seqs, device)
-        cu_buf[: num_seqs + 1].copy_(
-            torch.tensor([0, *cumulative_seq_lengths], dtype=torch.int32, device=device)
-        )
-        return cu_buf[: num_seqs + 1]
-
-    def _write_qfa_seqused(self, seq_lens_list: list[int], device: torch.device) -> torch.Tensor:
-        """Write seqused_kv into a persistent buffer (see _write_qfa_cu_seqlens)."""
-        num_tokens = sum(seq_lens_list) if seq_lens_list else 0
-        num_seqs = len(seq_lens_list)
-        _, seq_buf = self._qfa_step_buffers(max(num_tokens, 1), num_seqs, device)
-        seq_buf[:num_seqs].copy_(
-            torch.tensor(seq_lens_list, dtype=torch.int32, device=device)
-        )
-        return seq_buf[:num_seqs]
 
     # KV cache writes for C8_MXFP happen in reshape_and_cache(), invoked from forward()
     # when key/value are present. This hook is only reached when attention is split from

--- a/vllm_ascend/attention/attention_v1.py
+++ b/vllm_ascend/attention/attention_v1.py
@@ -2415,9 +2415,13 @@ class AscendC8MXFPAttentionBackendImpl(AscendAttentionBackendImpl):
             # must NOT be passed with a TND layout_q (the checker rejects
             # it); the op infers it from cu_seqlens_q.
             _, metadata_op = _get_qfa_ops()
+            # NOTE: torch_npu.float8_e8m0fnu is the integer dtype ID (293) on
+            # this torch_npu build, not a torch.dtype; tensor.view() would
+            # parse it as a target shape. Bitcast with the stock torch dtype
+            # instead (itemsize 1 -> 1, shape preserved).
             v_descale_stub = torch.zeros(
                 1, 1, 1, 1, 2, dtype=torch.uint8, device=cu_seqlens_q.device
-            ).view(torch_npu.float8_e8m0fnu)
+            ).view(torch.float8_e8m0fnu)
             metadata = metadata_op(
                 self.num_heads,
                 self.num_kv_heads,
@@ -2468,14 +2472,16 @@ class AscendC8MXFPAttentionBackendImpl(AscendAttentionBackendImpl):
         key, value, key_scale, value_scale = kv_cache
         # The scale caches are stored as raw uint8 (index_put_ on float8
         # either errors or falls back to AICPU); QFA's checker wants E8M0, so
-        # bitcast at the call boundary. Same for the q scale when the quant
-        # helper returns it as uint8 bytes.
-        if key_scale.dtype != torch_npu.float8_e8m0fnu:
-            key_scale = key_scale.view(torch_npu.float8_e8m0fnu)
-        if value_scale.dtype != torch_npu.float8_e8m0fnu:
-            value_scale = value_scale.view(torch_npu.float8_e8m0fnu)
-        if query_scale.dtype != torch_npu.float8_e8m0fnu:
-            query_scale = query_scale.view(torch_npu.float8_e8m0fnu)
+        # bitcast at the call boundary (torch.float8_e8m0fnu -- the torch
+        # dtype; torch_npu.float8_e8m0fnu is the integer ID 293 on this
+        # build and would be parsed as a view *shape*). Same for the q scale
+        # when the quant helper returns it as uint8 bytes.
+        if key_scale.dtype != torch.float8_e8m0fnu:
+            key_scale = key_scale.view(torch.float8_e8m0fnu)
+        if value_scale.dtype != torch.float8_e8m0fnu:
+            value_scale = value_scale.view(torch.float8_e8m0fnu)
+        if query_scale.dtype != torch.float8_e8m0fnu:
+            query_scale = query_scale.view(torch.float8_e8m0fnu)
         main_op, _ = _get_qfa_ops()
         # cann_ops_transformer delivery signature (verified on-device):
         # q/k/v/q_descale/k_descale/v_descale/quant_mode positional, p_scale

--- a/vllm_ascend/attention/attention_v1.py
+++ b/vllm_ascend/attention/attention_v1.py
@@ -164,7 +164,15 @@ class AscendC8MXFPAttentionBackend(AscendAttentionBackend):
 
     @staticmethod
     def get_impl_cls() -> type["AscendC8MXFPAttentionBackendImpl"]:
+        if enable_pcp() or enable_dcp():
+            raise NotImplementedError("C8_MXFP attention does not support PCP/DCP yet.")
         return AscendC8MXFPAttentionBackendImpl
+
+    @staticmethod
+    def get_builder_cls() -> type["AscendC8MXFPMetadataBuilder"]:
+        if enable_pcp() or enable_dcp():
+            raise NotImplementedError("C8_MXFP attention does not support PCP/DCP yet.")
+        return AscendC8MXFPMetadataBuilder
 
     @staticmethod
     def get_supported_kernel_block_sizes() -> list[int]:
@@ -513,6 +521,31 @@ class AscendAttentionPCPMetadataBuilder(AscendAttentionMetadataBuilder):
         if metadata.num_prefills > 0:
             metadata.attn_state = AscendAttentionState.ChunkedPrefill
         return metadata
+
+
+class AscendC8MXFPMetadataBuilder(AscendAttentionMetadataBuilder):
+    """Metadata builder for the C8-MXFP (QFA) backend.
+
+    The generic Ascend builder advertises ALWAYS cudagraph support and sizes
+    its block-table width with the 128-token generic block. The QFA path is
+    eager-only (graph capture raises in the impl) and uses 512-token kernel
+    blocks, so declare NEVER here: the engine then disables graph capture
+    during startup instead of failing later at capture time.
+    """
+
+    @classmethod
+    def get_cudagraph_support(
+        cls,
+        vllm_config: VllmConfig,
+        kv_cache_spec,
+    ) -> AttentionCGSupport:
+        return AttentionCGSupport.NEVER
+
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
+        self.max_num_blocks_per_req = cdiv(
+            self.model_config.max_model_len, AscendC8MXFPAttentionBackend.get_supported_kernel_block_sizes()[0]
+        )
 
 
 class AscendAttentionBackendImpl(AttentionImpl):
@@ -2295,9 +2328,14 @@ class AscendC8MXFPAttentionBackendImpl(AscendAttentionBackendImpl):
     Speculative decoding is also out of scope for v1.
 
     NOTE: kwarg names of the two QFA calls follow the QFA requirement doc's
-    torch-level calling example. Re-verify them against the delivered
-    torch_npu wrapper signature before on-device bring-up; they are the only
-    integration point expected to need renaming.
+    torch-level calling example (torch_npu.npu_quant_flash_attn*,
+    dequant_scale_query/key/value, quant_scale_p, pa_block_size,
+    return_softmax_lse=bool). The public ops-transformer extension exposes a
+    DIFFERENT wrapper (cann_ops_transformer.quant_flash_attn: positional
+    q_descale/k_descale/v_descale, no pa_block_size, an extra
+    layout_q_descale); re-verify against the actual torch_npu build before
+    on-device bring-up. Any mismatch is confined to _get_qfa_metadata /
+    _run_qfa (see the bring-up checklist for the full signature diff).
     """
 
     # Installed via ``layer.impl.__class__`` assignment, which does not call
@@ -2348,6 +2386,12 @@ class AscendC8MXFPAttentionBackendImpl(AscendAttentionBackendImpl):
         if metadata is None:
             # TND + PA: pass cu_seqlens_q only; the KV side is addressed via
             # block_table + seqused_kv (QFA requirement doc, 3.2.3).
+            # NOTE: kwargs follow the delivered torch_npu wrapper example in
+            # the QFA requirement doc (3.4.2D). The public ops-transformer
+            # extension uses a different signature (positional
+            # q_descale/k_descale/v_descale, no pa_block_size, and an extra
+            # layout_q_descale); re-verify against the actual torch_npu build
+            # before on-device bring-up (see the bring-up checklist).
             metadata = torch_npu.npu_quant_flash_attn_metadata(
                 num_heads_q=self.num_heads,
                 num_heads_kv=self.num_kv_heads,
@@ -2364,7 +2408,6 @@ class AscendC8MXFPAttentionBackendImpl(AscendAttentionBackendImpl):
                 win_left=-1,
                 win_right=-1,
                 layout_q=QFA_LAYOUT_TND,
-                layout_q_descale=QFA_LAYOUT_TND,
                 layout_kv=QFA_LAYOUT_PA_BNBD,
                 layout_out=QFA_LAYOUT_TND,
             )
@@ -2372,15 +2415,14 @@ class AscendC8MXFPAttentionBackendImpl(AscendAttentionBackendImpl):
         return metadata
 
     def _qfa_int8_mask(self, attn_metadata: AscendMetadata) -> torch.Tensor | None:
-        """QFA's attn_mask is INT8; cache the cast once per step."""
+        """QFA's attn_mask is INT8/UINT8/bool; the shared builder already
+        hands out an int8 2048x2048 causal mask, so only convert when some
+        other mask source slips in."""
         if attn_metadata.attn_mask is None:
             return None
-        cache = self._qfa_step_cache(attn_metadata)
-        attn_mask = cache.get("attn_mask_int8")
-        if attn_mask is None:
-            attn_mask = attn_metadata.attn_mask.to(torch.int8)
-            cache["attn_mask_int8"] = attn_mask
-        return attn_mask
+        if attn_metadata.attn_mask.dtype == torch.int8:
+            return attn_metadata.attn_mask
+        return attn_metadata.attn_mask.to(torch.int8)
 
     def _run_qfa(
         self,
@@ -2648,8 +2690,14 @@ class AscendC8MXFPAttentionBackendImpl(AscendAttentionBackendImpl):
             filled_caches = set()
             self._v_scale_filled_caches = filled_caches
         if value_scale_cache not in filled_caches:
-            # (hidden_size) -> (num_kv_heads, head_size) -> broadcast -> (num_blocks, num_kv_heads, block_size // 64, head_size, 2)
-            value_scale_cache.copy_(value_scale.view(1, self.num_kv_heads, 1, self.head_size, 1))
+            # (hidden_size) -> (num_kv_heads, head_size) -> broadcast ->
+            # (num_blocks, num_kv_heads, block_size // 64, head_size, 2).
+            # Derive num_kv_heads / v head_dim from the cache layout instead
+            # of self.num_kv_heads / self.head_size so models whose V head
+            # dim differs from the Q/K head dim stay correct.
+            num_kv_heads = value_scale_cache.shape[1]
+            v_head_dim = value_scale_cache.shape[3]
+            value_scale_cache.copy_(value_scale.view(1, num_kv_heads, 1, v_head_dim, 1))
             filled_caches.add(value_scale_cache)
 
     def forward(
@@ -2675,40 +2723,59 @@ class AscendC8MXFPAttentionBackendImpl(AscendAttentionBackendImpl):
             raise NotImplementedError("C8_MXFP attention does not support hamming sparse KV compression yet.")
         if self.vllm_config.speculative_config is not None:
             raise NotImplementedError("C8_MXFP v1 does not support speculative decoding yet.")
+        if self.vllm_config.kv_transfer_config is not None:
+            raise NotImplementedError("C8_MXFP v1 does not support PD disaggregation (kv_transfer) yet.")
         if _EXTRA_CTX.capturing:
             # v1 is eager-only: FULL graph capture needs the operator aclgraph
             # ("path 7") contract, and PIECEWISE capture of the AICPU metadata
             # operator needs its own confirmation. Run with
-            # cudagraph_mode=NONE / enforce_eager until then.
+            # cudagraph_mode=NONE / enforce_eager until then. The metadata
+            # builder already reports AttentionCGSupport.NEVER so a normal
+            # engine start disables graphs before reaching this guard; it
+            # only fires when graphs were forced on.
             raise NotImplementedError(
                 "C8_MXFP QFA does not support ACL graph capture yet; "
                 "run with cudagraph_mode=NONE (or enforce_eager)."
             )
+        if kv_cache is None or len(kv_cache) < 4:
+            raise RuntimeError(
+                "C8_MXFP attention requires a (k, v, k_scale, v_scale) KV cache "
+                f"tuple, got: {type(kv_cache)} with length "
+                f"{len(kv_cache) if kv_cache is not None else 0}."
+            )
+
+        record_attention_compute_start()
 
         query_mxfp8, query_scale = torch_npu.npu_dynamic_mx_quant(
             query[: attn_metadata.num_actual_tokens],
             dst_type=torch.float8_e4m3fn,
         )
-        key_mxfp8, key_scale = torch_npu.npu_dynamic_mx_quant(
-            key[: attn_metadata.num_actual_tokens],
-            dst_type=torch.float8_e4m3fn,
-        )
 
-        original_value_shape = value.shape
-        value = value.view(original_value_shape[0], -1)
-        value_mxfp8 = torch_npu.npu_quantize(
-            value[: attn_metadata.num_actual_tokens],
-            layer.v_cache_scale_float_reciprocal,
-            None,
-            torch.float8_e4m3fn,
-            -1,
-            False,
-        )
-        value_mxfp8 = value_mxfp8.view((attn_metadata.num_actual_tokens, *original_value_shape[1:]))
+        # KV-sharing consumer layers reuse another layer's cache; writing
+        # their (dummy) K/V would corrupt the shared slots, so only the
+        # owner layer quantizes and scatters K/V. key/value may also be None
+        # on pure decode paths.
+        if key is not None and value is not None and self.kv_sharing_target_layer_name is None:
+            key_mxfp8, key_scale = torch_npu.npu_dynamic_mx_quant(
+                key[: attn_metadata.num_actual_tokens],
+                dst_type=torch.float8_e4m3fn,
+            )
 
-        self.reshape_and_cache(
-            key_mxfp8, value_mxfp8, key_scale, layer.v_cache_scale, kv_cache, attn_metadata
-        )
+            original_value_shape = value.shape
+            value = value.view(original_value_shape[0], -1)
+            value_mxfp8 = torch_npu.npu_quantize(
+                value[: attn_metadata.num_actual_tokens],
+                layer.v_cache_scale_float_reciprocal,
+                None,
+                torch.float8_e4m3fn,
+                -1,
+                False,
+            )
+            value_mxfp8 = value_mxfp8.view((attn_metadata.num_actual_tokens, *original_value_shape[1:]))
+
+            self.reshape_and_cache(
+                key_mxfp8, value_mxfp8, key_scale, layer.v_cache_scale, kv_cache, attn_metadata
+            )
 
         qfa_kv_cache = self._transpose_kv_cache(kv_cache)
         return self._forward_mxfp8_attention(

--- a/vllm_ascend/attention/attention_v1.py
+++ b/vllm_ascend/attention/attention_v1.py
@@ -2643,7 +2643,7 @@ class AscendC8MXFPAttentionBackendImpl(AscendAttentionBackendImpl):
         """
         num_tokens = int(cumulative_seq_lengths[-1]) if cumulative_seq_lengths else 0
         num_seqs = len(cumulative_seq_lengths)
-        cu_buf, _, cu_cpu = self._qfa_step_buffers(max(num_tokens, 1), num_seqs, device)
+        cu_buf, _, cu_cpu, _ = self._qfa_step_buffers(max(num_tokens, 1), num_seqs, device)
         cu_cpu[: num_seqs + 1] = torch.tensor(
             [0, *cumulative_seq_lengths], dtype=torch.int32, device="cpu"
         )

--- a/vllm_ascend/attention/attention_v1.py
+++ b/vllm_ascend/attention/attention_v1.py
@@ -562,6 +562,100 @@ class AscendC8MXFPMetadataBuilder(AscendAttentionMetadataBuilder):
         )
 
 
+def _update_qfa_graph_param(update_stream, handle, event, param, metadata) -> None:
+    """Replay-time update for one captured QFA .out op (vendored-QFA bring-up
+    methodology, fe58a86a).
+
+    Re-sends the whole call with the current step's tensors: aclnn recomputes
+    tiling on every invocation, so the update replaces tiling as well, not
+    just buffer addresses. q_fp8 / q_descale keep their captured graph-internal
+    addresses (the graph recomputes them from the step's query). The metadata
+    plan is recomputed here per update (the graph replay itself does not run
+    the Python impl, so the per-step plan cache on AscendMetadata is not
+    populated on this path); the plan write is an AICPU op whose completion
+    must be pinned against this update stream before the re-sent call reads
+    the plan (waiting on the whole stream would deadlock a graph parked on
+    the event -- only the recorded point is awaited).
+    """
+    _, metadata_op, out_op = _get_qfa_ops()
+
+    actual_seq_lengths_q = metadata.actual_seq_lengths_q
+    num_tokens = int(actual_seq_lengths_q[-1])
+    device = param.seqused_kv.device
+    cu_seqlens_q = _build_qfa_cu_seqlens(actual_seq_lengths_q, device)
+    seqused_kv = torch.tensor(metadata.seq_lens_list, dtype=torch.int32, device=device)
+    max_seqlen_q = num_tokens
+
+    # Recompute the AICPU plan for this step (per-step, shared by all layers:
+    # the plan depends on heads/batch, which are identical across layers, and
+    # not on per-layer caches). The e8m0 v_descale stub is only checked for
+    # non-nullness under PA_BBND.
+    v_descale_stub = torch.zeros(1, 1, 1, 1, 2, dtype=torch.uint8, device=device).view(
+        torch.float8_e8m0fnu
+    )
+    qfa_plan = metadata_op(
+        param.num_heads,
+        _qfa_plan_kv_heads(param),
+        param.head_size,
+        QFA_QUANT_MODE_MXFP8,
+        cu_seqlens_q=cu_seqlens_q,
+        cu_seqlens_kv=None,
+        seqused_q=None,
+        seqused_kv=seqused_kv,
+        v_descale=v_descale_stub,
+        max_seqlen_q=max_seqlen_q,
+        max_seqlen_kv=-1,
+        mask_mode=QFA_MASK_MODE_CAUSAL,
+        win_left=-1,
+        win_right=-1,
+        layout_q=QFA_LAYOUT_TND,
+        layout_q_descale=QFA_LAYOUT_TND,
+        layout_kv=QFA_LAYOUT_PA_BBND,
+        layout_out=QFA_LAYOUT_TND,
+    )
+
+    torch.npu.graph_task_update_begin(update_stream, handle)
+    out_op(
+        param.q_fp8,
+        param.k,
+        param.v,
+        param.q_descale,
+        param.k_descale,
+        param.v_descale,
+        QFA_QUANT_MODE_MXFP8,
+        block_table=metadata.block_tables,
+        p_scale=None,
+        cu_seqlens_q=cu_seqlens_q,
+        cu_seqlens_kv=None,
+        seqused_q=None,
+        seqused_kv=seqused_kv,
+        sinks=None,
+        attn_mask=param.attn_mask,
+        metadata=qfa_plan,
+        softmax_scale=param.softmax_scale,
+        mask_mode=QFA_MASK_MODE_CAUSAL,
+        win_left=-1,
+        win_right=-1,
+        max_seqlen_q=max_seqlen_q,
+        max_seqlen_kv=-1,
+        layout_q=QFA_LAYOUT_TND,
+        layout_q_descale=QFA_LAYOUT_TND,
+        layout_kv=QFA_LAYOUT_PA_BBND,
+        layout_out=QFA_LAYOUT_TND,
+        return_softmax_lse=False,
+        out=param.attn_output,
+        softmax_lse=param.softmax_lse,
+    )
+    torch.npu.graph_task_update_end(update_stream)
+    event.record(update_stream)
+
+
+def _qfa_plan_kv_heads(param) -> int:
+    """KV head count for the metadata plan, derived from the captured K cache
+    (PA_BBND: [num_blocks, block_size, num_kv_heads, head_dim])."""
+    return param.k.shape[2]
+
+
 class AscendAttentionBackendImpl(AttentionImpl):
     def __init__(
         self,
@@ -882,6 +976,22 @@ class AscendAttentionBackendImpl(AttentionImpl):
                     handles,
                     events,
                 ):
+                    if isinstance(param, QFAGraphAttentionParams):
+                        if _EXTRA_CTX.is_draft_model:
+                            draft_step, key = draft_attn_key_steps[attn_count]
+                            metadata = attn_metadata[draft_step][key]
+                            attn_count = attn_count + 1
+                        else:
+                            metadata_key = (
+                                param.layer_name
+                                if getattr(param, "layer_name", None) is not None and param.layer_name in attn_metadata
+                                else key
+                            )
+                            metadata = attn_metadata[metadata_key]
+                        _update_qfa_graph_param(
+                            update_stream, handle, event, param, metadata
+                        )
+                        continue
                     if isinstance(param, PagedAttentionGraphParam):
                         if _EXTRA_CTX.is_draft_model:
                             draft_step, key = draft_attn_key_steps[attn_count]
@@ -2326,18 +2436,22 @@ def _build_qfa_cu_seqlens(cumulative_seq_lengths: list[int], device: torch.devic
     return torch.tensor([0, *cumulative_seq_lengths], dtype=torch.int32, device=device)
 
 
-# Resolved lazily and cached: (main_op, metadata_op). The QFA dual operators
-# are delivered through the cann_ops_transformer package shipped with the
-# CANN toolkit (confirmed final delivery form). That wrapper's call shape
-# (verified on-device): positional q/k/v/q_descale/k_descale/v_descale/
-# quant_mode, p_scale instead of quant_scale_p, an extra layout_q_descale,
-# no pa_block_size, and a required non-null v_descale placeholder on the
-# metadata call for quant_mode=1 (batch_size must not be passed with a TND
-# layout_q; the op infers it from cu_seqlens_q).
-_QFA_OPS: tuple[Any, Any] | None = None
+# Resolved lazily and cached: (main_op, metadata_op, out_op | None). The QFA
+# dual operators are delivered through the cann_ops_transformer package
+# shipped with the CANN toolkit (confirmed final delivery form). That
+# wrapper's call shape (verified on-device): positional q/k/v/q_descale/
+# k_descale/v_descale/quant_mode, p_scale instead of quant_scale_p, an extra
+# layout_q_descale, no pa_block_size, and a required non-null v_descale
+# placeholder on the metadata call for quant_mode=1 (batch_size must not be
+# passed with a TND layout_q; the op infers it from cu_seqlens_q).
+# ``out_op`` is the caller-owned-output variant needed for FULL-graph capture
+# (torch.npu.graph_task_group); it comes from the out-variant patch to the
+# CANN package and is None on unpatched builds (FULL capture then raises
+# with the actionable reason).
+_QFA_OPS: tuple[Any, Any, Any | None] | None = None
 
 
-def _get_qfa_ops() -> tuple[Any, Any]:
+def _get_qfa_ops() -> tuple[Any, Any, Any | None]:
     global _QFA_OPS
     if _QFA_OPS is None:
         try:
@@ -2350,8 +2464,41 @@ def _get_qfa_ops() -> tuple[Any, Any]:
                 "cann_ops_transformer.ops.quant_flash_attn(_metadata) could not "
                 "be imported in this environment."
             ) from None
-        _QFA_OPS = (main_op, metadata_op)
+        try:
+            from cann_ops_transformer.ops import quant_flash_attn_out as out_op
+        except ImportError:
+            out_op = None
+        _QFA_OPS = (main_op, metadata_op, out_op)
     return _QFA_OPS
+
+
+@dataclass
+class QFAGraphAttentionParams:
+    """Captured QFA call parameters for FULL-graph replay.
+
+    Mirrors the vendored-QFA bring-up (TallMessiWu#2, fe58a86a): the capture
+    holds caller-owned output buffers (fixed addresses for replay) plus weak
+    refs to the per-step tensors that the replay-time update re-sends. q_fp8 /
+    q_descale are NOT re-sent on update -- the graph recomputes them from the
+    current step's query, so their captured addresses are already correct.
+    """
+
+    q_fp8: torch.Tensor
+    q_descale: torch.Tensor
+    k: torch.Tensor
+    v: torch.Tensor
+    k_descale: torch.Tensor
+    v_descale: torch.Tensor
+    block_table: torch.Tensor
+    cu_seqlens_q: torch.Tensor
+    seqused_kv: torch.Tensor
+    attn_mask: torch.Tensor | None
+    softmax_scale: float
+    max_seqlen_q: int
+    num_heads: int
+    head_size: int
+    attn_output: torch.Tensor
+    softmax_lse: torch.Tensor
 
 
 class AscendC8MXFPAttentionBackendImpl(AscendAttentionBackendImpl):
@@ -2496,7 +2643,42 @@ class AscendC8MXFPAttentionBackendImpl(AscendAttentionBackendImpl):
             value_scale = value_scale.view(torch.float8_e8m0fnu)
         if query_scale.dtype != torch.float8_e8m0fnu:
             query_scale = query_scale.view(torch.float8_e8m0fnu)
-        main_op, _ = _get_qfa_ops()
+        attn_mask = self._qfa_int8_mask(attn_metadata)
+        main_op, _, out_op = _get_qfa_ops()
+
+        if _EXTRA_CTX.capturing and self.vllm_config.compilation_config.cudagraph_mode.has_full_cudagraphs():
+            # FULL-graph capture path (vendored-QFA bring-up, fe58a86a):
+            # wrap the caller-owned-output call in graph_task_group_begin/end
+            # so the op becomes a replayable task; register the captured
+            # params for the replay-time update (which re-sends the call with
+            # the current step's tensors -- aclnn recomputes tiling on every
+            # call, so the update replaces tiling as well, not just addresses).
+            if out_op is None:
+                raise NotImplementedError(
+                    "C8_MXFP QFA FULL-graph capture requires the .out() wrapper variant of "
+                    "cann_ops_transformer.quant_flash_attn (caller-owned output tensors for "
+                    "torch.npu.graph_task_group). The current wrapper only exposes the "
+                    "allocating variant, which cannot be captured safely. Apply the "
+                    "quant_flash_attn_out patch to the CANN package (or run with "
+                    "cudagraph_mode=PIECEWISE / NONE)."
+                )
+            return self._capture_qfa_full_graph(
+                quant_query,
+                query_scale,
+                key,
+                value,
+                key_scale,
+                value_scale,
+                cu_seqlens_q,
+                seqused_kv,
+                attn_mask,
+                qfa_metadata,
+                max_seqlen_q,
+                num_tokens,
+                output,
+                out_op,
+            )
+
         # cann_ops_transformer delivery signature (verified on-device):
         # q/k/v/q_descale/k_descale/v_descale/quant_mode positional, p_scale
         # instead of quant_scale_p, layout_q_descale, and no pa_block_size
@@ -2516,7 +2698,7 @@ class AscendC8MXFPAttentionBackendImpl(AscendAttentionBackendImpl):
             seqused_q=None,
             seqused_kv=seqused_kv,
             sinks=None,
-            attn_mask=self._qfa_int8_mask(attn_metadata),
+            attn_mask=attn_mask,
             metadata=qfa_metadata,
             softmax_scale=self.scale,
             mask_mode=QFA_MASK_MODE_CAUSAL,
@@ -2535,6 +2717,113 @@ class AscendC8MXFPAttentionBackendImpl(AscendAttentionBackendImpl):
         attn_output = result[0] if isinstance(result, tuple) else result
         attn_output = attn_output.view(num_tokens, self.num_heads, self.head_size)
         output[:num_tokens] = attn_output
+        return output
+
+    def _capture_qfa_full_graph(
+        self,
+        quant_query: torch.Tensor,
+        query_scale: torch.Tensor,
+        key: torch.Tensor,
+        value: torch.Tensor,
+        key_scale: torch.Tensor,
+        value_scale: torch.Tensor,
+        cu_seqlens_q: torch.Tensor,
+        seqused_kv: torch.Tensor,
+        attn_mask: torch.Tensor | None,
+        qfa_metadata: torch.Tensor,
+        max_seqlen_q: int,
+        num_tokens: int,
+        output: torch.Tensor,
+        out_op: Any,
+    ) -> torch.Tensor:
+        """Capture the QFA .out call into the current NPU graph task group.
+
+        Registers a QFAGraphAttentionParams entry; the replay-time update
+        (update_graph_params) re-sends the call with the current step's
+        block_table / lengths / metadata before every replay. q_fp8/q_descale
+        are recomputed inside the graph each step, so they are registered but
+        never re-sent (their captured addresses are the graph-internal ones).
+        """
+        if _EXTRA_CTX.is_draft_model:
+            graph_params = get_draft_graph_params()
+        else:
+            graph_params = get_graph_params()
+        assert graph_params is not None, "QFA capture requires initialized graph params"
+
+        # Caller-owned output buffers: fixed addresses across capture/replay.
+        # The capture-time output slice is the tensor the graph writes into;
+        # the softmax LSE buffer is unused (return_softmax_lse=False) but must
+        # be a valid device tensor for the op signature.
+        attn_output = output
+        softmax_lse = torch.zeros(1, dtype=torch.float32, device=quant_query.device)
+
+        stream = torch_npu.npu.current_stream()
+        event = torch.npu.ExternalEvent()
+        event.wait(stream)
+        event.reset(stream)
+        graph_params.events[num_tokens].append(event)
+
+        graph_params.attn_params[num_tokens].append(
+            QFAGraphAttentionParams(
+                # Strong refs for q_fp8/q_descale: the graph recomputes them
+                # from the step's query INTO these captured buffers every
+                # replay, so the buffers must stay alive (weak refs would let
+                # the allocator reuse them; the vendored bring-up kept them
+                # alive for exactly this reason).
+                q_fp8=quant_query,
+                q_descale=query_scale,
+                k=key,
+                v=value,
+                k_descale=key_scale,
+                v_descale=value_scale,
+                block_table=weak_ref_tensors(attn_metadata.block_tables),
+                cu_seqlens_q=weak_ref_tensors(cu_seqlens_q),
+                seqused_kv=weak_ref_tensors(seqused_kv),
+                attn_mask=weak_ref_tensors(attn_mask) if attn_mask is not None else None,
+                softmax_scale=self.scale,
+                max_seqlen_q=max_seqlen_q,
+                num_heads=self.num_heads,
+                head_size=self.head_size,
+                attn_output=weak_ref_tensors(attn_output),
+                softmax_lse=softmax_lse,
+            )
+        )
+
+        torch.npu.graph_task_group_begin(stream)
+        out_op(
+            quant_query,
+            key,
+            value,
+            query_scale,
+            key_scale,
+            value_scale,
+            QFA_QUANT_MODE_MXFP8,
+            block_table=attn_metadata.block_tables,
+            p_scale=None,
+            cu_seqlens_q=cu_seqlens_q,
+            cu_seqlens_kv=None,
+            seqused_q=None,
+            seqused_kv=seqused_kv,
+            sinks=None,
+            attn_mask=attn_mask,
+            metadata=qfa_metadata,
+            softmax_scale=self.scale,
+            mask_mode=QFA_MASK_MODE_CAUSAL,
+            win_left=-1,
+            win_right=-1,
+            max_seqlen_q=max_seqlen_q,
+            max_seqlen_kv=-1,
+            layout_q=QFA_LAYOUT_TND,
+            layout_q_descale=QFA_LAYOUT_TND,
+            layout_kv=QFA_LAYOUT_PA_BBND,
+            layout_out=QFA_LAYOUT_TND,
+            return_softmax_lse=False,
+            out=attn_output,
+            softmax_lse=softmax_lse,
+        )
+        handle = torch.npu.graph_task_group_end(stream)
+        graph_params.handles[num_tokens].append(handle)
+        # The captured op already wrote into ``output``; nothing to copy.
         return output
 
     def _forward_mxfp8_attention(
@@ -2681,29 +2970,31 @@ class AscendC8MXFPAttentionBackendImpl(AscendAttentionBackendImpl):
         if self.vllm_config.kv_transfer_config is not None:
             raise NotImplementedError("C8_MXFP v1 does not support PD disaggregation (kv_transfer) yet.")
         if _EXTRA_CTX.capturing:
-            # Phase-2 bring-up, staged graph support:
+            # Phase-2 graph support, staged:
             # - PIECEWISE: the compiled region covers non-attention ops; QFA
             #   runs outside it as a plain call and is capture-compatible
             #   (validated on-device by the vendored-QFA bring-up PR).
-            # - FULL (incl. FULL_DECODE_ONLY): capture requires the caller-
-            #   owned-output (.out) wrapper variant of quant_flash_attn, which
-            #   the current cann_ops_transformer build lacks -- the allocating
-            #   variant re-allocates outputs every call, so a captured graph
-            #   would replay writes to freed/wild addresses (observed as AI
-            #   core wild-pointer crashes in the vendored bring-up). Fail at
-            #   capture time with the actionable reason instead of corrupting
-            #   replay. Land the out-variant patch (see
-            #   docs/qfa_out_overload_patch) to enable FULL graphs.
+            # - FULL (incl. FULL_DECODE_ONLY): _run_qfa routes to
+            #   _capture_qfa_full_graph, which wraps the caller-owned-output
+            #   (.out) variant in graph_task_group_begin/end and registers
+            #   the replay params. The out variant comes from the CANN-package
+            #   patch; without it, capture raises the actionable error below
+            #   (the allocating variant re-allocates outputs every call, so a
+            #   captured graph would replay writes to freed/wild addresses --
+            #   observed as AI core wild-pointer crashes in the vendored
+            #   bring-up).
             mode = self.vllm_config.compilation_config.cudagraph_mode
             if mode.has_full_cudagraphs():
-                raise NotImplementedError(
-                    "C8_MXFP QFA FULL-graph capture requires the .out() wrapper variant of "
-                    "cann_ops_transformer.quant_flash_attn (caller-owned output tensors for "
-                    "torch.npu.graph_task_group). The current wrapper only exposes the "
-                    "allocating variant, which cannot be captured safely. Apply the "
-                    "quant_flash_attn_out patch to the CANN package (or run with "
-                    "cudagraph_mode=PIECEWISE / NONE)."
-                )
+                _, _, out_op = _get_qfa_ops()
+                if out_op is None:
+                    raise NotImplementedError(
+                        "C8_MXFP QFA FULL-graph capture requires the .out() wrapper variant of "
+                        "cann_ops_transformer.quant_flash_attn (caller-owned output tensors for "
+                        "torch.npu.graph_task_group). The current wrapper only exposes the "
+                        "allocating variant, which cannot be captured safely. Apply the "
+                        "quant_flash_attn_out patch to the CANN package (or run with "
+                        "cudagraph_mode=PIECEWISE / NONE)."
+                    )
             # PIECEWISE capture: QFA executes outside the compiled region;
             # proceed.
         if kv_cache is None or len(kv_cache) < 4:

--- a/vllm_ascend/attention/attention_v1.py
+++ b/vllm_ascend/attention/attention_v1.py
@@ -2852,6 +2852,29 @@ class AscendC8MXFPAttentionBackendImpl(AscendAttentionBackendImpl):
         num_tokens = int(actual_seq_lengths_q[-1])  # type: ignore[index]
         if num_tokens <= 0:
             return output
+
+        if _EXTRA_CTX.capturing and self.vllm_config.compilation_config.cudagraph_mode.has_full_cudagraphs():
+            # FULL-graph capture: the captured graph must contain NO host-side
+            # tensor construction (H2D copies replay against freed host memory)
+            # and no AICPU metadata op (its captured inputs would be stale).
+            # Use persistent placeholder tensors for the captured call; the
+            # replay-time update (_update_qfa_graph_param) re-sends the whole
+            # call with the current step's freshly-built tensors, so the
+            # placeholders only need to stay alive and address-stable.
+            ph_cu_seqlens_q, ph_seqused_kv, ph_metadata = self._qfa_capture_placeholders(num_tokens, device)
+            return self._run_qfa(
+                quant_query,
+                query_scale,
+                kv_cache,
+                attn_metadata,
+                cu_seqlens_q=ph_cu_seqlens_q,
+                seqused_kv=ph_seqused_kv,
+                qfa_metadata=ph_metadata,
+                max_seqlen_q=num_tokens,
+                num_tokens=num_tokens,
+                output=output,
+            )
+
         cu_seqlens_q = _build_qfa_cu_seqlens(actual_seq_lengths_q, device)
         seqused_kv = torch.tensor(attn_metadata.seq_lens_list, dtype=torch.int32, device=device)
         # Upper bound on any single query length (the step's total token
@@ -2878,6 +2901,24 @@ class AscendC8MXFPAttentionBackendImpl(AscendAttentionBackendImpl):
             num_tokens=num_tokens,
             output=output,
         )
+
+    def _qfa_capture_placeholders(self, num_tokens: int, device: torch.device) -> tuple:
+        """Persistent placeholder tensors for FULL-graph capture (per size).
+
+        Allocated once per capture size and cached on the instance; kept alive
+        for the process lifetime so the captured references stay valid. The
+        replay update replaces every parameter of the re-sent call, so their
+        VALUES are never consumed -- only their addresses matter.
+        """
+        if not hasattr(self, "_qfa_placeholders"):
+            self._qfa_placeholders = {}
+        if num_tokens not in self._qfa_placeholders:
+            self._qfa_placeholders[num_tokens] = (
+                torch.zeros(num_tokens + 1, dtype=torch.int32, device=device),  # cu_seqlens_q
+                torch.ones(1, dtype=torch.int32, device=device),  # seqused_kv (len>=1 for checker)
+                torch.zeros(4096, dtype=torch.int32, device=device),  # metadata plan (checker: non-null)
+            )
+        return self._qfa_placeholders[num_tokens]
 
     # KV cache writes for C8_MXFP happen in reshape_and_cache(), invoked from forward()
     # when key/value are present. This hook is only reached when attention is split from

--- a/vllm_ascend/attention/attention_v1.py
+++ b/vllm_ascend/attention/attention_v1.py
@@ -558,6 +558,14 @@ class AscendC8MXFPMetadataBuilder(AscendAttentionMetadataBuilder):
         vllm_config: VllmConfig,
         kv_cache_spec,
     ) -> AttentionCGSupport:
+        if vllm_config.speculative_config is not None:
+            # MTP bring-up stage: force attention eager so the draft-step
+            # eager semantics (per-step metadata, spec slot writes) land
+            # first. The draft FULL graph reuses the same
+            # persistent-buffer derivation chain (Step3.5 proposer refreshes
+            # query_start_loc/seq_lens in place before each replay) and is
+            # re-enabled after the eager bring-up is verified.
+            return AttentionCGSupport.NEVER
         mode = vllm_config.compilation_config.cudagraph_mode
         if mode.has_piecewise_cudagraphs() and not mode.has_full_cudagraphs():
             # PIECEWISE: QFA runs outside the compiled region as a plain
@@ -2412,8 +2420,11 @@ class AscendC8MXFPAttentionBackendImpl(AscendAttentionBackendImpl):
     each replay). The K-scale scatter uses a device-side mask pattern (no
     host sync). No Python-side buffer refresh exists in the captured
     region -- ACL-graph replay never re-runs Python, so such refreshes
-    would freeze at capture values. Speculative decoding remains out of
-    scope for v1.
+    would freeze at capture values. Speculative decoding (MTP) uses the
+    same derivation chain: the draft metadata builders route through
+    AscendAttentionMetadataBuilder.build(), and the Step3.5 proposer
+    refreshes its persistent query_start_loc/seq_lens buffers in place
+    before each draft-step replay.
 
     NOTE: the QFA dual operators are called through _get_qfa_ops(), which
     resolves cann_ops_transformer.ops.quant_flash_attn(_metadata) -- the
@@ -2763,8 +2774,6 @@ class AscendC8MXFPAttentionBackendImpl(AscendAttentionBackendImpl):
             return output.fill_(0)
         if getattr(self, "enable_hamming_sparse", False):
             raise NotImplementedError("C8_MXFP attention does not support hamming sparse KV compression yet.")
-        if self.vllm_config.speculative_config is not None:
-            raise NotImplementedError("C8_MXFP v1 does not support speculative decoding yet.")
         if self.vllm_config.kv_transfer_config is not None:
             raise NotImplementedError("C8_MXFP v1 does not support PD disaggregation (kv_transfer) yet.")
         if _EXTRA_CTX.capturing:

--- a/vllm_ascend/attention/attention_v1.py
+++ b/vllm_ascend/attention/attention_v1.py
@@ -526,11 +526,20 @@ class AscendAttentionPCPMetadataBuilder(AscendAttentionMetadataBuilder):
 class AscendC8MXFPMetadataBuilder(AscendAttentionMetadataBuilder):
     """Metadata builder for the C8-MXFP (QFA) backend.
 
-    The generic Ascend builder advertises ALWAYS cudagraph support and sizes
-    its block-table width with the 128-token generic block. The QFA path is
-    eager-only (graph capture raises in the impl) and uses 512-token kernel
-    blocks, so declare NEVER here: the engine then disables graph capture
-    during startup instead of failing later at capture time.
+    The generic Ascend builder sizes its block-table width with the
+    128-token generic block; this backend uses 512-token kernel blocks.
+
+    Cudagraph support is staged (phase-2 bring-up):
+    - PIECEWISE: supported -- QFA executes outside the compiled region as a
+      plain call (validated on-device by the vendored-QFA bring-up PR).
+    - FULL / FULL_DECODE_ONLY: the engine is allowed to attempt capture so
+      the missing .out() wrapper variant surfaces as a concrete capture-time
+      failure instead of being silently downgraded to eager. The vendored
+      bring-up proved the aclnn layer itself is out-semantics and works in
+      FULL graphs once the wrapper exposes caller-owned outputs; until the
+      cann_ops_transformer patch lands, FULL capture is expected to fail or
+      replay corrupt -- the impl guards with an explicit error at capture
+      time.
     """
 
     @classmethod
@@ -539,7 +548,12 @@ class AscendC8MXFPMetadataBuilder(AscendAttentionMetadataBuilder):
         vllm_config: VllmConfig,
         kv_cache_spec,
     ) -> AttentionCGSupport:
-        return AttentionCGSupport.NEVER
+        mode = vllm_config.compilation_config.cudagraph_mode
+        if mode.has_piecewise_cudagraphs() and not mode.has_full_cudagraphs():
+            return AttentionCGSupport.PARTIAL
+        # FULL (incl. FULL_DECODE_ONLY): let the engine attempt the capture;
+        # the impl raises at capture time with the actionable reason.
+        return AttentionCGSupport.ALWAYS
 
     def __init__(self, *args, **kwargs) -> None:
         super().__init__(*args, **kwargs)
@@ -2667,17 +2681,31 @@ class AscendC8MXFPAttentionBackendImpl(AscendAttentionBackendImpl):
         if self.vllm_config.kv_transfer_config is not None:
             raise NotImplementedError("C8_MXFP v1 does not support PD disaggregation (kv_transfer) yet.")
         if _EXTRA_CTX.capturing:
-            # v1 is eager-only: FULL graph capture needs the operator aclgraph
-            # ("path 7") contract, and PIECEWISE capture of the AICPU metadata
-            # operator needs its own confirmation. Run with
-            # cudagraph_mode=NONE / enforce_eager until then. The metadata
-            # builder already reports AttentionCGSupport.NEVER so a normal
-            # engine start disables graphs before reaching this guard; it
-            # only fires when graphs were forced on.
-            raise NotImplementedError(
-                "C8_MXFP QFA does not support ACL graph capture yet; "
-                "run with cudagraph_mode=NONE (or enforce_eager)."
-            )
+            # Phase-2 bring-up, staged graph support:
+            # - PIECEWISE: the compiled region covers non-attention ops; QFA
+            #   runs outside it as a plain call and is capture-compatible
+            #   (validated on-device by the vendored-QFA bring-up PR).
+            # - FULL (incl. FULL_DECODE_ONLY): capture requires the caller-
+            #   owned-output (.out) wrapper variant of quant_flash_attn, which
+            #   the current cann_ops_transformer build lacks -- the allocating
+            #   variant re-allocates outputs every call, so a captured graph
+            #   would replay writes to freed/wild addresses (observed as AI
+            #   core wild-pointer crashes in the vendored bring-up). Fail at
+            #   capture time with the actionable reason instead of corrupting
+            #   replay. Land the out-variant patch (see
+            #   docs/qfa_out_overload_patch) to enable FULL graphs.
+            mode = self.vllm_config.compilation_config.cudagraph_mode
+            if mode.has_full_cudagraphs():
+                raise NotImplementedError(
+                    "C8_MXFP QFA FULL-graph capture requires the .out() wrapper variant of "
+                    "cann_ops_transformer.quant_flash_attn (caller-owned output tensors for "
+                    "torch.npu.graph_task_group). The current wrapper only exposes the "
+                    "allocating variant, which cannot be captured safely. Apply the "
+                    "quant_flash_attn_out patch to the CANN package (or run with "
+                    "cudagraph_mode=PIECEWISE / NONE)."
+                )
+            # PIECEWISE capture: QFA executes outside the compiled region;
+            # proceed.
         if kv_cache is None or len(kv_cache) < 4:
             raise RuntimeError(
                 "C8_MXFP attention requires a (k, v, k_scale, v_scale) KV cache "

--- a/vllm_ascend/attention/attention_v1.py
+++ b/vllm_ascend/attention/attention_v1.py
@@ -550,9 +550,13 @@ class AscendC8MXFPMetadataBuilder(AscendAttentionMetadataBuilder):
     ) -> AttentionCGSupport:
         mode = vllm_config.compilation_config.cudagraph_mode
         if mode.has_piecewise_cudagraphs() and not mode.has_full_cudagraphs():
-            return AttentionCGSupport.PARTIAL
-        # FULL (incl. FULL_DECODE_ONLY): let the engine attempt the capture;
-        # the impl raises at capture time with the actionable reason.
+            # PIECEWISE: QFA runs outside the compiled region as a plain
+            # call (validated on-device). UNIFORM_BATCH is the support
+            # level the other piecewise-capable Ascend backends report
+            # (e.g. mla_v1); AttentionCGSupport has no PARTIAL member.
+            return AttentionCGSupport.UNIFORM_BATCH
+        # FULL (incl. FULL_DECODE_ONLY): npugraph_ex captures the
+        # allocating QFA wrapper natively (golden-test GRAPH_PATH=7).
         return AttentionCGSupport.ALWAYS
 
     def __init__(self, *args, **kwargs) -> None:

--- a/vllm_ascend/attention/attention_v1.py
+++ b/vllm_ascend/attention/attention_v1.py
@@ -2575,7 +2575,7 @@ class AscendC8MXFPAttentionBackendImpl(AscendAttentionBackendImpl):
             # reads it -- a minimal 5D E8M0 placeholder suffices. batch_size
             # must NOT be passed with a TND layout_q (the checker rejects
             # it); the op infers it from cu_seqlens_q.
-            _, metadata_op = _get_qfa_ops()
+            _, metadata_op, _ = _get_qfa_ops()
             # NOTE: torch_npu.float8_e8m0fnu is the integer dtype ID (293) on
             # this torch_npu build, not a torch.dtype; tensor.view() would
             # parse it as a target shape. Bitcast with the stock torch dtype

--- a/vllm_ascend/attention/attention_v1.py
+++ b/vllm_ascend/attention/attention_v1.py
@@ -2296,10 +2296,9 @@ class AscendC8AttentionBackendImpl(AscendAttentionBackendImpl):
 
 
 QFA_QUANT_MODE_MXFP8 = 1
-QFA_MASK_MODE_NO_MASK = 0
 QFA_MASK_MODE_CAUSAL = 3
 QFA_LAYOUT_TND = "TND"
-QFA_LAYOUT_PA_BNBD = "PA_BNBD"
+QFA_LAYOUT_PA_BBND = "PA_BBND"
 
 
 def _build_qfa_cu_seqlens(cumulative_seq_lengths: list[int], device: torch.device) -> torch.Tensor:
@@ -2321,7 +2320,21 @@ class AscendC8MXFPAttentionBackendImpl(AscendAttentionBackendImpl):
     per-channel E8M0 scale), scatters quantized K/V plus their scale caches
     into the paged cache, and calls
     ``torch_npu.npu_quant_flash_attn_metadata`` + ``torch_npu.npu_quant_flash_attn``
-    on the PA_BNBD transposed cache view.
+    directly on the paged cache.
+
+    Layout: PA_BBND. K/V and both E8M0 scale caches are stored in the natural
+    ``[num_blocks, block_size, num_kv_heads, head_dim]`` order that
+    reshape_and_cache writes, which is exactly what QFA's PA_BBND reads -- so
+    no layer ever transposes or copies the cache (the per-step
+    ``transpose(1,2).contiguous()`` full-cache copy of the FIA-based design is
+    gone; validated on-device by the vendored-QFA bring-up on the same
+    operator).
+
+    One QFA call per step: decode and prefill requests share a single
+    CAUSAL-masked invocation (cu_seqlens_q over the whole batch), instead of
+    per-subset calls -- the causal mask already covers decode rows and the
+    batch is smaller to feed. PrefillNoCache also reads from pages:
+    reshape_and_cache has written this step's K/V before attention runs.
 
     v1 scope (C8 branch): eager paths only. ACL graph capture (operator
     aclgraph "path 7") is pending the operator-side contract and raises here.
@@ -2332,10 +2345,12 @@ class AscendC8MXFPAttentionBackendImpl(AscendAttentionBackendImpl):
     dequant_scale_query/key/value, quant_scale_p, pa_block_size,
     return_softmax_lse=bool). The public ops-transformer extension exposes a
     DIFFERENT wrapper (cann_ops_transformer.quant_flash_attn: positional
-    q_descale/k_descale/v_descale, no pa_block_size, an extra
-    layout_q_descale); re-verify against the actual torch_npu build before
-    on-device bring-up. Any mismatch is confined to _get_qfa_metadata /
-    _run_qfa (see the bring-up checklist for the full signature diff).
+    q_descale/k_descale/v_descale, p_scale, no pa_block_size, an extra
+    layout_q_descale, and a v_descale placeholder requirement on the metadata
+    call); re-verify against the actual torch_npu build before on-device
+    bring-up. Any mismatch is confined to _get_qfa_metadata / _run_qfa (see
+    the bring-up checklist for the full signature diff and the
+    machine-validated vendored-wrapper call to fall back to).
     """
 
     # Installed via ``layer.impl.__class__`` assignment, which does not call
@@ -2343,24 +2358,6 @@ class AscendC8MXFPAttentionBackendImpl(AscendAttentionBackendImpl):
     # required for objects that predate the class swap.
     enable_hamming_sparse: bool = False
     _v_scale_filled_caches: set[torch.Tensor] | None = None
-
-    def _transpose_kv_cache(
-        self, kv_cache: tuple[torch.Tensor]
-    ) -> tuple[torch.Tensor]:
-        """Swap block_size (dim 1) and num_kv_heads (dim 2) on paged K/V for QFA.
-
-        [num_blocks, block_size, num_kv_heads, head_dim]
-        -> [num_blocks, num_kv_heads, block_size, head_dim]  (PA_BNBD)
-
-        The scale caches are already allocated in PA_BNBD order and are passed
-        through unchanged. TODO: the ``contiguous()`` materializes a full copy
-        of the cache per step; QFA documents non-contiguous K/V support for
-        PA layouts, so try dropping ``contiguous()`` during on-device
-        bring-up.
-        """
-        key = kv_cache[0].transpose(1, 2).contiguous()
-        value = kv_cache[1].transpose(1, 2).contiguous()
-        return (key, value, kv_cache[2], kv_cache[3])
 
     def _qfa_step_cache(self, attn_metadata: AscendMetadata) -> dict:
         cache = getattr(attn_metadata, "qfa_metadata_cache", None)
@@ -2373,25 +2370,27 @@ class AscendC8MXFPAttentionBackendImpl(AscendAttentionBackendImpl):
         self,
         attn_metadata: AscendMetadata,
         *,
-        subset: str,
         cu_seqlens_q: torch.Tensor,
         seqused_kv: torch.Tensor,
         batch_size: int,
         max_seqlen_q: int,
-        mask_mode: int,
     ):
-        """Return (computing once per step and subset) the QFA metadata plan."""
+        """Return (computing once per step) the QFA metadata plan.
+
+        The AICPU metadata operator is head/batch dependent but sequence-length
+        agnostic, so all full-attention layers of a step share one plan.
+        """
         cache = self._qfa_step_cache(attn_metadata)
-        metadata = cache.get(subset)
+        metadata = cache.get("step")
         if metadata is None:
             # TND + PA: pass cu_seqlens_q only; the KV side is addressed via
             # block_table + seqused_kv (QFA requirement doc, 3.2.3).
             # NOTE: kwargs follow the delivered torch_npu wrapper example in
             # the QFA requirement doc (3.4.2D). The public ops-transformer
-            # extension uses a different signature (positional
-            # q_descale/k_descale/v_descale, no pa_block_size, and an extra
-            # layout_q_descale); re-verify against the actual torch_npu build
-            # before on-device bring-up (see the bring-up checklist).
+            # wrapper is machine-validated to additionally require a non-null
+            # v_descale for quant_mode=1 (a minimal 5D E8M0 placeholder
+            # suffices) plus layout_q_descale; if the torch_npu build matches
+            # that API instead, add both here (see the bring-up checklist).
             metadata = torch_npu.npu_quant_flash_attn_metadata(
                 num_heads_q=self.num_heads,
                 num_heads_kv=self.num_kv_heads,
@@ -2404,14 +2403,14 @@ class AscendC8MXFPAttentionBackendImpl(AscendAttentionBackendImpl):
                 batch_size=batch_size,
                 max_seqlen_q=max_seqlen_q,
                 max_seqlen_kv=-1,
-                mask_mode=mask_mode,
+                mask_mode=QFA_MASK_MODE_CAUSAL,
                 win_left=-1,
                 win_right=-1,
                 layout_q=QFA_LAYOUT_TND,
-                layout_kv=QFA_LAYOUT_PA_BNBD,
+                layout_kv=QFA_LAYOUT_PA_BBND,
                 layout_out=QFA_LAYOUT_TND,
             )
-            cache[subset] = metadata
+            cache["step"] = metadata
         return metadata
 
     def _qfa_int8_mask(self, attn_metadata: AscendMetadata) -> torch.Tensor | None:
@@ -2428,54 +2427,54 @@ class AscendC8MXFPAttentionBackendImpl(AscendAttentionBackendImpl):
         self,
         quant_query: torch.Tensor,
         query_scale: torch.Tensor,
-        key: torch.Tensor,
-        value: torch.Tensor,
-        key_scale: torch.Tensor,
-        value_scale: torch.Tensor,
+        kv_cache: tuple[torch.Tensor],
         attn_metadata: AscendMetadata,
         *,
-        block_size: int,
-        block_table: torch.Tensor,
         cu_seqlens_q: torch.Tensor,
         seqused_kv: torch.Tensor,
         qfa_metadata,
         max_seqlen_q: int,
-        mask_mode: int,
         num_tokens: int,
         output: torch.Tensor,
-        token_offset: int = 0,
-        use_attn_mask: bool = True,
     ) -> torch.Tensor:
-        attn_mask = self._qfa_int8_mask(attn_metadata) if use_attn_mask else None
-        # TODO: decode passes the 4D (TND) q_descale, so tiling selects the
-        # prefill template for decode steps. Functionally fine (QFA only
-        # loses performance); switch to the 5D [N2, T, G, D//64, 2] decode
-        # layout as a follow-up optimization.
+        key, value, key_scale, value_scale = kv_cache
+        # PA_BBND: block axis is dim 1 of the paged K/V cache.
+        block_size = key.shape[1]
+        # The scale caches are stored as raw uint8 (index_put_ on float8
+        # either errors or falls back to AICPU); QFA's checker wants E8M0, so
+        # bitcast at the call boundary. Same for the q scale when the quant
+        # helper returns it as uint8 bytes.
+        if key_scale.dtype != torch.float8_e8m0fnu:
+            key_scale = key_scale.view(torch.float8_e8m0fnu)
+        if value_scale.dtype != torch.float8_e8m0fnu:
+            value_scale = value_scale.view(torch.float8_e8m0fnu)
+        if query_scale.dtype != torch.float8_e8m0fnu:
+            query_scale = query_scale.view(torch.float8_e8m0fnu)
         result = torch_npu.npu_quant_flash_attn(
-            quant_query[token_offset : token_offset + num_tokens],
+            quant_query,
             key,
             value,
-            dequant_scale_query=query_scale[token_offset : token_offset + num_tokens],
+            dequant_scale_query=query_scale,
             dequant_scale_key=key_scale,
             dequant_scale_value=value_scale,
-            block_table=block_table,
+            block_table=attn_metadata.block_tables,
             quant_scale_p=None,
             cu_seqlens_q=cu_seqlens_q,
             cu_seqlens_kv=None,
             seqused_q=None,
             seqused_kv=seqused_kv,
             sinks=None,
-            attn_mask=attn_mask,
+            attn_mask=self._qfa_int8_mask(attn_metadata),
             metadata=qfa_metadata,
             quant_mode=QFA_QUANT_MODE_MXFP8,
             softmax_scale=self.scale,
-            mask_mode=mask_mode,
+            mask_mode=QFA_MASK_MODE_CAUSAL,
             win_left=-1,
             win_right=-1,
             max_seqlen_q=max_seqlen_q,
             max_seqlen_kv=-1,
             layout_q=QFA_LAYOUT_TND,
-            layout_kv=QFA_LAYOUT_PA_BNBD,
+            layout_kv=QFA_LAYOUT_PA_BBND,
             layout_out=QFA_LAYOUT_TND,
             pa_block_size=block_size,
             return_softmax_lse=False,
@@ -2484,134 +2483,7 @@ class AscendC8MXFPAttentionBackendImpl(AscendAttentionBackendImpl):
         # builds; tolerate both tuple and single-tensor returns.
         attn_output = result[0] if isinstance(result, tuple) else result
         attn_output = attn_output.view(num_tokens, self.num_heads, self.head_size)
-        output[token_offset : token_offset + num_tokens] = attn_output
-        return output
-
-    def _forward_mxfp8_decode(
-        self,
-        quant_query: torch.Tensor,
-        query_scale: torch.Tensor,
-        kv_cache: tuple[torch.Tensor],
-        attn_metadata: AscendMetadata,
-        output: torch.Tensor,
-    ) -> torch.Tensor:
-        key, value, key_scale, value_scale = kv_cache[0], kv_cache[1], kv_cache[2], kv_cache[3]
-        # K/V are transposed to [num_blocks, num_kv_heads, block_size, head_dim].
-        block_size = key.shape[2]
-        num_decodes = attn_metadata.num_decodes
-        device = quant_query.device
-
-        # A decode query attends to the whole (paged) KV context, so the
-        # causal relation is implicit and no mask is needed (NO_MASK).
-        cu_seqlens_q = _build_qfa_cu_seqlens(attn_metadata.actual_seq_lengths_q[:num_decodes], device)
-        seqused_kv = torch.tensor(attn_metadata.seq_lens_list[:num_decodes], dtype=torch.int32, device=device)
-        max_seqlen_q = 1
-
-        qfa_metadata = self._get_qfa_metadata(
-            attn_metadata,
-            subset="decode",
-            cu_seqlens_q=cu_seqlens_q,
-            seqused_kv=seqused_kv,
-            batch_size=num_decodes,
-            max_seqlen_q=max_seqlen_q,
-            mask_mode=QFA_MASK_MODE_NO_MASK,
-        )
-        return self._run_qfa(
-            quant_query,
-            query_scale,
-            key,
-            value,
-            key_scale,
-            value_scale,
-            attn_metadata,
-            block_size=block_size,
-            block_table=attn_metadata.block_tables[:num_decodes],
-            cu_seqlens_q=cu_seqlens_q,
-            seqused_kv=seqused_kv,
-            qfa_metadata=qfa_metadata,
-            max_seqlen_q=max_seqlen_q,
-            mask_mode=QFA_MASK_MODE_NO_MASK,
-            num_tokens=attn_metadata.num_decode_tokens,
-            output=output,
-            use_attn_mask=False,
-        )
-
-    def _forward_mxfp8_prefill(
-        self,
-        quant_query: torch.Tensor,
-        query_scale: torch.Tensor,
-        kv_cache: tuple[torch.Tensor],
-        attn_metadata: AscendMetadata,
-        output: torch.Tensor,
-        *,
-        token_offset: int,
-    ) -> torch.Tensor:
-        """Prefill path: paged FP8 KV + scale cache (K/V read from the transposed cache)."""
-        actual_seq_qlen_full = attn_metadata.actual_seq_lengths_q
-        num_tokens = int(actual_seq_qlen_full[-1])  # type: ignore[index]
-        num_prefill_tokens = num_tokens - token_offset
-        if num_prefill_tokens <= 0:
-            return output
-
-        num_decodes = attn_metadata.num_decodes
-        device = quant_query.device
-        # Cumulative query lengths of the prefill subset, relative to token_offset.
-        prefill_seq_qlen = [
-            actual_seq_qlen_full[i] - token_offset for i in range(num_decodes, len(actual_seq_qlen_full))
-        ]
-        cu_seqlens_q = _build_qfa_cu_seqlens(prefill_seq_qlen, device)
-        seqused_kv = torch.tensor(attn_metadata.seq_lens_list[num_decodes:], dtype=torch.int32, device=device)
-        max_seqlen_q = max(int(attn_metadata.max_query_len or 1), 1)
-
-        qfa_metadata = self._get_qfa_metadata(
-            attn_metadata,
-            subset="prefill",
-            cu_seqlens_q=cu_seqlens_q,
-            seqused_kv=seqused_kv,
-            batch_size=len(prefill_seq_qlen),
-            max_seqlen_q=max_seqlen_q,
-            mask_mode=QFA_MASK_MODE_CAUSAL,
-        )
-        return self._run_qfa(
-            quant_query,
-            query_scale,
-            kv_cache[0],
-            kv_cache[1],
-            kv_cache[2],
-            kv_cache[3],
-            attn_metadata,
-            block_size=kv_cache[0].shape[2],
-            block_table=attn_metadata.block_tables[num_decodes:],
-            cu_seqlens_q=cu_seqlens_q,
-            seqused_kv=seqused_kv,
-            qfa_metadata=qfa_metadata,
-            max_seqlen_q=max_seqlen_q,
-            mask_mode=QFA_MASK_MODE_CAUSAL,
-            num_tokens=num_prefill_tokens,
-            output=output,
-            token_offset=token_offset,
-            use_attn_mask=True,
-        )
-
-    def _forward_mxfp8_chunked_prefill(
-        self,
-        quant_query: torch.Tensor,
-        query_scale: torch.Tensor,
-        kv_cache: tuple[torch.Tensor],
-        attn_metadata: AscendMetadata,
-        output: torch.Tensor,
-    ) -> torch.Tensor:
-        """ChunkedPrefill: decode requests first, then prefill (same batch ordering as MLA)."""
-        if attn_metadata.num_decodes > 0:
-            self._forward_mxfp8_decode(quant_query, query_scale, kv_cache, attn_metadata, output)
-        self._forward_mxfp8_prefill(
-            quant_query,
-            query_scale,
-            kv_cache,
-            attn_metadata,
-            output,
-            token_offset=attn_metadata.num_decode_tokens,
-        )
+        output[:num_tokens] = attn_output
         return output
 
     def _forward_mxfp8_attention(
@@ -2622,19 +2494,50 @@ class AscendC8MXFPAttentionBackendImpl(AscendAttentionBackendImpl):
         attn_metadata: AscendMetadata,
         output: torch.Tensor,
     ) -> torch.Tensor:
+        """One QFA call per step for the whole batch (decode + prefill alike).
+
+        The causal mask covers decode rows as well, so the per-subset split of
+        the FIA-based design is unnecessary. PrefillNoCache is included:
+        reshape_and_cache has already written this step's K/V into the paged
+        cache before attention runs (single-call design validated on-device
+        by the vendored-QFA bring-up).
+        """
         if not attn_metadata.causal:
             raise NotImplementedError("C8_MXFP attention does not support non-causal attention yet.")
         if self.sliding_window is not None:
             raise NotImplementedError("C8_MXFP attention does not support sliding window attention yet.")
 
-        if attn_metadata.attn_state == AscendAttentionState.DecodeOnly:
-            return self._forward_mxfp8_decode(quant_query, query_scale, kv_cache, attn_metadata, output)
-        if attn_metadata.attn_state == AscendAttentionState.ChunkedPrefill:
-            return self._forward_mxfp8_chunked_prefill(
-                quant_query, query_scale, kv_cache, attn_metadata, output
-            )
-        return self._forward_mxfp8_prefill(
-            quant_query, query_scale, kv_cache, attn_metadata, output, token_offset=0
+        device = quant_query.device
+        actual_seq_lengths_q = attn_metadata.actual_seq_lengths_q
+        num_tokens = int(actual_seq_lengths_q[-1])  # type: ignore[index]
+        if num_tokens <= 0:
+            return output
+        cu_seqlens_q = _build_qfa_cu_seqlens(actual_seq_lengths_q, device)
+        seqused_kv = torch.tensor(attn_metadata.seq_lens_list, dtype=torch.int32, device=device)
+        # Upper bound on any single query length (the step's total token
+        # count); the vendored-QFA bring-up measured prefill against a constant
+        # max_model_len bound as safe too, so a loose bound only affects
+        # tiling, not correctness.
+        max_seqlen_q = num_tokens
+
+        qfa_metadata = self._get_qfa_metadata(
+            attn_metadata,
+            cu_seqlens_q=cu_seqlens_q,
+            seqused_kv=seqused_kv,
+            batch_size=len(seqused_kv),
+            max_seqlen_q=max_seqlen_q,
+        )
+        return self._run_qfa(
+            quant_query,
+            query_scale,
+            kv_cache,
+            attn_metadata,
+            cu_seqlens_q=cu_seqlens_q,
+            seqused_kv=seqused_kv,
+            qfa_metadata=qfa_metadata,
+            max_seqlen_q=max_seqlen_q,
+            num_tokens=num_tokens,
+            output=output,
         )
 
     # KV cache writes for C8_MXFP happen in reshape_and_cache(), invoked from forward()
@@ -2680,7 +2583,9 @@ class AscendC8MXFPAttentionBackendImpl(AscendAttentionBackendImpl):
         # cache are both initialized without a reset hook).
         key_scale_cache, value_scale_cache = kv_cache[2], kv_cache[3]
         scatter_mxfp_k_scale_cache(
-            key_scale,
+            # Byte view: index_put_ on float8 either errors or falls back to
+            # AICPU (the cache side is already uint8 raw storage).
+            key_scale.view(torch.uint8) if key_scale.dtype != torch.uint8 else key_scale,
             key_scale_cache,
             slot_mapping,
             key_cache.shape[1],
@@ -2691,13 +2596,13 @@ class AscendC8MXFPAttentionBackendImpl(AscendAttentionBackendImpl):
             self._v_scale_filled_caches = filled_caches
         if value_scale_cache not in filled_caches:
             # (hidden_size) -> (num_kv_heads, head_size) -> broadcast ->
-            # (num_blocks, num_kv_heads, block_size // 64, head_size, 2).
-            # Derive num_kv_heads / v head_dim from the cache layout instead
-            # of self.num_kv_heads / self.head_size so models whose V head
-            # dim differs from the Q/K head dim stay correct.
-            num_kv_heads = value_scale_cache.shape[1]
+            # (num_blocks, block_size // 64, num_kv_heads, head_size, 2)
+            # (PA_BBND). Derive num_kv_heads / v head_dim from the cache
+            # layout instead of self.num_kv_heads / self.head_size so models
+            # whose V head dim differs from the Q/K head dim stay correct.
+            num_kv_heads = value_scale_cache.shape[2]
             v_head_dim = value_scale_cache.shape[3]
-            value_scale_cache.copy_(value_scale.view(1, num_kv_heads, 1, v_head_dim, 1))
+            value_scale_cache.copy_(value_scale.view(1, 1, num_kv_heads, v_head_dim, 1))
             filled_caches.add(value_scale_cache)
 
     def forward(
@@ -2777,7 +2682,6 @@ class AscendC8MXFPAttentionBackendImpl(AscendAttentionBackendImpl):
                 key_mxfp8, value_mxfp8, key_scale, layer.v_cache_scale, kv_cache, attn_metadata
             )
 
-        qfa_kv_cache = self._transpose_kv_cache(kv_cache)
-        return self._forward_mxfp8_attention(
-            query_mxfp8, query_scale, qfa_kv_cache, attn_metadata, output
-        )
+        # PA_BBND: QFA reads the paged cache in the order it is stored, so the
+        # cache tuple is passed through as-is -- no transpose, no copy.
+        return self._forward_mxfp8_attention(query_mxfp8, query_scale, kv_cache, attn_metadata, output)

--- a/vllm_ascend/attention/attention_v1.py
+++ b/vllm_ascend/attention/attention_v1.py
@@ -223,6 +223,16 @@ class AscendMetadata:
     # Maximum query length in the batch (None for decoding).
     max_query_len: int | None = None
 
+    # Persistent GPU-side length sources, refreshed in place by the model
+    # runner every step: query_start_loc_gpu is the 0-prefixed cumulative
+    # query boundaries (int32) and seq_lens_gpu the per-request KV lengths
+    # (int32). Graph-capturing backends must source cu_seqlens/seqused from
+    # these instead of the CPU lists above -- ACL-graph replay re-executes
+    # only device work, so Python-side refreshes of hand-managed buffers
+    # never run again after capture.
+    query_start_loc_gpu: torch.Tensor = None
+    seq_lens_gpu: torch.Tensor = None
+
     # ********************** KV Cache Related Properties ********************* #
     # Block addresses per sequence (Seq id -> list of physical block).
     # (batch_size, max_blocks_per_seq)
@@ -432,6 +442,8 @@ class AscendAttentionMetadataBuilder(AttentionMetadataBuilder[AscendMetadata]):
             num_decode_tokens=num_decode_tokens,
             block_tables=block_table,
             query_start_loc=query_start_loc,
+            query_start_loc_gpu=common_attn_metadata.query_start_loc,
+            seq_lens_gpu=common_attn_metadata.seq_lens,
             seq_lens=seq_lens,
             seq_lens_cpu=seq_lens,
             seq_lens_list=seq_lens_list,
@@ -529,17 +541,15 @@ class AscendC8MXFPMetadataBuilder(AscendAttentionMetadataBuilder):
     The generic Ascend builder sizes its block-table width with the
     128-token generic block; this backend uses 512-token kernel blocks.
 
-    Cudagraph support is staged (phase-2 bring-up):
-    - PIECEWISE: supported -- QFA executes outside the compiled region as a
-      plain call (validated on-device by the vendored-QFA bring-up PR).
-    - FULL / FULL_DECODE_ONLY: the engine is allowed to attempt capture so
-      the missing .out() wrapper variant surfaces as a concrete capture-time
-      failure instead of being silently downgraded to eager. The vendored
-      bring-up proved the aclnn layer itself is out-semantics and works in
-      FULL graphs once the wrapper exposes caller-owned outputs; until the
-      cann_ops_transformer patch lands, FULL capture is expected to fail or
-      replay corrupt -- the impl guards with an explicit error at capture
-      time.
+    Cudagraph support (final form, no .out wrapper variant needed):
+    - PIECEWISE: QFA executes outside the compiled region as a plain call.
+    - FULL / FULL_DECODE_ONLY: npugraph_ex captures the allocating QFA
+      wrapper plus the in-graph metadata op natively (golden-test
+      GRAPH_PATH=7 methodology). Replay correctness relies on the model
+      runner's persistent length buffers (query_start_loc_gpu /
+      seq_lens_gpu), which the impl derives QFA's cu_seqlens/seqused from
+      through captured device-side ops, so every replay re-reads the
+      current step's lengths.
     """
 
     @classmethod
@@ -2392,12 +2402,18 @@ class AscendC8MXFPAttentionBackendImpl(AscendAttentionBackendImpl):
     Graph capture: handled natively by torch_npu's npugraph_ex backend (the
     FULL-graph mechanism of this vLLM build), following the ops-transformer
     golden-test methodology (GRAPH_PATH=7). The allocating wrapper is
-    captured directly (at::empty outputs land in the graph pool), the AICPU
-    metadata op runs inline inside the graph, and our only obligations are
-    graph-safe surrounding code: the K-scale scatter uses a device-side
-    mask pattern (no host sync) and the per-step length tensors are written
-    into persistent instance-owned buffers (no H2D construction inside the
-    captured region). Speculative decoding remains out of scope for v1.
+    captured directly (at::empty outputs land in the graph pool) and the
+    AICPU metadata op runs inline inside the graph. Replay safety relies on
+    every per-step input being a stable-address tensor whose content is
+    refreshed outside Python: block_table / slot_mapping come from the
+    model runner's persistent CpuGpuBuffer storages, and cu_seqlens_q /
+    seqused_kv are derived IN-GRAPH from the runner's persistent
+    query_start_loc / seq_lens buffers (captured clamp/cummax ops re-execute
+    each replay). The K-scale scatter uses a device-side mask pattern (no
+    host sync). No Python-side buffer refresh exists in the captured
+    region -- ACL-graph replay never re-runs Python, so such refreshes
+    would freeze at capture values. Speculative decoding remains out of
+    scope for v1.
 
     NOTE: the QFA dual operators are called through _get_qfa_ops(), which
     resolves cann_ops_transformer.ops.quant_flash_attn(_metadata) -- the
@@ -2442,9 +2458,13 @@ class AscendC8MXFPAttentionBackendImpl(AscendAttentionBackendImpl):
         during capture are free (AICPU, ~us) and each layer's captured call
         consumes the plan it just produced.
         """
-        use_step_cache = not (
-            _EXTRA_CTX.capturing and self.vllm_config.compilation_config.cudagraph_mode.has_full_cudagraphs()
-        )
+        # Bypass the cache during ANY graph capture (FULL and PIECEWISE
+        # warmups alike): the metadata op must execute inside the captured
+        # region so each replay recomputes the plan from the replayed
+        # length buffers. During PIECEWISE capture the attention runs
+        # eagerly between the compiled pieces, so the uncached per-layer
+        # calls are just normal eager executions (~us, AICPU).
+        use_step_cache = not _EXTRA_CTX.capturing
         cache = self._qfa_step_cache(attn_metadata) if use_step_cache else {}
         metadata = cache.get("step")
         if metadata is None:
@@ -2585,28 +2605,53 @@ class AscendC8MXFPAttentionBackendImpl(AscendAttentionBackendImpl):
         by the vendored-QFA bring-up).
 
         npugraph_ex capture compatibility (golden-test methodology,
-        GRAPH_PATH=7): everything from here down is device-side work on
-        persistent tensors -- cu_seqlens_q / seqused_kv are refreshed each
-        step via pinned CPU staging tensors copied into instance-owned NPU
-        buffers (torch.tensor(device="npu") is an H2D aclrtMemcpy, illegal
-        mid-capture), and the AICPU metadata op is called inline so the
-        captured graph recomputes the plan from the replayed length buffers
-        each step. The per-step Python-side metadata cache is disabled during
-        capture so the metadata op is always re-executed inside the graph.
+        GRAPH_PATH=7): cu_seqlens_q / seqused_kv are derived ON DEVICE from
+        the model runner's persistent int32 buffers (query_start_loc.gpu /
+        seq_lens), which _prepare_inputs refreshes in place every step.
+        The deriving ops are captured together with the QFA calls, so every
+        replay re-executes them and the operators always see the current
+        step's lengths. This replaces the former Python-side staging
+        writes: ACL-graph replay never re-runs Python, so those refreshes
+        only executed during capture and froze the buffers at capture
+        values (and the pinned staging buffer itself was racy under the
+        async scheduler, where the host could overwrite it while the
+        previous step's async H2D copy was still in flight).
         """
         if not attn_metadata.causal:
             raise NotImplementedError("C8_MXFP attention does not support non-causal attention yet.")
         if self.sliding_window is not None:
             raise NotImplementedError("C8_MXFP attention does not support sliding window attention yet.")
 
-        device = quant_query.device
-        actual_seq_lengths_q = attn_metadata.actual_seq_lengths_q
-        num_tokens = int(actual_seq_lengths_q[-1])  # type: ignore[index]
+        # T as QFA sees it: the query rows actually fed to the operator
+        # (forward slices query[:num_actual_tokens] before quantizing), so
+        # the TND constraint cu_seqlens_q[-1] == T, the view/output row
+        # counts and the sanitize clamp bound below all share one source.
+        # At graph capture this is the bucket size; eagerly it is the real
+        # token count -- both stay clean where actual_seq_lengths_q[-1]
+        # may carry stale tail entries (padded batches).
+        num_tokens = quant_query.shape[0]
         if num_tokens <= 0:
             return output
 
-        cu_seqlens_q = self._write_qfa_cu_seqlens(actual_seq_lengths_q, device)
-        seqused_kv = self._write_qfa_seqused(attn_metadata.seq_lens_list, device)
+        qsl_gpu = attn_metadata.query_start_loc_gpu
+        seq_lens_gpu = attn_metadata.seq_lens_gpu
+        if qsl_gpu is None or seq_lens_gpu is None:
+            raise RuntimeError(
+                "C8_MXFP attention requires the GPU-side length sources "
+                "(query_start_loc_gpu / seq_lens_gpu) on AscendMetadata."
+            )
+        # Sanitize the tail beyond the current requests: unused
+        # query_start_loc slots carry -1 (the FIA padding convention) and
+        # may also hold stale entries from larger earlier steps (the FULL
+        # dummy-request padding re-copies the whole CPU buffer to GPU).
+        # clamp to [0, num_tokens] bounds both; cummax restores
+        # monotonicity, turning the tail into zero-length requests whose
+        # cu_seqlens_q[-1] still equals the token total. Unused seq_lens
+        # slots are zero-filled by the runner every step; clamp(min=1)
+        # matches the dummy-request convention (block 0, one token). On
+        # clean eager data both ops are identity transforms.
+        cu_seqlens_q = qsl_gpu.clamp(min=0, max=num_tokens).cummax(dim=0).values
+        seqused_kv = seq_lens_gpu.clamp(min=1)
         # Upper bound on any single query length (the step's total token
         # count); the vendored-QFA bring-up measured prefill against a constant
         # max_model_len bound as safe too, so a loose bound only affects
@@ -2631,64 +2676,6 @@ class AscendC8MXFPAttentionBackendImpl(AscendAttentionBackendImpl):
             num_tokens=num_tokens,
             output=output,
         )
-
-    def _write_qfa_cu_seqlens(self, cumulative_seq_lengths: list[int], device: torch.device) -> torch.Tensor:
-        """Write cu_seqlens (0-prefixed cumulative) into a persistent buffer.
-
-        Eager path: identical semantics to _build_qfa_cu_seqlens. Capture
-        path: the write goes through a persistent CPU-side staging tensor
-        (pinned) into the persistent NPU buffer, so the captured graph sees
-        only a D2D copy between two stable allocations -- torch.tensor(...,
-        device="npu") would be an H2D aclrtMemcpy, which is illegal
-        mid-capture ("operation not permitted when a stream is capturing").
-        The staging tensor's CONTENTS are refreshed from the host list each
-        step before the copy, so replays that re-execute the copy pick up
-        the current values.
-        """
-        num_tokens = int(cumulative_seq_lengths[-1]) if cumulative_seq_lengths else 0
-        num_seqs = len(cumulative_seq_lengths)
-        cu_buf, _, cu_cpu, _ = self._qfa_step_buffers(max(num_tokens, 1), num_seqs, device)
-        cu_cpu[: num_seqs + 1] = torch.tensor(
-            [0, *cumulative_seq_lengths], dtype=torch.int32, device="cpu"
-        )
-        cu_buf[: num_seqs + 1].copy_(cu_cpu[: num_seqs + 1], non_blocking=True)
-        return cu_buf[: num_seqs + 1]
-
-    def _write_qfa_seqused(self, seq_lens_list: list[int], device: torch.device) -> torch.Tensor:
-        """Write seqused_kv into a persistent buffer (see _write_qfa_cu_seqlens)."""
-        num_tokens = sum(seq_lens_list) if seq_lens_list else 0
-        num_seqs = len(seq_lens_list)
-        _, seq_buf, _, seq_cpu = self._qfa_step_buffers(max(num_tokens, 1), num_seqs, device)
-        seq_cpu[:num_seqs] = torch.tensor(seq_lens_list, dtype=torch.int32, device="cpu")
-        seq_buf[:num_seqs].copy_(seq_cpu[:num_seqs], non_blocking=True)
-        return seq_buf[:num_seqs]
-
-    def _qfa_step_buffers(self, num_tokens: int, num_seqs: int, device: torch.device) -> tuple:
-        """Instance-owned persistent buffers for the per-step lengths.
-
-        Returns (cu_buf, seq_buf, cu_cpu, seq_cpu): the NPU-side int32
-        buffers the captured graph reads, plus CPU-side int32 staging
-        tensors (pinned memory) that feed them via D2D copy_ each step.
-        torch.tensor(..., device="npu") is an H2D aclrtMemcpy and illegal
-        inside ACL graph capture, so the host values are first written into
-        the CPU staging tensors and then copied into the NPU buffers. The
-        buffers are sized to the capture bucket (num_tokens) and rewritten
-        every step, so replay refreshes them in-place.
-        """
-        if not hasattr(self, "_qfa_len_buffers"):
-            self._qfa_len_buffers = {}
-        key = (num_tokens, num_seqs)
-        if key not in self._qfa_len_buffers:
-            # cu_seqlens_q needs B+1 entries; overallocate to the max batch
-            # for this token bucket to survive mixed batch shapes.
-            max_seqs = max(num_seqs, num_tokens) + 1
-            self._qfa_len_buffers[key] = (
-                torch.zeros(max_seqs + 1, dtype=torch.int32, device=device),
-                torch.zeros(max_seqs, dtype=torch.int32, device=device),
-                torch.zeros(max_seqs + 1, dtype=torch.int32, pin_memory=True),
-                torch.zeros(max_seqs, dtype=torch.int32, pin_memory=True),
-            )
-        return self._qfa_len_buffers[key]
 
     # KV cache writes for C8_MXFP happen in reshape_and_cache(), invoked from forward()
     # when key/value are present. This hook is only reached when attention is split from
@@ -2789,9 +2776,10 @@ class AscendC8MXFPAttentionBackendImpl(AscendAttentionBackendImpl):
             # (GRAPH_PATH=7: torch.compile(backend="npugraph_ex") with the
             # metadata op called inline in forward). The requirements on our
             # side are only graph-safety of the surrounding Python: no host
-            # syncs (scatter uses the device-side mask pattern) and no H2D
-            # tensor construction inside the captured region (cu_seqlens /
-            # seqused are written into persistent instance-owned buffers).
+            # syncs (scatter uses the device-side mask pattern) and no
+            # Python-side refresh of tensors the captured region consumes
+            # (replay never re-runs Python; the per-step lengths are derived
+            # in-graph from the runner's persistent buffers instead).
             pass
         if kv_cache is None or len(kv_cache) < 4:
             raise RuntimeError(

--- a/vllm_ascend/attention/attention_v1.py
+++ b/vllm_ascend/attention/attention_v1.py
@@ -252,9 +252,10 @@ class AscendMetadata:
 
     # Per-step scratch for C8-MXFP (QFA) layers. The builder creates one
     # AscendMetadata per step shared by all attention layers, so the QFA
-    # metadata operator output and the int8 causal mask are computed once per
-    # step (per decode/prefill subset) instead of once per layer. Keys:
-    # "decode" / "prefill" -> QFA metadata tensor, "attn_mask_int8" -> Tensor.
+    # metadata operator output is computed once per step instead of once
+    # per layer. Key: "step" -> QFA metadata tensor. Only used on the eager
+    # path -- graph capture bypasses the cache so the metadata op executes
+    # inside the captured region.
     qfa_metadata_cache: dict = field(default_factory=dict)
 
 
@@ -2777,20 +2778,6 @@ class AscendC8MXFPAttentionBackendImpl(AscendAttentionBackendImpl):
             raise NotImplementedError("C8_MXFP attention does not support hamming sparse KV compression yet.")
         if self.vllm_config.kv_transfer_config is not None:
             raise NotImplementedError("C8_MXFP v1 does not support PD disaggregation (kv_transfer) yet.")
-        if _EXTRA_CTX.capturing:
-            # Graph capture is handled natively by npugraph_ex (the backend
-            # this vLLM build uses for FULL graphs -- confirmed in the
-            # on-device capture stack): it captures the ALLOCATING QFA
-            # wrapper directly (internal at::empty lands in the graph pool),
-            # and the ops-transformer golden tests exercise exactly this
-            # (GRAPH_PATH=7: torch.compile(backend="npugraph_ex") with the
-            # metadata op called inline in forward). The requirements on our
-            # side are only graph-safety of the surrounding Python: no host
-            # syncs (scatter uses the device-side mask pattern) and no
-            # Python-side refresh of tensors the captured region consumes
-            # (replay never re-runs Python; the per-step lengths are derived
-            # in-graph from the runner's persistent buffers instead).
-            pass
         if kv_cache is None or len(kv_cache) < 4:
             raise RuntimeError(
                 "C8_MXFP attention requires a (k, v, k_scale, v_scale) KV cache "

--- a/vllm_ascend/attention/attention_v1.py
+++ b/vllm_ascend/attention/attention_v1.py
@@ -558,14 +558,6 @@ class AscendC8MXFPMetadataBuilder(AscendAttentionMetadataBuilder):
         vllm_config: VllmConfig,
         kv_cache_spec,
     ) -> AttentionCGSupport:
-        if vllm_config.speculative_config is not None:
-            # MTP bring-up stage: force attention eager so the draft-step
-            # eager semantics (per-step metadata, spec slot writes) land
-            # first. The draft FULL graph reuses the same
-            # persistent-buffer derivation chain (Step3.5 proposer refreshes
-            # query_start_loc/seq_lens in place before each replay) and is
-            # re-enabled after the eager bring-up is verified.
-            return AttentionCGSupport.NEVER
         mode = vllm_config.compilation_config.cudagraph_mode
         if mode.has_piecewise_cudagraphs() and not mode.has_full_cudagraphs():
             # PIECEWISE: QFA runs outside the compiled region as a plain
@@ -575,6 +567,15 @@ class AscendC8MXFPMetadataBuilder(AscendAttentionMetadataBuilder):
             return AttentionCGSupport.UNIFORM_BATCH
         # FULL (incl. FULL_DECODE_ONLY): npugraph_ex captures the
         # allocating QFA wrapper natively (golden-test GRAPH_PATH=7).
+        # Spec decode (MTP) included: the draft graph is a plain
+        # torch.npu.graph ACLGraphWrapper capture whose metadata goes
+        # through the same builder.build() (field passthrough) and whose
+        # per-step lengths live in the proposer's persistent buffers,
+        # refreshed in place before each draft replay -- the same
+        # stable-address contract as the main-model graphs. During draft
+        # capture _EXTRA_CTX.capturing is set by the ACLGraphWrapper
+        # (shared forward-context object), so the QFA metadata op is
+        # still executed inline inside the captured region.
         return AttentionCGSupport.ALWAYS
 
     def __init__(self, *args, **kwargs) -> None:
@@ -2421,10 +2422,10 @@ class AscendC8MXFPAttentionBackendImpl(AscendAttentionBackendImpl):
     host sync). No Python-side buffer refresh exists in the captured
     region -- ACL-graph replay never re-runs Python, so such refreshes
     would freeze at capture values. Speculative decoding (MTP) uses the
-    same derivation chain: the draft metadata builders route through
-    AscendAttentionMetadataBuilder.build(), and the Step3.5 proposer
-    refreshes its persistent query_start_loc/seq_lens buffers in place
-    before each draft-step replay.
+    same derivation chain: the draft metadata builder routes through
+    AscendAttentionMetadataBuilder.build(), and the MTP proposer
+    refreshes its persistent query_start_loc/seq_lens/block-table
+    buffers in place before each draft-step replay.
 
     NOTE: the QFA dual operators are called through _get_qfa_ops(), which
     resolves cann_ops_transformer.ops.quant_flash_attn(_metadata) -- the

--- a/vllm_ascend/attention/attention_v1.py
+++ b/vllm_ascend/attention/attention_v1.py
@@ -2312,6 +2312,34 @@ def _build_qfa_cu_seqlens(cumulative_seq_lengths: list[int], device: torch.devic
     return torch.tensor([0, *cumulative_seq_lengths], dtype=torch.int32, device=device)
 
 
+# Resolved lazily and cached: (main_op, metadata_op). The QFA dual operators
+# are delivered through the cann_ops_transformer package shipped with the
+# CANN toolkit (confirmed final delivery form). That wrapper's call shape
+# (verified on-device): positional q/k/v/q_descale/k_descale/v_descale/
+# quant_mode, p_scale instead of quant_scale_p, an extra layout_q_descale,
+# no pa_block_size, and a required non-null v_descale placeholder on the
+# metadata call for quant_mode=1 (batch_size must not be passed with a TND
+# layout_q; the op infers it from cu_seqlens_q).
+_QFA_OPS: tuple[Any, Any] | None = None
+
+
+def _get_qfa_ops() -> tuple[Any, Any]:
+    global _QFA_OPS
+    if _QFA_OPS is None:
+        try:
+            from cann_ops_transformer.ops import quant_flash_attn as main_op
+            from cann_ops_transformer.ops import quant_flash_attn_metadata as metadata_op
+        except ImportError:
+            raise RuntimeError(
+                "C8_MXFP requires the QFA dual operators delivered in the "
+                "cann_ops_transformer package (shipped with the CANN toolkit): "
+                "cann_ops_transformer.ops.quant_flash_attn(_metadata) could not "
+                "be imported in this environment."
+            ) from None
+        _QFA_OPS = (main_op, metadata_op)
+    return _QFA_OPS
+
+
 class AscendC8MXFPAttentionBackendImpl(AscendAttentionBackendImpl):
     """MXFP8 KV cache backend computed by the QFA dual-operator interface.
 
@@ -2319,8 +2347,8 @@ class AscendC8MXFPAttentionBackendImpl(AscendAttentionBackendImpl):
     per-token-group E8M0 scales) and V statically (the checkpoint's
     per-channel E8M0 scale), scatters quantized K/V plus their scale caches
     into the paged cache, and calls
-    ``torch_npu.npu_quant_flash_attn_metadata`` + ``torch_npu.npu_quant_flash_attn``
-    directly on the paged cache.
+    ``cann_ops_transformer.ops.quant_flash_attn_metadata`` +
+    ``cann_ops_transformer.ops.quant_flash_attn`` directly on the paged cache.
 
     Layout: PA_BBND. K/V and both E8M0 scale caches are stored in the natural
     ``[num_blocks, block_size, num_kv_heads, head_dim]`` order that
@@ -2340,17 +2368,14 @@ class AscendC8MXFPAttentionBackendImpl(AscendAttentionBackendImpl):
     aclgraph "path 7") is pending the operator-side contract and raises here.
     Speculative decoding is also out of scope for v1.
 
-    NOTE: kwarg names of the two QFA calls follow the QFA requirement doc's
-    torch-level calling example (torch_npu.npu_quant_flash_attn*,
-    dequant_scale_query/key/value, quant_scale_p, pa_block_size,
-    return_softmax_lse=bool). The public ops-transformer extension exposes a
-    DIFFERENT wrapper (cann_ops_transformer.quant_flash_attn: positional
-    q_descale/k_descale/v_descale, p_scale, no pa_block_size, an extra
-    layout_q_descale, and a v_descale placeholder requirement on the metadata
-    call); re-verify against the actual torch_npu build before on-device
-    bring-up. Any mismatch is confined to _get_qfa_metadata / _run_qfa (see
-    the bring-up checklist for the full signature diff and the
-    machine-validated vendored-wrapper call to fall back to).
+    NOTE: the QFA dual operators are called through _get_qfa_ops(), which
+    resolves cann_ops_transformer.ops.quant_flash_attn(_metadata) -- the
+    confirmed final delivery form, shipped with the CANN toolkit. That
+    wrapper's signature (verified on-device via inspect + the vendored-QFA
+    bring-up) differs from the requirement doc's torch_npu example: positional
+    q_descale/k_descale/v_descale/quant_mode, p_scale instead of
+    quant_scale_p, an extra layout_q_descale, no pa_block_size, and a
+    required v_descale placeholder on the metadata call for quant_mode=1.
     """
 
     # Installed via ``layer.impl.__class__`` assignment, which does not call
@@ -2372,7 +2397,6 @@ class AscendC8MXFPAttentionBackendImpl(AscendAttentionBackendImpl):
         *,
         cu_seqlens_q: torch.Tensor,
         seqused_kv: torch.Tensor,
-        batch_size: int,
         max_seqlen_q: int,
     ):
         """Return (computing once per step) the QFA metadata plan.
@@ -2385,28 +2409,32 @@ class AscendC8MXFPAttentionBackendImpl(AscendAttentionBackendImpl):
         if metadata is None:
             # TND + PA: pass cu_seqlens_q only; the KV side is addressed via
             # block_table + seqused_kv (QFA requirement doc, 3.2.3).
-            # NOTE: kwargs follow the delivered torch_npu wrapper example in
-            # the QFA requirement doc (3.4.2D). The public ops-transformer
-            # wrapper is machine-validated to additionally require a non-null
-            # v_descale for quant_mode=1 (a minimal 5D E8M0 placeholder
-            # suffices) plus layout_q_descale; if the torch_npu build matches
-            # that API instead, add both here (see the bring-up checklist).
-            metadata = torch_npu.npu_quant_flash_attn_metadata(
-                num_heads_q=self.num_heads,
-                num_heads_kv=self.num_kv_heads,
-                head_dim=self.head_size,
-                quant_mode=QFA_QUANT_MODE_MXFP8,
+            # quant_mode=1 refuses a null v_descale at the aclnn entry
+            # (quant_flash_attn_metadata_check.h), but under PA_BBND nothing
+            # reads it -- a minimal 5D E8M0 placeholder suffices. batch_size
+            # must NOT be passed with a TND layout_q (the checker rejects
+            # it); the op infers it from cu_seqlens_q.
+            _, metadata_op = _get_qfa_ops()
+            v_descale_stub = torch.zeros(
+                1, 1, 1, 1, 2, dtype=torch.uint8, device=cu_seqlens_q.device
+            ).view(torch_npu.float8_e8m0fnu)
+            metadata = metadata_op(
+                self.num_heads,
+                self.num_kv_heads,
+                self.head_size,
+                QFA_QUANT_MODE_MXFP8,
                 cu_seqlens_q=cu_seqlens_q,
                 cu_seqlens_kv=None,
                 seqused_q=None,
                 seqused_kv=seqused_kv,
-                batch_size=batch_size,
+                v_descale=v_descale_stub,
                 max_seqlen_q=max_seqlen_q,
                 max_seqlen_kv=-1,
                 mask_mode=QFA_MASK_MODE_CAUSAL,
                 win_left=-1,
                 win_right=-1,
                 layout_q=QFA_LAYOUT_TND,
+                layout_q_descale=QFA_LAYOUT_TND,
                 layout_kv=QFA_LAYOUT_PA_BBND,
                 layout_out=QFA_LAYOUT_TND,
             )
@@ -2438,27 +2466,31 @@ class AscendC8MXFPAttentionBackendImpl(AscendAttentionBackendImpl):
         output: torch.Tensor,
     ) -> torch.Tensor:
         key, value, key_scale, value_scale = kv_cache
-        # PA_BBND: block axis is dim 1 of the paged K/V cache.
-        block_size = key.shape[1]
         # The scale caches are stored as raw uint8 (index_put_ on float8
         # either errors or falls back to AICPU); QFA's checker wants E8M0, so
         # bitcast at the call boundary. Same for the q scale when the quant
         # helper returns it as uint8 bytes.
-        if key_scale.dtype != torch.float8_e8m0fnu:
-            key_scale = key_scale.view(torch.float8_e8m0fnu)
-        if value_scale.dtype != torch.float8_e8m0fnu:
-            value_scale = value_scale.view(torch.float8_e8m0fnu)
-        if query_scale.dtype != torch.float8_e8m0fnu:
-            query_scale = query_scale.view(torch.float8_e8m0fnu)
-        result = torch_npu.npu_quant_flash_attn(
+        if key_scale.dtype != torch_npu.float8_e8m0fnu:
+            key_scale = key_scale.view(torch_npu.float8_e8m0fnu)
+        if value_scale.dtype != torch_npu.float8_e8m0fnu:
+            value_scale = value_scale.view(torch_npu.float8_e8m0fnu)
+        if query_scale.dtype != torch_npu.float8_e8m0fnu:
+            query_scale = query_scale.view(torch_npu.float8_e8m0fnu)
+        main_op, _ = _get_qfa_ops()
+        # cann_ops_transformer delivery signature (verified on-device):
+        # q/k/v/q_descale/k_descale/v_descale/quant_mode positional, p_scale
+        # instead of quant_scale_p, layout_q_descale, and no pa_block_size
+        # (the op infers the block size from the k/v cache shapes).
+        result = main_op(
             quant_query,
             key,
             value,
-            dequant_scale_query=query_scale,
-            dequant_scale_key=key_scale,
-            dequant_scale_value=value_scale,
+            query_scale,
+            key_scale,
+            value_scale,
+            QFA_QUANT_MODE_MXFP8,
             block_table=attn_metadata.block_tables,
-            quant_scale_p=None,
+            p_scale=None,
             cu_seqlens_q=cu_seqlens_q,
             cu_seqlens_kv=None,
             seqused_q=None,
@@ -2466,7 +2498,6 @@ class AscendC8MXFPAttentionBackendImpl(AscendAttentionBackendImpl):
             sinks=None,
             attn_mask=self._qfa_int8_mask(attn_metadata),
             metadata=qfa_metadata,
-            quant_mode=QFA_QUANT_MODE_MXFP8,
             softmax_scale=self.scale,
             mask_mode=QFA_MASK_MODE_CAUSAL,
             win_left=-1,
@@ -2474,13 +2505,13 @@ class AscendC8MXFPAttentionBackendImpl(AscendAttentionBackendImpl):
             max_seqlen_q=max_seqlen_q,
             max_seqlen_kv=-1,
             layout_q=QFA_LAYOUT_TND,
+            layout_q_descale=QFA_LAYOUT_TND,
             layout_kv=QFA_LAYOUT_PA_BBND,
             layout_out=QFA_LAYOUT_TND,
-            pa_block_size=block_size,
             return_softmax_lse=False,
         )
-        # return_softmax_lse=False yields an empty LSE tensor in current QFA
-        # builds; tolerate both tuple and single-tensor returns.
+        # return_softmax_lse=False yields an empty LSE tensor in the
+        # cann_ops flavor; tolerate both tuple and single-tensor returns.
         attn_output = result[0] if isinstance(result, tuple) else result
         attn_output = attn_output.view(num_tokens, self.num_heads, self.head_size)
         output[:num_tokens] = attn_output
@@ -2524,7 +2555,6 @@ class AscendC8MXFPAttentionBackendImpl(AscendAttentionBackendImpl):
             attn_metadata,
             cu_seqlens_q=cu_seqlens_q,
             seqused_kv=seqused_kv,
-            batch_size=len(seqused_kv),
             max_seqlen_q=max_seqlen_q,
         )
         return self._run_qfa(

--- a/vllm_ascend/attention/attention_v1.py
+++ b/vllm_ascend/attention/attention_v1.py
@@ -562,100 +562,6 @@ class AscendC8MXFPMetadataBuilder(AscendAttentionMetadataBuilder):
         )
 
 
-def _update_qfa_graph_param(update_stream, handle, event, param, metadata) -> None:
-    """Replay-time update for one captured QFA .out op (vendored-QFA bring-up
-    methodology, fe58a86a).
-
-    Re-sends the whole call with the current step's tensors: aclnn recomputes
-    tiling on every invocation, so the update replaces tiling as well, not
-    just buffer addresses. q_fp8 / q_descale keep their captured graph-internal
-    addresses (the graph recomputes them from the step's query). The metadata
-    plan is recomputed here per update (the graph replay itself does not run
-    the Python impl, so the per-step plan cache on AscendMetadata is not
-    populated on this path); the plan write is an AICPU op whose completion
-    must be pinned against this update stream before the re-sent call reads
-    the plan (waiting on the whole stream would deadlock a graph parked on
-    the event -- only the recorded point is awaited).
-    """
-    _, metadata_op, out_op = _get_qfa_ops()
-
-    actual_seq_lengths_q = metadata.actual_seq_lengths_q
-    num_tokens = int(actual_seq_lengths_q[-1])
-    device = param.seqused_kv.device
-    cu_seqlens_q = _build_qfa_cu_seqlens(actual_seq_lengths_q, device)
-    seqused_kv = torch.tensor(metadata.seq_lens_list, dtype=torch.int32, device=device)
-    max_seqlen_q = num_tokens
-
-    # Recompute the AICPU plan for this step (per-step, shared by all layers:
-    # the plan depends on heads/batch, which are identical across layers, and
-    # not on per-layer caches). The e8m0 v_descale stub is only checked for
-    # non-nullness under PA_BBND.
-    v_descale_stub = torch.zeros(1, 1, 1, 1, 2, dtype=torch.uint8, device=device).view(
-        torch.float8_e8m0fnu
-    )
-    qfa_plan = metadata_op(
-        param.num_heads,
-        _qfa_plan_kv_heads(param),
-        param.head_size,
-        QFA_QUANT_MODE_MXFP8,
-        cu_seqlens_q=cu_seqlens_q,
-        cu_seqlens_kv=None,
-        seqused_q=None,
-        seqused_kv=seqused_kv,
-        v_descale=v_descale_stub,
-        max_seqlen_q=max_seqlen_q,
-        max_seqlen_kv=-1,
-        mask_mode=QFA_MASK_MODE_CAUSAL,
-        win_left=-1,
-        win_right=-1,
-        layout_q=QFA_LAYOUT_TND,
-        layout_q_descale=QFA_LAYOUT_TND,
-        layout_kv=QFA_LAYOUT_PA_BBND,
-        layout_out=QFA_LAYOUT_TND,
-    )
-
-    torch.npu.graph_task_update_begin(update_stream, handle)
-    out_op(
-        param.q_fp8,
-        param.k,
-        param.v,
-        param.q_descale,
-        param.k_descale,
-        param.v_descale,
-        QFA_QUANT_MODE_MXFP8,
-        block_table=metadata.block_tables,
-        p_scale=None,
-        cu_seqlens_q=cu_seqlens_q,
-        cu_seqlens_kv=None,
-        seqused_q=None,
-        seqused_kv=seqused_kv,
-        sinks=None,
-        attn_mask=param.attn_mask,
-        metadata=qfa_plan,
-        softmax_scale=param.softmax_scale,
-        mask_mode=QFA_MASK_MODE_CAUSAL,
-        win_left=-1,
-        win_right=-1,
-        max_seqlen_q=max_seqlen_q,
-        max_seqlen_kv=-1,
-        layout_q=QFA_LAYOUT_TND,
-        layout_q_descale=QFA_LAYOUT_TND,
-        layout_kv=QFA_LAYOUT_PA_BBND,
-        layout_out=QFA_LAYOUT_TND,
-        return_softmax_lse=False,
-        out=param.attn_output,
-        softmax_lse=param.softmax_lse,
-    )
-    torch.npu.graph_task_update_end(update_stream)
-    event.record(update_stream)
-
-
-def _qfa_plan_kv_heads(param) -> int:
-    """KV head count for the metadata plan, derived from the captured K cache
-    (PA_BBND: [num_blocks, block_size, num_kv_heads, head_dim])."""
-    return param.k.shape[2]
-
-
 class AscendAttentionBackendImpl(AttentionImpl):
     def __init__(
         self,
@@ -976,22 +882,6 @@ class AscendAttentionBackendImpl(AttentionImpl):
                     handles,
                     events,
                 ):
-                    if isinstance(param, QFAGraphAttentionParams):
-                        if _EXTRA_CTX.is_draft_model:
-                            draft_step, key = draft_attn_key_steps[attn_count]
-                            metadata = attn_metadata[draft_step][key]
-                            attn_count = attn_count + 1
-                        else:
-                            metadata_key = (
-                                param.layer_name
-                                if getattr(param, "layer_name", None) is not None and param.layer_name in attn_metadata
-                                else key
-                            )
-                            metadata = attn_metadata[metadata_key]
-                        _update_qfa_graph_param(
-                            update_stream, handle, event, param, metadata
-                        )
-                        continue
                     if isinstance(param, PagedAttentionGraphParam):
                         if _EXTRA_CTX.is_draft_model:
                             draft_step, key = draft_attn_key_steps[attn_count]
@@ -2436,22 +2326,25 @@ def _build_qfa_cu_seqlens(cumulative_seq_lengths: list[int], device: torch.devic
     return torch.tensor([0, *cumulative_seq_lengths], dtype=torch.int32, device=device)
 
 
-# Resolved lazily and cached: (main_op, metadata_op, out_op | None). The QFA
-# dual operators are delivered through the cann_ops_transformer package
-# shipped with the CANN toolkit (confirmed final delivery form). That
-# wrapper's call shape (verified on-device): positional q/k/v/q_descale/
-# k_descale/v_descale/quant_mode, p_scale instead of quant_scale_p, an extra
-# layout_q_descale, no pa_block_size, and a required non-null v_descale
-# placeholder on the metadata call for quant_mode=1 (batch_size must not be
-# passed with a TND layout_q; the op infers it from cu_seqlens_q).
-# ``out_op`` is the caller-owned-output variant needed for FULL-graph capture
-# (torch.npu.graph_task_group); it comes from the out-variant patch to the
-# CANN package and is None on unpatched builds (FULL capture then raises
-# with the actionable reason).
-_QFA_OPS: tuple[Any, Any, Any | None] | None = None
+# Resolved lazily and cached: (main_op, metadata_op). The QFA dual operators
+# are delivered through the cann_ops_transformer package shipped with the
+# CANN toolkit (confirmed final delivery form). That wrapper's call shape
+# (verified on-device): positional q/k/v/q_descale/k_descale/v_descale/
+# quant_mode, p_scale instead of quant_scale_p, an extra layout_q_descale,
+# no pa_block_size, and a required non-null v_descale placeholder on the
+# metadata call for quant_mode=1 (batch_size must not be passed with a TND
+# layout_q; the op infers it from cu_seqlens_q).
+# Graph capture: torch_npu's npugraph_ex backend (the mechanism this vLLM
+# build uses for FULL graphs, confirmed in the on-device capture stack)
+# captures the ALLOCATING wrapper directly -- internal at::empty allocations
+# land in the graph's private pool and replay safely. The ops-transformer
+# golden tests exercise exactly this path (GRAPH_PATH=7: torch.compile with
+# backend="npugraph_ex", metadata op called INSIDE forward, no .out variant).
+# No task_group/update machinery is needed on our side.
+_QFA_OPS: tuple[Any, Any] | None = None
 
 
-def _get_qfa_ops() -> tuple[Any, Any, Any | None]:
+def _get_qfa_ops() -> tuple[Any, Any]:
     global _QFA_OPS
     if _QFA_OPS is None:
         try:
@@ -2464,41 +2357,8 @@ def _get_qfa_ops() -> tuple[Any, Any, Any | None]:
                 "cann_ops_transformer.ops.quant_flash_attn(_metadata) could not "
                 "be imported in this environment."
             ) from None
-        try:
-            from cann_ops_transformer.ops import quant_flash_attn_out as out_op
-        except ImportError:
-            out_op = None
-        _QFA_OPS = (main_op, metadata_op, out_op)
+        _QFA_OPS = (main_op, metadata_op)
     return _QFA_OPS
-
-
-@dataclass
-class QFAGraphAttentionParams:
-    """Captured QFA call parameters for FULL-graph replay.
-
-    Mirrors the vendored-QFA bring-up (TallMessiWu#2, fe58a86a): the capture
-    holds caller-owned output buffers (fixed addresses for replay) plus weak
-    refs to the per-step tensors that the replay-time update re-sends. q_fp8 /
-    q_descale are NOT re-sent on update -- the graph recomputes them from the
-    current step's query, so their captured addresses are already correct.
-    """
-
-    q_fp8: torch.Tensor
-    q_descale: torch.Tensor
-    k: torch.Tensor
-    v: torch.Tensor
-    k_descale: torch.Tensor
-    v_descale: torch.Tensor
-    block_table: torch.Tensor
-    cu_seqlens_q: torch.Tensor
-    seqused_kv: torch.Tensor
-    attn_mask: torch.Tensor | None
-    softmax_scale: float
-    max_seqlen_q: int
-    num_heads: int
-    head_size: int
-    attn_output: torch.Tensor
-    softmax_lse: torch.Tensor
 
 
 class AscendC8MXFPAttentionBackendImpl(AscendAttentionBackendImpl):
@@ -2525,9 +2385,15 @@ class AscendC8MXFPAttentionBackendImpl(AscendAttentionBackendImpl):
     batch is smaller to feed. PrefillNoCache also reads from pages:
     reshape_and_cache has written this step's K/V before attention runs.
 
-    v1 scope (C8 branch): eager paths only. ACL graph capture (operator
-    aclgraph "path 7") is pending the operator-side contract and raises here.
-    Speculative decoding is also out of scope for v1.
+    Graph capture: handled natively by torch_npu's npugraph_ex backend (the
+    FULL-graph mechanism of this vLLM build), following the ops-transformer
+    golden-test methodology (GRAPH_PATH=7). The allocating wrapper is
+    captured directly (at::empty outputs land in the graph pool), the AICPU
+    metadata op runs inline inside the graph, and our only obligations are
+    graph-safe surrounding code: the K-scale scatter uses a device-side
+    mask pattern (no host sync) and the per-step length tensors are written
+    into persistent instance-owned buffers (no H2D construction inside the
+    captured region). Speculative decoding remains out of scope for v1.
 
     NOTE: the QFA dual operators are called through _get_qfa_ops(), which
     resolves cann_ops_transformer.ops.quant_flash_attn(_metadata) -- the
@@ -2560,12 +2426,22 @@ class AscendC8MXFPAttentionBackendImpl(AscendAttentionBackendImpl):
         seqused_kv: torch.Tensor,
         max_seqlen_q: int,
     ):
-        """Return (computing once per step) the QFA metadata plan.
+        """Return the QFA metadata plan (AICPU op output).
 
-        The AICPU metadata operator is head/batch dependent but sequence-length
-        agnostic, so all full-attention layers of a step share one plan.
+        Eager: computed once per step and cached on the AscendMetadata (the
+        plan depends on heads/batch, identical across full-attention layers).
+        npugraph_ex capture: the Python-side cache is bypassed so the metadata
+        op executes INSIDE the captured region on every layer visit -- the
+        graph then recomputes the plan from the replayed length buffers each
+        step (golden-test GRAPH_PATH=7 methodology: Network.forward calls the
+        metadata op inline before the main op). The per-layer redundant calls
+        during capture are free (AICPU, ~us) and each layer's captured call
+        consumes the plan it just produced.
         """
-        cache = self._qfa_step_cache(attn_metadata)
+        use_step_cache = not (
+            _EXTRA_CTX.capturing and self.vllm_config.compilation_config.cudagraph_mode.has_full_cudagraphs()
+        )
+        cache = self._qfa_step_cache(attn_metadata) if use_step_cache else {}
         metadata = cache.get("step")
         if metadata is None:
             # TND + PA: pass cu_seqlens_q only; the KV side is addressed via
@@ -2575,7 +2451,7 @@ class AscendC8MXFPAttentionBackendImpl(AscendAttentionBackendImpl):
             # reads it -- a minimal 5D E8M0 placeholder suffices. batch_size
             # must NOT be passed with a TND layout_q (the checker rejects
             # it); the op infers it from cu_seqlens_q.
-            _, metadata_op, _ = _get_qfa_ops()
+            _, metadata_op = _get_qfa_ops()
             # NOTE: torch_npu.float8_e8m0fnu is the integer dtype ID (293) on
             # this torch_npu build, not a torch.dtype; tensor.view() would
             # parse it as a target shape. Bitcast with the stock torch dtype
@@ -2603,7 +2479,8 @@ class AscendC8MXFPAttentionBackendImpl(AscendAttentionBackendImpl):
                 layout_kv=QFA_LAYOUT_PA_BBND,
                 layout_out=QFA_LAYOUT_TND,
             )
-            cache["step"] = metadata
+            if use_step_cache:
+                cache["step"] = metadata
         return metadata
 
     def _qfa_int8_mask(self, attn_metadata: AscendMetadata) -> torch.Tensor | None:
@@ -2643,46 +2520,14 @@ class AscendC8MXFPAttentionBackendImpl(AscendAttentionBackendImpl):
             value_scale = value_scale.view(torch.float8_e8m0fnu)
         if query_scale.dtype != torch.float8_e8m0fnu:
             query_scale = query_scale.view(torch.float8_e8m0fnu)
-        attn_mask = self._qfa_int8_mask(attn_metadata)
-        main_op, _, out_op = _get_qfa_ops()
-
-        if _EXTRA_CTX.capturing and self.vllm_config.compilation_config.cudagraph_mode.has_full_cudagraphs():
-            # FULL-graph capture path (vendored-QFA bring-up, fe58a86a):
-            # wrap the caller-owned-output call in graph_task_group_begin/end
-            # so the op becomes a replayable task; register the captured
-            # params for the replay-time update (which re-sends the call with
-            # the current step's tensors -- aclnn recomputes tiling on every
-            # call, so the update replaces tiling as well, not just addresses).
-            if out_op is None:
-                raise NotImplementedError(
-                    "C8_MXFP QFA FULL-graph capture requires the .out() wrapper variant of "
-                    "cann_ops_transformer.quant_flash_attn (caller-owned output tensors for "
-                    "torch.npu.graph_task_group). The current wrapper only exposes the "
-                    "allocating variant, which cannot be captured safely. Apply the "
-                    "quant_flash_attn_out patch to the CANN package (or run with "
-                    "cudagraph_mode=PIECEWISE / NONE)."
-                )
-            return self._capture_qfa_full_graph(
-                quant_query,
-                query_scale,
-                key,
-                value,
-                key_scale,
-                value_scale,
-                cu_seqlens_q,
-                seqused_kv,
-                attn_mask,
-                qfa_metadata,
-                max_seqlen_q,
-                num_tokens,
-                output,
-                out_op,
-            )
-
+        main_op, _ = _get_qfa_ops()
         # cann_ops_transformer delivery signature (verified on-device):
         # q/k/v/q_descale/k_descale/v_descale/quant_mode positional, p_scale
         # instead of quant_scale_p, layout_q_descale, and no pa_block_size
         # (the op infers the block size from the k/v cache shapes).
+        # The allocating wrapper is capture-safe under npugraph_ex (internal
+        # at::empty allocations land in the graph pool); the ops-transformer
+        # golden tests capture exactly this call (GRAPH_PATH=7).
         result = main_op(
             quant_query,
             key,
@@ -2698,7 +2543,7 @@ class AscendC8MXFPAttentionBackendImpl(AscendAttentionBackendImpl):
             seqused_q=None,
             seqused_kv=seqused_kv,
             sinks=None,
-            attn_mask=attn_mask,
+            attn_mask=self._qfa_int8_mask(attn_metadata),
             metadata=qfa_metadata,
             softmax_scale=self.scale,
             mask_mode=QFA_MASK_MODE_CAUSAL,
@@ -2719,113 +2564,6 @@ class AscendC8MXFPAttentionBackendImpl(AscendAttentionBackendImpl):
         output[:num_tokens] = attn_output
         return output
 
-    def _capture_qfa_full_graph(
-        self,
-        quant_query: torch.Tensor,
-        query_scale: torch.Tensor,
-        key: torch.Tensor,
-        value: torch.Tensor,
-        key_scale: torch.Tensor,
-        value_scale: torch.Tensor,
-        cu_seqlens_q: torch.Tensor,
-        seqused_kv: torch.Tensor,
-        attn_mask: torch.Tensor | None,
-        qfa_metadata: torch.Tensor,
-        max_seqlen_q: int,
-        num_tokens: int,
-        output: torch.Tensor,
-        out_op: Any,
-    ) -> torch.Tensor:
-        """Capture the QFA .out call into the current NPU graph task group.
-
-        Registers a QFAGraphAttentionParams entry; the replay-time update
-        (update_graph_params) re-sends the call with the current step's
-        block_table / lengths / metadata before every replay. q_fp8/q_descale
-        are recomputed inside the graph each step, so they are registered but
-        never re-sent (their captured addresses are the graph-internal ones).
-        """
-        if _EXTRA_CTX.is_draft_model:
-            graph_params = get_draft_graph_params()
-        else:
-            graph_params = get_graph_params()
-        assert graph_params is not None, "QFA capture requires initialized graph params"
-
-        # Caller-owned output buffers: fixed addresses across capture/replay.
-        # The capture-time output slice is the tensor the graph writes into;
-        # the softmax LSE buffer is unused (return_softmax_lse=False) but must
-        # be a valid device tensor for the op signature.
-        attn_output = output
-        softmax_lse = torch.zeros(1, dtype=torch.float32, device=quant_query.device)
-
-        stream = torch_npu.npu.current_stream()
-        event = torch.npu.ExternalEvent()
-        event.wait(stream)
-        event.reset(stream)
-        graph_params.events[num_tokens].append(event)
-
-        graph_params.attn_params[num_tokens].append(
-            QFAGraphAttentionParams(
-                # Strong refs for q_fp8/q_descale: the graph recomputes them
-                # from the step's query INTO these captured buffers every
-                # replay, so the buffers must stay alive (weak refs would let
-                # the allocator reuse them; the vendored bring-up kept them
-                # alive for exactly this reason).
-                q_fp8=quant_query,
-                q_descale=query_scale,
-                k=key,
-                v=value,
-                k_descale=key_scale,
-                v_descale=value_scale,
-                block_table=weak_ref_tensors(attn_metadata.block_tables),
-                cu_seqlens_q=weak_ref_tensors(cu_seqlens_q),
-                seqused_kv=weak_ref_tensors(seqused_kv),
-                attn_mask=weak_ref_tensors(attn_mask) if attn_mask is not None else None,
-                softmax_scale=self.scale,
-                max_seqlen_q=max_seqlen_q,
-                num_heads=self.num_heads,
-                head_size=self.head_size,
-                attn_output=weak_ref_tensors(attn_output),
-                softmax_lse=softmax_lse,
-            )
-        )
-
-        torch.npu.graph_task_group_begin(stream)
-        out_op(
-            quant_query,
-            key,
-            value,
-            query_scale,
-            key_scale,
-            value_scale,
-            QFA_QUANT_MODE_MXFP8,
-            block_table=attn_metadata.block_tables,
-            p_scale=None,
-            cu_seqlens_q=cu_seqlens_q,
-            cu_seqlens_kv=None,
-            seqused_q=None,
-            seqused_kv=seqused_kv,
-            sinks=None,
-            attn_mask=attn_mask,
-            metadata=qfa_metadata,
-            softmax_scale=self.scale,
-            mask_mode=QFA_MASK_MODE_CAUSAL,
-            win_left=-1,
-            win_right=-1,
-            max_seqlen_q=max_seqlen_q,
-            max_seqlen_kv=-1,
-            layout_q=QFA_LAYOUT_TND,
-            layout_q_descale=QFA_LAYOUT_TND,
-            layout_kv=QFA_LAYOUT_PA_BBND,
-            layout_out=QFA_LAYOUT_TND,
-            return_softmax_lse=False,
-            out=attn_output,
-            softmax_lse=softmax_lse,
-        )
-        handle = torch.npu.graph_task_group_end(stream)
-        graph_params.handles[num_tokens].append(handle)
-        # The captured op already wrote into ``output``; nothing to copy.
-        return output
-
     def _forward_mxfp8_attention(
         self,
         quant_query: torch.Tensor,
@@ -2841,6 +2579,16 @@ class AscendC8MXFPAttentionBackendImpl(AscendAttentionBackendImpl):
         reshape_and_cache has already written this step's K/V into the paged
         cache before attention runs (single-call design validated on-device
         by the vendored-QFA bring-up).
+
+        npugraph_ex capture compatibility (golden-test methodology,
+        GRAPH_PATH=7): everything from here down is device-side work on
+        persistent tensors -- cu_seqlens_q / seqused_kv are written into
+        instance-owned buffers (copy_, a D2D op) instead of being built with
+        torch.tensor (an H2D copy that would replay against freed host
+        memory), and the AICPU metadata op is called inline so the captured
+        graph recomputes the plan from the (replayed) length buffers each
+        step. The per-step Python-side metadata cache is disabled during
+        capture so the metadata op is always re-executed inside the graph.
         """
         if not attn_metadata.causal:
             raise NotImplementedError("C8_MXFP attention does not support non-causal attention yet.")
@@ -2853,30 +2601,8 @@ class AscendC8MXFPAttentionBackendImpl(AscendAttentionBackendImpl):
         if num_tokens <= 0:
             return output
 
-        if _EXTRA_CTX.capturing and self.vllm_config.compilation_config.cudagraph_mode.has_full_cudagraphs():
-            # FULL-graph capture: the captured graph must contain NO host-side
-            # tensor construction (H2D copies replay against freed host memory)
-            # and no AICPU metadata op (its captured inputs would be stale).
-            # Use persistent placeholder tensors for the captured call; the
-            # replay-time update (_update_qfa_graph_param) re-sends the whole
-            # call with the current step's freshly-built tensors, so the
-            # placeholders only need to stay alive and address-stable.
-            ph_cu_seqlens_q, ph_seqused_kv, ph_metadata = self._qfa_capture_placeholders(num_tokens, device)
-            return self._run_qfa(
-                quant_query,
-                query_scale,
-                kv_cache,
-                attn_metadata,
-                cu_seqlens_q=ph_cu_seqlens_q,
-                seqused_kv=ph_seqused_kv,
-                qfa_metadata=ph_metadata,
-                max_seqlen_q=num_tokens,
-                num_tokens=num_tokens,
-                output=output,
-            )
-
-        cu_seqlens_q = _build_qfa_cu_seqlens(actual_seq_lengths_q, device)
-        seqused_kv = torch.tensor(attn_metadata.seq_lens_list, dtype=torch.int32, device=device)
+        cu_seqlens_q = self._write_qfa_cu_seqlens(actual_seq_lengths_q, device)
+        seqused_kv = self._write_qfa_seqused(attn_metadata.seq_lens_list, device)
         # Upper bound on any single query length (the step's total token
         # count); the vendored-QFA bring-up measured prefill against a constant
         # max_model_len bound as safe too, so a loose bound only affects
@@ -2902,23 +2628,53 @@ class AscendC8MXFPAttentionBackendImpl(AscendAttentionBackendImpl):
             output=output,
         )
 
-    def _qfa_capture_placeholders(self, num_tokens: int, device: torch.device) -> tuple:
-        """Persistent placeholder tensors for FULL-graph capture (per size).
+    def _qfa_step_buffers(self, num_tokens: int, num_seqs: int, device: torch.device) -> tuple:
+        """Instance-owned persistent int32 buffers for the per-step lengths.
 
-        Allocated once per capture size and cached on the instance; kept alive
-        for the process lifetime so the captured references stay valid. The
-        replay update replaces every parameter of the re-sent call, so their
-        VALUES are never consumed -- only their addresses matter.
+        During npugraph_ex capture every tensor consumed by the captured
+        region must live in a stable allocation; rebuilding cu_seqlens_q /
+        seqused_kv with torch.tensor (H2D) each step would leave the captured
+        graph reading freed host memory. The buffers are sized to the capture
+        bucket (num_tokens) and rewritten with copy_ (D2D) each step, so
+        replay refreshes them in-place.
         """
-        if not hasattr(self, "_qfa_placeholders"):
-            self._qfa_placeholders = {}
-        if num_tokens not in self._qfa_placeholders:
-            self._qfa_placeholders[num_tokens] = (
-                torch.zeros(num_tokens + 1, dtype=torch.int32, device=device),  # cu_seqlens_q
-                torch.ones(1, dtype=torch.int32, device=device),  # seqused_kv (len>=1 for checker)
-                torch.zeros(4096, dtype=torch.int32, device=device),  # metadata plan (checker: non-null)
+        if not hasattr(self, "_qfa_len_buffers"):
+            self._qfa_len_buffers = {}
+        key = (num_tokens, num_seqs)
+        if key not in self._qfa_len_buffers:
+            # cu_seqlens_q needs B+1 entries; overallocate to the max batch
+            # for this token bucket to survive mixed batch shapes.
+            max_seqs = max(num_seqs, num_tokens) + 1
+            self._qfa_len_buffers[key] = (
+                torch.zeros(max_seqs + 1, dtype=torch.int32, device=device),
+                torch.zeros(max_seqs, dtype=torch.int32, device=device),
             )
-        return self._qfa_placeholders[num_tokens]
+        return self._qfa_len_buffers[key]
+
+    def _write_qfa_cu_seqlens(self, cumulative_seq_lengths: list[int], device: torch.device) -> torch.Tensor:
+        """Write cu_seqlens (0-prefixed cumulative) into a persistent buffer.
+
+        Eager path: identical semantics to _build_qfa_cu_seqlens. Capture
+        path: the D2D copy_ is recorded into the graph, so replays refresh
+        the buffer contents from the (persistent) host-side list each step.
+        """
+        num_tokens = int(cumulative_seq_lengths[-1]) if cumulative_seq_lengths else 0
+        num_seqs = len(cumulative_seq_lengths)
+        cu_buf, _ = self._qfa_step_buffers(max(num_tokens, 1), num_seqs, device)
+        cu_buf[: num_seqs + 1].copy_(
+            torch.tensor([0, *cumulative_seq_lengths], dtype=torch.int32, device=device)
+        )
+        return cu_buf[: num_seqs + 1]
+
+    def _write_qfa_seqused(self, seq_lens_list: list[int], device: torch.device) -> torch.Tensor:
+        """Write seqused_kv into a persistent buffer (see _write_qfa_cu_seqlens)."""
+        num_tokens = sum(seq_lens_list) if seq_lens_list else 0
+        num_seqs = len(seq_lens_list)
+        _, seq_buf = self._qfa_step_buffers(max(num_tokens, 1), num_seqs, device)
+        seq_buf[:num_seqs].copy_(
+            torch.tensor(seq_lens_list, dtype=torch.int32, device=device)
+        )
+        return seq_buf[:num_seqs]
 
     # KV cache writes for C8_MXFP happen in reshape_and_cache(), invoked from forward()
     # when key/value are present. This hook is only reached when attention is split from
@@ -3011,33 +2767,18 @@ class AscendC8MXFPAttentionBackendImpl(AscendAttentionBackendImpl):
         if self.vllm_config.kv_transfer_config is not None:
             raise NotImplementedError("C8_MXFP v1 does not support PD disaggregation (kv_transfer) yet.")
         if _EXTRA_CTX.capturing:
-            # Phase-2 graph support, staged:
-            # - PIECEWISE: the compiled region covers non-attention ops; QFA
-            #   runs outside it as a plain call and is capture-compatible
-            #   (validated on-device by the vendored-QFA bring-up PR).
-            # - FULL (incl. FULL_DECODE_ONLY): _run_qfa routes to
-            #   _capture_qfa_full_graph, which wraps the caller-owned-output
-            #   (.out) variant in graph_task_group_begin/end and registers
-            #   the replay params. The out variant comes from the CANN-package
-            #   patch; without it, capture raises the actionable error below
-            #   (the allocating variant re-allocates outputs every call, so a
-            #   captured graph would replay writes to freed/wild addresses --
-            #   observed as AI core wild-pointer crashes in the vendored
-            #   bring-up).
-            mode = self.vllm_config.compilation_config.cudagraph_mode
-            if mode.has_full_cudagraphs():
-                _, _, out_op = _get_qfa_ops()
-                if out_op is None:
-                    raise NotImplementedError(
-                        "C8_MXFP QFA FULL-graph capture requires the .out() wrapper variant of "
-                        "cann_ops_transformer.quant_flash_attn (caller-owned output tensors for "
-                        "torch.npu.graph_task_group). The current wrapper only exposes the "
-                        "allocating variant, which cannot be captured safely. Apply the "
-                        "quant_flash_attn_out patch to the CANN package (or run with "
-                        "cudagraph_mode=PIECEWISE / NONE)."
-                    )
-            # PIECEWISE capture: QFA executes outside the compiled region;
-            # proceed.
+            # Graph capture is handled natively by npugraph_ex (the backend
+            # this vLLM build uses for FULL graphs -- confirmed in the
+            # on-device capture stack): it captures the ALLOCATING QFA
+            # wrapper directly (internal at::empty lands in the graph pool),
+            # and the ops-transformer golden tests exercise exactly this
+            # (GRAPH_PATH=7: torch.compile(backend="npugraph_ex") with the
+            # metadata op called inline in forward). The requirements on our
+            # side are only graph-safety of the surrounding Python: no host
+            # syncs (scatter uses the device-side mask pattern) and no H2D
+            # tensor construction inside the captured region (cu_seqlens /
+            # seqused are written into persistent instance-owned buffers).
+            pass
         if kv_cache is None or len(kv_cache) < 4:
             raise RuntimeError(
                 "C8_MXFP attention requires a (k, v, k_scale, v_scale) KV cache "

--- a/vllm_ascend/attention/attention_v1.py
+++ b/vllm_ascend/attention/attention_v1.py
@@ -15,7 +15,7 @@
 # This file is a part of the vllm-ascend project.
 #
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from enum import Enum
 from typing import Any
 
@@ -62,6 +62,7 @@ from vllm_ascend.compilation.acl_graph import (
 )
 from vllm_ascend.device.device_op import DeviceOperator
 from vllm_ascend.device.hardware_profile import HardwareCapability, get_current_hardware_profile
+from vllm_ascend.device.mxfp_kv_cache import scatter_mxfp_k_scale_cache
 from vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.attention_fence import record_attention_compute_start
 from vllm_ascend.utils import vllm_version_is, weak_ref_tensors
 
@@ -127,13 +128,13 @@ class AscendAttentionBackend(AttentionBackend):
         dst_kv_cache: list[torch.Tensor],
         src_to_dst: torch.Tensor,
     ) -> None:
-        src_key_cache, src_value_cache = src_kv_cache[0], src_kv_cache[1]
-        dst_key_cache, dst_value_cache = dst_kv_cache[0], dst_kv_cache[1]
         src_indices = src_to_dst[:, 0]
         dst_indices = src_to_dst[:, 1]
 
-        dst_key_cache[dst_indices] = src_key_cache[src_indices].to(dst_key_cache.device)
-        dst_value_cache[dst_indices] = src_value_cache[src_indices].to(dst_key_cache.device)
+        # C8-MXFP layers carry (k, v, k_scale, v_scale) tuples; generalize to
+        # any cache tuple length so scale caches are swapped alongside K/V.
+        for src_cache, dst_cache in zip(src_kv_cache, dst_kv_cache):
+            dst_cache[dst_indices] = src_cache[src_indices].to(dst_cache.device)
 
     @staticmethod
     def copy_blocks(
@@ -144,14 +145,30 @@ class AscendAttentionBackend(AttentionBackend):
         dst_indices = src_to_dists[:, 1]
 
         for kv_cache in kv_caches:
-            key_caches = kv_cache[0]
-            value_caches = kv_cache[1]
-            key_caches[dst_indices] = key_caches[src_indices]
-            value_caches[dst_indices] = value_caches[src_indices]
+            for cache in kv_cache:
+                cache[dst_indices] = cache[src_indices]
 
     @staticmethod
     def get_supported_kernel_block_sizes() -> list[int]:
         return [128]
+
+
+class AscendC8MXFPAttentionBackend(AscendAttentionBackend):
+    """Backend for C8-MXFP KV cache layers (QFA dual-operator interface).
+
+    C8-MXFP QFA requires 512-token pages (the D=256 requirement doc allows
+    512/1024). This must not be advertised by the generic backend because
+    hybrid BF16 models (e.g. Qwen3.5/3.6 linear-attention mixes) use its
+    128-token logical block layout when reshaping their KV cache.
+    """
+
+    @staticmethod
+    def get_impl_cls() -> type["AscendC8MXFPAttentionBackendImpl"]:
+        return AscendC8MXFPAttentionBackendImpl
+
+    @staticmethod
+    def get_supported_kernel_block_sizes() -> list[int]:
+        return [512]
 
 
 class AscendAttentionState(Enum):
@@ -214,6 +231,13 @@ class AscendMetadata:
     model_runner_type: str = ""
     # prefill reshape_and_cache event
     reshape_cache_event: torch.npu.Event = None
+
+    # Per-step scratch for C8-MXFP (QFA) layers. The builder creates one
+    # AscendMetadata per step shared by all attention layers, so the QFA
+    # metadata operator output and the int8 causal mask are computed once per
+    # step (per decode/prefill subset) instead of once per layer. Keys:
+    # "decode" / "prefill" -> QFA metadata tensor, "attn_mask_int8" -> Tensor.
+    qfa_metadata_cache: dict = field(default_factory=dict)
 
 
 @dataclass
@@ -2236,3 +2260,457 @@ class AscendC8AttentionBackendImpl(AscendAttentionBackendImpl):
 
             notify_kv_cache_written()
         return query, key, value, output
+
+
+QFA_QUANT_MODE_MXFP8 = 1
+QFA_MASK_MODE_NO_MASK = 0
+QFA_MASK_MODE_CAUSAL = 3
+QFA_LAYOUT_TND = "TND"
+QFA_LAYOUT_PA_BNBD = "PA_BNBD"
+
+
+def _build_qfa_cu_seqlens(cumulative_seq_lengths: list[int], device: torch.device) -> torch.Tensor:
+    """Build QFA ``cu_seqlens``: int32 (B+1,) with a leading 0.
+
+    FIA-style ``actual_seq_lengths`` are B cumulative entries; QFA expects the
+    cumulative sums prefixed with 0 so batch i spans
+    ``[cu_seqlens[i], cu_seqlens[i + 1])`` (QFA requirement doc, sequence
+    length conversion rules).
+    """
+    return torch.tensor([0, *cumulative_seq_lengths], dtype=torch.int32, device=device)
+
+
+class AscendC8MXFPAttentionBackendImpl(AscendAttentionBackendImpl):
+    """MXFP8 KV cache backend computed by the QFA dual-operator interface.
+
+    forward() quantizes Q/K dynamically (``npu_dynamic_mx_quant``, FP8 E4M3 +
+    per-token-group E8M0 scales) and V statically (the checkpoint's
+    per-channel E8M0 scale), scatters quantized K/V plus their scale caches
+    into the paged cache, and calls
+    ``torch_npu.npu_quant_flash_attn_metadata`` + ``torch_npu.npu_quant_flash_attn``
+    on the PA_BNBD transposed cache view.
+
+    v1 scope (C8 branch): eager paths only. ACL graph capture (operator
+    aclgraph "path 7") is pending the operator-side contract and raises here.
+    Speculative decoding is also out of scope for v1.
+
+    NOTE: kwarg names of the two QFA calls follow the QFA requirement doc's
+    torch-level calling example. Re-verify them against the delivered
+    torch_npu wrapper signature before on-device bring-up; they are the only
+    integration point expected to need renaming.
+    """
+
+    # Installed via ``layer.impl.__class__`` assignment, which does not call
+    # this subclass's constructor. Class-level defaults are therefore
+    # required for objects that predate the class swap.
+    enable_hamming_sparse: bool = False
+    _v_scale_filled_caches: set[torch.Tensor] | None = None
+
+    def _transpose_kv_cache(
+        self, kv_cache: tuple[torch.Tensor]
+    ) -> tuple[torch.Tensor]:
+        """Swap block_size (dim 1) and num_kv_heads (dim 2) on paged K/V for QFA.
+
+        [num_blocks, block_size, num_kv_heads, head_dim]
+        -> [num_blocks, num_kv_heads, block_size, head_dim]  (PA_BNBD)
+
+        The scale caches are already allocated in PA_BNBD order and are passed
+        through unchanged. TODO: the ``contiguous()`` materializes a full copy
+        of the cache per step; QFA documents non-contiguous K/V support for
+        PA layouts, so try dropping ``contiguous()`` during on-device
+        bring-up.
+        """
+        key = kv_cache[0].transpose(1, 2).contiguous()
+        value = kv_cache[1].transpose(1, 2).contiguous()
+        return (key, value, kv_cache[2], kv_cache[3])
+
+    def _qfa_step_cache(self, attn_metadata: AscendMetadata) -> dict:
+        cache = getattr(attn_metadata, "qfa_metadata_cache", None)
+        if cache is None:
+            cache = {}
+            attn_metadata.qfa_metadata_cache = cache
+        return cache
+
+    def _get_qfa_metadata(
+        self,
+        attn_metadata: AscendMetadata,
+        *,
+        subset: str,
+        cu_seqlens_q: torch.Tensor,
+        seqused_kv: torch.Tensor,
+        batch_size: int,
+        max_seqlen_q: int,
+        mask_mode: int,
+    ):
+        """Return (computing once per step and subset) the QFA metadata plan."""
+        cache = self._qfa_step_cache(attn_metadata)
+        metadata = cache.get(subset)
+        if metadata is None:
+            # TND + PA: pass cu_seqlens_q only; the KV side is addressed via
+            # block_table + seqused_kv (QFA requirement doc, 3.2.3).
+            metadata = torch_npu.npu_quant_flash_attn_metadata(
+                num_heads_q=self.num_heads,
+                num_heads_kv=self.num_kv_heads,
+                head_dim=self.head_size,
+                quant_mode=QFA_QUANT_MODE_MXFP8,
+                cu_seqlens_q=cu_seqlens_q,
+                cu_seqlens_kv=None,
+                seqused_q=None,
+                seqused_kv=seqused_kv,
+                batch_size=batch_size,
+                max_seqlen_q=max_seqlen_q,
+                max_seqlen_kv=-1,
+                mask_mode=mask_mode,
+                win_left=-1,
+                win_right=-1,
+                layout_q=QFA_LAYOUT_TND,
+                layout_q_descale=QFA_LAYOUT_TND,
+                layout_kv=QFA_LAYOUT_PA_BNBD,
+                layout_out=QFA_LAYOUT_TND,
+            )
+            cache[subset] = metadata
+        return metadata
+
+    def _qfa_int8_mask(self, attn_metadata: AscendMetadata) -> torch.Tensor | None:
+        """QFA's attn_mask is INT8; cache the cast once per step."""
+        if attn_metadata.attn_mask is None:
+            return None
+        cache = self._qfa_step_cache(attn_metadata)
+        attn_mask = cache.get("attn_mask_int8")
+        if attn_mask is None:
+            attn_mask = attn_metadata.attn_mask.to(torch.int8)
+            cache["attn_mask_int8"] = attn_mask
+        return attn_mask
+
+    def _run_qfa(
+        self,
+        quant_query: torch.Tensor,
+        query_scale: torch.Tensor,
+        key: torch.Tensor,
+        value: torch.Tensor,
+        key_scale: torch.Tensor,
+        value_scale: torch.Tensor,
+        attn_metadata: AscendMetadata,
+        *,
+        block_size: int,
+        block_table: torch.Tensor,
+        cu_seqlens_q: torch.Tensor,
+        seqused_kv: torch.Tensor,
+        qfa_metadata,
+        max_seqlen_q: int,
+        mask_mode: int,
+        num_tokens: int,
+        output: torch.Tensor,
+        token_offset: int = 0,
+        use_attn_mask: bool = True,
+    ) -> torch.Tensor:
+        attn_mask = self._qfa_int8_mask(attn_metadata) if use_attn_mask else None
+        # TODO: decode passes the 4D (TND) q_descale, so tiling selects the
+        # prefill template for decode steps. Functionally fine (QFA only
+        # loses performance); switch to the 5D [N2, T, G, D//64, 2] decode
+        # layout as a follow-up optimization.
+        result = torch_npu.npu_quant_flash_attn(
+            quant_query[token_offset : token_offset + num_tokens],
+            key,
+            value,
+            dequant_scale_query=query_scale[token_offset : token_offset + num_tokens],
+            dequant_scale_key=key_scale,
+            dequant_scale_value=value_scale,
+            block_table=block_table,
+            quant_scale_p=None,
+            cu_seqlens_q=cu_seqlens_q,
+            cu_seqlens_kv=None,
+            seqused_q=None,
+            seqused_kv=seqused_kv,
+            sinks=None,
+            attn_mask=attn_mask,
+            metadata=qfa_metadata,
+            quant_mode=QFA_QUANT_MODE_MXFP8,
+            softmax_scale=self.scale,
+            mask_mode=mask_mode,
+            win_left=-1,
+            win_right=-1,
+            max_seqlen_q=max_seqlen_q,
+            max_seqlen_kv=-1,
+            layout_q=QFA_LAYOUT_TND,
+            layout_kv=QFA_LAYOUT_PA_BNBD,
+            layout_out=QFA_LAYOUT_TND,
+            pa_block_size=block_size,
+            return_softmax_lse=False,
+        )
+        # return_softmax_lse=False yields an empty LSE tensor in current QFA
+        # builds; tolerate both tuple and single-tensor returns.
+        attn_output = result[0] if isinstance(result, tuple) else result
+        attn_output = attn_output.view(num_tokens, self.num_heads, self.head_size)
+        output[token_offset : token_offset + num_tokens] = attn_output
+        return output
+
+    def _forward_mxfp8_decode(
+        self,
+        quant_query: torch.Tensor,
+        query_scale: torch.Tensor,
+        kv_cache: tuple[torch.Tensor],
+        attn_metadata: AscendMetadata,
+        output: torch.Tensor,
+    ) -> torch.Tensor:
+        key, value, key_scale, value_scale = kv_cache[0], kv_cache[1], kv_cache[2], kv_cache[3]
+        # K/V are transposed to [num_blocks, num_kv_heads, block_size, head_dim].
+        block_size = key.shape[2]
+        num_decodes = attn_metadata.num_decodes
+        device = quant_query.device
+
+        # A decode query attends to the whole (paged) KV context, so the
+        # causal relation is implicit and no mask is needed (NO_MASK).
+        cu_seqlens_q = _build_qfa_cu_seqlens(attn_metadata.actual_seq_lengths_q[:num_decodes], device)
+        seqused_kv = torch.tensor(attn_metadata.seq_lens_list[:num_decodes], dtype=torch.int32, device=device)
+        max_seqlen_q = 1
+
+        qfa_metadata = self._get_qfa_metadata(
+            attn_metadata,
+            subset="decode",
+            cu_seqlens_q=cu_seqlens_q,
+            seqused_kv=seqused_kv,
+            batch_size=num_decodes,
+            max_seqlen_q=max_seqlen_q,
+            mask_mode=QFA_MASK_MODE_NO_MASK,
+        )
+        return self._run_qfa(
+            quant_query,
+            query_scale,
+            key,
+            value,
+            key_scale,
+            value_scale,
+            attn_metadata,
+            block_size=block_size,
+            block_table=attn_metadata.block_tables[:num_decodes],
+            cu_seqlens_q=cu_seqlens_q,
+            seqused_kv=seqused_kv,
+            qfa_metadata=qfa_metadata,
+            max_seqlen_q=max_seqlen_q,
+            mask_mode=QFA_MASK_MODE_NO_MASK,
+            num_tokens=attn_metadata.num_decode_tokens,
+            output=output,
+            use_attn_mask=False,
+        )
+
+    def _forward_mxfp8_prefill(
+        self,
+        quant_query: torch.Tensor,
+        query_scale: torch.Tensor,
+        kv_cache: tuple[torch.Tensor],
+        attn_metadata: AscendMetadata,
+        output: torch.Tensor,
+        *,
+        token_offset: int,
+    ) -> torch.Tensor:
+        """Prefill path: paged FP8 KV + scale cache (K/V read from the transposed cache)."""
+        actual_seq_qlen_full = attn_metadata.actual_seq_lengths_q
+        num_tokens = int(actual_seq_qlen_full[-1])  # type: ignore[index]
+        num_prefill_tokens = num_tokens - token_offset
+        if num_prefill_tokens <= 0:
+            return output
+
+        num_decodes = attn_metadata.num_decodes
+        device = quant_query.device
+        # Cumulative query lengths of the prefill subset, relative to token_offset.
+        prefill_seq_qlen = [
+            actual_seq_qlen_full[i] - token_offset for i in range(num_decodes, len(actual_seq_qlen_full))
+        ]
+        cu_seqlens_q = _build_qfa_cu_seqlens(prefill_seq_qlen, device)
+        seqused_kv = torch.tensor(attn_metadata.seq_lens_list[num_decodes:], dtype=torch.int32, device=device)
+        max_seqlen_q = max(int(attn_metadata.max_query_len or 1), 1)
+
+        qfa_metadata = self._get_qfa_metadata(
+            attn_metadata,
+            subset="prefill",
+            cu_seqlens_q=cu_seqlens_q,
+            seqused_kv=seqused_kv,
+            batch_size=len(prefill_seq_qlen),
+            max_seqlen_q=max_seqlen_q,
+            mask_mode=QFA_MASK_MODE_CAUSAL,
+        )
+        return self._run_qfa(
+            quant_query,
+            query_scale,
+            kv_cache[0],
+            kv_cache[1],
+            kv_cache[2],
+            kv_cache[3],
+            attn_metadata,
+            block_size=kv_cache[0].shape[2],
+            block_table=attn_metadata.block_tables[num_decodes:],
+            cu_seqlens_q=cu_seqlens_q,
+            seqused_kv=seqused_kv,
+            qfa_metadata=qfa_metadata,
+            max_seqlen_q=max_seqlen_q,
+            mask_mode=QFA_MASK_MODE_CAUSAL,
+            num_tokens=num_prefill_tokens,
+            output=output,
+            token_offset=token_offset,
+            use_attn_mask=True,
+        )
+
+    def _forward_mxfp8_chunked_prefill(
+        self,
+        quant_query: torch.Tensor,
+        query_scale: torch.Tensor,
+        kv_cache: tuple[torch.Tensor],
+        attn_metadata: AscendMetadata,
+        output: torch.Tensor,
+    ) -> torch.Tensor:
+        """ChunkedPrefill: decode requests first, then prefill (same batch ordering as MLA)."""
+        if attn_metadata.num_decodes > 0:
+            self._forward_mxfp8_decode(quant_query, query_scale, kv_cache, attn_metadata, output)
+        self._forward_mxfp8_prefill(
+            quant_query,
+            query_scale,
+            kv_cache,
+            attn_metadata,
+            output,
+            token_offset=attn_metadata.num_decode_tokens,
+        )
+        return output
+
+    def _forward_mxfp8_attention(
+        self,
+        quant_query: torch.Tensor,
+        query_scale: torch.Tensor,
+        kv_cache: tuple[torch.Tensor],
+        attn_metadata: AscendMetadata,
+        output: torch.Tensor,
+    ) -> torch.Tensor:
+        if not attn_metadata.causal:
+            raise NotImplementedError("C8_MXFP attention does not support non-causal attention yet.")
+        if self.sliding_window is not None:
+            raise NotImplementedError("C8_MXFP attention does not support sliding window attention yet.")
+
+        if attn_metadata.attn_state == AscendAttentionState.DecodeOnly:
+            return self._forward_mxfp8_decode(quant_query, query_scale, kv_cache, attn_metadata, output)
+        if attn_metadata.attn_state == AscendAttentionState.ChunkedPrefill:
+            return self._forward_mxfp8_chunked_prefill(
+                quant_query, query_scale, kv_cache, attn_metadata, output
+            )
+        return self._forward_mxfp8_prefill(
+            quant_query, query_scale, kv_cache, attn_metadata, output, token_offset=0
+        )
+
+    # KV cache writes for C8_MXFP happen in reshape_and_cache(), invoked from forward()
+    # when key/value are present. This hook is only reached when attention is split from
+    # cache update, e.g. Attention.forward with forward_includes_kv_cache_update=False
+    # (unified_kv_cache_update -> do_kv_cache_update). AscendAttentionBackend keeps
+    # forward_includes_kv_cache_update=True, so normal inference never calls this.
+    def do_kv_cache_update(
+        self,
+        layer: torch.nn.Module,
+        key: torch.Tensor,
+        value: torch.Tensor,
+        kv_cache: list[torch.Tensor],
+        slot_mapping: torch.Tensor,
+    ) -> None:
+        raise NotImplementedError(
+            "C8_MXFP KV cache update is only supported via reshape_and_cache in forward()."
+        )
+
+    def reshape_and_cache(
+        self,
+        quant_key: torch.Tensor,
+        quant_value: torch.Tensor,
+        key_scale: torch.Tensor,
+        value_scale: torch.Tensor,
+        kv_cache: tuple[torch.Tensor],
+        attn_metadata: AscendMetadata,
+    ) -> None:
+        num_actual_tokens = quant_key.shape[0]
+        slot_mapping = attn_metadata.slot_mapping[:num_actual_tokens]
+        key_cache, value_cache = kv_cache[0], kv_cache[1]
+        DeviceOperator.reshape_and_cache(
+            key=quant_key,
+            value=quant_value,
+            key_cache=key_cache,
+            value_cache=value_cache,
+            slot_mapping=slot_mapping,
+        )
+
+        # Scatter the dynamic per-token K scales; V's static per-channel scale
+        # is broadcast into its group-layout cache once per cache instance
+        # (tracked by identity so memory-profiling dummy caches and the real
+        # cache are both initialized without a reset hook).
+        key_scale_cache, value_scale_cache = kv_cache[2], kv_cache[3]
+        scatter_mxfp_k_scale_cache(
+            key_scale,
+            key_scale_cache,
+            slot_mapping,
+            key_cache.shape[1],
+        )
+        filled_caches = self._v_scale_filled_caches
+        if filled_caches is None:
+            filled_caches = set()
+            self._v_scale_filled_caches = filled_caches
+        if value_scale_cache not in filled_caches:
+            # (hidden_size) -> (num_kv_heads, head_size) -> broadcast -> (num_blocks, num_kv_heads, block_size // 64, head_size, 2)
+            value_scale_cache.copy_(value_scale.view(1, self.num_kv_heads, 1, self.head_size, 1))
+            filled_caches.add(value_scale_cache)
+
+    def forward(
+        self,
+        layer: AttentionLayer,
+        query: torch.Tensor,
+        key: torch.Tensor,
+        value: torch.Tensor,
+        kv_cache: tuple[torch.Tensor],
+        attn_metadata: AscendMetadata,
+        output: torch.Tensor | None = None,
+        output_scale: torch.Tensor | None = None,
+        output_block_scale: torch.Tensor | None = None,
+    ) -> torch.Tensor:
+        assert output is not None, "Output tensor must be provided."
+        if output_scale is not None or output_block_scale is not None:
+            raise NotImplementedError(
+                "fused output quantization is not yet supported for AscendC8MXFPAttentionBackendImpl"
+            )
+        if attn_metadata is None:
+            return output.fill_(0)
+        if getattr(self, "enable_hamming_sparse", False):
+            raise NotImplementedError("C8_MXFP attention does not support hamming sparse KV compression yet.")
+        if self.vllm_config.speculative_config is not None:
+            raise NotImplementedError("C8_MXFP v1 does not support speculative decoding yet.")
+        if _EXTRA_CTX.capturing:
+            # v1 is eager-only: FULL graph capture needs the operator aclgraph
+            # ("path 7") contract, and PIECEWISE capture of the AICPU metadata
+            # operator needs its own confirmation. Run with
+            # cudagraph_mode=NONE / enforce_eager until then.
+            raise NotImplementedError(
+                "C8_MXFP QFA does not support ACL graph capture yet; "
+                "run with cudagraph_mode=NONE (or enforce_eager)."
+            )
+
+        query_mxfp8, query_scale = torch_npu.npu_dynamic_mx_quant(
+            query[: attn_metadata.num_actual_tokens],
+            dst_type=torch.float8_e4m3fn,
+        )
+        key_mxfp8, key_scale = torch_npu.npu_dynamic_mx_quant(
+            key[: attn_metadata.num_actual_tokens],
+            dst_type=torch.float8_e4m3fn,
+        )
+
+        original_value_shape = value.shape
+        value = value.view(original_value_shape[0], -1)
+        value_mxfp8 = torch_npu.npu_quantize(
+            value[: attn_metadata.num_actual_tokens],
+            layer.v_cache_scale_float_reciprocal,
+            None,
+            torch.float8_e4m3fn,
+            -1,
+            False,
+        )
+        value_mxfp8 = value_mxfp8.view((attn_metadata.num_actual_tokens, *original_value_shape[1:]))
+
+        self.reshape_and_cache(
+            key_mxfp8, value_mxfp8, key_scale, layer.v_cache_scale, kv_cache, attn_metadata
+        )
+
+        qfa_kv_cache = self._transpose_kv_cache(kv_cache)
+        return self._forward_mxfp8_attention(
+            query_mxfp8, query_scale, qfa_kv_cache, attn_metadata, output
+        )

--- a/vllm_ascend/attention/attention_v1.py
+++ b/vllm_ascend/attention/attention_v1.py
@@ -2753,7 +2753,18 @@ class AscendC8MXFPAttentionBackendImpl(AscendAttentionBackendImpl):
             num_kv_heads = value_scale_cache.shape[2]
             v_head_dim = value_scale_cache.shape[3]
             value_scale_cache.copy_(value_scale.view(1, 1, num_kv_heads, v_head_dim, 1))
-            filled_caches.add(value_scale_cache)
+            # Only claim the cache is filled when the copy actually ran. Graph
+            # capture records the copy without executing it, while this Python
+            # line runs for real -- so marking it there leaves the cache full of
+            # zeros forever and every later call skips the fill. V then
+            # dequantizes to zero and attention returns exactly zero. That is
+            # invisible for the target model, whose first execution of this
+            # path is an eager forward, but the draft's first execution is the
+            # capture itself, which is why MTP acceptance collapses as soon as
+            # the draft graph is enabled. The copy stays inside the captured
+            # graph and is idempotent, so replays keep writing the same value.
+            if not _EXTRA_CTX.capturing:
+                filled_caches.add(value_scale_cache)
         notify_kv_cache_written()
 
     def forward(

--- a/vllm_ascend/attention/attention_v1.py
+++ b/vllm_ascend/attention/attention_v1.py
@@ -64,7 +64,7 @@ from vllm_ascend.device.device_op import DeviceOperator
 from vllm_ascend.device.hardware_profile import HardwareCapability, get_current_hardware_profile
 from vllm_ascend.device.mxfp_kv_cache import scatter_mxfp_k_scale_cache
 from vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.attention_fence import record_attention_compute_start
-from vllm_ascend.utils import vllm_version_is, weak_ref_tensors
+from vllm_ascend.utils import uses_mooncake_connector, vllm_version_is, weak_ref_tensors
 
 if vllm_version_is("0.27.1"):
     from vllm.model_executor.layers.attention.pcp import _gather_prefill_cache_inputs  # type: ignore[import-not-found]
@@ -2754,6 +2754,7 @@ class AscendC8MXFPAttentionBackendImpl(AscendAttentionBackendImpl):
             v_head_dim = value_scale_cache.shape[3]
             value_scale_cache.copy_(value_scale.view(1, 1, num_kv_heads, v_head_dim, 1))
             filled_caches.add(value_scale_cache)
+        notify_kv_cache_written()
 
     def forward(
         self,
@@ -2776,8 +2777,16 @@ class AscendC8MXFPAttentionBackendImpl(AscendAttentionBackendImpl):
             return output.fill_(0)
         if getattr(self, "enable_hamming_sparse", False):
             raise NotImplementedError("C8_MXFP attention does not support hamming sparse KV compression yet.")
-        if self.vllm_config.kv_transfer_config is not None:
-            raise NotImplementedError("C8_MXFP v1 does not support PD disaggregation (kv_transfer) yet.")
+        if self.vllm_config.kv_transfer_config is not None and not uses_mooncake_connector(
+            self.vllm_config.kv_transfer_config
+        ):
+            raise NotImplementedError(
+                "C8_MXFP v1 PD disaggregation (kv_transfer) is only supported with "
+                "MooncakeConnectorV1, whose block-level transfer registers and moves "
+                "every per-layer cache tensor (FP8 K/V plus both E8M0 scale caches) "
+                "as raw blocks. Connectors that only move the K/V pair would "
+                "silently drop the scale caches."
+            )
         if kv_cache is None or len(kv_cache) < 4:
             raise RuntimeError(
                 "C8_MXFP attention requires a (k, v, k_scale, v_scale) KV cache "

--- a/vllm_ascend/device/device_op.py
+++ b/vllm_ascend/device/device_op.py
@@ -763,6 +763,11 @@ class BaseDeviceAdaptor:
         indices: torch.Tensor,
         value: int,
     ) -> torch.Tensor:
+        # aclnnInplaceIndexFill rejects empty indices (EZ0015: shape size
+        # must be greater than zero), which callers legitimately produce
+        # when nothing needs filling (e.g. no discarded spec requests).
+        if indices.numel() == 0:
+            return tensor
         tensor.index_fill_(dim, indices, value)
         return tensor
 

--- a/vllm_ascend/device/mxfp_kv_cache.py
+++ b/vllm_ascend/device/mxfp_kv_cache.py
@@ -1,7 +1,6 @@
 import torch
 import torch_npu
 
-
 # KV cache MXFP8 scale layouts. The block and head axes are ordered the way
 # QuantFlashAttn's PA_BBND reads them -- the same order as the K/V caches
 # themselves ([num_blocks, block_size, num_kv_heads, head_dim]) -- so attention

--- a/vllm_ascend/device/mxfp_kv_cache.py
+++ b/vllm_ascend/device/mxfp_kv_cache.py
@@ -191,28 +191,29 @@ def scatter_mxfp_k_scale_cache(
     (any 1-byte dtype; callers pass a uint8 view of the E8M0 scale).
     ``key_scale_cache`` shape (PA_BBND, block before head):
     ``[num_blocks, block_size, num_kv_heads, head_dim // 64, 2]``.
+
+    ACL-graph-capture safe: no host-device synchronization (``.all()``/
+    ``bool()``/``.item()`` are illegal mid-capture -- "Stream during the
+    capture stage is not supported") and no data-dependent shapes. Padded
+    rows (slot -1) are clamped to slot 0 via ``torch.where`` and write back
+    the cache's existing value times a 0/1 row mask, making them bit-exact
+    no-ops while keeping the write pattern static. (The earlier
+    bool-compressed variant was fine eager but crashed graph capture.)
     """
     validate_mxfp_v_scale_block_size(block_size)
     slots = slot_mapping.to(torch.long)
     if slots.numel() == 0:
         return
 
-    # Graph replay keeps the captured token shape and marks padded rows with
-    # slot -1. Remapping -1 to a sentinel slot and writing back the cached
-    # value is NOT a no-op when a real token also targets that slot in the
-    # same batch: the duplicate-index write order would let the padding row
-    # clobber the real token's scale. Drop the padded rows instead (v1 is
-    # eager-only, so the dynamic shape is acceptable).
-    valid_slots = slots >= 0
-    if not bool(valid_slots.all()):
-        slots = slots[valid_slots]
-        key_scale = key_scale[valid_slots]
-        if slots.numel() == 0:
-            return
-
-    block_ids = slots // block_size
-    block_offsets = slots % block_size
-    key_scale_cache[block_ids, block_offsets] = key_scale
+    valid = slots >= 0
+    safe_slots = torch.where(valid, slots, torch.zeros_like(slots))
+    block_ids = safe_slots // block_size
+    block_offsets = safe_slots % block_size
+    # Row mask (device-only): valid rows take the new scale, padded rows
+    # rewrite the current content of their clamp target -- a no-op.
+    cached = key_scale_cache[block_ids, block_offsets]
+    updates = torch.where(valid.view(-1, 1, 1, 1), key_scale, cached)
+    key_scale_cache[block_ids, block_offsets] = updates
 
 
 def scatter_mxfp_v_cache(

--- a/vllm_ascend/device/mxfp_kv_cache.py
+++ b/vllm_ascend/device/mxfp_kv_cache.py
@@ -193,17 +193,21 @@ def scatter_mxfp_k_scale_cache(
         return
 
     # Graph replay keeps the captured token shape and marks padded rows with
-    # slot -1. Advanced indexing would interpret -1 as the last cache entry
-    # and silently corrupt its scale. Remap padding to slot 0 and write back
-    # the existing value so the padded rows perform a no-op.
+    # slot -1. Remapping -1 to a sentinel slot and writing back the cached
+    # value is NOT a no-op when a real token also targets that slot in the
+    # same batch: the duplicate-index write order would let the padding row
+    # clobber the real token's scale. Drop the padded rows instead (v1 is
+    # eager-only, so the dynamic shape is acceptable).
     valid_slots = slots >= 0
-    safe_slots = torch.where(valid_slots, slots, torch.zeros_like(slots))
-    block_ids = safe_slots // block_size
-    block_offsets = safe_slots % block_size
-    cached_scale = key_scale_cache[block_ids, :, block_offsets, :, :]
-    scale_mask = valid_slots.view(-1, 1, 1, 1)
-    scale_updates = torch.where(scale_mask, key_scale, cached_scale)
-    key_scale_cache[block_ids, :, block_offsets, :, :] = scale_updates
+    if not bool(valid_slots.all()):
+        slots = slots[valid_slots]
+        key_scale = key_scale[valid_slots]
+        if slots.numel() == 0:
+            return
+
+    block_ids = slots // block_size
+    block_offsets = slots % block_size
+    key_scale_cache[block_ids, :, block_offsets, :, :] = key_scale
 
 
 def scatter_mxfp_v_cache(

--- a/vllm_ascend/device/mxfp_kv_cache.py
+++ b/vllm_ascend/device/mxfp_kv_cache.py
@@ -1,0 +1,258 @@
+import torch
+import torch_npu
+
+
+# KV cache MXFP8 scale layouts (QFA requirement doc, KScale/VScale sections):
+# K scale token:  [num_tokens, num_kv_heads, head_dim // 64, 2]
+# K scale cache:  [num_blocks, num_kv_heads, block_size, head_dim // 64, 2]  (PA_BNBD)
+# V scale token (axis=0 quant): [cdiv(num_tokens, 64), num_kv_heads, head_dim, 2]
+# V scale cache:  [num_blocks, num_kv_heads, block_size // 64, head_dim, 2]  (PA_BNBD)
+MXFP_KV_SCALE_GROUP_SIZE = 64
+MXFP_KV_SCALE_VALUES_PER_GROUP = 2
+# Unified per-block scale bytes: num_kv_heads * block_size * head_dim / MXFP8_GROUP_SIZE (K and V).
+MXFP8_GROUP_SIZE = 32
+# E8M0 scale elements are always 1 byte in KV cache budgeting.
+MXFP_SCALE_DTYPE_SIZE = 1
+
+
+def validate_mxfp_k_scale_head_dim(head_dim: int) -> None:
+    if head_dim % MXFP_KV_SCALE_GROUP_SIZE != 0:
+        raise ValueError(
+            f"C8_MXFP K scale cache requires head_dim divisible by {MXFP_KV_SCALE_GROUP_SIZE}, got {head_dim}."
+        )
+
+
+def validate_mxfp_v_scale_block_size(block_size: int) -> None:
+    if block_size % MXFP_KV_SCALE_GROUP_SIZE != 0:
+        raise ValueError(
+            f"C8_MXFP V scale cache requires block_size divisible by {MXFP_KV_SCALE_GROUP_SIZE}, got {block_size}."
+        )
+
+
+def mxfp_kv_scale_groups(head_dim: int) -> int:
+    validate_mxfp_k_scale_head_dim(head_dim)
+    return head_dim // MXFP_KV_SCALE_GROUP_SIZE
+
+
+def mxfp_kv_block_scale_groups(block_size: int) -> int:
+    validate_mxfp_v_scale_block_size(block_size)
+    return block_size // MXFP_KV_SCALE_GROUP_SIZE
+
+
+def mxfp_k_scale_page_bytes(num_kv_heads: int, block_size: int, head_dim: int) -> int:
+    """Bytes per block for k_scale cache."""
+    validate_mxfp_k_scale_head_dim(head_dim)
+    return num_kv_heads * block_size * head_dim // MXFP8_GROUP_SIZE
+
+
+def mxfp_v_scale_page_bytes(num_kv_heads: int, block_size: int, head_dim: int) -> int:
+    """Bytes per block for v_scale cache."""
+    validate_mxfp_v_scale_block_size(block_size)
+    return num_kv_heads * block_size * head_dim // MXFP8_GROUP_SIZE
+
+
+def mxfp_k_scale_cache_shape(
+    num_blocks: int,
+    block_size: int,
+    num_kv_heads: int,
+    head_dim: int,
+) -> tuple[int, int, int, int, int]:
+    return (
+        num_blocks,
+        num_kv_heads,
+        block_size,
+        mxfp_kv_scale_groups(head_dim),
+        MXFP_KV_SCALE_VALUES_PER_GROUP,
+    )
+
+
+def mxfp_v_scale_cache_shape(
+    num_blocks: int,
+    block_size: int,
+    num_kv_heads: int,
+    head_dim: int,
+) -> tuple[int, int, int, int, int]:
+    return (
+        num_blocks,
+        num_kv_heads,
+        mxfp_kv_block_scale_groups(block_size),
+        head_dim,
+        MXFP_KV_SCALE_VALUES_PER_GROUP,
+    )
+
+
+def mxfp_kv_page_size_bytes(
+    block_size: int,
+    num_kv_heads: int,
+    k_dim: int,
+    v_dim: int,
+    kv_dtype_size: int,
+) -> int:
+    """Bytes per KV cache page for C8_MXFP (FP8 K/V tensors + E8M0 scale caches)."""
+    kv_bytes = block_size * num_kv_heads * (k_dim + v_dim) * kv_dtype_size
+    scale_bytes = (
+        mxfp_k_scale_page_bytes(num_kv_heads, block_size, k_dim)
+        + mxfp_v_scale_page_bytes(num_kv_heads, block_size, v_dim)
+    ) * MXFP_SCALE_DTYPE_SIZE
+    return kv_bytes + scale_bytes
+
+
+def mxfp_resolve_kv_cache_layout(
+    *,
+    raw_k_numel: int,
+    raw_v_numel: int,
+    raw_k_scale_numel: int,
+    raw_v_scale_numel: int,
+    block_size: int,
+    num_kv_heads: int,
+    k_dim: int,
+    v_dim: int,
+    layer_name: str = "",
+    num_blocks_hint: int | None = None,
+) -> tuple[
+    tuple[int, int, int, int],
+    tuple[int, int, int, int],
+    tuple[int, int, int, int, int],
+    tuple[int, int, int, int, int],
+]:
+    """Derive C8_MXFP KV cache shapes from spec dims and allocated raw buffer sizes.
+
+    ``num_blocks`` is derived from the k_scale buffer; ``k_dim``/``v_dim`` come from the caller
+    (typically ``KVCacheSpec``). All four raw buffers must match the expected numel.
+
+    Returns (k_shape, v_shape, k_scale_shape, v_scale_shape).
+    """
+    validate_mxfp_v_scale_block_size(block_size)
+    validate_mxfp_k_scale_head_dim(k_dim)
+    if v_dim != k_dim:
+        validate_mxfp_k_scale_head_dim(v_dim)
+
+    k_scale_per_block = mxfp_k_scale_page_bytes(num_kv_heads, block_size, k_dim)
+    v_scale_per_block = mxfp_v_scale_page_bytes(num_kv_heads, block_size, v_dim)
+    if raw_k_scale_numel % k_scale_per_block != 0:
+        raise ValueError(
+            f"C8_MXFP k_scale buffer size mismatch for layer={layer_name}: "
+            f"raw_k_scale_numel={raw_k_scale_numel}, k_scale_per_block={k_scale_per_block}, "
+            f"k_dim={k_dim}, block_size={block_size}, num_kv_heads={num_kv_heads}."
+        )
+    num_blocks = raw_k_scale_numel // k_scale_per_block
+    if num_blocks <= 0:
+        raise ValueError(
+            f"C8_MXFP invalid num_blocks={num_blocks} for layer={layer_name}, "
+            f"raw_k_scale_numel={raw_k_scale_numel}, k_scale_per_block={k_scale_per_block}."
+        )
+    if num_blocks_hint is not None and num_blocks != num_blocks_hint:
+        raise ValueError(
+            f"C8_MXFP num_blocks mismatch for layer={layer_name}: "
+            f"from_k_scale={num_blocks}, num_blocks_hint={num_blocks_hint}."
+        )
+
+    kv_slot_per_block = block_size * num_kv_heads
+    expected_k = num_blocks * kv_slot_per_block * k_dim
+    expected_v = num_blocks * kv_slot_per_block * v_dim
+    expected_k_scale = num_blocks * k_scale_per_block
+    expected_v_scale = num_blocks * v_scale_per_block
+    if (
+        raw_k_numel != expected_k
+        or raw_v_numel != expected_v
+        or raw_k_scale_numel != expected_k_scale
+        or raw_v_scale_numel != expected_v_scale
+    ):
+        raise ValueError(
+            f"C8_MXFP KV cache buffer layout mismatch for layer={layer_name}: "
+            f"num_blocks={num_blocks}, k_dim={k_dim}, v_dim={v_dim}, "
+            f"raw_k_numel={raw_k_numel} (expected {expected_k}), "
+            f"raw_v_numel={raw_v_numel} (expected {expected_v}), "
+            f"raw_k_scale_numel={raw_k_scale_numel} (expected {expected_k_scale}), "
+            f"raw_v_scale_numel={raw_v_scale_numel} (expected {expected_v_scale}), "
+            f"block_size={block_size}, num_kv_heads={num_kv_heads}."
+        )
+
+    k_shape = (num_blocks, block_size, num_kv_heads, k_dim)
+    v_shape = (num_blocks, block_size, num_kv_heads, v_dim)
+    k_scale_shape = mxfp_k_scale_cache_shape(num_blocks, block_size, num_kv_heads, k_dim)
+    v_scale_shape = mxfp_v_scale_cache_shape(num_blocks, block_size, num_kv_heads, v_dim)
+    return k_shape, v_shape, k_scale_shape, v_scale_shape
+
+
+def scatter_mxfp_k_scale_cache(
+    key_scale: torch.Tensor,
+    key_scale_cache: torch.Tensor,
+    slot_mapping: torch.Tensor,
+    block_size: int,
+) -> None:
+    """Scatter per-token K scales into the paged K-scale cache.
+
+    ``key_scale`` shape: ``[num_tokens, num_kv_heads, head_dim // 64, 2]``.
+    ``key_scale_cache`` shape:
+    ``[num_blocks, num_kv_heads, block_size, head_dim // 64, 2]``.
+    """
+    validate_mxfp_v_scale_block_size(block_size)
+    slots = slot_mapping.to(torch.long)
+    if slots.numel() == 0:
+        return
+
+    # Graph replay keeps the captured token shape and marks padded rows with
+    # slot -1. Advanced indexing would interpret -1 as the last cache entry
+    # and silently corrupt its scale. Remap padding to slot 0 and write back
+    # the existing value so the padded rows perform a no-op.
+    valid_slots = slots >= 0
+    safe_slots = torch.where(valid_slots, slots, torch.zeros_like(slots))
+    block_ids = safe_slots // block_size
+    block_offsets = safe_slots % block_size
+    cached_scale = key_scale_cache[block_ids, :, block_offsets, :, :]
+    scale_mask = valid_slots.view(-1, 1, 1, 1)
+    scale_updates = torch.where(scale_mask, key_scale, cached_scale)
+    key_scale_cache[block_ids, :, block_offsets, :, :] = scale_updates
+
+
+def scatter_mxfp_v_cache(
+    quant_value: torch.Tensor,
+    value_cache: torch.Tensor,
+    slot_mapping: torch.Tensor,
+    block_size: int,
+) -> None:
+    """Scatter per-token quantized V into the paged V cache.
+
+    ``quant_value`` shape: ``[num_tokens, num_kv_heads, v_dim]``.
+    ``value_cache`` shape: ``[num_blocks, block_size, num_kv_heads, v_dim]``.
+    """
+    validate_mxfp_v_scale_block_size(block_size)
+    slots = slot_mapping.to(torch.long)
+    if slots.numel() == 0:
+        return
+
+    num_kv_heads = quant_value.shape[1]
+    v_dim = quant_value.shape[2]
+    flat_cache = value_cache.view(-1, num_kv_heads * v_dim)
+    torch_npu.npu_scatter_nd_update_(
+        flat_cache,
+        slots.view(-1, 1),
+        quant_value.reshape(quant_value.shape[0], num_kv_heads * v_dim),
+    )
+
+
+def scatter_mxfp_v_scale_cache(
+    value_scale: torch.Tensor,
+    value_scale_cache: torch.Tensor,
+    slot_mapping: torch.Tensor,
+    block_size: int,
+) -> None:
+    """Scatter per-64-token-group V scales into the paged V-scale cache.
+
+    ``value_scale`` comes from ``npu_dynamic_mx_quant(..., axis=0)`` and has shape
+    ``[ceil(num_tokens / 64), num_kv_heads, head_dim, 2]``. The cache layout is
+    ``[num_blocks, num_kv_heads, block_size // 64, head_dim, 2]``.
+    """
+    validate_mxfp_v_scale_block_size(block_size)
+    num_scales = value_scale.shape[0]
+    v_scale_slot_mapping = (slot_mapping // MXFP_KV_SCALE_GROUP_SIZE).unique()
+    if v_scale_slot_mapping.numel() != num_scales:
+        raise ValueError(
+            f"C8_MXFP V scale slot mapping mismatch: expected {v_scale_slot_mapping.numel()}, got {num_scales}."
+        )
+
+    v_scale_cache_block_size = mxfp_kv_block_scale_groups(block_size)
+    block_ids = v_scale_slot_mapping // v_scale_cache_block_size
+    v_scale_cache_offsets = v_scale_slot_mapping % v_scale_cache_block_size
+    value_scale_cache[block_ids, :, v_scale_cache_offsets, :, :] = value_scale

--- a/vllm_ascend/device/mxfp_kv_cache.py
+++ b/vllm_ascend/device/mxfp_kv_cache.py
@@ -2,11 +2,16 @@ import torch
 import torch_npu
 
 
-# KV cache MXFP8 scale layouts (QFA requirement doc, KScale/VScale sections):
+# KV cache MXFP8 scale layouts. The block and head axes are ordered the way
+# QuantFlashAttn's PA_BBND reads them -- the same order as the K/V caches
+# themselves ([num_blocks, block_size, num_kv_heads, head_dim]) -- so attention
+# consumes cache and scales without transposing either (validated on-device by
+# the vendored-QFA bring-up; the public ops-transformer doc lists PA_BBND
+# k_descale (Bn, Bs, KV_N, D/64, 2) / v_descale (Bn, Bs/64, KV_N, D, 2)).
 # K scale token:  [num_tokens, num_kv_heads, head_dim // 64, 2]
-# K scale cache:  [num_blocks, num_kv_heads, block_size, head_dim // 64, 2]  (PA_BNBD)
+# K scale cache:  [num_blocks, block_size, num_kv_heads, head_dim // 64, 2]
 # V scale token (axis=0 quant): [cdiv(num_tokens, 64), num_kv_heads, head_dim, 2]
-# V scale cache:  [num_blocks, num_kv_heads, block_size // 64, head_dim, 2]  (PA_BNBD)
+# V scale cache:  [num_blocks, block_size // 64, num_kv_heads, head_dim, 2]
 MXFP_KV_SCALE_GROUP_SIZE = 64
 MXFP_KV_SCALE_VALUES_PER_GROUP = 2
 # Unified per-block scale bytes: num_kv_heads * block_size * head_dim / MXFP8_GROUP_SIZE (K and V).
@@ -59,8 +64,8 @@ def mxfp_k_scale_cache_shape(
 ) -> tuple[int, int, int, int, int]:
     return (
         num_blocks,
-        num_kv_heads,
         block_size,
+        num_kv_heads,
         mxfp_kv_scale_groups(head_dim),
         MXFP_KV_SCALE_VALUES_PER_GROUP,
     )
@@ -74,8 +79,8 @@ def mxfp_v_scale_cache_shape(
 ) -> tuple[int, int, int, int, int]:
     return (
         num_blocks,
-        num_kv_heads,
         mxfp_kv_block_scale_groups(block_size),
+        num_kv_heads,
         head_dim,
         MXFP_KV_SCALE_VALUES_PER_GROUP,
     )
@@ -183,9 +188,10 @@ def scatter_mxfp_k_scale_cache(
 ) -> None:
     """Scatter per-token K scales into the paged K-scale cache.
 
-    ``key_scale`` shape: ``[num_tokens, num_kv_heads, head_dim // 64, 2]``.
-    ``key_scale_cache`` shape:
-    ``[num_blocks, num_kv_heads, block_size, head_dim // 64, 2]``.
+    ``key_scale`` shape: ``[num_tokens, num_kv_heads, head_dim // 64, 2]``
+    (any 1-byte dtype; callers pass a uint8 view of the E8M0 scale).
+    ``key_scale_cache`` shape (PA_BBND, block before head):
+    ``[num_blocks, block_size, num_kv_heads, head_dim // 64, 2]``.
     """
     validate_mxfp_v_scale_block_size(block_size)
     slots = slot_mapping.to(torch.long)
@@ -207,7 +213,7 @@ def scatter_mxfp_k_scale_cache(
 
     block_ids = slots // block_size
     block_offsets = slots % block_size
-    key_scale_cache[block_ids, :, block_offsets, :, :] = key_scale
+    key_scale_cache[block_ids, block_offsets] = key_scale
 
 
 def scatter_mxfp_v_cache(
@@ -246,7 +252,12 @@ def scatter_mxfp_v_scale_cache(
 
     ``value_scale`` comes from ``npu_dynamic_mx_quant(..., axis=0)`` and has shape
     ``[ceil(num_tokens / 64), num_kv_heads, head_dim, 2]``. The cache layout is
-    ``[num_blocks, num_kv_heads, block_size // 64, head_dim, 2]``.
+    ``[num_blocks, block_size // 64, num_kv_heads, head_dim, 2]`` (PA_BBND).
+
+    Unused while V's scale is the checkpoint's static per-channel one (a
+    static V scale is broadcast into the cache once and never scattered);
+    kept for a dynamic-V design. Indexing follows the PA_BBND order the rest
+    of this module uses, so it stays correct if a dynamic-V path ever calls it.
     """
     validate_mxfp_v_scale_block_size(block_size)
     num_scales = value_scale.shape[0]
@@ -259,4 +270,4 @@ def scatter_mxfp_v_scale_cache(
     v_scale_cache_block_size = mxfp_kv_block_scale_groups(block_size)
     block_ids = v_scale_slot_mapping // v_scale_cache_block_size
     v_scale_cache_offsets = v_scale_slot_mapping % v_scale_cache_block_size
-    value_scale_cache[block_ids, :, v_scale_cache_offsets, :, :] = value_scale
+    value_scale_cache[block_ids, v_scale_cache_offsets] = value_scale

--- a/vllm_ascend/device/mxfp_kv_cache.py
+++ b/vllm_ascend/device/mxfp_kv_cache.py
@@ -196,9 +196,12 @@ def scatter_mxfp_k_scale_cache(
     ``bool()``/``.item()`` are illegal mid-capture -- "Stream during the
     capture stage is not supported") and no data-dependent shapes. Padded
     rows (slot -1) are clamped to slot 0 via ``torch.where`` and write back
-    the cache's existing value times a 0/1 row mask, making them bit-exact
-    no-ops while keeping the write pattern static. (The earlier
-    bool-compressed variant was fine eager but crashed graph capture.)
+    the cache's pre-read content, making them no-ops. Known edge (unreachable
+    in supported paths): a real token targeting slot 0 IN THE SAME BATCH as a
+    padded row would be a duplicate-index write where the padding row's
+    read-back clobbers the real value -- eager batches never carry -1 rows,
+    and graph-mode padding uses valid dummy slots, so this combination cannot
+    occur in v1.
     """
     validate_mxfp_v_scale_block_size(block_size)
     slots = slot_mapping.to(torch.long)

--- a/vllm_ascend/ops/fused_moe/fused_moe.py
+++ b/vllm_ascend/ops/fused_moe/fused_moe.py
@@ -24,6 +24,7 @@ from vllm.distributed import (
 )
 from vllm.model_executor.layers.fused_moe import FusedMoEConfig, FusedMoERouter
 from vllm.model_executor.layers.fused_moe.layer import MoERunner
+from vllm.utils.torch_utils import direct_register_custom_op
 
 from vllm_ascend.ascend_forward_context import _EXTRA_CTX, MoECommType
 from vllm_ascend.distributed.parallel_state import get_mc2_group
@@ -34,6 +35,135 @@ from vllm_ascend.ops.fused_moe.shared_experts import (
     SharedExpertParallelMode,
 )
 from vllm_ascend.utils import vllm_version_is
+
+
+def _reduced_by_combine(comm_type, is_sequence_parallel: bool) -> bool:
+    """Whether the combine kernel already all-reduced the routed output over TP."""
+    return comm_type in (
+        MoECommType.ALLTOALL,
+        MoECommType.MC2,
+        MoECommType.FUSED_MC2,
+    ) or (comm_type == MoECommType.ALLGATHER and is_sequence_parallel)
+
+
+def _reduced_after_pre_transform(
+    comm_type,
+    is_sequence_parallel: bool,
+    has_routed_output_transform: bool,
+    tp_or_ep_gt_one: bool,
+    shared_dp_only: bool,
+) -> bool:
+    """Whether the routed output is reduced once the pre-transform step is done.
+
+    That step tops the reduction up in two cases -- a latent output transform
+    needs its input summed in latent space, and a DP-only shared expert needs
+    the routed half reduced on its own -- so the later two decisions have to
+    account for it or they would reduce a second time.
+    """
+    if _reduced_by_combine(comm_type, is_sequence_parallel):
+        return True
+    if has_routed_output_transform and not is_sequence_parallel and tp_or_ep_gt_one:
+        return True
+    return shared_dp_only
+
+
+# All three reductions below are custom ops for one reason: the predicate they
+# share reads _EXTRA_CTX.moe_comm_type, which changes from step to step (a
+# forward wider than mc2_tokens_capacity falls from MC2 to ALLGATHER, and only
+# ALLGATHER leaves the routed output un-reduced across TP). MoERunner.forward
+# evaluates that predicate once near its top and carries the result down as a
+# plain Python bool, which the compiled artifact bakes in -- measured on a long
+# prompt: comm=ALLGATHER while the value handed down still said "reduced", so
+# the collective was skipped and the MoE output stayed TP-partial. Inside a
+# custom op the read is opaque to the compiler and happens on every eager call.
+# torch._dynamo.disable would be the smaller change but vLLM compiles with
+# fullgraph=True, where a graph break raises instead of degrading.
+#
+# Every op writes into a separate `out`. With no shared expert the caller's
+# `result` *is* `fused_output`, so writing back into the input would corrupt a
+# tensor the caller still holds; the original code rebound a local name to a
+# fresh tensor and this keeps that contract.
+
+
+def _moe_pre_transform_all_reduce(
+    fused_output: torch.Tensor,
+    out: torch.Tensor,
+    is_sequence_parallel: bool,
+    has_routed_output_transform: bool,
+    tp_or_ep_gt_one: bool,
+    shared_dp_only: bool,
+) -> None:
+    comm_type = _EXTRA_CTX.moe_comm_type
+    need = not _reduced_by_combine(comm_type, is_sequence_parallel) and (
+        (has_routed_output_transform and not is_sequence_parallel and tp_or_ep_gt_one) or shared_dp_only
+    )
+    out.copy_(tensor_model_parallel_all_reduce(fused_output) if need else fused_output)
+
+
+def _moe_shared_all_reduce(
+    shared_output: torch.Tensor,
+    out: torch.Tensor,
+    is_sequence_parallel: bool,
+    has_routed_output_transform: bool,
+    tp_or_ep_gt_one: bool,
+    shared_dp_only: bool,
+) -> None:
+    comm_type = _EXTRA_CTX.moe_comm_type
+    reduced = _reduced_after_pre_transform(
+        comm_type,
+        is_sequence_parallel,
+        has_routed_output_transform,
+        tp_or_ep_gt_one,
+        shared_dp_only,
+    )
+    out.copy_(tensor_model_parallel_all_reduce(shared_output) if reduced else shared_output)
+
+
+def _moe_final_all_reduce(
+    states: torch.Tensor,
+    out: torch.Tensor,
+    is_sequence_parallel: bool,
+    has_routed_output_transform: bool,
+    tp_or_ep_gt_one: bool,
+    shared_dp_only: bool,
+) -> None:
+    comm_type = _EXTRA_CTX.moe_comm_type
+    reduced = _reduced_after_pre_transform(
+        comm_type,
+        is_sequence_parallel,
+        has_routed_output_transform,
+        tp_or_ep_gt_one,
+        shared_dp_only,
+    )
+    # Sequence-parallel outputs are token shards, so reducing them
+    # position-wise would corrupt the result.
+    need = not reduced and not is_sequence_parallel
+    out.copy_(tensor_model_parallel_all_reduce(states) if need else states)
+
+
+def _moe_all_reduce_fake(
+    src: torch.Tensor,
+    out: torch.Tensor,
+    is_sequence_parallel: bool,
+    has_routed_output_transform: bool,
+    tp_or_ep_gt_one: bool,
+    shared_dp_only: bool,
+) -> None:
+    return
+
+
+for _op_name, _op_func in (
+    ("ascend_moe_pre_transform_all_reduce", _moe_pre_transform_all_reduce),
+    ("ascend_moe_shared_all_reduce", _moe_shared_all_reduce),
+    ("ascend_moe_final_all_reduce", _moe_final_all_reduce),
+):
+    direct_register_custom_op(
+        op_name=_op_name,
+        op_func=_op_func,
+        fake_impl=_moe_all_reduce_fake,
+        mutates_args=["out"],
+        dispatch_key="PrivateUse1",
+    )
 
 
 class AscendMoERunner(MoERunner):  # type: ignore[no-redef]
@@ -128,6 +258,22 @@ class AscendMoERunner(MoERunner):  # type: ignore[no-redef]
             MoECommType.FUSED_MC2,
         } or (moe_comm_type == MoECommType.ALLGATHER and self.moe_config.is_sequence_parallel)
 
+    @property
+    def _reduce_static_flags(self) -> tuple[bool, bool, bool, bool]:
+        """The four conditions the three reductions share, all process-constant.
+
+        Only moe_comm_type varies per step, which is why it is read inside the
+        ops instead of here. parallel_mode() derives from tp_group.world_size /
+        is_sequence_parallel / weights_replicated and routed_output_transform is
+        fixed at construction, so both are stable for the life of the layer.
+        """
+        return (
+            self.moe_config.is_sequence_parallel,
+            getattr(self, "routed_output_transform", None) is not None,
+            self.moe_config.tp_size > 1 or self.moe_config.ep_size > 1,
+            self._get_shared_expert_parallel_mode() is SharedExpertParallelMode.SHARED_EXPERT_DATA_PARALLEL_ONLY,
+        )
+
     def _get_shared_expert_parallel_mode(self) -> SharedExpertParallelMode:
         shared_experts = getattr(self, "ascend_shared_experts", None)
         if shared_experts is None or not hasattr(shared_experts, "parallel_mode"):
@@ -139,13 +285,13 @@ class AscendMoERunner(MoERunner):  # type: ignore[no-redef]
         shared_output: torch.Tensor | None,
         fused_output_is_reduced: bool,
     ) -> torch.Tensor | None:
-        if (
-            shared_output is not None
-            and fused_output_is_reduced
-            and self._get_shared_expert_parallel_mode() is SharedExpertParallelMode.TENSOR_PARALLEL
-        ):
-            shared_output = tensor_model_parallel_all_reduce(shared_output)
-        return shared_output
+        if shared_output is None:
+            return shared_output
+        if self._get_shared_expert_parallel_mode() is not SharedExpertParallelMode.TENSOR_PARALLEL:
+            return shared_output
+        reduced = torch.empty_like(shared_output)
+        torch.ops.vllm.ascend_moe_shared_all_reduce(shared_output, reduced, *self._reduce_static_flags)
+        return reduced
 
     @property
     def local_num_experts(self) -> int:
@@ -176,18 +322,22 @@ class AscendMoERunner(MoERunner):  # type: ignore[no-redef]
         fused_output: torch.Tensor,
         fused_output_is_reduced: bool,
     ) -> tuple[torch.Tensor, bool]:
-        fused_output, fused_output_is_reduced = super()._maybe_reduce_routed_output_before_transform(
-            fused_output,
-            fused_output_is_reduced,
-        )
+        flags = self._reduce_static_flags
+        _, has_routed_output_transform, _, shared_dp_only = flags
+        if not (has_routed_output_transform or shared_dp_only):
+            # Neither top-up branch can fire for this layer, so the upstream
+            # body and the DP-only branch below are both no-ops. Skip the op
+            # rather than pay a copy for nothing.
+            return fused_output, fused_output_is_reduced
 
-        if (
-            self._get_shared_expert_parallel_mode() is SharedExpertParallelMode.SHARED_EXPERT_DATA_PARALLEL_ONLY
-            and not fused_output_is_reduced
-        ):
-            fused_output = tensor_model_parallel_all_reduce(fused_output)
-            fused_output_is_reduced = True
-        return fused_output, fused_output_is_reduced
+        # Deliberately not calling super(): its own branch keys off the same
+        # value handed down from forward, which is the one that goes stale.
+        reduced = torch.empty_like(fused_output)
+        torch.ops.vllm.ascend_moe_pre_transform_all_reduce(fused_output, reduced, *flags)
+        # The returned flag is no longer read by anything: both remaining
+        # consumers recompute it from the current moe_comm_type inside their
+        # own op. Passed through unchanged to keep the upstream signature.
+        return reduced, fused_output_is_reduced
 
     # Ascend already handles reduction in its own dispatch path, so
     # the upstream kwarg is accepted for interface alignment only.
@@ -197,13 +347,12 @@ class AscendMoERunner(MoERunner):  # type: ignore[no-redef]
         trunc_size: int | None,
         output_is_reduced: bool | None = None,
     ) -> torch.Tensor:
-        if output_is_reduced is None:
-            output_is_reduced = self._fused_output_is_reduced
-        if not output_is_reduced and not self.moe_config.is_sequence_parallel:
-            # Use the normal TP collective when the upstream reduction
-            # contract requires it. Sequence-parallel outputs are token
-            # shards, so reducing them position-wise would corrupt the result.
-            states = tensor_model_parallel_all_reduce(states)
+        # output_is_reduced is ignored on purpose: MoERunner.forward always
+        # supplies it, and it is exactly the value that goes stale. The op
+        # recomputes the predicate from the comm type in effect right now.
+        reduced = torch.empty_like(states)
+        torch.ops.vllm.ascend_moe_final_all_reduce(states, reduced, *self._reduce_static_flags)
+        states = reduced
         if trunc_size is not None and trunc_size > 0:
             return states[..., :trunc_size]
         return states

--- a/vllm_ascend/platform.py
+++ b/vllm_ascend/platform.py
@@ -46,9 +46,11 @@ from vllm_ascend.utils import (
     COMPILATION_PASS_KEY,
     COMPRESSED_TENSORS_METHOD,
     FP8_METHOD,
+    A5_C8_MXFP_KV_CACHE_BLOCK_SIZE,
     bootstrap_custom_op_env,
     check_kv_extra_config,
     enable_sfa_dcp_replicated_indexer,
+    is_c8_mxfp_kv_quant,
     is_moe_model,
     model_uses_sfa_sparse,
     refresh_block_size,
@@ -343,6 +345,9 @@ class NPUPlatform(Platform):
                 assert cache_config.mamba_block_size % cache_config.block_size == 0, (
                     f"mamba_block_size must be a multiple of block_size: {cache_config.block_size}"
                 )
+
+        if model_config is not None and model_config.is_hybrid:
+            _realign_c8_mxfp_hybrid_page_size(vllm_config)
 
     @classmethod
     def _validate_indexer_pp_config(cls, vllm_config: VllmConfig) -> None:
@@ -1191,6 +1196,82 @@ def _setup_compile_backend(
             "for example, check the plog files (default: $HOME/ascend/log/debug) "
             "for more information about runtime errors."
         )
+
+
+def _realign_c8_mxfp_hybrid_page_size(vllm_config: VllmConfig) -> None:
+    """Re-align the hybrid block/mamba page sizes for C8-MXFP models.
+
+    ``patch_mamba_config.HybridAttentionMambaModelConfig`` aligns the mamba
+    page with the *bf16* attention page early, during
+    ``VllmConfig.try_verify_and_update_config``. C8-MXFP layers instead store
+    fp8 K/V with the E8M0 scale bytes packed into the spec head_size, so the
+    real per-token page is much smaller. Left as-is,
+    ``unify_kv_cache_spec_page_size`` would see a mamba page that neither
+    equals nor divides the real attention page and raise NotImplementedError.
+
+    Fix: bump ``block_size`` (in multiples of the 512-token QFA kernel block)
+    until the packed fp8 attention page covers the mamba page, then pad the
+    mamba page to exactly that attention page. This runs after model layers
+    are constructed (the executor calls it via
+    ``update_block_size_for_backend``), so the C8 backend is already installed
+    on the layers. Non-C8 models are untouched.
+    """
+    if not is_c8_mxfp_kv_quant(vllm_config):
+        return
+
+    from vllm.utils.math_utils import cdiv
+    from vllm.utils.torch_utils import get_dtype_size
+
+    from vllm_ascend.device.mxfp_kv_cache import MXFP8_GROUP_SIZE
+
+    cache_config = vllm_config.cache_config
+    model_config = vllm_config.model_config
+    parallel_config = vllm_config.parallel_config
+
+    get_mamba_state_shape = None
+    try:
+        from vllm.model_executor.models import ModelRegistry
+
+        model_cls, _ = ModelRegistry.resolve_model_cls(
+            model_config.architecture,
+            model_config=model_config,
+        )
+        get_mamba_state_shape = getattr(model_cls, "get_mamba_state_shape_from_config", None)
+        get_mamba_state_dtype = getattr(model_cls, "get_mamba_state_dtype_from_config", None)
+    except Exception:  # noqa: BLE001
+        logger.debug("Could not resolve model class for C8-MXFP page re-alignment.", exc_info=True)
+        return
+    if get_mamba_state_shape is None or get_mamba_state_dtype is None:
+        return
+
+    mamba_page_size = sum(
+        math.prod(shape) * get_dtype_size(dtype)
+        for shape, dtype in zip(
+            get_mamba_state_shape(vllm_config),
+            get_mamba_state_dtype(vllm_config),
+        )
+    )
+    if mamba_page_size == 0:
+        return
+
+    # Real per-token page: fp8 K/V (1B) plus the packed E8M0 scale bytes
+    # (head_dim // MXFP8_GROUP_SIZE per head, per side). Must stay in sync
+    # with get_kv_cache_spec / _allocate_kv_cache_tensors.
+    num_kv_heads = model_config.get_num_kv_heads(parallel_config)
+    head_dim = model_config.get_head_size()
+    per_token_bytes = num_kv_heads * 2 * (head_dim + head_dim // MXFP8_GROUP_SIZE)
+
+    kernel_block = A5_C8_MXFP_KV_CACHE_BLOCK_SIZE
+    required_blocks = kernel_block * max(1, cdiv(mamba_page_size, kernel_block * per_token_bytes))
+    if cache_config.block_size < required_blocks:
+        cache_config.block_size = required_blocks
+        logger.info(
+            "Setting attention block size to %d tokens so the C8-MXFP fp8 "
+            "KV page covers the mamba page (%d bytes).",
+            required_blocks,
+            mamba_page_size,
+        )
+    cache_config.mamba_page_size_padded = cache_config.block_size * per_token_bytes
 
 
 def _setup_worker_and_scheduler(

--- a/vllm_ascend/platform.py
+++ b/vllm_ascend/platform.py
@@ -46,11 +46,9 @@ from vllm_ascend.utils import (
     COMPILATION_PASS_KEY,
     COMPRESSED_TENSORS_METHOD,
     FP8_METHOD,
-    A5_C8_MXFP_KV_CACHE_BLOCK_SIZE,
     bootstrap_custom_op_env,
     check_kv_extra_config,
     enable_sfa_dcp_replicated_indexer,
-    is_c8_mxfp_kv_quant,
     is_moe_model,
     model_uses_sfa_sparse,
     refresh_block_size,
@@ -345,9 +343,6 @@ class NPUPlatform(Platform):
                 assert cache_config.mamba_block_size % cache_config.block_size == 0, (
                     f"mamba_block_size must be a multiple of block_size: {cache_config.block_size}"
                 )
-
-        if model_config is not None and model_config.is_hybrid:
-            _realign_c8_mxfp_hybrid_page_size(vllm_config)
 
     @classmethod
     def _validate_indexer_pp_config(cls, vllm_config: VllmConfig) -> None:
@@ -1196,82 +1191,6 @@ def _setup_compile_backend(
             "for example, check the plog files (default: $HOME/ascend/log/debug) "
             "for more information about runtime errors."
         )
-
-
-def _realign_c8_mxfp_hybrid_page_size(vllm_config: VllmConfig) -> None:
-    """Re-align the hybrid block/mamba page sizes for C8-MXFP models.
-
-    ``patch_mamba_config.HybridAttentionMambaModelConfig`` aligns the mamba
-    page with the *bf16* attention page early, during
-    ``VllmConfig.try_verify_and_update_config``. C8-MXFP layers instead store
-    fp8 K/V with the E8M0 scale bytes packed into the spec head_size, so the
-    real per-token page is much smaller. Left as-is,
-    ``unify_kv_cache_spec_page_size`` would see a mamba page that neither
-    equals nor divides the real attention page and raise NotImplementedError.
-
-    Fix: bump ``block_size`` (in multiples of the 512-token QFA kernel block)
-    until the packed fp8 attention page covers the mamba page, then pad the
-    mamba page to exactly that attention page. This runs after model layers
-    are constructed (the executor calls it via
-    ``update_block_size_for_backend``), so the C8 backend is already installed
-    on the layers. Non-C8 models are untouched.
-    """
-    if not is_c8_mxfp_kv_quant(vllm_config):
-        return
-
-    from vllm.utils.math_utils import cdiv
-    from vllm.utils.torch_utils import get_dtype_size
-
-    from vllm_ascend.device.mxfp_kv_cache import MXFP8_GROUP_SIZE
-
-    cache_config = vllm_config.cache_config
-    model_config = vllm_config.model_config
-    parallel_config = vllm_config.parallel_config
-
-    get_mamba_state_shape = None
-    try:
-        from vllm.model_executor.models import ModelRegistry
-
-        model_cls, _ = ModelRegistry.resolve_model_cls(
-            model_config.architecture,
-            model_config=model_config,
-        )
-        get_mamba_state_shape = getattr(model_cls, "get_mamba_state_shape_from_config", None)
-        get_mamba_state_dtype = getattr(model_cls, "get_mamba_state_dtype_from_config", None)
-    except Exception:  # noqa: BLE001
-        logger.debug("Could not resolve model class for C8-MXFP page re-alignment.", exc_info=True)
-        return
-    if get_mamba_state_shape is None or get_mamba_state_dtype is None:
-        return
-
-    mamba_page_size = sum(
-        math.prod(shape) * get_dtype_size(dtype)
-        for shape, dtype in zip(
-            get_mamba_state_shape(vllm_config),
-            get_mamba_state_dtype(vllm_config),
-        )
-    )
-    if mamba_page_size == 0:
-        return
-
-    # Real per-token page: fp8 K/V (1B) plus the packed E8M0 scale bytes
-    # (head_dim // MXFP8_GROUP_SIZE per head, per side). Must stay in sync
-    # with get_kv_cache_spec / _allocate_kv_cache_tensors.
-    num_kv_heads = model_config.get_num_kv_heads(parallel_config)
-    head_dim = model_config.get_head_size()
-    per_token_bytes = num_kv_heads * 2 * (head_dim + head_dim // MXFP8_GROUP_SIZE)
-
-    kernel_block = A5_C8_MXFP_KV_CACHE_BLOCK_SIZE
-    required_blocks = kernel_block * max(1, cdiv(mamba_page_size, kernel_block * per_token_bytes))
-    if cache_config.block_size < required_blocks:
-        cache_config.block_size = required_blocks
-        logger.info(
-            "Setting attention block size to %d tokens so the C8-MXFP fp8 "
-            "KV page covers the mamba page (%d bytes).",
-            required_blocks,
-            mamba_page_size,
-        )
-    cache_config.mamba_page_size_padded = cache_config.block_size * per_token_bytes
 
 
 def _setup_worker_and_scheduler(

--- a/vllm_ascend/quantization/configs/modelslim_config.py
+++ b/vllm_ascend/quantization/configs/modelslim_config.py
@@ -667,6 +667,10 @@ class AscendModelSlimConfig(QuantizationConfig):
                     ".v_proj.kv_cache_offset": ".attn.v_cache_offset",
                 }
             )
+        if self.enable_mxfp_c8_quant:
+            # MXFP C8 quantizes K dynamically, but V uses the static E8M0
+            # per-channel scale stored in the ModelSlim checkpoint.
+            suffix_map[".v_proj.kv_cache_scale"] = ".attn.v_cache_scale"
         if self.enable_fa_quant:
             # Some models (e.g., Kimi-K2.6) have a nested module and call AutoWeightsLoader twice, to avoid double
             # mapping, we use regex mapping.
@@ -806,6 +810,11 @@ class AscendModelSlimConfig(QuantizationConfig):
 
             logger.debug("Select AscendKVCacheMethod(C8) for %s (layer=%s)", prefix, "AttentionLayerBase[C8]")
             return AscendKVCacheMethod(AscendC8KVCacheAttentionMethod(self.quant_description, prefix))
+        elif isinstance(layer, AttentionLayerBase) and self.enable_mxfp_c8_quant:
+            from ..methods.kv_cache.mxfp_c8 import AscendC8MXFPKVCacheAttentionMethod
+
+            logger.debug("Select AscendKVCacheMethod(C8-MXFP) for %s (layer=%s)", prefix, "AttentionLayerBase[C8-MXFP]")
+            return AscendKVCacheMethod(AscendC8MXFPKVCacheAttentionMethod(self.quant_description, prefix))
         elif is_fused_moe_layer(layer):
             if self.is_layer_skipped_ascend(prefix, self.packed_modules_mapping):
                 # Delayed import to avoid circular import
@@ -902,6 +911,8 @@ class AscendModelSlimConfig(QuantizationConfig):
         return False
 
     def get_kv_quant_dtype(self, layer_name, cache_dtype, model_config):
+        if self.enable_mxfp_c8_quant:
+            return torch.float8_e4m3fn, torch.float8_e4m3fn
         if self.enable_fa_quant and self.is_fa_quant_layer(layer_name):
             ori_dtype = model_config.dtype
             quant_dtype = (
@@ -1105,6 +1116,9 @@ class AscendModelSlimConfig(QuantizationConfig):
         self.enable_indexer_quant = indexer_quant_type != ""
         self.indexer_quant_layers = []
         kv_quant_type = self.quant_description.get("kv_cache_type", "")
+        self.enable_mxfp_c8_quant = kv_quant_type == "K_DYNAMIC_V_STATIC_MXFP8_PER_CHANNEL"
+        if self.enable_mxfp_c8_quant:
+            logger.info_once("[quantization] Enable C8 MXFP8 quantization!")
         self.enable_c8_quant = kv_quant_type == "C8"
         self.c8_quant_layers = []
         if self.enable_fa_quant or self.enable_indexer_quant or self.enable_c8_quant:

--- a/vllm_ascend/quantization/configs/modelslim_config.py
+++ b/vllm_ascend/quantization/configs/modelslim_config.py
@@ -810,7 +810,11 @@ class AscendModelSlimConfig(QuantizationConfig):
 
             logger.debug("Select AscendKVCacheMethod(C8) for %s (layer=%s)", prefix, "AttentionLayerBase[C8]")
             return AscendKVCacheMethod(AscendC8KVCacheAttentionMethod(self.quant_description, prefix))
-        elif isinstance(layer, AttentionLayerBase) and self.enable_mxfp_c8_quant:
+        elif (
+            isinstance(layer, AttentionLayerBase)
+            and self.enable_mxfp_c8_quant
+            and self._is_c8_mxfp_kv_layer(layer)
+        ):
             from ..methods.kv_cache.mxfp_c8 import AscendC8MXFPKVCacheAttentionMethod
 
             logger.debug("Select AscendKVCacheMethod(C8-MXFP) for %s (layer=%s)", prefix, "AttentionLayerBase[C8-MXFP]")
@@ -910,9 +914,21 @@ class AscendModelSlimConfig(QuantizationConfig):
                 return True
         return False
 
+    @staticmethod
+    def _is_c8_mxfp_kv_layer(layer: torch.nn.Module) -> bool:
+        """C8-MXFP only applies to standard full-attention ``Attention``
+        layers. Other AttentionLayerBase subclasses (GDN/Mamba, encoder
+        attention, ...) must not get the MXFP KV-cache method: they have no
+        ``num_kv_heads``/``head_size_v`` and install the QFA backend on the
+        wrong layer type."""
+        from vllm.model_executor.layers.attention import Attention
+
+        return isinstance(layer, Attention)
+
     def get_kv_quant_dtype(self, layer_name, cache_dtype, model_config):
-        if self.enable_mxfp_c8_quant:
-            return torch.float8_e4m3fn, torch.float8_e4m3fn
+        # Note: C8-MXFP models never reach this hook — its only caller in
+        # model_runner_v1 is gated by enable_fa_quant(), and the C8-MXFP
+        # cache dtype comes from the rebuilt fp8 spec in get_kv_cache_spec.
         if self.enable_fa_quant and self.is_fa_quant_layer(layer_name):
             ori_dtype = model_config.dtype
             quant_dtype = (

--- a/vllm_ascend/quantization/configs/modelslim_config.py
+++ b/vllm_ascend/quantization/configs/modelslim_config.py
@@ -671,6 +671,14 @@ class AscendModelSlimConfig(QuantizationConfig):
             # MXFP C8 quantizes K dynamically, but V uses the static E8M0
             # per-channel scale stored in the ModelSlim checkpoint.
             suffix_map[".v_proj.kv_cache_scale"] = ".attn.v_cache_scale"
+            # Newer ModelSlim recipes name it v_proj.v_scale. vLLM's own
+            # cache-scale regex has already rewritten that to attn.v_scale by
+            # the time suffixes run (WeightsMapper._map_name applies regexes
+            # first), so catch it under the rewritten name or it lands on a
+            # parameter this scheme never registers and is silently dropped
+            # (the vendored-QFA bring-up served with the 127 fallback for a
+            # whole run because of this).
+            suffix_map[".attn.v_scale"] = ".attn.v_cache_scale"
         if self.enable_fa_quant:
             # Some models (e.g., Kimi-K2.6) have a nested module and call AutoWeightsLoader twice, to avoid double
             # mapping, we use regex mapping.

--- a/vllm_ascend/quantization/configs/modelslim_config.py
+++ b/vllm_ascend/quantization/configs/modelslim_config.py
@@ -55,6 +55,25 @@ _MOE_WEIGHT_LOADER_NAME_MAP = {
     "w2_scale_bias": "w2_scale",
 }
 
+# Older ModelSlim checkpoints declare the MXFP8 KV cache once, model-wide, as
+# ``kv_cache_type``. Newer ones drop that key and state the recipe per layer
+# instead, which is also how a hybrid model says that only its full-attention
+# layers have a KV cache at all. We still enable the scheme model-wide, since
+# the backend has no per-layer switch, and the linear-attention layers never
+# reach it.
+_MXFP_C8_KV_CACHE_TYPE = "K_DYNAMIC_V_STATIC_MXFP8_PER_CHANNEL"
+_MXFP_C8_LAYER_QUANT_TYPE_SUFFIX = ".self_attn.quant_type"
+_MXFP_C8_LAYER_QUANT_TYPES = ("QK_MXFP8_DYNAMIC_V_MXFP8_PER_CHANNEL",)
+# FAKQuant parameters that MXFP8 has no home for: K and Q are quantized
+# dynamically at runtime, so their checkpoint scales have no parameter to land
+# on. Without these AutoWeightsLoader rejects the checkpoint outright.
+_MXFP_C8_UNUSED_FA_SUFFIXES = (
+    ".fa_q.scale",
+    ".fa_k.scale",
+    ".fa_q.offset",
+    ".fa_k.offset",
+)
+
 
 def _make_modelslim_moe_weight_loader(
     weight_loader: Callable[..., bool | None],
@@ -679,6 +698,13 @@ class AscendModelSlimConfig(QuantizationConfig):
             # (the vendored-QFA bring-up served with the 127 fallback for a
             # whole run because of this).
             suffix_map[".attn.v_scale"] = ".attn.v_cache_scale"
+            # And the newest ones name it fa_v.scale, reusing FAKQuant's key for
+            # a different recipe. Safe to hang on the raw name: no regex in
+            # either mapper rewrites it once FAKQuant has stood down.
+            suffix_map[".fa_v.scale"] = ".attn.v_cache_scale"
+            # The offset comes along with it. MXFP8 is symmetric so it has to
+            # be zero; loading it is how that gets checked rather than assumed.
+            suffix_map[".fa_v.offset"] = ".attn.v_cache_offset"
         if self.enable_fa_quant:
             # Some models (e.g., Kimi-K2.6) have a nested module and call AutoWeightsLoader twice, to avoid double
             # mapping, we use regex mapping.
@@ -1140,9 +1166,29 @@ class AscendModelSlimConfig(QuantizationConfig):
         self.enable_indexer_quant = indexer_quant_type != ""
         self.indexer_quant_layers = []
         kv_quant_type = self.quant_description.get("kv_cache_type", "")
-        self.enable_mxfp_c8_quant = kv_quant_type == "K_DYNAMIC_V_STATIC_MXFP8_PER_CHANNEL"
+        self.enable_mxfp_c8_quant = kv_quant_type == _MXFP_C8_KV_CACHE_TYPE or any(
+            key.endswith(_MXFP_C8_LAYER_QUANT_TYPE_SUFFIX) and value in _MXFP_C8_LAYER_QUANT_TYPES
+            for key, value in self.quant_description.items()
+        )
         if self.enable_mxfp_c8_quant:
             logger.info_once("[quantization] Enable C8 MXFP8 quantization!")
+            self._ignore_unexpected_suffixes = (
+                *QuantizationConfig._ignore_unexpected_suffixes,
+                *_MXFP_C8_UNUSED_FA_SUFFIXES,
+            )
+            if self.enable_fa_quant:
+                # A checkpoint can carry the top-level fa_quant_type while the
+                # per-layer quant_type says MXFP8; the two are alternative KV
+                # cache recipes for the same layer, and FAKQuant wins every
+                # dispatch they share -- get_quant_method tests it first, and
+                # its weight mapping renames fa_v.scale into an MLA submodule
+                # this dense model does not have, so the scale would be
+                # silently dropped. Stand FAKQuant down and let MXFP8 own it.
+                logger.warning_once(
+                    "[quantization] fa_quant_type=%s is declared alongside an MXFP8 KV cache; ignoring FAKQuant.",
+                    fa_quant_type,
+                )
+                self.enable_fa_quant = False
         self.enable_c8_quant = kv_quant_type == "C8"
         self.c8_quant_layers = []
         if self.enable_fa_quant or self.enable_indexer_quant or self.enable_c8_quant:

--- a/vllm_ascend/quantization/methods/kv_cache/mxfp_c8.py
+++ b/vllm_ascend/quantization/methods/kv_cache/mxfp_c8.py
@@ -10,25 +10,27 @@ def _quant_weight_loader(param: torch.Tensor, loaded_weight: torch.Tensor):
         param.data.fill_(loaded_weight.item())
     else:
         # ModelSlim exports the per-channel V cache scale as a column vector
-        # ([hidden, 1]) while the registered parameter is 1-D; flatten first
-        # so both the TP narrow and the final shape comparison see plain
-        # element counts (reshape to param.shape alone would fail under TP,
-        # where the checkpoint is full-width but the parameter is sharded).
+        # ([hidden, 1]) while the registered parameter is 1-D; flatten first.
+        # No TP narrow here: under tensor parallelism vLLM's param loader has
+        # already sliced the checkpoint to this rank's share (per output
+        # channels / KV heads) before calling the weight loader -- slicing
+        # again double-shards it (passed on TP1/TP2 only by coincidence:
+        # with num_kv_heads == tp_size, channel-even split equals per-head
+        # split; it breaks on TP4 where heads < tp size). Assert on numel so
+        # any future mismatch in the upstream sharding semantics fails loud
+        # instead of silently loading wrong scales.
         if loaded_weight.dim() != 1:
             loaded_weight = loaded_weight.flatten()
-        if loaded_weight.shape != param.shape:
-            tp_rank = get_tensor_model_parallel_rank()
-            tp_size = get_tensor_model_parallel_world_size()
-            shard_size = loaded_weight.shape[0] // tp_size
-            loaded_weight = loaded_weight.narrow(0, shard_size * tp_rank, shard_size)
-        assert param.size() == loaded_weight.size(), (
-            "[vllm-ascend/MXFP8_PER_CHANNEL] Attempted to load weight "
-            f"({loaded_weight.size()}) into parameter ({param.size()}) "
-            f"when TP size is {get_tensor_model_parallel_world_size()} and TP rank is "
-            f"{get_tensor_model_parallel_rank()}."
+        assert param.numel() == loaded_weight.numel(), (
+            "[vllm-ascend/MXFP8_PER_CHANNEL] V cache scale size mismatch: parameter "
+            f"has {param.numel()} elements (num_kv_heads x head_dim on this rank) but "
+            f"the loader delivered {loaded_weight.numel()} (TP size "
+            f"{get_tensor_model_parallel_world_size()}, TP rank "
+            f"{get_tensor_model_parallel_rank()}). The upstream sharding of "
+            "v_cache_scale does not match the per-head layout this scheme "
+            "registers."
         )
-
-        param.data.copy_(loaded_weight)
+        param.data.copy_(loaded_weight.view_as(param))
 
 
 class AscendC8MXFPKVCacheAttentionMethod(AscendAttentionScheme):

--- a/vllm_ascend/quantization/methods/kv_cache/mxfp_c8.py
+++ b/vllm_ascend/quantization/methods/kv_cache/mxfp_c8.py
@@ -10,10 +10,12 @@ def _quant_weight_loader(param: torch.Tensor, loaded_weight: torch.Tensor):
         param.data.fill_(loaded_weight.item())
     else:
         # ModelSlim exports the per-channel V cache scale as a column vector
-        # ([hidden, 1]) while the registered parameter is 1-D; squeeze the
-        # trailing size-1 dims so the shapes match before TP narrow/copy.
-        if loaded_weight.dim() > param.dim():
-            loaded_weight = loaded_weight.reshape(param.shape)
+        # ([hidden, 1]) while the registered parameter is 1-D; flatten first
+        # so both the TP narrow and the final shape comparison see plain
+        # element counts (reshape to param.shape alone would fail under TP,
+        # where the checkpoint is full-width but the parameter is sharded).
+        if loaded_weight.dim() != 1:
+            loaded_weight = loaded_weight.flatten()
         if loaded_weight.shape != param.shape:
             tp_rank = get_tensor_model_parallel_rank()
             tp_size = get_tensor_model_parallel_world_size()

--- a/vllm_ascend/quantization/methods/kv_cache/mxfp_c8.py
+++ b/vllm_ascend/quantization/methods/kv_cache/mxfp_c8.py
@@ -10,25 +10,37 @@ def _quant_weight_loader(param: torch.Tensor, loaded_weight: torch.Tensor):
         param.data.fill_(loaded_weight.item())
     else:
         # ModelSlim exports the per-channel V cache scale as a column vector
-        # ([hidden, 1]) while the registered parameter is 1-D; flatten first.
-        # No TP narrow here: under tensor parallelism vLLM's param loader has
-        # already sliced the checkpoint to this rank's share (per output
-        # channels / KV heads) before calling the weight loader -- slicing
-        # again double-shards it (passed on TP1/TP2 only by coincidence:
-        # with num_kv_heads == tp_size, channel-even split equals per-head
-        # split; it breaks on TP4 where heads < tp size). Assert on numel so
-        # any future mismatch in the upstream sharding semantics fails loud
-        # instead of silently loading wrong scales.
+        # ([hidden, 1]); flatten it first. The loader delivers the FULL-width
+        # scale on every rank (attention-module parameters bypass the
+        # ColumnParallelLinear sharding), so slice it here following the same
+        # rule vLLM uses to replicate KV heads under GQA TP: with
+        # num_kv_heads < tp_size each head is replicated across
+        # tp_size // num_kv_heads ranks and rank r owns the 256-dim slice of
+        # head r // (tp_size // num_kv_heads). When num_kv_heads >= tp_size
+        # this degenerates to the plain contiguous narrow.
         if loaded_weight.dim() != 1:
             loaded_weight = loaded_weight.flatten()
+        if loaded_weight.numel() != param.numel():
+            tp_rank = get_tensor_model_parallel_rank()
+            tp_size = get_tensor_model_parallel_world_size()
+            head_dim = param.numel()  # this rank's full (possibly replicated) head width
+            total = loaded_weight.numel()
+            num_heads_total = total // head_dim if total % head_dim == 0 else None
+            if num_heads_total is None or num_heads_total < 1:
+                raise AssertionError(
+                    "[vllm-ascend/MXFP8_PER_CHANNEL] Cannot map V cache scale of "
+                    f"{total} elements onto a per-rank head width of {head_dim} "
+                    f"(TP size {tp_size}, TP rank {tp_rank})."
+                )
+            heads_per_rank_group = max(1, tp_size // num_heads_total)
+            src_head = tp_rank // heads_per_rank_group
+            loaded_weight = loaded_weight.narrow(0, src_head * head_dim, head_dim)
         assert param.numel() == loaded_weight.numel(), (
             "[vllm-ascend/MXFP8_PER_CHANNEL] V cache scale size mismatch: parameter "
-            f"has {param.numel()} elements (num_kv_heads x head_dim on this rank) but "
-            f"the loader delivered {loaded_weight.numel()} (TP size "
+            f"has {param.numel()} elements but the sliced weight has "
+            f"{loaded_weight.numel()} (TP size "
             f"{get_tensor_model_parallel_world_size()}, TP rank "
-            f"{get_tensor_model_parallel_rank()}). The upstream sharding of "
-            "v_cache_scale does not match the per-head layout this scheme "
-            "registers."
+            f"{get_tensor_model_parallel_rank()})."
         )
         param.data.copy_(loaded_weight.view_as(param))
 

--- a/vllm_ascend/quantization/methods/kv_cache/mxfp_c8.py
+++ b/vllm_ascend/quantization/methods/kv_cache/mxfp_c8.py
@@ -9,14 +9,21 @@ def _quant_weight_loader(param: torch.Tensor, loaded_weight: torch.Tensor):
     if param.numel() == 1 and loaded_weight.numel() == 1:
         param.data.fill_(loaded_weight.item())
     else:
-        tp_rank = get_tensor_model_parallel_rank()
-        tp_size = get_tensor_model_parallel_world_size()
-        shard_size = loaded_weight.shape[0] // tp_size
-        loaded_weight = loaded_weight.narrow(0, shard_size * tp_rank, shard_size)
+        # ModelSlim exports the per-channel V cache scale as a column vector
+        # ([hidden, 1]) while the registered parameter is 1-D; squeeze the
+        # trailing size-1 dims so the shapes match before TP narrow/copy.
+        if loaded_weight.dim() > param.dim():
+            loaded_weight = loaded_weight.reshape(param.shape)
+        if loaded_weight.shape != param.shape:
+            tp_rank = get_tensor_model_parallel_rank()
+            tp_size = get_tensor_model_parallel_world_size()
+            shard_size = loaded_weight.shape[0] // tp_size
+            loaded_weight = loaded_weight.narrow(0, shard_size * tp_rank, shard_size)
         assert param.size() == loaded_weight.size(), (
             "[vllm-ascend/MXFP8_PER_CHANNEL] Attempted to load weight "
             f"({loaded_weight.size()}) into parameter ({param.size()}) "
-            f"when TP size is {tp_size} and TP rank is {tp_rank}."
+            f"when TP size is {get_tensor_model_parallel_world_size()} and TP rank is "
+            f"{get_tensor_model_parallel_rank()}."
         )
 
         param.data.copy_(loaded_weight)

--- a/vllm_ascend/quantization/methods/kv_cache/mxfp_c8.py
+++ b/vllm_ascend/quantization/methods/kv_cache/mxfp_c8.py
@@ -73,9 +73,11 @@ class AscendC8MXFPKVCacheAttentionMethod(AscendAttentionScheme):
         vllm_config = get_current_vllm_config()
         target_dtype = vllm_config.model_config.dtype
         exponent = layer.v_cache_scale.data.to(torch.float32) - 127
-        layer.v_cache_scale_float = torch.nn.Parameter(torch.exp2(exponent).to(target_dtype), requires_grad=False)
+        # Only the reciprocal is consumed (npu_quantize needs 1/scale); the
+        # forward scale itself is written into the V-scale cache as raw E8M0
+        # bytes straight from v_cache_scale.
         layer.v_cache_scale_float_reciprocal = torch.nn.Parameter(
-            1 / torch.exp2(exponent).to(target_dtype),
+            (1 / torch.exp2(exponent)).to(target_dtype),
             requires_grad=False,
         )
 

--- a/vllm_ascend/quantization/methods/kv_cache/mxfp_c8.py
+++ b/vllm_ascend/quantization/methods/kv_cache/mxfp_c8.py
@@ -1,0 +1,97 @@
+import torch
+from vllm.config import get_current_vllm_config
+from vllm.distributed import get_tensor_model_parallel_rank, get_tensor_model_parallel_world_size
+
+from ..base import AscendAttentionScheme
+
+
+def _quant_weight_loader(param: torch.Tensor, loaded_weight: torch.Tensor):
+    if param.numel() == 1 and loaded_weight.numel() == 1:
+        param.data.fill_(loaded_weight.item())
+    else:
+        tp_rank = get_tensor_model_parallel_rank()
+        tp_size = get_tensor_model_parallel_world_size()
+        shard_size = loaded_weight.shape[0] // tp_size
+        loaded_weight = loaded_weight.narrow(0, shard_size * tp_rank, shard_size)
+        assert param.size() == loaded_weight.size(), (
+            "[vllm-ascend/MXFP8_PER_CHANNEL] Attempted to load weight "
+            f"({loaded_weight.size()}) into parameter ({param.size()}) "
+            f"when TP size is {tp_size} and TP rank is {tp_rank}."
+        )
+
+        param.data.copy_(loaded_weight)
+
+
+class AscendC8MXFPKVCacheAttentionMethod(AscendAttentionScheme):
+    """MXFP8 KV cache storage for dense-attention models.
+
+    K/V are cached as FP8 E4M3 and their E8M0 scales are stored in extra cache
+    tensors: K uses dynamic per-token-group scales written at scatter time, V
+    uses the static per-channel E8M0 scale stored in the ModelSlim checkpoint
+    (kv_cache_type == "K_DYNAMIC_V_STATIC_MXFP8_PER_CHANNEL"). The C8-MXFP
+    backend owns the matching 512-token kernel block size, keeping hybrid
+    cache scheduling and cache views aligned.
+    """
+
+    def __init__(self, quant_description: dict, prefix: str):
+        self.quant_description = quant_description
+        self.prefix = prefix
+
+    def create_weights(self, layer: torch.nn.Module) -> None:
+        layer.kv_cache_torch_dtype = torch.float8_e4m3fn
+        if hasattr(layer, "impl"):
+            from vllm_ascend.attention.attention_v1 import (
+                AscendC8MXFPAttentionBackend,
+                AscendC8MXFPAttentionBackendImpl,
+            )
+
+            layer.attn_backend = AscendC8MXFPAttentionBackend
+            layer.impl.__class__ = AscendC8MXFPAttentionBackendImpl
+            # Changing __class__ does not invoke the new class's __init__, so
+            # initialize the state the impl relies on here. The V-scale fill
+            # tracker is keyed by cache tensor identity, which stays correct
+            # across memory-profiling runs (fresh dummy caches) and the real
+            # KV cache without any explicit reset hook.
+            layer.impl.enable_hamming_sparse = False
+            layer.impl._v_scale_filled_caches = set()
+
+        # Load v_cache static quantization scale
+        hidden_size = layer.num_kv_heads * layer.head_size_v
+        # E8M0 stores the exponent with a bias of 127, so 127 represents a
+        # neutral scale of 1.0. Use it as a deterministic fallback instead of
+        # leaving the parameter with uninitialized memory when a checkpoint is
+        # missing a layer's V-cache scale.
+        weight_param = torch.nn.Parameter(
+            torch.full((hidden_size,), 127, dtype=torch.uint8),
+            requires_grad=False,
+        )
+        layer.register_parameter("v_cache_scale", weight_param)
+        # When loading weights, segment them according to TP
+        weight_param.weight_loader = _quant_weight_loader
+
+    def process_weights_after_loading(self, layer: torch.nn.Module) -> None:
+        vllm_config = get_current_vllm_config()
+        target_dtype = vllm_config.model_config.dtype
+        exponent = layer.v_cache_scale.data.to(torch.float32) - 127
+        layer.v_cache_scale_float = torch.nn.Parameter(torch.exp2(exponent).to(target_dtype), requires_grad=False)
+        layer.v_cache_scale_float_reciprocal = torch.nn.Parameter(
+            1 / torch.exp2(exponent).to(target_dtype),
+            requires_grad=False,
+        )
+
+    def apply(
+        self,
+        layer: torch.nn.Module,
+        query: torch.Tensor,
+        key: torch.Tensor,
+        value: torch.Tensor,
+        kv_cache,
+        attn_metadata,
+        attn_type,
+        scale,
+        output,
+    ) -> torch.Tensor:
+        raise RuntimeError(
+            "AscendC8MXFPKVCacheAttentionMethod.apply should not be called. "
+            "C8_MXFP KV cache quantization is handled by the attention backend."
+        )

--- a/vllm_ascend/quantization/methods/kv_cache/mxfp_c8.py
+++ b/vllm_ascend/quantization/methods/kv_cache/mxfp_c8.py
@@ -72,7 +72,17 @@ class AscendC8MXFPKVCacheAttentionMethod(AscendAttentionScheme):
     def process_weights_after_loading(self, layer: torch.nn.Module) -> None:
         vllm_config = get_current_vllm_config()
         target_dtype = vllm_config.model_config.dtype
-        exponent = layer.v_cache_scale.data.to(torch.float32) - 127
+        raw = layer.v_cache_scale.data
+        # A minmax calibrator emits 0 for a channel whose absmax was 0, and
+        # 2^-127 there would make the quantization reciprocal 2^127 -- any
+        # activation that is not exactly zero at inference would go to inf.
+        # Sanitize the stored bytes in place so BOTH consumers stay neutral:
+        # the reciprocal below and the raw bytes broadcast into the V-scale
+        # cache (2^-127 there would zero the channel on dequant)  -- a
+        # real-checkpoint pitfall hit during the vendored-QFA bring-up.
+        if bool((raw == 0).any()):
+            raw[raw == 0] = 127
+        exponent = raw.to(torch.float32) - 127
         # Only the reciprocal is consumed (npu_quantize needs 1/scale); the
         # forward scale itself is written into the V-scale cache as raw E8M0
         # bytes straight from v_cache_scale.

--- a/vllm_ascend/quantization/methods/kv_cache/mxfp_c8.py
+++ b/vllm_ascend/quantization/methods/kv_cache/mxfp_c8.py
@@ -20,6 +20,11 @@ def _quant_weight_loader(param: torch.Tensor, loaded_weight: torch.Tensor):
         # this degenerates to the plain contiguous narrow.
         if loaded_weight.dim() != 1:
             loaded_weight = loaded_weight.flatten()
+        if loaded_weight.numel() < param.numel() and param.numel() % loaded_weight.numel() == 0:
+            # Some ModelSlim recipes store a single set of per-channel scales
+            # shared by every KV head instead of one set per head. Tile it out
+            # to this rank's head count; the narrow below is then a no-op.
+            loaded_weight = loaded_weight.repeat(param.numel() // loaded_weight.numel())
         if loaded_weight.numel() != param.numel():
             tp_rank = get_tensor_model_parallel_rank()
             tp_size = get_tensor_model_parallel_world_size()
@@ -89,12 +94,31 @@ class AscendC8MXFPKVCacheAttentionMethod(AscendAttentionScheme):
             requires_grad=False,
         )
         layer.register_parameter("v_cache_scale", weight_param)
+        # Some ModelSlim recipes emit a V offset next to the scale, borrowed
+        # from the affine FAKQuant template. MXFP8 per-channel is symmetric and
+        # the operator takes no offset, so the only correct value is zero --
+        # register it to check that, rather than dropping it unread.
+        offset_param = torch.nn.Parameter(
+            torch.zeros((hidden_size,), dtype=torch.float32),
+            requires_grad=False,
+        )
+        layer.register_parameter("v_cache_offset", offset_param)
         # When loading weights, segment them according to TP
         weight_param.weight_loader = _quant_weight_loader
+        offset_param.weight_loader = _quant_weight_loader
 
     def process_weights_after_loading(self, layer: torch.nn.Module) -> None:
         vllm_config = get_current_vllm_config()
         target_dtype = vllm_config.model_config.dtype
+        offset = layer.v_cache_offset.data
+        if bool(offset.any()):
+            raise RuntimeError(
+                "[vllm-ascend/MXFP8_PER_CHANNEL] V cache offset is non-zero "
+                f"(min={float(offset.min())} max={float(offset.max())}), but the MXFP8 "
+                "per-channel scheme and the QuantFlashAttn operator are both symmetric. "
+                "This checkpoint was calibrated with an affine V quantizer and cannot be "
+                "served by this scheme."
+            )
         raw = layer.v_cache_scale.data
         # A minmax calibrator emits 0 for a channel whose absmax was 0, and
         # 2^-127 there would make the quantization reciprocal 2^127 -- any

--- a/vllm_ascend/utils.py
+++ b/vllm_ascend/utils.py
@@ -1170,7 +1170,12 @@ A5_C8_MXFP_KV_CACHE_BLOCK_SIZE = 512
 
 
 def is_c8_mxfp_kv_quant(vllm_config: VllmConfig) -> bool:
-    return vllm_config.quant_config is not None and vllm_config.quant_config.enable_mxfp_c8_quant
+    # getattr: non-ModelSlim quant configs (fp8/mxfp8/compressed-tensors/...)
+    # do not define this attribute; this helper runs for every engine start
+    # via refresh_block_size.
+    return vllm_config.quant_config is not None and getattr(
+        vllm_config.quant_config, "enable_mxfp_c8_quant", False
+    )
 
 
 def refresh_block_size(vllm_config):
@@ -1189,7 +1194,11 @@ def refresh_block_size(vllm_config):
 
     # Must run before the hybrid early-return below: C8-MXFP hybrid models
     # (e.g. Qwen3.5/3.6 linear-attention + full-attention mixes) still need
-    # the 512-token pages that the QFA PA path requires.
+    # the 512-token pages that the QFA PA path requires. This value is the
+    # final block size for dense models; for hybrid models,
+    # AscendPlatform.update_block_size_for_backend re-aligns it (upwards, in
+    # multiples of 512) with the mamba page so that
+    # unify_kv_cache_spec_page_size sees a single page size.
     if is_c8_mxfp_kv_quant(vllm_config):
         if cache_config.block_size != A5_C8_MXFP_KV_CACHE_BLOCK_SIZE:
             logger.info(

--- a/vllm_ascend/utils.py
+++ b/vllm_ascend/utils.py
@@ -1164,6 +1164,15 @@ def has_layer_idx(model_instance: torch.nn.Module) -> bool:
     return _HAS_LAYER_IDX
 
 
+# C8_MXFP (FP8 KV + E8M0 scales) on Ascend A5 uses 512-token pages for the QFA path
+# (the QFA D=256 requirement doc allows block sizes 512/1024).
+A5_C8_MXFP_KV_CACHE_BLOCK_SIZE = 512
+
+
+def is_c8_mxfp_kv_quant(vllm_config: VllmConfig) -> bool:
+    return vllm_config.quant_config is not None and vllm_config.quant_config.enable_mxfp_c8_quant
+
+
 def refresh_block_size(vllm_config):
     """
     Refresh the block size in cache config.
@@ -1177,6 +1186,20 @@ def refresh_block_size(vllm_config):
 
     if cache_config.block_size is None:
         cache_config.block_size = 128
+
+    # Must run before the hybrid early-return below: C8-MXFP hybrid models
+    # (e.g. Qwen3.5/3.6 linear-attention + full-attention mixes) still need
+    # the 512-token pages that the QFA PA path requires.
+    if is_c8_mxfp_kv_quant(vllm_config):
+        if cache_config.block_size != A5_C8_MXFP_KV_CACHE_BLOCK_SIZE:
+            logger.info(
+                "Ascend A5 with C8_MXFP KV cache requires block_size=%s; "
+                "overriding block_size from %s.",
+                A5_C8_MXFP_KV_CACHE_BLOCK_SIZE,
+                cache_config.block_size,
+            )
+            cache_config.block_size = A5_C8_MXFP_KV_CACHE_BLOCK_SIZE
+        return
 
     if not scheduler_config or not model_config:
         return

--- a/vllm_ascend/utils.py
+++ b/vllm_ascend/utils.py
@@ -1194,11 +1194,10 @@ def refresh_block_size(vllm_config):
 
     # Must run before the hybrid early-return below: C8-MXFP hybrid models
     # (e.g. Qwen3.5/3.6 linear-attention + full-attention mixes) still need
-    # the 512-token pages that the QFA PA path requires. This value is the
-    # final block size for dense models; for hybrid models,
-    # AscendPlatform.update_block_size_for_backend re-aligns it (upwards, in
-    # multiples of 512) with the mamba page so that
-    # unify_kv_cache_spec_page_size sees a single page size.
+    # the 512-token pages that the QFA PA path requires. Hybrid page-size
+    # unification is handled downstream: get_kv_cache_spec pads the C8
+    # attention spec's page up to the mamba page, so all specs share one
+    # page size and unify_kv_cache_spec_page_size passes.
     if is_c8_mxfp_kv_quant(vllm_config):
         if cache_config.block_size != A5_C8_MXFP_KV_CACHE_BLOCK_SIZE:
             logger.info(

--- a/vllm_ascend/worker/model_runner_v1.py
+++ b/vllm_ascend/worker/model_runner_v1.py
@@ -4837,17 +4837,21 @@ class NPUModelRunner(GPUModelRunner):
                     if current_sparse_sfa_c8:
                         kv_caches[layer_name] = (k_cache,)
                     elif self._is_c8_mxfp_kv_cache(current_kv_cache_spec):
+                        # PA_BBND order (block before head): the scale caches
+                        # sit next to their K/V payloads in the layout QFA
+                        # reads, so no layer transposes anything at attention
+                        # time.
                         k_scale_cache_shape = (
                             k_shape[0],
-                            k_shape[2],
                             k_shape[1],
+                            k_shape[2],
                             k_shape[3] // MXFP_KV_SCALE_GROUP_SIZE,
                             MXFP_KV_SCALE_VALUES_PER_GROUP,
                         )
                         v_scale_cache_shape = (
                             v_shape[0],
-                            v_shape[2],
                             v_shape[1] // MXFP_KV_SCALE_GROUP_SIZE,
+                            v_shape[2],
                             v_shape[3],
                             MXFP_KV_SCALE_VALUES_PER_GROUP,
                         )

--- a/vllm_ascend/worker/model_runner_v1.py
+++ b/vllm_ascend/worker/model_runner_v1.py
@@ -76,6 +76,7 @@ from vllm.v1.core.sched.output import SchedulerOutput
 from vllm.v1.kv_cache_interface import (
     AttentionSpec,
     EncoderOnlyAttentionSpec,
+    FullAttentionSpec,
     HiddenStateCacheSpec,
     KVCacheConfig,
     KVCacheGroupSpec,
@@ -143,6 +144,13 @@ from vllm_ascend.distributed.kv_transfer.sparse_kv_offload.sparse_kv_offload_man
     reshape_kv_cache_tensors_for_sparse_kv_offload,
     update_sparse_kv_offload_metadata,
 )
+from vllm_ascend.device.mxfp_kv_cache import (
+    MXFP8_GROUP_SIZE,
+    MXFP_KV_SCALE_GROUP_SIZE,
+    MXFP_KV_SCALE_VALUES_PER_GROUP,
+    mxfp_k_scale_cache_shape,
+    mxfp_v_scale_cache_shape,
+)
 from vllm_ascend.eplb.adaptor.vllm_adaptor import VllmEplbAdaptor
 from vllm_ascend.eplb.core.eplb_device_transfer_loader import D2DExpertWeightLoader
 from vllm_ascend.eplb.core.eplb_worker import EplbProcess
@@ -181,6 +189,7 @@ from vllm_ascend.utils import (
     get_ascend_device_type,
     get_c_env,
     global_stream,
+    is_c8_mxfp_kv_quant,
     is_hidden_state_cache_spec,
     is_score_encoder_cache_manager,
     kv_cache_spec_uses_sparse_sfa_c8,
@@ -3983,6 +3992,62 @@ class NPUModelRunner(GPUModelRunner):
         offset = (aligned_addr - data_ptr) // tensor.element_size()
         return tensor[int(offset) :]
 
+    def _is_c8_mxfp_kv_cache(self, kv_cache_spec: AttentionSpec) -> bool:
+        return isinstance(kv_cache_spec, FullAttentionSpec) and is_c8_mxfp_kv_quant(self.vllm_config)
+
+    @staticmethod
+    def _split_hybrid_c8_mxfp_cache_buffer(
+        raw_tensor: torch.Tensor,
+        k_shape: tuple[int, ...],
+        v_shape: tuple[int, ...],
+    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+        """Split a hybrid Mamba/attention buffer into C8 MXFP payloads.
+
+        Hybrid cache groups allocate one padded raw buffer that is shared by
+        Mamba and full-attention layers. Mamba state views start at the front
+        of that buffer, while attention payloads are placed at the end. C8
+        MXFP needs four payloads instead of the regular K/V pair.
+        """
+        num_blocks, block_size, num_kv_heads, k_dim = k_shape
+        if len(v_shape) != 4:
+            raise ValueError(f"Expected a four-dimensional V cache shape, got {v_shape}.")
+        if v_shape[:3] != k_shape[:3]:
+            raise ValueError(
+                "C8_MXFP hybrid K/V cache shapes must share block and head dimensions, "
+                f"got k_shape={k_shape}, v_shape={v_shape}."
+            )
+
+        v_dim = v_shape[3]
+        k_scale_shape = mxfp_k_scale_cache_shape(
+            num_blocks,
+            block_size,
+            num_kv_heads,
+            k_dim,
+        )
+        v_scale_shape = mxfp_v_scale_cache_shape(
+            num_blocks,
+            block_size,
+            num_kv_heads,
+            v_dim,
+        )
+        payload_sizes = [
+            math.prod(k_shape),
+            math.prod(v_shape),
+            math.prod(k_scale_shape),
+            math.prod(v_scale_shape),
+        ]
+        payload_size = sum(payload_sizes)
+        if raw_tensor.numel() < payload_size:
+            raise ValueError(
+                "C8_MXFP hybrid cache buffer is too small: "
+                f"raw_numel={raw_tensor.numel()}, payload_numel={payload_size}, "
+                f"k_shape={k_shape}, v_shape={v_shape}."
+            )
+
+        payload = raw_tensor[raw_tensor.numel() - payload_size :]
+        raw_k, raw_v, raw_k_scale, raw_v_scale = torch.split(payload, payload_sizes)
+        return raw_k, raw_v, raw_k_scale, raw_v_scale
+
     def initialize_kv_cache_tensors(self, kv_cache_config: KVCacheConfig) -> dict[str, torch.Tensor]:
         """
         Initialize the memory buffer for KV cache.
@@ -4296,6 +4361,7 @@ class NPUModelRunner(GPUModelRunner):
                     current_sparse_sfa_c8 = self.use_sparse and kv_cache_spec_uses_sparse_sfa_c8(
                         current_kv_cache_spec
                     )
+                    k_scale_tensor, v_scale_tensor = None, None
 
                     if current_sparse_sfa_c8:
                         k_tensor_size = kv_cache_tensor.size
@@ -4311,6 +4377,30 @@ class NPUModelRunner(GPUModelRunner):
                             k_tensor_split_factor, v_tensor_split_factor = (
                                 self.vllm_config.quant_config.get_kv_quant_split_factor(layer_name, kv_head_dim_list)
                             )
+                        elif self._is_c8_mxfp_kv_cache(current_kv_cache_spec):
+                            # The packed spec head_size carries the E8M0 scale
+                            # bytes (head_size + head_size // MXFP8_GROUP_SIZE,
+                            # see get_kv_cache_spec); recover the real K/V head
+                            # dims and split the page budget into four raw
+                            # payloads: K, V, K-scale, V-scale.
+                            ori_k_dim = k_dim // (1 + MXFP8_GROUP_SIZE) * MXFP8_GROUP_SIZE
+                            ori_v_dim = v_dim // (1 + MXFP8_GROUP_SIZE) * MXFP8_GROUP_SIZE
+                            kv_head_dim_list = [
+                                ori_k_dim,
+                                ori_v_dim,
+                                ori_k_dim // MXFP8_GROUP_SIZE,
+                                ori_v_dim // MXFP8_GROUP_SIZE,
+                            ]
+                            (
+                                k_tensor_split_factor,
+                                v_tensor_split_factor,
+                                k_scale_tensor_split_factor,
+                                v_scale_tensor_split_factor,
+                            ) = calc_split_factor(kv_head_dim_list)
+                            k_scale_tensor_size = int(kv_cache_tensor.size // k_scale_tensor_split_factor)
+                            v_scale_tensor_size = int(kv_cache_tensor.size // v_scale_tensor_split_factor)
+                            k_scale_tensor = self._allocate_int8_cache_tensor(k_scale_tensor_size, alignment)
+                            v_scale_tensor = self._allocate_int8_cache_tensor(v_scale_tensor_size, alignment)
                         else:
                             k_tensor_split_factor, v_tensor_split_factor = calc_split_factor(kv_head_dim_list)
                         k_tensor_size = int(kv_cache_tensor.size // k_tensor_split_factor)
@@ -4349,6 +4439,14 @@ class NPUModelRunner(GPUModelRunner):
                         if "attn" in layer_name_inner and "linear_attn" not in layer_name_inner:
                             if current_sparse_sfa_c8:
                                 kv_cache_raw_tensors[layer_name_inner] = (k_tensor,)
+                            elif self._is_c8_mxfp_kv_cache(current_kv_cache_spec):
+                                assert v_tensor is not None and k_scale_tensor is not None and v_scale_tensor is not None
+                                kv_cache_raw_tensors[layer_name_inner] = (
+                                    k_tensor,
+                                    v_tensor,
+                                    k_scale_tensor,
+                                    v_scale_tensor,
+                                )
                             else:
                                 assert v_tensor is not None
                                 kv_cache_raw_tensors[layer_name_inner] = (k_tensor, v_tensor)
@@ -4516,6 +4614,7 @@ class NPUModelRunner(GPUModelRunner):
                         )
                         kv_caches[layer_name] = (indexer_k_cache, indexer_scale_cache)
                 elif isinstance(current_kv_cache_spec, AttentionSpec):
+                    hybrid_c8_raw_tensor = None
                     # cache_only_layers (extract_hidden_states) are allocated
                     # as a single tensor by the branch at the top of
                     # _allocate_kv_cache_tensors; route them to the dedicated
@@ -4556,6 +4655,8 @@ class NPUModelRunner(GPUModelRunner):
                         # Currently, we ensure that the same kvcache format is used even if there
                         # is no shared layer, such as the full attention mtp layer of qwen3.5, etc.
                         raw_k_tensor, raw_v_tensor = kv_cache_raw_tensors[layer_name], kv_cache_raw_tensors[layer_name]
+                        if self._is_c8_mxfp_kv_cache(current_kv_cache_spec):
+                            hybrid_c8_raw_tensor = raw_k_tensor
                         sum_page_size_bytes = raw_k_tensor.numel()
                     elif (
                         "cache_only_layers" in layer_name
@@ -4595,14 +4696,30 @@ class NPUModelRunner(GPUModelRunner):
                             k_cache = raw_tensor.view(kv_cache_shape)
                         kv_caches[layer_name] = k_cache
                         continue  # Skip the rest of the AttentionSpec handling
+                    elif self._is_c8_mxfp_kv_cache(current_kv_cache_spec):
+                        raw_k_tensor, raw_v_tensor, raw_k_scale_tensor, raw_v_scale_tensor = kv_cache_raw_tensors[
+                            layer_name
+                        ]
+                        sum_page_size_bytes = (
+                            raw_k_tensor.numel()
+                            + raw_v_tensor.numel()
+                            + raw_k_scale_tensor.numel()
+                            + raw_v_scale_tensor.numel()
+                        )
                     else:
                         raw_k_tensor, raw_v_tensor = kv_cache_raw_tensors[  # type: ignore
                             layer_name
                         ]
                         sum_page_size_bytes = raw_k_tensor.numel() + raw_v_tensor.numel()
                     assert raw_k_tensor is not None
-                    assert sum_page_size_bytes % current_kv_cache_spec.page_size_bytes == 0
-                    num_blocks = sum_page_size_bytes // current_kv_cache_spec.page_size_bytes
+                    if hybrid_c8_raw_tensor is not None:
+                        # The shared raw buffer uses Mamba's padded page size,
+                        # which is intentionally larger than the C8 payload.
+                        # KVCacheManager only addresses the common num_blocks.
+                        num_blocks = kv_cache_config.num_blocks
+                    else:
+                        assert sum_page_size_bytes % current_kv_cache_spec.page_size_bytes == 0
+                        num_blocks = sum_page_size_bytes // current_kv_cache_spec.page_size_bytes
 
                     # `num_blocks` is the number of blocks the model runner can use.
                     # `kv_cache_config.num_blocks` is the number of blocks that
@@ -4624,7 +4741,11 @@ class NPUModelRunner(GPUModelRunner):
                             current_kv_cache_spec.head_size,
                         )
                         if self.hybrid_with_attn_and_mamba:
-                            if not isinstance(current_kv_cache_spec, AscendMLAAttentionSpec):
+                            if hybrid_c8_raw_tensor is not None:
+                                # C8 K/V and scale payloads are split after
+                                # their virtual kernel-block shapes are known.
+                                pass
+                            elif not isinstance(current_kv_cache_spec, AscendMLAAttentionSpec):
                                 attn_tensor_page_size = int(np.prod(kv_cache_shape[1:])) * get_dtype_size(
                                     current_kv_cache_spec.dtype
                                 )
@@ -4651,7 +4772,23 @@ class NPUModelRunner(GPUModelRunner):
                             current_kv_cache_spec.num_kv_heads,
                             current_kv_cache_spec.head_size,
                         )
-                    if not isinstance(current_kv_cache_spec, AscendMLAAttentionSpec):
+                    if self._is_c8_mxfp_kv_cache(current_kv_cache_spec):
+                        # Use the unpacked head_dim; the spec head_size still
+                        # carries the packed scale bytes.
+                        k_shape = (*kv_cache_shape[1:-1], self.model_config.hf_text_config.head_dim)
+                        v_shape = k_shape
+                        if hybrid_c8_raw_tensor is not None:
+                            (
+                                raw_k_tensor,
+                                raw_v_tensor,
+                                raw_k_scale_tensor,
+                                raw_v_scale_tensor,
+                            ) = self._split_hybrid_c8_mxfp_cache_buffer(
+                                hybrid_c8_raw_tensor,
+                                k_shape,
+                                v_shape,
+                            )
+                    elif not isinstance(current_kv_cache_spec, AscendMLAAttentionSpec):
                         k_shape = kv_cache_shape[1:]
                         if hasattr(current_kv_cache_spec, "head_size_v"):
                             v_shape = (*kv_cache_shape[1:-1], current_kv_cache_spec.head_size_v)
@@ -4699,6 +4836,24 @@ class NPUModelRunner(GPUModelRunner):
 
                     if current_sparse_sfa_c8:
                         kv_caches[layer_name] = (k_cache,)
+                    elif self._is_c8_mxfp_kv_cache(current_kv_cache_spec):
+                        k_scale_cache_shape = (
+                            k_shape[0],
+                            k_shape[2],
+                            k_shape[1],
+                            k_shape[3] // MXFP_KV_SCALE_GROUP_SIZE,
+                            MXFP_KV_SCALE_VALUES_PER_GROUP,
+                        )
+                        v_scale_cache_shape = (
+                            v_shape[0],
+                            v_shape[2],
+                            v_shape[1] // MXFP_KV_SCALE_GROUP_SIZE,
+                            v_shape[3],
+                            MXFP_KV_SCALE_VALUES_PER_GROUP,
+                        )
+                        k_scale_cache = raw_k_scale_tensor.view(torch.uint8).view(k_scale_cache_shape)
+                        v_scale_cache = raw_v_scale_tensor.view(torch.uint8).view(v_scale_cache_shape)
+                        kv_caches[layer_name] = (k_cache, v_cache, k_scale_cache, v_scale_cache)
                     else:
                         assert v_cache is not None
                         kv_caches[layer_name] = (k_cache, v_cache)
@@ -4982,7 +5137,22 @@ class NPUModelRunner(GPUModelRunner):
                     kv_cache_spec[layer_name] = spec
             elif isinstance(attn_module, Attention):
                 if spec := attn_module.get_kv_cache_spec(self.vllm_config):
-                    kv_cache_spec[layer_name] = spec
+                    if self._is_c8_mxfp_kv_cache(spec):
+                        # Pack the E8M0 scale bytes into the page budget:
+                        # per token-head the cache stores head_size FP8 K/V
+                        # bytes plus head_size / MXFP8_GROUP_SIZE scale bytes
+                        # (K per-token-group + V per-channel broadcast).
+                        # _allocate_kv_cache_tensors re-derives the four raw
+                        # payloads from this packed spec.
+                        head_size = spec.head_size + spec.head_size // MXFP8_GROUP_SIZE
+                        kv_cache_spec[layer_name] = FullAttentionSpec(
+                            block_size=spec.block_size,
+                            num_kv_heads=spec.num_kv_heads,
+                            head_size=head_size,
+                            dtype=torch.float8_e4m3fn,
+                        )
+                    else:
+                        kv_cache_spec[layer_name] = spec
                     attn_layer_names.add(layer_name)
 
             elif isinstance(attn_module, MLAAttention):

--- a/vllm_ascend/worker/model_runner_v1.py
+++ b/vllm_ascend/worker/model_runner_v1.py
@@ -134,6 +134,13 @@ from vllm_ascend.compilation.acl_graph import (
     update_full_graph_params,
 )
 from vllm_ascend.compilation.breakable_aclgraph import BreakableACLGraphWrapper
+from vllm_ascend.device.mxfp_kv_cache import (
+    MXFP8_GROUP_SIZE,
+    MXFP_KV_SCALE_GROUP_SIZE,
+    MXFP_KV_SCALE_VALUES_PER_GROUP,
+    mxfp_k_scale_cache_shape,
+    mxfp_v_scale_cache_shape,
+)
 from vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.layerwise_cache_layout import (
     apply_layerwise_kv_cache_plan,
 )
@@ -143,13 +150,6 @@ from vllm_ascend.distributed.kv_transfer.sparse_kv_offload.sparse_kv_offload_man
     init_sparse_kv_offload_manager,
     reshape_kv_cache_tensors_for_sparse_kv_offload,
     update_sparse_kv_offload_metadata,
-)
-from vllm_ascend.device.mxfp_kv_cache import (
-    MXFP8_GROUP_SIZE,
-    MXFP_KV_SCALE_GROUP_SIZE,
-    MXFP_KV_SCALE_VALUES_PER_GROUP,
-    mxfp_k_scale_cache_shape,
-    mxfp_v_scale_cache_shape,
 )
 from vllm_ascend.eplb.adaptor.vllm_adaptor import VllmEplbAdaptor
 from vllm_ascend.eplb.core.eplb_device_transfer_loader import D2DExpertWeightLoader
@@ -4440,7 +4440,9 @@ class NPUModelRunner(GPUModelRunner):
                             if current_sparse_sfa_c8:
                                 kv_cache_raw_tensors[layer_name_inner] = (k_tensor,)
                             elif self._is_c8_mxfp_kv_cache(current_kv_cache_spec):
-                                assert v_tensor is not None and k_scale_tensor is not None and v_scale_tensor is not None
+                                assert (
+                                    v_tensor is not None and k_scale_tensor is not None and v_scale_tensor is not None
+                                )
                                 kv_cache_raw_tensors[layer_name_inner] = (
                                     k_tensor,
                                     v_tensor,

--- a/vllm_ascend/worker/model_runner_v1.py
+++ b/vllm_ascend/worker/model_runner_v1.py
@@ -832,6 +832,29 @@ class NPUModelRunner(GPUModelRunner):
             device=self.device,
         ).unsqueeze(1)
 
+    def _copy_kv_cache_blocks_by_layer_views(self, block_copies: list) -> None:
+        """Apply prefix-cache CoW block copies through the per-layer views.
+
+        The generic runner views each cache tensor's whole untyped_storage()
+        as (num_blocks, page_bytes) and copies whole pages. That breaks on
+        Ascend twice: PD deployments over-allocate 2 MiB-aligned buffers
+        (storage = num_blocks * page + alignment, so the divisibility assert
+        fires), and hybrid buffers are sectioned ([pad|conv|..|k|ssm|..|v|pad])
+        rather than block-major, so a whole-storage block view would copy
+        across section boundaries even when the assert passes. Every per-layer
+        cache view is (num_blocks, ...) indexed by the global block id, so
+        copying through the views is correct for every layout -- mirroring
+        KVBlockZeroer's approach.
+        """
+        ids = torch.tensor(block_copies, dtype=torch.long, device=self.device)
+        src_ids, dst_ids = ids.unbind(dim=1)
+        for layer_cache in self.kv_caches.values():
+            tensors = layer_cache if isinstance(layer_cache, (list, tuple)) else (layer_cache,)
+            for cache_tensor in tensors:
+                if cache_tensor is None or cache_tensor.dim() == 0:
+                    continue
+                cache_tensor[dst_ids] = cache_tensor[src_ids]
+
     def _update_states(self, scheduler_output: "SchedulerOutput") -> Callable | None:
         # Temporary rewind guard for KV-load-failure recompute.
         # This can be removed after the upstream fix is merged.
@@ -846,6 +869,11 @@ class NPUModelRunner(GPUModelRunner):
                 num_computed_tokens = req_data.num_computed_tokens[i]
                 if num_computed_tokens < req_state.num_computed_tokens:
                     req_state.prev_num_draft_len = 0
+
+        block_copies = scheduler_output.kv_cache_block_copies
+        if block_copies:
+            scheduler_output.kv_cache_block_copies = None
+            self._copy_kv_cache_blocks_by_layer_views(block_copies)
 
         self._apply_pp_sampled_tokens_from_scheduler_output(scheduler_output)
         sampling_metadata = super()._update_states(scheduler_output)

--- a/vllm_ascend/worker/model_runner_v1.py
+++ b/vllm_ascend/worker/model_runner_v1.py
@@ -853,6 +853,11 @@ class NPUModelRunner(GPUModelRunner):
             for cache_tensor in tensors:
                 if cache_tensor is None or cache_tensor.dim() == 0:
                     continue
+                # aclnnIndex rejects FP8 dtypes (EZ1001); copy through a uint8
+                # byte view instead -- same storage, same rows, same bytes
+                # (same workaround as scatter_mxfp_k_scale_cache).
+                if cache_tensor.dtype == torch.float8_e4m3fn:
+                    cache_tensor = cache_tensor.view(torch.uint8)
                 cache_tensor[dst_ids] = cache_tensor[src_ids]
 
     def _update_states(self, scheduler_output: "SchedulerOutput") -> Callable | None:

--- a/vllm_ascend/worker/model_runner_v1.py
+++ b/vllm_ascend/worker/model_runner_v1.py
@@ -848,7 +848,7 @@ class NPUModelRunner(GPUModelRunner):
         """
         ids = torch.tensor(block_copies, dtype=torch.long, device=self.device)
         src_ids, dst_ids = ids.unbind(dim=1)
-        for layer_cache in self.kv_caches.values():
+        for layer_cache in self.kv_caches:
             tensors = layer_cache if isinstance(layer_cache, (list, tuple)) else (layer_cache,)
             for cache_tensor in tensors:
                 if cache_tensor is None or cache_tensor.dim() == 0:


### PR DESCRIPTION
### What this PR does / why we need it?
This PR introduces support for C8-MXFP (MXFP8) KV cache storage and attention execution on Ascend using the QFA (Quant Flash Attention) dual-operator interface. It implements dynamic quantization for Q/K and static quantization for V, along with the necessary layout resolution, scattering, and cache management for K/V and their scale caches. It also updates the model runner to support allocating and reshaping these caches, including handling hybrid Mamba/attention buffers, and enforces the required 512-token block size.

Feedback: A performance improvement opportunity was identified in `vllm_ascend/attention/attention_v1.py` where the use of `.contiguous()` during KV cache transposition could be avoided to prevent unnecessary memory copies.

### Does this PR introduce _any_ user-facing change?
Yes, it adds support for the `K_DYNAMIC_V_STATIC_MXFP8_PER_CHANNEL` KV cache quantization type.

### How was this patch tested?
Tested with new unit tests added in `tests/ut/quantization/methods/test_mxfp_c8.py`.


- vLLM main: https://github.com/vllm-project/vllm/commit/84030bbe3d74d99bad477a3d2e37a973ccd8865c
