### PR TITLE
[v0.26.0rc][Performance] Fuse DSV4 multi-group slot mapping

### DIFF
--- a/vllm_ascend/ops/triton/compute_slot_mapping.py
+++ b/vllm_ascend/ops/triton/compute_slot_mapping.py
@@ -82,3 +82,291 @@ def _compute_slot_mapping_kernel(
         if TOTAL_CP_WORLD_SIZE != 1:
             slot_ids = tl.where(is_local, slot_ids, PAD_ID)
         tl.store(slot_mapping_ptr + offsets, slot_ids, mask=mask)
+
+
+@triton.jit
+def _compute_slot_mapping_request(
+    start_idx,
+    end_idx,
+    req_idx,
+    positions_ptr,
+    block_table_ptr,
+    block_table_stride,
+    block_size,
+    slot_mapping_ptr,
+    KV_CACHE_BLOCK_SIZE: tl.constexpr,
+    BLOCKS_PER_KV_BLOCK: tl.constexpr,
+    TOTAL_CP_WORLD_SIZE: tl.constexpr,
+    TOTAL_CP_RANK: tl.constexpr,
+    CP_KV_CACHE_INTERLEAVE_SIZE: tl.constexpr,
+    PAD_ID: tl.constexpr,
+    TILE_BLOCK_SIZE: tl.constexpr,
+    BLOCK_TABLE_WINDOW_SIZE: tl.constexpr,
+):
+    row_offset = req_idx * block_table_stride
+    block_table_offsets = tl.arange(0, BLOCK_TABLE_WINDOW_SIZE)
+    for i in range(start_idx, end_idx, TILE_BLOCK_SIZE):
+        offsets = i + tl.arange(0, TILE_BLOCK_SIZE)
+        mask = offsets < end_idx
+        pos = tl.load(positions_ptr + offsets, mask=mask, other=0).to(tl.int32)
+        if TOTAL_CP_WORLD_SIZE == 1:
+            block_indices = pos // block_size
+            slot_offsets = pos - block_indices * block_size
+        else:
+            virtual_block_size = KV_CACHE_BLOCK_SIZE * TOTAL_CP_WORLD_SIZE
+            virtual_block_indices = pos // virtual_block_size
+            virtual_block_offsets = pos - virtual_block_indices * virtual_block_size
+            is_local = (virtual_block_offsets // CP_KV_CACHE_INTERLEAVE_SIZE) % TOTAL_CP_WORLD_SIZE == TOTAL_CP_RANK
+            local_block_offsets = (
+                virtual_block_offsets // (TOTAL_CP_WORLD_SIZE * CP_KV_CACHE_INTERLEAVE_SIZE)
+            ) * CP_KV_CACHE_INTERLEAVE_SIZE + (virtual_block_offsets % CP_KV_CACHE_INTERLEAVE_SIZE)
+
+            block_indices = virtual_block_indices * BLOCKS_PER_KV_BLOCK + local_block_offsets // block_size
+            slot_offsets = local_block_offsets % block_size
+
+        INT32_MAX = 2147483647
+        valid_block_indices = tl.where(mask, block_indices, INT32_MAX)
+        block_idx_base = tl.min(valid_block_indices, axis=0)
+        block_table_window_offsets = block_idx_base + block_table_offsets
+        block_table_window = tl.load(
+            block_table_ptr + row_offset + block_table_window_offsets,
+            mask=block_table_window_offsets < block_table_stride,
+            other=0,
+        ).to(tl.float32)
+        if TOTAL_CP_WORLD_SIZE == 1:
+            relative_block_indices = tl.where(mask, block_indices - block_idx_base, 0)
+        else:
+            relative_block_indices = tl.where(mask & is_local, block_indices - block_idx_base, 0)
+        block_numbers = tl.gather(block_table_window, relative_block_indices, 0).to(tl.int32)
+        slot_ids = block_numbers * block_size + slot_offsets
+        if TOTAL_CP_WORLD_SIZE != 1:
+            slot_ids = tl.where(is_local, slot_ids, PAD_ID)
+        tl.store(slot_mapping_ptr + offsets, slot_ids, mask=mask)
+
+
+@triton.jit(do_not_specialize=["num_tokens", "max_num_tokens"])
+def _compute_slot_mapping_fused_groups_kernel(
+    num_tokens,
+    max_num_tokens,
+    query_start_loc_ptr,
+    positions_ptr,
+    block_table_addrs_ptr,
+    slot_mapping_addrs_ptr,
+    block_table_strides_ptr,
+    block_sizes_ptr,
+    PAD_ID: tl.constexpr,
+    NUM_REQS: tl.constexpr,
+    TILE_BLOCK_SIZE: tl.constexpr,
+    PARALLEL_TILES: tl.constexpr,
+    BLOCK_TABLE_WINDOW_SIZE: tl.constexpr,
+):
+    program_idx = tl.program_id(0)
+    programs_per_group: tl.constexpr = NUM_REQS * PARALLEL_TILES + 1
+    group_idx = program_idx // programs_per_group
+    group_program_idx = program_idx - group_idx * programs_per_group
+
+    block_table_addr = tl.load(block_table_addrs_ptr + group_idx)
+    slot_mapping_addr = tl.load(slot_mapping_addrs_ptr + group_idx)
+    block_table_ptr = tl.cast(block_table_addr, tl.pointer_type(tl.int32))
+    slot_mapping_ptr = tl.cast(slot_mapping_addr, tl.pointer_type(tl.int32))
+
+    if group_program_idx == programs_per_group - 1:
+        for i in range(num_tokens, max_num_tokens, TILE_BLOCK_SIZE):
+            offsets = i + tl.arange(0, TILE_BLOCK_SIZE)
+            tl.store(
+                slot_mapping_ptr + offsets,
+                PAD_ID,
+                mask=offsets < max_num_tokens,
+            )
+        return
+
+    req_idx = group_program_idx // PARALLEL_TILES
+    tile_idx = group_program_idx - req_idx * PARALLEL_TILES
+    start_idx = tl.load(query_start_loc_ptr + req_idx).to(tl.int64)
+    end_idx = tl.load(query_start_loc_ptr + req_idx + 1).to(tl.int64)
+    block_table_stride = tl.load(block_table_strides_ptr + group_idx)
+    block_size = tl.load(block_sizes_ptr + group_idx)
+    row_offset = req_idx * block_table_stride
+    block_table_offsets = tl.arange(0, BLOCK_TABLE_WINDOW_SIZE)
+    for i in range(
+        start_idx + tile_idx * TILE_BLOCK_SIZE,
+        end_idx,
+        TILE_BLOCK_SIZE * PARALLEL_TILES,
+    ):
+        offsets = i + tl.arange(0, TILE_BLOCK_SIZE)
+        mask = offsets < end_idx
+        pos = tl.load(positions_ptr + offsets, mask=mask, other=0).to(tl.int32)
+        block_indices = pos // block_size
+        slot_offsets = pos - block_indices * block_size
+
+        INT32_MAX = 2147483647
+        valid_block_indices = tl.where(mask, block_indices, INT32_MAX)
+        block_idx_base = tl.min(valid_block_indices, axis=0)
+        block_table_window_offsets = block_idx_base + block_table_offsets
+        block_table_window = tl.load(
+            block_table_ptr + row_offset + block_table_window_offsets,
+            mask=block_table_window_offsets < block_table_stride,
+            other=0,
+        ).to(tl.float32)
+        relative_block_indices = tl.where(mask, block_indices - block_idx_base, 0)
+        block_numbers = tl.gather(block_table_window, relative_block_indices, 0).to(tl.int32)
+        slot_ids = block_numbers * block_size + slot_offsets
+        tl.store(slot_mapping_ptr + offsets, slot_ids, mask=mask)
+
+
+@triton.jit(do_not_specialize=["num_tokens", "max_num_tokens"])
+def _compute_slot_mapping_fused_groups_adaptive_kernel(
+    num_tokens,
+    max_num_tokens,
+    query_start_loc_ptr,
+    positions_ptr,
+    block_table_addrs_ptr,
+    slot_mapping_addrs_ptr,
+    block_table_strides_ptr,
+    block_sizes_ptr,
+    PAD_ID: tl.constexpr,
+    NUM_REQS: tl.constexpr,
+    SMALL_TILE_BLOCK_SIZE: tl.constexpr,
+    SMALL_BLOCK_TABLE_WINDOW_SIZE: tl.constexpr,
+    LARGE_BLOCK_TABLE_WINDOW_SIZE: tl.constexpr,
+):
+    program_idx = tl.program_id(0)
+    programs_per_group: tl.constexpr = NUM_REQS + 1
+    group_idx = program_idx // programs_per_group
+    group_program_idx = program_idx - group_idx * programs_per_group
+
+    block_table_addr = tl.load(block_table_addrs_ptr + group_idx)
+    slot_mapping_addr = tl.load(slot_mapping_addrs_ptr + group_idx)
+    block_table_ptr = tl.cast(block_table_addr, tl.pointer_type(tl.int32))
+    slot_mapping_ptr = tl.cast(slot_mapping_addr, tl.pointer_type(tl.int32))
+
+    if group_program_idx == NUM_REQS:
+        for i in range(num_tokens, max_num_tokens, 1024):
+            offsets = i + tl.arange(0, 1024)
+            tl.store(
+                slot_mapping_ptr + offsets,
+                PAD_ID,
+                mask=offsets < max_num_tokens,
+            )
+        return
+
+    req_idx = group_program_idx
+    start_idx = tl.load(query_start_loc_ptr + req_idx).to(tl.int64)
+    end_idx = tl.load(query_start_loc_ptr + req_idx + 1).to(tl.int64)
+    block_table_stride = tl.load(block_table_strides_ptr + group_idx)
+    block_size = tl.load(block_sizes_ptr + group_idx)
+    request_tokens = end_idx - start_idx
+    if request_tokens <= SMALL_TILE_BLOCK_SIZE:
+        _compute_slot_mapping_request(
+            start_idx,
+            end_idx,
+            req_idx,
+            positions_ptr,
+            block_table_ptr,
+            block_table_stride,
+            block_size,
+            slot_mapping_ptr,
+            1,
+            1,
+            1,
+            0,
+            1,
+            PAD_ID,
+            SMALL_TILE_BLOCK_SIZE,
+            SMALL_BLOCK_TABLE_WINDOW_SIZE,
+        )
+    else:
+        _compute_slot_mapping_request(
+            start_idx,
+            end_idx,
+            req_idx,
+            positions_ptr,
+            block_table_ptr,
+            block_table_stride,
+            block_size,
+            slot_mapping_ptr,
+            1,
+            1,
+            1,
+            0,
+            1,
+            PAD_ID,
+            1024,
+            LARGE_BLOCK_TABLE_WINDOW_SIZE,
+        )
+
+
+def _select_slot_mapping_launch_config(
+    num_reqs: int,
+    num_tokens: int,
+    max_tile_block_size: int = 1024,
+) -> tuple[int, int]:
+    tile_block_size = max_tile_block_size
+    if num_reqs > 1:
+        tokens_per_req = (num_tokens + num_reqs - 1) // num_reqs
+        tokens_per_req = 1 if tokens_per_req < 1 else tokens_per_req
+        request_tile = _next_power_of_2(tokens_per_req)
+        request_tile = 16 if request_tile < 16 else request_tile
+        tile_block_size = request_tile if request_tile < max_tile_block_size else max_tile_block_size
+
+    parallel_tiles = (num_tokens + tile_block_size - 1) // tile_block_size
+    parallel_tiles = 4 if parallel_tiles > 4 else parallel_tiles
+    if num_reqs == 1:
+        parallel_tiles = parallel_tiles if num_tokens >= 2 * tile_block_size else 1
+    elif num_reqs == 2 and num_tokens >= 4 * tile_block_size:
+        parallel_tiles = 2
+    else:
+        parallel_tiles = 1
+    return tile_block_size, parallel_tiles
+
+
+def compute_slot_mapping_fused_groups(
+    group_count,
+    num_reqs,
+    num_tokens,
+    max_num_tokens,
+    query_start_loc_ptr,
+    positions_ptr,
+    block_table_addrs_ptr,
+    slot_mapping_addrs_ptr,
+    block_table_strides_ptr,
+    block_sizes_ptr,
+    min_block_size,
+    *,
+    pad_id,
+):
+    tile_block_size, parallel_tiles = _select_slot_mapping_launch_config(num_reqs, num_tokens)
+    block_table_window_size = _next_power_of_2((tile_block_size + min_block_size - 1) // min_block_size + 1)
+    if num_reqs > 1 and tile_block_size < 1024:
+        _compute_slot_mapping_fused_groups_adaptive_kernel[(group_count * (num_reqs + 1),)](
+            num_tokens,
+            max_num_tokens,
+            query_start_loc_ptr,
+            positions_ptr,
+            block_table_addrs_ptr,
+            slot_mapping_addrs_ptr,
+            block_table_strides_ptr,
+            block_sizes_ptr,
+            PAD_ID=pad_id,
+            NUM_REQS=num_reqs,
+            SMALL_TILE_BLOCK_SIZE=tile_block_size,
+            SMALL_BLOCK_TABLE_WINDOW_SIZE=block_table_window_size,
+            LARGE_BLOCK_TABLE_WINDOW_SIZE=_next_power_of_2((1024 + min_block_size - 1) // min_block_size + 1),
+        )
+    else:
+        programs_per_group = num_reqs * parallel_tiles + 1
+        _compute_slot_mapping_fused_groups_kernel[(group_count * programs_per_group,)](
+            num_tokens,
+            max_num_tokens,
+            query_start_loc_ptr,
+            positions_ptr,
+            block_table_addrs_ptr,
+            slot_mapping_addrs_ptr,
+            block_table_strides_ptr,
+            block_sizes_ptr,
+            PAD_ID=pad_id,
+            NUM_REQS=num_reqs,
+            TILE_BLOCK_SIZE=tile_block_size,
+            PARALLEL_TILES=parallel_tiles,
+            BLOCK_TABLE_WINDOW_SIZE=block_table_window_size,
+        )

--- a/vllm_ascend/worker/block_table.py
+++ b/vllm_ascend/worker/block_table.py
@@ -10,6 +10,7 @@ from vllm_ascend.distributed.utils import get_decode_context_model_parallel_worl
 from vllm_ascend.ops.triton.compute_slot_mapping import (
     _compute_slot_mapping_kernel,
     _next_power_of_2,
+    compute_slot_mapping_fused_groups,
 )
 
 
@@ -404,6 +405,35 @@ class MultiGroupBlockTable:
                 )
             ]
 
+        active_block_tables = [block_table for block_table in self.block_tables if not block_table.is_mamba_group]
+        self._can_fuse_slot_mapping = len(active_block_tables) > 1 and all(
+            block_table.dcp_world_size == 1 for block_table in active_block_tables
+        )
+        if self._can_fuse_slot_mapping:
+            self._fused_slot_mapping_group_count = len(active_block_tables)
+            self._fused_max_num_batched_tokens = active_block_tables[0].max_num_batched_tokens
+            self._fused_block_table_addrs = torch.tensor(
+                [block_table.block_table.gpu.data_ptr() for block_table in active_block_tables],
+                dtype=torch.uint64,
+                device=device,
+            )
+            self._fused_slot_mapping_addrs = torch.tensor(
+                [block_table.slot_mapping.gpu.data_ptr() for block_table in active_block_tables],
+                dtype=torch.uint64,
+                device=device,
+            )
+            self._fused_block_table_strides = torch.tensor(
+                [block_table.block_table.gpu.stride(0) for block_table in active_block_tables],
+                dtype=torch.int64,
+                device=device,
+            )
+            self._fused_block_sizes = torch.tensor(
+                [block_table.block_size for block_table in active_block_tables],
+                dtype=torch.int32,
+                device=device,
+            )
+            self._fused_min_block_size = min(block_table.block_size for block_table in active_block_tables)
+
     def append_row(self, block_ids: tuple[list[int], ...], row_idx: int) -> None:
         for i, block_table in enumerate(self.block_tables):
             block_table.append_row(block_ids[i], row_idx)
@@ -432,6 +462,24 @@ class MultiGroupBlockTable:
         positions_compressed_list: list[np.ndarray] | None = None,
         req_indices_compressed_list: list[np.ndarray] | None = None,
     ) -> None:
+        num_tokens = positions.shape[0]
+        if self._can_fuse_slot_mapping and not positions_compressed_list and not req_indices_compressed_list:
+            compute_slot_mapping_fused_groups(
+                self._fused_slot_mapping_group_count,
+                num_reqs,
+                num_tokens,
+                self._fused_max_num_batched_tokens,
+                query_start_loc,
+                positions,
+                self._fused_block_table_addrs,
+                self._fused_slot_mapping_addrs,
+                self._fused_block_table_strides,
+                self._fused_block_sizes,
+                self._fused_min_block_size,
+                pad_id=PAD_SLOT_ID,
+            )
+            return
+
         for i, block_table in enumerate(self.block_tables):
             if block_table.is_mamba_group:
                 continue


### PR DESCRIPTION
### What this PR does / why we need it?

Backport of #15289 to `releases/v0.26.0rc`.

This change merges repeated DSV4 slot-mapping calculations for multiple attention KV-cache groups into one Triton launch.

- Build device-side pointer and metadata tables for eligible attention groups.
- Address each request row inside the fused kernel.
- Route balanced, uneven, short-prefill, long-prefill, and decode-like request shapes through fixed or adaptive fused kernels.
- Keep DCP, Mamba, and speculative-decoding cases that require group-specific metadata on their existing paths.

The backport applies the source commit cleanly with an identical stable patch ID.

### Performance

The source PR measured the implementation on one Ascend A3 device at 1850 MHz with CANN 9.1.0. For the heterogeneous profile-derived DSV4 six-group case, aggregate kernel time decreased from 26.321 us to 4.570 us (82.6%). Across the reported generalization matrix, the fused route improved aggregate kernel time by 51.9%-80.5%.

### Does this PR introduce any user-facing change?

No API or configuration change. This is an internal Triton launch-consolidation optimization.

### How was this patch tested?

Backport static checks:

- `uvx ruff==0.14.0 check vllm_ascend/ops/triton/compute_slot_mapping.py vllm_ascend/worker/block_table.py`
- `uvx ruff==0.14.0 format --check vllm_ascend/ops/triton/compute_slot_mapping.py vllm_ascend/worker/block_table.py`
- `python3 -m py_compile vllm_ascend/ops/triton/compute_slot_mapping.py vllm_ascend/worker/block_table.py`
- `git diff --check upstream/releases/v0.26.0rc...HEAD`

Source PR A3 evidence:

- Five representative shapes passed exactly in eager and ACL Graph modes.
- An earlier generalized matrix passed 8/8 eager and 8/8 ACL Graph cases exactly.
- Coverage included a profile-derived six-group long request, balanced and uneven 8-request batches, 64-request decode, and short multi-request prefill.

The NPU matrix was run on the source PR against main; it was not rerun on the release-branch backport.

- vLLM main: https://github.com/vllm-project/vllm/commit/d02df748bf9efd99022f1a062597dc3cb3808485
