### PR TITLE
[v0.27.1rc][Bugfix][Attention] Gate parallel-drafting seq-lens override

### DIFF
--- a/tests/ut/attention/test_attention_v1.py
+++ b/tests/ut/attention/test_attention_v1.py
@@ -200,6 +200,40 @@ class TestAscendAttentionMetadataBuilder(TestBase):
 
         self.builder.build(1, common_attn_metadata, mock_model)
 
+    @patch.object(AscendAttentionMetadataBuilder, "metadata_cls")
+    def test_parallel_drafting_seq_lens_override_switch(self, mock_ascend_metadata):
+        host_seq_lens = torch.tensor([11, 12, 13], dtype=torch.int32)
+        device_seq_lens = torch.tensor([21, 22, 23], dtype=torch.int32)
+        common_attn_metadata = AscendCommonAttentionMetadata(
+            query_start_loc=torch.tensor([0, 1, 2, 3]),
+            query_start_loc_cpu=torch.tensor([0, 1, 2, 3]),
+            seq_lens=device_seq_lens,
+            _seq_lens_cpu=host_seq_lens,
+            seq_lens_cpu=None,
+            num_reqs=3,
+            num_actual_tokens=3,
+            max_query_len=1,
+            decode_token_per_req=torch.tensor([1, 1, 1]),
+            block_table_tensor=torch.zeros((3, 1), dtype=torch.int32),
+            slot_mapping=torch.arange(3, dtype=torch.int32),
+            actual_seq_lengths_q=torch.tensor([1, 1, 1]),
+            positions=torch.arange(3),
+            attn_state=AscendAttentionState.SpecDecoding,
+            num_computed_tokens_cpu=None,
+            max_seq_len=23,
+        )
+        self.builder.speculative_config = SimpleNamespace(
+            parallel_drafting=True,
+            skip_parallel_drafting_seq_lens_override=False,
+        )
+
+        self.builder.build(0, common_attn_metadata)
+        torch.testing.assert_close(mock_ascend_metadata.call_args.kwargs["seq_lens"], device_seq_lens)
+
+        self.builder.speculative_config.skip_parallel_drafting_seq_lens_override = True
+        self.builder.build(0, common_attn_metadata)
+        torch.testing.assert_close(mock_ascend_metadata.call_args.kwargs["seq_lens"], host_seq_lens)
+
 
 def test_pcp_metadata_keeps_expanded_slot_mapping() -> None:
     builder = AscendAttentionMetadataBuilder.__new__(AscendAttentionMetadataBuilder)

--- a/tests/ut/attention/test_attention_v1.py
+++ b/tests/ut/attention/test_attention_v1.py
@@ -222,15 +222,15 @@ class TestAscendAttentionMetadataBuilder(TestBase):
             num_computed_tokens_cpu=None,
             max_seq_len=23,
         )
-        self.builder.speculative_config = SimpleNamespace(
-            parallel_drafting=True,
-            skip_parallel_drafting_seq_lens_override=False,
-        )
+        self.builder.speculative_config = SimpleNamespace(parallel_drafting=True)
 
         self.builder.build(0, common_attn_metadata)
         torch.testing.assert_close(mock_ascend_metadata.call_args.kwargs["seq_lens"], device_seq_lens)
 
-        self.builder.speculative_config.skip_parallel_drafting_seq_lens_override = True
+        self.builder.speculative_config = SimpleNamespace(
+            parallel_drafting=True,
+            skip_parallel_drafting_seq_lens_override=True,
+        )
         self.builder.build(0, common_attn_metadata)
         torch.testing.assert_close(mock_ascend_metadata.call_args.kwargs["seq_lens"], host_seq_lens)
 

--- a/tests/ut/patch/platform/test_patch_speculative_config_dspark.py
+++ b/tests/ut/patch/platform/test_patch_speculative_config_dspark.py
@@ -1,7 +1,10 @@
+from types import SimpleNamespace
+from unittest.mock import patch
+
 from transformers import Qwen3Config
 from vllm.config.speculative import SpeculativeConfig
 
-import vllm_ascend.patch.platform.patch_speculative_config  # noqa: F401
+import vllm_ascend.patch.platform.patch_speculative_config as patch_speculative_config
 
 
 def test_ascend_speculative_config_field_defaults_to_false():
@@ -9,6 +12,22 @@ def test_ascend_speculative_config_field_defaults_to_false():
 
     assert SpeculativeConfig.__dataclass_fields__[field_name].default is False
     assert SpeculativeConfig.__pydantic_fields__[field_name].default is False
+
+
+def test_seq_lens_override_warns_about_host_side_metadata():
+    config = SimpleNamespace(
+        skip_parallel_drafting_seq_lens_override=True,
+        use_dspark=lambda: False,
+    )
+
+    with (
+        patch.object(patch_speculative_config, "_orig_post_init"),
+        patch.object(patch_speculative_config.logger, "warning_once") as warning,
+    ):
+        patch_speculative_config._dspark_post_init(config)
+
+    warning.assert_called_once()
+    assert "host-side sequence lengths" in warning.call_args.args[0]
 
 
 def test_legacy_qwen3_dspark_config_uses_qwen3_loader():

--- a/tests/ut/patch/platform/test_patch_speculative_config_dspark.py
+++ b/tests/ut/patch/platform/test_patch_speculative_config_dspark.py
@@ -4,6 +4,13 @@ from vllm.config.speculative import SpeculativeConfig
 import vllm_ascend.patch.platform.patch_speculative_config  # noqa: F401
 
 
+def test_ascend_speculative_config_field_defaults_to_false():
+    field_name = "skip_parallel_drafting_seq_lens_override"
+
+    assert SpeculativeConfig.__dataclass_fields__[field_name].default is False
+    assert SpeculativeConfig.__pydantic_fields__[field_name].default is False
+
+
 def test_legacy_qwen3_dspark_config_uses_qwen3_loader():
     config = Qwen3Config(
         architectures=["DSparkDraftModel"],

--- a/vllm_ascend/attention/attention_v1.py
+++ b/vllm_ascend/attention/attention_v1.py
@@ -334,7 +334,11 @@ class AscendAttentionMetadataBuilder(AttentionMetadataBuilder[AscendMetadata]):
         if isinstance(self.kv_cache_spec, CrossAttentionSpec):
             seq_lens = common_attn_metadata.seq_lens
             slot_mapping = common_attn_metadata.slot_mapping.to(torch.int32)
-        elif self.speculative_config and self.speculative_config.parallel_drafting:
+        elif (
+            self.speculative_config
+            and self.speculative_config.parallel_drafting
+            and not self.speculative_config.skip_parallel_drafting_seq_lens_override
+        ):
             seq_lens = common_attn_metadata.seq_lens
 
         attn_state = common_attn_metadata.attn_state

--- a/vllm_ascend/attention/attention_v1.py
+++ b/vllm_ascend/attention/attention_v1.py
@@ -336,8 +336,8 @@ class AscendAttentionMetadataBuilder(AttentionMetadataBuilder[AscendMetadata]):
             slot_mapping = common_attn_metadata.slot_mapping.to(torch.int32)
         elif (
             self.speculative_config
-            and self.speculative_config.parallel_drafting
-            and not self.speculative_config.skip_parallel_drafting_seq_lens_override
+            and getattr(self.speculative_config, "parallel_drafting", False)
+            and not getattr(self.speculative_config, "skip_parallel_drafting_seq_lens_override", False)
         ):
             seq_lens = common_attn_metadata.seq_lens
 

--- a/vllm_ascend/patch/__init__.py
+++ b/vllm_ascend/patch/__init__.py
@@ -495,6 +495,20 @@
 #       models without a custom `hf_config_override`, or exposes a plugin hook
 #       for MTP model_type/architecture remapping.
 #
+#   2. `vllm.config.speculative.SpeculativeConfig`
+#    Why:
+#       Ascend parallel drafting may need to preserve the host-side sequence
+#       lengths instead of replacing them with the device-side buffer.
+#    How:
+#       Add `skip_parallel_drafting_seq_lens_override` (default `False`) to the
+#       speculative config. When enabled, the Ascend attention metadata builder
+#       keeps the sequence lengths selected before the parallel-drafting branch.
+#    Related PR (if no, explain why):
+#       https://github.com/vllm-project/vllm-ascend/pull/15681
+#    Future Plan:
+#       Remove the field after the parallel-drafting metadata path no longer
+#       requires an Ascend-specific compatibility switch.
+#
 # ** 19. File: platform/patch_structured_output.py**
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 #   1. `vllm.sampling_params.SamplingParams._validate_structured_outputs`

--- a/vllm_ascend/patch/platform/patch_speculative_config.py
+++ b/vllm_ascend/patch/platform/patch_speculative_config.py
@@ -1,4 +1,8 @@
+from dataclasses import dataclass
+
+from pydantic.dataclasses import rebuild_dataclass
 from transformers import DeepseekV2Config, PretrainedConfig
+from vllm.config import VllmConfig
 from vllm.config.speculative import SpeculativeConfig
 
 _orig_post_init = SpeculativeConfig.__post_init__
@@ -50,5 +54,25 @@ def _dspark_post_init(self):
             draft_hf_config.ptd_token_id = getattr(draft_hf_config, "mask_token_id", None)  # type: ignore
 
 
+@dataclass
+class _AscendSpeculativeConfigFields:
+    skip_parallel_drafting_seq_lens_override: bool = False
+
+
+def _add_ascend_speculative_config_fields() -> None:
+    """Add plugin-owned fields before speculative config validation runs."""
+    field_name = "skip_parallel_drafting_seq_lens_override"
+    if field_name in SpeculativeConfig.__dataclass_fields__:
+        return
+
+    SpeculativeConfig.__annotations__[field_name] = bool
+    SpeculativeConfig.__dataclass_fields__[field_name] = _AscendSpeculativeConfigFields.__dataclass_fields__[field_name]
+    setattr(SpeculativeConfig, field_name, False)
+    rebuild_dataclass(SpeculativeConfig, force=True)
+    # VllmConfig may already have cached the nested SpeculativeConfig schema.
+    rebuild_dataclass(VllmConfig, force=True)
+
+
 SpeculativeConfig.hf_config_override = staticmethod(_normalize_legacy_qwen3_dspark_config)
 SpeculativeConfig.__post_init__ = _dspark_post_init
+_add_ascend_speculative_config_fields()

--- a/vllm_ascend/patch/platform/patch_speculative_config.py
+++ b/vllm_ascend/patch/platform/patch_speculative_config.py
@@ -4,6 +4,7 @@ from pydantic.dataclasses import rebuild_dataclass
 from transformers import DeepseekV2Config, PretrainedConfig
 from vllm.config import VllmConfig
 from vllm.config.speculative import SpeculativeConfig
+from vllm.logger import logger
 
 _orig_post_init = SpeculativeConfig.__post_init__
 _orig_hf_config_override = SpeculativeConfig.hf_config_override
@@ -43,6 +44,13 @@ def _normalize_legacy_qwen3_dspark_config(hf_config: PretrainedConfig) -> Pretra
 
 def _dspark_post_init(self):
     _orig_post_init(self)
+    if getattr(self, "skip_parallel_drafting_seq_lens_override", False):
+        logger.warning_once(
+            "skip_parallel_drafting_seq_lens_override is enabled: parallel "
+            "drafting attention will preserve host-side sequence lengths "
+            "instead of using the device-side sequence-length buffers. Enable "
+            "this only when the draft model requires host-side metadata."
+        )
     if self.use_dspark():
         draft_model_config = getattr(self, "draft_model_config", None)
         draft_hf_config = getattr(draft_model_config, "hf_config", None)


### PR DESCRIPTION
### What this PR does / why we need it?

This PR ports only the `attention_v1.py` parallel-drafting sequence-length behavior from #15681 to the v0.27.1 release branch and puts it behind an opt-in speculative-config switch.

- Add `skip_parallel_drafting_seq_lens_override` to `SpeculativeConfig`, defaulting to `False`.
- Keep the existing device-side `seq_lens` override when the option is omitted or disabled.
- Preserve the previously selected host-side sequence lengths when the option is enabled.
- Do not include the unrelated Kimi KDA early-return change from #15681.

The vLLM config schema is rebuilt after adding the plugin-owned field so the option is accepted inside `--speculative-config`, including through the nested `VllmConfig` schema.

### Does this PR introduce _any_ user-facing change?

Yes. Users can opt in with:

```json
{"skip_parallel_drafting_seq_lens_override": true}
```

> [!WARNING]
> Enabling `skip_parallel_drafting_seq_lens_override` makes parallel-drafting attention preserve host-side sequence lengths instead of using the device-side sequence-length buffers. Enable it only when the draft model explicitly requires host-side metadata; otherwise leave the option disabled.

The default is `False`, so existing behavior is unchanged.

### How was this patch tested?

- Added a unit test covering both switch states in the Ascend attention metadata builder.
- Added a unit test verifying that the new speculative-config field defaults to `False` in both the dataclass and Pydantic schemas.
- `ruff check` passed for all modified Python files.
- `python -m compileall` passed for all modified Python files.
- Full pytest execution was not run locally because the local Python environment does not contain vLLM or torch-npu; repository CI is expected to run the added tests.

- vLLM main: https://github.com/vllm-project/vllm/commit/ba07e4a48fc951300d97eb506217dd530583dea3
