### PR TITLE
[0.27.1rc][Bugfix][KV Pool]  Fix AscendStore hybrid Mamba cache release

### DIFF
--- a/tests/ut/distributed/ascend_store/test_pool_scheduler.py
+++ b/tests/ut/distributed/ascend_store/test_pool_scheduler.py
@@ -337,7 +337,7 @@ class TestKVPoolSchedulerBuildMeta(unittest.TestCase):
         return sched_output
 
     @patch("vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.pool_scheduler.LookupKeyClient")
-    def test_running_chunk_updates_mamba_blocks_at_current_position(self, mock_client_cls):
+    def test_running_chunk_passes_computed_tokens_to_tracker(self, mock_client_cls):
         scheduler = KVPoolScheduler(self._make_config(), use_layerwise=False)
         request = MagicMock()
         request.num_computed_tokens = 128
@@ -346,19 +346,13 @@ class TestKVPoolSchedulerBuildMeta(unittest.TestCase):
         request.all_token_ids = list(range(256))
         request.block_hashes = [b"h"] * 16
         scheduler._unfinished_requests["r1"] = (request, [[] for _ in range(4)])
-        scheduler._request_trackers["r1"] = RequestTracker(
+        request_tracker = RequestTracker(
             req_id="r1",
             token_len=128,
-            allocated_block_ids_by_group=[
-                [1, 2, 3, 4, 5, 6, 7, 8],
-                [0, 0, 0, 0, 0, 0, 0, 9, 10, 11, 12],
-                [0, 0, 0, 0, 0, 0, 0, 13, 14, 15, 16],
-                [0, 0, 0, 0, 0, 0, 0, 17, 18, 19, 20],
-            ],
-            mamba_group_ids=[1, 2, 3],
-            num_speculative_blocks=3,
-            block_sizes=[16] * 4,
+            allocated_block_ids_by_group=[[] for _ in range(4)],
         )
+        request_tracker.update = MagicMock()
+        scheduler._request_trackers["r1"] = request_tracker
         new_block_ids = (
             [21, 22, 23, 24, 25, 26, 27, 28],
             [0, 0, 0, 0, 10, 11, 12, 29],
@@ -376,10 +370,7 @@ class TestKVPoolSchedulerBuildMeta(unittest.TestCase):
             False,
         )
 
-        self.assertEqual(
-            scheduler._request_trackers["r1"].allocated_block_ids_by_group[1],
-            [0, 0, 0, 0, 0, 0, 0, 9, 0, 0, 0, 0, 0, 0, 0, 10, 11, 12, 29],
-        )
+        request_tracker.update.assert_called_once_with(new_block_ids, 128)
 
     @patch("vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.pool_scheduler.LookupKeyClient")
     def test_build_connector_meta_new_req(self, mock_client_cls):

--- a/tests/ut/distributed/ascend_store/test_pool_scheduler.py
+++ b/tests/ut/distributed/ascend_store/test_pool_scheduler.py
@@ -337,6 +337,51 @@ class TestKVPoolSchedulerBuildMeta(unittest.TestCase):
         return sched_output
 
     @patch("vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.pool_scheduler.LookupKeyClient")
+    def test_running_chunk_updates_mamba_blocks_at_current_position(self, mock_client_cls):
+        scheduler = KVPoolScheduler(self._make_config(), use_layerwise=False)
+        request = MagicMock()
+        request.num_computed_tokens = 128
+        request.num_prompt_tokens = 256
+        request.prompt_token_ids = list(range(256))
+        request.all_token_ids = list(range(256))
+        request.block_hashes = [b"h"] * 16
+        scheduler._unfinished_requests["r1"] = (request, [[] for _ in range(4)])
+        scheduler._request_trackers["r1"] = RequestTracker(
+            req_id="r1",
+            token_len=128,
+            allocated_block_ids_by_group=[
+                [1, 2, 3, 4, 5, 6, 7, 8],
+                [0, 0, 0, 0, 0, 0, 0, 9, 10, 11, 12],
+                [0, 0, 0, 0, 0, 0, 0, 13, 14, 15, 16],
+                [0, 0, 0, 0, 0, 0, 0, 17, 18, 19, 20],
+            ],
+            mamba_group_ids=[1, 2, 3],
+            num_speculative_blocks=3,
+            block_sizes=[16] * 4,
+        )
+        new_block_ids = (
+            [21, 22, 23, 24, 25, 26, 27, 28],
+            [0, 0, 0, 0, 10, 11, 12, 29],
+            [0, 0, 0, 0, 14, 15, 16, 30],
+            [0, 0, 0, 0, 18, 19, 20, 31],
+        )
+        scheduler._build_req_meta = MagicMock(return_value=None)
+
+        scheduler._process_running_cached_request(
+            new_block_ids,
+            "r1",
+            0,
+            MagicMock(),
+            self._make_running_chunk_output(new_block_ids),
+            False,
+        )
+
+        self.assertEqual(
+            scheduler._request_trackers["r1"].allocated_block_ids_by_group[1],
+            [0, 0, 0, 0, 0, 0, 0, 9, 0, 0, 0, 0, 0, 0, 0, 10, 11, 12, 29],
+        )
+
+    @patch("vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.pool_scheduler.LookupKeyClient")
     def test_build_connector_meta_new_req(self, mock_client_cls):
         config = self._make_config()
         scheduler = KVPoolScheduler(config, use_layerwise=False)

--- a/tests/ut/distributed/ascend_store/test_pool_worker.py
+++ b/tests/ut/distributed/ascend_store/test_pool_worker.py
@@ -109,6 +109,17 @@ class TestKVPoolWorkerHelpers(unittest.TestCase):
             with self.subTest(exists=exists):
                 self.assertEqual(cls.check_all_layers_exists(None, exists, num_layers), expected)
 
+    def test_uses_mamba_kv_cache_inside_uniform_group(self):
+        from vllm.v1.kv_cache_interface import MambaSpec, UniformTypeKVCacheSpecs
+
+        cls = self._make_worker_class()
+        mamba_spec = MambaSpec(block_size=384, shapes=((1,),), dtypes=(np.dtype("float32"),))
+        uniform_spec = UniformTypeKVCacheSpecs.from_specs({"mamba.layer": mamba_spec})
+        self.assertIsNotNone(uniform_spec)
+        kv_cache_config = SimpleNamespace(kv_cache_groups=[SimpleNamespace(kv_cache_spec=uniform_spec)])
+
+        self.assertTrue(cls._uses_mamba_kv_cache(True, kv_cache_config))
+
     def test_find_all_continuous_hit_positions(self):
         cls = self._make_worker_class()
         cases = [

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/pool_scheduler.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/pool_scheduler.py
@@ -761,7 +761,7 @@ class KVPoolScheduler:
         else:
             raise ValueError(f"Request {req_id} is not in _unfinished_requests, but it is scheduled to be cached")
         if new_block_ids is not None:
-            request_tracker.update(new_block_ids)
+            request_tracker.update(new_block_ids, request.num_computed_tokens)
         load_spec = None
         if self.layerwise_offload and num_current_tokens > 0:
             load_spec = LoadSpec(

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/pool_scheduler.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/pool_scheduler.py
@@ -529,7 +529,7 @@ class KVPoolScheduler:
         else:
             need_to_allocate = num_external_hit_tokens - num_computed_tokens
 
-        logger.debug(
+        logger.info(
             "Reqid: %s, Total tokens %d, kvpool hit tokens: %d, need to load: %d",
             request.request_id,
             request.num_tokens,

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/pool_worker.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/pool_worker.py
@@ -643,7 +643,14 @@ class KVPoolWorker:
     def _uses_mamba_kv_cache(use_hybrid: bool, kv_cache_config: KVCacheConfig | None):
         if not use_hybrid or kv_cache_config is None:
             return False
-        return any([isinstance(g.kv_cache_spec, MambaSpec) for g in kv_cache_config.kv_cache_groups])
+        for group in kv_cache_config.kv_cache_groups:
+            kv_cache_spec = group.kv_cache_spec
+            if isinstance(kv_cache_spec, UniformTypeKVCacheSpecs):
+                if any(isinstance(spec, MambaSpec) for spec in kv_cache_spec.kv_cache_specs.values()):
+                    return True
+            elif isinstance(kv_cache_spec, MambaSpec):
+                return True
+        return False
 
     @staticmethod
     def _as_cache_tuple(cache_or_caches) -> tuple[torch.Tensor, ...]:


### PR DESCRIPTION
### What this PR does / why we need it?

This PR fixes AscendStore block tracking for hybrid Mamba KV cache workloads such as DSpark:

- Detect Mamba cache groups when the worker receives `UniformTypeKVCacheSpecs` containing `MambaSpec`. This enables workers to report completed store events so the scheduler can release the temporary references held for in-flight Mamba blocks.
- Apply newly allocated block IDs at `request.num_computed_tokens` for running chunked requests. This preserves the position-indexed Mamba block table instead of updating it from position zero.

Without these fixes, AscendStore can retain references to completed Mamba store blocks during long-running chunked-prefill workloads. Available GPU KV blocks gradually decrease until subsequent requests can no longer be scheduled.

### Does this PR introduce _any_ user-facing change?

NO

### How was this patch tested?

- `pytest -q tests/ut/distributed/ascend_store/test_pool_scheduler.py tests/ut/distributed/ascend_store/test_pool_worker.py`
  - 116 passed
- End-to-end test with AscendStore and DSpark on a DP4/TP16 deployment:
  - Completed 128 requests with 131,024 input tokens each without stalling.
  - GPU KV cache usage returned to zero after completion.
- vLLM main: https://github.com/vllm-project/vllm/commit/ba07e4a48fc951300d97eb506217dd530583dea3
