### PR TITLE
[BugFix][GDN] Skip recurrent state updates for idle DP dummy runs

### DIFF
--- a/tests/ut/worker/test_model_runner_v1.py
+++ b/tests/ut/worker/test_model_runner_v1.py
@@ -1485,7 +1485,10 @@ class TestNPUModelRunnerDebugger(unittest.TestCase):
 
         runner.execute_model(scheduler_output)
 
-        runner._dummy_run.assert_called_once_with(1)
+        runner._dummy_run.assert_called_once_with(
+            1,
+            skip_gdn_state_update=True,
+        )
         runner._start_dump_data.assert_not_called()
 
     @patch("vllm_ascend.worker.model_runner_v1.has_kv_transfer_group", return_value=False)

--- a/vllm_ascend/_310p/model_runner_310p.py
+++ b/vllm_ascend/_310p/model_runner_310p.py
@@ -576,6 +576,7 @@ class NPUModelRunner310(NPUModelRunner):
         is_graph_capturing: bool = False,
         num_active_loras: int = 0,
         profile_seq_lens: int | None = None,
+        skip_gdn_state_update: bool = False,
     ):
         temporary_context = self.temporary_modify_uniform_decode_query_len() if uniform_decode else nullcontext()
         # All the spec decoding cases has to run splitfuse op on 310P.
@@ -602,6 +603,7 @@ class NPUModelRunner310(NPUModelRunner):
                     is_graph_capturing=is_graph_capturing,
                     num_active_loras=num_active_loras,
                     profile_seq_lens=profile_seq_lens,
+                    skip_gdn_state_update=skip_gdn_state_update,
                 )
             finally:
                 self._spec_dummy_capture = False

--- a/vllm_ascend/worker/model_runner_v1.py
+++ b/vllm_ascend/worker/model_runner_v1.py
@@ -2150,7 +2150,7 @@ class NPUModelRunner(GPUModelRunner):
                         # returns True. before returning early here we call
                         # dummy run to ensure coordinate_batch_across_dp
                         # is called into to avoid out of sync issues.
-                        self._dummy_run(1)
+                        self._dummy_run(1, skip_gdn_state_update=True)
                     if not has_kv_transfer_group():
                         # Return empty ModelRunnerOutput if no work to do.
                         return EMPTY_MODEL_RUNNER_OUTPUT
@@ -3125,6 +3125,7 @@ class NPUModelRunner(GPUModelRunner):
         num_scheduled_tokens: dict[str, int] | None = None,
         num_scheduled_tokens_np: np.ndarray | None = None,
         cascade_attn_prefix_lens: list[list[int]] | None = None,
+        skip_gdn_state_update: bool = False,
         cudagraph_runtime_mode: CUDAGraphMode | None = None,
         batch_descriptor: BatchDescriptor | None = None,
     ) -> tuple[PerLayerAttnMetadata, CommonAttentionMetadata | None]:
@@ -3294,6 +3295,36 @@ class NPUModelRunner(GPUModelRunner):
         ) -> None:
             attn_group = self.attn_groups[kv_cache_gid][attn_gid]
             builder = attn_group.get_metadata_builder(ubid or 0)
+            is_gdn_noop = skip_gdn_state_update and isinstance(
+                builder,
+                GDNAttentionMetadataBuilder,
+            )
+            if is_gdn_noop:
+                # Dummy-run callers coalesce this; fall back to the unpadded
+                # batch size instead of asserting in the execute path.
+                gdn_num_reqs = (
+                    num_reqs if num_reqs_padded is None else num_reqs_padded
+                )
+                # Idle DP dummy: keep captured GDN tensor ranks for graph
+                # replay/collectives. num_actual_tokens=0 is the kernel no-op
+                # (ops slice mixed_qkv[:0]); query_start_loc is a zero-filled
+                # prefix sized to the graph, not a real token schedule.
+                common_attn_metadata = replace(
+                    common_attn_metadata,
+                    query_start_loc=self.gdn_query_start_loc.gpu[
+                        : gdn_num_reqs + 1
+                    ],
+                    query_start_loc_cpu=self.gdn_query_start_loc.cpu[
+                        : gdn_num_reqs + 1
+                    ],
+                    num_actual_tokens=0,
+                    max_query_len=0,
+                    is_prefilling=(
+                        torch.zeros_like(common_attn_metadata.is_prefilling)
+                        if common_attn_metadata.is_prefilling is not None
+                        else None
+                    ),
+                )
             device_metadata_provider = (
                 self.device_metadata_providers.get(id(builder))
                 if self.device_metadata_providers is not None
@@ -3304,7 +3335,11 @@ class NPUModelRunner(GPUModelRunner):
             )
 
             extra_attn_metadata_args = {}
-            if use_spec_decode and isinstance(builder, GDNAttentionMetadataBuilder):
+            if (
+                use_spec_decode
+                and isinstance(builder, GDNAttentionMetadataBuilder)
+                and not is_gdn_noop
+            ):
                 assert ubid is None, "UBatching not supported with GDN yet"
                 extra_attn_metadata_args = dict(
                     num_accepted_tokens=self.num_accepted_tokens.gpu[:num_reqs_padded],
@@ -3472,6 +3507,7 @@ class NPUModelRunner(GPUModelRunner):
         num_active_loras: int = 0,
         profile_seq_lens: int | None = None,
         profile_cpp: bool = False,
+        skip_gdn_state_update: bool = False,
     ) -> tuple[torch.Tensor, torch.Tensor]:
         # only support eager mode and piecewise graph now
         assert cudagraph_runtime_mode is None or cudagraph_runtime_mode.valid_runtime_modes()
@@ -3610,7 +3646,12 @@ class NPUModelRunner(GPUModelRunner):
                 self.query_start_loc.np[1 : num_reqs_padded + 1] = cum_num_tokens
                 self.query_start_loc.copy_to_gpu()
                 if self._has_gdn:
-                    self.gdn_query_start_loc.np[1 : num_reqs_padded + 1] = cum_num_tokens
+                    if skip_gdn_state_update:
+                        self.gdn_query_start_loc.np.fill(0)
+                    else:
+                        self.gdn_query_start_loc.np[
+                            1 : num_reqs_padded + 1
+                        ] = cum_num_tokens
                     self.gdn_query_start_loc.copy_to_gpu()
 
                 if not profile_cpp:
@@ -3651,6 +3692,7 @@ class NPUModelRunner(GPUModelRunner):
                     num_scheduled_tokens_np=num_scheduled_tokens,
                     cudagraph_runtime_mode=cudagraph_runtime_mode,
                     batch_descriptor=batch_desc,
+                    skip_gdn_state_update=skip_gdn_state_update,
                 )
         with self.maybe_dummy_run_with_lora(
             self.lora_config,


### PR DESCRIPTION
> Rebased resubmission of #15253 onto current `main` (`f69831343`). The original review fixes are included in this branch.

## What this PR does / why we need it

Data-parallel ranks with no scheduled requests still execute a one-token dummy batch to participate in graph replay and collectives. For GDN/Mamba layers, treating that synchronization-only token as a real decode token can advance causal-conv and KDA recurrent state through block-table entries left by an earlier request.

This PR keeps the model/collective dummy shape unchanged, but builds zero-length GDN metadata for idle DP dummies. Both captured recurrent branches become no-ops while other layers and distributed communication continue to execute normally.

The change restores the behavior previously validated on the v0.26 Kimi K3 path. It adds no device-wide synchronization and does not change GDN kernels.

## Does this PR introduce any user-facing change?

No API change. Multi-node GDN/Mamba inference no longer depends on whether another DP rank was idle between requests.

## How was this patch tested?

- `python -m compileall` for the changed runtime files
- `git diff --check`
- Existing unit expectations updated for both idle-dummy entry points; the existing GDN builder regression covers zero-length recurrent metadata
- Real-weight A/B on two A3 nodes, TP16 x DP2 / EP32, Kimi K3 GQA DSpark, async scheduling, prefix cache, FULL_DECODE_ONLY graph, 131072-input + 1024-output:
  - before: a cache-hit repeat diverged from token 0 and collapsed into a repeated `1.1.1...` output while speculative acceptance remained 80.55%
  - after: no corrupted output in five cold/warm repeats; the last four cold/warm pairs were token-for-token identical, with per-token acceptance between 95.81% and 97.49%
- Real-weight four-node smoke on TP16 x DP4 / EP64 with full QuaRot weights and the same 128K-to-1K case:
  - repetition 1: aggregate acceptance 85.40%, mean accepted length 6.98, per-DP acceptance 88.11% / 89.03% / 85.91% / 79.16%
  - repetition 2: aggregate acceptance 87.00%, mean accepted length 7.09, per-DP acceptance 87.40% / 84.08% / 87.09% / 89.56%
  - both repetitions reported a 94.63% prefix-cache hit rate and completed without the cross-DP rotating collapse seen before the fix
  - repetition 3 was not counted: the DP2 EngineCore exited concurrently with an external Docker exec ending with status 137. The host reported no OOM or device fault, but the initiating command was not captured, so this is recorded as an interrupted run rather than attributed to the patch. The shared nodes were reclaimed and no restart was performed.

- vLLM main: https://github.com/vllm-project/vllm/commit/ba07e4a48fc951300d97eb506217dd530583dea3
