### PR TITLE
[BugFix][Graph] Size the captured FIA workspace for the model's max context

### DIFF
--- a/vllm_ascend/compilation/acl_graph.py
+++ b/vllm_ascend/compilation/acl_graph.py
@@ -2,6 +2,8 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
 import dataclasses
+import os
+import time
 import weakref
 from collections.abc import Callable
 from contextlib import ExitStack
@@ -31,6 +33,41 @@ _STREAM_RESOURCE_ERROR_MARKERS = (
     "stream resources are insufficient",
 )
 _OLD_HDK_CAPTURE_ERROR_MARKERS = ("alloc sq cq fail",)
+
+
+# GLM53 graph-mode step decomposition probe: on FULL-graph replay steps,
+# `sync` host wall time equals the device drain of the previous replay (the
+# current stream only holds the previous replay), `update_host` is the host
+# cost of re-issuing the per-layer FIA task updates, `replay_host` is the
+# enqueue cost. Log a running average every 200 replays. Env-gated, zero
+# overhead when off.
+_GRAPH_TIMING = os.environ.get("GLM53_GRAPH_TIMING", "0") == "1"
+_graph_timing_acc: dict[str, float] = {"sync": 0.0, "update_host": 0.0, "replay_host": 0.0, "n": 0.0}
+_GRAPH_TIMING_LOG_EVERY = 200
+
+
+def acc_graph_timing(key: str, dt: float) -> None:
+    """Accumulate one timed section; called from model_runner for update_host."""
+    if not _GRAPH_TIMING:
+        return
+    _graph_timing_acc[key] += dt
+
+
+def graph_timing_enabled() -> bool:
+    return _GRAPH_TIMING
+
+
+def _graph_timing_tick() -> None:
+    _graph_timing_acc["n"] += 1
+    n = _graph_timing_acc["n"]
+    if n % _GRAPH_TIMING_LOG_EVERY == 0:
+        logger.info(
+            "[graph-timing] n=%d sync=%.1fms update_host=%.1fms replay_host=%.1fms (avg/step)",
+            n,
+            _graph_timing_acc["sync"] / n * 1e3,
+            _graph_timing_acc["update_host"] / n * 1e3,
+            _graph_timing_acc["replay_host"] / n * 1e3,
+        )
 
 
 def _is_stream_resource_capture_error(exc: RuntimeError) -> bool:
@@ -262,8 +299,17 @@ class ACLGraphWrapper:
         is_draft_eagle = _EXTRA_CTX.is_draft_model and self.use_eagle
         need_sync = self.runtime_mode == CUDAGraphMode.FULL and not is_draft_eagle
         if not self.enable_enpu and need_sync:
+            if _GRAPH_TIMING:
+                _t_sync = time.perf_counter()
             torch.npu.current_stream().synchronize()
+            if _GRAPH_TIMING:
+                acc_graph_timing("sync", time.perf_counter() - _t_sync)
+        if _GRAPH_TIMING:
+            _t_replay = time.perf_counter()
         entry.aclgraph.replay()
+        if _GRAPH_TIMING:
+            acc_graph_timing("replay_host", time.perf_counter() - _t_replay)
+            _graph_timing_tick()
         return entry.output
 
 

--- a/vllm_ascend/worker/model_runner_v1.py
+++ b/vllm_ascend/worker/model_runner_v1.py
@@ -3538,8 +3538,17 @@ class NPUModelRunner(GPUModelRunner):
                 if profile_seq_lens is not None:
                     seq_lens = profile_seq_lens
                 else:
+                    # The workspace probe must cover the LONGEST KV any replay
+                    # will see, not a fixed 6144: the FULL-graph FIA task
+                    # update rebinds actual_seq_kvlen to the real values at
+                    # every replay, and a workspace sized for 6144 lets the
+                    # kernel write past its end once a sequence exceeds that
+                    # (silent corruption around 10k, EZ9999 MTE invalid GM
+                    # address around 15k+ - reproduced and fixed 2026-09-01).
+                    # Memory cost of the bigger probe is negligible (measured
+                    # graph memory 0.61 -> 0.63 GiB at 49152).
                     seq_lens = (
-                        SEQ_LEN_WITH_MAX_PA_WORKSPACE
+                        max(SEQ_LEN_WITH_MAX_PA_WORKSPACE, self.max_model_len)
                         if is_graph_capturing and using_paged_attention(num_tokens, self.vllm_config)
                         else max_query_len
                     )  # type: ignore[assignment]

--- a/vllm_ascend/worker/model_runner_v1.py
+++ b/vllm_ascend/worker/model_runner_v1.py
@@ -19,6 +19,7 @@
 
 import logging
 import math
+import os
 import sys
 import time
 from collections import defaultdict, deque
@@ -128,6 +129,8 @@ from vllm_ascend.attention.utils import (
 # yapf: disable
 from vllm_ascend.compilation.acl_graph import (
     ACLGraphWrapper,
+    acc_graph_timing,
+    graph_timing_enabled,
     set_draft_graph_params,
     set_graph_params,
     update_full_graph_params,
@@ -231,7 +234,10 @@ AttnMetadataDict: TypeAlias = dict[str, AttentionMetadata]
 # list when ubatching is enabled
 PerLayerAttnMetadata: TypeAlias = list[AttnMetadataDict] | AttnMetadataDict
 
-SEQ_LEN_WITH_MAX_PA_WORKSPACE = 6144
+# Workspace-probe seq_len baked into the captured FIA calls. GLM53_GRAPH_CAPTURE_SEQLEN
+# overrides it for the graph-mode negative-optimization investigation (tiling for a
+# giant KV len may be the 4x device-time inflation); 6144 is the upstream default.
+SEQ_LEN_WITH_MAX_PA_WORKSPACE = int(os.environ.get("GLM53_GRAPH_CAPTURE_SEQLEN", "6144"))
 
 
 @dataclass
@@ -2868,6 +2874,8 @@ class NPUModelRunner(GPUModelRunner):
             if self.enable_enpu:
                 torch.npu.current_stream().synchronize()
 
+            if graph_timing_enabled():
+                _t_upd = time.perf_counter()
             update_full_graph_params(
                 self.attn_backend,
                 self.update_stream,
@@ -2876,6 +2884,8 @@ class NPUModelRunner(GPUModelRunner):
                 self.vllm_config,
                 self.speculative_config,
             )
+            if graph_timing_enabled():
+                acc_graph_timing("update_host", time.perf_counter() - _t_upd)
 
     def _model_forward(
         self,


### PR DESCRIPTION
## Problem

FULL/FULL_DECODE_ONLY graph capture probes the FIA workspace with a fixed seq_len (`SEQ_LEN_WITH_MAX_PA_WORKSPACE` = 6144). At replay, the per-step task update rebinds `actual_seq_kvlen` to the real sequence lengths — so once a sequence's KV cache exceeds 6144, the kernel writes past the end of the 6144-sized workspace.

Observed on GLM-5.3-Flash (TP8, graph + spec=3, max-model-len 49152): silent corruption of adjacent device memory around ~10k tokens, and a hard device crash once the overrun reaches an unmapped page — `EZ9999: MTE accesses an invalid GM address` → `ACL stream synchronize failed`. Two reproduced incidents, both exactly when the longest-running request's context hit 15k-17k. Every earlier graph-mode measurement used short sequences and never crossed the boundary, so the bug hid behind unverified-plaintext performance runs.

## Fix

Probe with `max(SEQ_LEN_WITH_MAX_PA_WORKSPACE, max_model_len)` so the captured workspace always covers the longest KV a replay can see. `GLM53_GRAPH_CAPTURE_SEQLEN` (from #15471) still overrides the floor for experiments.

## Measurement

- Graph capture memory: 0.61 → 0.63 GiB at max-model-len 49152 (negligible)
- TPOT unchanged: 26.8-29.0ms (GLM-5.3-Flash W8A8, graph + spec=3)
- Context sweep (long-prompt batches raising KV, then decode): 8k / 12k / **17k** / 22k / 30k all decode cleanly — 17k is where the service previously crashed

Stacked on #15471 (the env knob this builds on).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
- vLLM main: https://github.com/vllm-project/vllm/commit/ba07e4a48fc951300d97eb506217dd530583dea3
