### PR TITLE
[Ops][Performance] Warm up GDN prefill kernels before KV-cache allocation

### DIFF
--- a/tests/ut/patch/worker/test_patch_gdn_prefill_warmup.py
+++ b/tests/ut/patch/worker/test_patch_gdn_prefill_warmup.py
@@ -1,0 +1,216 @@
+# Copyright (c) 2026 Huawei Technologies Co., Ltd. All Rights Reserved.
+# This file is a part of the vllm-ascend project.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from types import SimpleNamespace
+from unittest.mock import Mock, patch
+
+import pytest
+import torch
+
+from vllm_ascend.patch.worker import patch_gdn_prefill_warmup as warmup
+
+
+class _WarmupLayer:
+    prefix = "layers.0.linear_attn"
+    num_k_heads = 2
+    num_v_heads = 4
+    tp_size = 1
+    head_k_dim = 2
+    head_v_dim = 3
+
+    def __init__(self):
+        self.A_log = torch.zeros(self.num_v_heads, dtype=torch.float32)
+        self.dt_bias = torch.zeros(self.num_v_heads, dtype=torch.float32)
+
+    def get_state_dtype(self):
+        return torch.float16, torch.float32
+
+    def rearrange_mixed_qkv(self, mixed_qkv: torch.Tensor):
+        tokens = mixed_qkv.shape[0]
+        query = torch.zeros(1, tokens, self.num_k_heads, self.head_k_dim)
+        key = torch.zeros_like(query)
+        value = torch.zeros(1, tokens, self.num_v_heads, self.head_v_dim)
+        return query, key, value
+
+
+@pytest.fixture(autouse=True)
+def clear_warmup_signatures():
+    warmup._GDN_PREFILL_WARMUP_SIGNATURES.clear()
+    yield
+    warmup._GDN_PREFILL_WARMUP_SIGNATURES.clear()
+
+
+def _gating_outputs():
+    return (
+        torch.zeros(1, warmup._GDN_PREFILL_WARMUP_TOKENS, 4),
+        torch.zeros(1, warmup._GDN_PREFILL_WARMUP_TOKENS, 4),
+    )
+
+
+def test_fallback_prefill_warmup_runs_once_per_signature():
+    first_layer = _WarmupLayer()
+    second_layer = _WarmupLayer()
+    mixed_qkv = torch.zeros(8, 20, dtype=torch.bfloat16)
+    fallback = Mock(return_value=(Mock(), Mock()))
+
+    with (
+        patch.object(
+            warmup.AscendGatedDeltaNetAttention,
+            "_probe_fused_chunk",
+            return_value=False,
+        ),
+        patch.object(
+            warmup.DeviceOperator,
+            "fused_gdn_gating",
+            return_value=_gating_outputs(),
+        ),
+        patch.object(warmup, "get_pcp_group", return_value=SimpleNamespace(world_size=1)),
+        patch.object(warmup, "chunk_gated_delta_rule", fallback),
+    ):
+        warmup._warmup_gdn_prefill_kernels(first_layer, mixed_qkv, 0)
+        warmup._warmup_gdn_prefill_kernels(second_layer, mixed_qkv, 0)
+
+    fallback.assert_called_once()
+    kwargs = fallback.call_args.kwargs
+    assert kwargs["q"].shape == (1, 64, 2, 2)
+    assert kwargs["k"].shape == (1, 64, 2, 2)
+    assert kwargs["v"].shape == (1, 64, 4, 3)
+    assert kwargs["initial_state"].shape == (1, 4, 2, 3)
+    assert kwargs["initial_state"].dtype == torch.float32
+    assert kwargs["cu_seqlens"].tolist() == [0, 64]
+    assert kwargs["use_qk_l2norm_in_kernel"] is True
+    assert len(warmup._GDN_PREFILL_WARMUP_SIGNATURES) == 1
+
+
+def test_fused_prefill_warmup_uses_live_state_layout():
+    layer = _WarmupLayer()
+    mixed_qkv = torch.zeros(8, 20, dtype=torch.bfloat16)
+    fused = Mock(return_value=(Mock(), Mock()))
+    fallback = Mock()
+
+    with (
+        patch.object(
+            warmup.AscendGatedDeltaNetAttention,
+            "_probe_fused_chunk",
+            return_value=True,
+        ),
+        patch.object(
+            warmup.AscendGatedDeltaNetAttention,
+            "_chunk_gated_delta_rule_fused",
+            fused,
+        ),
+        patch.object(
+            warmup.DeviceOperator,
+            "fused_gdn_gating",
+            return_value=_gating_outputs(),
+        ),
+        patch.object(warmup, "get_pcp_group", return_value=SimpleNamespace(world_size=1)),
+        patch.object(warmup, "chunk_gated_delta_rule", fallback),
+    ):
+        warmup._warmup_gdn_prefill_kernels(layer, mixed_qkv, 0)
+
+    fused.assert_called_once()
+    assert fused.call_args.kwargs["initial_state"].shape == (1, 4, 3, 2)
+    fallback.assert_not_called()
+
+
+def test_failed_prefill_warmup_is_retryable():
+    layer = _WarmupLayer()
+    mixed_qkv = torch.zeros(8, 20, dtype=torch.bfloat16)
+    fallback = Mock(side_effect=[RuntimeError("warmup failed"), (Mock(), Mock())])
+
+    with (
+        patch.object(
+            warmup.AscendGatedDeltaNetAttention,
+            "_probe_fused_chunk",
+            return_value=False,
+        ),
+        patch.object(
+            warmup.DeviceOperator,
+            "fused_gdn_gating",
+            return_value=_gating_outputs(),
+        ),
+        patch.object(warmup, "get_pcp_group", return_value=SimpleNamespace(world_size=1)),
+        patch.object(warmup, "chunk_gated_delta_rule", fallback),
+    ):
+        warmup._warmup_gdn_prefill_kernels(layer, mixed_qkv, 0)
+        assert not warmup._GDN_PREFILL_WARMUP_SIGNATURES
+        warmup._warmup_gdn_prefill_kernels(layer, mixed_qkv, 0)
+
+    assert fallback.call_count == 2
+    assert len(warmup._GDN_PREFILL_WARMUP_SIGNATURES) == 1
+
+
+def test_profile_forward_invokes_prefill_warmup_instead_of_runtime_core():
+    layer = _WarmupLayer()
+    mixed_qkv = torch.zeros(8, 20, dtype=torch.bfloat16)
+    b = torch.zeros(8, 4)
+    a = torch.zeros(8, 4)
+    output = torch.zeros(8, 4, 3)
+
+    with (
+        patch.object(
+            warmup,
+            "get_forward_context",
+            return_value=SimpleNamespace(attn_metadata=None),
+        ),
+        patch.object(warmup, "_warmup_gdn_prefill_kernels") as run_warmup,
+        patch.object(warmup, "_ASCEND_GDN_FORWARD_CORE") as runtime_core,
+    ):
+        result = warmup._forward_core_with_prefill_warmup(
+            layer,
+            mixed_qkv,
+            b,
+            a,
+            output,
+        )
+
+    assert result is None
+    run_warmup.assert_called_once_with(layer, mixed_qkv, 0)
+    runtime_core.assert_not_called()
+
+
+def test_runtime_forward_delegates_when_metadata_is_available():
+    layer = _WarmupLayer()
+    mixed_qkv = torch.zeros(8, 20, dtype=torch.bfloat16)
+    b = torch.zeros(8, 4)
+    a = torch.zeros(8, 4)
+    output = torch.zeros(8, 4, 3)
+    expected = object()
+
+    with (
+        patch.object(
+            warmup,
+            "get_forward_context",
+            return_value=SimpleNamespace(attn_metadata={layer.prefix: object()}),
+        ),
+        patch.object(warmup, "_warmup_gdn_prefill_kernels") as run_warmup,
+        patch.object(
+            warmup,
+            "_ASCEND_GDN_FORWARD_CORE",
+            return_value=expected,
+        ) as runtime_core,
+    ):
+        result = warmup._forward_core_with_prefill_warmup(
+            layer,
+            mixed_qkv,
+            b,
+            a,
+            output,
+        )
+
+    assert result is expected
+    run_warmup.assert_not_called()
+    runtime_core.assert_called_once_with(layer, mixed_qkv, b, a, output)

--- a/vllm_ascend/patch/worker/__init__.py
+++ b/vllm_ascend/patch/worker/__init__.py
@@ -32,6 +32,7 @@ import vllm_ascend.patch.worker.patch_step3p5  # noqa
 
 if get_current_hardware_profile().supports(HardwareCapability.STANDARD_WORKER_PATCHES):
     import vllm_ascend.patch.worker.patch_qwen3_5  # noqa
+    import vllm_ascend.patch.worker.patch_gdn_prefill_warmup  # noqa
     import vllm_ascend.patch.worker.patch_qwen3_dflash  # noqa
     import vllm_ascend.patch.worker.patch_qwen3vl  # noqa
 else:

--- a/vllm_ascend/patch/worker/patch_gdn_prefill_warmup.py
+++ b/vllm_ascend/patch/worker/patch_gdn_prefill_warmup.py
@@ -1,0 +1,213 @@
+#
+# Copyright (c) 2026 Huawei Technologies Co., Ltd. All Rights Reserved.
+# This file is a part of the vllm-ascend project.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# mypy: ignore-errors
+
+import torch
+import torch_npu  # noqa: F401
+from vllm.distributed import get_pcp_group
+from vllm.forward_context import get_forward_context
+from vllm.logger import logger
+from vllm.model_executor.layers.mamba.gdn.qwen_gdn_linear_attn import (
+    QwenGatedDeltaNetAttention,
+)
+
+from vllm_ascend.device.device_op import DeviceOperator
+from vllm_ascend.ops.gdn import AscendGatedDeltaNetAttention
+from vllm_ascend.ops.triton.fla.chunk import chunk_gated_delta_rule
+
+_GDN_PREFILL_WARMUP_TOKENS = 64
+_GDN_PREFILL_WARMUP_SIGNATURES: set[tuple[object, ...]] = set()
+_ASCEND_GDN_FORWARD_CORE = QwenGatedDeltaNetAttention._forward_core
+
+
+def _warmup_gdn_prefill_kernels(
+    self,
+    qkv_or_qkvz: torch.Tensor,
+    v_dim: int,
+) -> None:
+    """Warm Ascend GDN prefill kernels before KV-cache allocation.
+
+    During the V1 profile run, GDN receives no attention metadata. The Ascend
+    forward core therefore exits before the gating and chunked-prefill kernels
+    execute. Without an explicit warmup, the first real prefill may trigger
+    Triton autotuning after most free HBM has already been assigned to KV cache.
+
+    One 64-token warmup is run for each process-level kernel signature.
+    Successful signatures are shared across GDN layers, while failed attempts
+    remain retryable.
+    """
+    qkv_dim = int(qkv_or_qkvz.shape[-1]) - int(v_dim)
+    if qkv_dim <= 0:
+        logger.warning(
+            "Skipping Ascend GDN prefill warmup for layer %s: invalid qkv dimension %d (input=%d, v_dim=%d).",
+            getattr(self, "prefix", "<unnamed>"),
+            qkv_dim,
+            qkv_or_qkvz.shape[-1],
+            v_dim,
+        )
+        return
+
+    num_k_heads = self.num_k_heads // self.tp_size
+    num_v_heads = self.num_v_heads // self.tp_size
+    _, state_dtype = self.get_state_dtype()
+    pcp_world_size = get_pcp_group().world_size
+    use_fused_chunk = AscendGatedDeltaNetAttention._probe_fused_chunk() and pcp_world_size == 1
+
+    signature = (
+        str(qkv_or_qkvz.device),
+        qkv_or_qkvz.dtype,
+        state_dtype,
+        qkv_dim,
+        num_k_heads,
+        num_v_heads,
+        self.head_k_dim,
+        self.head_v_dim,
+        pcp_world_size,
+        use_fused_chunk,
+    )
+    if signature in _GDN_PREFILL_WARMUP_SIGNATURES:
+        return
+
+    device = qkv_or_qkvz.device
+    dtype = qkv_or_qkvz.dtype
+    warmup_tokens = _GDN_PREFILL_WARMUP_TOKENS
+
+    def _run_warmup() -> None:
+        dummy_mixed_qkv = torch.randn(
+            warmup_tokens,
+            qkv_dim,
+            device=device,
+            dtype=dtype,
+        )
+        query, key, value = self.rearrange_mixed_qkv(dummy_mixed_qkv)
+        dummy_a = torch.randn(
+            warmup_tokens,
+            num_v_heads,
+            device=device,
+            dtype=dtype,
+        )
+        dummy_b = torch.randn_like(dummy_a)
+        g, beta = DeviceOperator.fused_gdn_gating(
+            self.A_log,
+            dummy_a,
+            dummy_b,
+            self.dt_bias,
+        )
+        cu_seqlens = torch.tensor(
+            [0, warmup_tokens],
+            device=device,
+            dtype=torch.int32,
+        )
+
+        if use_fused_chunk:
+            # Live fused-CANN state layout: [num_seqs, heads, value_dim, key_dim].
+            initial_state = torch.zeros(
+                1,
+                num_v_heads,
+                self.head_v_dim,
+                self.head_k_dim,
+                device=device,
+                dtype=state_dtype,
+            )
+            AscendGatedDeltaNetAttention._chunk_gated_delta_rule_fused(
+                q=query,
+                k=key,
+                v=value,
+                g=g,
+                beta=beta,
+                initial_state=initial_state,
+                cu_seqlens=cu_seqlens,
+                scale=self.head_k_dim**-0.5,
+            )
+        else:
+            # Live FLA fallback layout after the SSM state transpose: [N, H, K, V].
+            initial_state = torch.zeros(
+                1,
+                num_v_heads,
+                self.head_k_dim,
+                self.head_v_dim,
+                device=device,
+                dtype=state_dtype,
+            )
+            chunk_gated_delta_rule(
+                q=query,
+                k=key,
+                v=value,
+                g=g,
+                beta=beta,
+                initial_state=initial_state,
+                output_final_state=True,
+                cu_seqlens=cu_seqlens,
+                prebuilt_meta=None,
+                head_first=False,
+                use_qk_l2norm_in_kernel=True,
+            )
+
+    try:
+        _run_warmup()
+        if device.type == "npu":
+            torch.npu.synchronize()
+    except Exception:
+        logger.warning(
+            "Ascend GDN prefill warmup failed for layer %s "
+            "(tokens=%d, qkv_dim=%d, dtype=%s, state_dtype=%s, "
+            "pcp_world_size=%d, fused=%s). The first real prefill will retry "
+            "kernel initialization.",
+            getattr(self, "prefix", "<unnamed>"),
+            warmup_tokens,
+            qkv_dim,
+            dtype,
+            state_dtype,
+            pcp_world_size,
+            use_fused_chunk,
+            exc_info=True,
+        )
+    else:
+        _GDN_PREFILL_WARMUP_SIGNATURES.add(signature)
+        logger.debug(
+            "Ascend GDN prefill warmup completed for layer %s (tokens=%d, qkv_dim=%d, fused=%s).",
+            getattr(self, "prefix", "<unnamed>"),
+            warmup_tokens,
+            qkv_dim,
+            use_fused_chunk,
+        )
+    finally:
+        if device.type == "npu":
+            torch.npu.empty_cache()
+
+
+def _forward_core_with_prefill_warmup(
+    self,
+    mixed_qkv: torch.Tensor,
+    b: torch.Tensor,
+    a: torch.Tensor,
+    core_attn_out: torch.Tensor,
+):
+    if get_forward_context().attn_metadata is None:
+        _warmup_gdn_prefill_kernels(self, mixed_qkv, 0)
+        return
+    return _ASCEND_GDN_FORWARD_CORE(
+        self,
+        mixed_qkv,
+        b,
+        a,
+        core_attn_out,
+    )
+
+
+QwenGatedDeltaNetAttention._warmup_prefill_kernels = _warmup_gdn_prefill_kernels
+QwenGatedDeltaNetAttention._forward_core = _forward_core_with_prefill_warmup


### PR DESCRIPTION
### What this PR does / why we need it?

Upstream vLLM warms Qwen GDN prefill kernels during the V1 profile run. The current Ascend adapter replaces that method with a no-op, and its `_forward_core` returns when attention metadata is absent. As a result, the first real prefill remains the first execution of the Ascend GDN gating and chunked-prefill path.

This draft tests whether moving that first-use initialization into profiling improves cold-start behavior on Ascend A2/A3. It:

- intercepts the no-metadata GDN profile path and runs one 64-token prefill shape;
- warms `DeviceOperator.fused_gdn_gating` and the active Ascend GDN prefill backend;
- uses the fused CANN chunk operator when its runtime probe succeeds and PCP is disabled;
- otherwise warms the existing FLA/Triton JIT path;
- preserves the live recurrent-state layout for each backend (`[N,H,V,K]` for fused CANN and `[N,H,K,V]` for the FLA fallback);
- caches successful warmup signatures across GDN layers in the process;
- leaves failed signatures retryable and lets the normal first request initialize the backend;
- synchronizes before recording success and releases temporary cached NPU memory;
- loads only for `STANDARD_WORKER_PATCHES`, leaving the existing 310P no-op behavior unchanged.

The metadata-backed runtime path delegates unchanged to the existing Ascend `_forward_core` implementation.

This is deliberately framed as a hardware-validation experiment. The current Ascend FLA kernels are JIT-compiled Triton kernels; this PR does not claim an autotuning or OOM improvement until an A2/A3 cold-start A/B run demonstrates it.

### Does this PR introduce _any_ user-facing change?

No API or configuration change. It moves one internal GDN first-use execution into the existing V1 profile phase on supported standard-worker hardware.

### How was this patch tested?

Repository CI on the current head has passed:

- PR-title validation;
- Gitleaks;
- the complete pre-commit hook set, including Ruff check/format and repository policy checks;
- mypy.

Added CPU unit coverage for:

- FLA/Triton fallback dispatch;
- fused-CANN dispatch;
- backend-specific recurrent-state layouts;
- one warmup per process-level signature;
- retry after a failed warmup;
- profile-path interception;
- unchanged delegation for normal runtime metadata.

The focused pytest file has not yet run because maintainer-selected test CI has not been enabled for this draft.

### Hardware validation still required

Before marking the PR ready, an Ascend A2/A3 cold-start A/B run should record:

- service startup time to `/health=200`;
- profile-stage GDN warmup duration;
- first-request and second-request TTFT;
- first-request end-to-end latency;
- NPU memory before and after KV-cache allocation;
- the location of Triton JIT/backend initialization in the logs or profiler trace;
- deterministic output parity between the base and warmup branches.

The PR should be closed rather than promoted if the warmup only shifts latency into startup without improving first-request stability or total cold-start cost.

- vLLM Ascend base: `eb617eaf14d35d94fcbd391357d925d1833389a5`
- vLLM main: https://github.com/vllm-project/vllm/commit/ba07e4a48fc951300d97eb506217dd530583dea3
