### PR TITLE
[v0.26.0rc][BugFix][Proxy] Treat missing Prefill cached tokens as zero

### DIFF
--- a/examples/disaggregated_prefill_v1/load_balance_proxy_server_example.py
+++ b/examples/disaggregated_prefill_v1/load_balance_proxy_server_example.py
@@ -177,7 +177,7 @@ def extract_cached_tokens(response_json: dict) -> int | None:
     usage = response_json.get("usage") or {}
     prompt_tokens_details = usage.get("prompt_tokens_details") or {}
     cached_tokens = prompt_tokens_details.get("cached_tokens")
-    return cached_tokens if isinstance(cached_tokens, int) else None
+    return cached_tokens if isinstance(cached_tokens, int) else 0
 
 
 def update_cached_tokens_in_chunk(chunk_json: dict, cached_tokens: int | None) -> bool:

--- a/tests/ut/test_prefill_proxy_cached_tokens.py
+++ b/tests/ut/test_prefill_proxy_cached_tokens.py
@@ -1,0 +1,29 @@
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+
+from examples.disaggregated_prefill_v1 import load_balance_proxy_server_example as proxy
+
+
+@pytest.mark.parametrize(
+    ("payload", "expected"),
+    [
+        ({}, 0),
+        ({"usage": {}}, 0),
+        ({"usage": {"prompt_tokens_details": {}}}, 0),
+        ({"usage": {"prompt_tokens_details": {"cached_tokens": 0}}}, 0),
+        ({"usage": {"prompt_tokens_details": {"cached_tokens": 32}}}, 32),
+    ],
+)
+def test_extract_cached_tokens_cold_and_warm(payload, expected):
+    assert proxy.extract_cached_tokens(payload) == expected
+
+
+def test_update_cached_tokens_in_nonstream_response():
+    payload = {
+        "choices": [{"text": "ok"}],
+        "usage": {"prompt_tokens": 33, "prompt_tokens_details": {}},
+    }
+
+    assert proxy.update_cached_tokens_in_chunk(payload, 0)
+    assert payload["usage"]["prompt_tokens_details"]["cached_tokens"] == 0


### PR DESCRIPTION
### What this PR does / why we need it?

This is the missing release-branch part of https://github.com/vllm-project/vllm-ascend/pull/13040, adapted for the refactored proxy on `releases/v0.26.0rc`.

On a cold Prefix Cache request, the Prefill response can omit `usage.prompt_tokens_details.cached_tokens`. `extract_cached_tokens()` currently converts that omission to `None`. The response rewrite then intentionally skips `None`, leaving the Decoder's misleading `cached_tokens = prompt_tokens - 1` value visible to the client even though the actual Prefill cache hit is zero.

This patch treats a missing or non-integer Prefill `cached_tokens` field as `0`. The release branch already rewrites usage for both streaming and non-streaming responses in the refactored paths introduced by https://github.com/vllm-project/vllm-ascend/pull/14389, so the older control-flow hunk from #13040 must not be copied again. Only the missing cold-cache fallback is added here.

Regression tests cover absent `usage`, absent `prompt_tokens_details`, absent `cached_tokens`, explicit zero, a warm-cache value, and rewriting a non-streaming response.

A duplicate search found no equivalent PR targeting `releases/v0.26.0rc`.

### Does this PR introduce _any_ user-facing change?

Yes. Cold Prefix Cache requests report `cached_tokens: 0` instead of retaining the Decoder-side `prompt_tokens - 1` statistic. Valid Prefill cache-hit counts continue to be forwarded unchanged.

### How was this patch tested?

- `uvx ruff@0.14.0 check examples/disaggregated_prefill_v1/load_balance_proxy_server_example.py tests/ut/test_prefill_proxy_cached_tokens.py` — passed.
- `uvx ruff@0.14.0 format --check examples/disaggregated_prefill_v1/load_balance_proxy_server_example.py tests/ut/test_prefill_proxy_cached_tokens.py` — passed.
- File-scoped pre-commit hooks: ruff, ruff-format, codespell, typos, import/policy, long-function, and symbolic-shape checks passed. Bash-only local hooks could not run on the Windows development host because `/bin/bash` is unavailable; repository CI remains authoritative for those hooks.
- Applied the generated patch in an ephemeral container from `quay.io/ascend/vllm-ascend:v0.26.0rc1-openeuler` on an Ascend host, then ran:

  ```text
  pytest -q --noconftest tests/ut/test_prefill_proxy_cached_tokens.py
  ```

  Result: `6 passed, 14 warnings in 4.82s`. The warnings are existing PyTorch `torch.jit.script_method` deprecation warnings.
- `git show --check` — passed.

No model evaluation was run because this patch changes only proxy usage-metadata rewriting and does not alter model execution or generated tokens.

AI assistance disclosure: OpenAI Codex was used to analyze the release-branch delta and prepare the adapted backport and tests. The source PR, adaptation scope, and validation results are disclosed above.

- vLLM main: https://github.com/vllm-project/vllm/commit/d02df748bf9efd99022f1a062597dc3cb3808485
