### PR TITLE
[Kernel] Add optional split q/k/v outputs to fused CausalConv1d to eliminate post-conv chunk/rearrange copies

### DIFF
--- a/csrc/moe/causal_conv1d/op_host/causal_conv1d_def.cpp
+++ b/csrc/moe/causal_conv1d/op_host/causal_conv1d_def.cpp
@@ -62,8 +62,25 @@ public:
             .FormatList({ge::FORMAT_ND})
             .AutoContiguous();
 
+        // P1: y is OPTIONAL now — default path binds y (merged [N,3C]); the KDA
+        // split path (split_qkv=true) binds y_q/y_k/y_v (each [N,C]) instead.
         this->Output("y")
-            .ParamType(REQUIRED)
+            .ParamType(OPTIONAL)
+            .DataType({ge::DT_FLOAT16, ge::DT_BF16})
+            .FormatList({ge::FORMAT_ND})
+            .AutoContiguous();
+        this->Output("y_q")
+            .ParamType(OPTIONAL)
+            .DataType({ge::DT_FLOAT16, ge::DT_BF16})
+            .FormatList({ge::FORMAT_ND})
+            .AutoContiguous();
+        this->Output("y_k")
+            .ParamType(OPTIONAL)
+            .DataType({ge::DT_FLOAT16, ge::DT_BF16})
+            .FormatList({ge::FORMAT_ND})
+            .AutoContiguous();
+        this->Output("y_v")
+            .ParamType(OPTIONAL)
             .DataType({ge::DT_FLOAT16, ge::DT_BF16})
             .FormatList({ge::FORMAT_ND})
             .AutoContiguous();
@@ -71,6 +88,9 @@ public:
         this->Attr("activationMode").AttrType(OPTIONAL).Int(0);
         this->Attr("padSlotId").AttrType(OPTIONAL).Int(-1);
         this->Attr("runMode").AttrType(OPTIONAL).Int(0);
+        // P1: when true, kernel writes q/k/v into y_q/y_k/y_v (eliminating the
+        // external chunk(3)+rearrange+.contiguous). Default false -> merged y.
+        this->Attr("split_qkv").AttrType(OPTIONAL).Bool(false);
 
         OpAICoreConfig aicoreConfig;
         aicoreConfig.DynamicCompileStaticFlag(true)

--- a/csrc/moe/causal_conv1d/op_host/causal_conv1d_infershape.cpp
+++ b/csrc/moe/causal_conv1d/op_host/causal_conv1d_infershape.cpp
@@ -20,19 +20,66 @@ using namespace ge;
 
 namespace ops {
 static constexpr int64_t IDX_0 = 0;
+static constexpr int64_t IDX_Y = 0;
+// Attrs are positional, in op-def declaration order:
+// activationMode(0), padSlotId(1), runMode(2), split_qkv(3).
+static constexpr size_t IDX_ATTR_SPLIT_QKV = 3;
+static constexpr int64_t IDX_Y_Q = 1;
+static constexpr int64_t IDX_Y_K = 2;
+static constexpr int64_t IDX_Y_V = 3;
 
 static ge::graphStatus InferShapeCausalConv1d(gert::InferShapeContext* context)
 {
     OP_LOGD(context->GetNodeName(), "Begin to do InferShapeCausalConv1d");
 
-    // get input shapes
+    // get input shapes: x is [N, 3*C] (merged qkv)
     const gert::Shape* xShape = context->GetInputShape(IDX_0);
     OP_CHECK_NULL_WITH_CONTEXT(context, xShape);
 
-    // get output shapes
-    gert::Shape* yShape = context->GetOutputShape(IDX_0);
-    OP_CHECK_NULL_WITH_CONTEXT(context, yShape);
-    *yShape = *xShape;
+    // P1: split_qkv attr decides output layout.
+    bool splitQkv = false;
+    auto *attrs = context->GetAttrs();
+    if (attrs != nullptr) {
+        const bool *splitPtr = attrs->GetAttrPointer<bool>(IDX_ATTR_SPLIT_QKV);
+        if (splitPtr != nullptr) {
+            splitQkv = *splitPtr;
+        }
+    }
+
+    if (splitQkv) {
+        // y_q / y_k / y_v keep x's leading dims with the last (merged qkv
+        // channel) dim divided by 3, e.g. x [N, 3*C] -> [N, C] each; the
+        // caller can then view [N, C] as [1, N, H, D] without a copy. The
+        // merged y stays unset in this mode.
+        OP_CHECK_IF(xShape->GetDimNum() < 1,
+                    OP_LOGE(context->GetNodeName(), "x rank must be >= 1."),
+                    return GRAPH_FAILED);
+        const int64_t lastDimIdx = static_cast<int64_t>(xShape->GetDimNum()) - 1;
+        const int64_t lastDim = xShape->GetDim(lastDimIdx);
+        OP_CHECK_IF(lastDim > 0 && lastDim % 3 != 0,
+                    OP_LOGE(context->GetNodeName(),
+                            "split_qkv requires the last dim of x to be divisible by 3, but got [%ld].",
+                            lastDim),
+                    return GRAPH_FAILED);
+        gert::Shape singleShape = *xShape;
+        // Propagate unknown (-1) dims instead of truncating them to 0.
+        singleShape.SetDim(lastDimIdx, lastDim > 0 ? lastDim / 3 : lastDim);
+
+        gert::Shape* yQShape = context->GetOutputShape(IDX_Y_Q);
+        OP_CHECK_NULL_WITH_CONTEXT(context, yQShape);
+        *yQShape = singleShape;
+        gert::Shape* yKShape = context->GetOutputShape(IDX_Y_K);
+        OP_CHECK_NULL_WITH_CONTEXT(context, yKShape);
+        *yKShape = singleShape;
+        gert::Shape* yVShape = context->GetOutputShape(IDX_Y_V);
+        OP_CHECK_NULL_WITH_CONTEXT(context, yVShape);
+        *yVShape = singleShape;
+    } else {
+        // default: merged y [N, 3*C] == x.
+        gert::Shape* yShape = context->GetOutputShape(IDX_Y);
+        OP_CHECK_NULL_WITH_CONTEXT(context, yShape);
+        *yShape = *xShape;
+    }
 
     OP_LOGD(context->GetNodeName(), "End to do InferShapeCausalConv1d");
     return GRAPH_SUCCESS;

--- a/csrc/moe/causal_conv1d/op_host/causal_conv1d_tiling_utils.h
+++ b/csrc/moe/causal_conv1d/op_host/causal_conv1d_tiling_utils.h
@@ -29,6 +29,7 @@ constexpr uint32_t NUM_ACCEPTED_TOKENS_INDEX = 7;
 constexpr int32_t ATTR_ACTIVATION_MODE_INDEX = 0;
 constexpr int32_t ATTR_PAD_SLOT_ID_INDEX = 1;
 constexpr int32_t ATTR_RUN_MODE_INDEX = 2;
+constexpr int32_t IDX_ATTR_SPLIT_QKV = 3;
 constexpr int64_t ASCENDC_RESERVED_WORKSPACE_SIZE = 16 * 1024 * 1024;
 
 struct CausalConv1dCompileInfo {
@@ -40,6 +41,7 @@ struct CausalConv1dAttrInfo {
     int64_t activationMode = 0;
     int64_t padSlotId = -1;
     int64_t runMode = 0;
+    bool split_qkv = false;
 };
 
 struct DimTileChoice {

--- a/csrc/moe/causal_conv1d/op_host/causal_conv1d_tiling_validation.h
+++ b/csrc/moe/causal_conv1d/op_host/causal_conv1d_tiling_validation.h
@@ -60,6 +60,11 @@
      attrInfo.runMode = (runModePtr == nullptr) ? 0 : *runModePtr;
      OP_CHECK_IF(attrInfo.runMode != 0 && attrInfo.runMode != 1, OP_LOGE(context, "runMode only supports 0/1"),
                  return ge::GRAPH_FAILED);
+
+     // P2: split_qkv attr (Bool, optional, default false). When true the kernel writes
+     // q/k/v into y_q/y_k/y_v instead of a merged y.
+     const bool *splitQkvPtr = attrs->GetAttrPointer<bool>(IDX_ATTR_SPLIT_QKV);
+     attrInfo.split_qkv = (splitQkvPtr == nullptr) ? false : *splitQkvPtr;
      return ge::GRAPH_SUCCESS;
  }
  
@@ -81,6 +86,7 @@
      const bool isDecodeMode = (attrInfo.runMode == 1);
      tiling.activationMode = attrInfo.activationMode;
      tiling.padSlotId = attrInfo.padSlotId;
+     tiling.split_qkv = attrInfo.split_qkv ? 1 : 0;
  
      auto xShapePtr = context->GetInputShape(X_INDEX);
      OP_CHECK_NULL_WITH_CONTEXT(context, xShapePtr);
@@ -124,6 +130,18 @@
      OP_CHECK_IF(ValidateAlignedDim(context, dim) != ge::GRAPH_SUCCESS,
                  OP_LOGE(context, "dim alignment validation failed"),
                  return ge::GRAPH_FAILED);
+
+     // P2: when split_qkv is enabled, dim must be 3*C with C itself 16-aligned so the
+     // per-third sub-range DataCopys stay 16-aligned (Ascend MTE3 requirement).
+     if (attrInfo.split_qkv) {
+         OP_CHECK_IF(dim % 3 != 0,
+                     OP_LOGE(context, "split_qkv requires dim %% 3 == 0 (dim=%ld)", dim),
+                     return ge::GRAPH_FAILED);
+         OP_CHECK_IF((dim / 3) % DIM_ALIGN_ELEMS != 0,
+                     OP_LOGE(context, "split_qkv requires (dim/3) %% %ld == 0 (dim=%ld)",
+                             DIM_ALIGN_ELEMS, dim),
+                     return ge::GRAPH_FAILED);
+     }
  
      auto wShapePtr = context->GetInputShape(WEIGHT_INDEX);
      OP_CHECK_NULL_WITH_CONTEXT(context, wShapePtr);

--- a/csrc/moe/causal_conv1d/op_kernel/causal_conv1d.cpp
+++ b/csrc/moe/causal_conv1d/op_kernel/causal_conv1d.cpp
@@ -22,17 +22,17 @@ namespace {
 template <typename T, uint32_t runModeKey, uint32_t widthKey, uint32_t fnPlanKey>
 __aicore__ inline void RunCausalConv1d(GM_ADDR x, GM_ADDR weight, GM_ADDR bias, GM_ADDR convStates,
                                        GM_ADDR queryStartLoc, GM_ADDR cacheIndices, GM_ADDR initialStateMode,
-                                       GM_ADDR numAcceptedTokens, GM_ADDR y, GM_ADDR workspace,
-                                       const CausalConv1dTilingData *tilingData)
+                                       GM_ADDR numAcceptedTokens, GM_ADDR y, GM_ADDR y_q, GM_ADDR y_k, GM_ADDR y_v,
+                                       GM_ADDR workspace, const CausalConv1dTilingData *tilingData)
 {
     if constexpr (runModeKey == CAUSAL_CONV1D_TPL_RUN_MODE_FN) {
         NsCausalConv1d::RunCausalConv1dFn<T, widthKey, fnPlanKey>(
-            x, weight, bias, convStates, queryStartLoc, cacheIndices, initialStateMode, numAcceptedTokens, y, workspace,
-            tilingData);
+            x, weight, bias, convStates, queryStartLoc, cacheIndices, initialStateMode, numAcceptedTokens, y, y_q, y_k,
+            y_v, workspace, tilingData);
     } else {
         NsCausalConv1d::RunCausalConv1dUpdate<T>(
-            x, weight, bias, convStates, queryStartLoc, cacheIndices, initialStateMode, numAcceptedTokens, y, workspace,
-            tilingData);
+            x, weight, bias, convStates, queryStartLoc, cacheIndices, initialStateMode, numAcceptedTokens, y, y_q, y_k,
+            y_v, workspace, tilingData);
     }
 }
 
@@ -41,7 +41,8 @@ __aicore__ inline void RunCausalConv1d(GM_ADDR x, GM_ADDR weight, GM_ADDR bias, 
 template <uint32_t runModeKey, uint32_t widthKey, uint32_t fnPlanKey>
 __global__ __aicore__ void causal_conv1d(GM_ADDR x, GM_ADDR weight, GM_ADDR bias, GM_ADDR convStates,
                                          GM_ADDR queryStartLoc, GM_ADDR cacheIndices, GM_ADDR initialStateMode,
-                                         GM_ADDR numAcceptedTokens, GM_ADDR y, GM_ADDR workspace, GM_ADDR tiling)
+                                         GM_ADDR numAcceptedTokens, GM_ADDR y, GM_ADDR y_q, GM_ADDR y_k, GM_ADDR y_v,
+                                         GM_ADDR workspace, GM_ADDR tiling)
 {
     REGISTER_TILING_DEFAULT(CausalConv1dTilingData);
     GET_TILING_DATA(tilingData, tiling);
@@ -52,6 +53,6 @@ __global__ __aicore__ void causal_conv1d(GM_ADDR x, GM_ADDR weight, GM_ADDR bias
     }
 
     RunCausalConv1d<DTYPE_X, runModeKey, widthKey, fnPlanKey>(
-        x, weight, bias, convStates, queryStartLoc, cacheIndices, initialStateMode, numAcceptedTokens, y,
+        x, weight, bias, convStates, queryStartLoc, cacheIndices, initialStateMode, numAcceptedTokens, y, y_q, y_k, y_v,
         userWorkspace, &tilingData);
 }

--- a/csrc/moe/causal_conv1d/op_kernel/causal_conv1d.h
+++ b/csrc/moe/causal_conv1d/op_kernel/causal_conv1d.h
@@ -166,6 +166,7 @@
      __aicore__ inline const CausalConv1dTilingData *GetTilingData() const;
      __aicore__ inline bool HasActivation() const;
      __aicore__ inline bool HasBias() const;
+     __aicore__ inline bool IsSplitQkv() const;
      __aicore__ inline bool IsUpdateMode() const;
      __aicore__ inline bool IsFnRollingFastPathEnabled() const;
      __aicore__ inline bool HasExplicitFnTokenSeqRanges() const;
@@ -209,6 +210,10 @@
      GlobalTensor<int32_t> numAcceptedTokensGmInt32;
      GlobalTensor<int64_t> numAcceptedTokensGmInt64;
      GlobalTensor<T> yGm;
+     // P2: split-write output buffers (bound only when tilingData_->split_qkv != 0).
+     GlobalTensor<T> yQGm;
+     GlobalTensor<T> yKGm;
+     GlobalTensor<T> yVGm;
      GlobalTensor<int32_t> initStateSyncGm_;
      GlobalTensor<T> initStateWorkspaceGm_;
  
@@ -475,7 +480,34 @@
  
          const int64_t outOffset = static_cast<int64_t>(start + t) * dim + channelStart;
          WaitFlag<HardEvent::V_MTE3>(outVToMte3Event_[outSlot]);
-         DataCopy(yGm[outOffset], outSlotT, baseDim);
+         if (IsSplitQkv()) {
+             // P2: demux the channel tile [channelStart, channelStart+baseDim) of the
+             // merged [N, dim] output into the q/k/v thirds (each [N, dim/3]) written
+             // to yQGm/yKGm/yVGm. dim is 3*C with C 16-aligned (host guard), so every
+             // sub-range here is 16-aligned.
+             const int32_t thirdBase = dim / 3;
+             for (int32_t third = 0; third < 3; ++third) {
+                 const int32_t thirdLo = third * thirdBase;
+                 const int32_t thirdHi = thirdLo + thirdBase;
+                 const int32_t ovLo = (channelStart > thirdLo) ? channelStart : thirdLo;
+                 const int32_t ovHi = ((channelStart + baseDim) < thirdHi) ? (channelStart + baseDim) : thirdHi;
+                 if (ovLo >= ovHi) {
+                     continue;
+                 }
+                 const int32_t srcOff = ovLo - channelStart;
+                 const int32_t subLen = ovHi - ovLo;
+                 const int64_t dstOff = static_cast<int64_t>(start + t) * thirdBase + (ovLo - thirdLo);
+                 if (third == 0) {
+                     DataCopy(yQGm[dstOff], outSlotT[srcOff], subLen);
+                 } else if (third == 1) {
+                     DataCopy(yKGm[dstOff], outSlotT[srcOff], subLen);
+                 } else {
+                     DataCopy(yVGm[dstOff], outSlotT[srcOff], subLen);
+                 }
+             }
+         } else {
+             DataCopy(yGm[outOffset], outSlotT, baseDim);
+         }
          if (t + 2 < len) {
              SetFlag<HardEvent::MTE3_V>(outMte3ToVEvent_[outSlot]);
          }
@@ -693,7 +725,34 @@
  
          const int64_t outOffset = static_cast<int64_t>(start + t) * dim + channelStart;
          WaitFlag<HardEvent::V_MTE3>(outVToMte3Event_[outSlot]);
-         DataCopy(yGm[outOffset], outSlotT, baseDim);
+         if (IsSplitQkv()) {
+             // P2: demux the channel tile [channelStart, channelStart+baseDim) of the
+             // merged [N, dim] output into the q/k/v thirds (each [N, dim/3]) written
+             // to yQGm/yKGm/yVGm. dim is 3*C with C 16-aligned (host guard), so every
+             // sub-range here is 16-aligned.
+             const int32_t thirdBase = dim / 3;
+             for (int32_t third = 0; third < 3; ++third) {
+                 const int32_t thirdLo = third * thirdBase;
+                 const int32_t thirdHi = thirdLo + thirdBase;
+                 const int32_t ovLo = (channelStart > thirdLo) ? channelStart : thirdLo;
+                 const int32_t ovHi = ((channelStart + baseDim) < thirdHi) ? (channelStart + baseDim) : thirdHi;
+                 if (ovLo >= ovHi) {
+                     continue;
+                 }
+                 const int32_t srcOff = ovLo - channelStart;
+                 const int32_t subLen = ovHi - ovLo;
+                 const int64_t dstOff = static_cast<int64_t>(start + t) * thirdBase + (ovLo - thirdLo);
+                 if (third == 0) {
+                     DataCopy(yQGm[dstOff], outSlotT[srcOff], subLen);
+                 } else if (third == 1) {
+                     DataCopy(yKGm[dstOff], outSlotT[srcOff], subLen);
+                 } else {
+                     DataCopy(yVGm[dstOff], outSlotT[srcOff], subLen);
+                 }
+             }
+         } else {
+             DataCopy(yGm[outOffset], outSlotT, baseDim);
+         }
          if (t + 2 < len) {
              SetFlag<HardEvent::MTE3_V>(outMte3ToVEvent_[outSlot]);
          }
@@ -1050,6 +1109,14 @@
  __aicore__ inline bool CAUSAL_CONV1D_CLASS::HasBias() const
  {
      return (tilingData_ != nullptr) && (tilingData_->hasBias != 0);
+ }
+
+ // P2: when true, the output write demuxes each channel tile into y_q/y_k/y_v
+ // (each [N, dim/3]) instead of a merged [N, dim] y.
+ template <CAUSAL_CONV1D_TEMPLATE_ARGS>
+ __aicore__ inline bool CAUSAL_CONV1D_CLASS::IsSplitQkv() const
+ {
+     return (tilingData_ != nullptr) && (tilingData_->split_qkv != 0);
  }
  
  template <CAUSAL_CONV1D_TEMPLATE_ARGS>

--- a/csrc/moe/causal_conv1d/op_kernel/causal_conv1d_fn.h
+++ b/csrc/moe/causal_conv1d/op_kernel/causal_conv1d_fn.h
@@ -21,7 +21,8 @@
  public:
      __aicore__ inline void Init(GM_ADDR x, GM_ADDR weight, GM_ADDR bias, GM_ADDR convStates, GM_ADDR queryStartLoc,
                                  GM_ADDR cacheIndices, GM_ADDR initialStateMode, GM_ADDR numAcceptedTokens, GM_ADDR y,
-                                 GM_ADDR workspace, const CausalConv1dTilingData *tilingData)
+                                 GM_ADDR y_q, GM_ADDR y_k, GM_ADDR y_v, GM_ADDR workspace,
+                                 const CausalConv1dTilingData *tilingData)
      {
          (void)numAcceptedTokens;
          this->ResetRuntimeState(tilingData);
@@ -53,6 +54,11 @@
              }
          }
          this->yGm.SetGlobalBuffer(reinterpret_cast<__gm__ T *>(y));
+         if (tilingData->split_qkv != 0) {
+             this->yQGm.SetGlobalBuffer(reinterpret_cast<__gm__ T *>(y_q));
+             this->yKGm.SetGlobalBuffer(reinterpret_cast<__gm__ T *>(y_k));
+             this->yVGm.SetGlobalBuffer(reinterpret_cast<__gm__ T *>(y_v));
+         }
          if (tilingData->hasInitStateWorkspace != 0) {
              const uint64_t syncElems =
                  static_cast<uint64_t>(GetBlockNum()) * INIT_STATE_SYNCALL_NEED_SIZE;
@@ -79,12 +85,12 @@
  template <typename T, uint32_t widthKey, uint32_t fnPlanKey>
  __aicore__ inline void RunCausalConv1dFn(GM_ADDR x, GM_ADDR weight, GM_ADDR bias, GM_ADDR convStates,
                                           GM_ADDR queryStartLoc, GM_ADDR cacheIndices, GM_ADDR initialStateMode,
-                                          GM_ADDR numAcceptedTokens, GM_ADDR y, GM_ADDR workspace,
-                                          const CausalConv1dTilingData *tilingData)
+                                          GM_ADDR numAcceptedTokens, GM_ADDR y, GM_ADDR y_q, GM_ADDR y_k, GM_ADDR y_v,
+                                          GM_ADDR workspace, const CausalConv1dTilingData *tilingData)
  {
      CausalConv1dFn<T, widthKey, fnPlanKey> op;
-     op.Init(x, weight, bias, convStates, queryStartLoc, cacheIndices, initialStateMode, numAcceptedTokens, y, workspace,
-             tilingData);
+     op.Init(x, weight, bias, convStates, queryStartLoc, cacheIndices, initialStateMode, numAcceptedTokens, y, y_q, y_k,
+             y_v, workspace, tilingData);
      op.Process();
  }
  

--- a/csrc/moe/causal_conv1d/op_kernel/causal_conv1d_tiling_data.h
+++ b/csrc/moe/causal_conv1d/op_kernel/causal_conv1d_tiling_data.h
@@ -46,6 +46,7 @@ struct CausalConv1dTilingData {
     int64_t activationMode;
     int64_t padSlotId;
     int64_t hasBias;
+    int64_t split_qkv; // P2: when 1, kernel writes q/k/v into y_q/y_k/y_v (each [N, dim/3]) instead of merged y
     int64_t baseDim;
     int64_t baseDimCnt;
     int64_t hasNumAcceptedTokens;

--- a/csrc/moe/causal_conv1d/op_kernel/causal_conv1d_update.h
+++ b/csrc/moe/causal_conv1d/op_kernel/causal_conv1d_update.h
@@ -22,7 +22,8 @@ class CausalConv1dUpdate
                           CAUSAL_CONV1D_TPL_FN_PLAN_INVALID> {
 public:
     __aicore__ inline void Init(GM_ADDR x, GM_ADDR weight, GM_ADDR bias, GM_ADDR convStates, GM_ADDR queryStartLoc,
-                                GM_ADDR cacheIndices, GM_ADDR, GM_ADDR numAcceptedTokens, GM_ADDR y, GM_ADDR workspace,
+                                GM_ADDR cacheIndices, GM_ADDR, GM_ADDR numAcceptedTokens, GM_ADDR y, GM_ADDR y_q,
+                                GM_ADDR y_k, GM_ADDR y_v, GM_ADDR workspace,
                                 const CausalConv1dTilingData *tilingData)
     {
         (void)workspace;
@@ -53,6 +54,11 @@ public:
             }
         }
         this->yGm.SetGlobalBuffer(reinterpret_cast<__gm__ T *>(y));
+        if (tilingData->split_qkv != 0) {
+            this->yQGm.SetGlobalBuffer(reinterpret_cast<__gm__ T *>(y_q));
+            this->yKGm.SetGlobalBuffer(reinterpret_cast<__gm__ T *>(y_k));
+            this->yVGm.SetGlobalBuffer(reinterpret_cast<__gm__ T *>(y_v));
+        }
         this->InitSharedBuffersAndEvents();
     }
 
@@ -77,12 +83,12 @@ public:
 template <typename T>
 __aicore__ inline void RunCausalConv1dUpdate(GM_ADDR x, GM_ADDR weight, GM_ADDR bias, GM_ADDR convStates,
                                              GM_ADDR queryStartLoc, GM_ADDR cacheIndices, GM_ADDR initialStateMode,
-                                             GM_ADDR numAcceptedTokens, GM_ADDR y, GM_ADDR workspace,
-                                             const CausalConv1dTilingData *tilingData)
+                                             GM_ADDR numAcceptedTokens, GM_ADDR y, GM_ADDR y_q, GM_ADDR y_k, GM_ADDR y_v,
+                                             GM_ADDR workspace, const CausalConv1dTilingData *tilingData)
 {
     CausalConv1dUpdate<T> op;
-    op.Init(x, weight, bias, convStates, queryStartLoc, cacheIndices, initialStateMode, numAcceptedTokens, y, workspace,
-            tilingData);
+    op.Init(x, weight, bias, convStates, queryStartLoc, cacheIndices, initialStateMode, numAcceptedTokens, y, y_q, y_k,
+            y_v, workspace, tilingData);
     op.Process();
 }
 

--- a/csrc/torch_binding.cpp
+++ b/csrc/torch_binding.cpp
@@ -640,6 +640,13 @@ at::Tensor npu_causal_conv1d_custom(
     int64_t  pad_slot_id,
     int64_t  run_mode)
 {
+    // P2: regenerated aclnn_causal_conv1d.h signature is positional in OpDef order
+    // (8 inputs, 4 attrs: activation/pad/run/split_qkv, 4 outputs: y/y_q/y_k/y_v).
+    // Single-output path: split_qkv=false, y=output, y_q/y_k/y_v left unbound (nullptr).
+    bool splitQkv = false;
+    c10::optional<at::Tensor> yqUnused;
+    c10::optional<at::Tensor> ykUnused;
+    c10::optional<at::Tensor> yvUnused;
     EXEC_NPU_CMD(aclnnCausalConv1d,
                     x,
                     weight,
@@ -652,10 +659,62 @@ at::Tensor npu_causal_conv1d_custom(
                     activation_mode,
                     pad_slot_id,
                     run_mode,
-                    output
+                    splitQkv,
+                    output,
+                    yqUnused,
+                    ykUnused,
+                    yvUnused
                 );
 
     return output;
+}
+
+// P1: split-output variant for KDA. Writes q/k/v into 3 separate contiguous
+// tensors (y_q/y_k/y_v, each [N, C] with the same leading dims as x; the
+// caller can view [N, C] as [1, N, H, D] without a copy) instead of a merged
+// y, eliminating the external chunk(3)+rearrange+.contiguous(). Reuses the
+// same aclnnCausalConv1d op with split_qkv=true (ge OpDef routes the 4
+// outputs; the merged y slot stays unbound via an empty optional). gdn.py
+// keeps using the single-output npu_causal_conv1d_custom.
+std::tuple<at::Tensor, at::Tensor, at::Tensor> npu_causal_conv1d_custom_3io(
+    const at::Tensor& y_q,
+    const at::Tensor& y_k,
+    const at::Tensor& y_v,
+    const at::Tensor& x,
+    const at::Tensor& weight,
+    const at::Tensor& conv_state,
+    const c10::optional<at::Tensor>& bias_opt,
+    const c10::optional<at::Tensor>& query_start_loc_opt,
+    const c10::optional<at::Tensor>& cache_indices_opt,
+    const c10::optional<at::Tensor>& initial_state_mode_opt,
+    const c10::optional<at::Tensor>& num_accepted_tokens_opt,
+    int64_t  activation_mode,
+    int64_t  pad_slot_id,
+    int64_t  run_mode)
+{
+    // P2: split path. split_qkv=true; merged y left unbound (nullptr), y_q/y_k/y_v bound.
+    bool splitQkv = true;
+    c10::optional<at::Tensor> yMergedUnused;
+    EXEC_NPU_CMD(aclnnCausalConv1d,
+                    x,
+                    weight,
+                    bias_opt,
+                    conv_state,
+                    query_start_loc_opt,
+                    cache_indices_opt,
+                    initial_state_mode_opt,
+                    num_accepted_tokens_opt,
+                    activation_mode,
+                    pad_slot_id,
+                    run_mode,
+                    splitQkv,
+                    yMergedUnused,
+                    y_q,
+                    y_k,
+                    y_v
+                );
+
+    return std::make_tuple(y_q, y_k, y_v);
 }
 
 // It is expected that further improvements will be made after it is incorporated into CANN on June 30th.
@@ -2706,6 +2765,22 @@ TORCH_LIBRARY_EXPAND(CONCAT(_C, _ascend), ops)
         "                         int run_mode"
         ") -> (Tensor output)");
     ops.impl("npu_causal_conv1d_custom", torch::kPrivateUse1, &vllm_ascend::npu_causal_conv1d_custom);
+    // P1: split-output variant (KDA only). Returns (y_q, y_k, y_v) directly;
+    // gdn.py keeps the single-output npu_causal_conv1d_custom above.
+    ops.def(
+        "npu_causal_conv1d_custom_3io(Tensor y_q, Tensor y_k, Tensor y_v, Tensor x, "
+        "                              Tensor weight, "
+        "                              Tensor conv_state, "
+        "                              Tensor? bias_opt, "
+        "                              Tensor? query_start_loc_opt, "
+        "                              Tensor? cache_indices_opt, "
+        "                              Tensor? initial_state_mode_opt, "
+        "                              Tensor? num_accepted_tokens_opt, "
+        "                              int activation_mode, "
+        "                              int pad_slot_id, "
+        "                              int run_mode"
+        ") -> (Tensor y_q, Tensor y_k, Tensor y_v)");
+    ops.impl("npu_causal_conv1d_custom_3io", torch::kPrivateUse1, &vllm_ascend::npu_causal_conv1d_custom_3io);
     ops.def(
         "moe_grouped_matmul("
             "Tensor x,"

--- a/csrc/torch_binding_meta.cpp
+++ b/csrc/torch_binding_meta.cpp
@@ -562,6 +562,26 @@ at::Tensor npu_causal_conv1d_custom_meta(
     return output;
 }
 
+// P1: meta for split-output variant (mirrors npu_causal_conv1d_custom_3io).
+std::tuple<at::Tensor, at::Tensor, at::Tensor> npu_causal_conv1d_custom_3io_meta(
+    const at::Tensor& y_q,
+    const at::Tensor& y_k,
+    const at::Tensor& y_v,
+    const at::Tensor& x,
+    const at::Tensor& weight,
+    const at::Tensor& conv_state,
+    const c10::optional<at::Tensor>& bias_opt,
+    const c10::optional<at::Tensor>& query_start_loc_opt,
+    const c10::optional<at::Tensor>& cache_indices_opt,
+    const c10::optional<at::Tensor>& initial_state_mode_opt,
+    const c10::optional<at::Tensor>& num_accepted_tokens_opt,
+    int64_t  activation_mode,
+    int64_t  pad_slot_id,
+    int64_t  run_mode)
+{
+    return std::make_tuple(y_q, y_k, y_v);
+}
+
 at::Tensor npu_causal_conv1d_310_meta(
     const at::Tensor& x,
     const at::Tensor& weight,
@@ -1995,6 +2015,7 @@ TORCH_LIBRARY_IMPL_EXPAND(CONCAT(_C, _ascend), Meta, ops) {
     ops.impl("npu_copy_and_expand_eagle_inputs", &vllm_ascend::meta::npu_copy_and_expand_eagle_inputs_meta);
     // causal_conv1d_fn
     ops.impl("npu_causal_conv1d_custom", &vllm_ascend::meta::npu_causal_conv1d_custom_meta);
+    ops.impl("npu_causal_conv1d_custom_3io", &vllm_ascend::meta::npu_causal_conv1d_custom_3io_meta);
     // moe_grouped_matmul
     ops.impl("moe_grouped_matmul", &vllm_ascend::meta::moe_grouped_matmul_meta);
     ops.impl("moe_gating_top_k_hash", &vllm_ascend::meta::moe_gating_top_k_hash_meta);

--- a/vllm_ascend/ops/kimi_kda.py
+++ b/vllm_ascend/ops/kimi_kda.py
@@ -311,8 +311,8 @@ class AscendKimiGatedDeltaNetAttention(KimiGatedDeltaNetAttention):
             )
         return self.o_norm(core_attn_out, output_gate)
 
-    @staticmethod
     def _run_causal_conv1d(
+        self,
         mixed_qkv: torch.Tensor,
         conv_weights_t: torch.Tensor,
         conv_state: torch.Tensor,
@@ -320,13 +320,22 @@ class AscendKimiGatedDeltaNetAttention(KimiGatedDeltaNetAttention):
         *,
         run_mode: int,
         num_accepted_tokens: torch.Tensor | None = None,
-    ) -> torch.Tensor:
-        out = torch.empty_like(mixed_qkv)
-        torch.ops._C_ascend.npu_causal_conv1d_custom(
-            out,
+    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+        # P2: split-write path. The kernel writes q/k/v directly into 3 contiguous
+        # [N, C] buffers (C = local_num_heads * head_dim = dim/3), eliminating the
+        # external chunk(3)+rearrange+.contiguous() that emitted 3 aclnnInplaceCopy.
+        n = mixed_qkv.shape[0]
+        c = self.local_num_heads * self.head_dim
+        y_q = torch.empty((n, c), dtype=mixed_qkv.dtype, device=mixed_qkv.device)
+        y_k = torch.empty((n, c), dtype=mixed_qkv.dtype, device=mixed_qkv.device)
+        y_v = torch.empty((n, c), dtype=mixed_qkv.dtype, device=mixed_qkv.device)
+        torch.ops._C_ascend.npu_causal_conv1d_custom_3io(
+            y_q,
+            y_k,
+            y_v,
             mixed_qkv,
             conv_weights_t,
-            conv_state=conv_state,
+            conv_state,
             bias_opt=None,
             query_start_loc_opt=metadata.query_start_loc,
             cache_indices_opt=metadata.cache_indices,
@@ -336,7 +345,8 @@ class AscendKimiGatedDeltaNetAttention(KimiGatedDeltaNetAttention):
             pad_slot_id=PAD_SLOT_ID,
             run_mode=run_mode,
         )
-        return out
+        h, d = self.local_num_heads, self.head_dim
+        return y_q.view(1, n, h, d), y_k.view(1, n, h, d), y_v.view(1, n, h, d)
 
     def _packed_conv_shape(self) -> tuple[int, int]:
         local_channels = self.local_num_heads * self.head_dim
@@ -587,10 +597,7 @@ class AscendKimiGatedDeltaNetAttention(KimiGatedDeltaNetAttention):
                 run_mode=1,
                 num_accepted_tokens=spec_conv_meta.num_accepted_tokens,
             )
-            q_spec, k_spec, v_spec = mixed_spec.chunk(3, dim=-1)
-            q_spec, k_spec, v_spec = (
-                rearrange(x, "n (h d) -> 1 n h d", d=self.head_dim) for x in (q_spec, k_spec, v_spec)
-            )
+            q_spec, k_spec, v_spec = mixed_spec
             assert raw_gate_spec is not None and beta_spec is not None
             assert attn_metadata.spec_query_start_loc is not None
             assert attn_metadata.spec_state_indices_tensor is not None
@@ -635,10 +642,7 @@ class AscendKimiGatedDeltaNetAttention(KimiGatedDeltaNetAttention):
                     run_mode=1,
                 )
 
-            q_non_spec, k_non_spec, v_non_spec = mixed_non_spec.chunk(3, dim=-1)
-            q_non_spec, k_non_spec, v_non_spec = (
-                rearrange(x, "n (h d) -> 1 n h d", d=self.head_dim) for x in (q_non_spec, k_non_spec, v_non_spec)
-            )
+            q_non_spec, k_non_spec, v_non_spec = mixed_non_spec
             assert raw_gate_non_spec is not None and beta_non_spec is not None
 
             split_non_spec = spec_masks is None and attn_metadata.num_prefills > 0 and attn_metadata.num_decodes > 0


### PR DESCRIPTION
### What this PR does / why we need it?

In the Kimi K3 KDA (gated delta-net) layer, every call to the fused `CausalConv1d` is followed by `chunk(3) + rearrange + .contiguous()` to split the merged conv output back into q/k/v. Profiling shows this emits **exactly 3 `aclnnInplaceCopy_SliceAiCore_Slice` copies after every `CausalConv1d`** (3.00 copies/conv1d — 837 kernels / 2101us in a 128-token decode window) with no semantic value: the conv weights are already packed as `[conv_size, 3*C]` and the kernel computes q/k/v together, so only the output write addressing needs to change.

This PR lets the conv emit q/k/v directly into three contiguous tensors:

- **ge op interface**: extend the existing `CausalConv1d` ge op with OPTIONAL outputs `y_q`/`y_k`/`y_v` and a `split_qkv` attr (default `false`). The merged-y default path stays byte-compatible — `gdn.py`'s callers and any existing `npu_causal_conv1d_custom` user are zero-change. Infershape derives the split output shape (`[N, C]`, viewable as `[1, N, H, D]` without a copy) from x's actual rank, validates the last dim is divisible by 3, and propagates unknown (`-1`) dims.
- **torch bindings**: add `npu_causal_conv1d_custom_3io`; `npu_causal_conv1d_custom` gains `split_qkv=false` + 3 empty optional output placeholders so both bindings match the regenerated positional aclnn signature. Note for reviewers: `EXEC_NPU_CMD` resolves the aclnn API at runtime and `reinterpret_cast`s it to the call-site arity (no compile-time signature check) and binds args by lvalue reference (`ConvertTypes(Ts&...)`), so both bindings pass the full 18-param list via named locals with unbound outputs as empty optionals.
- **kernel split-write**: tiling reads `split_qkv` (attr index 3 — `gert::RuntimeAttrs::GetAttrPointer` is addressed positionally, not by name) into the tiling data, with a host-side guard `dim%3==0 && (dim/3)%16==0` keeping the sub-copies aligned. `y_q`/`y_k`/`y_v` GM_ADDRs thread through the entry and are bound only when `split_qkv`; each channel tile is demuxed into up to 3 sub-range DataCopys at both write sites (the `RunSeq` slow path and the `RunSeqFnRolling` fast path). The merged path is unchanged. (The opc-generated kernel dispatch passes every declared output to the AscendC entry positionally, which is why the entry signature accepts the 3 new outputs.)
- **caller**: `kimi_kda`'s `_run_causal_conv1d` switches to `npu_causal_conv1d_custom_3io`, pre-allocates `[N, C]` outputs and views them to `[1, N, H, D]`; the external `chunk(3) + rearrange` is dropped at both decode caller sites (speculative and non-speculative). `gdn.py` stays on the single-output path.

Measured (single-node TP16/DP1, `kernel_details.csv`, identical 128-token decode window): the 3 `aclnnInplaceCopy_SliceAiCore_Slice` copies that followed every `CausalConv1d` are **fully eliminated (3.00 → 0.00 copies/conv1d)**; `CausalConv1d` average duration unchanged (9.16us → 9.23us).

### Does this PR introduce _any_ user-facing change?

Additive only:

- New torch op `npu_causal_conv1d_custom_3io` (three split outputs). The default `npu_causal_conv1d_custom` behavior is unchanged (`split_qkv=false` → merged `y`).
- No numerical change: the merged default path is byte-identical; in split mode the kernel performs the same compute and only demuxes the output write addresses into per-q/k/v sub-ranges.

### How was this patch tested?

- **Full source build** with `SOC_VERSION=<soc> COMPILE_CUSTOM_KERNELS=1 pip install -e . --no-build-isolation --no-deps` on Atlas A3 (CANN 9.1.0): the `build_aclnn` opc step completes and both `torch.ops._C_ascend.npu_causal_conv1d_custom` and `..._3io` register. (The first full opc build surfaced the integration constraints above — positional output dispatch to the kernel entry, positional attr indexing, lvalue binding in `EXEC_NPU_CMD` — all addressed in this PR.)
- **Default merged-path regression**: `torch.ops._C_ascend.npu_causal_conv1d_custom` compared against the triton reference `causal_conv1d_fn` (from `vllm_ascend._310p.ops.causal_conv1d`) across 4 cases (multi-sequence prefill with/without initial state, `dim=4160`, `width=2`): outputs and in-place `conv_states` updates all match. This also confirms the extended binding with 3 unbound optional outputs behaves exactly as before on the default path.
- **End-to-end split-path verification** (editable install, single-node TP16/DP1/EP16 on Atlas A3, dspark speculative decoding): with the split-write path active on both decode routes (speculative and non-speculative), `kernel_details.csv` over the same 128-token decode window shows the 3 `aclnnInplaceCopy_SliceAiCore_Slice` copies after every `CausalConv1d` fully eliminated (3.00 → 0.00/conv1d), with `CausalConv1d` average duration unchanged (9.16us → 9.23us).
- No dedicated unit test was added for the split mode itself: the split-write only repartitions output write addresses (the compute core is unchanged, and each q/k/v sub-range copy is contiguous and 16-aligned by the host-side guard); the path is exercised end to end on both decode routes as above. A standalone unit test comparing split-mode outputs against the merged path is a natural follow-up.
- vLLM main: https://github.com/vllm-project/vllm/commit/d02df748bf9efd99022f1a062597dc3cb3808485
