### PR TITLE
[Ops][BugFix] Fix RoPE sin offsets and dynamically compute tile size from UB

### DIFF
--- a/tests/e2e/nightly/single_node/ops/singlecard_ops/triton/test_rope.py
+++ b/tests/e2e/nightly/single_node/ops/singlecard_ops/triton/test_rope.py
@@ -14,9 +14,28 @@ MAX_POSITION_EMBEDDINGS = [262144]
 
 # parameters for test_rotary_embedding_triton_kernel only
 # (head_size, rotary_dim)
+# Coverage rationale:
+#   (64, 64)   - full RoPE, small head, power-of-two (baseline)
+#   (64, 32)   - partial RoPE, rope_dim < head_dim (LLaMA-2 style)
+#   (128, 128) - full RoPE, large head, power-of-two (common case)
+#   (128, 96)  - non-power-of-two rotary_dim; triggers sin-offset bug
+#                where old code used pad_rope_dim//2=64 instead of
+#                rope_dim//2=48
+#   (128, 64)  - partial RoPE with non-power-of-two head_dim/rope_dim
+#                ratio; exercises rope_dim resolution path
+#   (256, 192) - large head_dim that triggers UB-based dynamic tile
+#                sizing (head_dim=192 exceeds old hardcoded threshold);
+#                also non-power-of-two rotary_dim
+#   (256, 256) - full RoPE, very large head, power-of-two; verifies
+#                dynamic tile sizing caps correctly at default_max
 HEAD_ROTARY_DIMS = [
+    (64, 64),
     (64, 32),
     (128, 128),
+    (128, 96),
+    (128, 64),
+    (256, 192),
+    (256, 256),
 ]
 # (num_q_heads, num_k_heads)
 NUM_QK_HEADS = [
@@ -25,8 +44,18 @@ NUM_QK_HEADS = [
 ]
 
 # parameters for test_rotary_embedding_triton_kernel_siso only
-SISO_HEAD_SIZES = [64, 128]
-SISO_ROTARY_DIMS = [32, 64]
+# Coverage rationale:
+#   32  - small power-of-two (baseline)
+#   64  - medium power-of-two
+#   96  - non-power-of-two; triggers sin-offset bug in siso kernel
+#         (old code: pad_rope_dim//2=64 vs correct rope_dim//2=48)
+#   128 - large power-of-two; verifies dynamic tile sizing scales down
+#         for larger half_dim within siso's 6-tensor memory model
+#   192 - large non-power-of-two; combined with head_size=256 exercises
+#         full-RoPE with non-power-of-two rotary_dim. Invalid combos
+#         (rotary_dim > head_size) are skipped at runtime.
+SISO_HEAD_SIZES = [64, 128, 256]
+SISO_ROTARY_DIMS = [32, 64, 96, 128, 192]
 SISO_NUM_HEADS = [64]
 
 NUM_TOKENS = [1, 4, 8, 16, 1024]
@@ -39,6 +68,13 @@ FP8_ROPE_CASES = [
     pytest.param(1, 2, 1, 128, 128, id="single-token-full-rope"),
     pytest.param(17, 8, 1, 128, 64, id="partial-rope"),
     pytest.param(1024, 8, 1, 128, 128, id="multi-row-grid"),
+    # Non-power-of-two rotary_dim: triggers sin-offset fix in fp8 kernel
+    # path; old code used pad_rope_dim//2=64 instead of rope_dim//2=48
+    # for rotary_dim=96 (pad_rope_dim=128).
+    pytest.param(17, 8, 1, 128, 96, id="non-pow2-rope"),
+    # Large head_dim with non-power-of-two rotary_dim: exercises both the
+    # sin-offset fix and UB-based dynamic tile sizing in fp8 path.
+    pytest.param(17, 8, 1, 256, 192, id="large-head-non-pow2-rope"),
 ]
 
 
@@ -319,6 +355,10 @@ def test_rotary_embedding_triton_kernel_siso(
 
     if rotary_dim == -1:
         rotary_dim = head_size
+    # Skip invalid combinations where rotary_dim > head_size (RoPE cannot
+    # rotate more dimensions than the head has).
+    if rotary_dim > head_size:
+        pytest.skip(f"rotary_dim {rotary_dim} > head_size {head_size}")
     sin = torch.randn(num_tokens, rotary_dim // 2, dtype=dtype, device=device)
     cos = torch.randn(num_tokens, rotary_dim // 2, dtype=dtype, device=device)
     q_trt = torch.randn(num_tokens, num_q_heads, head_size, dtype=dtype, device=device)

--- a/tests/ut/ops/test_rope_tile_sizing.py
+++ b/tests/ut/ops/test_rope_tile_sizing.py
@@ -41,7 +41,6 @@ from vllm_ascend.ops.triton.rope import (
     _compute_rope_block_size_head,
 )
 
-
 # ──────────────────────────────────────────────────────────────────────────────
 # Helpers
 # ──────────────────────────────────────────────────────────────────────────────
@@ -163,7 +162,7 @@ class TestComputeBlockSizeHead:
         actual = _compute_rope_block_size_head(head_dim, rope_dim, is_neox)
         expected = _expected_block(head_dim, rope_dim, is_neox, DEFAULT_UB_BYTES)
         assert actual == expected, (
-             f"{desc}: got {actual}, expected {expected} (head_dim={head_dim}, rope_dim={rope_dim}, neox={is_neox})"
+            f"{desc}: got {actual}, expected {expected} (head_dim={head_dim}, rope_dim={rope_dim}, neox={is_neox})"
         )
 
     @pytest.mark.parametrize(

--- a/tests/ut/ops/test_rope_tile_sizing.py
+++ b/tests/ut/ops/test_rope_tile_sizing.py
@@ -1,0 +1,314 @@
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# This file is a part of the vllm-ascend project.
+#
+
+"""Unit tests for _compute_rope_block_size_head.
+
+These tests verify that the dynamic tile sizing logic correctly:
+  1. Produces BLOCK_SIZE_HEAD values that fit within the UB safety budget.
+  2. Respects the power-of-2 constraint required by Triton.
+  3. Caps results at the default max for each kernel variant.
+  4. Falls back gracefully when rope_dim is unknown (-1).
+  5. Returns at least _ROPE_MIN_BLOCK_SIZE (1) for extreme inputs.
+
+The tests do NOT require NPU hardware; get_ub_size_bytes() is mocked to
+a controlled value so the arithmetic is deterministic.
+"""
+
+from unittest.mock import patch
+
+import pytest
+
+from vllm_ascend.ops.triton.rope import (
+    _ROPE_DEFAULT_BLOCK_SIZE_NEOX,
+    _ROPE_DEFAULT_BLOCK_SIZE_NON_NEOX,
+    _ROPE_FLOAT32_BYTES,
+    _ROPE_MIN_BLOCK_SIZE,
+    _ROPE_NUM_LIVE_TENSORS_NEOX,
+    _ROPE_NUM_LIVE_TENSORS_NON_NEOX,
+    _ROPE_UB_SAFETY_FACTOR,
+    _compute_rope_block_size_head,
+)
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Helpers
+# ──────────────────────────────────────────────────────────────────────────────
+
+
+def _expected_block(
+    head_dim: int,
+    rope_dim: int,
+    is_neox_style: bool,
+    ub_bytes: int,
+) -> int:
+    """Reimplement the tile-sizing formula independently for cross-checking."""
+    effective = rope_dim if rope_dim > 0 else head_dim
+    # Triton's next_power_of_2(n) returns the smallest 2^k >= n, with 2^k=1
+    # when n <= 1.
+    pad = 1
+    while pad < effective:
+        pad *= 2
+    half = pad // 2
+    half = max(half, 1)
+
+    if is_neox_style:
+        num_live = _ROPE_NUM_LIVE_TENSORS_NEOX
+        bytes_per_head_per_tensor = half * _ROPE_FLOAT32_BYTES
+        default_max = _ROPE_DEFAULT_BLOCK_SIZE_NEOX
+    else:
+        num_live = _ROPE_NUM_LIVE_TENSORS_NON_NEOX
+        bytes_per_head_per_tensor = half * 2 * _ROPE_FLOAT32_BYTES
+        default_max = _ROPE_DEFAULT_BLOCK_SIZE_NON_NEOX
+
+    shared = 2 * half * _ROPE_FLOAT32_BYTES
+    available = int(ub_bytes * _ROPE_UB_SAFETY_FACTOR) - shared
+    bytes_per_head = num_live * bytes_per_head_per_tensor
+    if bytes_per_head <= 0:
+        return default_max
+    max_block = max(available // bytes_per_head, _ROPE_MIN_BLOCK_SIZE)
+    block_size = min(max_block, default_max)
+    result = 1
+    while result * 2 <= block_size:
+        result *= 2
+    return result
+
+
+def _ub_footprint_bytes(
+    block_size: int,
+    rope_dim: int,
+    is_neox_style: bool,
+) -> int:
+    """Compute the actual UB footprint for a given (block_size, rope_dim)."""
+    effective = rope_dim if rope_dim > 0 else 0
+    pad = 1
+    while pad < effective:
+        pad *= 2
+    half = max(pad // 2, 1)
+
+    if is_neox_style:
+        num_live = _ROPE_NUM_LIVE_TENSORS_NEOX
+        bytes_per_head_per_tensor = half * _ROPE_FLOAT32_BYTES
+    else:
+        num_live = _ROPE_NUM_LIVE_TENSORS_NON_NEOX
+        bytes_per_head_per_tensor = half * 2 * _ROPE_FLOAT32_BYTES
+
+    shared = 2 * half * _ROPE_FLOAT32_BYTES
+    return shared + block_size * num_live * bytes_per_head_per_tensor
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Test fixtures
+# ──────────────────────────────────────────────────────────────────────────────
+
+# Default UB size used by most tests: 192 KB (Ascend 910B/C).
+DEFAULT_UB_BYTES = 192 * 1024
+
+# Realistic (head_dim, rope_dim) pairs seen in production models.
+# Each entry is (head_dim, rope_dim, is_neox, description).
+REALISTIC_CASES = [
+    # Full RoPE, power-of-two
+    (64, 64, True, "small head, full rope, neox"),
+    (128, 128, True, "medium head, full rope, neox (Qwen/Llama)"),
+    (256, 256, True, "large head, full rope, neox"),
+    # Partial RoPE (rope_dim < head_dim)
+    (128, 64, True, "partial rope, neox (Llama-2 style)"),
+    (256, 128, True, "large head, partial rope, neox"),
+    # Non-power-of-two rotary_dim (triggers sin-offset path)
+    (128, 96, True, "non-pow2 rope, neox"),
+    (256, 192, True, "large non-pow2 rope, neox"),
+    # Non-NeoX (GPT-J style) variants
+    (64, 64, False, "small head, full rope, non-neox"),
+    (128, 128, False, "medium head, full rope, non-neox"),
+    (128, 96, False, "non-pow2 rope, non-neox"),
+]
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Tests
+# ──────────────────────────────────────────────────────────────────────────────
+
+
+@pytest.fixture
+def mock_ub_size():
+    """Mock get_ub_size_bytes to return DEFAULT_UB_BYTES."""
+    with patch(
+        "vllm_ascend.ops.triton.rope.get_ub_size_bytes",
+        return_value=DEFAULT_UB_BYTES,
+    ):
+        yield
+
+
+class TestComputeBlockSizeHead:
+    """Functional correctness of _compute_rope_block_size_head."""
+
+    @pytest.mark.parametrize(
+        "head_dim, rope_dim, is_neox, desc",
+        REALISTIC_CASES,
+        ids=[c[3] for c in REALISTIC_CASES],
+    )
+    def test_result_matches_independent_formula(self, mock_ub_size, head_dim, rope_dim, is_neox, desc):
+        """Cross-check against an independent reimplementation of the formula."""
+        actual = _compute_rope_block_size_head(head_dim, rope_dim, is_neox)
+        expected = _expected_block(head_dim, rope_dim, is_neox, DEFAULT_UB_BYTES)
+        assert actual == expected, (
+            f"{desc}: got {actual}, expected {expected} "
+            f"(head_dim={head_dim}, rope_dim={rope_dim}, neox={is_neox})"
+        )
+
+    @pytest.mark.parametrize(
+        "head_dim, rope_dim, is_neox, desc",
+        REALISTIC_CASES,
+        ids=[c[3] for c in REALISTIC_CASES],
+    )
+    def test_result_is_power_of_two(self, mock_ub_size, head_dim, rope_dim, is_neox, desc):
+        """Triton requires BLOCK_SIZE_HEAD to be a power-of-2 constexpr."""
+        result = _compute_rope_block_size_head(head_dim, rope_dim, is_neox)
+        assert result >= 1
+        assert (result & (result - 1)) == 0, f"{desc}: {result} is not a power of 2"
+
+    @pytest.mark.parametrize(
+        "head_dim, rope_dim, is_neox, desc",
+        REALISTIC_CASES,
+        ids=[c[3] for c in REALISTIC_CASES],
+    )
+    def test_result_respects_default_cap(self, mock_ub_size, head_dim, rope_dim, is_neox, desc):
+        """Result must not exceed the default max for the kernel variant."""
+        result = _compute_rope_block_size_head(head_dim, rope_dim, is_neox)
+        cap = _ROPE_DEFAULT_BLOCK_SIZE_NEOX if is_neox else _ROPE_DEFAULT_BLOCK_SIZE_NON_NEOX
+        assert result <= cap, f"{desc}: {result} > cap {cap}"
+
+    @pytest.mark.parametrize(
+        "head_dim, rope_dim, is_neox, desc",
+        REALISTIC_CASES,
+        ids=[c[3] for c in REALISTIC_CASES],
+    )
+    def test_result_fits_within_ub_budget(self, mock_ub_size, head_dim, rope_dim, is_neox, desc):
+        """The computed tile must fit within (ub_size * safety_factor)."""
+        result = _compute_rope_block_size_head(head_dim, rope_dim, is_neox)
+        footprint = _ub_footprint_bytes(result, rope_dim, is_neox)
+        budget = int(DEFAULT_UB_BYTES * _ROPE_UB_SAFETY_FACTOR)
+        assert footprint <= budget, (
+            f"{desc}: footprint={footprint} > budget={budget} "
+            f"(block={result}, rope_dim={rope_dim}, neox={is_neox})"
+        )
+
+
+class TestBlockSizeWithinBudget:
+    """Verify that doubling the block would exceed the UB budget.
+
+    This guards against the tile being needlessly conservative: if 2*block
+    still fits in UB, the power-of-2 search should have picked it instead.
+    """
+
+    @pytest.mark.parametrize(
+        "head_dim, rope_dim, is_neox, desc",
+        REALISTIC_CASES,
+        ids=[c[3] for c in REALISTIC_CASES],
+    )
+    def test_next_power_of_two_would_overflow_ub(self, mock_ub_size, head_dim, rope_dim, is_neox, desc):
+        result = _compute_rope_block_size_head(head_dim, rope_dim, is_neox)
+        cap = _ROPE_DEFAULT_BLOCK_SIZE_NEOX if is_neox else _ROPE_DEFAULT_BLOCK_SIZE_NON_NEOX
+        # If already at the default cap, doubling is capped away — skip.
+        if result >= cap:
+            return
+        doubled = result * 2
+        footprint_doubled = _ub_footprint_bytes(doubled, rope_dim, is_neox)
+        budget = int(DEFAULT_UB_BYTES * _ROPE_UB_SAFETY_FACTOR)
+        assert footprint_doubled > budget, (
+            f"{desc}: doubled block {doubled} fits ({footprint_doubled} <= "
+            f"{budget}) but function returned {result}"
+        )
+
+
+class TestRopeDimFallback:
+    """rope_dim=-1 (unknown) should fall back to head_dim."""
+
+    @pytest.mark.parametrize("head_dim", [64, 128, 256])
+    @pytest.mark.parametrize("is_neox", [True, False])
+    def test_unknown_rope_dim_uses_head_dim(self, mock_ub_size, head_dim, is_neox):
+        """When rope_dim=-1, the function uses head_dim as an upper bound."""
+        result_unknown = _compute_rope_block_size_head(head_dim, -1, is_neox)
+        result_full = _compute_rope_block_size_head(head_dim, head_dim, is_neox)
+        assert result_unknown == result_full, (
+            f"head_dim={head_dim}, neox={is_neox}: "
+            f"rope_dim=-1 gave {result_unknown}, full gave {result_full}"
+        )
+
+
+class TestMinimumBlockSize:
+    """Extreme small UB should still yield at least _ROPE_MIN_BLOCK_SIZE."""
+
+    def test_tiny_ub_returns_minimum(self):
+        """With a 1 KB UB, no realistic tile fits — should return 1."""
+        with patch(
+            "vllm_ascend.ops.triton.rope.get_ub_size_bytes",
+            return_value=1024,
+        ):
+            result = _compute_rope_block_size_head(128, 128, True)
+        assert result >= _ROPE_MIN_BLOCK_SIZE
+
+    def test_zero_ub_returns_minimum(self):
+        """With a zero UB, the function must not crash and return >= 1."""
+        with patch(
+            "vllm_ascend.ops.triton.rope.get_ub_size_bytes",
+            return_value=0,
+        ):
+            result = _compute_rope_block_size_head(128, 128, True)
+        assert result >= _ROPE_MIN_BLOCK_SIZE
+
+
+class TestUbScaling:
+    """Tile size should scale (weakly) up with available UB."""
+
+    @pytest.mark.parametrize("is_neox", [True, False])
+    def test_larger_ub_never_reduces_tile(self, is_neox):
+        """Doubling UB should never produce a smaller tile."""
+        with patch(
+            "vllm_ascend.ops.triton.rope.get_ub_size_bytes",
+            return_value=128 * 1024,
+        ):
+            small_ub = _compute_rope_block_size_head(128, 128, is_neox)
+        with patch(
+            "vllm_ascend.ops.triton.rope.get_ub_size_bytes",
+            return_value=256 * 1024,
+        ):
+            big_ub = _compute_rope_block_size_head(128, 128, is_neox)
+        assert big_ub >= small_ub
+
+
+class TestLiveTensorRegression:
+    """Guard against accidentally lowering the live-tensor counts.
+
+    The counts (8/10) were calibrated by inspecting the Triton Ascend
+    compiler IR and verified empirically on Ascend 910B. Lowering them
+    would cause UB overflow at the original BLOCK_SIZE_HEAD=64.
+    """
+
+    def test_neox_live_tensor_count(self):
+        assert _ROPE_NUM_LIVE_TENSORS_NEOX == 8, (
+            "NeoX live-tensor count was calibrated to 8 from compiler IR; "
+            "do not lower without re-running UB overflow verification."
+        )
+
+    def test_non_neox_live_tensor_count(self):
+        assert _ROPE_NUM_LIVE_TENSORS_NON_NEOX == 10, (
+            "Non-NeoX live-tensor count was calibrated to 10 from compiler "
+            "IR; do not lower without re-running UB overflow verification."
+        )
+
+    def test_neox_count_higher_than_original_undercount(self):
+        """The original code had 4/6 — the fix raises to 8/10."""
+        assert _ROPE_NUM_LIVE_TENSORS_NEOX > 4
+        assert _ROPE_NUM_LIVE_TENSORS_NON_NEOX > 6

--- a/tests/ut/ops/test_rope_tile_sizing.py
+++ b/tests/ut/ops/test_rope_tile_sizing.py
@@ -163,8 +163,7 @@ class TestComputeBlockSizeHead:
         actual = _compute_rope_block_size_head(head_dim, rope_dim, is_neox)
         expected = _expected_block(head_dim, rope_dim, is_neox, DEFAULT_UB_BYTES)
         assert actual == expected, (
-            f"{desc}: got {actual}, expected {expected} "
-            f"(head_dim={head_dim}, rope_dim={rope_dim}, neox={is_neox})"
+             f"{desc}: got {actual}, expected {expected} (head_dim={head_dim}, rope_dim={rope_dim}, neox={is_neox})"
         )
 
     @pytest.mark.parametrize(
@@ -200,8 +199,7 @@ class TestComputeBlockSizeHead:
         footprint = _ub_footprint_bytes(result, rope_dim, is_neox)
         budget = int(DEFAULT_UB_BYTES * _ROPE_UB_SAFETY_FACTOR)
         assert footprint <= budget, (
-            f"{desc}: footprint={footprint} > budget={budget} "
-            f"(block={result}, rope_dim={rope_dim}, neox={is_neox})"
+            f"{desc}: footprint={footprint} > budget={budget} (block={result}, rope_dim={rope_dim}, neox={is_neox})"
         )
 
 
@@ -227,8 +225,7 @@ class TestBlockSizeWithinBudget:
         footprint_doubled = _ub_footprint_bytes(doubled, rope_dim, is_neox)
         budget = int(DEFAULT_UB_BYTES * _ROPE_UB_SAFETY_FACTOR)
         assert footprint_doubled > budget, (
-            f"{desc}: doubled block {doubled} fits ({footprint_doubled} <= "
-            f"{budget}) but function returned {result}"
+            f"{desc}: doubled block {doubled} fits ({footprint_doubled} <= {budget}) but function returned {result}"
         )
 
 
@@ -242,8 +239,7 @@ class TestRopeDimFallback:
         result_unknown = _compute_rope_block_size_head(head_dim, -1, is_neox)
         result_full = _compute_rope_block_size_head(head_dim, head_dim, is_neox)
         assert result_unknown == result_full, (
-            f"head_dim={head_dim}, neox={is_neox}: "
-            f"rope_dim=-1 gave {result_unknown}, full gave {result_full}"
+            f"head_dim={head_dim}, neox={is_neox}: rope_dim=-1 gave {result_unknown}, full gave {result_full}"
         )
 
 

--- a/vllm_ascend/envs.py
+++ b/vllm_ascend/envs.py
@@ -75,7 +75,7 @@ env_variables: dict[str, Callable[[], Any]] = {
     # 0 (default): auto-detect from device properties, falling back to 192 KB
     # (safe for Ascend 910B/A3). Set to a positive value to override when
     # auto-detection is unavailable or for debugging UB overflow issues.
-    "VLLM_ASCEND_ROPE_UB_SIZE_KB": lambda: int(os.getenv("VLLM_ASCEND_ROPE_UB_SIZE_KB", 0)),
+    "VLLM_ASCEND_ROPE_UB_SIZE_KB": lambda: int(os.getenv("VLLM_ASCEND_ROPE_UB_SIZE_KB") or 0),
 }
 
 # end-env-vars-definition

--- a/vllm_ascend/envs.py
+++ b/vllm_ascend/envs.py
@@ -71,6 +71,11 @@ env_variables: dict[str, Callable[[], Any]] = {
     # Control the aclrtMemcpyBatchAsync compile path for KV cache offloading.
     # "1": force enable, "0": force disable, None: auto-detect from CANN headers.
     "VLLM_ASCEND_ENABLE_BATCH_MEMCPY": lambda: os.getenv("VLLM_ASCEND_ENABLE_BATCH_MEMCPY", None),
+    # Override the Unified Buffer (UB) size in KB for Triton kernel tile sizing.
+    # 0 (default): auto-detect from device properties, falling back to 192 KB
+    # (safe for Ascend 910B/A3). Set to a positive value to override when
+    # auto-detection is unavailable or for debugging UB overflow issues.
+    "VLLM_ASCEND_ROPE_UB_SIZE_KB": lambda: int(os.getenv("VLLM_ASCEND_ROPE_UB_SIZE_KB", 0)),
 }
 
 # end-env-vars-definition

--- a/vllm_ascend/ops/triton/rope.py
+++ b/vllm_ascend/ops/triton/rope.py
@@ -17,9 +17,27 @@
 import torch
 from vllm.triton_utils import tl, triton
 
-from vllm_ascend.ops.triton.triton_utils import get_vectorcore_num
+from vllm_ascend.ops.triton.triton_utils import get_ub_size_bytes, get_vectorcore_num
 
 _FP8_E4M3_MAX = 448.0
+
+# --- RoPE tile sizing constants ---
+# All Triton RoPE arithmetic promotes to float32 (4 bytes) per element.
+_ROPE_FLOAT32_BYTES = 4
+# Fraction of total UB that may be used for RoPE tiles. The remainder
+# absorbs compiler scratch, register spill, and double-buffering overhead.
+_ROPE_UB_SAFETY_FACTOR = 0.5
+# Default tile sizes when UB headroom is sufficient (common head_dim <= 128).
+_ROPE_DEFAULT_BLOCK_SIZE_NEOX = 64
+_ROPE_DEFAULT_BLOCK_SIZE_NON_NEOX = 32
+# Minimum tile size (Triton requires power-of-2 constexpr >= 1).
+_ROPE_MIN_BLOCK_SIZE = 1
+# Live tensors in the hottest loop iteration (all float32):
+#   NeoX:     q_tile_1, q_tile_2, new_q_tile_1, new_q_tile_2  -> 4
+#   Non-NeoX: q_tile(x2), new_q_tile_1, new_q_tile_2, q_tile_out(x2) -> 6
+# Each "x2" accounts for the extra dimension in the 3-D pair layout.
+_ROPE_NUM_LIVE_TENSORS_NEOX = 4
+_ROPE_NUM_LIVE_TENSORS_NON_NEOX = 6
 
 
 def _fp8_rope_head_block(n_heads: int, cap: int = 16) -> int:
@@ -27,6 +45,69 @@ def _fp8_rope_head_block(n_heads: int, cap: int = 16) -> int:
     if n_heads <= 0:
         return 1
     return min(triton.next_power_of_2(n_heads), cap)
+
+
+def _compute_rope_block_size_head(
+    head_dim: int,
+    rope_dim: int,
+    is_neox_style: bool,
+) -> int:
+    """Dynamically compute BLOCK_SIZE_HEAD so the RoPE tile fits within NPU UB.
+
+    The Triton RoPE kernel tiles over q/k heads in chunks of BLOCK_SIZE_HEAD.
+    Each tile keeps multiple float32 tensors alive in the Unified Buffer:
+
+    NeoX path (per head-tile iteration):
+      q_tile_1, q_tile_2            -- input halves,  (BLOCK, rope_dim/2)
+      new_q_tile_1, new_q_tile_2    -- output halves, (BLOCK, rope_dim/2)
+      cos_row, sin_row              -- shared, (rope_dim/2,)  [small]
+
+    Non-NeoX path uses a 3-D pair layout (BLOCK, rope_dim/2, 2), so each
+    full tensor occupies twice the memory of a single NeoX half.
+
+    The calculation:
+      1. Determine pad_rope_dim (power-of-2 ceiling of rope_dim).
+      2. Compute bytes-per-head for the live tensors.
+      3. Find the largest power-of-2 BLOCK_SIZE_HEAD whose total UB
+         footprint stays within (ub_size * safety_factor).
+      4. Cap at the default max for performance on small head_dim.
+    """
+    # When rope_dim is unknown (-1), head_dim is a safe upper bound
+    # because rope_dim <= head_dim is always asserted by the caller.
+    effective_rope_dim = rope_dim if rope_dim > 0 else head_dim
+    pad_rope_dim = triton.next_power_of_2(effective_rope_dim)
+    half_dim = pad_rope_dim // 2
+
+    if is_neox_style:
+        num_live_tensors = _ROPE_NUM_LIVE_TENSORS_NEOX
+        bytes_per_head_per_tensor = half_dim * _ROPE_FLOAT32_BYTES
+        default_max = _ROPE_DEFAULT_BLOCK_SIZE_NEOX
+    else:
+        num_live_tensors = _ROPE_NUM_LIVE_TENSORS_NON_NEOX
+        bytes_per_head_per_tensor = half_dim * 2 * _ROPE_FLOAT32_BYTES
+        default_max = _ROPE_DEFAULT_BLOCK_SIZE_NON_NEOX
+
+    # cos_row + sin_row are loaded once per row and shared across tiles.
+    shared_bytes = 2 * half_dim * _ROPE_FLOAT32_BYTES
+
+    ub_size = get_ub_size_bytes()
+    available_ub = int(ub_size * _ROPE_UB_SAFETY_FACTOR) - shared_bytes
+
+    bytes_per_head = num_live_tensors * bytes_per_head_per_tensor
+    if bytes_per_head <= 0:
+        return default_max
+
+    max_block = available_ub // bytes_per_head
+    max_block = max(max_block, _ROPE_MIN_BLOCK_SIZE)
+
+    # Cap at the default max for performance on small head_dim.
+    block_size = min(max_block, default_max)
+
+    # Triton requires power-of-2 constexpr; find largest pow2 <= block_size.
+    result = 1
+    while result * 2 <= block_size:
+        result *= 2
+    return result
 
 
 @triton.jit
@@ -99,7 +180,7 @@ def _triton_rope(
         # m of this program instance
         # ####################################################################
         cos_offsets = tl.arange(0, pad_rope_dim // 2)
-        sin_offsets = tl.arange(pad_rope_dim // 2, pad_rope_dim)
+        sin_offsets = cos_offsets + (rope_dim // 2)
         cos_mask = cos_offsets < (rope_dim // 2)
         if USE_COS_SIN:
             pos_idx = tl.load(pos_ptr + row_idx).to(tl.int64)
@@ -224,7 +305,7 @@ def _triton_rope_siso(
         # m of this program instance
         # ####################################################################
         cos_offsets = tl.arange(0, pad_rope_dim // 2)
-        sin_offsets = tl.arange(pad_rope_dim // 2, pad_rope_dim)
+        sin_offsets = cos_offsets + (rope_dim // 2)
         cos_mask = cos_offsets < (rope_dim // 2)
         if USE_COS_SIN:
             pos_idx = tl.load(pos_ptr + row_idx).to(tl.int64)
@@ -448,16 +529,9 @@ def rope_forward_triton(
 
     num_tokens, n_q_head, head_dim = q.shape
     n_kv_head = k.shape[1]
-    # TODO: use a more robust method to get BLOCK_SIZE_HEAD
-    if is_neox_style:
-        BLOCK_SIZE_HEAD = 64
-    else:
-        BLOCK_SIZE_HEAD = 32
-    # Large head_dim RoPE can overflow UB with the default tile on A2/A3.
-    # Keep the original tile for common head_dim models.
-    large_head_dim_threshold, large_head_block_size = 256, 16
-    if head_dim >= large_head_dim_threshold:
-        BLOCK_SIZE_HEAD = min(BLOCK_SIZE_HEAD, large_head_block_size)
+    # Dynamically size the head tile to fit within NPU Unified Buffer,
+    # replacing the previous hardcoded head_dim threshold approach.
+    BLOCK_SIZE_HEAD = _compute_rope_block_size_head(head_dim, rope_dim, is_neox_style)
     num_vectorcore = get_vectorcore_num()
     n_row = min(num_tokens, num_vectorcore)
 

--- a/vllm_ascend/ops/triton/rope.py
+++ b/vllm_ascend/ops/triton/rope.py
@@ -529,6 +529,13 @@ def rope_forward_triton(
 
     num_tokens, n_q_head, head_dim = q.shape
     n_kv_head = k.shape[1]
+    # Resolve rope_dim early so tile sizing uses the actual rotary dimension
+    # instead of falling back to head_dim (which may be much larger).
+    if rope_dim == -1:
+        if cos is not None:
+            rope_dim = cos.shape[-1] * 2
+        elif cos_sin_cache is not None:
+            rope_dim = cos_sin_cache.shape[-1]
     # Dynamically size the head tile to fit within NPU Unified Buffer,
     # replacing the previous hardcoded head_dim threshold approach.
     BLOCK_SIZE_HEAD = _compute_rope_block_size_head(head_dim, rope_dim, is_neox_style)

--- a/vllm_ascend/ops/triton/rope.py
+++ b/vllm_ascend/ops/triton/rope.py
@@ -45,34 +45,42 @@ _ROPE_MIN_BLOCK_SIZE = 1
 # Used to compute UB footprint: bytes = num_live_tensors * half_dim * 4 * BLOCK
 # These values are tightly coupled to the kernel implementation.
 #
-# NeoX path (4 tensors) - see _triton_rope lines 207-218:
-#   line 207: q_tile_1 = tl.load(...)       # input half 1
-#   line 212: q_tile_2 = tl.load(...)       # input half 2
-#   line 215: new_q_tile_1 = q_tile_1 * cos - q_tile_2 * sin  # output half 1
-#   line 218: new_q_tile_2 stored
-#   -> At line 216 (storing new_q_tile_1): q_tile_1, q_tile_2,
-#      new_q_tile_1 are live. new_q_tile_2 is computed at line 217.
-#   -> Peak live count = 4 (both inputs + both outputs) right before
-#      the final store at line 218.
+# NeoX path (8 tensors) - the user-visible IR undercounts because the Triton
+# Ascend compiler materializes intermediate high-level IR (HLIR) tensors
+# that are not present in the Python source. Analysis of the generated IR
+# for the NeoX hot loop (see _triton_rope lines 207-218) shows the compiler
+# keeps the following float32 tensors alive simultaneously at the peak:
+#   - q_tile_1, q_tile_2                   # input halves (BLOCK, rope_dim/2)
+#   - new_q_tile_1, new_q_tile_2           # output halves (BLOCK, rope_dim/2)
+#   - cos_row_broadcast (x2)               # cos broadcast to (BLOCK, half)
+#   - sin_row_broadcast (x2)               # sin broadcast to (BLOCK, half)
+#   -> Peak live count = 8.
+#   -> Verified empirically on Ascend 910B: with the original count of 4 and
+#      BLOCK_SIZE_HEAD=64 on head_dim=128/rope_dim=128, the kernel triggers
+#      "ub overflow, requires 1839104 bits while 1572864 bits available!".
+#      Raising to 8 yields BLOCK_SIZE_HEAD=32, which compiles and runs cleanly.
 #
-# Non-NeoX path (6 tensors, due to 3-D pair layout) - see lines 228-233:
-#   line 228: q_tile = tl.load(...)         # 3D (BLOCK, half, 2), counts as 2
-#   line 229: q_tile_1, q_tile_2 = tl.split(q_tile)
-#   line 230: new_q_tile_1 = ...            # output half 1
-#   line 231: new_q_tile_2 = ...            # output half 2
-#   line 232: q_tile_out = tl.join(...)     # 3D (BLOCK, half, 2), counts as 2
-#   line 233: tl.store(q_tile_out, ...)
-#   -> At line 233 (storing q_tile_out): q_tile_1, q_tile_2,
-#      new_q_tile_1, new_q_tile_2, q_tile_out (x2) all live.
-#   -> Peak live count = 6 (q_tile x2 + new_q_tile_1 + new_q_tile_2 +
-#      q_tile_out x2).
+# Non-NeoX path (10 tensors) - same compiler-materialed-broadcast effect, but
+# on the 3-D pair layout (BLOCK, rope_dim/2, 2) the source already counts 6
+# live tensors; the compiler adds 4 more for cos/sin broadcasts (x2 each):
+#   - q_tile (x2)                          # 3D input, counts as 2
+#   - q_tile_1, q_tile_2                   # split halves
+#   - new_q_tile_1, new_q_tile_2           # output halves
+#   - q_tile_out (x2)                       # 3D join output, counts as 2
+#   - cos_row_broadcast (x2)               # compiler-materialized
+#   - sin_row_broadcast (x2)               # compiler-materialized
+#   -> Peak live count = 10.
 #
 # MAINTENANCE NOTE: If the kernel's hot loop is modified (e.g., adding
 # intermediate buffers, changing load/store order, or introducing streaming
 # writes), update these counts to reflect the new peak live-tensor count.
-# Overestimating is safe (just smaller tiles); underestimating risks UB overflow.
-_ROPE_NUM_LIVE_TENSORS_NEOX = 4
-_ROPE_NUM_LIVE_TENSORS_NON_NEOX = 6
+# The counts must include both source-visible tensors AND any tensors the
+# Triton Ascend compiler materializes from broadcasts/fusions. When in doubt,
+# inspect the generated IR (dump via MLIR_ARGS=... or by running the kernel
+# with a small input and checking for "ub overflow" errors). Overestimating
+# is safe (just smaller tiles); underestimating risks UB overflow.
+_ROPE_NUM_LIVE_TENSORS_NEOX = 8
+_ROPE_NUM_LIVE_TENSORS_NON_NEOX = 10
 
 
 def _fp8_rope_head_block(n_heads: int, cap: int = 16) -> int:

--- a/vllm_ascend/ops/triton/rope.py
+++ b/vllm_ascend/ops/triton/rope.py
@@ -23,19 +23,54 @@ _FP8_E4M3_MAX = 448.0
 
 # --- RoPE tile sizing constants ---
 # All Triton RoPE arithmetic promotes to float32 (4 bytes) per element.
+# Applies to cos_row, sin_row, q_tile_*, new_q_tile_* throughout the kernel.
 _ROPE_FLOAT32_BYTES = 4
 # Fraction of total UB that may be used for RoPE tiles. The remainder
 # absorbs compiler scratch, register spill, and double-buffering overhead.
+# Conservative at 0.5 - safe but possibly suboptimal. If future profiling
+# shows compiler overhead is lower, this can be raised. Never set >= 1.0
+# as that leaves no room for non-RoPE UB usage.
 _ROPE_UB_SAFETY_FACTOR = 0.5
-# Default tile sizes when UB headroom is sufficient (common head_dim <= 128).
+# Default (max) tile sizes when UB headroom is sufficient. Acts as a cap:
+#   block_size = min(max_block_from_ub, default_max)
+# Beyond this size, launch overhead and cache effects start to dominate.
+# Typical "performance knee" for vector-core NPU is 64 (NeoX) / 32 (Non-NeoX).
+# Not hardware-UB-dependent - change only if kernel launch characteristics
+# change (e.g., different vector core count).
 _ROPE_DEFAULT_BLOCK_SIZE_NEOX = 64
 _ROPE_DEFAULT_BLOCK_SIZE_NON_NEOX = 32
 # Minimum tile size (Triton requires power-of-2 constexpr >= 1).
 _ROPE_MIN_BLOCK_SIZE = 1
-# Live tensors in the hottest loop iteration (all float32):
-#   NeoX:     q_tile_1, q_tile_2, new_q_tile_1, new_q_tile_2  -> 4
-#   Non-NeoX: q_tile(x2), new_q_tile_1, new_q_tile_2, q_tile_out(x2) -> 6
-# Each "x2" accounts for the extra dimension in the 3-D pair layout.
+# Number of live float32 tensors in the hottest loop iteration of the kernel.
+# Used to compute UB footprint: bytes = num_live_tensors * half_dim * 4 * BLOCK
+# These values are tightly coupled to the kernel implementation.
+#
+# NeoX path (4 tensors) - see _triton_rope lines 207-218:
+#   line 207: q_tile_1 = tl.load(...)       # input half 1
+#   line 212: q_tile_2 = tl.load(...)       # input half 2
+#   line 215: new_q_tile_1 = q_tile_1 * cos - q_tile_2 * sin  # output half 1
+#   line 218: new_q_tile_2 stored
+#   -> At line 216 (storing new_q_tile_1): q_tile_1, q_tile_2,
+#      new_q_tile_1 are live. new_q_tile_2 is computed at line 217.
+#   -> Peak live count = 4 (both inputs + both outputs) right before
+#      the final store at line 218.
+#
+# Non-NeoX path (6 tensors, due to 3-D pair layout) - see lines 228-233:
+#   line 228: q_tile = tl.load(...)         # 3D (BLOCK, half, 2), counts as 2
+#   line 229: q_tile_1, q_tile_2 = tl.split(q_tile)
+#   line 230: new_q_tile_1 = ...            # output half 1
+#   line 231: new_q_tile_2 = ...            # output half 2
+#   line 232: q_tile_out = tl.join(...)     # 3D (BLOCK, half, 2), counts as 2
+#   line 233: tl.store(q_tile_out, ...)
+#   -> At line 233 (storing q_tile_out): q_tile_1, q_tile_2,
+#      new_q_tile_1, new_q_tile_2, q_tile_out (x2) all live.
+#   -> Peak live count = 6 (q_tile x2 + new_q_tile_1 + new_q_tile_2 +
+#      q_tile_out x2).
+#
+# MAINTENANCE NOTE: If the kernel's hot loop is modified (e.g., adding
+# intermediate buffers, changing load/store order, or introducing streaming
+# writes), update these counts to reflect the new peak live-tensor count.
+# Overestimating is safe (just smaller tiles); underestimating risks UB overflow.
 _ROPE_NUM_LIVE_TENSORS_NEOX = 4
 _ROPE_NUM_LIVE_TENSORS_NON_NEOX = 6
 

--- a/vllm_ascend/ops/triton/rope.py
+++ b/vllm_ascend/ops/triton/rope.py
@@ -118,7 +118,14 @@ def _compute_rope_block_size_head(
     # When rope_dim is unknown (-1), head_dim is a safe upper bound
     # because rope_dim <= head_dim is always asserted by the caller.
     effective_rope_dim = rope_dim if rope_dim > 0 else head_dim
-    pad_rope_dim = triton.next_power_of_2(effective_rope_dim)
+    # Compute next power-of-2 without relying on triton.next_power_of_2,
+    # which is not available on all triton versions (e.g. CPU CI env).
+    # The result is only used for UB footprint estimation, not for
+    # kernel constexpr values, so an exact match to triton's helper
+    # is not required.
+    pad_rope_dim = 1
+    while pad_rope_dim < effective_rope_dim:
+        pad_rope_dim *= 2
     half_dim = pad_rope_dim // 2
 
     if is_neox_style:

--- a/vllm_ascend/ops/triton/triton_utils.py
+++ b/vllm_ascend/ops/triton/triton_utils.py
@@ -3,9 +3,25 @@ from typing import Any
 import torch
 from vllm.triton_utils import HAS_TRITON, tl, triton
 
+from vllm_ascend import envs
+
 _NUM_AICORE = -1
 _NUM_VECTORCORE = -1
+_UB_SIZE_BYTES = -1
 _extension_module = None
+
+# Safe default for Ascend 910B (A2) and 910C (A3), both have 192 KB UB.
+# Used when device properties do not expose UB size and no env override is set.
+DEFAULT_UB_SIZE_BYTES = 192 * 1024
+
+# Candidate keys that Triton Ascend driver may use to report UB size.
+_UB_SIZE_PROPERTY_KEYS = (
+    "ub_size",
+    "max_ub_size",
+    "unified_buffer_size",
+    "max_shared_memory",
+    "max_shared_mem",
+)
 
 if HAS_TRITON:
     try:
@@ -44,7 +60,7 @@ else:
 
 
 def init_device_properties_triton():
-    global _NUM_AICORE, _NUM_VECTORCORE
+    global _NUM_AICORE, _NUM_VECTORCORE, _UB_SIZE_BYTES
     if _NUM_AICORE == -1 and HAS_TRITON:
         device_properties: dict[str, Any] = triton.runtime.driver.active.utils.get_device_properties(
             torch.npu.current_device()
@@ -52,6 +68,21 @@ def init_device_properties_triton():
         _NUM_AICORE = device_properties.get("num_aicore", -1)
         _NUM_VECTORCORE = device_properties.get("num_vectorcore", -1)
         assert _NUM_AICORE > 0 and _NUM_VECTORCORE > 0, "Failed to detect device properties."
+
+        # Detect UB size: try each candidate key from device properties.
+        for key in _UB_SIZE_PROPERTY_KEYS:
+            value = device_properties.get(key)
+            if isinstance(value, (int, float)) and value > 0:
+                _UB_SIZE_BYTES = int(value)
+                break
+        # Fall back to safe default if not found.
+        if _UB_SIZE_BYTES <= 0:
+            _UB_SIZE_BYTES = DEFAULT_UB_SIZE_BYTES
+
+        # Allow env var override for debugging or unsupported hardware.
+        env_override = envs.VLLM_ASCEND_ROPE_UB_SIZE_KB
+        if env_override > 0:
+            _UB_SIZE_BYTES = env_override * 1024
 
 
 def get_aicore_num():
@@ -64,3 +95,16 @@ def get_vectorcore_num():
     global _NUM_VECTORCORE
     assert _NUM_VECTORCORE > 0, "Device properties not initialized. Please call init_device_properties_triton() first."
     return _NUM_VECTORCORE
+
+
+def get_ub_size_bytes():
+    """Return the Unified Buffer (UB) size in bytes for the current NPU.
+
+    Used by Triton kernels to dynamically size tiles so they fit within UB.
+    The value is auto-detected from device properties during
+    ``init_device_properties_triton()``, with a safe fallback of 192 KB
+    (covering Ascend 910B/A3). Override via ``VLLM_ASCEND_ROPE_UB_SIZE_KB``.
+    """
+    global _UB_SIZE_BYTES
+    assert _UB_SIZE_BYTES > 0, "Device properties not initialized. Please call init_device_properties_triton() first."
+    return _UB_SIZE_BYTES

--- a/vllm_ascend/ops/triton/triton_utils.py
+++ b/vllm_ascend/ops/triton/triton_utils.py
@@ -14,6 +14,15 @@ _extension_module = None
 # Used when device properties do not expose UB size and no env override is set.
 DEFAULT_UB_SIZE_BYTES = 192 * 1024
 
+# Minimum plausible UB size in bytes. Some Ascend driver versions return
+# invalid values (e.g., 1) for UB-related device properties when the real
+# information is unavailable. Any detected value below this threshold is
+# treated as invalid and falls back to DEFAULT_UB_SIZE_BYTES. The smallest
+# real UB on any shipping Ascend NPU is 128 KB (older 310P), so 4 KB is a
+# conservative floor that rejects sentinel/error values while accepting any
+# genuine UB report.
+_MIN_UB_SIZE_BYTES = 4 * 1024
+
 # Candidate keys that Triton Ascend driver may use to report UB size.
 _UB_SIZE_PROPERTY_KEYS = (
     "ub_size",
@@ -70,12 +79,15 @@ def init_device_properties_triton():
         assert _NUM_AICORE > 0 and _NUM_VECTORCORE > 0, "Failed to detect device properties."
 
         # Detect UB size: try each candidate key from device properties.
+        # Reject values below _MIN_UB_SIZE_BYTES: some driver versions return
+        # sentinels (e.g., 1) when UB info is unavailable, which would produce
+        # absurdly small tiles and kernel compilation failures.
         for key in _UB_SIZE_PROPERTY_KEYS:
             value = device_properties.get(key)
-            if isinstance(value, (int, float)) and value > 0:
+            if isinstance(value, (int, float)) and value >= _MIN_UB_SIZE_BYTES:
                 _UB_SIZE_BYTES = int(value)
                 break
-        # Fall back to safe default if not found.
+        # Fall back to safe default if not found or invalid.
         if _UB_SIZE_BYTES <= 0:
             _UB_SIZE_BYTES = DEFAULT_UB_SIZE_BYTES
 


### PR DESCRIPTION
### What this PR does / why we need it?

This PR fixes two issues in the Triton RoPE kernels (`vllm_ascend/ops/triton/rope.py`):

---

#### Issue 1: Incorrect `sin` offsets for non-power-of-two `rotary_dim`

**Root cause:** Triton requires power-of-2 constexpr tile shapes, so the kernel pads the block dimension with `pad_rope_dim = triton.next_power_of_2(rope_dim)`. This padding is correct for the tile shape, but the previous implementation mistakenly used the padded dimension to compute the start of the `sin` block in `cos_sin_cache`:

```python
# Before (incorrect)
sin_offsets = tl.arange(pad_rope_dim // 2, pad_rope_dim)
```

The physical `cos_sin_cache` layout is based on the **actual** `rope_dim`, not the padded one:

```
[cos_0, ..., cos_{rope_dim/2-1}, sin_0, ..., sin_{rope_dim/2-1}]
```

So `sin` starts at offset `rope_dim // 2`, not `pad_rope_dim // 2`.

**Example** (`rope_dim = 96`, `pad_rope_dim = 128`):

| Item                      | Value         |
| ------------------------- | ------------- |
| Correct sin start offset  | 96 // 2 = 48  |
| Previous sin start offset | 128 // 2 = 64 |

This caused the kernel to read `sin` values from wrong cache positions, producing silently incorrect RoPE output for any model whose `rotary_dim` is not a power of two (e.g., `rotary_dim = 96`).

**Fix:** Use `cos_offsets + (rope_dim // 2)` so the offset is anchored to the actual `rope_dim`, not the padded dimension:

```python
# After (correct)
sin_offsets = cos_offsets + (rope_dim // 2)
```

Applied to both `_triton_rope` and `_triton_rope_siso` for consistency. The `_triton_rope_fp8` kernel already uses the correct pattern.

**Backward compatibility:** When `rope_dim` is a power of two (e.g., 64/128/256 used by LLaMA/Qwen), `pad_rope_dim == rope_dim` and the new code produces identical results to the old code.

Fixes [#12723](https://github.com/vllm-project/vllm-ascend/issues/12723)

---

#### Issue 2: Hardcoded `BLOCK_SIZE_HEAD` thresholds cause UB overflow on large `head_dim`

**Root cause:** The previous `rope_forward_triton` sized `BLOCK_SIZE_HEAD` using hardcoded thresholds that ignored the actual NPU Unified Buffer (UB) capacity:

```python
# Before (hardcoded)
if is_neox_style:
    BLOCK_SIZE_HEAD = 64
else:
    BLOCK_SIZE_HEAD = 32
large_head_dim_threshold, large_head_block_size = 256, 16
if head_dim >= large_head_dim_threshold:
    BLOCK_SIZE_HEAD = min(BLOCK_SIZE_HEAD, large_head_block_size)
```

These constants were calibrated for the common `head_dim=128` case but are not portable across hardware or head configurations. On Ascend 910B with `head_dim=128` and `rope_dim=128`, the Triton Ascend compiler materializes additional broadcast tensors (cos/sin broadcasts to `(BLOCK, half)`) that are not visible in the Python source. The previous `BLOCK_SIZE_HEAD=64` exceeded the 192 KB UB budget and triggered compilation failure:

```
ub overflow, requires 1839104 bits while 1572864 bits available!
```

**Fix:** Replace the hardcoded thresholds with a dynamic computation based on the actual UB size and the live-tensor count derived from compiler IR analysis.

New function `_compute_rope_block_size_head(head_dim, rope_dim, is_neox_style)` in `rope.py`:

1. Resolves `rope_dim` early (falls back to `head_dim` when `-1`), so tile sizing uses the actual rotary dimension instead of an overestimated `head_dim`.
2. Computes the UB footprint per head-tile iteration as:
   ```
   footprint = shared_bytes + BLOCK_SIZE_HEAD * num_live_tensors * bytes_per_head_per_tensor
   ```
3. Picks the largest power-of-2 `BLOCK_SIZE_HEAD` whose footprint stays within `ub_size * _ROPE_UB_SAFETY_FACTOR` (0.5).
4. Caps at `_ROPE_DEFAULT_BLOCK_SIZE_NEOX` (64) / `_ROPE_DEFAULT_BLOCK_SIZE_NON_NEOX` (32) for performance on small `head_dim`.

Live-tensor counts are calibrated from Triton Ascend compiler IR analysis and empirical UB-overflow verification on Ascend 910B:

| Kernel variant | Source-visible tensors | Compiler-materialized broadcasts | Total live |
| ------------- | --------------------- | ------------------------------ | ---------- |
| NeoX          | 4 (q_tile_1/2, new_q_tile_1/2) | 4 (cos/sin broadcasts ×2 each) | **8** |
| Non-NeoX      | 6 (q_tile ×2, new_q_tile_1/2, q_tile_out ×2) | 4 (cos/sin broadcasts ×2 each) | **10** |

Supporting infrastructure changes:

- `vllm_ascend/ops/triton/triton_utils.py`:
  - New `get_ub_size_bytes()` returns the auto-detected UB size, with a safe fallback of `DEFAULT_UB_SIZE_BYTES = 192 * 1024` (covers Ascend 910B/910C).
  - New `_MIN_UB_SIZE_BYTES = 4 * 1024` filters invalid sentinel values (e.g., some driver versions return `ub_size=1`), preventing absurdly small tiles.
  - `init_device_properties_triton()` now probes multiple candidate keys (`ub_size`, `max_ub_size`, `unified_buffer_size`, `max_shared_memory`, `max_shared_mem`) for UB detection.
- `vllm_ascend/envs.py`:
  - New `VLLM_ASCEND_ROPE_UB_SIZE_KB` environment variable for manual override / debugging on unsupported hardware.

**Backward compatibility:** For the common `head_dim=128, rope_dim=128` NeoX case on Ascend 910B (192 KB UB), the dynamic computation yields `BLOCK_SIZE_HEAD=32`, which is the largest power-of-2 tile that fits within the UB budget given the corrected live-tensor count. The old `BLOCK_SIZE_HEAD=64` was actually unsafe (causes UB overflow); the new value is the correct, UB-safe tile.

---

### Does this PR introduce _any_ user-facing change?

- **Issue 1 (sin offsets):** Fixes a silent correctness bug for models with non-power-of-two `rotary_dim`. For models with power-of-two `rotary_dim` (the common case), behavior is unchanged.
- **Issue 2 (UB tile sizing):** Changes `BLOCK_SIZE_HEAD` from hardcoded values to dynamically computed values based on hardware UB. On Ascend 910B, the common `head_dim=128` NeoX case changes from 64 → 32 (the old value triggered UB overflow). Models that previously failed to compile due to UB overflow will now compile successfully. No user-facing API change.

Users can override the detected UB size via the new `VLLM_ASCEND_ROPE_UB_SIZE_KB` environment variable for debugging or unsupported hardware.

---

### How was this patch tested?

#### Issue 1 (sin offsets) — correctness verification

- **Existing tests:** All existing RoPE e2e tests pass (covering `head_size=64, rotary_dim=32` and `head_size=128, rotary_dim=128`), confirming no regression for power-of-two `rotary_dim`.
- **New test cases:** Extended `HEAD_ROTARY_DIMS`, `SISO_ROTARY_DIMS`, and `FP8_ROPE_CASES` in `tests/e2e/nightly/single_node/ops/singlecard_ops/triton/test_rope.py` to cover non-power-of-two `rotary_dim` (96, 192) across all three kernel paths (`_triton_rope`, `_triton_rope_siso`, `_triton_rope_fp8`).
- **Verification method:** Triton kernel output compared against PyTorch reference implementation via `torch.testing.assert_close`; `max_diff < epsilon` confirms the sin-offset fix is correct.

#### Issue 2 (UB tile sizing) — three-layer verification

**Layer 1 — Logic correctness (offline UT, no NPU required):**

New unit test file `tests/ut/ops/test_rope_tile_sizing.py` with **63 test cases** across 6 test classes:

| Test class | Verification target | Cases |
| ---------- | ------------------- | ----- |
| `TestComputeBlockSizeHead` | Formula correctness + power-of-2 + UB budget + default cap | 4 × 10 = 40 |
| `TestBlockSizeWithinBudget` | Tile is not conservative (doubling must overflow UB) | 10 |
| `TestRopeDimFallback` | `rope_dim=-1` falls back to `head_dim` | 6 |
| `TestMinimumBlockSize` | Extreme UB (0 / 1 KB) returns minimum | 2 |
| `TestUbScaling` | Larger UB never reduces tile | 2 |
| `TestLiveTensorRegression` | Live-tensor counts 8/10 regression guard | 3 |

Tests mock `get_ub_size_bytes()` so they run on CI without NPU hardware. An independent reimplementation `_expected_block()` cross-checks the formula to avoid self-verification.

```bash
pytest tests/ut/ops/test_rope_tile_sizing.py -v
```

**Layer 2 — UB overflow elimination (compile-time, NPU):**

Reproduced on Ascend 910B: with the original `_ROPE_NUM_LIVE_TENSORS_NEOX=4` and `BLOCK_SIZE_HEAD=64` on `head_dim=128, rope_dim=128`, the Triton Ascend compiler reports:

```
ub overflow, requires 1839104 bits while 1572864 bits available!
```

IR analysis of the NeoX hot loop confirms the compiler materializes 4 additional broadcast tensors (cos/sin ×2 each), raising the peak live count from 4 (source-visible) to 8 (actual). With the corrected count of 8, `_compute_rope_block_size_head` yields `BLOCK_SIZE_HEAD=32`, which compiles and runs cleanly.

**Layer 3 — End-to-end inference (runtime, NPU):**

Verified on 4 × Ascend 910B (cards 4,5,6,7) with Qwen3-8B (`head_dim=128, rope_dim=128`, NeoX style) in TP=4 mode:

```
UB size: 192 KB
Model loaded in 50.9s
Generation: 10.8s, 0.37 prompts/s, output: 23.86 toks/s

[Prompt]: The capital of China is
[Output]:  Beijing. The capital of China is Beijing...

[Prompt]: Explain what is rotation position embedding in one sentence:
[Output]:  Rotation Position Embedding (RoPE) is a method for incorporating
           positional information into transformer models by rotating...

RESULT: ALL PROMPTS PRODUCED COHERENT OUTPUTS
```

The dynamic tile sizing does not break end-to-end inference; the common `head_dim=128` case (which previously triggered UB overflow) now compiles and generates coherent outputs.

#### Lint

```bash
ruff check vllm_ascend/ops/triton/rope.py vllm_ascend/ops/triton/triton_utils.py
ruff format --check vllm_ascend/ops/triton/rope.py vllm_ascend/ops/triton/triton_utils.py
```

Both pass.

---


- vLLM main: https://github.com/vllm-project/vllm/commit/b2f685834a6456197e7033966fdef52a23f1abcd
