### PR TITLE
[Bugfix] Prevent DSpark metadata H2D lifetime corruption

### DIFF
--- a/vllm_ascend/worker/model_runner_v1.py
+++ b/vllm_ascend/worker/model_runner_v1.py
@@ -1633,12 +1633,36 @@ class NPUModelRunner(GPUModelRunner):
         # [0, 1, 2, 5, 6, 9]
         target_logits_indices += arange
 
-        # TODO: Optimize the CPU -> NPU copy.
-        cu_num_draft_tokens = torch.from_numpy(cu_num_draft_tokens).pin_memory().to(self.device, non_blocking=True)
-        cu_num_sampled_tokens = torch.from_numpy(cu_num_sampled_tokens).pin_memory().to(self.device, non_blocking=True)
-        logits_indices = torch.from_numpy(logits_indices).pin_memory().to(self.device, non_blocking=True)
-        target_logits_indices = torch.from_numpy(target_logits_indices).pin_memory().to(self.device, non_blocking=True)
-        bonus_logits_indices = torch.from_numpy(bonus_logits_indices).pin_memory().to(self.device, non_blocking=True)
+        # The pinned CPU tensors created here are temporary. On Ascend, their
+        # storage can be reused before an asynchronous H2D copy has completed,
+        # corrupting the speculative-decode indices. Keep these small metadata
+        # transfers synchronous until persistent staging buffers with explicit
+        # lifetime management are used.
+        cu_num_draft_tokens = (
+            torch.from_numpy(cu_num_draft_tokens)
+            .pin_memory()
+            .to(self.device, non_blocking=False)
+        )
+        cu_num_sampled_tokens = (
+            torch.from_numpy(cu_num_sampled_tokens)
+            .pin_memory()
+            .to(self.device, non_blocking=False)
+        )
+        logits_indices = (
+            torch.from_numpy(logits_indices)
+            .pin_memory()
+            .to(self.device, non_blocking=False)
+        )
+        target_logits_indices = (
+            torch.from_numpy(target_logits_indices)
+            .pin_memory()
+            .to(self.device, non_blocking=False)
+        )
+        bonus_logits_indices = (
+            torch.from_numpy(bonus_logits_indices)
+            .pin_memory()
+            .to(self.device, non_blocking=False)
+        )
 
         # Compute the draft token ids.
         # draft_token_indices:      [  1,   2,   3, 105, 106, 208]


### PR DESCRIPTION
## What this PR does

Prevents speculative-decoding metadata corruption on Ascend by making the five small CPU-to-NPU transfers produced by `_calc_spec_decode_metadata()` synchronous.

The source tensors are temporary pinned CPU tensors. Under high-concurrency DSpark serving, their storage can be reused before an asynchronous H2D transfer completes. This can corrupt `target_logits_indices` and terminate the worker in `IndexCheck_int64_high_performance_0`.

## Reproduction evidence

The failure was reproduced with:

- DeepSeek V4 Vision W8A8
- DP4 / TP4 / EP16
- `--max-num-seqs 32`
- DSpark with 6 speculative tokens
- 128 concurrent requests
- graph mode and asynchronous scheduling

The CANN exception dump captured a 1,536-byte index input, exactly 192 `int64` values (`32 requests * 6 draft tokens`). The first six indices were corrupted to `1049846013..1049846018`, while the remaining values formed valid groups of six consecutive indices. The corrupted values have float-like bit patterns and are not derived from the request input.

vLLM PR #53613 improves cross-step ordering, but it does not extend the lifetime of temporary staging tensors created and released inside this function.

## Validation

- `python3 -m py_compile vllm_ascend/worker/model_runner_v1.py`
- `git diff --check`
- `tests/ut/worker/test_model_runner_v1.py::TestNPUModelRunnerOutputTokenIds::test_mtp3_placeholder_metadata_is_preserved_before_sanitizing_forward` (`1 passed`)

High-concurrency graph + async-scheduling integration validation is in progress. The PR is draft until that completes.

## Performance consideration

This is a correctness-first fix. The transferred tensors are small, but synchronous H2D transfers reduce overlap. A future optimization can use persistent staging buffers with explicit event-based lifetime management before restoring non-blocking copies.

- vLLM main: https://github.com/vllm-project/vllm/commit/ba07e4a48fc951300d97eb506217dd530583dea3
