### PR TITLE
[Feature][Model][MOE] Align shared activation with routed GMM2

### DIFF
--- a/tests/ut/_310p/fused_moe/test_shared_fused_moe_310.py
+++ b/tests/ut/_310p/fused_moe/test_shared_fused_moe_310.py
@@ -205,18 +205,17 @@ class _Gate(nn.Module):
 @pytest.mark.parametrize("with_gate", [False, True])
 def test_shared_experts_part2_310_applies_optional_gate(with_gate):
     shared_experts_layer = SimpleNamespace(
-        act_fn=nn.Identity(),
         down_proj=_Projection(),
         expert_gate=_Gate() if with_gate else None,
     )
     shared_experts = AscendSharedExperts.__new__(AscendSharedExperts)
     shared_experts.layer = shared_experts_layer
     hidden_states = torch.randn(3, 4)
-    shared_gate_up = torch.randn(3, 4)
+    shared_act = torch.randn(3, 4)
 
-    output = shared_experts.part2(hidden_states, shared_gate_up)
+    output = shared_experts.part2(hidden_states, shared_act)
 
-    expected = shared_gate_up * 2.0 + 1.0
+    expected = shared_act * 2.0 + 1.0
     if with_gate:
         expected = expected * 0.5
     torch.testing.assert_close(output, expected)

--- a/tests/ut/ops/test_fused_moe.py
+++ b/tests/ut/ops/test_fused_moe.py
@@ -859,18 +859,17 @@ class _Gate(nn.Module):
 @pytest.mark.parametrize("with_gate", [False, True])
 def test_shared_experts_part2_applies_optional_gate(with_gate):
     shared_experts_layer = SimpleNamespace(
-        act_fn=nn.Identity(),
         down_proj=_Projection(),
         expert_gate=_Gate() if with_gate else None,
     )
     shared_experts = AscendSharedExperts.__new__(AscendSharedExperts)
     shared_experts.layer = shared_experts_layer
     hidden_states = torch.randn(3, 4)
-    shared_gate_up = torch.randn(3, 4)
+    shared_act = torch.randn(3, 4)
 
-    output = shared_experts.part2(hidden_states, shared_gate_up)
+    output = shared_experts.part2(hidden_states, shared_act)
 
-    expected = shared_gate_up * 2.0 + 1.0
+    expected = shared_act * 2.0 + 1.0
     if with_gate:
         expected = expected * 0.5
     torch.testing.assert_close(output, expected)
@@ -1170,9 +1169,11 @@ def test_sp_multistream_down_projection_and_reduce_scatter_wait_for_routed_final
     shared_experts.parallel_mode = MagicMock(return_value=SharedExpertParallelMode.SEQUENCE_PARALLEL_ONLY)
     hidden_states = torch.randn(4, 4)
     part1_out = torch.randn(4, 8)
+    shared_act = torch.randn(4, 4)
     shared_out = torch.randn(4, 4)
     reduced_out = torch.randn(2, 4)
     shared_experts.part1 = MagicMock(return_value=part1_out)
+    shared_experts.apply_activation = MagicMock(return_value=shared_act)
     shared_experts.part2 = MagicMock(return_value=shared_out)
     shared_experts._gather_sp_input = MagicMock()
     shared_experts._pad_and_reduce_scatter = MagicMock(return_value=reduced_out)
@@ -1182,6 +1183,7 @@ def test_sp_multistream_down_projection_and_reduce_scatter_wait_for_routed_final
     events = FusedMoEEvents(
         before_routed_experts=MagicMock(),
         before_dispatch=MagicMock(),
+        before_gmm2=MagicMock(),
         before_combine=MagicMock(),
         after_routed_finalize=MagicMock(),
     )
@@ -1212,7 +1214,9 @@ def test_sp_multistream_down_projection_and_reduce_scatter_wait_for_routed_final
     assert not any(
         event_wait.args == (events.before_combine,) for event_wait in auxiliary_stream.wait_event.call_args_list
     )
-    shared_experts.part2.assert_called_once_with(hidden_states, part1_out)
+    auxiliary_stream.wait_event.assert_any_call(events.before_gmm2)
+    shared_experts.apply_activation.assert_called_once_with(part1_out)
+    shared_experts.part2.assert_called_once_with(hidden_states, shared_act)
     shared_experts._pad_and_reduce_scatter.assert_called_once_with(shared_out)
     default_stream.wait_stream.assert_called_once_with(auxiliary_stream)
 
@@ -1224,23 +1228,25 @@ def test_sequence_parallel_sedp_forward_skips_token_comms(monkeypatch):
     shared_experts.layer = SimpleNamespace(
         gate_up_proj=SimpleNamespace(),
         down_proj=SimpleNamespace(),
-    )  # no weight_scale -> dense part1/part2 path
+    )  # no weight_scale -> dense split path
     shared_experts.multistream_overlap = False
     shared_experts.quant_type = QuantType.NONE
     shared_experts.lora_context = None
     shared_experts.parallel_mode = MagicMock(return_value=SharedExpertParallelMode.SEQUENCE_PARALLEL_SEDP)
     hidden_states = torch.randn(2, 4)
     part1_out = torch.randn(2, 8)
+    shared_act = torch.randn(2, 4)
     shared_out = torch.randn(2, 4)
     shared_experts.part1 = MagicMock(return_value=part1_out)
+    shared_experts.apply_activation = MagicMock(return_value=shared_act)
     shared_experts.part2 = MagicMock(return_value=shared_out)
     current_stream = MagicMock()
     events = SimpleNamespace(
-        before_routed_experts=None,
+        before_routed_experts=MagicMock(),
         after_routed_experts=None,
-        before_dispatch=None,
-        before_gmm2=None,
-        before_combine=None,
+        before_dispatch=MagicMock(),
+        before_gmm2=MagicMock(),
+        before_combine=MagicMock(),
     )
     all_gather = MagicMock()
     reduce_scatter = MagicMock()
@@ -1256,7 +1262,14 @@ def test_sequence_parallel_sedp_forward_skips_token_comms(monkeypatch):
     all_gather.assert_not_called()
     reduce_scatter.assert_not_called()
     shared_experts.part1.assert_called_once_with(hidden_states)
-    shared_experts.part2.assert_called_once_with(hidden_states, part1_out)
+    shared_experts.apply_activation.assert_called_once_with(part1_out)
+    shared_experts.part2.assert_called_once_with(hidden_states, shared_act)
+    assert [event_wait.args[0] for event_wait in current_stream.wait_event.call_args_list] == [
+        events.before_routed_experts,
+        events.before_dispatch,
+        events.before_gmm2,
+        events.before_combine,
+    ]
 
 
 def test_active_shared_expert_lora_uses_dense_wrappers(monkeypatch):
@@ -1270,8 +1283,10 @@ def test_active_shared_expert_lora_uses_dense_wrappers(monkeypatch):
     shared_experts.parallel_mode = MagicMock(return_value=SharedExpertParallelMode.SEQUENCE_PARALLEL_SEDP)
     hidden_states = torch.randn(2, 4)
     part1_out = torch.randn(2, 8)
+    shared_act = torch.randn(2, 4)
     shared_out = torch.randn(2, 4)
     shared_experts.part1 = MagicMock(return_value=part1_out)
+    shared_experts.apply_activation = MagicMock(return_value=shared_act)
     shared_experts.part2 = MagicMock(return_value=shared_out)
     current_stream = MagicMock()
     lora_context = SimpleNamespace(punica_wrapper=SimpleNamespace(no_lora=False))
@@ -1294,7 +1309,8 @@ def test_active_shared_expert_lora_uses_dense_wrappers(monkeypatch):
     assert output is shared_out
     dynamic_quant.assert_not_called()
     shared_experts.part1.assert_called_once_with(hidden_states)
-    shared_experts.part2.assert_called_once_with(hidden_states, part1_out)
+    shared_experts.apply_activation.assert_called_once_with(part1_out)
+    shared_experts.part2.assert_called_once_with(hidden_states, shared_act)
 
 
 @pytest.mark.parametrize("has_shared_experts", [False, True])

--- a/vllm_ascend/ops/fused_moe/shared_experts.py
+++ b/vllm_ascend/ops/fused_moe/shared_experts.py
@@ -96,7 +96,7 @@ class AscendSharedExperts:
 
         if self.multistream_overlap:
             # Wrap the quant_method's process_weights_after_loading to validate that
-            # splitting shared expert computation (gate_up projection + activation,
+            # splitting shared expert computation (gate_up projection, activation,
             # then down projection) yields identical results to integrated
             # computation after weight loading.
             original_process_weights = quant_method.process_weights_after_loading
@@ -127,7 +127,8 @@ class AscendSharedExperts:
 
         integrated_out = self.layer(test_input)
         part1_out = self.part1(test_input)
-        split_out = self.part2(test_input, part1_out)
+        shared_act = self.apply_activation(part1_out)
+        split_out = self.part2(test_input, shared_act)
 
         if not torch.allclose(integrated_out, split_out):
             diff = (integrated_out - split_out).abs()
@@ -154,8 +155,10 @@ class AscendSharedExperts:
         shared_gate_up, _ = self.layer.gate_up_proj(hidden_states)  # type: ignore
         return shared_gate_up
 
-    def part2(self, hidden_states: torch.Tensor, shared_gate_up: torch.Tensor):
-        shared_act = self.layer.act_fn(shared_gate_up)  # type: ignore
+    def apply_activation(self, shared_gate_up: torch.Tensor):
+        return self.layer.act_fn(shared_gate_up)  # type: ignore
+
+    def part2(self, hidden_states: torch.Tensor, shared_act: torch.Tensor):
         shared_out, _ = self.layer.down_proj(shared_act)  # type: ignore
 
         # Qwen3-Next specific gating mechanism
@@ -390,12 +393,15 @@ class AscendSharedExperts:
             else:
                 # Ensure the shared experts wait for hidden_states to be ready.
                 torch.npu.current_stream().wait_event(fused_moe_evts.before_routed_experts)
-                # Execute the gate projection and activation concurrently with the
-                # dispatch communication.
+                # Execute the gate projection concurrently with dispatch.
                 maybe_wait_event(fused_moe_evts.before_dispatch)
                 part1_out = self.part1(hidden_states)
+                # Execute activation concurrently with routed GMM2.
+                maybe_wait_event(fused_moe_evts.before_gmm2)
+                shared_act = self.apply_activation(part1_out)
+                # Execute the down projection concurrently with combine.
                 maybe_wait_event(down_projection_ready)
-                shared_out = self.part2(hidden_states, part1_out)
+                shared_out = self.part2(hidden_states, shared_act)
 
         if self.multistream_overlap and mode is SharedExpertParallelMode.SEQUENCE_PARALLEL_ONLY:
             # Keep the shared-expert output collective on the auxiliary stream,


### PR DESCRIPTION
### What this PR does / why we need it?

Related to #15353.

This PR aligns shared-expert activation with routed-expert GMM2 in the existing multistream schedule:

- record the routed `before_gmm2` event in the unquantized MoE MLP path after activation and before the down projection;
- propagate an explicit recording flag so the event is created only when shared-expert multistream overlap is enabled;
- split the generic shared-expert path into Gate-Up, activation, and Down stages;
- wait for `before_gmm2` before shared activation so its Vector work can overlap routed GMM2 Cube work;
- keep the shared Down projection behind the existing combine/finalize boundary;
- make the MLP tuple return contract explicit in its type annotations;
- update coverage for event placement, disabled-path behavior, and shared-stage ordering, including the 310P contract.

This is a deliberately narrow alternative to #15352. That PR introduces new prepared-input and semantic-milestone contracts across the routed/shared MoE implementation. This PR preserves the existing `FusedMoEEvents` and call contracts and changes only the scheduling boundary needed for activation/GMM2 overlap. It does not change the dedicated W8A8/W4A8 or W4A8 MXFP pipelines; quantization schemes and LoRA configurations that use the generic linear-wrapper path inherit the same split scheduling.

No NPU performance improvement is claimed without device profiling.

Duplicate-work checks searched open PRs for `shared activation`, `before_gmm2`, and `shared expert overlap`. #15352 is the only PR that contains the same overlap goal, with the broader implementation difference described above.

### Does this PR introduce _any_ user-facing change?

No. There is no intended API, configuration, checkpoint-format, or numerical behavior change. The change only adjusts internal stream scheduling when shared-expert multistream overlap is enabled.

### How was this patch tested?

Static checks completed locally:

- Python syntax compilation passed for all changed Python files.
- `git diff --check` passed.

Tests were added or updated in:

- `tests/ut/ops/test_moe_mlp.py`
- `tests/ut/ops/test_moe_comm_method.py`
- `tests/ut/ops/test_fused_moe.py`
- `tests/ut/_310p/fused_moe/test_shared_fused_moe_310.py`
- `tests/e2e/nightly/single_node/ops/singlecard_ops/test_fused_moe.py`

The pytest cases were not executed on this Windows host because the workspace has no project pytest environment. Ascend NPU correctness, timeline, and performance validation have not been run and remain required before merge.

### AI assistance

AI assistance was used to prepare this change. The human submitter is responsible for reviewing and understanding every changed line and for completing the required NPU validation.

- vLLM main: https://github.com/vllm-project/vllm/commit/e6bfe03ad73a3330cb427885aa90d97a12e1c704
