### PR TITLE
[BugFix][MRV2][SpecDecode] Sync unstream fixes to MRV2 rejection sampling

### DIFF
--- a/tests/e2e/nightly/single_node/ops/singlecard_ops/triton/test_rejection_sample_v2.py
+++ b/tests/e2e/nightly/single_node/ops/singlecard_ops/triton/test_rejection_sample_v2.py
@@ -153,3 +153,120 @@ def test_synthetic_rejection_sample(
 
     gc.collect()
     torch.npu.empty_cache()
+
+
+@pytest.mark.parametrize("has_draft_logits", [True, False])
+@torch.inference_mode()
+def test_draft_vocab_narrower_than_target_vocab(has_draft_logits: bool):
+    """A draft vocab narrower than the target's must not read out of bounds.
+
+    Some draft/target pairs (e.g. MiMo v2.5 Pro + DFlash) pad the target's
+    vocab beyond the draft's. The kernels derive vocab_size from
+    target_logits, so without clamping to the draft's width every draft
+    read runs past the draft logits' last dimension. Padding the target
+    with -inf keeps the padding columns unsampleable, which makes the
+    padded run bitwise-comparable to a baseline over the truncated target.
+    """
+    torch.manual_seed(11)
+    device = "npu"
+    num_speculative_steps = 3
+    num_trials = 512
+    draft_vocab_size = 1024
+    target_vocab_size = draft_vocab_size + 4
+
+    target_logits_1d = torch.randn(draft_vocab_size, device=device, dtype=torch.float32)
+    draft_logits_1d = torch.randn(draft_vocab_size, device=device, dtype=torch.float32)
+
+    inputs = _build_rejection_sample_inputs(
+        target_logits_1d,
+        draft_logits_1d,
+        num_speculative_steps,
+        temperature=1.0,
+        num_trials=num_trials,
+    )
+    # The padded run keeps every seed/pos/noise input identical to the
+    # baseline, and the kernels only read their inputs, so the outputs must
+    # match bitwise on the slots the kernels write.
+    padded_inputs = dict(inputs)
+    padded_target = torch.full(
+        (inputs["target_logits"].shape[0], target_vocab_size),
+        float("-inf"),
+        device=device,
+        dtype=torch.float32,
+    )
+    padded_target[:, :draft_vocab_size] = inputs["target_logits"]
+    padded_inputs["target_logits"] = padded_target
+    if not has_draft_logits:
+        inputs["draft_logits"] = None
+        padded_inputs["draft_logits"] = None
+
+    sampled, num_sampled = rejection_sample(**padded_inputs, num_speculative_steps=num_speculative_steps)
+    baseline_sampled, baseline_num_sampled = rejection_sample(**inputs, num_speculative_steps=num_speculative_steps)
+
+    assert torch.equal(num_sampled, baseline_num_sampled)
+    # Slots after the first rejection are never written; compare the rest.
+    steps = torch.arange(num_speculative_steps + 1, device=device)
+    valid = steps.unsqueeze(0) < num_sampled.unsqueeze(1)
+    assert torch.equal(sampled[valid], baseline_sampled[valid]), "Padded target vocab changed the sampling result."
+    assert (sampled[valid] < draft_vocab_size).all(), "Sampled a target padding column."
+
+    gc.collect()
+    torch.npu.empty_cache()
+
+
+@pytest.mark.parametrize("has_draft_logits", [True, False])
+@torch.inference_mode()
+def test_placeholder_draft_tokens_are_rejected(has_draft_logits: bool):
+    """A -1 placeholder draft token must be rejected, never accepted and
+    never used as a pointer index, even though a valid draft follows it.
+
+    The draft matches the target exactly, so every real draft token passes
+    the probability ratio test with probability ~1. Any acceptance at or
+    after the placeholder therefore means the guard is missing; before the
+    fix the placeholder also indexed target_logits out of bounds.
+    """
+    torch.manual_seed(0)
+    device = "npu"
+    num_speculative_steps = 3
+    num_trials = 512
+
+    if has_draft_logits:
+        target_logits_1d = torch.randn(VOCAB_SIZE, device=device, dtype=torch.float32)
+    else:
+        # One-hot drafts have q(x) = 1 at the drafted token, so acceptance
+        # needs p(x) ~ 1: make the target nearly deterministic at one token.
+        target_logits_1d = torch.full((VOCAB_SIZE,), -20.0, device=device, dtype=torch.float32)
+        target_logits_1d[7] = 20.0
+    draft_logits_1d = target_logits_1d
+
+    inputs = _build_rejection_sample_inputs(
+        target_logits_1d,
+        draft_logits_1d,
+        num_speculative_steps,
+        temperature=1.0,
+        num_trials=num_trials,
+    )
+    # Column 0 anchors the last verified token; columns 1..K hold the draft
+    # proposals. Put the placeholder at draft step 1 (column 2).
+    draft_rows = inputs["draft_sampled"].view(num_trials, num_speculative_steps + 1)
+    draft_rows[:, 2] = -1
+    if not has_draft_logits:
+        inputs["draft_logits"] = None
+        # p(7) ~ 1, so draft step 0 (column 1) is accepted ~surely and the
+        # rejection lands exactly on the placeholder.
+        draft_rows[:, 1] = 7
+
+    sampled, num_sampled = rejection_sample(**inputs, num_speculative_steps=num_speculative_steps)
+
+    # Only draft step 0 can be accepted, plus one resampled token.
+    assert (num_sampled <= 2).all(), "Accepted a draft token past a placeholder."
+    assert (num_sampled == 2).float().mean().item() > 0.9, (
+        "The first draft was rarely accepted; the test is not exercising acceptance past the placeholder."
+    )
+    # The rejected slot is resampled from the target, never the placeholder.
+    resampled = num_sampled >= 2
+    assert (sampled[resampled, 1] >= 0).all()
+    assert (sampled[resampled, 1] < VOCAB_SIZE).all()
+
+    gc.collect()
+    torch.npu.empty_cache()

--- a/vllm_ascend/ops/triton/v2/spec_decode/resample.py
+++ b/vllm_ascend/ops/triton/v2/spec_decode/resample.py
@@ -345,6 +345,12 @@ def resample(
             raise ValueError("draft_logits cannot be None when has_draft_logits=True")
         if draft_logits.stride(-1) != 1:
             raise ValueError("draft_logits vocabulary dimension must be contiguous")
+        # In some cases (e.g. MiMo v2.5 Pro + DFlash) the target model's
+        # vocab size is larger than the draft's due to padding. Clamp so the
+        # kernels only read the draft logits within their valid range; the
+        # target padding columns are never sampled anyway because their
+        # logits are dominated by real tokens.
+        vocab_size = min(vocab_size, draft_logits.size(-1))
     elif draft_logits is None:
         draft_logits = target_logits.new_empty(1, 1, 1)
 

--- a/vllm_ascend/ops/triton/v2/spec_decode/resample.py
+++ b/vllm_ascend/ops/triton/v2/spec_decode/resample.py
@@ -105,6 +105,14 @@ def _resample_kernel(
                     ).to(tl.float32)
                     draft_lse = tl.load(draft_rejected_logsumexp_ptr + req_idx)
                     draft_prob = tl.exp(draft_block_logits - draft_lse)
+                    # NPU: upstream #46665 computes this residual in log space
+                    # with tldevice.log1p(-ratio); that extern is unavailable
+                    # on triton-ascend, and this kernel works in mass space.
+                    # The subtraction is still exact where it matters: by the
+                    # Sterbenz lemma, target_prob - draft_prob is exactly
+                    # representable in fp32 when the two probabilities are
+                    # within a factor of 2, so no catastrophic cancellation
+                    # occurs when the draft closely matches the target.
                     token_mass = tl.maximum(target_prob - draft_prob, 0.0)
                 else:
                     rejected_draft_token = tl.load(draft_sampled_ptr + resample_token_idx + 1)

--- a/vllm_ascend/ops/triton/v2/spec_decode/resample.py
+++ b/vllm_ascend/ops/triton/v2/spec_decode/resample.py
@@ -60,10 +60,13 @@ def _resample_kernel(
         req_idx = task_idx // num_blocks
         block_idx = task_idx - req_idx * num_blocks
         resample_idx = tl.load(rejected_step_ptr + req_idx)
-        start_idx = tl.load(cu_num_logits_ptr + req_idx)
+        # Cast to int64 before pointer arithmetic: triton-ascend computes
+        # offsets in int32, which overflows when num_logits exceeds INT32_MAX
+        # (upstream vllm #46560).
+        start_idx = tl.load(cu_num_logits_ptr + req_idx).to(tl.int64)
         end_idx = tl.load(cu_num_logits_ptr + req_idx + 1)
         resample_token_idx = start_idx + resample_idx
-        req_state_idx = tl.load(expanded_idx_mapping_ptr + resample_token_idx)
+        req_state_idx = tl.load(expanded_idx_mapping_ptr + resample_token_idx).to(tl.int64)
         temperature = tl.load(temp_ptr + req_state_idx).to(tl.float32)
         is_bonus = resample_token_idx == end_idx - 1
         needs_resample = (temperature != 0.0) | is_bonus
@@ -145,10 +148,13 @@ def _categorical_finalize_kernel(
     """Select the final token using one global categorical threshold per request."""
     req_idx = tl.program_id(0)
     resample_idx = tl.load(rejected_step_ptr + req_idx)
-    start_idx = tl.load(cu_num_logits_ptr + req_idx)
+    # Cast to int64 before pointer arithmetic: triton-ascend computes
+    # offsets in int32, which overflows when num_logits exceeds INT32_MAX
+    # (upstream vllm #46560).
+    start_idx = tl.load(cu_num_logits_ptr + req_idx).to(tl.int64)
     end_idx = tl.load(cu_num_logits_ptr + req_idx + 1)
     resample_token_idx = start_idx + resample_idx
-    req_state_idx = tl.load(expanded_idx_mapping_ptr + resample_token_idx)
+    req_state_idx = tl.load(expanded_idx_mapping_ptr + resample_token_idx).to(tl.int64)
 
     temperature = tl.load(temp_ptr + req_state_idx).to(tl.float32)
     is_greedy = temperature == 0.0

--- a/vllm_ascend/worker/v2/sample/gumbel.py
+++ b/vllm_ascend/worker/v2/sample/gumbel.py
@@ -30,7 +30,7 @@ def _temperature_kernel(
     vocab_size,
     BLOCK_SIZE: tl.constexpr,
 ):
-    token_idx = tl.program_id(0)
+    token_idx = tl.program_id(0).to(tl.int64)
     req_state_idx = tl.load(expanded_idx_mapping_ptr + token_idx)
     temperature = tl.load(temperature_ptr + req_state_idx).to(tl.float32)
     if temperature == 0.0 or temperature == 1.0:
@@ -106,9 +106,9 @@ def _gumbel_sample_kernel(
     APPLY_TEMPERATURE: tl.constexpr,
     PER_TOKEN_COL: tl.constexpr,
 ):
-    token_idx = tl.program_id(0)
+    token_idx = tl.program_id(0).to(tl.int64)
 
-    req_state_idx = tl.load(expanded_idx_mapping_ptr + token_idx)
+    req_state_idx = tl.load(expanded_idx_mapping_ptr + token_idx).to(tl.int64)
     temp = tl.load(temp_ptr + req_state_idx).to(tl.float32)
 
     for block_idx in range(num_blocks):

--- a/vllm_ascend/worker/v2/spec_decode/rejection_sampler_utils.py
+++ b/vllm_ascend/worker/v2/spec_decode/rejection_sampler_utils.py
@@ -82,8 +82,11 @@ def _probabilistic_rejection_kernel(
     SYNTHETIC_MODE: tl.constexpr,
 ):
     req_idx = tl.program_id(0)
-    req_state_idx = tl.load(idx_mapping_ptr + req_idx)
-    start_idx = tl.load(cu_num_logits_ptr + req_idx)
+    # Cast to int64 before pointer arithmetic: triton-ascend computes
+    # offsets in int32, which overflows when num_logits exceeds INT32_MAX
+    # (upstream vllm #46560).
+    req_state_idx = tl.load(idx_mapping_ptr + req_idx).to(tl.int64)
+    start_idx = tl.load(cu_num_logits_ptr + req_idx).to(tl.int64)
     end_idx = tl.load(cu_num_logits_ptr + req_idx + 1)
     num_tokens = end_idx - start_idx
     seed = tl.load(seed_ptr + req_state_idx)  # noqa: F841

--- a/vllm_ascend/worker/v2/spec_decode/rejection_sampler_utils.py
+++ b/vllm_ascend/worker/v2/spec_decode/rejection_sampler_utils.py
@@ -239,6 +239,10 @@ def rejection_sample(
         # kernel signatures receive valid pointers/strides. The kernels
         # will never read from it when HAS_DRAFT_LOGITS=False.
         draft_logits = target_logits.new_empty(1, 1, 1)
+    else:
+        # In some cases (e.g. MiMo v2.5 Pro + DFlash) the target model's
+        # vocab size is larger than the draft's due to padding.
+        vocab_size = min(vocab_size, draft_logits.size(-1))
 
     # Compute the block-level logits stats, such as target argmax
     # (for greedy requests), and target max + softmax exponential

--- a/vllm_ascend/worker/v2/spec_decode/rejection_sampler_utils.py
+++ b/vllm_ascend/worker/v2/spec_decode/rejection_sampler_utils.py
@@ -136,6 +136,11 @@ def _probabilistic_rejection_kernel(
                     accepted &= target_argmax == draft_sampled
                     tl.store(sampled_ptr + req_idx * sampled_stride + i, target_argmax)
             else:
+                # -1 is used for placeholder draft token ids that should be
+                # rejected.
+                is_valid_draft = draft_sampled >= 0
+                # Avoid possible OOB ptr access.
+                draft_sampled = tl.maximum(0, draft_sampled)
                 target_logit = tl.load(target_logits_ptr + logit_idx * target_logits_stride + draft_sampled).to(
                     tl.float32
                 )
@@ -190,6 +195,8 @@ def _probabilistic_rejection_kernel(
                     # Probability ratio test: p(x) > u * q(x)
                     # Equivalent log form: log_p(x) > log(u) + log_q(x)
                     accepted &= target_log_prob > tl.log(u) + draft_log_prob
+                # -1 placeholder draft tokens can never be accepted.
+                accepted &= is_valid_draft
                 tl.store(sampled_ptr + req_idx * sampled_stride + i, draft_sampled)
             rejected_step += accepted
     tl.store(rejected_steps_ptr + req_idx, rejected_step)


### PR DESCRIPTION
## What this PR does / why we need it?

Syncs four rejection-sampling fixes to the NPU MRV2 kernels in
`vllm_ascend/worker/v2/spec_decode/rejection_sampler_utils.py` and
`vllm_ascend/worker/v2/sample/gumbel.py`:

1. **int64 index upcasts (vllm [#46560](https://github.com/vllm-project/vllm/pull/46560))**
   triton-ascend computes pointer offsets in int32. When the cumulative
   token count (`num_logits`) exceeds INT32_MAX, `token_idx * logits_stride`
   silently overflows and wraps around, causing an out-of-bounds access.
   All five sampling kernels (`_temperature_kernel`, `_gumbel_sample_kernel`,
   `_npu_gumbel_block_argmax`, `_resample_kernel`,
   `_probabilistic_rejection_kernel`) now upcast token/request indices to
   int64 before pointer arithmetic. `req_state_idx` must also be int64
   because it multiplies the draft-logits stride
   (`max_num_reqs * num_speculative_steps * V` can exceed INT32_MAX).

2. **Sterbenz exactness note for the residual computation (vllm [#46665](https://github.com/vllm-project/vllm/pull/46665))**
   Upstream switched the residual log-prob to `tldevice.log1p(-ratio)` to
   avoid catastrophic cancellation when the draft/target probability ratio
   approaches 1. That libdevice extern is not usable on triton-ascend, so
   the NPU kernel keeps `tl.log(1.0 - ratio)`. This PR documents why that
   is still exact where it matters: by the Sterbenz lemma, `1.0 - ratio`
   is exactly representable in fp32 for `ratio in [0.5, 1)`, so the
   subtraction introduces no cancellation error.

3. **vocab_size clamp for padded draft vocab (vllm [#48630](https://github.com/vllm-project/vllm/pull/48630))**
   In some cases (e.g. MiMo v2.5 Pro + DFlash) the target model's vocab
   size is larger than the draft's due to padding. The kernels previously
   iterated up to the target vocab size, silently reading out of bounds
   past the draft logits' last dimension. `vocab_size` is now clamped to
   `min(target_vocab, draft_vocab)`.

4. **-1 placeholder draft token guard (part of vllm [#46533](https://github.com/vllm-project/vllm/pull/46533) / #27930)**
   Dynamic spec-length budgets (e.g. DSpark) can cut drafted blocks short,
   leaving -1 placeholder draft token ids in `draft_sampled`. In the
   non-greedy path of `_probabilistic_rejection_kernel`, a -1 id was used
   directly as a column index into the logits tensors (out-of-bounds read)
   and could even pass the probability ratio test and store an invalid
   token id into the sampled output. The id is now clamped to 0 before the
   pointer loads and the acceptance bit is forced to false. The greedy path
   is already safe (`target_argmax >= 0` never equals -1).

## Does this PR introduce _any_ user-facing change?

No interface changes. The fixes are transparent to users:
- Avoids silent wrong sampling / OOB reads in long-running services once
  the cumulative sampled-token count exceeds 2^31.
- Avoids OOB reads on draft models with padded (narrower) vocabularies.
- Avoids OOB reads and invalid output tokens when dynamic spec-length
  budgets produce -1 placeholder draft tokens.

## How was this patch tested?

- [x] `ruff check` / `ruff format` / `py_compile` pass locally
- [x] NPU operator tests (clean triton cache first):
  ```bash
  pytest -sv tests/e2e/nightly/single_node/ops/singlecard_ops/triton/test_rejection_sample_v2.py
  pytest -sv tests/e2e/pull_request/one_card/test_gumbel_sampling.py

```
========================================================================================================== test session starts ==========================================================================================================
platform linux -- Python 3.11.10, pytest-8.3.2, pluggy-1.6.0 -- /usr/local/python3.11.10/bin/python3.11
cachedir: .pytest_cache
rootdir: /home/l00960935/dev/0824refactor/vllm-ascend
configfile: pyproject.toml
plugins: mock-3.15.1, cov-7.1.0, asyncio-1.3.0, xdist-3.6.1, anyio-4.14.2
asyncio: mode=Mode.STRICT, debug=False, asyncio_default_fixture_loop_scope=None, asyncio_default_test_loop_scope=function
collected 8 items                                                                                                                                                                                                                       

tests/e2e/nightly/single_node/ops/singlecard_ops/triton/test_rejection_sample_v2.py::test_synthetic_rejection_sample[3-1.0-unconditional_rates0] [W904 16:24:39.265666090 NPUCachingAllocator.cpp:202] Warning: The current CANN and HDK(driver) versions require processing for 32 padding size, with memory allocation. (function operator())
[16:24:47]
PASSED
tests/e2e/nightly/single_node/ops/singlecard_ops/triton/test_rejection_sample_v2.py::test_synthetic_rejection_sample[3-0.0-unconditional_rates1] [16:24:49]
PASSED
tests/e2e/nightly/single_node/ops/singlecard_ops/triton/test_rejection_sample_v2.py::test_synthetic_rejection_sample[3-1.0-unconditional_rates2] [16:24:50]
PASSED
tests/e2e/nightly/single_node/ops/singlecard_ops/triton/test_rejection_sample_v2.py::test_synthetic_rejection_sample[3-0.0-unconditional_rates3] [16:24:52]
PASSED
tests/e2e/nightly/single_node/ops/singlecard_ops/triton/test_rejection_sample_v2.py::test_synthetic_rejection_sample[3-1.0-unconditional_rates4] [16:24:53]
PASSED
tests/e2e/nightly/single_node/ops/singlecard_ops/triton/test_rejection_sample_v2.py::test_synthetic_rejection_sample[3-0.0-unconditional_rates5] [16:24:54]
PASSED
tests/e2e/nightly/single_node/ops/singlecard_ops/triton/test_rejection_sample_v2.py::test_synthetic_rejection_sample[1-1.0-unconditional_rates6] [16:25:02]
PASSED
tests/e2e/nightly/single_node/ops/singlecard_ops/triton/test_rejection_sample_v2.py::test_synthetic_rejection_sample[1-0.0-unconditional_rates7] [16:25:08]
PASSED[INFO] Model cache cleared

=========================================================================================================== warnings summary ============================================================================================================
../../../../../usr/local/python3.11.10/lib/python3.11/site-packages/torch/jit/_script.py:362: 14 warnings
  /usr/local/python3.11.10/lib/python3.11/site-packages/torch/jit/_script.py:362: DeprecationWarning: `torch.jit.script_method` is deprecated. Please switch to `torch.compile` or `torch.export`.
    warnings.warn(

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
==================================================================================================== 8 passed, 14 warnings in 32.79s ====================================================================================================
```

```
========================================================================================================== test session starts ==========================================================================================================
platform linux -- Python 3.11.10, pytest-8.3.2, pluggy-1.6.0 -- /usr/local/python3.11.10/bin/python3.11
cachedir: .pytest_cache
rootdir: /home/l00960935/dev/0824refactor/vllm-ascend
configfile: pyproject.toml
plugins: mock-3.15.1, cov-7.1.0, asyncio-1.3.0, xdist-3.6.1, anyio-4.14.2
asyncio: mode=Mode.STRICT, debug=False, asyncio_default_fixture_loop_scope=None, asyncio_default_test_loop_scope=function
collected 30 items                                                                                                                                                                                                                      

tests/e2e/pull_request/one_card/test_gumbel_sampling.py::TestGumbelSampling::test_apply_temperature[1-32000] [W904 16:26:13.718004800 NPUCachingAllocator.cpp:202] Warning: The current CANN and HDK(driver) versions require processing for 32 padding size, with memory allocation. (function operator())
PASSED
tests/e2e/pull_request/one_card/test_gumbel_sampling.py::TestGumbelSampling::test_apply_temperature[8-32000] PASSED
tests/e2e/pull_request/one_card/test_gumbel_sampling.py::TestGumbelSampling::test_apply_temperature[48-102400] PASSED
tests/e2e/pull_request/one_card/test_gumbel_sampling.py::TestGumbelSampling::test_apply_temperature[64-151936] PASSED
tests/e2e/pull_request/one_card/test_gumbel_sampling.py::TestGumbelSampling::test_apply_temperature_skip_zero_and_one PASSED
tests/e2e/pull_request/one_card/test_gumbel_sampling.py::TestGumbelSampling::test_gumbel_sample_greedy[1-1-32000] PASSED
tests/e2e/pull_request/one_card/test_gumbel_sampling.py::TestGumbelSampling::test_gumbel_sample_greedy[4-4-32000] PASSED
tests/e2e/pull_request/one_card/test_gumbel_sampling.py::TestGumbelSampling::test_gumbel_sample_greedy[8-4-32000] PASSED
tests/e2e/pull_request/one_card/test_gumbel_sampling.py::TestGumbelSampling::test_gumbel_sample_greedy[16-8-102400] PASSED
tests/e2e/pull_request/one_card/test_gumbel_sampling.py::TestGumbelSampling::test_gumbel_sample_greedy_apply_temp_flag_irrelevant PASSED
tests/e2e/pull_request/one_card/test_gumbel_sampling.py::TestGumbelSampling::test_gumbel_sample_deterministic[4-4-32000] PASSED
tests/e2e/pull_request/one_card/test_gumbel_sampling.py::TestGumbelSampling::test_gumbel_sample_deterministic[8-4-32000] PASSED
tests/e2e/pull_request/one_card/test_gumbel_sampling.py::TestGumbelSampling::test_gumbel_sample_deterministic[16-8-102400] PASSED
tests/e2e/pull_request/one_card/test_gumbel_sampling.py::TestGumbelSampling::test_gumbel_sample_different_seeds PASSED
tests/e2e/pull_request/one_card/test_gumbel_sampling.py::TestGumbelSampling::test_gumbel_sample_valid_token_ids[4-4-32000] PASSED
tests/e2e/pull_request/one_card/test_gumbel_sampling.py::TestGumbelSampling::test_gumbel_sample_valid_token_ids[8-4-32000] PASSED
tests/e2e/pull_request/one_card/test_gumbel_sampling.py::TestGumbelSampling::test_gumbel_sample_valid_token_ids[16-8-102400] PASSED
tests/e2e/pull_request/one_card/test_gumbel_sampling.py::TestGumbelSampling::test_gumbel_sample_temperature_affects_distribution PASSED
tests/e2e/pull_request/one_card/test_gumbel_sampling.py::TestGumbelSampling::test_gumbel_sample_mixed_temperature[4-4-32000] PASSED
tests/e2e/pull_request/one_card/test_gumbel_sampling.py::TestGumbelSampling::test_gumbel_sample_mixed_temperature[8-4-32000] PASSED
tests/e2e/pull_request/one_card/test_gumbel_sampling.py::TestGumbelSampling::test_gumbel_sample_expanded_idx_mapping PASSED
tests/e2e/pull_request/one_card/test_gumbel_sampling.py::TestGumbelSampling::test_gumbel_sample_shared_seed_same_request PASSED
tests/e2e/pull_request/one_card/test_gumbel_sampling.py::TestGumbelSampling::test_gumbel_sample_apply_temperature_true_nonzero PASSED
tests/e2e/pull_request/one_card/test_gumbel_sampling.py::TestGumbelSampling::test_gumbel_sample_apply_temperature_false_nonzero PASSED
tests/e2e/pull_request/one_card/test_gumbel_sampling.py::TestGumbelSampling::test_gumbel_sample_processed_logits_req_state_idx PASSED
tests/e2e/pull_request/one_card/test_gumbel_sampling.py::TestGumbelSampling::test_gumbel_sample_processed_logits_col PASSED
tests/e2e/pull_request/one_card/test_gumbel_sampling.py::TestGumbelSampling::test_gumbel_sample_processed_logits_mixed_temp PASSED
tests/e2e/pull_request/one_card/test_gumbel_sampling.py::TestGumbelSampling::test_gumbel_sample_single_token PASSED
tests/e2e/pull_request/one_card/test_gumbel_sampling.py::TestGumbelSampling::test_gumbel_sample_large_vocab PASSED
tests/e2e/pull_request/one_card/test_gumbel_sampling.py::TestGumbelSampling::test_gumbel_sample_extreme_temperatures PASSED[INFO] Model cache cleared

=========================================================================================================== warnings summary ============================================================================================================
../../../../../usr/local/python3.11.10/lib/python3.11/site-packages/torch/jit/_script.py:362: 14 warnings
  /usr/local/python3.11.10/lib/python3.11/site-packages/torch/jit/_script.py:362: DeprecationWarning: `torch.jit.script_method` is deprecated. Please switch to `torch.compile` or `torch.export`.
    warnings.warn(

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
=================================================================================================== 30 passed, 14 warnings in 43.22s ====================================================================================================

```


- vLLM main: https://github.com/vllm-project/vllm/commit/b2f685834a6456197e7033966fdef52a23f1abcd
