### PR TITLE
[Feature] Add global expert pool EPLB policy

### DIFF
--- a/tests/ut/eplb/adaptor/test_vllm_adaptor.py
+++ b/tests/ut/eplb/adaptor/test_vllm_adaptor.py
@@ -4,6 +4,7 @@ from unittest.mock import MagicMock, call, patch
 import torch
 from transformers import DeepseekV2Config
 
+from vllm_ascend.ascend_config import EplbConfig
 from vllm_ascend.eplb.adaptor.vllm_adaptor import EPLB_EXPERT_WEIGHT_NAMES, VllmEplbAdaptor
 from vllm_ascend.quantization.quant_type import QuantType
 
@@ -44,7 +45,7 @@ class TestVllmAdaptor(unittest.TestCase):
     @patch("torch.empty_like", return_value=torch.zeros(16, 32))
     @patch("vllm_ascend.eplb.adaptor.vllm_adaptor.get_ascend_config")
     def test_init_fp16(self, mock_get_config, mock_func):
-        mock_config = MagicMock()
+        mock_config = MagicMock(eplb_config=EplbConfig())
         mock_config.enable_fused_mc2 = 1
         mock_get_config.return_value = mock_config
         self.model.quant_config = None
@@ -56,7 +57,7 @@ class TestVllmAdaptor(unittest.TestCase):
     @patch("torch.empty_like", return_value=torch.zeros(16, 32))
     @patch("vllm_ascend.eplb.adaptor.vllm_adaptor.get_ascend_config")
     def test_init_fp16_with_parameter_accessor(self, mock_get_config, mock_func):
-        mock_config = MagicMock()
+        mock_config = MagicMock(eplb_config=EplbConfig())
         mock_config.enable_fused_mc2 = 1
         mock_get_config.return_value = mock_config
         self.model.quant_config = None
@@ -71,7 +72,7 @@ class TestVllmAdaptor(unittest.TestCase):
     @patch("torch.empty_like", return_value=torch.zeros(16, 32))
     @patch("vllm_ascend.eplb.adaptor.vllm_adaptor.get_ascend_config")
     def test_init_w8a8(self, mock_get_config, mock_func):
-        mock_config = MagicMock()
+        mock_config = MagicMock(eplb_config=EplbConfig())
         mock_config.enable_fused_mc2 = 0
         mock_get_config.return_value = mock_config
         VllmEplbAdaptor(self.model)
@@ -79,7 +80,7 @@ class TestVllmAdaptor(unittest.TestCase):
     @patch("torch.empty_like", return_value=torch.zeros(16, 32))
     @patch("vllm_ascend.eplb.adaptor.vllm_adaptor.get_ascend_config")
     def test_language_model_w8a8(self, mock_get_config, mock_func):
-        mock_config = MagicMock()
+        mock_config = MagicMock(eplb_config=EplbConfig())
         mock_config.enable_fused_mc2 = 0
         mock_get_config.return_value = mock_config
         model = MagicMock()
@@ -104,7 +105,7 @@ class TestVllmAdaptor(unittest.TestCase):
         VllmEplbAdaptor.register_layer(layer)
 
         with patch("vllm_ascend.eplb.adaptor.vllm_adaptor.get_ascend_config") as mock_get_config:
-            mock_config = MagicMock()
+            mock_config = MagicMock(eplb_config=EplbConfig())
             mock_config.enable_fused_mc2 = 0
             mock_get_config.return_value = mock_config
             model = MagicMock()
@@ -119,7 +120,7 @@ class TestVllmAdaptor(unittest.TestCase):
 
     @patch("vllm_ascend.eplb.adaptor.vllm_adaptor.get_ascend_config")
     def test_init_mixed_quant_type_per_layer(self, mock_get_config):
-        mock_config = MagicMock()
+        mock_config = MagicMock(eplb_config=EplbConfig())
         mock_config.enable_fused_mc2 = 1
         mock_get_config.return_value = mock_config
 
@@ -171,7 +172,7 @@ class TestVllmAdaptor(unittest.TestCase):
 
     @patch("vllm_ascend.eplb.adaptor.vllm_adaptor.get_ascend_config")
     def test_reused_buffer_requires_same_expert_weight_shape(self, mock_get_config):
-        mock_config = MagicMock()
+        mock_config = MagicMock(eplb_config=EplbConfig())
         mock_config.enable_fused_mc2 = 0
         mock_get_config.return_value = mock_config
 
@@ -198,6 +199,16 @@ class TestVllmAdaptor(unittest.TestCase):
 
         with self.assertRaisesRegex(AssertionError, "EPLB expert weight shapes mismatch"):
             VllmEplbAdaptor(model)
+
+    @patch("vllm_ascend.eplb.adaptor.vllm_adaptor.get_ascend_config")
+    def test_global_pool_rejects_fused_mc2(self, mock_get_config):
+        with patch.dict("os.environ", {"DYNAMIC_EPLB": "true"}):
+            eplb_config = EplbConfig(dynamic_eplb=True, eplb_policy_type=4, num_redundant_experts=1)
+        mock_get_config.return_value = MagicMock(enable_fused_mc2=1, eplb_config=eplb_config)
+        self.model.quant_config = None
+
+        with self.assertRaisesRegex(NotImplementedError, "fused MC2 disabled"):
+            VllmEplbAdaptor(self.model)
 
     def tearDown(self):
         self.mock_rank.stop()

--- a/tests/ut/eplb/core/policy/test_policy_layer.py
+++ b/tests/ut/eplb/core/policy/test_policy_layer.py
@@ -1,0 +1,31 @@
+# SPDX-License-Identifier: Apache-2.0
+import unittest
+
+import numpy as np
+
+from vllm_ascend.eplb.core.policy.layer_placement import _residual_placement_is_feasible
+from vllm_ascend.eplb.core.policy.policy_layer import LayerPlanner
+
+
+class TestLayerPlanner(unittest.TestCase):
+    def test_scores_replay_source_rank_routing(self):
+        table = np.array([[[0, 1], [0, 2]]])
+        heat = np.array([[8.0, 2.0, 6.0]])
+        # The replicated expert contributes four tokens per rank: loads 6, 10.
+        np.testing.assert_allclose(LayerPlanner._scores(table, heat, 3), [0.8])
+
+    def test_zero_heat_keeps_current_placement(self):
+        table = np.array([[[0, 1], [0, 2]]])
+        planner = LayerPlanner(1)
+        for _ in range(3):
+            decision = planner.plan(table, np.zeros_like(table))
+            self.assertFalse(decision.should_apply)
+            np.testing.assert_array_equal(decision.placement, table)
+
+    def test_residual_placement_respects_existing_copy(self):
+        self.assertTrue(_residual_placement_is_feasible(np.array([1, 1]), np.array([1, 1]), [{0}, set()]))
+        self.assertFalse(_residual_placement_is_feasible(np.array([1, 1]), np.array([2, 0]), [{0}, set()]))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/ut/ops/test_moe_mlp.py
+++ b/tests/ut/ops/test_moe_mlp.py
@@ -336,6 +336,30 @@ class TestUnquantizedFusedMoEMethod(unittest.TestCase):
         method._lora_routing = None
         return method
 
+    def test_shared_pool_weight_lists_in_both_projections(self):
+        method = self._make_method()
+        for need_trans in (False, True):
+            with self.subTest(need_trans=need_trans):
+                layer = SimpleNamespace(
+                    w13_weight_list=[torch.randn(8, 16) for _ in range(3)],
+                    w2_weight_list=[torch.randn(16, 8) for _ in range(3)],
+                )
+                mlp_input = _mlp_compute_input(layer=layer, need_trans=need_trans)
+                with patch("torch_npu.npu_grouped_matmul", return_value=[torch.randn(4, 8)], create=True) as gmm:
+                    gate_up = method.apply_gmm1(mlp_input)
+                    method.apply_gmm2(mlp_input, gate_up, None)
+                for call, weights in zip(gmm.call_args_list, (layer.w13_weight_list, layer.w2_weight_list)):
+                    actual = call.kwargs["weight"]
+                    self.assertEqual(len(actual), len(weights))
+                    for result, original in zip(actual, weights):
+                        expected = original.transpose(0, 1) if need_trans else original
+                        torch.testing.assert_close(result, expected)
+
+    def test_transpose_preserves_batched_weight_list_support(self):
+        weights = [torch.randn(1, 8, 16)]
+        result = self._make_method()._maybe_transpose(weights, True)
+        torch.testing.assert_close(result[0], weights[0].transpose(1, 2))
+
     def test_apply_gmm1_transposes_and_runs_grouped_matmul(self):
         method = self._make_method()
         layer = SimpleNamespace(
@@ -506,6 +530,17 @@ class TestApplyMoeMlp(unittest.TestCase):
 
 
 class TestUnifiedApplyActivation(unittest.TestCase):
+    def test_swigluoai_accepts_shared_pool_weight_lists(self):
+        quant_method = MagicMock()
+        quant_method.get_mlp_weights.return_value = ([torch.randn(8, 16)], [torch.randn(16, 8)])
+        hidden_states = torch.randn(4, 16)
+        with patch(f"{MOE_MLP}.AscendSwigluOAIAndMul.swiglu_oai_forward", return_value="out") as activation:
+            out = _unified_apply_activation(
+                _mlp_compute_input(activation=MoEActivation.SWIGLUOAI), hidden_states, quant_method
+            )
+        self.assertEqual(out, "out")
+        torch.testing.assert_close(activation.call_args.args[0], hidden_states)
+
     def _quant_method(self):
         quant_method = MagicMock()
         quant_method.get_mlp_weights.return_value = (torch.randn(2, 8, 16), torch.randn(2, 16, 8))

--- a/tests/ut/patch/platform/test_patch_fused_moe.py
+++ b/tests/ut/patch/platform/test_patch_fused_moe.py
@@ -73,6 +73,7 @@ def test_factory_keeps_v1_eplb_on_the_legacy_routing_path():
             dynamic_eplb=True,
             expert_map_path=None,
             num_redundant_experts=2,
+            uses_global_expert_pool=False,
         )
     )
 

--- a/vllm_ascend/ascend_config.py
+++ b/vllm_ascend/ascend_config.py
@@ -121,10 +121,17 @@ class EplbConfig:
     num_redundant_experts: int = 0
     eplb_policy_type: int = 2
     eplb_heat_collection_stage: str = "all"
+    # Policy 4 uses a cross-layer pool on P nodes and conventional per-layer
+    # redundant experts on D nodes.
+    eplb_node_role: Literal["prefill", "decode"] = "prefill"
     # Model Runner V2 only. Restricts which batch phase contributes to the
     # upstream EPLB expert-load window; any prefill request marks the batch
     # as prefill.
     load_collection_phase: str = "all"
+
+    @property
+    def uses_global_expert_pool(self) -> bool:
+        return self.dynamic_eplb and self.eplb_policy_type == 4 and self.eplb_node_role == "prefill"
 
     @model_validator(mode="after")
     def _validate_config(self):
@@ -146,8 +153,20 @@ class EplbConfig:
                 raise TypeError(f"{key} must be an integer")
             if value < 0:
                 raise ValueError(f"{key} must greater than 0; got {value} instead")
-        if self.eplb_policy_type not in [0, 1, 2, 3]:
-            raise ValueError("eplb_policy_type must in [0, 1, 2, 3]")
+        if self.eplb_policy_type not in [0, 1, 2, 3, 4]:
+            raise ValueError("eplb_policy_type must be one of [0, 1, 2, 3, 4]")
+        if self.eplb_policy_type == 4:
+            if not self.dynamic_eplb:
+                raise ValueError("eplb_policy_type 4 requires dynamic_eplb")
+            if self.num_redundant_experts <= 0:
+                raise ValueError("eplb_policy_type 4 requires a positive num_redundant_experts")
+            if self.eplb_heat_collection_stage == "all":
+                self.eplb_heat_collection_stage = self.eplb_node_role
+            elif self.eplb_heat_collection_stage != self.eplb_node_role:
+                raise ValueError(
+                    "eplb_policy_type 4 requires eplb_heat_collection_stage "
+                    "to match eplb_node_role"
+                )
         if self.dynamic_eplb:
             assert (
                 os.getenv("DYNAMIC_EPLB", "false").lower() in ("true", "1")

--- a/vllm_ascend/ascend_config.py
+++ b/vllm_ascend/ascend_config.py
@@ -163,10 +163,7 @@ class EplbConfig:
             if self.eplb_heat_collection_stage == "all":
                 self.eplb_heat_collection_stage = self.eplb_node_role
             elif self.eplb_heat_collection_stage != self.eplb_node_role:
-                raise ValueError(
-                    "eplb_policy_type 4 requires eplb_heat_collection_stage "
-                    "to match eplb_node_role"
-                )
+                raise ValueError("eplb_policy_type 4 requires eplb_heat_collection_stage to match eplb_node_role")
         if self.dynamic_eplb:
             assert (
                 os.getenv("DYNAMIC_EPLB", "false").lower() in ("true", "1")

--- a/vllm_ascend/eplb/adaptor/vllm_adaptor.py
+++ b/vllm_ascend/eplb/adaptor/vllm_adaptor.py
@@ -97,20 +97,118 @@ class VllmEplbAdaptor:
 
         # Get num_local_experts from first real MoE layer
         first_layer = self.moe_layers[0]
+        eplb_config = get_ascend_config().eplb_config
+        self.global_slots_per_rank = (
+            eplb_config.num_redundant_experts if eplb_config.uses_global_expert_pool else 0
+        )
         self.num_local_experts = first_layer.local_num_experts
+        self.base_num_local_experts = self.num_local_experts
         self.ep_rank = first_layer.ep_rank
+        self.ep_size = first_layer.moe_config.ep_size
 
         self.expert_param_per_layer = dict()
         self.expert_weight_key_per_layer = dict()
         self.init_expert_param_per_layer()
+        if self.global_slots_per_rank:
+            self._init_global_slot_pool(self.global_slots_per_rank)
+            self.num_local_experts += self.global_slots_per_rank
+            self.init_expert_param_per_layer()
+            self._resize_initial_log2phy_maps()
 
-        num_buffer_tensor = self.num_local_experts
+        num_buffer_tensor = 0 if self.global_slots_per_rank else self.num_local_experts
         self.buffer_tensor_list: dict[Any, list[list[Any]]] = dict()
         self.init_buffer_tensor(num_buffer_tensor)
 
         self.log2phy_map_per_layer = dict()
         for local_idx, layer in enumerate(self.moe_layers):
             self.log2phy_map_per_layer[local_idx] = layer.get_log2phy_map()
+
+    def _init_global_slot_pool(self, slots_per_rank: int) -> None:
+        """Allocate one per-rank expert pool shared by every local MoE layer."""
+        first_layer = self.moe_layers[0]
+        first_weight_key = self.expert_weight_key_per_layer[0]
+        if first_weight_key != (QuantType.NONE, False):
+            raise NotImplementedError(
+                "EPLB policy 4 currently supports unquantized weights with fused MC2 disabled only"
+            )
+        weight_names = EPLB_EXPERT_WEIGHT_NAMES[first_weight_key]
+        pool: dict[str, list[torch.Tensor]] = {}
+        for name in weight_names:
+            source = self.param_dict[f"0.{name}"]
+            if len(source) != self.base_num_local_experts:
+                raise ValueError(
+                    f"Unexpected base expert count for {name}: "
+                    f"expected {self.base_num_local_experts}, got {len(source)}"
+                )
+            pool[name] = []
+            for slot_id in range(slots_per_rank):
+                buffer_name = f"_eplb_global_{name}_{slot_id}"
+                first_layer.register_buffer(
+                    buffer_name,
+                    torch.empty_like(source[0]),
+                    persistent=False,
+                )
+                pool[name].append(getattr(first_layer, buffer_name))
+
+        global_redundancy = slots_per_rank * self.ep_size
+        for local_idx, layer in enumerate(self.moe_layers):
+            if self.expert_weight_key_per_layer[local_idx] != first_weight_key:
+                raise ValueError("EPLB policy 4 requires identical expert weight formats across MoE layers")
+            for name in weight_names:
+                values = self.param_dict[f"{local_idx}.{name}"]
+                expected_shape = pool[name][0].shape
+                if values[0].shape != expected_shape:
+                    raise ValueError(f"EPLB policy 4 requires identical {name} shapes across MoE layers")
+                if isinstance(values, list):
+                    values.extend(pool[name])
+                elif torch.is_tensor(values):
+                    setattr(
+                        layer,
+                        f"{name}_list",
+                        [values[expert_id] for expert_id in range(self.base_num_local_experts)] + pool[name],
+                    )
+                else:
+                    raise TypeError(
+                        f"Unsupported EPLB policy 4 expert weight container for {name}: {type(values).__name__}"
+                    )
+
+            layer.moe_config.num_local_experts += slots_per_rank
+            layer.moe_config.num_experts += global_redundancy
+            layer.moe_config.global_redundant_expert_num += global_redundancy
+            layer.global_redundant_expert_num += global_redundancy
+            layer.moe_load = torch.cat(
+                (
+                    layer.moe_load,
+                    torch.zeros(
+                        slots_per_rank,
+                        dtype=layer.moe_load.dtype,
+                        device=layer.moe_load.device,
+                    ),
+                )
+            )
+
+        from vllm_ascend.ops.fused_moe.moe_comm_method import resize_moe_comm_expert_layout
+
+        resize_moe_comm_expert_layout(
+            first_layer.moe_config.num_experts,
+            self.base_num_local_experts + slots_per_rank,
+        )
+        self.global_slot_pool = pool
+
+    def _resize_initial_log2phy_maps(self) -> None:
+        """Account for the shared slots in each rank's physical stride."""
+        expanded_slots = self.base_num_local_experts + self.global_slots_per_rank
+        for layer in self.moe_layers:
+            log2phy_map = layer.get_log2phy_map()
+            if log2phy_map is None:
+                continue
+            rank_ids = torch.div(
+                log2phy_map,
+                self.base_num_local_experts,
+                rounding_mode="floor",
+            )
+            local_ids = torch.remainder(log2phy_map, self.base_num_local_experts)
+            log2phy_map.copy_(rank_ids * expanded_slots + local_ids)
 
     def init_buffer_tensor(self, num_buffer_tensor):
         buffer_tensor_shapes: dict[Any, list[torch.Size]] = dict()

--- a/vllm_ascend/eplb/adaptor/vllm_adaptor.py
+++ b/vllm_ascend/eplb/adaptor/vllm_adaptor.py
@@ -98,9 +98,7 @@ class VllmEplbAdaptor:
         # Get num_local_experts from first real MoE layer
         first_layer = self.moe_layers[0]
         eplb_config = get_ascend_config().eplb_config
-        self.global_slots_per_rank = (
-            eplb_config.num_redundant_experts if eplb_config.uses_global_expert_pool else 0
-        )
+        self.global_slots_per_rank = eplb_config.num_redundant_experts if eplb_config.uses_global_expert_pool else 0
         self.num_local_experts = first_layer.local_num_experts
         self.base_num_local_experts = self.num_local_experts
         self.ep_rank = first_layer.ep_rank

--- a/vllm_ascend/eplb/core/eplb_device_transfer_loader.py
+++ b/vllm_ascend/eplb/core/eplb_device_transfer_loader.py
@@ -16,6 +16,7 @@
 #
 from enum import Enum
 
+import torch
 import torch.distributed as dist
 from vllm.logger import logger
 from vllm.v1.utils import record_function_or_nullcontext
@@ -42,6 +43,65 @@ class D2DExpertWeightLoader:
 
     def set_adator(self, eplb_adaptor):
         self.eplb_adaptor = eplb_adaptor
+
+    def initialize_redundant_expert_weights(self):
+        """Populate per-layer redundant slots before they become routable.
+
+        Fused expert checkpoints load the original experts as one 3D tensor,
+        so upstream's per-expert mapping cannot duplicate the trailing physical
+        slots. Initialize those slots from the original physical experts with
+        the same P2P path used by runtime migrations.
+        """
+        adaptor = self.eplb_adaptor
+        if not adaptor.moe_layers:
+            return
+
+        moe_config = adaptor.moe_layers[0].moe_config
+        num_logical_experts = int(moe_config.num_logical_experts)
+        num_physical_experts = int(moe_config.num_experts)
+        num_redundant_experts = num_physical_experts - num_logical_experts
+        if num_redundant_experts <= 0:
+            return
+
+        local_capacity = adaptor.num_local_experts
+        if num_physical_experts != local_capacity * adaptor.ep_size:
+            raise ValueError(
+                "Initial redundant expert layout must be evenly distributed: "
+                f"physical={num_physical_experts}, local={local_capacity}, ep={adaptor.ep_size}."
+            )
+
+        rank = adaptor.ep_rank
+        step = {"send": [], "recv": []}
+        local_copies = []
+        for layer_id in range(adaptor.num_moe_layers):
+            for redundant_id in range(num_redundant_experts):
+                logical_id = redundant_id % num_logical_experts
+                src_rank, source_slot = divmod(logical_id, local_capacity)
+                dst_rank, target_slot = divmod(num_logical_experts + redundant_id, local_capacity)
+                if src_rank == dst_rank:
+                    if rank == src_rank:
+                        local_copies.append((layer_id, source_slot, target_slot))
+                elif rank == src_rank:
+                    step["send"].append((dst_rank, layer_id, source_slot))
+                elif rank == dst_rank:
+                    step["recv"].append((src_rank, layer_id, target_slot))
+
+        for layer_id, source_slot, target_slot in local_copies:
+            for source_tensor, target_tensor in zip(
+                adaptor.expert_param_per_layer[layer_id][source_slot],
+                adaptor.expert_param_per_layer[layer_id][target_slot],
+            ):
+                target_tensor.copy_(source_tensor)
+
+        requests = self.start_global_slot_transfer(step)
+        for request in requests:
+            request.wait()
+        if rank == 0:
+            logger.info(
+                "[eplb/d2d_loader] Initialized %s redundant experts across %s layers",
+                num_redundant_experts,
+                adaptor.num_moe_layers,
+            )
 
     def generate_expert_d2d_transfer_task(self, expert_send_info, expert_recv_info, updated_expert_map, layer_id):
         # When current send/recv and weight.expert_map update tasks are not finished, cannot accept new d2d task
@@ -136,3 +196,43 @@ class D2DExpertWeightLoader:
         self.updated_expert_map = None
         self.layer_id = -1
         self.state = ExpertWeightUpdateState.WAITING
+
+    def apply_global_map_updates(self, updates):
+        """Apply the map half of one staged policy-4 transaction."""
+        for update in updates:
+            layer_id = update["layer_id"]
+            self.eplb_adaptor.do_update_expert_map(layer_id, torch.tensor(update["rank_map"], dtype=torch.int32))
+            self.eplb_adaptor.do_update_log2phy_map(layer_id, torch.tensor(update["log2phy_map"], dtype=torch.int32))
+
+    def start_global_slot_transfer(self, step):
+        """Start D2D into slots deactivated before this model iteration."""
+        comm_ops = []
+        for dst_rank, relative_layer, source_slot in step["send"]:
+            layer_id = relative_layer
+            for source_tensor in self.eplb_adaptor.expert_param_per_layer[layer_id][source_slot]:
+                comm_ops.append(
+                    dist.P2POp(
+                        dist.isend,
+                        source_tensor,
+                        self.comm_group.ranks[dst_rank],
+                        group=self.comm_group.device_group,
+                    )
+                )
+        for src_rank, relative_layer, target_slot in step["recv"]:
+            layer_id = relative_layer
+            for target_tensor in self.eplb_adaptor.expert_param_per_layer[layer_id][target_slot]:
+                comm_ops.append(
+                    dist.P2POp(
+                        dist.irecv,
+                        target_tensor,
+                        self.comm_group.ranks[src_rank],
+                        group=self.comm_group.device_group,
+                    )
+                )
+        return dist.batch_isend_irecv(comm_ops) if comm_ops else []
+
+    def finish_global_slot_transfer(self, requests, step):
+        """Wait for staged weights, then expose them to token routing."""
+        for request in requests:
+            request.wait()
+        self.apply_global_map_updates(step["activate"])

--- a/vllm_ascend/eplb/core/eplb_device_transfer_loader.py
+++ b/vllm_ascend/eplb/core/eplb_device_transfer_loader.py
@@ -71,7 +71,7 @@ class D2DExpertWeightLoader:
             )
 
         rank = adaptor.ep_rank
-        step = {"send": [], "recv": []}
+        step: dict[str, list[tuple[int, int, int]]] = {"send": [], "recv": []}
         local_copies = []
         for layer_id in range(adaptor.num_moe_layers):
             for redundant_id in range(num_redundant_experts):

--- a/vllm_ascend/eplb/core/eplb_global_worker.py
+++ b/vllm_ascend/eplb/core/eplb_global_worker.py
@@ -1,0 +1,214 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Atomic update-plan construction for policy-4 shared expert slots."""
+
+from __future__ import annotations
+
+import numpy as np
+import torch
+from vllm.logger import logger
+
+_GLOBAL_SLOT_BATCH_PER_RANK = 4
+
+
+def _global_maps_to_table(global_maps: np.ndarray, local_slots: int) -> np.ndarray:
+    num_layers, num_ranks, num_experts = global_maps.shape
+    table = np.full((num_layers, num_ranks, local_slots), -1, dtype=np.int64)
+    for layer_id in range(num_layers):
+        for rank_id in range(num_ranks):
+            for expert_id in range(num_experts):
+                local_slot = int(global_maps[layer_id, rank_id, expert_id])
+                if local_slot < 0:
+                    continue
+                if local_slot >= local_slots or table[layer_id, rank_id, local_slot] >= 0:
+                    raise ValueError("invalid global expert map for policy 4")
+                table[layer_id, rank_id, local_slot] = expert_id
+    return table
+
+
+def _table_to_global_maps(table: np.ndarray, num_experts: int) -> np.ndarray:
+    maps = np.full((table.shape[0], table.shape[1], num_experts), -1, dtype=np.int32)
+    for layer_id in range(table.shape[0]):
+        for rank_id in range(table.shape[1]):
+            for local_slot, expert_id in enumerate(table[layer_id, rank_id]):
+                if expert_id < 0:
+                    continue
+                if maps[layer_id, rank_id, expert_id] >= 0:
+                    raise ValueError("a rank cannot hold two copies of one logical expert")
+                maps[layer_id, rank_id, expert_id] = local_slot
+    return maps
+
+
+def _log2phy_map(global_map: np.ndarray, ep_rank: int, local_slots: int) -> list[int]:
+    result = np.empty(global_map.shape[1], dtype=np.int32)
+    for expert_id in range(global_map.shape[1]):
+        holders = [
+            int(global_map[rank_id, expert_id]) + rank_id * local_slots
+            for rank_id in range(global_map.shape[0])
+            if global_map[rank_id, expert_id] >= 0
+        ]
+        if not holders:
+            raise ValueError(f"logical expert {expert_id} has no physical copy")
+        result[expert_id] = holders[ep_rank % len(holders)]
+    return result.tolist()
+
+
+def _layer_updates(
+    global_maps: np.ndarray,
+    layer_ids: set[int],
+    rank_id: int,
+    local_slots: int,
+) -> list[dict]:
+    return [
+        {
+            "layer_id": layer_id,
+            "rank_map": global_maps[layer_id, rank_id].tolist(),
+            "log2phy_map": _log2phy_map(global_maps[layer_id], rank_id, local_slots),
+        }
+        for layer_id in sorted(layer_ids)
+    ]
+
+
+def do_global_slot_update(worker):
+    global_maps_value = worker.shared_dict.get("expert_maps", None)
+    workload_value = worker.shared_dict.get("moe_load", None)
+    if global_maps_value is None or workload_value is None:
+        return {"kind": "global_slots", "changed": False}
+    global_maps = np.asarray(
+        global_maps_value.numpy() if isinstance(global_maps_value, torch.Tensor) else global_maps_value,
+        dtype=np.int32,
+    )
+    workload = np.asarray(
+        workload_value.numpy() if isinstance(workload_value, torch.Tensor) else workload_value,
+        dtype=np.float64,
+    )
+    local_slots = workload.shape[-1]
+    old_table = _global_maps_to_table(global_maps, local_slots)
+    changed, _, placement = worker.policy.rebalance_experts(old_table, workload)
+    decision = getattr(worker.policy, "last_decision", None)
+    if not changed:
+        if worker.rank_id == 0 and decision is not None:
+            logger.debug(
+                "[eplb/global] Skip plan reason=%s gain=%.6f changed_slots=%s",
+                decision.reason,
+                decision.gain,
+                decision.changed_slots,
+            )
+        return {"kind": "global_slots", "changed": False}
+
+    new_table = np.asarray(placement, dtype=np.int64)
+    num_layers, num_ranks, _ = new_table.shape
+    num_experts = global_maps.shape[-1]
+    base_slots = num_experts // num_ranks
+    new_maps = _table_to_global_maps(new_table, num_experts)
+    transitions_by_slot: list[list[dict]] = [[] for _ in range(local_slots - base_slots)]
+    for dst_rank in range(num_ranks):
+        for shared_slot in range(local_slots - base_slots):
+            local_slot = base_slots + shared_slot
+            old_owners = [
+                (layer_id, int(old_table[layer_id, dst_rank, local_slot]))
+                for layer_id in range(num_layers)
+                if old_table[layer_id, dst_rank, local_slot] >= 0
+            ]
+            new_owners = [
+                (layer_id, int(new_table[layer_id, dst_rank, local_slot]))
+                for layer_id in range(num_layers)
+                if new_table[layer_id, dst_rank, local_slot] >= 0
+            ]
+            if len(old_owners) > 1 or len(new_owners) > 1:
+                raise ValueError("a global physical slot cannot be owned by multiple layers")
+            old_owner = old_owners[0] if old_owners else None
+            new_owner = new_owners[0] if new_owners else None
+            if new_owner == old_owner:
+                continue
+            transitions_by_slot[shared_slot].append(
+                {
+                    "dst_rank": dst_rank,
+                    "local_slot": local_slot,
+                    "old_owner": old_owner,
+                    "new_owner": new_owner,
+                }
+            )
+
+    working_maps = global_maps.copy()
+    steps: list[dict] = []
+    for first_slot in range(0, len(transitions_by_slot), _GLOBAL_SLOT_BATCH_PER_RANK):
+        transitions = [
+            transition
+            for slot_transitions in transitions_by_slot[first_slot : first_slot + _GLOBAL_SLOT_BATCH_PER_RANK]
+            for transition in slot_transitions
+        ]
+        if not transitions:
+            continue
+
+        deactivate_layers: set[int] = set()
+        for transition in transitions:
+            old_owner = transition["old_owner"]
+            if old_owner is None:
+                continue
+            layer_id, expert_id = old_owner
+            dst_rank = transition["dst_rank"]
+            local_slot = transition["local_slot"]
+            if working_maps[layer_id, dst_rank, expert_id] != local_slot:
+                raise ValueError("policy 4 old slot owner does not match the active map")
+            working_maps[layer_id, dst_rank, expert_id] = -1
+            deactivate_layers.add(layer_id)
+        deactivated_maps = working_maps.copy()
+
+        send: list[list[int]] = []
+        recv: list[list[int]] = []
+        activate_layers: set[int] = set()
+        for transition in transitions:
+            new_owner = transition["new_owner"]
+            if new_owner is None:
+                continue
+            layer_id, expert_id = new_owner
+            dst_rank = transition["dst_rank"]
+            local_slot = transition["local_slot"]
+            source_locations = np.argwhere(new_table[layer_id, :, :base_slots] == expert_id)
+            if source_locations.shape[0] != 1:
+                raise ValueError("policy 4 requires one immutable base source for every expert")
+            src_rank, source_slot = (int(value) for value in source_locations[0])
+            if worker.rank_id == src_rank:
+                send.append([dst_rank, layer_id, source_slot])
+            if worker.rank_id == dst_rank:
+                recv.append([src_rank, layer_id, local_slot])
+            working_maps[layer_id, dst_rank, expert_id] = local_slot
+            activate_layers.add(layer_id)
+
+        steps.append(
+            {
+                "deactivate": _layer_updates(
+                    deactivated_maps,
+                    deactivate_layers,
+                    worker.rank_id,
+                    local_slots,
+                ),
+                "send": send,
+                "recv": recv,
+                "activate": _layer_updates(working_maps, activate_layers, worker.rank_id, local_slots),
+                "changed_slots": len(transitions),
+            }
+        )
+
+    if not np.array_equal(working_maps, new_maps):
+        raise ValueError("policy 4 staged update does not reach the planned map")
+
+    changed_layers = int(np.count_nonzero(np.any(new_table != old_table, axis=(1, 2))))
+    if worker.rank_id == 0:
+        logger.info(
+            "[eplb/global] Apply plan gain=%.6f changed_slots=%s changed_layers=%s steps=%s active_slots=%s",
+            decision.gain if decision is not None else 0.0,
+            decision.changed_slots if decision is not None else sum(step["changed_slots"] for step in steps),
+            changed_layers,
+            len(steps),
+            int(np.count_nonzero(new_table[:, :, base_slots:] >= 0)),
+        )
+    return {
+        "kind": "global_slots",
+        "changed": True,
+        "steps": steps,
+        "global_maps": new_maps.tolist(),
+    }
+
+
+__all__ = ["do_global_slot_update"]

--- a/vllm_ascend/eplb/core/eplb_worker.py
+++ b/vllm_ascend/eplb/core/eplb_worker.py
@@ -33,17 +33,26 @@ class EplbWorker:
         policy_type,
         enable_d2d: bool = True,
         tp_size: int | None = None,
+        policy_config: dict | None = None,
     ):
         self.policy_type = policy_type
-        self.policy = PolicyFactory.generate_policy(policy_type)
+        self.policy = PolicyFactory.generate_policy(policy_type, policy_config)
         self.shared_dict = shared_dict
         self.old_expert_maps = None
         self.enable_d2d = enable_d2d
         self.tp_size = tp_size
         self.rank_id = get_ep_group().rank_in_group
         self.multi_stage = policy_type == 3
+        self.uses_global_expert_pool = (
+            policy_type == 4 and (policy_config or {}).get("node_role", "prefill") == "prefill"
+        )
 
     def do_update(self):
+        if self.uses_global_expert_pool:
+            torch.set_num_threads(1)
+            from vllm_ascend.eplb.core.eplb_global_worker import do_global_slot_update
+
+            return do_global_slot_update(self)
         # put data in to queue
         # in process self.policy.generate_policy()
         # get epxert table && tensor
@@ -341,12 +350,14 @@ class EplbProcess:
         policy_type: int = 0,
         enable_d2d: bool = True,
         tp_size: int | None = None,
+        policy_config: dict | None = None,
     ):
         """
         Args:
             shared_dict: Cross-process shared dict returned by Manager().dict()
             policy_type: Integer passed to PolicyFactory.generate_policy
             enable_d2d: Whether to enable D2D loading
+            policy_config: Optional constructor arguments for the selected policy
         """
         self.shared_dict = shared_dict
         self.policy_type = policy_type
@@ -360,6 +371,7 @@ class EplbProcess:
             self.policy_type,
             self.enable_d2d,
             tp_size=tp_size,
+            policy_config=policy_config,
         )
 
     def worker_process(self, planner_q, block_update_q):
@@ -386,11 +398,7 @@ class EplbProcess:
 
                 packed_update_info = self.worker.do_update()
 
-                while True:
-                    if not block_update_q.empty():
-                        continue
-                    block_update_q.put(packed_update_info)
-                    break
+                block_update_q.put(packed_update_info)
 
             except Exception as e:
                 logger.warning(

--- a/vllm_ascend/eplb/core/policy/layer_placement.py
+++ b/vllm_ascend/eplb/core/policy/layer_placement.py
@@ -1,0 +1,558 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# Capacity-aware per-layer expert placement utilities.
+#
+# This module intentionally has no dependency on torch or the EPLB runtime.  It
+# can therefore be used by an offline map builder and by a background dynamic
+# policy worker without importing device libraries.
+
+from __future__ import annotations
+
+from typing import Sequence
+
+import numpy as np
+
+
+Placement = tuple[tuple[np.ndarray, ...], ...]
+
+
+def _strict_integer(value: object, name: str, *, minimum: int | None = None) -> int:
+    if isinstance(value, (bool, np.bool_)) or not isinstance(value, (int, np.integer)):
+        raise TypeError(f"{name} must be an integer")
+    result = int(value)
+    if minimum is not None and result < minimum:
+        raise ValueError(f"{name} must be at least {minimum}, got {result}")
+    return result
+
+
+def _strict_integer_array(value: object, name: str, *, ndim: int | None = None) -> np.ndarray:
+    result = np.asarray(value)
+    if result.dtype == np.bool_ or not np.issubdtype(result.dtype, np.integer):
+        raise TypeError(f"{name} must contain only integers")
+    if ndim is not None and result.ndim != ndim:
+        raise ValueError(f"{name} must be {ndim}-dimensional")
+    return result.astype(np.int64, copy=False)
+
+
+def _normalise_load(expert_load: np.ndarray | Sequence[object]) -> np.ndarray:
+    raw_load = np.asarray(expert_load)
+    if raw_load.dtype == np.bool_:
+        raise TypeError("expert_load must be numeric, not boolean")
+    load = np.asarray(expert_load, dtype=np.float64)
+    if load.ndim == 2:
+        load = load[np.newaxis, ...]
+    if load.ndim != 3:
+        raise ValueError(
+            "expert_load must have shape [layers, experts] or "
+            f"[batches, layers, experts], got {load.shape}"
+        )
+    if 0 in load.shape:
+        raise ValueError(f"expert_load dimensions must be non-zero, got {load.shape}")
+    if not np.all(np.isfinite(load)):
+        raise ValueError("expert_load must contain only finite values")
+    if np.any(load < 0):
+        raise ValueError("expert_load must be non-negative")
+    return load
+
+
+def capacity_aware_interleaving(
+    physical_experts_by_layer: Sequence[int] | np.ndarray,
+    num_ranks: int,
+) -> np.ndarray:
+    """Distribute variable layer capacities while balancing total rank memory.
+
+    This is Algorithm 3 from layer-aware, applied to total physical experts.  Applying
+    it to total experts is equivalent to applying it to replicas when the
+    logical expert count is divisible by the EP rank count, and also handles
+    the non-divisible case.
+    """
+
+    totals = _strict_integer_array(
+        physical_experts_by_layer,
+        "physical_experts_by_layer",
+        ndim=1,
+    )
+    if totals.ndim != 1 or totals.size == 0:
+        raise ValueError("physical_experts_by_layer must be a non-empty vector")
+    if np.any(totals < 0):
+        raise ValueError("physical expert counts must be non-negative")
+    num_ranks = _strict_integer(num_ranks, "num_ranks", minimum=1)
+
+    base = totals // num_ranks
+    remainder = totals % num_ranks
+    capacity = np.repeat(base[:, np.newaxis], num_ranks, axis=1)
+    rank_totals = capacity.sum(axis=0)
+
+    for layer, count in enumerate(remainder.tolist()):
+        if count == 0:
+            continue
+        ordered = np.argsort(rank_totals, kind="stable")
+        cutoff = rank_totals[ordered[count - 1]]
+        must_choose = np.flatnonzero(rank_totals < cutoff)
+        tied = np.flatnonzero(rank_totals == cutoff)
+        tie_count = count - must_choose.size
+        if tie_count:
+            positions = np.linspace(0, tied.size - 1, tie_count).astype(np.int64)
+            selected = np.concatenate((must_choose, tied[positions]))
+        else:
+            selected = must_choose
+        capacity[layer, selected] += 1
+        rank_totals[selected] += 1
+
+    return capacity
+
+
+def _replicate_layer(
+    logical_load: np.ndarray,
+    num_replicas: int,
+    num_ranks: int,
+) -> tuple[np.ndarray, np.ndarray]:
+    """Select replicas by repeatedly splitting the hottest effective expert."""
+
+    num_replicas = _strict_integer(num_replicas, "num_replicas", minimum=0)
+    num_ranks = _strict_integer(num_ranks, "num_ranks", minimum=1)
+    num_experts = logical_load.size
+    max_replicas = num_experts * (num_ranks - 1)
+    if num_replicas < 0 or num_replicas > max_replicas:
+        raise ValueError(
+            "infeasible replica budget: each logical expert may have at most "
+            f"{num_ranks} total copies, so at most {max_replicas} additional "
+            f"replicas are possible; got {num_replicas}"
+        )
+
+    copy_count = np.ones(num_experts, dtype=np.int64)
+    replicas: list[int] = []
+    for _ in range(num_replicas):
+        eligible = np.flatnonzero(copy_count < num_ranks)
+        if eligible.size == 0:
+            raise ValueError(
+                "infeasible replica budget: all logical experts already have "
+                f"the maximum {num_ranks} total copies"
+            )
+        source_multiplicity = np.ceil(num_ranks / copy_count[eligible])
+        effective_load = logical_load[eligible] * source_multiplicity / num_ranks
+        expert = int(eligible[int(np.argmax(effective_load))])
+        replicas.append(expert)
+        copy_count[expert] += 1
+        if copy_count[expert] > num_ranks:
+            raise RuntimeError(
+                "layer-aware replica planner violated the per-expert copy limit"
+            )
+
+    physical_to_logical = np.concatenate(
+        (
+            np.arange(num_experts, dtype=np.int64),
+            np.asarray(replicas, dtype=np.int64),
+        )
+    )
+    return physical_to_logical, copy_count
+
+
+def _source_ranks_per_copy(copy_count: int, num_ranks: int) -> np.ndarray:
+    """Return runtime owners for ``source_rank % copy_count`` routing."""
+
+    copy_count = _strict_integer(copy_count, "copy_count", minimum=1)
+    num_ranks = _strict_integer(num_ranks, "num_ranks", minimum=1)
+    if copy_count > num_ranks:
+        raise ValueError("copy_count cannot exceed num_ranks")
+    return np.bincount(
+        np.arange(num_ranks, dtype=np.int64) % copy_count,
+        minlength=copy_count,
+    )
+
+
+def _physical_copy_loads(
+    physical_to_logical: np.ndarray,
+    logical_load: np.ndarray,
+    copy_count: np.ndarray,
+    num_ranks: int,
+) -> np.ndarray:
+    occurrence = np.zeros(logical_load.size, dtype=np.int64)
+    result = np.empty(physical_to_logical.size, dtype=np.float64)
+    weights = [
+        _source_ranks_per_copy(int(count), num_ranks) / num_ranks
+        for count in copy_count.tolist()
+    ]
+    for physical, logical_value in enumerate(physical_to_logical.tolist()):
+        logical = int(logical_value)
+        copy_index = int(occurrence[logical])
+        result[physical] = logical_load[logical] * weights[logical][copy_index]
+        occurrence[logical] += 1
+    return result
+
+
+def _complete_degree_sequence_is_feasible(
+    logical_remaining: np.ndarray,
+    rank_remaining: np.ndarray,
+) -> bool:
+    """Check an unrestricted bipartite degree sequence with Gale-Ryser."""
+
+    logical = np.asarray(logical_remaining, dtype=np.int64)
+    ranks = np.asarray(rank_remaining, dtype=np.int64)
+    if np.any(logical < 0) or np.any(ranks < 0):
+        return False
+    if int(logical.sum()) != int(ranks.sum()):
+        return False
+
+    logical = np.sort(logical[logical > 0])[::-1]
+    ranks = np.sort(ranks[ranks > 0])[::-1]
+    if logical.size == 0:
+        return ranks.size == 0
+    if ranks.size == 0:
+        return False
+    if int(logical[0]) > ranks.size or int(ranks[0]) > logical.size:
+        return False
+
+    counts = np.arange(1, logical.size + 1, dtype=np.int64)
+    logical_prefix = np.cumsum(logical)
+    rank_prefix_bound = np.minimum(
+        ranks[:, None], counts[None, :]
+    ).sum(axis=0)
+    return bool(np.all(logical_prefix <= rank_prefix_bound))
+
+
+def _residual_placement_is_feasible(
+    logical_remaining: np.ndarray,
+    rank_remaining: np.ndarray,
+    selected_ranks: Sequence[set[int]],
+) -> bool:
+    """Check whether the residual duplicate-free placement has a completion."""
+
+    logical = np.asarray(logical_remaining, dtype=np.int64)
+    ranks = np.asarray(rank_remaining, dtype=np.int64)
+    if logical.ndim != 1 or ranks.ndim != 1:
+        return False
+    if len(selected_ranks) != logical.size:
+        return False
+    if np.any(logical < 0) or np.any(ranks < 0):
+        return False
+    required = int(logical.sum())
+    if required != int(ranks.sum()):
+        return False
+    if required == 0:
+        return True
+
+    active_logical = np.flatnonzero(logical > 0)
+    active_ranks = np.flatnonzero(ranks > 0)
+    for logical_id in active_logical.tolist():
+        available = sum(
+            rank_id not in selected_ranks[logical_id]
+            for rank_id in active_ranks.tolist()
+        )
+        if int(logical[logical_id]) > available:
+            return False
+
+    has_active_forbidden_edges = any(
+        selected_ranks[logical_id]
+        for logical_id in active_logical.tolist()
+    )
+    if not has_active_forbidden_edges:
+        return _complete_degree_sequence_is_feasible(logical, ranks)
+
+    partial = [
+        logical_id
+        for logical_id in active_logical.tolist()
+        if selected_ranks[logical_id]
+    ]
+    if len(partial) == 1:
+        logical_id = partial[0]
+        available = [
+            rank_id
+            for rank_id in active_ranks.tolist()
+            if rank_id not in selected_ranks[logical_id]
+        ]
+        needed = int(logical[logical_id])
+        residual_logical = logical.copy()
+        residual_logical[logical_id] = 0
+        preferred = sorted(
+            available,
+            key=lambda rank_id: (-int(ranks[rank_id]), rank_id),
+        )[:needed]
+        residual_ranks = ranks.copy()
+        residual_ranks[preferred] -= 1
+        return _complete_degree_sequence_is_feasible(
+            residual_logical, residual_ranks
+        )
+
+    raise RuntimeError(
+        "layer-aware placement order produced multiple partially placed experts"
+    )
+
+
+def _place_layer(
+    physical_to_logical: np.ndarray,
+    logical_load: np.ndarray,
+    copy_count: np.ndarray,
+    rank_capacity: np.ndarray,
+    num_nodes: int,
+) -> tuple[tuple[np.ndarray, ...], np.ndarray]:
+    """Artifact-style capacity-aware, node-interleaved greedy placement."""
+
+    num_ranks = rank_capacity.size
+    if num_nodes <= 0 or num_ranks % num_nodes != 0:
+        raise ValueError(
+            f"num_nodes={num_nodes} must divide num_ranks={num_ranks}"
+        )
+    if int(rank_capacity.sum()) != physical_to_logical.size:
+        raise ValueError(
+            "rank capacity does not match physical expert count: "
+            f"{rank_capacity.sum()} != {physical_to_logical.size}"
+        )
+
+    ranks_per_node = num_ranks // num_nodes
+    physical_copy_load = _physical_copy_loads(
+        physical_to_logical,
+        logical_load,
+        copy_count,
+        num_ranks,
+    )
+    rank_load = np.zeros(num_ranks, dtype=np.float64)
+    rank_count = np.zeros(num_ranks, dtype=np.int64)
+    rank_remaining = rank_capacity.astype(np.int64, copy=True)
+    rank_lists: list[list[int]] = [[] for _ in range(num_ranks)]
+    physical_to_rank = np.full(physical_to_logical.size, -1, dtype=np.int64)
+
+    remaining_copies = copy_count.astype(np.int64, copy=True)
+    selected_ranks: list[set[int]] = [
+        set() for _ in range(logical_load.size)
+    ]
+    # Process all copies of one logical expert contiguously. This preserves the
+    # bipartite Havel-Hakimi invariant: at most one active expert has forbidden
+    # ranks, so residual feasibility needs one vectorized degree check instead
+    # of rebuilding a generic max-flow graph for every candidate.
+    physical_by_logical = tuple(
+        np.flatnonzero(physical_to_logical == logical)
+        for logical in range(logical_load.size)
+    )
+    logical_order = sorted(
+        range(logical_load.size),
+        key=lambda logical: (
+            -float(physical_copy_load[physical_by_logical[logical]].max()),
+            logical,
+        ),
+    )
+    physical_order = [
+        int(physical)
+        for logical in logical_order
+        for physical in sorted(
+            physical_by_logical[logical].tolist(),
+            key=lambda physical: (-float(physical_copy_load[physical]), physical),
+        )
+    ]
+    for physical in physical_order:
+        logical = int(physical_to_logical[physical])
+        copies_by_node = np.zeros(num_nodes, dtype=np.int64)
+        for selected in selected_ranks[logical]:
+            copies_by_node[selected // ranks_per_node] += 1
+
+        eligible = [
+            rank
+            for rank in range(num_ranks)
+            if rank_remaining[rank] > 0
+            and rank not in selected_ranks[logical]
+        ]
+        if not eligible:
+            raise RuntimeError(
+                "rank capacities cannot realize a duplicate-free "
+                f"placement for logical expert {logical}"
+            )
+
+        ordered_candidates = sorted(
+            eligible,
+            key=lambda rank: (
+                float(rank_load[rank]),
+                int(copies_by_node[rank // ranks_per_node]),
+                -int(rank_remaining[rank]),
+                rank,
+            ),
+        )
+        target = None
+        for candidate in ordered_candidates:
+            remaining_copies[logical] -= 1
+            rank_remaining[candidate] -= 1
+            selected_ranks[logical].add(candidate)
+            if _residual_placement_is_feasible(
+                remaining_copies,
+                rank_remaining,
+                selected_ranks,
+            ):
+                target = candidate
+                break
+            selected_ranks[logical].remove(candidate)
+            rank_remaining[candidate] += 1
+            remaining_copies[logical] += 1
+
+        if target is None:
+            raise RuntimeError(
+                "no load-ordered rank preserves residual placement "
+                f"feasibility for logical expert {logical}"
+            )
+
+        physical_to_rank[physical] = target
+        rank_lists[target].append(logical)
+        rank_load[target] += physical_copy_load[physical]
+        rank_count[target] += 1
+
+    if not np.array_equal(rank_count, rank_capacity):
+        raise RuntimeError(
+            f"placement did not fill capacities: {rank_count} != {rank_capacity}"
+        )
+    if np.any(remaining_copies != 0) or np.any(rank_remaining != 0):
+        raise RuntimeError("placement left a non-empty residual degree sequence")
+    # Runtime enumerates a logical expert's copies in physical rank order.
+    # Canonicalize the otherwise interchangeable planner copy ids to that order.
+    for logical in range(logical_load.size):
+        physical = np.flatnonzero(physical_to_logical == logical)
+        physical_to_rank[physical] = np.sort(physical_to_rank[physical])
+    placement = tuple(np.asarray(values, dtype=np.int64) for values in rank_lists)
+    return placement, physical_to_rank
+
+
+def build_layer_placement(
+    aggregate_load: np.ndarray,
+    replica_count_by_layer: Sequence[int] | np.ndarray,
+    num_ranks: int,
+    *,
+    num_nodes: int = 1,
+) -> tuple[
+    np.ndarray,
+    Placement,
+    tuple[np.ndarray, ...],
+    tuple[np.ndarray, ...],
+    np.ndarray,
+]:
+    """Build capacities and physical placement for a layer replica vector."""
+
+    weights = np.asarray(aggregate_load, dtype=np.float64)
+    replicas = _strict_integer_array(
+        replica_count_by_layer,
+        "replica_count_by_layer",
+        ndim=1,
+    )
+    if weights.ndim != 2:
+        raise ValueError(f"aggregate_load must have shape [L, E], got {weights.shape}")
+    if replicas.shape != (weights.shape[0],):
+        raise ValueError(
+            f"replica vector must have shape {(weights.shape[0],)}, got {replicas.shape}"
+        )
+    if np.any(replicas < 0):
+        raise ValueError("replica counts must be non-negative")
+
+    num_layers, num_experts = weights.shape
+    capacities = capacity_aware_interleaving(
+        num_experts + replicas,
+        num_ranks,
+    )
+    placements: list[tuple[np.ndarray, ...]] = []
+    physical_to_logical: list[np.ndarray] = []
+    physical_to_rank: list[np.ndarray] = []
+    copy_counts = np.empty((num_layers, num_experts), dtype=np.int64)
+
+    for layer in range(num_layers):
+        phy2log, copies = _replicate_layer(
+            weights[layer],
+            int(replicas[layer]),
+            num_ranks,
+        )
+        placement, phy2rank = _place_layer(
+            phy2log,
+            weights[layer],
+            copies,
+            capacities[layer],
+            num_nodes,
+        )
+        placements.append(placement)
+        physical_to_logical.append(phy2log)
+        physical_to_rank.append(phy2rank)
+        copy_counts[layer] = copies
+
+    return (
+        capacities,
+        tuple(placements),
+        tuple(physical_to_logical),
+        tuple(physical_to_rank),
+        copy_counts,
+    )
+
+
+def replay_balancedness(
+    expert_load: np.ndarray | Sequence[object],
+    physical_to_logical: Sequence[np.ndarray],
+    physical_to_rank: Sequence[np.ndarray],
+    logical_copy_count: np.ndarray,
+    num_ranks: int,
+) -> np.ndarray:
+    """Replay source-rank modulo routing and return per-layer balancedness.
+
+    The runtime sends all traffic from source rank ``s`` to copy
+    ``s % copy_count``. The profile contains cluster-aggregate logical load,
+    so each source rank contributes one ``1 / num_ranks`` share. This differs
+    from equal ``load / copy_count`` splitting whenever the copy count does
+    not divide the EP size, notably for three and five copies on eight ranks.
+    """
+
+    load = _normalise_load(expert_load)
+    num_ranks = _strict_integer(num_ranks, "num_ranks", minimum=1)
+    num_batches, num_layers, num_experts = load.shape
+    if len(physical_to_logical) != num_layers or len(physical_to_rank) != num_layers:
+        raise ValueError("placement layer count does not match expert_load")
+    copy_table = _strict_integer_array(
+        logical_copy_count,
+        "logical_copy_count",
+        ndim=2,
+    )
+    if copy_table.shape != (num_layers, num_experts):
+        raise ValueError(
+            "logical_copy_count must have shape "
+            f"{(num_layers, num_experts)}, got {copy_table.shape}"
+        )
+    if np.any(copy_table < 1) or np.any(copy_table > num_ranks):
+        raise ValueError("logical_copy_count entries must be in [1, num_ranks]")
+
+    result = np.empty(num_layers, dtype=np.float64)
+    for layer in range(num_layers):
+        phy2log = _strict_integer_array(
+            physical_to_logical[layer],
+            f"physical_to_logical[{layer}]",
+            ndim=1,
+        )
+        phy2rank = _strict_integer_array(
+            physical_to_rank[layer],
+            f"physical_to_rank[{layer}]",
+            ndim=1,
+        )
+        if phy2log.shape != phy2rank.shape:
+            raise ValueError(f"layer {layer} physical maps have different shapes")
+        if np.any(phy2log < 0) or np.any(phy2log >= num_experts):
+            raise ValueError(f"layer {layer} contains an invalid logical expert id")
+        if np.any(phy2rank < 0) or np.any(phy2rank >= num_ranks):
+            raise ValueError(f"layer {layer} contains an invalid rank id")
+
+        actual_copy_count = np.bincount(phy2log, minlength=num_experts)
+        if not np.array_equal(actual_copy_count, copy_table[layer]):
+            raise ValueError(f"layer {layer} physical maps do not match logical_copy_count")
+        gpu_load = np.zeros((num_batches, num_ranks), dtype=np.float64)
+        for logical in range(num_experts):
+            physical = np.flatnonzero(phy2log == logical)
+            physical = physical[np.argsort(phy2rank[physical], kind="stable")]
+            target_ranks = phy2rank[physical]
+            if np.unique(target_ranks).size != target_ranks.size:
+                raise ValueError(
+                    f"layer {layer} logical expert {logical} has two copies on one rank"
+                )
+            source_counts = _source_ranks_per_copy(physical.size, num_ranks)
+            for copy_index, rank in enumerate(target_ranks.tolist()):
+                gpu_load[:, rank] += (
+                    load[:, layer, logical]
+                    * float(source_counts[copy_index])
+                    / num_ranks
+                )
+
+        maximum = gpu_load.max(axis=1)
+        balancedness = np.ones(num_batches, dtype=np.float64)
+        nonzero = maximum > 0
+        balancedness[nonzero] = (
+            gpu_load[nonzero].mean(axis=1) / maximum[nonzero]
+        )
+        result[layer] = balancedness.mean()
+    return result

--- a/vllm_ascend/eplb/core/policy/layer_placement.py
+++ b/vllm_ascend/eplb/core/policy/layer_placement.py
@@ -8,10 +8,9 @@
 
 from __future__ import annotations
 
-from typing import Sequence
+from collections.abc import Sequence
 
 import numpy as np
-
 
 Placement = tuple[tuple[np.ndarray, ...], ...]
 
@@ -43,8 +42,7 @@ def _normalise_load(expert_load: np.ndarray | Sequence[object]) -> np.ndarray:
         load = load[np.newaxis, ...]
     if load.ndim != 3:
         raise ValueError(
-            "expert_load must have shape [layers, experts] or "
-            f"[batches, layers, experts], got {load.shape}"
+            f"expert_load must have shape [layers, experts] or [batches, layers, experts], got {load.shape}"
         )
     if 0 in load.shape:
         raise ValueError(f"expert_load dimensions must be non-zero, got {load.shape}")
@@ -126,8 +124,7 @@ def _replicate_layer(
         eligible = np.flatnonzero(copy_count < num_ranks)
         if eligible.size == 0:
             raise ValueError(
-                "infeasible replica budget: all logical experts already have "
-                f"the maximum {num_ranks} total copies"
+                f"infeasible replica budget: all logical experts already have the maximum {num_ranks} total copies"
             )
         source_multiplicity = np.ceil(num_ranks / copy_count[eligible])
         effective_load = logical_load[eligible] * source_multiplicity / num_ranks
@@ -135,9 +132,7 @@ def _replicate_layer(
         replicas.append(expert)
         copy_count[expert] += 1
         if copy_count[expert] > num_ranks:
-            raise RuntimeError(
-                "layer-aware replica planner violated the per-expert copy limit"
-            )
+            raise RuntimeError("layer-aware replica planner violated the per-expert copy limit")
 
     physical_to_logical = np.concatenate(
         (
@@ -169,10 +164,7 @@ def _physical_copy_loads(
 ) -> np.ndarray:
     occurrence = np.zeros(logical_load.size, dtype=np.int64)
     result = np.empty(physical_to_logical.size, dtype=np.float64)
-    weights = [
-        _source_ranks_per_copy(int(count), num_ranks) / num_ranks
-        for count in copy_count.tolist()
-    ]
+    weights = [_source_ranks_per_copy(int(count), num_ranks) / num_ranks for count in copy_count.tolist()]
     for physical, logical_value in enumerate(physical_to_logical.tolist()):
         logical = int(logical_value)
         copy_index = int(occurrence[logical])
@@ -205,9 +197,7 @@ def _complete_degree_sequence_is_feasible(
 
     counts = np.arange(1, logical.size + 1, dtype=np.int64)
     logical_prefix = np.cumsum(logical)
-    rank_prefix_bound = np.minimum(
-        ranks[:, None], counts[None, :]
-    ).sum(axis=0)
+    rank_prefix_bound = np.minimum(ranks[:, None], counts[None, :]).sum(axis=0)
     return bool(np.all(logical_prefix <= rank_prefix_bound))
 
 
@@ -235,48 +225,30 @@ def _residual_placement_is_feasible(
     active_logical = np.flatnonzero(logical > 0)
     active_ranks = np.flatnonzero(ranks > 0)
     for logical_id in active_logical.tolist():
-        available = sum(
-            rank_id not in selected_ranks[logical_id]
-            for rank_id in active_ranks.tolist()
-        )
+        available = sum(rank_id not in selected_ranks[logical_id] for rank_id in active_ranks.tolist())
         if int(logical[logical_id]) > available:
             return False
 
-    has_active_forbidden_edges = any(
-        selected_ranks[logical_id]
-        for logical_id in active_logical.tolist()
-    )
+    has_active_forbidden_edges = any(selected_ranks[logical_id] for logical_id in active_logical.tolist())
     if not has_active_forbidden_edges:
         return _complete_degree_sequence_is_feasible(logical, ranks)
 
-    partial = [
-        logical_id
-        for logical_id in active_logical.tolist()
-        if selected_ranks[logical_id]
-    ]
+    partial = [logical_id for logical_id in active_logical.tolist() if selected_ranks[logical_id]]
     if len(partial) == 1:
         logical_id = partial[0]
-        available = [
-            rank_id
-            for rank_id in active_ranks.tolist()
-            if rank_id not in selected_ranks[logical_id]
-        ]
+        available_ranks = [rank_id for rank_id in active_ranks.tolist() if rank_id not in selected_ranks[logical_id]]
         needed = int(logical[logical_id])
         residual_logical = logical.copy()
         residual_logical[logical_id] = 0
         preferred = sorted(
-            available,
+            available_ranks,
             key=lambda rank_id: (-int(ranks[rank_id]), rank_id),
         )[:needed]
         residual_ranks = ranks.copy()
         residual_ranks[preferred] -= 1
-        return _complete_degree_sequence_is_feasible(
-            residual_logical, residual_ranks
-        )
+        return _complete_degree_sequence_is_feasible(residual_logical, residual_ranks)
 
-    raise RuntimeError(
-        "layer-aware placement order produced multiple partially placed experts"
-    )
+    raise RuntimeError("layer-aware placement order produced multiple partially placed experts")
 
 
 def _place_layer(
@@ -290,13 +262,10 @@ def _place_layer(
 
     num_ranks = rank_capacity.size
     if num_nodes <= 0 or num_ranks % num_nodes != 0:
-        raise ValueError(
-            f"num_nodes={num_nodes} must divide num_ranks={num_ranks}"
-        )
+        raise ValueError(f"num_nodes={num_nodes} must divide num_ranks={num_ranks}")
     if int(rank_capacity.sum()) != physical_to_logical.size:
         raise ValueError(
-            "rank capacity does not match physical expert count: "
-            f"{rank_capacity.sum()} != {physical_to_logical.size}"
+            f"rank capacity does not match physical expert count: {rank_capacity.sum()} != {physical_to_logical.size}"
         )
 
     ranks_per_node = num_ranks // num_nodes
@@ -313,17 +282,12 @@ def _place_layer(
     physical_to_rank = np.full(physical_to_logical.size, -1, dtype=np.int64)
 
     remaining_copies = copy_count.astype(np.int64, copy=True)
-    selected_ranks: list[set[int]] = [
-        set() for _ in range(logical_load.size)
-    ]
+    selected_ranks: list[set[int]] = [set() for _ in range(logical_load.size)]
     # Process all copies of one logical expert contiguously. This preserves the
     # bipartite Havel-Hakimi invariant: at most one active expert has forbidden
     # ranks, so residual feasibility needs one vectorized degree check instead
     # of rebuilding a generic max-flow graph for every candidate.
-    physical_by_logical = tuple(
-        np.flatnonzero(physical_to_logical == logical)
-        for logical in range(logical_load.size)
-    )
+    physical_by_logical = tuple(np.flatnonzero(physical_to_logical == logical) for logical in range(logical_load.size))
     logical_order = sorted(
         range(logical_load.size),
         key=lambda logical: (
@@ -346,15 +310,11 @@ def _place_layer(
             copies_by_node[selected // ranks_per_node] += 1
 
         eligible = [
-            rank
-            for rank in range(num_ranks)
-            if rank_remaining[rank] > 0
-            and rank not in selected_ranks[logical]
+            rank for rank in range(num_ranks) if rank_remaining[rank] > 0 and rank not in selected_ranks[logical]
         ]
         if not eligible:
             raise RuntimeError(
-                "rank capacities cannot realize a duplicate-free "
-                f"placement for logical expert {logical}"
+                f"rank capacities cannot realize a duplicate-free placement for logical expert {logical}"
             )
 
         ordered_candidates = sorted(
@@ -384,8 +344,7 @@ def _place_layer(
 
         if target is None:
             raise RuntimeError(
-                "no load-ordered rank preserves residual placement "
-                f"feasibility for logical expert {logical}"
+                f"no load-ordered rank preserves residual placement feasibility for logical expert {logical}"
             )
 
         physical_to_rank[physical] = target
@@ -394,9 +353,7 @@ def _place_layer(
         rank_count[target] += 1
 
     if not np.array_equal(rank_count, rank_capacity):
-        raise RuntimeError(
-            f"placement did not fill capacities: {rank_count} != {rank_capacity}"
-        )
+        raise RuntimeError(f"placement did not fill capacities: {rank_count} != {rank_capacity}")
     if np.any(remaining_copies != 0) or np.any(rank_remaining != 0):
         raise RuntimeError("placement left a non-empty residual degree sequence")
     # Runtime enumerates a logical expert's copies in physical rank order.
@@ -432,9 +389,7 @@ def build_layer_placement(
     if weights.ndim != 2:
         raise ValueError(f"aggregate_load must have shape [L, E], got {weights.shape}")
     if replicas.shape != (weights.shape[0],):
-        raise ValueError(
-            f"replica vector must have shape {(weights.shape[0],)}, got {replicas.shape}"
-        )
+        raise ValueError(f"replica vector must have shape {(weights.shape[0],)}, got {replicas.shape}")
     if np.any(replicas < 0):
         raise ValueError("replica counts must be non-negative")
 
@@ -502,10 +457,7 @@ def replay_balancedness(
         ndim=2,
     )
     if copy_table.shape != (num_layers, num_experts):
-        raise ValueError(
-            "logical_copy_count must have shape "
-            f"{(num_layers, num_experts)}, got {copy_table.shape}"
-        )
+        raise ValueError(f"logical_copy_count must have shape {(num_layers, num_experts)}, got {copy_table.shape}")
     if np.any(copy_table < 1) or np.any(copy_table > num_ranks):
         raise ValueError("logical_copy_count entries must be in [1, num_ranks]")
 
@@ -537,22 +489,14 @@ def replay_balancedness(
             physical = physical[np.argsort(phy2rank[physical], kind="stable")]
             target_ranks = phy2rank[physical]
             if np.unique(target_ranks).size != target_ranks.size:
-                raise ValueError(
-                    f"layer {layer} logical expert {logical} has two copies on one rank"
-                )
+                raise ValueError(f"layer {layer} logical expert {logical} has two copies on one rank")
             source_counts = _source_ranks_per_copy(physical.size, num_ranks)
             for copy_index, rank in enumerate(target_ranks.tolist()):
-                gpu_load[:, rank] += (
-                    load[:, layer, logical]
-                    * float(source_counts[copy_index])
-                    / num_ranks
-                )
+                gpu_load[:, rank] += load[:, layer, logical] * float(source_counts[copy_index]) / num_ranks
 
         maximum = gpu_load.max(axis=1)
         balancedness = np.ones(num_batches, dtype=np.float64)
         nonzero = maximum > 0
-        balancedness[nonzero] = (
-            gpu_load[nonzero].mean(axis=1) / maximum[nonzero]
-        )
+        balancedness[nonzero] = gpu_load[nonzero].mean(axis=1) / maximum[nonzero]
         result[layer] = balancedness.mean()
     return result

--- a/vllm_ascend/eplb/core/policy/policy_factory.py
+++ b/vllm_ascend/eplb/core/policy/policy_factory.py
@@ -5,13 +5,15 @@ from vllm.logger import logger
 from .policy_abstract import EplbPolicy
 from .policy_default_eplb import DefaultEplb
 from .policy_flashlb import FlashLB, warm_up
+from .policy_global_expert_pool import GlobalExpertPoolEplb
+from .policy_layer import LayerEplb
 from .policy_random import RandomLoadBalance
 from .policy_swift_balancer import SwiftBalanceEplb
 
 
 class PolicyFactory:
     @staticmethod
-    def generate_policy(policy_type: int) -> EplbPolicy:
+    def generate_policy(policy_type: int, policy_config: dict | None = None) -> EplbPolicy:
         policy: dict[int, type[EplbPolicy]] = {
             # Constraint applying Dynamic EPLB policy V2:
             # If there exists redundant expert:
@@ -24,8 +26,16 @@ class PolicyFactory:
             # FlashLB EPLB policy: expert replacement based on Joint Optimization,
             # Multi-Shot Enhancement and Incremental Adjustment
             3: FlashLB,
+            # Role-aware policy: cross-layer slots for prefill, per-layer
+            # redundant experts for decode.
+            4: GlobalExpertPoolEplb,
         }
         policy_class = policy.get(policy_type)
+        if policy_type == 4:
+            node_role = (policy_config or {}).get("node_role", "prefill")
+            if node_role not in ("prefill", "decode"):
+                raise ValueError("policy 4 node_role must be 'prefill' or 'decode'")
+            policy_class = GlobalExpertPoolEplb if node_role == "prefill" else LayerEplb
         if policy_class is None:
             policy_class = RandomLoadBalance
             logger.warning(
@@ -35,7 +45,12 @@ class PolicyFactory:
             )
         else:
             logger.info("[eplb/policy] Policy: %s (type=%s)", policy_class.__name__, policy_type)
-        policy_instance = policy_class()
+        if policy_type == 4:
+            constructor_config = dict(policy_config or {})
+            constructor_config.pop("node_role", None)
+            policy_instance = policy_class(**constructor_config)
+        else:
+            policy_instance = policy_class()
         if policy_type == 3:
             warm_up()
         return policy_instance

--- a/vllm_ascend/eplb/core/policy/policy_global_expert_pool.py
+++ b/vllm_ascend/eplb/core/policy/policy_global_expert_pool.py
@@ -1,0 +1,295 @@
+# SPDX-License-Identifier: Apache-2.0
+"""P-node global expert pool policy using cross-layer shared slots."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+import numpy as np
+
+from .policy_abstract import EplbPolicy
+
+_SLOT_GAIN_EPSILON = 1e-12
+# Policy 4 owns its stability and migration thresholds. Keeping these values
+# internal avoids a second set of user-facing tuning knobs and, importantly,
+# prevents low-signal decode windows from forcing repeated weight migration.
+_MIN_EFFECTIVE_GAIN = 0.01
+_REQUIRED_STABLE_WINDOWS = 2
+_POST_APPLY_COOLDOWN_WINDOWS = 1
+_MIGRATION_AMORTIZATION_WINDOWS = 4.0
+_NORMALIZED_MIGRATION_COST = 0.02
+_HEAT_EMA_ALPHA = 0.25
+
+
+@dataclass(frozen=True)
+class GlobalExpertPoolDecision:
+    should_apply: bool
+    reason: str
+    placement: tuple[tuple[tuple[int, ...], ...], ...]
+    priority: tuple[float, ...]
+    gain: float
+    changed_slots: int
+
+
+def _logical_heat(table: np.ndarray, workload: np.ndarray, num_experts: int) -> np.ndarray:
+    heat = np.zeros((table.shape[0], num_experts), dtype=np.float64)
+    for layer_id in range(table.shape[0]):
+        valid = table[layer_id] >= 0
+        np.add.at(heat[layer_id], table[layer_id][valid], workload[layer_id][valid])
+    return heat
+
+
+def _allocate_critical_path_replicas(
+    base: np.ndarray,
+    heat: np.ndarray,
+    slots_per_rank: int,
+    num_ranks: int,
+) -> list[list[tuple[int, int]]]:
+    """Greedily minimize the summed per-layer critical-path load."""
+    num_layers, _, _ = base.shape
+    num_experts = heat.shape[1]
+    holders = np.zeros((num_layers, num_experts, num_ranks), dtype=bool)
+    rank_load = np.zeros((num_layers, num_ranks), dtype=np.float64)
+    for layer_id in range(num_layers):
+        for rank_id in range(num_ranks):
+            experts = base[layer_id, rank_id]
+            holders[layer_id, experts, rank_id] = True
+            rank_load[layer_id, rank_id] = float(heat[layer_id, experts].sum())
+
+    copies = holders.sum(axis=-1).astype(np.int64)
+    remaining = np.full(num_ranks, slots_per_rank, dtype=np.int64)
+    targets_by_rank: list[list[tuple[int, int]]] = [[] for _ in range(num_ranks)]
+    rank_indices = np.arange(num_ranks)
+
+    for _ in range(slots_per_rank * num_ranks):
+        next_share = np.divide(
+            heat,
+            copies + 1,
+            out=np.zeros_like(heat, dtype=np.float64),
+            where=copies >= 0,
+        )
+        current_share = np.divide(
+            heat,
+            copies,
+            out=np.zeros_like(heat, dtype=np.float64),
+            where=copies > 0,
+        )
+        reduction = current_share - next_share
+        reduced_loads = rank_load[:, None, None, :] - holders[:, :, None, :] * reduction[:, :, None, None]
+        candidate_loads = np.broadcast_to(
+            reduced_loads,
+            (num_layers, num_experts, num_ranks, num_ranks),
+        ).copy()
+        candidate_loads[:, :, rank_indices, rank_indices] += next_share[:, :, None]
+
+        critical_gain = rank_load.max(axis=-1)[:, None, None] - candidate_loads.max(axis=-1)
+        second_moment_gain = np.square(rank_load).sum(axis=-1)[:, None, None] - np.square(candidate_loads).sum(axis=-1)
+        valid = (~holders) & (copies[:, :, None] < num_ranks) & (heat[:, :, None] > 0) & (remaining[None, None, :] > 0)
+        critical_gain[~valid] = -np.inf
+        second_moment_gain[~valid] = -np.inf
+
+        best_primary = float(np.max(critical_gain))
+        if not np.isfinite(best_primary):
+            break
+        if best_primary > _SLOT_GAIN_EPSILON:
+            eligible = critical_gain >= best_primary - _SLOT_GAIN_EPSILON
+            score = np.where(eligible, second_moment_gain, -np.inf)
+        else:
+            score = second_moment_gain
+            if float(np.max(score)) <= _SLOT_GAIN_EPSILON:
+                break
+
+        layer_id, expert_id, rank_id = (int(value) for value in np.unravel_index(int(np.argmax(score)), score.shape))
+        old_share = current_share[layer_id, expert_id]
+        new_share = next_share[layer_id, expert_id]
+        rank_load[layer_id, holders[layer_id, expert_id]] += new_share - old_share
+        rank_load[layer_id, rank_id] += new_share
+        holders[layer_id, expert_id, rank_id] = True
+        copies[layer_id, expert_id] += 1
+        remaining[rank_id] -= 1
+        targets_by_rank[rank_id].append((layer_id, expert_id))
+
+    return targets_by_rank
+
+
+def _align_shared_slots(
+    current: np.ndarray,
+    base_slots: int,
+    targets_by_rank: list[list[tuple[int, int]]],
+) -> np.ndarray:
+    candidate = current.copy()
+    candidate[:, :, base_slots:] = -1
+    num_layers, num_ranks, local_slots = current.shape
+    shared_slots = local_slots - base_slots
+    for rank_id in range(num_ranks):
+        remaining = list(targets_by_rank[rank_id])
+        assigned: list[tuple[int, int] | None] = [None] * shared_slots
+        old_owner: list[tuple[int, int] | None] = []
+        for slot_id in range(shared_slots):
+            owners = [
+                (layer_id, int(current[layer_id, rank_id, base_slots + slot_id]))
+                for layer_id in range(num_layers)
+                if current[layer_id, rank_id, base_slots + slot_id] >= 0
+            ]
+            if len(owners) > 1:
+                raise ValueError("one shared physical slot is owned by multiple layers")
+            old_owner.append(owners[0] if owners else None)
+        for slot_id, owner in enumerate(old_owner):
+            if owner is not None and owner in remaining:
+                assigned[slot_id] = owner
+                remaining.remove(owner)
+        for slot_id, owner in enumerate(old_owner):
+            if assigned[slot_id] is not None or owner is None:
+                continue
+            same_layer = next((item for item in remaining if item[0] == owner[0]), None)
+            if same_layer is not None:
+                assigned[slot_id] = same_layer
+                remaining.remove(same_layer)
+        remaining.sort()
+        for slot_id in range(shared_slots):
+            if assigned[slot_id] is None and remaining:
+                assigned[slot_id] = remaining.pop(0)
+        if remaining:
+            raise ValueError("target placement exceeds the shared slot budget")
+        for slot_id, owner in enumerate(assigned):
+            if owner is not None:
+                layer_id, expert_id = owner
+                candidate[layer_id, rank_id, base_slots + slot_id] = expert_id
+    return candidate
+
+
+def _rank_loads_by_layer(table: np.ndarray, heat: np.ndarray, num_ranks: int) -> np.ndarray:
+    result = np.zeros((table.shape[0], num_ranks), dtype=np.float64)
+    for layer_id in range(table.shape[0]):
+        placement = table[layer_id]
+        valid_values = placement[placement >= 0]
+        counts = np.bincount(valid_values, minlength=heat.shape[1]).clip(min=1)
+        for rank_id in range(num_ranks):
+            experts = placement[rank_id]
+            experts = experts[experts >= 0]
+            result[layer_id, rank_id] = float(np.sum(heat[layer_id, experts] / counts[experts]))
+    return result
+
+
+def _immutable(table: np.ndarray) -> tuple[tuple[tuple[int, ...], ...], ...]:
+    return tuple(tuple(tuple(int(value) for value in rank) for rank in layer) for layer in table)
+
+
+class GlobalExpertPoolPlanner:
+    """Plan shared slots with conservative, implementation-owned gating."""
+
+    def __init__(self, num_redundant_experts: int) -> None:
+        if isinstance(num_redundant_experts, bool) or not isinstance(num_redundant_experts, int):
+            raise TypeError("num_redundant_experts must be an integer")
+        if num_redundant_experts <= 0:
+            raise ValueError("policy 4 requires num_redundant_experts > 0")
+        self.slots_per_rank = int(num_redundant_experts)
+        self._heat_distribution_ema: np.ndarray | None = None
+        self._last_candidate: np.ndarray | None = None
+        self._stable_windows = 0
+        self._cooldown_remaining = 0
+
+    def _smooth_heat_distribution(self, heat: np.ndarray) -> np.ndarray:
+        totals = heat.sum(axis=-1, keepdims=True)
+        distribution = np.divide(
+            heat,
+            totals,
+            out=np.zeros_like(heat, dtype=np.float64),
+            where=totals > 0,
+        )
+        if self._heat_distribution_ema is None or self._heat_distribution_ema.shape != distribution.shape:
+            smoothed = distribution
+        else:
+            smoothed = self._heat_distribution_ema.copy()
+            observed = totals[:, 0] > 0
+            smoothed[observed] = (1.0 - _HEAT_EMA_ALPHA) * smoothed[observed] + _HEAT_EMA_ALPHA * distribution[observed]
+            smoothed_totals = smoothed.sum(axis=-1, keepdims=True)
+            smoothed = np.divide(
+                smoothed,
+                smoothed_totals,
+                out=np.zeros_like(smoothed),
+                where=smoothed_totals > 0,
+            )
+        self._heat_distribution_ema = smoothed.copy()
+        return smoothed * totals
+
+    def plan(self, current_expert_table: Any, expert_workload: Any) -> GlobalExpertPoolDecision:
+        table = np.asarray(current_expert_table, dtype=np.int64)
+        workload = np.asarray(expert_workload, dtype=np.float64)
+        if table.ndim != 3 or workload.shape != table.shape or 0 in table.shape:
+            raise ValueError("policy 4 expects matching non-empty [layers, ranks, local_slots] table and workload")
+        if not np.all(np.isfinite(workload)) or np.any(workload < 0):
+            raise ValueError("policy 4 workload must be non-negative and finite")
+        num_layers, num_ranks, local_slots = table.shape
+        base_slots = local_slots - self.slots_per_rank
+        if base_slots <= 0:
+            raise ValueError("global slots must be smaller than local physical capacity")
+        num_experts = base_slots * num_ranks
+        for layer_id in range(num_layers):
+            base = table[layer_id, :, :base_slots].reshape(-1)
+            if np.any(base < 0) or not np.array_equal(np.sort(base), np.arange(num_experts)):
+                raise ValueError(f"layer {layer_id} base slots must contain one immutable copy per expert")
+
+        heat = self._smooth_heat_distribution(_logical_heat(table, workload, num_experts))
+        targets_by_rank = _allocate_critical_path_replicas(
+            table[:, :, :base_slots], heat, self.slots_per_rank, num_ranks
+        )
+
+        candidate = _align_shared_slots(table, base_slots, targets_by_rank)
+        current_rank_loads = _rank_loads_by_layer(table, heat, num_ranks)
+        predicted_rank_loads = _rank_loads_by_layer(candidate, heat, num_ranks)
+        current_critical_path = current_rank_loads.max(axis=-1)
+        predicted_critical_path = predicted_rank_loads.max(axis=-1)
+        priority = current_critical_path - predicted_critical_path
+        raw_gain = float(priority.sum()) / max(float(current_critical_path.sum()), _SLOT_GAIN_EPSILON)
+        changed_slots = int(np.count_nonzero(np.any(candidate[:, :, base_slots:] != table[:, :, base_slots:], axis=0)))
+        migration_penalty = (
+            _NORMALIZED_MIGRATION_COST
+            * changed_slots
+            / max(1, self.slots_per_rank * num_ranks)
+            / _MIGRATION_AMORTIZATION_WINDOWS
+        )
+        effective_gain = raw_gain - migration_penalty
+        if self._last_candidate is not None and np.array_equal(candidate, self._last_candidate):
+            self._stable_windows += 1
+        else:
+            self._last_candidate = candidate.copy()
+            self._stable_windows = 1
+
+        reason, should_apply = "apply", True
+        if changed_slots == 0:
+            reason, should_apply = "unchanged", False
+        elif effective_gain < _MIN_EFFECTIVE_GAIN:
+            reason, should_apply = "insufficient_gain", False
+        elif self._stable_windows < _REQUIRED_STABLE_WINDOWS:
+            reason, should_apply = "unstable", False
+        elif self._cooldown_remaining > 0:
+            reason, should_apply = "cooldown", False
+        if self._cooldown_remaining > 0:
+            self._cooldown_remaining -= 1
+        if should_apply:
+            self._cooldown_remaining = _POST_APPLY_COOLDOWN_WINDOWS
+
+        return GlobalExpertPoolDecision(
+            should_apply=should_apply,
+            reason=reason,
+            placement=_immutable(candidate if should_apply else table),
+            priority=tuple(float(value) for value in priority),
+            gain=effective_gain,
+            changed_slots=changed_slots,
+        )
+
+
+class GlobalExpertPoolEplb(EplbPolicy):
+    def __init__(self, num_redundant_experts: int) -> None:
+        self.planner = GlobalExpertPoolPlanner(num_redundant_experts)
+        self.last_decision: GlobalExpertPoolDecision | None = None
+
+    def rebalance_experts(self, current_expert_table, expert_workload):
+        self.last_decision = self.planner.plan(current_expert_table, expert_workload)
+        decision = self.last_decision
+        return int(decision.should_apply), np.asarray(decision.priority), decision.placement
+
+
+__all__ = ["GlobalExpertPoolEplb"]

--- a/vllm_ascend/eplb/core/policy/policy_layer.py
+++ b/vllm_ascend/eplb/core/policy/policy_layer.py
@@ -1,0 +1,350 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Dynamic per-layer placement for the fixed-capacity EPLB runtime."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import numpy as np
+
+from .policy_abstract import EplbPolicy
+from .layer_placement import build_layer_placement, replay_balancedness
+
+
+_PER_LAYER_GAIN_EPSILON = 1e-12
+_MAX_MIGRATION_LAYER_FRACTION = 0.25
+_MIN_EFFECTIVE_GAIN = 0.02
+_REQUIRED_STABLE_WINDOWS = 2
+_POST_APPLY_COOLDOWN_WINDOWS = 1
+_MIGRATION_AMORTIZATION_WINDOWS = 4.0
+_NORMALIZED_MIGRATION_COST = 0.02
+
+
+@dataclass(frozen=True)
+class LayerDecision:
+    should_apply: bool
+    placement: tuple[tuple[tuple[int, ...], ...], ...]
+    priority: tuple[int, ...]
+
+
+def _numpy(value, dtype) -> np.ndarray:
+    if hasattr(value, "detach"):
+        value = value.detach().cpu().numpy()
+    return np.asarray(value, dtype=dtype)
+
+
+def _inputs(current_expert_table, expert_workload) -> tuple[np.ndarray, np.ndarray, int]:
+    table = _numpy(current_expert_table, np.int64).copy()
+    load = _numpy(expert_workload, np.float64).copy()
+    if table.ndim != 3 or table.shape != load.shape or 0 in table.shape:
+        raise ValueError("Policy4 expects matching non-empty [L, R, S] table and load")
+    if np.any(table < 0) or not np.all(np.isfinite(load)) or np.any(load < 0):
+        raise ValueError("Policy4 table and load must be non-negative and finite")
+    num_experts = int(table.max()) + 1
+    expected = np.arange(num_experts, dtype=np.int64)
+    for layer in table:
+        if not np.array_equal(np.unique(layer), expected):
+            raise ValueError("Policy4 placement must cover every logical expert")
+        for rank in layer:
+            if np.unique(rank).size != rank.size:
+                raise ValueError("Policy4 cannot place two copies on one rank")
+    return table, load, num_experts
+
+
+def _logical_heat(table: np.ndarray, load: np.ndarray, num_experts: int) -> np.ndarray:
+    heat = np.zeros((table.shape[0], num_experts), dtype=np.float64)
+    for layer in range(table.shape[0]):
+        np.add.at(heat[layer], table[layer].reshape(-1), load[layer].reshape(-1))
+    return heat
+
+
+def _placement_maps(table: np.ndarray, num_experts: int):
+    phy2log = []
+    phy2rank = []
+    copies = np.empty((table.shape[0], num_experts), dtype=np.int64)
+    for layer in range(table.shape[0]):
+        logical = table[layer].reshape(-1)
+        phy2log.append(logical)
+        phy2rank.append(np.repeat(np.arange(table.shape[1]), table.shape[2]))
+        copies[layer] = np.bincount(logical, minlength=num_experts)
+    return tuple(phy2log), tuple(phy2rank), copies
+
+
+def _placement_risk_by_layer(
+    current: np.ndarray,
+    candidate: np.ndarray,
+    heat: np.ndarray,
+    num_experts: int,
+) -> np.ndarray:
+    """Estimate migration and communication-locality risk per layer.
+
+    The runtime currently exposes logical-expert heat, but not a
+    source-rank-to-expert traffic matrix.  Retaining the current owners of hot
+    experts is therefore the safest available locality proxy.  Peak per-rank
+    slot churn additionally avoids concentrating weight transfers on one rank.
+    """
+    changed = candidate != current
+    mean_rank_churn = changed.mean(axis=(1, 2))
+    peak_rank_churn = changed.mean(axis=2).max(axis=1)
+
+    current_owners = np.zeros(
+        (current.shape[0], num_experts, current.shape[1]), dtype=bool
+    )
+    candidate_owners = np.zeros_like(current_owners)
+    for layer in range(current.shape[0]):
+        for rank in range(current.shape[1]):
+            current_owners[layer, current[layer, rank], rank] = True
+            candidate_owners[layer, candidate[layer, rank], rank] = True
+
+    current_copies = current_owners.sum(axis=2)
+    retired_owner_fraction = np.divide(
+        np.count_nonzero(current_owners & ~candidate_owners, axis=2),
+        current_copies,
+        out=np.zeros_like(current_copies, dtype=np.float64),
+        where=current_copies != 0,
+    )
+    total_heat = heat.sum(axis=1)
+    hot_owner_churn = np.divide(
+        (heat * retired_owner_fraction).sum(axis=1),
+        total_heat,
+        out=np.zeros_like(total_heat, dtype=np.float64),
+        where=total_heat != 0,
+    )
+
+    return (mean_rank_churn + peak_rank_churn + hot_owner_churn) / 3.0
+
+
+def _align_retained_slots(current: np.ndarray, desired) -> np.ndarray:
+    result = np.full_like(current, -1)
+    for layer in range(current.shape[0]):
+        for rank in range(current.shape[1]):
+            wanted = [int(item) for item in desired[layer][rank]]
+            wanted_set = set(wanted)
+            retained = set()
+            for slot, expert in enumerate(current[layer, rank]):
+                if int(expert) in wanted_set:
+                    result[layer, rank, slot] = expert
+                    retained.add(int(expert))
+            remaining = (item for item in wanted if item not in retained)
+            for slot in np.flatnonzero(result[layer, rank] < 0):
+                result[layer, rank, slot] = next(remaining)
+    return result
+
+
+def _immutable(table: np.ndarray):
+    return tuple(
+        tuple(tuple(int(value) for value in rank) for rank in layer)
+        for layer in table
+    )
+
+
+class LayerPlanner:
+    """Plan stable per-layer placements using implementation-owned thresholds."""
+
+    def __init__(self, num_redundant_experts: int) -> None:
+        if isinstance(num_redundant_experts, bool) or not isinstance(
+            num_redundant_experts, int
+        ):
+            raise TypeError("num_redundant_experts must be an integer")
+        if num_redundant_experts <= 0:
+            raise ValueError("num_redundant_experts must be positive")
+        self.num_redundant_experts = num_redundant_experts
+        self.window = 0
+        self.last_apply_window: int | None = None
+        self.pending: np.ndarray | None = None
+        self.pending_base: np.ndarray | None = None
+        self.pending_streak = 0
+
+    @staticmethod
+    def _scores(table: np.ndarray, heat: np.ndarray, num_experts: int) -> np.ndarray:
+        return replay_balancedness(
+            heat, *_placement_maps(table, num_experts), table.shape[1]
+        )
+
+    @classmethod
+    def _limit_migration_scope(
+        cls,
+        current: np.ndarray,
+        candidate: np.ndarray,
+        current_score: np.ndarray,
+        heat: np.ndarray,
+        num_experts: int,
+    ) -> np.ndarray:
+        changed_by_layer = np.count_nonzero(candidate != current, axis=(1, 2))
+        changed_layers = np.flatnonzero(changed_by_layer)
+        if changed_layers.size == 0:
+            return candidate
+
+        gain_by_layer = cls._scores(candidate, heat, num_experts) - current_score
+        risk_by_layer = _placement_risk_by_layer(
+            current, candidate, heat, num_experts
+        )
+        net_gain_by_layer = (
+            gain_by_layer * _MIGRATION_AMORTIZATION_WINDOWS
+            - risk_by_layer * _NORMALIZED_MIGRATION_COST
+        )
+        profitable_layers = changed_layers[
+            net_gain_by_layer[changed_layers] > _PER_LAYER_GAIN_EPSILON
+        ]
+        if profitable_layers.size == 0:
+            return current.copy()
+
+        max_layers = max(
+            1,
+            int(np.ceil(current.shape[0] * _MAX_MIGRATION_LAYER_FRACTION)),
+        )
+        selected_layers = sorted(
+            profitable_layers.tolist(),
+            key=lambda layer: (
+                -float(net_gain_by_layer[layer]),
+                -float(
+                    gain_by_layer[layer]
+                    / max(risk_by_layer[layer], _PER_LAYER_GAIN_EPSILON)
+                ),
+                -float(gain_by_layer[layer]),
+                layer,
+            ),
+        )[:max_layers]
+        limited = current.copy()
+        limited[selected_layers] = candidate[selected_layers]
+        return limited
+
+    def _eligible(
+        self,
+        current: np.ndarray,
+        candidate: np.ndarray,
+        current_score: np.ndarray,
+        heat: np.ndarray,
+        num_experts: int,
+    ) -> tuple[bool, np.ndarray]:
+        predicted = self._scores(candidate, heat, num_experts)
+        per_layer_gain = predicted - current_score
+        gain = float(per_layer_gain.mean())
+        changed = int(np.count_nonzero(candidate != current))
+        placement_risk = _placement_risk_by_layer(
+            current, candidate, heat, num_experts
+        )
+        cost = float(placement_risk.mean()) * _NORMALIZED_MIGRATION_COST
+        ready = (
+            changed > 0
+            and gain >= _MIN_EFFECTIVE_GAIN
+            and float(per_layer_gain.min()) >= -_PER_LAYER_GAIN_EPSILON
+            and gain * _MIGRATION_AMORTIZATION_WINDOWS > cost
+        )
+        return ready, per_layer_gain
+
+    def plan(self, current_expert_table, expert_workload) -> LayerDecision:
+        table, load, num_experts = _inputs(current_expert_table, expert_workload)
+        self.window += 1
+        heat = _logical_heat(table, load, num_experts)
+        current_by_layer = self._scores(table, heat, num_experts)
+        replicas = table.shape[1] * table.shape[2] - num_experts
+        if replicas != self.num_redundant_experts:
+            raise ValueError(
+                "Policy4 runtime placement has "
+                f"{replicas} redundant experts, expected "
+                f"{self.num_redundant_experts} from configuration"
+            )
+        _, desired, _, _, _ = build_layer_placement(
+            heat, np.full(table.shape[0], replicas), table.shape[1]
+        )
+        candidate = _align_retained_slots(table, desired)
+        candidate = self._limit_migration_scope(
+            table,
+            candidate,
+            current_by_layer,
+            heat,
+            num_experts,
+        )
+
+        fresh_ready, fresh_gain_by_layer = self._eligible(
+            table, candidate, current_by_layer, heat, num_experts
+        )
+        selected = candidate
+        selected_ready = fresh_ready
+        selected_gain_by_layer = fresh_gain_by_layer
+
+        base_unchanged = (
+            self.pending_base is not None
+            and np.array_equal(self.pending_base, table)
+        )
+        if not fresh_ready:
+            self.pending = None
+            self.pending_base = None
+            self.pending_streak = 0
+        elif self.pending is None or not base_unchanged:
+            self.pending = candidate.copy()
+            self.pending_base = table.copy()
+            self.pending_streak = 1
+        elif np.array_equal(self.pending, candidate):
+            self.pending_streak += 1
+            selected = self.pending
+        else:
+            pending_ready, pending_gains = self._eligible(
+                table, self.pending, current_by_layer, heat, num_experts
+            )
+            # Stability means that the incumbent remains beneficial under a
+            # fresh load window, not that a deterministic optimizer reproduces
+            # the same placement. Chasing every newly optimal placement keeps
+            # resetting the streak on otherwise stable traffic and can prevent
+            # EPLB from ever applying a valid plan.
+            if pending_ready:
+                self.pending_streak += 1
+                selected = self.pending
+                selected_ready = True
+                selected_gain_by_layer = pending_gains
+            else:
+                self.pending = candidate.copy()
+                self.pending_base = table.copy()
+                self.pending_streak = 1
+
+        cooldown = (
+            self.last_apply_window is not None
+            and self.window - self.last_apply_window
+            <= _POST_APPLY_COOLDOWN_WINDOWS
+        )
+        should_apply = (
+            selected_ready
+            and self.pending_streak >= _REQUIRED_STABLE_WINDOWS
+            and not cooldown
+        )
+        if should_apply:
+            self.last_apply_window = self.window
+            self.pending = None
+            self.pending_base = None
+            self.pending_streak = 0
+
+        selected_risk_by_layer = _placement_risk_by_layer(
+            table, selected, heat, num_experts
+        )
+        selected_net_gain_by_layer = (
+            selected_gain_by_layer * _MIGRATION_AMORTIZATION_WINDOWS
+            - selected_risk_by_layer * _NORMALIZED_MIGRATION_COST
+        )
+        priority = tuple(
+            int(value)
+            for value in np.argsort(-selected_net_gain_by_layer, kind="stable")
+        )
+        return LayerDecision(
+            should_apply=should_apply,
+            placement=_immutable(selected if should_apply else table),
+            priority=priority,
+        )
+
+
+class LayerEplb(EplbPolicy):
+    def __init__(self, num_redundant_experts: int) -> None:
+        self.planner = LayerPlanner(num_redundant_experts)
+
+    def rebalance_experts(self, current_expert_table, expert_workload):
+        decision = self.planner.plan(
+            current_expert_table, expert_workload
+        )
+        return (
+            int(decision.should_apply),
+            np.asarray(decision.priority),
+            decision.placement,
+        )
+
+
+__all__ = ["LayerEplb"]

--- a/vllm_ascend/eplb/core/policy/policy_layer.py
+++ b/vllm_ascend/eplb/core/policy/policy_layer.py
@@ -7,9 +7,8 @@ from dataclasses import dataclass
 
 import numpy as np
 
-from .policy_abstract import EplbPolicy
 from .layer_placement import build_layer_placement, replay_balancedness
-
+from .policy_abstract import EplbPolicy
 
 _PER_LAYER_GAIN_EPSILON = 1e-12
 _MAX_MIGRATION_LAYER_FRACTION = 0.25
@@ -87,9 +86,7 @@ def _placement_risk_by_layer(
     mean_rank_churn = changed.mean(axis=(1, 2))
     peak_rank_churn = changed.mean(axis=2).max(axis=1)
 
-    current_owners = np.zeros(
-        (current.shape[0], num_experts, current.shape[1]), dtype=bool
-    )
+    current_owners = np.zeros((current.shape[0], num_experts, current.shape[1]), dtype=bool)
     candidate_owners = np.zeros_like(current_owners)
     for layer in range(current.shape[0]):
         for rank in range(current.shape[1]):
@@ -132,19 +129,14 @@ def _align_retained_slots(current: np.ndarray, desired) -> np.ndarray:
 
 
 def _immutable(table: np.ndarray):
-    return tuple(
-        tuple(tuple(int(value) for value in rank) for rank in layer)
-        for layer in table
-    )
+    return tuple(tuple(tuple(int(value) for value in rank) for rank in layer) for layer in table)
 
 
 class LayerPlanner:
     """Plan stable per-layer placements using implementation-owned thresholds."""
 
     def __init__(self, num_redundant_experts: int) -> None:
-        if isinstance(num_redundant_experts, bool) or not isinstance(
-            num_redundant_experts, int
-        ):
+        if isinstance(num_redundant_experts, bool) or not isinstance(num_redundant_experts, int):
             raise TypeError("num_redundant_experts must be an integer")
         if num_redundant_experts <= 0:
             raise ValueError("num_redundant_experts must be positive")
@@ -157,9 +149,8 @@ class LayerPlanner:
 
     @staticmethod
     def _scores(table: np.ndarray, heat: np.ndarray, num_experts: int) -> np.ndarray:
-        return replay_balancedness(
-            heat, *_placement_maps(table, num_experts), table.shape[1]
-        )
+        physical_to_logical, physical_to_rank, copy_count = _placement_maps(table, num_experts)
+        return replay_balancedness(heat, physical_to_logical, physical_to_rank, copy_count, table.shape[1])
 
     @classmethod
     def _limit_migration_scope(
@@ -176,16 +167,9 @@ class LayerPlanner:
             return candidate
 
         gain_by_layer = cls._scores(candidate, heat, num_experts) - current_score
-        risk_by_layer = _placement_risk_by_layer(
-            current, candidate, heat, num_experts
-        )
-        net_gain_by_layer = (
-            gain_by_layer * _MIGRATION_AMORTIZATION_WINDOWS
-            - risk_by_layer * _NORMALIZED_MIGRATION_COST
-        )
-        profitable_layers = changed_layers[
-            net_gain_by_layer[changed_layers] > _PER_LAYER_GAIN_EPSILON
-        ]
+        risk_by_layer = _placement_risk_by_layer(current, candidate, heat, num_experts)
+        net_gain_by_layer = gain_by_layer * _MIGRATION_AMORTIZATION_WINDOWS - risk_by_layer * _NORMALIZED_MIGRATION_COST
+        profitable_layers = changed_layers[net_gain_by_layer[changed_layers] > _PER_LAYER_GAIN_EPSILON]
         if profitable_layers.size == 0:
             return current.copy()
 
@@ -197,10 +181,7 @@ class LayerPlanner:
             profitable_layers.tolist(),
             key=lambda layer: (
                 -float(net_gain_by_layer[layer]),
-                -float(
-                    gain_by_layer[layer]
-                    / max(risk_by_layer[layer], _PER_LAYER_GAIN_EPSILON)
-                ),
+                -float(gain_by_layer[layer] / max(risk_by_layer[layer], _PER_LAYER_GAIN_EPSILON)),
                 -float(gain_by_layer[layer]),
                 layer,
             ),
@@ -221,9 +202,7 @@ class LayerPlanner:
         per_layer_gain = predicted - current_score
         gain = float(per_layer_gain.mean())
         changed = int(np.count_nonzero(candidate != current))
-        placement_risk = _placement_risk_by_layer(
-            current, candidate, heat, num_experts
-        )
+        placement_risk = _placement_risk_by_layer(current, candidate, heat, num_experts)
         cost = float(placement_risk.mean()) * _NORMALIZED_MIGRATION_COST
         ready = (
             changed > 0
@@ -245,9 +224,7 @@ class LayerPlanner:
                 f"{replicas} redundant experts, expected "
                 f"{self.num_redundant_experts} from configuration"
             )
-        _, desired, _, _, _ = build_layer_placement(
-            heat, np.full(table.shape[0], replicas), table.shape[1]
-        )
+        _, desired, _, _, _ = build_layer_placement(heat, np.full(table.shape[0], replicas), table.shape[1])
         candidate = _align_retained_slots(table, desired)
         candidate = self._limit_migration_scope(
             table,
@@ -257,17 +234,12 @@ class LayerPlanner:
             num_experts,
         )
 
-        fresh_ready, fresh_gain_by_layer = self._eligible(
-            table, candidate, current_by_layer, heat, num_experts
-        )
+        fresh_ready, fresh_gain_by_layer = self._eligible(table, candidate, current_by_layer, heat, num_experts)
         selected = candidate
         selected_ready = fresh_ready
         selected_gain_by_layer = fresh_gain_by_layer
 
-        base_unchanged = (
-            self.pending_base is not None
-            and np.array_equal(self.pending_base, table)
-        )
+        base_unchanged = self.pending_base is not None and np.array_equal(self.pending_base, table)
         if not fresh_ready:
             self.pending = None
             self.pending_base = None
@@ -280,9 +252,7 @@ class LayerPlanner:
             self.pending_streak += 1
             selected = self.pending
         else:
-            pending_ready, pending_gains = self._eligible(
-                table, self.pending, current_by_layer, heat, num_experts
-            )
+            pending_ready, pending_gains = self._eligible(table, self.pending, current_by_layer, heat, num_experts)
             # Stability means that the incumbent remains beneficial under a
             # fresh load window, not that a deterministic optimizer reproduces
             # the same placement. Chasing every newly optimal placement keeps
@@ -299,32 +269,21 @@ class LayerPlanner:
                 self.pending_streak = 1
 
         cooldown = (
-            self.last_apply_window is not None
-            and self.window - self.last_apply_window
-            <= _POST_APPLY_COOLDOWN_WINDOWS
+            self.last_apply_window is not None and self.window - self.last_apply_window <= _POST_APPLY_COOLDOWN_WINDOWS
         )
-        should_apply = (
-            selected_ready
-            and self.pending_streak >= _REQUIRED_STABLE_WINDOWS
-            and not cooldown
-        )
+        should_apply = selected_ready and self.pending_streak >= _REQUIRED_STABLE_WINDOWS and not cooldown
         if should_apply:
             self.last_apply_window = self.window
             self.pending = None
             self.pending_base = None
             self.pending_streak = 0
 
-        selected_risk_by_layer = _placement_risk_by_layer(
-            table, selected, heat, num_experts
-        )
+        selected_risk_by_layer = _placement_risk_by_layer(table, selected, heat, num_experts)
         selected_net_gain_by_layer = (
             selected_gain_by_layer * _MIGRATION_AMORTIZATION_WINDOWS
             - selected_risk_by_layer * _NORMALIZED_MIGRATION_COST
         )
-        priority = tuple(
-            int(value)
-            for value in np.argsort(-selected_net_gain_by_layer, kind="stable")
-        )
+        priority = tuple(int(value) for value in np.argsort(-selected_net_gain_by_layer, kind="stable"))
         return LayerDecision(
             should_apply=should_apply,
             placement=_immutable(selected if should_apply else table),
@@ -337,9 +296,7 @@ class LayerEplb(EplbPolicy):
         self.planner = LayerPlanner(num_redundant_experts)
 
     def rebalance_experts(self, current_expert_table, expert_workload):
-        decision = self.planner.plan(
-            current_expert_table, expert_workload
-        )
+        decision = self.planner.plan(current_expert_table, expert_workload)
         return (
             int(decision.should_apply),
             np.asarray(decision.priority),

--- a/vllm_ascend/eplb/eplb_updator.py
+++ b/vllm_ascend/eplb/eplb_updator.py
@@ -15,6 +15,9 @@
 # This file is a part of the vllm-ascend project.
 #
 # Todo: Once https://github.com/vllm-project/vllm/issues/22246 is merged in vllm. Remove this updator.
+import time
+from queue import Empty
+
 import numpy
 import torch
 import torch.distributed as dist
@@ -33,6 +36,7 @@ class EplbUpdator:
     def __init__(self, eplb_config, loader: D2DExpertWeightLoader, eplb_process: EplbProcess, process):
         self.eplb_config = eplb_config
         self.multi_stage = eplb_config.eplb_policy_type == 3
+        self.global_slots = eplb_config.num_redundant_experts if eplb_config.uses_global_expert_pool else 0
         self.init_eplb(self.eplb_config.expert_map_path, process)
         self.eplb_loader = loader
         self.eplb_process = eplb_process
@@ -67,6 +71,15 @@ class EplbUpdator:
 
         self.reqs = []
         self.update_info_all = []
+        self.global_update_info = {}
+        self.update_plan_active = False
+        self.awaiting_plan = False
+        self.pending_update_info = None
+        self.global_update_steps = []
+        self.global_pending_step = None
+        self.global_transfer_reqs = []
+        self.global_total_steps = 0
+        self.global_plan_started_at = 0.0
 
         self.cur_iterations: torch.int64 = 0
 
@@ -87,6 +100,15 @@ class EplbUpdator:
 
             self.adaptor.clear_all_moe_loads()
             self.cur_iterations = 0
+            self.update_plan_active = False
+            self.awaiting_plan = False
+            self.pending_update_info = None
+            self.global_update_info = {}
+            self.global_update_steps = []
+            self.global_pending_step = None
+            self.global_transfer_reqs = []
+            self.global_total_steps = 0
+            self.global_plan_started_at = 0.0
 
     def get_update_info_flag(self):
         return self.cur_iterations == (self.expert_heat_collection_interval + self.algorithm_execution_interval - 1)
@@ -103,7 +125,59 @@ class EplbUpdator:
     def wakeup_eplb_worker(self):
         self.eplb_process.planner_q.put(1)
 
+    def _poll_global_update_plan(self) -> None:
+        if self.update_plan_active or not (self.get_update_info_flag() or self.awaiting_plan):
+            return
+
+        planner_state = 1
+        if self.pending_update_info is None:
+            try:
+                self.pending_update_info = self.eplb_process.block_update_q.get_nowait()
+            except Empty:
+                planner_state = 0 if self.process.is_alive() else -1
+
+        readiness = torch.tensor([planner_state], dtype=torch.int32, device=self.device)
+        dist.all_reduce(
+            readiness,
+            op=dist.ReduceOp.MIN,
+            group=self.comm_group.device_group,
+        )
+        global_state = int(readiness.item())
+        if global_state < 0:
+            raise RuntimeError("An EPLB planner exited before publishing an update plan")
+        if global_state == 0:
+            self.awaiting_plan = True
+            return
+
+        if not isinstance(self.pending_update_info, dict):
+            raise RuntimeError("EPLB policy 4 published an invalid update plan")
+        self.global_update_info = self.pending_update_info
+        self.pending_update_info = None
+        self.awaiting_plan = False
+        self.update_plan_active = bool(self.global_update_info.get("changed", False))
+        if self.update_plan_active:
+            self.global_update_steps = list(self.global_update_info.get("steps", []))
+            if not self.global_update_steps:
+                raise RuntimeError("EPLB policy 4 published a changed plan without migration steps")
+            self.global_total_steps = len(self.global_update_steps)
+            self.global_plan_started_at = time.perf_counter()
+
+    def _start_global_update_step(self) -> None:
+        if not self.update_plan_active or self.global_pending_step is not None:
+            return
+        # An eager kernel from the preceding iteration may still read a shared
+        # slot. Drain it before changing maps or writing that slot via HCCL.
+        torch.npu.current_stream().synchronize()
+        self.global_pending_step = self.global_update_steps.pop(0)
+        self.eplb_loader.apply_global_map_updates(self.global_pending_step["deactivate"])
+        self.global_transfer_reqs = self.eplb_loader.start_global_slot_transfer(self.global_pending_step)
+
     def forward_before(self):
+        if self.global_slots:
+            self._poll_global_update_plan()
+            self._start_global_update_step()
+            return
+
         # Batch after eplb process being triggered, get update info provided by eplb process
         if self.get_update_info_flag():
             self.update_info_all = self.eplb_process.block_update_q.get()
@@ -132,14 +206,37 @@ class EplbUpdator:
                 self.compute_and_set_moe_load()
                 self.wakeup_eplb_worker()
 
-        if self.update_expert_weight_flag() and self.expert_map_record_path is None:
+        if self.global_slots and self.global_pending_step is not None:
+            self.eplb_loader.finish_global_slot_transfer(
+                self.global_transfer_reqs,
+                self.global_pending_step,
+            )
+            self.global_pending_step = None
+            self.global_transfer_reqs = []
+            if not self.global_update_steps:
+                self.shared_dict["expert_maps"] = torch.tensor(
+                    self.global_update_info["global_maps"], dtype=torch.int32
+                )
+                self.update_plan_active = False
+                if self.rank_id == 0:
+                    logger.info(
+                        "[eplb/global] Migration completed steps=%s elapsed_ms=%.3f",
+                        self.global_total_steps,
+                        (time.perf_counter() - self.global_plan_started_at) * 1000.0,
+                    )
+
+        if not self.global_slots and self.update_expert_weight_flag() and self.expert_map_record_path is None:
             self.eplb_loader.update_expert_map_and_weight(self.reqs)
 
         # One circle of eplb update includes expert_heat_collection_interval + algorithm_execution_interval
         # + num_moe_layers (for weight update). In expert_heat_collection stage, we only update the counter
         # when eplb_heat_collection_status is True. In later stages, the counter is always updated.
         # TODO(Angazenn): Decouple algorithm execution && weight update with heat collection iterations.
-        if self.cur_iterations >= self.expert_heat_collection_interval - 1 or eplb_heat_collection_status:
+        if (
+            not self.awaiting_plan
+            and not (self.global_slots and self.update_plan_active)
+            and (self.cur_iterations >= self.expert_heat_collection_interval - 1 or eplb_heat_collection_status)
+        ):
             self.update_iteration()
 
     def compute_and_set_moe_load(self):
@@ -156,6 +253,8 @@ class EplbUpdator:
 
     def warm_up_eplb(self):
         logger.info("[eplb/updator] Starting EPLB warm-up, rank=%s, world_size=%s", self.rank_id, self.world_size)
+        if not self.global_slots:
+            self.eplb_loader.initialize_redundant_expert_weights()
         self.shared_dict["expert_maps"] = self.adaptor.get_global_expert_map()
         self.compute_and_set_moe_load()
 

--- a/vllm_ascend/ops/fused_moe/moe_comm_method.py
+++ b/vllm_ascend/ops/fused_moe/moe_comm_method.py
@@ -62,6 +62,17 @@ def setup_moe_comm_method(moe_config):
         _MoECommMethods[MoECommType.ALLGATHER] = AllGatherCommImpl(moe_config)
 
 
+def resize_moe_comm_expert_layout(num_experts: int, num_local_experts: int) -> None:
+    """Resize dispatcher caches after adding a cross-layer expert pool."""
+    seen_dispatchers: set[int] = set()
+    for method in _MoECommMethods.values():
+        dispatcher = method.token_dispatcher
+        if id(dispatcher) in seen_dispatchers:
+            continue
+        dispatcher.resize_expert_layout(num_experts, num_local_experts)
+        seen_dispatchers.add(id(dispatcher))
+
+
 @dataclass
 class FusedExpertsResult:
     routed_out: torch.Tensor

--- a/vllm_ascend/ops/fused_moe/moe_mlp.py
+++ b/vllm_ascend/ops/fused_moe/moe_mlp.py
@@ -70,7 +70,7 @@ def _unified_apply_activation(
         )
     elif activation == MoEActivation.SWIGLUOAI:
         w1, _ = quant_method.get_mlp_weights(mlp_compute_input.layer)
-        _, _, hidden_size = w1.shape
+        hidden_size = (w1[0] if isinstance(w1, list) else w1).shape[-1]
         hidden_states = AscendSwigluOAIAndMul.swiglu_oai_forward(hidden_states.view(-1, hidden_size))
     elif activation == MoEActivation.SWIGLUOAI_UNINTERLEAVE:
         hidden_states = DeviceOperator.clipped_swiglu(

--- a/vllm_ascend/ops/fused_moe/routed_experts.py
+++ b/vllm_ascend/ops/fused_moe/routed_experts.py
@@ -204,7 +204,7 @@ class AscendUnquantizedFusedMoEMethod(UnquantizedFusedMoEMethod):
         if not need_trans:
             return weight
         if isinstance(weight, list):
-            return [w.transpose(1, 2) for w in weight]
+            return [w.transpose(-2, -1) for w in weight]
         return weight.transpose(1, 2)
 
     def apply_gmm1(self, mlp_compute_input: MoEMlpComputeInput):
@@ -430,7 +430,8 @@ class AscendRoutedExperts(RoutedExperts):  # type: ignore[no-redef]
             n_shared_experts if self.mix_placement else 0
         )
         allocated_redundancy = self.moe_config.num_experts - self.moe_config.num_logical_experts
-        if eplb_config.num_redundant_experts not in (0, allocated_redundancy):
+        uses_global_slots = eplb_config.uses_global_expert_pool
+        if not uses_global_slots and eplb_config.num_redundant_experts not in (0, allocated_redundancy):
             raise ValueError(
                 "Conflicting EPLB redundant expert counts: "
                 f"allocated={allocated_redundancy}, Ascend={eplb_config.num_redundant_experts}."
@@ -516,6 +517,9 @@ class AscendRoutedExperts(RoutedExperts):  # type: ignore[no-redef]
 
     def get_eplb_parameter(self, name: str):
         """Return an expert parameter from the refactored weight owner."""
+        expert_list = getattr(self, f"{name}_list", None)
+        if isinstance(expert_list, list):
+            return expert_list
         return getattr(self, name)
 
     @property

--- a/vllm_ascend/ops/fused_moe/token_dispatcher.py
+++ b/vllm_ascend/ops/fused_moe/token_dispatcher.py
@@ -76,6 +76,10 @@ class MoETokenDispatcher(ABC, Generic[TMoECombineMetadata]):
     def set_lora_context(self, lora_context) -> None:
         self.lora_context = lora_context
 
+    def resize_expert_layout(self, num_experts: int, num_local_experts: int) -> None:
+        """Update cached physical expert dimensions after weight loading."""
+        self.num_experts = int(num_experts)
+
     @property
     def ep_group(self):
         """Get expert model parallel group."""
@@ -342,6 +346,10 @@ class TokenDispatcherWithAllGather(MoETokenDispatcher[MoEAllGatherCombineMetadat
             num_experts_local.item() if torch.is_tensor(num_experts_local) else int(num_experts_local)
         )
 
+    def resize_expert_layout(self, num_experts: int, num_local_experts: int) -> None:
+        super().resize_expert_layout(num_experts, num_local_experts)
+        self.num_experts_local = int(num_local_experts)
+
     def token_dispatch(
         self,
         token_dispatch_input: MoETokenDispatchInput,
@@ -448,9 +456,23 @@ class TokenDispatcherWithAll2AllV(MoETokenDispatcher[MoEAllToAllCombineMetadata]
 
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
-        self.num_local_experts = kwargs.get("num_local_experts", 0)
+        self._set_expert_layout(self.num_experts, kwargs.get("num_local_experts", 0))
+
+        # TODO: Try local_rank = ep_group.rank_in_group
+        local_rank = torch.distributed.get_rank(group=self.ep_group)
+        backend = self.ep_group._get_backend(torch.device("npu"))
+        self.moe_all_to_all_group_name = backend.get_hccl_comm_name(local_rank)
+
+    def resize_expert_layout(self, num_experts: int, num_local_experts: int) -> None:
+        super().resize_expert_layout(num_experts, num_local_experts)
+        self._set_expert_layout(num_experts, num_local_experts)
+
+    def _set_expert_layout(self, num_experts: int, num_local_experts: int) -> None:
+        self.num_experts = int(num_experts)
+        self.num_local_experts = int(num_local_experts)
 
         assert self.num_local_experts > 0, "Expected at least one expert"
+        self.expert_ids_per_ep_rank = None
         if self.num_local_experts > 1:
             self.expert_ids_per_ep_rank = torch.tensor(
                 [i % self.num_local_experts for i in range(self.num_experts)],
@@ -466,11 +488,6 @@ class TokenDispatcherWithAll2AllV(MoETokenDispatcher[MoEAllToAllCombineMetadata]
             assert self.local_expert_indices[i] == self.local_expert_indices[i + 1] - 1, (
                 "local_expert_indices must be continuous"
             )
-
-        # TODO: Try local_rank = ep_group.rank_in_group
-        local_rank = torch.distributed.get_rank(group=self.ep_group)
-        backend = self.ep_group._get_backend(torch.device("npu"))
-        self.moe_all_to_all_group_name = backend.get_hccl_comm_name(local_rank)
 
     def token_dispatch(
         self,

--- a/vllm_ascend/patch/platform/patch_fused_moe.py
+++ b/vllm_ascend/patch/platform/patch_fused_moe.py
@@ -143,9 +143,16 @@ def _ascend_FusedMoE(
     # constructed. Propagate Ascend EPLB capacity into the upstream factory so
     # redundant expert slots are present when weights are created and loaded.
     eplb_config = get_ascend_config().eplb_config
-    if eplb_config.dynamic_eplb or eplb_config.expert_map_path is not None:
-        configured_redundancy = eplb_config.num_redundant_experts
+    use_ascend_eplb = eplb_config.dynamic_eplb or eplb_config.expert_map_path is not None
+    if use_ascend_eplb:
+        uses_global_slots = eplb_config.uses_global_expert_pool
+        configured_redundancy = 0 if uses_global_slots else eplb_config.num_redundant_experts
         upstream_redundancy = num_redundant_experts
+        if uses_global_slots and upstream_redundancy:
+            raise ValueError(
+                "EPLB policy 4 owns a cross-layer expert pool and cannot be "
+                "combined with upstream per-layer redundant experts."
+            )
         if configured_redundancy and upstream_redundancy not in (0, configured_redundancy):
             raise ValueError(
                 f"Conflicting EPLB redundant expert counts: vLLM={upstream_redundancy}, Ascend={configured_redundancy}."
@@ -156,7 +163,11 @@ def _ascend_FusedMoE(
     # the legacy Ascend quant-method path until that path also routes solely
     # through the Router.
     hash_indices_table_for_legacy_path = hash_indices_table if hash_indices_table is not None else tid2eid
-    enable_router_eplb = enable_eplb and get_current_vllm_config().use_v2_model_runner
+    # Ascend EPLB owns routing through RoutedExperts.log2phy and updates that
+    # table together with expert weights. Attaching the upstream router state
+    # here would map logical IDs twice and would not follow Ascend D2D updates.
+    # Keep router-side EPLB available only for native vLLM EPLB callers.
+    enable_router_eplb = enable_eplb and not use_ascend_eplb and get_current_vllm_config().use_v2_model_runner
     if router is None:
         router = create_ascend_fused_moe_router(
             top_k=top_k,

--- a/vllm_ascend/worker/model_runner_v1.py
+++ b/vllm_ascend/worker/model_runner_v1.py
@@ -526,14 +526,28 @@ class NPUModelRunner(GPUModelRunner):
         if self.dynamic_eplb:
             self.is_eplb_warmuped = False
             self.policy_type = eplb_config.eplb_policy_type
+            if eplb_config.uses_global_expert_pool:
+                if self.compilation_config.cudagraph_mode != CUDAGraphMode.NONE:
+                    raise ValueError("EPLB policy 4 on a prefill node currently requires eager mode")
+                if self.ascend_config.enable_fused_mc2:
+                    raise ValueError("EPLB policy 4 on a prefill node currently requires fused MC2 to be disabled")
             self.eplb_loader = D2DExpertWeightLoader()
             self.manager = Manager()
             self.shared_dict = self.manager.dict({"expert_map": None, "moe_load": None, "expert_maps": None})
+            policy_config = (
+                {
+                    "num_redundant_experts": eplb_config.num_redundant_experts,
+                    "node_role": eplb_config.eplb_node_role,
+                }
+                if self.policy_type == 4
+                else None
+            )
             self.eplb_process = EplbProcess(
                 shared_dict=self.shared_dict,
                 policy_type=self.policy_type,
                 enable_d2d=True,
                 tp_size=self.parallel_config.tensor_parallel_size,
+                policy_config=policy_config,
             )
             self.process = self.eplb_process._launch_process()
             self.eplb_updator = EplbUpdator(eplb_config, self.eplb_loader, self.eplb_process, self.process)


### PR DESCRIPTION
Add MRv1 policy 4, which keeps the base expert placement immutable and dynamically assigns a small per-rank expert pool across MoE layers based on predicted prefill benefit.\n\nReuse the existing EPLB worker, adaptor, D2D loader, and token dispatcher contracts while keeping the initial per-layer redundant expert count at zero. Document the experimental eager prefill scope and add planner and migration regression coverage.

### What this PR does / why we need it?

### Does this PR introduce _any_ user-facing change?

### How was this patch tested?

- vLLM main: https://github.com/vllm-project/vllm/commit/84030bbe3d74d99bad477a3d2e37a973ccd8865c
