### PR TITLE
[Bugfix][DSA] Honor q_norm_without_weight callable in BaseDeviceAdapt…

### DIFF
--- a/vllm_ascend/device/device_op.py
+++ b/vllm_ascend/device/device_op.py
@@ -798,6 +798,9 @@ class BaseDeviceAdaptor:
     def apply_dsa_q_rms(q, eps, q_norm_without_weight=None):
         """Apply Q RMS norm. Non-A5: triton_q_rms.
         A5: uses q_norm_without_weight callable when provided."""
+        if q_norm_without_weight is not None:
+            return q_norm_without_weight(q)
+
         if triton_q_rms is not None:
             return triton_q_rms(q, eps)
         else:


### PR DESCRIPTION
## Description

`BaseDeviceAdaptor.apply_dsa_q_rms` accepted a `q_norm_without_weight` parameter but silently ignored it, always falling back to `triton_q_rms` (or the naive RMSNorm). This diverged from `A5DeviceAdaptor`, which honors the callable.

When the model layer provides a custom Q RMS norm callable (e.g. fused norm implementation), non-A5 devices would bypass it and compute a different normalization, causing incorrect DSA indexer query norms on non-A5 hardware.

## What's changed

- `vllm_ascend/device/device_op.py`: `BaseDeviceAdaptor.apply_dsa_q_rms` now uses `q_norm_without_weight(q)` when provided, matching the A5 adaptor behavior

## Verification

- Inspected the diff: single-file, +3 lines, identical to the A5 adaptor branch structure
- vLLM main: https://github.com/vllm-project/vllm/commit/d02df748bf9efd99022f1a062597dc3cb3808485
