### PR TITLE
[v0.27.1rc][BugFix][Scheduler] Preserve Mamba spec window on PD consumers

### DIFF
--- a/tests/ut/patch/platform/test_patch_mamba_block_aligned_split.py
+++ b/tests/ut/patch/platform/test_patch_mamba_block_aligned_split.py
@@ -1,0 +1,117 @@
+# Copyright (c) 2026 Huawei Technologies Co., Ltd. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import inspect
+from types import SimpleNamespace
+
+import vllm.v1.core.sched.scheduler as scheduler_module
+
+from vllm_ascend.patch.platform.patch_mamba_block_aligned_split import (
+    _mamba_block_aligned_split,
+    _original_mamba_block_aligned_split,
+)
+
+
+def _scheduler(*, is_kv_consumer: bool | None):
+    kv_transfer_config = None if is_kv_consumer is None else SimpleNamespace(is_kv_consumer=is_kv_consumer)
+    return SimpleNamespace(
+        vllm_config=SimpleNamespace(kv_transfer_config=kv_transfer_config),
+        cache_config=SimpleNamespace(block_size=384),
+        use_eagle=True,
+        max_num_scheduled_tokens=8192,
+        scheduler_config=SimpleNamespace(long_prefill_token_threshold=0),
+        hash_block_size=384,
+        mamba_partial_cache_hit=False,
+    )
+
+
+def _request(
+    *,
+    num_computed_tokens: int = 379,
+    num_prompt_tokens: int = 380,
+    num_tokens: int = 380,
+):
+    return SimpleNamespace(
+        num_computed_tokens=num_computed_tokens,
+        num_prompt_tokens=num_prompt_tokens,
+        num_tokens=num_tokens,
+        shared_prefix_boundary=0,
+    )
+
+
+def test_pd_consumer_preserves_complete_speculative_window():
+    result = _mamba_block_aligned_split(
+        _scheduler(is_kv_consumer=True),
+        _request(),
+        num_new_tokens=8,
+    )
+
+    assert result == 8
+
+
+def test_producer_retains_upstream_mamba_boundary_split():
+    result = _mamba_block_aligned_split(
+        _scheduler(is_kv_consumer=False),
+        _request(),
+        num_new_tokens=8,
+    )
+
+    assert result == 5
+
+
+def test_non_pd_request_retains_upstream_mamba_boundary_split():
+    result = _mamba_block_aligned_split(
+        _scheduler(is_kv_consumer=None),
+        _request(),
+        num_new_tokens=8,
+    )
+
+    assert result == 5
+
+
+def test_pd_consumer_preserves_window_after_external_cache_hit():
+    result = _mamba_block_aligned_split(
+        _scheduler(is_kv_consumer=True),
+        _request(num_computed_tokens=0),
+        num_new_tokens=8,
+        num_external_computed_tokens=379,
+    )
+
+    assert result == 8
+
+
+def test_producer_splits_window_after_external_cache_hit():
+    result = _mamba_block_aligned_split(
+        _scheduler(is_kv_consumer=False),
+        _request(num_computed_tokens=0),
+        num_new_tokens=8,
+        num_external_computed_tokens=379,
+    )
+
+    assert result == 5
+
+
+def test_producer_decode_fast_path_remains_unsplit():
+    result = _mamba_block_aligned_split(
+        _scheduler(is_kv_consumer=False),
+        _request(num_computed_tokens=380),
+        num_new_tokens=8,
+    )
+
+    assert result == 8
+
+
+def test_patch_is_registered_with_upstream_signature():
+    assert scheduler_module.Scheduler._mamba_block_aligned_split is _mamba_block_aligned_split
+    assert inspect.signature(_mamba_block_aligned_split) == inspect.signature(_original_mamba_block_aligned_split)

--- a/vllm_ascend/patch/__init__.py
+++ b/vllm_ascend/patch/__init__.py
@@ -191,7 +191,25 @@
 #       Remove this patch once upstream vLLM supports hybrid KV cache + CP for
 #       non-CUDA backends, or exposes a platform hook for this behavior.
 #
-# ** 10. File: platform/patch_mamba_config.py**
+# ** 10. File: platform/patch_mamba_block_aligned_split.py**
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+#   1. `vllm.v1.core.sched.scheduler.Scheduler._mamba_block_aligned_split`
+#    Why:
+#       On a PD decode consumer, a request with one prompt token remaining can
+#       be padded to a `1 + K` speculative verifier window before Mamba
+#       alignment runs. Splitting that window at the next block boundary makes
+#       its physical width smaller than the advertised speculative placeholder
+#       count.
+#    How:
+#       Return the complete requested width on KV consumers. Delegate producers
+#       and non-PD deployments to the original upstream method unchanged.
+#    Related issue:
+#       https://github.com/vllm-project/vllm/issues/54392
+#    Future Plan:
+#       Remove this compatibility patch once upstream preserves speculative
+#       window atomicity for PD-admitted requests.
+#
+# ** 10a. File: platform/patch_mamba_config.py**
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 #   1. `vllm.model_executor.models.config.HybridAttentionMambaModelConfig.verify_and_update_config`
 #    Why:

--- a/vllm_ascend/patch/platform/__init__.py
+++ b/vllm_ascend/patch/platform/__init__.py
@@ -18,6 +18,7 @@ import os
 
 import vllm_ascend.patch.platform.patch_distributed  # noqa
 import vllm_ascend.patch.platform.patch_kv_cache_utils  # noqa
+import vllm_ascend.patch.platform.patch_mamba_block_aligned_split  # noqa
 import vllm_ascend.patch.platform.patch_mla_prefill_backend  # noqa
 import vllm_ascend.patch.platform.patch_pp_mtp  # noqa
 import vllm_ascend.patch.platform.patch_use_v2_model_runner  # noqa

--- a/vllm_ascend/patch/platform/patch_mamba_block_aligned_split.py
+++ b/vllm_ascend/patch/platform/patch_mamba_block_aligned_split.py
@@ -1,0 +1,74 @@
+# Copyright (c) 2026 Huawei Technologies Co., Ltd. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Keep speculative verifier windows intact on PD decode consumers.
+
+A newly admitted KV-consumer request can have one prompt token left after the
+external cache hit. The waiting scheduler pads that token to a ``1 + K``
+speculative verifier window before Mamba alignment is applied. If the window
+starts mid-block, the alignment split can shorten its physical width while the
+request still advertises all ``K`` speculative placeholders.
+
+Decode consumers preserve the complete verifier window. Producers continue to
+use the upstream Mamba boundary logic unchanged.
+"""
+
+import functools
+import inspect
+
+from vllm.v1.core.sched.scheduler import Scheduler
+from vllm.v1.request import Request
+
+_EXPECTED_PARAMETERS = (
+    "self",
+    "request",
+    "num_new_tokens",
+    "num_new_local_computed_tokens",
+    "num_external_computed_tokens",
+)
+
+_original_mamba_block_aligned_split = Scheduler._mamba_block_aligned_split
+
+
+@functools.wraps(_original_mamba_block_aligned_split)
+def _mamba_block_aligned_split(
+    self: Scheduler,
+    request: Request,
+    num_new_tokens: int,
+    num_new_local_computed_tokens: int = 0,
+    num_external_computed_tokens: int = 0,
+) -> int:
+    """Bypass Mamba splitting on KV consumers and preserve it elsewhere."""
+    kv_transfer_config = self.vllm_config.kv_transfer_config
+    if kv_transfer_config is not None and kv_transfer_config.is_kv_consumer:
+        return num_new_tokens
+
+    return _original_mamba_block_aligned_split(
+        self,
+        request,
+        num_new_tokens,
+        num_new_local_computed_tokens,
+        num_external_computed_tokens,
+    )
+
+
+current_parameters = tuple(inspect.signature(_original_mamba_block_aligned_split).parameters)
+if current_parameters != _EXPECTED_PARAMETERS:
+    raise RuntimeError(
+        "Cannot apply the PD consumer Mamba split patch: unexpected "
+        "Scheduler._mamba_block_aligned_split signature "
+        f"{current_parameters}"
+    )
+
+Scheduler._mamba_block_aligned_split = _mamba_block_aligned_split


### PR DESCRIPTION
### What this PR does / why we need it?

Cherry-pick of #15516 onto `releases/v0.27.1rc`.

In PD-disaggregated serving with a hybrid Mamba model and speculative decoding, a newly admitted KV-consumer request may retain one prompt token after an external cache hit. The scheduler pads it to a `1 + K` verifier window, while Mamba block alignment can shorten the physical token span without shortening the advertised speculative placeholders.

For the reproduced `start=379`, block size `384`, and `K=7` case, the requested 8-token window was shortened to 5 physical tokens and produced invalid DSpark metadata. This change preserves the complete verifier window on KV consumers while leaving producer and non-PD scheduling on the upstream Mamba boundary logic.

The release branch is paired with vLLM `v0.27.1` at `ba07e4a48fc951300d97eb506217dd530583dea3`, the same upstream version used for the original patch validation.

Related discussion: https://github.com/vllm-project/vllm/issues/54392

### Does this PR introduce _any_ user-facing change?

Yes. PD KV consumers preserve the complete speculative verifier window when Mamba block alignment would otherwise shorten it. Producer and non-PD behavior is unchanged.

### How was this patch tested?

- Cherry-picked `88ac3d79a` (the squash merge commit of `#15516`) onto `releases/v0.27.1rc` with no conflicts.
- `ruff check` passed for the changed Python files.
- `ruff format --check` passed for the changed Python files.
- `py_compile` and `git diff --check` passed.
- The seven focused Mamba scheduler unit tests passed in the original PR CI.
- Four-node 2P+2D A/B validation reproduced the baseline metadata mismatch and completed two patched rounds without request failures or metadata mismatches.

- vLLM main: https://github.com/vllm-project/vllm/commit/ba07e4a48fc951300d97eb506217dd530583dea3
