### PR TITLE
[v0.26.0rc][Bugfix] Fix CPU binding device mapping

### DIFF
--- a/tests/ut/device_allocator/test_cpu_binding.py
+++ b/tests/ut/device_allocator/test_cpu_binding.py
@@ -27,6 +27,7 @@ from vllm_ascend.utils import AscendDeviceType
 def make_cpu_alloc(rank_id=0):
     cpu_alloc = object.__new__(CpuAlloc)
     cpu_alloc.rank_id = rank_id
+    cpu_alloc.current_npu = 0
     cpu_alloc.device_info = SimpleNamespace(
         running_npu_list=[0],
         all_logic_npus=[0],
@@ -302,7 +303,15 @@ class TestCpuAlloc(unittest.TestCase):
             ("| NPU Chip | Process id |\n| 0 0 | 1234 | vllm | 56000 |\n| 1 0 | 1235 | vllm | 56000 |", 0),
             ("", 0),
         ]
-        self.cpu_alloc = CpuAlloc(0)
+        self.cpu_alloc = CpuAlloc(0, npu_id=0)
+
+    @patch("vllm_ascend.cpu_binding.DeviceInfo")
+    def test_explicit_npu_id_overrides_running_npu_order(self, mock_device_info):
+        mock_device_info.return_value.running_npu_list = [1, 3]
+
+        cpu_alloc = CpuAlloc(rank_id=0, npu_id=3)
+
+        self.assertEqual(cpu_alloc.current_npu, 3)
 
     def test_average_distribute(self):
         self.cpu_alloc.npu_cpu_pool = {0: [10, 11, 12, 13], 1: [10, 11, 12, 13]}
@@ -542,6 +551,7 @@ class TestCpuAlloc(unittest.TestCase):
         mock_execute_command.return_value = ("PCIe Bus Info 0000:03:00.0", 0)
         self.cpu_alloc.rank_id = 0
         self.cpu_alloc.device_info.running_npu_list = [3]
+        self.cpu_alloc.current_npu = 3
         self.cpu_alloc.npu_cpu_pool = {3: [0, 1, 2, 3, 4]}
 
         self.cpu_alloc.bind_npu_irq()
@@ -888,6 +898,7 @@ class TestCpuBindingSupplemental(unittest.TestCase):
     def test_print_plan_handles_empty_release_assignment(self, mock_logger_info, _mock_get_device_type):
         cpu_alloc = make_cpu_alloc()
         cpu_alloc.device_info.running_npu_list = [1]
+        cpu_alloc.current_npu = 1
         cpu_alloc.rank_id = 0
         cpu_alloc.assign_main = {1: [2, 3]}
         cpu_alloc.assign_acl = {1: [4]}
@@ -902,6 +913,7 @@ class TestCpuBindingSupplemental(unittest.TestCase):
     def test_print_plan_uses_ascend_950_worker_log(self, mock_logger_info, _mock_get_device_type):
         cpu_alloc = make_cpu_alloc()
         cpu_alloc.device_info.running_npu_list = [1]
+        cpu_alloc.current_npu = 1
         cpu_alloc.rank_id = 0
         cpu_alloc.assign_main = {1: [2, 3]}
         cpu_alloc.assign_acl = {1: []}
@@ -922,6 +934,7 @@ class TestCpuBindingSupplemental(unittest.TestCase):
     def test_print_plan_handles_non_empty_release_assignment(self, mock_logger_info, _mock_get_device_type):
         cpu_alloc = make_cpu_alloc()
         cpu_alloc.device_info.running_npu_list = [1]
+        cpu_alloc.current_npu = 1
         cpu_alloc.rank_id = 0
         cpu_alloc.assign_main = {1: [2, 3]}
         cpu_alloc.assign_acl = {1: [4]}
@@ -1238,15 +1251,15 @@ class TestBindingSwitch(unittest.TestCase):
     @patch("vllm_ascend.cpu_binding.is_arm_cpu")
     def test_bind_cpus_skip_non_arm(self, mock_is_arm_cpu, mock_cpu_alloc):
         mock_is_arm_cpu.return_value = False
-        bind_cpus(0)
+        bind_cpus(0, npu_id=0)
         mock_cpu_alloc.assert_not_called()
 
     @patch("vllm_ascend.cpu_binding.CpuAlloc")
     @patch("vllm_ascend.cpu_binding.is_arm_cpu", return_value=True)
     def test_bind_cpus_runs_allocator_on_arm(self, _mock_is_arm_cpu, mock_cpu_alloc):
-        bind_cpus(1)
+        bind_cpus(1, npu_id=3)
 
-        mock_cpu_alloc.assert_called_once_with(1)
+        mock_cpu_alloc.assert_called_once_with(1, npu_id=3)
         mock_cpu_alloc.return_value.run_all.assert_called_once_with()
 
 

--- a/vllm_ascend/cpu_binding.py
+++ b/vllm_ascend/cpu_binding.py
@@ -205,9 +205,10 @@ class DeviceInfo:
 
 
 class CpuAlloc:
-    def __init__(self, rank_id: int):
+    def __init__(self, rank_id: int, npu_id: int):
         self.rank_id = rank_id
         self.device_info: DeviceInfo = DeviceInfo()
+        self.current_npu = npu_id
         self.cpu_node: dict[int, int] = {}
         self.numa_to_cpu_map: dict[int, list[int]] = defaultdict(list)
         self.npu_cpu_pool: dict[int, list[int]] = {}
@@ -624,11 +625,10 @@ class CpuAlloc:
 
     def print_plan(self) -> None:
         logger.info("The CPU allocation plan is as follows:")
-        current_npu = self.device_info.running_npu_list[self.rank_id]
         if self._is_ascend_950():
-            self._print_ascend_950_plan(current_npu)
+            self._print_ascend_950_plan(self.current_npu)
             return
-        self._print_default_plan(current_npu)
+        self._print_default_plan(self.current_npu)
 
     def _print_ascend_950_plan(self, current_npu: int) -> None:
         main = " ".join(map(str, self.assign_main[current_npu]))
@@ -684,20 +684,18 @@ class CpuAlloc:
         thread_message, _ = execute_command(["ps", "-Te"])
         threads_map = self.get_threads_map(thread_message)
         main_pid = str(psutil.Process().pid)
-        current_npu = self.device_info.running_npu_list[self.rank_id]
-        self.bind(main_pid, self.assign_main[current_npu], True)
+        self.bind(main_pid, self.assign_main[self.current_npu], True)
         for thread_id in threads_map.get(main_pid, {}).get("acl_thread", []):
-            self.bind(thread_id, self.assign_acl[current_npu], False)
+            self.bind(thread_id, self.assign_acl[self.current_npu], False)
         for thread_id in threads_map.get(main_pid, {}).get("release_thread", []):
-            self.bind(thread_id, self.assign_rel[current_npu], False)
+            self.bind(thread_id, self.assign_rel[self.current_npu], False)
         # Migrate memory once for the whole process, after all threads are pinned.
-        self.bind_memory(main_pid, current_npu)
+        self.bind_memory(main_pid, self.current_npu)
 
     def bind_ascend_950_threads(self) -> None:
         main_pid = str(psutil.Process().pid)
-        current_npu = self.device_info.running_npu_list[self.rank_id]
-        self.bind(main_pid, self.assign_main[current_npu], True)
-        self.bind_memory(main_pid, current_npu)
+        self.bind(main_pid, self.assign_main[self.current_npu], True)
+        self.bind_memory(main_pid, self.current_npu)
 
     def bind_npu_irq(self) -> None:
         if not self._reserve_irq_cpus():
@@ -708,9 +706,8 @@ class CpuAlloc:
             return
 
         # Only bind IRQ for current rank's NPU to avoid multi-process overwrite.
-        current_npu = self.device_info.running_npu_list[self.rank_id]
-        if current_npu not in self.npu_cpu_pool:
-            logger.warning("[irq] NPU has no CPU pool. rank=%s, npu=%s. ", self.rank_id, current_npu)
+        if self.current_npu not in self.npu_cpu_pool:
+            logger.warning("[irq] NPU has no CPU pool. rank=%s, npu=%s. ", self.rank_id, self.current_npu)
             return
 
         if shutil.which("systemctl"):
@@ -731,7 +728,7 @@ class CpuAlloc:
                     irq = line.split(":")[0].strip()
                     sq_irqs.append(irq)
 
-        npu = current_npu
+        npu = self.current_npu
         cpus = self.npu_cpu_pool[npu]
         if len(cpus) < 2:
             logger.warning("[irq] CPU pool too small. npu=%s, cpu_count=%d, min_required=2. ", npu, len(cpus))
@@ -798,9 +795,9 @@ class CpuAlloc:
         self.bind_npu_irq()
 
 
-def bind_cpus(rank_id: int) -> None:
+def bind_cpus(rank_id: int, npu_id: int) -> None:
     if not is_arm_cpu():
         logger.info("CPU binding skipped: non-ARM CPU detected.")
         return
-    binder = CpuAlloc(rank_id)
+    binder = CpuAlloc(rank_id, npu_id=npu_id)
     binder.run_all()

--- a/vllm_ascend/worker/worker.py
+++ b/vllm_ascend/worker/worker.py
@@ -826,7 +826,10 @@ class NPUWorker(WorkerBase):
         # worker process before migratepages/taskset run.
         if get_ascend_config().enable_cpu_binding:
             try:
-                bind_cpus(self.local_rank)
+                bind_cpus(
+                    self.local_rank,
+                    npu_id=current_platform.device_id_to_physical_device_id(self.local_rank),
+                )
             except Exception as e:
                 logger.warning("Bind cpus failed in rank%s: %s Skip binding cpu.", self.local_rank, e)
 


### PR DESCRIPTION
### What this PR does / why we need it?

vLLM v0.24 changed worker device assignment so a local rank is not always the device ID that CPU binding should use. Indexing the discovered NPU list by `local_rank` can therefore select the wrong CPU/NUMA/IRQ pool and amplify cross-rank waiting at communication barriers.

This patch keeps the change narrow:

- `NPUWorker` resolves its assigned device through `current_platform.device_id_to_physical_device_id(local_rank)` when CPU binding runs.
- `bind_cpus` and `CpuAlloc` require that resolved NPU ID and use it for the current worker binding.
- Existing hardware-specific allocation behavior for A2, A3, 310P, and A5/Ascend 950 is unchanged.
- No worker helper, worker state, or 310P-specific worker path is added.

### Does this PR introduce any user-facing change?

No CLI or public configuration is added. CPU binding now follows the worker assigned device mapping.

### How was this patch tested?

- `git diff --check`
- `ruff check .`
- `ruff format --check .`
- `PYTHONDONTWRITEBYTECODE=1 python3 -m compileall -q` for changed Python files
- Focused CPU binding pytest was attempted locally, but collection requires the unavailable `vllm` package.
- `pre-commit` is unavailable locally; GitHub pre-commit CI is used.
- vLLM main: https://github.com/vllm-project/vllm/commit/d02df748bf9efd99022f1a062597dc3cb3808485
