### PR TITLE
[CI] Read Torch version from package metadata

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,9 +20,10 @@ set(VLLM_ASCEND_INSTALL_PATH "${CMAKE_INSTALL_PREFIX}")
 find_package(Torch REQUIRED)
 
 run_python(TORCH_VERSION
-  "import torch; print(torch.__version__)" "Failed to locate torch path")
+  "from importlib.metadata import version; print(version('torch').split('+', 1)[0])"
+  "Failed to locate torch version")
 # check torch version is 2.10.0
-if(NOT ${TORCH_VERSION} VERSION_EQUAL "2.10.0")
+if(NOT "${TORCH_VERSION}" VERSION_EQUAL "2.10.0")
   message(FATAL_ERROR "Expected PyTorch version 2.10.0, but found ${TORCH_VERSION}")
 endif()
 

--- a/tests/ut/test_cmake_torch_version_contract.py
+++ b/tests/ut/test_cmake_torch_version_contract.py
@@ -1,0 +1,10 @@
+from pathlib import Path
+
+
+def test_cmake_reads_torch_version_without_importing_device_backend():
+    cmake = (Path(__file__).parents[2] / "CMakeLists.txt").read_text()
+
+    assert "from importlib.metadata import version" in cmake
+    assert "version('torch').split('+', 1)[0]" in cmake
+    assert "import torch; print(torch.__version__)" not in cmake
+    assert 'if(NOT "${TORCH_VERSION}" VERSION_EQUAL "2.10.0")' in cmake


### PR DESCRIPTION
### What this PR does / why we need it?

The CMake configure step currently imports `torch` only to read `torch.__version__`. Importing Torch may auto-load a registered device backend such as torch-NPU, which makes a metadata-only configure check depend on driver availability and can emit device initialization errors in isolated builders.

This change reads the installed distribution version through `importlib.metadata`, strips the local version suffix, and preserves the existing exact PyTorch `2.10.0` compatibility check. No backend is imported merely to inspect package metadata.

### Does this PR introduce _any_ user-facing change?

No runtime behavior changes. Source and wheel builds fail against the same unsupported Torch versions, but the configure-time version query no longer initializes a device backend.

### How was this patch tested?

Focused test on the PR branch (based on vLLM Ascend `8a4ea1478b2eefcc516ce687674c7bef3db1f0eb`):

```bash
python -m pytest --noconftest -q tests/ut/test_cmake_torch_version_contract.py
```

Result: `1 passed`. The contract test verifies the metadata query, local-suffix handling, retained `2.10.0` boundary, and absence of `import torch` from the CMake version probe.

The same metadata-only configure behavior was forward-ported into the currently verified HUST production pair and used to build immutable wheels:

- vLLM-HUST core: `762f85b311fbab0bcf8921dd216f5093cd58b9b8`
- vLLM upstream anchor: `2a4e3cc3dbddf4f44d69864209361f1e2a70c79a`
- vLLM-Ascend-HUST plugin: `4e57439e58ed3d78e675f9fd7b4614fb183c5394`
- vLLM Ascend upstream anchor: `6d02e22f078e59eb4b7947a887116151ad8eb100`
- Runtime: CANN `9.1.0`, Torch `2.13.0+cpu`, torch-NPU `2.13.0rc1`, Triton Ascend `3.6.0+gitb52af7fc`
- Serving acceptance: `Qwen/Qwen3.8-27B`, TP4, graph mode, physical NPU 0–3

The immutable production image was `sha256:de1742dd6a1bc7ed1cbfff78d508ffa8ac769e58518d4e04d35a5d8203b88252`. Its build verified package metadata, wheel hashes, imports and plugin discovery before the TP4 graph-mode serving acceptance. This production evidence exercises the forward-ported implementation in the HUST main pair; the focused unit test above is the evidence for this exact PR diff.

### CI status

Pre-commit and DCO pass. The aggregate `ci-gate` is currently blocked because selected test jobs are skipped until an upstream maintainer adds the `ready-precise` label (recommended) or `ready-all`.
