### PR TITLE
[Performance][KV Pool] Prefetch two AscendStore layers by default

### DIFF
--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/pool_worker.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/pool_worker.py
@@ -436,7 +436,7 @@ class KVPoolWorker:
                 self.prefetch_layer_map = self._layerwise_reuse_layout.prefetch_layer_map
                 self.num_prefetch_layers = self._layerwise_reuse_layout.num_prefetch_layers
         else:
-            self.num_prefetch_layers = int(self._extra_config.get("layerwise_prefetch_layers", 1))
+            self.num_prefetch_layers = int(self._extra_config.get("layerwise_prefetch_layers", 2))
         self.sync_save_events: list[torch.npu.Event] | None = None
 
         logger.info(


### PR DESCRIPTION
### What this PR does / why we need it?

This PR increases the fallback value of layerwise_prefetch_layers from 1 to 2 for AscendStore layerwise transfers. Prefetching two layers improves overlap between KV transfer and attention computation while keeping explicit user configuration unchanged.


### Does this PR introduce _any_ user-facing change?

Yes. When layerwise_prefetch_layers is not explicitly configured, AscendStore now prefetches two layers instead of one. Users can still set the option explicitly to override the default.

### How was this patch tested?

- Verified that the PR changes only the fallback default from 1 to 2.
- No unit test was added because existing explicit configuration and reuse-layout behavior are unchanged; this patch only adjusts a constant fallback value.
- vLLM main: https://github.com/vllm-project/vllm/commit/ba07e4a48fc951300d97eb506217dd530583dea3
