### PR TITLE
[Feature][Spec Decode] Support custom class proposer backend

### DIFF
--- a/tests/e2e/pull_request/one_card/spec_decode/test_custom_proposer.py
+++ b/tests/e2e/pull_request/one_card/spec_decode/test_custom_proposer.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+import torch
+from vllm import SamplingParams
+from vllm.config import VllmConfig
+
+from tests.e2e.conftest import VllmRunner
+
+MODEL_NAME = "Qwen/Qwen3-0.6B"
+NUM_SPECULATIVE_TOKENS = 3
+
+
+class RepeatLastTokenProposer:
+    """Minimal CPU proposer used to exercise the custom-class interface."""
+
+    def __init__(self, vllm_config: VllmConfig):
+        assert vllm_config.speculative_config is not None
+        self.num_speculative_tokens = vllm_config.speculative_config.num_speculative_tokens
+
+    def propose(
+        self,
+        sampled_token_ids: list[list[int]],
+        num_tokens_no_spec: torch.Tensor,
+        token_ids_cpu: torch.Tensor,
+        slot_mappings: torch.Tensor | None = None,
+    ) -> list[list[int]]:
+        del num_tokens_no_spec, token_ids_cpu, slot_mappings
+        return [
+            [sampled_ids[-1]] * self.num_speculative_tokens if sampled_ids else [] for sampled_ids in sampled_token_ids
+        ]
+
+    def dummy_run(self, *args, **kwargs):
+        raise AssertionError("custom proposer dummy_run must not be called")
+
+
+def test_custom_proposer_single_card_npu():
+    prompts = [
+        "The capital of France is",
+        "Repeat the word hello several times:",
+    ]
+    sampling_params = SamplingParams(temperature=0, max_tokens=16)
+
+    with VllmRunner(
+        MODEL_NAME,
+        speculative_config={
+            "method": "custom_class",
+            "model": f"{__name__}.RepeatLastTokenProposer",
+            "num_speculative_tokens": NUM_SPECULATIVE_TOKENS,
+        },
+        max_model_len=1024,
+        enforce_eager=True,
+        disable_log_stats=False,
+    ) as runner:
+        outputs = runner.model.generate(prompts, sampling_params)
+        runner.model.generate(prompts[:1], sampling_params)
+        metrics = runner.model.get_metrics()
+
+    assert all(output.outputs[0].token_ids for output in outputs)
+    num_draft_tokens = sum(metric.value for metric in metrics if metric.name == "vllm:spec_decode_num_draft_tokens")
+    assert num_draft_tokens > 0

--- a/tests/ut/spec_decode/test_custom_proposer.py
+++ b/tests/ut/spec_decode/test_custom_proposer.py
@@ -1,0 +1,62 @@
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import numpy as np
+import pytest
+
+from vllm_ascend.spec_decode import get_spec_decode_method
+from vllm_ascend.worker.model_runner_v1 import NPUModelRunner
+
+
+def test_get_spec_decode_method_dispatches_custom_class():
+    vllm_config = MagicMock()
+
+    with patch(
+        "vllm_ascend.spec_decode.create_custom_proposer",
+        return_value="custom-proposer",
+    ) as create:
+        proposer = get_spec_decode_method(
+            "custom_class",
+            vllm_config,
+            device="npu",
+            runner=MagicMock(),
+        )
+
+    assert proposer == "custom-proposer"
+    create.assert_called_once_with(vllm_config)
+
+
+@pytest.mark.parametrize("has_attention_metadata", [True, False])
+def test_propose_draft_token_ids_calls_custom_proposer(has_attention_metadata):
+    runner = NPUModelRunner.__new__(NPUModelRunner)
+    runner.speculative_config = SimpleNamespace(method="custom_class")
+    runner.drafter = MagicMock()
+    runner.drafter.propose.return_value = [[11, 12], [21, 22]]
+    runner.input_batch = SimpleNamespace(
+        num_tokens_no_spec=np.array([3, 2], dtype=np.int32),
+        token_ids_cpu=np.array([[1, 2, 3], [4, 5, 0]], dtype=np.int32),
+    )
+    runner._log_propose_draft_token_ids_entry = MagicMock()
+
+    sampled_token_ids = [[3], [5]]
+    scheduler_output = SimpleNamespace(num_spec_tokens_to_schedule=2)
+    slot_mapping = MagicMock()
+    attention_metadata = SimpleNamespace(slot_mapping=slot_mapping) if has_attention_metadata else None
+    draft_token_ids = runner.propose_draft_token_ids(
+        valid_sampled_token_ids=sampled_token_ids,
+        sampling_metadata=MagicMock(),
+        scheduler_output=scheduler_output,
+        spec_decode_metadata=MagicMock(),
+        spec_decode_common_attn_metadata=attention_metadata,
+        positions=MagicMock(),
+        num_scheduled_tokens=2,
+        hidden_states=MagicMock(),
+    )
+
+    assert draft_token_ids == [[11, 12], [21, 22]]
+    runner.drafter.propose.assert_called_once_with(
+        sampled_token_ids,
+        runner.input_batch.num_tokens_no_spec,
+        runner.input_batch.token_ids_cpu,
+        slot_mappings=slot_mapping if has_attention_metadata else None,
+    )

--- a/vllm_ascend/spec_decode/__init__.py
+++ b/vllm_ascend/spec_decode/__init__.py
@@ -18,6 +18,8 @@
 #
 
 
+from vllm.v1.spec_decode.custom_class_proposer import create_custom_proposer
+
 from vllm_ascend.spec_decode.dflash2_proposer import AscendDflash2Proposer, is_dflash2_draft
 from vllm_ascend.spec_decode.dflash_proposer import AscendDflashProposer
 from vllm_ascend.spec_decode.draft_proposer import AscendDraftModelProposer
@@ -34,7 +36,9 @@ from vllm_ascend.spec_decode.suffix_proposer import AscendSuffixDecodingProposer
 
 
 def get_spec_decode_method(method, vllm_config, device, runner):
-    if method == "ngram":
+    if method == "custom_class":
+        return create_custom_proposer(vllm_config)
+    elif method == "ngram":
         return AscendNgramProposer(vllm_config, runner)
     elif method == "ngram_gpu":
         return AscendNgramProposerNPU(vllm_config, device, runner)

--- a/vllm_ascend/worker/model_runner_v1.py
+++ b/vllm_ascend/worker/model_runner_v1.py
@@ -28,7 +28,7 @@ from copy import copy, deepcopy
 from dataclasses import dataclass, replace
 from functools import partial
 from multiprocessing import Manager
-from typing import TYPE_CHECKING, Any, NamedTuple, TypeAlias
+from typing import TYPE_CHECKING, Any, NamedTuple, TypeAlias, cast
 
 import numpy as np
 import torch
@@ -1710,7 +1710,7 @@ class NPUModelRunner(GPUModelRunner):
         sampling_metadata: SamplingMetadata,
         scheduler_output: "SchedulerOutput",
         spec_decode_metadata: SpecDecodeMetadata,
-        spec_decode_common_attn_metadata: AscendCommonAttentionMetadata,
+        spec_decode_common_attn_metadata: AscendCommonAttentionMetadata | None,
         positions: torch.Tensor,
         num_scheduled_tokens: int,
         hidden_states: torch.Tensor,
@@ -1728,6 +1728,18 @@ class NPUModelRunner(GPUModelRunner):
         if not self.drafter:
             # Speculative decoding is not enabled.
             draft_token_ids = None
+        elif self.speculative_config.method == "custom_class":
+            assert isinstance(valid_sampled_token_ids, list)
+            draft_token_ids = cast(Any, self.drafter).propose(
+                valid_sampled_token_ids,
+                self.input_batch.num_tokens_no_spec,
+                self.input_batch.token_ids_cpu,
+                slot_mappings=(
+                    spec_decode_common_attn_metadata.slot_mapping
+                    if spec_decode_common_attn_metadata is not None
+                    else None
+                ),
+            )
         elif isinstance(self.drafter, AscendNgramProposer):
             draft_token_ids = self.drafter.propose(
                 scheduler_output.num_spec_tokens_to_schedule,
@@ -3705,7 +3717,11 @@ class NPUModelRunner(GPUModelRunner):
                 hidden_states = outputs
             dummy_compute_logits(hidden_states)
 
-            if self.drafter and not profile_cpp:
+            if (
+                self.drafter
+                and self.speculative_config.method != "custom_class"
+                and not profile_cpp
+            ):
                 self.drafter.dummy_run(
                     num_tokens=num_tokens_padded,
                     with_prefill=with_prefill,
@@ -3809,8 +3825,9 @@ class NPUModelRunner(GPUModelRunner):
                     break
             if self.drafter:
                 logger.info("Loading drafter model...")
-                with get_tp_context(self.drafter):
-                    self.drafter.load_model(self.model)
+                if hasattr(self.drafter, "load_model"):
+                    with get_tp_context(self.drafter):
+                        self.drafter.load_model(self.model)
 
             pp_group = get_pp_group()
             should_configure_aux_hidden_states = (


### PR DESCRIPTION
### What this PR does / why we need it?

This PR adds Ascend Model Runner V1 support for vLLM's upstream
`custom_class` speculative proposer backend.

Upstream implementation: https://github.com/vllm-project/vllm/pull/39487

It:

- creates custom proposers through the upstream `create_custom_proposer()` factory;
- invokes the user-provided `propose()` method from the Ascend V1 model runner;
- passes sampled token IDs, CPU token metadata, and the Ascend slot mapping to the proposer;
- treats `load_model()` and `dummy_run()` as optional lifecycle methods, consistent with the upstream custom proposer contract;
- adds unit tests and a single-card Ascend NPU end-to-end test.

Model Runner V2 is intentionally out of scope because upstream vLLM currently rejects `custom_class` when MRV2 is enabled.

### Does this PR introduce _any_ user-facing change?

Yes. Users can configure an external Python proposer class with
`speculative_config.method="custom_class"` when using the Ascend V1 model runner.

The upstream custom proposer interface is experimental, and async scheduling is automatically disabled by vLLM for this method.

### How was this patch tested?

Hardware and software:

- Ascend 910B3 64GB, single card
- Qwen/Qwen3-0.6B with real weights

Unit tests:

```bash
pytest -q \
  tests/ut/spec_decode/test_custom_proposer.py \
  tests/ut/spec_decode/test_dflash2_proposer.py
```

Result: `10 passed`.

Single-card NPU E2E:

```bash
ASCEND_RT_VISIBLE_DEVICES=4 \
VLLM_USE_V2_MODEL_RUNNER=0 \
pytest -sv \
  tests/e2e/pull_request/one_card/spec_decode/test_custom_proposer.py
```

Result: `1 passed`.

Additional manual validation:

- real-weight eager inference;
- ACLGraph capture and replay;
- exact greedy token equality against non-speculative decoding;
- online OpenAI-compatible serving;
- 50/50 successful non-empty requests with concurrency 8;
- speculative metrics confirmed both draft and accepted tokens.

Formatting and targeted lint:

```bash
ruff format --check <changed Python files>
ruff check <changed Python files>
git diff --check
```

- vLLM main: https://github.com/vllm-project/vllm/commit/ba07e4a48fc951300d97eb506217dd530583dea3
