### PR TITLE
[BugFix][Perf] Combine CPU binding mapping and KV cache fixes

### DIFF
--- a/tests/ut/device_allocator/test_cpu_binding.py
+++ b/tests/ut/device_allocator/test_cpu_binding.py
@@ -28,6 +28,7 @@ from vllm_ascend.utils import AscendDeviceType
 def make_cpu_alloc(rank_id=0):
     cpu_alloc = object.__new__(CpuAlloc)
     cpu_alloc.rank_id = rank_id
+    cpu_alloc.current_npu = 0
     cpu_alloc.device_info = SimpleNamespace(
         running_npu_list=[0],
         all_logic_npus=[0],
@@ -306,7 +307,15 @@ class TestCpuAlloc(unittest.TestCase):
             ("| NPU Chip | Process id |\n| 0 0 | 1234 | vllm | 56000 |\n| 1 0 | 1235 | vllm | 56000 |", 0),
             ("", 0),
         ]
-        self.cpu_alloc = CpuAlloc(0)
+        self.cpu_alloc = CpuAlloc(0, npu_id=0)
+
+    @patch("vllm_ascend.cpu_binding.DeviceInfo")
+    def test_explicit_npu_id_overrides_running_npu_order(self, mock_device_info):
+        mock_device_info.return_value.running_npu_list = [1, 3]
+
+        cpu_alloc = CpuAlloc(rank_id=0, npu_id=3)
+
+        self.assertEqual(cpu_alloc.current_npu, 3)
 
     def test_average_distribute(self):
         self.cpu_alloc.npu_cpu_pool = {0: [10, 11, 12, 13], 1: [10, 11, 12, 13]}
@@ -554,6 +563,7 @@ class TestCpuAlloc(unittest.TestCase):
         mock_execute_command.return_value = ("PCIe Bus Info 0000:03:00.0", 0)
         self.cpu_alloc.rank_id = 0
         self.cpu_alloc.device_info.running_npu_list = [3]
+        self.cpu_alloc.current_npu = 3
         self.cpu_alloc.npu_cpu_pool = {3: [0, 1, 2, 3, 4]}
 
         self.cpu_alloc.bind_npu_irq()
@@ -915,6 +925,7 @@ class TestCpuBindingSupplemental(unittest.TestCase):
     def test_print_plan_handles_empty_release_assignment(self, mock_logger_info, _mock_get_device_type):
         cpu_alloc = make_cpu_alloc()
         cpu_alloc.device_info.running_npu_list = [1]
+        cpu_alloc.current_npu = 1
         cpu_alloc.rank_id = 0
         cpu_alloc.assign_main = {1: [2, 3]}
         cpu_alloc.assign_acl = {1: [4]}
@@ -931,6 +942,7 @@ class TestCpuBindingSupplemental(unittest.TestCase):
     def test_print_plan_uses_ascend_950_worker_log(self, mock_logger_info, _mock_get_device_type):
         cpu_alloc = make_cpu_alloc()
         cpu_alloc.device_info.running_npu_list = [1]
+        cpu_alloc.current_npu = 1
         cpu_alloc.rank_id = 0
         cpu_alloc.assign_main = {1: [2, 3]}
         cpu_alloc.assign_acl = {1: []}
@@ -953,6 +965,7 @@ class TestCpuBindingSupplemental(unittest.TestCase):
     def test_print_plan_handles_non_empty_release_assignment(self, mock_logger_info, _mock_get_device_type):
         cpu_alloc = make_cpu_alloc()
         cpu_alloc.device_info.running_npu_list = [1]
+        cpu_alloc.current_npu = 1
         cpu_alloc.rank_id = 0
         cpu_alloc.assign_main = {1: [2, 3]}
         cpu_alloc.assign_acl = {1: [4]}
@@ -1289,15 +1302,15 @@ class TestBindingSwitch(unittest.TestCase):
     @patch("vllm_ascend.cpu_binding.is_arm_cpu")
     def test_bind_cpus_skip_non_arm(self, mock_is_arm_cpu, mock_cpu_alloc):
         mock_is_arm_cpu.return_value = False
-        bind_cpus(0)
+        bind_cpus(0, npu_id=0)
         mock_cpu_alloc.assert_not_called()
 
     @patch("vllm_ascend.cpu_binding.CpuAlloc")
     @patch("vllm_ascend.cpu_binding.is_arm_cpu", return_value=True)
     def test_bind_cpus_runs_allocator_on_arm(self, _mock_is_arm_cpu, mock_cpu_alloc):
-        bind_cpus(1)
+        bind_cpus(1, npu_id=3)
 
-        mock_cpu_alloc.assert_called_once_with(1)
+        mock_cpu_alloc.assert_called_once_with(1, npu_id=3)
         mock_cpu_alloc.return_value.run_all.assert_called_once_with()
 
 

--- a/vllm_ascend/cpu_binding.py
+++ b/vllm_ascend/cpu_binding.py
@@ -202,9 +202,10 @@ class DeviceInfo:
 
 
 class CpuAlloc:
-    def __init__(self, rank_id: int):
+    def __init__(self, rank_id: int, npu_id: int):
         self.rank_id = rank_id
         self.device_info: DeviceInfo = DeviceInfo()
+        self.current_npu = npu_id
         self.cpu_node: dict[int, int] = {}
         self.numa_to_cpu_map: dict[int, list[int]] = defaultdict(list)
         self.npu_cpu_pool: dict[int, list[int]] = {}
@@ -620,11 +621,10 @@ class CpuAlloc:
 
     def print_plan(self) -> None:
         logger.info("The CPU allocation plan is as follows:")
-        current_npu = self.device_info.running_npu_list[self.rank_id]
         if self._uses_cluster_cpu_topology():
-            self._print_ascend_950_plan(current_npu)
+            self._print_ascend_950_plan(self.current_npu)
             return
-        self._print_default_plan(current_npu)
+        self._print_default_plan(self.current_npu)
 
     def _print_ascend_950_plan(self, current_npu: int) -> None:
         main = " ".join(map(str, self.assign_main[current_npu]))
@@ -680,20 +680,18 @@ class CpuAlloc:
         thread_message, _ = execute_command(["ps", "-Te"])
         threads_map = self.get_threads_map(thread_message)
         main_pid = str(psutil.Process().pid)
-        current_npu = self.device_info.running_npu_list[self.rank_id]
-        self.bind(main_pid, self.assign_main[current_npu], True)
+        self.bind(main_pid, self.assign_main[self.current_npu], True)
         for thread_id in threads_map.get(main_pid, {}).get("acl_thread", []):
-            self.bind(thread_id, self.assign_acl[current_npu], False)
+            self.bind(thread_id, self.assign_acl[self.current_npu], False)
         for thread_id in threads_map.get(main_pid, {}).get("release_thread", []):
-            self.bind(thread_id, self.assign_rel[current_npu], False)
+            self.bind(thread_id, self.assign_rel[self.current_npu], False)
         # Migrate memory once for the whole process, after all threads are pinned.
-        self.bind_memory(main_pid, current_npu)
+        self.bind_memory(main_pid, self.current_npu)
 
     def bind_ascend_950_threads(self) -> None:
         main_pid = str(psutil.Process().pid)
-        current_npu = self.device_info.running_npu_list[self.rank_id]
-        self.bind(main_pid, self.assign_main[current_npu], True)
-        self.bind_memory(main_pid, current_npu)
+        self.bind(main_pid, self.assign_main[self.current_npu], True)
+        self.bind_memory(main_pid, self.current_npu)
 
     def bind_npu_irq(self) -> None:
         if not self._reserve_irq_cpus():
@@ -707,9 +705,8 @@ class CpuAlloc:
             return
 
         # Only bind IRQ for current rank's NPU to avoid multi-process overwrite.
-        current_npu = self.device_info.running_npu_list[self.rank_id]
-        if current_npu not in self.npu_cpu_pool:
-            logger.warning("[irq] NPU has no CPU pool. rank=%s, npu=%s. ", self.rank_id, current_npu)
+        if self.current_npu not in self.npu_cpu_pool:
+            logger.warning("[irq] NPU has no CPU pool. rank=%s, npu=%s. ", self.rank_id, self.current_npu)
             return
 
         if shutil.which("systemctl"):
@@ -730,7 +727,7 @@ class CpuAlloc:
                     irq = line.split(":")[0].strip()
                     sq_irqs.append(irq)
 
-        npu = current_npu
+        npu = self.current_npu
         cpus = self.npu_cpu_pool[npu]
         if len(cpus) < 2:
             logger.warning("[irq] CPU pool too small. npu=%s, cpu_count=%d, min_required=2. ", npu, len(cpus))
@@ -796,9 +793,9 @@ class CpuAlloc:
         self.bind_npu_irq()
 
 
-def bind_cpus(rank_id: int) -> None:
+def bind_cpus(rank_id: int, npu_id: int) -> None:
     if not is_arm_cpu():
         logger.info("CPU binding skipped: non-ARM CPU detected.")
         return
-    binder = CpuAlloc(rank_id)
+    binder = CpuAlloc(rank_id, npu_id=npu_id)
     binder.run_all()

--- a/vllm_ascend/device/device_op.py
+++ b/vllm_ascend/device/device_op.py
@@ -40,13 +40,14 @@ else:
 class BaseDeviceAdaptor:
     @classmethod
     def reshape_and_cache(cls, key, value, key_cache, value_cache, slot_mapping):
-        torch_npu.npu_scatter_pa_kv_cache(
-            key=key.contiguous(),
-            value=value.contiguous(),
+        # npu_scatter_pa_kv_cache (#11713) adds host-side overhead that costs
+        # ~9% end-to-end throughput on Atlas A3; see commit message for data.
+        torch_npu._npu_reshape_and_cache(
+            key=key,
+            value=value,
             key_cache=key_cache,
             value_cache=value_cache,
-            slot_mapping=slot_mapping.contiguous(),
-            cache_mode="Norm",
+            slot_indices=slot_mapping,
         )
 
     @classmethod

--- a/vllm_ascend/worker/worker.py
+++ b/vllm_ascend/worker/worker.py
@@ -827,7 +827,10 @@ class NPUWorker(WorkerBase):
         # worker process before migratepages/taskset run.
         if get_ascend_config().enable_cpu_binding:
             try:
-                bind_cpus(self.local_rank)
+                bind_cpus(
+                    self.local_rank,
+                    npu_id=current_platform.device_id_to_physical_device_id(self.local_rank),
+                )
             except Exception as e:
                 logger.warning("Bind cpus failed in rank%s: %s Skip binding cpu.", self.local_rank, e)
 


### PR DESCRIPTION
### What this PR does / why we need it?

This PR combines the changes from #15444 and #15517 on the latest `main` branch:

- Restore `torch_npu._npu_reshape_and_cache` for ND page-attention KV cache writes. The `npu_scatter_pa_kv_cache` path introduced by #11713 showed a host-side performance regression on Atlas A3.
- Resolve the worker's assigned physical NPU with `current_platform.device_id_to_physical_device_id(local_rank)` before CPU binding, then use that explicit NPU ID for CPU, NUMA memory, and IRQ allocation.
- Add a regression test proving an explicit NPU ID takes precedence over the discovered NPU list order.

The combined commit preserves both original authors as co-authors.

Source PRs:

- #15444
- #15517

### Does this PR introduce _any_ user-facing change?

No CLI or public API changes. CPU binding now follows the worker's assigned physical device, and ND page-attention KV cache writes use the lower-overhead operation again.

### How was this patch tested?

Local checks on the combined diff:

- `git diff --check`
- `ruff check tests/ut/device_allocator/test_cpu_binding.py vllm_ascend/cpu_binding.py vllm_ascend/device/device_op.py vllm_ascend/worker/worker.py`
- `ruff format --check tests/ut/device_allocator/test_cpu_binding.py vllm_ascend/cpu_binding.py vllm_ascend/device/device_op.py vllm_ascend/worker/worker.py`
- `python -m compileall -q tests/ut/device_allocator/test_cpu_binding.py vllm_ascend/cpu_binding.py vllm_ascend/device/device_op.py vllm_ascend/worker/worker.py`
- Targeted pre-commit checks passed for ruff, formatting, codespell, typos, forbidden imports, symbolic shapes, and repository Python rules.
- `tools/check_logger.sh` passed under Git Bash.

The focused pytest collection was attempted, but this Windows checkout does not have the Linux/NPU runtime dependency `torch`; full unit and NPU validation is therefore left to CI. The Atlas A3 performance evidence remains documented in #15444: Qwen3-32B-W8A8-QuaRot + EAGLE3, TP2, 80 prompts at concurrency 20 completed 80/80 requests, with the restored operation recovering throughput from 382.03 tok/s to 404.62 and 428.88 tok/s in two runs.
- vLLM main: https://github.com/vllm-project/vllm/commit/ba07e4a48fc951300d97eb506217dd530583dea3
