### PR TITLE
[Ops][Feature] Enable Qwen4Exp (Qwen3.8-Flash-Next) on Ascend NPU

### DIFF
--- a/tests/ut/patch/worker/test_patch_qwen4_exp.py
+++ b/tests/ut/patch/worker/test_patch_qwen4_exp.py
@@ -1,0 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+
+from vllm_ascend.patch.worker import patch_qwen4_exp
+
+
+def test_patch_qwen4_exp_module_exports_availability_flag():
+    assert isinstance(patch_qwen4_exp.QWEN4_EXP_AVAILABLE, bool)

--- a/vllm_ascend/patch/__init__.py
+++ b/vllm_ascend/patch/__init__.py
@@ -833,6 +833,20 @@
 #    Future Plan:
 #       Remove this patch when all ops in _forward_core support both Qwen3_5 and Qwen3Next.
 #
+# ** 14b. File: worker/patch_qwen4_exp.py**
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+#   1. `vllm.models.qwen4_exp.nvidia.low_latency_gemm.enable_qwen4_exp_low_latency_gemm`
+#   2. `vllm.models.qwen4_exp.nvidia.qsa.Qwen4ExpQSAAttention._project_qkv_gate`
+#    Why:
+#       Qwen4Exp (Qwen3.8-Flash-Next) ships CUDA-only decode GEMM hooks and reuses
+#       Qwen3Next QKV/RoPE paths for QSA owners. GDN layers already use
+#       `QwenGatedDeltaNetAttention`, patched by `patch_qwen3_5.py`.
+#    How:
+#       No-op the CUDA skinny GEMM hook on NPU and route QSA QKV projection through
+#       the Ascend Qwen3Next RoPE path. QSA/PLE/HyperConnection kernels remain upstream.
+#    Future Plan:
+#       Add dedicated NPU QSA/PLE backends and remove eager fallbacks once validated.
+#
 # ** 15. File: worker/patch_qwen3_dflash.py**
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 #   1. `vllm.model_executor.models.qwen3_dflash.DFlashQwen3Model.precompute_and_store_context_kv`

--- a/vllm_ascend/patch/worker/__init__.py
+++ b/vllm_ascend/patch/worker/__init__.py
@@ -33,6 +33,7 @@ import vllm_ascend.patch.worker.patch_step3p5  # noqa
 
 if get_current_hardware_profile().supports(HardwareCapability.STANDARD_WORKER_PATCHES):
     import vllm_ascend.patch.worker.patch_qwen3_5  # noqa
+    import vllm_ascend.patch.worker.patch_qwen4_exp  # noqa
     import vllm_ascend.patch.worker.patch_qwen3_dflash  # noqa
     import vllm_ascend.patch.worker.patch_qwen3vl  # noqa
 else:

--- a/vllm_ascend/patch/worker/patch_qwen4_exp.py
+++ b/vllm_ascend/patch/worker/patch_qwen4_exp.py
@@ -54,7 +54,7 @@ else:
         if self.attn_output_gate:
             q_gate, k, v = qkv.split([self.q_size * 2, self.kv_size, self.kv_size], dim=-1)
             orig_shape = q_gate.shape[:-1]
-            q_gate = q_gate.view(*orig_shape, self.num_heads, -1)
+            q_gate = q_gate.reshape(*orig_shape, self.num_heads, -1)
             q, gate = torch.chunk(q_gate, 2, dim=-1)
             q = q.reshape(*orig_shape, -1)
             gate = gate.reshape(*orig_shape, -1)
@@ -62,8 +62,8 @@ else:
             q, k, v = qkv.split([self.q_size, self.kv_size, self.kv_size], dim=-1)
             gate = None
 
-        q = self.q_norm(q.view(-1, self.num_heads, self.head_dim)).view(-1, self.num_heads * self.head_dim)
-        k = self.k_norm(k.view(-1, self.num_kv_heads, self.head_dim)).view(
+        q = self.q_norm(q.reshape(-1, self.num_heads, self.head_dim)).reshape(-1, self.num_heads * self.head_dim)
+        k = self.k_norm(k.reshape(-1, self.num_kv_heads, self.head_dim)).reshape(
             -1, self.num_kv_heads * self.head_dim
         )
         q, k = self.rotary_emb(positions, q, k)

--- a/vllm_ascend/patch/worker/patch_qwen4_exp.py
+++ b/vllm_ascend/patch/worker/patch_qwen4_exp.py
@@ -1,0 +1,72 @@
+#
+# Copyright (c) 2026 Huawei Technologies Co., Ltd. All Rights Reserved.
+# This file is a part of the vllm-ascend project.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on the "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# mypy: ignore-errors
+
+"""NPU enablement scaffold for Qwen4Exp (Qwen3.8-Flash-Next).
+
+Upstream vLLM registers ``qwen4_exp`` in its model registry (#53896). This
+patch wires Ascend-specific behavior without duplicating model files.
+
+GDN layers reuse ``QwenGatedDeltaNetAttention``, already patched in
+``patch_qwen3_5.py``. QSA/PLE/HyperConnection NPU backends are follow-up work.
+"""
+
+from __future__ import annotations
+
+import torch
+from torch import nn
+
+QWEN4_EXP_AVAILABLE = False
+
+try:
+    import vllm.models.qwen4_exp.nvidia.model as qwen4_exp_model_module
+    from vllm.models.qwen4_exp.nvidia.qsa import Qwen4ExpQSAAttention
+except ImportError:
+    pass
+else:
+    QWEN4_EXP_AVAILABLE = True
+
+    def enable_qwen4_exp_low_latency_gemm(module: nn.Module, dtype: torch.dtype) -> None:
+        """Skip CUDA-only skinny GEMM hooks on Ascend NPU."""
+        del module, dtype
+
+    qwen4_exp_model_module.enable_qwen4_exp_low_latency_gemm = enable_qwen4_exp_low_latency_gemm
+
+    def _ascend_qwen4_exp_qsa_project_qkv_gate(
+        self: Qwen4ExpQSAAttention,
+        qkv: torch.Tensor,
+        positions: torch.Tensor,
+    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor | None]:
+        """Apply the Ascend text-only QKV/RoPE path used by Qwen3Next attention."""
+        if self.attn_output_gate:
+            q_gate, k, v = qkv.split([self.q_size * 2, self.kv_size, self.kv_size], dim=-1)
+            orig_shape = q_gate.shape[:-1]
+            q_gate = q_gate.view(*orig_shape, self.num_heads, -1)
+            q, gate = torch.chunk(q_gate, 2, dim=-1)
+            q = q.reshape(*orig_shape, -1)
+            gate = gate.reshape(*orig_shape, -1)
+        else:
+            q, k, v = qkv.split([self.q_size, self.kv_size, self.kv_size], dim=-1)
+            gate = None
+
+        q = self.q_norm(q.view(-1, self.num_heads, self.head_dim)).view(-1, self.num_heads * self.head_dim)
+        k = self.k_norm(k.view(-1, self.num_kv_heads, self.head_dim)).view(
+            -1, self.num_kv_heads * self.head_dim
+        )
+        q, k = self.rotary_emb(positions, q, k)
+        return q, k, v, gate
+
+    Qwen4ExpQSAAttention._project_qkv_gate = _ascend_qwen4_exp_qsa_project_qkv_gate


### PR DESCRIPTION
### What this PR does / why we need it?
This PR adds an NPU enablement scaffold for Qwen4Exp (Qwen3.8-Flash-Next) to support it on Ascend NPU without duplicating model files. It disables CUDA-only low-latency GEMM hooks and routes QSA QKV projection through the Ascend Qwen3Next RoPE path.

Feedback: In `patch_qwen4_exp.py`, using `.view()` on non-contiguous tensors returned by `split` or `chunk` will raise a runtime error. It is highly recommended to use `.reshape()` instead to safely handle non-contiguous tensors.

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
Added a unit test `test_patch_qwen4_exp_module_exports_availability_flag` to verify the module's availability flag.