### PR TITLE
[Performance][Worker] Build DeepSeek V4 metadata asynchronously on v0.27

### DIFF
--- a/.github/workflows/configs/nightly_config.yaml
+++ b/.github/workflows/configs/nightly_config.yaml
@@ -250,6 +250,9 @@ a3:
   multi_card:
     test_config:
       # pytest-driven tests
+      - name: compressor-metadata-cross-stream
+        os: linux-aarch64-a3-2
+        tests: tests/e2e/nightly/single_node/ops/singlecard_ops/test_compressor_metadata.py
       - name: qwen3-30b-acc
         os: linux-aarch64-nightly-a3-4
         tests: tests/e2e/weekly/single_node/models/test_qwen3_30b_acc.py

--- a/tests/e2e/nightly/single_node/ops/singlecard_ops/test_compressor_metadata.py
+++ b/tests/e2e/nightly/single_node/ops/singlecard_ops/test_compressor_metadata.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 from dataclasses import dataclass
+from functools import partial
 from typing import Any
 
 import pytest
@@ -11,6 +12,12 @@ from vllm_ascend.utils import bootstrap_custom_op_env
 
 bootstrap_custom_op_env(include_vendor_lib=True)
 import vllm_ascend.vllm_ascend_C  # type: ignore[import-untyped] # noqa: E402,F401
+
+from vllm_ascend.worker.device_metadata import (  # noqa: E402
+    DeviceMetadataExecutor,
+    DeviceMetadataStage,
+    DeviceMetadataTask,
+)
 
 KV_BLOCK_SIZE = 128
 SLOT_MAPPING_FLAT = 1
@@ -401,42 +408,30 @@ def test_compressor_metadata_out_cross_stream_buffer_reuse():
     out_cos = torch.empty((max_rows, 1, 1, ROPE_DIM), dtype=prepared[0][1].dtype, device="npu")
     out_sin = torch.empty_like(out_cos)
     out_slot = torch.empty((max_rows, 2), dtype=torch.int32, device="npu")
-    output_ptrs = (out_cos.data_ptr(), out_sin.data_ptr(), out_slot.data_ptr())
-    model_stream = torch.npu.current_stream()
-    metadata_stream = torch.npu.Stream()
-    inputs_ready = torch.npu.Event()
-    metadata_ready = torch.npu.Event()
-    buffer_reusable = torch.npu.Event()
+    executor = DeviceMetadataExecutor()
     snapshots = []
 
-    for index, (case, rope_cos, rope_sin, query_start_loc, start_pos, block_table, expected) in enumerate(prepared):
+    for case, rope_cos, rope_sin, query_start_loc, start_pos, block_table, expected in prepared:
         num_rows = expected[2].shape[0]
-        assert (
-            out_cos[:num_rows].data_ptr(),
-            out_sin[:num_rows].data_ptr(),
-            out_slot[:num_rows].data_ptr(),
-        ) == output_ptrs
-        inputs_ready.record(model_stream)
-        with torch.npu.stream(metadata_stream):
-            metadata_stream.wait_event(inputs_ready)
-            if index:
-                metadata_stream.wait_event(buffer_reusable)
-            torch.ops._C_ascend.compressor_metadata_out(
-                rope_cos,
-                rope_sin,
-                query_start_loc,
-                start_pos,
-                block_table,
-                KV_BLOCK_SIZE,
-                case.slot_mapping_format,
-                case.compress_ratio,
-                len(case.start_pos),
-                out_cos[:num_rows],
-                out_sin[:num_rows],
-                out_slot[:num_rows],
-            )
-            metadata_ready.record(metadata_stream)
-        model_stream.wait_event(metadata_ready)
+        build_metadata = partial(
+            torch.ops._C_ascend.compressor_metadata_out,
+            rope_cos,
+            rope_sin,
+            query_start_loc,
+            start_pos,
+            block_table,
+            KV_BLOCK_SIZE,
+            case.slot_mapping_format,
+            case.compress_ratio,
+            len(case.start_pos),
+            out_cos[:num_rows],
+            out_sin[:num_rows],
+            out_slot[:num_rows],
+        )
+
+        group_id = id(out_cos)
+        executor.submit((DeviceMetadataTask(DeviceMetadataStage.COMPRESSOR, build_metadata, group_id),))
+        executor.wait(DeviceMetadataStage.COMPRESSOR, group_id)
         snapshots.append(
             (
                 out_cos[:num_rows].clone(),
@@ -445,7 +440,7 @@ def test_compressor_metadata_out_cross_stream_buffer_reuse():
                 expected,
             )
         )
-        buffer_reusable.record(model_stream)
+        executor.release()
 
     torch.npu.synchronize()
     for actual_cos, actual_sin, actual_slot, expected in snapshots:

--- a/tests/e2e/nightly/single_node/ops/singlecard_ops/test_compressor_metadata.py
+++ b/tests/e2e/nightly/single_node/ops/singlecard_ops/test_compressor_metadata.py
@@ -355,3 +355,101 @@ def test_compressor_metadata_dsv4_flash_real_metadata(case: CompressorMetadataCa
     assert torch.equal(out_slot.cpu(), expected_slot)
     assert torch.equal(out_cos.cpu(), expected_cos)
     assert torch.equal(out_sin.cpu(), expected_sin)
+
+
+def test_compressor_metadata_out_cross_stream_buffer_reuse():
+    torch.npu.set_device(0)
+    cases_by_name = {case.name: case for case in DSV4_FLASH_CASES}
+    cases = [
+        CompressorMetadataCase(
+            name="cross_stream_c4_first",
+            compress_ratio=4,
+            query_start_loc=(0, 131),
+            start_pos=(1,),
+            block_table=((1,),),
+            num_rows=33,
+        ),
+        cases_by_name["dsv4_flash_c128_two_request_prefill_padded_127"],
+        CompressorMetadataCase(
+            name="cross_stream_c4_rewrite",
+            compress_ratio=4,
+            query_start_loc=(0, 131),
+            start_pos=(129,),
+            block_table=((9,),),
+            num_rows=33,
+        ),
+    ]
+    prepared = []
+    for case in cases:
+        rope_cos, rope_sin = _make_rope(case)
+        rope_cos = rope_cos.float()
+        rope_sin = rope_sin.float()
+        expected = _reference_outputs(case, rope_cos, rope_sin)
+        prepared.append(
+            (
+                case,
+                rope_cos.npu(),
+                rope_sin.npu(),
+                torch.tensor(case.query_start_loc, dtype=torch.int32, device="npu"),
+                torch.tensor(case.start_pos, dtype=torch.int32, device="npu"),
+                torch.tensor(case.block_table, dtype=torch.int32, device="npu"),
+                expected,
+            )
+        )
+
+    max_rows = max(expected[2].shape[0] for *_, expected in prepared)
+    out_cos = torch.empty((max_rows, 1, 1, ROPE_DIM), dtype=prepared[0][1].dtype, device="npu")
+    out_sin = torch.empty_like(out_cos)
+    out_slot = torch.empty((max_rows, 2), dtype=torch.int32, device="npu")
+    output_ptrs = (out_cos.data_ptr(), out_sin.data_ptr(), out_slot.data_ptr())
+    model_stream = torch.npu.current_stream()
+    metadata_stream = torch.npu.Stream()
+    inputs_ready = torch.npu.Event()
+    metadata_ready = torch.npu.Event()
+    buffer_reusable = torch.npu.Event()
+    snapshots = []
+
+    for index, (case, rope_cos, rope_sin, query_start_loc, start_pos, block_table, expected) in enumerate(prepared):
+        num_rows = expected[2].shape[0]
+        assert (
+            out_cos[:num_rows].data_ptr(),
+            out_sin[:num_rows].data_ptr(),
+            out_slot[:num_rows].data_ptr(),
+        ) == output_ptrs
+        inputs_ready.record(model_stream)
+        with torch.npu.stream(metadata_stream):
+            metadata_stream.wait_event(inputs_ready)
+            if index:
+                metadata_stream.wait_event(buffer_reusable)
+            torch.ops._C_ascend.compressor_metadata_out(
+                rope_cos,
+                rope_sin,
+                query_start_loc,
+                start_pos,
+                block_table,
+                KV_BLOCK_SIZE,
+                case.slot_mapping_format,
+                case.compress_ratio,
+                len(case.start_pos),
+                out_cos[:num_rows],
+                out_sin[:num_rows],
+                out_slot[:num_rows],
+            )
+            metadata_ready.record(metadata_stream)
+        model_stream.wait_event(metadata_ready)
+        snapshots.append(
+            (
+                out_cos[:num_rows].clone(),
+                out_sin[:num_rows].clone(),
+                out_slot[:num_rows].clone(),
+                expected,
+            )
+        )
+        buffer_reusable.record(model_stream)
+
+    torch.npu.synchronize()
+    for actual_cos, actual_sin, actual_slot, expected in snapshots:
+        expected_cos, expected_sin, expected_slot = expected
+        assert torch.equal(actual_cos.cpu(), expected_cos)
+        assert torch.equal(actual_sin.cpu(), expected_sin)
+        assert torch.equal(actual_slot.cpu(), expected_slot)

--- a/tests/ut/attention/test_dsa_v1.py
+++ b/tests/ut/attention/test_dsa_v1.py
@@ -47,6 +47,7 @@ from vllm_ascend.attention.dsa_v1 import (
     AscendDSAMetadataBuilder,
     AscendDSAReqMetadata,
     build_compressor_metadata_out,
+    build_dspark_swa_indices,
 )
 from vllm_ascend.device.device_op import DeviceOperator
 from vllm_ascend.models.deepseek_v4.compressor import AscendCompressorMetadata
@@ -72,7 +73,10 @@ def _mock_dsa_kv_plan(**method_returns) -> MagicMock:
     return plan
 
 
-def _make_builder(compressor_ratio: int = 4) -> AscendDSAMetadataBuilder:
+def _make_builder(
+    compressor_ratio: int = 4,
+    num_speculative_tokens: int | None = None,
+) -> AscendDSAMetadataBuilder:
     model_config = SimpleNamespace(
         hf_config=SimpleNamespace(
             model_type="test",
@@ -92,7 +96,9 @@ def _make_builder(compressor_ratio: int = 4) -> AscendDSAMetadataBuilder:
             max_num_batched_tokens=16,
             max_num_seqs=4,
         ),
-        speculative_config=None,
+        speculative_config=(
+            None if num_speculative_tokens is None else SimpleNamespace(num_speculative_tokens=num_speculative_tokens)
+        ),
         compilation_config=SimpleNamespace(cudagraph_mode=CUDAGraphMode.NONE),
         parallel_config=SimpleNamespace(tensor_parallel_size=2),
     )
@@ -115,6 +121,156 @@ def _make_builder(compressor_ratio: int = 4) -> AscendDSAMetadataBuilder:
     builder.seq_lens = torch.tensor([8, 6], dtype=torch.int32)
     builder.num_decodes = 2
     return builder
+
+
+@pytest.mark.parametrize("num_speculative_tokens", [1, 3, 7])
+def test_build_dspark_swa_indices_writes_active_output(num_speculative_tokens: int):
+    block_table = torch.tensor([[2, 3], [5, 6]], dtype=torch.int32)
+    num_decode_tokens = 2 * num_speculative_tokens
+    query_start_loc = torch.tensor([0, num_speculative_tokens, num_decode_tokens], dtype=torch.int32)
+    seq_lens = torch.tensor([10, 14], dtype=torch.int32)
+    expected, expected_lens = build_dspark_swa_indices(
+        block_table,
+        num_speculative_tokens,
+        4,
+        8,
+        query_start_loc,
+        seq_lens,
+        num_decode_tokens,
+        index_width=16,
+    )
+    output = torch.empty_like(expected)
+
+    actual, actual_lens = build_dspark_swa_indices(
+        block_table,
+        num_speculative_tokens,
+        4,
+        8,
+        query_start_loc,
+        seq_lens,
+        num_decode_tokens,
+        index_width=16,
+        indices_output=output,
+    )
+
+    assert actual.data_ptr() == output.data_ptr()
+    assert torch.equal(actual, expected)
+    assert torch.equal(actual_lens, expected_lens)
+
+
+def test_draft_swa_and_sas_share_attention_task():
+    builder = _make_builder(1, num_speculative_tokens=3)
+    builder.enable_dspark_device_metadata(max_num_tokens=16)
+    assert builder.dspark_swa_indices_buffer is not None
+    buffer = builder.dspark_swa_indices_buffer
+    buffer_address = buffer.data_ptr()
+    builder.num_actual_tokens = 6
+    builder.num_prefills = 0
+    builder.seq_lens = torch.tensor([10, 14], dtype=torch.int32)
+    builder.block_table = torch.tensor([[2, 3], [5, 6]], dtype=torch.int32)
+    query_start_loc = torch.tensor([0, 3, 6], dtype=torch.int32)
+    common_attn_metadata = SimpleNamespace(
+        num_reqs=2,
+        query_start_loc=query_start_loc,
+        query_start_loc_cpu=query_start_loc,
+        seq_lens_cpu=builder.seq_lens,
+        _seq_lens_cpu=builder.seq_lens,
+        causal=False,
+    )
+    sas_result = torch.arange(DSA_METADATA_BUFFER_SIZE, dtype=torch.int32)
+
+    with (
+        patch.object(
+            DeviceOperator,
+            "get_dsa_decode_cu_seqlens_ori_kv",
+            return_value=torch.tensor([0, 10, 24], dtype=torch.int32),
+        ),
+        patch.object(DeviceOperator, "get_dsa_decode_cu_seqlens_cmp_kv", return_value=None),
+        patch.object(DeviceOperator, "get_dsa_sparse_attn_metadata_kwargs", return_value={}),
+        patch.object(
+            DeviceOperator,
+            "get_dsa_sparse_attn_metadata_op",
+            return_value=MagicMock(return_value=sas_result),
+        ),
+        patch(
+            "vllm_ascend.attention.dsa_v1.build_dspark_swa_indices",
+            wraps=build_dspark_swa_indices,
+        ) as build_swa,
+    ):
+        metadata = builder.build_req_metadata_for_drafting(
+            1,
+            common_attn_metadata,
+            torch.ones(6),
+            torch.zeros(6),
+        )
+        task = builder.take_device_metadata_tasks()
+        assert build_swa.call_count == 0
+        assert builder.dspark_swa_indices_buffer is buffer
+        assert metadata.dspark_swa_indices.data_ptr() == buffer_address
+        assert len(task) == 1
+        assert task[0].stage == DeviceMetadataStage.ATTENTION
+        assert task[0].group_id == id(metadata.sas_metadata)
+
+        task[0].run()
+
+        first_indices = metadata.dspark_swa_indices.clone()
+        builder.num_actual_tokens = 3
+        builder.seq_lens = torch.tensor([12], dtype=torch.int32)
+        builder.block_table = torch.tensor([[9, 10]], dtype=torch.int32)
+        next_query_start_loc = torch.tensor([0, 3], dtype=torch.int32)
+        next_common_attn_metadata = SimpleNamespace(
+            num_reqs=1,
+            query_start_loc=next_query_start_loc,
+            query_start_loc_cpu=next_query_start_loc,
+            seq_lens_cpu=builder.seq_lens,
+            _seq_lens_cpu=builder.seq_lens,
+            causal=False,
+        )
+        next_metadata = builder.build_req_metadata_for_drafting(
+            1,
+            next_common_attn_metadata,
+            torch.ones(3),
+            torch.zeros(3),
+        )
+        next_task = builder.take_device_metadata_tasks()
+        assert builder.dspark_swa_indices_buffer is buffer
+        assert builder.dspark_swa_indices_buffer.data_ptr() == buffer_address
+        assert next_metadata.dspark_swa_indices.shape[0] == 3
+        assert next_metadata.dspark_swa_indices.data_ptr() == metadata.dspark_swa_indices.data_ptr()
+        next_task[0].run()
+
+    assert build_swa.call_count == 2
+    assert build_swa.call_args.kwargs["indices_output"] is next_metadata.dspark_swa_indices
+    assert metadata.dspark_swa_indices.data_ptr() == builder.dspark_swa_indices_buffer.data_ptr()
+    assert builder.dspark_swa_indices_buffer.shape[0] == 16
+    assert not torch.equal(next_metadata.dspark_swa_indices, first_indices[:3])
+    assert torch.equal(metadata.sas_metadata, sas_result)
+
+
+def test_draft_swa_metadata_rejects_rows_above_buffer_capacity():
+    builder = _make_builder(1, num_speculative_tokens=3)
+    builder.enable_dspark_device_metadata(max_num_tokens=16)
+    builder.num_actual_tokens = 17
+    builder.num_prefills = 0
+    builder.seq_lens = torch.tensor([17], dtype=torch.int32)
+    builder.block_table = torch.ones((1, 2), dtype=torch.int32)
+    query_start_loc = torch.tensor([0, 17], dtype=torch.int32)
+    common_attn_metadata = SimpleNamespace(
+        num_reqs=1,
+        query_start_loc=query_start_loc,
+        query_start_loc_cpu=query_start_loc,
+        seq_lens_cpu=builder.seq_lens,
+        _seq_lens_cpu=builder.seq_lens,
+        causal=False,
+    )
+
+    with pytest.raises(ValueError, match=r"active=17, capacity=16"):
+        builder.build_req_metadata_for_drafting(
+            1,
+            common_attn_metadata,
+            torch.ones(17),
+            torch.zeros(17),
+        )
 
 
 @pytest.mark.parametrize(

--- a/tests/ut/attention/test_dsa_v1.py
+++ b/tests/ut/attention/test_dsa_v1.py
@@ -731,11 +731,17 @@ def test_dsa_cp_device_metadata_tasks(
             "sl_cpu": builder.seq_lens,
         }
     }
-    build_local_metadata = (
-        MagicMock(side_effect=lambda: builder.start_pos_prefill.fill_(1)) if device_metadata_enabled else None
-    )
+    build_local_metadata = MagicMock(side_effect=lambda: builder.start_pos_prefill.fill_(1))
     builder._ensure_device_local_metadata = MagicMock(
-        return_value=(0, 3, 3, 3, query_start_loc, builder.seq_lens, build_local_metadata)
+        return_value=(
+            0,
+            3,
+            3,
+            3,
+            query_start_loc,
+            builder.seq_lens,
+            build_local_metadata if device_metadata_enabled else None,
+        )
     )
     builder._get_cmp_seqlens_for_metadata = MagicMock(return_value=None)
     builder._build_sas_metadata = MagicMock(return_value=builder.req_sas_metadata)
@@ -813,7 +819,7 @@ def test_dsa_cp_device_metadata_tasks(
 
 
 def test_dsa_cp_device_local_metadata_is_deferred_and_reused():
-    cache = {}
+    cache: dict[str, dict[str, torch.Tensor]] = {}
 
     def make_builder():
         builder = AscendDSACPMetadataBuilder.__new__(AscendDSACPMetadataBuilder)

--- a/tests/ut/attention/test_dsa_v1.py
+++ b/tests/ut/attention/test_dsa_v1.py
@@ -1108,6 +1108,7 @@ def test_dsa_cp_attention_waits_before_sas_consumer(compress_ratio: int):
     impl.compressor_ape = torch.empty(0)
     impl.compressor_norm = SimpleNamespace(weight=torch.empty(0))
     impl.compressor_norm_eps = 1e-6
+    impl.indexer = SimpleNamespace(skip_topk=False, use_index_cache=False)
     impl.vllm_config = MagicMock()
 
     swa_sas = torch.zeros(1024, dtype=torch.int32)

--- a/tests/ut/attention/test_dsa_v1.py
+++ b/tests/ut/attention/test_dsa_v1.py
@@ -675,9 +675,17 @@ def test_pure_full_graph_keeps_compressor_metadata_on_legacy_path():
         "expected_stages",
     ),
     [
-        (4, True, False, 3, None, 2, list(DeviceMetadataStage)),
-        (128, True, False, 3, None, 2, [DeviceMetadataStage.COMPRESSOR, DeviceMetadataStage.ATTENTION]),
-        (4, True, True, 4, 1, 3, list(DeviceMetadataStage)),
+        (4, True, False, 3, None, 2, [DeviceMetadataStage.COMPRESSOR, *list(DeviceMetadataStage)]),
+        (
+            128,
+            True,
+            False,
+            3,
+            None,
+            2,
+            [DeviceMetadataStage.COMPRESSOR, DeviceMetadataStage.COMPRESSOR, DeviceMetadataStage.ATTENTION],
+        ),
+        (4, True, True, 4, 1, 3, [DeviceMetadataStage.COMPRESSOR, *list(DeviceMetadataStage)]),
         (4, False, False, 3, None, 2, []),
     ],
 )
@@ -720,7 +728,12 @@ def test_dsa_cp_device_metadata_tasks(
             "sl_cpu": builder.seq_lens,
         }
     }
-    builder._ensure_device_local_metadata = MagicMock(return_value=(0, 3, 3, 3, query_start_loc, builder.seq_lens))
+    build_local_metadata = (
+        MagicMock(side_effect=lambda: builder.start_pos_prefill.fill_(1)) if device_metadata_enabled else None
+    )
+    builder._ensure_device_local_metadata = MagicMock(
+        return_value=(0, 3, 3, 3, query_start_loc, builder.seq_lens, build_local_metadata)
+    )
     builder._get_cmp_seqlens_for_metadata = MagicMock(return_value=None)
     builder._build_sas_metadata = MagicMock(return_value=builder.req_sas_metadata)
     builder._build_qli_metadata = MagicMock(return_value=builder.req_qli_metadata)
@@ -784,6 +797,9 @@ def test_dsa_cp_device_metadata_tasks(
             for task in tasks:
                 task.run()
         build_compressor.assert_called_once()
+        build_local_metadata.assert_called_once_with()
+        expected_start_pos = torch.tensor([1, 0] if full_graph_mode else [1, 1], dtype=torch.int32)
+        assert torch.equal(builder.start_pos_prefill, expected_start_pos)
     builder._build_sas_metadata.assert_called_once()
     if compressor_ratio == 4:
         builder._build_qli_metadata.assert_called_once()
@@ -791,6 +807,52 @@ def test_dsa_cp_device_metadata_tasks(
         assert builder._build_qli_metadata.call_args.kwargs["max_seqlen_k"] == 8
     else:
         builder._build_qli_metadata.assert_not_called()
+
+
+def test_dsa_cp_device_local_metadata_is_deferred_and_reused():
+    cache = {}
+
+    def make_builder():
+        builder = AscendDSACPMetadataBuilder.__new__(AscendDSACPMetadataBuilder)
+        builder._device_metadata_enabled = True
+        builder.common_ratio_to_sas_metadata = cache
+        builder.local_query_start_loc = torch.zeros(3, dtype=torch.int32)
+        builder.local_seq_lens = torch.zeros(2, dtype=torch.int32)
+        builder.start_pos_prefill = torch.zeros(2, dtype=torch.int32)
+        return builder
+
+    first_builder = make_builder()
+    second_builder = make_builder()
+    query_start_loc = torch.tensor([0, 2, 4], dtype=torch.int32)
+    seq_lens = torch.tensor([2, 4], dtype=torch.int32)
+    first_addresses = (
+        first_builder.local_query_start_loc.data_ptr(),
+        first_builder.local_seq_lens.data_ptr(),
+        first_builder.start_pos_prefill.data_ptr(),
+    )
+
+    with patch(
+        "vllm_ascend.attention.context_parallel.dsa_cp.get_tp_group",
+        return_value=SimpleNamespace(world_size=2, rank_in_group=0),
+    ):
+        first = first_builder._ensure_device_local_metadata(2, 4, query_start_loc, seq_lens)
+        second = second_builder._ensure_device_local_metadata(2, 4, query_start_loc, seq_lens)
+        first[-1]()
+        second[-1]()
+
+    assert first[:4] == (0, 2, 2, 4)
+    assert torch.equal(first_builder.local_query_start_loc, torch.tensor([0, 2, 2], dtype=torch.int32))
+    assert torch.equal(first_builder.local_seq_lens, torch.tensor([2, 0], dtype=torch.int32))
+    assert torch.equal(first_builder.start_pos_prefill, torch.tensor([0, 2], dtype=torch.int32))
+    assert torch.equal(second_builder.local_query_start_loc, first_builder.local_query_start_loc)
+    assert torch.equal(second_builder.local_seq_lens, first_builder.local_seq_lens)
+    assert torch.equal(second_builder.start_pos_prefill, first_builder.start_pos_prefill)
+    assert cache["_device_local"]["qsl"].data_ptr() == first_addresses[0]
+    assert first_addresses == (
+        first_builder.local_query_start_loc.data_ptr(),
+        first_builder.local_seq_lens.data_ptr(),
+        first_builder.start_pos_prefill.data_ptr(),
+    )
 
 
 def test_dsa_cp_qli_metadata_uses_host_maxima():
@@ -866,6 +928,32 @@ def test_dsa_cp_compressor_waits_for_precomputed_metadata():
         assert impl._compute_compressor_metadata(metadata) is outputs
 
     wait.assert_called_once_with(DeviceMetadataStage.COMPRESSOR, 17)
+
+
+def test_dsa_cp_legacy_compressor_waits_for_device_local_metadata():
+    impl = AscendDSACPImpl.__new__(AscendDSACPImpl)
+    metadata = SimpleNamespace(
+        compressor_metadata=None,
+        device_local_metadata_group_id=23,
+        full_compress_cos=torch.ones((1, 1, 1, 2)),
+        full_compress_sin=torch.zeros((1, 1, 1, 2)),
+        num_compressed_tokens=1,
+        start_pos=torch.zeros(1, dtype=torch.int32),
+        num_actual_reqs=1,
+        query_start_loc=torch.tensor([0, 1], dtype=torch.int32),
+        block_table=torch.zeros((1, 1), dtype=torch.int32),
+        storage_block_size=128,
+    )
+    impl.compress_ratio = 4
+
+    with (
+        patch("vllm_ascend.attention.context_parallel.dsa_cp.wait_for_device_metadata") as wait,
+        patch.object(DeviceOperator, "get_dsa_compressor_slot_mapping_format", return_value=2),
+        patch.object(torch.ops._C_ascend, "compressor_metadata", create=True, return_value=(1, 2, 3)),
+    ):
+        assert impl._compute_compressor_metadata(metadata) == (1, 2, 3)
+
+    wait.assert_called_once_with(DeviceMetadataStage.COMPRESSOR, 23)
 
 
 def _make_dsa_cp_metadata(sas_metadata: torch.Tensor) -> AscendDSACPMetadata:

--- a/tests/ut/attention/test_dsa_v1.py
+++ b/tests/ut/attention/test_dsa_v1.py
@@ -22,9 +22,19 @@ import pytest
 import torch
 
 from vllm_ascend.attention.context_parallel.dsa_cp import (
+    AscendDSACPImpl,
+    AscendDSACPLayerMetadata,
+    AscendDSACPMetadataBuilder,
     AscendDSAPCPImpl,
     AscendDSAPCPMetadata,
     AscendDSAPCPMetadataBuilder,
+    DSACPMetadata,
+)
+from vllm_ascend.attention.context_parallel.dsa_cp import (
+    AscendDSAMetadata as AscendDSACPMetadata,
+)
+from vllm_ascend.attention.context_parallel.dsa_cp import (
+    AscendDSAReqMetadata as AscendDSACPReqMetadata,
 )
 from vllm_ascend.attention.dsa_v1 import (
     DSA_METADATA_BUFFER_SIZE,
@@ -41,7 +51,14 @@ from vllm_ascend.models.deepseek_v4.indexer import (
     AscendIndexerMetadata,
     IndexerOverlapPlan,
 )
-from vllm_ascend.worker.v2.pcp_manager import AscendPCPManager
+from vllm_ascend.worker.device_metadata import (
+    DeviceMetadataStage,
+    DeviceMetadataTask,
+)
+from vllm_ascend.worker.v2.pcp_manager import (
+    AscendPCPAttentionContext,
+    AscendPCPManager,
+)
 
 
 def _mock_dsa_kv_plan(**method_returns) -> MagicMock:
@@ -251,8 +268,8 @@ def test_build_req_metadata_uses_for_prefill_and_decode(
         attn_state=MagicMock(),
         causal=True,
     )
-    sas_metadata = torch.full((DSA_METADATA_BUFFER_SIZE,), 1, dtype=torch.int32)
-    qli_metadata = torch.full((DSA_METADATA_BUFFER_SIZE,), 2, dtype=torch.int32)
+    sas_metadata = builder.sas_metadata_buffer.fill_(1)
+    qli_metadata = builder.qli_metadata_buffer.fill_(2)
     builder._build_sas_metadata = MagicMock(return_value=sas_metadata)
     builder._build_qli_metadata = MagicMock(return_value=qli_metadata)
     decode_cu_seqlens_ori_kv = torch.tensor([0, 8, 14], dtype=torch.int32)
@@ -343,6 +360,392 @@ def test_build_req_metadata_uses_for_prefill_and_decode(
     )
     assert req_metadata.num_compressed_tokens == 2
     assert req_metadata.slot_mapping is None
+
+
+@pytest.mark.parametrize(
+    ("compressor_ratio", "expected_stages"),
+    [
+        (4, [DeviceMetadataStage.INDEXER, DeviceMetadataStage.ATTENTION]),
+        (128, [DeviceMetadataStage.ATTENTION]),
+    ],
+)
+def test_build_req_metadata_defers_device_work_to_fixed_buffers(
+    compressor_ratio: int,
+    expected_stages: list[DeviceMetadataStage],
+):
+    builder = _make_builder(compressor_ratio)
+    builder.enable_device_metadata()
+    builder.num_actual_tokens = 3
+    builder.num_prefills = 1
+    builder.seq_lens = torch.tensor([8, 6], dtype=torch.int32)
+    builder.block_table = torch.tensor([[1, 2], [3, 4]], dtype=torch.int32)
+    builder.common_ratio_to_sas_metadata = {}
+    query_start_loc = torch.tensor([0, 2, 3], dtype=torch.int32)
+    common_attn_metadata = SimpleNamespace(
+        num_reqs=2,
+        num_input_tokens=3,
+        positions=torch.arange(3),
+        query_start_loc=query_start_loc,
+        query_start_loc_cpu=query_start_loc,
+        causal=True,
+    )
+    builder._build_sas_metadata = MagicMock()
+    builder._build_qli_metadata = MagicMock()
+
+    with patch(
+        "vllm_ascend.attention.dsa_v1.get_full_cos_and_sin_dsa",
+        return_value=(torch.ones(1), torch.zeros(1)),
+    ):
+        req_metadata = builder.build_req_metadata(
+            common_attn_metadata=common_attn_metadata,
+            seq_lens_cpu=builder.seq_lens,
+            num_actual_reqs=None,
+            cos=torch.ones(3),
+            sin=torch.zeros(3),
+        )
+
+    assert req_metadata.sas_metadata is builder.sas_metadata_buffer
+    assert (req_metadata.qli_metadata is builder.qli_metadata_buffer) is (compressor_ratio == 4)
+    builder._build_sas_metadata.assert_not_called()
+    builder._build_qli_metadata.assert_not_called()
+
+    tasks = builder.take_device_metadata_tasks()
+    assert builder.take_device_metadata_tasks() == ()
+    assert [task.stage for task in tasks] == expected_stages
+    assert all(task.group_id in (id(builder.qli_metadata_buffer), id(builder.sas_metadata_buffer)) for task in tasks)
+    for task in tasks:
+        task.run()
+    builder._build_sas_metadata.assert_called_once()
+    if compressor_ratio == 4:
+        builder._build_qli_metadata.assert_called_once()
+    else:
+        builder._build_qli_metadata.assert_not_called()
+
+
+@pytest.mark.parametrize(
+    ("compressor_ratio", "device_metadata_enabled", "expected_stages"),
+    [
+        (4, True, [DeviceMetadataStage.INDEXER, DeviceMetadataStage.ATTENTION]),
+        (128, True, [DeviceMetadataStage.ATTENTION]),
+        (4, False, []),
+    ],
+)
+def test_dsa_cp_device_metadata_tasks(
+    compressor_ratio: int,
+    device_metadata_enabled: bool,
+    expected_stages: list[DeviceMetadataStage],
+):
+    builder = AscendDSACPMetadataBuilder.__new__(AscendDSACPMetadataBuilder)
+    builder.num_prefills = 1
+    builder.num_actual_tokens = 3
+    builder.compressor_ratio = compressor_ratio
+    builder.storage_block_size = 128
+    builder.seq_lens = torch.tensor([8, 6], dtype=torch.int32)
+    builder.seq_lens_cpu = builder.seq_lens
+    builder.block_table = torch.tensor([[1, 2], [3, 4]], dtype=torch.int32)
+    builder.start_pos_prefill = torch.zeros(2, dtype=torch.int32)
+    builder.slot_mapping = torch.zeros((3, 2), dtype=torch.int32)
+    builder.req_sas_metadata = torch.zeros(1024, dtype=torch.int32)
+    builder.req_qli_metadata = torch.zeros(1024, dtype=torch.int32)
+    builder._device_metadata_enabled = device_metadata_enabled
+    builder._device_metadata_tasks = ()
+    builder.model_config = SimpleNamespace(
+        hf_config=SimpleNamespace(num_attention_heads=64, index_topk=512),
+        get_head_size=lambda: 512,
+    )
+    query_start_loc = torch.tensor([0, 2, 3], dtype=torch.int32)
+    builder.common_ratio_to_sas_metadata = {
+        "_cpu_local": {
+            "qsl_cpu": query_start_loc,
+            "sl_cpu": builder.seq_lens,
+        }
+    }
+    builder._ensure_device_local_metadata = MagicMock(return_value=(0, 3, 3, 3, query_start_loc, builder.seq_lens))
+    builder._get_cmp_seqlens_for_metadata = MagicMock(return_value=None)
+    builder._num_compressor_metadata_rows = MagicMock(return_value=2)
+    builder._build_sas_metadata = MagicMock(return_value=builder.req_sas_metadata)
+    builder._build_qli_metadata = MagicMock(return_value=builder.req_qli_metadata)
+    common_attn_metadata = SimpleNamespace(
+        num_reqs=2,
+        query_start_loc=query_start_loc,
+        query_start_loc_cpu=query_start_loc,
+    )
+
+    with patch(
+        "vllm_ascend.attention.context_parallel.dsa_cp.get_full_cos_and_sin_dsa",
+        return_value=(torch.ones(1), torch.zeros(1)),
+    ):
+        req_metadata = builder.build_req_metadata(
+            common_attn_metadata,
+            input_positions=None,
+            num_input_tokens=3,
+            num_actual_reqs=None,
+            attn_state=MagicMock(),
+            cos=MagicMock(),
+            sin=MagicMock(),
+        )
+
+    tasks = builder.take_device_metadata_tasks()
+    assert builder.take_device_metadata_tasks() == ()
+    assert [task.stage for task in tasks] == expected_stages
+    assert all(task.group_id in (id(builder.req_qli_metadata), id(builder.req_sas_metadata)) for task in tasks)
+    assert req_metadata.sas_metadata is builder.req_sas_metadata
+    assert (req_metadata.qli_metadata is builder.req_qli_metadata) is (compressor_ratio == 4)
+    if device_metadata_enabled:
+        builder._build_sas_metadata.assert_not_called()
+        builder._build_qli_metadata.assert_not_called()
+        for task in tasks:
+            task.run()
+    builder._build_sas_metadata.assert_called_once()
+    if compressor_ratio == 4:
+        builder._build_qli_metadata.assert_called_once()
+        assert builder._build_qli_metadata.call_args.kwargs["max_seqlen_q"] == 2
+        assert builder._build_qli_metadata.call_args.kwargs["max_seqlen_k"] == 8
+    else:
+        builder._build_qli_metadata.assert_not_called()
+
+
+def test_dsa_cp_qli_metadata_uses_host_maxima():
+    builder = AscendDSACPMetadataBuilder.__new__(AscendDSACPMetadataBuilder)
+    builder.compressor_ratio = 4
+    builder.common_ratio_to_sas_metadata = {}
+    builder.req_qli_metadata = torch.zeros(1024, dtype=torch.int32)
+    builder.seqused_q = torch.empty(0)
+    builder.model_config = SimpleNamespace(
+        hf_config=SimpleNamespace(
+            index_n_heads=64,
+            index_head_dim=128,
+            index_topk=512,
+        )
+    )
+    seq_lens = MagicMock()
+    seq_lens.clone.return_value = torch.tensor([8, 6], dtype=torch.int32)
+    generated_metadata = torch.arange(1024, dtype=torch.int32)
+
+    with patch.object(
+        torch.ops._C_ascend,
+        "npu_vllm_quant_lightning_indexer_metadata",
+        create=True,
+        return_value=generated_metadata,
+    ) as metadata_op:
+        builder._build_qli_metadata(
+            query_start_loc=torch.tensor([0, 2, 3], dtype=torch.int32),
+            seq_lens=seq_lens,
+            num_reqs=2,
+            max_seqlen_q=2,
+            max_seqlen_k=8,
+        )
+
+    seq_lens.max.assert_not_called()
+    assert metadata_op.call_args.kwargs["max_seqlen_q"] == 2
+    assert metadata_op.call_args.kwargs["max_seqlen_k"] == 8
+
+
+def _make_dsa_cp_metadata(sas_metadata: torch.Tensor) -> AscendDSACPMetadata:
+    query_start_loc = torch.tensor([0, 1], dtype=torch.int32)
+    seq_lens = torch.tensor([1], dtype=torch.int32)
+    cp_metadata = DSACPMetadata(
+        local_query_start_loc=query_start_loc,
+        local_seq_lens=seq_lens,
+        local_start=0,
+        local_end=1,
+        tokens_per_rank=1,
+        num_tokens_pad=1,
+        local_sin=cast(Any, {"layer": torch.zeros((1, 1, 1, 2))}),
+        local_cos=cast(Any, {"layer": torch.ones((1, 1, 1, 2))}),
+    )
+    req_metadata = AscendDSACPReqMetadata(
+        input_positions=torch.zeros(1, dtype=torch.int32),
+        block_table=torch.zeros((1, 1), dtype=torch.int32),
+        seq_lens=seq_lens,
+        slot_mapping=torch.zeros((1, 2), dtype=torch.int32),
+        storage_block_size=128,
+        query_start_loc=query_start_loc,
+        cp_metadata=cp_metadata,
+        sin=cast(Any, {"layer": torch.zeros((1, 1, 1, 2))}),
+        cos=cast(Any, {"layer": torch.ones((1, 1, 1, 2))}),
+        sas_metadata=sas_metadata,
+        qli_metadata=torch.zeros(1024, dtype=torch.int32),
+        cu_cmp_seqlen_list=torch.tensor([0, 1], dtype=torch.int32),
+    )
+    return AscendDSACPMetadata(
+        num_actual_tokens=1,
+        query_start_loc=query_start_loc,
+        seq_lens=seq_lens,
+        block_tables=req_metadata.block_table,
+        sin=req_metadata.sin,
+        cos=req_metadata.cos,
+        num_decodes=0,
+        num_decode_tokens=0,
+        num_prefills=1,
+        req_metadata=req_metadata,
+        hadamard=torch.eye(2),
+    )
+
+
+def test_dsa_cp_indexer_waits_before_qli_consumer():
+    impl = AscendDSACPImpl.__new__(AscendDSACPImpl)
+    impl.inderxer_wq_b = MagicMock(return_value=torch.ones((1, 2)))
+    impl.inderxer_wq_b.quant_method = MagicMock()
+    impl.indexer_heads = 1
+    impl.indexcom_head_dim = 2
+    impl.rope_head_dim = 1
+    impl.weights_proj = MagicMock(return_value=torch.ones((1, 1)))
+    impl.indexer_softmax_scale = 1.0
+    impl.index_topk = 1
+    qli_metadata = torch.zeros(1024, dtype=torch.int32)
+    indexer_cache = SimpleNamespace(
+        req_metadata=SimpleNamespace(
+            qli_metadata=qli_metadata,
+            block_table=torch.zeros((1, 1), dtype=torch.int32),
+        ),
+        hadamard=torch.eye(2),
+    )
+    layer_metadata = AscendDSACPLayerMetadata(
+        swa=cast(Any, object()),
+        indexer_cache=cast(Any, indexer_cache),
+    )
+    waited = False
+
+    def record_wait(stage: DeviceMetadataStage, group_id: int) -> None:
+        nonlocal waited
+        assert (stage, group_id) == (DeviceMetadataStage.INDEXER, id(qli_metadata))
+        waited = True
+
+    def run_indexer(**kwargs):
+        assert waited
+        return torch.zeros((1, 1, 1), dtype=torch.int32), None
+
+    with (
+        patch.object(
+            DeviceOperator,
+            "unpack_dsa_indexer_kv_cache",
+            return_value=(torch.empty(0),) * 4,
+        ),
+        patch.object(DeviceOperator, "indexer_quantize_query", return_value=(torch.ones((1, 1, 2)), torch.ones(1))),
+        patch.object(DeviceOperator, "prepare_dsa_indexer_weights", side_effect=lambda value: value),
+        patch.object(DeviceOperator, "prepare_dsa_indexer_query_scale", side_effect=lambda value: value),
+        patch.object(DeviceOperator, "prepare_dsa_indexer_key_scale", side_effect=lambda value: value),
+        patch.object(torch.ops._C_ascend, "inplace_partial_rotary_mul", create=True),
+        patch.object(
+            torch.ops._C_ascend,
+            "npu_vllm_quant_lightning_indexer",
+            create=True,
+            side_effect=run_indexer,
+        ),
+        patch("vllm_ascend.attention.context_parallel.dsa_cp.rotate_activation", side_effect=lambda value, _: value),
+        patch(
+            "vllm_ascend.attention.context_parallel.dsa_cp.wait_for_device_metadata",
+            side_effect=record_wait,
+        ),
+    ):
+        impl._indexer_select_topk(
+            x=torch.ones((1, 2)),
+            qr=torch.ones((1, 2)),
+            kv_cache=(torch.empty(0),),
+            metadata=layer_metadata,
+            cos=torch.ones((1, 1, 1, 2)),
+            sin=torch.zeros((1, 1, 1, 2)),
+            actual_seq_lengths_query=torch.tensor([0, 1], dtype=torch.int32),
+            actual_seq_lengths_key=torch.tensor([1], dtype=torch.int32),
+        )
+
+    assert waited
+
+
+@pytest.mark.parametrize("compress_ratio", [1, 4, 128])
+def test_dsa_cp_attention_waits_before_sas_consumer(compress_ratio: int):
+    impl = AscendDSACPImpl.__new__(AscendDSACPImpl)
+    impl.compress_ratio = compress_ratio
+    impl.num_heads = 1
+    impl.head_dim = 2
+    impl.nope_head_dim = 1
+    impl.rope_head_dim = 1
+    impl.window_size = 16
+    impl.softmax_scale = 1.0
+    impl.eps = 1e-6
+    impl.attn_sink = None
+    impl.compressor_overlap = False
+    impl.wq_a = MagicMock(return_value=torch.ones((1, 2)))
+    impl.q_norm = MagicMock(side_effect=lambda value: value)
+    impl.wq_b = MagicMock(return_value=torch.ones((1, 2)))
+    impl.wq_b.quant_method = MagicMock()
+    impl.q_norm_without_weight = MagicMock()
+    impl.wkv = MagicMock(return_value=torch.ones((1, 2)))
+    impl.kv_norm = MagicMock(side_effect=lambda value: value)
+    impl._maybe_all_gather_o_proj_full_weight = MagicMock()
+    impl.compressor_wkv = SimpleNamespace(weight=torch.empty(0))
+    impl.compressor_wgate = SimpleNamespace(weight=torch.empty(0))
+    impl.compressor_ape = torch.empty(0)
+    impl.compressor_norm = SimpleNamespace(weight=torch.empty(0))
+    impl.compressor_norm_eps = 1e-6
+
+    swa_sas = torch.zeros(1024, dtype=torch.int32)
+    compressor_sas = torch.ones(1024, dtype=torch.int32)
+    swa_metadata = _make_dsa_cp_metadata(swa_sas)
+    compressor_metadata = _make_dsa_cp_metadata(compressor_sas)
+    layer_metadata = AscendDSACPLayerMetadata(
+        swa=swa_metadata,
+        compressor_cache=compressor_metadata if compress_ratio > 1 else None,
+        compressor_state=compressor_metadata if compress_ratio > 1 else None,
+        indexer_cache=compressor_metadata if compress_ratio == 4 else None,
+        indexer_state=compressor_metadata if compress_ratio == 4 else None,
+    )
+    expected_sas = swa_sas if compress_ratio <= 1 else compressor_sas
+    waited = False
+
+    def record_wait(stage: DeviceMetadataStage, group_id: int) -> None:
+        nonlocal waited
+        assert (stage, group_id) == (DeviceMetadataStage.ATTENTION, id(expected_sas))
+        waited = True
+
+    def run_attention(*args, **kwargs):
+        assert waited
+        return (torch.ones((1, 1, 2)),)
+
+    def add_extra_kwargs(extra_kwargs: dict[str, Any], **kwargs) -> None:
+        extra_kwargs.update(kwargs)
+
+    with (
+        patch.object(
+            DeviceOperator,
+            "unpack_dsa_forward_kv_cache",
+            return_value=(torch.empty(0), torch.empty(0), torch.zeros((1, 1, 1)), None, None, None),
+        ),
+        patch.object(DeviceOperator, "apply_dsa_q_rms", side_effect=lambda value, *_: value),
+        patch.object(DeviceOperator, "dsa_kv_compress_scatter"),
+        patch.object(DeviceOperator, "get_dsa_sparse_attn_op", return_value=run_attention),
+        patch.object(DeviceOperator, "get_dsa_sparse_attn_base_kwargs", return_value={}),
+        patch.object(DeviceOperator, "add_dsa_sparse_attn_extra_kwargs", side_effect=add_extra_kwargs),
+        patch.object(torch.ops._C_ascend, "inplace_partial_rotary_mul", create=True),
+        patch.object(torch.ops._C_ascend, "compressor", create=True, return_value=torch.empty(0)),
+        patch.object(impl, "_split_full_hidden_states_for_cp", side_effect=lambda value, _: value),
+        patch.object(impl, "_update_indexer_cache"),
+        patch.object(impl, "_indexer_select_topk", return_value=torch.zeros((1, 1, 1), dtype=torch.int32)),
+        patch.object(
+            impl,
+            "_compute_compressor_metadata",
+            return_value=(
+                torch.ones((1, 2)),
+                torch.zeros((1, 2)),
+                torch.zeros((1, 2), dtype=torch.int32),
+            ),
+        ),
+        patch("vllm_ascend.attention.context_parallel.dsa_cp.notify_kv_cache_written"),
+        patch("vllm_ascend.attention.context_parallel.dsa_cp.record_attention_compute_start"),
+        patch(
+            "vllm_ascend.attention.context_parallel.dsa_cp.wait_for_device_metadata",
+            side_effect=record_wait,
+        ),
+    ):
+        impl._forward(
+            "layer",
+            torch.ones((1, 2)),
+            (torch.empty(0),),
+            layer_metadata,
+        )
+
+    assert waited
 
 
 @pytest.mark.parametrize("for_drafting", [False, True])
@@ -1226,6 +1629,31 @@ def test_pcp_metadata_builds_from_manager_global_view():
     assert global_call.kwargs["common_ratio_to_sas_metadata"] == {}
     assert build_local.call_args.args[2] is local_common
     assert build_local.call_args.kwargs["num_actual_reqs"] == 7
+
+
+def test_pcp_metadata_provider_discards_unused_global_tasks():
+    builder = AscendDSAPCPMetadataBuilder.__new__(AscendDSAPCPMetadataBuilder)
+    local_task = DeviceMetadataTask(DeviceMetadataStage.INDEXER, MagicMock(), 1)
+    global_task = DeviceMetadataTask(DeviceMetadataStage.ATTENTION, MagicMock(), 2)
+    builder._device_metadata_tasks = (local_task,)
+    builder._global_metadata_builder = SimpleNamespace(
+        take_device_metadata_tasks=MagicMock(return_value=(global_task,)),
+    )
+
+    assert builder.take_device_metadata_tasks() == (local_task,)
+    assert builder._device_metadata_tasks == ()
+    builder._global_metadata_builder.take_device_metadata_tasks.assert_called_once_with()
+
+
+def test_pcp_metadata_provider_enables_local_and_global_builders():
+    builder = AscendDSAPCPMetadataBuilder.__new__(AscendDSAPCPMetadataBuilder)
+    builder._device_metadata_enabled = False
+    builder._global_metadata_builder = SimpleNamespace(enable_device_metadata=MagicMock())
+
+    builder.enable_device_metadata()
+
+    assert builder._device_metadata_enabled
+    builder._global_metadata_builder.enable_device_metadata.assert_called_once_with()
 
 
 @pytest.mark.parametrize("local_num_actual_tokens", [2, 0], ids=["local_tokens", "empty_rank"])

--- a/tests/ut/attention/test_dsa_v1.py
+++ b/tests/ut/attention/test_dsa_v1.py
@@ -178,6 +178,12 @@ def test_draft_swa_and_sas_share_attention_task():
         causal=False,
     )
     sas_result = torch.arange(DSA_METADATA_BUFFER_SIZE, dtype=torch.int32)
+    metadata_op = MagicMock(return_value=sas_result)
+    plan = _mock_dsa_kv_plan(
+        get_dsa_sparse_attn_metadata_kwargs={},
+        get_dsa_sparse_attn_metadata_op=metadata_op,
+    )
+    plan.layout_kv = "PA_BBND"
 
     with (
         patch.object(
@@ -186,12 +192,7 @@ def test_draft_swa_and_sas_share_attention_task():
             return_value=torch.tensor([0, 10, 24], dtype=torch.int32),
         ),
         patch.object(DeviceOperator, "get_dsa_decode_cu_seqlens_cmp_kv", return_value=None),
-        patch.object(DeviceOperator, "get_dsa_sparse_attn_metadata_kwargs", return_value={}),
-        patch.object(
-            DeviceOperator,
-            "get_dsa_sparse_attn_metadata_op",
-            return_value=MagicMock(return_value=sas_result),
-        ),
+        patch("vllm_ascend.attention.dsa_v1.get_dsa_attn_kv_plan", return_value=plan),
         patch(
             "vllm_ascend.attention.dsa_v1.build_dspark_swa_indices",
             wraps=build_dspark_swa_indices,
@@ -245,6 +246,7 @@ def test_draft_swa_and_sas_share_attention_task():
     assert builder.dspark_swa_indices_buffer.shape[0] == 16
     assert not torch.equal(next_metadata.dspark_swa_indices, first_indices[:3])
     assert torch.equal(metadata.sas_metadata, sas_result)
+    assert metadata_op.call_args.kwargs["layout_kv"] == "PA_BBND"
 
 
 def test_draft_swa_metadata_rejects_rows_above_buffer_capacity():
@@ -717,6 +719,7 @@ def test_dsa_cp_device_metadata_tasks(
     builder.req_qli_metadata = torch.zeros(1024, dtype=torch.int32)
     builder._device_metadata_enabled = device_metadata_enabled
     builder._device_metadata_tasks = ()
+    builder.vllm_config = MagicMock()
     builder.model_config = SimpleNamespace(
         hf_config=SimpleNamespace(num_attention_heads=64, index_topk=512),
         get_head_size=lambda: 512,
@@ -906,14 +909,17 @@ def test_build_compressor_metadata_out_uses_fixed_outputs():
         torch.empty((2, 1, 1, 4)),
         torch.empty((2, 2), dtype=torch.int32),
     )
+    vllm_config = MagicMock()
+    plan = _mock_dsa_kv_plan(get_dsa_compressor_slot_mapping_format=2)
 
     with (
-        patch.object(DeviceOperator, "get_dsa_compressor_slot_mapping_format", return_value=2),
+        patch("vllm_ascend.attention.dsa_v1.get_dsa_attn_kv_plan", return_value=plan),
         patch.object(torch.ops._C_ascend, "compressor_metadata_out", create=True) as metadata_out,
     ):
-        build_compressor_metadata_out(metadata, 4, outputs)
+        build_compressor_metadata_out(metadata, 4, outputs, vllm_config)
 
     assert metadata_out.call_args.args[-3:] == outputs
+    assert metadata_out.call_args.args[6] == 2
 
 
 def test_dsa_cp_compressor_waits_for_precomputed_metadata():
@@ -945,10 +951,12 @@ def test_dsa_cp_legacy_compressor_waits_for_device_local_metadata():
         storage_block_size=128,
     )
     impl.compress_ratio = 4
+    impl.vllm_config = MagicMock()
+    plan = _mock_dsa_kv_plan(get_dsa_compressor_slot_mapping_format=2)
 
     with (
         patch("vllm_ascend.attention.context_parallel.dsa_cp.wait_for_device_metadata") as wait,
-        patch.object(DeviceOperator, "get_dsa_compressor_slot_mapping_format", return_value=2),
+        patch("vllm_ascend.attention.context_parallel.dsa_cp.get_dsa_attn_kv_plan", return_value=plan),
         patch.object(torch.ops._C_ascend, "compressor_metadata", create=True, return_value=(1, 2, 3)),
     ):
         assert impl._compute_compressor_metadata(metadata) == (1, 2, 3)
@@ -1094,6 +1102,7 @@ def test_dsa_cp_attention_waits_before_sas_consumer(compress_ratio: int):
     impl.compressor_ape = torch.empty(0)
     impl.compressor_norm = SimpleNamespace(weight=torch.empty(0))
     impl.compressor_norm_eps = 1e-6
+    impl.vllm_config = MagicMock()
 
     swa_sas = torch.zeros(1024, dtype=torch.int32)
     compressor_sas = torch.ones(1024, dtype=torch.int32)
@@ -1107,19 +1116,25 @@ def test_dsa_cp_attention_waits_before_sas_consumer(compress_ratio: int):
         indexer_state=compressor_metadata if compress_ratio == 4 else None,
     )
     expected_sas = swa_sas if compress_ratio <= 1 else compressor_sas
-    waited = False
+    events: list[str] = []
 
     def record_wait(stage: DeviceMetadataStage, group_id: int) -> None:
-        nonlocal waited
         assert (stage, group_id) == (DeviceMetadataStage.ATTENTION, id(expected_sas))
-        waited = True
+        events.append("wait")
 
     def run_attention(*args, **kwargs):
-        assert waited
+        assert events == ["wait", "record"]
+        events.append("attention")
         return (torch.ones((1, 1, 2)),)
 
     def add_extra_kwargs(extra_kwargs: dict[str, Any], **kwargs) -> None:
         extra_kwargs.update(kwargs)
+
+    plan = _mock_dsa_kv_plan(
+        get_dsa_sparse_attn_op=run_attention,
+        get_dsa_sparse_attn_base_kwargs={},
+    )
+    plan.add_dsa_sparse_attn_extra_kwargs.side_effect = add_extra_kwargs
 
     with (
         patch.object(
@@ -1128,10 +1143,8 @@ def test_dsa_cp_attention_waits_before_sas_consumer(compress_ratio: int):
             return_value=(torch.empty(0), torch.empty(0), torch.zeros((1, 1, 1)), None, None, None),
         ),
         patch.object(DeviceOperator, "apply_dsa_q_rms", side_effect=lambda value, *_: value),
-        patch.object(DeviceOperator, "dsa_kv_compress_scatter"),
-        patch.object(DeviceOperator, "get_dsa_sparse_attn_op", return_value=run_attention),
-        patch.object(DeviceOperator, "get_dsa_sparse_attn_base_kwargs", return_value={}),
-        patch.object(DeviceOperator, "add_dsa_sparse_attn_extra_kwargs", side_effect=add_extra_kwargs),
+        patch("vllm_ascend.attention.context_parallel.dsa_cp.get_dsa_attn_kv_plan", return_value=plan),
+        patch("vllm_ascend.attention.dsa_v1.get_dsa_attn_kv_plan", return_value=plan),
         patch.object(torch.ops._C_ascend, "inplace_partial_rotary_mul", create=True),
         patch.object(torch.ops._C_ascend, "compressor", create=True, return_value=torch.empty(0)),
         patch.object(impl, "_split_full_hidden_states_for_cp", side_effect=lambda value, _: value),
@@ -1147,7 +1160,10 @@ def test_dsa_cp_attention_waits_before_sas_consumer(compress_ratio: int):
             ),
         ),
         patch("vllm_ascend.attention.context_parallel.dsa_cp.notify_kv_cache_written"),
-        patch("vllm_ascend.attention.context_parallel.dsa_cp.record_attention_compute_start"),
+        patch(
+            "vllm_ascend.attention.context_parallel.dsa_cp.record_attention_compute_start",
+            side_effect=lambda: events.append("record"),
+        ),
         patch(
             "vllm_ascend.attention.context_parallel.dsa_cp.wait_for_device_metadata",
             side_effect=record_wait,
@@ -1160,7 +1176,7 @@ def test_dsa_cp_attention_waits_before_sas_consumer(compress_ratio: int):
             layer_metadata,
         )
 
-    assert waited
+    assert events == ["wait", "record", "attention"]
 
 
 @pytest.mark.parametrize("for_drafting", [False, True])
@@ -1537,7 +1553,13 @@ def test_forward_attention_routes_unified_req_metadata(
         req_metadata=req_metadata,
     )
     swa_kv_cache = torch.empty(0)
-    sparse_attn_op = MagicMock(return_value=(attention_output,))
+    events: list[str] = []
+
+    def run_attention(*args, **kwargs):
+        events.append("attention")
+        return (attention_output,)
+
+    sparse_attn_op = MagicMock(side_effect=run_attention)
 
     def add_extra_kwargs(extra_kwargs: dict[str, Any], **kwargs) -> None:
         extra_kwargs.update(kwargs)
@@ -1568,7 +1590,14 @@ def test_forward_attention_routes_unified_req_metadata(
         ) as mla_prolog,
         patch("vllm_ascend.attention.dsa_v1.get_dsa_attn_kv_plan", return_value=plan),
         patch("vllm_ascend.attention.dsa_v1.notify_kv_cache_written"),
-        patch("vllm_ascend.attention.dsa_v1.record_attention_compute_start"),
+        patch(
+            "vllm_ascend.attention.dsa_v1.wait_for_device_metadata",
+            side_effect=lambda *_: events.append("wait"),
+        ),
+        patch(
+            "vllm_ascend.attention.dsa_v1.record_attention_compute_start",
+            side_effect=lambda: events.append("record"),
+        ),
     ):
         layer_metadata = impl._get_layer_metadata(
             "layer",
@@ -1582,6 +1611,7 @@ def test_forward_attention_routes_unified_req_metadata(
         )
 
     assert actual is attention_output
+    assert events == ["wait", "record", "attention"]
     mla_call = mla_prolog.call_args
     assert torch.equal(mla_call.args[0], hidden_states)
     assert torch.equal(mla_call.args[1], cos[:3])

--- a/tests/ut/attention/test_dsa_v1.py
+++ b/tests/ut/attention/test_dsa_v1.py
@@ -21,7 +21,6 @@ import numpy as np
 import pytest
 import torch
 from vllm.config import CUDAGraphMode
-from vllm.v1.attention.backend import AttentionCGSupport
 
 from vllm_ascend.attention.context_parallel.dsa_cp import (
     AscendDSACPImpl,
@@ -55,7 +54,6 @@ from vllm_ascend.worker.device_metadata import (
     DeviceMetadataTask,
 )
 from vllm_ascend.worker.v2.pcp_manager import (
-    AscendPCPAttentionContext,
     AscendPCPManager,
 )
 

--- a/tests/ut/attention/test_dsa_v1.py
+++ b/tests/ut/attention/test_dsa_v1.py
@@ -30,13 +30,9 @@ from vllm_ascend.attention.context_parallel.dsa_cp import (
     AscendDSAPCPImpl,
     AscendDSAPCPMetadata,
     AscendDSAPCPMetadataBuilder,
-    DSACPMetadata,
 )
 from vllm_ascend.attention.context_parallel.dsa_cp import (
     AscendDSAMetadata as AscendDSACPMetadata,
-)
-from vllm_ascend.attention.context_parallel.dsa_cp import (
-    AscendDSAReqMetadata as AscendDSACPReqMetadata,
 )
 from vllm_ascend.attention.dsa_v1 import (
     DSA_METADATA_BUFFER_SIZE,
@@ -47,7 +43,6 @@ from vllm_ascend.attention.dsa_v1 import (
     AscendDSAMetadataBuilder,
     AscendDSAReqMetadata,
     build_compressor_metadata_out,
-    build_dspark_swa_indices,
 )
 from vllm_ascend.device.device_op import DeviceOperator
 from vllm_ascend.models.deepseek_v4.compressor import AscendCompressorMetadata
@@ -73,10 +68,7 @@ def _mock_dsa_kv_plan(**method_returns) -> MagicMock:
     return plan
 
 
-def _make_builder(
-    compressor_ratio: int = 4,
-    num_speculative_tokens: int | None = None,
-) -> AscendDSAMetadataBuilder:
+def _make_vllm_config(num_speculative_tokens: int | None = None) -> SimpleNamespace:
     model_config = SimpleNamespace(
         hf_config=SimpleNamespace(
             model_type="test",
@@ -90,7 +82,7 @@ def _make_builder(
         enable_sleep_mode=False,
         get_head_size=lambda: 512,
     )
-    vllm_config = SimpleNamespace(
+    return SimpleNamespace(
         model_config=model_config,
         scheduler_config=SimpleNamespace(
             max_num_batched_tokens=16,
@@ -102,15 +94,25 @@ def _make_builder(
         compilation_config=SimpleNamespace(cudagraph_mode=CUDAGraphMode.NONE),
         parallel_config=SimpleNamespace(tensor_parallel_size=2),
     )
+
+
+def _make_kv_cache_spec(compressor_ratio: int) -> SimpleNamespace:
     physical_block_size = 128
     logical_compress_ratio = 128 if compressor_ratio > 4 else compressor_ratio
-    kv_cache_spec = SimpleNamespace(
+    return SimpleNamespace(
         compress_ratio=compressor_ratio,
         block_size=physical_block_size * logical_compress_ratio,
         storage_block_size=physical_block_size,
     )
+
+
+def _make_builder(
+    compressor_ratio: int = 4,
+    num_speculative_tokens: int | None = None,
+) -> AscendDSAMetadataBuilder:
+    vllm_config = _make_vllm_config(num_speculative_tokens)
     builder = AscendDSAMetadataBuilder(
-        kv_cache_spec=kv_cache_spec,
+        kv_cache_spec=_make_kv_cache_spec(compressor_ratio),
         layer_names=["model.layers.0.self_attn.attn"],
         vllm_config=vllm_config,
         device=torch.device("cpu"),
@@ -123,60 +125,50 @@ def _make_builder(
     return builder
 
 
-@pytest.mark.parametrize("num_speculative_tokens", [1, 3, 7])
-def test_build_dspark_swa_indices_writes_active_output(num_speculative_tokens: int):
-    block_table = torch.tensor([[2, 3], [5, 6]], dtype=torch.int32)
-    num_decode_tokens = 2 * num_speculative_tokens
-    query_start_loc = torch.tensor([0, num_speculative_tokens, num_decode_tokens], dtype=torch.int32)
-    seq_lens = torch.tensor([10, 14], dtype=torch.int32)
-    expected, expected_lens = build_dspark_swa_indices(
-        block_table,
-        num_speculative_tokens,
-        4,
-        8,
-        query_start_loc,
-        seq_lens,
-        num_decode_tokens,
-        index_width=16,
+def _make_cp_builder(compressor_ratio: int = 4) -> AscendDSACPMetadataBuilder:
+    builder = AscendDSACPMetadataBuilder(
+        kv_cache_spec=_make_kv_cache_spec(compressor_ratio),
+        layer_names=["model.layers.0.self_attn.attn"],
+        vllm_config=_make_vllm_config(),
+        device=torch.device("cpu"),
     )
-    output = torch.empty_like(expected)
+    builder.common_ratio_to_sas_metadata = {}
+    builder.seq_lens = torch.tensor([8, 6], dtype=torch.int32)
+    builder.seq_lens_cpu = builder.seq_lens
+    return builder
 
-    actual, actual_lens = build_dspark_swa_indices(
-        block_table,
-        num_speculative_tokens,
-        4,
-        8,
-        query_start_loc,
-        seq_lens,
-        num_decode_tokens,
-        index_width=16,
-        indices_output=output,
+
+def _build_draft_req_metadata(
+    builder: AscendDSAMetadataBuilder,
+    seq_lens: torch.Tensor,
+    block_table: torch.Tensor,
+    query_start_loc: torch.Tensor,
+) -> AscendDSAReqMetadata:
+    num_tokens = int(query_start_loc[-1])
+    builder.num_actual_tokens = num_tokens
+    builder.num_prefills = 0
+    builder.seq_lens = seq_lens
+    builder.block_table = block_table
+    common_attn_metadata = SimpleNamespace(
+        num_reqs=seq_lens.shape[0],
+        query_start_loc=query_start_loc,
+        query_start_loc_cpu=query_start_loc,
+        seq_lens_cpu=seq_lens,
+        _seq_lens_cpu=seq_lens,
+        causal=False,
     )
-
-    assert actual.data_ptr() == output.data_ptr()
-    assert torch.equal(actual, expected)
-    assert torch.equal(actual_lens, expected_lens)
+    return builder.build_req_metadata_for_drafting(
+        1,
+        common_attn_metadata,
+        torch.ones(num_tokens),
+        torch.zeros(num_tokens),
+    )
 
 
 def test_draft_swa_and_sas_share_attention_task():
     builder = _make_builder(1, num_speculative_tokens=3)
     builder.enable_dspark_device_metadata(max_num_tokens=16)
     assert builder.dspark_swa_indices_buffer is not None
-    buffer = builder.dspark_swa_indices_buffer
-    buffer_address = buffer.data_ptr()
-    builder.num_actual_tokens = 6
-    builder.num_prefills = 0
-    builder.seq_lens = torch.tensor([10, 14], dtype=torch.int32)
-    builder.block_table = torch.tensor([[2, 3], [5, 6]], dtype=torch.int32)
-    query_start_loc = torch.tensor([0, 3, 6], dtype=torch.int32)
-    common_attn_metadata = SimpleNamespace(
-        num_reqs=2,
-        query_start_loc=query_start_loc,
-        query_start_loc_cpu=query_start_loc,
-        seq_lens_cpu=builder.seq_lens,
-        _seq_lens_cpu=builder.seq_lens,
-        causal=False,
-    )
     sas_result = torch.arange(DSA_METADATA_BUFFER_SIZE, dtype=torch.int32)
     metadata_op = MagicMock(return_value=sas_result)
     plan = _mock_dsa_kv_plan(
@@ -193,336 +185,48 @@ def test_draft_swa_and_sas_share_attention_task():
         ),
         patch.object(DeviceOperator, "get_dsa_decode_cu_seqlens_cmp_kv", return_value=None),
         patch("vllm_ascend.attention.dsa_v1.get_dsa_attn_kv_plan", return_value=plan),
-        patch(
-            "vllm_ascend.attention.dsa_v1.build_dspark_swa_indices",
-            wraps=build_dspark_swa_indices,
-        ) as build_swa,
     ):
-        metadata = builder.build_req_metadata_for_drafting(
-            1,
-            common_attn_metadata,
-            torch.ones(6),
-            torch.zeros(6),
+        metadata = _build_draft_req_metadata(
+            builder,
+            torch.tensor([10, 14], dtype=torch.int32),
+            torch.tensor([[2, 3], [5, 6]], dtype=torch.int32),
+            torch.tensor([0, 3, 6], dtype=torch.int32),
         )
         task = builder.take_device_metadata_tasks()
-        assert build_swa.call_count == 0
-        assert builder.dspark_swa_indices_buffer is buffer
-        assert metadata.dspark_swa_indices.data_ptr() == buffer_address
-        assert len(task) == 1
+        metadata_op.assert_not_called()
+        assert metadata.dspark_swa_indices.data_ptr() == builder.dspark_swa_indices_buffer.data_ptr()
         assert task[0].stage == DeviceMetadataStage.ATTENTION
         assert task[0].group_id == id(metadata.sas_metadata)
 
         task[0].run()
 
         first_indices = metadata.dspark_swa_indices.clone()
-        builder.num_actual_tokens = 3
-        builder.seq_lens = torch.tensor([12], dtype=torch.int32)
-        builder.block_table = torch.tensor([[9, 10]], dtype=torch.int32)
-        next_query_start_loc = torch.tensor([0, 3], dtype=torch.int32)
-        next_common_attn_metadata = SimpleNamespace(
-            num_reqs=1,
-            query_start_loc=next_query_start_loc,
-            query_start_loc_cpu=next_query_start_loc,
-            seq_lens_cpu=builder.seq_lens,
-            _seq_lens_cpu=builder.seq_lens,
-            causal=False,
-        )
-        next_metadata = builder.build_req_metadata_for_drafting(
-            1,
-            next_common_attn_metadata,
-            torch.ones(3),
-            torch.zeros(3),
+        next_metadata = _build_draft_req_metadata(
+            builder,
+            torch.tensor([12], dtype=torch.int32),
+            torch.tensor([[9, 10]], dtype=torch.int32),
+            torch.tensor([0, 3], dtype=torch.int32),
         )
         next_task = builder.take_device_metadata_tasks()
-        assert builder.dspark_swa_indices_buffer is buffer
-        assert builder.dspark_swa_indices_buffer.data_ptr() == buffer_address
-        assert next_metadata.dspark_swa_indices.shape[0] == 3
         assert next_metadata.dspark_swa_indices.data_ptr() == metadata.dspark_swa_indices.data_ptr()
         next_task[0].run()
 
-    assert build_swa.call_count == 2
-    assert build_swa.call_args.kwargs["indices_output"] is next_metadata.dspark_swa_indices
-    assert metadata.dspark_swa_indices.data_ptr() == builder.dspark_swa_indices_buffer.data_ptr()
-    assert builder.dspark_swa_indices_buffer.shape[0] == 16
+    assert metadata_op.call_count == 2
     assert not torch.equal(next_metadata.dspark_swa_indices, first_indices[:3])
     assert torch.equal(metadata.sas_metadata, sas_result)
-    assert metadata_op.call_args.kwargs["layout_kv"] == "PA_BBND"
 
 
 def test_draft_swa_metadata_rejects_rows_above_buffer_capacity():
     builder = _make_builder(1, num_speculative_tokens=3)
     builder.enable_dspark_device_metadata(max_num_tokens=16)
-    builder.num_actual_tokens = 17
-    builder.num_prefills = 0
-    builder.seq_lens = torch.tensor([17], dtype=torch.int32)
-    builder.block_table = torch.ones((1, 2), dtype=torch.int32)
-    query_start_loc = torch.tensor([0, 17], dtype=torch.int32)
-    common_attn_metadata = SimpleNamespace(
-        num_reqs=1,
-        query_start_loc=query_start_loc,
-        query_start_loc_cpu=query_start_loc,
-        seq_lens_cpu=builder.seq_lens,
-        _seq_lens_cpu=builder.seq_lens,
-        causal=False,
-    )
 
     with pytest.raises(ValueError, match=r"active=17, capacity=16"):
-        builder.build_req_metadata_for_drafting(
-            1,
-            common_attn_metadata,
-            torch.ones(17),
-            torch.zeros(17),
+        _build_draft_req_metadata(
+            builder,
+            torch.tensor([17], dtype=torch.int32),
+            torch.ones((1, 2), dtype=torch.int32),
+            torch.tensor([0, 17], dtype=torch.int32),
         )
-
-
-@pytest.mark.parametrize(
-    ("compressor_ratio", "num_tokens", "num_reqs", "expected_rows"),
-    [
-        (1, 13, 3, 13),
-        (4, 13, 3, 6),
-        (128, 13, 3, 3),
-    ],
-)
-def test_num_compressor_metadata_rows(
-    compressor_ratio: int,
-    num_tokens: int,
-    num_reqs: int,
-    expected_rows: int,
-):
-    builder = _make_builder(compressor_ratio)
-    builder.num_actual_tokens = num_tokens
-
-    assert builder._num_compressor_metadata_rows(num_reqs) == expected_rows
-
-
-@pytest.mark.parametrize(
-    ("compressor_ratio", "expected_cmp_ratio", "expected_cmp_topk", "expected_has_cmp_kv"),
-    [
-        (1, 1, 0, False),
-        (4, 4, 512, True),
-        (8, 128, 0, True),
-        (128, 128, 0, True),
-    ],
-)
-def test_build_sas_metadata_parameters_cache_and_builder_buffer(
-    compressor_ratio,
-    expected_cmp_ratio,
-    expected_cmp_topk,
-    expected_has_cmp_kv,
-):
-    builder = _make_builder(compressor_ratio)
-    metadata_cache: dict[str, torch.Tensor] = {}
-    query_start_loc = torch.tensor([0, 2, 3], dtype=torch.int32)
-    seq_lens = torch.tensor([8, 6], dtype=torch.int32)
-    cu_seqlens_ori_kv = torch.tensor([0, 8, 14], dtype=torch.int32)
-    cu_seqlens_cmp_kv = torch.tensor([0, 2, 4], dtype=torch.int32)
-    generated_metadata = torch.arange(DSA_METADATA_BUFFER_SIZE, dtype=torch.int32)
-    metadata_op = MagicMock(return_value=generated_metadata)
-    plan = _mock_dsa_kv_plan(
-        get_dsa_sparse_attn_metadata_op=metadata_op,
-        get_dsa_sparse_attn_metadata_kwargs={"device": "cpu"},
-    )
-
-    with (
-        patch(
-            "vllm_ascend.attention.dsa_v1.get_tensor_model_parallel_world_size",
-            return_value=2,
-        ),
-        patch("vllm_ascend.attention.dsa_v1.get_dsa_attn_kv_plan", return_value=plan),
-    ):
-        result = builder._build_sas_metadata(
-            metadata_cache=metadata_cache,
-            layer_name=f"c{compressor_ratio}",
-            query_start_loc=query_start_loc,
-            seq_lens=seq_lens,
-            max_seqlen_q=2,
-            max_seqlen_kv=8,
-            cu_seqlens_ori_kv=cu_seqlens_ori_kv,
-            cu_seqlens_cmp_kv=cu_seqlens_cmp_kv,
-        )
-        cached_result = builder._build_sas_metadata(
-            metadata_cache=metadata_cache,
-            layer_name=f"c{compressor_ratio}",
-            query_start_loc=query_start_loc,
-            seq_lens=seq_lens,
-            max_seqlen_q=2,
-            max_seqlen_kv=8,
-            cu_seqlens_ori_kv=cu_seqlens_ori_kv,
-            cu_seqlens_cmp_kv=cu_seqlens_cmp_kv,
-        )
-
-    assert result is builder.sas_metadata_buffer
-    assert cached_result is builder.sas_metadata_buffer
-    assert torch.equal(builder.sas_metadata_buffer, generated_metadata)
-    metadata_op.assert_called_once()
-    call_kwargs = metadata_op.call_args.kwargs
-    assert call_kwargs["device"] == "cpu"
-    assert call_kwargs["num_heads_q"] == 32
-    assert call_kwargs["cmp_ratio"] == expected_cmp_ratio
-    assert call_kwargs["cmp_topk"] == expected_cmp_topk
-    assert call_kwargs["has_cmp_kv"] is expected_has_cmp_kv
-    assert call_kwargs["cu_seqlens_q"] is query_start_loc
-    assert call_kwargs["cu_seqlens_ori_kv"] is cu_seqlens_ori_kv
-    assert call_kwargs["cu_seqlens_cmp_kv"] is cu_seqlens_cmp_kv
-    assert call_kwargs["seqused_kv"] is seq_lens
-
-
-def test_build_qli_metadata_parameters_cache_and_builder_buffer():
-    builder = _make_builder()
-    metadata_cache: dict[str, torch.Tensor] = {}
-    query_start_loc = torch.tensor([0, 2, 3], dtype=torch.int32)
-    seq_lens = torch.tensor([8, 6], dtype=torch.int32)
-    generated_metadata = torch.arange(DSA_METADATA_BUFFER_SIZE, dtype=torch.int32)
-
-    with patch.object(
-        torch.ops._C_ascend,
-        "npu_vllm_quant_lightning_indexer_metadata",
-        create=True,
-        return_value=generated_metadata,
-    ) as metadata_op:
-        result = builder._build_qli_metadata(
-            metadata_cache=metadata_cache,
-            query_start_loc=query_start_loc,
-            seq_lens=seq_lens,
-            max_seqlen_q=2,
-            max_seqlen_kv=8,
-        )
-        cached_result = builder._build_qli_metadata(
-            metadata_cache=metadata_cache,
-            query_start_loc=query_start_loc,
-            seq_lens=seq_lens,
-            max_seqlen_q=2,
-            max_seqlen_kv=8,
-        )
-
-    assert result is builder.qli_metadata_buffer
-    assert cached_result is builder.qli_metadata_buffer
-    assert torch.equal(builder.qli_metadata_buffer, generated_metadata)
-    metadata_op.assert_called_once()
-    call_kwargs = metadata_op.call_args.kwargs
-    assert torch.equal(call_kwargs["actual_seq_lengths_query"], query_start_loc[1:])
-    assert torch.equal(call_kwargs["actual_seq_lengths_key"], seq_lens)
-    assert call_kwargs["max_seqlen_q"] == 2
-    assert call_kwargs["max_seqlen_k"] == 8
-    assert call_kwargs["cmp_ratio"] == 4
-
-
-@pytest.mark.parametrize("num_prefills", [0, 1])
-def test_build_req_metadata_uses_for_prefill_and_decode(
-    num_prefills: int,
-):
-    builder = _make_builder()
-    metadata_cache: dict[str, Any] = {}
-    query_start_loc = torch.tensor([0, 2, 3], dtype=torch.int32)
-    seq_lens_cpu = torch.tensor([8, 6], dtype=torch.int32)
-    input_positions = torch.tensor([0, 1, 2], dtype=torch.int64)
-    common_attn_metadata = SimpleNamespace(
-        num_reqs=2,
-        num_actual_tokens=3,
-        num_input_tokens=3,
-        positions=input_positions,
-        seq_lens=seq_lens_cpu,
-        _seq_lens_cpu=seq_lens_cpu,
-        seq_lens_cpu=None,
-        slot_mapping=torch.arange(3, dtype=torch.int32),
-        block_table_tensor=torch.tensor([[1, 2], [3, 4]], dtype=torch.int32),
-        query_start_loc=query_start_loc,
-        query_start_loc_cpu=query_start_loc,
-        attn_state=MagicMock(),
-        causal=True,
-    )
-    sas_metadata = builder.sas_metadata_buffer.fill_(1)
-    qli_metadata = builder.qli_metadata_buffer.fill_(2)
-    builder._build_sas_metadata = MagicMock(return_value=sas_metadata)
-    builder._build_qli_metadata = MagicMock(return_value=qli_metadata)
-    decode_cu_seqlens_ori_kv = torch.tensor([0, 8, 14], dtype=torch.int32)
-    decode_cu_seqlens_cmp_kv = torch.tensor([0, 2, 4], dtype=torch.int32)
-    full_compress_cos = torch.ones((4, 1, 1, 2))
-    full_compress_sin = torch.zeros((4, 1, 1, 2))
-    cos = torch.ones((3, 1, 1, 2))
-    sin = torch.zeros((3, 1, 1, 2))
-
-    with (
-        patch(
-            "vllm_ascend.attention.dsa_v1.split_decodes_and_prefills",
-            return_value=(2, 0, 3, 0) if num_prefills == 0 else (1, 1, 1, 2),
-        ),
-        patch(
-            "vllm_ascend.attention.dsa_v1.get_dsa_attn_kv_plan",
-            return_value=_mock_dsa_kv_plan(
-                format_dsa_slot_mapping=torch.zeros((3, 2), dtype=torch.int32),
-            ),
-        ),
-        patch.object(
-            DeviceOperator,
-            "get_dsa_decode_cu_seqlens_ori_kv",
-            return_value=decode_cu_seqlens_ori_kv,
-        ),
-        patch.object(
-            DeviceOperator,
-            "get_dsa_decode_cu_seqlens_cmp_kv",
-            return_value=decode_cu_seqlens_cmp_kv,
-        ),
-        patch(
-            "vllm_ascend.attention.dsa_v1.get_full_cos_and_sin_dsa",
-            return_value=(full_compress_cos, full_compress_sin),
-        ),
-        patch(
-            "vllm_ascend.attention.dsa_v1.get_cos_and_sin_dsa",
-            return_value=(cos, sin),
-        ) as rope_op,
-    ):
-        metadata = builder.build(
-            common_prefix_len=0,
-            common_attn_metadata=common_attn_metadata,
-            common_ratio_to_sas_metadata=metadata_cache,
-        )
-        cached_metadata = builder.build(
-            common_prefix_len=0,
-            common_attn_metadata=common_attn_metadata,
-            common_ratio_to_sas_metadata=metadata_cache,
-        )
-
-    rope_op.assert_called_once()
-    assert torch.equal(rope_op.call_args.args[0], input_positions)
-    assert rope_op.call_args.kwargs["use_cache"] is (num_prefills == 0)
-    assert metadata_cache["cos"] is cos
-    assert metadata_cache["sin"] is sin
-    req_metadata = cast(AscendDSAReqMetadata, metadata.req_metadata)
-    cached_req_metadata = cast(AscendDSAReqMetadata, cached_metadata.req_metadata)
-    assert req_metadata.cos is cos
-    assert req_metadata.sin is sin
-    assert cached_req_metadata.cos is cos
-    assert cached_req_metadata.sin is sin
-    sas_kwargs = builder._build_sas_metadata.call_args.kwargs
-    qli_kwargs = builder._build_qli_metadata.call_args.kwargs
-    assert sas_kwargs["metadata_cache"] is metadata_cache
-    assert torch.equal(sas_kwargs["query_start_loc"], query_start_loc)
-    assert torch.equal(sas_kwargs["seq_lens"], builder.seq_lens)
-    assert sas_kwargs["max_seqlen_q"] == 2
-    assert sas_kwargs["max_seqlen_kv"] == 8
-    assert qli_kwargs["metadata_cache"] is metadata_cache
-    assert torch.equal(qli_kwargs["query_start_loc"], query_start_loc)
-    assert torch.equal(qli_kwargs["seq_lens"], builder.seq_lens)
-    assert qli_kwargs["max_seqlen_q"] == 2
-    assert qli_kwargs["max_seqlen_kv"] == 8
-    if num_prefills:
-        assert torch.equal(sas_kwargs["cu_seqlens_ori_kv"], query_start_loc)
-        assert sas_kwargs["cu_seqlens_cmp_kv"] is None
-    else:
-        assert sas_kwargs["cu_seqlens_ori_kv"] is decode_cu_seqlens_ori_kv
-        assert sas_kwargs["cu_seqlens_cmp_kv"] is decode_cu_seqlens_cmp_kv
-
-    assert req_metadata.sas_metadata is sas_metadata
-    assert req_metadata.qli_metadata is qli_metadata
-    assert torch.equal(req_metadata.query_start_loc, query_start_loc)
-    assert torch.equal(req_metadata.block_table, builder.block_table)
-    assert torch.equal(
-        req_metadata.start_pos,
-        torch.tensor([6, 5], dtype=torch.int32),
-    )
-    assert req_metadata.num_compressed_tokens == 2
-    assert req_metadata.slot_mapping is None
 
 
 @pytest.mark.parametrize(
@@ -645,85 +349,50 @@ def test_full_graph_compressor_metadata_uses_capture_bucket_extent():
     assert capture_metadata.compressor_metadata is not None
     assert capture_metadata.compressor_metadata[0].shape == metadata.compressor_metadata[0].shape
     assert capture_metadata.compressor_metadata[0].data_ptr() == metadata.compressor_metadata[0].data_ptr()
-
-
-def test_pure_full_graph_keeps_compressor_metadata_on_legacy_path():
-    builder = _make_builder(128)
-    builder.vllm_config.compilation_config.cudagraph_mode = CUDAGraphMode.FULL
-
-    builder.enable_device_metadata()
-
-    assert builder.compressor_metadata_buffers is None
-
-    cp_builder = AscendDSACPMetadataBuilder.__new__(AscendDSACPMetadataBuilder)
-    cp_builder._device_metadata_enabled = False
-    cp_builder.compressor_ratio = 128
-    cp_builder.compressor_metadata_buffers = None
-    cp_builder.vllm_config = builder.vllm_config
-    cp_builder.enable_device_metadata()
-
-    assert cp_builder._device_metadata_enabled
-    assert cp_builder.compressor_metadata_buffers is None
+    for full_graph_builder in (_make_builder(128), _make_cp_builder(128)):
+        full_graph_builder.vllm_config.compilation_config.cudagraph_mode = CUDAGraphMode.FULL
+        full_graph_builder.enable_device_metadata()
+        assert full_graph_builder.compressor_metadata_buffers is None
 
 
 @pytest.mark.parametrize(
     (
         "compressor_ratio",
-        "device_metadata_enabled",
         "full_graph_mode",
         "num_input_tokens",
         "num_actual_reqs",
-        "expected_rows",
         "expected_stages",
     ),
     [
-        (4, True, False, 3, None, 2, [DeviceMetadataStage.COMPRESSOR, *list(DeviceMetadataStage)]),
+        (4, False, 3, None, [DeviceMetadataStage.COMPRESSOR, *list(DeviceMetadataStage)]),
         (
             128,
-            True,
             False,
             3,
             None,
-            2,
             [DeviceMetadataStage.COMPRESSOR, DeviceMetadataStage.COMPRESSOR, DeviceMetadataStage.ATTENTION],
         ),
-        (4, True, True, 4, 1, 3, [DeviceMetadataStage.COMPRESSOR, *list(DeviceMetadataStage)]),
-        (4, False, False, 3, None, 2, []),
+        (4, True, 4, 1, [DeviceMetadataStage.COMPRESSOR, *list(DeviceMetadataStage)]),
     ],
 )
 def test_dsa_cp_device_metadata_tasks(
     compressor_ratio: int,
-    device_metadata_enabled: bool,
     full_graph_mode: bool,
     num_input_tokens: int,
     num_actual_reqs: int | None,
-    expected_rows: int,
     expected_stages: list[DeviceMetadataStage],
 ):
-    builder = AscendDSACPMetadataBuilder.__new__(AscendDSACPMetadataBuilder)
+    builder = _make_cp_builder(compressor_ratio)
     builder.num_prefills = 1
     builder.num_actual_tokens = 3
-    builder.compressor_ratio = compressor_ratio
-    builder.storage_block_size = 128
-    builder.seq_lens = torch.tensor([8, 6], dtype=torch.int32)
-    builder.seq_lens_cpu = builder.seq_lens
     builder.block_table = torch.tensor([[1, 2], [3, 4]], dtype=torch.int32)
-    builder.start_pos_prefill = torch.zeros(2, dtype=torch.int32)
     builder.slot_mapping = torch.zeros((3, 2), dtype=torch.int32)
     builder.compressor_metadata_buffers = (
         torch.empty((3, 1, 1, 4)),
         torch.empty((3, 1, 1, 4)),
         builder.slot_mapping,
     )
-    builder.req_sas_metadata = torch.zeros(1024, dtype=torch.int32)
-    builder.req_qli_metadata = torch.zeros(1024, dtype=torch.int32)
-    builder._device_metadata_enabled = device_metadata_enabled
-    builder._device_metadata_tasks = ()
-    builder.vllm_config = MagicMock()
-    builder.model_config = SimpleNamespace(
-        hf_config=SimpleNamespace(num_attention_heads=64, index_topk=512),
-        get_head_size=lambda: 512,
-    )
+    builder._device_metadata_enabled = True
     query_start_loc = torch.tensor([0, 2, num_input_tokens], dtype=torch.int32)
     builder.common_ratio_to_sas_metadata = {
         "_cpu_local": {
@@ -740,7 +409,7 @@ def test_dsa_cp_device_metadata_tasks(
             3,
             query_start_loc,
             builder.seq_lens,
-            build_local_metadata if device_metadata_enabled else None,
+            build_local_metadata,
         )
     )
     builder._get_cmp_seqlens_for_metadata = MagicMock(return_value=None)
@@ -756,20 +425,6 @@ def test_dsa_cp_device_metadata_tasks(
         "vllm_ascend.attention.context_parallel.dsa_cp.get_full_cos_and_sin_dsa",
         return_value=(torch.ones(1), torch.zeros(1)),
     ):
-        capture_metadata = None
-        if full_graph_mode:
-            builder.num_actual_tokens = num_input_tokens
-            capture_metadata = builder.build_req_metadata(
-                common_attn_metadata,
-                input_positions=None,
-                num_input_tokens=num_input_tokens,
-                num_actual_reqs=2,
-                attn_state=MagicMock(),
-                cos=MagicMock(),
-                sin=MagicMock(),
-                full_graph_mode=True,
-            )
-            builder.num_actual_tokens = 3
         req_metadata = builder.build_req_metadata(
             common_attn_metadata,
             input_positions=None,
@@ -791,24 +446,15 @@ def test_dsa_cp_device_metadata_tasks(
     )
     assert all(task.group_id in group_ids for task in tasks)
     assert req_metadata.sas_metadata is builder.req_sas_metadata
-    assert req_metadata.num_compressed_tokens == expected_rows
     assert req_metadata.num_actual_reqs == (2 if full_graph_mode else num_actual_reqs or 2)
-    if capture_metadata is not None:
-        assert capture_metadata.compressor_metadata is not None
-        assert req_metadata.compressor_metadata is not None
-        assert capture_metadata.compressor_metadata[0].shape == req_metadata.compressor_metadata[0].shape
-        assert capture_metadata.compressor_metadata[0].data_ptr() == req_metadata.compressor_metadata[0].data_ptr()
     assert (req_metadata.qli_metadata is builder.req_qli_metadata) is (compressor_ratio == 4)
-    if device_metadata_enabled:
-        builder._build_sas_metadata.assert_not_called()
-        builder._build_qli_metadata.assert_not_called()
-        with patch("vllm_ascend.attention.dsa_v1.build_compressor_metadata_out") as build_compressor:
-            for task in tasks:
-                task.run()
-        build_compressor.assert_called_once()
-        build_local_metadata.assert_called_once_with()
-        expected_start_pos = torch.tensor([1, 0] if full_graph_mode else [1, 1], dtype=torch.int32)
-        assert torch.equal(builder.start_pos_prefill, expected_start_pos)
+    builder._build_sas_metadata.assert_not_called()
+    builder._build_qli_metadata.assert_not_called()
+    with patch("vllm_ascend.attention.dsa_v1.build_compressor_metadata_out") as build_compressor:
+        for task in tasks:
+            task.run()
+    build_compressor.assert_called_once()
+    build_local_metadata.assert_called_once_with()
     builder._build_sas_metadata.assert_called_once()
     if compressor_ratio == 4:
         builder._build_qli_metadata.assert_called_once()
@@ -822,23 +468,16 @@ def test_dsa_cp_device_local_metadata_is_deferred_and_reused():
     cache: dict[str, dict[str, torch.Tensor]] = {}
 
     def make_builder():
-        builder = AscendDSACPMetadataBuilder.__new__(AscendDSACPMetadataBuilder)
+        builder = _make_cp_builder()
         builder._device_metadata_enabled = True
         builder.common_ratio_to_sas_metadata = cache
-        builder.local_query_start_loc = torch.zeros(3, dtype=torch.int32)
-        builder.local_seq_lens = torch.zeros(2, dtype=torch.int32)
-        builder.start_pos_prefill = torch.zeros(2, dtype=torch.int32)
         return builder
 
     first_builder = make_builder()
     second_builder = make_builder()
     query_start_loc = torch.tensor([0, 2, 4], dtype=torch.int32)
     seq_lens = torch.tensor([2, 4], dtype=torch.int32)
-    first_addresses = (
-        first_builder.local_query_start_loc.data_ptr(),
-        first_builder.local_seq_lens.data_ptr(),
-        first_builder.start_pos_prefill.data_ptr(),
-    )
+    first_qsl_address = first_builder.local_query_start_loc.data_ptr()
 
     with patch(
         "vllm_ascend.attention.context_parallel.dsa_cp.get_tp_group",
@@ -850,33 +489,18 @@ def test_dsa_cp_device_local_metadata_is_deferred_and_reused():
         second[-1]()
 
     assert first[:4] == (0, 2, 2, 4)
-    assert torch.equal(first_builder.local_query_start_loc, torch.tensor([0, 2, 2], dtype=torch.int32))
-    assert torch.equal(first_builder.local_seq_lens, torch.tensor([2, 0], dtype=torch.int32))
-    assert torch.equal(first_builder.start_pos_prefill, torch.tensor([0, 2], dtype=torch.int32))
-    assert torch.equal(second_builder.local_query_start_loc, first_builder.local_query_start_loc)
-    assert torch.equal(second_builder.local_seq_lens, first_builder.local_seq_lens)
-    assert torch.equal(second_builder.start_pos_prefill, first_builder.start_pos_prefill)
-    assert cache["_device_local"]["qsl"].data_ptr() == first_addresses[0]
-    assert first_addresses == (
-        first_builder.local_query_start_loc.data_ptr(),
-        first_builder.local_seq_lens.data_ptr(),
-        first_builder.start_pos_prefill.data_ptr(),
-    )
+    assert torch.equal(first_builder.local_query_start_loc[:3], torch.tensor([0, 2, 2], dtype=torch.int32))
+    assert torch.equal(first_builder.local_seq_lens[:2], torch.tensor([2, 0], dtype=torch.int32))
+    assert torch.equal(first_builder.start_pos_prefill[:2], torch.tensor([0, 2], dtype=torch.int32))
+    assert torch.equal(second_builder.local_query_start_loc[:3], first_builder.local_query_start_loc[:3])
+    assert torch.equal(second_builder.local_seq_lens[:2], first_builder.local_seq_lens[:2])
+    assert torch.equal(second_builder.start_pos_prefill[:2], first_builder.start_pos_prefill[:2])
+    assert cache["_device_local"]["qsl"].data_ptr() == first_qsl_address
+    assert first_builder.local_query_start_loc.data_ptr() == first_qsl_address
 
 
 def test_dsa_cp_qli_metadata_uses_host_maxima():
-    builder = AscendDSACPMetadataBuilder.__new__(AscendDSACPMetadataBuilder)
-    builder.compressor_ratio = 4
-    builder.common_ratio_to_sas_metadata = {}
-    builder.req_qli_metadata = torch.zeros(1024, dtype=torch.int32)
-    builder.seqused_q = torch.empty(0)
-    builder.model_config = SimpleNamespace(
-        hf_config=SimpleNamespace(
-            index_n_heads=64,
-            index_head_dim=128,
-            index_topk=512,
-        )
-    )
+    builder = _make_cp_builder()
     seq_lens = MagicMock()
     seq_lens.clone.return_value = torch.tensor([8, 6], dtype=torch.int32)
     generated_metadata = torch.arange(1024, dtype=torch.int32)
@@ -972,47 +596,39 @@ def test_dsa_cp_legacy_compressor_waits_for_device_local_metadata():
 
 def _make_dsa_cp_metadata(sas_metadata: torch.Tensor) -> AscendDSACPMetadata:
     query_start_loc = torch.tensor([0, 1], dtype=torch.int32)
-    seq_lens = torch.tensor([1], dtype=torch.int32)
-    cp_metadata = DSACPMetadata(
+    cp_metadata = SimpleNamespace(
         local_query_start_loc=query_start_loc,
-        local_seq_lens=seq_lens,
-        local_start=0,
-        local_end=1,
-        tokens_per_rank=1,
-        num_tokens_pad=1,
-        local_sin=cast(Any, {"layer": torch.zeros((1, 1, 1, 2))}),
-        local_cos=cast(Any, {"layer": torch.ones((1, 1, 1, 2))}),
+        local_seq_lens=torch.ones(1, dtype=torch.int32),
+        local_sin={"layer": torch.zeros((1, 1, 1, 2))},
+        local_cos={"layer": torch.ones((1, 1, 1, 2))},
     )
-    req_metadata = AscendDSACPReqMetadata(
-        input_positions=torch.zeros(1, dtype=torch.int32),
+    req_metadata = SimpleNamespace(
         block_table=torch.zeros((1, 1), dtype=torch.int32),
-        seq_lens=seq_lens,
         slot_mapping=torch.zeros((1, 2), dtype=torch.int32),
-        storage_block_size=128,
         query_start_loc=query_start_loc,
         cp_metadata=cp_metadata,
-        sin=cast(Any, {"layer": torch.zeros((1, 1, 1, 2))}),
-        cos=cast(Any, {"layer": torch.ones((1, 1, 1, 2))}),
+        sin={"layer": torch.zeros((1, 1, 1, 2))},
+        cos={"layer": torch.ones((1, 1, 1, 2))},
         sas_metadata=sas_metadata,
         qli_metadata=torch.zeros(1024, dtype=torch.int32),
         cu_cmp_seqlen_list=torch.tensor([0, 1], dtype=torch.int32),
+        start_pos=torch.zeros(1, dtype=torch.int32),
+        dspark_swa_indices=None,
+        ori_win_left=None,
+        ori_win_right=None,
     )
-    return AscendDSACPMetadata(
-        num_actual_tokens=1,
-        query_start_loc=query_start_loc,
-        seq_lens=seq_lens,
-        block_tables=req_metadata.block_table,
-        sin=req_metadata.sin,
-        cos=req_metadata.cos,
-        num_decodes=0,
-        num_decode_tokens=0,
-        num_prefills=1,
-        req_metadata=req_metadata,
-        hadamard=torch.eye(2),
+    return cast(
+        AscendDSACPMetadata,
+        SimpleNamespace(
+            num_actual_tokens=1,
+            num_prefills=1,
+            req_metadata=req_metadata,
+            hadamard=torch.eye(2),
+        ),
     )
 
 
-def test_dsa_cp_indexer_waits_before_qli_consumer():
+def test_dsa_cp_indexer_waits_before_qli_consumer(monkeypatch):
     impl = AscendDSACPImpl.__new__(AscendDSACPImpl)
     impl.inderxer_wq_b = MagicMock(return_value=torch.ones((1, 2)))
     impl.inderxer_wq_b.quant_method = MagicMock()
@@ -1045,63 +661,52 @@ def test_dsa_cp_indexer_waits_before_qli_consumer():
         assert waited
         return torch.zeros((1, 1, 1), dtype=torch.int32), None
 
-    with (
-        patch.object(
-            DeviceOperator,
-            "unpack_dsa_indexer_kv_cache",
-            return_value=(torch.empty(0),) * 4,
-        ),
-        patch.object(DeviceOperator, "indexer_quantize_query", return_value=(torch.ones((1, 1, 2)), torch.ones(1))),
-        patch.object(DeviceOperator, "prepare_dsa_indexer_weights", side_effect=lambda value: value),
-        patch.object(DeviceOperator, "prepare_dsa_indexer_query_scale", side_effect=lambda value: value),
-        patch.object(DeviceOperator, "prepare_dsa_indexer_key_scale", side_effect=lambda value: value),
-        patch.object(torch.ops._C_ascend, "inplace_partial_rotary_mul", create=True),
-        patch.object(
-            torch.ops._C_ascend,
-            "npu_vllm_quant_lightning_indexer",
-            create=True,
-            side_effect=run_indexer,
-        ),
-        patch("vllm_ascend.attention.context_parallel.dsa_cp.rotate_activation", side_effect=lambda value, _: value),
-        patch(
-            "vllm_ascend.attention.context_parallel.dsa_cp.wait_for_device_metadata",
-            side_effect=record_wait,
-        ),
-    ):
-        impl._indexer_select_topk(
-            x=torch.ones((1, 2)),
-            qr=torch.ones((1, 2)),
-            kv_cache=(torch.empty(0),),
-            metadata=layer_metadata,
-            cos=torch.ones((1, 1, 1, 2)),
-            sin=torch.zeros((1, 1, 1, 2)),
-            actual_seq_lengths_query=torch.tensor([0, 1], dtype=torch.int32),
-            actual_seq_lengths_key=torch.tensor([1], dtype=torch.int32),
-        )
+    monkeypatch.setattr(DeviceOperator, "unpack_dsa_indexer_kv_cache", lambda *_: (torch.empty(0),) * 4)
+    monkeypatch.setattr(
+        DeviceOperator,
+        "indexer_quantize_query",
+        lambda *_: (torch.ones((1, 1, 2)), torch.ones(1)),
+    )
+    for name in ("prepare_dsa_indexer_weights", "prepare_dsa_indexer_query_scale", "prepare_dsa_indexer_key_scale"):
+        monkeypatch.setattr(DeviceOperator, name, lambda value: value)
+    monkeypatch.setattr(torch.ops._C_ascend, "inplace_partial_rotary_mul", lambda *_, **__: None, raising=False)
+    monkeypatch.setattr(torch.ops._C_ascend, "npu_vllm_quant_lightning_indexer", run_indexer, raising=False)
+    monkeypatch.setattr("vllm_ascend.attention.context_parallel.dsa_cp.rotate_activation", lambda value, _: value)
+    monkeypatch.setattr("vllm_ascend.attention.context_parallel.dsa_cp.wait_for_device_metadata", record_wait)
+    impl._indexer_select_topk(
+        x=torch.ones((1, 2)),
+        qr=torch.ones((1, 2)),
+        kv_cache=(torch.empty(0),),
+        metadata=layer_metadata,
+        cos=torch.ones((1, 1, 1, 2)),
+        sin=torch.zeros((1, 1, 1, 2)),
+        actual_seq_lengths_query=torch.tensor([0, 1], dtype=torch.int32),
+        actual_seq_lengths_key=torch.tensor([1], dtype=torch.int32),
+    )
 
     assert waited
 
 
 @pytest.mark.parametrize("compress_ratio", [1, 4, 128])
-def test_dsa_cp_attention_waits_before_sas_consumer(compress_ratio: int):
-    impl = AscendDSACPImpl.__new__(AscendDSACPImpl)
+def test_dsa_cp_attention_waits_before_sas_consumer(compress_ratio: int, monkeypatch):
+    monkeypatch.setattr(
+        "vllm_ascend.attention.context_parallel.dsa_cp.get_tp_group",
+        lambda: SimpleNamespace(world_size=1, rank_in_group=0),
+    )
+    monkeypatch.setattr("vllm_ascend.attention.context_parallel.dsa_cp.enable_dsa_cp_with_o_proj_tp", lambda: False)
+    monkeypatch.setattr(
+        "vllm_ascend.attention.context_parallel.dsa_cp.get_current_vllm_config",
+        _make_vllm_config,
+    )
+    impl = cast(AscendDSACPImpl, _make_impl(AscendDSACPImpl))
     impl.compress_ratio = compress_ratio
-    impl.num_heads = 1
-    impl.head_dim = 2
-    impl.nope_head_dim = 1
-    impl.rope_head_dim = 1
-    impl.window_size = 16
-    impl.softmax_scale = 1.0
-    impl.eps = 1e-6
-    impl.attn_sink = None
     impl.compressor_overlap = False
-    impl.wq_a = MagicMock(return_value=torch.ones((1, 2)))
-    impl.q_norm = MagicMock(side_effect=lambda value: value)
-    impl.wq_b = MagicMock(return_value=torch.ones((1, 2)))
+    impl.wq_a.return_value = torch.ones((1, 2))
+    impl.q_norm.side_effect = lambda value: value
+    impl.wq_b.return_value = torch.ones((1, 2))
     impl.wq_b.quant_method = MagicMock()
-    impl.q_norm_without_weight = MagicMock()
-    impl.wkv = MagicMock(return_value=torch.ones((1, 2)))
-    impl.kv_norm = MagicMock(side_effect=lambda value: value)
+    impl.wkv.return_value = torch.ones((1, 2))
+    impl.kv_norm.side_effect = lambda value: value
     impl._maybe_all_gather_o_proj_full_weight = MagicMock()
     impl.compressor_wkv = SimpleNamespace(weight=torch.empty(0))
     impl.compressor_wgate = SimpleNamespace(weight=torch.empty(0))
@@ -1143,45 +748,29 @@ def test_dsa_cp_attention_waits_before_sas_consumer(compress_ratio: int):
     )
     plan.add_dsa_sparse_attn_extra_kwargs.side_effect = add_extra_kwargs
 
-    with (
-        patch.object(
-            DeviceOperator,
-            "unpack_dsa_forward_kv_cache",
-            return_value=(torch.empty(0), torch.empty(0), torch.zeros((1, 1, 1)), None, None, None),
-        ),
-        patch.object(DeviceOperator, "apply_dsa_q_rms", side_effect=lambda value, *_: value),
-        patch("vllm_ascend.attention.context_parallel.dsa_cp.get_dsa_attn_kv_plan", return_value=plan),
-        patch("vllm_ascend.attention.dsa_v1.get_dsa_attn_kv_plan", return_value=plan),
-        patch.object(torch.ops._C_ascend, "inplace_partial_rotary_mul", create=True),
-        patch.object(torch.ops._C_ascend, "compressor", create=True, return_value=torch.empty(0)),
-        patch.object(impl, "_split_full_hidden_states_for_cp", side_effect=lambda value, _: value),
-        patch.object(impl, "_update_indexer_cache"),
-        patch.object(impl, "_indexer_select_topk", return_value=torch.zeros((1, 1, 1), dtype=torch.int32)),
-        patch.object(
-            impl,
-            "_compute_compressor_metadata",
-            return_value=(
-                torch.ones((1, 2)),
-                torch.zeros((1, 2)),
-                torch.zeros((1, 2), dtype=torch.int32),
-            ),
-        ),
-        patch("vllm_ascend.attention.context_parallel.dsa_cp.notify_kv_cache_written"),
-        patch(
-            "vllm_ascend.attention.context_parallel.dsa_cp.record_attention_compute_start",
-            side_effect=lambda: events.append("record"),
-        ),
-        patch(
-            "vllm_ascend.attention.context_parallel.dsa_cp.wait_for_device_metadata",
-            side_effect=record_wait,
-        ),
-    ):
-        impl._forward(
-            "layer",
-            torch.ones((1, 2)),
-            (torch.empty(0),),
-            layer_metadata,
-        )
+    monkeypatch.setattr(
+        DeviceOperator,
+        "unpack_dsa_forward_kv_cache",
+        lambda *_: (torch.empty(0), torch.empty(0), torch.zeros((1, 1, 1)), None, None, None),
+    )
+    monkeypatch.setattr(DeviceOperator, "apply_dsa_q_rms", lambda value, *_: value)
+    monkeypatch.setattr("vllm_ascend.attention.context_parallel.dsa_cp.get_dsa_attn_kv_plan", lambda *_: plan)
+    monkeypatch.setattr("vllm_ascend.attention.dsa_v1.get_dsa_attn_kv_plan", lambda *_: plan)
+    monkeypatch.setattr(torch.ops._C_ascend, "inplace_partial_rotary_mul", lambda *_, **__: None, raising=False)
+    monkeypatch.setattr(torch.ops._C_ascend, "compressor", lambda *_, **__: torch.empty(0), raising=False)
+    impl._split_full_hidden_states_for_cp = lambda value, _: value
+    impl._update_indexer_cache = MagicMock()
+    impl._indexer_select_topk = MagicMock(return_value=torch.zeros((1, 1, 1), dtype=torch.int32))
+    impl._compute_compressor_metadata = MagicMock(
+        return_value=(torch.ones((1, 2)), torch.zeros((1, 2)), torch.zeros((1, 2), dtype=torch.int32))
+    )
+    monkeypatch.setattr("vllm_ascend.attention.context_parallel.dsa_cp.notify_kv_cache_written", lambda *_: None)
+    monkeypatch.setattr(
+        "vllm_ascend.attention.context_parallel.dsa_cp.record_attention_compute_start",
+        lambda: events.append("record"),
+    )
+    monkeypatch.setattr("vllm_ascend.attention.context_parallel.dsa_cp.wait_for_device_metadata", record_wait)
+    impl._forward("layer", torch.ones((1, 2)), (torch.empty(0),), layer_metadata)
 
     assert events == ["wait", "record", "attention"]
 
@@ -2096,19 +1685,6 @@ def test_pcp_metadata_provider_discards_unused_global_tasks():
     assert builder.take_device_metadata_tasks() == (global_compressor_task, local_task)
     assert builder._device_metadata_tasks == ()
     builder._global_metadata_builder.take_device_metadata_tasks.assert_called_once_with()
-
-
-def test_pcp_metadata_provider_enables_local_and_global_builders():
-    builder = AscendDSAPCPMetadataBuilder.__new__(AscendDSAPCPMetadataBuilder)
-    builder._device_metadata_enabled = False
-    builder.compressor_metadata_buffers = None
-    builder._global_metadata_builder = SimpleNamespace(enable_device_metadata=MagicMock())
-
-    builder.enable_device_metadata()
-
-    assert builder._device_metadata_enabled
-    assert builder.compressor_metadata_buffers is None
-    builder._global_metadata_builder.enable_device_metadata.assert_called_once_with()
 
 
 @pytest.mark.parametrize("local_num_actual_tokens", [2, 0], ids=["local_tokens", "empty_rank"])

--- a/tests/ut/attention/test_dsa_v1.py
+++ b/tests/ut/attention/test_dsa_v1.py
@@ -20,6 +20,8 @@ from unittest.mock import MagicMock, patch
 import numpy as np
 import pytest
 import torch
+from vllm.config import CUDAGraphMode
+from vllm.v1.attention.backend import AttentionCGSupport
 
 from vllm_ascend.attention.context_parallel.dsa_cp import (
     AscendDSACPImpl,
@@ -44,6 +46,7 @@ from vllm_ascend.attention.dsa_v1 import (
     AscendDSAMetadata,
     AscendDSAMetadataBuilder,
     AscendDSAReqMetadata,
+    build_compressor_metadata_out,
 )
 from vllm_ascend.device.device_op import DeviceOperator
 from vllm_ascend.models.deepseek_v4.compressor import AscendCompressorMetadata
@@ -77,6 +80,7 @@ def _make_builder(compressor_ratio: int = 4) -> AscendDSAMetadataBuilder:
             index_topk=512,
             index_n_heads=64,
             index_head_dim=128,
+            qk_rope_head_dim=4,
             sliding_window=4096,
         ),
         enable_sleep_mode=False,
@@ -89,6 +93,7 @@ def _make_builder(compressor_ratio: int = 4) -> AscendDSAMetadataBuilder:
             max_num_seqs=4,
         ),
         speculative_config=None,
+        compilation_config=SimpleNamespace(cudagraph_mode=CUDAGraphMode.NONE),
         parallel_config=SimpleNamespace(tensor_parallel_size=2),
     )
     physical_block_size = 128
@@ -365,8 +370,8 @@ def test_build_req_metadata_uses_for_prefill_and_decode(
 @pytest.mark.parametrize(
     ("compressor_ratio", "expected_stages"),
     [
-        (4, [DeviceMetadataStage.INDEXER, DeviceMetadataStage.ATTENTION]),
-        (128, [DeviceMetadataStage.ATTENTION]),
+        (4, list(DeviceMetadataStage)),
+        (128, [DeviceMetadataStage.COMPRESSOR, DeviceMetadataStage.ATTENTION]),
     ],
 )
 def test_build_req_metadata_defers_device_work_to_fixed_buffers(
@@ -374,6 +379,7 @@ def test_build_req_metadata_defers_device_work_to_fixed_buffers(
     expected_stages: list[DeviceMetadataStage],
 ):
     builder = _make_builder(compressor_ratio)
+    assert builder.compressor_metadata_buffers is None
     builder.enable_device_metadata()
     builder.num_actual_tokens = 3
     builder.num_prefills = 1
@@ -412,9 +418,19 @@ def test_build_req_metadata_defers_device_work_to_fixed_buffers(
     tasks = builder.take_device_metadata_tasks()
     assert builder.take_device_metadata_tasks() == ()
     assert [task.stage for task in tasks] == expected_stages
-    assert all(task.group_id in (id(builder.qli_metadata_buffer), id(builder.sas_metadata_buffer)) for task in tasks)
-    for task in tasks:
-        task.run()
+    assert builder.compressor_metadata_buffers is not None
+    assert req_metadata.compressor_metadata is not None
+    assert req_metadata.compressor_metadata_group_id == id(builder.compressor_metadata_buffers[0])
+    group_ids = (
+        id(builder.compressor_metadata_buffers[0]),
+        id(builder.qli_metadata_buffer),
+        id(builder.sas_metadata_buffer),
+    )
+    assert all(task.group_id in group_ids for task in tasks)
+    with patch("vllm_ascend.attention.dsa_v1.build_compressor_metadata_out") as build_compressor:
+        for task in tasks:
+            task.run()
+    build_compressor.assert_called_once()
     builder._build_sas_metadata.assert_called_once()
     if compressor_ratio == 4:
         builder._build_qli_metadata.assert_called_once()
@@ -422,17 +438,100 @@ def test_build_req_metadata_defers_device_work_to_fixed_buffers(
         builder._build_qli_metadata.assert_not_called()
 
 
+def test_full_graph_compressor_metadata_uses_capture_bucket_extent():
+    builder = _make_builder(4)
+    builder.enable_device_metadata()
+    builder.num_actual_tokens = 4
+    builder.num_prefills = 0
+    builder.seq_lens = torch.tensor([8, 8, 8, 0], dtype=torch.int32)
+    builder.block_table = torch.ones((4, 2), dtype=torch.int32)
+    builder.common_ratio_to_sas_metadata = {}
+    query_start_loc = torch.arange(5, dtype=torch.int32)
+    common_attn_metadata = SimpleNamespace(
+        num_reqs=4,
+        num_input_tokens=4,
+        positions=torch.arange(4),
+        query_start_loc=query_start_loc,
+        query_start_loc_cpu=query_start_loc,
+        causal=True,
+    )
+    builder._build_sas_metadata = MagicMock()
+    builder._build_qli_metadata = MagicMock()
+
+    with patch(
+        "vllm_ascend.attention.dsa_v1.get_full_cos_and_sin_dsa",
+        return_value=(torch.ones(1), torch.zeros(1)),
+    ):
+        capture_metadata = builder.build_req_metadata(
+            common_attn_metadata,
+            builder.seq_lens,
+            num_actual_reqs=4,
+            cos=torch.ones(4),
+            sin=torch.zeros(4),
+            full_graph_mode=True,
+        )
+        builder.num_actual_tokens = 3
+        metadata = builder.build_req_metadata(
+            common_attn_metadata,
+            builder.seq_lens,
+            num_actual_reqs=3,
+            cos=torch.ones(4),
+            sin=torch.zeros(4),
+            full_graph_mode=True,
+        )
+
+    assert metadata.num_compressed_tokens == 4
+    assert metadata.num_actual_reqs == 4
+    assert metadata.compressor_metadata is not None
+    assert metadata.compressor_metadata[0].shape[0] == 4
+    assert capture_metadata.compressor_metadata is not None
+    assert capture_metadata.compressor_metadata[0].shape == metadata.compressor_metadata[0].shape
+    assert capture_metadata.compressor_metadata[0].data_ptr() == metadata.compressor_metadata[0].data_ptr()
+
+
+def test_pure_full_graph_keeps_compressor_metadata_on_legacy_path():
+    builder = _make_builder(128)
+    builder.vllm_config.compilation_config.cudagraph_mode = CUDAGraphMode.FULL
+
+    builder.enable_device_metadata()
+
+    assert builder.compressor_metadata_buffers is None
+
+    cp_builder = AscendDSACPMetadataBuilder.__new__(AscendDSACPMetadataBuilder)
+    cp_builder._device_metadata_enabled = False
+    cp_builder.compressor_ratio = 128
+    cp_builder.compressor_metadata_buffers = None
+    cp_builder.vllm_config = builder.vllm_config
+    cp_builder.enable_device_metadata()
+
+    assert cp_builder._device_metadata_enabled
+    assert cp_builder.compressor_metadata_buffers is None
+
+
 @pytest.mark.parametrize(
-    ("compressor_ratio", "device_metadata_enabled", "expected_stages"),
+    (
+        "compressor_ratio",
+        "device_metadata_enabled",
+        "full_graph_mode",
+        "num_input_tokens",
+        "num_actual_reqs",
+        "expected_rows",
+        "expected_stages",
+    ),
     [
-        (4, True, [DeviceMetadataStage.INDEXER, DeviceMetadataStage.ATTENTION]),
-        (128, True, [DeviceMetadataStage.ATTENTION]),
-        (4, False, []),
+        (4, True, False, 3, None, 2, list(DeviceMetadataStage)),
+        (128, True, False, 3, None, 2, [DeviceMetadataStage.COMPRESSOR, DeviceMetadataStage.ATTENTION]),
+        (4, True, True, 4, 1, 3, list(DeviceMetadataStage)),
+        (4, False, False, 3, None, 2, []),
     ],
 )
 def test_dsa_cp_device_metadata_tasks(
     compressor_ratio: int,
     device_metadata_enabled: bool,
+    full_graph_mode: bool,
+    num_input_tokens: int,
+    num_actual_reqs: int | None,
+    expected_rows: int,
     expected_stages: list[DeviceMetadataStage],
 ):
     builder = AscendDSACPMetadataBuilder.__new__(AscendDSACPMetadataBuilder)
@@ -445,6 +544,11 @@ def test_dsa_cp_device_metadata_tasks(
     builder.block_table = torch.tensor([[1, 2], [3, 4]], dtype=torch.int32)
     builder.start_pos_prefill = torch.zeros(2, dtype=torch.int32)
     builder.slot_mapping = torch.zeros((3, 2), dtype=torch.int32)
+    builder.compressor_metadata_buffers = (
+        torch.empty((3, 1, 1, 4)),
+        torch.empty((3, 1, 1, 4)),
+        builder.slot_mapping,
+    )
     builder.req_sas_metadata = torch.zeros(1024, dtype=torch.int32)
     builder.req_qli_metadata = torch.zeros(1024, dtype=torch.int32)
     builder._device_metadata_enabled = device_metadata_enabled
@@ -453,7 +557,7 @@ def test_dsa_cp_device_metadata_tasks(
         hf_config=SimpleNamespace(num_attention_heads=64, index_topk=512),
         get_head_size=lambda: 512,
     )
-    query_start_loc = torch.tensor([0, 2, 3], dtype=torch.int32)
+    query_start_loc = torch.tensor([0, 2, num_input_tokens], dtype=torch.int32)
     builder.common_ratio_to_sas_metadata = {
         "_cpu_local": {
             "qsl_cpu": query_start_loc,
@@ -462,7 +566,6 @@ def test_dsa_cp_device_metadata_tasks(
     }
     builder._ensure_device_local_metadata = MagicMock(return_value=(0, 3, 3, 3, query_start_loc, builder.seq_lens))
     builder._get_cmp_seqlens_for_metadata = MagicMock(return_value=None)
-    builder._num_compressor_metadata_rows = MagicMock(return_value=2)
     builder._build_sas_metadata = MagicMock(return_value=builder.req_sas_metadata)
     builder._build_qli_metadata = MagicMock(return_value=builder.req_qli_metadata)
     common_attn_metadata = SimpleNamespace(
@@ -475,27 +578,56 @@ def test_dsa_cp_device_metadata_tasks(
         "vllm_ascend.attention.context_parallel.dsa_cp.get_full_cos_and_sin_dsa",
         return_value=(torch.ones(1), torch.zeros(1)),
     ):
+        capture_metadata = None
+        if full_graph_mode:
+            builder.num_actual_tokens = num_input_tokens
+            capture_metadata = builder.build_req_metadata(
+                common_attn_metadata,
+                input_positions=None,
+                num_input_tokens=num_input_tokens,
+                num_actual_reqs=2,
+                attn_state=MagicMock(),
+                cos=MagicMock(),
+                sin=MagicMock(),
+                full_graph_mode=True,
+            )
+            builder.num_actual_tokens = 3
         req_metadata = builder.build_req_metadata(
             common_attn_metadata,
             input_positions=None,
-            num_input_tokens=3,
-            num_actual_reqs=None,
+            num_input_tokens=num_input_tokens,
+            num_actual_reqs=num_actual_reqs,
             attn_state=MagicMock(),
             cos=MagicMock(),
             sin=MagicMock(),
+            full_graph_mode=full_graph_mode,
         )
 
     tasks = builder.take_device_metadata_tasks()
     assert builder.take_device_metadata_tasks() == ()
     assert [task.stage for task in tasks] == expected_stages
-    assert all(task.group_id in (id(builder.req_qli_metadata), id(builder.req_sas_metadata)) for task in tasks)
+    group_ids = (
+        id(builder.compressor_metadata_buffers[0]),
+        id(builder.req_qli_metadata),
+        id(builder.req_sas_metadata),
+    )
+    assert all(task.group_id in group_ids for task in tasks)
     assert req_metadata.sas_metadata is builder.req_sas_metadata
+    assert req_metadata.num_compressed_tokens == expected_rows
+    assert req_metadata.num_actual_reqs == (2 if full_graph_mode else num_actual_reqs or 2)
+    if capture_metadata is not None:
+        assert capture_metadata.compressor_metadata is not None
+        assert req_metadata.compressor_metadata is not None
+        assert capture_metadata.compressor_metadata[0].shape == req_metadata.compressor_metadata[0].shape
+        assert capture_metadata.compressor_metadata[0].data_ptr() == req_metadata.compressor_metadata[0].data_ptr()
     assert (req_metadata.qli_metadata is builder.req_qli_metadata) is (compressor_ratio == 4)
     if device_metadata_enabled:
         builder._build_sas_metadata.assert_not_called()
         builder._build_qli_metadata.assert_not_called()
-        for task in tasks:
-            task.run()
+        with patch("vllm_ascend.attention.dsa_v1.build_compressor_metadata_out") as build_compressor:
+            for task in tasks:
+                task.run()
+        build_compressor.assert_called_once()
     builder._build_sas_metadata.assert_called_once()
     if compressor_ratio == 4:
         builder._build_qli_metadata.assert_called_once()
@@ -539,6 +671,45 @@ def test_dsa_cp_qli_metadata_uses_host_maxima():
     seq_lens.max.assert_not_called()
     assert metadata_op.call_args.kwargs["max_seqlen_q"] == 2
     assert metadata_op.call_args.kwargs["max_seqlen_k"] == 8
+
+
+def test_build_compressor_metadata_out_uses_fixed_outputs():
+    metadata = SimpleNamespace(
+        full_compress_cos=torch.ones((8, 1, 1, 4)),
+        full_compress_sin=torch.zeros((8, 1, 1, 4)),
+        query_start_loc=torch.tensor([0, 2], dtype=torch.int32),
+        start_pos=torch.tensor([1], dtype=torch.int32),
+        block_table=torch.tensor([[3]], dtype=torch.int32),
+        storage_block_size=128,
+        num_actual_reqs=1,
+    )
+    outputs = (
+        torch.empty((2, 1, 1, 4)),
+        torch.empty((2, 1, 1, 4)),
+        torch.empty((2, 2), dtype=torch.int32),
+    )
+
+    with (
+        patch.object(DeviceOperator, "get_dsa_compressor_slot_mapping_format", return_value=2),
+        patch.object(torch.ops._C_ascend, "compressor_metadata_out", create=True) as metadata_out,
+    ):
+        build_compressor_metadata_out(metadata, 4, outputs)
+
+    assert metadata_out.call_args.args[-3:] == outputs
+
+
+def test_dsa_cp_compressor_waits_for_precomputed_metadata():
+    impl = AscendDSACPImpl.__new__(AscendDSACPImpl)
+    outputs = (torch.ones(1), torch.zeros(1), torch.zeros(1, dtype=torch.int32))
+    metadata = SimpleNamespace(
+        compressor_metadata=outputs,
+        compressor_metadata_group_id=17,
+    )
+
+    with patch("vllm_ascend.attention.context_parallel.dsa_cp.wait_for_device_metadata") as wait:
+        assert impl._compute_compressor_metadata(metadata) is outputs
+
+    wait.assert_called_once_with(DeviceMetadataStage.COMPRESSOR, 17)
 
 
 def _make_dsa_cp_metadata(sas_metadata: torch.Tensor) -> AscendDSACPMetadata:
@@ -1634,13 +1805,14 @@ def test_pcp_metadata_builds_from_manager_global_view():
 def test_pcp_metadata_provider_discards_unused_global_tasks():
     builder = AscendDSAPCPMetadataBuilder.__new__(AscendDSAPCPMetadataBuilder)
     local_task = DeviceMetadataTask(DeviceMetadataStage.INDEXER, MagicMock(), 1)
-    global_task = DeviceMetadataTask(DeviceMetadataStage.ATTENTION, MagicMock(), 2)
+    global_compressor_task = DeviceMetadataTask(DeviceMetadataStage.COMPRESSOR, MagicMock(), 2)
+    global_attention_task = DeviceMetadataTask(DeviceMetadataStage.ATTENTION, MagicMock(), 3)
     builder._device_metadata_tasks = (local_task,)
     builder._global_metadata_builder = SimpleNamespace(
-        take_device_metadata_tasks=MagicMock(return_value=(global_task,)),
+        take_device_metadata_tasks=MagicMock(return_value=(global_compressor_task, global_attention_task)),
     )
 
-    assert builder.take_device_metadata_tasks() == (local_task,)
+    assert builder.take_device_metadata_tasks() == (global_compressor_task, local_task)
     assert builder._device_metadata_tasks == ()
     builder._global_metadata_builder.take_device_metadata_tasks.assert_called_once_with()
 
@@ -1648,11 +1820,13 @@ def test_pcp_metadata_provider_discards_unused_global_tasks():
 def test_pcp_metadata_provider_enables_local_and_global_builders():
     builder = AscendDSAPCPMetadataBuilder.__new__(AscendDSAPCPMetadataBuilder)
     builder._device_metadata_enabled = False
+    builder.compressor_metadata_buffers = None
     builder._global_metadata_builder = SimpleNamespace(enable_device_metadata=MagicMock())
 
     builder.enable_device_metadata()
 
     assert builder._device_metadata_enabled
+    assert builder.compressor_metadata_buffers is None
     builder._global_metadata_builder.enable_device_metadata.assert_called_once_with()
 
 

--- a/tests/ut/attention/test_dsv4_block_geometry.py
+++ b/tests/ut/attention/test_dsv4_block_geometry.py
@@ -35,6 +35,7 @@ def test_compressor_metadata_uses_physical_storage_geometry(
         storage_block_size=128,
         num_compressed_tokens=2,
         num_actual_reqs=1,
+        device_local_metadata_group_id=None,
     )
     captured = {}
     expected = (

--- a/tests/ut/models/test_deepseek_v4_compressor.py
+++ b/tests/ut/models/test_deepseek_v4_compressor.py
@@ -13,9 +13,24 @@ from vllm_ascend.models.deepseek_v4.compressor import (
     AscendCompressorStateCache,
     Compressor,
 )
+from vllm_ascend.worker.device_metadata import DeviceMetadataStage
 
 
 class TestCompressorMetadata:
+    def test_compute_metadata_waits_for_precomputed_output(self):
+        compressor = Compressor.__new__(Compressor)
+        torch.nn.Module.__init__(compressor)
+        outputs = (torch.ones(1), torch.zeros(1), torch.zeros(1, dtype=torch.int32))
+        metadata = SimpleNamespace(
+            compressor_metadata=outputs,
+            compressor_metadata_group_id=11,
+        )
+
+        with patch("vllm_ascend.models.deepseek_v4.compressor.wait_for_device_metadata") as wait:
+            assert compressor._compute_metadata(metadata) is outputs
+
+        wait.assert_called_once_with(DeviceMetadataStage.COMPRESSOR, 11)
+
     def test_compute_metadata_flattens_rotary_inputs(self):
         compressor = Compressor.__new__(Compressor)
         torch.nn.Module.__init__(compressor)

--- a/tests/ut/spec_decode/test_dspark_proposer.py
+++ b/tests/ut/spec_decode/test_dspark_proposer.py
@@ -89,6 +89,7 @@ def test_build_draft_metadata_submits_only_non_cp_device_tasks(
         method="dspark",
         runner=SimpleNamespace(device_metadata_executor=executor),
         dcp_size=dcp_size,
+        sliding_window=None,
         _per_group_block_table_buffers={group_id: torch.ones((1, 1), dtype=torch.int32) for group_id in range(2)},
         _per_group_query_slot_mapping_buffers={group_id: torch.zeros(1, dtype=torch.int32) for group_id in range(2)},
     )

--- a/tests/ut/spec_decode/test_dspark_proposer.py
+++ b/tests/ut/spec_decode/test_dspark_proposer.py
@@ -19,12 +19,14 @@
 
 from __future__ import annotations
 
+from contextlib import contextmanager
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 import numpy as np
 import pytest
 import torch
+from vllm.config import CUDAGraphMode
 from vllm.v1.kv_cache_interface import (
     FullAttentionSpec,
     MLAAttentionSpec,
@@ -34,6 +36,8 @@ from vllm.v1.worker.utils import AttentionGroup
 
 from vllm_ascend.attention.attention_v1 import AscendAttentionState
 from vllm_ascend.spec_decode.dspark_proposer import AscendDSparkProposer
+from vllm_ascend.spec_decode.llm_base_proposer import AscendSpecDecodeBaseProposer
+from vllm_ascend.worker.device_metadata import DeviceMetadataStage, DeviceMetadataTask
 
 # 0 = single-DP (no padding); >0 = multi-DP where num_input_tokens >
 # num_query_total, the out-of-bounds regime.
@@ -42,6 +46,179 @@ _NUM_SPECULATIVE_TOKENS = 3
 _MAX_BATCH_SIZE = 2
 _MAX_NUM_TOKENS = 8
 _HIDDEN_SIZE = 16
+
+
+@pytest.mark.parametrize(
+    ("dcp_size", "pcp_enabled", "expected_submit"),
+    [(1, False, True), (2, False, False), (1, True, False)],
+)
+def test_build_draft_metadata_submits_only_non_cp_device_tasks(
+    dcp_size: int,
+    pcp_enabled: bool,
+    expected_submit: bool,
+):
+    tasks = [DeviceMetadataTask(DeviceMetadataStage.ATTENTION, lambda: None, group_id) for group_id in (7, 9)]
+
+    class DraftMetadataProvider:
+        def __init__(self, task):
+            self.enabled = False
+            self.task = task
+
+        def enable_device_metadata(self):
+            self.enabled = True
+
+        def take_device_metadata_tasks(self):
+            return (self.task,)
+
+        def build_for_drafting(self, common_attn_metadata, draft_index, **kwargs):
+            return SimpleNamespace()
+
+    builders = [DraftMetadataProvider(task) for task in tasks]
+    groups = [
+        SimpleNamespace(
+            kv_cache_group_id=group_id,
+            layer_names=[f"draft.attn.{group_id}"],
+            get_metadata_builder=lambda builder=builder: builder,
+        )
+        for group_id, builder in enumerate(builders)
+    ]
+    executor = MagicMock()
+    proposer = SimpleNamespace(
+        draft_attn_groups=groups,
+        use_compress=False,
+        method="dspark",
+        runner=SimpleNamespace(device_metadata_executor=executor),
+        dcp_size=dcp_size,
+        _per_group_block_table_buffers={group_id: torch.ones((1, 1), dtype=torch.int32) for group_id in range(2)},
+        _per_group_query_slot_mapping_buffers={group_id: torch.zeros(1, dtype=torch.int32) for group_id in range(2)},
+    )
+    common_attn_metadata = SimpleNamespace(
+        num_reqs=1,
+        block_table_tensor=torch.ones((1, 1), dtype=torch.int32),
+        slot_mapping=torch.zeros(1, dtype=torch.int32),
+    )
+
+    with patch("vllm_ascend.spec_decode.llm_base_proposer.enable_pcp", return_value=pcp_enabled):
+        metadata, first = AscendSpecDecodeBaseProposer.build_draft_attn_metadata(
+            proposer,
+            common_attn_metadata,
+            num_input_tokens=1,
+            num_actual_tokens=1,
+        )
+
+    assert metadata[0]["draft.attn.0"] is first
+    assert all(not builder.enabled for builder in builders)
+    if expected_submit:
+        executor.submit.assert_called_once_with(tasks)
+    else:
+        executor.submit.assert_not_called()
+
+
+@pytest.mark.parametrize("has_task", [True, False])
+def test_dspark_device_metadata_executor_forward_lifecycle(has_task: bool):
+    events = []
+    executor = SimpleNamespace(submission_in_flight=False)
+
+    def release():
+        events.append("release")
+
+    executor.release = release
+    runner = SimpleNamespace(
+        device_metadata_executor=executor,
+        dcp_manager=None,
+        input_batch=SimpleNamespace(lora_id_to_lora_request={}),
+        _sync_metadata_across_dp=lambda num_tokens, **kwargs: (num_tokens, torch.tensor(1), None),
+        dynamic_eplb=False,
+        eplb_heat_collection_status=False,
+    )
+    proposer = AscendSpecDecodeBaseProposer.__new__(AscendSpecDecodeBaseProposer)
+    proposer.runner = runner
+    proposer.method = "dspark"
+    proposer.model = SimpleNamespace(combine_hidden_states=lambda hidden_states: hidden_states)
+    proposer.hidden_size = 4
+    proposer.use_cuda_graph = False
+    proposer.dcp_size = 1
+    proposer.vllm_config = SimpleNamespace(model_config=SimpleNamespace(use_mla=True))
+    proposer.draft_window_size = None
+    proposer.supports_mm_inputs = False
+    proposer.slot_mapping_group = [torch.zeros(2, dtype=torch.int32)]
+    proposer.seq_lens_group = [torch.zeros(2, dtype=torch.int32)]
+    proposer.query_start_loc_group = [torch.zeros(3, dtype=torch.int32)]
+    proposer._pad_draft_buffers = MagicMock()
+    proposer.uses_mrope = False
+    proposer.positions = torch.arange(2, dtype=torch.int32)
+    proposer.parallel_drafting = True
+    proposer.token_indices_to_sample = torch.zeros(2, dtype=torch.int32)
+    proposer.enable_enpu = False
+    proposer._update_full_graph_params_if_needed = MagicMock()
+    proposer.set_inputs_first_pass = MagicMock()
+    proposer.build_draft_attn_metadata = MagicMock()
+
+    query_start_loc = torch.tensor([0, 1], dtype=torch.int32)
+    common_attn_metadata = SimpleNamespace(
+        batch_size=lambda: 1,
+        num_reqs=1,
+        query_start_loc=query_start_loc,
+        query_start_loc_cpu=query_start_loc,
+        seq_lens=torch.tensor([8], dtype=torch.int32),
+        seq_lens_cpu=torch.tensor([8], dtype=torch.int32),
+        _seq_lens_cpu=torch.tensor([8], dtype=torch.int32),
+        block_table_tensor=torch.ones((1, 1), dtype=torch.int32),
+        slot_mapping=torch.zeros(1, dtype=torch.int32),
+    )
+    proposer.set_inputs_first_pass.return_value = (
+        1,
+        torch.tensor([0], dtype=torch.int32),
+        common_attn_metadata,
+        None,
+    )
+
+    def build_metadata(*args, **kwargs):
+        events.append("submit" if has_task else "build")
+        executor.submission_in_flight = has_task
+        metadata = {"draft.attn": SimpleNamespace(num_prefills=0)}
+        return [metadata], metadata["draft.attn"]
+
+    proposer.build_draft_attn_metadata.side_effect = build_metadata
+
+    def run_draft(**kwargs):
+        events.append("run")
+        return torch.ones((1, 1), dtype=torch.int64)
+
+    proposer._runnable = run_draft
+    forward_context = SimpleNamespace(moe_layer_index=-1, cudagraph_runtime_mode=CUDAGraphMode.NONE)
+    context_executors = []
+
+    @contextmanager
+    def forward_context_manager(*args, **kwargs):
+        context_executors.append(kwargs["device_metadata_executor"])
+        events.append("context")
+        yield
+
+    with (
+        patch("vllm_ascend.spec_decode.llm_base_proposer._HIDDEN_STATE_DRAFTER_TYPES", (object,)),
+        patch(
+            "vllm_ascend.spec_decode.llm_base_proposer.set_ascend_forward_context",
+            forward_context_manager,
+        ),
+        patch("vllm_ascend.spec_decode.llm_base_proposer.get_forward_context", return_value=forward_context),
+    ):
+        result = AscendSpecDecodeBaseProposer._propose(
+            proposer,
+            3,
+            target_token_ids=torch.ones(1, dtype=torch.int64),
+            target_positions=torch.zeros(1, dtype=torch.int32),
+            target_hidden_states=torch.ones((1, 4)),
+            next_token_ids=torch.ones(1, dtype=torch.int64),
+            token_indices_to_sample=torch.tensor([0], dtype=torch.int32),
+            common_attn_metadata=common_attn_metadata,
+            target_model_batch_desc=SimpleNamespace(uniform=True),
+            sampling_metadata=MagicMock(),
+        )
+
+    assert torch.equal(result, torch.ones((1, 1), dtype=torch.int64))
+    assert context_executors == [executor if has_task else None]
+    assert events == (["submit", "context", "run", "release"] if has_task else ["build", "context", "run"])
 
 
 @pytest.fixture(autouse=True)
@@ -520,7 +697,63 @@ class TestInitializeAttnBackend(_DSparkProposerTestBase):
         proposer = AscendDSparkProposer.__new__(AscendDSparkProposer)
         proposer.vllm_config = SimpleNamespace()
         proposer.device = torch.device("cpu")
+        proposer.runner = SimpleNamespace(device_metadata_executor=None)
+        proposer.dcp_size = 1
         return proposer
+
+    @pytest.mark.parametrize(
+        ("dcp_size", "pcp_enabled", "has_executor", "expected_tokens"),
+        [
+            (1, False, True, 8),
+            (2, False, True, None),
+            (1, True, True, None),
+            (1, False, False, None),
+        ],
+    )
+    def test_initializes_device_metadata_only_for_eligible_dsa_draft(
+        self,
+        monkeypatch,
+        dcp_size,
+        pcp_enabled,
+        has_executor,
+        expected_tokens,
+    ):
+        class DraftBuilder:
+            def __init__(self):
+                self.max_num_tokens = None
+
+            def enable_dspark_device_metadata(self, max_num_tokens):
+                self.max_num_tokens = max_num_tokens
+
+        backend = MagicMock()
+        backend.full_cls_name.return_value = "fake.backend"
+        layer = MagicMock()
+        layer.get_attn_backend.return_value = backend
+        monkeypatch.setattr(
+            "vllm_ascend.spec_decode.dspark_proposer.get_layers_from_vllm_config",
+            lambda *args, **kwargs: {"L0": layer},
+        )
+        proposer = self._make_proposer_for_init()
+        proposer.model = SimpleNamespace(get_draft_kv_cache_layer_names=lambda: {"L0"})
+        proposer.max_query_tokens = 8
+        proposer.max_num_tokens = 16
+        proposer.dcp_size = dcp_size
+        proposer.runner.device_metadata_executor = object() if has_executor else None
+        kv_cache_spec = MagicMock(block_size=128)
+        kv_cache_config = SimpleNamespace(
+            kv_cache_groups=[SimpleNamespace(layer_names=["L0"], kv_cache_spec=kv_cache_spec)]
+        )
+        builder = DraftBuilder()
+
+        with (
+            patch.object(AttentionGroup, "create_metadata_builders"),
+            patch.object(AttentionGroup, "get_metadata_builder", return_value=builder),
+            patch("vllm_ascend.spec_decode.dspark_proposer.AscendDSAMetadataBuilder", DraftBuilder),
+            patch("vllm_ascend.spec_decode.dspark_proposer.enable_pcp", return_value=pcp_enabled),
+        ):
+            proposer.initialize_attn_backend(kv_cache_config)
+
+        assert builder.max_num_tokens == expected_tokens
 
     def test_initialization_tracks_logical_block_size_per_gid(self, monkeypatch):
         manager_specs = [MagicMock(), MagicMock()]

--- a/tests/ut/spec_decode/test_dspark_proposer.py
+++ b/tests/ut/spec_decode/test_dspark_proposer.py
@@ -89,6 +89,9 @@ def test_build_draft_metadata_submits_only_non_cp_device_tasks(
         method="dspark",
         runner=SimpleNamespace(device_metadata_executor=executor),
         dcp_size=dcp_size,
+        vllm_config=SimpleNamespace(
+            parallel_config=SimpleNamespace(prefill_context_parallel_size=2 if pcp_enabled else 1)
+        ),
         sliding_window=None,
         _per_group_block_table_buffers={group_id: torch.ones((1, 1), dtype=torch.int32) for group_id in range(2)},
         _per_group_query_slot_mapping_buffers={group_id: torch.zeros(1, dtype=torch.int32) for group_id in range(2)},
@@ -99,13 +102,12 @@ def test_build_draft_metadata_submits_only_non_cp_device_tasks(
         slot_mapping=torch.zeros(1, dtype=torch.int32),
     )
 
-    with patch("vllm_ascend.spec_decode.llm_base_proposer.enable_pcp", return_value=pcp_enabled):
-        metadata, first = AscendSpecDecodeBaseProposer.build_draft_attn_metadata(
-            proposer,
-            common_attn_metadata,
-            num_input_tokens=1,
-            num_actual_tokens=1,
-        )
+    metadata, first = AscendSpecDecodeBaseProposer.build_draft_attn_metadata(
+        proposer,
+        common_attn_metadata,
+        num_input_tokens=1,
+        num_actual_tokens=1,
+    )
 
     assert metadata[0]["draft.attn.0"] is first
     assert all(not builder.enabled for builder in builders)

--- a/tests/ut/worker/test_device_metadata.py
+++ b/tests/ut/worker/test_device_metadata.py
@@ -172,6 +172,29 @@ def test_executor_rejects_overlapping_submissions(executor_env):
         executor.submit(tasks)
 
 
+def test_submit_failure_keeps_partial_submission_in_flight(executor_env):
+    executor, calls, _ = executor_env
+
+    def fail_task() -> None:
+        raise RuntimeError("task failed")
+
+    tasks = (
+        DeviceMetadataTask(
+            DeviceMetadataStage.COMPRESSOR,
+            lambda: calls.append(("task", "started")),
+            1,
+        ),
+        DeviceMetadataTask(DeviceMetadataStage.INDEXER, fail_task, 2),
+    )
+
+    with pytest.raises(RuntimeError, match="task failed"):
+        executor.submit(tasks)
+
+    assert executor.submission_in_flight
+    with pytest.raises(RuntimeError, match="has not been released"):
+        executor.submit(tasks)
+
+
 def test_submit_orders_tasks_by_stage(executor_env):
     executor, calls, _ = executor_env
     tasks = tuple(reversed(_tasks(calls)))

--- a/tests/ut/worker/test_device_metadata.py
+++ b/tests/ut/worker/test_device_metadata.py
@@ -25,7 +25,6 @@ from vllm_ascend.worker.device_metadata import (
     DeviceMetadataExecutor,
     DeviceMetadataStage,
     DeviceMetadataTask,
-    DeviceMetadataTaskProvider,
     wait_for_device_metadata,
 )
 
@@ -108,15 +107,16 @@ def _tasks(calls: list[tuple]) -> tuple[DeviceMetadataTask, ...]:
     )
 
 
-def test_submit_records_inputs_and_stage_frontiers(executor_env):
+def test_stream_lifecycle_and_stage_frontiers(executor_env):
     executor, calls, allocations = executor_env
-
     assert allocations == [
         "stream",
         "inputs",
         "reusable",
     ]
-    executor.submit(_tasks(calls))
+    tasks = tuple(reversed(_tasks(calls)))
+    executor.submit(tasks)
+    assert executor.submission_in_flight
     assert allocations == [
         "stream",
         "inputs",
@@ -136,15 +136,13 @@ def test_submit_records_inputs_and_stage_frontiers(executor_env):
         ("task", "attention"),
         ("metadata", "record", "attention"),
     ]
-
-
-def test_wait_and_release_fence_buffer_reuse(executor_env):
-    executor, calls, _ = executor_env
-    tasks = _tasks(calls)
-
-    executor.submit(tasks)
     executor.wait(DeviceMetadataStage.INDEXER, 2)
+    executor.wait(DeviceMetadataStage.INDEXER, 2)
+    assert calls.count(("model", "wait", "indexer")) == 1
+    with pytest.raises(RuntimeError, match="has not been released"):
+        executor.submit(tasks)
     executor.release()
+    assert not executor.submission_in_flight
     assert calls[-2:] == [
         ("model", "wait", "indexer"),
         ("model", "record", "reusable"),
@@ -159,17 +157,7 @@ def test_wait_and_release_fence_buffer_reuse(executor_env):
     ]
 
 
-def test_wait_records_each_stage_once_per_submission(executor_env):
-    executor, calls, _ = executor_env
-    executor.submit(_tasks(calls))
-
-    executor.wait(DeviceMetadataStage.INDEXER, 2)
-    executor.wait(DeviceMetadataStage.INDEXER, 2)
-
-    assert calls.count(("model", "wait", "indexer")) == 1
-
-
-def test_external_events_bridge_full_graph_and_are_reused(executor_env):
+def test_external_events_are_reused_per_batch_descriptor(executor_env):
     executor, calls, allocations = executor_env
     descriptor = BatchDescriptor(num_tokens=4, num_reqs=4)
 
@@ -187,18 +175,10 @@ def test_external_events_bridge_full_graph_and_are_reused(executor_env):
     assert calls.index(("metadata", "record", "external-1")) < calls.index(("model", "external_wait", "external-1"))
     executor.release()
     assert not executor.uses_external_events
-
     executor.submit(_tasks(calls), descriptor)
     assert allocations.count("external-0") == 1
-
-
-def test_external_events_are_isolated_by_batch_descriptor(executor_env):
-    executor, calls, allocations = executor_env
-
-    executor.submit(_tasks(calls), BatchDescriptor(num_tokens=4, num_reqs=4))
     executor.release()
     executor.submit(_tasks(calls), BatchDescriptor(num_tokens=8, num_reqs=4))
-
     assert allocations[-3:] == ["external-3", "external-4", "external-5"]
 
 
@@ -217,25 +197,6 @@ def test_external_event_frontiers_must_remain_stable(executor_env):
     assert calls == []
     assert allocations == allocations_before
     assert not executor.submission_in_flight
-
-
-def test_submission_in_flight_tracks_release(executor_env):
-    executor, calls, _ = executor_env
-
-    assert not executor.submission_in_flight
-    executor.submit(_tasks(calls))
-    assert executor.submission_in_flight
-    executor.release()
-    assert not executor.submission_in_flight
-
-
-def test_executor_rejects_overlapping_submissions(executor_env):
-    executor, calls, _ = executor_env
-    tasks = _tasks(calls)
-    executor.submit(tasks)
-
-    with pytest.raises(RuntimeError, match="has not been released"):
-        executor.submit(tasks)
 
 
 def test_submit_failure_keeps_partial_submission_in_flight(executor_env):
@@ -261,19 +222,6 @@ def test_submit_failure_keeps_partial_submission_in_flight(executor_env):
         executor.submit(tasks)
 
 
-def test_submit_orders_tasks_by_stage(executor_env):
-    executor, calls, _ = executor_env
-    tasks = tuple(reversed(_tasks(calls)))
-
-    executor.submit(tasks)
-
-    assert [call for call in calls if call[0] == "task"] == [
-        ("task", "compressor"),
-        ("task", "indexer"),
-        ("task", "attention"),
-    ]
-
-
 def test_wait_uses_group_specific_frontier(executor_env):
     executor, calls, _ = executor_env
     tasks = (
@@ -288,21 +236,6 @@ def test_wait_uses_group_specific_frontier(executor_env):
     waits = [call for call in calls if call[:2] == ("model", "wait")]
     assert len(waits) == 2
     assert waits[0][2] != waits[1][2]
-
-
-def test_task_provider_is_structural():
-    class LegacyBuilder:
-        pass
-
-    class ProviderBuilder:
-        def enable_device_metadata(self):
-            pass
-
-        def take_device_metadata_tasks(self):
-            return (DeviceMetadataTask(DeviceMetadataStage.INDEXER, lambda: None, 1),)
-
-    assert not isinstance(LegacyBuilder(), DeviceMetadataTaskProvider)
-    assert isinstance(ProviderBuilder(), DeviceMetadataTaskProvider)
 
 
 def test_submit_rejects_empty_tasks(executor_env):

--- a/tests/ut/worker/test_device_metadata.py
+++ b/tests/ut/worker/test_device_metadata.py
@@ -53,7 +53,7 @@ def executor_env(monkeypatch):
     allocations: list[str] = []
     model_stream = _FakeStream("model", calls)
     metadata_stream = _FakeStream("metadata", calls)
-    event_names = iter(("inputs", "compressor", "indexer", "attention", "reusable"))
+    event_names = iter(("inputs", "reusable", "compressor", "indexer", "attention", "indexer-2"))
 
     def make_stream():
         allocations.append("stream")
@@ -77,14 +77,17 @@ def _tasks(calls: list[tuple]) -> tuple[DeviceMetadataTask, ...]:
         DeviceMetadataTask(
             DeviceMetadataStage.COMPRESSOR,
             lambda: calls.append(("task", "compressor")),
+            1,
         ),
         DeviceMetadataTask(
             DeviceMetadataStage.INDEXER,
             lambda: calls.append(("task", "indexer")),
+            2,
         ),
         DeviceMetadataTask(
             DeviceMetadataStage.ATTENTION,
             lambda: calls.append(("task", "attention")),
+            3,
         ),
     )
 
@@ -95,12 +98,17 @@ def test_submit_records_inputs_and_stage_frontiers(executor_env):
     assert allocations == [
         "stream",
         "inputs",
-        "compressor",
-        "indexer",
-        "attention",
         "reusable",
     ]
     executor.submit(_tasks(calls))
+    assert allocations == [
+        "stream",
+        "inputs",
+        "reusable",
+        "compressor",
+        "indexer",
+        "attention",
+    ]
 
     assert calls == [
         ("model", "record", "inputs"),
@@ -119,7 +127,7 @@ def test_wait_and_release_fence_buffer_reuse(executor_env):
     tasks = _tasks(calls)
 
     executor.submit(tasks)
-    executor.wait(DeviceMetadataStage.INDEXER)
+    executor.wait(DeviceMetadataStage.INDEXER, 2)
     executor.release()
     assert calls[-2:] == [
         ("model", "wait", "indexer"),
@@ -139,8 +147,8 @@ def test_wait_records_each_stage_once_per_submission(executor_env):
     executor, calls, _ = executor_env
     executor.submit(_tasks(calls))
 
-    executor.wait(DeviceMetadataStage.INDEXER)
-    executor.wait(DeviceMetadataStage.INDEXER)
+    executor.wait(DeviceMetadataStage.INDEXER, 2)
+    executor.wait(DeviceMetadataStage.INDEXER, 2)
 
     assert calls.count(("model", "wait", "indexer")) == 1
 
@@ -177,13 +185,32 @@ def test_submit_orders_tasks_by_stage(executor_env):
     ]
 
 
+def test_wait_uses_group_specific_frontier(executor_env):
+    executor, calls, _ = executor_env
+    tasks = (
+        DeviceMetadataTask(DeviceMetadataStage.INDEXER, lambda: None, 2),
+        DeviceMetadataTask(DeviceMetadataStage.INDEXER, lambda: None, 4),
+    )
+
+    executor.submit(tasks)
+    executor.wait(DeviceMetadataStage.INDEXER, 2)
+    executor.wait(DeviceMetadataStage.INDEXER, 4)
+
+    waits = [call for call in calls if call[:2] == ("model", "wait")]
+    assert len(waits) == 2
+    assert waits[0][2] != waits[1][2]
+
+
 def test_task_provider_is_structural():
     class LegacyBuilder:
         pass
 
     class ProviderBuilder:
-        def build_device_metadata_tasks(self, _context):
-            return (DeviceMetadataTask(DeviceMetadataStage.INDEXER, lambda: None),)
+        def enable_device_metadata(self):
+            pass
+
+        def take_device_metadata_tasks(self):
+            return (DeviceMetadataTask(DeviceMetadataStage.INDEXER, lambda: None, 1),)
 
     assert not isinstance(LegacyBuilder(), DeviceMetadataTaskProvider)
     assert isinstance(ProviderBuilder(), DeviceMetadataTaskProvider)
@@ -198,7 +225,7 @@ def test_submit_rejects_empty_tasks(executor_env):
 
 def test_wait_helper_uses_active_forward_executor(monkeypatch):
     calls = []
-    executor = SimpleNamespace(wait=lambda stage: calls.append(stage))
+    executor = SimpleNamespace(wait=lambda stage, group_id: calls.append((stage, group_id)))
     monkeypatch.setattr(device_metadata, "is_forward_context_available", lambda: True)
     monkeypatch.setattr(
         device_metadata,
@@ -206,9 +233,9 @@ def test_wait_helper_uses_active_forward_executor(monkeypatch):
         lambda: SimpleNamespace(device_metadata_executor=executor),
     )
 
-    wait_for_device_metadata(DeviceMetadataStage.ATTENTION)
+    wait_for_device_metadata(DeviceMetadataStage.ATTENTION, 7)
 
-    assert calls == [DeviceMetadataStage.ATTENTION]
+    assert calls == [(DeviceMetadataStage.ATTENTION, 7)]
 
 
 def test_wait_helper_is_noop_without_forward_context(monkeypatch):
@@ -219,4 +246,4 @@ def test_wait_helper_is_noop_without_forward_context(monkeypatch):
         lambda: pytest.fail("forward context should not be read"),
     )
 
-    wait_for_device_metadata(DeviceMetadataStage.ATTENTION)
+    wait_for_device_metadata(DeviceMetadataStage.ATTENTION, 7)

--- a/tests/ut/worker/test_device_metadata.py
+++ b/tests/ut/worker/test_device_metadata.py
@@ -18,6 +18,7 @@ from types import SimpleNamespace
 
 import pytest
 import torch
+from vllm.forward_context import BatchDescriptor
 
 import vllm_ascend.worker.device_metadata as device_metadata
 from vllm_ascend.worker.device_metadata import (
@@ -47,6 +48,14 @@ class _FakeEvent:
         self.calls.append((stream.name, "record", self.name))
 
 
+class _FakeExternalEvent(_FakeEvent):
+    def wait(self, stream: _FakeStream) -> None:
+        self.calls.append((stream.name, "external_wait", self.name))
+
+    def reset(self, stream: _FakeStream) -> None:
+        self.calls.append((stream.name, "reset", self.name))
+
+
 @pytest.fixture
 def executor_env(monkeypatch):
     calls: list[tuple] = []
@@ -54,6 +63,7 @@ def executor_env(monkeypatch):
     model_stream = _FakeStream("model", calls)
     metadata_stream = _FakeStream("metadata", calls)
     event_names = iter(("inputs", "reusable", "compressor", "indexer", "attention", "indexer-2"))
+    external_event_names = iter(f"external-{index}" for index in range(6))
 
     def make_stream():
         allocations.append("stream")
@@ -64,8 +74,14 @@ def executor_env(monkeypatch):
         allocations.append(name)
         return _FakeEvent(name, calls)
 
+    def make_external_event():
+        name = next(external_event_names)
+        allocations.append(name)
+        return _FakeExternalEvent(name, calls)
+
     monkeypatch.setattr(torch.npu, "Stream", make_stream)
     monkeypatch.setattr(torch.npu, "Event", make_event)
+    monkeypatch.setattr(torch.npu, "ExternalEvent", make_external_event, raising=False)
     monkeypatch.setattr(torch.npu, "current_stream", lambda: model_stream)
     monkeypatch.setattr(torch.npu, "stream", lambda stream: nullcontext())
 
@@ -153,20 +169,54 @@ def test_wait_records_each_stage_once_per_submission(executor_env):
     assert calls.count(("model", "wait", "indexer")) == 1
 
 
-def test_wait_all_waits_current_frontiers_once(executor_env):
-    executor, calls, _ = executor_env
-    tasks = (*_tasks(calls), _tasks(calls)[1])
-    executor.submit(tasks)
+def test_external_events_bridge_full_graph_and_are_reused(executor_env):
+    executor, calls, allocations = executor_env
+    descriptor = BatchDescriptor(num_tokens=4, num_reqs=4)
 
-    executor.wait_all()
+    executor.submit(_tasks(calls), descriptor)
+    assert executor.uses_external_events
+    assert allocations[-3:] == ["external-0", "external-1", "external-2"]
     executor.wait(DeviceMetadataStage.INDEXER, 2)
-
-    waits = [call for call in calls if call[:2] == ("model", "wait")]
-    assert waits == [
-        ("model", "wait", "compressor"),
-        ("model", "wait", "indexer"),
-        ("model", "wait", "attention"),
+    executor.wait(DeviceMetadataStage.INDEXER, 2)
+    assert calls[-2:] == [
+        ("model", "external_wait", "external-1"),
+        ("model", "reset", "external-1"),
     ]
+    assert calls.count(("model", "external_wait", "external-1")) == 1
+    assert calls.count(("model", "reset", "external-1")) == 1
+    assert calls.index(("metadata", "record", "external-1")) < calls.index(("model", "external_wait", "external-1"))
+    executor.release()
+    assert not executor.uses_external_events
+
+    executor.submit(_tasks(calls), descriptor)
+    assert allocations.count("external-0") == 1
+
+
+def test_external_events_are_isolated_by_batch_descriptor(executor_env):
+    executor, calls, allocations = executor_env
+
+    executor.submit(_tasks(calls), BatchDescriptor(num_tokens=4, num_reqs=4))
+    executor.release()
+    executor.submit(_tasks(calls), BatchDescriptor(num_tokens=8, num_reqs=4))
+
+    assert allocations[-3:] == ["external-3", "external-4", "external-5"]
+
+
+def test_external_event_frontiers_must_remain_stable(executor_env):
+    executor, calls, allocations = executor_env
+    descriptor = BatchDescriptor(num_tokens=4, num_reqs=4)
+
+    executor.submit(_tasks(calls), descriptor)
+    executor.release()
+    calls.clear()
+    allocations_before = list(allocations)
+
+    with pytest.raises(RuntimeError, match="frontiers changed"):
+        executor.submit(_tasks(calls)[:-1], descriptor)
+
+    assert calls == []
+    assert allocations == allocations_before
+    assert not executor.submission_in_flight
 
 
 def test_submission_in_flight_tracks_release(executor_env):

--- a/tests/ut/worker/test_device_metadata.py
+++ b/tests/ut/worker/test_device_metadata.py
@@ -20,9 +20,9 @@ import torch
 
 from vllm_ascend.worker.device_metadata import (
     DeviceMetadataExecutor,
-    DeviceMetadataPlan,
     DeviceMetadataStage,
     DeviceMetadataTask,
+    DeviceMetadataTaskProvider,
 )
 
 
@@ -47,45 +47,57 @@ class _FakeEvent:
 @pytest.fixture
 def executor_env(monkeypatch):
     calls: list[tuple] = []
+    allocations: list[str] = []
     model_stream = _FakeStream("model", calls)
     metadata_stream = _FakeStream("metadata", calls)
     event_names = iter(("inputs", "compressor", "indexer", "attention", "reusable"))
 
-    monkeypatch.setattr(torch.npu, "Stream", lambda: metadata_stream)
-    monkeypatch.setattr(
-        torch.npu,
-        "Event",
-        lambda: _FakeEvent(next(event_names), calls),
-    )
+    def make_stream():
+        allocations.append("stream")
+        return metadata_stream
+
+    def make_event():
+        name = next(event_names)
+        allocations.append(name)
+        return _FakeEvent(name, calls)
+
+    monkeypatch.setattr(torch.npu, "Stream", make_stream)
+    monkeypatch.setattr(torch.npu, "Event", make_event)
     monkeypatch.setattr(torch.npu, "current_stream", lambda: model_stream)
     monkeypatch.setattr(torch.npu, "stream", lambda stream: nullcontext())
 
-    return DeviceMetadataExecutor(), calls
+    return DeviceMetadataExecutor(), calls, allocations
 
 
-def _plan(calls: list[tuple]) -> DeviceMetadataPlan:
-    return DeviceMetadataPlan(
-        tasks=(
-            DeviceMetadataTask(
-                DeviceMetadataStage.COMPRESSOR,
-                lambda: calls.append(("task", "compressor")),
-            ),
-            DeviceMetadataTask(
-                DeviceMetadataStage.INDEXER,
-                lambda: calls.append(("task", "indexer")),
-            ),
-            DeviceMetadataTask(
-                DeviceMetadataStage.ATTENTION,
-                lambda: calls.append(("task", "attention")),
-            ),
-        )
+def _tasks(calls: list[tuple]) -> tuple[DeviceMetadataTask, ...]:
+    return (
+        DeviceMetadataTask(
+            DeviceMetadataStage.COMPRESSOR,
+            lambda: calls.append(("task", "compressor")),
+        ),
+        DeviceMetadataTask(
+            DeviceMetadataStage.INDEXER,
+            lambda: calls.append(("task", "indexer")),
+        ),
+        DeviceMetadataTask(
+            DeviceMetadataStage.ATTENTION,
+            lambda: calls.append(("task", "attention")),
+        ),
     )
 
 
 def test_submit_records_inputs_and_stage_frontiers(executor_env):
-    executor, calls = executor_env
+    executor, calls, allocations = executor_env
 
-    executor.submit(_plan(calls))
+    assert allocations == [
+        "stream",
+        "inputs",
+        "compressor",
+        "indexer",
+        "attention",
+        "reusable",
+    ]
+    executor.submit(_tasks(calls))
 
     assert calls == [
         ("model", "record", "inputs"),
@@ -100,10 +112,10 @@ def test_submit_records_inputs_and_stage_frontiers(executor_env):
 
 
 def test_wait_and_release_fence_buffer_reuse(executor_env):
-    executor, calls = executor_env
-    plan = _plan(calls)
+    executor, calls, _ = executor_env
+    tasks = _tasks(calls)
 
-    executor.submit(plan)
+    executor.submit(tasks)
     executor.wait(DeviceMetadataStage.INDEXER)
     executor.release()
     assert calls[-2:] == [
@@ -111,7 +123,7 @@ def test_wait_and_release_fence_buffer_reuse(executor_env):
         ("model", "record", "reusable"),
     ]
     calls.clear()
-    executor.submit(plan)
+    executor.submit(tasks)
 
     assert calls[:3] == [
         ("model", "record", "inputs"),
@@ -120,20 +132,42 @@ def test_wait_and_release_fence_buffer_reuse(executor_env):
     ]
 
 
-def test_executor_rejects_overlapping_plans(executor_env):
-    executor, calls = executor_env
-    plan = _plan(calls)
-    executor.submit(plan)
+def test_executor_rejects_overlapping_submissions(executor_env):
+    executor, calls, _ = executor_env
+    tasks = _tasks(calls)
+    executor.submit(tasks)
 
     with pytest.raises(RuntimeError, match="has not been released"):
-        executor.submit(plan)
+        executor.submit(tasks)
 
 
-def test_plan_rejects_out_of_order_tasks():
-    with pytest.raises(ValueError, match="ordered by stage"):
-        DeviceMetadataPlan(
-            tasks=(
-                DeviceMetadataTask(DeviceMetadataStage.ATTENTION, lambda: None),
-                DeviceMetadataTask(DeviceMetadataStage.COMPRESSOR, lambda: None),
-            )
-        )
+def test_submit_orders_tasks_by_stage(executor_env):
+    executor, calls, _ = executor_env
+    tasks = tuple(reversed(_tasks(calls)))
+
+    executor.submit(tasks)
+
+    assert [call for call in calls if call[0] == "task"] == [
+        ("task", "compressor"),
+        ("task", "indexer"),
+        ("task", "attention"),
+    ]
+
+
+def test_task_provider_is_structural():
+    class LegacyBuilder:
+        pass
+
+    class ProviderBuilder:
+        def build_device_metadata_tasks(self, _context):
+            return (DeviceMetadataTask(DeviceMetadataStage.INDEXER, lambda: None),)
+
+    assert not isinstance(LegacyBuilder(), DeviceMetadataTaskProvider)
+    assert isinstance(ProviderBuilder(), DeviceMetadataTaskProvider)
+
+
+def test_submit_rejects_empty_tasks(executor_env):
+    executor, _, _ = executor_env
+
+    with pytest.raises(ValueError, match="At least one"):
+        executor.submit(())

--- a/tests/ut/worker/test_device_metadata.py
+++ b/tests/ut/worker/test_device_metadata.py
@@ -14,15 +14,18 @@
 # limitations under the License.
 
 from contextlib import nullcontext
+from types import SimpleNamespace
 
 import pytest
 import torch
 
+import vllm_ascend.worker.device_metadata as device_metadata
 from vllm_ascend.worker.device_metadata import (
     DeviceMetadataExecutor,
     DeviceMetadataStage,
     DeviceMetadataTask,
     DeviceMetadataTaskProvider,
+    wait_for_device_metadata,
 )
 
 
@@ -132,6 +135,26 @@ def test_wait_and_release_fence_buffer_reuse(executor_env):
     ]
 
 
+def test_wait_records_each_stage_once_per_submission(executor_env):
+    executor, calls, _ = executor_env
+    executor.submit(_tasks(calls))
+
+    executor.wait(DeviceMetadataStage.INDEXER)
+    executor.wait(DeviceMetadataStage.INDEXER)
+
+    assert calls.count(("model", "wait", "indexer")) == 1
+
+
+def test_submission_in_flight_tracks_release(executor_env):
+    executor, calls, _ = executor_env
+
+    assert not executor.submission_in_flight
+    executor.submit(_tasks(calls))
+    assert executor.submission_in_flight
+    executor.release()
+    assert not executor.submission_in_flight
+
+
 def test_executor_rejects_overlapping_submissions(executor_env):
     executor, calls, _ = executor_env
     tasks = _tasks(calls)
@@ -171,3 +194,29 @@ def test_submit_rejects_empty_tasks(executor_env):
 
     with pytest.raises(ValueError, match="At least one"):
         executor.submit(())
+
+
+def test_wait_helper_uses_active_forward_executor(monkeypatch):
+    calls = []
+    executor = SimpleNamespace(wait=lambda stage: calls.append(stage))
+    monkeypatch.setattr(device_metadata, "is_forward_context_available", lambda: True)
+    monkeypatch.setattr(
+        device_metadata,
+        "get_forward_context",
+        lambda: SimpleNamespace(device_metadata_executor=executor),
+    )
+
+    wait_for_device_metadata(DeviceMetadataStage.ATTENTION)
+
+    assert calls == [DeviceMetadataStage.ATTENTION]
+
+
+def test_wait_helper_is_noop_without_forward_context(monkeypatch):
+    monkeypatch.setattr(device_metadata, "is_forward_context_available", lambda: False)
+    monkeypatch.setattr(
+        device_metadata,
+        "get_forward_context",
+        lambda: pytest.fail("forward context should not be read"),
+    )
+
+    wait_for_device_metadata(DeviceMetadataStage.ATTENTION)

--- a/tests/ut/worker/test_device_metadata.py
+++ b/tests/ut/worker/test_device_metadata.py
@@ -1,0 +1,139 @@
+#
+# Copyright (c) 2026 Huawei Technologies Co., Ltd. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from contextlib import nullcontext
+
+import pytest
+import torch
+
+from vllm_ascend.worker.device_metadata import (
+    DeviceMetadataExecutor,
+    DeviceMetadataPlan,
+    DeviceMetadataStage,
+    DeviceMetadataTask,
+)
+
+
+class _FakeStream:
+    def __init__(self, name: str, calls: list[tuple]) -> None:
+        self.name = name
+        self.calls = calls
+
+    def wait_event(self, event: "_FakeEvent") -> None:
+        self.calls.append((self.name, "wait", event.name))
+
+
+class _FakeEvent:
+    def __init__(self, name: str, calls: list[tuple]) -> None:
+        self.name = name
+        self.calls = calls
+
+    def record(self, stream: _FakeStream) -> None:
+        self.calls.append((stream.name, "record", self.name))
+
+
+@pytest.fixture
+def executor_env(monkeypatch):
+    calls: list[tuple] = []
+    model_stream = _FakeStream("model", calls)
+    metadata_stream = _FakeStream("metadata", calls)
+    event_names = iter(("inputs", "compressor", "indexer", "attention", "reusable"))
+
+    monkeypatch.setattr(torch.npu, "Stream", lambda: metadata_stream)
+    monkeypatch.setattr(
+        torch.npu,
+        "Event",
+        lambda: _FakeEvent(next(event_names), calls),
+    )
+    monkeypatch.setattr(torch.npu, "current_stream", lambda: model_stream)
+    monkeypatch.setattr(torch.npu, "stream", lambda stream: nullcontext())
+
+    return DeviceMetadataExecutor(), calls
+
+
+def _plan(calls: list[tuple]) -> DeviceMetadataPlan:
+    return DeviceMetadataPlan(
+        tasks=(
+            DeviceMetadataTask(
+                DeviceMetadataStage.COMPRESSOR,
+                lambda: calls.append(("task", "compressor")),
+            ),
+            DeviceMetadataTask(
+                DeviceMetadataStage.INDEXER,
+                lambda: calls.append(("task", "indexer")),
+            ),
+            DeviceMetadataTask(
+                DeviceMetadataStage.ATTENTION,
+                lambda: calls.append(("task", "attention")),
+            ),
+        )
+    )
+
+
+def test_submit_records_inputs_and_stage_frontiers(executor_env):
+    executor, calls = executor_env
+
+    executor.submit(_plan(calls))
+
+    assert calls == [
+        ("model", "record", "inputs"),
+        ("metadata", "wait", "inputs"),
+        ("task", "compressor"),
+        ("metadata", "record", "compressor"),
+        ("task", "indexer"),
+        ("metadata", "record", "indexer"),
+        ("task", "attention"),
+        ("metadata", "record", "attention"),
+    ]
+
+
+def test_wait_and_release_fence_buffer_reuse(executor_env):
+    executor, calls = executor_env
+    plan = _plan(calls)
+
+    executor.submit(plan)
+    executor.wait(DeviceMetadataStage.INDEXER)
+    executor.release()
+    assert calls[-2:] == [
+        ("model", "wait", "indexer"),
+        ("model", "record", "reusable"),
+    ]
+    calls.clear()
+    executor.submit(plan)
+
+    assert calls[:3] == [
+        ("model", "record", "inputs"),
+        ("metadata", "wait", "inputs"),
+        ("metadata", "wait", "reusable"),
+    ]
+
+
+def test_executor_rejects_overlapping_plans(executor_env):
+    executor, calls = executor_env
+    plan = _plan(calls)
+    executor.submit(plan)
+
+    with pytest.raises(RuntimeError, match="has not been released"):
+        executor.submit(plan)
+
+
+def test_plan_rejects_out_of_order_tasks():
+    with pytest.raises(ValueError, match="ordered by stage"):
+        DeviceMetadataPlan(
+            tasks=(
+                DeviceMetadataTask(DeviceMetadataStage.ATTENTION, lambda: None),
+                DeviceMetadataTask(DeviceMetadataStage.COMPRESSOR, lambda: None),
+            )
+        )

--- a/tests/ut/worker/test_device_metadata.py
+++ b/tests/ut/worker/test_device_metadata.py
@@ -153,6 +153,22 @@ def test_wait_records_each_stage_once_per_submission(executor_env):
     assert calls.count(("model", "wait", "indexer")) == 1
 
 
+def test_wait_all_waits_current_frontiers_once(executor_env):
+    executor, calls, _ = executor_env
+    tasks = (*_tasks(calls), _tasks(calls)[1])
+    executor.submit(tasks)
+
+    executor.wait_all()
+    executor.wait(DeviceMetadataStage.INDEXER, 2)
+
+    waits = [call for call in calls if call[:2] == ("model", "wait")]
+    assert waits == [
+        ("model", "wait", "compressor"),
+        ("model", "wait", "indexer"),
+        ("model", "wait", "attention"),
+    ]
+
+
 def test_submission_in_flight_tracks_release(executor_env):
     executor, calls, _ = executor_env
 

--- a/tests/ut/worker/test_model_runner_v1.py
+++ b/tests/ut/worker/test_model_runner_v1.py
@@ -76,22 +76,27 @@ class TestDummyRunSlotInvalidation(unittest.TestCase):
             runner._dummy_run(1)
 
 
-class TestDeviceMetadataFullGraphWait(unittest.TestCase):
-    def test_waits_all_only_for_effective_full_mode(self):
-        for mode, should_wait in (
-            (CUDAGraphMode.FULL, True),
-            (CUDAGraphMode.PIECEWISE, False),
-            (CUDAGraphMode.NONE, False),
+class TestDeviceMetadataFullGraphEvents(unittest.TestCase):
+    def test_full_mode_requires_external_events(self):
+        for mode, uses_external_events, should_raise in (
+            (CUDAGraphMode.FULL, False, True),
+            (CUDAGraphMode.FULL, True, False),
+            (CUDAGraphMode.PIECEWISE, False, False),
+            (CUDAGraphMode.NONE, False, False),
         ):
-            with self.subTest(mode=mode):
+            with self.subTest(mode=mode, uses_external_events=uses_external_events):
                 runner = NPUModelRunner.__new__(NPUModelRunner)
-                executor = MagicMock(submission_in_flight=True)
+                executor = SimpleNamespace(
+                    submission_in_flight=True,
+                    uses_external_events=uses_external_events,
+                )
                 runner.device_metadata_executor = executor
 
-                active_executor = runner._prepare_device_metadata_for_forward(mode)
-
-                self.assertIs(active_executor, executor)
-                self.assertEqual(executor.wait_all.call_count, int(should_wait))
+                if should_raise:
+                    with self.assertRaisesRegex(RuntimeError, "requires external events"):
+                        runner._prepare_device_metadata_for_forward(mode)
+                else:
+                    self.assertIs(runner._prepare_device_metadata_for_forward(mode), executor)
 
     def test_ignores_executor_without_active_submission(self):
         runner = NPUModelRunner.__new__(NPUModelRunner)
@@ -101,9 +106,8 @@ class TestDeviceMetadataFullGraphWait(unittest.TestCase):
         active_executor = runner._prepare_device_metadata_for_forward(CUDAGraphMode.FULL)
 
         self.assertIsNone(active_executor)
-        executor.wait_all.assert_not_called()
 
-    def test_dummy_full_waits_before_graph_forward(self):
+    def test_dummy_full_uses_external_events_without_global_wait(self):
         from contextlib import contextmanager, nullcontext
 
         events = []
@@ -147,7 +151,7 @@ class TestDeviceMetadataFullGraphWait(unittest.TestCase):
 
         runner._model_forward = MagicMock(side_effect=model_forward)
         executor = MagicMock(submission_in_flight=True)
-        executor.wait_all.side_effect = lambda: events.append("wait_all")
+        executor.uses_external_events = True
         executor.release.side_effect = lambda: events.append("release")
         runner.device_metadata_executor = executor
 
@@ -165,7 +169,7 @@ class TestDeviceMetadataFullGraphWait(unittest.TestCase):
         ):
             runner._dummy_run(4, cudagraph_runtime_mode=CUDAGraphMode.FULL, is_graph_capturing=True)
 
-        self.assertEqual(events, ["wait_all", "context_enter", "forward", "context_exit", "release"])
+        self.assertEqual(events, ["context_enter", "forward", "context_exit", "release"])
 
 
 class TestDSparkAuxCaptureMode(unittest.TestCase):

--- a/tests/ut/worker/test_model_runner_v1.py
+++ b/tests/ut/worker/test_model_runner_v1.py
@@ -140,7 +140,12 @@ class TestDeviceMetadataFullGraphWait(unittest.TestCase):
         runner.use_aux_hidden_state_outputs = False
         runner.use_compress = False
         runner._finalize_dump_data = MagicMock()
-        runner._model_forward = MagicMock(side_effect=lambda *args: events.append("forward") or torch.zeros((4, 1)))
+
+        def model_forward(*args):
+            events.append("forward")
+            return torch.zeros((4, 1))
+
+        runner._model_forward = MagicMock(side_effect=model_forward)
         executor = MagicMock(submission_in_flight=True)
         executor.wait_all.side_effect = lambda: events.append("wait_all")
         executor.release.side_effect = lambda: events.append("release")

--- a/tests/ut/worker/test_model_runner_v1.py
+++ b/tests/ut/worker/test_model_runner_v1.py
@@ -76,6 +76,93 @@ class TestDummyRunSlotInvalidation(unittest.TestCase):
             runner._dummy_run(1)
 
 
+class TestDeviceMetadataFullGraphWait(unittest.TestCase):
+    def test_waits_all_only_for_effective_full_mode(self):
+        for mode, should_wait in (
+            (CUDAGraphMode.FULL, True),
+            (CUDAGraphMode.PIECEWISE, False),
+            (CUDAGraphMode.NONE, False),
+        ):
+            with self.subTest(mode=mode):
+                runner = NPUModelRunner.__new__(NPUModelRunner)
+                executor = MagicMock(submission_in_flight=True)
+                runner.device_metadata_executor = executor
+
+                active_executor = runner._prepare_device_metadata_for_forward(mode)
+
+                self.assertIs(active_executor, executor)
+                self.assertEqual(executor.wait_all.call_count, int(should_wait))
+
+    def test_ignores_executor_without_active_submission(self):
+        runner = NPUModelRunner.__new__(NPUModelRunner)
+        executor = MagicMock(submission_in_flight=False)
+        runner.device_metadata_executor = executor
+
+        active_executor = runner._prepare_device_metadata_for_forward(CUDAGraphMode.FULL)
+
+        self.assertIsNone(active_executor)
+        executor.wait_all.assert_not_called()
+
+    def test_dummy_full_waits_before_graph_forward(self):
+        from contextlib import contextmanager, nullcontext
+
+        events = []
+        runner = NPUModelRunner.__new__(NPUModelRunner)
+        runner.uniform_decode_query_len = 1
+        runner.scheduler_config = SimpleNamespace(max_num_batched_tokens=4, max_num_seqs=4)
+        runner.dynamic_eplb = False
+        runner.dcp_size = 1
+        runner._determine_batch_execution_and_padding = MagicMock(
+            return_value=(
+                CUDAGraphMode.FULL,
+                SimpleNamespace(num_tokens=4, num_reqs=4),
+                None,
+                None,
+                None,
+            )
+        )
+        runner.synchronize_input_prep = nullcontext
+        runner._should_build_dummy_attn_metadata = MagicMock(return_value=False)
+        runner.maybe_dummy_run_with_lora = MagicMock(return_value=nullcontext())
+        runner.lora_config = None
+        runner.max_num_tokens = 4
+        runner.supports_mm_inputs = False
+        runner.model_config = SimpleNamespace(is_encoder_decoder=False)
+        runner.enable_prompt_embeds = False
+        runner.input_ids = SimpleNamespace(gpu=torch.zeros(4, dtype=torch.int64))
+        runner.uses_mrope = False
+        runner.uses_xdrope_dim = 0
+        runner.positions = torch.zeros(4, dtype=torch.int64)
+        runner.drafter = None
+        runner.vllm_config = MagicMock()
+        runner.model = MagicMock()
+        runner._has_sinks = False
+        runner.use_aux_hidden_state_outputs = False
+        runner.use_compress = False
+        runner._finalize_dump_data = MagicMock()
+        runner._model_forward = MagicMock(side_effect=lambda *args: events.append("forward") or torch.zeros((4, 1)))
+        executor = MagicMock(submission_in_flight=True)
+        executor.wait_all.side_effect = lambda: events.append("wait_all")
+        executor.release.side_effect = lambda: events.append("release")
+        runner.device_metadata_executor = executor
+
+        @contextmanager
+        def forward_context(*args, **kwargs):
+            events.append("context_enter")
+            yield
+            events.append("context_exit")
+
+        with (
+            patch("vllm_ascend.worker.model_runner_v1.get_pp_group", return_value=SimpleNamespace(is_first_rank=True)),
+            patch("vllm_ascend.worker.model_runner_v1.lmhead_tp_enable", return_value=False),
+            patch("vllm_ascend.worker.model_runner_v1.set_ascend_forward_context", forward_context),
+            patch("vllm_ascend.worker.model_runner_v1.update_cos_sin"),
+        ):
+            runner._dummy_run(4, cudagraph_runtime_mode=CUDAGraphMode.FULL, is_graph_capturing=True)
+
+        self.assertEqual(events, ["wait_all", "context_enter", "forward", "context_exit", "release"])
+
+
 class TestDSparkAuxCaptureMode(unittest.TestCase):
     def _build_runner(
         self,

--- a/tests/ut/worker/test_model_runner_v1.py
+++ b/tests/ut/worker/test_model_runner_v1.py
@@ -130,6 +130,7 @@ class TestDeviceMetadataFullGraphEvents(unittest.TestCase):
         runner.maybe_dummy_run_with_lora = MagicMock(return_value=nullcontext())
         runner.lora_config = None
         runner.max_num_tokens = 4
+        runner.device = torch.device("cpu")
         runner.supports_mm_inputs = False
         runner.model_config = SimpleNamespace(is_encoder_decoder=False)
         runner.enable_prompt_embeds = False

--- a/vllm_ascend/ascend_forward_context.py
+++ b/vllm_ascend/ascend_forward_context.py
@@ -109,6 +109,7 @@ def set_ascend_forward_context(
     skip_compiled: bool = False,
     max_tokens_across_pcp: int = 0,
     draft_attn_metadatas=None,
+    device_metadata_executor=None,
     has_sinks=False,
     eplb_heat_collection_status: bool = False,
 ):
@@ -135,6 +136,7 @@ def set_ascend_forward_context(
     with set_current_vllm_config(vllm_config), set_forward_context(**forward_context_kwargs):
         forward_context = get_forward_context()
         forward_context.draft_attn_metadatas = draft_attn_metadatas
+        forward_context.device_metadata_executor = device_metadata_executor
 
         from vllm_ascend.ops.fused_moe.moe_comm_method import get_moe_comm_method
 

--- a/vllm_ascend/attention/context_parallel/dsa_cp.py
+++ b/vllm_ascend/attention/context_parallel/dsa_cp.py
@@ -126,6 +126,7 @@ class AscendDSAReqMetadata:
     qli_metadata: torch.Tensor = None
     compressor_metadata: dsa_v1.CompressorMetadataOutput | None = None
     compressor_metadata_group_id: int | None = None
+    device_local_metadata_group_id: int | None = None
     cu_cmp_seqlen_list: torch.Tensor = None
     attn_mask: torch.Tensor | None = None
     ori_win_left: int | None = None
@@ -633,46 +634,66 @@ class AscendDSACPMetadataBuilder(AttentionMetadataBuilder[AscendDSAMetadata]):
         The computation (clamp + cumsum + offset + mask) is identical for
         all attention groups, so we compute once and cache the results.
         """
+        build_local_metadata = None
         cache = self.common_ratio_to_sas_metadata.get("_device_local")
         if cache is None:
-            # Calc and cache device tensor results
-            (
-                local_start,
-                local_end_with_pad,
-                tokens_per_rank,
-                num_tokens_pad,
-                local_query_start_loc,
-                local_seq_lens,
-            ) = self._build_local_token_metadata(
-                num_reqs=num_reqs,
-                num_input_tokens=num_input_tokens,
-                query_start_loc=query_start_loc,
-                seq_lens=seq_lens,
-                local_query_start_loc=self.local_query_start_loc,
-                local_seq_lens=self.local_seq_lens,
-                start_pos_out=self.start_pos_prefill,
-            )
+            local_start, local_end_with_pad, tokens_per_rank, num_tokens_pad = self._local_token_range(num_input_tokens)
+            local_query_start_loc = self.local_query_start_loc[: num_reqs + 1]
+            local_seq_lens = self.local_seq_lens[:num_reqs]
+            if self._device_metadata_enabled:
+
+                def build_local_metadata() -> None:
+                    self._build_local_token_metadata(
+                        num_reqs=num_reqs,
+                        num_input_tokens=num_input_tokens,
+                        query_start_loc=query_start_loc,
+                        seq_lens=seq_lens,
+                        local_query_start_loc=self.local_query_start_loc,
+                        local_seq_lens=self.local_seq_lens,
+                        start_pos_out=self.start_pos_prefill,
+                    )
+
+            else:
+                self._build_local_token_metadata(
+                    num_reqs=num_reqs,
+                    num_input_tokens=num_input_tokens,
+                    query_start_loc=query_start_loc,
+                    seq_lens=seq_lens,
+                    local_query_start_loc=self.local_query_start_loc,
+                    local_seq_lens=self.local_seq_lens,
+                    start_pos_out=self.start_pos_prefill,
+                )
             self.common_ratio_to_sas_metadata["_device_local"] = {
                 "local_start": local_start,
                 "local_end": local_end_with_pad,
                 "tokens_per_rank": tokens_per_rank,
                 "num_tokens_pad": num_tokens_pad,
-                "qsl": self.local_query_start_loc[: num_reqs + 1].clone(),
-                "sl": self.local_seq_lens[:num_reqs].clone(),
-                "sp": self.start_pos_prefill[:num_reqs].clone(),
+                "qsl": local_query_start_loc if self._device_metadata_enabled else local_query_start_loc.clone(),
+                "sl": local_seq_lens if self._device_metadata_enabled else local_seq_lens.clone(),
+                "sp": (
+                    self.start_pos_prefill[:num_reqs]
+                    if self._device_metadata_enabled
+                    else self.start_pos_prefill[:num_reqs].clone()
+                ),
             }
         else:
-            # copy from cache
-            assert cache is not None
             local_start = cache["local_start"]
             local_end_with_pad = cache["local_end"]
             tokens_per_rank = cache["tokens_per_rank"]
             num_tokens_pad = cache["num_tokens_pad"]
-            self.local_query_start_loc[: num_reqs + 1].copy_(cache["qsl"])
-            self.local_seq_lens[:num_reqs].copy_(cache["sl"])
-            self.start_pos_prefill[:num_reqs].copy_(cache["sp"])
             local_query_start_loc = self.local_query_start_loc[: num_reqs + 1]
             local_seq_lens = self.local_seq_lens[:num_reqs]
+            if self._device_metadata_enabled:
+
+                def build_local_metadata() -> None:
+                    local_query_start_loc.copy_(cache["qsl"])
+                    local_seq_lens.copy_(cache["sl"])
+                    self.start_pos_prefill[:num_reqs].copy_(cache["sp"])
+
+            else:
+                local_query_start_loc.copy_(cache["qsl"])
+                local_seq_lens.copy_(cache["sl"])
+                self.start_pos_prefill[:num_reqs].copy_(cache["sp"])
 
         return (
             local_start,
@@ -681,6 +702,7 @@ class AscendDSACPMetadataBuilder(AttentionMetadataBuilder[AscendDSAMetadata]):
             num_tokens_pad,
             local_query_start_loc,
             local_seq_lens,
+            build_local_metadata,
         )
 
     def build_req_metadata(
@@ -708,6 +730,7 @@ class AscendDSACPMetadataBuilder(AttentionMetadataBuilder[AscendDSAMetadata]):
             num_tokens_pad,
             local_query_start_loc,
             local_seq_lens,
+            build_local_metadata,
         ) = self._ensure_device_local_metadata(
             num_reqs=num_reqs,
             num_input_tokens=num_input_tokens,
@@ -747,7 +770,6 @@ class AscendDSACPMetadataBuilder(AttentionMetadataBuilder[AscendDSAMetadata]):
             assert cpu_cache is not None
             local_query_start_loc_cpu = cpu_cache["qsl_cpu"]
             local_seq_lens_cpu = cpu_cache["sl_cpu"]
-        local_seq_lens_q = local_query_start_loc[1 : num_reqs + 1] - local_query_start_loc[:num_reqs]
         local_seq_lens_q_cpu = local_query_start_loc_cpu[1 : num_reqs + 1] - local_query_start_loc_cpu[:num_reqs]
         max_local_query_len = max(1, int(local_seq_lens_q_cpu.max().item()))
         max_local_seq_lens = max(1, int(local_seq_lens_cpu.max().item()))
@@ -757,7 +779,16 @@ class AscendDSACPMetadataBuilder(AttentionMetadataBuilder[AscendDSAMetadata]):
         else:
             num_actual_reqs = min(num_actual_reqs, num_reqs)
             if num_actual_reqs < num_reqs:
-                self.start_pos_prefill[num_actual_reqs:].fill_(0)
+                if build_local_metadata is None:
+                    self.start_pos_prefill[num_actual_reqs:].fill_(0)
+                else:
+                    build_device_local_metadata = build_local_metadata
+                    valid_num_reqs = num_actual_reqs
+
+                    def build_local_metadata() -> None:
+                        build_device_local_metadata()
+                        self.start_pos_prefill[valid_num_reqs:].fill_(0)
+
                 self.block_table[num_actual_reqs:num_reqs, ...].fill_(0)
         # --- Compressed positions ---
         full_compress_cos, full_compress_sin = None, None
@@ -786,13 +817,19 @@ class AscendDSACPMetadataBuilder(AttentionMetadataBuilder[AscendDSAMetadata]):
         index_topk = self.model_config.hf_config.index_topk
 
         if self._device_metadata_enabled:
+            assert build_local_metadata is not None
+            device_local_metadata_group_id = id(self.req_sas_metadata)
+            local_metadata_task = DeviceMetadataTask(
+                DeviceMetadataStage.COMPRESSOR,
+                build_local_metadata,
+                device_local_metadata_group_id,
+            )
 
             def build_sas_metadata() -> None:
                 self._build_sas_metadata(
                     num_heads=num_heads,
                     query_start_loc=local_query_start_loc,
                     seq_lens=local_seq_lens,
-                    seq_lens_q=local_seq_lens_q,
                     max_query_len=max_local_query_len,
                     max_seq_lens=max_local_seq_lens,
                     index_topk=index_topk,
@@ -812,22 +849,24 @@ class AscendDSACPMetadataBuilder(AttentionMetadataBuilder[AscendDSAMetadata]):
 
             if self.compressor_ratio == 4:
                 self._device_metadata_tasks = (
+                    local_metadata_task,
                     DeviceMetadataTask(DeviceMetadataStage.INDEXER, build_qli_metadata, id(self.req_qli_metadata)),
                     DeviceMetadataTask(DeviceMetadataStage.ATTENTION, build_sas_metadata, id(self.req_sas_metadata)),
                 )
             else:
                 self._device_metadata_tasks = (
+                    local_metadata_task,
                     DeviceMetadataTask(DeviceMetadataStage.ATTENTION, build_sas_metadata, id(self.req_sas_metadata)),
                 )
             sas_metadata = self.req_sas_metadata
             qli_metadata = self.req_qli_metadata if self.compressor_ratio == 4 else None
         else:
+            device_local_metadata_group_id = None
             self._device_metadata_tasks = ()
             sas_metadata = self._build_sas_metadata(
                 num_heads=num_heads,
                 query_start_loc=local_query_start_loc,
                 seq_lens=local_seq_lens,
-                seq_lens_q=local_seq_lens_q,
                 max_query_len=max_local_query_len,
                 max_seq_lens=max_local_seq_lens,
                 index_topk=index_topk,
@@ -871,6 +910,7 @@ class AscendDSACPMetadataBuilder(AttentionMetadataBuilder[AscendDSAMetadata]):
             num_actual_reqs=num_actual_reqs,
             sas_metadata=sas_metadata,
             qli_metadata=qli_metadata,
+            device_local_metadata_group_id=device_local_metadata_group_id,
             cu_cmp_seqlen_list=cu_cmp_seqlens,
         )
         if self._device_metadata_enabled and self.compressor_metadata_buffers is not None:
@@ -885,12 +925,13 @@ class AscendDSACPMetadataBuilder(AttentionMetadataBuilder[AscendDSAMetadata]):
             req_metadata.compressor_metadata = outputs
             req_metadata.compressor_metadata_group_id = group_id
             self._device_metadata_tasks = (
+                local_metadata_task,
                 DeviceMetadataTask(
                     DeviceMetadataStage.COMPRESSOR,
                     lambda: dsa_v1.build_compressor_metadata_out(req_metadata, self.compressor_ratio, outputs),
                     group_id,
                 ),
-                *self._device_metadata_tasks,
+                *self._device_metadata_tasks[1:],
             )
         return req_metadata
 
@@ -909,6 +950,14 @@ class AscendDSACPMetadataBuilder(AttentionMetadataBuilder[AscendDSAMetadata]):
         tasks = self._device_metadata_tasks
         self._device_metadata_tasks = ()
         return tasks
+
+    @staticmethod
+    def _local_token_range(num_input_tokens: int) -> tuple[int, int, int, int]:
+        tp_group = get_tp_group()
+        num_tokens_pad = ((num_input_tokens + tp_group.world_size - 1) // tp_group.world_size) * tp_group.world_size
+        tokens_per_rank = num_tokens_pad // tp_group.world_size
+        local_start = tp_group.rank_in_group * tokens_per_rank
+        return local_start, local_start + tokens_per_rank, tokens_per_rank, num_tokens_pad
 
     def _build_local_token_metadata(
         self,
@@ -936,15 +985,9 @@ class AscendDSACPMetadataBuilder(AttentionMetadataBuilder[AscendDSAMetadata]):
         local_reqs_mask = [0, 0, 0, 0, 0, 1, 1, 1, 0]
         local_seq_lens = [0, 0, 0, 0, 0, 6, 7, 2, 0]
         """
-        tp_group = get_tp_group()
-        tp_size = tp_group.world_size
-        tp_rank = tp_group.rank_in_group
         # Split the flattened token stream evenly across TP ranks. Padding keeps
         # every rank's local slice the same length, which simplifies CP kernels.
-        num_tokens_pad = ((num_input_tokens + tp_size - 1) // tp_size) * tp_size
-        tokens_per_rank = num_tokens_pad // tp_size
-        local_start = tp_rank * tokens_per_rank
-        local_end = local_start + tokens_per_rank
+        local_start, local_end, tokens_per_rank, num_tokens_pad = self._local_token_range(num_input_tokens)
 
         if local_query_start_loc is not None:
             local_query_start_loc.fill_(0)
@@ -1026,7 +1069,6 @@ class AscendDSACPMetadataBuilder(AttentionMetadataBuilder[AscendDSAMetadata]):
         num_heads,
         query_start_loc,
         seq_lens,
-        seq_lens_q,
         max_query_len,
         max_seq_lens,
         index_topk,
@@ -1294,6 +1336,11 @@ class AscendDSACPImpl(AttentionImplBase[Any]):
                 metadata.compressor_metadata_group_id,
             )
             return precomputed
+        if metadata.device_local_metadata_group_id is not None:
+            wait_for_device_metadata(
+                DeviceMetadataStage.COMPRESSOR,
+                metadata.device_local_metadata_group_id,
+            )
 
         assert metadata.full_compress_cos is not None
         assert metadata.full_compress_sin is not None

--- a/vllm_ascend/attention/context_parallel/dsa_cp.py
+++ b/vllm_ascend/attention/context_parallel/dsa_cp.py
@@ -928,7 +928,9 @@ class AscendDSACPMetadataBuilder(AttentionMetadataBuilder[AscendDSAMetadata]):
                 local_metadata_task,
                 DeviceMetadataTask(
                     DeviceMetadataStage.COMPRESSOR,
-                    lambda: dsa_v1.build_compressor_metadata_out(req_metadata, self.compressor_ratio, outputs),
+                    lambda: dsa_v1.build_compressor_metadata_out(
+                        req_metadata, self.compressor_ratio, outputs, self.vllm_config
+                    ),
                     group_id,
                 ),
                 *self._device_metadata_tasks[1:],
@@ -1830,7 +1832,6 @@ class AscendDSACPImpl(AttentionImplBase[Any]):
             )
 
         notify_kv_cache_written(layer_name)
-        record_attention_compute_start()
         kv_plan = get_dsa_attn_kv_plan(self.vllm_config)
         attn_op = kv_plan.get_dsa_sparse_attn_op()
         extra_attn_kwargs = kv_plan.get_dsa_sparse_attn_base_kwargs()
@@ -1858,6 +1859,7 @@ class AscendDSACPImpl(AttentionImplBase[Any]):
 
         if self.compress_ratio <= 1:
             wait_for_device_metadata(DeviceMetadataStage.ATTENTION, id(swa_metadata.req_metadata.sas_metadata))
+            record_attention_compute_start()
             attn_output = attn_op(
                 q,
                 ori_kv=swa_kv_cache,
@@ -1873,6 +1875,7 @@ class AscendDSACPImpl(AttentionImplBase[Any]):
                 common_attn_kwargs, cu_seqlens_cmp_kv=req_metadata.cu_cmp_seqlen_list
             )
             wait_for_device_metadata(DeviceMetadataStage.ATTENTION, id(req_metadata.sas_metadata))
+            record_attention_compute_start()
             attn_output = attn_op(
                 q,
                 ori_kv=swa_kv_cache,
@@ -1892,6 +1895,7 @@ class AscendDSACPImpl(AttentionImplBase[Any]):
                 common_attn_kwargs, cu_seqlens_cmp_kv=req_metadata.cu_cmp_seqlen_list
             )
             wait_for_device_metadata(DeviceMetadataStage.ATTENTION, id(compressor_req_metadata.sas_metadata))
+            record_attention_compute_start()
             attn_output = attn_op(
                 q,
                 ori_kv=swa_kv_cache,

--- a/vllm_ascend/attention/context_parallel/dsa_cp.py
+++ b/vllm_ascend/attention/context_parallel/dsa_cp.py
@@ -48,6 +48,11 @@ from vllm_ascend.utils import (
     enable_dsa_cp_with_o_proj_tp,
     olora_tp_enable,
 )
+from vllm_ascend.worker.device_metadata import (
+    DeviceMetadataStage,
+    DeviceMetadataTask,
+    wait_for_device_metadata,
+)
 
 if TYPE_CHECKING:
     from vllm_ascend.worker.v2.pcp_manager import AscendPCPAttentionContext
@@ -233,6 +238,8 @@ class AscendDSACPMetadataBuilder(AttentionMetadataBuilder[AscendDSAMetadata]):
         self.start_pos_prefill = torch.zeros(scheduler_config.max_num_seqs, dtype=torch.int32, device=self.device)
         self.req_sas_metadata = torch.zeros(1024, dtype=torch.int32, device=self.device)
         self.req_qli_metadata = torch.zeros(1024, dtype=torch.int32, device=self.device)
+        self._device_metadata_enabled = False
+        self._device_metadata_tasks: tuple[DeviceMetadataTask, ...] = ()
         self.cu_seqlens_ori_kv = torch.tensor([], device=self.device)
         self.cu_seqlens_cmp_kv = torch.tensor([], device=self.device)
         self.seqused_q = torch.tensor([], device=self.device)
@@ -767,26 +774,63 @@ class AscendDSACPMetadataBuilder(AttentionMetadataBuilder[AscendDSAMetadata]):
         num_heads = self.model_config.hf_config.num_attention_heads
         index_topk = self.model_config.hf_config.index_topk
 
-        sas_metadata = self._build_sas_metadata(
-            num_heads=num_heads,
-            query_start_loc=local_query_start_loc,
-            seq_lens=local_seq_lens,
-            seq_lens_q=local_seq_lens_q,
-            max_query_len=max_local_query_len,
-            max_seq_lens=max_local_seq_lens,
-            index_topk=index_topk,
-            num_reqs=num_reqs,
-            has_prefill=has_prefill,
-            cu_cmp_seqlen_list=cu_cmp_seqlens,
-        )
+        if self._device_metadata_enabled:
 
-        # --- QLI metadata (all requests combined) ---
-        qli_metadata = self._build_qli_metadata(
-            query_start_loc=local_query_start_loc,
-            seq_lens=local_seq_lens,
-            seq_lens_q=local_seq_lens_q,
-            num_reqs=num_reqs,
-        )
+            def build_sas_metadata() -> None:
+                self._build_sas_metadata(
+                    num_heads=num_heads,
+                    query_start_loc=local_query_start_loc,
+                    seq_lens=local_seq_lens,
+                    seq_lens_q=local_seq_lens_q,
+                    max_query_len=max_local_query_len,
+                    max_seq_lens=max_local_seq_lens,
+                    index_topk=index_topk,
+                    num_reqs=num_reqs,
+                    has_prefill=has_prefill,
+                    cu_cmp_seqlen_list=cu_cmp_seqlens,
+                )
+
+            def build_qli_metadata() -> None:
+                self._build_qli_metadata(
+                    query_start_loc=local_query_start_loc,
+                    seq_lens=local_seq_lens,
+                    num_reqs=num_reqs,
+                    max_seqlen_q=max_local_query_len,
+                    max_seqlen_k=max_local_seq_lens,
+                )
+
+            if self.compressor_ratio == 4:
+                self._device_metadata_tasks = (
+                    DeviceMetadataTask(DeviceMetadataStage.INDEXER, build_qli_metadata, id(self.req_qli_metadata)),
+                    DeviceMetadataTask(DeviceMetadataStage.ATTENTION, build_sas_metadata, id(self.req_sas_metadata)),
+                )
+            else:
+                self._device_metadata_tasks = (
+                    DeviceMetadataTask(DeviceMetadataStage.ATTENTION, build_sas_metadata, id(self.req_sas_metadata)),
+                )
+            sas_metadata = self.req_sas_metadata
+            qli_metadata = self.req_qli_metadata if self.compressor_ratio == 4 else None
+        else:
+            self._device_metadata_tasks = ()
+            sas_metadata = self._build_sas_metadata(
+                num_heads=num_heads,
+                query_start_loc=local_query_start_loc,
+                seq_lens=local_seq_lens,
+                seq_lens_q=local_seq_lens_q,
+                max_query_len=max_local_query_len,
+                max_seq_lens=max_local_seq_lens,
+                index_topk=index_topk,
+                num_reqs=num_reqs,
+                has_prefill=has_prefill,
+                cu_cmp_seqlen_list=cu_cmp_seqlens,
+            )
+            qli_metadata = self._build_qli_metadata(
+                query_start_loc=local_query_start_loc,
+                seq_lens=local_seq_lens,
+                num_reqs=num_reqs,
+                max_seqlen_q=max_local_query_len,
+                max_seqlen_k=max_local_seq_lens,
+            )
 
         cp_metadata = DSACPMetadata(
             local_query_start_loc=local_query_start_loc,
@@ -818,6 +862,14 @@ class AscendDSACPMetadataBuilder(AttentionMetadataBuilder[AscendDSAMetadata]):
             qli_metadata=qli_metadata,
             cu_cmp_seqlen_list=cu_cmp_seqlens,
         )
+
+    def enable_device_metadata(self) -> None:
+        self._device_metadata_enabled = True
+
+    def take_device_metadata_tasks(self) -> tuple[DeviceMetadataTask, ...]:
+        tasks = self._device_metadata_tasks
+        self._device_metadata_tasks = ()
+        return tasks
 
     def _build_local_token_metadata(
         self,
@@ -1004,7 +1056,14 @@ class AscendDSACPMetadataBuilder(AttentionMetadataBuilder[AscendDSAMetadata]):
         self.req_sas_metadata[:1024] = metadata
         return self.req_sas_metadata[:1024]
 
-    def _build_qli_metadata(self, query_start_loc, seq_lens, seq_lens_q, num_reqs):
+    def _build_qli_metadata(
+        self,
+        query_start_loc,
+        seq_lens,
+        num_reqs,
+        max_seqlen_q,
+        max_seqlen_k,
+    ):
         if self.compressor_ratio != 4:
             return None
 
@@ -1012,8 +1071,6 @@ class AscendDSACPMetadataBuilder(AttentionMetadataBuilder[AscendDSAMetadata]):
         metadata = self.common_ratio_to_sas_metadata.get(cache_key)
 
         if metadata is None:
-            max_seqlen_q = max(1, int(seq_lens_q.max().item()))
-            max_seqlen_k = max(1, int(seq_lens.max().item()))
             metadata = torch.ops._C_ascend.npu_vllm_quant_lightning_indexer_metadata(
                 actual_seq_lengths_query=query_start_loc[1:].clone(),
                 actual_seq_lengths_key=seq_lens.clone(),
@@ -1705,6 +1762,7 @@ class AscendDSACPImpl(AttentionImplBase[Any]):
         )
 
         if self.compress_ratio <= 1:
+            wait_for_device_metadata(DeviceMetadataStage.ATTENTION, id(swa_metadata.req_metadata.sas_metadata))
             attn_output = attn_op(
                 q,
                 ori_kv=swa_kv_cache,
@@ -1719,6 +1777,7 @@ class AscendDSACPImpl(AttentionImplBase[Any]):
             kv_plan.add_dsa_sparse_attn_extra_kwargs(
                 common_attn_kwargs, cu_seqlens_cmp_kv=req_metadata.cu_cmp_seqlen_list
             )
+            wait_for_device_metadata(DeviceMetadataStage.ATTENTION, id(req_metadata.sas_metadata))
             attn_output = attn_op(
                 q,
                 ori_kv=swa_kv_cache,
@@ -1737,6 +1796,7 @@ class AscendDSACPImpl(AttentionImplBase[Any]):
             kv_plan.add_dsa_sparse_attn_extra_kwargs(
                 common_attn_kwargs, cu_seqlens_cmp_kv=req_metadata.cu_cmp_seqlen_list
             )
+            wait_for_device_metadata(DeviceMetadataStage.ATTENTION, id(compressor_req_metadata.sas_metadata))
             attn_output = attn_op(
                 q,
                 ori_kv=swa_kv_cache,
@@ -1888,6 +1948,7 @@ class AscendDSACPImpl(AttentionImplBase[Any]):
 
         assert indexer_kv_scale_metadata.req_metadata is not None
         qli_metadata = indexer_kv_scale_metadata.req_metadata.qli_metadata
+        wait_for_device_metadata(DeviceMetadataStage.INDEXER, id(qli_metadata))
         block_table = indexer_kv_scale_metadata.req_metadata.block_table
         topk_idxs, _ = torch.ops._C_ascend.npu_vllm_quant_lightning_indexer(
             query=q,
@@ -2053,6 +2114,7 @@ class AscendDSAPCPMetadataBuilder(dsa_v1.AscendDSAMetadataBuilder):
             )
 
         # Empty ranks still participate in the global cache update collectives.
+        self._device_metadata_tasks = ()
         self.common_ratio_to_sas_metadata = kwargs.get(
             "common_ratio_to_sas_metadata",
         )
@@ -2124,6 +2186,14 @@ class AscendDSAPCPMetadataBuilder(dsa_v1.AscendDSAMetadataBuilder):
             pcp_context.hidden_restore_idx,
             global_dsa_metadata,
         )
+
+    def enable_device_metadata(self) -> None:
+        super().enable_device_metadata()
+        self._global_metadata_builder.enable_device_metadata()
+
+    def take_device_metadata_tasks(self) -> tuple[DeviceMetadataTask, ...]:
+        self._global_metadata_builder.take_device_metadata_tasks()
+        return super().take_device_metadata_tasks()
 
 
 class AscendDSAPCPImpl(dsa_v1.AscendDSAImpl):

--- a/vllm_ascend/attention/context_parallel/dsa_cp.py
+++ b/vllm_ascend/attention/context_parallel/dsa_cp.py
@@ -6,7 +6,7 @@ import torch
 import torch.distributed as dist
 import torch.nn.functional as F
 import torch_npu
-from vllm.config import VllmConfig, get_current_vllm_config
+from vllm.config import CUDAGraphMode, VllmConfig, get_current_vllm_config
 from vllm.distributed import get_pcp_group, get_tp_group
 from vllm.triton_utils import HAS_TRITON, triton
 from vllm.v1.attention.backend import AttentionCGSupport, AttentionImplBase, AttentionMetadataBuilder
@@ -124,6 +124,8 @@ class AscendDSAReqMetadata:
     num_actual_reqs: int | None = None
     sas_metadata: torch.Tensor = None
     qli_metadata: torch.Tensor = None
+    compressor_metadata: dsa_v1.CompressorMetadataOutput | None = None
+    compressor_metadata_group_id: int | None = None
     cu_cmp_seqlen_list: torch.Tensor = None
     attn_mask: torch.Tensor | None = None
     ori_win_left: int | None = None
@@ -283,6 +285,7 @@ class AscendDSACPMetadataBuilder(AttentionMetadataBuilder[AscendDSAMetadata]):
         # Note(qcs): we use two dimension slot_mapping for kvcache with shape
         # [block_nums, block_size, head_num, head_dim]
         self.slot_mapping = torch.zeros(self.slot_mapping_shape, dtype=torch.int32, device=self.device)
+        self.compressor_metadata_buffers: dsa_v1.CompressorMetadataOutput | None = None
 
     @classmethod
     def get_cudagraph_support(
@@ -372,6 +375,7 @@ class AscendDSACPMetadataBuilder(AttentionMetadataBuilder[AscendDSAMetadata]):
             attn_state,
             cos=cos,
             sin=sin,
+            full_graph_mode=kwargs.get("full_graph_mode", False),
         )
 
         return self.metadata_cls(  # type: ignore
@@ -688,6 +692,7 @@ class AscendDSACPMetadataBuilder(AttentionMetadataBuilder[AscendDSAMetadata]):
         attn_state: AscendAttentionState,
         cos: RopeDataProxy,
         sin: RopeDataProxy,
+        full_graph_mode: bool = False,
     ) -> AscendDSAReqMetadata:
         """Build a single unified metadata for all requests (prefill + decode)."""
         num_reqs = common_attn_metadata.num_reqs
@@ -754,7 +759,6 @@ class AscendDSACPMetadataBuilder(AttentionMetadataBuilder[AscendDSAMetadata]):
             if num_actual_reqs < num_reqs:
                 self.start_pos_prefill[num_actual_reqs:].fill_(0)
                 self.block_table[num_actual_reqs:num_reqs, ...].fill_(0)
-
         # --- Compressed positions ---
         full_compress_cos, full_compress_sin = None, None
         cu_cmp_seqlens = self._get_cmp_seqlens_for_metadata(has_prefill)
@@ -763,7 +767,14 @@ class AscendDSACPMetadataBuilder(AttentionMetadataBuilder[AscendDSAMetadata]):
             layer_name = f"c{self.compressor_ratio}"
             # Keep only graph inputs here. The compressor metadata op itself is
             # launched in forward at the real compressor consumer.
-            num_compressed_tokens = self._num_compressor_metadata_rows(common_attn_metadata)
+            if full_graph_mode:
+                num_compressed_tokens = min(
+                    num_input_tokens,
+                    num_input_tokens // self.compressor_ratio + num_reqs,
+                )
+                num_actual_reqs = num_reqs
+            else:
+                num_compressed_tokens = self._num_compressor_metadata_rows(common_attn_metadata)
             full_compress_cos, full_compress_sin = get_full_cos_and_sin_dsa(layer_name)
             slot_mapping = None
         else:
@@ -843,7 +854,7 @@ class AscendDSACPMetadataBuilder(AttentionMetadataBuilder[AscendDSAMetadata]):
             local_cos=local_cos,
         )
 
-        return AscendDSAReqMetadata(
+        req_metadata = AscendDSAReqMetadata(
             input_positions=input_positions,
             block_table=self.block_table[:num_reqs, ...],
             slot_mapping=slot_mapping,
@@ -862,9 +873,37 @@ class AscendDSACPMetadataBuilder(AttentionMetadataBuilder[AscendDSAMetadata]):
             qli_metadata=qli_metadata,
             cu_cmp_seqlen_list=cu_cmp_seqlens,
         )
+        if self._device_metadata_enabled and self.compressor_metadata_buffers is not None:
+            assert num_compressed_tokens is not None
+            buffers = self.compressor_metadata_buffers
+            outputs = (
+                buffers[0][:num_compressed_tokens],
+                buffers[1][:num_compressed_tokens],
+                buffers[2][:num_compressed_tokens],
+            )
+            group_id = id(buffers[0])
+            req_metadata.compressor_metadata = outputs
+            req_metadata.compressor_metadata_group_id = group_id
+            self._device_metadata_tasks = (
+                DeviceMetadataTask(
+                    DeviceMetadataStage.COMPRESSOR,
+                    lambda: dsa_v1.build_compressor_metadata_out(req_metadata, self.compressor_ratio, outputs),
+                    group_id,
+                ),
+                *self._device_metadata_tasks,
+            )
+        return req_metadata
 
     def enable_device_metadata(self) -> None:
         self._device_metadata_enabled = True
+        if self.compressor_ratio > 1 and self.vllm_config.compilation_config.cudagraph_mode != CUDAGraphMode.FULL:
+            max_tokens = self.vllm_config.scheduler_config.max_num_batched_tokens
+            output_shape = (max_tokens, 1, 1, self.model_config.hf_config.qk_rope_head_dim)
+            self.compressor_metadata_buffers = (
+                torch.empty(output_shape, dtype=torch.float32, device=self.device),
+                torch.empty(output_shape, dtype=torch.float32, device=self.device),
+                self.slot_mapping,
+            )
 
     def take_device_metadata_tasks(self) -> tuple[DeviceMetadataTask, ...]:
         tasks = self._device_metadata_tasks
@@ -1247,6 +1286,15 @@ class AscendDSACPImpl(AttentionImplBase[Any]):
         self,
         metadata: AscendDSAReqMetadata,
     ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+        precomputed = getattr(metadata, "compressor_metadata", None)
+        if precomputed is not None:
+            assert metadata.compressor_metadata_group_id is not None
+            wait_for_device_metadata(
+                DeviceMetadataStage.COMPRESSOR,
+                metadata.compressor_metadata_group_id,
+            )
+            return precomputed
+
         assert metadata.full_compress_cos is not None
         assert metadata.full_compress_sin is not None
         assert metadata.num_compressed_tokens is not None
@@ -2188,12 +2236,15 @@ class AscendDSAPCPMetadataBuilder(dsa_v1.AscendDSAMetadataBuilder):
         )
 
     def enable_device_metadata(self) -> None:
-        super().enable_device_metadata()
+        self._device_metadata_enabled = True
         self._global_metadata_builder.enable_device_metadata()
 
     def take_device_metadata_tasks(self) -> tuple[DeviceMetadataTask, ...]:
-        self._global_metadata_builder.take_device_metadata_tasks()
-        return super().take_device_metadata_tasks()
+        global_tasks = self._global_metadata_builder.take_device_metadata_tasks()
+        return (
+            tuple(task for task in global_tasks if task.stage == DeviceMetadataStage.COMPRESSOR)
+            + super().take_device_metadata_tasks()
+        )
 
 
 class AscendDSAPCPImpl(dsa_v1.AscendDSAImpl):

--- a/vllm_ascend/attention/dsa_v1.py
+++ b/vllm_ascend/attention/dsa_v1.py
@@ -49,6 +49,7 @@ from vllm_ascend.utils import (
     olora_tp_enable,
     oproj_tp_enable,
 )
+from vllm_ascend.worker.device_metadata import DeviceMetadataStage, wait_for_device_metadata
 from vllm_ascend.worker.npu_input_batch import NPUInputBatch
 
 if TYPE_CHECKING:
@@ -1668,6 +1669,7 @@ class AscendDSAImpl(AttentionImplBase[Any]):
 
         notify_kv_cache_written(layer_name)
         record_attention_compute_start()
+        wait_for_device_metadata(DeviceMetadataStage.ATTENTION)
         kv_plan = get_dsa_attn_kv_plan(self.vllm_config)
         attn_op = kv_plan.get_dsa_sparse_attn_op()
         attn_kwargs = kv_plan.get_dsa_sparse_attn_base_kwargs()

--- a/vllm_ascend/attention/dsa_v1.py
+++ b/vllm_ascend/attention/dsa_v1.py
@@ -5,7 +5,7 @@ from typing import TYPE_CHECKING, Any, TypeAlias
 import torch
 import torch.distributed as dist
 import torch_npu
-from vllm.config import VllmConfig
+from vllm.config import CUDAGraphMode, VllmConfig
 from vllm.distributed import get_tensor_model_parallel_world_size
 from vllm.triton_utils import HAS_TRITON
 from vllm.v1.attention.backend import (
@@ -69,8 +69,40 @@ else:
 
 # The SAS and QLI metadata operators use a fixed 1024-element int32 layout.
 DSA_METADATA_BUFFER_SIZE = 1024
+CompressorMetadataOutput: TypeAlias = tuple[torch.Tensor, torch.Tensor, torch.Tensor]
 
 _DSV4_DSA_OVERLAP_STREAM = None
+
+
+def build_compressor_metadata_out(
+    metadata: Any,
+    compress_ratio: int,
+    outputs: CompressorMetadataOutput,
+) -> None:
+    assert metadata.full_compress_cos is not None
+    assert metadata.full_compress_sin is not None
+    assert metadata.start_pos is not None
+    assert metadata.num_actual_reqs is not None
+    full_compress_cos = metadata.full_compress_cos.view(
+        metadata.full_compress_cos.shape[0],
+        metadata.full_compress_cos.shape[-1],
+    )
+    full_compress_sin = metadata.full_compress_sin.view(
+        metadata.full_compress_sin.shape[0],
+        metadata.full_compress_sin.shape[-1],
+    )
+    torch.ops._C_ascend.compressor_metadata_out(
+        full_compress_cos,
+        full_compress_sin,
+        metadata.query_start_loc,
+        metadata.start_pos,
+        metadata.block_table,
+        metadata.storage_block_size,
+        DeviceOperator.get_dsa_compressor_slot_mapping_format(),
+        compress_ratio,
+        metadata.num_actual_reqs,
+        *outputs,
+    )
 
 
 def dsv4_dsa_overlap_stream() -> torch.npu.Stream:
@@ -241,6 +273,8 @@ class AscendDSAReqMetadata:
     num_actual_reqs: int | None = None
     sas_metadata: torch.Tensor = None
     qli_metadata: torch.Tensor = None
+    compressor_metadata: CompressorMetadataOutput | None = None
+    compressor_metadata_group_id: int | None = None
     attn_mask: torch.Tensor | None = None
     cu_cmp_seqlen_list: torch.Tensor = None
     ori_win_left: int | None = None
@@ -436,6 +470,7 @@ class AscendDSAMetadataBuilder(AttentionMetadataBuilder[AscendDSAMetadata]):
         # Note(qcs): we use two dimension slot_mapping for kvcache with shape
         # [block_nums, block_size, head_num, head_dim]
         self.slot_mapping = torch.zeros(self.slot_mapping_shape, dtype=torch.int32, device=self.device)
+        self.compressor_metadata_buffers: CompressorMetadataOutput | None = None
 
     def _init_hadamard(self, layer_names: list[str]) -> None:
         hf_config = self.model_config.hf_config
@@ -608,6 +643,7 @@ class AscendDSAMetadataBuilder(AttentionMetadataBuilder[AscendDSAMetadata]):
             num_actual_reqs=num_actual_reqs,
             cos=cos,
             sin=sin,
+            full_graph_mode=kwargs.get("full_graph_mode", False),
         )
 
         return self.metadata_cls(  # type: ignore
@@ -713,6 +749,14 @@ class AscendDSAMetadataBuilder(AttentionMetadataBuilder[AscendDSAMetadata]):
 
     def enable_device_metadata(self) -> None:
         self._device_metadata_enabled = True
+        if self.compressor_ratio > 1 and self.vllm_config.compilation_config.cudagraph_mode != CUDAGraphMode.FULL:
+            max_tokens = self.vllm_config.scheduler_config.max_num_batched_tokens
+            output_shape = (max_tokens, 1, 1, self.model_config.hf_config.qk_rope_head_dim)
+            self.compressor_metadata_buffers = (
+                torch.empty(output_shape, dtype=torch.float32, device=self.device),
+                torch.empty(output_shape, dtype=torch.float32, device=self.device),
+                self.slot_mapping,
+            )
 
     def take_device_metadata_tasks(self) -> tuple[DeviceMetadataTask, ...]:
         tasks = self._device_metadata_tasks
@@ -726,6 +770,7 @@ class AscendDSAMetadataBuilder(AttentionMetadataBuilder[AscendDSAMetadata]):
         num_actual_reqs: int | None,
         cos: torch.Tensor,
         sin: torch.Tensor,
+        full_graph_mode: bool = False,
     ) -> AscendDSAReqMetadata:
         assert self.common_ratio_to_sas_metadata is not None
         metadata_cache = self.common_ratio_to_sas_metadata
@@ -748,7 +793,6 @@ class AscendDSAMetadataBuilder(AttentionMetadataBuilder[AscendDSAMetadata]):
             if num_actual_reqs < num_reqs:
                 self.start_pos_prefill[num_actual_reqs:num_reqs].fill_(0)
                 self.block_table[num_actual_reqs:num_reqs, ...].fill_(0)
-
         layer_name = f"c{self.compressor_ratio}"
         cu_seqlens_ori_kv = None
         cu_seqlens_cmp_kv = None
@@ -841,14 +885,19 @@ class AscendDSAMetadataBuilder(AttentionMetadataBuilder[AscendDSAMetadata]):
 
         full_compress_cos, full_compress_sin = None, None
         if self.compressor_ratio > 1:
-            num_compressed_tokens = self._num_compressor_metadata_rows(num_reqs)
+            if full_graph_mode:
+                num_tokens = common_attn_metadata.num_input_tokens
+                num_compressed_tokens = min(num_tokens, num_tokens // self.compressor_ratio + num_reqs)
+                num_actual_reqs = num_reqs
+            else:
+                num_compressed_tokens = self._num_compressor_metadata_rows(num_reqs)
             full_compress_cos, full_compress_sin = get_full_cos_and_sin_dsa(layer_name)
             slot_mapping = None
         else:
             num_compressed_tokens = self.num_actual_tokens
             slot_mapping = self.slot_mapping[: self.num_actual_tokens]
 
-        return AscendDSAReqMetadata(
+        req_metadata = AscendDSAReqMetadata(
             block_table=self.block_table[:num_reqs, ...],
             seq_lens=seq_lens,
             slot_mapping=slot_mapping,
@@ -869,6 +918,26 @@ class AscendDSAMetadataBuilder(AttentionMetadataBuilder[AscendDSAMetadata]):
             ori_win_right=ori_win_right,
             dspark_swa_indices=dspark_swa_indices,
         )
+        if self._device_metadata_enabled and self.compressor_metadata_buffers is not None:
+            assert num_compressed_tokens is not None
+            buffers = self.compressor_metadata_buffers
+            outputs = (
+                buffers[0][:num_compressed_tokens],
+                buffers[1][:num_compressed_tokens],
+                buffers[2][:num_compressed_tokens],
+            )
+            group_id = id(buffers[0])
+            req_metadata.compressor_metadata = outputs
+            req_metadata.compressor_metadata_group_id = group_id
+            self._device_metadata_tasks = (
+                DeviceMetadataTask(
+                    DeviceMetadataStage.COMPRESSOR,
+                    lambda: build_compressor_metadata_out(req_metadata, self.compressor_ratio, outputs),
+                    group_id,
+                ),
+                *self._device_metadata_tasks,
+            )
+        return req_metadata
 
     def build_for_drafting(
         self,

--- a/vllm_ascend/attention/dsa_v1.py
+++ b/vllm_ascend/attention/dsa_v1.py
@@ -78,6 +78,7 @@ def build_compressor_metadata_out(
     metadata: Any,
     compress_ratio: int,
     outputs: CompressorMetadataOutput,
+    vllm_config: VllmConfig,
 ) -> None:
     assert metadata.full_compress_cos is not None
     assert metadata.full_compress_sin is not None
@@ -98,7 +99,7 @@ def build_compressor_metadata_out(
         metadata.start_pos,
         metadata.block_table,
         metadata.storage_block_size,
-        DeviceOperator.get_dsa_compressor_slot_mapping_format(),
+        get_dsa_attn_kv_plan(vllm_config).get_dsa_compressor_slot_mapping_format(),
         compress_ratio,
         metadata.num_actual_reqs,
         *outputs,
@@ -956,7 +957,9 @@ class AscendDSAMetadataBuilder(AttentionMetadataBuilder[AscendDSAMetadata]):
             self._device_metadata_tasks = (
                 DeviceMetadataTask(
                     DeviceMetadataStage.COMPRESSOR,
-                    lambda: build_compressor_metadata_out(req_metadata, self.compressor_ratio, outputs),
+                    lambda: build_compressor_metadata_out(
+                        req_metadata, self.compressor_ratio, outputs, self.vllm_config
+                    ),
                     group_id,
                 ),
                 *self._device_metadata_tasks,
@@ -1848,8 +1851,8 @@ class AscendDSAImpl(AttentionImplBase[Any]):
             )
 
         notify_kv_cache_written(layer_name)
-        record_attention_compute_start()
         wait_for_device_metadata(DeviceMetadataStage.ATTENTION, id(common_metadata.sas_metadata))
+        record_attention_compute_start()
         kv_plan = get_dsa_attn_kv_plan(self.vllm_config)
         attn_op = kv_plan.get_dsa_sparse_attn_op()
         attn_kwargs = kv_plan.get_dsa_sparse_attn_base_kwargs()

--- a/vllm_ascend/attention/dsa_v1.py
+++ b/vllm_ascend/attention/dsa_v1.py
@@ -49,7 +49,11 @@ from vllm_ascend.utils import (
     olora_tp_enable,
     oproj_tp_enable,
 )
-from vllm_ascend.worker.device_metadata import DeviceMetadataStage, wait_for_device_metadata
+from vllm_ascend.worker.device_metadata import (
+    DeviceMetadataStage,
+    DeviceMetadataTask,
+    wait_for_device_metadata,
+)
 from vllm_ascend.worker.npu_input_batch import NPUInputBatch
 
 if TYPE_CHECKING:
@@ -423,6 +427,8 @@ class AscendDSAMetadataBuilder(AttentionMetadataBuilder[AscendDSAMetadata]):
         self.qli_metadata_buffer: torch.Tensor = torch.zeros(
             DSA_METADATA_BUFFER_SIZE, dtype=torch.int32, device=self.device
         )
+        self._device_metadata_enabled = False
+        self._device_metadata_tasks: tuple[DeviceMetadataTask, ...] = ()
         self.cu_seqlens_ori_kv = torch.tensor([], device=self.device)
         self.cu_seqlens_cmp_kv = torch.tensor([], device=self.device)
         self.seqused_q = torch.tensor([], device=self.device)
@@ -705,6 +711,14 @@ class AscendDSAMetadataBuilder(AttentionMetadataBuilder[AscendDSAMetadata]):
         self.qli_metadata_buffer[:DSA_METADATA_BUFFER_SIZE] = qli_metadata
         return self.qli_metadata_buffer
 
+    def enable_device_metadata(self) -> None:
+        self._device_metadata_enabled = True
+
+    def take_device_metadata_tasks(self) -> tuple[DeviceMetadataTask, ...]:
+        tasks = self._device_metadata_tasks
+        self._device_metadata_tasks = ()
+        return tasks
+
     def build_req_metadata(
         self,
         common_attn_metadata: AscendCommonAttentionMetadata,
@@ -714,6 +728,7 @@ class AscendDSAMetadataBuilder(AttentionMetadataBuilder[AscendDSAMetadata]):
         sin: torch.Tensor,
     ) -> AscendDSAReqMetadata:
         assert self.common_ratio_to_sas_metadata is not None
+        metadata_cache = self.common_ratio_to_sas_metadata
         assert self.num_actual_tokens is not None
         num_reqs = common_attn_metadata.num_reqs
         query_start_loc = common_attn_metadata.query_start_loc[: num_reqs + 1]
@@ -770,23 +785,59 @@ class AscendDSAMetadataBuilder(AttentionMetadataBuilder[AscendDSAMetadata]):
         elif has_prefill:
             cu_seqlens_ori_kv = query_start_loc
 
-        sas_metadata = self._build_sas_metadata(
-            metadata_cache=self.common_ratio_to_sas_metadata,
-            layer_name=layer_name,
-            query_start_loc=query_start_loc,
-            seq_lens=seq_lens,
-            max_seqlen_q=max_seqlen_q,
-            max_seqlen_kv=max_seqlen_kv,
-            cu_seqlens_ori_kv=cu_seqlens_ori_kv,
-            cu_seqlens_cmp_kv=cu_seqlens_cmp_kv,
-        )
-        qli_metadata = self._build_qli_metadata(
-            metadata_cache=self.common_ratio_to_sas_metadata,
-            query_start_loc=query_start_loc,
-            seq_lens=seq_lens,
-            max_seqlen_q=max_seqlen_q,
-            max_seqlen_kv=max_seqlen_kv,
-        )
+        if self._device_metadata_enabled:
+
+            def build_sas_metadata() -> None:
+                self._build_sas_metadata(
+                    metadata_cache=metadata_cache,
+                    layer_name=layer_name,
+                    query_start_loc=query_start_loc,
+                    seq_lens=seq_lens,
+                    max_seqlen_q=max_seqlen_q,
+                    max_seqlen_kv=max_seqlen_kv,
+                    cu_seqlens_ori_kv=cu_seqlens_ori_kv,
+                    cu_seqlens_cmp_kv=cu_seqlens_cmp_kv,
+                )
+
+            def build_qli_metadata() -> None:
+                self._build_qli_metadata(
+                    metadata_cache=metadata_cache,
+                    query_start_loc=query_start_loc,
+                    seq_lens=seq_lens,
+                    max_seqlen_q=max_seqlen_q,
+                    max_seqlen_kv=max_seqlen_kv,
+                )
+
+            if self.compressor_ratio == 4:
+                self._device_metadata_tasks = (
+                    DeviceMetadataTask(DeviceMetadataStage.INDEXER, build_qli_metadata, id(self.qli_metadata_buffer)),
+                    DeviceMetadataTask(DeviceMetadataStage.ATTENTION, build_sas_metadata, id(self.sas_metadata_buffer)),
+                )
+            else:
+                self._device_metadata_tasks = (
+                    DeviceMetadataTask(DeviceMetadataStage.ATTENTION, build_sas_metadata, id(self.sas_metadata_buffer)),
+                )
+            sas_metadata = self.sas_metadata_buffer
+            qli_metadata = self.qli_metadata_buffer if self.compressor_ratio == 4 else None
+        else:
+            self._device_metadata_tasks = ()
+            sas_metadata = self._build_sas_metadata(
+                metadata_cache=metadata_cache,
+                layer_name=layer_name,
+                query_start_loc=query_start_loc,
+                seq_lens=seq_lens,
+                max_seqlen_q=max_seqlen_q,
+                max_seqlen_kv=max_seqlen_kv,
+                cu_seqlens_ori_kv=cu_seqlens_ori_kv,
+                cu_seqlens_cmp_kv=cu_seqlens_cmp_kv,
+            )
+            qli_metadata = self._build_qli_metadata(
+                metadata_cache=metadata_cache,
+                query_start_loc=query_start_loc,
+                seq_lens=seq_lens,
+                max_seqlen_q=max_seqlen_q,
+                max_seqlen_kv=max_seqlen_kv,
+            )
 
         full_compress_cos, full_compress_sin = None, None
         if self.compressor_ratio > 1:
@@ -1669,7 +1720,7 @@ class AscendDSAImpl(AttentionImplBase[Any]):
 
         notify_kv_cache_written(layer_name)
         record_attention_compute_start()
-        wait_for_device_metadata(DeviceMetadataStage.ATTENTION)
+        wait_for_device_metadata(DeviceMetadataStage.ATTENTION, id(common_metadata.sas_metadata))
         kv_plan = get_dsa_attn_kv_plan(self.vllm_config)
         attn_op = kv_plan.get_dsa_sparse_attn_op()
         attn_kwargs = kv_plan.get_dsa_sparse_attn_base_kwargs()

--- a/vllm_ascend/attention/dsa_v1.py
+++ b/vllm_ascend/attention/dsa_v1.py
@@ -344,6 +344,7 @@ def build_dspark_swa_indices(
     seq_lens: torch.Tensor,
     num_decode_tokens: int | None = None,
     index_width: int | None = None,
+    indices_output: torch.Tensor | None = None,
 ) -> tuple[torch.Tensor, torch.Tensor]:
     """Build DSpark non-causal visible slot ids for a paged SWA cache.
 
@@ -382,6 +383,15 @@ def build_dspark_swa_indices(
 
     per_token_slots = torch.repeat_interleave(slot_ids, query_lens, dim=0, output_size=num_decode_tokens).unsqueeze(1)
     per_token_lens = torch.repeat_interleave(visible_lens, query_lens, dim=0, output_size=num_decode_tokens)
+
+    if indices_output is not None:
+        if indices_output.shape != per_token_slots.shape:
+            raise ValueError(
+                "DSpark SWA indices output shape does not match active metadata: "
+                f"output={tuple(indices_output.shape)}, active={tuple(per_token_slots.shape)}"
+            )
+        indices_output.copy_(per_token_slots)
+        per_token_slots = indices_output
 
     return per_token_slots, per_token_lens
 
@@ -471,6 +481,7 @@ class AscendDSAMetadataBuilder(AttentionMetadataBuilder[AscendDSAMetadata]):
         # [block_nums, block_size, head_num, head_dim]
         self.slot_mapping = torch.zeros(self.slot_mapping_shape, dtype=torch.int32, device=self.device)
         self.compressor_metadata_buffers: CompressorMetadataOutput | None = None
+        self.dspark_swa_indices_buffer: torch.Tensor | None = None
 
     def _init_hadamard(self, layer_names: list[str]) -> None:
         hf_config = self.model_config.hf_config
@@ -758,6 +769,19 @@ class AscendDSAMetadataBuilder(AttentionMetadataBuilder[AscendDSAMetadata]):
                 self.slot_mapping,
             )
 
+    def enable_dspark_device_metadata(self, max_num_tokens: int) -> None:
+        self.enable_device_metadata()
+        assert self.speculative_config is not None
+        index_width = _aligned_dspark_index_width(
+            self.model_config.hf_config.sliding_window,
+            self.speculative_config.num_speculative_tokens,
+        )
+        self.dspark_swa_indices_buffer = torch.empty(
+            (max_num_tokens, 1, index_width),
+            dtype=torch.int32,
+            device=self.device,
+        )
+
     def take_device_metadata_tasks(self) -> tuple[DeviceMetadataTask, ...]:
         tasks = self._device_metadata_tasks
         self._device_metadata_tasks = ()
@@ -1010,11 +1034,12 @@ class AscendDSAMetadataBuilder(AttentionMetadataBuilder[AscendDSAMetadata]):
         has_prefill = self.num_prefills > 0
 
         dspark_swa_indices = None
+        build_dspark_swa = None
         ori_win_left = self.model_config.hf_config.sliding_window - 1
         ori_win_right = 0
         if not common_attn_metadata.causal:
             assert self.speculative_config is not None
-            dspark_swa_indices, _ = build_dspark_swa_indices(
+            dspark_swa_args = (
                 self.block_table[:num_reqs],
                 self.speculative_config.num_speculative_tokens,
                 self.model_config.hf_config.sliding_window,
@@ -1023,7 +1048,24 @@ class AscendDSAMetadataBuilder(AttentionMetadataBuilder[AscendDSAMetadata]):
                 seq_lens,
                 self.num_actual_tokens,
             )
-            dspark_swa_indices = dspark_swa_indices[: self.num_actual_tokens]
+            if self._device_metadata_enabled and not has_prefill:
+                if self.dspark_swa_indices_buffer is None:
+                    raise RuntimeError(
+                        "DSpark device metadata buffers must be initialized before building draft attention metadata"
+                    )
+                if self.num_actual_tokens > self.dspark_swa_indices_buffer.shape[0]:
+                    raise ValueError(
+                        "DSpark SWA metadata rows exceed the persistent buffer capacity: "
+                        f"active={self.num_actual_tokens}, capacity={self.dspark_swa_indices_buffer.shape[0]}"
+                    )
+                dspark_swa_indices = self.dspark_swa_indices_buffer[: self.num_actual_tokens]
+                build_dspark_swa = lambda: build_dspark_swa_indices(
+                    *dspark_swa_args,
+                    indices_output=dspark_swa_indices,
+                )
+            else:
+                dspark_swa_indices, _ = build_dspark_swa_indices(*dspark_swa_args)
+                dspark_swa_indices = dspark_swa_indices[: self.num_actual_tokens]
             ori_win_left, ori_win_right = get_dspark_sparse_sas_window(self.vllm_config)
 
         cu_seqlens_ori_kv = (
@@ -1046,35 +1088,53 @@ class AscendDSAMetadataBuilder(AttentionMetadataBuilder[AscendDSAMetadata]):
         metadata_kwargs = kv_plan.get_dsa_sparse_attn_metadata_kwargs(self.seqused_q.device)
         tp_size = self.vllm_config.parallel_config.tensor_parallel_size
         n_local_heads = self.model_config.hf_config.num_attention_heads // tp_size
-        sas_metadata = metadata_op(
-            **metadata_kwargs,
-            num_heads_q=n_local_heads,
-            num_heads_kv=1,
-            head_dim=self.model_config.get_head_size(),
-            cu_seqlens_q=query_start_loc,
-            cu_seqlens_ori_kv=cu_seqlens_ori_kv,
-            cu_seqlens_cmp_kv=cu_seqlens_cmp_kv,
-            seqused_q=self.seqused_q,
-            seqused_kv=seq_lens,
-            max_seqlen_q=max_seqlen_q,
-            max_seqlen_kv=max_seqlen_kv,
-            batch_size=num_reqs,
-            cmp_ratio=1,
-            ori_mask_mode=4,
-            cmp_mask_mode=3,
-            ori_win_left=ori_win_left,
-            ori_win_right=ori_win_right,
-            layout_q="TND",
-            layout_kv=_dsa_layout_kv(self.vllm_config),
-            has_ori_kv=True,
-            has_cmp_kv=False,
-        )
-        if not has_prefill:
-            assert self.spec_sas_metadata is not None
-            self.spec_sas_metadata[draft_index - 1][:DSA_METADATA_BUFFER_SIZE].copy_(
-                sas_metadata[:DSA_METADATA_BUFFER_SIZE]
+
+        def build_attention_metadata() -> torch.Tensor:
+            if build_dspark_swa is not None:
+                build_dspark_swa()
+            result = metadata_op(
+                **metadata_kwargs,
+                num_heads_q=n_local_heads,
+                num_heads_kv=1,
+                head_dim=self.model_config.get_head_size(),
+                cu_seqlens_q=query_start_loc,
+                cu_seqlens_ori_kv=cu_seqlens_ori_kv,
+                cu_seqlens_cmp_kv=cu_seqlens_cmp_kv,
+                seqused_q=self.seqused_q,
+                seqused_kv=seq_lens,
+                max_seqlen_q=max_seqlen_q,
+                max_seqlen_kv=max_seqlen_kv,
+                batch_size=num_reqs,
+                cmp_ratio=1,
+                ori_mask_mode=4,
+                cmp_mask_mode=3,
+                ori_win_left=ori_win_left,
+                ori_win_right=ori_win_right,
+                layout_q="TND",
+                layout_kv=_dsa_layout_kv(self.vllm_config),
+                has_ori_kv=True,
+                has_cmp_kv=False,
             )
+            if not has_prefill:
+                assert self.spec_sas_metadata is not None
+                self.spec_sas_metadata[draft_index - 1][:DSA_METADATA_BUFFER_SIZE].copy_(
+                    result[:DSA_METADATA_BUFFER_SIZE]
+                )
+                return self.spec_sas_metadata[draft_index - 1]
+            return result
+
+        if build_dspark_swa is not None:
             sas_metadata = self.spec_sas_metadata[draft_index - 1]
+
+            def run_attention_metadata() -> None:
+                build_attention_metadata()
+
+            self._device_metadata_tasks = (
+                DeviceMetadataTask(DeviceMetadataStage.ATTENTION, run_attention_metadata, id(sas_metadata)),
+            )
+        else:
+            self._device_metadata_tasks = ()
+            sas_metadata = build_attention_metadata()
 
         assert self.spec_slot_mapping is not None
         slot_mapping = self.spec_slot_mapping[draft_index - 1][: self.num_actual_tokens]

--- a/vllm_ascend/models/deepseek_v4/compressor.py
+++ b/vllm_ascend/models/deepseek_v4/compressor.py
@@ -39,6 +39,7 @@ from vllm.v1.kv_cache_interface import KVCacheSpec
 
 from vllm_ascend.core.kv_cache_interface import AscendSlidingWindowMLASpec
 from vllm_ascend.device.hardware_profile import HardwareCapability, get_current_hardware_profile
+from vllm_ascend.worker.device_metadata import DeviceMetadataStage, wait_for_device_metadata
 
 
 class AscendCompressorStateCache(CompressorStateCache):
@@ -214,6 +215,7 @@ class Compressor(nn.Module):
         state_metadata = metadata.state.req_metadata
         assert compressor_metadata is not None
         assert state_metadata is not None
+        wait_for_device_metadata(DeviceMetadataStage.COMPRESSOR)
         compress_cos, compress_sin, slot_mapping = self._compute_metadata(compressor_metadata)
         compressed_kv = torch.ops._C_ascend.compressor(
             hidden_states,

--- a/vllm_ascend/models/deepseek_v4/compressor.py
+++ b/vllm_ascend/models/deepseek_v4/compressor.py
@@ -39,6 +39,7 @@ from vllm.v1.kv_cache_interface import KVCacheSpec
 
 from vllm_ascend.core.kv_cache_interface import AscendSlidingWindowMLASpec
 from vllm_ascend.device.hardware_profile import HardwareCapability, get_current_hardware_profile
+from vllm_ascend.worker.device_metadata import DeviceMetadataStage, wait_for_device_metadata
 
 
 class AscendCompressorStateCache(CompressorStateCache):
@@ -177,6 +178,13 @@ class Compressor(nn.Module):
         metadata: typing.Any,
     ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
         from vllm_ascend.attention.dsa_attn_kv_plan import get_dsa_attn_kv_plan
+
+        precomputed = getattr(metadata, "compressor_metadata", None)
+        if precomputed is not None:
+            group_id = metadata.compressor_metadata_group_id
+            assert group_id is not None
+            wait_for_device_metadata(DeviceMetadataStage.COMPRESSOR, group_id)
+            return precomputed
 
         assert metadata.full_compress_cos is not None
         assert metadata.full_compress_sin is not None

--- a/vllm_ascend/models/deepseek_v4/compressor.py
+++ b/vllm_ascend/models/deepseek_v4/compressor.py
@@ -39,7 +39,6 @@ from vllm.v1.kv_cache_interface import KVCacheSpec
 
 from vllm_ascend.core.kv_cache_interface import AscendSlidingWindowMLASpec
 from vllm_ascend.device.hardware_profile import HardwareCapability, get_current_hardware_profile
-from vllm_ascend.worker.device_metadata import DeviceMetadataStage, wait_for_device_metadata
 
 
 class AscendCompressorStateCache(CompressorStateCache):
@@ -215,7 +214,6 @@ class Compressor(nn.Module):
         state_metadata = metadata.state.req_metadata
         assert compressor_metadata is not None
         assert state_metadata is not None
-        wait_for_device_metadata(DeviceMetadataStage.COMPRESSOR)
         compress_cos, compress_sin, slot_mapping = self._compute_metadata(compressor_metadata)
         compressed_kv = torch.ops._C_ascend.compressor(
             hidden_states,

--- a/vllm_ascend/models/deepseek_v4/indexer.py
+++ b/vllm_ascend/models/deepseek_v4/indexer.py
@@ -46,6 +46,7 @@ from vllm_ascend.ops.cv_linear import CVLinearWrapper
 from vllm_ascend.ops.linear import AscendUnquantizedLinearMethod
 from vllm_ascend.quantization.methods import AscendW8A8DynamicLinearMethod
 from vllm_ascend.utils import npu_stream_switch
+from vllm_ascend.worker.device_metadata import DeviceMetadataStage, wait_for_device_metadata
 
 
 def hadamard_linear(x: torch.Tensor, hadamard: torch.Tensor) -> tuple[torch.Tensor, tuple[int, ...], int]:
@@ -190,6 +191,7 @@ class AscendIndexerOps:
         scale_cache: torch.Tensor,
         metadata: typing.Any,
     ) -> torch.Tensor:
+        wait_for_device_metadata(DeviceMetadataStage.INDEXER)
         topk_idxs, _ = torch.ops._C_ascend.npu_vllm_quant_lightning_indexer(
             query=query,
             key=key_cache,

--- a/vllm_ascend/models/deepseek_v4/indexer.py
+++ b/vllm_ascend/models/deepseek_v4/indexer.py
@@ -191,7 +191,7 @@ class AscendIndexerOps:
         scale_cache: torch.Tensor,
         metadata: typing.Any,
     ) -> torch.Tensor:
-        wait_for_device_metadata(DeviceMetadataStage.INDEXER)
+        wait_for_device_metadata(DeviceMetadataStage.INDEXER, id(metadata.qli_metadata))
         topk_idxs, _ = torch.ops._C_ascend.npu_vllm_quant_lightning_indexer(
             query=query,
             key=key_cache,

--- a/vllm_ascend/spec_decode/dspark_proposer.py
+++ b/vllm_ascend/spec_decode/dspark_proposer.py
@@ -13,6 +13,8 @@ from vllm.v1.worker.utils import AttentionGroup
 from vllm_ascend.ascend_config import get_ascend_config
 from vllm_ascend.ascend_forward_context import set_ascend_forward_context
 from vllm_ascend.attention.attention_v1 import AscendAttentionState
+from vllm_ascend.attention.dsa_v1 import AscendDSAMetadataBuilder
+from vllm_ascend.attention.utils import enable_pcp
 from vllm_ascend.ops.triton.spec_decode.utils import copy_and_expand_dflash_and_dspark_inputs_kernel
 from vllm_ascend.spec_decode.dflash_proposer import AscendDflashProposer, _compute_num_programs
 from vllm_ascend.spec_decode.utils import DynamicSpecScheduler
@@ -175,6 +177,16 @@ class AscendDSparkProposer(AscendDflashProposer):
                     attention_groups[key].layer_names.append(layer_name)
 
             self.draft_attn_groups.extend(attention_groups.values())
+
+        if (
+            getattr(self.runner, "device_metadata_executor", None) is not None
+            and self.dcp_size == 1
+            and not enable_pcp()
+        ):
+            for attn_group in self.draft_attn_groups:
+                builder = attn_group.get_metadata_builder()
+                if isinstance(builder, AscendDSAMetadataBuilder):
+                    builder.enable_dspark_device_metadata(self.max_query_tokens)
 
         self.kv_cache_gid = self.draft_attn_groups[0].kv_cache_group_id
         self.kernel_block_size = self._per_group_kernel_block_sizes[self.kv_cache_gid]

--- a/vllm_ascend/spec_decode/llm_base_proposer.py
+++ b/vllm_ascend/spec_decode/llm_base_proposer.py
@@ -44,7 +44,7 @@ from vllm.v1.worker.gpu_input_batch import CachedRequestState, InputBatch
 from vllm_ascend.ascend_config import get_ascend_config
 from vllm_ascend.ascend_forward_context import _EXTRA_CTX, set_ascend_forward_context
 from vllm_ascend.attention.attention_v1 import AscendAttentionState
-from vllm_ascend.attention.utils import AscendCommonAttentionMetadata, enable_pcp
+from vllm_ascend.attention.utils import AscendCommonAttentionMetadata
 from vllm_ascend.compilation.acl_graph import ACLGraphWrapper, update_full_graph_params
 from vllm_ascend.compilation.breakable_aclgraph import BreakableACLGraphWrapper
 from vllm_ascend.device.device_op import DeviceOperator
@@ -2379,7 +2379,11 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
         device_metadata_tasks: list[DeviceMetadataTask] = []
         device_metadata_executor = (
             getattr(self.runner, "device_metadata_executor", None)
-            if self.method == "dspark" and self.dcp_size == 1 and not enable_pcp()
+            if (
+                self.method == "dspark"
+                and self.dcp_size == 1
+                and self.vllm_config.parallel_config.prefill_context_parallel_size == 1
+            )
             else None
         )
         for attn_group in self.draft_attn_groups:

--- a/vllm_ascend/spec_decode/llm_base_proposer.py
+++ b/vllm_ascend/spec_decode/llm_base_proposer.py
@@ -44,7 +44,7 @@ from vllm.v1.worker.gpu_input_batch import CachedRequestState, InputBatch
 from vllm_ascend.ascend_config import get_ascend_config
 from vllm_ascend.ascend_forward_context import _EXTRA_CTX, set_ascend_forward_context
 from vllm_ascend.attention.attention_v1 import AscendAttentionState
-from vllm_ascend.attention.utils import AscendCommonAttentionMetadata
+from vllm_ascend.attention.utils import AscendCommonAttentionMetadata, enable_pcp
 from vllm_ascend.compilation.acl_graph import ACLGraphWrapper, update_full_graph_params
 from vllm_ascend.compilation.breakable_aclgraph import BreakableACLGraphWrapper
 from vllm_ascend.device.device_op import DeviceOperator
@@ -63,6 +63,7 @@ from vllm_ascend.spec_decode.utils import (
     patch_tensor_parallel_group,
 )
 from vllm_ascend.utils import check_gdn_layer, enable_sp, lmhead_tp_enable, vllm_version_is
+from vllm_ascend.worker.device_metadata import DeviceMetadataTask, DeviceMetadataTaskProvider
 
 # Currently we will fix block size to a small one since `num_reqs` can't be too large
 _PREPARE_INPUTS_BLOCK_SIZE = 4
@@ -1081,6 +1082,11 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
         self.token_indices_to_sample[:token_indices_to_sample_len].copy_(token_indices_to_sample)
         self.token_indices_to_sample[token_indices_to_sample_len:].fill_(0)
 
+        active_device_metadata_executor = (
+            getattr(self.runner, "device_metadata_executor", None) if self.method == "dspark" else None
+        )
+        if active_device_metadata_executor is not None and not active_device_metadata_executor.submission_in_flight:
+            active_device_metadata_executor = None
         with set_ascend_forward_context(
             multi_steps_attn_metadata[0],
             self.vllm_config,
@@ -1091,6 +1097,7 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
             aclgraph_runtime_mode=aclgraph_runtime_mode,
             is_draft_model=True,
             draft_attn_metadatas=multi_steps_attn_metadata,
+            device_metadata_executor=active_device_metadata_executor,
             eplb_heat_collection_status=(
                 self.runner.eplb_heat_collection_status if self.runner.dynamic_eplb else False
             ),
@@ -1120,6 +1127,8 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
             else:
                 draft_token_ids = run_draft()
                 self._update_full_graph_params_if_needed(forward_context, num_input_tokens, multi_steps_attn_metadata)
+        if active_device_metadata_executor is not None:
+            active_device_metadata_executor.release()
         return draft_token_ids
 
     def _sample_draft_from_logits(
@@ -2356,13 +2365,31 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
         # FIXME(woosuk): The below two ops cause synchronization. Optimize.
         assert len(self.draft_attn_groups) > 0
         per_layer_attn_metadata: dict[str, Any] = {}
+        # One DSA cache dict shared by all attn groups within this decode step.
+        # DSpark draft layers span multiple kv-cache groups; every group gets
+        # its own build_for_drafting call but most of the drafted metadata
+        # (RoPE tables, local token metadata, SAS metadata) only depends
+        # on group-invariant fields of common_attn_metadata, so it is computed
+        # by the first group and reused by the remaining ones. Only the DSA
+        # metadata builder (used by dspark) understands this kwarg; the generic
+        # GQA builder used by dflash/eagle does not accept **kwargs, so leave
+        # the cache empty in the non-compression path to avoid passing an
+        # unexpected argument.
+        shared_dsa_draft_cache: dict = dict(common_ratio_to_sas_metadata=dict()) if self.use_compress else {}
+        device_metadata_tasks: list[DeviceMetadataTask] = []
+        device_metadata_executor = (
+            getattr(self.runner, "device_metadata_executor", None)
+            if self.method == "dspark" and self.dcp_size == 1 and not enable_pcp()
+            else None
+        )
         for attn_group in self.draft_attn_groups:
             builder = attn_group.get_metadata_builder()
-            extra_attn_metadata_args: dict = {}
-            if self.use_compress:
-                extra_attn_metadata_args = dict(
-                    common_ratio_to_sas_metadata=dict(),
-                )
+            device_metadata_provider = (
+                builder
+                if device_metadata_executor is not None and isinstance(builder, DeviceMetadataTaskProvider)
+                else None
+            )
+            extra_attn_metadata_args: dict = dict(shared_dsa_draft_cache)
             if self.method == "dspark":
                 gid = attn_group.kv_cache_group_id
                 common_attn_metadata = copy.copy(common_attn_metadata)
@@ -2384,6 +2411,8 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
                 attn_metadata = builder.build_for_drafting(
                     common_attn_metadata, draft_index=1, **extra_attn_metadata_args
                 )
+                if device_metadata_provider is not None:
+                    device_metadata_tasks.extend(device_metadata_provider.take_device_metadata_tasks())
             else:
                 attn_metadata = builder.build(
                     0, common_attn_metadata, self.runner.get_model(), **extra_attn_metadata_args
@@ -2393,6 +2422,8 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
 
             for layer_name in attn_group.layer_names:
                 per_layer_attn_metadata[layer_name] = attn_metadata
+        if device_metadata_tasks:
+            device_metadata_executor.submit(device_metadata_tasks)
         multi_steps_attn_metadata = [per_layer_attn_metadata]
         # Copy the old attn_metadata and update
         attn_metadata_i = per_layer_attn_metadata[self.draft_attn_groups[0].layer_names[0]]

--- a/vllm_ascend/spec_decode/llm_base_proposer.py
+++ b/vllm_ascend/spec_decode/llm_base_proposer.py
@@ -2422,7 +2422,7 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
 
             for layer_name in attn_group.layer_names:
                 per_layer_attn_metadata[layer_name] = attn_metadata
-        if device_metadata_tasks:
+        if device_metadata_executor is not None and device_metadata_tasks:
             device_metadata_executor.submit(device_metadata_tasks)
         multi_steps_attn_metadata = [per_layer_attn_metadata]
         # Copy the old attn_metadata and update

--- a/vllm_ascend/worker/device_metadata.py
+++ b/vllm_ascend/worker/device_metadata.py
@@ -13,9 +13,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from collections.abc import Callable
+from collections.abc import Callable, Iterable
 from dataclasses import dataclass
 from enum import IntEnum
+from typing import Protocol, runtime_checkable
 
 import torch
 
@@ -33,19 +34,19 @@ class DeviceMetadataTask:
 
 
 @dataclass(frozen=True, slots=True)
-class DeviceMetadataPlan:
-    tasks: tuple[DeviceMetadataTask, ...]
+class DeviceMetadataTaskContext:
+    common_attn_metadata: object
+    layer_attn_metadata: object
+    for_cudagraph_capture: bool
 
-    def __post_init__(self) -> None:
-        if not self.tasks:
-            raise ValueError("A device metadata plan must contain at least one task")
-        stages = tuple(task.stage for task in self.tasks)
-        if stages != tuple(sorted(stages)):
-            raise ValueError("Device metadata tasks must be ordered by stage")
+
+@runtime_checkable
+class DeviceMetadataTaskProvider(Protocol):
+    def build_device_metadata_tasks(self, context: DeviceMetadataTaskContext) -> tuple[DeviceMetadataTask, ...]: ...
 
 
 class DeviceMetadataExecutor:
-    """Submit one metadata plan at a time on a worker-owned NPU stream."""
+    """Submit device metadata tasks on a worker-owned NPU stream."""
 
     def __init__(self) -> None:
         self.stream = torch.npu.Stream()
@@ -53,11 +54,14 @@ class DeviceMetadataExecutor:
         self._stage_ready = {stage: torch.npu.Event() for stage in DeviceMetadataStage}
         self._buffer_reusable = torch.npu.Event()
         self._has_reuse_fence = False
-        self._plan_in_flight = False
+        self._submission_in_flight = False
 
-    def submit(self, plan: DeviceMetadataPlan) -> None:
-        if self._plan_in_flight:
-            raise RuntimeError("The previous device metadata plan has not been released")
+    def submit(self, tasks: Iterable[DeviceMetadataTask]) -> None:
+        if self._submission_in_flight:
+            raise RuntimeError("The previous device metadata submission has not been released")
+        ordered_tasks = tuple(sorted(tasks, key=lambda task: task.stage))
+        if not ordered_tasks:
+            raise ValueError("At least one device metadata task is required")
 
         self._inputs_ready.record(torch.npu.current_stream())
         with torch.npu.stream(self.stream):
@@ -67,21 +71,21 @@ class DeviceMetadataExecutor:
 
             task_index = 0
             for stage in DeviceMetadataStage:
-                while task_index < len(plan.tasks) and plan.tasks[task_index].stage == stage:
-                    plan.tasks[task_index].run()
+                while task_index < len(ordered_tasks) and ordered_tasks[task_index].stage == stage:
+                    ordered_tasks[task_index].run()
                     task_index += 1
                 self._stage_ready[stage].record(self.stream)
 
-        self._plan_in_flight = True
+        self._submission_in_flight = True
 
     def wait(self, stage: DeviceMetadataStage) -> None:
-        if not self._plan_in_flight:
-            raise RuntimeError("No device metadata plan is in flight")
+        if not self._submission_in_flight:
+            raise RuntimeError("No device metadata submission is in flight")
         torch.npu.current_stream().wait_event(self._stage_ready[stage])
 
     def release(self) -> None:
-        if not self._plan_in_flight:
-            raise RuntimeError("No device metadata plan is in flight")
+        if not self._submission_in_flight:
+            raise RuntimeError("No device metadata submission is in flight")
         self._buffer_reusable.record(torch.npu.current_stream())
         self._has_reuse_fence = True
-        self._plan_in_flight = False
+        self._submission_in_flight = False

--- a/vllm_ascend/worker/device_metadata.py
+++ b/vllm_ascend/worker/device_metadata.py
@@ -1,0 +1,87 @@
+#
+# Copyright (c) 2026 Huawei Technologies Co., Ltd. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from collections.abc import Callable
+from dataclasses import dataclass
+from enum import IntEnum
+
+import torch
+
+
+class DeviceMetadataStage(IntEnum):
+    COMPRESSOR = 0
+    INDEXER = 1
+    ATTENTION = 2
+
+
+@dataclass(frozen=True, slots=True)
+class DeviceMetadataTask:
+    stage: DeviceMetadataStage
+    run: Callable[[], None]
+
+
+@dataclass(frozen=True, slots=True)
+class DeviceMetadataPlan:
+    tasks: tuple[DeviceMetadataTask, ...]
+
+    def __post_init__(self) -> None:
+        if not self.tasks:
+            raise ValueError("A device metadata plan must contain at least one task")
+        stages = tuple(task.stage for task in self.tasks)
+        if stages != tuple(sorted(stages)):
+            raise ValueError("Device metadata tasks must be ordered by stage")
+
+
+class DeviceMetadataExecutor:
+    """Submit one metadata plan at a time on a worker-owned NPU stream."""
+
+    def __init__(self) -> None:
+        self.stream = torch.npu.Stream()
+        self._inputs_ready = torch.npu.Event()
+        self._stage_ready = {stage: torch.npu.Event() for stage in DeviceMetadataStage}
+        self._buffer_reusable = torch.npu.Event()
+        self._has_reuse_fence = False
+        self._plan_in_flight = False
+
+    def submit(self, plan: DeviceMetadataPlan) -> None:
+        if self._plan_in_flight:
+            raise RuntimeError("The previous device metadata plan has not been released")
+
+        self._inputs_ready.record(torch.npu.current_stream())
+        with torch.npu.stream(self.stream):
+            self.stream.wait_event(self._inputs_ready)
+            if self._has_reuse_fence:
+                self.stream.wait_event(self._buffer_reusable)
+
+            task_index = 0
+            for stage in DeviceMetadataStage:
+                while task_index < len(plan.tasks) and plan.tasks[task_index].stage == stage:
+                    plan.tasks[task_index].run()
+                    task_index += 1
+                self._stage_ready[stage].record(self.stream)
+
+        self._plan_in_flight = True
+
+    def wait(self, stage: DeviceMetadataStage) -> None:
+        if not self._plan_in_flight:
+            raise RuntimeError("No device metadata plan is in flight")
+        torch.npu.current_stream().wait_event(self._stage_ready[stage])
+
+    def release(self) -> None:
+        if not self._plan_in_flight:
+            raise RuntimeError("No device metadata plan is in flight")
+        self._buffer_reusable.record(torch.npu.current_stream())
+        self._has_reuse_fence = True
+        self._plan_in_flight = False

--- a/vllm_ascend/worker/device_metadata.py
+++ b/vllm_ascend/worker/device_metadata.py
@@ -69,6 +69,7 @@ class DeviceMetadataExecutor:
             if frontier not in self._stage_ready:
                 self._stage_ready[frontier] = torch.npu.Event()
 
+        self._submission_in_flight = True
         self._waited_stages.clear()
         self._inputs_ready.record(torch.npu.current_stream())
         with torch.npu.stream(self.stream):
@@ -83,8 +84,6 @@ class DeviceMetadataExecutor:
                     task.run()
                     self._stage_ready[(stage, task.group_id)].record(self.stream)
                     task_index += 1
-
-        self._submission_in_flight = True
 
     def wait(self, stage: DeviceMetadataStage, group_id: int) -> None:
         if not self._submission_in_flight:

--- a/vllm_ascend/worker/device_metadata.py
+++ b/vllm_ascend/worker/device_metadata.py
@@ -32,18 +32,14 @@ class DeviceMetadataStage(IntEnum):
 class DeviceMetadataTask:
     stage: DeviceMetadataStage
     run: Callable[[], None]
-
-
-@dataclass(frozen=True, slots=True)
-class DeviceMetadataTaskContext:
-    common_attn_metadata: object
-    layer_attn_metadata: object
-    for_cudagraph_capture: bool
+    group_id: int
 
 
 @runtime_checkable
 class DeviceMetadataTaskProvider(Protocol):
-    def build_device_metadata_tasks(self, context: DeviceMetadataTaskContext) -> tuple[DeviceMetadataTask, ...]: ...
+    def enable_device_metadata(self) -> None: ...
+
+    def take_device_metadata_tasks(self) -> tuple[DeviceMetadataTask, ...]: ...
 
 
 class DeviceMetadataExecutor:
@@ -52,11 +48,11 @@ class DeviceMetadataExecutor:
     def __init__(self) -> None:
         self.stream = torch.npu.Stream()
         self._inputs_ready = torch.npu.Event()
-        self._stage_ready = {stage: torch.npu.Event() for stage in DeviceMetadataStage}
+        self._stage_ready: dict[tuple[DeviceMetadataStage, int], torch.npu.Event] = {}
         self._buffer_reusable = torch.npu.Event()
         self._has_reuse_fence = False
         self._submission_in_flight = False
-        self._waited_stages: set[DeviceMetadataStage] = set()
+        self._waited_stages: set[tuple[DeviceMetadataStage, int]] = set()
 
     @property
     def submission_in_flight(self) -> bool:
@@ -68,6 +64,10 @@ class DeviceMetadataExecutor:
         ordered_tasks = tuple(sorted(tasks, key=lambda task: task.stage))
         if not ordered_tasks:
             raise ValueError("At least one device metadata task is required")
+        for task in ordered_tasks:
+            frontier = (task.stage, task.group_id)
+            if frontier not in self._stage_ready:
+                self._stage_ready[frontier] = torch.npu.Event()
 
         self._waited_stages.clear()
         self._inputs_ready.record(torch.npu.current_stream())
@@ -79,18 +79,20 @@ class DeviceMetadataExecutor:
             task_index = 0
             for stage in DeviceMetadataStage:
                 while task_index < len(ordered_tasks) and ordered_tasks[task_index].stage == stage:
-                    ordered_tasks[task_index].run()
+                    task = ordered_tasks[task_index]
+                    task.run()
+                    self._stage_ready[(stage, task.group_id)].record(self.stream)
                     task_index += 1
-                self._stage_ready[stage].record(self.stream)
 
         self._submission_in_flight = True
 
-    def wait(self, stage: DeviceMetadataStage) -> None:
+    def wait(self, stage: DeviceMetadataStage, group_id: int) -> None:
         if not self._submission_in_flight:
             raise RuntimeError("No device metadata submission is in flight")
-        if stage not in self._waited_stages:
-            torch.npu.current_stream().wait_event(self._stage_ready[stage])
-            self._waited_stages.add(stage)
+        frontier = (stage, group_id)
+        if frontier not in self._waited_stages:
+            torch.npu.current_stream().wait_event(self._stage_ready[frontier])
+            self._waited_stages.add(frontier)
 
     def release(self) -> None:
         if not self._submission_in_flight:
@@ -100,9 +102,9 @@ class DeviceMetadataExecutor:
         self._submission_in_flight = False
 
 
-def wait_for_device_metadata(stage: DeviceMetadataStage) -> None:
+def wait_for_device_metadata(stage: DeviceMetadataStage, group_id: int) -> None:
     if not is_forward_context_available():
         return
     executor = getattr(get_forward_context(), "device_metadata_executor", None)
     if executor is not None:
-        executor.wait(stage)
+        executor.wait(stage, group_id)

--- a/vllm_ascend/worker/device_metadata.py
+++ b/vllm_ascend/worker/device_metadata.py
@@ -52,6 +52,7 @@ class DeviceMetadataExecutor:
         self._buffer_reusable = torch.npu.Event()
         self._has_reuse_fence = False
         self._submission_in_flight = False
+        self._submitted_frontiers: tuple[tuple[DeviceMetadataStage, int], ...] = ()
         self._waited_stages: set[tuple[DeviceMetadataStage, int]] = set()
 
     @property
@@ -70,6 +71,7 @@ class DeviceMetadataExecutor:
                 self._stage_ready[frontier] = torch.npu.Event()
 
         self._submission_in_flight = True
+        self._submitted_frontiers = tuple(dict.fromkeys((task.stage, task.group_id) for task in ordered_tasks))
         self._waited_stages.clear()
         self._inputs_ready.record(torch.npu.current_stream())
         with torch.npu.stream(self.stream):
@@ -92,6 +94,12 @@ class DeviceMetadataExecutor:
         if frontier not in self._waited_stages:
             torch.npu.current_stream().wait_event(self._stage_ready[frontier])
             self._waited_stages.add(frontier)
+
+    def wait_all(self) -> None:
+        if not self._submission_in_flight:
+            raise RuntimeError("No device metadata submission is in flight")
+        for stage, group_id in self._submitted_frontiers:
+            self.wait(stage, group_id)
 
     def release(self) -> None:
         if not self._submission_in_flight:

--- a/vllm_ascend/worker/device_metadata.py
+++ b/vllm_ascend/worker/device_metadata.py
@@ -19,7 +19,7 @@ from enum import IntEnum
 from typing import Protocol, runtime_checkable
 
 import torch
-from vllm.forward_context import get_forward_context, is_forward_context_available
+from vllm.forward_context import BatchDescriptor, get_forward_context, is_forward_context_available
 
 
 class DeviceMetadataStage(IntEnum):
@@ -49,29 +49,48 @@ class DeviceMetadataExecutor:
         self.stream = torch.npu.Stream()
         self._inputs_ready = torch.npu.Event()
         self._stage_ready: dict[tuple[DeviceMetadataStage, int], torch.npu.Event] = {}
+        self._external_stage_ready: dict[tuple[BatchDescriptor, DeviceMetadataStage, int], torch.npu.ExternalEvent] = {}
+        self._external_frontiers: dict[BatchDescriptor, tuple[tuple[DeviceMetadataStage, int], ...]] = {}
         self._buffer_reusable = torch.npu.Event()
         self._has_reuse_fence = False
         self._submission_in_flight = False
-        self._submitted_frontiers: tuple[tuple[DeviceMetadataStage, int], ...] = ()
         self._waited_stages: set[tuple[DeviceMetadataStage, int]] = set()
+        self._batch_descriptor: BatchDescriptor | None = None
 
     @property
     def submission_in_flight(self) -> bool:
         return self._submission_in_flight
 
-    def submit(self, tasks: Iterable[DeviceMetadataTask]) -> None:
+    @property
+    def uses_external_events(self) -> bool:
+        return self._batch_descriptor is not None
+
+    def submit(
+        self,
+        tasks: Iterable[DeviceMetadataTask],
+        batch_descriptor: BatchDescriptor | None = None,
+    ) -> None:
         if self._submission_in_flight:
             raise RuntimeError("The previous device metadata submission has not been released")
         ordered_tasks = tuple(sorted(tasks, key=lambda task: task.stage))
         if not ordered_tasks:
             raise ValueError("At least one device metadata task is required")
+        submitted_frontiers = tuple(dict.fromkeys((task.stage, task.group_id) for task in ordered_tasks))
+        expected_frontiers = self._external_frontiers.get(batch_descriptor) if batch_descriptor is not None else None
+        if expected_frontiers is not None and expected_frontiers != submitted_frontiers:
+            raise RuntimeError("Device metadata frontiers changed for an existing full-graph batch descriptor")
         for task in ordered_tasks:
             frontier = (task.stage, task.group_id)
-            if frontier not in self._stage_ready:
+            external_frontier = (batch_descriptor, *frontier) if batch_descriptor is not None else None
+            if external_frontier is not None and external_frontier not in self._external_stage_ready:
+                self._external_stage_ready[external_frontier] = torch.npu.ExternalEvent()
+            elif external_frontier is None and frontier not in self._stage_ready:
                 self._stage_ready[frontier] = torch.npu.Event()
+        if batch_descriptor is not None and expected_frontiers is None:
+            self._external_frontiers[batch_descriptor] = submitted_frontiers
 
         self._submission_in_flight = True
-        self._submitted_frontiers = tuple(dict.fromkeys((task.stage, task.group_id) for task in ordered_tasks))
+        self._batch_descriptor = batch_descriptor
         self._waited_stages.clear()
         self._inputs_ready.record(torch.npu.current_stream())
         with torch.npu.stream(self.stream):
@@ -84,7 +103,11 @@ class DeviceMetadataExecutor:
                 while task_index < len(ordered_tasks) and ordered_tasks[task_index].stage == stage:
                     task = ordered_tasks[task_index]
                     task.run()
-                    self._stage_ready[(stage, task.group_id)].record(self.stream)
+                    frontier = (stage, task.group_id)
+                    if batch_descriptor is None:
+                        self._stage_ready[frontier].record(self.stream)
+                    else:
+                        self._external_stage_ready[(batch_descriptor, *frontier)].record(self.stream)
                     task_index += 1
 
     def wait(self, stage: DeviceMetadataStage, group_id: int) -> None:
@@ -92,14 +115,14 @@ class DeviceMetadataExecutor:
             raise RuntimeError("No device metadata submission is in flight")
         frontier = (stage, group_id)
         if frontier not in self._waited_stages:
-            torch.npu.current_stream().wait_event(self._stage_ready[frontier])
+            stream = torch.npu.current_stream()
+            if self._batch_descriptor is None:
+                stream.wait_event(self._stage_ready[frontier])
+            else:
+                event = self._external_stage_ready[(self._batch_descriptor, *frontier)]
+                event.wait(stream)
+                event.reset(stream)
             self._waited_stages.add(frontier)
-
-    def wait_all(self) -> None:
-        if not self._submission_in_flight:
-            raise RuntimeError("No device metadata submission is in flight")
-        for stage, group_id in self._submitted_frontiers:
-            self.wait(stage, group_id)
 
     def release(self) -> None:
         if not self._submission_in_flight:
@@ -107,6 +130,7 @@ class DeviceMetadataExecutor:
         self._buffer_reusable.record(torch.npu.current_stream())
         self._has_reuse_fence = True
         self._submission_in_flight = False
+        self._batch_descriptor = None
 
 
 def wait_for_device_metadata(stage: DeviceMetadataStage, group_id: int) -> None:

--- a/vllm_ascend/worker/device_metadata.py
+++ b/vllm_ascend/worker/device_metadata.py
@@ -19,6 +19,7 @@ from enum import IntEnum
 from typing import Protocol, runtime_checkable
 
 import torch
+from vllm.forward_context import get_forward_context, is_forward_context_available
 
 
 class DeviceMetadataStage(IntEnum):
@@ -55,6 +56,11 @@ class DeviceMetadataExecutor:
         self._buffer_reusable = torch.npu.Event()
         self._has_reuse_fence = False
         self._submission_in_flight = False
+        self._waited_stages: set[DeviceMetadataStage] = set()
+
+    @property
+    def submission_in_flight(self) -> bool:
+        return self._submission_in_flight
 
     def submit(self, tasks: Iterable[DeviceMetadataTask]) -> None:
         if self._submission_in_flight:
@@ -63,6 +69,7 @@ class DeviceMetadataExecutor:
         if not ordered_tasks:
             raise ValueError("At least one device metadata task is required")
 
+        self._waited_stages.clear()
         self._inputs_ready.record(torch.npu.current_stream())
         with torch.npu.stream(self.stream):
             self.stream.wait_event(self._inputs_ready)
@@ -81,7 +88,9 @@ class DeviceMetadataExecutor:
     def wait(self, stage: DeviceMetadataStage) -> None:
         if not self._submission_in_flight:
             raise RuntimeError("No device metadata submission is in flight")
-        torch.npu.current_stream().wait_event(self._stage_ready[stage])
+        if stage not in self._waited_stages:
+            torch.npu.current_stream().wait_event(self._stage_ready[stage])
+            self._waited_stages.add(stage)
 
     def release(self) -> None:
         if not self._submission_in_flight:
@@ -89,3 +98,11 @@ class DeviceMetadataExecutor:
         self._buffer_reusable.record(torch.npu.current_stream())
         self._has_reuse_fence = True
         self._submission_in_flight = False
+
+
+def wait_for_device_metadata(stage: DeviceMetadataStage) -> None:
+    if not is_forward_context_available():
+        return
+    executor = getattr(get_forward_context(), "device_metadata_executor", None)
+    if executor is not None:
+        executor.wait(stage)

--- a/vllm_ascend/worker/model_runner_v1.py
+++ b/vllm_ascend/worker/model_runner_v1.py
@@ -195,7 +195,6 @@ from vllm_ascend.worker.dcp_utils import DCPAsyncSpecDecodeRebuildResult, DCPMan
 from vllm_ascend.worker.device_metadata import (
     DeviceMetadataExecutor,
     DeviceMetadataTask,
-    DeviceMetadataTaskContext,
     DeviceMetadataTaskProvider,
 )
 from vllm_ascend.worker.npu_input_batch import NPUInputBatch
@@ -311,6 +310,7 @@ class NPUModelRunner(GPUModelRunner):
             super().__init__(vllm_config, device)
 
         self.device_metadata_executor: DeviceMetadataExecutor | None = None
+        self.device_metadata_providers: dict[int, DeviceMetadataTaskProvider] | None = None
         self.pin_memory = PIN_MEMORY
 
         set_offloader(create_offloader(self.offload_config))
@@ -3309,6 +3309,11 @@ class NPUModelRunner(GPUModelRunner):
                         else None
                     ),
                 )
+            device_metadata_provider = (
+                self.device_metadata_providers.get(id(builder))
+                if self.device_metadata_providers is not None
+                else None
+            )
             cascade_attn_prefix_len = (
                 cascade_attn_prefix_lens[kv_cache_gid][attn_gid] if cascade_attn_prefix_lens else 0
             )
@@ -3332,7 +3337,6 @@ class NPUModelRunner(GPUModelRunner):
                     num_actual_reqs=num_reqs,
                     common_ratio_to_sas_metadata=common_ratio_to_sas_metadata,
                 )
-
             if (for_cudagraph_capture
                     and not isinstance(builder, (
                         AscendDSAMetadataBuilder,
@@ -3352,18 +3356,9 @@ class NPUModelRunner(GPUModelRunner):
                     and isinstance(builder, GDNAttentionMetadataBuilder) and attn_metadata_i.num_prefills == 0:
                     if attn_metadata_i.num_decodes == 0 and attn_metadata_i.num_spec_decodes > 0:
                         attn_metadata_i.spec_state_indices_tensor[attn_metadata_i.num_spec_decodes:].fill_(0)
-            if device_metadata_tasks is not None and isinstance(
-                builder, DeviceMetadataTaskProvider
-            ):
-                device_metadata_tasks.extend(
-                    builder.build_device_metadata_tasks(
-                        DeviceMetadataTaskContext(
-                            common_attn_metadata=common_attn_metadata,
-                            layer_attn_metadata=attn_metadata_i,
-                            for_cudagraph_capture=for_cudagraph_capture,
-                        )
-                    ),
-                )
+            if device_metadata_provider is not None:
+                assert device_metadata_tasks is not None
+                device_metadata_tasks.extend(device_metadata_provider.take_device_metadata_tasks())
             if isinstance(builder, AscendDSAMetadataBuilder):
                 common_ratio_to_sas_metadata = builder.common_ratio_to_sas_metadata  # type: ignore[assignment]
 
@@ -5049,13 +5044,18 @@ class NPUModelRunner(GPUModelRunner):
         for i, attn_backend_map in enumerate(attention_backend_maps):
             self.attn_groups.append(create_attn_groups(attn_backend_map, i))
 
-        if any(
-            isinstance(builder, DeviceMetadataTaskProvider)
+        device_metadata_providers = {
+            id(builder): builder
             for attn_groups in self.attn_groups
             for attn_group in attn_groups
             for builder in attn_group.metadata_builders
-        ):
+            if isinstance(builder, DeviceMetadataTaskProvider)
+        }
+        if device_metadata_providers:
             self.device_metadata_executor = DeviceMetadataExecutor()
+            self.device_metadata_providers = device_metadata_providers
+            for provider in device_metadata_providers.values():
+                provider.enable_device_metadata()
 
         # Calculate reorder batch threshold (if needed)
         self.calculate_reorder_batch_threshold()

--- a/vllm_ascend/worker/model_runner_v1.py
+++ b/vllm_ascend/worker/model_runner_v1.py
@@ -2315,6 +2315,7 @@ class NPUModelRunner(GPUModelRunner):
                     num_scheduled_tokens_np=num_scheduled_tokens_np,
                     cascade_attn_prefix_lens=cascade_attn_prefix_lens,
                     cudagraph_runtime_mode=cudagraph_mode,
+                    batch_descriptor=batch_desc,
                 )
 
                 self._sanitize_placeholder_input_ids_for_forward(
@@ -2948,8 +2949,8 @@ class NPUModelRunner(GPUModelRunner):
         executor = self.device_metadata_executor
         if executor is None or not executor.submission_in_flight:
             return None
-        if cudagraph_runtime_mode == CUDAGraphMode.FULL:
-            executor.wait_all()
+        if cudagraph_runtime_mode == CUDAGraphMode.FULL and not executor.uses_external_events:
+            raise RuntimeError("Full-graph device metadata requires external events")
         return executor
 
     def _pad_for_sequence_parallelism(self, num_scheduled_tokens: int) -> int:
@@ -3122,6 +3123,7 @@ class NPUModelRunner(GPUModelRunner):
         cascade_attn_prefix_lens: list[list[int]] | None = None,
         skip_gdn_state_update: bool = False,
         cudagraph_runtime_mode: CUDAGraphMode | None = None,
+        batch_descriptor: BatchDescriptor | None = None,
     ) -> tuple[PerLayerAttnMetadata, CommonAttentionMetadata | None]:
         """
         :return: tuple[attn_metadata, spec_decode_common_attn_metadata]
@@ -3464,7 +3466,10 @@ class NPUModelRunner(GPUModelRunner):
             spec_decode_common_attn_metadata = spec_decode_common_attn_metadata.unpadded(num_tokens, num_reqs)
         if device_metadata_tasks:
             assert self.device_metadata_executor is not None
-            self.device_metadata_executor.submit(device_metadata_tasks)
+            self.device_metadata_executor.submit(
+                device_metadata_tasks,
+                batch_descriptor if cudagraph_runtime_mode == CUDAGraphMode.FULL else None,
+            )
         return attn_metadata, spec_decode_common_attn_metadata
 
     def _should_build_dummy_attn_metadata(
@@ -3682,6 +3687,7 @@ class NPUModelRunner(GPUModelRunner):
                     for_cudagraph_capture=is_graph_capturing,
                     num_scheduled_tokens_np=num_scheduled_tokens,
                     cudagraph_runtime_mode=cudagraph_runtime_mode,
+                    batch_descriptor=batch_desc,
                     skip_gdn_state_update=skip_gdn_state_update,
                 )
         with self.maybe_dummy_run_with_lora(

--- a/vllm_ascend/worker/model_runner_v1.py
+++ b/vllm_ascend/worker/model_runner_v1.py
@@ -2314,6 +2314,7 @@ class NPUModelRunner(GPUModelRunner):
                     num_scheduled_tokens=scheduler_output.num_scheduled_tokens,
                     num_scheduled_tokens_np=num_scheduled_tokens_np,
                     cascade_attn_prefix_lens=cascade_attn_prefix_lens,
+                    cudagraph_runtime_mode=cudagraph_mode,
                 )
 
                 self._sanitize_placeholder_input_ids_for_forward(
@@ -3112,6 +3113,7 @@ class NPUModelRunner(GPUModelRunner):
         num_scheduled_tokens_np: np.ndarray | None = None,
         cascade_attn_prefix_lens: list[list[int]] | None = None,
         skip_gdn_state_update: bool = False,
+        cudagraph_runtime_mode: CUDAGraphMode | None = None,
     ) -> tuple[PerLayerAttnMetadata, CommonAttentionMetadata | None]:
         """
         :return: tuple[attn_metadata, spec_decode_common_attn_metadata]
@@ -3336,6 +3338,7 @@ class NPUModelRunner(GPUModelRunner):
                 extra_attn_metadata_args = dict(
                     num_actual_reqs=num_reqs,
                     common_ratio_to_sas_metadata=common_ratio_to_sas_metadata,
+                    full_graph_mode=cudagraph_runtime_mode == CUDAGraphMode.FULL,
                 )
             if (for_cudagraph_capture
                     and not isinstance(builder, (
@@ -3670,6 +3673,7 @@ class NPUModelRunner(GPUModelRunner):
                     ubatch_slices=ubatch_slices_padded if pad_attn else ubatch_slices,
                     for_cudagraph_capture=is_graph_capturing,
                     num_scheduled_tokens_np=num_scheduled_tokens,
+                    cudagraph_runtime_mode=cudagraph_runtime_mode,
                     skip_gdn_state_update=skip_gdn_state_update,
                 )
         with self.maybe_dummy_run_with_lora(

--- a/vllm_ascend/worker/model_runner_v1.py
+++ b/vllm_ascend/worker/model_runner_v1.py
@@ -2358,6 +2358,9 @@ class NPUModelRunner(GPUModelRunner):
         defer_kv_connector_finalize = self.speculative_config is not None and (
             get_pp_group().is_last_rank or self.broadcast_pp_output
         )
+        active_device_metadata_executor = self.device_metadata_executor
+        if active_device_metadata_executor is not None and not active_device_metadata_executor.submission_in_flight:
+            active_device_metadata_executor = None
         with (
             record_function_or_nullcontext("forward"),
             set_ascend_forward_context(
@@ -2369,6 +2372,7 @@ class NPUModelRunner(GPUModelRunner):
                 batch_descriptor=batch_desc,
                 num_actual_tokens=scheduler_output.total_num_scheduled_tokens,
                 model_instance=self.model,
+                device_metadata_executor=active_device_metadata_executor,
                 skip_compiled=has_encoder_input,
                 has_sinks=self._has_sinks,
                 eplb_heat_collection_status=self.eplb_heat_collection_status if self.dynamic_eplb else False,
@@ -2407,6 +2411,8 @@ class NPUModelRunner(GPUModelRunner):
             # Verify every scheduled layer executed its deferred copy.
             if self.cache_config.mamba_cache_mode == "align" and mamba_copy_connector is not None:
                 mamba_copy_connector.finish_mamba_state_copy()
+        if active_device_metadata_executor is not None:
+            active_device_metadata_executor.release()
         with record_function_or_nullcontext("post process"):
             aux_hidden_states = None
             if self.use_aux_hidden_state_outputs:
@@ -3743,6 +3749,9 @@ class NPUModelRunner(GPUModelRunner):
                 if hasattr(self.drafter, "model") and hasattr(self.drafter.model, "compute_logits"):
                     return self.drafter.model.compute_logits(hidden_states[dummy_indices])
 
+            active_device_metadata_executor = self.device_metadata_executor
+            if active_device_metadata_executor is not None and not active_device_metadata_executor.submission_in_flight:
+                active_device_metadata_executor = None
             with set_ascend_forward_context(
                 attn_metadata,
                 self.vllm_config,
@@ -3753,12 +3762,15 @@ class NPUModelRunner(GPUModelRunner):
                 aclgraph_runtime_mode=cudagraph_runtime_mode,
                 batch_descriptor=batch_desc,
                 model_instance=self.model,
+                device_metadata_executor=active_device_metadata_executor,
                 has_sinks = self._has_sinks,
                 eplb_heat_collection_status=self.eplb_heat_collection_status if self.dynamic_eplb else False,
             ):
                 outputs = self._model_forward(
                     num_tokens_padded, input_ids, positions, intermediate_tensors, inputs_embeds
                 )
+            if active_device_metadata_executor is not None:
+                active_device_metadata_executor.release()
             if self.use_aux_hidden_state_outputs:
                 hidden_states, _ = outputs
             else:

--- a/vllm_ascend/worker/model_runner_v1.py
+++ b/vllm_ascend/worker/model_runner_v1.py
@@ -2359,9 +2359,7 @@ class NPUModelRunner(GPUModelRunner):
         defer_kv_connector_finalize = self.speculative_config is not None and (
             get_pp_group().is_last_rank or self.broadcast_pp_output
         )
-        active_device_metadata_executor = self.device_metadata_executor
-        if active_device_metadata_executor is not None and not active_device_metadata_executor.submission_in_flight:
-            active_device_metadata_executor = None
+        active_device_metadata_executor = self._prepare_device_metadata_for_forward(cudagraph_mode)
         with (
             record_function_or_nullcontext("forward"),
             set_ascend_forward_context(
@@ -2943,6 +2941,16 @@ class NPUModelRunner(GPUModelRunner):
             self._update_full_graph_params_if_needed(forward_context, num_tokens_padded)
 
         return hidden_states
+
+    def _prepare_device_metadata_for_forward(
+        self, cudagraph_runtime_mode: CUDAGraphMode
+    ) -> DeviceMetadataExecutor | None:
+        executor = self.device_metadata_executor
+        if executor is None or not executor.submission_in_flight:
+            return None
+        if cudagraph_runtime_mode == CUDAGraphMode.FULL:
+            executor.wait_all()
+        return executor
 
     def _pad_for_sequence_parallelism(self, num_scheduled_tokens: int) -> int:
         # Pad tokens to multiple of tensor_parallel_size when
@@ -3748,9 +3756,7 @@ class NPUModelRunner(GPUModelRunner):
                 if hasattr(self.drafter, "model") and hasattr(self.drafter.model, "compute_logits"):
                     return self.drafter.model.compute_logits(hidden_states[dummy_indices])
 
-            active_device_metadata_executor = self.device_metadata_executor
-            if active_device_metadata_executor is not None and not active_device_metadata_executor.submission_in_flight:
-                active_device_metadata_executor = None
+            active_device_metadata_executor = self._prepare_device_metadata_for_forward(cudagraph_runtime_mode)
             with set_ascend_forward_context(
                 attn_metadata,
                 self.vllm_config,

--- a/vllm_ascend/worker/model_runner_v1.py
+++ b/vllm_ascend/worker/model_runner_v1.py
@@ -192,6 +192,12 @@ from vllm_ascend.utils import (
     weak_ref_tensors,
 )
 from vllm_ascend.worker.dcp_utils import DCPAsyncSpecDecodeRebuildResult, DCPManager
+from vllm_ascend.worker.device_metadata import (
+    DeviceMetadataExecutor,
+    DeviceMetadataTask,
+    DeviceMetadataTaskContext,
+    DeviceMetadataTaskProvider,
+)
 from vllm_ascend.worker.npu_input_batch import NPUInputBatch
 from vllm_ascend.worker.utils import AscendKVBlockZeroer
 
@@ -304,6 +310,7 @@ class NPUModelRunner(GPUModelRunner):
         with _torch_cuda_wrapper():
             super().__init__(vllm_config, device)
 
+        self.device_metadata_executor: DeviceMetadataExecutor | None = None
         self.pin_memory = PIN_MEMORY
 
         set_offloader(create_offloader(self.offload_config))
@@ -3120,6 +3127,9 @@ class NPUModelRunner(GPUModelRunner):
                 self._offload_token_to_req,
             )
         attn_metadata: PerLayerAttnMetadata = {}
+        device_metadata_tasks: list[DeviceMetadataTask] | None = (
+            [] if self.device_metadata_executor is not None else None
+        )
         if ubatch_slices is not None:
             attn_metadata = [dict() for _ in range(len(ubatch_slices))]
 
@@ -3336,6 +3346,18 @@ class NPUModelRunner(GPUModelRunner):
                     and isinstance(builder, GDNAttentionMetadataBuilder) and attn_metadata_i.num_prefills == 0:
                     if attn_metadata_i.num_decodes == 0 and attn_metadata_i.num_spec_decodes > 0:
                         attn_metadata_i.spec_state_indices_tensor[attn_metadata_i.num_spec_decodes:].fill_(0)
+            if device_metadata_tasks is not None and isinstance(
+                builder, DeviceMetadataTaskProvider
+            ):
+                device_metadata_tasks.extend(
+                    builder.build_device_metadata_tasks(
+                        DeviceMetadataTaskContext(
+                            common_attn_metadata=common_attn_metadata,
+                            layer_attn_metadata=attn_metadata_i,
+                            for_cudagraph_capture=for_cudagraph_capture,
+                        )
+                    ),
+                )
             if isinstance(builder, AscendDSAMetadataBuilder):
                 common_ratio_to_sas_metadata = builder.common_ratio_to_sas_metadata  # type: ignore[assignment]
 
@@ -3428,6 +3450,9 @@ class NPUModelRunner(GPUModelRunner):
             # the attention metadata in directly), and therefore does not want to use
             # padded attention metadata.
             spec_decode_common_attn_metadata = spec_decode_common_attn_metadata.unpadded(num_tokens, num_reqs)
+        if device_metadata_tasks:
+            assert self.device_metadata_executor is not None
+            self.device_metadata_executor.submit(device_metadata_tasks)
         return attn_metadata, spec_decode_common_attn_metadata
 
     def _should_build_dummy_attn_metadata(
@@ -5011,6 +5036,14 @@ class NPUModelRunner(GPUModelRunner):
 
         for i, attn_backend_map in enumerate(attention_backend_maps):
             self.attn_groups.append(create_attn_groups(attn_backend_map, i))
+
+        if any(
+            isinstance(builder, DeviceMetadataTaskProvider)
+            for attn_groups in self.attn_groups
+            for attn_group in attn_groups
+            for builder in attn_group.metadata_builders
+        ):
+            self.device_metadata_executor = DeviceMetadataExecutor()
 
         # Calculate reorder batch threshold (if needed)
         self.calculate_reorder_batch_threshold()


### PR DESCRIPTION
### What this PR does / why we need it?

Refs https://github.com/vllm-project/vllm-ascend/issues/15280. Backports #15443 to `releases/v0.27.1rc`.

DeepSeek V4 currently constructs compressor, Quant Lightning Indexer (QLI), Sparse Attention Selector (SAS), DSpark sliding-window, and local DSA-CP metadata on the model stream. These device operators serialize metadata construction with otherwise independent model work.

This PR adds the worker-owned asynchronous metadata execution path from #15443 for DeepSeek V4 on Model Runner V1:

- Eligible attention builders opt into one `DeviceMetadataExecutor` per worker.
- Metadata work runs on a dedicated NPU stream with stage/group-specific readiness events and a reuse fence for persistent output buffers.
- Consumers wait only at their first compressor, indexer, or attention dependency.
- QLI, SAS, compressor, DSpark SWA, and communication-free local DSA-CP metadata are submitted asynchronously where supported.
- Existing synchronous behavior remains for ineligible prefill/topology combinations and graph modes that cannot safely overlap metadata construction.

The v0.27 adaptation preserves the branch's existing DSpark shared `common_ratio_to_sas_metadata` interface while adding the asynchronous task submission and cross-cache-group reuse from #15443.

### Does this PR introduce _any_ user-facing change?

No API or configuration change. Eligible DeepSeek V4 Model Runner V1 executions use the asynchronous path automatically. Other models and Model Runner V2 keep their existing behavior.

### Performance

The performance measurements are documented in #15443. This backport does not claim a new benchmark result for the v0.27 branch.

### How was this patch tested?

- `bash format.sh ci`
- 128 focused unit tests covering executor lifecycle, provider gating, DSA/DSA-CP staging, compressor reuse, DSpark metadata, graph handling, and Model Runner V1 integration.
- Full mypy runs for Python 3.10, 3.11, and 3.12: zero issues in `vllm_ascend`, `examples`, and `tests` for each version.
- Real NPU validation of all 20 compressor-metadata cases, including cross-stream event ordering, stable output addresses, buffer reuse, and buffer rewriting.


- vLLM main: https://github.com/vllm-project/vllm/commit/ba07e4a48fc951300d97eb506217dd530583dea3
