### PR TITLE
[v0.26.0rc][Feature][Quantization] Support NZ for A5 MX quantization

### DIFF
--- a/tests/ut/attention/a2/test_sfa_v1.py
+++ b/tests/ut/attention/a2/test_sfa_v1.py
@@ -1089,17 +1089,17 @@ class TestAscendSFAImpl(TestBase):
         path = self.impl._resolve_preprocess_type(torch.bfloat16)
         self.assertEqual(path, PreprocessType.PROLOG_V3)
 
-    def test_resolve_path_unquantized_c8_goes_prolog_v3(self):
-        """Unquantized + is_kv_consumer + C8 → PROLOG_V3 (blocked by reasons)."""
+    def test_resolve_path_unquantized_c8_goes_native(self):
+        """Unquantized + is_kv_consumer + C8 → NATIVE (blocked by reasons)."""
         self._set_quant(None)
         self.impl.is_kv_consumer = True
         self.impl.enable_sparse_sfa_c8 = True
 
         path = self.impl._resolve_preprocess_type(torch.bfloat16)
-        # Enters candidate but blocked by _get_fused_type_unsupported_reasons
-        # (unquantized + C8).  With _try_enable_type mocked to True, still
-        # returns PROLOG_V3 in the test.
-        self.assertEqual(path, PreprocessType.PROLOG_V3)
+        # The candidate is blocked by _get_fused_type_unsupported_reasons
+        # (unquantized + C8), so the path must fall back to NATIVE even when
+        # _try_enable_type is mocked to True.
+        self.assertEqual(path, PreprocessType.NATIVE)
 
     def test_resolve_path_no_mlapo_goes_native(self):
         """No quant + MLAPO disabled → NATIVE."""
@@ -1123,6 +1123,9 @@ class TestAscendSFAImpl(TestBase):
         """Minimal setup so unsupported-reasons checks can run."""
         self.impl.preprocess_type = PreprocessType.PROLOG_V3
         self.impl._quant_type = AscendW8A8DynamicLinearMethod
+        quant_method = AscendW8A8DynamicLinearMethod.__new__(AscendW8A8DynamicLinearMethod)
+        self.impl.fused_qkv_a_proj = MagicMock()
+        self.impl.fused_qkv_a_proj.quant_method = SimpleNamespace(quant_method=quant_method)
         self.impl.kv_a_layernorm = MagicMock()
         self.impl.kv_a_layernorm.variance_epsilon = 1e-5
         self.impl.q_a_layernorm = MagicMock()
@@ -1147,6 +1150,7 @@ class TestAscendSFAImpl(TestBase):
     def test_reasons_unquantized_c8_blocked(self):
         self._setup_prolog_v3_state()
         self.impl._quant_type = None
+        self.impl.fused_qkv_a_proj.quant_method = SimpleNamespace(quant_method=None)
         self.impl.enable_sparse_sfa_c8 = True
 
         reasons = self.impl._get_fused_type_unsupported_reasons(PreprocessType.PROLOG_V3)

--- a/tests/ut/conftest.py
+++ b/tests/ut/conftest.py
@@ -56,7 +56,7 @@ if not _npu_available:
     torch_npu.npu = MagicMock()  # type: ignore[attr-defined]
     torch_npu.profiler = MagicMock()  # type: ignore[attr-defined]
     torch_npu.npu_fusion_attention = MagicMock()  # type: ignore[attr-defined]
-    torch_npu.npu_format_cast = MagicMock(side_effect=lambda weight, fmt: weight)  # type: ignore[attr-defined]
+    torch_npu.npu_format_cast = MagicMock(side_effect=lambda weight, fmt, **kwargs: weight)  # type: ignore[attr-defined]
     torch_npu._C = MagicMock()  # type: ignore[attr-defined]
     torch_npu._C._NPUTaskGroupHandle = MagicMock
     sys.modules["torch_npu"] = torch_npu

--- a/tests/ut/ops/test_mla.py
+++ b/tests/ut/ops/test_mla.py
@@ -1,3 +1,4 @@
+from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 import torch
@@ -7,6 +8,7 @@ from vllm.forward_context import ForwardContext
 from vllm.model_executor.layers.mla import MLAModules
 
 from tests.ut.base import TestBase
+from vllm_ascend.attention.sfa_v1 import PreprocessType
 from vllm_ascend.ops.mla import AscendMultiHeadLatentAttention, IndexerWrapper
 
 
@@ -106,6 +108,47 @@ class TestAscendMultiHeadLatentAttention(TestBase):
 
             self.assertEqual(attn.tp_size, 2)
             self.assertIsNotNone(attn.mla_attn)
+
+    @patch("vllm_ascend.ops.mla.get_current_vllm_config")
+    @patch("vllm_ascend.ops.mla.get_tensor_model_parallel_world_size")
+    def test_marks_layers_only_when_fused_preprocess_type_resolved(self, mock_tp_size, mock_get_vllm_config):
+        for resolved_type, should_mark in ((PreprocessType.MLAPO, True), (None, False)):
+            with self.subTest(resolved_type=resolved_type):
+                fused_qkv_a_proj = SimpleNamespace()
+                q_proj = SimpleNamespace()
+                mock_mla_attn = MagicMock()
+                mock_mla_attn.process_weights_after_loading = MagicMock()
+                mock_mla_attn.impl = MagicMock()
+                mock_mla_attn.impl._fused_preprocess_type.return_value = resolved_type
+                mock_mla_attn.impl.fused_qkv_a_proj = fused_qkv_a_proj
+                mock_mla_attn.impl.q_proj = q_proj
+
+                with patch("vllm_ascend.ops.mla.MLAAttention", return_value=mock_mla_attn):
+                    mock_tp_size.return_value = 2
+                    mock_vllm_config = MagicMock(spec=VllmConfig)
+                    mock_vllm_config.model_config.hf_text_config = MagicMock(
+                        num_hidden_layers=32, first_k_dense_replace=True
+                    )
+                    mock_get_vllm_config.return_value = mock_vllm_config
+                    mock_vllm_config.compilation_config = CompilationConfig()
+
+                    AscendMultiHeadLatentAttention(
+                        hidden_size=self.hidden_size,
+                        num_heads=self.num_heads,
+                        scale=self.scale,
+                        qk_nope_head_dim=self.qk_nope_head_dim,
+                        qk_rope_head_dim=self.qk_rope_head_dim,
+                        v_head_dim=self.v_head_dim,
+                        q_lora_rank=self.q_lora_rank,
+                        kv_lora_rank=self.kv_lora_rank,
+                        mla_modules=self.mock_mla_modules,
+                        cache_config=self.mock_cache_config,
+                        quant_config=self.mock_quant_config,
+                        prefix=self.prefix,
+                    )
+
+                self.assertEqual(hasattr(fused_qkv_a_proj, "_fused_preprocess_managed"), should_mark)
+                self.assertEqual(hasattr(q_proj, "_fused_preprocess_managed"), should_mark)
 
     @patch("vllm_ascend.ops.mla.torch.ops.vllm.mla_forward")
     @patch("vllm_ascend.ops.mla.get_current_vllm_config")

--- a/tests/ut/quantization/methods/test_w4a4_mxfp4.py
+++ b/tests/ut/quantization/methods/test_w4a4_mxfp4.py
@@ -41,6 +41,17 @@ class TestAscendW4A4MXFP4LinearMethod(TestBase):
         self.assertEqual(layer.weight.shape, (128, 128))
         self.assertEqual(layer.weight_scale.shape[0], 4)
 
+    @patch("vllm_ascend.quantization.methods.w4a4_mxfp4._should_trans_nz", return_value=False)
+    def test_process_weights_nz_disabled_keeps_pre_nz_layout(self, mock_should_trans_nz):
+        layer = nn.Module()
+        layer.weight = nn.Parameter(torch.randint(0, 255, (128, 128), dtype=torch.uint8), requires_grad=False)
+        layer.weight_scale = nn.Parameter(torch.randint(0, 255, (128, 8), dtype=torch.uint8), requires_grad=False)
+        self.scheme.process_weights_after_loading(layer)
+        self.assertEqual(layer.weight.shape, (128, 128))
+        self.assertEqual(layer.weight_scale.shape[0], 4)
+        self.assertFalse(layer.weight.data.is_contiguous())
+        self.assertFalse(layer.weight_scale.data.is_contiguous())
+
     @patch("vllm_ascend.quantization.methods.w4a4_mxfp4.torch_npu")
     def test_apply_3d_input(self, mock_npu):
         mock_npu.npu_dynamic_mx_quant.return_value = (

--- a/tests/ut/quantization/methods/test_w4a4_mxfp4.py
+++ b/tests/ut/quantization/methods/test_w4a4_mxfp4.py
@@ -41,7 +41,7 @@ class TestAscendW4A4MXFP4LinearMethod(TestBase):
         self.assertEqual(layer.weight.shape, (128, 128))
         self.assertEqual(layer.weight_scale.shape[0], 4)
 
-    @patch("vllm_ascend.quantization.methods.w4a4_mxfp4._should_trans_nz", return_value=False)
+    @patch("vllm_ascend.utils._should_trans_nz", return_value=False)
     def test_process_weights_nz_disabled_keeps_pre_nz_layout(self, mock_should_trans_nz):
         layer = nn.Module()
         layer.weight = nn.Parameter(torch.randint(0, 255, (128, 128), dtype=torch.uint8), requires_grad=False)

--- a/tests/ut/quantization/methods/test_w8a8_mxfp8.py
+++ b/tests/ut/quantization/methods/test_w8a8_mxfp8.py
@@ -136,6 +136,12 @@ class TestAscendW8A8MXFP8MoEMethod(TestBase):
         mock_ascend.return_value = create_mock_ascend_config()
         mock_ensure.return_value = None
         self.scheme = AscendW8A8MXFP8DynamicFusedMoEMethod()
+        patcher = patch(
+            "vllm_ascend.quantization.methods.w8a8_mxfp8.maybe_trans_nz",
+            side_effect=lambda x, **kwargs: x,
+        )
+        self.mock_maybe_trans_nz = patcher.start()
+        self.addCleanup(patcher.stop)
 
     def test_get_weight_various_expert_counts(self):
         for num_experts in [4, 8, 16]:
@@ -159,6 +165,20 @@ class TestAscendW8A8MXFP8MoEMethod(TestBase):
         self.assertTrue(hasattr(layer, "_mxfp8_original_shapes"))
         self.assertIn("w13_weight", layer._mxfp8_original_shapes)
         self.assertEqual(layer.w13_weight.shape, (original_shape[0], original_shape[2], original_shape[1]))
+        self.assertTrue(layer.w13_weight.data.is_contiguous())
+        self.assertTrue(layer.w2_weight.data.is_contiguous())
+        self.assertTrue(layer.w13_weight_scale.data.is_contiguous())
+        self.assertTrue(layer.w2_weight_scale.data.is_contiguous())
+        self.assertEqual(self.mock_maybe_trans_nz.call_count, 2)
+        for call in self.mock_maybe_trans_nz.call_args_list:
+            self.assertEqual(call.kwargs["customize_dtype"], torch.float8_e4m3fn)
+
+    @patch("vllm_ascend.quantization.methods.w8a8_mxfp8._should_trans_nz", return_value=False)
+    def test_process_weights_nz_disabled_keeps_pre_nz_layout(self, mock_should_trans_nz):
+        layer = create_mxfp_moe_layer(
+            num_experts=self.num_experts, hidden_size=self.hidden_size, intermediate_size=self.intermediate_size
+        )
+        self.scheme.process_weights_after_loading(layer)
         self.assertFalse(layer.w13_weight.data.is_contiguous())
         self.assertFalse(layer.w2_weight.data.is_contiguous())
         self.assertFalse(layer.w13_weight_scale.data.is_contiguous())

--- a/tests/ut/quantization/methods/test_w8a8_mxfp8.py
+++ b/tests/ut/quantization/methods/test_w8a8_mxfp8.py
@@ -136,12 +136,6 @@ class TestAscendW8A8MXFP8MoEMethod(TestBase):
         mock_ascend.return_value = create_mock_ascend_config()
         mock_ensure.return_value = None
         self.scheme = AscendW8A8MXFP8DynamicFusedMoEMethod()
-        patcher = patch(
-            "vllm_ascend.quantization.methods.w8a8_mxfp8.maybe_trans_nz",
-            side_effect=lambda x, **kwargs: x,
-        )
-        self.mock_maybe_trans_nz = patcher.start()
-        self.addCleanup(patcher.stop)
 
     def test_get_weight_various_expert_counts(self):
         for num_experts in [4, 8, 16]:
@@ -169,11 +163,8 @@ class TestAscendW8A8MXFP8MoEMethod(TestBase):
         self.assertTrue(layer.w2_weight.data.is_contiguous())
         self.assertTrue(layer.w13_weight_scale.data.is_contiguous())
         self.assertTrue(layer.w2_weight_scale.data.is_contiguous())
-        self.assertEqual(self.mock_maybe_trans_nz.call_count, 2)
-        for call in self.mock_maybe_trans_nz.call_args_list:
-            self.assertEqual(call.kwargs["customize_dtype"], torch.float8_e4m3fn)
 
-    @patch("vllm_ascend.quantization.methods.w8a8_mxfp8._should_trans_nz", return_value=False)
+    @patch("vllm_ascend.utils._should_trans_nz", return_value=False)
     def test_process_weights_nz_disabled_keeps_pre_nz_layout(self, mock_should_trans_nz):
         layer = create_mxfp_moe_layer(
             num_experts=self.num_experts, hidden_size=self.hidden_size, intermediate_size=self.intermediate_size

--- a/tests/ut/test_utils.py
+++ b/tests/ut/test_utils.py
@@ -20,6 +20,7 @@ from unittest import mock
 
 import pytest
 import torch
+import torch_npu
 
 from tests.ut.base import TestBase
 from vllm_ascend import utils
@@ -425,6 +426,68 @@ class TestUtils(TestBase):
             result = utils.maybe_trans_nz(weight)
             self.assertIs(result, weight)
             assert_nz_cast(weight)
+
+        # Test case 8: customize_dtype is passed through to npu_format_cast
+        mock_npu_format_cast.reset_mock()
+        mock_config.weight_nz_mode = 2
+        with (
+            mock.patch("vllm_ascend.utils.get_ascend_config", return_value=mock_config),
+            mock.patch("vllm_ascend.utils.is_310p", return_value=False),
+        ):
+            weight = torch.randn(32, 64, dtype=torch.float8_e4m3fn)
+            result = utils.maybe_trans_nz(weight, customize_dtype=torch.float8_e4m3fn)
+            self.assertIs(result, weight)
+            mock_npu_format_cast.assert_called_once()
+            args, kwargs = mock_npu_format_cast.call_args
+            self.assertEqual(kwargs["customize_dtype"], torch.float8_e4m3fn)
+            self.assertNotIn("input_dtype", kwargs)
+
+        # Test case 9: input_dtype is passed through to npu_format_cast
+        mock_npu_format_cast.reset_mock()
+        mock_config.weight_nz_mode = 2
+        with (
+            mock.patch("vllm_ascend.utils.get_ascend_config", return_value=mock_config),
+            mock.patch("vllm_ascend.utils.is_310p", return_value=False),
+        ):
+            weight = torch.randn(32, 64, dtype=torch.float8_e4m3fn)
+            result = utils.maybe_trans_nz(weight, input_dtype=torch_npu.float4_e2m1fn_x2)
+            self.assertIs(result, weight)
+            mock_npu_format_cast.assert_called_once()
+            args, kwargs = mock_npu_format_cast.call_args
+            self.assertEqual(kwargs["input_dtype"], torch_npu.float4_e2m1fn_x2)
+            self.assertNotIn("customize_dtype", kwargs)
+
+        # Test case 10: both customize_dtype and input_dtype passed through
+        mock_npu_format_cast.reset_mock()
+        mock_config.weight_nz_mode = 2
+        with (
+            mock.patch("vllm_ascend.utils.get_ascend_config", return_value=mock_config),
+            mock.patch("vllm_ascend.utils.is_310p", return_value=False),
+        ):
+            weight = torch.randn(32, 64, dtype=torch.float8_e4m3fn)
+            result = utils.maybe_trans_nz(
+                weight,
+                customize_dtype=torch.float8_e4m3fn,
+                input_dtype=torch_npu.float4_e2m1fn_x2,
+            )
+            self.assertIs(result, weight)
+            mock_npu_format_cast.assert_called_once()
+            args, kwargs = mock_npu_format_cast.call_args
+            self.assertEqual(kwargs["customize_dtype"], torch.float8_e4m3fn)
+            self.assertEqual(kwargs["input_dtype"], torch_npu.float4_e2m1fn_x2)
+
+        # Test case 11: no conversion when _should_trans_nz returns False,
+        # even when customize_dtype is provided
+        mock_npu_format_cast.reset_mock()
+        mock_config.weight_nz_mode = 0
+        with (
+            mock.patch("vllm_ascend.utils.get_ascend_config", return_value=mock_config),
+            mock.patch("vllm_ascend.utils.is_310p", return_value=False),
+        ):
+            weight = torch.randn(32, 64, dtype=torch.float16)
+            result = utils.maybe_trans_nz(weight, customize_dtype=torch.float8_e4m3fn)
+            self.assertIs(result, weight)
+            mock_npu_format_cast.assert_not_called()
 
 
 def test_is_pd_decode_recompute_scheduler_enabled_without_config():

--- a/tests/ut/test_utils.py
+++ b/tests/ut/test_utils.py
@@ -434,7 +434,7 @@ class TestUtils(TestBase):
             mock.patch("vllm_ascend.utils.get_ascend_config", return_value=mock_config),
             mock.patch("vllm_ascend.utils.is_310p", return_value=False),
         ):
-            weight = torch.randn(32, 64, dtype=torch.float8_e4m3fn)
+            weight = torch.empty(32, 64, dtype=torch.float8_e4m3fn)
             result = utils.maybe_trans_nz(weight, customize_dtype=torch.float8_e4m3fn)
             self.assertIs(result, weight)
             mock_npu_format_cast.assert_called_once()
@@ -449,7 +449,7 @@ class TestUtils(TestBase):
             mock.patch("vllm_ascend.utils.get_ascend_config", return_value=mock_config),
             mock.patch("vllm_ascend.utils.is_310p", return_value=False),
         ):
-            weight = torch.randn(32, 64, dtype=torch.float8_e4m3fn)
+            weight = torch.empty(32, 64, dtype=torch.float8_e4m3fn)
             result = utils.maybe_trans_nz(weight, input_dtype=torch_npu.float4_e2m1fn_x2)
             self.assertIs(result, weight)
             mock_npu_format_cast.assert_called_once()
@@ -464,7 +464,7 @@ class TestUtils(TestBase):
             mock.patch("vllm_ascend.utils.get_ascend_config", return_value=mock_config),
             mock.patch("vllm_ascend.utils.is_310p", return_value=False),
         ):
-            weight = torch.randn(32, 64, dtype=torch.float8_e4m3fn)
+            weight = torch.empty(32, 64, dtype=torch.float8_e4m3fn)
             result = utils.maybe_trans_nz(
                 weight,
                 customize_dtype=torch.float8_e4m3fn,
@@ -488,6 +488,47 @@ class TestUtils(TestBase):
             result = utils.maybe_trans_nz(weight, customize_dtype=torch.float8_e4m3fn)
             self.assertIs(result, weight)
             mock_npu_format_cast.assert_not_called()
+
+    @mock.patch("torch_npu.npu_format_cast")
+    def test_maybe_trans_nz_with_scale(self, mock_npu_format_cast):
+        from vllm_ascend.utils import ACL_FORMAT_FRACTAL_NZ, maybe_trans_nz_with_scale
+
+        mock_npu_format_cast.side_effect = lambda weight, fmt, **kwargs: weight
+
+        def run(nz_mode):
+            mock_config = mock.MagicMock()
+            mock_config.weight_nz_mode = nz_mode
+            with (
+                mock.patch("vllm_ascend.utils.get_ascend_config", return_value=mock_config),
+                mock.patch("vllm_ascend.utils.is_310p", return_value=False),
+            ):
+                weight = torch.randn(4, 8, dtype=torch.float16)
+                scale = torch.randn(4, 4, 2, dtype=torch.float16)
+                return maybe_trans_nz_with_scale(
+                    weight,
+                    scale,
+                    transpose_dims=(0, 1),
+                    customize_dtype=torch.float8_e4m3fn,
+                    input_dtype=torch_npu.float4_e2m1fn_x2,
+                )
+
+        # NZ disabled: keep non-contiguous layout, no cast.
+        w, s = run(0)
+        self.assertEqual(w.shape, (8, 4))
+        self.assertFalse(w.is_contiguous())
+        self.assertFalse(s.is_contiguous())
+        mock_npu_format_cast.assert_not_called()
+
+        # NZ enabled: contiguous + cast with dtype hints.
+        mock_npu_format_cast.reset_mock()
+        w, s = run(2)
+        self.assertTrue(w.is_contiguous())
+        self.assertTrue(s.is_contiguous())
+        mock_npu_format_cast.assert_called_once()
+        args, kwargs = mock_npu_format_cast.call_args
+        self.assertEqual(args[1], ACL_FORMAT_FRACTAL_NZ)
+        self.assertEqual(kwargs["customize_dtype"], torch.float8_e4m3fn)
+        self.assertEqual(kwargs["input_dtype"], torch_npu.float4_e2m1fn_x2)
 
 
 def test_is_pd_decode_recompute_scheduler_enabled_without_config():

--- a/vllm_ascend/attention/sfa_v1.py
+++ b/vllm_ascend/attention/sfa_v1.py
@@ -757,21 +757,32 @@ class AscendSFAImpl(MLAAttentionImpl):
     def _resolve_preprocess_type(self, act_dtype: torch.dtype) -> PreprocessType:
         quant_method = self._get_layer_quant_method(self.fused_qkv_a_proj)
         self._quant_type = type(quant_method) if quant_method is not None else None
-        qt = self._quant_type
 
-        if self.is_kv_consumer and (
-            (qt is AscendW8A8DynamicLinearMethod and self.enable_sparse_sfa_c8)
-            or qt is AscendW8A8MXFP8DynamicLinearMethod
-            or qt is None
-        ):
-            if self._try_enable_type(PreprocessType.PROLOG_V3, act_dtype):
+        pp_type = self._fused_preprocess_type()
+        if pp_type is not None and self._try_enable_type(pp_type, act_dtype):
+            return pp_type
+        return PreprocessType.NATIVE
+
+    def _fused_preprocess_type(self) -> PreprocessType | None:
+        """Return the enabled fused preprocess type, or None if it cannot run."""
+        quant_method = self._get_layer_quant_method(self.fused_qkv_a_proj)
+        qt = type(quant_method) if quant_method is not None else None
+
+        # PROLOG_V3 takes precedence over MLAPO.
+        if getattr(self, "dcp_group", None) is None:
+            eligible = self.is_kv_consumer and (
+                (qt is AscendW8A8DynamicLinearMethod and self.enable_sparse_sfa_c8)
+                or qt is AscendW8A8MXFP8DynamicLinearMethod
+                or qt is None
+            )
+            if eligible and not self._get_fused_type_unsupported_reasons(PreprocessType.PROLOG_V3):
                 return PreprocessType.PROLOG_V3
 
-        if qt is AscendW8A8LinearMethod and self.enable_mlapo:
-            if self._try_enable_type(PreprocessType.MLAPO, act_dtype):
-                return PreprocessType.MLAPO
+        eligible = qt is AscendW8A8LinearMethod and self.enable_mlapo
+        if eligible and not self._get_fused_type_unsupported_reasons(PreprocessType.MLAPO):
+            return PreprocessType.MLAPO
 
-        return PreprocessType.NATIVE
+        return None
 
     def _try_enable_type(self, pp_type: PreprocessType, act_dtype: torch.dtype) -> bool:
         reasons = self._get_fused_type_unsupported_reasons(pp_type)
@@ -794,10 +805,12 @@ class AscendSFAImpl(MLAAttentionImpl):
         if self.fused_qkv_a_proj is None:
             reasons.append("fused_qkv_a_proj is None, mlapo is disabled.")
 
+        quant_method = self._get_layer_quant_method(self.fused_qkv_a_proj)
+        qt = type(quant_method) if quant_method is not None else None
         if pp_type is PreprocessType.PROLOG_V3:
             if self.is_kv_producer:
                 reasons.append("PROLOG_V3 is disabled on KV producer workers.")
-            if self._quant_type is None and self.enable_sparse_sfa_c8:
+            if qt is None and self.enable_sparse_sfa_c8:
                 reasons.append("PROLOG_V3: C8 sparse requires quantized MLAPO.")
             if getattr(self.q_proj, "_chunk_size", 0):
                 reasons.append("PROLOG_V3 does not support chunked q_proj weights yet.")

--- a/vllm_ascend/ops/mla.py
+++ b/vllm_ascend/ops/mla.py
@@ -128,6 +128,15 @@ class AscendMultiHeadLatentAttention(MultiHeadLatentAttentionWrapper):
             layer_name=f"{prefix}.attn",
         )
 
+        # Fused preprocess (mlapo/prolog_v3) owns transpose+NZ for these
+        # layers, so quant methods must skip their own NZ conversion.
+        # Mark before VLLM calls process_weights_after_loading on submodules.
+        impl = self.mla_attn.impl
+        if getattr(impl, "_fused_preprocess_type", None) and impl._fused_preprocess_type() is not None:
+            for _layer in (impl.fused_qkv_a_proj, impl.q_proj):
+                if _layer is not None:
+                    _layer._fused_preprocess_managed = True
+
         original_process_weights = self.mla_attn.process_weights_after_loading
 
         def wrapped_process_weights(act_dtype: torch.dtype):

--- a/vllm_ascend/quantization/methods/w4a4_mxfp4.py
+++ b/vllm_ascend/quantization/methods/w4a4_mxfp4.py
@@ -33,6 +33,7 @@ from vllm_ascend.device.mxfp_compat import (
 )
 from vllm_ascend.ops.fused_moe.experts_selector import select_experts
 from vllm_ascend.ops.fused_moe.moe_runtime_args import build_fused_experts_input
+from vllm_ascend.utils import _should_trans_nz, maybe_trans_nz
 
 from .base import AscendLinearScheme, AscendMoEScheme, QuantType, get_moe_num_logical_experts
 from .registry import register_scheme
@@ -118,8 +119,16 @@ class AscendW4A4MXFP4DynamicLinearMethod(AscendLinearScheme):
             layer.weight_scale.data = layer.weight_scale.data.reshape(n_dim, k_dim // 2 + 1, 2)
         else:
             layer.weight_scale.data = layer.weight_scale.data.reshape(n_dim, k_dim // 2, 2)
-        layer.weight.data = layer.weight.data.transpose(0, 1)
-        layer.weight_scale.data = layer.weight_scale.data.transpose(0, 1)
+        if _should_trans_nz(layer.weight.data):
+            layer.weight.data = layer.weight.data.transpose(0, 1).contiguous()
+            layer.weight_scale.data = layer.weight_scale.data.transpose(0, 1).contiguous()
+            layer.weight.data = maybe_trans_nz(
+                layer.weight.data, customize_dtype=torch.float8_e4m3fn, input_dtype=torch_npu.float4_e2m1fn_x2
+            )
+        else:
+            # NZ disabled: keep the pre-NZ non-contiguous transpose layout.
+            layer.weight.data = layer.weight.data.transpose(0, 1)
+            layer.weight_scale.data = layer.weight_scale.data.transpose(0, 1)
 
 
 @register_scheme("W4A4_MXFP4", "moe")

--- a/vllm_ascend/quantization/methods/w4a4_mxfp4.py
+++ b/vllm_ascend/quantization/methods/w4a4_mxfp4.py
@@ -33,7 +33,7 @@ from vllm_ascend.device.mxfp_compat import (
 )
 from vllm_ascend.ops.fused_moe.experts_selector import select_experts
 from vllm_ascend.ops.fused_moe.moe_runtime_args import build_fused_experts_input
-from vllm_ascend.utils import _should_trans_nz, maybe_trans_nz
+from vllm_ascend.utils import maybe_trans_nz_with_scale
 
 from .base import AscendLinearScheme, AscendMoEScheme, QuantType, get_moe_num_logical_experts
 from .registry import register_scheme
@@ -119,16 +119,13 @@ class AscendW4A4MXFP4DynamicLinearMethod(AscendLinearScheme):
             layer.weight_scale.data = layer.weight_scale.data.reshape(n_dim, k_dim // 2 + 1, 2)
         else:
             layer.weight_scale.data = layer.weight_scale.data.reshape(n_dim, k_dim // 2, 2)
-        if _should_trans_nz(layer.weight.data):
-            layer.weight.data = layer.weight.data.transpose(0, 1).contiguous()
-            layer.weight_scale.data = layer.weight_scale.data.transpose(0, 1).contiguous()
-            layer.weight.data = maybe_trans_nz(
-                layer.weight.data, customize_dtype=torch.float8_e4m3fn, input_dtype=torch_npu.float4_e2m1fn_x2
-            )
-        else:
-            # NZ disabled: keep the pre-NZ non-contiguous transpose layout.
-            layer.weight.data = layer.weight.data.transpose(0, 1)
-            layer.weight_scale.data = layer.weight_scale.data.transpose(0, 1)
+        layer.weight.data, layer.weight_scale.data = maybe_trans_nz_with_scale(
+            layer.weight.data,
+            layer.weight_scale.data,
+            transpose_dims=(0, 1),
+            customize_dtype=torch.float8_e4m3fn,
+            input_dtype=torch_npu.float4_e2m1fn_x2,
+        )
 
 
 @register_scheme("W4A4_MXFP4", "moe")

--- a/vllm_ascend/quantization/methods/w8a8_mxfp8.py
+++ b/vllm_ascend/quantization/methods/w8a8_mxfp8.py
@@ -34,6 +34,7 @@ from vllm_ascend.device.mxfp_compat import (
 )
 from vllm_ascend.ops.fused_moe.experts_selector import select_experts
 from vllm_ascend.ops.fused_moe.moe_runtime_args import build_fused_experts_input
+from vllm_ascend.utils import _should_trans_nz, maybe_trans_nz
 
 from .base import AscendLinearScheme, AscendMoEScheme, QuantType, get_moe_num_logical_experts
 from .registry import register_scheme
@@ -156,6 +157,8 @@ class AscendW8A8MXFP8DynamicLinearMethod(AscendLinearScheme):
 
         layer.weight.data = layer._mxfp8_weight_buf
         layer.weight_scale.data = layer._mxfp8_scale_buf
+        if not getattr(layer, "_fused_preprocess_managed", False):
+            layer.weight.data = maybe_trans_nz(layer.weight.data, customize_dtype=torch.float8_e4m3fn)
 
         # Mark as transformed
         layer._mxfp8_transformed = True
@@ -347,8 +350,8 @@ class AscendW8A8MXFP8DynamicFusedMoEMethod(AscendMoEScheme):
         """Process weights after loading for MXFP8 inference.
 
         This method transforms weights for NPU MXFP8 computation:
-        - w13_weight: (g_num, n_size, k_size) -> (g_num, k_size, n_size)
-        - w2_weight: (g_num, n_size, k_size) -> (g_num, k_size, n_size)
+        - w13_weight: (g_num, n_size, k_size) -> (g_num, k_size, n_size) in FRACTAL_NZ
+        - w2_weight: (g_num, n_size, k_size) -> (g_num, k_size, n_size) in FRACTAL_NZ
         - w13_weight_scale: (g_num, n_size, k_size) -> (g_num, k_size//2, n_size, 2)
         - w2_weight_scale: (g_num, n_size, k_size) -> (g_num, k_size//2, n_size, 2)
 
@@ -376,10 +379,19 @@ class AscendW8A8MXFP8DynamicFusedMoEMethod(AscendMoEScheme):
         layer.w13_weight_scale.data = layer.w13_weight_scale.data.reshape(g_num, n_size, k_size // 2, 2)
         g_num, n_size, k_size = layer.w2_weight_scale.shape
         layer.w2_weight_scale.data = layer.w2_weight_scale.data.reshape(g_num, n_size, k_size // 2, 2)
-        layer.w13_weight.data = layer.w13_weight.data.transpose(1, 2)
-        layer.w2_weight.data = layer.w2_weight.data.transpose(1, 2)
-        layer.w13_weight_scale.data = layer.w13_weight_scale.data.transpose(1, 2)
-        layer.w2_weight_scale.data = layer.w2_weight_scale.data.transpose(1, 2)
+        if _should_trans_nz(layer.w13_weight.data):
+            layer.w13_weight.data = layer.w13_weight.data.transpose(1, 2).contiguous()
+            layer.w2_weight.data = layer.w2_weight.data.transpose(1, 2).contiguous()
+            layer.w13_weight.data = maybe_trans_nz(layer.w13_weight.data, customize_dtype=torch.float8_e4m3fn)
+            layer.w2_weight.data = maybe_trans_nz(layer.w2_weight.data, customize_dtype=torch.float8_e4m3fn)
+            layer.w13_weight_scale.data = layer.w13_weight_scale.data.transpose(1, 2).contiguous()
+            layer.w2_weight_scale.data = layer.w2_weight_scale.data.transpose(1, 2).contiguous()
+        else:
+            # NZ disabled: keep the pre-NZ non-contiguous transpose layout.
+            layer.w13_weight.data = layer.w13_weight.data.transpose(1, 2)
+            layer.w2_weight.data = layer.w2_weight.data.transpose(1, 2)
+            layer.w13_weight_scale.data = layer.w13_weight_scale.data.transpose(1, 2)
+            layer.w2_weight_scale.data = layer.w2_weight_scale.data.transpose(1, 2)
 
         # Mark as transformed
         layer._mxfp8_transformed = True
@@ -429,7 +441,7 @@ class AscendW8A8MXFP8DynamicFusedMoEMethod(AscendMoEScheme):
             orig_scale_shape = orig_shapes[scale_key]
 
             target_scale = scale_tensor.data.transpose(1, 2).reshape(orig_scale_shape).contiguous()
-            scale_tensor.data = scale_tensor.data.transpose(1, 2).view(orig_scale_shape)
+            scale_tensor.data = scale_tensor.data.transpose(1, 2).reshape(orig_scale_shape)
             scale_tensor.data.copy_(target_scale)
 
         _restore("w13_weight", "w13_weight_scale")

--- a/vllm_ascend/quantization/methods/w8a8_mxfp8.py
+++ b/vllm_ascend/quantization/methods/w8a8_mxfp8.py
@@ -34,7 +34,7 @@ from vllm_ascend.device.mxfp_compat import (
 )
 from vllm_ascend.ops.fused_moe.experts_selector import select_experts
 from vllm_ascend.ops.fused_moe.moe_runtime_args import build_fused_experts_input
-from vllm_ascend.utils import _should_trans_nz, maybe_trans_nz
+from vllm_ascend.utils import maybe_trans_nz, maybe_trans_nz_with_scale
 
 from .base import AscendLinearScheme, AscendMoEScheme, QuantType, get_moe_num_logical_experts
 from .registry import register_scheme
@@ -379,19 +379,18 @@ class AscendW8A8MXFP8DynamicFusedMoEMethod(AscendMoEScheme):
         layer.w13_weight_scale.data = layer.w13_weight_scale.data.reshape(g_num, n_size, k_size // 2, 2)
         g_num, n_size, k_size = layer.w2_weight_scale.shape
         layer.w2_weight_scale.data = layer.w2_weight_scale.data.reshape(g_num, n_size, k_size // 2, 2)
-        if _should_trans_nz(layer.w13_weight.data):
-            layer.w13_weight.data = layer.w13_weight.data.transpose(1, 2).contiguous()
-            layer.w2_weight.data = layer.w2_weight.data.transpose(1, 2).contiguous()
-            layer.w13_weight.data = maybe_trans_nz(layer.w13_weight.data, customize_dtype=torch.float8_e4m3fn)
-            layer.w2_weight.data = maybe_trans_nz(layer.w2_weight.data, customize_dtype=torch.float8_e4m3fn)
-            layer.w13_weight_scale.data = layer.w13_weight_scale.data.transpose(1, 2).contiguous()
-            layer.w2_weight_scale.data = layer.w2_weight_scale.data.transpose(1, 2).contiguous()
-        else:
-            # NZ disabled: keep the pre-NZ non-contiguous transpose layout.
-            layer.w13_weight.data = layer.w13_weight.data.transpose(1, 2)
-            layer.w2_weight.data = layer.w2_weight.data.transpose(1, 2)
-            layer.w13_weight_scale.data = layer.w13_weight_scale.data.transpose(1, 2)
-            layer.w2_weight_scale.data = layer.w2_weight_scale.data.transpose(1, 2)
+        layer.w13_weight.data, layer.w13_weight_scale.data = maybe_trans_nz_with_scale(
+            layer.w13_weight.data,
+            layer.w13_weight_scale.data,
+            transpose_dims=(1, 2),
+            customize_dtype=torch.float8_e4m3fn,
+        )
+        layer.w2_weight.data, layer.w2_weight_scale.data = maybe_trans_nz_with_scale(
+            layer.w2_weight.data,
+            layer.w2_weight_scale.data,
+            transpose_dims=(1, 2),
+            customize_dtype=torch.float8_e4m3fn,
+        )
 
         # Mark as transformed
         layer._mxfp8_transformed = True

--- a/vllm_ascend/utils.py
+++ b/vllm_ascend/utils.py
@@ -299,6 +299,33 @@ def maybe_trans_nz(
     return torch_npu.npu_format_cast(weight, ACL_FORMAT_FRACTAL_NZ, **kwargs)
 
 
+def maybe_trans_nz_with_scale(
+    weight: torch.Tensor,
+    weight_scale: torch.Tensor,
+    transpose_dims: tuple[int, ...],
+    *,
+    customize_dtype: torch.dtype | None = None,
+    input_dtype: torch.dtype | None = None,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Transpose weight/scale and convert to FRACTAL_NZ when NZ applies.
+
+    Preserves the pre-NZ non-contiguous layout when NZ is disabled.
+    """
+    weight = weight.transpose(*transpose_dims)
+    weight_scale = weight_scale.transpose(*transpose_dims)
+    if not _should_trans_nz(weight):
+        return weight, weight_scale
+    weight = weight.contiguous()
+    weight_scale = weight_scale.contiguous()
+    kwargs = {}
+    if customize_dtype is not None:
+        kwargs["customize_dtype"] = customize_dtype
+    if input_dtype is not None:
+        kwargs["input_dtype"] = input_dtype
+    weight = torch_npu.npu_format_cast(weight, ACL_FORMAT_FRACTAL_NZ, **kwargs)
+    return weight, weight_scale
+
+
 def _round_up(x: int, align: int):
     # round up x to align, for example, if align is 16, x will be rounded up to 16, 32, 48, etc.
     # input: 15, 16 -> output: 16

--- a/vllm_ascend/utils.py
+++ b/vllm_ascend/utils.py
@@ -284,10 +284,19 @@ def _should_trans_nz(weight: torch.Tensor) -> bool:
 # - non-310P: follow VLLM_ASCEND_ENABLE_NZ
 # - FP32: never convert
 # - meta tensor: never convert
-def maybe_trans_nz(weight: torch.Tensor) -> torch.Tensor:
+def maybe_trans_nz(
+    weight: torch.Tensor,
+    customize_dtype: torch.dtype | None = None,
+    input_dtype: torch.dtype | None = None,
+) -> torch.Tensor:
     if not _should_trans_nz(weight):
         return weight
-    return torch_npu.npu_format_cast(weight, ACL_FORMAT_FRACTAL_NZ)
+    kwargs = {}
+    if customize_dtype is not None:
+        kwargs["customize_dtype"] = customize_dtype
+    if input_dtype is not None:
+        kwargs["input_dtype"] = input_dtype
+    return torch_npu.npu_format_cast(weight, ACL_FORMAT_FRACTAL_NZ, **kwargs)
 
 
 def _round_up(x: int, align: int):


### PR DESCRIPTION
﻿### What this PR does / why we need it?

Backports the A5 MX quantization FRACTAL_NZ support to v0.26.0rc.

A5 requires FRACTAL_NZ for MX quantized W8A8/W4A4 weights. Previously the code always kept the non-contiguous transpose layout, which is not compatible with NZ-enabled execution on A5.

This PR:
- Extends `maybe_trans_nz` to forward `customize_dtype` / `input_dtype` to `npu_format_cast` so FP8/FP4 MX weights can be converted to FRACTAL_NZ with correct dtype hints.
- Updates W8A8 MXFP8 and W4A4 MXFP4 weight processing to convert to FRACTAL_NZ when NZ is enabled, while preserving the old non-contiguous layout when NZ is disabled.
- Avoids double NZ conversion for layers processed by fused SFA preprocess (MLAPO/PROLOG_V3).
- Refactors SFA preprocess type resolution so the fused preprocess decision can be queried before submodule weight processing.

Related to #15865

### Does this PR introduce _any_ user-facing change?

No new user-facing API. Behavior is affected only when NZ is enabled on supported hardware; with NZ disabled, existing MX layout behavior is preserved.

### How was this patch tested?

- Unit tests: `pytest -sv tests/ut/attention/a2/test_sfa_v1.py tests/ut/ops/test_mla.py tests/ut/quantization/methods/test_w4a4_mxfp4.py tests/ut/quantization/methods/test_w8a8_mxfp8.py tests/ut/test_utils.py`




- vLLM main: https://github.com/vllm-project/vllm/commit/d02df748bf9efd99022f1a062597dc3cb3808485
