### PR TITLE
[Feature][Ops] Add VectorPagedAttention, a vector-core paged decode attention

### DIFF
--- a/csrc/attention/vector_paged_attention/CMakeLists.txt
+++ b/csrc/attention/vector_paged_attention/CMakeLists.txt
@@ -1,0 +1,19 @@
+# -----------------------------------------------------------------------------------------------------------
+# Copyright (c) 2026 Huawei Technologies Co., Ltd.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+
+file(GLOB CURRENT_DIRS RELATIVE ${CMAKE_CURRENT_SOURCE_DIR} ${CMAKE_CURRENT_SOURCE_DIR}/*)
+if(NOT ENABLE_TEST AND NOT BENCHMARK)
+    list(REMOVE_ITEM CURRENT_DIRS tests)
+endif()
+foreach(SUB_DIR ${CURRENT_DIRS})
+    if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/${SUB_DIR}/CMakeLists.txt")
+        add_subdirectory(${SUB_DIR})
+    endif()
+endforeach()

--- a/csrc/attention/vector_paged_attention/README.md
+++ b/csrc/attention/vector_paged_attention/README.md
@@ -1,0 +1,79 @@
+# VectorPagedAttention
+
+Single-query paged attention for small decode shapes, executed entirely on the
+AI vector cores.
+
+## Why it exists
+
+At a decode step with one query row per request, a short context and a modest
+head count, the general fused attention operator is dominated by fixed
+per-call cost rather than by the KV traffic it performs. Raising the declared
+KV capacity from 128 to 512 on an Atlas A3 costs about 1.3 us of the ~25 us a
+call takes, so most of that time is not the work.
+
+This operator removes the fixed cost by doing only one thing. A single AI
+vector core owns one `(request, head)` pair: it reads that head's slice of the
+pages the sequence actually occupies, keeps the whole softmax in UB and writes
+its own `head_dim` outputs. No core waits for another, there is no combine
+pass, and the operator asks for no workspace of its own beyond the system
+reserve. The kernel is `KERNEL_TYPE_AIV_ONLY`.
+
+It also reads `seq_lens` from device memory, so it touches only the pages the
+sequence occupies rather than a padded capacity. That matters when the caller
+declares a constant capacity to keep host-side arguments stable across an
+aclgraph replay.
+
+## Interface
+
+```python
+from vllm_ascend.utils import enable_custom_op
+
+enable_custom_op()
+attn_out = torch.ops._C_ascend.npu_vector_paged_attention(
+    query,             # [batch, num_heads, head_dim] bfloat16
+    key_cache,         # [num_blocks, block_size, num_kv_heads * head_dim] bfloat16
+    value_cache,       # same shape as key_cache
+    block_table,       # [batch, max_blocks] int32
+    seq_lens,          # [batch] int32
+    num_kv_heads=num_heads,
+    scale=head_dim ** -0.5,
+)                      # -> [batch, num_heads, head_dim] bfloat16
+```
+
+`key_cache` and `value_cache` may also be given as
+`[num_blocks, block_size, num_kv_heads, head_dim]`; the adapter views them,
+never copies.
+
+## Declared domain
+
+This is a narrow operator, not a general one. Everything below is checked in
+the torch adapter, which raises a `RuntimeError` naming the violated rule, and
+again in tiling. **Check the domain before an aclgraph capture**: a tiling
+failure during capture is an error, not a fallback to another kernel.
+
+| property | supported |
+| --- | --- |
+| dtype | bfloat16 |
+| `head_dim` | 64 |
+| heads | multi-head only, `num_kv_heads == num_heads`, up to 128 heads |
+| query rows | one per request |
+| `batch` | 1 to 32 |
+| `block_size` | a power of two in [8, 128] |
+| `block_size * block_table.size(1)` | at most 4096 |
+| `batch * num_heads` | at most the die's AI vector core count, 48 on both supported SOCs |
+| SOC | `ascend910b`, `ascend910_93` |
+
+The `batch * num_heads` bound is the operator's shape: one task per core, no
+tail loop. A caller can test it directly with
+`torch_npu.npu.get_device_properties(device).vector_core_num`.
+
+Outside this domain, keep using
+`torch_npu.npu_fused_infer_attention_score`, which is what this operator is
+narrower than, not a replacement for.
+
+## Accuracy
+
+The kernel accumulates in fp32 throughout: it casts the bfloat16 query and KV
+pages up on load, applies the scale to the query rather than to every score,
+and rounds once on the way out. Against an fp32 reference it is bit-exact at
+the shapes in `tests/e2e/nightly/single_node/ops/singlecard_ops/test_vector_paged_attention.py`.

--- a/csrc/attention/vector_paged_attention/op_host/CMakeLists.txt
+++ b/csrc/attention/vector_paged_attention/op_host/CMakeLists.txt
@@ -1,0 +1,29 @@
+# This program is free software, you can redistribute it and/or modify it.
+# Copyright (c) 2026 Huawei Technologies Co., Ltd.
+# This file is a part of the CANN Open Software.
+# Licensed under CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# ======================================================================================================================
+add_op_to_compiled_list()
+
+if (BUILD_OPEN_PROJECT)
+    target_sources(op_host_aclnn PRIVATE
+        vector_paged_attention_def.cpp
+    )
+endif()
+
+add_ops_compile_options(
+    OP_NAME VectorPagedAttention
+    OPTIONS
+        --cce-auto-sync=off
+        -Wno-deprecated-declarations
+)
+
+if (NOT BUILD_OPS_RTY_KERNEL)
+    add_modules_sources(OPTYPE vector_paged_attention ACLNNTYPE aclnn)
+    target_include_directories(${OPHOST_NAME}_tiling_obj PRIVATE
+        ${CMAKE_CURRENT_SOURCE_DIR}
+    )
+endif()

--- a/csrc/attention/vector_paged_attention/op_host/vector_paged_attention_def.cpp
+++ b/csrc/attention/vector_paged_attention/op_host/vector_paged_attention_def.cpp
@@ -1,0 +1,80 @@
+/**
+ * Copyright (c) Huawei Technologies Co., Ltd. 2026. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*!
+ * \file vector_paged_attention_def.cpp
+ * \brief Operator definition for VectorPagedAttention
+ */
+#include "register/op_def_registry.h"
+
+namespace ops {
+class VectorPagedAttention : public OpDef {
+ public:
+  explicit VectorPagedAttention(const char* name) : OpDef(name) {
+    this->Input("query")
+        .ParamType(REQUIRED)
+        .DataType({ge::DT_BF16})
+        .Format({ge::FORMAT_ND})
+        .UnknownShapeFormat({ge::FORMAT_ND})
+        .AutoContiguous();
+    this->Input("keyCache")
+        .ParamType(REQUIRED)
+        .DataType({ge::DT_BF16})
+        .Format({ge::FORMAT_ND})
+        .UnknownShapeFormat({ge::FORMAT_ND});
+    this->Input("valueCache")
+        .ParamType(REQUIRED)
+        .DataType({ge::DT_BF16})
+        .Format({ge::FORMAT_ND})
+        .UnknownShapeFormat({ge::FORMAT_ND});
+    this->Input("blockTable")
+        .ParamType(REQUIRED)
+        .DataType({ge::DT_INT32})
+        .Format({ge::FORMAT_ND})
+        .UnknownShapeFormat({ge::FORMAT_ND})
+        .AutoContiguous();
+    this->Input("seqLens")
+        .ParamType(REQUIRED)
+        .DataType({ge::DT_INT32})
+        .Format({ge::FORMAT_ND})
+        .UnknownShapeFormat({ge::FORMAT_ND})
+        .AutoContiguous();
+    this->Output("attnOut")
+        .ParamType(REQUIRED)
+        .DataType({ge::DT_BF16})
+        .Format({ge::FORMAT_ND})
+        .UnknownShapeFormat({ge::FORMAT_ND});
+    this->Attr("numHeads").Int();
+    this->Attr("numKvHeads").Int();
+    this->Attr("scale").Float();
+
+    OpAICoreConfig aicoreConfig;
+    aicoreConfig.DynamicCompileStaticFlag(true)
+        .DynamicFormatFlag(true)
+        .DynamicRankSupportFlag(true)
+        .DynamicShapeSupportFlag(true)
+        .NeedCheckSupportFlag(false)
+        // The kernel casts bfloat16 up on load and accumulates in fp32
+        // throughout, so there is no reduced-precision variant to fall back to.
+        .PrecisionReduceFlag(false)
+        .ExtendCfgInfo("aclnnSupport.value", "support_aclnn");
+    this->AICore().AddConfig("ascend910b", aicoreConfig);
+    this->AICore().AddConfig("ascend910_93", aicoreConfig);
+  }
+};
+
+OP_ADD(VectorPagedAttention);
+}  // namespace ops

--- a/csrc/attention/vector_paged_attention/op_host/vector_paged_attention_infershape.cpp
+++ b/csrc/attention/vector_paged_attention/op_host/vector_paged_attention_infershape.cpp
@@ -1,0 +1,48 @@
+/**
+ * This program is free software, you can redistribute it and/or modify.
+ * Copyright (c) 2026 Huawei Technologies Co., Ltd.
+ * This file is a part of the CANN Open Software.
+ * Licensed under CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ */
+
+/*!
+ * \file vector_paged_attention_infershape.cpp
+ * \brief InferShape implementation for VectorPagedAttention
+ */
+#include <graph/utils/type_utils.h>
+#include <register/op_impl_registry.h>
+
+using namespace ge;
+namespace ops {
+namespace {
+constexpr size_t QUERY_INDEX = 0;
+constexpr size_t ATTN_OUT_INDEX = 0;
+constexpr size_t QUERY_DIM_NUM = 3;
+}  // namespace
+
+// The output carries the query's [batch, numHeads, headDim] shape: one row of
+// attention output per query row.
+static ge::graphStatus InferShape4VectorPagedAttention(gert::InferShapeContext* context)
+{
+    const gert::Shape* query = context->GetInputShape(QUERY_INDEX);
+    gert::Shape* attnOut = context->GetOutputShape(ATTN_OUT_INDEX);
+    if (query == nullptr || attnOut == nullptr || query->GetDimNum() != QUERY_DIM_NUM) {
+        return GRAPH_FAILED;
+    }
+    *attnOut = *query;
+    return GRAPH_SUCCESS;
+}
+
+static graphStatus InferDataType4VectorPagedAttention(gert::InferDataTypeContext* context)
+{
+    context->SetOutputDataType(ATTN_OUT_INDEX, context->GetInputDataType(QUERY_INDEX));
+    return GRAPH_SUCCESS;
+}
+
+IMPL_OP_INFERSHAPE(VectorPagedAttention)
+    .InferShape(InferShape4VectorPagedAttention)
+    .InferDataType(InferDataType4VectorPagedAttention);
+}  // namespace ops

--- a/csrc/attention/vector_paged_attention/op_host/vector_paged_attention_tiling.cpp
+++ b/csrc/attention/vector_paged_attention/op_host/vector_paged_attention_tiling.cpp
@@ -1,0 +1,210 @@
+/**
+ * Copyright (c) Huawei Technologies Co., Ltd. 2026. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*!
+ * \file vector_paged_attention_tiling.cpp
+ * \brief Tiling implementation for VectorPagedAttention
+ */
+#include "vector_paged_attention_tiling.h"
+
+#include "register/op_def_registry.h"
+#include "tiling/platform/platform_ascendc.h"
+#include "tiling_base/error_log.h"
+
+namespace optiling {
+namespace {
+// The operator's declared domain. Everything outside it is rejected here and,
+// earlier and with a better message, by the torch adapter -- a tiling failure
+// during aclgraph capture is an error, not a fallback to another kernel.
+constexpr int64_t SUPPORTED_HEAD_DIM = 64;
+constexpr int64_t MAX_BLOCK_SIZE = 128;
+constexpr int64_t MAX_KV_CAPACITY = 4096;
+constexpr int64_t MAX_BATCH = 32;
+constexpr int64_t MAX_NUM_HEADS = 128;
+
+constexpr size_t QUERY_INDEX = 0;
+constexpr size_t KEY_CACHE_INDEX = 1;
+constexpr size_t VALUE_CACHE_INDEX = 2;
+constexpr size_t BLOCK_TABLE_INDEX = 3;
+constexpr size_t SEQ_LENS_INDEX = 4;
+
+constexpr size_t ATTR_NUM_HEADS = 0;
+constexpr size_t ATTR_NUM_KV_HEADS = 1;
+constexpr size_t ATTR_SCALE = 2;
+
+constexpr size_t KV_CACHE_DIM_NUM = 3;
+constexpr size_t QUERY_DIM_NUM = 3;
+constexpr size_t BLOCK_TABLE_DIM_NUM = 2;
+constexpr size_t SEQ_LENS_DIM_NUM = 1;
+
+struct VectorPagedAttentionParams {
+    int64_t batch{0};
+    int64_t numHeads{0};
+    int64_t headDim{0};
+    int64_t blockSize{0};
+    int64_t maxBlocks{0};
+    int64_t kvStride{0};
+    int64_t numBlocks{0};
+    int64_t numKvHeads{0};
+    float scale{0.0F};
+};
+
+bool ReadAttrs(gert::TilingContext* context, VectorPagedAttentionParams& params)
+{
+    const gert::RuntimeAttrs* attrs = context->GetAttrs();
+    if (attrs == nullptr) {
+        return false;
+    }
+    const int64_t* numHeads = attrs->GetInt(ATTR_NUM_HEADS);
+    const int64_t* numKvHeads = attrs->GetInt(ATTR_NUM_KV_HEADS);
+    const float* scale = attrs->GetFloat(ATTR_SCALE);
+    if (numHeads == nullptr || numKvHeads == nullptr || scale == nullptr) {
+        return false;
+    }
+    params.numHeads = *numHeads;
+    params.numKvHeads = *numKvHeads;
+    params.scale = *scale;
+    return true;
+}
+
+// query [batch, numHeads, headDim]
+// keyCache / valueCache [numBlocks, blockSize, numKvHeads * headDim]
+// blockTable [batch, maxBlocks], seqLens [batch]
+bool ReadShapes(gert::TilingContext* context, VectorPagedAttentionParams& params)
+{
+    const gert::StorageShape* query = context->GetInputShape(QUERY_INDEX);
+    const gert::StorageShape* keyCache = context->GetInputShape(KEY_CACHE_INDEX);
+    const gert::StorageShape* valueCache = context->GetInputShape(VALUE_CACHE_INDEX);
+    const gert::StorageShape* blockTable = context->GetInputShape(BLOCK_TABLE_INDEX);
+    const gert::StorageShape* seqLens = context->GetInputShape(SEQ_LENS_INDEX);
+    if (query == nullptr || keyCache == nullptr || valueCache == nullptr ||
+        blockTable == nullptr || seqLens == nullptr) {
+        return false;
+    }
+    const gert::Shape& q = query->GetStorageShape();
+    const gert::Shape& k = keyCache->GetStorageShape();
+    const gert::Shape& v = valueCache->GetStorageShape();
+    const gert::Shape& bt = blockTable->GetStorageShape();
+    const gert::Shape& sl = seqLens->GetStorageShape();
+    if (q.GetDimNum() != QUERY_DIM_NUM || k.GetDimNum() != KV_CACHE_DIM_NUM ||
+        v.GetDimNum() != KV_CACHE_DIM_NUM || bt.GetDimNum() != BLOCK_TABLE_DIM_NUM ||
+        sl.GetDimNum() != SEQ_LENS_DIM_NUM) {
+        return false;
+    }
+    for (size_t axis = 0; axis < KV_CACHE_DIM_NUM; ++axis) {
+        if (k.GetDim(axis) != v.GetDim(axis)) {
+            return false;
+        }
+    }
+    params.batch = q.GetDim(0);
+    params.headDim = q.GetDim(2);
+    params.numBlocks = k.GetDim(0);
+    params.blockSize = k.GetDim(1);
+    params.kvStride = k.GetDim(2);
+    params.maxBlocks = bt.GetDim(1);
+    return q.GetDim(1) == params.numHeads && bt.GetDim(0) == params.batch &&
+           sl.GetDim(0) == params.batch;
+}
+
+bool InDeclaredDomain(const VectorPagedAttentionParams& params)
+{
+    return params.numHeads >= 1 && params.numHeads <= MAX_NUM_HEADS &&
+           // Multi-head only: one core owns one (request, head) and reads that
+           // head's own slice of every page, so heads cannot share KV rows.
+           params.numKvHeads == params.numHeads &&
+           params.headDim == SUPPORTED_HEAD_DIM &&
+           params.kvStride == params.numKvHeads * params.headDim &&
+           params.batch >= 1 && params.batch <= MAX_BATCH &&
+           params.blockSize >= 8 && params.blockSize <= MAX_BLOCK_SIZE &&
+           // The value pass folds a page's rows pairwise, which needs no tail
+           // handling only when the page holds a power-of-two number of rows.
+           (params.blockSize & (params.blockSize - 1)) == 0 &&
+           params.numBlocks >= 1 && params.maxBlocks >= 1 &&
+           params.blockSize * params.maxBlocks <= MAX_KV_CAPACITY;
+}
+}  // namespace
+
+static ge::graphStatus VectorPagedAttentionTilingFunc(gert::TilingContext* context)
+{
+    VectorPagedAttentionParams params;
+    if (!ReadAttrs(context, params) || !ReadShapes(context, params)) {
+        OP_LOGE(context->GetNodeName(), "VectorPagedAttention got malformed inputs or attributes.");
+        return ge::GRAPH_FAILED;
+    }
+    if (!InDeclaredDomain(params)) {
+        OP_LOGE(context->GetNodeName(),
+                "VectorPagedAttention outside its declared domain: batch=%ld numHeads=%ld "
+                "numKvHeads=%ld headDim=%ld blockSize=%ld maxBlocks=%ld. Requires headDim=64, "
+                "numKvHeads==numHeads, batch<=32, a power-of-two blockSize<=128 and "
+                "blockSize*maxBlocks<=4096.",
+                params.batch, params.numHeads, params.numKvHeads, params.headDim,
+                params.blockSize, params.maxBlocks);
+        return ge::GRAPH_FAILED;
+    }
+
+    auto* platformInfo = context->GetPlatformInfo();
+    OP_CHECK_NULL_WITH_CONTEXT(context, platformInfo);
+    auto ascendcPlatform = platform_ascendc::PlatformAscendC(platformInfo);
+    uint32_t aivCoreNum = ascendcPlatform.GetCoreNumAiv();
+    if (aivCoreNum == 0) {
+        aivCoreNum = ascendcPlatform.GetCoreNum();
+    }
+
+    // One AI vector core per (request, head). A decode step is tiny, so the
+    // split that pays is the one needing no cross-core reduction: a core owns a
+    // whole head, keeps its running softmax in UB and writes its own headDim
+    // outputs, so the operator needs no workspace of its own.
+    const int64_t blockDim = params.batch * params.numHeads;
+    if (blockDim > static_cast<int64_t>(aivCoreNum)) {
+        OP_LOGE(context->GetNodeName(),
+                "VectorPagedAttention needs batch*numHeads (%ld) <= AIV core count (%u).",
+                blockDim, aivCoreNum);
+        return ge::GRAPH_FAILED;
+    }
+
+    VectorPagedAttentionTilingData tilingData;
+    tilingData.set_batch(static_cast<uint32_t>(params.batch));
+    tilingData.set_numHeads(static_cast<uint32_t>(params.numHeads));
+    tilingData.set_headDim(static_cast<uint32_t>(params.headDim));
+    tilingData.set_blockSize(static_cast<uint32_t>(params.blockSize));
+    tilingData.set_maxBlocks(static_cast<uint32_t>(params.maxBlocks));
+    tilingData.set_kvStride(static_cast<uint32_t>(params.kvStride));
+    tilingData.set_kvCapacity(static_cast<uint32_t>(params.blockSize * params.maxBlocks));
+    tilingData.set_numBlocks(static_cast<uint32_t>(params.numBlocks));
+    tilingData.set_scale(params.scale);
+
+    context->SetBlockDim(static_cast<uint32_t>(blockDim));
+    context->SetTilingKey(0);
+    tilingData.SaveToBuffer(context->GetRawTilingData()->GetData(),
+                            context->GetRawTilingData()->GetCapacity());
+    context->GetRawTilingData()->SetDataSize(tilingData.GetDataSize());
+
+    size_t* workspaceSize = context->GetWorkspaceSizes(1);
+    OP_CHECK_NULL_WITH_CONTEXT(context, workspaceSize);
+    workspaceSize[0] = ascendcPlatform.GetLibApiWorkSpaceSize();
+    return ge::GRAPH_SUCCESS;
+}
+
+static ge::graphStatus TilingParseForVectorPagedAttention(gert::TilingParseContext* context)
+{
+    return ge::GRAPH_SUCCESS;
+}
+
+IMPL_OP_OPTILING(VectorPagedAttention)
+    .Tiling(VectorPagedAttentionTilingFunc)
+    .TilingParse<VectorPagedAttentionCompileInfo>(TilingParseForVectorPagedAttention);
+
+}  // namespace optiling

--- a/csrc/attention/vector_paged_attention/op_host/vector_paged_attention_tiling.h
+++ b/csrc/attention/vector_paged_attention/op_host/vector_paged_attention_tiling.h
@@ -1,0 +1,47 @@
+/**
+ * Copyright (c) Huawei Technologies Co., Ltd. 2026. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*!
+ * \file vector_paged_attention_tiling.h
+ * \brief Tiling data for VectorPagedAttention
+ */
+#ifndef VECTOR_PAGED_ATTENTION_TILING_H
+#define VECTOR_PAGED_ATTENTION_TILING_H
+
+#include "register/tilingdata_base.h"
+
+namespace optiling {
+BEGIN_TILING_DATA_DEF(VectorPagedAttentionTilingData)
+    TILING_DATA_FIELD_DEF(uint32_t, batch);       // requests in the step
+    TILING_DATA_FIELD_DEF(uint32_t, numHeads);    // query heads
+    TILING_DATA_FIELD_DEF(uint32_t, headDim);     // per-head width
+    TILING_DATA_FIELD_DEF(uint32_t, blockSize);   // KV rows per page
+    TILING_DATA_FIELD_DEF(uint32_t, maxBlocks);   // block_table row stride
+    TILING_DATA_FIELD_DEF(uint32_t, kvStride);    // elements per KV cache row
+    TILING_DATA_FIELD_DEF(uint32_t, kvCapacity);  // blockSize * maxBlocks
+    TILING_DATA_FIELD_DEF(uint32_t, numBlocks);   // pages in the cache
+    TILING_DATA_FIELD_DEF(float, scale);
+END_TILING_DATA_DEF;
+
+REGISTER_TILING_DATA_CLASS(VectorPagedAttention, VectorPagedAttentionTilingData)
+
+struct VectorPagedAttentionCompileInfo {
+    uint32_t aivCoreNum;
+};
+
+}  // namespace optiling
+
+#endif  // VECTOR_PAGED_ATTENTION_TILING_H

--- a/csrc/attention/vector_paged_attention/op_kernel/vector_paged_attention.cpp
+++ b/csrc/attention/vector_paged_attention/op_kernel/vector_paged_attention.cpp
@@ -1,0 +1,33 @@
+/**
+ * Copyright (c) Huawei Technologies Co., Ltd. 2026. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*!
+ * \file vector_paged_attention.cpp
+ * \brief Kernel entry for VectorPagedAttention
+ */
+#include "vector_paged_attention.h"
+
+extern "C" __global__ __aicore__ void vector_paged_attention(
+    GM_ADDR query, GM_ADDR key_cache, GM_ADDR value_cache, GM_ADDR block_table,
+    GM_ADDR seq_lens, GM_ADDR attn_out, GM_ADDR workspace, GM_ADDR tiling)
+{
+    KERNEL_TASK_TYPE_DEFAULT(KERNEL_TYPE_AIV_ONLY);
+    GET_TILING_DATA(tilingData, tiling);
+    (void)workspace;
+    VectorPagedAttentionOp::KernelVectorPagedAttention kernel;
+    kernel.Init(query, key_cache, value_cache, block_table, seq_lens, attn_out, tilingData);
+    kernel.Process();
+}

--- a/csrc/attention/vector_paged_attention/op_kernel/vector_paged_attention.h
+++ b/csrc/attention/vector_paged_attention/op_kernel/vector_paged_attention.h
@@ -1,0 +1,279 @@
+/**
+ * Copyright (c) Huawei Technologies Co., Ltd. 2026. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*!
+ * \file vector_paged_attention.h
+ * \brief Kernel implementation for VectorPagedAttention
+ */
+#ifndef VECTOR_PAGED_ATTENTION_H
+#define VECTOR_PAGED_ATTENTION_H
+
+#include "kernel_operator.h"
+
+namespace VectorPagedAttentionOp {
+using namespace AscendC;
+
+// The declared domain, enforced in the torch adapter and again in tiling:
+// 64-wide heads, multi-head (no GQA) and a power-of-two page.
+constexpr uint32_t HEAD_DIM = 64;
+constexpr uint32_t MAX_BLOCK_SIZE = 128;
+constexpr uint32_t MAX_CAPACITY = 4096;
+constexpr uint32_t MAX_BLOCK_TABLE = MAX_CAPACITY / 8;
+constexpr uint32_t MAX_BATCH = 32;
+// One repeat of a float vector instruction is 256 B.
+constexpr uint32_t FP32_PER_REPEAT = 64;
+constexpr uint32_t BLOCKS_PER_REPEAT = 8;
+// Small enough that exp() underflows to zero, large enough not to be a max.
+constexpr float MASKED_SCORE = -1.0e30F;
+
+class KernelVectorPagedAttention {
+public:
+    __aicore__ inline void Init(GM_ADDR query, GM_ADDR keyCache, GM_ADDR valueCache,
+                                GM_ADDR blockTable, GM_ADDR seqLens, GM_ADDR attnOut,
+                                const VectorPagedAttentionTilingData &tiling)
+    {
+        batch_ = tiling.batch;
+        numHeads_ = tiling.numHeads;
+        headDim_ = tiling.headDim;
+        blockSize_ = tiling.blockSize;
+        maxBlocks_ = tiling.maxBlocks;
+        kvStride_ = tiling.kvStride;
+        kvCapacity_ = tiling.kvCapacity;
+        scale_ = tiling.scale;
+
+        // One core owns one (request, head): it reads that head's whole KV
+        // prefix and writes its own 64 outputs, so no core ever waits for
+        // another and there is no combine pass.
+        const uint32_t task = GetBlockIdx();
+        batchIdx_ = task / numHeads_;
+        headIdx_ = task % numHeads_;
+
+        const uint64_t kvElems = static_cast<uint64_t>(tiling.numBlocks) * blockSize_ * kvStride_;
+        queryGm_.SetGlobalBuffer(reinterpret_cast<__gm__ bfloat16_t *>(query),
+                                 static_cast<uint64_t>(batch_) * numHeads_ * headDim_);
+        keyGm_.SetGlobalBuffer(reinterpret_cast<__gm__ bfloat16_t *>(keyCache), kvElems);
+        valueGm_.SetGlobalBuffer(reinterpret_cast<__gm__ bfloat16_t *>(valueCache), kvElems);
+        blockTableGm_.SetGlobalBuffer(reinterpret_cast<__gm__ int32_t *>(blockTable),
+                                      static_cast<uint64_t>(batch_) * maxBlocks_);
+        seqLensGm_.SetGlobalBuffer(reinterpret_cast<__gm__ int32_t *>(seqLens), batch_);
+        outGm_.SetGlobalBuffer(reinterpret_cast<__gm__ bfloat16_t *>(attnOut),
+                               static_cast<uint64_t>(batch_) * numHeads_ * headDim_);
+
+        pipe_.InitBuffer(seqBuf_, MAX_BATCH * sizeof(int32_t));
+        pipe_.InitBuffer(blockTableBuf_, MAX_BLOCK_TABLE * sizeof(int32_t));
+        pipe_.InitBuffer(qHalfBuf_, HEAD_DIM * sizeof(bfloat16_t));
+        pipe_.InitBuffer(qBuf_, HEAD_DIM * sizeof(float));
+        pipe_.InitBuffer(tileHalfBuf_, MAX_BLOCK_SIZE * HEAD_DIM * sizeof(bfloat16_t));
+        pipe_.InitBuffer(tileBuf_, MAX_BLOCK_SIZE * HEAD_DIM * sizeof(float));
+        pipe_.InitBuffer(scoreBuf_, MAX_CAPACITY * sizeof(float));
+        pipe_.InitBuffer(weightBuf_, MAX_BLOCK_SIZE * BLOCKS_PER_REPEAT * sizeof(float));
+        pipe_.InitBuffer(accumBuf_, HEAD_DIM * sizeof(float));
+        pipe_.InitBuffer(outHalfBuf_, HEAD_DIM * sizeof(bfloat16_t));
+        pipe_.InitBuffer(reduceBuf_, FP32_PER_REPEAT * sizeof(float));
+        pipe_.InitBuffer(workBuf_, 2 * FP32_PER_REPEAT * BLOCKS_PER_REPEAT * sizeof(float));
+    }
+
+    __aicore__ inline void Process()
+    {
+        LocalTensor<int32_t> seqLocal = seqBuf_.Get<int32_t>();
+        LocalTensor<int32_t> blockIds = blockTableBuf_.Get<int32_t>();
+        LocalTensor<bfloat16_t> qHalf = qHalfBuf_.Get<bfloat16_t>();
+        const DataCopyPadExtParams<int32_t> intPad{false, 0, 0, 0};
+        DataCopyPad(seqLocal, seqLensGm_,
+                    DataCopyExtParams{1, batch_ * static_cast<uint32_t>(sizeof(int32_t)), 0, 0, 0}, intPad);
+        DataCopyPad(blockIds, blockTableGm_[batchIdx_ * maxBlocks_],
+                    DataCopyExtParams{1, maxBlocks_ * static_cast<uint32_t>(sizeof(int32_t)), 0, 0, 0}, intPad);
+        DataCopy(qHalf, queryGm_[(batchIdx_ * numHeads_ + headIdx_) * headDim_], headDim_);
+        SetFlag<HardEvent::MTE2_S>(EVENT_ID0);
+        WaitFlag<HardEvent::MTE2_S>(EVENT_ID0);
+        SetFlag<HardEvent::MTE2_V>(EVENT_ID0);
+        WaitFlag<HardEvent::MTE2_V>(EVENT_ID0);
+
+        int32_t length = seqLocal.GetValue(batchIdx_);
+        if (length < 1) length = 1;
+        if (length > static_cast<int32_t>(kvCapacity_)) length = static_cast<int32_t>(kvCapacity_);
+        const uint32_t seqLen = static_cast<uint32_t>(length);
+        // Only the pages the sequence actually occupies are read. The declared
+        // capacity bounds the buffers; it does not bound the traffic, which is
+        // the whole reason this operator can be cheaper than a fixed-capacity
+        // general attention.
+        const uint32_t pages = (seqLen + blockSize_ - 1) / blockSize_;
+        const uint32_t covered = pages * blockSize_;
+
+        LocalTensor<float> q = qBuf_.Get<float>();
+        Cast(q, qHalf, RoundMode::CAST_NONE, headDim_);
+        PipeBarrier<PIPE_V>();
+        // The scale rides on the query, so it costs one 64-wide op instead of
+        // one pass over every score.
+        Muls(q, q, scale_, headDim_);
+        PipeBarrier<PIPE_V>();
+
+        LocalTensor<bfloat16_t> tileHalf = tileHalfBuf_.Get<bfloat16_t>();
+        LocalTensor<float> tile = tileBuf_.Get<float>();
+        LocalTensor<float> scores = scoreBuf_.Get<float>();
+        // A page holds `blockSize` rows of `kvStride` elements; this head owns
+        // `headDim` of each row, so one strided burst per page reads it all.
+        const DataCopyParams pageCopy{
+            static_cast<uint16_t>(blockSize_),
+            static_cast<uint16_t>(headDim_ * sizeof(bfloat16_t) / 32),
+            static_cast<uint16_t>((kvStride_ - headDim_) * sizeof(bfloat16_t) / 32),
+            0};
+        // Every repeat is one KV row against the whole query: src1 walks its
+        // eight blocks (blkStride 1) and restarts each repeat (repStride 0).
+        const BinaryRepeatParams queryBroadcast{1, 1, 1, BLOCKS_PER_REPEAT, BLOCKS_PER_REPEAT, 0};
+
+        for (uint32_t page = 0; page < pages; ++page) {
+            LoadPage(tileHalf, keyGm_, blockIds.GetValue(page), pageCopy);
+            Cast(tile, tileHalf, RoundMode::CAST_NONE, blockSize_ * headDim_);
+            PipeBarrier<PIPE_V>();
+            Mul(tile, tile, q, FP32_PER_REPEAT, blockSize_, queryBroadcast);
+            PipeBarrier<PIPE_V>();
+            WholeReduceSum<float>(scores[page * blockSize_], tile, FP32_PER_REPEAT,
+                                  blockSize_, 1, 1, BLOCKS_PER_REPEAT);
+            PipeBarrier<PIPE_V>();
+            SetFlag<HardEvent::V_MTE2>(EVENT_ID0);
+            WaitFlag<HardEvent::V_MTE2>(EVENT_ID0);
+        }
+
+        // Mask the tail of the last page. A vector instruction's operand has
+        // to start on a 32 B boundary, and `seqLen` is an arbitrary number of
+        // floats into the buffer, so the few elements below the next boundary
+        // are written as scalars and the aligned remainder in one go.
+        if (covered > seqLen) {
+            const uint32_t aligned = (seqLen + 7U) & ~7U;
+            if (aligned > seqLen) {
+                SetFlag<HardEvent::V_S>(EVENT_ID0);
+                WaitFlag<HardEvent::V_S>(EVENT_ID0);
+                for (uint32_t index = seqLen; index < aligned && index < covered; ++index) {
+                    scores.SetValue(index, MASKED_SCORE);
+                }
+                SetFlag<HardEvent::S_V>(EVENT_ID0);
+                WaitFlag<HardEvent::S_V>(EVENT_ID0);
+            }
+            if (covered > aligned) {
+                Duplicate(scores[aligned], MASKED_SCORE, static_cast<int32_t>(covered - aligned));
+                PipeBarrier<PIPE_V>();
+            }
+        }
+
+        LocalTensor<float> reduce = reduceBuf_.Get<float>();
+        LocalTensor<float> work = workBuf_.Get<float>();
+        ReduceMax<float>(reduce, scores, work, static_cast<int32_t>(covered), false);
+        PipeBarrier<PIPE_V>();
+        SetFlag<HardEvent::V_S>(EVENT_ID0);
+        WaitFlag<HardEvent::V_S>(EVENT_ID0);
+        const float peak = reduce.GetValue(0);
+        SetFlag<HardEvent::S_V>(EVENT_ID0);
+        WaitFlag<HardEvent::S_V>(EVENT_ID0);
+        Adds(scores, scores, -peak, static_cast<int32_t>(covered));
+        PipeBarrier<PIPE_V>();
+        Exp(scores, scores, static_cast<int32_t>(covered));
+        PipeBarrier<PIPE_V>();
+        ReduceSum<float>(reduce, scores, work, static_cast<int32_t>(covered));
+        PipeBarrier<PIPE_V>();
+        SetFlag<HardEvent::V_S>(EVENT_ID0);
+        WaitFlag<HardEvent::V_S>(EVENT_ID0);
+        const float denominator = reduce.GetValue(0);
+        SetFlag<HardEvent::S_V>(EVENT_ID0);
+        WaitFlag<HardEvent::S_V>(EVENT_ID0);
+
+        LocalTensor<float> accum = accumBuf_.Get<float>();
+        LocalTensor<float> weights = weightBuf_.Get<float>();
+        Duplicate(accum, 0.0F, static_cast<int32_t>(headDim_));
+        PipeBarrier<PIPE_V>();
+        // Each repeat of this multiply wants one score replicated across the
+        // whole 64-wide row; Brcb puts it in a block and src1BlkStride=0 makes
+        // all eight blocks of the repeat read that one block.
+        const BinaryRepeatParams weightBroadcast{1, 1, 0, BLOCKS_PER_REPEAT, BLOCKS_PER_REPEAT, 1};
+        for (uint32_t page = 0; page < pages; ++page) {
+            LoadPage(tileHalf, valueGm_, blockIds.GetValue(page), pageCopy);
+            Cast(tile, tileHalf, RoundMode::CAST_NONE, blockSize_ * headDim_);
+            PipeBarrier<PIPE_V>();
+            Brcb(weights, scores[page * blockSize_],
+                 static_cast<uint8_t>(blockSize_ / BLOCKS_PER_REPEAT),
+                 BrcbRepeatParams{1, BLOCKS_PER_REPEAT});
+            PipeBarrier<PIPE_V>();
+            Mul(tile, tile, weights, FP32_PER_REPEAT, blockSize_, weightBroadcast);
+            PipeBarrier<PIPE_V>();
+            // Fold the page's rows into row 0 by halving; a page holds a
+            // power-of-two number of rows, so this needs no tail handling.
+            for (uint32_t half = blockSize_ >> 1; half > 0; half >>= 1) {
+                Add(tile, tile, tile[half * headDim_], FP32_PER_REPEAT, half,
+                    BinaryRepeatParams{1, 1, 1, BLOCKS_PER_REPEAT, BLOCKS_PER_REPEAT, BLOCKS_PER_REPEAT});
+                PipeBarrier<PIPE_V>();
+            }
+            Add(accum, accum, tile, static_cast<int32_t>(headDim_));
+            PipeBarrier<PIPE_V>();
+            SetFlag<HardEvent::V_MTE2>(EVENT_ID0);
+            WaitFlag<HardEvent::V_MTE2>(EVENT_ID0);
+        }
+
+        Muls(accum, accum, 1.0F / denominator, static_cast<int32_t>(headDim_));
+        PipeBarrier<PIPE_V>();
+        LocalTensor<bfloat16_t> outHalf = outHalfBuf_.Get<bfloat16_t>();
+        Cast(outHalf, accum, RoundMode::CAST_RINT, headDim_);
+        SetFlag<HardEvent::V_MTE3>(EVENT_ID0);
+        WaitFlag<HardEvent::V_MTE3>(EVENT_ID0);
+        DataCopy(outGm_[(batchIdx_ * numHeads_ + headIdx_) * headDim_], outHalf, headDim_);
+    }
+
+private:
+    __aicore__ inline void LoadPage(const LocalTensor<bfloat16_t> &dst,
+                                    const GlobalTensor<bfloat16_t> &cache,
+                                    int32_t blockId, const DataCopyParams &params)
+    {
+        const uint64_t base =
+            static_cast<uint64_t>(blockId) * blockSize_ * kvStride_ + headIdx_ * headDim_;
+        SetFlag<HardEvent::S_MTE2>(EVENT_ID0);
+        WaitFlag<HardEvent::S_MTE2>(EVENT_ID0);
+        DataCopy(dst, cache[base], params);
+        SetFlag<HardEvent::MTE2_V>(EVENT_ID0);
+        WaitFlag<HardEvent::MTE2_V>(EVENT_ID0);
+    }
+
+    TPipe pipe_;
+    TBuf<TPosition::VECCALC> seqBuf_;
+    TBuf<TPosition::VECCALC> blockTableBuf_;
+    TBuf<TPosition::VECCALC> qHalfBuf_;
+    TBuf<TPosition::VECCALC> qBuf_;
+    TBuf<TPosition::VECCALC> tileHalfBuf_;
+    TBuf<TPosition::VECCALC> tileBuf_;
+    TBuf<TPosition::VECCALC> scoreBuf_;
+    TBuf<TPosition::VECCALC> weightBuf_;
+    TBuf<TPosition::VECCALC> accumBuf_;
+    TBuf<TPosition::VECCALC> outHalfBuf_;
+    TBuf<TPosition::VECCALC> reduceBuf_;
+    TBuf<TPosition::VECCALC> workBuf_;
+    GlobalTensor<bfloat16_t> queryGm_;
+    GlobalTensor<bfloat16_t> keyGm_;
+    GlobalTensor<bfloat16_t> valueGm_;
+    GlobalTensor<int32_t> blockTableGm_;
+    GlobalTensor<int32_t> seqLensGm_;
+    GlobalTensor<bfloat16_t> outGm_;
+    uint32_t batch_ = 1;
+    uint32_t numHeads_ = 1;
+    uint32_t headDim_ = HEAD_DIM;
+    uint32_t blockSize_ = MAX_BLOCK_SIZE;
+    uint32_t maxBlocks_ = 1;
+    uint32_t kvStride_ = HEAD_DIM;
+    uint32_t kvCapacity_ = MAX_BLOCK_SIZE;
+    uint32_t batchIdx_ = 0;
+    uint32_t headIdx_ = 0;
+    float scale_ = 1.0F;
+};
+}  // namespace VectorPagedAttentionOp
+
+#endif  // VECTOR_PAGED_ATTENTION_H

--- a/csrc/attention/vector_paged_attention/vector_paged_attention_torch_adpt.h
+++ b/csrc/attention/vector_paged_attention/vector_paged_attention_torch_adpt.h
@@ -1,0 +1,131 @@
+/*
+ * Copyright (c) Huawei Technologies Co., Ltd. 2026. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#ifndef VECTOR_PAGED_ATTENTION_TORCH_ADPT_H
+#define VECTOR_PAGED_ATTENTION_TORCH_ADPT_H
+
+namespace vllm_ascend {
+namespace vector_paged_attention_detail {
+
+constexpr int64_t QUERY_DIM_NUM = 3;
+constexpr int64_t KV_CACHE_DIM_NUM = 3;
+constexpr int64_t KV_CACHE_WITH_HEAD_DIM_NUM = 4;
+constexpr int64_t BLOCK_TABLE_DIM_NUM = 2;
+constexpr int64_t SEQ_LENS_DIM_NUM = 1;
+
+constexpr int64_t SUPPORTED_HEAD_DIM = 64;
+constexpr int64_t MIN_BLOCK_SIZE = 8;
+constexpr int64_t MAX_BLOCK_SIZE = 128;
+constexpr int64_t MAX_KV_CAPACITY = 4096;
+constexpr int64_t MAX_BATCH = 32;
+// One AI vector core runs one (request, head), so the whole step must fit in
+// the vector cores of a single die. Both SOCs this operator declares support
+// for have 48; tiling re-checks against the platform value it is given.
+constexpr int64_t MAX_TASKS = 48;
+
+// Normalize [num_blocks, block_size, num_kv_heads, head_dim] to the
+// [num_blocks, block_size, num_kv_heads * head_dim] the kernel indexes. Both
+// spell the same memory, so this is a view and never a copy.
+inline at::Tensor FlattenCache(const at::Tensor& cache)
+{
+    if (cache.dim() == KV_CACHE_WITH_HEAD_DIM_NUM) {
+        return cache.view({cache.size(0), cache.size(1), cache.size(2) * cache.size(3)});
+    }
+    return cache;
+}
+
+inline void CheckVectorPagedAttentionParams(
+    const at::Tensor& query, const at::Tensor& keyCache, const at::Tensor& valueCache,
+    const at::Tensor& blockTable, const at::Tensor& seqLens, int64_t numKvHeads)
+{
+    TORCH_CHECK(query.dim() == QUERY_DIM_NUM,
+                "query must be [batch, num_heads, head_dim]; got ", query.dim(), " dims");
+    TORCH_CHECK(query.scalar_type() == at::kBFloat16,
+                "vector paged attention is bfloat16 only; query is ", query.scalar_type());
+    TORCH_CHECK(keyCache.scalar_type() == at::kBFloat16 &&
+                    valueCache.scalar_type() == at::kBFloat16,
+                "key_cache and value_cache must be bfloat16");
+    TORCH_CHECK(keyCache.sizes() == valueCache.sizes(),
+                "key_cache and value_cache must have the same shape");
+    TORCH_CHECK(keyCache.dim() == KV_CACHE_DIM_NUM || keyCache.dim() == KV_CACHE_WITH_HEAD_DIM_NUM,
+                "key_cache must be [num_blocks, block_size, num_kv_heads*head_dim] or "
+                "[num_blocks, block_size, num_kv_heads, head_dim]");
+    TORCH_CHECK(keyCache.is_contiguous() && valueCache.is_contiguous(),
+                "key_cache and value_cache must be contiguous");
+    TORCH_CHECK(blockTable.dim() == BLOCK_TABLE_DIM_NUM && blockTable.scalar_type() == at::kInt,
+                "block_table must be a 2D int32 tensor");
+    TORCH_CHECK(seqLens.dim() == SEQ_LENS_DIM_NUM && seqLens.scalar_type() == at::kInt,
+                "seq_lens must be a 1D int32 tensor");
+
+    const int64_t batch = query.size(0);
+    const int64_t numHeads = query.size(1);
+    const int64_t headDim = query.size(2);
+    const at::Tensor flatKey = FlattenCache(keyCache);
+    const int64_t blockSize = flatKey.size(1);
+    const int64_t kvStride = flatKey.size(2);
+    const int64_t maxBlocks = blockTable.size(1);
+
+    TORCH_CHECK(blockTable.size(0) == batch && seqLens.size(0) == batch,
+                "block_table and seq_lens must have one row per request; got ",
+                blockTable.size(0), " and ", seqLens.size(0), " for batch ", batch);
+    TORCH_CHECK(headDim == SUPPORTED_HEAD_DIM,
+                "vector paged attention supports head_dim ", SUPPORTED_HEAD_DIM,
+                " only; got ", headDim);
+    TORCH_CHECK(numKvHeads == numHeads,
+                "vector paged attention is multi-head only: num_kv_heads (", numKvHeads,
+                ") must equal num_heads (", numHeads, ")");
+    TORCH_CHECK(kvStride == numKvHeads * headDim,
+                "key_cache row must hold num_kv_heads*head_dim (", numKvHeads * headDim,
+                ") elements; got ", kvStride);
+    TORCH_CHECK(batch >= 1 && batch <= MAX_BATCH,
+                "batch must be in [1, ", MAX_BATCH, "]; got ", batch);
+    TORCH_CHECK(blockSize >= MIN_BLOCK_SIZE && blockSize <= MAX_BLOCK_SIZE &&
+                    (blockSize & (blockSize - 1)) == 0,
+                "block_size must be a power of two in [", MIN_BLOCK_SIZE, ", ", MAX_BLOCK_SIZE,
+                "]; got ", blockSize);
+    TORCH_CHECK(blockSize * maxBlocks <= MAX_KV_CAPACITY,
+                "block_size*block_table.size(1) must not exceed ", MAX_KV_CAPACITY, "; got ",
+                blockSize * maxBlocks);
+    TORCH_CHECK(batch * numHeads <= MAX_TASKS,
+                "batch*num_heads must not exceed the die's AI vector core count (", MAX_TASKS,
+                "); got ", batch * numHeads);
+}
+
+}  // namespace vector_paged_attention_detail
+
+// Single-query paged attention for small decode shapes, executed entirely on
+// the AI vector cores. See csrc/attention/vector_paged_attention/README.md for
+// the declared domain and when this is faster than the general fused operator.
+at::Tensor npu_vector_paged_attention(
+    const at::Tensor& query, const at::Tensor& keyCache, const at::Tensor& valueCache,
+    const at::Tensor& blockTable, const at::Tensor& seqLens,
+    int64_t numKvHeads, double scale)
+{
+    vector_paged_attention_detail::CheckVectorPagedAttentionParams(
+        query, keyCache, valueCache, blockTable, seqLens, numKvHeads);
+
+    const at::Tensor flatKey = vector_paged_attention_detail::FlattenCache(keyCache);
+    const at::Tensor flatValue = vector_paged_attention_detail::FlattenCache(valueCache);
+    const int64_t numHeads = query.size(1);
+    at::Tensor attnOut = at::empty(query.sizes(), query.options());
+
+    EXEC_NPU_CMD(aclnnVectorPagedAttention, query, flatKey, flatValue, blockTable, seqLens,
+                 numHeads, numKvHeads, scale, attnOut);
+    return attnOut;
+}
+
+}  // namespace vllm_ascend
+
+#endif  // VECTOR_PAGED_ATTENTION_TORCH_ADPT_H

--- a/csrc/build_aclnn.sh
+++ b/csrc/build_aclnn.sh
@@ -135,6 +135,7 @@ elif [[ "$SOC_VERSION" =~ ^ascend910b ]]; then
         "sparse_attention_score"
         "k2q_csr"
         "msa_index_score"
+        "vector_paged_attention"
     )
 
     CUSTOM_OPS=$(IFS=';'; echo "${CUSTOM_OPS_ARRAY[*]}")
@@ -188,6 +189,7 @@ elif [[ "$SOC_VERSION" =~ ^ascend910_93 ]]; then
         "sparse_attention_score"
         "k2q_csr"
         "msa_index_score"
+        "vector_paged_attention"
     )
     CUSTOM_OPS=$(IFS=';'; echo "${CUSTOM_OPS_ARRAY[*]}")
     SOC_ARG="ascend910_93"

--- a/csrc/torch_binding.cpp
+++ b/csrc/torch_binding.cpp
@@ -51,6 +51,7 @@
 #include "attention/recurrent_gated_delta_rule_v310/recurrent_gated_delta_rule_310_torch_adpt.h"
 #include "attention/k2q_csr/k2q_csr_torch_adpt.h"
 #include "attention/msa_index_score/msa_index_score_torch_adpt.h"
+#include "attention/vector_paged_attention/vector_paged_attention_torch_adpt.h"
 #include "attention/sparse_attention_score/sparse_attention_score_torch_adpt.h"
 #include "attention/store_kv_block/store_kv_block_torch_adpt.h"
 #include "attention/store_kv_block_metadata/store_kv_block_metadata_torch_adpt.cpp"
@@ -2703,5 +2704,14 @@ TORCH_LIBRARY_EXPAND(CONCAT(_C, _ascend), ops)
     );
     ops.impl("npu_msa_index_score", torch::kPrivateUse1,
              &vllm_ascend::npu_msa_index_score);
+
+    ops.def(
+        "npu_vector_paged_attention("
+        "Tensor query, Tensor key_cache, Tensor value_cache, "
+        "Tensor block_table, Tensor seq_lens, *, "
+        "int num_kv_heads, float scale) -> Tensor"
+    );
+    ops.impl("npu_vector_paged_attention", torch::kPrivateUse1,
+             &vllm_ascend::npu_vector_paged_attention);
 }
 #endif

--- a/csrc/torch_binding_meta.cpp
+++ b/csrc/torch_binding_meta.cpp
@@ -345,6 +345,13 @@ at::Tensor npu_msa_index_score_meta(
         output_size, query.options().dtype(at::kFloat).device(c10::kMeta));
 }
 
+at::Tensor npu_vector_paged_attention_meta(
+    const at::Tensor &query, const at::Tensor &, const at::Tensor &,
+    const at::Tensor &, const at::Tensor &, int64_t, double)
+{
+    return at::empty_symint(query.sym_sizes(), query.options().device(c10::kMeta));
+}
+
 std::tuple<at::Tensor, at::Tensor, at::Tensor> npu_kv_quant_sparse_flash_attention_meta(
     const at::Tensor &query,
     const at::Tensor &key,
@@ -1971,6 +1978,8 @@ TORCH_LIBRARY_IMPL_EXPAND(CONCAT(_C, _ascend), Meta, ops) {
     ops.impl("npu_sparse_attention_score_prefill",
              &vllm_ascend::meta::npu_sparse_attention_score_prefill_meta);
     ops.impl("npu_msa_index_score", &vllm_ascend::meta::npu_msa_index_score_meta);
+    ops.impl("npu_vector_paged_attention",
+             &vllm_ascend::meta::npu_vector_paged_attention_meta);
     ops.impl("npu_kv_quant_sparse_flash_attention",
              &vllm_ascend::meta::npu_kv_quant_sparse_flash_attention_meta);
     // MoE dispatch-ffn-combine

--- a/tests/e2e/nightly/single_node/ops/singlecard_ops/test_vector_paged_attention.py
+++ b/tests/e2e/nightly/single_node/ops/singlecard_ops/test_vector_paged_attention.py
@@ -1,0 +1,164 @@
+#
+# Copyright (c) 2026 Huawei Technologies Co., Ltd. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+"""Correctness of the VectorPagedAttention custom operator.
+
+The reference is computed in fp32 from the same pages the operator reads, so a
+mismatch is the kernel's and not the layout's.
+"""
+
+import pytest
+import torch
+import torch_npu  # noqa: F401
+
+from vllm_ascend.utils import enable_custom_op
+
+enable_custom_op()
+
+HEAD_DIM = 64
+
+
+def _reference(query, key_cache, value_cache, block_table, seq_lens, scale):
+    """Paged single-query attention, fp32, straight from the definition."""
+    batch, num_heads, head_dim = query.shape
+    block_size = key_cache.shape[1]
+    out = torch.empty(batch, num_heads, head_dim, dtype=torch.float32)
+    for b in range(batch):
+        length = int(seq_lens[b])
+        rows = [(int(block_table[b, pos // block_size]), pos % block_size) for pos in range(length)]
+        keys = torch.stack([key_cache[blk, off] for blk, off in rows])
+        values = torch.stack([value_cache[blk, off] for blk, off in rows])
+        keys = keys.view(length, num_heads, head_dim).float()
+        values = values.view(length, num_heads, head_dim).float()
+        for h in range(num_heads):
+            scores = (keys[:, h, :] * query[b, h].float()).sum(-1) * scale
+            weights = torch.softmax(scores, dim=0)
+            out[b, h] = (weights.unsqueeze(-1) * values[:, h, :]).sum(0)
+    return out
+
+
+def _build(batch, num_heads, block_size, max_blocks, lengths, seed):
+    generator = torch.Generator().manual_seed(seed)
+    num_blocks = batch * max_blocks + 3
+    shape = (num_blocks, block_size, num_heads * HEAD_DIM)
+    query = torch.randn(batch, num_heads, HEAD_DIM, generator=generator).bfloat16()
+    key_cache = torch.randn(shape, generator=generator).bfloat16()
+    value_cache = torch.randn(shape, generator=generator).bfloat16()
+    # Deliberately non-contiguous page ids: the kernel must follow the table.
+    block_table = torch.arange(batch * max_blocks, dtype=torch.int32)
+    block_table = block_table.flip(0).reshape(batch, max_blocks) % num_blocks
+    seq_lens = torch.tensor(lengths, dtype=torch.int32)
+    return query, key_cache, value_cache, block_table, seq_lens
+
+
+@pytest.mark.parametrize(
+    "batch, num_heads, block_size, max_blocks, lengths",
+    [
+        (1, 12, 128, 4, [1]),  # a single token
+        (1, 12, 128, 4, [137]),  # mid-page
+        (1, 12, 128, 4, [512]),  # exactly the declared capacity
+        (1, 12, 16, 8, [128]),  # exactly full pages
+        (1, 12, 32, 8, [200]),  # a smaller page
+        (2, 12, 128, 4, [137, 512]),  # unequal lengths in one step
+        (4, 8, 64, 8, [7, 64, 65, 300]),  # several requests, several page counts
+        (1, 1, 8, 16, [61]),  # one head, the smallest page
+    ],
+)
+def test_matches_fp32_reference(batch, num_heads, block_size, max_blocks, lengths):
+    query, key_cache, value_cache, block_table, seq_lens = _build(
+        batch, num_heads, block_size, max_blocks, lengths, seed=1234
+    )
+    scale = HEAD_DIM**-0.5
+    expected = _reference(query, key_cache, value_cache, block_table, seq_lens, scale)
+
+    actual = torch.ops._C_ascend.npu_vector_paged_attention(
+        query.npu(),
+        key_cache.npu(),
+        value_cache.npu(),
+        block_table.npu(),
+        seq_lens.npu(),
+        num_kv_heads=num_heads,
+        scale=scale,
+    )
+
+    # The kernel accumulates in fp32 and rounds once on the way out, so the
+    # only difference from the reference should be that final rounding.
+    torch.testing.assert_close(actual.cpu().float(), expected.bfloat16().float(), atol=0.0, rtol=0.0)
+
+
+def test_accepts_a_four_dimensional_cache():
+    batch, num_heads, block_size, max_blocks = 1, 12, 128, 4
+    query, key_cache, value_cache, block_table, seq_lens = _build(
+        batch, num_heads, block_size, max_blocks, [137], seed=7
+    )
+    scale = HEAD_DIM**-0.5
+    flat = torch.ops._C_ascend.npu_vector_paged_attention(
+        query.npu(),
+        key_cache.npu(),
+        value_cache.npu(),
+        block_table.npu(),
+        seq_lens.npu(),
+        num_kv_heads=num_heads,
+        scale=scale,
+    )
+    shape = (key_cache.shape[0], block_size, num_heads, HEAD_DIM)
+    nested = torch.ops._C_ascend.npu_vector_paged_attention(
+        query.npu(),
+        key_cache.view(shape).npu(),
+        value_cache.view(shape).npu(),
+        block_table.npu(),
+        seq_lens.npu(),
+        num_kv_heads=num_heads,
+        scale=scale,
+    )
+    torch.testing.assert_close(flat.cpu(), nested.cpu(), atol=0.0, rtol=0.0)
+
+
+@pytest.mark.parametrize(
+    "mutate, message",
+    [
+        (lambda kw: kw.update(head_dim=32), "head_dim"),
+        (lambda kw: kw.update(num_kv_heads=6), "multi-head only"),
+        (lambda kw: kw.update(block_size=48), "power of two"),
+        (lambda kw: kw.update(dtype=torch.float16), "bfloat16"),
+        (lambda kw: kw.update(batch=8, num_heads=12), "vector core count"),
+    ],
+)
+def test_rejects_outside_its_declared_domain(mutate, message):
+    """Out-of-domain shapes must fail in the adapter, not during capture."""
+    kw = dict(
+        batch=1, num_heads=12, head_dim=HEAD_DIM, block_size=128, max_blocks=4, dtype=torch.bfloat16, num_kv_heads=None
+    )
+    mutate(kw)
+    batch, num_heads, head_dim = kw["batch"], kw["num_heads"], kw["head_dim"]
+    block_size, max_blocks = kw["block_size"], kw["max_blocks"]
+    num_kv_heads = kw["num_kv_heads"] if kw["num_kv_heads"] else num_heads
+    num_blocks = batch * max_blocks + 3
+    query = torch.randn(batch, num_heads, head_dim).to(kw["dtype"]).npu()
+    cache = torch.randn(num_blocks, block_size, num_kv_heads * head_dim)
+    cache = cache.to(kw["dtype"]).npu()
+    block_table = torch.zeros(batch, max_blocks, dtype=torch.int32).npu()
+    seq_lens = torch.full((batch,), 8, dtype=torch.int32).npu()
+
+    with pytest.raises(RuntimeError, match=message):
+        torch.ops._C_ascend.npu_vector_paged_attention(
+            query,
+            cache,
+            cache,
+            block_table,
+            seq_lens,
+            num_kv_heads=num_kv_heads,
+            scale=head_dim**-0.5,
+        )


### PR DESCRIPTION
### What this PR does / why we need it?

Adds `VectorPagedAttention`, a narrow custom aclnn operator: single-query paged
attention for small decode shapes, executed entirely on the AI vector cores.

**The problem.** At a decode step with one query row per request, a short
context and a modest head count, `npu_fused_infer_attention_score` is dominated
by fixed per-call cost rather than by the KV traffic it performs. Its own
numbers below say so: on an Atlas A3 (910C) the call costs 23.21 us at a KV
length of 137 and 23.88 us at 512, so reading 3.7x as much KV adds 0.67 us to a
23 us call. Almost all of the call is not the work.

**What this operator does instead.** One AI vector core owns one
`(request, head)` pair. It reads that head's slice of the pages the sequence
actually occupies, keeps the whole softmax in UB, and writes its own 64
outputs. No core waits for another, there is no combine pass, and the operator
asks for no workspace of its own. `seq_lens` is read from device memory, so the
traffic follows the real length even when the caller pins host-side arguments
to a constant capacity to keep an aclgraph replay stable.

**What it costs.** Graph-replay slope on an Atlas A3 (910C, 48 vector cores):
capture N calls and 2N calls into `NPUGraph`s and take the difference, so the
per-call figure carries no host dispatch. That protocol matters here, because
eager back-to-back calls sit on a ~9 us dispatch floor and cannot see the
device at all at these sizes.

| heads | capacity | seq_len | this operator | `npu_fused_infer_attention_score` | |
| ---: | ---: | ---: | ---: | ---: | --- |
| 12 | 512 | 137 | **6.52 us** | 23.21 us | 3.56x |
| 12 | 512 | 512 | **10.22 us** | 23.88 us | 2.34x |
| 12 | 4096 | 137 | **6.73 us** | 23.18 us | 3.44x |
| 8 | 1024 | 300 | **8.09 us** | 22.46 us | 2.77x |

Rows one and three are the same work with an eight-fold larger declared
capacity, and neither operator pays for it. Rows one and two are where the
difference in shape shows: 3.7x the KV costs the general operator 0.67 us and
costs this one 3.70 us, because this one is actually spending its time on the
KV it reads.

**And it is more accurate than the operator it is narrower than.** The kernel
casts the bfloat16 query and pages up on load, applies the scale to the query
rather than to every score, accumulates in fp32 and rounds once on the way out.
Against an fp32 reference rounded to bfloat16, maximum absolute error:

| case | this operator | `npu_fused_infer_attention_score` |
| --- | ---: | ---: |
| b1 h12 block 128, L=1 | **0** | 0 |
| b1 h12 block 128, L=137 | **0** | 1.95e-3 |
| b1 h12 block 128, L=512 | **0** | 9.77e-4 |
| b1 h12 block 16, L=128 | **0** | 1.95e-3 |
| b1 h12 block 32, L=200 | **0** | 1.95e-3 |
| b2 h12 block 128, L=137/512 | **0** | 1.95e-3 |
| b4 h8 block 64, L=7/64/65/300 | **0** | 3.91e-3 |
| b1 h1 block 8, L=61 | **0** | n/a |

Zero means the operator's only departure from exact arithmetic is the final
bfloat16 round. The last row has no comparison because I could not get the
general operator to accept a block size of 8 in this configuration.

**This PR adds the operator only.** Nothing in `vllm_ascend` calls it yet.
Wiring it into an attention backend needs its own selection rule and its own
end-to-end evidence, and I would rather that be reviewed separately.

**Scope, deliberately narrow.** This is a special case of the general operator,
not a replacement, and the special case is declared: bfloat16, `head_dim` 64,
`num_kv_heads == num_heads`, one query row per request, batch up to 32, a
power-of-two `block_size` in [8, 128], `block_size * block_table.size(1)` up to
4096, and `batch * num_heads` no greater than the die's AI vector core count.
`TORCH_CHECK` in the torch adapter rejects anything outside that with a message
naming the rule, and tiling checks it again. The adapter check is the
load-bearing one: a tiling failure during aclgraph capture is an error, not a
fallback to another kernel, so a caller has to know the domain before it
captures. `csrc/attention/vector_paged_attention/README.md` states it, and a
caller can test the core-count rule with
`torch_npu.npu.get_device_properties(device).vector_core_num`.

For provenance: an earlier build of this kernel, called from a small
autoregressive audio decoder in a serving stack, measured a 7.1% end-to-end
real-time-factor improvement over two die-swapped paired rounds with identical
output token counts. That number belongs to that stack rather than to this
repository, so the per-call figures above are what this PR claims.

### Does this PR introduce _any_ user-facing change?

One addition, no change to existing behaviour: after `enable_custom_op()`,
`torch.ops._C_ascend.npu_vector_paged_attention` exists, built for `ascend910b`
and `ascend910_93`. No existing operator, backend, configuration or default is
touched.

### How was this patch tested?

On an Atlas A3 (`Ascend910_9382`, 48 vector cores), CANN 9.0.0, torch/torch_npu
2.10.0.

**1. It builds through this repository's own operator build.**

```bash
bash csrc/build.sh --pkg \
  --ops="vector_paged_attention;sparse_attn_sharedkv_metadata;vllm_quant_lightning_indexer_metadata" \
  --soc=ascend910_93
```

Exit 0, no failed targets, and a `cann-ops-transformer-custom_linux-aarch64.run`
produced. The two `*_metadata` entries are only there because the aicpu symbol
step in `csrc/CMakeLists.txt` references those targets unconditionally, so a
single-operator build cannot configure; `csrc/build_aclnn.sh` always builds the
whole list, so this is not a problem for the normal path.

**2. Accuracy and timing, through the adapter in this PR.** The two tables
above. The harness compiles
`csrc/attention/vector_paged_attention/vector_paged_attention_torch_adpt.h`
verbatim, supplying only `EXEC_NPU_CMD` locally so it forwards to the same
generated `aclnnVectorPagedAttention` entry point with the same argument order.
Every `TORCH_CHECK`, the 4-D cache view and the output allocation exercised are
the ones in this PR.

**3. The declared domain is rejected in the adapter, before any dispatch.**

```
head_dim 32           vector paged attention supports head_dim 64 only; got 32
num_kv_heads 6 of 12  vector paged attention is multi-head only: num_kv_heads (6) must equal num_heads (12)
block_size 48         block_size must be a power of two in [8, 128]; got 48
float16               vector paged attention is bfloat16 only; query is Half
batch 8 x 12 heads    batch*num_heads must not exceed the die's AI vector core count (48); got 96
batch 64              batch must be in [1, 32]; got 64
```

**4. A 4-D cache is a view, not a copy.** Passing
`[num_blocks, block_size, num_kv_heads, head_dim]` and
`[num_blocks, block_size, num_kv_heads * head_dim]` returns bit-identical
output.

**5. Added test.** `tests/e2e/nightly/single_node/ops/singlecard_ops/test_vector_paged_attention.py`
covers the same eight shapes against the fp32 reference, the two cache
layouts, and five out-of-domain rejections.

**Two gaps, stated plainly.**

`ascend910b` is declared in the operator's `AICore` config and in
`build_aclnn.sh`, but **everything above was built and run on `ascend910_93`
only** — an A2 machine was not available to me. The kernel uses no A3-specific
feature (plain vector intrinsics, `KERNEL_TYPE_AIV_ONLY`, and both SOCs report
48 AI vector cores), so I expect it to behave the same, but that is an
expectation and not a measurement. If you would rather I drop `ascend910b`
until it has been run there, say so and I will.

And the `_C_ascend`
torch extension itself was not rebuilt, because the vllm-ascend install on this
machine is an older release and rebuilding it would have replaced the image's
working one. So the `ops.def`/`ops.impl` lines in `csrc/torch_binding.cpp` and
the meta implementation in `csrc/torch_binding_meta.cpp` are covered by review
and CI rather than by a local run. Everything below them, the operator
definition, tiling, kernel, build wiring and torch adapter, was built and run
as described above.
