### PR TITLE
[Refactor][Attention]Move MLAPO_MAX_SUPPORTED_TOKENS to shared utils module

### DIFF
--- a/vllm_ascend/attention/mla_v1.py
+++ b/vllm_ascend/attention/mla_v1.py
@@ -26,6 +26,7 @@ from vllm_ascend.ascend_forward_context import _EXTRA_CTX
 from vllm_ascend.attention.attention_mask import AttentionMaskBuilder
 from vllm_ascend.attention.attention_v1 import AscendAttentionState
 from vllm_ascend.attention.utils import (
+    MLAPO_MAX_SUPPORTED_TOKENS,
     AscendCommonAttentionMetadata,
     ascend_chunked_prefill_workspace_size,
     enable_dcp,
@@ -70,8 +71,6 @@ if TYPE_CHECKING:
 
 BUILD_METADATA_STEP_PREFILL = 0
 BUILD_METADATA_STEP_DECODE = 1
-# token count limits within the mlapo operator
-MLAPO_MAX_SUPPORTED_TOKENS = 1024
 
 
 def _npu_mla_prolog_v3_no_rope(**kwargs):

--- a/vllm_ascend/attention/sfa_v1.py
+++ b/vllm_ascend/attention/sfa_v1.py
@@ -22,8 +22,8 @@ from vllm.v1.worker.utils import select_common_block_size
 from vllm_ascend.ascend_config import get_ascend_config
 from vllm_ascend.attention.attention_mask import AttentionMaskBuilder
 from vllm_ascend.attention.attention_v1 import AscendAttentionState
-from vllm_ascend.attention.mla_v1 import MLAPO_MAX_SUPPORTED_TOKENS
 from vllm_ascend.attention.utils import (
+    MLAPO_MAX_SUPPORTED_TOKENS,
     SFA_QSFA_TILE_SIZE,
     AscendCommonAttentionMetadata,
     ascend_chunked_prefill_workspace_size,

--- a/vllm_ascend/attention/utils.py
+++ b/vllm_ascend/attention/utils.py
@@ -20,6 +20,7 @@ from vllm_ascend.utils import (
 )
 
 SFA_QSFA_TILE_SIZE = 128
+MLAPO_MAX_SUPPORTED_TOKENS = 1024
 
 
 def get_or_register_attention_buffer(


### PR DESCRIPTION
### What this PR does / why we need it?

Moves `MLAPO_MAX_SUPPORTED_TOKENS = 1024` out of `vllm_ascend/attention/mla_v1.py` into the shared module `vllm_ascend/attention/utils.py`, and updates both `mla_v1.py` and `sfa_v1.py` to import it from there.

This cuts the module-level dependency of `sfa_v1` on `mla_v1`, avoiding pulling `mla_v1`'s heavier imports (e.g., `numpy`, `torch.nn.functional`, `get_pcp_group`) when only `sfa_v1` is loaded. It also prevents unrelated MLA code from being counted as covered during SFA precision tests, which collects dynamic coverage while importing `sfa_v1`.

Fixes #15594

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

- Unit tests: `pytest tests/ut/attention/test_sfa_v1.py tests/ut/attention/test_mla_v1.py`
- Local compilation check: `python -m py_compile` on all modified files.