### PR TITLE
[CI] Migrate cpu-ut to a standalone job and gate the NPU test pipeline

### DIFF
--- a/.github/workflows/pr_test.yaml
+++ b/.github/workflows/pr_test.yaml
@@ -221,17 +221,30 @@ jobs:
             echo "============================"
           done
 
+  cpu-ut:
+    needs: pre-commit
+    if: ${{ needs.pre-commit.result == 'success' }}
+    uses: ./.github/workflows/_selected_tests.yaml
+    with:
+      vllm: ${{ needs.pre-commit.outputs.main_commit }}
+      ref: ${{ github.event.pull_request.head.sha }}
+      base_ref: ${{ github.base_ref }}
+      test_groups: >-
+        [{"partition_name":"cpu-ut","runner":"linux-amd64-cpu-8-hk","image_tag":"9.1.0-910b-ubuntu22.04-py3.12","npu_type":"cpu","num_npus":0,"tests":"tests/ut"}]
+      enable-coverage: false
+
   recommend-tests:
     name: Recommend tests
-    needs: pre-commit
+    needs: [pre-commit, cpu-ut]
     # The recommendation only runs under the ready-precise label: that is the
     # only mode whose result depends on it. ready-all runs --all-tests and
-    # unlabeled runs select nothing, so both skip this job. The pre-commit
-    # check is explicit so the job can never be made to run after a failed
-    # pre-commit by adding !cancelled().
+    # unlabeled runs select nothing, so both skip this job. The pre-commit +
+    # cpu-ut checks are explicit so the job can never be made to run after a
+    # failed upstream by adding !cancelled().
     if: >-
       ${{
         needs.pre-commit.result == 'success' &&
+        needs.cpu-ut.result == 'success' &&
         contains(github.event.pull_request.labels.*.name, 'ready-precise')
       }}
     runs-on: linux-amd64-cpu-8-hk
@@ -330,15 +343,16 @@ jobs:
   select-tests:
     needs:
       - pre-commit
+      - cpu-ut
       - recommend-tests
     # select-tests is the single producer of test_groups / base_sha / has_tests.
     # It runs only when a ready label asks for test execution; unlabeled runs
     # skip it and ci-gate decides whether that is allowed (no src paths) or
     # requires a label (src or ci_pipeline paths present). !cancelled() keeps
     # it out of the graph only when the workflow itself is cancelled; the
-    # explicit pre-commit success check stops it from running when pre-commit
-    # failed (!cancelled() alone would override the transitive skip). The
-    # src/ci_pipeline path categories are computed by the paths-filter step
+    # explicit pre-commit + cpu-ut success check stops it from running when
+    # either failed (!cancelled() alone would override the transitive skip).
+    # The src/ci_pipeline path categories are computed by the paths-filter step
     # in pre-commit. Modes:
     #   recommended - recommend job succeeded with coverage paths (ready-precise)
     #   all         - ready-all forced, or the PR touches the CI pipeline itself
@@ -347,6 +361,7 @@ jobs:
       ${{
         !cancelled() &&
         needs.pre-commit.result == 'success' &&
+        needs.cpu-ut.result == 'success' &&
         (
           contains(github.event.pull_request.labels.*.name, 'ready-precise') ||
           contains(github.event.pull_request.labels.*.name, 'ready-all')
@@ -461,7 +476,8 @@ jobs:
           echo "Recommended paths from coverage:"
           cat "$LIST_FILE"
           python3 .github/workflows/scripts/select_tests.py \
-            --test-list-file "$LIST_FILE"
+            --test-list-file "$LIST_FILE" \
+            --skip-cpu-ut
 
       - name: Select all tests
         id: scope-all
@@ -469,7 +485,9 @@ jobs:
         run: |
           git config --global --add safe.directory "$GITHUB_WORKSPACE"
           pip install regex
-          python3 .github/workflows/scripts/select_tests.py --all-tests
+          python3 .github/workflows/scripts/select_tests.py \
+            --all-tests \
+            --skip-cpu-ut
 
       - name: Set no-tests output when no tests selected
         id: noop
@@ -634,7 +652,7 @@ jobs:
   # Summary gate job — use this single, stable name as the required status check
   # in GitHub branch protection rules instead of tracking individual matrix job names.
   ci-gate:
-    needs: [pre-commit, select-tests, run-selected-tests, run-selected-tests-a5]
+    needs: [pre-commit, cpu-ut, select-tests, run-selected-tests, run-selected-tests-a5]
     if: ${{ !cancelled() }}
     runs-on: linux-amd64-cpu-2-hk
     steps:
@@ -649,12 +667,14 @@ jobs:
           set -euo pipefail
 
           PRE_COMMIT_RESULT="${{ needs.pre-commit.result }}"
+          CPU_UT_RESULT="${{ needs.cpu-ut.result }}"
           SELECT_TESTS_RESULT="${{ needs.select-tests.result }}"
           HAS_TESTS="${{ needs.select-tests.outputs.has_tests == 'true' }}"
           HAS_TESTS_A5="${{ needs.select-tests.outputs.has_tests_a5 }}"
 
           echo "=== CI Gate Summary ==="
           echo "pre-commit: ${PRE_COMMIT_RESULT}"
+          echo "cpu-ut: ${CPU_UT_RESULT}"
           echo "src filter: ${{ needs.pre-commit.outputs.src }}"
           echo "ci_pipeline filter: ${{ needs.pre-commit.outputs.ci_pipeline }}"
           echo "select-tests: ${SELECT_TESTS_RESULT} (source: ${SELECTION_SOURCE:-unknown})"
@@ -668,6 +688,12 @@ jobs:
           if [ "${PRE_COMMIT_RESULT}" != "success" ]; then
             echo "::error::pre-commit did not succeed (result: ${PRE_COMMIT_RESULT})."
             echo "::error::This job runs lint / markdownlint / mypy / gitleaks on all files. Open the failed 'pre-commit' job above, fix the reported issues in your PR, and push again. No test label is needed for this failure."
+            exit 1
+          fi
+
+          if [ "${CPU_UT_RESULT}" != "success" ]; then
+            echo "::error::cpu-ut did not succeed (result: ${CPU_UT_RESULT})."
+            echo "::error::Open the failed 'cpu-ut' job above, fix the failing test(s) and push again."
             exit 1
           fi
 

--- a/.github/workflows/scripts/select_tests.py
+++ b/.github/workflows/scripts/select_tests.py
@@ -104,6 +104,13 @@ CPU_UT_BATCH_PATH = "tests/ut"
 # Full-suite mode roots scanned by --all-tests.
 _ALL_TESTS_ROOTS = ("tests/ut", "tests/e2e/pull_request")
 
+# When set via --skip-cpu-ut, tests/ut targets are dropped from every selection
+# mode. CPU UTs are executed by the cpu-ut job on every PR; the PR test
+# scheduling path must not reserve a runner for them. Scheduled full-suite
+# coverage runs (schedule_test_coverage.yaml) do NOT pass this flag, so their
+# --all-tests runs keep collecting CPU UT coverage.
+_SKIP_CPU_UT = False
+
 # Generic ``linux-aarch64-a3-N-`` labels are mixed pools of 560T and 752T
 # machines (i.e. random machine class). When accuracy tests are selected (or
 # the full suite runs), reroute those partitions to the dedicated 560T labels.
@@ -301,6 +308,12 @@ def _route_explicit_test_target(
     groups: dict[PartitionKey, list[str]],
 ) -> None:
     """Route a single explicit UT/E2E target to the appropriate runner group."""
+    if _SKIP_CPU_UT and (target == CPU_UT_BATCH_ALIAS or _is_ut_path(_pytest_node_file_path(target))):
+        print(
+            f"Warning: Skipping CPU UT target (--skip-cpu-ut is set): {target}",
+            file=sys.stderr,
+        )
+        return
     # The coverage recommender emits "cpu-ut" (the batch label of the
     # default_cpu_ut module) instead of the real pytest path "tests/ut".
     # Map it back so the recommended path runs the same CPU UTs the
@@ -731,7 +744,17 @@ def main():
         default=None,
         help="Force route all non-CPU tests to an exact label from runner_label.json",
     )
+    parser.add_argument(
+        "--skip-cpu-ut",
+        action="store_true",
+        help="Drop tests/ut targets from every selection mode. Used by the PR "
+        "scheduling path, where CPU UTs run in the cpu-ut job instead of "
+        "on a reserved runner. Scheduled full-suite coverage runs do not pass "
+        "this flag, so --all-tests keeps collecting CPU UT coverage.",
+    )
     args = parser.parse_args()
+    global _SKIP_CPU_UT
+    _SKIP_CPU_UT = args.skip_cpu_ut
     meta = yaml.safe_load(args.config.read_text()) or {}
     runners = _load_runners()
     partition_config = _load_partition_config(meta)
@@ -772,6 +795,12 @@ def main():
     elif args.all_tests:
         matched_modules = ["all"]
         for root in _ALL_TESTS_ROOTS:
+            if _SKIP_CPU_UT and _is_ut_path(root):
+                print(
+                    f"  Skipping {root} (--skip-cpu-ut is set)",
+                    file=sys.stderr,
+                )
+                continue
             path = Path(root)
             if _is_ut_path(root):
                 _scan_ut_test_dir(root, all_groups)


### PR DESCRIPTION
### What this PR does / why we need it?

Run the CPU unit tests in a dedicated `cpu-ut` job (depending on `pre-commit`) instead of bundling them into the NPU test pipeline. The new job reuses `_selected_tests.yaml` with `enable-coverage: false`.

- Add `--skip-cpu-ut` to select_tests.py to drop `tests/ut` targets from all selection modes.
- Pass `--skip-cpu-ut` in both `select-tests` calls in pr_test.yaml.
- Gate `recommend-tests` and `select-tests` on the `cpu-ut` result and include it in the `ci-gate` check.


### Does this PR introduce _any_ user-facing change?

### How was this patch tested?


- vLLM main: https://github.com/vllm-project/vllm/commit/ba07e4a48fc951300d97eb506217dd530583dea3
