### PR TITLE
[Ops][BugFix][MRV2] Fix apply bit mask kernel

### DIFF
--- a/tests/e2e/nightly/single_node/ops/singlecard_ops/triton/test_apply_grammar_bitmask_triton.py
+++ b/tests/e2e/nightly/single_node/ops/singlecard_ops/triton/test_apply_grammar_bitmask_triton.py
@@ -10,22 +10,29 @@ from vllm_ascend.ops.triton.v2.apply_grammar_bitmask import (
 )
 
 ROWS = 64
+NUM_REQS = 16
+LOGITS_PER_REQ = 4
 VOCAB_SIZE = 151936
 BLOCK_SIZE = 8192
 BITMASK_WORDS = (VOCAB_SIZE + 31) // 32
+# Must exceed the largest position packed into the mapping.
+MASK_STRIDE = 8
 
 
 def _build_reference(
     logits: torch.Tensor,
-    logits_indices: torch.Tensor,
+    logit_rows: torch.Tensor,
+    active: torch.Tensor,
     bitmask: torch.Tensor,
 ) -> torch.Tensor:
     bit_values = torch.ones(32, dtype=torch.int64) << torch.arange(32, dtype=torch.int64)
     blocked = (bitmask.to(torch.int64)[:, :, None] & bit_values[None, None, :]) == 0
     blocked = blocked.reshape(ROWS, -1)[:, :VOCAB_SIZE]
+    # Inactive mapping entries must not touch the logits.
+    blocked &= active[:, None]
 
     expected = logits.clone()
-    indices = logits_indices.to(torch.int64)
+    indices = logit_rows.to(torch.int64)
     mapped = expected.index_select(0, indices)
     mapped.masked_fill_(blocked, -float("inf"))
     expected.index_copy_(0, indices, mapped)
@@ -42,14 +49,25 @@ def test_apply_grammar_bitmask_business_shape():
         generator=generator,
     ).to(torch.bfloat16)
 
-    # Use a non-identity mapping to cover the compact-mask-row -> logits-row
-    # contract used by structured output.
-    logits_indices = torch.arange(
-        ROWS - 1,
-        -1,
-        -1,
+    # cu_num_logits: cumulative logit rows per request (NUM_REQS + 1 entries).
+    cu_num_logits = torch.arange(
+        0,
+        (NUM_REQS + 1) * LOGITS_PER_REQ,
+        LOGITS_PER_REQ,
         dtype=torch.int32,
     )
+
+    # Mapping packs (req_idx, position) as req_idx * MASK_STRIDE + position.
+    # Mask rows 0..59 use positions 0..3 of requests 0..14 (all active); the
+    # last 4 rows point at out-of-range positions of request 15, which must be
+    # skipped (position_is_active=False).
+    req_idx = torch.arange(ROWS) // LOGITS_PER_REQ
+    position = torch.arange(ROWS) % LOGITS_PER_REQ
+    position[60:] += LOGITS_PER_REQ  # positions 4..7 -> inactive
+    mapping = req_idx * MASK_STRIDE + position
+    logit_rows = req_idx * LOGITS_PER_REQ + torch.clamp(position, max=LOGITS_PER_REQ - 1)
+    active = position < LOGITS_PER_REQ
+    mapping = mapping.to(torch.int32)
 
     bitmask = torch.randint(
         -(2**31),
@@ -68,13 +86,15 @@ def test_apply_grammar_bitmask_business_shape():
 
     expected = _build_reference(
         logits,
-        logits_indices,
+        logit_rows,
+        active,
         bitmask,
     )
 
     device = torch.device("npu:0")
     actual = logits.to(device)
-    logits_indices_npu = logits_indices.to(device)
+    mapping_npu = mapping.to(device)
+    cu_num_logits_npu = cu_num_logits.to(device)
     bitmask_npu = bitmask.to(device)
 
     grid = (
@@ -84,10 +104,12 @@ def test_apply_grammar_bitmask_business_shape():
     _apply_grammar_bitmask_kernel[grid](
         actual,
         actual.stride(0),
-        logits_indices_npu,
+        mapping_npu,
+        cu_num_logits_npu,
         bitmask_npu,
         bitmask_npu.stride(0),
         VOCAB_SIZE,
+        MASK_STRIDE=MASK_STRIDE,
         BLOCK_SIZE=BLOCK_SIZE,
     )
     torch.npu.synchronize()

--- a/tests/e2e/pull_request/one_card/test_guided_decoding.py
+++ b/tests/e2e/pull_request/one_card/test_guided_decoding.py
@@ -81,7 +81,7 @@ def sample_json_schema():
 )
 def test_guided_json_completion_xgrammar(sample_json_schema, request):
     sampling_params = SamplingParams(
-        temperature=1.0, max_tokens=500, structured_outputs=StructuredOutputsParams(json=sample_json_schema)
+        temperature=0.0, max_tokens=500, structured_outputs=StructuredOutputsParams(json=sample_json_schema)
     )
     model_marker = request.node.get_closest_marker("model")
     model_marker.kwargs["env_vars"] = REGEX_COMPILATION_TIMEOUT_ENV
@@ -143,7 +143,7 @@ def test_guided_regex_xgrammar(sample_regex, vllm_runner):
 )
 def test_guided_json_completion_guidance(sample_json_schema, vllm_runner):
     sampling_params = SamplingParams(
-        temperature=1.0, max_tokens=500, structured_outputs=StructuredOutputsParams(json=sample_json_schema)
+        temperature=0.0, max_tokens=500, structured_outputs=StructuredOutputsParams(json=sample_json_schema)
     )
     prompts = [f"Give an example JSON for an employee profile that fits this schema: {sample_json_schema}"] * 2
     inputs = vllm_runner.get_inputs(prompts)
@@ -241,7 +241,7 @@ def test_guided_auto_rejects_mixed_structured_output_backends(vllm_runner):
 )
 def test_guided_json_completion_outlines(sample_json_schema, request):
     sampling_params = SamplingParams(
-        temperature=1.0, max_tokens=500, structured_outputs=StructuredOutputsParams(json=sample_json_schema)
+        temperature=0.0, max_tokens=500, structured_outputs=StructuredOutputsParams(json=sample_json_schema)
     )
     model_marker = request.node.get_closest_marker("model")
     model_marker.kwargs["env_vars"] = REGEX_COMPILATION_TIMEOUT_ENV
@@ -290,7 +290,7 @@ def test_guided_json_completion_xgrammar_model_runner_v2(sample_json_schema, req
         assert vllm_runner.model.llm_engine.vllm_config.use_v2_model_runner is True
 
         sampling_params = SamplingParams(
-            temperature=1.0, max_tokens=500, structured_outputs=StructuredOutputsParams(json=sample_json_schema)
+            temperature=0.0, max_tokens=500, structured_outputs=StructuredOutputsParams(json=sample_json_schema)
         )
         prompts = [f"Give an example JSON for an employee profile that fits this schema: {sample_json_schema}"] * 2
         inputs = vllm_runner.get_inputs(prompts)

--- a/tests/e2e/pull_request/one_card/test_guided_decoding.py
+++ b/tests/e2e/pull_request/one_card/test_guided_decoding.py
@@ -37,14 +37,6 @@ GuidedDecodingBackend = ["xgrammar", "guidance", "outlines"]
 REGEX_COMPILATION_TIMEOUT_ENV = {"VLLM_REGEX_COMPILATION_TIMEOUT_S": "30"}
 
 
-@pytest.fixture(params=[False, True], ids=["v1", "v2"])
-def model_runner_env(request):
-    use_v2_model_runner = request.param
-
-    with patch.dict(os.environ, {"VLLM_USE_V2_MODEL_RUNNER": "1" if use_v2_model_runner else "0"}):
-        yield
-
-
 @pytest.fixture(scope="module")
 def sample_regex():
     return (
@@ -81,8 +73,11 @@ def sample_json_schema():
 @pytest.mark.timeout(1000)
 @pytest.mark.model(
     model_name=MODEL_NAME,
-    compilation_config={"cudagraph_capture_sizes": [1, 2, 4, 8]},
-    extra_kwargs={"seed": 0, "structured_outputs_config": {"backend": "xgrammar"}},
+    extra_kwargs={
+        "seed": 0,
+        "enforce_eager": True,
+        "structured_outputs_config": {"backend": "xgrammar", "disable_any_whitespace": True},
+    },
 )
 def test_guided_json_completion_xgrammar(sample_json_schema, request):
     sampling_params = SamplingParams(
@@ -103,6 +98,7 @@ def test_guided_json_completion_xgrammar(sample_json_schema, request):
             prompt = output.prompt
             generated_text = output.outputs[0].text
             assert generated_text is not None
+            assert "\n" not in generated_text
             print(f"Prompt: {prompt!r}, Generated text: {generated_text!r}")
             output_json = json.loads(generated_text)
             jsonschema.validate(instance=output_json, schema=sample_json_schema)
@@ -111,8 +107,11 @@ def test_guided_json_completion_xgrammar(sample_json_schema, request):
 @pytest.mark.timeout(1000)
 @pytest.mark.model(
     model_name=MODEL_NAME,
-    compilation_config={"cudagraph_capture_sizes": [1, 2, 4, 8]},
-    extra_kwargs={"seed": 0, "structured_outputs_config": {"backend": "xgrammar"}},
+    extra_kwargs={
+        "seed": 0,
+        "enforce_eager": True,
+        "structured_outputs_config": {"backend": "xgrammar", "disable_any_whitespace": True},
+    },
 )
 def test_guided_regex_xgrammar(sample_regex, vllm_runner):
     sampling_params = SamplingParams(
@@ -136,8 +135,11 @@ def test_guided_regex_xgrammar(sample_regex, vllm_runner):
 @pytest.mark.timeout(1000)
 @pytest.mark.model(
     model_name=MODEL_NAME,
-    compilation_config={"cudagraph_capture_sizes": [1, 2, 4, 8]},
-    extra_kwargs={"seed": 0, "structured_outputs_config": {"backend": "guidance"}},
+    extra_kwargs={
+        "seed": 0,
+        "enforce_eager": True,
+        "structured_outputs_config": {"backend": "guidance", "disable_any_whitespace": True},
+    },
 )
 def test_guided_json_completion_guidance(sample_json_schema, vllm_runner):
     sampling_params = SamplingParams(
@@ -154,6 +156,7 @@ def test_guided_json_completion_guidance(sample_json_schema, vllm_runner):
         prompt = output.prompt
         generated_text = output.outputs[0].text
         assert generated_text is not None
+        assert "\n" not in generated_text
         print(f"Prompt: {prompt!r}, Generated text: {generated_text!r}")
         output_json = json.loads(generated_text)
         jsonschema.validate(instance=output_json, schema=sample_json_schema)
@@ -162,8 +165,11 @@ def test_guided_json_completion_guidance(sample_json_schema, vllm_runner):
 @pytest.mark.timeout(1000)
 @pytest.mark.model(
     model_name=MODEL_NAME,
-    compilation_config={"cudagraph_capture_sizes": [1, 2, 4, 8]},
-    extra_kwargs={"seed": 0, "structured_outputs_config": {"backend": "guidance"}},
+    extra_kwargs={
+        "seed": 0,
+        "enforce_eager": True,
+        "structured_outputs_config": {"backend": "guidance", "disable_any_whitespace": True},
+    },
 )
 def test_guided_regex_guidance(sample_regex, vllm_runner):
     sampling_params = SamplingParams(
@@ -187,8 +193,9 @@ def test_guided_regex_guidance(sample_regex, vllm_runner):
 @pytest.mark.timeout(1000)
 @pytest.mark.model(
     model_name=MODEL_NAME,
-    compilation_config={"cudagraph_capture_sizes": [1, 2, 4, 8]},
-    extra_kwargs={"seed": 0, "structured_outputs_config": {"backend": "auto"}},
+    # disable_any_whitespace is only supported by xgrammar/guidance backends,
+    # so it cannot be enabled here (backend="auto").
+    extra_kwargs={"seed": 0, "enforce_eager": True, "structured_outputs_config": {"backend": "auto"}},
 )
 def test_guided_auto_rejects_mixed_structured_output_backends(vllm_runner):
     xgrammar_schema = {
@@ -228,8 +235,9 @@ def test_guided_auto_rejects_mixed_structured_output_backends(vllm_runner):
 @pytest.mark.timeout(1000)
 @pytest.mark.model(
     model_name=MODEL_NAME,
-    compilation_config={"cudagraph_capture_sizes": [1, 2, 4, 8]},
-    extra_kwargs={"seed": 0, "structured_outputs_config": {"backend": "outlines"}},
+    # disable_any_whitespace is only supported by xgrammar/guidance backends,
+    # so it cannot be enabled here (backend="outlines").
+    extra_kwargs={"seed": 0, "enforce_eager": True, "structured_outputs_config": {"backend": "outlines"}},
 )
 def test_guided_json_completion_outlines(sample_json_schema, request):
     sampling_params = SamplingParams(
@@ -251,5 +259,50 @@ def test_guided_json_completion_outlines(sample_json_schema, request):
             generated_text = output.outputs[0].text
             assert generated_text is not None
             print(f"Prompt: {prompt!r}, Generated text: {generated_text!r}")
+            output_json = json.loads(generated_text)
+            jsonschema.validate(instance=output_json, schema=sample_json_schema)
+
+
+@pytest.mark.timeout(1000)
+@pytest.mark.model(
+    model_name=MODEL_NAME,
+    extra_kwargs={
+        "seed": 0,
+        "enforce_eager": True,
+        "structured_outputs_config": {"backend": "xgrammar", "disable_any_whitespace": True},
+    },
+)
+def test_guided_json_completion_xgrammar_model_runner_v2(sample_json_schema, request):
+    """Guard xgrammar guided decoding on the V2 model runner.
+
+    xgrammar is the production default backend, so this covers the path most
+    users will actually hit once V2 becomes the default.
+    TODO: Remove this test once the V2 model runner is the default.
+    """
+    env = {"VLLM_USE_V2_MODEL_RUNNER": "1"}
+    # The VllmRunner ModelCache key is derived from the model marker kwargs,
+    # so tag it with the env to give this test its own engine (the other
+    # xgrammar tests in this module run with the env unset).
+    model_marker = request.node.get_closest_marker("model")
+    model_marker.kwargs["env_vars"] = env
+    with patch.dict(os.environ, env):
+        vllm_runner = request.getfixturevalue("vllm_runner")
+        assert vllm_runner.model.llm_engine.vllm_config.use_v2_model_runner is True
+
+        sampling_params = SamplingParams(
+            temperature=1.0, max_tokens=500, structured_outputs=StructuredOutputsParams(json=sample_json_schema)
+        )
+        prompts = [f"Give an example JSON for an employee profile that fits this schema: {sample_json_schema}"] * 2
+        inputs = vllm_runner.get_inputs(prompts)
+        outputs = vllm_runner.model.generate(inputs, sampling_params=sampling_params)
+
+        assert outputs is not None
+        for output in outputs:
+            assert output is not None
+            assert isinstance(output, RequestOutput)
+            generated_text = output.outputs[0].text
+            assert generated_text is not None
+            assert "\n" not in generated_text
+            print(f"Prompt: {output.prompt!r}, Generated text: {generated_text!r}")
             output_json = json.loads(generated_text)
             jsonschema.validate(instance=output_json, schema=sample_json_schema)

--- a/vllm_ascend/ops/triton/v2/apply_grammar_bitmask.py
+++ b/vllm_ascend/ops/triton/v2/apply_grammar_bitmask.py
@@ -29,12 +29,14 @@ def _apply_grammar_bitmask_kernel_impl(
     logits_ptr,
     logits_stride,
     logits_indices_ptr,
+    cu_num_logits_ptr,
     bitmask_ptr,
     bitmask_stride,
     vocab_size,
     total_tasks,
     NUM_PROGRAMS: tl.constexpr,
     NUM_VOCAB_BLOCKS: tl.constexpr,
+    MASK_STRIDE: tl.constexpr,
     BLOCK_SIZE: tl.constexpr,
 ):
     pid = tl.program_id(0)
@@ -49,7 +51,18 @@ def _apply_grammar_bitmask_kernel_impl(
     for task_id in tl.range(task_start, task_end):
         bitmask_idx = task_id // NUM_VOCAB_BLOCKS
         block_id = task_id - bitmask_idx * NUM_VOCAB_BLOCKS
-        logits_idx = tl.load(logits_indices_ptr + bitmask_idx)
+
+        # Each mapping entry packs (req_idx, position) as
+        # req_idx * MASK_STRIDE + position; the absolute logit row is
+        # resolved on device from cu_num_logits (adaptive verification
+        # finalizes per-request logit offsets there).
+        mapping_idx = tl.load(logits_indices_ptr + bitmask_idx)
+        req_idx = mapping_idx // MASK_STRIDE
+        position_idx = mapping_idx % MASK_STRIDE
+        logits_idx = tl.load(cu_num_logits_ptr + req_idx)
+        num_req_logits = tl.load(cu_num_logits_ptr + req_idx + 1) - logits_idx
+        logits_idx += position_idx
+        position_is_active = position_idx < num_req_logits
 
         bitmask_offset = block_id * (BLOCK_SIZE // 32) + tl.arange(0, BLOCK_SIZE // 32)
         packed_bitmask = tl.load(
@@ -64,7 +77,7 @@ def _apply_grammar_bitmask_kernel_impl(
         tl.store(
             logits_ptr + logits_idx * logits_stride + block_offset,
             -float("inf"),
-            mask=blocked & (block_offset < vocab_size),
+            mask=position_is_active & blocked & (block_offset < vocab_size),
         )
 
 
@@ -82,9 +95,11 @@ class _ApplyGrammarBitmaskKernelLauncher:
             logits_ptr,
             logits_stride,
             logits_indices_ptr,
+            cu_num_logits_ptr,
             bitmask_ptr,
             bitmask_stride,
             vocab_size,
+            MASK_STRIDE,
             BLOCK_SIZE,
         ):
             # Disable MULTIBUFFER to better utilize the UB buffer, which gives
@@ -94,12 +109,14 @@ class _ApplyGrammarBitmaskKernelLauncher:
                 logits_ptr,
                 logits_stride,
                 logits_indices_ptr,
+                cu_num_logits_ptr,
                 bitmask_ptr,
                 bitmask_stride,
                 vocab_size,
                 total_tasks,
                 NUM_PROGRAMS=num_programs,
                 NUM_VOCAB_BLOCKS=num_vocab_blocks,
+                MASK_STRIDE=MASK_STRIDE,
                 BLOCK_SIZE=BLOCK_SIZE,
                 multibuffer=False,
             )

--- a/vllm_ascend/ops/triton/v2/docs/apply_grammar_bitmask.md
+++ b/vllm_ascend/ops/triton/v2/docs/apply_grammar_bitmask.md
@@ -117,8 +117,10 @@
   ```text
   logits.shape         = [64, 151936]
   logits.dtype         = BFLOAT16
-  logits_indices.shape = [64]
+  logits_indices.shape = [64]          # packed (req_idx, position) mapping
   logits_indices.dtype = INT32
+  cu_num_logits.shape  = [num_reqs + 1]
+  cu_num_logits.dtype  = INT32
   bitmask.shape        = [64, 4748]
   bitmask.dtype        = INT32
   BLOCK_SIZE           = 8192
@@ -139,8 +141,11 @@ from vllm_ascend.ops.triton.v2.apply_grammar_bitmask import (
 device = torch.device("npu:0")
 
 rows = 64
+num_reqs = 16
+logits_per_req = 4
 vocab_size = 151936
 block_size = 8192
+mask_stride = 8  # must exceed the largest packed position
 bitmask_words = (vocab_size + 31) // 32
 
 logits = torch.randn(
@@ -150,11 +155,19 @@ logits = torch.randn(
     device=device,
 )
 
-logits_indices = torch.arange(
-    rows,
+# Cumulative logit rows per request.
+cu_num_logits = torch.arange(
+    0,
+    (num_reqs + 1) * logits_per_req,
+    logits_per_req,
     dtype=torch.int32,
     device=device,
 )
+
+# Each entry packs (req_idx, position) as req_idx * mask_stride + position.
+req_idx = torch.arange(rows) // logits_per_req
+position = torch.arange(rows) % logits_per_req
+logits_indices = (req_idx * mask_stride + position).to(torch.int32).to(device)
 
 # bit=1 means allowed. -1 means all 32 bits are 1.
 bitmask = torch.full(
@@ -173,9 +186,11 @@ _apply_grammar_bitmask_kernel[grid](
     logits,
     logits.stride(0),
     logits_indices,
+    cu_num_logits,
     bitmask,
     bitmask.stride(0),
     vocab_size,
+    MASK_STRIDE=mask_stride,
     BLOCK_SIZE=block_size,
 )
 ```

--- a/vllm_ascend/patch/__init__.py
+++ b/vllm_ascend/patch/__init__.py
@@ -612,6 +612,28 @@
 #       before grammar compilation or safely handles mixed-backend grammar
 #       failures without killing the engine.
 #
+#   2. `vllm.v1.structured_output.backend_outlines.OutlinesGrammar.accept_tokens`
+#    Why:
+#       After the outlines FSM finishes (e.g. the JSON is complete), the
+#       scheduler emits one more mask that allows EOS/stop tokens so the
+#       request can terminate normally. Those tokens are not part of the FSM
+#       alphabet built from the JSON regex, so `guide.accepts_tokens()` rejects
+#       them and the scheduler terminates the request with FINISHED_ERROR,
+#       logging "Unexpected: grammar rejected tokens". The xgrammar backend
+#       already short-circuits in this case (`if self._is_terminated:
+#       return True`); outlines is missing the same guard.
+#    How:
+#       Wrap `OutlinesGrammar.accept_tokens` with a terminal short-circuit
+#       that returns True once `guide.is_finished()` is set, mirroring the
+#       xgrammar behavior. Applies to both model runner v1 and v2 since the
+#       fix targets the scheduler-side grammar class.
+#    Related PR (if no, explain why):
+#       https://github.com/vllm-project/vllm/pull/49227 (fixed the analogous
+#       stop-token handling for xgrammar only; outlines was left out)
+#    Future Plan:
+#       Remove this patch once upstream vLLM adds the terminal short-circuit
+#       to the outlines backend.
+#
 # ** 20. File: platform/patch_torch_accelerator.py**
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 #   1. `torch.accelerator.memory_stats`, `torch.accelerator.memory_reserved`,

--- a/vllm_ascend/patch/platform/patch_structured_output.py
+++ b/vllm_ascend/patch/platform/patch_structured_output.py
@@ -14,6 +14,7 @@ from vllm.v1.structured_output import StructuredOutputManager
 _BACKEND_ATTR = "_vllm_ascend_structured_output_backend"
 _ORIGINAL_GRAMMAR_INIT_ATTR = "_vllm_ascend_original_grammar_init"
 _ORIGINAL_VALIDATE_ATTR = "_vllm_ascend_original_validate_structured_outputs"
+_ORIGINAL_OUTLINES_ACCEPT_ATTR = "_vllm_ascend_original_outlines_accept_tokens"
 
 
 def _request_backend(request: Any) -> str | None:
@@ -130,5 +131,33 @@ def _patch_structured_output_manager() -> None:
     StructuredOutputManager.grammar_init = grammar_init
 
 
+def _patch_outlines_accept_tokens() -> None:
+    # Importing this module is safe without outlines installed: it loads
+    # outlines_core lazily.
+    from vllm.v1.structured_output.backend_outlines import OutlinesGrammar
+
+    original_accept = getattr(OutlinesGrammar, _ORIGINAL_OUTLINES_ACCEPT_ATTR, None)
+    if original_accept is not None:
+        return
+    original_accept = OutlinesGrammar.accept_tokens
+    setattr(OutlinesGrammar, _ORIGINAL_OUTLINES_ACCEPT_ATTR, original_accept)
+
+    def accept_tokens(self: Any, request_id: str, tokens: list[int]) -> bool:
+        # Mirror xgrammar's terminal short-circuit
+        # (backend_xgrammar.py: `if self._is_terminated: return True`).
+        # Once the outlines FSM finishes, the scheduler still emits one more
+        # mask that allows EOS/stop tokens so the request can terminate
+        # normally. Those tokens are not part of the FSM alphabet built from
+        # the JSON regex, so `guide.accepts_tokens()` rejects them and the
+        # scheduler terminates the request with FINISHED_ERROR even though
+        # the grammar text is already complete.
+        if self.guide.is_finished():
+            return True
+        return original_accept(self, request_id, tokens)
+
+    OutlinesGrammar.accept_tokens = accept_tokens
+
+
 _patch_sampling_params_validation()
 _patch_structured_output_manager()
+_patch_outlines_accept_tokens()


### PR DESCRIPTION
### What this PR does / why we need it?
This PR aligns upstream function interface and fixes the `apply_grammar_bitmask` Triton kernel to correctly handle adaptive verification and per-request logit offsets. It introduces `cu_num_logits` to resolve absolute logit rows on device and handles inactive mapping entries safely.
### Does this PR introduce _any_ user-facing change?
No.
### How was this patch tested?
Tested with CI case.


- vLLM main: https://github.com/vllm-project/vllm/commit/e6bfe03ad73a3330cb427885aa90d97a12e1c704
