### PR TITLE
[BugFix][DCP] Fix MLA chunked context lengths for DSpark drafting

### DIFF
--- a/tests/ut/attention/test_mla_cp.py
+++ b/tests/ut/attention/test_mla_cp.py
@@ -96,6 +96,24 @@ def test_mla_dcp_uses_padded_local_chunk_lengths() -> None:
     torch.testing.assert_close(impl.get_context_seq_len_npu(1, metadata), padded_lengths[1])
 
 
+def test_mla_dcp_chunked_context_uses_computed_lengths() -> None:
+    """Draft key lengths must not replace chunked-cache context lengths."""
+    builder = AscendMlaDCPMetadataBuilder.__new__(AscendMlaDCPMetadataBuilder)
+    builder.context_lens_cpu = torch.tensor([1, 31], dtype=torch.int32)
+    builder.dcp_size = 4
+    builder.cp_local_block_size = 16
+
+    local_context_lens = builder._get_dcp_local_context_lens_allranks()
+
+    torch.testing.assert_close(
+        local_context_lens,
+        torch.tensor(
+            [[1, 0, 0, 0], [16, 15, 0, 0]],
+            dtype=torch.int32,
+        ),
+    )
+
+
 @patch(
     "vllm_ascend.attention.context_parallel.mla_cp._EXTRA_CTX",
     SimpleNamespace(is_draft_model=False, capturing=False),

--- a/vllm_ascend/attention/context_parallel/mla_cp.py
+++ b/vllm_ascend/attention/context_parallel/mla_cp.py
@@ -88,10 +88,7 @@ class AscendMlaDCPMetadataBuilder(
         if chunked_context_metadata is None:
             return None
 
-        local_context_lens_allranks = self._get_dcp_context_lens(
-            common_attn_metadata,
-            start=self.num_decodes,
-        )
+        local_context_lens_allranks = self._get_dcp_local_context_lens_allranks()
         padded_local_context_lens_cpu = (
             cdiv(self.context_lens_cpu, self.cp_virtual_block_size) * self.cp_local_block_size
         )
@@ -137,6 +134,23 @@ class AscendMlaDCPMetadataBuilder(
             ),
             cu_seq_lens_lst=self.cu_seq_lens_cpu.tolist(),
             chunk_size=padded_local_max_context_chunk_across_ranks,
+        )
+
+    def _get_dcp_local_context_lens_allranks(self) -> torch.Tensor:
+        """Build DCP-local lengths for the KV cache loaded by chunked prefill.
+
+        Speculative draft metadata repurposes ``num_computed_tokens_of_dcp``
+        for the draft's full KV length. Chunked-context reorganization only
+        loads the already-computed cache, whose global lengths are kept in
+        ``context_lens_cpu`` by the base MLA builder. Derive the local layout
+        from that authoritative source so the gathered tensors and target
+        cumulative sequence lengths describe the same token set.
+        """
+        assert self.context_lens_cpu is not None
+        return get_dcp_local_seq_lens(
+            self.context_lens_cpu,
+            self.dcp_size,
+            self.cp_local_block_size,
         )
 
     def build_decode_metadata(

--- a/vllm_ascend/attention/context_parallel/mla_cp.py
+++ b/vllm_ascend/attention/context_parallel/mla_cp.py
@@ -23,6 +23,7 @@ from vllm_ascend.ascend_forward_context import _EXTRA_CTX
 from vllm_ascend.attention.context_parallel.common_cp import (
     DCPImplMixin,
     DCPMetadataBuilderMixin,
+    get_dcp_local_seq_lens,
 )
 from vllm_ascend.attention.utils import AscendCommonAttentionMetadata
 from vllm_ascend.compilation.acl_graph import (


### PR DESCRIPTION
### What this PR does / why we need it?

Fixes MLA DCP chunked-context metadata construction during DSpark drafting.

`num_computed_tokens_of_dcp` may carry the full draft KV length in speculative metadata, while MLA chunked KV-cache reorganization must use the already-computed context length. This mismatch can cause DCP ranks to build inconsistent sequence-length metadata and fail during MLA KV-cache reorganization.

This PR derives DCP-local chunked-context lengths from `context_lens_cpu`, imports the shared helper explicitly, and adds focused coverage for non-uniform context lengths.

### Does this PR introduce any user-facing change?

No new API or configuration is introduced.

It fixes a runtime failure for MLA + DCP + DSpark speculative decoding workloads.

### How was this patch tested?

- Ran `git diff --check`.
- Ran Python syntax checks for:
  - `vllm_ascend/attention/context_parallel/mla_cp.py`
  - `tests/ut/attention/test_mla_cp.py`
- Verified the shared DCP sequence-length helper imports successfully.
- Manually validated a four-node Kimi K3 deployment (`TP=16`, `DP=4`, `DCP=16`, DSpark): a `/v1/chat/completions` request completed successfully after the fix, with no MLA-DCP assertion, `NameError`, NPU error, or engine failure.

`pytest` was not available in the deployment container, so the focused unit test was not executed there.
- vLLM main: https://github.com/vllm-project/vllm/commit/ba07e4a48fc951300d97eb506217dd530583dea3
