### PR TITLE
[Bugfix] Keep Ascend config unit test CPU-only

### DIFF
--- a/tests/ut/test_ascend_config.py
+++ b/tests/ut/test_ascend_config.py
@@ -21,7 +21,7 @@ from importlib.util import find_spec as real_find_spec
 from types import SimpleNamespace
 from unittest.mock import patch
 
-from vllm.config import KVTransferConfig, ModelConfig, VllmConfig
+from vllm.config import KVTransferConfig, VllmConfig
 
 from tests.ut.base import TestBase
 from vllm_ascend.ascend_config import (
@@ -1226,7 +1226,10 @@ class TestTopLevelSwitchTypeValidation(TestBase):
         ),
     )
     def test_omni_additional_config_warns_and_is_preserved(self, _mock_find_spec, mock_warning):
-        vllm_config = VllmConfig(model_config=ModelConfig(), additional_config={"vllm_omni_option": True})
+        vllm_config = VllmConfig()
+        vllm_config.additional_config = {"vllm_omni_option": True}
+
+        init_ascend_config(vllm_config)
 
         self.assertIs(vllm_config.additional_config["vllm_omni_option"], True)
         mock_warning.assert_any_call(


### PR DESCRIPTION
<!--  Thanks for sending a pull request!

BEFORE SUBMITTING, PLEASE READ https://docs.vllm.ai/en/latest/contributing/overview.html

-->
### What this PR does / why we need it?
<!--
- Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue.
If possible, please consider writing useful notes for better and faster reviews in your PR.

- Please clarify why the changes are needed. For instance, the use case and bug description.

- Fixes #
-->
Fix cpu test breaks.

Avoids constructing a real `ModelConfig` in the Ascend configuration unit test.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as API, interface or other behavior changes.
Documentation-only updates are not considered user-facing changes.
-->

No

### How was this patch tested?
<!--
CI passed with new added/existing test.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->

tested on cpu only container:

```bash
unset ASCEND_RT_VISIBLE_DEVICES
export TORCH_DEVICE_BACKEND_AUTOLOAD=0

python -m pytest -sv tests/ut/test_ascend_config.py::TestTopLevelSwitchTypeValidation::test_omni_additional_config_warns_and_is_preserved
```

```bash
1 passed, 14 warnings in 0.05s
```