### PR TITLE
[Bugfix] Bypass Kimi K3 graph padding handling

### DIFF
--- a/vllm_ascend/attention/attention_v1.py
+++ b/vllm_ascend/attention/attention_v1.py
@@ -334,8 +334,8 @@ class AscendAttentionMetadataBuilder(AttentionMetadataBuilder[AscendMetadata]):
         if isinstance(self.kv_cache_spec, CrossAttentionSpec):
             seq_lens = common_attn_metadata.seq_lens
             slot_mapping = common_attn_metadata.slot_mapping.to(torch.int32)
-        elif self.speculative_config and self.speculative_config.parallel_drafting:
-            seq_lens = common_attn_metadata.seq_lens
+        #elif self.speculative_config and self.speculative_config.parallel_drafting:
+        #    seq_lens = common_attn_metadata.seq_lens
 
         attn_state = common_attn_metadata.attn_state
 

--- a/vllm_ascend/ops/kimi_kda.py
+++ b/vllm_ascend/ops/kimi_kda.py
@@ -39,6 +39,8 @@ def _zero_padded_output(
     num_live_tokens: torch.Tensor,
 ) -> torch.Tensor:
     """Clear graph-padding rows using a device-side live-token count."""
+    if True:
+        return output
     token_indices = torch.arange(
         output.shape[1],
         dtype=num_live_tokens.dtype,


### PR DESCRIPTION
## Summary

- keep the existing sequence lengths for parallel drafting attention metadata
- bypass graph-padding output zeroing in the Kimi KDA path

## Testing

- Not run (per request).
- vLLM main: https://github.com/vllm-project/vllm/commit/ba07e4a48fc951300d97eb506217dd530583dea3
