### PR TITLE
[Doc][Feature] Add HRM-Text-1B support coverage

### DIFF
--- a/.github/workflows/misc/model_dataset_list.json
+++ b/.github/workflows/misc/model_dataset_list.json
@@ -207,6 +207,7 @@
             "qwen/Qwen1.5-0.5B-Chat",
             "rhymes-ai/Aria",
             "riverclouds/qwen_image_random",
+            "sapientinc/HRM-Text-1B",
             "sentence-transformers/all-MiniLM-L12-v2",
             "swift/Qwen3-235B-A22B-Instruct-2507-AWQ",
             "tclf90/Qwen3-VL-235B-A22B-Instruct-AWQ",

--- a/docs/source/tutorials/models/HRM-Text-1B.md
+++ b/docs/source/tutorials/models/HRM-Text-1B.md
@@ -1,0 +1,143 @@
+# HRM-Text-1B
+
+## Introduction
+
+`HRM-Text-1B` is a 1-billion-parameter base language model from Sapient Intelligence. It uses two recurrent Transformer stacks at different timescales and was pretrained with a PrefixLM objective. The checkpoint is a pre-alignment base model rather than a chat or instruction-following assistant.
+
+This guide describes single-NPU deployment, PrefixLM prompting, functional verification, and accuracy evaluation with vLLM Ascend. See the [model card](https://huggingface.co/sapientinc/HRM-Text-1B) for architecture and training details.
+
+## Supported Features
+
+| Feature | Status | Notes |
+| --- | --- | --- |
+| BF16 | ✅ | Verified with the released checkpoint. |
+| Tensor parallelism | ✅ | TP=1 was verified on one Atlas A2 64 GB NPU. |
+| Piecewise ACL Graph | ✅ | Verified with real weights. |
+| Chunked prefill | ❌ | Disabled by vLLM because PrefixLM uses non-causal attention during prefill. |
+| Automatic prefix caching | ❌ | Disabled for the same non-causal attention constraint. |
+| Expert parallelism / FlashComm | N/A | The checkpoint is dense, not MoE. |
+| MTP | N/A | The checkpoint does not contain speculative decoding weights. |
+| Multimodal input | N/A | This is a text-only model. |
+
+The configured maximum sequence length is 4096 tokens. Because chunked prefill is unavailable, `--max-num-batched-tokens` must be at least `--max-model-len`; otherwise prompts larger than the scheduling token budget cannot be processed.
+
+## Environment Preparation
+
+### Model Weight
+
+Download the BF16 checkpoint from [Hugging Face](https://huggingface.co/sapientinc/HRM-Text-1B). One Atlas A2 64 GB NPU is sufficient for the configuration in this guide.
+
+```bash
+huggingface-cli download sapientinc/HRM-Text-1B \
+  --local-dir /data/models/HRM-Text-1B
+```
+
+### Docker
+
+Use a vLLM Ascend image that matches the target vLLM version. Replace `/data/models` with the host directory containing the checkpoint.
+
+=== "Atlas A2 inference products"
+
+    ```bash
+    export IMAGE=quay.io/ascend/vllm-ascend:{{ vllm_ascend_version }}
+
+    docker run --rm -it \
+      --name vllm-ascend-hrm \
+      --net host \
+      --shm-size=1g \
+      --device /dev/davinci0 \
+      --device /dev/davinci_manager \
+      --device /dev/devmm_svm \
+      --device /dev/hisi_hdc \
+      -v /usr/local/dcmi:/usr/local/dcmi \
+      -v /usr/local/bin/npu-smi:/usr/local/bin/npu-smi \
+      -v /usr/local/Ascend/driver/lib64:/usr/local/Ascend/driver/lib64 \
+      -v /usr/local/Ascend/driver/version.info:/usr/local/Ascend/driver/version.info \
+      -v /etc/ascend_install.info:/etc/ascend_install.info \
+      -v /data/models:/data/models \
+      $IMAGE bash
+    ```
+
+=== "Atlas A3 inference products"
+
+    ```bash
+    export IMAGE=quay.io/ascend/vllm-ascend:{{ vllm_ascend_version }}
+
+    docker run --rm -it \
+      --name vllm-ascend-hrm \
+      --net host \
+      --shm-size=1g \
+      --device /dev/davinci0 \
+      --device /dev/davinci_manager \
+      --device /dev/devmm_svm \
+      --device /dev/hisi_hdc \
+      -v /usr/local/dcmi:/usr/local/dcmi \
+      -v /usr/local/bin/npu-smi:/usr/local/bin/npu-smi \
+      -v /usr/local/Ascend/driver/lib64:/usr/local/Ascend/driver/lib64 \
+      -v /usr/local/Ascend/driver/version.info:/usr/local/Ascend/driver/version.info \
+      -v /etc/ascend_install.info:/etc/ascend_install.info \
+      -v /data/models:/data/models \
+      $IMAGE bash
+    ```
+
+For source installation, follow the [Installation Guide](../../getting_started/installation.md).
+
+## Deployment
+
+Start the server from the container workspace. ACL Graph is enabled by default.
+
+```bash
+cd /workspace
+
+vllm serve /data/models/HRM-Text-1B \
+  --served-model-name hrm-text-1b \
+  --tensor-parallel-size 1 \
+  --dtype bfloat16 \
+  --max-model-len 4096 \
+  --max-num-batched-tokens 4096 \
+  --gpu-memory-utilization 0.9 \
+  --trust-remote-code \
+  --port 8000
+```
+
+Use `--enforce-eager` as an isolation fallback if graph capture fails in a development environment. Eager mode is also used by the accuracy regression configuration to minimize graph-capture overhead in CI.
+
+## Functional Verification
+
+Use the Completions API because this checkpoint is not chat-tuned. Condition tokens control the desired generation style: `<|object_ref_start|>` requests a direct answer, while `<|quad_end|><|object_ref_end|>` requests synthetic chain-of-thought style generation.
+
+```bash
+curl http://localhost:8000/v1/completions \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "hrm-text-1b",
+    "prompt": "<|im_start|><|object_ref_start|>What is the capital of France?<|im_end|>",
+    "max_tokens": 16,
+    "temperature": 0
+  }'
+```
+
+Expected result: HTTP 200 with `Paris` in the generated completion.
+
+## Accuracy Evaluation
+
+The regression test uses the GSM8K test split with 5-shot prompting, no chat template, and 100 samples. The model is evaluated as a base model; these numbers are intended as a reproducible vLLM Ascend regression baseline, not as a reproduction of the model card's full benchmark recipe.
+
+| Dataset | Samples | Few-shot | Metric | Result |
+| --- | ---: | ---: | --- | ---: |
+| GSM8K | 100 | 5 | exact_match,strict-match | 0.01 |
+| GSM8K | 100 | 5 | exact_match,flexible-extract | 0.66 |
+
+Run the registered evaluation with:
+
+```bash
+pytest -sv tests/e2e/models/test_lm_eval_correctness.py \
+  --config tests/e2e/models/configs/HRM-Text-1B.yaml \
+  --tp-size 1
+```
+
+## Performance
+
+On one Atlas A2 64 GB NPU, real-weight startup and inference were verified with a 4096-token maximum context and up to 16 concurrent requests. The practical maximum context matched the checkpoint's theoretical 4096-token limit when `--max-num-batched-tokens 4096` was set.
+
+In a stability run, 320 short requests completed successfully without sustained HBM growth. Actual latency and throughput depend on prompt length, generation length, concurrency, graph cache state, and runtime versions; benchmark with production traffic before choosing serving parameters.

--- a/docs/source/tutorials/models/index.md
+++ b/docs/source/tutorials/models/index.md
@@ -1,3 +1,5 @@
 # Model Tutorials
 
 This section provides tutorials for different models of vLLM Ascend.
+
+- [HRM-Text-1B](HRM-Text-1B.md)

--- a/docs/source/user_guide/support_matrix/supported_models.md
+++ b/docs/source/user_guide/support_matrix/supported_models.md
@@ -76,6 +76,7 @@ Get the latest info here: <https://github.com/vllm-project/vllm-ascend/issues/16
 | Ernie4.5-Moe                  | 🔵        |                                                                      | A2/A3 |
 | Gemma-2                       | 🔵        |                                                                      | A2/A3 |
 | Gemma-3                       | 🔵        |                                                                      | A2/A3 |
+| HRM-Text-1B                   | 🔵        | BF16 PrefixLM; set `max-num-batched-tokens=4096`                     | A2    |
 | Phi-3/4                       | 🔵        |                                                                      | A2/A3 |
 | Mistral/Mistral-Instruct      | 🔵        |                                                                      | A2/A3 |
 | Hy3-preview                   | 🔵        |                                                                      | A3    |

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -248,6 +248,7 @@ nav:
         - tutorials/models/Hy3-preview.md
         - tutorials/models/Hy4-preview.md
         - tutorials/models/Minitron-8B-Base.md
+        - tutorials/models/HRM-Text-1B.md
         - tutorials/models/LLaVA-OneVision-Qwen2-0.5B-OV.md
         - tutorials/models/gpt-oss-120b.md
         - tutorials/models/Mixtral-8x7B-Instruct-v0.1.md

--- a/tests/e2e/models/configs/HRM-Text-1B.yaml
+++ b/tests/e2e/models/configs/HRM-Text-1B.yaml
@@ -1,0 +1,26 @@
+model_name: "sapientinc/HRM-Text-1B"
+model_type: "vllm"
+hardware: "Atlas A2 Series"
+
+serve:
+  tensor_parallel_size: 1
+  dtype: bfloat16
+  max_model_len: 4096
+  max_num_batched_tokens: 4096
+  gpu_memory_utilization: 0.9
+  enforce_eager: true
+  trust_remote_code: true
+
+tasks:
+  - name: "gsm8k"
+    metrics:
+      - name: "exact_match,strict-match"
+        value: 0.01
+      - name: "exact_match,flexible-extract"
+        value: 0.66
+
+limit: 100
+num_fewshot: 5
+apply_chat_template: false
+fewshot_as_multiturn: false
+batch_size: "auto"

--- a/tests/e2e/models/configs/accuracy.txt
+++ b/tests/e2e/models/configs/accuracy.txt
@@ -12,3 +12,4 @@ Molmo-7B-D-0924.yaml
 llava-onevision-qwen2-0.5b-ov-hf.yaml
 Llama-3.2-3B-Instruct.yaml
 Qwen3-ASR-1.7B.yaml
+HRM-Text-1B.yaml

--- a/tests/e2e/models/test_lm_eval_correctness.py
+++ b/tests/e2e/models/test_lm_eval_correctness.py
@@ -50,6 +50,7 @@ def build_model_args(eval_config, tp_size):
     for s in [
         "max_images",
         "gpu_memory_utilization",
+        "max_num_batched_tokens",
         "enable_expert_parallel",
         "tensor_parallel_size",
         "enforce_eager",


### PR DESCRIPTION
### What this PR does / why we need it?

This PR registers and documents `sapientinc/HRM-Text-1B`, a 1B PrefixLM model already implemented by upstream vLLM. No Ascend-specific model implementation or custom CANN operator is needed.

It adds:

- an Atlas A2 model/dataset entry and GSM8K accuracy regression config;
- propagation of `max_num_batched_tokens` through the shared lm-eval harness;
- the support-matrix entry and a deployment tutorial covering PrefixLM prompting, scheduling constraints, accuracy, and stability;
- the tutorial navigation entry.

HRM uses non-causal prefill, so vLLM disables chunked prefill and prefix caching. The guide and test explicitly set `max_num_batched_tokens=4096` to match `max_model_len=4096`. The related upstream startup-validation fix is vllm-project/vllm#55130.

### Does this PR introduce _any_ user-facing change?

Yes. Users can discover HRM-Text-1B as experimentally supported on Atlas A2 and follow a tested single-NPU deployment/evaluation recipe. There is no API change.

### How was this patch tested?

Hardware: one Atlas A2 (Ascend 910B3, 64 GB), isolated with `ASCEND_RT_VISIBLE_DEVICES=4`.

Real checkpoint: `/mnt/mog2/wyl/models/HRM-Text-1B` (equivalent to `sapientinc/HRM-Text-1B`).

- The exact registered pytest command passed on the 2026-09-03 `nightly-main` image: `1 passed` in 232.76 s. The measured GSM8K scores were strict `0.01` and flexible-extract `0.65`; both pass the configured regression expectations (`0.01` and `0.66`, `rtol=5%`).
- A separate 100-sample run measured strict `0.01` and flexible-extract `0.66`, which is the documented baseline.
- BF16 eager and Piecewise ACL Graph inference passed.
- Context boundary checks passed through 4095 input tokens with `max_model_len=max_num_batched_tokens=4096`.
- 16 concurrent requests and a 320-request stability run completed successfully without sustained HBM growth.
- Relevant formatting/static checks passed: Ruff check/format, markdownlint, codespell, typos, gitleaks, filename, import, logger, boolean-context, long-function, and symbolic-meta hooks.

The registered command is:

```bash
pytest -sv tests/e2e/models/test_lm_eval_correctness.py \
  --config tests/e2e/models/configs/HRM-Text-1B.yaml \
  --tp-size 1
```

- vLLM version: 0.27.1
- vLLM main: https://github.com/vllm-project/vllm/commit/ba07e4a48fc951300d97eb506217dd530583dea3