### PR TITLE
[Feat][Worker] Pass lease TTL to memcache batch_alloc

### DIFF
--- a/tests/ut/distributed/ascend_store/test_pool_worker.py
+++ b/tests/ut/distributed/ascend_store/test_pool_worker.py
@@ -1445,6 +1445,10 @@ class TestKVPoolWorkerProcessLayerData(unittest.TestCase):
         )
 
     def test_evicted_allocated_gva_is_reallocated(self):
+        from vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.pool_worker import (
+            LAYERWISE_READ_LEASE_TTL_MS,
+        )
+
         worker = self._make_gva_worker()
         key = worker._make_layerwise_full_key(0, "h0")
         worker._allocated_gvas[key] = 101
@@ -1454,7 +1458,7 @@ class TestKVPoolWorkerProcessLayerData(unittest.TestCase):
 
         worker._alloc_gvas_for_save([request])
 
-        worker.m_store.batch_alloc.assert_called_once_with([key], [64])
+        worker.m_store.batch_alloc.assert_called_once_with([key], [64], LAYERWISE_READ_LEASE_TTL_MS)
         self.assertEqual(worker._allocated_gvas[key], 202)
         self.assertEqual(request.block_gvas_by_group_np[0].tolist(), [202])
 

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/backend/base.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/backend/base.py
@@ -40,7 +40,7 @@ class Backend(ABC):
     def batch_get_key_info(self, keys: list[str]):
         raise NotImplementedError(f"{type(self).__name__} does not support batch_get_key_info")
 
-    def batch_alloc(self, keys: list[str], sizes: list[int]) -> list[int]:
+    def batch_alloc(self, keys: list[str], sizes: list[int], lease_ttl_ms: int = 0) -> list[int]:
         raise NotImplementedError(f"{type(self).__name__} does not support batch_alloc")
 
     def batch_add_lease(self, keys: list[str], lease_ttl_ms: int = 0) -> list[int]:

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/backend/memcache_backend.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/backend/memcache_backend.py
@@ -250,10 +250,10 @@ class MemcacheBackend(Backend):
         assert self.store is not None
         return self.store.batch_get_key_info(keys)
 
-    def batch_alloc(self, keys: list[str], sizes: list[int]) -> list[int]:
+    def batch_alloc(self, keys: list[str], sizes: list[int], lease_ttl_ms: int = 0) -> list[int]:
         self.ensure_initialized()
         assert self.store is not None
-        return self.store.batch_alloc(keys, sizes)
+        return self.store.batch_alloc(keys, sizes, lease_ttl_ms)
 
     def batch_add_lease(self, keys: list[str], lease_ttl_ms: int = 0) -> list[int]:
         assert self.store is not None

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/pool_worker.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/pool_worker.py
@@ -1255,7 +1255,9 @@ class KVPoolWorker:
                         block_gvas.append(0)
 
                 if new_keys:
-                    new_gvas = self.m_store.batch_alloc(new_keys, [alloc_size] * len(new_keys))
+                    new_gvas = self.m_store.batch_alloc(
+                        new_keys, [alloc_size] * len(new_keys), LAYERWISE_READ_LEASE_TTL_MS
+                    )
                     if any(gva <= 0 for gva in new_gvas):
                         logger.error(
                             "alloc_gvas FAIL: req=%s group=%d alloc_size=%d new_keys=%d gvas_sample=%s zero_count=%d",
@@ -1290,6 +1292,7 @@ class KVPoolWorker:
                         allocated = self.m_store.batch_alloc(
                             [partial_key],
                             [alloc_size],
+                            LAYERWISE_READ_LEASE_TTL_MS,
                         )
                         partial_gva = allocated[0] if allocated else 0
                         if partial_gva > 0:


### PR DESCRIPTION
### What this PR does / why we need it?

The memcache_hybrid `batch_alloc` interface supports a `leaseTtlMs` parameter, but vllm-ascend currently only passes `keys` and `sizes`, so allocated blocks are not covered by a lease at allocation time.

- Add `lease_ttl_ms` parameter to `Backend.batch_alloc` and `MemcacheBackend.batch_alloc`, forwarded to the underlying memcache_hybrid store as `leaseTtlMs` (default `0` keeps existing behavior for other backends)
- Pass `LAYERWISE_READ_LEASE_TTL_MS` (5 min, the same constant already used by the layerwise load path) at both GVA allocation call sites in `_alloc_gvas_for_save` so newly allocated blocks are covered by a lease
- Update the UT assertion to cover the new argument

### Does this PR introduce _any_ user-facing change?

No

### How was this patch tested?

- Unit test updated: `tests/ut/distributed/ascend_store/test_pool_worker.py::test_evicted_allocated_gva_is_reallocated` now asserts `batch_alloc` is called with the lease TTL
- `pytest -sv tests/ut/distributed/ascend_store/` (302 passed locally; remaining failures are pre-existing on unmodified main and caused by the local Windows environment lacking `torch.npu` / real vllm)
- `ruff check` / `ruff format --check` pass
- vLLM main: https://github.com/vllm-project/vllm/commit/ba07e4a48fc951300d97eb506217dd530583dea3
