### PR TITLE
[Ops][BugFix] Fallback to intermediate_size when moe_intermediate_size is missing

### DIFF
--- a/tests/e2e/nightly/single_node/models/configs/Minimax_m2.7_w8a8_A3.yaml
+++ b/tests/e2e/nightly/single_node/models/configs/Minimax_m2.7_w8a8_A3.yaml
@@ -39,7 +39,7 @@ _server_cmd: &server_cmd
   - "--compilation-config"
   - '{"cudagraph_mode": "FULL_DECODE_ONLY"}'
   - "--additional-config"
-  - '{"enable_cpu_binding": true, "ascend_compilation_config": {"enable_npugraph_ex": true, "enable_static_kernel": false}, "enable_fused_mc2": true, "weight_nz_mode": 1, "enable_flashcomm1": true}'
+  - '{"enable_cpu_binding": true, "enable_fused_mc2": true, "weight_nz_mode": 1, "enable_flashcomm1": true}'
 
 _benchmarks_3500: &benchmarks_3500
   perf_50:

--- a/vllm_ascend/ascend_config.py
+++ b/vllm_ascend/ascend_config.py
@@ -769,6 +769,8 @@ class AscendConfig:
 
         moe_intermediate_size = getattr(hf_text_config, "moe_intermediate_size", None)
         if moe_intermediate_size is None:
+            moe_intermediate_size = getattr(hf_text_config, "intermediate_size", None)
+        if moe_intermediate_size is None:
             return False
         if moe_intermediate_size < 1024 or moe_intermediate_size > 3072 or moe_intermediate_size % 512 != 0:
             return False


### PR DESCRIPTION
### What this PR does / why we need it?

Rebase of #15477 (originally by @nanshen3000) onto latest main.

`_is_megamoe_supported_by_config()` currently returns `False` when the model config has no `moe_intermediate_size` field, which silently disables `enable_fused_mc2` for models like **MiniMax-M2.7** (its config only has `intermediate_size=1536\), causing ~25% nightly perf regression since #13675. This PR falls back to reading `intermediate_size` instead.

**Why rebase is required:** #15477's original base predates #15303, so `_MEGA_MOE_SUPPORTED` was still imported by value and the #15267 megamoe rollback did not take effect — re-enabling mc2=1 routed MiniMax into the rolled-back CANN MegaMoe op and made nightly perf *worse*. On latest main (#15303's `is_mega_moe_supported()` accessor included), mc2=1 correctly routes to `dispatch_ffn_combine`.

### Verification (Ascend910, MiniMax-M2.7-w8a8-QuaRot, TP8+DP2+EP, eagle3, nightly perf_20 case)

| Scenario | Path | Output Token Throughput (baseline 2229) |
|---|---|---|
| This PR on latest main | dispatch_ffn_combine | **2371.6 (106%)** ✅ |
| Original #15477 base (stale import) | CANN MegaMoe (rolled back) | crash / 1693 on CANN 9.1.0 ❌ |

Profiler confirms the `DispatchFFNCombine` fused kernel runs and no MegaMoe ops appear.

CC @nanshen3000 (original author)

- vLLM main: https://github.com/vllm-project/vllm/commit/ba07e4a48fc951300d97eb506217dd530583dea3
