### PR TITLE
[Refactor]Remove unused npu_flash_attention wrappers and their UTs

### DIFF
--- a/tests/ut/device/test_device_op.py
+++ b/tests/ut/device/test_device_op.py
@@ -1,9 +1,8 @@
 from unittest import mock
 
-import pytest
 import torch
 
-from vllm_ascend.device.device_op import A5DeviceAdaptor, BaseDeviceAdaptor
+from vllm_ascend.device.device_op import BaseDeviceAdaptor
 
 
 def test_reshape_and_cache_makes_scatter_inputs_contiguous():
@@ -69,116 +68,3 @@ def test_kv_cache_load_makes_seq_lens_contiguous():
     assert mock_gather.call_args.kwargs["seq_offset"] is seq_starts
     assert mock_gather.call_args.kwargs["key"] is key
     assert mock_gather.call_args.kwargs["value"] is value
-
-
-def test_npu_flash_attention_uses_fusion_attention_for_fp32():
-    query = torch.randn(5, 4, 64, dtype=torch.float32)
-    key = torch.randn_like(query)
-    value = torch.randn_like(query)
-    seq_lens_cpu = torch.tensor([2, 3], dtype=torch.int32)
-    expected = torch.randn_like(query)
-
-    with (
-        mock.patch(
-            "vllm_ascend.device.device_op.torch_npu.npu_fusion_attention",
-            return_value=(expected,),
-        ) as mock_fusion_attention,
-        mock.patch(
-            "vllm_ascend.device.device_op.torch_npu._npu_flash_attention_unpad",
-            create=True,
-        ) as mock_flash_attention,
-    ):
-        output = BaseDeviceAdaptor.npu_flash_attention(
-            query=query,
-            key=key,
-            value=value,
-            seq_lens_cpu=seq_lens_cpu,
-            head_num=4,
-            scale_value=0.125,
-            num_kv_heads=4,
-        )
-
-    assert output is expected
-    mock_flash_attention.assert_not_called()
-    mock_fusion_attention.assert_called_once()
-    call_kwargs = mock_fusion_attention.call_args.kwargs
-    assert call_kwargs["query"] is query
-    assert call_kwargs["key"] is key
-    assert call_kwargs["value"] is value
-    assert call_kwargs["actual_seq_qlen"] == [2, 5]
-    assert all(isinstance(seq_len, int) for seq_len in call_kwargs["actual_seq_qlen"])
-    assert call_kwargs["actual_seq_kvlen"] is call_kwargs["actual_seq_qlen"]
-    assert call_kwargs["head_num"] == 4
-    assert call_kwargs["scale"] == 0.125
-    assert call_kwargs["input_layout"] == "TND"
-
-
-@pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16])
-def test_npu_flash_attention_uses_unpad_attention_for_low_precision(dtype):
-    query = torch.randn(5, 4, 64, dtype=dtype)
-    key = torch.randn_like(query)
-    value = torch.randn_like(query)
-    seq_lens_cpu = torch.tensor([2, 3], dtype=torch.int32)
-
-    def fake_flash_attention(*, query, key, value, seq_len, scale_value, num_heads, num_kv_heads, out):
-        out.copy_(query + 1)
-
-    with (
-        mock.patch(
-            "vllm_ascend.device.device_op.torch_npu.npu_fusion_attention",
-        ) as mock_fusion_attention,
-        mock.patch(
-            "vllm_ascend.device.device_op.torch_npu._npu_flash_attention_unpad",
-            side_effect=fake_flash_attention,
-            create=True,
-        ) as mock_flash_attention,
-    ):
-        output = BaseDeviceAdaptor.npu_flash_attention(
-            query=query,
-            key=key,
-            value=value,
-            seq_lens_cpu=seq_lens_cpu,
-            head_num=4,
-            scale_value=0.125,
-            num_kv_heads=4,
-        )
-
-    mock_fusion_attention.assert_not_called()
-    mock_flash_attention.assert_called_once()
-    call_kwargs = mock_flash_attention.call_args.kwargs
-    assert call_kwargs["query"] is query
-    assert call_kwargs["key"] is key
-    assert call_kwargs["value"] is value
-    assert call_kwargs["seq_len"] is seq_lens_cpu
-    assert call_kwargs["num_heads"] == 4
-    assert call_kwargs["num_kv_heads"] == 4
-    assert call_kwargs["scale_value"] == 0.125
-    torch.testing.assert_close(output, query + 1)
-
-
-def test_a5_npu_flash_attention_uses_python_sequence_lengths():
-    query = torch.randn(5, 4, 64, dtype=torch.float16)
-    key = torch.randn_like(query)
-    value = torch.randn_like(query)
-    seq_lens_cpu = torch.tensor([2, 3], dtype=torch.int32)
-    expected = torch.randn_like(query)
-
-    with mock.patch(
-        "vllm_ascend.device.device_op.torch_npu.npu_fusion_attention",
-        return_value=(expected,),
-    ) as mock_fusion_attention:
-        output = A5DeviceAdaptor.npu_flash_attention(
-            query=query,
-            key=key,
-            value=value,
-            seq_lens_cpu=seq_lens_cpu,
-            head_num=4,
-            scale_value=0.125,
-            num_kv_heads=4,
-        )
-
-    assert output is expected
-    call_kwargs = mock_fusion_attention.call_args.kwargs
-    assert call_kwargs["actual_seq_qlen"] == [2, 5]
-    assert all(isinstance(seq_len, int) for seq_len in call_kwargs["actual_seq_qlen"])
-    assert call_kwargs["actual_seq_kvlen"] is call_kwargs["actual_seq_qlen"]

--- a/vllm_ascend/device/device_op.py
+++ b/vllm_ascend/device/device_op.py
@@ -491,37 +491,6 @@ class BaseDeviceAdaptor:
             return_softmax_lse=return_lse,
         )
 
-    @staticmethod
-    def npu_flash_attention(query, key, value, seq_lens_cpu, head_num, scale_value, num_kv_heads):
-        if query.dtype == torch.float32:
-            # _npu_flash_attention_unpad does not support FP32.
-            cumulative_seq_lens = seq_lens_cpu.cumsum(0).tolist()
-            return torch_npu.npu_fusion_attention(
-                query=query,
-                key=key,
-                value=value,
-                actual_seq_qlen=cumulative_seq_lens,
-                actual_seq_kvlen=cumulative_seq_lens,
-                head_num=head_num,
-                scale=scale_value,
-                input_layout="TND",
-            )[0]
-
-        context_layer = torch.empty_like(query)
-
-        torch_npu._npu_flash_attention_unpad(
-            query=query,
-            key=key,
-            value=value,
-            seq_len=seq_lens_cpu,
-            scale_value=scale_value,
-            num_heads=head_num,
-            num_kv_heads=num_kv_heads,
-            out=context_layer,
-        )
-
-        return context_layer
-
     # ===== SWA / Compressor KV Scatter =====
 
     @staticmethod
@@ -1349,23 +1318,6 @@ class A5DeviceAdaptor(BaseDeviceAdaptor):
                 sparse_mode=3,
             )
         return topk_indices
-
-    @staticmethod
-    def npu_flash_attention(query, key, value, seq_lens_cpu, head_num, scale_value, num_kv_heads):
-        cumulative_seq_lens = seq_lens_cpu.cumsum(0).tolist()
-
-        context_layer = torch_npu.npu_fusion_attention(
-            query=query,
-            key=key,
-            value=value,
-            actual_seq_qlen=cumulative_seq_lens,
-            actual_seq_kvlen=cumulative_seq_lens,
-            head_num=head_num,
-            scale=scale_value,
-            input_layout="TND",
-        )[0]
-
-        return context_layer
 
     @staticmethod
     def chunk_scaled_dot_kkt_fwd(


### PR DESCRIPTION
## Description

Remove the unused `npu_flash_attention` wrappers and their unit tests.

- `BaseDeviceAdaptor.npu_flash_attention` (dispatching to `torch_npu.npu_fusion_attention` / `torch_npu._npu_flash_attention_unpad`)
- `A5DeviceAdaptor.npu_flash_attention` (dispatching to `torch_npu.npu_fusion_attention`)

These wrappers have no callers anywhere in `vllm_ascend` (the attention layer now goes through `FlashAttentionImpl` / `npu_fusion_attention` directly), so they are dead code. The corresponding UTs in `tests/ut/device/test_device_op.py` only test the removed wrappers and are removed together.

Pure deletion, no functional change: `+1 / -163` lines.

## What's changed

- `vllm_ascend/device/device_op.py`: remove `npu_flash_attention` static methods from `BaseDeviceAdaptor` and `A5DeviceAdaptor`
- `tests/ut/device/test_device_op.py`: remove the three wrapper-only tests
  (`test_npu_flash_attention_uses_fusion_attention_for_fp32`,
  `test_npu_flash_attention_uses_unpad_attention_for_low_precision`,
  `test_a5_npu_flash_attention_uses_python_sequence_lengths`)

## Verification

- Searched the whole repo: no references to `npu_flash_attention` remain outside the deleted code
- `ruff check` / `ruff format` pass

## Notes for reviewers

Double-checked with `grep -rn "npu_flash_attention" vllm_ascend/` — zero hits after this change. Grep for callers of `device_op.npu_flash_attention` on `main` also returns nothing, confirming the wrappers were dead code.

- vLLM main: https://github.com/vllm-project/vllm/commit/e6bfe03ad73a3330cb427885aa90d97a12e1c704
