### PR TITLE
[v0.27.1rc][Performance] Skip per-layer indexer cache for GLM-5.1 IndexCache S layers

### DIFF
--- a/tests/ut/attention/test_sfa_v1.py
+++ b/tests/ut/attention/test_sfa_v1.py
@@ -26,6 +26,7 @@ from vllm_ascend.attention.sfa_v1 import (
     AscendSFAMetadata,
     AscendSFAMetadataBuilder,
     PreprocessType,
+    _is_mtp_layer,
     custom_kv_rmsnorm_rope,
 )
 from vllm_ascend.attention.utils import get_sfa_qsfa_packed_head_dim
@@ -108,6 +109,47 @@ class TestAscendSFABackend(TestBase):
         mock_get_ascend_config.return_value.sparse_kv_offload_config.enabled = True
         result = AscendSFABackend.get_impl_cls()
         self.assertEqual(result, AscendSFAKVOffloadImpl)
+
+
+class TestIsMtpLayer(TestBase):
+    def test_backbone_layer_is_not_mtp(self):
+        config = SimpleNamespace(num_hidden_layers=80)
+        self.assertFalse(
+            _is_mtp_layer(
+                config,
+                "model.layers.2.self_attn.attn",
+            )
+        )
+
+    def test_mtp_layer_is_mtp(self):
+        config = SimpleNamespace(num_hidden_layers=80)
+        self.assertTrue(
+            _is_mtp_layer(
+                config,
+                "model.layers.80.self_attn.attn",
+            )
+        )
+        self.assertTrue(
+            _is_mtp_layer(
+                config,
+                "mtp.0.self_attn.attn",
+            )
+        )
+
+    def test_missing_layer_info_is_not_mtp(self):
+        config = SimpleNamespace(num_hidden_layers=80)
+        self.assertFalse(
+            _is_mtp_layer(
+                config,
+                "unknown",
+            )
+        )
+        self.assertFalse(
+            _is_mtp_layer(
+                SimpleNamespace(),
+                "model.layers.0.self_attn.attn",
+            )
+        )
 
 
 class TestAscendSFADeviceOperator(TestBase):

--- a/tests/ut/test_ascend_config.py
+++ b/tests/ut/test_ascend_config.py
@@ -144,8 +144,8 @@ class TestAscendConfig(TestBase):
     def test_sparse_li_c8_layer_filter_uses_indexer_wq_b_weight(self):
         config = self._make_sparse_li_c8_config(
             {
-                "model.layers.3.self_attn.indexer.wq_b_weight": "W8A8_MXFP8",
-                "model.layers.4.self_attn.indexer.wq_b_weight": "W8A8_DYNAMIC",
+                "model.layers.3.self_attn.indexer.wq_b.weight": "W8A8_MXFP8",
+                "model.layers.4.self_attn.indexer.wq_b.weight": "W8A8_DYNAMIC",
             }
         )
 

--- a/tests/ut/worker/test_model_runner_v1.py
+++ b/tests/ut/worker/test_model_runner_v1.py
@@ -738,6 +738,51 @@ class TestNPUModelRunnerKVCache(unittest.TestCase):
         self.assertEqual(v_cache.shape, (2, 16, 1, 64))
         self.assertEqual(indexer_cache.shape, (4, 16, 1, 128))
 
+    @patch("vllm_ascend.worker.model_runner_v1.has_ec_transfer", return_value=False)
+    @patch("vllm_ascend.worker.model_runner_v1.get_layers_from_vllm_config")
+    def test_sparse_indexer_skips_allocation_for_runtime_shared_s_layer(
+        self,
+        mock_get_layers,
+        _mock_has_ec_transfer,
+    ):
+        runner = self._build_runner()
+        runner.use_sparse = True
+        runner.block_size = 16
+        runner.sfa_dcp_replicated_indexer_size = 1
+        runner.kv_cache_dtype = torch.bfloat16
+        runner.shared_kv_cache_layers = {}
+        runner.ascend_config = MagicMock()
+        runner.ascend_config.is_sparse_li_c8_layer.return_value = False
+        runner.model_config.hf_text_config = SimpleNamespace(
+            kv_lora_rank=512,
+            qk_rope_head_dim=64,
+            index_head_dim=128,
+        )
+        runner.vllm_config.cache_config.cache_dtype = "auto"
+
+        attn_module = MLAAttention.__new__(MLAAttention)
+        torch.nn.Module.__init__(attn_module)
+        attn_module.impl = SimpleNamespace(
+            has_indexer=True,
+            runtime_has_indexer=False,
+            enable_sparse_sfa_c8=False,
+            enable_sparse_li_c8=False,
+        )
+        attn_module.kv_lora_rank = 512
+        attn_module.qk_rope_head_dim = 64
+        indexer_module = DeepseekV32IndexerCache.__new__(DeepseekV32IndexerCache)
+        torch.nn.Module.__init__(indexer_module)
+        attn_layer_name = "model.layers.1.self_attn.attn"
+        indexer_layer_name = "model.layers.1.self_attn.indexer.k_cache"
+        mock_get_layers.return_value = {
+            attn_layer_name: attn_module,
+            indexer_layer_name: indexer_module,
+        }
+
+        specs = runner.get_kv_cache_spec()
+        self.assertIn(attn_layer_name, specs)
+        self.assertNotIn(indexer_layer_name, specs)
+
     def test_sparse_c8_indexer_owns_quantized_cache_accounting(self):
         main_spec = AscendMLAAttentionSpec(
             block_size=16,

--- a/vllm_ascend/ascend_config.py
+++ b/vllm_ascend/ascend_config.py
@@ -811,7 +811,7 @@ class AscendConfig:
         quant_description = getattr(quant_config, "quant_description", None)
         if not isinstance(quant_description, dict):
             return False
-        quant_suffixes = (".indexer.quant_type", ".indexer.wq_b_weight")
+        quant_suffixes = (".indexer.quant_type", ".indexer.wq_b.weight")
         return any(isinstance(key, str) and key.endswith(quant_suffixes) for key in quant_description)
 
     @classmethod
@@ -820,7 +820,7 @@ class AscendConfig:
         if not isinstance(quant_description, dict):
             return set(), set()
 
-        QUANT_SUFFIXES = (".indexer.quant_type", ".indexer.wq_b_weight")
+        QUANT_SUFFIXES = (".indexer.quant_type", ".indexer.wq_b.weight")
         VALID_QUANT_TYPES = ("INT8_DYNAMIC", "W8A8_MXFP8")
 
         layer_ids: set[int] = set()

--- a/vllm_ascend/attention/sfa_v1.py
+++ b/vllm_ascend/attention/sfa_v1.py
@@ -559,7 +559,7 @@ class AscendSFAImpl(MLAAttentionImpl):
 
     @property
     def runtime_has_indexer(self) -> bool:
-        return self.has_indexer and not self.skip_indexer_pre_process
+        return self.has_indexer and not getattr(self, "skip_indexer_pre_process", False)
 
     @property
     def kv_cache_indexer_k_idx(self) -> int:

--- a/vllm_ascend/attention/sfa_v1.py
+++ b/vllm_ascend/attention/sfa_v1.py
@@ -57,6 +57,7 @@ from vllm_ascend.utils import (
     dispose_layer,
     enable_sp,
     maybe_trans_nz,
+    parse_layer_idx,
 )
 
 if TYPE_CHECKING:
@@ -96,6 +97,19 @@ def _get_config_bool(configs: tuple[Any, ...], attr: str) -> bool:
         if config is not None and hasattr(config, attr):
             return bool(getattr(config, attr))
     return False
+
+
+def _is_mtp_layer(hf_config: Any, layer_name: str | None) -> bool:
+    layer_name = layer_name or ""
+    num_hidden_layers = getattr(hf_config, "num_hidden_layers", None)
+    if num_hidden_layers is None:
+        return False
+    if ".mtp." in f".{layer_name}.":
+        return True
+    layer_id = parse_layer_idx(layer_name)
+    if layer_id is None:
+        return False
+    return layer_id >= num_hidden_layers
 
 
 class AscendSFABackend(AttentionBackend):
@@ -449,7 +463,7 @@ class AscendSFAImpl(MLAAttentionImpl):
         self.kv_a_layernorm = kwargs.get("kv_a_layernorm")
         self.q_a_layernorm = kwargs.get("q_a_layernorm")
         self.tp_size = get_tensor_model_parallel_world_size()
-        self.skip_topk = kwargs.get("skip_topk", False)
+        self._skip_topk = bool(kwargs.get("skip_topk", False))
         self.topk_indices_buffer = kwargs.get("topk_indices_buffer")
 
         ascend_config = get_ascend_config()
@@ -473,6 +487,8 @@ class AscendSFAImpl(MLAAttentionImpl):
             "use_index_cache",
         ) or _has_shared_indexer_layers(config_candidates)
         self.use_index_cache = self.skip_topk or index_cache_enabled
+        self._is_mtp_layer = _is_mtp_layer(hf_config, self.layer_name)
+        self.skip_indexer_pre_process = self.skip_topk and not self._is_mtp_layer
         self.has_indexer = self.indexer is not None
         if not self.has_indexer and not self.skip_topk:
             raise ValueError(
@@ -530,6 +546,20 @@ class AscendSFAImpl(MLAAttentionImpl):
         self.enable_mlapo = bool(get_ascend_config().enable_mlapo)
 
         self.enable_sp = enable_sp()
+
+    @property
+    def skip_topk(self) -> bool:
+        return self._skip_topk
+
+    @skip_topk.setter
+    def skip_topk(self, value: bool) -> None:
+        self._skip_topk = bool(value)
+        if hasattr(self, "_is_mtp_layer"):
+            self.skip_indexer_pre_process = self._skip_topk and not self._is_mtp_layer
+
+    @property
+    def runtime_has_indexer(self) -> bool:
+        return self.has_indexer and not self.skip_indexer_pre_process
 
     @property
     def kv_cache_indexer_k_idx(self) -> int:
@@ -1426,7 +1456,7 @@ class AscendSFAImpl(MLAAttentionImpl):
         # separate cache specs, while the current kernel path still expects the
         # legacy combined tuple layout.
         main_cache = kv_cache
-        if main_cache is None or not self.has_indexer:
+        if main_cache is None or not self.runtime_has_indexer:
             return main_cache
 
         # Sparse KV offload registers the main MLA cache as a 6-tuple
@@ -1546,7 +1576,7 @@ class AscendSFAImpl(MLAAttentionImpl):
                     "SFA Prolog V3 requires one cache index per input token, "
                     f"got token_x={hidden_states.shape[0]} and cache_index={slot_mapping_sfa.numel()}."
                 )
-            if self.has_indexer:
+            if self.runtime_has_indexer:
                 k_li, k_li_scale = self.indexer_select_pre_process(x=hidden_states, cos=cos, sin=sin)
             else:
                 k_li, k_li_scale = None, None
@@ -1581,7 +1611,7 @@ class AscendSFAImpl(MLAAttentionImpl):
             assert self.q_a_layernorm is not None, "q_a_layernorm must be initialized"
             q_c = self.q_a_layernorm(q_c)
 
-            if self.has_indexer:
+            if self.runtime_has_indexer:
                 k_li, k_li_scale = self.indexer_select_pre_process(
                     x=hidden_states,
                     cos=cos,
@@ -1636,7 +1666,7 @@ class AscendSFAImpl(MLAAttentionImpl):
                 parallel_context.gather_full_o_proj,
             )
 
-        if self.has_indexer:
+        if self.runtime_has_indexer:
             assert k_li is not None
             if self.vllm_config.parallel_config.prefill_context_parallel_size > 1:
                 assert attn_metadata.pcp_slot_mapping is not None

--- a/vllm_ascend/attention/sfa_v1.py
+++ b/vllm_ascend/attention/sfa_v1.py
@@ -102,7 +102,7 @@ def _get_config_bool(configs: tuple[Any, ...], attr: str) -> bool:
 def _is_mtp_layer(hf_config: Any, layer_name: str | None) -> bool:
     layer_name = layer_name or ""
     num_hidden_layers = getattr(hf_config, "num_hidden_layers", None)
-    if num_hidden_layers is None:
+    if not isinstance(num_hidden_layers, int):
         return False
     if ".mtp." in f".{layer_name}.":
         return True

--- a/vllm_ascend/worker/model_runner_v1.py
+++ b/vllm_ascend/worker/model_runner_v1.py
@@ -5058,6 +5058,12 @@ class NPUModelRunner(GPUModelRunner):
                     attn_layer_names.add(layer_name)
 
             elif isinstance(attn_module, DeepseekV32IndexerCache):
+                if not getattr(
+                    getattr(attn_layers.get(layer_name.replace(".indexer.k_cache", ".attn")), "impl", None),
+                    "runtime_has_indexer",
+                    True,
+                ):
+                    continue
                 # TODO: This mirrors upstream's separated KV/indexer specs for
                 # SFA, but keeps Ascend-specific shape/block-size accounting.
                 # Remove this special case once the generic vLLM spec/backend


### PR DESCRIPTION
﻿### What this PR does / why we need it?

Backports the GLM-5.1 IndexCache optimization to v0.27.1rc.

GLM-5.1 IndexCache keeps an `Indexer` module on static S layers for weight-loading compatibility, but those layers reuse another layer's top-k indices at runtime. Previously they still allocated and wrote a per-layer indexer KV cache even though the computed indexer keys were never consumed.

This PR:
- Adds `_is_mtp_layer()` so MTP/nextn layers stay on the existing per-layer indexer path.
- Adds `runtime_has_indexer` to distinguish weight-loading-only modules from runtime indexer owners.
- Skips indexer pre-processing and indexer KV cache writes for static S layers.
- Skips indexer KV cache allocation in `NPUModelRunner.get_kv_cache_spec()` for those layers.
- Also fixes the sparse LI C8 quant-description suffix to use `.indexer.wq_b.weight`.

Related to #15866

### Does this PR introduce _any_ user-facing change?

No user-facing API or configuration change. Internal memory/compute savings for GLM-5.1 IndexCache deployments; MTP layers keep existing behavior.

### How was this patch tested?

- Unit tests: `pytest -sv tests/ut/attention/test_sfa_v1.py tests/ut/test_ascend_config.py tests/ut/worker/test_model_runner_v1.py`


- vLLM main: https://github.com/vllm-project/vllm/commit/ba07e4a48fc951300d97eb506217dd530583dea3

