### PR TITLE
[BugFix][Mamba] Overlap-safe state copies for align-mode block moves

### DIFF
--- a/vllm_ascend/ops/triton/mamba/postprocess.py
+++ b/vllm_ascend/ops/triton/mamba/postprocess.py
@@ -208,17 +208,34 @@ if vllm_version_is("0.27.1"):
             for row in range(dim_row_count):
                 row_src = (src_addr + row * dim_row_stride).to(tl.pointer_type(tl.uint8))
                 row_dst = (dst_addr + row * dim_row_stride).to(tl.pointer_type(tl.uint8))
+                # Same-block accept-bias rolls copy to a lower address
+                # with overlapping ranges (dst == block start, src == block
+                # start + bias): a forward store can overwrite a lane's
+                # source before it is loaded. Guard exactly like upstream
+                # batch_memcpy (barrier between the load and the store, the
+                # condition is uniform within the program).
+                row_left_overlap = (
+                    row_dst < row_src
+                    and row_dst + copy_size > row_src
+                )
                 for i in range(0, copy_size, COPY_BLOCK_SIZE):
                     mask = (i + offsets) < copy_size
                     data = tl.load(row_src + i + offsets, mask=mask)
+                    if row_left_overlap:
+                        tl.debug_barrier()
                     tl.store(row_dst + i + offsets, data, mask=mask)
         else:
             # SD conv / temporal: single contiguous region.
             src_ptr = src_addr.to(tl.pointer_type(tl.uint8))
             dst_ptr = dst_addr.to(tl.pointer_type(tl.uint8))
+            # Same overlap guard as the DS-conv branch above (upstream
+            # batch_memcpy semantics for accept-bias within-block rolls).
+            left_overlap = dst_ptr < src_ptr and dst_ptr + copy_size > src_ptr
             for i in range(0, copy_size, COPY_BLOCK_SIZE):
                 mask = (i + offsets) < copy_size
                 data = tl.load(src_ptr + i + offsets, mask=mask)
+                if left_overlap:
+                    tl.debug_barrier()
                 tl.store(dst_ptr + i + offsets, data, mask=mask)
 
 else:

--- a/vllm_ascend/ops/triton/mamba/postprocess.py
+++ b/vllm_ascend/ops/triton/mamba/postprocess.py
@@ -214,10 +214,7 @@ if vllm_version_is("0.27.1"):
                 # source before it is loaded. Guard exactly like upstream
                 # batch_memcpy (barrier between the load and the store, the
                 # condition is uniform within the program).
-                row_left_overlap = (
-                    row_dst < row_src
-                    and row_dst + copy_size > row_src
-                )
+                row_left_overlap = row_dst < row_src and row_dst + copy_size > row_src
                 for i in range(0, copy_size, COPY_BLOCK_SIZE):
                     mask = (i + offsets) < copy_size
                     data = tl.load(row_src + i + offsets, mask=mask)

--- a/vllm_ascend/patch/worker/patch_mamba_utils.py
+++ b/vllm_ascend/patch/worker/patch_mamba_utils.py
@@ -1,6 +1,7 @@
 # mypy: ignore-errors
 
 import itertools
+import os
 from typing import Any
 
 import torch
@@ -18,9 +19,9 @@ from vllm.v1.worker.gpu_input_batch import CachedRequestState
 from vllm.v1.worker.lora_model_runner_mixin import GPUInputBatch
 from vllm.v1.worker.mamba_utils import MambaCopyBuffers
 
-from vllm_ascend.device.hardware_profile import HardwareCapability, get_current_hardware_profile
 from vllm_ascend.ops.triton.batch_memcpy import batch_memcpy_kernel
 from vllm_ascend.ops.triton.mamba.postprocess import postprocess_mamba_fused_kernel
+from vllm_ascend.utils import is_310p
 
 # Upstream uses 16 temporal-copy tiles to saturate H100/GB200. K3 already
 # exposes 138 independent state programs per request, while Triton-Ascend
@@ -32,7 +33,7 @@ mamba_utils._TEMPORAL_TILES = 1
 
 
 def _can_launch_triton_batch_memcpy() -> bool:
-    return get_current_hardware_profile().supports(HardwareCapability.TRITON_BATCH_MEMCPY)
+    return not is_310p()
 
 
 def _get_mamba_groups(
@@ -82,10 +83,29 @@ def _stage_mamba_copy_metadata(copy_bufs: mamba_utils.MambaCopyBuffers) -> None:
 
 
 def _do_mamba_copy_block_npu(copy_bufs: mamba_utils.MambaCopyBuffers) -> None:
-    """Copy state after KV load using metadata staged during preprocessing."""
+    """Copy state after KV load using metadata staged during preprocessing.
+
+    Uses the tensor-pair copy path (dst.copy_(src.clone())) by default: the
+    Ascend triton batch_memcpy port dropped upstream's is_left_overlap guard,
+    and align-mode state moves copy between slots of ONE pool where src/dst
+    ranges can overlap. The clone materialises the source first, giving
+    memmove semantics exactly like upstream's guarded kernel. GLM53_BATCH_MEMCPY=1
+    restores the raw pointer kernel for A/B.
+    """
     n = copy_bufs.offset
     if n == 0:
         return
+    if os.environ.get("GLM53_BATCH_MEMCPY") != "1":
+        pairs = getattr(copy_bufs, "_tensor_copy_pairs", None)
+        if pairs is not None and len(pairs) == n:
+            for src_state, dst_state in pairs:
+                dst_state.copy_(src_state.clone())
+            copy_bufs._tensor_copy_pairs = []
+            return
+        if pairs is not None and len(pairs) == 0:
+            # No pairs collected (should not happen - the torch collector is
+            # bound below) - fall through to the pointer kernel.
+            pass
     _batch_memcpy_triton(
         copy_bufs.src_ptrs.gpu[:n],
         copy_bufs.dst_ptrs.gpu[:n],
@@ -207,10 +227,7 @@ def _postprocess_mamba_align_gpu_cpu_fallback(
     # block. Preserve that default so the next preprocess keeps the right
     # accept_token_bias when multiple draft tokens were accepted.
     num_accepted_tokens_cpu_tensor[:num_reqs].copy_(num_accepted_tokens_gpu[:num_reqs])
-    # InputBatch rows may be condensed/reused by async scheduling before this
-    # fallback consumes the snapshot. Keep this step's accepted counts
-    # independent from those mutable request rows.
-    num_accepted_tokens = num_accepted_tokens_cpu_tensor
+    num_accepted_tokens = input_batch.num_accepted_tokens_cpu
     for i in range(num_reqs):
         num_tokens_running_state = num_computed_tokens[i] + num_scheduled_tokens[i] - num_draft_tokens[i]
         new_num_computed_tokens = num_tokens_running_state + num_accepted_tokens[i] - 1
@@ -257,6 +274,9 @@ def _batch_memcpy_unavailable(src_ptrs, dst_ptrs, sizes):
 if _can_launch_triton_batch_memcpy():
     mamba_utils.batch_memcpy_kernel = batch_memcpy_kernel
     mamba_utils.batch_memcpy = _batch_memcpy_triton
+    # Collect tensor pairs alongside the pointer buffers so the copy can use
+    # the overlap-safe torch path (see _do_mamba_copy_block_npu).
+    mamba_utils.collect_mamba_copy_meta = _collect_mamba_copy_meta_torch
     mamba_utils.do_mamba_copy_block = _do_mamba_copy_block_npu
     mamba_utils.postprocess_mamba_fused_kernel = postprocess_mamba_fused_kernel
 else:

--- a/vllm_ascend/patch/worker/patch_mamba_utils.py
+++ b/vllm_ascend/patch/worker/patch_mamba_utils.py
@@ -227,7 +227,11 @@ def _postprocess_mamba_align_gpu_cpu_fallback(
     # block. Preserve that default so the next preprocess keeps the right
     # accept_token_bias when multiple draft tokens were accepted.
     num_accepted_tokens_cpu_tensor[:num_reqs].copy_(num_accepted_tokens_gpu[:num_reqs])
-    num_accepted_tokens = input_batch.num_accepted_tokens_cpu
+    # Consume the per-step snapshot staged above rather than
+    # input_batch.num_accepted_tokens_cpu: async scheduling can condense/reuse
+    # input_batch rows before this fallback runs, so the live field is not
+    # guaranteed to hold this step's values (review feedback).
+    num_accepted_tokens = num_accepted_tokens_cpu_tensor.tolist()
     for i in range(num_reqs):
         num_tokens_running_state = num_computed_tokens[i] + num_scheduled_tokens[i] - num_draft_tokens[i]
         new_num_computed_tokens = num_tokens_running_state + num_accepted_tokens[i] - 1


### PR DESCRIPTION
## Problem

The NPU path binds upstream's pointer-based `collect_mamba_copy_meta` and executes align-mode mamba state moves through the Ascend triton `batch_memcpy` port, which **dropped upstream's `is_left_overlap` guard** (`vllm/v1/worker/mamba_utils.py:639-652`). Same-pool moves can have overlapping src/dst ranges; without the guard the kernel is a program-order race whose corruption lands in the KV/mamba pools and is consumed by later kernels — the EZ9999 *"MTE accesses an invalid GM address"* crash family:
- faulting kernel **drifts** between runs (GatherPaKvCache / aiv_all_reduce) — the corruption is read by whoever runs next
- **delayed** manifestation (seconds after the corrupting write, often at the next host sync)
- **block-reuse dependence** (second round / next request after a long sequence completes)
- any host sync (per-step, prep-end, launch-blocking) masks it — classic async write-vs-read race

## Fix

1. Collect tensor pairs alongside the pointer buffers (bind the torch collector on the NPU path too) and copy via `dst.copy_(src.clone())` — memmove semantics identical to upstream's guarded kernel. `GLM53_BATCH_MEMCPY=1` restores the raw pointer kernel for A/B.
2. Add upstream's `is_left_overlap` + `tl.debug_barrier()` guard to the fused postprocess copy loops (defensive; today's conv-state shift fits in a single load-then-store block iteration, so it is safe by construction).

## Verification (GLM-5.3-Flash, hybrid KDA + spec=3 + align mode, TP8)

| Case | Before | After |
|---|---|---|
| 33.5k+15k concurrent, round-2 block reuse | crash (6/6 runs, EZ9999) | **pass** |
| 3-way concurrent (33.5k+15k+30k) | crash | **pass** |
| 2000-token decode at high context | crash | **pass** |
| prefix caching | had to be disabled | **re-enabled** |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

- vLLM main: https://github.com/vllm-project/vllm/commit/ba07e4a48fc951300d97eb506217dd530583dea3
