### PR TITLE
[BugFix][Device] Restore eager ATB registration on 310P

### DIFF
--- a/tests/ut/device/test_hardware_profile.py
+++ b/tests/ut/device/test_hardware_profile.py
@@ -55,6 +55,7 @@ _EXPECTED_CAPABILITIES = {
     },
     AscendDeviceType._310P: frozenset(
         {
+            HardwareCapability.ATB_EXTENSIONS,
             HardwareCapability.COMPATIBILITY_OP_IMPLEMENTATIONS,
             HardwareCapability.DISTRIBUTED_COMMUNICATION_ADAPTATION,
             HardwareCapability.FUSED_MOE_COMPATIBILITY,
@@ -187,6 +188,13 @@ def test_hardware_profile_capability_matrix(device_type: AscendDeviceType) -> No
     assert profile.capabilities == expected_capabilities
     for capability in HardwareCapability:
         assert profile.supports(capability) is (capability in expected_capabilities)
+
+
+def test_310p_eager_atb_registration_does_not_enable_matmul_warmup() -> None:
+    profile = get_hardware_profile(AscendDeviceType._310P)
+
+    assert profile.supports(HardwareCapability.ATB_EXTENSIONS)
+    assert not profile.supports(HardwareCapability.ATB_WARMUP)
 
 
 def test_current_hardware_profile_uses_device_config() -> None:

--- a/vllm_ascend/device/hardware_profile.py
+++ b/vllm_ascend/device/hardware_profile.py
@@ -197,6 +197,7 @@ _HARDWARE_PROFILES: Mapping[AscendDeviceType, HardwareProfile] = MappingProxyTyp
             quantization_backend_family=QuantizationBackendFamily.COMPATIBILITY,
             capabilities=frozenset(
                 {
+                    HardwareCapability.ATB_EXTENSIONS,
                     HardwareCapability.COMPATIBILITY_OP_IMPLEMENTATIONS,
                     HardwareCapability.DISTRIBUTED_COMMUNICATION_ADAPTATION,
                     HardwareCapability.FUSED_MOE_COMPATIBILITY,


### PR DESCRIPTION
### What this PR does / why we need it?

PR #15256 migrated the worker's direct device check to the hardware-profile matrix, but accidentally narrowed eager ATB extension registration from all non-A5 devices to A2/A3 only.

The direct baseline called `_register_atb_extensions()` for A2, A3, and 310P. `NPUWorker310` inherits `NPUWorker.__init__`, so omitting `ATB_EXTENSIONS` from the 310P profile silently moved registration from worker construction to the first lazily wrapped ATB operation.

This PR:
- restores `ATB_EXTENSIONS` for the 310P profile;
- keeps `ATB_WARMUP` disabled on 310P because its `_warm_up_atb()` override explicitly skips the unsupported `_npu_matmul_add_fp32` warmup;
- adds a regression test that locks these two independent contracts.

### Does this PR introduce _any_ user-facing change?

Yes. It restores the pre-#15256 eager ATB extension initialization timing on 310P. A2/A3/A5 behavior is unchanged.

### How was this patch tested?

- Based on `main@222677fc719c7014879b161ed1dd3ed3276d7a5d`.
- `git diff --check`: passed.
- `python -m compileall` on both changed files: passed.
- Commit includes `Signed-off-by`.
- The available hosts do not provide Ruff, pytest, mypy, or the vLLM runtime; the focused regression test, Ruff checks, and Python 3.10/3.11/3.12 mypy checks are left to CI.

- vLLM main: https://github.com/vllm-project/vllm/commit/84030bbe3d74d99bad477a3d2e37a973ccd8865c
