### PR TITLE
[BugFix] Preserve native Triton Gluon on Triton 3.6+

### DIFF
--- a/tests/ut/test_triton_compat.py
+++ b/tests/ut/test_triton_compat.py
@@ -1,0 +1,74 @@
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+from types import ModuleType
+
+import pytest
+
+MODULE_PATH = Path(__file__).parents[2] / "vllm_ascend" / "_triton_compat.py"
+SPEC = importlib.util.spec_from_file_location("vllm_ascend_triton_compat_test", MODULE_PATH)
+assert SPEC is not None and SPEC.loader is not None
+compat = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(compat)
+
+
+@pytest.fixture(autouse=True)
+def isolate_gluon_modules(monkeypatch: pytest.MonkeyPatch):
+    original = {
+        name: module
+        for name, module in sys.modules.items()
+        if name == "triton.experimental" or name.startswith("triton.experimental.gluon")
+    }
+    for name in list(original):
+        monkeypatch.delitem(sys.modules, name, raising=False)
+    yield
+    for name in list(sys.modules):
+        if name == "triton.experimental" or name.startswith("triton.experimental.gluon"):
+            monkeypatch.delitem(sys.modules, name, raising=False)
+    sys.modules.update(original)
+
+
+def test_modern_triton_loads_real_gluon_without_stubs(monkeypatch: pytest.MonkeyPatch):
+    loaded: list[str] = []
+
+    def import_module(name: str):
+        loaded.append(name)
+        module = ModuleType(name)
+        module.__path__ = []
+        sys.modules[name] = module
+        return module
+
+    monkeypatch.setattr(compat, "_triton_version", lambda: compat.Version("3.6.0"))
+    monkeypatch.setattr(compat.importlib, "import_module", import_module)
+
+    compat.ensure_gluon_compatibility()
+
+    assert loaded == ["triton.experimental.gluon", "triton.experimental.gluon.language"]
+
+
+def test_legacy_triton_gets_complete_parent_child_hierarchy(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setattr(compat, "_triton_version", lambda: compat.Version("3.5.0"))
+
+    compat.ensure_gluon_compatibility()
+
+    experimental = sys.modules["triton.experimental"]
+    gluon = sys.modules["triton.experimental.gluon"]
+    language = sys.modules["triton.experimental.gluon.language"]
+    assert experimental.gluon is gluon
+    assert gluon.language is language
+    assert experimental.__path__ == []
+    assert gluon.__path__ == []
+
+
+def test_modern_triton_import_failure_is_not_hidden(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setattr(compat, "_triton_version", lambda: compat.Version("3.6.0"))
+
+    def fail_import(name: str):
+        raise ImportError(f"broken modern Gluon: {name}")
+
+    monkeypatch.setattr(compat.importlib, "import_module", fail_import)
+
+    with pytest.raises(ImportError, match="broken modern Gluon"):
+        compat.ensure_gluon_compatibility()

--- a/vllm_ascend/__init__.py
+++ b/vllm_ascend/__init__.py
@@ -16,21 +16,12 @@
 #
 
 import importlib.util
-import sys
-from types import ModuleType
+
+from vllm_ascend._triton_compat import ensure_gluon_compatibility
 
 _triton_available = importlib.util.find_spec("triton") is not None
 
-if "triton.experimental" not in sys.modules:
-    _experimental = ModuleType("triton.experimental")
-    _experimental.__path__ = []
-    sys.modules["triton.experimental"] = _experimental
-for _gluon_stub in (
-    "triton.experimental.gluon",
-    "triton.experimental.gluon.language",
-):
-    if _gluon_stub not in sys.modules:
-        sys.modules[_gluon_stub] = ModuleType(_gluon_stub)
+ensure_gluon_compatibility()
 
 # main2main compat: `_aggregate` was added to triton.language.core in
 # vllm main post-0.26.0. Stub it here so vllm.triton_utils can import it

--- a/vllm_ascend/_triton_compat.py
+++ b/vllm_ascend/_triton_compat.py
@@ -1,0 +1,66 @@
+"""Compatibility helpers for Triton's experimental Gluon module hierarchy."""
+
+from __future__ import annotations
+
+import importlib
+import importlib.metadata
+import sys
+from types import ModuleType
+from typing import Any, cast
+
+from packaging.version import InvalidVersion, Version
+
+_REAL_GLUON_MIN_VERSION = Version("3.6")
+
+
+def _triton_version() -> Version | None:
+    try:
+        return Version(importlib.metadata.version("triton"))
+    except (importlib.metadata.PackageNotFoundError, InvalidVersion):
+        return None
+
+
+def _install_legacy_gluon_stubs() -> None:
+    """Install the complete hierarchy required by Triton before 3.6."""
+
+    experimental = sys.modules.get("triton.experimental")
+    if experimental is None:
+        experimental = ModuleType("triton.experimental")
+        experimental.__path__ = []
+        sys.modules["triton.experimental"] = experimental
+
+    gluon = sys.modules.get("triton.experimental.gluon")
+    if gluon is None:
+        gluon = ModuleType("triton.experimental.gluon")
+        gluon.__path__ = []
+        sys.modules["triton.experimental.gluon"] = gluon
+
+    language = sys.modules.get("triton.experimental.gluon.language")
+    if language is None:
+        language = ModuleType("triton.experimental.gluon.language")
+        sys.modules["triton.experimental.gluon.language"] = language
+
+    cast(Any, experimental).gluon = gluon
+    cast(Any, gluon).language = language
+
+
+def ensure_gluon_compatibility() -> None:
+    """Use real Gluon on Triton 3.6+, otherwise retain the legacy stub.
+
+    Triton 3.6 ships a Gluon implementation compatible with its own runtime.
+    Shadowing it with the historical empty vLLM-Ascend stub breaks native
+    specialization during graph-mode compilation. Older Triton dependency
+    lines either do not provide Gluon or provide one incompatible with their
+    core, so they still require the complete compatibility hierarchy.
+    """
+
+    version = _triton_version()
+    if version is not None and version >= _REAL_GLUON_MIN_VERSION:
+        # Deliberately propagate failures from inside a real modern Gluon
+        # package: replacing a broken installation with empty modules would
+        # hide an ABI/package error until the first compiled kernel.
+        importlib.import_module("triton.experimental.gluon")
+        importlib.import_module("triton.experimental.gluon.language")
+        return
+
+    _install_legacy_gluon_stubs()


### PR DESCRIPTION
### What this PR does / why we need it?

Triton 3.6 ships a native `triton.experimental.gluon` implementation. vLLM Ascend currently installs empty compatibility modules unconditionally during package import, which shadows the native package. Modern Triton specialization then fails when it imports its Gluon implementation or vendor modules.

This change makes the compatibility behavior version-aware:

- Triton 3.6 and newer load the real Gluon package and propagate a broken-installation error instead of hiding it.
- Older Triton versions retain the complete compatibility hierarchy expected by the existing plugin.
- The compatibility code is isolated in `_triton_compat.py` and invoked before the remaining vLLM Ascend imports.

The change is general to the Triton version boundary and contains no product-specific behavior.

### Does this PR introduce _any_ user-facing change?

Yes. Users running Triton 3.6 or newer no longer see the native Gluon package shadowed by empty compatibility modules. Older supported Triton lines retain their previous behavior.

### How was this patch tested?

Focused test on the PR branch (based on vLLM Ascend `8a4ea1478b2eefcc516ce687674c7bef3db1f0eb`):

```bash
python -m pytest --noconftest -q tests/ut/test_triton_compat.py
```

Result: `3 passed`. The tests cover native Gluon loading on Triton 3.6, the complete legacy parent/child module hierarchy, and propagation of errors from a broken modern Triton installation.

The corresponding compatibility behavior was also forward-ported into the currently verified HUST production pair:

- vLLM-HUST core: `762f85b311fbab0bcf8921dd216f5093cd58b9b8`
- vLLM upstream anchor: `2a4e3cc3dbddf4f44d69864209361f1e2a70c79a`
- vLLM-Ascend-HUST plugin: `4e57439e58ed3d78e675f9fd7b4614fb183c5394`
- vLLM Ascend upstream anchor: `6d02e22f078e59eb4b7947a887116151ad8eb100`
- Runtime: CANN `9.1.0`, Torch `2.13.0+cpu`, torch-NPU `2.13.0rc1`, Triton Ascend `3.6.0+gitb52af7fc`
- Serving acceptance: `Qwen/Qwen3.8-27B`, TP4, graph mode, physical NPU 0–3

The immutable production image was `sha256:de1742dd6a1bc7ed1cbfff78d508ffa8ac769e58518d4e04d35a5d8203b88252`. Graph capture completed, ordinary and native-thinking completions passed, streaming and cancellation recovered cleanly, and the application returned grounded Support sources. This production evidence exercises the forward-ported implementation in the HUST main pair; the focused unit test above is the evidence for this exact PR diff.

### CI status

Pre-commit and DCO pass. The aggregate `ci-gate` is currently blocked because selected test jobs are skipped until an upstream maintainer adds the `ready-precise` label (recommended) or `ready-all`.
