### PR TITLE
[BugFix] Scope PyTorch AOT cache override to npugraph_ex

### DIFF
--- a/tests/ut/compilation/test_compiler_interface_aot_cache.py
+++ b/tests/ut/compilation/test_compiler_interface_aot_cache.py
@@ -1,0 +1,54 @@
+#
+# Copyright (c) 2026 Huawei Technologies Co., Ltd. All Rights Reserved.
+# This file is a part of the vllm-ascend project.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import torch
+
+from vllm_ascend.compilation.compiler_interface import _disable_pytorch_aot_cache_for_npugraph_ex
+
+
+def test_npugraph_ex_aot_cache_settings_are_scoped():
+    dynamo_config = torch._dynamo.config
+    functorch_config = torch._functorch.config
+    original = {
+        "caching_precompile": dynamo_config.caching_precompile,
+        "bundled_autograd_cache": functorch_config.bundled_autograd_cache,
+        "force_autograd_cache": functorch_config.force_autograd_cache,
+        "enable_autograd_cache": functorch_config.enable_autograd_cache,
+    }
+
+    with (
+        dynamo_config.patch(caching_precompile=True),
+        functorch_config.patch(
+            bundled_autograd_cache=True,
+            force_autograd_cache=True,
+            enable_autograd_cache=True,
+        ),
+    ):
+        with _disable_pytorch_aot_cache_for_npugraph_ex():
+            assert dynamo_config.caching_precompile is False
+            assert functorch_config.bundled_autograd_cache is False
+            assert functorch_config.force_autograd_cache is False
+            assert functorch_config.enable_autograd_cache is False
+
+        assert dynamo_config.caching_precompile is True
+        assert functorch_config.bundled_autograd_cache is True
+        assert functorch_config.force_autograd_cache is True
+        assert functorch_config.enable_autograd_cache is True
+
+    assert dynamo_config.caching_precompile == original["caching_precompile"]
+    assert functorch_config.bundled_autograd_cache == original["bundled_autograd_cache"]
+    assert functorch_config.force_autograd_cache == original["force_autograd_cache"]
+    assert functorch_config.enable_autograd_cache == original["enable_autograd_cache"]

--- a/vllm_ascend/compilation/compiler_interface.py
+++ b/vllm_ascend/compilation/compiler_interface.py
@@ -19,6 +19,7 @@ import copy
 import functools
 import os
 from collections.abc import Callable
+from contextlib import ExitStack, contextmanager
 from typing import Any, cast
 
 import torch
@@ -34,6 +35,41 @@ from vllm.logger import logger
 
 from vllm_ascend.ascend_config import AscendCompilationConfig, get_ascend_config
 from vllm_ascend.utils import COMPILATION_PASS_KEY
+
+
+@contextmanager
+def _disable_pytorch_aot_cache_for_npugraph_ex():
+    """Disable PyTorch cache formats that npugraph_ex cannot serialize.
+
+    PyTorch 2.13 enables bundled AOTAutograd caching while vLLM performs its
+    precompile pass.  Bundling requires every backend compiler to return an
+    ``OutputCode`` instance.  The torch-npu npugraph_ex backend intentionally
+    returns its own ``_CompiledFxGraph`` callable instead, so attempting to
+    bundle that result raises an assertion before model initialization.
+
+    npugraph_ex already owns its graph cache below.  Keep the workaround scoped
+    to its backend invocation and restore every PyTorch setting afterwards.
+    Older PyTorch versions do not expose all of these settings, hence the
+    feature checks.
+    """
+    with ExitStack() as stack:
+        dynamo_config = torch._dynamo.config
+        if hasattr(dynamo_config, "caching_precompile"):
+            stack.enter_context(dynamo_config.patch(caching_precompile=False))
+
+        functorch_config = torch._functorch.config
+        functorch_options = {
+            name: False
+            for name in (
+                "bundled_autograd_cache",
+                "force_autograd_cache",
+                "enable_autograd_cache",
+            )
+            if hasattr(functorch_config, name)
+        }
+        if functorch_options:
+            stack.enter_context(functorch_config.patch(**functorch_options))
+        yield
 
 
 def compile_fx(graph: GraphModule, example_inputs: list, inner_compile: Callable, decompositions: dict) -> Callable:
@@ -201,11 +237,12 @@ def npugraph_ex_compile(
 
         nfx._NpuFxCompiler._get_compiled_gm = patched_get_compiled_gm
         backend = nge.get_npu_backend(compiler_config=config)
-        # torch.compile requires the output of the fx graph to be a tuple
-        if not graph_returns_tuple(graph):
-            compiled_fn = make_graph_return_tuple(graph, example_inputs, backend)
-        else:
-            compiled_fn = backend(graph, example_inputs)
+        with _disable_pytorch_aot_cache_for_npugraph_ex():
+            # torch.compile requires the output of the fx graph to be a tuple
+            if not graph_returns_tuple(graph):
+                compiled_fn = make_graph_return_tuple(graph, example_inputs, backend)
+            else:
+                compiled_fn = backend(graph, example_inputs)
         nfx._NpuFxCompiler._get_compiled_gm = _original_get_compiled_gm
         return compiled_fn, (key, cache_path)
     except ImportError:


### PR DESCRIPTION
### What this PR does / why we need it?

On newer PyTorch lines, bundled AOT/autograd caching assumes that a backend returns PyTorch's cacheable output-code representation. The `npugraph_ex` backend returns its own compiled graph object, so leaving those cache paths enabled can fail after graph compilation even though the NPU graph itself is valid.

This change disables the relevant Dynamo/Functorch cache flags only while vLLM Ascend invokes the `npugraph_ex` backend. It uses configuration patch context managers and restores every previous value afterward. Graph mode remains enabled; this does not select eager execution and does not change other Torch compilation backends.

The compatibility layer is guarded with `hasattr` so it remains valid on Torch versions that do not expose every newer cache option.

### Does this PR introduce _any_ user-facing change?

Yes. `npugraph_ex` compilation no longer enters incompatible PyTorch bundled-cache paths, while global cache configuration and non-Ascend backends remain unchanged.

### How was this patch tested?

Focused test on the PR branch (based on vLLM Ascend `8a4ea1478b2eefcc516ce687674c7bef3db1f0eb`):

```bash
python -m pytest --noconftest -q tests/ut/compilation/test_compiler_interface_aot_cache.py
```

Result: `1 passed`. The test enables all affected cache flags, enters the scoped compatibility context, verifies they are disabled inside it, and verifies their exact previous values are restored on exit.

The corresponding scoped cache behavior was forward-ported into the currently verified HUST production pair:

- vLLM-HUST core: `762f85b311fbab0bcf8921dd216f5093cd58b9b8`
- vLLM upstream anchor: `2a4e3cc3dbddf4f44d69864209361f1e2a70c79a`
- vLLM-Ascend-HUST plugin: `4e57439e58ed3d78e675f9fd7b4614fb183c5394`
- vLLM Ascend upstream anchor: `6d02e22f078e59eb4b7947a887116151ad8eb100`
- Runtime: CANN `9.1.0`, Torch `2.13.0+cpu`, torch-NPU `2.13.0rc1`, Triton Ascend `3.6.0+gitb52af7fc`
- Serving acceptance: `Qwen/Qwen3.8-27B`, TP4, graph mode, physical NPU 0–3

The immutable production image was `sha256:de1742dd6a1bc7ed1cbfff78d508ffa8ac769e58518d4e04d35a5d8203b88252`. Graph capture completed without an eager fallback; ordinary and native-thinking completions, streaming, cancellation, two-concurrent requests, cold managed restart and public grounded chat all passed. This is real NPU graph-mode evidence for the forward-ported implementation in the HUST main pair; the focused unit test above is the evidence for this exact PR diff.

### CI status

Pre-commit and DCO pass. The aggregate `ci-gate` is currently blocked because selected test jobs are skipped until an upstream maintainer adds the `ready-precise` label (recommended) or `ready-all`.
