### PR TITLE
[Feature][BugFix][Spec Decode] Support DSpark with LMHead TP

### DIFF
--- a/vllm_ascend/models/deepseek_v4/dspark.py
+++ b/vllm_ascend/models/deepseek_v4/dspark.py
@@ -73,24 +73,22 @@ def _get_dspark_num_mtp_layers(config: PretrainedConfig) -> int:
 class DSparkMarkovHead(nn.Module):
     def __init__(self, config: PretrainedConfig, prefix: str) -> None:
         super().__init__()
-        self.markov_w1 = VocabParallelEmbedding(
-            config.vocab_size,
+        # Markov decoding runs serially for every draft position. Keep both
+        # low-rank weights replicated so each step remains communication-free.
+        self.markov_w1 = nn.Embedding(config.vocab_size, config.dspark_markov_rank)
+        self.markov_w2 = ReplicatedLinear(
             config.dspark_markov_rank,
-            prefix=f"{prefix}.markov_w1",
-        )
-        self.markov_w2 = ParallelLMHead(
             config.vocab_size,
-            config.dspark_markov_rank,
-            org_num_embeddings=config.vocab_size,
+            bias=False,
+            return_bias=False,
             prefix=f"{prefix}.markov_w2",
         )
-        self.logits_processor = LogitsProcessor(config.vocab_size)
 
     def embed(self, token_ids: torch.Tensor) -> torch.Tensor:
         return self.markov_w1(token_ids)
 
     def bias(self, markov_embed: torch.Tensor) -> torch.Tensor:
-        return self.logits_processor(self.markov_w2, markov_embed)
+        return self.markov_w2(markov_embed)
 
 
 class DSparkConfidenceHead(nn.Module):

--- a/vllm_ascend/spec_decode/llm_base_proposer.py
+++ b/vllm_ascend/spec_decode/llm_base_proposer.py
@@ -1236,11 +1236,18 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
 
         num_indices = token_indices_to_sample.shape[0]
         if lmhead_tp_enable():
-            max_num_reqs_across_dp = (
-                self.vllm_config.scheduler_config.max_num_seqs * self.runner.uniform_decode_query_len
-            )
+            if self.method == "dspark":
+                # DSpark draft decoding runs outside ACLGraph. Its real LMHead
+                # input is B * K; only pad it to the current target graph bucket.
+                num_indices = batch_size * self.num_speculative_tokens
+                token_indices_to_sample = token_indices_to_sample[:num_indices]
+                max_num_reqs_across_dp = (num_input_tokens // self.num_query_per_req) * self.num_speculative_tokens
+            else:
+                max_num_reqs_across_dp = (
+                    self.vllm_config.scheduler_config.max_num_seqs * self.runner.uniform_decode_query_len
+                )
             # It is necessary to evaluate the case where num_indices becomes large
-            # in the context of the dummy‑run accompaniment of p‑eagle.
+            # in the context of the dummy-run accompaniment of p-eagle.
             if num_indices > max_num_reqs_across_dp:
                 ori_token_indices_to_sample = token_indices_to_sample
             else:
@@ -1322,6 +1329,9 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
                         "rejection sampling. Falling back to greedy."
                     )
                 raw_logits = self.model.compute_logits(sample_hidden_states)
+                if lmhead_tp_enable():
+                    # Remove B_max - B communication padding.
+                    raw_logits = raw_logits[:num_indices]
                 logits = raw_logits.view(-1, self.num_speculative_tokens, raw_logits.shape[-1])
                 num_blk = logits.shape[0]
                 draft_token_ids = self._dspark_draft_buffer[:num_blk]

--- a/vllm_ascend/worker/model_runner_v1.py
+++ b/vllm_ascend/worker/model_runner_v1.py
@@ -3633,7 +3633,13 @@ class NPUModelRunner(GPUModelRunner):
 
             need_dummy_logits = not is_profile and lmhead_tp_enable()
             max_num_reqs_across_dp = max_num_reqs * self.uniform_decode_query_len
-            dummy_indices = torch.zeros(max_num_reqs_across_dp, dtype=torch.int32)
+            # Keep indices on the same device as hidden_states to avoid an
+            # implicit synchronous CPU-to-NPU copy during dummy-run indexing.
+            dummy_indices = torch.zeros(
+                max_num_reqs_across_dp,
+                dtype=torch.int32,
+                device=self.device,
+            )
 
             def dummy_compute_logits(hidden_states):
                 if not need_dummy_logits:


### PR DESCRIPTION
### What this PR does / why we need it?

This PR fixes DSpark speculative decoding when fine-grained LMHead tensor parallelism is enabled.

- Keep the DSpark Markov embedding and low-rank vocabulary projection replicated. Markov decoding is serial across draft positions, so sharding these weights through the LMHead TP group adds an unintended collective to every Markov step.
- Pad the DSpark LMHead input with the draft width `K`, instead of the target runner decode-query width `K + 1`.
- Remove flat dummy sampling rows immediately after the LMHead TP collective and before reshaping logits to `[batch, K, vocab]`.

Without these changes, DSpark uses the generic LMHead TP path with incompatible draft-side shapes and dummy request blocks can reach Markov decoding.

### Does this PR introduce _any_ user-facing change?

N/A

### How was this patch tested?

```
No LMHead TP                                          │ LMHead TP=4
======================================================│======================================================
============ Serving Benchmark Result ===============│============ Serving Benchmark Result ===============
Successful requests:                     100          │Successful requests:                     100
Failed requests:                         0            │Failed requests:                         0
Maximum request concurrency:             4            │Maximum request concurrency:             4
Benchmark duration (s):                  136.02       │Benchmark duration (s):                  127.96
Total input tokens:                      26148        │Total input tokens:                      26148
Total generated tokens:                  31188        │Total generated tokens:                  31394
Request throughput (req/s):              0.74         │Request throughput (req/s):              0.78
Output token throughput (tok/s):         229.29       │Output token throughput (tok/s):         245.34
Peak output token throughput (tok/s):    84.00        │Peak output token throughput (tok/s):    80.00
Peak concurrent requests:                6.00         │Peak concurrent requests:                7.00
Total token throughput (tok/s):          421.52       │Total token throughput (tok/s):          449.68
---------------Time to First Token-------------------│---------------Time to First Token-------------------
Mean TTFT (ms):                          474.37       │Mean TTFT (ms):                          461.21
Median TTFT (ms):                        432.57       │Median TTFT (ms):                        422.38
P50 TTFT (ms):                           432.57       │P50 TTFT (ms):                           422.38
P75 TTFT (ms):                           466.12       │P75 TTFT (ms):                           455.02
P90 TTFT (ms):                           696.29       │P90 TTFT (ms):                           653.06
P99 TTFT (ms):                           841.05       │P99 TTFT (ms):                           888.03
-----Time per Output Token (excl. 1st token)---------│-----Time per Output Token (excl. 1st token)---------
Mean TPOT (ms):                          15.55        │Mean TPOT (ms):                          14.34
Median TPOT (ms):                        15.55        │Median TPOT (ms):                        14.60
P50 TPOT (ms):                           15.55        │P50 TPOT (ms):                           14.60
P75 TPOT (ms):                           16.73        │P75 TPOT (ms):                           15.34
P90 TPOT (ms):                           17.94        │P90 TPOT (ms):                           16.24
P99 TPOT (ms):                           20.13        │P99 TPOT (ms):                           17.65
---------------Inter-token Latency-------------------│---------------Inter-token Latency-------------------
Mean ITL (ms):                           64.76        │Mean ITL (ms):                           59.78
Median ITL (ms):                         55.38        │Median ITL (ms):                         50.40
P50 ITL (ms):                            55.38        │P50 ITL (ms):                            50.40
P75 ITL (ms):                            56.58        │P75 ITL (ms):                            51.58
P90 ITL (ms):                            58.30        │P90 ITL (ms):                            53.97
P99 ITL (ms):                            371.27       │P99 ITL (ms):                            336.08
----------------End-to-end Latency-------------------│----------------End-to-end Latency-------------------
Mean E2EL (ms):                          5363.61      │Mean E2EL (ms):                          5014.37
Median E2EL (ms):                        4943.06      │Median E2EL (ms):                        4471.54
P50 E2EL (ms):                           4943.06      │P50 E2EL (ms):                           4471.54
P75 E2EL (ms):                           7161.59      │P75 E2EL (ms):                           6990.36
P90 E2EL (ms):                           8997.23      │P90 E2EL (ms):                           8441.55
P99 E2EL (ms):                           10116.44     │P99 E2EL (ms):                           9485.92
---------------Speculative Decoding------------------│---------------Speculative Decoding------------------
Acceptance rate (%):                     63.79        │Acceptance rate (%):                     63.55
Acceptance length:                       4.19         │Acceptance length:                       4.18
Drafts:                                  7450         │Drafts:                                  7517
Draft tokens:                            37250        │Draft tokens:                            37585
Accepted tokens:                         23762        │Accepted tokens:                         23885
Per-position acceptance (%):                          │Per-position acceptance (%):
  Position 0:                            88.52        │  Position 0:                            88.45
  Position 1:                            75.10        │  Position 1:                            74.98
  Position 2:                            62.75        │  Position 2:                            62.46
  Position 3:                            51.65        │  Position 3:                            51.32
  Position 4:                            40.93        │  Position 4:                            40.53
======================================================│======================================================
```

- vLLM main: https://github.com/vllm-project/vllm/commit/ba07e4a48fc951300d97eb506217dd530583dea3
