### PR TITLE
[Feature] add force EPLB Feature through additional config

### DIFF
--- a/tests/ut/ops/test_force_eplb.py
+++ b/tests/ut/ops/test_force_eplb.py
@@ -1,0 +1,103 @@
+# SPDX-License-Identifier: Apache-2.0
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+import torch
+
+from vllm_ascend.ops.fused_moe import force_eplb
+
+
+def _make_moe_comm_method(*, ep_rank: int = 1):
+    return SimpleNamespace(
+        moe_config=SimpleNamespace(
+            ep_size=2,
+            ep_rank=ep_rank,
+            experts_per_token=2,
+            num_logical_experts=8,
+        )
+    )
+
+
+def test_build_round_robin_topk_returns_expected_ids():
+    result = force_eplb._build_round_robin_topk(
+        num_tokens=2,
+        top_k=2,
+        num_logical_experts=8,
+        ep_size=2,
+        ep_rank=1,
+        device=torch.device("cpu"),
+        dtype=torch.int32,
+    )
+
+    torch.testing.assert_close(result, torch.tensor([[6, 3], [7, 0]], dtype=torch.int32))
+
+
+@pytest.mark.parametrize(
+    ("kwargs", "message"),
+    [
+        ({"num_tokens": 0}, "num_tokens must be positive"),
+        ({"top_k": 0}, "top_k must be positive"),
+        ({"ep_size": 0}, "ep_size must be positive"),
+        ({"num_logical_experts": 7}, "num_logical_experts must be divisible"),
+    ],
+)
+def test_build_round_robin_topk_rejects_invalid_shape(kwargs, message):
+    params = {
+        "num_tokens": 2,
+        "top_k": 2,
+        "num_logical_experts": 8,
+        "ep_size": 2,
+        "ep_rank": 0,
+        "device": torch.device("cpu"),
+        "dtype": torch.int32,
+    }
+    params.update(kwargs)
+
+    with pytest.raises(ValueError, match=message):
+        force_eplb._build_round_robin_topk(**params)
+
+
+def test_get_force_eplb_topk_reuses_cached_table():
+    moe_comm_method = _make_moe_comm_method()
+    context = SimpleNamespace(moe_comm_method=moe_comm_method)
+    topk_ids = torch.empty((2, 2), dtype=torch.int32)
+
+    with patch.object(force_eplb, "get_forward_context", return_value=context):
+        first = force_eplb.get_force_eplb_topk(topk_ids, num_logical_experts=8)
+        second = force_eplb.get_force_eplb_topk(topk_ids, num_logical_experts=8)
+
+    assert first is second
+    assert len(moe_comm_method._force_eplb_topk_cache) == 1
+
+
+def test_get_force_eplb_topk_returns_none_without_comm_method():
+    context = SimpleNamespace(moe_comm_method=None)
+
+    with patch.object(force_eplb, "get_forward_context", return_value=context):
+        result = force_eplb.get_force_eplb_topk(torch.empty((2, 2)), num_logical_experts=8)
+
+    assert result is None
+
+
+@pytest.mark.parametrize(
+    ("configured_sizes", "expected_sizes"),
+    [
+        ([4, 8], {4, 8}),
+        ([], {16}),
+    ],
+)
+def test_build_force_eplb_topk_uses_configured_or_fallback_sizes(configured_sizes, expected_sizes):
+    moe_comm_method = _make_moe_comm_method(ep_rank=0)
+    context = SimpleNamespace(moe_comm_method=moe_comm_method)
+    vllm_config = SimpleNamespace(compilation_config=SimpleNamespace(cudagraph_capture_sizes=configured_sizes))
+
+    with (
+        patch.object(force_eplb, "get_forward_context", return_value=context),
+        patch.object(force_eplb, "get_current_vllm_config", return_value=vllm_config),
+    ):
+        force_eplb.build_force_eplb_topk(torch.device("cpu"), max_num_tokens=16)
+
+    cached_sizes = {key[0] for key in moe_comm_method._force_eplb_topk_cache}
+    assert cached_sizes == expected_sizes
+    assert len(moe_comm_method._force_eplb_topk_cache) == 2 * len(expected_sizes)

--- a/tests/ut/test_ascend_config.py
+++ b/tests/ut/test_ascend_config.py
@@ -48,6 +48,27 @@ from vllm_ascend.device.hardware_profile import get_hardware_profile
 from vllm_ascend.utils import clear_enable_sp, enable_dsa_cp, enable_sp, shared_expert_dp_enabled
 
 
+_VllmConfig = VllmConfig
+
+
+def VllmConfig(*args, **kwargs):
+    """Build a test config with the model metadata required by AscendConfig."""
+    config = _VllmConfig(*args, **kwargs)
+    if config.model_config is None:
+        config.model_config = SimpleNamespace(
+            is_moe=False,
+            is_deepseek_mla=False,
+            use_mla=False,
+            enforce_eager=True,
+            architectures=[],
+            hf_text_config=SimpleNamespace(),
+            get_total_num_kv_heads=lambda: 0,
+            get_num_experts=lambda: 0,
+            get_hidden_size=lambda: 0,
+        )
+    return config
+
+
 def test_config_modules_do_not_load_vllm_config():
     """Keep platform discovery from recursing into a partial vllm.config."""
     code = (
@@ -108,6 +129,7 @@ class TestAscendConfig(TestBase):
         is_deepseek_mla: bool = False,
     ):
         return SimpleNamespace(
+            is_moe=False,
             is_deepseek_mla=is_deepseek_mla,
             use_mla=is_deepseek_mla,
             enforce_eager=True,

--- a/tests/ut/test_ascend_config.py
+++ b/tests/ut/test_ascend_config.py
@@ -22,7 +22,8 @@ from types import SimpleNamespace
 from typing import Any
 from unittest.mock import patch
 
-from vllm.config import KVTransferConfig, VllmConfig as _VllmConfig
+from vllm.config import KVTransferConfig
+from vllm.config import VllmConfig as _VllmConfig
 
 from tests.ut.base import TestBase
 from vllm_ascend.ascend_config import (
@@ -47,6 +48,7 @@ from vllm_ascend.ascend_config import (
 from vllm_ascend.device.hardware import AscendDeviceType
 from vllm_ascend.device.hardware_profile import get_hardware_profile
 from vllm_ascend.utils import clear_enable_sp, enable_dsa_cp, enable_sp, shared_expert_dp_enabled
+
 
 def VllmConfig(*args: Any, **kwargs: Any) -> _VllmConfig:
     """Build a test config with the model metadata required by AscendConfig."""

--- a/tests/ut/test_ascend_config.py
+++ b/tests/ut/test_ascend_config.py
@@ -47,7 +47,6 @@ from vllm_ascend.device.hardware import AscendDeviceType
 from vllm_ascend.device.hardware_profile import get_hardware_profile
 from vllm_ascend.utils import clear_enable_sp, enable_dsa_cp, enable_sp, shared_expert_dp_enabled
 
-
 _VllmConfig = VllmConfig
 
 

--- a/tests/ut/test_ascend_config.py
+++ b/tests/ut/test_ascend_config.py
@@ -19,9 +19,10 @@ import subprocess
 import sys
 from importlib.util import find_spec as real_find_spec
 from types import SimpleNamespace
+from typing import Any
 from unittest.mock import patch
 
-from vllm.config import KVTransferConfig, VllmConfig
+from vllm.config import KVTransferConfig, VllmConfig as _VllmConfig
 
 from tests.ut.base import TestBase
 from vllm_ascend.ascend_config import (
@@ -47,10 +48,7 @@ from vllm_ascend.device.hardware import AscendDeviceType
 from vllm_ascend.device.hardware_profile import get_hardware_profile
 from vllm_ascend.utils import clear_enable_sp, enable_dsa_cp, enable_sp, shared_expert_dp_enabled
 
-_VllmConfig = VllmConfig
-
-
-def VllmConfig(*args, **kwargs):
+def VllmConfig(*args: Any, **kwargs: Any) -> _VllmConfig:
     """Build a test config with the model metadata required by AscendConfig."""
     config = _VllmConfig(*args, **kwargs)
     if config.model_config is None:

--- a/tests/ut/test_ascend_config.py
+++ b/tests/ut/test_ascend_config.py
@@ -1080,6 +1080,7 @@ class TestTopLevelSwitchTypeValidation(TestBase):
 
         supported_vc = VllmConfig()
         supported_vc.model_config = SimpleNamespace(
+            is_moe=False,
             hf_text_config=SimpleNamespace(index_topk=2048),
             hf_config=SimpleNamespace(),
             enforce_eager=True,
@@ -1177,7 +1178,12 @@ class TestTopLevelSwitchTypeValidation(TestBase):
     @patch("vllm_ascend.platform.NPUPlatform.check_and_update_config")
     def test_enable_kv_nz_uses_vllm_config_preconditions(self, mock_fix, mock_sparse):
         vc = VllmConfig()
-        vc.model_config = SimpleNamespace(is_deepseek_mla=True, architectures=[], enforce_eager=True)
+        vc.model_config = SimpleNamespace(
+            is_moe=False,
+            is_deepseek_mla=True,
+            architectures=[],
+            enforce_eager=True,
+        )
         vc.kv_transfer_config = SimpleNamespace(is_kv_consumer=True)
         vc.additional_config = {"enable_kv_nz": "true"}
 

--- a/tests/ut/test_ascend_config.py
+++ b/tests/ut/test_ascend_config.py
@@ -232,6 +232,7 @@ class TestAscendConfig(TestBase):
                 "fusion_ops_gmmswigluquant": False,
             },
             "multistream_overlap_shared_expert": True,
+            "enable_force_eplb": True,
             "eplb_config": {"num_redundant_experts": 2},
             "refresh": True,
             "enable_kv_nz": False,
@@ -242,6 +243,7 @@ class TestAscendConfig(TestBase):
         ascend_config = init_ascend_config(test_vllm_config)
         self.assertEqual(ascend_config.eplb_config.num_redundant_experts, 2)
         self.assertTrue(ascend_config.multistream_overlap_shared_expert)
+        self.assertTrue(ascend_config.enable_force_eplb)
         self.assertEqual(ascend_config.mega_moe_max_tokens, 32768)
 
         ascend_compilation_config = ascend_config.ascend_compilation_config

--- a/vllm_ascend/ascend_config.py
+++ b/vllm_ascend/ascend_config.py
@@ -257,6 +257,7 @@ class AscendConfig:
             "enable_mc2_hierarchy_comm": false,
             "enable_reduce_sample": false,
             "enable_dsa_cp": false,
+            "enable_force_eplb": false,
             "draft_window_size": null,
             "mix_placement": false,
             "pa_shape_list": [],
@@ -391,6 +392,7 @@ class AscendConfig:
     enable_mc2_hierarchy_comm: bool = False  # deprecated, will be replaced by mc2_comm_alg = "hierarchy"
     enable_reduce_sample: bool = False
     enable_dsa_cp: bool = False
+    enable_force_eplb: bool = False
     draft_window_size: int | None = None
     mix_placement: bool = False
     pa_shape_list: list[Any] = dataclasses.field(default_factory=list)
@@ -479,6 +481,8 @@ class AscendConfig:
     # the max_num_batched_tokens that sequence-parallel writeback corrected).
     def derive_and_validate(self, vllm_config: VllmConfig) -> AscendConfig:
         vc = vllm_config
+        if vc.model_config.is_moe and self.enable_force_eplb and self.eplb_config.dynamic_eplb:
+            raise ValueError("enable_force_eplb cannot be mixed with dynamic_eplb.")
         self._check_mooncake_c8_kv_cache_quant(vc)
 
         # profiling_chunk vs min_chunk clamp

--- a/vllm_ascend/ascend_config.py
+++ b/vllm_ascend/ascend_config.py
@@ -481,7 +481,7 @@ class AscendConfig:
     # the max_num_batched_tokens that sequence-parallel writeback corrected).
     def derive_and_validate(self, vllm_config: VllmConfig) -> AscendConfig:
         vc = vllm_config
-        if vc.model_config is not None and self.enable_force_eplb and self.eplb_config.dynamic_eplb:
+        if vc.model_config.is_moe and self.enable_force_eplb and self.eplb_config.dynamic_eplb:
             raise ValueError("enable_force_eplb cannot be mixed with dynamic_eplb.")
         self._check_mooncake_c8_kv_cache_quant(vc)
 

--- a/vllm_ascend/ascend_config.py
+++ b/vllm_ascend/ascend_config.py
@@ -481,7 +481,12 @@ class AscendConfig:
     # the max_num_batched_tokens that sequence-parallel writeback corrected).
     def derive_and_validate(self, vllm_config: VllmConfig) -> AscendConfig:
         vc = vllm_config
-        if vc.model_config.is_moe and self.enable_force_eplb and self.eplb_config.dynamic_eplb:
+        if (
+            self.enable_force_eplb
+            and self.eplb_config.dynamic_eplb
+            and vc.model_config is not None
+            and vc.model_config.is_moe
+        ):
             raise ValueError("enable_force_eplb cannot be mixed with dynamic_eplb.")
         self._check_mooncake_c8_kv_cache_quant(vc)
 

--- a/vllm_ascend/ascend_config.py
+++ b/vllm_ascend/ascend_config.py
@@ -481,7 +481,7 @@ class AscendConfig:
     # the max_num_batched_tokens that sequence-parallel writeback corrected).
     def derive_and_validate(self, vllm_config: VllmConfig) -> AscendConfig:
         vc = vllm_config
-        if vc.model_config.is_moe and self.enable_force_eplb and self.eplb_config.dynamic_eplb:
+        if vc.model_config is not None and self.enable_force_eplb and self.eplb_config.dynamic_eplb:
             raise ValueError("enable_force_eplb cannot be mixed with dynamic_eplb.")
         self._check_mooncake_c8_kv_cache_quant(vc)
 

--- a/vllm_ascend/ops/fused_moe/force_eplb.py
+++ b/vllm_ascend/ops/fused_moe/force_eplb.py
@@ -1,0 +1,142 @@
+#
+# Copyright (c) 2026 Huawei Technologies Co., Ltd. All Rights Reserved.
+# This file is a part of the vllm-ascend project.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+import torch
+from vllm.config import get_current_vllm_config
+from vllm.forward_context import get_forward_context
+
+
+def _build_or_get_topk(
+    moe_comm_method,
+    *,
+    num_tokens: int,
+    top_k: int,
+    num_logical_experts: int,
+    dtype: torch.dtype,
+    device: torch.device,
+) -> torch.Tensor:
+    cache = getattr(moe_comm_method, "_force_eplb_topk_cache", None)
+    if cache is None:
+        cache = {}
+        moe_comm_method._force_eplb_topk_cache = cache
+    key = (
+        int(num_tokens),
+        int(top_k),
+        int(num_logical_experts),
+        int(moe_comm_method.moe_config.ep_size),
+        int(moe_comm_method.moe_config.ep_rank),
+        dtype,
+        device,
+    )
+    table = cache.get(key)
+    if table is None:
+        table = _build_round_robin_topk(
+            num_tokens=num_tokens,
+            top_k=top_k,
+            num_logical_experts=num_logical_experts,
+            ep_size=int(moe_comm_method.moe_config.ep_size),
+            ep_rank=int(moe_comm_method.moe_config.ep_rank),
+            device=device,
+            dtype=dtype,
+        )
+        cache[key] = table
+    return table
+
+
+def build_force_eplb_topk(
+    device: torch.device,
+    max_num_tokens: int,
+) -> None:
+    """Build force-EPLB tables before ACLGraph capture."""
+    forward_context = get_forward_context()
+    moe_comm_method = forward_context.moe_comm_method
+    if moe_comm_method is None:
+        return
+
+    vllm_config = get_current_vllm_config()
+    capture_sizes = {int(size) for size in (vllm_config.compilation_config.cudagraph_capture_sizes or [])}
+    if not capture_sizes:
+        capture_sizes.add(int(max_num_tokens))
+
+    moe_config = moe_comm_method.moe_config
+    top_k = int(moe_config.experts_per_token)
+    num_logical_experts = int(moe_config.num_logical_experts)
+    for num_tokens in capture_sizes:
+        for dtype in (torch.int32, torch.int64):
+            _build_or_get_topk(
+                moe_comm_method,
+                num_tokens=int(num_tokens),
+                top_k=top_k,
+                num_logical_experts=num_logical_experts,
+                dtype=dtype,
+                device=device,
+            )
+
+
+def get_force_eplb_topk(
+    topk_ids: torch.Tensor,
+    num_logical_experts: int,
+) -> torch.Tensor | None:
+    """Return deterministic round-robin ids when the policy is enabled."""
+    moe_comm_method = get_forward_context().moe_comm_method
+    if moe_comm_method is None:
+        return None
+    top_k = int(topk_ids.shape[1])
+    return _build_or_get_topk(
+        moe_comm_method,
+        num_tokens=int(topk_ids.shape[0]),
+        top_k=int(top_k),
+        num_logical_experts=int(num_logical_experts),
+        dtype=topk_ids.dtype,
+        device=topk_ids.device,
+    )
+
+
+def _build_round_robin_topk(
+    *,
+    num_tokens: int,
+    top_k: int,
+    num_logical_experts: int,
+    ep_size: int,
+    ep_rank: int,
+    device: torch.device,
+    dtype: torch.dtype,
+) -> torch.Tensor:
+    if num_tokens <= 0:
+        raise ValueError(f"num_tokens must be positive, got {num_tokens}")
+    if top_k <= 0:
+        raise ValueError(f"top_k must be positive, got {top_k}")
+    if ep_size <= 0:
+        raise ValueError(f"ep_size must be positive, got {ep_size}")
+    if num_logical_experts % ep_size != 0:
+        raise ValueError(
+            "num_logical_experts must be divisible by ep_size: "
+            f"num_logical_experts={num_logical_experts}, ep_size={ep_size}"
+        )
+
+    experts_per_rank = num_logical_experts // ep_size
+    expanded_tokens = num_tokens * top_k
+    expanded_offset = expanded_tokens * ep_rank + ep_rank
+
+    idx = torch.arange(expanded_tokens, device=device, dtype=torch.int64)
+    cursor = idx + expanded_offset
+    col = torch.remainder(cursor, ep_size)
+    row = torch.remainder(
+        torch.div(cursor, ep_size, rounding_mode="floor"),
+        experts_per_rank,
+    )
+    expert_ids = row + col * experts_per_rank
+    return expert_ids.to(dtype=dtype).view(num_tokens, top_k)

--- a/vllm_ascend/ops/fused_moe/routed_experts.py
+++ b/vllm_ascend/ops/fused_moe/routed_experts.py
@@ -35,6 +35,7 @@ from vllm_ascend.eplb.adaptor.vllm_adaptor import VllmEplbAdaptor
 from vllm_ascend.eplb.core.eplb_utils import init_eplb_config
 from vllm_ascend.lora.fused_moe import sync_lora_context
 from vllm_ascend.ops.fused_moe.dataclass.fused_experts import build_fused_experts_input
+from vllm_ascend.ops.fused_moe.force_eplb import get_force_eplb_topk
 from vllm_ascend.ops.fused_moe.moe_comm_method import AllGatherCommImpl, FusedExpertsResult
 from vllm_ascend.ops.fused_moe.moe_utils import get_moe_num_logical_experts
 from vllm_ascend.ops.fused_moe.shared_experts import FusedMoEEvents
@@ -479,10 +480,9 @@ class AscendRoutedExperts(RoutedExperts):  # type: ignore[no-redef]
         # fp32, which is what npu_moe_token_unpermute expects for its `probs` arg.
         if hidden_states.dtype not in [torch.uint8, torch.float8_e4m3fn]:
             topk_weights = topk_weights.to(hidden_states.dtype)
-        # This is a naive implementation for experts load balance so as to
-        # avoid accumulating too much tokens on a single rank. It is only
-        # activated when doing profile runs.
-        if enable_force_load_balance:
+        if get_ascend_config().enable_force_eplb:
+            topk_ids = get_force_eplb_topk(topk_ids, num_logical_experts)
+        elif enable_force_load_balance:
             random_matrix = torch.rand(
                 topk_ids.size(0),
                 num_logical_experts,

--- a/vllm_ascend/worker/model_runner_v1.py
+++ b/vllm_ascend/worker/model_runner_v1.py
@@ -3605,7 +3605,7 @@ class NPUModelRunner(GPUModelRunner):
                     for_cudagraph_capture=is_graph_capturing,
                     num_scheduled_tokens_np=num_scheduled_tokens,
                 )
-        with (self.maybe_dummy_run_with_lora(
+        with self.maybe_dummy_run_with_lora(
             self.lora_config,
             num_scheduled_tokens,
             num_sampled_tokens,
@@ -3614,7 +3614,7 @@ class NPUModelRunner(GPUModelRunner):
             # to fix the accuracy issue of test_llama32_lora.py,
             # which is introduced by vllm-project/vllm#32005
             num_active_loras=(self.lora_config.max_loras if self.lora_config is not None else num_active_loras),
-        )):
+        ):
             # Make sure padding doesn't exceed max_num_tokens
             assert num_tokens_padded <= self.max_num_tokens
             if self.supports_mm_inputs and not self.model_config.is_encoder_decoder or self.enable_prompt_embeds:

--- a/vllm_ascend/worker/model_runner_v1.py
+++ b/vllm_ascend/worker/model_runner_v1.py
@@ -149,6 +149,7 @@ from vllm_ascend.eplb.core.eplb_device_transfer_loader import D2DExpertWeightLoa
 from vllm_ascend.eplb.core.eplb_worker import EplbProcess
 from vllm_ascend.eplb.eplb_updator import EplbUpdator
 from vllm_ascend.model_executor.offloader import create_offloader
+from vllm_ascend.ops.fused_moe.force_eplb import build_force_eplb_topk
 from vllm_ascend.ops.rotary_embedding import set_cos_and_sin, update_cos_sin
 from vllm_ascend.ops.triton.spec_decode.ngram import triton_ngram_spec_decode
 from vllm_ascend.quantization.utils import enable_fa_quant
@@ -3604,7 +3605,7 @@ class NPUModelRunner(GPUModelRunner):
                     for_cudagraph_capture=is_graph_capturing,
                     num_scheduled_tokens_np=num_scheduled_tokens,
                 )
-        with self.maybe_dummy_run_with_lora(
+        with (self.maybe_dummy_run_with_lora(
             self.lora_config,
             num_scheduled_tokens,
             num_sampled_tokens,
@@ -3613,7 +3614,7 @@ class NPUModelRunner(GPUModelRunner):
             # to fix the accuracy issue of test_llama32_lora.py,
             # which is introduced by vllm-project/vllm#32005
             num_active_loras=(self.lora_config.max_loras if self.lora_config is not None else num_active_loras),
-        ):
+        )):
             # Make sure padding doesn't exceed max_num_tokens
             assert num_tokens_padded <= self.max_num_tokens
             if self.supports_mm_inputs and not self.model_config.is_encoder_decoder or self.enable_prompt_embeds:
@@ -3689,6 +3690,9 @@ class NPUModelRunner(GPUModelRunner):
                 has_sinks = self._has_sinks,
                 eplb_heat_collection_status=self.eplb_heat_collection_status if self.dynamic_eplb else False,
             ):
+                if not is_graph_capturing and self.ascend_config.enable_force_eplb \
+                    and self.vllm_config.model_config.is_moe:
+                    build_force_eplb_topk(self.device, self.max_num_tokens)
                 outputs = self._model_forward(
                     num_tokens_padded, input_ids, positions, intermediate_tensors, inputs_embeds
                 )


### PR DESCRIPTION
  ## Motivation
   PR: #15121 

  The previous implementation had force-EPLB logic distributed across `NPUModelRunner` and `AscendRoutedExperts`:

  - Policy parsing was based on an environment variable.
  - The model runner traversed all model modules to find force-EPLB helpers.
  - Each routed-expert layer owned its own cache and helper methods.
  - Cache construction, policy checks, and expert-parameter derivation were
    duplicated across different components.

  This made the feature harder to configure and increased coupling between the model runner and individual MoE layers.

  Using `additional_config` provides a typed, validated configuration path that is included in the vLLM configuration lifecycle and can be represented together with the rest of the Ascend options.

  ## Changes

  ### `vllm_ascend/ascend_config.py`

  - Add the following configuration option:

    ```json
    {
      "enable_force_eplb": false
    }

  - enable_force_eplb=true enables the Round-Robin force-EPLB path.
  - Add validation to reject configurations that enable both enable_force_eplb and eplb_config.dynamic_eplb.

  Example:

  vllm serve <model> \
    --additional-config '{"enable_force_eplb": true}'

  ### vllm_ascend/ops/fused_moe/force_eplb.py

  Add a centralized implementation for force-EPLB table handling:

  - _build_or_get_topk() manages table construction and caching.
  - prebuild_force_eplb_topk() builds tables before ACLGraph capture.
  - apply_force_eplb_topk() obtains the deterministic expert IDs at runtime.
  - build_round_robin_topk() contains the deterministic Round-Robin mapping algorithm.

  The cache is associated with the active MoE communication method and uses the following values as part of its key:

  - Number of tokens
  - Top-k value
  - Number of logical experts
  - EP size
  - EP rank
  - Tensor dtype
  - Device

  This prevents tables with different shapes, ranks, dtypes, or devices from being incorrectly reused.

  The helper functions also preserve the previous behavior of returning without force-EPLB work when no MoE communication method is available.

  ### vllm_ascend/ops/fused_moe/routed_experts.py

  - Move the force-EPLB enable check to the routing call site.
  - Use apply_force_eplb_topk() when get_ascend_config().enable_force_eplb is enabled.

  - Preserve the existing random expert selection fallback when force EPLB is disabled and enable_force_load_balance is enabled.

  The normal routing path is therefore unchanged when enable_force_eplb=false.

  ### vllm_ascend/worker/model_runner_v1.py

  - Move force-EPLB prebuild invocation into the non-capturing dummy-run path.
  - Avoid performing force-EPLB table construction while is_graph_capturing=true.

  - Pass the current device and max_num_tokens to the centralized prebuild function.

  This keeps the first table construction outside the ACLGraph capture path.

  ### Tests

  Update the Ascend configuration unit test to verify that additional_config.enable_force_eplb=true is correctly parsed and exposed through AscendConfig.

  ## User-facing change

  Yes.

  Force EPLB should now be enabled through:

  {
    "enable_force_eplb": true
  }

 
  ## How was this patch tested?

  The following static checks passed:

  python -m py_compile \
    tests/ut/test_ascend_config.py \
    vllm_ascend/ascend_config.py \
    vllm_ascend/ops/fused_moe/force_eplb.py \
    vllm_ascend/ops/fused_moe/routed_experts.py \
    vllm_ascend/worker/model_runner_v1.py

  git diff --check

  NPU runtime and ACLGraph validation were not performed in the current environment because the required NPU runtime/test dependencies were unavailable.

Co-authored-by: [shunqinlu](https://github.com/shunqinlu)

- vLLM main: https://github.com/vllm-project/vllm/commit/ba07e4a48fc951300d97eb506217dd530583dea3
