### PR TITLE
[BugFix][KV Pool] Restore TP-mismatch transfer wiring for AscendStoreConnector

### DIFF
--- a/tests/ut/distributed/ascend_store/test_pool_worker.py
+++ b/tests/ut/distributed/ascend_store/test_pool_worker.py
@@ -614,6 +614,8 @@ class TestKVPoolWorkerRegisterAndTransfer(unittest.TestCase):
 
         self.assertEqual(send_thread.call_args.args[2], worker.grouped_block_size)
         self.assertEqual(recv_thread.call_args.args[2], worker.grouped_block_size)
+        self.assertIsNone(send_thread.call_args.kwargs["worker"])
+        self.assertIsNone(recv_thread.call_args.kwargs["worker"])
         event.return_value.wait.assert_called()
 
     def test_register_kv_caches_initializes_layerwise_memcache(self):
@@ -1610,6 +1612,78 @@ class TestKVPoolWorkerTpMismatch(unittest.TestCase):
         self.assertEqual(worker.local_heads_per_rank, 4)
         self.assertEqual(worker.effective_heads_per_rank, 2)
         self.assertEqual(worker.num_sub_keys, 2)
+
+    def test_tp_mismatch_detected_for_both_roles_and_tp_directions(self):
+        cases = [
+            ("kv_consumer", 2, "prefill_tp_size", 4, 2),
+            ("kv_consumer", 4, "prefill_tp_size", 2, 1),
+            ("kv_producer", 2, "decode_tp_size", 4, 2),
+            ("kv_producer", 4, "decode_tp_size", 2, 1),
+        ]
+        for kv_role, local_tp, peer_key, peer_tp, expected_sub_keys in cases:
+            with self.subTest(kv_role=kv_role, local_tp=local_tp, peer_tp=peer_tp):
+                worker = self._make_worker(
+                    tp_size=local_tp,
+                    kv_role=kv_role,
+                    extra_config={"backend": "mooncake", peer_key: peer_tp},
+                    num_kv_heads=8,
+                )
+                self.assertTrue(worker.tp_mismatch)
+                self.assertEqual(worker.effective_tp_size, 4)
+                self.assertEqual(worker.num_sub_keys, expected_sub_keys)
+
+    @patch("vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.pool_worker.threading.Event")
+    @patch("vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.pool_worker.KVCacheStoreRecvingThread")
+    @patch("vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.pool_worker.KVCacheStoreSendingThread")
+    def test_transfer_threads_receive_worker_when_tp_mismatch(self, send_thread, recv_thread, event):
+        worker = self._make_worker(
+            tp_size=2,
+            kv_role="kv_consumer",
+            extra_config={
+                "backend": "mooncake",
+                "prefill_tp_size": 4,
+                "consumer_is_to_put": True,
+                "load_async": True,
+            },
+            num_kv_heads=8,
+        )
+
+        worker._start_kv_transfer_threads()
+
+        self.assertIs(send_thread.call_args.kwargs["worker"], worker)
+        self.assertIs(recv_thread.call_args.kwargs["worker"], worker)
+        event.return_value.wait.assert_called()
+
+    def test_start_load_kv_sync_dispatches_tp_mismatch_reader(self):
+        worker = self._make_strided_worker()
+        worker.grouped_block_size = [4]
+        worker.m_store = MagicMock()
+        worker._load_kv_tp_mismatch = MagicMock()
+        load_spec = LoadSpec(
+            vllm_cached_tokens=4,
+            kvpool_cached_tokens=8,
+            can_load=True,
+            token_len=8,
+        )
+        request = ReqMeta(
+            req_id="r1",
+            token_len_chunk=8,
+            block_ids_by_group=[[10, 11]],
+            block_hashes=[b"h0", b"h1"],
+            load_spec=load_spec,
+        )
+        metadata = AscendConnectorMetadata(set())
+        metadata.add_request(request)
+
+        worker.start_load_kv(metadata)
+
+        worker._load_kv_tp_mismatch.assert_called_once_with(
+            [b"h0", b"h1"],
+            [10, 11],
+            8,
+            4,
+        )
+        worker.m_store.get.assert_not_called()
 
     def test_register_kv_caches_initializes_tp_mismatch_strides(self):
         worker = self._make_worker(

--- a/tests/ut/distributed/ascend_store/test_pool_worker.py
+++ b/tests/ut/distributed/ascend_store/test_pool_worker.py
@@ -1520,6 +1520,7 @@ class TestKVPoolWorkerTpMismatch(unittest.TestCase):
             config.model_config.hf_text_config.index_topk = 32
         else:
             config.model_config.hf_text_config = MagicMock(spec=[])  # no index_topk
+            config.model_config.hf_text_config.num_hidden_layers = 36
         config.model_config.get_num_layers.return_value = 36
         config.model_config.get_total_num_kv_heads.return_value = num_kv_heads
         config.model_config.max_model_len = 4096

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/pool_worker.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/pool_worker.py
@@ -582,6 +582,7 @@ class KVPoolWorker:
                     ready_event_sending,
                     self.group_uses_align_state,
                     self.enable_kv_events,
+                    worker=self if self.tp_mismatch else None,
                 )
                 self.kv_send_thread.start()
                 ready_event_sending.wait()
@@ -597,6 +598,7 @@ class KVPoolWorker:
                     ready_event,
                     invalid_block_ids=self._invalid_block_ids,
                     invalid_block_ids_lock=self._invalid_block_ids_lock,
+                    worker=self if self.tp_mismatch else None,
                 )
                 self.kv_recv_thread.start()
                 ready_event.wait()
@@ -894,6 +896,18 @@ class KVPoolWorker:
             if self.load_async:
                 self.kv_recv_thread.add_request(  # type: ignore[union-attr]
                     request,
+                )
+                continue
+
+            if self.tp_mismatch:
+                # TP mismatch is restricted to non-hybrid, single-group KV.
+                group_block_size = self.grouped_block_size[0]
+                mask_num = load_spec.vllm_cached_tokens // group_block_size * group_block_size
+                self._load_kv_tp_mismatch(
+                    request.block_hashes,
+                    request.block_ids_by_group[0],
+                    token_len,
+                    mask_num,
                 )
                 continue
 


### PR DESCRIPTION
### What this PR does / why we need it?

This PR restores the production wiring for the TP-mismatch strided KV load/store paths introduced by [#11582](https://github.com/vllm-project/vllm-ascend/pull/11582) and later dropped when [#11444](https://github.com/vllm-project/vllm-ascend/pull/11444) refactored KV Pool initialization, transfer-thread construction, and load dispatch.

Fixes #15842.

[#11582](https://github.com/vllm-project/vllm-ascend/pull/11582) introduced an `effective_tp=max(prefill_tp, decode_tp)` key space and strided KV-head split/merge helpers for dense GQA models. The later refactor in [#11444](https://github.com/vllm-project/vllm-ascend/pull/11444) retained those helpers but removed their production wiring from transfer-thread construction and synchronous load dispatch. The interaction and restoration direction have been confirmed with the developer of #11444.

The primary production use case is PD disaggregation with `MultiConnector`:

```text
First turn:  Prefill --P2P connector--> Decode --strided write-back--> KV Pool
Next turn:   KV Pool --AscendStoreConnector--> Prefill
```

When Prefill TP is greater than Decode TP, a lower-TP Decode rank owns more KV heads and must split them into the effective-TP key space during write-back so that the next-turn Prefill ranks can load their corresponding shards.

This PR:

- passes the worker to `KVCacheStoreSendingThread` under TP mismatch, restoring strided PUT;
- passes the worker to `KVCacheStoreRecvingThread` under TP mismatch, restoring asynchronous strided GET dispatch;
- routes synchronous TP-mismatch loads through `_load_kv_tp_mismatch()` instead of the regular GET path;
- checks `load_async` before the synchronous mismatch branch so asynchronous loads enter the receiving-thread queue;
- keeps `worker=None` for same-TP configurations, preserving the regular path.

The support boundary is unchanged from #11582: dense GQA with a single KV cache group. MLA, hybrid KV layouts, sparse KV, and layerwise transfer are not enabled by this change.

### Does this PR introduce any user-facing change?

Yes. Existing `AscendStoreConnector` TP-mismatch configurations again use the specialized strided load/store paths. There is no configuration schema or public API change.

### How was this patch tested?

Unit tests cover:

- producer and consumer roles with local TP both smaller and larger than peer TP;
- worker injection into both sending and receiving threads under TP mismatch;
- `worker=None` and the regular path for same-TP configurations;
- synchronous dispatch to `_load_kv_tp_mismatch()` without invoking regular GET;
- asynchronous receiving-thread TP-mismatch dispatch.

The targeted unit tests passed in an Ascend A2 environment. The repository CPU unit-test workflow also passed.

End-to-end tests passed on Ascend A2 for four topology/path categories:

1. `MultiConnector`, Prefill TP=2 and Decode TP=1: P-to-D KV uses the P2P connector; Decode splits its generated KV into two effective-rank keys per block; the next-turn Prefill finds and loads all shards from KV Pool.
2. `AscendStoreConnector` only, Prefill TP=2 and Decode TP=1: both synchronous and asynchronous load modes exercise the TP-mismatch load/store paths.
3. `AscendStoreConnector` only, Prefill TP=1 and Decode TP=2: the lower-TP reader loads and merges both effective-rank shards.
4. Prefill TP=2 and Decode TP=2: no `TP mismatch detected` path is entered, and the regular same-TP KV Pool path remains functional.

- vLLM main: https://github.com/vllm-project/vllm/commit/b2f685834a6456197e7033966fdef52a23f1abcd
