### PR TITLE
[BugFix] Keep unsupported DeepSeek V4 weights in ND format

### DIFF
--- a/tests/ut/ops/test_linear.py
+++ b/tests/ut/ops/test_linear.py
@@ -59,6 +59,7 @@ class TestAscendUnquantizedLinearMethod(TestBase):
         mock_is_meta = mock.PropertyMock(return_value=False)
         type(self.layer.weight.data).is_meta = mock_is_meta
         self.layer.precast_fp32_weight = False
+        self.layer.skip_weight_nz_conversion = False
 
     @patch("vllm_ascend.utils.get_ascend_config")
     @mock.patch("torch_npu.npu_format_cast")
@@ -86,6 +87,19 @@ class TestAscendUnquantizedLinearMethod(TestBase):
         mock_get_config.return_value = mock_config
         self.method.process_weights_after_loading(self.layer)
         mock_format_cast.assert_called_once()
+
+    @patch("vllm_ascend.utils.get_ascend_config")
+    @mock.patch("torch_npu.npu_format_cast")
+    def test_process_weights_after_loading_skips_nz_for_marked_layer(self, mock_format_cast, mock_get_config):
+        mock_config = MagicMock()
+        mock_config.weight_nz_mode = 2
+        mock_get_config.return_value = mock_config
+        self.layer.skip_weight_nz_conversion = True
+        self.layer.precast_fp32_weight = True
+
+        self.method.process_weights_after_loading(self.layer)
+
+        mock_format_cast.assert_not_called()
 
 
 class TestAscendRowParallelLinear(BaseLinearTest):

--- a/vllm_ascend/models/deepseek_v4.py
+++ b/vllm_ascend/models/deepseek_v4.py
@@ -90,6 +90,8 @@ from vllm_ascend.utils import (
     extract_dsv4_layer_index,
     get_ascend_device_type,
     get_dsv4_compress_ratio,
+    olora_tp_enable,
+    oproj_tp_enable,
 )
 
 
@@ -651,6 +653,10 @@ class Compressor(nn.Module):
             return_bias=False,
         )
 
+        # The custom compressor op consumes ND weights directly.
+        self.wkv.skip_weight_nz_conversion = True
+        self.wgate.skip_weight_nz_conversion = True
+
         # Compressor kernel only accepts FP32 norm_weight.
         self.norm = RMSNorm(self.head_dim, config.rms_norm_eps, dtype=torch.float32)
 
@@ -790,6 +796,12 @@ class DeepseekV4Attention(nn.Module):
             quant_config=quant_config,
             prefix=f"{prefix}.wo_a",
             return_bias=False,
+        )
+        # DSA paths that bypass the Linear method use
+        # npu_transpose_batchmatmul, whose weight must remain ND on non-A5
+        # devices.
+        self.wo_a.skip_weight_nz_conversion = get_ascend_device_type() != AscendDeviceType.A5 and (
+            oproj_tp_enable() or not olora_tp_enable()
         )
         self.wo_b = RowParallelLinear(
             self.n_groups * config.o_lora_rank,

--- a/vllm_ascend/ops/linear.py
+++ b/vllm_ascend/ops/linear.py
@@ -86,11 +86,14 @@ class AscendUnquantizedLinearMethod(UnquantizedLinearMethod):
     def process_weights_after_loading(self, layer: torch.nn.Module) -> None:
         super().process_weights_after_loading(layer)
         keep_nd_weight = _should_keep_nd_for_310p_weight(layer.weight.data)
+        skip_weight_nz_conversion = getattr(layer, "skip_weight_nz_conversion", False)
         # must use fp32 to avoid accuracy degradation in dsv4.
         if getattr(layer, "precast_fp32_weight", False):
             weight_fp32 = layer.weight.data.to(torch.float32)
-            layer.weight_fp32 = weight_fp32 if keep_nd_weight else maybe_trans_nz(weight_fp32)
-        if "conv1d" not in layer.prefix:
+            layer.weight_fp32 = (
+                weight_fp32 if keep_nd_weight or skip_weight_nz_conversion else maybe_trans_nz(weight_fp32)
+            )
+        if "conv1d" not in layer.prefix and not skip_weight_nz_conversion:
             # 310P torch_npu rejects FRACTAL_NZ matmul when the weight-side
             # matrix has n=1 or k=1. Keep scalar gates such as Qwen MoE's
             # shared_expert_gate in ND format, leaving non-310P policy intact.


### PR DESCRIPTION
### What this PR does / why we need it?

DeepSeek V4 has weight consumers that bypass the regular Linear method and require ND weights:

- The custom compressor operator consumes wkv and wgate weights directly.
- DSA output-projection paths using npu_transpose_batchmatmul require wo_a to remain ND on non-A5 devices.

Add a per-layer skip_weight_nz_conversion flag to the unquantized Linear weight-loading path and set it only for those affected DSV4 layers. Other Linear weights continue to use the existing NZ conversion policy.

### Does this PR introduce _any_ user-facing change?

No API change. This fixes DeepSeek V4 execution paths that require ND-formatted weights.

### How was this patch tested?

- Added a unit test verifying that a marked Linear layer bypasses NZ conversion while the existing NZ-mode coverage remains intact.
- uvx ruff format --check vllm_ascend/models/deepseek_v4.py vllm_ascend/ops/linear.py tests/ut/ops/test_linear.py
- uvx ruff check vllm_ascend/models/deepseek_v4.py vllm_ascend/ops/linear.py tests/ut/ops/test_linear.py
- py -3 -m compileall -q vllm_ascend/models/deepseek_v4.py vllm_ascend/ops/linear.py tests/ut/ops/test_linear.py

NPU-dependent tests are left to the PR CI environment.

- vLLM main: https://github.com/vllm-project/vllm/commit/d02df748bf9efd99022f1a062597dc3cb3808485
