### PR TITLE
perf: fuse MLA query projection transposes

### DIFF
--- a/tests/ut/attention/a2/test_mla_v1.py
+++ b/tests/ut/attention/a2/test_mla_v1.py
@@ -1328,6 +1328,7 @@ class TestAscendMLAImpl(TestBase):
         self.assertEqual(impl.num_heads_padded, 32)  # next power of 2
         self.assertEqual(impl.head_padding, 12)  # 32 - 20
 
+    @patch("vllm_ascend.attention.mla_v1.torch_npu", SimpleNamespace())
     def test_q_proj_and_k_up_proj(self):
         batch_size = 4
         x = torch.randn(batch_size, self.impl.num_heads, self.impl.qk_head_dim)
@@ -1335,14 +1336,74 @@ class TestAscendMLAImpl(TestBase):
         self.impl.q_proj.return_value = (q_proj_output,)
         if not hasattr(self.impl, "W_UK_T") or self.impl.W_UK_T is None:
             self.impl.W_UK_T = torch.randn(self.impl.num_heads, self.impl.qk_nope_head_dim, self.impl.kv_lora_rank)
-        result = self.impl._q_proj_and_k_up_proj(x)
-        ql_nope, q_pe = result
+        expected_q_nope, expected_q_pe = q_proj_output.split(
+            [self.impl.qk_nope_head_dim, self.impl.qk_rope_head_dim], dim=-1
+        )
+        expected_ql_nope = torch.bmm(expected_q_nope.transpose(0, 1), self.impl.W_UK_T).transpose(0, 1)
+
+        ql_nope, q_pe = self.impl._q_proj_and_k_up_proj(x)
+
         self.assertEqual(ql_nope.shape[0], batch_size)
         self.assertEqual(ql_nope.shape[1], self.impl.num_heads)
         self.assertEqual(ql_nope.shape[2], self.impl.kv_lora_rank)
         self.assertEqual(q_pe.shape[0], batch_size)
         self.assertEqual(q_pe.shape[1], self.impl.num_heads)
         self.assertEqual(q_pe.shape[2], self.impl.qk_rope_head_dim)
+        torch.testing.assert_close(ql_nope, expected_ql_nope)
+        torch.testing.assert_close(q_pe, expected_q_pe)
+
+    @patch("vllm_ascend.attention.mla_v1.torch_npu")
+    def test_q_proj_and_k_up_proj_fuses_transposes(self, mock_torch_npu):
+        batch_size = 8
+        self.impl.num_heads = 6
+        self.impl.qk_nope_head_dim = 128
+        self.impl.qk_rope_head_dim = 64
+        self.impl.qk_head_dim = 192
+        self.impl.kv_lora_rank = 512
+
+        x = torch.randn(batch_size, self.impl.num_heads, self.impl.qk_head_dim)
+        q_proj_output = torch.randn(batch_size, self.impl.num_heads, self.impl.qk_head_dim)
+        self.impl.q_proj.return_value = (q_proj_output,)
+        self.impl.W_UK_T = torch.randn(
+            self.impl.num_heads,
+            self.impl.qk_nope_head_dim,
+            self.impl.kv_lora_rank,
+        )
+        expected_q_nope, expected_q_pe = q_proj_output.split(
+            [self.impl.qk_nope_head_dim, self.impl.qk_rope_head_dim], dim=-1
+        )
+        self.assertFalse(expected_q_nope.is_contiguous())
+        expected_ql_nope = torch.bmm(expected_q_nope.transpose(0, 1), self.impl.W_UK_T).transpose(0, 1).contiguous()
+
+        def fake_transpose_batchmatmul(input_tensor, weight, *, perm_x1, perm_y):
+            return torch.bmm(input_tensor.permute(perm_x1), weight).permute(perm_y).contiguous()
+
+        mock_torch_npu.npu_transpose_batchmatmul.side_effect = fake_transpose_batchmatmul
+
+        ql_nope, q_pe = self.impl._q_proj_and_k_up_proj(x)
+
+        mock_torch_npu.npu_transpose_batchmatmul.assert_called_once()
+        call_args, call_kwargs = mock_torch_npu.npu_transpose_batchmatmul.call_args
+        torch.testing.assert_close(call_args[0], expected_q_nope)
+        self.assertIs(call_args[1], self.impl.W_UK_T)
+        self.assertEqual(call_kwargs, {"perm_x1": (1, 0, 2), "perm_y": (1, 0, 2)})
+        torch.testing.assert_close(ql_nope, expected_ql_nope)
+        torch.testing.assert_close(q_pe, expected_q_pe)
+        self.assertTrue(ql_nope.is_contiguous())
+        self.assertEqual(
+            ql_nope.stride(),
+            (self.impl.num_heads * self.impl.kv_lora_rank, self.impl.kv_lora_rank, 1),
+        )
+
+    def test_q_proj_transpose_batchmatmul_operator_availability(self):
+        with patch(
+            "vllm_ascend.attention.mla_v1.torch_npu",
+            SimpleNamespace(npu_transpose_batchmatmul=object()),
+        ):
+            self.assertTrue(self.impl._can_use_q_proj_transpose_batchmatmul())
+
+        with patch("vllm_ascend.attention.mla_v1.torch_npu", SimpleNamespace()):
+            self.assertFalse(self.impl._can_use_q_proj_transpose_batchmatmul())
 
     @patch("torch_npu.npu_interleave_rope")
     def test_rope_single(self, mock_npu_interleave_rope):
@@ -1912,6 +1973,35 @@ class TestAscendMLAImpl(TestBase):
         self.assertEqual(self.impl.W_UV.shape[0], self.impl.num_heads)
         self.assertEqual(self.impl.W_UV.shape[1], self.impl.kv_lora_rank)
         self.assertEqual(self.impl.W_UV.shape[2], self.impl.v_head_dim)
+
+    @patch("vllm_ascend.attention.mla_v1.maybe_trans_nz")
+    @patch("vllm_ascend.attention.mla_v1.torch_npu")
+    def test_process_weights_keeps_w_uk_t_nd_for_fused_q_proj(self, mock_torch_npu, mock_maybe_trans_nz):
+        self.impl.num_heads = 6
+        self.impl.qk_nope_head_dim = 128
+        self.impl.qk_rope_head_dim = 64
+        self.impl.qk_head_dim = 192
+        self.impl.kv_lora_rank = 512
+        self.impl.enable_mlapo = False
+        self.impl.fa_quant_layer = False
+
+        layer = MagicMock(spec=LinearBase)
+        layer.quant_method = MagicMock(spec=UnquantizedLinearMethod)
+        layer.weight = torch.randn(
+            self.impl.num_heads * (self.impl.qk_nope_head_dim + self.impl.v_head_dim),
+            self.impl.kv_lora_rank,
+        )
+        self.impl.kv_b_proj = layer
+        mock_torch_npu.npu_format_cast.return_value = layer.weight
+
+        self.impl.process_weights_after_loading(torch.bfloat16)
+
+        mock_maybe_trans_nz.assert_not_called()
+        self.assertTrue(self.impl.W_UK_T.is_contiguous())
+        self.assertEqual(
+            self.impl.W_UK_T.shape,
+            (self.impl.num_heads, self.impl.qk_nope_head_dim, self.impl.kv_lora_rank),
+        )
 
     @patch("torch_npu.npu_format_cast")
     def test_process_weights_after_loading_with_mlapo(self, mock_format_cast):

--- a/vllm_ascend/attention/mla_v1.py
+++ b/vllm_ascend/attention/mla_v1.py
@@ -1118,6 +1118,9 @@ class AscendMLAImpl(MLAAttentionImpl):
             self.num_heads * self.v_head_dim,
         )
 
+    def _can_use_q_proj_transpose_batchmatmul(self) -> bool:
+        return hasattr(torch_npu, "npu_transpose_batchmatmul")
+
     # Return `ql_nope`, `q_pe`
     def _q_proj_and_k_up_proj(self, x):
         q_nope, q_pe = (
@@ -1125,6 +1128,18 @@ class AscendMLAImpl(MLAAttentionImpl):
             .view(-1, self.num_heads, self.qk_head_dim)
             .split([self.qk_nope_head_dim, self.qk_rope_head_dim], dim=-1)
         )
+
+        if self._can_use_q_proj_transpose_batchmatmul():
+            # Multiply (B, N, P) x (N, P, L) -> (B, N, L), with both
+            # transposes fused into the batch matmul. The contiguous output
+            # avoids materializing the (N, B, L) -> (B, N, L) view later.
+            ql_nope = torch_npu.npu_transpose_batchmatmul(
+                q_nope,
+                self.W_UK_T,
+                perm_x1=(1, 0, 2),
+                perm_y=(1, 0, 2),
+            )
+            return ql_nope, q_pe
 
         # Convert from (B, N, P) to (N, B, P)
         q_nope = q_nope.transpose(0, 1)
@@ -1196,8 +1211,11 @@ class AscendMLAImpl(MLAAttentionImpl):
         elif self.fa_quant_layer:
             self._process_weights_for_fused_fa_quant()
         else:
-            # if mlapo, W_UK_T can't trans nz
-            self.W_UK_T = maybe_trans_nz(self.W_UK_T)
+            # TransposeBatchMatMul accepts only ND weights. Keep W_UK_T in ND
+            # when the fused q projection path is available; otherwise retain
+            # the existing NZ conversion policy for torch.bmm.
+            if not self._can_use_q_proj_transpose_batchmatmul():
+                self.W_UK_T = maybe_trans_nz(self.W_UK_T)
 
     def _process_weights_for_fused_fa_quant(self):
         if get_ascend_device_type() == AscendDeviceType.A5:
@@ -1735,7 +1753,9 @@ class AscendMLAImpl(MLAAttentionImpl):
             # output. It is set to NTD to avoid the need for a transpose
             # operation after attention.
             input_layout = "TND_NTD"
-            # TODO: If the driver is upgraded later, the contiguous function can be deleted.
+            # The fused q projection already returns contiguous TND. Keep this
+            # for environments without the fused operator, which use the
+            # non-contiguous bmm fallback.
             # Input shape: [num_tokens, num_heads, dim]
             q_nope = q_nope.view(num_tokens, self.num_heads, -1).contiguous()
             q_pe = q_pe.view(num_tokens, self.num_heads, -1)


### PR DESCRIPTION
### What this PR does / why we need it?

This PR optimizes the MLA query projection path by using `npu_transpose_batchmatmul` to fuse the input and output transposes into the batched matrix multiplication.

The change:

- Avoids materializing the intermediate `(B, N, P) -> (N, B, P)` and `(N, B, L) -> (B, N, L)` transposes.
- Produces a contiguous batch-major query projection output.
- Keeps `W_UK_T` in ND format when the fused operator is available, as required by `npu_transpose_batchmatmul`.
- Preserves the existing `torch.bmm` and NZ-format path as a fallback when the fused operator is unavailable.

This reduces layout-conversion overhead in the MLA attention hot path while preserving numerical behavior and backward compatibility.

<img width="1920" height="1036" alt="screenshot_2026-09-04_10-36-54" src="https://github.com/user-attachments/assets/b5abf63f-6425-4f46-8910-189cb85613f9" />
<img width="1920" height="1042" alt="screenshot_2026-09-04_10-52-45" src="https://github.com/user-attachments/assets/b8e49606-a02f-4a4d-a00e-540d030c690a" />
<img width="1920" height="1038" alt="screenshot_2026-09-04_10-52-21" src="https://github.com/user-attachments/assets/2c690d8d-db27-438a-b783-9dd176ce1f7f" />

### Does this PR introduce _any_ user-facing change?

No. This is an internal performance optimization and does not change any public API or user-visible behavior.

### How was this patch tested?

Unit tests were added and updated in `tests/ut/attention/a2/test_mla_v1.py` to cover:

- Numerical correctness of the original fallback path.
- Correct invocation and numerical behavior of `npu_transpose_batchmatmul`.
- Contiguity and stride of the fused operator output.
- Fused-operator availability detection.
- Preservation of `W_UK_T` in ND format when the fused path is enabled.