### PR TITLE
[Backport v0.26.0rc][Doc][Model] Align serving environment variables

### DIFF
--- a/docs/source/tutorials/models/Qwen3-Dense.md
+++ b/docs/source/tutorials/models/Qwen3-Dense.md
@@ -231,10 +231,9 @@ Single-node deployment completes both Prefill and Decode within the same node, s
     Qwen3-32B-W8A8:
 
     ```bash
+    export HCCL_OP_EXPANSION_MODE="AIV"
     export ASCEND_RT_VISIBLE_DEVICES=0,1,2,3
     export PYTORCH_NPU_ALLOC_CONF=expandable_segments:True
-    export TASK_QUEUE_ENABLE=1
-    export HCCL_OP_EXPANSION_MODE="AIV"
 
     vllm serve your_model_path \
         --served-model-name qwen3 \
@@ -253,10 +252,8 @@ Single-node deployment completes both Prefill and Decode within the same node, s
     Qwen3-32B-W4A4:
 
     ```bash
-    export ASCEND_RT_VISIBLE_DEVICES=0,1
-    export VLLM_USE_V1=1
-    export TASK_QUEUE_ENABLE=1
     export HCCL_BUFFSIZE=1024
+    export ASCEND_RT_VISIBLE_DEVICES=0,1
     vllm serve your_model_path \
         --port 8004 \
         --data-parallel-size 1 \
@@ -540,10 +537,9 @@ Please refer to the [vLLM Features](https://docs.vllm.ai/en/stable/features), [v
 <u>High Throughput Configuration:</u>
 
 ```bash
+export HCCL_OP_EXPANSION_MODE="AIV"
 export ASCEND_RT_VISIBLE_DEVICES=0,1,2,3
 export PYTORCH_NPU_ALLOC_CONF=expandable_segments:True
-export TASK_QUEUE_ENABLE=1
-export HCCL_OP_EXPANSION_MODE="AIV"
 
 vllm serve your_model_path \
     --served-model-name qwen3 \
@@ -565,10 +561,9 @@ vllm serve your_model_path \
 <u>Long Context Configuration:</u>
 
 ```bash
+export HCCL_OP_EXPANSION_MODE="AIV"
 export ASCEND_RT_VISIBLE_DEVICES=0,1,2,3
 export PYTORCH_NPU_ALLOC_CONF=expandable_segments:True
-export TASK_QUEUE_ENABLE=1
-export HCCL_OP_EXPANSION_MODE="AIV"
 
 vllm serve your_model_path \
     --host <host_ip> \
@@ -592,10 +587,9 @@ vllm serve your_model_path \
 <u>Low Latency Configuration:</u>
 
 ```bash
+export HCCL_OP_EXPANSION_MODE="AIV"
 export ASCEND_RT_VISIBLE_DEVICES=0,1,2,3,4,5,6,7
 export PYTORCH_NPU_ALLOC_CONF=expandable_segments:True
-export TASK_QUEUE_ENABLE=1
-export HCCL_OP_EXPANSION_MODE="AIV"
 
 vllm serve your_model_path \
     --served-model-name qwen3 \


### PR DESCRIPTION
### What this PR does / why we need it?

Backport the environment-variable documentation cleanup from #15628 to `releases/v0.26.0rc`.

- remove deprecated `TASK_QUEUE_ENABLE` and `VLLM_USE_V1` exports from Qwen3-Dense serving examples
- order retained environment variables by the documented priority
- intentionally omit Hy4-preview because that guide does not exist on this release branch

### Does this PR introduce _any_ user-facing change?

No. This is a documentation-only correction.

### How was this patch tested?

- Audited all 9 `vllm serve` blocks in `Qwen3-Dense.md`; no targeted deprecated exports or ordering violations remain.
- `python -m pre_commit run markdownlint --hook-stage manual --files docs/source/tutorials/models/Qwen3-Dense.md`
- `git diff --check upstream/releases/v0.26.0rc...HEAD`
- vLLM main: https://github.com/vllm-project/vllm/commit/d02df748bf9efd99022f1a062597dc3cb3808485
