### PR TITLE
[BugFix][Config] Warn and skip unknown top-level keys when vLLM-Omni is installed

### DIFF
--- a/tests/ut/test_ascend_config.py
+++ b/tests/ut/test_ascend_config.py
@@ -17,10 +17,11 @@ import json
 import os
 import subprocess
 import sys
+from importlib.util import find_spec as real_find_spec
 from types import SimpleNamespace
 from unittest.mock import patch
 
-from vllm.config import KVTransferConfig, VllmConfig
+from vllm.config import KVTransferConfig, ModelConfig, VllmConfig
 
 from tests.ut.base import TestBase
 from vllm_ascend.ascend_config import (
@@ -1189,5 +1190,27 @@ class TestTopLevelSwitchTypeValidation(TestBase):
         # only _NON_USER_INPUT_KEYS is stripped, so typos reach pydantic and are rejected.
         vc = VllmConfig()
         vc.additional_config = {"unknown_option": True}
-        with self.assertRaises(ValueError):
+        with (
+            patch("vllm_ascend.ascend_config.importlib.util.find_spec", return_value=None),
+            self.assertRaises(ValueError),
+        ):
             init_ascend_config(vc)
+
+    @_clean_up
+    @patch("vllm_ascend.ascend_config.logger.warning")
+    @patch(
+        "vllm_ascend.ascend_config.importlib.util.find_spec",
+        side_effect=lambda name, *args, **kwargs: (
+            object() if name == "vllm_omni" else real_find_spec(name, *args, **kwargs)
+        ),
+    )
+    def test_omni_additional_config_warns_and_is_preserved(self, _mock_find_spec, mock_warning):
+        vllm_config = VllmConfig(model_config=ModelConfig(), additional_config={"vllm_omni_option": True})
+
+        self.assertIs(vllm_config.additional_config["vllm_omni_option"], True)
+        mock_warning.assert_any_call(
+            "The following additional_config keys are invalid for vLLM-Ascend: %s. "
+            "They may be used by vLLM-Omni or another project. "
+            "Please remove them if they are not needed for your use case.",
+            ["vllm_omni_option"],
+        )

--- a/vllm_ascend/ascend_config.py
+++ b/vllm_ascend/ascend_config.py
@@ -1400,6 +1400,17 @@ def init_ascend_config(vllm_config):
         "batch_job_sched_config",
     }
     kwargs = {k: v for k, v in additional_config.items() if k not in _NON_USER_INPUT_KEYS}
+    unknown_keys = sorted(set(kwargs) - AscendConfig.__dataclass_fields__.keys())
+    # vLLM-Omni shares this mapping with the platform plugin. Preserve its
+    # extension keys on VllmConfig while excluding them from Ascend validation.
+    if unknown_keys and importlib.util.find_spec("vllm_omni") is not None:
+        logger.warning(
+            "The following additional_config keys are invalid for vLLM-Ascend: %s. "
+            "They may be used by vLLM-Omni or another project. "
+            "Please remove them if they are not needed for your use case.",
+            unknown_keys,
+        )
+        kwargs = {k: v for k, v in kwargs.items() if k not in unknown_keys}
 
     new_config = AscendConfig(  # type: ignore[call-arg]
         scheduler_config=sched,


### PR DESCRIPTION
### What this PR does / why we need it?

`VllmConfig.additional_config` is shared by vLLM-Ascend and downstream projects. After the strict Pydantic validation introduced by #13838, vLLM-Ascend rejects configuration keys owned and consumed by vLLM-Omni, such as `code2wav_enable_npu_graph`.

This PR checks whether vLLM-Omni is installed using `importlib.util.find_spec("vllm_omni")`. When it is installed, unknown top-level `additional_config` keys produce a warning and are excluded only from `AscendConfig` validation. These keys remain in `VllmConfig.additional_config` so downstream consumers can still access them.

When vLLM-Omni is not installed, unknown keys are still rejected. Declared vLLM-Ascend fields and nested Ascend configurations remain strictly validated in both cases.

Fixes #15418

### Does this PR introduce _any_ user-facing change?

Yes. When vLLM-Omni is installed, unknown top-level `additional_config` keys no longer cause vLLM-Ascend configuration initialization to fail. A warning is emitted instead:

```text
The following additional_config keys are invalid for vLLM-Ascend: [...]. They may be used by vLLM-Omni or another project. Please remove them if they are not needed for your use case.
```

Strict validation remains unchanged when vLLM-Omni is not installed.

### How was this patch tested?

Tested the complete Ascend config unit test file on Ascend with vLLM-Omni installed:

```bash
python -m pytest -sv tests/ut/test_ascend_config.py
```

Result: `91 passed, 14 warnings, 4 subtests passed in 24.05s`.

The suite includes the regression test confirming that `VllmConfig` is constructed successfully, the expected warning is emitted for the vLLM-Omni option, and the key remains available in `VllmConfig.additional_config`.

- vLLM main: https://github.com/vllm-project/vllm/commit/ba07e4a48fc951300d97eb506217dd530583dea3
