### PR TITLE
[Feature][MRV2] Support Kimi K3 DSpark with PP

### DIFF
--- a/tests/ut/worker/test_model_runner_v2_mamba.py
+++ b/tests/ut/worker/test_model_runner_v2_mamba.py
@@ -10,6 +10,7 @@ from vllm.v1.kv_cache_interface import (
     KVCacheGroupSpec,
     KVCacheTensor,
     MambaSpec,
+    UniformTypeKVCacheSpecs,
 )
 from vllm.v1.worker.gpu.model_states.mamba_hybrid import MambaHybridModelState
 
@@ -67,6 +68,30 @@ def test_mamba_model_state_inherits_upstream_state_management():
     assert issubclass(AscendMambaHybridModelState, MambaHybridModelState)
     assert AscendMambaHybridModelState.preprocess_state is MambaHybridModelState.preprocess_state
     assert AscendMambaHybridModelState.postprocess_state is MambaHybridModelState.postprocess_state
+
+
+def test_mamba_group_info_supports_uniform_type_groups():
+    spec = _mamba_spec()
+    uniform_spec = UniformTypeKVCacheSpecs.from_specs({"mamba.0": spec, "mamba.1": spec})
+    assert uniform_spec is not None
+    config = KVCacheConfig(
+        num_blocks=3,
+        kv_cache_tensors=[],
+        kv_cache_groups=[
+            KVCacheGroupSpec(
+                layer_names=["mamba.0", "mamba.1"],
+                kv_cache_spec=uniform_spec,
+            )
+        ],
+    )
+    state = object.__new__(AscendMambaHybridModelState)
+    state._mamba_spec = None
+    state._mamba_group_ids = []
+
+    group_ids, selected_spec = state._get_mamba_group_info(config)
+
+    assert group_ids == [0]
+    assert selected_spec == spec
 
 
 def test_prepare_inputs_propagates_padded_request_count():

--- a/vllm_ascend/models/kimi_k3.py
+++ b/vllm_ascend/models/kimi_k3.py
@@ -80,6 +80,14 @@ from vllm.utils.math_utils import cdiv
 
 from vllm_ascend.ops.kimi_kda import AscendKimiK3DeltaAttention  # type: ignore[import-untyped]
 from vllm_ascend.utils import get_rotation_path
+from vllm_ascend.worker.v2.pp_utils import (
+    PPTransportDataType,
+    add_pp_transport_tensors,
+    get_pp_transport_tensors,
+)
+from vllm_ascend.worker.v2.pp_utils import (
+    make_empty_intermediate_tensors as make_pp_empty_intermediate_tensors,
+)
 
 if HAS_TRITON:
     from vllm_ascend.ops.triton.kimi_k3.attention_residual import (  # type: ignore[import-untyped]
@@ -590,6 +598,10 @@ class AscendKimiLinearModel(UpstreamKimiLinearModel):
 
         world_size = get_tensor_model_parallel_world_size()
         assert config.num_attention_heads % world_size == 0, "num_attention_heads must be divisible by world_size"
+        self.make_empty_intermediate_tensors = make_pp_empty_intermediate_tensors(  # type: ignore[has-type]
+            self,
+            self.make_empty_intermediate_tensors,
+        )
 
     def load_weights(self, weights):
         """Route mixed-precision KDA gates through vLLM's packed loader."""
@@ -634,7 +646,8 @@ class AscendKimiLinearModel(UpstreamKimiLinearModel):
                 **kwargs,
             )
 
-        if get_pp_group().is_first_rank:
+        pp_group = get_pp_group()
+        if pp_group.is_first_rank:
             hidden_states = inputs_embeds if inputs_embeds is not None else self.embed_input_ids(input_ids)
             residual = None
         else:
@@ -653,11 +666,13 @@ class AscendKimiLinearModel(UpstreamKimiLinearModel):
             hidden_states = sp_shard(hidden_states)
             assert residual is None, "Sequence parallelism is not supported with pipeline parallelism"
 
-        if self.dspark_aux_capture_materialized:
-            aux_hidden_states: list[torch.Tensor] = []
-        else:
-            aux_hidden_states = self._maybe_add_hidden_state(
-                [],
+        aux_hidden_states = get_pp_transport_tensors(
+            intermediate_tensors,
+            PPTransportDataType.AUX_HIDDEN_STATES,
+        )
+        if not self.dspark_aux_capture_materialized and pp_group.is_first_rank:
+            self._maybe_add_hidden_state(
+                aux_hidden_states,
                 self.start_layer,
                 hidden_states,
                 residual,
@@ -702,13 +717,18 @@ class AscendKimiLinearModel(UpstreamKimiLinearModel):
                     residual,
                 )
 
-        if not get_pp_group().is_last_rank:
+        if not pp_group.is_last_rank:
             assert not self.use_sequence_parallel, "Sequence parallelism is not supported with pipeline parallelism"
-            return IntermediateTensors(
+            intermediate_tensors = IntermediateTensors(
                 {
                     "hidden_states": hidden_states,
                     "residual": residual,
                 }
+            )
+            return add_pp_transport_tensors(
+                intermediate_tensors,
+                PPTransportDataType.AUX_HIDDEN_STATES,
+                aux_hidden_states,
             )
 
         hidden_states = _apply_ascend_attn_res(

--- a/vllm_ascend/models/kimi_k3_dspark.py
+++ b/vllm_ascend/models/kimi_k3_dspark.py
@@ -7,6 +7,7 @@ from collections.abc import Iterable
 import torch
 from torch import nn
 from vllm.config import VllmConfig
+from vllm.distributed import get_pp_group
 from vllm.model_executor.layers.layernorm import RMSNorm
 from vllm.model_executor.layers.linear import ReplicatedLinear
 from vllm.model_executor.layers.logits_processor import LogitsProcessor
@@ -259,6 +260,14 @@ class AscendK3DSparkForCausalLM(UpstreamK3DSparkForCausalLM):
         )
         self.rotation_path = get_rotation_path(vllm_config)
         self.target_model_path = vllm_config.model_config.model
+        self._load_pp_embedding = get_pp_group().world_size > 1 and self.rotation_path is None
+        if self._load_pp_embedding:
+            target_config = vllm_config.model_config.hf_text_config
+            self.model.embed_tokens = VocabParallelEmbedding(
+                target_config.vocab_size,
+                target_config.hidden_size,
+                prefix=maybe_prefix(maybe_prefix(prefix, "model"), "embed_tokens"),
+            )
         if self.rotation_path is not None:
             target_config = vllm_config.model_config.hf_text_config
             model_prefix = maybe_prefix(prefix, "model")
@@ -330,6 +339,16 @@ class AscendK3DSparkForCausalLM(UpstreamK3DSparkForCausalLM):
             )
             self.has_own_embed_tokens = True
             self.has_own_lm_head = True
+        elif self._load_pp_embedding:
+            assert self.model.embed_tokens is not None
+            load_quarot_target_layer(
+                self.model.embed_tokens,
+                self.target_model_path,
+                TARGET_EMBED_WEIGHT_NAMES,
+                None,
+                "draft embed_tokens.weight",
+            )
+            self.has_own_embed_tokens = True
         return loaded_weights
 
     def embed_input_ids(

--- a/vllm_ascend/models/llama_eagle3.py
+++ b/vllm_ascend/models/llama_eagle3.py
@@ -60,10 +60,10 @@ def load_quarot_target_layer(
     layer: nn.Module,
     target_model_path: Path | str,
     weight_names: tuple[str, ...],
-    rotation: torch.Tensor,
+    rotation: torch.Tensor | None,
     label: str,
 ) -> None:
-    """Load one target vocab shard into the draft's unrotated hidden basis."""
+    """Load one target vocab shard, optionally aligning its hidden basis."""
     target_model_path = Path(target_model_path)
     shard_path, weight_name = _find_safetensors_weight(
         target_model_path,
@@ -80,20 +80,24 @@ def load_quarot_target_layer(
     with safe_open(shard_path, framework="pt", device="cpu") as shard:
         target_weight = shard.get_slice(weight_name)[start_index:end_index]
 
-    rotation = rotation.to(
-        device=layer.weight.device,
-        dtype=torch.float32,
-    )
-    target_weight = target_weight.to(
-        device=layer.weight.device,
-        dtype=torch.float32,
-    )
-    aligned_weight = torch.matmul(target_weight, rotation.T)
+    if rotation is None:
+        aligned_weight = target_weight.to(device=layer.weight.device)
+    else:
+        rotation = rotation.to(
+            device=layer.weight.device,
+            dtype=torch.float32,
+        )
+        target_weight = target_weight.to(
+            device=layer.weight.device,
+            dtype=torch.float32,
+        )
+        aligned_weight = torch.matmul(target_weight, rotation.T)
     loaded_rows = aligned_weight.shape[0]
     layer.weight.data[:loaded_rows].copy_(aligned_weight.to(layer.weight.dtype))
     layer.weight.data[loaded_rows:].zero_()
     logger.info(
-        "[spec_decode/quarot] Loaded and aligned %s from %s (%s).",
+        "[spec_decode] Loaded%s %s from %s (%s).",
+        " and aligned" if rotation is not None else "",
         label,
         shard_path.name,
         tuple(layer.weight.shape),

--- a/vllm_ascend/patch/platform/patch_pp_mtp.py
+++ b/vllm_ascend/patch/platform/patch_pp_mtp.py
@@ -311,7 +311,7 @@ def _patch_model_config_validation() -> None:
             arch.startswith("Eagle") or arch.endswith("Eagle3") for arch in architectures
         )
         is_mtp_drafter = model_type in mtp_model_types
-        is_dspark_drafter = "DSparkDraftModel" in architectures
+        is_dspark_drafter = any(arch.endswith("DSparkModel") for arch in architectures)
         if (
             getattr(self, "runner", None) == "draft"
             and (is_eagle_drafter or is_mtp_drafter or is_dspark_drafter)

--- a/vllm_ascend/worker/v2/attn_utils.py
+++ b/vllm_ascend/worker/v2/attn_utils.py
@@ -922,7 +922,12 @@ def build_attn_metadata_wrapper():
 
 
 @contextmanager
-def build_draft_attn_metadata_factory(positions, pad, is_prefilling):
+def build_draft_attn_metadata_factory(
+    positions,
+    pad,
+    is_prefilling,
+    attn_state=None,
+):
     """Wrap build_attn_metadata to forward rotary positions for the draft block.
 
     The generic (Ascend) ``build_attn_metadata`` reads ``positions`` inside the
@@ -935,6 +940,8 @@ def build_draft_attn_metadata_factory(positions, pad, is_prefilling):
     def build_attn_metadata(*args, **kwargs):
         kwargs["positions"] = positions[:pad]
         kwargs["is_prefilling"] = is_prefilling
+        if attn_state is not None:
+            kwargs["attn_state"] = attn_state
         return raw(*args, **kwargs)
 
     try:

--- a/vllm_ascend/worker/v2/model_states/mamba_hybrid.py
+++ b/vllm_ascend/worker/v2/model_states/mamba_hybrid.py
@@ -21,7 +21,7 @@ from typing import Any
 import numpy as np
 import torch
 from vllm.config.compilation import CUDAGraphMode
-from vllm.v1.kv_cache_interface import KVCacheConfig
+from vllm.v1.kv_cache_interface import KVCacheConfig, MambaSpec, UniformTypeKVCacheSpecs
 from vllm.v1.worker.gpu.model_states.mamba_hybrid import (
     MambaHybridAttnMetadata,
     MambaHybridModelState,
@@ -40,6 +40,26 @@ class AscendMambaHybridModelState(MambaHybridModelState, AscendModelState):
     :class:`MambaHybridModelState`. ``AscendModelState`` remains the second
     base so cooperative ``super()`` calls retain the Ascend model-state MRO.
     """
+
+    def _get_mamba_group_info(self, kv_cache_config: KVCacheConfig) -> tuple[list[int], MambaSpec]:
+        if self._mamba_spec is None:
+            group_ids: list[int] = []
+            specs: list[MambaSpec] = []
+            for group_id, group in enumerate(kv_cache_config.kv_cache_groups):
+                spec = group.kv_cache_spec
+                if isinstance(spec, UniformTypeKVCacheSpecs):
+                    inner_specs = list(spec.kv_cache_specs.values())
+                    if inner_specs and all(isinstance(inner_spec, MambaSpec) for inner_spec in inner_specs):
+                        assert all(inner_specs[0] == inner_spec for inner_spec in inner_specs)
+                        spec = inner_specs[0]
+                if isinstance(spec, MambaSpec):
+                    group_ids.append(group_id)
+                    specs.append(spec)
+            assert specs, "no mamba layers in the model"
+            assert all(specs[0] == spec for spec in specs)
+            self._mamba_group_ids = group_ids
+            self._mamba_spec = specs[0]
+        return self._mamba_group_ids, self._mamba_spec
 
     def prepare_attn(
         self,

--- a/vllm_ascend/worker/v2/pp_utils.py
+++ b/vllm_ascend/worker/v2/pp_utils.py
@@ -51,7 +51,12 @@ _SPEC_PP_SUPPORT_BY_METHOD: Mapping[str, SpecPPSupport] = MappingProxyType(
             unsupported_feature="EAGLE3 with pipeline parallelism",
         ),
         "dspark": SpecPPSupport(
-            architectures=frozenset({"DeepseekV4ForCausalLM"}),
+            architectures=frozenset(
+                {
+                    "DeepseekV4ForCausalLM",
+                    "KimiK3ForConditionalGeneration",
+                }
+            ),
             needs_aux_hidden_states=True,
             bypass_upstream_pp_guard=True,
         ),

--- a/vllm_ascend/worker/v2/spec_decode/dspark/speculator.py
+++ b/vllm_ascend/worker/v2/spec_decode/dspark/speculator.py
@@ -27,6 +27,7 @@ from vllm.v1.worker.gpu.spec_decode.dspark.speculator import (
     DSparkSpeculator,
 )
 
+from vllm_ascend.attention.attention_v1 import AscendAttentionState
 from vllm_ascend.models.qwen3_dspark import process_weight
 from vllm_ascend.utils import (
     get_rotation_matrix,
@@ -117,6 +118,7 @@ class AscendDSparkSpeculator(DSparkSpeculator):
                 self.input_buffers.positions,
                 num_tokens_padded,
                 torch.from_numpy(self.input_batch.is_prefilling_np),
+                attn_state=AscendAttentionState.SpecDecoding,
             ),
         ):
             attn_metadata = self._build_draft_attn_metadata(
@@ -173,7 +175,10 @@ class AscendDSparkSpeculator(DSparkSpeculator):
         with (
             build_attn_metadata_wrapper(),
             build_draft_attn_metadata_factory(
-                self.input_buffers.positions, self.max_num_tokens, torch.from_numpy(self.input_batch.is_prefilling_np)
+                self.input_buffers.positions,
+                self.max_num_tokens,
+                torch.from_numpy(self.input_batch.is_prefilling_np),
+                attn_state=AscendAttentionState.SpecDecoding,
             ),
         ):
             return super().propose(


### PR DESCRIPTION
### What this PR does / why we need it?

This PR extends the Model Runner V2 speculative pipeline-parallel support introduced by #14822 to Kimi K3 with DSpark.

It adds only the Kimi K3-specific pieces required by the existing shared Spec+PP path:

- register `KimiK3ForConditionalGeneration` for DSpark with PP;
- carry Kimi K3 auxiliary hidden states across PP stages through the existing typed PP transport;
- allocate matching auxiliary receive buffers on downstream stages;
- load a TP-sharded target embedding into the rank-local DSpark model on the last PP stage, where the target embedding is otherwise a `PPMissingLayer`.

The non-PP path is unchanged. Kimi K3 DSpark remains eager-only.

### Does this PR introduce _any_ user-facing change?

Yes. Model Runner V2 users can combine Kimi K3 DSpark with pipeline parallelism in eager mode.

### How was this patch tested?

- `python3 -m py_compile` on all changed Python files.
- `git diff --check`.
- Four-node real-weight validation with Kimi K3, PP and DSpark is in progress and will be added here.

- vLLM main: https://github.com/vllm-project/vllm/commit/ba07e4a48fc951300d97eb506217dd530583dea3
