### PR TITLE
[Performance][Backport v0.27.1rc] Backport #15416, #15265 and #15252

### DIFF
--- a/tests/ut/_310p/fused_moe/test_shared_fused_moe_310.py
+++ b/tests/ut/_310p/fused_moe/test_shared_fused_moe_310.py
@@ -21,6 +21,8 @@ from vllm_ascend.ops.fused_moe.shared_experts import AscendSharedExperts, FusedM
 def _build_runner() -> AscendMoERunner310:
     runner = AscendMoERunner310.__new__(AscendMoERunner310)
     nn.Module.__init__(runner)
+    runner.routed_input_transform = None
+    runner.routed_output_transform = None
     return runner
 
 

--- a/tests/ut/_310p/fused_moe/test_shared_fused_moe_310.py
+++ b/tests/ut/_310p/fused_moe/test_shared_fused_moe_310.py
@@ -101,6 +101,8 @@ def test_runner_310_installs_specialized_comm():
     runner.gate = None
     routed_experts = SimpleNamespace(quant_config=None, quant_method=None)
     runner.ascend_shared_experts = SimpleNamespace(multistream_overlap=True)
+    upstream_forward_entry = object()
+    runner._select_forward = MagicMock(return_value=upstream_forward_entry)
     comm_method = object()
 
     with (
@@ -118,6 +120,8 @@ def test_runner_310_installs_specialized_comm():
 
         assert routed_experts.quant_method is None
         assert runner.ascend_shared_experts.multistream_overlap is False
+        assert runner._forward_entry is upstream_forward_entry
+        runner._select_forward.assert_called_once_with()
         assert fused_moe_310_module._MoECommMethods[MoECommType.ALLGATHER] is comm_method
         parent_init.assert_called_once()
 
@@ -230,7 +234,8 @@ def test_forward_impl_310_returns_current_runner_contract(monkeypatch, has_share
     routed_out = torch.randn(2, 4)
     shared_out = torch.randn(2, 4)
     ascend_shared_experts = SimpleNamespace(
-        prepare_input_before_routed_experts=MagicMock(return_value=(hidden_states, None)),
+        multistream_overlap=False,
+        local_input_from_gathered=MagicMock(return_value=hidden_states),
         forward=MagicMock(return_value=shared_out),
     )
     routed_events = FusedMoEEvents(

--- a/tests/ut/attention/test_mla_v1.py
+++ b/tests/ut/attention/test_mla_v1.py
@@ -1124,6 +1124,7 @@ class TestAscendMLAImpl(TestBase):
         speculative_config.num_speculative_tokens = 4
         vllm_config.speculative_config = speculative_config
         model_config.dtype = torch.float16
+        model_config.runner_type = "generate"
         vllm_config.model_config = model_config
         get_current_vllm_config.return_value = vllm_config
         vllm_config.additional_config = {"refresh": True}
@@ -1191,9 +1192,49 @@ class TestAscendMLAImpl(TestBase):
         self.assertIsNotNone(self.impl.kv_a_proj_with_mqa)
         self.assertIsNotNone(self.impl.kv_a_layernorm)
         self.assertEqual(self.impl.num_queries_per_kv, 32)
+        self.assertFalse(self.impl.is_draft_model)
         # 256 is power of 2, so padding should be 0
         self.assertEqual(self.impl.num_heads_padded, 256)
         self.assertEqual(self.impl.head_padding, 0)
+
+    @patch("vllm_ascend.attention.mla_v1.enabling_mlapo", return_value=True)
+    @patch("vllm_ascend.attention.mla_v1.get_current_vllm_config")
+    def test_draft_model_disables_mlapo_at_init(self, mock_get_current_vllm_config, mock_enabling_mlapo):
+        self.impl.vllm_config.model_config.runner_type = "draft"
+        mock_get_current_vllm_config.return_value = self.impl.vllm_config
+        impl = AscendMLAImpl(
+            num_heads=self.impl.num_heads,
+            head_size=self.impl.head_size,
+            scale=self.impl.scale,
+            num_kv_heads=self.impl.num_kv_heads,
+            alibi_slopes=None,
+            sliding_window=None,
+            kv_cache_dtype=self.impl.kv_cache_dtype,
+            blocksparse_params=None,
+            logits_soft_cap=None,
+            attn_type=None,
+            kv_sharing_target_layer_name=None,
+            kv_lora_rank=self.impl.kv_lora_rank,
+            qk_nope_head_dim=self.impl.qk_nope_head_dim,
+            qk_rope_head_dim=self.impl.qk_rope_head_dim,
+            qk_head_dim=self.impl.qk_head_dim,
+            v_head_dim=self.impl.v_head_dim,
+            q_lora_rank=self.impl.q_lora_rank,
+            q_proj=self.impl.q_proj,
+            q_b_proj=self.impl.q_proj,
+            kv_b_proj=self.impl.kv_b_proj,
+            o_proj=self.impl.o_proj,
+            kv_a_proj_with_mqa=self.impl.kv_a_proj_with_mqa,
+            fused_qkv_a_proj=self.impl.fused_qkv_a_proj,
+            kv_a_layernorm=self.impl.kv_a_layernorm,
+            rotary_emb=self.impl.rotary_emb,
+            g_proj=None,
+            use_mla_rope=True,
+        )
+
+        self.assertTrue(impl.is_draft_model)
+        self.assertFalse(impl.enable_mlapo)
+        mock_enabling_mlapo.assert_not_called()
 
     @patch("vllm_ascend.attention.mla_v1.get_current_vllm_config")
     def test_init_head_padding_for_non_power_of_two(self, mock_get_current_vllm_config):

--- a/tests/ut/models/test_kimi_k3_adapter.py
+++ b/tests/ut/models/test_kimi_k3_adapter.py
@@ -2,7 +2,7 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
 from types import MethodType, SimpleNamespace
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import torch
 from safetensors.torch import save_file
@@ -16,6 +16,24 @@ from vllm_ascend.models.kimi_k3 import (
 from vllm_ascend.models.kimi_k3_dspark import (
     AscendK3DSparkForCausalLM,
 )
+
+
+def test_kimi_moe_leaves_routed_input_transform_to_runner():
+    moe = kimi_k3.AscendKimiMoE.__new__(kimi_k3.AscendKimiMoE)
+    nn.Module.__init__(moe)
+    hidden_states = torch.randn(4, 8)
+    router_logits = torch.randn(4, 16)
+    output = torch.randn(4, 8)
+    moe.gate = MagicMock(return_value=(router_logits, None))
+    moe.experts = MagicMock(return_value=output)
+
+    result = moe.forward(hidden_states)
+
+    moe.experts.assert_called_once_with(
+        hidden_states=hidden_states,
+        router_logits=router_logits,
+    )
+    torch.testing.assert_close(result, output)
 
 
 def test_ascend_attn_res_matches_canonical_k3_math():

--- a/tests/ut/models/test_kimi_k3_adapter.py
+++ b/tests/ut/models/test_kimi_k3_adapter.py
@@ -31,8 +31,8 @@ def test_kimi_moe_leaves_routed_input_transform_to_runner():
 
     moe.experts.assert_called_once()
     call_kwargs = moe.experts.call_args.kwargs
-    assert call_kwargs["hidden_states"] is hidden_states
-    assert call_kwargs["router_logits"] is router_logits
+    torch.testing.assert_close(call_kwargs["hidden_states"], hidden_states)
+    torch.testing.assert_close(call_kwargs["router_logits"], router_logits)
     torch.testing.assert_close(result, output)
 
 

--- a/tests/ut/models/test_kimi_k3_adapter.py
+++ b/tests/ut/models/test_kimi_k3_adapter.py
@@ -69,9 +69,11 @@ def test_kimi_mixed_kda_gate_weights_use_upstream_packed_loader(monkeypatch):
     nn.Module.__init__(model)
     layer = nn.Module()
     layer.self_attn = nn.Module()
-    layer.self_attn.in_proj_gfab = nn.Module()
+    layer.self_attn.fused_bfg_proj = nn.Module()
     packed_weight = nn.Parameter(torch.empty(6, 4))
-    layer.self_attn.in_proj_gfab.register_parameter("weight", packed_weight)
+    layer.self_attn.fused_bfg_proj.register_parameter("weight", packed_weight)
+    layer.self_attn.fused_bfg_proj.register_parameter("f_a_weight", nn.Parameter(torch.empty(1)))
+    layer.self_attn.fused_bfg_proj.register_parameter("f_b_weight", nn.Parameter(torch.empty(1)))
     layer.router = nn.Linear(4, 1, bias=False)
     model.layers = nn.ModuleList([layer])
 
@@ -90,24 +92,38 @@ def test_kimi_mixed_kda_gate_weights_use_upstream_packed_loader(monkeypatch):
         ("layers.0.router.weight", torch.full((1, 4), 0.5)),
         ("layers.0.self_attn.g_proj.weight", torch.full((1,), 1.0)),
         ("layers.0.self_attn.f_a_proj.weight", torch.full((1,), 2.0)),
-        ("layers.0.self_attn.b_proj.weight", torch.full((1,), 3.0)),
-        ("layers.0.self_attn.o_proj.weight", torch.full((1,), 4.0)),
+        ("layers.0.self_attn.f_b_proj.weight", torch.full((1,), 3.0)),
+        ("layers.0.self_attn.b_proj.weight", torch.full((1,), 4.0)),
+        ("layers.0.self_attn.o_proj.weight", torch.full((1,), 5.0)),
     ]
 
     loaded = model.load_weights(iter(source_weights))
 
     assert remaining[0] == source_weights[0]
     assert remaining[-1] == source_weights[-1]
-    assert [name for name, _, _ in remaining[1:4]] == [
-        "layers.0.self_attn.in_proj_gfab.weight",
-    ] * 3
-    assert [loaded_weight.item() for _, loaded_weight, _ in remaining[1:4]] == [1.0, 2.0, 3.0]
-    assert [kwargs["loaded_shard_id"] for _, _, kwargs in remaining[1:4]] == [0, 1, 2]
+    assert [name for name, _, _ in remaining[1:5]] == [
+        "layers.0.self_attn.fused_bfg_proj.weight",
+        "layers.0.self_attn.fused_bfg_proj.f_a_weight",
+        "layers.0.self_attn.fused_bfg_proj.f_b_weight",
+        "layers.0.self_attn.fused_bfg_proj.weight",
+    ]
+    assert [loaded_weight.item() for _, loaded_weight, _ in remaining[1:5]] == [1.0, 2.0, 3.0, 4.0]
+    assert [kwargs["loaded_shard_id"] for _, _, kwargs in remaining[1:5]] == [2, None, None, 0]
     assert loaded == {
-        "layers.0.self_attn.in_proj_gfab.weight",
+        "layers.0.self_attn.fused_bfg_proj.weight",
+        "layers.0.self_attn.fused_bfg_proj.f_a_weight",
+        "layers.0.self_attn.fused_bfg_proj.f_b_weight",
         "layers.0.router.weight",
         "layers.0.self_attn.o_proj.weight",
     }
+
+
+def test_kimi_model_declares_fused_bfg_checkpoint_mapping():
+    assert AscendKimiLinearModel.packed_modules_mapping["fused_bfg_proj"] == [
+        "b_proj",
+        "f_a_proj",
+        "g_proj",
+    ]
 
 
 def test_kimi_attention_residual_stays_sequence_sharded(monkeypatch):

--- a/tests/ut/models/test_kimi_k3_adapter.py
+++ b/tests/ut/models/test_kimi_k3_adapter.py
@@ -29,10 +29,10 @@ def test_kimi_moe_leaves_routed_input_transform_to_runner():
 
     result = moe.forward(hidden_states)
 
-    moe.experts.assert_called_once_with(
-        hidden_states=hidden_states,
-        router_logits=router_logits,
-    )
+    moe.experts.assert_called_once()
+    call_kwargs = moe.experts.call_args.kwargs
+    assert call_kwargs["hidden_states"] is hidden_states
+    assert call_kwargs["router_logits"] is router_logits
     torch.testing.assert_close(result, output)
 
 

--- a/tests/ut/ops/test_fused_moe.py
+++ b/tests/ut/ops/test_fused_moe.py
@@ -1081,6 +1081,7 @@ def test_k3_w4a8_mxfp_multistream_schedule_on_a3_and_a5(monkeypatch, device_type
         torch.randn(4, 4, dtype=torch.bfloat16),
         events,
         input_is_gathered=True,
+        defer_output_wait=True,
     )
 
     assert result is reduced_out
@@ -1300,18 +1301,20 @@ def test_sp_multistream_custom_op_fake_returns_local_token_shape(hidden_dim_unpa
 
 
 @pytest.mark.parametrize(
-    ("mode", "multistream_overlap", "uses_sp_custom_op"),
+    ("mode", "multistream_overlap", "has_routed_input_transform", "uses_sp_custom_op"),
     [
-        (SharedExpertParallelMode.SEQUENCE_PARALLEL_ONLY, True, True),
-        (SharedExpertParallelMode.SEQUENCE_PARALLEL_ONLY, False, False),
-        (SharedExpertParallelMode.SEQUENCE_PARALLEL_SEDP, True, False),
-        (SharedExpertParallelMode.TENSOR_PARALLEL, True, False),
+        (SharedExpertParallelMode.SEQUENCE_PARALLEL_ONLY, True, True, True),
+        (SharedExpertParallelMode.SEQUENCE_PARALLEL_ONLY, True, False, False),
+        (SharedExpertParallelMode.SEQUENCE_PARALLEL_ONLY, False, True, False),
+        (SharedExpertParallelMode.SEQUENCE_PARALLEL_SEDP, True, True, False),
+        (SharedExpertParallelMode.TENSOR_PARALLEL, True, True, False),
     ],
 )
 def test_runner_selects_sp_multistream_custom_op(
     monkeypatch,
     mode,
     multistream_overlap,
+    has_routed_input_transform,
     uses_sp_custom_op,
 ):
     upstream_forward_entry = object()
@@ -1364,6 +1367,7 @@ def test_runner_selects_sp_multistream_custom_op(
         router=object(),
         routed_experts=routed_experts,
         shared_experts=object(),
+        routed_input_transform=object() if has_routed_input_transform else None,
     )
 
     if uses_sp_custom_op:
@@ -1392,7 +1396,11 @@ def test_sp_multistream_all_gather_starts_before_routed_input_transform(monkeypa
         assert states is hidden_states
         return routed_states, None
 
-    runner.ascend_shared_experts = SimpleNamespace(start_input_all_gather=MagicMock(side_effect=start_all_gather))
+    runner.ascend_shared_experts = SimpleNamespace(
+        multistream_overlap=True,
+        parallel_mode=MagicMock(return_value=SharedExpertParallelMode.SEQUENCE_PARALLEL_ONLY),
+        start_input_all_gather=MagicMock(side_effect=start_all_gather),
+    )
     runner.routed_input_transform = MagicMock(side_effect=latent_down)
     monkeypatch.setattr(fused_moe_module.torch.npu, "current_stream", lambda: current_stream)
 
@@ -1402,6 +1410,24 @@ def test_sp_multistream_all_gather_starts_before_routed_input_transform(monkeypa
     assert shared_input is gathered_states
     assert operation_order == ["all_gather", "latent_down", "wait_all_gather"]
     current_stream.wait_event.assert_called_once_with(all_gather_done)
+
+
+def test_runner_without_routed_input_transform_keeps_original_shared_input_path():
+    runner = AscendMoERunner.__new__(AscendMoERunner)
+    hidden_states = torch.randn(4, 4)
+    runner._shared_experts = object()
+    runner.routed_input_transform = None
+    runner.ascend_shared_experts = SimpleNamespace(
+        multistream_overlap=True,
+        parallel_mode=MagicMock(return_value=SharedExpertParallelMode.SEQUENCE_PARALLEL_ONLY),
+        start_input_all_gather=MagicMock(),
+    )
+
+    routed_input, shared_input = runner.apply_routed_input_transform(hidden_states)
+
+    assert routed_input is hidden_states
+    assert shared_input is hidden_states
+    runner.ascend_shared_experts.start_input_all_gather.assert_not_called()
 
 
 def test_sp_multistream_reduce_scatter_overlaps_routed_output_transform():
@@ -1417,7 +1443,9 @@ def test_sp_multistream_reduce_scatter_overlaps_routed_output_transform():
 
     runner.routed_output_transform = MagicMock(side_effect=latent_up)
     runner.ascend_shared_experts = SimpleNamespace(
-        wait_for_output=MagicMock(side_effect=lambda: operation_order.append("join_shared_output"))
+        multistream_overlap=True,
+        parallel_mode=MagicMock(return_value=SharedExpertParallelMode.SEQUENCE_PARALLEL_ONLY),
+        wait_for_output=MagicMock(side_effect=lambda: operation_order.append("join_shared_output")),
     )
 
     result = runner.apply_routed_output_transform(latent_states)
@@ -1426,14 +1454,33 @@ def test_sp_multistream_reduce_scatter_overlaps_routed_output_transform():
     assert operation_order == ["latent_up", "join_shared_output"]
 
 
+def test_runner_without_routed_output_transform_does_not_defer_shared_output_join():
+    runner = AscendMoERunner.__new__(AscendMoERunner)
+    fused_output = torch.randn(4, 4)
+    runner.routed_output_transform = None
+    runner.ascend_shared_experts = SimpleNamespace(
+        multistream_overlap=True,
+        parallel_mode=MagicMock(return_value=SharedExpertParallelMode.SEQUENCE_PARALLEL_ONLY),
+        wait_for_output=MagicMock(),
+    )
+
+    result = runner.apply_routed_output_transform(fused_output)
+
+    assert result is fused_output
+    runner.ascend_shared_experts.wait_for_output.assert_not_called()
+
+
 def test_sp_multistream_fp16_scaling_joins_shared_output_before_inplace_write():
     runner = AscendMoERunner.__new__(AscendMoERunner)
     shared_output = torch.randn(4, 4, dtype=torch.float16)
     fused_output = torch.randn(4, 4, dtype=torch.float16)
     operation_order = []
     runner.routed_scaling_factor = 2.0
+    runner.routed_output_transform = object()
     runner.ascend_shared_experts = SimpleNamespace(
-        wait_for_output=MagicMock(side_effect=lambda: operation_order.append("join_shared_output"))
+        multistream_overlap=True,
+        parallel_mode=MagicMock(return_value=SharedExpertParallelMode.SEQUENCE_PARALLEL_ONLY),
+        wait_for_output=MagicMock(side_effect=lambda: operation_order.append("join_shared_output")),
     )
 
     result_shared, result_fused = runner._maybe_apply_routed_scale_to_output(shared_output, fused_output)
@@ -1509,6 +1556,7 @@ def test_sp_multistream_down_projection_overlaps_combine_and_reduce_scatter_wait
         hidden_states,
         events,
         input_is_gathered=True,
+        defer_output_wait=True,
     )
 
     assert result is reduced_out
@@ -1528,6 +1576,15 @@ def test_sp_multistream_down_projection_overlaps_combine_and_reduce_scatter_wait
 
     shared_experts.wait_for_output()
 
+    default_stream.wait_stream.assert_called_once_with(auxiliary_stream)
+
+    default_stream.wait_stream.reset_mock()
+    shared_experts.forward(
+        hidden_states,
+        events,
+        input_is_gathered=True,
+        defer_output_wait=False,
+    )
     default_stream.wait_stream.assert_called_once_with(auxiliary_stream)
 
 
@@ -1700,6 +1757,8 @@ def test_forward_impl_keeps_full_width_input_for_shared_experts(monkeypatch):
         before_combine=None,
     )
     runner.routed_experts = SimpleNamespace(forward_impl=MagicMock(return_value=(routed_out, routed_events)))
+    runner.routed_input_transform = object()
+    runner.routed_output_transform = object()
     num_tokens = 3
     prepared_shared_hidden_states = shared_hidden_states[:num_tokens]
     runner.ascend_shared_experts = SimpleNamespace(
@@ -1740,6 +1799,7 @@ def test_forward_impl_keeps_full_width_input_for_shared_experts(monkeypatch):
         prepared_shared_hidden_states,
         routed_events,
         input_is_gathered=True,
+        defer_output_wait=True,
     )
     assert result[0] is shared_out
     assert result[1] is routed_out

--- a/tests/ut/ops/test_fused_moe.py
+++ b/tests/ut/ops/test_fused_moe.py
@@ -886,18 +886,7 @@ def _make_shared_expert_events():
     )
 
 
-@pytest.mark.parametrize(
-    ("device_type", "expects_glu_parameters"),
-    [
-        (shared_experts_module.AscendDeviceType.A3, True),
-        (shared_experts_module.AscendDeviceType.A5, False),
-    ],
-)
-def test_w8a8_shared_situ_uses_device_specific_dequant_situ_quant(
-    monkeypatch,
-    device_type,
-    expects_glu_parameters,
-):
+def test_w8a8_shared_situ_uses_dequant_situ_quant(monkeypatch):
     gate_up_proj = SimpleNamespace(
         weight=torch.ones(4, 4, dtype=torch.int8),
         weight_scale=torch.ones(4),
@@ -918,7 +907,6 @@ def test_w8a8_shared_situ_uses_device_specific_dequant_situ_quant(
     dequant_situ_quant = MagicMock(return_value=(quantized_situ, situ_scale))
 
     monkeypatch.setattr(shared_experts_module, "has_lora", lambda _: False)
-    monkeypatch.setattr(shared_experts_module, "get_ascend_device_type", lambda: device_type)
     monkeypatch.setattr(shared_experts_module, "npu_stream_switch", lambda *_args, **_kwargs: nullcontext())
     monkeypatch.setattr(shared_experts_module, "shared_experts_calculation_stream", MagicMock())
     monkeypatch.setattr(shared_experts_module.torch.npu, "current_stream", MagicMock(return_value=MagicMock()))
@@ -946,8 +934,6 @@ def test_w8a8_shared_situ_uses_device_specific_dequant_situ_quant(
     assert situ_kwargs["x"] is gate_up_out
     assert situ_kwargs["beta"] == 4.0
     assert situ_kwargs["linear_beta"] == 25.0
-    assert ("glu_alpha" in situ_kwargs) is expects_glu_parameters
-    assert ("glu_bias" in situ_kwargs) is expects_glu_parameters
 
 
 def test_w4a8_mxfp_shared_situ_uses_situ_mx_quant(monkeypatch):
@@ -1688,6 +1674,8 @@ def test_set_lora_context_updates_experts(has_shared_experts):
 def test_forward_impl_returns_current_runner_contract(monkeypatch, has_shared_experts):
     runner = AscendMoERunner.__new__(AscendMoERunner)
     nn.Module.__init__(runner)
+    runner.routed_input_transform = None
+    runner.routed_output_transform = None
     hidden_states = torch.randn(2, 4)
     router_logits = torch.randn(2, 3)
     input_ids = torch.tensor([11, 22])
@@ -1795,11 +1783,13 @@ def test_forward_impl_keeps_full_width_input_for_shared_experts(monkeypatch):
     )
     current_stream.wait_event.assert_not_called()
     assert routed_events.after_routed_finalize is current_stream.record_event.return_value
-    runner.ascend_shared_experts.forward.assert_called_once_with(
-        prepared_shared_hidden_states,
-        routed_events,
-        input_is_gathered=True,
-        defer_output_wait=True,
-    )
+    runner.ascend_shared_experts.forward.assert_called_once()
+    call_args = runner.ascend_shared_experts.forward.call_args
+    torch.testing.assert_close(call_args.args[0], prepared_shared_hidden_states)
+    assert call_args.args[1] is routed_events
+    assert call_args.kwargs == {
+        "input_is_gathered": True,
+        "defer_output_wait": True,
+    }
     assert result[0] is shared_out
     assert result[1] is routed_out

--- a/tests/ut/ops/test_fused_moe.py
+++ b/tests/ut/ops/test_fused_moe.py
@@ -886,7 +886,18 @@ def _make_shared_expert_events():
     )
 
 
-def test_w8a8_shared_situ_uses_dequant_situ_quant(monkeypatch):
+@pytest.mark.parametrize(
+    ("device_type", "expects_glu_parameters"),
+    [
+        (shared_experts_module.AscendDeviceType.A3, True),
+        (shared_experts_module.AscendDeviceType.A5, False),
+    ],
+)
+def test_w8a8_shared_situ_uses_device_specific_dequant_situ_quant(
+    monkeypatch,
+    device_type,
+    expects_glu_parameters,
+):
     gate_up_proj = SimpleNamespace(
         weight=torch.ones(4, 4, dtype=torch.int8),
         weight_scale=torch.ones(4),
@@ -907,6 +918,7 @@ def test_w8a8_shared_situ_uses_dequant_situ_quant(monkeypatch):
     dequant_situ_quant = MagicMock(return_value=(quantized_situ, situ_scale))
 
     monkeypatch.setattr(shared_experts_module, "has_lora", lambda _: False)
+    monkeypatch.setattr(shared_experts_module, "get_ascend_device_type", lambda: device_type)
     monkeypatch.setattr(shared_experts_module, "npu_stream_switch", lambda *_args, **_kwargs: nullcontext())
     monkeypatch.setattr(shared_experts_module, "shared_experts_calculation_stream", MagicMock())
     monkeypatch.setattr(shared_experts_module.torch.npu, "current_stream", MagicMock(return_value=MagicMock()))
@@ -934,6 +946,8 @@ def test_w8a8_shared_situ_uses_dequant_situ_quant(monkeypatch):
     assert situ_kwargs["x"] is gate_up_out
     assert situ_kwargs["beta"] == 4.0
     assert situ_kwargs["linear_beta"] == 25.0
+    assert ("glu_alpha" in situ_kwargs) is expects_glu_parameters
+    assert ("glu_bias" in situ_kwargs) is expects_glu_parameters
 
 
 def test_w4a8_mxfp_shared_situ_uses_situ_mx_quant(monkeypatch):
@@ -974,6 +988,117 @@ def test_w4a8_mxfp_shared_situ_uses_situ_mx_quant(monkeypatch):
     assert situ_kwargs["beta"] == 4.0
     assert situ_kwargs["linear_beta"] == 25.0
     assert situ_kwargs["dst_type"] == shared_experts_module.SITU_MX_DST_TYPE_E4M3FN
+
+
+@pytest.mark.parametrize(
+    "device_type",
+    [
+        shared_experts_module.AscendDeviceType.A3,
+        shared_experts_module.AscendDeviceType.A5,
+    ],
+)
+def test_k3_w4a8_mxfp_multistream_schedule_on_a3_and_a5(monkeypatch, device_type):
+    quantized_input = torch.ones(4, 4, dtype=torch.float8_e4m3fn)
+    input_scale = torch.ones(4, 1)
+    gate_up_out = torch.randn(4, 4, dtype=torch.bfloat16)
+    quantized_activation = torch.ones(4, 2, dtype=torch.float8_e4m3fn)
+    activation_scale = torch.ones(4, 1)
+    shared_out = torch.randn(4, 2, dtype=torch.bfloat16)
+    reduced_out = torch.randn(2, 2, dtype=torch.bfloat16)
+    operation_order = []
+
+    def gate_up(*_args):
+        operation_order.append("shared_gate_up")
+        return gate_up_out, None
+
+    def down(*_args):
+        operation_order.append("shared_down")
+        return shared_out, None
+
+    gate_up_proj = MagicMock(side_effect=gate_up)
+    gate_up_proj.weight_scale = torch.ones(1)
+    down_proj = MagicMock(side_effect=down)
+    down_proj.weight_scale = torch.ones(1)
+    shared_experts = _make_quantized_situ_shared_experts(QuantType.W4A8MXFP, gate_up_proj, down_proj)
+    shared_experts.multistream_overlap = True
+    shared_experts.parallel_mode = MagicMock(return_value=SharedExpertParallelMode.SEQUENCE_PARALLEL_ONLY)
+
+    events = FusedMoEEvents(
+        before_routed_experts=MagicMock(),
+        before_dispatch=MagicMock(),
+        before_gmm2=MagicMock(),
+        before_combine=MagicMock(),
+        after_routed_finalize=MagicMock(),
+    )
+    event_names = {
+        events.before_routed_experts: "before_routed_experts",
+        events.before_dispatch: "before_dispatch",
+        events.before_gmm2: "before_gmm2",
+        events.before_combine: "before_combine",
+        events.after_routed_finalize: "after_routed_finalize",
+    }
+    main_stream = MagicMock()
+    auxiliary_stream = MagicMock()
+    stream_state = {"current": main_stream}
+
+    @contextmanager
+    def switch_stream(stream, enabled):
+        previous_stream = stream_state["current"]
+        if enabled:
+            stream_state["current"] = stream
+        try:
+            yield
+        finally:
+            stream_state["current"] = previous_stream
+
+    def dynamic_quant(_states, **_kwargs):
+        operation_order.append("dynamic_quant")
+        return quantized_input, input_scale
+
+    def activation(**_kwargs):
+        operation_order.append("shared_activation")
+        return quantized_activation, activation_scale
+
+    def reduce_scatter(_states):
+        operation_order.append("reduce_scatter")
+        return reduced_out
+
+    auxiliary_stream.wait_event.side_effect = lambda event: operation_order.append(f"wait_{event_names[event]}")
+    shared_experts._pad_and_reduce_scatter = MagicMock(side_effect=reduce_scatter)
+    monkeypatch.setattr(shared_experts_module, "has_lora", lambda _: False)
+    monkeypatch.setattr(shared_experts_module, "get_ascend_device_type", lambda: device_type)
+    monkeypatch.setattr(shared_experts_module, "npu_stream_switch", switch_stream)
+    monkeypatch.setattr(shared_experts_module, "shared_experts_calculation_stream", lambda: auxiliary_stream)
+    monkeypatch.setattr(shared_experts_module.torch.npu, "current_stream", lambda: stream_state["current"])
+    monkeypatch.setattr(shared_experts_module.torch_npu, "npu_dynamic_mx_quant", dynamic_quant, raising=False)
+    monkeypatch.setattr(
+        shared_experts_module.torch.ops,
+        "_C_ascend",
+        SimpleNamespace(situ_mx_quant=MagicMock(side_effect=activation)),
+    )
+
+    result = shared_experts.forward(
+        torch.randn(4, 4, dtype=torch.bfloat16),
+        events,
+        input_is_gathered=True,
+    )
+
+    assert result is reduced_out
+    assert operation_order == [
+        "wait_before_routed_experts",
+        "dynamic_quant",
+        "wait_before_dispatch",
+        "shared_gate_up",
+        "wait_before_gmm2",
+        "shared_activation",
+        "wait_before_combine",
+        "shared_down",
+        "wait_after_routed_finalize",
+        "reduce_scatter",
+    ]
+    main_stream.wait_stream.assert_not_called()
+    shared_experts.wait_for_output()
+    main_stream.wait_stream.assert_called_once_with(auxiliary_stream)
 
 
 @pytest.mark.parametrize(
@@ -1080,15 +1205,31 @@ def test_sequence_parallel_only_gathers_unpads_pads_and_reduce_scatters(monkeypa
         )
 
 
+def test_sp_multistream_recovers_local_router_input_from_early_gather():
+    shared_experts = AscendSharedExperts.__new__(AscendSharedExperts)
+    shared_experts.multistream_overlap = True
+    shared_experts.parallel_mode = MagicMock(return_value=SharedExpertParallelMode.SEQUENCE_PARALLEL_ONLY)
+    shared_experts.moe_config = SimpleNamespace(tp_group=SimpleNamespace(rank_in_group=2))
+    gathered_states = torch.arange(32, dtype=torch.float32).view(8, 4)
+
+    local_states = shared_experts.local_input_from_gathered(
+        gathered_states,
+        local_num_tokens=2,
+    )
+
+    torch.testing.assert_close(local_states, gathered_states[4:6])
+
+
 @pytest.mark.parametrize(
     ("mode", "multistream_overlap", "starts_all_gather"),
     [
         (SharedExpertParallelMode.SEQUENCE_PARALLEL_ONLY, True, True),
         (SharedExpertParallelMode.SEQUENCE_PARALLEL_ONLY, False, False),
         (SharedExpertParallelMode.SEQUENCE_PARALLEL_SEDP, True, False),
+        (SharedExpertParallelMode.TENSOR_PARALLEL, True, False),
     ],
 )
-def test_prepare_shared_expert_input_only_starts_sp_tp_all_gather(
+def test_early_all_gather_only_runs_for_sp_with_tp_sharded_weights(
     monkeypatch,
     mode,
     multistream_overlap,
@@ -1099,14 +1240,14 @@ def test_prepare_shared_expert_input_only_starts_sp_tp_all_gather(
     shared_experts.parallel_mode = MagicMock(return_value=mode)
     hidden_states = torch.randn(2, 4)
     gathered_states = torch.randn(4, 4)
-    shared_experts._gather_sp_input = MagicMock(return_value=gathered_states)
-    default_stream = MagicMock()
+    all_gather = MagicMock(return_value=gathered_states)
+    main_stream = MagicMock()
     auxiliary_stream = MagicMock()
     input_ready = MagicMock()
     all_gather_done = MagicMock()
-    default_stream.record_event.return_value = input_ready
+    main_stream.record_event.return_value = input_ready
     auxiliary_stream.record_event.return_value = all_gather_done
-    stream_state = {"current": default_stream}
+    stream_state = {"current": main_stream}
 
     @contextmanager
     def switch_stream(stream, enabled):
@@ -1118,27 +1259,191 @@ def test_prepare_shared_expert_input_only_starts_sp_tp_all_gather(
         finally:
             stream_state["current"] = previous_stream
 
+    monkeypatch.setattr(shared_experts_module, "tensor_model_parallel_all_gather", all_gather)
     monkeypatch.setattr(shared_experts_module, "npu_stream_switch", switch_stream)
     monkeypatch.setattr(shared_experts_module, "shared_experts_calculation_stream", lambda: auxiliary_stream)
     monkeypatch.setattr(shared_experts_module.torch.npu, "current_stream", lambda: stream_state["current"])
 
-    result, done_event = shared_experts.prepare_input_before_routed_experts(hidden_states)
+    result, done_event = shared_experts.start_input_all_gather(hidden_states)
 
     if starts_all_gather:
         assert result is gathered_states
         assert done_event is all_gather_done
-        default_stream.record_event.assert_called_once_with()
+        main_stream.record_event.assert_called_once_with()
         auxiliary_stream.wait_event.assert_called_once_with(input_ready)
-        shared_experts._gather_sp_input.assert_called_once_with(hidden_states)
+        all_gather.assert_called_once_with(hidden_states, dim=0)
         auxiliary_stream.record_event.assert_called_once_with()
     else:
         assert result is hidden_states
         assert done_event is None
-        default_stream.record_event.assert_not_called()
-        shared_experts._gather_sp_input.assert_not_called()
+        main_stream.record_event.assert_not_called()
+        all_gather.assert_not_called()
 
 
-def test_sp_multistream_down_projection_and_reduce_scatter_wait_for_routed_finalize(
+@pytest.mark.parametrize("hidden_dim_unpadded", [0, 3])
+def test_sp_multistream_custom_op_fake_returns_local_token_shape(hidden_dim_unpadded):
+    routed_states = torch.randn(2, 4)
+    gathered_shared_states = torch.randn(8, 6)
+
+    shared_out, routed_out = fused_moe_module._ascend_moe_forward_shared_sp_fake(
+        routed_states,
+        router_logits=torch.randn(2, 4),
+        shared_experts_input=gathered_shared_states,
+        input_ids=None,
+        layer_name="layer",
+        hidden_dim_unpadded=hidden_dim_unpadded,
+    )
+
+    assert shared_out.shape == torch.Size([2, 6])
+    expected_routed_width = hidden_dim_unpadded or routed_states.shape[-1]
+    assert routed_out.shape == torch.Size([2, expected_routed_width])
+
+
+@pytest.mark.parametrize(
+    ("mode", "multistream_overlap", "uses_sp_custom_op"),
+    [
+        (SharedExpertParallelMode.SEQUENCE_PARALLEL_ONLY, True, True),
+        (SharedExpertParallelMode.SEQUENCE_PARALLEL_ONLY, False, False),
+        (SharedExpertParallelMode.SEQUENCE_PARALLEL_SEDP, True, False),
+        (SharedExpertParallelMode.TENSOR_PARALLEL, True, False),
+    ],
+)
+def test_runner_selects_sp_multistream_custom_op(
+    monkeypatch,
+    mode,
+    multistream_overlap,
+    uses_sp_custom_op,
+):
+    upstream_forward_entry = object()
+    moe_config = SimpleNamespace(hidden_dim=4, ep_size=1)
+    routed_experts = SimpleNamespace(
+        quant_type=QuantType.NONE,
+        quant_method=object(),
+        return_with_event=False,
+    )
+    shared_executor = SimpleNamespace(
+        multistream_overlap=multistream_overlap,
+        parallel_mode=MagicMock(return_value=mode),
+    )
+
+    def init_base_runner(
+        runner,
+        layer_name,
+        config,
+        _router,
+        experts,
+        _enable_dbo,
+        gate,
+        shared_experts,
+        _shared_expert_gate,
+        routed_input_transform,
+        routed_output_transform,
+        routed_scaling_factor,
+    ):
+        nn.Module.__init__(runner)
+        runner.layer_name = layer_name
+        runner.moe_config = config
+        runner.routed_experts = experts
+        runner._shared_experts = shared_experts
+        runner._gate = gate
+        runner.routed_input_transform = routed_input_transform
+        runner.routed_output_transform = routed_output_transform
+        runner.routed_scaling_factor = routed_scaling_factor
+        runner._forward_entry = upstream_forward_entry
+
+    monkeypatch.setattr(fused_moe_module.MoERunner, "__init__", init_base_runner)
+    monkeypatch.setattr(fused_moe_module, "AscendSharedExperts", MagicMock(return_value=shared_executor))
+    monkeypatch.setattr(fused_moe_module, "get_tp_group", MagicMock(return_value=object()))
+    monkeypatch.setattr(fused_moe_module, "get_dp_group", MagicMock(return_value=object()))
+    monkeypatch.setattr(fused_moe_module, "setup_moe_comm_method", MagicMock())
+    monkeypatch.setattr(fused_moe_module, "get_moe_comm_method", MagicMock(return_value=None))
+
+    runner = AscendMoERunner(
+        "model.layers.0.mlp",
+        moe_config,
+        router=object(),
+        routed_experts=routed_experts,
+        shared_experts=object(),
+    )
+
+    if uses_sp_custom_op:
+        assert runner._forward_entry is torch.ops.vllm.ascend_moe_forward_shared_sp
+    else:
+        assert runner._forward_entry is upstream_forward_entry
+
+
+def test_sp_multistream_all_gather_starts_before_routed_input_transform(monkeypatch):
+    runner = AscendMoERunner.__new__(AscendMoERunner)
+    hidden_states = torch.randn(4, 4)
+    gathered_states = torch.randn(8, 4)
+    routed_states = torch.randn(4, 2)
+    all_gather_done = MagicMock()
+    operation_order = []
+    current_stream = MagicMock()
+    current_stream.wait_event.side_effect = lambda event: operation_order.append("wait_all_gather")
+
+    def start_all_gather(states):
+        operation_order.append("all_gather")
+        assert states is hidden_states
+        return gathered_states, all_gather_done
+
+    def latent_down(states):
+        operation_order.append("latent_down")
+        assert states is hidden_states
+        return routed_states, None
+
+    runner.ascend_shared_experts = SimpleNamespace(start_input_all_gather=MagicMock(side_effect=start_all_gather))
+    runner.routed_input_transform = MagicMock(side_effect=latent_down)
+    monkeypatch.setattr(fused_moe_module.torch.npu, "current_stream", lambda: current_stream)
+
+    result, shared_input = runner.apply_routed_input_transform(hidden_states)
+
+    assert result is routed_states
+    assert shared_input is gathered_states
+    assert operation_order == ["all_gather", "latent_down", "wait_all_gather"]
+    current_stream.wait_event.assert_called_once_with(all_gather_done)
+
+
+def test_sp_multistream_reduce_scatter_overlaps_routed_output_transform():
+    runner = AscendMoERunner.__new__(AscendMoERunner)
+    latent_states = torch.randn(4, 2)
+    full_states = torch.randn(4, 4)
+    operation_order = []
+
+    def latent_up(states):
+        operation_order.append("latent_up")
+        assert states is latent_states
+        return full_states, None
+
+    runner.routed_output_transform = MagicMock(side_effect=latent_up)
+    runner.ascend_shared_experts = SimpleNamespace(
+        wait_for_output=MagicMock(side_effect=lambda: operation_order.append("join_shared_output"))
+    )
+
+    result = runner.apply_routed_output_transform(latent_states)
+
+    assert result is full_states
+    assert operation_order == ["latent_up", "join_shared_output"]
+
+
+def test_sp_multistream_fp16_scaling_joins_shared_output_before_inplace_write():
+    runner = AscendMoERunner.__new__(AscendMoERunner)
+    shared_output = torch.randn(4, 4, dtype=torch.float16)
+    fused_output = torch.randn(4, 4, dtype=torch.float16)
+    operation_order = []
+    runner.routed_scaling_factor = 2.0
+    runner.ascend_shared_experts = SimpleNamespace(
+        wait_for_output=MagicMock(side_effect=lambda: operation_order.append("join_shared_output"))
+    )
+
+    result_shared, result_fused = runner._maybe_apply_routed_scale_to_output(shared_output, fused_output)
+
+    assert operation_order == ["join_shared_output"]
+    assert result_shared is shared_output
+    assert result_fused is fused_output
+
+
+def test_sp_multistream_down_projection_overlaps_combine_and_reduce_scatter_waits_for_finalize(
     monkeypatch,
 ):
     shared_experts = AscendSharedExperts.__new__(AscendSharedExperts)
@@ -1154,10 +1459,20 @@ def test_sp_multistream_down_projection_and_reduce_scatter_wait_for_routed_final
     part1_out = torch.randn(4, 8)
     shared_out = torch.randn(4, 4)
     reduced_out = torch.randn(2, 4)
+    operation_order = []
     shared_experts.part1 = MagicMock(return_value=part1_out)
-    shared_experts.part2 = MagicMock(return_value=shared_out)
+
+    def run_down_projection(*_args):
+        operation_order.append("down_projection")
+        return shared_out
+
+    def run_reduce_scatter(*_args):
+        operation_order.append("reduce_scatter")
+        return reduced_out
+
+    shared_experts.part2 = MagicMock(side_effect=run_down_projection)
     shared_experts._gather_sp_input = MagicMock()
-    shared_experts._pad_and_reduce_scatter = MagicMock(return_value=reduced_out)
+    shared_experts._pad_and_reduce_scatter = MagicMock(side_effect=run_reduce_scatter)
     default_stream = MagicMock()
     auxiliary_stream = MagicMock()
     stream_state = {"current": default_stream}
@@ -1182,6 +1497,14 @@ def test_sp_multistream_down_projection_and_reduce_scatter_wait_for_routed_final
     monkeypatch.setattr(shared_experts_module, "shared_experts_calculation_stream", lambda: auxiliary_stream)
     monkeypatch.setattr(shared_experts_module.torch.npu, "current_stream", lambda: stream_state["current"])
 
+    def record_wait(event):
+        if event is events.before_combine:
+            operation_order.append("wait_before_combine")
+        elif event is events.after_routed_finalize:
+            operation_order.append("wait_after_routed_finalize")
+
+    auxiliary_stream.wait_event.side_effect = record_wait
+
     result = shared_experts.forward(
         hidden_states,
         events,
@@ -1190,12 +1513,21 @@ def test_sp_multistream_down_projection_and_reduce_scatter_wait_for_routed_final
 
     assert result is reduced_out
     shared_experts._gather_sp_input.assert_not_called()
-    auxiliary_stream.wait_event.assert_any_call(events.after_routed_finalize)
-    assert not any(
-        event_wait.args == (events.before_combine,) for event_wait in auxiliary_stream.wait_event.call_args_list
-    )
+    wait_calls = auxiliary_stream.wait_event.call_args_list
+    assert wait_calls[-2].args[0] is events.before_combine
+    assert wait_calls[-1].args[0] is events.after_routed_finalize
+    assert operation_order == [
+        "wait_before_combine",
+        "down_projection",
+        "wait_after_routed_finalize",
+        "reduce_scatter",
+    ]
     shared_experts.part2.assert_called_once_with(hidden_states, part1_out)
     shared_experts._pad_and_reduce_scatter.assert_called_once_with(shared_out)
+    default_stream.wait_stream.assert_not_called()
+
+    shared_experts.wait_for_output()
+
     default_stream.wait_stream.assert_called_once_with(auxiliary_stream)
 
 
@@ -1305,7 +1637,8 @@ def test_forward_impl_returns_current_runner_contract(monkeypatch, has_shared_ex
     routed_out = torch.randn(2, 4)
     shared_out = torch.randn(2, 4)
     ascend_shared_experts = SimpleNamespace(
-        prepare_input_before_routed_experts=MagicMock(return_value=(hidden_states, None)),
+        multistream_overlap=False,
+        local_input_from_gathered=MagicMock(return_value=hidden_states),
         forward=MagicMock(return_value=shared_out),
     )
     routed_events = FusedMoEEvents(
@@ -1333,7 +1666,6 @@ def test_forward_impl_returns_current_runner_contract(monkeypatch, has_shared_ex
     )
 
     if has_shared_experts:
-        ascend_shared_experts.prepare_input_before_routed_experts.assert_called_once_with(hidden_states)
         runner.routed_experts.forward_impl.assert_called_once_with(
             hidden_states=hidden_states,
             router_logits=router_logits,
@@ -1356,7 +1688,7 @@ def test_forward_impl_keeps_full_width_input_for_shared_experts(monkeypatch):
     runner = AscendMoERunner.__new__(AscendMoERunner)
     nn.Module.__init__(runner)
     routed_hidden_states = torch.randn(2, 4)
-    shared_hidden_states = torch.randn(2, 8)
+    shared_hidden_states = torch.randn(4, 8)
     router_logits = torch.randn(2, 3)
     routed_out = torch.randn(2, 4)
     shared_out = torch.randn(2, 8)
@@ -1368,12 +1700,12 @@ def test_forward_impl_keeps_full_width_input_for_shared_experts(monkeypatch):
         before_combine=None,
     )
     runner.routed_experts = SimpleNamespace(forward_impl=MagicMock(return_value=(routed_out, routed_events)))
-    shared_input_all_gather_done = MagicMock()
-    prepared_shared_hidden_states = torch.randn(4, 8)
+    num_tokens = 3
+    prepared_shared_hidden_states = shared_hidden_states[:num_tokens]
     runner.ascend_shared_experts = SimpleNamespace(
-        prepare_input_before_routed_experts=MagicMock(
-            return_value=(prepared_shared_hidden_states, shared_input_all_gather_done),
-        ),
+        multistream_overlap=True,
+        parallel_mode=MagicMock(return_value=SharedExpertParallelMode.SEQUENCE_PARALLEL_ONLY),
+        local_input_from_gathered=MagicMock(return_value=shared_hidden_states[:2]),
         forward=MagicMock(return_value=shared_out),
     )
     runner._sequence_parallel_context = MagicMock(return_value=nullcontext())
@@ -1389,6 +1721,7 @@ def test_forward_impl_keeps_full_width_input_for_shared_experts(monkeypatch):
         "current_stream",
         lambda: current_stream,
     )
+    monkeypatch.setattr(fused_moe_module, "_EXTRA_CTX", SimpleNamespace(num_tokens=num_tokens))
 
     result = runner._forward_impl(
         routed_hidden_states,
@@ -1401,8 +1734,7 @@ def test_forward_impl_keeps_full_width_input_for_shared_experts(monkeypatch):
         router_logits=router_logits,
         input_ids=None,
     )
-    runner.ascend_shared_experts.prepare_input_before_routed_experts.assert_called_once_with(shared_hidden_states)
-    current_stream.wait_event.assert_called_once_with(shared_input_all_gather_done)
+    current_stream.wait_event.assert_not_called()
     assert routed_events.after_routed_finalize is current_stream.record_event.return_value
     runner.ascend_shared_experts.forward.assert_called_once_with(
         prepared_shared_hidden_states,

--- a/tests/ut/ops/test_kimi_kda.py
+++ b/tests/ut/ops/test_kimi_kda.py
@@ -135,6 +135,24 @@ def test_prepare_beta_slices_and_applies_sigmoid_in_fp32():
     assert torch.all((beta >= 0.0) & (beta <= 1.0))
 
 
+def test_prepare_beta_does_not_repeat_auxiliary_sigmoid():
+    raw_beta = torch.tensor(
+        [[[-20.0], [0.0], [20.0], [100.0]]],
+        dtype=torch.bfloat16,
+    )
+    preprocessed_beta = raw_beta.float().sigmoid()
+
+    beta = _prepare_beta(
+        preprocessed_beta,
+        num_actual_tokens=3,
+        is_preprocessed=True,
+    )
+
+    assert beta.dtype == torch.float32
+    assert beta.shape == (1, 3, 1)
+    torch.testing.assert_close(beta, preprocessed_beta[:, :3])
+
+
 @pytest.mark.parametrize("f_b_is_local", [False, True])
 def test_fused_bfg_linear_composes_f_and_packs_bfg(f_b_is_local: bool):
     with (
@@ -211,36 +229,75 @@ def test_fused_bfg_projection_preserves_staged_outputs():
     attention.head_dim = 3
     attention._fused_bfg_output_sizes = (2, 6, 6)
     hidden_states = torch.randn(4, 5)
-    fused_output = torch.arange(56, dtype=torch.float32).reshape(4, 14)
+    fused_output = torch.arange(56, dtype=torch.float32).reshape(4, 14).to(torch.bfloat16)
     attention.fused_bfg_proj = _RecordingLinear(fused_output)
 
-    beta, raw_gate, output_gate = attention._project_bfg(hidden_states)
-    torch.testing.assert_close(beta, fused_output[:, :2])
-    torch.testing.assert_close(raw_gate, fused_output[:, 2:8])
-    torch.testing.assert_close(output_gate, fused_output[:, 8:])
+    projected_bfg = attention._project_bfg(hidden_states)
+    assert projected_bfg is fused_output
 
-    beta, raw_gate, output_gate = attention._postprocess_bfg(beta, raw_gate, output_gate)
-    torch.testing.assert_close(beta, fused_output[:, :2].unsqueeze(0))
+    beta, raw_gate, output_gate = attention._postprocess_bfg(projected_bfg)
+    assert beta.dtype == torch.float32
+    torch.testing.assert_close(beta, fused_output[:, :2].float().sigmoid().unsqueeze(0))
     torch.testing.assert_close(raw_gate, fused_output[:, 2:8].reshape(4, 2, 3).unsqueeze(0))
     torch.testing.assert_close(output_gate, fused_output[:, 8:].reshape(4, 2, 3))
 
 
-def test_overlapped_qkv_bfg_joins_auxiliary_tail_for_graph_capture():
+def test_mixed_forward_marks_auxiliary_beta_as_preprocessed():
+    attention = AscendKimiK3DeltaAttention.__new__(AscendKimiK3DeltaAttention)
+    nn.Module.__init__(attention)
+    attention.uses_mixed_projection = True
+    attention.local_num_heads = 2
+    attention.head_dim = 3
+    hidden_states = torch.randn(4, 6)
+    positions = torch.arange(4)
+    mixed_qkv = torch.randn(4, 18)
+    beta = torch.rand(1, 4, 2, dtype=torch.float32)
+    raw_gate = torch.randn(1, 4, 2, 3)
+    output_gate = torch.randn(4, 2, 3)
+    projected = torch.randn(4, 6)
+    attention._run_overlapped_qkv_bfg = MagicMock(return_value=(mixed_qkv, beta, raw_gate, output_gate))
+    attention._forward = MagicMock()
+    attention.o_proj = _RecordingLinear(projected)
+
+    actual = attention.forward(hidden_states, positions)
+
+    assert actual is projected
+    assert attention._forward.call_args.kwargs["beta"] is beta
+    assert attention._forward.call_args.kwargs["beta_is_preprocessed"] is True
+
+
+def test_overlapped_qkv_bfg_keeps_two_stage_vector_cube_overlap():
     attention = AscendKimiK3DeltaAttention.__new__(AscendKimiK3DeltaAttention)
     nn.Module.__init__(attention)
     trace: list[str] = []
     main_stream = _RecordingStream("main", ["hidden_ready", "quant_ready"], trace)
     bfg_stream = _RecordingStream("bfg", ["bfg_projection_ready", "bfg_ready"], trace)
     hidden_states = _RecordingTensor("hidden", trace)
-    raw_bfg = tuple(_RecordingTensor(name, trace) for name in ("beta_raw", "raw_gate_raw", "gate_raw"))
+    fused_bfg = _RecordingTensor("fused_bfg", trace)
     processed_bfg = tuple(_RecordingTensor(name, trace) for name in ("beta", "raw_gate", "output_gate"))
     quantized_qkv = object()
     qkv = object()
 
-    attention._project_bfg = MagicMock(side_effect=lambda _: (trace.append("project_bfg"), raw_bfg)[1])
-    attention._quantize_fused_qkv = MagicMock(side_effect=lambda _: (trace.append("dynamic_quant"), quantized_qkv)[1])
-    attention._matmul_fused_qkv = MagicMock(side_effect=lambda _: (trace.append("qkv_matmul"), qkv)[1])
-    attention._postprocess_bfg = MagicMock(side_effect=lambda *_: (trace.append("postprocess_bfg"), processed_bfg)[1])
+    def record_project_bfg(_hidden_states: object) -> _RecordingTensor:
+        trace.append("project_bfg")
+        return fused_bfg
+
+    def record_dynamic_quant(_hidden_states: object) -> object:
+        trace.append("dynamic_quant")
+        return quantized_qkv
+
+    def record_qkv_matmul(_qkv_input: object) -> object:
+        trace.append("qkv_matmul")
+        return qkv
+
+    def record_postprocess_bfg(*_args: object) -> tuple[_RecordingTensor, ...]:
+        trace.append("postprocess_bfg")
+        return processed_bfg
+
+    attention._project_bfg = MagicMock(side_effect=record_project_bfg)
+    attention._quantize_fused_qkv = MagicMock(side_effect=record_dynamic_quant)
+    attention._matmul_fused_qkv = MagicMock(side_effect=record_qkv_matmul)
+    attention._postprocess_bfg = MagicMock(side_effect=record_postprocess_bfg)
 
     with (
         patch("vllm_ascend.ops.kimi_kda.torch.npu.current_stream", return_value=main_stream),

--- a/tests/ut/ops/test_kimi_kda.py
+++ b/tests/ut/ops/test_kimi_kda.py
@@ -8,13 +8,6 @@ import pytest
 import torch
 from torch import nn
 
-from vllm_ascend.quantization.methods.w4a8_mxfp4 import (
-    AscendW4A8MXFPDynamicLinearMethod,
-)
-from vllm_ascend.quantization.methods.w8a8_mxfp8 import (
-    AscendW8A8MXFP8DynamicLinearMethod,
-)
-
 from vllm_ascend.ops.kimi_kda import (
     _PACKED_CONV_WEIGHT_NAME,
     AscendKimiK3DeltaAttention,
@@ -22,6 +15,12 @@ from vllm_ascend.ops.kimi_kda import (
     _prepare_beta,
     _zero_padded_output,
     _zero_padded_recurrent_output,
+)
+from vllm_ascend.quantization.methods.w4a8.w4a8_mxfp4 import (
+    AscendW4A8MXFPDynamicLinearMethod,
+)
+from vllm_ascend.quantization.methods.w8a8.w8a8_mxfp8 import (
+    AscendW8A8MXFP8DynamicLinearMethod,
 )
 
 

--- a/tests/ut/ops/test_kimi_kda.py
+++ b/tests/ut/ops/test_kimi_kda.py
@@ -2,18 +2,71 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
 from types import SimpleNamespace
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
+import pytest
 import torch
 from torch import nn
 
 from vllm_ascend.ops.kimi_kda import (
     _PACKED_CONV_WEIGHT_NAME,
     AscendKimiK3DeltaAttention,
+    _KDAFusedBFGLinear,
     _prepare_beta,
     _zero_padded_output,
     _zero_padded_recurrent_output,
 )
+from vllm_ascend.quantization.methods.w4a8_mxfp4 import (
+    AscendW4A8MXFPDynamicLinearMethod,
+)
+from vllm_ascend.quantization.methods.w8a8_mxfp8 import (
+    AscendW8A8MXFP8DynamicLinearMethod,
+)
+
+
+class _RecordingLinear(nn.Module):
+    def __init__(self, output: torch.Tensor) -> None:
+        super().__init__()
+        self.output = output
+
+    def forward(self, _input: torch.Tensor):
+        return self.output, None
+
+
+class _RecordingStream:
+    def __init__(self, name: str, event_names: list[str], trace: list[str]) -> None:
+        self.name = name
+        self.event_names = iter(event_names)
+        self.trace = trace
+
+    def record_event(self) -> str:
+        event = next(self.event_names)
+        self.trace.append(f"{self.name}.record:{event}")
+        return event
+
+    def wait_event(self, event: str) -> None:
+        self.trace.append(f"{self.name}.wait:{event}")
+
+
+class _RecordingTensor:
+    def __init__(self, name: str, trace: list[str]) -> None:
+        self.name = name
+        self.trace = trace
+
+    def record_stream(self, stream: _RecordingStream) -> None:
+        self.trace.append(f"{self.name}.record_stream:{stream.name}")
+
+
+class _RecordingStreamSwitch:
+    def __init__(self, stream: _RecordingStream, trace: list[str]) -> None:
+        self.stream = stream
+        self.trace = trace
+
+    def __enter__(self) -> None:
+        self.trace.append(f"enter:{self.stream.name}")
+
+    def __exit__(self, *args) -> None:
+        self.trace.append(f"exit:{self.stream.name}")
 
 
 def test_zero_padded_recurrent_output_clears_uncovered_tail():
@@ -80,6 +133,209 @@ def test_prepare_beta_slices_and_applies_sigmoid_in_fp32():
     assert beta.shape == (1, 3, 1)
     torch.testing.assert_close(beta, raw_beta[:, :3].float().sigmoid())
     assert torch.all((beta >= 0.0) & (beta <= 1.0))
+
+
+@pytest.mark.parametrize("f_b_is_local", [False, True])
+def test_fused_bfg_linear_composes_f_and_packs_bfg(f_b_is_local: bool):
+    with (
+        patch("vllm.model_executor.layers.linear.get_tensor_model_parallel_world_size", return_value=4),
+        patch("vllm.model_executor.layers.linear.get_tensor_model_parallel_rank", return_value=2),
+        patch("vllm.model_executor.parameter.get_tensor_model_parallel_rank", return_value=2),
+        patch("vllm.model_executor.parameter.get_tensor_model_parallel_world_size", return_value=4),
+    ):
+        linear = _KDAFusedBFGLinear(
+            hidden_size=6,
+            num_heads=8,
+            head_dim=3,
+            tp_size=4,
+            quant_config=None,
+            prefix="model.layers.0.self_attn.in_proj_gfab",
+        )
+
+    linear.weight.data.zero_()
+    b_weight = torch.arange(8 * 6, dtype=linear.weight.dtype).reshape(8, 6)
+    f_a_weight = torch.arange(3 * 6, dtype=linear.weight.dtype).reshape(3, 6) + 100
+    global_f_b_weight = torch.arange(24 * 3, dtype=linear.weight.dtype).reshape(24, 3) + 200
+    local_f_b_weight = global_f_b_weight[12:18]
+    g_weight = torch.arange(24 * 6, dtype=linear.weight.dtype).reshape(24, 6) + 200
+
+    linear.weight.weight_loader(linear.weight, b_weight, 0)
+    linear.f_a_weight.weight_loader(linear.f_a_weight, f_a_weight)
+    linear.f_b_weight.weight_loader(
+        linear.f_b_weight,
+        local_f_b_weight if f_b_is_local else global_f_b_weight,
+    )
+    linear.weight.weight_loader(linear.weight, g_weight, 2)
+
+    expected_f = (local_f_b_weight.float() @ f_a_weight.float()).to(linear.weight.dtype)
+    assert tuple(linear.weight.shape) == (14, 6)
+    torch.testing.assert_close(linear.weight[:2], b_weight[4:6])
+    torch.testing.assert_close(linear.weight[2:8], expected_f)
+    torch.testing.assert_close(linear.weight[8:], g_weight[12:18])
+
+
+def test_fused_bfg_linear_recomposes_f_after_source_reload():
+    with (
+        patch("vllm.model_executor.layers.linear.get_tensor_model_parallel_world_size", return_value=1),
+        patch("vllm.model_executor.layers.linear.get_tensor_model_parallel_rank", return_value=0),
+        patch("vllm.model_executor.parameter.get_tensor_model_parallel_rank", return_value=0),
+        patch("vllm.model_executor.parameter.get_tensor_model_parallel_world_size", return_value=1),
+    ):
+        linear = _KDAFusedBFGLinear(
+            hidden_size=4,
+            num_heads=2,
+            head_dim=2,
+            tp_size=1,
+            quant_config=None,
+            prefix="model.layers.0.self_attn.in_proj_gfab",
+        )
+
+    linear.weight.data.zero_()
+    first_f_a = torch.arange(8, dtype=linear.weight.dtype).reshape(2, 4)
+    first_f_b = torch.arange(8, dtype=linear.weight.dtype).reshape(4, 2)
+    linear.f_a_weight.weight_loader(linear.f_a_weight, first_f_a)
+    torch.testing.assert_close(linear.weight[2:6], torch.zeros_like(linear.weight[2:6]))
+    linear.f_b_weight.weight_loader(linear.f_b_weight, first_f_b)
+    torch.testing.assert_close(linear.weight[2:6], first_f_b.float() @ first_f_a.float())
+
+    reloaded_f_a = first_f_a + 10
+    reloaded_f_b = first_f_b + 20
+    linear.f_a_weight.weight_loader(linear.f_a_weight, reloaded_f_a)
+    linear.f_b_weight.weight_loader(linear.f_b_weight, reloaded_f_b)
+    torch.testing.assert_close(linear.weight[2:6], reloaded_f_b.float() @ reloaded_f_a.float())
+
+
+def test_fused_bfg_projection_preserves_staged_outputs():
+    attention = AscendKimiK3DeltaAttention.__new__(AscendKimiK3DeltaAttention)
+    nn.Module.__init__(attention)
+    attention.head_dim = 3
+    attention._fused_bfg_output_sizes = (2, 6, 6)
+    hidden_states = torch.randn(4, 5)
+    fused_output = torch.arange(56, dtype=torch.float32).reshape(4, 14)
+    attention.fused_bfg_proj = _RecordingLinear(fused_output)
+
+    beta, raw_gate, output_gate = attention._project_bfg(hidden_states)
+    torch.testing.assert_close(beta, fused_output[:, :2])
+    torch.testing.assert_close(raw_gate, fused_output[:, 2:8])
+    torch.testing.assert_close(output_gate, fused_output[:, 8:])
+
+    beta, raw_gate, output_gate = attention._postprocess_bfg(beta, raw_gate, output_gate)
+    torch.testing.assert_close(beta, fused_output[:, :2].unsqueeze(0))
+    torch.testing.assert_close(raw_gate, fused_output[:, 2:8].reshape(4, 2, 3).unsqueeze(0))
+    torch.testing.assert_close(output_gate, fused_output[:, 8:].reshape(4, 2, 3))
+
+
+def test_overlapped_qkv_bfg_joins_auxiliary_tail_for_graph_capture():
+    attention = AscendKimiK3DeltaAttention.__new__(AscendKimiK3DeltaAttention)
+    nn.Module.__init__(attention)
+    trace: list[str] = []
+    main_stream = _RecordingStream("main", ["hidden_ready", "quant_ready"], trace)
+    bfg_stream = _RecordingStream("bfg", ["bfg_projection_ready", "bfg_ready"], trace)
+    hidden_states = _RecordingTensor("hidden", trace)
+    raw_bfg = tuple(_RecordingTensor(name, trace) for name in ("beta_raw", "raw_gate_raw", "gate_raw"))
+    processed_bfg = tuple(_RecordingTensor(name, trace) for name in ("beta", "raw_gate", "output_gate"))
+    quantized_qkv = object()
+    qkv = object()
+
+    attention._project_bfg = MagicMock(side_effect=lambda _: (trace.append("project_bfg"), raw_bfg)[1])
+    attention._quantize_fused_qkv = MagicMock(side_effect=lambda _: (trace.append("dynamic_quant"), quantized_qkv)[1])
+    attention._matmul_fused_qkv = MagicMock(side_effect=lambda _: (trace.append("qkv_matmul"), qkv)[1])
+    attention._postprocess_bfg = MagicMock(side_effect=lambda *_: (trace.append("postprocess_bfg"), processed_bfg)[1])
+
+    with (
+        patch("vllm_ascend.ops.kimi_kda.torch.npu.current_stream", return_value=main_stream),
+        patch("vllm_ascend.ops.kimi_kda._kda_bfg_stream", return_value=bfg_stream),
+        patch(
+            "vllm_ascend.ops.kimi_kda.npu_stream_switch",
+            side_effect=lambda stream: _RecordingStreamSwitch(stream, trace),
+        ),
+    ):
+        actual = attention._run_overlapped_qkv_bfg(hidden_states)
+
+    assert actual == (qkv, *processed_bfg)
+    assert trace == [
+        "main.record:hidden_ready",
+        "hidden.record_stream:bfg",
+        "enter:bfg",
+        "bfg.wait:hidden_ready",
+        "project_bfg",
+        "bfg.record:bfg_projection_ready",
+        "exit:bfg",
+        "dynamic_quant",
+        "main.record:quant_ready",
+        "main.wait:bfg_projection_ready",
+        "qkv_matmul",
+        "enter:bfg",
+        "bfg.wait:quant_ready",
+        "postprocess_bfg",
+        "bfg.record:bfg_ready",
+        "exit:bfg",
+        "beta.record_stream:main",
+        "raw_gate.record_stream:main",
+        "output_gate.record_stream:main",
+        "main.wait:bfg_ready",
+    ]
+
+
+@pytest.mark.parametrize(
+    "quant_method_type",
+    [AscendW4A8MXFPDynamicLinearMethod, AscendW8A8MXFP8DynamicLinearMethod],
+)
+def test_fused_qkv_splits_mxfp_dynamic_quant_from_matmul(quant_method_type):
+    attention = AscendKimiK3DeltaAttention.__new__(AscendKimiK3DeltaAttention)
+    nn.Module.__init__(attention)
+    inner_quant_method = quant_method_type.__new__(quant_method_type)
+    if isinstance(inner_quant_method, AscendW8A8MXFP8DynamicLinearMethod):
+        inner_quant_method.dynamic_mx_quant_scale_alg = "floor"
+    adapter = SimpleNamespace(
+        quant_method=inner_quant_method,
+        apply=MagicMock(return_value=torch.randn(4, 18)),
+    )
+    attention.in_proj_qkvgfab = SimpleNamespace(quant_method=adapter)
+    hidden_states = torch.randn(4, 6, dtype=torch.bfloat16)
+    quantized = torch.empty(4, 6, dtype=torch.float8_e4m3fn)
+    dynamic_scale = torch.empty(4, 1, dtype=torch.uint8)
+
+    with patch(
+        "vllm_ascend.ops.kimi_kda.torch_npu.npu_dynamic_mx_quant",
+        return_value=(quantized, dynamic_scale),
+    ) as dynamic_quant:
+        qkv_input = attention._quantize_fused_qkv(hidden_states)
+
+    assert isinstance(qkv_input, tuple)
+    assert qkv_input[0] is quantized
+    assert qkv_input[1] is dynamic_scale
+    if isinstance(inner_quant_method, AscendW8A8MXFP8DynamicLinearMethod):
+        dynamic_quant.assert_called_once_with(
+            hidden_states,
+            dst_type=torch.float8_e4m3fn,
+            scale_alg="floor",
+        )
+    else:
+        dynamic_quant.assert_called_once_with(hidden_states, dst_type=torch.float8_e4m3fn)
+    output = attention._matmul_fused_qkv(qkv_input)
+    assert output is adapter.apply.return_value
+    adapter.apply.assert_called_once_with(attention.in_proj_qkvgfab, qkv_input, bias=None)
+
+
+def test_fused_qkv_keeps_non_mxfp_quantization_in_linear_apply():
+    attention = AscendKimiK3DeltaAttention.__new__(AscendKimiK3DeltaAttention)
+    nn.Module.__init__(attention)
+    adapter = SimpleNamespace(
+        quant_method=object(),
+        apply=MagicMock(return_value=torch.randn(4, 18)),
+    )
+    attention.in_proj_qkvgfab = SimpleNamespace(quant_method=adapter)
+    hidden_states = torch.randn(4, 6)
+
+    with patch("vllm_ascend.ops.kimi_kda.torch_npu.npu_dynamic_mx_quant") as dynamic_quant:
+        qkv_input = attention._quantize_fused_qkv(hidden_states)
+
+    assert qkv_input is hidden_states
+    dynamic_quant.assert_not_called()
+    output = attention._matmul_fused_qkv(qkv_input)
+    assert output is adapter.apply.return_value
+    adapter.apply.assert_called_once_with(attention.in_proj_qkvgfab, hidden_states, bias=None)
 
 
 def test_prefill_fuses_raw_gate_and_updates_v_first_state():

--- a/tests/ut/ops/test_kimi_kda.py
+++ b/tests/ut/ops/test_kimi_kda.py
@@ -8,6 +8,13 @@ import pytest
 import torch
 from torch import nn
 
+from vllm_ascend.quantization.methods.w4a8_mxfp4 import (
+    AscendW4A8MXFPDynamicLinearMethod,
+)
+from vllm_ascend.quantization.methods.w8a8_mxfp8 import (
+    AscendW8A8MXFP8DynamicLinearMethod,
+)
+
 from vllm_ascend.ops.kimi_kda import (
     _PACKED_CONV_WEIGHT_NAME,
     AscendKimiK3DeltaAttention,
@@ -15,12 +22,6 @@ from vllm_ascend.ops.kimi_kda import (
     _prepare_beta,
     _zero_padded_output,
     _zero_padded_recurrent_output,
-)
-from vllm_ascend.quantization.methods.w4a8_mxfp4 import (
-    AscendW4A8MXFPDynamicLinearMethod,
-)
-from vllm_ascend.quantization.methods.w8a8_mxfp8 import (
-    AscendW8A8MXFP8DynamicLinearMethod,
 )
 
 

--- a/tests/ut/spec_decode/test_llm_base_proposer.py
+++ b/tests/ut/spec_decode/test_llm_base_proposer.py
@@ -195,10 +195,18 @@ def test_load_model_reads_validated_draft_window_size():
     mock_adapter.assert_called_once_with(4096, 16, 8, 4, "cpu")
 
 
-def test_draft_vllm_config_uses_draft_model_config():
-    draft_model_config = SimpleNamespace(runner_type="draft")
-    base_vllm_config = SimpleNamespace(model_config=SimpleNamespace(runner_type="generate"))
-    expected_vllm_config = SimpleNamespace(model_config=draft_model_config)
+def test_draft_vllm_config_only_propagates_draft_runner_type():
+    draft_model_config = SimpleNamespace(
+        runner_type="draft",
+        architecture="draft-architecture",
+        num_experts=0,
+    )
+    base_model_config = SimpleNamespace(
+        runner_type="generate",
+        architecture="target-architecture",
+        num_experts=256,
+    )
+    base_vllm_config = SimpleNamespace(model_config=base_model_config)
     proposer = AscendSpecDecodeBaseProposer.__new__(AscendSpecDecodeBaseProposer)
     proposer.speculative_config = SimpleNamespace(
         draft_model_config=draft_model_config,
@@ -209,18 +217,16 @@ def test_draft_vllm_config_uses_draft_model_config():
             "vllm.v1.spec_decode.llm_base_proposer.SpecDecodeBaseProposer._create_draft_vllm_config",
             return_value=base_vllm_config,
         ),
-        patch(
-            "vllm_ascend.spec_decode.llm_base_proposer.replace",
-            return_value=expected_vllm_config,
-        ) as mock_replace,
     ):
         draft_vllm_config = proposer._create_draft_vllm_config()
 
-    assert draft_vllm_config is expected_vllm_config
-    mock_replace.assert_called_once_with(
-        base_vllm_config,
-        model_config=draft_model_config,
-    )
+    assert draft_vllm_config is not base_vllm_config
+    assert draft_vllm_config.model_config is not base_model_config
+    assert draft_vllm_config.model_config is not draft_model_config
+    assert draft_vllm_config.model_config.runner_type == "draft"
+    assert draft_vllm_config.model_config.architecture == "target-architecture"
+    assert draft_vllm_config.model_config.num_experts == 256
+    assert base_model_config.runner_type == "generate"
 
 
 class TestDisablePaddedDrafterBatchWithFullGraph:

--- a/tests/ut/spec_decode/test_llm_base_proposer.py
+++ b/tests/ut/spec_decode/test_llm_base_proposer.py
@@ -195,6 +195,34 @@ def test_load_model_reads_validated_draft_window_size():
     mock_adapter.assert_called_once_with(4096, 16, 8, 4, "cpu")
 
 
+def test_draft_vllm_config_uses_draft_model_config():
+    draft_model_config = SimpleNamespace(runner_type="draft")
+    base_vllm_config = SimpleNamespace(model_config=SimpleNamespace(runner_type="generate"))
+    expected_vllm_config = SimpleNamespace(model_config=draft_model_config)
+    proposer = AscendSpecDecodeBaseProposer.__new__(AscendSpecDecodeBaseProposer)
+    proposer.speculative_config = SimpleNamespace(
+        draft_model_config=draft_model_config,
+    )
+
+    with (
+        patch(
+            "vllm.v1.spec_decode.llm_base_proposer.SpecDecodeBaseProposer._create_draft_vllm_config",
+            return_value=base_vllm_config,
+        ),
+        patch(
+            "vllm_ascend.spec_decode.llm_base_proposer.replace",
+            return_value=expected_vllm_config,
+        ) as mock_replace,
+    ):
+        draft_vllm_config = proposer._create_draft_vllm_config()
+
+    assert draft_vllm_config is expected_vllm_config
+    mock_replace.assert_called_once_with(
+        base_vllm_config,
+        model_config=draft_model_config,
+    )
+
+
 class TestDisablePaddedDrafterBatchWithFullGraph:
     """Guard: ``disable_padded_drafter_batch=True`` + cuda graph + any full
     cudagraph mode must raise ``NotImplementedError``.

--- a/vllm_ascend/_310p/fused_moe/fused_moe.py
+++ b/vllm_ascend/_310p/fused_moe/fused_moe.py
@@ -137,4 +137,8 @@ class AscendMoERunner310(AscendMoERunner):
         ascend_shared_experts = getattr(self, "ascend_shared_experts", None)
         if ascend_shared_experts is not None:
             ascend_shared_experts.multistream_overlap = False
+            # The parent may have selected the SP-multistream custom op before
+            # 310P disables the unsupported feature. Restore the upstream entry
+            # so its fake output contract matches the single-stream execution.
+            self._forward_entry = self._select_forward()
         _MoECommMethods[MoECommType.ALLGATHER] = AllGatherCommImpl310(self.moe_config)

--- a/vllm_ascend/attention/mla_v1.py
+++ b/vllm_ascend/attention/mla_v1.py
@@ -860,7 +860,8 @@ class AscendMLAImpl(MLAAttentionImpl):
         self.ring_mla_mask_size = 512
 
         self.speculative_config = self.vllm_config.speculative_config
-        self.enable_mlapo = enabling_mlapo(self.vllm_config)
+        self.is_draft_model = self.vllm_config.model_config.runner_type == "draft"
+        self.enable_mlapo = not self.is_draft_model and enabling_mlapo(self.vllm_config)
 
         self.layer_name = kwargs.get("layer_name")
         self.fa_quant_layer = enable_fa_quant(self.vllm_config, self.layer_name)

--- a/vllm_ascend/models/kimi_k3.py
+++ b/vllm_ascend/models/kimi_k3.py
@@ -524,7 +524,14 @@ class AscendKimiDecoderLayer(UpstreamKimiDecoderLayer):
 class AscendKimiLinearModel(UpstreamKimiLinearModel):
     """Kimi text model assembled from the Ascend decoder layer."""
 
-    packed_modules_mapping = UpstreamPackedKimiLinearModel.packed_modules_mapping
+    packed_modules_mapping = {
+        name: list(shards) for name, shards in UpstreamPackedKimiLinearModel.packed_modules_mapping.items()
+    }
+    packed_modules_mapping["fused_bfg_proj"] = [
+        "b_proj",
+        "f_a_proj",
+        "g_proj",
+    ]
     # Legacy Qwen3 GQA DSpark checkpoints consume the materialized input
     # to each selected Kimi layer. MLA DSpark checkpoints consume the raw
     # prefix-sum stream used by upstream vLLM, so keep that as the default.
@@ -595,9 +602,10 @@ class AscendKimiLinearModel(UpstreamKimiLinearModel):
         """Route mixed-precision KDA gates through vLLM's packed loader."""
         params_dict = dict(self.named_parameters())
         gate_mapping = (
-            (".g_proj", ".in_proj_gfab", 0),
-            (".f_a_proj", ".in_proj_gfab", 1),
-            (".b_proj", ".in_proj_gfab", 2),
+            (".b_proj.weight", ".fused_bfg_proj.weight", 0),
+            (".f_a_proj.weight", ".fused_bfg_proj.f_a_weight", None),
+            (".f_b_proj.weight", ".fused_bfg_proj.f_b_weight", None),
+            (".g_proj.weight", ".fused_bfg_proj.weight", 2),
         )
 
         def remap_mixed_gate_weights():

--- a/vllm_ascend/ops/fused_moe/fused_moe.py
+++ b/vllm_ascend/ops/fused_moe/fused_moe.py
@@ -273,8 +273,10 @@ class AscendMoERunner(MoERunner):  # type: ignore[no-redef]
         """Start the SP shared-input gather before the latent down projection."""
         gathered_input = hidden_states
         all_gather_done = None
+        shared_experts = self.ascend_shared_experts
         if self._can_overlap_sp_shared_with(self.routed_input_transform):
-            gathered_input, all_gather_done = self.ascend_shared_experts.start_input_all_gather(hidden_states)
+            assert shared_experts is not None
+            gathered_input, all_gather_done = shared_experts.start_input_all_gather(hidden_states)
         routed_input, shared_input = super().apply_routed_input_transform(hidden_states)
         if all_gather_done is not None:
             torch.npu.current_stream().wait_event(all_gather_done)
@@ -284,8 +286,10 @@ class AscendMoERunner(MoERunner):  # type: ignore[no-redef]
     def apply_routed_output_transform(self, fused_output: torch.Tensor) -> torch.Tensor:
         """Run the latent up projection before joining the SP shared output."""
         fused_output = super().apply_routed_output_transform(fused_output)
+        shared_experts = self.ascend_shared_experts
         if self._can_overlap_sp_shared_with(self.routed_output_transform):
-            self.ascend_shared_experts.wait_for_output()
+            assert shared_experts is not None
+            shared_experts.wait_for_output()
         return fused_output
 
     def _maybe_apply_routed_scale_to_output(
@@ -293,16 +297,18 @@ class AscendMoERunner(MoERunner):  # type: ignore[no-redef]
         shared_output: torch.Tensor | None,
         fused_output: torch.Tensor,
     ) -> tuple[torch.Tensor | None, torch.Tensor]:
+        shared_experts = self.ascend_shared_experts
         if (
             shared_output is not None
             and fused_output.dtype == torch.float16
             and self.routed_scaling_factor != 1.0
             and self._can_overlap_sp_shared_with(self.routed_output_transform)
         ):
+            assert shared_experts is not None
             # The base FP16 overflow path scales shared_output in place. Join
             # a deferred SP reduce-scatter before that write; BF16 keeps the
             # overlap because only fused_output is touched.
-            self.ascend_shared_experts.wait_for_output()
+            shared_experts.wait_for_output()
         return super()._maybe_apply_routed_scale_to_output(shared_output, fused_output)
 
     if vllm_version_is("0.27.1"):

--- a/vllm_ascend/ops/fused_moe/fused_moe.py
+++ b/vllm_ascend/ops/fused_moe/fused_moe.py
@@ -24,6 +24,8 @@ from vllm.distributed import (
 )
 from vllm.model_executor.layers.fused_moe import FusedMoEConfig, FusedMoERouter
 from vllm.model_executor.layers.fused_moe.layer import MoERunner
+from vllm.model_executor.layers.fused_moe.runner.moe_runner import _moe_forward_shared
+from vllm.utils.torch_utils import direct_register_custom_op
 
 from vllm_ascend.ascend_forward_context import _EXTRA_CTX, MoECommType
 from vllm_ascend.distributed.parallel_state import get_mc2_group
@@ -34,6 +36,45 @@ from vllm_ascend.ops.fused_moe.shared_experts import (
     SharedExpertParallelMode,
 )
 from vllm_ascend.utils import vllm_version_is
+
+
+def _ascend_moe_forward_shared_sp_fake(
+    hidden_states: torch.Tensor,
+    router_logits: torch.Tensor,
+    shared_experts_input: torch.Tensor | None,
+    input_ids: torch.Tensor | None,
+    layer_name: object,
+    hidden_dim_unpadded: int,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Infer the local SP outputs of the shared-expert custom op.
+
+    The explicit shared input contains all gathered tokens, while the real
+    shared output has already been reduce-scattered back to the routed input's
+    local token count.  The upstream fake uses the shared input's token count,
+    which is only correct before the early all-gather optimization.
+    """
+    del router_logits, input_ids, layer_name
+    assert shared_experts_input is not None
+    shared_out = shared_experts_input.new_empty(
+        (*hidden_states.shape[:-1], shared_experts_input.shape[-1]),
+    )
+    if hidden_dim_unpadded > 0:
+        fused_out = hidden_states.new_empty(
+            (*hidden_states.shape[:-1], hidden_dim_unpadded),
+        )
+    else:
+        fused_out = torch.empty_like(hidden_states)
+    return shared_out, fused_out
+
+
+# Keep the gathered shared input as an explicit graph dependency, but expose
+# the SP-local shared output shape to torch.compile/ACL graph tracing.
+direct_register_custom_op(
+    op_name="ascend_moe_forward_shared_sp",
+    op_func=_moe_forward_shared,
+    fake_impl=_ascend_moe_forward_shared_sp_fake,
+    tags=(torch.Tag.needs_fixed_stride_order,),
+)
 
 
 class AscendMoERunner(MoERunner):  # type: ignore[no-redef]
@@ -85,6 +126,11 @@ class AscendMoERunner(MoERunner):  # type: ignore[no-redef]
                 self.quant_type,
                 self._quant_method,
             )
+            if (
+                self.ascend_shared_experts.multistream_overlap
+                and self.ascend_shared_experts.parallel_mode() is SharedExpertParallelMode.SEQUENCE_PARALLEL_ONLY
+            ):
+                self._forward_entry = torch.ops.vllm.ascend_moe_forward_shared_sp
 
         setup_moe_comm_method(self.moe_config)
         alltoall_comm = get_moe_comm_method(MoECommType.ALLTOALL)
@@ -213,6 +259,45 @@ class AscendMoERunner(MoERunner):  # type: ignore[no-redef]
         if self.ascend_shared_experts is not None:
             self.ascend_shared_experts.set_lora_context(lora_context)
 
+    def apply_routed_input_transform(
+        self,
+        hidden_states: torch.Tensor,
+    ) -> tuple[torch.Tensor, torch.Tensor | None]:
+        """Start the SP shared-input gather before the latent down projection."""
+        gathered_input = hidden_states
+        all_gather_done = None
+        if self.ascend_shared_experts is not None:
+            gathered_input, all_gather_done = self.ascend_shared_experts.start_input_all_gather(hidden_states)
+        routed_input, shared_input = super().apply_routed_input_transform(hidden_states)
+        if all_gather_done is not None:
+            torch.npu.current_stream().wait_event(all_gather_done)
+            shared_input = gathered_input
+        return routed_input, shared_input
+
+    def apply_routed_output_transform(self, fused_output: torch.Tensor) -> torch.Tensor:
+        """Run the latent up projection before joining the SP shared output."""
+        fused_output = super().apply_routed_output_transform(fused_output)
+        if self.ascend_shared_experts is not None:
+            self.ascend_shared_experts.wait_for_output()
+        return fused_output
+
+    def _maybe_apply_routed_scale_to_output(
+        self,
+        shared_output: torch.Tensor | None,
+        fused_output: torch.Tensor,
+    ) -> tuple[torch.Tensor | None, torch.Tensor]:
+        if (
+            shared_output is not None
+            and fused_output.dtype == torch.float16
+            and self.routed_scaling_factor != 1.0
+            and self.ascend_shared_experts is not None
+        ):
+            # The base FP16 overflow path scales shared_output in place. Join
+            # a deferred SP reduce-scatter before that write; BF16 keeps the
+            # overlap because only fused_output is touched.
+            self.ascend_shared_experts.wait_for_output()
+        return super()._maybe_apply_routed_scale_to_output(shared_output, fused_output)
+
     if vllm_version_is("0.27.1"):
 
         def _forward_impl(
@@ -230,17 +315,28 @@ class AscendMoERunner(MoERunner):  # type: ignore[no-redef]
                         router_logits=router_logits,
                         input_ids=input_ids,
                     )
-                shared_expert_input, shared_input_all_gather_done = (
-                    self.ascend_shared_experts.prepare_input_before_routed_experts(shared_hidden_states)
+                # The runner input transform provides a padded gathered tensor
+                # in SP multistream mode. Trim only the shared-MLP view; retain
+                # the padded tensor for local internal-router reconstruction.
+                shared_input_is_gathered = (
+                    self.ascend_shared_experts.multistream_overlap
+                    and self.ascend_shared_experts.parallel_mode() is SharedExpertParallelMode.SEQUENCE_PARALLEL_ONLY
+                )
+                shared_expert_input = (
+                    shared_hidden_states[: _EXTRA_CTX.num_tokens] if shared_input_is_gathered else shared_hidden_states
                 )
                 if self.is_internal_router:
+                    router_hidden_states = self.ascend_shared_experts.local_input_from_gathered(
+                        shared_hidden_states,
+                        local_num_tokens=hidden_states.shape[0],
+                    )
                     gate = self.gate
                     assert gate is not None
                     # NOTE(Angazenn): To make this cast explicitly, the hbm usage might
                     # increase with extra hidden states. We also assume that all gate
                     # linear is unquantized so that we the weight is pre-casted in
                     # process_weights_after_loading of AscendUnquantizedLinearMethod.
-                    hidden_states_fp32 = shared_hidden_states.float()
+                    hidden_states_fp32 = router_hidden_states.float()
                     before_routed_experts = torch.npu.current_stream().record_event()
                     # v0.27.1: weight_fp32 is guaranteed by is_internal_router.
                     router_logits = F.linear(hidden_states_fp32, gate.weight_fp32)
@@ -249,8 +345,6 @@ class AscendMoERunner(MoERunner):  # type: ignore[no-redef]
                     before_routed_experts = torch.npu.current_stream().record_event()
                     after_routed_experts = None
 
-                if shared_input_all_gather_done is not None:
-                    torch.npu.current_stream().wait_event(shared_input_all_gather_done)
                 routed_out, fused_moe_events = self.routed_experts.forward_impl(
                     hidden_states=hidden_states,
                     router_logits=router_logits,
@@ -258,13 +352,13 @@ class AscendMoERunner(MoERunner):  # type: ignore[no-redef]
                 )
                 fused_moe_events.before_routed_experts = before_routed_experts
                 fused_moe_events.after_routed_experts = after_routed_experts
-                if shared_input_all_gather_done is not None:
+                if shared_input_is_gathered:
                     fused_moe_events.after_routed_finalize = torch.npu.current_stream().record_event()
 
                 shared_out = self.ascend_shared_experts.forward(
                     shared_expert_input,
                     fused_moe_events,
-                    input_is_gathered=shared_input_all_gather_done is not None,
+                    input_is_gathered=shared_input_is_gathered,
                 )
                 return shared_out, routed_out
 
@@ -293,17 +387,26 @@ class AscendMoERunner(MoERunner):  # type: ignore[no-redef]
                         router_logits=router_logits,
                         input_ids=input_ids,
                     )
-                shared_expert_input, shared_input_all_gather_done = (
-                    self.ascend_shared_experts.prepare_input_before_routed_experts(shared_hidden_states)
+                # See the v0.27.1 branch above for the input-shape contract.
+                shared_input_is_gathered = (
+                    self.ascend_shared_experts.multistream_overlap
+                    and self.ascend_shared_experts.parallel_mode() is SharedExpertParallelMode.SEQUENCE_PARALLEL_ONLY
+                )
+                shared_expert_input = (
+                    shared_hidden_states[: _EXTRA_CTX.num_tokens] if shared_input_is_gathered else shared_hidden_states
                 )
                 if self.is_internal_router:
+                    router_hidden_states = self.ascend_shared_experts.local_input_from_gathered(
+                        shared_hidden_states,
+                        local_num_tokens=hidden_states.shape[0],
+                    )
                     gate = self.gate
                     assert gate is not None
                     # NOTE(Angazenn): To make this cast explicitly, the hbm usage might
                     # increase with extra hidden states. We also assume that all gate
                     # linear is unquantized so that we the weight is pre-casted in
                     # process_weights_after_loading of AscendUnquantizedLinearMethod.
-                    hidden_states_fp32 = shared_hidden_states.float()
+                    hidden_states_fp32 = router_hidden_states.float()
                     before_routed_experts = torch.npu.current_stream().record_event()
                     # main (cdc4824a21): is_internal_router only checks self.gate,
                     # weight_fp32 may be absent, fall back to gate.weight.
@@ -316,8 +419,6 @@ class AscendMoERunner(MoERunner):  # type: ignore[no-redef]
                     before_routed_experts = torch.npu.current_stream().record_event()
                     after_routed_experts = None
 
-                if shared_input_all_gather_done is not None:
-                    torch.npu.current_stream().wait_event(shared_input_all_gather_done)
                 routed_out, fused_moe_events = self.routed_experts.forward_impl(
                     hidden_states=hidden_states,
                     router_logits=router_logits,
@@ -325,12 +426,12 @@ class AscendMoERunner(MoERunner):  # type: ignore[no-redef]
                 )
                 fused_moe_events.before_routed_experts = before_routed_experts
                 fused_moe_events.after_routed_experts = after_routed_experts
-                if shared_input_all_gather_done is not None:
+                if shared_input_is_gathered:
                     fused_moe_events.after_routed_finalize = torch.npu.current_stream().record_event()
 
                 shared_out = self.ascend_shared_experts.forward(
                     shared_expert_input,
                     fused_moe_events,
-                    input_is_gathered=shared_input_all_gather_done is not None,
+                    input_is_gathered=shared_input_is_gathered,
                 )
                 return shared_out, routed_out

--- a/vllm_ascend/ops/fused_moe/fused_moe.py
+++ b/vllm_ascend/ops/fused_moe/fused_moe.py
@@ -126,10 +126,7 @@ class AscendMoERunner(MoERunner):  # type: ignore[no-redef]
                 self.quant_type,
                 self._quant_method,
             )
-            if (
-                self.ascend_shared_experts.multistream_overlap
-                and self.ascend_shared_experts.parallel_mode() is SharedExpertParallelMode.SEQUENCE_PARALLEL_ONLY
-            ):
+            if self._can_overlap_sp_shared_with(self.routed_input_transform):
                 self._forward_entry = torch.ops.vllm.ascend_moe_forward_shared_sp
 
         setup_moe_comm_method(self.moe_config)
@@ -159,6 +156,16 @@ class AscendMoERunner(MoERunner):  # type: ignore[no-redef]
         """Ascend uses its own forward_impl path, not the FlashInfer Cutlass
         chunked path. Always return False to stay on forward_impl."""
         return False
+
+    def _can_overlap_sp_shared_with(self, routed_transform: object | None) -> bool:
+        """Limit SP shared-expert overlap changes to routed transforms."""
+        shared_experts = getattr(self, "ascend_shared_experts", None)
+        return (
+            routed_transform is not None
+            and shared_experts is not None
+            and shared_experts.multistream_overlap
+            and shared_experts.parallel_mode() is SharedExpertParallelMode.SEQUENCE_PARALLEL_ONLY
+        )
 
     @property
     def _fused_output_is_reduced(self) -> bool:
@@ -266,7 +273,7 @@ class AscendMoERunner(MoERunner):  # type: ignore[no-redef]
         """Start the SP shared-input gather before the latent down projection."""
         gathered_input = hidden_states
         all_gather_done = None
-        if self.ascend_shared_experts is not None:
+        if self._can_overlap_sp_shared_with(self.routed_input_transform):
             gathered_input, all_gather_done = self.ascend_shared_experts.start_input_all_gather(hidden_states)
         routed_input, shared_input = super().apply_routed_input_transform(hidden_states)
         if all_gather_done is not None:
@@ -277,7 +284,7 @@ class AscendMoERunner(MoERunner):  # type: ignore[no-redef]
     def apply_routed_output_transform(self, fused_output: torch.Tensor) -> torch.Tensor:
         """Run the latent up projection before joining the SP shared output."""
         fused_output = super().apply_routed_output_transform(fused_output)
-        if self.ascend_shared_experts is not None:
+        if self._can_overlap_sp_shared_with(self.routed_output_transform):
             self.ascend_shared_experts.wait_for_output()
         return fused_output
 
@@ -290,7 +297,7 @@ class AscendMoERunner(MoERunner):  # type: ignore[no-redef]
             shared_output is not None
             and fused_output.dtype == torch.float16
             and self.routed_scaling_factor != 1.0
-            and self.ascend_shared_experts is not None
+            and self._can_overlap_sp_shared_with(self.routed_output_transform)
         ):
             # The base FP16 overflow path scales shared_output in place. Join
             # a deferred SP reduce-scatter before that write; BF16 keeps the
@@ -318,10 +325,8 @@ class AscendMoERunner(MoERunner):  # type: ignore[no-redef]
                 # The runner input transform provides a padded gathered tensor
                 # in SP multistream mode. Trim only the shared-MLP view; retain
                 # the padded tensor for local internal-router reconstruction.
-                shared_input_is_gathered = (
-                    self.ascend_shared_experts.multistream_overlap
-                    and self.ascend_shared_experts.parallel_mode() is SharedExpertParallelMode.SEQUENCE_PARALLEL_ONLY
-                )
+                shared_input_is_gathered = self._can_overlap_sp_shared_with(self.routed_input_transform)
+                defer_shared_output_wait = self._can_overlap_sp_shared_with(self.routed_output_transform)
                 shared_expert_input = (
                     shared_hidden_states[: _EXTRA_CTX.num_tokens] if shared_input_is_gathered else shared_hidden_states
                 )
@@ -359,6 +364,7 @@ class AscendMoERunner(MoERunner):  # type: ignore[no-redef]
                     shared_expert_input,
                     fused_moe_events,
                     input_is_gathered=shared_input_is_gathered,
+                    defer_output_wait=defer_shared_output_wait,
                 )
                 return shared_out, routed_out
 
@@ -388,10 +394,8 @@ class AscendMoERunner(MoERunner):  # type: ignore[no-redef]
                         input_ids=input_ids,
                     )
                 # See the v0.27.1 branch above for the input-shape contract.
-                shared_input_is_gathered = (
-                    self.ascend_shared_experts.multistream_overlap
-                    and self.ascend_shared_experts.parallel_mode() is SharedExpertParallelMode.SEQUENCE_PARALLEL_ONLY
-                )
+                shared_input_is_gathered = self._can_overlap_sp_shared_with(self.routed_input_transform)
+                defer_shared_output_wait = self._can_overlap_sp_shared_with(self.routed_output_transform)
                 shared_expert_input = (
                     shared_hidden_states[: _EXTRA_CTX.num_tokens] if shared_input_is_gathered else shared_hidden_states
                 )
@@ -433,5 +437,6 @@ class AscendMoERunner(MoERunner):  # type: ignore[no-redef]
                     shared_expert_input,
                     fused_moe_events,
                     input_is_gathered=shared_input_is_gathered,
+                    defer_output_wait=defer_shared_output_wait,
                 )
                 return shared_out, routed_out

--- a/vllm_ascend/ops/fused_moe/shared_experts.py
+++ b/vllm_ascend/ops/fused_moe/shared_experts.py
@@ -243,20 +243,42 @@ class AscendSharedExperts:
             shared_out = F.pad(shared_out, (0, 0, 0, pad_size))
         return tensor_model_parallel_reduce_scatter(shared_out, dim=0)
 
-    def prepare_input_before_routed_experts(
+    def start_input_all_gather(
         self,
         hidden_states: torch.Tensor,
     ) -> tuple[torch.Tensor, torch.npu.Event | None]:
-        """Start the SP-only input all-gather on the shared-expert stream."""
+        """Start an SP gather that can overlap the routed input transform."""
         if not (self.multistream_overlap and self.parallel_mode() is SharedExpertParallelMode.SEQUENCE_PARALLEL_ONLY):
             return hidden_states, None
 
         input_ready = torch.npu.current_stream().record_event()
         with npu_stream_switch(shared_experts_calculation_stream(), enabled=True):
             torch.npu.current_stream().wait_event(input_ready)
-            hidden_states = self._gather_sp_input(hidden_states)
+            # Keep TP padding across the custom-op boundary.  Internal routing
+            # may need the equal-sized local shard; the shared MLP trims it.
+            hidden_states = tensor_model_parallel_all_gather(hidden_states, dim=0)
             all_gather_done = torch.npu.current_stream().record_event()
         return hidden_states, all_gather_done
+
+    def local_input_from_gathered(
+        self,
+        hidden_states: torch.Tensor,
+        local_num_tokens: int,
+    ) -> torch.Tensor:
+        """Recover this TP rank's original SP shard from an early gather."""
+        if not (
+            self.multistream_overlap
+            and self.parallel_mode() is SharedExpertParallelMode.SEQUENCE_PARALLEL_ONLY
+            and hidden_states.shape[0] > local_num_tokens
+        ):
+            return hidden_states
+        shard_start = self.moe_config.tp_group.rank_in_group * local_num_tokens
+        return hidden_states.narrow(0, shard_start, local_num_tokens)
+
+    def wait_for_output(self) -> None:
+        """Join a deferred SP shared-output collective on the current stream."""
+        if self.multistream_overlap and self.parallel_mode() is SharedExpertParallelMode.SEQUENCE_PARALLEL_ONLY:
+            torch.npu.current_stream().wait_stream(shared_experts_calculation_stream())
 
     def forward(
         self,
@@ -266,11 +288,10 @@ class AscendSharedExperts:
     ):
         mode = self.parallel_mode()
         local_dp_metadata = None
-        down_projection_ready = (
-            fused_moe_evts.after_routed_finalize
-            if self.multistream_overlap and mode is SharedExpertParallelMode.SEQUENCE_PARALLEL_ONLY
-            else fused_moe_evts.before_combine
-        )
+        # The down projection only depends on the shared-expert activation and
+        # should overlap the routed-expert combine.  The later shared-output
+        # collective is the operation that must wait for routed finalization.
+        down_projection_ready = fused_moe_evts.before_combine
 
         def maybe_wait_event(evt: torch.npu.Event | None):
             if evt is not None:
@@ -406,8 +427,9 @@ class AscendSharedExperts:
                 maybe_wait_event(fused_moe_evts.after_routed_finalize)
                 shared_out = self._pad_and_reduce_scatter(shared_out)
 
-        # Make sure the default stream waits for the shared experts stream to finish.
-        if self.multistream_overlap:
+        # SP-only defers this join until after the routed latent up projection,
+        # allowing that matmul to overlap the shared-output reduce-scatter.
+        if self.multistream_overlap and mode is not SharedExpertParallelMode.SEQUENCE_PARALLEL_ONLY:
             torch.npu.current_stream().wait_stream(shared_experts_calculation_stream())
 
         if mode is SharedExpertParallelMode.SHARED_EXPERT_DATA_PARALLEL_ONLY:

--- a/vllm_ascend/ops/fused_moe/shared_experts.py
+++ b/vllm_ascend/ops/fused_moe/shared_experts.py
@@ -285,6 +285,7 @@ class AscendSharedExperts:
         hidden_states: torch.Tensor,
         fused_moe_evts: FusedMoEEvents,
         input_is_gathered: bool = False,
+        defer_output_wait: bool = False,
     ):
         mode = self.parallel_mode()
         local_dp_metadata = None
@@ -427,9 +428,11 @@ class AscendSharedExperts:
                 maybe_wait_event(fused_moe_evts.after_routed_finalize)
                 shared_out = self._pad_and_reduce_scatter(shared_out)
 
-        # SP-only defers this join until after the routed latent up projection,
-        # allowing that matmul to overlap the shared-output reduce-scatter.
-        if self.multistream_overlap and mode is not SharedExpertParallelMode.SEQUENCE_PARALLEL_ONLY:
+        # Defer only when a routed output transform can overlap this collective;
+        # otherwise preserve the original join point for non-latent models.
+        if self.multistream_overlap and (
+            mode is not SharedExpertParallelMode.SEQUENCE_PARALLEL_ONLY or not defer_output_wait
+        ):
             torch.npu.current_stream().wait_stream(shared_experts_calculation_stream())
 
         if mode is SharedExpertParallelMode.SHARED_EXPERT_DATA_PARALLEL_ONLY:

--- a/vllm_ascend/ops/kimi_kda.py
+++ b/vllm_ascend/ops/kimi_kda.py
@@ -137,7 +137,7 @@ class _KDAFusedBFGLinear(MergedColumnParallelLinear):
             raise ValueError("KDA fused f_proj requires an output-sharded parameter")
         shard_offset = sum(self.output_sizes[:_F_PROJ_SHARD_ID]) // self.tp_size
         shard_size = self.output_sizes[_F_PROJ_SHARD_ID] // self.tp_size
-        param_shard = self.weight.data.narrow(output_dim, shard_offset, shard_size)
+        param_shard = self.weight.narrow(output_dim, shard_offset, shard_size)
         fused_weight = torch.matmul(
             self.f_b_weight.float(),
             self.f_a_weight.float(),
@@ -173,11 +173,14 @@ def _zero_padded_recurrent_output(
 
 
 def _prepare_beta(
-    raw_beta: torch.Tensor,
+    beta: torch.Tensor,
     num_actual_tokens: int,
+    *,
+    is_preprocessed: bool = False,
 ) -> torch.Tensor:
-    """Convert vLLM 0.27's packed raw beta to the AscendC contract."""
-    return raw_beta[:, :num_actual_tokens].float().sigmoid()
+    """Slice beta and apply sigmoid unless the auxiliary stream already did."""
+    beta = beta[:, :num_actual_tokens]
+    return beta if is_preprocessed else beta.float().sigmoid()
 
 
 class AscendKimiK3DeltaAttention(KimiK3DeltaAttention):
@@ -273,6 +276,7 @@ class AscendKimiK3DeltaAttention(KimiK3DeltaAttention):
                 g2=g2,
                 beta=beta,
                 core_attn_out=core_attn_out,
+                beta_is_preprocessed=True,
             )
             core_attn_out = rearrange(core_attn_out, "1 n h d -> n (h d)")
             return self.o_proj(core_attn_out)[0]
@@ -290,18 +294,24 @@ class AscendKimiK3DeltaAttention(KimiK3DeltaAttention):
         hidden_states.record_stream(bfg_stream)
         with npu_stream_switch(bfg_stream):
             bfg_stream.wait_event(hidden_states_ready)
-            raw_bfg = self._project_bfg(hidden_states)
+            fused_bfg = self._project_bfg(hidden_states)
             bfg_projection_ready = bfg_stream.record_event()
 
         quantized_qkv = self._quantize_fused_qkv(hidden_states)
         quant_ready = main_stream.record_event()
 
+        # Stage 1 join: DynamicQuant on main overlaps the BFG GEMM on the
+        # auxiliary stream, but the two Cube matmuls remain serialized.
         main_stream.wait_event(bfg_projection_ready)
         mixed_qkv = self._matmul_fused_qkv(quantized_qkv)
 
         with npu_stream_switch(bfg_stream):
+            # Stage 2: after both first-stage branches complete, overlap the
+            # QKV Cube matmul with beta's FP32 conversion and sigmoid vector
+            # work. Split and reshape the F/output gates here as well so all
+            # BFG output handling occurs after the QKV matmul is enqueued.
             bfg_stream.wait_event(quant_ready)
-            beta, g1, g2 = self._postprocess_bfg(*raw_bfg)
+            beta, g1, g2 = self._postprocess_bfg(fused_bfg)
             bfg_ready = bfg_stream.record_event()
 
         for tensor in (beta, g1, g2):
@@ -314,17 +324,18 @@ class AscendKimiK3DeltaAttention(KimiK3DeltaAttention):
     def _project_bfg(
         self,
         hidden_states: torch.Tensor,
-    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
-        fused_bfg = self.fused_bfg_proj(hidden_states)[0]
-        return fused_bfg.split(self._fused_bfg_output_sizes, dim=-1)
+    ) -> torch.Tensor:
+        return self.fused_bfg_proj(hidden_states)[0]
 
     def _postprocess_bfg(
         self,
-        beta: torch.Tensor,
-        raw_gate: torch.Tensor,
-        output_gate: torch.Tensor,
+        fused_bfg: torch.Tensor,
     ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
-        beta = beta.unsqueeze(0)
+        beta, raw_gate, output_gate = fused_bfg.split(
+            self._fused_bfg_output_sizes,
+            dim=-1,
+        )
+        beta = beta.float().sigmoid().unsqueeze(0)
         raw_gate = rearrange(raw_gate, "n (h d) -> 1 n h d", d=self.head_dim)
         output_gate = rearrange(output_gate, "n (h d) -> n h d", d=self.head_dim)
         return beta, raw_gate, output_gate
@@ -516,6 +527,8 @@ class AscendKimiK3DeltaAttention(KimiK3DeltaAttention):
         g2: torch.Tensor,
         beta: torch.Tensor,
         core_attn_out: torch.Tensor,
+        *,
+        beta_is_preprocessed: bool = False,
     ) -> None:
         """Dispatch speculative, prefill, and decode tokens through KDA kernels."""
         forward_context = get_forward_context()
@@ -532,7 +545,11 @@ class AscendKimiK3DeltaAttention(KimiK3DeltaAttention):
         mixed_qkv = mixed_qkv[:num_actual_tokens]
         g1 = g1[:, :num_actual_tokens]
         g2 = g2[:num_actual_tokens]
-        beta = _prepare_beta(beta, num_actual_tokens)
+        beta = _prepare_beta(
+            beta,
+            num_actual_tokens,
+            is_preprocessed=beta_is_preprocessed,
+        )
 
         conv_state, recurrent_state = self.kv_cache
         conv_weights_t = self.get_parameter(_PACKED_CONV_WEIGHT_NAME)

--- a/vllm_ascend/ops/kimi_kda.py
+++ b/vllm_ascend/ops/kimi_kda.py
@@ -10,6 +10,7 @@ replaced here with the Ascend metadata builder and AscendC operators.
 from functools import wraps
 
 import torch
+import torch_npu
 from einops import rearrange
 from torch import nn
 from vllm.compilation.breakable_cudagraph import eager_break_during_capture
@@ -20,7 +21,6 @@ from vllm.model_executor.layers.linear import (
 from vllm.model_executor.utils import replace_parameter
 from vllm.models.kimi_k3.nvidia.kda import (
     KimiK3DeltaAttention,
-    _KimiGDNMergedColumnParallelLinear,
 )
 from vllm.third_party.flash_linear_attention.ops.l2norm import l2norm_fwd
 from vllm.v1.attention.backend import AttentionBackend
@@ -29,9 +29,125 @@ from vllm.v1.attention.backends.utils import PAD_SLOT_ID
 
 from vllm_ascend.ops.gdn_attn_builder import AscendGDNAttentionBackend
 from vllm_ascend.ops.triton.fla.utils import clear_ssm_states
+from vllm_ascend.quantization.methods.w4a8_mxfp4 import (
+    AscendW4A8MXFPDynamicLinearMethod,
+)
+from vllm_ascend.quantization.methods.w8a8_mxfp8 import (
+    AscendW8A8MXFP8DynamicLinearMethod,
+)
+from vllm_ascend.utils import npu_stream_switch
 
 _KDA_CHUNK_SIZE = 64
 _PACKED_CONV_WEIGHT_NAME = "ascend_conv1d_weight"
+_F_PROJ_SHARD_ID = 1
+_KDA_BFG_STREAM: torch.npu.Stream | None = None
+
+
+def _kda_bfg_stream() -> torch.npu.Stream:
+    global _KDA_BFG_STREAM
+    if _KDA_BFG_STREAM is None:
+        _KDA_BFG_STREAM = torch_npu.npu.Stream()
+    return _KDA_BFG_STREAM
+
+
+class _KDAFusedBFGLinear(MergedColumnParallelLinear):
+    """Pack beta, an offline-composed F projection, and the output gate."""
+
+    def __init__(
+        self,
+        hidden_size: int,
+        num_heads: int,
+        head_dim: int,
+        tp_size: int,
+        quant_config,
+        prefix: str,
+    ) -> None:
+        projection_size = num_heads * head_dim
+        super().__init__(
+            input_size=hidden_size,
+            output_sizes=[num_heads, projection_size, projection_size],
+            bias=False,
+            quant_config=quant_config,
+            prefix=prefix,
+        )
+        if self.tp_size != tp_size:
+            raise ValueError(f"KDA fused BFG TP mismatch: layer={self.tp_size}, attention={tp_size}")
+        local_projection_size = projection_size // tp_size
+        self.f_a_weight = nn.Parameter(
+            self.weight.new_empty((head_dim, hidden_size)),
+            requires_grad=False,
+        )
+        self.f_b_weight = nn.Parameter(
+            self.weight.new_empty((local_projection_size, head_dim)),
+            requires_grad=False,
+        )
+        self.f_a_weight.weight_loader = self._load_f_a_weight
+        self.f_b_weight.weight_loader = self._load_f_b_weight
+        self._f_a_loaded = False
+        self._f_b_loaded = False
+
+    def _load_f_a_weight(
+        self,
+        param: nn.Parameter,
+        loaded_weight: torch.Tensor,
+        loaded_shard_id: tuple[int, ...] | int | None = None,
+    ) -> None:
+        del loaded_shard_id
+        if param.shape != loaded_weight.shape:
+            raise ValueError(
+                "KDA f_a_proj checkpoint shape mismatch: "
+                f"expected {tuple(param.shape)}, got {tuple(loaded_weight.shape)}"
+            )
+        param.data.copy_(loaded_weight)
+        self._f_a_loaded = True
+        self._maybe_fuse_f_proj()
+
+    def _load_f_b_weight(
+        self,
+        param: nn.Parameter,
+        loaded_weight: torch.Tensor,
+        loaded_shard_id: tuple[int, ...] | int | None = None,
+    ) -> None:
+        del loaded_shard_id
+        if loaded_weight.shape == param.shape:
+            local_weight = loaded_weight
+        else:
+            expected_shape = (param.shape[0] * self.tp_size, param.shape[1])
+            if loaded_weight.shape != expected_shape:
+                raise ValueError(
+                    "KDA f_b_proj checkpoint shape mismatch: "
+                    f"expected {expected_shape} or {tuple(param.shape)}, "
+                    f"got {tuple(loaded_weight.shape)}"
+                )
+            local_weight = loaded_weight.narrow(
+                0,
+                self.tp_rank * param.shape[0],
+                param.shape[0],
+            )
+        param.data.copy_(local_weight)
+        self._f_b_loaded = True
+        self._maybe_fuse_f_proj()
+
+    @torch.no_grad()
+    def _maybe_fuse_f_proj(self) -> None:
+        if not self._f_a_loaded or not self._f_b_loaded:
+            return
+        output_dim = getattr(self.weight, "output_dim", None)
+        if output_dim is None:
+            raise ValueError("KDA fused f_proj requires an output-sharded parameter")
+        shard_offset = sum(self.output_sizes[:_F_PROJ_SHARD_ID]) // self.tp_size
+        shard_size = self.output_sizes[_F_PROJ_SHARD_ID] // self.tp_size
+        param_shard = self.weight.data.narrow(output_dim, shard_offset, shard_size)
+        fused_weight = torch.matmul(
+            self.f_b_weight.float(),
+            self.f_a_weight.float(),
+        ).to(dtype=param_shard.dtype)
+        if fused_weight.shape != param_shard.shape:
+            raise ValueError(
+                "KDA composed f_proj shape mismatch: "
+                f"expected {tuple(param_shard.shape)}, got {tuple(fused_weight.shape)}"
+            )
+        param_shard.copy_(fused_weight)
 
 
 def _zero_padded_output(
@@ -81,9 +197,9 @@ class AscendKimiK3DeltaAttention(KimiK3DeltaAttention):
         self.uses_mixed_projection = uses_mixed_projection
         if uses_mixed_projection:
             # vLLM 0.27 packs all KDA input projections into one linear.  A
-            # QuaRot checkpoint instead stores q/k/v as W8A8 and keeps the
-            # three gates in floating point, so form one fused GEMM per
-            # precision group instead of falling back to four projections.
+            # QuaRot checkpoint instead stores q/k/v as W8A8 and keeps B/F/G
+            # in floating point. Split those precision groups so DynamicQuant
+            # can overlap the composed BFG projection.
             self.in_proj_qkvgfab = MergedColumnParallelLinear(
                 self.hidden_size,
                 [self.projection_size] * 3,
@@ -91,24 +207,20 @@ class AscendKimiK3DeltaAttention(KimiK3DeltaAttention):
                 quant_config=quant_config,
                 prefix=f"{prefix}.in_proj_qkv",
             )
-            gate_output_sizes = [
-                self.projection_size,
-                self.head_dim,
-                self.num_heads,
-            ]
-            if self.in_proj_padding:
-                gate_output_sizes.append(self.in_proj_padding * self.tp_size)
-            self.in_proj_gfab = _KimiGDNMergedColumnParallelLinear(
-                self.hidden_size,
-                gate_output_sizes,
-                replicated_shard_id=1,
+            del self.f_b_proj
+            self.fused_bfg_proj = _KDAFusedBFGLinear(
+                hidden_size=self.hidden_size,
+                num_heads=self.num_heads,
+                head_dim=self.head_dim,
                 tp_size=self.tp_size,
-                bias=False,
                 quant_config=quant_config,
                 prefix=f"{prefix}.in_proj_gfab",
             )
-            if self.in_proj_padding:
-                self.in_proj_gfab.weight.data[-self.in_proj_padding :].zero_()
+            self._fused_bfg_output_sizes = (
+                self.local_num_heads,
+                self.local_projection_size,
+                self.local_projection_size,
+            )
         # Upstream's FusedRMSNormGated constructor defaults to 1e-5, while
         # Kimi K3 checkpoints use the model-configured RMS epsilon (1e-6 for
         # the production checkpoint). Preserve the checkpoint contract used
@@ -149,21 +261,7 @@ class AscendKimiK3DeltaAttention(KimiK3DeltaAttention):
     ) -> torch.Tensor:
         if self.uses_mixed_projection:
             num_tokens = hidden_states.size(0)
-            mixed_qkv = self.in_proj_qkvgfab(hidden_states)[0]
-            projected_gfab = self.in_proj_gfab(hidden_states)[0]
-            split_sizes = [
-                self.local_projection_size,
-                self.head_dim,
-                self.local_num_heads,
-            ]
-            if self.in_proj_padding:
-                split_sizes.append(self.in_proj_padding)
-            g_proj_states, f_a, beta = projected_gfab.split(split_sizes, dim=-1)[:3]
-            beta = beta.unsqueeze(0)
-
-            g1 = self.f_b_proj(f_a)[0]
-            g1 = rearrange(g1, "n (h d) -> 1 n h d", d=self.head_dim)
-            g2 = rearrange(g_proj_states, "... (h d) -> ... h d", d=self.head_dim)
+            mixed_qkv, beta, g1, g2 = self._run_overlapped_qkv_bfg(hidden_states)
             core_attn_out = torch.empty(
                 (1, num_tokens, self.local_num_heads, self.head_dim),
                 dtype=hidden_states.dtype,
@@ -179,6 +277,99 @@ class AscendKimiK3DeltaAttention(KimiK3DeltaAttention):
             core_attn_out = rearrange(core_attn_out, "1 n h d -> n (h d)")
             return self.o_proj(core_attn_out)[0]
         return super().forward(hidden_states, positions)
+
+    def _run_overlapped_qkv_bfg(
+        self,
+        hidden_states: torch.Tensor,
+    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+        """Fork BFG work to an auxiliary stream and join it back to main."""
+        main_stream = torch.npu.current_stream()
+        bfg_stream = _kda_bfg_stream()
+
+        hidden_states_ready = main_stream.record_event()
+        hidden_states.record_stream(bfg_stream)
+        with npu_stream_switch(bfg_stream):
+            bfg_stream.wait_event(hidden_states_ready)
+            raw_bfg = self._project_bfg(hidden_states)
+            bfg_projection_ready = bfg_stream.record_event()
+
+        quantized_qkv = self._quantize_fused_qkv(hidden_states)
+        quant_ready = main_stream.record_event()
+
+        main_stream.wait_event(bfg_projection_ready)
+        mixed_qkv = self._matmul_fused_qkv(quantized_qkv)
+
+        with npu_stream_switch(bfg_stream):
+            bfg_stream.wait_event(quant_ready)
+            beta, g1, g2 = self._postprocess_bfg(*raw_bfg)
+            bfg_ready = bfg_stream.record_event()
+
+        for tensor in (beta, g1, g2):
+            tensor.record_stream(main_stream)
+        # bfg_ready is the auxiliary stream tail. Joining that exact event is
+        # required for multi-stream ACL graph capture as well as eager reuse.
+        main_stream.wait_event(bfg_ready)
+        return mixed_qkv, beta, g1, g2
+
+    def _project_bfg(
+        self,
+        hidden_states: torch.Tensor,
+    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+        fused_bfg = self.fused_bfg_proj(hidden_states)[0]
+        return fused_bfg.split(self._fused_bfg_output_sizes, dim=-1)
+
+    def _postprocess_bfg(
+        self,
+        beta: torch.Tensor,
+        raw_gate: torch.Tensor,
+        output_gate: torch.Tensor,
+    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+        beta = beta.unsqueeze(0)
+        raw_gate = rearrange(raw_gate, "n (h d) -> 1 n h d", d=self.head_dim)
+        output_gate = rearrange(output_gate, "n (h d) -> n h d", d=self.head_dim)
+        return beta, raw_gate, output_gate
+
+    def _quantize_fused_qkv(
+        self,
+        hidden_states: torch.Tensor,
+    ) -> torch.Tensor | tuple[torch.Tensor, torch.Tensor]:
+        quant_method = self.in_proj_qkvgfab.quant_method
+        inner_quant_method = getattr(quant_method, "quant_method", quant_method)
+        if (
+            isinstance(
+                inner_quant_method,
+                (
+                    AscendW4A8MXFPDynamicLinearMethod,
+                    AscendW8A8MXFP8DynamicLinearMethod,
+                ),
+            )
+            and hidden_states.dtype == torch.bfloat16
+            and hidden_states.ndim == 2
+        ):
+            if isinstance(inner_quant_method, AscendW8A8MXFP8DynamicLinearMethod):
+                return torch_npu.npu_dynamic_mx_quant(
+                    hidden_states,
+                    dst_type=torch.float8_e4m3fn,
+                    scale_alg=inner_quant_method.dynamic_mx_quant_scale_alg,
+                )
+            return torch_npu.npu_dynamic_mx_quant(
+                hidden_states,
+                dst_type=torch.float8_e4m3fn,
+            )
+        return hidden_states
+
+    def _matmul_fused_qkv(
+        self,
+        qkv_input: torch.Tensor | tuple[torch.Tensor, torch.Tensor],
+    ) -> torch.Tensor:
+        quant_method = self.in_proj_qkvgfab.quant_method
+        if quant_method is None:
+            raise RuntimeError("KDA fused QKV quantization method is not initialized")
+        return quant_method.apply(
+            self.in_proj_qkvgfab,
+            qkv_input,
+            bias=None,
+        )
 
     @staticmethod
     def _run_causal_conv1d(

--- a/vllm_ascend/ops/kimi_kda.py
+++ b/vllm_ascend/ops/kimi_kda.py
@@ -29,10 +29,10 @@ from vllm.v1.attention.backends.utils import PAD_SLOT_ID
 
 from vllm_ascend.ops.gdn_attn_builder import AscendGDNAttentionBackend
 from vllm_ascend.ops.triton.fla.utils import clear_ssm_states
-from vllm_ascend.quantization.methods.w4a8_mxfp4 import (
+from vllm_ascend.quantization.methods.w4a8.w4a8_mxfp4 import (
     AscendW4A8MXFPDynamicLinearMethod,
 )
-from vllm_ascend.quantization.methods.w8a8_mxfp8 import (
+from vllm_ascend.quantization.methods.w8a8.w8a8_mxfp8 import (
     AscendW8A8MXFP8DynamicLinearMethod,
 )
 from vllm_ascend.utils import npu_stream_switch

--- a/vllm_ascend/spec_decode/llm_base_proposer.py
+++ b/vllm_ascend/spec_decode/llm_base_proposer.py
@@ -9,7 +9,6 @@ import numpy as np
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
-from typing_extensions import override
 from vllm.config import CUDAGraphMode, VllmConfig, get_layers_from_vllm_config, replace
 from vllm.distributed.parallel_state import (
     get_pp_group,
@@ -112,7 +111,6 @@ def _is_glm_model(model_config) -> bool:
 class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
     _runnable: ACLGraphWrapper | Callable
 
-    @override
     def _create_draft_vllm_config(self) -> VllmConfig:
         """Expose the validated draft model config during model construction.
 

--- a/vllm_ascend/spec_decode/llm_base_proposer.py
+++ b/vllm_ascend/spec_decode/llm_base_proposer.py
@@ -9,7 +9,8 @@ import numpy as np
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
-from vllm.config import CUDAGraphMode, VllmConfig, get_layers_from_vllm_config
+from typing_extensions import override
+from vllm.config import CUDAGraphMode, VllmConfig, get_layers_from_vllm_config, replace
 from vllm.distributed.parallel_state import (
     get_pp_group,
     get_tp_group,
@@ -110,6 +111,20 @@ def _is_glm_model(model_config) -> bool:
 
 class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
     _runnable: ACLGraphWrapper | Callable
+
+    @override
+    def _create_draft_vllm_config(self) -> VllmConfig:
+        """Expose the validated draft model config during model construction.
+
+        ``_get_model`` calls this hook before ``get_model`` installs the
+        returned config as the current vLLM config. Attention constructors can
+        then identify the draft model from ``runner_type="draft"``.
+        """
+        draft_vllm_config = super()._create_draft_vllm_config()
+        return replace(
+            draft_vllm_config,
+            model_config=self.speculative_config.draft_model_config,
+        )
 
     @staticmethod
     def _get_multimodal_image_token_index(model_name: str, config: Any) -> int:

--- a/vllm_ascend/spec_decode/llm_base_proposer.py
+++ b/vllm_ascend/spec_decode/llm_base_proposer.py
@@ -9,7 +9,7 @@ import numpy as np
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
-from vllm.config import CUDAGraphMode, VllmConfig, get_layers_from_vllm_config, replace
+from vllm.config import CUDAGraphMode, VllmConfig, get_layers_from_vllm_config
 from vllm.distributed.parallel_state import (
     get_pp_group,
     get_tp_group,
@@ -112,17 +112,21 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
     _runnable: ACLGraphWrapper | Callable
 
     def _create_draft_vllm_config(self) -> VllmConfig:
-        """Expose the validated draft model config during model construction.
+        """Expose the draft runner type during model construction.
 
         ``_get_model`` calls this hook before ``get_model`` installs the
         returned config as the current vLLM config. Attention constructors can
         then identify the draft model from ``runner_type="draft"``.
+
+        Keep the target-derived model config otherwise unchanged. Replacing it
+        with ``draft_model_config`` changes how generic proposers construct
+        their layers and can invalidate target parallel settings.
         """
         draft_vllm_config = super()._create_draft_vllm_config()
-        return replace(
-            draft_vllm_config,
-            model_config=self.speculative_config.draft_model_config,
-        )
+        draft_vllm_config = copy.copy(draft_vllm_config)
+        draft_vllm_config.model_config = copy.copy(draft_vllm_config.model_config)
+        draft_vllm_config.model_config.runner_type = self.speculative_config.draft_model_config.runner_type
+        return draft_vllm_config
 
     @staticmethod
     def _get_multimodal_image_token_index(model_name: str, config: Any) -> int:


### PR DESCRIPTION
## Summary

- Backport #15416: overlap Kimi K3 projection preprocessing.
- Backport #15265: detect speculative draft models from runner type.
- Backport #15252: overlap shared-expert collectives with routed latent transforms.
- Exclude the source branches' merge-from-main commits so unrelated main history is not introduced into `releases/v0.27.1rc`.

## Validation

- `python -m compileall` on all changed Python files
- `python -m ruff check` on all changed Python files
- `git diff --check upstream/releases/v0.27.1rc..HEAD`
- Verified each backported commit has a `Signed-off-by` matching its author

The selected unit tests could not be collected in the local Windows environment because the `vllm` package is unavailable; no NPU tests were run.

- vLLM main: https://github.com/vllm-project/vllm/commit/ba07e4a48fc951300d97eb506217dd530583dea3
