### PR TITLE
[BugFix][ModelLoader] Improve NetLoader manifest building and fallback cleanup

### DIFF
--- a/tests/ut/model_loader/netloader/test_netloader.py
+++ b/tests/ut/model_loader/netloader/test_netloader.py
@@ -126,12 +126,17 @@ def _capturing_elastic_server(instances: list):
     return CapturingElasticServer
 
 
-def _patch_dist_barrier(monkeypatch) -> list[str]:
+def _patch_dist_barrier(
+    monkeypatch,
+    *,
+    world_size: int = 1,
+    rank: int = 0,
+) -> list[str]:
     barrier_calls: list[str] = []
     monkeypatch.setattr("torch.distributed.is_available", lambda: True)
     monkeypatch.setattr("torch.distributed.is_initialized", lambda: True)
-    monkeypatch.setattr("torch.distributed.get_world_size", lambda: 1)
-    monkeypatch.setattr("torch.distributed.get_rank", lambda: 0)
+    monkeypatch.setattr("torch.distributed.get_world_size", lambda: world_size)
+    monkeypatch.setattr("torch.distributed.get_rank", lambda: rank)
 
     def _barrier(*args, **kwargs):
         barrier_calls.append("barrier")
@@ -561,28 +566,6 @@ def test_seed_process_weights_order_depends_on_int8_cache(mock_logger, monkeypat
     assert calls == expected_calls
 
 
-@pytest.mark.parametrize("int8_cache", ["dram", "no"])
-@patch("vllm_ascend.model_loader.netloader.netloader.logger")
-def test_target_model_barrier_before_draft(mock_logger, monkeypatch, int8_cache):
-    dummy_model = _patch_loader_common(monkeypatch)
-    monkeypatch.setattr("vllm_ascend.model_loader.netloader.netloader.elastic_load", lambda **kwargs: dummy_model)
-    _install_elastic_server(monkeypatch)
-    barrier_calls = _patch_dist_barrier(monkeypatch)
-
-    extra = {
-        "SOURCE": [{"device_id": 0, "sources": ["127.0.0.1:5000"]}],
-        "MODEL": "dummy-model",
-        "LISTEN_PORT": 5555,
-        "INT8_CACHE": int8_cache,
-    }
-    loader = make_loader_with_config(extra)
-    vllm_config = DummyVllmConfig()
-    vllm_config.speculative_config = object()
-    loader.load_model(vllm_config, DummyModelConfig())
-
-    assert barrier_calls == ["barrier"]
-
-
 @patch("vllm_ascend.model_loader.netloader.netloader.logger")
 def test_failed_target_model_participates_in_barrier_before_error(mock_logger, monkeypatch):
     _patch_loader_common(monkeypatch)
@@ -592,7 +575,7 @@ def test_failed_target_model_participates_in_barrier_before_error(mock_logger, m
         "revert_to_default",
         lambda self, *args, **kwargs: (None, False),
     )
-    barrier_calls = _patch_dist_barrier(monkeypatch)
+    barrier_calls = _patch_dist_barrier(monkeypatch, world_size=4)
 
     extra = {
         "SOURCE": [{"device_id": 0, "sources": ["127.0.0.1:5000"]}],
@@ -602,6 +585,7 @@ def test_failed_target_model_participates_in_barrier_before_error(mock_logger, m
     }
     loader = make_loader_with_config(extra)
     vllm_config = DummyVllmConfig()
+    vllm_config.parallel_config.local_world_size = 4
     vllm_config.speculative_config = object()
 
     with pytest.raises(RuntimeError, match="NetLoader elastic loads model fails"):
@@ -632,7 +616,22 @@ def test_draft_model_does_not_wait_for_target_netloader_barrier(mock_logger, mon
 
 
 @patch("vllm_ascend.model_loader.netloader.netloader.logger")
-def test_target_model_uses_node_local_barrier(mock_logger, monkeypatch):
+@pytest.mark.parametrize(
+    "world_size,local_world_size,rank,expected_groups,expected_barrier_group",
+    [
+        (4, 4, 0, [], None),
+        (8, 4, 2, [[0, 1, 2, 3], [4, 5, 6, 7]], "pg-0"),
+    ],
+)
+def test_target_model_uses_node_local_barrier(
+    mock_logger,
+    monkeypatch,
+    world_size,
+    local_world_size,
+    rank,
+    expected_groups,
+    expected_barrier_group,
+):
     dummy_model = _patch_loader_common(monkeypatch)
     monkeypatch.setattr("vllm_ascend.model_loader.netloader.netloader.elastic_load", lambda **kwargs: dummy_model)
     _install_elastic_server(monkeypatch)
@@ -650,13 +649,13 @@ def test_target_model_uses_node_local_barrier(mock_logger, monkeypatch):
 
     monkeypatch.setattr("torch.distributed.is_available", lambda: True)
     monkeypatch.setattr("torch.distributed.is_initialized", lambda: True)
-    monkeypatch.setattr("torch.distributed.get_world_size", lambda: 8)
-    monkeypatch.setattr("torch.distributed.get_rank", lambda: 2)
+    monkeypatch.setattr("torch.distributed.get_world_size", lambda: world_size)
+    monkeypatch.setattr("torch.distributed.get_rank", lambda: rank)
     monkeypatch.setattr("torch.distributed.new_group", fake_new_group)
     monkeypatch.setattr("torch.distributed.barrier", fake_barrier)
 
     extra = {
-        "SOURCE": [{"device_id": 2, "sources": ["127.0.0.1:5000"]}],
+        "SOURCE": [{"device_id": rank, "sources": ["127.0.0.1:5000"]}],
         "MODEL": "dummy-model",
         "LISTEN_PORT": 5555,
         "INT8_CACHE": "no",
@@ -664,12 +663,12 @@ def test_target_model_uses_node_local_barrier(mock_logger, monkeypatch):
     loader = make_loader_with_config(extra)
     vllm_config = DummyVllmConfig()
     vllm_config.parallel_config = DummyParallelConfig()
-    vllm_config.parallel_config.local_world_size = 4
+    vllm_config.parallel_config.local_world_size = local_world_size
     vllm_config.speculative_config = object()
     loader.load_model(vllm_config, DummyModelConfig())
 
-    assert created_groups == [[0, 1, 2, 3], [4, 5, 6, 7]]
-    assert barrier_groups == ["pg-0"]
+    assert created_groups == expected_groups
+    assert barrier_groups == [expected_barrier_group]
 
 
 @pytest.mark.parametrize(

--- a/tests/ut/model_loader/netloader/test_netloader.py
+++ b/tests/ut/model_loader/netloader/test_netloader.py
@@ -39,6 +39,7 @@ class DummyDeviceConfig:
 class DummyParallelConfig:
     tensor_parallel_size = 1
     pipeline_parallel_size = 1
+    local_world_size = 1
 
 
 class DummyVllmConfig:
@@ -129,7 +130,13 @@ def _patch_dist_barrier(monkeypatch) -> list[str]:
     barrier_calls: list[str] = []
     monkeypatch.setattr("torch.distributed.is_available", lambda: True)
     monkeypatch.setattr("torch.distributed.is_initialized", lambda: True)
-    monkeypatch.setattr("torch.distributed.barrier", lambda: barrier_calls.append("barrier"))
+    monkeypatch.setattr("torch.distributed.get_world_size", lambda: 1)
+    monkeypatch.setattr("torch.distributed.get_rank", lambda: 0)
+
+    def _barrier(*args, **kwargs):
+        barrier_calls.append("barrier")
+
+    monkeypatch.setattr("torch.distributed.barrier", _barrier)
     return barrier_calls
 
 
@@ -546,6 +553,47 @@ def test_draft_model_does_not_wait_for_target_netloader_barrier(mock_logger, mon
     loader.load_model(vllm_config, DummyDraftModelConfig())
 
     assert barrier_calls == []
+
+
+@patch("vllm_ascend.model_loader.netloader.netloader.logger")
+def test_target_model_uses_node_local_barrier(mock_logger, monkeypatch):
+    dummy_model = _patch_loader_common(monkeypatch)
+    monkeypatch.setattr("vllm_ascend.model_loader.netloader.netloader.elastic_load", lambda **kwargs: dummy_model)
+    _install_elastic_server(monkeypatch)
+
+    created_groups: list[list[int]] = []
+    barrier_groups: list[Any] = []
+
+    def fake_new_group(ranks=None, **kwargs):
+        rank_list = list(ranks)
+        created_groups.append(rank_list)
+        return f"pg-{rank_list[0]}"
+
+    def fake_barrier(*args, **kwargs):
+        barrier_groups.append(kwargs.get("group", args[0] if args else None))
+
+    monkeypatch.setattr("torch.distributed.is_available", lambda: True)
+    monkeypatch.setattr("torch.distributed.is_initialized", lambda: True)
+    monkeypatch.setattr("torch.distributed.get_world_size", lambda: 8)
+    monkeypatch.setattr("torch.distributed.get_rank", lambda: 2)
+    monkeypatch.setattr("torch.distributed.new_group", fake_new_group)
+    monkeypatch.setattr("torch.distributed.barrier", fake_barrier)
+
+    extra = {
+        "SOURCE": [{"device_id": 2, "sources": ["127.0.0.1:5000"]}],
+        "MODEL": "dummy-model",
+        "LISTEN_PORT": 5555,
+        "INT8_CACHE": "no",
+    }
+    loader = make_loader_with_config(extra)
+    vllm_config = DummyVllmConfig()
+    vllm_config.parallel_config = DummyParallelConfig()
+    vllm_config.parallel_config.local_world_size = 4
+    vllm_config.speculative_config = object()
+    loader.load_model(vllm_config, DummyModelConfig())
+
+    assert created_groups == [[0, 1, 2, 3], [4, 5, 6, 7]]
+    assert barrier_groups == ["pg-0"]
 
 
 @pytest.mark.parametrize(

--- a/tests/ut/model_loader/netloader/test_netloader.py
+++ b/tests/ut/model_loader/netloader/test_netloader.py
@@ -319,7 +319,7 @@ def test_fallback_cleanup_context_releases_references_and_restores_state(monkeyp
     ("memory_usage", "expected_attempts"),
     [
         ([(300, 400), (100, 150)], 1),
-        ([(300, 400), (250, 300), (250, 300), (100, 150)], 2),
+        ([(300, 400), (250, 300), (100, 150)], 2),
     ],
 )
 @patch("vllm_ascend.model_loader.netloader.netloader.torch.npu.empty_cache")
@@ -335,11 +335,13 @@ def test_reclaim_failed_model_memory_attempts(
         "_get_npu_memory_usage",
         side_effect=memory_usage,
     ) as mock_memory_usage:
-        ModelNetLoaderElastic._reclaim_failed_model_memory("npu", (100, 200))
+        result = ModelNetLoaderElastic._reclaim_failed_model_memory("npu", (100, 200))
 
+    assert result.attempts == expected_attempts
+    assert result.reached_baseline is True
     assert mock_gc.call_count == expected_attempts
     assert mock_empty_cache.call_count == expected_attempts
-    assert mock_memory_usage.call_count == expected_attempts * 2
+    assert mock_memory_usage.call_count == expected_attempts + 1
 
 
 def test_pre_transfer_weight_processing_unwraps_and_restores_quant_methods():
@@ -413,6 +415,7 @@ def test_load_model_elastic_success(mock_logger, monkeypatch, tmp_path):
     result = make_loader_with_config(extra).load_model(DummyVllmConfig(), DummyModelConfig())
     assert isinstance(result, nn.Module)
     assert (tmp_path / "output_0.txt").exists()
+    assert any("Netloader manifest build time" in call.args[0] for call in mock_logger.info.call_args_list)
 
 
 @patch("vllm_ascend.model_loader.netloader.netloader.logger")
@@ -425,10 +428,11 @@ def test_target_elastic_failure_sets_fallback_flag(mock_logger, monkeypatch):
         "revert_to_default",
         lambda self, *args, **kwargs: (dummy_model, False),
     )
-    cleanup_context = object()
+    cleanup_context = SimpleNamespace(memory_baseline=None)
+    reclaim_result = SimpleNamespace(attempts=1, before=None, after=None, reached_baseline=False)
     monkeypatch.setattr(ModelNetLoaderElastic, "_create_fallback_cleanup_context", lambda *args: cleanup_context)
     monkeypatch.setattr(ModelNetLoaderElastic, "_release_failed_model_references", lambda *args: lambda: None)
-    monkeypatch.setattr(ModelNetLoaderElastic, "_reclaim_failed_model_memory", lambda *args: None)
+    monkeypatch.setattr(ModelNetLoaderElastic, "_reclaim_failed_model_memory", lambda *args: reclaim_result)
     _install_elastic_server(monkeypatch)
 
     extra = {
@@ -441,6 +445,9 @@ def test_target_elastic_failure_sets_fallback_flag(mock_logger, monkeypatch):
     loader.load_model(DummyVllmConfig(), DummyModelConfig())
 
     assert ModelNetLoaderElastic._target_elastic_fallback is True
+    log_formats = [call.args[0] for call in mock_logger.method_calls]
+    assert any("Netloader load failed" in message for message in log_formats)
+    assert any("stage=fallback_cleanup" in message for message in log_formats)
     ModelNetLoaderElastic._target_elastic_fallback = False
 
 

--- a/tests/ut/model_loader/netloader/test_netloader.py
+++ b/tests/ut/model_loader/netloader/test_netloader.py
@@ -239,34 +239,107 @@ def test_init_with_invalid_config(monkeypatch):
     assert loader.output_prefix is None
 
 
-def test_remove_new_static_forward_context_keys_preserves_baseline(monkeypatch):
-    class DummyCompilationConfig:
-        def __init__(self):
-            self.static_forward_context = {}
+def test_fallback_cleanup_context_releases_references_and_restores_state(monkeypatch):
+    from vllm.model_executor.layers import rotary_embedding
 
-    class ConfigWithCompilation:
-        def __init__(self):
-            self.compilation_config = DummyCompilationConfig()
+    from vllm_ascend.eplb.adaptor.vllm_adaptor import VllmEplbAdaptor
 
-    passed_config = ConfigWithCompilation()
-    current_config = ConfigWithCompilation()
-    target_layer = object()
-    draft_layer = object()
-    passed_config.compilation_config.static_forward_context["target.layer"] = target_layer
-    current_config.compilation_config.static_forward_context["current.target"] = target_layer
+    class FakeCompileWrapper(nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.cleanup_calls = 0
+
+        def cleanup(self):
+            self.cleanup_calls += 1
+
+    target_layer = nn.Module()
+    draft_layer = nn.Module()
+    stale_layer = nn.Module()
+    compile_wrapper = FakeCompileWrapper()
+    failed_model = nn.Module()
+    failed_model.add_module("stale", stale_layer)
+    failed_model.add_module("draft", draft_layer)
+    failed_model.add_module("compiled", compile_wrapper)
+    shared_moe_layers = [target_layer]
+    eplb_layers = [target_layer]
+    passed_config = SimpleNamespace(
+        compilation_config=SimpleNamespace(
+            static_forward_context={"target.layer": target_layer, "stale.layer": stale_layer},
+            static_all_moe_layers=shared_moe_layers,
+        )
+    )
+    current_config = SimpleNamespace(
+        compilation_config=SimpleNamespace(
+            static_forward_context={"current.target": target_layer},
+            static_all_moe_layers=shared_moe_layers,
+        )
+    )
     monkeypatch.setattr(
         "vllm_ascend.model_loader.netloader.netloader.get_current_vllm_config_or_none",
         lambda: current_config,
     )
+    target_key = ("target", 1)
+    draft_key = ("draft", 2)
+    target_rope = object()
+    rope_cache = {target_key: target_rope}
+    monkeypatch.setattr(rotary_embedding, "_ROPE_DICT", rope_cache)
+    monkeypatch.setattr(VllmEplbAdaptor, "_registered_moe_layers", eplb_layers)
+    monkeypatch.setattr(
+        "vllm.compilation.wrapper.TorchCompileWithNoGuardsWrapper",
+        FakeCompileWrapper,
+    )
+    monkeypatch.setattr(
+        ModelNetLoaderElastic,
+        "_get_npu_memory_usage",
+        staticmethod(lambda device_type: (100, 200)),
+    )
 
-    snapshots = ModelNetLoaderElastic._snapshot_static_forward_context_keys(passed_config)
+    cleanup_context = ModelNetLoaderElastic._create_fallback_cleanup_context(passed_config, "npu")
     passed_config.compilation_config.static_forward_context["draft.layer"] = draft_layer
     current_config.compilation_config.static_forward_context["current.draft"] = draft_layer
+    shared_moe_layers.append(draft_layer)
+    eplb_layers.append(draft_layer)
+    rope_cache[draft_key] = object()
 
-    ModelNetLoaderElastic._remove_new_static_forward_context_keys(passed_config, snapshots)
+    failed_model_ref = ModelNetLoaderElastic._release_failed_model_references(
+        failed_model, passed_config, cleanup_context
+    )
 
     assert passed_config.compilation_config.static_forward_context == {"target.layer": target_layer}
     assert current_config.compilation_config.static_forward_context == {"current.target": target_layer}
+    assert shared_moe_layers == [target_layer]
+    assert eplb_layers == [target_layer]
+    assert rope_cache == {target_key: target_rope}
+    assert cleanup_context.memory_baseline == (100, 200)
+    assert failed_model_ref() is failed_model
+    assert compile_wrapper.cleanup_calls == 1
+
+
+@pytest.mark.parametrize(
+    ("memory_usage", "expected_attempts"),
+    [
+        ([(300, 400), (100, 150)], 1),
+        ([(300, 400), (250, 300), (250, 300), (100, 150)], 2),
+    ],
+)
+@patch("vllm_ascend.model_loader.netloader.netloader.torch.npu.empty_cache")
+@patch("vllm_ascend.model_loader.netloader.netloader.gc.collect")
+def test_reclaim_failed_model_memory_attempts(
+    mock_gc,
+    mock_empty_cache,
+    memory_usage,
+    expected_attempts,
+):
+    with patch.object(
+        ModelNetLoaderElastic,
+        "_get_npu_memory_usage",
+        side_effect=memory_usage,
+    ) as mock_memory_usage:
+        ModelNetLoaderElastic._reclaim_failed_model_memory("npu", (100, 200))
+
+    assert mock_gc.call_count == expected_attempts
+    assert mock_empty_cache.call_count == expected_attempts
+    assert mock_memory_usage.call_count == expected_attempts * 2
 
 
 def test_pre_transfer_weight_processing_unwraps_and_restores_quant_methods():
@@ -352,14 +425,10 @@ def test_target_elastic_failure_sets_fallback_flag(mock_logger, monkeypatch):
         "revert_to_default",
         lambda self, *args, **kwargs: (dummy_model, False),
     )
-    monkeypatch.setattr(
-        "vllm_ascend.model_loader.netloader.netloader.ModelNetLoaderElastic._snapshot_static_forward_context_keys",
-        lambda *args, **kwargs: {},
-    )
-    monkeypatch.setattr(
-        "vllm_ascend.model_loader.netloader.netloader.ModelNetLoaderElastic._remove_new_static_forward_context_keys",
-        lambda *args, **kwargs: None,
-    )
+    cleanup_context = object()
+    monkeypatch.setattr(ModelNetLoaderElastic, "_create_fallback_cleanup_context", lambda *args: cleanup_context)
+    monkeypatch.setattr(ModelNetLoaderElastic, "_release_failed_model_references", lambda *args: lambda: None)
+    monkeypatch.setattr(ModelNetLoaderElastic, "_reclaim_failed_model_memory", lambda *args: None)
     _install_elastic_server(monkeypatch)
 
     extra = {

--- a/tests/ut/model_loader/netloader/test_netloader_elastic.py
+++ b/tests/ut/model_loader/netloader/test_netloader_elastic.py
@@ -34,6 +34,7 @@ from vllm_ascend.model_loader.netloader.executor.elastic_load import (
     _finalize_hccl_recv_buffer,
     _get_recv_transfer_items,
     _get_send_transfer_items,
+    _iter_tensors_in_value,
     _prepare_hccl_recv_buffer,
     cache_processed_layout_transfer_manifest,
     get_cached_processed_layout_transfer_items,
@@ -319,6 +320,55 @@ def test_processed_layout_transfer_items_include_module_attribute_tensors(monkey
     assert "layer.weight" in send_names
     assert "layer.aclnn_input_scale_reciprocal" in send_names
     assert send_names == recv_names
+
+
+def test_iter_tensors_in_value_handles_cyclic_containers():
+    tensor = torch.ones(2)
+    cyclic_values = [tensor]
+    cyclic_values.append(cyclic_values)
+
+    tensors = list(_iter_tensors_in_value("values", cyclic_values, set()))
+
+    assert tensors == [("values.0", tensor)]
+
+
+def test_processed_layout_collection_scans_shared_impl_graph_once(monkeypatch):
+    monkeypatch.setattr(
+        p2p_elastic_load,
+        "_is_transferable_tensor",
+        lambda tensor: not tensor.is_meta and tensor.numel() > 0,
+    )
+
+    class SharedState:
+        def __init__(self):
+            self.tensor = torch.ones(2)
+
+    class Impl:
+        def __init__(self, shared_state):
+            self.shared_state = shared_state
+
+    class Layer(torch.nn.Module):
+        def __init__(self, shared_state):
+            super().__init__()
+            self.impl = Impl(shared_state)
+
+    class Model(torch.nn.Module):
+        def __init__(self, shared_state):
+            super().__init__()
+            self.layer_0 = Layer(shared_state)
+            self.layer_1 = Layer(shared_state)
+
+    shared_state = SharedState()
+    with patch.object(
+        p2p_elastic_load,
+        "_try_collect_transferable_tensor",
+        wraps=p2p_elastic_load._try_collect_transferable_tensor,
+    ) as mock_collect:
+        names = [name for name, _ in _collect_processed_layout_tensors(Model(shared_state))]
+
+    assert names == ["layer_0.impl.shared_state.tensor"]
+    shared_tensor_calls = [call for call in mock_collect.call_args_list if call.args[1] is shared_state.tensor]
+    assert len(shared_tensor_calls) == 1
 
 
 def test_dram_transfer_items_still_use_named_parameters_only():

--- a/vllm_ascend/model_loader/netloader/executor/elastic_load.py
+++ b/vllm_ascend/model_loader/netloader/executor/elastic_load.py
@@ -42,6 +42,12 @@ def _iter_tensors_in_value(prefix: str, value: Any, visited_object_ids: set[int]
     if isinstance(value, (Module, str, bytes)) or callable(value):
         return
 
+    if isinstance(value, (list, tuple, dict)):
+        value_id = id(value)
+        if value_id in visited_object_ids:
+            return
+        visited_object_ids.add(value_id)
+
     if isinstance(value, (list, tuple)):
         for index, item in enumerate(value):
             yield from _iter_tensors_in_value(f"{prefix}.{index}", item, visited_object_ids, scan_objects)
@@ -52,11 +58,13 @@ def _iter_tensors_in_value(prefix: str, value: Any, visited_object_ids: set[int]
             yield from _iter_tensors_in_value(f"{prefix}.{key}", item, visited_object_ids, scan_objects)
         return
 
-    if not scan_objects or not hasattr(value, "__dict__"):
+    if not scan_objects:
         return
 
     value_id = id(value)
     if value_id in visited_object_ids:
+        return
+    if not hasattr(value, "__dict__"):
         return
     visited_object_ids.add(value_id)
     for attr_name, attr_value in vars(value).items():
@@ -85,6 +93,7 @@ def _try_collect_transferable_tensor(
 def _collect_processed_layout_tensors(model: Module) -> list[tuple[str, torch.Tensor]]:
     """Collect live inference tensors for int8_cache=no processed-weight transfer."""
     seen_data_ptrs: set[int] = set()
+    visited_object_ids: set[int] = set()
     collected_tensors: list[tuple[str, torch.Tensor]] = []
 
     for name, tensor in model.named_parameters():
@@ -102,9 +111,16 @@ def _collect_processed_layout_tensors(model: Module) -> list[tuple[str, torch.Te
 
             # Attention impl objects store derived tensors (e.g. W_UV/W_UK_T) on plain Python
             # attributes; only "impl" needs deep scan. Other attrs are direct tensors,
-            # list/dict containers, or nn.Module children already covered above.
+            # list/dict containers, or nn.Module children already covered above. Keep
+            # one visited set for the entire model because every attention impl can
+            # reference the same large vllm_config object graph.
             scan_objects = attr_name == "impl"
-            for tensor_name, tensor in _iter_tensors_in_value(attr_name, attr_value, set(), scan_objects):
+            for tensor_name, tensor in _iter_tensors_in_value(
+                attr_name,
+                attr_value,
+                visited_object_ids,
+                scan_objects,
+            ):
                 full_name = f"{module_prefix}.{tensor_name}" if module_prefix else tensor_name
                 _try_collect_transferable_tensor(full_name, tensor, seen_data_ptrs, collected_tensors)
 

--- a/vllm_ascend/model_loader/netloader/load.py
+++ b/vllm_ascend/model_loader/netloader/load.py
@@ -58,7 +58,6 @@ def elastic_load(
         return None
 
     try:
-        start_elastic_client_join = time.perf_counter()
         # Initialize the interaction layer with the ElasticClient
         with ElasticClient(
             sources_this_device,
@@ -69,13 +68,6 @@ def elastic_load(
             group_name=group_name,
             int8_cache=int8_cache,
         ) as client_interaction_layer:
-            elastic_client_join_time = time.perf_counter() - start_elastic_client_join
-            logger.info(
-                "Netloader elastic client join time: %s, device_id: %s, group: %s",
-                elastic_client_join_time,
-                device_id,
-                group_name,
-            )
             if client_interaction_layer.s is None or client_interaction_layer.server_addr is None:
                 raise RuntimeError("Failed to initialize ElasticClient: socket or server_addr is None")
             ack = client_interaction_layer.ack

--- a/vllm_ascend/model_loader/netloader/netloader.py
+++ b/vllm_ascend/model_loader/netloader/netloader.py
@@ -214,6 +214,8 @@ class ModelNetLoaderElastic(BaseModelLoader):
         local_world_size = getattr(vllm_config.parallel_config, "local_world_size", world_size)
         if not isinstance(local_world_size, int) or local_world_size <= 0 or world_size % local_world_size != 0:
             local_world_size = world_size
+        if local_world_size == 1:
+            return
 
         # Same-node ranks only; skip cross-node wait for disk/HBM/NIC contention.
         group = None
@@ -296,13 +298,13 @@ class ModelNetLoaderElastic(BaseModelLoader):
         failed_model: nn.Module | None = None,
     ) -> None:
         """Remove new keys and any registrations owned by the failed model."""
-        stale_modules = set(failed_model.modules()) if failed_model is not None else set()
+        stale_module_ids = {id(module) for module in failed_model.modules()} if failed_model is not None else set()
         for _, static_forward_context in ModelNetLoaderElastic._iter_static_forward_contexts(vllm_config):
             keep_keys = snapshots.get(id(static_forward_context), set())
             new_keys = [
                 key
                 for key, module in list(static_forward_context.items())
-                if key not in keep_keys or module in stale_modules
+                if key not in keep_keys or id(module) in stale_module_ids
             ]
             for key in new_keys:
                 del static_forward_context[key]

--- a/vllm_ascend/model_loader/netloader/netloader.py
+++ b/vllm_ascend/model_loader/netloader/netloader.py
@@ -187,9 +187,30 @@ class ModelNetLoaderElastic(BaseModelLoader):
         if not torch.distributed.is_available() or not torch.distributed.is_initialized():
             return
 
-        logger.info("Waiting for all target netloader ranks before loading draft model")
+        world_size = torch.distributed.get_world_size()
+        rank = torch.distributed.get_rank()
+        local_world_size = getattr(vllm_config.parallel_config, "local_world_size", world_size)
+        if not isinstance(local_world_size, int) or local_world_size <= 0 or world_size % local_world_size != 0:
+            local_world_size = world_size
+
+        # Same-node ranks only; skip cross-node wait for disk/HBM/NIC contention.
+        group = None
+        if local_world_size < world_size:
+            my_node = rank // local_world_size
+            # new_group is world-collective: every rank must create every node group.
+            for node_idx in range(world_size // local_world_size):
+                ranks = list(range(node_idx * local_world_size, (node_idx + 1) * local_world_size))
+                pg = torch.distributed.new_group(ranks=ranks)
+                if node_idx == my_node:
+                    group = pg
+
+        logger.info(
+            "Waiting for local target netloader ranks before loading draft model "
+            "(local_world_size=%s)",
+            local_world_size,
+        )
         barrier_start = time.perf_counter()
-        torch.distributed.barrier()
+        torch.distributed.barrier(group=group)
         logger.info(
             "Target netloader barrier before draft model time: %s",
             time.perf_counter() - barrier_start,

--- a/vllm_ascend/model_loader/netloader/netloader.py
+++ b/vllm_ascend/model_loader/netloader/netloader.py
@@ -19,7 +19,9 @@ import json
 import time
 from contextlib import contextmanager
 from copy import deepcopy
+from dataclasses import dataclass
 from typing import Any, ClassVar, cast
+from weakref import ReferenceType, ref
 
 import torch
 from torch import nn
@@ -38,6 +40,18 @@ from .utils import find_free_port, is_valid_path_prefix
 
 DRAFT_PORT_OFFSET = 10000
 MAX_FREE_PORT_RETRIES = 5
+MAX_FALLBACK_MEMORY_RECLAIM_ATTEMPTS = 2
+BYTES_PER_MIB = 1024**2
+
+
+@dataclass
+class _FallbackCleanupContext:
+    context_keys: dict[int, set[Any]]
+    static_all_moe_layers: dict[int, tuple[list[Any], list[Any]]]
+    rope_cache: dict[Any, Any] | None
+    eplb_layers: list[nn.Module]
+    eplb_layer_count: int
+    memory_baseline: tuple[int, int] | None
 
 
 @contextmanager
@@ -205,8 +219,7 @@ class ModelNetLoaderElastic(BaseModelLoader):
                     group = pg
 
         logger.info(
-            "Waiting for local target netloader ranks before loading draft model "
-            "(local_world_size=%s)",
+            "Waiting for local target netloader ranks before loading draft model (local_world_size=%s)",
             local_world_size,
         )
         barrier_start = time.perf_counter()
@@ -225,17 +238,31 @@ class ModelNetLoaderElastic(BaseModelLoader):
         return static_forward_context
 
     @staticmethod
-    def _iter_static_forward_contexts(vllm_config: VllmConfig):
-        """Yield unique (source_name, context_dict) pairs for this and current vllm config."""
+    def _iter_compilation_configs(vllm_config: VllmConfig):
+        """Yield unique compilation configs for the passed and current vLLM configs."""
         candidates = [("vllm_config", vllm_config)]
         current_vllm_config = get_current_vllm_config_or_none()
         if current_vllm_config is not None:
             candidates.append(("current_vllm_config", current_vllm_config))
 
-        seen_context_ids: set[int] = set()
+        seen_config_ids: set[int] = set()
         for source, config in candidates:
-            static_forward_context = ModelNetLoaderElastic._get_static_forward_context(config)
-            if static_forward_context is None:
+            compilation_config = getattr(config, "compilation_config", None)
+            if compilation_config is None:
+                continue
+            config_id = id(compilation_config)
+            if config_id in seen_config_ids:
+                continue
+            seen_config_ids.add(config_id)
+            yield source, compilation_config
+
+    @staticmethod
+    def _iter_static_forward_contexts(vllm_config: VllmConfig):
+        """Yield unique (source_name, context_dict) pairs for this and current vllm config."""
+        seen_context_ids: set[int] = set()
+        for source, compilation_config in ModelNetLoaderElastic._iter_compilation_configs(vllm_config):
+            static_forward_context = getattr(compilation_config, "static_forward_context", None)
+            if static_forward_context is None or not hasattr(static_forward_context, "clear"):
                 continue
             context_id = id(static_forward_context)
             if context_id in seen_context_ids:
@@ -255,12 +282,21 @@ class ModelNetLoaderElastic(BaseModelLoader):
         return snapshots
 
     @staticmethod
-    def _remove_new_static_forward_context_keys(vllm_config: VllmConfig, snapshots: dict[int, set[Any]]) -> None:
-        """Remove keys added after snapshot; preserve target registrations on draft fallback."""
+    def _remove_new_static_forward_context_keys(
+        vllm_config: VllmConfig,
+        snapshots: dict[int, set[Any]],
+        failed_model: nn.Module | None = None,
+    ) -> None:
+        """Remove new keys and any registrations owned by the failed model."""
+        stale_modules = set(failed_model.modules()) if failed_model is not None else set()
         removed_contexts = []
         for source, static_forward_context in ModelNetLoaderElastic._iter_static_forward_contexts(vllm_config):
             keep_keys = snapshots.get(id(static_forward_context), set())
-            new_keys = [key for key in list(static_forward_context.keys()) if key not in keep_keys]
+            new_keys = [
+                key
+                for key, module in list(static_forward_context.items())
+                if key not in keep_keys or module in stale_modules
+            ]
             for key in new_keys:
                 del static_forward_context[key]
             if new_keys:
@@ -271,6 +307,150 @@ class ModelNetLoaderElastic(BaseModelLoader):
                 "Removed new static_forward_context keys before fallback: %s",
                 removed_contexts,
             )
+
+    @staticmethod
+    def _snapshot_static_all_moe_layers(
+        vllm_config: VllmConfig,
+    ) -> dict[int, tuple[list[Any], list[Any]]]:
+        """Snapshot shared MoE registries so fallback preserves existing target layers."""
+        snapshots: dict[int, tuple[list[Any], list[Any]]] = {}
+        for _, compilation_config in ModelNetLoaderElastic._iter_compilation_configs(vllm_config):
+            static_all_moe_layers = getattr(compilation_config, "static_all_moe_layers", None)
+            if isinstance(static_all_moe_layers, list) and id(static_all_moe_layers) not in snapshots:
+                snapshots[id(static_all_moe_layers)] = (static_all_moe_layers, list(static_all_moe_layers))
+        return snapshots
+
+    @staticmethod
+    def _restore_static_all_moe_layers(snapshots: dict[int, tuple[list[Any], list[Any]]]) -> None:
+        restored = []
+        for static_all_moe_layers, baseline_layers in snapshots.values():
+            removed_count = max(0, len(static_all_moe_layers) - len(baseline_layers))
+            static_all_moe_layers[:] = baseline_layers
+            if removed_count:
+                restored.append(removed_count)
+        if restored:
+            logger.info("Removed new static_all_moe_layers entries before fallback: %s", restored)
+
+    @staticmethod
+    def _snapshot_rope_cache() -> dict[Any, Any] | None:
+        try:
+            from vllm.model_executor.layers.rotary_embedding import _ROPE_DICT
+
+            return dict(_ROPE_DICT) if isinstance(_ROPE_DICT, dict) else None
+        except Exception as exc:
+            logger.debug("Netloader fallback: skip snapshotting _ROPE_DICT: %s", exc)
+            return None
+
+    @staticmethod
+    def _restore_rope_cache(snapshot: dict[Any, Any] | None) -> None:
+        if snapshot is None:
+            return
+        try:
+            from vllm.model_executor.layers.rotary_embedding import _ROPE_DICT
+
+            if isinstance(_ROPE_DICT, dict):
+                removed_count = len([key for key in _ROPE_DICT if key not in snapshot])
+                _ROPE_DICT.clear()
+                _ROPE_DICT.update(snapshot)
+                if removed_count:
+                    logger.info("Removed new _ROPE_DICT entries before fallback: %s", removed_count)
+        except Exception as exc:
+            logger.debug("Netloader fallback: skip restoring _ROPE_DICT: %s", exc)
+
+    @staticmethod
+    def _cleanup_compilation_hooks(model: nn.Module) -> None:
+        """Remove bytecode hooks that otherwise pin a failed compiled model."""
+        try:
+            from vllm.compilation.wrapper import TorchCompileWithNoGuardsWrapper
+
+            cleaned = 0
+            for module in model.modules():
+                if isinstance(module, TorchCompileWithNoGuardsWrapper):
+                    module.cleanup()
+                    cleaned += 1
+            if cleaned:
+                logger.info("Removed compilation bytecode hooks before fallback: %s", cleaned)
+        except Exception as exc:
+            logger.warning("Netloader fallback: failed to remove compilation bytecode hooks: %s", exc)
+
+    @classmethod
+    def _create_fallback_cleanup_context(
+        cls,
+        vllm_config: VllmConfig,
+        device_type: str,
+    ) -> _FallbackCleanupContext:
+        from vllm_ascend.eplb.adaptor.vllm_adaptor import VllmEplbAdaptor
+
+        eplb_layers = VllmEplbAdaptor._registered_moe_layers
+        return _FallbackCleanupContext(
+            context_keys=cls._snapshot_static_forward_context_keys(vllm_config),
+            static_all_moe_layers=cls._snapshot_static_all_moe_layers(vllm_config),
+            rope_cache=cls._snapshot_rope_cache(),
+            eplb_layers=eplb_layers,
+            eplb_layer_count=len(eplb_layers),
+            memory_baseline=cls._get_npu_memory_usage(device_type),
+        )
+
+    @classmethod
+    def _release_failed_model_references(
+        cls,
+        model: nn.Module,
+        vllm_config: VllmConfig,
+        context: _FallbackCleanupContext,
+    ) -> ReferenceType[nn.Module]:
+        """Detach process-global references before the caller drops the model."""
+        model_ref = ref(model)
+        cls._cleanup_compilation_hooks(model)
+        cls._remove_new_static_forward_context_keys(vllm_config, context.context_keys, model)
+        cls._restore_static_all_moe_layers(context.static_all_moe_layers)
+        cls._restore_rope_cache(context.rope_cache)
+        del context.eplb_layers[context.eplb_layer_count :]
+        return model_ref
+
+    @staticmethod
+    def _get_npu_memory_usage(device_type: str) -> tuple[int, int] | None:
+        if device_type != "npu":
+            return None
+        try:
+            return int(torch.npu.memory_allocated()), int(torch.npu.memory_reserved())
+        except Exception as exc:
+            logger.debug("Netloader fallback: failed to query NPU memory usage: %s", exc)
+            return None
+
+    @staticmethod
+    def _reclaim_failed_model_memory(
+        device_type: str,
+        memory_baseline: tuple[int, int] | None,
+    ) -> None:
+        if device_type != "npu":
+            gc.collect()
+            if device_type == "cuda":
+                logger.info("Empty CUDA cache")
+                torch.cuda.empty_cache()
+            return
+
+        baseline_allocated = memory_baseline[0] if memory_baseline is not None else None
+        for attempt in range(1, MAX_FALLBACK_MEMORY_RECLAIM_ATTEMPTS + 1):
+            before = ModelNetLoaderElastic._get_npu_memory_usage(device_type)
+            collected = gc.collect()
+            torch.npu.empty_cache()
+            after = ModelNetLoaderElastic._get_npu_memory_usage(device_type)
+            reached_baseline = baseline_allocated is not None and after is not None and after[0] <= baseline_allocated
+            logger.info(
+                "[netloader_client] stage=fallback_memory_reclaim attempt=%s collected=%s "
+                "baseline_allocated_mib=%s before_allocated_mib=%s before_reserved_mib=%s "
+                "after_allocated_mib=%s after_reserved_mib=%s reached_baseline=%s",
+                attempt,
+                collected,
+                f"{baseline_allocated / BYTES_PER_MIB:.2f}" if baseline_allocated is not None else "unknown",
+                f"{before[0] / BYTES_PER_MIB:.2f}" if before is not None else "unknown",
+                f"{before[1] / BYTES_PER_MIB:.2f}" if before is not None else "unknown",
+                f"{after[0] / BYTES_PER_MIB:.2f}" if after is not None else "unknown",
+                f"{after[1] / BYTES_PER_MIB:.2f}" if after is not None else "unknown",
+                reached_baseline,
+            )
+            if reached_baseline:
+                break
 
     def load_model(self, vllm_config: VllmConfig, model_config: ModelConfig, prefix: str = "") -> nn.Module:
         """
@@ -336,14 +516,15 @@ class ModelNetLoaderElastic(BaseModelLoader):
             _quant_config = getattr(vllm_config, "quant_config", None)
             _quant_config = deepcopy(_quant_config) if _quant_config is not None else None
             model_config_backup = deepcopy(model_config)
-            context_key_snapshot = self._snapshot_static_forward_context_keys(vllm_config)
-            from vllm_ascend.eplb.adaptor.vllm_adaptor import VllmEplbAdaptor
-
-            moe_layer_count_snapshot = len(VllmEplbAdaptor._registered_moe_layers)
+            fallback_cleanup_context = self._create_fallback_cleanup_context(
+                vllm_config,
+                device_config.device_type,
+            )
 
             with set_default_torch_dtype(model_config.dtype):
                 with target_device:
                     model = initialize_model(vllm_config=vllm_config, model_config=model_config, prefix=prefix)
+                elastic_model = model
 
                 if load_int8_cache == "no":
                     try:
@@ -387,7 +568,6 @@ class ModelNetLoaderElastic(BaseModelLoader):
                         logger.warning("Skip draft elastic load: source port exceeds 65535")
                         model = None
 
-                elastic_model = model
                 if model is not None:
                     model = elastic_load(
                         model=elastic_model,
@@ -413,18 +593,22 @@ class ModelNetLoaderElastic(BaseModelLoader):
                         vllm_config.quant_config = _quant_config
                     model_config = model_config_backup
 
-                    # Drop layer refs before reclaiming memory. MoE experts are also
-                    # held by VllmEplbAdaptor._registered_moe_layers.
-                    self._remove_new_static_forward_context_keys(vllm_config, context_key_snapshot)
-                    del VllmEplbAdaptor._registered_moe_layers[moe_layer_count_snapshot:]
-                    del elastic_model
-                    gc.collect()
-                    if device_config.device_type == "npu":
-                        logger.info("Empty NPU cache")
-                        torch.npu.empty_cache()
-                    elif device_config.device_type == "cuda":
-                        logger.info("Empty CUDA cache")
-                        torch.cuda.empty_cache()
+                    elastic_model_ref = self._release_failed_model_references(
+                        elastic_model,
+                        vllm_config,
+                        fallback_cleanup_context,
+                    )
+                    elastic_model = None
+                    self._reclaim_failed_model_memory(
+                        device_config.device_type,
+                        fallback_cleanup_context.memory_baseline,
+                    )
+                    logger.info(
+                        "[netloader_client] stage=fallback_reference_cleanup "
+                        "model_released=%s remaining_eplb_layers=%s",
+                        elastic_model_ref() is None,
+                        len(fallback_cleanup_context.eplb_layers),
+                    )
 
                     if not is_draft:
                         ModelNetLoaderElastic._target_elastic_fallback = True

--- a/vllm_ascend/model_loader/netloader/netloader.py
+++ b/vllm_ascend/model_loader/netloader/netloader.py
@@ -54,6 +54,14 @@ class _FallbackCleanupContext:
     memory_baseline: tuple[int, int] | None
 
 
+@dataclass
+class _FallbackReclaimResult:
+    attempts: int
+    before: tuple[int, int] | None
+    after: tuple[int, int] | None
+    reached_baseline: bool
+
+
 @contextmanager
 def pre_transfer_weight_processing(model: nn.Module):
     """Unwrap MoE shared-expert validation during pre-transfer process_weights."""
@@ -289,8 +297,7 @@ class ModelNetLoaderElastic(BaseModelLoader):
     ) -> None:
         """Remove new keys and any registrations owned by the failed model."""
         stale_modules = set(failed_model.modules()) if failed_model is not None else set()
-        removed_contexts = []
-        for source, static_forward_context in ModelNetLoaderElastic._iter_static_forward_contexts(vllm_config):
+        for _, static_forward_context in ModelNetLoaderElastic._iter_static_forward_contexts(vllm_config):
             keep_keys = snapshots.get(id(static_forward_context), set())
             new_keys = [
                 key
@@ -299,14 +306,6 @@ class ModelNetLoaderElastic(BaseModelLoader):
             ]
             for key in new_keys:
                 del static_forward_context[key]
-            if new_keys:
-                removed_contexts.append(f"{source}:{len(new_keys)}")
-
-        if removed_contexts:
-            logger.info(
-                "Removed new static_forward_context keys before fallback: %s",
-                removed_contexts,
-            )
 
     @staticmethod
     def _snapshot_static_all_moe_layers(
@@ -322,14 +321,8 @@ class ModelNetLoaderElastic(BaseModelLoader):
 
     @staticmethod
     def _restore_static_all_moe_layers(snapshots: dict[int, tuple[list[Any], list[Any]]]) -> None:
-        restored = []
         for static_all_moe_layers, baseline_layers in snapshots.values():
-            removed_count = max(0, len(static_all_moe_layers) - len(baseline_layers))
             static_all_moe_layers[:] = baseline_layers
-            if removed_count:
-                restored.append(removed_count)
-        if restored:
-            logger.info("Removed new static_all_moe_layers entries before fallback: %s", restored)
 
     @staticmethod
     def _snapshot_rope_cache() -> dict[Any, Any] | None:
@@ -349,11 +342,8 @@ class ModelNetLoaderElastic(BaseModelLoader):
             from vllm.model_executor.layers.rotary_embedding import _ROPE_DICT
 
             if isinstance(_ROPE_DICT, dict):
-                removed_count = len([key for key in _ROPE_DICT if key not in snapshot])
                 _ROPE_DICT.clear()
                 _ROPE_DICT.update(snapshot)
-                if removed_count:
-                    logger.info("Removed new _ROPE_DICT entries before fallback: %s", removed_count)
         except Exception as exc:
             logger.debug("Netloader fallback: skip restoring _ROPE_DICT: %s", exc)
 
@@ -363,13 +353,9 @@ class ModelNetLoaderElastic(BaseModelLoader):
         try:
             from vllm.compilation.wrapper import TorchCompileWithNoGuardsWrapper
 
-            cleaned = 0
             for module in model.modules():
                 if isinstance(module, TorchCompileWithNoGuardsWrapper):
                     module.cleanup()
-                    cleaned += 1
-            if cleaned:
-                logger.info("Removed compilation bytecode hooks before fallback: %s", cleaned)
         except Exception as exc:
             logger.warning("Netloader fallback: failed to remove compilation bytecode hooks: %s", exc)
 
@@ -421,36 +407,25 @@ class ModelNetLoaderElastic(BaseModelLoader):
     def _reclaim_failed_model_memory(
         device_type: str,
         memory_baseline: tuple[int, int] | None,
-    ) -> None:
+    ) -> _FallbackReclaimResult:
         if device_type != "npu":
             gc.collect()
             if device_type == "cuda":
-                logger.info("Empty CUDA cache")
                 torch.cuda.empty_cache()
-            return
+            return _FallbackReclaimResult(1, None, None, False)
 
         baseline_allocated = memory_baseline[0] if memory_baseline is not None else None
+        before = ModelNetLoaderElastic._get_npu_memory_usage(device_type)
+        after = None
+        reached_baseline = False
         for attempt in range(1, MAX_FALLBACK_MEMORY_RECLAIM_ATTEMPTS + 1):
-            before = ModelNetLoaderElastic._get_npu_memory_usage(device_type)
-            collected = gc.collect()
+            gc.collect()
             torch.npu.empty_cache()
             after = ModelNetLoaderElastic._get_npu_memory_usage(device_type)
             reached_baseline = baseline_allocated is not None and after is not None and after[0] <= baseline_allocated
-            logger.info(
-                "[netloader_client] stage=fallback_memory_reclaim attempt=%s collected=%s "
-                "baseline_allocated_mib=%s before_allocated_mib=%s before_reserved_mib=%s "
-                "after_allocated_mib=%s after_reserved_mib=%s reached_baseline=%s",
-                attempt,
-                collected,
-                f"{baseline_allocated / BYTES_PER_MIB:.2f}" if baseline_allocated is not None else "unknown",
-                f"{before[0] / BYTES_PER_MIB:.2f}" if before is not None else "unknown",
-                f"{before[1] / BYTES_PER_MIB:.2f}" if before is not None else "unknown",
-                f"{after[0] / BYTES_PER_MIB:.2f}" if after is not None else "unknown",
-                f"{after[1] / BYTES_PER_MIB:.2f}" if after is not None else "unknown",
-                reached_baseline,
-            )
             if reached_baseline:
                 break
+        return _FallbackReclaimResult(attempt, before, after, reached_baseline)
 
     def load_model(self, vllm_config: VllmConfig, model_config: ModelConfig, prefix: str = "") -> nn.Module:
         """
@@ -525,27 +500,24 @@ class ModelNetLoaderElastic(BaseModelLoader):
                 with target_device:
                     model = initialize_model(vllm_config=vllm_config, model_config=model_config, prefix=prefix)
                 elastic_model = model
+                fallback_reason = "elastic load failed"
 
                 if load_int8_cache == "no":
                     try:
                         with pre_transfer_weight_processing(model):
                             process_weights_after_loading(model, model_config, torch.device(device_config.device))
                         synchronize_npu(device_config.device_type)
+                        manifest_build_start = time.perf_counter()
                         manifest_count = cache_processed_layout_transfer_manifest(model)
                         logger.info(
-                            "Netloader client pre-recv process_weights done, rank: %s, manifest=%s",
+                            "Netloader manifest build time: %s, rank: %s, manifest=%s",
+                            time.perf_counter() - manifest_build_start,
                             device_id,
                             manifest_count,
                         )
                     except Exception as exc:
-                        logger.warning(
-                            "Netloader pre-recv process_weights failed, rank: %s, fallback to DefaultModelLoader: %s",
-                            device_id,
-                            exc,
-                        )
+                        fallback_reason = f"pre-recv preparation failed: {exc}"
                         model = None
-                start_elastic_load = time.perf_counter()
-
                 # Narrowed by has_valid_source above.
                 assert self.source is not None
                 sources: list[dict] = self.source
@@ -565,7 +537,7 @@ class ModelNetLoaderElastic(BaseModelLoader):
                         if isinstance(s, dict) and "device_id" in s
                     ]
                     if any(int(addr.rsplit(":", 1)[1]) > 65535 for s in sources for addr in s.get("sources", [])):
-                        logger.warning("Skip draft elastic load: source port exceeds 65535")
+                        fallback_reason = "draft source port exceeds 65535"
                         model = None
 
                 if model is not None:
@@ -579,15 +551,14 @@ class ModelNetLoaderElastic(BaseModelLoader):
                         group_name="netloader_draft" if is_draft else "netloader",
                         int8_cache=load_int8_cache,
                     )
-                logger.info(
-                    "Elastic load time: %s, rank: %s",
-                    time.perf_counter() - start_elastic_load,
-                    device_id,
-                )
                 need_process_weights_after_loading = load_int8_cache != "no"
 
                 if model is None:
-                    logger.warning("Netloader elastic loading fails, use load format DefaultModelLoader")
+                    logger.warning(
+                        "Netloader load failed, fallback to DefaultModelLoader, rank=%s, reason=%s",
+                        device_id,
+                        fallback_reason,
+                    )
 
                     if hasattr(vllm_config, "quant_config"):
                         vllm_config.quant_config = _quant_config
@@ -599,15 +570,33 @@ class ModelNetLoaderElastic(BaseModelLoader):
                         fallback_cleanup_context,
                     )
                     elastic_model = None
-                    self._reclaim_failed_model_memory(
+                    reclaim_result = self._reclaim_failed_model_memory(
                         device_config.device_type,
                         fallback_cleanup_context.memory_baseline,
                     )
+                    baseline_allocated = (
+                        fallback_cleanup_context.memory_baseline[0]
+                        if fallback_cleanup_context.memory_baseline is not None
+                        else None
+                    )
                     logger.info(
-                        "[netloader_client] stage=fallback_reference_cleanup "
-                        "model_released=%s remaining_eplb_layers=%s",
+                        "[netloader_client] stage=fallback_cleanup rank=%s attempts=%s model_released=%s "
+                        "baseline_allocated_mib=%s before_allocated_mib=%s after_allocated_mib=%s "
+                        "after_reserved_mib=%s reached_baseline=%s",
+                        device_id,
+                        reclaim_result.attempts,
                         elastic_model_ref() is None,
-                        len(fallback_cleanup_context.eplb_layers),
+                        f"{baseline_allocated / BYTES_PER_MIB:.2f}" if baseline_allocated is not None else "unknown",
+                        f"{reclaim_result.before[0] / BYTES_PER_MIB:.2f}"
+                        if reclaim_result.before is not None
+                        else "unknown",
+                        f"{reclaim_result.after[0] / BYTES_PER_MIB:.2f}"
+                        if reclaim_result.after is not None
+                        else "unknown",
+                        f"{reclaim_result.after[1] / BYTES_PER_MIB:.2f}"
+                        if reclaim_result.after is not None
+                        else "unknown",
+                        reclaim_result.reached_baseline,
                     )
 
                     if not is_draft:


### PR DESCRIPTION
### What this PR does / why we need it?

This PR improves NetLoader performance and reliability in several areas.
fixes #15388 
cherry-pick from https://github.com/vllm-project/vllm-ascend/pull/15385

1. Optimize processed-layout manifest construction

NetLoader recursively scans module attributes to collect tensors generated by post-load processing. Multiple modules may reference the same shared object graph, such as `vllm_config`, which caused the same objects to be traversed repeatedly and made manifest construction take more than 30 seconds for large models.

This PR:

- Reuses one visited-object set across the entire model scan.
- Avoids repeatedly traversing shared Python object graphs.
- Handles cyclic list, tuple, and dictionary containers safely.
- Preserves the first discovered tensor name and existing data-pointer deduplication behavior.

2. Reclaim failed NetLoader models before disk fallback

When NetLoader failed and fell back to `DefaultModelLoader`, the failed model could remain referenced by process-global state. In particular, TorchDynamo bytecode hooks could pin the compiled inner model even after the outer model wrapper was released. Loading another copy from disk could consequently cause an NPU OOM.

The fallback cleanup now:

- Removes TorchDynamo bytecode hooks registered by compiled model modules.
- Restores `static_forward_context` and `static_all_moe_layers` to their pre-load state.
- Restores the global RoPE cache.
- Removes newly registered EPLB MoE layers.
- Drops the failed model before loading from disk.
- Runs at most two GC and device-cache reclamation attempts, skipping the second attempt when allocated memory has already returned to the baseline.
- Skips the draft NetLoader attempt when the target model has already fallen
  back on the same worker.

### Does this PR introduce _any_ user-facing change?

Yes, but it does not change any public API or configuration interface.

NetLoader users should observe:

- Faster processed-layout manifest construction for models with shared object graphs.
- Node-local rather than cross-node synchronization before draft-model loading.
- Lower OOM risk when NetLoader falls back to disk loading.
- Less verbose and more actionable NetLoader timing and fallback logs.

### How was this patch tested?

Unit tests were added or updated in:

- `tests/ut/model_loader/netloader/test_netloader.py`
  - Node-local target-to-draft barrier behavior
  - Fallback process-global state restoration
  - TorchDynamo compilation-hook cleanup
  - One-pass and two-pass memory reclamation
  - Target fallback and draft-skip behavior
  - Manifest-build timing log

- `tests/ut/model_loader/netloader/test_netloader_elastic.py`
  - Cyclic-container traversal
  - Shared object graphs are scanned only once
  - Existing processed-layout tensor collection behavior

E2E test results:
- improve manifest build efficiency

before:
<img width="1535" height="576" alt="image" src="https://github.com/user-attachments/assets/136554d5-7dc9-40ed-a0eb-ac72a6b1aea8" />
after:
<img width="1511" height="483" alt="image" src="https://github.com/user-attachments/assets/bfa43beb-d9fd-4cb0-92fb-4054b3a9189f" />
<img width="933" height="312" alt="image" src="https://github.com/user-attachments/assets/b13a2e2c-419f-4bfa-9400-260acec0983e" />

- fallback cleanup

before:
<img width="1531" height="499" alt="image" src="https://github.com/user-attachments/assets/3ffdebfb-9122-46c0-a52f-e2dc6cc1ca7e" />
after:
<img width="1523" height="701" alt="image" src="https://github.com/user-attachments/assets/d19dfd8f-7a63-4962-800a-74e32e92a2bd" />
<img width="1528" height="679" alt="image" src="https://github.com/user-attachments/assets/dea5c8e7-3a78-4e3c-bdd4-dd8123925de3" />
<img width="924" height="288" alt="image" src="https://github.com/user-attachments/assets/ce6c4029-1202-4122-be99-27c1935e6a5f" />


- vLLM main: https://github.com/vllm-project/vllm/commit/ba07e4a48fc951300d97eb506217dd530583dea3
