### PR TITLE
[Feat][MoE] Support A5 MegaMoe for W4A8 MXFP

### DIFF
--- a/docs/source/user_guide/configuration/additional_config.md
+++ b/docs/source/user_guide/configuration/additional_config.md
@@ -71,7 +71,7 @@ The following table lists additional configuration options available in vLLM Asc
 | `enable_mlapo`                      | bool | `True`  | Whether to enable MLAPO (Model Layer-wise Adaptive Parallel Optimization). The legacy `VLLM_ASCEND_ENABLE_MLAPO` environment variable is no longer supported. |
 | `mlapo_keep_prefill_weights`        | bool | `False` | When True, keep MLAPO prefill weights on NPU instead of freeing them on kv_consumer (decode-only D) nodes. D nodes have normal local-prefill paths (recompute / fallback / preempt) that crash when the weights are freed (issue #11882). Enable this to trade NPU memory for stability. |
 | `weight_nz_mode`                    | int  | `1`     | Weight NZ mode. `0` disables NZ, `1` enables NZ only for quantized weights, and `2` also enables NZ for BF16/FP16 weights when supported. The legacy `VLLM_ASCEND_ENABLE_NZ` environment variable is no longer supported. |
-| `enable_fused_mc2`                  | int  | `0`     | Fused MC2 configuration. `0` disables the fused path and `1` enables it when the model and parallel configuration support it. The legacy `VLLM_ASCEND_ENABLE_FUSED_MC2` environment variable is no longer supported. |
+| `enable_fused_mc2`                  | int  | `0`     | Fused MC2 configuration. With `1`, MegaMoe is selected from instantiated layer capabilities: A2/A3 support BF16/W8A8/W4A8, and A5 supports W4A8 MXFP with `group_size=32`. Unsupported layouts keep the non-MegaMoe path. The legacy `VLLM_ASCEND_ENABLE_FUSED_MC2` environment variable is no longer supported. |
 | `enable_transpose_kv_cache_by_block`| bool | `True`  | Whether to enable transpose KV cache by block. The legacy `VLLM_ASCEND_FUSION_OP_TRANSPOSE_KV_CACHE_BY_BLOCK` environment variable is no longer supported. |
 | `enable_dsa_cp`                     | bool | `False` | Whether to enable dsa_cp for DeepSeek V3.2, DeepSeek V4, and other models with the same architecture. This feature requires sequence parallelism to be enabled.|
 | `rejection_sampler_config`          | dict | `{}`    | Configuration options for rejection sampler (block verify and entropy verify). |
@@ -81,6 +81,42 @@ The following table lists additional configuration options available in vLLM Asc
 | `enable_reduce_sample`              | bool | `False` | Whether to enable reduce sample optimization to reduce communication and computation overheads in the tensor parallelism scenario. When enabled, logits are kept partitioned across TP ranks and only the small set of top-k candidate values/indices is communicated, instead of performing a full-vocabulary all-to-all/all-gather. **Note**: This is an experimental feature. **Limitations**: (1) Not supported on PD-disaggregated scenario. (2) Must be disabled when sampling logprobs are requested. When reduce sample is enabled, logprobs are silently computed over partitioned logits instead of the full vocabulary, producing incorrect logprob values and top-k rankings. (3) Cannot be enabled together with lmhead TP.|
 
 The details of each configuration option are as follows:
+
+**enable_fused_mc2 (CANN MegaMoe / dispatch_ffn_combine)**
+
+When `enable_fused_mc2=1`, MoE communication may be replaced by the fused
+`dispatch_ffn_combine` or `mega_moe` operator. On A5 the MegaMoe path is
+selected from the instantiated MoE layer capabilities instead of checkpoint
+metadata; unsupported layer layouts keep the decomposed MC2/AllToAll path.
+
+| Item | A2 / A3 | A5 (Ascend 950PR / 950DT) |
+| ---- | ------- | ------------------------- |
+| Quantization | W8A8 / W4A8 (INT) and BF16 | W4A8 MXFP only, `group_size=32` |
+| Activation | SwiGLU | SwiGLU and SiTU (`activation_params={beta, linear_beta}`) |
+| Max routed experts | 1024 | 2048 (must be divisible by EP size) |
+| Max EP world size | 64 | 1024 |
+| Max top-k | 16 | 32 |
+| Hidden size | [1024, 8192], multiple of 512 | [1024, 8192], multiple of 512 |
+
+Notes for A5:
+
+- Requires a `cann_ops_transformer` build with SiTUGLU support and the
+  `mega_moe` custom operator package. If the package is installed under
+  `${ASCEND_HOME_PATH}/opp/vendors`, make sure `ASCEND_CUSTOM_OPP_PATH` also
+  contains that vendor directory. vLLM Ascend prepends its own bundled vendors
+  path at startup, which otherwise shadows the installed package and makes the
+  call fall back to the built-in older operator.
+- The symmetric buffer receive capacity uses the operator's automatic mode
+  (`max_recv_token_num=0`); `mega_moe_max_tokens` is not used on A5.
+- The MegaMoe path is mutually exclusive with
+  `multistream_overlap_shared_expert`; the latter is force-disabled when
+  `enable_fused_mc2=1`.
+
+```bash
+vllm serve <model> \
+    --tensor-parallel-size 8 --enable-expert-parallel \
+    --additional-config '{"enable_fused_mc2": 1}'
+```
 
 **xlite_graph_config**
 

--- a/tests/ut/ops/test_mega_moe_adapter.py
+++ b/tests/ut/ops/test_mega_moe_adapter.py
@@ -1,0 +1,228 @@
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+import torch
+from vllm.model_executor.layers.fused_moe.activation import MoEActivation
+
+from vllm_ascend.ops.fused_moe.mega_moe_adapter import (
+    CannMegaMoeApiCapability,
+    CannMegaMoeLayerCapability,
+    evaluate_cann_mega_moe_layer,
+    get_model_cann_mega_moe_capability,
+    probe_cann_mega_moe_api,
+    resolve_cann_mega_moe_activation,
+)
+from vllm_ascend.quantization.quant_type import QuantType
+from vllm_ascend.utils import AscendDeviceType
+
+
+@pytest.fixture
+def a5_api_capability():
+    return CannMegaMoeApiCapability(
+        available=True,
+        supports_situ=True,
+        supports_comm_context_preload=True,
+    )
+
+
+def _moe_config(**overrides):
+    values = {
+        "in_dtype": torch.bfloat16,
+        "hidden_dim": 3584,
+        "intermediate_size_per_partition": 3072,
+        "experts_per_token": 16,
+        "ep_size": 32,
+        "num_experts": 896,
+    }
+    values.update(overrides)
+    return SimpleNamespace(**values)
+
+
+def _quant_method(quant_type=QuantType.W4A8MXFP, group_size=32):
+    return SimpleNamespace(quant_type=quant_type, group_size=group_size)
+
+
+def _compatible_mega_moe(*args, **kwargs):
+    return args, kwargs
+
+
+def _situ_mega_moe(
+    x,
+    topk_ids,
+    topk_weights,
+    l1_weights,
+    l2_weights,
+    sym_buffer,
+    *,
+    l1_weights_sf=None,
+    l2_weights_sf=None,
+    l1_bias=None,
+    l2_bias=None,
+    x_active_mask=None,
+    activation="swiglu",
+    activation_clamp=None,
+    activation_params=None,
+    weight1_type=None,
+    weight2_type=None,
+):
+    return x, topk_ids
+
+
+def test_api_probe_separates_base_backend_from_a5_extensions():
+    ops_module = SimpleNamespace(
+        mega_moe=_compatible_mega_moe,
+        get_symm_buffer_for_mega_moe=object(),
+    )
+
+    probe_cann_mega_moe_api.cache_clear()
+    with patch(
+        "vllm_ascend.ops.fused_moe.mega_moe_adapter.import_module",
+        side_effect=[ops_module, ImportError("comm context is unavailable")],
+    ):
+        capability = probe_cann_mega_moe_api()
+    probe_cann_mega_moe_api.cache_clear()
+
+    assert capability.available
+    assert not capability.supports_situ
+    assert not capability.supports_comm_context_preload
+
+
+def test_api_probe_recognizes_explicit_a5_situ_contract():
+    ops_module = SimpleNamespace(
+        mega_moe=_situ_mega_moe,
+        get_symm_buffer_for_mega_moe=object(),
+    )
+    comm_context_module = SimpleNamespace(
+        comm_context_op_builder=SimpleNamespace(load=lambda: None),
+    )
+
+    probe_cann_mega_moe_api.cache_clear()
+    with patch(
+        "vllm_ascend.ops.fused_moe.mega_moe_adapter.import_module",
+        side_effect=[ops_module, comm_context_module],
+    ):
+        capability = probe_cann_mega_moe_api()
+    probe_cann_mega_moe_api.cache_clear()
+
+    assert capability.available
+    assert capability.supports_situ
+    assert capability.supports_comm_context_preload
+
+
+def test_a5_capability_uses_instantiated_layer_contract(a5_api_capability):
+    capability = evaluate_cann_mega_moe_layer(
+        _moe_config(),
+        _quant_method(),
+        MoEActivation.SITU,
+        situ_beta=4.0,
+        situ_linear_beta=25.0,
+        device_type=AscendDeviceType.A5,
+        api_capability=a5_api_capability,
+    )
+
+    assert capability.supported
+    assert capability.quant_type == QuantType.W4A8MXFP
+    assert capability.activation is not None
+    assert capability.activation.name == "situglu"
+    assert capability.activation.alpha == 25.0
+    assert capability.activation.beta == 4.0
+
+
+def test_a5_capability_unwraps_the_runtime_quant_scheme(a5_api_capability):
+    wrapped_quant_method = SimpleNamespace(quant_method=_quant_method())
+
+    capability = evaluate_cann_mega_moe_layer(
+        _moe_config(),
+        wrapped_quant_method,
+        MoEActivation.SILU,
+        device_type=AscendDeviceType.A5,
+        api_capability=a5_api_capability,
+    )
+
+    assert capability.supported
+    assert capability.quant_type == QuantType.W4A8MXFP
+
+
+@pytest.mark.parametrize(
+    ("config_overrides", "quant_overrides", "reason"),
+    [
+        ({}, {"group_size": 64}, "group_size=32"),
+        ({"hidden_dim": 3600}, {}, "hidden size"),
+        ({"experts_per_token": 33}, {}, "top-k"),
+        ({"num_experts": 895}, {}, "divisible by EP size"),
+    ],
+)
+def test_a5_capability_rejects_unsupported_runtime_layout(
+    a5_api_capability,
+    config_overrides,
+    quant_overrides,
+    reason,
+):
+    capability = evaluate_cann_mega_moe_layer(
+        _moe_config(**config_overrides),
+        _quant_method(**quant_overrides),
+        MoEActivation.SILU,
+        device_type=AscendDeviceType.A5,
+        api_capability=a5_api_capability,
+    )
+
+    assert not capability.supported
+    assert reason in capability.reason
+
+
+def test_a3_keeps_unquantized_megamoe_support(a5_api_capability):
+    capability = evaluate_cann_mega_moe_layer(
+        _moe_config(num_experts=128, ep_size=8),
+        _quant_method(QuantType.NONE, group_size=None),
+        MoEActivation.SILU,
+        device_type=AscendDeviceType.A3,
+        api_capability=a5_api_capability,
+    )
+
+    assert capability.supported
+    assert capability.quant_type == QuantType.NONE
+
+
+def test_a3_rejects_mxfp4_instead_of_entering_incompatible_operator(a5_api_capability):
+    capability = evaluate_cann_mega_moe_layer(
+        _moe_config(num_experts=128, ep_size=8),
+        _quant_method(),
+        MoEActivation.SILU,
+        device_type=AscendDeviceType.A3,
+        api_capability=a5_api_capability,
+    )
+
+    assert not capability.supported
+    assert "W4A8MXFP" in capability.reason
+
+
+def test_situ_requires_linear_beta():
+    activation = resolve_cann_mega_moe_activation(MoEActivation.SITU, situ_beta=1.0)
+
+    assert activation is None
+
+
+def test_model_capability_requires_every_registered_moe_layer():
+    model = torch.nn.Module()
+    model.first_moe = torch.nn.Module()
+    model.second_moe = torch.nn.Module()
+    supported = CannMegaMoeLayerCapability(True, "", QuantType.W4A8MXFP)
+    unsupported = CannMegaMoeLayerCapability(False, "unsupported activation", QuantType.W4A8MXFP)
+    model.first_moe.cann_mega_moe_capability = supported
+    model.second_moe.cann_mega_moe_capability = unsupported
+
+    assert get_model_cann_mega_moe_capability(model) is unsupported
+
+
+def test_model_capability_ignores_checkpoint_metadata_without_registered_layers():
+    model = torch.nn.Module()
+    model.quantization_config = {
+        "quant_method": "compressed-tensors",
+        "format": "mxfp4-pack-quantized",
+    }
+
+    capability = get_model_cann_mega_moe_capability(model)
+
+    assert not capability.supported
+    assert "no registered" in capability.reason

--- a/vllm_ascend/ascend_forward_context.py
+++ b/vllm_ascend/ascend_forward_context.py
@@ -12,6 +12,7 @@ from vllm.forward_context import BatchDescriptor, get_forward_context, set_forwa
 from vllm.logger import logger
 
 from vllm_ascend.ascend_config import get_ascend_config, is_mega_moe_supported
+from vllm_ascend.ops.fused_moe.mega_moe_adapter import get_model_cann_mega_moe_capability
 from vllm_ascend.utils import (
     AscendDeviceType,
     get_ascend_device_type,
@@ -116,6 +117,7 @@ def set_ascend_forward_context(
         moe_comm_type = select_moe_comm_method(
             max_num_tokens,
             vllm_config,
+            model_instance=model_instance,
         )
 
         forward_context.moe_comm_type = moe_comm_type
@@ -283,11 +285,23 @@ def _select_a5_moe_comm_method(
     num_tokens: int,
     vllm_config: VllmConfig,
     mc2_tokens_capacity: int,
+    model_instance: torch.nn.Module | None = None,
+    cann_mega_moe_supported: bool | None = None,
 ) -> MoECommType:
+    hf_text_config = vllm_config.model_config.hf_text_config
+    if cann_mega_moe_supported is None:
+        cann_mega_moe_supported = get_model_cann_mega_moe_capability(model_instance).supported
+    if (
+        get_ascend_config().enable_fused_mc2 == 1
+        and cann_mega_moe_supported
+        and (num_tokens is None or num_tokens <= mc2_tokens_capacity)
+    ):
+        return MoECommType.FUSED_MC2
+
     num_experts_per_tok = getattr(
-        vllm_config.model_config.hf_text_config,
+        hf_text_config,
         "num_experts_per_tok",
-        getattr(vllm_config.model_config.hf_text_config, "top_k_experts", 1),
+        getattr(hf_text_config, "top_k_experts", 1),
     )
     world_size = vllm_config.parallel_config.world_size_across_dp
     if (num_tokens is None or num_tokens <= mc2_tokens_capacity) and world_size > 1:
@@ -297,7 +311,13 @@ def _select_a5_moe_comm_method(
     return MoECommType.ALLTOALL
 
 
-def select_moe_comm_method(num_tokens: int, vllm_config: VllmConfig) -> MoECommType | None:
+def select_moe_comm_method(
+    num_tokens: int,
+    vllm_config: VllmConfig,
+    *,
+    model_instance: torch.nn.Module | None = None,
+    cann_mega_moe_supported: bool | None = None,
+) -> MoECommType | None:
     """Select the MoE communication method according to parallel settings,
     device generation, and token count.
 
@@ -316,7 +336,10 @@ def select_moe_comm_method(num_tokens: int, vllm_config: VllmConfig) -> MoECommT
     Args:
         num_tokens (int): The number of tokens in the current batch.
         vllm_config (VllmConfig): Runtime configuration for the model.
-        is_draft_model (bool): Whether the model runs in MTP mode.
+        model_instance (torch.nn.Module | None): Loaded model used to aggregate
+            registered MegaMoe layer capabilities.
+        cann_mega_moe_supported (bool | None): Optional already-aggregated
+            capability result for initialization paths without a model handle.
 
     Raises:
         ValueError: If the soc version is unsupported.
@@ -347,7 +370,13 @@ def select_moe_comm_method(num_tokens: int, vllm_config: VllmConfig) -> MoECommT
             vllm_config,
         )
     elif soc_version == AscendDeviceType.A5:
-        moe_comm_type = _select_a5_moe_comm_method(num_tokens, vllm_config, mc2_tokens_capacity)
+        moe_comm_type = _select_a5_moe_comm_method(
+            num_tokens,
+            vllm_config,
+            mc2_tokens_capacity,
+            model_instance,
+            cann_mega_moe_supported,
+        )
     elif soc_version == AscendDeviceType._310P:
         moe_comm_type = MoECommType.ALLGATHER
 

--- a/vllm_ascend/ops/fused_moe/fused_moe.py
+++ b/vllm_ascend/ops/fused_moe/fused_moe.py
@@ -22,11 +22,14 @@ from vllm.distributed import (
     get_tp_group,
     tensor_model_parallel_all_reduce,
 )
+from vllm.logger import logger
 from vllm.model_executor.layers.fused_moe import FusedMoEConfig, FusedMoERouter
 from vllm.model_executor.layers.fused_moe.layer import MoERunner
 
+from vllm_ascend.ascend_config import get_ascend_config
 from vllm_ascend.ascend_forward_context import _EXTRA_CTX, MoECommType
 from vllm_ascend.distributed.parallel_state import get_mc2_group
+from vllm_ascend.ops.fused_moe.mega_moe_adapter import evaluate_cann_mega_moe_layer
 from vllm_ascend.ops.fused_moe.moe_comm_method import get_moe_comm_method, setup_moe_comm_method
 from vllm_ascend.ops.fused_moe.routed_experts import AscendRoutedExperts
 from vllm_ascend.ops.fused_moe.shared_experts import (
@@ -86,7 +89,25 @@ class AscendMoERunner(MoERunner):  # type: ignore[no-redef]
                 self._quant_method,
             )
 
-        setup_moe_comm_method(self.moe_config)
+        self.cann_mega_moe_capability = evaluate_cann_mega_moe_layer(
+            self.moe_config,
+            routed_experts.quant_method,
+            getattr(self.moe_config, "activation", getattr(routed_experts, "activation", "silu")),
+            situ_beta=getattr(self.moe_config, "activation_situ_beta", None),
+            situ_linear_beta=getattr(self.moe_config, "activation_situ_linear_beta", None),
+        )
+        if get_ascend_config().enable_fused_mc2 == 1:
+            logger.info_once(
+                "CANN MegaMoe layer capability: supported=%s, quant=%s, activation=%s, reason=%s.",
+                self.cann_mega_moe_capability.supported,
+                self.cann_mega_moe_capability.quant_type,
+                self.cann_mega_moe_capability.activation,
+                self.cann_mega_moe_capability.reason or "supported",
+            )
+        setup_moe_comm_method(
+            self.moe_config,
+            cann_mega_moe_capability=self.cann_mega_moe_capability,
+        )
         alltoall_comm = get_moe_comm_method(MoECommType.ALLTOALL)
         if alltoall_comm is not None:
             expert_ids_per_ep_rank = getattr(alltoall_comm.token_dispatcher, "expert_ids_per_ep_rank", None)

--- a/vllm_ascend/ops/fused_moe/mega_moe_adapter.py
+++ b/vllm_ascend/ops/fused_moe/mega_moe_adapter.py
@@ -1,0 +1,245 @@
+# Copyright (c) 2026 Huawei Technologies Co., Ltd. All Rights Reserved.
+# This file is a part of the vllm-ascend project.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Capability-driven adapter for the external CANN MegaMoe operator.
+
+The adapter deliberately reasons about the instantiated MoE layer instead of
+checkpoint metadata or model names. This keeps communication selection
+independent of how a quantized checkpoint describes the same runtime layout.
+"""
+
+from __future__ import annotations
+
+import inspect
+from dataclasses import dataclass
+from functools import cache
+from importlib import import_module
+from typing import TYPE_CHECKING, Any
+
+import torch
+
+from vllm_ascend.quantization.quant_type import QuantType
+from vllm_ascend.utils import AscendDeviceType, get_ascend_device_type
+
+if TYPE_CHECKING:
+    from vllm.model_executor.layers.fused_moe import FusedMoEConfig
+
+
+_LAYER_CAPABILITY_ATTR = "cann_mega_moe_capability"
+_MODEL_CAPABILITY_ATTR = "_ascend_cann_mega_moe_capability"
+
+_A3_QUANT_TYPES = frozenset({QuantType.NONE, QuantType.W8A8, QuantType.W4A8})
+_A5_QUANT_TYPES = frozenset({QuantType.W4A8MXFP})
+_SWIGLU_ACTIVATIONS = frozenset({"silu", "swiglu", "moeactivation.silu"})
+_SITU_ACTIVATIONS = frozenset({"situ", "situglu", "moeactivation.situ"})
+_COMMON_MEGA_MOE_KEYWORDS = frozenset(
+    {
+        "activation_clamp",
+        "l1_bias",
+        "l1_weights_sf",
+        "l2_bias",
+        "l2_weights_sf",
+        "weight1_type",
+        "weight2_type",
+        "x_active_mask",
+    }
+)
+
+
+@dataclass(frozen=True, slots=True)
+class CannMegaMoeApiCapability:
+    available: bool
+    supports_situ: bool = False
+    supports_comm_context_preload: bool = False
+    reason: str = ""
+
+
+@dataclass(frozen=True, slots=True)
+class CannMegaMoeActivation:
+    name: str
+    alpha: float | None = None
+    beta: float | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class CannMegaMoeLayerCapability:
+    supported: bool
+    reason: str
+    quant_type: QuantType
+    activation: CannMegaMoeActivation | None = None
+
+
+@cache
+def probe_cann_mega_moe_api() -> CannMegaMoeApiCapability:
+    """Probe the Python API surface without compiling the comm extension."""
+    try:
+        ops_module = import_module("cann_ops_transformer.ops")
+        mega_moe = ops_module.mega_moe
+        _ = ops_module.get_symm_buffer_for_mega_moe
+        parameters = inspect.signature(mega_moe).parameters
+        accepts_arbitrary_keywords = any(
+            parameter.kind == inspect.Parameter.VAR_KEYWORD for parameter in parameters.values()
+        )
+        if not accepts_arbitrary_keywords and not _COMMON_MEGA_MOE_KEYWORDS.issubset(parameters):
+            missing = sorted(_COMMON_MEGA_MOE_KEYWORDS.difference(parameters))
+            raise TypeError(f"mega_moe is missing keyword parameters: {missing}")
+    except Exception as exc:
+        return CannMegaMoeApiCapability(False, reason=f"incompatible cann_ops_transformer API: {exc}")
+
+    try:
+        comm_context_module = import_module("cann_ops_transformer.ops.comm_context")
+        comm_context_builder = comm_context_module.comm_context_op_builder
+        _ = comm_context_builder.load
+        supports_comm_context_preload = True
+    except Exception:
+        # The A2/A3 operator does not require this extension. Keep the base
+        # backend available and let the A5 capability check reject preloading.
+        supports_comm_context_preload = False
+
+    return CannMegaMoeApiCapability(
+        True,
+        supports_situ={"activation", "activation_params"}.issubset(parameters),
+        supports_comm_context_preload=supports_comm_context_preload,
+    )
+
+
+def resolve_cann_mega_moe_activation(
+    activation: Any,
+    *,
+    situ_beta: float | None = None,
+    situ_linear_beta: float | None = None,
+) -> CannMegaMoeActivation | None:
+    """Normalize both legacy activation objects and main's MoEActivation."""
+    activation_name = str(getattr(activation, "value", activation)).lower()
+    linear_beta = getattr(activation, "linear_beta", situ_linear_beta)
+    beta = getattr(activation, "beta", situ_beta)
+
+    if activation_name in _SITU_ACTIVATIONS or linear_beta is not None:
+        if linear_beta is None:
+            return None
+        return CannMegaMoeActivation(name="situglu", alpha=linear_beta, beta=beta)
+
+    if activation_name in _SWIGLU_ACTIVATIONS:
+        return CannMegaMoeActivation(name="swiglu")
+    return None
+
+
+def _unsupported(reason: str, quant_type: QuantType) -> CannMegaMoeLayerCapability:
+    return CannMegaMoeLayerCapability(False, reason, quant_type)
+
+
+def evaluate_cann_mega_moe_layer(
+    moe_config: FusedMoEConfig,
+    quant_method: object,
+    activation: Any,
+    *,
+    situ_beta: float | None = None,
+    situ_linear_beta: float | None = None,
+    device_type: AscendDeviceType | None = None,
+    api_capability: CannMegaMoeApiCapability | None = None,
+) -> CannMegaMoeLayerCapability:
+    """Evaluate an instantiated MoE layer against the operator contract."""
+    device_type = device_type or get_ascend_device_type()
+    api_capability = api_capability or probe_cann_mega_moe_api()
+    # ModelSlim wraps the concrete MoE scheme in AscendFusedMoEMethod, which
+    # delegates to an inner scheme that carries quant_type / group_size.
+    inner_scheme = getattr(quant_method, "quant_method", None)
+    if inner_scheme is not None and hasattr(inner_scheme, "quant_type"):
+        quant_method = inner_scheme
+    quant_type = getattr(quant_method, "quant_type", QuantType.NONE)
+
+    if not api_capability.available:
+        return _unsupported(api_capability.reason, quant_type)
+
+    if device_type == AscendDeviceType.A5:
+        if quant_type not in _A5_QUANT_TYPES:
+            return _unsupported(f"A5 MegaMoe does not support {quant_type.name}", quant_type)
+        if getattr(quant_method, "group_size", None) != 32:
+            return _unsupported("A5 MXFP MegaMoe requires group_size=32", quant_type)
+        if not api_capability.supports_comm_context_preload:
+            return _unsupported("A5 MegaMoe requires comm-context preloading", quant_type)
+    elif device_type in {AscendDeviceType.A2, AscendDeviceType.A3}:
+        if quant_type not in _A3_QUANT_TYPES:
+            return _unsupported(f"A2/A3 MegaMoe does not support {quant_type.name}", quant_type)
+    else:
+        return _unsupported(f"MegaMoe is not supported on {device_type}", quant_type)
+
+    resolved_activation = resolve_cann_mega_moe_activation(
+        activation,
+        situ_beta=situ_beta,
+        situ_linear_beta=situ_linear_beta,
+    )
+    if resolved_activation is None:
+        return _unsupported(f"unsupported MegaMoe activation: {activation}", quant_type)
+    if resolved_activation.name == "situglu" and not api_capability.supports_situ:
+        return _unsupported("installed MegaMoe API does not expose SiTU parameters", quant_type)
+    if resolved_activation.name == "situglu" and device_type != AscendDeviceType.A5:
+        return _unsupported("SiTU MegaMoe is supported only on A5", quant_type)
+
+    in_dtype = getattr(moe_config, "in_dtype", None)
+    if in_dtype not in {torch.bfloat16, torch.float16}:
+        return _unsupported(f"unsupported MegaMoe input dtype: {in_dtype}", quant_type)
+
+    hidden = int(moe_config.hidden_dim)
+    if hidden < 1024 or hidden > 8192 or hidden % 512 != 0:
+        return _unsupported(f"unsupported MegaMoe hidden size: {hidden}", quant_type)
+
+    intermediate_hidden = 2 * int(moe_config.intermediate_size_per_partition)
+    if intermediate_hidden < 1024 or intermediate_hidden % 512 != 0:
+        return _unsupported(f"unsupported MegaMoe intermediate size: {intermediate_hidden}", quant_type)
+
+    num_topk = int(moe_config.experts_per_token)
+    max_topk = 32 if device_type == AscendDeviceType.A5 else 16
+    if num_topk < 1 or num_topk > max_topk:
+        return _unsupported(f"unsupported MegaMoe top-k: {num_topk}", quant_type)
+
+    ep_size = int(moe_config.ep_size)
+    max_ep_size = 1024 if device_type == AscendDeviceType.A5 else 64
+    if ep_size < 2 or ep_size > max_ep_size:
+        return _unsupported(f"unsupported MegaMoe EP size: {ep_size}", quant_type)
+
+    num_experts = int(moe_config.num_experts)
+    max_num_experts = 2048 if device_type == AscendDeviceType.A5 else 1024
+    if num_experts < ep_size or num_experts > max_num_experts or num_experts % ep_size != 0:
+        return _unsupported(
+            f"MegaMoe requires experts divisible by EP size, got experts={num_experts}, EP={ep_size}",
+            quant_type,
+        )
+
+    return CannMegaMoeLayerCapability(True, "", quant_type, resolved_activation)
+
+
+def get_model_cann_mega_moe_capability(model_instance: torch.nn.Module | None) -> CannMegaMoeLayerCapability:
+    """Aggregate immutable layer capabilities and cache the model result."""
+    if model_instance is None:
+        return _unsupported("model instance is unavailable", QuantType.NONE)
+
+    cached = getattr(model_instance, _MODEL_CAPABILITY_ATTR, None)
+    if isinstance(cached, CannMegaMoeLayerCapability):
+        return cached
+
+    layer_capabilities = [
+        capability
+        for module in model_instance.modules()
+        if isinstance((capability := getattr(module, _LAYER_CAPABILITY_ATTR, None)), CannMegaMoeLayerCapability)
+    ]
+    if not layer_capabilities:
+        # The model can be queried while its module tree is still being built.
+        # Do not cache this transient result.
+        return _unsupported("model has no registered MegaMoe-capable layers", QuantType.NONE)
+
+    first_unsupported = next((capability for capability in layer_capabilities if not capability.supported), None)
+    result = first_unsupported or layer_capabilities[0]
+    setattr(model_instance, _MODEL_CAPABILITY_ATTR, result)
+    return result

--- a/vllm_ascend/ops/fused_moe/moe_comm_method.py
+++ b/vllm_ascend/ops/fused_moe/moe_comm_method.py
@@ -30,6 +30,10 @@ from vllm_ascend.ops.fused_moe.dataclass.fused_experts import MoEFusedExpertsInp
 from vllm_ascend.ops.fused_moe.dataclass.moe_mlp import MoEMlpComputeInput, build_mlp_compute_input
 from vllm_ascend.ops.fused_moe.dataclass.prepare_finalize import MoEPrepareOutput
 from vllm_ascend.ops.fused_moe.dataclass.token_dispatcher import build_token_dispatch_input
+from vllm_ascend.ops.fused_moe.mega_moe_adapter import (
+    CannMegaMoeLayerCapability,
+    resolve_cann_mega_moe_activation,
+)
 from vllm_ascend.ops.fused_moe.moe_mlp import unified_apply_mlp
 from vllm_ascend.ops.fused_moe.prepare_finalize import (
     PrepareAndFinalize,
@@ -52,12 +56,19 @@ def get_moe_comm_method(moe_comm_type: MoECommType | None) -> MoECommMethod | No
     return _MoECommMethods.get(moe_comm_type)
 
 
-def setup_moe_comm_method(moe_config):
+def setup_moe_comm_method(
+    moe_config,
+    *,
+    cann_mega_moe_capability: CannMegaMoeLayerCapability | None = None,
+):
     if moe_config.ep_size > 1:
         _MoECommMethods[MoECommType.ALLTOALL] = AlltoAllCommImpl(moe_config)
         _MoECommMethods[MoECommType.ALLGATHER] = AllGatherCommImpl(moe_config)
         _MoECommMethods[MoECommType.MC2] = MC2CommImpl(moe_config)
-        _MoECommMethods[MoECommType.FUSED_MC2] = FusedMC2CommImpl(moe_config)
+        _MoECommMethods[MoECommType.FUSED_MC2] = FusedMC2CommImpl(
+            moe_config,
+            cann_mega_moe_capability=cann_mega_moe_capability,
+        )
     else:
         _MoECommMethods[MoECommType.ALLGATHER] = AllGatherCommImpl(moe_config)
 
@@ -257,12 +268,26 @@ class FusedMC2CommImpl(MoECommMethod):
     Communication and Computation parallelism on Ascend devices.
     """
 
-    def __init__(self, moe_config):
+    def __init__(
+        self,
+        moe_config,
+        *,
+        cann_mega_moe_capability: CannMegaMoeLayerCapability | None = None,
+    ):
+        self.cann_mega_moe_capability = cann_mega_moe_capability or CannMegaMoeLayerCapability(
+            False,
+            "layer capability was not registered",
+            QuantType.NONE,
+        )
         super().__init__(moe_config)
         self.enable_fused_mc2 = get_ascend_config().enable_fused_mc2
-        if self.enable_fused_mc2 == 1 and is_mega_moe_supported():
-            self.mega_moe_symm_buffer = None
-            self.get_symm_buffer_for_mega_moe, self.mega_moe = moe_utils.load_cann_mega_moe_ops()
+        self.mega_moe_symm_buffer = None
+        self.get_symm_buffer_for_mega_moe = None
+        self.mega_moe = None
+        if self.enable_fused_mc2 == 1 and self.cann_mega_moe_capability.supported:
+            self.get_symm_buffer_for_mega_moe, self.mega_moe = moe_utils.load_cann_mega_moe_ops(
+                preload_comm_context=self.token_dispatcher.a5_need_extra_args,
+            )
         if self.enable_fused_mc2 == 1:
             self.expert_token_nums = torch.zeros([self.moe_config.num_local_experts], dtype=torch.int32, device="npu")
         else:
@@ -276,7 +301,9 @@ class FusedMC2CommImpl(MoECommMethod):
         return self.prepare_finalize.pad_and_split_input_ids(input_ids)  # type: ignore[attr-defined]
 
     def _get_token_dispatcher(self):
-        return TokenDispatcherWithMC2()
+        return TokenDispatcherWithMC2(
+            cann_mega_moe_supported=self.cann_mega_moe_capability.supported,
+        )
 
     def _get_prepare_finalize(self):
         return PrepareAndFinalizeWithMC2(self.moe_config)
@@ -311,19 +338,31 @@ class FusedMC2CommImpl(MoECommMethod):
             num_max_tokens_per_rank = max(1, int(rank_invariant_cap))
         num_topk = self.moe_config.experts_per_token
         num_experts = self.moe_config.num_experts
-        expert_per_rank = max(1, num_experts // int(self.token_dispatcher.ep_world_size))
-        max_recv_token_num = max(
-            1,
-            num_max_tokens_per_rank * int(self.token_dispatcher.ep_world_size) * min(num_topk, expert_per_rank),
-        )
+        if self.token_dispatcher.a5_need_extra_args:
+            # A5 accepts this attribute only in [0, 4096]. Zero selects the
+            # operator's documented automatic mode.
+            max_recv_token_num = 0
+        else:
+            expert_per_rank = max(1, num_experts // int(self.token_dispatcher.ep_world_size))
+            max_recv_token_num = max(
+                1,
+                num_max_tokens_per_rank * int(self.token_dispatcher.ep_world_size) * min(num_topk, expert_per_rank),
+            )
 
         logger.info(
-            "CANN MegaMoe sym-buffer alloc (must match across all EP ranks): ep_rank=%s ep_world=%s global_bs=%s",
+            "CANN MegaMoe sym-buffer alloc (must match across all EP ranks): "
+            "ep_rank=%s ep_world=%s global_bs=%s tokens_per_rank=%s "
+            "num_experts=%s num_topk=%s hidden=%s",
             getattr(self.token_dispatcher, "ep_rank_id", "?"),
             getattr(self.token_dispatcher, "ep_world_size", "?"),
             self.token_dispatcher.global_bs,
+            num_max_tokens_per_rank,
+            num_experts,
+            num_topk,
+            self.moe_config.hidden_dim,
         )
 
+        assert self.get_symm_buffer_for_mega_moe is not None
         return self.get_symm_buffer_for_mega_moe(
             group,
             num_experts,
@@ -339,10 +378,13 @@ class FusedMC2CommImpl(MoECommMethod):
     def _apply_cann_mega_moe(
         self,
         fused_experts_input: MoEFusedExpertsInput,
+        topk_ids: torch.Tensor,
     ):
         # TokenDispatcherWithMC2 carries global_bs (used below for the mc2_mask
         # branch); assert the subtype so mypy resolves it off the base class.
         assert isinstance(self.token_dispatcher, TokenDispatcherWithMC2)
+        assert fused_experts_input.weights.w1_scale is not None
+        assert fused_experts_input.weights.w2_scale is not None
         num_tokens = fused_experts_input.hidden_states.shape[0]
         num_max_tokens = self.token_dispatcher.max_num_tokens_per_rank
         if num_tokens > num_max_tokens:
@@ -355,16 +397,31 @@ class FusedMC2CommImpl(MoECommMethod):
         def to_list(x):
             return x if isinstance(x, list) else [x]
 
-        weight1 = to_list(fused_experts_input.weights.w1)
-        weight2 = to_list(fused_experts_input.weights.w2)
+        if fused_experts_input.quant.quant_type == QuantType.W4A8MXFP:
+            # W4A8 MXFP weights are stored as transposed views for grouped
+            # matmul. Transpose those views back without duplicating storage.
+            # Relative dimensions also handle one tensor per expert.
+            weight1 = [tensor.transpose(-2, -1) for tensor in to_list(fused_experts_input.weights.w1)]
+            weight2 = [tensor.transpose(-2, -1) for tensor in to_list(fused_experts_input.weights.w2)]
+            weight_scales1 = [tensor.transpose(-3, -2) for tensor in to_list(fused_experts_input.weights.w1_scale)]
+            weight_scales2 = [tensor.transpose(-3, -2) for tensor in to_list(fused_experts_input.weights.w2_scale)]
+        else:
+            weight1 = to_list(fused_experts_input.weights.w1)
+            weight2 = to_list(fused_experts_input.weights.w2)
+            weight_scales1 = to_list(fused_experts_input.weights.w1_scale)
+            weight_scales2 = to_list(fused_experts_input.weights.w2_scale)
         # A8W4-INT MegaMoe reads N from weight1.storageShape.lastDim treated as int8 (N = lastDim*2)
         # and checks weight2.dim0 == N/2, so the weights MUST be int8-shaped (two int4 per byte), NOT
         # the eight-int4-per-int32 packing (that makes the op read N four times too small and fail
         # CheckWeight2Input). The op prototype also REQUIRES FRACTAL_NZ per expert. The W4A8 quant
         # method therefore builds per-expert int8 + FRACTAL_NZ lists (cann_mega_moe_*_weight_list) and
         # they are passed through as-is here. W8A8 weights are already int8 + FRACTAL_NZ, also as-is.
-        weight_scales1 = fused_experts_input.weights.w1_scale
-        weight_scales2 = fused_experts_input.weights.w2_scale
+        weight_scales1 = [
+            tensor.squeeze(0) if tensor.dim() == 2 and tensor.shape[0] == 1 else tensor for tensor in weight_scales1
+        ]
+        weight_scales2 = [
+            tensor.squeeze(0) if tensor.dim() == 2 and tensor.shape[0] == 1 else tensor for tensor in weight_scales2
+        ]
         dispatch_quant_mode, dispatch_quant_out_dtype, weight_type = moe_utils._get_cann_mega_moe_quant_settings(
             fused_experts_input.quant.quant_type
         )
@@ -378,9 +435,21 @@ class FusedMC2CommImpl(MoECommMethod):
             self.mega_moe_symm_buffer.dispatch_quant_mode = dispatch_quant_mode
             self.mega_moe_symm_buffer.dispatch_quant_out_dtype = dispatch_quant_out_dtype
 
-        activation_clamp = self.swiglu_limit if self.swiglu_limit > 0 else None
+        activation_config = resolve_cann_mega_moe_activation(
+            fused_experts_input.activation,
+            situ_beta=getattr(self.moe_config, "activation_situ_beta", None),
+            situ_linear_beta=getattr(self.moe_config, "activation_situ_linear_beta", None),
+        )
+        if activation_config is None:
+            raise RuntimeError(f"Unsupported CANN MegaMoe activation: {fused_experts_input.activation}")
+        activation = activation_config.name
+        activation_clamp = None if activation == "situglu" else self.swiglu_limit if self.swiglu_limit > 0 else None
         x_active_mask = None
-        if self.token_dispatcher.global_bs == 0 and fused_experts_input.routing.mc2_mask is not None:
+        if (
+            fused_experts_input.quant.quant_type != QuantType.W4A8MXFP
+            and self.token_dispatcher.global_bs == 0
+            and fused_experts_input.routing.mc2_mask is not None
+        ):
             # mc2_mask comes from the reserved bool buffer in
             # ascend_forward_context.set_mc2_mask. MegaMoe wants int8 as
             # the per-token active mask, so cast only when the dtype does
@@ -395,9 +464,21 @@ class FusedMC2CommImpl(MoECommMethod):
         l1_bias = fused_experts_input.weights.w1_scale_bias
         l2_bias = fused_experts_input.weights.w2_scale_bias
 
+        activation_kwargs = {}
+        if activation == "situglu":
+            activation_kwargs = {
+                "activation": activation,
+                "activation_params": {
+                    "beta": activation_config.beta,
+                    "linear_beta": activation_config.alpha,
+                },
+            }
+
+        assert self.mega_moe is not None
+
         out, expert_tokens = self.mega_moe(
             fused_experts_input.hidden_states,
-            fused_experts_input.topk_ids.to(torch.int32),
+            topk_ids.to(torch.int32),
             fused_experts_input.topk_weights.to(torch.float32),
             weight1,
             weight2,
@@ -410,6 +491,7 @@ class FusedMC2CommImpl(MoECommMethod):
             activation_clamp=activation_clamp,
             weight1_type=weight_type,
             weight2_type=weight_type,
+            **activation_kwargs,
         )
         # NOTE: self.expert_token_nums is only used by the
         # mega_moe path (enable_fused_mc2 == 1) as a
@@ -426,10 +508,28 @@ class FusedMC2CommImpl(MoECommMethod):
             "token_dispatcher must be an instance of TokenDispatcherWithMC2."
         )
 
+        runtime_activation = resolve_cann_mega_moe_activation(
+            fused_experts_input.activation,
+            situ_beta=getattr(self.moe_config, "activation_situ_beta", None),
+            situ_linear_beta=getattr(self.moe_config, "activation_situ_linear_beta", None),
+        )
+        use_cann_mega_moe = (
+            self.cann_mega_moe_capability.supported
+            and self.mega_moe is not None
+            and fused_experts_input.quant.quant_type == self.cann_mega_moe_capability.quant_type
+            and runtime_activation == self.cann_mega_moe_capability.activation
+        )
+        if is_mega_moe_supported() and not use_cann_mega_moe:
+            return super().fused_experts(fused_experts_input)
+
+        topk_ids = fused_experts_input.topk_ids
+        if fused_experts_input.routing.log2phy is not None:
+            topk_ids = fused_experts_input.routing.log2phy[topk_ids]
+
         expert_tokens = None
         if get_ascend_config().enable_fused_mc2 == 1:
-            if _EXTRA_CTX.use_mega_moe:
-                out, expert_tokens = self._apply_cann_mega_moe(fused_experts_input)
+            if use_cann_mega_moe:
+                out, expert_tokens = self._apply_cann_mega_moe(fused_experts_input, topk_ids)
             else:
                 assert not (
                     fused_experts_input.weights.w1_scale_bias is None
@@ -441,7 +541,7 @@ class FusedMC2CommImpl(MoECommMethod):
                     x=fused_experts_input.hidden_states,
                     weight1=fused_experts_input.weights.w1,
                     weight2=fused_experts_input.weights.w2,
-                    expert_idx=fused_experts_input.topk_ids,
+                    expert_idx=topk_ids,
                     scale1=fused_experts_input.weights.w1_scale,
                     scale2=fused_experts_input.weights.w2_scale,
                     bias1=fused_experts_input.weights.w1_scale_bias,

--- a/vllm_ascend/ops/fused_moe/moe_utils.py
+++ b/vllm_ascend/ops/fused_moe/moe_utils.py
@@ -15,7 +15,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-from functools import lru_cache
+from functools import cache, lru_cache
 from importlib import import_module
 
 import torch
@@ -31,6 +31,7 @@ _CANN_ACL_INT8 = 258
 _CANN_ACL_INT4 = 285
 _CANN_MEGA_MOE_QUANT_MODE_None = 0
 _CANN_MEGA_MOE_QUANT_MODE_INT8 = 2
+_CANN_MEGA_MOE_QUANT_MODE_MX = 4
 
 
 def async_all_to_all(input_, output_split_sizes, input_split_sizes, group, event=None):
@@ -114,14 +115,24 @@ def gather_from_sequence_parallel_region(
     return _gather_along_first_dim(input_, group, output_split_sizes)
 
 
-def load_cann_mega_moe_ops():
+@cache
+def load_cann_mega_moe_ops(*, preload_comm_context: bool = False):
+    if preload_comm_context:
+        # A5 multi-node MegaMoe must build the communication-context extension
+        # during model initialization. Deferring it until the first collective
+        # serializes local workers on the JIT lock and can make other ranks time
+        # out in HCCL. Preserve the existing lazy behavior on A2/A3.
+        comm_context_module = import_module("cann_ops_transformer.ops.comm_context")
+        comm_context_module.comm_context_op_builder.load()
     ops_module = import_module("cann_ops_transformer.ops")
     get_symm_buffer_for_mega_moe = ops_module.get_symm_buffer_for_mega_moe
     mega_moe = ops_module.mega_moe
     return get_symm_buffer_for_mega_moe, mega_moe
 
 
-def _get_cann_mega_moe_quant_settings(quant_type: QuantType) -> tuple[int, int | None, int | None]:
+def _get_cann_mega_moe_quant_settings(
+    quant_type: QuantType,
+) -> tuple[int, int | torch.dtype | None, int | torch.dtype | None]:
     # Returns (dispatch_quant_mode, dispatch_quant_out_dtype, weight_type).
     # The current custom op package still requires explicit INT4 for W4A8
     # packed weights; otherwise it derives W4A8's packed N as an INT8 N and
@@ -137,6 +148,15 @@ def _get_cann_mega_moe_quant_settings(quant_type: QuantType) -> tuple[int, int |
         return (_CANN_MEGA_MOE_QUANT_MODE_INT8, _CANN_ACL_INT8, _CANN_ACL_INT8)
     if quant_type == QuantType.W4A8:
         return (_CANN_MEGA_MOE_QUANT_MODE_INT8, _CANN_ACL_INT8, _CANN_ACL_INT4)
+    if quant_type == QuantType.W4A8MXFP:
+        # The packaged wrapper maps torch dtypes via _TORCH_DTYPE_TO_INT. Raw
+        # ACL enum integers are passed through unchanged and corrupt the ACL
+        # parameter binding (surfacing later as moeExpertNum=0).
+        return (
+            _CANN_MEGA_MOE_QUANT_MODE_MX,
+            torch.float8_e4m3fn,
+            torch_npu.float4_e2m1fn_x2,
+        )
     if quant_type == QuantType.NONE:
         return (_CANN_MEGA_MOE_QUANT_MODE_None, None, None)
 

--- a/vllm_ascend/ops/fused_moe/token_dispatcher.py
+++ b/vllm_ascend/ops/fused_moe/token_dispatcher.py
@@ -110,7 +110,7 @@ class MoETokenDispatcher(ABC, Generic[TMoECombineMetadata]):
 
 
 class TokenDispatcherWithMC2(MoETokenDispatcher[MoEMC2CombineMetadata]):
-    def __init__(self, **kwargs):
+    def __init__(self, *, cann_mega_moe_supported: bool | None = None, **kwargs):
         super().__init__(**kwargs)
         device_group = get_mc2_group().device_group
         # TODO: Try local_rank = ep_group.rank_in_group
@@ -132,18 +132,28 @@ class TokenDispatcherWithMC2(MoETokenDispatcher[MoEMC2CombineMetadata]):
         tp_size = vllm_config.parallel_config.tensor_parallel_size
         mc2_tokens_capacity = get_mc2_tokens_capacity()
         num_tokens_per_tp_rank = mc2_tokens_capacity // tp_size
-        # Surface the per-rank capacity for CANN MegaMoe's get_symm_buffer
-        # sizing (used by FusedMC2CommImpl._get_cann_symm_buffer). Without
-        # this, MegaMoe falls back to hidden_states.shape[0] which jitters
-        # under eager mode and forces sym-buffer rebuilds every step.
+        # MegaMoe is selected for prefill as well as decode. Preserve the
+        # existing decode-derived MC2 capacity for global_bs, but size its
+        # symmetric buffer for the larger of decode and a full prefill shard.
         self.max_num_tokens_per_rank = num_tokens_per_tp_rank
+        if self.a5_need_extra_args:
+            max_num_batched_tokens = int(vllm_config.scheduler_config.max_num_batched_tokens)
+            prefill_tokens_per_tp_rank = (max_num_batched_tokens + tp_size - 1) // tp_size
+            self.max_num_tokens_per_rank = max(num_tokens_per_tp_rank, prefill_tokens_per_tp_rank)
         _max_global_bs = num_tokens_per_tp_rank * self.ep_world_size
 
         # When allreduce across DP is not skipped, tokens are uniform across ranks:
         # use global_bs=0 (uniform mode) and pass mc2_mask.
         # When allreduce is skipped, tokens may differ per rank:
         # use the real global_bs and do NOT pass mc2_mask.
-        self.global_bs = _max_global_bs if should_skip_allreduce_across_dp_group(vllm_config) else 0
+        self.global_bs = (
+            _max_global_bs
+            if should_skip_allreduce_across_dp_group(
+                vllm_config,
+                cann_mega_moe_supported=cann_mega_moe_supported,
+            )
+            else 0
+        )
 
     def refresh_hccl_group(self) -> None:
         """Refresh MC2 communicator metadata after HCCL groups are recreated."""

--- a/vllm_ascend/utils.py
+++ b/vllm_ascend/utils.py
@@ -1100,7 +1100,13 @@ def get_potential_max_tokens() -> int:
     return _potential_max_tokens
 
 
-def should_skip_allreduce_across_dp_group(vllm_config: VllmConfig, is_draft_model: bool = False) -> bool:
+def should_skip_allreduce_across_dp_group(
+    vllm_config: VllmConfig,
+    is_draft_model: bool = False,
+    *,
+    model_instance: torch.nn.Module | None = None,
+    cann_mega_moe_supported: bool | None = None,
+) -> bool:
     """Decide whether to skip the all-reduce across the DP group.
 
     Skipping is applicable for all dense models and for moe models only on ranks
@@ -1137,13 +1143,21 @@ def should_skip_allreduce_across_dp_group(vllm_config: VllmConfig, is_draft_mode
         return False
 
     from vllm_ascend.ascend_forward_context import select_moe_comm_method, use_cann_megamoe
+    from vllm_ascend.ops.fused_moe.mega_moe_adapter import get_model_cann_mega_moe_capability
     from vllm_ascend.ops.fused_moe.moe_comm_method import MoECommType
 
-    if use_cann_megamoe(vllm_config):
+    if cann_mega_moe_supported is None and model_instance is not None:
+        cann_mega_moe_supported = get_model_cann_mega_moe_capability(model_instance).supported
+    if use_cann_megamoe(vllm_config) or cann_mega_moe_supported:
         return False
 
     def needs_mc2(n: int) -> bool:
-        return select_moe_comm_method(n, vllm_config) in {MoECommType.MC2, MoECommType.FUSED_MC2}
+        return select_moe_comm_method(
+            n,
+            vllm_config,
+            model_instance=model_instance,
+            cann_mega_moe_supported=cann_mega_moe_supported,
+        ) in {MoECommType.MC2, MoECommType.FUSED_MC2}
 
     scheduler_config = vllm_config.scheduler_config
     # potential_max_tokens is read from the set/get global (computed once in init).

--- a/vllm_ascend/worker/model_runner_v1.py
+++ b/vllm_ascend/worker/model_runner_v1.py
@@ -724,7 +724,11 @@ class NPUModelRunner(GPUModelRunner):
         if self.dp_size == 1:
             return num_tokens, None, cudagraph_mode
 
-        if should_skip_allreduce_across_dp_group(self.vllm_config, is_draft_model):
+        if should_skip_allreduce_across_dp_group(
+            self.vllm_config,
+            is_draft_model,
+            model_instance=None if is_draft_model else self.model,
+        ):
             num_tokens_after_padding = torch.tensor([num_tokens] * self.dp_size, device="cpu", dtype=torch.int32)
             return num_tokens, num_tokens_after_padding, cudagraph_mode
 


### PR DESCRIPTION
### What this PR does / why we need it?

This PR migrates the final changes from #14780, whose base is `releases/v0.26.0rc`, to the current `main` branch and adapts them to the refactored MoE runtime.

- Selects CANN MegaMoe from instantiated layer capabilities instead of checkpoint metadata or model names.
- Adds A5 W4A8 MXFP (`group_size=32`) support, including SiTU parameters, MXFP weight/scale layout conversion, logical-to-physical expert mapping, comm-context preloading, and A5 symmetric-buffer sizing.
- Preserves A2/A3 BF16, W8A8, and W4A8 behavior and falls back to the existing non-MegaMoe path for unsupported layouts or operator APIs.
- Propagates the aggregated model capability through communication selection and DP token synchronization.
- Documents the supported configurations and adds unit coverage for API probing, capability decisions, invalid layouts, A2/A3 compatibility, and model aggregation.

### Does this PR introduce _any_ user-facing change?

Yes. With `enable_fused_mc2=1`, supported A5 W4A8 MXFP MoE layers can use CANN MegaMoe. Unsupported layer layouts continue to use the existing fallback path.

### How was this patch tested?

- `ruff check` passed for all changed Python files.
- `ruff format --check` passed for all changed Python files.
- `markdownlint-cli@0.45.0` passed for the updated documentation.
- Added `tests/ut/ops/test_mega_moe_adapter.py`.
- The unit test file and NPU end-to-end path were not executed locally because the available Windows host has no Python/torch-npu or NPU runtime; they require CI and A5 hardware validation.

- vLLM main: https://github.com/vllm-project/vllm/commit/ba07e4a48fc951300d97eb506217dd530583dea3
