### PR TITLE
[Bugfix][MRV2] Bound slot mapping block table staging

### DIFF
--- a/tests/e2e/nightly/single_node/ops/singlecard_ops/triton/test_compute_slot_mapping.py
+++ b/tests/e2e/nightly/single_node/ops/singlecard_ops/triton/test_compute_slot_mapping.py
@@ -12,6 +12,7 @@ from vllm_ascend.ops.triton.v2.block_table.compute_slot_mappings import (
     _compute_slot_mappings_kernel as ascend_compute_slot_mappings_kernel,
 )
 from vllm_ascend.worker.v2.block_table import (
+    _MAX_STAGED_BLOCK_TABLE_PAD_SIZE,
     AscendBlockTables,
 )
 
@@ -75,12 +76,72 @@ def test_compute_slot_mapping_npu_kernel_cp(cp_size: int, cp_rank: int, cp_inter
         cp_rank,
         **kernel_kwargs,
         BLOCK_TABLE_PAD_SIZE=triton.next_power_of_2(max(table.stride(0) for table in block_tables)),
+        USE_BLOCK_TABLE_STAGING=True,
     )
     ref_compute_slot_mappings_kernel[grid](
         *kernel_args,
         ref_slot_mappings,
         ref_slot_mappings.stride(0),
         cp_rank,
+        **kernel_kwargs,
+    )
+
+    torch.testing.assert_close(slot_mappings, ref_slot_mappings)
+
+
+@pytest.mark.parametrize(
+    ("block_table_width", "use_block_table_staging"),
+    [
+        pytest.param(_MAX_STAGED_BLOCK_TABLE_PAD_SIZE, True, id="staged-boundary"),
+        pytest.param(131072, False, id="long-row-direct-load"),
+    ],
+)
+def test_compute_slot_mapping_npu_kernel_long_block_table(
+    block_table_width: int, use_block_table_staging: bool
+) -> None:
+    """Long rows must compile without overflowing UB and match upstream."""
+    device = "npu"
+    max_num_tokens = 2048
+    idx_mapping = torch.tensor([1], dtype=torch.int32, device=device)
+    query_start_loc = torch.tensor([0, 1025], dtype=torch.int32, device=device)
+    positions = torch.arange(1025, dtype=torch.int64, device=device)
+    block_table = torch.arange(2 * block_table_width, dtype=torch.int32, device=device).reshape(2, block_table_width)
+    block_table_ptrs = torch.tensor([block_table.data_ptr()], dtype=torch.uint64, device=device)
+    block_table_strides = torch.tensor([block_table.stride(0)], dtype=torch.int64, device=device)
+    block_sizes = torch.tensor([64], dtype=torch.int32, device=device)
+    slot_mappings = torch.zeros((1, max_num_tokens), dtype=torch.int32, device=device)
+    ref_slot_mappings = torch.zeros_like(slot_mappings)
+    kernel_args = (
+        max_num_tokens,
+        idx_mapping,
+        query_start_loc,
+        positions,
+        block_table_ptrs,
+        block_table_strides,
+        block_sizes,
+    )
+    kernel_kwargs = {
+        "CP_SIZE": 1,
+        "CP_INTERLEAVE": 1,
+        "PAD_ID": -1,
+        "TRITON_BLOCK_SIZE": 1024,
+    }
+    grid = (1, 2)
+
+    ascend_compute_slot_mappings_kernel[grid](
+        *kernel_args,
+        slot_mappings,
+        slot_mappings.stride(0),
+        0,
+        **kernel_kwargs,
+        BLOCK_TABLE_PAD_SIZE=triton.next_power_of_2(block_table_width),
+        USE_BLOCK_TABLE_STAGING=use_block_table_staging,
+    )
+    ref_compute_slot_mappings_kernel[grid](
+        *kernel_args,
+        ref_slot_mappings,
+        ref_slot_mappings.stride(0),
+        0,
         **kernel_kwargs,
     )
 

--- a/vllm_ascend/ops/triton/v2/block_table/compute_slot_mappings.py
+++ b/vllm_ascend/ops/triton/v2/block_table/compute_slot_mappings.py
@@ -22,6 +22,7 @@ def _compute_slot_mappings_kernel(
     PAD_ID: tl.constexpr,
     TRITON_BLOCK_SIZE: tl.constexpr,
     BLOCK_TABLE_PAD_SIZE: tl.constexpr,
+    USE_BLOCK_TABLE_STAGING: tl.constexpr,
 ):
     group_id = tl.program_id(0)
     batch_idx = tl.program_id(1)
@@ -42,14 +43,17 @@ def _compute_slot_mappings_kernel(
     end_idx = tl.load(query_start_loc + batch_idx + 1)
 
     lane_offsets = tl.arange(0, TRITON_BLOCK_SIZE)
-    # BLOCK_TABLE_PAD_SIZE is a compile-time upper bound for every group's row.
-    # The runtime stride mask keeps loads within the current group's row.
-    block_table_offsets = tl.arange(0, BLOCK_TABLE_PAD_SIZE)
-    block_table_values = tl.load(
-        block_table_ptr + req_state_idx * block_table_stride + block_table_offsets,
-        mask=block_table_offsets < block_table_stride,
-        other=0,
-    ).to(tl.float32)
+    if USE_BLOCK_TABLE_STAGING:
+        # BLOCK_TABLE_PAD_SIZE is a compile-time upper bound for every group's
+        # row. The runtime stride mask keeps loads within the current group's
+        # row. Large rows deliberately skip this allocation because staging a
+        # complete fp32 row can exceed UB during Triton compilation.
+        block_table_offsets = tl.arange(0, BLOCK_TABLE_PAD_SIZE)
+        block_table_values = tl.load(
+            block_table_ptr + req_state_idx * block_table_stride + block_table_offsets,
+            mask=block_table_offsets < block_table_stride,
+            other=0,
+        ).to(tl.float32)
 
     for i in range(start_idx, end_idx, TRITON_BLOCK_SIZE):
         offset = i + lane_offsets
@@ -59,7 +63,10 @@ def _compute_slot_mappings_kernel(
         # block_offset = positions % (block_size * CP_SIZE). Replacing the
         # remainder with multiply/subtract avoids scalar fallback on Ascend.
         block_offsets = positions - (block_size * CP_SIZE) * block_indices
-        block_numbers = tl.gather(block_table_values, block_indices, 0).to(tl.int32)
+        if USE_BLOCK_TABLE_STAGING:
+            block_numbers = tl.gather(block_table_values, block_indices, 0).to(tl.int32)
+        else:
+            block_numbers = tl.load(block_table_ptr + req_state_idx * block_table_stride + block_indices)
 
         if CP_SIZE == 1:
             slot_ids = block_numbers * block_size + block_offsets

--- a/vllm_ascend/ops/triton/v2/block_table/docs/compute_slot_mappings.md
+++ b/vllm_ascend/ops/triton/v2/block_table/docs/compute_slot_mappings.md
@@ -40,10 +40,11 @@
      padding program per group.
   2. Resolve the selected request through `idx_mapping`, then read its token
      interval from `query_start_loc`.
-  3. Load the selected request's block-table row once with a contiguous GM
-     load, then process the interval in `TRITON_BLOCK_SIZE` tiles. Convert
-     positions to INT32, calculate block indices and offsets, and gather the
-     physical block number from the staged row.
+  3. For block-table rows up to the validated staging limit, load the selected
+     request's row once with a contiguous GM load. Larger rows use per-token
+     direct GM loads so the compiler does not allocate an unbounded staged row
+     in UB. Process the interval in `TRITON_BLOCK_SIZE` tiles, convert positions
+     to INT32, and calculate block indices and offsets.
   4. Calculate slot IDs directly for non-CP execution. For CP execution,
      convert virtual offsets to rank-local offsets and replace non-local slots
      with `PAD_ID`.
@@ -76,6 +77,7 @@
 | `PAD_ID` | Attribute | Value written for padding and token positions owned by another CP rank; production uses `PAD_SLOT_ID`. | constexpr INT | scalar |
 | `TRITON_BLOCK_SIZE` | Attribute | Number of token positions processed per loop tile; production uses 1024. | constexpr INT | scalar |
 | `BLOCK_TABLE_PAD_SIZE` | Attribute | Power-of-two upper bound for the allocated row stride. The load is masked by the runtime row stride. | constexpr INT | scalar |
+| `USE_BLOCK_TABLE_STAGING` | Attribute | Selects the contiguous staged-row path for bounded rows; larger rows use direct block-number loads. | constexpr BOOL | scalar |
 
 ## Constraints
 
@@ -96,6 +98,10 @@
   group. `TRITON_BLOCK_SIZE` must be a positive compile-time constant.
 - Every derived block index must be smaller than its group's runtime row stride,
   which in turn must not exceed `BLOCK_TABLE_PAD_SIZE`.
+- `USE_BLOCK_TABLE_STAGING` may only be enabled when the staged row and the
+  per-token temporaries fit the target UB. The host currently enables it for
+  power-of-two row bounds up to 16K entries, the largest size validated by the
+  original optimization on Ascend A3.
 - Graph capture requires the number of groups, request capacity, output
   capacity, and compile-time CP attributes to remain compatible with the
   captured launch.
@@ -109,9 +115,9 @@
     - Converts logical positions from INT64 to INT32 before block-index,
     block-offset, and address calculations, reducing INT64 scalar arithmetic
     on Ascend NPU.
-    - Stages one complete request row with a contiguous masked GM load and uses
-    `tl.gather` for token-to-block lookup, avoiding per-token non-contiguous GM
-    loads.
+    - Stages one complete bounded request row with a contiguous masked GM load
+    and uses `tl.gather` for token-to-block lookup. Rows above the validated
+    staging limit preserve the upstream direct-load algorithm to bound UB use.
     - Replaces the INT32 remainder used for the block offset with
     multiply/subtract to avoid scalar fallback on Ascend.
     - Preserves the upstream launch grid, CP mapping, padding behavior, and
@@ -125,6 +131,7 @@
 The single-operator test compares the Ascend kernel bit-for-bit with the
 upstream MRV2 kernel for two KV-cache groups and CP configurations
 `(size, rank, interleave) = (1, 0, 1), (2, 1, 2), (4, 2, 1)`. It also exercises
+both the staged-row boundary and a 131072-entry direct-load row, then exercises
 the `AscendBlockTables.compute_slot_mappings(..., out=...)` override and checks
 the returned view, physical slot IDs, and padded tail.
 

--- a/vllm_ascend/worker/v2/block_table.py
+++ b/vllm_ascend/worker/v2/block_table.py
@@ -25,6 +25,13 @@ from vllm_ascend.ops.triton.v2.block_table.compute_slot_mappings import (
     _compute_slot_mappings_kernel,
 )
 
+# Staging a complete block-table row gives substantially faster contiguous GM
+# access on Ascend, but the staged fp32 row must fit in UB together with the
+# per-token temporaries. PR #15212 validated rows through 16K entries on A3.
+# Larger rows use the direct-load path in the same kernel to keep compilation
+# resource usage bounded.
+_MAX_STAGED_BLOCK_TABLE_PAD_SIZE = 16384
+
 
 class AscendBlockTables(BlockTables):
     """Block table for Ascend NPUs."""
@@ -100,5 +107,6 @@ class AscendBlockTables(BlockTables):
             PAD_ID=PAD_SLOT_ID,
             TRITON_BLOCK_SIZE=1024,
             BLOCK_TABLE_PAD_SIZE=self._block_table_pad_size,
+            USE_BLOCK_TABLE_STAGING=(self._block_table_pad_size <= _MAX_STAGED_BLOCK_TABLE_PAD_SIZE),
         )
         return slot_mappings[:, :num_tokens_padded]


### PR DESCRIPTION
### What this PR does / why we need it?

MRV2 stages a complete request block-table row in the Ascend Triton slot-mapping kernel and converts it to fp32 before gathering physical block numbers. For long rows (for example, a 131072-entry padded row), the staged tensor plus per-token temporaries can exceed UB capacity during compilation, causing DeepSeek V4 Flash graph warmup/capture to hang before the service becomes ready.

This patch bounds the optimized staged-row path to power-of-two row sizes up to 16384 entries, the largest size already validated on A3. Larger rows use indexed GM loads in the same kernel. Slot-mapping semantics, CP ownership, padding, and the existing fast path are unchanged.

This is split from the DeepSeek V4 MRV2 nightly change in #15765 so the runtime fix can be reviewed independently.

### Does this PR introduce _any_ user-facing change?

No API or configuration change. Long block-table rows no longer overflow compiler UB resources; smaller rows retain the staged fast path.

### How was this patch tested?

- Added NPU regression coverage at the 16384-entry staged boundary and for a 131072-entry direct-load row. Both are compared with the upstream MRV2 reference kernel.
- Existing CP slot-mapping cases remain bit-for-bit aligned with the reference implementation.
- Ran the complete slot-mapping test file successfully (6 tests).
- Validated DeepSeek V4 Flash W8A8 MRV2 with graph mode and enable_npugraph_ex: service startup, curl smoke requests, full GPQA evaluation (88.89), and three stable performance runs (mean 234.6171 requests/s).
- vLLM main: https://github.com/vllm-project/vllm/commit/ba07e4a48fc951300d97eb506217dd530583dea3
