### PR TITLE
[BugFix] Fix GLM5.2 MTP index cache

### DIFF
--- a/tests/e2e/nightly/single_node/ops/multicard_ops_a3/test_mtp_index_cache.py
+++ b/tests/e2e/nightly/single_node/ops/multicard_ops_a3/test_mtp_index_cache.py
@@ -1,0 +1,96 @@
+# SPDX-License-Identifier: Apache-2.0
+
+import random
+import traceback
+
+import torch
+import torch.multiprocessing as mp
+import torch_npu
+from vllm.distributed.parallel_state import (
+    destroy_distributed_environment,
+    init_distributed_environment,
+    init_model_parallel_group,
+)
+
+from vllm_ascend.spec_decode.mtp import compact_mtp_topk_indices
+
+
+@torch.inference_mode()
+def _worker(rank, port, result_queue):
+    group = None
+    try:
+        torch_npu.npu.set_device(rank)
+        init_distributed_environment(
+            world_size=2,
+            rank=rank,
+            local_rank=rank,
+            distributed_init_method=f"tcp://127.0.0.1:{port}",
+            backend="hccl",
+        )
+        group = init_model_parallel_group(
+            [[0, 1]],
+            local_rank=rank,
+            backend="hccl",
+            group_name="mtp_index_cache_test",
+            use_device_communicator=True,
+        )
+        for num_tokens, sample_ids in [(8, [3, 7]), (7, [0, 2, 6]), (4, [0, 1, 2, 3])]:
+            local_tokens = (num_tokens + 1) // 2
+            start = rank * local_tokens
+            global_rows = torch.arange(local_tokens * 2 * 2048, dtype=torch.int32, device="npu").reshape(-1, 2048)
+            global_rows[:, -1] = -1
+            indices = torch.tensor(sample_ids, dtype=torch.int32, device="npu")
+            model = torch.nn.Module()
+            model.topk_indices_buffer = torch.full_like(global_rows, -99)
+            model.add_module("attention", torch.nn.Module())
+            model.attention.topk_indices_buffer = model.topk_indices_buffer
+            buffer = model.topk_indices_buffer
+            count = max(0, min(local_tokens, len(sample_ids) - start))
+
+            for _ in range(3):
+                buffer[:local_tokens].copy_(global_rows[start : start + local_tokens])
+                compact_mtp_topk_indices(model, indices, num_tokens, group)
+            expected = global_rows[indices][start : start + count]
+            torch.testing.assert_close(buffer[:count], expected, atol=0, rtol=0)
+
+            # Capture the real HCCL operation and replay with changed source
+            # values and sampling positions, preserving all input addresses.
+            torch.npu.synchronize()
+            graph = torch.npu.NPUGraph()
+            buffer[:local_tokens].copy_(global_rows[start : start + local_tokens])
+            with torch.npu.graph(graph):
+                compact_mtp_topk_indices(model, indices, num_tokens, group)
+            for offset in (100, 200):
+                global_rows.add_(offset)
+                indices.copy_(torch.tensor(list(reversed(sample_ids)), dtype=torch.int32, device="npu"))
+                buffer[:local_tokens].copy_(global_rows[start : start + local_tokens])
+                graph.replay()
+                expected = global_rows[indices][start : start + count]
+                torch.testing.assert_close(buffer[:count], expected, atol=0, rtol=0)
+        result_queue.put(None)
+    except Exception:
+        result_queue.put(traceback.format_exc())
+    finally:
+        if group is not None:
+            group.destroy()
+        destroy_distributed_environment()
+
+
+def test_mtp_index_cache_dsa_cp_eager_and_graph():
+    context = mp.get_context("spawn")
+    result_queue = context.Queue()
+    port = 29_501 + random.randint(0, 10_000)
+    processes = [context.Process(target=_worker, args=(rank, port, result_queue)) for rank in range(2)]
+    try:
+        for process in processes:
+            process.start()
+        results = [result_queue.get(timeout=300) for _ in processes]
+        for process in processes:
+            process.join(timeout=30)
+        assert all(process.exitcode == 0 for process in processes)
+        assert results == [None, None], "\n".join(result for result in results if result is not None)
+    finally:
+        for process in processes:
+            if process.is_alive():
+                process.terminate()
+                process.join(timeout=10)

--- a/tests/ut/ops/test_mla.py
+++ b/tests/ut/ops/test_mla.py
@@ -502,7 +502,8 @@ class TestAscendMultiHeadLatentAttention(TestBase):
         mock_mla_attn.impl = MagicMock()
         mock_mla_attn.impl.process_weights_after_loading = MagicMock()
 
-        with patch("vllm_ascend.ops.mla.MLAAttention", return_value=mock_mla_attn):
+        with patch("vllm_ascend.ops.mla.MLAAttention",
+                   return_value=mock_mla_attn) as mock_mla_attn_cls:
             mock_tp_size.return_value = 2
             mock_vllm_config = MagicMock(spec=VllmConfig)
             mock_vllm_config.model_config.hf_text_config = MagicMock(num_hidden_layers=32, first_k_dense_replace=True)
@@ -526,4 +527,4 @@ class TestAscendMultiHeadLatentAttention(TestBase):
             )
 
             self.assertTrue(attn.skip_topk)
-            self.assertEqual(mock_mla_attn.call_args.kwargs.get("skip_topk"), True)
+            self.assertEqual(mock_mla_attn_cls.call_args.kwargs.get("skip_topk"), True)

--- a/tests/ut/ops/test_mla.py
+++ b/tests/ut/ops/test_mla.py
@@ -451,3 +451,79 @@ class TestAscendMultiHeadLatentAttention(TestBase):
         output = attn.forward(positions, hidden_states)
 
         self.assertEqual(output.shape, (3, self.hidden_size))
+
+    def test_skip_topk_property_forwards_to_impl(self):
+        """The proposer's set_skip_topk must reach the impl that gates the indexer."""
+        attn = AscendMultiHeadLatentAttention.__new__(AscendMultiHeadLatentAttention)
+
+        # Before mla_attn exists, the setter only stores the backing value.
+        attn.skip_topk = True
+        self.assertTrue(attn.skip_topk)
+        attn.skip_topk = False
+        self.assertFalse(attn.skip_topk)
+
+        # Once the impl exists, the setter must forward the toggle to it.
+        mock_impl = MagicMock()
+        mock_impl.skip_topk = False
+        mock_mla_attn = MagicMock()
+        mock_mla_attn.impl = mock_impl
+        attn.mla_attn = mock_mla_attn
+
+        attn.skip_topk = True
+        self.assertTrue(attn.skip_topk)
+        self.assertTrue(mock_impl.skip_topk, "impl skip_topk should be forwarded by the wrapper setter.")
+
+        attn.skip_topk = False
+        self.assertFalse(attn.skip_topk)
+        self.assertFalse(mock_impl.skip_topk, "impl skip_topk should follow the wrapper toggle back.")
+
+    def test_topk_indices_buffer_property_forwards_to_impl(self):
+        """_maybe_share_topk_indices / compact_topk_indices must reach the impl buffer."""
+        attn = AscendMultiHeadLatentAttention.__new__(AscendMultiHeadLatentAttention)
+        self.assertIsNone(attn.topk_indices_buffer)
+
+        buffer = torch.empty(8, 2048, dtype=torch.int32)
+        mock_impl = MagicMock()
+        mock_impl.topk_indices_buffer = None
+        mock_mla_attn = MagicMock()
+        mock_mla_attn.impl = mock_impl
+        attn.mla_attn = mock_mla_attn
+
+        attn.topk_indices_buffer = buffer
+        self.assertIs(attn.topk_indices_buffer, buffer)
+        self.assertIs(mock_impl.topk_indices_buffer, buffer)
+
+    @patch("vllm_ascend.ops.mla.get_current_vllm_config")
+    @patch("vllm_ascend.ops.mla.get_tensor_model_parallel_world_size")
+    def test_initialization_skip_topk_consistency(self, mock_tp_size, mock_get_vllm_config):
+        """Init must store skip_topk on the wrapper and pass it to MLAAttention."""
+        mock_mla_attn = MagicMock()
+        mock_mla_attn.process_weights_after_loading = MagicMock()
+        mock_mla_attn.impl = MagicMock()
+        mock_mla_attn.impl.process_weights_after_loading = MagicMock()
+
+        with patch("vllm_ascend.ops.mla.MLAAttention", return_value=mock_mla_attn):
+            mock_tp_size.return_value = 2
+            mock_vllm_config = MagicMock(spec=VllmConfig)
+            mock_vllm_config.model_config.hf_text_config = MagicMock(num_hidden_layers=32, first_k_dense_replace=True)
+            mock_get_vllm_config.return_value = mock_vllm_config
+            mock_vllm_config.compilation_config = CompilationConfig()
+
+            attn = AscendMultiHeadLatentAttention(
+                hidden_size=self.hidden_size,
+                num_heads=self.num_heads,
+                scale=self.scale,
+                qk_nope_head_dim=self.qk_nope_head_dim,
+                qk_rope_head_dim=self.qk_rope_head_dim,
+                v_head_dim=self.v_head_dim,
+                q_lora_rank=self.q_lora_rank,
+                kv_lora_rank=self.kv_lora_rank,
+                mla_modules=self.mock_mla_modules,
+                cache_config=self.mock_cache_config,
+                quant_config=self.mock_quant_config,
+                prefix=self.prefix,
+                skip_topk=True,
+            )
+
+            self.assertTrue(attn.skip_topk)
+            self.assertEqual(mock_mla_attn.call_args.kwargs.get("skip_topk"), True)

--- a/tests/ut/ops/test_mla.py
+++ b/tests/ut/ops/test_mla.py
@@ -502,7 +502,10 @@ class TestAscendMultiHeadLatentAttention(TestBase):
         mock_mla_attn.impl = MagicMock()
         mock_mla_attn.impl.process_weights_after_loading = MagicMock()
 
-        with patch("vllm_ascend.ops.mla.MLAAttention", return_value=mock_mla_attn) as mock_mla_attn_cls:
+        with (
+            patch("vllm_ascend.ops.mla.MLAAttention", return_value=mock_mla_attn) as mock_mla_attn_cls,
+            patch("vllm_ascend.ops.mla.IndexerWrapper"),
+        ):
             mock_tp_size.return_value = 2
             mock_vllm_config = MagicMock(spec=VllmConfig)
             mock_vllm_config.model_config.hf_text_config = MagicMock(num_hidden_layers=32, first_k_dense_replace=True)

--- a/tests/ut/ops/test_mla.py
+++ b/tests/ut/ops/test_mla.py
@@ -502,8 +502,7 @@ class TestAscendMultiHeadLatentAttention(TestBase):
         mock_mla_attn.impl = MagicMock()
         mock_mla_attn.impl.process_weights_after_loading = MagicMock()
 
-        with patch("vllm_ascend.ops.mla.MLAAttention",
-                   return_value=mock_mla_attn) as mock_mla_attn_cls:
+        with patch("vllm_ascend.ops.mla.MLAAttention", return_value=mock_mla_attn) as mock_mla_attn_cls:
             mock_tp_size.return_value = 2
             mock_vllm_config = MagicMock(spec=VllmConfig)
             mock_vllm_config.model_config.hf_text_config = MagicMock(num_hidden_layers=32, first_k_dense_replace=True)

--- a/tests/ut/spec_decode/test_eagle_proposer.py
+++ b/tests/ut/spec_decode/test_eagle_proposer.py
@@ -4224,11 +4224,12 @@ class TestDeepSeekMTPIndicesSharing(unittest.TestCase):
         self.assertFalse(hasattr(mod2, "topk_indices_buffer"), "Module 2 should not have a buffer added.")
 
     def test_run_merge_draft_mtp_skip_topk(self):
-        """Test the set_skip_topk calling logic in step 0 and step 1 of run_merge_draft."""
+        """Test the set_skip_topk / compact_topk_indices calling logic in step 0
+        and step 1 of run_merge_draft."""
         proposer = AscendEagleProposer.__new__(AscendEagleProposer)
         proposer._share_mtp_indices = True
 
-        # Mock Draft Model and its set_skip_topk method
+        # Mock Draft Model and its set_skip_topk / compact_topk_indices methods
         draft_model_mock = MagicMock()
         proposer.model = MagicMock()
         proposer.model.model = draft_model_mock
@@ -4237,9 +4238,11 @@ class TestDeepSeekMTPIndicesSharing(unittest.TestCase):
         proposer.model_returns_tuple = MagicMock(return_value=False)
         proposer.model.return_value = MagicMock()
 
+        token_indices_to_sample = torch.arange(8, dtype=torch.int32)
+
         # Mock the run_merge_draft logic from your PR
         # (Since this is a class method, we use an inner function to simulate and verify the core logic)
-        def mock_run_merge_draft(**model_kwargs):
+        def mock_run_merge_draft(token_indices_to_sample, **model_kwargs):
             # Step 0
             draft_model = getattr(proposer.model, "model", None)
             if proposer._share_mtp_indices and draft_model is not None and hasattr(draft_model, "set_skip_topk"):
@@ -4251,9 +4254,11 @@ class TestDeepSeekMTPIndicesSharing(unittest.TestCase):
             # Step 1
             if proposer._share_mtp_indices and draft_model is not None and hasattr(draft_model, "set_skip_topk"):
                 draft_model.set_skip_topk(True)
+                if hasattr(draft_model, "compact_topk_indices"):
+                    draft_model.compact_topk_indices(token_indices_to_sample)
 
         # Run the test
-        mock_run_merge_draft(input_ids=torch.tensor([1, 2, 3]))
+        mock_run_merge_draft(token_indices_to_sample, input_ids=torch.tensor([1, 2, 3]))
 
         # Assert calling conditions
         self.assertTrue(draft_model_mock.set_skip_topk.called, "set_skip_topk should be called.")
@@ -4263,3 +4268,50 @@ class TestDeepSeekMTPIndicesSharing(unittest.TestCase):
         self.assertEqual(len(calls), 2, "set_skip_topk should be called exactly twice.")
         self.assertEqual(calls[0][0][0], False, "Step 0 should call set_skip_topk(False).")
         self.assertEqual(calls[1][0][0], True, "Step 1 should call set_skip_topk(True).")
+
+        # Compact must run exactly once, right after step 0, with the
+        # step-0 sampling indices.
+        self.assertTrue(
+            draft_model_mock.compact_topk_indices.called,
+            "compact_topk_indices should be called.",
+        )
+        compact_calls = draft_model_mock.compact_topk_indices.call_args_list
+        self.assertEqual(len(compact_calls), 1, "compact_topk_indices should be called exactly once.")
+        self.assertTrue(
+            torch.equal(compact_calls[0][0][0], token_indices_to_sample),
+            "compact_topk_indices must receive token_indices_to_sample.",
+        )
+
+    def test_run_merge_draft_mtp_skip_topk_without_compact(self):
+        """Draft predictors without compact_topk_indices (e.g. the
+        vllm-ascend DeepSeekV4MTP predictor) must be left untouched."""
+        proposer = AscendEagleProposer.__new__(AscendEagleProposer)
+        proposer._share_mtp_indices = True
+
+        # Mock Draft Model without the compact method
+        draft_model_mock = MagicMock()
+        del draft_model_mock.compact_topk_indices
+        proposer.model = MagicMock()
+        proposer.model.model = draft_model_mock
+
+        proposer.model_returns_tuple = MagicMock(return_value=False)
+        proposer.model.return_value = MagicMock()
+
+        token_indices_to_sample = torch.arange(4, dtype=torch.int32)
+
+        def mock_run_merge_draft(token_indices_to_sample, **model_kwargs):
+            draft_model = getattr(proposer.model, "model", None)
+            if proposer._share_mtp_indices and draft_model is not None and hasattr(draft_model, "set_skip_topk"):
+                draft_model.set_skip_topk(False)
+            proposer.model(**model_kwargs)
+            if proposer._share_mtp_indices and draft_model is not None and hasattr(draft_model, "set_skip_topk"):
+                draft_model.set_skip_topk(True)
+                if hasattr(draft_model, "compact_topk_indices"):
+                    draft_model.compact_topk_indices(token_indices_to_sample)
+
+        mock_run_merge_draft(token_indices_to_sample, input_ids=torch.tensor([1, 2, 3]))
+
+        # set_skip_topk still toggles, but compact is skipped entirely.
+        self.assertTrue(draft_model_mock.set_skip_topk.called, "set_skip_topk should be called.")
+        self.assertEqual(len(draft_model_mock.set_skip_topk.call_args_list), 2)
+        self.assertFalse(hasattr(draft_model_mock, "compact_topk_indices"))

--- a/tests/ut/spec_decode/test_eagle_proposer.py
+++ b/tests/ut/spec_decode/test_eagle_proposer.py
@@ -4237,6 +4237,7 @@ class TestDeepSeekMTPIndicesSharing(unittest.TestCase):
         proposer.supports_mm_inputs = False
         proposer.uses_mrope = False
         proposer.use_cuda_graph = False
+        proposer.use_compress = False
         proposer.device = torch.device("cpu")
         proposer.input_ids = torch.arange(8, dtype=torch.int32)
         proposer.positions = torch.arange(8, dtype=torch.int64)

--- a/tests/ut/spec_decode/test_eagle_proposer.py
+++ b/tests/ut/spec_decode/test_eagle_proposer.py
@@ -4265,7 +4265,7 @@ class TestDeepSeekMTPIndicesSharing(unittest.TestCase):
         if not supports_compact:
             predictor = SimpleNamespace(set_skip_topk=predictor.set_skip_topk)
 
-        observed = []
+        observed: list[tuple[bool, torch.Tensor]] = []
         step0_rows = torch.arange(32, dtype=torch.int32).reshape(8, 4)
         indices = torch.tensor([1, 6], dtype=torch.int32)
         group = MagicMock(world_size=2, rank_in_group=0)

--- a/tests/ut/spec_decode/test_eagle_proposer.py
+++ b/tests/ut/spec_decode/test_eagle_proposer.py
@@ -4290,7 +4290,7 @@ class TestDeepSeekMTPIndicesSharing(unittest.TestCase):
         proposer.model.model = predictor
         with (
             patch.object(llm_base_proposer, "lmhead_tp_enable", return_value=False),
-            patch.object(llm_base_proposer, "enable_dsa_cp", return_value=dsa_cp),
+            patch.object(llm_base_proposer.ascend_utils, "enable_dsa_cp", return_value=dsa_cp),
             patch.object(llm_base_proposer, "get_tp_group", return_value=group),
             patch.object(
                 llm_base_proposer, "get_ascend_config", return_value=SimpleNamespace(enable_reduce_sample=True)

--- a/tests/ut/spec_decode/test_eagle_proposer.py
+++ b/tests/ut/spec_decode/test_eagle_proposer.py
@@ -11,6 +11,7 @@ import pytest
 import torch
 from vllm.config import CacheConfig, CompilationMode, CUDAGraphMode, VllmConfig, set_current_vllm_config
 from vllm.forward_context import BatchDescriptor
+from vllm.model_executor.models.deepseek_mtp import DeepSeekMultiTokenPredictor
 from vllm.model_executor.models.llama_eagle3 import Eagle3LlamaForCausalLM
 from vllm.v1.spec_decode.draft_model import DraftModelProposer
 
@@ -19,6 +20,7 @@ from tests.ut.base import TestBase
 from vllm_ascend.ascend_config import clear_ascend_config, init_ascend_config
 from vllm_ascend.attention.attention_v1 import AscendAttentionState
 from vllm_ascend.attention.utils import AscendCommonAttentionMetadata
+from vllm_ascend.ops.mla import AscendMultiHeadLatentAttention
 from vllm_ascend.spec_decode.draft_proposer import AscendDraftModelProposer
 from vllm_ascend.spec_decode.eagle_proposer import AscendEagleProposer
 from vllm_ascend.spec_decode.utils import SlidingWindowAdapter
@@ -4223,95 +4225,109 @@ class TestDeepSeekMTPIndicesSharing(unittest.TestCase):
         self.assertEqual(mod3.topk_indices_buffer, target_buffer_mock, "Module 3 buffer should be updated.")
         self.assertFalse(hasattr(mod2, "topk_indices_buffer"), "Module 2 should not have a buffer added.")
 
-    def test_run_merge_draft_mtp_skip_topk(self):
-        """Test the set_skip_topk / compact_topk_indices calling logic in step 0
-        and step 1 of run_merge_draft."""
+    def _run_index_sharing_draft(self, share=True, supports_compact=True, dsa_cp=False):
+        """Run the real proposer and MLA hooks with known rows in place of model compute."""
         proposer = AscendEagleProposer.__new__(AscendEagleProposer)
-        proposer._share_mtp_indices = True
+        proposer.runner = None
+        proposer.method = "mtp"
+        proposer._share_mtp_indices = share
+        proposer.num_speculative_tokens = 2
+        proposer.parallel_drafting = False
+        proposer.pass_hidden_states_to_model = True
+        proposer.supports_mm_inputs = False
+        proposer.uses_mrope = False
+        proposer.use_cuda_graph = False
+        proposer.device = torch.device("cpu")
+        proposer.input_ids = torch.arange(8, dtype=torch.int32)
+        proposer.positions = torch.arange(8, dtype=torch.int64)
+        proposer.hidden_states = torch.arange(32, dtype=torch.float32).reshape(8, 4)
+        proposer.arange = torch.arange(8, dtype=torch.int32)
+        proposer.vllm_config = SimpleNamespace(model_config=SimpleNamespace(max_model_len=128))
+        proposer._get_positions = lambda n: proposer.positions[:n]
+        proposer._set_positions = lambda n, positions: proposer.positions[:n].copy_(positions)
+        proposer.maybe_pad_and_reduce = lambda hidden, positions: (hidden, positions)
+        proposer.maybe_all_gather_and_unpad = lambda last, positions, hidden: (last, positions, hidden)
+        proposer.compute_draft_token_ids = lambda hidden, sampling_metadata: (torch.arange(hidden.shape[0]), None)
 
-        # Mock Draft Model and its set_skip_topk / compact_topk_indices methods
-        draft_model_mock = MagicMock()
-        proposer.model = MagicMock()
-        proposer.model.model = draft_model_mock
+        buffer = torch.full((8, 4), -1, dtype=torch.int32)
+        impl = SimpleNamespace(skip_topk=False, topk_indices_buffer=buffer)
+        attention = AscendMultiHeadLatentAttention.__new__(AscendMultiHeadLatentAttention)
+        torch.nn.Module.__init__(attention)
+        attention.mla_attn = SimpleNamespace(impl=impl)
+        attention.skip_topk = False
+        predictor = DeepSeekMultiTokenPredictor.__new__(DeepSeekMultiTokenPredictor)
+        torch.nn.Module.__init__(predictor)
+        layer = torch.nn.Module()
+        layer.mtp_block = torch.nn.Module()
+        layer.mtp_block.self_attn = torch.nn.Module()
+        layer.mtp_block.self_attn.mla_attn = attention
+        predictor.layers = torch.nn.ModuleDict({"80": layer})
+        if not supports_compact:
+            predictor = SimpleNamespace(set_skip_topk=predictor.set_skip_topk)
 
-        # Mock model inference return
-        proposer.model_returns_tuple = MagicMock(return_value=False)
-        proposer.model.return_value = MagicMock()
+        observed = []
+        step0_rows = torch.arange(32, dtype=torch.int32).reshape(8, 4)
+        indices = torch.tensor([1, 6], dtype=torch.int32)
+        group = MagicMock(world_size=2, rank_in_group=0)
 
-        token_indices_to_sample = torch.arange(8, dtype=torch.int32)
+        def all_reduce(rows):
+            expected_contribution = torch.stack([step0_rows[1], torch.zeros(4, dtype=torch.int32)])
+            torch.testing.assert_close(rows, expected_contribution)
+            return step0_rows[indices]
 
-        # Mock the run_merge_draft logic from your PR
-        # (Since this is a class method, we use an inner function to simulate and verify the core logic)
-        def mock_run_merge_draft(token_indices_to_sample, **model_kwargs):
-            # Step 0
-            draft_model = getattr(proposer.model, "model", None)
-            if proposer._share_mtp_indices and draft_model is not None and hasattr(draft_model, "set_skip_topk"):
-                draft_model.set_skip_topk(False)
+        group.all_reduce.side_effect = all_reduce
 
-            # (Model inference...)
-            proposer.model(**model_kwargs)
+        def forward(**kwargs):
+            if not observed:
+                if dsa_cp:
+                    buffer[:4].copy_(step0_rows[:4])
+                else:
+                    buffer.copy_(step0_rows)
+            observed.append((impl.skip_topk, buffer.clone()))
+            return kwargs["hidden_states"].clone()
 
-            # Step 1
-            if proposer._share_mtp_indices and draft_model is not None and hasattr(draft_model, "set_skip_topk"):
-                draft_model.set_skip_topk(True)
-                if hasattr(draft_model, "compact_topk_indices"):
-                    draft_model.compact_topk_indices(token_indices_to_sample)
+        proposer.model = MagicMock(side_effect=forward)
+        proposer.model.model = predictor
+        with (
+            patch.object(llm_base_proposer, "lmhead_tp_enable", return_value=False),
+            patch.object(llm_base_proposer, "enable_dsa_cp", return_value=dsa_cp),
+            patch.object(llm_base_proposer, "get_tp_group", return_value=group),
+            patch.object(
+                llm_base_proposer, "get_ascend_config", return_value=SimpleNamespace(enable_reduce_sample=True)
+            ),
+            patch("vllm.forward_context._forward_context", SimpleNamespace(moe_layer_index=0)),
+        ):
+            result = proposer._run_merged_draft(
+                num_input_tokens=8,
+                batch_size=2,
+                token_indices_to_sample=indices,
+                target_positions=proposer.positions,
+                inputs_embeds=None,
+                multi_steps_attn_metadata=[None, None],
+                num_tokens=8,
+            )
+        self.assertEqual(result.shape, (2, 2))
+        self.assertEqual(len(observed), 2)
+        if dsa_cp:
+            group.all_reduce.assert_called_once()
+        return observed, step0_rows, indices
 
-        # Run the test
-        mock_run_merge_draft(token_indices_to_sample, input_ids=torch.tensor([1, 2, 3]))
-
-        # Assert calling conditions
-        self.assertTrue(draft_model_mock.set_skip_topk.called, "set_skip_topk should be called.")
-
-        # Verify calling order: False first, then True
-        calls = draft_model_mock.set_skip_topk.call_args_list
-        self.assertEqual(len(calls), 2, "set_skip_topk should be called exactly twice.")
-        self.assertEqual(calls[0][0][0], False, "Step 0 should call set_skip_topk(False).")
-        self.assertEqual(calls[1][0][0], True, "Step 1 should call set_skip_topk(True).")
-
-        # Compact must run exactly once, right after step 0, with the
-        # step-0 sampling indices.
-        self.assertTrue(
-            draft_model_mock.compact_topk_indices.called,
-            "compact_topk_indices should be called.",
-        )
-        compact_calls = draft_model_mock.compact_topk_indices.call_args_list
-        self.assertEqual(len(compact_calls), 1, "compact_topk_indices should be called exactly once.")
-        self.assertTrue(
-            torch.equal(compact_calls[0][0][0], token_indices_to_sample),
-            "compact_topk_indices must receive token_indices_to_sample.",
-        )
+    def test_run_merge_draft_mtp_skip_topk(self):
+        observed, original, indices = self._run_index_sharing_draft()
+        self.assertEqual([skip for skip, _ in observed], [False, True])
+        torch.testing.assert_close(observed[1][1][:2], original[indices])
 
     def test_run_merge_draft_mtp_skip_topk_without_compact(self):
-        """Draft predictors without compact_topk_indices (e.g. the
-        vllm-ascend DeepSeekV4MTP predictor) must be left untouched."""
-        proposer = AscendEagleProposer.__new__(AscendEagleProposer)
-        proposer._share_mtp_indices = True
+        observed, original, _ = self._run_index_sharing_draft(supports_compact=False)
+        self.assertEqual([skip for skip, _ in observed], [False, True])
+        torch.testing.assert_close(observed[1][1], original)
 
-        # Mock Draft Model without the compact method
-        draft_model_mock = MagicMock()
-        del draft_model_mock.compact_topk_indices
-        proposer.model = MagicMock()
-        proposer.model.model = draft_model_mock
+    def test_run_merge_draft_mtp_dsa_cp_compacts_remote_rows(self):
+        observed, original, indices = self._run_index_sharing_draft(dsa_cp=True)
+        self.assertEqual([skip for skip, _ in observed], [False, True])
+        torch.testing.assert_close(observed[1][1][:2], original[indices])
 
-        proposer.model_returns_tuple = MagicMock(return_value=False)
-        proposer.model.return_value = MagicMock()
-
-        token_indices_to_sample = torch.arange(4, dtype=torch.int32)
-
-        def mock_run_merge_draft(token_indices_to_sample, **model_kwargs):
-            draft_model = getattr(proposer.model, "model", None)
-            if proposer._share_mtp_indices and draft_model is not None and hasattr(draft_model, "set_skip_topk"):
-                draft_model.set_skip_topk(False)
-            proposer.model(**model_kwargs)
-            if proposer._share_mtp_indices and draft_model is not None and hasattr(draft_model, "set_skip_topk"):
-                draft_model.set_skip_topk(True)
-                if hasattr(draft_model, "compact_topk_indices"):
-                    draft_model.compact_topk_indices(token_indices_to_sample)
-
-        mock_run_merge_draft(token_indices_to_sample, input_ids=torch.tensor([1, 2, 3]))
-
-        # set_skip_topk still toggles, but compact is skipped entirely.
-        self.assertTrue(draft_model_mock.set_skip_topk.called, "set_skip_topk should be called.")
-        self.assertEqual(len(draft_model_mock.set_skip_topk.call_args_list), 2)
-        self.assertFalse(hasattr(draft_model_mock, "compact_topk_indices"))
+    def test_run_merge_draft_mtp_sharing_disabled(self):
+        observed, original, _ = self._run_index_sharing_draft(share=False)
+        self.assertEqual([skip for skip, _ in observed], [False, False])
+        torch.testing.assert_close(observed[1][1], original)

--- a/tests/ut/spec_decode/test_mtp.py
+++ b/tests/ut/spec_decode/test_mtp.py
@@ -1,0 +1,59 @@
+# SPDX-License-Identifier: Apache-2.0
+
+from types import SimpleNamespace
+from unittest.mock import Mock
+
+import pytest
+import torch
+from torch import nn
+
+from vllm_ascend.spec_decode.mtp import compact_mtp_topk_indices
+
+
+@pytest.mark.parametrize(
+    "num_input_tokens,sample_ids,world_size",
+    [(8, [3, 7], 2), (7, [0, 2, 6], 2), (12, [1, 5, 10], 4), (4, [0, 1, 2, 3], 2)],
+)
+def test_dsa_cp_compaction_moves_rows_to_next_step_owner(num_input_tokens, sample_ids, world_size):
+    local_tokens = (num_input_tokens + world_size - 1) // world_size
+    all_rows = torch.arange(local_tokens * world_size * 4, dtype=torch.int32).reshape(-1, 4)
+    all_rows[:, -1] = -1
+    sample_ids = torch.tensor(sample_ids, dtype=torch.int32)
+    expected_rows = all_rows[sample_ids]
+
+    for rank in range(world_size):
+        start = rank * local_tokens
+        model = nn.Module()
+        model.topk_indices_buffer = torch.full_like(all_rows, -99)
+        model.topk_indices_buffer[:local_tokens].copy_(all_rows[start : start + local_tokens])
+        # The predictor and MLA wrappers can expose the same underlying buffer.
+        model.add_module("attention", nn.Module())
+        model.attention.topk_indices_buffer = model.topk_indices_buffer
+        original_buffer = model.topk_indices_buffer
+        owns_row = (sample_ids >= start) & (sample_ids < start + local_tokens)
+
+        def reduce_rows(rows, owns_row=owns_row):
+            torch.testing.assert_close(rows, expected_rows.masked_fill(~owns_row[:, None], 0))
+            return expected_rows.clone()
+
+        group = SimpleNamespace(world_size=world_size, rank_in_group=rank, all_reduce=Mock(side_effect=reduce_rows))
+        compact_mtp_topk_indices(model, sample_ids, num_input_tokens, group)
+
+        group.all_reduce.assert_called_once()
+        assert model.topk_indices_buffer is original_buffer
+        count = max(0, min(local_tokens, len(sample_ids) - start))
+        torch.testing.assert_close(original_buffer[:count], expected_rows[start : start + count])
+
+
+def test_compaction_without_dsa_cp_uses_predictor_hook():
+    model = nn.Module()
+    model.compact_topk_indices = Mock()
+    indices = torch.tensor([1, 5], dtype=torch.int32)
+    compact_mtp_topk_indices(model, indices, 6)
+    model.compact_topk_indices.assert_called_once_with(indices)
+
+
+def test_dsa_cp_compaction_empty_batch_skips_collective():
+    group = SimpleNamespace(all_reduce=Mock())
+    compact_mtp_topk_indices(nn.Module(), torch.empty(0, dtype=torch.int32), 0, group)
+    group.all_reduce.assert_not_called()

--- a/vllm_ascend/ops/mla.py
+++ b/vllm_ascend/ops/mla.py
@@ -96,6 +96,37 @@ class IndexerWrapper(nn.Module):
 
 
 class AscendMultiHeadLatentAttention(MultiHeadLatentAttentionWrapper):
+    # IndexCache (index_share_for_mtp_iteration): the spec-decode proposer
+    # toggles ``skip_topk`` on this wrapper at runtime (set_skip_topk) and
+    # compacts the shared top-k buffer (compact_topk_indices). The actual
+    # indexer gate and buffer live in the inner impl (e.g. AscendSFAImpl),
+    # which is not an nn.Module and is therefore invisible to
+    # named_modules(). Expose both as properties forwarding to the impl so
+    # the upstream DeepSeekMultiTokenPredictor hooks keep working on Ascend.
+    @property
+    def skip_topk(self) -> bool:
+        return self.__dict__.get("_skip_topk", False)
+
+    @skip_topk.setter
+    def skip_topk(self, value: bool) -> None:
+        self.__dict__["_skip_topk"] = bool(value)
+        impl = getattr(getattr(self, "mla_attn", None), "impl", None)
+        if impl is not None and hasattr(impl, "skip_topk"):
+            impl.skip_topk = self.__dict__["_skip_topk"]
+
+    @property
+    def topk_indices_buffer(self) -> torch.Tensor | None:
+        impl = getattr(getattr(self, "mla_attn", None), "impl", None)
+        if impl is None:
+            return None
+        return getattr(impl, "topk_indices_buffer", None)
+
+    @topk_indices_buffer.setter
+    def topk_indices_buffer(self, value: torch.Tensor | None) -> None:
+        impl = getattr(getattr(self, "mla_attn", None), "impl", None)
+        if impl is not None and hasattr(impl, "topk_indices_buffer"):
+            impl.topk_indices_buffer = value
+
     def __init__(
         self,
         hidden_size: int,
@@ -128,6 +159,9 @@ class AscendMultiHeadLatentAttention(MultiHeadLatentAttentionWrapper):
         self.qk_head_dim = qk_nope_head_dim + qk_rope_head_dim
         self.v_head_dim = v_head_dim
         self.prefix = prefix
+        # Goes through the property setter above; mla_attn is not created yet,
+        # so only the backing value is stored here. MLAAttention below receives
+        # the same value and initializes the impl consistently.
         self.skip_topk = skip_topk
         # This is an upstream CUDA indexer hint. Ascend accepts it to preserve
         # constructor compatibility, but its indexer does not consume it.

--- a/vllm_ascend/patch/__init__.py
+++ b/vllm_ascend/patch/__init__.py
@@ -702,7 +702,11 @@
 #    How:
 #       Skip `Indexer` construction only when the layer both skips top-k and is
 #       explicitly marked `shared` in `indexer_types`. MTP layers always retain
-#       a complete `Indexer`.
+#       a complete `Indexer`. The runtime `skip_topk` handed to the MLA wrapper
+#       is additionally masked with `not is_mtp_layer` (same as upstream
+#       deepseek_v2.py): MTP layers must never start in skip mode, because they
+#       compute their own indices at draft step 0 and toggle at runtime via
+#       `set_skip_topk` (index_share_for_mtp_iteration).
 #    Related PR (if no, explain why):
 #       https://github.com/vllm-project/vllm/pull/45895
 #    Future Plan:

--- a/vllm_ascend/patch/worker/patch_deepseek_v2.py
+++ b/vllm_ascend/patch/worker/patch_deepseek_v2.py
@@ -226,6 +226,14 @@ def _deepseek_v2_mla_attention_init(
     elif 0 <= layer_id < len(_index_topk_pattern):
         _skip_topk = _index_topk_pattern[layer_id] == "S"
 
+    # The skip pattern only governs backbone layers. MTP/nextn layers
+    # (layer_id >= num_hidden_layers) must never start with skip_topk=True:
+    # they compute their own indices at draft step 0 and toggle at runtime
+    # via set_skip_topk (index_share_for_mtp_iteration). Matches upstream
+    # deepseek_v2.py behavior.
+    num_hidden_layers = getattr(config, "num_hidden_layers", None)
+    is_mtp_layer = num_hidden_layers is not None and layer_id >= num_hidden_layers
+
     skip_indexer_init = _should_skip_indexer_init(config, prefix, _skip_topk)
     if self.is_v32 and not skip_indexer_init:
         self.indexer_rope_emb = get_rope(
@@ -283,7 +291,7 @@ def _deepseek_v2_mla_attention_init(
         cache_config,
         quant_config,
         prefix,
-        skip_topk=_skip_topk,
+        skip_topk=_skip_topk and not is_mtp_layer,
     )
 
 

--- a/vllm_ascend/spec_decode/llm_base_proposer.py
+++ b/vllm_ascend/spec_decode/llm_base_proposer.py
@@ -42,6 +42,7 @@ from vllm.v1.spec_decode.utils import (
 )
 from vllm.v1.worker.gpu_input_batch import CachedRequestState, InputBatch
 
+from vllm_ascend import utils as ascend_utils
 from vllm_ascend.ascend_config import get_ascend_config
 from vllm_ascend.ascend_forward_context import _EXTRA_CTX, set_ascend_forward_context
 from vllm_ascend.attention.attention_v1 import AscendAttentionState
@@ -64,7 +65,7 @@ from vllm_ascend.spec_decode.utils import (
     _maybe_eager_context,
     patch_tensor_parallel_group,
 )
-from vllm_ascend.utils import check_gdn_layer, enable_dsa_cp, enable_sp, lmhead_tp_enable, vllm_version_is
+from vllm_ascend.utils import check_gdn_layer, enable_sp, lmhead_tp_enable, vllm_version_is
 from vllm_ascend.worker.device_metadata import DeviceMetadataTask, DeviceMetadataTaskProvider
 
 # Currently we will fix block size to a small one since `num_reqs` can't be too large
@@ -1290,7 +1291,7 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
                     draft_model,
                     token_indices_to_sample,
                     num_input_tokens,
-                    tp_group=get_tp_group() if enable_dsa_cp() else None,
+                    tp_group=get_tp_group() if ascend_utils.enable_dsa_cp() else None,
                 )
 
         if self.method != "dflash":

--- a/vllm_ascend/spec_decode/llm_base_proposer.py
+++ b/vllm_ascend/spec_decode/llm_base_proposer.py
@@ -1284,6 +1284,14 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
         draft_model = getattr(self.model, "model", None)
         if self._share_mtp_indices and draft_model is not None and hasattr(draft_model, "set_skip_topk"):
             draft_model.set_skip_topk(True)
+            if hasattr(draft_model, "compact_topk_indices"):
+                # Step 0 wrote top-k rows for every query token in the
+                # multi-token batch. Compact the rows of each request's last
+                # token to the buffer front so steps 1+ read request-aligned
+                # rows (mirrors the upstream proposer). Draft predictors
+                # without this method (e.g. vllm-ascend DeepSeekV4MTP) are
+                # left untouched.
+                draft_model.compact_topk_indices(token_indices_to_sample)
 
         if self.method != "dflash":
             last_hidden_states, model_positions, hidden_states = self.maybe_all_gather_and_unpad(

--- a/vllm_ascend/spec_decode/llm_base_proposer.py
+++ b/vllm_ascend/spec_decode/llm_base_proposer.py
@@ -58,12 +58,13 @@ from vllm_ascend.models.llama_eagle3_vwn import Eagle3VwnLlamaForCausalLM
 from vllm_ascend.ops.triton.spec_decode.utils import prepare_inputs_padded_kernel
 from vllm_ascend.ops.triton.triton_utils import get_vectorcore_num
 from vllm_ascend.ops.vocab_parallel_embedding import lmhead_all_to_all
+from vllm_ascend.spec_decode.mtp import compact_mtp_topk_indices
 from vllm_ascend.spec_decode.utils import (
     SlidingWindowAdapter,
     _maybe_eager_context,
     patch_tensor_parallel_group,
 )
-from vllm_ascend.utils import check_gdn_layer, enable_sp, lmhead_tp_enable, vllm_version_is
+from vllm_ascend.utils import check_gdn_layer, enable_dsa_cp, enable_sp, lmhead_tp_enable, vllm_version_is
 from vllm_ascend.worker.device_metadata import DeviceMetadataTask, DeviceMetadataTaskProvider
 
 # Currently we will fix block size to a small one since `num_reqs` can't be too large
@@ -1285,13 +1286,12 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
         if self._share_mtp_indices and draft_model is not None and hasattr(draft_model, "set_skip_topk"):
             draft_model.set_skip_topk(True)
             if hasattr(draft_model, "compact_topk_indices"):
-                # Step 0 wrote top-k rows for every query token in the
-                # multi-token batch. Compact the rows of each request's last
-                # token to the buffer front so steps 1+ read request-aligned
-                # rows (mirrors the upstream proposer). Draft predictors
-                # without this method (e.g. vllm-ascend DeepSeekV4MTP) are
-                # left untouched.
-                draft_model.compact_topk_indices(token_indices_to_sample)
+                compact_mtp_topk_indices(
+                    draft_model,
+                    token_indices_to_sample,
+                    num_input_tokens,
+                    tp_group=get_tp_group() if enable_dsa_cp() else None,
+                )
 
         if self.method != "dflash":
             last_hidden_states, model_positions, hidden_states = self.maybe_all_gather_and_unpad(

--- a/vllm_ascend/spec_decode/mtp.py
+++ b/vllm_ascend/spec_decode/mtp.py
@@ -1,0 +1,50 @@
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import torch
+from torch import nn
+
+if TYPE_CHECKING:
+    from vllm.distributed.parallel_state import GroupCoordinator
+
+
+def compact_mtp_topk_indices(
+    draft_model: nn.Module,
+    token_indices_to_sample: torch.Tensor,
+    num_input_tokens: int,
+    tp_group: GroupCoordinator | None = None,
+) -> None:
+    """Move step-0 top-k rows to the query layout of subsequent MTP steps."""
+    if tp_group is None:
+        draft_model.compact_topk_indices(token_indices_to_sample)
+        return
+    if token_indices_to_sample.numel() == 0:
+        return
+
+    # DSA-CP stores each rank's query rows at the front of its buffer. MTP
+    # keeps the padded input size, but steps 1+ contain one query per request.
+    local_num_tokens = (num_input_tokens + tp_group.world_size - 1) // tp_group.world_size
+    local_start = tp_group.rank_in_group * local_num_tokens
+    local_indices = token_indices_to_sample - local_start
+    owns_row = (local_indices >= 0) & (local_indices < local_num_tokens)
+    gather_indices = local_indices.clamp(0, local_num_tokens - 1).long()
+    local_num_reqs = max(0, min(local_num_tokens, token_indices_to_sample.numel() - local_start))
+
+    seen_buffers: set[int] = set()
+    for module in draft_model.modules():
+        buffer = getattr(module, "topk_indices_buffer", None)
+        if buffer is None or id(buffer) in seen_buffers:
+            continue
+        seen_buffers.add(id(buffer))
+
+        # Exactly one rank owns each sampled row. Summing masked rows moves
+        # only request_count * topk entries, rather than all step-0 tokens.
+        # Keep indices and masks on device; no scalar D2H extraction is needed.
+        rows = buffer.index_select(0, gather_indices)
+        rows.masked_fill_(~owns_row.view(-1, *([1] * (rows.ndim - 1))), 0)
+        rows = tp_group.all_reduce(rows)
+        if local_num_reqs:
+            buffer[:local_num_reqs].copy_(rows[local_start : local_start + local_num_reqs])


### PR DESCRIPTION
﻿### What this PR does / why we need it?

GLM5.2 MTP with shared index (`index_share_for_mtp_iteration`) was broken on Ascend because the runtime index-cache state was not correctly exposed or initialized:

1. The actual indexer gate (`skip_topk`) and shared top-k buffer (`topk_indices_buffer`) live in the inner MLA implementation (`AscendSFAImpl`), which is not an `nn.Module` and is invisible to `named_modules()`. Upstream `DeepSeekMultiTokenPredictor` hooks call `set_skip_topk` / `compact_topk_indices` on the module, so those calls never reached the inner implementation on Ascend.
2. MTP/nextn layers could be initialized with `skip_topk=True` from the backbone skip pattern. They must never start in skip mode because they compute their own indices at draft step 0 and toggle at runtime.
3. After draft step 0, the shared top-k buffer rows were not compacted to request-aligned positions, so steps 1+ could read the wrong rows.

This PR fixes the Ascend MTP index-cache path by:

- Adding `skip_topk` and `topk_indices_buffer` properties on `AscendMultiHeadLatentAttention` that forward to the inner MLA impl, so upstream proposer hooks keep working.
- Masking the initial `skip_topk` with `not is_mtp_layer` in `_deepseek_v2_mla_attention_init`.
- Calling `compact_topk_indices(token_indices_to_sample)` after draft step 0 in `AscendSpecDecodeBaseProposer` when supported.

Fixes #15864

### Does this PR introduce _any_ user-facing change?

No user-facing API or configuration change. This is an internal fix for GLM5.2 MTP index-cache sharing on Ascend.

### How was this patch tested?

- Unit tests: `pytest -sv tests/ut/ops/test_mla.py tests/ut/spec_decode/test_eagle_proposer.py`




- vLLM main: https://github.com/vllm-project/vllm/commit/b2f685834a6456197e7033966fdef52a23f1abcd
