### PR TITLE
[CI] Clean up UT related select logic

### DIFF
--- a/.github/workflows/scripts/select_tests.py
+++ b/.github/workflows/scripts/select_tests.py
@@ -29,9 +29,9 @@ Test selection is driven by the coverage/AST based precision testing pipeline
   e2e test paths (files or directories) supplied via the ``/e2e`` PR
   comment. Each path is routed directly to the appropriate runner.
 
-- ``--all-tests``: Full-suite mode. Scans ``tests/ut`` and
-  ``tests/e2e/pull_request`` and routes every test file by its directory
-  convention. Used for ready-all runs and scheduled full scans.
+- ``--all-tests``: Full-suite mode. Scans ``tests/ut`` (routed to the CPU
+  runner) and ``tests/e2e/pull_request`` (routed by directory convention).
+  Used for ready-all runs and scheduled full scans.
 
 - ``--curated``: Curated-suite mode. Reads the named test list from
   ``curated_tests:`` in the routing config and routes each path.
@@ -97,9 +97,7 @@ _DEFAULT_KEY: PartitionKey = "cpu-0"
 
 # The coverage-based recommendation emits this batch label (not a real pytest
 # path) to represent the always-on CPU UT suite. Map it to ``tests/ut`` so
-# the ``--test-list-file`` flow runs the CPU UT suite: the directory is
-# scanned with cpu_only=True, i.e. NPU-convention subdirs are skipped and
-# the remaining files route to the CPU runner.
+# the ``--test-list-file`` flow runs the CPU UT suite. All UTs run on CPU.
 CPU_UT_BATCH_ALIAS = "cpu-ut"
 CPU_UT_BATCH_PATH = "tests/ut"
 
@@ -162,11 +160,6 @@ def _resolve_partition(file_path: str) -> PartitionKey | None:
     return None
 
 
-def _route_ut_dir(dir_path: str) -> PartitionKey:
-    result = _resolve_partition(dir_path)
-    return result if result is not None else _DEFAULT_KEY
-
-
 def _route_e2e_dir(dir_path: str) -> PartitionKey | None:
     return _resolve_partition(dir_path)
 
@@ -219,18 +212,12 @@ def _is_test_path(path: str) -> bool:
 def _scan_ut_test_dir(
     dir_path: str,
     groups: dict[PartitionKey, list[str]],
-    cpu_only: bool = False,
 ) -> None:
-    """Scan a UT directory and route tests by directory convention.
+    """Scan a UT directory into the CPU group.
 
-    Walks the directory tree. Each test file is routed individually based on
-    its path — files under convention directories (e.g. ``a2/``, ``a3_2/``)
-    go to the corresponding NPU runner, others go to the CPU group.
-
-    If *cpu_only* is True, files under NPU convention directories are skipped.
-
-    Always emits individual file paths to avoid test pollution when pytest
-    runs a whole directory.
+    All UTs run on CPU, so every test file under ``tests/ut`` is appended to
+    the default CPU partition. Individual file paths are always emitted to
+    avoid test pollution when pytest runs a whole directory.
     """
     path = Path(_pytest_node_file_path(dir_path))
     if not path.exists():
@@ -238,24 +225,13 @@ def _scan_ut_test_dir(
         return
 
     if path.is_file():
-        key = _route_ut_dir(dir_path)
-        if cpu_only and key != _DEFAULT_KEY:
-            print(
-                f"Warning: cpu_only module test {dir_path} routes to NPU runner;"
-                " check test_config.yaml for misconfigured cpu_only tests.",
-                file=sys.stderr,
-            )
-            return
-        groups[key].append(dir_path)
+        groups[_DEFAULT_KEY].append(dir_path)
         return
 
     for f in sorted(path.rglob("test_*.py")):
         if "__pycache__" in f.parts:
             continue
-        key = _route_ut_dir(str(f))
-        if cpu_only and key != _DEFAULT_KEY:
-            continue
-        groups[key].append(str(f))
+        groups[_DEFAULT_KEY].append(str(f))
 
 
 def _scan_e2e_test_dir(
@@ -328,16 +304,10 @@ def _route_explicit_test_target(
     # The coverage recommender emits "cpu-ut" (the batch label of the
     # default_cpu_ut module) instead of the real pytest path "tests/ut".
     # Map it back so the recommended path runs the same CPU UTs the
-    # diff-based select-tests path selects for default_cpu_ut: tests/ut
-    # scanned with cpu_only=True, i.e. NPU-convention subdirs are skipped
-    # and the remaining files route to the CPU runner.
-    cpu_only = False
+    # diff-based select-tests path selects for default_cpu_ut.
     if target == CPU_UT_BATCH_ALIAS:
         target = CPU_UT_BATCH_PATH
-        file_path = target
-        cpu_only = True
-    else:
-        file_path = _pytest_node_file_path(target)
+    file_path = _pytest_node_file_path(target)
     if not _is_test_path(file_path):
         print(
             f"Warning: Skipping non-test path: {target}",
@@ -354,18 +324,11 @@ def _route_explicit_test_target(
         return
 
     if _is_ut_path(file_path):
+        # All UTs run on CPU, so UT targets always go to the CPU group.
         if "::" in target or path.is_file():
-            key = _route_ut_dir(file_path)
-            if cpu_only and key != _DEFAULT_KEY:
-                print(
-                    f"Warning: cpu_only module test {target} routes to NPU runner;"
-                    " check test_config.yaml for misconfigured cpu_only tests.",
-                    file=sys.stderr,
-                )
-                return
-            groups[key].append(target)
+            groups[_DEFAULT_KEY].append(target)
         else:
-            _scan_ut_test_dir(target, groups, cpu_only=cpu_only)
+            _scan_ut_test_dir(target, groups)
         return
 
     if _is_e2e_path(file_path):
@@ -747,8 +710,8 @@ def main():
     input_group.add_argument(
         "--all-tests",
         action="store_true",
-        help="Run the full test suite: scan tests/ut and tests/e2e/pull_request "
-        "and route every test file by its directory convention",
+        help="Run the full test suite: scan tests/ut (CPU) and "
+        "tests/e2e/pull_request, routing e2e tests by directory convention",
     )
     input_group.add_argument(
         "--curated",

--- a/tests/ut/conftest.py
+++ b/tests/ut/conftest.py
@@ -21,13 +21,9 @@ NPU vs CPU routing is determined by directory convention, not decorators.
 See ``.github/workflows/scripts/select_tests.py`` and
 ``.github/workflows/scripts/test_config.yaml`` for the routing rules.
 
-Conventions for UT directories:
-    tests/ut/<module>/            -> CPU runner (default)
-    tests/ut/<module>/a2/         -> A2 NPU x1
-    tests/ut/<module>/a2_2/       -> A2 NPU x2
-    tests/ut/<module>/a3_2/       -> A3 NPU x2
-    tests/ut/<module>/a3_4/       -> A3 NPU x4
-    tests/ut/<module>/310p/       -> 310P NPU x1
+All UTs run on CPU: mock ``torch_npu``/``torch.npu`` are installed when no
+NPU is available. 310P-specific tests live in ``tests/ut/_310p/`` but also
+run on CPU via mocks.
 """
 
 import importlib.util


### PR DESCRIPTION
### What this PR does / why we need it?
This PR updates the docstring in `tests/ut/conftest.py` to reflect the new conventions for unit tests. It removes the outdated directory conventions for various NPU runners (A2, A3, 310P) and documents that all UTs now run on CPU using mocked `torch_npu` and `torch.npu` when no NPU is available. It also notes that 310P-specific tests have been moved to `tests/ut/_310p/` and run on CPU via mocks.

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
No functional changes were made; this is a documentation-only update to the test configuration file.

- vLLM main: https://github.com/vllm-project/vllm/commit/ba07e4a48fc951300d97eb506217dd530583dea3
