### PR TITLE
[Ci][BugFix] Fix CANN ops package to 9.2.0 for a2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -49,7 +49,7 @@ RUN ARCH=$(case "${TARGETPLATFORM}" in \
         "linux/arm64") echo "aarch64" ;; \
         *) echo "Unsupported TARGETPLATFORM: ${TARGETPLATFORM}" && exit 1 ;; \
     esac) && \
-    CANN_OPS_URL=https://ascend-repo.obs.cn-east-2.myhuaweicloud.com/CANN/CANN%209.2.T3/Ascend-cann-910-ops_9.2.0-beta.2_linux-${ARCH}.run && \
+    CANN_OPS_URL=https://ascend-repo.obs.cn-east-2.myhuaweicloud.com/CANN/CANN%209.2.T3/Ascend-cann-910b-ops_9.2.0-beta.2_linux-${ARCH}.run && \
     wget --quiet --header="Referer: https://www.hiascend.com/" ${CANN_OPS_URL} -O ~/Ascend-cann-ops-9.2.0.run && \
     chmod +x ~/Ascend-cann-ops-9.2.0.run && \
     ~/Ascend-cann-ops-9.2.0.run --quiet --install --install-for-all && \

--- a/Dockerfile.openEuler
+++ b/Dockerfile.openEuler
@@ -46,7 +46,7 @@ RUN ARCH=$(case "${TARGETPLATFORM}" in \
         "linux/arm64") echo "aarch64" ;; \
         *) echo "Unsupported TARGETPLATFORM: ${TARGETPLATFORM}" && exit 1 ;; \
     esac) && \
-    CANN_OPS_URL=https://ascend-repo.obs.cn-east-2.myhuaweicloud.com/CANN/CANN%209.2.T3/Ascend-cann-910-ops_9.2.0-beta.2_linux-${ARCH}.run && \
+    CANN_OPS_URL=https://ascend-repo.obs.cn-east-2.myhuaweicloud.com/CANN/CANN%209.2.T3/Ascend-cann-910b-ops_9.2.0-beta.2_linux-${ARCH}.run && \
     wget --quiet --header="Referer: https://www.hiascend.com/" ${CANN_OPS_URL} -O ~/Ascend-cann-ops-9.2.0.run && \
     chmod +x ~/Ascend-cann-ops-9.2.0.run && \
     ~/Ascend-cann-ops-9.2.0.run --quiet --install --install-for-all && \


### PR DESCRIPTION
### What this PR does / why we need it?

Fix CANN ops package to 9.2.0 for a2

### Does this PR introduce _any_ user-facing change?

### How was this patch tested?


- vLLM main: https://github.com/vllm-project/vllm/commit/ba07e4a48fc951300d97eb506217dd530583dea3
