### PR TITLE
[Doc][Misc] Restructure GLM-5.2 tutorial and detail PD deployments

### DIFF
--- a/docs/source/tutorials/models/GLM5.2.md
+++ b/docs/source/tutorials/models/GLM5.2.md
@@ -1,29 +1,28 @@
 # GLM-5.2
 
-## Introduction
+## 1 Introduction
 
 [GLM-5.2](https://huggingface.co/zai-org/GLM-5.2) uses a Mixture-of-Experts (MoE) architecture and targets complex systems engineering and long-horizon agentic tasks.
 
 This document will show the main verification steps of the model, including supported features, feature configuration, environment preparation, single-node and multi-node deployment, accuracy and performance evaluation.
 
-## Supported Features
+## 2 Supported Features
 
 Refer to [Supported Features List](../../user_guide/support_matrix/supported_models.md) to get the model's supported feature matrix.
 
 Refer to [Feature Guide](../../user_guide/feature_guide/index.md) to get the feature's configuration.
 
-## Environment Preparation
-
-### Model Weight
+## 3 Model Weight
 
 - `GLM-5.2`(BF16 version): requires 2 Atlas 800 A3 (128GB × 8) node or 4 Atlas 800 A2 (64GB × 8) node.[Download model weight](https://www.modelscope.cn/models/ZhipuAI/GLM-5.2).
 - `GLM-5.2-w8a8`: requires 1 Atlas 800 A3 (128GB × 8) node or 2 Atlas 800 A2 (64GB × 8) node.[Download model weight](https://www.modelscope.cn/models/Eco-Tech/GLM-5.2-w8a8).
+- `GLM-5.2-w8a8c8`(Quantized version for Atlas 800 A3): requires 2 Atlas 800 A3 (64GB × 16) node.[Download model weight](https://modelers.cn/models/Eco-Tech/GLM-5.2-w8a8c8).
 - `GLM-5.2-w4a8c8`: requires 1 Atlas 800 A3 (128GB × 8) node or 2 Atlas 800 A2 (64GB × 8) node.[Download model weight](https://modelscope.cn/models/Eco-Tech/GLM-5.2-w4a8c8).
 - You can use [msmodelslim](https://gitcode.com/Ascend/msmodelslim) to quantize the model directly.
 
 It is recommended to download the model weight to the shared directory of multiple nodes, such as `/root/.cache/`
 
-### Installation
+## 4 Installation
 
 - You can use our official docker image to run GLM-5.2 directly.
 - [KV Cache Pool (Ascend Store) Deployment Guide](https://docs.vllm.ai/projects/ascend/zh-cn/latest/user_guide/feature_guide/kv_pool.html)
@@ -106,9 +105,11 @@ It is recommended to download the model weight to the shared directory of multip
 
 If you want to deploy multi-node environment, you need to set up environment on each node.
 
-## Deployment
+## 5 Deployment
 
-### Single-node Deployment
+### 5.1 Context Below 1M
+
+#### 5.1.1 Single-node Deployment
 
 - Quantized model `GLM-5.2-w4a8c8` can be deployed on 1 Atlas 800 A3 (64GB × 16) .
 
@@ -151,7 +152,7 @@ The parameters are explained as follows:
 
 - For single-node deployment, we recommend using `dp1tp16` and turn off expert parallel in low-latency scenarios.
 
-### Multi-node Deployment
+#### 5.1.2 Multi-node Deployment
 
 If you want to deploy multi-node environment, you need to verify multi-node communication according to [verify multi-node communication environment](../../installation.md#verify-multi-node-communication).
 
@@ -289,14 +290,10 @@ If you want to deploy multi-node environment, you need to verify multi-node comm
     export OMP_NUM_THREADS=10
     export PYTORCH_NPU_ALLOC_CONF=expandable_segments:True
     export ACL_OP_INIT_MODE=1
-    #export VLLM_ASCEND_ENABLE_FLASHCOMM1=1
-    #export USE_MULTI_GROUPS_KV_CACHE=1
-    #export USE_MULTI_BLOCK_POOL=1
     export TASK_QUEUE_ENABLE=1
     export CPU_AFFINITY_CONF=1
     export VLLM_ENGINE_READY_TIMEOUT_S=1200
 
-    export VLLM_VERSION=0.21.0
     vllm serve /root/.cache/modelscope/hub/models/vllm-ascend/GLM-5.2-w4a8c8 \
     --max_model_len 40000 \
     --max-num-batched-tokens 4096 \
@@ -344,14 +341,10 @@ If you want to deploy multi-node environment, you need to verify multi-node comm
     export OMP_NUM_THREADS=10
     export PYTORCH_NPU_ALLOC_CONF=expandable_segments:True
     export ACL_OP_INIT_MODE=1
-    #export VLLM_ASCEND_ENABLE_FLASHCOMM1=1
-    #export USE_MULTI_GROUPS_KV_CACHE=1
-    #export USE_MULTI_BLOCK_POOL=1
     export TASK_QUEUE_ENABLE=1
     export CPU_AFFINITY_CONF=1
     export VLLM_ENGINE_READY_TIMEOUT_S=1200
 
-    export VLLM_VERSION=0.21.0
     vllm serve /root/.cache/modelscope/hub/models/vllm-ascend/GLM-5.2-w4a8c8 \
     --max_model_len 40000 \
     --max-num-batched-tokens 4096 \
@@ -376,11 +369,15 @@ If you want to deploy multi-node environment, you need to verify multi-node comm
     --speculative-config '{"num_speculative_tokens": 5, "method": "deepseek_mtp", "enforce_eager": true}'
     ```
 
-### Prefill-Decode Disaggregation
+#### 5.1.3 Prefill-Decode Disaggregation
 
 We'd like to show the deployment guide of `GLM-5.2` on multi-node environment with 1P1D for better performance.
 
-Prefill-Decode disaggregation can be deployed on 4 Atlas 800 A3 (64GB × 32).
+In the PD disaggregation scenario, Mooncake is used as the KV cache transfer connector between the prefill and decode nodes. Please refer to [KV Cache Pool (Ascend Store) Deployment Guide](https://github.com/vllm-project/vllm-ascend/blob/main/docs/source/user_guide/feature_guide/kv_pool.md) for the Mooncake configuration.
+
+##### 5.1.3.1 Deployment on 4 Atlas 800 A3
+
+Prefill-Decode disaggregation with the `GLM-5.2-w8a8c8` weights can be deployed on 4 Atlas 800 A3 (64GB × 16).
 
 Before you start, please
 
@@ -395,53 +392,20 @@ Before you start, please
 
     def parse_args():
         parser = argparse.ArgumentParser()
-        parser.add_argument(
-            "--dp-size",
-            type=int,
-            required=True,
-            help="Data parallel size."
-        )
-        parser.add_argument(
-            "--tp-size",
-            type=int,
-            default=1,
-            help="Tensor parallel size."
-        )
-        parser.add_argument(
-            "--dp-size-local",
-            type=int,
-            default=-1,
-            help="Local data parallel size."
-        )
-        parser.add_argument(
-            "--dp-rank-start",
-            type=int,
-            default=0,
-            help="Starting rank for data parallel."
-        )
-        parser.add_argument(
-            "--dp-address",
-            type=str,
-            required=True,
-            help="IP address for data parallel master node."
-        )
-        parser.add_argument(
-            "--dp-rpc-port",
-            type=str,
-            default=12345,
-            help="Port for data parallel master node."
-        )
-        parser.add_argument(
-            "--vllm-start-port",
-            type=int,
-            default=9000,
-            help="Starting port for the engine."
-        )
+        parser.add_argument("--dp-size", type=int, required=True, help="Data parallel size.")
+        parser.add_argument("--tp-size", type=int, default=1, help="Tensor parallel size.")
+        parser.add_argument("--pp-size", type=int, default=1, help="Pipeline parallel size.")
+        parser.add_argument("--dp-size-local", type=int, default=-1, help="Local data parallel size.")
+        parser.add_argument("--dp-rank-start", type=int, default=0, help="Starting rank for data parallel.")
+        parser.add_argument("--dp-address", type=str, required=True, help="IP address for data parallel master node.")
+        parser.add_argument("--dp-rpc-port", type=str, default="12321", help="Port for data parallel master node.")
+        parser.add_argument("--vllm-start-port", type=int, default=8000, help="Starting port for the engine.")
         return parser.parse_args()
 
     args = parse_args()
     dp_size = args.dp_size
     tp_size = args.tp_size
+    pp_size = args.pp_size
     dp_size_local = args.dp_size_local
     if dp_size_local == -1:
         dp_size_local = dp_size
@@ -449,6 +413,7 @@ Before you start, please
     dp_address = args.dp_address
     dp_rpc_port = args.dp_rpc_port
     vllm_start_port = args.vllm_start_port
+    gpus_per_dp_rank = tp_size * pp_size
 
     def run_command(visible_devices, dp_rank, vllm_engine_port):
         command = [
@@ -461,6 +426,7 @@ Before you start, please
             dp_address,
             dp_rpc_port,
             str(tp_size),
+            str(pp_size),
         ]
         subprocess.run(command, check=True)
 
@@ -471,14 +437,16 @@ Before you start, please
             sys.exit(1)
 
         processes = []
-        num_cards = dp_size_local * tp_size
+        num_cards = dp_size_local * gpus_per_dp_rank
+
         for i in range(dp_size_local):
             dp_rank = dp_rank_start + i
             vllm_engine_port = vllm_start_port + i
-            visible_devices = ",".join(str(x) for x in range(i * tp_size, (i + 1) * tp_size))
-            process = multiprocessing.Process(target=run_command,
-                                            args=(visible_devices, dp_rank,
-                                                    vllm_engine_port))
+            visible_devices = ",".join(str(x) for x in range(i * gpus_per_dp_rank, (i + 1) * gpus_per_dp_rank))
+            process = multiprocessing.Process(
+                target=run_command,
+                args=(visible_devices, dp_rank, vllm_engine_port)
+            )
             processes.append(process)
             process.start()
 
@@ -511,49 +479,50 @@ Before you start, please
         export ACL_OP_INIT_MODE=1
         export ASCEND_A3_ENABLE=1
 
-        export ASCEND_RT_VISIBLE_DEVICES=$1
         export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/local/lib
 
         export VLLM_ASCEND_ENABLE_FLASHCOMM1=1
 
-        vllm serve /root/.cache/modelscope/hub/models/vllm-ascend/GLM-5.2-w4a8c8 \
+        # pp=2
+        export VLLM_PP_LAYER_PARTITION="41,37"
+
+        vllm serve <MODEL_PATH> \
             --host 0.0.0.0 \
             --port $2 \
-            --data-parallel-size $3 \
-            --data-parallel-rank $4 \
-            --data-parallel-address $5 \
-            --data-parallel-rpc-port $6 \
-            --tensor-parallel-size $7 \
+            --tensor-parallel-size 16 \
             --enable-expert-parallel \
-            --speculative-config '{"num_speculative_tokens":1, "method":"deepseek_mtp","enforce_eager":true}' \
+            --pipeline-parallel-size 2 \
+            --distributed-executor-backend mp \
+            --master-addr $local_ip \
+            --master-port 7060 \
+            --nnodes 2 \
+            --node-rank 0 \
+            --speculative-config '{"num_speculative_tokens": 1, "method":"deepseek_mtp","enforce_eager":true}' \
             --seed 1024 \
             --served-model-name glm-5 \
-            --max-model-len 133120 \
-            --additional-config '{"recompute_scheduler_enable" : false,"multistream_overlap_shared_expert": true, "enable_dsa_cp":true,"enable_sparse_sfa_c8": false, "enable_sparse_li_c8": true,"c8_enable_reshape_optim":false}' \
-            --max-num-batched-tokens 8192 \
+            --max-model-len 202752 \
+            --safetensors-load-strategy 'prefetch' \
+            --additional-config '{"fuse_muls_add":true, "enable_dsa_cp":true, "enable_sparse_sfa_c8": true, "enable_sparse_li_c8": true, "c8_enable_reshape_optim":true}' \
+            --max-num-batched-tokens 16384 \
             --trust-remote-code \
+            --enable-prefix-caching \
             --max-num-seqs 64 \
             --quantization ascend \
-            --gpu-memory-utilization 0.92 \
+            --gpu-memory-utilization 0.85 \
+            --api-server-count 1 \
             --enforce-eager \
             --enable-auto-tool-choice \
             --tool-call-parser glm47 \
             --reasoning-parser glm45 \
-            --kv-transfer-config \
-            '{"kv_connector": "MooncakeConnectorV1",
-            "kv_role": "kv_producer",
-            "kv_port": "30000",
-            "engine_id": "0",
-            "kv_connector_extra_config": {
-                        "use_ascend_direct": true,
-                        "prefill": {
-                                "dp_size": 4,
-                                "tp_size": 8
-                        },
-                        "decode": {
-                                "dp_size": 32,
-                                "tp_size": 1
-                        }
+            --kv-transfer-config '{
+                "kv_connector": "MooncakeConnectorV1",
+                "kv_role": "kv_producer",
+                "kv_port": "30000",
+                "engine_id": "0",
+                "kv_connector_extra_config": {
+                    "use_ascend_direct": true,
+                    "prefill": {"dp_size": 1, "pp_size": 2, "tp_size": 16, "pp_layer_partition": "41,37"},
+                    "decode": { "dp_size": 16, "tp_size": 2}
                 }
             }'
 
@@ -564,6 +533,9 @@ Before you start, please
         ```shell
         nic_name="xxxx" # change to your own nic name
         local_ip="xxxx" # change to your own ip
+
+        # The value of node_p0_ip must be consistent with the value of local_ip set in prefill node 0 (p0, PP master node)
+        node_p0_ip="xxxx"
 
         export VLLM_ASCEND_ENABLE_FUSED_MC2=1
         export HCCL_OP_EXPANSION_MODE="AIV"
@@ -581,49 +553,50 @@ Before you start, please
         export ACL_OP_INIT_MODE=1
         export ASCEND_A3_ENABLE=1
 
-        export ASCEND_RT_VISIBLE_DEVICES=$1
         export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/local/lib
 
         export VLLM_ASCEND_ENABLE_FLASHCOMM1=1
 
-        vllm serve /root/.cache/modelscope/hub/models/vllm-ascend/GLM-5.2-w4a8c8 \
+        # pp=2
+        export VLLM_PP_LAYER_PARTITION="41,37"
+
+        vllm serve <MODEL_PATH> \
             --host 0.0.0.0 \
             --port $2 \
-            --data-parallel-size $3 \
-            --data-parallel-rank $4 \
-            --data-parallel-address $5 \
-            --data-parallel-rpc-port $6 \
-            --tensor-parallel-size $7 \
+            --tensor-parallel-size 16 \
             --enable-expert-parallel \
-            --speculative-config '{"num_speculative_tokens":1, "method":"deepseek_mtp","enforce_eager":true}' \
+            --pipeline-parallel-size 2 \
+            --distributed-executor-backend mp \
+            --master-addr $node_p0_ip \
+            --master-port 7060 \
+            --nnodes 2 \
+            --node-rank 1 \
+            --speculative-config '{"num_speculative_tokens": 1, "method":"deepseek_mtp","enforce_eager":true}' \
             --seed 1024 \
             --served-model-name glm-5 \
-            --max-model-len 133120 \
-            --additional-config '{"recompute_scheduler_enable" : false,"multistream_overlap_shared_expert": true, "enable_dsa_cp":true,"enable_sparse_sfa_c8": false, "enable_sparse_li_c8": true,"c8_enable_reshape_optim":false}' \
-            --max-num-batched-tokens 8192 \
+            --max-model-len 202752 \
+            --safetensors-load-strategy 'prefetch' \
+            --additional-config '{"fuse_muls_add":true, "enable_dsa_cp":true, "enable_sparse_sfa_c8": true, "enable_sparse_li_c8": true, "c8_enable_reshape_optim":true}' \
+            --max-num-batched-tokens 16384 \
             --trust-remote-code \
+            --enable-prefix-caching \
             --max-num-seqs 64 \
             --quantization ascend \
-            --gpu-memory-utilization 0.92 \
+            --gpu-memory-utilization 0.85 \
+            --headless \
             --enforce-eager \
             --enable-auto-tool-choice \
             --tool-call-parser glm47 \
             --reasoning-parser glm45 \
-            --kv-transfer-config \
-            '{"kv_connector": "MooncakeConnectorV1",
-            "kv_role": "kv_producer",
-            "kv_port": "30000",
-            "engine_id": "0",
-            "kv_connector_extra_config": {
-                        "use_ascend_direct": true,
-                        "prefill": {
-                                "dp_size": 4,
-                                "tp_size": 8
-                        },
-                        "decode": {
-                                "dp_size": 32,
-                                "tp_size": 1
-                        }
+            --kv-transfer-config '{
+                "kv_connector": "MooncakeConnectorV1",
+                "kv_role": "kv_producer",
+                "kv_port": "30000",
+                "engine_id": "0",
+                "kv_connector_extra_config": {
+                    "use_ascend_direct": true,
+                    "prefill": {"dp_size": 1, "pp_size": 2, "tp_size": 16, "pp_layer_partition": "41,37"},
+                    "decode": { "dp_size": 16, "tp_size": 2}
                 }
             }'
         ```
@@ -634,6 +607,10 @@ Before you start, please
         nic_name="xxxx" # change to your own nic name
         local_ip="xxxx" # change to your own ip
 
+        # d0: api server on this node; d1: --headless
+        server_role_args="--api-server-count 1"
+
+        export VLLM_ASCEND_ENABLE_FUSED_MC2=1
         export HCCL_OP_EXPANSION_MODE="AIV"
 
         export HCCL_IF_IP=$local_ip
@@ -651,10 +628,11 @@ Before you start, please
         export ASCEND_A3_ENABLE=1
         export TASK_QUEUE_ENABLE=1
         export ASCEND_RT_VISIBLE_DEVICES=$1
-        export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/local/lib
-        export VLLM_ASCEND_ENABLE_FUSED_MC2=1
 
-        vllm serve /root/.cache/modelscope/hub/models/vllm-ascend/GLM-5.2-w4a8c8 \
+        export VLLM_ASCEND_ENABLE_MLAPO=1
+        export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/local/lib
+
+        vllm serve <MODEL_PATH> \
             --host 0.0.0.0 \
             --port $2 \
             --data-parallel-size $3 \
@@ -665,33 +643,30 @@ Before you start, please
             --enable-expert-parallel \
             --seed 1024 \
             --served-model-name glm-5 \
-            --max-model-len 133120 \
-            --max-num-batched-tokens 164 \
+            --max-model-len 202752 \
+            --safetensors-load-strategy 'prefetch' \
+            --max-num-batched-tokens 192 \
             --compilation-config '{"cudagraph_mode":"FULL_DECODE_ONLY"}' \
             --speculative-config '{"num_speculative_tokens": 5,  "method":"deepseek_mtp","enforce_eager":true}' \
-            --additional-config '{"recompute_scheduler_enable":true,"multistream_overlap_shared_expert":true,"enable_sparse_sfa_c8": false, "enable_sparse_li_c8": true}' \
+            --additional-config '{"fuse_muls_add":true, "recompute_scheduler_enable":true, "enable_sparse_sfa_c8": true, "enable_sparse_li_c8": true}' \
             --trust-remote-code \
             --max-num-seqs 32 \
-            --gpu-memory-utilization 0.92 \
+            --gpu-memory-utilization 0.90 \
+            ${server_role_args} \
+            --async-scheduling \
             --quantization ascend \
             --enable-auto-tool-choice \
             --tool-call-parser glm47 \
             --reasoning-parser glm45 \
-            --kv-transfer-config \
-            '{"kv_connector": "MooncakeConnectorV1",
-            "kv_role": "kv_consumer",
-            "kv_port": "30100",
-            "engine_id": "1",
-            "kv_connector_extra_config": {
-                        "use_ascend_direct": true,
-                        "prefill": {
-                                "dp_size": 4,
-                                "tp_size": 8
-                        },
-                        "decode": {
-                                "dp_size": 32,
-                                "tp_size": 1
-                        }
+            --kv-transfer-config '{
+                "kv_connector": "MooncakeConnectorV1",
+                "kv_role": "kv_consumer",
+                "kv_port": "30200",
+                "engine_id": "2",
+                "kv_connector_extra_config": {
+                    "use_ascend_direct": true,
+                    "prefill": {"dp_size": 1, "pp_size": 2, "tp_size": 16, "pp_layer_partition": "41,37"},
+                    "decode": { "dp_size": 16, "tp_size": 2}
                 }
             }'
         ```
@@ -702,6 +677,10 @@ Before you start, please
         nic_name="xxxx" # change to your own nic name
         local_ip="xxxx" # change to your own ip
 
+        # d0: api server on this node; d1: --headless
+        server_role_args="--headless"
+
+        export VLLM_ASCEND_ENABLE_FUSED_MC2=1
         export HCCL_OP_EXPANSION_MODE="AIV"
 
         export HCCL_IF_IP=$local_ip
@@ -715,14 +694,16 @@ Before you start, please
 
         export PYTORCH_NPU_ALLOC_CONF=expandable_segments:True
         export HCCL_BUFFSIZE=256
+
         export ACL_OP_INIT_MODE=1
         export ASCEND_A3_ENABLE=1
         export TASK_QUEUE_ENABLE=1
         export ASCEND_RT_VISIBLE_DEVICES=$1
-        export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/local/lib
-        export VLLM_ASCEND_ENABLE_FUSED_MC2=1
 
-        vllm serve /root/.cache/modelscope/hub/models/vllm-ascend/GLM-5.2-w4a8c8 \
+        export VLLM_ASCEND_ENABLE_MLAPO=1
+        export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/local/lib
+
+        vllm serve <MODEL_PATH> \
             --host 0.0.0.0 \
             --port $2 \
             --data-parallel-size $3 \
@@ -733,33 +714,30 @@ Before you start, please
             --enable-expert-parallel \
             --seed 1024 \
             --served-model-name glm-5 \
-            --max-model-len 133120 \
-            --max-num-batched-tokens 164 \
+            --max-model-len 202752 \
+            --safetensors-load-strategy 'prefetch' \
+            --max-num-batched-tokens 192 \
             --compilation-config '{"cudagraph_mode":"FULL_DECODE_ONLY"}' \
             --speculative-config '{"num_speculative_tokens": 5,  "method":"deepseek_mtp","enforce_eager":true}' \
-            --additional-config '{"recompute_scheduler_enable":true,"multistream_overlap_shared_expert":true,"enable_sparse_sfa_c8": false, "enable_sparse_li_c8": true}' \
+            --additional-config '{"fuse_muls_add":true, "recompute_scheduler_enable":true, "enable_sparse_sfa_c8": true, "enable_sparse_li_c8": true}' \
             --trust-remote-code \
             --max-num-seqs 32 \
-            --gpu-memory-utilization 0.92 \
+            --gpu-memory-utilization 0.90 \
+            ${server_role_args} \
+            --async-scheduling \
             --quantization ascend \
             --enable-auto-tool-choice \
             --tool-call-parser glm47 \
             --reasoning-parser glm45 \
-            --kv-transfer-config \
-            '{"kv_connector": "MooncakeConnectorV1",
-            "kv_role": "kv_consumer",
-            "kv_port": "30100",
-            "engine_id": "1",
-            "kv_connector_extra_config": {
-                        "use_ascend_direct": true,
-                        "prefill": {
-                                "dp_size": 4,
-                                "tp_size": 8
-                        },
-                        "decode": {
-                                "dp_size": 32,
-                                "tp_size": 1
-                        }
+            --kv-transfer-config '{
+                "kv_connector": "MooncakeConnectorV1",
+                "kv_role": "kv_consumer",
+                "kv_port": "30200",
+                "engine_id": "2",
+                "kv_connector_extra_config": {
+                    "use_ascend_direct": true,
+                    "prefill": {"dp_size": 1, "pp_size": 2, "tp_size": 16, "pp_layer_partition": "41,37"},
+                    "decode": { "dp_size": 16, "tp_size": 2}
                 }
             }'
         ```
@@ -769,29 +747,27 @@ Once the preparation is done, you can start the server with the following comman
 1. Prefill node 0
 
     ```shell
-    # change ip to your own
-    python launch_online_dp.py --dp-size 4 --tp-size 8  --dp-size-local 1 --dp-rank-start 0 --dp-address $node_p0_ip --dp-rpc-port 16591 --vllm-start-port 9081
+    bash run_dp_template.sh
     ```
 
 2. Prefill node 1
 
     ```shell
-    # change ip to your own
-    python launch_online_dp.py --dp-size 4 --tp-size 8  --dp-size-local 1 --dp-rank-start 1 --dp-address $node_p0_ip --dp-rpc-port 16591 --vllm-start-port 9081
+    bash run_dp_template.sh
     ```
 
 3. Decode node 0
 
     ```shell
     # change ip to your own
-    python launch_online_dp.py --dp-size 32 --tp-size 1 --dp-size-local 4 --dp-rank-start 0 --dp-address $node_d0_ip --dp-rpc-port 16600 --vllm-start-port 9900
+    python launch_online_dp.py --dp-size 16 --tp-size 2 --pp-size 1 --dp-size-local 8 --dp-rank-start 0 --dp-address $node_d0_ip --dp-rpc-port 16600 --vllm-start-port 9900
     ```
 
 4. Decode node 1
 
     ```shell
     # change ip to your own
-    python launch_online_dp.py --dp-size 32 --tp-size 1 --dp-size-local 4 --dp-rank-start 4 --dp-address $node_d0_ip --dp-rpc-port 16600 --vllm-start-port 9900
+    python launch_online_dp.py --dp-size 16 --tp-size 2 --pp-size 1 --dp-size-local 8 --dp-rank-start 8 --dp-address $node_d0_ip --dp-rpc-port 16600 --vllm-start-port 9900
     ```
 
 To set up request forwarding, run the following script on any machine. You can get the proxy program in the repository's examples: [load_balance_proxy_server_example.py](https://github.com/vllm-project/vllm-ascend/blob/main/examples/disaggregated_prefill_v1/load_balance_proxy_server_example.py)
@@ -805,12 +781,8 @@ python load_balance_proxy_server_example.py \
     --host 0.0.0.0 \
     --prefiller-hosts \
       $node_p0_ip \
-      $node_p0_ip \
-      $node_p1_ip \
-      $node_p1_ip \
     --prefiller-ports \
-      9081 9082 \
-      9081 9082 \
+      9081 \
     --decoder-hosts \
       $node_d0_ip \
       $node_d0_ip \
@@ -820,36 +792,48 @@ python load_balance_proxy_server_example.py \
       $node_d0_ip \
       $node_d0_ip \
       $node_d0_ip \
-      $node_d0_ip \
-      $node_d0_ip \
-      $node_d0_ip \
-      $node_d0_ip \
-      $node_d0_ip \
-      $node_d0_ip \
-      $node_d0_ip \
-      $node_d0_ip \
-      $node_d1_ip \
-      $node_d1_ip \
-      $node_d1_ip \
-      $node_d1_ip \
-      $node_d1_ip \
-      $node_d1_ip \
-      $node_d1_ip \
-      $node_d1_ip \
-      $node_d1_ip \
-      $node_d1_ip \
-      $node_d1_ip \
-      $node_d1_ip \
-      $node_d1_ip \
-      $node_d1_ip \
-      $node_d1_ip \
-      $node_d1_ip \
     --decoder-ports \
-      9900 9901 9902 9903 9904 9905 9906 9907 9908 9909 9910 9911 9912 9913 9914 9915 \
-      9900 9901 9902 9903 9904 9905 9906 9907 9908 9909 9910 9911 9912 9913 9914 9915
+      9900 9901 9902 9903 9904 9905 9906 9907
 ```
 
-#### Deployment on 8 Atlas 800 A2
+Key Parameter Descriptions:
+
+Only the key parameters specific to this model/scenario are described below. `max-model-len` and `max-num-seqs` need to be set according to the actual usage scenario.
+
+**PP2 prefill node-specific configurations (p0/p1):**
+
+- `VLLM_PP_LAYER_PARTITION="41,37"` / `--pipeline-parallel-size 2` / `--nnodes 2` / `--node-rank`: The prefill engine is split as PP2 over the two prefill nodes — the 78 layers are partitioned as `41/37`. `--node-rank` is `0` on prefill node 0 (p0) and `1` on prefill node 1 (p1).
+- `--distributed-executor-backend mp` / `--master-addr` / `--master-port 7060`: PP runs over two nodes with the `mp` executor (no Ray required). `--master-addr` is `$local_ip` on prefill node 0 (p0, PP master) and `$node_p0_ip` on prefill node 1 (p1).
+- `VLLM_ASCEND_ENABLE_FUSED_MC2=1`: Enables the fused `dispatch_ffn_combine`/`mega_moe` operators.
+- `VLLM_ASCEND_ENABLE_FLASHCOMM1=1`: Enables FlashComm optimization to reduce communication and computation overhead on prefill nodes.
+- `--enforce-eager`: The prefill side runs in eager mode (the `FULL_DECODE_ONLY` graph capture is used on the decode side instead).
+- `--speculative-config '{"num_speculative_tokens": 1, ...}'`: Minimal MTP speculation during prefill (decode nodes use a higher count, see below).
+- `fuse_muls_add` / `enable_dsa_cp` / `enable_sparse_sfa_c8` / `enable_sparse_li_c8` / `c8_enable_reshape_optim` (in `--additional-config`): Mul-Add fusion, DSA context parallelism for long-context prefill, the SFA/LI sparse attention optimizations and the reshape optimization of the C8 quantized model.
+
+**Decode node-specific configurations (d0/d1):**
+
+- `VLLM_ASCEND_ENABLE_MLAPO=1`: MLAPO fusion on decode nodes for memory-bandwidth-bound token generation.
+- `--max-num-batched-tokens 192`: Small batch token limit on decode nodes — decode processes one target token plus the 5 speculated MTP tokens per sequence per step (`(5 + 1) × 32`).
+- `--speculative-config '{"num_speculative_tokens": 5, ...}'`: Higher MTP speculation count on decode nodes to maximize decode throughput.
+- `recompute_scheduler_enable=true` (in `--additional-config`): Enables the recomputation scheduler. When the decode node KV cache is insufficient, requests are sent back to the prefill node to recompute the KV cache.
+- `--async-scheduling`: Async scheduling on the decode side.
+
+**Mooncake KV transfer configuration (`--kv-transfer-config`):**
+
+- `"kv_connector": "MooncakeConnectorV1"`: Uses Mooncake as the KV cache transfer connector between prefill and decode nodes.
+- `"kv_role": "kv_producer"` / `"kv_consumer"`: `kv_producer` on prefill nodes, `kv_consumer` on decode nodes.
+- `"kv_port"`: Port for Mooncake KV transfer communication. Use different port ranges for prefill (`30000`) and decode (`30200`) node groups.
+- `"use_ascend_direct": true`: Enables Ascend direct transfer for KV cache, reducing latency.
+- `"engine_id"`: Fixed engine id of the Mooncake connector per role group: `0` for the prefill engine (shared by the two PP ranks) and `2` for the decode engines.
+- `"prefill"` / `"decode"` sections: Specify the parallelism of the prefill and decode node groups respectively. These must match the actual deployment topology (`prefill: dp_size 1, pp_size 2, tp_size 16, pp_layer_partition "41,37"`, `decode: dp_size 16, tp_size 2`).
+
+**Request forwarding (proxy):**
+
+- The proxy program can be found in [load_balance_proxy_server_example.py](https://github.com/vllm-project/vllm-ascend/blob/main/examples/disaggregated_prefill_v1/load_balance_proxy_server_example.py).
+
+Please refer to [envs.py](https://github.com/vllm-project/vllm-ascend/blob/main/vllm_ascend/envs.py) for further explanation and restrictions of the environment variables above.
+
+##### 5.1.3.2 Deployment on 8 Atlas 800 A2
 
 On Atlas 800 A2, where each node exposes 8 cards, the same global P/D topology (Prefill `DP4 TP8`, Decode `DP8 TP4`) is split across 8 nodes: 4 prefill nodes hosting 1 DP rank each (8 cards per rank), and 4 decode nodes hosting 2 DP ranks each (4 cards per rank). The `launch_online_dp.py` above is reused as-is. The prefill side enables FlashComm1 and DSA CP; the decode side enables MLAPO and `DYNAMIC_EPLB` with a `FULL_DECODE_ONLY` graph. Both sides enable prefix caching and MTP (`num_speculative_tokens=3`). All IPs, NIC names, ports and weight paths below are placeholders.
 
@@ -1120,7 +1104,7 @@ Some configurations for optimization are shown below:
 
 Please refer to the following python file for further explanation and restrictions of the environment variables above: [envs.py](https://github.com/vllm-project/vllm-ascend/blob/main/vllm_ascend/envs.py)
 
-### 1M Context Configuration
+### 5.2 1M Context Configuration
 
 Recommended configurations for serving `GLM-5.2` with a 1M context window on Atlas 800 A3 (64GB x 16) and quantized GLM-5.2(W4A8C8) weights:
 
@@ -1128,9 +1112,9 @@ Recommended configurations for serving `GLM-5.2` with a 1M context window on Atl
 | ---- | -------- | ----------- | ------- |
 | Single-node co-located | 1 Atlas 800 A3 (64GB x 16) | `DP1 PP1 TP16 PCP1 DCP16` | `1024000` |
 | Dual-node co-located | 2 Atlas 800 A3 (64GB x 16) | `DP4 PP1 TP8 PCP1 DCP8` | `1024000` |
-| 1P1D PD disaggregation | 1 prefiller with 2 A3 nodes + 1 decoder with 2 A3 nodes | Prefill `DP4 PP1 TP8 PCP1 DCP8`, Decode `DP4 PP1 TP8 PCP1 DCP8` | `1024000` |
+| 1P1D PD disaggregation | 4 Atlas 800 A3 (64GB x 16) | Prefill `DP2 PP1 TP16 PCP1 DCP16`, Decode `DP4 PP1 TP8 PCP1 DCP8` | `1048576` |
 
-#### Single-Node 1M Deployment
+#### 5.2.1 Single-Node 1M Deployment
 
 Recommended command:
 
@@ -1169,7 +1153,7 @@ vllm serve <MODEL_PATH> \
   --safetensors-load-strategy prefetch
 ```
 
-#### Dual-Node Co-Located 1M Deployment
+#### 5.2.2 Dual-Node Co-Located 1M Deployment
 
 Recommended command for both co-located nodes:
 
@@ -1224,166 +1208,513 @@ vllm serve <MODEL_PATH> \
   --safetensors-load-strategy prefetch
 ```
 
-#### PD Disaggregation 1M Deployment
+#### 5.2.3 PD Disaggregation 1M Deployment
 
-Recommended command for both prefiller nodes:
+PD disaggregation for the 1M context with the `GLM-5.2-w8a8c8` weights can be deployed on 4 Atlas 800 A3 (64GB × 16).
 
-```shell
-nic_name="<NIC_NAME>"
-local_ip="<CURRENT_PREFILL_NODE_IP>"
-node_p0_ip="<PREFILL_NODE0_IP>"
-# Prefiller node 0: data_parallel_start_rank=0, server_role_args="--api-server-count 1"
-# Prefiller node 1: data_parallel_start_rank=2, server_role_args="--headless"
-data_parallel_start_rank=0
-server_role_args="--api-server-count 1"
+Before you start, please
 
-export HCCL_IF_IP=$local_ip
-export GLOO_SOCKET_IFNAME=$nic_name
-export TP_SOCKET_IFNAME=$nic_name
-export HCCL_SOCKET_IFNAME=$nic_name
+prepare the script `launch_online_dp.py` on each node (used by the prefill and decode nodes below to pass the engine port and DP parameters):
 
-export VLLM_ASCEND_ENABLE_NZ=1
-export HCCL_OP_EXPANSION_MODE="AIV"
-export OMP_PROC_BIND=false
-export OMP_NUM_THREADS=20
-export HCCL_BUFFSIZE=768
-export PYTORCH_NPU_ALLOC_CONF=expandable_segments:True
-export VLLM_WORKER_MULTIPROC_METHOD=spawn
-export TASK_QUEUE_ENABLE=1
-export VLLM_MOONCAKE_ABORT_REQUEST_TIMEOUT=480
+    ```python
+    import argparse
+    import multiprocessing
+    import os
+    import subprocess
+    import sys
 
-vllm serve <MODEL_PATH> \
-  --seed 1024 \
-  --host 0.0.0.0 \
-  --port 9081 \
-  --served-model-name glm-52 \
-  --max-model-len 1024000 \
-  --max-num-batched-tokens 16384 \
-  --gpu-memory-utilization 0.75 \
-  ${server_role_args} \
-  --max-num-seqs 8 \
-  --data-parallel-size 4 \
-  --data-parallel-size-local 2 \
-  --data-parallel-start-rank $data_parallel_start_rank \
-  --data-parallel-address $node_p0_ip \
-  --data-parallel-rpc-port 16591 \
-  --pipeline-parallel-size 1 \
-  --tensor-parallel-size 8 \
-  --prefill-context-parallel-size 1 \
-  --decode-context-parallel-size 8 \
-  --cp-kv-cache-interleave-size 128 \
-  --enforce-eager \
-  --additional-config '{"enable_flashcomm1": true, "enable_dsa_cp": true, "ascend_compilation_config": {"enable_npugraph_ex": true, "enable_static_kernel": false}, "fuse_muls_add": true, "multistream_overlap_shared_expert": true, "enable_mc2_hierarchy_comm": false, "enable_sparse_sfa_c8": true, "enable_sparse_li_c8": true, "enable_cpu_binding": true, "recompute_scheduler_enable": true}' \
-  --speculative-config '{"num_speculative_tokens": 1, "method": "deepseek_mtp", "enforce_eager": true}' \
-  --quantization ascend \
-  --enable-expert-parallel \
-  --safetensors-load-strategy prefetch \
-  --kv-transfer-config \
-  '{"kv_connector": "MooncakeConnectorV1",
-    "kv_role": "kv_producer",
-    "kv_port": "30000",
-    "engine_id": "0",
-    "kv_connector_extra_config": {
-      "use_ascend_direct": true,
-      "prefill": {
-        "dp_size": 4,
-        "tp_size": 8
-      },
-      "decode": {
-        "dp_size": 4,
-        "tp_size": 8
-      }
-    }
-  }'
-```
+    def parse_args():
+        parser = argparse.ArgumentParser()
+        parser.add_argument(
+            "--dp-size",
+            type=int,
+            required=True,
+            help="Data parallel size."
+        )
+        parser.add_argument(
+            "--tp-size",
+            type=int,
+            default=1,
+            help="Tensor parallel size."
+        )
+        parser.add_argument(
+            "--dp-size-local",
+            type=int,
+            default=-1,
+            help="Local data parallel size."
+        )
+        parser.add_argument(
+            "--dp-rank-start",
+            type=int,
+            default=0,
+            help="Starting rank for data parallel."
+        )
+        parser.add_argument(
+            "--dp-address",
+            type=str,
+            required=True,
+            help="IP address for data parallel master node."
+        )
+        parser.add_argument(
+            "--dp-rpc-port",
+            type=str,
+            default=12345,
+            help="Port for data parallel master node."
+        )
+        parser.add_argument(
+            "--vllm-start-port",
+            type=int,
+            default=9000,
+            help="Starting port for the engine."
+        )
+        return parser.parse_args()
 
-Recommended command for both decoder nodes:
+    args = parse_args()
+    dp_size = args.dp_size
+    tp_size = args.tp_size
+    dp_size_local = args.dp_size_local
+    if dp_size_local == -1:
+        dp_size_local = dp_size
+    dp_rank_start = args.dp_rank_start
+    dp_address = args.dp_address
+    dp_rpc_port = args.dp_rpc_port
+    vllm_start_port = args.vllm_start_port
 
-```shell
-nic_name="<NIC_NAME>"
-local_ip="<CURRENT_DECODE_NODE_IP>"
-node_d0_ip="<DECODE_NODE0_IP>"
-# Decoder node 0: data_parallel_start_rank=0, server_role_args="--api-server-count 1"
-# Decoder node 1: data_parallel_start_rank=2, server_role_args="--headless"
-data_parallel_start_rank=0
-server_role_args="--api-server-count 1"
+    def run_command(visible_devices, dp_rank, vllm_engine_port):
+        command = [
+            "bash",
+            "./run_dp_template.sh",
+            visible_devices,
+            str(vllm_engine_port),
+            str(dp_size),
+            str(dp_rank),
+            dp_address,
+            dp_rpc_port,
+            str(tp_size),
+        ]
+        subprocess.run(command, check=True)
 
-export HCCL_IF_IP=$local_ip
-export GLOO_SOCKET_IFNAME=$nic_name
-export TP_SOCKET_IFNAME=$nic_name
-export HCCL_SOCKET_IFNAME=$nic_name
+    if __name__ == "__main__":
+        template_path = "./run_dp_template.sh"
+        if not os.path.exists(template_path):
+            print(f"Template file {template_path} does not exist.")
+            sys.exit(1)
 
-export VLLM_ASCEND_ENABLE_NZ=1
-export HCCL_OP_EXPANSION_MODE="AIV"
-export OMP_PROC_BIND=false
-export OMP_NUM_THREADS=20
-export HCCL_BUFFSIZE=768
-export PYTORCH_NPU_ALLOC_CONF=expandable_segments:True
-export VLLM_WORKER_MULTIPROC_METHOD=spawn
-export TASK_QUEUE_ENABLE=1
-export VLLM_MOONCAKE_ABORT_REQUEST_TIMEOUT=480
+        processes = []
+        num_cards = dp_size_local * tp_size
+        for i in range(dp_size_local):
+            dp_rank = dp_rank_start + i
+            vllm_engine_port = vllm_start_port + i
+            visible_devices = ",".join(str(x) for x in range(i * tp_size, (i + 1) * tp_size))
+            process = multiprocessing.Process(target=run_command,
+                                            args=(visible_devices, dp_rank,
+                                                    vllm_engine_port))
+            processes.append(process)
+            process.start()
 
-vllm serve <MODEL_PATH> \
-  --seed 1024 \
-  --host 0.0.0.0 \
-  --port 9900 \
-  --served-model-name glm-52 \
-  --max-model-len 1024000 \
-  --max-num-batched-tokens 128 \
-  --gpu-memory-utilization 0.93 \
-  ${server_role_args} \
-  --max-num-seqs 32 \
-  --data-parallel-size 4 \
-  --data-parallel-size-local 2 \
-  --data-parallel-start-rank $data_parallel_start_rank \
-  --data-parallel-address $node_d0_ip \
-  --data-parallel-rpc-port 16600 \
-  --pipeline-parallel-size 1 \
-  --tensor-parallel-size 8 \
-  --prefill-context-parallel-size 1 \
-  --decode-context-parallel-size 8 \
-  --cp-kv-cache-interleave-size 128 \
-  --compilation-config '{"cudagraph_mode": "FULL_DECODE_ONLY"}' \
-  --additional-config '{"enable_flashcomm1": false, "enable_dsa_cp": false, "ascend_compilation_config": {"enable_npugraph_ex": true, "enable_static_kernel": false}, "fuse_muls_add": true, "multistream_overlap_shared_expert": true, "enable_mc2_hierarchy_comm": false, "enable_sparse_sfa_c8": true, "enable_sparse_li_c8": true, "enable_cpu_binding": true, "recompute_scheduler_enable": true}' \
-  --speculative-config '{"num_speculative_tokens": 3, "method": "deepseek_mtp", "enforce_eager": true}' \
-  --quantization ascend \
-  --enable-expert-parallel \
-  --safetensors-load-strategy prefetch \
-  --kv-transfer-config \
-  '{"kv_connector": "MooncakeConnectorV1",
-    "kv_role": "kv_consumer",
-    "kv_port": "30100",
-    "engine_id": "1",
-    "kv_connector_extra_config": {
-      "use_ascend_direct": true,
-      "prefill": {
-        "dp_size": 4,
-        "tp_size": 8
-      },
-      "decode": {
-        "dp_size": 4,
-        "tp_size": 8
-      }
-    }
-  }'
-```
+        for process in processes:
+            process.join()
+    ```
 
-Recommended proxy command:
+prepare the script `run_dp_template.sh` on each node.
+
+1. Prefill node 0
+
+    ```shell
+    nic_name="<NIC_NAME>" # change to your own nic name
+    local_ip="<CURRENT_PREFILL_NODE_IP>" # change to your own ip
+    # p0: api server on this node; p1: --headless
+    server_role_args="--api-server-count 1"
+
+    export VLLM_ASCEND_ENABLE_FUSED_MC2=1
+    export HCCL_OP_EXPANSION_MODE="AIV"
+
+    export VLLM_ENGINE_READY_TIMEOUT_S=100000
+    export VLLM_RPC_TIMEOUT=3600000
+    export VLLM_EXECUTE_MODEL_TIMEOUT_SECONDS=30000
+    export HCCL_EXEC_TIMEOUT=204
+    export HCCL_CONNECT_TIMEOUT=7200
+    export ASCEND_CONNECT_TIMEOUT=10000
+    export ASCEND_TRANSFER_TIMEOUT=10000
+    export MF_GROUP_JOIN_MAX_TIMEOUT=1200
+
+    export HCCL_IF_IP=$local_ip
+    export GLOO_SOCKET_IFNAME=$nic_name
+    export TP_SOCKET_IFNAME=$nic_name
+    export HCCL_SOCKET_IFNAME=$nic_name
+
+    export OMP_PROC_BIND=false
+    export OMP_NUM_THREADS=1
+    export PYTORCH_NPU_ALLOC_CONF=expandable_segments:True
+    export HCCL_BUFFSIZE=400
+
+    export ACL_OP_INIT_MODE=1
+    export ASCEND_A3_ENABLE=1
+
+    export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/local/lib
+
+    export VLLM_ASCEND_ENABLE_FLASHCOMM1=1
+
+    vllm serve <MODEL_PATH> \
+        --host 0.0.0.0 \
+        --port $2 \
+        --data-parallel-size $3 \
+        --data-parallel-rank $4 \
+        --data-parallel-address $5 \
+        --data-parallel-rpc-port $6 \
+        --tensor-parallel-size $7 \
+        --enable-expert-parallel \
+        --prefill-context-parallel-size 1 \
+        --decode-context-parallel-size 16 \
+        --cp-kv-cache-interleave-size 128 \
+        --speculative-config '{"num_speculative_tokens": 1, "method":"deepseek_mtp","enforce_eager":true}' \
+        --seed 1024 \
+        --served-model-name glm-5 \
+        --max-model-len 1048576 \
+        --safetensors-load-strategy 'prefetch' \
+        --additional-config '{"fuse_muls_add":true, "multistream_overlap_shared_expert": true, "enable_dsa_cp":true, "enable_sparse_sfa_c8": true, "enable_sparse_li_c8": true, "c8_enable_reshape_optim":true, "mega_moe_max_tokens": 8192}' \
+        --max-num-batched-tokens 8192 \
+        --trust-remote-code \
+        --enable-prefix-caching \
+        --max-num-seqs 64 \
+        --quantization ascend \
+        --gpu-memory-utilization 0.85 \
+        ${server_role_args} \
+        --enforce-eager \
+        --enable-auto-tool-choice \
+        --tool-call-parser glm47 \
+        --reasoning-parser glm45 \
+        --kv-transfer-config '{
+            "kv_connector": "MooncakeConnectorV1",
+            "kv_role": "kv_producer",
+            "kv_port": "30000",
+            "engine_id": "0",
+            "kv_connector_extra_config": {
+                "use_ascend_direct": true,
+                "prefill": {"dp_size": 2, "tp_size": 16},
+                "decode": { "dp_size": 4, "tp_size": 8}
+            }
+        }'
+    ```
+
+2. Prefill node 1
+
+    DP rank `1`, engine port `9082`. Same script as p0 with `server_role_args="--headless"` (non-master node, no API server); `--data-parallel-address` (`$5`) still points to prefill node 0 (DP master node).
+
+    ```shell
+    nic_name="<NIC_NAME>" # change to your own nic name
+    local_ip="<CURRENT_PREFILL_NODE_IP>" # change to your own ip
+    # p0: api server on this node; p1: --headless
+    server_role_args="--headless"
+
+    export VLLM_ASCEND_ENABLE_FUSED_MC2=1
+    export HCCL_OP_EXPANSION_MODE="AIV"
+
+    export VLLM_ENGINE_READY_TIMEOUT_S=100000
+    export VLLM_RPC_TIMEOUT=3600000
+    export VLLM_EXECUTE_MODEL_TIMEOUT_SECONDS=30000
+    export HCCL_EXEC_TIMEOUT=204
+    export HCCL_CONNECT_TIMEOUT=7200
+    export ASCEND_CONNECT_TIMEOUT=10000
+    export ASCEND_TRANSFER_TIMEOUT=10000
+    export MF_GROUP_JOIN_MAX_TIMEOUT=1200
+
+    export HCCL_IF_IP=$local_ip
+    export GLOO_SOCKET_IFNAME=$nic_name
+    export TP_SOCKET_IFNAME=$nic_name
+    export HCCL_SOCKET_IFNAME=$nic_name
+
+    export OMP_PROC_BIND=false
+    export OMP_NUM_THREADS=1
+    export PYTORCH_NPU_ALLOC_CONF=expandable_segments:True
+    export HCCL_BUFFSIZE=400
+
+    export ACL_OP_INIT_MODE=1
+    export ASCEND_A3_ENABLE=1
+
+    export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/local/lib
+
+    export VLLM_ASCEND_ENABLE_FLASHCOMM1=1
+
+    vllm serve <MODEL_PATH> \
+        --host 0.0.0.0 \
+        --port $2 \
+        --data-parallel-size $3 \
+        --data-parallel-rank $4 \
+        --data-parallel-address $5 \
+        --data-parallel-rpc-port $6 \
+        --tensor-parallel-size $7 \
+        --enable-expert-parallel \
+        --prefill-context-parallel-size 1 \
+        --decode-context-parallel-size 16 \
+        --cp-kv-cache-interleave-size 128 \
+        --speculative-config '{"num_speculative_tokens": 1, "method":"deepseek_mtp","enforce_eager":true}' \
+        --seed 1024 \
+        --served-model-name glm-5 \
+        --max-model-len 1048576 \
+        --safetensors-load-strategy 'prefetch' \
+        --additional-config '{"fuse_muls_add":true, "multistream_overlap_shared_expert": true, "enable_dsa_cp":true, "enable_sparse_sfa_c8": true, "enable_sparse_li_c8": true, "c8_enable_reshape_optim":true, "mega_moe_max_tokens": 8192}' \
+        --max-num-batched-tokens 8192 \
+        --trust-remote-code \
+        --enable-prefix-caching \
+        --max-num-seqs 64 \
+        --quantization ascend \
+        --gpu-memory-utilization 0.85 \
+        ${server_role_args} \
+        --enforce-eager \
+        --enable-auto-tool-choice \
+        --tool-call-parser glm47 \
+        --reasoning-parser glm45 \
+        --kv-transfer-config '{
+            "kv_connector": "MooncakeConnectorV1",
+            "kv_role": "kv_producer",
+            "kv_port": "30000",
+            "engine_id": "0",
+            "kv_connector_extra_config": {
+                "use_ascend_direct": true,
+                "prefill": {"dp_size": 2, "tp_size": 16},
+                "decode": { "dp_size": 4, "tp_size": 8}
+            }
+        }'
+    ```
+
+3. Decode node 0
+
+    ```shell
+    nic_name="<NIC_NAME>" # change to your own nic name
+    local_ip="<CURRENT_DECODE_NODE_IP>" # change to your own ip
+
+    # d0: api server on this node; d1: --headless
+    server_role_args="--api-server-count 1"
+
+    export VLLM_ASCEND_ENABLE_FUSED_MC2=1
+    export HCCL_OP_EXPANSION_MODE="AIV"
+
+    export VLLM_ENGINE_READY_TIMEOUT_S=100000
+    export VLLM_RPC_TIMEOUT=3600000
+    export VLLM_EXECUTE_MODEL_TIMEOUT_SECONDS=30000
+    export HCCL_EXEC_TIMEOUT=204
+    export HCCL_CONNECT_TIMEOUT=7200
+    export ASCEND_CONNECT_TIMEOUT=10000
+    export ASCEND_TRANSFER_TIMEOUT=10000
+    export MF_GROUP_JOIN_MAX_TIMEOUT=1200
+
+    export HCCL_IF_IP=$local_ip
+    export GLOO_SOCKET_IFNAME=$nic_name
+    export TP_SOCKET_IFNAME=$nic_name
+    export HCCL_SOCKET_IFNAME=$nic_name
+
+    #Mooncake
+    export OMP_PROC_BIND=false
+    export OMP_NUM_THREADS=1
+
+    export PYTORCH_NPU_ALLOC_CONF=expandable_segments:True
+    export HCCL_BUFFSIZE=400
+
+    export ACL_OP_INIT_MODE=1
+    export ASCEND_A3_ENABLE=1
+    export TASK_QUEUE_ENABLE=1
+
+    export VLLM_ASCEND_ENABLE_MLAPO=1
+    export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/local/lib
+
+    vllm serve <MODEL_PATH> \
+        --host 0.0.0.0 \
+        --port $2 \
+        --data-parallel-size $3 \
+        --data-parallel-rank $4 \
+        --data-parallel-address $5 \
+        --data-parallel-rpc-port $6 \
+        --tensor-parallel-size $7 \
+        --enable-expert-parallel \
+        --prefill-context-parallel-size 1 \
+        --decode-context-parallel-size 8 \
+        --cp-kv-cache-interleave-size 128 \
+        --seed 1024 \
+        --served-model-name glm-5 \
+        --max-model-len 1048576 \
+        --safetensors-load-strategy 'prefetch' \
+        --max-num-batched-tokens 192 \
+        --compilation-config '{"cudagraph_mode":"FULL_DECODE_ONLY"}' \
+        --speculative-config '{"num_speculative_tokens": 5,  "method":"deepseek_mtp","enforce_eager":true}' \
+        --additional-config '{"fuse_muls_add":true, "recompute_scheduler_enable":true, "multistream_overlap_shared_expert":true, "enable_sparse_sfa_c8": true, "enable_sparse_li_c8": true}' \
+        --trust-remote-code \
+        --max-num-seqs 32 \
+        --gpu-memory-utilization 0.90 \
+        ${server_role_args} \
+        --async-scheduling \
+        --quantization ascend \
+        --enable-auto-tool-choice \
+        --tool-call-parser glm47 \
+        --reasoning-parser glm45 \
+        --kv-transfer-config '{
+            "kv_connector": "MooncakeConnectorV1",
+            "kv_role": "kv_consumer",
+            "kv_port": "30200",
+            "engine_id": "2",
+            "kv_connector_extra_config": {
+                "use_ascend_direct": true,
+                "prefill": {"dp_size": 2, "tp_size": 16},
+                "decode": { "dp_size": 4, "tp_size": 8}
+            }
+        }'
+    ```
+
+4. Decode node 1
+
+    ```shell
+    nic_name="<NIC_NAME>" # change to your own nic name
+    local_ip="<CURRENT_DECODE_NODE_IP>" # change to your own ip
+
+    # d0: api server on this node; d1: --headless
+    server_role_args="--headless"
+
+    export VLLM_ASCEND_ENABLE_FUSED_MC2=1
+    export HCCL_OP_EXPANSION_MODE="AIV"
+
+    export VLLM_ENGINE_READY_TIMEOUT_S=100000
+    export VLLM_RPC_TIMEOUT=3600000
+    export VLLM_EXECUTE_MODEL_TIMEOUT_SECONDS=30000
+    export HCCL_EXEC_TIMEOUT=204
+    export HCCL_CONNECT_TIMEOUT=7200
+    export ASCEND_CONNECT_TIMEOUT=10000
+    export ASCEND_TRANSFER_TIMEOUT=10000
+    export MF_GROUP_JOIN_MAX_TIMEOUT=1200
+
+    export HCCL_IF_IP=$local_ip
+    export GLOO_SOCKET_IFNAME=$nic_name
+    export TP_SOCKET_IFNAME=$nic_name
+    export HCCL_SOCKET_IFNAME=$nic_name
+
+    #Mooncake
+    export OMP_PROC_BIND=false
+    export OMP_NUM_THREADS=1
+
+    export PYTORCH_NPU_ALLOC_CONF=expandable_segments:True
+    export HCCL_BUFFSIZE=400
+
+    export ACL_OP_INIT_MODE=1
+    export ASCEND_A3_ENABLE=1
+    export TASK_QUEUE_ENABLE=1
+
+    export VLLM_ASCEND_ENABLE_MLAPO=1
+    export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/local/lib
+
+    vllm serve <MODEL_PATH> \
+        --host 0.0.0.0 \
+        --port $2 \
+        --data-parallel-size $3 \
+        --data-parallel-rank $4 \
+        --data-parallel-address $5 \
+        --data-parallel-rpc-port $6 \
+        --tensor-parallel-size $7 \
+        --enable-expert-parallel \
+        --prefill-context-parallel-size 1 \
+        --decode-context-parallel-size 8 \
+        --cp-kv-cache-interleave-size 128 \
+        --seed 1024 \
+        --served-model-name glm-5 \
+        --max-model-len 1048576 \
+        --safetensors-load-strategy 'prefetch' \
+        --max-num-batched-tokens 192 \
+        --compilation-config '{"cudagraph_mode":"FULL_DECODE_ONLY"}' \
+        --speculative-config '{"num_speculative_tokens": 5,  "method":"deepseek_mtp","enforce_eager":true}' \
+        --additional-config '{"fuse_muls_add":true, "recompute_scheduler_enable":true, "multistream_overlap_shared_expert":true, "enable_sparse_sfa_c8": true, "enable_sparse_li_c8": true}' \
+        --trust-remote-code \
+        --max-num-seqs 32 \
+        --gpu-memory-utilization 0.90 \
+        ${server_role_args} \
+        --async-scheduling \
+        --quantization ascend \
+        --enable-auto-tool-choice \
+        --tool-call-parser glm47 \
+        --reasoning-parser glm45 \
+        --kv-transfer-config '{
+            "kv_connector": "MooncakeConnectorV1",
+            "kv_role": "kv_consumer",
+            "kv_port": "30200",
+            "engine_id": "2",
+            "kv_connector_extra_config": {
+                "use_ascend_direct": true,
+                "prefill": {"dp_size": 2, "tp_size": 16},
+                "decode": { "dp_size": 4, "tp_size": 8}
+            }
+        }'
+    ```
+
+Once the preparation is done, start the server on each node:
+
+1. Prefill node 0
+
+    ```shell
+    # change ip to your own
+    python launch_online_dp.py --dp-size 2 --tp-size 16 --dp-size-local 1 --dp-rank-start 0 --dp-address $node_p0_ip --dp-rpc-port 16591 --vllm-start-port 9081
+    ```
+
+2. Prefill node 1
+
+    ```shell
+    # change ip to your own
+    python launch_online_dp.py --dp-size 2 --tp-size 16 --dp-size-local 1 --dp-rank-start 1 --dp-address $node_p0_ip --dp-rpc-port 16591 --vllm-start-port 9082
+    ```
+
+3. Decode node 0
+
+    ```shell
+    # change ip to your own
+    python launch_online_dp.py --dp-size 4 --tp-size 8 --dp-size-local 2 --dp-rank-start 0 --dp-address $node_d0_ip --dp-rpc-port 16600 --vllm-start-port 9900
+    ```
+
+4. Decode node 1
+
+    ```shell
+    # change ip to your own
+    python launch_online_dp.py --dp-size 4 --tp-size 8 --dp-size-local 2 --dp-rank-start 2 --dp-address $node_d0_ip --dp-rpc-port 16600 --vllm-start-port 9900
+    ```
+
+To set up request forwarding, run the following script on any machine.
 
 ```shell
 unset http_proxy
 unset https_proxy
 
 python load_balance_proxy_server_example.py \
-  --host 0.0.0.0 \
-  --port 8000 \
-  --prefiller-hosts <PREFILL_NODE0_IP> \
-  --prefiller-ports 9081 \
-  --decoder-hosts <DECODE_NODE0_IP> \
-  --decoder-ports 9900
+    --port 8000 \
+    --host 0.0.0.0 \
+    --prefiller-hosts \
+      $node_p0_ip \
+    --prefiller-ports \
+      9081 \
+    --decoder-hosts \
+      $node_d0_ip \
+      $node_d0_ip \
+    --decoder-ports \
+      9900 9901
 ```
 
-## Functional Verification
+Key Parameter Descriptions (in addition to [Prefill-Decode Disaggregation](#513-prefill-decode-disaggregation) and [Single-Node 1M Deployment](#521-single-node-1m-deployment)):
+
+The `run_dp_template.sh` templates use the positional parameters passed by `launch_online_dp.py`: `$1` = visible devices, `$2` = engine port, `$3` = data-parallel-size, `$4` = data-parallel-rank, `$5` = data-parallel-address, `$6` = data-parallel-rpc-port, `$7` = tensor-parallel-size.
+
+**1M-specific environment variables (both prefiller and decoder nodes):**
+
+- `VLLM_ENGINE_READY_TIMEOUT_S=100000` / `VLLM_RPC_TIMEOUT=3600000` / `VLLM_EXECUTE_MODEL_TIMEOUT_SECONDS=30000` / `HCCL_EXEC_TIMEOUT=204` / `HCCL_CONNECT_TIMEOUT=7200` / `ASCEND_CONNECT_TIMEOUT=10000` / `ASCEND_TRANSFER_TIMEOUT=10000` / `MF_GROUP_JOIN_MAX_TIMEOUT=1200`: Timeout settings for the slow multi-node startup and model execution of the 1M context scenario. Increase them if the engine fails to become ready in time.
+
+**Prefill nodes (1M):**
+
+- `--speculative-config '{"num_speculative_tokens": 1, ...}'`: Minimal MTP speculation during prefill.
+- `mega_moe_max_tokens=8192` (in `--additional-config`): Per-rank token capacity after dispatch in the fused MC2/MegaMoe path.
+- `--kv-transfer-config`: Mooncake connector as `kv_producer` with `prefill: dp2 tp16` / `decode: dp4 tp8`.
+
+**Decode nodes (1M):**
+
+- `--max-num-batched-tokens 192`: Small batch token limit on decode nodes — decode nodes store the large 1M KV cache received from prefill nodes.
+- `VLLM_ASCEND_ENABLE_MLAPO=1`: MLAPO fusion on decode nodes for memory-bandwidth-bound token generation.
+- `--kv-transfer-config`: Mooncake connector as `kv_consumer` (`kv_port: 30200`).
+
+Please refer to [envs.py](https://github.com/vllm-project/vllm-ascend/blob/main/vllm_ascend/envs.py) for further explanation and restrictions of the environment variables above.
+
+## 6 Functional Verification
 
 Once your server is started, you can query the model with input prompts:
 
@@ -1398,34 +1729,103 @@ curl http://<node0_ip>:<port>/v1/completions \
     }'
 ```
 
-## Accuracy Evaluation
+Expected Result:
+
+The service returns HTTP 200 OK. The JSON response contains the `choices` field with the generated text, along with usage statistics:
+
+```json
+{
+    "id": "chatcmpl-90e6de0720743e72",
+    "object": "text_completion",
+    "created": 1784891079,
+    "model": "glm-52",
+    "choices": [
+        {
+            "index": 0,
+            "text": "here,and it's not just about chatbots. It's about AI agents",
+            "logprobs":null,
+            "finish_reason”:"length",
+            "stop_reason":null,
+            "token_ids":null,
+            "prompt_logprobs":null,
+            "prompt_token_ids":null,
+            "routed_experts":null
+        }
+    ],
+    "service_tier":null,
+    "system fingerprint":"vllm-0.26.0-tp16-ep-2a76151d",
+    "usage":{
+        "prompt tokens :5,
+        "total tokens :21,
+        "completion tokens":16,
+        "prompt tokens details :null
+        },
+        "ky transfer params":null
+    }
+}
+```
+
+## 7 Accuracy Evaluation
 
 Here are two accuracy evaluation methods.
 
-### Using AISBench
+### 7.1 Using AISBench
 
 1. Refer to [Using AISBench](../../developer_guide/evaluation/using_ais_bench.md) for details.
 
 2. After execution, you can get the result.
 
-### Using Language Model Evaluation Harness
+| dataset | version | metric | mode | vllm-api-general-chat | note |
+| ----- | ----- | ----- | ----- | ----- | ----- |
+| AIME2026 | - | accuracy | gen | 93.33 | 4 Atlas 800 A3 (64GB × 16) |
+| GPQA | - | accuracy | gen | 90.4 | 8 Atlas 800 A3 (64GB × 16) |
 
-Not tested yet.
+## 8 Performance Evaluation
 
-## Performance
-
-### Using AISBench
+### 8.1 Using AISBench
 
 Refer to [Using AISBench for performance evaluation](../../developer_guide/evaluation/using_ais_bench.md#execute-performance-evaluation) for details.
 
-### Using vLLM Benchmark
+### 8.2 Using vLLM Benchmark
 
-Refer to [vllm benchmark](https://docs.vllm.ai/en/latest/contributing/) for more details.
+Refer to [vllm benchmark](https://docs.vllm.ai/en/latest/benchmarking/) for more details.
 
 **Notice:**
-`max-model-len` and `max-num-seqs` need to be set according to the actual usage scenario. For other settings, please refer to the **[Deployment](#deployment)** chapter.
+`max-model-len` and `max-num-seqs` need to be set according to the actual usage scenario. For other settings, please refer to the **[Deployment](#5-deployment)** chapter.
 
-## FAQ
+## 9 Performance Tuning
+
+### 9.1 Tested Performance Cases
+
+#### Table 1: Prefill-Only Test Cases
+
+|Scenario|Configuration|NPUs|TP|DP|PP|Max Model Len|MTP Speculation Num|
+|--------|-------------|-----|--|--|--|-------------------|--------------------|
+|Decode-only|Server-P Node|32 (A3)|16|1|2|198k|1|
+|Decode-only|Server-D Node|32 (A3)|16|2|1|198k|5|
+|Prefill-only|Server-P Node|32 (A3)|16|1|2|198k|1|
+|Prefill-only|Server-D Node|32 (A3)|16|2|1|198k|5|
+|high concurrency|Server-P Node|32 (A3)|16|1|2|198k|1|
+|high concurrency|Server-D Node|32 (A3)|16|2|1|198k|5|
+|high concurrency(1M)|Server-P Node|32 (A3)|2|16|-|198k|1|
+|high concurrency(1M)|Server-D Node|32 (A3)|4|8|-|198k|5|
+
+### 9.2 Recommended Configurations
+
+#### Table 2: Optimizations Requiring Explicit Enablement
+
+|Optimization|Scenario|Enablement|Principle (Benefits)|Notes|
+|------------|--------|----------|---------------------|-----|
+|FlashComm_v1|A3 prefill nodes / co-located nodes|`export VLLM_ASCEND_ENABLE_FLASHCOMM1=1`|Splits AllReduce into Reduce-Scatter and All-Gather, improving prefill throughput and reducing communication latency|Not available when `layer_sharding` includes `o_proj`|
+|Fused MC2|A3 prefill nodes|`export VLLM_ASCEND_ENABLE_FUSED_MC2=1`|Replaces ALLTOALL+MC2 with the `dispatch_ffn_combine`/`dispatch_gmm_combine_decode` operators, reducing MoE communication overhead and improving MoE inference performance|`dispatch_ffn_combine` only for w8a8, EP≤32, non-MTP, non-dynamic-EPLB; conflicts with `multistream_overlap_shared_expert` (the latter is auto-disabled)|
+|MLAPO|A3 co-located / PD decode nodes; A2 P/D nodes|`export VLLM_ASCEND_ENABLE_MLAPO=1`|Fuses the MLA preprocess operations, significantly improving decode performance|Consumes more NPU memory; in PD scenarios enable on decode nodes only|
+|DSA CP|A3 prefill nodes; long context|`--additional-config '{"enable_dsa_cp": true}'`|DSA context parallelism accelerates long-context prefill, reducing TTFT for long prompts|In the reference configs, enabled on co-located nodes and PD prefill nodes; PD decode nodes use decode context parallelism instead|
+|Sparse SFA C8|A3 (w8a8c8); long-context prefill|`--additional-config '{"enable_sparse_sfa_c8": true}'`|Sparse Flash Attention skips unnecessary attention computation of the C8 quantized model, accelerating long-context prefill|Experimental in v0.23.0. On the w8a8c8 weights it can be combined with DCP/context parallelism (as in the reference configs in this document); on the w4a8c8 weights enabling both together has known issues and is not recommended|
+|Sparse LI C8|A3 (w8a8c8)|`--additional-config '{"enable_sparse_li_c8": true}'`|Sparse attention optimization reduces computation of the C8 quantized model, improving throughput|Independent of `enable_sparse_sfa_c8`|
+|Recompute Scheduler|A3 decode nodes|`--additional-config '{"recompute_scheduler_enable": true}'`|Recomputes KV cache on prefill nodes when decode KV cache is insufficient, avoiding decode-side OOM and improving throughput|Set to `false` on prefill nodes|
+|Multistream Overlap Shared Expert|A3|`--additional-config '{"multistream_overlap_shared_expert": true}'`|Overlaps shared-expert computation on an additional stream, hiding its latency and improving decode performance|Auto-disabled when `VLLM_ASCEND_ENABLE_FUSED_MC2=1`|
+
+## 10 FAQ
 
 - **Q: How to enable function calling for GLM-5.2?**
 

--- a/docs/source/tutorials/models/GLM5.2.md
+++ b/docs/source/tutorials/models/GLM5.2.md
@@ -1108,13 +1108,10 @@ Please refer to the following python file for further explanation and restrictio
 
 Recommended configurations for serving `GLM-5.2` with a 1M context window on Atlas 800 A3 (64GB x 16) and quantized GLM-5.2(W4A8C8) weights:
 
-| Mode | Hardware | Parallelism | Context |
-| ---- | -------- | ----------- | ------- |
-| Single-node co-located | 1 Atlas 800 A3 (64GB x 16) | `DP1 PP1 TP16 PCP1 DCP16` | `1024000` |
-| Dual-node co-located | 2 Atlas 800 A3 (64GB x 16) | `DP4 PP1 TP8 PCP1 DCP8` | `1024000` |
-| 1P1D PD disaggregation | 4 Atlas 800 A3 (64GB x 16) | Prefill `DP2 PP1 TP16 PCP1 DCP16`, Decode `DP4 PP1 TP8 PCP1 DCP8` | `1048576` |
 
 #### 5.2.1 Single-Node 1M Deployment
+
+- Quantized model `GLM-5.2-w4a8c8` can be deployed on 1 Atlas 800 A3 (64GB × 16) for the 1M context.
 
 Recommended command:
 
@@ -1154,6 +1151,8 @@ vllm serve <MODEL_PATH> \
 ```
 
 #### 5.2.2 Dual-Node Co-Located 1M Deployment
+
+- `GLM-5.2-w4a8c8` can be deployed on 2 Atlas 800 A3 (64GB × 16) for the 1M context.
 
 Recommended command for both co-located nodes:
 
@@ -1767,9 +1766,7 @@ The service returns HTTP 200 OK. The JSON response contains the `choices` field 
 
 ## 7 Accuracy Evaluation
 
-Here are two accuracy evaluation methods.
-
-### 7.1 Using AISBench
+### Using AISBench
 
 1. Refer to [Using AISBench](../../developer_guide/evaluation/using_ais_bench.md) for details.
 

--- a/docs/source/tutorials/models/GLM5.2.md
+++ b/docs/source/tutorials/models/GLM5.2.md
@@ -1108,7 +1108,6 @@ Please refer to the following python file for further explanation and restrictio
 
 Recommended configurations for serving `GLM-5.2` with a 1M context window on Atlas 800 A3 (64GB x 16) and quantized GLM-5.2(W4A8C8) weights:
 
-
 #### 5.2.1 Single-Node 1M Deployment
 
 - Quantized model `GLM-5.2-w4a8c8` can be deployed on 1 Atlas 800 A3 (64GB × 16) for the 1M context.

--- a/docs/source/tutorials/models/GLM5.2.md
+++ b/docs/source/tutorials/models/GLM5.2.md
@@ -1106,8 +1106,6 @@ Please refer to the following python file for further explanation and restrictio
 
 ### 5.2 1M Context Configuration
 
-Recommended configurations for serving `GLM-5.2` with a 1M context window on Atlas 800 A3 (64GB x 16) and quantized GLM-5.2(W4A8C8) weights:
-
 #### 5.2.1 Single-Node 1M Deployment
 
 - Quantized model `GLM-5.2-w4a8c8` can be deployed on 1 Atlas 800 A3 (64GB × 16) for the 1M context.

--- a/docs/source/user_guide/support_matrix/supported_models.md
+++ b/docs/source/user_guide/support_matrix/supported_models.md
@@ -86,16 +86,16 @@ Get the latest info here: <https://github.com/vllm-project/vllm-ascend/issues/16
 
 === "A2/A3"
 
-    | Model                         | Support   | Note                                                                 |    Supported Hardware | W8A8   |  Doc |
-    |-------------------------------|-----------|----------------------------------------------------------------------|------------------------------|------|
-    | Qwen3-Embedding               | 🔵        |                                                                      |         A2/A3           | 🟡| [Qwen3-Embedding](../../tutorials/models/Qwen3-Embedding.md)|
-    | Qwen3-VL-Embedding            | 🔵        |                                                                      |         A2/A3            | 🔵| [Qwen3-VL-Embedding](../../tutorials/models/Qwen3-VL-Embedding.md)|
-    | Qwen3-Reranker                | 🔵        |                                                                      |         A2/A3            |🟡 | [Qwen3-Reranker](../../tutorials/models/Qwen3-Reranker.md)|
-    | Qwen3-VL-Reranker             | 🔵        |                                                                      |         A2/A3            | 🔵| [Qwen3-VL-Reranker](../../tutorials/models/Qwen3-VL-Reranker.md)|
-    | Molmo                         | 🔵        | [1942](https://github.com/vllm-project/vllm-ascend/issues/1942)      |         A2/A3            | 🟡|      |
-    | XLM-RoBERTa-based             | 🔵        |                                                                      |         A2/A3            | 🟡|      |
-    | Bert                          | 🔵        |                                                                      |         A2/A3            |🟡 |      |
-    | Qwen2.5-Math-RM-72B           | ✅        | Reward Model, gsm8k_correctness accuracy=0.80 | A2 | [Qwen2.5-Math-RM-72B](../../tutorials/models/Qwen2.5-Math-RM-72B.md) |
+    | Model                         | Support | Note                                                            | Supported Hardware | W8A8 | Doc                                                                         |
+    |-------------------------------|---------|-----------------------------------------------------------------|--------------------|------|-----------------------------------------------------------------------------|
+    | Qwen3-Embedding               | 🔵       |                                                                 | A2/A3              | 🟡    | [Qwen3-Embedding](../../tutorials/models/Qwen3-Embedding.md)                 |
+    | Qwen3-VL-Embedding            | 🔵       |                                                                 | A2/A3              | 🔵    | [Qwen3-VL-Embedding](../../tutorials/models/Qwen3-VL-Embedding.md)           |
+    | Qwen3-Reranker                | 🔵       |                                                                 | A2/A3              | 🟡    | [Qwen3-Reranker](../../tutorials/models/Qwen3-Reranker.md)                   |
+    | Qwen3-VL-Reranker             | 🔵       |                                                                 | A2/A3              | 🔵    | [Qwen3-VL-Reranker](../../tutorials/models/Qwen3-VL-Reranker.md)             |
+    | Molmo                         | 🔵       | [1942](https://github.com/vllm-project/vllm-ascend/issues/1942) | A2/A3              | 🟡    |                                                                             |
+    | XLM-RoBERTa-based             | 🔵       |                                                                 | A2/A3              | 🟡    |                                                                             |
+    | Bert                          | 🔵       |                                                                 | A2/A3              | 🟡    |                                                                             |
+    | Qwen2.5-Math-RM-72B           | ✅       | Reward Model, gsm8k_correctness accuracy=0.80                   | A2                 |       | [Qwen2.5-Math-RM-72B](../../tutorials/models/Qwen2.5-Math-RM-72B.md)         |
 
 === "Atlas inference products"
 


### PR DESCRIPTION
- Add consistent numbered sections and fix internal anchor links in the deployment chapter
- Add GLM-5.2-w8a8c8 model weight entry; drop stale VLLM_VERSION pin and commented-out environment variables
- Add key parameter descriptions and launch scripts for PD disaggregation (A3 PP2, A2) and 1M-context PD deployments
- Rework accuracy/performance evaluation sections and add performance tuning case and optimization tables

### What this PR does / why we need it?
 - Add consistent numbered sections — the Deployment chapter now groups scenarios under 5.1 Context Below 1M
  (single-node / multi-node / prefill-decode disaggregation, incl. the 4-node A3 and 8-node A2 layouts) and 5.2 1M
  Context Configuration — and fix the internal anchor links accordingly.
  - Add the GLM-5.2-w8a8c8 model weight entry; drop the stale VLLM_VERSION pin and commented-out environment variables.
  - Add key parameter descriptions and launch scripts for PD disaggregation (A3 PP2, A2) and 1M-context PD deployments.
  - Rework the accuracy/performance evaluation sections and add performance-tuning test-case and optimization tables.

### Does this PR introduce _any_ user-facing change?
No. Documentation-only update.
### How was this patch tested?
— documentation-only change; no code or tests are affected.

- vLLM main: https://github.com/vllm-project/vllm/commit/d02df748bf9efd99022f1a062597dc3cb3808485
