### PR TITLE
[Performance] Reuse PA workspace across layers in graph param update

### DIFF
--- a/vllm_ascend/attention/attention_v1.py
+++ b/vllm_ascend/attention/attention_v1.py
@@ -538,6 +538,16 @@ class AscendAttentionBackendImpl(AttentionImpl):
             else:
                 graph_params = get_graph_params()
             with torch.npu.stream(update_stream):
+                # The workspace size depends only on shapes and seq_lens, which
+                # are shared by all layers within one graph-param update pass,
+                # so one get_workspace call per pass is sufficient. Reuse the
+                # workspace across layers and re-query only when any
+                # size-relevant input changes. This mirrors the FIA path, which already
+                # reuses graph_params.workspaces[num_tokens], and removes the
+                # redundant per-layer get_workspace calls (each backed by a
+                # ~36-54MB buffer allocation) per decode step.
+                step_ws_key = None
+                workspace = None
                 for key, param, handle, event in zip(
                     forward_context.attn_metadata,
                     graph_params.attn_params[num_tokens],
@@ -557,17 +567,39 @@ class AscendAttentionBackendImpl(AttentionImpl):
                     ) = param
                     seq_lens = forward_context.attn_metadata[key].seq_lens
 
-                    workspace = torch_npu._npu_paged_attention_get_workspace(
-                        query=query,
-                        key_cache=key_cache,
-                        value_cache=value_cache,
-                        num_kv_heads=num_kv_heads,
-                        num_heads=num_heads,
-                        scale_value=scale,
-                        block_table=block_table,
-                        context_lens=seq_lens,
-                        out=output,
+                    # The key covers every size-relevant input, so models
+                    # with heterogeneous layer configs simply trigger a
+                    # re-query instead of reusing a wrong-sized workspace.
+                    ws_key = (
+                        seq_lens.data_ptr(),
+                        tuple(seq_lens.shape),
+                        query.shape,
+                        query.dtype,
+                        key_cache.shape,
+                        key_cache.dtype,
+                        value_cache.shape,
+                        value_cache.dtype,
+                        block_table.shape if block_table is not None else None,
+                        block_table.dtype if block_table is not None else None,
+                        output.shape,
+                        output.dtype,
+                        num_kv_heads,
+                        num_heads,
+                        scale,
                     )
+                    if step_ws_key != ws_key:
+                        workspace = torch_npu._npu_paged_attention_get_workspace(
+                            query=query,
+                            key_cache=key_cache,
+                            value_cache=value_cache,
+                            num_kv_heads=num_kv_heads,
+                            num_heads=num_heads,
+                            scale_value=scale,
+                            block_table=block_table,
+                            context_lens=seq_lens,
+                            out=output,
+                        )
+                        step_ws_key = ws_key
                     torch.npu.graph_task_update_begin(update_stream, handle)
                     torch_npu._npu_paged_attention(
                         query=query,


### PR DESCRIPTION
# perf(attention): reuse PA workspace across layers in graph param update

## Motivation

In `AscendAttentionBackendImpl` (graph mode, `_npu_paged_attention` path), the
graph-param update loop calls `torch_npu._npu_paged_attention_get_workspace`
**once per layer**. On a 28-layer model this is 28 calls per decode step, each
backed by a ~36-54MB buffer allocation and a host-side "Setup" round trip.

Profiling on Ascend 910B (vLLM v0.26.0, vllm-ascend v0.19.1rc1 base, TP=1,
FULL_DECODE_ONLY, steady-state c=32):

| Metric | Before | After |
|---|---|---|
| get_workspace Setup / Execute ratio | 2.000 (22232/11116) | **1.036** (14355/13860) |
| update_graph_params avg | 2.4-2.95 ms | **1.65-1.67 ms** (-1.1~1.3 ms/step) |
| Host ACL API total (5.1s window) | 1335 ms | **1040 ms** (-22%) |
| QPS c=1 / c=32 / c=64 | 1.27 / 16.73 / 21.49 | **1.35 / 17.13 / 21.90** (+5.9% / +2.4% / +1.9%) |

Functional outputs are unchanged (same md5 on the full functional suite).

## Change

Hoist the workspace out of the per-layer loop: query it once per update pass
and reuse across layers, re-querying only when the seq_lens tensor identity
changes (`(data_ptr, shape)` key). This is the same shape as the FIA path,
which already reuses `graph_params.workspaces[num_tokens]`.

## Why per-pass (not cross-step) reuse is safe

- The workspace size depends only on shapes **and seq_lens**, and all layers
  within one update pass share the same step's `seq_lens` tensor, so one call
  is sufficient.
- Cross-step reuse is deliberately **avoided**: the workspace size also
  depends on the *values* of seq_lens (observed 36MB for lens<=80 vs 54MB for
  lens<=400), which grow as decode progresses — a cached workspace from a
  previous step can be too small.
- If any layer's seq_lens tensor differs (key mismatch), the code falls back
  to a fresh `get_workspace` call — conservative by construction.

## Environment

- Ascend 910B, CANN 8.x, torch_npu 2.10.0.post2
  the touched code is identical on main as of 2026-09-02)

- vLLM main: https://github.com/vllm-project/vllm/commit/ba07e4a48fc951300d97eb506217dd530583dea3
