### PR TITLE
[Performance][Worker] Build DeepSeek V4 metadata asynchronously on v0.26

### DIFF
--- a/.github/workflows/configs/nightly_config.yaml
+++ b/.github/workflows/configs/nightly_config.yaml
@@ -217,6 +217,9 @@ a3:
   multi_card:
     test_config:
       # pytest-driven tests
+      - name: compressor-metadata-cross-stream
+        os: linux-aarch64-a3-2
+        tests: tests/e2e/nightly/single_node/ops/singlecard_ops/test_compressor_metadata.py
       - name: qwen3-30b-acc
         os: linux-aarch64-nightly-a3-4
         tests: tests/e2e/weekly/single_node/models/test_qwen3_30b_acc.py

--- a/tests/e2e/nightly/single_node/ops/singlecard_ops/test_compressor_metadata.py
+++ b/tests/e2e/nightly/single_node/ops/singlecard_ops/test_compressor_metadata.py
@@ -335,3 +335,101 @@ def test_compressor_metadata_dsv4_flash_real_metadata(case: CompressorMetadataCa
     assert torch.equal(out_slot.cpu(), expected_slot)
     assert torch.equal(out_cos.cpu(), expected_cos)
     assert torch.equal(out_sin.cpu(), expected_sin)
+
+
+def test_compressor_metadata_out_cross_stream_buffer_reuse():
+    torch.npu.set_device(0)
+    cases_by_name = {case.name: case for case in DSV4_FLASH_CASES}
+    cases = [
+        CompressorMetadataCase(
+            name="cross_stream_c4_first",
+            compress_ratio=4,
+            query_start_loc=(0, 131),
+            start_pos=(1,),
+            block_table=((1,),),
+            num_rows=33,
+        ),
+        cases_by_name["dsv4_flash_c128_two_request_prefill_padded_127"],
+        CompressorMetadataCase(
+            name="cross_stream_c4_rewrite",
+            compress_ratio=4,
+            query_start_loc=(0, 131),
+            start_pos=(129,),
+            block_table=((9,),),
+            num_rows=33,
+        ),
+    ]
+    prepared = []
+    for case in cases:
+        rope_cos, rope_sin = _make_rope()
+        rope_cos = rope_cos.float()
+        rope_sin = rope_sin.float()
+        expected = _reference_outputs(case, rope_cos, rope_sin)
+        prepared.append(
+            (
+                case,
+                rope_cos.npu(),
+                rope_sin.npu(),
+                torch.tensor(case.query_start_loc, dtype=torch.int32, device="npu"),
+                torch.tensor(case.start_pos, dtype=torch.int32, device="npu"),
+                torch.tensor(case.block_table, dtype=torch.int32, device="npu"),
+                expected,
+            )
+        )
+
+    max_rows = max(expected[2].shape[0] for *_, expected in prepared)
+    out_cos = torch.empty((max_rows, 1, 1, ROPE_DIM), dtype=prepared[0][1].dtype, device="npu")
+    out_sin = torch.empty_like(out_cos)
+    out_slot = torch.empty((max_rows, 2), dtype=torch.int32, device="npu")
+    output_ptrs = (out_cos.data_ptr(), out_sin.data_ptr(), out_slot.data_ptr())
+    model_stream = torch.npu.current_stream()
+    metadata_stream = torch.npu.Stream()
+    inputs_ready = torch.npu.Event()
+    metadata_ready = torch.npu.Event()
+    buffer_reusable = torch.npu.Event()
+    snapshots = []
+
+    for index, (case, rope_cos, rope_sin, query_start_loc, start_pos, block_table, expected) in enumerate(prepared):
+        num_rows = expected[2].shape[0]
+        assert (
+            out_cos[:num_rows].data_ptr(),
+            out_sin[:num_rows].data_ptr(),
+            out_slot[:num_rows].data_ptr(),
+        ) == output_ptrs
+        inputs_ready.record(model_stream)
+        with torch.npu.stream(metadata_stream):
+            metadata_stream.wait_event(inputs_ready)
+            if index:
+                metadata_stream.wait_event(buffer_reusable)
+            torch.ops._C_ascend.compressor_metadata_out(
+                rope_cos,
+                rope_sin,
+                query_start_loc,
+                start_pos,
+                block_table,
+                KV_BLOCK_SIZE,
+                case.slot_mapping_format,
+                case.compress_ratio,
+                len(case.start_pos),
+                out_cos[:num_rows],
+                out_sin[:num_rows],
+                out_slot[:num_rows],
+            )
+            metadata_ready.record(metadata_stream)
+        model_stream.wait_event(metadata_ready)
+        snapshots.append(
+            (
+                out_cos[:num_rows].clone(),
+                out_sin[:num_rows].clone(),
+                out_slot[:num_rows].clone(),
+                expected,
+            )
+        )
+        buffer_reusable.record(model_stream)
+
+    torch.npu.synchronize()
+    for actual_cos, actual_sin, actual_slot, expected in snapshots:
+        expected_cos, expected_sin, expected_slot = expected
+        assert torch.equal(actual_cos.cpu(), expected_cos)
+        assert torch.equal(actual_sin.cpu(), expected_sin)
+        assert torch.equal(actual_slot.cpu(), expected_slot)

--- a/tests/e2e/nightly/single_node/ops/singlecard_ops/test_compressor_metadata.py
+++ b/tests/e2e/nightly/single_node/ops/singlecard_ops/test_compressor_metadata.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 from dataclasses import dataclass
+from functools import partial
 from typing import Any
 
 import pytest
@@ -11,6 +12,12 @@ from vllm_ascend.utils import bootstrap_custom_op_env
 
 bootstrap_custom_op_env(include_vendor_lib=True)
 import vllm_ascend.vllm_ascend_C  # type: ignore[import-untyped] # noqa: E402,F401
+
+from vllm_ascend.worker.device_metadata import (  # noqa: E402
+    DeviceMetadataExecutor,
+    DeviceMetadataStage,
+    DeviceMetadataTask,
+)
 
 KV_BLOCK_SIZE = 128
 SLOT_MAPPING_FLAT = 1
@@ -381,42 +388,30 @@ def test_compressor_metadata_out_cross_stream_buffer_reuse():
     out_cos = torch.empty((max_rows, 1, 1, ROPE_DIM), dtype=prepared[0][1].dtype, device="npu")
     out_sin = torch.empty_like(out_cos)
     out_slot = torch.empty((max_rows, 2), dtype=torch.int32, device="npu")
-    output_ptrs = (out_cos.data_ptr(), out_sin.data_ptr(), out_slot.data_ptr())
-    model_stream = torch.npu.current_stream()
-    metadata_stream = torch.npu.Stream()
-    inputs_ready = torch.npu.Event()
-    metadata_ready = torch.npu.Event()
-    buffer_reusable = torch.npu.Event()
+    executor = DeviceMetadataExecutor()
     snapshots = []
 
-    for index, (case, rope_cos, rope_sin, query_start_loc, start_pos, block_table, expected) in enumerate(prepared):
+    for case, rope_cos, rope_sin, query_start_loc, start_pos, block_table, expected in prepared:
         num_rows = expected[2].shape[0]
-        assert (
-            out_cos[:num_rows].data_ptr(),
-            out_sin[:num_rows].data_ptr(),
-            out_slot[:num_rows].data_ptr(),
-        ) == output_ptrs
-        inputs_ready.record(model_stream)
-        with torch.npu.stream(metadata_stream):
-            metadata_stream.wait_event(inputs_ready)
-            if index:
-                metadata_stream.wait_event(buffer_reusable)
-            torch.ops._C_ascend.compressor_metadata_out(
-                rope_cos,
-                rope_sin,
-                query_start_loc,
-                start_pos,
-                block_table,
-                KV_BLOCK_SIZE,
-                case.slot_mapping_format,
-                case.compress_ratio,
-                len(case.start_pos),
-                out_cos[:num_rows],
-                out_sin[:num_rows],
-                out_slot[:num_rows],
-            )
-            metadata_ready.record(metadata_stream)
-        model_stream.wait_event(metadata_ready)
+        build_metadata = partial(
+            torch.ops._C_ascend.compressor_metadata_out,
+            rope_cos,
+            rope_sin,
+            query_start_loc,
+            start_pos,
+            block_table,
+            KV_BLOCK_SIZE,
+            case.slot_mapping_format,
+            case.compress_ratio,
+            len(case.start_pos),
+            out_cos[:num_rows],
+            out_sin[:num_rows],
+            out_slot[:num_rows],
+        )
+
+        group_id = id(out_cos)
+        executor.submit((DeviceMetadataTask(DeviceMetadataStage.COMPRESSOR, build_metadata, group_id),))
+        executor.wait(DeviceMetadataStage.COMPRESSOR, group_id)
         snapshots.append(
             (
                 out_cos[:num_rows].clone(),
@@ -425,7 +420,7 @@ def test_compressor_metadata_out_cross_stream_buffer_reuse():
                 expected,
             )
         )
-        buffer_reusable.record(model_stream)
+        executor.release()
 
     torch.npu.synchronize()
     for actual_cos, actual_sin, actual_slot, expected in snapshots:

--- a/tests/ut/attention/test_dsa_v1.py
+++ b/tests/ut/attention/test_dsa_v1.py
@@ -755,7 +755,11 @@ def test_indexer_waits_for_qli_consumer(with_prefill: bool):
         decode=None if with_prefill else metadata_value,
         prefill=metadata_value if with_prefill else None,
     )
-    calls = []
+    calls: list[object] = []
+
+    def run_indexer(**kwargs: Any):
+        calls.append("indexer")
+        return torch.zeros(1), None
 
     with (
         patch.object(
@@ -781,7 +785,7 @@ def test_indexer_waits_for_qli_consumer(with_prefill: bool):
             torch.ops._C_ascend,
             "npu_vllm_quant_lightning_indexer",
             create=True,
-            side_effect=lambda **kwargs: (calls.append("indexer") or torch.zeros(1), None),
+            side_effect=run_indexer,
         ),
     ):
         impl._indexer_qli(
@@ -867,10 +871,19 @@ def test_consumers_wait_for_their_metadata(compressor_ratio: int, phase: str):
     else:
         attn_metadata = [wrap(compressor), wrap(compressor_state), wrap(swa)]
 
-    events = []
+    events: list[object] = []
+
+    def run_attention(*args: Any, **kwargs: Any):
+        events.append("attention")
+        return (torch.ones(1),)
+
+    def run_indexer(**kwargs: Any):
+        events.append("indexer")
+        return torch.ones(1), None
+
     stream = MagicMock()
     stream.record_event.return_value = object()
-    attn_op = MagicMock(side_effect=lambda *args, **kwargs: (events.append("attention") or torch.ones(1),))
+    attn_op = MagicMock(side_effect=run_attention)
 
     with (
         patch.object(
@@ -908,7 +921,7 @@ def test_consumers_wait_for_their_metadata(compressor_ratio: int, phase: str):
             torch.ops._C_ascend,
             "npu_vllm_quant_lightning_indexer",
             create=True,
-            side_effect=lambda **kwargs: (events.append("indexer") or torch.ones(1), None),
+            side_effect=run_indexer,
         ),
     ):
         getattr(impl, f"_forward_{phase}")("layer", torch.ones((1, 1)), tuple(), attn_metadata)
@@ -970,21 +983,27 @@ def test_dsa_cp_defers_device_metadata(
             "sl_cpu": builder.seq_lens,
         }
     }
-    events = []
+    events: list[str] = []
 
     def build_local() -> None:
         events.append("local")
         builder.start_pos_prefill.fill_(1)
+
+    def build_sas(**_: Any):
+        events.append("sas")
+        return builder.req_sas_metadata
+
+    def build_qli(**_: Any):
+        events.append("qli")
+        return builder.req_qli_metadata if compressor_ratio == 4 else None
 
     build_local_metadata = MagicMock(side_effect=build_local) if enabled else None
     builder._ensure_device_local_metadata = MagicMock(
         return_value=(0, 3, 3, 3, query_start_loc, builder.seq_lens, build_local_metadata)
     )
     builder._get_cmp_seqlens_for_metadata = MagicMock(return_value=None)
-    builder._build_sas_metadata = MagicMock(side_effect=lambda **_: events.append("sas") or builder.req_sas_metadata)
-    builder._build_qli_metadata = MagicMock(
-        side_effect=lambda **_: events.append("qli") or (builder.req_qli_metadata if compressor_ratio == 4 else None)
-    )
+    builder._build_sas_metadata = MagicMock(side_effect=build_sas)
+    builder._build_qli_metadata = MagicMock(side_effect=build_qli)
     common_metadata = SimpleNamespace(
         num_reqs=2,
         query_start_loc=query_start_loc,
@@ -1019,6 +1038,7 @@ def test_dsa_cp_defers_device_metadata(
     assert (metadata.qli_metadata is builder.req_qli_metadata) is (compressor_ratio == 4)
     assert (metadata.compressor_metadata is not None) is (builder.compressor_metadata_buffers is not None)
     if enabled:
+        assert build_local_metadata is not None
         build_local_metadata.assert_not_called()
         builder._build_sas_metadata.assert_not_called()
         builder._build_qli_metadata.assert_not_called()
@@ -1151,7 +1171,7 @@ def test_dsa_cp_full_graph_compressor_uses_stable_bucket_extent():
 
 
 def test_dsa_cp_device_local_metadata_is_deferred_and_reused():
-    cache = {}
+    cache: dict[Any, Any] = {}
 
     def make_builder():
         builder = AscendDSACPMetadataBuilder.__new__(AscendDSACPMetadataBuilder)
@@ -1241,7 +1261,11 @@ def test_dsa_cp_legacy_compressor_waits_for_local_metadata():
         device_local_metadata_group_id=23,
     )
     result = (torch.ones(1), torch.zeros(1), torch.zeros(1, dtype=torch.int32))
-    events = []
+    events: list[object] = []
+
+    def compute_compressor(*_: Any):
+        events.append("compressor")
+        return result
 
     with (
         patch(
@@ -1250,7 +1274,7 @@ def test_dsa_cp_legacy_compressor_waits_for_local_metadata():
         ),
         patch(
             "vllm_ascend.attention.context_parallel.dsa_cp.get_or_compute_compressor_metadata",
-            side_effect=lambda *_: events.append("compressor") or result,
+            side_effect=compute_compressor,
         ),
     ):
         assert impl._compute_compressor_metadata(metadata) is result
@@ -1335,7 +1359,11 @@ def test_dsa_cp_indexer_waits_before_qli_consumer():
     indexer_metadata.req_metadata.qli_metadata = qli_metadata
     indexer_metadata.hadamard = torch.eye(2)
     attn_metadata = [None, None, None, indexer_metadata, None]
-    events = []
+    events: list[object] = []
+
+    def run_indexer(**kwargs: Any):
+        events.append("indexer")
+        return torch.zeros((1, 1, 1)), None
 
     with (
         patch.object(
@@ -1352,7 +1380,7 @@ def test_dsa_cp_indexer_waits_before_qli_consumer():
             torch.ops._C_ascend,
             "npu_vllm_quant_lightning_indexer",
             create=True,
-            side_effect=lambda **kwargs: (events.append("indexer") or torch.zeros((1, 1, 1)), None),
+            side_effect=run_indexer,
         ),
         patch("vllm_ascend.attention.context_parallel.dsa_cp.rotate_activation", side_effect=lambda value, _: value),
         patch(
@@ -1420,7 +1448,7 @@ def test_dsa_cp_attention_waits_before_memcache_fence(compress_ratio: int):
     else:
         attn_metadata = [compressor_metadata, compressor_metadata, swa_metadata]
         expected_sas = compressor_sas
-    events = []
+    events: list[object] = []
 
     def run_attention(*args, **kwargs):
         assert kwargs["metadata"] is expected_sas

--- a/tests/ut/attention/test_dsa_v1.py
+++ b/tests/ut/attention/test_dsa_v1.py
@@ -148,8 +148,188 @@ def test_decode_metadata_defers_device_work(
             assert torch.equal(builder.decode_qli_metadata, qli_output)
 
 
+def _make_prefill_builder(compressor_ratio: int, enabled: bool):
+    builder = _make_decode_builder(compressor_ratio, enabled)
+    builder.prefill_ratio_to_sas_metadata = {
+        "input_positions": torch.arange(3),
+        "max_query_len": 2,
+        "max_seq_lens": 3,
+        "prefill_input_positions": torch.tensor([1, 2]),
+        "prefill_query_start_loc": torch.tensor([0, 2], dtype=torch.int32),
+        "cos": torch.ones((2, 1)),
+        "sin": torch.zeros((2, 1)),
+        "prefill_seq_lens": torch.tensor([3], dtype=torch.int32),
+        "num_prefill": 1,
+    }
+    builder.decode_ratio_to_sas_metadata = {}
+    builder.num_decodes = 1
+    builder.num_decode_tokens = 1
+    builder.num_prefill_tokens = 2
+    builder.num_actual_tokens = 3
+    builder.query_lens = torch.tensor([1, 2], dtype=torch.int32)
+    builder.seq_lens = torch.tensor([1, 3], dtype=torch.int32)
+    builder.start_pos_prefill = torch.zeros(2, dtype=torch.int32)
+    builder.block_table = torch.zeros((2, 2), dtype=torch.int32)
+    builder.slot_mapping = torch.zeros((3, 2), dtype=torch.int32)
+    builder.prefill_sas_metadata = torch.zeros(1024, dtype=torch.int32)
+    builder.prefill_qli_metadata = torch.zeros(1024, dtype=torch.int32)
+    return builder
+
+
+@pytest.mark.parametrize("compressor_ratio", [1, 4, 128])
+@pytest.mark.parametrize("enabled", [False, True])
+def test_prefill_metadata_defers_device_work(
+    compressor_ratio: int,
+    enabled: bool,
+):
+    builder = _make_prefill_builder(compressor_ratio, enabled)
+    sas_output = torch.full((1024,), 5, dtype=torch.int32)
+    qli_output = torch.full((1024,), 6, dtype=torch.int32)
+    sas_op = MagicMock(return_value=sas_output)
+    common_metadata = SimpleNamespace(
+        query_start_loc=torch.tensor([0, 1, 3], dtype=torch.int32),
+    )
+
+    with (
+        patch(
+            "vllm_ascend.attention.dsa_v1.get_tensor_model_parallel_world_size",
+            return_value=1,
+        ),
+        patch(
+            "vllm_ascend.attention.dsa_v1.get_full_cos_and_sin_dsa",
+            return_value=(torch.ones(1), torch.zeros(1)),
+        ),
+        patch.object(
+            DeviceOperator,
+            "get_dsa_sparse_attn_metadata_op",
+            return_value=sas_op,
+        ),
+        patch.object(
+            DeviceOperator,
+            "get_dsa_sparse_attn_metadata_kwargs",
+            return_value={},
+        ),
+        patch.object(
+            torch.ops._C_ascend,
+            "npu_vllm_quant_lightning_indexer_metadata",
+            create=True,
+            return_value=qli_output,
+        ) as qli_op,
+    ):
+        metadata = builder.build_prefill_metadata(0, common_metadata, 2)
+        tasks = builder.take_device_metadata_tasks()
+
+        if enabled:
+            expected_stages = (
+                [DeviceMetadataStage.INDEXER, DeviceMetadataStage.ATTENTION]
+                if compressor_ratio == 4
+                else [DeviceMetadataStage.ATTENTION]
+            )
+            expected_groups = (
+                [id(builder.prefill_qli_metadata), id(builder.prefill_sas_metadata)]
+                if compressor_ratio == 4
+                else [id(builder.prefill_sas_metadata)]
+            )
+            assert [task.stage for task in tasks] == expected_stages
+            assert [task.group_id for task in tasks] == expected_groups
+            sas_op.assert_not_called()
+            qli_op.assert_not_called()
+            for task in tasks:
+                task.run()
+        else:
+            assert tasks == ()
+
+        sas_op.assert_called_once()
+        assert sas_op.call_args.kwargs["cmp_ratio"] == compressor_ratio
+        assert ("cmp_mask_mode" in sas_op.call_args.kwargs) == (compressor_ratio > 1)
+        assert ("cmp_topk" in sas_op.call_args.kwargs) == (compressor_ratio == 4)
+        if enabled and compressor_ratio != 4:
+            qli_op.assert_not_called()
+        else:
+            qli_op.assert_called_once()
+            assert qli_op.call_args.kwargs["max_seqlen_q"] == 2
+            assert qli_op.call_args.kwargs["max_seqlen_k"] == 3
+        if enabled:
+            assert metadata.sas_metadata is builder.prefill_sas_metadata
+            assert metadata.qli_metadata is builder.prefill_qli_metadata
+            assert torch.equal(builder.prefill_sas_metadata, sas_output)
+            if compressor_ratio == 4:
+                assert torch.equal(builder.prefill_qli_metadata, qli_output)
+        else:
+            assert metadata.sas_metadata is sas_output
+            assert metadata.qli_metadata is qli_output
+
+
+def test_mixed_metadata_keeps_prefill_and_decode_groups_isolated():
+    builder = _make_prefill_builder(4, True)
+    builder.decode_ratio_to_sas_metadata = {
+        "query_start_loc": torch.tensor([0, 1], dtype=torch.int32),
+        "input_positions": torch.arange(1),
+        "cos": torch.ones((1, 1)),
+        "sin": torch.zeros((1, 1)),
+        "query_start_loc_cpu": torch.tensor([0, 1], dtype=torch.int32),
+        "max_seq_lens": 1,
+        "seq_lens_list": [1],
+        "max_seqlen_kv": 1,
+        "max_seqlen_q": 1,
+        "start_pos_decode": torch.zeros(1, dtype=torch.int32),
+    }
+    sas_op = MagicMock(return_value=torch.ones(1024, dtype=torch.int32))
+    qli_op = MagicMock(return_value=torch.ones(1024, dtype=torch.int32))
+
+    with (
+        patch(
+            "vllm_ascend.attention.dsa_v1.get_tensor_model_parallel_world_size",
+            return_value=1,
+        ),
+        patch(
+            "vllm_ascend.attention.dsa_v1.get_full_cos_and_sin_dsa",
+            return_value=(torch.ones(1), torch.zeros(1)),
+        ),
+        patch.object(DeviceOperator, "get_dsa_sparse_attn_metadata_op", return_value=sas_op),
+        patch.object(DeviceOperator, "get_dsa_sparse_attn_metadata_kwargs", return_value={}),
+        patch.object(
+            DeviceOperator,
+            "get_dsa_decode_cu_seqlens_ori_kv",
+            return_value=torch.tensor([0, 1], dtype=torch.int32),
+        ),
+        patch.object(DeviceOperator, "get_dsa_decode_cu_seqlens_cmp_kv", return_value=None),
+        patch.object(
+            torch.ops._C_ascend,
+            "npu_vllm_quant_lightning_indexer_metadata",
+            create=True,
+            new=qli_op,
+        ),
+    ):
+        builder.build_prefill_metadata(
+            0,
+            SimpleNamespace(query_start_loc=torch.tensor([0, 1, 3], dtype=torch.int32)),
+            2,
+        )
+        builder.build_decode_metadata(0, SimpleNamespace(), 2)
+        tasks = builder.take_device_metadata_tasks()
+        for task in tasks:
+            task.run()
+
+    assert [task.stage for task in tasks] == [
+        DeviceMetadataStage.INDEXER,
+        DeviceMetadataStage.ATTENTION,
+        DeviceMetadataStage.INDEXER,
+        DeviceMetadataStage.ATTENTION,
+    ]
+    assert [task.group_id for task in tasks] == [
+        id(builder.prefill_qli_metadata),
+        id(builder.prefill_sas_metadata),
+        id(builder.decode_qli_metadata),
+        id(builder.decode_sas_metadata),
+    ]
+    assert len(set(task.group_id for task in tasks)) == 4
+    assert sas_op.call_count == 2
+    assert qli_op.call_count == 2
+
+
 @pytest.mark.parametrize("with_prefill", [False, True])
-def test_indexer_waits_only_for_decode_qli_consumer(with_prefill: bool):
+def test_indexer_waits_for_qli_consumer(with_prefill: bool):
     impl = AscendDSAImpl.__new__(AscendDSAImpl)
     impl.index_topk = 512
     qli_metadata = torch.zeros(1024, dtype=torch.int32)
@@ -202,12 +382,12 @@ def test_indexer_waits_only_for_decode_qli_consumer(with_prefill: bool):
             with_prefill=with_prefill,
         )
 
-    expected = [] if with_prefill else [(DeviceMetadataStage.INDEXER, id(qli_metadata))]
-    assert calls == [*expected, "indexer"]
+    assert calls == [(DeviceMetadataStage.INDEXER, id(qli_metadata)), "indexer"]
 
 
 @pytest.mark.parametrize("compressor_ratio", [1, 4, 128])
-def test_decode_consumers_wait_for_their_metadata(compressor_ratio: int):
+@pytest.mark.parametrize("phase", ["prefill", "decode"])
+def test_consumers_wait_for_their_metadata(compressor_ratio: int, phase: str):
     impl = AscendDSAImpl.__new__(AscendDSAImpl)
     impl.compress_ratio = compressor_ratio
     impl.multistream_dsv4_dsa_overlap = True
@@ -244,6 +424,8 @@ def test_decode_consumers_wait_for_their_metadata(compressor_ratio: int):
         start_pos=torch.zeros(1, dtype=torch.int32),
         sas_metadata=sas_metadata,
         block_table=torch.zeros((1, 1), dtype=torch.int32),
+        cu_c4_cmp_seqlen_list=None,
+        cu_c128_cmp_seqlen_list=None,
     )
     swa_values = dict(vars(common))
     swa_values.update(
@@ -264,7 +446,7 @@ def test_decode_consumers_wait_for_their_metadata(compressor_ratio: int):
     )
 
     def wrap(value):
-        return SimpleNamespace(decode=value)
+        return SimpleNamespace(**{phase: value}, num_decode_tokens=1)
 
     if compressor_ratio == 1:
         attn_metadata = [wrap(swa)]
@@ -287,6 +469,7 @@ def test_decode_consumers_wait_for_their_metadata(compressor_ratio: int):
         patch.object(DeviceOperator, "dsa_kv_compress_scatter"),
         patch.object(DeviceOperator, "get_dsa_sparse_attn_op", return_value=attn_op),
         patch.object(DeviceOperator, "get_dsa_sparse_attn_base_kwargs", return_value={}),
+        patch.object(DeviceOperator, "add_dsa_sparse_attn_extra_kwargs"),
         patch.object(DeviceOperator, "indexer_quantize_query", return_value=(torch.ones(1), torch.ones(1))),
         patch.object(DeviceOperator, "prepare_dsa_indexer_weights", side_effect=lambda value: value),
         patch.object(DeviceOperator, "prepare_dsa_indexer_query_scale", side_effect=lambda value: value),
@@ -316,7 +499,7 @@ def test_decode_consumers_wait_for_their_metadata(compressor_ratio: int):
             side_effect=lambda **kwargs: (events.append("indexer") or torch.ones(1), None),
         ),
     ):
-        impl._forward_decode("layer", torch.ones((1, 1)), tuple(), attn_metadata)
+        getattr(impl, f"_forward_{phase}")("layer", torch.ones((1, 1)), tuple(), attn_metadata)
 
     expected_sas = sas_metadata if compressor_ratio == 1 else compressor.sas_metadata
     expected = []

--- a/tests/ut/attention/test_dsa_v1.py
+++ b/tests/ut/attention/test_dsa_v1.py
@@ -22,9 +22,222 @@ from vllm_ascend.attention.dsa_v1 import (
     AscendDSAImpl,
     AscendDSAMetadataBuilder,
     build_compressor_metadata_out,
+    build_dspark_swa_indices,
 )
 from vllm_ascend.device.device_op import DeviceOperator
-from vllm_ascend.worker.device_metadata import DeviceMetadataStage
+from vllm_ascend.worker.device_metadata import DeviceMetadataStage, DeviceMetadataTask
+
+
+@pytest.mark.parametrize("num_speculative_tokens", [1, 3, 7])
+def test_build_dspark_swa_indices_writes_active_output(num_speculative_tokens: int):
+    block_table = torch.tensor([[2, 3], [5, 6]], dtype=torch.int32)
+    num_decode_tokens = 2 * num_speculative_tokens
+    query_start_loc = torch.tensor([0, num_speculative_tokens, num_decode_tokens], dtype=torch.int32)
+    seq_lens = torch.tensor([10, 14], dtype=torch.int32)
+    expected, expected_lens = build_dspark_swa_indices(
+        block_table,
+        num_speculative_tokens,
+        4,
+        8,
+        query_start_loc,
+        seq_lens,
+        num_decode_tokens,
+        index_width=16,
+    )
+    output = torch.empty_like(expected)
+
+    actual, actual_lens = build_dspark_swa_indices(
+        block_table,
+        num_speculative_tokens,
+        4,
+        8,
+        query_start_loc,
+        seq_lens,
+        num_decode_tokens,
+        index_width=16,
+        indices_output=output,
+    )
+
+    assert actual.data_ptr() == output.data_ptr()
+    assert torch.equal(actual, expected)
+    assert torch.equal(actual_lens, expected_lens)
+
+
+def _make_dspark_draft_builder(max_num_tokens: int = 16):
+    builder = AscendDSAMetadataBuilder.__new__(AscendDSAMetadataBuilder)
+    builder.compressor_ratio = 1
+    builder.speculative_config = SimpleNamespace(num_speculative_tokens=3)
+    builder.model_config = SimpleNamespace(
+        hf_config=SimpleNamespace(num_attention_heads=8, sliding_window=4),
+        get_head_size=lambda: 192,
+    )
+    builder.vllm_config = SimpleNamespace(
+        model_config=builder.model_config,
+        speculative_config=builder.speculative_config,
+    )
+    builder.device = torch.device("cpu")
+    builder.block_size = 8
+    builder.spec_slot_mapping = [torch.zeros((max_num_tokens, 2), dtype=torch.int32)]
+    builder.spec_sas_metadata = [torch.zeros(1024, dtype=torch.int32)]
+    builder.seqused_q = torch.empty(0)
+    builder.cu_seqlens_ori_kv = torch.empty(0, dtype=torch.int32)
+    builder.cu_seqlens_cmp_kv = torch.empty(0, dtype=torch.int32)
+    builder._device_metadata_enabled = False
+    builder._device_metadata_tasks = ()
+    builder.dspark_swa_indices_buffer = None
+    builder.cache_group_key = "draft"
+    builder.enable_dspark_device_metadata(max_num_tokens)
+    return builder
+
+
+def _make_dspark_common_metadata(num_reqs: int, num_tokens: int):
+    query_start_loc = torch.arange(num_reqs + 1, dtype=torch.int32) * 3
+    seq_lens = torch.arange(num_reqs, dtype=torch.int32) * 4 + 10
+    return SimpleNamespace(
+        num_reqs=num_reqs,
+        query_start_loc=query_start_loc,
+        query_start_loc_cpu=query_start_loc,
+        seq_lens=seq_lens,
+        seq_lens_cpu=seq_lens,
+        _seq_lens_cpu=seq_lens,
+        positions=torch.arange(num_tokens),
+        block_table_tensor=torch.tensor([[2, 3], [5, 6]], dtype=torch.int32)[:num_reqs],
+        causal=False,
+    )
+
+
+def test_draft_swa_and_sas_share_attention_task():
+    builder = _make_dspark_draft_builder()
+    common = _make_dspark_common_metadata(2, 6)
+    sas_result = torch.arange(1024, dtype=torch.int32)
+    buffer = builder.dspark_swa_indices_buffer
+    assert buffer is not None
+
+    with (
+        patch("vllm_ascend.attention.dsa_v1.get_tensor_model_parallel_world_size", return_value=1),
+        patch("vllm_ascend.attention.dsa_v1.get_cos_and_sin_dsa", return_value=(torch.ones(6), torch.zeros(6))),
+        patch.object(DeviceOperator, "get_dsa_sparse_attn_metadata_kwargs", return_value={}),
+        patch.object(
+            DeviceOperator,
+            "get_dsa_sparse_attn_metadata_op",
+            return_value=MagicMock(return_value=sas_result),
+        ),
+        patch("vllm_ascend.attention.dsa_v1.build_dspark_swa_indices", wraps=build_dspark_swa_indices) as build_swa,
+    ):
+        metadata = builder.build_decode_metadata_for_drafting(
+            1,
+            common,
+            num_decodes=2,
+            num_decode_tokens=6,
+        )
+        tasks = builder.take_device_metadata_tasks()
+        assert build_swa.call_count == 0
+        assert metadata.dspark_swa_indices.shape == (6, 1, buffer.shape[2])
+        assert metadata.dspark_swa_indices.data_ptr() == buffer.data_ptr()
+        assert [(task.stage, task.group_id) for task in tasks] == [
+            (DeviceMetadataStage.ATTENTION, id(metadata.sas_metadata))
+        ]
+
+        tasks[0].run()
+
+        first_indices = metadata.dspark_swa_indices.clone()
+        next_common = _make_dspark_common_metadata(1, 3)
+        next_common.block_table_tensor = torch.tensor([[9, 10]], dtype=torch.int32)
+        next_metadata = builder.build_decode_metadata_for_drafting(
+            1,
+            next_common,
+            num_decodes=1,
+            num_decode_tokens=3,
+        )
+        next_tasks = builder.take_device_metadata_tasks()
+        assert next_metadata.dspark_swa_indices.shape == (3, 1, buffer.shape[2])
+        assert next_metadata.dspark_swa_indices.data_ptr() == metadata.dspark_swa_indices.data_ptr()
+        next_tasks[0].run()
+
+    assert build_swa.call_count == 2
+    assert build_swa.call_args.kwargs["indices_output"] is next_metadata.dspark_swa_indices
+    assert builder.dspark_swa_indices_buffer is buffer
+    assert buffer.data_ptr() == metadata.dspark_swa_indices.data_ptr()
+    assert not torch.equal(next_metadata.dspark_swa_indices, first_indices[:3])
+    assert torch.equal(metadata.sas_metadata, sas_result)
+
+
+def test_mixed_draft_metadata_keeps_swa_and_sas_synchronous():
+    builder = _make_dspark_draft_builder()
+    common = _make_dspark_common_metadata(2, 3)
+    common.query_start_loc = torch.tensor([0, 3, 4], dtype=torch.int32)
+    common.query_start_loc_cpu = common.query_start_loc
+    sas_op = MagicMock(return_value=torch.arange(1024, dtype=torch.int32))
+
+    with (
+        patch("vllm_ascend.attention.dsa_v1.get_tensor_model_parallel_world_size", return_value=1),
+        patch("vllm_ascend.attention.dsa_v1.get_cos_and_sin_dsa", return_value=(torch.ones(3), torch.zeros(3))),
+        patch.object(DeviceOperator, "get_dsa_sparse_attn_metadata_kwargs", return_value={}),
+        patch.object(DeviceOperator, "get_dsa_sparse_attn_metadata_op", return_value=sas_op),
+        patch("vllm_ascend.attention.dsa_v1.build_dspark_swa_indices", wraps=build_dspark_swa_indices) as build_swa,
+    ):
+        builder.build_decode_metadata_for_drafting(
+            1,
+            common,
+            num_decodes=1,
+            num_decode_tokens=3,
+        )
+
+    assert builder.take_device_metadata_tasks() == ()
+    build_swa.assert_called_once()
+    sas_op.assert_called_once()
+
+
+def test_pure_prefill_draft_build_keeps_device_tasks_empty():
+    builder = _make_dspark_draft_builder()
+    builder.metadata_cls = SimpleNamespace
+    builder.decode_threshold = 4
+    common = _make_dspark_common_metadata(1, 3)
+    common.num_input_tokens = 3
+    common.num_actual_tokens = 3
+    common.slot_mapping = torch.zeros(3, dtype=torch.int32)
+    common.attn_state = None
+    prefill_metadata = object()
+    builder._device_metadata_tasks = (DeviceMetadataTask(DeviceMetadataStage.ATTENTION, lambda: None, 1),)
+
+    with (
+        patch("vllm_ascend.attention.dsa_v1.split_decodes_and_prefills", return_value=(0, 1, 0, 3)),
+        patch("vllm_ascend.attention.dsa_v1.get_cos_and_sin_dsa", return_value=(torch.ones(3), torch.zeros(3))),
+        patch.object(DeviceOperator, "format_dsa_slot_mapping", return_value=torch.zeros((3, 2), dtype=torch.int32)),
+        patch.object(
+            builder,
+            "build_prefill_metadata_for_drafting",
+            return_value=prefill_metadata,
+        ) as build_prefill,
+    ):
+        metadata = builder.build_for_drafting(common, draft_index=1)
+
+    build_prefill.assert_called_once()
+    assert metadata.prefill is prefill_metadata
+    assert metadata.decode is None
+    assert builder.take_device_metadata_tasks() == ()
+
+
+def test_draft_swa_metadata_rejects_rows_above_buffer_capacity():
+    builder = _make_dspark_draft_builder()
+    common = _make_dspark_common_metadata(1, 17)
+    common.query_start_loc = torch.tensor([0, 17], dtype=torch.int32)
+    common.query_start_loc_cpu = common.query_start_loc
+    common.seq_lens = torch.tensor([17], dtype=torch.int32)
+    common.seq_lens_cpu = common.seq_lens
+    common._seq_lens_cpu = common.seq_lens
+
+    with (
+        patch("vllm_ascend.attention.dsa_v1.get_tensor_model_parallel_world_size", return_value=1),
+        patch("vllm_ascend.attention.dsa_v1.get_cos_and_sin_dsa", return_value=(torch.ones(17), torch.zeros(17))),
+        pytest.raises(ValueError, match=r"active=17, capacity=16"),
+    ):
+        builder.build_decode_metadata_for_drafting(
+            1,
+            common,
+            num_decodes=1,
+            num_decode_tokens=17,
+        )
 
 
 def _make_decode_builder(compressor_ratio: int, enabled: bool):

--- a/tests/ut/attention/test_dsa_v1.py
+++ b/tests/ut/attention/test_dsa_v1.py
@@ -1,11 +1,23 @@
 from contextlib import nullcontext
 from types import SimpleNamespace
+from typing import Any
 from unittest.mock import MagicMock, patch
 
 import pytest
 import torch
 from vllm.config import CUDAGraphMode
 
+from vllm_ascend.attention.context_parallel.dsa_cp import (
+    AscendDSACPImpl,
+    AscendDSACPMetadataBuilder,
+    DSACPMetadata,
+)
+from vllm_ascend.attention.context_parallel.dsa_cp import (
+    AscendDSAMetadata as AscendDSACPMetadata,
+)
+from vllm_ascend.attention.context_parallel.dsa_cp import (
+    AscendDSAReqMetadata as AscendDSACPReqMetadata,
+)
 from vllm_ascend.attention.dsa_v1 import (
     AscendDSAImpl,
     AscendDSAMetadataBuilder,
@@ -700,3 +712,411 @@ def test_consumers_wait_for_their_metadata(compressor_ratio: int, phase: str):
         ]
     )
     assert events == expected
+
+
+@pytest.mark.parametrize(
+    ("compressor_ratio", "enabled", "expected_stages"),
+    [
+        (1, True, [DeviceMetadataStage.COMPRESSOR, DeviceMetadataStage.ATTENTION]),
+        (4, True, list(DeviceMetadataStage)),
+        (128, True, [DeviceMetadataStage.COMPRESSOR, DeviceMetadataStage.ATTENTION]),
+        (4, False, []),
+    ],
+)
+def test_dsa_cp_defers_device_metadata(
+    compressor_ratio: int,
+    enabled: bool,
+    expected_stages: list[DeviceMetadataStage],
+):
+    builder = AscendDSACPMetadataBuilder.__new__(AscendDSACPMetadataBuilder)
+    builder.num_prefills = 1
+    builder.num_actual_tokens = 3
+    builder.compressor_ratio = compressor_ratio
+    builder.block_size = 128
+    builder.cache_group_key = "group"
+    builder.seq_lens = torch.tensor([8, 6], dtype=torch.int32)
+    builder.seq_lens_cpu = builder.seq_lens
+    builder.block_table = torch.tensor([[1, 2], [3, 4]], dtype=torch.int32)
+    builder.start_pos_prefill = torch.zeros(2, dtype=torch.int32)
+    builder.slot_mapping = torch.zeros((3, 2), dtype=torch.int32)
+    builder.req_sas_metadata = torch.zeros(1024, dtype=torch.int32)
+    builder.req_qli_metadata = torch.zeros(1024, dtype=torch.int32)
+    builder._device_metadata_enabled = enabled
+    builder._device_metadata_tasks = ()
+    builder.model_config = SimpleNamespace(
+        hf_config=SimpleNamespace(num_attention_heads=64, index_topk=512),
+        get_head_size=lambda: 512,
+    )
+    query_start_loc = torch.tensor([0, 2, 3], dtype=torch.int32)
+    builder.common_ratio_to_sas_metadata = {
+        "_cpu_local": {
+            "qsl_cpu": query_start_loc,
+            "sl_cpu": builder.seq_lens,
+        }
+    }
+    build_local_metadata = MagicMock(side_effect=lambda: builder.start_pos_prefill.fill_(1)) if enabled else None
+    builder._ensure_device_local_metadata = MagicMock(
+        return_value=(0, 3, 3, 3, query_start_loc, builder.seq_lens, build_local_metadata)
+    )
+    builder._get_cmp_seqlens_for_metadata = MagicMock(return_value=None)
+    builder._build_sas_metadata = MagicMock(return_value=builder.req_sas_metadata)
+    builder._build_qli_metadata = MagicMock(return_value=builder.req_qli_metadata if compressor_ratio == 4 else None)
+    common_metadata = SimpleNamespace(
+        num_reqs=2,
+        query_start_loc=query_start_loc,
+        query_start_loc_cpu=query_start_loc,
+    )
+
+    with patch(
+        "vllm_ascend.attention.context_parallel.dsa_cp.get_full_cos_and_sin_dsa",
+        return_value=(torch.ones(1), torch.zeros(1)),
+    ):
+        metadata = builder.build_req_metadata(
+            common_metadata,
+            input_positions=None,
+            num_input_tokens=3,
+            num_reqs_actual=1,
+            attn_state=MagicMock(),
+            cos=MagicMock(),
+            sin=MagicMock(),
+        )
+
+    tasks = builder.take_device_metadata_tasks()
+    assert builder.take_device_metadata_tasks() == ()
+    assert [task.stage for task in tasks] == expected_stages
+    expected_group_ids = (
+        [id(builder.req_sas_metadata), id(builder.req_qli_metadata), id(builder.req_sas_metadata)]
+        if compressor_ratio == 4 and enabled
+        else [id(builder.req_sas_metadata)] * len(tasks)
+    )
+    assert [task.group_id for task in tasks] == expected_group_ids
+    assert metadata.device_local_metadata_group_id == (id(builder.req_sas_metadata) if enabled else None)
+    assert metadata.sas_metadata is builder.req_sas_metadata
+    assert (metadata.qli_metadata is builder.req_qli_metadata) is (compressor_ratio == 4)
+    if enabled:
+        build_local_metadata.assert_not_called()
+        builder._build_sas_metadata.assert_not_called()
+        builder._build_qli_metadata.assert_not_called()
+        for task in tasks:
+            task.run()
+        build_local_metadata.assert_called_once_with()
+        assert torch.equal(builder.start_pos_prefill, torch.tensor([1, 0], dtype=torch.int32))
+    builder._build_sas_metadata.assert_called_once()
+    if compressor_ratio == 4:
+        builder._build_qli_metadata.assert_called_once()
+        assert builder._build_qli_metadata.call_args.kwargs["max_seqlen_q"] == 2
+        assert builder._build_qli_metadata.call_args.kwargs["max_seqlen_k"] == 8
+    else:
+        builder._build_qli_metadata.assert_not_called()
+
+
+def test_dsa_cp_device_local_metadata_is_deferred_and_reused():
+    cache = {}
+
+    def make_builder():
+        builder = AscendDSACPMetadataBuilder.__new__(AscendDSACPMetadataBuilder)
+        builder._device_metadata_enabled = True
+        builder.common_ratio_to_sas_metadata = cache
+        builder.local_query_start_loc = torch.zeros(3, dtype=torch.int32)
+        builder.local_seq_lens = torch.zeros(2, dtype=torch.int32)
+        builder.start_pos_prefill = torch.zeros(2, dtype=torch.int32)
+        return builder
+
+    first_builder = make_builder()
+    second_builder = make_builder()
+    query_start_loc = torch.tensor([0, 2, 4], dtype=torch.int32)
+    seq_lens = torch.tensor([2, 4], dtype=torch.int32)
+    first_addresses = (
+        first_builder.local_query_start_loc.data_ptr(),
+        first_builder.local_seq_lens.data_ptr(),
+        first_builder.start_pos_prefill.data_ptr(),
+    )
+
+    with patch(
+        "vllm_ascend.attention.context_parallel.dsa_cp.get_tp_group",
+        return_value=SimpleNamespace(world_size=2, rank_in_group=0),
+    ):
+        first = first_builder._ensure_device_local_metadata(2, 4, query_start_loc, seq_lens)
+        second = second_builder._ensure_device_local_metadata(2, 4, query_start_loc, seq_lens)
+        first[-1]()
+        second[-1]()
+
+    assert first[:4] == (0, 2, 2, 4)
+    assert torch.equal(first_builder.local_query_start_loc, torch.tensor([0, 2, 2], dtype=torch.int32))
+    assert torch.equal(first_builder.local_seq_lens, torch.tensor([2, 0], dtype=torch.int32))
+    assert torch.equal(first_builder.start_pos_prefill, torch.tensor([0, 2], dtype=torch.int32))
+    assert torch.equal(second_builder.local_query_start_loc, first_builder.local_query_start_loc)
+    assert torch.equal(second_builder.local_seq_lens, first_builder.local_seq_lens)
+    assert torch.equal(second_builder.start_pos_prefill, first_builder.start_pos_prefill)
+    assert cache["_device_local"]["qsl"].data_ptr() == first_addresses[0]
+    assert first_addresses == (
+        first_builder.local_query_start_loc.data_ptr(),
+        first_builder.local_seq_lens.data_ptr(),
+        first_builder.start_pos_prefill.data_ptr(),
+    )
+
+
+def test_dsa_cp_qli_metadata_uses_host_maxima():
+    builder = AscendDSACPMetadataBuilder.__new__(AscendDSACPMetadataBuilder)
+    builder.compressor_ratio = 4
+    builder.common_ratio_to_sas_metadata = {}
+    builder.req_qli_metadata = torch.zeros(1024, dtype=torch.int32)
+    builder.seqused_q = torch.empty(0)
+    builder.model_config = SimpleNamespace(
+        hf_config=SimpleNamespace(
+            index_n_heads=64,
+            index_head_dim=128,
+            index_topk=512,
+        )
+    )
+    seq_lens = MagicMock()
+    seq_lens.clone.return_value = torch.tensor([8, 6], dtype=torch.int32)
+    generated_metadata = torch.arange(1024, dtype=torch.int32)
+
+    with patch.object(
+        torch.ops._C_ascend,
+        "npu_vllm_quant_lightning_indexer_metadata",
+        create=True,
+        return_value=generated_metadata,
+    ) as metadata_op:
+        builder._build_qli_metadata(
+            query_start_loc=torch.tensor([0, 2, 3], dtype=torch.int32),
+            seq_lens=seq_lens,
+            num_reqs=2,
+            max_seqlen_q=2,
+            max_seqlen_k=8,
+        )
+
+    seq_lens.max.assert_not_called()
+    assert metadata_op.call_args.kwargs["max_seqlen_q"] == 2
+    assert metadata_op.call_args.kwargs["max_seqlen_k"] == 8
+
+
+def test_dsa_cp_legacy_compressor_waits_for_local_metadata():
+    impl = AscendDSACPImpl.__new__(AscendDSACPImpl)
+    impl.compress_ratio = 4
+    metadata = SimpleNamespace(device_local_metadata_group_id=23)
+    result = (torch.ones(1), torch.zeros(1), torch.zeros(1, dtype=torch.int32))
+    events = []
+
+    with (
+        patch(
+            "vllm_ascend.attention.context_parallel.dsa_cp.wait_for_device_metadata",
+            side_effect=lambda stage, group_id: events.append((stage, group_id)),
+        ),
+        patch(
+            "vllm_ascend.attention.context_parallel.dsa_cp.get_or_compute_compressor_metadata",
+            side_effect=lambda *_: events.append("compressor") or result,
+        ),
+    ):
+        assert impl._compute_compressor_metadata(metadata) is result
+
+    assert events == [(DeviceMetadataStage.COMPRESSOR, 23), "compressor"]
+
+
+def _make_dsa_cp_metadata(sas_metadata: torch.Tensor) -> AscendDSACPMetadata:
+    query_start_loc = torch.tensor([0, 1], dtype=torch.int32)
+    seq_lens = torch.tensor([1], dtype=torch.int32)
+    cp_metadata = DSACPMetadata(
+        local_query_start_loc=query_start_loc,
+        local_seq_lens=seq_lens,
+        local_start=0,
+        local_end=1,
+        tokens_per_rank=1,
+        num_tokens_pad=1,
+        local_sin={"layer": torch.zeros((1, 1, 1, 2))},
+        local_cos={"layer": torch.ones((1, 1, 1, 2))},
+    )
+    req_metadata = AscendDSACPReqMetadata(
+        input_positions=torch.zeros(1, dtype=torch.int32),
+        block_table=torch.zeros((1, 1), dtype=torch.int32),
+        seq_lens=seq_lens,
+        slot_mapping=torch.zeros((1, 2), dtype=torch.int32),
+        block_size=128,
+        query_start_loc=query_start_loc,
+        cp_metadata=cp_metadata,
+        sin={"layer": torch.zeros((1, 1, 1, 2))},
+        cos={"layer": torch.ones((1, 1, 1, 2))},
+        start_pos=torch.zeros(1, dtype=torch.int32),
+        sas_metadata=sas_metadata,
+        qli_metadata=torch.zeros(1024, dtype=torch.int32),
+        cu_cmp_seqlen_list=torch.tensor([0, 1], dtype=torch.int32),
+    )
+    return AscendDSACPMetadata(
+        num_actual_tokens=1,
+        query_start_loc=query_start_loc,
+        seq_lens=seq_lens,
+        block_tables=req_metadata.block_table,
+        sin=req_metadata.sin,
+        cos=req_metadata.cos,
+        num_decodes=0,
+        num_decode_tokens=0,
+        num_prefills=1,
+        req_metadata=req_metadata,
+    )
+
+
+def test_dsa_cp_indexer_waits_before_qli_consumer():
+    impl = AscendDSACPImpl.__new__(AscendDSACPImpl)
+    impl.inderxer_wq_b = MagicMock(return_value=torch.ones((1, 2)))
+    impl.inderxer_wq_b.quant_method = MagicMock()
+    impl.indexer_heads = 1
+    impl.indexcom_head_dim = 2
+    impl.rope_head_dim = 1
+    impl.weights_proj = MagicMock(return_value=torch.ones((1, 1)))
+    impl.indexer_softmax_scale = 1.0
+    impl.index_topk = 1
+    qli_metadata = torch.zeros(1024, dtype=torch.int32)
+    indexer_metadata = _make_dsa_cp_metadata(torch.zeros(1024, dtype=torch.int32))
+    assert indexer_metadata.req_metadata is not None
+    indexer_metadata.req_metadata.qli_metadata = qli_metadata
+    indexer_metadata.hadamard = torch.eye(2)
+    attn_metadata = [None, None, None, indexer_metadata, None]
+    events = []
+
+    with (
+        patch.object(
+            DeviceOperator,
+            "unpack_dsa_indexer_kv_cache",
+            return_value=(torch.empty(0),) * 4,
+        ),
+        patch.object(DeviceOperator, "indexer_quantize_query", return_value=(torch.ones((1, 1, 2)), torch.ones(1))),
+        patch.object(DeviceOperator, "prepare_dsa_indexer_weights", side_effect=lambda value: value),
+        patch.object(DeviceOperator, "prepare_dsa_indexer_query_scale", side_effect=lambda value: value),
+        patch.object(DeviceOperator, "prepare_dsa_indexer_key_scale", side_effect=lambda value: value),
+        patch.object(torch.ops._C_ascend, "inplace_partial_rotary_mul", create=True),
+        patch.object(
+            torch.ops._C_ascend,
+            "npu_vllm_quant_lightning_indexer",
+            create=True,
+            side_effect=lambda **kwargs: (events.append("indexer") or torch.zeros((1, 1, 1)), None),
+        ),
+        patch("vllm_ascend.attention.context_parallel.dsa_cp.rotate_activation", side_effect=lambda value, _: value),
+        patch(
+            "vllm_ascend.attention.context_parallel.dsa_cp.wait_for_device_metadata",
+            side_effect=lambda stage, group_id: events.append((stage, group_id)),
+        ),
+    ):
+        impl._indexer_select_topk(
+            x=torch.ones((1, 2)),
+            qr=torch.ones((1, 2)),
+            kv_cache=(torch.empty(0),),
+            attn_metadata=attn_metadata,
+            cos=torch.ones((1, 1, 1, 2)),
+            sin=torch.zeros((1, 1, 1, 2)),
+            actual_seq_lengths_query=torch.tensor([0, 1], dtype=torch.int32),
+            actual_seq_lengths_key=torch.tensor([1], dtype=torch.int32),
+        )
+
+    assert events == [(DeviceMetadataStage.INDEXER, id(qli_metadata)), "indexer"]
+
+
+@pytest.mark.parametrize("compress_ratio", [1, 4, 128])
+def test_dsa_cp_attention_waits_before_memcache_fence(compress_ratio: int):
+    impl = AscendDSACPImpl.__new__(AscendDSACPImpl)
+    impl.compress_ratio = compress_ratio
+    impl.num_heads = 1
+    impl.head_dim = 2
+    impl.nope_head_dim = 1
+    impl.rope_head_dim = 1
+    impl.window_size = 16
+    impl.softmax_scale = 1.0
+    impl.eps = 1e-6
+    impl.attn_sink = None
+    impl.compressor_overlap = False
+    impl.wq_a = MagicMock(return_value=torch.ones((1, 2)))
+    impl.q_norm = MagicMock(side_effect=lambda value: value)
+    impl.wq_b = MagicMock(return_value=torch.ones((1, 2)))
+    impl.wq_b.quant_method = MagicMock()
+    impl.q_norm_without_weight = MagicMock()
+    impl.wkv = MagicMock(return_value=torch.ones((1, 2)))
+    impl.kv_norm = MagicMock(side_effect=lambda value: value)
+    impl._maybe_all_gather_o_proj_full_weight = MagicMock(return_value=None)
+    impl.compressor_wkv = SimpleNamespace(weight=torch.empty(0))
+    impl.compressor_wgate = SimpleNamespace(weight=torch.empty(0))
+    impl.compressor_ape = torch.empty(0)
+    impl.compressor_norm = SimpleNamespace(weight=torch.empty(0))
+    impl.compressor_norm_eps = 1e-6
+
+    swa_sas = torch.zeros(1024, dtype=torch.int32)
+    compressor_sas = torch.ones(1024, dtype=torch.int32)
+    swa_metadata = _make_dsa_cp_metadata(swa_sas)
+    compressor_metadata = _make_dsa_cp_metadata(compressor_sas)
+    if compress_ratio == 1:
+        attn_metadata = [swa_metadata]
+        expected_sas = swa_sas
+    elif compress_ratio == 4:
+        attn_metadata = [
+            compressor_metadata,
+            compressor_metadata,
+            compressor_metadata,
+            compressor_metadata,
+            swa_metadata,
+        ]
+        expected_sas = compressor_sas
+    else:
+        attn_metadata = [compressor_metadata, compressor_metadata, swa_metadata]
+        expected_sas = compressor_sas
+    events = []
+
+    def run_attention(*args, **kwargs):
+        assert kwargs["metadata"] is expected_sas
+        events.append("attention")
+        return (torch.ones((1, 1, 2)),)
+
+    def add_extra_kwargs(extra_kwargs: dict[str, Any], **kwargs) -> None:
+        extra_kwargs.update(kwargs)
+
+    with (
+        patch.object(
+            DeviceOperator,
+            "unpack_dsa_forward_kv_cache",
+            return_value=(torch.empty(0), torch.empty(0), torch.zeros((1, 1, 1)), None, None, None),
+        ),
+        patch.object(DeviceOperator, "apply_dsa_q_rms", side_effect=lambda value, *_: value),
+        patch.object(DeviceOperator, "dsa_kv_compress_scatter"),
+        patch.object(DeviceOperator, "get_dsa_sparse_attn_op", return_value=run_attention),
+        patch.object(DeviceOperator, "get_dsa_sparse_attn_base_kwargs", return_value={}),
+        patch.object(DeviceOperator, "add_dsa_sparse_attn_extra_kwargs", side_effect=add_extra_kwargs),
+        patch.object(
+            torch.ops.vllm, "maybe_all_gather_and_maybe_unpad", create=True, side_effect=lambda value, _: value
+        ),
+        patch.object(torch.ops._C_ascend, "inplace_partial_rotary_mul", create=True),
+        patch.object(torch.ops._C_ascend, "compressor", create=True, return_value=torch.empty(0)),
+        patch.object(impl, "_update_indexer_cache"),
+        patch.object(impl, "_indexer_select_topk", return_value=torch.zeros((1, 1, 1), dtype=torch.int32)),
+        patch.object(
+            impl,
+            "_compute_compressor_metadata",
+            return_value=(
+                torch.ones((1, 2)),
+                torch.zeros((1, 2)),
+                torch.zeros((1, 2), dtype=torch.int32),
+            ),
+        ),
+        patch(
+            "vllm_ascend.attention.context_parallel.dsa_cp.wait_for_device_metadata",
+            side_effect=lambda stage, group_id: events.append((stage, group_id)),
+        ),
+        patch(
+            "vllm_ascend.attention.context_parallel.dsa_cp.notify_kv_cache_written",
+            side_effect=lambda *_: events.append("cache-written"),
+        ),
+        patch(
+            "vllm_ascend.attention.context_parallel.dsa_cp.record_attention_compute_start",
+            side_effect=lambda: events.append("attention-start"),
+        ),
+    ):
+        impl._forward(
+            "layer",
+            torch.ones((1, 2)),
+            (torch.empty(0),),
+            attn_metadata,
+        )
+
+    assert events == [
+        "cache-written",
+        (DeviceMetadataStage.ATTENTION, id(expected_sas)),
+        "attention-start",
+        "attention",
+    ]

--- a/tests/ut/attention/test_dsa_v1.py
+++ b/tests/ut/attention/test_dsa_v1.py
@@ -718,8 +718,8 @@ def test_consumers_wait_for_their_metadata(compressor_ratio: int, phase: str):
     ("compressor_ratio", "enabled", "expected_stages"),
     [
         (1, True, [DeviceMetadataStage.COMPRESSOR, DeviceMetadataStage.ATTENTION]),
-        (4, True, list(DeviceMetadataStage)),
-        (128, True, [DeviceMetadataStage.COMPRESSOR, DeviceMetadataStage.ATTENTION]),
+        (4, True, [DeviceMetadataStage.COMPRESSOR, *list(DeviceMetadataStage)]),
+        (128, True, [DeviceMetadataStage.COMPRESSOR, DeviceMetadataStage.COMPRESSOR, DeviceMetadataStage.ATTENTION]),
         (4, False, []),
     ],
 )
@@ -739,6 +739,9 @@ def test_dsa_cp_defers_device_metadata(
     builder.block_table = torch.tensor([[1, 2], [3, 4]], dtype=torch.int32)
     builder.start_pos_prefill = torch.zeros(2, dtype=torch.int32)
     builder.slot_mapping = torch.zeros((3, 2), dtype=torch.int32)
+    builder.compressor_metadata_buffers = (
+        (torch.empty((3, 1)), torch.empty((3, 1)), builder.slot_mapping) if enabled and compressor_ratio > 1 else None
+    )
     builder.req_sas_metadata = torch.zeros(1024, dtype=torch.int32)
     builder.req_qli_metadata = torch.zeros(1024, dtype=torch.int32)
     builder._device_metadata_enabled = enabled
@@ -754,13 +757,21 @@ def test_dsa_cp_defers_device_metadata(
             "sl_cpu": builder.seq_lens,
         }
     }
-    build_local_metadata = MagicMock(side_effect=lambda: builder.start_pos_prefill.fill_(1)) if enabled else None
+    events = []
+
+    def build_local() -> None:
+        events.append("local")
+        builder.start_pos_prefill.fill_(1)
+
+    build_local_metadata = MagicMock(side_effect=build_local) if enabled else None
     builder._ensure_device_local_metadata = MagicMock(
         return_value=(0, 3, 3, 3, query_start_loc, builder.seq_lens, build_local_metadata)
     )
     builder._get_cmp_seqlens_for_metadata = MagicMock(return_value=None)
-    builder._build_sas_metadata = MagicMock(return_value=builder.req_sas_metadata)
-    builder._build_qli_metadata = MagicMock(return_value=builder.req_qli_metadata if compressor_ratio == 4 else None)
+    builder._build_sas_metadata = MagicMock(side_effect=lambda **_: events.append("sas") or builder.req_sas_metadata)
+    builder._build_qli_metadata = MagicMock(
+        side_effect=lambda **_: events.append("qli") or (builder.req_qli_metadata if compressor_ratio == 4 else None)
+    )
     common_metadata = SimpleNamespace(
         num_reqs=2,
         query_start_loc=query_start_loc,
@@ -784,23 +795,35 @@ def test_dsa_cp_defers_device_metadata(
     tasks = builder.take_device_metadata_tasks()
     assert builder.take_device_metadata_tasks() == ()
     assert [task.stage for task in tasks] == expected_stages
-    expected_group_ids = (
-        [id(builder.req_sas_metadata), id(builder.req_qli_metadata), id(builder.req_sas_metadata)]
-        if compressor_ratio == 4 and enabled
-        else [id(builder.req_sas_metadata)] * len(tasks)
-    )
+    expected_group_ids = [id(builder.req_sas_metadata)] * len(tasks)
+    if builder.compressor_metadata_buffers is not None:
+        expected_group_ids[1] = id(builder.compressor_metadata_buffers[0])
+    if compressor_ratio == 4 and enabled:
+        expected_group_ids[-2] = id(builder.req_qli_metadata)
     assert [task.group_id for task in tasks] == expected_group_ids
     assert metadata.device_local_metadata_group_id == (id(builder.req_sas_metadata) if enabled else None)
     assert metadata.sas_metadata is builder.req_sas_metadata
     assert (metadata.qli_metadata is builder.req_qli_metadata) is (compressor_ratio == 4)
+    assert (metadata.compressor_metadata is not None) is (builder.compressor_metadata_buffers is not None)
     if enabled:
         build_local_metadata.assert_not_called()
         builder._build_sas_metadata.assert_not_called()
         builder._build_qli_metadata.assert_not_called()
-        for task in tasks:
-            task.run()
+        with patch(
+            "vllm_ascend.attention.context_parallel.dsa_cp.build_compressor_metadata_out",
+            side_effect=lambda *_: events.append("compressor"),
+        ):
+            for task in tasks:
+                task.run()
         build_local_metadata.assert_called_once_with()
         assert torch.equal(builder.start_pos_prefill, torch.tensor([1, 0], dtype=torch.int32))
+        expected_events = ["local"]
+        if compressor_ratio > 1:
+            expected_events.append("compressor")
+        if compressor_ratio == 4:
+            expected_events.append("qli")
+        expected_events.append("sas")
+        assert events == expected_events
     builder._build_sas_metadata.assert_called_once()
     if compressor_ratio == 4:
         builder._build_qli_metadata.assert_called_once()
@@ -808,6 +831,110 @@ def test_dsa_cp_defers_device_metadata(
         assert builder._build_qli_metadata.call_args.kwargs["max_seqlen_k"] == 8
     else:
         builder._build_qli_metadata.assert_not_called()
+
+
+@pytest.mark.parametrize(
+    ("mode", "ratio", "allocates_buffers"),
+    [
+        (CUDAGraphMode.FULL, 4, False),
+        (CUDAGraphMode.PIECEWISE, 4, True),
+        (CUDAGraphMode.FULL_DECODE_ONLY, 4, True),
+        (CUDAGraphMode.FULL_AND_PIECEWISE, 128, True),
+        (CUDAGraphMode.NONE, 1, False),
+    ],
+)
+def test_dsa_cp_enable_device_metadata_allocates_compressor_buffers(
+    mode: CUDAGraphMode,
+    ratio: int,
+    allocates_buffers: bool,
+):
+    builder = AscendDSACPMetadataBuilder.__new__(AscendDSACPMetadataBuilder)
+    builder._device_metadata_enabled = False
+    builder.compressor_ratio = ratio
+    builder.compressor_metadata_buffers = None
+    builder.vllm_config = SimpleNamespace(
+        compilation_config=SimpleNamespace(cudagraph_mode=mode),
+        scheduler_config=SimpleNamespace(max_num_batched_tokens=8),
+    )
+    builder.model_config = SimpleNamespace(hf_config=SimpleNamespace(qk_rope_head_dim=4))
+    builder.device = torch.device("cpu")
+    builder.slot_mapping = torch.empty((8, 2), dtype=torch.int32)
+
+    builder.enable_device_metadata()
+
+    assert builder._device_metadata_enabled
+    assert (builder.compressor_metadata_buffers is not None) is allocates_buffers
+    if allocates_buffers:
+        assert builder.compressor_metadata_buffers is not None
+        cos, sin, slot = builder.compressor_metadata_buffers
+        assert cos.shape == sin.shape == (8, 1, 1, 4)
+        assert cos.dtype == sin.dtype == torch.float32
+        assert slot is builder.slot_mapping
+        assert slot.shape == (8, 2)
+        assert slot.dtype == torch.int32
+
+
+def test_dsa_cp_full_graph_compressor_uses_stable_bucket_extent():
+    builder = AscendDSACPMetadataBuilder.__new__(AscendDSACPMetadataBuilder)
+    builder.num_prefills = 0
+    builder.num_actual_tokens = 4
+    builder.compressor_ratio = 4
+    builder.block_size = 128
+    builder.cache_group_key = "group"
+    builder.seq_lens = torch.tensor([8, 6], dtype=torch.int32)
+    builder.seq_lens_cpu = builder.seq_lens
+    builder.block_table = torch.tensor([[1, 2], [3, 4]], dtype=torch.int32)
+    builder.start_pos_prefill = torch.zeros(2, dtype=torch.int32)
+    builder.slot_mapping = torch.zeros((4, 2), dtype=torch.int32)
+    builder.compressor_metadata_buffers = (
+        torch.empty((4, 1)),
+        torch.empty((4, 1)),
+        builder.slot_mapping,
+    )
+    base_pointers = tuple(buffer.data_ptr() for buffer in builder.compressor_metadata_buffers)
+    builder.req_sas_metadata = torch.zeros(1024, dtype=torch.int32)
+    builder.req_qli_metadata = torch.zeros(1024, dtype=torch.int32)
+    builder._device_metadata_enabled = True
+    builder._device_metadata_tasks = ()
+    builder.model_config = SimpleNamespace(
+        hf_config=SimpleNamespace(num_attention_heads=64, index_topk=512),
+        get_head_size=lambda: 512,
+    )
+    query_start_loc = torch.tensor([0, 2, 4], dtype=torch.int32)
+    builder.common_ratio_to_sas_metadata = {"_cpu_local": {"qsl_cpu": query_start_loc, "sl_cpu": builder.seq_lens}}
+    builder._ensure_device_local_metadata = MagicMock(
+        return_value=(0, 4, 4, 4, query_start_loc, builder.seq_lens, MagicMock())
+    )
+    builder._get_cmp_seqlens_for_metadata = MagicMock(return_value=None)
+    builder._build_sas_metadata = MagicMock(return_value=builder.req_sas_metadata)
+    builder._build_qli_metadata = MagicMock(return_value=builder.req_qli_metadata)
+    common_metadata = SimpleNamespace(
+        num_reqs=2,
+        query_start_loc=query_start_loc,
+        query_start_loc_cpu=query_start_loc,
+    )
+
+    with patch(
+        "vllm_ascend.attention.context_parallel.dsa_cp.get_full_cos_and_sin_dsa",
+        return_value=(torch.ones(1), torch.zeros(1)),
+    ):
+        capture = builder.build_req_metadata(
+            common_metadata, None, 4, 2, MagicMock(), MagicMock(), MagicMock(), full_graph_mode=True
+        )
+        builder.num_actual_tokens = 3
+        runtime = builder.build_req_metadata(
+            common_metadata, None, 4, 1, MagicMock(), MagicMock(), MagicMock(), full_graph_mode=True
+        )
+
+    assert capture.num_compressed_tokens == runtime.num_compressed_tokens == 3
+    assert capture.num_reqs_actual == runtime.num_reqs_actual == 2
+    assert capture.compressor_metadata is not None
+    assert runtime.compressor_metadata is not None
+    for index, (capture_output, runtime_output) in enumerate(
+        zip(capture.compressor_metadata, runtime.compressor_metadata)
+    ):
+        assert capture_output.shape == runtime_output.shape == (3, 1 if index < 2 else 2)
+        assert capture_output.data_ptr() == runtime_output.data_ptr() == base_pointers[index]
 
 
 def test_dsa_cp_device_local_metadata_is_deferred_and_reused():
@@ -895,7 +1022,11 @@ def test_dsa_cp_qli_metadata_uses_host_maxima():
 def test_dsa_cp_legacy_compressor_waits_for_local_metadata():
     impl = AscendDSACPImpl.__new__(AscendDSACPImpl)
     impl.compress_ratio = 4
-    metadata = SimpleNamespace(device_local_metadata_group_id=23)
+    metadata = SimpleNamespace(
+        compressor_metadata=None,
+        compressor_metadata_group_id=None,
+        device_local_metadata_group_id=23,
+    )
     result = (torch.ones(1), torch.zeros(1), torch.zeros(1, dtype=torch.int32))
     events = []
 
@@ -912,6 +1043,25 @@ def test_dsa_cp_legacy_compressor_waits_for_local_metadata():
         assert impl._compute_compressor_metadata(metadata) is result
 
     assert events == [(DeviceMetadataStage.COMPRESSOR, 23), "compressor"]
+
+
+def test_dsa_cp_compressor_waits_for_precomputed_metadata():
+    impl = AscendDSACPImpl.__new__(AscendDSACPImpl)
+    outputs = (torch.ones(1), torch.zeros(1), torch.zeros(1, dtype=torch.int32))
+    metadata = SimpleNamespace(
+        compressor_metadata=outputs,
+        compressor_metadata_group_id=29,
+        device_local_metadata_group_id=23,
+    )
+
+    with (
+        patch("vllm_ascend.attention.context_parallel.dsa_cp.wait_for_device_metadata") as wait,
+        patch("vllm_ascend.attention.context_parallel.dsa_cp.get_or_compute_compressor_metadata") as legacy,
+    ):
+        assert impl._compute_compressor_metadata(metadata) is outputs
+
+    wait.assert_called_once_with(DeviceMetadataStage.COMPRESSOR, 29)
+    legacy.assert_not_called()
 
 
 def _make_dsa_cp_metadata(sas_metadata: torch.Tensor) -> AscendDSACPMetadata:

--- a/tests/ut/attention/test_dsa_v1.py
+++ b/tests/ut/attention/test_dsa_v1.py
@@ -1,4 +1,3 @@
-from contextlib import nullcontext
 from types import SimpleNamespace
 from typing import Any
 from unittest.mock import MagicMock, patch
@@ -19,48 +18,12 @@ from vllm_ascend.attention.context_parallel.dsa_cp import (
     AscendDSAReqMetadata as AscendDSACPReqMetadata,
 )
 from vllm_ascend.attention.dsa_v1 import (
-    AscendDSAImpl,
     AscendDSAMetadataBuilder,
     build_compressor_metadata_out,
     build_dspark_swa_indices,
 )
 from vllm_ascend.device.device_op import DeviceOperator
 from vllm_ascend.worker.device_metadata import DeviceMetadataStage, DeviceMetadataTask
-
-
-@pytest.mark.parametrize("num_speculative_tokens", [1, 3, 7])
-def test_build_dspark_swa_indices_writes_active_output(num_speculative_tokens: int):
-    block_table = torch.tensor([[2, 3], [5, 6]], dtype=torch.int32)
-    num_decode_tokens = 2 * num_speculative_tokens
-    query_start_loc = torch.tensor([0, num_speculative_tokens, num_decode_tokens], dtype=torch.int32)
-    seq_lens = torch.tensor([10, 14], dtype=torch.int32)
-    expected, expected_lens = build_dspark_swa_indices(
-        block_table,
-        num_speculative_tokens,
-        4,
-        8,
-        query_start_loc,
-        seq_lens,
-        num_decode_tokens,
-        index_width=16,
-    )
-    output = torch.empty_like(expected)
-
-    actual, actual_lens = build_dspark_swa_indices(
-        block_table,
-        num_speculative_tokens,
-        4,
-        8,
-        query_start_loc,
-        seq_lens,
-        num_decode_tokens,
-        index_width=16,
-        indices_output=output,
-    )
-
-    assert actual.data_ptr() == output.data_ptr()
-    assert torch.equal(actual, expected)
-    assert torch.equal(actual_lens, expected_lens)
 
 
 def _make_dspark_draft_builder(max_num_tokens: int = 16):
@@ -275,6 +238,10 @@ def _make_decode_builder(compressor_ratio: int, enabled: bool):
     builder.seqused_q = torch.empty(0)
     builder.decode_sas_metadata = torch.zeros(1024, dtype=torch.int32)
     builder.decode_qli_metadata = torch.zeros(1024, dtype=torch.int32)
+    builder.prefill_qli_seqused_k = torch.zeros(2, dtype=torch.int32)
+    builder.prefill_qli_cmp_residual_k = torch.zeros(2, dtype=torch.int32)
+    builder.decode_qli_seqused_k = torch.zeros(2, dtype=torch.int32)
+    builder.decode_qli_cmp_residual_k = torch.zeros(2, dtype=torch.int32)
     builder._zero_i32 = torch.zeros(1, dtype=torch.int32)
     builder.cu_seqlens_ori_kv = torch.empty(0, dtype=torch.int32)
     builder.cu_seqlens_cmp_kv = torch.empty(0, dtype=torch.int32)
@@ -339,7 +306,7 @@ def test_decode_metadata_defers_device_work(
         ),
         patch.object(
             torch.ops._C_ascend,
-            "npu_vllm_quant_lightning_indexer_metadata",
+            "npu_quant_lightning_indexer_v2_metadata",
             create=True,
             return_value=qli_output,
         ) as qli_op,
@@ -375,15 +342,19 @@ def test_decode_metadata_defers_device_work(
 
         sas_op.assert_called_once()
         assert sas_op.call_args.kwargs["cmp_ratio"] == compressor_ratio
-        if enabled and compressor_ratio != 4:
-            qli_op.assert_not_called()
-        else:
+        if compressor_ratio == 4:
             qli_op.assert_called_once()
+            assert qli_op.call_args.kwargs["max_seqlen_q"] == 1
+            assert qli_op.call_args.kwargs["max_seqlen_k"] == 2
+        else:
+            qli_op.assert_not_called()
         assert metadata.sas_metadata is builder.decode_sas_metadata
-        assert metadata.qli_metadata is builder.decode_qli_metadata
+        assert (metadata.qli_metadata is builder.decode_qli_metadata) is (compressor_ratio == 4)
         assert torch.equal(builder.decode_sas_metadata, sas_output)
-        if not enabled or compressor_ratio == 4:
+        if compressor_ratio == 4:
             assert torch.equal(builder.decode_qli_metadata, qli_output)
+            assert torch.equal(metadata.qli_seqused_k, torch.tensor([2, 2], dtype=torch.int32))
+            assert torch.equal(metadata.qli_cmp_residual_k, torch.tensor([0, 1], dtype=torch.int32))
 
 
 def _make_prefill_builder(compressor_ratio: int, enabled: bool):
@@ -449,7 +420,7 @@ def test_prefill_metadata_defers_device_work(
         ),
         patch.object(
             torch.ops._C_ascend,
-            "npu_vllm_quant_lightning_indexer_metadata",
+            "npu_quant_lightning_indexer_v2_metadata",
             create=True,
             return_value=qli_output,
         ) as qli_op,
@@ -486,94 +457,24 @@ def test_prefill_metadata_defers_device_work(
         assert sas_op.call_args.kwargs["cmp_ratio"] == compressor_ratio
         assert ("cmp_mask_mode" in sas_op.call_args.kwargs) == (compressor_ratio > 1)
         assert ("cmp_topk" in sas_op.call_args.kwargs) == (compressor_ratio == 4)
-        if enabled and compressor_ratio != 4:
-            qli_op.assert_not_called()
-        else:
+        if compressor_ratio == 4:
             qli_op.assert_called_once()
             assert qli_op.call_args.kwargs["max_seqlen_q"] == 2
-            assert qli_op.call_args.kwargs["max_seqlen_k"] == 3
+            assert qli_op.call_args.kwargs["max_seqlen_k"] == 0
+        else:
+            qli_op.assert_not_called()
         if enabled:
             assert metadata.sas_metadata is builder.prefill_sas_metadata
-            assert metadata.qli_metadata is builder.prefill_qli_metadata
+            assert (metadata.qli_metadata is builder.prefill_qli_metadata) is (compressor_ratio == 4)
             assert torch.equal(builder.prefill_sas_metadata, sas_output)
             if compressor_ratio == 4:
                 assert torch.equal(builder.prefill_qli_metadata, qli_output)
         else:
             assert metadata.sas_metadata is sas_output
-            assert metadata.qli_metadata is qli_output
-
-
-def test_mixed_metadata_keeps_prefill_and_decode_groups_isolated():
-    builder = _make_prefill_builder(4, True)
-    builder.decode_ratio_to_sas_metadata = {
-        "query_start_loc": torch.tensor([0, 1], dtype=torch.int32),
-        "input_positions": torch.arange(1),
-        "cos": torch.ones((1, 1)),
-        "sin": torch.zeros((1, 1)),
-        "query_start_loc_cpu": torch.tensor([0, 1], dtype=torch.int32),
-        "max_seq_lens": 1,
-        "seq_lens_list": [1],
-        "max_seqlen_kv": 1,
-        "max_seqlen_q": 1,
-        "start_pos_decode": torch.zeros(1, dtype=torch.int32),
-    }
-    sas_op = MagicMock(return_value=torch.ones(1024, dtype=torch.int32))
-    qli_op = MagicMock(return_value=torch.ones(1024, dtype=torch.int32))
-
-    with (
-        patch(
-            "vllm_ascend.attention.dsa_v1.get_tensor_model_parallel_world_size",
-            return_value=1,
-        ),
-        patch(
-            "vllm_ascend.attention.dsa_v1.get_full_cos_and_sin_dsa",
-            return_value=(torch.ones(1), torch.zeros(1)),
-        ),
-        patch.object(DeviceOperator, "get_dsa_sparse_attn_metadata_op", return_value=sas_op),
-        patch.object(DeviceOperator, "get_dsa_sparse_attn_metadata_kwargs", return_value={}),
-        patch.object(
-            DeviceOperator,
-            "get_dsa_decode_cu_seqlens_ori_kv",
-            return_value=torch.tensor([0, 1], dtype=torch.int32),
-        ),
-        patch.object(DeviceOperator, "get_dsa_decode_cu_seqlens_cmp_kv", return_value=None),
-        patch.object(
-            torch.ops._C_ascend,
-            "npu_vllm_quant_lightning_indexer_metadata",
-            create=True,
-            new=qli_op,
-        ),
-    ):
-        builder.build_prefill_metadata(
-            0,
-            SimpleNamespace(query_start_loc=torch.tensor([0, 1, 3], dtype=torch.int32)),
-            2,
-        )
-        builder.build_decode_metadata(0, SimpleNamespace(), 2)
-        tasks = builder.take_device_metadata_tasks()
-        with patch("vllm_ascend.attention.dsa_v1.build_compressor_metadata_out"):
-            for task in tasks:
-                task.run()
-
-    ordered_tasks = sorted(tasks, key=lambda task: task.stage)
-    assert [task.stage for task in ordered_tasks] == [
-        DeviceMetadataStage.COMPRESSOR,
-        DeviceMetadataStage.COMPRESSOR,
-        DeviceMetadataStage.INDEXER,
-        DeviceMetadataStage.INDEXER,
-        DeviceMetadataStage.ATTENTION,
-        DeviceMetadataStage.ATTENTION,
-    ]
-    assert {task.group_id for task in tasks} == {
-        id(builder.prefill_compressor_metadata_buffers[0]),
-        id(builder.decode_compressor_metadata_buffers[0]),
-        id(builder.prefill_qli_metadata),
-        id(builder.decode_qli_metadata),
-        id(builder.prefill_sas_metadata),
-        id(builder.decode_sas_metadata),
-    }
-    assert sas_op.call_count == 2
-    assert qli_op.call_count == 2
+            assert (metadata.qli_metadata is qli_output) is (compressor_ratio == 4)
+        if compressor_ratio == 4:
+            assert torch.equal(metadata.qli_seqused_k, torch.tensor([0], dtype=torch.int32))
+            assert torch.equal(metadata.qli_cmp_residual_k, torch.tensor([3], dtype=torch.int32))
 
 
 def test_build_compressor_metadata_out_uses_fixed_outputs():
@@ -686,6 +587,12 @@ def test_full_graph_compressor_uses_stable_padded_extent(phase: str):
             return_value=torch.tensor([0, 8, 17], dtype=torch.int32),
         ),
         patch.object(DeviceOperator, "get_dsa_decode_cu_seqlens_cmp_kv", return_value=None),
+        patch.object(
+            torch.ops._C_ascend,
+            "npu_quant_lightning_indexer_v2_metadata",
+            create=True,
+            return_value=torch.ones(1024, dtype=torch.int32),
+        ),
     ):
         if phase == "prefill":
             capture_metadata = builder.build_prefill_metadata(0, common, 2, full_graph_mode=True)
@@ -711,233 +618,6 @@ def test_full_graph_compressor_uses_stable_padded_extent(phase: str):
     assert capture_metadata.compressor_metadata is not None
     assert capture_metadata.compressor_metadata[0].shape == metadata.compressor_metadata[0].shape
     assert capture_metadata.compressor_metadata[0].data_ptr() == metadata.compressor_metadata[0].data_ptr()
-
-
-def test_compressor_consumer_waits_only_for_precomputed_metadata():
-    impl = AscendDSAImpl.__new__(AscendDSAImpl)
-    impl.compress_ratio = 4
-    outputs = (torch.ones(1), torch.zeros(1), torch.zeros(1, dtype=torch.int32))
-    precomputed = SimpleNamespace(
-        compressor_metadata=outputs,
-        compressor_metadata_group_id=17,
-    )
-    legacy = SimpleNamespace(
-        compressor_metadata=None,
-        compressor_metadata_group_id=None,
-    )
-
-    with (
-        patch("vllm_ascend.attention.dsa_v1.wait_for_device_metadata") as wait,
-        patch(
-            "vllm_ascend.attention.dsa_v1.get_or_compute_compressor_metadata",
-            return_value=(torch.ones(1), torch.ones(1), torch.ones(1)),
-        ) as legacy_compute,
-    ):
-        assert impl._compute_compressor_metadata(precomputed) is outputs
-        impl._compute_compressor_metadata(legacy)
-
-    wait.assert_called_once_with(DeviceMetadataStage.COMPRESSOR, 17)
-    legacy_compute.assert_called_once_with(legacy, 4)
-
-
-@pytest.mark.parametrize("with_prefill", [False, True])
-def test_indexer_waits_for_qli_consumer(with_prefill: bool):
-    impl = AscendDSAImpl.__new__(AscendDSAImpl)
-    impl.index_topk = 512
-    qli_metadata = torch.zeros(1024, dtype=torch.int32)
-    metadata_value = SimpleNamespace(
-        query_start_loc=torch.tensor([0, 1], dtype=torch.int32),
-        seq_lens=torch.tensor([1], dtype=torch.int32),
-        block_table=torch.zeros((1, 1), dtype=torch.int32),
-        qli_metadata=qli_metadata,
-    )
-    metadata = SimpleNamespace(
-        decode=None if with_prefill else metadata_value,
-        prefill=metadata_value if with_prefill else None,
-    )
-    calls: list[object] = []
-
-    def run_indexer(**kwargs: Any):
-        calls.append("indexer")
-        return torch.zeros(1), None
-
-    with (
-        patch.object(
-            DeviceOperator,
-            "prepare_dsa_indexer_weights",
-            side_effect=lambda value: value,
-        ),
-        patch.object(
-            DeviceOperator,
-            "prepare_dsa_indexer_query_scale",
-            side_effect=lambda value: value,
-        ),
-        patch.object(
-            DeviceOperator,
-            "prepare_dsa_indexer_key_scale",
-            side_effect=lambda value: value,
-        ),
-        patch(
-            "vllm_ascend.attention.dsa_v1.wait_for_device_metadata",
-            side_effect=lambda stage, group_id: calls.append((stage, group_id)),
-        ),
-        patch.object(
-            torch.ops._C_ascend,
-            "npu_vllm_quant_lightning_indexer",
-            create=True,
-            side_effect=run_indexer,
-        ),
-    ):
-        impl._indexer_qli(
-            torch.ones((1, 1)),
-            torch.ones((1, 1)),
-            torch.ones(1),
-            torch.ones((1, 1)),
-            torch.ones((1, 1)),
-            metadata,
-            with_prefill=with_prefill,
-        )
-
-    assert calls == [(DeviceMetadataStage.INDEXER, id(qli_metadata)), "indexer"]
-
-
-@pytest.mark.parametrize("compressor_ratio", [1, 4, 128])
-@pytest.mark.parametrize("phase", ["prefill", "decode"])
-def test_consumers_wait_for_their_metadata(compressor_ratio: int, phase: str):
-    impl = AscendDSAImpl.__new__(AscendDSAImpl)
-    impl.compress_ratio = compressor_ratio
-    impl.multistream_dsv4_dsa_overlap = True
-    impl.skip_topk = False
-    impl.use_index_cache = False
-    impl.window_size = 4096
-    impl.compressor_overlap = False
-    impl.compressor_wkv = SimpleNamespace(weight=torch.ones(1))
-    impl.compressor_wgate = SimpleNamespace(weight=torch.ones(1))
-    impl.compressor_ape = torch.ones(1)
-    impl.compressor_norm = SimpleNamespace(weight=torch.ones(1))
-    impl.rope_head_dim = 1
-    impl.compressor_norm_eps = 1e-6
-    impl.attn_sink = None
-    impl.softmax_scale = 1.0
-    impl.indexer_softmax_scale = 1.0
-    impl.indexer_heads = 1
-    impl.index_topk = 512
-    impl.weights_proj = MagicMock(return_value=torch.ones((1, 1)))
-    impl._mla_prolog_multistream = MagicMock(return_value=(torch.ones((1, 1, 1)), torch.ones((1, 1)), torch.ones(1)))
-    impl.cv_indexer_select_qli = MagicMock(return_value=torch.ones((1, 1)))
-    impl._compute_compressor_metadata = MagicMock(
-        return_value=(torch.ones((1, 1)), torch.ones((1, 1)), torch.zeros(1, dtype=torch.int32))
-    )
-
-    sas_metadata = torch.zeros(1024, dtype=torch.int32)
-    other_sas_metadata = torch.ones(1024, dtype=torch.int32)
-    qli_metadata = torch.full((1024,), 2, dtype=torch.int32)
-    common = SimpleNamespace(
-        cos={"layer": torch.ones((1, 1))},
-        sin={"layer": torch.ones((1, 1))},
-        query_start_loc=torch.tensor([0, 1], dtype=torch.int32),
-        seq_lens=torch.tensor([1], dtype=torch.int32),
-        start_pos=torch.zeros(1, dtype=torch.int32),
-        sas_metadata=sas_metadata,
-        block_table=torch.zeros((1, 1), dtype=torch.int32),
-        cu_c4_cmp_seqlen_list=None,
-        cu_c128_cmp_seqlen_list=None,
-    )
-    swa_values = dict(vars(common))
-    swa_values.update(
-        slot_mapping=torch.zeros(1, dtype=torch.int32),
-        ori_win_left=None,
-        ori_win_right=None,
-        dspark_swa_indices=None,
-        sas_metadata=sas_metadata if compressor_ratio == 1 else other_sas_metadata,
-    )
-    swa = SimpleNamespace(**swa_values)
-    compressor = SimpleNamespace(**vars(common))
-    compressor_state = SimpleNamespace(block_table=common.block_table)
-    indexer = SimpleNamespace(
-        query_start_loc=common.query_start_loc,
-        seq_lens=common.seq_lens,
-        block_table=common.block_table,
-        qli_metadata=qli_metadata,
-    )
-
-    def wrap(value):
-        return SimpleNamespace(**{phase: value}, num_decode_tokens=1)
-
-    if compressor_ratio == 1:
-        attn_metadata = [wrap(swa)]
-    elif compressor_ratio == 4:
-        attn_metadata = [wrap(compressor), wrap(compressor_state), wrap(common), wrap(indexer), wrap(swa)]
-    else:
-        attn_metadata = [wrap(compressor), wrap(compressor_state), wrap(swa)]
-
-    events: list[object] = []
-
-    def run_attention(*args: Any, **kwargs: Any):
-        events.append("attention")
-        return (torch.ones(1),)
-
-    def run_indexer(**kwargs: Any):
-        events.append("indexer")
-        return torch.ones(1), None
-
-    stream = MagicMock()
-    stream.record_event.return_value = object()
-    attn_op = MagicMock(side_effect=run_attention)
-
-    with (
-        patch.object(
-            DeviceOperator,
-            "unpack_dsa_forward_kv_cache",
-            return_value=tuple(torch.ones((1, 1)) for _ in range(6)),
-        ),
-        patch.object(DeviceOperator, "dsa_kv_compress_scatter"),
-        patch.object(DeviceOperator, "get_dsa_sparse_attn_op", return_value=attn_op),
-        patch.object(DeviceOperator, "get_dsa_sparse_attn_base_kwargs", return_value={}),
-        patch.object(DeviceOperator, "add_dsa_sparse_attn_extra_kwargs"),
-        patch.object(DeviceOperator, "indexer_quantize_query", return_value=(torch.ones(1), torch.ones(1))),
-        patch.object(DeviceOperator, "prepare_dsa_indexer_weights", side_effect=lambda value: value),
-        patch.object(DeviceOperator, "prepare_dsa_indexer_query_scale", side_effect=lambda value: value),
-        patch.object(DeviceOperator, "prepare_dsa_indexer_key_scale", side_effect=lambda value: value),
-        patch.object(torch.npu, "current_stream", return_value=stream),
-        patch("vllm_ascend.attention.dsa_v1.dsv4_dsa_overlap_stream", return_value=MagicMock()),
-        patch("vllm_ascend.attention.dsa_v1.npu_stream_switch", return_value=nullcontext()),
-        patch("vllm_ascend.attention.dsa_v1.notify_kv_cache_written"),
-        patch(
-            "vllm_ascend.attention.dsa_v1.record_attention_compute_start",
-            side_effect=lambda: events.append("attention-start"),
-        ),
-        patch(
-            "vllm_ascend.attention.dsa_v1.wait_for_device_metadata",
-            side_effect=lambda stage, group_id: events.append((stage, group_id)),
-        ),
-        patch.object(
-            torch.ops._C_ascend,
-            "compressor",
-            create=True,
-            return_value=torch.ones((1, 1)),
-        ),
-        patch.object(
-            torch.ops._C_ascend,
-            "npu_vllm_quant_lightning_indexer",
-            create=True,
-            side_effect=run_indexer,
-        ),
-    ):
-        getattr(impl, f"_forward_{phase}")("layer", torch.ones((1, 1)), tuple(), attn_metadata)
-
-    expected_sas = sas_metadata if compressor_ratio == 1 else compressor.sas_metadata
-    expected = []
-    if compressor_ratio == 4:
-        expected.extend([(DeviceMetadataStage.INDEXER, id(qli_metadata)), "indexer"])
-    expected.extend(
-        [
-            (DeviceMetadataStage.ATTENTION, id(expected_sas)),
-            "attention-start",
-            "attention",
-        ]
-    )
-    assert events == expected
 
 
 @pytest.mark.parametrize(
@@ -970,6 +650,8 @@ def test_dsa_cp_defers_device_metadata(
     )
     builder.req_sas_metadata = torch.zeros(1024, dtype=torch.int32)
     builder.req_qli_metadata = torch.zeros(1024, dtype=torch.int32)
+    builder.qli_seqused_k = torch.zeros(2, dtype=torch.int32)
+    builder.qli_cmp_residual_k = torch.zeros(2, dtype=torch.int32)
     builder._device_metadata_enabled = enabled
     builder._device_metadata_tasks = ()
     builder.model_config = SimpleNamespace(
@@ -995,7 +677,9 @@ def test_dsa_cp_defers_device_metadata(
 
     def build_qli(**_: Any):
         events.append("qli")
-        return builder.req_qli_metadata if compressor_ratio == 4 else None
+        if compressor_ratio != 4:
+            return None, None, None, None
+        return query_start_loc, builder.qli_seqused_k, builder.qli_cmp_residual_k, builder.req_qli_metadata
 
     build_local_metadata = MagicMock(side_effect=build_local) if enabled else None
     builder._ensure_device_local_metadata = MagicMock(
@@ -1066,47 +750,6 @@ def test_dsa_cp_defers_device_metadata(
         builder._build_qli_metadata.assert_not_called()
 
 
-@pytest.mark.parametrize(
-    ("mode", "ratio", "allocates_buffers"),
-    [
-        (CUDAGraphMode.FULL, 4, False),
-        (CUDAGraphMode.PIECEWISE, 4, True),
-        (CUDAGraphMode.FULL_DECODE_ONLY, 4, True),
-        (CUDAGraphMode.FULL_AND_PIECEWISE, 128, True),
-        (CUDAGraphMode.NONE, 1, False),
-    ],
-)
-def test_dsa_cp_enable_device_metadata_allocates_compressor_buffers(
-    mode: CUDAGraphMode,
-    ratio: int,
-    allocates_buffers: bool,
-):
-    builder = AscendDSACPMetadataBuilder.__new__(AscendDSACPMetadataBuilder)
-    builder._device_metadata_enabled = False
-    builder.compressor_ratio = ratio
-    builder.compressor_metadata_buffers = None
-    builder.vllm_config = SimpleNamespace(
-        compilation_config=SimpleNamespace(cudagraph_mode=mode),
-        scheduler_config=SimpleNamespace(max_num_batched_tokens=8),
-    )
-    builder.model_config = SimpleNamespace(hf_config=SimpleNamespace(qk_rope_head_dim=4))
-    builder.device = torch.device("cpu")
-    builder.slot_mapping = torch.empty((8, 2), dtype=torch.int32)
-
-    builder.enable_device_metadata()
-
-    assert builder._device_metadata_enabled
-    assert (builder.compressor_metadata_buffers is not None) is allocates_buffers
-    if allocates_buffers:
-        assert builder.compressor_metadata_buffers is not None
-        cos, sin, slot = builder.compressor_metadata_buffers
-        assert cos.shape == sin.shape == (8, 1, 1, 4)
-        assert cos.dtype == sin.dtype == torch.float32
-        assert slot is builder.slot_mapping
-        assert slot.shape == (8, 2)
-        assert slot.dtype == torch.int32
-
-
 def test_dsa_cp_full_graph_compressor_uses_stable_bucket_extent():
     builder = AscendDSACPMetadataBuilder.__new__(AscendDSACPMetadataBuilder)
     builder.num_prefills = 0
@@ -1127,6 +770,8 @@ def test_dsa_cp_full_graph_compressor_uses_stable_bucket_extent():
     base_pointers = tuple(buffer.data_ptr() for buffer in builder.compressor_metadata_buffers)
     builder.req_sas_metadata = torch.zeros(1024, dtype=torch.int32)
     builder.req_qli_metadata = torch.zeros(1024, dtype=torch.int32)
+    builder.qli_seqused_k = torch.zeros(2, dtype=torch.int32)
+    builder.qli_cmp_residual_k = torch.zeros(2, dtype=torch.int32)
     builder._device_metadata_enabled = True
     builder._device_metadata_tasks = ()
     builder.model_config = SimpleNamespace(
@@ -1140,7 +785,9 @@ def test_dsa_cp_full_graph_compressor_uses_stable_bucket_extent():
     )
     builder._get_cmp_seqlens_for_metadata = MagicMock(return_value=None)
     builder._build_sas_metadata = MagicMock(return_value=builder.req_sas_metadata)
-    builder._build_qli_metadata = MagicMock(return_value=builder.req_qli_metadata)
+    builder._build_qli_metadata = MagicMock(
+        return_value=(query_start_loc, builder.qli_seqused_k, builder.qli_cmp_residual_k, builder.req_qli_metadata)
+    )
     common_metadata = SimpleNamespace(
         num_reqs=2,
         query_start_loc=query_start_loc,
@@ -1221,6 +868,8 @@ def test_dsa_cp_qli_metadata_uses_host_maxima():
     builder.compressor_ratio = 4
     builder.common_ratio_to_sas_metadata = {}
     builder.req_qli_metadata = torch.zeros(1024, dtype=torch.int32)
+    builder.qli_seqused_k = torch.zeros(2, dtype=torch.int32)
+    builder.qli_cmp_residual_k = torch.zeros(2, dtype=torch.int32)
     builder.seqused_q = torch.empty(0)
     builder.model_config = SimpleNamespace(
         hf_config=SimpleNamespace(
@@ -1229,13 +878,12 @@ def test_dsa_cp_qli_metadata_uses_host_maxima():
             index_topk=512,
         )
     )
-    seq_lens = MagicMock()
-    seq_lens.clone.return_value = torch.tensor([8, 6], dtype=torch.int32)
+    seq_lens = torch.tensor([8, 6], dtype=torch.int32)
     generated_metadata = torch.arange(1024, dtype=torch.int32)
 
     with patch.object(
         torch.ops._C_ascend,
-        "npu_vllm_quant_lightning_indexer_metadata",
+        "npu_quant_lightning_indexer_v2_metadata",
         create=True,
         return_value=generated_metadata,
     ) as metadata_op:
@@ -1247,9 +895,10 @@ def test_dsa_cp_qli_metadata_uses_host_maxima():
             max_seqlen_k=8,
         )
 
-    seq_lens.max.assert_not_called()
     assert metadata_op.call_args.kwargs["max_seqlen_q"] == 2
-    assert metadata_op.call_args.kwargs["max_seqlen_k"] == 8
+    assert metadata_op.call_args.kwargs["max_seqlen_k"] == 2
+    assert torch.equal(builder.qli_seqused_k, torch.tensor([2, 1], dtype=torch.int32))
+    assert torch.equal(builder.qli_cmp_residual_k, torch.tensor([0, 2], dtype=torch.int32))
 
 
 def test_dsa_cp_legacy_compressor_waits_for_local_metadata():
@@ -1327,6 +976,9 @@ def _make_dsa_cp_metadata(sas_metadata: torch.Tensor) -> AscendDSACPMetadata:
         start_pos=torch.zeros(1, dtype=torch.int32),
         sas_metadata=sas_metadata,
         qli_metadata=torch.zeros(1024, dtype=torch.int32),
+        qli_cu_seqlens_q=query_start_loc,
+        qli_seqused_k=torch.zeros(1, dtype=torch.int32),
+        qli_cmp_residual_k=torch.ones(1, dtype=torch.int32),
         cu_cmp_seqlen_list=torch.tensor([0, 1], dtype=torch.int32),
     )
     return AscendDSACPMetadata(
@@ -1378,7 +1030,7 @@ def test_dsa_cp_indexer_waits_before_qli_consumer():
         patch.object(torch.ops._C_ascend, "inplace_partial_rotary_mul", create=True),
         patch.object(
             torch.ops._C_ascend,
-            "npu_vllm_quant_lightning_indexer",
+            "npu_quant_lightning_indexer_v2",
             create=True,
             side_effect=run_indexer,
         ),
@@ -1395,8 +1047,6 @@ def test_dsa_cp_indexer_waits_before_qli_consumer():
             attn_metadata=attn_metadata,
             cos=torch.ones((1, 1, 1, 2)),
             sin=torch.zeros((1, 1, 1, 2)),
-            actual_seq_lengths_query=torch.tensor([0, 1], dtype=torch.int32),
-            actual_seq_lengths_key=torch.tensor([1], dtype=torch.int32),
         )
 
     assert events == [(DeviceMetadataStage.INDEXER, id(qli_metadata)), "indexer"]

--- a/tests/ut/attention/test_dsa_v1.py
+++ b/tests/ut/attention/test_dsa_v1.py
@@ -4,10 +4,12 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 import torch
+from vllm.config import CUDAGraphMode
 
 from vllm_ascend.attention.dsa_v1 import (
     AscendDSAImpl,
     AscendDSAMetadataBuilder,
+    build_compressor_metadata_out,
 )
 from vllm_ascend.device.device_op import DeviceOperator
 from vllm_ascend.worker.device_metadata import DeviceMetadataStage
@@ -53,6 +55,11 @@ def _make_decode_builder(compressor_ratio: int, enabled: bool):
     builder.cu_seqlens_cmp_kv = torch.empty(0, dtype=torch.int32)
     builder._device_metadata_enabled = enabled
     builder._device_metadata_tasks = ()
+    builder.prefill_compressor_metadata_buffers = None
+    builder.decode_compressor_metadata_buffers = None
+    if enabled and compressor_ratio > 1:
+        builder.prefill_compressor_metadata_buffers = tuple(torch.empty((8, 2), dtype=torch.int32) for _ in range(3))
+        builder.decode_compressor_metadata_buffers = tuple(torch.empty((8, 2), dtype=torch.int32) for _ in range(3))
     builder.block_size = 128
     builder.cache_group_key = "group"
     builder.get_block_table_size = MagicMock(return_value=2)
@@ -118,20 +125,26 @@ def test_decode_metadata_defers_device_work(
 
         if enabled:
             expected = (
-                [DeviceMetadataStage.INDEXER, DeviceMetadataStage.ATTENTION]
+                list(DeviceMetadataStage)
                 if compressor_ratio == 4
+                else [DeviceMetadataStage.COMPRESSOR, DeviceMetadataStage.ATTENTION]
+                if compressor_ratio > 1
                 else [DeviceMetadataStage.ATTENTION]
             )
             assert [task.stage for task in tasks] == expected
-            assert [task.group_id for task in tasks] == (
-                [id(builder.decode_qli_metadata), id(builder.decode_sas_metadata)]
-                if compressor_ratio == 4
-                else [id(builder.decode_sas_metadata)]
-            )
+            expected_groups = []
+            if compressor_ratio > 1:
+                assert builder.decode_compressor_metadata_buffers is not None
+                expected_groups.append(id(builder.decode_compressor_metadata_buffers[0]))
+            if compressor_ratio == 4:
+                expected_groups.append(id(builder.decode_qli_metadata))
+            expected_groups.append(id(builder.decode_sas_metadata))
+            assert [task.group_id for task in tasks] == expected_groups
             sas_op.assert_not_called()
             qli_op.assert_not_called()
-            for task in tasks:
-                task.run()
+            with patch("vllm_ascend.attention.dsa_v1.build_compressor_metadata_out"):
+                for task in tasks:
+                    task.run()
         else:
             assert tasks == ()
 
@@ -221,21 +234,26 @@ def test_prefill_metadata_defers_device_work(
 
         if enabled:
             expected_stages = (
-                [DeviceMetadataStage.INDEXER, DeviceMetadataStage.ATTENTION]
+                list(DeviceMetadataStage)
                 if compressor_ratio == 4
+                else [DeviceMetadataStage.COMPRESSOR, DeviceMetadataStage.ATTENTION]
+                if compressor_ratio > 1
                 else [DeviceMetadataStage.ATTENTION]
             )
-            expected_groups = (
-                [id(builder.prefill_qli_metadata), id(builder.prefill_sas_metadata)]
-                if compressor_ratio == 4
-                else [id(builder.prefill_sas_metadata)]
-            )
+            expected_groups = []
+            if compressor_ratio > 1:
+                assert builder.prefill_compressor_metadata_buffers is not None
+                expected_groups.append(id(builder.prefill_compressor_metadata_buffers[0]))
+            if compressor_ratio == 4:
+                expected_groups.append(id(builder.prefill_qli_metadata))
+            expected_groups.append(id(builder.prefill_sas_metadata))
             assert [task.stage for task in tasks] == expected_stages
             assert [task.group_id for task in tasks] == expected_groups
             sas_op.assert_not_called()
             qli_op.assert_not_called()
-            for task in tasks:
-                task.run()
+            with patch("vllm_ascend.attention.dsa_v1.build_compressor_metadata_out"):
+                for task in tasks:
+                    task.run()
         else:
             assert tasks == ()
 
@@ -308,24 +326,193 @@ def test_mixed_metadata_keeps_prefill_and_decode_groups_isolated():
         )
         builder.build_decode_metadata(0, SimpleNamespace(), 2)
         tasks = builder.take_device_metadata_tasks()
-        for task in tasks:
-            task.run()
+        with patch("vllm_ascend.attention.dsa_v1.build_compressor_metadata_out"):
+            for task in tasks:
+                task.run()
 
-    assert [task.stage for task in tasks] == [
+    ordered_tasks = sorted(tasks, key=lambda task: task.stage)
+    assert [task.stage for task in ordered_tasks] == [
+        DeviceMetadataStage.COMPRESSOR,
+        DeviceMetadataStage.COMPRESSOR,
+        DeviceMetadataStage.INDEXER,
         DeviceMetadataStage.INDEXER,
         DeviceMetadataStage.ATTENTION,
-        DeviceMetadataStage.INDEXER,
         DeviceMetadataStage.ATTENTION,
     ]
-    assert [task.group_id for task in tasks] == [
+    assert {task.group_id for task in tasks} == {
+        id(builder.prefill_compressor_metadata_buffers[0]),
+        id(builder.decode_compressor_metadata_buffers[0]),
         id(builder.prefill_qli_metadata),
-        id(builder.prefill_sas_metadata),
         id(builder.decode_qli_metadata),
+        id(builder.prefill_sas_metadata),
         id(builder.decode_sas_metadata),
-    ]
-    assert len(set(task.group_id for task in tasks)) == 4
+    }
     assert sas_op.call_count == 2
     assert qli_op.call_count == 2
+
+
+def test_build_compressor_metadata_out_uses_fixed_outputs():
+    metadata = SimpleNamespace(
+        full_compress_cos=torch.ones((8, 1, 1, 4)),
+        full_compress_sin=torch.zeros((8, 1, 1, 4)),
+        query_start_loc=torch.tensor([0, 2], dtype=torch.int32),
+        start_pos=torch.tensor([1], dtype=torch.int32),
+        block_table=torch.tensor([[3]], dtype=torch.int32),
+        block_size=128,
+        num_reqs_actual=1,
+    )
+    outputs = (
+        torch.empty((2, 1, 1, 4)),
+        torch.empty((2, 1, 1, 4)),
+        torch.empty((2, 2), dtype=torch.int32),
+    )
+
+    with (
+        patch.object(DeviceOperator, "get_dsa_compressor_slot_mapping_format", return_value=2),
+        patch.object(torch.ops._C_ascend, "compressor_metadata_out", create=True) as metadata_out,
+    ):
+        build_compressor_metadata_out(metadata, 4, outputs)
+
+    assert metadata_out.call_args.args[-3:] == outputs
+
+
+@pytest.mark.parametrize(
+    ("mode", "allocates_buffers"),
+    [
+        (CUDAGraphMode.NONE, True),
+        (CUDAGraphMode.FULL_AND_PIECEWISE, True),
+        (CUDAGraphMode.FULL, False),
+    ],
+)
+def test_enable_device_metadata_keeps_pure_full_compressor_legacy(
+    mode: CUDAGraphMode,
+    allocates_buffers: bool,
+):
+    builder = AscendDSAMetadataBuilder.__new__(AscendDSAMetadataBuilder)
+    builder._device_metadata_enabled = False
+    builder.compressor_ratio = 4
+    builder.device = torch.device("cpu")
+    builder.slot_mapping_shape = (8, 2)
+    builder.model_config = SimpleNamespace(hf_config=SimpleNamespace(qk_rope_head_dim=4))
+    builder.vllm_config = SimpleNamespace(
+        compilation_config=SimpleNamespace(cudagraph_mode=mode),
+        scheduler_config=SimpleNamespace(max_num_batched_tokens=8),
+    )
+    builder.prefill_compressor_metadata_buffers = None
+    builder.decode_compressor_metadata_buffers = None
+
+    builder.enable_device_metadata()
+
+    assert builder._device_metadata_enabled
+    assert (builder.prefill_compressor_metadata_buffers is not None) is allocates_buffers
+    assert (builder.decode_compressor_metadata_buffers is not None) is allocates_buffers
+    if allocates_buffers:
+        assert builder.prefill_compressor_metadata_buffers is not None
+        assert builder.decode_compressor_metadata_buffers is not None
+        for buffers in (
+            builder.prefill_compressor_metadata_buffers,
+            builder.decode_compressor_metadata_buffers,
+        ):
+            assert buffers[0].shape == (8, 1, 1, 4)
+            assert buffers[1].shape == (8, 1, 1, 4)
+            assert buffers[2].shape == (8, 2)
+            assert buffers[0].dtype == buffers[1].dtype == torch.float32
+            assert buffers[2].dtype == torch.int32
+
+
+@pytest.mark.parametrize("phase", ["prefill", "decode"])
+def test_full_graph_compressor_uses_stable_padded_extent(phase: str):
+    builder = _make_prefill_builder(4, True)
+    builder.decode_ratio_to_sas_metadata = {
+        "query_start_loc": torch.tensor([0, 1, 2], dtype=torch.int32),
+        "input_positions": torch.arange(2),
+        "cos": torch.ones((2, 1)),
+        "sin": torch.zeros((2, 1)),
+        "query_start_loc_cpu": torch.tensor([0, 1, 2], dtype=torch.int32),
+        "max_seq_lens": 9,
+        "seq_lens_list": [8, 9],
+        "max_seqlen_kv": 9,
+        "max_seqlen_q": 1,
+        "start_pos_decode": torch.tensor([7, 8], dtype=torch.int32),
+    }
+    common = SimpleNamespace(
+        num_input_tokens=8,
+        query_start_loc=torch.tensor([0, 1, 3], dtype=torch.int32),
+    )
+
+    with (
+        patch(
+            "vllm_ascend.attention.dsa_v1.get_tensor_model_parallel_world_size",
+            return_value=1,
+        ),
+        patch(
+            "vllm_ascend.attention.dsa_v1.get_full_cos_and_sin_dsa",
+            return_value=(torch.ones(1), torch.zeros(1)),
+        ),
+        patch.object(
+            DeviceOperator,
+            "get_dsa_sparse_attn_metadata_op",
+            return_value=MagicMock(return_value=torch.ones(1024, dtype=torch.int32)),
+        ),
+        patch.object(DeviceOperator, "get_dsa_sparse_attn_metadata_kwargs", return_value={}),
+        patch.object(
+            DeviceOperator,
+            "get_dsa_decode_cu_seqlens_ori_kv",
+            return_value=torch.tensor([0, 8, 17], dtype=torch.int32),
+        ),
+        patch.object(DeviceOperator, "get_dsa_decode_cu_seqlens_cmp_kv", return_value=None),
+    ):
+        if phase == "prefill":
+            capture_metadata = builder.build_prefill_metadata(0, common, 2, full_graph_mode=True)
+            metadata = builder.build_prefill_metadata(0, common, 1, full_graph_mode=True)
+            buffers = builder.prefill_compressor_metadata_buffers
+            expected_rows = 3
+            expected_reqs = 1
+        else:
+            builder.num_decodes = 2
+            builder.num_decode_tokens = 2
+            capture_metadata = builder.build_decode_metadata(0, common, 2, full_graph_mode=True)
+            metadata = builder.build_decode_metadata(0, common, 1, full_graph_mode=True)
+            buffers = builder.decode_compressor_metadata_buffers
+            expected_rows = 4
+            expected_reqs = 2
+
+    assert buffers is not None
+    assert metadata.num_compressed_tokens == expected_rows
+    assert metadata.num_reqs_actual == expected_reqs
+    assert metadata.compressor_metadata is not None
+    assert metadata.compressor_metadata[0].shape[0] == expected_rows
+    assert metadata.compressor_metadata[0].data_ptr() == buffers[0].data_ptr()
+    assert capture_metadata.compressor_metadata is not None
+    assert capture_metadata.compressor_metadata[0].shape == metadata.compressor_metadata[0].shape
+    assert capture_metadata.compressor_metadata[0].data_ptr() == metadata.compressor_metadata[0].data_ptr()
+
+
+def test_compressor_consumer_waits_only_for_precomputed_metadata():
+    impl = AscendDSAImpl.__new__(AscendDSAImpl)
+    impl.compress_ratio = 4
+    outputs = (torch.ones(1), torch.zeros(1), torch.zeros(1, dtype=torch.int32))
+    precomputed = SimpleNamespace(
+        compressor_metadata=outputs,
+        compressor_metadata_group_id=17,
+    )
+    legacy = SimpleNamespace(
+        compressor_metadata=None,
+        compressor_metadata_group_id=None,
+    )
+
+    with (
+        patch("vllm_ascend.attention.dsa_v1.wait_for_device_metadata") as wait,
+        patch(
+            "vllm_ascend.attention.dsa_v1.get_or_compute_compressor_metadata",
+            return_value=(torch.ones(1), torch.ones(1), torch.ones(1)),
+        ) as legacy_compute,
+    ):
+        assert impl._compute_compressor_metadata(precomputed) is outputs
+        impl._compute_compressor_metadata(legacy)
+
+    wait.assert_called_once_with(DeviceMetadataStage.COMPRESSOR, 17)
+    legacy_compute.assert_called_once_with(legacy, 4)
 
 
 @pytest.mark.parametrize("with_prefill", [False, True])

--- a/tests/ut/attention/test_dsa_v1.py
+++ b/tests/ut/attention/test_dsa_v1.py
@@ -1,0 +1,332 @@
+from contextlib import nullcontext
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+import torch
+
+from vllm_ascend.attention.dsa_v1 import (
+    AscendDSAImpl,
+    AscendDSAMetadataBuilder,
+)
+from vllm_ascend.device.device_op import DeviceOperator
+from vllm_ascend.worker.device_metadata import DeviceMetadataStage
+
+
+def _make_decode_builder(compressor_ratio: int, enabled: bool):
+    builder = AscendDSAMetadataBuilder.__new__(AscendDSAMetadataBuilder)
+    query_start_loc = torch.tensor([0, 1, 2], dtype=torch.int32)
+    builder.decode_ratio_to_sas_metadata = {
+        "query_start_loc": query_start_loc,
+        "input_positions": torch.arange(2),
+        "cos": torch.ones((2, 1)),
+        "sin": torch.zeros((2, 1)),
+        "query_start_loc_cpu": query_start_loc,
+        "max_seq_lens": 9,
+        "seq_lens_list": [8, 9],
+        "max_seqlen_kv": 9,
+        "max_seqlen_q": 1,
+        "start_pos_decode": torch.tensor([7, 8], dtype=torch.int32),
+    }
+    builder.compressor_ratio = compressor_ratio
+    builder.num_decodes = 2
+    builder.num_decode_tokens = 2
+    builder.seq_lens = torch.tensor([8, 9], dtype=torch.int32)
+    builder.start_pos_decode = torch.zeros(2, dtype=torch.int32)
+    builder.block_table = torch.zeros((2, 2), dtype=torch.int32)
+    builder.slot_mapping = torch.zeros((2, 2), dtype=torch.int32)
+    builder.model_config = SimpleNamespace(
+        hf_config=SimpleNamespace(
+            num_attention_heads=8,
+            index_topk=512,
+            index_n_heads=64,
+            index_head_dim=128,
+            sliding_window=4096,
+        ),
+        get_head_size=lambda: 192,
+    )
+    builder.seqused_q = torch.empty(0)
+    builder.decode_sas_metadata = torch.zeros(1024, dtype=torch.int32)
+    builder.decode_qli_metadata = torch.zeros(1024, dtype=torch.int32)
+    builder._zero_i32 = torch.zeros(1, dtype=torch.int32)
+    builder.cu_seqlens_ori_kv = torch.empty(0, dtype=torch.int32)
+    builder.cu_seqlens_cmp_kv = torch.empty(0, dtype=torch.int32)
+    builder._device_metadata_enabled = enabled
+    builder._device_metadata_tasks = ()
+    builder.block_size = 128
+    builder.cache_group_key = "group"
+    builder.get_block_table_size = MagicMock(return_value=2)
+    builder._num_compressor_metadata_rows = MagicMock(return_value=2)
+    return builder
+
+
+@pytest.mark.parametrize("compressor_ratio", [1, 4, 128])
+@pytest.mark.parametrize("enabled", [False, True])
+def test_decode_metadata_defers_device_work(
+    compressor_ratio: int,
+    enabled: bool,
+):
+    builder = _make_decode_builder(compressor_ratio, enabled)
+    sas_output = torch.full((1024,), 3, dtype=torch.int32)
+    qli_output = torch.full((1024,), 4, dtype=torch.int32)
+    sas_op = MagicMock(return_value=sas_output)
+
+    with (
+        patch(
+            "vllm_ascend.attention.dsa_v1.get_tensor_model_parallel_world_size",
+            return_value=1,
+        ),
+        patch(
+            "vllm_ascend.attention.dsa_v1.get_full_cos_and_sin_dsa",
+            return_value=(torch.ones(1), torch.zeros(1)),
+        ),
+        patch.object(
+            DeviceOperator,
+            "pad_dsa_decode_slot_mapping",
+            return_value=torch.zeros((2, 2), dtype=torch.int32),
+        ),
+        patch.object(
+            DeviceOperator,
+            "get_dsa_decode_cu_seqlens_ori_kv",
+            return_value=torch.tensor([0, 8, 17], dtype=torch.int32),
+        ),
+        patch.object(
+            DeviceOperator,
+            "get_dsa_decode_cu_seqlens_cmp_kv",
+            return_value=None,
+        ),
+        patch.object(
+            DeviceOperator,
+            "get_dsa_sparse_attn_metadata_op",
+            return_value=sas_op,
+        ),
+        patch.object(
+            DeviceOperator,
+            "get_dsa_sparse_attn_metadata_kwargs",
+            return_value={},
+        ),
+        patch.object(
+            torch.ops._C_ascend,
+            "npu_vllm_quant_lightning_indexer_metadata",
+            create=True,
+            return_value=qli_output,
+        ) as qli_op,
+    ):
+        metadata = builder.build_decode_metadata(0, SimpleNamespace(), 2)
+        tasks = builder.take_device_metadata_tasks()
+        assert builder.take_device_metadata_tasks() == ()
+
+        if enabled:
+            expected = (
+                [DeviceMetadataStage.INDEXER, DeviceMetadataStage.ATTENTION]
+                if compressor_ratio == 4
+                else [DeviceMetadataStage.ATTENTION]
+            )
+            assert [task.stage for task in tasks] == expected
+            assert [task.group_id for task in tasks] == (
+                [id(builder.decode_qli_metadata), id(builder.decode_sas_metadata)]
+                if compressor_ratio == 4
+                else [id(builder.decode_sas_metadata)]
+            )
+            sas_op.assert_not_called()
+            qli_op.assert_not_called()
+            for task in tasks:
+                task.run()
+        else:
+            assert tasks == ()
+
+        sas_op.assert_called_once()
+        assert sas_op.call_args.kwargs["cmp_ratio"] == compressor_ratio
+        if enabled and compressor_ratio != 4:
+            qli_op.assert_not_called()
+        else:
+            qli_op.assert_called_once()
+        assert metadata.sas_metadata is builder.decode_sas_metadata
+        assert metadata.qli_metadata is builder.decode_qli_metadata
+        assert torch.equal(builder.decode_sas_metadata, sas_output)
+        if not enabled or compressor_ratio == 4:
+            assert torch.equal(builder.decode_qli_metadata, qli_output)
+
+
+@pytest.mark.parametrize("with_prefill", [False, True])
+def test_indexer_waits_only_for_decode_qli_consumer(with_prefill: bool):
+    impl = AscendDSAImpl.__new__(AscendDSAImpl)
+    impl.index_topk = 512
+    qli_metadata = torch.zeros(1024, dtype=torch.int32)
+    metadata_value = SimpleNamespace(
+        query_start_loc=torch.tensor([0, 1], dtype=torch.int32),
+        seq_lens=torch.tensor([1], dtype=torch.int32),
+        block_table=torch.zeros((1, 1), dtype=torch.int32),
+        qli_metadata=qli_metadata,
+    )
+    metadata = SimpleNamespace(
+        decode=None if with_prefill else metadata_value,
+        prefill=metadata_value if with_prefill else None,
+    )
+    calls = []
+
+    with (
+        patch.object(
+            DeviceOperator,
+            "prepare_dsa_indexer_weights",
+            side_effect=lambda value: value,
+        ),
+        patch.object(
+            DeviceOperator,
+            "prepare_dsa_indexer_query_scale",
+            side_effect=lambda value: value,
+        ),
+        patch.object(
+            DeviceOperator,
+            "prepare_dsa_indexer_key_scale",
+            side_effect=lambda value: value,
+        ),
+        patch(
+            "vllm_ascend.attention.dsa_v1.wait_for_device_metadata",
+            side_effect=lambda stage, group_id: calls.append((stage, group_id)),
+        ),
+        patch.object(
+            torch.ops._C_ascend,
+            "npu_vllm_quant_lightning_indexer",
+            create=True,
+            side_effect=lambda **kwargs: (calls.append("indexer") or torch.zeros(1), None),
+        ),
+    ):
+        impl._indexer_qli(
+            torch.ones((1, 1)),
+            torch.ones((1, 1)),
+            torch.ones(1),
+            torch.ones((1, 1)),
+            torch.ones((1, 1)),
+            metadata,
+            with_prefill=with_prefill,
+        )
+
+    expected = [] if with_prefill else [(DeviceMetadataStage.INDEXER, id(qli_metadata))]
+    assert calls == [*expected, "indexer"]
+
+
+@pytest.mark.parametrize("compressor_ratio", [1, 4, 128])
+def test_decode_consumers_wait_for_their_metadata(compressor_ratio: int):
+    impl = AscendDSAImpl.__new__(AscendDSAImpl)
+    impl.compress_ratio = compressor_ratio
+    impl.multistream_dsv4_dsa_overlap = True
+    impl.skip_topk = False
+    impl.use_index_cache = False
+    impl.window_size = 4096
+    impl.compressor_overlap = False
+    impl.compressor_wkv = SimpleNamespace(weight=torch.ones(1))
+    impl.compressor_wgate = SimpleNamespace(weight=torch.ones(1))
+    impl.compressor_ape = torch.ones(1)
+    impl.compressor_norm = SimpleNamespace(weight=torch.ones(1))
+    impl.rope_head_dim = 1
+    impl.compressor_norm_eps = 1e-6
+    impl.attn_sink = None
+    impl.softmax_scale = 1.0
+    impl.indexer_softmax_scale = 1.0
+    impl.indexer_heads = 1
+    impl.index_topk = 512
+    impl.weights_proj = MagicMock(return_value=torch.ones((1, 1)))
+    impl._mla_prolog_multistream = MagicMock(return_value=(torch.ones((1, 1, 1)), torch.ones((1, 1)), torch.ones(1)))
+    impl.cv_indexer_select_qli = MagicMock(return_value=torch.ones((1, 1)))
+    impl._compute_compressor_metadata = MagicMock(
+        return_value=(torch.ones((1, 1)), torch.ones((1, 1)), torch.zeros(1, dtype=torch.int32))
+    )
+
+    sas_metadata = torch.zeros(1024, dtype=torch.int32)
+    other_sas_metadata = torch.ones(1024, dtype=torch.int32)
+    qli_metadata = torch.full((1024,), 2, dtype=torch.int32)
+    common = SimpleNamespace(
+        cos={"layer": torch.ones((1, 1))},
+        sin={"layer": torch.ones((1, 1))},
+        query_start_loc=torch.tensor([0, 1], dtype=torch.int32),
+        seq_lens=torch.tensor([1], dtype=torch.int32),
+        start_pos=torch.zeros(1, dtype=torch.int32),
+        sas_metadata=sas_metadata,
+        block_table=torch.zeros((1, 1), dtype=torch.int32),
+    )
+    swa_values = dict(vars(common))
+    swa_values.update(
+        slot_mapping=torch.zeros(1, dtype=torch.int32),
+        ori_win_left=None,
+        ori_win_right=None,
+        dspark_swa_indices=None,
+        sas_metadata=sas_metadata if compressor_ratio == 1 else other_sas_metadata,
+    )
+    swa = SimpleNamespace(**swa_values)
+    compressor = SimpleNamespace(**vars(common))
+    compressor_state = SimpleNamespace(block_table=common.block_table)
+    indexer = SimpleNamespace(
+        query_start_loc=common.query_start_loc,
+        seq_lens=common.seq_lens,
+        block_table=common.block_table,
+        qli_metadata=qli_metadata,
+    )
+
+    def wrap(value):
+        return SimpleNamespace(decode=value)
+
+    if compressor_ratio == 1:
+        attn_metadata = [wrap(swa)]
+    elif compressor_ratio == 4:
+        attn_metadata = [wrap(compressor), wrap(compressor_state), wrap(common), wrap(indexer), wrap(swa)]
+    else:
+        attn_metadata = [wrap(compressor), wrap(compressor_state), wrap(swa)]
+
+    events = []
+    stream = MagicMock()
+    stream.record_event.return_value = object()
+    attn_op = MagicMock(side_effect=lambda *args, **kwargs: (events.append("attention") or torch.ones(1),))
+
+    with (
+        patch.object(
+            DeviceOperator,
+            "unpack_dsa_forward_kv_cache",
+            return_value=tuple(torch.ones((1, 1)) for _ in range(6)),
+        ),
+        patch.object(DeviceOperator, "dsa_kv_compress_scatter"),
+        patch.object(DeviceOperator, "get_dsa_sparse_attn_op", return_value=attn_op),
+        patch.object(DeviceOperator, "get_dsa_sparse_attn_base_kwargs", return_value={}),
+        patch.object(DeviceOperator, "indexer_quantize_query", return_value=(torch.ones(1), torch.ones(1))),
+        patch.object(DeviceOperator, "prepare_dsa_indexer_weights", side_effect=lambda value: value),
+        patch.object(DeviceOperator, "prepare_dsa_indexer_query_scale", side_effect=lambda value: value),
+        patch.object(DeviceOperator, "prepare_dsa_indexer_key_scale", side_effect=lambda value: value),
+        patch.object(torch.npu, "current_stream", return_value=stream),
+        patch("vllm_ascend.attention.dsa_v1.dsv4_dsa_overlap_stream", return_value=MagicMock()),
+        patch("vllm_ascend.attention.dsa_v1.npu_stream_switch", return_value=nullcontext()),
+        patch("vllm_ascend.attention.dsa_v1.notify_kv_cache_written"),
+        patch(
+            "vllm_ascend.attention.dsa_v1.record_attention_compute_start",
+            side_effect=lambda: events.append("attention-start"),
+        ),
+        patch(
+            "vllm_ascend.attention.dsa_v1.wait_for_device_metadata",
+            side_effect=lambda stage, group_id: events.append((stage, group_id)),
+        ),
+        patch.object(
+            torch.ops._C_ascend,
+            "compressor",
+            create=True,
+            return_value=torch.ones((1, 1)),
+        ),
+        patch.object(
+            torch.ops._C_ascend,
+            "npu_vllm_quant_lightning_indexer",
+            create=True,
+            side_effect=lambda **kwargs: (events.append("indexer") or torch.ones(1), None),
+        ),
+    ):
+        impl._forward_decode("layer", torch.ones((1, 1)), tuple(), attn_metadata)
+
+    expected_sas = sas_metadata if compressor_ratio == 1 else compressor.sas_metadata
+    expected = []
+    if compressor_ratio == 4:
+        expected.extend([(DeviceMetadataStage.INDEXER, id(qli_metadata)), "indexer"])
+    expected.extend(
+        [
+            (DeviceMetadataStage.ATTENTION, id(expected_sas)),
+            "attention-start",
+            "attention",
+        ]
+    )
+    assert events == expected

--- a/tests/ut/spec_decode/test_dspark_proposer.py
+++ b/tests/ut/spec_decode/test_dspark_proposer.py
@@ -20,12 +20,14 @@
 from __future__ import annotations
 
 import inspect
+from contextlib import contextmanager
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 import numpy as np
 import pytest
 import torch
+from vllm.config import CUDAGraphMode
 from vllm.v1.worker.utils import AttentionGroup
 
 import vllm_ascend.spec_decode.dspark_proposer as dspark_proposer_module
@@ -33,6 +35,7 @@ from vllm_ascend.attention.attention_v1 import AscendAttentionState
 from vllm_ascend.spec_decode.dflash_proposer import AscendDflashProposer
 from vllm_ascend.spec_decode.dspark_proposer import AscendDSparkProposer
 from vllm_ascend.spec_decode.llm_base_proposer import AscendSpecDecodeBaseProposer
+from vllm_ascend.worker.device_metadata import DeviceMetadataStage, DeviceMetadataTask
 
 # 0 = single-DP (no padding); >0 = multi-DP where num_input_tokens >
 # num_query_total, the out-of-bounds regime.
@@ -41,6 +44,197 @@ _NUM_SPECULATIVE_TOKENS = 3
 _MAX_BATCH_SIZE = 2
 _MAX_NUM_TOKENS = 8
 _HIDDEN_SIZE = 16
+
+
+@pytest.mark.parametrize(
+    ("dcp_size", "pcp_size", "expected_submit"),
+    [(1, 1, True), (2, 1, False), (1, 2, False)],
+)
+def test_build_draft_metadata_submits_only_non_cp_device_tasks(
+    dcp_size: int,
+    pcp_size: int,
+    expected_submit: bool,
+):
+    tasks = [DeviceMetadataTask(DeviceMetadataStage.ATTENTION, lambda: None, group_id) for group_id in (7, 9)]
+
+    class DraftMetadataProvider:
+        def __init__(self, task):
+            self.task = task
+
+        def enable_device_metadata(self):
+            pass
+
+        def take_device_metadata_tasks(self):
+            return (self.task,)
+
+        def build_for_drafting(self, common_attn_metadata, draft_index, **kwargs):
+            return SimpleNamespace()
+
+    builders = [DraftMetadataProvider(task) for task in tasks]
+    groups = [
+        SimpleNamespace(
+            kv_cache_group_id=group_id,
+            layer_names=[f"draft.attn.{group_id}"],
+            get_metadata_builder=lambda builder=builder: builder,
+        )
+        for group_id, builder in enumerate(builders)
+    ]
+    executor = MagicMock()
+    proposer = SimpleNamespace(
+        draft_attn_groups=groups,
+        use_compress=False,
+        method="dspark",
+        runner=SimpleNamespace(device_metadata_executor=executor),
+        dcp_size=dcp_size,
+        vllm_config=SimpleNamespace(
+            parallel_config=SimpleNamespace(prefill_context_parallel_size=pcp_size),
+        ),
+        _per_group_block_table_buffers={group_id: torch.ones((1, 1), dtype=torch.int32) for group_id in range(2)},
+        _per_group_query_slot_mapping_buffers={group_id: torch.zeros(1, dtype=torch.int32) for group_id in range(2)},
+    )
+    common_attn_metadata = SimpleNamespace(
+        num_reqs=1,
+        block_table_tensor=torch.ones((1, 1), dtype=torch.int32),
+        slot_mapping=torch.zeros(1, dtype=torch.int32),
+    )
+
+    metadata, first = AscendSpecDecodeBaseProposer.build_draft_attn_metadata(
+        proposer,
+        common_attn_metadata,
+        num_input_tokens=1,
+        num_actual_tokens=1,
+    )
+
+    assert metadata[0]["draft.attn.0"] is first
+    if expected_submit:
+        executor.submit.assert_called_once_with(tasks)
+    else:
+        executor.submit.assert_not_called()
+
+
+@pytest.mark.parametrize(
+    ("has_task", "failure"),
+    [(True, None), (False, None), (True, "run"), (True, "context")],
+)
+def test_dspark_device_metadata_executor_forward_lifecycle(has_task: bool, failure: str | None):
+    events = []
+    executor = SimpleNamespace(submission_in_flight=False)
+
+    def release():
+        events.append("release")
+        executor.submission_in_flight = False
+
+    executor.release = release
+    runner = SimpleNamespace(
+        device_metadata_executor=executor,
+        dcp_manager=None,
+        input_batch=SimpleNamespace(lora_id_to_lora_request={}),
+        _sync_metadata_across_dp=lambda num_tokens, **kwargs: (num_tokens, torch.tensor(1), None),
+        dynamic_eplb=False,
+        eplb_heat_collection_status=False,
+    )
+    proposer = AscendSpecDecodeBaseProposer.__new__(AscendSpecDecodeBaseProposer)
+    proposer.runner = runner
+    proposer.method = "dspark"
+    proposer.model = SimpleNamespace(combine_hidden_states=lambda hidden_states: hidden_states)
+    proposer.get_model = lambda: proposer.model
+    proposer.hidden_size = 4
+    proposer.use_cuda_graph = False
+    proposer.dcp_size = 1
+    proposer.vllm_config = SimpleNamespace(model_config=SimpleNamespace(use_mla=True))
+    proposer.draft_window_size = None
+    proposer.supports_mm_inputs = False
+    proposer.slot_mapping_group = [torch.zeros(2, dtype=torch.int32)]
+    proposer.seq_lens_group = [torch.zeros(2, dtype=torch.int32)]
+    proposer.query_start_loc_group = [torch.zeros(3, dtype=torch.int32)]
+    proposer._pad_draft_buffers = MagicMock()
+    proposer._prepare_parallel_draft_seq_lens_cpu = MagicMock()
+    proposer.uses_mrope = False
+    proposer.positions = torch.arange(2, dtype=torch.int32)
+    proposer.parallel_drafting = True
+    proposer.token_indices_to_sample = torch.zeros(2, dtype=torch.int32)
+    proposer.enable_enpu = False
+    proposer._update_full_graph_params_if_needed = MagicMock()
+    proposer.set_inputs_first_pass = MagicMock()
+    proposer.build_draft_attn_metadata = MagicMock()
+
+    query_start_loc = torch.tensor([0, 1], dtype=torch.int32)
+    common_attn_metadata = SimpleNamespace(
+        batch_size=lambda: 1,
+        num_reqs=1,
+        query_start_loc=query_start_loc,
+        query_start_loc_cpu=query_start_loc,
+        seq_lens=torch.tensor([8], dtype=torch.int32),
+        seq_lens_cpu=torch.tensor([8], dtype=torch.int32),
+        _seq_lens_cpu=torch.tensor([8], dtype=torch.int32),
+        block_table_tensor=torch.ones((1, 1), dtype=torch.int32),
+        slot_mapping=torch.zeros(1, dtype=torch.int32),
+    )
+    proposer.set_inputs_first_pass.return_value = (
+        1,
+        torch.tensor([0], dtype=torch.int32),
+        common_attn_metadata,
+        None,
+    )
+
+    def build_metadata(*args, **kwargs):
+        events.append("submit" if has_task else "build")
+        executor.submission_in_flight = has_task
+        metadata = {"draft.attn": SimpleNamespace(num_prefills=0)}
+        return [metadata], metadata["draft.attn"]
+
+    proposer.build_draft_attn_metadata.side_effect = build_metadata
+
+    def run_draft(**kwargs):
+        events.append("run")
+        if failure == "run":
+            raise RuntimeError("draft run failed")
+        return torch.ones((1, 1), dtype=torch.int64)
+
+    proposer._runnable = run_draft
+    forward_context = SimpleNamespace(moe_layer_index=-1, cudagraph_runtime_mode=CUDAGraphMode.NONE)
+    context_executors = []
+
+    @contextmanager
+    def forward_context_manager(*args, **kwargs):
+        context_executors.append(kwargs["device_metadata_executor"])
+        events.append("context")
+        if failure == "context":
+            raise RuntimeError("draft context failed")
+        yield
+
+    with (
+        patch("vllm_ascend.spec_decode.llm_base_proposer.DSparkDeepseekV4ForCausalLM", object),
+        patch("vllm_ascend.spec_decode.llm_base_proposer.set_ascend_forward_context", forward_context_manager),
+        patch("vllm_ascend.spec_decode.llm_base_proposer.get_forward_context", return_value=forward_context),
+    ):
+        call = lambda: AscendSpecDecodeBaseProposer._propose(
+            proposer,
+            target_token_ids=torch.ones(1, dtype=torch.int64),
+            target_positions=torch.zeros(1, dtype=torch.int32),
+            target_hidden_states=torch.ones((1, 4)),
+            next_token_ids=torch.ones(1, dtype=torch.int64),
+            token_indices_to_sample=torch.tensor([0], dtype=torch.int32),
+            common_attn_metadata=common_attn_metadata,
+            target_model_batch_desc=SimpleNamespace(uniform=True),
+            sampling_metadata=MagicMock(),
+        )
+        if failure is None:
+            result = call()
+            assert torch.equal(result, torch.ones((1, 1), dtype=torch.int64))
+        else:
+            with pytest.raises(RuntimeError, match=f"draft {failure} failed"):
+                call()
+
+    assert context_executors == [executor if has_task else None]
+    expected_events = ["submit" if has_task else "build", "context"]
+    if failure != "context":
+        expected_events.append("run")
+    if has_task and failure is None:
+        expected_events.append("release")
+    assert events == expected_events
+    if failure is not None:
+        assert executor.submission_in_flight
 
 
 class _DSparkProposerTestBase:
@@ -743,13 +937,71 @@ class TestInitializeAttnBackendErrors(_DSparkProposerTestBase):
     @staticmethod
     def _make_proposer_for_init():
         proposer = AscendDSparkProposer.__new__(AscendDSparkProposer)
-        proposer.vllm_config = SimpleNamespace()
+        proposer.vllm_config = SimpleNamespace(
+            parallel_config=SimpleNamespace(prefill_context_parallel_size=1),
+        )
         # The real proposer constructor always sets this field.  These
         # lightweight initializer tests bypass __init__, so preserve that
         # production invariant with a generic non-K3 draft config.
         proposer.draft_model_config = SimpleNamespace(hf_config=object())
         proposer.device = torch.device("cpu")
+        proposer.runner = SimpleNamespace(device_metadata_executor=None)
+        proposer.dcp_size = 1
         return proposer
+
+    @pytest.mark.parametrize(
+        ("dcp_size", "pcp_size", "has_executor", "expected_tokens"),
+        [
+            (1, 1, True, 8),
+            (2, 1, True, None),
+            (1, 2, True, None),
+            (1, 1, False, None),
+        ],
+    )
+    def test_initializes_device_metadata_only_for_eligible_dsa_draft(
+        self,
+        monkeypatch,
+        dcp_size,
+        pcp_size,
+        has_executor,
+        expected_tokens,
+    ):
+        class DraftBuilder:
+            def __init__(self):
+                self.max_num_tokens = None
+
+            def enable_dspark_device_metadata(self, max_num_tokens):
+                self.max_num_tokens = max_num_tokens
+
+        backend = MagicMock()
+        backend.full_cls_name.return_value = "fake.backend"
+        layer = MagicMock()
+        layer.get_attn_backend.return_value = backend
+        monkeypatch.setattr(
+            "vllm_ascend.spec_decode.dspark_proposer.get_layers_from_vllm_config",
+            lambda *args, **kwargs: {"L0": layer},
+        )
+        proposer = self._make_proposer_for_init()
+        proposer.model = SimpleNamespace(get_draft_kv_cache_layer_names=lambda: {"L0"})
+        proposer.max_query_tokens = 8
+        proposer.max_num_tokens = 16
+        proposer.dcp_size = dcp_size
+        proposer.vllm_config.parallel_config.prefill_context_parallel_size = pcp_size
+        proposer.runner.device_metadata_executor = object() if has_executor else None
+        kv_cache_spec = MagicMock(block_size=128)
+        kv_cache_config = SimpleNamespace(
+            kv_cache_groups=[SimpleNamespace(layer_names=["L0"], kv_cache_spec=kv_cache_spec)]
+        )
+        builder = DraftBuilder()
+
+        with (
+            patch.object(AttentionGroup, "create_metadata_builders"),
+            patch.object(AttentionGroup, "get_metadata_builder", return_value=builder),
+            patch("vllm_ascend.spec_decode.dspark_proposer.AscendDSAMetadataBuilder", DraftBuilder),
+        ):
+            proposer.initialize_attn_backend(kv_cache_config)
+
+        assert builder.max_num_tokens == expected_tokens
 
     def test_model_without_draft_layer_names_raises(self, monkeypatch):
         # get_layers_from_vllm_config is called first; stub it so the model

--- a/tests/ut/test_ascend_forward_context.py
+++ b/tests/ut/test_ascend_forward_context.py
@@ -1,4 +1,6 @@
-from types import SimpleNamespace
+import sys
+from contextlib import contextmanager
+from types import ModuleType, SimpleNamespace
 
 import pytest
 
@@ -96,6 +98,40 @@ def _patch_select_moe_comm_method_deps(
         "get_ascend_config",
         lambda: SimpleNamespace(enable_fused_mc2=enable_fused_mc2, enable_prefill_mc2=enable_prefill_mc2),
     )
+
+
+def test_forward_context_exposes_device_metadata_executor(monkeypatch):
+    forward_context = SimpleNamespace(dp_metadata=None)
+    moe_comm_method = ModuleType("vllm_ascend.ops.fused_moe.moe_comm_method")
+    moe_comm_method.get_moe_comm_method = lambda comm_type: None
+
+    @contextmanager
+    def fake_set_forward_context(**kwargs):
+        yield
+
+    executor = object()
+    monkeypatch.setattr(afc, "set_forward_context", fake_set_forward_context)
+    monkeypatch.setattr(afc, "get_forward_context", lambda: forward_context)
+    monkeypatch.setattr(afc, "select_moe_comm_method", lambda *args, **kwargs: None)
+    monkeypatch.setattr(afc, "use_cann_megamoe", lambda config: False)
+    monkeypatch.setattr(afc, "is_moe_model", lambda config: False)
+    monkeypatch.setattr(afc, "get_tensor_model_parallel_world_size", lambda: 1)
+    monkeypatch.setattr(afc, "has_layer_idx", lambda model: False)
+    monkeypatch.setattr(afc, "get_dp_group", lambda: SimpleNamespace(world_size=1))
+    monkeypatch.setattr(afc, "get_mc2_mask", lambda: None)
+    monkeypatch.setitem(
+        sys.modules,
+        "vllm_ascend.ops.fused_moe.moe_comm_method",
+        moe_comm_method,
+    )
+
+    with afc.set_ascend_forward_context(
+        None,
+        _make_vllm_config(),
+        num_tokens=1,
+        device_metadata_executor=executor,
+    ):
+        assert forward_context.device_metadata_executor is executor
 
 
 def test_set_mc2_tokens_capacity_without_cudagraph_aligns_per_tp_rank():

--- a/tests/ut/test_ascend_forward_context.py
+++ b/tests/ut/test_ascend_forward_context.py
@@ -103,7 +103,7 @@ def _patch_select_moe_comm_method_deps(
 def test_forward_context_exposes_device_metadata_executor(monkeypatch):
     forward_context = SimpleNamespace(dp_metadata=None)
     moe_comm_method = ModuleType("vllm_ascend.ops.fused_moe.moe_comm_method")
-    moe_comm_method.get_moe_comm_method = lambda comm_type: None
+    moe_comm_method.__dict__["get_moe_comm_method"] = lambda comm_type: None
 
     @contextmanager
     def fake_set_forward_context(**kwargs):

--- a/tests/ut/worker/test_device_metadata.py
+++ b/tests/ut/worker/test_device_metadata.py
@@ -1,0 +1,261 @@
+#
+# Copyright (c) 2026 Huawei Technologies Co., Ltd. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from contextlib import nullcontext
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+import vllm_ascend.worker.device_metadata as device_metadata
+from vllm_ascend.worker.device_metadata import (
+    DeviceMetadataExecutor,
+    DeviceMetadataStage,
+    DeviceMetadataTask,
+    DeviceMetadataTaskProvider,
+    wait_for_device_metadata,
+)
+
+
+class _FakeStream:
+    def __init__(self, name: str, calls: list[tuple]) -> None:
+        self.name = name
+        self.calls = calls
+
+    def wait_event(self, event: "_FakeEvent") -> None:
+        self.calls.append((self.name, "wait", event.name))
+
+
+class _FakeEvent:
+    def __init__(self, name: str, calls: list[tuple]) -> None:
+        self.name = name
+        self.calls = calls
+
+    def record(self, stream: _FakeStream) -> None:
+        self.calls.append((stream.name, "record", self.name))
+
+
+@pytest.fixture
+def executor_env(monkeypatch):
+    calls: list[tuple] = []
+    allocations: list[str] = []
+    model_stream = _FakeStream("model", calls)
+    metadata_stream = _FakeStream("metadata", calls)
+    event_names = iter(("inputs", "reusable", "compressor", "indexer", "attention", "indexer-2"))
+
+    def make_stream():
+        allocations.append("stream")
+        return metadata_stream
+
+    def make_event():
+        name = next(event_names)
+        allocations.append(name)
+        return _FakeEvent(name, calls)
+
+    monkeypatch.setattr(torch.npu, "Stream", make_stream)
+    monkeypatch.setattr(torch.npu, "Event", make_event)
+    monkeypatch.setattr(torch.npu, "current_stream", lambda: model_stream)
+    monkeypatch.setattr(torch.npu, "stream", lambda stream: nullcontext())
+
+    return DeviceMetadataExecutor(), calls, allocations
+
+
+def _tasks(calls: list[tuple]) -> tuple[DeviceMetadataTask, ...]:
+    return (
+        DeviceMetadataTask(
+            DeviceMetadataStage.COMPRESSOR,
+            lambda: calls.append(("task", "compressor")),
+            1,
+        ),
+        DeviceMetadataTask(
+            DeviceMetadataStage.INDEXER,
+            lambda: calls.append(("task", "indexer")),
+            2,
+        ),
+        DeviceMetadataTask(
+            DeviceMetadataStage.ATTENTION,
+            lambda: calls.append(("task", "attention")),
+            3,
+        ),
+    )
+
+
+def test_submit_records_inputs_and_stage_frontiers(executor_env):
+    executor, calls, allocations = executor_env
+
+    assert allocations == ["stream", "inputs", "reusable"]
+    executor.submit(_tasks(calls))
+    assert allocations == ["stream", "inputs", "reusable", "compressor", "indexer", "attention"]
+
+    assert calls == [
+        ("model", "record", "inputs"),
+        ("metadata", "wait", "inputs"),
+        ("task", "compressor"),
+        ("metadata", "record", "compressor"),
+        ("task", "indexer"),
+        ("metadata", "record", "indexer"),
+        ("task", "attention"),
+        ("metadata", "record", "attention"),
+    ]
+
+
+def test_wait_and_release_fence_buffer_reuse(executor_env):
+    executor, calls, _ = executor_env
+    tasks = _tasks(calls)
+
+    executor.submit(tasks)
+    executor.wait(DeviceMetadataStage.INDEXER, 2)
+    executor.release()
+    assert calls[-2:] == [
+        ("model", "wait", "indexer"),
+        ("model", "record", "reusable"),
+    ]
+    calls.clear()
+    executor.submit(tasks)
+
+    assert calls[:3] == [
+        ("model", "record", "inputs"),
+        ("metadata", "wait", "inputs"),
+        ("metadata", "wait", "reusable"),
+    ]
+
+
+def test_wait_records_each_stage_once_per_submission(executor_env):
+    executor, calls, _ = executor_env
+    executor.submit(_tasks(calls))
+
+    executor.wait(DeviceMetadataStage.INDEXER, 2)
+    executor.wait(DeviceMetadataStage.INDEXER, 2)
+
+    assert calls.count(("model", "wait", "indexer")) == 1
+
+
+def test_submission_in_flight_tracks_release(executor_env):
+    executor, calls, _ = executor_env
+
+    assert not executor.submission_in_flight
+    executor.submit(_tasks(calls))
+    assert executor.submission_in_flight
+    executor.release()
+    assert not executor.submission_in_flight
+
+
+def test_executor_rejects_overlapping_submissions(executor_env):
+    executor, calls, _ = executor_env
+    tasks = _tasks(calls)
+    executor.submit(tasks)
+
+    with pytest.raises(RuntimeError, match="has not been released"):
+        executor.submit(tasks)
+
+
+def test_submit_failure_keeps_partial_submission_in_flight(executor_env):
+    executor, calls, _ = executor_env
+
+    def fail_task() -> None:
+        raise RuntimeError("task failed")
+
+    tasks = (
+        DeviceMetadataTask(
+            DeviceMetadataStage.COMPRESSOR,
+            lambda: calls.append(("task", "started")),
+            1,
+        ),
+        DeviceMetadataTask(DeviceMetadataStage.INDEXER, fail_task, 2),
+    )
+
+    with pytest.raises(RuntimeError, match="task failed"):
+        executor.submit(tasks)
+
+    assert executor.submission_in_flight
+    with pytest.raises(RuntimeError, match="has not been released"):
+        executor.submit(tasks)
+
+
+def test_submit_orders_tasks_by_stage(executor_env):
+    executor, calls, _ = executor_env
+    tasks = tuple(reversed(_tasks(calls)))
+
+    executor.submit(tasks)
+
+    assert [call for call in calls if call[0] == "task"] == [
+        ("task", "compressor"),
+        ("task", "indexer"),
+        ("task", "attention"),
+    ]
+
+
+def test_wait_uses_group_specific_frontier(executor_env):
+    executor, calls, _ = executor_env
+    tasks = (
+        DeviceMetadataTask(DeviceMetadataStage.INDEXER, lambda: None, 2),
+        DeviceMetadataTask(DeviceMetadataStage.INDEXER, lambda: None, 4),
+    )
+
+    executor.submit(tasks)
+    executor.wait(DeviceMetadataStage.INDEXER, 2)
+    executor.wait(DeviceMetadataStage.INDEXER, 4)
+
+    waits = [call for call in calls if call[:2] == ("model", "wait")]
+    assert len(waits) == 2
+    assert waits[0][2] != waits[1][2]
+
+
+def test_task_provider_is_structural():
+    class LegacyBuilder:
+        pass
+
+    class ProviderBuilder:
+        def enable_device_metadata(self):
+            pass
+
+        def take_device_metadata_tasks(self):
+            return (DeviceMetadataTask(DeviceMetadataStage.INDEXER, lambda: None, 1),)
+
+    assert not isinstance(LegacyBuilder(), DeviceMetadataTaskProvider)
+    assert isinstance(ProviderBuilder(), DeviceMetadataTaskProvider)
+
+
+def test_submit_rejects_empty_tasks(executor_env):
+    executor, _, _ = executor_env
+
+    with pytest.raises(ValueError, match="At least one"):
+        executor.submit(())
+
+
+def test_wait_helper_uses_active_forward_executor(monkeypatch):
+    calls = []
+    executor = SimpleNamespace(wait=lambda stage, group_id: calls.append((stage, group_id)))
+    monkeypatch.setattr(device_metadata, "is_forward_context_available", lambda: True)
+    monkeypatch.setattr(
+        device_metadata,
+        "get_forward_context",
+        lambda: SimpleNamespace(device_metadata_executor=executor),
+    )
+
+    wait_for_device_metadata(DeviceMetadataStage.ATTENTION, 7)
+
+    assert calls == [(DeviceMetadataStage.ATTENTION, 7)]
+
+
+def test_wait_helper_is_noop_without_forward_context(monkeypatch):
+    monkeypatch.setattr(device_metadata, "is_forward_context_available", lambda: False)
+    monkeypatch.setattr(
+        device_metadata,
+        "get_forward_context",
+        lambda: pytest.fail("forward context should not be read"),
+    )
+
+    wait_for_device_metadata(DeviceMetadataStage.ATTENTION, 7)

--- a/tests/ut/worker/test_device_metadata.py
+++ b/tests/ut/worker/test_device_metadata.py
@@ -25,7 +25,6 @@ from vllm_ascend.worker.device_metadata import (
     DeviceMetadataExecutor,
     DeviceMetadataStage,
     DeviceMetadataTask,
-    DeviceMetadataTaskProvider,
     wait_for_device_metadata,
 )
 
@@ -108,11 +107,12 @@ def _tasks(calls: list[tuple]) -> tuple[DeviceMetadataTask, ...]:
     )
 
 
-def test_submit_records_inputs_and_stage_frontiers(executor_env):
+def test_stream_lifecycle_and_stage_frontiers(executor_env):
     executor, calls, allocations = executor_env
-
     assert allocations == ["stream", "inputs", "reusable"]
-    executor.submit(_tasks(calls))
+    tasks = tuple(reversed(_tasks(calls)))
+    executor.submit(tasks)
+    assert executor.submission_in_flight
     assert allocations == ["stream", "inputs", "reusable", "compressor", "indexer", "attention"]
 
     assert calls == [
@@ -125,15 +125,13 @@ def test_submit_records_inputs_and_stage_frontiers(executor_env):
         ("task", "attention"),
         ("metadata", "record", "attention"),
     ]
-
-
-def test_wait_and_release_fence_buffer_reuse(executor_env):
-    executor, calls, _ = executor_env
-    tasks = _tasks(calls)
-
-    executor.submit(tasks)
     executor.wait(DeviceMetadataStage.INDEXER, 2)
+    executor.wait(DeviceMetadataStage.INDEXER, 2)
+    assert calls.count(("model", "wait", "indexer")) == 1
+    with pytest.raises(RuntimeError, match="has not been released"):
+        executor.submit(tasks)
     executor.release()
+    assert not executor.submission_in_flight
     assert calls[-2:] == [
         ("model", "wait", "indexer"),
         ("model", "record", "reusable"),
@@ -148,17 +146,7 @@ def test_wait_and_release_fence_buffer_reuse(executor_env):
     ]
 
 
-def test_wait_records_each_stage_once_per_submission(executor_env):
-    executor, calls, _ = executor_env
-    executor.submit(_tasks(calls))
-
-    executor.wait(DeviceMetadataStage.INDEXER, 2)
-    executor.wait(DeviceMetadataStage.INDEXER, 2)
-
-    assert calls.count(("model", "wait", "indexer")) == 1
-
-
-def test_external_events_bridge_full_graph_and_are_reused(executor_env):
+def test_external_events_are_reused_per_batch_descriptor(executor_env):
     executor, calls, allocations = executor_env
     descriptor = BatchDescriptor(num_tokens=4, num_reqs=4)
 
@@ -172,20 +160,14 @@ def test_external_events_bridge_full_graph_and_are_reused(executor_env):
         ("model", "reset", "external-1"),
     ]
     assert calls.count(("model", "external_wait", "external-1")) == 1
+    assert calls.count(("model", "reset", "external-1")) == 1
+    assert calls.index(("metadata", "record", "external-1")) < calls.index(("model", "external_wait", "external-1"))
     executor.release()
     assert not executor.uses_external_events
-
     executor.submit(_tasks(calls), descriptor)
     assert allocations.count("external-0") == 1
-
-
-def test_external_events_are_isolated_by_batch_descriptor(executor_env):
-    executor, calls, allocations = executor_env
-
-    executor.submit(_tasks(calls), BatchDescriptor(num_tokens=4, num_reqs=4))
     executor.release()
     executor.submit(_tasks(calls), BatchDescriptor(num_tokens=8, num_reqs=4))
-
     assert allocations[-3:] == ["external-3", "external-4", "external-5"]
 
 
@@ -204,25 +186,6 @@ def test_external_event_frontiers_must_remain_stable(executor_env):
     assert calls == []
     assert allocations == allocations_before
     assert not executor.submission_in_flight
-
-
-def test_submission_in_flight_tracks_release(executor_env):
-    executor, calls, _ = executor_env
-
-    assert not executor.submission_in_flight
-    executor.submit(_tasks(calls))
-    assert executor.submission_in_flight
-    executor.release()
-    assert not executor.submission_in_flight
-
-
-def test_executor_rejects_overlapping_submissions(executor_env):
-    executor, calls, _ = executor_env
-    tasks = _tasks(calls)
-    executor.submit(tasks)
-
-    with pytest.raises(RuntimeError, match="has not been released"):
-        executor.submit(tasks)
 
 
 def test_submit_failure_keeps_partial_submission_in_flight(executor_env):
@@ -248,19 +211,6 @@ def test_submit_failure_keeps_partial_submission_in_flight(executor_env):
         executor.submit(tasks)
 
 
-def test_submit_orders_tasks_by_stage(executor_env):
-    executor, calls, _ = executor_env
-    tasks = tuple(reversed(_tasks(calls)))
-
-    executor.submit(tasks)
-
-    assert [call for call in calls if call[0] == "task"] == [
-        ("task", "compressor"),
-        ("task", "indexer"),
-        ("task", "attention"),
-    ]
-
-
 def test_wait_uses_group_specific_frontier(executor_env):
     executor, calls, _ = executor_env
     tasks = (
@@ -275,21 +225,6 @@ def test_wait_uses_group_specific_frontier(executor_env):
     waits = [call for call in calls if call[:2] == ("model", "wait")]
     assert len(waits) == 2
     assert waits[0][2] != waits[1][2]
-
-
-def test_task_provider_is_structural():
-    class LegacyBuilder:
-        pass
-
-    class ProviderBuilder:
-        def enable_device_metadata(self):
-            pass
-
-        def take_device_metadata_tasks(self):
-            return (DeviceMetadataTask(DeviceMetadataStage.INDEXER, lambda: None, 1),)
-
-    assert not isinstance(LegacyBuilder(), DeviceMetadataTaskProvider)
-    assert isinstance(ProviderBuilder(), DeviceMetadataTaskProvider)
 
 
 def test_submit_rejects_empty_tasks(executor_env):

--- a/tests/ut/worker/test_device_metadata.py
+++ b/tests/ut/worker/test_device_metadata.py
@@ -18,6 +18,7 @@ from types import SimpleNamespace
 
 import pytest
 import torch
+from vllm.forward_context import BatchDescriptor
 
 import vllm_ascend.worker.device_metadata as device_metadata
 from vllm_ascend.worker.device_metadata import (
@@ -47,6 +48,14 @@ class _FakeEvent:
         self.calls.append((stream.name, "record", self.name))
 
 
+class _FakeExternalEvent(_FakeEvent):
+    def wait(self, stream: _FakeStream) -> None:
+        self.calls.append((stream.name, "external_wait", self.name))
+
+    def reset(self, stream: _FakeStream) -> None:
+        self.calls.append((stream.name, "reset", self.name))
+
+
 @pytest.fixture
 def executor_env(monkeypatch):
     calls: list[tuple] = []
@@ -54,6 +63,7 @@ def executor_env(monkeypatch):
     model_stream = _FakeStream("model", calls)
     metadata_stream = _FakeStream("metadata", calls)
     event_names = iter(("inputs", "reusable", "compressor", "indexer", "attention", "indexer-2"))
+    external_event_names = iter(f"external-{index}" for index in range(6))
 
     def make_stream():
         allocations.append("stream")
@@ -64,8 +74,14 @@ def executor_env(monkeypatch):
         allocations.append(name)
         return _FakeEvent(name, calls)
 
+    def make_external_event():
+        name = next(external_event_names)
+        allocations.append(name)
+        return _FakeExternalEvent(name, calls)
+
     monkeypatch.setattr(torch.npu, "Stream", make_stream)
     monkeypatch.setattr(torch.npu, "Event", make_event)
+    monkeypatch.setattr(torch.npu, "ExternalEvent", make_external_event, raising=False)
     monkeypatch.setattr(torch.npu, "current_stream", lambda: model_stream)
     monkeypatch.setattr(torch.npu, "stream", lambda stream: nullcontext())
 
@@ -140,6 +156,54 @@ def test_wait_records_each_stage_once_per_submission(executor_env):
     executor.wait(DeviceMetadataStage.INDEXER, 2)
 
     assert calls.count(("model", "wait", "indexer")) == 1
+
+
+def test_external_events_bridge_full_graph_and_are_reused(executor_env):
+    executor, calls, allocations = executor_env
+    descriptor = BatchDescriptor(num_tokens=4, num_reqs=4)
+
+    executor.submit(_tasks(calls), descriptor)
+    assert executor.uses_external_events
+    assert allocations[-3:] == ["external-0", "external-1", "external-2"]
+    executor.wait(DeviceMetadataStage.INDEXER, 2)
+    executor.wait(DeviceMetadataStage.INDEXER, 2)
+    assert calls[-2:] == [
+        ("model", "external_wait", "external-1"),
+        ("model", "reset", "external-1"),
+    ]
+    assert calls.count(("model", "external_wait", "external-1")) == 1
+    executor.release()
+    assert not executor.uses_external_events
+
+    executor.submit(_tasks(calls), descriptor)
+    assert allocations.count("external-0") == 1
+
+
+def test_external_events_are_isolated_by_batch_descriptor(executor_env):
+    executor, calls, allocations = executor_env
+
+    executor.submit(_tasks(calls), BatchDescriptor(num_tokens=4, num_reqs=4))
+    executor.release()
+    executor.submit(_tasks(calls), BatchDescriptor(num_tokens=8, num_reqs=4))
+
+    assert allocations[-3:] == ["external-3", "external-4", "external-5"]
+
+
+def test_external_event_frontiers_must_remain_stable(executor_env):
+    executor, calls, allocations = executor_env
+    descriptor = BatchDescriptor(num_tokens=4, num_reqs=4)
+
+    executor.submit(_tasks(calls), descriptor)
+    executor.release()
+    calls.clear()
+    allocations_before = list(allocations)
+
+    with pytest.raises(RuntimeError, match="frontiers changed"):
+        executor.submit(_tasks(calls)[:-1], descriptor)
+
+    assert calls == []
+    assert allocations == allocations_before
+    assert not executor.submission_in_flight
 
 
 def test_submission_in_flight_tracks_release(executor_env):

--- a/tests/ut/worker/test_device_metadata_runner.py
+++ b/tests/ut/worker/test_device_metadata_runner.py
@@ -1,0 +1,314 @@
+from contextlib import contextmanager, nullcontext
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import numpy as np
+import pytest
+import torch
+from vllm.config import CUDAGraphMode
+
+from vllm_ascend.worker import model_runner_v1
+from vllm_ascend.worker.model_runner_v1 import NPUModelRunner
+
+
+@contextmanager
+def _record_forward_context(trace, *args, **kwargs):
+    trace.executors.append(kwargs["device_metadata_executor"])
+    trace.events.append("context-enter")
+    try:
+        yield
+    finally:
+        trace.events.append("context-exit")
+
+
+def _make_executor(active: bool, trace):
+    return SimpleNamespace(
+        submission_in_flight=active,
+        release=MagicMock(side_effect=lambda: trace.events.append("release")),
+    )
+
+
+def _make_execute_runner(executor, trace, forward_error=None):
+    runner = NPUModelRunner.__new__(NPUModelRunner)
+    model_config = SimpleNamespace(
+        enable_return_routed_experts=False,
+        enforce_eager=False,
+        is_encoder_decoder=False,
+        use_mla=True,
+    )
+    runner.vllm_config = SimpleNamespace(model_config=model_config)
+    runner.model_config = model_config
+    runner.ascend_config = SimpleNamespace(
+        scheduler_config=SimpleNamespace(
+            profiling_chunk_config=SimpleNamespace(need_timing=False)
+        )
+    )
+    runner.execute_model_state = None
+    runner.speculative_config = None
+    runner.use_async_scheduling = False
+    runner.num_spec_tokens = 0
+    runner._draft_token_ids = None
+    runner.parallel_config = SimpleNamespace(
+        distributed_executor_backend=None,
+        data_parallel_size=1,
+        enable_dbo=False,
+        num_ubatches=1,
+    )
+    runner.cache_config = SimpleNamespace(
+        kv_sharing_fast_prefill=False,
+        mamba_cache_mode="none",
+    )
+    runner.input_batch = SimpleNamespace(
+        num_reqs=1,
+        req_ids=["req"],
+        prev_req_id_to_index=None,
+        num_computed_tokens_cpu=np.zeros(1, dtype=np.int32),
+    )
+    runner.requests = {}
+    runner.synchronize_input_prep = nullcontext
+    runner._update_states = MagicMock(return_value=None)
+    runner._start_dump_data = MagicMock()
+    runner._prepare_inputs = MagicMock(return_value=(slice(None), None, 1))
+    runner.cascade_attn_enabled = False
+    batch_desc = SimpleNamespace(num_tokens=1, num_reqs=1)
+    runner._determine_batch_execution_and_padding = MagicMock(
+        return_value=(CUDAGraphMode.NONE, batch_desc, False, None, None)
+    )
+    runner.dynamic_eplb = False
+    runner.use_compress = False
+    runner.dcp_size = 1
+    runner._build_attention_metadata = MagicMock(return_value=("metadata", None))
+    runner._sanitize_placeholder_input_ids_for_forward = MagicMock()
+    runner._preprocess = MagicMock(
+        return_value=(torch.zeros(1, dtype=torch.int64), None, torch.zeros(1), None, {}, None)
+    )
+    runner.calculate_kv_scales = False
+    runner.broadcast_pp_output = False
+    runner.device_metadata_executor = executor
+    runner._has_sinks = False
+    runner.eplb_heat_collection_status = False
+    runner.maybe_get_kv_connector_output = MagicMock(
+        return_value=nullcontext(SimpleNamespace())
+    )
+    runner.model = MagicMock()
+    def model_forward(*args, **kwargs):
+        trace.events.append("model-forward")
+        if forward_error is not None:
+            raise forward_error
+        return torch.zeros((1, 1))
+
+    runner._model_forward = MagicMock(side_effect=model_forward)
+    runner.use_aux_hidden_state_outputs = False
+    runner.is_pooling_model = True
+    runner._pool = MagicMock(return_value=SimpleNamespace(kv_connector_output=None))
+    runner._finalize_dump_data = MagicMock()
+    return runner
+
+
+def _make_dummy_runner(executor, trace, mode, forward_error=None):
+    runner = NPUModelRunner.__new__(NPUModelRunner)
+    runner.uniform_decode_query_len = 1
+    runner.scheduler_config = SimpleNamespace(
+        max_num_batched_tokens=4,
+        max_num_seqs=4,
+    )
+    runner.dynamic_eplb = False
+    batch_desc = SimpleNamespace(num_tokens=1, num_reqs=1)
+    runner._determine_batch_execution_and_padding = MagicMock(
+        return_value=(mode, batch_desc, False, None, None)
+    )
+    runner.use_dcp = False
+    runner.speculative_config = None
+    runner.synchronize_input_prep = nullcontext
+    runner.optimistic_seq_lens_cpu = torch.zeros(4, dtype=torch.int32)
+    runner.seq_lens = MagicMock()
+    runner.query_pos = SimpleNamespace(np=np.zeros(1, dtype=np.int32))
+    runner.query_start_loc = SimpleNamespace(
+        np=np.zeros(5, dtype=np.int32),
+        copy_to_gpu=MagicMock(),
+    )
+    runner._get_cumsum_and_arange = MagicMock(
+        return_value=np.ones(1, dtype=np.int32)
+    )
+    runner._has_gdn = False
+    runner._pad_query_start_loc_for_fia = MagicMock(return_value=1)
+    runner.input_batch = SimpleNamespace(
+        block_table=SimpleNamespace(commit_block_table=MagicMock())
+    )
+    runner.kv_cache_config = SimpleNamespace(kv_cache_groups=[])
+
+    def build_metadata(*args, **kwargs):
+        trace.events.append("metadata-build")
+        executor.submission_in_flight = True
+        return "metadata", None
+
+    runner._build_attention_metadata = MagicMock(side_effect=build_metadata)
+    runner.maybe_dummy_run_with_lora = MagicMock(return_value=nullcontext())
+    runner.lora_config = None
+    runner.supports_mm_inputs = False
+    runner.model_config = SimpleNamespace(is_encoder_decoder=False)
+    runner.enable_prompt_embeds = False
+    runner.input_ids = SimpleNamespace(gpu=torch.zeros(1, dtype=torch.int64))
+    runner.positions = torch.zeros(1)
+    runner.uses_mrope = False
+    runner.uses_xdrope_dim = 0
+    runner.model = MagicMock()
+    runner.vllm_config = SimpleNamespace(model_config=runner.model_config)
+    runner.device_metadata_executor = executor
+    runner._has_sinks = False
+    runner.eplb_heat_collection_status = False
+    def model_forward(*args, **kwargs):
+        trace.events.append("model-forward")
+        if forward_error is not None:
+            raise forward_error
+        return torch.zeros((1, 1))
+
+    runner._model_forward = MagicMock(side_effect=model_forward)
+    runner.use_aux_hidden_state_outputs = False
+    runner.drafter = None
+    runner.use_compress = False
+    return runner
+
+
+@pytest.fixture
+def forward_patches(monkeypatch):
+    trace = SimpleNamespace(executors=[], events=[])
+    pp_group = SimpleNamespace(world_size=1, is_first_rank=True, is_last_rank=True)
+    monkeypatch.setattr(model_runner_v1, "get_pp_group", lambda: pp_group)
+    monkeypatch.setattr(model_runner_v1, "has_kv_transfer_group", lambda: False)
+    monkeypatch.setattr(model_runner_v1, "has_ec_transfer", lambda: False)
+    monkeypatch.setattr(model_runner_v1, "enable_sp", lambda *args: False)
+    monkeypatch.setattr(
+        model_runner_v1,
+        "maybe_create_ubatch_slices",
+        lambda *args, **kwargs: (None, None),
+    )
+    monkeypatch.setattr(model_runner_v1, "update_cos_sin", lambda *args: None)
+    monkeypatch.setattr(model_runner_v1, "using_paged_attention", lambda *args: False)
+    monkeypatch.setattr(model_runner_v1, "lmhead_tp_enable", lambda: False)
+    monkeypatch.setattr(
+        model_runner_v1,
+        "record_function_or_nullcontext",
+        lambda *args: nullcontext(),
+    )
+    monkeypatch.setattr(
+        model_runner_v1,
+        "set_ascend_forward_context",
+        lambda *args, **kwargs: _record_forward_context(
+            trace, *args, **kwargs
+        ),
+    )
+    return trace
+
+
+@pytest.mark.parametrize("active", [True, False])
+def test_execute_model_releases_only_active_submission(forward_patches, active):
+    executor = _make_executor(active, forward_patches)
+    runner = _make_execute_runner(executor, forward_patches)
+    scheduler_output = SimpleNamespace(
+        total_num_scheduled_tokens=1,
+        num_scheduled_tokens={"req": 1},
+        scheduled_cached_reqs=SimpleNamespace(new_token_ids=[]),
+        scheduled_spec_decode_tokens=[],
+        scheduled_encoder_inputs=[],
+        num_common_prefix_blocks=0,
+    )
+
+    runner.execute_model(scheduler_output)
+
+    assert forward_patches.executors == [executor if active else None]
+    assert forward_patches.events == [
+        "context-enter",
+        "model-forward",
+        "context-exit",
+        *(["release"] if active else []),
+    ]
+    assert executor.release.call_count == int(active)
+
+
+def test_execute_model_does_not_release_failed_forward(forward_patches):
+    executor = _make_executor(True, forward_patches)
+    runner = _make_execute_runner(
+        executor, forward_patches, RuntimeError("forward failed")
+    )
+    scheduler_output = SimpleNamespace(
+        total_num_scheduled_tokens=1,
+        num_scheduled_tokens={"req": 1},
+        scheduled_cached_reqs=SimpleNamespace(new_token_ids=[]),
+        scheduled_spec_decode_tokens=[],
+        scheduled_encoder_inputs=[],
+        num_common_prefix_blocks=0,
+    )
+
+    with pytest.raises(RuntimeError, match="forward failed"):
+        runner.execute_model(scheduler_output)
+
+    assert forward_patches.executors == [executor]
+    assert forward_patches.events == [
+        "context-enter",
+        "model-forward",
+        "context-exit",
+    ]
+    executor.release.assert_not_called()
+
+
+@pytest.mark.parametrize(
+    ("is_profile", "mode", "is_graph_capturing", "expected_events"),
+    [
+        (
+            False,
+            CUDAGraphMode.FULL,
+            True,
+            ["metadata-build", "context-enter", "model-forward", "context-exit", "release"],
+        ),
+        (True, CUDAGraphMode.NONE, False, ["context-enter", "model-forward", "context-exit"]),
+        (False, CUDAGraphMode.PIECEWISE, True, ["context-enter", "model-forward", "context-exit"]),
+    ],
+)
+def test_dummy_run_releases_only_active_submission(
+    forward_patches,
+    is_profile,
+    mode,
+    is_graph_capturing,
+    expected_events,
+):
+    executor = _make_executor(False, forward_patches)
+    runner = _make_dummy_runner(executor, forward_patches, mode)
+
+    runner._dummy_run(
+        1,
+        cudagraph_runtime_mode=mode,
+        is_profile=is_profile,
+        is_graph_capturing=is_graph_capturing,
+    )
+
+    active = mode == CUDAGraphMode.FULL
+    assert forward_patches.executors == [executor if active else None]
+    assert forward_patches.events == expected_events
+    assert executor.release.call_count == int(active)
+
+
+def test_dummy_run_does_not_release_failed_forward(forward_patches):
+    executor = _make_executor(False, forward_patches)
+    runner = _make_dummy_runner(
+        executor,
+        forward_patches,
+        CUDAGraphMode.FULL,
+        RuntimeError("forward failed"),
+    )
+
+    with pytest.raises(RuntimeError, match="forward failed"):
+        runner._dummy_run(
+            1,
+            cudagraph_runtime_mode=CUDAGraphMode.FULL,
+            is_graph_capturing=True,
+        )
+
+    assert forward_patches.executors == [executor]
+    assert forward_patches.events == [
+        "metadata-build",
+        "context-enter",
+        "model-forward",
+        "context-exit",
+    ]
+    executor.release.assert_not_called()

--- a/tests/ut/worker/test_device_metadata_runner.py
+++ b/tests/ut/worker/test_device_metadata_runner.py
@@ -21,9 +21,10 @@ def _record_forward_context(trace, *args, **kwargs):
         trace.events.append("context-exit")
 
 
-def _make_executor(active: bool, trace):
+def _make_executor(active: bool, trace, uses_external_events: bool = False):
     return SimpleNamespace(
         submission_in_flight=active,
+        uses_external_events=uses_external_events,
         release=MagicMock(side_effect=lambda: trace.events.append("release")),
     )
 
@@ -39,9 +40,7 @@ def _make_execute_runner(executor, trace, forward_error=None):
     runner.vllm_config = SimpleNamespace(model_config=model_config)
     runner.model_config = model_config
     runner.ascend_config = SimpleNamespace(
-        scheduler_config=SimpleNamespace(
-            profiling_chunk_config=SimpleNamespace(need_timing=False)
-        )
+        scheduler_config=SimpleNamespace(profiling_chunk_config=SimpleNamespace(need_timing=False))
     )
     runner.execute_model_state = None
     runner.speculative_config = None
@@ -87,10 +86,9 @@ def _make_execute_runner(executor, trace, forward_error=None):
     runner.device_metadata_executor = executor
     runner._has_sinks = False
     runner.eplb_heat_collection_status = False
-    runner.maybe_get_kv_connector_output = MagicMock(
-        return_value=nullcontext(SimpleNamespace())
-    )
+    runner.maybe_get_kv_connector_output = MagicMock(return_value=nullcontext(SimpleNamespace()))
     runner.model = MagicMock()
+
     def model_forward(*args, **kwargs):
         trace.events.append("model-forward")
         if forward_error is not None:
@@ -115,9 +113,7 @@ def _make_dummy_runner(executor, trace, mode, forward_error=None):
     runner.max_num_tokens = 4
     runner.dynamic_eplb = False
     batch_desc = SimpleNamespace(num_tokens=1, num_reqs=1)
-    runner._determine_batch_execution_and_padding = MagicMock(
-        return_value=(mode, batch_desc, False, None, None)
-    )
+    runner._determine_batch_execution_and_padding = MagicMock(return_value=(mode, batch_desc, False, None, None))
     runner.dcp_size = 1
     runner.speculative_config = None
     runner.synchronize_input_prep = nullcontext
@@ -128,19 +124,16 @@ def _make_dummy_runner(executor, trace, mode, forward_error=None):
         np=np.zeros(5, dtype=np.int32),
         copy_to_gpu=MagicMock(),
     )
-    runner._get_cumsum_and_arange = MagicMock(
-        return_value=np.ones(1, dtype=np.int32)
-    )
+    runner._get_cumsum_and_arange = MagicMock(return_value=np.ones(1, dtype=np.int32))
     runner._has_gdn = False
     runner._pad_query_start_loc_for_fia = MagicMock(return_value=1)
-    runner.input_batch = SimpleNamespace(
-        block_table=SimpleNamespace(commit_block_table=MagicMock())
-    )
+    runner.input_batch = SimpleNamespace(block_table=SimpleNamespace(commit_block_table=MagicMock()))
     runner.kv_cache_config = SimpleNamespace(kv_cache_groups=[])
 
     def build_metadata(*args, **kwargs):
         trace.events.append("metadata-build")
         executor.submission_in_flight = True
+        executor.uses_external_events = kwargs["batch_descriptor"] is not None
         return "metadata", None
 
     runner._build_attention_metadata = MagicMock(side_effect=build_metadata)
@@ -158,6 +151,7 @@ def _make_dummy_runner(executor, trace, mode, forward_error=None):
     runner.device_metadata_executor = executor
     runner._has_sinks = False
     runner.eplb_heat_collection_status = False
+
     def model_forward(*args, **kwargs):
         trace.events.append("model-forward")
         if forward_error is not None:
@@ -170,6 +164,40 @@ def _make_dummy_runner(executor, trace, mode, forward_error=None):
     runner.use_compress = False
     runner._finalize_dump_data = MagicMock()
     return runner
+
+
+@pytest.mark.parametrize(
+    ("mode", "uses_external_events", "should_raise"),
+    [
+        (CUDAGraphMode.FULL, False, True),
+        (CUDAGraphMode.FULL, True, False),
+        (CUDAGraphMode.PIECEWISE, False, False),
+        (CUDAGraphMode.NONE, False, False),
+    ],
+)
+def test_full_mode_requires_external_events(mode, uses_external_events, should_raise):
+    runner = NPUModelRunner.__new__(NPUModelRunner)
+    executor = SimpleNamespace(
+        submission_in_flight=True,
+        uses_external_events=uses_external_events,
+    )
+    runner.device_metadata_executor = executor
+
+    if should_raise:
+        with pytest.raises(RuntimeError, match="requires external events"):
+            runner._prepare_device_metadata_for_forward(mode)
+    else:
+        assert runner._prepare_device_metadata_for_forward(mode) is executor
+
+
+def test_inactive_executor_is_not_forwarded():
+    runner = NPUModelRunner.__new__(NPUModelRunner)
+    runner.device_metadata_executor = SimpleNamespace(
+        submission_in_flight=False,
+        uses_external_events=False,
+    )
+
+    assert runner._prepare_device_metadata_for_forward(CUDAGraphMode.FULL) is None
 
 
 @pytest.fixture
@@ -196,9 +224,7 @@ def forward_patches(monkeypatch):
     monkeypatch.setattr(
         model_runner_v1,
         "set_ascend_forward_context",
-        lambda *args, **kwargs: _record_forward_context(
-            trace, *args, **kwargs
-        ),
+        lambda *args, **kwargs: _record_forward_context(trace, *args, **kwargs),
     )
     return trace
 
@@ -230,9 +256,7 @@ def test_execute_model_releases_only_active_submission(forward_patches, active):
 
 def test_execute_model_does_not_release_failed_forward(forward_patches):
     executor = _make_executor(True, forward_patches)
-    runner = _make_execute_runner(
-        executor, forward_patches, RuntimeError("forward failed")
-    )
+    runner = _make_execute_runner(executor, forward_patches, RuntimeError("forward failed"))
     scheduler_output = SimpleNamespace(
         total_num_scheduled_tokens=1,
         num_scheduled_tokens={"req": 1},

--- a/tests/ut/worker/test_device_metadata_runner.py
+++ b/tests/ut/worker/test_device_metadata_runner.py
@@ -105,6 +105,7 @@ def _make_execute_runner(executor, trace, forward_error=None):
 
 def _make_dummy_runner(executor, trace, mode, forward_error=None):
     runner = NPUModelRunner.__new__(NPUModelRunner)
+    runner.device = torch.device("cpu")
     runner.uniform_decode_query_len = 1
     runner.scheduler_config = SimpleNamespace(
         max_num_batched_tokens=4,

--- a/tests/ut/worker/test_device_metadata_runner.py
+++ b/tests/ut/worker/test_device_metadata_runner.py
@@ -112,12 +112,13 @@ def _make_dummy_runner(executor, trace, mode, forward_error=None):
         max_num_batched_tokens=4,
         max_num_seqs=4,
     )
+    runner.max_num_tokens = 4
     runner.dynamic_eplb = False
     batch_desc = SimpleNamespace(num_tokens=1, num_reqs=1)
     runner._determine_batch_execution_and_padding = MagicMock(
         return_value=(mode, batch_desc, False, None, None)
     )
-    runner.use_dcp = False
+    runner.dcp_size = 1
     runner.speculative_config = None
     runner.synchronize_input_prep = nullcontext
     runner.optimistic_seq_lens_cpu = torch.zeros(4, dtype=torch.int32)
@@ -167,6 +168,7 @@ def _make_dummy_runner(executor, trace, mode, forward_error=None):
     runner.use_aux_hidden_state_outputs = False
     runner.drafter = None
     runner.use_compress = False
+    runner._finalize_dump_data = MagicMock()
     return runner
 
 

--- a/vllm_ascend/ascend_forward_context.py
+++ b/vllm_ascend/ascend_forward_context.py
@@ -112,6 +112,7 @@ def set_ascend_forward_context(
     skip_compiled: bool = False,
     max_tokens_across_pcp: int = 0,
     draft_attn_metadatas=None,
+    device_metadata_executor=None,
     has_sinks=False,
     input_ids=None,
     eplb_heat_collection_status: bool = False,
@@ -132,6 +133,7 @@ def set_ascend_forward_context(
     with set_forward_context(**forward_context_kwargs):
         forward_context = get_forward_context()
         forward_context.draft_attn_metadatas = draft_attn_metadatas
+        forward_context.device_metadata_executor = device_metadata_executor
 
         forward_context.input_ids = input_ids
 

--- a/vllm_ascend/attention/context_parallel/dsa_cp.py
+++ b/vllm_ascend/attention/context_parallel/dsa_cp.py
@@ -7,7 +7,7 @@ import torch
 import torch.distributed as dist
 import torch.nn.functional as F
 import torch_npu
-from vllm.config import VllmConfig, get_current_vllm_config
+from vllm.config import CUDAGraphMode, VllmConfig, get_current_vllm_config
 from vllm.distributed import get_tp_group
 from vllm.triton_utils import HAS_TRITON, triton
 from vllm.v1.attention.backend import AttentionCGSupport, AttentionMetadataBuilder
@@ -16,6 +16,8 @@ from vllm.v1.kv_cache_interface import AttentionSpec
 from vllm_ascend.attention.abstract import DSAAttentionImpl
 from vllm_ascend.attention.attention_v1 import AscendAttentionState
 from vllm_ascend.attention.dsa_v1 import (
+    CompressorMetadataOutput,
+    build_compressor_metadata_out,
     build_dspark_swa_indices,
     get_dspark_sparse_sas_window,
     get_or_compute_compressor_metadata,
@@ -110,6 +112,8 @@ class AscendDSAReqMetadata:
     qli_seqused_k: torch.Tensor = None
     qli_cmp_residual_k: torch.Tensor = None
     device_local_metadata_group_id: int | None = None
+    compressor_metadata: CompressorMetadataOutput | None = None
+    compressor_metadata_group_id: int | None = None
     cu_cmp_seqlen_list: torch.Tensor = None
     attn_mask: torch.Tensor | None = None
     ori_win_left: int | None = None
@@ -278,6 +282,7 @@ class AscendDSACPMetadataBuilder(AttentionMetadataBuilder[AscendDSAMetadata]):
         # Note(qcs): we use two dimension slot_mapping for kvcache with shape
         # [block_nums, block_size, head_num, head_dim]
         self.slot_mapping = torch.zeros(self.slot_mapping_shape, dtype=torch.int32, device=self.device)
+        self.compressor_metadata_buffers: CompressorMetadataOutput | None = None
 
     @classmethod
     def get_cudagraph_support(
@@ -363,6 +368,7 @@ class AscendDSACPMetadataBuilder(AttentionMetadataBuilder[AscendDSAMetadata]):
             attn_state,
             cos=cos,
             sin=sin,
+            full_graph_mode=kwargs.get("full_graph_mode", False),
         )
 
         return self.metadata_cls(  # type: ignore
@@ -695,6 +701,7 @@ class AscendDSACPMetadataBuilder(AttentionMetadataBuilder[AscendDSAMetadata]):
         attn_state: AscendAttentionState,
         cos: RopeDataProxy,
         sin: RopeDataProxy,
+        full_graph_mode: bool = False,
     ) -> AscendDSAReqMetadata:
         """Build a single unified metadata for all requests (prefill + decode)."""
         num_reqs = common_attn_metadata.num_reqs
@@ -779,7 +786,14 @@ class AscendDSACPMetadataBuilder(AttentionMetadataBuilder[AscendDSAMetadata]):
             layer_name = f"c{self.compressor_ratio}"
             # Keep only graph inputs here. The compressor metadata op itself is
             # launched in forward at the real compressor consumer.
-            num_compressed_tokens = self._num_compressor_metadata_rows(common_attn_metadata)
+            if full_graph_mode:
+                num_compressed_tokens = min(
+                    num_input_tokens,
+                    num_input_tokens // self.compressor_ratio + num_reqs,
+                )
+                num_reqs_actual = num_reqs
+            else:
+                num_compressed_tokens = self._num_compressor_metadata_rows(common_attn_metadata)
             full_compress_cos, full_compress_sin = get_full_cos_and_sin_dsa(layer_name)
             slot_mapping = None
         else:
@@ -865,7 +879,7 @@ class AscendDSACPMetadataBuilder(AttentionMetadataBuilder[AscendDSAMetadata]):
             local_cos=local_cos,
         )
 
-        return AscendDSAReqMetadata(
+        req_metadata = AscendDSAReqMetadata(
             input_positions=input_positions,
             block_table=self.block_table[:num_reqs, ...],
             slot_mapping=slot_mapping,
@@ -889,9 +903,45 @@ class AscendDSACPMetadataBuilder(AttentionMetadataBuilder[AscendDSAMetadata]):
             device_local_metadata_group_id=local_group_id,
             cu_cmp_seqlen_list=cu_cmp_seqlens,
         )
+        if self._device_metadata_enabled and self.compressor_metadata_buffers is not None:
+            assert num_compressed_tokens is not None
+            buffers = self.compressor_metadata_buffers
+            outputs = (
+                buffers[0][:num_compressed_tokens],
+                buffers[1][:num_compressed_tokens],
+                buffers[2][:num_compressed_tokens],
+            )
+            group_id = id(buffers[0])
+            req_metadata.compressor_metadata = outputs
+            req_metadata.compressor_metadata_group_id = group_id
+            compressor_task = DeviceMetadataTask(
+                DeviceMetadataStage.COMPRESSOR,
+                lambda: build_compressor_metadata_out(req_metadata, self.compressor_ratio, outputs),
+                group_id,
+            )
+            # start_pos is produced by the first local-metadata task.
+            self._device_metadata_tasks = (
+                self._device_metadata_tasks[0],
+                compressor_task,
+                *self._device_metadata_tasks[1:],
+            )
+        return req_metadata
 
     def enable_device_metadata(self) -> None:
         self._device_metadata_enabled = True
+        if self.compressor_ratio <= 1 or self.vllm_config.compilation_config.cudagraph_mode == CUDAGraphMode.FULL:
+            return
+        output_shape = (
+            self.vllm_config.scheduler_config.max_num_batched_tokens,
+            1,
+            1,
+            self.model_config.hf_config.qk_rope_head_dim,
+        )
+        self.compressor_metadata_buffers = (
+            torch.empty(output_shape, dtype=torch.float32, device=self.device),
+            torch.empty(output_shape, dtype=torch.float32, device=self.device),
+            self.slot_mapping,
+        )
 
     def take_device_metadata_tasks(self) -> tuple[DeviceMetadataTask, ...]:
         tasks = self._device_metadata_tasks
@@ -1262,6 +1312,13 @@ class AscendDSACPImpl(DSAAttentionImpl):
         self,
         metadata: AscendDSAReqMetadata,
     ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+        if metadata.compressor_metadata is not None:
+            assert metadata.compressor_metadata_group_id is not None
+            wait_for_device_metadata(
+                DeviceMetadataStage.COMPRESSOR,
+                metadata.compressor_metadata_group_id,
+            )
+            return metadata.compressor_metadata
         if metadata.device_local_metadata_group_id is not None:
             wait_for_device_metadata(
                 DeviceMetadataStage.COMPRESSOR,

--- a/vllm_ascend/attention/context_parallel/dsa_cp.py
+++ b/vllm_ascend/attention/context_parallel/dsa_cp.py
@@ -1,4 +1,5 @@
 import math
+from collections.abc import Callable
 from dataclasses import dataclass
 from typing import ClassVar, TypeVar
 
@@ -40,6 +41,7 @@ from vllm_ascend.utils import (
     get_ascend_device_type,
     olora_tp_enable,
 )
+from vllm_ascend.worker.device_metadata import DeviceMetadataStage, DeviceMetadataTask, wait_for_device_metadata
 
 
 def hadamard_transform_ref(
@@ -107,6 +109,7 @@ class AscendDSAReqMetadata:
     qli_cu_seqlens_q: torch.Tensor = None
     qli_seqused_k: torch.Tensor = None
     qli_cmp_residual_k: torch.Tensor = None
+    device_local_metadata_group_id: int | None = None
     cu_cmp_seqlen_list: torch.Tensor = None
     attn_mask: torch.Tensor | None = None
     ori_win_left: int | None = None
@@ -240,6 +243,8 @@ class AscendDSACPMetadataBuilder(AttentionMetadataBuilder[AscendDSAMetadata]):
             scheduler_config.max_num_seqs + 1, dtype=torch.int32, device=self.device
         )
         self.local_seq_lens = torch.zeros(scheduler_config.max_num_seqs, dtype=torch.int32, device=self.device)
+        self._device_metadata_enabled = False
+        self._device_metadata_tasks: tuple[DeviceMetadataTask, ...] = ()
 
         self.speculative_config = vllm_config.speculative_config
         self.decode_threshold = 1
@@ -618,46 +623,58 @@ class AscendDSACPMetadataBuilder(AttentionMetadataBuilder[AscendDSAMetadata]):
         The computation (clamp + cumsum + offset + mask) is identical for
         all attention groups, so we compute once and cache the results.
         """
+        build_local_metadata: Callable[[], None] | None = None
         cache = self.common_ratio_to_sas_metadata.get("_device_local")
         if cache is None:
-            # Calc and cache device tensor results
-            (
-                local_start,
-                local_end_with_pad,
-                tokens_per_rank,
-                num_tokens_pad,
-                local_query_start_loc,
-                local_seq_lens,
-            ) = self._build_local_token_metadata(
-                num_reqs=num_reqs,
-                num_input_tokens=num_input_tokens,
-                query_start_loc=query_start_loc,
-                seq_lens=seq_lens,
-                local_query_start_loc=self.local_query_start_loc,
-                local_seq_lens=self.local_seq_lens,
-                start_pos_out=self.start_pos_prefill,
-            )
+            local_start, local_end_with_pad, tokens_per_rank, num_tokens_pad = self._local_token_range(num_input_tokens)
+            local_query_start_loc = self.local_query_start_loc[: num_reqs + 1]
+            local_seq_lens = self.local_seq_lens[:num_reqs]
+
+            def build_first_local_metadata() -> None:
+                self._build_local_token_metadata(
+                    num_reqs=num_reqs,
+                    num_input_tokens=num_input_tokens,
+                    query_start_loc=query_start_loc,
+                    seq_lens=seq_lens,
+                    local_query_start_loc=self.local_query_start_loc,
+                    local_seq_lens=self.local_seq_lens,
+                    start_pos_out=self.start_pos_prefill,
+                )
+
+            if self._device_metadata_enabled:
+                build_local_metadata = build_first_local_metadata
+            else:
+                build_first_local_metadata()
             self.common_ratio_to_sas_metadata["_device_local"] = {
                 "local_start": local_start,
                 "local_end": local_end_with_pad,
                 "tokens_per_rank": tokens_per_rank,
                 "num_tokens_pad": num_tokens_pad,
-                "qsl": self.local_query_start_loc[: num_reqs + 1].clone(),
-                "sl": self.local_seq_lens[:num_reqs].clone(),
-                "sp": self.start_pos_prefill[:num_reqs].clone(),
+                "qsl": local_query_start_loc if self._device_metadata_enabled else local_query_start_loc.clone(),
+                "sl": local_seq_lens if self._device_metadata_enabled else local_seq_lens.clone(),
+                "sp": (
+                    self.start_pos_prefill[:num_reqs]
+                    if self._device_metadata_enabled
+                    else self.start_pos_prefill[:num_reqs].clone()
+                ),
             }
         else:
-            # copy from cache
-            assert cache is not None
             local_start = cache["local_start"]
             local_end_with_pad = cache["local_end"]
             tokens_per_rank = cache["tokens_per_rank"]
             num_tokens_pad = cache["num_tokens_pad"]
-            self.local_query_start_loc[: num_reqs + 1].copy_(cache["qsl"])
-            self.local_seq_lens[:num_reqs].copy_(cache["sl"])
-            self.start_pos_prefill[:num_reqs].copy_(cache["sp"])
             local_query_start_loc = self.local_query_start_loc[: num_reqs + 1]
             local_seq_lens = self.local_seq_lens[:num_reqs]
+
+            def copy_local_metadata() -> None:
+                local_query_start_loc.copy_(cache["qsl"])
+                local_seq_lens.copy_(cache["sl"])
+                self.start_pos_prefill[:num_reqs].copy_(cache["sp"])
+
+            if self._device_metadata_enabled:
+                build_local_metadata = copy_local_metadata
+            else:
+                copy_local_metadata()
 
         return (
             local_start,
@@ -666,6 +683,7 @@ class AscendDSACPMetadataBuilder(AttentionMetadataBuilder[AscendDSAMetadata]):
             num_tokens_pad,
             local_query_start_loc,
             local_seq_lens,
+            build_local_metadata,
         )
 
     def build_req_metadata(
@@ -692,6 +710,7 @@ class AscendDSACPMetadataBuilder(AttentionMetadataBuilder[AscendDSAMetadata]):
             num_tokens_pad,
             local_query_start_loc,
             local_seq_lens,
+            build_local_metadata,
         ) = self._ensure_device_local_metadata(
             num_reqs=num_reqs,
             num_input_tokens=num_input_tokens,
@@ -731,7 +750,6 @@ class AscendDSACPMetadataBuilder(AttentionMetadataBuilder[AscendDSAMetadata]):
             assert cpu_cache is not None
             local_query_start_loc_cpu = cpu_cache["qsl_cpu"]
             local_seq_lens_cpu = cpu_cache["sl_cpu"]
-        local_seq_lens_q = local_query_start_loc[1 : num_reqs + 1] - local_query_start_loc[:num_reqs]
         local_seq_lens_q_cpu = local_query_start_loc_cpu[1 : num_reqs + 1] - local_query_start_loc_cpu[:num_reqs]
         max_local_query_len = max(1, int(local_seq_lens_q_cpu.max().item()))
         max_local_seq_lens = max(1, int(local_seq_lens_cpu.max().item()))
@@ -741,7 +759,16 @@ class AscendDSACPMetadataBuilder(AttentionMetadataBuilder[AscendDSAMetadata]):
         else:
             num_reqs_actual = min(num_reqs_actual, num_reqs)
             if num_reqs_actual < num_reqs:
-                self.start_pos_prefill[num_reqs_actual:].fill_(0)
+                if build_local_metadata is None:
+                    self.start_pos_prefill[num_reqs_actual:].fill_(0)
+                else:
+                    build_device_local_metadata = build_local_metadata
+                    valid_num_reqs = num_reqs_actual
+
+                    def build_local_metadata() -> None:
+                        build_device_local_metadata()
+                        self.start_pos_prefill[valid_num_reqs:].fill_(0)
+
                 self.block_table[num_reqs_actual:num_reqs, ...].fill_(0)
 
         # --- Compressed positions ---
@@ -763,27 +790,69 @@ class AscendDSACPMetadataBuilder(AttentionMetadataBuilder[AscendDSAMetadata]):
         num_heads = self.model_config.hf_config.num_attention_heads
         index_topk = self.model_config.hf_config.index_topk
 
-        sas_metadata = self._build_sas_metadata(
-            num_heads=num_heads,
-            query_start_loc=local_query_start_loc,
-            seq_lens=local_seq_lens,
-            seq_lens_q=local_seq_lens_q,
-            max_query_len=max_local_query_len,
-            max_seq_lens=max_local_seq_lens,
-            index_topk=index_topk,
-            num_reqs=num_reqs,
-            has_prefill=has_prefill,
-            cu_cmp_seqlen_list=cu_cmp_seqlens,
-        )
+        def build_sas_metadata() -> torch.Tensor:
+            return self._build_sas_metadata(
+                num_heads=num_heads,
+                query_start_loc=local_query_start_loc,
+                seq_lens=local_seq_lens,
+                max_query_len=max_local_query_len,
+                max_seq_lens=max_local_seq_lens,
+                index_topk=index_topk,
+                num_reqs=num_reqs,
+                has_prefill=has_prefill,
+                cu_cmp_seqlen_list=cu_cmp_seqlens,
+            )
 
         # --- QLI metadata (all requests combined) ---
-        qli_cu_seqlens_q, qli_seqused_k, qli_cmp_residual_k, qli_metadata = self._build_qli_metadata(
-            query_start_loc=local_query_start_loc,
-            seq_lens=local_seq_lens,
-            seq_lens_q=local_seq_lens_q,
-            max_seq_lens=max_local_seq_lens,
-            num_reqs=num_reqs,
-        )
+        qli_cu_seqlens_q = local_query_start_loc if self.compressor_ratio == 4 else None
+        qli_seqused_k = self.qli_seqused_k[:num_reqs] if self.compressor_ratio == 4 else None
+        qli_cmp_residual_k = self.qli_cmp_residual_k[:num_reqs] if self.compressor_ratio == 4 else None
+
+        def build_qli_metadata() -> tuple[
+            torch.Tensor | None,
+            torch.Tensor | None,
+            torch.Tensor | None,
+            torch.Tensor | None,
+        ]:
+            return self._build_qli_metadata(
+                query_start_loc=local_query_start_loc,
+                seq_lens=local_seq_lens,
+                num_reqs=num_reqs,
+                max_seqlen_q=max_local_query_len,
+                max_seqlen_k=max_local_seq_lens,
+            )
+
+        def run_sas_metadata() -> None:
+            build_sas_metadata()
+
+        def run_qli_metadata() -> None:
+            build_qli_metadata()
+
+        if self._device_metadata_enabled:
+            assert build_local_metadata is not None
+            local_group_id = id(self.req_sas_metadata)
+            local_metadata_task = DeviceMetadataTask(
+                DeviceMetadataStage.COMPRESSOR, build_local_metadata, local_group_id
+            )
+
+            if self.compressor_ratio == 4:
+                self._device_metadata_tasks = (
+                    local_metadata_task,
+                    DeviceMetadataTask(DeviceMetadataStage.INDEXER, run_qli_metadata, id(self.req_qli_metadata)),
+                    DeviceMetadataTask(DeviceMetadataStage.ATTENTION, run_sas_metadata, id(self.req_sas_metadata)),
+                )
+            else:
+                self._device_metadata_tasks = (
+                    local_metadata_task,
+                    DeviceMetadataTask(DeviceMetadataStage.ATTENTION, run_sas_metadata, id(self.req_sas_metadata)),
+                )
+            sas_metadata = self.req_sas_metadata
+            qli_metadata = self.req_qli_metadata if self.compressor_ratio == 4 else None
+        else:
+            local_group_id = None
+            self._device_metadata_tasks = ()
+            sas_metadata = build_sas_metadata()
+            qli_cu_seqlens_q, qli_seqused_k, qli_cmp_residual_k, qli_metadata = build_qli_metadata()
 
         cp_metadata = DSACPMetadata(
             local_query_start_loc=local_query_start_loc,
@@ -817,8 +886,25 @@ class AscendDSACPMetadataBuilder(AttentionMetadataBuilder[AscendDSAMetadata]):
             qli_cu_seqlens_q=qli_cu_seqlens_q,
             qli_seqused_k=qli_seqused_k,
             qli_cmp_residual_k=qli_cmp_residual_k,
+            device_local_metadata_group_id=local_group_id,
             cu_cmp_seqlen_list=cu_cmp_seqlens,
         )
+
+    def enable_device_metadata(self) -> None:
+        self._device_metadata_enabled = True
+
+    def take_device_metadata_tasks(self) -> tuple[DeviceMetadataTask, ...]:
+        tasks = self._device_metadata_tasks
+        self._device_metadata_tasks = ()
+        return tasks
+
+    @staticmethod
+    def _local_token_range(num_input_tokens: int) -> tuple[int, int, int, int]:
+        tp_group = get_tp_group()
+        num_tokens_pad = ((num_input_tokens + tp_group.world_size - 1) // tp_group.world_size) * tp_group.world_size
+        tokens_per_rank = num_tokens_pad // tp_group.world_size
+        local_start = tp_group.rank_in_group * tokens_per_rank
+        return local_start, local_start + tokens_per_rank, tokens_per_rank, num_tokens_pad
 
     def _build_local_token_metadata(
         self,
@@ -846,15 +932,9 @@ class AscendDSACPMetadataBuilder(AttentionMetadataBuilder[AscendDSAMetadata]):
         local_reqs_mask = [0, 0, 0, 0, 0, 1, 1, 1, 0]
         local_seq_lens = [0, 0, 0, 0, 0, 6, 7, 2, 0]
         """
-        tp_group = get_tp_group()
-        tp_size = tp_group.world_size
-        tp_rank = tp_group.rank_in_group
         # Split the flattened token stream evenly across TP ranks. Padding keeps
         # every rank's local slice the same length, which simplifies CP kernels.
-        num_tokens_pad = ((num_input_tokens + tp_size - 1) // tp_size) * tp_size
-        tokens_per_rank = num_tokens_pad // tp_size
-        local_start = tp_rank * tokens_per_rank
-        local_end = local_start + tokens_per_rank
+        local_start, local_end, tokens_per_rank, num_tokens_pad = self._local_token_range(num_input_tokens)
 
         if local_query_start_loc is not None:
             local_query_start_loc.fill_(0)
@@ -936,7 +1016,6 @@ class AscendDSACPMetadataBuilder(AttentionMetadataBuilder[AscendDSAMetadata]):
         num_heads,
         query_start_loc,
         seq_lens,
-        seq_lens_q,
         max_query_len,
         max_seq_lens,
         index_topk,
@@ -1005,7 +1084,14 @@ class AscendDSACPMetadataBuilder(AttentionMetadataBuilder[AscendDSAMetadata]):
         self.req_sas_metadata[:1024] = metadata
         return self.req_sas_metadata[:1024]
 
-    def _build_qli_metadata(self, query_start_loc, seq_lens, seq_lens_q, max_seq_lens, num_reqs):
+    def _build_qli_metadata(
+        self,
+        query_start_loc,
+        seq_lens,
+        num_reqs,
+        max_seqlen_q,
+        max_seqlen_k,
+    ):
         if self.compressor_ratio != 4:
             return None, None, None, None
 
@@ -1026,7 +1112,6 @@ class AscendDSACPMetadataBuilder(AttentionMetadataBuilder[AscendDSAMetadata]):
         metadata = self.common_ratio_to_sas_metadata.get(cache_key)
 
         if metadata is None:
-            max_seqlen_q = max(1, int(seq_lens_q.max().item()))
             metadata = torch.ops._C_ascend.npu_quant_lightning_indexer_v2_metadata(
                 num_heads_q=self.model_config.hf_config.index_n_heads,
                 num_heads_k=1,
@@ -1038,7 +1123,7 @@ class AscendDSACPMetadataBuilder(AttentionMetadataBuilder[AscendDSAMetadata]):
                 cmp_residual_k=qli_cmp_residual_k,
                 batch_size=num_reqs,
                 max_seqlen_q=max_seqlen_q,
-                max_seqlen_k=max_seq_lens // 4,
+                max_seqlen_k=max_seqlen_k // 4,
                 layout_q="TND",
                 layout_k="PA_BBND",
                 mask_mode=3,
@@ -1177,6 +1262,11 @@ class AscendDSACPImpl(DSAAttentionImpl):
         self,
         metadata: AscendDSAReqMetadata,
     ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+        if metadata.device_local_metadata_group_id is not None:
+            wait_for_device_metadata(
+                DeviceMetadataStage.COMPRESSOR,
+                metadata.device_local_metadata_group_id,
+            )
         return get_or_compute_compressor_metadata(metadata, self.compress_ratio)
 
     def process_weights_after_loading(self, act_dtype: torch.dtype):
@@ -1563,7 +1653,15 @@ class AscendDSACPImpl(DSAAttentionImpl):
                 compressed_kv = None
             DeviceOperator.dsa_kv_compress_scatter(compress_kv_cache, compressed_kv, compress_slot_mapping)
 
+        if self.compress_ratio <= 1:
+            sas_metadata = swa_req_metadata.sas_metadata
+        elif self.compress_ratio == 4:
+            sas_metadata = req_metadata.sas_metadata
+        else:
+            assert compressor_attn_metadata.req_metadata is not None
+            sas_metadata = compressor_attn_metadata.req_metadata.sas_metadata
         notify_kv_cache_written(layer_name)
+        wait_for_device_metadata(DeviceMetadataStage.ATTENTION, id(sas_metadata))
         record_attention_compute_start()
         attn_op = DeviceOperator.get_dsa_sparse_attn_op()
         extra_attn_kwargs: dict = DeviceOperator.get_dsa_sparse_attn_base_kwargs()
@@ -1596,7 +1694,7 @@ class AscendDSACPImpl(DSAAttentionImpl):
                 q,
                 ori_kv=swa_kv_cache,
                 ori_block_table=swa_metadata.req_metadata.block_table,
-                metadata=swa_metadata.req_metadata.sas_metadata,
+                metadata=sas_metadata,
                 **common_attn_kwargs,
             )[0]
         elif self.compress_ratio == 4:
@@ -1611,7 +1709,7 @@ class AscendDSACPImpl(DSAAttentionImpl):
                 cmp_sparse_indices=compress_topk_idxs,
                 ori_block_table=swa_metadata.req_metadata.block_table,
                 cmp_block_table=compressor_attn_metadata.req_metadata.block_table,
-                metadata=req_metadata.sas_metadata,
+                metadata=sas_metadata,
                 cmp_mask_mode=3,
                 **common_attn_kwargs,
             )[0]
@@ -1626,7 +1724,7 @@ class AscendDSACPImpl(DSAAttentionImpl):
                 cmp_kv=compress_kv_cache,
                 ori_block_table=swa_metadata.req_metadata.block_table,
                 cmp_block_table=compressor_attn_metadata.req_metadata.block_table,
-                metadata=compressor_attn_metadata.req_metadata.sas_metadata,
+                metadata=sas_metadata,
                 cmp_mask_mode=3,
                 **common_attn_kwargs,
             )[0]
@@ -1768,6 +1866,9 @@ class AscendDSACPImpl(DSAAttentionImpl):
 
         assert indexer_kv_scale_metadata.req_metadata is not None
         dsa_meta = indexer_kv_scale_metadata.req_metadata
+        qli_metadata = dsa_meta.qli_metadata
+        assert qli_metadata is not None
+        wait_for_device_metadata(DeviceMetadataStage.INDEXER, id(qli_metadata))
         topk_idxs, _ = torch.ops._C_ascend.npu_quant_lightning_indexer_v2(
             query=q,
             key=indexer_k_cache,
@@ -1780,7 +1881,7 @@ class AscendDSACPImpl(DSAAttentionImpl):
             seqused_k=dsa_meta.qli_seqused_k,
             cmp_residual_k=dsa_meta.qli_cmp_residual_k,
             block_table=dsa_meta.block_table,
-            metadata=dsa_meta.qli_metadata,
+            metadata=qli_metadata,
             layout_q="TND",
             layout_k="PA_BBND",
             mask_mode=3,

--- a/vllm_ascend/attention/dsa_v1.py
+++ b/vllm_ascend/attention/dsa_v1.py
@@ -8,7 +8,7 @@ import torch.distributed as dist
 import torch.nn.functional as F
 import torch_npu
 import vllm.envs as envs_vllm
-from vllm.config import VllmConfig, get_current_vllm_config
+from vllm.config import CUDAGraphMode, VllmConfig, get_current_vllm_config
 from vllm.distributed import get_tensor_model_parallel_world_size
 from vllm.forward_context import get_forward_context
 from vllm.triton_utils import HAS_TRITON
@@ -67,6 +67,37 @@ CompressorMetadataOutput = tuple[torch.Tensor, torch.Tensor, torch.Tensor]
 CompressorForwardOutput = tuple[torch.Tensor, torch.Tensor]
 CompressorOverlapOutput = tuple[CompressorForwardOutput, torch.npu.Event]
 _COMPRESSOR_METADATA_CACHE_KEY = "dsv4_compressor_metadata_cache"
+
+
+def build_compressor_metadata_out(
+    metadata: Any,
+    compress_ratio: int,
+    outputs: CompressorMetadataOutput,
+) -> None:
+    assert metadata.full_compress_cos is not None
+    assert metadata.full_compress_sin is not None
+    assert metadata.start_pos is not None
+    assert metadata.num_reqs_actual is not None
+    full_compress_cos = metadata.full_compress_cos.view(
+        metadata.full_compress_cos.shape[0],
+        metadata.full_compress_cos.shape[-1],
+    )
+    full_compress_sin = metadata.full_compress_sin.view(
+        metadata.full_compress_sin.shape[0],
+        metadata.full_compress_sin.shape[-1],
+    )
+    torch.ops._C_ascend.compressor_metadata_out(
+        full_compress_cos,
+        full_compress_sin,
+        metadata.query_start_loc,
+        metadata.start_pos,
+        metadata.block_table,
+        metadata.block_size,
+        DeviceOperator.get_dsa_compressor_slot_mapping_format(),
+        compress_ratio,
+        metadata.num_reqs_actual,
+        *outputs,
+    )
 
 
 def reset_compressor_metadata_cache() -> None:
@@ -325,6 +356,8 @@ class AscendDSAPrefillMetadata:
     qli_cu_seqlens_q: torch.Tensor = None
     qli_seqused_k: torch.Tensor = None
     qli_cmp_residual_k: torch.Tensor = None
+    compressor_metadata: CompressorMetadataOutput | None = None
+    compressor_metadata_group_id: int | None = None
     cu_c4_cmp_seqlen_list: torch.Tensor = None
     cu_c128_cmp_seqlen_list: torch.Tensor = None
     ori_win_left: int | None = None
@@ -364,6 +397,8 @@ class AscendDSADecodeMetadata:
     qli_cu_seqlens_q: torch.Tensor = None
     qli_seqused_k: torch.Tensor = None
     qli_cmp_residual_k: torch.Tensor = None
+    compressor_metadata: CompressorMetadataOutput | None = None
+    compressor_metadata_group_id: int | None = None
     ori_win_left: int | None = None
     ori_win_right: int | None = None
     dspark_swa_indices: torch.Tensor | None = None
@@ -621,6 +656,8 @@ class AscendDSAMetadataBuilder(AttentionMetadataBuilder[AscendDSAMetadata]):
         )
         self._device_metadata_enabled = False
         self._device_metadata_tasks: tuple[DeviceMetadataTask, ...] = ()
+        self.prefill_compressor_metadata_buffers: CompressorMetadataOutput | None = None
+        self.decode_compressor_metadata_buffers: CompressorMetadataOutput | None = None
         self.cu_seqlens_ori_kv = torch.tensor([], device=self.device)
         self.cu_seqlens_cmp_kv = torch.tensor([], device=self.device)
         self.seqused_q = torch.tensor([], device=self.device)
@@ -694,6 +731,24 @@ class AscendDSAMetadataBuilder(AttentionMetadataBuilder[AscendDSAMetadata]):
 
     def enable_device_metadata(self) -> None:
         self._device_metadata_enabled = True
+        if self.compressor_ratio <= 1 or self.vllm_config.compilation_config.cudagraph_mode == CUDAGraphMode.FULL:
+            return
+        output_shape = (
+            self.vllm_config.scheduler_config.max_num_batched_tokens,
+            1,
+            1,
+            self.model_config.hf_config.qk_rope_head_dim,
+        )
+        self.prefill_compressor_metadata_buffers = (
+            torch.empty(output_shape, dtype=torch.float32, device=self.device),
+            torch.empty(output_shape, dtype=torch.float32, device=self.device),
+            torch.empty(self.slot_mapping_shape, dtype=torch.int32, device=self.device),
+        )
+        self.decode_compressor_metadata_buffers = (
+            torch.empty(output_shape, dtype=torch.float32, device=self.device),
+            torch.empty(output_shape, dtype=torch.float32, device=self.device),
+            torch.empty(self.slot_mapping_shape, dtype=torch.int32, device=self.device),
+        )
 
     def take_device_metadata_tasks(self) -> tuple[DeviceMetadataTask, ...]:
         tasks = self._device_metadata_tasks
@@ -726,6 +781,7 @@ class AscendDSAMetadataBuilder(AttentionMetadataBuilder[AscendDSAMetadata]):
         num_reqs = common_attn_metadata.num_reqs
         query_start_loc = common_attn_metadata.query_start_loc
         num_reqs_actual = kwargs.get("num_reqs_actual")
+        full_graph_mode = kwargs.get("full_graph_mode", False)
         self.prefill_ratio_to_sas_metadata = kwargs.get("prefill_ratio_to_sas_metadata")
         self.decode_ratio_to_sas_metadata = kwargs.get("decode_ratio_to_sas_metadata")
         assert self.prefill_ratio_to_sas_metadata is not None
@@ -789,12 +845,18 @@ class AscendDSAMetadataBuilder(AttentionMetadataBuilder[AscendDSAMetadata]):
                 common_prefix_len,
                 common_attn_metadata,
                 num_reqs_actual,
+                full_graph_mode,
             )
 
         decode_metadata = None
 
         if self.num_decodes > 0:
-            decode_metadata = self.build_decode_metadata(common_prefix_len, common_attn_metadata, num_reqs_actual)
+            decode_metadata = self.build_decode_metadata(
+                common_prefix_len,
+                common_attn_metadata,
+                num_reqs_actual,
+                full_graph_mode,
+            )
 
         return self.metadata_cls(  # type: ignore
             num_input_tokens=common_attn_metadata.num_input_tokens,
@@ -822,6 +884,7 @@ class AscendDSAMetadataBuilder(AttentionMetadataBuilder[AscendDSAMetadata]):
         common_prefix_len: int,
         common_attn_metadata: AscendCommonAttentionMetadata,
         num_reqs_actual: int | None,
+        full_graph_mode: bool = False,
     ) -> AscendDSAPrefillMetadata:
         assert self.prefill_ratio_to_sas_metadata is not None
         assert self.decode_ratio_to_sas_metadata is not None
@@ -891,10 +954,15 @@ class AscendDSAMetadataBuilder(AttentionMetadataBuilder[AscendDSAMetadata]):
         if self.compressor_ratio > 1:
             # Keep only graph inputs here. The compressor metadata op itself is
             # launched in forward at the real compressor consumer.
-            num_compressed_tokens = self._num_compressor_metadata_rows(
-                BUILD_METADATA_STEP_PREFILL,
-                common_attn_metadata,
-            )
+            if full_graph_mode:
+                num_tokens = common_attn_metadata.num_input_tokens
+                num_compressed_tokens = min(num_tokens, num_tokens // self.compressor_ratio + num_prefill)
+                num_prefills_actual = num_prefill
+            else:
+                num_compressed_tokens = self._num_compressor_metadata_rows(
+                    BUILD_METADATA_STEP_PREFILL,
+                    common_attn_metadata,
+                )
             full_compress_cos, full_compress_sin = get_full_cos_and_sin_dsa(layer_name)
             prefill_slot_mapping = None
         else:
@@ -1011,7 +1079,7 @@ class AscendDSAMetadataBuilder(AttentionMetadataBuilder[AscendDSAMetadata]):
             sas_metadata = get_sas_metadata()
             qli_metadata = get_qli_metadata() if self.compressor_ratio == 4 else None
 
-        return AscendDSAPrefillMetadata(
+        prefill_metadata = AscendDSAPrefillMetadata(
             attn_mask=None,
             query_lens=self.query_lens[reqs_start:].to(torch.int32),
             seq_lens=self.seq_lens[reqs_start:],
@@ -1039,12 +1107,32 @@ class AscendDSAMetadataBuilder(AttentionMetadataBuilder[AscendDSAMetadata]):
             cu_c4_cmp_seqlen_list=cu_c4_cmp_seqlen_list,
             cu_c128_cmp_seqlen_list=cu_c128_cmp_seqlen_list,
         )
+        if self._device_metadata_enabled and self.prefill_compressor_metadata_buffers is not None:
+            buffers = self.prefill_compressor_metadata_buffers
+            outputs = (
+                buffers[0][:num_compressed_tokens],
+                buffers[1][:num_compressed_tokens],
+                buffers[2][:num_compressed_tokens],
+            )
+            group_id = id(buffers[0])
+            prefill_metadata.compressor_metadata = outputs
+            prefill_metadata.compressor_metadata_group_id = group_id
+            self._device_metadata_tasks = (
+                DeviceMetadataTask(
+                    DeviceMetadataStage.COMPRESSOR,
+                    lambda: build_compressor_metadata_out(prefill_metadata, self.compressor_ratio, outputs),
+                    group_id,
+                ),
+                *self._device_metadata_tasks,
+            )
+        return prefill_metadata
 
     def build_decode_metadata(
         self,
         common_prefix_len: int,
         common_attn_metadata: AscendCommonAttentionMetadata,
         num_reqs_actual: int | None,
+        full_graph_mode: bool = False,
     ) -> AscendDSADecodeMetadata:
         assert self.decode_ratio_to_sas_metadata is not None
         if self.decode_ratio_to_sas_metadata.get("query_start_loc", None) is None:
@@ -1110,10 +1198,15 @@ class AscendDSAMetadataBuilder(AttentionMetadataBuilder[AscendDSAMetadata]):
         if self.compressor_ratio > 1:
             # Keep only graph inputs here. The compressor metadata op itself is
             # launched in forward at the real compressor consumer.
-            num_compressed_tokens = self._num_compressor_metadata_rows(
-                BUILD_METADATA_STEP_DECODE,
-                common_attn_metadata,
-            )
+            if full_graph_mode:
+                num_tokens = common_attn_metadata.num_input_tokens
+                num_compressed_tokens = min(num_tokens, num_tokens // self.compressor_ratio + self.num_decodes)
+                num_decodes_actual = self.num_decodes
+            else:
+                num_compressed_tokens = self._num_compressor_metadata_rows(
+                    BUILD_METADATA_STEP_DECODE,
+                    common_attn_metadata,
+                )
             full_compress_cos, full_compress_sin = get_full_cos_and_sin_dsa(layer_name)
             slot_mapping = None
         else:
@@ -1260,6 +1353,24 @@ class AscendDSAMetadataBuilder(AttentionMetadataBuilder[AscendDSAMetadata]):
             qli_seqused_k=qli_seqused_k,
             qli_cmp_residual_k=qli_cmp_residual_k,
         )
+        if self._device_metadata_enabled and self.decode_compressor_metadata_buffers is not None:
+            buffers = self.decode_compressor_metadata_buffers
+            outputs = (
+                buffers[0][:num_compressed_tokens],
+                buffers[1][:num_compressed_tokens],
+                buffers[2][:num_compressed_tokens],
+            )
+            group_id = id(buffers[0])
+            decode_metadata.compressor_metadata = outputs
+            decode_metadata.compressor_metadata_group_id = group_id
+            self._device_metadata_tasks = (
+                DeviceMetadataTask(
+                    DeviceMetadataStage.COMPRESSOR,
+                    lambda: build_compressor_metadata_out(decode_metadata, self.compressor_ratio, outputs),
+                    group_id,
+                ),
+                *self._device_metadata_tasks,
+            )
         return decode_metadata
 
     def build_for_drafting(
@@ -1690,6 +1801,13 @@ class AscendDSAImpl(DSAAttentionImpl):
         self,
         metadata: AscendDSAPrefillMetadata | AscendDSADecodeMetadata,
     ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+        if metadata.compressor_metadata is not None:
+            assert metadata.compressor_metadata_group_id is not None
+            wait_for_device_metadata(
+                DeviceMetadataStage.COMPRESSOR,
+                metadata.compressor_metadata_group_id,
+            )
+            return metadata.compressor_metadata
         return get_or_compute_compressor_metadata(metadata, self.compress_ratio)
 
     def _forward_compressor(

--- a/vllm_ascend/attention/dsa_v1.py
+++ b/vllm_ascend/attention/dsa_v1.py
@@ -607,6 +607,8 @@ class AscendDSAMetadataBuilder(AttentionMetadataBuilder[AscendDSAMetadata]):
                     ).to(torch.bfloat16)
         self.start_pos_prefill = torch.zeros(scheduler_config.max_num_seqs, dtype=torch.int32, device=self.device)
         self.start_pos_decode = torch.zeros(scheduler_config.max_num_seqs, dtype=torch.int32, device=self.device)
+        self.prefill_sas_metadata = torch.zeros(1024, dtype=torch.int32, device=self.device)
+        self.prefill_qli_metadata = torch.zeros(1024, dtype=torch.int32, device=self.device)
         self.decode_sas_metadata = torch.zeros(1024, dtype=torch.int32, device=self.device)
         self.decode_qli_metadata = torch.zeros(1024, dtype=torch.int32, device=self.device)
         self.prefill_qli_seqused_k = torch.zeros(scheduler_config.max_num_seqs, dtype=torch.int32, device=self.device)
@@ -908,89 +910,41 @@ class AscendDSAMetadataBuilder(AttentionMetadataBuilder[AscendDSAMetadata]):
 
         metadata_op = DeviceOperator.get_dsa_sparse_attn_metadata_op()
         metadata_kwargs = DeviceOperator.get_dsa_sparse_attn_metadata_kwargs(self.seqused_q.device)
-        if self.compressor_ratio <= 1:
+        sas_kwargs = dict(
+            metadata_kwargs,
+            num_heads_q=n_local_heads,
+            num_heads_kv=1,
+            head_dim=self.model_config.get_head_size(),
+            cu_seqlens_q=prefill_query_start_loc,
+            cu_seqlens_ori_kv=prefill_query_start_loc,
+            cu_seqlens_cmp_kv=(cu_c4_cmp_seqlen_list if self.compressor_ratio == 4 else cu_c128_cmp_seqlen_list),
+            seqused_q=self.seqused_q,
+            seqused_kv=self.seq_lens[reqs_start:],
+            max_seqlen_q=seq_lens_q.max(),
+            max_seqlen_kv=self.seq_lens[reqs_start:].max(),
+            batch_size=len(self.seq_lens[reqs_start:]),
+            cmp_ratio=(1 if self.compressor_ratio <= 1 else 4 if self.compressor_ratio == 4 else 128),
+            ori_mask_mode=4,
+            ori_win_left=self.model_config.hf_config.sliding_window - 1,
+            ori_win_right=0,
+            layout_q="TND",
+            layout_kv="PA_ND",
+            has_ori_kv=True,
+            has_cmp_kv=self.compressor_ratio > 1,
+        )
+        if self.compressor_ratio > 1:
+            sas_kwargs["cmp_mask_mode"] = 3
+        if self.compressor_ratio == 4:
+            sas_kwargs["cmp_topk"] = index_topk
+
+        def get_sas_metadata() -> torch.Tensor:
             if self.prefill_ratio_to_sas_metadata.get(layer_name) is None:
-                self.prefill_ratio_to_sas_metadata[layer_name] = metadata_op(
-                    **metadata_kwargs,
-                    num_heads_q=n_local_heads,
-                    num_heads_kv=1,
-                    head_dim=self.model_config.get_head_size(),
-                    cu_seqlens_q=prefill_query_start_loc,
-                    cu_seqlens_ori_kv=prefill_query_start_loc,
-                    cu_seqlens_cmp_kv=None,
-                    seqused_q=self.seqused_q,
-                    seqused_kv=self.seq_lens[reqs_start:],
-                    max_seqlen_q=seq_lens_q.max(),
-                    max_seqlen_kv=self.seq_lens[reqs_start:].max(),
-                    batch_size=len(self.seq_lens[reqs_start:]),
-                    cmp_ratio=1,
-                    ori_mask_mode=4,  # 4:sliding window
-                    ori_win_left=self.model_config.hf_config.sliding_window - 1,
-                    ori_win_right=0,
-                    layout_q="TND",
-                    layout_kv="PA_ND",
-                    has_ori_kv=True,
-                    has_cmp_kv=False,
-                )
-            sas_metadata = self.prefill_ratio_to_sas_metadata[layer_name]
-        elif self.compressor_ratio == 4:
-            if self.prefill_ratio_to_sas_metadata.get(layer_name) is None:
-                self.prefill_ratio_to_sas_metadata[layer_name] = metadata_op(
-                    **metadata_kwargs,
-                    num_heads_q=n_local_heads,
-                    num_heads_kv=1,
-                    head_dim=self.model_config.get_head_size(),
-                    cu_seqlens_q=prefill_query_start_loc,
-                    cu_seqlens_ori_kv=prefill_query_start_loc,
-                    cu_seqlens_cmp_kv=cu_c4_cmp_seqlen_list,
-                    seqused_q=self.seqused_q,
-                    seqused_kv=self.seq_lens[reqs_start:],
-                    max_seqlen_q=seq_lens_q.max(),
-                    max_seqlen_kv=self.seq_lens[reqs_start:].max(),
-                    batch_size=len(self.seq_lens[reqs_start:]),
-                    cmp_topk=index_topk,
-                    # topk=index_topk,
-                    cmp_ratio=4,
-                    ori_mask_mode=4,
-                    cmp_mask_mode=3,
-                    ori_win_left=self.model_config.hf_config.sliding_window - 1,
-                    ori_win_right=0,
-                    layout_q="TND",
-                    layout_kv="PA_ND",
-                    has_ori_kv=True,
-                    has_cmp_kv=True,
-                )
-            sas_metadata = self.prefill_ratio_to_sas_metadata[layer_name]
-        else:
-            if self.prefill_ratio_to_sas_metadata.get(layer_name) is None:
-                self.prefill_ratio_to_sas_metadata[layer_name] = metadata_op(
-                    **metadata_kwargs,
-                    num_heads_q=n_local_heads,
-                    num_heads_kv=1,
-                    head_dim=self.model_config.get_head_size(),
-                    cu_seqlens_q=prefill_query_start_loc,
-                    cu_seqlens_ori_kv=prefill_query_start_loc,
-                    cu_seqlens_cmp_kv=cu_c128_cmp_seqlen_list,
-                    seqused_q=self.seqused_q,
-                    seqused_kv=self.seq_lens[reqs_start:],
-                    max_seqlen_q=seq_lens_q.max(),
-                    max_seqlen_kv=self.seq_lens[reqs_start:].max(),
-                    batch_size=len(self.seq_lens[reqs_start:]),
-                    cmp_ratio=128,  #
-                    ori_mask_mode=4,  # 4:sliding window
-                    cmp_mask_mode=3,  # 3:causal
-                    ori_win_left=self.model_config.hf_config.sliding_window - 1,
-                    ori_win_right=0,
-                    layout_q="TND",
-                    layout_kv="PA_ND",
-                    has_ori_kv=True,
-                    has_cmp_kv=True,
-                )
-            sas_metadata = self.prefill_ratio_to_sas_metadata[layer_name]
+                self.prefill_ratio_to_sas_metadata[layer_name] = metadata_op(**sas_kwargs)
+            return self.prefill_ratio_to_sas_metadata[layer_name]
+
         qli_cu_seqlens_q = None
         qli_seqused_k = None
         qli_cmp_residual_k = None
-        qli_metadata = None
         if self.compressor_ratio == 4:
             # QLI v2 PA_BBND reads the compressed K length plus the residual
             # from the original length. Write both into persistent builder
@@ -1008,26 +962,54 @@ class AscendDSAMetadataBuilder(AttentionMetadataBuilder[AscendDSAMetadata]):
                 4,
                 out=qli_cmp_residual_k,
             )
+
+        def get_qli_metadata() -> torch.Tensor:
+            assert qli_cu_seqlens_q is not None
+            assert qli_seqused_k is not None
+            assert qli_cmp_residual_k is not None
             if self.prefill_ratio_to_sas_metadata.get("qli") is None:
-                self.prefill_ratio_to_sas_metadata["qli"] = torch.ops._C_ascend.npu_quant_lightning_indexer_v2_metadata(
-                    num_heads_q=self.model_config.hf_config.index_n_heads,  # 64
-                    num_heads_k=1,
-                    head_dim=self.model_config.hf_config.index_head_dim,  # 128
-                    topk=self.model_config.hf_config.index_topk,
-                    quant_mode=2,
-                    cu_seqlens_q=qli_cu_seqlens_q,
-                    seqused_k=qli_seqused_k,
-                    cmp_residual_k=qli_cmp_residual_k,
-                    batch_size=len(self.seq_lens[reqs_start:]),
-                    max_seqlen_q=seq_lens_q.max().item(),
-                    max_seqlen_k=max_seq_lens // 4,
-                    layout_q="TND",
-                    layout_k="PA_BBND",
-                    mask_mode=3,
-                    cmp_ratio=4,
-                    device=str(self.seqused_q.device),
+                self.prefill_ratio_to_sas_metadata["qli"] = (
+                    torch.ops._C_ascend.npu_quant_lightning_indexer_v2_metadata(
+                        num_heads_q=self.model_config.hf_config.index_n_heads,  # 64
+                        num_heads_k=1,
+                        head_dim=self.model_config.hf_config.index_head_dim,  # 128
+                        topk=self.model_config.hf_config.index_topk,
+                        quant_mode=2,
+                        cu_seqlens_q=qli_cu_seqlens_q,
+                        seqused_k=qli_seqused_k,
+                        cmp_residual_k=qli_cmp_residual_k,
+                        batch_size=len(self.seq_lens[reqs_start:]),
+                        max_seqlen_q=max_query_len,
+                        max_seqlen_k=max_seq_lens // 4,
+                        layout_q="TND",
+                        layout_k="PA_BBND",
+                        mask_mode=3,
+                        cmp_ratio=4,
+                        device=str(self.seqused_q.device),
+                    )
                 )
-            qli_metadata = self.prefill_ratio_to_sas_metadata.get("qli")
+            return self.prefill_ratio_to_sas_metadata["qli"]
+
+        if self._device_metadata_enabled:
+
+            def build_sas_metadata() -> None:
+                self.prefill_sas_metadata[:1024] = get_sas_metadata()
+
+            def build_qli_metadata() -> None:
+                self.prefill_qli_metadata[:1024] = get_qli_metadata()
+
+            if self.compressor_ratio == 4:
+                self._device_metadata_tasks += (
+                    DeviceMetadataTask(DeviceMetadataStage.INDEXER, build_qli_metadata, id(self.prefill_qli_metadata)),
+                )
+            self._device_metadata_tasks += (
+                DeviceMetadataTask(DeviceMetadataStage.ATTENTION, build_sas_metadata, id(self.prefill_sas_metadata)),
+            )
+            sas_metadata = self.prefill_sas_metadata
+            qli_metadata = self.prefill_qli_metadata if self.compressor_ratio == 4 else None
+        else:
+            sas_metadata = get_sas_metadata()
+            qli_metadata = get_qli_metadata() if self.compressor_ratio == 4 else None
 
         return AscendDSAPrefillMetadata(
             attn_mask=None,
@@ -2218,6 +2200,7 @@ class AscendDSAImpl(DSAAttentionImpl):
             if swa_prefill_metadata.dspark_swa_indices is not None:
                 extra_attn_kwargs["ori_sparse_indices"] = swa_prefill_metadata.dspark_swa_indices
             notify_kv_cache_written(layer_name)
+            wait_for_device_metadata(DeviceMetadataStage.ATTENTION, id(common_prefill_metadata.sas_metadata))
             record_attention_compute_start()
             return attn_op(
                 q,
@@ -2312,6 +2295,9 @@ class AscendDSAImpl(DSAAttentionImpl):
                 weights = weights_proj_output * (self.indexer_softmax_scale * self.indexer_heads**-0.5)
                 # lightning_indexer
                 indexer_scale_prefill_metadata = _require_prefill_metadata(indexer_kv_scale_metadata)
+                qli_metadata = indexer_scale_prefill_metadata.qli_metadata
+                assert qli_metadata is not None
+                wait_for_device_metadata(DeviceMetadataStage.INDEXER, id(qli_metadata))
                 compress_topk_idxs, _ = torch.ops._C_ascend.npu_quant_lightning_indexer_v2(
                     query=q_quant,
                     key=indexer_k_cache,
@@ -2324,7 +2310,7 @@ class AscendDSAImpl(DSAAttentionImpl):
                     seqused_k=indexer_scale_prefill_metadata.qli_seqused_k,
                     cmp_residual_k=indexer_scale_prefill_metadata.qli_cmp_residual_k,
                     block_table=indexer_scale_prefill_metadata.block_table,
-                    metadata=indexer_scale_prefill_metadata.qli_metadata,
+                    metadata=qli_metadata,
                     layout_q="TND",
                     layout_k="PA_BBND",
                     mask_mode=3,
@@ -2336,6 +2322,7 @@ class AscendDSAImpl(DSAAttentionImpl):
                 self._update_indexcache_topk_indices(compress_topk_idxs, offset=prefill_offset)
 
             notify_kv_cache_written(layer_name)
+            wait_for_device_metadata(DeviceMetadataStage.ATTENTION, id(common_prefill_metadata.sas_metadata))
             record_attention_compute_start()
 
             if self.compress_ratio == 4:
@@ -2884,9 +2871,9 @@ class AscendDSAImpl(DSAAttentionImpl):
         else:
             assert indexer_kv_scale_metadata.decode is not None
             dsa_meta = indexer_kv_scale_metadata.decode
-            qli_metadata = dsa_meta.qli_metadata
-            assert qli_metadata is not None
-            wait_for_device_metadata(DeviceMetadataStage.INDEXER, id(qli_metadata))
+        qli_metadata = dsa_meta.qli_metadata
+        assert qli_metadata is not None
+        wait_for_device_metadata(DeviceMetadataStage.INDEXER, id(qli_metadata))
         topk_idxs, _ = torch.ops._C_ascend.npu_quant_lightning_indexer_v2(
             query=q,
             key=indexer_k_cache,
@@ -2899,7 +2886,7 @@ class AscendDSAImpl(DSAAttentionImpl):
             seqused_k=dsa_meta.qli_seqused_k,
             cmp_residual_k=dsa_meta.qli_cmp_residual_k,
             block_table=dsa_meta.block_table,
-            metadata=dsa_meta.qli_metadata,
+            metadata=qli_metadata,
             layout_q="TND",
             layout_k="PA_BBND",
             mask_mode=3,

--- a/vllm_ascend/attention/dsa_v1.py
+++ b/vllm_ascend/attention/dsa_v1.py
@@ -42,6 +42,11 @@ from vllm_ascend.utils import (
     olora_tp_enable,
     oproj_tp_enable,
 )
+from vllm_ascend.worker.device_metadata import (
+    DeviceMetadataStage,
+    DeviceMetadataTask,
+    wait_for_device_metadata,
+)
 from vllm_ascend.worker.npu_input_batch import NPUInputBatch
 
 if TYPE_CHECKING:
@@ -612,6 +617,8 @@ class AscendDSAMetadataBuilder(AttentionMetadataBuilder[AscendDSAMetadata]):
         self.decode_qli_cmp_residual_k = torch.zeros(
             scheduler_config.max_num_seqs, dtype=torch.int32, device=self.device
         )
+        self._device_metadata_enabled = False
+        self._device_metadata_tasks: tuple[DeviceMetadataTask, ...] = ()
         self.cu_seqlens_ori_kv = torch.tensor([], device=self.device)
         self.cu_seqlens_cmp_kv = torch.tensor([], device=self.device)
         self.seqused_q = torch.tensor([], device=self.device)
@@ -683,6 +690,14 @@ class AscendDSAMetadataBuilder(AttentionMetadataBuilder[AscendDSAMetadata]):
     ):
         self.num_actual_tokens = common_attn_metadata.num_actual_tokens
 
+    def enable_device_metadata(self) -> None:
+        self._device_metadata_enabled = True
+
+    def take_device_metadata_tasks(self) -> tuple[DeviceMetadataTask, ...]:
+        tasks = self._device_metadata_tasks
+        self._device_metadata_tasks = ()
+        return tasks
+
     def _num_compressor_metadata_rows(
         self,
         build_step: int,
@@ -705,6 +720,7 @@ class AscendDSAMetadataBuilder(AttentionMetadataBuilder[AscendDSAMetadata]):
         fast_build: bool = False,
         **kwargs,
     ) -> AscendDSAMetadata:
+        self._device_metadata_tasks = ()
         num_reqs = common_attn_metadata.num_reqs
         query_start_loc = common_attn_metadata.query_start_loc
         num_reqs_actual = kwargs.get("num_reqs_actual")
@@ -1144,85 +1160,35 @@ class AscendDSAMetadataBuilder(AttentionMetadataBuilder[AscendDSAMetadata]):
         metadata_op = DeviceOperator.get_dsa_sparse_attn_metadata_op()
         metadata_kwargs = DeviceOperator.get_dsa_sparse_attn_metadata_kwargs(self.seqused_q.device)
         cu_seqlens_cmp_kv = DeviceOperator.get_dsa_decode_cu_seqlens_cmp_kv(self.cu_seqlens_cmp_kv)
-        if self.compressor_ratio <= 1:
+        sas_kwargs = dict(
+            metadata_kwargs,
+            num_heads_q=n_local_heads,
+            num_heads_kv=1,
+            head_dim=self.model_config.get_head_size(),
+            cu_seqlens_q=query_start_loc,
+            cu_seqlens_ori_kv=cu_seqlens_ori_kv,
+            cu_seqlens_cmp_kv=cu_seqlens_cmp_kv,
+            seqused_q=self.seqused_q,
+            seqused_kv=self.seq_lens[: self.num_decodes],
+            max_seqlen_q=max_seqlen_q,
+            max_seqlen_kv=max_seqlen_kv,
+            batch_size=len(self.seq_lens[: self.num_decodes]),
+            cmp_ratio=(1 if self.compressor_ratio <= 1 else 4 if self.compressor_ratio == 4 else 128),
+            ori_mask_mode=4,
+            cmp_mask_mode=3,
+            ori_win_left=self.model_config.hf_config.sliding_window - 1,
+            ori_win_right=0,
+            layout_q="TND",
+            layout_kv="PA_ND",
+            has_ori_kv=True,
+            has_cmp_kv=self.compressor_ratio > 1,
+        )
+        if self.compressor_ratio == 4:
+            sas_kwargs["cmp_topk"] = index_topk
+
+        def build_sas_metadata() -> None:
             if self.decode_ratio_to_sas_metadata.get(layer_name) is None:
-                self.decode_ratio_to_sas_metadata[layer_name] = metadata_op(
-                    **metadata_kwargs,
-                    num_heads_q=n_local_heads,
-                    num_heads_kv=1,
-                    head_dim=self.model_config.get_head_size(),
-                    cu_seqlens_q=query_start_loc,  # cached
-                    cu_seqlens_ori_kv=cu_seqlens_ori_kv,
-                    cu_seqlens_cmp_kv=cu_seqlens_cmp_kv,
-                    seqused_q=self.seqused_q,
-                    seqused_kv=self.seq_lens[: self.num_decodes],  # cached
-                    max_seqlen_q=max_seqlen_q,
-                    max_seqlen_kv=max_seqlen_kv,
-                    batch_size=len(self.seq_lens[: self.num_decodes]),  # cached
-                    cmp_ratio=1,
-                    ori_mask_mode=4,
-                    cmp_mask_mode=3,
-                    ori_win_left=self.model_config.hf_config.sliding_window - 1,
-                    ori_win_right=0,
-                    layout_q="TND",
-                    layout_kv="PA_ND",
-                    has_ori_kv=True,
-                    has_cmp_kv=False,
-                )
-            self.decode_sas_metadata[:1024] = self.decode_ratio_to_sas_metadata[layer_name]
-        elif self.compressor_ratio == 4:
-            if self.decode_ratio_to_sas_metadata.get(layer_name) is None:
-                self.decode_ratio_to_sas_metadata[layer_name] = metadata_op(
-                    **metadata_kwargs,
-                    num_heads_q=n_local_heads,
-                    num_heads_kv=1,
-                    head_dim=self.model_config.get_head_size(),
-                    cu_seqlens_q=query_start_loc,  # cached
-                    cu_seqlens_ori_kv=cu_seqlens_ori_kv,
-                    cu_seqlens_cmp_kv=cu_seqlens_cmp_kv,
-                    seqused_q=self.seqused_q,
-                    seqused_kv=self.seq_lens[: self.num_decodes],  # cached
-                    max_seqlen_q=max_seqlen_q,
-                    max_seqlen_kv=max_seqlen_kv,
-                    batch_size=len(self.seq_lens[: self.num_decodes]),  # cached
-                    cmp_topk=index_topk,
-                    # topk=index_topk,
-                    cmp_ratio=4,
-                    ori_mask_mode=4,
-                    cmp_mask_mode=3,
-                    ori_win_left=self.model_config.hf_config.sliding_window - 1,
-                    ori_win_right=0,
-                    layout_q="TND",
-                    layout_kv="PA_ND",
-                    has_ori_kv=True,
-                    has_cmp_kv=True,
-                )
-            self.decode_sas_metadata[:1024] = self.decode_ratio_to_sas_metadata[layer_name]
-        else:
-            if self.decode_ratio_to_sas_metadata.get(layer_name) is None:
-                self.decode_ratio_to_sas_metadata[layer_name] = metadata_op(
-                    **metadata_kwargs,
-                    num_heads_q=n_local_heads,
-                    num_heads_kv=1,
-                    head_dim=self.model_config.get_head_size(),
-                    cu_seqlens_q=query_start_loc,
-                    cu_seqlens_ori_kv=cu_seqlens_ori_kv,
-                    cu_seqlens_cmp_kv=cu_seqlens_cmp_kv,
-                    seqused_q=self.seqused_q,
-                    seqused_kv=self.seq_lens[: self.num_decodes],
-                    max_seqlen_q=max_seqlen_q,
-                    max_seqlen_kv=max_seqlen_kv,
-                    batch_size=len(self.seq_lens[: self.num_decodes]),
-                    cmp_ratio=128,
-                    ori_mask_mode=4,
-                    cmp_mask_mode=3,
-                    ori_win_left=self.model_config.hf_config.sliding_window - 1,
-                    ori_win_right=0,
-                    layout_q="TND",
-                    layout_kv="PA_ND",
-                    has_ori_kv=True,
-                    has_cmp_kv=True,
-                )
+                self.decode_ratio_to_sas_metadata[layer_name] = metadata_op(**sas_kwargs)
             self.decode_sas_metadata[:1024] = self.decode_ratio_to_sas_metadata[layer_name]
         qli_cu_seqlens_q = None
         qli_seqused_k = None
@@ -1243,6 +1209,13 @@ class AscendDSAMetadataBuilder(AttentionMetadataBuilder[AscendDSAMetadata]):
                 4,
                 out=qli_cmp_residual_k,
             )
+
+        assert self.decode_qli_metadata is not None
+
+        def build_qli_metadata() -> None:
+            assert qli_cu_seqlens_q is not None
+            assert qli_seqused_k is not None
+            assert qli_cmp_residual_k is not None
             if self.decode_ratio_to_sas_metadata.get("qli") is None:
                 self.decode_ratio_to_sas_metadata["qli"] = torch.ops._C_ascend.npu_quant_lightning_indexer_v2_metadata(
                     num_heads_q=self.model_config.hf_config.index_n_heads,  # 64
@@ -1262,7 +1235,20 @@ class AscendDSAMetadataBuilder(AttentionMetadataBuilder[AscendDSAMetadata]):
                     cmp_ratio=4,
                     device=str(self.seqused_q.device),
                 )
-            self.decode_qli_metadata[:1024] = self.decode_ratio_to_sas_metadata.get("qli")
+            self.decode_qli_metadata[:1024] = self.decode_ratio_to_sas_metadata["qli"]
+
+        if self._device_metadata_enabled:
+            if self.compressor_ratio == 4:
+                self._device_metadata_tasks += (
+                    DeviceMetadataTask(DeviceMetadataStage.INDEXER, build_qli_metadata, id(self.decode_qli_metadata)),
+                )
+            self._device_metadata_tasks += (
+                DeviceMetadataTask(DeviceMetadataStage.ATTENTION, build_sas_metadata, id(self.decode_sas_metadata)),
+            )
+        else:
+            if self.compressor_ratio == 4:
+                build_qli_metadata()
+            build_sas_metadata()
         decode_metadata = AscendDSADecodeMetadata(
             input_positions=input_positions,
             block_table=self.block_table[:block_table_size, ...],
@@ -2630,6 +2616,9 @@ class AscendDSAImpl(DSAAttentionImpl):
                 weights = weights_proj_output * (self.indexer_softmax_scale * self.indexer_heads**-0.5)
                 # lightning_indexer
                 indexer_scale_decode_metadata = _require_decode_metadata(indexer_kv_scale_metadata)
+                qli_metadata = indexer_scale_decode_metadata.qli_metadata
+                assert qli_metadata is not None
+                wait_for_device_metadata(DeviceMetadataStage.INDEXER, id(qli_metadata))
                 compress_topk_idxs, _ = torch.ops._C_ascend.npu_quant_lightning_indexer_v2(
                     query=q_quant,
                     key=indexer_k_cache,
@@ -2642,7 +2631,7 @@ class AscendDSAImpl(DSAAttentionImpl):
                     seqused_k=indexer_scale_decode_metadata.qli_seqused_k,
                     cmp_residual_k=indexer_scale_decode_metadata.qli_cmp_residual_k,
                     block_table=indexer_scale_decode_metadata.block_table,
-                    metadata=indexer_scale_decode_metadata.qli_metadata,
+                    metadata=qli_metadata,
                     layout_q="TND",
                     layout_k="PA_BBND",
                     mask_mode=3,
@@ -2654,6 +2643,10 @@ class AscendDSAImpl(DSAAttentionImpl):
                 self._update_indexcache_topk_indices(compress_topk_idxs, offset=0)
 
         notify_kv_cache_written(layer_name)
+        sas_metadata = (
+            swa_decode_metadata.sas_metadata if self.compress_ratio <= 1 else compressor_decode_metadata.sas_metadata
+        )
+        wait_for_device_metadata(DeviceMetadataStage.ATTENTION, id(sas_metadata))
         record_attention_compute_start()
         attn_op = DeviceOperator.get_dsa_sparse_attn_op()
         extra_attn_kwargs: dict = DeviceOperator.get_dsa_sparse_attn_base_kwargs()
@@ -2891,6 +2884,9 @@ class AscendDSAImpl(DSAAttentionImpl):
         else:
             assert indexer_kv_scale_metadata.decode is not None
             dsa_meta = indexer_kv_scale_metadata.decode
+            qli_metadata = dsa_meta.qli_metadata
+            assert qli_metadata is not None
+            wait_for_device_metadata(DeviceMetadataStage.INDEXER, id(qli_metadata))
         topk_idxs, _ = torch.ops._C_ascend.npu_quant_lightning_indexer_v2(
             query=q,
             key=indexer_k_cache,

--- a/vllm_ascend/attention/dsa_v1.py
+++ b/vllm_ascend/attention/dsa_v1.py
@@ -1029,10 +1029,13 @@ class AscendDSAMetadataBuilder(AttentionMetadataBuilder[AscendDSAMetadata]):
         if self.compressor_ratio == 4:
             sas_kwargs["cmp_topk"] = index_topk
 
+        prefill_metadata_cache = self.prefill_ratio_to_sas_metadata
+        assert prefill_metadata_cache is not None
+
         def get_sas_metadata() -> torch.Tensor:
-            if self.prefill_ratio_to_sas_metadata.get(layer_name) is None:
-                self.prefill_ratio_to_sas_metadata[layer_name] = metadata_op(**sas_kwargs)
-            return self.prefill_ratio_to_sas_metadata[layer_name]
+            if prefill_metadata_cache.get(layer_name) is None:
+                prefill_metadata_cache[layer_name] = metadata_op(**sas_kwargs)
+            return prefill_metadata_cache[layer_name]
 
         qli_cu_seqlens_q = None
         qli_seqused_k = None
@@ -1059,28 +1062,26 @@ class AscendDSAMetadataBuilder(AttentionMetadataBuilder[AscendDSAMetadata]):
             assert qli_cu_seqlens_q is not None
             assert qli_seqused_k is not None
             assert qli_cmp_residual_k is not None
-            if self.prefill_ratio_to_sas_metadata.get("qli") is None:
-                self.prefill_ratio_to_sas_metadata["qli"] = (
-                    torch.ops._C_ascend.npu_quant_lightning_indexer_v2_metadata(
-                        num_heads_q=self.model_config.hf_config.index_n_heads,  # 64
-                        num_heads_k=1,
-                        head_dim=self.model_config.hf_config.index_head_dim,  # 128
-                        topk=self.model_config.hf_config.index_topk,
-                        quant_mode=2,
-                        cu_seqlens_q=qli_cu_seqlens_q,
-                        seqused_k=qli_seqused_k,
-                        cmp_residual_k=qli_cmp_residual_k,
-                        batch_size=len(self.seq_lens[reqs_start:]),
-                        max_seqlen_q=max_query_len,
-                        max_seqlen_k=max_seq_lens // 4,
-                        layout_q="TND",
-                        layout_k="PA_BBND",
-                        mask_mode=3,
-                        cmp_ratio=4,
-                        device=str(self.seqused_q.device),
-                    )
+            if prefill_metadata_cache.get("qli") is None:
+                prefill_metadata_cache["qli"] = torch.ops._C_ascend.npu_quant_lightning_indexer_v2_metadata(
+                    num_heads_q=self.model_config.hf_config.index_n_heads,  # 64
+                    num_heads_k=1,
+                    head_dim=self.model_config.hf_config.index_head_dim,  # 128
+                    topk=self.model_config.hf_config.index_topk,
+                    quant_mode=2,
+                    cu_seqlens_q=qli_cu_seqlens_q,
+                    seqused_k=qli_seqused_k,
+                    cmp_residual_k=qli_cmp_residual_k,
+                    batch_size=len(self.seq_lens[reqs_start:]),
+                    max_seqlen_q=max_query_len,
+                    max_seqlen_k=max_seq_lens // 4,
+                    layout_q="TND",
+                    layout_k="PA_BBND",
+                    mask_mode=3,
+                    cmp_ratio=4,
+                    device=str(self.seqused_q.device),
                 )
-            return self.prefill_ratio_to_sas_metadata["qli"]
+            return prefill_metadata_cache["qli"]
 
         if self._device_metadata_enabled:
 
@@ -1246,7 +1247,8 @@ class AscendDSAMetadataBuilder(AttentionMetadataBuilder[AscendDSAMetadata]):
         n_local_heads = self.model_config.hf_config.num_attention_heads // tp_size
         index_topk = self.model_config.hf_config.index_topk
 
-        assert self.decode_sas_metadata is not None
+        decode_sas_metadata = self.decode_sas_metadata
+        assert decode_sas_metadata is not None
 
         cu_seqlens_ori_kv = DeviceOperator.get_dsa_decode_cu_seqlens_ori_kv(
             self.decode_ratio_to_sas_metadata,
@@ -1285,10 +1287,9 @@ class AscendDSAMetadataBuilder(AttentionMetadataBuilder[AscendDSAMetadata]):
         if self.compressor_ratio == 4:
             sas_kwargs["cmp_topk"] = index_topk
 
-        def build_sas_metadata() -> None:
-            if self.decode_ratio_to_sas_metadata.get(layer_name) is None:
-                self.decode_ratio_to_sas_metadata[layer_name] = metadata_op(**sas_kwargs)
-            self.decode_sas_metadata[:1024] = self.decode_ratio_to_sas_metadata[layer_name]
+        decode_metadata_cache = self.decode_ratio_to_sas_metadata
+        assert decode_metadata_cache is not None
+
         qli_cu_seqlens_q = None
         qli_seqused_k = None
         qli_cmp_residual_k = None
@@ -1309,14 +1310,20 @@ class AscendDSAMetadataBuilder(AttentionMetadataBuilder[AscendDSAMetadata]):
                 out=qli_cmp_residual_k,
             )
 
-        assert self.decode_qli_metadata is not None
+        def build_sas_metadata() -> None:
+            if decode_metadata_cache.get(layer_name) is None:
+                decode_metadata_cache[layer_name] = metadata_op(**sas_kwargs)
+            decode_sas_metadata[:1024] = decode_metadata_cache[layer_name]
+
+        decode_qli_metadata = self.decode_qli_metadata
+        assert decode_qli_metadata is not None
 
         def build_qli_metadata() -> None:
             assert qli_cu_seqlens_q is not None
             assert qli_seqused_k is not None
             assert qli_cmp_residual_k is not None
-            if self.decode_ratio_to_sas_metadata.get("qli") is None:
-                self.decode_ratio_to_sas_metadata["qli"] = torch.ops._C_ascend.npu_quant_lightning_indexer_v2_metadata(
+            if decode_metadata_cache.get("qli") is None:
+                decode_metadata_cache["qli"] = torch.ops._C_ascend.npu_quant_lightning_indexer_v2_metadata(
                     num_heads_q=self.model_config.hf_config.index_n_heads,  # 64
                     num_heads_k=1,
                     head_dim=self.model_config.hf_config.index_head_dim,  # 128
@@ -1334,15 +1341,15 @@ class AscendDSAMetadataBuilder(AttentionMetadataBuilder[AscendDSAMetadata]):
                     cmp_ratio=4,
                     device=str(self.seqused_q.device),
                 )
-            self.decode_qli_metadata[:1024] = self.decode_ratio_to_sas_metadata["qli"]
+            decode_qli_metadata[:1024] = decode_metadata_cache["qli"]
 
         if self._device_metadata_enabled:
             if self.compressor_ratio == 4:
                 self._device_metadata_tasks += (
-                    DeviceMetadataTask(DeviceMetadataStage.INDEXER, build_qli_metadata, id(self.decode_qli_metadata)),
+                    DeviceMetadataTask(DeviceMetadataStage.INDEXER, build_qli_metadata, id(decode_qli_metadata)),
                 )
             self._device_metadata_tasks += (
-                DeviceMetadataTask(DeviceMetadataStage.ATTENTION, build_sas_metadata, id(self.decode_sas_metadata)),
+                DeviceMetadataTask(DeviceMetadataStage.ATTENTION, build_sas_metadata, id(decode_sas_metadata)),
             )
         else:
             if self.compressor_ratio == 4:

--- a/vllm_ascend/attention/dsa_v1.py
+++ b/vllm_ascend/attention/dsa_v1.py
@@ -492,6 +492,7 @@ def build_dspark_swa_indices(
     seq_lens: torch.Tensor,
     num_decode_tokens: int | None = None,
     index_width: int | None = None,
+    indices_output: torch.Tensor | None = None,
 ) -> tuple[torch.Tensor, torch.Tensor]:
     """Build DSpark non-causal visible slot ids for a paged SWA cache.
 
@@ -530,6 +531,15 @@ def build_dspark_swa_indices(
 
     per_token_slots = torch.repeat_interleave(slot_ids, query_lens, dim=0, output_size=num_decode_tokens).unsqueeze(1)
     per_token_lens = torch.repeat_interleave(visible_lens, query_lens, dim=0, output_size=num_decode_tokens)
+
+    if indices_output is not None:
+        if indices_output.shape != per_token_slots.shape:
+            raise ValueError(
+                "DSpark SWA indices output shape does not match active metadata: "
+                f"output={tuple(indices_output.shape)}, active={tuple(per_token_slots.shape)}"
+            )
+        indices_output.copy_(per_token_slots)
+        per_token_slots = indices_output
 
     return per_token_slots, per_token_lens
 
@@ -658,6 +668,7 @@ class AscendDSAMetadataBuilder(AttentionMetadataBuilder[AscendDSAMetadata]):
         self._device_metadata_tasks: tuple[DeviceMetadataTask, ...] = ()
         self.prefill_compressor_metadata_buffers: CompressorMetadataOutput | None = None
         self.decode_compressor_metadata_buffers: CompressorMetadataOutput | None = None
+        self.dspark_swa_indices_buffer: torch.Tensor | None = None
         self.cu_seqlens_ori_kv = torch.tensor([], device=self.device)
         self.cu_seqlens_cmp_kv = torch.tensor([], device=self.device)
         self.seqused_q = torch.tensor([], device=self.device)
@@ -748,6 +759,19 @@ class AscendDSAMetadataBuilder(AttentionMetadataBuilder[AscendDSAMetadata]):
             torch.empty(output_shape, dtype=torch.float32, device=self.device),
             torch.empty(output_shape, dtype=torch.float32, device=self.device),
             torch.empty(self.slot_mapping_shape, dtype=torch.int32, device=self.device),
+        )
+
+    def enable_dspark_device_metadata(self, max_num_tokens: int) -> None:
+        self.enable_device_metadata()
+        assert self.speculative_config is not None
+        index_width = _aligned_dspark_index_width(
+            self.model_config.hf_config.sliding_window,
+            self.speculative_config.num_speculative_tokens,
+        )
+        self.dspark_swa_indices_buffer = torch.empty(
+            (max_num_tokens, 1, index_width),
+            dtype=torch.int32,
+            device=self.device,
         )
 
     def take_device_metadata_tasks(self) -> tuple[DeviceMetadataTask, ...]:
@@ -1381,6 +1405,7 @@ class AscendDSAMetadataBuilder(AttentionMetadataBuilder[AscendDSAMetadata]):
         **kwargs,
     ) -> AscendDSADecodeMetadata:
         assert self.compressor_ratio <= 1, "vLLM-Ascend only support SWA-layer for Deepseek-V4 now."
+        self._device_metadata_tasks = ()
         # DSpark drafting operates on the paged SWA cache, whose block size is the
         # kv_cache_spec block size passed by the proposer (== swa_cache_layer.block_size),
         # NOT this builder's default MLA block size (128). Honor the kwarg so the
@@ -1554,11 +1579,12 @@ class AscendDSAMetadataBuilder(AttentionMetadataBuilder[AscendDSAMetadata]):
 
         slot_mapping = self.spec_slot_mapping[draft_index - 1][:num_decode_tokens_typed]  # type: ignore[index]
         dspark_swa_indices = None
+        build_dspark_swa = None
         ori_win_left, ori_win_right = self.model_config.hf_config.sliding_window - 1, 0
         block_table = common_attn_metadata.block_table_tensor
         if not common_attn_metadata.causal:
             assert num_decodes is not None
-            dspark_swa_indices, _ = build_dspark_swa_indices(
+            dspark_swa_args = (
                 block_table[:num_decodes],
                 self.speculative_config.num_speculative_tokens,
                 self.model_config.hf_config.sliding_window,
@@ -1567,37 +1593,68 @@ class AscendDSAMetadataBuilder(AttentionMetadataBuilder[AscendDSAMetadata]):
                 seq_lens[:num_decodes],
                 num_decode_tokens,
             )
-            dspark_swa_indices = dspark_swa_indices[:num_decode_tokens_typed]
+            if self._device_metadata_enabled and num_decodes_typed == common_attn_metadata.num_reqs:
+                if self.dspark_swa_indices_buffer is None:
+                    raise RuntimeError(
+                        "DSpark device metadata buffers must be initialized before building draft attention metadata"
+                    )
+                if num_decode_tokens_typed > self.dspark_swa_indices_buffer.shape[0]:
+                    raise ValueError(
+                        "DSpark SWA metadata rows exceed the persistent buffer capacity: "
+                        f"active={num_decode_tokens_typed}, capacity={self.dspark_swa_indices_buffer.shape[0]}"
+                    )
+                dspark_swa_indices = self.dspark_swa_indices_buffer[:num_decode_tokens_typed]
+                build_dspark_swa = lambda: build_dspark_swa_indices(
+                    *dspark_swa_args,
+                    indices_output=dspark_swa_indices,
+                )
+            else:
+                dspark_swa_indices, _ = build_dspark_swa_indices(*dspark_swa_args)
+                dspark_swa_indices = dspark_swa_indices[:num_decode_tokens_typed]
             ori_win_left, ori_win_right = get_dspark_sparse_sas_window(self.vllm_config)
 
         metadata_op = DeviceOperator.get_dsa_sparse_attn_metadata_op()
         metadata_kwargs = DeviceOperator.get_dsa_sparse_attn_metadata_kwargs(self.seqused_q.device)
 
-        decode_sas_metadata = metadata_op(
-            **metadata_kwargs,
-            num_heads_q=n_local_heads,
-            num_heads_kv=1,
-            head_dim=self.model_config.get_head_size(),
-            cu_seqlens_q=query_start_loc,
-            cu_seqlens_ori_kv=self.cu_seqlens_ori_kv,
-            cu_seqlens_cmp_kv=self.cu_seqlens_cmp_kv,
-            seqused_q=self.seqused_q,
-            seqused_kv=seq_lens[:num_decodes],
-            max_seqlen_q=max_seqlen_q,
-            max_seqlen_kv=max_seqlen_kv,
-            batch_size=len(seq_lens[:num_decodes]),
-            cmp_ratio=1,
-            ori_mask_mode=4,
-            cmp_mask_mode=3,
-            ori_win_left=ori_win_left,
-            ori_win_right=ori_win_right,
-            layout_q="TND",
-            layout_kv="PA_ND",
-            has_ori_kv=True,
-            has_cmp_kv=False,
-        )
-        self.spec_sas_metadata[draft_index - 1][:1024].copy_(decode_sas_metadata[:1024])
+        def build_attention_metadata() -> None:
+            if build_dspark_swa is not None:
+                build_dspark_swa()
+            result = metadata_op(
+                **metadata_kwargs,
+                num_heads_q=n_local_heads,
+                num_heads_kv=1,
+                head_dim=self.model_config.get_head_size(),
+                cu_seqlens_q=query_start_loc,
+                cu_seqlens_ori_kv=self.cu_seqlens_ori_kv,
+                cu_seqlens_cmp_kv=self.cu_seqlens_cmp_kv,
+                seqused_q=self.seqused_q,
+                seqused_kv=seq_lens[:num_decodes],
+                max_seqlen_q=max_seqlen_q,
+                max_seqlen_kv=max_seqlen_kv,
+                batch_size=len(seq_lens[:num_decodes]),
+                cmp_ratio=1,
+                ori_mask_mode=4,
+                cmp_mask_mode=3,
+                ori_win_left=ori_win_left,
+                ori_win_right=ori_win_right,
+                layout_q="TND",
+                layout_kv="PA_ND",
+                has_ori_kv=True,
+                has_cmp_kv=False,
+            )
+            self.spec_sas_metadata[draft_index - 1][:1024].copy_(result[:1024])
+
         decode_sas_metadata = self.spec_sas_metadata[draft_index - 1]
+        if build_dspark_swa is not None:
+            self._device_metadata_tasks = (
+                DeviceMetadataTask(
+                    DeviceMetadataStage.ATTENTION,
+                    build_attention_metadata,
+                    id(decode_sas_metadata),
+                ),
+            )
+        else:
+            build_attention_metadata()
 
         decode_metadata = AscendDSADecodeMetadata(
             input_positions=None,

--- a/vllm_ascend/attention/dsa_v1.py
+++ b/vllm_ascend/attention/dsa_v1.py
@@ -2812,9 +2812,11 @@ class AscendDSAImpl(DSAAttentionImpl):
                 self._update_indexcache_topk_indices(compress_topk_idxs, offset=0)
 
         notify_kv_cache_written(layer_name)
-        sas_metadata = (
-            swa_decode_metadata.sas_metadata if self.compress_ratio <= 1 else compressor_decode_metadata.sas_metadata
-        )
+        if self.compress_ratio <= 1:
+            sas_metadata = swa_decode_metadata.sas_metadata
+        else:
+            assert compressor_decode_metadata is not None
+            sas_metadata = compressor_decode_metadata.sas_metadata
         wait_for_device_metadata(DeviceMetadataStage.ATTENTION, id(sas_metadata))
         record_attention_compute_start()
         attn_op = DeviceOperator.get_dsa_sparse_attn_op()

--- a/vllm_ascend/spec_decode/dspark_proposer.py
+++ b/vllm_ascend/spec_decode/dspark_proposer.py
@@ -12,6 +12,7 @@ from vllm.v1.worker.utils import AttentionGroup
 
 from vllm_ascend.ascend_forward_context import set_ascend_forward_context
 from vllm_ascend.attention.attention_v1 import AscendAttentionState
+from vllm_ascend.attention.dsa_v1 import AscendDSAMetadataBuilder
 from vllm_ascend.attention.mla_v1 import AscendMLAMetadataBuilder
 from vllm_ascend.ops.triton.spec_decode.utils import copy_and_expand_dflash_and_dspark_inputs_kernel_single_grid
 from vllm_ascend.spec_decode.dflash_proposer import AscendDflashProposer
@@ -202,6 +203,16 @@ class AscendDSparkProposer(AscendDflashProposer):
                 "DSpark standard-cache path requires registered draft attention "
                 f"groups. Missing layers: {self.attn_layer_names}"
             )
+
+        if (
+            getattr(self.runner, "device_metadata_executor", None) is not None
+            and self.dcp_size == 1
+            and self.vllm_config.parallel_config.prefill_context_parallel_size == 1
+        ):
+            for attn_group in self.draft_attn_groups:
+                builder = attn_group.get_metadata_builder()
+                if isinstance(builder, AscendDSAMetadataBuilder):
+                    builder.enable_dspark_device_metadata(self.max_query_tokens)
 
         self.kv_cache_gid = self.draft_attn_groups[0].kv_cache_group_id
         self.kernel_block_size = self._per_group_kernel_block_sizes[self.kv_cache_gid]

--- a/vllm_ascend/spec_decode/llm_base_proposer.py
+++ b/vllm_ascend/spec_decode/llm_base_proposer.py
@@ -64,6 +64,7 @@ from vllm_ascend.spec_decode.utils import (
     patch_tensor_parallel_group,
 )
 from vllm_ascend.utils import check_gdn_layer, enable_sp, lmhead_tp_enable
+from vllm_ascend.worker.device_metadata import DeviceMetadataTask, DeviceMetadataTaskProvider
 
 # Currently we will fix block size to a small one since `num_reqs` can't be too large
 _PREPARE_INPUTS_BLOCK_SIZE = 4
@@ -1252,6 +1253,11 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
         self.token_indices_to_sample[:token_indices_to_sample_len].copy_(token_indices_to_sample)
         self.token_indices_to_sample[token_indices_to_sample_len:].fill_(0)
 
+        active_device_metadata_executor = (
+            getattr(self.runner, "device_metadata_executor", None) if self.method == "dspark" else None
+        )
+        if active_device_metadata_executor is not None and not active_device_metadata_executor.submission_in_flight:
+            active_device_metadata_executor = None
         with set_ascend_forward_context(
             multi_steps_attn_metadata[0],
             self.vllm_config,
@@ -1262,6 +1268,7 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
             aclgraph_runtime_mode=aclgraph_runtime_mode,
             is_draft_model=True,
             draft_attn_metadatas=multi_steps_attn_metadata,
+            device_metadata_executor=active_device_metadata_executor,
             eplb_heat_collection_status=(
                 self.runner.eplb_heat_collection_status if self.runner.dynamic_eplb else False
             ),
@@ -1290,6 +1297,8 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
             else:
                 draft_token_ids = run_draft()
                 self._update_full_graph_params_if_needed(forward_context, num_input_tokens, multi_steps_attn_metadata)
+        if active_device_metadata_executor is not None:
+            active_device_metadata_executor.release()
         return draft_token_ids
 
     def compute_draft_token_ids(self, hidden_states: torch.Tensor):
@@ -2413,8 +2422,21 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
         # FIXME(woosuk): The below two ops cause synchronization. Optimize.
         assert len(self.draft_attn_groups) > 0
         per_layer_attn_metadata: dict[str, Any] = {}
+        device_metadata_tasks: list[DeviceMetadataTask] = []
+        device_metadata_executor = (
+            getattr(self.runner, "device_metadata_executor", None)
+            if self.method == "dspark"
+            and self.dcp_size == 1
+            and self.vllm_config.parallel_config.prefill_context_parallel_size == 1
+            else None
+        )
         for attn_group in self.draft_attn_groups:
             builder = attn_group.get_metadata_builder()
+            device_metadata_provider = (
+                builder
+                if device_metadata_executor is not None and isinstance(builder, DeviceMetadataTaskProvider)
+                else None
+            )
             extra_attn_metadata_args: dict = {}
             if self.use_compress:
                 extra_attn_metadata_args = dict(
@@ -2435,6 +2457,8 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
                 attn_metadata = builder.build_for_drafting(
                     common_attn_metadata, draft_index=1, **extra_attn_metadata_args
                 )
+                if device_metadata_provider is not None:
+                    device_metadata_tasks.extend(device_metadata_provider.take_device_metadata_tasks())
             else:
                 attn_metadata = builder.build(
                     0, common_attn_metadata, self.runner.get_model(), **extra_attn_metadata_args
@@ -2444,6 +2468,9 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
 
             for layer_name in attn_group.layer_names:
                 per_layer_attn_metadata[layer_name] = attn_metadata
+        if device_metadata_tasks:
+            assert device_metadata_executor is not None
+            device_metadata_executor.submit(device_metadata_tasks)
         multi_steps_attn_metadata = [per_layer_attn_metadata]
         # Copy the old attn_metadata and update
         attn_metadata_i = per_layer_attn_metadata[self.draft_attn_groups[0].layer_names[0]]

--- a/vllm_ascend/worker/device_metadata.py
+++ b/vllm_ascend/worker/device_metadata.py
@@ -19,7 +19,7 @@ from enum import IntEnum
 from typing import Protocol, runtime_checkable
 
 import torch
-from vllm.forward_context import get_forward_context, is_forward_context_available
+from vllm.forward_context import BatchDescriptor, get_forward_context, is_forward_context_available
 
 
 class DeviceMetadataStage(IntEnum):
@@ -49,27 +49,48 @@ class DeviceMetadataExecutor:
         self.stream = torch.npu.Stream()
         self._inputs_ready = torch.npu.Event()
         self._stage_ready: dict[tuple[DeviceMetadataStage, int], torch.npu.Event] = {}
+        self._external_stage_ready: dict[tuple[BatchDescriptor, DeviceMetadataStage, int], torch.npu.ExternalEvent] = {}
+        self._external_frontiers: dict[BatchDescriptor, tuple[tuple[DeviceMetadataStage, int], ...]] = {}
         self._buffer_reusable = torch.npu.Event()
         self._has_reuse_fence = False
         self._submission_in_flight = False
         self._waited_stages: set[tuple[DeviceMetadataStage, int]] = set()
+        self._batch_descriptor: BatchDescriptor | None = None
 
     @property
     def submission_in_flight(self) -> bool:
         return self._submission_in_flight
 
-    def submit(self, tasks: Iterable[DeviceMetadataTask]) -> None:
+    @property
+    def uses_external_events(self) -> bool:
+        return self._batch_descriptor is not None
+
+    def submit(
+        self,
+        tasks: Iterable[DeviceMetadataTask],
+        batch_descriptor: BatchDescriptor | None = None,
+    ) -> None:
         if self._submission_in_flight:
             raise RuntimeError("The previous device metadata submission has not been released")
         ordered_tasks = tuple(sorted(tasks, key=lambda task: task.stage))
         if not ordered_tasks:
             raise ValueError("At least one device metadata task is required")
+        submitted_frontiers = tuple(dict.fromkeys((task.stage, task.group_id) for task in ordered_tasks))
+        expected_frontiers = self._external_frontiers.get(batch_descriptor) if batch_descriptor is not None else None
+        if expected_frontiers is not None and expected_frontiers != submitted_frontiers:
+            raise RuntimeError("Device metadata frontiers changed for an existing full-graph batch descriptor")
         for task in ordered_tasks:
             frontier = (task.stage, task.group_id)
-            if frontier not in self._stage_ready:
+            external_frontier = (batch_descriptor, *frontier) if batch_descriptor is not None else None
+            if external_frontier is not None and external_frontier not in self._external_stage_ready:
+                self._external_stage_ready[external_frontier] = torch.npu.ExternalEvent()
+            elif external_frontier is None and frontier not in self._stage_ready:
                 self._stage_ready[frontier] = torch.npu.Event()
+        if batch_descriptor is not None and expected_frontiers is None:
+            self._external_frontiers[batch_descriptor] = submitted_frontiers
 
         self._submission_in_flight = True
+        self._batch_descriptor = batch_descriptor
         self._waited_stages.clear()
         self._inputs_ready.record(torch.npu.current_stream())
         with torch.npu.stream(self.stream):
@@ -82,7 +103,11 @@ class DeviceMetadataExecutor:
                 while task_index < len(ordered_tasks) and ordered_tasks[task_index].stage == stage:
                     task = ordered_tasks[task_index]
                     task.run()
-                    self._stage_ready[(stage, task.group_id)].record(self.stream)
+                    frontier = (stage, task.group_id)
+                    if batch_descriptor is None:
+                        self._stage_ready[frontier].record(self.stream)
+                    else:
+                        self._external_stage_ready[(batch_descriptor, *frontier)].record(self.stream)
                     task_index += 1
 
     def wait(self, stage: DeviceMetadataStage, group_id: int) -> None:
@@ -90,7 +115,13 @@ class DeviceMetadataExecutor:
             raise RuntimeError("No device metadata submission is in flight")
         frontier = (stage, group_id)
         if frontier not in self._waited_stages:
-            torch.npu.current_stream().wait_event(self._stage_ready[frontier])
+            stream = torch.npu.current_stream()
+            if self._batch_descriptor is None:
+                stream.wait_event(self._stage_ready[frontier])
+            else:
+                event = self._external_stage_ready[(self._batch_descriptor, *frontier)]
+                event.wait(stream)
+                event.reset(stream)
             self._waited_stages.add(frontier)
 
     def release(self) -> None:
@@ -99,6 +130,7 @@ class DeviceMetadataExecutor:
         self._buffer_reusable.record(torch.npu.current_stream())
         self._has_reuse_fence = True
         self._submission_in_flight = False
+        self._batch_descriptor = None
 
 
 def wait_for_device_metadata(stage: DeviceMetadataStage, group_id: int) -> None:

--- a/vllm_ascend/worker/device_metadata.py
+++ b/vllm_ascend/worker/device_metadata.py
@@ -1,0 +1,109 @@
+#
+# Copyright (c) 2026 Huawei Technologies Co., Ltd. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from collections.abc import Callable, Iterable
+from dataclasses import dataclass
+from enum import IntEnum
+from typing import Protocol, runtime_checkable
+
+import torch
+from vllm.forward_context import get_forward_context, is_forward_context_available
+
+
+class DeviceMetadataStage(IntEnum):
+    COMPRESSOR = 0
+    INDEXER = 1
+    ATTENTION = 2
+
+
+@dataclass(frozen=True, slots=True)
+class DeviceMetadataTask:
+    stage: DeviceMetadataStage
+    run: Callable[[], None]
+    group_id: int
+
+
+@runtime_checkable
+class DeviceMetadataTaskProvider(Protocol):
+    def enable_device_metadata(self) -> None: ...
+
+    def take_device_metadata_tasks(self) -> tuple[DeviceMetadataTask, ...]: ...
+
+
+class DeviceMetadataExecutor:
+    """Submit device metadata tasks on a worker-owned NPU stream."""
+
+    def __init__(self) -> None:
+        self.stream = torch.npu.Stream()
+        self._inputs_ready = torch.npu.Event()
+        self._stage_ready: dict[tuple[DeviceMetadataStage, int], torch.npu.Event] = {}
+        self._buffer_reusable = torch.npu.Event()
+        self._has_reuse_fence = False
+        self._submission_in_flight = False
+        self._waited_stages: set[tuple[DeviceMetadataStage, int]] = set()
+
+    @property
+    def submission_in_flight(self) -> bool:
+        return self._submission_in_flight
+
+    def submit(self, tasks: Iterable[DeviceMetadataTask]) -> None:
+        if self._submission_in_flight:
+            raise RuntimeError("The previous device metadata submission has not been released")
+        ordered_tasks = tuple(sorted(tasks, key=lambda task: task.stage))
+        if not ordered_tasks:
+            raise ValueError("At least one device metadata task is required")
+        for task in ordered_tasks:
+            frontier = (task.stage, task.group_id)
+            if frontier not in self._stage_ready:
+                self._stage_ready[frontier] = torch.npu.Event()
+
+        self._submission_in_flight = True
+        self._waited_stages.clear()
+        self._inputs_ready.record(torch.npu.current_stream())
+        with torch.npu.stream(self.stream):
+            self.stream.wait_event(self._inputs_ready)
+            if self._has_reuse_fence:
+                self.stream.wait_event(self._buffer_reusable)
+
+            task_index = 0
+            for stage in DeviceMetadataStage:
+                while task_index < len(ordered_tasks) and ordered_tasks[task_index].stage == stage:
+                    task = ordered_tasks[task_index]
+                    task.run()
+                    self._stage_ready[(stage, task.group_id)].record(self.stream)
+                    task_index += 1
+
+    def wait(self, stage: DeviceMetadataStage, group_id: int) -> None:
+        if not self._submission_in_flight:
+            raise RuntimeError("No device metadata submission is in flight")
+        frontier = (stage, group_id)
+        if frontier not in self._waited_stages:
+            torch.npu.current_stream().wait_event(self._stage_ready[frontier])
+            self._waited_stages.add(frontier)
+
+    def release(self) -> None:
+        if not self._submission_in_flight:
+            raise RuntimeError("No device metadata submission is in flight")
+        self._buffer_reusable.record(torch.npu.current_stream())
+        self._has_reuse_fence = True
+        self._submission_in_flight = False
+
+
+def wait_for_device_metadata(stage: DeviceMetadataStage, group_id: int) -> None:
+    if not is_forward_context_available():
+        return
+    executor = getattr(get_forward_context(), "device_metadata_executor", None)
+    if executor is not None:
+        executor.wait(stage, group_id)

--- a/vllm_ascend/worker/model_runner_v1.py
+++ b/vllm_ascend/worker/model_runner_v1.py
@@ -2123,6 +2123,9 @@ class NPUModelRunner(GPUModelRunner):
         defer_kv_connector_finalize = self.speculative_config is not None and (
             get_pp_group().is_last_rank or self.broadcast_pp_output
         )
+        active_device_metadata_executor = self.device_metadata_executor
+        if active_device_metadata_executor is not None and not active_device_metadata_executor.submission_in_flight:
+            active_device_metadata_executor = None
         with (
             record_function_or_nullcontext("forward"),
             set_ascend_forward_context(
@@ -2134,6 +2137,7 @@ class NPUModelRunner(GPUModelRunner):
                 batch_descriptor=batch_desc,
                 num_actual_tokens=scheduler_output.total_num_scheduled_tokens,
                 model_instance=self.model,
+                device_metadata_executor=active_device_metadata_executor,
                 skip_compiled=has_encoder_input,
                 has_sinks=self._has_sinks,
                 input_ids=input_ids,
@@ -2151,6 +2155,8 @@ class NPUModelRunner(GPUModelRunner):
             hidden_states = self._model_forward(
                 num_tokens_padded, input_ids, positions, intermediate_tensors, inputs_embeds, **model_kwargs
             )
+        if active_device_metadata_executor is not None:
+            active_device_metadata_executor.release()
         with record_function_or_nullcontext("post process"):
             aux_hidden_states = None
             if self.use_aux_hidden_state_outputs:
@@ -3529,6 +3535,9 @@ class NPUModelRunner(GPUModelRunner):
                 if hasattr(self.drafter, "model") and hasattr(self.drafter.model, "compute_logits"):
                     return self.drafter.model.compute_logits(hidden_states[dummy_indices])
 
+            active_device_metadata_executor = self.device_metadata_executor
+            if active_device_metadata_executor is not None and not active_device_metadata_executor.submission_in_flight:
+                active_device_metadata_executor = None
             with set_ascend_forward_context(
                 attn_metadata,
                 self.vllm_config,
@@ -3539,6 +3548,7 @@ class NPUModelRunner(GPUModelRunner):
                 aclgraph_runtime_mode=cudagraph_runtime_mode,
                 batch_descriptor=batch_desc,
                 model_instance=self.model,
+                device_metadata_executor=active_device_metadata_executor,
                 has_sinks = self._has_sinks,
                 input_ids=input_ids,
                 eplb_heat_collection_status=self.eplb_heat_collection_status if self.dynamic_eplb else False,
@@ -3546,6 +3556,8 @@ class NPUModelRunner(GPUModelRunner):
                 outputs = self._model_forward(
                     num_tokens_padded, input_ids, positions, intermediate_tensors, inputs_embeds
                 )
+            if active_device_metadata_executor is not None:
+                active_device_metadata_executor.release()
             if self.use_aux_hidden_state_outputs:
                 hidden_states, _ = outputs
             else:

--- a/vllm_ascend/worker/model_runner_v1.py
+++ b/vllm_ascend/worker/model_runner_v1.py
@@ -2082,6 +2082,7 @@ class NPUModelRunner(GPUModelRunner):
                     num_scheduled_tokens_np=num_scheduled_tokens_np,
                     cascade_attn_prefix_lens=cascade_attn_prefix_lens,
                     cudagraph_runtime_mode=cudagraph_mode,
+                    batch_descriptor=batch_desc,
                 )
 
                 self._sanitize_placeholder_input_ids_for_forward(
@@ -2124,9 +2125,7 @@ class NPUModelRunner(GPUModelRunner):
         defer_kv_connector_finalize = self.speculative_config is not None and (
             get_pp_group().is_last_rank or self.broadcast_pp_output
         )
-        active_device_metadata_executor = self.device_metadata_executor
-        if active_device_metadata_executor is not None and not active_device_metadata_executor.submission_in_flight:
-            active_device_metadata_executor = None
+        active_device_metadata_executor = self._prepare_device_metadata_for_forward(cudagraph_mode)
         with (
             record_function_or_nullcontext("forward"),
             set_ascend_forward_context(
@@ -2730,6 +2729,16 @@ class NPUModelRunner(GPUModelRunner):
             hidden_states = self._all_gather_hidden_states_and_aux(hidden_states)
         return hidden_states
 
+    def _prepare_device_metadata_for_forward(
+        self, cudagraph_runtime_mode: CUDAGraphMode
+    ) -> DeviceMetadataExecutor | None:
+        executor = self.device_metadata_executor
+        if executor is None or not executor.submission_in_flight:
+            return None
+        if cudagraph_runtime_mode == CUDAGraphMode.FULL and not executor.uses_external_events:
+            raise RuntimeError("Full-graph device metadata requires external events")
+        return executor
+
     def _pad_for_sequence_parallelism(self, num_scheduled_tokens: int) -> int:
         # Pad tokens to multiple of tensor_parallel_size when
         # enabled collective fusion for SP
@@ -2902,6 +2911,7 @@ class NPUModelRunner(GPUModelRunner):
         cascade_attn_prefix_lens: list[list[int]] | None = None,
         skip_gdn_state_update: bool = False,
         cudagraph_runtime_mode: CUDAGraphMode | None = None,
+        batch_descriptor: BatchDescriptor | None = None,
     ) -> tuple[PerLayerAttnMetadata, CommonAttentionMetadata | None]:
         """
         :return: tuple[attn_metadata, spec_decode_common_attn_metadata]
@@ -3250,7 +3260,10 @@ class NPUModelRunner(GPUModelRunner):
             spec_decode_common_attn_metadata = spec_decode_common_attn_metadata.unpadded(num_tokens, num_reqs)
         if device_metadata_tasks:
             assert self.device_metadata_executor is not None
-            self.device_metadata_executor.submit(device_metadata_tasks)
+            self.device_metadata_executor.submit(
+                device_metadata_tasks,
+                batch_descriptor if cudagraph_runtime_mode == CUDAGraphMode.FULL else None,
+            )
         return attn_metadata, spec_decode_common_attn_metadata
 
     def _should_build_dummy_attn_metadata(
@@ -3467,6 +3480,7 @@ class NPUModelRunner(GPUModelRunner):
                     num_scheduled_tokens_np=num_scheduled_tokens,
                     skip_gdn_state_update=skip_gdn_state_update,
                     cudagraph_runtime_mode=cudagraph_runtime_mode,
+                    batch_descriptor=batch_desc,
                 )
         with self.maybe_dummy_run_with_lora(
             self.lora_config,
@@ -3539,9 +3553,7 @@ class NPUModelRunner(GPUModelRunner):
                 if hasattr(self.drafter, "model") and hasattr(self.drafter.model, "compute_logits"):
                     return self.drafter.model.compute_logits(hidden_states[dummy_indices])
 
-            active_device_metadata_executor = self.device_metadata_executor
-            if active_device_metadata_executor is not None and not active_device_metadata_executor.submission_in_flight:
-                active_device_metadata_executor = None
+            active_device_metadata_executor = self._prepare_device_metadata_for_forward(cudagraph_runtime_mode)
             with set_ascend_forward_context(
                 attn_metadata,
                 self.vllm_config,

--- a/vllm_ascend/worker/model_runner_v1.py
+++ b/vllm_ascend/worker/model_runner_v1.py
@@ -2081,6 +2081,7 @@ class NPUModelRunner(GPUModelRunner):
                     num_scheduled_tokens=scheduler_output.num_scheduled_tokens,
                     num_scheduled_tokens_np=num_scheduled_tokens_np,
                     cascade_attn_prefix_lens=cascade_attn_prefix_lens,
+                    cudagraph_runtime_mode=cudagraph_mode,
                 )
 
                 self._sanitize_placeholder_input_ids_for_forward(
@@ -2900,6 +2901,7 @@ class NPUModelRunner(GPUModelRunner):
         num_scheduled_tokens_np: np.ndarray | None = None,
         cascade_attn_prefix_lens: list[list[int]] | None = None,
         skip_gdn_state_update: bool = False,
+        cudagraph_runtime_mode: CUDAGraphMode | None = None,
     ) -> tuple[PerLayerAttnMetadata, CommonAttentionMetadata | None]:
         """
         :return: tuple[attn_metadata, spec_decode_common_attn_metadata]
@@ -3123,6 +3125,7 @@ class NPUModelRunner(GPUModelRunner):
                     decode_ratio_to_sas_metadata=decode_ratio_to_sas_metadata,
                     common_ratio_to_sas_metadata=common_ratio_to_sas_metadata,
                     block_size=attn_group.kv_cache_spec.block_size,
+                    full_graph_mode=cudagraph_runtime_mode == CUDAGraphMode.FULL,
                 )
 
             if (for_cudagraph_capture
@@ -3463,6 +3466,7 @@ class NPUModelRunner(GPUModelRunner):
                     for_cudagraph_capture=is_graph_capturing,
                     num_scheduled_tokens_np=num_scheduled_tokens,
                     skip_gdn_state_update=skip_gdn_state_update,
+                    cudagraph_runtime_mode=cudagraph_runtime_mode,
                 )
         with self.maybe_dummy_run_with_lora(
             self.lora_config,

--- a/vllm_ascend/worker/model_runner_v1.py
+++ b/vllm_ascend/worker/model_runner_v1.py
@@ -188,6 +188,11 @@ from vllm_ascend.utils import (
     should_skip_allreduce_across_dp_group,
 )
 from vllm_ascend.worker.dcp_utils import DCPAsyncSpecDecodeRebuildResult, DCPManager
+from vllm_ascend.worker.device_metadata import (
+    DeviceMetadataExecutor,
+    DeviceMetadataTask,
+    DeviceMetadataTaskProvider,
+)
 from vllm_ascend.worker.npu_input_batch import NPUInputBatch
 from vllm_ascend.worker.utils import AscendKVBlockZeroer, disable_compilation
 
@@ -301,6 +306,8 @@ class NPUModelRunner(GPUModelRunner):
         with _torch_cuda_wrapper():
             super().__init__(vllm_config, device)
 
+        self.device_metadata_executor: DeviceMetadataExecutor | None = None
+        self.device_metadata_providers: dict[int, DeviceMetadataTaskProvider] | None = None
         self.pin_memory = PIN_MEMORY
 
         set_offloader(create_offloader(self.offload_config))
@@ -2908,6 +2915,9 @@ class NPUModelRunner(GPUModelRunner):
                 self._offload_token_to_req,
             )
         attn_metadata: PerLayerAttnMetadata = {}
+        device_metadata_tasks: list[DeviceMetadataTask] | None = (
+            [] if self.device_metadata_executor is not None else None
+        )
         if ubatch_slices is not None:
             attn_metadata = [dict() for _ in range(len(ubatch_slices))]
 
@@ -3054,6 +3064,11 @@ class NPUModelRunner(GPUModelRunner):
             assert num_reqs_padded is not None
             attn_group = self.attn_groups[kv_cache_gid][attn_gid]
             builder = attn_group.get_metadata_builder(ubid or 0)
+            device_metadata_provider = (
+                self.device_metadata_providers.get(id(builder))
+                if self.device_metadata_providers is not None
+                else None
+            )
             is_gdn_noop = skip_gdn_state_update and isinstance(
                 builder,
                 GDNAttentionMetadataBuilder,
@@ -3123,6 +3138,9 @@ class NPUModelRunner(GPUModelRunner):
                     and isinstance(builder, GDNAttentionMetadataBuilder) and attn_metadata_i.num_prefills == 0:
                     if attn_metadata_i.num_decodes == 0 and attn_metadata_i.num_spec_decodes > 0:
                         attn_metadata_i.spec_state_indices_tensor[attn_metadata_i.num_spec_decodes:].fill_(0)
+            if device_metadata_provider is not None:
+                assert device_metadata_tasks is not None
+                device_metadata_tasks.extend(device_metadata_provider.take_device_metadata_tasks())
             if isinstance(builder, AscendDSAMetadataBuilder):
                 prefill_ratio_to_sas_metadata = builder.prefill_ratio_to_sas_metadata  # type: ignore[assignment]
                 decode_ratio_to_sas_metadata = builder.decode_ratio_to_sas_metadata  # type: ignore[assignment]
@@ -3221,6 +3239,9 @@ class NPUModelRunner(GPUModelRunner):
             # the attention metadata in directly), and therefore does not want to use
             # padded attention metadata.
             spec_decode_common_attn_metadata = spec_decode_common_attn_metadata.unpadded(num_tokens, num_reqs)
+        if device_metadata_tasks:
+            assert self.device_metadata_executor is not None
+            self.device_metadata_executor.submit(device_metadata_tasks)
         return attn_metadata, spec_decode_common_attn_metadata
 
     def _should_build_dummy_attn_metadata(
@@ -4795,6 +4816,19 @@ class NPUModelRunner(GPUModelRunner):
 
         for i, attn_backend_map in enumerate(attention_backend_maps):
             self.attn_groups.append(create_attn_groups(attn_backend_map, i))
+
+        device_metadata_providers = {
+            id(builder): builder
+            for attn_groups in self.attn_groups
+            for attn_group in attn_groups
+            for builder in attn_group.metadata_builders
+            if isinstance(builder, DeviceMetadataTaskProvider)
+        }
+        if device_metadata_providers:
+            self.device_metadata_executor = DeviceMetadataExecutor()
+            self.device_metadata_providers = device_metadata_providers
+            for provider in device_metadata_providers.values():
+                provider.enable_device_metadata()
 
         # Calculate reorder batch threshold (if needed)
         self.calculate_reorder_batch_threshold()


### PR DESCRIPTION
### What this PR does / why we need it?

Refs #15280. Release-branch counterpart of #15443.

DeepSeek V4 constructs compressor, Quant Lightning Indexer (QLI), Sparse Attention Selector (SAS), DSpark sliding-window, and local DSA-CP metadata before their consumers. Running all of these device operators on the model stream serializes metadata construction with otherwise independent model work.

This PR independently adapts the asynchronous metadata mechanism to the split prefill/decode builders on `releases/v0.26.0rc`:

- A structural task-provider capability opts eligible DeepSeek V4 Model Runner V1 builders into one worker-owned metadata executor. Other models retain the original path without allocating a metadata stream or events.
- The executor uses one dedicated NPU stream, staged readiness events, and a buffer-reuse fence for persistent outputs.
- Compressor, QLI, SAS, DSpark SWA, and communication-free local DSA-CP metadata are submitted asynchronously where their existing execution phase is eligible. Existing synchronous fallbacks remain unchanged.
- Consumers wait only at the first compressor, indexer, or attention dependency, and repeated waits are deduplicated within each submission.
- Full target-model graphs use stable `ExternalEvent` dependencies keyed by the effective graph batch descriptor. Eager and piecewise paths retain ordinary events.
- Fixed-output compressor metadata preserves graph-visible buffer addresses, while partial submission failures fail closed rather than retrying into partially modified buffers.

The implementation is independent of `num_speculative_tokens`, adds no user-facing flag, and does not backport the main-branch metadata refactor.

### Does this PR introduce _any_ user-facing change?

No API or configuration change. Eligible DeepSeek V4 Model Runner V1 executions use the asynchronous path automatically. Other models and Model Runner V2 continue to use the existing implementation.

### How was this patch tested?

- `bash format.sh ci`
- Full mypy gate for Python 3.10, 3.11, and 3.12: no issues in plugin source, examples, or tests.
- 172 focused tests on Ascend A3 covering executor lifecycle, provider gating, staged waits, full-graph external-event reuse, DSA/DSA-CP, DSpark, failure handling, persistent compressor outputs, and forward-context integration.
- The 172-test run includes 18 real-NPU compressor cases, including cross-stream fixed-buffer rewrite and reuse.

The release branch's independent end-to-end RFC workload remains the merge performance gate; the focused tests above make no release-branch TPOT claim.

- vLLM main: https://github.com/vllm-project/vllm/commit/d02df748bf9efd99022f1a062597dc3cb3808485
