### PR TITLE
[v0.26.0rc][BugFix][Proxy] Forward Prefill HTTP errors

### DIFF
--- a/examples/disaggregated_prefill_v1/load_balance_proxy_server_example.py
+++ b/examples/disaggregated_prefill_v1/load_balance_proxy_server_example.py
@@ -1118,7 +1118,7 @@ async def handle_completions_impl(api: str, request: Request):
 
         media_type = "text/event-stream; charset=utf-8" if stream_flag else "application/json"
         return StreamingResponse(generate_stream(), media_type=media_type)
-    except Exception:
+    except Exception as e:
         import traceback
 
         exc_info = sys.exc_info()
@@ -1127,6 +1127,16 @@ async def handle_completions_impl(api: str, request: Request):
         if not request_released and "instance_info" in locals():
             await _finish_instance(runtime, instance_info, release_prefill_kv=True)
             request_released = True
+        if isinstance(e, httpx.HTTPStatusError) and e.response is not None:
+            try:
+                error_body = e.response.json()
+            except ValueError:
+                error_body = {
+                    "error": {
+                        "message": e.response.text or "upstream error",
+                    }
+                }
+            return JSONResponse(error_body, status_code=e.response.status_code)
         raise
 
 

--- a/tests/ut/test_prefill_proxy_http_errors.py
+++ b/tests/ut/test_prefill_proxy_http_errors.py
@@ -1,0 +1,56 @@
+# SPDX-License-Identifier: Apache-2.0
+
+import argparse
+import asyncio
+import json
+from unittest.mock import AsyncMock
+
+import httpx
+import pytest
+
+from examples.disaggregated_prefill_v1 import load_balance_proxy_server_example as proxy
+
+
+@pytest.mark.parametrize(
+    ("response_kwargs", "expected_body"),
+    [
+        (
+            {"json": {"error": {"message": "maximum context length is 32"}}},
+            {"error": {"message": "maximum context length is 32"}},
+        ),
+        (
+            {"text": "prefill unavailable"},
+            {"error": {"message": "prefill unavailable"}},
+        ),
+    ],
+)
+def test_prefill_http_error_is_forwarded(
+    monkeypatch,
+    response_kwargs,
+    expected_body,
+):
+    upstream_request = httpx.Request("POST", "http://prefill/v1/completions")
+    upstream_response = httpx.Response(
+        400,
+        request=upstream_request,
+        **response_kwargs,
+    )
+    error = httpx.HTTPStatusError(
+        "upstream returned HTTP 400",
+        request=upstream_request,
+        response=upstream_response,
+    )
+    request = AsyncMock()
+    request.json.return_value = {"prompt": "test"}
+    request.body.return_value = b'{"prompt":"test"}'
+
+    monkeypatch.setattr(proxy, "runtime", object())
+    monkeypatch.setattr(proxy, "global_args", argparse.Namespace())
+    assign_instances = AsyncMock(side_effect=error)
+    monkeypatch.setattr(proxy, "assign_instances", assign_instances)
+
+    response = asyncio.run(proxy.handle_completions_impl("completions", request))
+
+    assert response.status_code == 400
+    assert json.loads(response.body) == expected_body
+    assign_instances.assert_awaited_once()


### PR DESCRIPTION
### What this PR does / why we need it?

This is a release-branch backport of https://github.com/vllm-project/vllm-ascend/pull/12097 for `releases/v0.26.0rc`.

When the Prefill backend returns an HTTP error, `httpx.HTTPStatusError` reaches the proxy's outer generic exception handler. The release branch currently re-raises it, so clients receive a generic HTTP 500 instead of the Prefill status and error payload.

This patch:

- preserves the Prefill response status code;
- forwards a JSON error body unchanged;
- wraps a plain-text body as `{"error":{"message":"..."}}`;
- keeps request/KV resource cleanup ahead of the error mapping; and
- adds regression tests for both JSON and plain-text HTTP 400 responses raised from the real `assign_instances()` call site.

A duplicate search found no equivalent PR targeting `releases/v0.26.0rc`. The original fix is already tracked by #12097 on the main development line.

### Does this PR introduce _any_ user-facing change?

Yes. Clients now receive the Prefill backend's original HTTP status and useful error payload instead of a generic HTTP 500.

### How was this patch tested?

- `uvx ruff@0.14.0 check examples/disaggregated_prefill_v1/load_balance_proxy_server_example.py tests/ut/test_prefill_proxy_http_errors.py` — passed.
- `uvx ruff@0.14.0 format --check examples/disaggregated_prefill_v1/load_balance_proxy_server_example.py tests/ut/test_prefill_proxy_http_errors.py` — passed.
- File-scoped pre-commit hooks: ruff, ruff-format, codespell, typos, import/policy, long-function, and symbolic-shape checks passed. Bash-only local hooks could not run on the Windows development host because `/bin/bash` is unavailable; repository CI remains authoritative for those hooks.
- Applied the generated patch in an ephemeral container from `quay.io/ascend/vllm-ascend:v0.26.0rc1-openeuler` on an Ascend host, then ran:

  ```text
  pytest -q --noconftest tests/ut/test_prefill_proxy_http_errors.py
  ```

  Result: `2 passed, 14 warnings in 4.86s`. The warnings are existing PyTorch `torch.jit.script_method` deprecation warnings.
- `git show --check` — passed.

No model evaluation was run because this patch changes only proxy HTTP error handling and does not alter model execution or outputs.

AI assistance disclosure: OpenAI Codex was used to analyze the release-branch delta and prepare the backport and tests. The source PR, adaptation scope, and validation results are disclosed above.

- vLLM main: https://github.com/vllm-project/vllm/commit/d02df748bf9efd99022f1a062597dc3cb3808485
