### PR TITLE
[BugFix][DSA-CP] Restore device-independent o_proj TP switching

### DIFF
--- a/tests/ut/attention/test_dsa_cp_o_proj_tp.py
+++ b/tests/ut/attention/test_dsa_cp_o_proj_tp.py
@@ -4,7 +4,7 @@ import sys
 import unittest
 from types import SimpleNamespace
 from typing import Any
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 import torch
 
@@ -12,6 +12,7 @@ if "torch_npu._inductor" not in sys.modules:
     sys.modules["torch_npu._inductor"] = MagicMock()
 
 from vllm_ascend.attention.context_parallel.dsa_cp import AscendDSACPImpl, DSACPMetadata
+from vllm_ascend.device.hardware_profile import HardwareCapability
 from vllm_ascend.quantization.tp_weight_switch import (
     TPWeightGatherSpec,
     TPWeightSwitchMixin,
@@ -49,6 +50,54 @@ class TestAscendDSACPOProjTPParams(unittest.TestCase):
         impl.wo_b = self._OProj()
         impl._o_proj_tp_weight_switch_enabled = False
         return impl
+
+    def test_enablement_is_not_gated_by_hardware_family(self):
+        profile = MagicMock()
+        profile.supports.return_value = False
+        tp_group = SimpleNamespace(world_size=2, rank_in_group=0)
+        layer = self._OProj()
+        with (
+            patch(
+                "vllm_ascend.attention.context_parallel.dsa_cp.enable_dsa_cp_with_o_proj_tp",
+                return_value=True,
+            ),
+            patch("vllm_ascend.attention.context_parallel.dsa_cp.get_tp_group", return_value=tp_group),
+            patch(
+                "vllm_ascend.attention.context_parallel.dsa_cp.get_current_hardware_profile",
+                return_value=profile,
+            ),
+            patch(
+                "vllm_ascend.attention.context_parallel.dsa_cp.get_current_vllm_config",
+                return_value=SimpleNamespace(),
+            ),
+        ):
+            impl = AscendDSACPImpl(
+                n_heads=2,
+                scale=1.0,
+                n_local_heads=1,
+                q_lora_rank=1,
+                o_lora_rank=1,
+                head_dim=2,
+                rope_head_dim=1,
+                nope_head_dim=1,
+                n_groups=2,
+                n_local_groups=1,
+                window_size=1,
+                compress_ratio=1,
+                wq_a=object(),
+                wq_b=object(),
+                wkv=object(),
+                q_norm=object(),
+                kv_norm=object(),
+                swa_cache_layer=SimpleNamespace(prefix="swa"),
+                wo_a=layer,
+                wo_b=layer,
+                eps=1e-6,
+                attn_sink=torch.empty(2),
+            )
+
+        self.assertTrue(impl.enable_dsa_cp_with_o_proj_tp)
+        profile.supports.assert_called_once_with(HardwareCapability.FP8_ATTENTION)
 
     def test_get_tp_weight_switch_method_unwraps_adapter_and_rejects_unsupported(self):
         layer = self._OProj()

--- a/tests/ut/device/test_hardware_profile.py
+++ b/tests/ut/device/test_hardware_profile.py
@@ -72,7 +72,6 @@ _EXPECTED_CAPABILITIES = {
             HardwareCapability.CHUNKED_PREFILL_PHASE_SPLIT,
             HardwareCapability.CLUSTER_CPU_TOPOLOGY,
             HardwareCapability.DSA_C128_STATE_SMALL_BLOCK_SIZES,
-            HardwareCapability.DSA_O_PROJ_TP,
             HardwareCapability.DSV4_COMPRESSED_CACHE,
             HardwareCapability.DYNAMIC_MX_QUANT_FUSION,
             HardwareCapability.DYNAMIC_MX_QUANT_SCALE_ALG_ONE,

--- a/vllm_ascend/attention/context_parallel/dsa_cp.py
+++ b/vllm_ascend/attention/context_parallel/dsa_cp.py
@@ -1351,9 +1351,9 @@ class AscendDSACPImpl(AttentionImplBase[Any]):
         self.wo_a = kwargs["wo_a"]
         self.wo_b = kwargs["wo_b"]
 
-        self.enable_dsa_cp_with_o_proj_tp = enable_dsa_cp_with_o_proj_tp() and get_current_hardware_profile().supports(
-            HardwareCapability.DSA_O_PROJ_TP
-        )
+        # Device-independent: the selected linear method validates whether
+        # its tensors support TP/full-weight switching.
+        self.enable_dsa_cp_with_o_proj_tp = enable_dsa_cp_with_o_proj_tp()
         self._o_proj_tp_weight_switch_enabled = False
 
         self.eps = kwargs["eps"]

--- a/vllm_ascend/device/hardware_profile.py
+++ b/vllm_ascend/device/hardware_profile.py
@@ -26,7 +26,6 @@ class HardwareCapability(Enum):
     COMPATIBILITY_OP_IMPLEMENTATIONS = auto()
     DISTRIBUTED_COMMUNICATION_ADAPTATION = auto()
     DSA_C128_STATE_SMALL_BLOCK_SIZES = auto()
-    DSA_O_PROJ_TP = auto()
     DSV4_COMPRESSED_CACHE = auto()
     DYNAMIC_MX_QUANT_FUSION = auto()
     DYNAMIC_MX_QUANT_SCALE_ALG_ONE = auto()
@@ -226,7 +225,6 @@ _HARDWARE_PROFILES: Mapping[AscendDeviceType, HardwareProfile] = MappingProxyTyp
                     HardwareCapability.CHUNKED_PREFILL_PHASE_SPLIT,
                     HardwareCapability.CLUSTER_CPU_TOPOLOGY,
                     HardwareCapability.DSA_C128_STATE_SMALL_BLOCK_SIZES,
-                    HardwareCapability.DSA_O_PROJ_TP,
                     HardwareCapability.DSV4_COMPRESSED_CACHE,
                     HardwareCapability.DYNAMIC_MX_QUANT_FUSION,
                     HardwareCapability.DYNAMIC_MX_QUANT_SCALE_ALG_ONE,


### PR DESCRIPTION
### What this PR does / why we need it?

Restores device-independent DSA-CP o_proj TP/full-weight switching.

PR #12982 generalized this path through TPWeightSwitchMixin so supported linear methods can use it across A2/A3. During the hardware-profile migration in #15376, the path was accidentally gated by the A5-only HardwareCapability.DSA_O_PROJ_TP, narrowing the direct baseline behavior.

This PR:

- removes the misleading A5-only DSA_O_PROJ_TP capability and profile-matrix entry;
- restores enablement based on the existing feature flag, while the selected linear method remains responsible for validating TP/full-weight-switch support;
- adds a regression test proving that a profile without the A5/FP8 capability does not disable o_proj TP switching.

### Does this PR introduce _any_ user-facing change?

Yes. It restores the intended DSA-CP o_proj TP optimization on supported A2/A3 configurations. A5 behavior is unchanged. There are no API, configuration, environment-variable, or schema changes.

### How was this patch tested?

- Rebased onto main@42e039a90215a0c111330a7081178cd1207cc14d.
- Verified the rebased commit is patch-equivalent with git range-diff.
- Passed Ruff check, Ruff format --check, compileall, and git diff --check on all four changed files.
- The available host does not include pytest, mypy, or vllm; the focused unit test and Python 3.10/3.11/3.12 mypy checks are left to CI.

- vLLM main: https://github.com/vllm-project/vllm/commit/ba07e4a48fc951300d97eb506217dd530583dea3
