### PR TITLE
[BugFix][KV Pool] Align layerwise MTP final-block trim to lcm boundary and pass lease TTL to memcache batch_alloc

### DIFF
--- a/tests/ut/distributed/ascend_store/test_pool_scheduler.py
+++ b/tests/ut/distributed/ascend_store/test_pool_scheduler.py
@@ -163,6 +163,33 @@ class TestKVPoolScheduler(unittest.TestCase):
         self.assertTrue(load_spec.can_load)
 
     @patch("vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.pool_scheduler.LookupKeyClient")
+    def test_layerwise_mtp_hit_on_final_block_boundary_not_trimmed(self, mock_client_cls):
+        scheduler = KVPoolScheduler(
+            self._make_config(block_size=16, extra_config={"backend": "memcache"}),
+            use_layerwise=True,
+        )
+        scheduler.use_eagle = True
+        scheduler.cache_transfer_granularity = 16
+        scheduler._get_layerwise_hit_tokens = MagicMock(return_value=96)
+
+        request = MagicMock()
+        request.prompt_token_ids = list(range(100))
+        request.num_tokens = 101
+        request.request_id = "r1"
+        request.block_hashes = [b"h"] * 7
+
+        need, is_async = scheduler.get_num_new_matched_tokens(request, 0)
+
+        # The hit (96) stops exactly on the final block's start boundary
+        # ((101 - 1) // 16 * 16 = 96) and must be loaded as-is instead of
+        # being trimmed back by one whole lcm block.
+        self.assertEqual(need, 96)
+        self.assertFalse(is_async)
+        load_spec = scheduler.load_specs["r1"]
+        self.assertEqual(load_spec.kvpool_cached_tokens, 96)
+        self.assertEqual(load_spec.kvpool_store_skip_tokens, 96)
+
+    @patch("vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.pool_scheduler.LookupKeyClient")
     def test_get_num_new_matched_tokens_full_hbm_hit_skips_external_lookup(self, mock_client_cls):
         scheduler = KVPoolScheduler(self._make_config(block_size=16), use_layerwise=False)
         request = MagicMock()

--- a/tests/ut/distributed/ascend_store/test_pool_worker.py
+++ b/tests/ut/distributed/ascend_store/test_pool_worker.py
@@ -1456,6 +1456,10 @@ class TestKVPoolWorkerProcessLayerData(unittest.TestCase):
         )
 
     def test_evicted_allocated_gva_is_reallocated(self):
+        from vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.pool_worker import (
+            LAYERWISE_READ_LEASE_TTL_MS,
+        )
+
         worker = self._make_gva_worker()
         key = worker._make_layerwise_full_key(0, "h0")
         worker._allocated_gvas[key] = 101
@@ -1465,7 +1469,7 @@ class TestKVPoolWorkerProcessLayerData(unittest.TestCase):
 
         worker._alloc_gvas_for_save([request])
 
-        worker.m_store.batch_alloc.assert_called_once_with([key], [64])
+        worker.m_store.batch_alloc.assert_called_once_with([key], [64], LAYERWISE_READ_LEASE_TTL_MS)
         self.assertEqual(worker._allocated_gvas[key], 202)
         self.assertEqual(request.block_gvas_by_group_np[0].tolist(), [202])
 

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/backend/base.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/backend/base.py
@@ -42,7 +42,7 @@ class Backend(ABC):
     def batch_get_key_info(self, keys: list[str]):
         raise NotImplementedError(f"{type(self).__name__} does not support batch_get_key_info")
 
-    def batch_alloc(self, keys: list[str], sizes: list[int]) -> list[int]:
+    def batch_alloc(self, keys: list[str], sizes: list[int], lease_ttl_ms: int = 0) -> list[int]:
         raise NotImplementedError(f"{type(self).__name__} does not support batch_alloc")
 
     def batch_add_lease(self, keys: list[str], lease_ttl_ms: int = 0) -> list[int]:

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/backend/memcache_backend.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/backend/memcache_backend.py
@@ -250,10 +250,10 @@ class MemcacheBackend(Backend):
         assert self.store is not None
         return self.store.batch_get_key_info(keys)
 
-    def batch_alloc(self, keys: list[str], sizes: list[int]) -> list[int]:
+    def batch_alloc(self, keys: list[str], sizes: list[int], lease_ttl_ms: int = 0) -> list[int]:
         self.ensure_initialized()
         assert self.store is not None
-        return self.store.batch_alloc(keys, sizes)
+        return self.store.batch_alloc(keys, sizes, lease_ttl_ms)
 
     def batch_add_lease(self, keys: list[str], lease_ttl_ms: int = 0) -> list[int]:
         assert self.store is not None

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/pool_scheduler.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/pool_scheduler.py
@@ -515,7 +515,12 @@ class KVPoolScheduler:
             # rewrite during MTP draft/verify steps. Partial hits that stop on
             # an interior block boundary carry a valid mamba state snapshot
             # at that boundary and can be loaded as-is.
-            hit_reaches_final_block = num_external_hit_tokens > (request.num_tokens - self.lcm_block_size)
+            # The final granularity block starts at the lcm-aligned boundary
+            # containing the last token; num_tokens - lcm_block_size equals
+            # that boundary only for lcm-aligned prompts and over-trims
+            # unaligned prompts whose hit stops exactly on the boundary.
+            final_block_start = (request.num_tokens - 1) // self.lcm_block_size * self.lcm_block_size
+            hit_reaches_final_block = num_external_hit_tokens > final_block_start
             if hit_reaches_final_block:
                 num_external_hit_tokens = max(
                     num_computed_tokens,

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/pool_worker.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/pool_worker.py
@@ -1262,7 +1262,9 @@ class KVPoolWorker:
                         block_gvas.append(0)
 
                 if new_keys:
-                    new_gvas = self.m_store.batch_alloc(new_keys, [alloc_size] * len(new_keys))
+                    new_gvas = self.m_store.batch_alloc(
+                        new_keys, [alloc_size] * len(new_keys), LAYERWISE_READ_LEASE_TTL_MS
+                    )
                     if any(gva <= 0 for gva in new_gvas):
                         logger.error(
                             "alloc_gvas FAIL: req=%s group=%d alloc_size=%d new_keys=%d gvas_sample=%s zero_count=%d",
@@ -1297,6 +1299,7 @@ class KVPoolWorker:
                         allocated = self.m_store.batch_alloc(
                             [partial_key],
                             [alloc_size],
+                            LAYERWISE_READ_LEASE_TTL_MS,
                         )
                         partial_gva = allocated[0] if allocated else 0
                         if partial_gva > 0:


### PR DESCRIPTION
### What this PR does / why we need it?

This PR combines two KV Pool changes and supersedes #15672 (its commit is included here so a single review is enough).

**1. Align the layerwise MTP final-block trim to the lcm block boundary**

- Fixes an over-conservative trim in `KVPoolScheduler.get_num_new_matched_tokens` for the layerwise + EAGLE/MTP path.
- The old condition compared the external hit against `num_tokens - lcm_block_size`, treating it as the final granularity block's start. That equality only holds when the prompt length is a multiple of `lcm_block_size`. For unaligned prompts the threshold is lower than the real (lcm-aligned) block start, so a quantized hit that stops exactly on the final block's start boundary - without entering the block - is trimmed by one whole lcm block. This contradicts the code comment stating that partial hits stopping on an interior block boundary can be loaded as-is.
- The trim now compares against the lcm-aligned start of the block containing the last token (`(num_tokens - 1) // lcm_block_size * lcm_block_size`), so only hits that genuinely reach into the final block are trimmed. Behavior for lcm-aligned prompts is unchanged (covered by the existing unit test).
- Measured impact (DeepSeek-V4-Flash, `block_size=32`, `lcm_block_size=4096`, input length 16000, 90% prefix repetition): the quantized hit is 12288, exactly the start of the final block `[12288, 16384)`. The old threshold `16001 - 4096 = 11905` trimmed the hit to 8192, cutting the pool hit rate to 51.19%. With this fix the full 12288 tokens are loaded and the measured hit rate is 76.78% (expected `floor(0.9 * 16000 / 4096) * 4096 / 16000 = 76.8%`).

**2. Pass lease TTL to memcache batch_alloc** (from #15672)

The memcache_hybrid `batch_alloc` interface supports a `leaseTtlMs` parameter, but vllm-ascend currently only passes `keys` and `sizes`, so allocated blocks are not covered by a lease at allocation time.

- Add `lease_ttl_ms` parameter to `Backend.batch_alloc` and `MemcacheBackend.batch_alloc`, forwarded to the underlying memcache_hybrid store as `leaseTtlMs` (default `0` keeps existing behavior for other backends)
- Pass `LAYERWISE_READ_LEASE_TTL_MS` (5 min, the same constant already used by the layerwise load path) at both GVA allocation call sites in `_alloc_gvas_for_save` so newly allocated blocks are covered by a lease
- Update the UT assertion to cover the new argument

### Does this PR introduce _any_ user-facing change?

No API or configuration change. For layerwise KV pool + MTP workloads with lcm-unaligned prompt lengths, up to one additional granularity block can now be loaded from the pool instead of being recomputed (higher pool hit rate, shorter prefill). Memcache KV pool allocations are now covered by a lease at allocation time.

### How was this patch tested?

- Unit tests on the combined branch (both commits, rebased on latest main): `pytest tests/ut/distributed/ascend_store/` - 338 passed, including:
  - existing `test_layerwise_mtp_hit_uses_safe_load_extent` (aligned case: trim still applies, unchanged);
  - new regression test `test_layerwise_mtp_hit_on_final_block_boundary_not_trimmed` (unaligned case: hit stopping on the final block boundary is not trimmed; fails on the old condition);
  - `tests/ut/distributed/ascend_store/test_pool_worker.py::test_evicted_allocated_gva_is_reallocated` now asserts `batch_alloc` is called with the lease TTL.
- `ruff check` / `ruff format --check` pass.
- Manual verification on DeepSeek-V4-Flash with a layerwise memcache KV pool + MTP (input 16000, 90% prefix repetition): pool hit rate 51.19% -> 76.78%, consistent with the granularity model.

- vLLM main: https://github.com/vllm-project/vllm/commit/ba07e4a48fc951300d97eb506217dd530583dea3
