### PR TITLE
[Bugfix] fix FlashComm1 + TP-sharded shared experts deadlock under multistream overlap

### DIFF
--- a/tests/ut/_310p/fused_moe/test_shared_fused_moe_310.py
+++ b/tests/ut/_310p/fused_moe/test_shared_fused_moe_310.py
@@ -120,6 +120,7 @@ def test_shared_forward_impl_310_returns_current_runner_contract(monkeypatch, ha
     router_logits = torch.randn(2, 3)
     routed_out = torch.randn(2, 4)
     shared_out = torch.randn(2, 4)
+    gathered = torch.randn(2, 4)
     routed_result = SimpleNamespace(
         routed_out=routed_out,
         before_dispatch_evt=None,
@@ -129,6 +130,7 @@ def test_shared_forward_impl_310_returns_current_runner_contract(monkeypatch, ha
     )
     runner.no_shared_forward_impl = MagicMock(return_value=routed_result)
     runner._forward_shared_experts = MagicMock(return_value=shared_out)
+    runner._prepare_shared_expert_input = MagicMock(return_value=gathered)
     current_stream = MagicMock()
 
     monkeypatch.setattr(AscendMoERunner310, "is_internal_router", property(lambda _: False))
@@ -144,7 +146,13 @@ def test_shared_forward_impl_310_returns_current_runner_contract(monkeypatch, ha
     if has_shared_experts:
         assert result[0] is shared_out
         assert result[1] is routed_out
-        runner._forward_shared_experts.assert_called_once()
+        # The gather is issued on the default stream (the mocked current stream)
+        # before the routed path is enqueued; the shared-experts stream consumes
+        # the gathered input once shared_input_ready fires.
+        runner._prepare_shared_expert_input.assert_called_once_with(hidden_states)
+        assert runner._forward_shared_experts.call_args.args[0] is gathered
+        assert runner._forward_shared_experts.call_args.args[1].shared_input_ready is not None
     else:
         assert result is routed_out
+        runner._prepare_shared_expert_input.assert_not_called()
         runner._forward_shared_experts.assert_not_called()

--- a/tests/ut/ops/test_fused_moe.py
+++ b/tests/ut/ops/test_fused_moe.py
@@ -433,6 +433,7 @@ def test_unquantized_shared_situ_uses_split_bf16_path(monkeypatch):
     runner.multistream_overlap_shared_expert = False
     events = fused_moe_module.FusedMoEEvents(
         before_routed_experts=MagicMock(),
+        shared_input_ready=MagicMock(),
         before_dispatch=MagicMock(),
         before_gmm2=MagicMock(),
         before_combine=MagicMock(),
@@ -489,6 +490,7 @@ def test_w8a8_shared_situ_uses_dequant_situ_quant(monkeypatch):
     stream = MagicMock()
     events = fused_moe_module.FusedMoEEvents(
         before_routed_experts=MagicMock(),
+        shared_input_ready=MagicMock(),
         before_dispatch=MagicMock(),
         before_gmm2=MagicMock(),
         before_combine=MagicMock(),
@@ -554,6 +556,7 @@ def test_mxfp_shared_situ_uses_situ_mx_quant(monkeypatch, quant_type):
     runner.multistream_overlap_shared_expert = False
     events = fused_moe_module.FusedMoEEvents(
         before_routed_experts=MagicMock(),
+        shared_input_ready=MagicMock(),
         before_dispatch=MagicMock(),
         before_gmm2=MagicMock(),
         before_combine=MagicMock(),
@@ -608,6 +611,7 @@ def test_shared_forward_impl_returns_current_runner_contract(monkeypatch, has_sh
     router_logits = torch.randn(2, 3)
     routed_out = torch.randn(2, 4)
     shared_out = torch.randn(2, 4)
+    gathered = torch.randn(2, 8)
     routed_result = SimpleNamespace(
         routed_out=routed_out,
         before_dispatch_evt=None,
@@ -617,6 +621,7 @@ def test_shared_forward_impl_returns_current_runner_contract(monkeypatch, has_sh
     )
     runner.no_shared_forward_impl = MagicMock(return_value=routed_result)
     runner._forward_shared_experts = MagicMock(return_value=shared_out)
+    runner._prepare_shared_expert_input = MagicMock(return_value=gathered)
     current_stream = MagicMock()
 
     monkeypatch.setattr(AscendMoERunner, "is_internal_router", property(lambda _: False))
@@ -632,10 +637,39 @@ def test_shared_forward_impl_returns_current_runner_contract(monkeypatch, has_sh
     if has_shared_experts:
         assert result[0] is shared_out
         assert result[1] is routed_out
-        assert runner._forward_shared_experts.call_args.args[0] is shared_experts_input
+        # The gather is issued on the default stream (the mocked current stream)
+        # before the routed path is enqueued; the shared-experts stream consumes
+        # the gathered input once shared_input_ready fires.
+        runner._prepare_shared_expert_input.assert_called_once_with(shared_experts_input)
+        assert runner._forward_shared_experts.call_args.args[0] is gathered
+        assert runner._forward_shared_experts.call_args.args[1].shared_input_ready is not None
     else:
         assert result is routed_out
+        runner._prepare_shared_expert_input.assert_not_called()
         runner._forward_shared_experts.assert_not_called()
+
+
+def test_forward_shared_experts_requires_shared_input_ready_event(monkeypatch):
+    runner = AscendMoERunner.__new__(AscendMoERunner)
+    nn.Module.__init__(runner)
+    runner._shared_experts = SimpleNamespace()
+    runner.multistream_overlap_shared_expert = False
+    events = fused_moe_module.FusedMoEEvents(
+        before_routed_experts=MagicMock(),
+        before_dispatch=MagicMock(),
+        before_gmm2=MagicMock(),
+        before_combine=MagicMock(),
+    )
+    monkeypatch.setattr(fused_moe_module, "npu_stream_switch", lambda *_args, **_kwargs: nullcontext())
+    monkeypatch.setattr(fused_moe_module, "shared_experts_calculation_stream", MagicMock())
+    monkeypatch.setattr(
+        fused_moe_module.torch.npu,
+        "current_stream",
+        MagicMock(return_value=MagicMock()),
+    )
+
+    with pytest.raises(AssertionError, match="shared_input_ready"):
+        runner._forward_shared_experts(torch.randn(2, 4), events)
 
 
 def test_forward_impl_preserves_original_input_for_shared_experts(monkeypatch):

--- a/vllm_ascend/ops/fused_moe/fused_moe.py
+++ b/vllm_ascend/ops/fused_moe/fused_moe.py
@@ -80,6 +80,7 @@ class FusedMoEResult:
 class FusedMoEEvents:
     before_routed_experts: torch.npu.Event
     after_routed_experts: torch.npu.Event | None = field(default=None)
+    shared_input_ready: torch.npu.Event | None = field(default=None)
     before_dispatch: torch.npu.Event | None = field(default=None)
     before_gmm2: torch.npu.Event | None = field(default=None)
     before_combine: torch.npu.Event | None = field(default=None)
@@ -830,9 +831,22 @@ class AscendMoERunner(MoERunner):  # type: ignore[no-redef]
 
         with npu_stream_switch(shared_experts_calculation_stream(), enabled=self.multistream_overlap_shared_expert):
             # FlashComm1 switches the token axis between complete TP blocks.
-            # Gather the sequence shard before entering a TP-sharded shared MLP.
-            torch.npu.current_stream().wait_event(fused_moe_evts.before_routed_experts)
-            hidden_states = self._prepare_shared_expert_input(hidden_states)
+            # The sequence-shard all-gather for the TP-sharded shared MLP runs
+            # on the DEFAULT stream (see shared_forward_impl) before the routed
+            # path is enqueued: issuing a TP-group collective here would run it
+            # concurrently with the routed path's EP-group collectives and can
+            # deadlock HCCL under multistream overlap. Wait for it before
+            # consuming the gathered input.
+            # shared_input_ready is unconditionally recorded by shared_forward_impl
+            # whenever shared experts run (the only caller), so there is deliberately
+            # no fallback: a missing event would mean the gather never ran, and
+            # waiting on before_routed_experts instead would silently consume
+            # ungathered sequence shards.
+            assert fused_moe_evts.shared_input_ready is not None, (
+                "shared_input_ready is None: the shared-expert input all-gather was "
+                "not issued on the default stream (see shared_forward_impl)"
+            )
+            torch.npu.current_stream().wait_event(fused_moe_evts.shared_input_ready)
 
             # Only used for int quantization
             has_quantized_shared = hasattr(self._shared_experts.gate_up_proj, "weight_scale") and hasattr(
@@ -972,6 +986,15 @@ class AscendMoERunner(MoERunner):  # type: ignore[no-redef]
             before_routed_experts = torch.npu.current_stream().record_event()
             after_routed_experts = None
 
+        # FlashComm1 + TP-sharded shared experts (sed_dp=false): gather the
+        # full sequence for the shared MLP on the DEFAULT stream, BEFORE the
+        # routed path is enqueued, so all collectives stay on one stream
+        # (multistream-safe); the shared-experts stream remains compute-only.
+        shared_input_ready = None
+        if self._shared_experts is not None:
+            shared_hidden_states = self._prepare_shared_expert_input(shared_hidden_states)
+            shared_input_ready = torch.npu.current_stream().record_event()
+
         fused_moe_results = self.no_shared_forward_impl(
             hidden_states,
             router_logits,
@@ -987,6 +1010,7 @@ class AscendMoERunner(MoERunner):  # type: ignore[no-redef]
             FusedMoEEvents(
                 after_routed_experts=after_routed_experts,
                 before_routed_experts=before_routed_experts,
+                shared_input_ready=shared_input_ready,
                 before_dispatch=fused_moe_results.before_dispatch_evt,
                 before_gmm2=fused_moe_results.before_gmm2_evt,
                 before_combine=fused_moe_results.before_combine_evt,


### PR DESCRIPTION
### What this PR does / why we need it?
Fixes a deterministic startup deadlock in the combination `enable_flashcomm1=true` + `enable_shared_expert_dp=false` + `multistream_overlap_shared_expert=true`: the engine hangs in the memory-profiling dummy run (~10 min watchdog), then dies with

```
RuntimeError: ... current working operator name is aclnnGroupedMatmulWeightNz.
EE9999: rtStreamSynchronizeWithTimeout execution failed, reason=task timeout
[Rank N] HCCL watchdog thread terminated with exception
```

**Root cause:** with FlashComm1 SP semantics and TP-sharded shared experts, `_forward_shared_experts` issued the shared-expert input all-gather (`_prepare_shared_expert_input`) on the **shared-experts compute stream**, while the routed path's EP-group collectives run concurrently on the default stream. Cross-group HCCL collectives from two streams with nondeterministic per-rank progress deadlock on shared links.

**Fix:** move the all-gather onto the **default stream**, before the routed path is enqueued, and hand the result to the shared-experts stream via a new `FusedMoEEvents.shared_input_ready` event. The shared-experts stream goes back to being compute-only (the design invariant everywhere else); its matmuls still overlap with the routed a2a/grouped-GEMM, so the multistream win is preserved.
### Does this PR introduce _any_ user-facing change?

### How was this patch tested?

- New/updated UTs: `tests/ut/ops/test_fused_moe.py` (the three situ-path tests now pass `shared_input_ready`; the ops/310P runner-contract tests mock `_prepare_shared_expert_input` and assert the default-stream gather handoff; a new `test_forward_shared_experts_requires_shared_input_ready_event` pins the deliberate no-fallback assert). A full `tests/ut/ops` + 310P shared-MoE run shows the same failure set as the unpatched `releases/v0.26.0rc` baseline, i.e. no UT regressions from this patch.
- End-to-end: the previously deadlocking configuration (`enable_flashcomm1=true` + `enable_shared_expert_dp=false` + `multistream_overlap_shared_expert=true`) boots a 4-node TP16/DP4/EP64 Kimi-K3 deployment with all DP ranks up (no HCCL watchdog hang, FULL_DECODE_ONLY cudagraph capture 8/8) and serves the serving benchmark + accuracy evaluation suite.

### Scope note: short-term narrow fix, long-term direction

This is a deliberately narrow fix to keep `fc1=true + shared_expert_dp=false + multistream_overlap_shared_expert=true` usable on this release branch. Two upstream movements affect its lifetime:

- vllm-ascend #15352 reworks the multistream event plumbing into `RoutedMoEMilestones`; once it lands, the `FusedMoEEvents` handoff used here (including the new `shared_input_ready`) should be migrated/reclaimed accordingly.

Rebase conflicts with the community direction are expected and accepted for the lifetime of this release branch; the fix is intended to be folded into the #15352 event model when that lands.

(Review update: the shared-experts stream now asserts `shared_input_ready` is present instead of falling back to `before_routed_experts` — the sole caller always records it, and the fallback would silently consume ungathered input if ever hit.)

- vLLM main: https://github.com/vllm-project/vllm/commit/d02df748bf9efd99022f1a062597dc3cb3808485
