### PR TITLE
[BugFix][Gemma4] initialize _enable_mm_lora for Gemma4 multimodal

### DIFF
--- a/tests/ut/models/test_gemma4_mm.py
+++ b/tests/ut/models/test_gemma4_mm.py
@@ -1,3 +1,4 @@
+from contextlib import nullcontext
 from types import SimpleNamespace
 from unittest.mock import patch
 
@@ -13,6 +14,76 @@ from vllm_ascend.quantization.methods import (
     AscendW4A4MXFP4DynamicLinearMethod,
     AscendW8A8MXFP8DynamicLinearMethod,
 )
+
+
+def test_gemma4_mm_lora_flag_follows_lora_config():
+    language_model = SimpleNamespace(
+        make_empty_intermediate_tensors=None,
+        moe_layers=None,
+        num_moe_layers=0,
+        num_logical_experts=0,
+        num_physical_experts=0,
+        num_local_physical_experts=0,
+        num_routed_experts=0,
+        num_expert_groups=0,
+        num_shared_experts=0,
+        num_redundant_experts=0,
+    )
+    vision_tower = SimpleNamespace(
+        patch_embedder=SimpleNamespace(
+            input_proj=SimpleNamespace(quant_method=None),
+        ),
+    )
+
+    for lora_config, expected in (
+        (None, False),
+        (SimpleNamespace(enable_tower_connector_lora=False), False),
+        (SimpleNamespace(enable_tower_connector_lora=True), True),
+    ):
+        model_config = SimpleNamespace(
+            dtype=torch.bfloat16,
+            hf_config=SimpleNamespace(
+                vision_config=SimpleNamespace(),
+                audio_config=None,
+                text_config=SimpleNamespace(
+                    hidden_size_per_layer_input=None,
+                    use_bidirectional_attention=None,
+                ),
+            ),
+            multimodal_config=SimpleNamespace(),
+            try_get_generation_config=lambda: None,
+        )
+        vllm_config = SimpleNamespace(
+            model_config=model_config,
+            quant_config=None,
+            lora_config=lora_config,
+        )
+
+        with (
+            patch.object(
+                AscendGemma4ForConditionalGeneration,
+                "_mark_tower_model",
+                return_value=nullcontext(),
+            ),
+            patch.object(
+                AscendGemma4ForConditionalGeneration,
+                "_mark_language_model",
+                return_value=nullcontext(),
+            ),
+            patch(
+                "vllm_ascend.models.gemma4_mm.AutoModel.from_config",
+                return_value=vision_tower,
+            ),
+            patch("vllm_ascend.models.gemma4_mm.Gemma4MultimodalEmbedder"),
+            patch("vllm_ascend.models.gemma4_mm.recursive_replace_linear"),
+            patch(
+                "vllm_ascend.models.gemma4_mm.init_vllm_registered_model",
+                return_value=language_model,
+            ),
+        ):
+            model = AscendGemma4ForConditionalGeneration(vllm_config=vllm_config)
+
+        assert model._enable_mm_lora is expected
 
 
 def test_mxfp4_vit_linear_registers_and_loads_weight_scale():

--- a/vllm_ascend/models/gemma4_mm.py
+++ b/vllm_ascend/models/gemma4_mm.py
@@ -80,6 +80,12 @@ class AscendGemma4ForConditionalGeneration(Gemma4ForConditionalGeneration):
         self.model_dtype = vllm_config.model_config.dtype
         self.vllm_config = vllm_config
 
+        # Keep consistent with Gemma4ForConditionalGeneration.
+        # _process_image_input accesses self._enable_mm_lora for multimodal LoRA handling.
+        # Initialize the attribute here to prevent AttributeError when processing image inputs.
+        lora_config = vllm_config.lora_config
+        self._enable_mm_lora = bool(lora_config is not None and lora_config.enable_tower_connector_lora)
+
         with self._mark_tower_model(vllm_config, {"image", "video"}):
             self.vision_tower = AutoModel.from_config(config=config.vision_config)
             self.embed_vision = Gemma4MultimodalEmbedder(


### PR DESCRIPTION
### What this PR does / why we need it?

This PR initializes `_enable_mm_lora` in `AscendGemma4ForConditionalGeneration`.

The Ascend Gemma4 multimodal implementation overrides the upstream model initialization to support quantized vision tower adaptation. Since the parent initializer is not called, the `_enable_mm_lora` attribute is not initialized.

During multimodal inference (e.g. MMMU-Pro evaluation), the runtime accesses this attribute, which may cause runtime failures.

This patch adds:

`self._enable_mm_lora = False`

to keep the default behavior when multimodal LoRA is disabled and align with the upstream initialization logic.

---

### Does this PR introduce any user-facing change?

No.

This change only fixes the internal initialization of the Gemma4 multimodal model. It does not introduce any API, interface, or behavior changes for users.

---

### How was this patch tested?

Tested with:

- Gemma4 multimodal model serving with vLLM-Ascend.
- MMMU-Pro evaluation through EvalScope.

The model can successfully initialize and run multimodal inference after this patch.

- vLLM main: https://github.com/vllm-project/vllm/commit/e6bfe03ad73a3330cb427885aa90d97a12e1c704
