### PR TITLE
[Performance][MoE] Reuse a persistent pad buffer in the MC2 prepare path

### DIFF
--- a/vllm_ascend/ops/fused_moe/prepare_finalize.py
+++ b/vllm_ascend/ops/fused_moe/prepare_finalize.py
@@ -238,6 +238,8 @@ class PrepareAndFinalizeWithMC2(PrepareAndFinalizeWithAll2All):
     def __init__(self, moe_config: FusedMoEConfig):
         super().__init__(moe_config)
         self._restore_tp_across_dp()
+        # (unpadded rows, trailing shape, dtype, padded rows) -> persistent padded buffer
+        self._pad_cache: dict[tuple[int, tuple[int, ...], torch.dtype, int], torch.Tensor] = {}
 
     def _restore_tp_across_dp(self):
         """
@@ -247,6 +249,39 @@ class PrepareAndFinalizeWithMC2(PrepareAndFinalizeWithAll2All):
         """
         self.tp_size = get_tensor_model_parallel_world_size()
         self.tp_rank = get_tensor_model_parallel_rank()
+
+    def _pad_to(self, t: torch.Tensor, target: int) -> torch.Tensor:
+        """Pad `t` up to `target` rows along dim 0 using a persistent buffer.
+
+        `nn.functional.pad` allocates a new tensor and zero-fills it on every call, which
+        for MC2 means two extra kernels (PadV3 + MemSet) per MoE layer per forward. The
+        padded length is `padded_num_tokens`, a function of the TP width rather than of the
+        data, so it is constant for a given captured shape and the buffer can be allocated
+        and zeroed once.
+
+        `nn.functional.pad` guarantees the padded rows are zero, and that guarantee must be
+        preserved: `mc2_mask` is only handed to the dispatch op when `global_bs == 0`, so on
+        the other path the op does read the padded rows.
+
+        The cache key therefore includes the unpadded row count as well as the target. Several
+        batch sizes map to the same `padded_num_tokens` (with tp_size 8, batches 1..8 all pad
+        to 8), and a buffer shared between them would keep the larger batch's rows where the
+        smaller one expects zeros. Keying on both means rows `[t.shape[0]:target]` are never
+        written for a given buffer, so they stay zero from allocation onwards. One buffer per
+        captured shape costs a few KB.
+
+        Reusing a buffer across layers is safe because this method has no multistream path, so
+        each layer's dispatch consumes the padded tensor before the next layer's `prepare`
+        rewrites it. A persistent allocation also suits ACL graph capture, which wants static
+        addresses.
+        """
+        key = (t.shape[0], tuple(t.shape[1:]), t.dtype, target)
+        buf = self._pad_cache.get(key)
+        if buf is None or buf.device != t.device:
+            buf = torch.zeros((target, *t.shape[1:]), dtype=t.dtype, device=t.device)
+            self._pad_cache[key] = buf
+        buf[: t.shape[0]].copy_(t)
+        return buf
 
     def prepare(
         self,
@@ -293,8 +328,8 @@ class PrepareAndFinalizeWithMC2(PrepareAndFinalizeWithAll2All):
             pad_size = target_pad_length - self.num_tokens
 
             if pad_size > 0:
-                hidden_states = nn.functional.pad(hidden_states, (0, 0, 0, pad_size))
-                router_logits = nn.functional.pad(router_logits, (0, 0, 0, pad_size))
+                hidden_states = self._pad_to(hidden_states, target_pad_length)
+                router_logits = self._pad_to(router_logits, target_pad_length)
                 padded_hidden_states_shape = hidden_states.shape
 
             # Slice across TP ranks


### PR DESCRIPTION
### What this PR does / why we need it?

`PrepareAndFinalizeWithMC2.prepare` pads `hidden_states` and `router_logits` up to `padded_num_tokens` with `nn.functional.pad`, which allocates a new tensor and zero-fills it on every call.

Since

```text
padded_num_tokens = ceil(max_tokens_across_dp / tp_size) * tp_size
```

the padded shape depends on the TP width and not on the data, so it is constant for a given captured shape and the allocation can be hoisted into a persistent buffer.

This costs two extra kernels per MoE layer per forward whenever `pad_size > 0`, i.e. whenever the token count is not an exact multiple of `tp_size` — **7 of every 8 batch sizes at `tp_size=8`**.

Profiled with `torch_npu.profiler` on Qwen3-30B-A3B, 8x Atlas 800I A2, EP=8, batch 1, ACL graph captured, rank 0:

| kernel | before | after |
|---|--:|--:|
| `aclnnConstantPadNd_PadV3AiCore_PadV3` | 945.2 us/step | 0.0 (0 calls) |
| `aclnnConstantPadNd_PadV3AiCore_MemSet` | 808.4 us/step | 0.0 (0 calls) |
| all padding kernels | 36.7 us/layer | 0.20 us/layer |

At 18.6 us per call for 32 KB of data, this is launch overhead rather than bandwidth, so the absolute cost is largely independent of how many rows are padded.

The AllGather path does not pay it at all: its pad size is `max_tokens_across_dp - num_tokens`, which is 0 when `dp_size == 1`.

Where `pad_size == 0`, the `if pad_size > 0` guard means `_pad_to` is never called, so the change is a no-op on those shapes rather than a different code path.

**Correctness of the padded rows.** `nn.functional.pad` guarantees the padded rows are zero, and that is preserved here because the cache key includes the unpadded row count as well as the padded length.

Several batch sizes map to the same `padded_num_tokens` (at `tp_size=8`, batches 1..8 all pad to 8 rows), so a buffer keyed only on the padded length would keep a larger batch's rows where a smaller one expects zeros. Keying on both means the padded rows are never written for a given buffer and stay zero from allocation onwards, at a cost of one small buffer per captured shape.

This is not hypothetical: `mc2_mask` is passed to the dispatch op only when `global_bs == 0`, so on the other path the op does read those rows.

### Does this PR introduce _any_ user-facing change?

No. Behaviour is unchanged; only the padding allocation strategy differs.

### How was this patch tested?

Qwen3-30B-A3B (48 layers, 128 experts, top-8, bf16), 8x Atlas 800I A2 (910B2), EP=8/TP=8, `cudagraph_mode: FULL_DECODE_ONLY`, MC2 comm path.

**Correctness** — paired per-token logprob over 510 prefill tokens:

 ```text
unpatched  ppl 1.7135
patched    ppl 1.7128
paired delta +0.000398 +/- 0.002108 nats (n=510, 0.19 sigma)
```

**Decode latency, batch 1** — 32 prompts served one at a time, 128 generated tokens, 3 rounds with the arms rotated within each round to cancel thermal drift:

| round | ITL unpatched | ITL patched | delta |
|--:|--:|--:|--:|
| 1 | 18.3972 ms | 17.6319 ms | -4.16% |
| 2 | 18.4899 ms | 17.5666 ms | -4.99% |
| 3 | 18.5019 ms | 17.7990 ms | -3.80% |

```text
ITL  -0.7972 ms (-4.32%), se 0.0656 -> 12.2 sigma
TTFT 176.36 -> 176.56 ms (unchanged)
```

AllGather runs at 16.9456 ms ITL in the same rounds, so MC2 goes from +8.95% to +4.25% against it.

**Decode throughput across batch sizes** — 3 reps per arm, medians:

| batch | pad_size | unpatched | patched | delta |
|--:|--:|--:|--:|--:|
| 1 | 7 | 46.2 tok/s | 48.5 tok/s | +5.0% |
| 4 | 4 | 156.9 tok/s | 165.8 tok/s | +5.7% |

The `pad_size == 0` row is the control: the padding path is not entered, and the residual +1.4% sets the noise floor for this measurement, against which the +5.0% and +5.7% stand.

Not yet measured: a large batch with `pad_size > 0` under graph capture. Batches that are not a multiple of 8 are only captured when `max_num_seqs` is raised to the next multiple, because vLLM's ladder is `[1, 2, 4] + range(8, max_capture + 1, 8)`; otherwise, the step exceeds every captured size and falls back to eager, where this padding is ~1% of the step and invisible.

The reasoning above (launch-bound, so roughly batch-independent) suggests the win persists, but it is reasoning rather than a measurement.