### PR TITLE
[Backport v0.27.1rc][BugFix][P/D] Fix Mooncake CP transfer group block IDs

### DIFF
--- a/tests/ut/kv_offload/test_mooncake_connector.py
+++ b/tests/ut/kv_offload/test_mooncake_connector.py
@@ -1166,6 +1166,56 @@ class TestCoreFunctionality(unittest.TestCase):
         mock_get_meta.assert_not_called()
 
     @patch.object(KVCacheRecvingThread, "_get_remote_metadata")
+    def test_transfer_sfa_metadata_plane_uses_cache_spec_type(self, mock_get_meta):
+        metadata_layer_idx = self.thread.index_cache_plane_base + 3
+        metadata_size = metadata_layer_idx + 1
+        local_base_addrs = [[] for _ in range(metadata_size)]
+        remote_base_addrs = [[] for _ in range(metadata_size)]
+        block_lens = [[] for _ in range(metadata_size)]
+        block_strides = [[] for _ in range(metadata_size)]
+        remote_block_strides = [[] for _ in range(metadata_size)]
+        block_size_scale = [[] for _ in range(metadata_size)]
+        local_base_addrs[metadata_layer_idx] = [0x2000]
+        remote_base_addrs[metadata_layer_idx] = [0x4000]
+        block_lens[metadata_layer_idx] = [2048]
+        block_strides[metadata_layer_idx] = [2048]
+        remote_block_strides[metadata_layer_idx] = [2048]
+        block_size_scale[metadata_layer_idx] = [1]
+
+        self.thread.kv_caches_base_addr["local_engine"][5555] = local_base_addrs
+        self.thread.kv_caches_base_addr["remote_engine"] = {6666: remote_base_addrs}
+        self.thread.block_len_per_addr = block_lens
+        self.thread.block_stride_per_addr = block_strides
+        self.thread.remote_block_stride_per_addr["remote_engine"][6666] = remote_block_strides
+        self.thread.block_size_scale = block_size_scale
+
+        for layer_name in (
+            "model.layers.3.attn.index_cache",
+            "model.layers.3.self_attn.indexer.k_cache",
+        ):
+            with self.subTest(layer_name=layer_name):
+                self.thread.kv_group2layeridx = {
+                    0: (
+                        {
+                            "kv_cache_spec_type": "AscendSFAIndexerCacheSpec",
+                            "layer_names": [layer_name],
+                        },
+                        [metadata_layer_idx],
+                    )
+                }
+                self.thread._transfer_kv_cache_all_groups(self.test_req)
+
+                self.engine.batch_transfer_sync_read.assert_called_once_with(
+                    "localhost:7777",
+                    [0x2000 + 2048],
+                    [0x4000 + 3 * 2048],
+                    [2 * 2048],
+                )
+                self.engine.batch_transfer_sync_read.reset_mock()
+
+        mock_get_meta.assert_not_called()
+
+    @patch.object(KVCacheRecvingThread, "_get_remote_metadata")
     def test_transfer_mamba_uses_normalized_prompt_state_block(self, mock_get_meta):
         # Pure metadata/address arithmetic: no NPU tensor or torch.npu call.
         self._configure_mock_mamba_transfer()

--- a/tests/ut/kv_offload/test_mooncake_connector.py
+++ b/tests/ut/kv_offload/test_mooncake_connector.py
@@ -1169,12 +1169,12 @@ class TestCoreFunctionality(unittest.TestCase):
     def test_transfer_sfa_metadata_plane_uses_cache_spec_type(self, mock_get_meta):
         metadata_layer_idx = self.thread.index_cache_plane_base + 3
         metadata_size = metadata_layer_idx + 1
-        local_base_addrs = [[] for _ in range(metadata_size)]
-        remote_base_addrs = [[] for _ in range(metadata_size)]
-        block_lens = [[] for _ in range(metadata_size)]
-        block_strides = [[] for _ in range(metadata_size)]
-        remote_block_strides = [[] for _ in range(metadata_size)]
-        block_size_scale = [[] for _ in range(metadata_size)]
+        local_base_addrs: list[list[int]] = [[] for _ in range(metadata_size)]
+        remote_base_addrs: list[list[int]] = [[] for _ in range(metadata_size)]
+        block_lens: list[list[int]] = [[] for _ in range(metadata_size)]
+        block_strides: list[list[int]] = [[] for _ in range(metadata_size)]
+        remote_block_strides: list[list[int]] = [[] for _ in range(metadata_size)]
+        block_size_scale: list[list[int]] = [[] for _ in range(metadata_size)]
         local_base_addrs[metadata_layer_idx] = [0x2000]
         remote_base_addrs[metadata_layer_idx] = [0x4000]
         block_lens[metadata_layer_idx] = [2048]

--- a/tests/ut/kv_offload/test_mooncake_connector.py
+++ b/tests/ut/kv_offload/test_mooncake_connector.py
@@ -315,6 +315,53 @@ class TestKVCacheSendingThread(unittest.TestCase):
 
 
 class TestMooncakeTransferGroups(unittest.TestCase):
+    def test_glm_sfa_indexer_uses_independent_metadata_layer(self):
+        mla_layer = "model.layers.3.self_attn.attn"
+        sfa_layer = "model.layers.3.self_attn.indexer.k_cache"
+        mtp_layer = "model.layers.60.mtp.attn"
+        mla_spec = MLAAttentionSpec(
+            block_size=128,
+            num_kv_heads=1,
+            head_size=512,
+            dtype=torch.bfloat16,
+        )
+        sfa_spec = AscendSFAIndexerCacheSpec(
+            block_size=128,
+            num_kv_heads=1,
+            head_size=128,
+            dtype=torch.bfloat16,
+            sfa_dcp_replicated_indexer_size=8,
+        )
+        layer_specs = {
+            sfa_layer: sfa_spec,
+            mla_layer: mla_spec,
+            mtp_layer: mla_spec,
+        }
+        uniform_spec = UniformTypeKVCacheSpecs(
+            block_size=128,
+            kv_cache_specs=layer_specs,
+        )
+        worker = MooncakeConnectorWorker.__new__(MooncakeConnectorWorker)
+        worker.vllm_config = MockVllmConfig()
+        worker.total_layers = 60
+        worker.kv_cache_config = MockKVCacheConfig(
+            kv_cache_groups=[
+                MockKVCacheGroup(
+                    layer_names=list(layer_specs),
+                    kv_cache_spec=uniform_spec,
+                )
+            ]
+        )
+        worker._layer_specs = dict(layer_specs)
+
+        kv_group2layeridx = worker._build_kv_group2layeridx()
+
+        self.assertEqual(len(kv_group2layeridx), 2)
+        self.assertEqual(kv_group2layeridx[0][0]["kv_cache_spec_type"], "AscendSFAIndexerCacheSpec")
+        self.assertEqual(kv_group2layeridx[0][1], [123])
+        self.assertEqual(kv_group2layeridx[1][0]["kv_cache_spec_type"], "MLAAttentionSpec")
+        self.assertEqual(kv_group2layeridx[1][1], [3, 60])
+
     def test_m3_index_spec_is_preserved_and_splits_transfer_group(self):
         main_layer = "model.layers.3.attn"
         index_layer = f"{main_layer}.index_cache"
@@ -382,16 +429,16 @@ class TestMooncakeTransferGroups(unittest.TestCase):
         self.assertEqual(kv_group2layeridx[0][0]["kv_cache_spec_type"], "FullAttentionSpec")
         self.assertEqual(kv_group2layeridx[0][1], [3])
         self.assertEqual(kv_group2layeridx[1][0]["kv_cache_spec_type"], "AscendSFAIndexerCacheSpec")
-        self.assertEqual(kv_group2layeridx[1][1], [63])
+        self.assertEqual(kv_group2layeridx[1][1], [123])
 
     def test_m3_index_uses_its_own_block_scale_and_non_mla_routing(self):
         worker = MooncakeConnectorWorker.__new__(MooncakeConnectorWorker)
         worker.vllm_config = MockVllmConfig()
         worker.vllm_config.model_config.is_deepseek_mla = False
         worker.num_key_value_heads = 4
-        worker.block_size_scale = [[] for _ in range(64)]
+        worker.block_size_scale = [[] for _ in range(124)]
         worker.block_size_scale[3] = [2]
-        worker.block_size_scale[63] = [1]
+        worker.block_size_scale[123] = [1]
         index_group = {
             "kv_cache_spec_type": "AscendSFAIndexerCacheSpec",
             "kv_cache_group_id": 0,
@@ -405,13 +452,13 @@ class TestMooncakeTransferGroups(unittest.TestCase):
             "layer_names": ["model.layers.3.attn"],
         }
 
-        self.assertEqual(worker._get_kernel_block_scale([63]), 1)
+        self.assertEqual(worker._get_kernel_block_scale([123]), 1)
         self.assertFalse(worker._group_use_mla_rank_routing(index_group))
         self.assertTrue(worker._group_skip_kv_reformat(index_group))
         self.assertEqual(worker._get_attention_group_num_key_value_heads(index_group), 4)
         self.assertTrue(
             transfer_groups_need_independent_block_ids(
-                {0: (main_group, [3]), 1: (index_group, [63])},
+                {0: (main_group, [3]), 1: (index_group, [123])},
                 worker.block_size_scale,
             )
         )
@@ -3543,23 +3590,24 @@ class TestMooncakeConnectorWorker(unittest.TestCase):
         worker.handshake_port = worker.side_channel_port + worker.tp_rank
         worker.local_remote_block_port_mapping = {}
         worker.remote_port_send_num = {}
-        worker.block_size_scale = [[1], [1]]
+        worker.block_size_scale = [[1], [], [8]]
         # GLM-5.2 exposes more than one Mooncake transfer group for one KV
-        # cache manager group. Request metadata still contains one block table.
+        # cache manager group. SFA and MLA belong to transformer layer 0 but
+        # use independent physical metadata layers with scales 8 and 1.
         worker.kv_group2layeridx = {
             0: (
+                {
+                    "kv_cache_spec_type": "AscendSFAIndexerCacheSpec",
+                    "kv_cache_group_id": 0,
+                },
+                [2],
+            ),
+            1: (
                 {
                     "kv_cache_spec_type": "MLAAttentionSpec",
                     "kv_cache_group_id": 0,
                 },
                 [0],
-            ),
-            1: (
-                {
-                    "kv_cache_spec_type": "AscendSFAIndexerCacheSpec",
-                    "kv_cache_group_id": 0,
-                },
-                [1],
             ),
         }
 
@@ -3592,20 +3640,10 @@ class TestMooncakeConnectorWorker(unittest.TestCase):
         ports, local_ids, remote_ids = worker._get_kv_split_metadata("issue-13934", cast(ReqMeta, meta))
 
         self.assertEqual(ports, [[31005]])
-        self.assertEqual(local_ids, [(local_blocks,)])
-        self.assertEqual(remote_ids, [(remote_blocks,)])
-
-        # If the split transfer groups use different kernel scales, they need
-        # separate output block-id lists while still reading cache group 0.
-        worker.block_size_scale = [[1], [2]]
-        meta.remote_engine_id = "issue-13934-prefill-independent-scales"
-        ports, local_ids, remote_ids = worker._get_kv_split_metadata("issue-13934", cast(ReqMeta, meta))
-        expanded_local_blocks = [kernel for block in local_blocks for kernel in (block * 2, block * 2 + 1)]
-        expanded_remote_blocks = [kernel for block in remote_blocks for kernel in (block * 2, block * 2 + 1)]
-
-        self.assertEqual(ports, [[31005]])
-        self.assertEqual(local_ids, [(local_blocks, expanded_local_blocks)])
-        self.assertEqual(remote_ids, [(remote_blocks, expanded_remote_blocks)])
+        expanded_local_blocks = [kernel for block in local_blocks for kernel in range(block * 8, block * 8 + 8)]
+        expanded_remote_blocks = [kernel for block in remote_blocks for kernel in range(block * 8, block * 8 + 8)]
+        self.assertEqual(local_ids, [(expanded_local_blocks, local_blocks)])
+        self.assertEqual(remote_ids, [(expanded_remote_blocks, remote_blocks)])
 
     def test_get_tp_num_need_pulls(self):
         worker = MooncakeConnectorWorker(self.vllm_config, self.engine_id, MockKVCacheConfig())

--- a/tests/ut/kv_offload/test_mooncake_connector.py
+++ b/tests/ut/kv_offload/test_mooncake_connector.py
@@ -3522,6 +3522,91 @@ class TestMooncakeConnectorWorker(unittest.TestCase):
         self.assertEqual(local_ids, [([70, 71, 72, 73], [80, 81, 82, 83])])
         self.assertEqual(remote_ids, [([50, 51, 52, 53], [60, 61, 62, 63])])
 
+    def test_issue_13934_dcp_split_transfer_groups_use_kv_cache_group_id(self):
+        """DCP metadata is cache-group indexed, not transfer-group indexed."""
+        worker = MooncakeConnectorWorker(self.vllm_config, self.engine_id, MockKVCacheConfig())
+        worker._is_hma_required = True
+        worker.use_mla = True
+        worker.use_sparse = False
+        worker.num_key_value_heads = 1
+        worker.tp_size = 8
+        worker.tp_rank = 5
+        worker.pcp_size = 1
+        worker.dcp_size = 8
+        worker.pcp_rank = 0
+        worker.dcp_rank = 5
+        worker._decode_tp_size = 8
+        worker._prefill_tp_size = 8
+        worker._prefill_pp_size = 1
+        worker.block_size = 128
+        worker.side_channel_port = 5000
+        worker.handshake_port = worker.side_channel_port + worker.tp_rank
+        worker.local_remote_block_port_mapping = {}
+        worker.remote_port_send_num = {}
+        worker.block_size_scale = [[1], [1]]
+        # GLM-5.2 exposes more than one Mooncake transfer group for one KV
+        # cache manager group. Request metadata still contains one block table.
+        worker.kv_group2layeridx = {
+            0: (
+                {
+                    "kv_cache_spec_type": "MLAAttentionSpec",
+                    "kv_cache_group_id": 0,
+                },
+                [0],
+            ),
+            1: (
+                {
+                    "kv_cache_spec_type": "AscendSFAIndexerCacheSpec",
+                    "kv_cache_group_id": 0,
+                },
+                [1],
+            ),
+        }
+
+        remote_blocks = list(range(1, 27))
+        local_blocks = list(range(101, 127))
+        remote_mapping = {
+            str(offset): {
+                "host": f"host-{offset}",
+                "engine_id": f"engine-{offset}",
+                "handshake_port": 31000 + offset,
+            }
+            for offset in range(8)
+        }
+        meta = types.SimpleNamespace(
+            remote_pcp_size=1,
+            remote_dcp_size=8,
+            remote_ptp_size=8,
+            remote_port=31000,
+            remote_block_ids=(remote_blocks,),
+            local_block_ids=(local_blocks,),
+            num_external_tokens=26262,
+            num_prompt_blocks=206,
+            num_computed_tokens=0,
+            remote_engine_id="issue-13934-prefill",
+            remote_host="localhost",
+            remote_multi_nodes_meta_mapping=remote_mapping,
+            remote_block_size=128,
+        )
+
+        ports, local_ids, remote_ids = worker._get_kv_split_metadata("issue-13934", cast(ReqMeta, meta))
+
+        self.assertEqual(ports, [[31005]])
+        self.assertEqual(local_ids, [(local_blocks,)])
+        self.assertEqual(remote_ids, [(remote_blocks,)])
+
+        # If the split transfer groups use different kernel scales, they need
+        # separate output block-id lists while still reading cache group 0.
+        worker.block_size_scale = [[1], [2]]
+        meta.remote_engine_id = "issue-13934-prefill-independent-scales"
+        ports, local_ids, remote_ids = worker._get_kv_split_metadata("issue-13934", cast(ReqMeta, meta))
+        expanded_local_blocks = [kernel for block in local_blocks for kernel in (block * 2, block * 2 + 1)]
+        expanded_remote_blocks = [kernel for block in remote_blocks for kernel in (block * 2, block * 2 + 1)]
+
+        self.assertEqual(ports, [[31005]])
+        self.assertEqual(local_ids, [(local_blocks, expanded_local_blocks)])
+        self.assertEqual(remote_ids, [(remote_blocks, expanded_remote_blocks)])
+
     def test_get_tp_num_need_pulls(self):
         worker = MooncakeConnectorWorker(self.vllm_config, self.engine_id, MockKVCacheConfig())
         worker.num_key_value_heads = 8

--- a/vllm_ascend/distributed/kv_transfer/kv_p2p/mooncake_connector.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_p2p/mooncake_connector.py
@@ -838,7 +838,7 @@ class KVCacheRecvingThread(threading.Thread):
             first_layer_index, end_layer_index = self.pp_layer_indices[prefill_pp_rank]
             if self.vllm_config.speculative_config is not None and prefill_pp_rank == self._prefill_pp_size - 1:
                 end_layer_index += self.num_draft_layers
-            is_index_cache_plane = any(".index_cache" in name for name in group_spec.get("layer_names", []))
+            is_index_cache_plane = group_spec.get("kv_cache_spec_type") == "AscendSFAIndexerCacheSpec"
 
             def in_partition(metadata_layer_idx: int) -> bool:
                 transformer_layer = (

--- a/vllm_ascend/distributed/kv_transfer/kv_p2p/mooncake_connector.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_p2p/mooncake_connector.py
@@ -842,7 +842,9 @@ class KVCacheRecvingThread(threading.Thread):
 
             def in_partition(metadata_layer_idx: int) -> bool:
                 transformer_layer = (
-                    metadata_layer_idx - self.index_cache_plane_base if is_index_cache_plane else metadata_layer_idx
+                    metadata_layer_idx - self.index_cache_plane_base
+                    if is_index_cache_plane and metadata_layer_idx >= self.index_cache_plane_base
+                    else metadata_layer_idx
                 )
                 return first_layer_index <= transformer_layer < end_layer_index
 

--- a/vllm_ascend/distributed/kv_transfer/kv_p2p/mooncake_connector.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_p2p/mooncake_connector.py
@@ -3119,6 +3119,10 @@ class MooncakeConnectorWorker:
         num_external_blocks_p = math.ceil(meta.num_external_tokens / remote_block_size)
 
         kv_group_items = list(self.kv_group2layeridx.items())
+        use_transfer_group_block_ids = transfer_groups_need_independent_block_ids(
+            self.kv_group2layeridx,
+            self.block_size_scale,
+        )
         sequence_group_idx = next(
             (
                 group_spec.get("kv_cache_group_id", group_idx)
@@ -3211,15 +3215,27 @@ class MooncakeConnectorWorker:
             shard_cp_rank = shard_cp_ranks[remote_kv_id]
             remote_first = (num_prefix_p_blocks - shard_cp_rank + remote_cp_size - 1) // remote_cp_size
 
-            group_remote_block_ids: list[list[int]] = []
-            group_local_block_ids: list[list[int]] = []
+            group_remote_block_ids: list[list[int]]
+            group_local_block_ids: list[list[int]]
+            if use_transfer_group_block_ids:
+                group_remote_block_ids = [[] for _ in self.kv_group2layeridx]
+                group_local_block_ids = [[] for _ in self.kv_group2layeridx]
+            else:
+                group_remote_block_ids = [[] for _ in meta.remote_block_ids]
+                group_local_block_ids = [[] for _ in meta.local_block_ids]
             is_final_shard = remote_kv_id == len(remote_handshake_port_list) - 1
             for group_idx, (group_spec, _) in kv_group_items:
+                kv_cache_group_id = self._get_kv_cache_group_id(group_idx, group_spec)
+                block_id_idx = group_idx if use_transfer_group_block_ids else kv_cache_group_id
                 if group_spec["kv_cache_spec_type"] == "MambaSpec":
                     # Mamba state is not context-block sharded like attention
                     # KV. Transfer the final state from the final PCP/DCP shard.
-                    group_remote_block_ids.append(list(meta.remote_block_ids[group_idx]) if is_final_shard else [])
-                    group_local_block_ids.append(list(meta.local_block_ids[group_idx]) if is_final_shard else [])
+                    group_remote_block_ids[block_id_idx] = (
+                        list(meta.remote_block_ids[kv_cache_group_id]) if is_final_shard else []
+                    )
+                    group_local_block_ids[block_id_idx] = (
+                        list(meta.local_block_ids[kv_cache_group_id]) if is_final_shard else []
+                    )
                     continue
                 # Attention: expand to kernel blocks here. Remote is sliced from remote_first
                 # (skips this rank's prefix-cached blocks) then expanded; local kernels are
@@ -3228,7 +3244,7 @@ class MooncakeConnectorWorker:
                 # n == 0, so both kernel lists naturally come out empty.
                 _, remote_scale, kernel_size = group_kernel_params[group_idx]
                 remote_logical = list(
-                    meta.remote_block_ids[group_idx][remote_first : remote_first + num_blocks_to_pull]
+                    meta.remote_block_ids[kv_cache_group_id][remote_first : remote_first + num_blocks_to_pull]
                 )
                 kernel_remote = self._expand_block_ids(remote_logical, remote_scale)
                 kernel_local = self._local_kernel_ids_for_shard(
@@ -3242,12 +3258,12 @@ class MooncakeConnectorWorker:
                     remote_cp_size,
                     remote_block_size,
                     kernel_size,
-                    list(meta.local_block_ids[group_idx]),
+                    list(meta.local_block_ids[kv_cache_group_id]),
                 )
                 num_kernel_blocks = min(len(kernel_remote), len(kernel_local))
-                group_remote_block_ids.append(kernel_remote[:num_kernel_blocks])
+                group_remote_block_ids[block_id_idx] = kernel_remote[:num_kernel_blocks]
 
-                group_local_block_ids.append(kernel_local[:num_kernel_blocks])
+                group_local_block_ids[block_id_idx] = kernel_local[:num_kernel_blocks]
             remote_block_ids_list.append(tuple(group_remote_block_ids))
             local_block_ids_list.append(tuple(group_local_block_ids))
 

--- a/vllm_ascend/distributed/kv_transfer/kv_p2p/mooncake_connector.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_p2p/mooncake_connector.py
@@ -530,7 +530,11 @@ class KVCacheRecvingThread(threading.Thread):
             hf_text_config = self.model_config.hf_config
         self.num_layers = hf_text_config.num_hidden_layers
         total_num_layers = self.vllm_config.model_config.get_total_num_hidden_layers()
-        self.index_cache_plane_base = total_num_layers if isinstance(total_num_layers, int) else self.num_layers
+        metadata_target_layers = total_num_layers if isinstance(total_num_layers, int) else self.num_layers
+        # Reserve one full metadata plane for MTP/Eagle layers so that the SFA
+        # plane is stable even when producer and consumer use different draft
+        # configurations.
+        self.index_cache_plane_base = metadata_target_layers * 2
         if block_size_scale is None:
             block_size_scale = []
         self.block_size_scale = block_size_scale
@@ -2271,11 +2275,14 @@ class MooncakeConnectorWorker:
             ]
         return serialized
 
-    _INDEX_CACHE_SUFFIX = ".index_cache"
+    def _is_index_cache_layer(self, layer_name: str) -> bool:
+        """Whether a layer needs the independent SFA metadata plane.
 
-    @classmethod
-    def _is_index_cache_layer(cls, layer_name: str) -> bool:
-        return cls._INDEX_CACHE_SUFFIX in layer_name
+        Indexer cache names are model-specific (for example ``.index_cache``
+        in MiniMax M3 and ``.indexer.k_cache`` in GLM-5.2), so identify the
+        physical layout from its cache spec instead of its name.
+        """
+        return isinstance(self._get_layer_spec(layer_name), AscendSFAIndexerCacheSpec)
 
     @staticmethod
     def _build_layer_specs_from_kv_cache_config(
@@ -2348,7 +2355,7 @@ class MooncakeConnectorWorker:
         kv_group2layeridx: dict[int, tuple[dict[str, Any], list[int]]] = {}
         model_type = self.vllm_config.model_config.hf_text_config.model_type
         num_attn_module = 2 if model_type in ("longcat_flash", "longcat_flash_ngram") else 1
-        index_cache_plane_base = self.total_layers
+        index_cache_plane_base = self.total_layers * 2
         next_mtp_layer_idx = self.total_layers
         transfer_group_id = 0
         for kv_cache_group_id, group_spec in enumerate(self.kv_cache_config.kv_cache_groups):
@@ -2363,8 +2370,7 @@ class MooncakeConnectorWorker:
                     layer_idx = next_mtp_layer_idx
                     next_mtp_layer_idx += 1
                 elif self._is_index_cache_layer(layer_name):
-                    parent_name = layer_name.replace(self._INDEX_CACHE_SUFFIX, ".attn")
-                    layer_idx = index_cache_plane_base + extract_layer_index(parent_name, num_attn_module)
+                    layer_idx = index_cache_plane_base + extract_layer_index(layer_name, num_attn_module)
                 else:
                     layer_idx = extract_layer_index(layer_name, num_attn_module)
                 layer_entries.append((layer_name, layer_idx))


### PR DESCRIPTION
### What this PR does / why we need it?

Backport of #13965 to `releases/v0.27.1rc`.

Mooncake request metadata stores block IDs by logical KV cache group, while Mooncake may split one KV cache group into multiple transfer groups. The CP path previously indexed scheduler block tables with the transfer-group index, which could cause an `IndexError` on the second transfer group.

The patch also isolates physical metadata planes for normal target KV, MTP/Eagle KV, and SFA/indexer KV. This prevents SFA (`scale=8`) and MLA (`scale=1`) transfer groups at the same transformer layer from sharing scale and expanded block-ID metadata.

### Backported commits

- `dac7f676a` `[BugFix][P/D] Fix Mooncake CP transfer group block IDs`
- `d4b724902` `[BugFix][P/D] Isolate SFA Mooncake metadata layout`
- `9a7ba208e` `[BugFix][P/D] Detect SFA metadata plane by cache spec`
- `36dcd8916` `[CI] Add receiver test type annotations`
- `9077b3c7b` `[CI] Preserve legacy SFA metadata indices`

The merge-from-main commit in the source PR was intentionally skipped. The five functional commits applied cleanly to `releases/v0.27.1rc`.

### Does this PR introduce _any_ user-facing change?

No API or configuration change. It fixes Mooncake KV loading for P/D-disaggregated CP deployments with split transfer groups.

### How was this patch tested?

- `git diff --check upstream/releases/v0.27.1rc..HEAD`
- `git cherry HEAD upstream/pr-13965` reports all five source commits as patch-equivalent (`-`).
- All five backport commits retain an author-matching `Signed-off-by` line.

The source patch was additionally exercised with a focused A3 four-node P/D smoke:

- 4 Atlas 800I A3 nodes, 16 NPUs per node
- nodes 0-1 prefill, nodes 2-3 decode
- DP=4 per plane (local DP=2), TP=8, DCP=8, Mooncake direct transfer
- model: `/mnt/share/weights/GLM-5.2-w4a8`
- image: `vllm-ascend:dev-26.2.0.day20260901-800I-A3-py311-Ubuntu24.04-lts-aarch64`
- all 8 serving ranks became ready
- the P/D proxy initialized 4 prefill and 4 decode instances
- `/healthcheck` and one `/v1/chat/completions` request both returned HTTP 200
- no `IndexError`, unregistered-address error, Mooncake error/failure, or traceback was found across the 8 rank logs

This was a focused smoke validation rather than a complete Weekly pass. The release backport itself has not been rerun on NPU; its runtime relevance is based on the patch-equivalent cherry-pick above and the source-patch smoke evidence.

- vLLM main: https://github.com/vllm-project/vllm/commit/ba07e4a48fc951300d97eb506217dd530583dea3
