### PR TITLE
[BugFix] 修复fp8 enable_sparse_li_c8不生效的问题

### DIFF
--- a/vllm_ascend/ascend_config.py
+++ b/vllm_ascend/ascend_config.py
@@ -832,7 +832,7 @@ class AscendConfig:
             return set(), set()
 
         QUANT_SUFFIXES = (".indexer.quant_type", ".indexer.wq_b_weight")
-        VALID_QUANT_TYPES = ("INT8_DYNAMIC", "W8A8_MXFP8")
+        VALID_QUANT_TYPES = ("INT8_DYNAMIC", "W8A8_MXFP8", "FP8_DYNAMIC")
 
         layer_ids: set[int] = set()
         layer_names: set[str] = set()


### PR DESCRIPTION
修复fp8 enable_sparse_li_c8不生效的问题

### What this PR does / why we need it?

When the `self_attn.indexer.quant_type` in the `quant_model_description.json` file is set to `"FP8_DYNAMIC"`, enable_sparse_li_c8 silent failure.

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
profiling: LightningIndexer->QuantLightningIndexer, modification takes effect.
- vLLM main: https://github.com/vllm-project/vllm/commit/ba07e4a48fc951300d97eb506217dd530583dea3
