### PR TITLE
[Performance][Kernel] Narrow tiling-key 1 scale synchronization in GroupedMatmulSwigluQuantWeightNZ

### DIFF
--- a/csrc/gmm/grouped_matmul_swiglu_quant_weight_nz_tensor_list/op_kernel/grouped_matmul_swiglu_quant_weight_nz_tensor_list_split_ws.h
+++ b/csrc/gmm/grouped_matmul_swiglu_quant_weight_nz_tensor_list/op_kernel/grouped_matmul_swiglu_quant_weight_nz_tensor_list_split_ws.h
@@ -550,18 +550,19 @@ __aicore__ inline void GMMSwigluSplitWorkSpaceCompute<mmType, sync, CHANNELDTYPE
         _inMMLocal[loopIdx * gmmSwigluTensorList->tokenLen],
         gmmSwigluTensorList->tokenLen / BISECT);
     LocalTensor<float> workspaceLocal= reduceWorkspace.Get<float>();
-    PipeBarrier<PIPE_ALL>();
+    PipeBarrier<PIPE_V>();
     ReduceMaxTemplate(workspaceLocal,
         _inMMLocal, loopIdx * gmmSwigluTensorList->tokenLen + gmmSwigluTensorList->tokenLen / BISECT, gmmSwigluTensorList->tokenLen / BISECT);
-    PipeBarrier<PIPE_ALL>();
+    int32_t eventIdVToS = static_cast<int32_t>(GetTPipePtr()->FetchEventID(HardEvent::V_S));
+    SetFlag<HardEvent::V_S>(eventIdVToS);
+    WaitFlag<HardEvent::V_S>(eventIdVToS);
     float quantScale = workspaceLocal.GetValue(0) / QUANT_SCALE_INT8;
-    PipeBarrier<PIPE_ALL>();
     LocalTensor<float> quantScaleLocal = quantScaleOutQueue.DeQue<float>();
-    PipeBarrier<PIPE_ALL>();
     quantScaleLocal.SetValue(loopIdx, quantScale);
-    PipeBarrier<PIPE_ALL>();
     quantScale = 1 / quantScale;
-    PipeBarrier<PIPE_ALL>();
+    int32_t eventIdSToV = static_cast<int32_t>(GetTPipePtr()->FetchEventID(HardEvent::S_V));
+    SetFlag<HardEvent::S_V>(eventIdSToV);
+    WaitFlag<HardEvent::S_V>(eventIdSToV);
     Muls(_inMMLocal[loopIdx * gmmSwigluTensorList->tokenLen], _inMMLocal[loopIdx * gmmSwigluTensorList->tokenLen],
          quantScale, gmmSwigluTensorList->tokenLen / BISECT);
     PipeBarrier<PIPE_V>();


### PR DESCRIPTION
### What this PR does / why we need it?

The `TILING_KEY_IS(1)` split-workspace quantization path in `GroupedMatmulSwigluQuantWeightNZ` uses broad `PIPE_ALL` barriers around two directional data dependencies:

1. vector `ReduceMaxTemplate` completion before the scalar `GetValue`;
2. scalar scale/reciprocal computation before the vector `Muls`.

This PR narrows synchronization to those actual hazards:

- replace the pre-reduction `PIPE_ALL` barrier with `PIPE_V`;
- use a `V_S` event between the vector reduction and scalar read;
- remove unrelated full-pipeline barriers around scalar-only scale handling;
- use an `S_V` event before the vector multiply.

The required happens-before relationships remain explicit. The patch changes one kernel header only (`7` insertions, `6` deletions) and does not change arithmetic, tiling selection, host dispatch, workspace layout, tensor layout, or the tiling-key 0 path.

### Does this PR introduce _any_ user-facing change?

No. Operator inputs, outputs, API, dispatch semantics, and numerical formula are unchanged.

### How was this patch tested?

#### Build and correctness

The comparator and candidate were built from immutable source snapshots with the same Ascend 910B2 environment, CANN 9.0.1 toolchain, compiler, flags, dependencies, and procedure:

```bash
MAX_JOBS=16 bash csrc/build.sh --pkg \
  --ops=grouped_matmul_swiglu_quant_weight_nz_tensor_list \
  --soc=ascend910b -j16 -O3
```

The fixed workload used:

```text
x:            int8     [16384, 2048]
weight:       int8     [2048, 1536]
x_scale:      float32  [16384]
weight_scale: float32  [1536]
output:                 [16384, 768]
```

Both tiling-key 0 (`group_num=127`, unaffected control) and tiling-key 1 (`group_num=128`, changed path) were exercised.

For comparator and candidate:

- quantized output, scale output, and offset output were byte-exact;
- two independent repeats per arm/key were deterministic;
- structured coverage included zero/signed extrema, saturation, rounding boundaries, row tails, vector-repeat boundaries, workspace-split boundaries, and the key-0/key-1 group boundary;
- the compiled candidate was bound to the expected `V_S` and `S_V` event sequence and the correct tiling-key suffix.

#### Matched performance

Device-side operator task duration was measured on the same Ascend 910B2 NPU with CANN 9.0.1 `msprof` task timing.

The protocol used five comparator-only pilot observations followed by six preregistered, counterbalanced paired macroblocks, with no sample exclusion or extension.

| Path | Comparator mean | Candidate mean | Paired effect |
| --- | ---: | ---: | ---: |
| tiling key 1 | 373.094 us | 364.210 us | **-2.356978%** |
| tiling key 0 control | 445.426 us | 445.222 us | **-0.042721%** |

For tiling key 1:

- all `6/6` paired deltas favored the candidate;
- the two-sided paired 95% Student-t interval was `[-4.506071%, -0.207886%]` for candidate-minus-comparator duration.

The tiling-key 0 control and comparator-anchor checks remained within their preregistered guardrails.

This evidence is intentionally scoped to the tested tiling-key 1 device-side operator task. It is not a model-level, serving, deployment, or production performance claim.

#### Current-main applicability

Immediately before submission, upstream `main` had advanced only through unrelated CI changes.

The target header and the complete `csrc/gmm/grouped_matmul_swiglu_quant_weight_nz_tensor_list` directory were unchanged from the tested source context.

The current PR commit preserves:

```text
stable patch-id:
7dcbdf8f40b152e4d06b00964aefc414d1d4fa38

patched target blob:
31e0be52ebe8e5d264fd6d21f8f3be9c492f27a8
```

These match the validated candidate exactly, so no duplicate NPU rerun was performed solely for unrelated upstream drift.

No new Python unit test is added because this is an internal AscendC synchronization change with no Python/API behavior.

The existing NPU E2E coverage remains the relevant repository regression test:

```text
tests/e2e/nightly/single_node/ops/singlecard_ops/
test_gmm_swiglu_quant_weight_nz_tensor_list.py
```

Because the PR changes `csrc/**`, upstream selected NPU CI is still required before merge.

### Risk and rollback

The remaining review risk is a hidden pipeline dependency previously covered by `PIPE_ALL`.

The two direct vector-to-scalar and scalar-to-vector dependencies are retained explicitly, and exact-output NPU validation passed.

Upstream csrc build/NPU CI is the final regression gate.

Rollback is a one-commit revert restoring the original barriers.

- vLLM main: https://github.com/vllm-project/vllm/commit/ba07e4a48fc951300d97eb506217dd530583dea3
