### PR TITLE
[Test][MRV2] Add Ascend trace replay coverage and guide

### DIFF
--- a/docs/hooks/nav_titles.py
+++ b/docs/hooks/nav_titles.py
@@ -220,6 +220,7 @@ TITLES = {
     "user_guide/feature_guide/sleep_mode.md": {"en": "Sleep Mode", "zh": "休眠模式"},
     "user_guide/feature_guide/speculative_decoding.md": {"en": "Speculative Decoding", "zh": "推测解码"},
     "user_guide/feature_guide/structured_output.md": {"en": "Structured Output", "zh": "结构化输出"},
+    "user_guide/feature_guide/trace_replay.md": {"en": "Trace Replay", "zh": "轨迹回放"},
     "user_guide/feature_guide/ucm_deployment.md": {"en": "UCM Deployment", "zh": "UCM 部署"},
     "user_guide/feature_guide/rl.md": {"en": "vLLM-Ascend for RL", "zh": "vLLM-Ascend 强化学习"},
     "user_guide/index.md": {"en": "Overview", "zh": "概览"},

--- a/docs/source/user_guide/feature_guide/trace_replay.md
+++ b/docs/source/user_guide/feature_guide/trace_replay.md
@@ -1,0 +1,123 @@
+# Trace Replay
+
+Trace replay forces decoding to follow a supplied token sequence while the
+model still runs every forward pass and computes logits normally. The returned
+logprobs and ranks therefore describe the model's real distribution for each
+forced token.
+
+This is useful for locating the first numerical divergence between Ascend and
+another backend, or between eager and ACL Graph execution, without allowing an
+earlier sampling difference to change the rest of the decode path.
+
+## Requirements
+
+Trace replay is provided by upstream vLLM and works on Ascend with Model Runner
+V2. It reserves a per-request trace buffer, so it is disabled by default.
+
+- Use a vLLM version that includes trace replay support.
+- Enable Model Runner V2 with `VLLM_USE_V2_MODEL_RUNNER=1`.
+- Construct the engine with `enable_trace_replay=True`.
+- Use the offline Python API. The OpenAI-compatible request schemas do not
+  currently expose `trace_decode_token_ids`.
+
+## Offline example
+
+```python
+from vllm import LLM, SamplingParams
+
+llm = LLM(
+    model="Qwen/Qwen3-0.6B",
+    enable_trace_replay=True,
+)
+
+trace_token_ids = [9707, 11, 358, 1097]
+params = SamplingParams(
+    trace_decode_token_ids=trace_token_ids,
+    logprobs=5,
+)
+
+output = llm.generate(["Hello, my name is"], params)[0].outputs[0]
+assert list(output.token_ids) == trace_token_ids
+
+for step, (token_id, step_logprobs) in enumerate(
+    zip(output.token_ids, output.logprobs, strict=True)
+):
+    token_logprob = step_logprobs[token_id]
+    print(
+        f"step={step} token={token_id} "
+        f"logprob={token_logprob.logprob} rank={token_logprob.rank}"
+    )
+```
+
+`max_tokens` is set to the effective trace length. The trace is truncated when
+it does not fit in the remaining model context. EOS tokens and other stop
+conditions inside the trace do not stop replay early.
+
+## Comparing eager and ACL Graph
+
+Capture one trace and replay that same list for both configurations. Keeping
+the token history identical makes the first logprob difference directly
+comparable.
+
+Eager configuration:
+
+```python
+llm = LLM(
+    model="Qwen/Qwen3-0.6B",
+    enable_trace_replay=True,
+    enforce_eager=True,
+)
+```
+
+ACL Graph decode configuration:
+
+```python
+llm = LLM(
+    model="Qwen/Qwen3-0.6B",
+    enable_trace_replay=True,
+    compilation_config={"cudagraph_mode": "FULL_DECODE_ONLY"},
+)
+```
+
+For each step, record at least the token ID, logprob, and rank. Compare the
+records in order and report the first step that exceeds the tolerance selected
+for the model and data type. Token IDs must match the trace exactly; logprobs
+need not be bitwise identical across devices or execution modes.
+
+## Dynamic batching
+
+Each request can use a different trace and trace length. Trace replay follows
+the request-state mapping as batches grow and shrink, and is compatible with
+asynchronous scheduling on Ascend. Pass one `SamplingParams` instance per
+prompt when traces differ:
+
+```python
+params = [
+    SamplingParams(trace_decode_token_ids=[9707, 11], logprobs=5),
+    SamplingParams(trace_decode_token_ids=[785, 374, 264], logprobs=5),
+]
+outputs = llm.generate(["Prompt A", "Prompt B"], params)
+```
+
+## Limitations
+
+Trace replay requires `n=1` and cannot be combined with:
+
+- prompt logprobs;
+- speculative decoding;
+- structured outputs;
+- repetition detection;
+- thinking token budgets;
+- bad-word logit masking.
+
+These combinations raise `ValueError` rather than silently disabling replay.
+
+## Ascend UVA fallback
+
+The upstream implementation stores trace state in a host-backed buffer. On
+Ascend software stacks where Triton UVA is unavailable, vLLM Ascend's existing
+UVA compatibility path transparently stages this state on the NPU. No Trace
+Replay-specific CANN operator or environment variable is required.
+
+For the generic API contract and additional examples, see the upstream
+[Trace Replay documentation](https://docs.vllm.ai/en/latest/serving/online_serving/trace_replay/).

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -279,6 +279,7 @@ nav:
         - user_guide/configuration/encoder_cache_manager.md
     - Feature Guide:
         - user_guide/feature_guide/index.md
+        - user_guide/feature_guide/trace_replay.md
         - user_guide/feature_guide/graph_mode.md
         - user_guide/feature_guide/cpu_binding.md
         - user_guide/feature_guide/Ai_QoS_introduction_en.md

--- a/tests/e2e/pull_request/one_card/model_runner_v2/test_trace_replay.py
+++ b/tests/e2e/pull_request/one_card/model_runner_v2/test_trace_replay.py
@@ -1,0 +1,130 @@
+#
+# Copyright (c) 2026 Huawei Technologies Co., Ltd. All Rights Reserved.
+# Copyright 2023 The vLLM team.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import math
+import os
+from unittest.mock import patch
+
+import pytest
+from vllm import SamplingParams
+
+from tests.e2e.conftest import VllmRunner, wait_until_npu_memory_free
+
+MODEL = "Qwen/Qwen3-0.6B"
+PROMPTS = [
+    "Hello, my name is",
+    "The capital of France is",
+    "The future of AI is",
+    "A short story starts with",
+]
+
+
+@pytest.mark.parametrize(
+    ("enforce_eager", "compilation_config", "additional_config"),
+    [
+        pytest.param(True, {}, {}, id="eager"),
+        pytest.param(
+            False,
+            {
+                "cudagraph_mode": "FULL_DECODE_ONLY",
+                "cudagraph_capture_sizes": [4],
+            },
+            {
+                "ascend_compilation_config": {
+                    "enable_npugraph_ex": False,
+                    "fuse_norm_quant": False,
+                    "fuse_qknorm_rope": False,
+                    "fuse_muls_add": False,
+                },
+            },
+            id="full_decode_only",
+        ),
+    ],
+)
+@patch.dict(
+    os.environ,
+    {
+        "VLLM_USE_V2_MODEL_RUNNER": "1",
+        "PYTORCH_NPU_ALLOC_CONF": "pinned_mem_register:True",
+    },
+)
+@wait_until_npu_memory_free(target_free_percentage=0.8)
+def test_trace_replay(
+    enforce_eager: bool,
+    compilation_config: dict,
+    additional_config: dict,
+) -> None:
+    """Replay distinct traces through dynamic batches on Ascend MRV2."""
+    with VllmRunner(
+        MODEL,
+        max_model_len=1024,
+        max_num_seqs=len(PROMPTS),
+        enforce_eager=enforce_eager,
+        async_scheduling=True,
+        enable_trace_replay=True,
+        compilation_config=compilation_config,
+        additional_config=additional_config,
+    ) as runner:
+        baseline_params = SamplingParams(
+            temperature=0.0,
+            max_tokens=8,
+            ignore_eos=True,
+        )
+        baseline_outputs = runner.model.generate(PROMPTS, baseline_params)
+        trace_lengths = [8, 6, 4, 7]
+        traces = [
+            list(output.outputs[0].token_ids[:trace_len])
+            for output, trace_len in zip(
+                baseline_outputs,
+                trace_lengths,
+                strict=True,
+            )
+        ]
+
+        # An EOS token inside a trace must be replayed without ending the
+        # request. This also ensures the test does not only replay greedy paths.
+        eos_token_id = runner.model.get_tokenizer().eos_token_id
+        assert eos_token_id is not None
+        traces[0][1] = eos_token_id
+
+        replay_params = [
+            SamplingParams(
+                trace_decode_token_ids=trace,
+                logprobs=5,
+            )
+            for trace in traces
+        ]
+        replay_outputs = runner.model.generate(PROMPTS, replay_params)
+
+        for output, expected_trace in zip(
+            replay_outputs,
+            traces,
+            strict=True,
+        ):
+            sample = output.outputs[0]
+            assert list(sample.token_ids) == expected_trace
+            assert sample.logprobs is not None
+            assert len(sample.logprobs) == len(expected_trace)
+
+            for token_id, step_logprobs in zip(
+                expected_trace,
+                sample.logprobs,
+                strict=True,
+            ):
+                trace_logprob = step_logprobs.get(token_id)
+                assert trace_logprob is not None
+                assert math.isfinite(trace_logprob.logprob)


### PR DESCRIPTION
### What this PR does / why we need it?

Upstream vLLM added Trace Replay in vllm-project/vllm#46701. It forces decode to follow caller-provided token IDs while still running the model forward pass and reporting the real logprob/rank of each forced token. This is particularly useful for locating the first numerical divergence between GPU and NPU, eager and ACL Graph, or different quantization paths.

Model Runner V2 on Ascend can use the upstream implementation through its existing runner and UVA compatibility paths, so no Ascend-specific runtime patch or CANN operator is needed. This PR makes that support explicit by:

- adding a single-card Qwen3-0.6B E2E for eager and `FULL_DECODE_ONLY` ACL Graph;
- covering per-request traces with different lengths, asynchronous scheduling, dynamic batch shrink, an EOS token inside a trace, and forced-token logprobs;
- documenting setup, offline usage, eager/ACL Graph comparison, limitations, and the Ascend UVA fallback.

### Does this PR introduce _any_ user-facing change?

No runtime behavior or public API changes. It adds Ascend-specific Trace Replay documentation and test coverage for the upstream API.

### How was this patch tested?

Hardware: one Ascend 910B3 64 GB NPU, Qwen3-0.6B, vLLM Model Runner V2, asynchronous scheduling.

- New E2E eager case: 4 distinct traces were replayed exactly; forced-token logprobs were present and finite.
- New E2E ACL Graph case: `FULL_DECODE_ONLY` captured a decode graph and replayed all traces exactly. The validation host uses an older driver that lacks `aclnnAddRmsNormBias`, so runtime custom ops were disabled for this local graph run; the committed test keeps the normal project runtime configuration for CI.
- Capacity/stability: eager and ACL Graph each completed 3 rounds of 32 requests (96 requests / 600 replayed tokens per mode), with exact token replay in every request.
- Numerical comparison: the maximum eager-vs-ACL-Graph absolute logprob difference for the same first-round traces was `0.0`.
- Upstream Trace Replay parameter/input contract tests: `17 passed`.
- `ruff check`, `ruff format --check`, `codespell`, `typos`, `markdownlint`, and `git diff --check`: passed.

```bash
pytest -sv tests/e2e/pull_request/one_card/model_runner_v2/test_trace_replay.py
pytest -q \
  /vllm-workspace/vllm/tests/v1/sample/test_trace_replay_params.py \
  /vllm-workspace/vllm/tests/v1/engine/test_input_processor_trace_replay.py
```

- vLLM main: https://github.com/vllm-project/vllm/commit/ba07e4a48fc951300d97eb506217dd530583dea3
