### PR TITLE
[BugFix][Core] Skip nd2nz for k/n=1 weights and fuse GDN q/k l2norm into one kernel launch

### DIFF
--- a/tests/e2e/nightly/single_node/ops/singlecard_ops/triton/test_l2norm.py
+++ b/tests/e2e/nightly/single_node/ops/singlecard_ops/triton/test_l2norm.py
@@ -4,7 +4,7 @@ import pytest
 import torch
 import torch.nn.functional as F
 
-from vllm_ascend.ops.triton.fla.l2norm import l2norm_fwd
+from vllm_ascend.ops.triton.fla.l2norm import l2norm_fwd, l2norm_qk_fwd
 from vllm_ascend.ops.triton.triton_utils import init_device_properties_triton
 
 
@@ -34,6 +34,80 @@ def test_l2norm(B: int, T: int, H: int, D: int, dtype: torch.dtype):
     tri = l2norm_fwd(x)
 
     assert torch.allclose(tri, ref, rtol=rtol, atol=atol)
+    gc.collect()
+    torch.npu.empty_cache()
+    torch.npu.reset_peak_memory_stats()
+
+
+@pytest.mark.parametrize(
+    ("B", "T", "H", "D", "dtype"),
+    [
+        pytest.param(*test, id="B{}-T{}-H{}-D{}-{}".format(*test))
+        for test in [
+            (1, 63, 1, 60, torch.float),
+            (2, 500, 4, 64, torch.float),
+            (2, 1000, 2, 100, torch.float),
+            (3, 1024, 4, 128, torch.float),
+            (1, 4096, 8, 128, torch.bfloat16),
+        ]
+    ],
+)
+def test_l2norm_qk_fwd(B: int, T: int, H: int, D: int, dtype: torch.dtype):
+    torch.manual_seed(42)
+    init_device_properties_triton()
+    device = "npu"
+    rtol, atol = (3e-4, 1e-3) if dtype == torch.float32 else (3e-3, 5e-3)
+    if dtype == torch.bfloat16:
+        rtol, atol = 1e-2, 5e-2
+    q = torch.randn(B, T, H, D, dtype=dtype).to(device) * 0.5 + 0.3
+    k = torch.randn(B, T, H, D, dtype=dtype).to(device) * 0.5 + 0.3
+
+    q_ref = F.normalize(q, dim=-1, p=2)
+    k_ref = F.normalize(k, dim=-1, p=2)
+    q_tri, k_tri = l2norm_qk_fwd(q, k)
+
+    assert torch.allclose(q_tri, q_ref, rtol=rtol, atol=atol)
+    assert torch.allclose(k_tri, k_ref, rtol=rtol, atol=atol)
+    # The fused kernel computes the same row-wise arithmetic as two separate
+    # l2norm_fwd launches, so the outputs must match exactly.
+    assert torch.equal(q_tri, l2norm_fwd(q))
+    assert torch.equal(k_tri, l2norm_fwd(k))
+    gc.collect()
+    torch.npu.empty_cache()
+    torch.npu.reset_peak_memory_stats()
+
+
+def test_l2norm_qk_fwd_mismatched_shapes_fall_back():
+    torch.manual_seed(42)
+    init_device_properties_triton()
+    device = "npu"
+    q = torch.randn(1, 128, 4, 128, dtype=torch.bfloat16).to(device)
+    k = torch.randn(1, 128, 8, 128, dtype=torch.bfloat16).to(device)
+
+    q_tri, k_tri = l2norm_qk_fwd(q, k)
+
+    assert q_tri.shape == q.shape and k_tri.shape == k.shape
+    assert torch.equal(q_tri, l2norm_fwd(q))
+    assert torch.equal(k_tri, l2norm_fwd(k))
+    gc.collect()
+    torch.npu.empty_cache()
+    torch.npu.reset_peak_memory_stats()
+
+
+def test_l2norm_qk_fwd_sliced_inputs():
+    # Mirrors the GDN call sites, which l2-normalize time-sliced views of
+    # q/k (e.g. ``query[:, num_decode_tokens:]``).
+    torch.manual_seed(42)
+    init_device_properties_triton()
+    device = "npu"
+    q = torch.randn(1, 600, 4, 128, dtype=torch.bfloat16).to(device)
+    k = torch.randn(1, 600, 4, 128, dtype=torch.bfloat16).to(device)
+    q_sliced, k_sliced = q[:, 100:], k[:, 100:]
+
+    q_tri, k_tri = l2norm_qk_fwd(q_sliced, k_sliced)
+
+    assert torch.equal(q_tri, l2norm_fwd(q_sliced))
+    assert torch.equal(k_tri, l2norm_fwd(k_sliced))
     gc.collect()
     torch.npu.empty_cache()
     torch.npu.reset_peak_memory_stats()

--- a/tests/ut/test_utils.py
+++ b/tests/ut/test_utils.py
@@ -414,7 +414,19 @@ class TestUtils(TestBase):
             self.assertIs(result, weight)
             assert_nz_cast(weight)
 
-        # Test case 7: non-310P quantized weights still convert by default
+        # Test case 7: non-310P NZ mode skips weights with k=1 or n=1.
+        for shape in ((32, 1), (1, 64), (2, 32, 1)):
+            mock_npu_format_cast.reset_mock()
+            with (
+                mock.patch("vllm_ascend.utils.get_ascend_config", return_value=mock_config),
+                mock.patch("vllm_ascend.utils.is_310p", return_value=False),
+            ):
+                weight = torch.randn(*shape, dtype=torch.float16)
+                result = utils.maybe_trans_nz(weight)
+                self.assertIs(result, weight)
+                mock_npu_format_cast.assert_not_called()
+
+        # Test case 8: non-310P quantized weights still convert by default
         mock_npu_format_cast.reset_mock()
         mock_config.weight_nz_mode = 1
         with (

--- a/vllm_ascend/ops/gdn.py
+++ b/vllm_ascend/ops/gdn.py
@@ -21,7 +21,6 @@ from vllm.distributed import get_pcp_group
 from vllm.forward_context import get_forward_context
 from vllm.model_executor.layers.mamba.gdn.base import GatedDeltaNetAttention
 from vllm.model_executor.layers.mamba.mamba_utils import MambaStateShapeCalculator
-from vllm.third_party.flash_linear_attention.ops.l2norm import l2norm_fwd
 from vllm.triton_utils import triton
 from vllm.v1.attention.backend import AttentionBackend, AttentionMetadata  # type: ignore
 from vllm.v1.attention.backends.gdn_attn import GDNAttentionMetadata
@@ -32,6 +31,7 @@ from vllm_ascend.device.device_op import DeviceOperator
 from vllm_ascend.ops.gdn_attn_builder import AscendGDNAttentionBackend
 from vllm_ascend.ops.triton.fla.chunk import chunk_gated_delta_rule
 from vllm_ascend.ops.triton.fla.fused_qkvzba_split_reshape import fused_qkvzba_split_reshape_cat
+from vllm_ascend.ops.triton.fla.l2norm import l2norm_qk_fwd
 from vllm_ascend.ops.triton.fla.utils import clear_ssm_states
 from vllm_ascend.ops.triton.mamba.causal_conv1d import extract_last_width
 
@@ -338,8 +338,7 @@ class AscendGatedDeltaNetAttention(GatedDeltaNetAttention):
         # 2.1: Process the multi-query part
         if spec_sequence_masks is not None:
             actual_seq_lengths = attn_metadata.spec_decode_metadata.actual_seq_lengths
-            query_spec = l2norm_fwd(query_spec)
-            key_spec = l2norm_fwd(key_spec)
+            query_spec, key_spec = l2norm_qk_fwd(query_spec, key_spec)
             # Dispatches to the vllm-ascend AscendC custom operator
             # (csrc/recurrent_gated_delta_rule), NOT the built-in CANN operator.
             # The custom op extends dtype support (e.g. float32 state) and is
@@ -366,8 +365,7 @@ class AscendGatedDeltaNetAttention(GatedDeltaNetAttention):
             assert beta_non_spec is not None
             query_decode, key_decode, value_decode = self.rearrange_mixed_qkv(mixed_qkv_non_spec[:num_decode_tokens])
             actual_seq_lengths = attn_metadata.non_spec_decode_metadata.actual_seq_lengths
-            query_decode = l2norm_fwd(query_decode)
-            key_decode = l2norm_fwd(key_decode)
+            query_decode, key_decode = l2norm_qk_fwd(query_decode, key_decode)
             core_attn_out_decode = torch.ops._C_ascend.npu_recurrent_gated_delta_rule(
                 query=query_decode.squeeze(0),
                 key=key_decode.squeeze(0),
@@ -422,8 +420,7 @@ class AscendGatedDeltaNetAttention(GatedDeltaNetAttention):
                 )
         elif attn_metadata.num_decodes > 0:
             actual_seq_lengths = attn_metadata.non_spec_decode_metadata.actual_seq_lengths
-            query_non_spec = l2norm_fwd(query_non_spec)
-            key_non_spec = l2norm_fwd(key_non_spec)
+            query_non_spec, key_non_spec = l2norm_qk_fwd(query_non_spec, key_non_spec)
             # Dispatches to the vllm-ascend AscendC custom operator
             # (csrc/recurrent_gated_delta_rule), NOT the built-in CANN operator.
             core_attn_out_non_spec = torch.ops._C_ascend.npu_recurrent_gated_delta_rule(

--- a/vllm_ascend/ops/triton/fla/l2norm.py
+++ b/vllm_ascend/ops/triton/fla/l2norm.py
@@ -31,6 +31,30 @@ def l2norm_fwd_kernel2_loop(X, Y, eps, M, N: tl.constexpr, MBLOCK: tl.constexpr,
         tl.store(Y + (rindex + N * row_idx), xs * rsqrt, xmask)
 
 
+@triton.jit(do_not_specialize=["eps", "M", "NUM_CHUNKS"])
+def l2norm_qk_fwd_kernel(XQ, XK, YQ, YK, eps, M, N: tl.constexpr, MBLOCK: tl.constexpr, NUM_CHUNKS):
+    # q and k share the same (M, N) shape, so each program normalizes the same
+    # row block of both tensors.
+    base_row = tl.program_id(0) * (NUM_CHUNKS * MBLOCK)
+    rindex = tl.arange(0, N)[None, :]
+
+    for chunk in range(NUM_CHUNKS):
+        row_idx = base_row + chunk * MBLOCK + tl.arange(0, MBLOCK)[:, None]
+        xmask = row_idx < M
+
+        qs = tl.load(XQ + (rindex + N * row_idx), mask=xmask, other=0.0).to(tl.float32)
+        q_square = qs * qs
+        q_square_sum = tl.sum(q_square, 1)[:, None]
+        q_rsqrt = tl.rsqrt(q_square_sum + eps)
+        tl.store(YQ + (rindex + N * row_idx), qs * q_rsqrt, xmask)
+
+        ks = tl.load(XK + (rindex + N * row_idx), mask=xmask, other=0.0).to(tl.float32)
+        k_square = ks * ks
+        k_square_sum = tl.sum(k_square, 1)[:, None]
+        k_rsqrt = tl.rsqrt(k_square_sum + eps)
+        tl.store(YK + (rindex + N * row_idx), ks * k_rsqrt, xmask)
+
+
 def l2norm_fwd(x: torch.Tensor, eps: float = 1e-6, output_dtype: torch.dtype | None = None):
     x_shape_og = x.shape
     x = x.reshape(-1, x.shape[-1])
@@ -64,3 +88,58 @@ def l2norm_fwd(x: torch.Tensor, eps: float = 1e-6, output_dtype: torch.dtype | N
     )
 
     return y.view(x_shape_og)
+
+
+def l2norm_qk_fwd(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    eps: float = 1e-6,
+    output_dtype: torch.dtype | None = None,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """L2-normalize ``q`` and ``k`` over the last dim in a single kernel launch.
+
+    Fused replacement for the ``q, k = l2norm_fwd(q), l2norm_fwd(k)`` pattern
+    used by GDN-style attention, where q and k always share the same shape: one
+    persistent kernel normalizes the same row block of both tensors per
+    program. When the flattened shapes differ, the pair degrades to two
+    single-tensor ``l2norm_fwd`` calls.
+    """
+    q_shape_og, k_shape_og = q.shape, k.shape
+    q2d = q.reshape(-1, q.shape[-1])
+    k2d = k.reshape(-1, k.shape[-1])
+
+    if q2d.shape != k2d.shape:
+        return l2norm_fwd(q, eps, output_dtype), l2norm_fwd(k, eps, output_dtype)
+
+    if output_dtype is None:
+        yq = torch.empty_like(q2d)
+        yk = torch.empty_like(k2d)
+    else:
+        yq = torch.empty_like(q2d, dtype=output_dtype)
+        yk = torch.empty_like(k2d, dtype=output_dtype)
+    assert yq.stride(-1) == 1 and yk.stride(-1) == 1
+    T, D = q2d.shape[0], q2d.shape[-1]
+    # Less than 64KB per feature: enqueue fused kernel
+    MAX_FUSED_SIZE = 65536 // max(q2d.element_size(), k2d.element_size())
+    BD = min(MAX_FUSED_SIZE, triton.next_power_of_2(D))
+    if D > BD:
+        raise RuntimeError(f"l2norm_qk_fwd: This layer doesn't support feature dim >= 64KB, got {D}.")
+
+    MBLOCK = 69
+    num_core = get_vectorcore_num()
+    main_bs = triton.cdiv(T, num_core)
+    num_sub_blocks = triton.cdiv(main_bs, MBLOCK)
+    grid = (num_core,)
+    l2norm_qk_fwd_kernel[grid](
+        XQ=q2d,
+        XK=k2d,
+        YQ=yq,
+        YK=yk,
+        eps=eps,
+        M=T,
+        N=D,
+        MBLOCK=MBLOCK,
+        NUM_CHUNKS=num_sub_blocks,
+    )
+
+    return yq.view(q_shape_og), yk.view(k_shape_og)

--- a/vllm_ascend/utils.py
+++ b/vllm_ascend/utils.py
@@ -259,6 +259,12 @@ def _should_trans_nz(weight: torch.Tensor) -> bool:
     if weight.is_meta:
         return False
 
+    # aclnnMatmulWeightNZ does not support matrices whose reduction/output
+    # dimension is one (k=1 or n=1). Keep these weights in ND format so the
+    # subsequent linear/matmul dispatch does not select the NZ-only path.
+    if weight.ndim >= 2 and (weight.shape[-1] == 1 or weight.shape[-2] == 1):
+        return False
+
     # 310P always converts to NZ.
     if is_310p():
         return True
@@ -284,6 +290,7 @@ def _should_trans_nz(weight: torch.Tensor) -> bool:
 # - non-310P: follow VLLM_ASCEND_ENABLE_NZ
 # - FP32: never convert
 # - meta tensor: never convert
+# - weights with a 1 in either of the lowest two dimensions: never convert
 def maybe_trans_nz(weight: torch.Tensor) -> torch.Tensor:
     if not _should_trans_nz(weight):
         return weight


### PR DESCRIPTION
### What this PR does / why we need it?

This PR contains two changes on the v0.26.0rc line:

**1. Skip ND2NZ conversion for weights with k=1 or n=1** (`vllm_ascend/utils.py`)

`aclnnMatmulWeightNZ` does not support matrices whose reduction/output dimension is 1. `_should_trans_nz` now keeps such weights in ND format so the subsequent linear/matmul dispatch does not select the NZ-only path.

**2. Fuse GDN query/key l2norm into a single triton kernel launch** (`vllm_ascend/ops/triton/fla/l2norm.py`, `vllm_ascend/ops/gdn.py`)

The GDN attention paths normalize query and key with two back-to-back `l2norm_fwd` kernel launches (spec decode, mixed decode, non-spec decode). Each launch carries fixed kernel dispatch overhead, which is significant for decode-size token counts. This change:

- Adds `l2norm_qk_fwd_kernel` and its wrapper `l2norm_qk_fwd`: a persistent triton-ascend kernel where each program normalizes the same row block of both q and k, so one launch replaces two.
- Numerics are unchanged: fp32 accumulation, `rsqrt(sum(x^2) + eps)`, cast back to the input dtype at store.
- When q and k flatten to different shapes, the wrapper falls back to two single-tensor `l2norm_fwd` calls.
- Replaces all q/k `l2norm_fwd` call pairs in the GDN attention paths with the single fused call.

### Does this PR introduce _any_ user-facing change?

No. Both changes are internal: the ND2NZ skip only changes the weight format selection for k/n=1 weights (avoiding an unsupported operator path), and `l2norm_qk_fwd` performs the same row-wise arithmetic as the two-launch path.

### How was this patch tested?

- nd2nz skip: unit test in `tests/ut/test_utils.py`.
- l2norm fusion: nightly NPU tests added in `tests/e2e/nightly/single_node/ops/singlecard_ops/triton/test_l2norm.py`:
  - `test_l2norm_qk_fwd`: parameterized shapes/dtypes (incl. non-power-of-2 D=60/100 and bf16), checked against `F.normalize` and asserted bit-identical to two separate `l2norm_fwd` launches.
  - `test_l2norm_qk_fwd_mismatched_shapes_fall_back`: fallback correctness for mismatched q/k shapes.
  - `test_l2norm_qk_fwd_sliced_inputs`: time-sliced views mirroring the GDN call sites.
  - Run with: `pytest -sv tests/e2e/nightly/single_node/ops/singlecard_ops/triton/test_l2norm.py` (requires NPU hardware, covered by the nightly CI).
- `ruff-check` / `ruff-format` / `typos` pre-commit hooks pass on the changed files.

- vLLM main: https://github.com/vllm-project/vllm/commit/d02df748bf9efd99022f1a062597dc3cb3808485