### PR TITLE
[Feature][Spec Decode] Support DSpark graph mode and draft KV eviction

### DIFF
--- a/docs/source/developer_guide/Design_Documents/speculative_kv_sliding_window.md
+++ b/docs/source/developer_guide/Design_Documents/speculative_kv_sliding_window.md
@@ -8,9 +8,9 @@ draft, the mean acceptance length dropped from ~5 to ~1 at 32k context, making
 speculation a net loss.
 
 The KV sliding window caps the **draft model's attention** to the most recent
-`draft_window_size` tokens. The target model is untouched - it always attends
-to the full context, so generation quality is preserved; only the draft reads
-a shorter, in-distribution window. On acceptance-collapsed drafts this
+`draft_window_size` tokens. The target model is untouched by this setting, so
+generation quality is preserved; only the draft reads a shorter,
+in-distribution window. On acceptance-collapsed drafts this
 restores acceptance (the same GLM-5.2 draft recovered from ~1.0 to ~4.7-5.5
 at 32k, up to +381% end-to-end throughput in the original evaluation).
 
@@ -28,6 +28,15 @@ target's own layers, so windowing the draft would window the target); for a
 DSpark draft that was natively trained together with a DeepSeek-V4 target, a
 warning is logged because the draft is already long-context stable and
 windowing degrades acceptance.
+
+For Qwen3-based DSpark drafts, this setting also changes the draft attention
+layers' KV cache specs to sliding-window specs before cache groups are built.
+The scheduler can therefore replace logical blocks outside the window with
+the null block and return their physical blocks to the shared pool. This
+physical eviction is limited to the DSpark draft KV groups; target-model KV
+groups keep their original cache specs. Other draft families currently use
+the setting only to limit the KV range read by attention unless their native
+model already exposes a sliding-window cache spec.
 
 ## Window math
 
@@ -58,9 +67,12 @@ capped at the same `windowed_len`.
 
 Two invariants hold throughout:
 
-- **slot_mapping is never windowed.** Draft KV writes still go through the
-  full block table at absolute positions, so the cache stays coherent for the
-  target model and for window sizes changed between steps.
+- **slot_mapping never uses the cropped attention table.** Draft KV writes go
+  through the full *logical* block table at absolute positions. For Qwen3
+  DSpark physical eviction, old logical entries can be null blocks, while the
+  current tail always maps to live physical blocks. The configured window is
+  fixed for the lifetime of the service and cannot be enlarged mid-request to
+  recover already-evicted KV.
 - **Only what FIA reads is capped.** The FIA kernel's KV-length inputs are the
   NPU `seq_lens` tensor plus CPU mirrors (`seq_lens_cpu`, `_seq_lens_cpu`,
   `seq_lens_cpu_upper_bound`); all of them are windowed with the same
@@ -85,6 +97,16 @@ There are two apply points because of how the drafts construct metadata:
   building. The adapter is therefore applied **after** the per-group overwrite
   and before `builder.build_for_drafting`, so FIA reads the windowed clone of
   the per-group table instead of the full one.
+
+For Qwen3 DSpark, `AscendQwen3DSparkForCausalLM` additionally translates
+`draft_window_size` into the DFlash backbone's `use_swa` /
+`swa_window_size` configuration before its attention layers are constructed.
+Those layers consequently publish `SlidingWindowSpec` rather than
+`FullAttentionSpec`, which makes the engine-core `SlidingWindowManager`
+physically recycle blocks outside the committed-token window. Graph replay
+remains address-stable because the KV pool tensor and the adapter's cropped
+block-table buffer are persistent; only the block IDs copied into that buffer
+change between steps.
 
 ## MRV2 status
 
@@ -116,3 +138,4 @@ and the two invariants above carry over unchanged.
 
 - Shared window adapter: `vllm_ascend/spec_decode/utils.py`
 - MRV1 proposer (apply points, config validation): `vllm_ascend/spec_decode/llm_base_proposer.py`
+- Qwen3 DSpark physical KV eviction setup: `vllm_ascend/models/qwen3_dspark.py`

--- a/tests/ut/attention/test_attention_v1.py
+++ b/tests/ut/attention/test_attention_v1.py
@@ -33,6 +33,21 @@ LARGE_HEAD_PREFILL_PATH = "vllm_ascend.device.utils.npu_large_head_prefill_atten
 
 
 class TestAttentionGraphHelpers(TestBase):
+    def test_fia_sparse_config_noncausal_ignores_sliding_window(self):
+        self.assertEqual(
+            attn_module._get_fia_sparse_config(1024, causal=False),
+            (0, attn_module.SWA_INT_MAX, attn_module.SWA_INT_MAX),
+        )
+
+    def test_fia_sparse_config_causal_sliding_window(self):
+        self.assertEqual(attn_module._get_fia_sparse_config(1024, causal=True), (4, 1024, 0))
+
+    def test_fia_sparse_config_causal_full_attention(self):
+        self.assertEqual(
+            attn_module._get_fia_sparse_config(None, causal=True),
+            (3, attn_module.SWA_INT_MAX, attn_module.SWA_INT_MAX),
+        )
+
     def test_cache_graph_workspace_keeps_first_workspace_by_default(self):
         graph_params = SimpleNamespace(workspaces={1: torch.empty(4)})
         candidate_workspace = torch.empty(8)

--- a/tests/ut/kv_offload/test_mooncake_connector.py
+++ b/tests/ut/kv_offload/test_mooncake_connector.py
@@ -2773,6 +2773,61 @@ class TestMooncakeConnectorWorker(unittest.TestCase):
         self.assertEqual(ptrs, [aligned_tensor.data_ptr()])
         self.assertEqual(lengths, [tensor_size])
 
+    def test_hybrid_registration_covers_separate_kv_storages(self):
+        worker = object.__new__(MooncakeConnectorWorker)
+        key = torch.empty(128, dtype=torch.int8)
+        value = torch.empty(96, dtype=torch.int8)
+        worker.kv_cache_config = types.SimpleNamespace(
+            kv_cache_tensors=[
+                types.SimpleNamespace(
+                    shared_by=["model.dspark.layers.0.self_attn"],
+                    size=key.nbytes + value.nbytes,
+                    offset=0,
+                    block_stride=0,
+                )
+            ]
+        )
+
+        ptrs, lengths = worker._get_registered_kv_tensor_buffers_hybrid(
+            {"model.dspark.layers.0.self_attn": (key, value)}
+        )
+
+        regions = list(zip(ptrs, lengths))
+        for tensor in (key, value):
+            storage = tensor.untyped_storage()
+            storage_start = storage.data_ptr()
+            storage_end = storage_start + storage.nbytes()
+            assert any(
+                region_start <= storage_start
+                and region_start + region_length >= storage_end
+                for region_start, region_length in regions
+            )
+
+    def test_hybrid_registration_keeps_packed_layout_path(self):
+        worker = object.__new__(MooncakeConnectorWorker)
+        layer_name = "model.layers.0.self_attn"
+        cache_size = 4096
+        worker.kv_cache_config = types.SimpleNamespace(
+            kv_cache_tensors=[
+                types.SimpleNamespace(
+                    shared_by=[layer_name],
+                    size=cache_size,
+                    offset=128,
+                    block_stride=8192,
+                )
+            ]
+        )
+        cache = MagicMock()
+        cache.data_ptr.return_value = 2 * 1024 * 1024
+        worker._as_kv_cache_tuple = MagicMock(return_value=(cache,))
+
+        ptrs, lengths = worker._get_registered_kv_tensor_buffers_hybrid(
+            {layer_name: cache}
+        )
+
+        self.assertEqual(ptrs, [2 * 1024 * 1024])
+        self.assertEqual(lengths, [cache_size])
+
     def test_device_id_selection_with_physical_devices(self):
         # Test with physical devices set
         worker = MooncakeConnectorWorker(self.vllm_config, self.engine_id, MockKVCacheConfig())

--- a/tests/ut/model_executor/test_qwen3_dspark.py
+++ b/tests/ut/model_executor/test_qwen3_dspark.py
@@ -23,6 +23,7 @@ import json
 from types import SimpleNamespace
 from unittest.mock import patch
 
+import pytest
 import torch
 from safetensors.torch import save_file
 from torch import nn
@@ -109,3 +110,29 @@ def test_quarot_loads_missing_target_vocab_shards(tmp_path) -> None:
         torch.testing.assert_close(layer.weight, expected)
     assert model.has_own_embed_tokens
     assert model.has_own_lm_head
+
+
+class TestQwen3DSparkRotationPath:
+    
+    def test_uses_legacy_quarot_path_when_metadata_is_incomplete(self, tmp_path) -> None:
+        """Honor ModelSlim's is_rot_used marker for legacy A5 checkpoints."""
+        target_path = tmp_path / "target"
+        rotation_path = target_path / "optional" / "quarot.safetensors"
+        rotation_path.parent.mkdir(parents=True)
+        rotation_path.touch()
+        vllm_config = SimpleNamespace(
+            quant_config=SimpleNamespace(quant_description={"is_rot_used": True, "optional": {}}),
+            model_config=SimpleNamespace(model=str(target_path)),
+        )
+
+        assert qwen3_dspark.get_dspark_rotation_path(vllm_config) == rotation_path
+
+    def test_fails_fast_when_rotated_target_has_no_dspark_matrix(self, tmp_path) -> None:
+        """Do not silently run an unrotated DSpark draft against a rotated target."""
+        vllm_config = SimpleNamespace(
+            quant_config=SimpleNamespace(quant_description={"is_rot_used": True, "optional": {}}),
+            model_config=SimpleNamespace(model=str(tmp_path / "target")),
+        )
+
+        with pytest.raises(FileNotFoundError, match="is_rot_used=true"):
+            qwen3_dspark.get_dspark_rotation_path(vllm_config)

--- a/tests/ut/model_executor/test_qwen3_dspark.py
+++ b/tests/ut/model_executor/test_qwen3_dspark.py
@@ -27,8 +27,64 @@ import pytest
 import torch
 from safetensors.torch import save_file
 from torch import nn
+from vllm.model_executor.models.qwen3_dflash import _resolve_layer_attention
 
 import vllm_ascend.models.qwen3_dspark as qwen3_dspark
+
+
+class TestQwen3DSparkDraftWindow:
+    """Tests for scheduler-visible DSpark draft KV window configuration."""
+
+    @staticmethod
+    def _make_config(window_size, dflash_config=None):
+        draft_hf_config = SimpleNamespace(dflash_config=dflash_config)
+        return SimpleNamespace(
+            additional_config={"draft_window_size": window_size},
+            speculative_config=SimpleNamespace(draft_model_config=SimpleNamespace(hf_config=draft_hf_config)),
+        ), draft_hf_config
+
+    def test_enables_physical_swa_cache_for_draft_layers(self) -> None:
+        vllm_config, draft_hf_config = self._make_config(1024)
+
+        qwen3_dspark._configure_dspark_draft_window(vllm_config)
+
+        assert draft_hf_config.dflash_config == {
+            "use_swa": True,
+            "swa_window_size": 1024,
+        }
+        assert _resolve_layer_attention(draft_hf_config, 0) == (1024, False)
+
+    def test_preserves_other_dflash_options(self) -> None:
+        vllm_config, draft_hf_config = self._make_config(
+            2048,
+            {"causal": False, "use_swa": False, "swa_window_size": 4096},
+        )
+
+        qwen3_dspark._configure_dspark_draft_window(vllm_config)
+
+        assert draft_hf_config.dflash_config == {
+            "causal": False,
+            "use_swa": True,
+            "swa_window_size": 2048,
+        }
+
+    def test_absent_window_keeps_draft_cache_spec_unchanged(self) -> None:
+        draft_hf_config = SimpleNamespace(dflash_config={"causal": False})
+        vllm_config = SimpleNamespace(
+            additional_config={},
+            speculative_config=SimpleNamespace(draft_model_config=SimpleNamespace(hf_config=draft_hf_config)),
+        )
+
+        qwen3_dspark._configure_dspark_draft_window(vllm_config)
+
+        assert draft_hf_config.dflash_config == {"causal": False}
+
+    @pytest.mark.parametrize("window_size", [0, -1, 1024.0, True])
+    def test_rejects_invalid_window(self, window_size) -> None:
+        vllm_config, _ = self._make_config(window_size)
+
+        with pytest.raises(ValueError, match="positive integer"):
+            qwen3_dspark._configure_dspark_draft_window(vllm_config)
 
 
 class TestQwen3DSparkWeightLoading:

--- a/tests/ut/patch/platform/test_patch_kv_cache_utils.py
+++ b/tests/ut/patch/platform/test_patch_kv_cache_utils.py
@@ -37,7 +37,8 @@ def _config(*, use_dspark=True, disable_hybrid=False):
         cache_config=SimpleNamespace(num_gpu_blocks_override=None),
         model_config=SimpleNamespace(max_model_len=257000),
         parallel_config=SimpleNamespace(decode_context_parallel_size=1),
-        max_in_flight_tokens=80,
+        # Async scheduling doubles --max-num-batched-tokens=80.
+        max_in_flight_tokens=160,
     )
 
 
@@ -206,7 +207,7 @@ def test_257k_request_fits_candidate_block_capacity():
     assert sum(
         tensor.size for tensor in cache_config.kv_cache_tensors
     ) == bytes_per_block * available_blocks
-    assert required_blocks == 2008 + 10
+    assert required_blocks == 2008 + 11
     assert required_blocks < cache_config.num_blocks
 
 

--- a/tests/ut/patch/platform/test_patch_kv_cache_utils.py
+++ b/tests/ut/patch/platform/test_patch_kv_cache_utils.py
@@ -1,0 +1,253 @@
+# SPDX-License-Identifier: Apache-2.0
+
+from types import SimpleNamespace
+
+import torch
+from vllm.v1.core.kv_cache_utils import generate_scheduler_kv_cache_config
+from vllm.v1.core.single_type_kv_cache_manager import (
+    SlidingWindowManager,
+    register_all_kvcache_specs,
+)
+from vllm.v1.kv_cache_interface import SlidingWindowSpec, UniformTypeKVCacheSpecs
+from vllm.v1.kv_cache_spec_registry import KVCacheSpecRegistry
+
+from vllm_ascend.core.kv_cache_interface import (
+    AscendMLAAttentionSpec,
+    AscendSFAIndexerCacheSpec,
+    register_ascend_kv_cache_specs,
+)
+from vllm_ascend.patch.platform.patch_kv_cache_utils import (
+    _ascend_get_kv_cache_config_from_groups,
+    _ascend_get_kv_cache_groups,
+    _ascend_max_memory_usage_bytes_from_groups,
+    _ascend_pool_bytes_per_block,
+    _dspark_native_layout_enabled,
+    _is_mla_regular_swa_groups,
+    _partition_mla_regular_swa_specs,
+    _use_dspark_native_layout,
+)
+
+
+def _config(*, use_dspark=True, disable_hybrid=False):
+    return SimpleNamespace(
+        scheduler_config=SimpleNamespace(
+            disable_hybrid_kv_cache_manager=disable_hybrid,
+        ),
+        speculative_config=SimpleNamespace(use_dspark=lambda: use_dspark),
+        cache_config=SimpleNamespace(num_gpu_blocks_override=None),
+        model_config=SimpleNamespace(max_model_len=257000),
+        parallel_config=SimpleNamespace(decode_context_parallel_size=1),
+        max_in_flight_tokens=80,
+    )
+
+
+def _glm_dspark_specs():
+    return {
+        # Put the indexer first deliberately. The grouping wrapper must keep
+        # the target-spec order and therefore preserve baseline manager choice.
+        "model.layers.0.self_attn.indexer": AscendSFAIndexerCacheSpec(
+            block_size=128,
+            num_kv_heads=1,
+            head_size=128,
+            dtype=torch.bfloat16,
+            scale_dim=0,
+            cache_sparse_li_c8=False,
+        ),
+        "model.layers.0.self_attn": AscendMLAAttentionSpec(
+            block_size=128,
+            num_kv_heads=1,
+            head_size=656,
+            dtype=torch.int8,
+            cache_sparse_sfa_c8=True,
+        ),
+        "model.dspark.layers.0.self_attn": SlidingWindowSpec(
+            block_size=128,
+            num_kv_heads=8,
+            head_size=192,
+            dtype=torch.bfloat16,
+            sliding_window=1024,
+        ),
+    }
+
+
+def _register_test_specs():
+    register_all_kvcache_specs(None)
+    register_ascend_kv_cache_specs()
+
+
+def test_glm_dspark_keeps_native_pages_and_sliding_window_manager():
+    _register_test_specs()
+    config = _config()
+    specs = _glm_dspark_specs()
+
+    groups = _ascend_get_kv_cache_groups(config, specs)
+
+    assert _is_mla_regular_swa_groups(groups)
+    assert len(groups) == 2
+    assert all(
+        isinstance(group.kv_cache_spec, UniformTypeKVCacheSpecs)
+        for group in groups
+    )
+    assert groups[0].layer_names == [
+        "model.layers.0.self_attn.indexer",
+        "model.layers.0.self_attn",
+    ]
+    assert groups[1].layer_names == ["model.dspark.layers.0.self_attn"]
+    draft_spec = specs["model.dspark.layers.0.self_attn"]
+    assert KVCacheSpecRegistry.get_manager_class(draft_spec) is SlidingWindowManager
+    assert draft_spec.page_size_bytes == 786432
+    assert specs["model.layers.0.self_attn"].page_size_bytes == 83968
+    assert (
+        specs["model.layers.0.self_attn.indexer"].page_size_bytes == 32768
+    )
+    assert all(
+        spec.page_size_padded is None
+        for spec in specs.values()
+        if hasattr(spec, "page_size_padded")
+    )
+
+
+def test_glm_dspark_allocates_one_native_layout_tensor_per_layer():
+    _register_test_specs()
+    config = _config()
+    specs = _glm_dspark_specs()
+    groups = _ascend_get_kv_cache_groups(config, specs)
+    bytes_per_block = sum(spec.page_size_bytes for spec in specs.values())
+
+    assert _ascend_pool_bytes_per_block(config, groups) == bytes_per_block
+    expected_blocks = 17
+    cache_config = _ascend_get_kv_cache_config_from_groups(
+        config,
+        groups,
+        bytes_per_block * expected_blocks + bytes_per_block // 2,
+    )
+
+    assert cache_config.num_blocks == expected_blocks
+    assert len(cache_config.kv_cache_tensors) == len(specs)
+    tensor_by_layer = {
+        tensor.shared_by[0]: tensor
+        for tensor in cache_config.kv_cache_tensors
+    }
+    assert all(
+        len(tensor.shared_by) == 1
+        for tensor in cache_config.kv_cache_tensors
+    )
+    for layer_name, spec in specs.items():
+        tensor = tensor_by_layer[layer_name]
+        assert tensor.size == spec.page_size_bytes * expected_blocks
+        assert tensor.offset == 0
+        assert tensor.block_stride == 0
+
+    scheduler_config = generate_scheduler_kv_cache_config([cache_config])
+    assert isinstance(
+        scheduler_config.kv_cache_groups[0].kv_cache_spec,
+        AscendSFAIndexerCacheSpec,
+    )
+    assert isinstance(
+        scheduler_config.kv_cache_groups[1].kv_cache_spec,
+        SlidingWindowSpec,
+    )
+
+    expected_pages = sum(
+        group.kv_cache_spec.max_memory_usage_pages(config)
+        for group in groups
+    )
+    assert _ascend_max_memory_usage_bytes_from_groups(
+        config, groups
+    ) == bytes_per_block * expected_pages
+
+
+def test_257k_request_fits_candidate_block_capacity():
+    _register_test_specs()
+    config = _config()
+    specs = {}
+    for index in range(78):
+        if index < 21:
+            specs[f"model.layers.{index}.self_attn.indexer"] = (
+                AscendSFAIndexerCacheSpec(
+                    block_size=128,
+                    num_kv_heads=1,
+                    head_size=128,
+                    dtype=torch.bfloat16,
+                    scale_dim=0,
+                    cache_sparse_li_c8=False,
+                )
+            )
+        specs[f"model.layers.{index}.self_attn"] = AscendMLAAttentionSpec(
+            block_size=128,
+            num_kv_heads=1,
+            head_size=656,
+            dtype=torch.int8,
+            cache_sparse_sfa_c8=True,
+        )
+    for index in range(5):
+        specs[f"model.dspark.layers.{index}.self_attn"] = SlidingWindowSpec(
+            block_size=128,
+            num_kv_heads=8,
+            head_size=192,
+            dtype=torch.bfloat16,
+            sliding_window=1024,
+        )
+
+    groups = _ascend_get_kv_cache_groups(config, specs)
+    bytes_per_block = _ascend_pool_bytes_per_block(config, groups)
+    available_blocks = 2752
+    cache_config = _ascend_get_kv_cache_config_from_groups(
+        config, groups, bytes_per_block * available_blocks
+    )
+    required_blocks = sum(
+        group.kv_cache_spec.max_memory_usage_pages(config)
+        for group in groups
+    )
+
+    assert cache_config.num_blocks == available_blocks
+    assert bytes_per_block == 11_169_792
+    assert len(cache_config.kv_cache_tensors) == 104
+    assert sum(
+        tensor.size for tensor in cache_config.kv_cache_tensors
+    ) == bytes_per_block * available_blocks
+    assert required_blocks == 2008 + 10
+    assert required_blocks < cache_config.num_blocks
+
+
+def test_compressed_target_does_not_use_dspark_native_layout_fast_path():
+    specs = _glm_dspark_specs()
+    specs["model.layers.0.self_attn"] = AscendMLAAttentionSpec(
+        block_size=128,
+        num_kv_heads=1,
+        head_size=656,
+        dtype=torch.int8,
+        cache_sparse_sfa_c8=True,
+        compress_ratio=2,
+    )
+
+    assert _partition_mla_regular_swa_specs(specs) is None
+
+
+def test_native_layout_preserves_main_first_target_order():
+    specs = _glm_dspark_specs()
+    main_name = "model.layers.0.self_attn"
+    indexer_name = "model.layers.0.self_attn.indexer"
+    draft_name = "model.dspark.layers.0.self_attn"
+    main_first_specs = {
+        main_name: specs[main_name],
+        indexer_name: specs[indexer_name],
+        draft_name: specs[draft_name],
+    }
+
+    groups = _ascend_get_kv_cache_groups(_config(), main_first_specs)
+
+    assert groups[0].layer_names == [main_name, indexer_name]
+
+
+def test_native_layout_gate_rejects_non_dspark_and_disabled_hybrid():
+    groups = _ascend_get_kv_cache_groups(_config(), _glm_dspark_specs())
+
+    assert _dspark_native_layout_enabled(_config())
+    assert _use_dspark_native_layout(_config(), groups)
+    assert not _dspark_native_layout_enabled(_config(use_dspark=False))
+    assert not _use_dspark_native_layout(_config(use_dspark=False), groups)
+    assert not _dspark_native_layout_enabled(_config(disable_hybrid=True))
+    assert not _use_dspark_native_layout(
+        _config(disable_hybrid=True), groups
+    )

--- a/tests/ut/spec_decode/test_dspark_proposer.py
+++ b/tests/ut/spec_decode/test_dspark_proposer.py
@@ -19,7 +19,8 @@
 
 from __future__ import annotations
 
-from contextlib import contextmanager
+import inspect
+from contextlib import contextmanager, nullcontext
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
@@ -35,6 +36,7 @@ from vllm.v1.kv_cache_interface import (
 from vllm.v1.worker.utils import AttentionGroup
 
 from vllm_ascend.attention.attention_v1 import AscendAttentionState
+from vllm_ascend.spec_decode.dflash_proposer import AscendDflashProposer
 from vllm_ascend.spec_decode.dspark_proposer import AscendDSparkProposer
 from vllm_ascend.spec_decode.llm_base_proposer import AscendSpecDecodeBaseProposer
 from vllm_ascend.worker.device_metadata import DeviceMetadataStage, DeviceMetadataTask
@@ -95,6 +97,7 @@ def test_build_draft_metadata_submits_only_non_cp_device_tasks(
         sliding_window=None,
         _per_group_block_table_buffers={group_id: torch.ones((1, 1), dtype=torch.int32) for group_id in range(2)},
         _per_group_query_slot_mapping_buffers={group_id: torch.zeros(1, dtype=torch.int32) for group_id in range(2)},
+        _prepare_dspark_group_metadata=lambda metadata, *_args, **_kwargs: metadata,
     )
     common_attn_metadata = SimpleNamespace(
         num_reqs=1,
@@ -156,6 +159,8 @@ def test_dspark_device_metadata_executor_forward_lifecycle(has_task: bool):
     proposer._update_full_graph_params_if_needed = MagicMock()
     proposer.set_inputs_first_pass = MagicMock()
     proposer.build_draft_attn_metadata = MagicMock()
+    proposer._context_slot_mapping_buffers = None
+    proposer.build_model_inputs_first_pass = MagicMock()
 
     query_start_loc = torch.tensor([0, 1], dtype=torch.int32)
     common_attn_metadata = SimpleNamespace(
@@ -186,7 +191,7 @@ def test_dspark_device_metadata_executor_forward_lifecycle(has_task: bool):
 
     def run_draft(**kwargs):
         events.append("run")
-        return torch.ones((1, 1), dtype=torch.int64)
+        return torch.ones((1, 3), dtype=torch.int64)
 
     proposer._runnable = run_draft
     forward_context = SimpleNamespace(moe_layer_index=-1, cudagraph_runtime_mode=CUDAGraphMode.NONE)
@@ -219,7 +224,7 @@ def test_dspark_device_metadata_executor_forward_lifecycle(has_task: bool):
             sampling_metadata=MagicMock(),
         )
 
-    assert torch.equal(result, torch.ones((1, 1), dtype=torch.int64))
+    assert torch.equal(result, torch.ones((1, 3), dtype=torch.int64))
     assert context_executors == [executor if has_task else None]
     assert events == (["submit", "context", "run", "release"] if has_task else ["build", "context", "run"])
 
@@ -235,6 +240,12 @@ def _stub_device_properties(monkeypatch):
     either way (matching ``test_kernel_called_with_has_num_rejected``)."""
     monkeypatch.setattr("vllm_ascend.ops.triton.triton_utils._NUM_AICORE", 8)
     monkeypatch.setattr("vllm_ascend.ops.triton.triton_utils._NUM_VECTORCORE", 8)
+    monkeypatch.setattr(
+        "vllm_ascend.spec_decode.dspark_proposer.get_ascend_config",
+        lambda: SimpleNamespace(
+            dynamic_spec_config=SimpleNamespace(method=None, method_params={})
+        ),
+    )
 
 
 class _DSparkProposerTestBase:
@@ -519,11 +530,422 @@ class TestDSparkInitialization(_DSparkProposerTestBase):
             hf_config=hf_config,
             draft_sample_method=draft_sample_method,
         )
-        expected_max_query_tokens = _MAX_BATCH_SIZE * expected_num_query_per_req
+        expected_max_query_tokens = _MAX_BATCH_SIZE * (1 + _NUM_SPECULATIVE_TOKENS)
         assert proposer.sample_from_anchor is expected_sample_from_anchor
         assert proposer.num_query_per_req == expected_num_query_per_req
         assert proposer.max_query_tokens == expected_max_query_tokens
         assert proposer._dspark_draft_buffer.shape == (_MAX_BATCH_SIZE, 1 + _NUM_SPECULATIVE_TOKENS)
+
+
+# fmt: off
+class TestSetPerGroupAttnMetadata(_DSparkProposerTestBase):
+    """``set_per_group_attn_metadata`` stores the runner-provided per-group
+    block table / slot mapping into the read-only dicts the proposer consults
+    during ``set_inputs_first_pass``."""
+
+    def test_stores_block_table_and_slot_mapping(self):
+        num_reqs, block_size, max_num_tokens = 4, 5, 256
+        proposer = self._make_proposer(
+            max_num_tokens=max_num_tokens, num_reqs=num_reqs, block_size=block_size
+        )
+        # a gid not pre-populated by _make_proposer (which only seeds gid=0)
+        gid = 7
+        block_table = torch.zeros((num_reqs, 16), dtype=torch.int32)
+        slot_mapping = torch.full((max_num_tokens,), 42, dtype=torch.int32)
+
+        proposer.set_per_group_attn_metadata(gid, block_table, slot_mapping)
+
+        assert proposer._per_group_block_tables[gid] is block_table
+        assert proposer._per_group_slot_mappings[gid] is slot_mapping
+
+    def test_overwrites_existing_gid(self):
+        num_reqs, block_size, max_num_tokens = 2, 5, 256
+        proposer = self._make_proposer(
+            max_num_tokens=max_num_tokens, num_reqs=num_reqs, block_size=block_size
+        )
+        gid = 0  # already populated by _make_proposer
+        old_block_table = proposer._per_group_block_tables[gid]
+        new_block_table = torch.ones((num_reqs, 16), dtype=torch.int32)
+        new_slot_mapping = torch.ones(max_num_tokens, dtype=torch.int32)
+
+        proposer.set_per_group_attn_metadata(gid, new_block_table, new_slot_mapping)
+
+        assert proposer._per_group_block_tables[gid] is new_block_table
+        assert proposer._per_group_slot_mappings[gid] is new_slot_mapping
+        assert proposer._per_group_block_tables[gid] is not old_block_table
+
+
+class TestDSparkInitValidation:
+    """Validate DSpark-specific buffers and DFlash graph overrides."""
+
+    @staticmethod
+    def _make_vllm_config(
+        *,
+        num_speculative_tokens,
+        max_batch_size,
+        max_num_tokens,
+        draft_sample_method,
+        hidden_size=8,
+    ):
+        speculative_config = SimpleNamespace(
+            num_speculative_tokens=num_speculative_tokens,
+            draft_sample_method=draft_sample_method,
+            draft_model_config=SimpleNamespace(
+                hf_config=SimpleNamespace(),
+                get_hidden_size=lambda: hidden_size
+            ),
+        )
+        return SimpleNamespace(speculative_config=speculative_config)
+
+    @staticmethod
+    def _stub_dflash_init(
+        monkeypatch,
+        *,
+        num_speculative_tokens,
+        max_batch_size,
+        max_num_tokens,
+        dtype,
+        device,
+    ):
+        """Replace the heavy DFlash/Eagle base init with a stub that only sets
+        the attributes DSpark's ``__init__`` subsequently reads."""
+
+        def _stub(self, vllm_config, device, runner=None):
+            self.num_speculative_tokens = num_speculative_tokens
+            self.max_batch_size = max_batch_size
+            self.max_num_tokens = max_num_tokens
+            self.dtype = dtype
+            self.device = device
+            self.draft_model_config = vllm_config.speculative_config.draft_model_config
+            # present so the ``del`` in DSpark.__init__ succeeds
+            self.hidden_size = 0
+            self.hidden_states = None
+            self._dflash_hidden_states = None
+            self.use_cuda_graph = True
+
+        monkeypatch.setattr(AscendDflashProposer, "__init__", _stub)
+
+    def test_greedy_allocates_dspark_buffers(self, monkeypatch):
+        device = torch.device("cpu")
+        num_spec, max_batch, max_num_tokens, hidden = 5, 16, 256, 8
+        self._stub_dflash_init(
+            monkeypatch,
+            num_speculative_tokens=num_spec,
+            max_batch_size=max_batch,
+            max_num_tokens=max_num_tokens,
+            dtype=torch.float32,
+            device=device,
+        )
+        vllm_config = self._make_vllm_config(
+            num_speculative_tokens=num_spec,
+            max_batch_size=max_batch,
+            max_num_tokens=max_num_tokens,
+            draft_sample_method="greedy",
+            hidden_size=hidden,
+        )
+        proposer = AscendDSparkProposer(vllm_config, device)
+
+        blk = 1 + num_spec
+        max_query_tokens = max_batch * (1 + num_spec)
+        # DSpark-specific draft / seed buffers.
+        assert proposer._dspark_draft_buffer.shape == (max_batch, blk)
+        assert proposer._dspark_draft_buffer.dtype == torch.int64
+        assert proposer._dspark_seed_buffer.shape == (max_batch,)
+        assert proposer._dspark_seed_buffer.dtype == torch.int64
+        # hidden_size / hidden states come from the draft model config.
+        assert proposer.hidden_size == hidden
+        assert proposer.hidden_states.shape == (max_num_tokens, hidden)
+        assert proposer._dflash_hidden_states.shape == (max_num_tokens, hidden)
+        # Static DSpark preserves the base proposer's graph-mode decision.
+        assert proposer.use_cuda_graph is True
+        # anchor-first: N query tokens per request, no bonus token (unlike
+        # DFlash's 1+N).
+        assert proposer.max_query_tokens == max_query_tokens
+        assert proposer.positions.shape == (max_query_tokens,)
+        assert proposer.positions.dtype == torch.int32
+        assert proposer._slot_mapping_buffer.shape == (max_query_tokens,)
+        # per-group bookkeeping dicts start empty / None.
+        assert proposer._per_group_block_tables == {}
+        assert proposer._per_group_slot_mappings == {}
+        assert proposer._context_slot_mapping_buffers is None
+
+    def test_dynamic_verify_length_disables_graph(self, monkeypatch):
+        device = torch.device("cpu")
+        self._stub_dflash_init(
+            monkeypatch,
+            num_speculative_tokens=5,
+            max_batch_size=16,
+            max_num_tokens=256,
+            dtype=torch.float32,
+            device=device,
+        )
+        monkeypatch.setattr(
+            "vllm_ascend.spec_decode.dspark_proposer.get_ascend_config",
+            lambda: SimpleNamespace(
+                dynamic_spec_config=SimpleNamespace(method="dspark", method_params={})
+            ),
+        )
+        monkeypatch.setattr(
+            "vllm_ascend.spec_decode.dspark_proposer.DynamicSpecScheduler",
+            MagicMock(),
+        )
+        vllm_config = self._make_vllm_config(
+            num_speculative_tokens=5,
+            max_batch_size=16,
+            max_num_tokens=256,
+            draft_sample_method="greedy",
+        )
+
+        proposer = AscendDSparkProposer(vllm_config, device)
+
+        assert proposer.use_cuda_graph is False
+
+
+class TestDSparkGraphDummyRun(_DSparkProposerTestBase):
+    def test_query_runnable_does_not_inject_hidden_states(self):
+        source = inspect.getsource(AscendSpecDecodeBaseProposer._run_merged_draft)
+        assert 'elif self.method != "dspark":' in source
+
+    def test_builds_group_metadata_without_writing_context_kv(self, monkeypatch):
+        proposer = self._make_proposer(
+            max_num_tokens=64,
+            num_reqs=2,
+            block_size=3,
+            draft_attn_causal=False,
+        )
+        metadata = SimpleNamespace(
+            attn_mask=object(),
+            attn_state=None,
+            actual_seq_lengths_q=[3, 6],
+            block_tables=torch.zeros((2, 4), dtype=torch.int32),
+            slot_mapping=torch.zeros(6, dtype=torch.int32),
+            causal=False,
+        )
+        builder = MagicMock()
+        builder.build_for_graph_capture.return_value = metadata
+        proposer.draft_attn_groups[0].get_metadata_builder = lambda: builder
+        proposer.runner = SimpleNamespace(
+            _sync_metadata_across_dp=lambda n, **kwargs: (n, None, None),
+            optimistic_seq_lens_cpu=torch.zeros(2, dtype=torch.int32),
+            seq_lens=torch.zeros(2, dtype=torch.int32),
+        )
+        proposer.vllm_config = SimpleNamespace()
+        proposer.use_cuda_graph = True
+        proposer.token_indices_to_sample = torch.zeros(6, dtype=torch.int32)
+        proposer._get_positions = lambda n: proposer.positions[:n]
+        proposer._runnable = MagicMock()
+        proposer.model.precompute_and_store_context_kv = MagicMock()
+        monkeypatch.setattr(
+            "vllm_ascend.spec_decode.dspark_proposer.set_ascend_forward_context",
+            lambda *args, **kwargs: nullcontext(),
+        )
+        monkeypatch.setattr(
+            "vllm_ascend.spec_decode.dspark_proposer.get_forward_context",
+            lambda: SimpleNamespace(cudagraph_runtime_mode=CUDAGraphMode.FULL),
+        )
+        monkeypatch.setattr(
+            "vllm_ascend.spec_decode.dspark_proposer._EXTRA_CTX",
+            SimpleNamespace(capturing=True),
+        )
+
+        proposer.dummy_run(
+            num_tokens=6,
+            num_reqs=2,
+            aclgraph_runtime_mode=CUDAGraphMode.FULL,
+        )
+
+        builder.build_for_graph_capture.assert_called_once()
+        proposer.model.precompute_and_store_context_kv.assert_not_called()
+        call_metadata = proposer._runnable.call_args.kwargs[
+            "multi_steps_attn_metadata"
+        ]
+        assert call_metadata == [{"L0": metadata}]
+        assert metadata.attn_mask is None
+        assert metadata.attn_state == AscendAttentionState.ChunkedPrefill
+
+    def test_pads_capture_metadata_to_target_graph_bucket(self, monkeypatch):
+        proposer = self._make_proposer(
+            max_num_tokens=64,
+            num_reqs=2,
+            block_size=3,
+            draft_attn_causal=False,
+        )
+        metadata = SimpleNamespace(
+            attn_mask=None,
+            attn_state=None,
+            actual_seq_lengths_q=[3, 6, 8],
+            block_tables=torch.zeros((3, 4), dtype=torch.int32),
+            slot_mapping=torch.zeros(8, dtype=torch.int32),
+            causal=False,
+        )
+        builder = MagicMock()
+        builder.build_for_graph_capture.return_value = metadata
+        proposer.draft_attn_groups[0].get_metadata_builder = lambda: builder
+        proposer.runner = SimpleNamespace(
+            _sync_metadata_across_dp=lambda n, **kwargs: (n, None, None),
+            optimistic_seq_lens_cpu=torch.zeros(2, dtype=torch.int32),
+            seq_lens=torch.zeros(2, dtype=torch.int32),
+        )
+        proposer.vllm_config = SimpleNamespace()
+        proposer.use_cuda_graph = True
+        proposer.token_indices_to_sample = torch.zeros(6, dtype=torch.int32)
+        proposer._get_positions = lambda n: proposer.positions[:n]
+        proposer._runnable = MagicMock()
+        monkeypatch.setattr(
+            "vllm_ascend.spec_decode.dspark_proposer.set_ascend_forward_context",
+            lambda *args, **kwargs: nullcontext(),
+        )
+        monkeypatch.setattr(
+            "vllm_ascend.spec_decode.dspark_proposer.get_forward_context",
+            lambda: SimpleNamespace(cudagraph_runtime_mode=CUDAGraphMode.FULL),
+        )
+        monkeypatch.setattr(
+            "vllm_ascend.spec_decode.dspark_proposer._EXTRA_CTX",
+            SimpleNamespace(capturing=True),
+        )
+
+        proposer.dummy_run(
+            num_tokens=8,
+            num_reqs=2,
+            aclgraph_runtime_mode=CUDAGraphMode.FULL,
+            batch_descriptor=SimpleNamespace(num_tokens=8),
+        )
+
+        common_metadata = builder.build_for_graph_capture.call_args.args[0]
+        assert common_metadata.num_actual_tokens == 6
+        assert common_metadata.num_input_tokens == 8
+        assert common_metadata.num_reqs == 3
+        assert common_metadata.query_start_loc_cpu.tolist() == [0, 3, 6, 8]
+        assert proposer._runnable.call_args.kwargs["num_input_tokens"] == 8
+
+
+class TestDSparkGraphRuntimePadding(_DSparkProposerTestBase):
+    @staticmethod
+    def _query_start_loc(values: list[int], capacity: int = 16):
+        array = np.zeros(capacity, dtype=np.int32)
+        array[: len(values)] = values
+        return SimpleNamespace(np=array, copy_to_gpu=MagicMock())
+
+    def test_single_request_pads_eight_query_tokens_to_nine_token_graph(self):
+        proposer = self._make_proposer(
+            max_num_tokens=64,
+            num_reqs=4,
+            block_size=8,
+        )
+        query_start_loc = self._query_start_loc([0, 8])
+
+        metadata_reqs = proposer.pad_query_start_loc_for_graph(
+            query_start_loc,
+            num_input_tokens=9,
+            real_num_reqs=1,
+            graph_num_reqs=1,
+        )
+
+        assert metadata_reqs == 2
+        assert query_start_loc.np[:3].tolist() == [0, 8, 9]
+        query_start_loc.copy_to_gpu.assert_called_once_with()
+
+    def test_three_requests_match_four_request_graph_capture_layout(self):
+        proposer = self._make_proposer(
+            max_num_tokens=64,
+            num_reqs=4,
+            block_size=8,
+        )
+        query_start_loc = self._query_start_loc([0, 8, 16, 24])
+
+        metadata_reqs = proposer.pad_query_start_loc_for_graph(
+            query_start_loc,
+            num_input_tokens=36,
+            real_num_reqs=3,
+            graph_num_reqs=4,
+        )
+
+        assert metadata_reqs == 5
+        assert query_start_loc.np[:6].tolist() == [0, 8, 16, 24, 32, 36]
+        query_start_loc.copy_to_gpu.assert_called_once_with()
+
+    @pytest.mark.parametrize("num_speculative_tokens", [1, 3, 5, 7, 8, 15])
+    @pytest.mark.parametrize(
+        ("real_num_reqs", "graph_num_reqs"),
+        [(1, 1), (2, 2), (3, 4), (4, 4), (5, 8), (8, 8)],
+    )
+    def test_padding_contract_is_parameterized_by_draft_width_and_batch(
+        self,
+        num_speculative_tokens,
+        real_num_reqs,
+        graph_num_reqs,
+    ):
+        """The N-query draft layout must match an (N+1)-wide target bucket.
+
+        This deliberately exercises widths other than the GLM-5.2 checkpoint's
+        current N=8, including the Ascend decode-round upper boundary N=15.
+        """
+        graph_num_tokens = graph_num_reqs * (num_speculative_tokens + 1)
+        proposer = self._make_proposer(
+            max_num_tokens=graph_num_tokens + 16,
+            num_reqs=graph_num_reqs,
+            block_size=num_speculative_tokens,
+        )
+        real_boundaries = [
+            req_idx * num_speculative_tokens
+            for req_idx in range(real_num_reqs + 1)
+        ]
+        query_start_loc = self._query_start_loc(
+            real_boundaries,
+            capacity=graph_num_reqs + 3,
+        )
+
+        metadata_reqs = proposer.pad_query_start_loc_for_graph(
+            query_start_loc,
+            num_input_tokens=graph_num_tokens,
+            real_num_reqs=real_num_reqs,
+            graph_num_reqs=graph_num_reqs,
+        )
+
+        expected_boundaries = [
+            req_idx * num_speculative_tokens
+            for req_idx in range(graph_num_reqs + 1)
+        ]
+        expected_boundaries.append(graph_num_tokens)
+        assert metadata_reqs == graph_num_reqs + 1
+        assert query_start_loc.np[: metadata_reqs + 1].tolist() == (
+            expected_boundaries
+        )
+        query_start_loc.copy_to_gpu.assert_called_once_with()
+
+    @pytest.mark.parametrize("num_speculative_tokens", [3, 5, 8, 15])
+    def test_non_anchor_layout_uses_exact_target_graph_width(
+        self,
+        num_speculative_tokens,
+    ):
+        """sample_from_anchor=False already has N+1 real query rows."""
+        graph_num_reqs = 4
+        real_num_reqs = 3
+        query_width = num_speculative_tokens + 1
+        graph_num_tokens = graph_num_reqs * query_width
+        proposer = self._make_proposer(
+            max_num_tokens=graph_num_tokens + 16,
+            num_reqs=graph_num_reqs,
+            block_size=num_speculative_tokens,
+            hf_config=SimpleNamespace(sample_from_anchor=False),
+        )
+        query_start_loc = self._query_start_loc(
+            [req_idx * query_width for req_idx in range(real_num_reqs + 1)],
+            capacity=graph_num_reqs + 2,
+        )
+
+        metadata_reqs = proposer.pad_query_start_loc_for_graph(
+            query_start_loc,
+            num_input_tokens=graph_num_tokens,
+            real_num_reqs=real_num_reqs,
+            graph_num_reqs=graph_num_reqs,
+        )
+
+        assert metadata_reqs == graph_num_reqs
+        assert query_start_loc.np[: metadata_reqs + 1].tolist() == [
+            req_idx * query_width for req_idx in range(graph_num_reqs + 1)
+        ]
+        query_start_loc.copy_to_gpu.assert_called_once_with()
 
 
 class TestSetInputsFirstPassOutputs(_DSparkProposerTestBase):

--- a/tests/ut/spec_decode/test_dspark_proposer.py
+++ b/tests/ut/spec_decode/test_dspark_proposer.py
@@ -39,6 +39,7 @@ from vllm_ascend.attention.attention_v1 import AscendAttentionState
 from vllm_ascend.spec_decode.dflash_proposer import AscendDflashProposer
 from vllm_ascend.spec_decode.dspark_proposer import AscendDSparkProposer
 from vllm_ascend.spec_decode.llm_base_proposer import AscendSpecDecodeBaseProposer
+from vllm_ascend.spec_decode.utils import SlidingWindowAdapter
 from vllm_ascend.worker.device_metadata import DeviceMetadataStage, DeviceMetadataTask
 
 # 0 = single-DP (no padding); >0 = multi-DP where num_input_tokens >
@@ -817,6 +818,64 @@ class TestDSparkGraphDummyRun(_DSparkProposerTestBase):
         assert common_metadata.num_reqs == 3
         assert common_metadata.query_start_loc_cpu.tolist() == [0, 3, 6, 8]
         assert proposer._runnable.call_args.kwargs["num_input_tokens"] == 8
+
+    def test_group_window_metadata_is_persistent_and_pads_virtual_request(self):
+        proposer = self._make_proposer(
+            max_num_tokens=64,
+            num_reqs=2,
+            block_size=8,
+            draft_attn_causal=False,
+        )
+        device = torch.device("cpu")
+        proposer.draft_window_size = 1024
+        proposer.sliding_window = None
+        proposer._per_group_sliding_windows = {
+            0: SlidingWindowAdapter(1024, 128, 3, 0, device),
+            1: SlidingWindowAdapter(1024, 128, 3, 0, device),
+        }
+        proposer._per_group_block_table_buffers = {
+            0: torch.arange(32, dtype=torch.int32).reshape(2, 16),
+            1: torch.arange(100, 132, dtype=torch.int32).reshape(2, 16),
+        }
+        proposer._per_group_query_slot_mapping_buffers = {
+            0: torch.arange(24, dtype=torch.int32),
+            1: torch.arange(24, dtype=torch.int32) + 100,
+        }
+        groups = [
+            SimpleNamespace(kv_cache_group_id=gid)
+            for gid in (0, 1)
+        ]
+        common = SimpleNamespace(
+            num_reqs=3,
+            seq_lens=torch.tensor([1152, 256], dtype=torch.int32),
+            seq_lens_cpu=torch.tensor([1152, 256], dtype=torch.int32),
+            seq_lens_cpu_upper_bound=torch.tensor([1152, 256], dtype=torch.int32),
+            block_table_tensor=None,
+            slot_mapping=None,
+        )
+
+        first = proposer._prepare_dspark_group_metadata(
+            common, groups[0], 18, real_num_reqs=2
+        )
+        second_group = proposer._prepare_dspark_group_metadata(
+            common, groups[1], 18, real_num_reqs=2
+        )
+
+        assert first.block_table_tensor.shape == (3, 9)
+        assert first.block_table_tensor[0, 0].item() == 1
+        assert second_group.block_table_tensor[0, 0].item() == 101
+        assert first.block_table_tensor.data_ptr() != second_group.block_table_tensor.data_ptr()
+        assert first.seq_lens.tolist() == [1024, 256, 1]
+        assert first.seq_lens_cpu.tolist() == [1024, 256, 1]
+        assert first.block_table_tensor[2].count_nonzero().item() == 0
+
+        stable_address = first.block_table_tensor.data_ptr()
+        proposer._per_group_block_table_buffers[0].add_(1000)
+        refreshed = proposer._prepare_dspark_group_metadata(
+            common, groups[0], 18, real_num_reqs=2
+        )
+        assert refreshed.block_table_tensor.data_ptr() == stable_address
+        assert refreshed.block_table_tensor[0, 0].item() == 1001
 
 
 class TestDSparkGraphRuntimePadding(_DSparkProposerTestBase):

--- a/tests/ut/spec_decode/test_llm_base_proposer.py
+++ b/tests/ut/spec_decode/test_llm_base_proposer.py
@@ -46,6 +46,36 @@ NON_FULL_CUDAGRAPH_MODES = [
 ]
 
 
+@pytest.mark.parametrize("method", ["mtp", "dspark"])
+def test_glm_moe_dsa_supported_methods_use_spec_decode_graph(method: str):
+    model_config = SimpleNamespace(hf_text_config=SimpleNamespace(model_type="glm_moe_dsa"))
+
+    assert _is_glm_model(model_config)
+    assert _supports_spec_decode_graph(model_config, method)
+
+
+@pytest.mark.parametrize("model_type", ["glm", "chatglm", "glm4_moe"])
+def test_other_glm_mtp_variants_remain_eager(model_type: str):
+    model_config = SimpleNamespace(hf_text_config=SimpleNamespace(model_type=model_type))
+
+    assert _is_glm_model(model_config)
+    assert not _supports_spec_decode_graph(model_config, "mtp")
+
+
+@pytest.mark.parametrize("method", ["eagle", "eagle3", "draft_model", "dflash"])
+def test_other_glm_spec_decode_methods_remain_eager(method: str):
+    model_config = SimpleNamespace(hf_text_config=SimpleNamespace(model_type="glm_moe_dsa"))
+
+    assert not _supports_spec_decode_graph(model_config, method)
+
+
+def test_non_glm_spec_decode_graph_support_is_unchanged():
+    model_config = SimpleNamespace(hf_text_config=SimpleNamespace(model_type="deepseek_v3"))
+
+    assert not _is_glm_model(model_config)
+    assert _supports_spec_decode_graph(model_config, "eagle")
+
+
 class TestMultimodalImageTokenIndex:
     @pytest.mark.parametrize(
         "model_name",

--- a/tests/ut/spec_decode/test_llm_base_proposer.py
+++ b/tests/ut/spec_decode/test_llm_base_proposer.py
@@ -29,6 +29,8 @@ from vllm.config import CUDAGraphMode
 from vllm_ascend.spec_decode.llm_base_proposer import (
     AscendSpecDecodeBaseProposer,
     _draft_embed_accepts_mm,
+    _is_glm_model,
+    _supports_spec_decode_graph,
 )
 
 # CUDAGraphMode values whose ``has_full_cudagraphs()`` is True: FULL plus the

--- a/tests/ut/test_ascend_forward_context.py
+++ b/tests/ut/test_ascend_forward_context.py
@@ -15,6 +15,7 @@ from vllm_ascend.device.hardware_profile import get_hardware_profile
 @pytest.fixture(autouse=True)
 def reset_mc2_tokens_capacity(monkeypatch):
     monkeypatch.setattr(afc, "_mc2_tokens_capacity", None)
+    monkeypatch.setattr(afc, "_reserved_mc2_mask", None)
     monkeypatch.setattr(
         afc,
         "get_ascend_config",
@@ -249,6 +250,26 @@ def test_is_decode_only_node_false_without_recompute_scheduler(monkeypatch):
     )
 
     assert afc._is_decode_only_node(vllm_config) is False
+
+
+@pytest.mark.parametrize(
+    ("max_num_batched_tokens", "expected_mask_tokens"),
+    [(80, 80), (90, 96)],
+)
+def test_set_mc2_mask_aligns_capacity_to_tp(
+    monkeypatch,
+    max_num_batched_tokens,
+    expected_mask_tokens,
+):
+    monkeypatch.setattr(afc, "is_moe_model", lambda _: True)
+    vllm_config = _make_vllm_config(
+        tensor_parallel_size=8,
+        max_num_batched_tokens=max_num_batched_tokens,
+    )
+
+    afc.set_mc2_mask(vllm_config, device="cpu")
+
+    assert afc.get_mc2_mask().shape == (expected_mask_tokens,)
 
 
 def test_select_moe_comm_method_returns_none_for_non_moe(monkeypatch):

--- a/vllm_ascend/ascend_forward_context.py
+++ b/vllm_ascend/ascend_forward_context.py
@@ -269,9 +269,10 @@ def set_mc2_mask(vllm_config, device):
     if _reserved_mc2_mask is not None:
         return
     if is_moe_model(vllm_config):
-        _reserved_mc2_mask = torch.zeros(
-            vllm_config.scheduler_config.max_num_batched_tokens, dtype=torch.bool, device=device
-        )
+        max_num_tokens = vllm_config.scheduler_config.max_num_batched_tokens
+        tp_size = vllm_config.parallel_config.tensor_parallel_size
+        padded_num_tokens = (max_num_tokens + tp_size - 1) // tp_size * tp_size
+        _reserved_mc2_mask = torch.zeros(padded_num_tokens, dtype=torch.bool, device=device)
     else:
         _reserved_mc2_mask = None
 

--- a/vllm_ascend/attention/attention_v1.py
+++ b/vllm_ascend/attention/attention_v1.py
@@ -75,6 +75,15 @@ SWA_INT_MAX = 2147483647
 _ATTN_KEYS_BUFFER = None
 
 
+def _get_fia_sparse_config(sliding_window: int | None, causal: bool) -> tuple[int, int, int]:
+    """Return sparse mode and token limits for FIAS graph execution."""
+    if not causal:
+        return 0, SWA_INT_MAX, SWA_INT_MAX
+    if sliding_window is not None:
+        return 4, sliding_window, 0
+    return 3, SWA_INT_MAX, SWA_INT_MAX
+
+
 @register_backend(AttentionBackendEnum.CUSTOM, "ASCEND")
 class AscendAttentionBackend(AttentionBackend):
     accept_output_buffer: bool = True
@@ -867,8 +876,10 @@ class AscendAttentionBackendImpl(AttentionImpl):
                         actual_seq_lengths_q = metadata.actual_seq_lengths_q
                         block_tables = metadata.block_tables
                         attn_count = attn_count + 1
-                        if not metadata.causal:
-                            sparse_mode = 0
+                        sparse_mode, pre_tokens, next_tokens = _get_fia_sparse_config(
+                            sliding_window,
+                            metadata.causal,
+                        )
                     else:
                         metadata_key = layer_name if layer_name is not None and layer_name in attn_metadata else key
                         seq_lens = attn_metadata[metadata_key].seq_lens_list
@@ -948,9 +959,9 @@ class AscendAttentionBackendImpl(AttentionImpl):
         softmax_lse = torch.empty(1, dtype=query.dtype, device=query.device)
         input_layout = "TND"
         attn_mask = attn_metadata.attn_mask
-        sparse_mode = 4 if self.sliding_window else 3 if attn_metadata.causal else 0
-        pre_tokens = self.sliding_window or SWA_INT_MAX
-        next_tokens = 0 if self.sliding_window else SWA_INT_MAX
+        sparse_mode, pre_tokens, next_tokens = _get_fia_sparse_config(
+            self.sliding_window, attn_metadata.causal
+        )
 
         extra_args = {}
         if self.enable_c8_quant and layer is not None:

--- a/vllm_ascend/attention/fa3_v1.py
+++ b/vllm_ascend/attention/fa3_v1.py
@@ -30,7 +30,7 @@ class AscendFABackend(AttentionBackend):
         block_size: int,
         num_kv_heads: int,
         head_size: int,
-        cache_type: str = "",
+        cache_dtype_str: str = "auto",
     ) -> tuple[int, ...]:
         return (2, num_blocks, block_size, num_kv_heads, head_size)
 

--- a/vllm_ascend/attention/indexer.py
+++ b/vllm_ascend/attention/indexer.py
@@ -53,7 +53,7 @@ class AscendSFAIndexerBackend(AttentionBackend):
         block_size: int,
         num_kv_heads: int,
         head_size: int,
-        cache_type: str = "",
+        cache_dtype_str: str = "auto",
     ) -> tuple[int, ...]:
         return (num_blocks, block_size, num_kv_heads, head_size)
 

--- a/vllm_ascend/attention/mla_v1.py
+++ b/vllm_ascend/attention/mla_v1.py
@@ -101,7 +101,7 @@ class AscendMLABackend(AttentionBackend):
         block_size: int,
         num_kv_heads: int,
         head_size: int,
-        cache_type: str = "",
+        cache_dtype_str: str = "auto",
     ) -> tuple[int, ...]:
         return num_blocks, block_size, num_kv_heads, head_size
 

--- a/vllm_ascend/attention/sfa_v1.py
+++ b/vllm_ascend/attention/sfa_v1.py
@@ -121,7 +121,7 @@ class AscendSFABackend(AttentionBackend):
         block_size: int,
         num_kv_heads: int,
         head_size: int,
-        cache_type: str = "",
+        cache_dtype_str: str = "auto",
     ) -> tuple[int, ...]:
         return (num_blocks, block_size, num_kv_heads, head_size)
 

--- a/vllm_ascend/distributed/kv_transfer/kv_p2p/mooncake_connector.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_p2p/mooncake_connector.py
@@ -2490,13 +2490,28 @@ class MooncakeConnectorWorker:
     def _get_registered_kv_tensor_buffers_hybrid(
         self, kv_caches: dict[str, torch.Tensor]
     ) -> tuple[list[int], list[int]]:
+        kv_cache_tensors = self.kv_cache_config.kv_cache_tensors
+        native_singleton_layout = bool(kv_cache_tensors) and all(
+            len(tensor.shared_by) == 1
+            and tensor.offset == 0
+            and tensor.block_stride == 0
+            for tensor in kv_cache_tensors
+        )
+        if native_singleton_layout:
+            # A singleton KVCacheTensor can be materialized as separate aligned
+            # K/V allocations. Register its actual storages instead of assuming
+            # ``min(data_ptr) + KVCacheTensor.size`` spans both allocations.
+            regions = collect_storage_merged_register_regions(kv_caches)
+            return regions.ptrs, regions.lengths
+
         ptrs: list[int] = []
         lengths: list[int] = []
-
-        for kv_cache_tensor in self.kv_cache_config.kv_cache_tensors:
+        for kv_cache_tensor in kv_cache_tensors:
             shared_addrs: list[int] = []
             for layer_name in kv_cache_tensor.shared_by:
-                for single_kv_cache in self._as_kv_cache_tuple(kv_caches[layer_name]):
+                for single_kv_cache in self._as_kv_cache_tuple(
+                    kv_caches[layer_name]
+                ):
                     shared_addrs.append(single_kv_cache.data_ptr())
 
             if not shared_addrs:

--- a/vllm_ascend/models/qwen3_dspark.py
+++ b/vllm_ascend/models/qwen3_dspark.py
@@ -28,6 +28,37 @@ TARGET_LM_HEAD_WEIGHT_NAMES = (
 logger = logging.getLogger(__name__)
 
 
+def _configure_dspark_draft_window(vllm_config: VllmConfig) -> None:
+    """Make ``draft_window_size`` a physical Qwen3 DSpark KV window.
+
+    ``SlidingWindowAdapter`` limits the block table consumed by attention, but
+    the scheduler can recycle old KV blocks only when the attention layers
+    expose a ``SlidingWindowSpec``. Qwen3 DSpark is built on the DFlash model,
+    whose ``dflash_config.use_swa`` switch selects that cache spec. Configure
+    it before the parent constructor creates the attention layers so only the
+    draft KV groups use ``SlidingWindowManager``; target-model groups are not
+    modified.
+    """
+    additional_config = vllm_config.additional_config or {}
+    window_size = additional_config.get("draft_window_size")
+    if window_size is None:
+        return
+    if isinstance(window_size, bool) or not isinstance(window_size, int) or window_size <= 0:
+        raise ValueError("draft_window_size must be a positive integer")
+
+    draft_config = vllm_config.speculative_config.draft_model_config.hf_config
+    dflash_config = dict(getattr(draft_config, "dflash_config", None) or {})
+    dflash_config.update(
+        use_swa=True,
+        swa_window_size=window_size,
+    )
+    draft_config.dflash_config = dflash_config
+    logger.info(
+        "Configuring Qwen3 DSpark draft KV cache as a %d-token physical sliding window.",
+        window_size,
+    )
+
+
 def get_dspark_rotation_path(vllm_config: VllmConfig) -> Path | None:
     """Resolve the target QuaRot matrix used to align DSpark FC weights.
 
@@ -109,6 +140,7 @@ class DSparkConfidenceHead(nn.Module):
 
 class AscendQwen3DSparkForCausalLM(Qwen3DSparkForCausalLM):
     def __init__(self, *, vllm_config: VllmConfig, prefix: str = "") -> None:
+        _configure_dspark_draft_window(vllm_config)
         super().__init__(vllm_config=vllm_config, prefix=prefix)
 
         config = self.config

--- a/vllm_ascend/models/qwen3_dspark.py
+++ b/vllm_ascend/models/qwen3_dspark.py
@@ -1,3 +1,4 @@
+import logging
 from collections.abc import Iterable
 from pathlib import Path
 
@@ -23,6 +24,44 @@ TARGET_LM_HEAD_WEIGHT_NAMES = (
     "language_model.lm_head.weight",
     "lm_head.weight",
 )
+
+logger = logging.getLogger(__name__)
+
+
+def get_dspark_rotation_path(vllm_config: VllmConfig) -> Path | None:
+    """Resolve the target QuaRot matrix used to align DSpark FC weights.
+
+    Some ModelSlim checkpoints mark ``is_rot_used`` but leave the newer
+    ``optional.quarot.rotation_map`` metadata empty.  Those checkpoints still
+    publish the matrix at the legacy ``optional/quarot.safetensors`` path.
+    Silently returning ``None`` in that case leaves the draft model in the
+    unrotated basis and collapses speculative-token acceptance.
+    """
+    rotation_path = get_rotation_path(vllm_config)
+    if rotation_path is not None:
+        return rotation_path
+
+    quant_config = vllm_config.quant_config
+    quant_description = getattr(quant_config, "quant_description", {}) if quant_config is not None else {}
+    if not quant_description.get("is_rot_used", False):
+        return None
+
+    target_model_path = Path(vllm_config.model_config.model)
+    legacy_rotation_path = target_model_path / "optional" / "quarot.safetensors"
+    if not legacy_rotation_path.is_file():
+        raise FileNotFoundError(
+            "The target checkpoint declares is_rot_used=true, but DSpark "
+            "could not find optional.quarot.rotation_map.global_rotation "
+            f"metadata or the legacy matrix at {legacy_rotation_path}."
+        )
+
+    logger.warning(
+        "The target checkpoint declares is_rot_used=true but does not provide "
+        "optional.quarot.rotation_map.global_rotation metadata; using the "
+        "legacy DSpark QuaRot matrix at %s.",
+        legacy_rotation_path,
+    )
+    return legacy_rotation_path
 
 
 # Process the first linear weight with rotation matrix, if the target model uses rotary quantization
@@ -80,7 +119,7 @@ class AscendQwen3DSparkForCausalLM(Qwen3DSparkForCausalLM):
                 config=config,
                 prefix=maybe_prefix(model_prefix, "confidence_head"),
             )
-        self.rotation_path = get_rotation_path(vllm_config) if vllm_config.quant_config is not None else None
+        self.rotation_path = get_dspark_rotation_path(vllm_config)
         self.target_model_path = Path(vllm_config.model_config.model)
 
     @staticmethod

--- a/vllm_ascend/patch/platform/patch_kv_cache_utils.py
+++ b/vllm_ascend/patch/platform/patch_kv_cache_utils.py
@@ -18,14 +18,24 @@ from vllm.v1.kv_cache_interface import (
     MambaSpec,
     MLAAttentionSpec,
     SlidingWindowMLASpec,
+    SlidingWindowSpec,
     UniformTypeKVCacheSpecs,
     get_kv_cache_spec_kind,
+)
+
+from vllm_ascend.core.kv_cache_interface import (
+    AscendMLAAttentionSpec,
+    AscendSFAIndexerCacheSpec,
 )
 
 _KIMI_K3_TARGET_LAYER_PREFIX = "language_model.model.layers."
 _KIMI_K3_DRAFT_LAYER_PREFIX = "model.layers."
 _orig_resolve_kv_cache_block_sizes = vllm.v1.core.kv_cache_utils.resolve_kv_cache_block_sizes
 _orig_get_kv_cache_groups_uniform_page_size = vllm.v1.core.kv_cache_utils._get_kv_cache_groups_uniform_page_size
+_orig_get_kv_cache_groups = vllm.v1.core.kv_cache_utils.get_kv_cache_groups
+_orig_get_kv_cache_config_from_groups = vllm.v1.core.kv_cache_utils.get_kv_cache_config_from_groups
+_orig_pool_bytes_per_block = vllm.v1.core.kv_cache_utils._pool_bytes_per_block
+_orig_max_memory_usage_bytes_from_groups = vllm.v1.core.kv_cache_utils._max_memory_usage_bytes_from_groups
 
 
 if UniformTypeKVCacheSpecs.max_num_blocks_per_req is KVCacheSpec.max_num_blocks_per_req:
@@ -46,6 +56,173 @@ if UniformTypeKVCacheSpecs.max_num_blocks_per_req is KVCacheSpec.max_num_blocks_
     UniformTypeKVCacheSpecs.max_num_blocks_per_req = (  # type: ignore[method-assign]
         _uniform_type_max_num_blocks_per_req
     )
+
+
+def _partition_mla_regular_swa_specs(
+    kv_cache_specs: dict[str, KVCacheSpec],
+) -> tuple[dict[str, KVCacheSpec], dict[str, KVCacheSpec]] | None:
+    """Recognize GLM MLA/indexer target caches plus regular DSpark SWA."""
+    target_specs: dict[str, KVCacheSpec] = {}
+    draft_specs: dict[str, KVCacheSpec] = {}
+    has_main_mla = False
+    has_indexer = False
+    for layer_name, spec in kv_cache_specs.items():
+        if isinstance(spec, AscendMLAAttentionSpec):
+            # A compressed target cache needs CompressAttentionManager.  Do
+            # not alter its grouping/representative as part of this narrowly
+            # scoped DSpark SWA fix.
+            if spec.compress_ratio != 1:
+                return None
+            target_specs[layer_name] = spec
+            has_main_mla = True
+        elif isinstance(spec, AscendSFAIndexerCacheSpec):
+            target_specs[layer_name] = spec
+            has_indexer = True
+        elif isinstance(spec, SlidingWindowSpec) and not isinstance(
+            spec, SlidingWindowMLASpec
+        ):
+            draft_specs[layer_name] = spec
+        else:
+            return None
+    if not (has_main_mla and has_indexer and draft_specs):
+        return None
+    # The scheduler uses the first spec in a UniformType group as its manager
+    # representative. Preserve the model's target-spec order so this wrapper
+    # does not change the already validated target-cache manager semantics.
+    return target_specs, draft_specs
+
+
+def _is_mla_regular_swa_groups(
+    kv_cache_groups: list[KVCacheGroupSpec],
+) -> bool:
+    if len(kv_cache_groups) != 2:
+        return False
+    if not all(
+        isinstance(group.kv_cache_spec, UniformTypeKVCacheSpecs)
+        for group in kv_cache_groups
+    ):
+        return False
+    combined_specs: dict[str, KVCacheSpec] = {}
+    for group in kv_cache_groups:
+        group_spec = group.kv_cache_spec
+        assert isinstance(group_spec, UniformTypeKVCacheSpecs)
+        if set(group.layer_names) != set(group_spec.kv_cache_specs):
+            return False
+        combined_specs.update(group_spec.kv_cache_specs)
+    return _partition_mla_regular_swa_specs(combined_specs) is not None
+
+
+def _dspark_native_layout_enabled(vllm_config: VllmConfig) -> bool:
+    speculative_config = getattr(vllm_config, "speculative_config", None)
+    scheduler_config = getattr(vllm_config, "scheduler_config", None)
+    use_dspark = getattr(speculative_config, "use_dspark", None)
+    return (
+        callable(use_dspark)
+        and use_dspark()
+        and scheduler_config is not None
+        and not scheduler_config.disable_hybrid_kv_cache_manager
+    )
+
+
+def _use_dspark_native_layout(
+    vllm_config: VllmConfig,
+    kv_cache_groups: list[KVCacheGroupSpec],
+) -> bool:
+    return _dspark_native_layout_enabled(vllm_config) and _is_mla_regular_swa_groups(
+        kv_cache_groups
+    )
+
+
+def _native_layout_bytes_per_block(
+    kv_cache_groups: list[KVCacheGroupSpec],
+) -> int:
+    total = 0
+    for group in kv_cache_groups:
+        group_spec = group.kv_cache_spec
+        assert isinstance(group_spec, UniformTypeKVCacheSpecs)
+        total += sum(
+            group_spec.kv_cache_specs[layer_name].page_size_bytes
+            for layer_name in group.layer_names
+        )
+    assert total > 0
+    return total
+
+
+def _ascend_get_kv_cache_groups(
+    vllm_config: VllmConfig,
+    kv_cache_specs: dict[str, KVCacheSpec],
+) -> list[KVCacheGroupSpec]:
+    partition = _partition_mla_regular_swa_specs(kv_cache_specs)
+    if partition is None or not _dspark_native_layout_enabled(vllm_config):
+        return _orig_get_kv_cache_groups(vllm_config, kv_cache_specs)
+
+    target_specs, draft_specs = partition
+    target_uniform = UniformTypeKVCacheSpecs.from_specs(target_specs)
+    draft_uniform = UniformTypeKVCacheSpecs.from_specs(draft_specs)
+    if target_uniform is None or draft_uniform is None:
+        return _orig_get_kv_cache_groups(vllm_config, kv_cache_specs)
+    return [
+        KVCacheGroupSpec(list(target_specs), target_uniform),
+        KVCacheGroupSpec(list(draft_specs), draft_uniform),
+    ]
+
+
+def _ascend_get_kv_cache_config_from_groups(
+    vllm_config: VllmConfig,
+    kv_cache_groups: list[KVCacheGroupSpec],
+    available_memory: int,
+) -> KVCacheConfig:
+    if not _use_dspark_native_layout(vllm_config, kv_cache_groups):
+        return _orig_get_kv_cache_config_from_groups(
+            vllm_config, kv_cache_groups, available_memory
+        )
+
+    bytes_per_block = _native_layout_bytes_per_block(kv_cache_groups)
+    num_blocks = max(available_memory // bytes_per_block, 0)
+    num_blocks = may_override_num_blocks(vllm_config, num_blocks)
+    kv_cache_tensors: list[KVCacheTensor] = []
+    for group in kv_cache_groups:
+        group_spec = group.kv_cache_spec
+        assert isinstance(group_spec, UniformTypeKVCacheSpecs)
+        for layer_name in group.layer_names:
+            layer_spec = group_spec.kv_cache_specs[layer_name]
+            kv_cache_tensors.append(
+                KVCacheTensor(
+                    size=layer_spec.page_size_bytes * num_blocks,
+                    shared_by=[layer_name],
+                )
+            )
+    return KVCacheConfig(
+        num_blocks=num_blocks,
+        kv_cache_tensors=kv_cache_tensors,
+        kv_cache_groups=kv_cache_groups,
+    )
+
+
+def _ascend_pool_bytes_per_block(
+    vllm_config: VllmConfig,
+    kv_cache_groups: list[KVCacheGroupSpec],
+) -> int:
+    if _use_dspark_native_layout(vllm_config, kv_cache_groups):
+        return _native_layout_bytes_per_block(kv_cache_groups)
+    return _orig_pool_bytes_per_block(vllm_config, kv_cache_groups)
+
+
+def _ascend_max_memory_usage_bytes_from_groups(
+    vllm_config: VllmConfig,
+    kv_cache_groups: list[KVCacheGroupSpec],
+) -> int:
+    if not _use_dspark_native_layout(vllm_config, kv_cache_groups):
+        return _orig_max_memory_usage_bytes_from_groups(
+            vllm_config, kv_cache_groups
+        )
+    bytes_per_block = _native_layout_bytes_per_block(kv_cache_groups)
+    blocks_needed = 0
+    for group in kv_cache_groups:
+        group_spec = group.kv_cache_spec
+        assert isinstance(group_spec, UniformTypeKVCacheSpecs)
+        blocks_needed += group_spec.max_memory_usage_pages(vllm_config)
+    return bytes_per_block * blocks_needed
 
 
 def _ascend_resolve_kv_cache_block_sizes(
@@ -375,6 +552,14 @@ def _get_kv_cache_config_deepseek_v4(
 
 
 vllm.v1.core.kv_cache_utils.resolve_kv_cache_block_sizes = _ascend_resolve_kv_cache_block_sizes
+vllm.v1.core.kv_cache_utils.get_kv_cache_groups = _ascend_get_kv_cache_groups
+vllm.v1.core.kv_cache_utils.get_kv_cache_config_from_groups = (
+    _ascend_get_kv_cache_config_from_groups
+)
+vllm.v1.core.kv_cache_utils._pool_bytes_per_block = _ascend_pool_bytes_per_block
+vllm.v1.core.kv_cache_utils._max_memory_usage_bytes_from_groups = (
+    _ascend_max_memory_usage_bytes_from_groups
+)
 vllm.v1.core.kv_cache_utils.group_and_unify_kv_cache_specs = group_and_unify_kv_cache_specs
 vllm.v1.core.kv_cache_utils._get_kv_cache_groups_uniform_groups = _get_kv_cache_groups_uniform_groups
 vllm.v1.core.kv_cache_utils._get_kv_cache_groups_uniform_page_size = _get_kv_cache_groups_uniform_page_size

--- a/vllm_ascend/spec_decode/dspark_proposer.py
+++ b/vllm_ascend/spec_decode/dspark_proposer.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
+import copy
 from typing import Any
 
 import torch
@@ -21,7 +22,7 @@ from vllm_ascend.ops.triton.spec_decode.utils import (
     copy_and_expand_dflash_and_dspark_inputs_kernel,
 )
 from vllm_ascend.spec_decode.dflash_proposer import AscendDflashProposer, _compute_num_programs
-from vllm_ascend.spec_decode.utils import DynamicSpecScheduler
+from vllm_ascend.spec_decode.utils import DynamicSpecScheduler, SlidingWindowAdapter
 
 
 class AscendDSparkProposer(AscendDflashProposer):
@@ -223,6 +224,78 @@ class AscendDSparkProposer(AscendDflashProposer):
             attn_group.kv_cache_group_id: torch.zeros(self.max_num_tokens, dtype=torch.int32, device=self.device)
             for attn_group in self.draft_attn_groups
         }
+        if getattr(self, "draft_window_size", None) is not None:
+            group_block_sizes: dict[int, int] = {}
+            for attn_group in self.draft_attn_groups:
+                gid = attn_group.kv_cache_group_id
+                block_size = int(attn_group.kv_cache_spec.block_size)
+                previous = group_block_sizes.setdefault(gid, block_size)
+                if previous != block_size:
+                    raise RuntimeError(
+                        "DSpark attention layers in one KV cache group must "
+                        f"share a block size, but group {gid} has both "
+                        f"{previous} and {block_size}."
+                    )
+            # A FULL graph bucket can contain one virtual remainder request.
+            # Keep a separate persistent output per group so capture and replay
+            # use the same address without cross-group aliasing.
+            self._per_group_sliding_windows = {
+                gid: SlidingWindowAdapter(
+                    self.draft_window_size,
+                    block_size,
+                    self.runner.max_num_reqs + 1,
+                    0,
+                    self.device,
+                )
+                for gid, block_size in group_block_sizes.items()
+            }
+
+    @staticmethod
+    def _pad_metadata_rows(tensor: torch.Tensor, rows: int, value: int) -> torch.Tensor:
+        if tensor.shape[0] >= rows:
+            return tensor[:rows]
+        pad_shape = (rows - tensor.shape[0], *tensor.shape[1:])
+        padding = tensor.new_full(pad_shape, value)
+        return torch.cat((tensor, padding), dim=0)
+
+    def _prepare_dspark_group_metadata(
+        self,
+        common_attn_metadata: AscendCommonAttentionMetadata,
+        attn_group: AttentionGroup,
+        num_input_tokens: int,
+        real_num_reqs: int | None = None,
+    ) -> AscendCommonAttentionMetadata:
+        """Select and window one DSpark KV group's persistent metadata."""
+        common_attn_metadata = copy.copy(common_attn_metadata)
+        gid = attn_group.kv_cache_group_id
+        rows = common_attn_metadata.num_reqs
+        source_rows = rows if real_num_reqs is None else real_num_reqs
+
+        block_table = self._per_group_block_table_buffers[gid][:source_rows]
+        common_attn_metadata.block_table_tensor = self._pad_metadata_rows(
+            block_table, rows, 0
+        )
+        common_attn_metadata.slot_mapping = (
+            self._per_group_query_slot_mapping_buffers[gid][:num_input_tokens]
+        )
+        if getattr(self, "draft_window_size", None) is not None:
+            common_attn_metadata.seq_lens = self._pad_metadata_rows(
+                common_attn_metadata.seq_lens[:source_rows], rows, 1
+            )
+            for name in ("seq_lens_cpu", "_seq_lens_cpu", "seq_lens_cpu_upper_bound"):
+                value = getattr(common_attn_metadata, name, None)
+                if value is not None:
+                    setattr(
+                        common_attn_metadata,
+                        name,
+                        self._pad_metadata_rows(value[:source_rows], rows, 1),
+                    )
+            sliding_window = getattr(self, "_per_group_sliding_windows", {}).get(
+                gid, getattr(self, "sliding_window", None)
+            )
+            assert sliding_window is not None
+            sliding_window.apply(common_attn_metadata)
+        return common_attn_metadata
 
     def set_per_group_attn_metadata(
         self,
@@ -464,6 +537,12 @@ class AscendDSparkProposer(AscendDflashProposer):
                     causal=causal,
                     is_prefilling=torch.zeros(num_metadata_reqs, dtype=torch.bool),
                     block_table_tensor=self._per_group_block_table_buffers[gid][:num_reqs],
+                )
+                common_attn_metadata = self._prepare_dspark_group_metadata(
+                    common_attn_metadata,
+                    attn_group,
+                    num_input_tokens,
+                    real_num_reqs=num_reqs,
                 )
                 metadata = attn_group.get_metadata_builder().build_for_graph_capture(
                     common_attn_metadata,

--- a/vllm_ascend/spec_decode/dspark_proposer.py
+++ b/vllm_ascend/spec_decode/dspark_proposer.py
@@ -5,17 +5,21 @@ from typing import Any
 
 import torch
 from vllm.config import CUDAGraphMode, VllmConfig, get_layers_from_vllm_config
+from vllm.forward_context import get_forward_context
+from vllm.logger import logger
 from vllm.model_executor.layers.attention_layer_base import AttentionLayerBase
 from vllm.v1.attention.backends.utils import CommonAttentionMetadata
 from vllm.v1.kv_cache_interface import UniformTypeKVCacheSpecs
 from vllm.v1.worker.utils import AttentionGroup
 
 from vllm_ascend.ascend_config import get_ascend_config
-from vllm_ascend.ascend_forward_context import set_ascend_forward_context
+from vllm_ascend.ascend_forward_context import _EXTRA_CTX, set_ascend_forward_context
 from vllm_ascend.attention.attention_v1 import AscendAttentionState
 from vllm_ascend.attention.dsa_v1 import AscendDSAMetadataBuilder
-from vllm_ascend.attention.utils import enable_pcp
-from vllm_ascend.ops.triton.spec_decode.utils import copy_and_expand_dflash_and_dspark_inputs_kernel
+from vllm_ascend.attention.utils import AscendCommonAttentionMetadata, enable_pcp
+from vllm_ascend.ops.triton.spec_decode.utils import (
+    copy_and_expand_dflash_and_dspark_inputs_kernel,
+)
 from vllm_ascend.spec_decode.dflash_proposer import AscendDflashProposer, _compute_num_programs
 from vllm_ascend.spec_decode.utils import DynamicSpecScheduler
 
@@ -69,10 +73,21 @@ class AscendDSparkProposer(AscendDflashProposer):
                 num_speculative_tokens=self.num_speculative_tokens,
                 device=device,
             )
-        # DSpark runs eager only (Ascend cudagraph unsupported on this path).
-        self.use_cuda_graph = False
-        # Max query tokens depend on whether sampling from anchor or not.
-        self.max_query_tokens = self.max_batch_size * self.num_query_per_req
+        # Dynamic verify-length performs a periodic host synchronization and
+        # therefore cannot be captured together with the query-block graph.
+        # Preserve the base proposer's ACLGraph decision for static DSpark.
+        self.use_cuda_graph = getattr(self, "use_cuda_graph", False)
+        if dynamic_spec_config.method == "dspark" and self.use_cuda_graph:
+            logger.warning(
+                "DSpark dynamic verify-length is not compatible with ACLGraph; "
+                "the draft model is falling back to eager mode."
+            )
+            self.use_cuda_graph = False
+        # FULL graph buckets follow the target verification width (1 + N),
+        # while sample-from-anchor DSpark has only N real query tokens. Keep
+        # room for the virtual request that pads the draft query block to the
+        # target graph bucket.
+        self.max_query_tokens = self.max_batch_size * (1 + self.num_speculative_tokens)
         # Position ids for the draft query block [max_query_tokens].
         # Overrides dflash:49; v2 uses input_buffers.positions.
         self.positions = torch.zeros(
@@ -338,6 +353,39 @@ class AscendDSparkProposer(AscendDflashProposer):
 
         return num_query_total, token_indices_to_sample, cad, None
 
+    def pad_query_start_loc_for_graph(
+        self,
+        query_start_loc,
+        num_input_tokens: int,
+        real_num_reqs: int,
+        graph_num_reqs: int,
+    ) -> int:
+        """Pad DSpark's N-token queries to target (1+N) graph buckets.
+
+        The runner's generic helper assumes every real request already has the
+        target verification width. With sample-from-anchor DSpark, real draft
+        requests have only N tokens, so that shortcut leaves the graph key at
+        N instead of 1+N. Build the virtual requests using the draft width,
+        then append one remainder request so capture and replay have identical
+        query_start_loc layouts for the same bucket.
+        """
+        last_loc = int(query_start_loc.np[real_num_reqs])
+        metadata_reqs = real_num_reqs
+
+        for req_idx in range(real_num_reqs, graph_num_reqs):
+            last_loc += self.num_query_per_req
+            assert last_loc <= num_input_tokens
+            query_start_loc.np[req_idx + 1] = last_loc
+            metadata_reqs += 1
+
+        if last_loc < num_input_tokens:
+            query_start_loc.np[metadata_reqs + 1] = num_input_tokens
+            metadata_reqs += 1
+
+        assert int(query_start_loc.np[metadata_reqs]) == num_input_tokens
+        query_start_loc.copy_to_gpu()
+        return metadata_reqs
+
     @torch.inference_mode()
     def dummy_run(
         self,
@@ -351,7 +399,10 @@ class AscendDSparkProposer(AscendDflashProposer):
         **kwargs,
     ) -> None:
         num_query_total = num_reqs * self.num_query_per_req
-        num_query_tokens = min(num_query_total if num_reqs > 0 else num_tokens, self.max_query_tokens)
+        num_query_tokens = num_query_total if num_reqs > 0 else num_tokens
+        if aclgraph_runtime_mode == CUDAGraphMode.FULL and batch_descriptor is not None:
+            num_query_tokens = batch_descriptor.num_tokens
+        num_query_tokens = min(num_query_tokens, self.max_query_tokens)
 
         (
             num_input_tokens,
@@ -368,8 +419,65 @@ class AscendDSparkProposer(AscendDflashProposer):
         self.token_indices_to_sample.fill_(0)
         self._pad_draft_buffers(num_query_total, num_input_tokens)
 
+        multi_steps_attn_metadata = []
+        if aclgraph_runtime_mode == CUDAGraphMode.FULL and self.draft_attn_groups:
+            query_start_loc_cpu = (
+                torch.from_numpy(self.token_arange_np[: num_reqs + 1]).clone()
+                * self.num_query_per_req
+            )
+            if num_input_tokens > num_query_total:
+                query_start_loc_cpu = torch.cat(
+                    [
+                        query_start_loc_cpu,
+                        query_start_loc_cpu.new_tensor([num_input_tokens]),
+                    ]
+                )
+            num_metadata_reqs = query_start_loc_cpu.shape[0] - 1
+            query_start_loc = query_start_loc_cpu.to(self.device)
+            assert num_input_tokens <= self.max_query_tokens, (
+                f"DSpark graph query size {num_input_tokens} exceeds persistent "
+                f"buffer capacity {self.max_query_tokens}."
+            )
+            assert int(query_start_loc_cpu[-1]) == num_input_tokens
+            self._per_group_block_table_buffers = {
+                group.kv_cache_group_id: self._per_group_block_tables[group.kv_cache_group_id]
+                for group in self.draft_attn_groups
+            }
+            per_layer_attn_metadata: dict[str, Any] = {}
+            causal = self.model.get_draft_attn_causal()[0]
+            for attn_group in self.draft_attn_groups:
+                gid = attn_group.kv_cache_group_id
+                common_attn_metadata = AscendCommonAttentionMetadata(
+                    query_start_loc=query_start_loc,
+                    query_start_loc_cpu=query_start_loc_cpu,
+                    seq_lens_cpu=self.runner.optimistic_seq_lens_cpu[:num_reqs],
+                    seq_lens_cpu_upper_bound=self.runner.optimistic_seq_lens_cpu[:num_reqs],
+                    seq_lens=self.runner.seq_lens[:num_reqs],
+                    num_reqs=num_metadata_reqs,
+                    num_actual_tokens=num_query_total,
+                    num_input_tokens=num_input_tokens,
+                    max_query_len=self.num_query_per_req,
+                    max_seq_len=0,
+                    slot_mapping=self._per_group_query_slot_mapping_buffers[gid][:num_input_tokens],
+                    positions=self.positions,
+                    attn_state=AscendAttentionState.ChunkedPrefill,
+                    causal=causal,
+                    is_prefilling=torch.zeros(num_metadata_reqs, dtype=torch.bool),
+                    block_table_tensor=self._per_group_block_table_buffers[gid][:num_reqs],
+                )
+                metadata = attn_group.get_metadata_builder().build_for_graph_capture(
+                    common_attn_metadata,
+                    AscendAttentionState.ChunkedPrefill,
+                )
+                if hasattr(metadata, "attn_mask") and not causal:
+                    metadata.attn_mask = None
+                metadata.attn_state = AscendAttentionState.ChunkedPrefill
+                for layer_name in attn_group.layer_names:
+                    per_layer_attn_metadata[layer_name] = metadata
+            multi_steps_attn_metadata.append(per_layer_attn_metadata)
+
         with set_ascend_forward_context(
-            None,
+            multi_steps_attn_metadata[0] if multi_steps_attn_metadata else None,
             self.vllm_config,
             num_tokens=num_input_tokens,
             num_tokens_across_dp=num_tokens_across_dp,
@@ -378,7 +486,7 @@ class AscendDSparkProposer(AscendDflashProposer):
             batch_descriptor=batch_descriptor,
             aclgraph_runtime_mode=aclgraph_runtime_mode,
             is_draft_model=True,
-            draft_attn_metadatas=[],
+            draft_attn_metadatas=multi_steps_attn_metadata,
         ):
             if is_profile:
                 self.model.precompute_and_store_context_kv(context_states, context_positions)
@@ -396,6 +504,10 @@ class AscendDSparkProposer(AscendDflashProposer):
                     token_indices_to_sample=self.token_indices_to_sample[: num_reqs * self.num_speculative_tokens],
                     target_positions=self._get_positions(num_input_tokens),
                     inputs_embeds=None,
-                    multi_steps_attn_metadata=[],
+                    multi_steps_attn_metadata=multi_steps_attn_metadata,
                     num_tokens=num_input_tokens,
                 )
+
+            forward_context = get_forward_context()
+            if forward_context.cudagraph_runtime_mode == CUDAGraphMode.FULL and not _EXTRA_CTX.capturing:
+                self._update_full_graph_params(forward_context, num_input_tokens, multi_steps_attn_metadata)

--- a/vllm_ascend/spec_decode/llm_base_proposer.py
+++ b/vllm_ascend/spec_decode/llm_base_proposer.py
@@ -304,6 +304,7 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
         self.use_eagle = self.runner.use_eagle
         self.draft_window_size = None
         self.sliding_window = None
+        self._per_group_sliding_windows: dict[int, SlidingWindowAdapter] = {}
 
     def _raise_if_padded_drafter_batch_disabled_and_full_graph_enabled(self):
         if (
@@ -2478,6 +2479,7 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
             )
             else None
         )
+        base_common_attn_metadata = common_attn_metadata
         for attn_group in self.draft_attn_groups:
             builder = attn_group.get_metadata_builder()
             device_metadata_provider = (
@@ -2489,23 +2491,11 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
             if self.use_compress:
                 extra_attn_metadata_args["block_size"] = attn_group.kv_cache_spec.block_size
             if self.method == "dspark":
-                gid = attn_group.kv_cache_group_id
-                common_attn_metadata = copy.copy(common_attn_metadata)
-                block_table = getattr(self, "_per_group_block_table_buffers", {}).get(gid)
-                if block_table is not None:
-                    common_attn_metadata.block_table_tensor = block_table[: common_attn_metadata.num_reqs]
-                slot_mapping = self._per_group_query_slot_mapping_buffers[gid]
-                if slot_mapping is not None:
-                    common_attn_metadata.slot_mapping = slot_mapping[:num_input_tokens]
-                # Apply the sliding window to the per-group block_table + seq_lens
-                # that DSpark's draft FIA actually reads. This branch overwrites
-                # common_attn_metadata.block_table_tensor with the full per-group
-                # table, so the window applied earlier (line 922) is bypassed; we
-                # skipped it there for dspark and re-apply here on the per-group
-                # table so FIA reads the recent-blocks clone instead of block 0.
-                # (dspark only - self.sliding_window is None for MTP.)
-                if self.sliding_window is not None:
-                    self.sliding_window.apply(common_attn_metadata)
+                common_attn_metadata = self._prepare_dspark_group_metadata(
+                    base_common_attn_metadata,
+                    attn_group,
+                    num_input_tokens,
+                )
                 attn_metadata = builder.build_for_drafting(
                     common_attn_metadata, draft_index=1, **extra_attn_metadata_args
                 )

--- a/vllm_ascend/spec_decode/llm_base_proposer.py
+++ b/vllm_ascend/spec_decode/llm_base_proposer.py
@@ -110,6 +110,19 @@ def _is_glm_model(model_config) -> bool:
     return "glm" in str(model_type).lower()
 
 
+def _supports_spec_decode_graph(model_config, method: str) -> bool:
+    """Return whether graph-mode drafting is supported for this model/method.
+
+    GLM graph-mode support is currently validated only for the GLM-MoE-DSA
+    MTP and DSpark drafters. Keep other GLM variants and speculative methods
+    on the existing eager path.
+    """
+    if not _is_glm_model(model_config):
+        return True
+    model_type = getattr(getattr(model_config, "hf_text_config", None), "model_type", "")
+    return str(model_type).lower() == "glm_moe_dsa" and method in ("mtp", "dspark")
+
+
 class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
     _runnable: ACLGraphWrapper | Callable
 
@@ -216,25 +229,21 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
             self.tp_group_context = nullcontext()
 
         self.use_cuda_graph = self.runner._use_aclgraph() and not self.speculative_config.enforce_eager
-        self._raise_if_padded_drafter_batch_disabled_and_full_graph_enabled()
-
-        # GLM series models: speculative decoding does not yet support running
-        # the draft model in graph mode. Force the draft model to always use
-        # eager mode. This is equivalent to the user adding
-        # `"enforce_eager": true` to the `--speculative-config`, and keeps
-        # the target model's graph-mode setting untouched.
-        # TODO(lilinsiman): Remove this code segment after future versions of the GLM
-        # series models support graph input for speculative inference.
-        if _is_glm_model(self.vllm_config.model_config):
-            if self.use_cuda_graph:
-                logger.warning(
-                    "GLM series models with speculative decoding currently do "
-                    "not support graph mode. The draft model has been "
-                    "automatically switched to eager mode "
-                    "(enforce_eager=true). Graph mode support for GLM "
-                    "speculative decoding will be added in a future release. "
-                )
+        is_glm_model = _is_glm_model(self.vllm_config.model_config)
+        if self.use_cuda_graph and not _supports_spec_decode_graph(self.vllm_config.model_config, self.method):
+            logger.warning(
+                "GLM graph-mode speculative decoding is currently supported "
+                "only for the MTP and DSpark methods. The %s draft model has been "
+                "automatically switched to eager mode.",
+                self.method,
+            )
             self.use_cuda_graph = False
+        elif self.use_cuda_graph and is_glm_model:
+            logger.info(
+                "Enabling ACL graph mode for the GLM-MoE-DSA %s draft model.", self.method
+            )
+
+        self._raise_if_padded_drafter_batch_disabled_and_full_graph_enabled()
 
         # NOTE: _enable_probabilistic_draft_probs is set by the upstream
         # SpecDecodeBaseProposer.__init__.

--- a/vllm_ascend/spec_decode/llm_base_proposer.py
+++ b/vllm_ascend/spec_decode/llm_base_proposer.py
@@ -954,14 +954,31 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
             num_reqs = common_attn_metadata.query_start_loc.shape[0]
             self.query_start_loc.gpu[:num_reqs].copy_(common_attn_metadata.query_start_loc)
             self.query_start_loc.cpu[:num_reqs].copy_(common_attn_metadata.query_start_loc_cpu)
-            num_reqs_padded = self.runner._pad_query_start_loc_for_fia(
-                self.query_start_loc,
-                num_input_tokens,
-                batch_descriptor.num_reqs if batch_descriptor.num_reqs is not None else common_attn_metadata.num_reqs,
-                common_attn_metadata.num_reqs,
-                aclgraph_runtime_mode,
-                batch_descriptor.num_reqs,
-            )
+            if self.method == "dspark":
+                graph_num_reqs = (
+                    batch_descriptor.num_reqs
+                    if batch_descriptor.num_reqs is not None
+                    else common_attn_metadata.num_reqs
+                )
+                num_reqs_padded = self.pad_query_start_loc_for_graph(
+                    self.query_start_loc,
+                    num_input_tokens,
+                    common_attn_metadata.num_reqs,
+                    graph_num_reqs,
+                )
+            else:
+                num_reqs_padded = self.runner._pad_query_start_loc_for_fia(
+                    self.query_start_loc,
+                    num_input_tokens,
+                    (
+                        batch_descriptor.num_reqs
+                        if batch_descriptor.num_reqs is not None
+                        else common_attn_metadata.num_reqs
+                    ),
+                    common_attn_metadata.num_reqs,
+                    aclgraph_runtime_mode,
+                    batch_descriptor.num_reqs,
+                )
             common_attn_metadata.num_reqs = num_reqs_padded
             common_attn_metadata.query_start_loc = self.query_start_loc.gpu[: num_reqs_padded + 1]
             common_attn_metadata.query_start_loc_cpu = self.query_start_loc.cpu[: num_reqs_padded + 1]
@@ -1058,6 +1075,12 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
         multi_steps_attn_metadata, attn_metadata_i = self.build_draft_attn_metadata(
             common_attn_metadata, num_input_tokens, num_tokens
         )
+        if self.method == "dspark" and self.use_cuda_graph:
+            graph_key = attn_metadata_i.actual_seq_lengths_q[-1]
+            assert graph_key == num_input_tokens, (
+                f"DSpark runtime metadata graph key {graph_key} does not match "
+                f"dispatched query size {num_input_tokens}."
+            )
 
         if self.uses_mrope:
             used_update_positions = self.mrope_positions[:, token_indices_to_sample]
@@ -1134,6 +1157,13 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
         )
         if active_device_metadata_executor is not None and not active_device_metadata_executor.submission_in_flight:
             active_device_metadata_executor = None
+
+        # DSpark context K/V has a step-dependent shape, so it must execute
+        # eagerly outside the captured query-block graph. The persistent
+        # context slot-mapping buffers prepared by set_inputs_first_pass keep
+        # the eager cache write and graph replay connected to the same cache.
+        if self.method == "dspark":
+            self.build_model_inputs_first_pass(num_input_tokens, self._context_slot_mapping_buffers)
         with set_ascend_forward_context(
             multi_steps_attn_metadata[0],
             self.vllm_config,
@@ -1176,6 +1206,13 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
                 self._update_full_graph_params_if_needed(forward_context, num_input_tokens, multi_steps_attn_metadata)
         if active_device_metadata_executor is not None:
             active_device_metadata_executor.release()
+        if self.method == "dspark":
+            assert draft_token_ids.ndim == 2
+            assert draft_token_ids.shape[0] >= batch_size, (
+                f"DSpark graph returned {draft_token_ids.shape[0]} request rows "
+                f"for a real batch of {batch_size}."
+            )
+            assert draft_token_ids.shape[1] == self.num_speculative_tokens
         return draft_token_ids
 
     def _sample_draft_from_logits(
@@ -1258,9 +1295,9 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
         model_positions = self._get_positions(num_input_tokens)
         model_kwargs = {"input_ids": model_input_ids, "positions": model_positions, "inputs_embeds": inputs_embeds}
 
-        if self.method in ("dflash", "dspark"):
+        if self.method == "dflash":
             self.build_model_inputs_first_pass(num_input_tokens, self._context_slot_mapping_buffers)
-        else:
+        elif self.method != "dspark":
             if self.pass_hidden_states_to_model:
                 model_hidden_states = self.hidden_states[:num_input_tokens]
                 model_hidden_states, model_positions = self.maybe_pad_and_reduce(model_hidden_states, model_positions)
@@ -2300,6 +2337,13 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
     # update full-graph params for one spec token
     def _update_full_graph_params(self, forward_context, num_tokens, draft_attn_metadatas=None):
         assert len(self.draft_attn_groups) > 0
+        if self.method == "dspark" and draft_attn_metadatas:
+            first_layer = self.draft_attn_groups[0].layer_names[0]
+            graph_key = draft_attn_metadatas[0][first_layer].actual_seq_lengths_q[-1]
+            assert graph_key == num_tokens, (
+                f"DSpark graph update key {graph_key} does not match "
+                f"captured query size {num_tokens}."
+            )
         attn_backend = self.draft_attn_groups[0].backend
         update_full_graph_params(
             attn_backend,


### PR DESCRIPTION
## What this PR does

- Preserves DSpark acceptance when rotation-quantized checkpoints use the legacy QuaRot layout.
- Supports DSpark ACLGraph proposal execution, including graph-bucket padding and stable per-group attention metadata.
- Enables GLM-MoE-DSA DSpark on MRV1 ACLGraph.
- Adds physical Qwen3 DSpark draft KV-cache eviction outside `draft_window_size`, with separate draft/target cache groups and async-capacity accounting.
- Handles native singleton KV storages in Mooncake registration while preserving the packed-layout path.
- Aligns MC2 mask capacity with tensor parallelism and updates attention cache-shape compatibility for current vLLM.

## Scope cleanup

This branch was rebuilt on vLLM-Ascend main at `8d838ee86935e872806a4c491d33782e69c59538`. It intentionally excludes the memfabric changes from #15570 and the quantized MoE top-k dtype fix from #15613.

## Validation

- Affected unit-test set: **334 passed, 2 deselected**.
- The two deselected Mooncake thread timing tests fail identically on the unmodified upstream base in this environment; the two new Mooncake registration tests pass.
- `ruff check` passed for all changed Python files.
- `python -m compileall` passed for all changed Python files.
- `git diff --check` passed.
- vLLM main: https://github.com/vllm-project/vllm/commit/ba07e4a48fc951300d97eb506217dd530583dea3
