### PR TITLE
 [v0.26.0][Performance][Communicator] Replace per-layer F.pad with cat of a persistent zero block in MoE prepare

### DIFF
--- a/tests/ut/ops/test_prepare_finalize.py
+++ b/tests/ut/ops/test_prepare_finalize.py
@@ -2,6 +2,7 @@ import unittest
 from unittest.mock import MagicMock, patch
 
 import torch
+from vllm.config import set_current_vllm_config
 from vllm.model_executor.layers.fused_moe import FusedMoEConfig
 
 from vllm_ascend.ops.fused_moe.prepare_finalize import (
@@ -29,6 +30,14 @@ class TestPrepareAndFinalize(unittest.TestCase):
         self.moe_config.ep_size = 1
         self.moe_config.dp_group = MagicMock()
         self.moe_config.original_num_experts = 8
+        # Provide a current vllm config so the MoE pad helper takes its
+        # zero-block cat path (tp_size=1 covers every pad in these tests)
+        # instead of falling back to F.pad outside a worker context.
+        mock_vllm_config = MagicMock()
+        mock_vllm_config.parallel_config.tensor_parallel_size = 1
+        config_context = set_current_vllm_config(mock_vllm_config)
+        config_context.__enter__()
+        self.addCleanup(config_context.__exit__, None, None, None)
 
     @patch("vllm_ascend.ops.fused_moe.prepare_finalize.get_tensor_model_parallel_world_size", return_value=1)
     @patch("vllm_ascend.ops.fused_moe.prepare_finalize.get_tensor_model_parallel_rank", return_value=0)

--- a/vllm_ascend/ops/fused_moe/comm_utils.py
+++ b/vllm_ascend/ops/fused_moe/comm_utils.py
@@ -22,7 +22,7 @@ import torch.distributed
 import torch.distributed as dist
 import torch.nn as nn
 import torch_npu
-from vllm.config import get_current_vllm_config
+from vllm.config import get_current_vllm_config_or_none
 
 from vllm_ascend.quantization.quant_type import QuantType
 
@@ -162,6 +162,10 @@ def _get_cann_mega_moe_quant_settings(quant_type: QuantType) -> tuple[int, int |
 # serves every pad and is allocated exactly once — never replaced or freed,
 # which is what makes it safe for captured graphs to reference.
 #
+# Outside a worker context there is no current vllm config (e.g. unit tests
+# calling prepare() directly): tp_size then reads as 0 and every pad takes
+# the F.pad fallback below.
+#
 # A pad wider than tp_size can only happen outside that invariant (e.g. an
 # eager call with zero tokens); it falls back to plain `nn.functional.pad`
 # instead of growing the entry, keeping the cache static.
@@ -179,7 +183,8 @@ def _pad_tokens_with_cat(x: torch.Tensor, padded_len: int) -> torch.Tensor:
     a slice of a cached zero block: value-equivalent to
     `F.pad(x, (0, 0, 0, padded_len - n))` at one kernel instead of two."""
     pad_rows = padded_len - x.shape[0]
-    tp_size = get_current_vllm_config().parallel_config.tensor_parallel_size
+    vllm_config = get_current_vllm_config_or_none()
+    tp_size = vllm_config.parallel_config.tensor_parallel_size if vllm_config is not None else 0
     if pad_rows > tp_size:
         return nn.functional.pad(x, (0, 0, 0, pad_rows))
     key = (*x.shape[1:], x.dtype, str(x.device))

--- a/vllm_ascend/ops/fused_moe/comm_utils.py
+++ b/vllm_ascend/ops/fused_moe/comm_utils.py
@@ -183,6 +183,7 @@ def _pad_tokens_with_cat(x: torch.Tensor, padded_len: int) -> torch.Tensor:
     a slice of a cached zero block: value-equivalent to
     `F.pad(x, (0, 0, 0, padded_len - n))` at one kernel instead of two."""
     pad_rows = padded_len - x.shape[0]
+    assert pad_rows >= 0, f"padded_len ({padded_len}) is smaller than the input's token dim ({x.shape[0]})"
     vllm_config = get_current_vllm_config_or_none()
     tp_size = vllm_config.parallel_config.tensor_parallel_size if vllm_config is not None else 0
     if pad_rows > tp_size:

--- a/vllm_ascend/ops/fused_moe/comm_utils.py
+++ b/vllm_ascend/ops/fused_moe/comm_utils.py
@@ -20,7 +20,9 @@ from importlib import import_module
 import torch
 import torch.distributed
 import torch.distributed as dist
+import torch.nn as nn
 import torch_npu
+from vllm.config import get_current_vllm_config
 
 from vllm_ascend.quantization.quant_type import QuantType
 
@@ -141,3 +143,48 @@ def _get_cann_mega_moe_quant_settings(quant_type: QuantType) -> tuple[int, int |
     raise RuntimeError(
         f"MegaMoe integration supports W8A8/W4A8/BF16 on A2/A3 MegaMoe platforms. Unsupported quant type: {quant_type}."
     )
+
+
+# Token-dim padding via `torch.cat` with a persistent zero block, replacing
+# `nn.functional.pad` in the MoE prepare paths. On NPU each `F.pad` lowers to
+# two device kernels (a full-output MemSet plus a PadV3 copy) while the padded
+# data is only a few KB in decode, so the pair is pure launch overhead
+# (~44us per MoE layer in a Kimi K3 TP16 decode profile). The cat variant is
+# one ConcatD kernel per tensor and is safe under cudagraph replay: the cat
+# output is a fresh tensor per call (each captured graph owns its output
+# buffer), and the zero block is never written after allocation, so the
+# zero-tail property is structural — no cross-call bookkeeping.
+
+# (width..., dtype, device) -> zero block of [tp_size, width...]. Both MoE
+# prepare paths pad to a multiple of tp_size by fewer than tp_size rows (MC2
+# pads the local token count up to the DP-uniform padded_num_tokens; All2All
+# pads up to exactly tp_size), so one tp_size-row block per tensor width
+# serves every pad and is allocated exactly once — never replaced or freed,
+# which is what makes it safe for captured graphs to reference.
+#
+# A pad wider than tp_size can only happen outside that invariant (e.g. an
+# eager call with zero tokens); it falls back to plain `nn.functional.pad`
+# instead of growing the entry, keeping the cache static.
+#
+# Memory footprint: the key drops the token dim, so the cache holds one entry
+# per distinct (trailing shape, dtype, device) — a set fixed by the model
+# config, independent of batch size and cudagraph capture sizes (two entries
+# for Kimi K3 TP16: hidden 3584, experts 896), each tp_size * width *
+# dtype.itemsize bytes, so the whole cache peaks at O(0.1) MB.
+_PAD_ZERO_BLOCKS: dict[tuple, torch.Tensor] = {}
+
+
+def _pad_tokens_with_cat(x: torch.Tensor, padded_len: int) -> torch.Tensor:
+    """Token-dim padding of `x` ([n, ...] -> [padded_len, ...]) by concatenating
+    a slice of a cached zero block: value-equivalent to
+    `F.pad(x, (0, 0, 0, padded_len - n))` at one kernel instead of two."""
+    pad_rows = padded_len - x.shape[0]
+    tp_size = get_current_vllm_config().parallel_config.tensor_parallel_size
+    if pad_rows > tp_size:
+        return nn.functional.pad(x, (0, 0, 0, pad_rows))
+    key = (*x.shape[1:], x.dtype, str(x.device))
+    zero_block = _PAD_ZERO_BLOCKS.get(key)
+    if zero_block is None:
+        zero_block = torch.zeros((tp_size, *x.shape[1:]), dtype=x.dtype, device=x.device)
+        _PAD_ZERO_BLOCKS[key] = zero_block
+    return torch.cat([x, zero_block[:pad_rows]], dim=0)

--- a/vllm_ascend/ops/fused_moe/prepare_finalize.py
+++ b/vllm_ascend/ops/fused_moe/prepare_finalize.py
@@ -31,6 +31,7 @@ from vllm.model_executor.layers.fused_moe import FusedMoEConfig
 
 from vllm_ascend.ascend_forward_context import _EXTRA_CTX
 from vllm_ascend.lora.fused_moe import prepare_lora_indices
+from vllm_ascend.ops.fused_moe.comm_utils import _pad_tokens_with_cat
 from vllm_ascend.ops.fused_moe.moe_runtime_args import MoEPrepareOutput
 from vllm_ascend.quantization.quant_type import QuantType
 from vllm_ascend.utils import enable_sp, enable_sp_by_pass
@@ -164,8 +165,8 @@ class PrepareAndFinalizeWithAll2All(PrepareAndFinalize):
                 )
 
             if pad_size > 0:
-                hidden_states = nn.functional.pad(hidden_states, (0, 0, 0, pad_size))
-                router_logits = nn.functional.pad(router_logits, (0, 0, 0, pad_size))
+                hidden_states = _pad_tokens_with_cat(hidden_states, self.num_tokens + pad_size)
+                router_logits = _pad_tokens_with_cat(router_logits, self.num_tokens + pad_size)
                 padded_hidden_states_shape = hidden_states.shape
 
             if self.tp_size > 1:
@@ -287,8 +288,8 @@ class PrepareAndFinalizeWithMC2(PrepareAndFinalizeWithAll2All):
             pad_size = target_pad_length - self.num_tokens
 
             if pad_size > 0:
-                hidden_states = nn.functional.pad(hidden_states, (0, 0, 0, pad_size))
-                router_logits = nn.functional.pad(router_logits, (0, 0, 0, pad_size))
+                hidden_states = _pad_tokens_with_cat(hidden_states, target_pad_length)
+                router_logits = _pad_tokens_with_cat(router_logits, target_pad_length)
                 padded_hidden_states_shape = hidden_states.shape
 
             # Slice across TP ranks


### PR DESCRIPTION
### What this PR does / why we need it?

`PrepareAndFinalizeWithMC2.prepare()` (and the identical site in `PrepareAndFinalizeWithAll2All`) pads `hidden_states` and `router_logits` to `padded_num_tokens` with `nn.functional.pad` on **every MoE layer, every step**, before the TP-split that feeds `MoeDistributeDispatchV2` (which requires a uniform token count across ranks). On NPU each `F.pad` lowers to two device kernels (`constant_pad_nd` → MemSet + PadV3) while the padded data is only a few KB in decode, so the four launches are pure overhead: ~44 us per MoE layer (~5.6% of a decode layer's kernel time in a Kimi K3 TP16 profile). With speculative decoding (`num_speculative_tokens=7`, minimum graph tier of 8 tokens), odd batch sizes always pad 8 rows to 16 and hit this path. The padded rows are dead data (dropped via `x_active_mask` in dispatch/combine and sliced off in finalize) — only the shape matters, so the padding can be made cheap.

This PR replaces both pads with `torch.cat([x, zero_block[:pad]], dim=0)` against a cached per-`(width, dtype)` zero block that is never written after allocation:

- one ConcatD kernel per tensor instead of MemSet + PadV3 (2 kernels per layer instead of 4);
- value-equivalent to `F.pad` — the zero tail is structural, not maintained by any cross-call bookkeeping;
- cudagraph-replay-safe by construction: the cat output is a fresh tensor per call, so each captured graph owns its output buffer and no mutable state is shared across capture sizes (a copy-into-persistent-buffer scheme breaks its zero-tail invariant when graphs of different sizes alternate at replay, and was rejected for that reason);
- covers eager and any capture size; applies to both MC2 and All2All paths.

### Does this PR introduce _any_ user-facing change?

### How was this patch tested?


- vLLM main: https://github.com/vllm-project/vllm/commit/d02df748bf9efd99022f1a062597dc3cb3808485
