### PR TITLE
[v0.27.1rc][BugFix] Fix GLM5.2 MTP index cache

### DIFF
--- a/tests/ut/ops/test_mla.py
+++ b/tests/ut/ops/test_mla.py
@@ -210,8 +210,7 @@ class TestAscendMultiHeadLatentAttention(TestBase):
         mock_mla_attn.impl = MagicMock()
         mock_mla_attn.impl.process_weights_after_loading = MagicMock()
 
-        with patch("vllm_ascend.ops.mla.MLAAttention",
-                   return_value=mock_mla_attn) as mock_mla_attn_cls:
+        with patch("vllm_ascend.ops.mla.MLAAttention", return_value=mock_mla_attn) as mock_mla_attn_cls:
             mock_tp_size.return_value = 2
             mock_vllm_config = MagicMock(spec=VllmConfig)
             mock_vllm_config.model_config.hf_text_config = MagicMock(num_hidden_layers=32, first_k_dense_replace=True)

--- a/tests/ut/ops/test_mla.py
+++ b/tests/ut/ops/test_mla.py
@@ -210,7 +210,8 @@ class TestAscendMultiHeadLatentAttention(TestBase):
         mock_mla_attn.impl = MagicMock()
         mock_mla_attn.impl.process_weights_after_loading = MagicMock()
 
-        with patch("vllm_ascend.ops.mla.MLAAttention", return_value=mock_mla_attn):
+        with patch("vllm_ascend.ops.mla.MLAAttention",
+                   return_value=mock_mla_attn) as mock_mla_attn_cls:
             mock_tp_size.return_value = 2
             mock_vllm_config = MagicMock(spec=VllmConfig)
             mock_vllm_config.model_config.hf_text_config = MagicMock(num_hidden_layers=32, first_k_dense_replace=True)
@@ -234,4 +235,4 @@ class TestAscendMultiHeadLatentAttention(TestBase):
             )
 
             self.assertTrue(attn.skip_topk)
-            self.assertEqual(mock_mla_attn.call_args.kwargs.get("skip_topk"), True)
+            self.assertEqual(mock_mla_attn_cls.call_args.kwargs.get("skip_topk"), True)

--- a/tests/ut/ops/test_mla.py
+++ b/tests/ut/ops/test_mla.py
@@ -159,3 +159,79 @@ class TestAscendMultiHeadLatentAttention(TestBase):
         output = attn.forward(positions, hidden_states)
 
         self.assertEqual(output.shape, (3, self.hidden_size))
+
+    def test_skip_topk_property_forwards_to_impl(self):
+        """The proposer's set_skip_topk must reach the impl that gates the indexer."""
+        attn = AscendMultiHeadLatentAttention.__new__(AscendMultiHeadLatentAttention)
+
+        # Before mla_attn exists, the setter only stores the backing value.
+        attn.skip_topk = True
+        self.assertTrue(attn.skip_topk)
+        attn.skip_topk = False
+        self.assertFalse(attn.skip_topk)
+
+        # Once the impl exists, the setter must forward the toggle to it.
+        mock_impl = MagicMock()
+        mock_impl.skip_topk = False
+        mock_mla_attn = MagicMock()
+        mock_mla_attn.impl = mock_impl
+        attn.mla_attn = mock_mla_attn
+
+        attn.skip_topk = True
+        self.assertTrue(attn.skip_topk)
+        self.assertTrue(mock_impl.skip_topk, "impl skip_topk should be forwarded by the wrapper setter.")
+
+        attn.skip_topk = False
+        self.assertFalse(attn.skip_topk)
+        self.assertFalse(mock_impl.skip_topk, "impl skip_topk should follow the wrapper toggle back.")
+
+    def test_topk_indices_buffer_property_forwards_to_impl(self):
+        """_maybe_share_topk_indices / compact_topk_indices must reach the impl buffer."""
+        attn = AscendMultiHeadLatentAttention.__new__(AscendMultiHeadLatentAttention)
+        self.assertIsNone(attn.topk_indices_buffer)
+
+        buffer = torch.empty(8, 2048, dtype=torch.int32)
+        mock_impl = MagicMock()
+        mock_impl.topk_indices_buffer = None
+        mock_mla_attn = MagicMock()
+        mock_mla_attn.impl = mock_impl
+        attn.mla_attn = mock_mla_attn
+
+        attn.topk_indices_buffer = buffer
+        self.assertIs(attn.topk_indices_buffer, buffer)
+        self.assertIs(mock_impl.topk_indices_buffer, buffer)
+
+    @patch("vllm_ascend.ops.mla.get_current_vllm_config")
+    @patch("vllm_ascend.ops.mla.get_tensor_model_parallel_world_size")
+    def test_initialization_skip_topk_consistency(self, mock_tp_size, mock_get_vllm_config):
+        """Init must store skip_topk on the wrapper and pass it to MLAAttention."""
+        mock_mla_attn = MagicMock()
+        mock_mla_attn.process_weights_after_loading = MagicMock()
+        mock_mla_attn.impl = MagicMock()
+        mock_mla_attn.impl.process_weights_after_loading = MagicMock()
+
+        with patch("vllm_ascend.ops.mla.MLAAttention", return_value=mock_mla_attn):
+            mock_tp_size.return_value = 2
+            mock_vllm_config = MagicMock(spec=VllmConfig)
+            mock_vllm_config.model_config.hf_text_config = MagicMock(num_hidden_layers=32, first_k_dense_replace=True)
+            mock_get_vllm_config.return_value = mock_vllm_config
+            mock_vllm_config.compilation_config = CompilationConfig()
+
+            attn = AscendMultiHeadLatentAttention(
+                hidden_size=self.hidden_size,
+                num_heads=self.num_heads,
+                scale=self.scale,
+                qk_nope_head_dim=self.qk_nope_head_dim,
+                qk_rope_head_dim=self.qk_rope_head_dim,
+                v_head_dim=self.v_head_dim,
+                q_lora_rank=self.q_lora_rank,
+                kv_lora_rank=self.kv_lora_rank,
+                mla_modules=self.mock_mla_modules,
+                cache_config=self.mock_cache_config,
+                quant_config=self.mock_quant_config,
+                prefix=self.prefix,
+                skip_topk=True,
+            )
+
+            self.assertTrue(attn.skip_topk)
+            self.assertEqual(mock_mla_attn.call_args.kwargs.get("skip_topk"), True)

--- a/tests/ut/spec_decode/test_eagle_proposer.py
+++ b/tests/ut/spec_decode/test_eagle_proposer.py
@@ -4224,11 +4224,12 @@ class TestDeepSeekMTPIndicesSharing(unittest.TestCase):
         self.assertFalse(hasattr(mod2, "topk_indices_buffer"), "Module 2 should not have a buffer added.")
 
     def test_run_merge_draft_mtp_skip_topk(self):
-        """Test the set_skip_topk calling logic in step 0 and step 1 of run_merge_draft."""
+        """Test the set_skip_topk / compact_topk_indices calling logic in step 0
+        and step 1 of run_merge_draft."""
         proposer = AscendEagleProposer.__new__(AscendEagleProposer)
         proposer._share_mtp_indices = True
 
-        # Mock Draft Model and its set_skip_topk method
+        # Mock Draft Model and its set_skip_topk / compact_topk_indices methods
         draft_model_mock = MagicMock()
         proposer.model = MagicMock()
         proposer.model.model = draft_model_mock
@@ -4237,9 +4238,11 @@ class TestDeepSeekMTPIndicesSharing(unittest.TestCase):
         proposer.model_returns_tuple = MagicMock(return_value=False)
         proposer.model.return_value = MagicMock()
 
+        token_indices_to_sample = torch.arange(8, dtype=torch.int32)
+
         # Mock the run_merge_draft logic from your PR
         # (Since this is a class method, we use an inner function to simulate and verify the core logic)
-        def mock_run_merge_draft(**model_kwargs):
+        def mock_run_merge_draft(token_indices_to_sample, **model_kwargs):
             # Step 0
             draft_model = getattr(proposer.model, "model", None)
             if proposer._share_mtp_indices and draft_model is not None and hasattr(draft_model, "set_skip_topk"):
@@ -4251,9 +4254,11 @@ class TestDeepSeekMTPIndicesSharing(unittest.TestCase):
             # Step 1
             if proposer._share_mtp_indices and draft_model is not None and hasattr(draft_model, "set_skip_topk"):
                 draft_model.set_skip_topk(True)
+                if hasattr(draft_model, "compact_topk_indices"):
+                    draft_model.compact_topk_indices(token_indices_to_sample)
 
         # Run the test
-        mock_run_merge_draft(input_ids=torch.tensor([1, 2, 3]))
+        mock_run_merge_draft(token_indices_to_sample, input_ids=torch.tensor([1, 2, 3]))
 
         # Assert calling conditions
         self.assertTrue(draft_model_mock.set_skip_topk.called, "set_skip_topk should be called.")
@@ -4263,3 +4268,50 @@ class TestDeepSeekMTPIndicesSharing(unittest.TestCase):
         self.assertEqual(len(calls), 2, "set_skip_topk should be called exactly twice.")
         self.assertEqual(calls[0][0][0], False, "Step 0 should call set_skip_topk(False).")
         self.assertEqual(calls[1][0][0], True, "Step 1 should call set_skip_topk(True).")
+
+        # Compact must run exactly once, right after step 0, with the
+        # step-0 sampling indices.
+        self.assertTrue(
+            draft_model_mock.compact_topk_indices.called,
+            "compact_topk_indices should be called.",
+        )
+        compact_calls = draft_model_mock.compact_topk_indices.call_args_list
+        self.assertEqual(len(compact_calls), 1, "compact_topk_indices should be called exactly once.")
+        self.assertTrue(
+            torch.equal(compact_calls[0][0][0], token_indices_to_sample),
+            "compact_topk_indices must receive token_indices_to_sample.",
+        )
+
+    def test_run_merge_draft_mtp_skip_topk_without_compact(self):
+        """Draft predictors without compact_topk_indices (e.g. the
+        vllm-ascend DeepSeekV4MTP predictor) must be left untouched."""
+        proposer = AscendEagleProposer.__new__(AscendEagleProposer)
+        proposer._share_mtp_indices = True
+
+        # Mock Draft Model without the compact method
+        draft_model_mock = MagicMock()
+        del draft_model_mock.compact_topk_indices
+        proposer.model = MagicMock()
+        proposer.model.model = draft_model_mock
+
+        proposer.model_returns_tuple = MagicMock(return_value=False)
+        proposer.model.return_value = MagicMock()
+
+        token_indices_to_sample = torch.arange(4, dtype=torch.int32)
+
+        def mock_run_merge_draft(token_indices_to_sample, **model_kwargs):
+            draft_model = getattr(proposer.model, "model", None)
+            if proposer._share_mtp_indices and draft_model is not None and hasattr(draft_model, "set_skip_topk"):
+                draft_model.set_skip_topk(False)
+            proposer.model(**model_kwargs)
+            if proposer._share_mtp_indices and draft_model is not None and hasattr(draft_model, "set_skip_topk"):
+                draft_model.set_skip_topk(True)
+                if hasattr(draft_model, "compact_topk_indices"):
+                    draft_model.compact_topk_indices(token_indices_to_sample)
+
+        mock_run_merge_draft(token_indices_to_sample, input_ids=torch.tensor([1, 2, 3]))
+
+        # set_skip_topk still toggles, but compact is skipped entirely.
+        self.assertTrue(draft_model_mock.set_skip_topk.called, "set_skip_topk should be called.")
+        self.assertEqual(len(draft_model_mock.set_skip_topk.call_args_list), 2)
+        self.assertFalse(hasattr(draft_model_mock, "compact_topk_indices"))

--- a/vllm_ascend/ops/mla.py
+++ b/vllm_ascend/ops/mla.py
@@ -62,6 +62,37 @@ class IndexerWrapper(nn.Module):
 
 
 class AscendMultiHeadLatentAttention(MultiHeadLatentAttentionWrapper):
+    # IndexCache (index_share_for_mtp_iteration): the spec-decode proposer
+    # toggles ``skip_topk`` on this wrapper at runtime (set_skip_topk) and
+    # compacts the shared top-k buffer (compact_topk_indices). The actual
+    # indexer gate and buffer live in the inner impl (e.g. AscendSFAImpl),
+    # which is not an nn.Module and is therefore invisible to
+    # named_modules(). Expose both as properties forwarding to the impl so
+    # the upstream DeepSeekMultiTokenPredictor hooks keep working on Ascend.
+    @property
+    def skip_topk(self) -> bool:
+        return self.__dict__.get("_skip_topk", False)
+
+    @skip_topk.setter
+    def skip_topk(self, value: bool) -> None:
+        self.__dict__["_skip_topk"] = bool(value)
+        impl = getattr(getattr(self, "mla_attn", None), "impl", None)
+        if impl is not None and hasattr(impl, "skip_topk"):
+            impl.skip_topk = self.__dict__["_skip_topk"]
+
+    @property
+    def topk_indices_buffer(self) -> torch.Tensor | None:
+        impl = getattr(getattr(self, "mla_attn", None), "impl", None)
+        if impl is None:
+            return None
+        return getattr(impl, "topk_indices_buffer", None)
+
+    @topk_indices_buffer.setter
+    def topk_indices_buffer(self, value: torch.Tensor | None) -> None:
+        impl = getattr(getattr(self, "mla_attn", None), "impl", None)
+        if impl is not None and hasattr(impl, "topk_indices_buffer"):
+            impl.topk_indices_buffer = value
+
     def __init__(
         self,
         hidden_size: int,
@@ -89,6 +120,9 @@ class AscendMultiHeadLatentAttention(MultiHeadLatentAttentionWrapper):
         self.qk_head_dim = qk_nope_head_dim + qk_rope_head_dim
         self.v_head_dim = v_head_dim
         self.prefix = prefix
+        # Goes through the property setter above; mla_attn is not created yet,
+        # so only the backing value is stored here. MLAAttention below receives
+        # the same value and initializes the impl consistently.
         self.skip_topk = skip_topk
         # This is an upstream CUDA indexer hint. Ascend accepts it to preserve
         # constructor compatibility, but its indexer does not consume it.

--- a/vllm_ascend/patch/__init__.py
+++ b/vllm_ascend/patch/__init__.py
@@ -607,7 +607,11 @@
 #    How:
 #       Skip `Indexer` construction only when the layer both skips top-k and is
 #       explicitly marked `shared` in `indexer_types`. MTP layers always retain
-#       a complete `Indexer`.
+#       a complete `Indexer`. The runtime `skip_topk` handed to the MLA wrapper
+#       is additionally masked with `not is_mtp_layer` (same as upstream
+#       deepseek_v2.py): MTP layers must never start in skip mode, because they
+#       compute their own indices at draft step 0 and toggle at runtime via
+#       `set_skip_topk` (index_share_for_mtp_iteration).
 #    Related PR (if no, explain why):
 #       https://github.com/vllm-project/vllm/pull/45895
 #    Future Plan:

--- a/vllm_ascend/patch/worker/patch_deepseek_v2.py
+++ b/vllm_ascend/patch/worker/patch_deepseek_v2.py
@@ -226,6 +226,14 @@ def _deepseek_v2_mla_attention_init(
     elif 0 <= layer_id < len(_index_topk_pattern):
         _skip_topk = _index_topk_pattern[layer_id] == "S"
 
+    # The skip pattern only governs backbone layers. MTP/nextn layers
+    # (layer_id >= num_hidden_layers) must never start with skip_topk=True:
+    # they compute their own indices at draft step 0 and toggle at runtime
+    # via set_skip_topk (index_share_for_mtp_iteration). Matches upstream
+    # deepseek_v2.py behavior.
+    num_hidden_layers = getattr(config, "num_hidden_layers", None)
+    is_mtp_layer = num_hidden_layers is not None and layer_id >= num_hidden_layers
+
     skip_indexer_init = _should_skip_indexer_init(config, prefix, _skip_topk)
     if self.is_v32 and not skip_indexer_init:
         self.indexer_rope_emb = get_rope(
@@ -283,7 +291,7 @@ def _deepseek_v2_mla_attention_init(
         cache_config,
         quant_config,
         prefix,
-        skip_topk=_skip_topk,
+        skip_topk=_skip_topk and not is_mtp_layer,
     )
 
 

--- a/vllm_ascend/spec_decode/llm_base_proposer.py
+++ b/vllm_ascend/spec_decode/llm_base_proposer.py
@@ -1228,6 +1228,14 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
         draft_model = getattr(self.model, "model", None)
         if self._share_mtp_indices and draft_model is not None and hasattr(draft_model, "set_skip_topk"):
             draft_model.set_skip_topk(True)
+            if hasattr(draft_model, "compact_topk_indices"):
+                # Step 0 wrote top-k rows for every query token in the
+                # multi-token batch. Compact the rows of each request's last
+                # token to the buffer front so steps 1+ read request-aligned
+                # rows (mirrors the upstream proposer). Draft predictors
+                # without this method (e.g. vllm-ascend DeepSeekV4MTP) are
+                # left untouched.
+                draft_model.compact_topk_indices(token_indices_to_sample)
 
         if self.method != "dflash":
             last_hidden_states, model_positions, hidden_states = self.maybe_all_gather_and_unpad(


### PR DESCRIPTION
﻿### What this PR does / why we need it?

Backports the GLM5.2 MTP shared-index fix to v0.27.1rc.

GLM5.2 MTP with shared index was broken on Ascend because the runtime index-cache state was not correctly exposed or initialized:
- The actual indexer gate (`skip_topk`) and shared top-k buffer (`topk_indices_buffer`) live in the inner MLA impl, which is not visible to `named_modules()`, so upstream proposer hooks never reached it.
- MTP/nextn layers could start in skip mode incorrectly.
- After draft step 0, the shared top-k buffer rows were not compacted to request-aligned positions.

This PR fixes the Ascend MTP index-cache path by adding the missing `skip_topk` / `topk_indices_buffer` forwarding, masking initial `skip_topk` for MTP layers, and calling `compact_topk_indices` after draft step 0 when supported.

Related to #15864

### Does this PR introduce _any_ user-facing change?

No user-facing API or configuration change. This is an internal fix for GLM5.2 MTP index-cache sharing on Ascend.

### How was this patch tested?

- Unit tests: `pytest -sv tests/ut/ops/test_mla.py tests/ut/spec_decode/test_eagle_proposer.py`


- vLLM main: https://github.com/vllm-project/vllm/commit/ba07e4a48fc951300d97eb506217dd530583dea3

