### PR TITLE
[BugFix][MoE] Align MC2 mask capacity with tensor parallelism

### DIFF
--- a/tests/ut/test_ascend_forward_context.py
+++ b/tests/ut/test_ascend_forward_context.py
@@ -15,6 +15,7 @@ from vllm_ascend.device.hardware_profile import get_hardware_profile
 @pytest.fixture(autouse=True)
 def reset_mc2_tokens_capacity(monkeypatch):
     monkeypatch.setattr(afc, "_mc2_tokens_capacity", None)
+    monkeypatch.setattr(afc, "_reserved_mc2_mask", None)
     monkeypatch.setattr(
         afc,
         "get_ascend_config",
@@ -241,6 +242,35 @@ def test_is_decode_only_node_false_without_recompute_scheduler(monkeypatch):
     )
 
     assert afc._is_decode_only_node(vllm_config) is False
+
+
+@pytest.mark.parametrize(
+    ("max_num_batched_tokens", "expected_mask_tokens"),
+    [(80, 80), (90, 96)],
+)
+def test_set_mc2_mask_aligns_capacity_to_tp(
+    monkeypatch,
+    max_num_batched_tokens,
+    expected_mask_tokens,
+):
+    monkeypatch.setattr(afc, "is_moe_model", lambda _: True)
+    vllm_config = _make_vllm_config(
+        tensor_parallel_size=8,
+        max_num_batched_tokens=max_num_batched_tokens,
+    )
+
+    afc.set_mc2_mask(vllm_config, device="cpu")
+
+    assert afc.get_mc2_mask().shape == (expected_mask_tokens,)
+
+
+def test_set_mc2_mask_clears_cached_mask_for_non_moe(monkeypatch):
+    monkeypatch.setattr(afc, "_reserved_mc2_mask", torch.ones(8, dtype=torch.bool))
+    monkeypatch.setattr(afc, "is_moe_model", lambda _: False)
+
+    afc.set_mc2_mask(_make_vllm_config(), device="cpu")
+
+    assert afc.get_mc2_mask() is None
 
 
 def test_select_moe_comm_method_returns_none_for_non_moe(monkeypatch):

--- a/vllm_ascend/ascend_forward_context.py
+++ b/vllm_ascend/ascend_forward_context.py
@@ -263,14 +263,15 @@ def get_mc2_tokens_capacity():
 
 def set_mc2_mask(vllm_config, device):
     global _reserved_mc2_mask
+    if not is_moe_model(vllm_config):
+        _reserved_mc2_mask = None
+        return
     if _reserved_mc2_mask is not None:
         return
-    if is_moe_model(vllm_config):
-        _reserved_mc2_mask = torch.zeros(
-            vllm_config.scheduler_config.max_num_batched_tokens, dtype=torch.bool, device=device
-        )
-    else:
-        _reserved_mc2_mask = None
+    max_num_tokens = vllm_config.scheduler_config.max_num_batched_tokens
+    tp_size = vllm_config.parallel_config.tensor_parallel_size
+    padded_num_tokens = (max_num_tokens + tp_size - 1) // tp_size * tp_size
+    _reserved_mc2_mask = torch.zeros(padded_num_tokens, dtype=torch.bool, device=device)
 
 
 def get_mc2_mask():


### PR DESCRIPTION
## Problem

MC2 mask buffers were sized from the local token count even when distributed execution padded the working token capacity to a tensor-parallel-aligned size.

## Change

Use the TP-aligned token capacity for MC2 mask allocation and preserve the real-token boundary used by consumers.

## Validation

- `tests/ut/test_ascend_forward_context.py`: **30 passed**
- `ruff check`, `compileall`, and `git diff --check` passed.

- vLLM main: https://github.com/vllm-project/vllm/commit/84030bbe3d74d99bad477a3d2e37a973ccd8865c
