### PR TITLE
[v0.26.0rc][Perf] Restore ND PA KV cache write performance

### DIFF
--- a/tests/ut/device/test_device_op.py
+++ b/tests/ut/device/test_device_op.py
@@ -155,7 +155,7 @@ def test_a5_mla_preprocess_only_decode_supports_native_bf16_weights(use_mla_rope
     assert call_kwargs["cache_index"].shape == (num_tokens,)
 
 
-def test_reshape_and_cache_makes_scatter_inputs_contiguous():
+def test_reshape_and_cache_uses_legacy_op_without_copies():
     key = torch.randn(2, 3, 4).transpose(0, 1)
     value = torch.randn(2, 3, 4).transpose(0, 1)
     slot_mapping = torch.arange(8, dtype=torch.int32)[::2]
@@ -166,23 +166,20 @@ def test_reshape_and_cache_makes_scatter_inputs_contiguous():
     assert not value.is_contiguous()
     assert not slot_mapping.is_contiguous()
 
-    with mock.patch("vllm_ascend.device.device_op.torch_npu.npu_scatter_pa_kv_cache") as mock_scatter:
+    with (
+        mock.patch("vllm_ascend.device.device_op.torch_npu._npu_reshape_and_cache") as mock_reshape,
+        mock.patch("vllm_ascend.device.device_op.torch_npu.npu_scatter_pa_kv_cache") as mock_scatter,
+    ):
         BaseDeviceAdaptor.reshape_and_cache(key, value, key_cache, value_cache, slot_mapping)
 
-    mock_scatter.assert_called_once()
-    call_kwargs = mock_scatter.call_args.kwargs
-    assert call_kwargs["key"] is not key
-    assert call_kwargs["value"] is not value
-    assert call_kwargs["slot_mapping"] is not slot_mapping
-    assert call_kwargs["key"].is_contiguous()
-    assert call_kwargs["value"].is_contiguous()
-    assert call_kwargs["slot_mapping"].is_contiguous()
-    torch.testing.assert_close(call_kwargs["key"], key)
-    torch.testing.assert_close(call_kwargs["value"], value)
-    torch.testing.assert_close(call_kwargs["slot_mapping"], slot_mapping)
+    mock_reshape.assert_called_once()
+    mock_scatter.assert_not_called()
+    call_kwargs = mock_reshape.call_args.kwargs
+    assert call_kwargs["key"] is key
+    assert call_kwargs["value"] is value
+    assert call_kwargs["slot_indices"] is slot_mapping
     assert call_kwargs["key_cache"] is key_cache
     assert call_kwargs["value_cache"] is value_cache
-    assert call_kwargs["cache_mode"] == "Norm"
 
 
 def test_kv_cache_load_makes_seq_lens_contiguous():

--- a/vllm_ascend/device/device_op.py
+++ b/vllm_ascend/device/device_op.py
@@ -55,13 +55,14 @@ else:
 class BaseDeviceAdaptor:
     @classmethod
     def reshape_and_cache(cls, key, value, key_cache, value_cache, slot_mapping):
-        torch_npu.npu_scatter_pa_kv_cache(
-            key=key.contiguous(),
-            value=value.contiguous(),
+        # npu_scatter_pa_kv_cache (#11713) adds host-side overhead that costs
+        # ~9% end-to-end throughput on Atlas A3; see commit message for data.
+        torch_npu._npu_reshape_and_cache(
+            key=key,
+            value=value,
             key_cache=key_cache,
             value_cache=value_cache,
-            slot_mapping=slot_mapping.contiguous(),
-            cache_mode="Norm",
+            slot_indices=slot_mapping,
         )
 
     @classmethod


### PR DESCRIPTION
### What this PR does / why we need it?

Backport #15444 to `releases/v0.26.0rc`.

PR #11713 replaced the ND page-attention KV cache write in `BaseDeviceAdaptor.reshape_and_cache` with `torch_npu.npu_scatter_pa_kv_cache(cache_mode="Norm")`. Profiling on Atlas A3 showed that path adds host-side overhead without changing the NPU kernel composition.

This patch restores `torch_npu._npu_reshape_and_cache` and avoids the extra contiguous copies for key, value, and slot mapping. It also updates the v0.26-specific unit test to verify the legacy operator receives the original tensors and that the scatter operator is not called.

Original PR: #15444

### Does this PR introduce _any_ user-facing change?

No CLI or public API changes. ND page-attention KV cache writes recover the lower-overhead implementation used before #11713.

### How was this patch tested?

Local checks on the v0.26 backport:

- `git diff --check`
- `ruff check tests/ut/device/test_device_op.py vllm_ascend/device/device_op.py`
- `ruff format --check tests/ut/device/test_device_op.py vllm_ascend/device/device_op.py`
- `python -m compileall -q tests/ut/device/test_device_op.py vllm_ascend/device/device_op.py`
- Targeted pre-commit checks passed for ruff, formatting, codespell, typos, forbidden imports, symbolic shapes, and repository Python rules.
- `tools/check_logger.sh` passed under Git Bash.

The focused pytest collection was attempted, but this Windows checkout does not have the Linux/NPU runtime dependency `torch`; full unit and NPU validation is left to CI.

The Atlas A3 performance evidence from #15444 used Qwen3-32B-W8A8-QuaRot + EAGLE3 with TP2, 80 prompts, and concurrency 20. All 80 requests succeeded. Throughput was 382.03 tok/s with the scatter operator and 404.62/428.88 tok/s in two runs after restoring `_npu_reshape_and_cache`.