### PR TITLE
[Performance] add swiglu_group_quant groupindex input

### DIFF
--- a/vllm_ascend/quantization/methods/w4a8/w4a8_mxfp4.py
+++ b/vllm_ascend/quantization/methods/w4a8/w4a8_mxfp4.py
@@ -252,7 +252,8 @@ class AscendW4A8MXFPDynamicFusedMoEMethod(AscendMoEScheme):
         hidden_states, out_scale, _ = torch.ops._C_ascend.npu_swiglu_group_quant(
             hidden_states,
             topk_weight=None,
-            # The `group_index` input for the `npu_swiglu_group_quant` operator currently only supports the `count` type.
+            # The `group_index` input for the `npu_swiglu_group_quant` operator 
+            # currently only supports the `count` type.
             group_index=cumsum_group_list(mlp_compute_input.group_list, mlp_compute_input.group_list_type, 1),
             dst_type=torch.float8_e4m3fn,
             quant_mode=2,

--- a/vllm_ascend/quantization/methods/w4a8/w4a8_mxfp4.py
+++ b/vllm_ascend/quantization/methods/w4a8/w4a8_mxfp4.py
@@ -204,35 +204,6 @@ class AscendW4A8MXFPDynamicFusedMoEMethod(AscendMoEScheme):
         hidden_states, pertoken_scale = self._quant_hidden_states(hidden_states, mlp_compute_input.dynamic_scale)
         layer = mlp_compute_input.layer
         assert layer is not None
-        if mlp_compute_input.activation == MoEActivation.SITU:
-            # SituAndMul: run the dequantized gmm1 first, then fuse the situ
-            # activation with MXFP output quantization (Kimi K3 SITU activation).
-            hidden_states = torch_npu.npu_grouped_matmul(
-                x=[hidden_states],
-                weight=[layer.w13_weight],
-                scale=None,
-                antiquant_scale=[layer.w13_weight_scale],
-                scale_dtype=None,
-                per_token_scale=[pertoken_scale],
-                per_token_scale_dtype=torch_npu.float8_e8m0fnu,
-                split_item=2,
-                group_type=0,
-                group_list=mlp_compute_input.group_list,
-                group_list_type=mlp_compute_input.group_list_type,
-                x_dtype=torch.float8_e4m3fn,
-                weight_dtype=torch_npu.float4_e2m1fn_x2,
-                output_dtype=torch.bfloat16,
-            )[0]
-            hidden_states, swiglu_out_scale = torch.ops._C_ascend.situ_mx_quant(
-                x=hidden_states,
-                beta=1.0 if mlp_compute_input.activation_situ_beta is None else mlp_compute_input.activation_situ_beta,
-                linear_beta=mlp_compute_input.activation_situ_linear_beta or 0.0,
-                activate_left=True,
-                dst_type=SITU_MX_DST_TYPE_E4M3FN,
-            )
-            dispose_tensor(mlp_compute_input.hidden_states)
-            return hidden_states, maybe_normalize_mxfp_scale_layout(swiglu_out_scale)
-
         hidden_states = torch_npu.npu_grouped_matmul(
             x=[hidden_states],
             weight=[layer.w13_weight],
@@ -243,18 +214,39 @@ class AscendW4A8MXFPDynamicFusedMoEMethod(AscendMoEScheme):
             per_token_scale_dtype=torch_npu.float8_e8m0fnu,
             split_item=2,
             group_type=0,
-            group_list=cumsum_group_list(mlp_compute_input.group_list, mlp_compute_input.group_list_type, 0),
+            group_list=mlp_compute_input.group_list,
+            group_list_type=mlp_compute_input.group_list_type,
             x_dtype=torch.float8_e4m3fn,
             weight_dtype=torch_npu.float4_e2m1fn_x2,
             output_dtype=torch.bfloat16,
         )[0]
         dispose_tensor(mlp_compute_input.hidden_states)
+        if mlp_compute_input.activation == MoEActivation.SITU:
+            # SituAndMul: run the dequantized gmm1 first, then fuse the situ
+            # activation with MXFP output quantization (Kimi K3 SITU activation).
+
+            hidden_states, swiglu_out_scale = torch.ops._C_ascend.situ_mx_quant(
+                x=hidden_states,
+                beta=1.0 if mlp_compute_input.activation_situ_beta is None else mlp_compute_input.activation_situ_beta,
+                linear_beta=mlp_compute_input.activation_situ_linear_beta or 0.0,
+                activate_left=True,
+                dst_type=SITU_MX_DST_TYPE_E4M3FN,
+            )
+            return hidden_states, maybe_normalize_mxfp_scale_layout(swiglu_out_scale)
+
+        # The `group_index` input for the `npu_swiglu_group_quant` operator
+        # currently only supports the `count` type. In the current version, the
+        # `npu_swiglu_group_quant` operator performs a summation calculation on
+        # `group_index`. Therefore, under the cumsum type, the last value is directly taken
+        # and Avoid executing two small operators.
+        if mlp_compute_input.group_list_type == 0:
+            group_index = mlp_compute_input.group_list[-1:]
+        else:
+            group_index = cumsum_group_list(mlp_compute_input.group_list, mlp_compute_input.group_list_type, 1)
         hidden_states, out_scale, _ = torch.ops._C_ascend.npu_swiglu_group_quant(
             hidden_states,
             topk_weight=None,
-            # The `group_index` input for the `npu_swiglu_group_quant` operator
-            # currently only supports the `count` type.
-            group_index=cumsum_group_list(mlp_compute_input.group_list, mlp_compute_input.group_list_type, 1),
+            group_index=group_index,
             dst_type=torch.float8_e4m3fn,
             quant_mode=2,
             clamp_value=mlp_compute_input.swiglu_limit,

--- a/vllm_ascend/quantization/methods/w4a8/w4a8_mxfp4.py
+++ b/vllm_ascend/quantization/methods/w4a8/w4a8_mxfp4.py
@@ -252,7 +252,7 @@ class AscendW4A8MXFPDynamicFusedMoEMethod(AscendMoEScheme):
         hidden_states, out_scale, _ = torch.ops._C_ascend.npu_swiglu_group_quant(
             hidden_states,
             topk_weight=None,
-            # The `group_index` input for the `npu_swiglu_group_quant` operator 
+            # The `group_index` input for the `npu_swiglu_group_quant` operator
             # currently only supports the `count` type.
             group_index=cumsum_group_list(mlp_compute_input.group_list, mlp_compute_input.group_list_type, 1),
             dst_type=torch.float8_e4m3fn,

--- a/vllm_ascend/quantization/methods/w4a8/w4a8_mxfp4.py
+++ b/vllm_ascend/quantization/methods/w4a8/w4a8_mxfp4.py
@@ -252,7 +252,8 @@ class AscendW4A8MXFPDynamicFusedMoEMethod(AscendMoEScheme):
         hidden_states, out_scale, _ = torch.ops._C_ascend.npu_swiglu_group_quant(
             hidden_states,
             topk_weight=None,
-            group_index=None,
+            # The `group_index` input for the `npu_swiglu_group_quant` operator currently only supports the `count` type.
+            group_index=cumsum_group_list(mlp_compute_input.group_list, mlp_compute_input.group_list_type, 1),
             dst_type=torch.float8_e4m3fn,
             quant_mode=2,
             clamp_value=mlp_compute_input.swiglu_limit,


### PR DESCRIPTION
### What does this PR do / why we need it?

  In the W4A8 MXFP quantization path of `npu_grouped_matmul_swiglu_quant`
  (`vllm_ascend/device/device_op.py`), the call to
  `torch.ops._C_ascend.npu_swiglu_group_quant` now passes a `group_index`
  instead of `None`.

  `npu_swiglu_group_quant`'s `group_index` input currently only supports the
  `count` type, and internally the operator uses `group_index` only for
  summation. We therefore pass the last value of the cumsum tensor
  (`group_list[-1:]`, i.e. the total token count across groups) as the
  `group_index`, which provides the operator with the count it needs.

  ### Does this PR introduce any user-facing change?

  No. 

  ### How was this patch tested?

  Tested with DSv4 Flash


- vLLM main: https://github.com/vllm-project/vllm/commit/b2f685834a6456197e7033966fdef52a23f1abcd
