### PR TITLE
[BugFix][CI] Propagate runtime library paths to non-interactive containers

### DIFF
--- a/Dockerfile.a3
+++ b/Dockerfile.a3
@@ -92,9 +92,11 @@ RUN cd /vllm-workspace/vllm && \
     python3 -m pip install setuptools-rust && \
     ./build_rust.sh
 
-# Append `libascend_hal.so` path (devlib) to LD_LIBRARY_PATH
-RUN echo "export LD_PRELOAD=/usr/lib/$(uname -m)-linux-gnu/libjemalloc.so.2:$LD_PRELOAD" >> ~/.bashrc
-RUN echo "export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/local/lib" >> ~/.bashrc
+# Make runtime library settings available to non-interactive processes.
+RUN ln -sf "/usr/lib/$(uname -m)-linux-gnu/libjemalloc.so.2" \
+    /usr/local/lib/libjemalloc.so.2
+ENV LD_PRELOAD="/usr/local/lib/libjemalloc.so.2"
+ENV LD_LIBRARY_PATH="${LD_LIBRARY_PATH}:/usr/local/lib"
 
 # ===== Conditional installation based on BUILD_TYPE =====
 # All ARG definitions are in the same stage for better maintainability


### PR DESCRIPTION
### What this PR does / why we need it?

`Dockerfile.a3` currently writes the jemalloc `LD_PRELOAD` setting and the
`/usr/local/lib` addition to `LD_LIBRARY_PATH` only to `~/.bashrc`.
Non-interactive container startup paths do not source that file, so direct
container commands, CI steps, and Kubernetes workloads can miss the required
runtime settings.

This draft:

- creates a stable `/usr/local/lib/libjemalloc.so.2` symlink during the image
  build, avoiding an architecture-specific path in `ENV`;
- declares `LD_PRELOAD` and the `/usr/local/lib` addition at image level;
- removes the two `.bashrc`-only exports from `Dockerfile.a3`.

The change is intentionally limited to `Dockerfile.a3`. Maintainer feedback is
requested on whether the same change should be extended to the openEuler, A5,
310P, or generic image variants in this PR.

Related to #12059.

### Does this PR introduce _any_ user-facing change?

Yes. Once runtime-validated, non-interactive processes created from the A3
Ubuntu image will receive the required jemalloc preload and `/usr/local/lib`
search path without sourcing `~/.bashrc`.

### How was this patch tested?

Static checks completed against base commit
`c6ee7e9585f117fff5e83b11ae186724918fc523`:

```text
git diff --check: PASS
Only Dockerfile.a3 changed: PASS
Stable jemalloc link declared: PASS
Image-level LD_PRELOAD declared: PASS
Image-level LD_LIBRARY_PATH addition declared: PASS
.bashrc-only target exports removed: PASS
```

Not yet completed:

```text
bash format.sh ci: BLOCKED (pre-commit is not installed on this host)
Docker build: NOT RUN (no Linux Docker environment available)
Non-interactive shell smoke tests: NOT RUN
Direct Python entrypoint test: NOT RUN
Mooncake import smoke test: NOT RUN
```

This PR is intentionally a draft for implementation and scope review. It must
not be marked ready until CI or a Linux Docker environment confirms that the
image builds and the before/after container startup checks pass.

- vLLM main: https://github.com/vllm-project/vllm/commit/ba07e4a48fc951300d97eb506217dd530583dea3
