### PR TITLE
[v0.23.0][ToolParser][BugFix] Fix DeepSeek V4 strict required tool-call parsing

### DIFF
--- a/tests/ut/patch/platform/test_patch_deepseek_v4_tool_call_parser.py
+++ b/tests/ut/patch/platform/test_patch_deepseek_v4_tool_call_parser.py
@@ -4,6 +4,8 @@ import json
 from unittest.mock import MagicMock
 
 from vllm.entrypoints.openai.chat_completion.protocol import ChatCompletionRequest
+from vllm.envs import VLLM_ENFORCE_STRICT_TOOL_CALLING
+from vllm.parser.parser_manager import ParserManager
 from vllm.tool_parsers.deepseekv4_tool_parser import DeepSeekV4ToolParser
 
 from vllm_ascend.patch.platform import patch_deepseek_v4_tool_call_parser
@@ -91,6 +93,16 @@ def _tools():
             },
         },
     }
+
+
+def _unified_parser():
+    parser_cls = ParserManager.get_parser(
+        tool_parser_name="deepseek_v4",
+        enable_auto_tools=True,
+        model_name="deepseek-v4-flash",
+    )
+    assert parser_cls is not None
+    return parser_cls(MOCK_TOKENIZER, tools=[_tools()])
 
 
 def test_streaming_deepseek_v4_tool_calls_emit_chunked_arguments():
@@ -349,3 +361,102 @@ def test_registered_parser_is_patch_loaded():
         DeepSeekV4ToolParser.extract_tool_calls_streaming
         is patch_deepseek_v4_tool_call_parser._patched_extract_tool_calls_streaming
     )
+    assert DeepSeekV4ToolParser.supports_required_and_named == (
+        not VLLM_ENFORCE_STRICT_TOOL_CALLING
+    )
+
+
+def test_required_and_named_support_tracks_strict_tool_calling():
+    original = DeepSeekV4ToolParser.supports_required_and_named
+    try:
+        patch_deepseek_v4_tool_call_parser._configure_required_and_named_support(True)
+        assert DeepSeekV4ToolParser.supports_required_and_named is False
+
+        patch_deepseek_v4_tool_call_parser._configure_required_and_named_support(False)
+        assert DeepSeekV4ToolParser.supports_required_and_named is True
+    finally:
+        DeepSeekV4ToolParser.supports_required_and_named = original
+
+
+def test_required_tool_choice_routes_strict_dsml_to_native_parser():
+    original = DeepSeekV4ToolParser.supports_required_and_named
+    try:
+        patch_deepseek_v4_tool_call_parser._configure_required_and_named_support(True)
+        request = ChatCompletionRequest(
+            model="deepseek-v4-flash",
+            messages=[],
+            tools=[_tools()],
+            tool_choice="required",
+        )
+        model_output = _build_tool_call(
+            "plan_trip",
+            {
+                "days": 3,
+                "flexible": False,
+                "cities": ["Beijing"],
+                "notes": "window seat",
+            },
+        )
+
+        tool_calls, content = _unified_parser()._extract_tool_calls(
+            content=model_output,
+            request=request,
+            enable_auto_tools=True,
+        )
+
+        assert tool_calls is not None
+        assert len(tool_calls) == 1
+        assert tool_calls[0].name == "plan_trip"
+        assert json.loads(tool_calls[0].arguments) == {
+            "days": 3,
+            "flexible": False,
+            "cities": ["Beijing"],
+            "notes": "window seat",
+        }
+        assert content is None
+    finally:
+        DeepSeekV4ToolParser.supports_required_and_named = original
+
+
+def test_required_tool_choice_keeps_json_parser_without_strict():
+    original = DeepSeekV4ToolParser.supports_required_and_named
+    try:
+        patch_deepseek_v4_tool_call_parser._configure_required_and_named_support(False)
+        request = ChatCompletionRequest(
+            model="deepseek-v4-flash",
+            messages=[],
+            tools=[_tools()],
+            tool_choice="required",
+        )
+        model_output = json.dumps(
+            [
+                {
+                    "name": "plan_trip",
+                    "parameters": {
+                        "days": 3,
+                        "flexible": False,
+                        "cities": ["Beijing"],
+                        "notes": "window seat",
+                    },
+                }
+            ]
+        )
+
+        tool_calls, content = _unified_parser()._extract_tool_calls(
+            content=model_output,
+            request=request,
+            enable_auto_tools=True,
+        )
+
+        assert tool_calls is not None
+        assert len(tool_calls) == 1
+        assert tool_calls[0].name == "plan_trip"
+        assert json.loads(tool_calls[0].arguments) == {
+            "days": 3,
+            "flexible": False,
+            "cities": ["Beijing"],
+            "notes": "window seat",
+        }
+        assert content is None
+    finally:
+        DeepSeekV4ToolParser.supports_required_and_named = original

--- a/tests/ut/patch/platform/test_patch_deepseek_v4_tool_call_parser.py
+++ b/tests/ut/patch/platform/test_patch_deepseek_v4_tool_call_parser.py
@@ -361,9 +361,7 @@ def test_registered_parser_is_patch_loaded():
         DeepSeekV4ToolParser.extract_tool_calls_streaming
         is patch_deepseek_v4_tool_call_parser._patched_extract_tool_calls_streaming
     )
-    assert DeepSeekV4ToolParser.supports_required_and_named == (
-        not VLLM_ENFORCE_STRICT_TOOL_CALLING
-    )
+    assert DeepSeekV4ToolParser.supports_required_and_named == (not VLLM_ENFORCE_STRICT_TOOL_CALLING)
 
 
 def test_required_and_named_support_tracks_strict_tool_calling():

--- a/vllm_ascend/patch/__init__.py
+++ b/vllm_ascend/patch/__init__.py
@@ -344,14 +344,20 @@
 #       Upstream vLLM now includes DeepSeek V4 tokenizer/renderer/reasoning
 #       registration, but its streaming tool-call delta parsing does not guarantee
 #       incremental `arguments` emission for long argument payloads.
+#       With strict tool calling enabled, `required` and named tool choices produce
+#       native DSML output. The inherited capability flag incorrectly routes that
+#       output through the generic JSON parser, causing tool calls to be dropped.
 #    How:
 #       Monkey-patch `DeepSeekV4ToolParser` stream parsing to emit tool-call
 #       metadata in the first delta and stream argument fragments incrementally.
+#       Set `supports_required_and_named` conditionally so strict mode uses the
+#       native DSML parser while non-strict mode keeps the generic JSON path.
 #    Related PR (if no, explain why):
-#       Upstream vLLM main behavior as of current runtime.
+#       No upstream PR yet. Follow up in vLLM core, where the parser capability
+#       is defined, then remove this release compatibility patch after backport.
 #    Future Plan:
-#       Remove this patch if upstream streaming behavior is updated to satisfy the
-#       same DeepSeek DSML incrementality contract.
+#       Remove this patch once upstream handles both the DeepSeek DSML
+#       incrementality contract and strict required/named routing.
 #
 # ** 12a. File: platform/patch_minimax_m2_tool_call_parser.py**
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/vllm_ascend/patch/platform/patch_deepseek_v4_tool_call_parser.py
+++ b/vllm_ascend/patch/platform/patch_deepseek_v4_tool_call_parser.py
@@ -35,9 +35,15 @@ from vllm.entrypoints.openai.engine.protocol import (
     FunctionCall,
     ToolCall,
 )
+from vllm.envs import VLLM_ENFORCE_STRICT_TOOL_CALLING
 from vllm.tool_parsers.deepseekv4_tool_parser import DeepSeekV4ToolParser
 
 ESCAPED_ARGUMENTS_PARAM_NAME = "__vllm_param_arguments__"
+
+
+def _configure_required_and_named_support(strict_tool_calling: bool) -> None:
+    """Use native DSML parsing when strict structural tags are enabled."""
+    DeepSeekV4ToolParser.supports_required_and_named = not strict_tool_calling
 
 
 def _ensure_parser_regexes(self: DeepSeekV4ToolParser) -> None:
@@ -770,6 +776,7 @@ def _patched_extract_tool_calls_streaming(
 
 
 # Backward-compatible monkey patches.
+_configure_required_and_named_support(VLLM_ENFORCE_STRICT_TOOL_CALLING)
 DeepSeekV4ToolParser._ensure_streaming_attrs = _ensure_streaming_attrs
 DeepSeekV4ToolParser._function_name = _function_name
 DeepSeekV4ToolParser._function_parameters = _function_parameters


### PR DESCRIPTION
### What this PR does / why we need it?

When strict tool calling is enabled, DeepSeek V4 structured decoding emits the
model-native DSML format. However, `DeepSeekV4ToolParser` inherits
`supports_required_and_named=True`, so the serving layer handles
`tool_choice="required"` and named function choices through the standard JSON
parser. The generated DSML does not match that JSON format and the response can
lose its `tool_calls`.

This patch keeps the parsing declaration aligned with the generated format:

- strict tool calling enabled: use the native DeepSeek V4 DSML parser;
- strict tool calling disabled: preserve the standard JSON path.

The change is implemented in the existing vLLM Ascend DeepSeek V4
compatibility patch for the vLLM 0.23.0 release line. There is no exact public
issue linked yet.

#### Why an Ascend compatibility patch?

The capability declaration belongs to the upstream vLLM parser, but the
v0.23.0 deployment needs a release-line fix. This change extends the existing
DeepSeek V4 compatibility patch without changing generation or NPU execution.
The follow-up plan is to submit the parser capability fix to vLLM core and
remove the Ascend patch once the supported upstream version contains it.

This PR is limited to the maintained v0.23.0 release line. A follow-up upstream
vLLM change will make the same capability declaration at its source and allow
this compatibility behavior to be removed in a future aligned release.

### Does this PR introduce _any_ user-facing change?

Yes. DeepSeek V4 requests using `tool_choice="required"` or a named function
choice return parsed OpenAI-compatible `tool_calls` when strict structural-tag
decoding is enabled. Non-strict behavior is unchanged.

### How was this patch tested?

- Added CPU-only tests for the strict/non-strict configuration mapping.
- Added a CPU-only serving-layer regression test that routes strict DSML output
  through the native DeepSeek V4 parser for `tool_choice="required"`.
- Added a non-strict regression test that preserves standard JSON parsing.
- `python3 -m py_compile`: passed.
- `git diff --check`: passed.
- `pytest -q tests/ut/patch/platform/test_patch_deepseek_v4_tool_call_parser.py`
  in `quay.io/ascend/vllm-ascend:v0.23.0rc1-a3`: `10 passed`.
- The same test command with `VLLM_ENFORCE_STRICT_TOOL_CALLING=1`:
  `10 passed`.

#### Reproduction configuration

```text
VLLM_ENFORCE_STRICT_TOOL_CALLING=1
--structured-outputs-config.enable_in_reasoning=True
tool_choice="required"
chat_template_kwargs.thinking=true
```

No NPU or model weights are required for the automated regression tests; they
use a constructed request and deterministic DSML output.

#### AI assistance

AI assistance was used to investigate the parser routing and prepare the
change and regression tests.

- vLLM main: https://github.com/vllm-project/vllm/commit/ee0da84ab9e04ac7610e28580af62c365e898389
