### PR TITLE
[BugFix][P/D] Sync Mooncake block size from workers

### DIFF
--- a/tests/ut/kv_offload/test_mooncake_connector.py
+++ b/tests/ut/kv_offload/test_mooncake_connector.py
@@ -19,6 +19,7 @@ from vllm.v1.kv_cache_interface import (
     FullAttentionSpec,
     KVCacheGroupSpec,
     MLAAttentionSpec,
+    SlidingWindowSpec,
     UniformTypeKVCacheSpecs,
 )
 from vllm.v1.request import RequestStatus
@@ -2061,6 +2062,73 @@ class TestMooncakeConnectorScheduler(unittest.TestCase):
         delay_free, params = self.scheduler.request_finished(request, [1, 2, 3])
         self.assertFalse(delay_free)
         self.assertIsNone(params)
+
+    def test_worker_handshake_block_size_is_used_for_transfer_metadata(self):
+        # EngineCore may replace cache_config.block_size with the smallest
+        # physical group size before constructing the scheduler. The workers
+        # retain the logical block size used to interpret their block IDs.
+        config = MockVllmConfig()
+        config.cache_config.block_size = 8
+        group_specs = (
+            FullAttentionSpec(
+                block_size=8,
+                num_kv_heads=1,
+                head_size=128,
+                dtype=torch.bfloat16,
+            ),
+            SlidingWindowSpec(
+                block_size=32,
+                num_kv_heads=1,
+                head_size=128,
+                dtype=torch.bfloat16,
+                sliding_window=64,
+            ),
+        )
+        kv_cache_config = MockKVCacheConfig(
+            kv_cache_groups=[
+                KVCacheGroupSpec([f"model.layers.{idx}.self_attn"], group_spec)
+                for idx, group_spec in enumerate(group_specs)
+            ]
+        )
+        with (
+            patch("vllm_ascend.distributed.kv_transfer.kv_p2p.mooncake_connector.init_ascend_config"),
+            patch(
+                "vllm_ascend.distributed.kv_transfer.kv_p2p.mooncake_connector.get_ascend_config",
+                return_value=MagicMock(),
+            ),
+        ):
+            scheduler = MooncakeConnectorScheduler(config, "test_engine", kv_cache_config)
+        group_tokens_per_block = [info.tokens_per_block for info in scheduler.group_transfer_info]
+        group_blocks_per_window = [info.blocks_per_window for info in scheduler.group_transfer_info]
+        metadata = {
+            0: make_agent_metadata(block_size=128, local_ip="host-0"),
+            1: make_agent_metadata(block_size=128, local_ip="host-1"),
+        }
+
+        scheduler.set_xfer_handshake_metadata_from_workers(metadata)
+        request = self._make_remote_decode_request(prompt_len=129)
+        delay_free, params = scheduler.request_finished(request, ([10, 11], [20, 21]))
+
+        self.assertTrue(delay_free)
+        self.assertIsNotNone(params)
+        assert params is not None
+        self.assertEqual(scheduler.block_size, 8)
+        self.assertEqual(scheduler.transfer_block_size, 128)
+        self.assertEqual(group_tokens_per_block, [8, 32])
+        self.assertEqual(group_blocks_per_window, [0, 3])
+        self.assertEqual([info.tokens_per_block for info in scheduler.group_transfer_info], group_tokens_per_block)
+        self.assertEqual([info.blocks_per_window for info in scheduler.group_transfer_info], group_blocks_per_window)
+        self.assertEqual(params["remote_block_size"], 128)
+        self.assertEqual(params["num_prompt_blocks"], 2)
+
+    def test_worker_handshake_rejects_inconsistent_block_sizes(self):
+        metadata = {
+            0: make_agent_metadata(block_size=64, local_ip="host-0"),
+            1: make_agent_metadata(block_size=128, local_ip="host-1"),
+        }
+
+        with self.assertRaisesRegex(ValueError, "inconsistent block sizes"):
+            self.scheduler.set_xfer_handshake_metadata_from_workers(metadata)
 
     def test_request_finished_rejected_remote_prefill_enqueues_empty_recv(self):
         request = MockRequest(

--- a/vllm_ascend/distributed/kv_transfer/kv_p2p/mooncake_connector.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_p2p/mooncake_connector.py
@@ -1724,6 +1724,9 @@ class MooncakeConnectorScheduler:
         init_ascend_config(vllm_config)
         self.ascend_config = get_ascend_config()
         self.block_size = vllm_config.cache_config.block_size
+        # Keep per-group cache geometry separate from the block size used in
+        # P/D transfer metadata, which is synchronized from local workers.
+        self.transfer_block_size = self.block_size
         self.engine_id = engine_id
         self.local_ip = get_ip()
         logger.info("Initializing Mooncake Scheduler %s", engine_id)
@@ -2021,7 +2024,7 @@ class MooncakeConnectorScheduler:
         if not params.get("do_remote_decode") or request.status != RequestStatus.FINISHED_LENGTH_CAPPED:
             return False, None
 
-        num_prompt_blocks = math.ceil(len(request.prompt_token_ids) / self.block_size)
+        num_prompt_blocks = math.ceil(len(request.prompt_token_ids) / self.transfer_block_size)
         computed_block_ids = self._get_transfer_block_ids(block_ids, len(request.prompt_token_ids))
         computed_block_ids = self._get_swa_transfer_block_ids(computed_block_ids)
         computed_block_lens = [len(block_id_list) for block_id_list in computed_block_ids]
@@ -2044,7 +2047,7 @@ class MooncakeConnectorScheduler:
             last_token_id=request.output_token_ids[-1],
             remote_multi_nodes_meta_mapping=self.multi_nodes_meta_mapping,
             num_prompt_blocks=num_prompt_blocks,
-            remote_block_size=self.block_size,
+            remote_block_size=self.transfer_block_size,
         )
 
     def _port_offset_from_handshake_metadata(
@@ -2064,9 +2067,26 @@ class MooncakeConnectorScheduler:
         self,
         metadata: Mapping[int | tuple[int, ...], KVConnectorHandshakeMetadata],
     ) -> None:
-        """Build host mapping for one DP group that may span multiple nodes."""
+        """Build host mapping and sync transfer geometry from local workers."""
         if not metadata:
             return
+
+        worker_block_sizes: set[int] = set()
+        for rank_metadata in metadata.values():
+            worker_block_size = getattr(rank_metadata, "block_size", None)
+            if not isinstance(worker_block_size, int) or worker_block_size <= 0:
+                raise ValueError(f"Mooncake worker reported invalid block size: {worker_block_size}")
+            worker_block_sizes.add(worker_block_size)
+        if len(worker_block_sizes) != 1:
+            raise ValueError(f"Mooncake workers reported inconsistent block sizes: {sorted(worker_block_sizes)}")
+        worker_block_size = worker_block_sizes.pop()
+        if self.transfer_block_size != worker_block_size:
+            logger.info(
+                "MooncakeConnector updated scheduler transfer block size from %d to worker-reported value %d",
+                self.transfer_block_size,
+                worker_block_size,
+            )
+            self.transfer_block_size = worker_block_size
 
         updated_mapping: dict[str, dict[str, Any]] = {}
         kv_port = self.vllm_config.kv_transfer_config.kv_port


### PR DESCRIPTION
### What this PR does / why we need it?

DeepSeek-V4 heterogeneous KV cache initialization rewrites `cache_config.block_size` in EngineCore to the smallest physical group block size. The Mooncake scheduler is created afterwards and snapshots that value, while workers were already spawned with the original logical block size. As a result, a producer configured with block size 128 can send `remote_block_size=8`, and the decoder rejects it because it is not divisible by the attention kernel size.

Mooncake workers already report their effective block size through `MooncakeAgentMetadata` after KV cache registration. This change treats that worker-reported value as the authoritative P/D transfer block size during the existing local worker handshake and validates that every worker reports the same positive value.

The scheduler now keeps `transfer_block_size` separate from `block_size`: the former is used only for `remote_block_size` and `num_prompt_blocks`, while `group_transfer_info` continues to use each KV cache group's own block size. This prevents the worker handshake from changing heterogeneous group geometry such as `tokens_per_block` and SWA `blocks_per_window`.

No P/D wire schema or `cache_config` mutation is introduced. Refs #14920.

### Does this PR introduce _any_ user-facing change?

No new option or API is introduced. It fixes MooncakeConnectorV1 P/D transfers when EngineCore's scheduler-facing cache block size differs from the block size used by workers.

### How was this patch tested?

- Added a scheduler regression test with scheduler block size 8, heterogeneous cache groups using block sizes 8 and 32 (including an SWA group), and worker transfer block size 128.
- Verified the handshake produces `remote_block_size=128` and computes a 129-token prompt as two transfer blocks, while group `tokens_per_block` and `blocks_per_window` remain unchanged.
- Added a failure-mode test for inconsistent worker block sizes.
- `ruff 0.14.0 check` passed for both changed files.
- `ruff 0.14.0 format --check` passed for both changed files.
- `python -m py_compile` passed for both changed files.
- The unit test was not executed on the Windows development host because the environment does not provide pytest, torch, or torch_npu; selected-test CI is expected to run it.

- vLLM main: https://github.com/vllm-project/vllm/commit/ba07e4a48fc951300d97eb506217dd530583dea3
