### PR TITLE
[Bugfix][MRV2][SpecDecode] fix draft Gumbel noise stream and add draft logits cache

### DIFF
--- a/tests/e2e/nightly/single_node/ops/singlecard_ops/triton/test_rejection_sample_v2.py
+++ b/tests/e2e/nightly/single_node/ops/singlecard_ops/triton/test_rejection_sample_v2.py
@@ -3,11 +3,13 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
 import gc
+import math
 
 import pytest
 import torch
 from vllm.v1.spec_decode.utils import unconditional_to_conditional_rates
 
+from vllm_ascend.worker.v2.sample.gumbel import gumbel_sample
 from vllm_ascend.worker.v2.spec_decode.rejection_sampler_utils import rejection_sample
 
 VOCAB_SIZE = 4096
@@ -67,6 +69,62 @@ def _build_rejection_sample_inputs(
         expanded_local_pos=expanded_local_pos,
         temperature=temp_tensor,
         seed=seed,
+    )
+
+
+def _assert_distribution_match(
+    sampled_tokens: torch.Tensor,
+    target_probs: torch.Tensor,
+    device: str,
+    label: str = "",
+    min_expected: float = 5.0,
+):
+    """
+    Assert sampled tokens match the target distribution via a
+    chi-squared goodness-of-fit test. This is done by computing
+    observed vs expected token counts (target_probs * num_samples),
+    then checking that the chi-squared statistic is below a conservative
+    threshold. The threshold is set at df + 10*sqrt(2*df), which
+    corresponds to ~10 sigma under the chi-squared distribution's
+    normal approximation, effectively disallowing false positives.
+
+    NOTE: Tokens with expected count < min_expected are merged into
+    a single "other" bin to minimize chi-squared noise.
+    """
+    num_samples = sampled_tokens.shape[0]
+    vocab_size = target_probs.shape[0]
+
+    observed = torch.zeros(vocab_size, device=device, dtype=torch.float32)
+    observed.scatter_add_(0, sampled_tokens, torch.ones(num_samples, device=device))
+    expected = target_probs * num_samples
+
+    sufficient = expected >= min_expected
+    obs_main = observed[sufficient]
+    exp_main = expected[sufficient]
+
+    obs_other = observed[~sufficient].sum().unsqueeze(0)
+    exp_other = expected[~sufficient].sum().unsqueeze(0)
+
+    if exp_other.item() >= min_expected:
+        obs_all = torch.cat([obs_main, obs_other])
+        exp_all = torch.cat([exp_main, exp_other])
+    else:
+        obs_all = obs_main
+        exp_all = exp_main
+
+    chi2 = ((obs_all - exp_all) ** 2 / exp_all).sum().item()
+    df = obs_all.shape[0] - 1
+    if df < 1:
+        # All samples were merged into < 2 bins, which is too
+        # few to evaluate.
+        return
+
+    threshold = df + 10 * math.sqrt(2 * df)
+    prefix = f"[{label}] " if label else ""
+    assert chi2 < threshold, (
+        f"{prefix}Chi-squared test failed: chi2={chi2:.1f}, "
+        f"df={df}, threshold={threshold:.1f}. "
+        f"Output distribution does not match target distribution."
     )
 
 
@@ -150,6 +208,97 @@ def test_synthetic_rejection_sample(
             f"Step {i}: observed rate {observed_rate:.4f} deviates from "
             f"expected rate {expected_rate:.4f} by more than {deviation_tol}."
         )
+
+    gc.collect()
+    torch.npu.empty_cache()
+
+
+# The wide-vocab stochastic tests above spread their samples too thin to
+# resolve a small distributional bias, so this test runs narrow: 16 bins over
+# 200K trials is ~12K per bin, which resolves a few percent.
+NARROW_VOCAB_SIZE = 16
+NARROW_NUM_TRIALS = 200_000
+
+
+def _gumbel_drafted_tokens(
+    inputs: dict,
+    draft_logits_1d: torch.Tensor,
+    num_trials: int,
+    num_speculative_steps: int,
+) -> torch.Tensor:
+    """Proposals drawn with gumbel_sample, shaped like inputs["draft_sampled"].
+
+    _build_rejection_sample_inputs draws them with torch.multinomial, which is
+    independent of the resample noise by construction. Production drafts come
+    from gumbel_sample keyed by pos[t * (K + 1) + i] for step i of trial t --
+    the same entry _rejection_kernel and _resample_kernel read for that token --
+    so the draft and the residual compete for one noise stream.
+
+    NPU: pos is int32 (triton-ascend philox), matching the pos tensor built by
+    _build_rejection_sample_inputs.
+    """
+    k = num_speculative_steps
+    vocab_size = draft_logits_1d.shape[0]
+    device = draft_logits_1d.device
+    draft_tokens = gumbel_sample(
+        draft_logits_1d.unsqueeze(0).expand(num_trials * k, vocab_size).float(),
+        inputs["expanded_idx_mapping"].view(num_trials, k + 1)[:, :k].reshape(-1).contiguous(),
+        inputs["temperature"],
+        inputs["seed"],
+        inputs["pos"].view(num_trials, k + 1)[:, :k].reshape(-1).contiguous(),
+        apply_temperature=True,
+        is_drafting=True,
+    )
+    draft_sampled = torch.zeros(num_trials * (k + 1), dtype=torch.int64, device=device)
+    draft_sampled.view(num_trials, k + 1)[:, 1:] = draft_tokens.view(num_trials, k)
+    return draft_sampled
+
+
+@pytest.mark.parametrize("num_speculative_steps", [1, 3])
+@torch.inference_mode()
+def test_gumbel_drafted_rejection_sample_is_unbiased(num_speculative_steps: int):
+    """The proposal and the residual resample must not share a noise vector.
+
+    Draws proposals on the same (seed, pos) stream the sampler verifies and
+    resamples with, then checks the output still follows the target. Conditioned
+    on a proposal winning the argmax, every other token's Gumbel is truncated
+    below that max -- most tightly for the tokens the draft ranked highest --
+    so a shared stream makes the residual under-weight exactly those tokens.
+
+    Runs narrow because the wide-vocab test above cannot resolve this: dropping
+    `is_drafting=True` in _gumbel_drafted_tokens takes position 0 from chi2 ~12
+    to ~1500 against a threshold of ~70 here, while leaving that test passing.
+    """
+    torch.manual_seed(42)
+    device = "npu"
+
+    # A draft that ranks tokens in exactly the opposite order rejects ~73% of
+    # proposals, so most trials reach the residual resample where the bias
+    # lives. The disagreement has to be constructed rather than sampled: two
+    # independent randn draws land close together often enough that the signal
+    # swings between chi2 ~14 and ~1900 depending on the seed. At temperature
+    # 1.0 the target needs no scaling before being passed in.
+    target_logits_1d = torch.randn(NARROW_VOCAB_SIZE, device=device, dtype=torch.float32)
+    draft_logits_1d = -target_logits_1d
+
+    inputs = _build_rejection_sample_inputs(
+        target_logits_1d,
+        draft_logits_1d,
+        num_speculative_steps,
+        temperature=1.0,
+        num_trials=NARROW_NUM_TRIALS,
+    )
+    inputs["draft_sampled"] = _gumbel_drafted_tokens(inputs, draft_logits_1d, NARROW_NUM_TRIALS, num_speculative_steps)
+
+    sampled, num_sampled = rejection_sample(**inputs, num_speculative_steps=num_speculative_steps)
+
+    # Position 0 carries the power: every trial reaches it, while later
+    # positions are only reached on acceptance, which is rare by construction.
+    assert (num_sampled >= 1).all()
+    target_probs = torch.softmax(target_logits_1d, dim=0)
+    for pos in range(num_speculative_steps + 1):
+        accepted_mask = num_sampled >= pos + 1
+        _assert_distribution_match(sampled[accepted_mask, pos], target_probs, device, label=f"position {pos}")
 
     gc.collect()
     torch.npu.empty_cache()

--- a/tests/e2e/pull_request/one_card/test_gumbel_sampling.py
+++ b/tests/e2e/pull_request/one_card/test_gumbel_sampling.py
@@ -7,10 +7,14 @@
 # Tests for vllm_ascend.worker.v2.sample.gumbel on Ascend NPU.
 # Validates gumbel_sample and apply_temperature against PyTorch references.
 
+import math
+
 import pytest
 import torch
+from vllm.triton_utils import tl, triton
 
 from vllm_ascend.worker.v2.sample.gumbel import apply_temperature, gumbel_sample
+from vllm_ascend.worker.v2.spec_decode.rejection_sampler_utils import _npu_gumbel_block_argmax
 
 DEVICE = "npu"
 
@@ -95,7 +99,9 @@ class TestGumbelSampling:
         seed = torch.randint(0, 2**31, (num_reqs,), dtype=torch.int64, device=DEVICE)
         pos = torch.arange(num_tokens, dtype=torch.int32, device=DEVICE)
 
-        sampled = gumbel_sample(logits, expanded_idx_mapping, temperature, seed, pos, apply_temperature=False)
+        sampled = gumbel_sample(
+            logits, expanded_idx_mapping, temperature, seed, pos, apply_temperature=False, is_drafting=False
+        )
         torch.npu.synchronize()
 
         expected = logits.argmax(dim=-1)
@@ -113,8 +119,12 @@ class TestGumbelSampling:
         seed = torch.randint(0, 2**31, (num_reqs,), dtype=torch.int64, device=DEVICE)
         pos = torch.arange(num_tokens, dtype=torch.int32, device=DEVICE)
 
-        s_false = gumbel_sample(logits, expanded_idx_mapping, temperature, seed, pos, apply_temperature=False)
-        s_true = gumbel_sample(logits, expanded_idx_mapping, temperature, seed, pos, apply_temperature=True)
+        s_false = gumbel_sample(
+            logits, expanded_idx_mapping, temperature, seed, pos, apply_temperature=False, is_drafting=False
+        )
+        s_true = gumbel_sample(
+            logits, expanded_idx_mapping, temperature, seed, pos, apply_temperature=True, is_drafting=False
+        )
         torch.npu.synchronize()
 
         expected = logits.argmax(dim=-1)
@@ -138,9 +148,13 @@ class TestGumbelSampling:
         seed = torch.randint(0, 2**31, (num_reqs,), dtype=torch.int64, device=DEVICE)
         pos = torch.arange(num_tokens, dtype=torch.int32, device=DEVICE)
 
-        r1 = gumbel_sample(logits, expanded_idx_mapping, temperature, seed, pos, apply_temperature=False)
+        r1 = gumbel_sample(
+            logits, expanded_idx_mapping, temperature, seed, pos, apply_temperature=False, is_drafting=False
+        )
         torch.npu.synchronize()
-        r2 = gumbel_sample(logits, expanded_idx_mapping, temperature, seed, pos, apply_temperature=False)
+        r2 = gumbel_sample(
+            logits, expanded_idx_mapping, temperature, seed, pos, apply_temperature=False, is_drafting=False
+        )
         torch.npu.synchronize()
 
         assert torch.equal(r1, r2), "gumbel_sample is non-deterministic with same seed"
@@ -159,8 +173,12 @@ class TestGumbelSampling:
         # Ensure seeds differ
         seed2[0] = seed1[0] + 1
 
-        r1 = gumbel_sample(logits, expanded_idx_mapping, temperature, seed1, pos, apply_temperature=False)
-        r2 = gumbel_sample(logits, expanded_idx_mapping, temperature, seed2, pos, apply_temperature=False)
+        r1 = gumbel_sample(
+            logits, expanded_idx_mapping, temperature, seed1, pos, apply_temperature=False, is_drafting=False
+        )
+        r2 = gumbel_sample(
+            logits, expanded_idx_mapping, temperature, seed2, pos, apply_temperature=False, is_drafting=False
+        )
         torch.npu.synchronize()
 
         # With 16 tokens and vocab 32000 at temp=1.0, identical results are astronomically unlikely
@@ -183,7 +201,9 @@ class TestGumbelSampling:
         seed = torch.randint(0, 2**31, (num_reqs,), dtype=torch.int64, device=DEVICE)
         pos = torch.arange(num_tokens, dtype=torch.int32, device=DEVICE)
 
-        sampled = gumbel_sample(logits, expanded_idx_mapping, temperature, seed, pos, apply_temperature=False)
+        sampled = gumbel_sample(
+            logits, expanded_idx_mapping, temperature, seed, pos, apply_temperature=False, is_drafting=False
+        )
         torch.npu.synchronize()
 
         assert sampled.shape == (num_tokens,)
@@ -215,10 +235,22 @@ class TestGumbelSampling:
             pos = torch.tensor([i], dtype=torch.int32, device=DEVICE)
 
             s_low = gumbel_sample(
-                logits_base.clone(), expanded_idx_mapping, low_temp, seed, pos, apply_temperature=True
+                logits_base.clone(),
+                expanded_idx_mapping,
+                low_temp,
+                seed,
+                pos,
+                apply_temperature=True,
+                is_drafting=False,
             )
             s_high = gumbel_sample(
-                logits_base.clone(), expanded_idx_mapping, high_temp, seed, pos, apply_temperature=True
+                logits_base.clone(),
+                expanded_idx_mapping,
+                high_temp,
+                seed,
+                pos,
+                apply_temperature=True,
+                is_drafting=False,
             )
             if s_low.item() == 0:
                 low_temp_winner_count += 1
@@ -255,7 +287,9 @@ class TestGumbelSampling:
         seed = torch.randint(0, 2**31, (num_tokens,), dtype=torch.int64, device=DEVICE)
         pos = torch.arange(num_tokens, dtype=torch.int32, device=DEVICE)
 
-        sampled = gumbel_sample(logits, expanded_idx_mapping, temperature, seed, pos, apply_temperature=False)
+        sampled = gumbel_sample(
+            logits, expanded_idx_mapping, temperature, seed, pos, apply_temperature=False, is_drafting=False
+        )
         torch.npu.synchronize()
 
         greedy = logits.argmax(dim=-1)
@@ -278,7 +312,9 @@ class TestGumbelSampling:
         seed = torch.randint(0, 2**31, (num_reqs,), dtype=torch.int64, device=DEVICE)
         pos = torch.arange(num_tokens, dtype=torch.int32, device=DEVICE)
 
-        sampled = gumbel_sample(logits, expanded_idx_mapping, temperature, seed, pos, apply_temperature=False)
+        sampled = gumbel_sample(
+            logits, expanded_idx_mapping, temperature, seed, pos, apply_temperature=False, is_drafting=False
+        )
         torch.npu.synchronize()
 
         expected = logits.argmax(dim=-1)
@@ -303,7 +339,9 @@ class TestGumbelSampling:
         # Same pos -> same Gumbel noise
         pos = torch.tensor([5, 5], dtype=torch.int32, device=DEVICE)
 
-        sampled = gumbel_sample(logits, expanded_idx_mapping, temperature, seed, pos, apply_temperature=True)
+        sampled = gumbel_sample(
+            logits, expanded_idx_mapping, temperature, seed, pos, apply_temperature=True, is_drafting=False
+        )
         torch.npu.synchronize()
 
         assert sampled[0].item() == sampled[1].item(), (
@@ -313,7 +351,9 @@ class TestGumbelSampling:
 
     def test_gumbel_sample_apply_temperature_true_nonzero(self):
         """apply_temperature=True with temp>0 must divide logits by temperature
-        before adding Gumbel noise. Verify via processed_logits output."""
+        before adding Gumbel noise. The logits cache stores the input logits
+        *before* temperature; consumers (the rejection sampler) divide by the
+        same temperature on load."""
         torch.manual_seed(77)
         num_tokens, num_reqs, vocab_size = 4, 4, 32000
         logits = torch.randn(num_tokens, vocab_size, dtype=torch.float32, device=DEVICE)
@@ -322,7 +362,6 @@ class TestGumbelSampling:
         seed = torch.randint(0, 2**31, (num_reqs,), dtype=torch.int64, device=DEVICE)
         pos = torch.arange(num_tokens, dtype=torch.int32, device=DEVICE)
 
-        # Use processed_logits to verify temperature was applied
         out_logits = torch.zeros(num_reqs, vocab_size, dtype=torch.float32, device=DEVICE)
         gumbel_sample(
             logits,
@@ -331,21 +370,22 @@ class TestGumbelSampling:
             seed,
             pos,
             apply_temperature=True,
-            output_processed_logits=out_logits,
+            is_drafting=False,
+            logits_cache=out_logits,
         )
         torch.npu.synchronize()
 
         for tok in range(num_tokens):
             req = expanded_idx_mapping[tok].item()
-            temp = temperature[req].item()
-            expected = logits[tok].float() / temp
+            # The cache stores the pre-temperature logits.
+            expected = logits[tok].float()
             assert torch.allclose(out_logits[req].float(), expected, atol=1e-4, rtol=1e-4), (
-                f"processed_logits mismatch at token {tok} (req {req}, temp={temp:.3f}): "
+                f"logits_cache mismatch at token {tok} (req {req}): "
                 f"max_diff={(out_logits[req].float() - expected).abs().max().item():.6f}"
             )
 
     def test_gumbel_sample_apply_temperature_false_nonzero(self):
-        """apply_temperature=False with temp>0: processed_logits must contain
+        """apply_temperature=False with temp>0: the logits cache must contain
         raw logits (no temperature division), but Gumbel noise is still added
         to sampling."""
         torch.manual_seed(78)
@@ -364,7 +404,8 @@ class TestGumbelSampling:
             seed,
             pos,
             apply_temperature=False,
-            output_processed_logits=out_logits,
+            is_drafting=False,
+            logits_cache=out_logits,
         )
         torch.npu.synchronize()
 
@@ -373,12 +414,12 @@ class TestGumbelSampling:
             # Without temperature application, stored logits should match raw logits
             expected = logits[tok].float()
             assert torch.allclose(out_logits[req].float(), expected, atol=1e-4, rtol=1e-4), (
-                f"processed_logits should be raw logits when apply_temperature=False: "
+                f"logits_cache should be raw logits when apply_temperature=False: "
                 f"max_diff={(out_logits[req].float() - expected).abs().max().item():.6f}"
             )
 
-    def test_gumbel_sample_processed_logits_req_state_idx(self):
-        """Processed logits must be stored at req_state_idx position, not token_idx.
+    def test_gumbel_sample_logits_cache_req_state_idx(self):
+        """Cached logits must be stored at req_state_idx position, not token_idx.
 
         This tests the EAGLE speculative decoding scenario where the idx_mapping
         is non-contiguous (e.g., active requests [2,5,7,0] out of 8 slots).
@@ -405,17 +446,18 @@ class TestGumbelSampling:
             seed,
             pos,
             apply_temperature=True,
-            output_processed_logits=out_logits,
+            is_drafting=False,
+            logits_cache=out_logits,
         )
         torch.npu.synchronize()
 
         for tok in range(num_tokens):
             req = expanded_idx_mapping[tok].item()
-            temp = temperature[req].item()
-            expected = logits[tok].float() / temp
+            # The cache stores the pre-temperature logits.
+            expected = logits[tok].float()
             actual = out_logits[req]
             assert torch.allclose(actual.float(), expected, atol=1e-4, rtol=1e-4), (
-                f"Req {req} (tok={tok}, temp={temp:.3f}): max_diff={(actual.float() - expected).abs().max().item():.6f}"
+                f"Req {req} (tok={tok}): max_diff={(actual.float() - expected).abs().max().item():.6f}"
             )
 
         # Also verify that unused request slots remain zero
@@ -424,8 +466,8 @@ class TestGumbelSampling:
             if req not in used_reqs:
                 assert (out_logits[req] == 0).all(), f"Unused request slot {req} should be all zeros"
 
-    def test_gumbel_sample_processed_logits_col(self):
-        """output_processed_logits_col selects which column (draft step) to write.
+    def test_gumbel_sample_logits_cache_col(self):
+        """logits_cache_col selects which column (draft step) to write.
 
         Simulates EAGLE with buffer [max_num_reqs, num_steps, vocab_size].
         """
@@ -453,15 +495,16 @@ class TestGumbelSampling:
             seed,
             pos,
             apply_temperature=True,
-            output_processed_logits=draft_logits,
-            output_processed_logits_col=col_tensor,
+            is_drafting=False,
+            logits_cache=draft_logits,
+            logits_cache_col=col_tensor,
         )
         torch.npu.synchronize()
 
         for tok in range(num_tokens):
             req = expanded_idx_mapping[tok].item()
-            temp = temperature[req].item()
-            expected = logits[tok].float() / temp
+            # The cache stores the pre-temperature logits.
+            expected = logits[tok].float()
             # Data should be at draft_logits[req, 1, :]  (column 1)
             actual = draft_logits[req, 1, :]
             assert torch.allclose(actual.float(), expected, atol=1e-4, rtol=1e-4), (
@@ -471,12 +514,11 @@ class TestGumbelSampling:
             assert (draft_logits[req, 0, :] == 0).all(), f"Col 0 should be zeros for req {req}"
             assert (draft_logits[req, 2, :] == 0).all(), f"Col 2 should be zeros for req {req}"
 
-    def test_gumbel_sample_processed_logits_mixed_temp(self):
-        """Processed logits with mixed temperature (1:1 token-to-request mapping):
-        - temp=0: stored logits should be raw (no scaling)
-        - temp>0 with apply_temperature=True: stored logits should be logits/temp
+    def test_gumbel_sample_logits_cache_mixed_temp(self):
+        """Cached logits with mixed temperature (1:1 token-to-request mapping):
+        the cache always stores the raw input logits regardless of temperature.
 
-        Note: In practice, output_processed_logits is only used by EAGLE
+        Note: In practice, the logits cache is only used by EAGLE
         speculative decoding, which always has 1:1 token-to-request mapping.
         Multiple tokens per request would cause a write race (undefined order).
         """
@@ -500,20 +542,18 @@ class TestGumbelSampling:
             seed,
             pos,
             apply_temperature=True,
-            output_processed_logits=out_logits,
+            is_drafting=False,
+            logits_cache=out_logits,
         )
         torch.npu.synchronize()
 
         for tok in range(num_tokens):
             req = expanded_idx_mapping[tok].item()
-            temp = temperature[req].item()
-            if temp == 0.0:
-                expected = logits[tok].float()
-            else:
-                expected = logits[tok].float() / temp
+            # The cache stores the pre-temperature logits.
+            expected = logits[tok].float()
             actual = out_logits[req]
             assert torch.allclose(actual.float(), expected, atol=1e-4, rtol=1e-4), (
-                f"Req {req} (tok={tok}, temp={temp:.3f}): max_diff={(actual.float() - expected).abs().max().item():.6f}"
+                f"Req {req} (tok={tok}): max_diff={(actual.float() - expected).abs().max().item():.6f}"
             )
 
     def test_gumbel_sample_single_token(self):
@@ -525,7 +565,9 @@ class TestGumbelSampling:
         seed = torch.tensor([12345], dtype=torch.int64, device=DEVICE)
         pos = torch.tensor([0], dtype=torch.int32, device=DEVICE)
 
-        sampled = gumbel_sample(logits, expanded_idx_mapping, temperature, seed, pos, apply_temperature=True)
+        sampled = gumbel_sample(
+            logits, expanded_idx_mapping, temperature, seed, pos, apply_temperature=True, is_drafting=False
+        )
         torch.npu.synchronize()
 
         assert sampled.shape == (1,)
@@ -542,7 +584,9 @@ class TestGumbelSampling:
         seed = torch.randint(0, 2**31, (num_tokens,), dtype=torch.int64, device=DEVICE)
         pos = torch.arange(num_tokens, dtype=torch.int32, device=DEVICE)
 
-        sampled = gumbel_sample(logits, expanded_idx_mapping, temperature, seed, pos, apply_temperature=False)
+        sampled = gumbel_sample(
+            logits, expanded_idx_mapping, temperature, seed, pos, apply_temperature=False, is_drafting=False
+        )
         torch.npu.synchronize()
 
         expected = logits.argmax(dim=-1)
@@ -559,12 +603,428 @@ class TestGumbelSampling:
 
         # Very low temperature (near-greedy)
         low_temp = torch.tensor([0.01, 0.01, 0.01, 0.01], dtype=torch.float32, device=DEVICE)
-        s1 = gumbel_sample(logits, expanded_idx_mapping, low_temp, seed, pos, apply_temperature=True)
+        s1 = gumbel_sample(logits, expanded_idx_mapping, low_temp, seed, pos, apply_temperature=True, is_drafting=False)
         torch.npu.synchronize()
         assert (s1 >= 0).all() and (s1 < vocab_size).all()
 
         # Very high temperature (near-uniform)
         high_temp = torch.tensor([100.0, 100.0, 100.0, 100.0], dtype=torch.float32, device=DEVICE)
-        s2 = gumbel_sample(logits, expanded_idx_mapping, high_temp, seed, pos, apply_temperature=True)
+        s2 = gumbel_sample(
+            logits, expanded_idx_mapping, high_temp, seed, pos, apply_temperature=True, is_drafting=False
+        )
         torch.npu.synchronize()
         assert (s2 >= 0).all() and (s2 < vocab_size).all()
+
+
+def _float_bits(t: torch.Tensor) -> torch.Tensor:
+    """Reinterpret floats as same-width ints, so equality is truly bitwise."""
+    int_dtype = torch.int32 if t.dtype == torch.float32 else torch.int16
+    return t.view(int_dtype)
+
+
+class TestGumbelSampleLogitsCache:
+    """Regression tests for the draft logits cache (upstream #50910)."""
+
+    @pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float16, torch.float32])
+    @pytest.mark.parametrize("per_token_col", [False, True])
+    def test_logits_cache_stores_input_logits_bitwise(self, dtype: torch.dtype, per_token_col: bool):
+        """`logits_cache` must receive the input logits, pre-temperature and bit-exact.
+
+        The cache is kept in the head's dtype, which is only lossless because the
+        stored value is the input logit itself. Storing `logit / temp` instead would
+        generally not be representable there, and the rejection sampler -- which
+        divides by the same temperature on load -- would then verify against a `q`
+        the draft never sampled from. Temperatures 0.0 and 1.0 are included because
+        both make the divide a no-op and would mask such a bug.
+
+        Both column-addressing modes are covered: a 0-d column (one draft step per
+        call, as MTP/EAGLE do) and a [num_tokens] column (as DFlash does, sampling
+        every step in one call).
+        """
+        torch.manual_seed(0)
+        num_reqs, vocab_size, num_steps = 8, 4099, 3
+        logits = torch.randn(num_reqs, vocab_size, device=DEVICE, dtype=dtype)
+        idx_mapping = torch.arange(num_reqs, dtype=torch.int32, device=DEVICE)
+        temp = torch.tensor([0.0, 0.1, 0.5, 1.0, 1.5, 2.0, 0.7, 1.0], dtype=torch.float32, device=DEVICE)
+        seed = torch.arange(num_reqs, dtype=torch.int64, device=DEVICE)
+        # NPU: pos is cast to int32 inside the kernel.
+        pos = torch.arange(num_reqs, dtype=torch.int32, device=DEVICE)
+
+        cache = torch.zeros(num_reqs, num_steps, vocab_size, device=DEVICE, dtype=dtype)
+        if per_token_col:
+            # Each token lands in its own column, cycling through the steps.
+            cols = torch.arange(num_reqs, dtype=torch.int32, device=DEVICE) % num_steps
+        else:
+            cols = torch.tensor(1, dtype=torch.int32, device=DEVICE)
+
+        gumbel_sample(
+            logits,
+            idx_mapping,
+            temp,
+            seed,
+            pos,
+            apply_temperature=True,
+            is_drafting=True,
+            logits_cache=cache,
+            logits_cache_col=cols,
+        )
+        torch.npu.synchronize()
+
+        if per_token_col:
+            stored = cache[torch.arange(num_reqs, device=DEVICE), cols.long()]
+        else:
+            stored = cache[:, 1]
+            # Untouched columns must stay untouched.
+            assert not cache[:, 0].any() and not cache[:, 2].any()
+        assert torch.equal(_float_bits(stored), _float_bits(logits)), "cached logits differ from the input logits"
+
+    @pytest.mark.parametrize("extra_cache_cols", [0, 1])
+    def test_logits_cache_columns_stay_separate_across_steps(self, extra_cache_cols: int):
+        """Each drafting step must land in its own cache column.
+
+        `extra_cache_cols=1` is the shape a draft produces when it adds an
+        input-only mask/noise row to its embedding table but keeps a full-width
+        output head: N-wide logits cached into N+1-wide rows. Striding cache
+        columns by the logits width instead of the cache's own row width leaves
+        step 0 correct and silently misaligns every step after it.
+        """
+        torch.manual_seed(0)
+        num_reqs, vocab_size, num_steps = 4, 1031, 3
+        idx_mapping = torch.arange(num_reqs, dtype=torch.int32, device=DEVICE)
+        temp = torch.ones(num_reqs, dtype=torch.float32, device=DEVICE)
+        seed = torch.arange(num_reqs, dtype=torch.int64, device=DEVICE)
+        # NPU: pos is cast to int32 inside the kernel.
+        pos = torch.arange(num_reqs, dtype=torch.int32, device=DEVICE)
+
+        cache = torch.zeros(num_reqs, num_steps, vocab_size + extra_cache_cols, device=DEVICE)
+        cols = torch.arange(num_steps, dtype=torch.int32, device=DEVICE)
+        per_step = [torch.randn(num_reqs, vocab_size, device=DEVICE) for _ in range(num_steps)]
+
+        for step, logits in enumerate(per_step):
+            gumbel_sample(
+                logits,
+                idx_mapping,
+                temp,
+                seed,
+                pos,
+                apply_temperature=True,
+                is_drafting=True,
+                logits_cache=cache,
+                logits_cache_col=cols[step],
+            )
+        torch.npu.synchronize()
+
+        for step, logits in enumerate(per_step):
+            stored = cache[:, step, :vocab_size]
+            assert torch.equal(_float_bits(stored), _float_bits(logits)), f"step {step} was overwritten by a later step"
+        # Columns past the sampled width belong to no step and stay untouched.
+        assert not cache[:, :, vocab_size:].any()
+
+    def test_logits_cache_narrower_than_logits_is_rejected(self):
+        """A cache too narrow to hold a step would silently drop its tail."""
+        num_reqs, vocab_size, num_steps = 2, 64, 3
+        logits = torch.randn(num_reqs, vocab_size, device=DEVICE)
+        idx_mapping = torch.arange(num_reqs, dtype=torch.int32, device=DEVICE)
+        temp = torch.ones(num_reqs, dtype=torch.float32, device=DEVICE)
+        seed = torch.zeros(num_reqs, dtype=torch.int64, device=DEVICE)
+        pos = torch.arange(num_reqs, dtype=torch.int32, device=DEVICE)
+        cache = torch.zeros(num_reqs, num_steps, vocab_size - 1, device=DEVICE)
+
+        with pytest.raises(AssertionError, match="narrower"):
+            gumbel_sample(
+                logits,
+                idx_mapping,
+                temp,
+                seed,
+                pos,
+                apply_temperature=True,
+                is_drafting=True,
+                logits_cache=cache,
+                logits_cache_col=torch.tensor(0, dtype=torch.int32, device=DEVICE),
+            )
+
+
+@triton.jit
+def _npu_gumbel_block_argmax_wrapper_kernel(
+    # [num_tokens, V]
+    logits_ptr,
+    # [num_tokens]
+    idx_mapping_ptr,
+    # [max_num_reqs]
+    temp_ptr,
+    # [max_num_reqs]
+    seed_ptr,
+    # [num_tokens]
+    pos_ptr,
+    # [max_num_reqs, num_cols, V]
+    cache_ptr,
+    cache_stride_0,
+    cache_stride_1,
+    # [] (shared column) or [num_tokens] (per-token column)
+    cache_col_ptr,
+    vocab_size,
+    # [num_tokens]
+    value_out_ptr,
+    idx_out_ptr,
+    APPLY_TEMPERATURE: tl.constexpr,
+    PER_TOKEN_COL: tl.constexpr,
+    BLOCK_SIZE: tl.constexpr,
+):
+    # Minimal launcher so _npu_gumbel_block_argmax's cache path can be tested
+    # directly: it is a device function, so a host-side call is impossible.
+    token_idx = tl.program_id(0).to(tl.int64)
+    block = tl.arange(0, BLOCK_SIZE)
+    mask = block < vocab_size
+    logits = tl.load(logits_ptr + token_idx * vocab_size + block, mask=mask, other=float("-inf"))
+    value, idx = _npu_gumbel_block_argmax(
+        logits,
+        block,
+        mask,
+        token_idx,
+        idx_mapping_ptr,
+        temp_ptr,
+        seed_ptr,
+        pos_ptr,
+        cache_ptr,
+        cache_stride_0,
+        cache_stride_1,
+        cache_col_ptr,
+        vocab_size,
+        IS_DRAFTING=False,
+        APPLY_TEMPERATURE=APPLY_TEMPERATURE,
+        USE_FP64=False,
+        PER_TOKEN_COL=PER_TOKEN_COL,
+    )
+    tl.store(value_out_ptr + token_idx, value)
+    tl.store(idx_out_ptr + token_idx, idx)
+
+
+class TestNpuGumbelBlockArgmaxCache:
+    """Direct coverage for _npu_gumbel_block_argmax's logits-cache path.
+
+    In production the rejection sampler's _resample_kernel calls the op with
+    logits_cache_ptr=None, so the cache path only runs when the NPU op is
+    patched into the upstream kernels (draft logits caching, upstream #50910).
+    These tests launch the op through a wrapper kernel (mirroring the
+    TestGumbelSampleLogitsCache assertions for gumbel_sample's cache) so the
+    fork-owned cache path keeps a regression guard.
+    """
+
+    BLOCK_SIZE = 8192
+
+    def _run(
+        self,
+        logits: torch.Tensor,
+        idx_mapping: torch.Tensor,
+        temp: torch.Tensor,
+        seed: torch.Tensor,
+        pos: torch.Tensor,
+        cache: torch.Tensor,
+        cols: torch.Tensor,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        num_tokens, vocab_size = logits.shape
+        value_out = torch.empty(num_tokens, dtype=torch.float32, device=DEVICE)
+        idx_out = torch.empty(num_tokens, dtype=torch.int64, device=DEVICE)
+        _npu_gumbel_block_argmax_wrapper_kernel[(num_tokens,)](
+            logits,
+            idx_mapping,
+            temp,
+            seed,
+            pos,
+            cache,
+            cache.stride(0),
+            cache.stride(1),
+            cols,
+            vocab_size,
+            value_out,
+            idx_out,
+            APPLY_TEMPERATURE=True,
+            PER_TOKEN_COL=cols.ndim > 0,
+            BLOCK_SIZE=self.BLOCK_SIZE,
+        )
+        torch.npu.synchronize()
+        return value_out, idx_out
+
+    @pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float16, torch.float32])
+    @pytest.mark.parametrize("per_token_col", [False, True])
+    @torch.inference_mode()
+    def test_cache_path_stores_input_logits_bitwise(self, dtype: torch.dtype, per_token_col: bool):
+        """The op's cache store must be pre-temperature and bit-exact.
+
+        Temps far from 0.0/1.0 make a post-temperature store fail the bitwise
+        check in every dtype. Both column-addressing modes are covered (shared
+        0-d column and per-token column), matching TestGumbelSampleLogitsCache.
+        """
+        torch.manual_seed(0)
+        num_reqs, vocab_size, num_steps = 8, 4099, 3
+        logits = torch.randn(num_reqs, vocab_size, device=DEVICE, dtype=dtype)
+        idx_mapping = torch.arange(num_reqs, dtype=torch.int32, device=DEVICE)
+        temp = torch.tensor([0.1, 0.5, 1.5, 2.0, 0.7, 0.3, 0.9, 1.1], dtype=torch.float32, device=DEVICE)
+        seed = torch.arange(num_reqs, dtype=torch.int64, device=DEVICE)
+        # NPU: pos is cast to int32 inside the kernel.
+        pos = torch.arange(num_reqs, dtype=torch.int32, device=DEVICE)
+
+        cache = torch.zeros(num_reqs, num_steps, vocab_size, device=DEVICE, dtype=dtype)
+        if per_token_col:
+            # Each token lands in its own column, cycling through the steps.
+            cols = torch.arange(num_reqs, dtype=torch.int32, device=DEVICE) % num_steps
+        else:
+            cols = torch.tensor(1, dtype=torch.int32, device=DEVICE)
+
+        _, idx_out = self._run(logits, idx_mapping, temp, seed, pos, cache, cols)
+        # Same (seed, pos) must reproduce the same noisy draw.
+        _, idx_out_2 = self._run(logits, idx_mapping, temp, seed, pos, cache, cols)
+        assert torch.equal(idx_out, idx_out_2), "same (seed, pos) produced different draws"
+
+        if per_token_col:
+            stored = cache[torch.arange(num_reqs, device=DEVICE), cols.long()]
+        else:
+            stored = cache[:, 1]
+            # Untouched columns must stay untouched.
+            assert not cache[:, 0].any() and not cache[:, 2].any()
+        assert torch.equal(_float_bits(stored), _float_bits(logits)), "cached logits differ from the input logits"
+        assert ((idx_out >= 0) & (idx_out < vocab_size)).all()
+
+    @torch.inference_mode()
+    def test_cache_path_greedy_returns_argmax(self):
+        """temp=0 applies neither temperature nor noise: argmax and raw max."""
+        torch.manual_seed(1)
+        num_reqs, vocab_size, num_steps = 4, 1031, 3
+        logits = torch.randn(num_reqs, vocab_size, device=DEVICE, dtype=torch.float32)
+        idx_mapping = torch.arange(num_reqs, dtype=torch.int32, device=DEVICE)
+        temp = torch.zeros(num_reqs, dtype=torch.float32, device=DEVICE)
+        seed = torch.arange(num_reqs, dtype=torch.int64, device=DEVICE)
+        pos = torch.arange(num_reqs, dtype=torch.int32, device=DEVICE)
+        cache = torch.zeros(num_reqs, num_steps, vocab_size, device=DEVICE, dtype=torch.float32)
+        cols = torch.tensor(0, dtype=torch.int32, device=DEVICE)
+
+        value_out, idx_out = self._run(logits, idx_mapping, temp, seed, pos, cache, cols)
+
+        assert torch.equal(idx_out, logits.argmax(dim=-1))
+        assert torch.equal(value_out, logits.max(dim=-1).values)
+        assert torch.equal(cache[:, 0], logits)
+
+
+# --------------------------- Noise streams ---------------------------------
+
+# Adapted from upstream tests/v1/worker/test_gpu_gumbel_sample.py
+# (upstream #54282: decouple the draft's Gumbel noise stream from the
+# target's via a Philox offset salt).
+
+# Dominant token is exp(HEAD_LOG_GAP)x larger than the unit-count tail, so the
+# tail sits ~HEAD_LOG_GAP logits below the top. That tail is the sensitive
+# part: the fp32 Gumbel noise must reach ~18 to ever sample it.
+HEAD_LOG_GAP = 18.0
+# 10-sigma band: a correct sampler effectively never trips it.
+Z_TOLERANCE = 10.0
+# NPU: upstream draws 500K samples in one call; the kernel's int64 argmax
+# scratch is [num_tokens, num_blocks], so draw in chunks to bound memory.
+NOISE_STREAM_VOCAB_SIZE = 200_000
+NOISE_STREAM_CHUNK = 50_000
+NOISE_STREAM_NUM_SAMPLES = 500_000
+
+
+def _make_heavy_tailed_counts(seed: int = 1234) -> torch.Tensor:
+    """Non-negative int64 counts of shape [vocab]; target prob = counts/N."""
+    gen = torch.Generator(device=DEVICE).manual_seed(seed)
+    counts = torch.randint(1, 4, (NOISE_STREAM_VOCAB_SIZE,), generator=gen, dtype=torch.int64, device=DEVICE)
+    counts[0] = round(math.exp(HEAD_LOG_GAP))  # dominant token
+    return counts
+
+
+def _counts_to_logits(counts: torch.Tensor) -> torch.Tensor:
+    # softmax(log(count)) == count / sum(count); count 0 -> logit -inf -> prob 0.
+    return counts.double().log().to(torch.float32)
+
+
+def _sample_noise_stream(
+    logits_1d: torch.Tensor,
+    *,
+    is_drafting: bool,
+) -> torch.Tensor:
+    """Sample NOISE_STREAM_NUM_SAMPLES tokens from one logit vector.
+
+    Fixed seed with a distinct `pos` per sample gives independent draws; the
+    logits are broadcast with a 0-stride view to avoid materializing
+    [num_samples, vocab_size]. NPU: pos is int32 (triton-ascend philox), and
+    draws are chunked to bound the kernel's scratch memory.
+    """
+    vocab_size = logits_1d.shape[0]
+    sampled_parts = []
+    for start in range(0, NOISE_STREAM_NUM_SAMPLES, NOISE_STREAM_CHUNK):
+        size = min(NOISE_STREAM_CHUNK, NOISE_STREAM_NUM_SAMPLES - start)
+        logits = logits_1d.unsqueeze(0).expand(size, vocab_size)
+        idx_mapping = torch.zeros(size, dtype=torch.int32, device=DEVICE)
+        temp = torch.tensor([1.0], dtype=torch.float32, device=DEVICE)
+        seed = torch.tensor([0xABCD], dtype=torch.int64, device=DEVICE)
+        pos = torch.arange(start, start + size, dtype=torch.int32, device=DEVICE)
+        sampled_parts.append(
+            gumbel_sample(
+                logits,
+                idx_mapping,
+                temp,
+                seed,
+                pos,
+                apply_temperature=True,
+                is_drafting=is_drafting,
+            )
+        )
+    return torch.cat(sampled_parts)
+
+
+def _z_score(observed: int, expected: float, num_trials: int) -> float:
+    p = expected / num_trials
+    return (observed - expected) / math.sqrt(num_trials * p * (1 - p))
+
+
+class TestGumbelSampleNoiseStreams:
+    """The draft's Gumbel noise stream must be disjoint from the target's."""
+
+    @torch.inference_mode()
+    def test_drafting_uses_a_separate_noise_stream(self):
+        """is_drafting salts the Philox offset: same inputs, different draws.
+
+        The draft proposal and the residual resample after a rejection must be
+        independent. They key noise by the same (seed, pos), so only the salt
+        keeps them apart -- without it the resample inherits the very noise
+        vector that picked the rejected proposal. See
+        test_gumbel_drafted_rejection_sample_is_unbiased in
+        tests/e2e/nightly/single_node/ops/singlecard_ops/triton/
+        test_rejection_sample_v2.py for the distributional consequence.
+
+        Relocating the offset must not distort the draw either, so both streams
+        are checked against the target's far-tail mass, which sits
+        HEAD_LOG_GAP logits below the head -- the regime where fp32 Gumbel
+        precision matters.
+        """
+        counts = _make_heavy_tailed_counts()
+        total = counts.sum().item()
+        logits = _counts_to_logits(counts)
+        tail_prob = (total - counts[0].item()) / total
+
+        target = _sample_noise_stream(logits, is_drafting=False)
+        draft = _sample_noise_stream(logits, is_drafting=True)
+
+        # The head dominates, so the streams agree on most draws by construction.
+        # Compare instead which draws leave the head: shared noise makes that
+        # identical, independent noise makes them differ on ~2p(1-p) of draws.
+        target_tail = target != 0
+        draft_tail = draft != 0
+        disagree = (target_tail != draft_tail).double().mean().item()
+        assert disagree > tail_prob, (
+            f"streams leave the head on the same draws ({disagree:.3e} disagreement "
+            f"vs tail mass {tail_prob:.3e}); the draft salt is not taking effect"
+        )
+
+        # Both streams must still reproduce the target's tail mass.
+        for name, tail in (("target", target_tail), ("draft", draft_tail)):
+            tail_count = tail.sum().item()
+            z = _z_score(tail_count, NOISE_STREAM_NUM_SAMPLES * tail_prob, NOISE_STREAM_NUM_SAMPLES)
+            assert abs(z) < Z_TOLERANCE, (
+                f"{name} tail mass {tail_count / NOISE_STREAM_NUM_SAMPLES:.3e} != {tail_prob:.3e} (z={z:.2f})"
+            )
+
+        # The draft stream is reproducible.
+        assert torch.equal(draft, _sample_noise_stream(logits, is_drafting=True))
+
+        torch.npu.synchronize()

--- a/vllm_ascend/worker/v2/sample/gumbel.py
+++ b/vllm_ascend/worker/v2/sample/gumbel.py
@@ -20,6 +20,14 @@
 import torch
 from vllm.triton_utils import tl, triton
 
+# Offset salt keeping the draft's Gumbel noise disjoint from the target's
+# (upstream #54282). Verification is a probability-ratio test, not a Gumbel
+# coupling, so a proposal and the residual it is resampled from must not share
+# a noise vector. Positions are well below 2**30, so the streams cannot
+# collide. NPU: pos is cast to int32 before salting, and the salt plus any
+# real position stays within int32 range.
+_DRAFT_NOISE_SALT = tl.constexpr(1 << 30)
+
 
 @triton.jit(do_not_specialize=["logits_stride", "vocab_size"])
 def _temperature_kernel(
@@ -80,7 +88,8 @@ def apply_temperature(
     do_not_specialize=[
         "local_argmax_stride",
         "local_max_stride",
-        "processed_logits_stride",
+        "logits_cache_stride_0",
+        "logits_cache_stride_1",
         "logits_stride",
         "vocab_size",
         "num_blocks",
@@ -91,9 +100,11 @@ def _gumbel_sample_kernel(
     local_argmax_stride,
     local_max_ptr,
     local_max_stride,
-    processed_logits_ptr,
-    processed_logits_stride,
-    processed_logits_col_ptr,
+    # [max_num_reqs, num_cols, vocab_size]
+    logits_cache_ptr,
+    logits_cache_stride_0,
+    logits_cache_stride_1,
+    logits_cache_col_ptr,
     logits_ptr,
     logits_stride,
     expanded_idx_mapping_ptr,
@@ -103,6 +114,7 @@ def _gumbel_sample_kernel(
     vocab_size,
     num_blocks,
     BLOCK_SIZE: tl.constexpr,
+    IS_DRAFTING: tl.constexpr,
     APPLY_TEMPERATURE: tl.constexpr,
     PER_TOKEN_COL: tl.constexpr,
 ):
@@ -121,24 +133,28 @@ def _gumbel_sample_kernel(
         )
         logits = logits.to(tl.float32)
 
-        block_temp = temp
-        if block_temp != 0.0 and APPLY_TEMPERATURE:
-            logits = logits / block_temp
-
-        if processed_logits_ptr is not None:
-            # Store the temperature-applied logits.
-            if processed_logits_col_ptr is not None:
+        if logits_cache_ptr is not None:
+            # Store the logits *before* temperature. Dividing first would
+            # produce a value that is generally not representable in the
+            # cache's dtype, forcing it to be fp32. Consumers (the rejection
+            # sampler) divide by the same temperature on load, which
+            # reproduces the value used below bitwise.
+            if logits_cache_col_ptr is not None:
                 if PER_TOKEN_COL:
-                    col = tl.load(processed_logits_col_ptr + token_idx)
+                    col = tl.load(logits_cache_col_ptr + token_idx)
                 else:
-                    col = tl.load(processed_logits_col_ptr)
+                    col = tl.load(logits_cache_col_ptr)
             else:
                 col = 0
             tl.store(
-                processed_logits_ptr + req_state_idx * processed_logits_stride + col * vocab_size + block,
+                logits_cache_ptr + req_state_idx * logits_cache_stride_0 + col * logits_cache_stride_1 + block,
                 logits,
                 mask=mask,
             )
+
+        block_temp = temp
+        if block_temp != 0.0 and APPLY_TEMPERATURE:
+            logits = logits / block_temp
 
         if block_temp != 0.0:
             # Calculate the seed for gumbel noise.
@@ -146,6 +162,14 @@ def _gumbel_sample_kernel(
             # NOTE(Ronald1995): change pos's dtype to tl.int32, because triton-ascend's
             # compiler doesn't support uint64 of pos arg.
             pos = tl.load(pos_ptr + token_idx).to(tl.int32)
+            if IS_DRAFTING:
+                # Offset salt keeping the draft's Gumbel noise disjoint from
+                # the target's (upstream #54282). Verification is a
+                # probability-ratio test, not a Gumbel coupling, so a proposal
+                # and the residual it is resampled from must not share a
+                # noise vector. NPU: pos is int32 here, and the salt (2**30)
+                # plus any real position stays within int32 range.
+                pos = pos + _DRAFT_NOISE_SALT
             gumbel_seed = tl.randint(seed, pos)
 
             # NOTE(Ronald1995): r is tl.float64 in vllm, change it to tl.float32,
@@ -171,13 +195,22 @@ def gumbel_sample(
     seed: torch.Tensor,  # [max_num_reqs]
     pos: torch.Tensor,  # [num_tokens]
     apply_temperature: bool,
-    output_processed_logits: torch.Tensor | None = None,
-    output_processed_logits_col: torch.Tensor | None = None,
+    is_drafting: bool,
+    logits_cache: torch.Tensor | None = None,  # [max_num_reqs, num_cols, vocab_size]
+    logits_cache_col: torch.Tensor | None = None,  # scalar or [num_tokens]
     use_fp64: bool = False,
 ) -> torch.Tensor:
     if use_fp64:
         raise NotImplementedError("FP64 Gumbel sampling is not supported on NPU.")
+    if logits_cache_col is not None:
+        logits_cache_col = logits_cache_col.contiguous()
     num_tokens, vocab_size = logits.shape
+    if logits_cache is not None:
+        assert logits_cache.size(-1) >= vocab_size, (
+            f"draft logits cache vocab dim ({logits_cache.size(-1)}) is narrower "
+            f"than the sampled logits ({vocab_size}). Cached logits would be "
+            "truncated."
+        )
     BLOCK_SIZE = 1024
     num_blocks = triton.cdiv(vocab_size, BLOCK_SIZE)
     local_argmax = torch.empty(
@@ -192,15 +225,16 @@ def gumbel_sample(
         dtype=torch.float32,
         device=logits.device,
     )
-    per_token_col = output_processed_logits_col is not None and output_processed_logits_col.dim() > 0
+    per_token_col = logits_cache_col is not None and logits_cache_col.dim() > 0
     _gumbel_sample_kernel[(num_tokens,)](
         local_argmax,
         local_argmax.stride(0),
         local_max,
         local_max.stride(0),
-        output_processed_logits,
-        output_processed_logits.stride(0) if output_processed_logits is not None else 0,
-        output_processed_logits_col,
+        logits_cache,
+        logits_cache.stride(0) if logits_cache is not None else 0,
+        logits_cache.stride(1) if logits_cache is not None else 0,
+        logits_cache_col,
         logits,
         logits.stride(0),
         expanded_idx_mapping,
@@ -210,6 +244,7 @@ def gumbel_sample(
         vocab_size,
         num_blocks,
         BLOCK_SIZE=BLOCK_SIZE,
+        IS_DRAFTING=is_drafting,
         APPLY_TEMPERATURE=apply_temperature,
         PER_TOKEN_COL=per_token_col,
     )

--- a/vllm_ascend/worker/v2/spec_decode/rejection_sampler_utils.py
+++ b/vllm_ascend/worker/v2/spec_decode/rejection_sampler_utils.py
@@ -40,34 +40,51 @@ def _npu_gumbel_block_argmax(
     temp_ptr,
     seeds_ptr,
     pos_ptr,
-    processed_logits_ptr,
-    processed_logits_stride,
-    processed_logits_col_ptr,
+    # [max_num_reqs, num_cols, vocab_size]
+    logits_cache_ptr,
+    logits_cache_stride_0,
+    logits_cache_stride_1,
+    logits_cache_col_ptr,
     vocab_size,
+    IS_DRAFTING: tl.constexpr,
     APPLY_TEMPERATURE: tl.constexpr,
+    USE_FP64: tl.constexpr,
+    PER_TOKEN_COL: tl.constexpr = False,
 ):
     req_state_idx = tl.load(expanded_idx_mapping_ptr + token_idx)
     temp = tl.load(temp_ptr + req_state_idx).to(tl.float32)
-    if temp != 0.0 and APPLY_TEMPERATURE:
-        logits = logits / temp
-
-    if processed_logits_ptr is not None:
-        if processed_logits_col_ptr is not None:
-            col = tl.load(processed_logits_col_ptr)
+    if logits_cache_ptr is not None:
+        # Store the logits *before* temperature. Dividing first would
+        # produce a value that is generally not representable in the
+        # cache's dtype, forcing it to be fp32. Consumers (the rejection
+        # sampler) divide by the same temperature on load, which
+        # reproduces the value used below bitwise.
+        if PER_TOKEN_COL:
+            col = tl.load(logits_cache_col_ptr + token_idx)
         else:
-            col = 0
+            col = tl.load(logits_cache_col_ptr)
         tl.store(
-            processed_logits_ptr + req_state_idx * processed_logits_stride + col * vocab_size + block,
+            logits_cache_ptr + req_state_idx * logits_cache_stride_0 + col * logits_cache_stride_1 + block,
             logits,
             mask=mask,
         )
 
+    if temp != 0.0 and APPLY_TEMPERATURE:
+        logits = logits / temp
+
+    # NPU: fp64 is unsupported; always reduce in fp32. USE_FP64 is kept
+    # for signature compatibility and guarded at the host level.
     logits = logits.to(tl.float32)
     if temp != 0.0:
         seed = tl.load(seeds_ptr + req_state_idx)
         # NPU: cast pos to int32 to avoid uint64 in philox (NPU umulhi only
         # supports int32/uint32). Position values fit in int32 in practice.
         pos = tl.load(pos_ptr + token_idx).to(tl.int32)
+        # IS_DRAFTING is kept for signature compatibility with upstream
+        # gumbel_block_argmax (upstream #54282). The rejection sampler's
+        # resample is the target side, so callers must always pass False;
+        # salting the noise here would corrupt the target's stream.
+        assert not IS_DRAFTING
         gumbel_seed = tl.randint(seed, pos)
         # NPU: use tl.rand (float32) instead of tl_rand64 (float64 not supported)
         r = tl.rand(gumbel_seed, block).to(tl.float32)
@@ -171,11 +188,14 @@ def _resample_kernel(
         temp_ptr,
         seed_ptr,
         pos_ptr,
-        None,
-        0,
-        None,
+        None,  # logits_cache_ptr
+        0,  # logits_cache_stride_0
+        0,  # logits_cache_stride_1
+        None,  # logits_cache_col_ptr
         vocab_size,
+        IS_DRAFTING=False,
         APPLY_TEMPERATURE=False,
+        USE_FP64=False,
     )
     token_id = block_idx * BLOCK_SIZE + idx
     tl.store(


### PR DESCRIPTION
**What this PR does / why we need it?**

Ports [vllm#54282](https://github.com/vllm-project/vllm/pull/54282) to the NPU Gumbel sampling path in the V2 model runner. Two related changes:

1. **Draft noise stream isolation (`is_drafting`)**: In speculative decoding, the draft proposal and the target's verification/resample previously drew Gumbel noise from the *same* `(seed, pos)` stream. The draft's argmax truncates every other token's Gumbel below its winning value — most tightly for the tokens the draft ranked highest — so sharing a stream makes the rejection sampler's residual under-weight exactly those tokens and skews the output distribution away from the target. The draft side is now salted (`_DRAFT_NOISE_SALT = 1 << 30`) so the two draws are independent, restoring unbiasedness.

2. **Draft logits cache (`logits_cache` / `logits_cache_col`)**: draft logits can now be cached at sample time — stored *pre-temperature* and bit-exact, so consumers (the rejection sampler) can divide by the same temperature on load and reproduce the value bitwise, avoiding a re-forward of the draft model.

NPU-specific notes:
- fp64 Gumbel is unsupported on triton-ascend; `use_fp64=True` raises `NotImplementedError` (reduction stays fp32, signature kept for upstream compatibility).
- `IS_DRAFTING` is accepted by `_npu_gumbel_block_argmax` but asserted `False`: the rejection sampler's resample is the target side, and salting there would corrupt the target's stream.

**Does this PR introduce _any_ user-facing change?**

No configuration or API change. Draft/target sampling correctness (distribution fidelity under speculative decoding) improves as a side effect of the noise-stream fix; no action is needed by users.

**How was this patch tested?**

- New unit tests in `tests/e2e/pull_request/one_card/test_gumbel_sampling.py`:
  - `TestGumbelSampleLogitsCache` — logits cache stores input logits bitwise (bf16/fp16/fp32, shared and per-token column addressing), column isolation across steps, mixed-temperature requests, narrower-cache rejection.
  - `TestNpuGumbelBlockArgmaxCache` — direct coverage of the op's cache path via a wrapper kernel (production passes `logits_cache=None`).
  - `TestGumbelSampleNoiseStreams` — draft and target sampling with the same `(seed, pos)` produce different results.
- New nightly test `test_gumbel_drafted_rejection_sample_is_unbiased` in `tests/e2e/nightly/single_node/ops/singlecard_ops/triton/test_rejection_sample_v2.py`: drafts proposals through `gumbel_sample` on the same stream the sampler verifies/resamples with, then chi-squared checks the output against the target distribution (16 bins × 200K trials; dropping the salt takes chi² from ~12 to ~1500 against a ~70 threshold, so the test resolves the bias).
- To run:
  ```
  pytest -sv tests/e2e/pull_request/one_card/test_gumbel_sampling.py
  pytest -sv tests/e2e/nightly/single_node/ops/singlecard_ops/triton/test_rejection_sample_v2.py::test_gumbel_drafted_rejection_sample_is_unbiased
  ```
  CI-only validation is sufficient for the rest of the diff (no changes to non-test runtime behavior beyond the ported kernels).

> - vLLM version:
> - vLLM main:

- vLLM main: https://github.com/vllm-project/vllm/commit/ba07e4a48fc951300d97eb506217dd530583dea3
