### PR TITLE
[BugFix][Worker] Hold spec-decode pinned staging tensors until async H2D completes

### DIFF
--- a/tests/ut/worker/test_model_runner_v1.py
+++ b/tests/ut/worker/test_model_runner_v1.py
@@ -1273,6 +1273,62 @@ class TestNPUModelRunnerScoreEncoderCache(unittest.TestCase):
         self.assertNotIn("image", runner.tmp_encoder_cache)
 
 
+class TestNPUModelRunnerAsyncH2DStaging(unittest.TestCase):
+    @staticmethod
+    def _build_runner():
+        runner = NPUModelRunner.__new__(NPUModelRunner)
+        runner.device = "npu"
+        runner._pending_h2d_staging = deque()
+        return runner
+
+    def test_async_h2d_from_numpy_keeps_pinned_source_until_event_completes(self):
+        runner = self._build_runner()
+        sources = [MagicMock() for _ in range(3)]
+        npu_values = [MagicMock() for _ in range(3)]
+        events = [MagicMock() for _ in range(3)]
+        for source, npu_value in zip(sources, npu_values):
+            source.pin_memory.return_value = source
+            source.to.return_value = npu_value
+        fake_npu = SimpleNamespace(
+            Event=MagicMock(side_effect=events),
+            current_stream=MagicMock(),
+        )
+
+        with (
+            patch.object(torch, "from_numpy", MagicMock(side_effect=sources)),
+            patch.object(torch, "npu", fake_npu, create=True),
+        ):
+            out = runner._async_h2d_from_numpy(np.array([0, 1, 2], dtype=np.int32))
+
+            self.assertIs(out, npu_values[0])
+            sources[0].pin_memory.assert_called_once()
+            sources[0].to.assert_called_once_with("npu", non_blocking=True)
+            self.assertEqual(
+                runner._pending_h2d_staging, [(sources[0], events[0])]
+            )
+            events[0].record.assert_called_once_with(
+                fake_npu.current_stream.return_value
+            )
+
+            # Unfinished staging tensors are retained across calls.
+            events[0].query.return_value = False
+            runner._async_h2d_from_numpy(np.array([3], dtype=np.int32))
+            self.assertEqual(
+                runner._pending_h2d_staging,
+                [(sources[0], events[0]), (sources[1], events[1])],
+            )
+
+            # Only the finished head entry is reclaimed; later unfinished
+            # entries survive the lazy front-only sweep.
+            events[0].query.return_value = True
+            events[1].query.return_value = False
+            runner._async_h2d_from_numpy(np.array([4], dtype=np.int32))
+            self.assertEqual(
+                runner._pending_h2d_staging,
+                [(sources[1], events[1]), (sources[2], events[2])],
+            )
+
+
 class TestNPUModelRunnerOutputTokenIds(unittest.TestCase):
     def _build_runner(self):
         runner = NPUModelRunner.__new__(NPUModelRunner)
@@ -1387,6 +1443,8 @@ class TestNPUModelRunnerOutputTokenIds(unittest.TestCase):
         scheduler_output = SimpleNamespace(
             scheduled_spec_decode_tokens={"req0": [-1, -1, -1]},
         )
+        # CPU-only environment: bypass the NPU async H2D staging path.
+        runner._async_h2d_from_numpy = torch.from_numpy
 
         spec_decode_metadata = runner._calc_spec_decode_metadata(
             num_draft_tokens=np.array([3], dtype=np.int32),

--- a/tests/ut/worker/test_model_runner_v1.py
+++ b/tests/ut/worker/test_model_runner_v1.py
@@ -1303,12 +1303,8 @@ class TestNPUModelRunnerAsyncH2DStaging(unittest.TestCase):
             self.assertIs(out, npu_values[0])
             sources[0].pin_memory.assert_called_once()
             sources[0].to.assert_called_once_with("npu", non_blocking=True)
-            self.assertEqual(
-                runner._pending_h2d_staging, [(sources[0], events[0])]
-            )
-            events[0].record.assert_called_once_with(
-                fake_npu.current_stream.return_value
-            )
+            self.assertEqual(runner._pending_h2d_staging, [(sources[0], events[0])])
+            events[0].record.assert_called_once_with(fake_npu.current_stream.return_value)
 
             # Unfinished staging tensors are retained across calls.
             events[0].query.return_value = False

--- a/vllm_ascend/worker/model_runner_v1.py
+++ b/vllm_ascend/worker/model_runner_v1.py
@@ -590,6 +590,10 @@ class NPUModelRunner(GPUModelRunner):
         self._pending_encoder_cache_copies: deque[
             tuple[torch.Tensor, torch.npu.Event]
         ] = deque()
+        # Pinned staging tensors kept alive until their async H2D completes.
+        self._pending_h2d_staging: deque[
+            tuple[torch.Tensor, torch.npu.Event]
+        ] = deque()
 
         self.sparse_kv_offload_config = self.ascend_config.sparse_kv_offload_config
         self.sparse_kv_offload_enabled = self.sparse_kv_offload_config.enabled
@@ -1595,6 +1599,25 @@ class NPUModelRunner(GPUModelRunner):
         input_ids = self.input_ids.gpu[:num_forward_tokens]
         input_ids.masked_fill_(input_ids == PLACEHOLDER_TOKEN_ID, 0)
 
+    def _async_h2d_from_numpy(self, data: np.ndarray) -> torch.Tensor:
+        """Async CPU-to-NPU copy that keeps the pinned staging tensor alive.
+
+        torch_npu's host allocator returns freed pinned blocks to the pool
+        immediately, so a temporary pinned tensor can be reallocated and
+        overwritten before its non_blocking H2D executes. Hold each staging
+        tensor with a completion event and reclaim both lazily via the
+        non-blocking Event.query().
+        """
+        while self._pending_h2d_staging and self._pending_h2d_staging[0][1].query():
+            self._pending_h2d_staging.popleft()
+
+        source = torch.from_numpy(data).pin_memory()
+        npu_value = source.to(self.device, non_blocking=True)
+        copy_done = torch.npu.Event()
+        copy_done.record(torch.npu.current_stream())
+        self._pending_h2d_staging.append((source, copy_done))
+        return npu_value
+
     def _calc_spec_decode_metadata(
         self,
         num_draft_tokens: np.ndarray,
@@ -1641,11 +1664,11 @@ class NPUModelRunner(GPUModelRunner):
         target_logits_indices += arange
 
         # TODO: Optimize the CPU -> NPU copy.
-        cu_num_draft_tokens = torch.from_numpy(cu_num_draft_tokens).pin_memory().to(self.device, non_blocking=True)
-        cu_num_sampled_tokens = torch.from_numpy(cu_num_sampled_tokens).pin_memory().to(self.device, non_blocking=True)
-        logits_indices = torch.from_numpy(logits_indices).pin_memory().to(self.device, non_blocking=True)
-        target_logits_indices = torch.from_numpy(target_logits_indices).pin_memory().to(self.device, non_blocking=True)
-        bonus_logits_indices = torch.from_numpy(bonus_logits_indices).pin_memory().to(self.device, non_blocking=True)
+        cu_num_draft_tokens = self._async_h2d_from_numpy(cu_num_draft_tokens)
+        cu_num_sampled_tokens = self._async_h2d_from_numpy(cu_num_sampled_tokens)
+        logits_indices = self._async_h2d_from_numpy(logits_indices)
+        target_logits_indices = self._async_h2d_from_numpy(target_logits_indices)
+        bonus_logits_indices = self._async_h2d_from_numpy(bonus_logits_indices)
 
         # Compute the draft token ids.
         # draft_token_indices:      [  1,   2,   3, 105, 106, 208]


### PR DESCRIPTION
### What this PR does / why we need it?

**Bug**: Under DSpark speculative decoding with `--async-scheduling` + graph mode at high concurrency (e.g., DeepSeek V4 Flash Vision W8A8, DP4/TP4/EP16, `num_speculative_tokens=6`, 128 concurrent requests, MMMU-Pro Options10), the service crashes with:

```
fault kernel_name=IndexCheck_int64_high_performance_0
Index out of range in dimension 0: index value 1048797440 exceeds bounds 1048576
```

**Root cause**: `NPUModelRunner._calc_spec_decode_metadata()` staged its 5 metadata tensors (`cu_num_draft_tokens`, `cu_num_sampled_tokens`, `logits_indices`, `target_logits_indices`, `bonus_logits_indices`) in **temporary pinned CPU tensors** that lost their last reference immediately after the `non_blocking=True` H2D was enqueued:

```python
target_logits_indices = torch.from_numpy(x).pin_memory().to(self.device, non_blocking=True)
```

Unlike CUDA's `CachingHostAllocator` (which quarantines freed pinned blocks behind stream events), torch_npu's host allocator returns freed pinned blocks to the pool immediately. The block could be reallocated and overwritten before the DMA actually executed, so the NPU received a corrupted `target_logits_indices`. The exception dump confirmed the signature: 192 indices with only the first 6 (48 bytes) replaced by foreign float bit-patterns while the remaining 186 stayed valid — classic head-of-buffer overwrite, not a computation error.

**Fix**: Retain each pinned staging tensor together with a completion event in a deque, and reclaim both lazily via the non-blocking `Event.query()` at the next call — mirroring the existing `_copy_cpu_encoder_cache_to_device()` pattern in the same file. The async copy semantics are unchanged (still `non_blocking=True`, zero host-side synchronization); the only hot-path overhead is one extra event record per tensor. Peak retained staging is bounded at ~2 steps' worth of metadata (< 2 KB).

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

- Added unit test `TestNPUModelRunnerAsyncH2DStaging` in `tests/ut/worker/test_model_runner_v1.py`; existing cpu-ut passes.
- NPU regression (graph + async scheduling, DSpark=6, concurrency 128) in progress; results will be appended.
- vLLM main: https://github.com/vllm-project/vllm/commit/ba07e4a48fc951300d97eb506217dd530583dea3
