### PR TITLE
[Refactor][Device] Complete hardware profile migration and enforce HAL boundary

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -121,6 +121,12 @@ repos:
     entry: python3 tools/check_boolean_context_manager.py
     language: python
     types: [python]
+  - id: check-hardware-identity
+    name: Forbid hardware identity use outside the HAL boundary
+    entry: python3 tools/check_hardware_identity.py
+    language: python
+    pass_filenames: false
+    always_run: true
   - id: check-long-functions
     name: Check that new functions over 100 lines have comments
     entry: python3 tools/check_long_functions.py

--- a/docs/source/developer_guide/contribution/index.md
+++ b/docs/source/developer_guide/contribution/index.md
@@ -71,6 +71,31 @@ git commit -sm "your commit info"
 
 You can refer to [Testing](./testing.md)  to set up a testing environment and running tests locally.
 
+## Hardware-specific behavior
+
+Shared runtime and model code must select hardware-specific behavior through
+`get_current_hardware_profile()`. Direct SoC checks such as `is_310p()`,
+`is_950()`, `get_ascend_device_type()`, or comparisons with
+`AscendDeviceType` belong only in the device detection and profile
+registration boundary. The pre-commit hardware-identity check enforces this
+rule for production Python code.
+
+Choose the profile abstraction by its contract:
+
+- A `HardwareCapability` is a positive, independently testable hardware or
+  runtime feature. Its name should make `profile.supports(...)` read as a
+  precise question.
+- A family selects one implementation contract from several alternatives.
+- A policy or explicit profile value selects a default behavior or a bounded
+  parameter, rather than claiming hardware support.
+
+New names must state the feature scope, action, and object. Avoid device and
+model codenames as the complete contract, and avoid unqualified terms such as
+`STANDARD`, `COMPATIBILITY`, `UNRESTRICTED`, or `EXTRA_ARGS`. If an established
+domain acronym remains necessary, document its stable runtime or operator ABI
+contract next to the profile definition. Add the exact device-profile matrix
+and a focused consumer test with every new profile dimension.
+
 ## DCO and Signed-off-by
 
 When contributing changes to this project, you must agree to the DCO. Commits must include a `Signed-off-by:` header which certifies agreement with the terms of the DCO (Developer Certificate of Origin).

--- a/tests/e2e/nightly/single_node/ops/singlecard_ops/test_causal_conv1d_310.py
+++ b/tests/e2e/nightly/single_node/ops/singlecard_ops/test_causal_conv1d_310.py
@@ -3,10 +3,10 @@ import torch
 import torch_npu
 from vllm.v1.attention.backends.utils import PAD_SLOT_ID
 
+from vllm_ascend.device.device_config import is_310p as is_310p_hw
 from vllm_ascend.ops.causal_conv1d import causal_conv1d_fn as causal_conv1d_fn_ref
 from vllm_ascend.ops.causal_conv1d import causal_conv1d_update as causal_conv1d_update_ref
 from vllm_ascend.utils import enable_custom_op
-from vllm_ascend.utils import is_310p as is_310p_hw
 
 torch_npu.npu.set_compile_mode(jit_compile=False)
 

--- a/tests/e2e/nightly/single_node/ops/singlecard_ops/test_recurrent_gated_delta_rule_310.py
+++ b/tests/e2e/nightly/single_node/ops/singlecard_ops/test_recurrent_gated_delta_rule_310.py
@@ -2,8 +2,8 @@ import pytest
 import torch
 import torch_npu
 
+from vllm_ascend.device.device_config import is_310p as is_310p_hw
 from vllm_ascend.utils import enable_custom_op
-from vllm_ascend.utils import is_310p as is_310p_hw
 
 torch_npu.npu.set_compile_mode(jit_compile=False)
 

--- a/tests/e2e/pull_request/two_card/aclgraph/test_aclgraph_capture_replay.py
+++ b/tests/e2e/pull_request/two_card/aclgraph/test_aclgraph_capture_replay.py
@@ -26,7 +26,8 @@ import torch
 from vllm.utils.network_utils import get_open_port
 
 from tests.e2e.conftest import wait_until_npu_memory_free
-from vllm_ascend.utils import AscendDeviceType, get_ascend_device_type
+from vllm_ascend.device.device_config import get_ascend_device_type
+from vllm_ascend.device.hardware import AscendDeviceType
 
 MODELS = [
     # Offline data parallel mode will be not supported/useful for dense models

--- a/tests/ut/_310p/test_model_runner_v2_310p.py
+++ b/tests/ut/_310p/test_model_runner_v2_310p.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright (c) 2026 Huawei Technologies Co., Ltd. All Rights Reserved.
 
+import importlib
 import sys
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
@@ -19,6 +20,7 @@ from vllm_ascend._310p.worker.v2.model_state import (
     Ascend310PModelState,
 )
 from vllm_ascend._310p.worker.v2.sampler import Ascend310PSampler
+from vllm_ascend.device.hardware_profile import ModelRunnerV2ImplementationFamily
 from vllm_ascend.worker.v2.model_runner import NPUModelRunner
 from vllm_ascend.worker.v2.model_states.default import AscendModelState
 from vllm_ascend.worker.v2.model_states.mamba_hybrid import AscendMambaHybridModelState
@@ -110,8 +112,8 @@ def test_310p_hybrid_model_state_initializes_full_upstream_contract() -> None:
     assert isinstance(state._capture_seq_lens_by_ptr, dict)
 
 
-def test_init_model_state_routes_qwen35_hybrid_to_310p() -> None:
-    """Qwen3.5 is_hybrid must select Ascend310PMambaHybridModelState on 310P."""
+def test_host_staged_family_routes_qwen35_hybrid_to_triton_free_state() -> None:
+    """The host-staged family selects the Triton-free hybrid state."""
     from vllm_ascend.worker.v2.model_states import init_asecnd_model_state
 
     vllm_config = SimpleNamespace(model_config=SimpleNamespace(is_hybrid=True))
@@ -119,9 +121,15 @@ def test_init_model_state_routes_qwen35_hybrid_to_310p() -> None:
     encoder_cache = object()
     device = torch.device("cpu")
     expected = object()
+    triton_free_profile = SimpleNamespace(
+        model_runner_v2_implementation_family=ModelRunnerV2ImplementationFamily.TRITON_FREE_HOST_METADATA
+    )
 
     with (
-        patch("vllm_ascend.worker.v2.model_states.is_310p", return_value=True),
+        patch(
+            "vllm_ascend.worker.v2.model_states._HARDWARE_PROFILE",
+            triton_free_profile,
+        ),
         patch(
             "vllm_ascend._310p.worker.v2.model_state.Ascend310PMambaHybridModelState",
             return_value=expected,
@@ -131,6 +139,115 @@ def test_init_model_state_routes_qwen35_hybrid_to_310p() -> None:
 
     assert state is expected
     hybrid_cls.assert_called_once_with(vllm_config, model, encoder_cache, device)
+
+
+@pytest.mark.parametrize(
+    ("family", "calls_upstream_validation"),
+    [
+        (ModelRunnerV2ImplementationFamily.DEFAULT_TRITON_BACKED, True),
+        (ModelRunnerV2ImplementationFamily.TRITON_FREE_HOST_METADATA, False),
+    ],
+)
+def test_model_runner_v2_validation_follows_implementation_family(
+    family: ModelRunnerV2ImplementationFamily,
+    calls_upstream_validation: bool,
+) -> None:
+    patch_module = importlib.import_module("vllm_ascend.patch.platform.patch_use_v2_model_runner")
+    vllm_config = object()
+    profile = SimpleNamespace(model_runner_v2_implementation_family=family)
+
+    with (
+        patch.object(patch_module, "_HARDWARE_PROFILE", profile),
+        patch.object(
+            patch_module,
+            "_original_validate_v2_model_runner",
+        ) as upstream_validation,
+    ):
+        patch_module._patched_validate_v2_model_runner(vllm_config)
+
+    if calls_upstream_validation:
+        upstream_validation.assert_called_once_with(vllm_config)
+    else:
+        upstream_validation.assert_not_called()
+
+
+@pytest.mark.parametrize(
+    ("family", "expected_block_tables"),
+    [
+        (ModelRunnerV2ImplementationFamily.DEFAULT_TRITON_BACKED, "default"),
+        (ModelRunnerV2ImplementationFamily.TRITON_FREE_HOST_METADATA, "host_metadata"),
+    ],
+)
+def test_block_tables_import_time_binding_follows_implementation_family(
+    family: ModelRunnerV2ImplementationFamily,
+    expected_block_tables: str,
+) -> None:
+    from vllm.v1.worker.gpu import model_runner as upstream_model_runner
+
+    import vllm_ascend.device.hardware_profile as hardware_profile
+    from vllm_ascend.worker.v2.block_table import (
+        AscendBlockTables as DefaultAscendBlockTables,
+    )
+
+    patch_module = importlib.import_module("vllm_ascend.patch.worker.patch_v2.patch_block_table")
+    profile = SimpleNamespace(model_runner_v2_implementation_family=family)
+    expected_cls = DefaultAscendBlockTables if expected_block_tables == "default" else Ascend310PBlockTables
+    original_upstream_cls = upstream_model_runner.BlockTables
+
+    try:
+        with patch.object(
+            hardware_profile,
+            "get_current_hardware_profile",
+            return_value=profile,
+        ):
+            patch_module = importlib.reload(patch_module)
+
+        assert patch_module.AscendBlockTables is expected_cls
+        assert upstream_model_runner.BlockTables is expected_cls
+    finally:
+        importlib.reload(patch_module)
+        upstream_model_runner.BlockTables = original_upstream_cls
+
+
+@pytest.mark.parametrize(
+    ("family", "state_class_path"),
+    [
+        (
+            ModelRunnerV2ImplementationFamily.DEFAULT_TRITON_BACKED,
+            "vllm_ascend.worker.v2.model_states.default.AscendModelState",
+        ),
+        (
+            ModelRunnerV2ImplementationFamily.TRITON_FREE_HOST_METADATA,
+            "vllm_ascend._310p.worker.v2.model_state.Ascend310PModelState",
+        ),
+    ],
+)
+def test_non_hybrid_model_state_follows_implementation_family(
+    family: ModelRunnerV2ImplementationFamily,
+    state_class_path: str,
+) -> None:
+    import vllm_ascend.worker.v2.model_states as model_states
+
+    vllm_config = SimpleNamespace(model_config=SimpleNamespace(is_hybrid=False))
+    model = MagicMock(spec=["forward"])
+    encoder_cache = object()
+    device = torch.device("cpu")
+    expected = object()
+    profile = SimpleNamespace(model_runner_v2_implementation_family=family)
+
+    with (
+        patch.object(model_states, "_HARDWARE_PROFILE", profile),
+        patch(state_class_path, return_value=expected) as state_cls,
+    ):
+        state = model_states.init_asecnd_model_state(
+            vllm_config,
+            model,
+            encoder_cache,
+            device,
+        )
+
+    assert state is expected
+    state_cls.assert_called_once_with(vllm_config, model, encoder_cache, device)
 
 
 def test_get_kv_cache_spec_restores_qwen35_linear_attn() -> None:

--- a/tests/ut/_310p/test_model_runner_v2_310p.py
+++ b/tests/ut/_310p/test_model_runner_v2_310p.py
@@ -185,6 +185,7 @@ def test_block_tables_import_time_binding_follows_implementation_family(
     from vllm.v1.worker.gpu import model_runner as upstream_model_runner
 
     import vllm_ascend.device.hardware_profile as hardware_profile
+    from vllm_ascend._310p.worker.v2.block_table import Ascend310PBlockTables
     from vllm_ascend.worker.v2.block_table import (
         AscendBlockTables as DefaultAscendBlockTables,
     )

--- a/tests/ut/_tools/test_check_hardware_identity.py
+++ b/tests/ut/_tools/test_check_hardware_identity.py
@@ -1,0 +1,655 @@
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# This file is a part of the vllm-ascend project.
+#
+
+from textwrap import dedent
+
+import pytest
+
+from tools.check_hardware_identity import check_source, main
+
+
+def _codes(source: str, path: str = "vllm_ascend/business_logic.py") -> set[str]:
+    return {violation.code for violation in check_source(dedent(source), path)}
+
+
+@pytest.mark.parametrize(
+    ("source", "expected_code"),
+    [
+        (
+            """
+            from vllm_ascend.utils import is_310p
+
+            if is_310p():
+                pass
+            """,
+            "HDI001",
+        ),
+        (
+            """
+            from vllm_ascend.device.device_config import is_950 as on_a5
+
+            if on_a5():
+                pass
+            """,
+            "HDI001",
+        ),
+        (
+            """
+            import vllm_ascend.device.device_config as dc
+
+            kind = dc.get_ascend_device_type()
+            """,
+            "HDI001",
+        ),
+        (
+            """
+            import vllm_ascend.utils as ascend_utils
+
+            enabled = ascend_utils.is_310p()
+            """,
+            "HDI001",
+        ),
+        (
+            """
+            from vllm_ascend.device.hardware import AscendDeviceType as DT
+
+            enabled = kind == DT.A5
+            """,
+            "HDI001",
+        ),
+        (
+            """
+            from vllm_ascend.device.hardware import AscendDeviceType as DT
+
+            enabled = DT.A5 is kind
+            """,
+            "HDI001",
+        ),
+        (
+            """
+            from vllm_ascend.device.hardware import AscendDeviceType
+
+            enabled = kind in {AscendDeviceType.A2, AscendDeviceType.A3}
+            """,
+            "HDI001",
+        ),
+        (
+            """
+            from vllm_ascend.device.hardware import AscendDeviceType
+
+            match kind:
+                case AscendDeviceType.A5:
+                    pass
+            """,
+            "HDI001",
+        ),
+        (
+            """
+            import torch_npu
+
+            runtime = torch_npu.npu.get_soc_version()
+            """,
+            "HDI002",
+        ),
+        (
+            """
+            import os
+
+            build_target = os.getenv("SOC_VERSION")
+            """,
+            "HDI002",
+        ),
+        (
+            """
+            import os
+
+            build_target = os.getenv(key="SOC_VERSION")
+            """,
+            "HDI002",
+        ),
+        (
+            """
+            import os
+
+            read_env = os.getenv
+            build_target = read_env(key="SOC_VERSION")
+            """,
+            "HDI002",
+        ),
+        (
+            """
+            import os
+
+            read_env = os.getenv
+
+            def read_build_target(read_env=read_env):
+                return read_env("SOC_VERSION")
+            """,
+            "HDI002",
+        ),
+        (
+            """
+            import os
+
+            read_env = os.getenv
+
+            def read_build_target(*, read_env=read_env):
+                return read_env("SOC_VERSION")
+            """,
+            "HDI002",
+        ),
+        (
+            """
+            import os
+
+            build_target = (read_env := os.getenv)("SOC_VERSION")
+            """,
+            "HDI002",
+        ),
+        (
+            """
+            import os
+
+            build_target = (environment := os.environ).get("SOC_VERSION")
+            """,
+            "HDI002",
+        ),
+        (
+            """
+            import os
+
+            build_target = (read_env := os.environ.get)("SOC_VERSION")
+            """,
+            "HDI002",
+        ),
+        (
+            """
+            import os
+
+            class Configuration:
+                if False:
+                    os = fake
+                build_target = os.getenv("SOC_VERSION")
+            """,
+            "HDI002",
+        ),
+        (
+            """
+            import os
+
+            class Configuration:
+                if use_fake_environment:
+                    os = fake
+                build_target = os.getenv("SOC_VERSION")
+            """,
+            "HDI002",
+        ),
+        (
+            """
+            import os
+
+            class Configuration:
+                build_target = os.getenv("SOC_VERSION")
+                os = fake
+            """,
+            "HDI002",
+        ),
+        (
+            """
+            from os import *
+
+            build_target = getenv("SOC_VERSION")
+            """,
+            "HDI002",
+        ),
+        (
+            """
+            import os
+
+            read_env = other = os.getenv
+            build_target = other("SOC_VERSION")
+            """,
+            "HDI002",
+        ),
+        (
+            """
+            import os
+
+            read_env = (other := os.getenv)
+            build_target = other("SOC_VERSION")
+            """,
+            "HDI002",
+        ),
+        (
+            """
+            import os
+
+            def read_build_target(read_env=os.getenv):
+                return read_env("SOC_VERSION")
+            """,
+            "HDI002",
+        ),
+        (
+            """
+            import os as operating_system
+
+            build_target = operating_system.environ.get("SOC_VERSION")
+            """,
+            "HDI002",
+        ),
+        (
+            """
+            from os import environ as process_environment
+
+            build_target = process_environment["SOC_VERSION"]
+            """,
+            "HDI002",
+        ),
+        (
+            """
+            import os
+
+            read_env = os.getenv
+            build_target = read_env("SOC_VERSION")
+            """,
+            "HDI002",
+        ),
+        (
+            """
+            import os
+
+            environment = os.environ
+            build_target = environment["SOC_VERSION"]
+            """,
+            "HDI002",
+        ),
+        (
+            """
+            import os
+
+            environment = os.environ
+            build_target = environment.get("SOC_VERSION")
+            """,
+            "HDI002",
+        ),
+        (
+            """
+            import os
+
+            read_env: object = os.environ.get
+            build_target = read_env("SOC_VERSION")
+            """,
+            "HDI002",
+        ),
+        (
+            """
+            def read_build_target():
+                return read_env("SOC_VERSION")
+
+            import os
+            read_env = os.getenv
+            """,
+            "HDI002",
+        ),
+        (
+            """
+            def read_build_target():
+                return read_env("SOC_VERSION")
+
+            from os import getenv as read_env
+            """,
+            "HDI002",
+        ),
+        (
+            """
+            def outer():
+                def read_build_target():
+                    return read_env("SOC_VERSION")
+
+                import os
+                read_env = os.getenv
+                return read_build_target()
+            """,
+            "HDI002",
+        ),
+        (
+            """
+            import os.path
+
+            build_target = os.getenv("SOC_VERSION")
+            """,
+            "HDI002",
+        ),
+        (
+            """
+            import os
+
+            read_env, other = os.getenv, object()
+            build_target = read_env("SOC_VERSION")
+            """,
+            "HDI002",
+        ),
+        (
+            """
+            import os
+
+            class Outer:
+                os = fake
+
+                class Inner:
+                    build_target = os.getenv("SOC_VERSION")
+            """,
+            "HDI002",
+        ),
+        (
+            """
+            device_kind = get_device_config()._device_type
+            """,
+            "HDI003",
+        ),
+        (
+            """
+            import vllm_ascend.device.device_config as dc
+
+            predicate = getattr(dc, "is_950")
+            """,
+            "HDI004",
+        ),
+        (
+            """
+            predicate = globals()["is_310p"]
+            """,
+            "HDI004",
+        ),
+        (
+            """
+            from vllm_ascend.device.device_config import *
+            """,
+            "HDI001",
+        ),
+        (
+            """
+            SOC_VERSION_INFERENCE_SERIES = ["Ascend310P3"]
+            """,
+            "HDI002",
+        ),
+        (
+            """
+            if torch.npu.get_device_name().startswith("Ascend950"):
+                enable_fast_path()
+            """,
+            "HDI005",
+        ),
+        (
+            """
+            if device_name in {"Ascend310P3", "Ascend310P5"}:
+                use_host_staging()
+            """,
+            "HDI005",
+        ),
+        (
+            """
+            match hardware_family:
+                case "A3":
+                    enable_fullmesh()
+            """,
+            "HDI005",
+        ),
+        (
+            """
+            A5_SOCS = {"Ascend950"}
+
+            if device_name in A5_SOCS:
+                enable_fast_path()
+            """,
+            "HDI005",
+        ),
+        (
+            """
+            predicate = globals().get("is_310p")
+            """,
+            "HDI004",
+        ),
+        (
+            """
+            def is_a5_bf16_kv_enabled():
+                return True
+            """,
+            "HDI001",
+        ),
+        (
+            """
+            if is_950_variant():
+                enable_fast_path()
+            """,
+            "HDI001",
+        ),
+        (
+            """
+            if is_310p3vir01():
+                use_host_staging()
+            """,
+            "HDI001",
+        ),
+    ],
+)
+def test_rejects_explicit_hardware_identity(source, expected_code):
+    assert expected_code in _codes(source)
+
+
+@pytest.mark.parametrize(
+    "source",
+    [
+        """
+        from vllm_ascend.device.hardware_profile import HardwareCapability
+        from vllm_ascend.device.hardware_profile import get_current_hardware_profile
+
+        enabled = get_current_hardware_profile().supports(
+            HardwareCapability.FP8_ATTENTION
+        )
+        """,
+        """
+        from vllm_ascend.device.hardware_profile import AttentionBackendFamily
+        from vllm_ascend.device.hardware_profile import get_current_hardware_profile
+
+        family = get_current_hardware_profile().attention_backend_family
+        enabled = family is AttentionBackendFamily.DENSE_MLA_SFA_DSA
+        """,
+        """
+        enabled = current_platform.device_type == "npu"
+        fallback = config.device_type == "cuda"
+        """,
+        """
+        # is_310p and AscendDeviceType are documentation here.
+        note = "Do not branch on get_ascend_device_type or Ascend950"
+        """,
+        """
+        class Ascend310PWorker:
+            pass
+
+        def get_310p_rope_state():
+            pass
+        """,
+        """
+        from vllm_ascend.device.device_config import check_ascend_device_type
+
+        check_ascend_device_type()
+        """,
+        """
+        from vllm_ascend.utils import *
+
+        enable_custom_op()
+        """,
+        """
+        import os
+
+        read_env = os.getenv
+        environment = os.environ
+        cache_root = read_env("VLLM_CACHE_ROOT")
+        executable_path = environment.get("PATH")
+        """,
+        """
+        import os
+
+        read_env = os.getenv
+
+        def read_setting(read_env):
+            return read_env("SOC_VERSION")
+        """,
+        """
+        import os
+
+        values = [os.getenv("SOC_VERSION") for os in providers]
+        """,
+        """
+        import os
+
+        class Configuration:
+            os = fake
+            build_target = os.getenv("SOC_VERSION")
+        """,
+    ],
+)
+def test_accepts_profile_queries_and_non_identity_device_names(source):
+    assert not _codes(source)
+
+
+@pytest.mark.parametrize(
+    "path",
+    [
+        "vllm_ascend/device/device_config.py",
+        "vllm_ascend/device/hardware.py",
+        "vllm_ascend/device/hardware_profile.py",
+    ],
+)
+def test_allows_identity_only_in_exact_hal_boundary_files(path):
+    source = """
+        from vllm_ascend.device.hardware import AscendDeviceType
+
+        enabled = get_ascend_device_type() is AscendDeviceType.A5
+    """
+    assert not _codes(source, path)
+
+
+def test_does_not_allow_neighboring_device_modules():
+    source = """
+        from vllm_ascend.device.hardware import AscendDeviceType
+
+        enabled = kind == AscendDeviceType.A5
+    """
+    assert "HDI001" in _codes(source, "vllm_ascend/device/backend.py")
+
+
+def test_skips_tests_that_construct_profiles_from_device_types():
+    source = """
+        from vllm_ascend.device.hardware import AscendDeviceType
+
+        profile = get_hardware_profile(AscendDeviceType.A3)
+    """
+    assert not _codes(source, "tests/ut/device/test_hardware_profile.py")
+
+
+def test_allows_the_existing_lazy_soc_version_environment_declaration():
+    source = """
+        import os
+
+        env_variables: dict[str, object] = {
+            "SOC_VERSION": lambda: os.getenv("SOC_VERSION", None),
+        }
+    """
+    assert not _codes(source, "vllm_ascend/envs.py")
+
+
+def test_envs_file_exception_does_not_cover_an_arbitrary_neighboring_dict():
+    source = """
+        import os
+
+        env_variables: dict[str, object] = {}
+        other_environment_variables = {
+            "SOC_VERSION": lambda: os.getenv("SOC_VERSION", None),
+        }
+    """
+    assert "HDI002" in _codes(source, "vllm_ascend/envs.py")
+
+
+@pytest.mark.parametrize(
+    "path",
+    [
+        "vllm_ascend/_build_info.py",
+        "vllm_ascend/_cann_ops_custom/vendor/generated_op.py",
+    ],
+)
+def test_skips_generated_build_outputs_outside_python_business_logic(path):
+    source = "selected = get_soc_version() == 'Ascend950'"
+    assert not _codes(source, path)
+
+
+def test_envs_file_exception_does_not_cover_a_soc_identity_branch():
+    source = """
+        import os
+
+        if os.getenv("SOC_VERSION") == "Ascend950":
+            enable_fast_path()
+    """
+    assert "HDI002" in _codes(source, "vllm_ascend/envs.py")
+
+
+def test_reports_parse_errors_in_scanned_production_files():
+    violations = check_source("if True print('broken')", "vllm_ascend/broken.py")
+    assert [violation.code for violation in violations] == ["HDI000"]
+
+
+@pytest.mark.parametrize(
+    "identity",
+    [
+        "910b",
+        "910c",
+        "910",
+        "310p",
+        "Ascend910",
+        "Ascend910B1",
+        "Ascend910B2",
+        "Ascend910B2C",
+        "Ascend910B3",
+        "Ascend910B4",
+        "Ascend910B4-1",
+        "Ascend910_9391",
+        "Ascend910_9381",
+        "Ascend910_9372",
+        "Ascend910_9392",
+        "Ascend910_9382",
+        "Ascend910_9362",
+        "Ascend310P1",
+        "Ascend310P3",
+        "Ascend310P5",
+        "Ascend310P7",
+        "Ascend310P3Vir01",
+        "Ascend310P3Vir02",
+        "Ascend310P3Vir04",
+        "Ascend310P3Vir08",
+        "Ascend950",
+        "_310P",
+        "A2",
+        "A3",
+        "A5",
+        "Ascend910C1",
+    ],
+)
+def test_rejects_known_and_forward_compatible_device_literals(identity: str):
+    assert "HDI005" in _codes(f"selected = device_name == {identity!r}")
+
+
+def test_default_cli_scan_covers_the_complete_production_tree():
+    assert main([]) == 0

--- a/tests/ut/attention/test_attention_utils.py
+++ b/tests/ut/attention/test_attention_utils.py
@@ -14,10 +14,12 @@
 # limitations under the License.
 
 from types import SimpleNamespace
+from unittest.mock import patch
 
 import torch
 
-from vllm_ascend.attention.utils import filter_chunked_req_indices, get_or_register_attention_buffer
+from vllm_ascend.attention.utils import enabling_mlapo, filter_chunked_req_indices, get_or_register_attention_buffer
+from vllm_ascend.device.hardware_profile import MLAPOEnablementPolicy
 
 
 def test_get_or_register_attention_buffer() -> None:
@@ -68,3 +70,32 @@ def test_filter_chunked_req_indices_mixed_mask() -> None:
     )
 
     torch.testing.assert_close(indices, torch.tensor([0, 1, 3, 4, 5]))
+
+
+def test_enabling_mlapo_respects_producer_and_consumer_policy() -> None:
+    cases = (
+        (MLAPOEnablementPolicy.DECODE_KV_CONSUMER_ONLY, True, False, True),
+        (MLAPOEnablementPolicy.DECODE_KV_CONSUMER_ONLY, False, True, False),
+        (MLAPOEnablementPolicy.ANY_CONFIGURED_INSTANCE, True, False, True),
+        (MLAPOEnablementPolicy.ANY_CONFIGURED_INSTANCE, False, True, True),
+    )
+
+    for policy, is_consumer, is_producer, expected in cases:
+        vllm_config = SimpleNamespace(
+            kv_transfer_config=SimpleNamespace(
+                is_kv_consumer=is_consumer,
+                is_kv_producer=is_producer,
+            )
+        )
+        profile = SimpleNamespace(mlapo_enablement_policy=policy)
+        with (
+            patch(
+                "vllm_ascend.attention.utils.get_ascend_config",
+                return_value=SimpleNamespace(enable_mlapo=True),
+            ),
+            patch(
+                "vllm_ascend.attention.utils.get_current_hardware_profile",
+                return_value=profile,
+            ),
+        ):
+            assert enabling_mlapo(vllm_config) is expected

--- a/tests/ut/attention/test_attention_v1.py
+++ b/tests/ut/attention/test_attention_v1.py
@@ -25,9 +25,9 @@ from vllm_ascend.attention.utils import (
     using_paged_attention,
 )
 from vllm_ascend.device.device_op import A5DeviceAdaptor
+from vllm_ascend.device.hardware import AscendDeviceType
 from vllm_ascend.device.hardware_profile import get_hardware_profile
 from vllm_ascend.device.utils import FIA_TND_LARGE_HEAD_FALLBACK_HEAD_SIZE
-from vllm_ascend.utils import AscendDeviceType
 
 LARGE_HEAD_PREFILL_PATH = "vllm_ascend.device.utils.npu_large_head_prefill_attention"
 

--- a/tests/ut/attention/test_dsa_attn_kv_plan.py
+++ b/tests/ut/attention/test_dsa_attn_kv_plan.py
@@ -13,12 +13,12 @@ from vllm_ascend.attention.dsa_attn_kv_plan import (
     DSA_COMPRESSOR_SLOT_MAPPING_FLAT,
     get_dsa_attn_kv_plan,
     get_dsv4_attn_kv_dtype,
-    is_a5_bf16_kv_enabled,
+    is_dsv4_bf16_sparse_flash_mla_enabled,
     resolve_dsv4_cache_dtype,
 )
 from vllm_ascend.attention.sparse_flash_mla import sparse_flash_mla
+from vllm_ascend.device.hardware import AscendDeviceType
 from vllm_ascend.device.hardware_profile import get_hardware_profile
-from vllm_ascend.utils import AscendDeviceType
 
 _DSA_C_ASCEND_OPS = (
     "npu_sparse_attn_sharedkv",
@@ -95,23 +95,23 @@ def test_scatter_skips_none_updates():
             epilog.assert_not_called()
 
 
-def test_is_a5_bf16_kv_enabled_requires_vllm_config():
+def test_bf16_sparse_flash_mla_selection_requires_vllm_config():
     with _on(AscendDeviceType.A5), pytest.raises(TypeError):
-        is_a5_bf16_kv_enabled()
+        is_dsv4_bf16_sparse_flash_mla_enabled()
 
 
 def test_only_explicit_bfloat16_selects_bf16_kv_on_a5():
     with _on(AscendDeviceType.A5):
-        assert is_a5_bf16_kv_enabled(_cache_config("bfloat16"))
-        assert not is_a5_bf16_kv_enabled(_cache_config())
-        assert not is_a5_bf16_kv_enabled(_cache_config("fp8"))
+        assert is_dsv4_bf16_sparse_flash_mla_enabled(_cache_config("bfloat16"))
+        assert not is_dsv4_bf16_sparse_flash_mla_enabled(_cache_config())
+        assert not is_dsv4_bf16_sparse_flash_mla_enabled(_cache_config("fp8"))
         # The A5 spec path rewrites cache_dtype once FP8 KV is chosen.
-        assert not is_a5_bf16_kv_enabled(_cache_config("float8_e4m3fn"))
+        assert not is_dsv4_bf16_sparse_flash_mla_enabled(_cache_config("float8_e4m3fn"))
 
 
 def test_a5_bf16_kv_is_disabled_on_non_a5():
     with _on(AscendDeviceType.A3):
-        assert not is_a5_bf16_kv_enabled(_cache_config("bfloat16"))
+        assert not is_dsv4_bf16_sparse_flash_mla_enabled(_cache_config("bfloat16"))
 
 
 @pytest.mark.parametrize(
@@ -146,9 +146,9 @@ def test_a5_mode_survives_the_spec_path_rewrite():
     with _on(AscendDeviceType.A5):
         for launch in ("auto", "fp8"):
             pinned = resolve_dsv4_cache_dtype(launch, "bfloat16")
-            assert not is_a5_bf16_kv_enabled(_cache_config(pinned))
+            assert not is_dsv4_bf16_sparse_flash_mla_enabled(_cache_config(pinned))
             # layer.get_kv_cache_spec pins FP8 once it has picked the mode.
-            assert not is_a5_bf16_kv_enabled(_cache_config("float8_e4m3fn"))
+            assert not is_dsv4_bf16_sparse_flash_mla_enabled(_cache_config("float8_e4m3fn"))
 
         pinned = resolve_dsv4_cache_dtype("bfloat16", "bfloat16")
-        assert is_a5_bf16_kv_enabled(_cache_config(pinned))
+        assert is_dsv4_bf16_sparse_flash_mla_enabled(_cache_config(pinned))

--- a/tests/ut/device/test_hardware_profile.py
+++ b/tests/ut/device/test_hardware_profile.py
@@ -2,6 +2,7 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 # Copyright (c) 2026 Huawei Technologies Co., Ltd. All Rights Reserved.
 
+from dataclasses import fields
 from typing import cast
 
 import pytest
@@ -11,173 +12,242 @@ from vllm_ascend.device.device_config import get_device_config
 from vllm_ascend.device.hardware import AscendDeviceType
 from vllm_ascend.device.hardware_profile import (
     AttentionBackendFamily,
+    CompilationCustomOpPolicy,
     CPUBindingMode,
     DeviceAdaptorFamily,
     DeviceAddressingMode,
+    DistributedCollectiveFamily,
+    DSAOProjWeightLayoutPolicy,
+    GDNPatchFamily,
     HardwareCapability,
+    HardwareProfile,
+    MambaConfigPatchFamily,
+    MC2FullmeshAliasPolicy,
+    MiniMaxM3IndexerFamily,
+    MiniMaxM3SparseAttentionPrefillFamily,
+    MLAPOEnablementPolicy,
+    ModelRunnerV2ImplementationFamily,
     MoECommPolicy,
+    MoEDistributeApiFamily,
+    MoERouterFamily,
+    OperatorRegistryFamily,
     QuantizationBackendFamily,
     WeightLayoutPolicy,
+    WorkerPatchFamily,
     get_current_hardware_profile,
     get_hardware_profile,
 )
 
-_STANDARD_CAPABILITIES = frozenset(
+_A2_A3_COMMON_CAPABILITIES = frozenset(
     {
-        HardwareCapability.AUTO_ENABLE_CUSTOM_OPS,
-        HardwareCapability.ATB_EXTENSIONS,
-        HardwareCapability.ATB_WARMUP,
-        HardwareCapability.BGMV_SGMV_META_REGISTRATION,
-        HardwareCapability.FUSED_SWIGLU_TUNING_ARGS,
+        HardwareCapability.ATB_MODEL_EXECUTION_EXTENSIONS,
+        HardwareCapability.BGMV_SGMV_META_KERNELS,
+        HardwareCapability.DEQUANT_SWIGLU_GLU_ALPHA_BIAS_ARGS,
         HardwareCapability.GRAPH_MULS_ADD_FUSION,
         HardwareCapability.GRAPH_NORM_QUANT_FUSION,
-        HardwareCapability.IRQ_CPU_RESERVATION,
-        HardwareCapability.LORA_CUSTOM_OPS,
+        HardwareCapability.LORA_BGMV_SGMV_CUSTOM_OPS,
         HardwareCapability.MC2_HIERARCHY_COMM,
-        HardwareCapability.NPUGRAPH_EX,
-        HardwareCapability.PAGED_ATTENTION,
-        HardwareCapability.RUNTIME_CUSTOM_OPS,
+        HardwareCapability.NPUGRAPH_EX_COMPILATION_BACKEND,
+        HardwareCapability.PAGED_ATTENTION_FULL_DECODE,
+        HardwareCapability.ASCEND_CUSTOM_OP_RUNTIME_REGISTRATION,
         HardwareCapability.SFA_DCP_REPLICATED_INDEXER,
-        HardwareCapability.STANDARD_MAMBA_PATCH,
-        HardwareCapability.STANDARD_WORKER_PATCHES,
-        HardwareCapability.TRITON_BATCH_MEMCPY,
+        HardwareCapability.TRITON_MAMBA_STATE_BATCH_MEMCPY,
+        HardwareCapability.XLITE_GRAPH_WORKER,
+    }
+)
+_MINIMAX_M3_FALLBACK_CAPABILITIES = frozenset(
+    {
+        # These preserve the previous ``device != A5`` behavior; they do not
+        # independently declare MiniMax-M3 support on every listed family.
+        HardwareCapability.MINIMAX_M3_FUSED_CLIPPED_SWIGLU,
+        HardwareCapability.MINIMAX_M3_FUSED_QKV_RMSNORM_ROPE,
+        HardwareCapability.MINIMAX_M3_TP_SHARDED_INDEX_DECODE,
     }
 )
 
 _EXPECTED_CAPABILITIES = {
-    AscendDeviceType.A2: _STANDARD_CAPABILITIES | {HardwareCapability.NPU_TOP_K_TOP_P},
-    AscendDeviceType.A3: _STANDARD_CAPABILITIES
+    AscendDeviceType.A2: _A2_A3_COMMON_CAPABILITIES
+    | _MINIMAX_M3_FALLBACK_CAPABILITIES
+    | {HardwareCapability.NATIVE_TOP_K_TOP_P_SAMPLING},
+    AscendDeviceType.A3: _A2_A3_COMMON_CAPABILITIES
+    | _MINIMAX_M3_FALLBACK_CAPABILITIES
     | {
-        HardwareCapability.CANN_MEGAMOE,
-        HardwareCapability.MC2_FULLMESH_V2_COMM,
-        HardwareCapability.MOE_DISPATCH_EXTRA_ARGS,
-        HardwareCapability.NPU_TOP_K_TOP_P,
+        HardwareCapability.CANN_MEGAMOE_FUSED_MC2,
+        HardwareCapability.MC2_FULLMESH_V2,
+        HardwareCapability.NATIVE_TOP_K_TOP_P_SAMPLING,
     },
-    AscendDeviceType._310P: frozenset(
+    AscendDeviceType._310P: _MINIMAX_M3_FALLBACK_CAPABILITIES
+    | frozenset(
         {
-            HardwareCapability.COMPATIBILITY_OP_IMPLEMENTATIONS,
-            HardwareCapability.DISTRIBUTED_COMMUNICATION_ADAPTATION,
-            HardwareCapability.FUSED_MOE_COMPATIBILITY,
-            HardwareCapability.FUSED_SWIGLU_TUNING_ARGS,
-            HardwareCapability.GDN_COMPATIBILITY,
-            HardwareCapability.IRQ_CPU_RESERVATION,
-            HardwareCapability.RC_DEVICE_DISCOVERY,
-            HardwareCapability.RUNTIME_CUSTOM_OPS,
+            HardwareCapability.DEQUANT_SWIGLU_GLU_ALPHA_BIAS_ARGS,
+            HardwareCapability.PCIE_ROOT_COMPLEX_MODE_DETECTION,
+            HardwareCapability.ASCEND_CUSTOM_OP_RUNTIME_REGISTRATION,
         }
     ),
     AscendDeviceType.A5: frozenset(
         {
-            HardwareCapability.AUTO_ENABLE_CUSTOM_OPS,
-            HardwareCapability.BGMV_SGMV_META_REGISTRATION,
-            HardwareCapability.CHUNKED_PREFILL_PHASE_SPLIT,
+            HardwareCapability.BGMV_SGMV_META_KERNELS,
+            HardwareCapability.BLOCK_FP8_TO_MXFP8_REQUANTIZATION,
             HardwareCapability.CLUSTER_CPU_TOPOLOGY,
-            HardwareCapability.DSA_C128_STATE_SMALL_BLOCK_SIZES,
             HardwareCapability.DSA_O_PROJ_TP,
-            HardwareCapability.DSV4_COMPRESSED_CACHE,
-            HardwareCapability.DYNAMIC_MX_QUANT_FUSION,
-            HardwareCapability.DYNAMIC_MX_QUANT_SCALE_ALG_ONE,
+            HardwareCapability.DSA_COMPRESSED_KV_CACHE,
+            HardwareCapability.DYNAMIC_MX_QUANT_E8M0_OVERFLOW_SAFE_SCALING,
             HardwareCapability.FP8_ATTENTION,
+            HardwareCapability.GRAPH_DYNAMIC_MX_QUANT_FUSION,
             HardwareCapability.GRAPH_MULS_ADD_FUSION,
             HardwareCapability.GRAPH_NORM_QUANT_FUSION,
-            HardwareCapability.LOCAL_KV_COMM_RESOURCE,
-            HardwareCapability.LORA_CUSTOM_OPS,
+            HardwareCapability.LOCAL_KV_TRANSFER_COMM_RESOURCE,
+            HardwareCapability.LORA_BGMV_SGMV_CUSTOM_OPS,
             HardwareCapability.MLA_DECODE_PROLOG_WITHOUT_ROPE,
-            HardwareCapability.MLAPO_NATIVE_WEIGHTS,
-            HardwareCapability.MOE_DISPATCH_EXTRA_ARGS,
-            HardwareCapability.MOE_DISPATCH_SHARED_EXPERT_ARGS,
-            HardwareCapability.NPUGRAPH_EX,
-            HardwareCapability.REDUCED_CUDAGRAPH_CAPTURE_SIZES,
-            HardwareCapability.STANDARD_MAMBA_PATCH,
-            HardwareCapability.STANDARD_WORKER_PATCHES,
-            HardwareCapability.SWIGLU_OAI_MX_QUANT,
-            HardwareCapability.TRITON_BATCH_MEMCPY,
-            HardwareCapability.UNRESTRICTED_MLAPO,
+            HardwareCapability.MLAPO_UNQUANTIZED_PROJECTION_WEIGHTS,
+            HardwareCapability.MINIMAX_M3_PAGED_INDEX_CACHE_SCATTER,
+            HardwareCapability.MINIMAX_M3_SWIGLU_OAI_MXFP8_OUTPUT_QUANTIZATION,
+            HardwareCapability.NPUGRAPH_EX_COMPILATION_BACKEND,
+            HardwareCapability.TRITON_MAMBA_STATE_BATCH_MEMCPY,
+            HardwareCapability.XLITE_GRAPH_WORKER,
         }
     ),
 }
 
+_EXPECTED_PROFILE_FIELDS: dict[AscendDeviceType, dict[str, object]] = {
+    AscendDeviceType.A2: {
+        "attention_backend_family": AttentionBackendFamily.DENSE_MLA_SFA_DSA,
+        "atb_matmul_warmup_required": True,
+        "cpu_binding_mode": CPUBindingMode.TOPO_AFFINITY,
+        "cudagraph_capture_size_limit": None,
+        "default_worker_cls": "vllm_ascend.worker.worker.NPUWorker",
+        "device_adaptor_family": DeviceAdaptorFamily.BASE_DEVICE_OPERATIONS,
+        "device_addressing_mode": DeviceAddressingMode.DIRECT,
+        "distributed_collective_family": DistributedCollectiveFamily.TORCH_NPU_NATIVE,
+        "dsa_c128_block_sizes": (8, 16, 32),
+        "dsa_o_proj_weight_layout_policy": DSAOProjWeightLayoutPolicy.ALWAYS_TRANSPOSE_WO_A,
+        "compilation_custom_op_policy": CompilationCustomOpPolicy.FORCE_ENABLE_ALL,
+        "gdn_patch_family": GDNPatchFamily.FULL_FORWARD_PATCH,
+        "mamba_config_patch_family": MambaConfigPatchFamily.MLA_OR_DENSE_CACHE_LAYOUT,
+        "mc2_fullmesh_alias_policy": MC2FullmeshAliasPolicy.PASSTHROUGH,
+        "minimax_m3_indexer_family": MiniMaxM3IndexerFamily.ASCENDC_SCORE_AND_DECODE_WITH_TRITON_TOPK,
+        "minimax_m3_sparse_attention_prefill_family": (
+            MiniMaxM3SparseAttentionPrefillFamily.SELECT_INDEX_AND_COUNT_SCORE
+        ),
+        "mlapo_enablement_policy": MLAPOEnablementPolicy.DECODE_KV_CONSUMER_ONLY,
+        "model_runner_v2_implementation_family": ModelRunnerV2ImplementationFamily.DEFAULT_TRITON_BACKED,
+        "moe_comm_policy": MoECommPolicy.MC2_IF_CAPACITY_AND_EXPERT_DENSITY_ELSE_ALLGATHER,
+        "moe_distribute_api_family": MoEDistributeApiFamily.EP_METADATA,
+        "moe_router_family": MoERouterFamily.FUSED_OR_GROUPED_TOP_K,
+        "operator_registry_family": OperatorRegistryFamily.BASE_ASCEND_IMPLEMENTATIONS,
+        "quantization_backend_family": QuantizationBackendFamily.COMPRESSED_TENSORS_FP8_MXFP8_AND_MODELSLIM,
+        "reserve_irq_cpus": True,
+        "split_fia_chunked_prefill_by_default": False,
+        "weight_layout_policy": WeightLayoutPolicy.CONFIGURABLE,
+        "worker_patch_family": WorkerPatchFamily.QWEN3_5_DFLASH_AND_VL,
+    },
+    AscendDeviceType.A3: {
+        "attention_backend_family": AttentionBackendFamily.DENSE_MLA_SFA_DSA,
+        "atb_matmul_warmup_required": True,
+        "cpu_binding_mode": CPUBindingMode.GLOBAL_SLICE,
+        "cudagraph_capture_size_limit": None,
+        "default_worker_cls": "vllm_ascend.worker.worker.NPUWorker",
+        "device_adaptor_family": DeviceAdaptorFamily.BASE_DEVICE_OPERATIONS,
+        "device_addressing_mode": DeviceAddressingMode.DUAL_CHIP_CARD,
+        "distributed_collective_family": DistributedCollectiveFamily.TORCH_NPU_NATIVE,
+        "dsa_c128_block_sizes": (8, 16, 32),
+        "dsa_o_proj_weight_layout_policy": DSAOProjWeightLayoutPolicy.ALWAYS_TRANSPOSE_WO_A,
+        "compilation_custom_op_policy": CompilationCustomOpPolicy.FORCE_ENABLE_ALL,
+        "gdn_patch_family": GDNPatchFamily.FULL_FORWARD_PATCH,
+        "mamba_config_patch_family": MambaConfigPatchFamily.MLA_OR_DENSE_CACHE_LAYOUT,
+        "mc2_fullmesh_alias_policy": MC2FullmeshAliasPolicy.MAP_FULLMESH_TO_V1,
+        "minimax_m3_indexer_family": MiniMaxM3IndexerFamily.ASCENDC_SCORE_AND_DECODE_WITH_TRITON_TOPK,
+        "minimax_m3_sparse_attention_prefill_family": (
+            MiniMaxM3SparseAttentionPrefillFamily.SELECT_INDEX_AND_COUNT_SCORE
+        ),
+        "mlapo_enablement_policy": MLAPOEnablementPolicy.DECODE_KV_CONSUMER_ONLY,
+        "model_runner_v2_implementation_family": ModelRunnerV2ImplementationFamily.DEFAULT_TRITON_BACKED,
+        "moe_comm_policy": MoECommPolicy.FUSED_MC2_THEN_CAPACITY_MC2_ELSE_ALLTOALL,
+        "moe_distribute_api_family": MoEDistributeApiFamily.EP_AND_TP_METADATA,
+        "moe_router_family": MoERouterFamily.FUSED_OR_GROUPED_TOP_K,
+        "operator_registry_family": OperatorRegistryFamily.BASE_ASCEND_IMPLEMENTATIONS,
+        "quantization_backend_family": QuantizationBackendFamily.COMPRESSED_TENSORS_FP8_MXFP8_AND_MODELSLIM,
+        "reserve_irq_cpus": True,
+        "split_fia_chunked_prefill_by_default": False,
+        "weight_layout_policy": WeightLayoutPolicy.CONFIGURABLE,
+        "worker_patch_family": WorkerPatchFamily.QWEN3_5_DFLASH_AND_VL,
+    },
+    AscendDeviceType._310P: {
+        "attention_backend_family": AttentionBackendFamily.DENSE_ONLY,
+        "atb_matmul_warmup_required": False,
+        "cpu_binding_mode": CPUBindingMode.TOPO_AFFINITY,
+        "cudagraph_capture_size_limit": None,
+        "default_worker_cls": "vllm_ascend._310p.worker_310p.NPUWorker310",
+        "device_adaptor_family": DeviceAdaptorFamily.RESHAPE_CACHE_AND_INDEX_FILL_OPERATIONS,
+        "device_addressing_mode": DeviceAddressingMode.DIRECT,
+        "distributed_collective_family": DistributedCollectiveFamily.BROADCAST_AND_INT64_ALLREDUCE_VIA_ALLGATHER,
+        "dsa_c128_block_sizes": (8, 16, 32),
+        "dsa_o_proj_weight_layout_policy": DSAOProjWeightLayoutPolicy.ALWAYS_TRANSPOSE_WO_A,
+        "compilation_custom_op_policy": CompilationCustomOpPolicy.PRESERVE_CONFIGURATION,
+        "gdn_patch_family": GDNPatchFamily.CORE_AND_DTYPE_PATCH,
+        "mamba_config_patch_family": MambaConfigPatchFamily.DENSE_ATTENTION_CACHE_ONLY,
+        "mc2_fullmesh_alias_policy": MC2FullmeshAliasPolicy.PASSTHROUGH,
+        "minimax_m3_indexer_family": MiniMaxM3IndexerFamily.ASCENDC_SCORE_AND_DECODE_WITH_TRITON_TOPK,
+        "minimax_m3_sparse_attention_prefill_family": (
+            MiniMaxM3SparseAttentionPrefillFamily.SELECT_INDEX_AND_COUNT_SCORE
+        ),
+        "mlapo_enablement_policy": MLAPOEnablementPolicy.DECODE_KV_CONSUMER_ONLY,
+        "model_runner_v2_implementation_family": ModelRunnerV2ImplementationFamily.TRITON_FREE_HOST_METADATA,
+        "moe_comm_policy": MoECommPolicy.ALLGATHER,
+        "moe_distribute_api_family": MoEDistributeApiFamily.EP_METADATA,
+        "moe_router_family": MoERouterFamily.CHUNKED_SOFTMAX_TOP_K,
+        "operator_registry_family": OperatorRegistryFamily.BASE_WITH_TRITON_FREE_KERNEL_OVERRIDES,
+        "quantization_backend_family": QuantizationBackendFamily.MODELSLIM_ONLY,
+        "reserve_irq_cpus": True,
+        "split_fia_chunked_prefill_by_default": False,
+        "weight_layout_policy": WeightLayoutPolicy.FORCE_NZ,
+        "worker_patch_family": WorkerPatchFamily.TRITON_FREE_GDN_QWEN3_VL_AND_SPEC_DECODE,
+    },
+    AscendDeviceType.A5: {
+        "attention_backend_family": AttentionBackendFamily.DENSE_MLA_SFA_DSA,
+        "atb_matmul_warmup_required": False,
+        "cpu_binding_mode": CPUBindingMode.TOPO_AFFINITY,
+        "cudagraph_capture_size_limit": 4,
+        "default_worker_cls": "vllm_ascend.worker.worker.NPUWorker",
+        "device_adaptor_family": DeviceAdaptorFamily.FP8_MXFP_DSA_AND_FUSED_MODEL_OPERATIONS,
+        "device_addressing_mode": DeviceAddressingMode.DIRECT,
+        "distributed_collective_family": DistributedCollectiveFamily.TORCH_NPU_NATIVE,
+        "dsa_c128_block_sizes": (4, 8, 16),
+        "dsa_o_proj_weight_layout_policy": DSAOProjWeightLayoutPolicy.TRANSPOSE_UNQUANTIZED_BF16_WO_A_ONLY,
+        "compilation_custom_op_policy": CompilationCustomOpPolicy.FORCE_ENABLE_ALL,
+        "gdn_patch_family": GDNPatchFamily.FULL_FORWARD_PATCH,
+        "mamba_config_patch_family": MambaConfigPatchFamily.MLA_OR_DENSE_CACHE_LAYOUT,
+        "mc2_fullmesh_alias_policy": MC2FullmeshAliasPolicy.PASSTHROUGH,
+        "minimax_m3_indexer_family": MiniMaxM3IndexerFamily.TRITON_SCORE_TOPK_DECODE,
+        "minimax_m3_sparse_attention_prefill_family": MiniMaxM3SparseAttentionPrefillFamily.K2Q_CSR_SCORE,
+        "mlapo_enablement_policy": MLAPOEnablementPolicy.ANY_CONFIGURED_INSTANCE,
+        "model_runner_v2_implementation_family": ModelRunnerV2ImplementationFamily.DEFAULT_TRITON_BACKED,
+        "moe_comm_policy": MoECommPolicy.MC2_IF_CAPACITY_ELSE_ALLGATHER_OR_ALLTOALL_BY_WORLD_SIZE,
+        "moe_distribute_api_family": MoEDistributeApiFamily.EP_TP_WITH_EXPERT_SCALES_MXFP_MODE_AND_QUANT_OUTPUT_DTYPE,
+        "moe_router_family": MoERouterFamily.FUSED_OR_GROUPED_TOP_K,
+        "operator_registry_family": OperatorRegistryFamily.BASE_ASCEND_IMPLEMENTATIONS,
+        "quantization_backend_family": QuantizationBackendFamily.COMPRESSED_TENSORS_FP8_MXFP8_AND_MODELSLIM,
+        "reserve_irq_cpus": False,
+        "split_fia_chunked_prefill_by_default": True,
+        "weight_layout_policy": WeightLayoutPolicy.CONFIGURABLE,
+        "worker_patch_family": WorkerPatchFamily.QWEN3_5_DFLASH_AND_VL,
+    },
+}
 
-@pytest.mark.parametrize(
-    (
-        "device_type",
-        "attention_backend_family",
-        "cpu_binding_mode",
-        "default_worker_cls",
-        "device_adaptor_family",
-        "device_addressing_mode",
-        "weight_layout_policy",
-        "moe_comm_policy",
-        "quantization_backend_family",
-    ),
-    [
-        (
-            AscendDeviceType.A2,
-            AttentionBackendFamily.STANDARD,
-            CPUBindingMode.TOPO_AFFINITY,
-            "vllm_ascend.worker.worker.NPUWorker",
-            DeviceAdaptorFamily.STANDARD,
-            DeviceAddressingMode.DIRECT,
-            WeightLayoutPolicy.CONFIGURABLE,
-            MoECommPolicy.CAPACITY_AND_EXPERT_DENSITY,
-            QuantizationBackendFamily.STANDARD,
-        ),
-        (
-            AscendDeviceType.A3,
-            AttentionBackendFamily.STANDARD,
-            CPUBindingMode.GLOBAL_SLICE,
-            "vllm_ascend.worker.worker.NPUWorker",
-            DeviceAdaptorFamily.STANDARD,
-            DeviceAddressingMode.DUAL_CHIP_CARD,
-            WeightLayoutPolicy.CONFIGURABLE,
-            MoECommPolicy.FUSED_OR_CAPACITY,
-            QuantizationBackendFamily.STANDARD,
-        ),
-        (
-            AscendDeviceType._310P,
-            AttentionBackendFamily.COMPATIBILITY,
-            CPUBindingMode.TOPO_AFFINITY,
-            "vllm_ascend._310p.worker_310p.NPUWorker310",
-            DeviceAdaptorFamily.COMPATIBILITY,
-            DeviceAddressingMode.DIRECT,
-            WeightLayoutPolicy.FORCE_NZ,
-            MoECommPolicy.ALLGATHER,
-            QuantizationBackendFamily.COMPATIBILITY,
-        ),
-        (
-            AscendDeviceType.A5,
-            AttentionBackendFamily.STANDARD,
-            CPUBindingMode.TOPO_AFFINITY,
-            "vllm_ascend.worker.worker.NPUWorker",
-            DeviceAdaptorFamily.FP8_OPTIMIZED,
-            DeviceAddressingMode.DIRECT,
-            WeightLayoutPolicy.CONFIGURABLE,
-            MoECommPolicy.CAPACITY_AND_WORLD_SIZE,
-            QuantizationBackendFamily.STANDARD,
-        ),
-    ],
-)
-def test_hardware_profile_implementation_matrix(
-    device_type: AscendDeviceType,
-    attention_backend_family: AttentionBackendFamily,
-    cpu_binding_mode: CPUBindingMode,
-    default_worker_cls: str,
-    device_adaptor_family: DeviceAdaptorFamily,
-    device_addressing_mode: DeviceAddressingMode,
-    weight_layout_policy: WeightLayoutPolicy,
-    moe_comm_policy: MoECommPolicy,
-    quantization_backend_family: QuantizationBackendFamily,
-) -> None:
+
+@pytest.mark.parametrize("device_type", list(AscendDeviceType))
+def test_hardware_profile_implementation_matrix(device_type: AscendDeviceType) -> None:
     profile = get_hardware_profile(device_type)
+    expected_fields = _EXPECTED_PROFILE_FIELDS[device_type]
+    implementation_field_names = {field.name for field in fields(HardwareProfile)} - {
+        "_device_type",
+        "capabilities",
+    }
 
     assert profile._device_type is device_type
-    assert profile.attention_backend_family is attention_backend_family
-    assert profile.cpu_binding_mode is cpu_binding_mode
-    assert profile.default_worker_cls == default_worker_cls
-    assert profile.device_adaptor_family is device_adaptor_family
-    assert profile.device_addressing_mode is device_addressing_mode
-    assert profile.weight_layout_policy is weight_layout_policy
-    assert profile.moe_comm_policy is moe_comm_policy
-    assert profile.quantization_backend_family is quantization_backend_family
+    assert set(expected_fields) == implementation_field_names
+    for field_name, expected in expected_fields.items():
+        assert getattr(profile, field_name) == expected
 
 
 @pytest.mark.parametrize("device_type", list(AscendDeviceType))
@@ -203,7 +273,7 @@ def test_current_hardware_profile_is_dynamo_safe(monkeypatch: pytest.MonkeyPatch
     monkeypatch.setattr(torch.accelerator, "is_available", lambda: False)
 
     def use_profile_capability(value: torch.Tensor) -> torch.Tensor:
-        if get_current_hardware_profile().supports(HardwareCapability.RUNTIME_CUSTOM_OPS):
+        if get_current_hardware_profile().supports(HardwareCapability.ASCEND_CUSTOM_OP_RUNTIME_REGISTRATION):
             return value + 1
         return value
 

--- a/tests/ut/device_allocator/test_cpu_binding.py
+++ b/tests/ut/device_allocator/test_cpu_binding.py
@@ -21,8 +21,8 @@ from unittest.mock import MagicMock, call, mock_open, patch
 
 import vllm_ascend.cpu_binding as cpu_binding_module
 from vllm_ascend.cpu_binding import CpuAlloc, DeviceInfo, bind_cpus, is_arm_cpu
+from vllm_ascend.device.hardware import AscendDeviceType
 from vllm_ascend.device.hardware_profile import get_hardware_profile
-from vllm_ascend.utils import AscendDeviceType
 
 
 def make_cpu_alloc(rank_id=0):

--- a/tests/ut/distributed/ascend_store/_mock_deps.py
+++ b/tests/ut/distributed/ascend_store/_mock_deps.py
@@ -479,11 +479,8 @@ _backend_init_path = os.path.join(_backend_pkg.__path__[0], "__init__.py")  # ty
 with open(_backend_init_path, encoding="utf-8") as _backend_init_file:
     exec(compile(_backend_init_file.read(), _backend_init_path, "exec"), vars(_backend_pkg))  # type: ignore[arg-type]
 
-if "vllm_ascend.utils" not in sys.modules or not hasattr(sys.modules["vllm_ascend.utils"], "AscendDeviceType"):
-    _ascend_utils = MagicMock()
-    _ascend_utils.AscendDeviceType = MagicMock()
-    _ascend_utils.get_ascend_device_type = MagicMock()
-    sys.modules["vllm_ascend.utils"] = _ascend_utils
+if "vllm_ascend.utils" not in sys.modules:
+    sys.modules["vllm_ascend.utils"] = MagicMock()
 
 # NOTE: vllm_ascend.{ascend_config, attention_fence} and their helpers
 # (get_ascend_config, AttentionComputeStartGate, ...) are intentionally NOT

--- a/tests/ut/models/minimax_m3/test_msa_m3.py
+++ b/tests/ut/models/minimax_m3/test_msa_m3.py
@@ -16,9 +16,16 @@ from vllm.v1.attention.backend import CommonAttentionMetadata
 from vllm.v1.kv_cache_interface import FullAttentionSpec
 
 from vllm_ascend.core.kv_cache_interface import AscendSFAIndexerCacheSpec
+from vllm_ascend.device.hardware_profile import (
+    HardwareCapability,
+    MiniMaxM3SparseAttentionPrefillFamily,
+)
 from vllm_ascend.models.minimax_m3 import MiniMaxM3SparseAttention
+from vllm_ascend.models.minimax_m3 import minimax_m3 as minimax_m3_model_module
 from vllm_ascend.models.minimax_m3 import msa_m3 as msa_m3_module
 from vllm_ascend.models.minimax_m3.minimax_m3 import (
+    MiniMaxM3MLP,
+    MiniMaxM3SwiGLUOAI,
     _cast_for_cache,
     _resolve_layer_kv_cache_dtype,
     _resolve_layer_kv_cache_dtypes,
@@ -45,6 +52,7 @@ from vllm_ascend.models.minimax_m3.msa_m3 import (
     _use_fused_qkv_indexer,
     minimax_m3_sparse_forward,
 )
+from vllm_ascend.models.minimax_m3.ops import msa_m3_npu as msa_m3_npu_module
 from vllm_ascend.models.minimax_m3.ops.msa_m3_npu import (
     MiniMaxM3TPDecodeScoreMetadata,
     _as_ascendc_index_kv_cache,
@@ -59,7 +67,26 @@ from vllm_ascend.models.minimax_m3.ops.msa_m3_npu import (
 from vllm_ascend.models.minimax_m3.ops.msa_m3_npu import (
     minimax_m3_sparse_attn_decode as minimax_m3_sparse_attn_decode_npu,
 )
-from vllm_ascend.utils import AscendDeviceType
+
+
+def _profile_supporting(*capabilities: HardwareCapability) -> SimpleNamespace:
+    supported = frozenset(capabilities)
+    return SimpleNamespace(supports=supported.__contains__)
+
+
+class _FakeLinear(torch.nn.Module):
+    def __init__(self, *, uses_mxfp8: bool) -> None:
+        super().__init__()
+        if uses_mxfp8:
+            quant_scheme_type = type(
+                "AscendW8A8MXFP8DynamicLinearMethod",
+                (),
+                {},
+            )
+            quant_scheme = quant_scheme_type()
+        else:
+            quant_scheme = object()
+        self.quant_method = SimpleNamespace(quant_method=quant_scheme)
 
 
 @dataclass
@@ -531,43 +558,370 @@ def test_register_m3_sparse_packed_modules_adds_split_indexer_mapping() -> None:
     }
 
 
-def test_sparse_prepare_bypasses_fused_qkv_norm_rope_on_a5() -> None:
+def _make_sparse_prepare_subject() -> tuple[
+    MiniMaxM3SparseAttention,
+    MagicMock,
+    MagicMock,
+    MagicMock,
+]:
+    attention = object.__new__(MiniMaxM3SparseAttention)
+    torch.nn.Module.__init__(attention)
+    attention.q_size = 4
+    attention.kv_size = 2
+    attention.index_q_size = 2
+    attention.idx_head_dim = 2
+
+    main_qkv = MagicMock(name="main_qkv")
+    main_qkv.device.type = "npu"
+    main_qkv.dtype = torch.bfloat16
+    attention.qkv_proj = MagicMock(return_value=(main_qkv, None))
+
+    index_qk = MagicMock(name="index_qk")
+    index_q = MagicMock(name="index_q")
+    index_k = MagicMock(name="index_k")
+    index_qk.split.return_value = (index_q, index_k)
+    attention.indexer_proj = MagicMock(return_value=(index_qk, None))
+
+    attention._qk_norm = MagicMock()
+    attention._index_qk_norm = MagicMock(return_value=(index_q, index_k))
+    attention.rotary_emb = MagicMock()
+    attention.rotary_emb.is_neox_style = True
+    attention.rotary_emb.cos_sin_cache = MagicMock(name="cos_sin_cache")
+    attention.q_norm = SimpleNamespace(
+        weight=torch.zeros(4, dtype=torch.bfloat16),
+        variance_epsilon=1.0e-6,
+    )
+    attention.k_norm = SimpleNamespace(
+        weight=torch.zeros(2, dtype=torch.bfloat16),
+    )
+    return attention, main_qkv, index_q, index_k
+
+
+def test_sparse_prepare_uses_fused_qkv_when_capability_and_contract_match() -> None:
+    attention, main_qkv, index_q, index_k = _make_sparse_prepare_subject()
+    fused_q = MagicMock(name="fused_q")
+    fused_k = MagicMock(name="fused_k")
+    fused_v = MagicMock(name="fused_v")
+    rotated_index_q = MagicMock(name="rotated_index_q")
+    rotated_index_k = MagicMock(name="rotated_index_k")
+    attention.rotary_emb.return_value = (rotated_index_q, rotated_index_k)
+    positions = torch.tensor([0, 1], dtype=torch.int64)
+    hidden_states = MagicMock(name="hidden_states")
+
+    with (
+        patch.object(
+            minimax_m3_model_module,
+            "_HARDWARE_PROFILE",
+            _profile_supporting(HardwareCapability.MINIMAX_M3_FUSED_QKV_RMSNORM_ROPE),
+        ),
+        patch.object(
+            minimax_m3_model_module.torch.ops.vllm,
+            "qkv_rmsnorm_rope",
+            create=True,
+            return_value=(fused_q, fused_k, fused_v),
+        ) as mock_fused_qkv,
+    ):
+        result = attention._sparse_prepare(positions, hidden_states)
+
+    assert result == (
+        fused_q,
+        fused_k,
+        fused_v,
+        rotated_index_q,
+        rotated_index_k,
+    )
+    attention._qk_norm.assert_not_called()
+    main_qkv.split.assert_not_called()
+    mock_fused_qkv.assert_called_once()
+    assert mock_fused_qkv.call_args.kwargs["input"] is main_qkv.contiguous.return_value
+    assert mock_fused_qkv.call_args.kwargs["positions"] is positions
+
+
+def test_sparse_prepare_uses_torch_fallback_without_fused_qkv_capability() -> None:
+    attention, main_qkv, index_q, index_k = _make_sparse_prepare_subject()
+    q = MagicMock(name="q")
+    k = MagicMock(name="k")
+    v = MagicMock(name="v")
+    normalized_q = MagicMock(name="normalized_q")
+    normalized_k = MagicMock(name="normalized_k")
+    rotated_q = MagicMock(name="rotated_q")
+    rotated_k = MagicMock(name="rotated_k")
+    rotated_index_q = MagicMock(name="rotated_index_q")
+    rotated_index_k = MagicMock(name="rotated_index_k")
+    main_qkv.split.return_value = (q, k, v)
+    attention._qk_norm.return_value = (normalized_q, normalized_k)
+    attention.rotary_emb.side_effect = [
+        (rotated_q, rotated_k),
+        (rotated_index_q, rotated_index_k),
+    ]
+    positions = torch.tensor([0, 1], dtype=torch.int64)
+
+    with (
+        patch.object(
+            minimax_m3_model_module,
+            "_HARDWARE_PROFILE",
+            _profile_supporting(),
+        ),
+        patch.object(
+            minimax_m3_model_module.torch.ops.vllm,
+            "qkv_rmsnorm_rope",
+            create=True,
+        ) as mock_fused_qkv,
+    ):
+        result = attention._sparse_prepare(positions, MagicMock())
+
+    assert result == (
+        rotated_q,
+        rotated_k,
+        v.contiguous.return_value,
+        rotated_index_q,
+        rotated_index_k,
+    )
+    main_qkv.split.assert_called_once_with([4, 2, 2], dim=-1)
+    attention._qk_norm.assert_called_once_with(q, k)
+    mock_fused_qkv.assert_not_called()
+
+
+def test_swiglu_without_mx_quant_uses_fused_op_when_supported() -> None:
+    activation = MiniMaxM3SwiGLUOAI(
+        alpha=1.5,
+        beta=0.5,
+        limit=4.0,
+        use_mx_quant=False,
+    )
+    x = torch.tensor([[1.0, -2.0, 3.0, -4.0]])
+    expected = torch.tensor([[10.0, 20.0]])
+
+    with (
+        patch.object(
+            minimax_m3_model_module,
+            "_HARDWARE_PROFILE",
+            _profile_supporting(HardwareCapability.MINIMAX_M3_FUSED_CLIPPED_SWIGLU),
+        ),
+        patch.object(
+            minimax_m3_model_module.torch.ops.npu,
+            "npu_clipped_swiglu",
+            create=True,
+            return_value=expected,
+        ) as mock_fused_swiglu,
+    ):
+        actual = activation(x)
+
+    assert actual is expected
+    mock_fused_swiglu.assert_called_once_with(
+        x,
+        dim=-1,
+        alpha=1.5,
+        limit=4.0,
+        bias=0.5,
+        interleaved=False,
+    )
+
+
+def test_swiglu_without_mx_quant_uses_torch_fallback_when_unsupported() -> None:
+    activation = MiniMaxM3SwiGLUOAI(
+        alpha=1.5,
+        beta=0.5,
+        limit=4.0,
+        use_mx_quant=False,
+    )
+    x = torch.tensor([[1.0, -2.0, 3.0, -5.0]])
+    gate = torch.clamp(x[..., :2], max=4.0)
+    up = torch.clamp(x[..., 2:], min=-4.0, max=4.0)
+    expected = gate * torch.sigmoid(1.5 * gate) * (up + 0.5)
+
+    with (
+        patch.object(
+            minimax_m3_model_module,
+            "_HARDWARE_PROFILE",
+            _profile_supporting(),
+        ),
+        patch.object(
+            minimax_m3_model_module.torch.ops.npu,
+            "npu_clipped_swiglu",
+            create=True,
+        ) as mock_fused_swiglu,
+    ):
+        actual = activation(x)
+
+    assert torch.equal(actual, expected)
+    mock_fused_swiglu.assert_not_called()
+
+
+@pytest.mark.parametrize(
+    ("capability_supported", "expected_use_mx_quant"),
+    [(False, False), (True, True)],
+)
+def test_mlp_mxfp8_activation_requires_hardware_capability(
+    capability_supported: bool,
+    expected_use_mx_quant: bool,
+) -> None:
+    config = SimpleNamespace(
+        hidden_size=4,
+        hidden_act="swigluoai",
+        intermediate_size=8,
+        swiglu_alpha=1.5,
+        swiglu_beta=0.5,
+        swiglu_limit=4.0,
+    )
+    capabilities = (HardwareCapability.MINIMAX_M3_SWIGLU_OAI_MXFP8_OUTPUT_QUANTIZATION,) if capability_supported else ()
+
+    with (
+        patch.object(
+            minimax_m3_model_module,
+            "_HARDWARE_PROFILE",
+            _profile_supporting(*capabilities),
+        ),
+        patch.object(
+            minimax_m3_model_module,
+            "MergedColumnParallelLinear",
+            return_value=_FakeLinear(uses_mxfp8=True),
+        ),
+        patch.object(
+            minimax_m3_model_module,
+            "RowParallelLinear",
+            return_value=_FakeLinear(uses_mxfp8=True),
+        ),
+    ):
+        mlp = MiniMaxM3MLP(config)
+
+    assert mlp.act_fn.use_mx_quant is expected_use_mx_quant
+
+
+def test_sparse_prepare_bypasses_fused_qkv_norm_rope_without_capability() -> None:
     source = inspect.getsource(MiniMaxM3SparseAttention._sparse_prepare)
 
     assert "qkv_rmsnorm_rope" in source
-    assert "get_ascend_device_type() == AscendDeviceType.A5" in source
+    assert "MINIMAX_M3_FUSED_QKV_RMSNORM_ROPE" in source
+    assert "not _HARDWARE_PROFILE.supports" in source
     assert 'main_qkv.device.type != "npu"' in source
     assert "1.0 + self.q_norm.weight" in source
 
 
-def test_a5_index_decode_uses_a5_triton_without_tp_block_sharding() -> None:
+def test_triton_index_decode_family_does_not_use_tp_block_sharding() -> None:
     module_source = inspect.getsource(msa_m3_module)
-    a5_branch_start = module_source.index("if not _USE_ASCENDC_INDEX_SCORE:")
-    a5_branch_end = module_source.index("\n\ndef _should_use_tp_sharded_index_decode", a5_branch_start)
-    import_branches = module_source[a5_branch_start:a5_branch_end]
+    triton_branch_start = module_source.index("if not _USE_ASCENDC_INDEX_SCORE:")
+    triton_branch_end = module_source.index("\n\ndef _should_use_tp_sharded_index_decode", triton_branch_start)
+    import_branches = module_source[triton_branch_start:triton_branch_end]
 
     assert import_branches.count("minimax_m3_index_decode") == 1
     assert "msa_m3_triton_a5" in import_branches
     assert "msa_m3_triton" not in import_branches.replace("msa_m3_triton_a5", "")
-    assert "get_ascend_device_type() != AscendDeviceType.A5" in module_source
-    with patch(
-        "vllm_ascend.models.minimax_m3.msa_m3.get_ascend_device_type",
-        return_value=AscendDeviceType.A5,
+    assert "MiniMaxM3IndexerFamily.ASCENDC_SCORE_AND_DECODE_WITH_TRITON_TOPK" in module_source
+    with patch.object(
+        msa_m3_module,
+        "_HARDWARE_PROFILE",
+        _profile_supporting(),
     ):
         assert not _should_use_tp_sharded_index_decode(tp_size=4, num_prefills=0)
 
 
-def test_non_a5_decode_keeps_tp_block_sharding() -> None:
-    with patch(
-        "vllm_ascend.models.minimax_m3.msa_m3.get_ascend_device_type",
-        return_value=AscendDeviceType.A3,
+def test_tp_sharded_index_decode_capability_enables_block_sharding() -> None:
+    with patch.object(
+        msa_m3_module,
+        "_HARDWARE_PROFILE",
+        _profile_supporting(HardwareCapability.MINIMAX_M3_TP_SHARDED_INDEX_DECODE),
     ):
         assert _should_use_tp_sharded_index_decode(tp_size=4, num_prefills=0)
         assert not _should_use_tp_sharded_index_decode(tp_size=1, num_prefills=0)
         assert not _should_use_tp_sharded_index_decode(tp_size=4, num_prefills=1)
 
+    builder_source = inspect.getsource(AscendMiniMaxM3IndexerMetadataBuilder.build)
+    forward_source = inspect.getsource(AscendMiniMaxM3IndexerImpl.forward)
+    assert "_should_use_tp_sharded_index_decode" in builder_source
+    assert forward_source.count("_should_use_tp_sharded_index_decode") == 2
 
-def test_a5_indexer_forward_keeps_original_decode_path() -> None:
+
+def test_sparse_attention_prefill_families_select_exact_implementations() -> None:
+    implementations = msa_m3_npu_module._MINIMAX_M3_SPARSE_ATTN_PREFILL_IMPLS
+
+    assert (
+        implementations[MiniMaxM3SparseAttentionPrefillFamily.SELECT_INDEX_AND_COUNT_SCORE]
+        is msa_m3_npu_module._minimax_m3_sparse_attn_select_count_score
+    )
+    assert (
+        implementations[MiniMaxM3SparseAttentionPrefillFamily.K2Q_CSR_SCORE]
+        is msa_m3_npu_module._minimax_m3_sparse_attn_k2q_csr_score
+    )
+
+
+@pytest.mark.parametrize(
+    "family",
+    [
+        MiniMaxM3SparseAttentionPrefillFamily.SELECT_INDEX_AND_COUNT_SCORE,
+        MiniMaxM3SparseAttentionPrefillFamily.K2Q_CSR_SCORE,
+    ],
+)
+def test_sparse_attention_prefill_wrapper_dispatches_by_family(
+    family: MiniMaxM3SparseAttentionPrefillFamily,
+) -> None:
+    implementations = {
+        MiniMaxM3SparseAttentionPrefillFamily.SELECT_INDEX_AND_COUNT_SCORE: MagicMock(name="select_count_score"),
+        MiniMaxM3SparseAttentionPrefillFamily.K2Q_CSR_SCORE: MagicMock(name="k2q_csr_score"),
+    }
+    args = [
+        MagicMock(name=name)
+        for name in (
+            "q",
+            "kv_cache",
+            "topk_idx",
+            "block_table",
+            "cu_seqlens_q",
+            "seq_lens",
+            "prefix_lens",
+            "output",
+        )
+    ]
+    q, kv_cache, topk_idx, block_table, cu_seqlens_q, seq_lens, prefix_lens, output = args
+
+    with (
+        patch.object(
+            msa_m3_npu_module,
+            "_HARDWARE_PROFILE",
+            SimpleNamespace(minimax_m3_sparse_attention_prefill_family=family),
+        ),
+        patch.object(
+            msa_m3_npu_module,
+            "_MINIMAX_M3_SPARSE_ATTN_PREFILL_IMPLS",
+            implementations,
+        ),
+    ):
+        msa_m3_npu_module.minimax_m3_sparse_attn(
+            q,
+            kv_cache,
+            topk_idx,
+            block_table,
+            cu_seqlens_q,
+            seq_lens,
+            prefix_lens,
+            max_query_len=32,
+            num_kv_heads=2,
+            sm_scale=0.5,
+            output=output,
+            block_size=128,
+        )
+
+    implementations[family].assert_called_once_with(
+        q,
+        kv_cache,
+        topk_idx,
+        block_table,
+        cu_seqlens_q,
+        seq_lens,
+        2,
+        0.5,
+        output,
+        128,
+    )
+    other_family = (
+        MiniMaxM3SparseAttentionPrefillFamily.K2Q_CSR_SCORE
+        if family is MiniMaxM3SparseAttentionPrefillFamily.SELECT_INDEX_AND_COUNT_SCORE
+        else MiniMaxM3SparseAttentionPrefillFamily.SELECT_INDEX_AND_COUNT_SCORE
+    )
+    implementations[other_family].assert_not_called()
+
+
+def test_triton_indexer_forward_keeps_unsharded_decode_path() -> None:
     impl = object.__new__(AscendMiniMaxM3IndexerImpl)
     torch.nn.Module.__init__(impl)
     impl.num_index_heads = 1
@@ -646,7 +1000,7 @@ def test_a5_indexer_forward_keeps_original_decode_path() -> None:
     assert mock_decode.call_args.kwargs == {"sm_scale": impl.scale}
 
 
-def test_a5_indexer_forward_keeps_original_prefill_path() -> None:
+def test_triton_indexer_forward_keeps_score_then_topk_prefill_path() -> None:
     impl = object.__new__(AscendMiniMaxM3IndexerImpl)
     torch.nn.Module.__init__(impl)
     impl.num_index_heads = 1
@@ -735,22 +1089,19 @@ def test_a5_indexer_forward_keeps_original_prefill_path() -> None:
 
 
 @patch(
-    "vllm_ascend.models.minimax_m3.minimax_m3.get_ascend_device_type",
-    return_value=AscendDeviceType.A5,
-)
-@patch(
     "vllm_ascend.models.minimax_m3.minimax_m3.torch_npu.npu_scatter_pa_cache",
     create=True,
 )
-def test_scatter_index_cache_uses_pa_cache_on_a5(
-    mock_scatter_pa_cache: MagicMock,
-    _mock_device_type: MagicMock,
-) -> None:
+def test_scatter_index_cache_uses_paged_scatter_when_supported(mock_scatter_pa_cache: MagicMock) -> None:
     cache = torch.zeros(2, 128, 4, dtype=torch.bfloat16)
     updates = torch.randn(3, 4, dtype=torch.bfloat16)
     slots = torch.tensor([0, 129, -1], dtype=torch.int64)
 
-    _scatter_index_cache(cache, updates, slots)
+    with patch(
+        "vllm_ascend.models.minimax_m3.minimax_m3._HARDWARE_PROFILE",
+        _profile_supporting(HardwareCapability.MINIMAX_M3_PAGED_INDEX_CACHE_SCATTER),
+    ):
+        _scatter_index_cache(cache, updates, slots)
 
     mock_scatter_pa_cache.assert_called_once()
     key, actual_slots = mock_scatter_pa_cache.call_args.args
@@ -764,20 +1115,22 @@ def test_scatter_index_cache_uses_pa_cache_on_a5(
     assert key_cache.data_ptr() == cache.data_ptr()
 
 
-@patch(
-    "vllm_ascend.models.minimax_m3.minimax_m3.get_ascend_device_type",
-    return_value=AscendDeviceType.A2,
-)
-def test_scatter_index_cache_keeps_legacy_op_off_a5(_mock_device_type: MagicMock) -> None:
+def test_scatter_index_cache_uses_flat_scatter_without_paged_capability() -> None:
     cache = torch.zeros(2, 128, 4, dtype=torch.bfloat16)
     updates = torch.randn(3, 4, dtype=torch.bfloat16)
     slots = torch.tensor([0, 1, 2], dtype=torch.int64)
 
-    with patch.object(
-        torch.ops._C_ascend,
-        "npu_scatter_nd_update_v2",
-        create=True,
-    ) as mock_scatter_nd_update:
+    with (
+        patch(
+            "vllm_ascend.models.minimax_m3.minimax_m3._HARDWARE_PROFILE",
+            _profile_supporting(),
+        ),
+        patch.object(
+            torch.ops._C_ascend,
+            "npu_scatter_nd_update_v2",
+            create=True,
+        ) as mock_scatter_nd_update,
+    ):
         _scatter_index_cache(cache, updates, slots)
 
     mock_scatter_nd_update.assert_called_once()

--- a/tests/ut/ops/test_layernorm.py
+++ b/tests/ut/ops/test_layernorm.py
@@ -6,9 +6,9 @@ from vllm.config import set_current_vllm_config
 from vllm.model_executor.layers.layernorm import RMSNorm
 from vllm.third_party.flash_linear_attention.ops.kda import FusedRMSNormGated
 
+from vllm_ascend.device.device_config import is_310p as is_310p_hw
 from vllm_ascend.ops.layernorm import AscendFusedRMSNormGated
 from vllm_ascend.utils import enable_custom_op
-from vllm_ascend.utils import is_310p as is_310p_hw
 
 enable_custom_op()
 

--- a/tests/ut/ops/test_linear.py
+++ b/tests/ut/ops/test_linear.py
@@ -1,4 +1,5 @@
 import unittest
+from types import SimpleNamespace
 from unittest import mock
 from unittest.mock import MagicMock, patch
 
@@ -6,8 +7,10 @@ import torch
 
 from tests.ut.base import TestBase
 from vllm_ascend import ascend_config
+from vllm_ascend.device.hardware_profile import DSAOProjWeightLayoutPolicy
 from vllm_ascend.distributed import parallel_state
 from vllm_ascend.ops.linear import (
+    AscendColumnParallelLinear,
     AscendMergedColumnParallelLinear,
     AscendReplicatedLinear,
     AscendRowParallelLinear,
@@ -86,6 +89,69 @@ class TestAscendUnquantizedLinearMethod(TestBase):
         mock_get_config.return_value = mock_config
         self.method.process_weights_after_loading(self.layer)
         mock_format_cast.assert_called_once()
+
+
+class TestDSAOProjWeightLayoutPolicy(unittest.TestCase):
+    @staticmethod
+    def _make_wo_a_layer(dtype, quant_config=None):
+        layer = AscendColumnParallelLinear.__new__(AscendColumnParallelLinear)
+        torch.nn.Module.__init__(layer)
+        layer.prefix = "model.layers.0.self_attn.wo_a"
+        layer.quant_config = quant_config
+        layer.n_local_groups = 2
+        layer.o_lora_rank = 3
+        layer.tp_rank = 0
+        layer.weight = torch.nn.Parameter(torch.empty((6, 4), dtype=dtype))
+        return layer
+
+    @staticmethod
+    def _base_weight_loader(_layer, param, loaded_weight):
+        param.data.copy_(loaded_weight)
+
+    def test_always_transpose_wo_a_applies_to_quantized_non_bfloat16_weight(self):
+        layer = self._make_wo_a_layer(torch.float16, quant_config=object())
+        loaded_weight = torch.arange(24, dtype=torch.float16).reshape(6, 4)
+        profile = SimpleNamespace(dsa_o_proj_weight_layout_policy=DSAOProjWeightLayoutPolicy.ALWAYS_TRANSPOSE_WO_A)
+
+        with (
+            patch("vllm_ascend.ops.linear.get_current_hardware_profile", return_value=profile),
+            patch(
+                "vllm_ascend.ops.linear.ColumnParallelLinear.weight_loader",
+                new=self._base_weight_loader,
+            ),
+        ):
+            layer.weight_loader(layer.weight, loaded_weight)
+
+        expected = loaded_weight.view(2, 3, 4).transpose(2, 1).contiguous()
+        torch.testing.assert_close(layer.weight, expected)
+
+    def test_transpose_unquantized_wo_a_only_requires_bfloat16_and_no_quantization(self):
+        cases = (
+            (torch.bfloat16, None, True),
+            (torch.float16, None, False),
+            (torch.bfloat16, object(), False),
+        )
+        profile = SimpleNamespace(
+            dsa_o_proj_weight_layout_policy=DSAOProjWeightLayoutPolicy.TRANSPOSE_UNQUANTIZED_BF16_WO_A_ONLY
+        )
+
+        for dtype, quant_config, should_transpose in cases:
+            with self.subTest(dtype=dtype, quantized=quant_config is not None):
+                layer = self._make_wo_a_layer(dtype, quant_config)
+                loaded_weight = torch.arange(24, dtype=dtype).reshape(6, 4)
+                with (
+                    patch("vllm_ascend.ops.linear.get_current_hardware_profile", return_value=profile),
+                    patch(
+                        "vllm_ascend.ops.linear.ColumnParallelLinear.weight_loader",
+                        new=self._base_weight_loader,
+                    ),
+                ):
+                    layer.weight_loader(layer.weight, loaded_weight)
+
+                expected = (
+                    loaded_weight.view(2, 3, 4).transpose(2, 1).contiguous() if should_transpose else loaded_weight
+                )
+                torch.testing.assert_close(layer.weight, expected)
 
 
 class TestAscendRowParallelLinear(BaseLinearTest):

--- a/tests/ut/ops/test_token_dispatcher.py
+++ b/tests/ut/ops/test_token_dispatcher.py
@@ -167,7 +167,7 @@ class TestTokenDispatcherWithMC2(TestBase):
     def test_init(self):
         self.assertEqual(self.dispatcher.ep_rank_id, 0)
         self.assertEqual(self.dispatcher.ep_world_size, 8)
-        self.assertTrue(self.dispatcher.need_extra_args)
+        self.assertTrue(self.dispatcher.uses_tp_metadata)
         self.assertEqual(self.dispatcher.global_bs, 0)
 
     def test_init_uses_mc2_capacity_for_non_uniform_global_bs(self):
@@ -333,7 +333,7 @@ class TestTokenDispatcherWithMC2(TestBase):
             quant=token_dispatch_input.quant,
         )
 
-        self.dispatcher.need_extra_args = True
+        self.dispatcher.uses_tp_metadata = True
         self.dispatcher.enable_dispatch_v2 = True
         self.dispatcher.moe_expert_num = len(expert_map)
         kwargs = self.dispatcher.get_combine_mc_kwargs(hidden_states, combine_metadata)
@@ -345,7 +345,7 @@ class TestTokenDispatcherWithMC2(TestBase):
         topk_weights = torch.randn(10, 1)
         expert_map = torch.tensor([0, 1, 2, 3, 4, 5, 6, 7])
 
-        self.dispatcher.need_shared_expert_args = True
+        self.dispatcher.uses_mxfp_dispatch_metadata = True
         token_dispatch_input = build_token_dispatch_input_fixture(
             hidden_states=hidden_states,
             topk_weights=topk_weights,
@@ -367,7 +367,7 @@ class TestTokenDispatcherWithMC2(TestBase):
         topk_ids = torch.randint(0, 8, (10, 1))
         expert_map = torch.tensor([0, 1, 2, 3, 4, 5, 6, 7])
 
-        self.dispatcher.need_shared_expert_args = True
+        self.dispatcher.uses_mxfp_dispatch_metadata = True
         token_dispatch_input = build_token_dispatch_input_fixture(
             hidden_states=hidden_states,
             topk_weights=topk_weights,

--- a/tests/ut/quantization/methods/test_fp8_block.py
+++ b/tests/ut/quantization/methods/test_fp8_block.py
@@ -23,6 +23,7 @@ import torch.nn as nn
 
 from tests.ut.base import TestBase
 from tests.ut.quantization.conftest_quantization import create_mock_vllm_config
+from vllm_ascend.device.hardware_profile import HardwareCapability
 from vllm_ascend.quantization.methods.w8a8.fp8_block import (
     AscendFp8BlockFusedMoEMethod,
     AscendFp8BlockLinearMethod,
@@ -94,15 +95,18 @@ class TestResolveBlockScales(TestBase):
 
 
 class TestAscendFp8BlockLinearMethod(TestBase):
-    def build_scheme(self, is_950=False, block_size=(128, 128)):
+    def build_scheme(self, supports_mxfp8_requantization=False, block_size=(128, 128)):
+        profile = MagicMock()
+        profile.supports.return_value = supports_mxfp8_requantization
         with (
             patch(f"{MODULE}.get_current_vllm_config", return_value=create_mock_vllm_config()),
-            patch(f"{MODULE}.is_950", return_value=is_950),
+            patch(f"{MODULE}._HARDWARE_PROFILE", profile),
             patch(f"{MODULE}.AscendW8A8MXFP8DynamicLinearMethod") as mock_mxfp8,
         ):
             mock_mxfp8.return_value.dynamic_mx_quant_scale_alg = 0
             mock_mxfp8.return_value.group_size = MX_GROUP_SIZE
             scheme = AscendFp8BlockLinearMethod(block_size)
+        profile.supports.assert_called_once_with(HardwareCapability.BLOCK_FP8_TO_MXFP8_REQUANTIZATION)
         return scheme
 
     def test_get_weight_is_fp8(self):
@@ -136,8 +140,8 @@ class TestAscendFp8BlockLinearMethod(TestBase):
         layer.weight_scale_inv = nn.Parameter(scale_inv, requires_grad=False)
         return layer, weight, scale_inv
 
-    def test_resolves_to_model_dtype_off_950(self):
-        scheme = self.build_scheme(is_950=False, block_size=(4, 32))
+    def test_resolves_to_model_dtype_without_mxfp8_requantization(self):
+        scheme = self.build_scheme(supports_mxfp8_requantization=False, block_size=(4, 32))
         layer, weight, scale_inv = self._make_layer()
 
         with patch(f"{MODULE}.maybe_trans_nz", side_effect=lambda tensor: tensor):
@@ -148,8 +152,8 @@ class TestAscendFp8BlockLinearMethod(TestBase):
         expected = reference_resolve(weight, scale_inv, 4, 32, torch.bfloat16)
         self.assertTrue(torch.equal(layer.weight.data, expected))
 
-    def test_requantizes_to_mxfp8_on_950(self):
-        scheme = self.build_scheme(is_950=True, block_size=(4, 32))
+    def test_requantizes_to_mxfp8_when_supported(self):
+        scheme = self.build_scheme(supports_mxfp8_requantization=True, block_size=(4, 32))
         layer, _, _ = self._make_layer()
         num_groups = 64 // MX_GROUP_SIZE
         quantized = torch.zeros(8, 64).to(torch.float8_e4m3fn)
@@ -172,7 +176,7 @@ class TestAscendFp8BlockLinearMethod(TestBase):
         # SFA splits kv_b_proj into W_UK/W_UV and disposes of the layer, so it
         # never runs a matmul. Requantizing it would only destroy the dense
         # matrix the attention backend has to absorb.
-        scheme = self.build_scheme(is_950=True, block_size=(4, 32))
+        scheme = self.build_scheme(supports_mxfp8_requantization=True, block_size=(4, 32))
         layer, weight, scale_inv = self._make_layer()
         layer.prefix = "model.layers.0.self_attn.kv_b_proj"
 
@@ -188,7 +192,7 @@ class TestAscendFp8BlockLinearMethod(TestBase):
         self.assertTrue(torch.equal(layer.weight.data, expected))
 
     def test_falls_back_when_reduction_dim_is_not_mx_aligned(self):
-        scheme = self.build_scheme(is_950=True, block_size=(4, 32))
+        scheme = self.build_scheme(supports_mxfp8_requantization=True, block_size=(4, 32))
         layer, weight, scale_inv = self._make_layer(out_features=8, in_features=48, block=(4, 32))
 
         with patch(f"{MODULE}.maybe_trans_nz", side_effect=lambda tensor: tensor):
@@ -200,9 +204,9 @@ class TestAscendFp8BlockLinearMethod(TestBase):
         self.assertTrue(torch.equal(layer.weight.data, expected))
 
     def test_mx_fallback_does_not_require_layer_prefix(self):
-        # The 950 MX-aligned path never logs this warning; this only covers the
-        # fallback log so a missing prefix cannot raise AttributeError.
-        scheme = self.build_scheme(is_950=True, block_size=(4, 32))
+        # The MX-aligned requantization path never logs this warning; this only
+        # covers the fallback log so a missing prefix cannot raise AttributeError.
+        scheme = self.build_scheme(supports_mxfp8_requantization=True, block_size=(4, 32))
         layer, _, _ = self._make_layer(out_features=8, in_features=48, block=(4, 32))
         delattr(layer, "prefix")
 
@@ -213,7 +217,7 @@ class TestAscendFp8BlockLinearMethod(TestBase):
         self.assertEqual(layer.weight.dtype, torch.bfloat16)
 
     def test_apply_uses_unquantized_gemm_when_resolved_to_bf16(self):
-        scheme = self.build_scheme(is_950=False)
+        scheme = self.build_scheme(supports_mxfp8_requantization=False)
         scheme.mxfp8_method = None
         layer = nn.Module()
         layer.weight = nn.Parameter(torch.randn(4, 8), requires_grad=False)
@@ -224,7 +228,7 @@ class TestAscendFp8BlockLinearMethod(TestBase):
         mock_gemm.assert_called_once_with(x, layer.weight, None)
 
     def test_apply_delegates_to_mxfp8_when_requantized(self):
-        scheme = self.build_scheme(is_950=True)
+        scheme = self.build_scheme(supports_mxfp8_requantization=True)
         scheme.mxfp8_method.apply.return_value = "mxfp8"
         layer = nn.Module()
         x = torch.randn(2, 8)
@@ -234,15 +238,18 @@ class TestAscendFp8BlockLinearMethod(TestBase):
 
 
 class TestAscendFp8BlockFusedMoEMethod(TestBase):
-    def build_scheme(self, is_950=False, block_size=(4, 32)):
+    def build_scheme(self, supports_mxfp8_requantization=False, block_size=(4, 32)):
+        profile = MagicMock()
+        profile.supports.return_value = supports_mxfp8_requantization
         with (
             patch(f"{MODULE}.get_current_vllm_config", return_value=create_mock_vllm_config()),
-            patch(f"{MODULE}.is_950", return_value=is_950),
+            patch(f"{MODULE}._HARDWARE_PROFILE", profile),
             patch(f"{MODULE}.AscendW8A8MXFP8DynamicFusedMoEMethod") as mock_mxfp8,
         ):
             mock_mxfp8.return_value.dynamic_mx_quant_scale_alg = 0
             mock_mxfp8.return_value.group_size = MX_GROUP_SIZE
             scheme = AscendFp8BlockFusedMoEMethod(block_size, MagicMock())
+        profile.supports.assert_called_once_with(HardwareCapability.BLOCK_FP8_TO_MXFP8_REQUANTIZATION)
         return scheme
 
     def test_weights_are_fp8_and_scales_are_block_shaped(self):
@@ -278,8 +285,8 @@ class TestAscendFp8BlockFusedMoEMethod(TestBase):
         )
         return layer
 
-    def test_resolves_every_expert_off_950(self):
-        scheme = self.build_scheme(is_950=False)
+    def test_resolves_every_expert_without_mxfp8_requantization(self):
+        scheme = self.build_scheme(supports_mxfp8_requantization=False)
         layer = self._make_moe_layer(intermediate=32)
         original_w13 = layer.w13_weight.data.clone()
         original_scale = layer.w13_weight_scale_inv.data.clone()
@@ -296,8 +303,8 @@ class TestAscendFp8BlockFusedMoEMethod(TestBase):
         expected = reference_resolve(original_w13[0], original_scale[0], 4, 32, torch.bfloat16)
         self.assertTrue(torch.equal(layer.w13_weight.data[0], expected))
 
-    def test_requantizes_every_expert_on_950(self):
-        scheme = self.build_scheme(is_950=True)
+    def test_requantizes_every_expert_when_supported(self):
+        scheme = self.build_scheme(supports_mxfp8_requantization=True)
         # Both weights need an even group count so the operator's split layout
         # is representable for each of them.
         layer = self._make_moe_layer(intermediate=64)
@@ -323,7 +330,7 @@ class TestAscendFp8BlockFusedMoEMethod(TestBase):
         scheme.mxfp8_method.process_weights_after_loading.assert_called_once_with(layer)
 
     def test_apply_delegates_to_the_active_method(self):
-        scheme = self.build_scheme(is_950=False)
+        scheme = self.build_scheme(supports_mxfp8_requantization=False)
         scheme._bf16_method = MagicMock()
         scheme._bf16_method.apply.return_value = "bf16"
         layer = nn.Module()

--- a/tests/ut/test_platform.py
+++ b/tests/ut/test_platform.py
@@ -11,6 +11,7 @@ from vllm.v1.attention.selector import AttentionSelectorConfig  # type: ignore
 
 from tests.ut.base import TestBase
 from vllm_ascend.ascend_forward_context import MoECommType, override_mrv2_in_profile_run
+from vllm_ascend.device.hardware import AscendDeviceType
 from vllm_ascend.device.hardware_profile import get_hardware_profile
 from vllm_ascend.platform import (
     NPUPlatform,
@@ -18,11 +19,7 @@ from vllm_ascend.platform import (
     _validate_eplb_config,
     _validate_sfa_dcp_kv_sp,
 )
-from vllm_ascend.utils import (
-    ASCEND_QUANTIZATION_METHOD,
-    COMPRESSED_TENSORS_METHOD,
-    AscendDeviceType,
-)
+from vllm_ascend.utils import ASCEND_QUANTIZATION_METHOD, COMPRESSED_TENSORS_METHOD
 
 
 class TestNPUPlatform(TestBase):
@@ -633,6 +630,49 @@ class TestNPUPlatform(TestBase):
                     vllm_config.update_sizes_for_sequence_parallelism.assert_not_called()
                     self.assertEqual(compilation_config.cudagraph_capture_sizes, [1, 2, 4, 8])
 
+    def test_setup_compile_backend_honors_cudagraph_capture_size_limit(self):
+        cases = (
+            ([1, 2, 4, 8, 16, 32], [1, 4, 8, 32], True),
+            ([1, 2, 4, 8], [1, 2, 4, 8], False),
+        )
+        profile = SimpleNamespace(cudagraph_capture_size_limit=4)
+
+        for original_sizes, expected_sizes, should_prune in cases:
+            with self.subTest(original_sizes=original_sizes):
+                vllm_config = TestNPUPlatform.mock_vllm_config()
+                compilation_config = vllm_config.compilation_config
+                compilation_config.mode = CompilationMode.VLLM_COMPILE
+                compilation_config.cudagraph_mode = CUDAGraphMode.PIECEWISE
+                compilation_config.cudagraph_capture_sizes = list(original_sizes)
+                compilation_config.max_cudagraph_capture_size = original_sizes[-1]
+                compilation_config.splitting_ops = []
+                compilation_config.post_init_cudagraph_sizes = MagicMock()
+                vllm_config.additional_config = {
+                    "ascend_compilation_config": {
+                        "enable_npugraph_ex": True,
+                        "enable_static_kernel": True,
+                    }
+                }
+                vllm_config.model_config.enforce_eager = False
+                vllm_config.parallel_config.tensor_parallel_size = 1
+                vllm_config._set_cudagraph_sizes = MagicMock()
+
+                with (
+                    patch.dict("os.environ", {}, clear=True),
+                    patch("vllm_ascend.platform.enable_sp", return_value=False),
+                    patch(
+                        "vllm_ascend.platform.get_current_hardware_profile",
+                        return_value=profile,
+                    ),
+                ):
+                    _setup_compile_backend(vllm_config, compile_backend="test_backend")
+
+                self.assertEqual(compilation_config.cudagraph_capture_sizes, expected_sizes)
+                if should_prune:
+                    compilation_config.post_init_cudagraph_sizes.assert_called_once()
+                else:
+                    compilation_config.post_init_cudagraph_sizes.assert_not_called()
+
     def test_get_device_capability(self):
         self.assertIsNone(self.platform.get_device_capability(device_id=0))
 
@@ -738,7 +778,7 @@ class TestNPUPlatform(TestBase):
     @patch("os.environ", {})
     @patch("vllm_ascend.core.recompute_scheduler.RecomputeSchedulerConfig.initialize_from_config")
     def test_check_and_update_config_basic_config_update(
-        self, mock_init_recompute, mock_soc_version, mock_init_ascend, mock_auto_detect
+        self, mock_init_recompute, _mock_hardware_profile, mock_init_ascend, mock_auto_detect
     ):
         mock_init_ascend.return_value = TestNPUPlatform.mock_vllm_ascend_config()
         vllm_config = TestNPUPlatform.mock_vllm_config()
@@ -770,7 +810,7 @@ class TestNPUPlatform(TestBase):
     @patch("vllm_ascend.ascend_config.init_ascend_config")
     @patch("vllm_ascend.core.recompute_scheduler.RecomputeSchedulerConfig.initialize_from_config")
     def test_check_and_update_config_no_model_config_warning(
-        self, mock_init_recompute, mock_init_ascend, mock_soc_version, mock_auto_detect
+        self, mock_init_recompute, mock_init_ascend, _mock_hardware_profile, mock_auto_detect
     ):
         mock_init_ascend.return_value = TestNPUPlatform.mock_vllm_ascend_config()
         vllm_config = TestNPUPlatform.mock_vllm_config()
@@ -802,7 +842,7 @@ class TestNPUPlatform(TestBase):
     @patch("vllm_ascend.ascend_config.init_ascend_config")
     @patch("vllm_ascend.core.recompute_scheduler.RecomputeSchedulerConfig.initialize_from_config")
     def test_check_and_update_config_enforce_eager_mode(
-        self, mock_init_recompute, mock_init_ascend, mock_soc_version, mock_auto_detect
+        self, mock_init_recompute, mock_init_ascend, _mock_hardware_profile, mock_auto_detect
     ):
         mock_init_ascend.return_value = TestNPUPlatform.mock_vllm_ascend_config()
         vllm_config = TestNPUPlatform.mock_vllm_config()
@@ -847,7 +887,7 @@ class TestNPUPlatform(TestBase):
     @patch("vllm_ascend.ascend_config.init_ascend_config")
     @patch("vllm_ascend.core.recompute_scheduler.RecomputeSchedulerConfig.initialize_from_config")
     def test_check_and_update_config_unsupported_compilation_level(
-        self, mock_init_recompute, mock_init_ascend, mock_soc_version, mock_auto_detect
+        self, mock_init_recompute, mock_init_ascend, _mock_hardware_profile, mock_auto_detect
     ):
         mock_init_ascend.return_value = TestNPUPlatform.mock_vllm_ascend_config()
         vllm_config = TestNPUPlatform.mock_vllm_config()
@@ -890,7 +930,7 @@ class TestNPUPlatform(TestBase):
     )
     @patch("vllm_ascend.ascend_config.init_ascend_config")
     def test_check_and_update_config_unsupported_cudagraph_mode(
-        self, mock_init_ascend, mock_soc_version, mock_auto_detect
+        self, mock_init_ascend, _mock_hardware_profile, mock_auto_detect
     ):
         mock_init_ascend.return_value = TestNPUPlatform.mock_vllm_ascend_config()
         vllm_config = TestNPUPlatform.mock_vllm_config()
@@ -921,7 +961,7 @@ class TestNPUPlatform(TestBase):
     @patch("vllm_ascend.ascend_config.init_ascend_config")
     @patch("vllm_ascend.core.recompute_scheduler.RecomputeSchedulerConfig.initialize_from_config")
     def test_check_and_update_config_cache_config_block_size(
-        self, mock_init_recompute, mock_init_ascend, mock_soc_version, mock_auto_detect
+        self, mock_init_recompute, mock_init_ascend, _mock_hardware_profile, mock_auto_detect
     ):
         mock_init_ascend.return_value = TestNPUPlatform.mock_vllm_ascend_config()
         vllm_config = TestNPUPlatform.mock_vllm_config()
@@ -949,7 +989,7 @@ class TestNPUPlatform(TestBase):
     @patch("vllm_ascend.ascend_config.init_ascend_config")
     @patch("vllm_ascend.core.recompute_scheduler.RecomputeSchedulerConfig.initialize_from_config")
     def test_check_and_update_config_recompute_scheduler_rejects_pd_mixed_no_kv_transfer(
-        self, mock_init_recompute, mock_init_ascend, mock_soc_version, mock_auto_detect
+        self, mock_init_recompute, mock_init_ascend, _mock_hardware_profile, mock_auto_detect
     ):
         mock_ascend_config = TestNPUPlatform.mock_vllm_ascend_config()
         mock_ascend_config.scheduler_config.recompute_scheduler_enable = True
@@ -984,7 +1024,7 @@ class TestNPUPlatform(TestBase):
     @patch("vllm_ascend.ascend_config.init_ascend_config")
     @patch("vllm_ascend.core.recompute_scheduler.RecomputeSchedulerConfig.initialize_from_config")
     def test_check_and_update_config_recompute_scheduler_rejects_pd_mixed_kv_both(
-        self, mock_init_recompute, mock_init_ascend, mock_soc_version, mock_auto_detect
+        self, mock_init_recompute, mock_init_ascend, _mock_hardware_profile, mock_auto_detect
     ):
         mock_ascend_config = TestNPUPlatform.mock_vllm_ascend_config()
         mock_ascend_config.scheduler_config.recompute_scheduler_enable = True
@@ -1020,7 +1060,7 @@ class TestNPUPlatform(TestBase):
     @patch("vllm_ascend.ascend_config.init_ascend_config")
     @patch("vllm_ascend.core.recompute_scheduler.RecomputeSchedulerConfig.initialize_from_config")
     def test_check_and_update_config_recompute_scheduler_warns_and_disables_kv_producer(
-        self, mock_init_recompute, mock_init_ascend, mock_soc_version, mock_auto_detect
+        self, mock_init_recompute, mock_init_ascend, _mock_hardware_profile, mock_auto_detect
     ):
         mock_ascend_config = TestNPUPlatform.mock_vllm_ascend_config()
         mock_ascend_config.scheduler_config.recompute_scheduler_enable = True
@@ -1065,7 +1105,7 @@ class TestNPUPlatform(TestBase):
     @patch("vllm_ascend.ascend_config.init_ascend_config")
     @patch("vllm_ascend.core.recompute_scheduler.RecomputeSchedulerConfig.initialize_from_config")
     def test_check_and_update_config_recompute_scheduler_accepts_kv_consumer(
-        self, mock_init_recompute, mock_init_ascend, mock_soc_version, mock_auto_detect
+        self, mock_init_recompute, mock_init_ascend, _mock_hardware_profile, mock_auto_detect
     ):
         mock_ascend_config = TestNPUPlatform.mock_vllm_ascend_config()
         mock_ascend_config.scheduler_config.recompute_scheduler_enable = True
@@ -1104,14 +1144,12 @@ class TestNPUPlatform(TestBase):
         )
 
     @patch("vllm_ascend.quantization.utils.maybe_auto_detect_quantization")
-    @patch("vllm_ascend.utils.get_ascend_device_type", return_value=AscendDeviceType.A3)
     @patch("vllm_ascend.ascend_config.init_ascend_config")
     @patch("vllm_ascend.core.recompute_scheduler.RecomputeSchedulerConfig.initialize_from_config")
     def test_check_and_update_config_selects_dyntra_lb_recompute_scheduler(
         self,
         mock_init_recompute,
         mock_init_ascend,
-        mock_soc_version,
         mock_auto_detect,
     ):
         cases = (
@@ -1168,7 +1206,7 @@ class TestNPUPlatform(TestBase):
     )
     @patch("vllm_ascend.ascend_config.init_ascend_config")
     def test_check_and_update_config_short_request_first_rejects_unsupported_combinations(
-        self, mock_init_ascend, mock_soc_version, mock_auto_detect
+        self, mock_init_ascend, _mock_hardware_profile, mock_auto_detect
     ):
         from vllm_ascend import platform
 
@@ -1222,7 +1260,7 @@ class TestNPUPlatform(TestBase):
     )
     @patch("vllm_ascend.ascend_config.init_ascend_config")
     def test_check_and_update_config_short_request_first_accepts_standard_prefill_paths(
-        self, mock_init_ascend, mock_soc_version, mock_auto_detect
+        self, mock_init_ascend, _mock_hardware_profile, mock_auto_detect
     ):
         from vllm_ascend import platform
 
@@ -1254,7 +1292,7 @@ class TestNPUPlatform(TestBase):
     )
     @patch("vllm_ascend.ascend_config.init_ascend_config")
     def test_check_and_update_config_short_request_first_selects_async_scheduler(
-        self, mock_init_ascend, mock_soc_version, mock_auto_detect
+        self, mock_init_ascend, _mock_hardware_profile, mock_auto_detect
     ):
         from vllm_ascend import platform
 
@@ -1291,7 +1329,7 @@ class TestNPUPlatform(TestBase):
     @patch("vllm_ascend.ascend_config.init_ascend_config")
     @patch("vllm_ascend.core.recompute_scheduler.RecomputeSchedulerConfig.initialize_from_config")
     def test_check_and_update_config_short_request_first_survives_p_recompute_disable(
-        self, mock_init_recompute, mock_init_ascend, mock_soc_version, mock_auto_detect
+        self, mock_init_recompute, mock_init_ascend, _mock_hardware_profile, mock_auto_detect
     ):
         ascend_config = TestNPUPlatform.mock_vllm_ascend_config()
         ascend_config.scheduler_config.short_request_first_config.enabled = True
@@ -1334,7 +1372,7 @@ class TestNPUPlatform(TestBase):
     )
     @patch("vllm_ascend.ascend_config.init_ascend_config")
     def test_check_and_update_config_selects_dyntra_lb_scheduler(
-        self, mock_init_ascend, mock_soc_version, mock_auto_detect
+        self, mock_init_ascend, _mock_hardware_profile, mock_auto_detect
     ):
         mock_ascend_config = TestNPUPlatform.mock_vllm_ascend_config()
         mock_ascend_config.scheduler_config.dyntra_lb_config.enabled = True
@@ -1389,10 +1427,9 @@ class TestNPUPlatform(TestBase):
                 )
 
     @patch("vllm_ascend.quantization.utils.maybe_auto_detect_quantization")
-    @patch("vllm_ascend.utils.get_ascend_device_type", return_value=AscendDeviceType.A3)
     @patch("vllm_ascend.ascend_config.init_ascend_config")
     def test_check_and_update_config_rejects_dyntra_lb_outside_disaggregated_d_node(
-        self, mock_init_ascend, mock_soc_version, mock_auto_detect
+        self, mock_init_ascend, mock_auto_detect
     ):
         for kv_role in (None, "kv_both", "kv_producer"):
             with self.subTest(kv_role=kv_role):
@@ -1427,11 +1464,8 @@ class TestNPUPlatform(TestBase):
                     self.platform.check_and_update_config(vllm_config)
 
     @patch("vllm_ascend.quantization.utils.maybe_auto_detect_quantization")
-    @patch("vllm_ascend.utils.get_ascend_device_type", return_value=AscendDeviceType.A3)
     @patch("vllm_ascend.ascend_config.init_ascend_config")
-    def test_check_and_update_config_rejects_multinode_dyntra_lb_decoder(
-        self, mock_init_ascend, mock_soc_version, mock_auto_detect
-    ):
+    def test_check_and_update_config_rejects_multinode_dyntra_lb_decoder(self, mock_init_ascend, mock_auto_detect):
         mock_ascend_config = TestNPUPlatform.mock_vllm_ascend_config()
         mock_ascend_config.scheduler_config.dyntra_lb_config.enabled = True
         mock_init_ascend.return_value = mock_ascend_config
@@ -1460,11 +1494,10 @@ class TestNPUPlatform(TestBase):
             self.platform.check_and_update_config(vllm_config)
 
     @patch("vllm_ascend.quantization.utils.maybe_auto_detect_quantization")
-    @patch("vllm_ascend.utils.get_ascend_device_type", return_value=AscendDeviceType.A3)
     @patch("vllm_ascend.ascend_config.init_ascend_config")
     @patch("vllm_ascend.core.recompute_scheduler.RecomputeSchedulerConfig.initialize_from_config")
     def test_check_and_update_config_balance_scheduler_rejects_pd_disaggregated_kv_producer(
-        self, mock_init_recompute, mock_init_ascend, mock_soc_version, mock_auto_detect
+        self, mock_init_recompute, mock_init_ascend, mock_auto_detect
     ):
         mock_ascend_config = TestNPUPlatform.mock_vllm_ascend_config()
         mock_ascend_config.scheduler_config.recompute_scheduler_enable = False
@@ -1499,7 +1532,7 @@ class TestNPUPlatform(TestBase):
     @patch("vllm_ascend.ascend_config.init_ascend_config")
     @patch("vllm_ascend.core.recompute_scheduler.RecomputeSchedulerConfig.initialize_from_config")
     def test_check_and_update_config_balance_scheduler_rejects_pd_disaggregated_kv_consumer(
-        self, mock_init_recompute, mock_init_ascend, mock_soc_version, mock_auto_detect
+        self, mock_init_recompute, mock_init_ascend, _mock_hardware_profile, mock_auto_detect
     ):
         mock_ascend_config = TestNPUPlatform.mock_vllm_ascend_config()
         mock_ascend_config.scheduler_config.recompute_scheduler_enable = False
@@ -1590,7 +1623,7 @@ class TestNPUPlatform(TestBase):
     @patch("vllm_ascend.ascend_config.init_ascend_config")
     @patch("vllm_ascend.core.recompute_scheduler.RecomputeSchedulerConfig.initialize_from_config")
     def test_check_and_update_config_v1_worker_class_selection(
-        self, mock_init_recompute, mock_init_ascend, mock_soc_version, mock_auto_detect
+        self, mock_init_recompute, mock_init_ascend, _mock_hardware_profile, mock_auto_detect
     ):
         mock_init_ascend.return_value = TestNPUPlatform.mock_vllm_ascend_config()
         vllm_config = TestNPUPlatform.mock_vllm_config()
@@ -1629,7 +1662,7 @@ class TestNPUPlatform(TestBase):
     )
     @patch("vllm_ascend.core.recompute_scheduler.RecomputeSchedulerConfig.initialize_from_config")
     def test_check_and_update_config_310p_no_custom_ops(
-        self, mock_init_recompute, mock_soc_version, mock_init_ascend, mock_auto_detect
+        self, mock_init_recompute, _mock_hardware_profile, mock_init_ascend, mock_auto_detect
     ):
         mock_init_ascend.return_value = TestNPUPlatform.mock_vllm_ascend_config()
         vllm_config = TestNPUPlatform.mock_vllm_config()

--- a/tests/ut/worker/test_model_runner_v1.py
+++ b/tests/ut/worker/test_model_runner_v1.py
@@ -25,8 +25,8 @@ from vllm.v1.worker.gpu_model_runner import GPUModelRunner
 from vllm_ascend.attention.mla_v1 import AscendMLABackend
 from vllm_ascend.attention.utils import get_sfa_qsfa_packed_head_dim
 from vllm_ascend.core.kv_cache_interface import AscendMLAAttentionSpec, AscendSFAIndexerCacheSpec
+from vllm_ascend.device.hardware import AscendDeviceType
 from vllm_ascend.device.hardware_profile import get_hardware_profile
-from vllm_ascend.utils import AscendDeviceType
 from vllm_ascend.worker.model_runner_v1 import NPUModelRunner
 
 

--- a/tools/check_hardware_identity.py
+++ b/tools/check_hardware_identity.py
@@ -1,0 +1,855 @@
+#!/usr/bin/env python3
+#
+# Copyright (c) 2026 Huawei Technologies Co., Ltd. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# This file is a part of the vllm-ascend project.
+#
+"""Forbid Ascend hardware-identity decisions outside the HAL boundary.
+
+Production code should select hardware-dependent behavior through
+``HardwareCapability`` or a profile policy/family. Only detection, identity
+mapping, and profile registration may interpret a concrete Ascend family.
+Generic platform introspection may report a device name, but business code
+must not use that value to choose an implementation.
+
+This check intentionally targets explicit identity access. Deliberately
+disguised or inter-procedural identity logic still requires code review.
+"""
+
+import ast
+import re
+import subprocess
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+PRODUCTION_PACKAGE = "vllm_ascend"
+
+# These paths are generated build metadata or staged vendor operator sources,
+# not Python business logic. They are ignored by Git and may appear only after
+# a local build, so they must not make the full-tree pre-commit check unstable.
+NON_BUSINESS_PYTHON_FILES = frozenset({"vllm_ascend/_build_info.py"})
+NON_BUSINESS_PYTHON_PREFIXES = ("vllm_ascend/_cann_ops_custom/",)
+
+# Keep this boundary file-specific. Allowing a directory would let unrelated
+# business logic placed beside the HAL silently bypass the guard.
+ALLOWED_IDENTITY_FILES = frozenset(
+    {
+        "vllm_ascend/device/device_config.py",
+        "vllm_ascend/device/hardware.py",
+        "vllm_ascend/device/hardware_profile.py",
+    }
+)
+
+ENV_CONFIG_FILE = "vllm_ascend/envs.py"
+SOC_VERSION_ENV_KEY = "SOC_VERSION"
+
+RAW_IDENTITY_NAMES = frozenset(
+    {
+        "AscendDeviceType",
+        "get_ascend_device_type",
+        "is_310p",
+        "is_950",
+        "device_type_from_runtime_soc",
+        "device_type_from_soc_version",
+    }
+)
+IDENTITY_MODULES = frozenset(
+    {
+        "vllm_ascend.device.device_config",
+        "vllm_ascend.device.hardware",
+    }
+)
+NON_IDENTITY_NAMES = frozenset({"check_ascend_device_type"})
+
+_DEVICE_PREDICATE_RE = re.compile(
+    r"^is_(?:ascend_?)?(?:310p\d*(?:vir\d+)?|950[a-z0-9]*|910[a-z0-9]*|a[235])(?:_[a-z0-9_]+)?$",
+    re.IGNORECASE,
+)
+_SOC_NAME_RE = re.compile(r"(?:^|_)soc(?:_|$)", re.IGNORECASE)
+_DEVICE_IDENTITY_LITERAL_RE = re.compile(
+    r"^(?:_310p|(?:ascend)?(?:310p\d*(?:vir\d+)?|910[a-z0-9_-]*|950[a-z0-9_-]*|a[235]))$",
+    re.IGNORECASE,
+)
+_STRING_IDENTITY_PREDICATES = frozenset({"startswith", "endswith"})
+
+
+@dataclass(frozen=True, order=True)
+class Violation:
+    line: int
+    column: int
+    code: str
+    message: str
+
+    def format(self, path: str) -> str:
+        return f"{path}:{self.line}:{self.column}: {self.code} {self.message}"
+
+
+def _normalized_repo_path(filepath: str | Path) -> str | None:
+    path = Path(filepath)
+    try:
+        resolved = path.resolve()
+        relative = resolved.relative_to(REPO_ROOT)
+    except (OSError, ValueError):
+        return None
+    return relative.as_posix()
+
+
+def _normalized_source_path(relative_path: str | Path) -> str:
+    return str(relative_path).replace("\\", "/").lstrip("./")
+
+
+def _is_production_python(path: str) -> bool:
+    parts = path.split("/")
+    return (
+        len(parts) > 1
+        and parts[0] == PRODUCTION_PACKAGE
+        and path.endswith(".py")
+        and path not in NON_BUSINESS_PYTHON_FILES
+        and not path.startswith(NON_BUSINESS_PYTHON_PREFIXES)
+    )
+
+
+def _default_python_paths() -> list[Path]:
+    """Return tracked production Python sources, with a source-tree fallback."""
+    try:
+        tracked = subprocess.run(
+            ["git", "ls-files", "-z", "--", PRODUCTION_PACKAGE],
+            cwd=REPO_ROOT,
+            check=False,
+            capture_output=True,
+        )
+    except OSError:
+        tracked = None
+
+    if tracked is not None and tracked.returncode == 0:
+        relative_paths = tracked.stdout.decode("utf-8", errors="surrogateescape").split("\0")
+        return [REPO_ROOT / path for path in relative_paths if _is_production_python(path)]
+
+    return sorted(
+        path
+        for path in (REPO_ROOT / PRODUCTION_PACKAGE).rglob("*.py")
+        if _is_production_python(_normalized_repo_path(path) or "")
+    )
+
+
+def _identifier_code(identifier: str) -> str | None:
+    if identifier in NON_IDENTITY_NAMES:
+        return None
+
+    lowered = identifier.casefold()
+    if lowered in {"_device_type", "__device_type__"}:
+        return "HDI003"
+    if (
+        identifier in RAW_IDENTITY_NAMES
+        or "ascend_device_type" in lowered
+        or _DEVICE_PREDICATE_RE.fullmatch(identifier)
+    ):
+        return "HDI001"
+    if "soc_version" in lowered or _SOC_NAME_RE.search(identifier) or lowered in {"get_soc_version", "__soc_version__"}:
+        return "HDI002"
+    return None
+
+
+def _message(code: str, identifier: str) -> str:
+    if code == "HDI001":
+        subject = "raw Ascend device identity"
+    elif code == "HDI002":
+        subject = "raw SoC identity"
+    elif code == "HDI003":
+        subject = "private detected device identity"
+    elif code == "HDI005":
+        subject = "concrete device-family literal"
+    else:
+        subject = "dynamic raw hardware identity"
+    return (
+        f"{subject} `{identifier}` is forbidden outside the HAL boundary; "
+        "query HardwareCapability or a profile policy/family instead"
+    )
+
+
+def _dotted_name(node: ast.expr) -> str | None:
+    parts: list[str] = []
+    current: ast.expr = node
+    while isinstance(current, ast.Attribute):
+        parts.append(current.attr)
+        current = current.value
+    if not isinstance(current, ast.Name):
+        return None
+    parts.append(current.id)
+    return ".".join(reversed(parts))
+
+
+def _string_literal(node: ast.expr) -> str | None:
+    if isinstance(node, ast.Constant) and isinstance(node.value, str):
+        return node.value
+    return None
+
+
+def _device_identity_literals(node: ast.AST) -> list[ast.Constant]:
+    return [
+        candidate
+        for candidate in ast.walk(node)
+        if isinstance(candidate, ast.Constant)
+        and isinstance(candidate.value, str)
+        and _DEVICE_IDENTITY_LITERAL_RE.fullmatch(candidate.value.strip())
+    ]
+
+
+def _resolve_import_from(node: ast.ImportFrom, source_path: str) -> str:
+    if node.level == 0:
+        return node.module or ""
+
+    path_parts = source_path.split("/")
+    package_parts = path_parts[:-1]
+    if path_parts[-1] == "__init__.py":
+        package_parts = path_parts[:-1]
+    trim = node.level - 1
+    if trim:
+        package_parts = package_parts[:-trim]
+    if node.module:
+        package_parts.extend(node.module.split("."))
+    return ".".join(package_parts)
+
+
+def _is_exact_env_declaration(node: ast.Call, tree: ast.AST, path: str) -> bool:
+    """Allow only envs.py's existing lazy declaration of SOC_VERSION."""
+    if path != ENV_CONFIG_FILE or _dotted_name(node.func) != "os.getenv":
+        return False
+    if not node.args or _string_literal(node.args[0]) != SOC_VERSION_ENV_KEY:
+        return False
+
+    if not isinstance(tree, ast.Module):
+        return False
+    for statement in tree.body:
+        if (
+            not isinstance(statement, ast.AnnAssign)
+            or not isinstance(statement.target, ast.Name)
+            or statement.target.id != "env_variables"
+            or not isinstance(statement.value, ast.Dict)
+        ):
+            continue
+        for key, value in zip(statement.value.keys, statement.value.values):
+            if (
+                key is not None
+                and _string_literal(key) == SOC_VERSION_ENV_KEY
+                and isinstance(value, ast.Lambda)
+                and value.body is node
+            ):
+                return True
+    return False
+
+
+@dataclass
+class _EnvironmentAliasState:
+    os_aliases: set[str]
+    getenv_aliases: set[str]
+    environ_aliases: set[str]
+
+    def copy(self) -> "_EnvironmentAliasState":
+        return _EnvironmentAliasState(
+            set(self.os_aliases),
+            set(self.getenv_aliases),
+            set(self.environ_aliases),
+        )
+
+
+def _bound_target_names(target: ast.expr) -> set[str]:
+    if isinstance(target, ast.Name):
+        return {target.id}
+    if isinstance(target, (ast.List, ast.Tuple)):
+        return {name for element in target.elts for name in _bound_target_names(element)}
+    return set()
+
+
+class _ScopeAliasCollector(ast.NodeVisitor):
+    """Collect aliases in one lexical scope without entering nested scopes."""
+
+    def __init__(
+        self,
+        parameter_names: set[str],
+        parameter_defaults: list[tuple[str, ast.expr]],
+    ) -> None:
+        self.bound_names = set(parameter_names)
+        self.parameter_defaults = list(parameter_defaults)
+        self.os_imports: set[str] = set()
+        self.getenv_imports: set[str] = set()
+        self.environ_imports: set[str] = set()
+        self.assignments: list[tuple[str, ast.expr]] = []
+
+    def _record_assignment(self, target: ast.expr, value: ast.expr) -> None:
+        if isinstance(value, ast.NamedExpr):
+            self._record_assignment(value.target, value.value)
+            value = value.value
+        names = _bound_target_names(target)
+        self.bound_names.update(names)
+        if len(names) == 1 and isinstance(target, ast.Name):
+            self.assignments.append((target.id, value))
+        elif (
+            isinstance(target, (ast.List, ast.Tuple))
+            and isinstance(value, (ast.List, ast.Tuple))
+            and len(target.elts) == len(value.elts)
+        ):
+            for element, element_value in zip(target.elts, value.elts):
+                self._record_assignment(element, element_value)
+
+    def visit_Import(self, node: ast.Import) -> None:
+        for alias in node.names:
+            bound_name = alias.asname or alias.name.split(".", 1)[0]
+            self.bound_names.add(bound_name)
+            if alias.name == "os" or (alias.asname is None and alias.name.startswith("os.")):
+                self.os_imports.add(bound_name)
+
+    def visit_ImportFrom(self, node: ast.ImportFrom) -> None:
+        for alias in node.names:
+            if alias.name == "*":
+                if node.level == 0 and node.module == "os":
+                    self.getenv_imports.add("getenv")
+                    self.environ_imports.add("environ")
+                continue
+            bound_name = alias.asname or alias.name
+            self.bound_names.add(bound_name)
+            if node.level == 0 and node.module == "os":
+                if alias.name == "getenv":
+                    self.getenv_imports.add(bound_name)
+                elif alias.name == "environ":
+                    self.environ_imports.add(bound_name)
+
+    def visit_Assign(self, node: ast.Assign) -> None:
+        for target in node.targets:
+            self._record_assignment(target, node.value)
+
+    def visit_AnnAssign(self, node: ast.AnnAssign) -> None:
+        self.bound_names.update(_bound_target_names(node.target))
+        if node.value is not None:
+            self._record_assignment(node.target, node.value)
+
+    def visit_NamedExpr(self, node: ast.NamedExpr) -> None:
+        self._record_assignment(node.target, node.value)
+
+    def _visit_for(self, node: ast.For | ast.AsyncFor) -> None:
+        self.bound_names.update(_bound_target_names(node.target))
+        self.generic_visit(node)
+
+    def visit_For(self, node: ast.For) -> None:
+        self._visit_for(node)
+
+    def visit_AsyncFor(self, node: ast.AsyncFor) -> None:
+        self._visit_for(node)
+
+    def _visit_with(self, node: ast.With | ast.AsyncWith) -> None:
+        for item in node.items:
+            if item.optional_vars is not None:
+                self.bound_names.update(_bound_target_names(item.optional_vars))
+        self.generic_visit(node)
+
+    def visit_With(self, node: ast.With) -> None:
+        self._visit_with(node)
+
+    def visit_AsyncWith(self, node: ast.AsyncWith) -> None:
+        self._visit_with(node)
+
+    def visit_ExceptHandler(self, node: ast.ExceptHandler) -> None:
+        if node.name is not None:
+            self.bound_names.add(node.name)
+        self.generic_visit(node)
+
+    def visit_FunctionDef(self, node: ast.FunctionDef) -> None:
+        self.bound_names.add(node.name)
+
+    def visit_AsyncFunctionDef(self, node: ast.AsyncFunctionDef) -> None:
+        self.bound_names.add(node.name)
+
+    def visit_ClassDef(self, node: ast.ClassDef) -> None:
+        self.bound_names.add(node.name)
+
+    def visit_Lambda(self, node: ast.Lambda) -> None:
+        return
+
+
+def _parameter_names(arguments: ast.arguments) -> set[str]:
+    parameters = [*arguments.posonlyargs, *arguments.args, *arguments.kwonlyargs]
+    if arguments.vararg is not None:
+        parameters.append(arguments.vararg)
+    if arguments.kwarg is not None:
+        parameters.append(arguments.kwarg)
+    return {parameter.arg for parameter in parameters}
+
+
+def _parameter_defaults(arguments: ast.arguments) -> list[tuple[str, ast.expr]]:
+    positional = [*arguments.posonlyargs, *arguments.args]
+    defaults = list(zip(positional[-len(arguments.defaults) :], arguments.defaults)) if arguments.defaults else []
+    defaults.extend(
+        (parameter, default)
+        for parameter, default in zip(arguments.kwonlyargs, arguments.kw_defaults)
+        if default is not None
+    )
+    return [(parameter.arg, default) for parameter, default in defaults]
+
+
+def _collect_scope_aliases(
+    nodes: list[ast.stmt] | list[ast.expr],
+    inherited: _EnvironmentAliasState,
+    *,
+    parameter_names: set[str] | None = None,
+    parameter_defaults: list[tuple[str, ast.expr]] | None = None,
+) -> _EnvironmentAliasState:
+    collector = _ScopeAliasCollector(
+        parameter_names or set(),
+        parameter_defaults or [],
+    )
+    for node in nodes:
+        collector.visit(node)
+
+    def is_os_module(
+        node: ast.expr,
+        aliases: _EnvironmentAliasState,
+    ) -> bool:
+        if isinstance(node, ast.NamedExpr):
+            return is_os_module(node.value, aliases)
+        return isinstance(node, ast.Name) and node.id in aliases.os_aliases
+
+    def is_environ(
+        node: ast.expr,
+        aliases: _EnvironmentAliasState,
+    ) -> bool:
+        if isinstance(node, ast.NamedExpr):
+            return is_environ(node.value, aliases)
+        return (
+            isinstance(node, ast.Name)
+            and node.id in aliases.environ_aliases
+            or (isinstance(node, ast.Attribute) and node.attr == "environ" and is_os_module(node.value, aliases))
+        )
+
+    def is_getenv(
+        node: ast.expr,
+        aliases: _EnvironmentAliasState,
+    ) -> bool:
+        if isinstance(node, ast.NamedExpr):
+            return is_getenv(node.value, aliases)
+        return (
+            isinstance(node, ast.Name)
+            and node.id in aliases.getenv_aliases
+            or (isinstance(node, ast.Attribute) and node.attr == "getenv" and is_os_module(node.value, aliases))
+            or (isinstance(node, ast.Attribute) and node.attr == "get" and is_environ(node.value, aliases))
+        )
+
+    state = inherited.copy()
+    state.os_aliases.difference_update(collector.bound_names)
+    state.getenv_aliases.difference_update(collector.bound_names)
+    state.environ_aliases.difference_update(collector.bound_names)
+    state.os_aliases.update(collector.os_imports)
+    state.getenv_aliases.update(collector.getenv_imports)
+    state.environ_aliases.update(collector.environ_imports)
+
+    # Function defaults are evaluated in the enclosing scope, before their
+    # parameter names shadow an outer alias with the same spelling.
+    for target, value in collector.parameter_defaults:
+        if is_os_module(value, inherited):
+            state.os_aliases.add(target)
+        elif is_environ(value, inherited):
+            state.environ_aliases.add(target)
+        elif is_getenv(value, inherited):
+            state.getenv_aliases.add(target)
+
+    changed = True
+    while changed:
+        changed = False
+        for target, value in collector.assignments:
+            alias_set: set[str] | None = None
+            if is_os_module(value, state):
+                alias_set = state.os_aliases
+            elif is_environ(value, state):
+                alias_set = state.environ_aliases
+            elif is_getenv(value, state):
+                alias_set = state.getenv_aliases
+            if alias_set is not None and target not in alias_set:
+                alias_set.add(target)
+                changed = True
+    return state
+
+
+class HardwareIdentityVisitor(ast.NodeVisitor):
+    def __init__(self, tree: ast.AST, source_path: str) -> None:
+        self._tree = tree
+        self._source_path = source_path
+        self._violations: list[Violation] = []
+        self._seen: set[tuple[int, int, str, str]] = set()
+        self._aliases = _EnvironmentAliasState({"os"}, set(), set())
+        self._function_parent_aliases = self._aliases
+
+    @property
+    def violations(self) -> list[Violation]:
+        return sorted(self._violations)
+
+    def _add(
+        self,
+        node: ast.AST,
+        code: str,
+        identifier: str,
+        *,
+        dynamic: bool = False,
+    ) -> None:
+        line = getattr(node, "lineno", 1)
+        column = getattr(node, "col_offset", 0) + 1
+        output_code = "HDI004" if dynamic else code
+        key = (line, column, output_code, identifier)
+        if key in self._seen:
+            return
+        self._seen.add(key)
+        self._violations.append(Violation(line, column, output_code, _message(output_code, identifier)))
+
+    def _check_identifier(self, node: ast.AST, identifier: str) -> None:
+        if code := _identifier_code(identifier):
+            self._add(node, code, identifier)
+
+    def visit_Import(self, node: ast.Import) -> None:
+        for alias in node.names:
+            imported_name = alias.name.rsplit(".", 1)[-1]
+            if code := _identifier_code(imported_name):
+                self._add(node, code, imported_name)
+            elif alias.asname and (code := _identifier_code(alias.asname)):
+                self._add(node, code, alias.asname)
+
+    def visit_ImportFrom(self, node: ast.ImportFrom) -> None:
+        module = _resolve_import_from(node, self._source_path)
+        for alias in node.names:
+            if alias.name == "*" and module in IDENTITY_MODULES:
+                self._add(node, "HDI001", f"{module}.*")
+            elif code := _identifier_code(alias.name):
+                self._add(node, code, alias.name)
+            elif alias.asname and (code := _identifier_code(alias.asname)):
+                self._add(node, code, alias.asname)
+
+    def _visit_scope(
+        self,
+        nodes: list[ast.stmt] | list[ast.expr],
+        inherited: _EnvironmentAliasState,
+        *,
+        parameter_names: set[str] | None = None,
+        parameter_defaults: list[tuple[str, ast.expr]] | None = None,
+        nested_function_parent: _EnvironmentAliasState | None = None,
+    ) -> None:
+        previous_aliases = self._aliases
+        previous_function_parent = self._function_parent_aliases
+        self._aliases = _collect_scope_aliases(
+            nodes,
+            inherited,
+            parameter_names=parameter_names,
+            parameter_defaults=parameter_defaults,
+        )
+        self._function_parent_aliases = nested_function_parent or self._aliases
+        try:
+            for node in nodes:
+                self.visit(node)
+        finally:
+            self._aliases = previous_aliases
+            self._function_parent_aliases = previous_function_parent
+
+    def visit_Module(self, node: ast.Module) -> None:
+        self._visit_scope(node.body, self._aliases)
+
+    def visit_Name(self, node: ast.Name) -> None:
+        self._check_identifier(node, node.id)
+
+    def visit_Attribute(self, node: ast.Attribute) -> None:
+        self._check_identifier(node, node.attr)
+        self.generic_visit(node)
+
+    def visit_arg(self, node: ast.arg) -> None:
+        self._check_identifier(node, node.arg)
+        self.generic_visit(node)
+
+    def _visit_function(
+        self,
+        node: ast.FunctionDef | ast.AsyncFunctionDef,
+    ) -> None:
+        self._check_identifier(node, node.name)
+        self.visit(node.args)
+        for decorator in node.decorator_list:
+            self.visit(decorator)
+        if node.returns is not None:
+            self.visit(node.returns)
+        for type_parameter in getattr(node, "type_params", []):
+            self.visit(type_parameter)
+        self._visit_scope(
+            node.body,
+            self._function_parent_aliases,
+            parameter_names=_parameter_names(node.args),
+            parameter_defaults=_parameter_defaults(node.args),
+        )
+
+    def visit_FunctionDef(self, node: ast.FunctionDef) -> None:
+        self._visit_function(node)
+
+    def visit_AsyncFunctionDef(self, node: ast.AsyncFunctionDef) -> None:
+        self._visit_function(node)
+
+    def visit_ClassDef(self, node: ast.ClassDef) -> None:
+        self._check_identifier(node, node.name)
+        for decorator in node.decorator_list:
+            self.visit(decorator)
+        for base in node.bases:
+            self.visit(base)
+        for keyword in node.keywords:
+            self.visit(keyword)
+        for type_parameter in getattr(node, "type_params", []):
+            self.visit(type_parameter)
+        previous_aliases = self._aliases
+        previous_function_parent = self._function_parent_aliases
+        self._aliases = self._function_parent_aliases.copy()
+        try:
+            # A class body executes sequentially and is not an enclosing
+            # lexical scope for nested classes or methods. Check each statement
+            # before applying the aliases and shadows that it binds.
+            for statement in node.body:
+                self.visit(statement)
+                previous_statement_aliases = self._aliases
+                self._aliases = _collect_scope_aliases(
+                    [statement],
+                    previous_statement_aliases,
+                )
+                if not isinstance(
+                    statement,
+                    (
+                        ast.AnnAssign,
+                        ast.Assign,
+                        ast.AsyncFunctionDef,
+                        ast.ClassDef,
+                        ast.FunctionDef,
+                        ast.Import,
+                        ast.ImportFrom,
+                    ),
+                ):
+                    # Conditional/loop/try bodies may not execute. Preserve
+                    # prior taint while also retaining aliases they may add.
+                    self._aliases.os_aliases.update(previous_statement_aliases.os_aliases)
+                    self._aliases.getenv_aliases.update(previous_statement_aliases.getenv_aliases)
+                    self._aliases.environ_aliases.update(previous_statement_aliases.environ_aliases)
+        finally:
+            self._aliases = previous_aliases
+            self._function_parent_aliases = previous_function_parent
+
+    def visit_Lambda(self, node: ast.Lambda) -> None:
+        self.visit(node.args)
+        self._visit_scope(
+            [node.body],
+            self._function_parent_aliases,
+            parameter_names=_parameter_names(node.args),
+            parameter_defaults=_parameter_defaults(node.args),
+        )
+
+    def _visit_comprehension(
+        self,
+        generators: list[ast.comprehension],
+        result_nodes: list[ast.expr],
+    ) -> None:
+        if not generators:
+            for result_node in result_nodes:
+                self.visit(result_node)
+            return
+
+        # The outermost iterable is evaluated in the enclosing scope. Targets,
+        # filters, later iterables, and result expressions use the comprehension's
+        # own scope, which must not inherit a shadowed class namespace.
+        self.visit(generators[0].iter)
+        bound_names = {name for generator in generators for name in _bound_target_names(generator.target)}
+        scoped_nodes: list[ast.expr] = []
+        for index, generator in enumerate(generators):
+            scoped_nodes.append(generator.target)
+            if index:
+                scoped_nodes.append(generator.iter)
+            scoped_nodes.extend(generator.ifs)
+        scoped_nodes.extend(result_nodes)
+        self._visit_scope(
+            scoped_nodes,
+            self._function_parent_aliases,
+            parameter_names=bound_names,
+        )
+
+    def visit_ListComp(self, node: ast.ListComp) -> None:
+        self._visit_comprehension(node.generators, [node.elt])
+
+    def visit_SetComp(self, node: ast.SetComp) -> None:
+        self._visit_comprehension(node.generators, [node.elt])
+
+    def visit_GeneratorExp(self, node: ast.GeneratorExp) -> None:
+        self._visit_comprehension(node.generators, [node.elt])
+
+    def visit_DictComp(self, node: ast.DictComp) -> None:
+        self._visit_comprehension(node.generators, [node.key, node.value])
+
+    def visit_keyword(self, node: ast.keyword) -> None:
+        if node.arg is not None:
+            self._check_identifier(node, node.arg)
+        self.generic_visit(node)
+
+    def visit_Global(self, node: ast.Global) -> None:
+        for name in node.names:
+            self._check_identifier(node, name)
+
+    def visit_Nonlocal(self, node: ast.Nonlocal) -> None:
+        for name in node.names:
+            self._check_identifier(node, name)
+
+    def _is_soc_env_call(self, node: ast.Call) -> bool:
+        key_node = (
+            node.args[0]
+            if node.args
+            else next(
+                (keyword.value for keyword in node.keywords if keyword.arg == "key"),
+                None,
+            )
+        )
+        if key_node is None or _string_literal(key_node) != SOC_VERSION_ENV_KEY:
+            return False
+        return self._is_getenv_callable(node.func)
+
+    def _is_getenv_callable(self, node: ast.expr) -> bool:
+        if isinstance(node, ast.NamedExpr):
+            return self._is_getenv_callable(node.value)
+        if isinstance(node, ast.Name):
+            return node.id in self._aliases.getenv_aliases
+        if not isinstance(node, ast.Attribute):
+            return False
+        if node.attr == "getenv":
+            return self._is_os_module(node.value)
+        return node.attr == "get" and self._is_os_environ(node.value)
+
+    def _is_os_module(self, node: ast.expr) -> bool:
+        if isinstance(node, ast.NamedExpr):
+            return self._is_os_module(node.value)
+        return isinstance(node, ast.Name) and node.id in self._aliases.os_aliases
+
+    def visit_Call(self, node: ast.Call) -> None:
+        call_name = _dotted_name(node.func)
+        tail = call_name.rsplit(".", 1)[-1] if call_name else None
+        if tail in {"getattr", "hasattr", "setattr", "delattr"} and len(node.args) >= 2:
+            if identifier := _string_literal(node.args[1]):
+                if code := _identifier_code(identifier):
+                    self._add(node, code, identifier, dynamic=True)
+
+        attribute_name = node.func.attr if isinstance(node.func, ast.Attribute) else tail
+        if attribute_name in _STRING_IDENTITY_PREDICATES:
+            for argument in node.args:
+                for literal in _device_identity_literals(argument):
+                    self._add(literal, "HDI005", literal.value)
+
+        if (
+            attribute_name == "get"
+            and isinstance(node.func, ast.Attribute)
+            and self._is_dynamic_namespace(node.func.value)
+            and node.args
+        ):
+            if identifier := _string_literal(node.args[0]):
+                if code := _identifier_code(identifier):
+                    self._add(node, code, identifier, dynamic=True)
+
+        if self._is_soc_env_call(node) and not _is_exact_env_declaration(node, self._tree, self._source_path):
+            self._add(node, "HDI002", "SOC_VERSION environment value")
+        self.generic_visit(node)
+
+    def visit_Constant(self, node: ast.Constant) -> None:
+        if isinstance(node.value, str) and _DEVICE_IDENTITY_LITERAL_RE.fullmatch(node.value.strip()):
+            self._add(node, "HDI005", node.value)
+
+    def visit_Compare(self, node: ast.Compare) -> None:
+        for operand in (node.left, *node.comparators):
+            for literal in _device_identity_literals(operand):
+                self._add(literal, "HDI005", literal.value)
+        self.generic_visit(node)
+
+    def visit_MatchValue(self, node: ast.MatchValue) -> None:
+        for literal in _device_identity_literals(node.value):
+            self._add(literal, "HDI005", literal.value)
+        self.generic_visit(node)
+
+    def _is_os_environ(self, node: ast.expr) -> bool:
+        if isinstance(node, ast.NamedExpr):
+            return self._is_os_environ(node.value)
+        if isinstance(node, ast.Name):
+            return node.id in self._aliases.environ_aliases
+        return isinstance(node, ast.Attribute) and node.attr == "environ" and self._is_os_module(node.value)
+
+    @staticmethod
+    def _is_dynamic_namespace(node: ast.expr) -> bool:
+        if isinstance(node, ast.Attribute):
+            return node.attr == "__dict__"
+        return (
+            isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Name)
+            and node.func.id in {"globals", "locals", "vars"}
+        )
+
+    def visit_Subscript(self, node: ast.Subscript) -> None:
+        if identifier := _string_literal(node.slice):
+            if identifier == SOC_VERSION_ENV_KEY and self._is_os_environ(node.value):
+                self._add(node, "HDI002", "SOC_VERSION environment value")
+            elif self._is_dynamic_namespace(node.value) and (code := _identifier_code(identifier)):
+                self._add(node, code, identifier, dynamic=True)
+        self.generic_visit(node)
+
+
+def check_source(source: str, relative_path: str | Path) -> list[Violation]:
+    source_path = _normalized_source_path(relative_path)
+    if not _is_production_python(source_path) or source_path in ALLOWED_IDENTITY_FILES:
+        return []
+
+    try:
+        tree = ast.parse(source, filename=source_path)
+    except SyntaxError as exc:
+        return [
+            Violation(
+                exc.lineno or 1,
+                exc.offset or 1,
+                "HDI000",
+                f"cannot parse file for hardware identity checks: {exc.msg}",
+            )
+        ]
+
+    visitor = HardwareIdentityVisitor(tree, source_path)
+    visitor.visit(tree)
+    return visitor.violations
+
+
+def check_file(filepath: str | Path) -> list[str]:
+    source_path = _normalized_repo_path(filepath)
+    if source_path is None or not _is_production_python(source_path):
+        return []
+
+    try:
+        source = Path(filepath).read_text(encoding="utf-8")
+    except (OSError, UnicodeDecodeError) as exc:
+        return [f"{source_path}:1:1: HDI000 cannot read file: {exc}"]
+
+    return [violation.format(source_path) for violation in check_source(source, source_path)]
+
+
+def main(argv: list[str] | None = None) -> int:
+    paths: list[str | Path] = list(sys.argv[1:] if argv is None else argv)
+    if not paths:
+        paths = _default_python_paths()
+
+    violations = [message for path in paths for message in check_file(path)]
+    if violations:
+        print("Raw hardware identity must stay inside the HAL boundary.\n")
+        for violation in sorted(violations):
+            print(f"  {violation}")
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/vllm_ascend/ascend_config.py
+++ b/vllm_ascend/ascend_config.py
@@ -75,7 +75,7 @@ class AscendCompilationConfig:
     def _apply_unsupported_hardware_downgrade_and_static_kernel_check(self):
         from vllm_ascend.device.hardware_profile import HardwareCapability, get_current_hardware_profile
 
-        if not get_current_hardware_profile().supports(HardwareCapability.NPUGRAPH_EX):
+        if not get_current_hardware_profile().supports(HardwareCapability.NPUGRAPH_EX_COMPILATION_BACKEND):
             if self.enable_npugraph_ex:
                 logger.warning("npugraph_ex is not supported by the current hardware profile. Disabling it.")
             if self.enable_static_kernel:
@@ -688,9 +688,7 @@ class AscendConfig:
         from vllm_ascend.device.hardware_profile import HardwareCapability, get_current_hardware_profile
 
         hardware_profile = get_current_hardware_profile()
-        if self.mc2_comm_alg == "fullmesh_v2" and not hardware_profile.supports(
-            HardwareCapability.MC2_FULLMESH_V2_COMM
-        ):
+        if self.mc2_comm_alg == "fullmesh_v2" and not hardware_profile.supports(HardwareCapability.MC2_FULLMESH_V2):
             raise NotImplementedError("mc2_comm_alg == 'fullmesh_v2' is not supported by the current hardware profile.")
 
         if self.mc2_comm_alg != "hierarchy":
@@ -882,12 +880,13 @@ class AscendConfig:
         return
 
     def get_mc2_comm_alg(self) -> str:
-        from vllm_ascend.device.hardware_profile import HardwareCapability, get_current_hardware_profile
+        from vllm_ascend.device.hardware_profile import MC2FullmeshAliasPolicy, get_current_hardware_profile
 
-        # When A3 and comm_alg == "fullmesh", dispatch/combine op need pass in "fullmesh_v1" instead of "fullmesh"
-        # TODO(zzzzwwjj): Remove it when op's param is uniformed between A2/A3/A5.
-        if self.mc2_comm_alg == "fullmesh" and get_current_hardware_profile().supports(
-            HardwareCapability.MC2_FULLMESH_V2_COMM
+        # Some distribute-v2 ABIs spell the configured "fullmesh" alias as
+        # "fullmesh_v1". Remove this policy when the operator ABI is uniform.
+        if (
+            self.mc2_comm_alg == "fullmesh"
+            and get_current_hardware_profile().mc2_fullmesh_alias_policy is MC2FullmeshAliasPolicy.MAP_FULLMESH_TO_V1
         ):
             return "fullmesh_v1"
         return self.mc2_comm_alg

--- a/vllm_ascend/ascend_forward_context.py
+++ b/vllm_ascend/ascend_forward_context.py
@@ -88,7 +88,7 @@ def use_cann_megamoe(vllm_config: VllmConfig) -> bool:
     # TODO: drop the EP-size guard when MegaMoe supports larger EP sizes.
     return (
         is_mega_moe_supported()
-        and get_current_hardware_profile().supports(HardwareCapability.CANN_MEGAMOE)
+        and get_current_hardware_profile().supports(HardwareCapability.CANN_MEGAMOE_FUSED_MC2)
         and get_ascend_config().enable_fused_mc2 == 1
         and is_moe_model(vllm_config)
         and vllm_config.parallel_config.enable_expert_parallel
@@ -332,9 +332,13 @@ def _select_capacity_and_world_size_moe_comm_method(
 
 
 _MOE_COMM_SELECTORS = {
-    MoECommPolicy.CAPACITY_AND_EXPERT_DENSITY: _select_capacity_and_expert_density_moe_comm_method,
-    MoECommPolicy.FUSED_OR_CAPACITY: _select_fused_or_capacity_moe_comm_method,
-    MoECommPolicy.CAPACITY_AND_WORLD_SIZE: _select_capacity_and_world_size_moe_comm_method,
+    MoECommPolicy.MC2_IF_CAPACITY_AND_EXPERT_DENSITY_ELSE_ALLGATHER: (
+        _select_capacity_and_expert_density_moe_comm_method
+    ),
+    MoECommPolicy.FUSED_MC2_THEN_CAPACITY_MC2_ELSE_ALLTOALL: _select_fused_or_capacity_moe_comm_method,
+    MoECommPolicy.MC2_IF_CAPACITY_ELSE_ALLGATHER_OR_ALLTOALL_BY_WORLD_SIZE: (
+        _select_capacity_and_world_size_moe_comm_method
+    ),
 }
 
 

--- a/vllm_ascend/attention/attention_v1.py
+++ b/vllm_ascend/attention/attention_v1.py
@@ -61,7 +61,7 @@ from vllm_ascend.compilation.acl_graph import (
     update_graph_params_workspaces,
 )
 from vllm_ascend.device.device_op import DeviceOperator
-from vllm_ascend.device.hardware_profile import HardwareCapability, get_current_hardware_profile
+from vllm_ascend.device.hardware_profile import get_current_hardware_profile
 from vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.attention_fence import record_attention_compute_start
 from vllm_ascend.utils import vllm_version_is, weak_ref_tensors
 
@@ -1422,7 +1422,7 @@ class AscendAttentionBackendImpl(AttentionImpl):
                     (
                         envs_vllm.VLLM_BATCH_INVARIANT
                         or (
-                            get_current_hardware_profile().supports(HardwareCapability.CHUNKED_PREFILL_PHASE_SPLIT)
+                            get_current_hardware_profile().split_fia_chunked_prefill_by_default
                             and attn_metadata.attn_state == AscendAttentionState.ChunkedPrefill
                         )
                     )

--- a/vllm_ascend/attention/context_parallel/dsa_cp.py
+++ b/vllm_ascend/attention/context_parallel/dsa_cp.py
@@ -17,7 +17,7 @@ from vllm_ascend.attention import dsa_v1
 from vllm_ascend.attention.attention_v1 import AscendAttentionState
 from vllm_ascend.attention.dsa_attn_kv_plan import (
     get_dsa_attn_kv_plan,
-    is_a5_bf16_kv_enabled,
+    is_dsv4_bf16_sparse_flash_mla_enabled,
 )
 from vllm_ascend.attention.dsa_v1 import (
     _dsa_layout_kv,
@@ -246,9 +246,9 @@ class AscendDSACPMetadataBuilder(AttentionMetadataBuilder[AscendDSAMetadata]):
         self.speculative_config = vllm_config.speculative_config
         self.decode_threshold = 1
         self.spec_slot_mapping = None
-        if get_current_hardware_profile().supports(HardwareCapability.FP8_ATTENTION) and not is_a5_bf16_kv_enabled(
-            vllm_config
-        ):
+        if get_current_hardware_profile().supports(
+            HardwareCapability.FP8_ATTENTION
+        ) and not is_dsv4_bf16_sparse_flash_mla_enabled(vllm_config):
             self.slot_mapping_shape = (vllm_config.scheduler_config.max_num_batched_tokens,)  # type: ignore
         else:
             self.slot_mapping_shape = (vllm_config.scheduler_config.max_num_batched_tokens, 2)  # type: ignore
@@ -1565,8 +1565,8 @@ class AscendDSACPImpl(AttentionImplBase[Any]):
             self._switch_o_proj_to_full_weight()
         o_proj_groups = self.n_group if full_gather_wo_a_enabled else self.n_local_groups
         try:
-            use_a5_quant_o_proj = self.support_fp8_attention and _has_weight_scale(self.wo_a)
-            if use_a5_quant_o_proj:
+            use_quantized_o_proj = self.support_fp8_attention and _has_weight_scale(self.wo_a)
+            if use_quantized_o_proj:
                 o = o_proj_input.view(num_tokens, o_proj_groups, -1)
                 wo_a_method = getattr(self.wo_a.quant_method, "quant_method", self.wo_a.quant_method)
                 if isinstance(wo_a_method, AscendUnquantizedLinearMethod):

--- a/vllm_ascend/attention/dsa_attn_kv_plan.py
+++ b/vllm_ascend/attention/dsa_attn_kv_plan.py
@@ -16,25 +16,26 @@ _BF16_KV_CACHE_DTYPES = frozenset({"bfloat16", "bf16"})
 
 
 def _supports_dsv4_compressed_cache() -> bool:
-    return get_current_hardware_profile().supports(HardwareCapability.DSV4_COMPRESSED_CACHE)
+    return get_current_hardware_profile().supports(HardwareCapability.DSA_COMPRESSED_KV_CACHE)
 
 
 def resolve_dsv4_cache_dtype(cache_dtype, model_dtype: str) -> str:
     """Return the KV cache dtype the platform should pin for DeepSeek-V4.
 
-    On A5 the launch request has to stay readable afterwards, because it is the
-    only thing that separates an explicit bfloat16 KV request from ``auto``.
-    ``auto`` and the model dtype resolve identically everywhere downstream, so
-    collapsing every non-bfloat16 request to ``auto`` preserves the upstream
-    values while keeping the mode recoverable.
+    On profiles with compressed DSA KV cache, the launch request has to stay
+    readable afterwards because it is the only thing that separates an
+    explicit bfloat16 KV request from ``auto``. ``auto`` and the model dtype
+    resolve identically everywhere downstream, so collapsing every
+    non-bfloat16 request to ``auto`` preserves the upstream values while
+    keeping the mode recoverable.
     """
     if not _supports_dsv4_compressed_cache():
         return model_dtype
     return "bfloat16" if str(cache_dtype).lower() in _BF16_KV_CACHE_DTYPES else "auto"
 
 
-def is_a5_bf16_kv_enabled(vllm_config) -> bool:
-    """Return whether BF16 SparseFlashMla KV is enabled on A5.
+def is_dsv4_bf16_sparse_flash_mla_enabled(vllm_config) -> bool:
+    """Return whether the BF16 SparseFlashMla DSA KV plan is enabled.
 
     Callers must pass the engine ``vllm_config``. Do not look it up from the
     process-global current config: that context is only set during
@@ -49,10 +50,10 @@ def is_a5_bf16_kv_enabled(vllm_config) -> bool:
 
 
 def get_dsv4_attn_kv_dtype(vllm_config) -> torch.dtype:
-    """Return the attention KV dtype while preserving non-A5 behavior."""
+    """Return the attention KV dtype for the selected DSA KV-cache plan."""
     return (
         torch.bfloat16
-        if not _supports_dsv4_compressed_cache() or is_a5_bf16_kv_enabled(vllm_config)
+        if not _supports_dsv4_compressed_cache() or is_dsv4_bf16_sparse_flash_mla_enabled(vllm_config)
         else torch.float8_e4m3fn
     )
 
@@ -136,7 +137,7 @@ class DsaAttnKvPlan:
 
 
 def get_dsa_attn_kv_plan(vllm_config) -> DsaAttnKvPlan:
-    """Return the explicit A5 BF16 or upstream-compatible FP8 DSA plan."""
+    """Return the explicit BF16 SparseFlashMla or compressed-FP8 DSA plan."""
     if not _supports_dsv4_compressed_cache():
         return DsaAttnKvPlan(
             uses_sparse_flash_mla=False,
@@ -152,7 +153,7 @@ def get_dsa_attn_kv_plan(vllm_config) -> DsaAttnKvPlan:
             applies_sparse_attn_runtime_kwargs=True,
         )
 
-    use_bf16 = is_a5_bf16_kv_enabled(vllm_config)
+    use_bf16 = is_dsv4_bf16_sparse_flash_mla_enabled(vllm_config)
     if use_bf16:
         return DsaAttnKvPlan(
             uses_sparse_flash_mla=True,

--- a/vllm_ascend/attention/dsa_v1.py
+++ b/vllm_ascend/attention/dsa_v1.py
@@ -21,7 +21,7 @@ from vllm_ascend.ascend_forward_context import _EXTRA_CTX
 from vllm_ascend.attention.attention_v1 import AscendAttentionState
 from vllm_ascend.attention.dsa_attn_kv_plan import (
     get_dsa_attn_kv_plan,
-    is_a5_bf16_kv_enabled,
+    is_dsv4_bf16_sparse_flash_mla_enabled,
 )
 from vllm_ascend.attention.utils import (
     AscendCommonAttentionMetadata,
@@ -94,7 +94,7 @@ def _dsa_layout_kv(vllm_config: VllmConfig) -> str:
 
 def _dsa_swa_only_cmp_ratio(compress_ratio: int, vllm_config: VllmConfig) -> int:
     """BF16 SWA-only attention takes no compressed stream; otherwise keep main's value."""
-    if is_a5_bf16_kv_enabled(vllm_config) and compress_ratio <= 1:
+    if is_dsv4_bf16_sparse_flash_mla_enabled(vllm_config) and compress_ratio <= 1:
         return 0
     return max(compress_ratio, 1)
 
@@ -212,9 +212,7 @@ class AscendDSAC128StateBackend(AscendDSABackend):
 
     @staticmethod
     def get_supported_kernel_block_sizes() -> list[int]:
-        if get_current_hardware_profile().supports(HardwareCapability.DSA_C128_STATE_SMALL_BLOCK_SIZES):
-            return [4, 8, 16]
-        return [8, 16, 32]
+        return list(get_current_hardware_profile().dsa_c128_block_sizes)
 
 
 @dataclass
@@ -373,9 +371,9 @@ class AscendDSAMetadataBuilder(AttentionMetadataBuilder[AscendDSAMetadata]):
         self.speculative_config = vllm_config.speculative_config
         self.decode_threshold = 1
         self.spec_slot_mapping = None
-        if get_current_hardware_profile().supports(HardwareCapability.FP8_ATTENTION) and not is_a5_bf16_kv_enabled(
-            vllm_config
-        ):
+        if get_current_hardware_profile().supports(
+            HardwareCapability.FP8_ATTENTION
+        ) and not is_dsv4_bf16_sparse_flash_mla_enabled(vllm_config):
             self.slot_mapping_shape = (vllm_config.scheduler_config.max_num_batched_tokens,)  # type: ignore
         else:
             self.slot_mapping_shape = (vllm_config.scheduler_config.max_num_batched_tokens, 2)  # type: ignore
@@ -1066,7 +1064,7 @@ class AscendDSAImpl(AttentionImplBase[Any]):
 
         ascend_config = get_ascend_config()
         self.multistream_dsv4_dsa_overlap = ascend_config.multistream_dsv4_dsa_overlap
-        if self.multistream_dsv4_dsa_overlap and is_a5_bf16_kv_enabled(self.vllm_config):
+        if self.multistream_dsv4_dsa_overlap and is_dsv4_bf16_sparse_flash_mla_enabled(self.vllm_config):
             self.multistream_dsv4_dsa_overlap = False
 
     def _get_layer_metadata(
@@ -1128,11 +1126,11 @@ class AscendDSAImpl(AttentionImplBase[Any]):
         num_tokens = o_proj_input.shape[0]
         group_hidden_dim = o_proj_input.shape[1] * o_proj_input.shape[2] // self.n_local_groups
         o_proj_input = o_proj_input.view(num_tokens, self.n_local_groups, group_hidden_dim)
-        # A5 (Ascend950) uses an FP8-quantized o_proj path (dynamic MX quant
-        # + quantized batch matmul). Preserve it as-is: it predates and is
-        # orthogonal to the OTP / olora_tp paths below, so it must win first.
-        use_a5_quant_o_proj = self.support_fp8_attention and _has_weight_scale(self.wo_a)
-        if use_a5_quant_o_proj:
+        # FP8 attention profiles use a quantized o_proj path (dynamic MX quant
+        # plus quantized batch matmul). It is orthogonal to the OTP / olora_tp
+        # paths below, so it must win first.
+        use_quantized_o_proj = self.support_fp8_attention and _has_weight_scale(self.wo_a)
+        if use_quantized_o_proj:
             o = o_proj_input
             o, swiglu_out_scale = torch_npu.npu_dynamic_mx_quant(o, dst_type=torch.float8_e4m3fn)
             o = torch_npu.npu_transpose_quant_batchmatmul(

--- a/vllm_ascend/attention/mla_v1.py
+++ b/vllm_ascend/attention/mla_v1.py
@@ -1061,7 +1061,7 @@ class AscendMLAImpl(MLAAttentionImpl):
                 (AscendW8A8LinearMethod, AscendW8A8MXFP8DynamicLinearMethod),
             )
             supports_native_weights = get_current_hardware_profile().supports(
-                HardwareCapability.MLAPO_NATIVE_WEIGHTS
+                HardwareCapability.MLAPO_UNQUANTIZED_PROJECTION_WEIGHTS
             ) and isinstance(layer_quant_method, UnquantizedLinearMethod)
             if self.fused_qkv_a_proj is None or not (supports_quantized_weights or supports_native_weights):
                 self.enable_mlapo = False

--- a/vllm_ascend/attention/utils.py
+++ b/vllm_ascend/attention/utils.py
@@ -12,7 +12,11 @@ from vllm.forward_context import ForwardContext, get_forward_context
 from vllm.utils.torch_utils import get_dtype_size
 from vllm.v1.attention.backends.utils import CommonAttentionMetadata
 
-from vllm_ascend.device.hardware_profile import HardwareCapability, get_current_hardware_profile
+from vllm_ascend.device.hardware_profile import (
+    HardwareCapability,
+    MLAPOEnablementPolicy,
+    get_current_hardware_profile,
+)
 from vllm_ascend.device.utils import FIA_TND_LARGE_HEAD_FALLBACK_HEAD_SIZE
 from vllm_ascend.utils import (
     get_ascend_config,
@@ -218,7 +222,7 @@ def ascend_chunked_prefill_workspace_size(vllm_config: VllmConfig) -> int:
 def using_paged_attention(runtime_shape: int, vllm_config: VllmConfig, head_size: int | None = None) -> bool:
     if vllm_config.speculative_config is not None:
         return False
-    if not get_current_hardware_profile().supports(HardwareCapability.PAGED_ATTENTION):
+    if not get_current_hardware_profile().supports(HardwareCapability.PAGED_ATTENTION_FULL_DECODE):
         return False
     # TODO: Remove this fallback when A2/A3 FIA TND supports Gemma4's
     # 512-dim global attention heads. Decode can use PA directly; prefill is
@@ -567,7 +571,7 @@ def transdata(nd_mat, block_size: tuple = (16, 16)):
 
 def enabling_mlapo(vllm_config: VllmConfig) -> bool:
     config_val = get_ascend_config().enable_mlapo
-    if get_current_hardware_profile().supports(HardwareCapability.UNRESTRICTED_MLAPO):
+    if get_current_hardware_profile().mlapo_enablement_policy is MLAPOEnablementPolicy.ANY_CONFIGURED_INSTANCE:
         return bool(config_val)
 
     is_decode_instance = (

--- a/vllm_ascend/compilation/passes/norm_quant_fusion_pass.py
+++ b/vllm_ascend/compilation/passes/norm_quant_fusion_pass.py
@@ -384,7 +384,7 @@ class AddRMSNormQuantFusionPass(VllmInductorPass):
 
         for eps in common_epsilons:
             AddRMSNormDynamicQuantPattern(vllm_config, eps=eps).register(self.pattern_match_passes)
-            if profile.supports(HardwareCapability.DYNAMIC_MX_QUANT_FUSION):
+            if profile.supports(HardwareCapability.GRAPH_DYNAMIC_MX_QUANT_FUSION):
                 AddRMSNormDynamicMXQuantPattern(vllm_config, eps=eps).register(self.pattern_match_passes)
                 RMSNormDynamicMXQuantPattern(vllm_config, eps=eps).register(self.pattern_match_passes)
             if enable_custom_op():

--- a/vllm_ascend/cpu_binding.py
+++ b/vllm_ascend/cpu_binding.py
@@ -524,7 +524,7 @@ class CpuAlloc:
 
     @staticmethod
     def _reserve_irq_cpus() -> bool:
-        return get_current_hardware_profile().supports(HardwareCapability.IRQ_CPU_RESERVATION)
+        return get_current_hardware_profile().reserve_irq_cpus
 
     @staticmethod
     def _min_cpus_per_npu() -> int:

--- a/vllm_ascend/device/device_config.py
+++ b/vllm_ascend/device/device_config.py
@@ -48,8 +48,8 @@ def get_device_config() -> DeviceConfig:
     return DeviceConfig(_device_type=_device_type_from_build_info())
 
 
-# Compatibility API. New business code must consume semantic DeviceConfig
-# capabilities instead of branching on these hardware identities.
+# Compatibility API. New business code must consume HardwareProfile
+# capabilities, policies, or families instead of these hardware identities.
 def get_ascend_device_type() -> AscendDeviceType:
     return get_device_config()._device_type
 

--- a/vllm_ascend/device/device_op.py
+++ b/vllm_ascend/device/device_op.py
@@ -1586,9 +1586,9 @@ class Ascend310PDeviceAdaptor(BaseDeviceAdaptor):
 
 def get_device_adaptor() -> type["BaseDeviceAdaptor"]:
     adaptor_by_family = {
-        DeviceAdaptorFamily.STANDARD: BaseDeviceAdaptor,
-        DeviceAdaptorFamily.FP8_OPTIMIZED: A5DeviceAdaptor,
-        DeviceAdaptorFamily.COMPATIBILITY: Ascend310PDeviceAdaptor,
+        DeviceAdaptorFamily.BASE_DEVICE_OPERATIONS: BaseDeviceAdaptor,
+        DeviceAdaptorFamily.FP8_MXFP_DSA_AND_FUSED_MODEL_OPERATIONS: A5DeviceAdaptor,
+        DeviceAdaptorFamily.RESHAPE_CACHE_AND_INDEX_FILL_OPERATIONS: Ascend310PDeviceAdaptor,
     }
     return adaptor_by_family[get_current_hardware_profile().device_adaptor_family]
 

--- a/vllm_ascend/device/hardware.py
+++ b/vllm_ascend/device/hardware.py
@@ -7,7 +7,7 @@
 This module deliberately depends only on the Python standard library so it can
 also be loaded by ``setup.py`` before vllm-ascend is installed. Device identity
 must stay inside the device abstraction package; callers outside this package
-should consume semantic capabilities from ``device_config`` instead.
+should consume semantic capabilities and policies from ``hardware_profile``.
 """
 
 from enum import Enum

--- a/vllm_ascend/device/hardware_profile.py
+++ b/vllm_ascend/device/hardware_profile.py
@@ -2,7 +2,14 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 # Copyright (c) 2026 Huawei Technologies Co., Ltd. All Rights Reserved.
 
-"""Capability-oriented profiles for supported Ascend hardware families."""
+"""Capability-oriented profiles for supported Ascend hardware families.
+
+``HardwareCapability`` contains only positive, independently testable hardware
+or runtime support. Profile families select implementation contracts; policies
+and explicitly named scalar fields select defaults or bounded parameters. New
+names state their scope, action, and object; a device codename is never the
+contract.
+"""
 
 from collections.abc import Mapping
 from dataclasses import dataclass
@@ -14,56 +21,93 @@ from vllm_ascend.device.hardware import AscendDeviceType
 
 
 class HardwareCapability(Enum):
-    """Independent SoC capabilities consumed by shared business logic."""
+    """Independent, positive features consumed by shared business logic."""
 
-    AUTO_ENABLE_CUSTOM_OPS = auto()
-    ATB_EXTENSIONS = auto()
-    ATB_WARMUP = auto()
-    BGMV_SGMV_META_REGISTRATION = auto()
-    CANN_MEGAMOE = auto()
-    CHUNKED_PREFILL_PHASE_SPLIT = auto()
+    # Registers the ATB-backed model execution extensions during worker setup.
+    ATB_MODEL_EXECUTION_EXTENSIONS = auto()
+    # Provides meta kernels for the LoRA BGMV and SGMV custom operators.
+    BGMV_SGMV_META_KERNELS = auto()
+    # Requantizes loaded block-FP8 weights to the MXFP8 execution format.
+    BLOCK_FP8_TO_MXFP8_REQUANTIZATION = auto()
+    # Provides the CANN MegaMoe fused-MC2 execution path.
+    CANN_MEGAMOE_FUSED_MC2 = auto()
+    # Exposes cluster topology used to build CPU affinity groups.
     CLUSTER_CPU_TOPOLOGY = auto()
-    COMPATIBILITY_OP_IMPLEMENTATIONS = auto()
-    DISTRIBUTED_COMMUNICATION_ADAPTATION = auto()
-    DSA_C128_STATE_SMALL_BLOCK_SIZES = auto()
+    # Accepts glu_alpha/glu_bias in the dequant-SwiGLU operator ABI.
+    DEQUANT_SWIGLU_GLU_ALPHA_BIAS_ARGS = auto()
+    # Supports tensor-parallel O projection in DSA context parallelism.
     DSA_O_PROJ_TP = auto()
-    DSV4_COMPRESSED_CACHE = auto()
-    DYNAMIC_MX_QUANT_FUSION = auto()
-    DYNAMIC_MX_QUANT_SCALE_ALG_ONE = auto()
+    # Supports the compressed attention KV-cache representation required by DSA.
+    DSA_COMPRESSED_KV_CACHE = auto()
+    # Supports overflow-safe E8M0 scale selection for DynamicMxQuantV3.
+    DYNAMIC_MX_QUANT_E8M0_OVERFLOW_SAFE_SCALING = auto()
+    # Provides FP8 attention kernels and their quantized KV-cache ABI.
     FP8_ATTENTION = auto()
-    FUSED_MOE_COMPATIBILITY = auto()
-    FUSED_SWIGLU_TUNING_ARGS = auto()
-    GDN_COMPATIBILITY = auto()
+    # Provides graph patterns for DynamicMxQuant fusion.
+    GRAPH_DYNAMIC_MX_QUANT_FUSION = auto()
+    # Provides the muls-add graph fusion pattern.
     GRAPH_MULS_ADD_FUSION = auto()
+    # Provides graph patterns that fuse normalization with quantization.
     GRAPH_NORM_QUANT_FUSION = auto()
-    IRQ_CPU_RESERVATION = auto()
-    LOCAL_KV_COMM_RESOURCE = auto()
-    LORA_CUSTOM_OPS = auto()
+    # Creates a process-local communication resource for KV transfer.
+    LOCAL_KV_TRANSFER_COMM_RESOURCE = auto()
+    # Provides the custom BGMV/SGMV kernels used by LoRA Punica.
+    LORA_BGMV_SGMV_CUSTOM_OPS = auto()
+    # Supports MLA decode-prolog execution without rotary embeddings.
     MLA_DECODE_PROLOG_WITHOUT_ROPE = auto()
-    MLAPO_NATIVE_WEIGHTS = auto()
-    MC2_FULLMESH_V2_COMM = auto()
+    # Allows MLAPO to consume unquantized projection weights directly.
+    MLAPO_UNQUANTIZED_PROJECTION_WEIGHTS = auto()
+    # Supports the fullmesh_v2 MC2 communication algorithm.
+    MC2_FULLMESH_V2 = auto()
+    # Supports hierarchical MC2 dispatch and combine communication.
     MC2_HIERARCHY_COMM = auto()
-    MOE_DISPATCH_EXTRA_ARGS = auto()
-    MOE_DISPATCH_SHARED_EXPERT_ARGS = auto()
-    NPUGRAPH_EX = auto()
-    NPU_TOP_K_TOP_P = auto()
-    PAGED_ATTENTION = auto()
-    RC_DEVICE_DISCOVERY = auto()
-    REDUCED_CUDAGRAPH_CAPTURE_SIZES = auto()
-    RUNTIME_CUSTOM_OPS = auto()
+    # Uses paged scatter updates for the MiniMax-M3 index-K cache.
+    MINIMAX_M3_PAGED_INDEX_CACHE_SCATTER = auto()
+    # Provides the fused MiniMax-M3 QKV RMSNorm and RoPE operator.
+    MINIMAX_M3_FUSED_QKV_RMSNORM_ROPE = auto()
+    # Provides the fused clipped-SwiGLU operator used by MiniMax-M3.
+    MINIMAX_M3_FUSED_CLIPPED_SWIGLU = auto()
+    # Quantizes MiniMax-M3 SwiGLU output for MXFP8 projections.
+    MINIMAX_M3_SWIGLU_OAI_MXFP8_OUTPUT_QUANTIZATION = auto()
+    # Supports TP-sharded sparse-index decode for MiniMax-M3.
+    MINIMAX_M3_TP_SHARDED_INDEX_DECODE = auto()
+    # Enables the NPUGraph extended compilation backend.
+    NPUGRAPH_EX_COMPILATION_BACKEND = auto()
+    # Provides the native NPU top-k/top-p sampling operator.
+    NATIVE_TOP_K_TOP_P_SAMPLING = auto()
+    # Provides the full paged-attention decode kernel.
+    PAGED_ATTENTION_FULL_DECODE = auto()
+    # Detects PCIe root-complex mode from the host's NPU topology.
+    PCIE_ROOT_COMPLEX_MODE_DETECTION = auto()
+    # Supports lazy registration and dispatch of the Ascend custom-op library.
+    ASCEND_CUSTOM_OP_RUNTIME_REGISTRATION = auto()
+    # Replicates the SFA indexer cache under decode-context parallelism.
     SFA_DCP_REPLICATED_INDEXER = auto()
-    STANDARD_WORKER_PATCHES = auto()
-    STANDARD_MAMBA_PATCH = auto()
-    SWIGLU_OAI_MX_QUANT = auto()
-    TRITON_BATCH_MEMCPY = auto()
-    UNRESTRICTED_MLAPO = auto()
+    # Provides Triton batch memcpy for Mamba state movement.
+    TRITON_MAMBA_STATE_BATCH_MEMCPY = auto()
+    # Allows the Xlite graph worker implementation.
+    XLITE_GRAPH_WORKER = auto()
 
 
 class AttentionBackendFamily(Enum):
     """Attention backend implementation families selected by the platform."""
 
-    STANDARD = auto()
-    COMPATIBILITY = auto()
+    DENSE_MLA_SFA_DSA = auto()
+    DENSE_ONLY = auto()
+
+
+class CompilationCustomOpPolicy(Enum):
+    """How platform setup updates ``compilation_config.custom_ops``."""
+
+    PRESERVE_CONFIGURATION = auto()
+    FORCE_ENABLE_ALL = auto()
+
+
+class DistributedCollectiveFamily(Enum):
+    """Distributed collective implementations used by runtime patches."""
+
+    TORCH_NPU_NATIVE = auto()
+    BROADCAST_AND_INT64_ALLREDUCE_VIA_ALLGATHER = auto()
 
 
 class CPUBindingMode(Enum):
@@ -76,9 +120,11 @@ class CPUBindingMode(Enum):
 class DeviceAdaptorFamily(Enum):
     """Device operation adaptor implementation families."""
 
-    STANDARD = auto()
-    FP8_OPTIMIZED = auto()
-    COMPATIBILITY = auto()
+    BASE_DEVICE_OPERATIONS = auto()
+    # Adds FP8/MXFP attention and MoE, DSA cache/indexer, MC2/GDN, and
+    # model-specific fused operator implementations.
+    FP8_MXFP_DSA_AND_FUSED_MODEL_OPERATIONS = auto()
+    RESHAPE_CACHE_AND_INDEX_FILL_OPERATIONS = auto()
 
 
 class DeviceAddressingMode(Enum):
@@ -88,20 +134,117 @@ class DeviceAddressingMode(Enum):
     DUAL_CHIP_CARD = auto()
 
 
+class DSAOProjWeightLayoutPolicy(Enum):
+    """Layout conversion applied while loading DSA ``wo_a`` weights."""
+
+    ALWAYS_TRANSPOSE_WO_A = auto()
+    TRANSPOSE_UNQUANTIZED_BF16_WO_A_ONLY = auto()
+
+
+class GDNPatchFamily(Enum):
+    """Gated-delta-net monkey-patch coverage."""
+
+    FULL_FORWARD_PATCH = auto()
+    CORE_AND_DTYPE_PATCH = auto()
+
+
+class MambaConfigPatchFamily(Enum):
+    """Mamba cache-layout validation implementations."""
+
+    MLA_OR_DENSE_CACHE_LAYOUT = auto()
+    DENSE_ATTENTION_CACHE_ONLY = auto()
+
+
+class MC2FullmeshAliasPolicy(Enum):
+    """Operator argument emitted for the configured ``fullmesh`` alias."""
+
+    PASSTHROUGH = auto()
+    MAP_FULLMESH_TO_V1 = auto()
+
+
+class MiniMaxM3IndexerFamily(Enum):
+    """MiniMax-M3 index-score, top-k, and decode implementation bundle."""
+
+    ASCENDC_SCORE_AND_DECODE_WITH_TRITON_TOPK = auto()
+    TRITON_SCORE_TOPK_DECODE = auto()
+
+
+class MiniMaxM3SparseAttentionPrefillFamily(Enum):
+    """MiniMax-M3 sparse-attention prefill metadata contract."""
+
+    SELECT_INDEX_AND_COUNT_SCORE = auto()
+    K2Q_CSR_SCORE = auto()
+
+
+class MLAPOEnablementPolicy(Enum):
+    """Runtime instances on which configured MLAPO may be enabled."""
+
+    DECODE_KV_CONSUMER_ONLY = auto()
+    ANY_CONFIGURED_INSTANCE = auto()
+
+
+class ModelRunnerV2ImplementationFamily(Enum):
+    """Model Runner V2 validation, state, and block-table implementation."""
+
+    DEFAULT_TRITON_BACKED = auto()
+    TRITON_FREE_HOST_METADATA = auto()
+
+
+class MoEDistributeApiFamily(Enum):
+    """Baseline CANN MoE distribute-v2 metadata contract.
+
+    A selected communication algorithm may add its own operands, such as
+    ``expert_scales`` for hierarchical communication.
+    """
+
+    EP_METADATA = auto()
+    EP_AND_TP_METADATA = auto()
+    # Adds always-on expert scales plus MXFP quant mode and output dtype.
+    EP_TP_WITH_EXPERT_SCALES_MXFP_MODE_AND_QUANT_OUTPUT_DTYPE = auto()
+
+
 class MoECommPolicy(Enum):
     """MoE communication selection policies."""
 
-    CAPACITY_AND_EXPERT_DENSITY = auto()
-    FUSED_OR_CAPACITY = auto()
-    CAPACITY_AND_WORLD_SIZE = auto()
+    # MC2 requires capacity plus a dense-enough expert placement; otherwise
+    # use all-gather.
+    MC2_IF_CAPACITY_AND_EXPERT_DENSITY_ELSE_ALLGATHER = auto()
+    # Prefer fused MC2, fall back to capacity-bounded MC2, then all-to-all.
+    FUSED_MC2_THEN_CAPACITY_MC2_ELSE_ALLTOALL = auto()
+    # Use MC2 within capacity; otherwise choose all-gather when world size is
+    # no greater than top-k, and all-to-all for larger worlds.
+    MC2_IF_CAPACITY_ELSE_ALLGATHER_OR_ALLTOALL_BY_WORLD_SIZE = auto()
     ALLGATHER = auto()
+
+
+class MoERouterFamily(Enum):
+    """Top-k routing implementation used by fused MoE layers."""
+
+    FUSED_OR_GROUPED_TOP_K = auto()
+    CHUNKED_SOFTMAX_TOP_K = auto()
+
+
+class OperatorRegistryFamily(Enum):
+    """Custom-op implementation set registered for shared business code."""
+
+    BASE_ASCEND_IMPLEMENTATIONS = auto()
+    # Overrides activation, rotary, normalization, embedding/LM-head,
+    # multimodal attention, Conv3d, GDN, and MoE implementations.
+    BASE_WITH_TRITON_FREE_KERNEL_OVERRIDES = auto()
 
 
 class QuantizationBackendFamily(Enum):
     """Quantization configuration implementation families."""
 
-    STANDARD = auto()
-    COMPATIBILITY = auto()
+    COMPRESSED_TENSORS_FP8_MXFP8_AND_MODELSLIM = auto()
+    MODELSLIM_ONLY = auto()
+
+
+class WorkerPatchFamily(Enum):
+    """Worker-time model patch bundles."""
+
+    QWEN3_5_DFLASH_AND_VL = auto()
+    TRITON_FREE_GDN_QWEN3_VL_AND_SPEC_DECODE = auto()
 
 
 class WeightLayoutPolicy(Enum):
@@ -117,13 +260,32 @@ class HardwareProfile:
 
     _device_type: AscendDeviceType
     attention_backend_family: AttentionBackendFamily
+    atb_matmul_warmup_required: bool
+    compilation_custom_op_policy: CompilationCustomOpPolicy
     cpu_binding_mode: CPUBindingMode
+    cudagraph_capture_size_limit: int | None
     default_worker_cls: str
     device_adaptor_family: DeviceAdaptorFamily
     device_addressing_mode: DeviceAddressingMode
-    weight_layout_policy: WeightLayoutPolicy
+    distributed_collective_family: DistributedCollectiveFamily
+    dsa_c128_block_sizes: tuple[int, ...]
+    dsa_o_proj_weight_layout_policy: DSAOProjWeightLayoutPolicy
+    gdn_patch_family: GDNPatchFamily
+    mamba_config_patch_family: MambaConfigPatchFamily
+    mc2_fullmesh_alias_policy: MC2FullmeshAliasPolicy
+    minimax_m3_indexer_family: MiniMaxM3IndexerFamily
+    minimax_m3_sparse_attention_prefill_family: MiniMaxM3SparseAttentionPrefillFamily
+    mlapo_enablement_policy: MLAPOEnablementPolicy
+    model_runner_v2_implementation_family: ModelRunnerV2ImplementationFamily
     moe_comm_policy: MoECommPolicy
+    moe_distribute_api_family: MoEDistributeApiFamily
+    moe_router_family: MoERouterFamily
+    operator_registry_family: OperatorRegistryFamily
     quantization_backend_family: QuantizationBackendFamily
+    reserve_irq_cpus: bool
+    split_fia_chunked_prefill_by_default: bool
+    weight_layout_policy: WeightLayoutPolicy
+    worker_patch_family: WorkerPatchFamily
     capabilities: frozenset[HardwareCapability]
 
     def supports(self, capability: HardwareCapability) -> bool:
@@ -132,120 +294,193 @@ class HardwareProfile:
         return capability in self.capabilities
 
 
-_STANDARD_CAPABILITIES = frozenset(
+_A2_A3_COMMON_CAPABILITIES = frozenset(
     {
-        HardwareCapability.AUTO_ENABLE_CUSTOM_OPS,
-        HardwareCapability.ATB_EXTENSIONS,
-        HardwareCapability.ATB_WARMUP,
-        HardwareCapability.BGMV_SGMV_META_REGISTRATION,
-        HardwareCapability.FUSED_SWIGLU_TUNING_ARGS,
+        HardwareCapability.ATB_MODEL_EXECUTION_EXTENSIONS,
+        HardwareCapability.BGMV_SGMV_META_KERNELS,
+        HardwareCapability.DEQUANT_SWIGLU_GLU_ALPHA_BIAS_ARGS,
         HardwareCapability.GRAPH_MULS_ADD_FUSION,
         HardwareCapability.GRAPH_NORM_QUANT_FUSION,
-        HardwareCapability.IRQ_CPU_RESERVATION,
-        HardwareCapability.LORA_CUSTOM_OPS,
+        HardwareCapability.LORA_BGMV_SGMV_CUSTOM_OPS,
         HardwareCapability.MC2_HIERARCHY_COMM,
-        HardwareCapability.NPUGRAPH_EX,
-        HardwareCapability.PAGED_ATTENTION,
-        HardwareCapability.RUNTIME_CUSTOM_OPS,
+        HardwareCapability.NPUGRAPH_EX_COMPILATION_BACKEND,
+        HardwareCapability.PAGED_ATTENTION_FULL_DECODE,
+        HardwareCapability.ASCEND_CUSTOM_OP_RUNTIME_REGISTRATION,
         HardwareCapability.SFA_DCP_REPLICATED_INDEXER,
-        HardwareCapability.STANDARD_MAMBA_PATCH,
-        HardwareCapability.STANDARD_WORKER_PATCHES,
-        HardwareCapability.TRITON_BATCH_MEMCPY,
+        HardwareCapability.TRITON_MAMBA_STATE_BATCH_MEMCPY,
+        HardwareCapability.XLITE_GRAPH_WORKER,
     }
 )
-_A3_CAPABILITIES = _STANDARD_CAPABILITIES | {HardwareCapability.MC2_FULLMESH_V2_COMM}
+_MINIMAX_M3_FALLBACK_CAPABILITIES = frozenset(
+    {
+        # Preserve the pre-profile ``device != A5`` behavior.  These entries
+        # do not by themselves declare MiniMax-M3 support on every family.
+        HardwareCapability.MINIMAX_M3_FUSED_CLIPPED_SWIGLU,
+        HardwareCapability.MINIMAX_M3_FUSED_QKV_RMSNORM_ROPE,
+        HardwareCapability.MINIMAX_M3_TP_SHARDED_INDEX_DECODE,
+    }
+)
 _DEFAULT_WORKER_CLS = "vllm_ascend.worker.worker.NPUWorker"
 _HARDWARE_PROFILES: Mapping[AscendDeviceType, HardwareProfile] = MappingProxyType(
     {
         AscendDeviceType.A2: HardwareProfile(
             _device_type=AscendDeviceType.A2,
-            attention_backend_family=AttentionBackendFamily.STANDARD,
+            attention_backend_family=AttentionBackendFamily.DENSE_MLA_SFA_DSA,
+            atb_matmul_warmup_required=True,
+            compilation_custom_op_policy=CompilationCustomOpPolicy.FORCE_ENABLE_ALL,
             cpu_binding_mode=CPUBindingMode.TOPO_AFFINITY,
+            cudagraph_capture_size_limit=None,
             default_worker_cls=_DEFAULT_WORKER_CLS,
-            device_adaptor_family=DeviceAdaptorFamily.STANDARD,
+            device_adaptor_family=DeviceAdaptorFamily.BASE_DEVICE_OPERATIONS,
             device_addressing_mode=DeviceAddressingMode.DIRECT,
+            distributed_collective_family=DistributedCollectiveFamily.TORCH_NPU_NATIVE,
+            dsa_c128_block_sizes=(8, 16, 32),
+            dsa_o_proj_weight_layout_policy=DSAOProjWeightLayoutPolicy.ALWAYS_TRANSPOSE_WO_A,
+            gdn_patch_family=GDNPatchFamily.FULL_FORWARD_PATCH,
+            mamba_config_patch_family=MambaConfigPatchFamily.MLA_OR_DENSE_CACHE_LAYOUT,
+            mc2_fullmesh_alias_policy=MC2FullmeshAliasPolicy.PASSTHROUGH,
+            minimax_m3_indexer_family=MiniMaxM3IndexerFamily.ASCENDC_SCORE_AND_DECODE_WITH_TRITON_TOPK,
+            minimax_m3_sparse_attention_prefill_family=MiniMaxM3SparseAttentionPrefillFamily.SELECT_INDEX_AND_COUNT_SCORE,
+            mlapo_enablement_policy=MLAPOEnablementPolicy.DECODE_KV_CONSUMER_ONLY,
+            model_runner_v2_implementation_family=ModelRunnerV2ImplementationFamily.DEFAULT_TRITON_BACKED,
+            moe_comm_policy=MoECommPolicy.MC2_IF_CAPACITY_AND_EXPERT_DENSITY_ELSE_ALLGATHER,
+            moe_distribute_api_family=MoEDistributeApiFamily.EP_METADATA,
+            moe_router_family=MoERouterFamily.FUSED_OR_GROUPED_TOP_K,
+            operator_registry_family=OperatorRegistryFamily.BASE_ASCEND_IMPLEMENTATIONS,
+            quantization_backend_family=QuantizationBackendFamily.COMPRESSED_TENSORS_FP8_MXFP8_AND_MODELSLIM,
+            reserve_irq_cpus=True,
+            split_fia_chunked_prefill_by_default=False,
             weight_layout_policy=WeightLayoutPolicy.CONFIGURABLE,
-            moe_comm_policy=MoECommPolicy.CAPACITY_AND_EXPERT_DENSITY,
-            quantization_backend_family=QuantizationBackendFamily.STANDARD,
-            capabilities=_STANDARD_CAPABILITIES | {HardwareCapability.NPU_TOP_K_TOP_P},
+            worker_patch_family=WorkerPatchFamily.QWEN3_5_DFLASH_AND_VL,
+            capabilities=_A2_A3_COMMON_CAPABILITIES
+            | _MINIMAX_M3_FALLBACK_CAPABILITIES
+            | {HardwareCapability.NATIVE_TOP_K_TOP_P_SAMPLING},
         ),
         AscendDeviceType.A3: HardwareProfile(
             _device_type=AscendDeviceType.A3,
-            attention_backend_family=AttentionBackendFamily.STANDARD,
+            attention_backend_family=AttentionBackendFamily.DENSE_MLA_SFA_DSA,
+            atb_matmul_warmup_required=True,
+            compilation_custom_op_policy=CompilationCustomOpPolicy.FORCE_ENABLE_ALL,
             cpu_binding_mode=CPUBindingMode.GLOBAL_SLICE,
+            cudagraph_capture_size_limit=None,
             default_worker_cls=_DEFAULT_WORKER_CLS,
-            device_adaptor_family=DeviceAdaptorFamily.STANDARD,
+            device_adaptor_family=DeviceAdaptorFamily.BASE_DEVICE_OPERATIONS,
             device_addressing_mode=DeviceAddressingMode.DUAL_CHIP_CARD,
+            distributed_collective_family=DistributedCollectiveFamily.TORCH_NPU_NATIVE,
+            dsa_c128_block_sizes=(8, 16, 32),
+            dsa_o_proj_weight_layout_policy=DSAOProjWeightLayoutPolicy.ALWAYS_TRANSPOSE_WO_A,
+            gdn_patch_family=GDNPatchFamily.FULL_FORWARD_PATCH,
+            mamba_config_patch_family=MambaConfigPatchFamily.MLA_OR_DENSE_CACHE_LAYOUT,
+            mc2_fullmesh_alias_policy=MC2FullmeshAliasPolicy.MAP_FULLMESH_TO_V1,
+            minimax_m3_indexer_family=MiniMaxM3IndexerFamily.ASCENDC_SCORE_AND_DECODE_WITH_TRITON_TOPK,
+            minimax_m3_sparse_attention_prefill_family=MiniMaxM3SparseAttentionPrefillFamily.SELECT_INDEX_AND_COUNT_SCORE,
+            mlapo_enablement_policy=MLAPOEnablementPolicy.DECODE_KV_CONSUMER_ONLY,
+            model_runner_v2_implementation_family=ModelRunnerV2ImplementationFamily.DEFAULT_TRITON_BACKED,
+            moe_comm_policy=MoECommPolicy.FUSED_MC2_THEN_CAPACITY_MC2_ELSE_ALLTOALL,
+            moe_distribute_api_family=MoEDistributeApiFamily.EP_AND_TP_METADATA,
+            moe_router_family=MoERouterFamily.FUSED_OR_GROUPED_TOP_K,
+            operator_registry_family=OperatorRegistryFamily.BASE_ASCEND_IMPLEMENTATIONS,
+            quantization_backend_family=QuantizationBackendFamily.COMPRESSED_TENSORS_FP8_MXFP8_AND_MODELSLIM,
+            reserve_irq_cpus=True,
+            split_fia_chunked_prefill_by_default=False,
             weight_layout_policy=WeightLayoutPolicy.CONFIGURABLE,
-            moe_comm_policy=MoECommPolicy.FUSED_OR_CAPACITY,
-            quantization_backend_family=QuantizationBackendFamily.STANDARD,
-            capabilities=_A3_CAPABILITIES
+            worker_patch_family=WorkerPatchFamily.QWEN3_5_DFLASH_AND_VL,
+            capabilities=_A2_A3_COMMON_CAPABILITIES
+            | _MINIMAX_M3_FALLBACK_CAPABILITIES
             | {
-                HardwareCapability.CANN_MEGAMOE,
-                HardwareCapability.MOE_DISPATCH_EXTRA_ARGS,
-                HardwareCapability.NPU_TOP_K_TOP_P,
+                HardwareCapability.CANN_MEGAMOE_FUSED_MC2,
+                HardwareCapability.MC2_FULLMESH_V2,
+                HardwareCapability.NATIVE_TOP_K_TOP_P_SAMPLING,
             },
         ),
         AscendDeviceType._310P: HardwareProfile(
             _device_type=AscendDeviceType._310P,
-            attention_backend_family=AttentionBackendFamily.COMPATIBILITY,
+            attention_backend_family=AttentionBackendFamily.DENSE_ONLY,
+            atb_matmul_warmup_required=False,
+            compilation_custom_op_policy=CompilationCustomOpPolicy.PRESERVE_CONFIGURATION,
             cpu_binding_mode=CPUBindingMode.TOPO_AFFINITY,
+            cudagraph_capture_size_limit=None,
             default_worker_cls="vllm_ascend._310p.worker_310p.NPUWorker310",
-            device_adaptor_family=DeviceAdaptorFamily.COMPATIBILITY,
+            device_adaptor_family=DeviceAdaptorFamily.RESHAPE_CACHE_AND_INDEX_FILL_OPERATIONS,
             device_addressing_mode=DeviceAddressingMode.DIRECT,
-            weight_layout_policy=WeightLayoutPolicy.FORCE_NZ,
+            distributed_collective_family=DistributedCollectiveFamily.BROADCAST_AND_INT64_ALLREDUCE_VIA_ALLGATHER,
+            dsa_c128_block_sizes=(8, 16, 32),
+            dsa_o_proj_weight_layout_policy=DSAOProjWeightLayoutPolicy.ALWAYS_TRANSPOSE_WO_A,
+            gdn_patch_family=GDNPatchFamily.CORE_AND_DTYPE_PATCH,
+            mamba_config_patch_family=MambaConfigPatchFamily.DENSE_ATTENTION_CACHE_ONLY,
+            mc2_fullmesh_alias_policy=MC2FullmeshAliasPolicy.PASSTHROUGH,
+            minimax_m3_indexer_family=MiniMaxM3IndexerFamily.ASCENDC_SCORE_AND_DECODE_WITH_TRITON_TOPK,
+            minimax_m3_sparse_attention_prefill_family=MiniMaxM3SparseAttentionPrefillFamily.SELECT_INDEX_AND_COUNT_SCORE,
+            mlapo_enablement_policy=MLAPOEnablementPolicy.DECODE_KV_CONSUMER_ONLY,
+            model_runner_v2_implementation_family=ModelRunnerV2ImplementationFamily.TRITON_FREE_HOST_METADATA,
             moe_comm_policy=MoECommPolicy.ALLGATHER,
-            quantization_backend_family=QuantizationBackendFamily.COMPATIBILITY,
-            capabilities=frozenset(
+            moe_distribute_api_family=MoEDistributeApiFamily.EP_METADATA,
+            moe_router_family=MoERouterFamily.CHUNKED_SOFTMAX_TOP_K,
+            operator_registry_family=OperatorRegistryFamily.BASE_WITH_TRITON_FREE_KERNEL_OVERRIDES,
+            quantization_backend_family=QuantizationBackendFamily.MODELSLIM_ONLY,
+            reserve_irq_cpus=True,
+            split_fia_chunked_prefill_by_default=False,
+            weight_layout_policy=WeightLayoutPolicy.FORCE_NZ,
+            worker_patch_family=WorkerPatchFamily.TRITON_FREE_GDN_QWEN3_VL_AND_SPEC_DECODE,
+            capabilities=_MINIMAX_M3_FALLBACK_CAPABILITIES
+            | frozenset(
                 {
-                    HardwareCapability.COMPATIBILITY_OP_IMPLEMENTATIONS,
-                    HardwareCapability.DISTRIBUTED_COMMUNICATION_ADAPTATION,
-                    HardwareCapability.FUSED_MOE_COMPATIBILITY,
-                    HardwareCapability.FUSED_SWIGLU_TUNING_ARGS,
-                    HardwareCapability.GDN_COMPATIBILITY,
-                    HardwareCapability.IRQ_CPU_RESERVATION,
-                    HardwareCapability.RC_DEVICE_DISCOVERY,
-                    HardwareCapability.RUNTIME_CUSTOM_OPS,
+                    HardwareCapability.DEQUANT_SWIGLU_GLU_ALPHA_BIAS_ARGS,
+                    HardwareCapability.PCIE_ROOT_COMPLEX_MODE_DETECTION,
+                    HardwareCapability.ASCEND_CUSTOM_OP_RUNTIME_REGISTRATION,
                 }
             ),
         ),
         AscendDeviceType.A5: HardwareProfile(
             _device_type=AscendDeviceType.A5,
-            attention_backend_family=AttentionBackendFamily.STANDARD,
+            attention_backend_family=AttentionBackendFamily.DENSE_MLA_SFA_DSA,
+            atb_matmul_warmup_required=False,
+            compilation_custom_op_policy=CompilationCustomOpPolicy.FORCE_ENABLE_ALL,
             cpu_binding_mode=CPUBindingMode.TOPO_AFFINITY,
+            cudagraph_capture_size_limit=4,
             default_worker_cls=_DEFAULT_WORKER_CLS,
-            device_adaptor_family=DeviceAdaptorFamily.FP8_OPTIMIZED,
+            device_adaptor_family=DeviceAdaptorFamily.FP8_MXFP_DSA_AND_FUSED_MODEL_OPERATIONS,
             device_addressing_mode=DeviceAddressingMode.DIRECT,
+            distributed_collective_family=DistributedCollectiveFamily.TORCH_NPU_NATIVE,
+            dsa_c128_block_sizes=(4, 8, 16),
+            dsa_o_proj_weight_layout_policy=DSAOProjWeightLayoutPolicy.TRANSPOSE_UNQUANTIZED_BF16_WO_A_ONLY,
+            gdn_patch_family=GDNPatchFamily.FULL_FORWARD_PATCH,
+            mamba_config_patch_family=MambaConfigPatchFamily.MLA_OR_DENSE_CACHE_LAYOUT,
+            mc2_fullmesh_alias_policy=MC2FullmeshAliasPolicy.PASSTHROUGH,
+            minimax_m3_indexer_family=MiniMaxM3IndexerFamily.TRITON_SCORE_TOPK_DECODE,
+            minimax_m3_sparse_attention_prefill_family=MiniMaxM3SparseAttentionPrefillFamily.K2Q_CSR_SCORE,
+            mlapo_enablement_policy=MLAPOEnablementPolicy.ANY_CONFIGURED_INSTANCE,
+            model_runner_v2_implementation_family=ModelRunnerV2ImplementationFamily.DEFAULT_TRITON_BACKED,
+            moe_comm_policy=MoECommPolicy.MC2_IF_CAPACITY_ELSE_ALLGATHER_OR_ALLTOALL_BY_WORLD_SIZE,
+            moe_distribute_api_family=MoEDistributeApiFamily.EP_TP_WITH_EXPERT_SCALES_MXFP_MODE_AND_QUANT_OUTPUT_DTYPE,
+            moe_router_family=MoERouterFamily.FUSED_OR_GROUPED_TOP_K,
+            operator_registry_family=OperatorRegistryFamily.BASE_ASCEND_IMPLEMENTATIONS,
+            quantization_backend_family=QuantizationBackendFamily.COMPRESSED_TENSORS_FP8_MXFP8_AND_MODELSLIM,
+            reserve_irq_cpus=False,
+            split_fia_chunked_prefill_by_default=True,
             weight_layout_policy=WeightLayoutPolicy.CONFIGURABLE,
-            moe_comm_policy=MoECommPolicy.CAPACITY_AND_WORLD_SIZE,
-            quantization_backend_family=QuantizationBackendFamily.STANDARD,
+            worker_patch_family=WorkerPatchFamily.QWEN3_5_DFLASH_AND_VL,
             capabilities=frozenset(
                 {
-                    HardwareCapability.AUTO_ENABLE_CUSTOM_OPS,
-                    HardwareCapability.BGMV_SGMV_META_REGISTRATION,
-                    HardwareCapability.CHUNKED_PREFILL_PHASE_SPLIT,
+                    HardwareCapability.BGMV_SGMV_META_KERNELS,
+                    HardwareCapability.BLOCK_FP8_TO_MXFP8_REQUANTIZATION,
                     HardwareCapability.CLUSTER_CPU_TOPOLOGY,
-                    HardwareCapability.DSA_C128_STATE_SMALL_BLOCK_SIZES,
                     HardwareCapability.DSA_O_PROJ_TP,
-                    HardwareCapability.DSV4_COMPRESSED_CACHE,
-                    HardwareCapability.DYNAMIC_MX_QUANT_FUSION,
-                    HardwareCapability.DYNAMIC_MX_QUANT_SCALE_ALG_ONE,
+                    HardwareCapability.DSA_COMPRESSED_KV_CACHE,
+                    HardwareCapability.DYNAMIC_MX_QUANT_E8M0_OVERFLOW_SAFE_SCALING,
                     HardwareCapability.FP8_ATTENTION,
+                    HardwareCapability.GRAPH_DYNAMIC_MX_QUANT_FUSION,
                     HardwareCapability.GRAPH_MULS_ADD_FUSION,
                     HardwareCapability.GRAPH_NORM_QUANT_FUSION,
-                    HardwareCapability.LOCAL_KV_COMM_RESOURCE,
-                    HardwareCapability.LORA_CUSTOM_OPS,
+                    HardwareCapability.LOCAL_KV_TRANSFER_COMM_RESOURCE,
+                    HardwareCapability.LORA_BGMV_SGMV_CUSTOM_OPS,
                     HardwareCapability.MLA_DECODE_PROLOG_WITHOUT_ROPE,
-                    HardwareCapability.MLAPO_NATIVE_WEIGHTS,
-                    HardwareCapability.MOE_DISPATCH_EXTRA_ARGS,
-                    HardwareCapability.MOE_DISPATCH_SHARED_EXPERT_ARGS,
-                    HardwareCapability.NPUGRAPH_EX,
-                    HardwareCapability.REDUCED_CUDAGRAPH_CAPTURE_SIZES,
-                    HardwareCapability.STANDARD_MAMBA_PATCH,
-                    HardwareCapability.STANDARD_WORKER_PATCHES,
-                    HardwareCapability.SWIGLU_OAI_MX_QUANT,
-                    HardwareCapability.TRITON_BATCH_MEMCPY,
-                    HardwareCapability.UNRESTRICTED_MLAPO,
+                    HardwareCapability.MLAPO_UNQUANTIZED_PROJECTION_WEIGHTS,
+                    HardwareCapability.MINIMAX_M3_PAGED_INDEX_CACHE_SCATTER,
+                    HardwareCapability.MINIMAX_M3_SWIGLU_OAI_MXFP8_OUTPUT_QUANTIZATION,
+                    HardwareCapability.NPUGRAPH_EX_COMPILATION_BACKEND,
+                    HardwareCapability.TRITON_MAMBA_STATE_BATCH_MEMCPY,
+                    HardwareCapability.XLITE_GRAPH_WORKER,
                 }
             ),
         ),

--- a/vllm_ascend/lora/punica_npu.py
+++ b/vllm_ascend/lora/punica_npu.py
@@ -22,7 +22,7 @@ class PunicaWrapperNPU(PunicaWrapperBase):
         PunicaWrapperBase.__init__(self, max_num_batched_tokens, max_batches, device)
         refresh_all_lora_classes()
         self.lora_config = kwargs.get("lora_config")
-        if not get_current_hardware_profile().supports(HardwareCapability.LORA_CUSTOM_OPS) or (
+        if not get_current_hardware_profile().supports(HardwareCapability.LORA_BGMV_SGMV_CUSTOM_OPS) or (
             self.lora_config is not None and self.lora_config.max_lora_rank >= 128
         ):
             from vllm.lora.ops.torch_ops import (

--- a/vllm_ascend/meta_registration.py
+++ b/vllm_ascend/meta_registration.py
@@ -72,6 +72,6 @@ def sgmv_expand_meta(
     return y_out
 
 
-if get_current_hardware_profile().supports(HardwareCapability.BGMV_SGMV_META_REGISTRATION):
+if get_current_hardware_profile().supports(HardwareCapability.BGMV_SGMV_META_KERNELS):
     register_meta_if_necessary("_C_ascend", "bgmv_expand", bgmv_expand_meta)
     register_meta_if_necessary("_C_ascend", "sgmv_expand", sgmv_expand_meta)

--- a/vllm_ascend/models/deepseek_v4/compressor.py
+++ b/vllm_ascend/models/deepseek_v4/compressor.py
@@ -127,7 +127,7 @@ class Compressor(nn.Module):
             self.coff * self.head_dim,
             bias=False,
             quant_config=None
-            if get_current_hardware_profile().supports(HardwareCapability.DSV4_COMPRESSED_CACHE)
+            if get_current_hardware_profile().supports(HardwareCapability.DSA_COMPRESSED_KV_CACHE)
             else quant_config,
             prefix=f"{prefix}.wkv",
             return_bias=False,
@@ -137,7 +137,7 @@ class Compressor(nn.Module):
             self.coff * self.head_dim,
             bias=False,
             quant_config=None
-            if get_current_hardware_profile().supports(HardwareCapability.DSV4_COMPRESSED_CACHE)
+            if get_current_hardware_profile().supports(HardwareCapability.DSA_COMPRESSED_KV_CACHE)
             else quant_config,
             prefix=f"{prefix}.wgate",
             return_bias=False,
@@ -145,7 +145,9 @@ class Compressor(nn.Module):
 
         # A5 compressor kernel needs float for norm_weight input
         norm_dtype = (
-            torch.float32 if get_current_hardware_profile().supports(HardwareCapability.DSV4_COMPRESSED_CACHE) else None
+            torch.float32
+            if get_current_hardware_profile().supports(HardwareCapability.DSA_COMPRESSED_KV_CACHE)
+            else None
         )
         self.norm = RMSNorm(self.head_dim, config.rms_norm_eps, dtype=norm_dtype)
 

--- a/vllm_ascend/models/deepseek_v4/indexer.py
+++ b/vllm_ascend/models/deepseek_v4/indexer.py
@@ -39,7 +39,7 @@ from vllm.models.deepseek_v4.attention import DeepseekV4IndexerCache
 from vllm.transformers_utils.configs.deepseek_v4 import DeepseekV4Config
 from vllm.v1.kv_cache_interface import KVCacheSpec
 
-from vllm_ascend.attention.dsa_attn_kv_plan import is_a5_bf16_kv_enabled
+from vllm_ascend.attention.dsa_attn_kv_plan import is_dsv4_bf16_sparse_flash_mla_enabled
 from vllm_ascend.device.hardware_profile import HardwareCapability, get_current_hardware_profile
 from vllm_ascend.models.deepseek_v4.compressor import AscendCompressorMetadata, Compressor
 from vllm_ascend.ops.cv_linear import CVLinearWrapper
@@ -90,9 +90,9 @@ class AscendDeepseekV4IndexerCache(DeepseekV4IndexerCache):
         super().__init__(head_dim, dtype, prefix, cache_config, compress_ratio)
 
     def get_kv_cache_spec(self, vllm_config: VllmConfig) -> KVCacheSpec:
-        if get_current_hardware_profile().supports(HardwareCapability.DSV4_COMPRESSED_CACHE):
+        if get_current_hardware_profile().supports(HardwareCapability.DSA_COMPRESSED_KV_CACHE):
             self.dtype = torch.float8_e4m3fn
-            if not is_a5_bf16_kv_enabled(vllm_config):
+            if not is_dsv4_bf16_sparse_flash_mla_enabled(vllm_config):
                 vllm_config.cache_config.cache_dtype = "float8_e4m3fn"
 
         from vllm_ascend.core.kv_cache_interface import AscendMLAAttentionSpec
@@ -109,7 +109,7 @@ class AscendDeepseekV4IndexerCache(DeepseekV4IndexerCache):
             cache_dtype_str=self.cache_config.cache_dtype,
             scale_dim=1 if self.head_dim == 128 else 0,
             scale_dtype=torch.float
-            if get_current_hardware_profile().supports(HardwareCapability.DSV4_COMPRESSED_CACHE)
+            if get_current_hardware_profile().supports(HardwareCapability.DSA_COMPRESSED_KV_CACHE)
             else torch.float16,
         )
 
@@ -292,7 +292,7 @@ class DeepseekV4Indexer(nn.Module):
         )
         k_dtype = (
             torch.float8_e4m3fn
-            if get_current_hardware_profile().supports(HardwareCapability.DSV4_COMPRESSED_CACHE)
+            if get_current_hardware_profile().supports(HardwareCapability.DSA_COMPRESSED_KV_CACHE)
             else torch.int8
         )
 

--- a/vllm_ascend/models/layer/attention/layer.py
+++ b/vllm_ascend/models/layer/attention/layer.py
@@ -19,7 +19,7 @@ from vllm.v1.attention.backend import AttentionBackend
 from vllm.v1.attention.backends.mla.sparse_swa import DeepseekV4SWACache
 from vllm.v1.kv_cache_interface import KVCacheSpec
 
-from vllm_ascend.attention.dsa_attn_kv_plan import is_a5_bf16_kv_enabled
+from vllm_ascend.attention.dsa_attn_kv_plan import is_dsv4_bf16_sparse_flash_mla_enabled
 from vllm_ascend.attention.dsa_v1 import (
     AscendDSAC4Backend,
     AscendDSAC128Backend,
@@ -29,7 +29,7 @@ from vllm_ascend.core.kv_cache_interface import AscendMLAAttentionSpec
 from vllm_ascend.device.hardware_profile import HardwareCapability, get_current_hardware_profile
 
 
-def get_dsv4_block_sizes(use_a5_bf16_kv: bool = False):
+def get_dsv4_block_sizes(use_bf16_sparse_flash_mla: bool = False):
     # cache_config.block_size: [mla, swa, c4 state, c128 state], [page_size_padded_t1, page_size_padded_t2]
     _DSV4_BLOCK_SIZES = {
         128: [[128, 128, 8, 32], [16640, 131072]],
@@ -41,26 +41,26 @@ def get_dsv4_block_sizes(use_a5_bf16_kv: bool = False):
         64: [[64, 64, 4, 8], [8448, 40960]],
         32: [[32, 32, 2, 4], [4224, 20480]],
     }
-    _DSV4_BLOCK_SIZES_A5_BF16 = {
+    _DSV4_BLOCK_SIZES_BF16_SPARSE_FLASH_MLA = {
         128: [[128, 128, 8, 16], [16896, 131072]],
         64: [[64, 64, 4, 8], [8448, 65536]],
         32: [[32, 32, 2, 4], [4224, 32768]],
     }
-    if get_current_hardware_profile().supports(HardwareCapability.DSV4_COMPRESSED_CACHE):
-        if use_a5_bf16_kv:
-            return _DSV4_BLOCK_SIZES_A5_BF16
+    if get_current_hardware_profile().supports(HardwareCapability.DSA_COMPRESSED_KV_CACHE):
+        if use_bf16_sparse_flash_mla:
+            return _DSV4_BLOCK_SIZES_BF16_SPARSE_FLASH_MLA
         return _DSV4_COMPRESSED_BLOCK_SIZES
     return _DSV4_BLOCK_SIZES
 
 
 DSV4_BLOCK_SIZES = get_dsv4_block_sizes()
-DSV4_BLOCK_SIZES_A5_BF16 = get_dsv4_block_sizes(use_a5_bf16_kv=True)
+DSV4_BLOCK_SIZES_BF16_SPARSE_FLASH_MLA = get_dsv4_block_sizes(use_bf16_sparse_flash_mla=True)
 
 
 def dsv4_block_sizes(vllm_config: VllmConfig):
-    """Return the A5 BF16 KV table when explicitly requested, else the upstream table."""
-    if is_a5_bf16_kv_enabled(vllm_config):
-        return DSV4_BLOCK_SIZES_A5_BF16
+    """Return the BF16 SparseFlashMla table when selected, else the default."""
+    if is_dsv4_bf16_sparse_flash_mla_enabled(vllm_config):
+        return DSV4_BLOCK_SIZES_BF16_SPARSE_FLASH_MLA
     return DSV4_BLOCK_SIZES
 
 
@@ -191,8 +191,8 @@ class DSAAttention(nn.Module, AttentionLayerBase):
         if self.compress_ratio <= 1:  # SWA part. Allocated separately as DeepseekV4SWACache.
             return None
         kv_cache_dtype = kv_cache_dtype_str_to_dtype(self.kv_cache_dtype, vllm_config.model_config)
-        use_bf16_kv = is_a5_bf16_kv_enabled(vllm_config)
-        has_compressed_cache = get_current_hardware_profile().supports(HardwareCapability.DSV4_COMPRESSED_CACHE)
+        use_bf16_kv = is_dsv4_bf16_sparse_flash_mla_enabled(vllm_config)
+        has_compressed_cache = get_current_hardware_profile().supports(HardwareCapability.DSA_COMPRESSED_KV_CACHE)
         if use_bf16_kv:
             kv_cache_dtype = torch.bfloat16
         elif has_compressed_cache:

--- a/vllm_ascend/models/minimax_m3/minimax_m3.py
+++ b/vllm_ascend/models/minimax_m3/minimax_m3.py
@@ -96,6 +96,10 @@ from vllm.v1.kv_cache_interface import (
 )
 
 from vllm_ascend.device.device_op import DeviceOperator
+from vllm_ascend.device.hardware_profile import (
+    HardwareCapability,
+    get_current_hardware_profile,
+)
 from vllm_ascend.models.minimax_m3.msa_m3 import (
     AscendMiniMaxM3Indexer,
     AscendMiniMaxM3IndexerLinear,
@@ -107,7 +111,6 @@ from vllm_ascend.models.minimax_m3.msa_m3 import (
     _register_m3_sparse_packed_modules,
     _use_fused_qkv_indexer,
 )
-from vllm_ascend.utils import AscendDeviceType, get_ascend_device_type
 from vllm_ascend.worker.v2.pp_utils import (
     PPTransportDataType,
     add_pp_transport_tensors,
@@ -161,6 +164,9 @@ def _cast_for_cache(tensor: torch.Tensor, cache: torch.Tensor) -> torch.Tensor:
     return tensor.to(cache.dtype)
 
 
+_HARDWARE_PROFILE = get_current_hardware_profile()
+
+
 def _scatter_index_cache(
     cache: torch.Tensor,
     updates: torch.Tensor,
@@ -175,9 +181,9 @@ def _scatter_index_cache(
     if updates.dtype != cache.dtype:
         updates = updates.to(cache.dtype)
 
-    if get_ascend_device_type() == AscendDeviceType.A5:
+    if _HARDWARE_PROFILE.supports(HardwareCapability.MINIMAX_M3_PAGED_INDEX_CACHE_SCATTER):
         if cache.ndim != 3:
-            raise ValueError(f"Unexpected MiniMax-M3 index cache ndim on A5: {cache.ndim}")
+            raise ValueError(f"Unexpected paged MiniMax-M3 index cache ndim: {cache.ndim}")
         key = updates.reshape(slots.shape[0], 1, cache.shape[-1]).contiguous()
         key_cache = cache.unsqueeze(2)
         torch_npu.npu_scatter_pa_cache(
@@ -418,7 +424,7 @@ class MiniMaxM3SparseAttention(nn.Module, AttentionLayerBase):
             )
 
         if (
-            get_ascend_device_type() == AscendDeviceType.A5
+            not _HARDWARE_PROFILE.supports(HardwareCapability.MINIMAX_M3_FUSED_QKV_RMSNORM_ROPE)
             or main_qkv.device.type != "npu"
             or main_qkv.dtype != torch.bfloat16
             or positions.ndim != 1
@@ -565,7 +571,7 @@ class MiniMaxM3SwiGLUOAI(nn.Module):
         self.use_mx_quant = use_mx_quant
 
     def forward(self, x: torch.Tensor) -> torch.Tensor | tuple[torch.Tensor, torch.Tensor]:
-        if self.use_mx_quant or get_ascend_device_type() == AscendDeviceType.A5:
+        if self.use_mx_quant or not _HARDWARE_PROFILE.supports(HardwareCapability.MINIMAX_M3_FUSED_CLIPPED_SWIGLU):
             d = x.shape[-1] // 2
             gate = torch.clamp(x[..., :d], max=self.limit)
             up = torch.clamp(x[..., d:], min=-self.limit, max=self.limit)
@@ -621,7 +627,7 @@ class MiniMaxM3MLP(nn.Module):
         )
         if hidden_act == "swigluoai":
             use_mx_quant = (
-                get_ascend_device_type() == AscendDeviceType.A5
+                _HARDWARE_PROFILE.supports(HardwareCapability.MINIMAX_M3_SWIGLU_OAI_MXFP8_OUTPUT_QUANTIZATION)
                 and _is_w8a8_mxfp8_linear(self.gate_up_proj)
                 and _is_w8a8_mxfp8_linear(self.down_proj)
             )

--- a/vllm_ascend/models/minimax_m3/msa_m3.py
+++ b/vllm_ascend/models/minimax_m3/msa_m3.py
@@ -39,6 +39,11 @@ from vllm.v1.kv_cache_interface import (
 
 from vllm_ascend.attention.attention_mask import AttentionMaskBuilder
 from vllm_ascend.core.kv_cache_interface import AscendSFAIndexerCacheSpec
+from vllm_ascend.device.hardware_profile import (
+    HardwareCapability,
+    MiniMaxM3IndexerFamily,
+    get_current_hardware_profile,
+)
 from vllm_ascend.models.minimax_m3.ops.msa_m3_npu import (
     MiniMaxM3TPDecodeScoreMetadata,
     minimax_m3_index_tp_block_parallel_decode,
@@ -53,9 +58,11 @@ from vllm_ascend.models.minimax_m3.ops.msa_m3_npu import (
 )
 from vllm_ascend.ops.linear import AscendColumnParallelLinear
 from vllm_ascend.ops.linear_op import get_parallel_op
-from vllm_ascend.utils import AscendDeviceType, get_ascend_device_type
 
-_USE_ASCENDC_INDEX_SCORE = get_ascend_device_type() != AscendDeviceType.A5
+_HARDWARE_PROFILE = get_current_hardware_profile()
+_USE_ASCENDC_INDEX_SCORE = (
+    _HARDWARE_PROFILE.minimax_m3_indexer_family is MiniMaxM3IndexerFamily.ASCENDC_SCORE_AND_DECODE_WITH_TRITON_TOPK
+)
 
 if not _USE_ASCENDC_INDEX_SCORE:
     from vllm_ascend.models.minimax_m3.ops.msa_m3_triton_a5 import (
@@ -66,10 +73,13 @@ if not _USE_ASCENDC_INDEX_SCORE:
 
 
 def _should_use_tp_sharded_index_decode(tp_size: int, num_prefills: int) -> bool:
-    # The A5 Triton decode kernel operates on the complete, replicated index-K
-    # cache on every TP rank. Keep the mainline block-sharded optimization for
-    # the other device families only.
-    return get_ascend_device_type() != AscendDeviceType.A5 and tp_size > 1 and num_prefills == 0
+    # Only profiles that explicitly support sharded index decode may use the
+    # block-parallel optimization, regardless of the selected indexer family.
+    return (
+        _HARDWARE_PROFILE.supports(HardwareCapability.MINIMAX_M3_TP_SHARDED_INDEX_DECODE)
+        and tp_size > 1
+        and num_prefills == 0
+    )
 
 
 def _active_decode_num_reqs(
@@ -361,7 +371,7 @@ class AscendMiniMaxM3IndexerMetadataBuilder(AttentionMetadataBuilder[AscendMiniM
                 cu_seqlens_q=decode_cu_seqlens_q,
                 context_lens=decode_context_lens,
             )
-            if _USE_ASCENDC_INDEX_SCORE and self.tp_size > 1 and active_prefills == 0:
+            if _USE_ASCENDC_INDEX_SCORE and _should_use_tp_sharded_index_decode(self.tp_size, active_prefills):
                 decode_metadata.tp_score = self._build_tp_score_metadata(
                     decode_metadata.block_table,
                     decode_cu_seqlens_q,
@@ -504,7 +514,7 @@ class AscendMiniMaxM3IndexerImpl(nn.Module):
             tp_group = get_tp_group()
             decode_iq = iq[:num_decode_tokens]
             if _USE_ASCENDC_INDEX_SCORE:
-                if tp_group.world_size > 1 and index_md.num_prefills == 0:
+                if _should_use_tp_sharded_index_decode(tp_group.world_size, index_md.num_prefills):
                     decode_topk = minimax_m3_index_tp_block_parallel_decode(
                         decode_iq,
                         kv,

--- a/vllm_ascend/models/minimax_m3/ops/msa_m3_npu.py
+++ b/vllm_ascend/models/minimax_m3/ops/msa_m3_npu.py
@@ -8,19 +8,20 @@ from typing import Any
 
 import torch
 
-from vllm_ascend.utils import (
-    AscendDeviceType,
-    enable_custom_op,
-    get_ascend_device_type,
+from vllm_ascend.device.hardware_profile import (
+    MiniMaxM3IndexerFamily,
+    MiniMaxM3SparseAttentionPrefillFamily,
+    get_current_hardware_profile,
 )
+from vllm_ascend.utils import enable_custom_op
 
 _SPARSE_ATTN_INNER_PRECISE = 4
 _MSA_INDEX_BLOCK_SIZE = 128
 _MSA_SCORE_BLOCK_ALIGNMENT = 16
-_ASCEND_DEVICE_TYPE = get_ascend_device_type()
 _FP8_E4M3_MAX = 448.0
+_HARDWARE_PROFILE = get_current_hardware_profile()
 
-if _ASCEND_DEVICE_TYPE != AscendDeviceType.A5:
+if _HARDWARE_PROFILE.minimax_m3_indexer_family is MiniMaxM3IndexerFamily.ASCENDC_SCORE_AND_DECODE_WITH_TRITON_TOPK:
     from vllm_ascend.models.minimax_m3.ops.msa_m3_triton import (
         minimax_m3_index_topk as _minimax_m3_index_prefill_topk,
     )
@@ -49,8 +50,8 @@ def _npu_k2q_csr(
     q_global_offset: int | bool = False,
 ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
     """Convert MiniMax-M3 q2k indices to k2q CSR on NPU."""
-    # A5 disables the generic custom-op loader, so register the in-tree
-    # MiniMax M3 operators lazily after the NPU runtime has been initialized.
+    # This path can run when the generic custom-op loader is disabled, so
+    # register the in-tree MiniMax M3 operators after NPU initialization.
     import vllm_ascend.vllm_ascend_C  # type: ignore[import-untyped]  # noqa: F401, PLC0415
 
     enable_custom_op()
@@ -495,7 +496,7 @@ def minimax_m3_index_tp_block_parallel_decode(
 
 
 @torch.no_grad()
-def _minimax_m3_sparse_attn_a3(
+def _minimax_m3_sparse_attn_select_count_score(
     q: torch.Tensor,
     kv_cache: torch.Tensor | tuple[torch.Tensor, ...] | list[torch.Tensor],
     topk_idx: torch.Tensor,
@@ -527,7 +528,7 @@ def _minimax_m3_sparse_attn_a3(
     output.copy_(out)
 
 
-def _minimax_m3_sparse_attn_a5(
+def _minimax_m3_sparse_attn_k2q_csr_score(
     q: torch.Tensor,
     kv_cache: torch.Tensor | tuple[torch.Tensor, ...] | list[torch.Tensor],
     topk_idx: torch.Tensor,
@@ -580,6 +581,12 @@ def _minimax_m3_sparse_attn_a5(
     output.copy_(out)
 
 
+_MINIMAX_M3_SPARSE_ATTN_PREFILL_IMPLS = {
+    MiniMaxM3SparseAttentionPrefillFamily.SELECT_INDEX_AND_COUNT_SCORE: _minimax_m3_sparse_attn_select_count_score,
+    MiniMaxM3SparseAttentionPrefillFamily.K2Q_CSR_SCORE: _minimax_m3_sparse_attn_k2q_csr_score,
+}
+
+
 @torch.no_grad()
 def minimax_m3_sparse_attn(
     q: torch.Tensor,
@@ -596,9 +603,9 @@ def minimax_m3_sparse_attn(
     block_size: int = 128,
 ) -> None:
     del prefix_lens, max_query_len
-    sparse_attn_impl = (
-        _minimax_m3_sparse_attn_a5 if _ASCEND_DEVICE_TYPE == AscendDeviceType.A5 else _minimax_m3_sparse_attn_a3
-    )
+    sparse_attn_impl = _MINIMAX_M3_SPARSE_ATTN_PREFILL_IMPLS[
+        _HARDWARE_PROFILE.minimax_m3_sparse_attention_prefill_family
+    ]
     sparse_attn_impl(
         q,
         kv_cache,

--- a/vllm_ascend/ops/dsa.py
+++ b/vllm_ascend/ops/dsa.py
@@ -223,12 +223,12 @@ def _build_kv_cache(self, forward_context):
             compress_kv_cache = compress_kv_cache[virtual_engine]
     if self.compress_ratio == 4:
         indexer_state_cache = self.indexer.compressor.state_cache.kv_cache
-        if get_current_hardware_profile().supports(HardwareCapability.DSV4_COMPRESSED_CACHE):
+        if get_current_hardware_profile().supports(HardwareCapability.DSA_COMPRESSED_KV_CACHE):
             indexer_k_cache, indexer_scale_cache, indexer_full_cache = unfold_kvcache(self.indexer.k_cache.kv_cache)
         else:
             indexer_k_cache, indexer_scale_cache = unfold_kvcache(self.indexer.k_cache.kv_cache)
 
-    if get_current_hardware_profile().supports(HardwareCapability.DSV4_COMPRESSED_CACHE):
+    if get_current_hardware_profile().supports(HardwareCapability.DSA_COMPRESSED_KV_CACHE):
         kv_cache = tuple(
             [
                 unfold_kvcache(cache)

--- a/vllm_ascend/ops/fused_moe/moe_mlp.py
+++ b/vllm_ascend/ops/fused_moe/moe_mlp.py
@@ -138,7 +138,7 @@ def _apply_clipped_swiglu(
     swiglu_alpha: float,
     swiglu_beta: float,
 ) -> torch.Tensor:
-    if get_current_hardware_profile().supports(HardwareCapability.SWIGLU_OAI_MX_QUANT):
+    if not get_current_hardware_profile().supports(HardwareCapability.MINIMAX_M3_FUSED_CLIPPED_SWIGLU):
         hidden_size = hidden_states.shape[-1] // 2
         gate = hidden_states[..., :hidden_size].clamp(max=swiglu_limit)
         up = hidden_states[..., hidden_size:].clamp(
@@ -164,8 +164,8 @@ def _swiglu_oai_dynamic_mx_quant(
     swiglu_alpha: float,
     swiglu_beta: float,
 ) -> tuple[torch.Tensor, torch.Tensor]:
-    if not get_current_hardware_profile().supports(HardwareCapability.SWIGLU_OAI_MX_QUANT):
-        raise RuntimeError("The MiniMax-M3 SwiGLU-OAI MX quant path is only expected on Ascend A5.")
+    if not get_current_hardware_profile().supports(HardwareCapability.MINIMAX_M3_SWIGLU_OAI_MXFP8_OUTPUT_QUANTIZATION):
+        raise RuntimeError("The active hardware profile does not support MiniMax-M3 SwiGLU-OAI MX quantization.")
 
     hidden_states = _apply_clipped_swiglu(
         hidden_states,

--- a/vllm_ascend/ops/fused_moe/router/router_factory.py
+++ b/vllm_ascend/ops/fused_moe/router/router_factory.py
@@ -5,7 +5,7 @@ from vllm.distributed.eplb.eplb_state import EplbLayerState
 from vllm.model_executor.layers.fused_moe import FusedMoERouter
 from vllm.model_executor.layers.fused_moe.router.custom_routing_router import CustomRoutingRouter
 
-from vllm_ascend.device.hardware_profile import HardwareCapability, get_current_hardware_profile
+from vllm_ascend.device.hardware_profile import MoERouterFamily, get_current_hardware_profile
 from vllm_ascend.ops.fused_moe.router.fused_topk_router import (
     AscendFusedTopKRouter as AscendFusedMoERouter,
 )
@@ -59,7 +59,7 @@ def create_ascend_fused_moe_router(
             custom_routing_function=custom_routing_function,
             renormalize=renormalize,
         )
-    if get_current_hardware_profile().supports(HardwareCapability.FUSED_MOE_COMPATIBILITY):
+    if get_current_hardware_profile().moe_router_family is MoERouterFamily.CHUNKED_SOFTMAX_TOP_K:
         from vllm_ascend._310p.fused_moe.grouped_topk_router import AscendGroupedTopKRouter310
 
         return AscendGroupedTopKRouter310(

--- a/vllm_ascend/ops/fused_moe/shared_experts.py
+++ b/vllm_ascend/ops/fused_moe/shared_experts.py
@@ -342,7 +342,9 @@ class AscendSharedExperts:
                         clamp_limit=self.swiglu_limit,
                         **(
                             {}
-                            if not get_current_hardware_profile().supports(HardwareCapability.FUSED_SWIGLU_TUNING_ARGS)
+                            if not get_current_hardware_profile().supports(
+                                HardwareCapability.DEQUANT_SWIGLU_GLU_ALPHA_BIAS_ARGS
+                            )
                             else {"glu_alpha": self.swiglu_alpha, "glu_bias": self.swiglu_beta}
                         ),
                     )

--- a/vllm_ascend/ops/fused_moe/token_dispatcher.py
+++ b/vllm_ascend/ops/fused_moe/token_dispatcher.py
@@ -31,7 +31,7 @@ from vllm.distributed.parallel_state import get_ep_group
 from vllm_ascend.ascend_config import get_ascend_config
 from vllm_ascend.ascend_forward_context import get_mc2_tokens_capacity
 from vllm_ascend.device.device_op import DeviceOperator
-from vllm_ascend.device.hardware_profile import HardwareCapability, get_current_hardware_profile
+from vllm_ascend.device.hardware_profile import MoEDistributeApiFamily, get_current_hardware_profile
 from vllm_ascend.distributed.parallel_state import get_mc2_group
 from vllm_ascend.lora.fused_moe import (
     all2all_lora_indices,
@@ -117,12 +117,20 @@ class TokenDispatcherWithMC2(MoETokenDispatcher[MoEMC2CombineMetadata]):
         self.ep_rank_id = get_mc2_group().rank_in_group
         self.ep_world_size = get_mc2_group().world_size
         profile = get_current_hardware_profile()
-        self.need_extra_args = profile.supports(HardwareCapability.MOE_DISPATCH_EXTRA_ARGS)
-        self.need_shared_expert_args = profile.supports(HardwareCapability.MOE_DISPATCH_SHARED_EXPERT_ARGS)
+        moe_distribute_api_family = profile.moe_distribute_api_family
+        self.uses_tp_metadata = moe_distribute_api_family in (
+            MoEDistributeApiFamily.EP_AND_TP_METADATA,
+            MoEDistributeApiFamily.EP_TP_WITH_EXPERT_SCALES_MXFP_MODE_AND_QUANT_OUTPUT_DTYPE,
+        )
+        self.uses_mxfp_dispatch_metadata = (
+            moe_distribute_api_family
+            is MoEDistributeApiFamily.EP_TP_WITH_EXPERT_SCALES_MXFP_MODE_AND_QUANT_OUTPUT_DTYPE
+        )
         self.mc2_comm_alg = get_ascend_config().get_mc2_comm_alg()
 
-        # When enable hierarchical communication or A5 case, param `expert_scales` need to be passed in.
-        self.need_expert_scale = self.need_shared_expert_args or self.mc2_comm_alg == "hierarchy"
+        # Hierarchical communication and API families with expert-scale
+        # metadata both require the `expert_scales` argument.
+        self.need_expert_scale = self.uses_mxfp_dispatch_metadata or self.mc2_comm_alg == "hierarchy"
 
         # Here we need to calculate the global_bs = max_bs_per_rank * ep_world_size to execute
         # dispatch & combine operators with different input num_tokens per rank.
@@ -168,7 +176,7 @@ class TokenDispatcherWithMC2(MoETokenDispatcher[MoEMC2CombineMetadata]):
         if comm_quant_mode is not None:
             quant_mode = comm_quant_mode
         elif token_dispatch_input.quant.dispatch_with_quant:
-            quant_mode = 4 if self.need_shared_expert_args and token_dispatch_input.quant.is_mxfp else 2
+            quant_mode = 4 if self.uses_mxfp_dispatch_metadata and token_dispatch_input.quant.is_mxfp else 2
         else:
             quant_mode = 0
         self.moe_expert_num = len(expert_map) + global_redundant_expert_num
@@ -193,7 +201,7 @@ class TokenDispatcherWithMC2(MoETokenDispatcher[MoEMC2CombineMetadata]):
             "ep_rank_id": self.ep_rank_id,
             "comm_alg": self.mc2_comm_alg,
         }
-        if self.need_extra_args:
+        if self.uses_tp_metadata:
             stage1_kwargs.update(
                 {
                     "group_tp": self.moe_all_to_all_group_name,
@@ -203,7 +211,7 @@ class TokenDispatcherWithMC2(MoETokenDispatcher[MoEMC2CombineMetadata]):
             )
         # Only dispatch-enabled MXFP paths pass y_dtype through MC2.
         if (
-            self.need_shared_expert_args
+            self.uses_mxfp_dispatch_metadata
             and (token_dispatch_input.quant.is_mxfp or token_dispatch_input.quant.is_fp8)
             and token_dispatch_input.quant.dispatch_with_quant
         ):
@@ -306,7 +314,7 @@ class TokenDispatcherWithMC2(MoETokenDispatcher[MoEMC2CombineMetadata]):
             "assist_info_for_combine": assist_info_for_combine,
         }
 
-        if self.need_extra_args:
+        if self.uses_tp_metadata:
             stage3_kwargs.update(
                 {
                     "tp_send_counts": tp_recv_counts,

--- a/vllm_ascend/ops/linear.py
+++ b/vllm_ascend/ops/linear.py
@@ -40,7 +40,11 @@ from vllm.model_executor.layers.quantization.base_config import QuantizationConf
 from vllm.model_executor.utils import set_weight_attrs
 from vllm.utils.torch_utils import direct_register_custom_op
 
-from vllm_ascend.device.hardware_profile import HardwareCapability, WeightLayoutPolicy, get_current_hardware_profile
+from vllm_ascend.device.hardware_profile import (
+    DSAOProjWeightLayoutPolicy,
+    WeightLayoutPolicy,
+    get_current_hardware_profile,
+)
 from vllm_ascend.ops.linear_op import get_parallel_op, get_replicated_op
 from vllm_ascend.quantization.tp_weight_switch import TPWeightGatherSpec, TPWeightSwitchMixin
 from vllm_ascend.utils import (
@@ -457,16 +461,16 @@ class AscendColumnParallelLinear(ColumnParallelLinear):
         return super().forward(input_)
 
     def weight_loader(self, param: Parameter, loaded_weight: torch.Tensor):
-        supports_dynamic_mx_quant_fusion = get_current_hardware_profile().supports(
-            HardwareCapability.DYNAMIC_MX_QUANT_FUSION
-        )
+        dsa_o_proj_weight_layout_policy = get_current_hardware_profile().dsa_o_proj_weight_layout_policy
         reshape_bf16_wo_a = (
             "wo_a" in self.prefix
-            and supports_dynamic_mx_quant_fusion
+            and dsa_o_proj_weight_layout_policy is DSAOProjWeightLayoutPolicy.TRANSPOSE_UNQUANTIZED_BF16_WO_A_ONLY
             and self.quant_config is None
             and loaded_weight.dtype == torch.bfloat16
         )
-        if "wo_a" in self.prefix and (not supports_dynamic_mx_quant_fusion or reshape_bf16_wo_a):
+        if "wo_a" in self.prefix and (
+            dsa_o_proj_weight_layout_policy is DSAOProjWeightLayoutPolicy.ALWAYS_TRANSPOSE_WO_A or reshape_bf16_wo_a
+        ):
             if self.weight.ndim == 2:
                 super().weight_loader(param, loaded_weight)
                 self.weight.data = (

--- a/vllm_ascend/patch/platform/__init__.py
+++ b/vllm_ascend/patch/platform/__init__.py
@@ -22,9 +22,9 @@ import vllm_ascend.patch.platform.patch_mamba_block_aligned_split  # noqa
 import vllm_ascend.patch.platform.patch_mla_prefill_backend  # noqa
 import vllm_ascend.patch.platform.patch_pp_mtp  # noqa
 import vllm_ascend.patch.platform.patch_use_v2_model_runner  # noqa
-from vllm_ascend.device.hardware_profile import HardwareCapability, get_current_hardware_profile
+from vllm_ascend.device.hardware_profile import MambaConfigPatchFamily, get_current_hardware_profile
 
-if get_current_hardware_profile().supports(HardwareCapability.STANDARD_MAMBA_PATCH):
+if get_current_hardware_profile().mamba_config_patch_family is MambaConfigPatchFamily.MLA_OR_DENSE_CACHE_LAYOUT:
     import vllm_ascend.patch.platform.patch_mamba_config  # noqa
 else:
     import vllm_ascend.patch.platform.patch_mamba_config_310  # noqa

--- a/vllm_ascend/patch/platform/patch_distributed.py
+++ b/vllm_ascend/patch/platform/patch_distributed.py
@@ -19,7 +19,7 @@
 
 import torch
 
-from vllm_ascend.device.hardware_profile import HardwareCapability, get_current_hardware_profile
+from vllm_ascend.device.hardware_profile import DistributedCollectiveFamily, get_current_hardware_profile
 
 
 class NullHandle:
@@ -85,5 +85,8 @@ def communication_adaptation_310p():
     )
 
 
-if get_current_hardware_profile().supports(HardwareCapability.DISTRIBUTED_COMMUNICATION_ADAPTATION):
+if (
+    get_current_hardware_profile().distributed_collective_family
+    is DistributedCollectiveFamily.BROADCAST_AND_INT64_ALLREDUCE_VIA_ALLGATHER
+):
     communication_adaptation_310p()

--- a/vllm_ascend/patch/platform/patch_use_v2_model_runner.py
+++ b/vllm_ascend/patch/platform/patch_use_v2_model_runner.py
@@ -1,11 +1,15 @@
 import vllm.envs as envs
 from vllm.config.vllm import VllmConfig
 
-from vllm_ascend.utils import is_310p
+from vllm_ascend.device.hardware_profile import (
+    ModelRunnerV2ImplementationFamily,
+    get_current_hardware_profile,
+)
 from vllm_ascend.worker.v2.pp_utils import resolve_spec_pp_support
 
 _original_validate_v2_model_runner = VllmConfig._validate_v2_model_runner
 _original_get_unsupported_features = VllmConfig._get_v2_model_runner_unsupported_features
+_HARDWARE_PROFILE = get_current_hardware_profile()
 
 
 def _patched_use_v2_model_runner(self) -> bool:
@@ -37,7 +41,10 @@ VllmConfig._get_v2_model_runner_unsupported_features = _patched_get_unsupported_
 
 
 def _patched_validate_v2_model_runner(self) -> None:
-    if is_310p():
+    if (
+        _HARDWARE_PROFILE.model_runner_v2_implementation_family
+        is ModelRunnerV2ImplementationFamily.TRITON_FREE_HOST_METADATA
+    ):
         return
     _original_validate_v2_model_runner(self)
 

--- a/vllm_ascend/patch/worker/__init__.py
+++ b/vllm_ascend/patch/worker/__init__.py
@@ -17,7 +17,7 @@
 
 from vllm.triton_utils import HAS_TRITON
 
-from vllm_ascend.device.hardware_profile import HardwareCapability, get_current_hardware_profile
+from vllm_ascend.device.hardware_profile import WorkerPatchFamily, get_current_hardware_profile
 
 if HAS_TRITON:
     import vllm_ascend.patch.worker.patch_triton
@@ -30,7 +30,7 @@ import vllm_ascend.patch.worker.patch_mamba_utils  # noqa
 import vllm_ascend.patch.worker.patch_bind_kv_cache  # noqa
 import vllm_ascend.patch.worker.patch_step3p5  # noqa
 
-if get_current_hardware_profile().supports(HardwareCapability.STANDARD_WORKER_PATCHES):
+if get_current_hardware_profile().worker_patch_family is WorkerPatchFamily.QWEN3_5_DFLASH_AND_VL:
     import vllm_ascend.patch.worker.patch_qwen3_5  # noqa
     import vllm_ascend.patch.worker.patch_qwen3_dflash  # noqa
     import vllm_ascend.patch.worker.patch_qwen3vl  # noqa

--- a/vllm_ascend/patch/worker/patch_mamba_utils.py
+++ b/vllm_ascend/patch/worker/patch_mamba_utils.py
@@ -32,7 +32,7 @@ mamba_utils._TEMPORAL_TILES = 1
 
 
 def _can_launch_triton_batch_memcpy() -> bool:
-    return get_current_hardware_profile().supports(HardwareCapability.TRITON_BATCH_MEMCPY)
+    return get_current_hardware_profile().supports(HardwareCapability.TRITON_MAMBA_STATE_BATCH_MEMCPY)
 
 
 def _get_mamba_groups(

--- a/vllm_ascend/patch/worker/patch_qwen3_5.py
+++ b/vllm_ascend/patch/worker/patch_qwen3_5.py
@@ -31,7 +31,7 @@ except ImportError:
     IntermediateTensors = None
 from vllm.model_executor.models.qwen3_next import Qwen3NextAttention
 
-from vllm_ascend.device.hardware_profile import HardwareCapability, get_current_hardware_profile
+from vllm_ascend.device.hardware_profile import GDNPatchFamily, get_current_hardware_profile
 from vllm_ascend.ops.gdn import AscendGatedDeltaNetAttention
 from vllm_ascend.utils import vllm_version_is
 
@@ -232,7 +232,7 @@ _GDN_PATCH_TARGET._split_ba_for_tp = AscendGatedDeltaNetAttention._split_ba_for_
 _GDN_PATCH_TARGET.get_state_shape = AscendGatedDeltaNetAttention.get_state_shape
 _GDN_PATCH_TARGET.get_attn_backend = AscendGatedDeltaNetAttention.get_attn_backend
 
-if get_current_hardware_profile().supports(HardwareCapability.GDN_COMPATIBILITY):
+if get_current_hardware_profile().gdn_patch_family is GDNPatchFamily.CORE_AND_DTYPE_PATCH:
     from vllm_ascend._310p.ops.fla.gdn_310 import AscendGatedDeltaNetAttention310
 
     _GDN_PATCH_TARGET._forward_core = AscendGatedDeltaNetAttention310._forward_core

--- a/vllm_ascend/patch/worker/patch_v2/patch_block_table.py
+++ b/vllm_ascend/patch/worker/patch_v2/patch_block_table.py
@@ -18,9 +18,15 @@
 #
 from vllm.v1.worker.gpu import model_runner
 
-from vllm_ascend.utils import is_310p
+from vllm_ascend.device.hardware_profile import (
+    ModelRunnerV2ImplementationFamily,
+    get_current_hardware_profile,
+)
 
-if is_310p():
+if (
+    get_current_hardware_profile().model_runner_v2_implementation_family
+    is ModelRunnerV2ImplementationFamily.TRITON_FREE_HOST_METADATA
+):
     from vllm_ascend._310p.worker.v2.block_table import Ascend310PBlockTables as AscendBlockTables
 else:
     from vllm_ascend.worker.v2.block_table import AscendBlockTables

--- a/vllm_ascend/platform.py
+++ b/vllm_ascend/platform.py
@@ -35,6 +35,7 @@ os.environ["VLLM_DISABLE_SHARED_EXPERTS_STREAM"] = "1"
 from vllm_ascend.ascend_config import get_ascend_config, init_ascend_config
 from vllm_ascend.device.hardware_profile import (
     AttentionBackendFamily,
+    CompilationCustomOpPolicy,
     HardwareCapability,
     QuantizationBackendFamily,
     get_current_hardware_profile,
@@ -74,8 +75,6 @@ logger.info_once(
 )
 
 _CUSTOM_OP_REGISTERED = False
-# Delete after the driver is released; temporarily hard-coded to 4
-MAX_REDUCED_CAPTURE_SIZES = 4
 
 
 class NPUPlatform(Platform):
@@ -256,7 +255,7 @@ class NPUPlatform(Platform):
             # (True, True):  "...AscendSFABackend310",
         }
 
-        if get_current_hardware_profile().attention_backend_family is AttentionBackendFamily.COMPATIBILITY:
+        if get_current_hardware_profile().attention_backend_family is AttentionBackendFamily.DENSE_ONLY:
             return compatibility_backend_map.get(key, compatibility_backend_map[(False, False)])
 
         if attn_selector_config.use_pcp:
@@ -305,7 +304,10 @@ class NPUPlatform(Platform):
                 if ASCEND_QUANTIZATION_METHOD not in quant_action.choices:
                     quant_action.choices.append(ASCEND_QUANTIZATION_METHOD)
 
-        if get_current_hardware_profile().quantization_backend_family is QuantizationBackendFamily.STANDARD:
+        if (
+            get_current_hardware_profile().quantization_backend_family
+            is QuantizationBackendFamily.COMPRESSED_TENSORS_FP8_MXFP8_AND_MODELSLIM
+        ):
             from vllm_ascend.quantization import (  # noqa: F401
                 AscendCompressedTensorsConfig,
                 AscendFp8Config,
@@ -1202,8 +1204,9 @@ def _setup_compile_backend(
             ]
         )
         # TODO(2026/7/15): Delete the reduced gear after the new driver is released.
-        if get_current_hardware_profile().supports(HardwareCapability.REDUCED_CUDAGRAPH_CAPTURE_SIZES):
-            _prune_reduced_capture_sizes(vllm_config)
+        capture_size_limit = get_current_hardware_profile().cudagraph_capture_size_limit
+        if capture_size_limit is not None:
+            _prune_reduced_capture_sizes(vllm_config, capture_size_limit)
         additional_config["ascend_compilation_config"]["enable_npugraph_ex"] = False
         additional_config["ascend_compilation_config"]["enable_static_kernel"] = False
     elif compilation_config.cudagraph_mode.has_full_cudagraphs():
@@ -1245,7 +1248,7 @@ def _setup_worker_and_scheduler(
             logger.info_once("FlashComm1 is disabled. Using flashinfer_all2allv as the all2all backend.")
         hardware_profile = get_current_hardware_profile()
         if ascend_config.xlite_graph_config.enabled and hardware_profile.supports(
-            HardwareCapability.STANDARD_WORKER_PATCHES
+            HardwareCapability.XLITE_GRAPH_WORKER
         ):
             logger.info("openEuler Xlite enabled. See: https://atomgit.com/openeuler/GVirt/tree/master/xlite")
             parallel_config.worker_cls = "vllm_ascend.xlite.xlite_worker.XliteWorker"
@@ -1254,8 +1257,9 @@ def _setup_worker_and_scheduler(
 
     refresh_block_size(vllm_config)
 
-    # Automatically activate all custom ops on profiles using the standard path.
-    if get_current_hardware_profile().supports(HardwareCapability.AUTO_ENABLE_CUSTOM_OPS):
+    # Force-enable the complete compilation custom-op set only when selected
+    # by the profile policy; otherwise preserve the user's configuration.
+    if get_current_hardware_profile().compilation_custom_op_policy is CompilationCustomOpPolicy.FORCE_ENABLE_ALL:
         vllm_config.compilation_config.custom_ops = ["all"]
 
     # Select specialized scheduler class
@@ -1453,14 +1457,14 @@ def _config_deprecated_logging():
     warnings_logger.propagate = False
 
 
-def _prune_reduced_capture_sizes(vllm_config):
+def _prune_reduced_capture_sizes(vllm_config, capture_size_limit: int):
     original_sizes = vllm_config.compilation_config.cudagraph_capture_sizes
     if not original_sizes:
         return
-    if len(original_sizes) <= MAX_REDUCED_CAPTURE_SIZES:
+    if len(original_sizes) <= capture_size_limit:
         return
-    step = (len(original_sizes) - 1) / (MAX_REDUCED_CAPTURE_SIZES - 1)
-    indices = [round(i * step) for i in range(MAX_REDUCED_CAPTURE_SIZES)]
+    step = (len(original_sizes) - 1) / (capture_size_limit - 1)
+    indices = [round(i * step) for i in range(capture_size_limit)]
     indices[0], indices[-1] = 0, len(original_sizes) - 1
     sampled_sizes = [original_sizes[i] for i in indices]
     update_cudagraph_capture_sizes(vllm_config, sampled_sizes)
@@ -1468,7 +1472,7 @@ def _prune_reduced_capture_sizes(vllm_config):
         "Adjusted ACL graph batch sizes for model: %d → %d sizes due to HDK incompatibility"
         "and this warning will be cleared soon.",
         len(original_sizes),
-        MAX_REDUCED_CAPTURE_SIZES,
+        capture_size_limit,
     )
 
 

--- a/vllm_ascend/quantization/methods/w8a8/fp8_block.py
+++ b/vllm_ascend/quantization/methods/w8a8/fp8_block.py
@@ -42,8 +42,9 @@ from vllm.logger import logger
 from vllm.model_executor.utils import replace_parameter
 from vllm.utils.math_utils import cdiv
 
+from vllm_ascend.device.hardware_profile import HardwareCapability, get_current_hardware_profile
 from vllm_ascend.quantization.utils import get_dynamic_mx_quant_scale_alg
-from vllm_ascend.utils import FP8_METHOD, is_950, maybe_trans_nz
+from vllm_ascend.utils import FP8_METHOD, maybe_trans_nz
 
 from ..base import AscendLinearScheme, AscendMoEScheme, QuantType
 from ..registry import register_scheme
@@ -54,6 +55,7 @@ BLOCK_FP8_WEIGHT_DTYPE = torch.float8_e4m3fn
 # Output rows resolved per step. Bounds the float32 staging buffer to
 # ``_ROWS_PER_DEQUANT_STEP * in_features * 4`` bytes regardless of layer size.
 _ROWS_PER_DEQUANT_STEP = 1024
+_HARDWARE_PROFILE = get_current_hardware_profile()
 
 
 def resolve_block_scales(
@@ -140,7 +142,11 @@ class AscendFp8BlockLinearMethod(AscendLinearScheme):
     def __init__(self, weight_block_size: tuple[int, int]):
         self.block_n, self.block_k = weight_block_size
         self.model_dtype = get_current_vllm_config().model_config.dtype
-        self.mxfp8_method = AscendW8A8MXFP8DynamicLinearMethod() if is_950() else None
+        self.mxfp8_method = (
+            AscendW8A8MXFP8DynamicLinearMethod()
+            if _HARDWARE_PROFILE.supports(HardwareCapability.BLOCK_FP8_TO_MXFP8_REQUANTIZATION)
+            else None
+        )
 
     def get_weight(self, input_size: int, output_size: int, params_dtype: torch.dtype) -> dict[str, Any]:
         return {"weight": torch.empty(output_size, input_size, dtype=BLOCK_FP8_WEIGHT_DTYPE)}
@@ -230,7 +236,11 @@ class AscendFp8BlockFusedMoEMethod(AscendMoEScheme):
         self.group_size = self.block_k
         self.model_dtype = get_current_vllm_config().model_config.dtype
         self.moe_config = moe_config
-        self.mxfp8_method = AscendW8A8MXFP8DynamicFusedMoEMethod() if is_950() else None
+        self.mxfp8_method = (
+            AscendW8A8MXFP8DynamicFusedMoEMethod()
+            if _HARDWARE_PROFILE.supports(HardwareCapability.BLOCK_FP8_TO_MXFP8_REQUANTIZATION)
+            else None
+        )
         # MoE MXFP8 has group_size only. Snapshot the Linear helper here so
         # requantize does not call get_current_vllm_config() at load time.
         self._mx_scale_alg = (

--- a/vllm_ascend/quantization/utils.py
+++ b/vllm_ascend/quantization/utils.py
@@ -51,7 +51,7 @@ def get_dynamic_mx_quant_scale_alg(vllm_config=None) -> int:
     destination FP8 range, then rounds the E8M0 scale exponent up to avoid
     quantization overflow. MiniMax M3 checkpoints require the latter.
     """
-    if not get_current_hardware_profile().supports(HardwareCapability.DYNAMIC_MX_QUANT_SCALE_ALG_ONE):
+    if not get_current_hardware_profile().supports(HardwareCapability.DYNAMIC_MX_QUANT_E8M0_OVERFLOW_SAFE_SCALING):
         return 0
 
     if vllm_config is None:

--- a/vllm_ascend/sample/sampler.py
+++ b/vllm_ascend/sample/sampler.py
@@ -270,6 +270,6 @@ def _apply_top_k_top_p_torch_npu(
 
 apply_top_k_top_p = (
     _apply_top_k_top_p_torch_npu
-    if get_current_hardware_profile().supports(HardwareCapability.NPU_TOP_K_TOP_P)
+    if get_current_hardware_profile().supports(HardwareCapability.NATIVE_TOP_K_TOP_P_SAMPLING)
     else _apply_top_k_top_p_pytorch
 )

--- a/vllm_ascend/utils.py
+++ b/vllm_ascend/utils.py
@@ -39,14 +39,13 @@ from vllm.sequence import IntermediateTensors
 
 import vllm_ascend.envs as envs_ascend
 from vllm_ascend.ascend_config import get_ascend_config
-from vllm_ascend.device.device_config import (  # noqa: F401
-    AscendDeviceType,
-    check_ascend_device_type,
-    get_ascend_device_type,
-    is_310p,
-    is_950,
+from vllm_ascend.device.device_config import check_ascend_device_type  # noqa: F401
+from vllm_ascend.device.hardware_profile import (
+    HardwareCapability,
+    OperatorRegistryFamily,
+    WeightLayoutPolicy,
+    get_current_hardware_profile,
 )
-from vllm_ascend.device.hardware_profile import HardwareCapability, WeightLayoutPolicy, get_current_hardware_profile
 
 if TYPE_CHECKING:
     from vllm.config import VllmConfig
@@ -57,7 +56,6 @@ COMPILATION_PASS_KEY = "graph_fusion_manager"
 ASCEND_QUANTIZATION_METHOD = "ascend"
 COMPRESSED_TENSORS_METHOD = "compressed-tensors"
 FP8_METHOD = "fp8"
-SOC_VERSION_INFERENCE_SERIES = ["Ascend310P3"]
 REGISTERED_ASCEND_OPS = {}
 
 ACL_FORMAT_FRACTAL_ND = 2
@@ -168,7 +166,7 @@ def is_rc_device() -> bool:
     ``accelerators``.
     """
     global _IS_RC_DEVICE
-    if not get_current_hardware_profile().supports(HardwareCapability.RC_DEVICE_DISCOVERY):
+    if not get_current_hardware_profile().supports(HardwareCapability.PCIE_ROOT_COMPLEX_MODE_DETECTION):
         return False
     if _IS_RC_DEVICE is not None:
         return _IS_RC_DEVICE
@@ -424,10 +422,12 @@ def enable_custom_op():
 
     # There are some customed operators which aren't implemented
     # with batch invariant in vllm-ascend, we need to disable them.
-    # FIXME(linfeng): Currently custom op compilation and execution are partially available
-    # in ASCEND950 chip, we temporarily disable all custom ops. Please refer to
+    # FIXME(linfeng): Custom-op compilation and execution are only partially
+    # available on profiles without runtime registration support. Please refer to
     # https://github.com/vllm-project/vllm-ascend/issues/7157 for latest update about custom op.
-    if envs.VLLM_BATCH_INVARIANT or not get_current_hardware_profile().supports(HardwareCapability.RUNTIME_CUSTOM_OPS):
+    if envs.VLLM_BATCH_INVARIANT or not get_current_hardware_profile().supports(
+        HardwareCapability.ASCEND_CUSTOM_OP_RUNTIME_REGISTRATION
+    ):
         _CUSTOM_OP_ENABLED = False
         return _CUSTOM_OP_ENABLED
 
@@ -759,8 +759,11 @@ def register_ascend_customop(vllm_config: VllmConfig | None = None):
 
         REGISTERED_ASCEND_OPS["GateLinear"] = AscendGateLinear
 
-    # Override selected ops when the compatibility implementations are required.
-    if get_current_hardware_profile().supports(HardwareCapability.COMPATIBILITY_OP_IMPLEMENTATIONS):
+    # Override only the kernels selected by the profile's registry family.
+    if (
+        get_current_hardware_profile().operator_registry_family
+        is OperatorRegistryFamily.BASE_WITH_TRITON_FREE_KERNEL_OVERRIDES
+    ):
         from vllm_ascend._310p.fused_moe.fused_moe import AscendMoERunner310, AscendRoutedExperts310
         from vllm_ascend._310p.ops.activation import AscendSiluAndMul310
         from vllm_ascend._310p.ops.conv import AscendConv3dLayer310

--- a/vllm_ascend/worker/model_runner_v1.py
+++ b/vllm_ascend/worker/model_runner_v1.py
@@ -4493,7 +4493,7 @@ class NPUModelRunner(GPUModelRunner):
                                                 current_kv_cache_spec.num_kv_heads,
                                                 current_kv_cache_spec.scale_dim
                                                 )
-                        if get_current_hardware_profile().supports(HardwareCapability.DSV4_COMPRESSED_CACHE):
+                        if get_current_hardware_profile().supports(HardwareCapability.DSA_COMPRESSED_KV_CACHE):
                             indexer_full_shape = self.attn_backend.get_kv_cache_shape(
                                 num_blocks, current_kv_cache_spec.storage_block_size,
                                 current_kv_cache_spec.num_kv_heads,

--- a/vllm_ascend/worker/v2/attn_utils.py
+++ b/vllm_ascend/worker/v2/attn_utils.py
@@ -453,7 +453,7 @@ def _view_dsv4_cache(
         )
         cache_shapes.append(scale_shape)
         cache_dtypes.append(scale_dtype)
-        if get_current_hardware_profile().supports(HardwareCapability.DSV4_COMPRESSED_CACHE):
+        if get_current_hardware_profile().supports(HardwareCapability.DSA_COMPRESSED_KV_CACHE):
             full_shape = attn_backend.get_kv_cache_shape(
                 num_blocks,
                 kv_cache_spec.storage_block_size,

--- a/vllm_ascend/worker/v2/model_states/__init__.py
+++ b/vllm_ascend/worker/v2/model_states/__init__.py
@@ -22,7 +22,12 @@ import torch.nn as nn
 from vllm.config import VllmConfig
 from vllm.v1.worker.gpu.mm.encoder_cache import EncoderCache
 
-from vllm_ascend.device.device_config import is_310p
+from vllm_ascend.device.hardware_profile import (
+    ModelRunnerV2ImplementationFamily,
+    get_current_hardware_profile,
+)
+
+_HARDWARE_PROFILE = get_current_hardware_profile()
 
 
 def init_asecnd_model_state(
@@ -36,9 +41,12 @@ def init_asecnd_model_state(
         cls = model.get_model_state_cls()
         return cls(vllm_config, model, encoder_cache, device)
 
-    # 310P uses Triton-free states under ``vllm_ascend._310p.worker.v2.model_state``.
+    use_triton_free_state = (
+        _HARDWARE_PROFILE.model_runner_v2_implementation_family
+        is ModelRunnerV2ImplementationFamily.TRITON_FREE_HOST_METADATA
+    )
     if vllm_config.model_config.is_hybrid:
-        if is_310p():
+        if use_triton_free_state:
             from vllm_ascend._310p.worker.v2.model_state import Ascend310PMambaHybridModelState
 
             return Ascend310PMambaHybridModelState(vllm_config, model, encoder_cache, device)
@@ -54,7 +62,7 @@ def init_asecnd_model_state(
             device,
         )
 
-    if is_310p():
+    if use_triton_free_state:
         from vllm_ascend._310p.worker.v2.model_state import (
             Ascend310PModelState,
         )

--- a/vllm_ascend/worker/worker.py
+++ b/vllm_ascend/worker/worker.py
@@ -134,7 +134,7 @@ class NPUWorker(WorkerBase):
         from vllm_ascend import ops
 
         ops.register_dummy_fusion_op()
-        if get_current_hardware_profile().supports(HardwareCapability.ATB_EXTENSIONS):
+        if get_current_hardware_profile().supports(HardwareCapability.ATB_MODEL_EXECUTION_EXTENSIONS):
             _register_atb_extensions()
         register_ascend_customop(vllm_config)
         # init ascend config and soc version
@@ -434,7 +434,7 @@ class NPUWorker(WorkerBase):
         gc.collect()
         torch.npu.empty_cache()
 
-        if get_current_hardware_profile().supports(HardwareCapability.LOCAL_KV_COMM_RESOURCE):
+        if get_current_hardware_profile().supports(HardwareCapability.LOCAL_KV_TRANSFER_COMM_RESOURCE):
             setup_ascend_local_comm_res(self.local_rank, self.vllm_config.kv_transfer_config)
 
         # take current memory snapshot
@@ -821,7 +821,7 @@ class NPUWorker(WorkerBase):
 
         # Call ATB matmul to warm up; otherwise, the first operation (ReshapeAndCache)
         # may cause performance degradation at runtime.
-        if get_current_hardware_profile().supports(HardwareCapability.ATB_WARMUP):
+        if get_current_hardware_profile().atb_matmul_warmup_required:
             self._warm_up_atb()
         # Bind after warmup so hot allocations are already materialized on the
         # worker process before migratepages/taskset run.


### PR DESCRIPTION
### What this PR does / why we need it?

This PR completes the Device HAL / Hardware Profile migration and makes the HAL boundary enforceable.

1. **Complete the remaining business-layer migration**
   - Migrates the remaining direct device-identity consumers to precise capability, policy, or implementation-family selectors.
   - Removes hidden device-name helpers from shared runtime/model paths.
   - Keeps device identity confined to detection, type mapping, and profile registration.

2. **Audit HAL semantics and naming**
   - Capabilities describe positive hardware/runtime functions.
   - Policies and families describe implementation, algorithm, layout, or default-behavior choices.
   - Replaces ambiguous unscoped names and device/model codenames with names that state scope, action, and object.
   - Documents the naming contract and updates the exact profile matrix and focused tests.

3. **Add a permanent regression guard**
   - Adds an AST checker that rejects production uses of direct device identity outside the audited HAL allowlist.
   - Detects direct calls/comparisons, aliases, imported aliases, dynamic attribute access, and scoped shadowing cases.
   - Wires the checker into pre-commit/required CI and adds positive, negative, and adversarial unit tests.

**Merge order:** #15695 fixes the independent PR5 DSA-CP o_proj TP behavior regression. This PR is opened now for review and CI, but #15695 must merge first; this branch will then be rebased so the obsolete DSA gate is removed by the dedicated BugFix rather than mixed into this refactor. Auto-merge remains disabled until that rebase.

### Does this PR introduce _any_ user-facing change?

No intended runtime behavior change. Shared code selects the same behavior through explicit HAL contracts instead of A2/A3/A5/310P identity branches. The developer workflow gains a CI error for new production device-identity branching outside the HAL boundary.

### How was this patch tested?

- Rebased onto `main@3546357838389aa7201d9b44e234f831e98b2fd4`; both commits remain patch-equivalent under `git range-diff`.
- Both commits include `Signed-off-by`.
- Passed Ruff check, Ruff format --check, compileall, the full-tree hardware-identity AST guard, adversarial diagnostics, and `git diff --check`.
- The available host does not provide pytest, mypy, or vLLM; focused matrix/consumer/checker unit tests and Python 3.10/3.11/3.12 mypy comparison are left to CI.

- vLLM main: https://github.com/vllm-project/vllm/commit/ba07e4a48fc951300d97eb506217dd530583dea3
