### PR TITLE
[Performance][Ops] Kimi k3 Fuse recurrent KDA padding-tail zeroing

### DIFF
--- a/csrc/attention/recurrent_kda/README.md
+++ b/csrc/attention/recurrent_kda/README.md
@@ -50,7 +50,7 @@ o_t = S @ (q_t * scale)
 - `A_log/dt_bias` 支持 `FP32`。
 - Kimi K3 torch/aclnn 入口的 `cu_seqlens` 为必传的设备 INT32/INT64 Tensor；offset 必须单调不减，
   末项不得超过输入 token capacity，各相邻差值必须不超过 8。末项小于 capacity 时，仅有效 token
-  对应的输出和 state 更新有定义，padding tail 输出不作保证。
+  对应的 state 会被更新，kernel 会将 padding tail 输出清零。
 - 仅支持 `layout="BSND"` 和 `layout="TND"`。
 - Kimi K3 Torch 入口固定 `state_v_first=True`，state layout 为 `[state_capacity,HV,V,K]`；底层 aclnn/kernel 同时支持 V-first 和 `[state_capacity,HV,K,V]` 的 K-first 布局。
 - `HV` 必须能被 `H` 整除；`H/HV <= 256`。底层 kernel 与 Kimi K3 Torch 入口均支持 `K=128,V=128/256`。

--- a/csrc/attention/recurrent_kda/op_kernel/arch35/recurrent_kda.h
+++ b/csrc/attention/recurrent_kda/op_kernel/arch35/recurrent_kda.h
@@ -31,6 +31,7 @@ constexpr uint32_t MAX_REPEAT_TIME = 255;
 constexpr uint32_t ADD_FOLD_REDUCE_MIN_K = 128;
 constexpr uint16_t V_LENGTH = VECTOR_REG_WIDTH / sizeof(float);
 constexpr uint16_t TWO_V_LENGTH = 2 * V_LENGTH;
+constexpr uint64_t MAX_INIT_OUTPUT_COUNT = 0xFFFFFFFFULL;
 constexpr uint64_t INVALID_STATE_SLOT = static_cast<uint64_t>(-1);
 
 #ifndef RKDA_ENABLE_ADD_FOLD_REDUCE
@@ -233,6 +234,7 @@ public:
             ReleaseEvents();
             return;
         }
+        ZeroPaddingTail();
         uint64_t vectorCoreNum = GetBlockNum();
         uint64_t taskNum = B_ * NV_;
         for (uint64_t taskIdx = blockIdx; taskIdx < taskNum; taskIdx += vectorCoreNum) {
@@ -262,6 +264,44 @@ public:
     }
 
 private:
+    __aicore__ inline void ZeroPaddingTail()
+    {
+        if (!hasCuSeqlens_ || realV_ == 0) {
+            return;
+        }
+
+        uint64_t validTokenCount = static_cast<uint64_t>(LoadCuSeqlens(B_));
+        if (validTokenCount >= T_) {
+            return;
+        }
+
+        uint64_t coreNum = GetBlockNum();
+        if (coreNum == 0) {
+            return;
+        }
+        // Partition complete V rows so each core owns an aligned, non-overlapping GM range.
+        uint64_t totalRows = (T_ - validTokenCount) * NV_;
+        uint64_t rowsPerCore = totalRows / coreNum + static_cast<uint64_t>(totalRows % coreNum != 0);
+        uint64_t startRow = blockIdx * rowsPerCore;
+        if (startRow >= totalRows) {
+            return;
+        }
+
+        uint64_t remainingRows = totalRows - startRow;
+        if (remainingRows > rowsPerCore) {
+            remainingRows = rowsPerCore;
+        }
+        uint64_t maxRowsPerInit = MAX_INIT_OUTPUT_COUNT / realV_;
+        uint64_t outputOffset = (validTokenCount * NV_ + startRow) * realV_;
+        while (remainingRows > 0) {
+            uint64_t rowsThisInit = remainingRows < maxRowsPerInit ? remainingRows : maxRowsPerInit;
+            uint32_t elementCount = static_cast<uint32_t>(rowsThisInit * realV_);
+            matmul::InitOutput<outType>(attnOutGm_[outputOffset], elementCount, 0);
+            outputOffset += elementCount;
+            remainingRows -= rowsThisInit;
+        }
+    }
+
     __aicore__ inline bool ValidateCuSeqlens() const
     {
         if (!hasCuSeqlens_) {

--- a/csrc/attention/recurrent_kda/op_kernel/recurrent_kda.h
+++ b/csrc/attention/recurrent_kda/op_kernel/recurrent_kda.h
@@ -28,6 +28,7 @@ constexpr uint64_t FP32_NUM_PER_BLOCK = 8;
 constexpr uint32_t REPEAT_LENTH = 64; // 256 bytes for float.
 constexpr uint32_t MAX_REPEAT_TIME = 255;
 constexpr uint32_t ADD_FOLD_REDUCE_MIN_K = 128;
+constexpr uint64_t MAX_INIT_OUTPUT_COUNT = 0xFFFFFFFFULL;
 constexpr uint64_t INVALID_STATE_SLOT = static_cast<uint64_t>(-1);
 
 #ifndef RKDA_ENABLE_ADD_FOLD_REDUCE
@@ -230,6 +231,7 @@ public:
             ReleaseEvents();
             return;
         }
+        ZeroPaddingTail();
         for (uint64_t batch_i = 0; batch_i < B_; batch_i++) {
             int64_t seq0 = SequenceStart(batch_i);
             int64_t seq1 = SequenceEnd(batch_i);
@@ -265,6 +267,44 @@ public:
     }
 
 private:
+    __aicore__ inline void ZeroPaddingTail()
+    {
+        if (!hasCuSeqlens_ || realV_ == 0) {
+            return;
+        }
+
+        uint64_t validTokenCount = static_cast<uint64_t>(LoadCuSeqlens(B_));
+        if (validTokenCount >= T_) {
+            return;
+        }
+
+        uint64_t coreNum = GetBlockNum();
+        if (coreNum == 0) {
+            return;
+        }
+        // Partition complete V rows so each core owns an aligned, non-overlapping GM range.
+        uint64_t totalRows = (T_ - validTokenCount) * NV_;
+        uint64_t rowsPerCore = totalRows / coreNum + static_cast<uint64_t>(totalRows % coreNum != 0);
+        uint64_t startRow = blockIdx * rowsPerCore;
+        if (startRow >= totalRows) {
+            return;
+        }
+
+        uint64_t remainingRows = totalRows - startRow;
+        if (remainingRows > rowsPerCore) {
+            remainingRows = rowsPerCore;
+        }
+        uint64_t maxRowsPerInit = MAX_INIT_OUTPUT_COUNT / realV_;
+        uint64_t outputOffset = (validTokenCount * NV_ + startRow) * realV_;
+        while (remainingRows > 0) {
+            uint64_t rowsThisInit = remainingRows < maxRowsPerInit ? remainingRows : maxRowsPerInit;
+            uint32_t elementCount = static_cast<uint32_t>(rowsThisInit * realV_);
+            matmul::InitOutput<outType>(attnOutGm_[outputOffset], elementCount, 0);
+            outputOffset += elementCount;
+            remainingRows -= rowsThisInit;
+        }
+    }
+
     __aicore__ inline bool ValidateCuSeqlens() const
     {
         if (!hasCuSeqlens_) {

--- a/tests/e2e/nightly/single_node/ops/singlecard_ops/test_kimi_kda_recurrent_ascendc_npu.py
+++ b/tests/e2e/nightly/single_node/ops/singlecard_ops/test_kimi_kda_recurrent_ascendc_npu.py
@@ -714,9 +714,16 @@ def test_kimi_k3_tp16_recurrent_kda_full_decode_graph_padding():
     torch.npu.synchronize()
 
     assert isinstance(ascendc_out, torch.Tensor)
-    assert torch.isfinite(ascendc_out[:, :active_tokens]).all()
+    assert torch.isfinite(ascendc_out).all()
     # A graph-padded call must update the active cache line while skipping
-    # zero-length rows. Padding-tail output is intentionally not compared.
+    # zero-length rows. The kernel clears the unused static output tail.
+    padding_out = ascendc_out[:, active_tokens:].cpu()
+    torch.testing.assert_close(
+        padding_out,
+        torch.zeros_like(padding_out),
+        rtol=0,
+        atol=0,
+    )
     torch.testing.assert_close(ascendc_state.cpu(), triton_state.cpu(), rtol=0.02, atol=0.02)
     torch.testing.assert_close(ascendc_state.cpu(), reference_state, rtol=0.02, atol=0.02)
     torch.testing.assert_close(
@@ -810,7 +817,7 @@ def test_kimi_k3_recurrent_kda_decode_wrapper_aclgraph_replay():
 
     torch.manual_seed(20260724)
     device = torch.device("npu")
-    tokens, heads, dim = 3, 6, 128
+    tokens, heads, dim = 4, 6, 128
     q = torch.randn(1, tokens, heads, dim, dtype=torch.bfloat16, device=device)
     k = torch.randn_like(q)
     v = torch.randn_like(q)
@@ -859,7 +866,7 @@ def test_kimi_k3_recurrent_kda_decode_wrapper_aclgraph_replay():
     v.copy_(torch.randn_like(v))
     raw_gate.copy_(torch.randn_like(raw_gate) * 0.25)
     beta.copy_(torch.rand_like(beta))
-    cu_seqlens.copy_(torch.tensor([0, 2, 3], dtype=torch.int32, device=device))
+    cu_seqlens.copy_(torch.tensor([0, 1, 2], dtype=torch.int32, device=device))
     state_indices.copy_(
         torch.tensor(
             [[7, 8, 8, 8, 8, 8, 8, 8], [3, 6, 6, 6, 6, 6, 6, 6]],
@@ -867,7 +874,7 @@ def test_kimi_k3_recurrent_kda_decode_wrapper_aclgraph_replay():
             device=device,
         )
     )
-    accepted.copy_(torch.tensor([2, 1], dtype=torch.int64, device=device))
+    accepted.copy_(torch.tensor([1, 1], dtype=torch.int64, device=device))
     state_graph.copy_(state_initial)
     graph.replay()
     torch.npu.synchronize()
@@ -875,5 +882,24 @@ def test_kimi_k3_recurrent_kda_decode_wrapper_aclgraph_replay():
     state_eager = state_initial.clone()
     eager_out = invoke(state_eager)
     torch.npu.synchronize()
-    torch.testing.assert_close(graph_out.cpu(), eager_out.cpu(), rtol=0.02, atol=0.02)
+    graph_out_cpu = graph_out.cpu()
+    torch.testing.assert_close(graph_out_cpu, eager_out.cpu(), rtol=0.02, atol=0.02)
     torch.testing.assert_close(state_graph.cpu(), state_eager.cpu(), rtol=0.02, atol=0.02)
+    padding_out = graph_out_cpu[:, 2:]
+    torch.testing.assert_close(
+        padding_out,
+        torch.zeros_like(padding_out),
+        rtol=0,
+        atol=0,
+    )
+
+    # Replaying the same graph with no active tokens must clear the complete
+    # static output without touching the state pool.
+    cu_seqlens.zero_()
+    accepted.zero_()
+    state_graph.copy_(state_initial)
+    graph.replay()
+    torch.npu.synchronize()
+    graph_out_cpu = graph_out.cpu()
+    torch.testing.assert_close(graph_out_cpu, torch.zeros_like(graph_out_cpu), rtol=0, atol=0)
+    torch.testing.assert_close(state_graph.cpu(), state_initial.cpu(), rtol=0, atol=0)

--- a/tests/ut/ops/test_kimi_kda.py
+++ b/tests/ut/ops/test_kimi_kda.py
@@ -32,7 +32,6 @@ from vllm_ascend.ops.kimi_kda import (
     _PACKED_CONV_WEIGHT_NAME,
     AscendKimiGatedDeltaNetAttention,
     _load_a_log,
-    _zero_padded_spec_output,
 )
 
 
@@ -133,42 +132,6 @@ def test_load_a_log_preserves_exact_local_4d_checkpoint():
 def test_load_a_log_rejects_unsupported_layout():
     with pytest.raises(ValueError, match="must be 1-D or 4-D"):
         _load_a_log(torch.empty(1, 1, 2, 1), torch.empty(2, 2), num_heads=4)
-
-
-def test_zero_padded_spec_output_clears_uninitialized_tail():
-    output = torch.arange(16 * 2 * 3, dtype=torch.float32).reshape(1, 16, 2, 3)
-    output[:, 8:] = torch.nan
-    query_start_loc = torch.tensor([0, 8, 8], dtype=torch.int32)
-
-    masked = _zero_padded_spec_output(output, query_start_loc)
-
-    torch.testing.assert_close(masked[:, :8], output[:, :8])
-    assert torch.equal(masked[:, 8:], torch.zeros_like(masked[:, 8:]))
-    assert torch.isfinite(masked).all()
-
-
-def test_zero_padded_spec_output_preserves_fully_covered_output():
-    output = torch.randn(1, 16, 2, 3)
-    query_start_loc = torch.tensor([0, 8, 16], dtype=torch.int32)
-
-    masked = _zero_padded_spec_output(output, query_start_loc)
-
-    torch.testing.assert_close(masked, output)
-
-
-def test_zero_padded_spec_output_supports_multiple_real_and_dummy_rows():
-    output = torch.randn(1, 32, 2, 3)
-    expected = output[:, :16].clone()
-    output[:, 16:] = torch.nan
-    query_start_loc = torch.tensor([0, 8, 16, 16, 16], dtype=torch.int32)
-
-    masked = _zero_padded_spec_output(output, query_start_loc)
-
-    torch.testing.assert_close(masked[:, :16], expected)
-    assert torch.equal(masked[:, 16:], torch.zeros_like(masked[:, 16:]))
-    assert masked.shape == output.shape
-    assert masked.dtype == output.dtype
-    assert masked.device == output.device
 
 
 def test_output_norm_gate_uses_kda_fused_triton_kernel():

--- a/vllm_ascend/ops/kimi_kda.py
+++ b/vllm_ascend/ops/kimi_kda.py
@@ -71,30 +71,6 @@ _PACKED_CONV_WEIGHT_NAME = "packed_conv_weights"
 _FUSED_QKV_NAME = "fused_qkv"
 
 
-def _zero_padded_spec_output(
-    output: torch.Tensor,
-    query_start_loc: torch.Tensor,
-) -> torch.Tensor:
-    """Zero graph-padding rows skipped by the recurrent KDA kernel.
-
-    ``recurrent_kda`` leaves the output for zero-length sequences
-    uninitialized. FULL graph replay keeps those rows in the static output
-    shape, so explicitly clear the uncovered tail before it reaches the
-    residual and MoE layers.
-    """
-    token_indices = torch.arange(
-        output.shape[1],
-        dtype=query_start_loc.dtype,
-        device=output.device,
-    )
-    valid_tokens = token_indices < query_start_loc[-1]
-    return torch.where(
-        valid_tokens.view(1, -1, 1, 1),
-        output,
-        0.0,
-    )
-
-
 def uses_kimi_k3_global_inputs_embeds(vllm_config: VllmConfig) -> bool:
     model_config = vllm_config.model_config
     if model_config.enable_prompt_embeds:
@@ -604,12 +580,6 @@ class AscendKimiGatedDeltaNetAttention(KimiGatedDeltaNetAttention):
                 attn_metadata.spec_query_start_loc,
                 attn_metadata.spec_state_indices_tensor,
                 num_accepted_tokens=spec_conv_meta.num_accepted_tokens,
-            )
-            # Clear only static dummy rows skipped by the kernel. Real query
-            # tokens and their accepted lengths are unchanged.
-            core_spec = _zero_padded_spec_output(
-                core_spec,
-                attn_metadata.spec_query_start_loc,
             )
 
         core_non_spec = None


### PR DESCRIPTION
### What this PR does / why we need it?

This PR moves speculative-decode padding-tail zeroing from the Python path into both the generic and arch35 recurrent KDA kernels.

The change:

- Adds kernel-side `ZeroPaddingTail()` handling.
- Removes the Python `_zero_padded_spec_output()` path and its extra graph operators.
- Ensures padding-tail outputs are deterministically zero.
- Adds a defensive `realV_ == 0` guard before calculating the `InitOutput` chunk size.
- Updates the documentation and NPU regression tests for partial-padding and fully padded replay cases.

This reduces graph overhead while preserving valid-token outputs and recurrent-state updates.

<img width="1920" height="1035" alt="screenshot_2026-09-04_10-58-29" src="https://github.com/user-attachments/assets/d259add5-017e-474d-98b5-3505b8b13aa2" />
<img width="1920" height="1007" alt="screenshot_2026-09-04_10-20-58" src="https://github.com/user-attachments/assets/7df98a4a-f0cd-4b6f-a641-c6bd7183667d" />


### Does this PR introduce _any_ user-facing change?

Yes. Padding-tail rows in recurrent KDA output are now guaranteed to be zero. Valid-token results and state-update behavior remain unchanged.

### How was this patch tested?

Local checks passed:

- `ruff check`
- Python `compileall`
- `git diff --check`

The NPU regression tests were updated to cover:

- Partial padding-tail zeroing.
- Fully padded graph replay.
- Preservation of the recurrent state when there are no active tokens.

NPU runtime tests were not executed locally because the current environment does not provide `torch`, `torch_npu`, or NPU hardware. They should be exercised by the NPU CI environment.
- vLLM main: https://github.com/vllm-project/vllm/commit/d02df748bf9efd99022f1a062597dc3cb3808485
