### PR TITLE
[BugFix][Attention] Gate SFA indexer quant matmul on wq_b, not on the activation shape

### DIFF
--- a/vllm_ascend/attention/sfa_v1.py
+++ b/vllm_ascend/attention/sfa_v1.py
@@ -1034,7 +1034,9 @@ class AscendSFAImpl(MLAAttentionImpl):
             if q_c is None:
                 raise RuntimeError("npu_mla_prolog_v3 did not return query_norm for SFA indexer.")
             q_c = q_c.view(-1, self.q_lora_rank)
-            if q_c_scale is not None:
+            # The quantized path in indexer_select_post_process reads
+            # wq_b.weight_scale, so gate on wq_b, not on the trunk's q_c_scale.
+            if q_c_scale is not None and getattr(self.wq_b, "weight_scale", None) is not None:
                 if qt is AscendW8A8MXFP8DynamicLinearMethod:
                     q_c_scale = q_c_scale.view(-1, q_c_scale.shape[-1])
                     q_c = (q_c, q_c_scale)


### PR DESCRIPTION
### What this PR does / why we need it?

Fixes the `AttributeError: 'AscendReplicatedLinear' object has no attribute 'weight_scale'` crash in `indexer_select_post_process` when the MLA trunk is quantized but the SFA indexer's `wq_b` is not.

Closes #15712

The packing site decides whether `indexer_select_post_process` takes the `npu_quant_matmul` path by testing whether the trunk produced a `q_c_scale`. That path reads `self.wq_b.weight_scale`, so it's only valid when `wq_b` itself is quantized. GLM-5.2 W8A8 quantizes the trunk but leaves the indexer's `wq_b` an unquantized `ReplicatedLinear`, so it crashes on the first forward.

I probe `weight_scale` rather than re-introducing the `_is_w8a8_dynamic_linear` helper that #11529 removed, since that helper only recognizes `AscendW8A8DynamicLinearMethod` and would misclassify MXFP8. Let me know if you'd prefer the helper restored instead.

No-op when `wq_b` is quantized: `weight_scale` is present and the condition is unchanged.

### Does this PR introduce _any_ user-facing change?

No. It only unbreaks configurations that previously crashed on the first forward.

### How was this patch tested?

End-to-end on 4x Atlas 800 A3, GLM-5.2 W8A8, P/D disaggregated (P: DP2/TP16/DCP16, D: DP4/TP8/DCP8), vLLM 0.26.0: requests complete normally, and `weight_scale` / `Traceback` / `EngineDeadError` counts are 0 on all four nodes. Before the patch the decode side couldn't complete a single decode step. Reverting reproduces the original `AttributeError`.
- vLLM main: https://github.com/vllm-project/vllm/commit/ba07e4a48fc951300d97eb506217dd530583dea3
