### PR TITLE
[BugFix][310P] fix server crash opening MTP+ACLGraph on the 310P

### DIFF
--- a/tests/e2e/pull_request/one_card/_310p/test_spec_decode_mtp_310p.py
+++ b/tests/e2e/pull_request/one_card/_310p/test_spec_decode_mtp_310p.py
@@ -15,6 +15,9 @@
 # limitations under the License.
 # This file is a part of the vllm-ascend project.
 
+import os
+from unittest.mock import patch
+
 from tests.e2e.conftest import VllmRunner
 
 
@@ -30,6 +33,30 @@ def test_qwen3_5_mtp_tp1_eager():
         speculative_config={
             "method": "qwen3_5_mtp",
             "num_speculative_tokens": 1,
+        },
+    ) as vllm_model:
+        vllm_model.generate_greedy(example_prompts, max_tokens=8)
+
+
+@patch.dict(os.environ, {"VLLM_USE_V2_MODEL_RUNNER": "0"})
+def test_qwen3_5_mtp_tp1_full_decode_only_graph():
+    """MRv1 Qwen3.5 MTP + FULL_DECODE_ONLY ACLGraph on 310P."""
+    example_prompts = ["Hello, my name is"]
+    with VllmRunner(
+        "Qwen/Qwen3.5-4B",
+        tensor_parallel_size=1,
+        enforce_eager=False,
+        dtype="float16",
+        max_model_len=2048,
+        mamba_ssm_cache_dtype="float16",
+        speculative_config={
+            "method": "mtp",
+            "num_speculative_tokens": 1,
+        },
+        compilation_config={
+            "cudagraph_mode": "FULL_DECODE_ONLY",
+            # last size = (num_speculative_tokens+1)*batch
+            "cudagraph_capture_sizes": [1, 2],
         },
     ) as vllm_model:
         vllm_model.generate_greedy(example_prompts, max_tokens=8)

--- a/tests/ut/_310p/attention/test_attention_mask_310.py
+++ b/tests/ut/_310p/attention/test_attention_mask_310.py
@@ -43,3 +43,32 @@ class TestAttentionMaskBuilder310(TestBase):
         attn_metadata.seq_lens = torch.tensor([7, 4])
         attn_mask = self.attention_mask_builder.get_splitfuse_mask(attn_metadata, torch.device("cpu"))
         self.assertEqual(attn_mask.shape, (1, self.max_seqlen // 16, 16, 16))
+
+    @patch("torch_npu.npu_format_cast")
+    def test_get_splitfuse_attn_mask_uses_host_copies(self, mock_format_cast):
+        mock_format_cast.side_effect = lambda x, y: x
+        attn_metadata = MagicMock()
+        npu_like = MagicMock()
+        npu_like.to.side_effect = RuntimeError("D2H not allowed")
+        npu_like.device = torch.device("npu:0")
+        attn_metadata.query_start_loc = npu_like
+        attn_metadata.seq_lens = npu_like
+        attn_metadata.query_lens_cpu = torch.tensor([1, 4], dtype=torch.int32)
+        attn_metadata.seq_lens_cpu = torch.tensor([7, 4], dtype=torch.int32)
+        attn_mask = self.attention_mask_builder.get_splitfuse_mask(attn_metadata, torch.device("cpu"))
+        self.assertEqual(attn_mask.shape, (1, self.max_seqlen // 16, 16, 16))
+        npu_like.to.assert_not_called()
+
+    def test_get_splitfuse_attn_mask_rejects_npu_d2h(self):
+        attn_metadata = MagicMock(spec=["query_start_loc", "seq_lens", "query_lens_cpu", "seq_lens_cpu"])
+
+        class _NpuTensor:
+            device = type("Dev", (), {"type": "npu"})()
+
+        attn_metadata.query_start_loc = _NpuTensor()
+        attn_metadata.seq_lens = _NpuTensor()
+        attn_metadata.query_lens_cpu = None
+        attn_metadata.seq_lens_cpu = None
+        with self.assertRaises(RuntimeError) as cm:
+            self.attention_mask_builder.get_splitfuse_mask(attn_metadata, torch.device("cpu"))
+        self.assertIn("107027", str(cm.exception))

--- a/tests/ut/_310p/attention/test_attention_v1_310.py
+++ b/tests/ut/_310p/attention/test_attention_v1_310.py
@@ -158,6 +158,35 @@ class TestAscendAttentionBackendImpl310(TestBase):
 
         mock_npu_paged_attention_splitfuse.assert_called_once()
 
+    @patch("vllm_ascend._310p.attention.attention_v1.AttentionMaskBuilder310.get_splitfuse_mask")
+    @patch("torch_npu._npu_paged_attention_splitfuse")
+    def test_forward_chunked_prefill_uses_precomputed_mask_during_capture(
+        self,
+        mock_npu_paged_attention_splitfuse,
+        mock_get_splitfuse_mask,
+    ):
+        query = torch.randn(5, 8, 64)
+        output = torch.empty_like(query)
+        metadata = self.attn_metadata
+        metadata.attn_state = AscendAttentionState.ChunkedPrefill
+        metadata.attn_mask = torch.randn(1, 128, 16, 16)
+        metadata.seq_lens = torch.tensor([1, 4])
+        metadata.query_start_loc = torch.tensor([0, 1, 5])
+        metadata.block_tables = torch.zeros(1, 5, dtype=torch.long)
+        metadata.num_actual_tokens = 5
+        from vllm_ascend._310p.attention.metadata_builder import set_query_lens_cpu
+
+        set_query_lens_cpu(metadata, torch.tensor([1, 4], dtype=torch.int32))
+        self.impl.support_compressed_mask = False
+        mock_npu_paged_attention_splitfuse.return_value = torch.ones(5, 8, 64)
+
+        with patch("vllm_ascend.ascend_forward_context._EXTRA_CTX") as mock_ctx:
+            mock_ctx.capturing = True
+            self.impl.forward_chunked_prefill_310(query, metadata, output)
+
+        mock_get_splitfuse_mask.assert_not_called()
+        mock_npu_paged_attention_splitfuse.assert_called_once()
+
     @patch("torch_npu.npu_format_cast", return_value=torch.randn((1, 128, 16, 16), dtype=torch.float16))
     @patch("torch_npu._npu_reshape_and_cache")
     @patch("torch_npu._npu_paged_attention_splitfuse")
@@ -266,6 +295,17 @@ class TestAscendAttentionMetadataBuilder310(TestBase):
         torch.testing.assert_close(result2, expected)
         assert result1.data_ptr() != builder._query_lens_cpu_buffer[:3].data_ptr()
         assert result2.data_ptr() != builder._query_lens_cpu_buffer[:3].data_ptr()
+
+    def test_bind_splitfuse_mask_reuses_stable_buffer(self):
+        builder = AscendMetadataBuilder310Direct.__new__(AscendMetadataBuilder310Direct)
+        builder._splitfuse_mask_buffers = {}
+        first = torch.arange(6, dtype=torch.float16).reshape(1, 2, 3)
+        bound = builder._bind_splitfuse_mask(first)
+        self.assertIs(bound, first)
+        second = torch.ones_like(first)
+        rebound = builder._bind_splitfuse_mask(second)
+        self.assertIs(rebound, first)
+        torch.testing.assert_close(first, second)
 
     def test_build_for_drafting_calls_build_with_is_drafting_true(self):
         builder = object.__new__(AscendMetadataBuilder310Direct)

--- a/vllm_ascend/_310p/attention/attention_mask.py
+++ b/vllm_ascend/_310p/attention/attention_mask.py
@@ -70,29 +70,57 @@ class AttentionMaskBuilder310:
         return mask
 
     @classmethod
+    def _host_query_lens(cls, attn_metadata: AscendMetadata) -> torch.Tensor:
+        """Host qLens for splitfuse row selection. Never D2H from captured NPU tensors."""
+        qlens = getattr(attn_metadata, "query_lens_cpu", None)
+        if isinstance(qlens, torch.Tensor) and qlens.device.type == "cpu":
+            return qlens
+        qsl = attn_metadata.query_start_loc
+        if not isinstance(qsl, torch.Tensor) or qsl.device.type != "cpu":
+            raise RuntimeError(
+                "310P get_splitfuse_mask requires host query_lens_cpu or CPU query_start_loc; "
+                "D2H inside ACLGraph capture is illegal (acl error 107027)."
+            )
+        return qsl[1:] - qsl[:-1]
+
+    @classmethod
+    def _host_seq_lens(cls, attn_metadata: AscendMetadata) -> torch.Tensor:
+        """Host context lengths for splitfuse row selection. Never D2H from captured NPU tensors."""
+        seq_lens_cpu = getattr(attn_metadata, "seq_lens_cpu", None)
+        if isinstance(seq_lens_cpu, torch.Tensor) and seq_lens_cpu.device.type == "cpu":
+            return seq_lens_cpu
+        seq_lens = attn_metadata.seq_lens
+        if not isinstance(seq_lens, torch.Tensor) or seq_lens.device.type != "cpu":
+            raise RuntimeError(
+                "310P get_splitfuse_mask requires seq_lens_cpu or CPU seq_lens; "
+                "D2H inside ACLGraph capture is illegal (acl error 107027)."
+            )
+        return seq_lens
+
+    @classmethod
     def get_splitfuse_mask(cls, attn_metadata: AscendMetadata, device: torch.device):
         """
         Generates and formats the attention mask for SplitFuse (chunked prefill) decoding.
 
-        It calculates the specific indices required based on query start locations
+        It calculates the specific indices required based on host query lengths
         and context lengths, selects the relevant parts from the global chunked
         mask, and converts the result to the NPU-specific fractal format.
 
+        Call this from metadata build() (outside ACLGraph), not from captured forward.
+
         Args:
-            attn_metadata (AscendMetadata): Metadata containing query start locations and sequence lengths.
+            attn_metadata (AscendMetadata): Metadata containing host query/seq lengths.
             device (torch.device): The device to perform operations on.
 
         Returns:
             torch.Tensor: The splitfuse attention mask cast to ACL_FORMAT_FRACTAL_NZ.
         """
-        if cls.chunked_prefill_attn_mask is None:
+        if cls.chunked_prefill_attn_mask is None or cls.chunked_prefill_attn_mask.device != device:
             cls.chunked_prefill_attn_mask = cls.gen_causal_additive_mask(cls.max_seqlen, device)
-        qsl = attn_metadata.query_start_loc.to("cpu", dtype=torch.int32)
-        qlens = qsl[1:] - qsl[:-1]
-        q_list = qlens.tolist()
-        context_lens = attn_metadata.seq_lens.to("cpu", dtype=torch.int32)
-        c_list = context_lens.tolist()
-        pos_list = [p for ql, cl in zip(q_list, c_list) for p in range(cl - ql, cl)]
+        q_list = cls._host_query_lens(attn_metadata).tolist()
+        c_list = cls._host_seq_lens(attn_metadata).tolist()
+        n = min(len(q_list), len(c_list))
+        pos_list = [p for ql, cl in zip(q_list[:n], c_list[:n]) for p in range(int(cl) - int(ql), int(cl))]
         position = torch.tensor(pos_list, dtype=torch.int32, device=device)
         splitfuse_mask = cls.chunked_prefill_attn_mask.index_select(0, position)
         splitfuse_mask_nz = torch_npu.npu_format_cast(nd_to_nz_spec(splitfuse_mask).contiguous(), ACL_FORMAT_FRACTAL_NZ)

--- a/vllm_ascend/_310p/attention/attention_v1.py
+++ b/vllm_ascend/_310p/attention/attention_v1.py
@@ -249,11 +249,11 @@ class AscendAttentionBackendImpl310(AscendAttentionBackendImpl):
         query = query[:num_actual_tokens]
         output_slice = output[:num_actual_tokens]
 
+        from vllm_ascend.ascend_forward_context import _EXTRA_CTX
+
         # Host qLens filled in AscendAttentionMetadataBuilder310.build(); eager fallback only.
         qlens = get_query_lens_cpu(attn_metadata)
         if qlens is None:
-            from vllm_ascend.ascend_forward_context import _EXTRA_CTX
-
             if _EXTRA_CTX.capturing:
                 raise RuntimeError(
                     "310P splitfuse requires attn_metadata.query_lens_cpu during graph capture; "
@@ -265,6 +265,12 @@ class AscendAttentionBackendImpl310(AscendAttentionBackendImpl):
         block_table = attn_metadata.block_tables
 
         if attn_metadata.seq_lens.device != query.device:
+            if _EXTRA_CTX.capturing:
+                raise RuntimeError(
+                    "310P splitfuse requires device seq_lens during graph capture; "
+                    "ensure AscendAttentionMetadataBuilder310.build() bound seq_lens "
+                    "before forward."
+                )
             attn_metadata.seq_lens = attn_metadata.seq_lens.to(
                 device=query.device,
                 non_blocking=True,
@@ -289,8 +295,17 @@ class AscendAttentionBackendImpl310(AscendAttentionBackendImpl):
             )
             return output
 
-        # Generate the specific mask for splitfuse
-        mask = AttentionMaskBuilder310.get_splitfuse_mask(attn_metadata, query.device)
+        # Prefill NZ mask from parent build() is the wrong shape for splitfuse.
+        # Uncompressed splitfuse mask is precomputed in
+        # AscendAttentionMetadataBuilder310.build() (outside ACLGraph).
+        mask = attn_metadata.attn_mask
+        if mask is None:
+            if _EXTRA_CTX.capturing:
+                raise RuntimeError(
+                    "310P splitfuse mask must be precomputed before graph capture; "
+                    "D2H in get_splitfuse_mask is illegal on a captured stream."
+                )
+            mask = AttentionMaskBuilder310.get_splitfuse_mask(attn_metadata, query.device)
         torch_npu._npu_paged_attention_splitfuse(
             query=query,
             key_cache=self.key_cache,

--- a/vllm_ascend/_310p/attention/metadata_builder.py
+++ b/vllm_ascend/_310p/attention/metadata_builder.py
@@ -81,6 +81,9 @@ class AscendAttentionMetadataBuilder310(AscendAttentionMetadataBuilder):
         self.attn_mask_builder: Any = AttentionMaskBuilder310(self.device, max_model_len)
 
         self._query_lens_cpu_buffer: torch.Tensor | None = None
+        # Stable NZ splitfuse masks keyed by shape so ACLGraph replay can
+        # copy_ into the same addresses captured during dummy_run.
+        self._splitfuse_mask_buffers: dict[tuple, torch.Tensor] = {}
         if device.type != "cpu":
             max_num_seqs = vllm_config.scheduler_config.max_num_seqs
             self._query_lens_cpu_buffer = torch.empty(max_num_seqs, dtype=torch.int32, device="cpu", pin_memory=True)
@@ -105,6 +108,16 @@ class AscendAttentionMetadataBuilder310(AscendAttentionMetadataBuilder):
         )
         return buffer
 
+    def _bind_splitfuse_mask(self, mask: torch.Tensor) -> torch.Tensor:
+        """Reuse a stable NZ buffer so graph capture/replay keep the same data_ptr."""
+        key = (tuple(mask.shape), str(mask.dtype), str(mask.device))
+        buf = self._splitfuse_mask_buffers.get(key)
+        if buf is None:
+            self._splitfuse_mask_buffers[key] = mask
+            return mask
+        buf.copy_(mask)
+        return buf
+
     def build(
         self,
         common_prefix_len: int,
@@ -113,12 +126,15 @@ class AscendAttentionMetadataBuilder310(AscendAttentionMetadataBuilder):
         is_drafting: bool = False,
     ) -> AscendMetadata:
         attn_metadata = super().build(common_prefix_len, common_attn_metadata, fast_build)
+        if not isinstance(attn_metadata.attn_state, AscendAttentionState):
+            return attn_metadata
 
         num_reqs = common_attn_metadata.num_reqs
 
         splitfuse_states = (
             AscendAttentionState.SpecDecoding,
             AscendAttentionState.ChunkedPrefill,
+            AscendAttentionState.PrefillCacheHit,
         )
 
         # Paged and splitfuse attention consume device-side context lengths.
@@ -144,6 +160,13 @@ class AscendAttentionMetadataBuilder310(AscendAttentionMetadataBuilder):
 
         if is_compressed_mask_supported():
             attn_metadata.attn_mask = AttentionMaskBuilder310.get_compressed_splitfuse_mask(self.device)
+        else:
+            # Uncompressed splitfuse mask is position-dependent. Build it here
+            # (CPU q/seq lens, outside ACLGraph) and bind a stable NPU buffer
+            # so captured forward never D2Hs query_start_loc / seq_lens.
+            attn_metadata.attn_mask = self._bind_splitfuse_mask(
+                AttentionMaskBuilder310.get_splitfuse_mask(attn_metadata, self.device)
+            )
 
         return attn_metadata
 

--- a/vllm_ascend/_310p/ops/fla/gdn_310.py
+++ b/vllm_ascend/_310p/ops/fla/gdn_310.py
@@ -64,15 +64,16 @@ def _flatten_state_indices(
         return ssm_state_indices[:total_tokens].to(torch.int32).contiguous()
 
     num_seqs = (cu_seqlens[1:] - cu_seqlens[:-1]).shape[0]
-    seq_lens = cu_seqlens[1 : num_seqs + 1] - cu_seqlens[:num_seqs]
-    ssm_state_indices = ssm_state_indices[:num_seqs]
+    q_per_seq = ssm_state_indices.shape[1]
 
     # Uniform spec-decode ACL graph uses fixed q_len per request; reshape avoids
-    # NPU masked_select which breaks stream capture (aclnnMaskedSelect / 107027).
-    if _EXTRA_CTX.capturing or (seq_lens.numel() > 0 and torch.all(seq_lens == seq_lens[0])):
-        q_per_seq = ssm_state_indices.shape[1]
-        flat = ssm_state_indices[:, :q_per_seq].reshape(-1)
+    # NPU masked_select and seq_lens scalar reads which break stream capture.
+    if _EXTRA_CTX.capturing or total_tokens == num_seqs * q_per_seq:
+        flat = ssm_state_indices[:num_seqs, :q_per_seq].reshape(-1)
         return flat[:total_tokens].to(torch.int32).contiguous()
+
+    seq_lens = cu_seqlens[1 : num_seqs + 1] - cu_seqlens[:num_seqs]
+    ssm_state_indices = ssm_state_indices[:num_seqs]
 
     # Eager mixed batches with variable seq_lens: compact on CPU, copy back async.
     ssm_cpu = ssm_state_indices.cpu()


### PR DESCRIPTION
### What this PR does / why we need it?

On Ascend 310P MRv1 (`NPUModelRunner310`), serving Qwen3.5 hybrid with `FULL_DECODE_ONLY` and `MTP` dies during ACLGraph capture (`compile_or_warm_up_model`) with `aclrtMemcpy 107030` / `Not allow to synchronize captured-stream (107027)`.

MTP dummy/verify uses `q_len = 1+K`, which 310P maps to splitfuse. Uncompressed NZ mask construction used to D2H `query_start_loc` / `seq_lens` inside the Python forward that MRv1 `ACLGraphWrapper` records. GDN flatten used `torch.all` on device `seq_lens`, which also syncs a captured stream. This is a 310P MRv1 path issue (no FIA / no `splitfuse_v2`); 910 A2/A3 MTP is unchanged.

Minimal fix (shared `_310p`/ only):
- Build splitfuse NZ mask from host `query_lens_cpu` / `seq_lens_cpu` in `AscendAttentionMetadataBuilder310.build()` (outside the graph), and bind a stable NPU buffer so capture/replay keep the same `data_ptr`.
- Captured `forward_chunked_prefill_310` consumes `attn_metadata.attn_mask` and must not rebuild the mask (or D2H `seq_lens`) on a captured stream.
- `GDN _flatten_state_indices` uses a shape check (`total_tokens == num_seqs * q_per_seq`) instead of `torch.all` on device lengths.

### Does this PR introduce _any_ user-facing change?

No new flags. Qwen3.5 on 310P can now start with `FULL_DECODE_ONLY` + `--speculative-config '{"method":"mtp","num_speculative_tokens":1}'`. 

### How was this patch tested?

- vLLM main: https://github.com/vllm-project/vllm/commit/ba07e4a48fc951300d97eb506217dd530583dea3
