### PR TITLE
[Bugfix][Hybrid] Fix overly strict hash_block_size assertion blocking prefix caching on hybrid models

### DIFF
--- a/vllm_ascend/patch/platform/patch_kv_cache_coordinator.py
+++ b/vllm_ascend/patch/platform/patch_kv_cache_coordinator.py
@@ -159,14 +159,26 @@ class AscendHybridKVCacheCoordinator(HybridKVCacheCoordinator):
             # can be a multiple of hash_block_size.
             self.hash_block_size = hash_block_size
             if enable_caching:
-                # The GLM kpool tail spec uses block_size=index_kpool and opts
-                # out of prefix caching, so it is not bound by the MLA hash
-                # block size.
-                assert all(
-                    self._get_effective_block_size(g.kv_cache_spec) % hash_block_size == 0
+                # Align with upstream vLLM semantics (vllm/v1/core/kv_cache_coordinator.py):
+                # the hash granularity and every participating group's effective block
+                # size must be aligned in either direction — a hash block covers an
+                # integer number of group blocks (fine-grained groups, e.g. 128-token
+                # attention blocks alongside 768-token GDN/mamba state blocks), or one
+                # group block covers an integer number of hash blocks (coarse groups on
+                # the partial-hit path). Groups that opt out of prefix caching (e.g. the
+                # GLM kpool tail spec) are not bound by the hash granularity. This also
+                # no longer trusts the caller-provided scheduler_block_size, which may
+                # be None or a non-LCM value depending on the caller.
+                eff_sizes = [
+                    self._get_effective_block_size(g.kv_cache_spec)
                     for g in kv_cache_config.kv_cache_groups
                     if getattr(g.kv_cache_spec, "participates_in_prefix_caching", True)
-                ), "block_size must be divisible by hash_block_size"
+                ]
+                assert all(hash_block_size % size == 0 or size % hash_block_size == 0 for size in eff_sizes), (
+                    f"hash_block_size={hash_block_size} must be aligned with every "
+                    f"participating group's effective block size in either direction, "
+                    f"effective={eff_sizes}"
+                )
             self.enable_partial_hash_hits = dcp_world_size == 1 and any(
                 isinstance(g.kv_cache_spec, MambaSpec)
                 and g.kv_cache_spec.mamba_cache_mode == "align"
@@ -272,14 +284,26 @@ class AscendHybridKVCacheCoordinator(HybridKVCacheCoordinator):
             # can be a multiple of hash_block_size.
             self.hash_block_size = hash_block_size
             if enable_caching:
-                # The GLM kpool tail spec uses block_size=index_kpool and opts
-                # out of prefix caching, so it is not bound by the MLA hash
-                # block size.
-                assert all(
-                    self._get_effective_block_size(g.kv_cache_spec) % hash_block_size == 0
+                # Align with upstream vLLM semantics (vllm/v1/core/kv_cache_coordinator.py):
+                # the hash granularity and every participating group's effective block
+                # size must be aligned in either direction — a hash block covers an
+                # integer number of group blocks (fine-grained groups, e.g. 128-token
+                # attention blocks alongside 768-token GDN/mamba state blocks), or one
+                # group block covers an integer number of hash blocks (coarse groups on
+                # the partial-hit path). Groups that opt out of prefix caching (e.g. the
+                # GLM kpool tail spec) are not bound by the hash granularity. This also
+                # no longer trusts the caller-provided scheduler_block_size, which may
+                # be None or a non-LCM value depending on the caller.
+                eff_sizes = [
+                    self._get_effective_block_size(g.kv_cache_spec)
                     for g in kv_cache_config.kv_cache_groups
                     if getattr(g.kv_cache_spec, "participates_in_prefix_caching", True)
-                ), "block_size must be divisible by hash_block_size"
+                ]
+                assert all(hash_block_size % size == 0 or size % hash_block_size == 0 for size in eff_sizes), (
+                    f"hash_block_size={hash_block_size} must be aligned with every "
+                    f"participating group's effective block size in either direction, "
+                    f"effective={eff_sizes}"
+                )
             self.enable_partial_hash_hits = dcp_world_size == 1 and any(
                 isinstance(g.kv_cache_spec, MambaSpec)
                 and g.kv_cache_spec.mamba_cache_mode == "align"


### PR DESCRIPTION
### What this PR does / why we need it?

**Problem**: `AscendHybridKVCacheCoordinator.__init__` asserts that every KV
cache group's effective block size must be divisible by `hash_block_size`.
This is stricter than upstream vLLM semantics and breaks `--enable-prefix-caching`
for hybrid GDN/attention models (e.g. Qwen3.8-Flash-Next / Qwen4Exp):

- vllm-ascend's own `patch_mamba_config` aligns the mamba page to 768 tokens,
  producing KV cache groups with block sizes `[128 (attention), 768, 768, 768 (GDN)]`
- when the resolved `hash_block_size` is 768 (e.g. paired with vLLM versions whose
  `resolve_kv_cache_block_sizes` falls back to the scheduler block size for
  divergent mamba groups), the assertion `128 % 768 == 0` fails and the engine
  fails to start:

```
AssertionError: block_size must be divisible by hash_block_size
```

Upstream vLLM (`vllm/v1/core/kv_cache_coordinator.py`) only requires the
*scheduling granularity* (LCM of group block sizes) to be divisible by both
`hash_block_size` and each group's block size — a hash block simply covers
multiple smaller group blocks (768 = 6 x 128), which is valid for caching.

**Fix**: replace the per-group assertion with the upstream-equivalent LCM check:
`scheduler_block_size % hash_block_size == 0` and
`scheduler_block_size % effective_block_size == 0` for every group.

### Does this PR introduce _any_ user-facing change?

No API/interface changes. It only relaxes an over-strict internal assertion so
that `--enable-prefix-caching` works on hybrid models whose KV cache groups have
heterogeneous block sizes. Previously-working configurations are unaffected
(the new condition is strictly weaker and equivalent when all group block sizes
are equal).

### How was this patch tested?

Tested end-to-end on 2 x 8 Ascend 910B3 (aarch64) with Qwen3.8-Flash-Next
(hybrid Gated-DeltaNet + QSA attention, BF16), TP=8 per node:

1. Start with `--enable-prefix-caching`:
   - **Before**: engine startup fails with
     `AssertionError: block_size must be divisible by hash_block_size`
     (hash_block_size=768, effective group sizes=[128, 768, 768, 768])
   - **After**: engine starts and serves normally
2. Prefix cache hit verification: two consecutive requests sharing a ~5K-token
   prefix — second request's latency dropped 11.84s -> 2.10s (~5.6x), and
   `vllm:prefix_cache_hits_total` / `vllm:prefix_cache_queries_total` metrics
   confirm real cache hits (4608/10314 blocks on the warm request).

No new unit test was added: reproducing requires a hybrid GDN+attention model
layout with divergent group block sizes on NPU; happy to add one if reviewers
can suggest a lightweight mock pattern for `AscendHybridKVCacheCoordinator`.

- vLLM main: https://github.com/vllm-project/vllm/commit/ba07e4a48fc951300d97eb506217dd530583dea3
