### PR TITLE
[Test][BugFix] Fix inconsistent enable_dsa_cp config in DeepSeek-V3.2-W8A8-EP test

### DIFF
--- a/tests/e2e/nightly/multi_node/internal_dp/config/DeepSeek-V3_2-W8A8-EP.yaml
+++ b/tests/e2e/nightly/multi_node/internal_dp/config/DeepSeek-V3_2-W8A8-EP.yaml
@@ -96,7 +96,7 @@ deployment:
           --gpu-memory-utilization 0.90
           --enforce-eager
           --no-enable-prefix-caching
-          --additional-config '{"enable_cpu_binding" : false, "enable_dsa_cp":false}'
+          --additional-config '{"enable_cpu_binding" : false, "enable_dsa_cp":true}'
           --tokenizer-mode deepseek_v32 
           --reasoning-parser deepseek_v3
           --kv-transfer-config


### PR DESCRIPTION
### What this PR does / why we need it?

In `tests/e2e/nightly/multi_node/internal_dp/config/DeepSeek-V3_2-W8A8-EP.yaml`, the two prefill (P) nodes of the disaggregated-prefill deployment had inconsistent `enable_dsa_cp` settings in `--additional-config`:

- P node 0 (kv_producer, `--data-parallel-start-rank 0`): `"enable_dsa_cp": true`
- P node 1 (kv_producer, `--data-parallel-start-rank 1`): `"enable_dsa_cp": false`

This PR aligns both prefill nodes to `"enable_dsa_cp": true` so the two prefill instances run with a consistent configuration.

### Does this PR introduce _any_ user-facing change?

No. This only fixes an internal e2e nightly test configuration.

### How was this patch tested?

- Verified the YAML file still parses correctly with `yaml.safe_load`.
- Verified both prefill nodes now contain `"enable_dsa_cp": true`.
- The nightly e2e CI running this config will exercise the change.

- vLLM main: https://github.com/vllm-project/vllm/commit/ba07e4a48fc951300d97eb506217dd530583dea3
