### PR TITLE
[BugFix] Keep unsupported DeepSeek V4 weights in ND format

### DIFF
--- a/tests/ut/ops/test_linear.py
+++ b/tests/ut/ops/test_linear.py
@@ -59,6 +59,7 @@ class TestAscendUnquantizedLinearMethod(TestBase):
         mock_is_meta = mock.PropertyMock(return_value=False)
         type(self.layer.weight.data).is_meta = mock_is_meta
         self.layer.precast_fp32_weight = False
+        self.layer.skip_weight_nz_conversion = False
 
     @patch("vllm_ascend.utils.get_ascend_config")
     @mock.patch("torch_npu.npu_format_cast")
@@ -86,6 +87,19 @@ class TestAscendUnquantizedLinearMethod(TestBase):
         mock_get_config.return_value = mock_config
         self.method.process_weights_after_loading(self.layer)
         mock_format_cast.assert_called_once()
+
+    @patch("vllm_ascend.utils.get_ascend_config")
+    @mock.patch("torch_npu.npu_format_cast")
+    def test_process_weights_after_loading_skips_nz_for_marked_layer(self, mock_format_cast, mock_get_config):
+        mock_config = MagicMock()
+        mock_config.weight_nz_mode = 2
+        mock_get_config.return_value = mock_config
+        self.layer.skip_weight_nz_conversion = True
+        self.layer.precast_fp32_weight = True
+
+        self.method.process_weights_after_loading(self.layer)
+
+        mock_format_cast.assert_not_called()
 
 
 class TestAscendRowParallelLinear(BaseLinearTest):

--- a/vllm_ascend/models/deepseek_v4/compressor.py
+++ b/vllm_ascend/models/deepseek_v4/compressor.py
@@ -144,6 +144,10 @@ class Compressor(nn.Module):
             return_bias=False,
         )
 
+        # The custom compressor op consumes ND weights directly.
+        self.wkv.skip_weight_nz_conversion = True
+        self.wgate.skip_weight_nz_conversion = True
+
         # The DSV4 compressor kernel only accepts FP32 norm_weight.
         self.norm = RMSNorm(self.head_dim, config.rms_norm_eps, dtype=torch.float32)
 

--- a/vllm_ascend/models/deepseek_v4/model.py
+++ b/vllm_ascend/models/deepseek_v4/model.py
@@ -88,6 +88,8 @@ from vllm_ascend.utils import (
     enable_dsa_cp,
     extract_dsv4_layer_index,
     get_dsv4_compress_ratio,
+    olora_tp_enable,
+    oproj_tp_enable,
 )
 from vllm_ascend.worker.v2.pp_utils import (
     PPTransportDataType,
@@ -534,6 +536,9 @@ class DeepseekV4Attention(nn.Module):
             prefix=f"{prefix}.wo_a",
             return_bias=False,
         )
+        # DSA paths that bypass the Linear method use
+        # npu_transpose_batchmatmul, whose weight must remain ND.
+        self.wo_a.skip_weight_nz_conversion = oproj_tp_enable() or not olora_tp_enable()
         self.wo_b = RowParallelLinear(
             self.n_groups * config.o_lora_rank,
             self.dim,

--- a/vllm_ascend/ops/linear.py
+++ b/vllm_ascend/ops/linear.py
@@ -91,11 +91,14 @@ class AscendUnquantizedLinearMethod(TPWeightSwitchMixin, UnquantizedLinearMethod
     def process_weights_after_loading(self, layer: torch.nn.Module) -> None:
         super().process_weights_after_loading(layer)
         keep_nd_weight = _should_keep_nd_for_compatibility_weight(layer.weight.data)
+        skip_weight_nz_conversion = getattr(layer, "skip_weight_nz_conversion", False)
         # must use fp32 to avoid accuracy degradation in dsv4.
         if getattr(layer, "precast_fp32_weight", False):
             weight_fp32 = layer.weight.data.to(torch.float32)
-            layer.weight_fp32 = weight_fp32 if keep_nd_weight else maybe_trans_nz(weight_fp32)
-        if "conv1d" not in layer.prefix:
+            layer.weight_fp32 = (
+                weight_fp32 if keep_nd_weight or skip_weight_nz_conversion else maybe_trans_nz(weight_fp32)
+            )
+        if "conv1d" not in layer.prefix and not skip_weight_nz_conversion:
             # 310P torch_npu rejects FRACTAL_NZ matmul when the weight-side
             # matrix has n=1 or k=1. Keep scalar gates such as Qwen MoE's
             # shared_expert_gate in ND format, leaving non-310P policy intact.


### PR DESCRIPTION
### What this PR does / why we need it?

Keep DeepSeek V4 weights in ND format when they are consumed by execution paths that bypass the regular Linear method:

- add a per-layer `skip_weight_nz_conversion` flag to unquantized Linear weight post-processing;
- preserve ND for both the original weight and the optional FP32 copy;
- mark compressor `wkv` and `wgate` weights, which are passed directly to the custom compressor op;
- mark DSA `wo_a` when OTP is enabled or OLoRA TP is disabled, because those paths call `npu_transpose_batchmatmul` directly.

This is the `main`-branch counterpart of #15684. It is adapted to the refactored DeepSeek V4 package layout and the hardware-profile-based main branch. In particular, the DSA decision follows the active execution path rather than hard-coding a device type; the A5 quantized path uses a separate quantization method and is unaffected.

### Does this PR introduce _any_ user-facing change?

No API change. It fixes DeepSeek V4 runtime compatibility by preventing unsupported ND-to-NZ weight conversion on custom execution paths.

### How was this patch tested?

- Added a unit test covering the per-layer bypass, including the FP32 weight-copy path.
- `ruff check` and `ruff format --check` on all changed Python files.
- Python `compileall` on all changed Python files.
- Project codespell, forbidden-import, boolean-context-manager, and long-function checks on the changed files.
- Full device coverage is delegated to the vLLM Ascend PR CI matrix.

- vLLM main: https://github.com/vllm-project/vllm/commit/ba07e4a48fc951300d97eb506217dd530583dea3
