### PR TITLE
[BugFix][Model] Fix DeepSeek V4 weight update in graph mode

### DIFF
--- a/vllm_ascend/ops/linear.py
+++ b/vllm_ascend/ops/linear.py
@@ -44,6 +44,7 @@ from vllm_ascend.device.hardware_profile import HardwareCapability, WeightLayout
 from vllm_ascend.ops.linear_op import get_parallel_op, get_replicated_op
 from vllm_ascend.utils import (
     maybe_trans_nz,
+    update_tensor_inplace,
 )
 from vllm_ascend.weight_switch import WeightSwitchGatherSpec, WeightSwitchMixin
 
@@ -96,17 +97,9 @@ class AscendUnquantizedLinearMethod(WeightSwitchMixin, UnquantizedLinearMethod):
         if getattr(layer, "precast_fp32_weight", False):
             weight_fp32 = layer.weight.data.to(torch.float32)
             new_fp32 = weight_fp32 if keep_nd_weight or skip_weight_nz_conversion else maybe_trans_nz(weight_fp32)
-            old_fp32 = getattr(layer, "weight_fp32", None)
-            if (
-                isinstance(old_fp32, torch.Tensor)
-                and old_fp32.data_ptr() != new_fp32.data_ptr()
-                and old_fp32.shape == new_fp32.shape
-                and old_fp32.dtype == new_fp32.dtype
-            ):
-                # RL weight-update path: copy the new weight to the existing fp32 weight tensor
-                old_fp32.copy_(new_fp32)
-            else:
-                layer.weight_fp32 = new_fp32
+            # keep the captured graph's weight reference to the updated weight
+            # during RL weight updates.
+            update_tensor_inplace(layer, "weight_fp32", new_fp32)
         if "conv1d" not in layer.prefix and not skip_weight_nz_conversion:
             # 310P torch_npu rejects FRACTAL_NZ matmul when the weight-side
             # matrix has n=1 or k=1. Keep scalar gates such as Qwen MoE's

--- a/vllm_ascend/ops/linear.py
+++ b/vllm_ascend/ops/linear.py
@@ -95,9 +95,18 @@ class AscendUnquantizedLinearMethod(WeightSwitchMixin, UnquantizedLinearMethod):
         # must use fp32 to avoid accuracy degradation in dsv4.
         if getattr(layer, "precast_fp32_weight", False):
             weight_fp32 = layer.weight.data.to(torch.float32)
-            layer.weight_fp32 = (
-                weight_fp32 if keep_nd_weight or skip_weight_nz_conversion else maybe_trans_nz(weight_fp32)
-            )
+            new_fp32 = weight_fp32 if keep_nd_weight or skip_weight_nz_conversion else maybe_trans_nz(weight_fp32)
+            old_fp32 = getattr(layer, "weight_fp32", None)
+            if (
+                isinstance(old_fp32, torch.Tensor)
+                and old_fp32.data_ptr() != new_fp32.data_ptr()
+                and old_fp32.shape == new_fp32.shape
+                and old_fp32.dtype == new_fp32.dtype
+            ):
+                # RL weight-update path: copy the new weight to the existing fp32 weight tensor
+                old_fp32.copy_(new_fp32)
+            else:
+                layer.weight_fp32 = new_fp32
         if "conv1d" not in layer.prefix and not skip_weight_nz_conversion:
             # 310P torch_npu rejects FRACTAL_NZ matmul when the weight-side
             # matrix has n=1 or k=1. Keep scalar gates such as Qwen MoE's

--- a/vllm_ascend/utils.py
+++ b/vllm_ascend/utils.py
@@ -712,6 +712,29 @@ def dispose_tensor(x: torch.Tensor):
     x.set_(torch.empty((0,), device=x.device, dtype=x.dtype))
 
 
+def update_tensor_inplace(layer: torch.nn.Module, name: str, new: torch.Tensor) -> None:
+    """Update ``layer.<name>`` to ``new`` while preserving tensor identity.
+
+    In graph mode (ACLGraph capture), the captured graph holds weight tensors
+    by reference. When weights are updated (e.g. in RL weight-update
+    scenarios) and ``process_weights_after_loading`` runs again, the new
+    values must be copied in-place into the existing tensor so captured
+    graphs keep referencing the updated weights. In all other cases, the
+    attribute is (re)assigned to ``new``.
+    """
+    old = getattr(layer, name, None)
+    if (
+        isinstance(old, torch.Tensor)
+        and old.data_ptr() != new.data_ptr()
+        and old.shape == new.shape
+        and old.dtype == new.dtype
+        and old.device == new.device
+    ):
+        old.copy_(new)
+    else:
+        setattr(layer, name, new)
+
+
 def register_ascend_customop(vllm_config: VllmConfig | None = None):
     """Register Ascend CustomOP
 


### PR DESCRIPTION
### What this PR does / why we need it?

`AscendUnquantizedLinearMethod.process_weights_after_loading` handles the `precast_fp32_weight` path for DeepSeek V4 by assigning a newly created fp32 weight tensor via `layer.weight_fp32 = new_fp32`.

In graph mode (ACLGraph capture), the captured graph holds weight tensors by reference. When the weights are updated (e.g., in RL weight-update scenarios) and `process_weights_after_loading` is called again, replacing the reference means the graph still holds the old tensor, so it keeps using stale weights and produces incorrect results.

This PR updates the `precast_fp32_weight` branch so that, when a `weight_fp32` tensor already exists , the new values are copied in-place via `copy_` instead of replacing the reference. This preserves tensor identity so that graphs captured in graph mode continue to reference the updated weights. All other cases fall back to the original create/assign logic.

### Does this PR introduce _any_ user-facing change?

No. 

### How was this patch tested?

- vLLM main: https://github.com/vllm-project/vllm/commit/84030bbe3d74d99bad477a3d2e37a973ccd8865c
