### PR TITLE
[CI] Temporarily constrain ModelScope to <1.38

### DIFF
--- a/.github/workflows/labeled_download_model_dataset.yaml
+++ b/.github/workflows/labeled_download_model_dataset.yaml
@@ -37,7 +37,7 @@ jobs:
         run: |
           apt-get update -y && apt-get install git jq -y
           pip config set global.index-url https://mirrors.aliyun.com/pypi/simple/
-          pip install modelscope datasets
+          pip install 'modelscope<1.38' datasets
 
       - name: Show Current Disk Usage
         run: |

--- a/Dockerfile
+++ b/Dockerfile
@@ -46,7 +46,7 @@ RUN if [ -n "$APTMIRROR" ]; then \
 # Install modelscope (for fast download) and ray (for multinode)
 RUN pip config set global.index-url ${PIP_INDEX_URL} && \
     if [ -n "$PIP_TRUSTED_HOST" ]; then pip config set global.trusted-host "$PIP_TRUSTED_HOST"; fi && \
-    python3 -m pip install modelscope 'ray>=2.47.1,<=2.48.0' 'protobuf>3.20.0' && \
+    python3 -m pip install 'modelscope<1.38' 'ray>=2.47.1,<=2.48.0' 'protobuf>3.20.0' && \
     python3 -m pip cache purge
 
 # Install vLLM

--- a/Dockerfile.310p
+++ b/Dockerfile.310p
@@ -41,7 +41,7 @@ RUN if [ -n "$APTMIRROR" ]; then \
 # Install modelscope (for fast download) and ray (for multinode)
 RUN pip config set global.index-url ${PIP_INDEX_URL} && \
     if [ -n "$PIP_TRUSTED_HOST" ]; then pip config set global.trusted-host "$PIP_TRUSTED_HOST"; fi && \
-    python3 -m pip install modelscope 'ray>=2.47.1,<=2.48.0' 'protobuf>3.20.0' && \
+    python3 -m pip install 'modelscope<1.38' 'ray>=2.47.1,<=2.48.0' 'protobuf>3.20.0' && \
     python3 -m pip cache purge
 
 # Install vLLM

--- a/Dockerfile.310p.openEuler
+++ b/Dockerfile.310p.openEuler
@@ -37,7 +37,7 @@ RUN yum update -y && \
 # Install modelscope (for fast download) and ray (for multinode)
 RUN pip config set global.index-url ${PIP_INDEX_URL} && \
     if [ -n "$PIP_TRUSTED_HOST" ]; then pip config set global.trusted-host "$PIP_TRUSTED_HOST"; fi && \
-    python3 -m pip install modelscope 'ray>=2.47.1,<=2.48.0' 'protobuf>3.20.0' && \
+    python3 -m pip install 'modelscope<1.38' 'ray>=2.47.1,<=2.48.0' 'protobuf>3.20.0' && \
     python3 -m pip cache purge
 
 # Install vLLM

--- a/Dockerfile.a3
+++ b/Dockerfile.a3
@@ -49,7 +49,7 @@ RUN if [ -n "$APTMIRROR" ]; then \
 # Install modelscope (for fast download) and ray (for multinode)
 RUN pip config set global.index-url ${PIP_INDEX_URL} && \
     if [ -n "$PIP_TRUSTED_HOST" ]; then pip config set global.trusted-host "$PIP_TRUSTED_HOST"; fi && \
-    python3 -m pip install modelscope 'ray>=2.47.1,<=2.48.0' 'protobuf>3.20.0' && \
+    python3 -m pip install 'modelscope<1.38' 'ray>=2.47.1,<=2.48.0' 'protobuf>3.20.0' && \
     python3 -m pip cache purge
 
 # Install vLLM

--- a/Dockerfile.a3.openEuler
+++ b/Dockerfile.a3.openEuler
@@ -43,7 +43,7 @@ RUN yum update -y && \
 # Install modelscope (for fast download) and ray (for multinode)
 RUN pip config set global.index-url ${PIP_INDEX_URL} && \
     if [ -n "$PIP_TRUSTED_HOST" ]; then pip config set global.trusted-host "$PIP_TRUSTED_HOST"; fi && \
-    python3 -m pip install modelscope 'ray>=2.47.1,<=2.48.0' 'protobuf>3.20.0' && \
+    python3 -m pip install 'modelscope<1.38' 'ray>=2.47.1,<=2.48.0' 'protobuf>3.20.0' && \
     python3 -m pip cache purge
 
 # Install vLLM

--- a/Dockerfile.a5
+++ b/Dockerfile.a5
@@ -49,7 +49,7 @@ RUN if [ -n "$APTMIRROR" ]; then \
 # Install modelscope (for fast download) and ray (for multinode)
 RUN pip config set global.index-url ${PIP_INDEX_URL} && \
     if [ -n "$PIP_TRUSTED_HOST" ]; then pip config set global.trusted-host "$PIP_TRUSTED_HOST"; fi && \
-    python3 -m pip install modelscope 'ray>=2.47.1,<=2.48.0' 'protobuf>3.20.0' && \
+    python3 -m pip install 'modelscope<1.38' 'ray>=2.47.1,<=2.48.0' 'protobuf>3.20.0' && \
     python3 -m pip cache purge
 
 # Install vLLM

--- a/Dockerfile.a5.openEuler
+++ b/Dockerfile.a5.openEuler
@@ -43,7 +43,7 @@ RUN yum update -y && \
 # Install modelscope (for fast download) and ray (for multinode)
 RUN pip config set global.index-url ${PIP_INDEX_URL} && \
     if [ -n "$PIP_TRUSTED_HOST" ]; then pip config set global.trusted-host "$PIP_TRUSTED_HOST"; fi && \
-    python3 -m pip install modelscope 'ray>=2.47.1,<=2.48.0' 'protobuf>3.20.0' && \
+    python3 -m pip install 'modelscope<1.38' 'ray>=2.47.1,<=2.48.0' 'protobuf>3.20.0' && \
     python3 -m pip cache purge
 
 # Install vLLM

--- a/Dockerfile.openEuler
+++ b/Dockerfile.openEuler
@@ -43,7 +43,7 @@ RUN yum update -y && \
 # Install modelscope (for fast download) and ray (for multinode)
 RUN pip config set global.index-url ${PIP_INDEX_URL} && \
     if [ -n "$PIP_TRUSTED_HOST" ]; then pip config set global.trusted-host "$PIP_TRUSTED_HOST"; fi && \
-    python3 -m pip install modelscope 'ray>=2.47.1,<=2.48.0' 'protobuf>3.20.0' && \
+    python3 -m pip install 'modelscope<1.38' 'ray>=2.47.1,<=2.48.0' 'protobuf>3.20.0' && \
     python3 -m pip cache purge
 
 # Install vLLM

--- a/benchmarks/requirements-bench.txt
+++ b/benchmarks/requirements-bench.txt
@@ -1,4 +1,4 @@
 pandas
 datasets
-modelscope
+modelscope<1.38
 tabulate

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,6 +1,6 @@
 -r requirements-lint.txt
 -r requirements.txt
-modelscope==1.35.3
+modelscope<1.38
 openai
 pytest >= 6.0,<9.0.0
 pytest-asyncio

--- a/tests/e2e/doctests/002-pip-binary-installation-test.sh
+++ b/tests/e2e/doctests/002-pip-binary-installation-test.sh
@@ -82,7 +82,7 @@ function install_binary_test() {
 
     # Verify the installation
     _info "====> Run offline example test"
-    pip install modelscope
+    pip install "modelscope<1.38"
     cd ${SCRIPT_DIR}/../../examples && python3 ./offline_inference_npu.py
     cd -
 


### PR DESCRIPTION
### What this PR does / why we need it?

This PR temporarily constrains the ModelScope version to `<1.38` in Docker images, development and benchmark dependencies, and CI installation workflows.

Starting from ModelScope 1.38.0, the Hub, model download, and cache mechanisms underwent significant changes, including:

- introducing the standalone `modelscope-hub` package;
- changing the model cache directory layout;
- adjusting the behavior of some Hub APIs.

These changes introduce compatibility risks for the current vLLM and vLLM Ascend environments, which still rely on parts of the legacy ModelScope behavior. This may cause issues such as:

- model download or Hub API failures;
- incompatibility between legacy and new cache directory layouts;
- existing cached models not being discovered;
- repeated downloads or failures during first-time deployment on new nodes with empty caches.

Upstream vLLM has already constrained ModelScope to `<1.38` in its Docker, CI, and test environments:

- https://github.com/vllm-project/vllm/pull/47465

To avoid introducing uncertain Hub API and cache-layout changes into the current CI and image environments, this PR aligns the remaining ModelScope installation paths with the upstream `<1.38` constraint.

Support for newer ModelScope versions can be enabled in a follow-up change after compatibility has been fully validated, including new-node deployment, empty-cache initialization, legacy-cache reuse, and model/dataset download workflows.

### Does this PR introduce _any_ user-facing change?

No intended user-facing change.

This change only constrains the ModelScope version installed by the repository-managed Docker, development, benchmark, and CI environments.

### How was this patch tested?

- vLLM main: https://github.com/vllm-project/vllm/commit/ba07e4a48fc951300d97eb506217dd530583dea3
