### PR TITLE
[Performance] Switch GDN prefill to aclnn chunk_gated_delta_rule op

### DIFF
--- a/csrc/attention/chunk_gated_delta_rule/chunk_gated_delta_rule_torch_adpt.h
+++ b/csrc/attention/chunk_gated_delta_rule/chunk_gated_delta_rule_torch_adpt.h
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) Huawei Technologies Co., Ltd. 2026. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#ifndef CHUNK_GATED_DELTA_RULE_TORCH_ADPT_H
+#define CHUNK_GATED_DELTA_RULE_TORCH_ADPT_H
+
+namespace vllm_ascend {
+
+// Dispatches to the CANN aclnn operator aclnnChunkGatedDeltaRule.
+// The operator is compiled/installed from the chunk_gated_delta_rule source
+// tree under csrc/attention/chunk_gated_delta_rule (see build_aclnn.sh) and
+// resolved at runtime by name via EXEC_NPU_CMD, so no aclnn header include is
+// needed here (same pattern as recurrent_gated_delta_rule_torch_adpt.h).
+//
+// Inputs (TND layout):
+//   query            (T, Nk, Dk)  bf16
+//   key              (T, Nk, Dk)  bf16
+//   value            (T, Nv, Dv)  bf16
+//   beta             (T, Nv)      bf16
+//   initial_state     (B, Nv, Dv, Dk)  bf16/fp32
+//   actual_seq_lengths (B,)        int32
+//   g                (T, Nv)      fp32 (optional; nullptr => all-zero)
+//   scale_value      float
+// Outputs:
+//   out              (T, Nv, Dv)  bf16
+//   final_state       (B, Nv, Dv, Dk)  bf16/fp32
+inline std::tuple<at::Tensor, at::Tensor> npu_chunk_gated_delta_rule(
+    const at::Tensor& query,
+    const at::Tensor& key,
+    const at::Tensor& value,
+    const at::Tensor& beta,
+    const at::Tensor& initial_state,
+    const at::Tensor& actual_seq_lengths,
+    const c10::optional<at::Tensor>& g,
+    double scale_value)
+{
+    TORCH_CHECK(scale_value != 0.0, "scale_value cannot be 0.");
+
+    // out: same shape as value, bf16.
+    auto out_options = value.options().dtype(at::ScalarType::BFloat16);
+    at::Tensor out = at::empty(value.sizes(), out_options);
+
+    // final_state: same shape and dtype as initial_state (bf16 or fp32).
+    at::Tensor final_state = at::empty(initial_state.sizes(), initial_state.options());
+
+    float scale_real = static_cast<float>(scale_value);
+    EXEC_NPU_CMD(aclnnChunkGatedDeltaRule,
+                 query,
+                 key,
+                 value,
+                 beta,
+                 initial_state,
+                 actual_seq_lengths,
+                 g,
+                 scale_real,
+                 out,
+                 final_state);
+    return std::make_tuple(out, final_state);
+}
+
+} // namespace vllm_ascend
+#endif // CHUNK_GATED_DELTA_RULE_TORCH_ADPT_H

--- a/csrc/torch_binding.cpp
+++ b/csrc/torch_binding.cpp
@@ -52,6 +52,7 @@
 #include "attention/k2q_csr/k2q_csr_torch_adpt.h"
 #include "attention/msa_index_score/msa_index_score_torch_adpt.h"
 #include "attention/sparse_attention_score/sparse_attention_score_torch_adpt.h"
+#include "attention/chunk_gated_delta_rule/chunk_gated_delta_rule_torch_adpt.h"
 #include "attention/store_kv_block/store_kv_block_torch_adpt.h"
 #include "attention/store_kv_block_metadata/store_kv_block_metadata_torch_adpt.cpp"
 #include "moe/dequant_situ_quant/dequant_situ_quant_torch_adpt.h"
@@ -2040,6 +2041,17 @@ TORCH_LIBRARY_EXPAND(CONCAT(_C, _ascend), ops)
         "                               Tensor? g=None, "
         "                               Tensor? gk=None) -> Tensor");
     ops.impl("npu_recurrent_gated_delta_rule", torch::kPrivateUse1, &vllm_ascend::npu_recurrent_gated_delta_rule);
+
+    ops.def(
+        "npu_chunk_gated_delta_rule(Tensor query, "
+        "                          Tensor key, "
+        "                          Tensor value, "
+        "                          Tensor beta, "
+        "                          Tensor initial_state, "
+        "                          Tensor actual_seq_lengths, "
+        "                          Tensor? g=None, "
+        "                          float scale_value=1.0) -> (Tensor out, Tensor final_state)");
+    ops.impl("npu_chunk_gated_delta_rule", torch::kPrivateUse1, &vllm_ascend::npu_chunk_gated_delta_rule);
 
     ops.def(
         "recurrent_kda(Tensor query, Tensor key, Tensor value, Tensor gate, Tensor beta, "

--- a/csrc/torch_binding_meta.cpp
+++ b/csrc/torch_binding_meta.cpp
@@ -644,6 +644,25 @@ at::Tensor npu_recurrent_gated_delta_rule_meta(
     return output;
 }
 
+// Meta for npu_chunk_gated_delta_rule. Returns (out, final_state) with the same
+// shapes as value (bf16) and initial_state respectively. No real computation.
+std::tuple<at::Tensor, at::Tensor> npu_chunk_gated_delta_rule_meta(
+    const at::Tensor& query,
+    const at::Tensor& key,
+    const at::Tensor& value,
+    const at::Tensor& beta,
+    const at::Tensor& initial_state,
+    const at::Tensor& actual_seq_lengths,
+    const c10::optional<at::Tensor>& g,
+    double scale_value)
+{
+    auto out_options = value.options().dtype(at::ScalarType::BFloat16);
+    at::Tensor out = at::empty_symint(value.sym_sizes(), out_options);
+    at::Tensor final_state =
+        at::empty_symint(initial_state.sym_sizes(), initial_state.options());
+    return std::make_tuple(out, final_state);
+}
+
 at::Tensor recurrent_kda_meta(
     const at::Tensor& query,
     const at::Tensor& key,
@@ -1944,6 +1963,7 @@ TORCH_LIBRARY_IMPL_EXPAND(CONCAT(_C, _ascend), Meta, ops) {
     ops.impl("npu_gemma_rms_norm", &vllm_ascend::meta::npu_gemma_rms_norm_meta);
     // recurrent_gated_delta_rule meta implementation
     ops.impl("npu_recurrent_gated_delta_rule", &vllm_ascend::meta::npu_recurrent_gated_delta_rule_meta);
+    ops.impl("npu_chunk_gated_delta_rule", &vllm_ascend::meta::npu_chunk_gated_delta_rule_meta);
     ops.impl("recurrent_kda", &vllm_ascend::meta::recurrent_kda_meta);
     ops.impl("dequant_situ_quant", &vllm_ascend::meta::dequant_situ_quant_meta);
     ops.impl("situ_mx_quant", &vllm_ascend::meta::situ_mx_quant_meta);

--- a/tests/ut/ops/test_gdn_attn_builder.py
+++ b/tests/ut/ops/test_gdn_attn_builder.py
@@ -2,7 +2,6 @@
 
 from dataclasses import dataclass
 from types import SimpleNamespace
-from unittest.mock import patch
 
 import pytest
 import torch
@@ -43,18 +42,6 @@ def _patch_triton_cdiv(monkeypatch):
             lambda a, b: (a + b - 1) // b,
             raising=False,
         )
-
-
-@pytest.fixture(autouse=True)
-def _no_pin_memory():
-    # compute_causal_conv1d_metadata uses np_to_pinned_tensor which reads
-    # PIN_MEMORY.  Without physical NPU, t.pin_memory() raises
-    # "Please register PrivateUse1HooksInterface first".
-    with (
-        patch("vllm.utils.torch_utils.PIN_MEMORY", False),
-        patch("vllm.v1.attention.backends.utils.PIN_MEMORY", False),
-    ):
-        yield
 
 
 @dataclass
@@ -227,10 +214,7 @@ def _build_attn_metadata(
 
 def _assert_chunk_meta_matches_runtime(builder, chunk_meta, cu_seqlens: torch.Tensor) -> None:
     hf_text_config = getattr(builder.vllm_config.model_config, "hf_text_config", None)
-    linear_attn_config = getattr(hf_text_config, "linear_attn_config", None)
-    if isinstance(linear_attn_config, dict) and linear_attn_config.get("num_heads") is not None:
-        gdn_num_heads = linear_attn_config["num_heads"] // builder.vllm_config.parallel_config.tensor_parallel_size
-    elif hf_text_config is not None and hasattr(hf_text_config, "linear_num_value_heads"):
+    if hf_text_config is not None and hasattr(hf_text_config, "linear_num_value_heads"):
         gdn_num_heads = (
             hf_text_config.linear_num_value_heads // builder.vllm_config.parallel_config.tensor_parallel_size
         )
@@ -241,7 +225,9 @@ def _assert_chunk_meta_matches_runtime(builder, chunk_meta, cu_seqlens: torch.Te
         ascend_gdn_attn_builder._GDN_CUMSUM_WORKING_SET // (gdn_num_heads * ascend_gdn_attn_builder._GDN_CHUNK_SIZE),
     )
     cumsum_chunk_size = 1 if cumsum_chunks <= 1 else 1 << (cumsum_chunks - 1).bit_length()
+    sequence_lengths = cu_seqlens[1:] - cu_seqlens[:-1]
 
+    assert chunk_meta.num_decodes == (sequence_lengths == 1).sum().item()
     assert torch.equal(
         chunk_meta.chunk_indices_chunk64,
         runtime_prepare_chunk_indices(cu_seqlens, ascend_gdn_attn_builder._GDN_CHUNK_SIZE),
@@ -289,26 +275,6 @@ def _patch_missing_runtime_cdiv(monkeypatch: pytest.MonkeyPatch) -> None:
         lambda x, y: (x + y - 1) // y,
         raising=False,
     )
-
-
-def test_kimi_chunk_metadata_uses_linear_attention_head_count() -> None:
-    builder = _make_builder(
-        device=torch.device("cpu"),
-        num_heads=128,
-        num_speculative_tokens=0,
-    )
-    builder.vllm_config.model_config.hf_text_config = SimpleNamespace(
-        linear_attn_config={"num_heads": 32},
-    )
-    cu_seqlens = torch.tensor([0, 130], dtype=torch.int32)
-
-    chunk_meta = ascend_gdn_attn_builder._build_non_spec_chunked_prefill_metadata(
-        builder,
-        cu_seqlens,
-        torch.device("cpu"),
-    )
-
-    _assert_chunk_meta_matches_runtime(builder, chunk_meta, cu_seqlens)
 
 
 def test_ascend_gdn_attention_uses_ascend_backend():
@@ -382,14 +348,12 @@ def _assert_non_spec_conv1d_args_match_metadata(attn_metadata) -> None:
     ],
     ids=lambda case: case.name if isinstance(case, BatchSpec) else None,
 )
-def test_non_spec_prefill_metadata_matches_original_inputs_and_runtime_helpers(
+def test_non_spec_prefill_metadata_keeps_only_conv1d_inputs(
     batch_spec: BatchSpec,
     num_speculative_tokens: int,
     num_decode_draft_tokens_cpu: torch.Tensor | None,
-    monkeypatch: pytest.MonkeyPatch,
 ):
-    _patch_missing_runtime_cdiv(monkeypatch)
-    builder, _, attn_metadata = _build_attn_metadata(
+    _, _, attn_metadata = _build_attn_metadata(
         batch_spec,
         num_speculative_tokens=num_speculative_tokens,
         num_decode_draft_tokens_cpu=num_decode_draft_tokens_cpu,
@@ -398,27 +362,23 @@ def test_non_spec_prefill_metadata_matches_original_inputs_and_runtime_helpers(
     prefill_metadata = getattr(attn_metadata, "non_spec_prefill_metadata", None)
     assert prefill_metadata is not None
     assert prefill_metadata.causal_conv1d is not None
-    assert prefill_metadata.chunk is not None
+    assert not hasattr(prefill_metadata, "chunk")
 
     _assert_non_spec_conv1d_args_match_metadata(attn_metadata)
+    assert attn_metadata.chunk_indices is None
+    assert attn_metadata.chunk_offsets is None
+    assert attn_metadata.nums_dict is None
+    assert attn_metadata.batch_ptr is None
+    assert attn_metadata.token_chunk_offset_ptr is None
 
-    _assert_chunk_meta_matches_runtime(
-        builder,
-        prefill_metadata.chunk,
-        attn_metadata.prefill_query_start_loc,
-    )
 
-
-def test_non_spec_prefill_metadata_uses_prefill_tail_for_chunk_metadata(
-    monkeypatch: pytest.MonkeyPatch,
-):
-    _patch_missing_runtime_cdiv(monkeypatch)
+def test_non_spec_prefill_metadata_uses_prefill_tail_for_fused_operator():
     batch_spec = BatchSpec(
         seq_lens=[5, 12, 9],
         query_lens=[1, 8, 4],
         name="decode_prefill_without_spec",
     )
-    builder, _, attn_metadata = _build_attn_metadata(
+    _, _, attn_metadata = _build_attn_metadata(
         batch_spec,
         num_speculative_tokens=0,
         num_decode_draft_tokens_cpu=None,
@@ -430,10 +390,7 @@ def test_non_spec_prefill_metadata_uses_prefill_tail_for_chunk_metadata(
         attn_metadata.non_spec_query_start_loc,
         torch.tensor([0, 1, 9, 13], dtype=torch.int32),
     )
-    assert torch.equal(
-        attn_metadata.prefill_query_start_loc,
-        torch.tensor([0, 8, 12], dtype=torch.int32),
-    )
+    assert attn_metadata.prefill_query_start_loc is None
     assert torch.equal(
         attn_metadata.non_spec_state_indices_tensor,
         torch.tensor([0, 1, 2], dtype=torch.int32),
@@ -455,11 +412,119 @@ def test_non_spec_prefill_metadata_uses_prefill_tail_for_chunk_metadata(
     assert torch.equal(conv1d_meta.query_start_loc, torch.tensor([0, 1, 9, 13], dtype=torch.int32))
     assert torch.equal(_cache_index_first_column(conv1d_meta.cache_indices), torch.tensor([0, 1, 2], dtype=torch.int32))
     assert torch.equal(conv1d_meta.initial_state_mode, torch.tensor([True, True, True]))
+    assert prefill_metadata.chunk.num_decodes == 0
     _assert_chunk_meta_matches_runtime(
         builder,
         prefill_metadata.chunk,
         attn_metadata.prefill_query_start_loc,
     )
+
+
+def test_mixed_spec_prefill_chunk_metadata_preserves_single_token_count(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    _patch_missing_runtime_cdiv(monkeypatch)
+    batch_spec = BatchSpec(
+        seq_lens=[1, 4, 8],
+        query_lens=[1, 4, 8],
+        name="mixed_spec_prefill_with_single_token_non_spec",
+    )
+    builder, _, attn_metadata = _build_attn_metadata(
+        batch_spec,
+        num_speculative_tokens=3,
+        num_decode_draft_tokens_cpu=torch.tensor([-1, 3, -1], dtype=torch.int32),
+    )
+
+    assert attn_metadata.num_decodes == 0
+    assert attn_metadata.num_prefills == 2
+    assert torch.equal(
+        attn_metadata.prefill_query_start_loc,
+        torch.tensor([0, 1, 9], dtype=torch.int32),
+    )
+    chunk_metadata = attn_metadata.non_spec_prefill_metadata.chunk
+    assert chunk_metadata.num_decodes == 1
+    _assert_chunk_meta_matches_runtime(
+        builder,
+        chunk_metadata,
+        attn_metadata.prefill_query_start_loc,
+    )
+
+
+@pytest.mark.parametrize(
+    ("seq_len", "expected_decodes", "expected_prefills"),
+    [
+        pytest.param(1, 0, 1, id="first_token_stays_prefill"),
+        pytest.param(5, 1, 0, id="stateful_token_becomes_decode"),
+    ],
+)
+def test_one_token_prefill_selection_respects_recurrent_state(
+    monkeypatch: pytest.MonkeyPatch,
+    seq_len: int,
+    expected_decodes: int,
+    expected_prefills: int,
+):
+    _patch_missing_runtime_cdiv(monkeypatch)
+    common_attn_metadata = create_common_attn_metadata(
+        BatchSpec(seq_lens=[seq_len], query_lens=[1]),
+        block_size=16,
+        device=torch.device("cpu"),
+    )
+    # Model a prompt chunk explicitly; the helper normally classifies a
+    # one-token row as decode when synthesizing test metadata.
+    common_attn_metadata.is_prefilling = torch.tensor([True])
+    builder = _make_builder(
+        device=torch.device("cpu"),
+        num_heads=32,
+        num_speculative_tokens=0,
+    )
+
+    attn_metadata = builder.build(0, common_attn_metadata)
+
+    assert common_attn_metadata.is_prefilling.tolist() == [True]
+    assert attn_metadata.num_decodes == expected_decodes
+    assert attn_metadata.num_prefills == expected_prefills
+
+
+@pytest.mark.parametrize(
+    ("seq_len", "expected_spec_decodes", "expected_prefills"),
+    [
+        pytest.param(4, 0, 1, id="first_chunk_stays_prefill"),
+        pytest.param(8, 1, 0, id="stateful_chunk_folds_into_spec"),
+    ],
+)
+def test_spec_sized_prefill_fold_requires_recurrent_state(
+    monkeypatch: pytest.MonkeyPatch,
+    seq_len: int,
+    expected_spec_decodes: int,
+    expected_prefills: int,
+):
+    _patch_missing_runtime_cdiv(monkeypatch)
+    common_attn_metadata = create_common_attn_metadata(
+        BatchSpec(seq_lens=[seq_len], query_lens=[4]),
+        block_size=16,
+        device=torch.device("cpu"),
+    )
+    builder = _make_builder(
+        device=torch.device("cpu"),
+        num_heads=32,
+        num_speculative_tokens=3,
+    )
+
+    attn_metadata = builder.build(
+        0,
+        common_attn_metadata,
+        num_accepted_tokens=torch.ones(1, dtype=torch.int32),
+        num_decode_draft_tokens_cpu=torch.full((1,), -1, dtype=torch.int32),
+    )
+
+    assert attn_metadata.num_spec_decodes == expected_spec_decodes
+    assert attn_metadata.num_prefills == expected_prefills
+    if expected_spec_decodes:
+        assert attn_metadata.spec_sequence_masks.tolist() == [True]
+        assert attn_metadata.num_accepted_tokens.tolist() == [4]
+    else:
+        assert attn_metadata.spec_sequence_masks is None
+        assert attn_metadata.num_accepted_tokens is None
 
 
 def test_spec_conv1d_args_use_device_cache_and_accepted_tokens():
@@ -589,10 +654,258 @@ def test_full_graph_spec_actual_seq_lengths_use_padded_builder_buffer():
         attn_metadata.spec_decode_metadata.actual_seq_lengths,
         torch.tensor([0, 4, 4, 0, 0], dtype=torch.int32),
     )
+    assert torch.equal(
+        attn_metadata.num_accepted_tokens,
+        torch.tensor([2, 4, 1, 1], dtype=torch.int32),
+    )
 
 
-def test_causal_conv1d_cache_indices_use_device_block_table(monkeypatch: pytest.MonkeyPatch):
-    _patch_missing_runtime_cdiv(monkeypatch)
+def test_full_graph_k7_dummy_row_has_zero_length_and_valid_accepted_sentinel():
+    batch_spec = BatchSpec(
+        seq_lens=[8],
+        query_lens=[8],
+        name="full_graph_k7_one_real_one_dummy",
+    )
+    common_attn_metadata = create_common_attn_metadata(
+        batch_spec=batch_spec,
+        block_size=16,
+        device=torch.device("cpu"),
+    )
+    # A size-16 graph for K=7 is one real 8-token request plus one
+    # zero-length padding request.
+    common_attn_metadata.num_reqs = 2
+    builder = _make_builder(
+        device=torch.device("cpu"),
+        num_heads=32,
+        num_speculative_tokens=7,
+        cudagraph_mode=CUDAGraphMode.FULL_DECODE_ONLY,
+    )
+
+    attn_metadata = builder.build(
+        0,
+        common_attn_metadata,
+        num_accepted_tokens=torch.tensor([6], dtype=torch.int32),
+        num_decode_draft_tokens_cpu=torch.tensor([7], dtype=torch.int32),
+    )
+
+    assert torch.equal(
+        attn_metadata.spec_query_start_loc,
+        torch.tensor([0, 8, 8], dtype=torch.int32),
+    )
+    assert torch.equal(
+        attn_metadata.spec_decode_metadata.actual_seq_lengths,
+        torch.tensor([0, 8, 0], dtype=torch.int32),
+    )
+    assert torch.equal(
+        attn_metadata.num_accepted_tokens,
+        torch.tensor([6, 1], dtype=torch.int32),
+    )
+    assert torch.equal(
+        attn_metadata.spec_state_indices_tensor[1],
+        torch.full((8,), NULL_BLOCK_ID, dtype=torch.int32),
+    )
+    assert torch.equal(
+        attn_metadata.spec_decode_metadata.spec_causal_conv1d.cache_indices[1],
+        torch.full((8,), NULL_BLOCK_ID, dtype=torch.int32),
+    )
+
+
+@pytest.mark.parametrize(
+    ("replay_batch", "replay_num_accepted_tokens", "replay_num_decode_draft_tokens"),
+    [
+        pytest.param(
+            BatchSpec(
+                seq_lens=[1, 1, 0, 0],
+                query_lens=[1, 1, 0, 0],
+                name="full_graph_non_spec_decode_replay",
+            ),
+            torch.ones(4, dtype=torch.int32),
+            torch.full((4,), -1, dtype=torch.int32),
+            id="non_spec_decode",
+        ),
+        pytest.param(
+            BatchSpec(
+                seq_lens=[8, 8, 0, 0],
+                query_lens=[8, 8, 0, 0],
+                name="full_graph_dummy_prefill_replay",
+            ),
+            None,
+            None,
+            id="dummy_prefill",
+        ),
+    ],
+)
+def test_full_graph_without_runtime_spec_resets_captured_spec_inputs(
+    replay_batch: BatchSpec,
+    replay_num_accepted_tokens: torch.Tensor | None,
+    replay_num_decode_draft_tokens: torch.Tensor | None,
+):
+    capture_batch = BatchSpec(
+        seq_lens=[4, 4],
+        query_lens=[4, 4],
+        name="full_graph_spec_capture",
+    )
+    capture_common_metadata = create_common_attn_metadata(
+        batch_spec=capture_batch,
+        block_size=16,
+        device=torch.device("cpu"),
+    )
+    capture_common_metadata.num_reqs = 4
+    capture_common_metadata.block_table_tensor = torch.tensor(
+        [[10, 11, 12, 13], [20, 21, 22, 23]],
+        dtype=torch.int32,
+    )
+    builder = _make_builder(
+        device=torch.device("cpu"),
+        num_heads=32,
+        num_speculative_tokens=3,
+        cudagraph_mode=CUDAGraphMode.FULL_DECODE_ONLY,
+    )
+    captured_metadata = builder.build(
+        0,
+        capture_common_metadata,
+        num_accepted_tokens=torch.tensor([2, 4], dtype=torch.int32),
+        num_decode_draft_tokens_cpu=torch.tensor([3, 3], dtype=torch.int32),
+    )
+    captured_spec_metadata = captured_metadata.spec_decode_metadata
+    captured_conv1d_metadata = captured_spec_metadata.spec_causal_conv1d
+
+    assert torch.count_nonzero(captured_conv1d_metadata.query_start_loc) > 0
+    assert torch.count_nonzero(captured_spec_metadata.actual_seq_lengths) > 0
+
+    replay_common_metadata = create_common_attn_metadata(
+        batch_spec=replay_batch,
+        block_size=16,
+        device=torch.device("cpu"),
+    )
+    replay_metadata = builder.build(
+        0,
+        replay_common_metadata,
+        num_accepted_tokens=replay_num_accepted_tokens,
+        num_decode_draft_tokens_cpu=replay_num_decode_draft_tokens,
+    )
+
+    assert replay_metadata.spec_sequence_masks is None
+    assert replay_metadata.spec_decode_metadata is None
+    assert torch.equal(
+        captured_conv1d_metadata.cache_indices,
+        torch.full((4, 4), PAD_SLOT_ID, dtype=torch.int32),
+    )
+    assert torch.count_nonzero(captured_conv1d_metadata.query_start_loc) == 0
+    assert torch.count_nonzero(captured_conv1d_metadata.num_accepted_tokens) == 0
+    assert torch.count_nonzero(captured_spec_metadata.actual_seq_lengths) == 0
+
+
+def test_full_graph_idle_dummy_uses_zero_length_recurrent_metadata():
+    common_attn_metadata = create_common_attn_metadata(
+        batch_spec=BatchSpec(
+            seq_lens=[8, 8, 8, 8],
+            query_lens=[0, 0, 0, 0],
+            name="full_graph_idle_dummy",
+        ),
+        block_size=16,
+        device=torch.device("cpu"),
+    )
+    common_attn_metadata.block_table_tensor[:, 0] = torch.tensor(
+        [10, 11, 98, 99],
+        dtype=torch.int32,
+    )
+    builder = _make_builder(
+        device=torch.device("cpu"),
+        num_heads=32,
+        num_speculative_tokens=3,
+        cudagraph_mode=CUDAGraphMode.FULL_DECODE_ONLY,
+    )
+    builder.spec_state_indices_tensor.fill_(77)
+    builder.spec_query_start_loc.fill_(77)
+    builder.non_spec_state_indices_tensor.fill_(77)
+    builder.non_spec_query_start_loc.fill_(77)
+
+    attn_metadata = builder.build(0, common_attn_metadata)
+
+    assert attn_metadata.num_actual_tokens == 0
+    assert attn_metadata.num_decode_tokens == 0
+    assert torch.count_nonzero(attn_metadata.non_spec_query_start_loc) == 0
+    assert torch.all(attn_metadata.non_spec_state_indices_tensor == NULL_BLOCK_ID)
+    assert torch.count_nonzero(builder.spec_query_start_loc[:5]) == 0
+    assert torch.all(builder.spec_state_indices_tensor[:4] == PAD_SLOT_ID)
+
+
+@pytest.mark.parametrize(
+    ("num_speculative_tokens", "num_decode_draft_tokens_cpu"),
+    [
+        pytest.param(0, None, id="without_mtp"),
+        pytest.param(
+            3,
+            torch.full((4,), -1, dtype=torch.int32),
+            id="mtp_without_spec_requests",
+        ),
+    ],
+)
+def test_full_graph_non_spec_metadata_nulls_padded_state_indices(
+    num_speculative_tokens: int,
+    num_decode_draft_tokens_cpu: torch.Tensor | None,
+):
+    batch_spec = BatchSpec(
+        seq_lens=[1, 1, 0, 0],
+        query_lens=[1, 1, 0, 0],
+        name="full_graph_padded_non_spec_actual_seq_lengths",
+    )
+    common_attn_metadata = create_common_attn_metadata(
+        batch_spec=batch_spec,
+        block_size=16,
+        device=torch.device("cpu"),
+    )
+    # PCP can leave padded block-table rows untouched. Model stale valid
+    # state slots from a preceding decode batch.
+    common_attn_metadata.block_table_tensor[:, 0] = torch.tensor([10, 11, 98, 99])
+    builder = _make_builder(
+        device=torch.device("cpu"),
+        num_heads=32,
+        num_speculative_tokens=num_speculative_tokens,
+        cudagraph_mode=CUDAGraphMode.FULL_DECODE_ONLY,
+    )
+    builder.non_spec_state_indices_tensor.fill_(77)
+    builder.non_spec_query_start_loc.fill_(77)
+    builder.non_spec_actual_seq_lengths.fill_(77)
+    if num_speculative_tokens == 0:
+        builder.spec_state_indices_tensor.fill_(77)
+
+    attn_metadata = builder.build(
+        0,
+        common_attn_metadata,
+        num_decode_draft_tokens_cpu=num_decode_draft_tokens_cpu,
+    )
+
+    assert attn_metadata.num_decodes == 4
+    assert attn_metadata.num_decode_tokens == 2
+    assert torch.equal(
+        attn_metadata.non_spec_query_start_loc,
+        torch.tensor([0, 1, 2, 2, 2], dtype=torch.int32),
+    )
+    assert torch.equal(
+        attn_metadata.non_spec_state_indices_tensor,
+        torch.tensor(
+            [10, 11, NULL_BLOCK_ID, NULL_BLOCK_ID],
+            dtype=torch.int32,
+        ),
+    )
+    if num_speculative_tokens == 0:
+        # A model without speculative decoding must not enter the captured
+        # spec-task reset path. Its real non-spec decode above remains live.
+        assert torch.all(builder.spec_state_indices_tensor == 77)
+    decode_metadata = attn_metadata.non_spec_decode_metadata
+    conv1d_metadata = decode_metadata.causal_conv1d
+    assert conv1d_metadata.query_start_loc.data_ptr() == attn_metadata.non_spec_query_start_loc.data_ptr()
+    assert conv1d_metadata.cache_indices.data_ptr() == attn_metadata.non_spec_state_indices_tensor.data_ptr()
+    assert decode_metadata.actual_seq_lengths.data_ptr() == builder.non_spec_actual_seq_lengths.data_ptr()
+    assert torch.equal(
+        decode_metadata.actual_seq_lengths,
+        torch.tensor([0, 1, 1, 0, 0], dtype=torch.int32),
+    )
+
+
+def test_causal_conv1d_cache_indices_use_device_block_table():
     batch_spec = BatchSpec(
         seq_lens=[4, 4],
         query_lens=[4, 4],
@@ -625,8 +938,7 @@ def test_causal_conv1d_cache_indices_use_device_block_table(monkeypatch: pytest.
     assert torch.equal(conv1d_meta.initial_state_mode, torch.tensor([False, False]))
 
 
-def test_mamba_align_cache_indices_follow_device_seq_lens(monkeypatch: pytest.MonkeyPatch):
-    _patch_missing_runtime_cdiv(monkeypatch)
+def test_mamba_align_cache_indices_follow_device_seq_lens():
     batch_spec = BatchSpec(
         seq_lens=[1, 9],
         query_lens=[1, 1],
@@ -657,8 +969,49 @@ def test_mamba_align_cache_indices_follow_device_seq_lens(monkeypatch: pytest.Mo
     )
 
 
-def test_builder_builds_prebuilt_chunk_metadata_with_prefill_query_start_loc(monkeypatch):
+def test_mamba_align_prefill_marks_only_prefix_hit_as_initial_state(monkeypatch: pytest.MonkeyPatch):
     _patch_missing_runtime_cdiv(monkeypatch)
+    batch_spec = BatchSpec(
+        seq_lens=[12, 4],
+        query_lens=[4, 4],
+        name="align_prefix_hit_and_cold_prefill",
+    )
+    common_attn_metadata = create_common_attn_metadata(
+        batch_spec=batch_spec,
+        block_size=4,
+        device=torch.device("cpu"),
+    )
+    common_attn_metadata.block_table_tensor = torch.arange(40, 60, dtype=torch.int32).view(2, 10)
+    builder = _make_builder(
+        device=torch.device("cpu"),
+        num_heads=32,
+        num_speculative_tokens=0,
+        mamba_cache_mode="align",
+        block_size=4,
+    )
+
+    attn_metadata = builder.build(0, common_attn_metadata)
+
+    assert torch.equal(
+        attn_metadata.prefill_state_indices,
+        torch.tensor([42, 50], dtype=torch.int32),
+    )
+    assert torch.equal(
+        attn_metadata.prefill_has_initial_state,
+        torch.tensor([True, False]),
+    )
+    conv1d_meta = attn_metadata.non_spec_prefill_metadata.causal_conv1d
+    assert torch.equal(
+        _cache_index_first_column(conv1d_meta.cache_indices),
+        attn_metadata.prefill_state_indices,
+    )
+    assert torch.equal(
+        conv1d_meta.initial_state_mode,
+        attn_metadata.prefill_has_initial_state,
+    )
+
+
+def test_builder_keeps_only_fused_operator_metadata():
     batch_spec = BatchSpec(
         seq_lens=[8, 4, 0, 12],
         query_lens=[4, 4, 0, 8],
@@ -677,20 +1030,16 @@ def test_builder_builds_prebuilt_chunk_metadata_with_prefill_query_start_loc(mon
         num_decode_draft_tokens_cpu=torch.tensor([-1, 3, -1, -1], dtype=torch.int32),
     )
 
-    chunk_meta = attn_metadata.non_spec_prefill_metadata.chunk
-    assert chunk_meta.chunk_indices_chunk64 is attn_metadata.chunk_indices
-    assert chunk_meta.chunk_offsets_chunk64 is attn_metadata.chunk_offsets
-    _assert_chunk_meta_matches_runtime(
-        builder,
-        chunk_meta,
-        attn_metadata.prefill_query_start_loc,
-    )
-    assert chunk_meta.cu_seqlens_host == tuple(attn_metadata.prefill_query_start_loc.to(torch.int64).tolist())
-    expected_chunk_indices = runtime_prepare_chunk_indices(
-        attn_metadata.prefill_query_start_loc,
-        ascend_gdn_attn_builder._GDN_CHUNK_SIZE,
-    )
-    assert chunk_meta.chunk_indices_chunk64_host == tuple(expected_chunk_indices.to(torch.int64).reshape(-1).tolist())
+    assert not hasattr(ascend_gdn_attn_builder, "GDNChunkedPrefillMetadata")
+    assert not hasattr(ascend_gdn_attn_builder, "_build_non_spec_chunked_prefill_metadata")
+    assert attn_metadata.chunk_indices is None
+    assert attn_metadata.chunk_offsets is None
+    assert attn_metadata.nums_dict is None
+    assert attn_metadata.batch_ptr is None
+    assert attn_metadata.token_chunk_offset_ptr is None
+    prefill_metadata = attn_metadata.non_spec_prefill_metadata
+    assert torch.equal(prefill_metadata.actual_seq_lengths, torch.tensor([4, 0, 8], dtype=torch.int32))
+    assert torch.equal(prefill_metadata.non_empty_indices, torch.tensor([0, 2], dtype=torch.int64))
 
 
 @pytest.mark.parametrize(
@@ -747,269 +1096,3 @@ def test_builder_skips_prebuilt_meta_without_non_spec_prefill(batch_spec: BatchS
             spec_decode_metadata.actual_seq_lengths,
             torch.tensor([0, 4, 4], dtype=torch.int32),
         )
-
-
-def test_mixed_spec_prefill_chunk_metadata_preserves_single_token_count(
-    monkeypatch: pytest.MonkeyPatch,
-):
-    _patch_missing_runtime_cdiv(monkeypatch)
-    batch_spec = BatchSpec(
-        seq_lens=[1, 4, 8],
-        query_lens=[1, 4, 8],
-        name="mixed_spec_prefill_with_single_token_non_spec",
-    )
-    builder, _, attn_metadata = _build_attn_metadata(
-        batch_spec,
-        num_speculative_tokens=3,
-        num_decode_draft_tokens_cpu=torch.tensor([-1, 3, -1], dtype=torch.int32),
-    )
-
-    assert attn_metadata.num_decodes == 0
-    assert attn_metadata.num_prefills == 2
-    assert torch.equal(
-        attn_metadata.prefill_query_start_loc,
-        torch.tensor([0, 1, 9], dtype=torch.int32),
-    )
-    chunk_metadata = attn_metadata.non_spec_prefill_metadata.chunk
-    _assert_chunk_meta_matches_runtime(
-        builder,
-        chunk_metadata,
-        attn_metadata.prefill_query_start_loc,
-    )
-
-
-@pytest.mark.parametrize(
-    ("seq_len", "expected_decodes", "expected_prefills"),
-    [
-        pytest.param(1, 0, 1, id="first_token_stays_prefill"),
-        pytest.param(17, 1, 0, id="block-size-plus-one-becomes-decode"),
-    ],
-)
-def test_one_token_prefill_selection_respects_recurrent_state(
-    monkeypatch: pytest.MonkeyPatch,
-    seq_len: int,
-    expected_decodes: int,
-    expected_prefills: int,
-):
-    _patch_missing_runtime_cdiv(monkeypatch)
-    common_attn_metadata = create_common_attn_metadata(
-        BatchSpec(seq_lens=[seq_len], query_lens=[1]),
-        block_size=16,
-        device=torch.device("cpu"),
-    )
-    # Model a prompt chunk explicitly. The helper normally classifies a
-    # one-token row as decode when synthesizing test metadata.
-    common_attn_metadata.is_prefilling = torch.tensor([True])
-    builder = _make_builder(
-        device=torch.device("cpu"),
-        num_heads=32,
-        num_speculative_tokens=0,
-    )
-
-    attn_metadata = builder.build(0, common_attn_metadata)
-
-    assert common_attn_metadata.is_prefilling.tolist() == [True]
-    assert attn_metadata.num_decodes == expected_decodes
-    assert attn_metadata.num_prefills == expected_prefills
-
-
-@pytest.mark.parametrize(
-    ("seq_len", "expected_spec_decodes", "expected_prefills"),
-    [
-        pytest.param(4, 0, 1, id="first_chunk_stays_prefill"),
-        pytest.param(8, 1, 0, id="stateful_chunk_folds_into_spec"),
-    ],
-)
-def test_spec_sized_prefill_fold_requires_recurrent_state(
-    monkeypatch: pytest.MonkeyPatch,
-    seq_len: int,
-    expected_spec_decodes: int,
-    expected_prefills: int,
-):
-    _patch_missing_runtime_cdiv(monkeypatch)
-    common_attn_metadata = create_common_attn_metadata(
-        BatchSpec(seq_lens=[seq_len], query_lens=[4]),
-        block_size=16,
-        device=torch.device("cpu"),
-    )
-    builder = _make_builder(
-        device=torch.device("cpu"),
-        num_heads=32,
-        num_speculative_tokens=3,
-    )
-
-    attn_metadata = builder.build(
-        0,
-        common_attn_metadata,
-        num_accepted_tokens=torch.ones(1, dtype=torch.int32),
-        num_decode_draft_tokens_cpu=torch.full((1,), -1, dtype=torch.int32),
-    )
-
-    assert attn_metadata.num_spec_decodes == expected_spec_decodes
-    assert attn_metadata.num_prefills == expected_prefills
-    if expected_spec_decodes:
-        assert attn_metadata.spec_sequence_masks.tolist() == [True]
-        assert attn_metadata.num_accepted_tokens.tolist() == [4]
-    else:
-        assert attn_metadata.spec_sequence_masks is None
-        assert attn_metadata.num_accepted_tokens is None
-
-
-def test_full_graph_without_runtime_spec_resets_captured_spec_inputs():
-    capture_common_metadata = create_common_attn_metadata(
-        batch_spec=BatchSpec(
-            seq_lens=[4, 4],
-            query_lens=[4, 4],
-            name="full_graph_spec_capture",
-        ),
-        block_size=16,
-        device=torch.device("cpu"),
-    )
-    capture_common_metadata.num_reqs = 4
-    capture_common_metadata.block_table_tensor = torch.tensor(
-        [[10, 11, 12, 13], [20, 21, 22, 23]],
-        dtype=torch.int32,
-    )
-    builder = _make_builder(
-        device=torch.device("cpu"),
-        num_heads=32,
-        num_speculative_tokens=3,
-        cudagraph_mode=CUDAGraphMode.FULL_DECODE_ONLY,
-    )
-    captured_metadata = builder.build(
-        0,
-        capture_common_metadata,
-        num_accepted_tokens=torch.tensor([2, 4], dtype=torch.int32),
-        num_decode_draft_tokens_cpu=torch.tensor([3, 3], dtype=torch.int32),
-    )
-    captured_spec_metadata = captured_metadata.spec_decode_metadata
-    captured_conv1d_metadata = captured_spec_metadata.spec_causal_conv1d
-
-    assert torch.count_nonzero(captured_conv1d_metadata.query_start_loc) > 0
-    assert torch.count_nonzero(captured_spec_metadata.actual_seq_lengths) > 0
-
-    replay_common_metadata = create_common_attn_metadata(
-        batch_spec=BatchSpec(
-            seq_lens=[1, 1, 0, 0],
-            query_lens=[1, 1, 0, 0],
-            name="full_graph_replay_without_spec",
-        ),
-        block_size=16,
-        device=torch.device("cpu"),
-    )
-    replay_metadata = builder.build(
-        0,
-        replay_common_metadata,
-        num_accepted_tokens=torch.ones(4, dtype=torch.int32),
-        num_decode_draft_tokens_cpu=torch.full((4,), -1, dtype=torch.int32),
-    )
-
-    assert replay_metadata.spec_sequence_masks is None
-    assert replay_metadata.spec_decode_metadata is None
-    assert torch.equal(
-        captured_conv1d_metadata.cache_indices,
-        torch.full((4, 4), PAD_SLOT_ID, dtype=torch.int32),
-    )
-    assert torch.count_nonzero(captured_conv1d_metadata.query_start_loc) == 0
-    assert torch.count_nonzero(captured_conv1d_metadata.num_accepted_tokens) == 0
-    assert torch.count_nonzero(captured_spec_metadata.actual_seq_lengths) == 0
-
-
-def test_full_graph_idle_dummy_uses_zero_length_recurrent_metadata():
-    common_attn_metadata = create_common_attn_metadata(
-        batch_spec=BatchSpec(
-            seq_lens=[8, 8, 8, 8],
-            query_lens=[0, 0, 0, 0],
-            name="full_graph_idle_dummy",
-        ),
-        block_size=16,
-        device=torch.device("cpu"),
-    )
-    common_attn_metadata.block_table_tensor[:, 0] = torch.tensor(
-        [10, 11, 98, 99],
-        dtype=torch.int32,
-    )
-    builder = _make_builder(
-        device=torch.device("cpu"),
-        num_heads=32,
-        num_speculative_tokens=3,
-        cudagraph_mode=CUDAGraphMode.FULL_DECODE_ONLY,
-    )
-    builder.spec_state_indices_tensor.fill_(77)
-    builder.spec_query_start_loc.fill_(77)
-    builder.non_spec_state_indices_tensor.fill_(77)
-    builder.non_spec_query_start_loc.fill_(77)
-
-    attn_metadata = builder.build(0, common_attn_metadata)
-
-    assert attn_metadata.num_actual_tokens == 0
-    assert attn_metadata.num_decode_tokens == 0
-    assert torch.count_nonzero(attn_metadata.non_spec_query_start_loc) == 0
-    assert torch.all(attn_metadata.non_spec_state_indices_tensor == NULL_BLOCK_ID)
-    assert torch.count_nonzero(builder.spec_query_start_loc[:5]) == 0
-    assert torch.all(builder.spec_state_indices_tensor[:4] == PAD_SLOT_ID)
-
-
-@pytest.mark.parametrize(
-    ("num_speculative_tokens", "num_decode_draft_tokens_cpu"),
-    [
-        pytest.param(0, None, id="without_spec_decode"),
-        pytest.param(
-            3,
-            torch.full((4,), -1, dtype=torch.int32),
-            id="spec_decode_without_runtime_spec_requests",
-        ),
-    ],
-)
-def test_full_graph_non_spec_metadata_nulls_padded_state_indices(
-    num_speculative_tokens: int,
-    num_decode_draft_tokens_cpu: torch.Tensor | None,
-):
-    common_attn_metadata = create_common_attn_metadata(
-        batch_spec=BatchSpec(
-            seq_lens=[1, 1, 0, 0],
-            query_lens=[1, 1, 0, 0],
-            name="full_graph_padded_non_spec_actual_seq_lengths",
-        ),
-        block_size=16,
-        device=torch.device("cpu"),
-    )
-    common_attn_metadata.block_table_tensor[:, 0] = torch.tensor([10, 11, 98, 99])
-    builder = _make_builder(
-        device=torch.device("cpu"),
-        num_heads=32,
-        num_speculative_tokens=num_speculative_tokens,
-        cudagraph_mode=CUDAGraphMode.FULL_DECODE_ONLY,
-    )
-    builder.non_spec_state_indices_tensor.fill_(77)
-    builder.non_spec_query_start_loc.fill_(77)
-    builder.non_spec_actual_seq_lengths.fill_(77)
-
-    attn_metadata = builder.build(
-        0,
-        common_attn_metadata,
-        num_decode_draft_tokens_cpu=num_decode_draft_tokens_cpu,
-    )
-
-    assert attn_metadata.num_decodes == 4
-    assert attn_metadata.num_decode_tokens == 2
-    assert torch.equal(
-        attn_metadata.non_spec_query_start_loc,
-        torch.tensor([0, 1, 2, 2, 2], dtype=torch.int32),
-    )
-    assert torch.equal(
-        attn_metadata.non_spec_state_indices_tensor,
-        torch.tensor(
-            [10, 11, NULL_BLOCK_ID, NULL_BLOCK_ID],
-            dtype=torch.int32,
-        ),
-    )
-    decode_metadata = attn_metadata.non_spec_decode_metadata
-    conv1d_metadata = decode_metadata.causal_conv1d
-    assert conv1d_metadata.query_start_loc.data_ptr() == attn_metadata.non_spec_query_start_loc.data_ptr()
-    assert conv1d_metadata.cache_indices.data_ptr() == attn_metadata.non_spec_state_indices_tensor.data_ptr()
-    assert decode_metadata.actual_seq_lengths.data_ptr() == builder.non_spec_actual_seq_lengths.data_ptr()
-    assert torch.equal(
-        decode_metadata.actual_seq_lengths,
-        torch.tensor([0, 1, 1, 0, 0], dtype=torch.int32),
-    )

--- a/tests/ut/ops/test_gdn_layerwise_kv.py
+++ b/tests/ut/ops/test_gdn_layerwise_kv.py
@@ -113,7 +113,6 @@ def _make_prefill_metadata(device: torch.device | str = "cpu") -> GDNAttentionMe
     # These fields are constructor arguments only in newer vLLM releases.
     # Assigning them after construction also supports the older metadata class
     # while exercising the same production GDN prefill path.
-    metadata.prefill_query_start_loc = torch.tensor([0, 2], dtype=torch.int32, device=device)
     metadata.prefill_state_indices = torch.tensor([0], dtype=torch.int64, device=device)
     metadata.prefill_has_initial_state = torch.tensor([True], device=device)
     metadata.non_spec_prefill_metadata = GDNPrefillMetadata(
@@ -122,7 +121,8 @@ def _make_prefill_metadata(device: torch.device | str = "cpu") -> GDNAttentionMe
             cache_indices=torch.tensor([0], dtype=torch.int32, device=device),
             initial_state_mode=torch.tensor([1], dtype=torch.int32, device=device),
         ),
-        chunk=Mock(),
+        actual_seq_lengths=torch.tensor([2], dtype=torch.int32, device=device),
+        non_empty_indices=None,
     )
     return metadata
 
@@ -157,9 +157,8 @@ def test_connector_observes_updated_gdn_state_for_each_compiled_call():
         output_tensor.copy_(mixed_qkv)
         model.kv_cache[0].add_(1)
 
-    def chunk_attention(**kwargs):
-        initial_state = kwargs["initial_state"]
-        value = kwargs["v"]
+    def chunk_attention(query, key, value, beta, initial_state, actual_seq_lengths, g, scale):
+        del query, key, beta, actual_seq_lengths, g, scale
         return value + 1, initial_state + 1
 
     gating = (
@@ -173,7 +172,12 @@ def test_connector_observes_updated_gdn_state_for_each_compiled_call():
         patch("vllm_ascend.ops.gdn.get_pcp_group", return_value=SimpleNamespace(world_size=1)),
         patch("vllm_ascend.ops.gdn.DeviceOperator.fused_gdn_gating", return_value=gating),
         patch("vllm_ascend.ops.gdn.clear_ssm_states"),
-        patch("vllm_ascend.ops.gdn.chunk_gated_delta_rule", side_effect=chunk_attention),
+        patch.object(
+            torch.ops._C_ascend,
+            "npu_chunk_gated_delta_rule",
+            side_effect=chunk_attention,
+            create=True,
+        ),
         patch.object(
             torch.ops._C_ascend,
             "npu_causal_conv1d_custom",
@@ -199,3 +203,69 @@ def test_connector_observes_updated_gdn_state_for_each_compiled_call():
     for execution, (conv_state, ssm_state) in enumerate(observed_states, start=1):
         torch.testing.assert_close(conv_state, torch.full_like(conv_state, execution))
         torch.testing.assert_close(ssm_state, torch.full_like(ssm_state, execution))
+
+
+def test_gdn_prefill_preserves_empty_sequence_states():
+    model = _GDNForwardWrapper()
+    model.ssm_state = torch.zeros(2, 1, 2, 2)
+    metadata = _make_prefill_metadata()
+    metadata.non_spec_state_indices_tensor = torch.tensor([0, 1], dtype=torch.int32)
+    metadata.prefill_state_indices = torch.tensor([0, 1], dtype=torch.int64)
+    metadata.prefill_has_initial_state = torch.tensor([True, True])
+    metadata.non_spec_prefill_metadata = GDNPrefillMetadata(
+        causal_conv1d=GDNCausalConv1dMetadata(
+            query_start_loc=torch.tensor([0, 2, 2], dtype=torch.int32),
+            cache_indices=torch.tensor([0, 1], dtype=torch.int32),
+            initial_state_mode=torch.tensor([1, 1], dtype=torch.int32),
+        ),
+        actual_seq_lengths=torch.tensor([2, 0], dtype=torch.int32),
+        non_empty_indices=torch.tensor([0], dtype=torch.int64),
+    )
+    forward_context = ForwardContext(
+        no_compile_layers={model.prefix: model},
+        attn_metadata={model.prefix: metadata},
+        slot_mapping={},
+    )
+
+    def causal_conv1d(output_tensor, mixed_qkv, conv_weights, **kwargs):
+        del conv_weights, kwargs
+        output_tensor.copy_(mixed_qkv)
+
+    def chunk_attention(query, key, value, beta, initial_state, actual_seq_lengths, g, scale):
+        del query, key, beta, g, scale
+        assert torch.equal(actual_seq_lengths, torch.tensor([2], dtype=torch.int32))
+        assert initial_state.shape[0] == 1
+        return value + 1, torch.full_like(initial_state, 7)
+
+    with (
+        override_forward_context(forward_context),
+        patch("vllm_ascend.ops.gdn.get_pcp_group", return_value=SimpleNamespace(world_size=1)),
+        patch(
+            "vllm_ascend.ops.gdn.DeviceOperator.fused_gdn_gating",
+            return_value=(torch.zeros(1, 2, 1), torch.zeros(1, 2, 1)),
+        ),
+        patch("vllm_ascend.ops.gdn.l2norm_fwd", side_effect=lambda tensor: tensor),
+        patch("vllm_ascend.ops.gdn.clear_ssm_states"),
+        patch("vllm_ascend.ops.gdn.maybe_save_kv_layer_to_connector"),
+        patch.object(
+            torch.ops._C_ascend,
+            "npu_causal_conv1d_custom",
+            side_effect=causal_conv1d,
+            create=True,
+        ),
+        patch.object(
+            torch.ops._C_ascend,
+            "npu_chunk_gated_delta_rule",
+            side_effect=chunk_attention,
+            create=True,
+        ),
+    ):
+        model._forward_core(
+            torch.ones(2, 2),
+            torch.zeros(2, 1),
+            torch.zeros(2, 1),
+            torch.empty(2, 1, 2),
+        )
+
+    torch.testing.assert_close(model.ssm_state[0], torch.full_like(model.ssm_state[0], 7))
+    torch.testing.assert_close(model.ssm_state[1], torch.zeros_like(model.ssm_state[1]))

--- a/vllm_ascend/ops/gdn.py
+++ b/vllm_ascend/ops/gdn.py
@@ -16,7 +16,6 @@
 #
 
 import torch
-import torch_npu
 from einops import rearrange
 from vllm.distributed import get_pcp_group
 from vllm.forward_context import get_forward_context
@@ -28,129 +27,15 @@ from vllm.v1.attention.backend import AttentionBackend, AttentionMetadata  # typ
 from vllm.v1.attention.backends.gdn_attn import GDNAttentionMetadata
 from vllm.v1.attention.backends.utils import PAD_SLOT_ID
 
-from vllm_ascend.attention.utils import (
-    maybe_save_kv_layer_to_connector,
-    wait_for_kv_layer_from_connector,
-)
+from vllm_ascend.attention.utils import maybe_save_kv_layer_to_connector
 from vllm_ascend.device.device_op import DeviceOperator
-from vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.attention_fence import record_attention_compute_start
 from vllm_ascend.ops.gdn_attn_builder import AscendGDNAttentionBackend
-from vllm_ascend.ops.triton.fla.chunk import chunk_gated_delta_rule
 from vllm_ascend.ops.triton.fla.fused_qkvzba_split_reshape import fused_qkvzba_split_reshape_cat
 from vllm_ascend.ops.triton.fla.utils import clear_ssm_states
 from vllm_ascend.ops.triton.mamba.causal_conv1d import extract_last_width
 
 
 class AscendGatedDeltaNetAttention(GatedDeltaNetAttention):
-    # Cached fused-op availability probe result, shared across all layers so the
-    # smoke call runs at most once per process.
-    _fused_chunk_available: bool | None = None
-
-    @classmethod
-    def _probe_fused_chunk(cls) -> bool:
-        """Whether ``torch_npu.npu_chunk_gated_delta_rule`` can actually be used.
-
-        The interface must exist AND a minimal smoke call must succeed (the op is
-        unavailable on some CANN builds / devices). Any failure disables the
-        fused path so we fall back to the Triton pipeline. The result is cached
-        on the class, so only the first layer runs the smoke call.
-        """
-        if cls._fused_chunk_available is not None:
-            return cls._fused_chunk_available
-
-        if not hasattr(torch_npu, "npu_chunk_gated_delta_rule"):
-            cls._fused_chunk_available = False
-            return False
-
-        # TODO(2026/8/6): The A5‑specific implementation is not available in the official release.
-        # Invoking npu_chunk_gated_delta_rule will result in errors.
-        # Remove this conditional block after the new A5 CANN package is released.
-        try:
-            # Minimal smoke call matching the op constraints (Dk == Dv == 128,
-            # Nv % Nk == 0). B=1, one short sequence.
-            device = torch.npu.current_device()
-            dk = dv = 128
-            nk, nv, seqlen = 1, 1, 64
-            q = torch.zeros((seqlen, nk, dk), dtype=torch.bfloat16, device=device)
-            k = torch.zeros((seqlen, nk, dk), dtype=torch.bfloat16, device=device)
-            v = torch.zeros((seqlen, nv, dv), dtype=torch.bfloat16, device=device)
-            beta = torch.full((seqlen, nv), 0.5, dtype=torch.bfloat16, device=device)
-            g = torch.full((seqlen, nv), -0.1, dtype=torch.float32, device=device)
-            initial_state = torch.zeros((1, nv, dv, dk), dtype=torch.bfloat16, device=device)
-            actual_seq_lengths = torch.tensor([seqlen], dtype=torch.int32, device=device)
-            torch_npu.npu_chunk_gated_delta_rule(
-                q,
-                k,
-                v,
-                beta=beta,
-                initial_state=initial_state,
-                actual_seq_lengths=actual_seq_lengths,
-                scale=dk**-0.5,
-                g=g,
-            )
-            torch.npu.synchronize()
-            cls._fused_chunk_available = True
-        except Exception:
-            cls._fused_chunk_available = False
-        return cls._fused_chunk_available
-
-    @staticmethod
-    def _chunk_gated_delta_rule_fused(
-        q: torch.Tensor,
-        k: torch.Tensor,
-        v: torch.Tensor,
-        g: torch.Tensor,
-        beta: torch.Tensor,
-        initial_state: torch.Tensor,
-        cu_seqlens: torch.Tensor,
-        scale: float,
-    ) -> tuple[torch.Tensor, torch.Tensor]:
-        """Fused prefill path using ``torch_npu.npu_chunk_gated_delta_rule``.
-
-        Drop-in replacement for the Triton ``chunk_gated_delta_rule`` pipeline
-        (chunk_scaled_dot_kkt_fwd + solve_tril + recompute_w_u_fwd + ...).
-        The fused CANN operator expects TND layout and does NOT apply q/k L2 norm
-        or the chunk-local cumsum of ``g`` internally, so q/k are normalized here
-        and the raw ``g`` is passed through.
-
-        Args:
-            q, k: ``[1, T, Nk, Dk]``   v: ``[1, T, Nv, Dv]``
-            g, beta: ``[1, T, Nv]``    g is fp32 (<=0), beta is (0, 1).
-            initial_state: ``[N, Nv, Dv, Dk]`` — same layout as ``ssm_state``,
-                no transpose required.
-            cu_seqlens: cumulative prefill query start locations ``[N+1]``.
-            scale: query scaling factor (``Dk ** -0.5``).
-
-        Returns:
-            o: ``[1, T, Nv, Dv]`` and final_state: ``[N, Nv, Dv, Dk]``.
-        """
-        # TND layout: drop the leading batch dim (batch size is always 1 here).
-        q = l2norm_fwd(q).squeeze(0).contiguous()  # [T, Nk, Dk]
-        k = l2norm_fwd(k).squeeze(0).contiguous()  # [T, Nk, Dk]
-        v = v.squeeze(0).contiguous()  # [T, Nv, Dv]
-        g = g.squeeze(0).to(torch.float32).contiguous()  # [T, Nv]
-        beta = beta.squeeze(0).to(v.dtype).contiguous()  # [T, Nv]
-
-        # The fused op only supports a bfloat16 initial_state, while ssm_state may
-        # be float32 (the recurrent path keeps fp32 state). Cast to bf16 here.
-        initial_state = initial_state.to(torch.bfloat16).contiguous()
-
-        # actual_seq_lengths is per-batch sequence length [N] (per the interface
-        # doc), derived from the cumulative query_start_loc.
-        actual_seq_lengths = torch.diff(cu_seqlens).to(torch.int32)
-
-        o, final_state = torch_npu.npu_chunk_gated_delta_rule(
-            q,
-            k,
-            v,
-            beta=beta,
-            initial_state=initial_state,
-            actual_seq_lengths=actual_seq_lengths,
-            scale=scale,
-            g=g,
-        )
-        return o.unsqueeze(0), final_state
-
     def _split_ba_for_tp(self, ba: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
         if hasattr(self, "split_ba"):
             return self.split_ba(ba)
@@ -276,14 +161,6 @@ class AscendGatedDeltaNetAttention(GatedDeltaNetAttention):
         if attn_metadata is None:
             # V1 profile run
             return
-
-        # Layerwise KV pool hooks must stay inside the custom op body: the
-        # forward() caller region is traced by Dynamo in fullgraph mode, and
-        # these side effects (thread locks, connector waits) would break the
-        # graph. Waiting here still orders the deferred mamba state copy and
-        # the layer load before conv/attention kernels touch mamba state.
-        wait_for_kv_layer_from_connector(self.prefix)
-        record_attention_compute_start()
 
         assert isinstance(attn_metadata, dict)
         attn_metadata = attn_metadata[self.prefix]
@@ -506,10 +383,10 @@ class AscendGatedDeltaNetAttention(GatedDeltaNetAttention):
 
         # 2.3: Process the remaining part
         if attn_metadata.num_prefills > 0:
-            prefill_query_start_loc = attn_metadata.prefill_query_start_loc
+            prefill_metadata = attn_metadata.non_spec_prefill_metadata
             prefill_state_indices = attn_metadata.prefill_state_indices
             prefill_has_initial_state = attn_metadata.prefill_has_initial_state
-            assert prefill_query_start_loc is not None
+            assert prefill_metadata is not None
             assert prefill_state_indices is not None
             assert prefill_has_initial_state is not None
             assert g_non_spec is not None
@@ -521,48 +398,56 @@ class AscendGatedDeltaNetAttention(GatedDeltaNetAttention):
                 g_non_spec = g_non_spec[:, num_decode_tokens:]
                 beta_non_spec = beta_non_spec[:, num_decode_tokens:]
 
-            # Use the fused CANN operator when available (probed once, cached on
-            # the class) and applicable. It only supports the non-PCP case; fall
-            # back to the Triton pipeline under PCP or if the op is unavailable.
-            use_fused_chunk = AscendGatedDeltaNetAttention._probe_fused_chunk() and get_pcp_group().world_size == 1
-            if use_fused_chunk:
-                # The fused op's state layout [N, Nv, Dv, Dk] matches ssm_state
-                # directly, so no transpose is needed. Advanced indexing already
-                # returns a copy, safe to clear in place.
-                initial_state = ssm_state[prefill_state_indices]
-                clear_ssm_states(initial_state, prefill_has_initial_state)
-                core_attn_out_non_spec, last_recurrent_state = (
-                    AscendGatedDeltaNetAttention._chunk_gated_delta_rule_fused(
-                        q=query_non_spec,
-                        k=key_non_spec,
-                        v=value_non_spec,
-                        g=g_non_spec,
-                        beta=beta_non_spec,
-                        initial_state=initial_state,
-                        cu_seqlens=prefill_query_start_loc,
-                        scale=key_non_spec.shape[-1] ** -0.5,
-                    )
-                )
-                ssm_state[prefill_state_indices] = last_recurrent_state.to(ssm_state.dtype)
+            # aclnn chunk op expects initial_state in (B, Nv, Dv, Dk) layout,
+            # which is exactly ssm_state's native (Nv, Dv, Dk)-per-seq layout
+            # (see MambaStateShapeCalculator.gated_delta_net_state_shape).
+            # Unlike the prior triton path (whose fwd_h sub-op used (B, Nv, Dk,
+            # Dv) and so required a transpose), NO transpose is needed here.
+            initial_state_full = ssm_state[prefill_state_indices].contiguous()
+            clear_ssm_states(initial_state_full, prefill_has_initial_state)
+
+            # q/k/v/g/beta are [1, T, H, *] (head_first=False, batch is flat B=1
+            # over the concatenated prefill tokens). The aclnn chunk_gated_delta
+            # rule op requires TND layout, so drop the leading batch dim.
+            # Note: this op does NOT l2-normalize q/k internally (the prior
+            # triton entry did via use_qk_l2norm_in_kernel=True), so do it here.
+            q_tnd = l2norm_fwd(query_non_spec.squeeze(0))  # (T, Nk, Dk)
+            k_tnd = l2norm_fwd(key_non_spec.squeeze(0))  # (T, Nk, Dk)
+            v_tnd = value_non_spec.squeeze(0)  # (T, Nv, Dv)
+            beta_tnd = beta_non_spec.squeeze(0)  # (T, Nv)
+            g_tnd = g_non_spec.squeeze(0)  # (T, Nv), fp32 log-gate
+
+            actual_seq_lengths = prefill_metadata.actual_seq_lengths
+            non_empty_indices = prefill_metadata.non_empty_indices
+            if non_empty_indices is None:
+                initial_state = initial_state_full
             else:
-                initial_state = ssm_state[prefill_state_indices].transpose(-1, -2).contiguous()
-                clear_ssm_states(initial_state, prefill_has_initial_state)
-                (core_attn_out_non_spec, last_recurrent_state) = chunk_gated_delta_rule(
-                    q=query_non_spec,
-                    k=key_non_spec,
-                    v=value_non_spec,
-                    g=g_non_spec,
-                    beta=beta_non_spec,
-                    initial_state=initial_state,
-                    output_final_state=True,
-                    cu_seqlens=prefill_query_start_loc,
-                    prebuilt_meta=attn_metadata.non_spec_prefill_metadata.chunk,
-                    head_first=False,
-                    use_qk_l2norm_in_kernel=True,
-                )
-                ssm_state[prefill_state_indices] = (
-                    last_recurrent_state.transpose(-1, -2).contiguous().to(ssm_state.dtype)
-                )
+                initial_state = initial_state_full.index_select(0, non_empty_indices)
+                actual_seq_lengths = actual_seq_lengths.index_select(0, non_empty_indices)
+
+            scale = q_tnd.shape[-1] ** -0.5
+            core_attn_out_non_spec, last_recurrent_state = torch.ops._C_ascend.npu_chunk_gated_delta_rule(
+                q_tnd,
+                k_tnd,
+                v_tnd,
+                beta_tnd,
+                initial_state,
+                actual_seq_lengths,
+                g_tnd,
+                scale,
+            )
+
+            # Op returns out=(T, Nv, Dv) bf16; restore the batch dim -> [1, T, Nv, Dv].
+            core_attn_out_non_spec = core_attn_out_non_spec.unsqueeze(0)
+            if non_empty_indices is not None:
+                initial_state_full.index_copy_(0, non_empty_indices, last_recurrent_state)
+                last_recurrent_state = initial_state_full
+
+            # final_state=(B, Nv, Dv, Dk), already matching ssm_state's native
+            # layout (no transpose needed, unlike the prior triton path).
+            # .contiguous() is a no-op here (the op returns an at::empty tensor,
+            # always contiguous) but kept for symmetry/defensiveness.
+            ssm_state[prefill_state_indices] = last_recurrent_state.contiguous().to(ssm_state.dtype)
             if split_non_spec:
                 core_attn_out_non_spec = torch.cat(
                     [core_attn_out_decode, core_attn_out_non_spec],

--- a/vllm_ascend/ops/gdn_attn_builder.py
+++ b/vllm_ascend/ops/gdn_attn_builder.py
@@ -27,23 +27,10 @@ from vllm.v1.attention.backends.gdn_attn import (
 from vllm.v1.attention.backends.utils import (
     NULL_BLOCK_ID,
     PAD_SLOT_ID,
-    compute_causal_conv1d_metadata,
     mamba_get_block_table_tensor,
     split_decodes_and_prefills,
 )
 from vllm.v1.kv_cache_interface import AttentionSpec
-
-from vllm_ascend.ops.triton.fla.utils import (
-    prepare_chunk_indices,
-    prepare_chunk_offsets,
-    prepare_final_chunk_indices,
-    prepare_update_chunk_offsets,
-)
-
-_GDN_CHUNK_SIZE = 64
-# Keep this aligned with solve_tril.LARGE_BLOCK_T in ops/triton/fla/solve_tril.py.
-_GDN_SOLVE_TRIL_LARGE_BLOCK_SIZE = 608 * 2
-_GDN_CUMSUM_WORKING_SET = 2**18
 
 
 def _stable_argsort_for_npu(tensor: torch.Tensor) -> torch.Tensor:
@@ -58,7 +45,7 @@ def _treat_single_token_prefills_with_state_as_decodes(
     """Use decode metadata for one-token stateful prompt chunks.
 
     A final one-token prompt chunk can replay the same fixed graph as an
-    ordinary decode. Once recurrent state exists, both paths must construct
+    ordinary decode.  Once recurrent state exists, both paths must construct
     identical GDN metadata so the graph consumes the current state indices.
     First-token prefills remain on the prefill path because they have no state
     to update.
@@ -79,21 +66,6 @@ def _treat_single_token_prefills_with_state_as_decodes(
 
 
 @dataclass
-class GDNChunkedPrefillMetadata:
-    cu_seqlens_host: tuple[int, ...]
-    chunk_indices_chunk64_host: tuple[int, ...]
-    chunk_indices_chunk64: torch.Tensor
-    chunk_offsets_chunk64: torch.Tensor
-    update_chunk_offsets_chunk64: torch.Tensor
-    final_chunk_indices_chunk64: torch.Tensor
-    chunk_indices_large_block: torch.Tensor
-    block_indices_cumsum: torch.Tensor
-    num_decodes: int = 0
-    cu_seqlens_kern: tuple[int, ...] | None = None
-    keep_meta: torch.Tensor | None = None
-
-
-@dataclass
 class GDNCausalConv1dMetadata:
     query_start_loc: torch.Tensor
     cache_indices: torch.Tensor
@@ -110,7 +82,8 @@ class GDNSpecCausalConv1dMetadata:
 @dataclass
 class GDNPrefillMetadata:
     causal_conv1d: GDNCausalConv1dMetadata
-    chunk: GDNChunkedPrefillMetadata
+    actual_seq_lengths: torch.Tensor
+    non_empty_indices: torch.Tensor | None
 
 
 @dataclass
@@ -142,82 +115,6 @@ def _build_actual_seq_lengths(
     return actual_seq_lengths
 
 
-def _compact_empty_segments(cu_seqlens_host, initial_state, device=None):
-    """Drop zero-length segments so AscendC fwd_h/fwd_o indexing lines up.
-
-    Returns ``(cu_seqlens_kern, initial_state_kern, keep_meta)``:
-    cu_seqlens / initial_state with empty segments removed, plus a bool
-    mask (None when nothing was removed).  The compacted ``final_state``
-    must be scattered back via ``keep_meta`` (empty segments keep their
-    initial state).
-
-    When *device* is given, ``keep_meta`` is moved to that device so that
-    callers can index NPU tensors without an extra host→device sync.
-    """
-    if cu_seqlens_host is None:
-        return None, initial_state, None
-    cu = torch.tensor(cu_seqlens_host, dtype=torch.int64)
-    keep = (cu[1:] - cu[:-1]) > 0
-    if bool(keep.all()):
-        return cu_seqlens_host, initial_state, None
-    # Compute compact cu_seqlens while keep is still on CPU (cu is CPU-only).
-    cu_kern = torch.cat([cu[:1], cu[1:][keep]]).tolist()
-    # Move keep to device only for indexing device-side tensors.
-    if device is not None:
-        keep = keep.to(device)
-    st_kern = initial_state[keep] if initial_state is not None else None
-    return cu_kern, st_kern, keep
-
-
-def _build_non_spec_chunked_prefill_metadata(
-    builder,
-    cu_seqlens_cpu: torch.Tensor,
-    device: torch.device,
-) -> GDNChunkedPrefillMetadata:
-    hf_text_config = getattr(builder.vllm_config.model_config, "hf_text_config", None)
-    linear_attn_config = getattr(hf_text_config, "linear_attn_config", None)
-    if isinstance(linear_attn_config, dict) and linear_attn_config.get("num_heads") is not None:
-        gdn_num_heads = linear_attn_config["num_heads"] // builder.vllm_config.parallel_config.tensor_parallel_size
-    elif hf_text_config is not None and hasattr(hf_text_config, "linear_num_value_heads"):
-        gdn_num_heads = (
-            hf_text_config.linear_num_value_heads // builder.vllm_config.parallel_config.tensor_parallel_size
-        )
-    else:
-        gdn_num_heads = builder.vllm_config.model_config.get_num_attention_heads(builder.vllm_config.parallel_config)
-    cumsum_chunks = max(1, _GDN_CUMSUM_WORKING_SET // (gdn_num_heads * _GDN_CHUNK_SIZE))
-    cumsum_chunk_size = 1 if cumsum_chunks <= 1 else 1 << (cumsum_chunks - 1).bit_length()
-
-    chunk_indices_chunk64 = prepare_chunk_indices(cu_seqlens_cpu, _GDN_CHUNK_SIZE)
-    chunk_offsets_chunk64 = prepare_chunk_offsets(cu_seqlens_cpu, _GDN_CHUNK_SIZE)
-    update_chunk_offsets_chunk64 = prepare_update_chunk_offsets(cu_seqlens_cpu, _GDN_CHUNK_SIZE)
-    final_chunk_indices_chunk64 = prepare_final_chunk_indices(cu_seqlens_cpu, _GDN_CHUNK_SIZE)
-    chunk_indices_large_block = prepare_chunk_indices(
-        cu_seqlens_cpu,
-        _GDN_SOLVE_TRIL_LARGE_BLOCK_SIZE,
-    )
-    block_indices_cumsum = prepare_chunk_indices(cu_seqlens_cpu, cumsum_chunk_size)
-
-    cu_seqlens_host = tuple(cu_seqlens_cpu.to(torch.int64).reshape(-1).tolist())
-    # Pre-compute compact cu_seqlens for AscendC kernels so each layer
-    # can reuse them instead of calling _compact_empty_segments again.
-    cu_seqlens_kern, _, keep_meta = _compact_empty_segments(cu_seqlens_host, None, device=device)
-    if keep_meta is None:
-        cu_seqlens_kern = None
-    else:
-        cu_seqlens_kern = tuple(cu_seqlens_kern)
-
-    return GDNChunkedPrefillMetadata(
-        cu_seqlens_host=cu_seqlens_host,
-        chunk_indices_chunk64_host=tuple(chunk_indices_chunk64.to(torch.int64).reshape(-1).tolist()),
-        chunk_indices_chunk64=chunk_indices_chunk64.to(device=device, non_blocking=True),
-        chunk_offsets_chunk64=chunk_offsets_chunk64.to(device=device, non_blocking=True),
-        update_chunk_offsets_chunk64=update_chunk_offsets_chunk64.to(device=device, non_blocking=True),
-        final_chunk_indices_chunk64=final_chunk_indices_chunk64.to(device=device, non_blocking=True),
-        chunk_indices_large_block=chunk_indices_large_block.to(device=device, non_blocking=True),
-        block_indices_cumsum=block_indices_cumsum.to(device=device, non_blocking=True),
-        cu_seqlens_kern=cu_seqlens_kern,
-        keep_meta=keep_meta,
-    )
 
 
 class AscendGDNAttentionMetadataBuilder(GDNAttentionMetadataBuilder):
@@ -335,7 +232,14 @@ class AscendGDNAttentionMetadataBuilder(GDNAttentionMetadataBuilder):
         num_decode_tokens: int,
         graph_batch_size: int,
     ) -> tuple[torch.Tensor, torch.Tensor]:
-        """Refresh fixed buffers consumed by a non-spec decode graph."""
+        """Refresh fixed buffers consumed by a non-spec decode graph.
+
+        ``num_decodes`` includes graph padding rows, while each real non-spec
+        decode contributes exactly one token.  Therefore
+        ``num_decode_tokens`` is the number of live rows to copy.  All other
+        state rows must be null and their repeated terminal offsets must
+        describe zero-length sequences.
+        """
         assert num_decode_tokens <= graph_batch_size
 
         padded_state_indices = self.non_spec_state_indices_tensor[:graph_batch_size]
@@ -369,8 +273,9 @@ class AscendGDNAttentionMetadataBuilder(GDNAttentionMetadataBuilder):
     def _attach_non_spec_prefill_metadata(
         self,
         attn_metadata: GDNAttentionMetadata,
-        chunk_metadata: GDNChunkedPrefillMetadata | None,
         non_spec_cache_indices: torch.Tensor | None,
+        prefill_actual_seq_lengths: torch.Tensor | None,
+        prefill_non_empty_indices: torch.Tensor | None,
     ) -> GDNAttentionMetadata:
         attn_metadata.non_spec_prefill_metadata = None
         if attn_metadata.num_prefills <= 0:
@@ -378,10 +283,8 @@ class AscendGDNAttentionMetadataBuilder(GDNAttentionMetadataBuilder):
 
         if attn_metadata.non_spec_query_start_loc is None:
             raise RuntimeError("Expected attn_metadata.non_spec_query_start_loc for Ascend GDN non-spec prefill path.")
-        if attn_metadata.prefill_query_start_loc is None:
-            raise RuntimeError("Expected attn_metadata.prefill_query_start_loc for Ascend GDN non-spec prefill path.")
-        if chunk_metadata is None:
-            raise RuntimeError("Expected chunk metadata for Ascend GDN non-spec prefill path.")
+        if prefill_actual_seq_lengths is None:
+            raise RuntimeError("Expected actual sequence lengths for Ascend GDN non-spec prefill path.")
 
         initial_state_mode = attn_metadata.has_initial_state
         if non_spec_cache_indices is None:
@@ -399,7 +302,8 @@ class AscendGDNAttentionMetadataBuilder(GDNAttentionMetadataBuilder):
                 cache_indices=non_spec_cache_indices[:prefill_num_rows],
                 initial_state_mode=initial_state_mode,
             ),
-            chunk=chunk_metadata,
+            actual_seq_lengths=prefill_actual_seq_lengths,
+            non_empty_indices=prefill_non_empty_indices,
         )
         return attn_metadata
 
@@ -480,12 +384,21 @@ class AscendGDNAttentionMetadataBuilder(GDNAttentionMetadataBuilder):
         spec_sequence_masks_cpu: torch.Tensor,
         num_accepted_tokens: torch.Tensor | None,
     ) -> tuple[torch.Tensor, torch.Tensor | None]:
-        """Advance stateful spec-width prompt chunks through live spec inputs."""
+        """Advance stateful spec-width prompt chunks through live spec inputs.
+
+        A stateful prompt chunk of exactly ``num_spec + 1`` tokens is
+        shape-identical to a speculative decode row and can replay that graph.
+        Mark it speculative and accept the complete chunk so conv1d and
+        recurrent state advance over every token.  First prompt chunks stay on
+        the prefill path because they have no prior state.
+        """
         is_prefilling = common_attn_metadata.is_prefilling
         seq_lens_cpu = common_attn_metadata.seq_lens_cpu_upper_bound
         if is_prefilling is None or seq_lens_cpu is None or num_accepted_tokens is None:
             return spec_sequence_masks_cpu, num_accepted_tokens
 
+        # Common metadata tensors can include graph padding; only leading rows
+        # correspond to requests represented by the runtime spec mask.
         num_reqs = min(
             spec_sequence_masks_cpu.numel(),
             is_prefilling.numel(),
@@ -522,8 +435,9 @@ class AscendGDNAttentionMetadataBuilder(GDNAttentionMetadataBuilder):
 
         query_start_loc = m.query_start_loc
         query_start_loc_cpu = m.query_start_loc_cpu
+        query_lens = query_start_loc[1:] - query_start_loc[:-1]
+        query_lens_cpu = query_start_loc_cpu[1:] - query_start_loc_cpu[:-1]
         context_lens_tensor = m.compute_num_computed_tokens()
-        nums_dict, batch_ptr, token_chunk_offset_ptr = None, None, None
         block_table_tensor = mamba_get_block_table_tensor(
             m.block_table_tensor,
             m.seq_lens,
@@ -541,18 +455,11 @@ class AscendGDNAttentionMetadataBuilder(GDNAttentionMetadataBuilder):
         else:
             num_reqs = num_decode_draft_tokens_cpu.numel()
             spec_sequence_masks_cpu = self.spec_sequence_masks_cpu[:num_reqs]
-            runtime_draft_tokens = num_decode_draft_tokens_cpu[num_decode_draft_tokens_cpu >= 0]
-            if runtime_draft_tokens.sum().item() > 0:
-                torch.ge(
-                    num_decode_draft_tokens_cpu,
-                    0,
-                    out=spec_sequence_masks_cpu,
-                )
-            else:
-                # Dynamic speculative decoding can be enabled while this batch
-                # carries no draft tokens. Treat it as ordinary decode unless a
-                # stateful spec-width prompt chunk must use the spec branch.
-                spec_sequence_masks_cpu.zero_()
+            torch.ge(
+                num_decode_draft_tokens_cpu,
+                0,
+                out=spec_sequence_masks_cpu,
+            )
             spec_sequence_masks_cpu, num_accepted_tokens = self._fold_spec_sized_prefill_chunks_into_spec(
                 m,
                 spec_sequence_masks_cpu,
@@ -584,11 +491,8 @@ class AscendGDNAttentionMetadataBuilder(GDNAttentionMetadataBuilder):
             non_spec_conv1d_cache_indices = block_table_tensor
             spec_query_start_loc = None
             non_spec_query_start_loc = query_start_loc
-            non_spec_query_start_loc_cpu = query_start_loc_cpu
             num_accepted_tokens = None
         else:
-            query_lens = query_start_loc[1:] - query_start_loc[:-1]
-            query_lens_cpu = query_start_loc_cpu[1:] - query_start_loc_cpu[:-1]
             assert spec_sequence_masks_cpu is not None
             assert spec_sequence_indices is not None
             assert non_spec_sequence_indices is not None
@@ -630,7 +534,6 @@ class AscendGDNAttentionMetadataBuilder(GDNAttentionMetadataBuilder):
                 non_spec_state_indices_tensor = None
                 spec_query_start_loc = query_start_loc[: num_spec_decodes + 1]
                 non_spec_query_start_loc = None
-                non_spec_query_start_loc_cpu = None
             else:
                 spec_token_masks = torch.repeat_interleave(
                     spec_sequence_masks,
@@ -684,15 +587,6 @@ class AscendGDNAttentionMetadataBuilder(GDNAttentionMetadataBuilder):
                     dim=0,
                     out=non_spec_query_start_loc[1:],
                 )
-                non_spec_query_start_loc_cpu = torch.zeros(
-                    query_lens_cpu.size(0) - num_spec_decodes + 1,
-                    dtype=torch.int32,
-                )
-                torch.cumsum(
-                    query_lens_cpu[~spec_sequence_masks_cpu],
-                    dim=0,
-                    out=non_spec_query_start_loc_cpu[1:],
-                )
 
             assert num_accepted_tokens is not None
             num_accepted_tokens = torch.index_select(
@@ -701,59 +595,47 @@ class AscendGDNAttentionMetadataBuilder(GDNAttentionMetadataBuilder):
                 spec_sequence_indices,
             )
 
-        # A FULL graph retains captured speculative conv/recurrent tasks. Clear
-        # their stable inputs on every no-spec replay so an idle or prefill
-        # batch cannot mutate state belonging to the preceding request.
+        # A FULL graph may retain a captured speculative conv/recurrent task
+        # even when the current replay contains only non-spec prefill work.
+        # Refresh its stable inputs for every no-spec replay, not only for the
+        # pure non-spec decode branch below. Otherwise a DP idle dummy can
+        # replay the preceding request's state indices and mutate live Mamba
+        # checkpoints after that request has finished.
         if self.use_full_cuda_graph and self.use_spec_decode and num_spec_decodes == 0:
             self._reset_spec_decode_graph_inputs(m.num_reqs)
 
-        chunk_indices: torch.Tensor | None = None
-        chunk_offsets: torch.Tensor | None = None
-        prefill_query_start_loc: torch.Tensor | None = None
-        prefill_query_start_loc_cpu: torch.Tensor | None = None
         prefill_state_indices: torch.Tensor | None = None
         prefill_has_initial_state: torch.Tensor | None = None
-        non_spec_chunked_prefill_metadata: GDNChunkedPrefillMetadata | None = None
+        prefill_actual_seq_lengths: torch.Tensor | None = None
+        prefill_non_empty_indices: torch.Tensor | None = None
         if num_prefills > 0:
             if spec_sequence_masks is None and num_decodes > 0:
-                assert non_spec_query_start_loc is not None
-                assert non_spec_query_start_loc_cpu is not None
                 assert non_spec_state_indices_tensor is not None
-                prefill_query_start_loc = non_spec_query_start_loc[num_decodes:] - num_decode_tokens
-                prefill_query_start_loc_cpu = non_spec_query_start_loc_cpu[num_decodes:] - num_decode_tokens
                 prefill_state_indices = non_spec_state_indices_tensor[num_decodes:]
+                prefill_query_lens_cpu = query_lens_cpu[num_decodes:]
+                prefill_actual_seq_lengths = query_lens[num_decodes:].contiguous()
             else:
-                prefill_query_start_loc = non_spec_query_start_loc
-                prefill_query_start_loc_cpu = non_spec_query_start_loc_cpu
                 prefill_state_indices = non_spec_state_indices_tensor
+                prefill_query_lens_cpu = query_lens_cpu if spec_sequence_masks is None else non_spec_query_lens_cpu
+                prefill_actual_seq_lengths = (
+                    query_lens.contiguous() if spec_sequence_masks is None else non_spec_query_lens.contiguous()
+                )
 
-            assert prefill_query_start_loc_cpu is not None
-            non_spec_chunked_prefill_metadata = _build_non_spec_chunked_prefill_metadata(
-                self,
-                prefill_query_start_loc_cpu,
-                query_start_loc.device,
-            )
-            # Preserve upstream GDNAttentionMetadata fields for callers that
-            # still use the chunk_gated_delta_rule API directly.
-            chunk_indices = non_spec_chunked_prefill_metadata.chunk_indices_chunk64
-            chunk_offsets = non_spec_chunked_prefill_metadata.chunk_offsets_chunk64
+            if bool(torch.any(prefill_query_lens_cpu == 0)):
+                prefill_non_empty_indices = torch.nonzero(
+                    prefill_actual_seq_lengths,
+                    as_tuple=False,
+                ).squeeze(-1)
 
         if num_prefills > 0:
-            (
-                has_initial_state,
-                nums_dict,
-                batch_ptr,
-                token_chunk_offset_ptr,
-            ) = self._build_prefill_has_initial_state_and_causal_conv1d_meta(
-                common_attn_metadata=m,
-                context_lens_tensor=context_lens_tensor,
-                num_prefills=num_prefills,
-                spec_sequence_masks_cpu=spec_sequence_masks_cpu,
-                non_spec_sequence_indices=non_spec_sequence_indices,
-                non_spec_query_start_loc_cpu=non_spec_query_start_loc_cpu,
-                query_start_loc=query_start_loc,
-            )
-            assert has_initial_state is not None
+            has_initial_state = context_lens_tensor > 0
+            if spec_sequence_masks_cpu is not None:
+                assert non_spec_sequence_indices is not None
+                has_initial_state = torch.index_select(
+                    has_initial_state,
+                    0,
+                    non_spec_sequence_indices,
+                )
             if spec_sequence_masks is None and num_decodes > 0:
                 prefill_has_initial_state = has_initial_state[num_decodes:]
             else:
@@ -820,6 +702,9 @@ class AscendGDNAttentionMetadataBuilder(GDNAttentionMetadataBuilder):
                 non_blocking=True,
             )
             num_accepted_tokens = self.num_accepted_tokens[:spec_batch_size]
+            # Zero-length rows are skipped before the recurrent kernel reads
+            # this value. Keep the padding sentinel within the public
+            # accepted-token range [1, query_width].
             num_accepted_tokens[num_spec_decodes:].fill_(1)
 
         if (
@@ -849,9 +734,9 @@ class AscendGDNAttentionMetadataBuilder(GDNAttentionMetadataBuilder):
             num_spec_decode_tokens=num_spec_decode_tokens,
             num_actual_tokens=m.num_actual_tokens,
             has_initial_state=has_initial_state,
-            chunk_indices=chunk_indices,
-            chunk_offsets=chunk_offsets,
-            prefill_query_start_loc=prefill_query_start_loc,
+            chunk_indices=None,
+            chunk_offsets=None,
+            prefill_query_start_loc=None,
             prefill_state_indices=prefill_state_indices,
             prefill_has_initial_state=prefill_has_initial_state,
             spec_query_start_loc=spec_query_start_loc,
@@ -862,14 +747,15 @@ class AscendGDNAttentionMetadataBuilder(GDNAttentionMetadataBuilder):
             spec_token_indx=spec_token_indx,
             non_spec_token_indx=non_spec_token_indx,
             num_accepted_tokens=num_accepted_tokens,
-            nums_dict=nums_dict,
-            batch_ptr=batch_ptr,
-            token_chunk_offset_ptr=token_chunk_offset_ptr,
+            nums_dict=None,
+            batch_ptr=None,
+            token_chunk_offset_ptr=None,
         )
         attn_metadata = self._attach_non_spec_prefill_metadata(
             attn_metadata,
-            non_spec_chunked_prefill_metadata,
             non_spec_conv1d_cache_indices,
+            prefill_actual_seq_lengths,
+            prefill_non_empty_indices,
         )
         attn_metadata = self._attach_spec_decode_metadata(
             attn_metadata,
@@ -877,43 +763,6 @@ class AscendGDNAttentionMetadataBuilder(GDNAttentionMetadataBuilder):
         return self._attach_non_spec_decode_metadata(
             attn_metadata,
             non_spec_conv1d_cache_indices,
-        )
-
-    def _build_prefill_has_initial_state_and_causal_conv1d_meta(
-        self,
-        *,
-        common_attn_metadata: CommonAttentionMetadata,
-        context_lens_tensor: torch.Tensor,
-        num_prefills: int,
-        spec_sequence_masks_cpu: torch.Tensor | None,
-        non_spec_sequence_indices: torch.Tensor | None,
-        non_spec_query_start_loc_cpu: torch.Tensor | None,
-        query_start_loc: torch.Tensor,
-    ) -> tuple[
-        torch.Tensor | None,
-        dict[int, dict[str, object]] | None,
-        torch.Tensor | None,
-        torch.Tensor | None,
-    ]:
-        del num_prefills
-        has_initial_state = context_lens_tensor > 0
-        if spec_sequence_masks_cpu is not None:
-            assert non_spec_sequence_indices is not None
-            has_initial_state = torch.index_select(
-                has_initial_state,
-                0,
-                non_spec_sequence_indices,
-            )
-            assert non_spec_query_start_loc_cpu is not None
-        nums_dict, batch_ptr, token_chunk_offset_ptr = compute_causal_conv1d_metadata(
-            non_spec_query_start_loc_cpu,
-            device=query_start_loc.device,
-        )
-        return (
-            has_initial_state,
-            nums_dict,
-            batch_ptr,
-            token_chunk_offset_ptr,
         )
 
 


### PR DESCRIPTION
## What this PR does / why we need it

Replace the triton-based chunk_gated_delta_rule entry in gdn.py prefill path with the single aclnn aclnnChunkGatedDeltaRule operator, using CANN built-in operator.

### Changes:
- Add C++ torch binding (chunk_gated_delta_rule_torch_adpt.h) plus ops.def/.impl in torch_binding.cpp and meta impl in torch_binding_meta.cpp, exposed as torch.ops._C_ascend.npu_chunk_gated_delta_rule
- In gdn.py rewrite prefill call to TND layout:
  - squeeze the flat B=1 batch dim off q/k/v/g/beta
  - l2-normalize q/k before the call
  - derive actual_seq_lengths from prefill metadata
  - pass g as raw float32 log-gate
  - restore batch dim on out and transpose final_state back
- Remove obsolete GDN prefill metadata (GDNChunkedPrefillMetadata, _compact_empty_segments, _build_non_spec_chunked_prefill_metadata)
- Register chunk_gated_delta_rule in build_aclnn.sh for ascend910b/910_93/950

### Backport from:
- #12607
- #13121

### Profiling verification:

| Metric | Baseline (v0.26.0rc1) | PR Image |
|--------|----------------------|-----------|
| Prefill op | aclnnChunkGatedDeltaRuleFwdH | aclnnChunkGatedDeltaRule |
| TTFT (ms) | 3376 | 2920 (-13.5%) |
| TPOT (ms) | 35.32 | 32.18 (-8.9%) |
| ITL (ms) | 84.03 | 75.70 (-9.9%) |

### Test conditions:
- Model: Qwen3.6-35B-A3B
- TP=4, EP, MTP=2
- Input=6144, Output=256, Concurrency=16
- Image: quay.nju.edu.cn/ascend/vllm-ascend:v0.26.0rc1-pr12607-pr13121

### Does this PR introduce any user-facing change?
No, this is an internal performance optimization.

### How was this patch tested?
- Verified via profiling that aclnnChunkGatedDeltaRule is called instead of aclnnChunkGatedDeltaRuleFwdH
- Benchmark results show TTFT improvement of 13.5%

Signed-off-by: chujiangang <chujiangang@huawei.com>
- vLLM main: https://github.com/vllm-project/vllm/commit/ba07e4a48fc951300d97eb506217dd530583dea3
