### PR TITLE
[Doc][Misc] Complete SP MoE guide and temporary FlashComm switch

### DIFF
--- a/docs/source/user_guide/configuration/additional_config.md
+++ b/docs/source/user_guide/configuration/additional_config.md
@@ -22,6 +22,7 @@ Starting from [PR #9064](https://github.com/vllm-project/vllm-ascend/pull/9064),
 | `VLLM_ASCEND_ENABLE_NZ` | `weight_nz_mode` | Integer (unchanged, field name changed) |
 | `VLLM_ASCEND_ENABLE_FUSED_MC2` | `enable_fused_mc2` | Integer (unchanged) |
 | `VLLM_ASCEND_FUSION_OP_TRANSPOSE_KV_CACHE_BY_BLOCK` | `enable_transpose_kv_cache_by_block` | `"1"` → `true`, `"0"` → `false` |
+| `VLLM_ASCEND_ENABLE_FLASHCOMM1` | `enable_flashcomm1` | `"1"` → `true`, `"0"` → `false` |
 
 ## How to use
 
@@ -73,6 +74,7 @@ The following table lists additional configuration options available in vLLM Asc
 | `enable_fused_mc2`                  | int  | `0`     | Fused MC2 configuration. `0` disables the fused path and `1` enables it when the model and parallel configuration support it. The legacy `VLLM_ASCEND_ENABLE_FUSED_MC2` environment variable is no longer supported. |
 | `enable_transpose_kv_cache_by_block`| bool | `True`  | Whether to enable transpose KV cache by block. The legacy `VLLM_ASCEND_FUSION_OP_TRANSPOSE_KV_CACHE_BY_BLOCK` environment variable is no longer supported. |
 | `enable_dsa_cp`                     | bool | `False` | Whether to enable dsa_cp for DeepSeek V3.2, DeepSeek V4, and other models with the same architecture. This feature requires sequence parallelism to be enabled. Enabling it automatically enables FlashComm.|
+| `enable_flashcomm1`                 | bool | `False` | Whether to enable SP MoE. The legacy `VLLM_ASCEND_ENABLE_FLASHCOMM1` environment variable is kept for compatibility. See [Sequence Parallelism](../feature_guide/sequence_parallelism.md). |
 | `enable_pcp_o_proj_weight_sharding`        | bool | `False` | Whether SFA-PCP shards the O-proj weight across the PCP group at load time and switches between PCP-local and gathered weight views at runtime. This option does not affect DSA-CP, whose original policy remains fixed: prefill gathers the full O-proj weight and decode uses the local weight. This option must be set when the server starts. |
 | `rejection_sampler_config`          | dict | `{}`    | Configuration options for rejection sampler (block verify and entropy verify). |
 | `dynamic_spec_config`               | dict | `{}`    | Configuration options for Dynamic Speculative Decoding. See [Dynamic Speculative Decoding](../feature_guide/speculative_decoding.md#dynamic-speculative-decoding). |

--- a/docs/source/user_guide/feature_guide/sequence_parallelism.md
+++ b/docs/source/user_guide/feature_guide/sequence_parallelism.md
@@ -3,15 +3,107 @@
 ## Overview
 
 Sequence Parallelism (SP) shards the token dimension across tensor-parallel
-ranks around the communication boundaries of transformer layers. vLLM owns
+ranks around the communication boundaries of transformer layers.
+
+On vLLM Ascend, SP currently covers the MoE path (SP MoE). The attention
+`o_proj` ends with a TP all-reduce, so its inputs are replicated on every TP
+rank. Feeding those replicated tokens directly into the experts duplicates
+compute and communication under expert parallelism. SP MoE keeps the expert
+inputs sharded by sequence and restores the expected layout at the MoE output
+boundary instead.
+
+## Principle
+
+Upstream vLLM owns the SP MoE switch. `ParallelConfig.use_sequence_parallel_moe`
+is true only when all of the following hold:
+
+- `tensor_parallel_size > 1` and `data_parallel_size > 1`.
+- `enable_expert_parallel` is set (MoE models only).
+- `all2all_backend` is an SP-capable backend: `allgather_reducescatter`,
+  `deepep_high_throughput`, `deepep_low_latency`, `mori_high_throughput`,
+  `mori_low_latency`, or `nixl_ep`.
+
+`vllm_ascend.utils.enable_sp()` is a thin wrapper over this flag and drives the
+Ascend runtime behavior (SP padding, TP-aligned graph capture sizes, and the
+MoE communication path).
+
+Per MoE layer, the communication flow with SP MoE enabled is:
+
+```text
+sequence_parallel_chunk
+  -> EP all-gather
+  -> unpad to the local token sizes of each rank
+  -> MoE compute
+  -> zero-pad back to the local sizes
+  -> EP reduce-scatter
+  -> upstream TP all-gather
+```
+
+DP ranks may hold uneven token counts, so the EP all-gather buffer must be
+unpadded by per-rank local sizes instead of being treated as a contiguous
+valid token sequence.
+
+At compile time, `compilation_config.pass_config.enable_sp` (implied by
+`fuse_gemm_comms`) lets the torch.compile sequence-parallelism fusion pass
+rewrite communication boundaries, guarded by the `sp_min_token_num` threshold
+derived from hidden size, TP size, and dtype. vLLM Ascend additionally derives
+`AscendConfig.enable_sp_by_pass` from this flag when graph compilation is
+active. At run time, cudagraph capture sizes are filtered to multiples of the
+TP size via `update_sizes_for_sequence_parallelism`.
 
 ## How to use
 
-Automatically enabled when DP>1, TP>1 are set, and specific all2all backend with moe model.
-The former FlashComm settings are removed.
+SP MoE needs no Ascend-specific model code. Configure the upstream parallel
+options:
 
-```text
-FlashComm is deprecated
+```bash
+vllm serve <moe-model> \
+  --data-parallel-size 2 \
+  --tensor-parallel-size 2 \
+  --enable-expert-parallel \
+  --all2all-backend allgather_reducescatter
 ```
 
-Use the upstream SP configuration shown above instead.
+Constraints:
+
+- SP requires `tensor_parallel_size > 1`; MoE models additionally require
+  `enable_expert_parallel`. Both are validated in `_validate_sfa_dcp_kv_sp`.
+- Cudagraph capture sizes must contain values that are multiples of the TP
+  size, otherwise server initialization fails.
+- Prefill Context Parallel (PCP) cannot be combined with SP.
+
+### Temporary FlashComm switch (Ascend only)
+
+Until SP support is fully validated, vLLM Ascend keeps SP MoE disabled by
+default: unless the temporary switch described below is on,
+`_setup_compile_backend` and `_setup_worker_and_scheduler` in
+`vllm_ascend/platform.py` override `all2all_backend` with
+`flashinfer_all2allv`, which is not an SP-capable backend, so
+`use_sequence_parallel_moe` stays false.
+
+To opt into upstream SP MoE, set one of the following (the
+`additional_config` form is preferred):
+
+```bash
+# Preferred.
+vllm serve <moe-model> \
+  --data-parallel-size 2 \
+  --tensor-parallel-size 2 \
+  --enable-expert-parallel \
+  --additional-config '{"enable_flashcomm1": true}'
+```
+
+```bash
+# Kept for compatibility.
+VLLM_ASCEND_ENABLE_FLASHCOMM1=1 vllm serve <moe-model> \
+  --data-parallel-size 2 \
+  --tensor-parallel-size 2 \
+  --enable-expert-parallel
+```
+
+This switch is temporary and deprecated. Referencing either form logs a
+`FlashComm is deprecated` warning from `init_ascend_config`, and the override
+carries a `TODO` to remove it once SP is supported — after that, the upstream
+configuration above takes effect directly. DSA-CP also depends on this switch
+(plus `pipeline_parallel_size == 1`); see the
+[Context Parallel Guide](context_parallel.md) for details.

--- a/docs/source/user_guide/feature_guide/sequence_parallelism.md
+++ b/docs/source/user_guide/feature_guide/sequence_parallelism.md
@@ -12,6 +12,8 @@ compute and communication under expert parallelism. SP MoE keeps the expert
 inputs sharded by sequence and restores the expected layout at the MoE output
 boundary instead.
 
+**The original flashcomm feature overlapped functionally with the SP feature and has been deprecated since v0.27.1.**
+
 ## Principle
 
 SP MoE shards the input along the token dimension at the MoE boundary in each
@@ -37,15 +39,10 @@ token size. This keeps tokens sequence-sharded during expert computation and
 reduces duplicate computation and unnecessary communication.
 
 ## How to use
-
-Upstream vLLM owns the SP MoE switch. `ParallelConfig.use_sequence_parallel_moe`
-is true only when all of the following hold:
-
+Steps to follow to enable SP currently：
 - `tensor_parallel_size > 1` and `data_parallel_size > 1`.
 - `enable_expert_parallel` is set (MoE models only).
-- `all2all_backend` is an SP-capable backend: `allgather_reducescatter`,
-  `deepep_high_throughput`, `deepep_low_latency`, `mori_high_throughput`,
-  `mori_low_latency`, or `nixl_ep`.
+- `--additional-config '{"enable_flashcomm1": true}'` set `flashcomm1` 
 
 ### Temporary FlashComm switch (Ascend only)
 
@@ -74,6 +71,4 @@ VLLM_ASCEND_ENABLE_FLASHCOMM1=1 vllm serve <moe-model> \
 This switch is temporary and deprecated. Referencing either form logs a
 `FlashComm is deprecated` warning from `init_ascend_config`, and the override
 carries a `TODO` to remove it once SP is supported — after that, the upstream
-configuration above takes effect directly. DSA-CP also depends on this switch
-(plus `pipeline_parallel_size == 1`); see the
-[Context Parallel Guide](context_parallel.md) for details.
+configuration above takes effect directly. 

--- a/docs/source/user_guide/feature_guide/sequence_parallelism.md
+++ b/docs/source/user_guide/feature_guide/sequence_parallelism.md
@@ -35,6 +35,9 @@ buffer after all-gather cannot be treated as a contiguous sequence of valid
 tokens; it must be unpadded and zero-padded according to each rank's local
 token size. This keeps tokens sequence-sharded during expert computation and
 reduces duplicate computation and unnecessary communication.
+
+## How to use
+
 Upstream vLLM owns the SP MoE switch. `ParallelConfig.use_sequence_parallel_moe`
 is true only when all of the following hold:
 
@@ -44,63 +47,9 @@ is true only when all of the following hold:
   `deepep_high_throughput`, `deepep_low_latency`, `mori_high_throughput`,
   `mori_low_latency`, or `nixl_ep`.
 
-`vllm_ascend.utils.enable_sp()` is a thin wrapper over this flag and drives the
-Ascend runtime behavior (SP padding, TP-aligned graph capture sizes, and the
-MoE communication path).
-
-Per MoE layer, the communication flow with SP MoE enabled is:
-
-```text
-sequence_parallel_chunk
-  -> EP all-gather
-  -> unpad to the local token sizes of each rank
-  -> MoE compute
-  -> zero-pad back to the local sizes
-  -> EP reduce-scatter
-  -> upstream TP all-gather
-```
-
-DP ranks may hold uneven token counts, so the EP all-gather buffer must be
-unpadded by per-rank local sizes instead of being treated as a contiguous
-valid token sequence.
-
-At compile time, `compilation_config.pass_config.enable_sp` (implied by
-`fuse_gemm_comms`) lets the torch.compile sequence-parallelism fusion pass
-rewrite communication boundaries, guarded by the `sp_min_token_num` threshold
-derived from hidden size, TP size, and dtype. vLLM Ascend additionally derives
-`AscendConfig.enable_sp_by_pass` from this flag when graph compilation is
-active. At run time, cudagraph capture sizes are filtered to multiples of the
-TP size via `update_sizes_for_sequence_parallelism`.
-
-## How to use
-
-SP MoE needs no Ascend-specific model code. Configure the upstream parallel
-options:
-
-```bash
-vllm serve <moe-model> \
-  --data-parallel-size 2 \
-  --tensor-parallel-size 2 \
-  --enable-expert-parallel \
-  --all2all-backend allgather_reducescatter
-```
-
-Constraints:
-
-- SP requires `tensor_parallel_size > 1`; MoE models additionally require
-  `enable_expert_parallel`. Both are validated in `_validate_sfa_dcp_kv_sp`.
-- Cudagraph capture sizes must contain values that are multiples of the TP
-  size, otherwise server initialization fails.
-- Prefill Context Parallel (PCP) cannot be combined with SP.
-
 ### Temporary FlashComm switch (Ascend only)
 
-Until SP support is fully validated, vLLM Ascend keeps SP MoE disabled by
-default: unless the temporary switch described below is on,
-`_setup_compile_backend` and `_setup_worker_and_scheduler` in
-`vllm_ascend/platform.py` override `all2all_backend` with
-`flashinfer_all2allv`, which is not an SP-capable backend, so
-`use_sequence_parallel_moe` stays false.
+Until SP support is fully validated, vLLM Ascend keeps SP MoE option by original flashcomm option.
 
 To opt into upstream SP MoE, set one of the following (the
 `additional_config` form is preferred):

--- a/docs/source/user_guide/feature_guide/sequence_parallelism.md
+++ b/docs/source/user_guide/feature_guide/sequence_parallelism.md
@@ -14,25 +14,27 @@ boundary instead.
 
 ## Principle
 
-SP MoE 在 Transformer 层的 MoE 边界沿 token 维度切分输入，使不同 TP rank
-分别处理不同的 token，避免各 rank 对同一批 token 重复执行专家计算。
+SP MoE shards the input along the token dimension at the MoE boundary in each
+Transformer layer. Different TP ranks therefore process different tokens,
+avoiding duplicate expert computation for the same tokens.
 
-一次 MoE 层的主要数据流如下：
+The main data flow of an MoE layer is:
 
 ```text
-按序列切分输入
-  -> EP all-gather：收集各 rank 的 token
-  -> 按各 rank 的实际 token 数 unpad
-  -> 路由、dispatch 和专家计算
-  -> 按实际 token 数 zero-pad
-  -> EP reduce-scatter：重新分发 token
-  -> TP all-gather：恢复后续层所需的布局
+Sequence-parallel input sharding
+  -> EP all-gather: collect tokens from all ranks
+  -> Unpad according to each rank's actual token count
+  -> Routing, dispatch, and expert computation
+  -> Zero-pad according to the actual token counts
+  -> EP reduce-scatter: redistribute tokens
+  -> TP all-gather: restore the layout required by subsequent layers
 ```
 
-由于不同 DP rank 的有效 token 数可能不同，all-gather 后的 buffer 不能直接
-当作连续的有效 token 使用，必须依据每个 rank 的 local token size 进行
-unpad 和 zero-pad。这样可以让 token 在专家计算期间保持序列分片，减少
-重复计算和不必要的通信。
+Different DP ranks may have different numbers of valid tokens. Therefore, the
+buffer after all-gather cannot be treated as a contiguous sequence of valid
+tokens; it must be unpadded and zero-padded according to each rank's local
+token size. This keeps tokens sequence-sharded during expert computation and
+reduces duplicate computation and unnecessary communication.
 Upstream vLLM owns the SP MoE switch. `ParallelConfig.use_sequence_parallel_moe`
 is true only when all of the following hold:
 

--- a/docs/source/user_guide/feature_guide/sequence_parallelism.md
+++ b/docs/source/user_guide/feature_guide/sequence_parallelism.md
@@ -39,10 +39,12 @@ token size. This keeps tokens sequence-sharded during expert computation and
 reduces duplicate computation and unnecessary communication.
 
 ## How to use
-Steps to follow to enable SP currently：
+
+Steps to follow to enable SP currently:
+
 - `tensor_parallel_size > 1` and `data_parallel_size > 1`.
 - `enable_expert_parallel` is set (MoE models only).
-- `--additional-config '{"enable_flashcomm1": true}'` set `flashcomm1` 
+- `--additional-config '{"enable_flashcomm1": true}'` set `flashcomm1`
 
 ### Temporary FlashComm switch (Ascend only)
 
@@ -71,4 +73,4 @@ VLLM_ASCEND_ENABLE_FLASHCOMM1=1 vllm serve <moe-model> \
 This switch is temporary and deprecated. Referencing either form logs a
 `FlashComm is deprecated` warning from `init_ascend_config`, and the override
 carries a `TODO` to remove it once SP is supported — after that, the upstream
-configuration above takes effect directly. 
+configuration above takes effect directly.

--- a/docs/source/user_guide/feature_guide/sequence_parallelism.md
+++ b/docs/source/user_guide/feature_guide/sequence_parallelism.md
@@ -14,6 +14,25 @@ boundary instead.
 
 ## Principle
 
+SP MoE 在 Transformer 层的 MoE 边界沿 token 维度切分输入，使不同 TP rank
+分别处理不同的 token，避免各 rank 对同一批 token 重复执行专家计算。
+
+一次 MoE 层的主要数据流如下：
+
+```text
+按序列切分输入
+  -> EP all-gather：收集各 rank 的 token
+  -> 按各 rank 的实际 token 数 unpad
+  -> 路由、dispatch 和专家计算
+  -> 按实际 token 数 zero-pad
+  -> EP reduce-scatter：重新分发 token
+  -> TP all-gather：恢复后续层所需的布局
+```
+
+由于不同 DP rank 的有效 token 数可能不同，all-gather 后的 buffer 不能直接
+当作连续的有效 token 使用，必须依据每个 rank 的 local token size 进行
+unpad 和 zero-pad。这样可以让 token 在专家计算期间保持序列分片，减少
+重复计算和不必要的通信。
 Upstream vLLM owns the SP MoE switch. `ParallelConfig.use_sequence_parallel_moe`
 is true only when all of the following hold:
 

--- a/docs/source/user_guide/feature_guide/sequence_parallelism.md
+++ b/docs/source/user_guide/feature_guide/sequence_parallelism.md
@@ -16,7 +16,7 @@ boundary instead.
 
 ## Principle
 
-SP MoE shards the input along the token dimension at the MoE boundary in each
+SP MoE shards the input along the token dimension in each
 Transformer layer. Different TP ranks therefore process different tokens,
 avoiding duplicate expert computation for the same tokens.
 
@@ -24,12 +24,13 @@ The main data flow of an MoE layer is:
 
 ```text
 Sequence-parallel input sharding
-  -> EP all-gather: collect tokens from all ranks
-  -> Unpad according to each rank's actual token count
-  -> Routing, dispatch, and expert computation
-  -> Zero-pad according to the actual token counts
-  -> EP reduce-scatter: redistribute tokens
-  -> TP all-gather: restore the layout required by subsequent layers
+  -> TP all-gather: collect tokens from all ranks
+  -> attention
+  -> TP reduce scatter
+  -> RMS Norm
+  -> Router
+  -> all-to-all
+  -> Moe
 ```
 
 Different DP ranks may have different numbers of valid tokens. Therefore, the

--- a/vllm_ascend/ops/register_custom_ops.py
+++ b/vllm_ascend/ops/register_custom_ops.py
@@ -41,15 +41,15 @@ def _pad_to_ep_local_size(x: torch.Tensor, max_local_size: int) -> torch.Tensor:
 
 
 def _maybe_all_gather_and_maybe_unpad_impl(x: torch.Tensor) -> torch.Tensor:
-    """仅用于 EP 通信场景：EP all_gather + 按 DP token 分布 unpad。"""
+    """EP communication only: EP all_gather followed by unpad according to the DP token distribution."""
     forward_context = get_forward_context()
     dp_metadata = forward_context.dp_metadata
     ep_group = get_ep_group()
     local_sizes = _get_ep_local_sizes(dp_metadata, ep_group)
     if local_sizes is not None:
         max_local_size = max(local_sizes)
-        # all_gather 要求各 rank 输入等长：先 pad 到 max_local_size，
-        # gather 后再按各 rank 真实的 local_sizes 截回。
+        # all_gather requires equal-length inputs on every rank: pad to
+        # max_local_size first, then trim back to each rank's real local size.
         x = _pad_to_ep_local_size(x, max_local_size)
     # need to unpad from ep size
     x = ep_group.all_gather(x, 0)
@@ -73,7 +73,7 @@ def _maybe_all_gather_and_maybe_unpad_impl(x: torch.Tensor) -> torch.Tensor:
 
 
 def _maybe_pad_and_reduce_impl(x: torch.Tensor) -> torch.Tensor:
-    """仅用于 EP 通信场景：按 DP token 分布 pad 后做 EP reduce_scatter。"""
+    """EP communication only: pad according to the DP token distribution, then EP reduce_scatter."""
     forward_context = get_forward_context()
 
     if _EXTRA_CTX.is_draft_model and is_vl_model():


### PR DESCRIPTION
### What this PR does / why we need it?

Completes the `sequence_parallelism.md` feature guide, which currently only has
an Overview skeleton plus a stale "FlashComm is deprecated" note. The new content
covers SP MoE end to end:

- Principle: upstream `ParallelConfig.use_sequence_parallel_moe` activation
  conditions (TP>1, DP>1, `enable_expert_parallel`, SP-capable `all2all_backend`),
  the per-layer EP all-gather/unpad -> MoE -> pad/reduce-scatter -> TP all-gather
  flow, and the compile-time (`pass_config.enable_sp`, `sp_min_token_num`,
  `enable_sp_by_pass`) / run-time (TP-aligned cudagraph sizes) behavior.
- How to use: upstream serve flags, constraints (TP>1, EP required for MoE,
  TP-multiple capture sizes, PCP incompatibility).
- The temporary Ascend-only FlashComm switch: by default the platform forces
  `all2all_backend=flashinfer_all2allv` (SP MoE off); setting
  `additional_config.enable_flashcomm1` (preferred) or
  `VLLM_ASCEND_ENABLE_FLASHCOMM1=1` opts into upstream SP MoE. Documents that the
  switch is temporary/deprecated and will be removed once SP is supported.

### Does this PR introduce _any_ user-facing change?

Documentation only. No code behavior change.

### How was this patch tested?

- `markdownlint docs/source/user_guide/feature_guide/sequence_parallelism.md` passes.
- No code changed, so no unit/e2e tests apply.

- vLLM main: https://github.com/vllm-project/vllm/commit/b2f685834a6456197e7033966fdef52a23f1abcd
