### PR TITLE
[Feature][Bugfix][Spec Decode][v0.26.0rc] Support DSpark with LMHead TP

### DIFF
--- a/tests/ut/spec_decode/test_dspark_proposer.py
+++ b/tests/ut/spec_decode/test_dspark_proposer.py
@@ -342,12 +342,6 @@ class TestDSparkInitialization(_DSparkProposerTestBase):
                 id="reduce-sample-bypasses-markov-head",
             ),
             pytest.param(
-                {"finegrained_tp_config": {"lmhead_tensor_parallel_size": 2}},
-                "greedy",
-                "does not support fine-grained LM-head",
-                id="finegrained-lmhead-tp",
-            ),
-            pytest.param(
                 {},
                 "probabilistic",
                 "probabilistic draft sampling is not supported",

--- a/vllm_ascend/models/deepseek_v4_dspark.py
+++ b/vllm_ascend/models/deepseek_v4_dspark.py
@@ -24,7 +24,7 @@ from vllm.distributed import (
 from vllm.logger import logger
 from vllm.model_executor.layers.fused_moe import fused_moe_make_expert_params_mapping
 from vllm.model_executor.layers.layernorm import RMSNorm
-from vllm.model_executor.layers.linear import ColumnParallelLinear
+from vllm.model_executor.layers.linear import ColumnParallelLinear, ReplicatedLinear
 from vllm.model_executor.layers.logits_processor import LogitsProcessor
 from vllm.model_executor.layers.vocab_parallel_embedding import (
     ParallelLMHead,
@@ -70,24 +70,22 @@ def _get_dspark_num_mtp_layers(config: PretrainedConfig) -> int:
 class DSparkMarkovHead(nn.Module):
     def __init__(self, config: PretrainedConfig, prefix: str) -> None:
         super().__init__()
-        self.markov_w1 = VocabParallelEmbedding(
-            config.vocab_size,
+        # Markov decoding runs serially for every draft position. Keep both
+        # low-rank weights replicated so each step remains communication-free.
+        self.markov_w1 = nn.Embedding(config.vocab_size, config.dspark_markov_rank)
+        self.markov_w2 = ReplicatedLinear(
             config.dspark_markov_rank,
-            prefix=f"{prefix}.markov_w1",
-        )
-        self.markov_w2 = ParallelLMHead(
             config.vocab_size,
-            config.dspark_markov_rank,
-            org_num_embeddings=config.vocab_size,
+            bias=False,
+            return_bias=False,
             prefix=f"{prefix}.markov_w2",
         )
-        self.logits_processor = LogitsProcessor(config.vocab_size)
 
     def embed(self, token_ids: torch.Tensor) -> torch.Tensor:
         return self.markov_w1(token_ids)
 
     def bias(self, markov_embed: torch.Tensor) -> torch.Tensor:
-        return self.logits_processor(self.markov_w2, markov_embed)
+        return self.markov_w2(markov_embed)
 
 
 class DeepseekV4DSparkModel(nn.Module):

--- a/vllm_ascend/spec_decode/dspark_proposer.py
+++ b/vllm_ascend/spec_decode/dspark_proposer.py
@@ -44,14 +44,6 @@ class AscendDSparkProposer(AscendDflashProposer):
                 "DSpark Markov-head correction. Set "
                 "additional_config.enable_reduce_sample=false."
             )
-        finegrained_tp_config = additional_config.get("finegrained_tp_config", {}) or {}
-        if finegrained_tp_config.get("lmhead_tensor_parallel_size", 0):
-            raise ValueError(
-                "DSpark on the v1 model runner does not support fine-grained "
-                "LM-head tensor parallelism; keep "
-                "additional_config.finegrained_tp_config."
-                "lmhead_tensor_parallel_size=0."
-            )
         if vllm_config.speculative_config.draft_sample_method == "probabilistic":
             raise ValueError(
                 "DSpark probabilistic draft sampling is not supported on the v1 "

--- a/vllm_ascend/spec_decode/llm_base_proposer.py
+++ b/vllm_ascend/spec_decode/llm_base_proposer.py
@@ -1359,11 +1359,18 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
 
         num_indices = token_indices_to_sample.shape[0]
         if lmhead_tp_enable():
-            max_num_reqs_across_dp = (
-                self.vllm_config.scheduler_config.max_num_seqs * self.runner.uniform_decode_query_len
-            )
+            if self.method == "dspark":
+                # DSpark draft decoding runs outside ACLGraph. Its real LMHead
+                # input is B * K; only pad it to the current target graph bucket.
+                num_indices = batch_size * self.num_speculative_tokens
+                token_indices_to_sample = token_indices_to_sample[:num_indices]
+                max_num_reqs_across_dp = (num_input_tokens // self.num_query_per_req) * self.num_speculative_tokens
+            else:
+                max_num_reqs_across_dp = (
+                    self.vllm_config.scheduler_config.max_num_seqs * self.runner.uniform_decode_query_len
+                )
             # It is necessary to evaluate the case where num_indices becomes large
-            # in the context of the dummy‑run accompaniment of p‑eagle.
+            # in the context of the dummy-run accompaniment of p-eagle.
             if num_indices > max_num_reqs_across_dp:
                 ori_token_indices_to_sample = token_indices_to_sample
             else:
@@ -1413,6 +1420,11 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
                 # We changed `flash_comm_v1_enabled` to avoid `markov_emb` from being split.
                 with _disable_flash_comm_v1_context():
                     raw_logits = self.model.compute_logits(sample_hidden_states)
+                    if lmhead_tp_enable():
+                        # Keep the padded shape through the LMHead TP collective,
+                        # then remove dummy sampling rows before grouping them by
+                        # request for Markov decoding.
+                        raw_logits = raw_logits[:num_indices]
                     logits = raw_logits.view(-1, self.num_speculative_tokens, raw_logits.shape[-1])
                     num_blk = logits.shape[0]
                     draft_token_ids = self._dspark_draft_buffer[:num_blk]

--- a/vllm_ascend/worker/model_runner_v1.py
+++ b/vllm_ascend/worker/model_runner_v1.py
@@ -3489,7 +3489,13 @@ class NPUModelRunner(GPUModelRunner):
 
             need_dummy_logits = not is_profile and lmhead_tp_enable()
             max_num_reqs_across_dp = max_num_reqs * self.uniform_decode_query_len
-            dummy_indices = torch.zeros(max_num_reqs_across_dp, dtype=torch.int32)
+            # Keep indices on the same device as hidden_states to avoid an
+            # implicit synchronous CPU-to-NPU copy during dummy-run indexing.
+            dummy_indices = torch.zeros(
+                max_num_reqs_across_dp,
+                dtype=torch.int32,
+                device=self.device,
+            )
 
             def dummy_compute_logits(hidden_states):
                 if not need_dummy_logits:


### PR DESCRIPTION
### What this PR does / why we need it?

Backport of #15495 to `releases/v0.26.0rc`.

This PR fixes DSpark speculative decoding when fine-grained LMHead tensor parallelism is enabled.

- Keep the DSpark Markov embedding and low-rank vocabulary projection replicated. Markov decoding is serial across draft positions, so sharding these weights through the LMHead TP group adds an unintended collective to every Markov step.
- Pad the DSpark LMHead input with the draft width `K`, instead of the target runner decode-query width `K + 1`.
- Remove flat dummy sampling rows immediately after the LMHead TP collective and before reshaping logits to `[batch, K, vocab]`.

Without these changes, DSpark uses the generic LMHead TP path with incompatible draft-side shapes and dummy request blocks can reach Markov decoding.

### Does this PR introduce _any_ user-facing change?

N/A

### How was this patch tested?

```
============lmheadtp=4  ==========================	============ No LMheadtp ============
Successful requests:                     100       	Successful requests:                     100       
Failed requests:                         0         	Failed requests:                         0         
Maximum request concurrency:             4         	Maximum request concurrency:             4         
Benchmark duration (s):                  139.06    	Benchmark duration (s):                  157.02    
Total input tokens:                      26148     	Total input tokens:                      26148     
Total generated tokens:                  30999     	Total generated tokens:                  30986     
Request throughput (req/s):              0.72      	Request throughput (req/s):              0.64      
Output token throughput (tok/s):         222.92    	Output token throughput (tok/s):         197.34    
Peak output token throughput (tok/s):    84.00     	Peak output token throughput (tok/s):    85.00     
Peak concurrent requests:                7.00      	Peak concurrent requests:                7.00      
Total token throughput (tok/s):          410.95    	Total token throughput (tok/s):          363.87    
---------------Time to First Token----------------	---------------Time to First Token----------------
Mean TTFT (ms):                          561.34    	Mean TTFT (ms):                          1271.84   
Median TTFT (ms):                        449.57    	Median TTFT (ms):                        439.87    
P50 TTFT (ms):                           449.57    	P50 TTFT (ms):                           439.87    
P75 TTFT (ms):                           501.61    	P75 TTFT (ms):                           476.26    
P90 TTFT (ms):                           753.99    	P90 TTFT (ms):                           783.11    
P99 TTFT (ms):                           2793.63   	P99 TTFT (ms):                           19022.78  
-----Time per Output Token (excl. 1st token)------	-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          15.77     	Mean TPOT (ms):                          16.10     
Median TPOT (ms):                        15.54     	Median TPOT (ms):                        15.37     
P50 TPOT (ms):                           15.54     	P50 TPOT (ms):                           15.37     
P75 TPOT (ms):                           17.20     	P75 TPOT (ms):                           17.05     
P90 TPOT (ms):                           18.74     	P90 TPOT (ms):                           18.68     
P99 TPOT (ms):                           22.27     	P99 TPOT (ms):                           34.44     
---------------Inter-token Latency----------------	---------------Inter-token Latency----------------
Mean ITL (ms):                           65.76     	Mean ITL (ms):                           65.75     
Median ITL (ms):                         55.39     	Median ITL (ms):                         54.07     
P50 ITL (ms):                            55.39     	P50 ITL (ms):                            54.07     
P75 ITL (ms):                            56.83     	P75 ITL (ms):                            55.41     
P90 ITL (ms):                            58.00     	P90 ITL (ms):                            59.54     
P99 ITL (ms):                            388.78    	P99 ITL (ms):                            377.98    
----------------End-to-end Latency----------------	----------------End-to-end Latency----------------
Mean E2EL (ms):                          5502.58   	Mean E2EL (ms):                          6214.29   
Median E2EL (ms):                        5262.48   	Median E2EL (ms):                        5209.53   
P50 E2EL (ms):                           5262.48   	P50 E2EL (ms):                           5209.53   
P75 E2EL (ms):                           7404.58   	P75 E2EL (ms):                           7879.40   
P90 E2EL (ms):                           9141.73   	P90 E2EL (ms):                           9302.35   
P99 E2EL (ms):                           10300.88  	P99 E2EL (ms):                           25240.52  
---------------Speculative Decoding---------------	---------------Speculative Decoding---------------
Acceptance rate (%):                     63.68     	Acceptance rate (%):                     63.59     
Acceptance length:                       4.18      	Acceptance length:                       4.18      
Drafts:                                  7414      	Drafts:                                  7417      
Draft tokens:                            37070     	Draft tokens:                            37085     
Accepted tokens:                         23605     	Accepted tokens:                         23583     
Per-position acceptance (%):	Per-position acceptance (%):
  Position 0:                            88.49     	  Position 0:                            88.36     
  Position 1:                            74.75     	  Position 1:                            74.73     
  Position 2:                            62.64     	  Position 2:                            62.61     
  Position 3:                            51.50     	  Position 3:                            51.50     
  Position 4:                            41.00     	  Position 4:                            40.74     
==================================================	==================================================
```
- vLLM main: https://github.com/vllm-project/vllm/commit/d02df748bf9efd99022f1a062597dc3cb3808485
