### PR TITLE
[BugFix][Attention] Restore 310P paged-attention selection

### DIFF
--- a/tests/ut/attention/test_attention_v1.py
+++ b/tests/ut/attention/test_attention_v1.py
@@ -51,14 +51,18 @@ class TestAttentionGraphHelpers(TestBase):
         self.assertEqual(result.numel(), 8)
         self.assertEqual(graph_params.workspaces[1].numel(), 8)
 
-    def test_large_head_uses_paged_attention_on_a2(self):
+    def test_large_head_uses_paged_attention_on_non_a5_profiles(self):
         vllm_config = MagicMock()
         vllm_config.speculative_config = None
-        with patch(
-            "vllm_ascend.attention.utils.get_current_hardware_profile",
-            return_value=get_hardware_profile(AscendDeviceType.A2),
-        ):
-            self.assertTrue(using_paged_attention(1, vllm_config, head_size=FIA_TND_LARGE_HEAD_FALLBACK_HEAD_SIZE))
+        for device_type in (AscendDeviceType.A2, AscendDeviceType.A3, AscendDeviceType._310P):
+            with self.subTest(device_type=device_type):
+                with patch(
+                    "vllm_ascend.attention.utils.get_current_hardware_profile",
+                    return_value=get_hardware_profile(device_type),
+                ):
+                    self.assertTrue(
+                        using_paged_attention(1, vllm_config, head_size=FIA_TND_LARGE_HEAD_FALLBACK_HEAD_SIZE)
+                    )
 
 
 class TestAscendAttentionBackend(TestBase):

--- a/tests/ut/attention/test_attention_v1.py
+++ b/tests/ut/attention/test_attention_v1.py
@@ -55,14 +55,14 @@ class TestAttentionGraphHelpers(TestBase):
         vllm_config = MagicMock()
         vllm_config.speculative_config = None
         for device_type in (AscendDeviceType.A2, AscendDeviceType.A3, AscendDeviceType._310P):
-            with self.subTest(device_type=device_type):
-                with patch(
+            with (
+                self.subTest(device_type=device_type),
+                patch(
                     "vllm_ascend.attention.utils.get_current_hardware_profile",
                     return_value=get_hardware_profile(device_type),
-                ):
-                    self.assertTrue(
-                        using_paged_attention(1, vllm_config, head_size=FIA_TND_LARGE_HEAD_FALLBACK_HEAD_SIZE)
-                    )
+                ),
+            ):
+                self.assertTrue(using_paged_attention(1, vllm_config, head_size=FIA_TND_LARGE_HEAD_FALLBACK_HEAD_SIZE))
 
 
 class TestAscendAttentionBackend(TestBase):

--- a/tests/ut/device/test_hardware_profile.py
+++ b/tests/ut/device/test_hardware_profile.py
@@ -61,6 +61,7 @@ _EXPECTED_CAPABILITIES = {
             HardwareCapability.FUSED_SWIGLU_TUNING_ARGS,
             HardwareCapability.GDN_COMPATIBILITY,
             HardwareCapability.IRQ_CPU_RESERVATION,
+            HardwareCapability.PAGED_ATTENTION,
             HardwareCapability.RC_DEVICE_DISCOVERY,
             HardwareCapability.RUNTIME_CUSTOM_OPS,
         }

--- a/vllm_ascend/device/hardware_profile.py
+++ b/vllm_ascend/device/hardware_profile.py
@@ -203,6 +203,7 @@ _HARDWARE_PROFILES: Mapping[AscendDeviceType, HardwareProfile] = MappingProxyTyp
                     HardwareCapability.FUSED_SWIGLU_TUNING_ARGS,
                     HardwareCapability.GDN_COMPATIBILITY,
                     HardwareCapability.IRQ_CPU_RESERVATION,
+                    HardwareCapability.PAGED_ATTENTION,
                     HardwareCapability.RC_DEVICE_DISCOVERY,
                     HardwareCapability.RUNTIME_CUSTOM_OPS,
                 }


### PR DESCRIPTION
### What this PR does / why we need it?

PR #15376 migrated `using_paged_attention()` from a direct device check to the hardware-profile matrix, but accidentally narrowed the eligible device set.

The direct baseline disabled this path only on A5, so A2, A3, and 310P could select paged attention when the remaining runtime conditions were satisfied. The migrated profile added `PAGED_ATTENTION` only to the A2/A3 common set and omitted 310P.

This PR:
- restores `PAGED_ATTENTION` for the 310P profile;
- keeps A5 disabled and A2/A3 unchanged;
- expands the focused large-head regression test to cover A2, A3, and 310P.

310P has its own paged-attention implementation, so the profile must not describe paged attention as unsupported.

### Does this PR introduce _any_ user-facing change?

Yes. It restores the pre-#15376 paged-attention selection result on 310P. A2/A3/A5 behavior is unchanged.

### How was this patch tested?

- Based on `main@222677fc719c7014879b161ed1dd3ed3276d7a5d`.
- `git diff --check`: passed.
- `python -m compileall` on all three changed Python files: passed.
- Commit includes `Signed-off-by`.
- Added a focused regression test covering A2, A3, and 310P through the actual `using_paged_attention()` helper.
- Ruff is not installed in the server environment; pytest/mypy/vLLM dependencies are also unavailable there, so those checks are delegated to CI.

- vLLM main: https://github.com/vllm-project/vllm/commit/84030bbe3d74d99bad477a3d2e37a973ccd8865c
