### PR TITLE
[BugFix] Rebind the PP _should_share wrapper on the DSpark caller module

### DIFF
--- a/vllm_ascend/patch/worker/patch_v2/patch_dspark.py
+++ b/vllm_ascend/patch/worker/patch_v2/patch_dspark.py
@@ -61,6 +61,7 @@ def _load_dspark_model_with_target_quant(target_model, vllm_config):
     bypass_pp_guard = spec_pp_support is not None
     original_get_pp_group = dspark_utils.get_pp_group
     original_should_share = eagle_utils._should_share
+    original_should_share_ds = dspark_utils._should_share
     if inherits_target_quant:
         model_utils.get_draft_quant_config = lambda _vllm_config: vllm_config.quant_config
     if bypass_pp_guard:
@@ -76,6 +77,11 @@ def _load_dspark_model_with_target_quant(target_model, vllm_config):
             return original_should_share(eagle, flag, draft, target)
 
         eagle_utils._should_share = should_share
+        # ``dspark/utils.py`` imports ``_should_share`` at module top level,
+        # so rebinding only the definer is not visible to its loader; rebind
+        # the caller namespace too (same concern as ``load_dspark_model``
+        # below).
+        dspark_utils._should_share = should_share
     try:
         # get_model also reads the config PP size; keep the draft unsharded.
         with bypass_upstream_spec_pp_guard(vllm_config, spec_pp_support):
@@ -86,6 +92,7 @@ def _load_dspark_model_with_target_quant(target_model, vllm_config):
         if bypass_pp_guard:
             dspark_utils.get_pp_group = original_get_pp_group
             eagle_utils._should_share = original_should_share
+            dspark_utils._should_share = original_should_share_ds
 
 
 # The speculator binds ``load_dspark_model`` by name at import time, so both

--- a/vllm_ascend/patch/worker/patch_v2/patch_dspark.py
+++ b/vllm_ascend/patch/worker/patch_v2/patch_dspark.py
@@ -61,7 +61,7 @@ def _load_dspark_model_with_target_quant(target_model, vllm_config):
     bypass_pp_guard = spec_pp_support is not None
     original_get_pp_group = dspark_utils.get_pp_group
     original_should_share = eagle_utils._should_share
-    original_should_share_ds = dspark_utils._should_share
+    original_should_share_ds = getattr(dspark_utils, "_should_share", None)
     if inherits_target_quant:
         model_utils.get_draft_quant_config = lambda _vllm_config: vllm_config.quant_config
     if bypass_pp_guard:
@@ -79,9 +79,10 @@ def _load_dspark_model_with_target_quant(target_model, vllm_config):
         eagle_utils._should_share = should_share
         # ``dspark/utils.py`` imports ``_should_share`` at module top level,
         # so rebinding only the definer is not visible to its loader; rebind
-        # the caller namespace too (same concern as ``load_dspark_model``
-        # below).
-        dspark_utils._should_share = should_share
+        # the caller namespace too when present (same concern as
+        # ``load_dspark_model`` below).
+        if original_should_share_ds is not None:
+            dspark_utils._should_share = should_share
     try:
         # get_model also reads the config PP size; keep the draft unsharded.
         with bypass_upstream_spec_pp_guard(vllm_config, spec_pp_support):
@@ -92,7 +93,8 @@ def _load_dspark_model_with_target_quant(target_model, vllm_config):
         if bypass_pp_guard:
             dspark_utils.get_pp_group = original_get_pp_group
             eagle_utils._should_share = original_should_share
-            dspark_utils._should_share = original_should_share_ds
+            if original_should_share_ds is not None:
+                dspark_utils._should_share = original_should_share_ds
 
 
 # The speculator binds ``load_dspark_model`` by name at import time, so both


### PR DESCRIPTION
### What this PR does / why we need it?

`vllm_ascend/patch/worker/patch_v2/patch_dspark.py` (from #14822) installs a
`PPMissingLayer`-safe wrapper for `_should_share` while loading the DSpark
draft under PP, but rebinds it only on the **defining** module
(`eagle.utils`).

Upstream `vllm/v1/worker/gpu/spec_decode/dspark/utils.py` imports
`_should_share` at module top level
(`from ...eagle.utils import _should_share`) and resolves it from its own
module globals inside `load_dspark_model`, so the wrapper never takes effect
on the DSpark path.

On the last PP stage the target embed/lm_head is `PPMissingLayer`; the
unwrapped `_should_share` dereferences `target.weight` and draft loading
crashes before the server becomes ready:

AttributeError: 'PPMissingLayer' object has no attribute 'weight'
  File ".../vllm/v1/worker/gpu/spec_decode/eagle/utils.py", line 25, in _should_share
  File ".../vllm/v1/worker/gpu/spec_decode/dspark/utils.py", line 62, in load_dspark_model
  File ".../vllm_ascend/patch/worker/patch_v2/patch_dspark.py", line 82, in _load_dspark_model_with_target_quant

Fix: save/install/restore `_should_share` on `dspark_utils` as well,
mirroring the existing `get_pp_group` rebinding in the same function — the
same caller-binding concern the file already handles for
`load_dspark_model` (see the comment at the bottom of the file).

Note: `tests/e2e/pull_request/eight_card/model_runner_v2/test_spec_pp_accuracy.py`
(added by #14822 and registered in `.github/workflows/scripts/test_config.yaml`)
hits the same crash at draft loading without the fix, so any CI lane that
picks that test up cannot pass on current main.

### Does this PR introduce _any_ user-facing change?

No behavior change beyond making the existing PP draft-embedding protection
take effect: any DSpark+PP run crashes at startup without it.

### How was this patch tested?

- DeepSeek V4 Flash w4a8 + DSpark (5 draft tokens) + V2 model runner +
  dual-node TP8×PP2 + EP, `--enforce-eager`: crashes during draft loading on
  the last PP stage without the fix; starts and serves with it.
- The e2e test above (`test_spec_pp_accuracy.py`, DSV4 DSpark PP2/TP4/EP
  eager) passed 5/5 consecutive runs with this fix applied on top of the
  pre-merge #14822 branch.

- vLLM main: https://github.com/vllm-project/vllm/commit/ba07e4a48fc951300d97eb506217dd530583dea3
