### PR TITLE
[CI] upgrade CANN ops packages to 9.2.0-beta.2 in Dockerfiles

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -42,6 +42,19 @@ RUN if [ -n "$APTMIRROR" ]; then \
     rm -rf /var/cache/apt/* && \
     rm -rf /var/lib/apt/lists/*
 
+# Upgrade CANN ops package to 9.2.0
+ARG TARGETPLATFORM
+RUN ARCH=$(case "${TARGETPLATFORM}" in \
+        "linux/amd64") echo "x86_64" ;; \
+        "linux/arm64") echo "aarch64" ;; \
+        *) echo "Unsupported TARGETPLATFORM: ${TARGETPLATFORM}" && exit 1 ;; \
+    esac) && \
+    CANN_OPS_URL=https://ascend-repo.obs.cn-east-2.myhuaweicloud.com/CANN/CANN%209.2.T3/Ascend-cann-910-ops_9.2.0-beta.2_linux-${ARCH}.run && \
+    wget --quiet --header="Referer: https://www.hiascend.com/" ${CANN_OPS_URL} -O ~/Ascend-cann-ops-9.2.0.run && \
+    chmod +x ~/Ascend-cann-ops-9.2.0.run && \
+    ~/Ascend-cann-ops-9.2.0.run --quiet --install --install-for-all && \
+    rm -f ~/Ascend-cann-ops-9.2.0.run
+
 # Install modelscope (for fast download) and ray (for multinode)
 RUN pip config set global.index-url ${PIP_INDEX_URL} && \
     if [ -n "$PIP_TRUSTED_HOST" ]; then pip config set global.trusted-host "$PIP_TRUSTED_HOST"; fi && \

--- a/Dockerfile.310p
+++ b/Dockerfile.310p
@@ -37,6 +37,19 @@ RUN if [ -n "$APTMIRROR" ]; then \
     rm -rf /var/cache/apt/* && \
     rm -rf /var/lib/apt/lists/*
 
+# Upgrade CANN ops package to 9.2.0
+ARG TARGETPLATFORM
+RUN ARCH=$(case "${TARGETPLATFORM}" in \
+        "linux/amd64") echo "x86_64" ;; \
+        "linux/arm64") echo "aarch64" ;; \
+        *) echo "Unsupported TARGETPLATFORM: ${TARGETPLATFORM}" && exit 1 ;; \
+    esac) && \
+    CANN_OPS_URL=https://ascend-repo.obs.cn-east-2.myhuaweicloud.com/CANN/CANN%209.2.T3/Ascend-cann-310p-ops_9.2.0-beta.2_linux-${ARCH}.run && \
+    wget --quiet --header="Referer: https://www.hiascend.com/" ${CANN_OPS_URL} -O ~/Ascend-cann-ops-9.2.0.run && \
+    chmod +x ~/Ascend-cann-ops-9.2.0.run && \
+    ~/Ascend-cann-ops-9.2.0.run --quiet --install --install-for-all && \
+    rm -f ~/Ascend-cann-ops-9.2.0.run
+
 # Install modelscope (for fast download) and ray (for multinode)
 RUN pip config set global.index-url ${PIP_INDEX_URL} && \
     if [ -n "$PIP_TRUSTED_HOST" ]; then pip config set global.trusted-host "$PIP_TRUSTED_HOST"; fi && \

--- a/Dockerfile.310p.openEuler
+++ b/Dockerfile.310p.openEuler
@@ -33,6 +33,19 @@ RUN yum update -y && \
     yum install -y python3-pip git vim wget protobuf-compiler curl net-tools gcc gcc-c++ make cmake numactl numactl-devel jemalloc patch && \
     rm -rf /var/cache/yum
 
+# Upgrade CANN ops package to 9.2.0
+ARG TARGETPLATFORM
+RUN ARCH=$(case "${TARGETPLATFORM}" in \
+        "linux/amd64") echo "x86_64" ;; \
+        "linux/arm64") echo "aarch64" ;; \
+        *) echo "Unsupported TARGETPLATFORM: ${TARGETPLATFORM}" && exit 1 ;; \
+    esac) && \
+    CANN_OPS_URL=https://ascend-repo.obs.cn-east-2.myhuaweicloud.com/CANN/CANN%209.2.T3/Ascend-cann-310p-ops_9.2.0-beta.2_linux-${ARCH}.run && \
+    wget --quiet --header="Referer: https://www.hiascend.com/" ${CANN_OPS_URL} -O ~/Ascend-cann-ops-9.2.0.run && \
+    chmod +x ~/Ascend-cann-ops-9.2.0.run && \
+    ~/Ascend-cann-ops-9.2.0.run --quiet --install --install-for-all && \
+    rm -f ~/Ascend-cann-ops-9.2.0.run
+
 # Install modelscope (for fast download) and ray (for multinode)
 RUN pip config set global.index-url ${PIP_INDEX_URL} && \
     if [ -n "$PIP_TRUSTED_HOST" ]; then pip config set global.trusted-host "$PIP_TRUSTED_HOST"; fi && \

--- a/Dockerfile.a3
+++ b/Dockerfile.a3
@@ -45,6 +45,19 @@ RUN if [ -n "$APTMIRROR" ]; then \
     rm -rf /var/cache/apt/* && \
     rm -rf /var/lib/apt/lists/*
 
+# Upgrade CANN ops package to 9.2.0
+ARG TARGETPLATFORM
+RUN ARCH=$(case "${TARGETPLATFORM}" in \
+        "linux/amd64") echo "x86_64" ;; \
+        "linux/arm64") echo "aarch64" ;; \
+        *) echo "Unsupported TARGETPLATFORM: ${TARGETPLATFORM}" && exit 1 ;; \
+    esac) && \
+    CANN_OPS_URL=https://ascend-repo.obs.cn-east-2.myhuaweicloud.com/CANN/CANN%209.2.T3/Ascend-cann-A3-ops_9.2.0-beta.2_linux-${ARCH}.run && \
+    wget --quiet --header="Referer: https://www.hiascend.com/" ${CANN_OPS_URL} -O ~/Ascend-cann-ops-9.2.0.run && \
+    chmod +x ~/Ascend-cann-ops-9.2.0.run && \
+    ~/Ascend-cann-ops-9.2.0.run --quiet --install --install-for-all && \
+    rm -f ~/Ascend-cann-ops-9.2.0.run
+
 # Install modelscope (for fast download) and ray (for multinode)
 RUN pip config set global.index-url ${PIP_INDEX_URL} && \
     if [ -n "$PIP_TRUSTED_HOST" ]; then pip config set global.trusted-host "$PIP_TRUSTED_HOST"; fi && \

--- a/Dockerfile.a3.openEuler
+++ b/Dockerfile.a3.openEuler
@@ -39,6 +39,19 @@ RUN yum update -y && \
     python3 -m pip install mooncake-transfer-engine-npu==${MOONCAKE_TAG} --extra-index-url ${MOONCAKE_INDEX_URL} && \
     rm -rf /var/cache/yum/*
 
+# Upgrade CANN ops package to 9.2.0
+ARG TARGETPLATFORM
+RUN ARCH=$(case "${TARGETPLATFORM}" in \
+        "linux/amd64") echo "x86_64" ;; \
+        "linux/arm64") echo "aarch64" ;; \
+        *) echo "Unsupported TARGETPLATFORM: ${TARGETPLATFORM}" && exit 1 ;; \
+    esac) && \
+    CANN_OPS_URL=https://ascend-repo.obs.cn-east-2.myhuaweicloud.com/CANN/CANN%209.2.T3/Ascend-cann-A3-ops_9.2.0-beta.2_linux-${ARCH}.run && \
+    wget --quiet --header="Referer: https://www.hiascend.com/" ${CANN_OPS_URL} -O ~/Ascend-cann-ops-9.2.0.run && \
+    chmod +x ~/Ascend-cann-ops-9.2.0.run && \
+    ~/Ascend-cann-ops-9.2.0.run --quiet --install --install-for-all && \
+    rm -f ~/Ascend-cann-ops-9.2.0.run
+
 # Install modelscope (for fast download) and ray (for multinode)
 RUN pip config set global.index-url ${PIP_INDEX_URL} && \
     if [ -n "$PIP_TRUSTED_HOST" ]; then pip config set global.trusted-host "$PIP_TRUSTED_HOST"; fi && \

--- a/Dockerfile.a5
+++ b/Dockerfile.a5
@@ -45,6 +45,19 @@ RUN if [ -n "$APTMIRROR" ]; then \
     rm -rf /var/cache/apt/* && \
     rm -rf /var/lib/apt/lists/*
 
+# Upgrade CANN ops package to 9.2.0
+ARG TARGETPLATFORM
+RUN ARCH=$(case "${TARGETPLATFORM}" in \
+        "linux/amd64") echo "x86_64" ;; \
+        "linux/arm64") echo "aarch64" ;; \
+        *) echo "Unsupported TARGETPLATFORM: ${TARGETPLATFORM}" && exit 1 ;; \
+    esac) && \
+    CANN_OPS_URL=https://ascend-repo.obs.cn-east-2.myhuaweicloud.com/CANN/CANN%209.2.T3/Ascend-cann-950-ops_9.2.0-beta.2_linux-${ARCH}.run && \
+    wget --quiet --header="Referer: https://www.hiascend.com/" ${CANN_OPS_URL} -O ~/Ascend-cann-ops-9.2.0.run && \
+    chmod +x ~/Ascend-cann-ops-9.2.0.run && \
+    ~/Ascend-cann-ops-9.2.0.run --quiet --install --install-for-all && \
+    rm -f ~/Ascend-cann-ops-9.2.0.run
+
 # Install modelscope (for fast download) and ray (for multinode)
 RUN pip config set global.index-url ${PIP_INDEX_URL} && \
     if [ -n "$PIP_TRUSTED_HOST" ]; then pip config set global.trusted-host "$PIP_TRUSTED_HOST"; fi && \

--- a/Dockerfile.a5.openEuler
+++ b/Dockerfile.a5.openEuler
@@ -39,6 +39,19 @@ RUN yum update -y && \
     python3 -m pip install mooncake-transfer-engine-npu==${MOONCAKE_TAG} --extra-index-url ${MOONCAKE_INDEX_URL} && \
     rm -rf /var/cache/yum/*
 
+# Upgrade CANN ops package to 9.2.0
+ARG TARGETPLATFORM
+RUN ARCH=$(case "${TARGETPLATFORM}" in \
+        "linux/amd64") echo "x86_64" ;; \
+        "linux/arm64") echo "aarch64" ;; \
+        *) echo "Unsupported TARGETPLATFORM: ${TARGETPLATFORM}" && exit 1 ;; \
+    esac) && \
+    CANN_OPS_URL=https://ascend-repo.obs.cn-east-2.myhuaweicloud.com/CANN/CANN%209.2.T3/Ascend-cann-950-ops_9.2.0-beta.2_linux-${ARCH}.run && \
+    wget --quiet --header="Referer: https://www.hiascend.com/" ${CANN_OPS_URL} -O ~/Ascend-cann-ops-9.2.0.run && \
+    chmod +x ~/Ascend-cann-ops-9.2.0.run && \
+    ~/Ascend-cann-ops-9.2.0.run --quiet --install --install-for-all && \
+    rm -f ~/Ascend-cann-ops-9.2.0.run
+
 # Install modelscope (for fast download) and ray (for multinode)
 RUN pip config set global.index-url ${PIP_INDEX_URL} && \
     if [ -n "$PIP_TRUSTED_HOST" ]; then pip config set global.trusted-host "$PIP_TRUSTED_HOST"; fi && \

--- a/Dockerfile.openEuler
+++ b/Dockerfile.openEuler
@@ -39,6 +39,19 @@ RUN yum update -y && \
     python3 -m pip install mooncake-transfer-engine-npu==${MOONCAKE_TAG} --extra-index-url ${MOONCAKE_INDEX_URL} && \
     rm -rf /var/cache/yum/*
 
+# Upgrade CANN ops package to 9.2.0
+ARG TARGETPLATFORM
+RUN ARCH=$(case "${TARGETPLATFORM}" in \
+        "linux/amd64") echo "x86_64" ;; \
+        "linux/arm64") echo "aarch64" ;; \
+        *) echo "Unsupported TARGETPLATFORM: ${TARGETPLATFORM}" && exit 1 ;; \
+    esac) && \
+    CANN_OPS_URL=https://ascend-repo.obs.cn-east-2.myhuaweicloud.com/CANN/CANN%209.2.T3/Ascend-cann-910-ops_9.2.0-beta.2_linux-${ARCH}.run && \
+    wget --quiet --header="Referer: https://www.hiascend.com/" ${CANN_OPS_URL} -O ~/Ascend-cann-ops-9.2.0.run && \
+    chmod +x ~/Ascend-cann-ops-9.2.0.run && \
+    ~/Ascend-cann-ops-9.2.0.run --quiet --install --install-for-all && \
+    rm -f ~/Ascend-cann-ops-9.2.0.run
+
 # Install modelscope (for fast download) and ray (for multinode)
 RUN pip config set global.index-url ${PIP_INDEX_URL} && \
     if [ -n "$PIP_TRUSTED_HOST" ]; then pip config set global.trusted-host "$PIP_TRUSTED_HOST"; fi && \


### PR DESCRIPTION
### What this PR does / why we need it?

Upgrade the CANN A3/910/950/310p ops packages from 9.1.0 to 9.2.0-beta.2 across all 8 Dockerfiles (ubuntu22.04 and openeuler24.03 variants), installing the ops package directly from the CANN 9.2.T3 repo during image build.

### Does this PR introduce _any_ user-facing change?

### How was this patch tested?

- vLLM main: https://github.com/vllm-project/vllm/commit/ba07e4a48fc951300d97eb506217dd530583dea3
