### PR TITLE
[Doc] Document Ascend Triton operators

### DIFF
--- a/vllm_ascend/ops/triton/docs/bad_words_kernel.md
+++ b/vllm_ascend/ops/triton/docs/bad_words_kernel.md
@@ -1,0 +1,50 @@
+# _bad_words_kernel
+
+## Description
+
+- **Function**: Masks the final token of every bad-word sequence whose prefix matches the request history by setting the corresponding logit to negative infinity.
+- **Formula**: For token row `t` and bad word `w=(w_0,...,w_n)`, `logits[t,w_n] = -inf` when the last `n` committed or speculative tokens equal `w_0,...,w_(n-1)`.
+- **Algorithm flow** (processed token row by token row, independently): map the expanded token to its request, scan that request's bad words, compare each prefix against committed and speculative token buffers, and mask the final token on a match.
+- **Supported modes**: Atlas A2, Atlas A3, and Ascend 950. Used by regular and speculative sampling; graph mode is N/A because sampling runs after the captured model-forward graph.
+
+## Parameters
+
+| Parameter | Input/Output/Attribute | Description | Data type | Data format |
+| --- | --- | --- | --- | --- |
+| `logits_ptr` | Input/Output | Logits `[num_tokens, vocab_size]`; modified in place | fp32 | ND |
+| `logits_stride` | Attribute | Row stride of `logits_ptr` | int | scalar |
+| `expanded_idx_mapping_ptr` | Input | Token-to-request mapping `[num_tokens]` | int32 | ND |
+| `bad_word_token_ids_ptr` | Input | Flattened bad-word tokens per request | int32 | ND |
+| `bad_word_token_ids_stride` | Attribute | Request stride of bad-word tokens | int | scalar |
+| `bad_word_offsets_ptr` | Input | Word boundaries `[max_num_reqs, max_num_bad_words + 1]` | int32 | ND |
+| `bad_word_offsets_stride` | Attribute | Request stride of offsets | int | scalar |
+| `num_bad_words_ptr` | Input | Bad-word count per request | int32 | ND |
+| `all_token_ids_ptr` | Input | Committed token history | int32 | ND |
+| `all_token_ids_stride` | Attribute | Request stride of token history | int | scalar |
+| `prompt_len_ptr`, `total_len_ptr` | Input | Prompt and total lengths per request | int32 | ND |
+| `input_ids_ptr` | Input | Current expanded input tokens | int32 | ND |
+| `expanded_local_pos_ptr` | Input | Local speculative position per token | int32 | ND |
+| `num_tokens`, `max_num_bad_words` | Attribute | Active token rows and scan bound | int | scalar |
+| `MAX_PREFIX_LEN` | Attribute | Reserved compile-time value passed as 32; currently unused by the kernel body | int32 | scalar |
+
+## Constraints
+
+- Bad-word token storage is limited to 1024 tokens and 128 words per request. Offsets must remain within the 1024-token row; final token IDs must lie in `[0, vocab_size)`.
+- There is no independently enforced 32-token prefix limit: `MAX_PREFIX_LEN=32` is passed by the wrapper but is not referenced in the kernel.
+- Mapping indices, offsets, lengths, positions, and token IDs must be valid for their backing tensors. Inputs must be contiguous in their documented last dimensions.
+- The kernel changes only matching logits and supports dynamic active-token counts without recompilation.
+
+## Origin and Differences
+
+- **Origin**: Adapted from vLLM's `vllm/v1/worker/gpu/sample/bad_words.py`.
+- **Differences**:
+    - NPU adaptation for performance: distributes token rows across Ascend vector cores and reuses request state inside each token loop.
+    - Modified for vllm-ascend logic: handles committed and speculative token histories in the same kernel.
+
+## Test Cases
+
+The NPU test covers 512–2048 token rows, 16–64 requests, vocabulary size 50257, zero and maximum bad-word counts, and the 1024-token storage boundary. It checks whether logits are changed or preserved as expected, but does not yet compare every element against a reference; no numerical tolerance applies.
+
+```bash
+pytest -sv tests/e2e/nightly/single_node/ops/singlecard_ops/triton/test_bad_words.py
+```

--- a/vllm_ascend/ops/triton/docs/batch_memcpy_kernel.md
+++ b/vllm_ascend/ops/triton/docs/batch_memcpy_kernel.md
@@ -1,0 +1,38 @@
+# batch_memcpy_kernel
+
+## Description
+
+- **Function**: Performs a batch of independent, variable-size device-to-device byte copies.
+- **Formula**: `dst[i][0:sizes[i]] = src[i][0:sizes[i]]`.
+- **Algorithm flow** (processed copy by copy, independently): load one source address, destination address, and byte count; cast addresses once; then copy masked byte tiles using streaming cache accesses.
+- **Supported modes**: Atlas A2, Atlas A3, and Ascend 950 hardware profiles with `TRITON_BATCH_MEMCPY`; 310P uses a tensor-copy fallback. Graph mode is N/A because aligned Mamba-state copies run outside the captured model forward.
+
+## Parameters
+
+| Parameter | Input/Output/Attribute | Description | Data type | Data format |
+| --- | --- | --- | --- | --- |
+| `src_ptrs` | Input | Absolute source addresses `[batch]` | int64 | ND |
+| `dst_ptrs` | Input | Absolute destination addresses `[batch]` | int64 | ND |
+| `sizes` | Input | Copy sizes in bytes `[batch]` | int32 | ND |
+| `BLOCK_SIZE` | Attribute | Compile-time byte tile size | int | scalar |
+
+## Constraints
+
+- Launch grid size must equal the number of copies; every address range must be valid for its byte count.
+- Source and destination ranges for a copy must not overlap. Zero-sized copies are allowed.
+- Copying is bytewise and therefore independent of the tensors' element dtypes.
+
+## Origin and Differences
+
+- **Origin**: Adapted from vLLM's `vllm/v1/worker/mamba_utils.py`.
+- **Differences**:
+    - NPU adaptation for performance: hoists pointer casts outside the loop to avoid Triton-Ascend pointer-analysis failures, uses an 8192-byte tile instead of upstream's 1024-byte tile, and bypasses L1 for streaming traffic.
+    - Modified behavior: unlike current upstream, this kernel has no left-overlap barrier. Callers must provide non-overlapping source and destination ranges.
+
+## Test Cases
+
+The NPU test copies four representative Mamba-state byte ranges `{24576, 262144, 24576, 262144}` using bf16 and fp32 backing tensors. It requires bit-exact output (`rtol=atol=0`). Overlap behavior is not tested because overlapping ranges are outside this kernel's contract.
+
+```bash
+pytest -sv tests/e2e/nightly/single_node/ops/singlecard_ops/triton/test_batch_memcpy.py
+```

--- a/vllm_ascend/ops/triton/docs/bonus_renew.md
+++ b/vllm_ascend/ops/triton/docs/bonus_renew.md
@@ -1,0 +1,38 @@
+# bonus_renew
+
+## Description
+
+- **Function**: Appends a request's bonus token after all of its draft tokens have been accepted.
+- **Formula**: `output[position, num_draft_tokens] = bonus_token_ids[position]`.
+- **Algorithm flow** (processed request by request, independently): load one bonus token and store it at the row offset following the accepted draft prefix.
+- **Supported modes**: Atlas A2, Atlas A3, and Ascend 950. Inlined into greedy rejection sampling; graph mode is N/A because sampling follows model-forward graph execution.
+
+## Parameters
+
+| Parameter | Input/Output/Attribute | Description | Data type | Data format |
+| --- | --- | --- | --- | --- |
+| `bonus_token_ids_ptr` | Input | Bonus token per request | int32 / int64 | ND |
+| `position` | Attribute | Request row index | int | scalar |
+| `output_token_ids_ptr` | Output | Output matrix `[batch_size, max_spec_len + 1]` | int32 / int64 | ND |
+| `max_spec_len` | Attribute | Maximum speculative length | int | scalar |
+| `num_tokens1` | Attribute | Accepted draft count for this request | int | scalar |
+
+## Constraints
+
+- `0 <= position < batch_size` and `0 <= num_tokens1 <= max_spec_len`.
+- Called only when every active draft token for the request was accepted.
+
+## Origin and Differences
+
+- **Origin**: Helper developed as part of the vLLM Ascend Triton rejection sampler.
+- **Differences**:
+    - NPU adaptation for performance: inlines the scalar bonus write into the vector-core greedy kernel, avoiding a separate launch.
+    - Modified for vllm-ascend logic: N/A.
+
+## Test Cases
+
+Covered through `rejection_greedy_sample_triton`:
+
+```bash
+pytest -sv tests/e2e/nightly/single_node/ops/singlecard_ops/triton/test_rejection_sample.py
+```

--- a/vllm_ascend/ops/triton/docs/expand_kernel.md
+++ b/vllm_ascend/ops/triton/docs/expand_kernel.md
@@ -1,0 +1,39 @@
+# expand_kernel
+
+## Description
+
+- **Function**: Repeats one value per request over that request's flattened token range, with an optional sentinel replacement.
+- **Formula**: `output[j] = replace_to if input[r] == replace_from else input[r]` for `cu[r-1] <= j < cu[r]`.
+- **Algorithm flow** (processed request by request, independently): derive start/end from cumulative counts, transform the source value, and fill the request's output interval.
+- **Supported modes**: Atlas A2, Atlas A3, and Ascend 950. Used to expand speculative-sampling metadata; graph mode is N/A because sampling follows the captured model-forward graph.
+
+## Parameters
+
+| Parameter | Input/Output/Attribute | Description | Data type | Data format |
+| --- | --- | --- | --- | --- |
+| `output_ptr` | Output | Flattened expanded values `[num_tokens]` | same as input | ND |
+| `input_ptr` | Input | One value per request `[batch_size]`; int32 and fp32 are used by serving | int32 / fp32 | ND |
+| `cu_num_tokens_ptr` | Input | Inclusive cumulative token counts | int32 / int64 | ND |
+| `replace_from`, `replace_to` | Attribute | Value substitution pair | same as input | scalar |
+| `vec_len` | Attribute | Active request count | int | scalar |
+| `MAX_NUM_TOKENS`, `BLOCK_SIZE` | Attribute | Compile-time maximum tokens per request and request tile | int | scalar |
+
+## Constraints
+
+- Cumulative counts must be nondecreasing and each difference must not exceed `MAX_NUM_TOKENS`.
+- Output capacity must be at least the final cumulative count.
+
+## Origin and Differences
+
+- **Origin**: Developed for vLLM Ascend speculative sampling metadata expansion.
+- **Differences**:
+    - NPU adaptation for performance: fuses request-wise repeat-interleave and value replacement in one vector-core launch.
+    - Modified for vllm-ascend logic: applies the speculative-sampling sentinel replacement while expanding request metadata.
+
+## Test Cases
+
+The NPU test expands five fp32 request values using cumulative counts `[2,2,5,6,9]`, which includes a zero-length request, and replaces `-1.0` with `99.0`. It requires bit-exact equality with the PyTorch reference. Kernel warm-up additionally covers int32 metadata values.
+
+```bash
+pytest -sv tests/e2e/nightly/single_node/ops/singlecard_ops/triton/test_rejection_sample.py::test_expand_kernel
+```

--- a/vllm_ascend/ops/triton/docs/kimi_delta_attention.md
+++ b/vllm_ascend/ops/triton/docs/kimi_delta_attention.md
@@ -1,0 +1,53 @@
+# Kimi Delta Attention (KDA)
+
+## Description
+
+- **Function**: Implements gated delta-rule linear attention with chunked prefill and fused recurrent paths.
+- **Formula**: Optionally L2-normalize `q_t` and `k_t`. In mathematical `[K,V]` layout, compute `S_tilde = Diag(exp(g_t)) * S_(t-1)`, `delta_t = beta_t * (v_t - S_tilde^T * k_t)`, `S_t = S_tilde + k_t * delta_t^T`, and `o_t = scale * S_t^T * q_t`. `beta_t` can be headwise or value-wise. The kernels physically store the state transposed in `[V,K]` order.
+- **Algorithm flow** (processed sequence by sequence): optionally normalize Q/K; the prefill path takes chunk-local cumulative gates, forms and solves a causal lower-triangular transform, derives chunk update factors, propagates fp32 state across 64-token chunks, and emits outputs; the recurrent path updates an optionally indexed state token by token and can write it in place.
+- **Supported modes**: Atlas A2, Atlas A3, and Ascend 950. The direct Triton APIs support chunked prefill, recurrent decode, packed variable-length sequences, and indexed in-place state updates in eager execution. Graph capture is not directly validated by the operator tests; the current `AscendKimiK3DeltaAttention` implementation routes its attention calls through AscendC operators.
+
+## Parameters
+
+| Parameter | Input/Output/Attribute | Description | Data type | Data format |
+| --- | --- | --- | --- | --- |
+| `q`, `k` | Input | Query/key `[B,T,H,K]` | fp16 / bf16 / fp32 | BTHD |
+| `v` | Input | Value `[B,T,HV,V]` | fp16 / bf16 / fp32 | BTHD |
+| `g` | Input | Per-token key-dimension gate `[B,T,H,K]` | fp16 / bf16 / fp32 | BTHD |
+| `beta` | Input | Headwise `[B,T,H]` or value-wise `[B,T,HV,V]` update rate | fp16 / bf16 / fp32 | BTH / BTHD |
+| `scale` | Attribute | Query-key scale; defaults to `K**-0.5` | fp32 | scalar |
+| `initial_state` | Input | Initial state `[state_slots, HV, V, K]` in physical layout | fp32 | ND |
+| `cu_seqlens` | Input | Optional packed sequence boundaries | int32 / int64 | ND |
+| `ssm_state_indices` | Input | Optional sequence/token-to-state-slot mapping | int64 | ND |
+| `inplace_final_state` | Attribute | Reuse `initial_state` for final state | bool | scalar |
+| `use_qk_l2norm_in_kernel` | Attribute | Fuse Q/K L2 normalization | bool | scalar |
+| `o` | Output | Attention output `[B,T,HV,V]` | same as `v` | BTHD |
+| `final_state` | Output | Per-sequence final state for chunk mode, per-token state for non-in-place recurrent mode, or the updated `initial_state` buffer in in-place mode | fp32 | ND |
+
+## Constraints
+
+- Q and K share head count and key dimension; V may use a different head count/value dimension according to Kimi K3 grouping. Inputs are made contiguous by the public wrapper.
+- The recurrent Triton path currently requires one key tile (`NK == 1`). Packed variable-length input requires `B == 1`.
+- Prefill uses chunk size 64 and supports tail chunks; state indices must reference allocated state slots. In-place state updates require exclusive ownership of each written slot.
+
+## Origin and Differences
+
+- **Origin**: Ported from the MIT-licensed flash-linear-attention KDA/gated-delta-rule implementation used by upstream vLLM.
+- **Differences**:
+    - NPU adaptation for performance: uses Ascend-oriented tiling, fp32 intermediate and state accumulation, optional fused Q/K normalization, and separate chunked and recurrent kernels.
+    - Modified for vllm-ascend logic: uses a physical `[V,K]` state layout, vector gates, packed-sequence metadata, and indexed in-place recurrent states.
+
+## Test Cases
+
+`test_chunk_kda_npu.py` compares output and final state with a naive fp32
+recurrent reference for 32 or 64 heads, dimension 128, fp16/bf16 inputs,
+single and packed sequences from 15 to 8192 tokens, and tail chunks. The
+recurrent suite covers single-token decode and sequences up to 64 tokens,
+32/64 heads, fp16/bf16 inputs, non-in-place per-token state, and indexed
+in-place state buffers with 1, 4, or 16 slots. Both suites require a relative
+RMSE below 0.005 for output and state.
+
+```bash
+pytest -sv tests/e2e/nightly/single_node/ops/singlecard_ops/triton/test_chunk_kda_npu.py
+pytest -sv tests/e2e/nightly/single_node/ops/singlecard_ops/triton/test_fused_recurrent_kda_npu.py
+```

--- a/vllm_ascend/ops/triton/docs/layer_norm_fwd_1pass_kernel_npu.md
+++ b/vllm_ascend/ops/triton/docs/layer_norm_fwd_1pass_kernel_npu.md
@@ -1,0 +1,50 @@
+# _layer_norm_fwd_1pass_kernel_npu
+
+## Description
+
+- **Function**: Computes grouped LayerNorm or RMSNorm, with optional bias and SiLU gating, in one pass.
+- **Formula**: Let `silu(z)=z*sigmoid(z)`. If `NORM_BEFORE_GATE=True`, compute `(norm(x)*w+b)*silu(z)`; otherwise normalize `x*silu(z)` before applying `w` and `b`. LayerNorm uses `(x-mean)/sqrt(var+eps)`; RMSNorm uses `x/sqrt(mean(x^2)+eps)`.
+- **Algorithm flow** (processed row by row, independently): load a row group and affine parameters in fp32, optionally pre-gate, reduce statistics, normalize and apply affine terms, optionally post-gate, and store output/statistics.
+- **Supported modes**: Atlas A2, Atlas A3, and Ascend 950; eager and graph-capture inference.
+
+## Parameters
+
+| Parameter | Input/Output/Attribute | Description | Data type | Data format |
+| --- | --- | --- | --- | --- |
+| `X` | Input | Flattened input `[M, D]`, where `D = groups * N` | fp16 / bf16 / fp32 | ND |
+| `Y` | Output | Normalized output with the same shape and dtype as `X` | same as `X` | ND |
+| `W` | Input | Affine weight `[D]` | same as `X` | ND |
+| `B` | Input | Optional affine bias `[D]` | same as `X` | ND |
+| `Z` | Input | Optional SiLU gate, same shape as `X` | same as `X` | ND |
+| `Mean`, `Rstd` | Output | Per-row/group mean and reciprocal standard deviation | fp32 | ND |
+| `stride_x_row`, `stride_y_row`, `stride_z_row` | Attribute | Row strides | int | scalar |
+| `M`, `N`, `eps` | Attribute | Row count, group width, and stability epsilon | int / fp32 | scalar |
+| `BLOCK_M`, `BLOCK_N` | Attribute | Compile-time row and column tiles | int | scalar |
+| `HAS_BIAS`, `HAS_Z`, `NORM_BEFORE_GATE`, `IS_RMS_NORM` | Attribute | Compile-time feature switches | bool | scalar |
+
+## Constraints
+
+- Inputs, outputs, weights, bias, and gate must be contiguous in the last dimension; `weight.shape == (D,)` and optional tensors must match `X`.
+- Total feature width must be divisible by group width. Group width must fit `65536 / element_size` elements.
+- `Mean` is unused for RMSNorm. `eps` must be positive.
+
+## Origin and Differences
+
+- **Origin**: Adapted from flash-linear-attention's gated LayerNorm, itself based on the Triton LayerNorm tutorial.
+- **Differences**:
+    - NPU adaptation for performance: processes 64 rows per Ascend tile and performs normalization, affine transformation, and gating in one pass.
+    - Modified for vllm-ascend logic: supports grouped LayerNorm/RMSNorm and optional pre- or post-normalization SiLU gating.
+
+## Test Cases
+
+The direct NPU test compares the output and fp32 statistics against a PyTorch
+reference. It covers LayerNorm and RMSNorm, group sizes `{60, 96, 128}`, fp16,
+bf16, and fp32 inputs, optional bias and SiLU gate, both gate orders, and reuse
+of a caller-provided output tensor. Tolerances are `(rtol, atol) = (2e-3,
+2e-2)` for fp16, `(2e-2, 5e-2)` for bf16, and `(1e-4, 1e-4)` for fp32. A
+negative test verifies rejection when the hidden size is not divisible by the
+group size.
+
+```bash
+pytest -sv tests/e2e/nightly/single_node/ops/singlecard_ops/triton/test_layernorm_gated.py
+```

--- a/vllm_ascend/ops/triton/docs/ranks_kernel.md
+++ b/vllm_ascend/ops/triton/docs/ranks_kernel.md
@@ -1,0 +1,41 @@
+# _ranks_kernel
+
+## Description
+
+- **Function**: Computes the rank of each sampled token in its logit row.
+- **Formula**: `rank[r] = sum_v(logits[r,v] > logits[r, sampled_token_ids[r]])`.
+- **Algorithm flow** (processed row by row, independently): load the sampled-token logit, scan the vocabulary in tiles, count strictly larger logits, reduce the count, and store it.
+- **Supported modes**: Atlas A2, Atlas A3, and Ascend 950. Used when producing sampled-token log probabilities; graph mode is N/A because output processing follows the captured model-forward graph.
+
+## Parameters
+
+| Parameter | Input/Output/Attribute | Description | Data type | Data format |
+| --- | --- | --- | --- | --- |
+| `output_ptr` | Output | Token ranks `[batch_size]` | int64 | ND |
+| `logits_ptr` | Input | Sampler logits `[batch_size, vocab_size]` | fp32 | ND |
+| `logits_stride` | Attribute | Logit row stride | int | scalar |
+| `token_ids_ptr` | Input | Sampled token ID per row | int64 | ND |
+| `vocab_size`, `batch_size` | Attribute | Valid column and row counts | int | scalar |
+| `rows_per_core` | Attribute | Rows assigned to each vector core | int | scalar |
+| `BLOCK_SIZE` | Attribute | Compile-time vocabulary tile size (8192 in the launcher) | int | scalar |
+
+## Constraints
+
+- Every sampled token ID must be in `[0, vocab_size)`; logits rows use a valid `logits_stride`.
+- Ties do not increase the rank. NaNs follow Triton's comparison semantics.
+- The row count may be dynamic; vocabulary tails are masked.
+
+## Origin and Differences
+
+- **Origin**: Adapted from vLLM's `vllm/v1/worker/gpu/sample/logprob.py`.
+- **Differences**:
+    - NPU adaptation for performance: batches multiple rows per Ascend vector core and accumulates counts in int32 vectors before producing int64 output.
+    - Modified behavior: uses a strict `>` comparison, so logits tied with the sampled-token logit do not increase its zero-based rank.
+
+## Test Cases
+
+The NPU test compares against PyTorch for `(batch_size, vocab_size, num_logprobs)` values `(48,1024,5)`, `(96,1024,0)`, `(24,1519,1)`, and `(1,320,10)`. Token IDs and ranks are bit-exact; the related fp32 log probabilities use `rtol=atol=1e-4`.
+
+```bash
+pytest -sv tests/e2e/nightly/single_node/ops/singlecard_ops/triton/test_compute_topk_logprobs.py
+```

--- a/vllm_ascend/ops/triton/docs/rejection_greedy_sample_spec_len_1_triton.md
+++ b/vllm_ascend/ops/triton/docs/rejection_greedy_sample_spec_len_1_triton.md
@@ -1,0 +1,42 @@
+# rejection_greedy_sample_spec_len_1_triton
+
+## Description
+
+- **Function**: Verifies one draft token per request and emits the target token plus a bonus token when accepted.
+- **Formula**: Normal mode accepts iff `draft == argmax(target)`; synthetic mode accepts iff `u < conditional_rate[0]` and `draft >= 0`.
+- **Algorithm flow** (processed request by request, independently): load draft, target argmax, and bonus; evaluate acceptance; write the selected first token and conditionally write the bonus.
+- **Supported modes**: Atlas A2, Atlas A3, and Ascend 950. Used during speculative sampling; graph mode is N/A because sampling follows the captured model-forward graph.
+
+## Parameters
+
+| Parameter | Input/Output/Attribute | Description | Data type | Data format |
+| --- | --- | --- | --- | --- |
+| `output_token_ids_ptr` | Output | Accepted/recovered tokens `[batch_size, 2]` | int32 / int64 | ND |
+| `draft_token_ids_ptr` | Input | One draft token per request | int32 / int64 | ND |
+| `target_argmax_ptr` | Input | Target argmax token per request | int64 | ND |
+| `bonus_token_ids_ptr` | Input | Bonus token per request | int32 / int64 | ND |
+| `vec_len` | Attribute | Active request count | int | scalar |
+| `uniform_probs_ptr` | Input | Synthetic acceptance uniforms, or null | fp32 | ND |
+| `synthetic_conditional_rates_ptr` | Input | Synthetic rate for position zero, or null | fp32 | ND |
+| `SYNTHETIC_MODE`, `BLOCK_SIZE` | Attribute | Synthetic switch and compile-time request tile | bool / int | scalar |
+
+## Constraints
+
+- This specialization requires exactly one draft token for every request and no per-request greedy mask.
+- Synthetic probabilities and rates must lie in `[0, 1]`; their pointers are required only in synthetic mode.
+- Output is preinitialized with invalid IDs by the caller; the bonus slot remains unchanged on rejection.
+
+## Origin and Differences
+
+- **Origin**: Adapted from vLLM's rejection sampler.
+- **Differences**:
+    - NPU adaptation for performance: specializes the one-draft-token case to avoid cumulative-count handling and request-local loops.
+    - Modified for vllm-ascend logic: supports the benchmark-only synthetic acceptance mode.
+
+## Test Cases
+
+The NPU test uses five requests and exercises normal and synthetic modes with a mix of accepted and rejected drafts. It compares the complete int64 output with the PyTorch reference using `torch.equal`.
+
+```bash
+pytest -sv tests/e2e/nightly/single_node/ops/singlecard_ops/triton/test_rejection_sample.py::test_rejection_greedy_sample_spec_len_1_triton_kernel
+```

--- a/vllm_ascend/ops/triton/docs/rejection_greedy_sample_triton.md
+++ b/vllm_ascend/ops/triton/docs/rejection_greedy_sample_triton.md
@@ -1,0 +1,42 @@
+# rejection_greedy_sample_triton
+
+## Description
+
+- **Function**: Performs greedy verification for variable-length draft sequences and appends a bonus token when the full sequence is accepted.
+- **Formula**: Emit target argmax values through the first position where `draft_i != target_argmax_i`; if no mismatch occurs, append the bonus token. Synthetic mode substitutes Bernoulli acceptance.
+- **Algorithm flow** (processed request by request, independently): derive its range from cumulative lengths, walk drafts until rejection, store target/draft results, and call `bonus_renew` after full acceptance.
+- **Supported modes**: Atlas A2, Atlas A3, and Ascend 950. Used during speculative sampling; graph mode is N/A because sampling follows the captured model-forward graph.
+
+## Parameters
+
+| Parameter | Input/Output/Attribute | Description | Data type | Data format |
+| --- | --- | --- | --- | --- |
+| `output_token_ids_ptr` | Output | Result `[batch_size, max_spec_len + 1]` | int32 / int64 | ND |
+| `cu_num_draft_tokens_ptr` | Input | Inclusive cumulative draft counts | int32 / int64 | ND |
+| `draft_token_ids_ptr`, `target_argmax_ptr` | Input | Flattened draft and target token IDs | int32 / int64 | ND |
+| `bonus_token_ids_ptr` | Input | Bonus token per request | int32 / int64 | ND |
+| `is_greedy_ptr` | Input | Optional per-request greedy mask | bool / int8 | ND |
+| `vec_len`, `max_spec_len` | Attribute | Active requests and output draft width | int | scalar |
+| `uniform_probs_ptr`, `synthetic_conditional_rates_ptr` | Input | Synthetic uniforms per token and rates per position, or null | fp32 | ND |
+| `SYNTHETIC_MODE`, `BLOCK_SIZE` | Attribute | Synthetic switch and compile-time request tile | bool / int | scalar |
+
+## Constraints
+
+- Cumulative counts must be monotonic and end at the flattened token count; each request length is at most `max_spec_len`.
+- Optional synthetic buffers are required only in synthetic mode and contain values in `[0, 1]`.
+- Rows not selected by `is_greedy_ptr` are not modified by this kernel.
+
+## Origin and Differences
+
+- **Origin**: Adapted from vLLM's rejection sampler.
+- **Differences**:
+    - NPU adaptation for performance: packs variable-length requests into vector-core tiles and avoids host-side per-request loops.
+    - Modified for vllm-ascend logic: supports synthetic acceptance for benchmarking.
+
+## Test Cases
+
+The NPU test uses six requests with draft lengths `[3,2,1,0,3,2]`, maximum speculative length 3, and both normal and synthetic acceptance. It covers first rejection, full acceptance plus bonus, and an empty draft row, requiring bit-exact equality with the PyTorch reference.
+
+```bash
+pytest -sv tests/e2e/nightly/single_node/ops/singlecard_ops/triton/test_rejection_sample.py::test_rejection_greedy_sample_triton_kernel
+```

--- a/vllm_ascend/ops/triton/docs/rejection_random_sample_block_verify_kernel.md
+++ b/vllm_ascend/ops/triton/docs/rejection_random_sample_block_verify_kernel.md
@@ -1,0 +1,49 @@
+# rejection_random_sample_block_verify_kernel
+
+## Description
+
+- **Function**: Verifies stochastic draft sequences with block-level cumulative acceptance and emits the accepted prefix, recovery token, or bonus token.
+- **Formula**: Starting from `pi_-1 = U_-1 = 1`, update `pi_i = min(pi_(i-1) * p_target(x_i) / p_draft(x_i), 1)` and `U_i = product_(j<=i) u_j`. Accept the prefix through the largest `i` satisfying `pi_i >= U_i`. In entropy-verification mode, compare against `min(exp(-alpha * entropy_i), posterior_threshold) * U_i` instead.
+- **Algorithm flow** (processed request by request, independently): locate the flattened draft range, skip greedy requests, scan all positions while accumulating probability ratios and uniforms, copy the longest accepted prefix, then append its precomputed recovery token or the bonus token after full acceptance.
+- **Supported modes**: Atlas A2, Atlas A3, and Ascend 950. The sampler selects this kernel when block verification is enabled and `max_spec_len >= 3`; graph mode is N/A because sampling follows the captured model-forward graph.
+
+## Parameters
+
+| Parameter | Input/Output/Attribute | Description | Data type | Data format |
+| --- | --- | --- | --- | --- |
+| `output_token_ids_ptr` | Output | Result `[batch_size, max_spec_len + 1]` | int32 / int64 | ND |
+| `cu_num_draft_tokens_ptr`, `draft_token_ids_ptr` | Input | Inclusive cumulative counts and flattened draft IDs | int32 / int64 | ND |
+| `draft_probs_ptr`, `target_probs_ptr`, `ori_target_probs_ptr` | Input | Draft, active target, and optional original target probabilities | fp32 | ND |
+| `target_indices_ptr` | Input | Global IDs for reduced target vocabulary | integer | ND |
+| `bonus_token_ids_ptr`, `recovered_token_ids_ptr` | Input | Bonus and recovery token IDs | integer | ND |
+| `uniform_probs_ptr`, `is_greedy_ptr` | Input | Uniform values per token and greedy mask per request | fp32 / bool | ND |
+| `max_spec_len`, `vocab_size`, `global_vocab_size`, `vec_len` | Attribute | Sequence, vocabulary, and request bounds | int | scalar |
+| `NO_ORI_TARGET_PROBS`, `NO_DRAFT_PROBS`, `ENABLE_REDUCE_SAMPLING`, `ENTROPY_VERIFY` | Attribute | Compile-time mode switches | bool | scalar |
+| `BLOCK_SIZE`, `VOCAB_BLOCK_SIZE`, `SUB_BLOCK` | Attribute | Request and vocabulary tiles | int | scalar |
+| `POSTERIOR_THRESHOLD`, `POSTERIOR_ALPHA`, `EPSILON` | Attribute | Entropy-verification constants | fp32 | scalar |
+
+## Constraints
+
+- Input layout and mode-dependent pointer requirements match `rejection_random_sample_kernel`; cumulative counts must be monotonic and bounded by allocated buffers.
+- Draft probability must be positive for acceptance. Invalid draft ID `-1` forces rejection.
+- The kernel processes only requests whose `is_greedy` value is false.
+- Entropy verification is applied only by the dense-vocabulary branch; the current reduced-vocabulary branch does not use `ENTROPY_VERIFY`.
+
+## Origin and Differences
+
+- **Origin**: Introduced for vLLM Ascend's MagicMTP path, based on the block-verification method described in *Block Verification Accelerates Speculative Decoding* (`arXiv:2403.10444`). Upstream vLLM does not provide the same Triton kernel.
+- **Differences**:
+    - NPU adaptation for performance: uses a persistent Ascend vector-core request grid and scans each request's draft block in one program.
+    - Modified for vllm-ascend logic: supports dense and reduced-vocabulary lookup and consumes precomputed recovery IDs instead of sampling a residual distribution inside this kernel.
+
+## Test Cases
+
+The direct NPU test compares bit-exact int64 output with a PyTorch reference
+for batch size 7, `max_spec_len=3`, vocabulary size 5, variable per-request
+draft counts including zero, `NO_DRAFT_PROBS=True`, and one greedy request.
+Draft-distribution, reduced-vocabulary, and entropy-verification variants are
+not directly covered by this test case.
+
+```bash
+pytest -sv tests/e2e/nightly/single_node/ops/singlecard_ops/triton/test_rejection_sample.py
+```

--- a/vllm_ascend/ops/triton/docs/rejection_random_sample_kernel.md
+++ b/vllm_ascend/ops/triton/docs/rejection_random_sample_kernel.md
@@ -1,0 +1,49 @@
+# rejection_random_sample_kernel
+
+## Description
+
+- **Function**: Sequentially verifies stochastic draft tokens per request, emits the precomputed recovery token at the first rejection, and appends a bonus after full acceptance.
+- **Formula**: Draft `x_i` is accepted when `p_draft(x_i) > 0` and `u_i <= p_target(x_i)/p_draft(x_i)`. With entropy verification, the effective uniform value is `u_i * min(exp(-alpha * entropy_i), posterior_threshold)`. Synthetic mode instead accepts when `u_i < conditional_rate[i]`.
+- **Algorithm flow** (processed request by request, independently): locate the flattened draft range, skip greedy requests, test tokens until rejection using full or reduced vocabulary probabilities, then write a recovered or bonus token.
+- **Supported modes**: Atlas A2, Atlas A3, and Ascend 950. Supports dense and reduced-vocabulary speculative sampling; graph mode is N/A because sampling follows the captured model-forward graph.
+
+## Parameters
+
+| Parameter | Input/Output/Attribute | Description | Data type | Data format |
+| --- | --- | --- | --- | --- |
+| `output_token_ids_ptr` | Output | Result `[batch_size, max_spec_len + 1]` | int32 / int64 | ND |
+| `cu_num_draft_tokens_ptr` | Input | Inclusive cumulative draft counts | int32 / int64 | ND |
+| `draft_token_ids_ptr` | Input | Flattened draft IDs | int32 / int64 | ND |
+| `draft_probs_ptr`, `target_probs_ptr` | Input | Draft and target distributions; draft may be null | fp32 | ND |
+| `target_indices_ptr` | Input | Global IDs for reduced target vocabulary, or null | int32 / int64 | ND |
+| `bonus_token_ids_ptr`, `recovered_token_ids_ptr` | Input | Bonus IDs per request and pre-sampled recovery IDs per token | int32 / int64 | ND |
+| `uniform_probs_ptr` | Input | Uniform random values per draft token | fp32 | ND |
+| `is_greedy_ptr` | Input | Per-request greedy mask | bool / int8 | ND |
+| `max_spec_len`, `vocab_size`, `global_vocab_size`, `vec_len` | Attribute | Output width, active/reduced vocabulary widths, and request count | int | scalar |
+| `ori_target_probs_ptr` | Input | Optional original distribution used for entropy | fp32 | ND |
+| `synthetic_conditional_rates_ptr` | Input | Optional benchmark-only rates per position | fp32 | ND |
+| `NO_ORI_TARGET_PROBS`, `NO_DRAFT_PROBS`, `ENABLE_REDUCE_SAMPLING`, `SYNTHETIC_MODE`, `ENTROPY_VERIFY` | Attribute | Compile-time mode switches | bool | scalar |
+| `BLOCK_SIZE`, `VOCAB_BLOCK_SIZE`, `SUB_BLOCK` | Attribute | Request and vocabulary tile sizes | int | scalar |
+| `POSTERIOR_THRESHOLD`, `POSTERIOR_ALPHA`, `EPSILON` | Attribute | Entropy-verification constants | fp32 | scalar |
+
+## Constraints
+
+- Cumulative counts are monotonic, each request has at most `max_spec_len` drafts, token IDs are valid or `-1`, and probabilities are finite and non-negative.
+- Reduced sampling requires `target_indices_ptr` and uses `vocab_size` as selected width; otherwise probability rows use `global_vocab_size`.
+- Mode-dependent nullable pointers must be present whenever their corresponding compile-time switch requires them.
+- Entropy verification is applied only by the dense-vocabulary branch; the current reduced-vocabulary branch does not use `ENTROPY_VERIFY`.
+
+## Origin and Differences
+
+- **Origin**: Adapted from vLLM's rejection sampler.
+- **Differences**:
+    - NPU adaptation for performance: verifies request-local draft sequences in an Ascend vector-core kernel without host-side token loops.
+    - Modified for vllm-ascend logic: combines dense and reduced-vocabulary sampling, entropy thresholds, missing draft distributions, and synthetic benchmarking modes.
+
+## Test Cases
+
+The direct NPU test compares bit-exact int64 output with the PyTorch reference for `max_spec_len` in `{1,2,3}`, batch sizes `{1,256,512,1024}`, vocabulary size 1024, and normal/synthetic modes. Reduced sampling, entropy verification, `NO_DRAFT_PROBS=True`, and placeholder ID `-1` are not directly covered by this test case; their compile variants are exercised by warm-up and broader integration tests.
+
+```bash
+pytest -sv tests/e2e/nightly/single_node/ops/singlecard_ops/triton/test_rejection_sample.py
+```

--- a/vllm_ascend/ops/triton/docs/sample_recovered_tokens_kernel.md
+++ b/vllm_ascend/ops/triton/docs/sample_recovered_tokens_kernel.md
@@ -1,0 +1,43 @@
+# sample_recovered_tokens_kernel
+
+## Description
+
+- **Function**: Selects recovery tokens from the positive residual distribution after stochastic speculative rejection.
+- **Formula**: `recovered = argmax_v(max(p_target(v)-p_draft(v),0)/q(v))`; without draft probabilities, the proposed draft ID is assigned zero probability.
+- **Algorithm flow** (processed request and draft position independently): resolve the flattened token index, scan full or reduced vocabulary tiles, track the highest valid residual-to-random score, and store its global token ID.
+- **Supported modes**: Atlas A2, Atlas A3, and Ascend 950. Supports dense and reduced-vocabulary speculative sampling; graph mode is N/A because sampling follows the captured model-forward graph.
+
+## Parameters
+
+| Parameter | Input/Output/Attribute | Description | Data type | Data format |
+| --- | --- | --- | --- | --- |
+| `output_token_ids_ptr` | Output | Recovery ID per flattened draft token | int32 / int64 | ND |
+| `cu_num_draft_tokens_ptr` | Input | Inclusive cumulative draft counts | int32 / int64 | ND |
+| `draft_token_ids_ptr` | Input | Proposed draft IDs | int32 / int64 | ND |
+| `draft_probs_ptr`, `target_probs_ptr` | Input | Draft and target probability rows | fp32 | ND |
+| `target_indices_ptr` | Input | Global IDs for reduced-vocabulary columns | int32 / int64 | ND |
+| `q_ptr` | Input | Positive exponential/random variates per request and candidate | fp32 | ND |
+| `vocab_size`, `global_vocab_size` | Attribute | Selected and global vocabulary sizes | int | scalar |
+| `NO_DRAFT_PROBS`, `ENABLE_REDUCE_SAMPLING` | Attribute | Compile-time distribution mode switches | bool | scalar |
+| `SUB_BLOCK`, `VOCAB_BLOCK_SIZE` | Attribute | Full and reduced vocabulary tile sizes, 4096 and 512 in serving | int | scalar |
+
+## Constraints
+
+- The launch grid is `(batch_size, max_spec_len)`; positions beyond a request's actual length return without writing.
+- Valid `q` entries must be finite and positive. Probability rows are finite and non-negative.
+- Reduced mode requires global target indices; all valid indices must be within `[0, global_vocab_size)`.
+
+## Origin and Differences
+
+- **Origin**: Adapted from vLLM's rejection-sampling recovery step.
+- **Differences**:
+    - NPU adaptation for performance: computes the residual-score argmax in vocabulary tiles suitable for Ascend vector cores.
+    - Modified for vllm-ascend logic: supports selected-vocabulary target probabilities without materializing a dense target row.
+
+## Test Cases
+
+The NPU test uses four requests, maximum speculative length 3, a five-token dense vocabulary, fp32 draft/target probabilities, and int64 token IDs. It includes a zero-draft request and requires bit-exact equality with the PyTorch reference. The direct test covers `NO_DRAFT_PROBS=False` and dense sampling; reduced-vocabulary and no-draft-probability variants are currently covered only by warm-up/integration paths.
+
+```bash
+pytest -sv tests/e2e/nightly/single_node/ops/singlecard_ops/triton/test_rejection_sample.py::test_sample_recovered_tokens_kernel
+```

--- a/vllm_ascend/ops/triton/docs/temperature_kernel.md
+++ b/vllm_ascend/ops/triton/docs/temperature_kernel.md
@@ -1,0 +1,40 @@
+# _temperature_kernel
+
+## Description
+
+- **Function**: Applies per-request temperature scaling to expanded token logits in place.
+- **Formula**: `logits[t,v] = logits[t,v] / temperature[request(t)]`; temperatures `0` and `1` leave the row unchanged.
+- **Algorithm flow** (processed token row by token row, independently): resolve the request, load its temperature, skip identity/disabled scaling, and divide vocabulary tiles in fp32.
+- **Supported modes**: Atlas A2, Atlas A3, and Ascend 950. Used by the V2 sampler; graph mode is N/A because sampling runs after the captured model-forward graph.
+
+## Parameters
+
+| Parameter | Input/Output/Attribute | Description | Data type | Data format |
+| --- | --- | --- | --- | --- |
+| `logits_ptr` | Input/Output | Logits `[num_tokens, vocab_size]` | fp32 | ND |
+| `logits_stride` | Attribute | Logit row stride | int | scalar |
+| `expanded_idx_mapping_ptr` | Input | Token-to-request mapping | int32 | ND |
+| `temperature_ptr` | Input | Temperature per request | fp32 | ND |
+| `vocab_size` | Attribute | Number of valid columns | int | scalar |
+| `BLOCK_SIZE` | Attribute | Compile-time vocabulary tile size (44032 in the launcher) | int | scalar |
+
+## Constraints
+
+- Request indices must index `temperature_ptr`; the last logits dimension must be contiguous.
+- Temperature values must be finite and non-negative. Zero is treated as disabled rather than used as a divisor.
+- Vocabulary tails are masked; arbitrary positive `vocab_size` values are supported.
+
+## Origin and Differences
+
+- **Origin**: Adapted from vLLM's `vllm/v1/worker/gpu/sample/gumbel.py`.
+- **Differences**:
+    - NPU adaptation for performance: uses a 44032-element fp32 tile instead of the upstream 8192-element tile to reduce vocabulary passes while fitting the Atlas A2/A3 192-KB UB, and disables multibuffering.
+    - Modified behavior: avoids loading logits when the temperature is `0` or `1`; both values leave the row unchanged.
+
+## Test Cases
+
+The NPU test compares with a PyTorch reference for fp32 logits, 1–64 rows, vocabulary sizes `{32000, 50257, 65024, 128256, 151936}`, and temperatures including `0.0` and `1.0`. It uses `rtol=1e-5` and `atol=1e-4`.
+
+```bash
+pytest -sv tests/e2e/nightly/single_node/ops/singlecard_ops/triton/test_temperature.py
+```

--- a/vllm_ascend/ops/triton/docs/triton_rms_kernel.md
+++ b/vllm_ascend/ops/triton/docs/triton_rms_kernel.md
@@ -1,0 +1,40 @@
+# triton_rms_kernel
+
+## Description
+
+- **Function**: Applies unweighted RMS normalization to query vectors.
+- **Formula**: `y = x / sqrt(mean(x^2) + variance_epsilon)` along the last dimension.
+- **Algorithm flow** (processed row by row, independently): distribute flattened batch/head rows across vector cores, load row tiles, accumulate fp32 mean squares, scale, and store in the input dtype.
+- **Supported modes**: Atlas A2, Atlas A3, and Ascend 950. Used for query RMS normalization in the DSA/DeepSeek V4 path; supported inside eager and captured model forward.
+
+## Parameters
+
+| Parameter | Input/Output/Attribute | Description | Data type | Data format |
+| --- | --- | --- | --- | --- |
+| `hidden_state_ptr` | Input | Flattened query rows `[total_batch, DIM]` | fp16 / bf16 / fp32 | ND |
+| `hidden_state_stride_bs` | Attribute | Input row stride | int | scalar |
+| `norm_output_ptr` | Output | RMS-normalized rows, same shape as input | same as input | ND |
+| `variance_epsilon` | Attribute | Positive numerical-stability epsilon | fp32 | scalar |
+| `total_batch` | Attribute | Flattened batch times head count | int | scalar |
+| `DIM`, `BLOCK_M` | Attribute | Compile-time row width and rows per tile | int | scalar |
+
+## Constraints
+
+- The public launcher accepts rank-3 contiguous query tensors and requires `DIM <= 2048`.
+- `variance_epsilon` must be positive; input and output use the same stride and dtype.
+- `BLOCK_M` is a power of two up to 16 selected from rows per vector core.
+
+## Origin and Differences
+
+- **Origin**: Developed in vllm-ascend for the DeepSeek V4 query-normalization path; there is no same-signature upstream vLLM Triton kernel.
+- **Differences**:
+    - NPU adaptation for performance: flattens batch and head axes and distributes several rows per Ascend vector core.
+    - Modified for vllm-ascend logic: omits affine weights and limits the query feature dimension to 2048.
+
+## Test Cases
+
+The NPU test compares against an fp32-accumulating PyTorch reference for shapes `(1,1,128)`, `(2,8,512)`, and `(1,17,2048)`, dtypes fp16/bf16/fp32, and epsilon values `1e-6` and `1e-5`. Tolerances are `(rtol, atol)=(2e-3,2e-2)` for fp16, `(2e-2,5e-2)` for bf16, and `(1e-4,1e-4)` for fp32. It also checks that dimension 2049 is rejected.
+
+```bash
+pytest -sv tests/e2e/nightly/single_node/ops/singlecard_ops/triton/test_rms_norm.py
+```

--- a/vllm_ascend/ops/triton/docs/zero_kv_blocks_kernel.md
+++ b/vllm_ascend/ops/triton/docs/zero_kv_blocks_kernel.md
@@ -1,0 +1,38 @@
+# _zero_kv_blocks_kernel
+
+## Description
+
+- **Function**: Zeros selected KV-cache pages across all independently allocated K/V segments in one launch.
+- **Formula**: For each requested block `b` and segment `s`, `segment_s[b * PAGE_SIZE_EL : (b + 1) * PAGE_SIZE_EL] = 0`.
+- **Algorithm flow** (processed work item by work item, independently): flatten `(block, segment, chunk)` work, recover its three indices, cast the stored absolute segment address to an int32 pointer, and write one zero tile.
+- **Supported modes**: Atlas A2, Atlas A3, and Ascend 950 standard workers. The 310P worker uses a non-Triton implementation. Graph mode is N/A because newly allocated blocks are cleared before the captured model forward.
+
+## Parameters
+
+| Parameter | Input/Output/Attribute | Description | Data type | Data format |
+| --- | --- | --- | --- | --- |
+| `seg_addrs_ptr` | Input | Absolute byte address of each cache segment | uint64 | ND |
+| `block_ids_ptr` | Input | Logical block IDs to clear | int64 | ND |
+| `n_blocks` | Attribute | Number of active block IDs | int | scalar |
+| `N_SEGS` | Attribute | Compile-time segment count | int | scalar |
+| `PAGE_SIZE_EL` | Attribute | int32 elements per logical page | int | scalar |
+| `BLOCK_SIZE` | Attribute | int32 elements written by one work item | int | scalar |
+| `GRID_SIZE` | Attribute | Number of launched vector-core programs | int | scalar |
+
+## Constraints
+
+- Segment addresses must point to writable NPU allocations and block IDs must be valid for every segment.
+- `PAGE_SIZE_EL` must be uniform across segments and divisible by `BLOCK_SIZE`; cache byte strides must be divisible by four.
+- Metadata excludes non-full-attention and runner-only layers. The launcher is a no-op for empty block lists.
+- The current Ascend implementation handles only `FullAttentionSpec`, expects separate K/V tensors, fixes the cache block dimension to 0, and requires the logical block size to be an integer multiple of the kernel block size.
+
+## Origin and Differences
+
+- **Origin**: Adapted from vLLM's `vllm/v1/worker/utils.py` `KVBlockZeroer` contract.
+- **Differences**:
+    - NPU adaptation for performance: flattens block, segment, and chunk work into a vector-core-sized 1-D grid-stride launch and writes cache storage as aligned int32 zero words.
+    - Modified for vllm-ascend logic: clears dirty full-attention pages that can otherwise retain NaNs when hybrid Mamba/full-attention blocks are reassigned during multi-token speculative decoding. It uses a single uniform page size for separate K/V allocations, unlike current upstream's per-segment stride/page metadata.
+
+## Test Cases
+
+N/A: coverage currently runs through KV-cache integration tests; no dedicated Triton single-operator test exists.


### PR DESCRIPTION
### What this PR does / why we need it?

Adds template-compliant documentation for 15 Ascend Triton operators, covering their behavior, formulas, parameters, constraints, NPU-specific differences, and existing single-operator accuracy tests.

The documented operators include sampling kernels, KV-cache zeroing, batch memcpy, gated LayerNorm/RMSNorm, and Kimi Delta Attention. This follows the operator documentation specification introduced in #14966.

### Does this PR introduce _any_ user-facing change?

No. This is a documentation-only change.

### How was this patch tested?

- `pytest -sv` on the 9 related single-operator test files under `tests/e2e/nightly/single_node/ops/singlecard_ops/triton`: 91 passed, 18 warnings.
- `pre-commit run markdownlint --hook-stage manual --files <15 docs>`
- `pre-commit run codespell --hook-stage manual --files <15 docs>`
- `pre-commit run typos --hook-stage manual --files <15 docs>`
- `pre-commit run check-filenames --hook-stage manual --all-files`

- vLLM main: https://github.com/vllm-project/vllm/commit/ba07e4a48fc951300d97eb506217dd530583dea3
