### PR TITLE
[Feature][MRV2] Support DSA PCP with MTP

### DIFF
--- a/.github/workflows/scripts/test_config.yaml
+++ b/.github/workflows/scripts/test_config.yaml
@@ -91,6 +91,7 @@ accuracy_tests:
   - tests/e2e/pull_request/four_card/test_graph_mode.py
   - tests/e2e/pull_request/four_card/test_pipeline_parallel.py
   - tests/e2e/pull_request/four_card/context_parallel/test_accuracy.py
+  - tests/e2e/pull_request/four_card/context_parallel/test_deepseek_v4.py
   - tests/e2e/pull_request/four_card/model_runner_v2/test_deepseek_v4.py
   - tests/e2e/pull_request/four_card/spec_decode/test_dspark_deepseekv4.py
   - tests/e2e/pull_request/four_card/spec_decode/test_mtp_qwen3_next.py
@@ -187,7 +188,8 @@ estimated_times:
   tests/e2e/pull_request/four_card/_310p/test_moe_model_310p.py: 800
   tests/e2e/pull_request/four_card/_310p/test_vl_model_310p.py: 370
   tests/e2e/pull_request/four_card/context_parallel/test_accuracy.py: 880
-  tests/e2e/pull_request/four_card/context_parallel/test_accuracy_v2.py: 900
+  tests/e2e/pull_request/four_card/context_parallel/test_accuracy_v2.py: 590
+  tests/e2e/pull_request/four_card/context_parallel/test_deepseek_v4.py: 310
   tests/e2e/pull_request/four_card/context_parallel/test_prefix_caching_cp.py: 210
   tests/e2e/pull_request/four_card/model_runner_v2/test_deepseek_v4.py: 520
   tests/e2e/pull_request/four_card/rlhf/consistency/test_batch_invariant_tp4.py: 210

--- a/docs/source/user_guide/feature_guide/context_parallel.md
+++ b/docs/source/user_guide/feature_guide/context_parallel.md
@@ -22,7 +22,7 @@ PCP support is experimental and available only with ModelRunner V2. The followin
 | MLA | ✅ Full compatibility | ✅ Full compatibility | ✅ Full compatibility | ✅ Full compatibility | 🟠 Partial compatibility (MTP, eager and `FULL_DECODE_ONLY`) | ❌ No compatibility | ❌ No compatibility |
 | GQA | ✅ Full compatibility | ✅ Full compatibility | ✅ Full compatibility | — Not applicable | 🟠 Partial compatibility (Eagle3, eager and `FULL_DECODE_ONLY`) | ❌ No compatibility | ❌ No compatibility |
 | SFA | ✅ Full compatibility | ✅ Full compatibility | ✅ Full compatibility | ❌ No compatibility | ❌ No compatibility | ❌ No compatibility | ❌ No compatibility |
-| DSA | ✅ Full compatibility | ✅ Full compatibility | ✅ Full compatibility | — Not applicable | ❌ No compatibility | ❌ No compatibility | ❌ No compatibility |
+| DSA | ✅ Full compatibility | ✅ Full compatibility | ✅ Full compatibility | — Not applicable | 🟠 Partial compatibility (MTP, eager and `FULL_DECODE_ONLY`) | ❌ No compatibility | ❌ No compatibility |
 
 - ✅ **Full compatibility**: The basic path or feature combination is supported.
 - 🟠 **Partial compatibility**: The basic path or feature combination is supported with the stated limitations.

--- a/tests/e2e/pull_request/four_card/context_parallel/test_accuracy_v2.py
+++ b/tests/e2e/pull_request/four_card/context_parallel/test_accuracy_v2.py
@@ -75,17 +75,6 @@ DSV3_2_SFA_PCP_GOLDENS = [
     "The president of United States isoint054 Rund959arki",
 ]
 
-DSV4_MODEL = "gdydems/DeepSeek-V4-Flash-w4a8-mtp"
-DSV4_PROMPTS = [
-    "Hello, my name is",
-    "What is the meaning of life?",
-]
-DSV4_DSA_PCP_GOLDENS = [
-    "Hello, my name is {name} and I",
-    'What is the meaning of life?",\n    "What is',
-]
-
-
 MTP_PCP_MODEL = "wemaster/deepseek_mtp_main_random_bf16"
 EAGLE3_PCP_TARGET_MODEL = "Qwen/Qwen3-8B"
 EAGLE3_PCP_DRAFT_MODEL = "RedHatAI/Qwen3-8B-speculator.eagle3"
@@ -192,32 +181,6 @@ DSV3_2_SFA_PCP_CASE = AccuracyCase(
     },
 )
 
-DSV4_DSA_PCP_CASE = AccuracyCase(
-    name="dsv4_dsa_pcp_mrv2_full_decode_only",
-    model=DSV4_MODEL,
-    prompts=DSV4_PROMPTS,
-    expected_outputs=DSV4_DSA_PCP_GOLDENS,
-    max_tokens=5,
-    runner_kwargs={
-        "max_model_len": 1024,
-        "max_num_seqs": MAX_NUM_SEQS,
-        "max_num_batched_tokens": 1024,
-        "dtype": "auto",
-        "tensor_parallel_size": 2,
-        "prefill_context_parallel_size": 2,
-        "enable_expert_parallel": True,
-        "gpu_memory_utilization": 0.9,
-        "block_size": 128,
-        "quantization": "ascend",
-        "tokenizer_mode": "deepseek_v4",
-        "compilation_config": FULL_DECODE_GRAPH,
-        "additional_config": {
-            "enable_dsa_cp": False,
-            "enable_prefill_mc2": True,
-        },
-    },
-)
-
 
 @patch.dict(
     os.environ,
@@ -258,32 +221,6 @@ def test_dsv3_2_sfa_dcp_tp2_dcp2_model_runner_v2_accuracy() -> None:
 def test_dsv3_2_sfa_pcp_model_runner_v2_graph_accuracy() -> None:
     """Guard MRV2 SFA PCP full-decode-only graph accuracy."""
     _run_accuracy_case(DSV3_2_SFA_PCP_CASE)
-
-
-@pytest.mark.e2e_model(DSV4_MODEL)
-@pytest.mark.e2e_coverage(
-    arch="moe",
-    feature="dsa_pcp",
-    parallel="TP,EP,PCP",
-    deploy="pd_mix",
-    hardware="A3",
-    quantization="W4A8",
-    graph_mode="full_decode_only",
-)
-@patch.dict(
-    os.environ,
-    {
-        "VLLM_USE_V2_MODEL_RUNNER": "1",
-        "VLLM_BATCH_INVARIANT": "1",
-        "VLLM_WORKER_MULTIPROC_METHOD": "spawn",
-        "HCCL_BUFFSIZE": "2560",
-        "PYTORCH_NPU_ALLOC_CONF": "expandable_segments:True",
-    },
-)
-@wait_until_npu_memory_free(target_free_percentage=0.8)
-def test_dsv4_dsa_pcp_model_runner_v2_graph_accuracy() -> None:
-    """Guard MRV2 DSA PCP full-decode-only graph accuracy."""
-    _run_accuracy_case(DSV4_DSA_PCP_CASE)
 
 
 def _run_pcp_spec_decode(

--- a/tests/e2e/pull_request/four_card/context_parallel/test_deepseek_v4.py
+++ b/tests/e2e/pull_request/four_card/context_parallel/test_deepseek_v4.py
@@ -1,0 +1,151 @@
+#
+# Copyright (c) 2026 Huawei Technologies Co., Ltd. All Rights Reserved.
+# Copyright 2023 The vLLM team.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+"""DeepSeek-V4 DSA-PCP accuracy and MTP acceptance test for Model Runner V2.
+
+Run `pytest tests/e2e/pull_request/four_card/context_parallel/test_deepseek_v4.py`.
+"""
+
+import os
+from unittest.mock import patch
+
+import pytest
+from vllm import SamplingParams
+from vllm.outputs import RequestOutput
+from vllm.v1.metrics.reader import Counter, Metric, Vector
+
+from tests.e2e.conftest import VllmRunner, wait_until_npu_memory_free
+from tests.e2e.pull_request.one_card.model_runner_v2.utils import calculate_acceptance_per_pos
+
+MODEL = "gdydems/DeepSeek-V4-Flash-w4a8-mtp"
+MAX_NUM_SEQS = 4
+NUM_SPECULATIVE_TOKENS = 3
+
+FULL_DECODE_GRAPH_CONFIG = {
+    "cudagraph_mode": "FULL_DECODE_ONLY",
+    "cudagraph_capture_sizes": [MAX_NUM_SEQS, 2 * MAX_NUM_SEQS],
+}
+
+PROMPTS = [
+    "Hello, my name is",
+    "The president of the United States is",
+    "The capital of France is",
+    "The future of AI is",
+    "What is the meaning of life?",
+]
+MAX_TOKENS = 1024
+EXPECTED_OUTPUT_PREFIXES = {
+    "Hello, my name is": "Hello, my name is {name} and I",
+    "What is the meaning of life?": 'What is the meaning of life?",\n    "What is',
+}
+
+MIN_ACCEPTANCE_RATES = [0.85, 0.65, 0.35]
+ACCEPTANCE_RATE_TOLERANCE = 0.03
+
+
+def _assert_output_accuracy(outputs: list[RequestOutput]) -> None:
+    assert len(outputs) == len(PROMPTS), f"Expected {len(PROMPTS)} outputs, got {len(outputs)}"
+    outputs_by_prompt = {output.prompt: output for output in outputs}
+
+    for prompt, expected_prefix in EXPECTED_OUTPUT_PREFIXES.items():
+        assert prompt in outputs_by_prompt, f"Missing output for prompt {prompt!r}"
+        request_output = outputs_by_prompt[prompt]
+        assert len(request_output.outputs) == 1, (
+            f"Expected one completion for prompt {prompt!r}, got {len(request_output.outputs)}"
+        )
+
+        output_text = prompt + request_output.outputs[0].text
+        assert output_text.startswith(expected_prefix), (
+            f"Unexpected output prefix for prompt {prompt!r}: "
+            f"got {output_text[: len(expected_prefix)]!r}, expected {expected_prefix!r}"
+        )
+
+
+def _assert_acceptance_rates(metrics: list[Metric]) -> None:
+    acceptance_rates = calculate_acceptance_per_pos(
+        metrics,
+        NUM_SPECULATIVE_TOKENS,
+        Counter,
+        Vector,
+    )
+    assert len(acceptance_rates) == len(MIN_ACCEPTANCE_RATES), (
+        f"Expected {len(MIN_ACCEPTANCE_RATES)} acceptance rates, got {len(acceptance_rates)}"
+    )
+    for position, (actual, minimum) in enumerate(zip(acceptance_rates, MIN_ACCEPTANCE_RATES, strict=True)):
+        assert actual >= minimum or minimum - actual < ACCEPTANCE_RATE_TOLERANCE, (
+            f"Acceptance rate at draft position {position} is {actual}, below minimum {minimum}"
+        )
+
+
+@pytest.mark.e2e_model(MODEL)
+@pytest.mark.e2e_coverage(
+    arch="moe",
+    feature="dsa_pcp,mtp",
+    parallel="TP,EP,PCP",
+    deploy="pd_mix",
+    hardware="A3",
+    quantization="W4A8",
+    graph_mode="full_decode_only",
+)
+@patch.dict(
+    os.environ,
+    {
+        "VLLM_USE_V2_MODEL_RUNNER": "1",
+        "VLLM_BATCH_INVARIANT": "1",
+        "VLLM_WORKER_MULTIPROC_METHOD": "spawn",
+        "HCCL_BUFFSIZE": "2560",
+        "PYTORCH_NPU_ALLOC_CONF": "expandable_segments:True",
+    },
+)
+@wait_until_npu_memory_free(target_free_percentage=0.8)
+def test_deepseek_v4_dsa_pcp_mtp_full_decode_only() -> None:
+    """Verify output accuracy and MTP acceptance for DSA-PCP graph execution."""
+    sampling_params = SamplingParams(
+        max_tokens=MAX_TOKENS,
+        temperature=0.0,
+        seed=0,
+    )
+
+    with VllmRunner(
+        MODEL,
+        max_model_len=8192,
+        max_num_seqs=MAX_NUM_SEQS,
+        max_num_batched_tokens=4096,
+        dtype="auto",
+        tensor_parallel_size=2,
+        prefill_context_parallel_size=2,
+        enable_expert_parallel=True,
+        gpu_memory_utilization=0.9,
+        quantization="ascend",
+        tokenizer_mode="deepseek_v4",
+        block_size=128,
+        enforce_eager=False,
+        compilation_config=FULL_DECODE_GRAPH_CONFIG,
+        disable_log_stats=False,
+        speculative_config={
+            "num_speculative_tokens": NUM_SPECULATIVE_TOKENS,
+            "method": "mtp",
+        },
+        additional_config={
+            "enable_dsa_cp": False,
+            "enable_prefill_mc2": True,
+        },
+    ) as runner:
+        outputs = runner.model.generate(PROMPTS, sampling_params)
+        metrics = runner.model.get_metrics()
+
+    _assert_output_accuracy(outputs)
+    _assert_acceptance_rates(metrics)

--- a/tests/e2e/pull_request/four_card/context_parallel/test_deepseek_v4.py
+++ b/tests/e2e/pull_request/four_card/context_parallel/test_deepseek_v4.py
@@ -123,7 +123,7 @@ def test_deepseek_v4_dsa_pcp_mtp_full_decode_only() -> None:
         MODEL,
         max_model_len=8192,
         max_num_seqs=MAX_NUM_SEQS,
-        max_num_batched_tokens=4096,
+        max_num_batched_tokens=1024,
         dtype="auto",
         tensor_parallel_size=2,
         prefill_context_parallel_size=2,

--- a/tests/ut/attention/test_dsa_v1.py
+++ b/tests/ut/attention/test_dsa_v1.py
@@ -1888,6 +1888,30 @@ def test_pcp_metadata_provider_discards_unused_global_tasks():
     builder._global_metadata_builder.take_device_metadata_tasks.assert_called_once_with()
 
 
+def test_pcp_graph_metadata_restores_mtp_query_offsets():
+    common_metadata = MagicMock(spec=AscendCommonAttentionMetadata)
+    common_metadata.num_reqs = 4
+    common_metadata.num_input_tokens = 8
+    common_metadata.is_prefilling = torch.zeros(2, dtype=torch.bool)
+    common_metadata.query_start_loc = torch.tensor(
+        [0, 2, 4, 4, 4],
+        dtype=torch.int32,
+    )
+    common_metadata.query_start_loc_cpu = common_metadata.query_start_loc.clone()
+    common_metadata.replace.return_value = common_metadata
+
+    actual = AscendDSAPCPMetadataBuilder._build_graph_common_attn_metadata(
+        common_metadata,
+        num_actual_reqs=2,
+    )
+
+    assert actual is common_metadata
+    expected_query_start_loc = torch.tensor([0, 2, 4, 6, 8], dtype=torch.int32)
+    replace_kwargs = common_metadata.replace.call_args.kwargs
+    assert torch.equal(replace_kwargs["query_start_loc"], expected_query_start_loc)
+    assert torch.equal(replace_kwargs["query_start_loc_cpu"], expected_query_start_loc)
+
+
 @pytest.mark.parametrize("local_num_actual_tokens", [2, 0], ids=["local_tokens", "empty_rank"])
 def test_pcp_forward_updates_global_caches_before_local_attention(
     local_num_actual_tokens: int,

--- a/tests/ut/worker/test_mtp_pcp_speculator_v2.py
+++ b/tests/ut/worker/test_mtp_pcp_speculator_v2.py
@@ -286,23 +286,40 @@ def test_prefill_rebuilds_replicated_pcp_metadata_before_filtering() -> None:
     assert parent_args[3] is global_slot_mappings
 
 
-def test_graph_prefill_reuses_model_state_metadata() -> None:
+@pytest.mark.parametrize("replicated_pcp", [False, True])
+def test_graph_prefill_builds_draft_metadata(replicated_pcp: bool) -> None:
     speculator = object.__new__(AscendMTPSpeculator)
+    speculator.replicated_pcp = replicated_pcp
     speculator.draft_attn_layer_names = {"draft.layer"}
-    draft_metadata = object()
+    local_draft_metadata = object()
+    global_draft_metadata = object()
     speculator.model_state = SimpleNamespace(
         attn_metadata={
-            "draft.layer": draft_metadata,
+            "draft.layer": local_draft_metadata,
             "target.layer": object(),
         }
+    )
+    prepared_draft_metadata = global_draft_metadata if replicated_pcp else local_draft_metadata
+    speculator._prepare_replicated_prefill_attn = MagicMock(
+        return_value=(
+            {"draft.layer": prepared_draft_metadata},
+            None,
+        )
     )
 
     actual = speculator.build_draft_attn_metadatas(
         num_reqs_padded=4,
+        num_tokens_padded=8,
         is_draft_model_prefill=True,
     )
 
-    assert actual == [{"draft.layer": draft_metadata}]
+    assert actual == [{"draft.layer": prepared_draft_metadata}]
+    speculator._prepare_replicated_prefill_attn.assert_called_once_with(
+        {"draft.layer": local_draft_metadata},
+        None,
+        4,
+        8,
+    )
 
 
 def test_propose_disables_target_pcp_manager_for_replicated_draft() -> None:

--- a/vllm_ascend/attention/context_parallel/dsa_cp.py
+++ b/vllm_ascend/attention/context_parallel/dsa_cp.py
@@ -2284,16 +2284,25 @@ class AscendDSAPCPMetadataBuilder(dsa_v1.AscendDSAMetadataBuilder):
         PCP preserves the fixed graph token shape, but represents the padded
         local rows as zero-token requests. DSA requires the query offsets to
         cover every decode graph token, so expand the padded query offsets in
-        both the NPU and CPU metadata views. Padded slot mappings are
-        invalidated separately.
+        both the NPU and CPU metadata views. A regular decode has one query
+        token per request, while MTP verification has a fixed K+1 query
+        length. Padded slot mappings are invalidated separately.
 
-        Example: 2 actual requests in a graph batch padded to 4::
+        Regular decode example: 2 actual requests in a graph batch padded to 4::
 
             After PCP partition:
                 query_start_loc = [0, 1, 2, 2, 2]
 
             After DSA restoration:
                 query_start_loc = [0, 1, 2, 3, 4]
+
+        With MTP=1, each request verifies K+1=2 tokens in the same graph::
+
+            After PCP partition:
+                query_start_loc = [0, 2, 4, 4, 4]
+
+            After DSA restoration:
+                query_start_loc = [0, 2, 4, 6, 8]
 
         ``num_actual_reqs`` remains 2, and the two padded slot mappings remain
         invalid.
@@ -2307,30 +2316,33 @@ class AscendDSAPCPMetadataBuilder(dsa_v1.AscendDSAMetadataBuilder):
         is_prefilling = common_attn_metadata.is_prefilling
         if is_prefilling is not None and bool(is_prefilling.any()):
             return common_attn_metadata
-        if common_attn_metadata.num_input_tokens != num_reqs:
-            raise RuntimeError("DSA PCP full-decode graph requires one input token per request.")
+
+        # FULL_DECODE_ONLY uses the same query length for every request.
+        query_len = common_attn_metadata.num_input_tokens // num_reqs
+        padded_offsets = slice(num_actual_reqs + 1, num_reqs + 1)
+        padding_start = (num_actual_reqs + 1) * query_len
+        padding_end = (num_reqs + 1) * query_len
 
         # Expand NPU and CPU query offsets to cover padded graph tokens.
         query_start_loc = common_attn_metadata.query_start_loc[: num_reqs + 1]
         torch.arange(
-            common_attn_metadata.num_actual_tokens + 1,
-            common_attn_metadata.num_input_tokens + 1,
+            padding_start,
+            padding_end,
+            query_len,
             dtype=query_start_loc.dtype,
             device=query_start_loc.device,
-            out=query_start_loc[num_actual_reqs + 1 : num_reqs + 1],
+            out=query_start_loc[padded_offsets],
         )
-        query_start_loc_cpu = torch.empty(
-            num_reqs + 1,
-            dtype=common_attn_metadata.query_start_loc_cpu.dtype,
-        )
+        query_start_loc_cpu = common_attn_metadata.query_start_loc_cpu.new_empty((num_reqs + 1,))
         query_start_loc_cpu[: num_actual_reqs + 1].copy_(
             common_attn_metadata.query_start_loc_cpu[: num_actual_reqs + 1]
         )
         torch.arange(
-            common_attn_metadata.num_actual_tokens + 1,
-            common_attn_metadata.num_input_tokens + 1,
+            padding_start,
+            padding_end,
+            query_len,
             dtype=query_start_loc_cpu.dtype,
-            out=query_start_loc_cpu[num_actual_reqs + 1 : num_reqs + 1],
+            out=query_start_loc_cpu[padded_offsets],
         )
 
         return common_attn_metadata.replace(

--- a/vllm_ascend/attention/utils.py
+++ b/vllm_ascend/attention/utils.py
@@ -240,7 +240,6 @@ def enable_dcp():
     return parallel_config.decode_context_parallel_size > 1
 
 
-@lru_cache(maxsize=1)
 def enable_pcp():
     parallel_config = get_current_vllm_config().parallel_config
     return parallel_config.prefill_context_parallel_size > 1

--- a/vllm_ascend/worker/v2/spec_decode/autoregressive/aclgraph.py
+++ b/vllm_ascend/worker/v2/spec_decode/autoregressive/aclgraph.py
@@ -134,7 +134,11 @@ class AutoRegressiveAclGraphManager(SpeculatorCudaGraphManager):
         else:
             logger.info_once("AutoRegressiveAclGraphManager: draft run_fullgraph with num_tokens=%s", num_tokens)
 
-        draft_attn_metadatas = self.speculator.build_draft_attn_metadatas(desc.num_reqs, self.is_draft_model_prefill)
+        draft_attn_metadatas = self.speculator.build_draft_attn_metadatas(
+            desc.num_reqs,
+            desc.num_tokens,
+            self.is_draft_model_prefill,
+        )
         self.update_stream.wait_stream(torch.npu.current_stream())
         ret = super().run_fullgraph(desc)
 

--- a/vllm_ascend/worker/v2/spec_decode/autoregressive/speculator.py
+++ b/vllm_ascend/worker/v2/spec_decode/autoregressive/speculator.py
@@ -23,7 +23,7 @@ from typing import TYPE_CHECKING, Any
 
 import numpy as np
 import torch
-from vllm.config import VllmConfig, replace
+from vllm.config import VllmConfig, replace, set_current_vllm_config
 from vllm.config.compilation import CUDAGraphMode
 from vllm.v1.attention.backend import AttentionBackend
 from vllm.v1.kv_cache_interface import KVCacheConfig
@@ -261,17 +261,19 @@ class AscendAutoRegressiveSpeculator(AutoRegressiveSpeculator):
         target_input_buffers: InputBuffers,
         target_attn_groups: list[list[AttentionGroup]],
     ) -> None:
-        super().set_attn(
-            model_state,
-            kv_cache_config,
-            block_tables,
-            target_input_buffers,
-            target_attn_groups,
-        )
+        # Initialize the draft attention backend with its PCP=1 config.
+        with set_current_vllm_config(self.attn_vllm_config):
+            super().set_attn(
+                model_state,
+                kv_cache_config,
+                block_tables,
+                target_input_buffers,
+                target_attn_groups,
+            )
 
-        # Use the first executable draft attention layer as the architecture
-        # discriminator and cache it for ACL graph parameter updates.
-        self.attn_backend = _get_graph_update_backend(self.attn_groups)
+            # Use the first executable draft attention layer as the architecture
+            # discriminator and cache it for ACL graph parameter updates.
+            self.attn_backend = _get_graph_update_backend(self.attn_groups)
         if issubclass(self.attn_backend, AscendDSABackend):
             self.attn_architecture = "DSA"
         elif issubclass(self.attn_backend, AscendMLABackend):
@@ -461,7 +463,12 @@ class AscendAutoRegressiveSpeculator(AutoRegressiveSpeculator):
                 metadata.attn_state = AscendAttentionState.DecodeOnly
         return attn_metadata
 
-    def build_draft_attn_metadatas(self, num_reqs_padded, is_draft_model_prefill):
+    def build_draft_attn_metadatas(
+        self,
+        num_reqs_padded: int,
+        num_tokens_padded: int,
+        is_draft_model_prefill: bool,
+    ):
         """Build draft_attn_metadatas for partial-merged draft graph."""
         attn_metadata = self.model_state.attn_metadata
         attn_metadata = {
@@ -469,7 +476,14 @@ class AscendAutoRegressiveSpeculator(AutoRegressiveSpeculator):
         }
 
         if is_draft_model_prefill:
-            return [attn_metadata]
+            prepared_attn_metadata, _ = self._prepare_replicated_prefill_attn(
+                attn_metadata,
+                None,
+                num_reqs_padded,
+                num_tokens_padded,
+            )
+            assert prepared_attn_metadata is not None
+            return [prepared_attn_metadata]
 
         draft_attn_metadatas = self._init_decode_draft_attn_metadatas(attn_metadata, num_reqs_padded)
 


### PR DESCRIPTION
### What this PR does / why we need it?

This PR extends the MRV2 PCP speculative decoding support from #14960 to DSA with MTP.

- Resolve DSA metadata-builder and implementation selection against the active target or replicated draft configuration, so the target keeps PCP execution while the draft uses PCP=1.
- Support fixed K+1 MTP verification query lengths in DSA PCP `FULL_DECODE_ONLY` graph metadata.
- Add focused unit coverage for restoring padded MTP query offsets in both device and CPU metadata.
- Update the PCP compatibility matrix for DSA PCP with MTP.

### Does this PR introduce _any_ user-facing change?

Yes. MRV2 users can combine DSA PCP with MTP speculative decoding. No new CLI option is introduced.

### How was this patch tested?

- Model: DeepSeek-V4-Flash W8A8 MTP
- Workload: GPQA Diamond first 100 questions, MTP=1, `FULL_DECODE_ONLY`, `max_out_len=65536`, concurrency 100, temperature 0, and seed 0
- Baseline: TP8 x PCP1
- Feature: TP4 x PCP2
- Weighted acceptance rate: accepted tokens / drafted tokens, calculated from the counter delta of each round

| Configuration | Round | Successful requests | Accuracy | Weighted acceptance rate | stop / length |
| --- | ---: | ---: | ---: | ---: | ---: |
| main TP8 x PCP1 | 1 | 100/100 | 76.00% | 88.76% | 84 / 16 |
| main TP8 x PCP1 | 2 | 100/100 | 76.00% | 89.46% | 79 / 21 |
| main TP8 x PCP1 | 3 | 100/100 | 74.00% | 89.46% | 82 / 18 |
| feature TP4 x PCP2 | 1 | 100/100 | 77.00% | 89.66% | 82 / 18 |
| feature TP4 x PCP2 | 2 | 100/100 | 74.00% | 88.63% | 85 / 15 |
| feature TP4 x PCP2 | 3 | 100/100 | 75.00% | 89.37% | 84 / 16 |

Three-round median:

- main: 76.00% accuracy and 89.46% weighted acceptance rate
- feature: 75.00% accuracy and 89.37% weighted acceptance rate
- feature vs. main: -1.00 percentage point accuracy and -0.09 percentage point weighted acceptance rate
- All six runs completed 100/100 requests with non-zero drafted and accepted token counts.

The feature results were collected from the Graph metadata fix snapshot later included in this PR. Nightly validation was not run.

- vLLM main: https://github.com/vllm-project/vllm/commit/ba07e4a48fc951300d97eb506217dd530583dea3
