### PR TITLE
[BugFix][Device Allocator] Fix CaMem sleep race with in-flight graph replay

### DIFF
--- a/vllm_ascend/device_allocator/camem.py
+++ b/vllm_ascend/device_allocator/camem.py
@@ -201,6 +201,11 @@ class CaMemAllocator:
             len(self.pointer_to_data),
             offload_tags,
         )
+        # Workaround for verl v0.8.0: synchronize pending NPU work before
+        # unmapping tensor memory. The exact root cause is unclear, but this
+        # avoids rtMemcpy errors observed when releasing the mappings too early.
+        torch.npu.synchronize()
+
         for ptr, data in self.pointer_to_data.items():
             if data.tag == CaMemAllocator.sleep_persistent_tag:
                 # This memory is not offloaded or released during sleep.


### PR DESCRIPTION
### What this PR does / why we need it?
Backport #13757 to releases/v0.23.0

Workaround for verl v0.8.0, but the exact root cause is unclear yet. `CaMemAllocator.sleep()` tears down the virtual memory mappings backing every tracked tensor via `unmap_and_release()`. NPU kernel launches and ACLGraph replay are asynchronous, so when `sleep()` ran there could still be in-flight device work referencing those mappings. 

Add a `torch.npu.synchronize()` *before* the loop so every consumer of the mappings finishes before the first unmap. The per-allocation D2H offload copy that precedes each unmap is safe because `aclrtMemcpy` (`acl.rt.memcpy`) is synchronous — the only outstanding async work was the pre-existing graph/kernel launches, which this fence drains.

### Does this PR introduce _any_ user-facing change?

No. Internal fix to the device allocator's sleep mode; no API or behavioral change beyond eliminating the race.

### How was this patch tested?

PPO training on GLM-5.2 with `enforce_eager=False`, `cudagraph_mode="FULL_DECODE_ONLY"`, and
`cudagraph_capture_sizes=[2, 4, 8, 16, 24, 32]` (i.e. exercising ACLGraph capture and replay on the rollout path).

- Before the fix: reproduced consistently —
```
Traceback (most recent call last):
  File "/vllm/vllm/v1/executor/multiproc_executor.py", line 957, in worker_busy_loop
    output = func(*args, **kwargs)
             ^^^^^^^^^^^^^^^^^^^^^
  File "/vllm-ascend/vllm_ascend/worker/worker.py", line 222, in sleep
    allocator.sleep(offload_tags=("weights",) if level == 1 else tuple())
  File "/vllm-ascend/vllm_ascend/device_allocator/camem.py", line 208, in sleep
    torch.npu.empty_cache()
  File "/usr/local/python3.11.15/lib/python3.11/site-packages/torch_npu/npu/memory.py", line 180, in empty_cache
    torch_npu._C._npu_emptyCache()
RuntimeError: npuSynchronizeDevice:../torch_npu/csrc/core/npu/NPUStream.cpp:576 NPU function error: AclrtSynchronizeDeviceWithTimeout, error code is 507011
```
or
```
rtMemcpy execution failed, reason=the current capture mode does not support this operation[FUNC:FuncErrorReason][FILE:error_message_manage.cc][LINE:65]
synchronized memcpy failed, kind = 1, runtime result = 107030[FUNC:ReportCallError][FILE:log_inner.cpp][LINE:148]
```
- After the fix: the same workload runs to completion cleanly.


- vLLM main: https://github.com/vllm-project/vllm/commit/ee0da84ab9e04ac7610e28580af62c365e898389
