### PR TITLE
[Doc] Update release note

### DIFF
--- a/docs/source/user_guide/release_notes.md
+++ b/docs/source/user_guide/release_notes.md
@@ -75,6 +75,7 @@ The following features are deprecated or subject to change:
 - Added deprecation warnings for W4A8 linear, W4A8 MoE per-group, and W8A8 PDMix MoE quantization. These quantization paths will be removed in a future release. [#13850](https://github.com/vllm-project/vllm-ascend/pull/13850)
 - The `mega_moe_max_tokens` and `enable_fused_mc2` configurations in `additional-config` will be moved into a new dedicated dict for centralized maintenance in the next release.
 - DeepSeek-V3, DeepSeek-V3.1, and DeepSeek-R1 model support will be removed in v0.28.0.
+- The `reduce sampling` feature is experimental and will be deprecated in future releases. We will follow the upstream vLLM community for the `batch-sharded sampling` feature.
 
 ### Documentation
 


### PR DESCRIPTION
### What this PR does / why we need it?

This PR updates the release notes to document the deprecation of the experimental `reduce sampling` feature in future releases, noting that the project will align with the upstream vLLM community's `batch-sharded sampling` feature.

### Does this PR introduce _any_ user-facing change?

no

### How was this patch tested?

Documentation-only update.

- vLLM main: https://github.com/vllm-project/vllm/commit/d02df748bf9efd99022f1a062597dc3cb3808485
