### PR TITLE
[BugFix][DeepSeek] Restore no-clamp shared expert group index for v0.26

### DIFF
--- a/tests/ut/ops/test_fused_moe.py
+++ b/tests/ut/ops/test_fused_moe.py
@@ -530,6 +530,71 @@ def test_w8a8_shared_situ_uses_dequant_situ_quant(monkeypatch):
     assert situ_call["linear_beta"] == 25.0
 
 
+@pytest.mark.parametrize("clamp_limit", [0.0, 10.0])
+def test_w8a8_shared_swiglu_uses_group_index_only_without_clamp(monkeypatch, clamp_limit):
+    runner = AscendMoERunner.__new__(AscendMoERunner)
+    nn.Module.__init__(runner)
+    hidden_states = torch.randn(3, 4, dtype=torch.bfloat16)
+    gate_up = torch.ones(3, 8, dtype=torch.int32)
+    quantized_input = torch.ones(3, 4, dtype=torch.int8)
+    input_scale = torch.ones(3, dtype=torch.float32)
+    quantized_swiglu = torch.ones(3, 4, dtype=torch.int8)
+    swiglu_scale = torch.ones(3, dtype=torch.float32)
+    down_out = torch.randn(3, 4, dtype=torch.bfloat16)
+    gate_up_proj = MagicMock()
+    gate_up_proj.weight = torch.ones(4, 8, dtype=torch.int8)
+    gate_up_proj.weight_scale = torch.ones(8, dtype=torch.bfloat16)
+    gate_up_proj.weight_scale_fp32 = torch.ones(8, dtype=torch.float32)
+    down_proj = MagicMock()
+    down_proj.weight = torch.ones(4, 4, dtype=torch.int8)
+    down_proj.weight_scale = torch.ones(4, dtype=torch.bfloat16)
+    runner._shared_experts = SimpleNamespace(
+        gate_up_proj=gate_up_proj,
+        down_proj=down_proj,
+        act_fn=nn.Identity(),
+    )
+    runner.quant_type = QuantType.W8A8
+    runner.multistream_overlap_shared_expert = False
+    events = fused_moe_module.FusedMoEEvents(
+        before_routed_experts=MagicMock(),
+        before_dispatch=MagicMock(),
+        before_gmm2=MagicMock(),
+        before_combine=MagicMock(),
+        swiglu_limit=clamp_limit,
+    )
+    fast_dynamic_quant = MagicMock(return_value=(quantized_input, input_scale))
+    fast_quant_matmul = MagicMock(side_effect=[gate_up, down_out])
+    custom_ops = SimpleNamespace(
+        npu_dequant_swiglu_quant=MagicMock(return_value=(quantized_swiglu, swiglu_scale)),
+    )
+
+    monkeypatch.setattr(fused_moe_module, "npu_stream_switch", lambda *_args, **_kwargs: nullcontext())
+    monkeypatch.setattr(fused_moe_module, "shared_expert_dp_enabled", lambda: True)
+    monkeypatch.setattr(fused_moe_module, "shared_experts_calculation_stream", MagicMock())
+    monkeypatch.setattr(fused_moe_module.torch.npu, "current_stream", MagicMock(return_value=MagicMock()))
+    monkeypatch.setattr(fused_moe_module.torch_npu, "npu_dynamic_quant", fast_dynamic_quant, raising=False)
+    monkeypatch.setattr(fused_moe_module.torch_npu, "npu_quant_matmul", fast_quant_matmul)
+    monkeypatch.setattr(fused_moe_module.torch.ops, "_C_ascend", custom_ops)
+    monkeypatch.setattr(
+        fused_moe_module,
+        "_EXTRA_CTX",
+        SimpleNamespace(
+            flash_comm_v1_enabled=False,
+            moe_comm_type=MoECommType.ALLGATHER,
+        ),
+    )
+
+    output = runner._forward_shared_experts(hidden_states, events)
+
+    torch.testing.assert_close(output, down_out)
+    swiglu_call = custom_ops.npu_dequant_swiglu_quant.call_args.kwargs
+    assert swiglu_call["clamp_limit"] == clamp_limit
+    if clamp_limit > 0.0:
+        assert swiglu_call["group_index"] is None
+    else:
+        torch.testing.assert_close(swiglu_call["group_index"], torch.tensor([hidden_states.shape[0]]))
+
+
 @pytest.mark.parametrize("quant_type", [QuantType.W4A8MXFP, QuantType.W8A8MXFP])
 def test_mxfp_shared_situ_uses_situ_mx_quant(monkeypatch, quant_type):
     runner = AscendMoERunner.__new__(AscendMoERunner)

--- a/vllm_ascend/ops/fused_moe/fused_moe.py
+++ b/vllm_ascend/ops/fused_moe/fused_moe.py
@@ -872,6 +872,11 @@ class AscendMoERunner(MoERunner):  # type: ignore[no-redef]
                         quant_mode="dynamic",
                     )
                 else:
+                    clamp_limit = fused_moe_evts.swiglu_limit or 0.0
+                    group_index = None
+                    if clamp_limit <= 0.0:
+                        group_index = torch.empty((1,), dtype=torch.int64, device=hidden_states.device)
+                        group_index.fill_(hidden_states.shape[0])
                     quantized_x, swiglu_out_scale = torch.ops._C_ascend.npu_dequant_swiglu_quant(
                         x=hidden_states,
                         weight_scale=self._shared_experts.gate_up_proj.weight_scale_fp32,
@@ -879,11 +884,11 @@ class AscendMoERunner(MoERunner):  # type: ignore[no-redef]
                         bias=None,
                         quant_scale=None,
                         quant_offset=None,
-                        group_index=None,
+                        group_index=group_index,
                         activate_left=True,
                         quant_mode=1,
                         swiglu_mode=1,
-                        clamp_limit=fused_moe_evts.swiglu_limit,
+                        clamp_limit=clamp_limit,
                         glu_alpha=fused_moe_evts.swiglu_alpha,
                         glu_bias=fused_moe_evts.swiglu_beta,
                     )


### PR DESCRIPTION
### What this PR does / why we need it?

This ports the behavior of #11775 to `releases/v0.26.0rc`.

#10258 preserved an omitted `group_index` for `npu_dequant_swiglu_quant` so clamp-enabled DeepSeek V4 shared experts stay on the no-group DSK path. For no-clamp configurations, however, the same call site must retain the earlier effective behavior where the wrapper synthesized `[x.size(0)]` as single-group metadata.

The v0.26 fused MoE runner currently always passes `group_index=None`. This change synthesizes a one-element group index only when the shared-expert SwiGLU clamp limit is disabled. Clamp-enabled paths continue to pass `group_index=None`, preserving the semantics fixed by #10258.

A regression test covers both the no-clamp single-group path and the clamp-enabled no-group path.

### Does this PR introduce _any_ user-facing change?

Yes. It restores the no-clamp W8A8 shared-expert path. In a four-host DeepSeek-V3.1 PD-disaggregated deployment, the missing metadata caused a P-node worker segfault followed by collective communication failures. With this patch, the same 2,400-request workload completed without failures.

There is no API or configuration change.

### How was this patch tested?

- `git diff --check`
- `python -m py_compile vllm_ascend/ops/fused_moe/fused_moe.py tests/ut/ops/test_fused_moe.py`
- `python -m pytest -q tests/ut/ops/test_fused_moe.py::test_w8a8_shared_swiglu_uses_group_index_only_without_clamp`
  - Result: `2 passed`
- `python -m pytest -q tests/ut/ops/test_fused_moe.py`
  - Result: `34 passed`
- Manual four-host A/B validation with DeepSeek-V3.1 W8A8, AIV enabled, P nodes using DP2/TP8 and D nodes using DP32/TP1:
  - Without this patch: P-node worker segfaulted; only 22 requests completed before failures propagated.
  - With this patch: 2,400/2,400 requests completed, 0 failed; total token throughput was 29,861.9 token/s.

- vLLM main: https://github.com/vllm-project/vllm/commit/d02df748bf9efd99022f1a062597dc3cb3808485
