### PR TITLE
[Feature][MRV2] sfa support dcp +pcp

### DIFF
--- a/.github/workflows/scripts/test_config.yaml
+++ b/.github/workflows/scripts/test_config.yaml
@@ -72,8 +72,6 @@ skip_tests:
   - tests/e2e/pull_request/four_card/model_runner_v2/test_deepseek_v4.py
   # Temporarily skipped: this test is currently broken
   - tests/e2e/pull_request/four_card/spec_decode/test_mtp_step3p5.py
-  # The use case is unstable and temporarily taken offline
-  - tests/e2e/pull_request/four_card/context_parallel/test_accuracy_v2.py
 
 # === Accuracy Tests ===
 # The accuracy tests. When at least one of these files is selected,

--- a/.github/workflows/scripts/test_config.yaml
+++ b/.github/workflows/scripts/test_config.yaml
@@ -89,6 +89,7 @@ accuracy_tests:
   - tests/e2e/pull_request/four_card/test_graph_mode.py
   - tests/e2e/pull_request/four_card/test_pipeline_parallel.py
   - tests/e2e/pull_request/four_card/context_parallel/test_accuracy.py
+  - tests/e2e/pull_request/four_card/context_parallel/test_accuracy_v2.py
   - tests/e2e/pull_request/four_card/context_parallel/test_deepseek_v4.py
   - tests/e2e/pull_request/four_card/model_runner_v2/test_deepseek_v4.py
   - tests/e2e/pull_request/four_card/spec_decode/test_dspark_deepseekv4.py

--- a/tests/e2e/pull_request/four_card/context_parallel/test_accuracy_v2.py
+++ b/tests/e2e/pull_request/four_card/context_parallel/test_accuracy_v2.py
@@ -148,34 +148,6 @@ def _run_accuracy_case(case: AccuracyCase) -> None:
             raise AssertionError(f"Output did not match any of the expected output sets:\n{failure_details}")
 
 
-DSV3_2_SFA_DCP_CASE = AccuracyCase(
-    name="dsv3_2_sfa_dcp_replicated_indexer_mrv2_tp2_dcp2",
-    model=DSV3_2_MODEL,
-    prompts=DSV3_2_PROMPTS,
-    expected_outputs=DSV3_2_SFA_DCP_GOLDENS,
-    max_tokens=5,
-    runner_kwargs={
-        "max_model_len": 1024,
-        "max_num_seqs": MAX_NUM_SEQS,
-        "max_num_batched_tokens": 1024,
-        "tensor_parallel_size": 2,
-        "decode_context_parallel_size": 2,
-        "enable_expert_parallel": True,
-        "gpu_memory_utilization": 0.4,
-        "block_size": 128,
-        "quantization": "ascend",
-        "compilation_config": FULL_DECODE_GRAPH,
-        "additional_config": {
-            "enable_dsa_cp": False,
-            "enable_sparse_li_c8": False,
-        },
-        "speculative_config": {
-            "method": "mtp",
-            "num_speculative_tokens": 3,
-        },
-    },
-)
-
 DSV3_2_SFA_PCP_CASE = AccuracyCase(
     name="dsv3_2_sfa_pcp_mrv2_full_decode_only",
     model=DSV3_2_MODEL,
@@ -199,20 +171,33 @@ DSV3_2_SFA_PCP_CASE = AccuracyCase(
     },
 )
 
-
-@patch.dict(
-    os.environ,
-    {
-        "VLLM_USE_V2_MODEL_RUNNER": "1",
-        "VLLM_BATCH_INVARIANT": "1",
-        "HCCL_BUFFSIZE": "768",
-        "PYTORCH_NPU_ALLOC_CONF": "expandable_segments:True",
+DSV3_2_SFA_PCP_DCP_CASE = AccuracyCase(
+    name="dsv3_2_sfa_pcp_dcp_replicated_indexer_mrv2_tp2_pcp2_dcp4",
+    model=DSV3_2_MODEL,
+    prompts=DSV3_2_PROMPTS,
+    expected_outputs=DSV3_2_SFA_DCP_GOLDENS,
+    max_tokens=5,
+    runner_kwargs={
+        "max_model_len": 1024,
+        "max_num_seqs": MAX_NUM_SEQS,
+        "max_num_batched_tokens": 1024,
+        "tensor_parallel_size": 2,
+        "prefill_context_parallel_size": 2,
+        "decode_context_parallel_size": 4,
+        "enable_expert_parallel": True,
+        "enable_chunked_prefill": True,
+        "enable_prefix_caching": True,
+        "gpu_memory_utilization": 0.8,
+        "cp_kv_cache_interleave_size": 128,
+        "block_size": 128,
+        "quantization": "ascend",
+        "compilation_config": FULL_DECODE_GRAPH,
+        "additional_config": {
+            "enable_dsa_cp": False,
+            "enable_sparse_li_c8": False,
+        },
     },
 )
-@wait_until_npu_memory_free(target_free_percentage=0.8)
-def test_dsv3_2_sfa_dcp_tp2_dcp2_model_runner_v2_accuracy() -> None:
-    """Guard MRV2 accuracy."""
-    _run_accuracy_case(DSV3_2_SFA_DCP_CASE)
 
 
 @pytest.mark.e2e_model(DSV3_2_MODEL)
@@ -239,6 +224,32 @@ def test_dsv3_2_sfa_dcp_tp2_dcp2_model_runner_v2_accuracy() -> None:
 def test_dsv3_2_sfa_pcp_model_runner_v2_graph_accuracy() -> None:
     """Guard MRV2 SFA PCP full-decode-only graph accuracy."""
     _run_accuracy_case(DSV3_2_SFA_PCP_CASE)
+
+
+@pytest.mark.e2e_model(DSV3_2_MODEL)
+@pytest.mark.e2e_coverage(
+    arch="moe",
+    feature="sfa_pcp",
+    parallel="TP,EP,PCP,DCP",
+    deploy="pd_mix",
+    hardware="A3",
+    quantization="W8A8",
+    graph_mode="full_decode_only",
+)
+@patch.dict(
+    os.environ,
+    {
+        "VLLM_USE_V2_MODEL_RUNNER": "1",
+        "VLLM_BATCH_INVARIANT": "1",
+        "VLLM_WORKER_MULTIPROC_METHOD": "spawn",
+        "HCCL_BUFFSIZE": "768",
+        "PYTORCH_NPU_ALLOC_CONF": "expandable_segments:True",
+    },
+)
+@wait_until_npu_memory_free(target_free_percentage=0.8)
+def test_dsv3_2_sfa_pcp_dcp_model_runner_v2_graph_accuracy() -> None:
+    """Guard MRV2 SFA PCP+DCP full-decode-only graph accuracy."""
+    _run_accuracy_case(DSV3_2_SFA_PCP_DCP_CASE)
 
 
 def _run_pcp_spec_decode(

--- a/tests/ut/attention/test_dsa_v1.py
+++ b/tests/ut/attention/test_dsa_v1.py
@@ -1723,6 +1723,8 @@ def test_pcp_metadata_builds_from_manager_global_view():
     )
     pcp_manager._global_batch_slot_mappings = global_slot_mappings
     pcp_manager._hidden_restore_idx = hidden_restore_idx
+    pcp_manager._padded_gather_idx = None
+    pcp_manager._gathered_kv_write_mask = None
     pcp_context = pcp_manager.build_attention_context()
     global_metadata = AscendDSAMetadata(
         num_actual_tokens=5,

--- a/tests/ut/attention/test_sfa_cp.py
+++ b/tests/ut/attention/test_sfa_cp.py
@@ -2,7 +2,7 @@
 
 from dataclasses import fields
 from types import SimpleNamespace
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock, Mock, patch
 
 import torch
 
@@ -18,6 +18,8 @@ from vllm_ascend.attention.context_parallel.sfa_cp import (
     AscendSFADSADCPImpl,
     AscendSFADSADCPMetadata,
     AscendSFADSADCPMetadataBuilder,
+    AscendSFAPCPDCPImpl,
+    AscendSFAPCPDCPMetadataBuilder,
     AscendSFAPCPImpl,
     resolve_sfa_impl,
     resolve_sfa_metadata_builder,
@@ -142,6 +144,145 @@ def test_sfa_pcp_resolution_for_mrv2_config() -> None:
         ),
     ):
         assert resolve_sfa_impl(vllm_config) is AscendSFAPCPImpl
+
+
+def test_sfa_pcp_dcp_builds_pcp_ordered_indexer_slots_with_receiver_local_blocks() -> None:
+    builder = AscendSFAPCPDCPMetadataBuilder.__new__(AscendSFAPCPDCPMetadataBuilder)
+    builder.pcp_indexer_slot_mapping_buf = torch.empty(8, dtype=torch.int32)
+    local_block_table = torch.tensor([[11, 12]], dtype=torch.int32)
+    replicated_block_table = torch.tensor([[22, 23, 24, 25]], dtype=torch.int32)
+    global_slot_mapping = torch.tensor([100, 101, 102], dtype=torch.int32)
+    builder._get_dcp_local_block_table = Mock(return_value=local_block_table)
+    builder._build_block_table_replicated_view = Mock(return_value=replicated_block_table)
+    builder._build_slot_mapping_replicated_view = Mock(return_value=global_slot_mapping)
+    global_batch = SimpleNamespace(
+        num_reqs=1,
+        num_tokens=3,
+        query_start_loc=torch.tensor([0, 3], dtype=torch.int32),
+        seq_lens=torch.tensor([3], dtype=torch.int32),
+        positions=torch.tensor([0, 1, 2], dtype=torch.int32),
+    )
+    pcp_context = SimpleNamespace(
+        global_batch=global_batch,
+        global_block_tables=(local_block_table,),
+        padded_gather_idx=torch.tensor([2, 0, 1, 0], dtype=torch.int64),
+        gathered_kv_write_mask=torch.tensor([True, True, True, False]),
+    )
+    global_common = SimpleNamespace(seq_lens=global_batch.seq_lens)
+    common_attn_metadata = SimpleNamespace(
+        replace=Mock(return_value=global_common),
+    )
+
+    result = builder._build_pcp_ordered_indexer_slot_mapping(
+        common_attn_metadata,
+        pcp_context,
+        0,
+    )
+
+    torch.testing.assert_close(
+        result,
+        torch.tensor([102, 100, 101, -1], dtype=torch.int32),
+    )
+    common_attn_metadata.replace.assert_called_once_with(
+        query_start_loc=global_batch.query_start_loc,
+        seq_lens=global_batch.seq_lens,
+        num_reqs=1,
+        num_actual_tokens=3,
+        num_input_tokens=3,
+        positions=global_batch.positions,
+        block_table_tensor=local_block_table,
+    )
+    builder._get_dcp_local_block_table.assert_called_once_with(
+        local_block_table,
+        1,
+    )
+    builder._build_block_table_replicated_view.assert_called_once_with(
+        local_block_table,
+        global_batch.seq_lens,
+    )
+
+
+def test_sfa_dcp_compact_kv_table_uses_logical_dcp_rank_order() -> None:
+    builder = AscendSFADCPMetadataBuilder.__new__(AscendSFADCPMetadataBuilder)
+    builder.dcp_size = 8
+    builder.dcp_collective_rank_order = torch.tensor(
+        [0, 4, 1, 5, 2, 6, 3, 7],
+        dtype=torch.int32,
+    )
+    dcp_block_table = torch.tensor([[5, 9]], dtype=torch.int32)
+
+    valid_block_ids, block_table = builder._build_compact_kv_gather_metadata(dcp_block_table)
+
+    torch.testing.assert_close(
+        valid_block_ids,
+        torch.tensor([5, 9], dtype=torch.int32),
+    )
+    torch.testing.assert_close(
+        block_table,
+        torch.tensor(
+            [[0, 8, 2, 10, 4, 12, 6, 14, 1, 9, 3, 11, 5, 13, 7, 15]],
+            dtype=torch.int32,
+        ),
+    )
+
+
+def test_sfa_pcp_dcp_builder_allows_decode_graph_metadata_without_pcp_context() -> None:
+    builder = AscendSFAPCPDCPMetadataBuilder.__new__(AscendSFAPCPDCPMetadataBuilder)
+    common_attn_metadata = SimpleNamespace()
+    expected = object()
+
+    with patch.object(
+        AscendSFADCPMetadataBuilder,
+        "build",
+        autospec=True,
+        return_value=expected,
+    ) as dcp_build:
+        result = builder.build(0, common_attn_metadata)
+
+    assert result is expected
+    dcp_build.assert_called_once_with(builder, 0, common_attn_metadata, False)
+
+
+def test_sfa_pcp_dcp_only_overrides_main_cache_slot_mapping() -> None:
+    impl = AscendSFAPCPDCPImpl.__new__(AscendSFAPCPDCPImpl)
+    attn_metadata = AscendSFADCPMetadata.__new__(AscendSFADCPMetadata)
+    attn_metadata.num_prefills = 1
+    attn_metadata.num_decode_tokens = 0
+    attn_metadata.num_input_tokens = 2
+    main_slots = torch.tensor([10, 11, 12, 13], dtype=torch.int64)
+    attn_metadata.dcp_context = SimpleNamespace(
+        slot_mapping=main_slots,
+    )
+    kv_no_split = torch.zeros(2, 3)
+    cos = torch.zeros(2, 1)
+    sin = torch.zeros(2, 1)
+    kv_cache = (torch.empty(1), torch.empty(1))
+
+    with patch.object(
+        AscendSFAPCPImpl,
+        "exec_kv",
+        autospec=True,
+        return_value="written",
+    ) as pcp_exec_kv:
+        result = impl.exec_kv(
+            kv_no_split,
+            cos,
+            sin,
+            kv_cache,
+            torch.tensor([-1, -1]),
+            attn_metadata,
+        )
+
+    assert result == "written"
+    pcp_exec_kv.assert_called_once_with(
+        impl,
+        kv_no_split,
+        cos,
+        sin,
+        kv_cache,
+        main_slots,
+        attn_metadata,
+    )
 
 
 def test_sfa_pcp_gathers_main_kv_before_base_cache_write() -> None:
@@ -348,25 +489,43 @@ def test_sfa_dcp_builder_sizes_replicated_view_from_padded_block_table() -> None
         self.kernel_block_size = 128
 
     kv_cache_spec = SimpleNamespace(block_size=128)
-    vllm_config = SimpleNamespace(
-        parallel_config=SimpleNamespace(cp_kv_cache_interleave_size=1),
-        scheduler_config=SimpleNamespace(
-            max_num_seqs=4,
-            max_num_batched_tokens=1024,
-        ),
-        model_config=SimpleNamespace(max_model_len=1024),
-    )
-
-    with patch.object(DCPMetadataBuilderMixin, "__init__", new=fake_base_init):
-        builder = AscendSFADCPMetadataBuilder(
-            kv_cache_spec,
-            [],
-            vllm_config,
-            torch.device("cpu"),
+    for pcp_size, expected_num_reqs in ((1, 5), (2, 9)):
+        vllm_config = SimpleNamespace(
+            parallel_config=SimpleNamespace(
+                cp_kv_cache_interleave_size=1,
+                prefill_context_parallel_size=pcp_size,
+            ),
+            scheduler_config=SimpleNamespace(
+                max_num_seqs=4,
+                max_num_batched_tokens=1024,
+            ),
+            model_config=SimpleNamespace(max_model_len=1024),
         )
 
-    assert builder.block_table_replicated_view_buf.shape == (5, 8)
-    assert builder.arange_buffer.shape == (8,)
+        with (
+            patch.object(
+                DCPMetadataBuilderMixin,
+                "__init__",
+                new=fake_base_init,
+            ),
+            patch(
+                "vllm_ascend.attention.context_parallel.sfa_cp.get_dcp_group",
+                return_value=SimpleNamespace(ranks=[0, 1]),
+            ),
+        ):
+            builder = AscendSFADCPMetadataBuilder(
+                kv_cache_spec,
+                [],
+                vllm_config,
+                torch.device("cpu"),
+            )
+
+        assert builder.dcp_local_seq_lens_buf.shape == (expected_num_reqs,)
+        assert builder.block_table_replicated_view_buf.shape == (
+            expected_num_reqs,
+            8,
+        )
+        assert builder.arange_buffer.shape == (8,)
 
 
 def _make_builder(rank: int = 0) -> AscendSFADCPMetadataBuilder:

--- a/tests/ut/test_platform.py
+++ b/tests/ut/test_platform.py
@@ -1783,6 +1783,32 @@ class TestNPUPlatform(TestBase):
         with self.assertRaisesRegex(NotImplementedError, "does not support PCP and DCP simultaneously"):
             self.platform.get_attn_backend_cls("ascend", attn_selector_config)
 
+    def test_get_attn_backend_cls_selects_sfa_pcp_dcp_backend(self):
+        if vllm_version_is("0.28.0"):
+            attn_selector_config = SimpleNamespace(
+                dtype=torch.float16,
+                head_size=0,
+                kv_cache_dtype=None,
+                block_size=128,
+                use_mla=True,
+                use_sparse=True,
+                use_pcp=True,
+                use_dcp=True,
+            )
+        else:
+            attn_selector_config = AttentionSelectorConfig(
+                dtype=torch.float16,
+                head_size=0,
+                kv_cache_dtype=None,
+                block_size=128,
+                use_mla=True,
+                use_sparse=True,
+                use_pcp=True,
+                use_dcp=True,
+            )
+        result = self.platform.get_attn_backend_cls("ascend", attn_selector_config)
+        self.assertEqual(result, "vllm_ascend.attention.sfa_v1.AscendSFABackend")
+
     def test_get_attn_backend_cls_supports_legacy_config_without_use_dcp(self):
         attn_selector_config = SimpleNamespace(
             use_mla=True,

--- a/tests/ut/test_platform.py
+++ b/tests/ut/test_platform.py
@@ -1759,56 +1759,6 @@ class TestNPUPlatform(TestBase):
                 result = self.platform.get_attn_backend_cls("ascend", attn_selector_config)
                 self.assertEqual(result, expected_backend)
 
-    def test_get_attn_backend_cls_rejects_pcp_and_dcp(self):
-        if vllm_version_is("0.28.0"):
-            attn_selector_config = SimpleNamespace(
-                dtype=torch.float16,
-                head_size=0,
-                kv_cache_dtype=None,
-                block_size=128,
-                use_pcp=True,
-                use_dcp=True,
-                use_mla=False,
-                use_sparse=False,
-            )
-        else:
-            attn_selector_config = AttentionSelectorConfig(
-                dtype=torch.float16,
-                head_size=0,
-                kv_cache_dtype=None,
-                block_size=128,
-                use_pcp=True,
-                use_dcp=True,
-            )
-        with self.assertRaisesRegex(NotImplementedError, "does not support PCP and DCP simultaneously"):
-            self.platform.get_attn_backend_cls("ascend", attn_selector_config)
-
-    def test_get_attn_backend_cls_selects_sfa_pcp_dcp_backend(self):
-        if vllm_version_is("0.28.0"):
-            attn_selector_config = SimpleNamespace(
-                dtype=torch.float16,
-                head_size=0,
-                kv_cache_dtype=None,
-                block_size=128,
-                use_mla=True,
-                use_sparse=True,
-                use_pcp=True,
-                use_dcp=True,
-            )
-        else:
-            attn_selector_config = AttentionSelectorConfig(
-                dtype=torch.float16,
-                head_size=0,
-                kv_cache_dtype=None,
-                block_size=128,
-                use_mla=True,
-                use_sparse=True,
-                use_pcp=True,
-                use_dcp=True,
-            )
-        result = self.platform.get_attn_backend_cls("ascend", attn_selector_config)
-        self.assertEqual(result, "vllm_ascend.attention.sfa_v1.AscendSFABackend")
-
     def test_get_attn_backend_cls_supports_legacy_config_without_use_dcp(self):
         attn_selector_config = SimpleNamespace(
             use_mla=True,

--- a/tests/ut/worker/test_attn_utils_v2.py
+++ b/tests/ut/worker/test_attn_utils_v2.py
@@ -754,20 +754,34 @@ def test_mrv2_builds_shared_dsa_metadata_for_each_execution_mode(
 
 
 class _PrefillStateBuilder:
-    def build(self, common_prefix_len, common_attn_metadata):
+    def __init__(self):
+        self.extra_kwargs = None
+
+    def build(self, common_prefix_len, common_attn_metadata, **kwargs):
         assert common_prefix_len == 0
+        self.extra_kwargs = kwargs
         return common_attn_metadata.is_prefilling
 
 
-def test_build_attn_metadata_propagates_prefill_state():
+class _CaptureStateBuilder(_PrefillStateBuilder):
+    def build_for_cudagraph_capture(self, common_attn_metadata, **kwargs):
+        self.extra_kwargs = kwargs
+        return common_attn_metadata.is_prefilling
+
+
+@pytest.mark.parametrize("for_cudagraph_capture", [False, True])
+def test_build_attn_metadata_propagates_prefill_and_pcp_context(monkeypatch, for_cudagraph_capture):
+    monkeypatch.setattr(attn_utils, "AscendSFAMetadataBuilder", _PrefillStateBuilder)
+    builder = _CaptureStateBuilder() if for_cudagraph_capture else _PrefillStateBuilder()
     attn_group = SimpleNamespace(
         layer_names=["layer.0"],
-        get_metadata_builder=lambda _: _PrefillStateBuilder(),
+        get_metadata_builder=lambda _: builder,
     )
     kv_cache_config = SimpleNamespace(
         kv_cache_groups=[SimpleNamespace(kv_cache_spec=object())],
     )
     is_prefilling = torch.tensor([True])
+    pcp_context = object()
 
     metadata = attn_utils.build_attn_metadata(
         attn_groups=[[attn_group]],
@@ -782,8 +796,14 @@ def test_build_attn_metadata_propagates_prefill_state():
         slot_mappings=(torch.zeros(1, dtype=torch.int64),),
         kv_cache_config=kv_cache_config,
         is_prefilling=is_prefilling,
+        pcp_context=pcp_context,
         seq_lens_np=np.array([1], dtype=np.int32),
         positions=torch.tensor([0], dtype=torch.int64),
+        for_cudagraph_capture=for_cudagraph_capture,
     )
 
     assert metadata["layer.0"] is is_prefilling
+    assert builder.extra_kwargs == {
+        "pcp_context": pcp_context,
+        "pcp_cache_group_idx": 0,
+    }

--- a/tests/ut/worker/test_pcp_manager_v2.py
+++ b/tests/ut/worker/test_pcp_manager_v2.py
@@ -933,7 +933,7 @@ def test_sample_tokens_uses_global_batch_only_on_non_last_pp_rank(
 
 def test_partition_batch_clears_padded_dcp_local_seq_lens() -> None:
     manager = AscendPCPManager.__new__(AscendPCPManager)
-    manager.vllm_config = object()
+    manager.vllm_config = _make_pcp_config(CUDAGraphMode.FULL_DECODE_ONLY)
     manager._input_buffers = AscendInputBuffers(
         max_num_reqs=8,
         max_num_tokens=16,

--- a/tests/ut/worker/test_pcp_manager_v2.py
+++ b/tests/ut/worker/test_pcp_manager_v2.py
@@ -461,6 +461,8 @@ def test_attention_context_collects_global_pcp_data():
     manager._global_batch_slot_mappings = global_slot_mappings
     hidden_restore_idx = torch.arange(input_batch.num_tokens, dtype=torch.int64)
     manager._hidden_restore_idx = hidden_restore_idx
+    manager._padded_gather_idx = None
+    manager._gathered_kv_write_mask = None
 
     actual = manager.build_attention_context()
 
@@ -927,3 +929,54 @@ def test_sample_tokens_uses_global_batch_only_on_non_last_pp_rank(
     assert runner.execute_model_state.input_batch is expected_batch
     assert actual_output is expected_output
     parent_sample_tokens.assert_called_once_with(grammar_output)
+
+
+def test_partition_batch_clears_padded_dcp_local_seq_lens() -> None:
+    manager = AscendPCPManager.__new__(AscendPCPManager)
+    manager.vllm_config = object()
+    manager._input_buffers = AscendInputBuffers(
+        max_num_reqs=8,
+        max_num_tokens=16,
+        device=torch.device("cpu"),
+    )
+    manager._input_buffers.dcp_local_seq_lens.fill_(777)
+    manager._input_buffers.dcp_local_seq_lens[:2].copy_(torch.tensor([4, 5], dtype=torch.int32))
+    manager._hidden_restore_idx = torch.arange(8, dtype=torch.int64)
+
+    local_batch = _make_local_pcp_batch()
+    local_batch.num_reqs = 2
+    local_batch.num_tokens = 6
+    local_batch.num_tokens_after_padding = 6
+    local_batch.is_prefilling_np = np.array([False, False])
+    local_batch.dcp_local_seq_lens = manager._input_buffers.dcp_local_seq_lens[:2]
+    global_batch = SimpleNamespace(
+        num_draft_tokens=0,
+        num_tokens=6,
+        num_tokens_after_padding=8,
+        num_reqs_after_padding=8,
+        query_start_loc_np=np.array([0, 1, 2, 2, 2, 2, 2, 2, 2], dtype=np.int32),
+        is_prefilling_np=np.array([False, False]),
+    )
+
+    with (
+        patch.object(
+            vllm_model_runner.pcp.PCPManager,
+            "partition_batch",
+            return_value=local_batch,
+        ),
+        patch(
+            "vllm_ascend.worker.v2.pcp_manager.build_attn_state",
+            return_value=object(),
+        ),
+        patch(
+            "vllm_ascend.worker.v2.pcp_manager.async_copy_to_gpu",
+            side_effect=_mock_async_copy_to_cpu,
+        ),
+    ):
+        result = manager.partition_batch(global_batch)
+
+    assert result.dcp_local_seq_lens is not None
+    torch.testing.assert_close(
+        result.dcp_local_seq_lens,
+        torch.tensor([4, 5, 0, 0, 0, 0, 0, 0], dtype=torch.int32),
+    )

--- a/vllm_ascend/attention/context_parallel/sfa_cp.py
+++ b/vllm_ascend/attention/context_parallel/sfa_cp.py
@@ -1,12 +1,12 @@
 from collections.abc import Callable
 from dataclasses import dataclass
-from typing import Any, NamedTuple, TypeVar
+from typing import Any, NamedTuple, TypeVar, cast
 
 import torch
 import torch_npu
 from torch import nn
 from vllm.config import VllmConfig
-from vllm.distributed import get_pcp_group, get_tp_group
+from vllm.distributed import get_dcp_group, get_pcp_group, get_tp_group
 from vllm.triton_utils import HAS_TRITON
 from vllm.utils.math_utils import cdiv
 from vllm.v1.kv_cache_interface import AttentionSpec
@@ -208,6 +208,8 @@ class DCPGatherContext(NamedTuple):
 
 @dataclass
 class DCPContext:
+    # Keep the complete main-cache mapping. Consumers that operate on the
+    # rank-local model input take a view of the required prefix.
     slot_mapping: torch.Tensor
     block_table: torch.Tensor
     seq_lens: torch.Tensor
@@ -633,8 +635,14 @@ class AscendSFADCPMetadataBuilder(
         if self.cp_kv_cache_interleave_size <= 0:
             raise RuntimeError(f"Invalid cp_kv_cache_interleave_size: {self.cp_kv_cache_interleave_size}")
 
-        # Full-graph FIA padding can append one dummy request.
-        max_num_reqs = vllm_config.scheduler_config.max_num_seqs + 1
+        # PCP represents each prefill with two local DualChunkSwap segments,
+        # while decode requests remain one local row. A mixed batch can
+        # therefore require up to twice max_num_seqs rows on each PCP rank.
+        # Full-graph FIA padding can append one additional dummy request.
+        max_num_reqs = vllm_config.scheduler_config.max_num_seqs
+        if vllm_config.parallel_config.prefill_context_parallel_size > 1:
+            max_num_reqs *= 2
+        max_num_reqs += 1
         self.dcp_local_seq_lens_buf = torch.empty(
             max_num_reqs,
             dtype=torch.int32,
@@ -664,6 +672,22 @@ class AscendSFADCPMetadataBuilder(
         )
         self.arange_buffer: torch.Tensor = torch.arange(
             max_replicated_block_table_cols,
+            dtype=torch.int32,
+            device=device,
+        )
+        dcp_group = get_dcp_group()
+        collective_ranks = sorted(dcp_group.ranks)
+        # ``dcp_group.ranks`` is in logical PCP-first DCP order, but
+        # ``torch.distributed.new_group`` sorts its global ranks and AllGather
+        # writes payload segments in that ProcessGroup order. For example,
+        # with PCP=2, TP=4, and DCP=8:
+        #   logical DCP ranks:       [0, 4, 1, 5, 2, 6, 3, 7]
+        #   AllGather segment ranks: [0, 1, 2, 3, 4, 5, 6, 7]
+        # Logical DCP rank positions therefore address gathered segments
+        # [0, 4, 1, 5, 2, 6, 3, 7]. Store this permutation for block-table
+        # offsets so the large gathered KV tensor can stay in HCCL order.
+        self.dcp_collective_rank_order = torch.tensor(
+            [collective_ranks.index(rank) for rank in dcp_group.ranks],
             dtype=torch.int32,
             device=device,
         )
@@ -800,9 +824,10 @@ class AscendSFADCPMetadataBuilder(
         valid_block_ids, compact_block_table = dcp_block_table.flatten().unique(return_inverse=True)
         compact_block_table = compact_block_table.view_as(dcp_block_table)
         num_blocks = valid_block_ids.shape[0]
-        dcp_rank_arange = self.arange_buffer[: self.dcp_size]
+        dcp_collective_rank_order = self.dcp_collective_rank_order[: self.dcp_size]
         remapped_block_table = (
-            compact_block_table.unsqueeze(-1) + (dcp_rank_arange * num_blocks).view(1, 1, -1).to(dcp_block_table)
+            compact_block_table.unsqueeze(-1)
+            + (dcp_collective_rank_order * num_blocks).view(1, 1, -1).to(dcp_block_table)
         ).reshape(dcp_block_table.shape[0], -1)
         return valid_block_ids, remapped_block_table.to(torch.int32)
 
@@ -855,7 +880,7 @@ class AscendSFADCPMetadataBuilder(
         if num_prefills > 0:
             kv_gather_block_ids, kv_gather_block_table = self._build_compact_kv_gather_metadata(dcp_block_table)
         metadata.dcp_context = DCPContext(
-            slot_mapping=dcp_slot_mapping[:num_input_tokens],
+            slot_mapping=dcp_slot_mapping,
             block_table=dcp_block_table,
             seq_lens=local_seq_lens,
             kv_gather_block_ids=kv_gather_block_ids,
@@ -886,6 +911,121 @@ class AscendSFADCPMetadataBuilder(
         )
         attn_metadata.attn_state = attn_state
         return attn_metadata
+
+
+class AscendSFAPCPDCPMetadataBuilder(AscendSFADCPMetadataBuilder):
+    """Adds PCP's main-cache token layout to the DCP metadata view."""
+
+    def __init__(
+        self,
+        kv_cache_spec: AttentionSpec,
+        layer_names: list[str],
+        vllm_config: VllmConfig,
+        device: torch.device,
+        metadata_cls: type[AscendSFAMetadata] | None = None,
+        supports_dcp_with_varlen: bool = False,
+    ):
+        super().__init__(
+            kv_cache_spec,
+            layer_names,
+            vllm_config,
+            device,
+            metadata_cls or AscendSFADCPMetadata,
+            supports_dcp_with_varlen,
+        )
+        pcp_size = vllm_config.parallel_config.prefill_context_parallel_size
+        max_num_input_tokens = vllm_config.scheduler_config.max_num_batched_tokens
+        self.pcp_indexer_slot_mapping_buf = torch.empty(
+            (max_num_input_tokens * pcp_size,),
+            dtype=torch.int32,
+            device=device,
+        )
+
+    def _build_pcp_ordered_indexer_slot_mapping(
+        self,
+        common_attn_metadata: AscendCommonAttentionMetadata,
+        pcp_context: Any,
+        pcp_cache_group_idx: int,
+    ) -> torch.Tensor:
+        """Build this receiver's Indexer addresses in PCP token order."""
+        global_batch = pcp_context.global_batch
+        num_reqs = global_batch.num_reqs
+        global_block_table = pcp_context.global_block_tables[pcp_cache_group_idx]
+        global_common_attn_metadata = cast(
+            AscendCommonAttentionMetadata,
+            common_attn_metadata.replace(
+                query_start_loc=global_batch.query_start_loc,
+                seq_lens=global_batch.seq_lens[:num_reqs],
+                num_reqs=num_reqs,
+                num_actual_tokens=global_batch.num_tokens,
+                num_input_tokens=global_batch.num_tokens,
+                positions=global_batch.positions,
+                block_table_tensor=global_block_table,
+            ),
+        )
+        dcp_block_table = self._get_dcp_local_block_table(
+            global_block_table,
+            num_reqs,
+        )
+        replicated_block_table = self._build_block_table_replicated_view(
+            dcp_block_table,
+            global_common_attn_metadata.seq_lens,
+        )
+        global_slot_mapping = self._build_slot_mapping_replicated_view(
+            global_common_attn_metadata,
+            replicated_block_table,
+        )
+
+        gather_idx = pcp_context.padded_gather_idx
+        write_mask = pcp_context.gathered_kv_write_mask
+        if gather_idx is None or write_mask is None:
+            raise RuntimeError("PCP+DCP prefill requires the PCP gathered-token layout.")
+        num_pcp_ordered_tokens = gather_idx.numel()
+        pcp_ordered_slot_mapping = self.pcp_indexer_slot_mapping_buf[:num_pcp_ordered_tokens]
+        torch.index_select(
+            global_slot_mapping,
+            0,
+            gather_idx,
+            out=pcp_ordered_slot_mapping,
+        )
+        pcp_ordered_slot_mapping.masked_fill_(~write_mask, -1)
+        return pcp_ordered_slot_mapping
+
+    def build(
+        self,
+        common_prefix_len: int,
+        common_attn_metadata: AscendCommonAttentionMetadata,
+        fast_build: bool = False,
+        pcp_context: Any | None = None,
+        pcp_cache_group_idx: int | None = None,
+        **kwargs,
+    ) -> AscendSFAMetadata:
+        if pcp_context is None:
+            # Decode-only graph capture builds dummy metadata without running
+            # PCP's prefill gather, so no PCP context is available or needed.
+            return super().build(
+                common_prefix_len,
+                common_attn_metadata,
+                fast_build,
+                **kwargs,
+            )
+        pcp_ordered_indexer_slot_mapping = None
+        if bool(pcp_context.global_batch.is_prefilling_np.any()):
+            if pcp_cache_group_idx is None:
+                raise RuntimeError("PCP+DCP prefill requires the PCP cache-group index.")
+            pcp_ordered_indexer_slot_mapping = self._build_pcp_ordered_indexer_slot_mapping(
+                common_attn_metadata, pcp_context, pcp_cache_group_idx
+            )
+        metadata = super().build(
+            common_prefix_len,
+            common_attn_metadata,
+            fast_build,
+            **kwargs,
+        )
+        assert isinstance(metadata, AscendSFADCPMetadata)
+        if pcp_ordered_indexer_slot_mapping is not None:
+            metadata.pcp_slot_mapping = pcp_ordered_indexer_slot_mapping
+        return metadata
 
 
 class AscendSFADCPImpl(DCPImplMixin, AscendSFAImpl):
@@ -1161,7 +1301,7 @@ class AscendSFADCPImpl(DCPImplMixin, AscendSFAImpl):
     ) -> torch.Tensor:
         assert isinstance(attn_metadata, AscendSFADCPMetadata)
         assert attn_metadata.dcp_context is not None
-        return attn_metadata.dcp_context.slot_mapping
+        return attn_metadata.dcp_context.slot_mapping[: attn_metadata.num_input_tokens]
 
     def _store_parallel_kv(
         self,
@@ -1285,6 +1425,32 @@ class AscendSFADCPImpl(DCPImplMixin, AscendSFAImpl):
         return output.to(output_dtype)
 
 
+class AscendSFAPCPDCPImpl(AscendSFADCPImpl, AscendSFAPCPImpl):
+    """Composes DCP attention with PCP gathered-token cache writes."""
+
+    def exec_kv(
+        self,
+        kv_no_split: torch.Tensor,
+        cos: torch.Tensor,
+        sin: torch.Tensor,
+        kv_cache: tuple,
+        slots: torch.Tensor,
+        attn_metadata: M,
+    ):
+        if self._has_prefill(attn_metadata):
+            assert isinstance(attn_metadata, AscendSFADCPMetadata)
+            assert attn_metadata.dcp_context is not None
+            slots = attn_metadata.dcp_context.slot_mapping
+        return super().exec_kv(
+            kv_no_split,
+            cos,
+            sin,
+            kv_cache,
+            slots,
+            attn_metadata,
+        )
+
+
 class AscendSFADSADCPMetadataBuilder(
     AscendSFADCPMetadataBuilder,
     AscendSFADSACPMetadataBuilder,
@@ -1314,29 +1480,37 @@ class AscendSFADSADCPImpl(AscendSFADCPImpl, AscendSFADSACPImpl):
     """Composes DCP collectives around the DSA-CP SFA implementation."""
 
 
-def resolve_sfa_metadata_builder() -> type[AscendSFAMetadataBuilder]:
-    """Resolve one SFA metadata builder from the two independent CP switches."""
+def resolve_sfa_metadata_builder(
+    vllm_config: VllmConfig | None = None,
+) -> type[AscendSFAMetadataBuilder]:
+    """Resolve one SFA metadata builder from the independent CP switches."""
     dsa_cp_enabled = enable_dsa_cp()
     dcp_enabled = enable_sfa_dcp_replicated_indexer()
+    pcp_enabled = vllm_config is not None and vllm_config.parallel_config.prefill_context_parallel_size > 1
     if dsa_cp_enabled and dcp_enabled:
         return AscendSFADSADCPMetadataBuilder
     if dsa_cp_enabled:
         return AscendSFADSACPMetadataBuilder
+    if pcp_enabled and dcp_enabled:
+        return AscendSFAPCPDCPMetadataBuilder
     if dcp_enabled:
         return AscendSFADCPMetadataBuilder
     return AscendSFAMetadataBuilder
 
 
 def resolve_sfa_impl(vllm_config: VllmConfig | None = None) -> type[AscendSFAImpl]:
-    """Resolve one SFA implementation from the two independent CP switches."""
+    """Resolve one SFA implementation from the independent CP switches."""
     dsa_cp_enabled = enable_dsa_cp()
     dcp_enabled = enable_sfa_dcp_replicated_indexer()
+    pcp_enabled = vllm_config is not None and vllm_config.parallel_config.prefill_context_parallel_size > 1
     if dsa_cp_enabled and dcp_enabled:
         return AscendSFADSADCPImpl
     if dsa_cp_enabled:
         return AscendSFADSACPImpl
+    if pcp_enabled and dcp_enabled:
+        return AscendSFAPCPDCPImpl
     if dcp_enabled:
         return AscendSFADCPImpl
-    if vllm_config is not None and vllm_config.parallel_config.prefill_context_parallel_size > 1:
+    if pcp_enabled:
         return AscendSFAPCPImpl
     return AscendSFAImpl

--- a/vllm_ascend/attention/context_parallel/sfa_cp.py
+++ b/vllm_ascend/attention/context_parallel/sfa_cp.py
@@ -1428,6 +1428,41 @@ class AscendSFADCPImpl(DCPImplMixin, AscendSFAImpl):
 class AscendSFAPCPDCPImpl(AscendSFADCPImpl, AscendSFAPCPImpl):
     """Composes DCP attention with PCP gathered-token cache writes."""
 
+    def _start_dcp_query_gather(
+        self,
+        ql_nope: torch.Tensor,
+        q_pe: torch.Tensor,
+    ) -> DCPGatherContext:
+        # Decode Q is replicated across PCP ranks. Only gather the distinct
+        # TP head shards inside this PCP partition, never the full DCP group.
+        # When DCP == PCP, each DCP group owns one TP shard already.
+        fused_q = torch.cat([ql_nope, q_pe], dim=-1).transpose(0, 1).contiguous()
+        if self.dcp_size == get_pcp_group().world_size:
+            gathered, handle = fused_q, None
+        else:
+            gathered, handle = all_gather_async(fused_q, get_tp_group())
+        return DCPGatherContext(
+            gathered=gathered,
+            handle=handle,
+            restore_perm=(1, 0, 2),
+            split_sizes=(ql_nope.shape[-1], q_pe.shape[-1]),
+        )
+
+    def _merge_dcp_outputs(
+        self,
+        sfa_output: torch.Tensor,
+        softmax_lse: torch.Tensor,
+        dsa_cp_context: DSACPContext | None = None,
+    ) -> torch.Tensor:
+        pcp_group = get_pcp_group()
+        tp_group = get_tp_group()
+        # Only scatter heads that were gathered by _start_dcp_query_gather.
+        # DCP == PCP already has TP-local heads; DCP == PCP * TP has full heads.
+        tp_size = tp_group.world_size if self.dcp_size > pcp_group.world_size else 1
+        return torch.ops.vllm.sfa_dcp_a2a_fused(
+            sfa_output, softmax_lse, tp_size, 1, tp_group.unique_name, pcp_group.unique_name
+        )
+
     def exec_kv(
         self,
         kv_no_split: torch.Tensor,

--- a/vllm_ascend/attention/sfa_v1.py
+++ b/vllm_ascend/attention/sfa_v1.py
@@ -111,7 +111,7 @@ class AscendSFABackend(AttentionBackend):
             return AscendSFAKVOffloadMetadataBuilder
         from vllm_ascend.attention.context_parallel.sfa_cp import resolve_sfa_metadata_builder
 
-        return resolve_sfa_metadata_builder()
+        return resolve_sfa_metadata_builder(get_current_vllm_config())
 
     @staticmethod
     def get_kv_cache_shape(
@@ -384,6 +384,17 @@ class AscendSFAMetadataBuilder(MLACommonMetadataBuilder[AscendSFAMetadata]):
             group_key_idx=common_attn_metadata.group_key_idx,
             group_key_cache_idx=common_attn_metadata.group_key_cache_idx,
             **parallel_metadata,
+        )
+
+    def build_for_cudagraph_capture(
+        self,
+        common_attn_metadata: AscendCommonAttentionMetadata,
+        **kwargs: Any,
+    ) -> AscendSFAMetadata:
+        return self.build(
+            common_prefix_len=0,
+            common_attn_metadata=common_attn_metadata,
+            **kwargs,
         )
 
     def build_for_graph_capture(

--- a/vllm_ascend/ops/triton/sfa_cp.py
+++ b/vllm_ascend/ops/triton/sfa_cp.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import torch
 import torch.distributed as dist
-from vllm.distributed.parallel_state import _groups
+from vllm.distributed.parallel_state import GroupCoordinator, _groups
 from vllm.triton_utils import tl, triton
 from vllm.utils.torch_utils import direct_register_custom_op
 
@@ -354,20 +354,38 @@ def fused_sfa_dcp_lse_combine(
 def sfa_dcp_a2a_fused_combine(
     sfa_output: torch.Tensor,
     softmax_lse: torch.Tensor,
-    dcp_size: int,
+    scatter_size: int,
     scatter_dim: int,
-    group: dist.ProcessGroup,
+    scatter_group: dist.ProcessGroup | None,
+    pcp_group: GroupCoordinator | None = None,
 ) -> torch.Tensor:
-    """Run stride-aware pack, one HCCL All2All, and fused LSE combine."""
+    """Pack, scatter over DCP or TP, optionally gather over PCP, then merge.
+
+    scatter_size is the All2All group size, not the unified DCP size when
+    stacking PCP and DCP. Use 1 when Q heads were not gathered over TP.
+    """
     send = pack_sfa_dcp_output_lse(
         sfa_output,
         softmax_lse,
-        dcp_size,
-        scatter_dim,
+        scatter_size,
+        scatter_dim=scatter_dim,
     )
-    recv = torch.empty_like(send)
-    dist.all_to_all_single(recv, send, group=group)
-    return fused_sfa_dcp_lse_combine(recv, sfa_output.shape[-1], scatter_dim)
+    if scatter_size > 1:
+        if scatter_group is None:
+            raise ValueError("SFA output scatter requires an explicit All2All group.")
+        recv = torch.empty_like(send)
+        dist.all_to_all_single(recv, send, group=scatter_group)
+    else:
+        recv = send
+
+    if pcp_group is not None:
+        # For head scatter, TP exchange gives [TP source, local H, T, packed D].
+        # PCP gathers the same TP head slice into [PCP * TP, local H, T, packed D].
+        # PCP2/TP4 thus supplies eight KV contributions per local head.
+        # O and LSE travel together, so the source-rank order is immaterial
+        # to their weighted sum; no logical-DCP permutation is needed here.
+        recv = pcp_group.all_gather(recv, dim=0)
+    return fused_sfa_dcp_lse_combine(recv, sfa_output.shape[-1], scatter_dim=scatter_dim)
 
 
 def sfa_dcp_a2a_fused(
@@ -376,24 +394,41 @@ def sfa_dcp_a2a_fused(
     dcp_size: int,
     scatter_dim: int,
     group_name: str,
+    pcp_group_name: str | None = None,
 ) -> torch.Tensor:
-    """Custom-op entry point for fused SFA DCP output post-processing."""
-    group_ref = _groups.get(group_name)
-    if group_ref is None:
-        raise RuntimeError(f"SFA DCP fused A2A group {group_name!r} is not registered.")
-    group = group_ref()
-    if group is None or group.device_group is None:
-        raise RuntimeError(f"SFA DCP fused A2A group {group_name!r} is unavailable.")
-    if group.world_size != dcp_size:
-        raise RuntimeError(
-            f"SFA DCP fused A2A group size does not match dcp_size: group={group.world_size}, dcp_size={dcp_size}."
-        )
+    """Fused SFA output merge, optionally gathering contributions across PCP.
+
+    Keep the original argument names for existing callers. With PCP enabled,
+    dcp_size/group_name describe the TP scatter group, not the unified DCP
+    group. A size of 1 skips scatter-group lookup and All2All.
+    """
+    scatter_group = None
+    if dcp_size > 1:
+        group_ref = _groups.get(group_name)
+        if group_ref is None:
+            raise RuntimeError(f"SFA DCP fused A2A group {group_name!r} is not registered.")
+        group = group_ref()
+        if group is None or group.device_group is None:
+            raise RuntimeError(f"SFA DCP fused A2A group {group_name!r} is unavailable.")
+        if group.world_size != dcp_size:
+            raise RuntimeError(
+                f"SFA DCP fused A2A group size does not match dcp_size: group={group.world_size}, dcp_size={dcp_size}."
+            )
+        scatter_group = group.device_group
+
+    pcp_group = None
+    if pcp_group_name is not None:
+        pcp_group_ref = _groups.get(pcp_group_name)
+        pcp_group = pcp_group_ref() if pcp_group_ref is not None else None
+        if pcp_group is None or pcp_group.device_group is None:
+            raise RuntimeError(f"SFA PCP+DCP group {pcp_group_name!r} is unavailable.")
     return sfa_dcp_a2a_fused_combine(
         sfa_output,
         softmax_lse,
         dcp_size,
         scatter_dim,
-        group.device_group,
+        scatter_group=scatter_group,
+        pcp_group=pcp_group,
     )
 
 
@@ -403,6 +438,7 @@ def sfa_dcp_a2a_fused_fake(
     dcp_size: int,
     scatter_dim: int,
     group_name: str,
+    pcp_group_name: str | None = None,
 ) -> torch.Tensor:
     """Propagate output metadata for torch.compile without running HCCL.
 
@@ -410,7 +446,7 @@ def sfa_dcp_a2a_fused_fake(
     operator. It must only describe the local output shape, dtype, and device;
     the real implementation performs the collective at execution time.
     """
-    del softmax_lse, group_name
+    del softmax_lse, group_name, pcp_group_name
     output_shape = list(sfa_output.shape)
     output_shape[scatter_dim] //= dcp_size
     return torch.empty(output_shape, dtype=sfa_output.dtype, device=sfa_output.device)

--- a/vllm_ascend/platform.py
+++ b/vllm_ascend/platform.py
@@ -240,9 +240,6 @@ class NPUPlatform(Platform):
         key = (use_mla, use_sparse)
         backend_key = (*key, use_compress)
 
-        if attn_selector_config.use_pcp and use_dcp and backend_key != (True, True, False):
-            raise NotImplementedError("Ascend MRV2 does not support PCP and DCP simultaneously yet.")
-
         if not attn_selector_config.use_pcp and _validate_fa3_backend(key, attn_selector_config):
             return "vllm_ascend.attention.fa3_v1.AscendFABackend"
 

--- a/vllm_ascend/platform.py
+++ b/vllm_ascend/platform.py
@@ -241,9 +241,6 @@ class NPUPlatform(Platform):
         key = (use_mla, use_sparse)
         backend_key = (*key, use_compress)
 
-        if attn_selector_config.use_pcp and use_dcp:
-            raise NotImplementedError("Ascend MRV2 does not support PCP and DCP simultaneously yet.")
-
         if not attn_selector_config.use_pcp and _validate_fa3_backend(key, attn_selector_config):
             return "vllm_ascend.attention.fa3_v1.AscendFABackend"
 
@@ -1519,10 +1516,15 @@ def _validate_parallel_config(vllm_config: VllmConfig) -> None:
 
     sfa_dcp_replicated_indexer = enable_sfa_dcp_replicated_indexer(vllm_config)
     if sfa_dcp_replicated_indexer:
-        if parallel_config.decode_context_parallel_size != parallel_config.tensor_parallel_size:
+        pcp_size = parallel_config.prefill_context_parallel_size
+        full_dcp_size = parallel_config.tensor_parallel_size * pcp_size
+        supported_dcp_sizes = {pcp_size, full_dcp_size}
+        if parallel_config.decode_context_parallel_size not in supported_dcp_sizes:
             raise AssertionError(
-                f"DCP for SFA is only supported when dcp_size({parallel_config.decode_context_parallel_size}) "
-                f"== tp_size({parallel_config.tensor_parallel_size})."
+                "DCP for SFA with replicated indexer is only supported when "
+                f"dcp_size({parallel_config.decode_context_parallel_size}) "
+                f"is pcp_size({pcp_size}) or tp_size({parallel_config.tensor_parallel_size}) "
+                f"* pcp_size({pcp_size}) ({full_dcp_size})."
             )
         if not get_current_hardware_profile().supports(HardwareCapability.SFA_DCP_REPLICATED_INDEXER):
             raise NotImplementedError(

--- a/vllm_ascend/platform.py
+++ b/vllm_ascend/platform.py
@@ -226,7 +226,6 @@ class NPUPlatform(Platform):
     @classmethod
     def get_attn_backend_cls(cls, selected_backend, attn_selector_config, num_heads: int | None = None):
         use_compress = getattr(attn_selector_config, "use_compress", False)
-        use_dcp = getattr(attn_selector_config, "use_dcp", False)
         use_mla = attn_selector_config.use_mla
         use_sparse = attn_selector_config.use_sparse
         # index_kpool GLM is not DeepSeek SFA; keep MLA backend.

--- a/vllm_ascend/platform.py
+++ b/vllm_ascend/platform.py
@@ -241,6 +241,9 @@ class NPUPlatform(Platform):
         key = (use_mla, use_sparse)
         backend_key = (*key, use_compress)
 
+        if attn_selector_config.use_pcp and use_dcp and backend_key != (True, True, False):
+            raise NotImplementedError("Ascend MRV2 does not support PCP and DCP simultaneously yet.")
+
         if not attn_selector_config.use_pcp and _validate_fa3_backend(key, attn_selector_config):
             return "vllm_ascend.attention.fa3_v1.AscendFABackend"
 

--- a/vllm_ascend/worker/v2/attn_utils.py
+++ b/vllm_ascend/worker/v2/attn_utils.py
@@ -45,6 +45,7 @@ from vllm.v1.worker.utils import AttentionGroup
 from vllm_ascend.ascend_config import get_ascend_config
 from vllm_ascend.attention.attention_v1 import AscendAttentionState
 from vllm_ascend.attention.dsa_v1 import AscendDSAMetadataBuilder
+from vllm_ascend.attention.sfa_v1 import AscendSFAMetadataBuilder
 from vllm_ascend.attention.utils import (
     AscendCommonAttentionMetadata,
     get_sfa_qsfa_packed_head_dim,
@@ -287,6 +288,7 @@ def build_attn_metadata(
         for attn_group in attn_groups[i]:
             attn_metadata_builder = attn_group.get_metadata_builder(0)
             is_dsa_builder = isinstance(attn_metadata_builder, AscendDSAMetadataBuilder)
+            is_sfa_builder = isinstance(attn_metadata_builder, AscendSFAMetadataBuilder)
             attn_metadata_extra_kwargs = (
                 model_specific_attn_metadata.get_extra_attn_kwargs(
                     attn_metadata_builder,
@@ -301,11 +303,12 @@ def build_attn_metadata(
                     num_actual_reqs=num_actual_reqs,
                     common_ratio_to_sas_metadata=common_ratio_to_sas_metadata,
                 )
-                if pcp_context is not None:
-                    attn_metadata_extra_kwargs.update(
-                        pcp_context=pcp_context,
-                        pcp_cache_group_idx=i,
-                    )
+            # Only SFA and DSA metadata builders consume PCP context.
+            if pcp_context is not None and (is_sfa_builder or is_dsa_builder):
+                attn_metadata_extra_kwargs.update(
+                    pcp_context=pcp_context,
+                    pcp_cache_group_idx=i,
+                )
 
             if for_cudagraph_capture:
                 metadata = attn_metadata_builder.build_for_cudagraph_capture(

--- a/vllm_ascend/worker/v2/pcp_manager.py
+++ b/vllm_ascend/worker/v2/pcp_manager.py
@@ -42,6 +42,8 @@ class AscendPCPAttentionContext:
     global_block_tables: tuple[torch.Tensor, ...]
     global_slot_mappings: torch.Tensor
     hidden_restore_idx: torch.Tensor
+    padded_gather_idx: torch.Tensor | None = None
+    gathered_kv_write_mask: torch.Tensor | None = None
 
 
 class AscendPCPManager(PCPManager):
@@ -272,6 +274,13 @@ class AscendPCPManager(PCPManager):
             # not initialize the corresponding hidden restore indices.
             assert self._hidden_restore_idx is not None
             self._hidden_restore_idx[global_batch.num_tokens : graph_num_tokens].zero_()
+            if local_batch.dcp_local_seq_lens is not None:
+                input_buffers.dcp_local_seq_lens[actual_reqs:graph_num_reqs].zero_()
+            dcp_local_seq_lens = (
+                input_buffers.dcp_local_seq_lens[:graph_num_reqs]
+                if local_batch.dcp_local_seq_lens is not None
+                else None
+            )
             seq_lens_cpu_upper_bound = torch.zeros(
                 graph_num_reqs,
                 dtype=local_batch.seq_lens_cpu_upper_bound.dtype,
@@ -285,6 +294,7 @@ class AscendPCPManager(PCPManager):
                 query_start_loc_np=graph_query_start_loc_np,
                 seq_lens=input_buffers.seq_lens[:graph_num_reqs],
                 seq_lens_cpu_upper_bound=seq_lens_cpu_upper_bound,
+                dcp_local_seq_lens=dcp_local_seq_lens,
                 input_ids=input_buffers.input_ids[:graph_num_tokens],
                 positions=input_buffers.positions[:graph_num_tokens],
                 is_padding=input_buffers.is_padding[:graph_num_tokens],
@@ -441,4 +451,6 @@ class AscendPCPManager(PCPManager):
             ),
             global_slot_mappings=self._global_batch_slot_mappings[:, : global_batch.num_tokens_after_padding],
             hidden_restore_idx=hidden_restore_idx,
+            padded_gather_idx=self._padded_gather_idx,
+            gathered_kv_write_mask=self._gathered_kv_write_mask,
         )


### PR DESCRIPTION
### What this PR does / why we need it?
Model Runner v2 SFA DCP adapted for PCP.

This PR enables combined PCP and DCP support for SFA in Model Runner V2.
The main changes include:
- Add AscendSFAPCPDCPMetadataBuilder and AscendSFAPCPDCPImpl for combined PCP and DCP execution.
- Adapt slot mappings and block tables for KV cache indexing under combined parallelism.
- Add PCPDCPContext and update AscendPCPManager to track gathered-token layouts.
- Update SFA metadata builder and implementation selection to dispatch to the combined execution path.
- Update parallel configuration validation to support PCP and DCP stacking.
- Extend unit tests for SFA context parallelism, configuration validation, backend selection, and PCP metadata management.

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?


- vLLM main: https://github.com/vllm-project/vllm/commit/b2f685834a6456197e7033966fdef52a23f1abcd
