### PR TITLE
[Feature][Model] Support DeepSeek V4 Vision with DSA-CP

### DIFF
--- a/tests/ut/attention/test_dsa_v1.py
+++ b/tests/ut/attention/test_dsa_v1.py
@@ -506,6 +506,76 @@ def test_dsa_cp_device_metadata_tasks(
         builder._build_qli_metadata.assert_not_called()
 
 
+def test_dsa_cp_builds_and_slices_vision_swa_indices():
+    builder = _make_cp_builder(compressor_ratio=1)
+    builder.num_prefills = 1
+    builder.num_actual_tokens = 4
+    builder.seq_lens = torch.tensor([4], dtype=torch.int32)
+    builder.seq_lens_cpu = builder.seq_lens
+    builder.block_table = torch.tensor([[1, 2]], dtype=torch.int32)
+    builder.slot_mapping = torch.zeros((4, 2), dtype=torch.int32)
+    builder.model_config.hf_config.vision_n_layers = 1
+    builder.model_config.hf_config.vision_max_n_token = 3
+    builder.model_config.hf_config.sliding_window = 2
+    builder.common_ratio_to_sas_metadata = {
+        "_cpu_local": {
+            "qsl_cpu": torch.tensor([0, 3], dtype=torch.int32),
+            "sl_cpu": torch.tensor([3], dtype=torch.int32),
+        }
+    }
+    builder._ensure_device_local_metadata = MagicMock(
+        return_value=(
+            3,
+            6,
+            3,
+            6,
+            torch.tensor([0, 3], dtype=torch.int32),
+            torch.tensor([3], dtype=torch.int32),
+            None,
+        )
+    )
+    builder._get_cmp_seqlens_for_metadata = MagicMock(return_value=None)
+    builder._build_sas_metadata = MagicMock(return_value=builder.req_sas_metadata)
+    global_indices = torch.arange(12, dtype=torch.int32).view(4, 1, 3)
+    common_attn_metadata = SimpleNamespace(
+        num_reqs=1,
+        query_start_loc=torch.tensor([0, 4], dtype=torch.int32),
+        query_start_loc_cpu=torch.tensor([0, 4], dtype=torch.int32),
+        mm_req_doc_ranges={0: [(1, 2)]},
+    )
+
+    with patch(
+        "vllm_ascend.attention.context_parallel.dsa_cp.build_vision_bidirectional_swa_indices",
+        return_value=(global_indices, None),
+    ) as build_vision_indices:
+        req_metadata = builder.build_req_metadata(
+            common_attn_metadata,
+            input_positions=None,
+            num_input_tokens=4,
+            num_actual_reqs=1,
+            attn_state=MagicMock(),
+            cos=MagicMock(),
+            sin=MagicMock(),
+        )
+
+    build_vision_indices.assert_called_once()
+    vision_kwargs = build_vision_indices.call_args.kwargs
+    assert torch.equal(vision_kwargs["block_table"], builder.block_table)
+    assert vision_kwargs["window_size"] == 2
+    assert vision_kwargs["max_image_tokens"] == 3
+    assert vision_kwargs["block_size"] == builder.storage_block_size
+    assert torch.equal(
+        vision_kwargs["query_start_loc"],
+        common_attn_metadata.query_start_loc,
+    )
+    assert torch.equal(vision_kwargs["seq_lens"], builder.seq_lens)
+    assert vision_kwargs["mm_prefix_ranges"] == (common_attn_metadata.mm_req_doc_ranges)
+    assert vision_kwargs["num_tokens"] == 4
+    expected = torch.full((3, 1, 3), -1, dtype=torch.int32)
+    expected[0] = global_indices[3]
+    assert torch.equal(req_metadata.vision_swa_indices, expected)
+
+
 def test_dsa_cp_device_local_metadata_is_deferred_and_reused():
     cache: dict[str, dict[str, torch.Tensor]] = {}
 
@@ -656,6 +726,7 @@ def _make_dsa_cp_metadata(sas_metadata: torch.Tensor) -> AscendDSACPMetadata:
         cu_cmp_seqlen_list=torch.tensor([0, 1], dtype=torch.int32),
         start_pos=torch.zeros(1, dtype=torch.int32),
         dspark_swa_indices=None,
+        vision_swa_indices=None,
         ori_win_left=None,
         ori_win_right=None,
     )
@@ -761,6 +832,8 @@ def test_dsa_cp_attention_waits_before_sas_consumer(compress_ratio: int, monkeyp
     swa_sas = torch.zeros(1024, dtype=torch.int32)
     compressor_sas = torch.ones(1024, dtype=torch.int32)
     swa_metadata = _make_dsa_cp_metadata(swa_sas)
+    vision_swa_indices = torch.tensor([[[3, 4, -1]]], dtype=torch.int32)
+    swa_metadata.req_metadata.vision_swa_indices = vision_swa_indices
     compressor_metadata = _make_dsa_cp_metadata(compressor_sas)
     layer_metadata = AscendDSACPLayerMetadata(
         swa=swa_metadata,
@@ -778,6 +851,7 @@ def test_dsa_cp_attention_waits_before_sas_consumer(compress_ratio: int, monkeyp
 
     def run_attention(*args, **kwargs):
         assert events == ["wait", "record"]
+        assert kwargs["ori_sparse_indices"] is vision_swa_indices
         events.append("attention")
         return (torch.ones((1, 1, 2)),)
 

--- a/tests/ut/worker/test_model_runner_v1.py
+++ b/tests/ut/worker/test_model_runner_v1.py
@@ -31,6 +31,67 @@ from vllm_ascend.worker.model_runner_v1 import NPUModelRunner
 
 
 class TestDummyRunSlotInvalidation(unittest.TestCase):
+    def test_dp_padding_keeps_real_scheduled_token_count(self):
+        runner = NPUModelRunner.__new__(NPUModelRunner)
+        runner.uniform_decode_query_len = 1
+        runner.scheduler_config = SimpleNamespace(
+            max_num_batched_tokens=8,
+            max_num_seqs=8,
+        )
+        runner.dynamic_eplb = False
+        runner.dcp_size = 1
+        runner.speculative_config = None
+        runner._has_gdn = False
+
+        num_tokens_across_dp = torch.zeros(2, dtype=torch.int32)
+        runner._determine_batch_execution_and_padding = MagicMock(
+            return_value=(
+                CUDAGraphMode.FULL,
+                SimpleNamespace(num_tokens=8, num_reqs=8),
+                None,
+                num_tokens_across_dp,
+                None,
+            )
+        )
+        runner._should_build_dummy_attn_metadata = MagicMock(return_value=True)
+        runner.synchronize_input_prep = MagicMock(return_value=nullcontext())
+
+        def build_cumsum(num_scheduled_tokens, _arange_out):
+            np.testing.assert_array_equal(
+                num_scheduled_tokens,
+                np.ones(7, dtype=np.int32),
+            )
+            return np.cumsum(num_scheduled_tokens)
+
+        runner._get_cumsum_and_arange = MagicMock(side_effect=build_cumsum)
+        runner.optimistic_seq_lens_cpu = torch.zeros(8, dtype=torch.int32)
+        runner.seq_lens = MagicMock()
+        runner.query_pos = SimpleNamespace(np=np.zeros(8, dtype=np.int32))
+        runner.query_start_loc = SimpleNamespace(
+            np=np.zeros(9, dtype=np.int32),
+            copy_to_gpu=MagicMock(),
+        )
+
+        def check_padded_query_start_loc(*_args, **_kwargs):
+            np.testing.assert_array_equal(
+                runner.query_start_loc.np,
+                np.array([0, 1, 2, 3, 4, 5, 6, 7, 7], dtype=np.int32),
+            )
+            raise RuntimeError("metadata checked")
+
+        runner._pad_query_start_loc_for_fia = MagicMock(side_effect=check_padded_query_start_loc)
+
+        with self.assertRaisesRegex(RuntimeError, "metadata checked"):
+            runner._dummy_run(
+                7,
+                cudagraph_runtime_mode=CUDAGraphMode.FULL,
+            )
+
+        torch.testing.assert_close(
+            num_tokens_across_dp,
+            torch.full_like(num_tokens_across_dp, 8),
+        )
+
     def test_backend_metadata_sees_invalidated_dummy_slots(self):
         runner = NPUModelRunner.__new__(NPUModelRunner)
         runner.uniform_decode_query_len = 1

--- a/vllm_ascend/attention/context_parallel/dsa_cp.py
+++ b/vllm_ascend/attention/context_parallel/dsa_cp.py
@@ -24,6 +24,7 @@ from vllm_ascend.attention.dsa_v1 import (
     _dsa_swa_only_cmp_ratio,
     _has_weight_scale,
     build_dspark_swa_indices,
+    build_vision_bidirectional_swa_indices,
     get_dspark_sparse_sas_window,
 )
 from vllm_ascend.attention.utils import (
@@ -133,6 +134,7 @@ class AscendDSAReqMetadata:
     ori_win_left: int | None = None
     ori_win_right: int = 0
     dspark_swa_indices: torch.Tensor | None = None
+    vision_swa_indices: torch.Tensor | None = None
 
 
 @dataclass
@@ -905,6 +907,41 @@ class AscendDSACPMetadataBuilder(AttentionMetadataBuilder[AscendDSAMetadata]):
             num_compressed_tokens = None
             slot_mapping = self.slot_mapping[: self.num_actual_tokens]
 
+        vision_swa_indices = None
+        mm_ranges = getattr(common_attn_metadata, "mm_req_doc_ranges", None)
+        hf_config = self.model_config.hf_config
+        max_image_tokens = (
+            getattr(hf_config, "vision_max_n_token", 0) if getattr(hf_config, "vision_n_layers", 0) > 0 else 0
+        )
+        if has_prefill and max_image_tokens > 0 and mm_ranges:
+            assert num_actual_reqs is not None
+            assert self.num_actual_tokens is not None
+            global_vision_indices, _ = build_vision_bidirectional_swa_indices(
+                block_table=self.block_table[:num_actual_reqs],
+                window_size=hf_config.sliding_window,
+                max_image_tokens=max_image_tokens,
+                block_size=self.storage_block_size,
+                query_start_loc=query_start_loc[: num_actual_reqs + 1],
+                seq_lens=self.seq_lens[:num_actual_reqs],
+                mm_prefix_ranges=mm_ranges,
+                num_tokens=self.num_actual_tokens,
+            )
+            pad_rows = num_tokens_pad - global_vision_indices.shape[0]
+            if pad_rows < 0:
+                raise ValueError(
+                    "Vision DSA-CP metadata has fewer padded query rows than "
+                    "actual rows: "
+                    f"num_tokens_pad={num_tokens_pad}, "
+                    f"actual={global_vision_indices.shape[0]}"
+                )
+            if pad_rows:
+                global_vision_indices = F.pad(
+                    global_vision_indices,
+                    (0, 0, 0, 0, 0, pad_rows),
+                    value=-1,
+                )
+            vision_swa_indices = global_vision_indices[local_start:local_end_with_pad].contiguous()
+
         # --- SAS metadata (all requests combined) ---
         num_heads = self.model_config.hf_config.num_attention_heads
         index_topk = self.model_config.hf_config.index_topk
@@ -1005,6 +1042,7 @@ class AscendDSACPMetadataBuilder(AttentionMetadataBuilder[AscendDSAMetadata]):
             qli_metadata=qli_metadata,
             device_local_metadata_group_id=device_local_metadata_group_id,
             cu_cmp_seqlen_list=cu_cmp_seqlens,
+            vision_swa_indices=vision_swa_indices,
         )
         if self._device_metadata_enabled and self.compressor_metadata_buffers is not None:
             assert num_compressed_tokens is not None
@@ -1932,6 +1970,8 @@ class AscendDSACPImpl(AttentionImplBase[Any]):
             kv_plan.add_dsa_sparse_attn_extra_kwargs(extra_attn_kwargs, cu_seqlens_ori_kv=local_seq_lengths_query)
         if swa_req_metadata.dspark_swa_indices is not None:
             extra_attn_kwargs["ori_sparse_indices"] = swa_req_metadata.dspark_swa_indices
+        if swa_req_metadata.vision_swa_indices is not None:
+            extra_attn_kwargs["ori_sparse_indices"] = swa_req_metadata.vision_swa_indices
 
         ori_win_left = self.window_size - 1 if swa_req_metadata.ori_win_left is None else swa_req_metadata.ori_win_left
         ori_win_right = 0 if swa_req_metadata.ori_win_right is None else swa_req_metadata.ori_win_right

--- a/vllm_ascend/worker/model_runner_v1.py
+++ b/vllm_ascend/worker/model_runner_v1.py
@@ -3661,7 +3661,6 @@ class NPUModelRunner(GPUModelRunner):
         if num_tokens_across_dp is not None and num_tokens_padded != num_tokens:
             # pad is needed if the pad of `num_tokens` is triggered inside CudagraphDispatcher
             num_tokens_across_dp[:] = num_tokens_padded
-            num_scheduled_tokens = num_scheduled_tokens.repeat(num_reqs_padded)
 
         if self.dynamic_eplb:
             self.update_eplb_heat_collection_status(num_tokens_padded)
@@ -3707,16 +3706,23 @@ class NPUModelRunner(GPUModelRunner):
                 self.seq_lens.copy_(self.optimistic_seq_lens_cpu, non_blocking=True)
 
                 cum_num_tokens = self._get_cumsum_and_arange(
-                num_scheduled_tokens, self.query_pos.np)
-                self.query_start_loc.np[1 : num_reqs_padded + 1] = cum_num_tokens
+                    num_scheduled_tokens, self.query_pos.np
+                )
+                self.query_start_loc.np[1 : num_reqs + 1] = cum_num_tokens
+                self.query_start_loc.np[
+                    num_reqs + 1 : num_reqs_padded + 1
+                ].fill(cum_num_tokens[-1])
                 self.query_start_loc.copy_to_gpu()
                 if self._has_gdn:
                     if skip_gdn_state_update:
                         self.gdn_query_start_loc.np.fill(0)
                     else:
+                        self.gdn_query_start_loc.np[1 : num_reqs + 1] = (
+                            cum_num_tokens
+                        )
                         self.gdn_query_start_loc.np[
-                            1 : num_reqs_padded + 1
-                        ] = cum_num_tokens
+                            num_reqs + 1 : num_reqs_padded + 1
+                        ].fill(cum_num_tokens[-1])
                     self.gdn_query_start_loc.copy_to_gpu()
 
                 if not profile_cpp:


### PR DESCRIPTION
### What this PR does / why we need it?

This PR adds DeepSeek V4 Vision support to the legacy MRV1 DSA context-parallel path after the base Vision support landed in #15457.

The regular DSA metadata builder already creates bidirectional sliding-window indices for image spans. The DSA-CP builder did not carry those indices into its rank-local metadata, so Vision requests with `additional_config.enable_dsa_cp=true` lost the image-aware attention mask.

This change:

- builds the global Vision SWA indices from `mm_req_doc_ranges` in the legacy DSA-CP metadata builder;
- pads and slices them to the token range owned by each TP rank;
- forwards the rank-local indices to the DSA attention operator;
- fixes MRV1 DP graph padding so padded request slots reuse the last cumulative token offset instead of repeating the real scheduled-token vector. The old behavior can produce a source/destination shape mismatch while capturing a padded FULL_DECODE graph.

### Does this PR introduce _any_ user-facing change?

Yes. DeepSeek V4 Vision can now be served with the legacy MRV1 DSA-CP path by setting `additional_config.enable_dsa_cp=true`.

### How was this patch tested?

- `python -m py_compile` on the four changed Python files.
- On an Ascend 800I A3 container:

  ```bash
  PYTHONPATH=/vllm-workspace/dsv4-vision-dsa-cp-pr:/vllm-workspace/vllm \
    pytest -q tests/ut/attention/test_dsa_v1.py \
      tests/ut/worker/test_model_runner_v1.py
  ```

  Result: `87 passed`.

- Started `DeepSeek-V4-Flash-Vision-Exp-w8a8` with MRV1, DP=4, TP=4, EP enabled, DSpark, `enable_dsa_cp=true`, and `cudagraph_mode=FULL_DECODE_ONLY` on 16 Ascend devices. All 29 graph-capture buckets completed; `/health` and `/v1/models` returned successfully, and a real image chat-completion request returned HTTP 200 with the expected answer.

- vLLM main: https://github.com/vllm-project/vllm/commit/ba07e4a48fc951300d97eb506217dd530583dea3
