### PR TITLE
[CI]Add noise filtering for function definitions, class definitions, and docstrings

### DIFF
--- a/.github/workflows/scripts/test_selector.py
+++ b/.github/workflows/scripts/test_selector.py
@@ -259,8 +259,19 @@ class CoverageSelector:
 
             tree = ast.parse(source, filename=filepath)
 
+            TARGET_DECORATORS = {"staticmethod", "classmethod", "property"}
             for node in ast.walk(tree):
                 if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                    # Add decorator lines (only @staticmethod, @classmethod, @property)
+                    for decorator in node.decorator_list:
+                        if isinstance(decorator, ast.Name) and decorator.id in TARGET_DECORATORS:
+                            if hasattr(decorator, "lineno") and decorator.lineno:
+                                def_lines.add(decorator.lineno)
+                                # Handle multi-line decorator expressions
+                                if hasattr(decorator, "end_lineno") and decorator.end_lineno:
+                                    for i in range(decorator.lineno, decorator.end_lineno + 1):
+                                        def_lines.add(i)
+
                     def_lines.add(node.lineno)
 
                     # Bracket counting to find header end

--- a/.github/workflows/scripts/test_selector.py
+++ b/.github/workflows/scripts/test_selector.py
@@ -420,7 +420,9 @@ class CoverageSelector:
                             source_file = self._resolve_source_file(filename)
                             if source_file and source_file.exists():
                                 lines = self._filter_noise_lines(str(source_file), lines)
-                        file_lines_map[filename].update(lines)
+                        # Skip files with no coverage after filtering
+                        if lines:
+                            file_lines_map[filename].update(lines)
 
             normalized_name = self.normalize_test_name(test_case)
             self.test_case_map[normalized_name] = {

--- a/.github/workflows/scripts/test_selector.py
+++ b/.github/workflows/scripts/test_selector.py
@@ -254,19 +254,97 @@ class CoverageSelector:
         def_lines = set()
         try:
             with open(filepath, encoding="utf-8") as f:
-                tree = ast.parse(f.read(), filename=filepath)
+                source = f.read()
+                lines = source.splitlines()
+
+            tree = ast.parse(source, filename=filepath)
+
             for node in ast.walk(tree):
                 if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
                     def_lines.add(node.lineno)
+
+                    # Bracket counting to find header end
+                    start_idx = node.lineno - 1
+                    paren_count = lines[start_idx].count('(') - lines[start_idx].count(')')
+
+                    line_idx = start_idx
+                    while paren_count > 0 and line_idx < len(lines):
+                        line_idx += 1
+                        paren_count += lines[line_idx].count('(') - lines[line_idx].count(')')
+
+                    header_end = line_idx + 1  # Convert to 1-indexed
+
+                    # Extend to return type annotation if present
+                    if node.returns:
+                        header_end = max(header_end, node.returns.end_lineno)
+
+                    # Record all lines from def to header end
+                    for l in range(node.lineno, header_end + 1):
+                        def_lines.add(l)
         except Exception:
             pass
         return def_lines
+
+    def _get_class_def_lines(self, filepath: str) -> set[int]:
+        """
+        Get line numbers of all class definition lines.
+
+        Args:
+            filepath: Source file path
+
+        Returns:
+            Set of line numbers where class definitions occur
+        """
+        class_lines = set()
+        try:
+            with open(filepath, encoding="utf-8") as f:
+                tree = ast.parse(f.read(), filename=filepath)
+
+            for node in ast.walk(tree):
+                if isinstance(node, ast.ClassDef):
+                    class_lines.add(node.lineno)
+        except Exception:
+            pass
+        return class_lines
+
+    def _get_docstring_lines(self, filepath: str) -> set[int]:
+        """
+        Get line numbers of all docstring lines (module, class, and function).
+
+        Docstrings are string literals that appear as the first statement
+        in a module, class, or function body.
+
+        Args:
+            filepath: Source file path
+
+        Returns:
+            Set of line numbers where docstrings occur
+        """
+        docstring_lines = set()
+        try:
+            with open(filepath, encoding="utf-8") as f:
+                tree = ast.parse(f.read(), filename=filepath)
+
+            # Module-level docstring
+            if tree.body and isinstance(tree.body[0], ast.Expr) and isinstance(tree.body[0].value, ast.Constant):
+                docstring_lines.add(tree.body[0].lineno)
+
+            # Class and function docstrings
+            for node in ast.walk(tree):
+                if isinstance(node, (ast.ClassDef, ast.FunctionDef, ast.AsyncFunctionDef)):
+                    if node.body and isinstance(node.body[0], ast.Expr) and isinstance(node.body[0].value, ast.Constant):
+                        docstring_lines.add(node.body[0].lineno)
+        except Exception:
+            pass
+        return docstring_lines
 
     def _filter_noise_lines(self, filepath: str, lines: set[int]) -> set[int]:
         """
         Filter out invalid noise lines from coverage data:
         1. import/from...import statement lines
         2. Function definition lines (def line only)
+        3. Class definition lines
+        4. Docstring lines
 
         Args:
             filepath: Source file path
@@ -281,9 +359,10 @@ class CoverageSelector:
         # Use cache to avoid re-parsing the same file multiple times
         if filepath not in self._noise_lines_cache:
             import_lines = FunctionParser._get_import_lines(filepath)
-            # Get function definition lines
             def_lines = self._get_function_def_lines(filepath)
-            self._noise_lines_cache[filepath] = import_lines | def_lines
+            class_lines = self._get_class_def_lines(filepath)
+            docstring_lines = self._get_docstring_lines(filepath)
+            self._noise_lines_cache[filepath] = import_lines | def_lines | class_lines | docstring_lines
 
         return lines - self._noise_lines_cache[filepath]
 

--- a/.github/workflows/scripts/test_selector.py
+++ b/.github/workflows/scripts/test_selector.py
@@ -265,12 +265,12 @@ class CoverageSelector:
 
                     # Bracket counting to find header end
                     start_idx = node.lineno - 1
-                    paren_count = lines[start_idx].count('(') - lines[start_idx].count(')')
+                    paren_count = lines[start_idx].count("(") - lines[start_idx].count(")")
 
                     line_idx = start_idx
                     while paren_count > 0 and line_idx < len(lines):
                         line_idx += 1
-                        paren_count += lines[line_idx].count('(') - lines[line_idx].count(')')
+                        paren_count += lines[line_idx].count("(") - lines[line_idx].count(")")
 
                     header_end = line_idx + 1  # Convert to 1-indexed
 
@@ -332,7 +332,11 @@ class CoverageSelector:
             # Class and function docstrings
             for node in ast.walk(tree):
                 if isinstance(node, (ast.ClassDef, ast.FunctionDef, ast.AsyncFunctionDef)):
-                    if node.body and isinstance(node.body[0], ast.Expr) and isinstance(node.body[0].value, ast.Constant):
+                    if (
+                        node.body
+                        and isinstance(node.body[0], ast.Expr)
+                        and isinstance(node.body[0].value, ast.Constant)
+                    ):
                         docstring_lines.add(node.body[0].lineno)
         except Exception:
             pass

--- a/.github/workflows/scripts/test_selector.py
+++ b/.github/workflows/scripts/test_selector.py
@@ -265,12 +265,12 @@ class CoverageSelector:
 
                     # Bracket counting to find header end
                     start_idx = node.lineno - 1
-                    paren_count = lines[start_idx].count('(') - lines[start_idx].count(')')
+                    paren_count = lines[start_idx].count("(") - lines[start_idx].count(")")
 
                     line_idx = start_idx
                     while paren_count > 0 and line_idx < len(lines):
                         line_idx += 1
-                        paren_count += lines[line_idx].count('(') - lines[line_idx].count(')')
+                        paren_count += lines[line_idx].count("(") - lines[line_idx].count(")")
 
                     header_end = line_idx + 1  # Convert to 1-indexed
 
@@ -279,8 +279,8 @@ class CoverageSelector:
                         header_end = max(header_end, node.returns.end_lineno)
 
                     # Record all lines from def to header end
-                    for l in range(node.lineno, header_end + 1):
-                        def_lines.add(l)
+                    for i in range(node.lineno, header_end + 1):
+                        def_lines.add(i)
         except Exception:
             pass
         return def_lines
@@ -332,7 +332,11 @@ class CoverageSelector:
             # Class and function docstrings
             for node in ast.walk(tree):
                 if isinstance(node, (ast.ClassDef, ast.FunctionDef, ast.AsyncFunctionDef)):
-                    if node.body and isinstance(node.body[0], ast.Expr) and isinstance(node.body[0].value, ast.Constant):
+                    if (
+                        node.body
+                        and isinstance(node.body[0], ast.Expr)
+                        and isinstance(node.body[0].value, ast.Constant)
+                    ):
                         docstring_lines.add(node.body[0].lineno)
         except Exception:
             pass


### PR DESCRIPTION
 

### What this PR does / why we need it?
This PR improves the precision testing recommendation pipeline by addressing multiple issues that affect test case selection accuracy and coverage data quality.
Coverage data noise filtering:
Adds invalid noise filtering to remove def function definitions, class definitions, import statements, and docstring lines
Filters coverage lines from imported modules that are not directly modified in the PR
Filters out non-product code file changes (docs, configs, etc.)
### Does this PR introduce _any_ user-facing change?
No. This PR does not introduce any user-facing changes.
### How was this patch tested?
This patch was tested through the following approaches:
Manual testing: Verified the following scenarios:
Coverage data noise filtering: def, class, import, and docstring lines are properly removed
Cross-import coverage contamination: coverage from imported modules (e.g., mla_v1.py) is properly filtered when the module is not directly modified

- vLLM main: https://github.com/vllm-project/vllm/commit/ba07e4a48fc951300d97eb506217dd530583dea3
