### PR TITLE
[Bugfix][MRV2] Fix eplb v2 with unquant type

### DIFF
--- a/vllm_ascend/ops/fused_moe/routed_experts.py
+++ b/vllm_ascend/ops/fused_moe/routed_experts.py
@@ -65,11 +65,19 @@ class AscendUnquantizedFusedMoEMethod(UnquantizedFusedMoEMethod):
 
     @staticmethod
     def get_eplb_weight_views(layer) -> list[torch.Tensor]:
-        weights = [layer.w13_weight, layer.w2_weight]
-        if layer.w13_bias is not None:
-            weights.append(layer.w13_bias)
-        if layer.w2_bias is not None:
-            weights.append(layer.w2_bias)
+        w13 = getattr(layer, "w13_weight_list", None) or getattr(layer, "w13_weight", None)
+        w2 = getattr(layer, "w2_weight_list", None) or getattr(layer, "w2_weight", None)
+        weights = []
+        if w13 is not None:
+            weights.append(w13)
+        if w2 is not None:
+            weights.append(w2)
+        w13_bias = getattr(layer, "w13_bias", None)
+        w2_bias = getattr(layer, "w2_bias", None)
+        if w13_bias is not None:
+            weights.append(w13_bias)
+        if w2_bias is not None:
+            weights.append(w2_bias)
         return weights
 
     def process_weights_after_loading(self, layer):


### PR DESCRIPTION
### What this PR does / why we need it?

This PR fixes an issue where EPLB weight views cannot be retrieved for unquantized MoE layers when dynamic EPLB or MegaMoe is enabled. In these scenarios, `layer.w13_weight` and `layer.w2_weight` are deleted and replaced by `layer.w13_weight_list` and `layer.w2_weight_list`. Accessing them directly in `get_eplb_weight_views` results in an `AttributeError`. This PR safely retrieves either the weight lists or the original weights using `getattr`.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Tested with unit tests and integration tests for unquantized MoE models with dynamic EPLB enabled.


- vLLM main: https://github.com/vllm-project/vllm/commit/e6bfe03ad73a3330cb427885aa90d97a12e1c704
