### PR TITLE
[CI]: collect and upload test case metadata and JUnit results

### DIFF
--- a/.github/workflows/_selected_tests.yaml
+++ b/.github/workflows/_selected_tests.yaml
@@ -346,6 +346,16 @@ jobs:
           retention-days: 14
           compression-level: 0
 
+      - name: Upload JUnit test results
+        if: ${{ !cancelled() }}
+        continue-on-error: true
+        uses: actions/upload-artifact@v7
+        with:
+          name: junit-${{ matrix.group.npu_type }}-${{ matrix.group.num_npus }}card-${{ matrix.group.partition }}
+          path: ${{ runner.temp }}/selected-tests-*/*.xml
+          if-no-files-found: ignore
+          retention-days: 7
+
   upload-coverage-to-obs:
       if: ${{ !cancelled() && inputs.enable-coverage }}
       needs: selected-tests

--- a/.github/workflows/pr_test.yaml
+++ b/.github/workflows/pr_test.yaml
@@ -649,3 +649,73 @@ jobs:
 
           echo "=== CI Gate: PASSED ==="
 
+  upload-reports:
+    needs:
+      - select-tests
+      - run-selected-tests
+      - run-selected-tests-a5
+    if: >-
+      ${{
+        !cancelled() &&
+        (
+          needs.run-selected-tests.result != 'skipped' ||
+          needs.run-selected-tests-a5.result != 'skipped'
+        )
+      }}
+    runs-on: linux-amd64-cpu-2-hk
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Setup Python
+        uses: actions/setup-python@v7
+        with:
+          python-version: '3.12'
+
+      - name: Download all JUnit artifacts
+        uses: actions/download-artifact@v8
+        with:
+          path: all-junit
+          pattern: junit-*
+
+      - name: Merge JUnit XML files
+        run: |
+          pip install junitparser --quiet
+          python .github/workflows/scripts/merge_junit_xml.py \
+            --input-dir all-junit \
+            --output merged_junit.xml
+
+      - name: Prepare metadata directory for selected tests
+        run: |
+          python .github/workflows/scripts/prepare_metadata_dir.py \
+            --test-groups '${{ needs.select-tests.outputs.test_groups }}' \
+            --test-groups '${{ needs.select-tests.outputs.test_groups_a5 }}' \
+            --output-dir selected-tests-metadata
+
+      - name: Collect test case metadata
+        id: collect-metadata
+        uses: lb-actions/openlibing-metadata-collect@v1.0.1
+        with:
+          testcase-path: selected-tests-metadata
+          metadata-output-path: metadata_test.xml
+
+      - name: Upload merged test results artifact
+        if: ${{ !cancelled() }}
+        continue-on-error: true
+        uses: actions/upload-artifact@v7
+        with:
+          name: merged-test-results
+          path: |
+            merged_junit.xml
+            metadata_test.xml
+          if-no-files-found: ignore
+          retention-days: 7
+
+      # - name: Upload reports
+      #   uses: lb-actions/openlibing-upload-reports@v1.0.0
+      #   with:
+      #     files: >
+      #       ${{ steps.collect-metadata.outputs.metadata-output-path }}
+      #       merged_junit.xml
+      #     openlibing-secret: ${{ secrets.scheduler_secret }}
+      #     github-token: ${{ secrets.mytoken }}
+

--- a/.github/workflows/scripts/merge_junit_xml.py
+++ b/.github/workflows/scripts/merge_junit_xml.py
@@ -1,0 +1,60 @@
+#
+# Copyright (c) 2025 Huawei Technologies Co., Ltd. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# This file is a part of the vllm-ascend project.
+#
+"""Merge multiple JUnit XML files from parallel test runs into a single file."""
+
+import argparse
+import os
+import sys
+from pathlib import Path
+
+from junitparser import JUnitXml
+
+
+def find_xml_files(input_dir: str) -> list[Path]:
+    return sorted(Path(input_dir).rglob("*.xml"))
+
+
+def merge_junit_xmls(input_dir: str, output: str) -> None:
+    xml_files = find_xml_files(input_dir)
+    if not xml_files:
+        print(f"::warning::No JUnit XML files found under {input_dir}", file=sys.stderr)
+        return
+
+    merged = JUnitXml()
+    for f in xml_files:
+        try:
+            suite = JUnitXml.fromfile(str(f))
+            merged += suite
+        except Exception as e:
+            print(f"::warning::Failed to parse {f}: {e}", file=sys.stderr)
+
+    merged.write(output)
+    print(f"Merged {len(xml_files)} JUnit XML files into {output}")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Merge JUnit XML files")
+    parser.add_argument("--input-dir", required=True, help="Directory containing JUnit XML files")
+    parser.add_argument("--output", required=True, help="Output merged JUnit XML file path")
+    args = parser.parse_args()
+
+    os.makedirs(os.path.dirname(args.output) or ".", exist_ok=True)
+    merge_junit_xmls(args.input_dir, args.output)
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/workflows/scripts/prepare_metadata_dir.py
+++ b/.github/workflows/scripts/prepare_metadata_dir.py
@@ -1,0 +1,106 @@
+#
+# Copyright (c) 2025 Huawei Technologies Co., Ltd. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# This file is a part of the vllm-ascend project.
+#
+"""Create a mirror of the tests tree with only selected test files for metadata collection.
+
+``openlibing-metadata-collect`` collects pytest test cases from a directory and
+typically relies on the surrounding test tree (conftest.py, __init__.py, data
+files). This script mirrors the full ``tests/`` tree as symlinks but keeps only
+the selected test files, so pytest collection works exactly as in the real tree.
+"""
+
+import argparse
+import json
+import os
+import sys
+
+
+def resolve_project_root() -> str:
+    return os.path.normpath(os.path.join(os.path.dirname(os.path.abspath(__file__)), "..", "..", ".."))
+
+
+def is_test_file(filename: str) -> bool:
+    return filename.startswith("test_") or filename.endswith("_test.py")
+
+
+def collect_selected_tests(test_groups_json: str) -> set[str]:
+    if not test_groups_json:
+        return set()
+    test_groups = json.loads(test_groups_json)
+    selected = set()
+    prefix = "tests" + os.sep
+    for group in test_groups:
+        for test_path in group.get("tests", "").split():
+            norm = os.path.normpath(test_path)
+            if norm.startswith(prefix):
+                norm = norm[len(prefix) :]
+            selected.add(norm)
+    return selected
+
+
+def mirror_symlink(src: str, dst: str) -> None:
+    os.makedirs(os.path.dirname(dst), exist_ok=True)
+    if not os.path.lexists(dst):
+        os.symlink(src, dst)
+
+
+def prepare_metadata_dir(test_groups_jsons: list[str], output_dir: str) -> None:
+    selected = set()
+    for test_groups_json in test_groups_jsons:
+        selected |= collect_selected_tests(test_groups_json)
+    if not selected:
+        print("::warning::test_groups is empty, no test files to collect", file=sys.stderr)
+        return
+
+    project_root = resolve_project_root()
+    tests_root = os.path.join(project_root, "tests")
+    os.makedirs(output_dir, exist_ok=True)
+
+    count = 0
+    for root, dirs, files in os.walk(tests_root):
+        dirs.sort()
+        for filename in sorted(files):
+            abs_path = os.path.join(root, filename)
+            rel_path = os.path.relpath(abs_path, tests_root)
+
+            if is_test_file(filename) and rel_path not in selected:
+                continue
+
+            dst = os.path.join(output_dir, rel_path)
+            mirror_symlink(abs_path, dst)
+            count += 1
+
+    print(f"Mirrored {count} files into {output_dir}")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Prepare metadata directory from selected test groups")
+    parser.add_argument(
+        "--test-groups",
+        action="append",
+        required=True,
+        help="JSON array of test groups (may be repeated, may be empty)",
+    )
+    parser.add_argument("--output-dir", required=True, help="Output directory for mirrored test files")
+    args = parser.parse_args()
+
+    prepare_metadata_dir(args.test_groups, args.output_dir)
+
+    print(f"metadata-dir={os.path.abspath(args.output_dir)}")
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/workflows/scripts/run_selected_tests.sh
+++ b/.github/workflows/scripts/run_selected_tests.sh
@@ -176,6 +176,7 @@ run_pytest_target() {
   log_name="${log_name%.py}"
   log_name="${log_name//[^a-zA-Z0-9_.-]/_}"
   local log_file="${pytest_log_dir}/${test_index}-${log_name}.log"
+  local junit_xml="${pytest_log_dir}/${test_index}-${log_name}.xml"
   echo "::group::${target}"
   echo -e "\033[1;34m=== Running target: ${target} ===\033[0m"
   local start_time=0
@@ -185,10 +186,10 @@ run_pytest_target() {
   if [ "${enable_coverage}" = "true" ]; then
     setup_coverage "${target}"
     set +e
-    run_logged_command "${log_file}" python -m coverage run --rcfile="${project_root}/tests/coveragerc" -m pytest -sv --color=yes "${target}"
+    run_logged_command "${log_file}" python -m coverage run --rcfile="${project_root}/tests/coveragerc" -m pytest -sv --color=yes --junitxml="${junit_xml}" "${target}"
   else
     set +e
-    run_logged_command "${log_file}" pytest -sv --color=yes "${target}"
+    run_logged_command "${log_file}" pytest -sv --color=yes --junitxml="${junit_xml}" "${target}"
   fi
   local status=$?
   set -e
@@ -225,6 +226,7 @@ run_pytest_batch() {
   local batch_targets=("$@")
   test_index=$((test_index + 1))
   local log_file="${pytest_log_dir}/${test_index}-cpu-ut.log"
+  local junit_xml="${pytest_log_dir}/${test_index}-cpu-ut.xml"
 
   echo "::group::${target}"
   echo -e "\033[1;34m=== Running target: ${target} ===\033[0m"
@@ -236,10 +238,10 @@ run_pytest_batch() {
     echo "DEBUG: Go to the [Coverage Branch] page."
     setup_coverage "cpu-ut"
     set +e
-    run_logged_command "${log_file}" python -m coverage run --rcfile="${project_root}/tests/coveragerc" -m pytest -sv --color=yes "${batch_targets[@]}"
+    run_logged_command "${log_file}" python -m coverage run --rcfile="${project_root}/tests/coveragerc" -m pytest -sv --color=yes --junitxml="${junit_xml}" "${batch_targets[@]}"
   else
     set +e
-    run_logged_command "${log_file}" pytest -sv --color=yes "${batch_targets[@]}"
+    run_logged_command "${log_file}" pytest -sv --color=yes --junitxml="${junit_xml}" "${batch_targets[@]}"
   fi
   local status=$?
   set -e


### PR DESCRIPTION

### What this PR does / why we need it?
collect and upload test case metadata and JUnit results:

- Add --junitxml to per-target pytest runs in run_selected_tests.sh
- Upload per-group JUnit XML artifacts from _selected_tests.yaml
- Add upload-reports job in pr_test.yaml to aggregate parallel results
- Add merge_junit_xml.py to merge JUnit XMLs and prepare_metadata_dir.py to mirror selected tests tree for metadata collection via openlibing-metadata-collect / upload-reports actions

### Does this PR introduce _any_ user-facing change?

### How was this patch tested?

- vLLM main: https://github.com/vllm-project/vllm/commit/ba07e4a48fc951300d97eb506217dd530583dea3
