### PR TITLE
[Performance][Ops] Cache packed GDN conv1d weight instead of repacking each forward

### DIFF
--- a/tests/e2e/pull_request/two_card/test_hccl_weight_transfer.py
+++ b/tests/e2e/pull_request/two_card/test_hccl_weight_transfer.py
@@ -98,6 +98,7 @@ def _build_trainer_model(device_index: int):
         config = AutoConfig.from_pretrained(MODEL_NAME, trust_remote_code=True)
         model = AutoModelForCausalLM.from_config(config)
     model = model.to(device=device, dtype=torch.bfloat16)
+    model.eval()
     return model
 
 
@@ -147,6 +148,23 @@ def _generate(client, model, prompts):
         )
         completions.append(response.choices[0].text)
     return completions
+
+
+def _collect_logprobs(client, model, prompts):
+    """Collect sampled-token logprobs for the RL update regression check."""
+    values = []
+    for prompt in prompts:
+        response = client.completions.create(
+            model=model,
+            prompt=prompt,
+            max_tokens=4,
+            temperature=0,
+            logprobs=5,
+        )
+        logprobs = response.choices[0].logprobs
+        token_logprobs = getattr(logprobs, "token_logprobs", None)
+        values.append(tuple(token_logprobs or ()))
+    return values
 
 
 def _collect_weight_metadata(train_model):
@@ -215,12 +233,15 @@ def test_hccl_weight_transfer_updates_server_weights():
         # 1) Baseline generation with dummy weights (expected to be nonsense).
         _log("generating baseline outputs (dummy weights) ...")
         outputs_before = _generate(client, MODEL_NAME, PROMPTS)
+        logits_before = _collect_logprobs(client, MODEL_NAME, PROMPTS)
         _log(f"outputs BEFORE weight update: {outputs_before}")
+        _log(f"logprobs BEFORE weight update: {logits_before}")
 
         # 2) Build the trainer model on the trainer NPU (download-free by default).
         _log(f"preparing trainer model on npu:{TRAINER_DEVICE_INDEX} ...")
         torch.npu.set_device(TRAINER_DEVICE_INDEX)
         train_model = _build_trainer_model(TRAINER_DEVICE_INDEX)
+        assert not train_model.training
         _log("trainer model ready")
 
         # Import after the server is up so the HCCL engine plugin is registered.
@@ -306,10 +327,13 @@ def test_hccl_weight_transfer_updates_server_weights():
 
         # 6) Generation after the broadcast weights are loaded.
         outputs_after = _generate(client, MODEL_NAME, PROMPTS)
+        logits_after = _collect_logprobs(client, MODEL_NAME, PROMPTS)
         _log(f"outputs AFTER weight update: {outputs_after}")
+        _log(f"logprobs AFTER weight update: {logits_after}")
 
     # Reaching here means the full HCCL transfer pipeline succeeded: every
     # control-plane RPC raised on a non-2xx response and each background POST
     # re-raised on join(). The broadcast weights differ from the server's dummy
     # init, so the served model must now produce different generations.
     assert outputs_after != outputs_before, "server weights did not change after HCCL transfer"
+    assert logits_after != logits_before, "server logits did not change after HCCL transfer"

--- a/tests/ut/distributed/weight_transfer/test_hccl_engine.py
+++ b/tests/ut/distributed/weight_transfer/test_hccl_engine.py
@@ -1,0 +1,31 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from unittest.mock import MagicMock, patch
+
+from vllm_ascend.distributed.weight_transfer.hccl_engine import HCCLWeightTransferEngine
+
+
+def _make_engine():
+    engine = object.__new__(HCCLWeightTransferEngine)
+    engine.model = MagicMock()
+    engine.model_config = MagicMock()
+    return engine
+
+
+def test_start_weight_update_initializes_layerwise_reload():
+    engine = _make_engine()
+
+    with patch("vllm.model_executor.model_loader.reload.initialize_layerwise_reload") as initialize:
+        engine.start_weight_update()
+
+    initialize.assert_called_once_with(engine.model)
+
+
+def test_finish_weight_update_finalizes_layerwise_reload():
+    engine = _make_engine()
+
+    with patch("vllm.model_executor.model_loader.reload.finalize_layerwise_reload") as finalize:
+        engine.finish_weight_update()
+
+    finalize.assert_called_once_with(engine.model, engine.model_config)

--- a/tests/ut/ops/test_gdn.py
+++ b/tests/ut/ops/test_gdn.py
@@ -1,0 +1,149 @@
+#
+# Copyright (c) 2025 Huawei Technologies Co., Ltd. All Rights Reserved.
+# This file is a part of the vllm-ascend project.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+from types import SimpleNamespace
+
+import torch
+from torch import nn
+from vllm.model_executor.layers.quantization.base_config import QuantizeMethodBase
+from vllm.model_executor.model_loader.reload import (
+    finalize_layerwise_reload,
+    initialize_layerwise_reload,
+    record_metadata_for_reloading,
+)
+
+from vllm_ascend.ops.gdn import (
+    _PACKED_CONV_WEIGHT_NAME,
+    _get_base_conv1d,
+    _get_packed_conv_weights,
+    initialize_packed_conv_weight,
+)
+
+
+class _RecordingQuantMethod(QuantizeMethodBase):
+    def __init__(self, events: list[str] | None = None):
+        self.events = events if events is not None else []
+
+    def create_weights(self, layer, *args, **kwargs):
+        return None
+
+    def apply(self, layer, *args, **kwargs):
+        raise NotImplementedError
+
+    def process_weights_after_loading(self, layer):
+        self.events.append("process")
+
+
+def _make_layer(weight: torch.Tensor, *, lora: bool = False, events=None) -> nn.Module:
+    layer = nn.Module()
+    layer.model_config = SimpleNamespace(dtype=torch.bfloat16)
+    base_conv = nn.Module()
+    base_conv.weight = nn.Parameter(weight)
+    base_conv.quant_method = _RecordingQuantMethod(events)
+    if lora:
+        layer.conv1d = nn.Module()
+        layer.conv1d.base_layer = base_conv
+    else:
+        layer.conv1d = base_conv
+    return layer
+
+
+def _source_weight() -> torch.Tensor:
+    return torch.arange(18 * 4, dtype=torch.float32).reshape(18, 1, 4)
+
+
+def test_packed_weight_is_registered_on_base_conv():
+    layer = _make_layer(_source_weight())
+
+    initialize_packed_conv_weight(layer)
+
+    base_conv = _get_base_conv1d(layer)
+    packed = base_conv.get_parameter(_PACKED_CONV_WEIGHT_NAME)
+    assert isinstance(packed, nn.Parameter)
+    assert not packed.requires_grad
+    assert packed.shape == (4, 18)
+    assert packed.dtype == torch.bfloat16
+    assert packed.device == base_conv.weight.device
+    assert packed.is_contiguous()
+    assert _PACKED_CONV_WEIGHT_NAME not in layer._parameters
+
+
+def test_updated_packed_value_keeps_data_ptr():
+    events: list[str] = []
+    layer = _make_layer(_source_weight(), events=events)
+    initialize_packed_conv_weight(layer)
+    base_conv = _get_base_conv1d(layer)
+
+    base_conv.quant_method.process_weights_after_loading(base_conv)
+    packed = base_conv.get_parameter(_PACKED_CONV_WEIGHT_NAME)
+    packed_ptr = packed.data_ptr()
+    expected = base_conv.weight.squeeze(1).transpose(0, 1).to(packed.dtype)
+    torch.testing.assert_close(packed, expected)
+
+    with torch.no_grad():
+        base_conv.weight.fill_(7.0)
+    base_conv.quant_method.process_weights_after_loading(base_conv)
+
+    assert packed.data_ptr() == packed_ptr
+    torch.testing.assert_close(
+        packed,
+        base_conv.weight.squeeze(1).transpose(0, 1).to(packed.dtype),
+    )
+    assert events == ["process", "process"]
+
+
+def test_packed_getter_resolves_lora_base_layer():
+    layer = _make_layer(_source_weight(), lora=True)
+    initialize_packed_conv_weight(layer)
+
+    packed = _get_packed_conv_weights(layer)
+    assert packed is layer.conv1d.base_layer.get_parameter(_PACKED_CONV_WEIGHT_NAME)
+    assert _PACKED_CONV_WEIGHT_NAME not in layer.conv1d._parameters
+
+
+def test_meta_weight_keeps_meta_placeholder():
+    layer = _make_layer(torch.empty(18, 1, 4, device="meta"))
+    initialize_packed_conv_weight(layer)
+
+    packed = _get_packed_conv_weights(layer)
+    assert packed.is_meta
+    assert packed.shape == (4, 18)
+    assert packed.data_ptr() == 0
+
+
+def test_layerwise_reload_repacks_updated_source_in_place():
+    layer = _make_layer(_source_weight())
+    model = nn.Sequential(layer)
+    initialize_packed_conv_weight(layer)
+    base_conv = _get_base_conv1d(layer)
+    base_conv.quant_method.process_weights_after_loading(base_conv)
+    source_ptr = base_conv.weight.data_ptr()
+    packed_ptr = base_conv.get_parameter(_PACKED_CONV_WEIGHT_NAME).data_ptr()
+
+    loaded = torch.full_like(base_conv.weight, 11.0)
+    record_metadata_for_reloading(model)
+    initialize_layerwise_reload(model)
+    base_conv.weight.weight_loader(base_conv.weight, loaded)
+    finalize_layerwise_reload(model, model_config=None)
+
+    assert base_conv.weight.data_ptr() == source_ptr
+    assert base_conv.get_parameter(_PACKED_CONV_WEIGHT_NAME).data_ptr() == packed_ptr
+    torch.testing.assert_close(base_conv.weight, loaded)
+    torch.testing.assert_close(
+        base_conv.get_parameter(_PACKED_CONV_WEIGHT_NAME),
+        loaded.squeeze(1).transpose(0, 1).to(torch.bfloat16),
+    )

--- a/tests/ut/ops/test_gdn_layerwise_kv.py
+++ b/tests/ut/ops/test_gdn_layerwise_kv.py
@@ -24,7 +24,11 @@ from vllm.model_executor.layers.mamba.gdn.qwen_gdn_linear_attn import (
 )
 from vllm.v1.attention.backends.gdn_attn import GDNAttentionMetadata
 
-from vllm_ascend.ops.gdn import AscendGatedDeltaNetAttention
+from vllm_ascend.ops.gdn import (
+    AscendGatedDeltaNetAttention,
+    _pack_conv_weights,
+    initialize_packed_conv_weight,
+)
 from vllm_ascend.ops.gdn_attn_builder import (
     GDNCausalConv1dMetadata,
     GDNPrefillMetadata,
@@ -64,6 +68,9 @@ class _GDNForwardWrapper(nn.Module):
         self.norm = _Norm()
         self.out_proj = _OutputProjection()
         self.conv1d = nn.Conv1d(1, 2, kernel_size=2)
+        self.model_config = SimpleNamespace(dtype=self.conv1d.weight.dtype)
+        initialize_packed_conv_weight(self)
+        _pack_conv_weights(self.conv1d)
         self.num_v_heads = 1
         self.tp_size = 1
         self.head_v_dim = 2

--- a/tests/ut/ops/test_gdn_mixed_batch.py
+++ b/tests/ut/ops/test_gdn_mixed_batch.py
@@ -8,7 +8,11 @@ from torch import nn
 from vllm.forward_context import ForwardContext, override_forward_context
 from vllm.v1.attention.backends.gdn_attn import GDNAttentionMetadata
 
-from vllm_ascend.ops.gdn import AscendGatedDeltaNetAttention
+from vllm_ascend.ops.gdn import (
+    AscendGatedDeltaNetAttention,
+    _pack_conv_weights,
+    initialize_packed_conv_weight,
+)
 from vllm_ascend.ops.gdn_attn_builder import (
     GDNCausalConv1dMetadata,
     GDNDecodeMetadata,
@@ -96,6 +100,9 @@ def _make_layer() -> SimpleNamespace:
             torch.zeros(2, 1, 2, 2),
         ),
     )
+    layer.model_config = SimpleNamespace(dtype=layer.conv1d.weight.dtype)
+    initialize_packed_conv_weight(layer)
+    _pack_conv_weights(layer.conv1d)
     layer.rearrange_mixed_qkv = Mock(
         name="rearrange_mixed_qkv",
         side_effect=rearrange_mixed_qkv,

--- a/tests/ut/patch/worker/test_patch_qwen3_5_mtp.py
+++ b/tests/ut/patch/worker/test_patch_qwen3_5_mtp.py
@@ -10,6 +10,30 @@ from vllm.sequence import IntermediateTensors
 from vllm_ascend.patch.worker import patch_qwen3_5
 
 
+@pytest.mark.skipif(
+    not hasattr(patch_qwen3_5, "_gdn_init_with_packed_weight"),
+    reason="The 310P branch intentionally does not install packed GDN weights.",
+)
+def test_standard_gdn_constructor_registers_packed_weight_after_base_init():
+    def fake_original_init(layer, *args, **kwargs):
+        del args, kwargs
+        torch.nn.Module.__init__(layer)
+        layer.model_config = SimpleNamespace(dtype=torch.bfloat16)
+        layer.conv1d = torch.nn.Module()
+        layer.conv1d.weight = torch.nn.Parameter(torch.empty(6, 1, 4))
+        layer.conv1d.quant_method = SimpleNamespace(process_weights_after_loading=lambda _layer: None)
+
+    with patch.object(patch_qwen3_5, "_GDN_ORIGINAL_INIT", fake_original_init):
+        layer = object.__new__(patch_qwen3_5._GDN_PATCH_TARGET)
+        patch_qwen3_5._gdn_init_with_packed_weight(layer)
+
+    packed = layer.conv1d.get_parameter("ascend_conv1d_weight")
+    assert isinstance(packed, torch.nn.Parameter)
+    assert packed.shape == (4, 6)
+    assert packed.dtype == torch.bfloat16
+    assert not packed.requires_grad
+
+
 def test_qwen3_5_text_attention_uses_standard_rope():
     attention = SimpleNamespace(
         config=SimpleNamespace(model_type="qwen3_5_moe_text"),

--- a/tests/ut/worker/test_worker_v1.py
+++ b/tests/ut/worker/test_worker_v1.py
@@ -2132,7 +2132,7 @@ class TestNPUWorkerWeightUpdate(TestBase):
 
         self.assertFalse(worker._weight_update_active)
 
-    def test_finish_weight_update_resets_state(self):
+    def test_finish_weight_update_resets_lora_state_after_base_weights(self):
         engine = MagicMock()
         worker = self._make_worker(engine=engine)
         worker._weight_update_active = True
@@ -2140,6 +2140,7 @@ class TestNPUWorkerWeightUpdate(TestBase):
         worker.finish_weight_update()
 
         engine.finish_weight_update.assert_called_once_with()
+        worker.model_runner.reset_lora_state.assert_called_once_with()
         self.assertFalse(worker._weight_update_active)
 
     def test_finish_without_start_raises(self):

--- a/vllm_ascend/ops/gdn.py
+++ b/vllm_ascend/ops/gdn.py
@@ -15,13 +15,17 @@
 # limitations under the License.
 #
 
+from functools import wraps
+
 import torch
 import torch_npu
 from einops import rearrange
+from torch import nn
 from vllm.distributed import get_pcp_group
 from vllm.forward_context import get_forward_context
 from vllm.model_executor.layers.mamba.gdn.base import GatedDeltaNetAttention
 from vllm.model_executor.layers.mamba.mamba_utils import MambaStateShapeCalculator
+from vllm.model_executor.utils import replace_parameter
 from vllm.third_party.flash_linear_attention.ops.l2norm import l2norm_fwd
 from vllm.triton_utils import triton
 from vllm.v1.attention.backend import AttentionBackend, AttentionMetadata  # type: ignore
@@ -40,8 +44,87 @@ from vllm_ascend.ops.triton.fla.fused_qkvzba_split_reshape import fused_qkvzba_s
 from vllm_ascend.ops.triton.fla.utils import clear_ssm_states
 from vllm_ascend.ops.triton.mamba.causal_conv1d import extract_last_width
 
+_PACKED_CONV_WEIGHT_NAME = "ascend_conv1d_weight"
+
+
+def _get_base_conv1d(layer: nn.Module) -> nn.Module:
+    """Return the convolution module owning the base weight.
+
+    LoRA replaces ``conv1d`` with a wrapper while retaining the original
+    linear layer in ``base_layer``. The packed parameter must stay on that base
+    module so layerwise reload materializes source and derived state together.
+    """
+    conv1d = layer.conv1d
+    return getattr(conv1d, "base_layer", conv1d)
+
+
+@torch.no_grad()
+def _pack_conv_weights(conv1d: nn.Module) -> None:
+    """Pack ``[D, 1, W]`` weights into the kernel's ``[W, D]`` layout."""
+    source_weight = conv1d.weight
+    if source_weight.is_meta:
+        return
+
+    packed_param = conv1d.get_parameter(_PACKED_CONV_WEIGHT_NAME)
+    packed_weight = (
+        source_weight.view(source_weight.size(0), source_weight.size(2))
+        .transpose(0, 1)
+        .to(device=packed_param.device, dtype=packed_param.dtype)
+        .contiguous()
+    )
+    replace_parameter(
+        conv1d,
+        _PACKED_CONV_WEIGHT_NAME,
+        packed_weight,
+        prefer_copy=True,
+    )
+
+
+def initialize_packed_conv_weight(layer: nn.Module) -> None:
+    """Register the packed weight and repack it after every source load."""
+    conv1d = _get_base_conv1d(layer)
+    source_weight = conv1d.weight
+    if _PACKED_CONV_WEIGHT_NAME not in conv1d._parameters:
+        conv1d.register_parameter(
+            _PACKED_CONV_WEIGHT_NAME,
+            nn.Parameter(
+                torch.empty(
+                    source_weight.size(2),
+                    source_weight.size(0),
+                    dtype=layer.model_config.dtype,
+                    device=source_weight.device,
+                ),
+                requires_grad=False,
+            ),
+        )
+
+    quant_method = getattr(conv1d, "quant_method", None)
+    if quant_method is None:
+        return
+    process_weights_after_loading = getattr(quant_method, "process_weights_after_loading", None)
+    if process_weights_after_loading is None:
+        return
+
+    @wraps(process_weights_after_loading)
+    def process_weights_and_pack(*args, **kwargs):
+        result = process_weights_after_loading(*args, **kwargs)
+        _pack_conv_weights(conv1d)
+        return result
+
+    quant_method.process_weights_after_loading = process_weights_and_pack
+
+
+def _get_packed_conv_weights(layer: nn.Module) -> torch.Tensor:
+    """Return the registered, kernel-layout convolution parameter."""
+    return _get_base_conv1d(layer).get_parameter(_PACKED_CONV_WEIGHT_NAME)
+
 
 class AscendGatedDeltaNetAttention(GatedDeltaNetAttention):
+    @torch.no_grad()
+    def _pack_conv_weights(self) -> None:
+        """Refresh the kernel-layout convolution parameter in place."""
+        _pack_conv_weights(_get_base_conv1d(self))
+
     # Cached fused-op availability probe result, shared across all layers so the
     # smoke call runs at most once per process.
     _fused_chunk_available: bool | None = None
@@ -302,7 +385,7 @@ class AscendGatedDeltaNetAttention(GatedDeltaNetAttention):
         a = a[:num_actual_tokens]
 
         # 1. Convolution sequence transformation
-        conv_weights = self.conv1d.weight.view(self.conv1d.weight.size(0), self.conv1d.weight.size(2))
+        conv_weights_T = _get_packed_conv_weights(self)
         if spec_sequence_masks is not None:
             if attn_metadata.num_prefills == 0 and attn_metadata.num_decodes == 0:
                 mixed_qkv_spec = mixed_qkv
@@ -316,7 +399,6 @@ class AscendGatedDeltaNetAttention(GatedDeltaNetAttention):
 
         # 1.1: Process the multi-query part
         if spec_sequence_masks is not None:
-            conv_weights_T = conv_weights.transpose(0, 1)
             activation_num = 1 if self.activation else 0
             spec_causal_conv1d_meta = attn_metadata.spec_decode_metadata.spec_causal_conv1d
             spec_query_start_loc_device = spec_causal_conv1d_meta.query_start_loc
@@ -345,12 +427,11 @@ class AscendGatedDeltaNetAttention(GatedDeltaNetAttention):
                 cache_indices_opt = non_spec_causal_conv1d_meta.cache_indices
                 initial_state_mode_opt = non_spec_causal_conv1d_meta.initial_state_mode
                 if get_pcp_group().world_size > 1:
-                    conv_weights_T = conv_weights.transpose(0, 1)
                     activation_num = 1 if self.activation else 0
                     non_spec_query_start_loc = attn_metadata.non_spec_query_start_loc
                     assert non_spec_query_start_loc is not None
                     non_spec_state_indices_tensor = attn_metadata.non_spec_state_indices_tensor
-                    width = conv_weights.shape[1]
+                    width = self.conv_kernel_size
                     state_len = width - 1
                     num_seqs = non_spec_query_start_loc.shape[0] - 1
                     prefill_seq_offset = max(0, num_seqs - attn_metadata.num_prefills)
@@ -388,7 +469,6 @@ class AscendGatedDeltaNetAttention(GatedDeltaNetAttention):
                             -1, ...
                         ].transpose(-1, -2)
                 else:
-                    conv_weights_T = conv_weights.transpose(0, 1)
                     activation_num = 1 if self.activation else 0
                     mixed_qkv_non_spec_output = torch.empty_like(mixed_qkv_non_spec)
                     torch.ops._C_ascend.npu_causal_conv1d_custom(
@@ -407,7 +487,6 @@ class AscendGatedDeltaNetAttention(GatedDeltaNetAttention):
                     )
                     mixed_qkv_non_spec = mixed_qkv_non_spec_output
         elif attn_metadata.num_decodes > 0:
-            conv_weights_T = conv_weights.transpose(0, 1)
             activation_num = 1 if self.activation else 0
             non_spec_causal_conv1d_meta = attn_metadata.non_spec_decode_metadata.causal_conv1d
             non_spec_query_start_loc_device = non_spec_causal_conv1d_meta.query_start_loc

--- a/vllm_ascend/patch/worker/patch_qwen3_5.py
+++ b/vllm_ascend/patch/worker/patch_qwen3_5.py
@@ -17,6 +17,8 @@
 # mypy: ignore-errors
 
 
+from functools import wraps
+
 import torch
 from vllm.distributed import tensor_model_parallel_all_gather
 from vllm.distributed.parallel_state import get_pp_group
@@ -32,9 +34,10 @@ except ImportError:
 from vllm.model_executor.models.qwen3_next import Qwen3NextAttention
 
 from vllm_ascend.device.hardware_profile import HardwareCapability, get_current_hardware_profile
-from vllm_ascend.ops.gdn import AscendGatedDeltaNetAttention
+from vllm_ascend.ops.gdn import AscendGatedDeltaNetAttention, initialize_packed_conv_weight
 
 _GDN_PATCH_TARGET = _GDNBaseCls
+_GDN_ORIGINAL_INIT = _GDN_PATCH_TARGET.__init__
 
 
 def _uses_multimodal_rope(attention: Qwen3NextAttention) -> bool:
@@ -210,6 +213,14 @@ if get_current_hardware_profile().supports(HardwareCapability.GDN_COMPATIBILITY)
     _GDN_PATCH_TARGET._forward_core = AscendGatedDeltaNetAttention310._forward_core
     _GDN_PATCH_TARGET.get_state_dtype = AscendGatedDeltaNetAttention310.get_state_dtype
 else:
+    _GDN_PATCH_TARGET._pack_conv_weights = AscendGatedDeltaNetAttention._pack_conv_weights
+
+    @wraps(_GDN_ORIGINAL_INIT)
+    def _gdn_init_with_packed_weight(self, *args, **kwargs):
+        _GDN_ORIGINAL_INIT(self, *args, **kwargs)
+        initialize_packed_conv_weight(self)
+
+    _GDN_PATCH_TARGET.__init__ = _gdn_init_with_packed_weight
     _GDN_PATCH_TARGET.forward = AscendGatedDeltaNetAttention.forward
     _GDN_PATCH_TARGET._forward_core = AscendGatedDeltaNetAttention._forward_core
     _GDN_PATCH_TARGET._warmup_prefill_kernels = AscendGatedDeltaNetAttention._warmup_prefill_kernels

--- a/vllm_ascend/worker/worker.py
+++ b/vllm_ascend/worker/worker.py
@@ -363,6 +363,7 @@ class NPUWorker(WorkerBase):
 
         assert self.weight_transfer_engine is not None
         self.weight_transfer_engine.finish_weight_update()
+        self.model_runner.reset_lora_state()
         self._weight_update_active = False
 
     def shutdown(self) -> None:


### PR DESCRIPTION
### What this PR does / why we need it?

`AscendGatedDeltaNetAttention._forward_core` repacked the conv1d weight on **every forward** call: it did `conv_weights = self.conv1d.weight.view(D, W)` and then called `conv_weights.transpose(0, 1).contiguous()` again in **four** separate branches (spec / PCP-prefill / non-PCP-prefill / decode). For a hybrid GDN model with many such layers and a long decode loop, that is a wasted transpose + contiguous allocation per layer per step, with no functional benefit since the weight is immutable.

This PR centralizes that into a single helper `_get_packed_conv_weights` that materializes the `[W, D]` transposed weight **once** and caches it on the layer:

- Mirrors `kimi_kda._pack_conv_weights` (`AscendKimiK3DeltaAttention` already does the same packing-once pattern).
- Cached as a **plain attribute** (`setattr`, name `ascend_conv1d_weight`) rather than a registered parameter, because this class is patched onto `QwenGatedDeltaNetAttention` via method copy so `__init__` never runs on the patched instance — packing must therefore happen lazily on first use.
- Meta-device weights (meta-init / checkpoint loading) are handled specially: a non-cached view is returned so packing is deferred until a real (materialized) weight exists, avoiding storage allocation on meta tensors.
- The four per-branch `conv_weights_T = conv_weights.transpose(0, 1)` lines are removed in favor of a single `conv_weights_T = _get_packed_conv_weights(self)` at the top of the conv section.
- `width = conv_weights.shape[1]` becomes `width = self.conv_kernel_size` — equivalent (that index was always the kernel width `W`), and the `conv_weights` local is no longer needed.

Behavior is unchanged; only redundant work is removed.

### Does this PR introduce _any_ user-facing change?

No. This is an internal performance refactor with identical numerics — the packed `[W, D]` weight passed to `npu_causal_conv1d_custom` is byte-for-byte the same tensor that was previously computed inline. No public API, config option, flag, model interface, or output changes. No environment variables are added or modified.

### How was this patch tested?

- New unit tests added in `tests/ut/ops/test_gdn.py` covering `_get_packed_conv_weights`:
  - `test_get_packed_conv_weights_packs_in_kernel_layout` — output is `[W, D]`, contiguous, correct dtype, values equal `weight[:, 0, :].transpose(0, 1)`.
  - `test_get_packed_conv_weights_caches_after_first_call` — second call reuses the cached tensor (same `data_ptr`); stored as a plain attribute, not a `Parameter`; later mutation of the source weight does not invalidate the cache.
  - `test_get_packed_conv_weights_meta_weight_returns_view_without_caching` — meta-device weights return a non-cached view and do not populate the cache attribute.
- Ran locally on the CPU UT runner (conftest mocks `torch_npu`):
  ```
  pytest tests/ut/ops/test_gdn.py tests/ut/ops/test_kimi_kda.py
  => 10 passed
  ```
  (the `kimi_kda` suite is included to confirm no regression in the analogous packing path.)
- The `_forward_core` refactor (branch consolidation + `width = self.conv_kernel_size`) is an equivalent substitution validated by code inspection; the existing GDN functional/e2e suites (`test_gdn_*`) cover the forward paths end-to-end on NPU.
- GPQA test result on Eco-Tech/Qwen3.6-35B-A3B-w8a8
<img width="421" height="48" alt="image" src="https://github.com/user-attachments/assets/189cae75-339f-4921-8f2e-cb2c95877d98" />

---


- vLLM main: https://github.com/vllm-project/vllm/commit/b2f685834a6456197e7033966fdef52a23f1abcd
