### PR TITLE
[Feature][Worker] Integrate vLLM StartPlan for startup acceleration

### DIFF
--- a/tests/ut/test_platform.py
+++ b/tests/ut/test_platform.py
@@ -647,9 +647,11 @@ class TestNPUPlatform(TestBase):
     def test_get_device_total_memory_before_npu_init(self):
         mock_npu = MagicMock()
         mock_npu.is_initialized.return_value = False
-        with patch.object(torch, "npu", mock_npu, create=True):
-            with pytest.raises(NotImplementedError):
-                self.platform.get_device_total_memory(device_id=0)
+        with (
+            patch.object(torch, "npu", mock_npu, create=True),
+            pytest.raises(NotImplementedError),
+        ):
+            self.platform.get_device_total_memory(device_id=0)
         mock_npu.is_initialized.assert_called_once_with()
         mock_npu.mem_get_info.assert_not_called()
 

--- a/tests/ut/test_platform.py
+++ b/tests/ut/test_platform.py
@@ -644,6 +644,25 @@ class TestNPUPlatform(TestBase):
         self.assertEqual(self.platform.get_device_name(device_id), device_name)
         mock_get_device_name.assert_called_once_with(0)
 
+    def test_get_device_total_memory_before_npu_init(self):
+        mock_npu = MagicMock()
+        mock_npu.is_initialized.return_value = False
+        with patch.object(torch, "npu", mock_npu, create=True):
+            with pytest.raises(NotImplementedError):
+                self.platform.get_device_total_memory(device_id=0)
+        mock_npu.is_initialized.assert_called_once_with()
+        mock_npu.mem_get_info.assert_not_called()
+
+    def test_get_device_total_memory_after_npu_init(self):
+        mock_npu = MagicMock()
+        mock_npu.is_initialized.return_value = True
+        mock_npu.mem_get_info.return_value = (8 << 30, 16 << 30)
+        with patch.object(torch, "npu", mock_npu, create=True):
+            total_memory = self.platform.get_device_total_memory(device_id=1)
+        self.assertEqual(total_memory, 16 << 30)
+        mock_npu.is_initialized.assert_called_once_with()
+        mock_npu.mem_get_info.assert_called_once_with(1)
+
     @patch("vllm_ascend.platform.torch.npu.get_device_properties")
     def test_get_device_uuid(self, mock_get_device_properties):
         device_id = 0

--- a/tests/ut/worker/test_worker_v1.py
+++ b/tests/ut/worker/test_worker_v1.py
@@ -954,6 +954,41 @@ class TestNPUWorker(TestBase):
             self.assertEqual(result, expected_result)
             worker._apply_kv_offload_decode_memory_constraints.assert_called_once_with(expected_result)
 
+    @patch("vllm_ascend.worker.worker.maybe_apply_startup_plan")
+    @patch("vllm_ascend.worker.worker.get_ascend_config")
+    @patch("vllm_ascend.worker.worker.memory_profiling")
+    def test_determine_available_memory_applies_startup_plan_before_fast_path(
+        self,
+        mock_memory_profiling,
+        mock_get_ascend_config,
+        mock_apply_startup_plan,
+    ):
+        """A startup-plan hit must select the existing KV-cache fast path."""
+        from vllm_ascend.worker.worker import NPUWorker
+
+        planned_kv_cache_memory = 4 << 30
+        mock_get_ascend_config.return_value.sparse_kv_offload_config.enabled = False
+
+        with patch.object(NPUWorker, "__init__", lambda x, **kwargs: None):
+            worker = NPUWorker()
+            worker.vllm_config = MagicMock(kv_transfer_config=None)
+            worker.cache_config = MagicMock()
+            worker.cache_config.kv_cache_memory_bytes = None
+            worker.init_snapshot = MagicMock(free_memory=8 << 30)
+            worker.model_runner = MagicMock()
+
+            def apply_plan(target_worker):
+                target_worker.cache_config.kv_cache_memory_bytes = planned_kv_cache_memory
+
+            mock_apply_startup_plan.side_effect = apply_plan
+
+            result = worker.determine_available_memory()
+
+            mock_apply_startup_plan.assert_called_once_with(worker)
+            mock_memory_profiling.assert_not_called()
+            worker.model_runner.profile_run.assert_called_once()
+            self.assertEqual(result, planned_kv_cache_memory)
+
     @patch("vllm_ascend.worker.worker.get_ascend_config")
     @patch("vllm_ascend.worker.worker.memory_profiling")
     @patch("vllm_ascend.worker.worker.torch.npu.reset_peak_memory_stats")
@@ -1515,6 +1550,58 @@ class TestNPUWorker(TestBase):
             # Verify atb warm up
             mock_warm_up_atb.assert_called_once()
             mock_kernel_warmup.assert_called_once_with(worker)
+
+    def test_compile_or_warm_up_model_saves_startup_plan_after_graph_capture(self):
+        """The persisted budget must include the measured NPU graph memory."""
+        from vllm_ascend.worker.worker import NPUWorker
+
+        requested_memory = 10 << 30
+        model_memory = 2 << 30
+        peak_activation_memory = 1 << 30
+        non_torch_memory = 512 << 20
+        npugraph_memory = 256 << 20
+        redundancy_buffer = 150 << 20
+        expected_kv_cache_memory = (
+            requested_memory
+            - (model_memory + peak_activation_memory + non_torch_memory + npugraph_memory)
+            - redundancy_buffer
+        )
+
+        with (
+            patch.object(NPUWorker, "__init__", lambda x, **kwargs: None),
+            patch.object(kw_module, "kernel_warmup") as mock_kernel_warmup,
+            patch("vllm_ascend.worker.worker.maybe_save_startup_plan") as mock_save_startup_plan,
+            patch("vllm_ascend.worker.worker.get_ascend_config") as mock_get_ascend_config,
+            patch("vllm_ascend.worker.worker.get_current_hardware_profile") as mock_get_hardware_profile,
+            patch("vllm_ascend.worker.worker.NPUWorker._warm_up_atb"),
+            patch("vllm_ascend.worker.worker.set_random_seed"),
+            patch("vllm_ascend.worker.worker.torch.npu.memory_reserved", return_value=0),
+            patch("vllm_ascend.worker.worker.torch.npu.memory_allocated", return_value=0),
+        ):
+            mock_get_ascend_config.return_value.enable_cpu_binding = False
+            mock_get_hardware_profile.return_value.supports.return_value = False
+
+            worker = NPUWorker()
+            worker.model_runner = MagicMock()
+            worker.model_runner.model_memory_usage = model_memory
+            worker.model_runner.capture_model.return_value = npugraph_memory
+            worker.vllm_config = MagicMock()
+            worker.vllm_config.compilation_config.compile_sizes = []
+            worker.vllm_config.compilation_config.cudagraph_capture_sizes = []
+            worker.vllm_config.compilation_config.get_compile_ranges.return_value = []
+            worker.model_config = MagicMock(enforce_eager=False, seed=1234)
+            worker.cache_config = MagicMock(kv_cache_memory_bytes=None, gpu_memory_utilization=0.9)
+            worker.init_snapshot = MagicMock(free_memory=12 << 30, total_memory=16 << 30)
+            worker.requested_memory = requested_memory
+            worker.available_kv_cache_memory_bytes = requested_memory - model_memory
+            worker.peak_activation_memory = peak_activation_memory
+            worker.non_torch_memory = non_torch_memory
+
+            worker.compile_or_warm_up_model()
+
+            mock_kernel_warmup.assert_called_once_with(worker)
+            worker.model_runner.capture_model.assert_called_once()
+            mock_save_startup_plan.assert_called_once_with(worker, expected_kv_cache_memory)
 
     @patch("vllm_ascend.worker.worker.ensure_kv_transfer_initialized")
     @patch("vllm_ascend.worker.worker.CaMemAllocator")

--- a/vllm_ascend/platform.py
+++ b/vllm_ascend/platform.py
@@ -211,11 +211,17 @@ class NPUPlatform(Platform):
     @classmethod
     def get_device_total_memory(cls, device_id: int = 0) -> int:
         """
-        Get the total memory of the NPU device in bytes.
-        DO NOT IMPLEMENT: Implementing it calls get_device_name() in advance and initializes torch_npu too early.
-        torch_npu allows global initialization only once; duplicate initialization causes errors.
+        Get the total memory of an initialized NPU device in bytes.
+
+        vLLM may query this method while resolving argument defaults, before
+        the worker initializes torch_npu. Keep the existing early-startup
+        behavior in that case, but allow runtime features such as StartPlan
+        to fingerprint an already initialized device safely.
         """
-        raise NotImplementedError
+        if not hasattr(torch, "npu") or not torch.npu.is_initialized():
+            raise NotImplementedError("NPU total memory is unavailable before torch_npu initialization")
+        _, total_memory = torch.npu.mem_get_info(device_id)
+        return total_memory
 
     @classmethod
     def get_attn_backend_cls(cls, selected_backend, attn_selector_config, num_heads: int | None = None):

--- a/vllm_ascend/worker/worker.py
+++ b/vllm_ascend/worker/worker.py
@@ -825,7 +825,8 @@ class NPUWorker(WorkerBase):
             )
             logger.info(msg)
 
-            maybe_save_startup_plan(self, suggested_to_requested)
+            if suggested_to_requested > 0:
+                maybe_save_startup_plan(self, suggested_to_requested)
 
         # Call ATB matmul to warm up; otherwise, the first operation (ReshapeAndCache)
         # may cause performance degradation at runtime.

--- a/vllm_ascend/worker/worker.py
+++ b/vllm_ascend/worker/worker.py
@@ -53,6 +53,10 @@ from vllm.v1.kv_cache_interface import KVCacheConfig, KVCacheSpec
 from vllm.v1.outputs import EMPTY_MODEL_RUNNER_OUTPUT, AsyncModelRunnerOutput, DraftTokenIds, ModelRunnerOutput
 from vllm.v1.utils import report_usage_stats
 from vllm.v1.worker.gpu_worker import AsyncIntermediateTensors
+from vllm.v1.worker.startup_plan import (
+    maybe_apply_startup_plan,
+    maybe_save_startup_plan,
+)
 from vllm.v1.worker.worker_base import CompilationTimes, WorkerBase
 from vllm.v1.worker.workspace import init_workspace_manager
 
@@ -543,6 +547,8 @@ class NPUWorker(WorkerBase):
         """
         GiB = lambda b: b / GiB_bytes
 
+        maybe_apply_startup_plan(self)
+
         # Fast path: user has explicitly specified KV cache size via
         # --kv-cache-memory. Still run profile_run() to compile the model,
         # but skip the memory profiling calculation entirely.
@@ -818,6 +824,8 @@ class NPUWorker(WorkerBase):
                 f"torch allocated memory {format_gib(torch.npu.memory_allocated())} GiB."
             )
             logger.info(msg)
+
+            maybe_save_startup_plan(self, suggested_to_requested)
 
         # Call ATB matmul to warm up; otherwise, the first operation (ReshapeAndCache)
         # may cause performance degradation at runtime.


### PR DESCRIPTION
### What this PR does / why we need it?

Backport of #15528 to `releases/v0.27.1rc`.

#15528 integrates vLLM's StartPlan mechanism into the Ascend worker so repeat startups can reuse the measured KV-cache budget and graph-capture results, skipping memory profiling and accelerating startup. The touched files on `releases/v0.27.1rc` are identical to `main`, so the upstream commits (`d79c357` and `7535099`) were cherry-picked as-is with no additional adaptation.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

The same unit tests as #15528:

- `tests/ut/test_platform.py::test_get_device_total_memory_before_npu_init`
- `tests/ut/test_platform.py::test_get_device_total_memory_after_npu_init`
- `tests/ut/worker/test_worker_v1.py::test_determine_available_memory_applies_startup_plan_before_fast_path`
- `tests/ut/worker/test_worker_v1.py::test_compile_or_warm_up_model_saves_startup_plan_after_graph_capture`

Both cherry-picks applied cleanly against `releases/v0.27.1rc`.
- vLLM main: https://github.com/vllm-project/vllm/commit/ba07e4a48fc951300d97eb506217dd530583dea3
