### PR TITLE
[Performance][Ops] fuse residual add and layernorm into the Kimi K3 attention-residual triton kernel

### DIFF
--- a/tests/e2e/nightly/single_node/ops/singlecard_ops/triton/test_kimi_k3_fusions.py
+++ b/tests/e2e/nightly/single_node/ops/singlecard_ops/triton/test_kimi_k3_fusions.py
@@ -59,3 +59,50 @@ def test_kimi_k3_attention_residual_triton_matches_reference():
     expected = torch.matmul(probabilities, values).squeeze(1).to(prefix_sum.dtype)
 
     torch.testing.assert_close(actual.cpu(), expected.cpu(), rtol=1e-2, atol=1e-2)
+
+
+@torch.inference_mode()
+def test_kimi_k3_attention_residual_fused_add_and_norm_matches_reference():
+    torch.manual_seed(2)
+    num_tokens = 8
+    hidden_size = 7168
+    num_blocks = 4
+    eps = 1e-6
+    prefix_sum = torch.randn((num_tokens, hidden_size), dtype=torch.bfloat16, device="npu")
+    addend = torch.randn((num_tokens, hidden_size), dtype=torch.bfloat16, device="npu")
+    block_residual = torch.randn(
+        (num_tokens, num_blocks, hidden_size),
+        dtype=torch.bfloat16,
+        device="npu",
+    )
+    projection = SimpleNamespace(weight=torch.randn((1, hidden_size), dtype=torch.bfloat16, device="npu"))
+    norm = SimpleNamespace(weight=torch.randn((hidden_size,), dtype=torch.bfloat16, device="npu"), variance_epsilon=eps)
+    out_norm = SimpleNamespace(
+        weight=torch.randn((hidden_size,), dtype=torch.bfloat16, device="npu"),
+        variance_epsilon=eps,
+    )
+    sum_out = torch.empty_like(prefix_sum)
+
+    actual = apply_attn_res(
+        prefix_sum,
+        block_residual,
+        projection,
+        norm,
+        addend=addend,
+        sum_out=sum_out,
+        out_norm=out_norm,
+    )
+
+    prefix_sum_ref = prefix_sum + addend
+    values = torch.cat((block_residual, prefix_sum_ref.unsqueeze(1)), dim=1).float()
+    normalized = values * torch.rsqrt(values.square().mean(dim=-1, keepdim=True) + eps)
+    score_weight = norm.weight.float() * projection.weight.squeeze(0).float()
+    scores = (normalized * score_weight).sum(dim=-1)
+    probabilities = scores.softmax(-1).unsqueeze(1)
+    mixed = torch.matmul(probabilities, values).squeeze(1)
+    expected = (
+        mixed * torch.rsqrt(mixed.square().mean(dim=-1, keepdim=True) + eps) * out_norm.weight.float()
+    ).to(prefix_sum.dtype)
+
+    torch.testing.assert_close(sum_out.cpu(), prefix_sum_ref.cpu())
+    torch.testing.assert_close(actual.cpu(), expected.cpu(), rtol=1e-2, atol=1e-2)

--- a/vllm_ascend/models/kimi_k3.py
+++ b/vllm_ascend/models/kimi_k3.py
@@ -912,10 +912,39 @@ def _apply_attention_residual(
     block_residual: torch.Tensor,
     projection: nn.Module,
     norm: RMSNorm,
+    *,
+    addend: torch.Tensor | None = None,
+    sum_out: torch.Tensor | None = None,
+    out_norm: RMSNorm | None = None,
 ) -> torch.Tensor:
-    """Apply K3's learned normalized mixture over residual block starts."""
-    if apply_attn_res is not None and prefix_sum.device.type == "npu" and prefix_sum.numel() > 0:
-        mixed = apply_attn_res(prefix_sum, block_residual, projection, norm)
+    """Apply K3's learned normalized mixture over residual block starts.
+
+    When ``addend`` is given the residual sum ``prefix_sum + addend`` is folded
+    into the fused kernel and written to ``sum_out`` (allocated here if not
+    supplied; materialized with a plain add on the fallback path).  When
+    ``out_norm`` is given it is applied to the mixture in-kernel, replacing the
+    following standalone layernorm launch.
+    """
+    fused = apply_attn_res is not None and prefix_sum.device.type == "npu" and prefix_sum.numel() > 0
+    if addend is not None:
+        if fused:
+            if sum_out is None:
+                sum_out = torch.empty_like(addend)
+        else:
+            if sum_out is None:
+                prefix_sum = prefix_sum + addend
+            else:
+                prefix_sum = torch.add(prefix_sum, addend, out=sum_out)
+    if fused:
+        mixed = apply_attn_res(
+            prefix_sum,
+            block_residual,
+            projection,
+            norm,
+            addend=addend,
+            sum_out=sum_out if addend is not None else None,
+            out_norm=out_norm,
+        )
     else:
         values = torch.cat((block_residual, prefix_sum.unsqueeze(1)), dim=1)
         values_fp32 = values.float()
@@ -927,6 +956,8 @@ def _apply_attention_residual(
         scores = torch.matmul(normalized, projection.weight.t().float()).squeeze(-1)
         probabilities = scores.softmax(-1).unsqueeze(1)
         mixed = torch.matmul(probabilities, values_fp32).squeeze(1).to(values.dtype)
+        if out_norm is not None:
+            mixed = out_norm(mixed)
     if _EXTRA_CTX.flash_comm_v1_enabled:
         # FlashComm changes the first decoder layer from the global token
         # layout to a TP-local layout.  The learned-residual arithmetic above
@@ -1028,14 +1059,16 @@ class KimiK3DecoderLayer(nn.Module):
                 block_residual,
                 self.self_attention_res_proj,
                 self.self_attention_res_norm,
+                out_norm=self.input_layernorm,
             )
+        else:
+            hidden_states = self.input_layernorm(hidden_states)
 
         if self.layer_idx % self.attn_res_block_size == 0:
             assert prefix_sum is not None
             block_residual = torch.cat((block_residual, prefix_sum.unsqueeze(1)), dim=1)
             prefix_sum = None
 
-        hidden_states = self.input_layernorm(hidden_states)
         if self.is_vl_first_layer and _EXTRA_CTX.flash_comm_v1_enabled:
             tp_size = get_tensor_model_parallel_world_size()
             num_local_tokens = hidden_states.shape[0] // tp_size
@@ -1057,15 +1090,30 @@ class KimiK3DecoderLayer(nn.Module):
                 attention_output.unsqueeze(1),
                 block_residual,
             )
-        prefix_sum = attention_output if prefix_sum is None else prefix_sum + attention_output
-
-        hidden_states = _apply_attention_residual(
-            prefix_sum,
-            block_residual,
-            self.mlp_res_proj,
-            self.mlp_res_norm,
-        )
-        hidden_states = self.post_attention_layernorm(hidden_states)
+        if prefix_sum is None:
+            prefix_sum = attention_output
+            hidden_states = _apply_attention_residual(
+                prefix_sum,
+                block_residual,
+                self.mlp_res_proj,
+                self.mlp_res_norm,
+                out_norm=self.post_attention_layernorm,
+            )
+        else:
+            # Fold the residual add into the fused kernel; it writes the
+            # materialized sum (still needed for the final layer add below)
+            # into sum_out.
+            sum_out = torch.empty_like(attention_output)
+            hidden_states = _apply_attention_residual(
+                prefix_sum,
+                block_residual,
+                self.mlp_res_proj,
+                self.mlp_res_norm,
+                addend=attention_output,
+                sum_out=sum_out,
+                out_norm=self.post_attention_layernorm,
+            )
+            prefix_sum = sum_out
         if hasattr(self, "block_sparse_moe"):
             hidden_states = self.block_sparse_moe(hidden_states)
         else:

--- a/vllm_ascend/ops/triton/kimi_k3/attention_residual.py
+++ b/vllm_ascend/ops/triton/kimi_k3/attention_residual.py
@@ -14,15 +14,22 @@ from vllm_ascend.ops.triton.triton_utils import get_vectorcore_num, init_device_
 def _apply_attn_res_kernel(
     block_residual_ptr,
     prefix_sum_ptr,
+    addend_ptr,
+    sum_out_ptr,
     norm_w_ptr,
     proj_w_ptr,
+    out_norm_w_ptr,
     out_ptr,
     N,
     H: tl.constexpr,
     B,
     EPS: tl.constexpr,
+    OUT_EPS: tl.constexpr,
     NUM_CORES: tl.constexpr,
     NB: tl.constexpr,
+    ADD: tl.constexpr,
+    WRITE_SUM: tl.constexpr,
+    OUT_NORM: tl.constexpr,
 ):
     block_size = (N - 1) // NUM_CORES + 1
     pid = tl.program_id(0)
@@ -37,16 +44,32 @@ def _apply_attn_res_kernel(
     norm_w = tl.load(norm_w_ptr + cols).to(tl.float32)
     proj_w = tl.load(proj_w_ptr + cols).to(tl.float32)
     w = norm_w * proj_w
+    if OUT_NORM:
+        out_norm_w = tl.load(out_norm_w_ptr + cols).to(tl.float32)
 
     br_stride = B * H
 
     for tok in range(tok0, tok1):
+        if WRITE_SUM:
+            va = tl.load(prefix_sum_ptr + tok * H + cols).to(tl.float32)
+            vb = tl.load(addend_ptr + tok * H + cols).to(tl.float32)
+            tl.store(
+                sum_out_ptr + tok * H + cols,
+                (va + vb).to(sum_out_ptr.dtype.element_ty),
+            )
         scores = tl.full([NB], -float("inf"), dtype=tl.float32)
         for s in range(B + 1):
             if s < B:
                 v = tl.load(block_residual_ptr + tok * br_stride + s * H + cols).to(tl.float32)
             else:
-                v = tl.load(prefix_sum_ptr + tok * H + cols).to(tl.float32)
+                if ADD:
+                    va = tl.load(prefix_sum_ptr + tok * H + cols).to(tl.float32)
+                    vb = tl.load(addend_ptr + tok * H + cols).to(tl.float32)
+                    # Round once to the storage dtype so the fused sum matches
+                    # the standalone aclnnAdd bf16 result bit-for-bit.
+                    v = (va + vb).to(sum_out_ptr.dtype.element_ty).to(tl.float32)
+                else:
+                    v = tl.load(prefix_sum_ptr + tok * H + cols).to(tl.float32)
             ms = tl.sum(v * v) / H
             rstd = tl.rsqrt(ms + EPS)
             k = v * rstd
@@ -61,9 +84,19 @@ def _apply_attn_res_kernel(
             if s < B:
                 v = tl.load(block_residual_ptr + tok * br_stride + s * H + cols).to(tl.float32)
             else:
-                v = tl.load(prefix_sum_ptr + tok * H + cols).to(tl.float32)
+                if ADD:
+                    va = tl.load(prefix_sum_ptr + tok * H + cols).to(tl.float32)
+                    vb = tl.load(addend_ptr + tok * H + cols).to(tl.float32)
+                    v = (va + vb).to(sum_out_ptr.dtype.element_ty).to(tl.float32)
+                else:
+                    v = tl.load(prefix_sum_ptr + tok * H + cols).to(tl.float32)
             w_s = tl.sum(tl.where(s_idx == s, weights, 0.0))
             out += w_s * v
+
+        if OUT_NORM:
+            out_ms = tl.sum(out * out) / H
+            out_rstd = tl.rsqrt(out_ms + OUT_EPS)
+            out = out * out_rstd * out_norm_w
 
         tl.store(out_ptr + tok * H + cols, out.to(out_ptr.dtype.element_ty))
 
@@ -73,8 +106,18 @@ def apply_attn_res(
     block_residual: torch.Tensor,
     proj: torch.nn.Module,
     norm: torch.nn.Module,
+    *,
+    addend: torch.Tensor | None = None,
+    sum_out: torch.Tensor | None = None,
+    out_norm: torch.nn.Module | None = None,
 ) -> torch.Tensor:
-    """Return K3's learned softmax mixture of residual streams."""
+    """Return K3's learned softmax mixture of residual streams.
+
+    ``addend``/``sum_out`` fold ``prefix_sum + addend`` into the kernel: the
+    mixture reads the sum directly and the rounded sum is written to
+    ``sum_out``.  ``out_norm`` (an RMSNorm module) is applied to the mixture
+    output in-kernel, replacing the following standalone RmsNorm launch.
+    """
     num_tokens, hidden_size = prefix_sum.shape
     num_blocks = block_residual.shape[1]
     proj_w = proj.weight.squeeze(0)
@@ -92,15 +135,22 @@ def apply_attn_res(
     _apply_attn_res_kernel[(num_vectorcore,)](
         block_residual,
         prefix_sum,
+        addend if addend is not None else prefix_sum,
+        sum_out if sum_out is not None else prefix_sum,
         norm_w,
         proj_w,
+        out_norm.weight if out_norm is not None else norm_w,
         out,
         N=num_tokens,
         H=hidden_size,
         B=num_blocks,
         EPS=eps,
+        OUT_EPS=out_norm.variance_epsilon if out_norm is not None else eps,
         NUM_CORES=num_vectorcore,
         NB=num_streams,
+        ADD=addend is not None,
+        WRITE_SUM=sum_out is not None,
+        OUT_NORM=out_norm is not None,
         multibuffer=True,
     )
     return out

--- a/vllm_ascend/ops/triton/kimi_k3/attention_residual.py
+++ b/vllm_ascend/ops/triton/kimi_k3/attention_residual.py
@@ -1,7 +1,15 @@
-"""Fused Kimi K3 attention-residual mixture.
+"""Fused Kimi K3 attention-residual mixture (v2: UB-optimized).
 
 This is the supplied Kimi K3 implementation, adapted only to use the
 vLLM-Ascend Triton device-property helper.
+
+v2 changes vs v1 (UB overflow fix, requires 3211776 bits vs 1572864 available):
+- ADD path reloads the rounded sum from sum_out (stored by WRITE_SUM at the
+  top of the same iteration) instead of holding va/vb f32 rows live through
+  both stream loops.  Bit-identical to v1: same rounded bf16 value.
+- out_norm_w is loaded at its use site instead of staying live across the
+  stream loops.
+- wrapper pins num_warps=32 so the JIT path matches the inductor AOT default.
 """
 
 import torch
@@ -44,8 +52,6 @@ def _apply_attn_res_kernel(
     norm_w = tl.load(norm_w_ptr + cols).to(tl.float32)
     proj_w = tl.load(proj_w_ptr + cols).to(tl.float32)
     w = norm_w * proj_w
-    if OUT_NORM:
-        out_norm_w = tl.load(out_norm_w_ptr + cols).to(tl.float32)
 
     br_stride = B * H
 
@@ -63,11 +69,15 @@ def _apply_attn_res_kernel(
                 v = tl.load(block_residual_ptr + tok * br_stride + s * H + cols).to(tl.float32)
             else:
                 if ADD:
-                    va = tl.load(prefix_sum_ptr + tok * H + cols).to(tl.float32)
-                    vb = tl.load(addend_ptr + tok * H + cols).to(tl.float32)
-                    # Round once to the storage dtype so the fused sum matches
-                    # the standalone aclnnAdd bf16 result bit-for-bit.
-                    v = (va + vb).to(sum_out_ptr.dtype.element_ty).to(tl.float32)
+                    if WRITE_SUM:
+                        # The rounded sum is already in sum_out from this
+                        # iteration's store; reload it instead of keeping
+                        # va/vb rows live through the stream loops.
+                        v = tl.load(sum_out_ptr + tok * H + cols).to(tl.float32)
+                    else:
+                        va = tl.load(prefix_sum_ptr + tok * H + cols).to(tl.float32)
+                        vb = tl.load(addend_ptr + tok * H + cols).to(tl.float32)
+                        v = (va + vb).to(sum_out_ptr.dtype.element_ty).to(tl.float32)
                 else:
                     v = tl.load(prefix_sum_ptr + tok * H + cols).to(tl.float32)
             ms = tl.sum(v * v) / H
@@ -85,15 +95,21 @@ def _apply_attn_res_kernel(
                 v = tl.load(block_residual_ptr + tok * br_stride + s * H + cols).to(tl.float32)
             else:
                 if ADD:
-                    va = tl.load(prefix_sum_ptr + tok * H + cols).to(tl.float32)
-                    vb = tl.load(addend_ptr + tok * H + cols).to(tl.float32)
-                    v = (va + vb).to(sum_out_ptr.dtype.element_ty).to(tl.float32)
+                    if WRITE_SUM:
+                        v = tl.load(sum_out_ptr + tok * H + cols).to(tl.float32)
+                    else:
+                        va = tl.load(prefix_sum_ptr + tok * H + cols).to(tl.float32)
+                        vb = tl.load(addend_ptr + tok * H + cols).to(tl.float32)
+                        v = (va + vb).to(sum_out_ptr.dtype.element_ty).to(tl.float32)
                 else:
                     v = tl.load(prefix_sum_ptr + tok * H + cols).to(tl.float32)
             w_s = tl.sum(tl.where(s_idx == s, weights, 0.0))
             out += w_s * v
 
         if OUT_NORM:
+            # Loaded at the use site so it does not stay live across the
+            # stream loops (UB pressure).
+            out_norm_w = tl.load(out_norm_w_ptr + cols).to(tl.float32)
             out_ms = tl.sum(out * out) / H
             out_rstd = tl.rsqrt(out_ms + OUT_EPS)
             out = out * out_rstd * out_norm_w
@@ -152,5 +168,6 @@ def apply_attn_res(
         WRITE_SUM=sum_out is not None,
         OUT_NORM=out_norm is not None,
         multibuffer=True,
+        num_warps=32,
     )
     return out


### PR DESCRIPTION
### What this PR does / why we need it?
very Kimi K3 decoder layer runs a fixed three-kernel AIV chain twice around its learned attention-residual mixture:

```
aclnnAdd (prefix_sum + attention_output) → _apply_attn_res_kernel → RmsNorm (input/post_attention_layernorm)
```

All three operate on the same `[num_tokens, hidden]` tensor, back to back. The Add and RmsNorm are pure memory round-trips around a kernel that already holds each token's full row in registers — the mixture output is consumed *only* by the following layernorm.

**Decode profiling** (rank0 `kernel_details.csv`, 14-layer validation model, TP16/DP1, 639 decode steps):

| kernel | count | total |
|--------|-------|-------|
| aclnnAdd(8,7168) | 23004 | 143.9 ms |
| RmsNorm(8,7168) | 16583 | 81.5 ms |

This PR folds both into the existing triton kernel, removing **4 standalone AIV kernel launches per layer per decode step**:

- **~24.5 us saved per layer per decode step** (2 × Add 6.3us + 2 × RmsNorm 5.0us, plus launch gaps)
- **~350 us per decode step** on the 14-layer validation model (~1.4% of kernel time)
- **~1.6 ms per decode step** extrapolated to the full ~92-layer model

Implementation: the kernel gains three optional constexpr stages — `ADD` (compute `prefix_sum + addend` in-kernel, rounded once to the storage dtype so it matches the standalone `aclnnAdd` result bit-for-bit; the sum is still materialized to `sum_out` for the layer's final residual add), `WRITE_SUM`, and `OUT_NORM` (apply the following RMSNorm to the mixture row already in registers). `kimi_k3.py` wires both layernorms and the residual add through the new kwargs; the positional signature and return type of `apply_attn_res` / `_apply_attention_residual` are unchanged, and the CPU fallback expands to the original standalone ops. Block-boundary layers keep the plain layernorm path.
### Does this PR introduce _any_ user-facing change?

### How was this patch tested?

- vLLM main: https://github.com/vllm-project/vllm/commit/d02df748bf9efd99022f1a062597dc3cb3808485
