### PR TITLE
[Doc][Misc] Update GLM-5.2 A2 deployment

### DIFF
--- a/docs/source/tutorials/models/GLM5.2.md
+++ b/docs/source/tutorials/models/GLM5.2.md
@@ -16,7 +16,7 @@ Refer to [Feature Guide](../../user_guide/feature_guide/index.md) to get the fea
 
 - `GLM-5.2`(BF16 version): requires 2 Atlas 800 A3 (128GB × 8) node or 4 Atlas 800 A2 (64GB × 8) node.[Download model weight](https://www.modelscope.cn/models/ZhipuAI/GLM-5.2).
 - `GLM-5.2-w8a8`: requires 1 Atlas 800 A3 (128GB × 8) node or 2 Atlas 800 A2 (64GB × 8) node.[Download model weight](https://www.modelscope.cn/models/Eco-Tech/GLM-5.2-w8a8).
-- `GLM-5.2-w8a8c8`(Quantized version for Atlas 800 A3): requires 2 Atlas 800 A3 (64GB × 16) node.[Download model weight](https://modelers.cn/models/Eco-Tech/GLM-5.2-w8a8c8).
+- `GLM-5.2-w8a8c8`(Quantized version for Atlas 800 A3): requires 2 Atlas 800 A3 (64GB × 16) node or 4 Atlas 800 A2 (64GB × 8) node.[Download model weight](https://modelers.cn/models/Eco-Tech/GLM-5.2-w8a8c8).
 - `GLM-5.2-w4a8c8`: requires 1 Atlas 800 A3 (128GB × 8) node or 2 Atlas 800 A2 (64GB × 8) node.[Download model weight](https://modelscope.cn/models/Eco-Tech/GLM-5.2-w4a8c8).
 - You can use [msmodelslim](https://gitcode.com/Ascend/msmodelslim) to quantize the model directly.
 
@@ -867,7 +867,7 @@ export MOONCAKE_CONFIG_PATH="/mnt/share/scripts/mooncake.json"
 export HCCL_INTRA_ROCE_ENABLE=1
 export ACL_OP_INIT_MODE=1
 
-vllm serve /root/.cache/modelscope/hub/models/vllm-ascend/GLM-5.2-w4a8c8 \
+vllm serve /root/.cache/modelscope/hub/models/vllm-ascend/GLM-5.2-w8a8c8 \
     --host 0.0.0.0 \
     --port $2 \
     --data-parallel-size $3 \
@@ -880,11 +880,11 @@ vllm serve /root/.cache/modelscope/hub/models/vllm-ascend/GLM-5.2-w4a8c8 \
     --seed 1024 \
     --enable-chunked-prefill \
     --served-model-name glm-5 \
-    --max-model-len 256000 \
+    --max-model-len 200000 \
     --max-num-batched-tokens 8192 \
     --trust-remote-code \
-    --max-num-seqs 256 \
-    --gpu-memory-utilization 0.95 \
+    --max-num-seqs 512 \
+    --gpu-memory-utilization 0.92 \
     --safetensors-load-strategy prefetch \
     --quantization ascend \
     --enforce-eager \
@@ -963,7 +963,6 @@ export HCCL_OP_EXPANSION_MODE="AIV"
 export VLLM_USE_V1=1
 export ASCEND_RT_VISIBLE_DEVICES=$1
 export LD_LIBRARY_PATH=/usr/local/python3.11.10/lib:/usr/local/lib:$LD_LIBRARY_PATH
-#export LD_LIBRARY_PATH=/usr/local/python3.11.10/lib/python3.11/site-packages/mooncake:$LD_LIBRARY_PATH
 
 export PYTHONHASHSEED=0
 export MOONCAKE_CONFIG_PATH="/mnt/share/scripts/mooncake.json"
@@ -971,7 +970,7 @@ export HCCL_INTRA_ROCE_ENABLE=1
 
 export ACL_OP_INIT_MODE=1
 
-vllm serve /root/.cache/modelscope/hub/models/vllm-ascend/GLM-5.2-w4a8c8 \
+vllm serve /root/.cache/modelscope/hub/models/vllm-ascend/GLM-5.2-w8a8c8 \
     --host 0.0.0.0 \
     --port $2 \
     --data-parallel-size $3 \
@@ -983,11 +982,11 @@ vllm serve /root/.cache/modelscope/hub/models/vllm-ascend/GLM-5.2-w4a8c8 \
     --enable-prefix-caching \
     --seed 1024 \
     --served-model-name glm-5 \
-    --max-model-len 256000 \
+    --max-model-len 200000 \
     --max-num-batched-tokens 256 \
     --trust-remote-code \
-    --max-num-seqs 128 \
-    --gpu-memory-utilization 0.95 \
+    --max-num-seqs 256 \
+    --gpu-memory-utilization 0.92 \
     --safetensors-load-strategy prefetch \
     --quantization ascend \
     --enable-auto-tool-choice \
@@ -1773,6 +1772,7 @@ The service returns HTTP 200 OK. The JSON response contains the `choices` field 
 | ----- | ----- | ----- | ----- | ----- | ----- |
 | AIME2026 | - | accuracy | gen | 93.33 | 4 Atlas 800 A3 (64GB × 16) |
 | GPQA | - | accuracy | gen | 90.4 | 8 Atlas 800 A3 (64GB × 16) |
+| GPQA | - | accuracy | gen | 91.92 | 8 Atlas 800 A2 (64GB × 8) |
 
 ## 8 Performance Evaluation
 


### PR DESCRIPTION
  ### What this PR does / why we need it?

  This PR updates the GLM-5.2 deployment guide for Atlas 800 A2:

  - Adds Atlas 800 A2 support information for the GLM-5.2 W8A8C8 weights.
  - Switches the eight-node A2 P/D deployment examples from W4A8C8 to W8A8C8.
  - Updates the context length, concurrency, and memory utilization settings for both prefill and decode nodes.
  - Removes an obsolete commented Mooncake library path.
  - Adds the GPQA accuracy result for the eight-node A2 deployment.

  These changes align the documentation with the validated A2 deployment configuration.

  ### Does this PR introduce _any_ user-facing change?

  No. This is a documentation-only update.

  ### How was this patch tested?

  - Verified the documentation diff with `git diff --check`.
  - No automated tests were run because this change only updates deployment documentation.
- vLLM main: https://github.com/vllm-project/vllm/commit/d02df748bf9efd99022f1a062597dc3cb3808485
