### PR TITLE
[BugFix][Scheduler] Return per-request spec decode metrics

### DIFF
--- a/docs/source/user_guide/feature_guide/speculative_decoding.md
+++ b/docs/source/user_guide/feature_guide/speculative_decoding.md
@@ -38,6 +38,26 @@ All speculative decoding methods are configured through the `speculative_config`
 - **`draft_tensor_parallel_size`** (int, optional): Tensor parallelism size for the draft model. Can only be `1` or the same as the target model's tensor parallel size.
 - **`disable_padded_drafter_batch`** (bool, default: `False`): Disable input padding for speculative decoding. If set to `True`, speculative input batches can contain sequences of different lengths, which may only be supported by certain attention backends. **Note:** Only effective with `eagle`, `eagle3`, `mtp`, `dflash`, `draft_model`, and `extract_hidden_states` methods.
 
+### Per-request metrics
+
+For online serving, `--per-request-spec-decode-metrics` adds speculative-decoding
+statistics to each single-sequence OpenAI API response. The supported levels are
+`none` (default), `summary`, and `detailed`:
+
+```shell
+vllm serve Qwen/Qwen3-0.6B \
+  --speculative-config '{"method":"ngram","num_speculative_tokens":3,"prompt_lookup_min":1,"prompt_lookup_max":4}' \
+  --per-request-spec-decode-metrics detailed
+```
+
+The result is returned under `metrics.speculative_decoding`. Summary mode reports
+the mean acceptance length, draft acceptance rate, acceptance histogram, and
+aggregate draft/accepted-token counts. Detailed mode additionally reports the
+drafted and accepted token count for every verification step. For streaming
+responses, set `stream_options.include_usage=true`; the metrics are included in
+the final usage chunk. Metrics are not returned for requests with multiple output
+sequences (`n > 1`).
+
 **Offline inference** — pass `speculative_config` as a Python dict to `LLM()`:
 
 ```python

--- a/tests/e2e/pull_request/one_card/spec_decode/test_per_request_metrics.py
+++ b/tests/e2e/pull_request/one_card/spec_decode/test_per_request_metrics.py
@@ -1,0 +1,106 @@
+from __future__ import annotations
+
+import json
+import math
+import os
+from typing import Any
+
+import requests
+from vllm.utils.network_utils import get_open_port
+
+from tests.e2e.conftest import RemoteOpenAIServer
+
+MODEL = os.environ.get("VLLM_TEST_MODEL", "Qwen/Qwen3-0.6B")
+
+
+def _validate_detailed_metrics(metrics: dict[str, Any]) -> None:
+    histogram = metrics["acceptance_histogram"]
+    accepted_per_step = metrics["per_step_accepted"]
+    drafted_per_step = metrics["per_step_drafted"]
+
+    assert metrics["num_spec_steps"] > 0
+    assert metrics["num_draft_tokens"] > 0
+    assert metrics["num_spec_steps"] == sum(histogram)
+    assert metrics["num_accepted_draft_tokens"] == sum(accepted * count for accepted, count in enumerate(histogram))
+    assert metrics["num_accepted_draft_tokens"] == sum(accepted_per_step)
+    assert metrics["num_draft_tokens"] == sum(drafted_per_step)
+    assert len(accepted_per_step) == metrics["num_spec_steps"]
+    assert len(drafted_per_step) == metrics["num_spec_steps"]
+    assert math.isclose(
+        metrics["mean_acceptance_length"],
+        1 + metrics["num_accepted_draft_tokens"] / metrics["num_spec_steps"],
+    )
+    assert math.isclose(
+        metrics["draft_acceptance_rate"],
+        metrics["num_accepted_draft_tokens"] / metrics["num_draft_tokens"],
+    )
+
+
+def test_per_request_spec_decode_metrics():
+    port = get_open_port()
+    server_args = [
+        "--enforce-eager",
+        "--max-model-len",
+        "1024",
+        "--gpu-memory-utilization",
+        "0.35",
+        "--speculative-config",
+        json.dumps(
+            {
+                "method": "ngram",
+                "num_speculative_tokens": 3,
+                "prompt_lookup_min": 1,
+                "prompt_lookup_max": 4,
+            }
+        ),
+        "--per-request-spec-decode-metrics",
+        "detailed",
+        "--port",
+        str(port),
+    ]
+    prompt = "alpha beta gamma alpha beta gamma alpha beta gamma alpha beta"
+    payload = {
+        "model": MODEL,
+        "prompt": prompt,
+        "temperature": 0,
+        "seed": 42,
+        "max_tokens": 24,
+    }
+
+    with RemoteOpenAIServer(
+        MODEL,
+        server_args,
+        server_host="127.0.0.1",
+        server_port=port,
+        auto_port=False,
+    ) as server:
+        response = requests.post(
+            server.url_for("v1", "completions"),
+            json=payload,
+            timeout=120,
+        )
+        response.raise_for_status()
+        metrics = response.json()["metrics"]["speculative_decoding"]
+        _validate_detailed_metrics(metrics)
+
+        stream_response = requests.post(
+            server.url_for("v1", "completions"),
+            json={
+                **payload,
+                "stream": True,
+                "stream_options": {"include_usage": True},
+            },
+            stream=True,
+            timeout=120,
+        )
+        stream_response.raise_for_status()
+        chunks = [
+            json.loads(line.removeprefix("data: "))
+            for line in stream_response.iter_lines(decode_unicode=True)
+            if line and line != "data: [DONE]"
+        ]
+        metric_chunks = [chunk for chunk in chunks if chunk.get("metrics") is not None]
+        assert len(metric_chunks) == 1
+        assert metric_chunks[0] is chunks[-1]
+        assert metric_chunks[0]["usage"] is not None
+        _validate_detailed_metrics(metric_chunks[0]["metrics"]["speculative_decoding"])

--- a/tests/ut/core/test_recompute_scheduler.py
+++ b/tests/ut/core/test_recompute_scheduler.py
@@ -23,6 +23,8 @@ from vllm.v1.kv_cache_interface import (
     MLAAttentionSpec,
     SlidingWindowMLASpec,
 )
+from vllm.v1.metrics.stats import RequestSpecDecodeMetrics
+from vllm.v1.outputs import ModelRunnerOutput
 from vllm.v1.request import Request, RequestStatus
 
 from vllm_ascend.core.recompute_scheduler import (
@@ -88,6 +90,81 @@ def test_recompute_notification_precedes_regular_output():
     assert output.finish_reason == FinishReason.STOP
     assert output.stop_reason == "recomputed"
     assert outputs[0][1].request_id == "regular-request"
+
+
+def test_update_from_output_returns_per_request_spec_decode_metrics():
+    scheduler = RecomputeScheduler.__new__(RecomputeScheduler)
+    scheduler.defer_block_free = False
+    scheduler.perf_metrics = None
+    scheduler.log_stats = False
+    scheduler.num_sampled_tokens_per_step = 1
+    scheduler.spec_decode_metrics_level = "detailed"
+    scheduler.enable_return_routed_experts = False
+    scheduler.connector = None
+    scheduler.grammar_compile_error_reqs = []
+    scheduler.recompute_kv_load_failures = True
+    scheduler.finished_req_ids_dict = None
+    scheduler.structured_output_manager = MagicMock()
+    scheduler.structured_output_manager.should_advance.return_value = False
+    scheduler.kv_cache_manager = MagicMock()
+    scheduler.kv_cache_manager.take_events.return_value = None
+    scheduler.kv_cache_manager.estimate_cached_tokens.return_value = 0
+    scheduler.kv_event_publisher = MagicMock()
+    scheduler.make_stats = MagicMock(return_value=None)
+    scheduler._handle_stopped_request = MagicMock(return_value=False)
+
+    request = Request(
+        request_id="spec-request",
+        prompt_token_ids=[1],
+        sampling_params=SamplingParams(max_tokens=4),
+        pooling_params=None,
+    )
+    request.status = RequestStatus.RUNNING
+    request.num_in_flight_tokens = 4
+    request.num_computed_tokens = 1
+    request.spec_decode_metrics = RequestSpecDecodeMetrics.new(3)
+    scheduler.requests = {request.request_id: request}
+    scheduler.running = [request]
+    scheduler.waiting = MagicMock()
+    scheduler.skipped_waiting = MagicMock()
+
+    def finish_request(req, token_ids, *, is_stale):
+        req.status = RequestStatus.FINISHED_LENGTH_CAPPED
+        return token_ids, True
+
+    scheduler._update_request_with_output = MagicMock(side_effect=finish_request)
+
+    scheduler_output = SimpleNamespace(
+        recomputed_reqs=None,
+        num_scheduled_tokens={request.request_id: 4},
+        total_num_scheduled_tokens=4,
+        scheduled_spec_decode_tokens={request.request_id: [11, 12, 13]},
+        num_invalid_spec_tokens={request.request_id: 1},
+    )
+    model_runner_output = ModelRunnerOutput(
+        req_ids=[request.request_id],
+        req_id_to_index={request.request_id: 0},
+        sampled_token_ids=[[11, 12, 99]],
+        logprobs=None,
+        prompt_logprobs_dict={},
+        pooler_output=[],
+    )
+
+    outputs = scheduler.update_from_output(scheduler_output, model_runner_output)
+
+    output = outputs[0].outputs[0]
+    assert output.spec_decode_metrics is request.spec_decode_metrics
+    assert output.spec_decode_metrics.to_dict() == {
+        "mean_acceptance_length": 3.0,
+        "draft_acceptance_rate": 1.0,
+        "acceptance_histogram": [0, 0, 1, 0],
+        "num_spec_steps": 1,
+        "num_accepted_draft_tokens": 2,
+        "num_draft_tokens": 2,
+        "num_spec_tokens": 3,
+        "per_step_accepted": [2],
+        "per_step_drafted": [2],
+    }
 
 
 def test_finish_recomputed_request_uses_normal_abort_cleanup():

--- a/vllm_ascend/core/recompute_scheduler.py
+++ b/vllm_ascend/core/recompute_scheduler.py
@@ -1189,6 +1189,18 @@ class RecomputeScheduler(Scheduler):
                     num_invalid_spec_tokens=scheduler_output.num_invalid_spec_tokens,
                     request_id=req_id,
                 )
+                if request.spec_decode_metrics is not None:
+                    # Exclude grammar-invalidated drafts from the proposed
+                    # count, mirroring make_spec_decoding_stats; the accepted
+                    # bucket (j) is unaffected.
+                    adj_draft_tokens = num_draft_tokens
+                    if scheduler_output.num_invalid_spec_tokens:
+                        adj_draft_tokens -= scheduler_output.num_invalid_spec_tokens.get(req_id, 0)
+                    request.spec_decode_metrics.observe(
+                        num_draft_tokens=adj_draft_tokens,
+                        num_accepted=num_accepted,
+                        detailed=self.spec_decode_metrics_level == "detailed",
+                    )
 
             # Free encoder inputs only after the step has actually executed.
             if request.has_encoder_inputs:
@@ -1312,6 +1324,7 @@ class RecomputeScheduler(Scheduler):
                         stop_reason=request.stop_reason,
                         events=request.take_events(),
                         prefill_stats=prefill_stats,
+                        spec_decode_metrics=(request.spec_decode_metrics if finish_reason is not None else None),
                         kv_transfer_params=kv_transfer_params,
                         ec_transfer_params=ec_transfer_params,
                         trace_headers=request.trace_headers,


### PR DESCRIPTION
### What this PR does / why we need it?

Upstream vLLM added per-request speculative decoding metrics in vllm-project/vllm#48915. The Ascend `RecomputeScheduler` maintains its own `update_from_output` implementation, but it did not update `RequestSpecDecodeMetrics` or attach the collected metrics to the final `EngineCoreOutput`. Consequently, requests using the recompute scheduler could not return the requested speculative decoding metrics.

This PR keeps the Ascend scheduler aligned with the upstream behavior by:

- recording drafted and accepted tokens for each request;
- excluding grammar-invalid draft tokens from the drafted-token count;
- attaching metrics only to the request's final engine output;
- adding focused unit coverage for the recompute scheduler;
- adding a single-card NPU OpenAI API E2E test for normal and streaming responses;
- documenting the `summary` and `detailed` response formats.

Related upstream change: https://github.com/vllm-project/vllm/pull/48915

### Does this PR introduce _any_ user-facing change?

Yes. When `--per-request-spec-decode-metrics summary` or `detailed` is explicitly enabled, requests handled by the Ascend recompute scheduler now return `metrics.speculative_decoding` in the final response. The default `none` behavior is unchanged.

### How was this patch tested?

- Unit regression: `pytest -q tests/ut/core/test_recompute_scheduler.py` (`6 passed`).
- Single-card Ascend 910B3 E2E with Qwen3-0.6B and the n-gram proposer: `VLLM_TEST_MODEL=Qwen/Qwen3-0.6B pytest -sv tests/e2e/pull_request/one_card/spec_decode/test_per_request_metrics.py` (`1 passed`).
- Manually verified `none`, `summary`, and `detailed` modes; streaming only exposes metrics on the final usage chunk; `n=2` remains unsupported and does not expose misleading metrics; n-gram and suffix proposer stability loops passed.
- Ruff 0.14.0 formatting and lint checks, Markdownlint 0.45.0, Codespell 2.4.1, and `git diff --check` passed for the changed files.
- The full `format.sh ci` wrapper was also attempted, but its first-time Actionlint bootstrap could not download a Go dependency because `proxy.golang.org` timed out. The direct language-specific checks above passed.

#### Real MTP model validation on Ascend 910B3

The OpenAI-compatible response path was additionally validated with two real Qwen3.6 checkpoints on two Ascend 910B3 64 GiB NPUs. Both services were restricted to physical devices 4 and 5 with `ASCEND_RT_VISIBLE_DEVICES=4,5` and used three speculative tokens per MTP step.

Common relevant arguments:

```bash
--tensor-parallel-size 2 \
--speculative-config '{"method":"qwen3_5_mtp","num_speculative_tokens":3,"enforce_eager":true}' \
--compilation-config '{"cudagraph_mode":"FULL_DECODE_ONLY"}' \
--per-request-spec-decode-metrics detailed
```

Model-specific configurations and results:

| Model | Configuration | Detailed response | Streaming | Stability |
| --- | --- | --- | --- | --- |
| Qwen3.6-27B-w8a8 | TP2, Ascend W8A8 | Passed | Passed | 5 sequential + 4 concurrent requests passed |
| Qwen3.6-35B-A3B | TP2 + EP2, BF16 MoE | Passed | Passed | 5 sequential + 4 concurrent requests passed |

Representative 27B response metrics:

```json
{
  "mean_acceptance_length": 3.6666666666666665,
  "draft_acceptance_rate": 0.8888888888888888,
  "num_spec_steps": 18,
  "num_accepted_draft_tokens": 48,
  "num_draft_tokens": 54,
  "num_spec_tokens": 3
}
```

Representative 35B-A3B response metrics:

```json
{
  "mean_acceptance_length": 3.142857142857143,
  "draft_acceptance_rate": 0.7142857142857143,
  "num_spec_steps": 21,
  "num_accepted_draft_tokens": 45,
  "num_draft_tokens": 63,
  "num_spec_tokens": 3
}
```

For both models, the following invariants were checked:

- the acceptance histogram sums to `num_spec_steps`;
- its weighted sum equals `num_accepted_draft_tokens`;
- the per-step accepted and drafted arrays reproduce their aggregate totals;
- every step satisfies `0 <= accepted <= drafted`;
- the reported acceptance rate and mean acceptance length match the aggregate counts;
- in streaming mode, metrics appear exactly once, on the final usage chunk.

No `ERROR`, traceback, OOM, or runtime failure was observed in either model log. This online-serving validation exercises the standard scheduler's upstream metric propagation with the Ascend MTP model runner and backend. The Ascend-specific `RecomputeScheduler` is selected only on a PD-disaggregated decode node, so its changed path is covered by the focused unit regression above rather than by these standalone `vllm serve` runs.

- vLLM main: https://github.com/vllm-project/vllm/commit/ba07e4a48fc951300d97eb506217dd530583dea3
