### PR TITLE
[BugFix][Spec Decode] Fail fast when Qwen3.5 SFT checkpoint lacks MTP weights

### DIFF
--- a/tests/ut/patch/platform/test_patch_speculative_config_qwen3_5_mtp.py
+++ b/tests/ut/patch/platform/test_patch_speculative_config_qwen3_5_mtp.py
@@ -1,0 +1,71 @@
+import json
+from types import SimpleNamespace
+
+import pytest
+import torch
+from safetensors.torch import save_file
+
+from vllm_ascend.patch.platform.patch_speculative_config import (
+    _checkpoint_has_qwen3_5_mtp_weights,
+    _validate_qwen3_5_mtp_checkpoint,
+)
+
+
+def _write_index(checkpoint_dir, weight_names):
+    weight_map = {name: "model-00001-of-00001.safetensors" for name in weight_names}
+    index_path = checkpoint_dir / "model.safetensors.index.json"
+    with index_path.open("w", encoding="utf-8") as index_file:
+        json.dump({"metadata": {}, "weight_map": weight_map}, index_file)
+
+
+def _make_speculative_config(model_path, method="qwen3_5_mtp"):
+    return SimpleNamespace(
+        method=method,
+        draft_model_config=SimpleNamespace(model=str(model_path)),
+    )
+
+
+def test_qwen3_5_mtp_preflight_accepts_indexed_checkpoint(tmp_path):
+    _write_index(
+        tmp_path,
+        ["model.layers.0.mlp.down_proj.weight", "mtp.fc.weight"],
+    )
+
+    assert _checkpoint_has_qwen3_5_mtp_weights(tmp_path) is True
+    _validate_qwen3_5_mtp_checkpoint(_make_speculative_config(tmp_path))
+
+
+def test_qwen3_5_mtp_preflight_rejects_sft_checkpoint_without_mtp(tmp_path):
+    _write_index(tmp_path, ["model.layers.0.mlp.down_proj.weight"])
+
+    assert _checkpoint_has_qwen3_5_mtp_weights(tmp_path) is False
+    with pytest.raises(ValueError, match=r"does not contain any 'mtp\.\*' tensors"):
+        _validate_qwen3_5_mtp_checkpoint(_make_speculative_config(tmp_path))
+
+
+def test_qwen3_5_mtp_preflight_reads_single_safetensors_file(tmp_path):
+    save_file(
+        {"mtp.layers.0.input_layernorm.weight": torch.zeros(1)},
+        tmp_path / "model.safetensors",
+    )
+
+    assert _checkpoint_has_qwen3_5_mtp_weights(tmp_path) is True
+
+
+def test_qwen3_5_mtp_preflight_skips_malformed_safetensors_file(tmp_path):
+    (tmp_path / "model.safetensors").write_text("not a safetensors file")
+
+    assert _checkpoint_has_qwen3_5_mtp_weights(tmp_path) is None
+
+
+def test_qwen3_5_mtp_preflight_skips_remote_or_uninspectable_checkpoint():
+    config = _make_speculative_config("Qwen/Qwen3.5-9B")
+
+    assert _checkpoint_has_qwen3_5_mtp_weights("Qwen/Qwen3.5-9B") is None
+    _validate_qwen3_5_mtp_checkpoint(config)
+
+
+def test_qwen3_5_mtp_preflight_does_not_affect_other_methods(tmp_path):
+    _write_index(tmp_path, ["model.layers.0.mlp.down_proj.weight"])
+
+    _validate_qwen3_5_mtp_checkpoint(_make_speculative_config(tmp_path, method="deepseek_mtp"))

--- a/vllm_ascend/patch/platform/patch_speculative_config.py
+++ b/vllm_ascend/patch/platform/patch_speculative_config.py
@@ -1,5 +1,12 @@
+import json
+from pathlib import Path
+
+from safetensors import safe_open
 from transformers import DeepseekV2Config, PretrainedConfig
 from vllm.config.speculative import SpeculativeConfig
+
+_SAFE_WEIGHTS_INDEX_NAME = "model.safetensors.index.json"
+_QWEN3_5_MTP_WEIGHT_PREFIX = "mtp."
 
 _orig_post_init = SpeculativeConfig.__post_init__
 _orig_hf_config_override = SpeculativeConfig.hf_config_override
@@ -37,8 +44,67 @@ def _normalize_legacy_qwen3_dspark_config(hf_config: PretrainedConfig) -> Pretra
     return hf_config
 
 
-def _dspark_post_init(self):
+def _checkpoint_has_qwen3_5_mtp_weights(model_path: str | Path | None) -> bool | None:
+    """Inspect a local safetensors checkpoint without loading tensor data."""
+    if not model_path:
+        return None
+
+    checkpoint_dir = Path(model_path)
+    if not checkpoint_dir.is_dir():
+        return None
+
+    index_path = checkpoint_dir / _SAFE_WEIGHTS_INDEX_NAME
+    if index_path.is_file():
+        try:
+            with index_path.open(encoding="utf-8") as index_file:
+                index = json.load(index_file)
+        except (OSError, json.JSONDecodeError):
+            return None
+        if not isinstance(index, dict):
+            return None
+        weight_map = index.get("weight_map")
+        if not isinstance(weight_map, dict):
+            return None
+        return any(name.startswith(_QWEN3_5_MTP_WEIGHT_PREFIX) for name in weight_map)
+
+    weight_files = sorted(checkpoint_dir.glob("*.safetensors"))
+    if not weight_files:
+        return None
+
+    try:
+        for weight_file in weight_files:
+            with safe_open(
+                str(weight_file),
+                framework="pt",
+                device="cpu",
+            ) as weights:
+                tensor_names = weights.keys()
+                if any(name.startswith(_QWEN3_5_MTP_WEIGHT_PREFIX) for name in tensor_names):
+                    return True
+    except Exception:
+        return None
+    return False
+
+
+def _validate_qwen3_5_mtp_checkpoint(speculative_config: SpeculativeConfig) -> None:
+    if speculative_config.method != "qwen3_5_mtp":
+        return
+
+    draft_model_config = getattr(speculative_config, "draft_model_config", None)
+    model_path = getattr(draft_model_config, "model", None)
+    if _checkpoint_has_qwen3_5_mtp_weights(model_path) is False:
+        raise ValueError(
+            "qwen3_5_mtp speculative decoding was requested, but the local "
+            f"checkpoint {model_path!r} does not contain any 'mtp.*' tensors. "
+            "SFT exports often save only the language-model backbone and drop "
+            "the pretrained MTP head. Remove the qwen3_5_mtp speculative config, "
+            "or export/merge the original MTP tensors before serving."
+        )
+
+
+def _speculative_config_post_init(self):
     _orig_post_init(self)
+    _validate_qwen3_5_mtp_checkpoint(self)
     if self.use_dspark():
         draft_model_config = getattr(self, "draft_model_config", None)
         draft_hf_config = getattr(draft_model_config, "hf_config", None)
@@ -51,4 +117,4 @@ def _dspark_post_init(self):
 
 
 SpeculativeConfig.hf_config_override = staticmethod(_normalize_legacy_qwen3_dspark_config)
-SpeculativeConfig.__post_init__ = _dspark_post_init
+SpeculativeConfig.__post_init__ = _speculative_config_post_init


### PR DESCRIPTION
### What this PR does / why we need it?

Supersedes #15373 and fixes #15201.

Qwen3.5 checkpoints can contain an integrated MTP head under `mtp.*`, but some SFT export workflows save only the language-model backbone while retaining MTP-related configuration. When `qwen3_5_mtp` is explicitly enabled for such a checkpoint, draft-model loading currently fails later with a generic missing-weight error.

This PR adds a local-checkpoint preflight during `SpeculativeConfig` post-initialization:

- inspect `model.safetensors.index.json` through its `weight_map` without loading tensor payloads;
- fall back to reading safetensors headers for unindexed local checkpoints;
- raise an actionable error when `qwen3_5_mtp` is requested but no `mtp.*` tensors exist;
- leave remote or uninspectable formats on the normal loader path;
- avoid affecting unrelated speculative-decoding methods.

The behavior intentionally fails fast instead of silently disabling a user-requested optimization.

### Does this PR introduce _any_ user-facing change?

Yes. A local Qwen3.5 SFT checkpoint without MTP tensors now fails during configuration validation with guidance to remove `qwen3_5_mtp` or export/merge the original MTP tensors, rather than failing later during engine initialization.

### How was this patch tested?

Added CPU unit coverage for:

- indexed checkpoints containing `mtp.*` tensors;
- indexed SFT-style checkpoints without MTP tensors;
- single-file safetensors checkpoints;
- malformed safetensors files;
- remote or otherwise uninspectable model identifiers;
- unrelated speculative-decoding methods.

This replacement branch is a clean, signed-off, single commit based on the current `main`. Maintainer edits are enabled. Repository CI remains the source of truth for the final test gate.

- vLLM main: https://github.com/vllm-project/vllm/commit/ba07e4a48fc951300d97eb506217dd530583dea3
