### PR TITLE
[v0.26.0rc][Ops][Feature] Add fastokens==0.3.1 dependency to enable VLLM_USE_FASTOKENS

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,8 @@ requires = [
     "fastapi<0.124.0",
     "compressed_tensors>=0.11.0",
     "arctic-inference==0.1.1",
-    "triton-ascend==3.2.2"
+    "triton-ascend==3.2.2",
+    "fastokens==0.3.1"
 ]
 build-backend = "setuptools.build_meta"
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -37,3 +37,6 @@ memcache_hybrid==1.2.0
 arctic-inference==0.1.1
 transformers==5.14.1
 fastapi<0.124.0
+
+# Required for VLLM_USE_FASTOKENS accelerated tokenizer
+fastokens==0.3.1


### PR DESCRIPTION
### What this PR does / why we need it?

Upstream vLLM already supports the fastokens accelerated tokenizer behind `VLLM_USE_FASTOKENS=1`, but current v0.26.0rc vllm-ascend images do not ship the dependency, so enabling the flag fails with ImportError (same gap as upstream vllm issue #47855 for the NVIDIA images).

This PR adds `fastokens==0.3.1` (latest release, ships aarch64 `manylinux_2_28` wheels) to `requirements.txt` and mirrors it in `pyproject.toml` per the repository dependency policy.

Note on relation to #15361: that PR pins the older 0.2.0. This PR pins 0.3.1, which is the version validated below.

### Does this PR introduce _any_ user-facing change?

Yes. With this PR, newly built v0.26.0rc vllm-ascend images include fastokens 0.3.1, making `VLLM_USE_FASTOKENS=1` usable out of the box. Current v0.26.0rc images do not include it.

### How was this patch tested?

fastokens 0.3.1 was manually installed into a running v0.26.0rc1-a3 deployment and validated on a DeepSeek-V4-Flash PD-disaggregated environment (Ascend A3, 3P + 1D, dspark MTP5):

- fastokens==0.3.1 installs cleanly on aarch64 via the `manylinux_2_28` wheel
- `VLLM_USE_FASTOKENS=1` starts without ImportError
- End-to-end streaming chat completions verified through the PD proxy (thinking on/off, 100K+ token prompts)