### PR TITLE
[Doc][BugFix] Fix incorrect w8a8 model weight paths for A2/A3 and 300I DUO

### DIFF
--- a/docs/source/tutorials/models/Qwen3.5-27B-Qwen3.6-27B.md
+++ b/docs/source/tutorials/models/Qwen3.5-27B-Qwen3.6-27B.md
@@ -267,7 +267,7 @@ Both `Qwen3.5-27B` and `Qwen3.6-27B` share the same MTP head design, so the `qwe
         ```bash
         #!/bin/sh
         # Load model from ModelScope to speed up download
-        export MODEL_PATH=Eco-Tech/Qwen3.6-27B-w8a8-310p
+        export MODEL_PATH=Eco-Tech/Qwen3.6-27B-w8a8
         export VLLM_USE_MODELSCOPE=True
         export HCCL_BUFFSIZE=512
         export PYTORCH_NPU_ALLOC_CONF=expandable_segments:True
@@ -351,7 +351,7 @@ Both `Qwen3.5-27B` and `Qwen3.6-27B` share the same MTP head design, so the `qwe
         ```bash
         #!/bin/sh
         # Load model from ModelScope to speed up download
-        export MODEL_PATH=Eco-Tech/Qwen3.6-27B-w8a8
+        export MODEL_PATH=Eco-Tech/Qwen3.6-27B-w8a8-310p
         export VLLM_USE_MODELSCOPE=True
 
         # Model weight path; can be a ModelScope model id (e.g., Eco-Tech/Qwen3.6-27B-w8a8) or a local directory path

--- a/docs/source/tutorials/models/Qwen3.8-27B.md
+++ b/docs/source/tutorials/models/Qwen3.8-27B.md
@@ -379,7 +379,7 @@ Before starting the service:
         export VLLM_USE_MODELSCOPE=True
 
         # Model weight path; can be a ModelScope model id (e.g., Eco-Tech/Qwen3.8-27B-w8a8) or a local directory path
-        export MODEL_PATH=Eco-Tech/Qwen3.8-27B-w8a8
+        export MODEL_PATH=Eco-Tech/Qwen3.8-27B-w8a8-310p
 
         vllm serve $MODEL_PATH \
             --host 127.0.0.1 \


### PR DESCRIPTION
### What this PR does / why we need it?

In the Qwen3.5/3.6/3.8-27B tutorials, the `w8a8` model weight paths for the Atlas 800 A3/A2 and Atlas 300I DUO deployment sections were incorrect: the `-310p` suffix weight (which is 300I DUO only) was used on A2/A3, and vice versa. Users on the wrong device would pull an incompatible weight and fail to start.

This PR corrects the paths to match the model download tables at the top of each document:
- `Qwen3.5-27B-Qwen3.6-27B.md`: A2/A3 `Eco-Tech/Qwen3.6-27B-w8a8-310p` -> `Eco-Tech/Qwen3.6-27B-w8a8`; 300I DUO `Eco-Tech/Qwen3.6-27B-w8a8` -> `Eco-Tech/Qwen3.6-27B-w8a8-310p`
- `Qwen3.8-27B.md`: 300I DUO `Eco-Tech/Qwen3.8-27B-w8a8` -> `Eco-Tech/Qwen3.8-27B-w8a8-310p`

Where `Qwen3.x-27B-w8a8` targets A2/A3 (and Ascend950PR for Qwen3.8) and `Qwen3.x-27B-w8a8-310p` targets Atlas 300I DUO.

Fixes #15621

### Does this PR introduce _any_ user-facing change?

No code change. Documentation only: corrects the model weight path used in the deployment startup commands so it matches the supported device.

### How was this patch tested?

Documentation-only change. Verified each `MODEL_PATH` against the model download table in the same file:
- `Qwen3.5-27B-Qwen3.6-27B.md` lines 27/29 (A2/A3 -> `Qwen3.6-27B-w8a8`, 300I DUO -> `Qwen3.6-27B-w8a8-310p`)
- `Qwen3.8-27B.md` line 28 (300I DUO -> `Qwen3.8-27B-w8a8-310p`)

Ran `markdownlint-cli2` on both changed files; no new issues introduced.

- vLLM main: https://github.com/vllm-project/vllm/commit/ba07e4a48fc951300d97eb506217dd530583dea3
