### PR TITLE
fix: combine KV cache and CPU device mapping fixes

### DIFF
--- a/tests/ut/_310p/test_model_runner_310p.py
+++ b/tests/ut/_310p/test_model_runner_310p.py
@@ -33,6 +33,11 @@ def _prepare_inputs_source() -> str:
     return source[start:end]
 
 
+def _worker_source() -> str:
+    source_path = Path(__file__).resolve().parents[3] / "vllm_ascend" / "_310p" / "worker_310p.py"
+    return source_path.read_text(encoding="utf-8")
+
+
 def test_prepare_inputs_keeps_aclgraph_metadata_on_cpu() -> None:
     source = _prepare_inputs_source()
 
@@ -89,6 +94,13 @@ def test_model_forward_updates_mtp_full_graph_params_before_replay() -> None:
 
     assert calls == ["update", "model"]
     torch.testing.assert_close(hidden_states, torch.ones(1))
+
+
+def test_310p_worker_init_device_uses_common_logical_to_physical_mapping() -> None:
+    source = _worker_source()
+
+    assert "device = self._resolve_device()" in source
+    assert 'torch.device(f"npu:{self.local_rank}")' not in source
 
 
 class TestNPUModelRunner310(TestBase):

--- a/tests/ut/device_allocator/test_cpu_binding.py
+++ b/tests/ut/device_allocator/test_cpu_binding.py
@@ -28,6 +28,7 @@ from vllm_ascend.utils import AscendDeviceType
 def make_cpu_alloc(rank_id=0):
     cpu_alloc = object.__new__(CpuAlloc)
     cpu_alloc.rank_id = rank_id
+    cpu_alloc.current_npu = 0
     cpu_alloc.device_info = SimpleNamespace(
         running_npu_list=[0],
         all_logic_npus=[0],
@@ -308,6 +309,28 @@ class TestCpuAlloc(unittest.TestCase):
         ]
         self.cpu_alloc = CpuAlloc(0)
 
+    @patch("vllm_ascend.cpu_binding.DeviceInfo")
+    def test_explicit_npu_id_overrides_running_npu_order(self, mock_device_info):
+        mock_device_info.return_value.running_npu_list = [1, 3]
+
+        cpu_alloc = CpuAlloc(rank_id=0, npu_id=3)
+
+        self.assertEqual(cpu_alloc.current_npu, 3)
+
+    @patch("vllm_ascend.cpu_binding.DeviceInfo")
+    def test_explicit_npu_id_must_be_running(self, mock_device_info):
+        mock_device_info.return_value.running_npu_list = [1, 3]
+
+        with self.assertRaisesRegex(RuntimeError, "Mapped NPU 2"):
+            CpuAlloc(rank_id=0, npu_id=2)
+
+    @patch("vllm_ascend.cpu_binding.DeviceInfo")
+    def test_rank_fallback_validates_running_npu_range(self, mock_device_info):
+        mock_device_info.return_value.running_npu_list = [1]
+
+        with self.assertRaisesRegex(RuntimeError, "Rank 1 is out of range"):
+            CpuAlloc(rank_id=1)
+
     def test_average_distribute(self):
         self.cpu_alloc.npu_cpu_pool = {0: [10, 11, 12, 13], 1: [10, 11, 12, 13]}
         groups = {"[10, 11, 12, 13]": [0, 1]}
@@ -336,6 +359,8 @@ class TestCpuAlloc(unittest.TestCase):
         self.assertEqual(self.cpu_alloc._binding_mode(), "topo_affinity")
         mock_get_device_type.return_value = get_hardware_profile(AscendDeviceType.A3)
         self.assertEqual(self.cpu_alloc._binding_mode(), "global_slice")
+        mock_get_device_type.return_value = get_hardware_profile(AscendDeviceType._310P)
+        self.assertEqual(self.cpu_alloc._binding_mode(), "topo_affinity")
         mock_get_device_type.return_value = get_hardware_profile(AscendDeviceType.A5)
         self.assertEqual(self.cpu_alloc._binding_mode(), "topo_affinity")
 
@@ -554,6 +579,7 @@ class TestCpuAlloc(unittest.TestCase):
         mock_execute_command.return_value = ("PCIe Bus Info 0000:03:00.0", 0)
         self.cpu_alloc.rank_id = 0
         self.cpu_alloc.device_info.running_npu_list = [3]
+        self.cpu_alloc.current_npu = 3
         self.cpu_alloc.npu_cpu_pool = {3: [0, 1, 2, 3, 4]}
 
         self.cpu_alloc.bind_npu_irq()
@@ -915,6 +941,7 @@ class TestCpuBindingSupplemental(unittest.TestCase):
     def test_print_plan_handles_empty_release_assignment(self, mock_logger_info, _mock_get_device_type):
         cpu_alloc = make_cpu_alloc()
         cpu_alloc.device_info.running_npu_list = [1]
+        cpu_alloc.current_npu = 1
         cpu_alloc.rank_id = 0
         cpu_alloc.assign_main = {1: [2, 3]}
         cpu_alloc.assign_acl = {1: [4]}
@@ -931,6 +958,7 @@ class TestCpuBindingSupplemental(unittest.TestCase):
     def test_print_plan_uses_ascend_950_worker_log(self, mock_logger_info, _mock_get_device_type):
         cpu_alloc = make_cpu_alloc()
         cpu_alloc.device_info.running_npu_list = [1]
+        cpu_alloc.current_npu = 1
         cpu_alloc.rank_id = 0
         cpu_alloc.assign_main = {1: [2, 3]}
         cpu_alloc.assign_acl = {1: []}
@@ -953,6 +981,7 @@ class TestCpuBindingSupplemental(unittest.TestCase):
     def test_print_plan_handles_non_empty_release_assignment(self, mock_logger_info, _mock_get_device_type):
         cpu_alloc = make_cpu_alloc()
         cpu_alloc.device_info.running_npu_list = [1]
+        cpu_alloc.current_npu = 1
         cpu_alloc.rank_id = 0
         cpu_alloc.assign_main = {1: [2, 3]}
         cpu_alloc.assign_acl = {1: [4]}
@@ -1295,9 +1324,9 @@ class TestBindingSwitch(unittest.TestCase):
     @patch("vllm_ascend.cpu_binding.CpuAlloc")
     @patch("vllm_ascend.cpu_binding.is_arm_cpu", return_value=True)
     def test_bind_cpus_runs_allocator_on_arm(self, _mock_is_arm_cpu, mock_cpu_alloc):
-        bind_cpus(1)
+        bind_cpus(1, npu_id=3)
 
-        mock_cpu_alloc.assert_called_once_with(1)
+        mock_cpu_alloc.assert_called_once_with(1, npu_id=3)
         mock_cpu_alloc.return_value.run_all.assert_called_once_with()
 
 

--- a/tests/ut/worker/test_worker_v1.py
+++ b/tests/ut/worker/test_worker_v1.py
@@ -516,6 +516,7 @@ class TestNPUWorker(TestBase):
         mock_snapshot_cls.return_value = mock_snapshot
 
         # Mock current_platform for v0.24.0 init_device path
+        mock_current_platform.device_id_to_physical_device_id.return_value = 4
         mock_current_platform.logical_device_id_to_visible_device_id.return_value = 0
         mock_current_platform.device_type = "npu"
 
@@ -535,10 +536,13 @@ class TestNPUWorker(TestBase):
             worker.cache_config = MagicMock()
             worker.cache_config.gpu_memory_utilization = 0.5
 
-            # Test _init_device
-            result = worker._init_device()
+            # Test _init_device without requiring an NPU runtime in the unit-test environment.
+            with patch("torch.npu.is_available", return_value=True), patch("torch.npu.device_count", return_value=1):
+                result = worker._init_device()
 
             mock_init_dist_env.assert_called_once()
+            mock_current_platform.device_id_to_physical_device_id.assert_called_once_with(0)
+            self.assertEqual(worker.physical_device_id, 4)
             self.assertEqual(str(result), "npu:0")
             self.assertEqual(worker.init_snapshot, mock_snapshot)
             self.assertEqual(worker.requested_memory, 2000 * 0.5)
@@ -1398,8 +1402,10 @@ class TestNPUWorker(TestBase):
     @patch("vllm_ascend.worker.worker.get_ascend_config")
     @patch("vllm_ascend.worker.worker.logger")
     @patch("vllm_ascend.worker.worker.NPUWorker._warm_up_atb")
+    @patch("vllm_ascend.worker.worker.bind_cpus")
     def test_compile_or_warm_up_model_with_eager_mode(
         self,
+        mock_bind_cpus,
         mock_warm_up_atb,
         mock_logger,
         mock_get_ascend_config,
@@ -1410,7 +1416,7 @@ class TestNPUWorker(TestBase):
         mock_ascend_config = MagicMock()
         mock_ascend_config.ascend_compilation_config = MagicMock()
         mock_ascend_config.ascend_compilation_config.enable_npugraph_ex = False
-        mock_ascend_config.enable_cpu_binding = False
+        mock_ascend_config.enable_cpu_binding = True
         mock_get_ascend_config.return_value = mock_ascend_config
         mock_get_ascend_device_type.return_value = get_hardware_profile(AscendDeviceType.A2)
         from vllm_ascend.worker.worker import NPUWorker
@@ -1428,6 +1434,8 @@ class TestNPUWorker(TestBase):
             worker.model_config.seed = 12345
             worker.cache_config = MagicMock()
             worker.cache_config.kv_cache_memory_bytes = 1024
+            worker.local_rank = 0
+            worker.physical_device_id = 4
 
             # Setup compilation config
             worker.vllm_config.compilation_config = MagicMock()
@@ -1455,6 +1463,7 @@ class TestNPUWorker(TestBase):
             # Verify atb warm up
             mock_warm_up_atb.assert_called_once()
             mock_kernel_warmup.assert_called_once_with(worker)
+            mock_bind_cpus.assert_called_once_with(0, npu_id=4)
 
     @patch("vllm_ascend.worker.worker.set_random_seed")
     @patch("vllm_ascend.worker.worker.get_current_hardware_profile")

--- a/vllm_ascend/_310p/worker_310p.py
+++ b/vllm_ascend/_310p/worker_310p.py
@@ -137,7 +137,9 @@ class NPUWorker310(NPUWorker):
         logger.info_once("Skip warm-up atb ops for 310P device.")
 
     def _init_device(self):
-        device = torch.device(f"npu:{self.local_rank}")
+        # Keep 310P's memory accounting below, but share the common v0.24
+        # logical/visible/physical device mapping with NPUWorker.
+        device = self._resolve_device()
         torch.npu.set_device(device)
 
         # This lazy import avoids torch_npu re-initialization in patch

--- a/vllm_ascend/cpu_binding.py
+++ b/vllm_ascend/cpu_binding.py
@@ -202,9 +202,10 @@ class DeviceInfo:
 
 
 class CpuAlloc:
-    def __init__(self, rank_id: int):
+    def __init__(self, rank_id: int, npu_id: int | None = None):
         self.rank_id = rank_id
         self.device_info: DeviceInfo = DeviceInfo()
+        self.current_npu = self._resolve_current_npu(npu_id)
         self.cpu_node: dict[int, int] = {}
         self.numa_to_cpu_map: dict[int, list[int]] = defaultdict(list)
         self.npu_cpu_pool: dict[int, list[int]] = {}
@@ -212,6 +213,16 @@ class CpuAlloc:
         self.assign_acl: dict[int, list[int]] = {}
         self.assign_rel: dict[int, list[int]] = {}
         self.uvb_cpu_pool: list[int] = []
+
+    def _resolve_current_npu(self, npu_id: int | None) -> int:
+        running_npus = self.device_info.running_npu_list
+        if npu_id is not None:
+            if npu_id not in running_npus:
+                raise RuntimeError(f"Mapped NPU {npu_id} is not in the running NPU list {running_npus}.")
+            return npu_id
+        if self.rank_id < 0 or self.rank_id >= len(running_npus):
+            raise RuntimeError(f"Rank {self.rank_id} is out of range for the running NPU list {running_npus}.")
+        return running_npus[self.rank_id]
 
     @staticmethod
     def cpu_to_mask(cpu: int) -> str:
@@ -536,7 +547,11 @@ class CpuAlloc:
 
         mode = self._binding_mode()
         logger.info(
-            "[cpu_bind_mode] mode=%s rank=%s visible_npus=%s", mode, self.rank_id, self.device_info.running_npu_list
+            "[cpu_bind_mode] mode=%s rank=%s npu=%s visible_npus=%s",
+            mode,
+            self.rank_id,
+            self.current_npu,
+            self.device_info.running_npu_list,
         )
         if self._uses_cluster_cpu_topology():
             self.bind_uvb_poll_window_threads()
@@ -620,11 +635,10 @@ class CpuAlloc:
 
     def print_plan(self) -> None:
         logger.info("The CPU allocation plan is as follows:")
-        current_npu = self.device_info.running_npu_list[self.rank_id]
         if self._uses_cluster_cpu_topology():
-            self._print_ascend_950_plan(current_npu)
+            self._print_ascend_950_plan(self.current_npu)
             return
-        self._print_default_plan(current_npu)
+        self._print_default_plan(self.current_npu)
 
     def _print_ascend_950_plan(self, current_npu: int) -> None:
         main = " ".join(map(str, self.assign_main[current_npu]))
@@ -680,20 +694,18 @@ class CpuAlloc:
         thread_message, _ = execute_command(["ps", "-Te"])
         threads_map = self.get_threads_map(thread_message)
         main_pid = str(psutil.Process().pid)
-        current_npu = self.device_info.running_npu_list[self.rank_id]
-        self.bind(main_pid, self.assign_main[current_npu], True)
+        self.bind(main_pid, self.assign_main[self.current_npu], True)
         for thread_id in threads_map.get(main_pid, {}).get("acl_thread", []):
-            self.bind(thread_id, self.assign_acl[current_npu], False)
+            self.bind(thread_id, self.assign_acl[self.current_npu], False)
         for thread_id in threads_map.get(main_pid, {}).get("release_thread", []):
-            self.bind(thread_id, self.assign_rel[current_npu], False)
+            self.bind(thread_id, self.assign_rel[self.current_npu], False)
         # Migrate memory once for the whole process, after all threads are pinned.
-        self.bind_memory(main_pid, current_npu)
+        self.bind_memory(main_pid, self.current_npu)
 
     def bind_ascend_950_threads(self) -> None:
         main_pid = str(psutil.Process().pid)
-        current_npu = self.device_info.running_npu_list[self.rank_id]
-        self.bind(main_pid, self.assign_main[current_npu], True)
-        self.bind_memory(main_pid, current_npu)
+        self.bind(main_pid, self.assign_main[self.current_npu], True)
+        self.bind_memory(main_pid, self.current_npu)
 
     def bind_npu_irq(self) -> None:
         if not self._reserve_irq_cpus():
@@ -707,9 +719,8 @@ class CpuAlloc:
             return
 
         # Only bind IRQ for current rank's NPU to avoid multi-process overwrite.
-        current_npu = self.device_info.running_npu_list[self.rank_id]
-        if current_npu not in self.npu_cpu_pool:
-            logger.warning("[irq] NPU has no CPU pool. rank=%s, npu=%s. ", self.rank_id, current_npu)
+        if self.current_npu not in self.npu_cpu_pool:
+            logger.warning("[irq] NPU has no CPU pool. rank=%s, npu=%s. ", self.rank_id, self.current_npu)
             return
 
         if shutil.which("systemctl"):
@@ -730,7 +741,7 @@ class CpuAlloc:
                     irq = line.split(":")[0].strip()
                     sq_irqs.append(irq)
 
-        npu = current_npu
+        npu = self.current_npu
         cpus = self.npu_cpu_pool[npu]
         if len(cpus) < 2:
             logger.warning("[irq] CPU pool too small. npu=%s, cpu_count=%d, min_required=2. ", npu, len(cpus))
@@ -796,9 +807,9 @@ class CpuAlloc:
         self.bind_npu_irq()
 
 
-def bind_cpus(rank_id: int) -> None:
+def bind_cpus(rank_id: int, npu_id: int | None = None) -> None:
     if not is_arm_cpu():
         logger.info("CPU binding skipped: non-ARM CPU detected.")
         return
-    binder = CpuAlloc(rank_id)
+    binder = CpuAlloc(rank_id, npu_id=npu_id)
     binder.run_all()

--- a/vllm_ascend/device/device_op.py
+++ b/vllm_ascend/device/device_op.py
@@ -40,13 +40,14 @@ else:
 class BaseDeviceAdaptor:
     @classmethod
     def reshape_and_cache(cls, key, value, key_cache, value_cache, slot_mapping):
-        torch_npu.npu_scatter_pa_kv_cache(
-            key=key.contiguous(),
-            value=value.contiguous(),
+        # npu_scatter_pa_kv_cache (#11713) adds host-side overhead that costs
+        # ~9% end-to-end throughput on Atlas A3; see commit message for data.
+        torch_npu._npu_reshape_and_cache(
+            key=key,
+            value=value,
             key_cache=key_cache,
             value_cache=value_cache,
-            slot_mapping=slot_mapping.contiguous(),
-            cache_mode="Norm",
+            slot_indices=slot_mapping,
         )
 
     @classmethod

--- a/vllm_ascend/worker/worker.py
+++ b/vllm_ascend/worker/worker.py
@@ -371,7 +371,7 @@ class NPUWorker(WorkerBase):
         self.cache_config.num_gpu_blocks = num_gpu_blocks
         self.cache_config.num_cpu_blocks = num_cpu_blocks
 
-    def _init_device(self):
+    def _resolve_device(self):
         # vLLM v0.24.0 (PR #45026) removed automatic per-process device
         # isolation for DP workers. Mirror gpu_worker.py::init_device:
         # shift self.local_rank by dp_local_rank * tp_pp_world_size so
@@ -417,8 +417,14 @@ class NPUWorker(WorkerBase):
                 f"DP adjusted local rank {self.local_rank} is out of bounds for {visible_device_count} devices."
             )
 
+        self.physical_device_id = current_platform.device_id_to_physical_device_id(self.local_rank)
         visible_device_index = current_platform.logical_device_id_to_visible_device_id(self.local_rank)
         device = torch.device(f"{current_platform.device_type}:{visible_device_index}")
+
+        return device
+
+    def _init_device(self):
+        device = self._resolve_device()
 
         torch.npu.set_device(device)
 
@@ -827,7 +833,7 @@ class NPUWorker(WorkerBase):
         # worker process before migratepages/taskset run.
         if get_ascend_config().enable_cpu_binding:
             try:
-                bind_cpus(self.local_rank)
+                bind_cpus(self.local_rank, npu_id=self.physical_device_id)
             except Exception as e:
                 logger.warning("Bind cpus failed in rank%s: %s Skip binding cpu.", self.local_rank, e)
 


### PR DESCRIPTION
Apply the Atlas A2/A3 KV cache write performance fix from upstream PR #15444 and adapt the CPU binding physical-device mapping fix from upstream PR #15518 to the current main branch.

<!--  Thanks for sending a pull request!

BEFORE SUBMITTING, PLEASE READ https://docs.vllm.ai/en/latest/contributing/overview.html

-->
### What this PR does / why we need it?
<!--
- Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue.
If possible, please consider writing useful notes for better and faster reviews in your PR.

- Please clarify why the changes are needed. For instance, the use case and bug description.

- Fixes #
-->

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as API, interface or other behavior changes.
Documentation-only updates are not considered user-facing changes.
-->

### How was this patch tested?
<!--
CI passed with new added/existing test.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
