### PR TITLE
[CI][Model] Increase MiniMax-M3 W8A8 context length

### DIFF
--- a/tests/e2e/nightly/single_node/models/configs/MiniMax-M3-W8A8-A3.yaml
+++ b/tests/e2e/nightly/single_node/models/configs/MiniMax-M3-W8A8-A3.yaml
@@ -35,7 +35,7 @@ test_cases:
       - "--gpu-memory-utilization"
       - "0.95"
       - "--max-model-len"
-      - "67560"
+      - "69632"
       - "--max-num-batched-tokens"
       - "32768"
       - "--long-prefill-token-threshold"


### PR DESCRIPTION
## What this PR does

Increase the MiniMax-M3-W8A8-A3 server `--max-model-len` from 67560 to 69632.

The GPQA case requests up to 65536 output tokens. With the current 67560-token server limit, only 2024 tokens remain for the rendered prompt. One GPQA Diamond sample (record `recnTTKdBzfuoZ7w7`) renders to 2558 prompt tokens with the MiniMax-M3 chat template, so the request requires up to 68094 tokens and is deterministically rejected with HTTP 400.

This was reproduced in two independent Nightly-A3 runs:

- https://github.com/vllm-project/vllm-ascend/actions/runs/33146862269
- https://github.com/vllm-project/vllm-ascend/actions/runs/33527643422

Both runs reported exactly one `400 Bad Request`, `POST=198 RECV=197 FAIL=1`, and one missing GPQA prediction.

69632 preserves the existing 64K GPQA output limit, covers the 68094-token longest request, and leaves 1538 tokens of headroom.

## Validation

- Parsed the updated YAML successfully.
- `git diff --check` passed.
- The commit changes only the `--max-model-len` value.

- vLLM main: https://github.com/vllm-project/vllm/commit/ba07e4a48fc951300d97eb506217dd530583dea3
