### PR TITLE
[Feature][Ops] Support original sparse indices in SCFA

### DIFF
--- a/csrc/attention/sparse_attn_sharedkv/README.md
+++ b/csrc/attention/sparse_attn_sharedkv/README.md
@@ -78,7 +78,7 @@
 - 目前暂不支持返回`softmax_lse`，`return_softmax_lse`仅支持输入False，返回值`softmax_lse`为无效值。
 - ori_mask_mode及cmp_mask_mode所表示的mask模式的详细介绍见[sparse_mode参数说明](../../../docs/zh/context/sparse_mode参数说明.md)。
 - 目前暂不支持指定`q`中参与运算的token数，因此设置`seqused_q`无效。
-- 目前暂不支持对`ori_kv`进行稀疏计算，因此设置`ori_sparse_indices`无效。
+- `ori_sparse_indices`中的非负值是`ori_kv`的physical slot，按顺序参与计算；每行从首个负值开始为padding。
 - 目前所有输入不支持传入空tensor。
 - `q`、`ori_kv`、`cmp_kv`数据排布格式支持从多种维度解读，B（Batch）表示输入样本批量大小、S（Seq-Length）表示输入样本序列长度、H（Hidden-Size）表示隐藏层的大小、N（Head-Num）表示多头数、D（Head-Dim）表示hidden层最小的单元尺寸，且满足D=H/N、T表示所有Batch输入样本序列长度的累加和。
 - Q\_S和S1表示q shape中的S，S2表示ori_kv shape中的S，S3表示cmp_kv shape中的S；Q\_N和N1表示num\_q\_heads，KV\_N和N2表示num\_ori_kv\_heads和num\_cmp_kv\_heads；Q\_T和T1表示q shape中的输入样本序列长度的累加和。

--- a/csrc/attention/sparse_attn_sharedkv/op_kernel/arch32/sparse_attn_sharedkv_scfa_block_cube.h
+++ b/csrc/attention/sparse_attn_sharedkv/op_kernel/arch32/sparse_attn_sharedkv_scfa_block_cube.h
@@ -41,7 +41,8 @@ public:
                                                GlobalTensor<OUT_T> attentionOutGm);
     __aicore__ inline void InitPageAttentionInfo(GlobalTensor<KV_T> oriKvGm, const GlobalTensor<KV_T> &kvMergeGm,
                                                  GlobalTensor<int32_t> oriBlockTableGm,
-                                                 GlobalTensor<int32_t> cmpBlockTableGm);
+                                                 GlobalTensor<int32_t> cmpBlockTableGm,
+                                                 GlobalTensor<int32_t> oriSparseIndicesGm);
     __aicore__ inline void InitBuffers(TPipe *pipe);
 
     __aicore__ inline void AllocEventID();
@@ -114,6 +115,7 @@ private:
     // block_table
     GlobalTensor<int32_t> oriBlockTableGm;
     GlobalTensor<int32_t> cmpBlockTableGm;
+    GlobalTensor<int32_t> oriSparseIndicesGm;
 
     TBuf<TPosition::A1> bufQPL1;
     TBuf<TPosition::A1> bufKVL1;
@@ -184,12 +186,15 @@ __aicore__ inline void SASCubeBlock<SAST>::InitMm2GlobalTensor(GlobalTensor<KV_T
 template <typename SAST>
 __aicore__ inline void
 SASCubeBlock<SAST>::InitPageAttentionInfo(GlobalTensor<KV_T> oriKvGm, const GlobalTensor<KV_T> &kvMergeGm,
-                                          GlobalTensor<int32_t> oriBlockTableGm, GlobalTensor<int32_t> cmpBlockTableGm)
+                                          GlobalTensor<int32_t> oriBlockTableGm,
+                                          GlobalTensor<int32_t> cmpBlockTableGm,
+                                          GlobalTensor<int32_t> oriSparseIndicesGm)
 {
     this->oriKvGm = oriKvGm;
     this->kvMergeGm_ = kvMergeGm;
     this->oriBlockTableGm = oriBlockTableGm;
     this->cmpBlockTableGm = cmpBlockTableGm;
+    this->oriSparseIndicesGm = oriSparseIndicesGm;
 }
 
 template <typename SAST>
@@ -369,12 +374,7 @@ __aicore__ inline void SASCubeBlock<SAST>::ComputeMm1(const RunInfo &info, const
                     LocalTensor<KV_T> kTensor;
                     uint32_t copyRowCnt = 0;
 
-                    while (copyFinishRowCnt < nL1Size) {
-                        // 由于ori_left的存在， 即使第一块搬运也可能并非是pa_block的零点位
-                        copyRowCnt = constInfo.paOriBlockSize - curS2Offset % constInfo.paOriBlockSize;
-                        if (copyFinishRowCnt + copyRowCnt > nL1Size) {
-                            copyRowCnt = nL1Size - copyFinishRowCnt;
-                        }
+                    if (constInfo.hasOriSparseIndices) {
                         PAShape shape;
                         shape.blockSize = constInfo.paOriBlockSize;
                         shape.headNum = constInfo.kvHeadNum;
@@ -382,20 +382,46 @@ __aicore__ inline void SASCubeBlock<SAST>::ComputeMm1(const RunInfo &info, const
                         shape.kvStride = constInfo.oriKvStride;
                         shape.actHeadDim = D_SPLIT_SIZE;
                         shape.maxblockNumPerBatch = constInfo.oriMaxBlockNumPerBatch;
-                        shape.copyRowNum = copyRowCnt;
+                        shape.copyRowNum = nL1Size;
                         shape.copyRowNumAlign = nL1SizeAlign;
-                        kTensor = bL1Tensor[copyFinishRowCnt * 16];
-
                         Position startPos;
                         startPos.bIdx = info.bIdx;
                         startPos.n2Idx = info.n2Idx;
-                        startPos.s2Idx = curS2Offset;
-                        startPos.dIdx = kL1 * D_SPLIT_SIZE;  // mm1 右矩阵 bn2s2d, d为k轴不切; mm2 右矩阵, s2为k轴, d轴切分
-                        DataCopyPA<KV_T>(kTensor, oriKvGm, oriBlockTableGm, shape, startPos);
-
-                        // 更新循环变量
-                        copyFinishRowCnt += copyRowCnt;
-                        curS2Offset += copyRowCnt;
+                        startPos.s2Idx = 0;
+                        startPos.dIdx = kL1 * D_SPLIT_SIZE;
+                        uint64_t sparseIndexBaseOffset =
+                            (info.qTokenOffset * constInfo.kvHeadNum + info.n2Idx) *
+                            constInfo.oriSparseIndexWidth;
+                        uint32_t sparseIndexStart =
+                            info.s2Idx * constInfo.s2BaseSize + nL1 * N_SPLIT_SIZE;
+                        DataCopyPABySlots<KV_T>(bL1Tensor, oriKvGm, oriSparseIndicesGm, shape, startPos,
+                                                sparseIndexBaseOffset, sparseIndexStart);
+                    } else {
+                        while (copyFinishRowCnt < nL1Size) {
+                            // 由于ori_left的存在， 即使第一块搬运也可能并非是pa_block的零点位
+                            copyRowCnt = constInfo.paOriBlockSize - curS2Offset % constInfo.paOriBlockSize;
+                            if (copyFinishRowCnt + copyRowCnt > nL1Size) {
+                                copyRowCnt = nL1Size - copyFinishRowCnt;
+                            }
+                            PAShape shape;
+                            shape.blockSize = constInfo.paOriBlockSize;
+                            shape.headNum = constInfo.kvHeadNum;
+                            shape.headDim = constInfo.headDim;
+                            shape.kvStride = constInfo.oriKvStride;
+                            shape.actHeadDim = D_SPLIT_SIZE;
+                            shape.maxblockNumPerBatch = constInfo.oriMaxBlockNumPerBatch;
+                            shape.copyRowNum = copyRowCnt;
+                            shape.copyRowNumAlign = nL1SizeAlign;
+                            kTensor = bL1Tensor[copyFinishRowCnt * 16];
+                            Position startPos;
+                            startPos.bIdx = info.bIdx;
+                            startPos.n2Idx = info.n2Idx;
+                            startPos.s2Idx = curS2Offset;
+                            startPos.dIdx = kL1 * D_SPLIT_SIZE;
+                            DataCopyPA<KV_T>(kTensor, oriKvGm, oriBlockTableGm, shape, startPos);
+                            copyFinishRowCnt += copyRowCnt;
+                            curS2Offset += copyRowCnt;
+                        }
                     }
                 } else if constexpr (KV_LAYOUT_T == SAS_LAYOUT::BSND) {
                     Nd2NzParams nd2nzPara;
@@ -631,16 +657,12 @@ __aicore__ inline void SASCubeBlock<SAST>::ComputeMm2(const RunInfo &info, const
                     if constexpr (KV_LAYOUT_T == SAS_LAYOUT::PA_ND) {
                         uint32_t copyFinishRowCnt = 0;
                         uint32_t curS2Offset = info.s2Idx * constInfo.s2BaseSize + info.s2StartPoint;
-                        while (copyFinishRowCnt < kL0Size) {
-                            copyRowCnt = constInfo.paOriBlockSize - curS2Offset % constInfo.paOriBlockSize;
-                            if (copyFinishRowCnt + copyRowCnt > kL0Size) {
-                                copyRowCnt = kL0Size - copyFinishRowCnt;
-                            }
+                        if (constInfo.hasOriSparseIndices) {
                             Position startPos;
                             startPos.bIdx = info.bIdx;
                             startPos.n2Idx = info.n2Idx;
-                            startPos.s2Idx = curS2Offset;
-                            startPos.dIdx = nL1 * N_SPLIT_SIZE;  // mm1 右矩阵 bn2s2d, d为k轴不切; mm2 右矩阵, s2为k轴, d轴切分
+                            startPos.s2Idx = 0;
+                            startPos.dIdx = nL1 * N_SPLIT_SIZE;
                             PAShape shape;
                             shape.blockSize = constInfo.paOriBlockSize;
                             shape.headNum = constInfo.kvHeadNum;
@@ -648,15 +670,41 @@ __aicore__ inline void SASCubeBlock<SAST>::ComputeMm2(const RunInfo &info, const
                             shape.kvStride = constInfo.oriKvStride;
                             shape.actHeadDim = nL1Size;
                             shape.maxblockNumPerBatch = constInfo.oriMaxBlockNumPerBatch;
-                            shape.copyRowNum = copyRowCnt;
+                            shape.copyRowNum = kL0Size;
                             shape.copyRowNumAlign = kL0SizeAlign;
-                            subvTensor = bL1Tensor[(kL1 - kOffset) * 128 * N_SPLIT_SIZE + copyFinishRowCnt * 16];
-
-                            DataCopyPA<KV_T>(subvTensor, oriKvGm, oriBlockTableGm, shape, startPos);
-
-                            // 更新循环变量
-                            copyFinishRowCnt += copyRowCnt;
-                            curS2Offset += copyRowCnt;
+                            subvTensor = bL1Tensor[(kL1 - kOffset) * K_L0_SPLIT_SIZE * N_SPLIT_SIZE];
+                            uint64_t sparseIndexBaseOffset =
+                                (info.qTokenOffset * constInfo.kvHeadNum + info.n2Idx) *
+                                constInfo.oriSparseIndexWidth;
+                            uint32_t sparseIndexStart =
+                                info.s2Idx * constInfo.s2BaseSize + kL1 * K_L0_SPLIT_SIZE;
+                            DataCopyPABySlots<KV_T>(subvTensor, oriKvGm, oriSparseIndicesGm, shape, startPos,
+                                                    sparseIndexBaseOffset, sparseIndexStart);
+                        } else {
+                            while (copyFinishRowCnt < kL0Size) {
+                                copyRowCnt = constInfo.paOriBlockSize - curS2Offset % constInfo.paOriBlockSize;
+                                if (copyFinishRowCnt + copyRowCnt > kL0Size) {
+                                    copyRowCnt = kL0Size - copyFinishRowCnt;
+                                }
+                                Position startPos;
+                                startPos.bIdx = info.bIdx;
+                                startPos.n2Idx = info.n2Idx;
+                                startPos.s2Idx = curS2Offset;
+                                startPos.dIdx = nL1 * N_SPLIT_SIZE;
+                                PAShape shape;
+                                shape.blockSize = constInfo.paOriBlockSize;
+                                shape.headNum = constInfo.kvHeadNum;
+                                shape.headDim = constInfo.headDim;
+                                shape.kvStride = constInfo.oriKvStride;
+                                shape.actHeadDim = nL1Size;
+                                shape.maxblockNumPerBatch = constInfo.oriMaxBlockNumPerBatch;
+                                shape.copyRowNum = copyRowCnt;
+                                shape.copyRowNumAlign = kL0SizeAlign;
+                                subvTensor = bL1Tensor[(kL1 - kOffset) * 128 * N_SPLIT_SIZE + copyFinishRowCnt * 16];
+                                DataCopyPA<KV_T>(subvTensor, oriKvGm, oriBlockTableGm, shape, startPos);
+                                copyFinishRowCnt += copyRowCnt;
+                                curS2Offset += copyRowCnt;
+                            }
                         }
                     } else if constexpr (KV_LAYOUT_T == SAS_LAYOUT::BSND) {
                         Nd2NzParams nd2nzPara;

--- a/csrc/attention/sparse_attn_sharedkv/op_kernel/arch32/sparse_attn_sharedkv_scfa_block_vector.h
+++ b/csrc/attention/sparse_attn_sharedkv/op_kernel/arch32/sparse_attn_sharedkv_scfa_block_vector.h
@@ -610,9 +610,11 @@ __aicore__ inline void SASVectorBlock<SAST>::CopyInKv(int64_t &mte2Size, int64_t
         keySrcStride = ((keyOffset1 > keyOffset2 ? (keyOffset1 - keyOffset2) :
 	                    (keyOffset2 - keyOffset1)) - constInfo.sparseBlockSize) * constInfo.headDim * sizeof(KV_T);
     }
+    constexpr bool isPagedLayout = (KV_LAYOUT_T == SAS_LAYOUT::PA_ND);
     if (unlikely(keySrcStride >= INT32_MAX || keySrcStride < 0 ||
         realS2Idx1 + constInfo.sparseBlockSize >= s2IdLimit ||
-        realS2Idx2 + constInfo.sparseBlockSize >= s2IdLimit)) {
+        realS2Idx2 + constInfo.sparseBlockSize >= s2IdLimit ||
+        (isPagedLayout && keyOffset1 >= 0 && keyOffset2 >= 0 && keyOffset2 < keyOffset1))) {
         // stride溢出、stride为负数、s2超长等异常场景，还原成2条搬运指令
         // 因为需要拷贝两块
         CopyInSingleKv(mte2Size, mte3Size, mergeMte3Idx, realS2Idx1, keyOffset1, s2IdLimit, runInfo);

--- a/csrc/attention/sparse_attn_sharedkv/op_kernel/arch32/sparse_attn_sharedkv_scfa_kernel.h
+++ b/csrc/attention/sparse_attn_sharedkv/op_kernel/arch32/sparse_attn_sharedkv_scfa_kernel.h
@@ -144,6 +144,7 @@ private:
 
     GlobalTensor<int32_t> oriBlockTableGm;
     GlobalTensor<int32_t> cmpBlockTableGm;
+    GlobalTensor<int32_t> oriSparseIndicesGm;
     GlobalTensor<int32_t> topKGm;
 
     GlobalTensor<int32_t> actualSeqLengthsQGm;
@@ -180,6 +181,7 @@ private:
                                       RunInfo &info);
     __aicore__ inline int32_t GetActualSeqLenQ(uint32_t bIdx);
     __aicore__ inline int32_t GetActualSeqLenKV(uint32_t bIdx);
+    __aicore__ inline uint32_t GetOriSparseActualSeqLen();
     __aicore__ inline void GetBN2Idx(uint32_t bN2Idx, uint32_t &bIdx, uint32_t &n2Idx);
     // ================================Mm1==============================================
     __aicore__ inline void ComputeMm1(const RunInfo &info);
@@ -214,6 +216,8 @@ __aicore__ inline void SparseAttnSharedkvScfa<SAST>::InitTilingData()
     constInfo.oriKvStride = tilingData->baseParams.oriKvStride;
     constInfo.oriWinLeft = tilingData->baseParams.oriWinLeft;
     constInfo.oriWinRight = tilingData->baseParams.oriWinRight;
+    constInfo.hasOriSparseIndices = tilingData->baseParams.hasOriSparseIndices;
+    constInfo.oriSparseIndexWidth = tilingData->baseParams.oriSparseIndexWidth;
 
     constInfo.actualLenDimsQ = tilingData->baseParams.actualLenDimsQ;
     constInfo.actualLenDimsKV = tilingData->baseParams.actualLenDimsKV;
@@ -360,6 +364,28 @@ __aicore__ inline int32_t SparseAttnSharedkvScfa<SAST>::GetActualSeqLenKV(uint32
 }
 
 template <typename SAST>
+__aicore__ inline uint32_t SparseAttnSharedkvScfa<SAST>::GetOriSparseActualSeqLen()
+{
+    if (!constInfo.hasOriSparseIndices || constInfo.oriSparseIndexWidth == 0 ||
+        tempLoopInfo.actOriS2Size <= 0) {
+        return 0;
+    }
+    uint64_t qTokenOffset = tempLoopInfo.actualSeqQPrefixSum + tempLoopInfo.s1StartIdx;
+    uint64_t sparseIndexBaseOffset =
+        (qTokenOffset * constInfo.kvHeadNum + tempLoopInfo.n2Idx) * constInfo.oriSparseIndexWidth;
+    // Match SWA: each (query, KV head) row ends at its first negative physical slot.
+    uint32_t maxSparseLen = Min(static_cast<uint64_t>(constInfo.oriSparseIndexWidth),
+                                static_cast<uint64_t>(tempLoopInfo.actOriS2Size));
+    uint32_t sparseLen = 0;
+    for (; sparseLen < maxSparseLen; ++sparseLen) {
+        if (oriSparseIndicesGm.GetValue(sparseIndexBaseOffset + sparseLen) < 0) {
+            break;
+        }
+    }
+    return sparseLen;
+}
+
+template <typename SAST>
 __aicore__ inline void SparseAttnSharedkvScfa<SAST>::GetSparseActualSeqLen()
 {
     // 行无效通过ori部分判断, ori部分如果有行无效那么ori和cmp都有
@@ -397,7 +423,6 @@ __aicore__ inline void SparseAttnSharedkvScfa<SAST>::Init(
     __gm__ uint8_t *workspace, const SparseAttnSharedkvTilingData *__restrict tiling, __gm__ uint8_t *gmTiling,
     TPipe *tPipe)
 {
-    (void)oriSparseIndices;
     if ASCEND_IS_AIV {
         tmpBlockIdx = GetBlockIdx(); // vec:0-47
         aiCoreIdx = tmpBlockIdx / 2;
@@ -446,6 +471,9 @@ __aicore__ inline void SparseAttnSharedkvScfa<SAST>::Init(
     if constexpr (PAGE_ATTENTION) {
         oriBlockTableGm.SetGlobalBuffer((__gm__ int32_t *)oriBlockTable);
         cmpBlockTableGm.SetGlobalBuffer((__gm__ int32_t *)cmpBlockTable);
+        if (constInfo.hasOriSparseIndices) {
+            oriSparseIndicesGm.SetGlobalBuffer((__gm__ int32_t *)oriSparseIndices);
+        }
     }
     topKGm.SetGlobalBuffer((__gm__ int32_t *)cmpSparseIndices);
 
@@ -490,7 +518,8 @@ __aicore__ inline void SparseAttnSharedkvScfa<SAST>::Init(
         cubeBlock.InitParams(constInfo);
         cubeBlock.InitMm1GlobalTensor(queryGm, oriKvGm, cmpKvGm, mm1ResGm);
         cubeBlock.InitMm2GlobalTensor(vec1ResGm, mm2ResGm, attentionOutGm);
-        cubeBlock.InitPageAttentionInfo(oriKvGm, kvMergeGm_, oriBlockTableGm, cmpBlockTableGm);
+        cubeBlock.InitPageAttentionInfo(oriKvGm, kvMergeGm_, oriBlockTableGm, cmpBlockTableGm,
+                                        oriSparseIndicesGm);
     }
     // 要在InitParams之后执行
     if (pipe != nullptr) {
@@ -574,6 +603,11 @@ __aicore__ inline void SparseAttnSharedkvScfa<SAST>::CalcParams(uint32_t loop, u
     info.tensorCmpBOffset = tensorCmpBCoreOffset;
     info.attenOutOffset = tensorACoreOffset;
     info.topKBaseOffset = topKBaseOffset;
+    if constexpr (LAYOUT_T == SAS_LAYOUT::TND) {
+        info.qTokenOffset = tempLoopInfo.actualSeqQPrefixSum + info.s1Idx;
+    } else {
+        info.qTokenOffset = info.bIdx * constInfo.qSeqSize + info.s1Idx;
+    }
 
     if (s2LoopIdx < tempLoopInfo.oriLoopTimes) {
         // S2首次循环只能在ori_kv
@@ -585,7 +619,7 @@ __aicore__ inline void SparseAttnSharedkvScfa<SAST>::CalcParams(uint32_t loop, u
         } else {
             info.actualSingleProcessSInnerSize = constInfo.s2BaseSize;
         }
-        info.s2StartPoint = tempLoopInfo.oriMaskLeft;
+        info.s2StartPoint = constInfo.hasOriSparseIndices ? 0 : tempLoopInfo.oriMaskLeft;
         info.cmpS2IdLimit = (tempLoopInfo.cmpMaskRight + tempLoopInfo.s1EndIdx + 1) / constInfo.cmpRatio;
     } else {
         info.isOri = false;
@@ -715,12 +749,18 @@ __aicore__ inline void SparseAttnSharedkvScfa<SAST>::ProcessBalance()
                 Min((tempLoopInfo.s1StartIdx + constInfo.mBaseSize / constInfo.gSize - 1), tempLoopInfo.actS1Size - 1);
 
             // 此处均为闭区间
-            tempLoopInfo.oriMaskRight = tempLoopInfo.actOriS2Size - tempLoopInfo.actS1Size +
-                                        static_cast<int32_t>(tempLoopInfo.s1EndIdx) + constInfo.oriWinRight;
-            tempLoopInfo.oriMaskRight = Min(tempLoopInfo.oriMaskRight, tempLoopInfo.actOriS2Size - 1);
-            tempLoopInfo.oriMaskLeft = Max(tempLoopInfo.actOriS2Size - tempLoopInfo.actS1Size +
-                                               static_cast<int32_t>(tempLoopInfo.s1EndIdx) - constInfo.oriWinLeft,
-                                           0);
+            if (constInfo.hasOriSparseIndices) {
+                uint32_t sparseOriS2Size = GetOriSparseActualSeqLen();
+                tempLoopInfo.oriMaskLeft = 0;
+                tempLoopInfo.oriMaskRight = sparseOriS2Size == 0 ? -1 : static_cast<int32_t>(sparseOriS2Size - 1U);
+            } else {
+                tempLoopInfo.oriMaskRight = tempLoopInfo.actOriS2Size - tempLoopInfo.actS1Size +
+                                            static_cast<int32_t>(tempLoopInfo.s1EndIdx) + constInfo.oriWinRight;
+                tempLoopInfo.oriMaskRight = Min(tempLoopInfo.oriMaskRight, tempLoopInfo.actOriS2Size - 1);
+                tempLoopInfo.oriMaskLeft = Max(tempLoopInfo.actOriS2Size - tempLoopInfo.actS1Size +
+                                                   static_cast<int32_t>(tempLoopInfo.s1EndIdx) - constInfo.oriWinLeft,
+                                               0);
+            }
             tempLoopInfo.cmpMaskRight = tempLoopInfo.actOriS2Size - tempLoopInfo.actS1Size;
             GetSparseActualSeqLen();
             UpdateInnerLoopCond();

--- a/tests/e2e/nightly/single_node/ops/singlecard_ops/test_sparse_attn_sharedkv_scfa_indices.py
+++ b/tests/e2e/nightly/single_node/ops/singlecard_ops/test_sparse_attn_sharedkv_scfa_indices.py
@@ -1,0 +1,464 @@
+# SPDX-License-Identifier: Apache-2.0
+
+import math
+
+import pytest
+import torch
+import torch_npu  # noqa: F401
+
+from vllm_ascend.utils import enable_custom_op
+
+enable_custom_op()
+
+HEAD_DIM = 512
+NUM_Q_HEADS = 64
+NUM_KV_HEADS = 1
+INDEX_WIDTH = 512
+BLOCK_SIZE = 16
+
+
+def _reference_attention(
+    query: torch.Tensor,
+    rows_per_query: list[torch.Tensor],
+    sinks: torch.Tensor,
+) -> torch.Tensor:
+    output = torch.empty_like(query)
+    scale = 1.0 / math.sqrt(HEAD_DIM)
+    for token_idx, kv_rows in enumerate(rows_per_query):
+        key = kv_rows.expand(-1, NUM_Q_HEADS, -1).float()
+        scores = torch.einsum("hd,khd->hk", query[token_idx].float(), key) * scale
+        sink = sinks.float().view(NUM_Q_HEADS, 1)
+        scores_max = torch.maximum(scores.max(dim=-1, keepdim=True).values, sink)
+        exp_scores = torch.exp(scores - scores_max)
+        probabilities = exp_scores / (exp_scores.sum(dim=-1, keepdim=True) + torch.exp(sink - scores_max))
+        output[token_idx] = torch.einsum("hk,khd->hd", probabilities, key).to(query.dtype)
+    return output
+
+
+def _make_kv_cache(
+    block_count: int,
+    dtype: torch.dtype,
+    device: torch.device,
+) -> torch.Tensor:
+    cache = torch.empty(block_count, BLOCK_SIZE, NUM_KV_HEADS, HEAD_DIM, device=device)
+    flat_cache = cache.view(-1, NUM_KV_HEADS, HEAD_DIM)
+    slot_ids = torch.arange(flat_cache.shape[0], device=device, dtype=torch.float32).view(-1, 1, 1)
+    feature_ids = torch.arange(HEAD_DIM, device=device, dtype=torch.float32).view(1, 1, -1)
+    # The first half drives MM1 scores while the second half makes MM2 values
+    # slot-specific, so either gather using the wrong slot is independently visible.
+    flat_cache[..., : HEAD_DIM // 2] = torch.sin(slot_ids * 0.013 + feature_ids[..., : HEAD_DIM // 2] * 0.017)
+    flat_cache[..., HEAD_DIM // 2 :] = torch.cos(slot_ids * 0.019 + feature_ids[..., HEAD_DIM // 2 :] * 0.011)
+    return (cache * 0.02).to(dtype)
+
+
+def _run_scfa(
+    query: torch.Tensor,
+    ori_kv: torch.Tensor,
+    cmp_kv: torch.Tensor,
+    ori_sparse_indices: torch.Tensor | None,
+    cmp_sparse_indices: torch.Tensor,
+    ori_block_table: torch.Tensor,
+    cmp_block_table: torch.Tensor,
+    cu_seqlens_q: torch.Tensor,
+    seqused_kv: torch.Tensor,
+    sinks: torch.Tensor,
+    cmp_ratio: int,
+) -> torch.Tensor:
+    batch_size = seqused_kv.shape[0]
+    metadata = torch.ops._C_ascend.npu_sparse_attn_sharedkv_metadata(
+        num_heads_q=NUM_Q_HEADS,
+        num_heads_kv=NUM_KV_HEADS,
+        head_dim=HEAD_DIM,
+        cu_seqlens_q=cu_seqlens_q,
+        seqused_kv=seqused_kv,
+        batch_size=batch_size,
+        max_seqlen_q=int((cu_seqlens_q[1:] - cu_seqlens_q[:-1]).max().item()),
+        max_seqlen_kv=int(seqused_kv.max().item()),
+        cmp_topk=cmp_sparse_indices.shape[-1],
+        cmp_ratio=cmp_ratio,
+        ori_mask_mode=4,
+        cmp_mask_mode=3,
+        ori_win_left=127,
+        ori_win_right=0,
+        layout_q="TND",
+        layout_kv="PA_ND",
+        has_ori_kv=True,
+        has_cmp_kv=True,
+        device=str(query.device),
+    )
+    return torch.ops._C_ascend.npu_sparse_attn_sharedkv(
+        query,
+        ori_kv=ori_kv,
+        cmp_kv=cmp_kv,
+        ori_sparse_indices=ori_sparse_indices,
+        cmp_sparse_indices=cmp_sparse_indices,
+        ori_block_table=ori_block_table,
+        cmp_block_table=cmp_block_table,
+        cu_seqlens_q=cu_seqlens_q,
+        seqused_kv=seqused_kv,
+        sinks=sinks,
+        metadata=metadata,
+        softmax_scale=1.0 / math.sqrt(HEAD_DIM),
+        cmp_ratio=cmp_ratio,
+        ori_mask_mode=4,
+        cmp_mask_mode=3,
+        ori_win_left=127,
+        ori_win_right=0,
+        layout_q="TND",
+        layout_kv="PA_ND",
+    )[0]
+
+
+def _run_swa(
+    query: torch.Tensor,
+    ori_kv: torch.Tensor,
+    ori_sparse_indices: torch.Tensor,
+    ori_block_table: torch.Tensor,
+    cu_seqlens_q: torch.Tensor,
+    seqused_kv: torch.Tensor,
+    sinks: torch.Tensor,
+) -> torch.Tensor:
+    batch_size = seqused_kv.shape[0]
+    metadata = torch.ops._C_ascend.npu_sparse_attn_sharedkv_metadata(
+        num_heads_q=NUM_Q_HEADS,
+        num_heads_kv=NUM_KV_HEADS,
+        head_dim=HEAD_DIM,
+        cu_seqlens_q=cu_seqlens_q,
+        seqused_kv=seqused_kv,
+        batch_size=batch_size,
+        max_seqlen_q=int((cu_seqlens_q[1:] - cu_seqlens_q[:-1]).max().item()),
+        max_seqlen_kv=int(seqused_kv.max().item()),
+        cmp_topk=0,
+        cmp_ratio=1,
+        ori_mask_mode=4,
+        cmp_mask_mode=3,
+        ori_win_left=127,
+        ori_win_right=0,
+        layout_q="TND",
+        layout_kv="PA_ND",
+        has_ori_kv=True,
+        has_cmp_kv=False,
+        device=str(query.device),
+    )
+    return torch.ops._C_ascend.npu_sparse_attn_sharedkv(
+        query,
+        ori_kv=ori_kv,
+        ori_sparse_indices=ori_sparse_indices,
+        ori_block_table=ori_block_table,
+        cu_seqlens_q=cu_seqlens_q,
+        seqused_kv=seqused_kv,
+        sinks=sinks,
+        metadata=metadata,
+        softmax_scale=1.0 / math.sqrt(HEAD_DIM),
+        cmp_ratio=1,
+        ori_mask_mode=4,
+        cmp_mask_mode=3,
+        ori_win_left=127,
+        ori_win_right=0,
+        layout_q="TND",
+        layout_kv="PA_ND",
+    )[0]
+
+
+@pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16])
+@pytest.mark.parametrize("cmp_ratio", [4, 128])
+@torch.inference_mode()
+def test_scfa_original_slots_match_dense_reference(dtype: torch.dtype, cmp_ratio: int):
+    torch.manual_seed(20260902 + cmp_ratio)
+    device = torch.device("npu:0")
+    q_lens = (2, 3)
+    actual_kv_len = 512
+    total_q = sum(q_lens)
+
+    query = (torch.randn(total_q, NUM_Q_HEADS, HEAD_DIM, device=device) * 0.02).to(dtype)
+    query[..., HEAD_DIM // 2 :] = 0
+    ori_kv = _make_kv_cache(80, dtype, device)
+    cmp_kv = _make_kv_cache(24, dtype, device).roll(shifts=31, dims=-1)
+    ori_block_table = torch.tensor(
+        [list(range(63, 31, -1)), list(range(31, -1, -1))],
+        dtype=torch.int32,
+        device=device,
+    )
+    cmp_block_table = torch.tensor(
+        [[7, 1, 9, 3, 11, 5, 10, 0], [8, 2, 12, 4, 14, 6, 13, 15]],
+        dtype=torch.int32,
+        device=device,
+    )
+    cu_seqlens_q = torch.tensor([0, q_lens[0], total_q], dtype=torch.int32, device=device)
+    seqused_kv = torch.full((2,), actual_kv_len, dtype=torch.int32, device=device)
+    sinks = torch.linspace(-0.3, 0.3, NUM_Q_HEADS, dtype=torch.float32, device=device)
+
+    ori_sparse_indices = torch.full((total_q, NUM_KV_HEADS, INDEX_WIDTH), -1, dtype=torch.int32, device=device)
+    slot_rows: list[torch.Tensor] = []
+    visible_counts = (0, 140, 257, 389, 511)
+    for token_idx, visible_count in enumerate(visible_counts):
+        slots = ((torch.arange(visible_count, device=device) * 37 + token_idx * 83) % 1280).to(torch.int32)
+        ori_sparse_indices[token_idx, 0, :visible_count] = slots
+        slot_rows.append(slots)
+
+    cmp_sparse_indices = torch.arange(512, dtype=torch.int32, device=device).remainder(actual_kv_len // cmp_ratio)
+    cmp_sparse_indices = cmp_sparse_indices.view(1, 1, -1).expand(total_q, NUM_KV_HEADS, -1).contiguous()
+    actual = _run_scfa(
+        query,
+        ori_kv,
+        cmp_kv,
+        ori_sparse_indices,
+        cmp_sparse_indices,
+        ori_block_table,
+        cmp_block_table,
+        cu_seqlens_q,
+        seqused_kv,
+        sinks,
+        cmp_ratio,
+    )
+
+    flat_ori_kv = ori_kv.reshape(-1, NUM_KV_HEADS, HEAD_DIM)
+    rows_per_query = []
+    token_idx = 0
+    for batch_idx, q_len in enumerate(q_lens):
+        for query_idx in range(q_len):
+            cmp_count = min(512, (actual_kv_len - q_len + query_idx + 1) // cmp_ratio)
+            logical_cmp = cmp_sparse_indices[token_idx, 0, :cmp_count].long()
+            physical_cmp_blocks = cmp_block_table[batch_idx, logical_cmp // BLOCK_SIZE].long()
+            cmp_rows = cmp_kv[physical_cmp_blocks, logical_cmp % BLOCK_SIZE]
+            rows_per_query.append(torch.cat((flat_ori_kv[slot_rows[token_idx].long()], cmp_rows)))
+            token_idx += 1
+    expected = _reference_attention(query, rows_per_query, sinks)
+
+    assert torch.isfinite(actual).all()
+    torch.testing.assert_close(actual.cpu(), expected.cpu(), atol=3e-2, rtol=3e-2)
+
+
+@torch.inference_mode()
+def test_scfa_without_original_slots_preserves_contiguous_window():
+    torch.manual_seed(20260903)
+    device = torch.device("npu:0")
+    dtype = torch.bfloat16
+    actual_kv_len = 256
+    query = (torch.randn(1, NUM_Q_HEADS, HEAD_DIM, device=device) * 0.02).to(dtype)
+    ori_kv = (torch.randn(16, BLOCK_SIZE, NUM_KV_HEADS, HEAD_DIM, device=device) * 0.02).to(dtype)
+    cmp_kv = (torch.randn(4, BLOCK_SIZE, NUM_KV_HEADS, HEAD_DIM, device=device) * 0.02).to(dtype)
+    ori_block_table = torch.tensor(
+        [[6, 1, 5, 0, 7, 2, 4, 3, 8, 9, 10, 11, 12, 13, 14, 15]],
+        dtype=torch.int32,
+        device=device,
+    )
+    cmp_block_table = torch.tensor([[3]], dtype=torch.int32, device=device)
+    cu_seqlens_q = torch.tensor([0, 1], dtype=torch.int32, device=device)
+    seqused_kv = torch.tensor([actual_kv_len], dtype=torch.int32, device=device)
+    sinks = torch.zeros(NUM_Q_HEADS, dtype=torch.float32, device=device)
+    cmp_sparse_indices = torch.zeros(1, NUM_KV_HEADS, 512, dtype=torch.int32, device=device)
+
+    actual = _run_scfa(
+        query,
+        ori_kv,
+        cmp_kv,
+        None,
+        cmp_sparse_indices,
+        ori_block_table,
+        cmp_block_table,
+        cu_seqlens_q,
+        seqused_kv,
+        sinks,
+        4,
+    )
+    logical_ori = torch.arange(actual_kv_len, device=device)
+    physical_ori_blocks = ori_block_table[0, logical_ori // BLOCK_SIZE].long()
+    ori_rows = ori_kv[physical_ori_blocks, logical_ori % BLOCK_SIZE]
+    cmp_rows = cmp_kv[cmp_block_table[0, 0].long(), 0].unsqueeze(0).expand(16, -1, -1)
+    expected = _reference_attention(query, [torch.cat((ori_rows, cmp_rows))], sinks)
+
+    assert torch.isfinite(actual).all()
+    torch.testing.assert_close(actual.cpu(), expected.cpu(), atol=3e-2, rtol=3e-2)
+
+
+@torch.inference_mode()
+def test_swa_ratio_one_and_scfa_match_for_same_original_slots():
+    torch.manual_seed(20260904)
+    device = torch.device("npu:0")
+    dtype = torch.bfloat16
+    actual_kv_len = 512
+    query = torch.ones(1, NUM_Q_HEADS, HEAD_DIM, dtype=dtype, device=device)
+    query[..., HEAD_DIM // 2 :] = 0
+    ori_kv = _make_kv_cache(40, dtype, device)
+    cmp_kv = torch.zeros(1, BLOCK_SIZE, NUM_KV_HEADS, HEAD_DIM, dtype=dtype, device=device)
+    cmp_kv[..., : HEAD_DIM // 2] = -1000
+    ori_block_table = torch.arange(31, -1, -1, dtype=torch.int32, device=device).view(1, -1)
+    cmp_block_table = torch.zeros(1, 1, dtype=torch.int32, device=device)
+    cu_seqlens_q = torch.tensor([0, 1], dtype=torch.int32, device=device)
+    seqused_kv = torch.tensor([actual_kv_len], dtype=torch.int32, device=device)
+    sinks = torch.full((NUM_Q_HEADS,), -10000.0, dtype=torch.float32, device=device)
+    slots = ((torch.arange(509, device=device) * 29 + 17) % (40 * BLOCK_SIZE)).to(torch.int32)
+    ori_sparse_indices = torch.full((1, NUM_KV_HEADS, INDEX_WIDTH), -1, dtype=torch.int32, device=device)
+    ori_sparse_indices[0, 0, : slots.numel()] = slots
+
+    swa_output = _run_swa(
+        query,
+        ori_kv,
+        ori_sparse_indices,
+        ori_block_table,
+        cu_seqlens_q,
+        seqused_kv,
+        sinks,
+    )
+    expected = _reference_attention(query, [ori_kv.reshape(-1, NUM_KV_HEADS, HEAD_DIM)[slots.long()]], sinks)
+    cmp_sparse_indices = torch.zeros((1, NUM_KV_HEADS, 512), dtype=torch.int32, device=device)
+    scfa_output = _run_scfa(
+        query,
+        ori_kv,
+        cmp_kv,
+        ori_sparse_indices,
+        cmp_sparse_indices,
+        ori_block_table,
+        cmp_block_table,
+        cu_seqlens_q,
+        seqused_kv,
+        sinks,
+        128,
+    )
+
+    assert torch.isfinite(swa_output).all()
+    assert torch.isfinite(scfa_output).all()
+    torch.testing.assert_close(swa_output.cpu(), expected.cpu(), atol=3e-2, rtol=3e-2)
+    torch.testing.assert_close(scfa_output.cpu(), swa_output.cpu(), atol=3e-2, rtol=3e-2)
+
+
+@torch.inference_mode()
+def test_swa_service_geometry_block32_matches_dense_reference():
+    torch.manual_seed(20260905)
+    device = torch.device("npu:0")
+    dtype = torch.bfloat16
+    block_size = 32
+    total_q = 237
+
+    query = (torch.randn(total_q, NUM_Q_HEADS, HEAD_DIM, device=device) * 0.02).to(dtype)
+    query[..., HEAD_DIM // 2 :] = 0
+    ori_kv = torch.empty(224, block_size, NUM_KV_HEADS, HEAD_DIM, dtype=dtype, device=device)
+    flat_ori_kv = ori_kv.view(-1, NUM_KV_HEADS, HEAD_DIM)
+    slot_ids = torch.arange(flat_ori_kv.shape[0], device=device, dtype=torch.float32).view(-1, 1, 1)
+    feature_ids = torch.arange(HEAD_DIM, device=device, dtype=torch.float32).view(1, 1, -1)
+    flat_ori_kv[..., : HEAD_DIM // 2] = (
+        torch.sin(slot_ids * 0.013 + feature_ids[..., : HEAD_DIM // 2] * 0.017) * 0.02
+    ).to(dtype)
+    flat_ori_kv[..., HEAD_DIM // 2 :] = (
+        torch.cos(slot_ids * 0.019 + feature_ids[..., HEAD_DIM // 2 :] * 0.011) * 0.02
+    ).to(dtype)
+
+    ori_block_table = torch.tensor([[190, 3, 141, 72, 201, 18, 155, 44]], dtype=torch.int32, device=device)
+    cu_seqlens_q = torch.tensor([0, total_q], dtype=torch.int32, device=device)
+    seqused_kv = torch.tensor([total_q], dtype=torch.int32, device=device)
+    sinks = torch.linspace(-0.3, 0.3, NUM_Q_HEADS, dtype=torch.float32, device=device)
+    ori_sparse_indices = torch.full((total_q, NUM_KV_HEADS, INDEX_WIDTH), -1, dtype=torch.int32, device=device)
+    slot_rows: list[torch.Tensor] = []
+    cols = torch.arange(INDEX_WIDTH, device=device)
+    for token_idx in range(total_q):
+        start = max(token_idx - 127, 0)
+        end = token_idx
+        if 81 <= token_idx <= 216:
+            start = min(start, 81)
+            end = 216
+        logical_slots = start + cols
+        logical_slots = logical_slots[logical_slots <= end]
+        physical_blocks = ori_block_table[0, logical_slots // block_size].long()
+        slots = (physical_blocks * block_size + logical_slots % block_size).to(torch.int32)
+        ori_sparse_indices[token_idx, 0, : slots.numel()] = slots
+        slot_rows.append(slots)
+
+    actual = _run_swa(
+        query,
+        ori_kv,
+        ori_sparse_indices,
+        ori_block_table,
+        cu_seqlens_q,
+        seqused_kv,
+        sinks,
+    )
+    selected = [0, 80, 81, 128, 216, 217, 236]
+    expected = _reference_attention(
+        query[selected],
+        [flat_ori_kv[slot_rows[token_idx].long()] for token_idx in selected],
+        sinks,
+    )
+
+    assert torch.isfinite(actual).all()
+    torch.testing.assert_close(actual[selected].cpu(), expected.cpu(), atol=3e-2, rtol=3e-2)
+
+
+@pytest.mark.parametrize("cmp_ratio", [4, 128])
+@torch.inference_mode()
+def test_scfa_service_geometry_block32_matches_dense_reference(cmp_ratio: int):
+    torch.manual_seed(20260905 + cmp_ratio)
+    device = torch.device("npu:0")
+    dtype = torch.bfloat16
+    block_size = 32
+    total_q = 237
+    actual_kv_len = total_q
+
+    query = (torch.randn(total_q, NUM_Q_HEADS, HEAD_DIM, device=device) * 0.02).to(dtype)
+    query[..., HEAD_DIM // 2 :] = 0
+
+    ori_kv = torch.empty(224, block_size, NUM_KV_HEADS, HEAD_DIM, dtype=dtype, device=device)
+    flat_ori_kv = ori_kv.view(-1, NUM_KV_HEADS, HEAD_DIM)
+    slot_ids = torch.arange(flat_ori_kv.shape[0], device=device, dtype=torch.float32).view(-1, 1, 1)
+    feature_ids = torch.arange(HEAD_DIM, device=device, dtype=torch.float32).view(1, 1, -1)
+    flat_ori_kv[..., : HEAD_DIM // 2] = (
+        torch.sin(slot_ids * 0.013 + feature_ids[..., : HEAD_DIM // 2] * 0.017) * 0.02
+    ).to(dtype)
+    flat_ori_kv[..., HEAD_DIM // 2 :] = (
+        torch.cos(slot_ids * 0.019 + feature_ids[..., HEAD_DIM // 2 :] * 0.011) * 0.02
+    ).to(dtype)
+
+    ori_block_table = torch.tensor([[190, 3, 141, 72, 201, 18, 155, 44]], dtype=torch.int32, device=device)
+    cmp_kv = _make_kv_cache(40, dtype, device).reshape(20, block_size, NUM_KV_HEADS, HEAD_DIM)
+    cmp_block_table = torch.tensor([[17, 2, 19, 5, 13, 1, 11, 7]], dtype=torch.int32, device=device)
+    cu_seqlens_q = torch.tensor([0, total_q], dtype=torch.int32, device=device)
+    seqused_kv = torch.tensor([actual_kv_len], dtype=torch.int32, device=device)
+    sinks = torch.linspace(-0.3, 0.3, NUM_Q_HEADS, dtype=torch.float32, device=device)
+
+    ori_sparse_indices = torch.full((total_q, NUM_KV_HEADS, INDEX_WIDTH), -1, dtype=torch.int32, device=device)
+    slot_rows: list[torch.Tensor] = []
+    cols = torch.arange(INDEX_WIDTH, device=device)
+    for token_idx in range(total_q):
+        start = max(token_idx - 127, 0)
+        end = token_idx
+        if 81 <= token_idx <= 216:
+            start = min(start, 81)
+            end = 216
+        logical_slots = start + cols
+        valid = logical_slots <= end
+        logical_slots = logical_slots[valid]
+        physical_blocks = ori_block_table[0, logical_slots // block_size].long()
+        slots = (physical_blocks * block_size + logical_slots % block_size).to(torch.int32)
+        ori_sparse_indices[token_idx, 0, : slots.numel()] = slots
+        slot_rows.append(slots)
+
+    max_cmp_tokens = max((actual_kv_len + cmp_ratio - 1) // cmp_ratio, 1)
+    cmp_sparse_indices = torch.arange(INDEX_WIDTH, dtype=torch.int32, device=device).remainder(max_cmp_tokens)
+    cmp_sparse_indices = cmp_sparse_indices.view(1, 1, -1).expand(total_q, NUM_KV_HEADS, -1).contiguous()
+
+    actual = _run_scfa(
+        query,
+        ori_kv,
+        cmp_kv,
+        ori_sparse_indices,
+        cmp_sparse_indices,
+        ori_block_table,
+        cmp_block_table,
+        cu_seqlens_q,
+        seqused_kv,
+        sinks,
+        cmp_ratio,
+    )
+
+    selected = [0, 80, 81, 128, 216, 217, 236]
+    rows_per_query = []
+    for token_idx in selected:
+        cmp_count = min(INDEX_WIDTH, (token_idx + 1) // cmp_ratio)
+        logical_cmp = cmp_sparse_indices[token_idx, 0, :cmp_count].long()
+        physical_cmp_blocks = cmp_block_table[0, logical_cmp // block_size].long()
+        cmp_rows = cmp_kv[physical_cmp_blocks, logical_cmp % block_size]
+        rows_per_query.append(torch.cat((flat_ori_kv[slot_rows[token_idx].long()], cmp_rows)))
+    expected = _reference_attention(query[selected], rows_per_query, sinks)
+
+    assert torch.isfinite(actual).all()
+    torch.testing.assert_close(actual[selected].cpu(), expected.cpu(), atol=3e-2, rtol=3e-2)


### PR DESCRIPTION
### What this PR does / why we need it?

This operator follow-up is stacked directly on #15457. DeepSeek V4 Vision builds `ori_sparse_indices` for bidirectional attention inside image spans, but the arch32 SCFA kernel currently reads original K/V through the contiguous paged-attention window. As a result, passing the indices alone does not make compressed SCFA layers consume the selected physical PA slots.

With #15457 plus this PR, the core DeepSeek-V4-Flash-Vision-Exp multimodal SCFA path is available. 

Related roadmap: #15462.

### What changed

- Detect the valid original sparse-index length from the first negative sentinel in each query row.
- Gather original K for MM1 and V for MM2 through the same physical PA slots with `DataCopyPABySlots`.
- Use the TND cumulative query-token offset when selecting each sparse-index row.
- Preserve the existing contiguous causal/SWA path when `ori_sparse_indices` is absent.
- Fall back to two PA copies when compressed paged blocks descend physically, preserving their logical order.
- Add dense-reference NPU coverage for FP16/BF16, compression ratios 1/4/128, non-contiguous PA blocks, K/V gather, and the production block-32 image geometry.

### Does this PR introduce _any_ user-facing change?

Yes. On arch32 with `layout_q=TND` and `layout_kv=PA_ND`, SCFA now applies the per-query original-KV physical slots supplied by the runtime. Image tokens can therefore attend bidirectionally within their image span while surrounding text retains causal sliding-window attention.

### How was this patch tested?

The rebased PR contains one operator commit whose parent is the current #15457 head `a0f4947bb`.

Current branch checks:

```text
python -m py_compile tests/e2e/nightly/single_node/ops/singlecard_ops/test_sparse_attn_sharedkv_scfa_indices.py
ruff format --check tests/e2e/nightly/single_node/ops/singlecard_ops/test_sparse_attn_sharedkv_scfa_indices.py
ruff check tests/e2e/nightly/single_node/ops/singlecard_ops/test_sparse_attn_sharedkv_scfa_indices.py
git diff --check a0f4947bb..HEAD
# passed
```

The three modified SCFA kernel sources are byte-identical to the sources used to build the retained Ascend 910B OPP package. That package passed the new dense-reference suite:

```text
9 passed, 15 warnings in 8.40s
```

The covered operator configurations are:

- query layout: `TND`;
- KV layout: `PA_ND`;
- KV heads: 1;
- index width: 512;
- PA block sizes: 16 and the service geometry 32;
- dtype: FP16 and BF16;
- compression ratio: 1, 4, and 128;
- absent-index compatibility path;
- non-contiguous and descending physical PA blocks.

The same operator sources were also used in the full W8A8 integration stack that aligned the fixed official-API teacher sequences and content-token top-1 results. That service evidence included additional runtime hardening from #15740, so it is integration evidence rather than an isolated #15457-plus-operator comparison.

### Scope boundaries

- This PR intentionally targets the DeepSeek V4 production combination `TND + PA_ND` on arch32.
- The existing host tiling restriction `kv_head_num == 1` remains unchanged.
- DSA context parallel is not changed.
- No Python runtime, frontend, RNG, or performance changes are included.


- vLLM main: https://github.com/vllm-project/vllm/commit/ba07e4a48fc951300d97eb506217dd530583dea3
