### PR TITLE
[CI]: collect coverage for test_glm5_2 and upload as artifact

### DIFF
--- a/.github/workflows/_selected_tests.yaml
+++ b/.github/workflows/_selected_tests.yaml
@@ -473,33 +473,45 @@ jobs:
               echo "TASK_NAME=${TASK_NAME}"
             } >> "${GITHUB_ENV}"
 
-        - name: Upload coverage to OBS
-          run: |
-            pip install esdk-obs-python --quiet
-            python3 - <<'EOF'
-            import os
-            from obs import ObsClient
+        # - name: Upload coverage to OBS
+        #   run: |
+        #     pip install esdk-obs-python --quiet
+        #     python3 - <<'EOF'
+        #     import os
+        #     from obs import ObsClient
+        #
+        #     OBS_BUCKET = 'vllm-ascend'
+        #     OBS_PREFIX = 'ci/precision-test'
+        #     client = ObsClient(
+        #         access_key_id=os.environ['OBS_ACCESS_KEY'],
+        #         secret_access_key=os.environ['OBS_SECRET_KEY'],
+        #         server='https://obs.cn-north-4.myhuaweicloud.com'
+        #     )
+        #
+        #     uploads = [
+        #         ('coverage.tar', f'{OBS_PREFIX}/coverage.tar'),
+        #         ('coverage_version.txt', f'{OBS_PREFIX}/coverage_version.txt'),
+        #         ('test_case_map.json', f'{OBS_PREFIX}/test_case_map.json'),
+        #     ]
+        #     for local_path, obs_path in uploads:
+        #         resp = client.putFile(OBS_BUCKET, obs_path, local_path)
+        #         if resp.status < 300:
+        #             print(f'Uploaded: {local_path} -> {obs_path}')
+        #         else:
+        #             raise Exception(f'Failed to upload {local_path}: {resp.errorMessage}')
+        #     EOF
 
-            OBS_BUCKET = 'vllm-ascend'
-            OBS_PREFIX = 'ci/precision-test'
-            client = ObsClient(
-                access_key_id=os.environ['OBS_ACCESS_KEY'],
-                secret_access_key=os.environ['OBS_SECRET_KEY'],
-                server='https://obs.cn-north-4.myhuaweicloud.com'
-            )
-
-            uploads = [
-                ('coverage.tar', f'{OBS_PREFIX}/coverage.tar'),
-                ('coverage_version.txt', f'{OBS_PREFIX}/coverage_version.txt'),
-                ('test_case_map.json', f'{OBS_PREFIX}/test_case_map.json'),
-            ]
-            for local_path, obs_path in uploads:
-                resp = client.putFile(OBS_BUCKET, obs_path, local_path)
-                if resp.status < 300:
-                    print(f'Uploaded: {local_path} -> {obs_path}')
-                else:
-                    raise Exception(f'Failed to upload {local_path}: {resp.errorMessage}')
-            EOF
+        - name: Upload coverage artifact
+          uses: actions/upload-artifact@v7
+          with:
+            name: assembled-coverage
+            path: |
+              coverage.tar
+              coverage_version.txt
+              test_case_map.json
+            if-no-files-found: error
+            retention-days: 14
+            compression-level: 0
 
         - name: Prune extra tests already present in coverage
           id: prune-extra

--- a/.github/workflows/schedule_test_coverage.yaml
+++ b/.github/workflows/schedule_test_coverage.yaml
@@ -18,6 +18,16 @@
 name: Schedule Test Coverage
 
 on:
+  pull_request:
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - labeled
+    branches:
+      - 'main'
+      - '*-dev'
+      - 'releases/v*'
   workflow_dispatch:
     inputs:
       vllm_ascend_ref:
@@ -39,7 +49,7 @@ concurrency:
 
 jobs:
   select-full-tests:
-    if: ${{ github.event_name == 'workflow_dispatch' }}
+    if: ${{ github.event_name == 'pull_request' }}
     runs-on: linux-amd64-cpu-8-hk
     container:
       image: quay.io/ascend-ci/vllm-ascend:lint
@@ -82,12 +92,13 @@ jobs:
             echo "release_tag=${release_tag}"
           } >> "$GITHUB_OUTPUT"
 
-      - name: Select all tests
+      - name: Select test_glm5_2.py
         id: full-scope
         run: |
           pip install regex pyyaml
           git config --global --add safe.directory "$GITHUB_WORKSPACE"
-          python3 .github/workflows/scripts/select_tests.py --all-tests
+          python3 .github/workflows/scripts/select_tests.py \
+            --explicit-e2e-tests tests/e2e/pull_request/eight_card/test_glm5_2.py
 
   ensure-csrc-cache:
     needs: select-full-tests


### PR DESCRIPTION
Run only tests/e2e/pull_request/eight_card/test_glm5_2.py and upload the assembled coverage package as a GitHub artifact instead of OBS.

### What this PR does / why we need it?

### Does this PR introduce _any_ user-facing change?

### How was this patch tested?

- vLLM main: https://github.com/vllm-project/vllm/commit/ba07e4a48fc951300d97eb506217dd530583dea3
