### PR TITLE
[Doc] Update installation links in GLM5.3 tutorial

### DIFF
--- a/docs/source/tutorials/models/GLM5.3.md
+++ b/docs/source/tutorials/models/GLM5.3.md
@@ -31,7 +31,7 @@ It is recommended to download the model weight to the shared directory of multip
 
 ### 3.2 Verify Multi-node Communication (Optional)
 
-If you want to deploy multi-node environment, you need to verify multi-node communication according to [verify multi-node communication environment](../../installation.md#verify-multi-node-communication).
+If you want to deploy multi-node environment, you need to verify multi-node communication according to [verify multi-node communication environment](../../getting_started/installation.md#installation-multi-node-interconnect).
 
 ## 4 Installation
 
@@ -121,7 +121,7 @@ If you want to deploy multi-node environment, you need to set up environment on 
 
 If you don't want to use the docker image as above, you can also build all from source:
 
-- Install `vllm-ascend` from source, refer to [installation](../../installation.md).
+- Install `vllm-ascend` from source, refer to [installation](../../getting_started/installation.md).
 
 ## 5 Online Service Deployment
 
@@ -133,7 +133,7 @@ The deployment scenarios validated for this release are organized by context win
 
 ### 5.1 Multi-node Deployment
 
-If you want to deploy multi-node environment, you need to verify multi-node communication according to [verify multi-node communication environment](../../installation.md#verify-multi-node-communication).
+If you want to deploy multi-node environment, you need to verify multi-node communication according to [verify multi-node communication environment](../../getting_started/installation.md#installation-multi-node-interconnect).
 
 Common Issues Tip: If you encounter issues, Refer to [Public FAQs](../../faqs.md).
 


### PR DESCRIPTION
### What this PR does / why we need it?

Due to the conflict from https://github.com/vllm-project/vllm-ascend/pull/15309 and https://github.com/vllm-project/vllm-ascend/pull/15375, GLM5.3.md needs to update doc links to fix ci.

### Does this PR introduce _any_ user-facing change?

No, it's a documentation-only update.

### How was this patch tested?

Not needed, it's a documentation-only update.

- vLLM main: https://github.com/vllm-project/vllm/commit/ba07e4a48fc951300d97eb506217dd530583dea3
