### PR TITLE
[BugFix][MoE] Keep topk weights in float dtype when hidden states arrive quantized (sequence-parallel MoE + W4A8/W8A8)

### DIFF
--- a/tests/ut/ops/test_routed_experts.py
+++ b/tests/ut/ops/test_routed_experts.py
@@ -110,3 +110,49 @@ def test_update_expert_map_preserves_upstream_and_legacy_contracts(monkeypatch):
 
     assert routed_experts.ascend_expert_map is legacy_map
     assert expert_map_manager._expert_map is legacy_map
+
+
+@pytest.mark.parametrize(
+    "hidden_dtype,expected_dtype",
+    [
+        (torch.float32, torch.float32),
+        (torch.float16, torch.float16),
+        (torch.bfloat16, torch.bfloat16),
+        (torch.float8_e4m3fn, torch.float32),
+        (torch.int8, torch.float32),
+        (torch.uint8, torch.float32),
+    ],
+)
+def test_select_experts_keeps_topk_weights_float_for_quantized_hidden(monkeypatch, hidden_dtype, expected_dtype):
+    """topk_weights must never inherit a quantized hidden_states dtype.
+
+    When the MoE sequence-parallel prepare (`_prepare_with_ep_group`) has
+    already quantized hidden_states (e.g. W8A8 -> int8, MXFP -> fp8/uint8),
+    propagating that dtype to topk_weights breaks downstream ops (e.g.
+    `topk_weights * mask` in the token dispatcher: fp8 x bool promotion is
+    unsupported).
+    """
+    router_weights = torch.tensor([[0.6, 0.4]], dtype=torch.float32)
+    router_ids = torch.tensor([[0, 1]], dtype=torch.int32)
+    routed_experts = AscendRoutedExperts.__new__(AscendRoutedExperts)
+    routed_experts.router = SimpleNamespace(
+        _select_experts=lambda **kwargs: (router_weights.clone(), router_ids.clone())
+    )
+    routed_experts.log2phy = None
+    routed_experts.n_shared_experts = 0
+    routed_experts.moe_config = SimpleNamespace(num_experts=2)
+    routed_experts.global_redundant_expert_num = 0
+    monkeypatch.setattr(
+        "vllm_ascend.ops.fused_moe.routed_experts.get_ascend_config",
+        lambda: SimpleNamespace(enable_force_eplb=False),
+    )
+
+    hidden_states = torch.zeros(1, 4, dtype=hidden_dtype)
+    topk_weights, topk_ids = routed_experts._select_experts(
+        hidden_states=hidden_states,
+        router_logits=torch.randn(1, 2),
+        enable_force_load_balance=False,
+    )
+
+    assert topk_weights.dtype == expected_dtype
+    assert topk_ids.dtype == torch.int32

--- a/vllm_ascend/ops/fused_moe/routed_experts.py
+++ b/vllm_ascend/ops/fused_moe/routed_experts.py
@@ -476,10 +476,18 @@ class AscendRoutedExperts(RoutedExperts):  # type: ignore[no-redef]
             )
             topk_ids = torch.cat([topk_ids, shared_expert_ids], dim=1)
             topk_weights = torch.cat([topk_weights, shared_expert_weights], dim=1)
-        # MXFP4 packs activations as uint8; skip the cast so topk_weights stays
-        # fp32, which is what npu_moe_token_unpermute expects for its `probs` arg.
-        if hidden_states.dtype not in [torch.uint8, torch.float8_e4m3fn]:
+        # Routing weights must stay in a floating compute dtype: the MoE
+        # sequence-parallel prepare (`_prepare_with_ep_group`) quantizes
+        # hidden_states for dynamic-quant schemes before routing (W8A8 ->
+        # int8, W8A8MXFP/W4A8MXFP -> float8_e4m3fn, W4A4MXFP -> uint8 fp4
+        # packs). Propagating that dtype to topk_weights breaks downstream
+        # ops (e.g. `topk_weights * mask` in the token dispatcher: fp8 x bool
+        # promotion is unsupported), and npu_moe_token_unpermute expects fp32
+        # `probs`.
+        if hidden_states.dtype in (torch.float32, torch.float16, torch.bfloat16):
             topk_weights = topk_weights.to(hidden_states.dtype)
+        else:
+            topk_weights = topk_weights.to(torch.float32)
         if get_ascend_config().enable_force_eplb:
             topk_ids = get_force_eplb_topk(topk_ids, num_logical_experts)
         elif enable_force_load_balance:

--- a/vllm_ascend/ops/fused_moe/router/grouped_topk_router.py
+++ b/vllm_ascend/ops/fused_moe/router/grouped_topk_router.py
@@ -119,7 +119,14 @@ class AscendGroupedTopKRouter(BaseRouter):
             topk_weights = topk_weights + self.e_score_correction_bias
 
         topk_weights, topk_ids = topk_weights.topk(self.top_k, dim=-1)
-        topk_weights = topk_weights.to(hidden_states.dtype)
+        # Keep routing weights in a floating compute dtype: the MoE
+        # sequence-parallel prepare (`_prepare_with_ep_group`) may have already
+        # quantized hidden_states (int8 / float8_e4m3fn / uint8), and
+        # quantized weights break downstream ops and the renormalization below.
+        if hidden_states.dtype in (torch.float32, torch.float16, torch.bfloat16):
+            topk_weights = topk_weights.to(hidden_states.dtype)
+        else:
+            topk_weights = topk_weights.to(torch.float32)
 
         # Required by npu_moe_init_routing
         topk_ids = topk_ids.to(torch.int32)


### PR DESCRIPTION
### What this PR does / why we need it?

The MoE sequence-parallel prepare step (`_prepare_with_ep_group`) quantizes `hidden_states` for dynamic-quant schemes **before routing**: `W8A8 -> int8`, `W8A8MXFP/W4A8MXFP -> float8_e4m3fn`, `W4A4MXFP -> uint8` (fp4 packs). `AscendRoutedExperts._select_experts` then propagated that dtype to `topk_weights`, which:

- breaks `topk_weights * mask` in the token dispatcher (fp8 x bool promotion is unsupported),
- silently truncates int8 weights (0..1 values become 0) — a live correctness bug on main for SP-MoE + W8A8,
- violates `npu_moe_token_unpermute`'s fp32 `probs` expectation.

Changes:
- `routed_experts.py`: only follow `hidden_states.dtype` for floating compute dtypes (fp32/fp16/bf16); otherwise fall back to `float32`. This whitelist subsumes the previous uint8/float8_e4m3fn skip added for MXFP4 and covers the int8 case the skip missed.
- `grouped_topk_router.py`: apply the same guard — without it the renormalization and `routed_scaling_factor` multiply would run in a quantized dtype.
- Add a UT covering the dtype contract for fp32/fp16/bf16 and quantized hidden_states dtypes.

### Does this PR introduce _any_ user-facing change?

No API/config change. Fixes a crash and a silent-precision bug when activations arrive pre-quantized from the MoE sequence-parallel prepare step.

### How was this patch tested?

```
pytest tests/ut/ops/test_routed_experts.py
# 16 passed (10 existing + 6 new parametrized dtype cases)
```

Validated on A5 nodes with dsa_cp + W4A8/W8A8 quantized models.

Signed-off-by: dsxsteven <dsxsteven@sina.com>
