### PR TITLE
[Doc] Update release doc title

### DIFF
--- a/docs/hooks/macros_main.py
+++ b/docs/hooks/macros_main.py
@@ -15,14 +15,14 @@ UI_STRINGS = {
     "en": {
         "banner_preview": "You are viewing the latest developer preview docs.",
         "banner_link": "Click here",
-        "banner_suffix": "to view docs for the latest stable release (v0.18.0).",
+        "banner_suffix": "to view docs for the latest stable release (v0.23.0).",
         "btn_report": "report issue",
         "aria_report": "Report a documentation issue",
     },
     "zh": {
         "banner_preview": "您正在查看最新的开发者预览版文档。",
         "banner_link": "点击此处",
-        "banner_suffix": "查看最新稳定版（v0.18.0）的文档。",
+        "banner_suffix": "查看最新稳定版（v0.23.0）的文档。",
         "btn_report": "反馈问题",
         "aria_report": "报告文档问题",
     },

--- a/docs/overrides/main.html
+++ b/docs/overrides/main.html
@@ -24,7 +24,7 @@
 {% if not config.extra.is_release %}
 <div class="md-announce">
   {{ t.banner_preview }}
-  <a href="https://docs.vllm.ai/projects/ascend/en/v0.18.0">{{ t.banner_link }}</a>
+  <a href="https://docs.vllm.ai/projects/ascend/en/v0.23.0">{{ t.banner_link }}</a>
   {{ t.banner_suffix }}
 </div>
 {% endif %}

--- a/docs/source/user_guide/release_notes.md
+++ b/docs/source/user_guide/release_notes.md
@@ -2,7 +2,7 @@
 
 ## v0.26.0rc1 - 2026.09.03
 
-This is the first release candidate of v0.26.0 for vLLM Ascend, aligned with upstream vLLM v0.26.0. This release is a model‑restricted version. Fully validated models include Kimi K3, GLM‑5.2, DeepSeek V4 Flash 0731, DeepSeek V4 Pro 0813. Availability is not guaranteed for other models. For the full test report, see: [v0.26.0rc1 Test Conclusion](https://github.com/vllm-project/vllm-ascend/blob/releases/v0.26.0rc/tests/vllm_ascend_v0.26.0rc1_test_conclusion.md). Please follow the [official documentation](https://docs.vllm.ai/projects/ascend/en/latest) to get started.
+This is the first release candidate of v0.26.0 for vLLM Ascend, aligned with upstream vLLM v0.26.0. This release is a model‑restricted version. Fully validated models include Kimi K3, GLM‑5.2, DeepSeek V4 Flash 0731, DeepSeek V4 Pro 0813. Availability is not guaranteed for other models. For the full test report, see: [v0.26.0rc1 Test Conclusion](https://github.com/vllm-project/vllm-ascend/blob/releases/v0.26.0rc/tests/vllm_ascend_v0.26.0rc1_test_conclusion.md). Please follow the [official documentation](https://docs.vllm.ai/projects/ascend/en/v0.26.0rc1/) to get started.
 
 ### Highlights
 


### PR DESCRIPTION
### What this PR does / why we need it?

This PR updates the stable release version referenced in the documentation from `v0.18.0` to `v0.23.0` across the macros hook and the main HTML template. It also corrects the documentation link in the `v0.26.0rc1` release notes to point to the specific release candidate version instead of `latest`.

### Does this PR introduce _any_ user-facing change?

No, this is a documentation-only update.

### How was this patch tested?

Documentation-only changes, verified by checking the updated links and version strings.


- vLLM main: https://github.com/vllm-project/vllm/commit/d02df748bf9efd99022f1a062597dc3cb3808485
