### PR TITLE
[Bugfix][MoE] Add BF16 MegaMoe regression coverage

### DIFF
--- a/tests/ut/ops/test_comm_utils.py
+++ b/tests/ut/ops/test_comm_utils.py
@@ -22,9 +22,28 @@ from pytest_mock import MockerFixture
 from tests.ut.base import PytestBase
 from vllm_ascend.ops.fused_moe.moe_utils import (
     _gather_along_first_dim,
+    _get_cann_mega_moe_quant_settings,
     async_all_to_all,
     gather_from_sequence_parallel_region,
 )
+from vllm_ascend.quantization.quant_type import QuantType
+
+
+class TestMegaMoeQuantSettings(PytestBase):
+    @pytest.mark.parametrize(
+        "quant_type, expected",
+        [
+            (QuantType.NONE, (0, None, None)),
+            (QuantType.W8A8, (2, 258, 258)),
+            (QuantType.W4A8, (2, 258, 285)),
+        ],
+    )
+    def test_supported_quant_types(self, quant_type, expected):
+        assert _get_cann_mega_moe_quant_settings(quant_type) == expected
+
+    def test_unsupported_quant_type_reports_supported_bf16(self):
+        with pytest.raises(RuntimeError, match=r"BF16 \(none quant\)"):
+            _get_cann_mega_moe_quant_settings(QuantType.W8A8FP)
 
 
 class TestDistributedCommunication(PytestBase):

--- a/vllm_ascend/ops/fused_moe/moe_utils.py
+++ b/vllm_ascend/ops/fused_moe/moe_utils.py
@@ -141,8 +141,8 @@ def _get_cann_mega_moe_quant_settings(quant_type: QuantType) -> tuple[int, int |
         return (_CANN_MEGA_MOE_QUANT_MODE_None, None, None)
 
     raise RuntimeError(
-        "MegaMoe integration supports W8A8/W4A8 INT on A2/A3 and MXFP on FP8-capable "
-        "MegaMoe platforms. "
+        "MegaMoe integration supports W8A8/W4A8 INT, BF16 (none quant), and MXFP "
+        "on supported A2/A3 platforms. "
         f"Unsupported quant type: {quant_type}."
     )
 


### PR DESCRIPTION
## Summary

Add regression coverage for the BF16 (`QuantType.NONE`) MegaMoe parameter
mapping introduced by #13675, and update the unsupported-quantization error
message to reflect BF16 support.

## Changes

- Cover `QuantType.NONE`, W8A8, and W4A8 MegaMoe settings.
- Verify unsupported quantization errors mention the supported BF16 path.
- Keep the change limited to the #13924 MegaMoe quantization contract.

## Validation

- `git diff --check`: PASS
- Python syntax compilation: PASS
- Target unit test: NOT RUN locally
- Reason: the local machine does not have the required vLLM/torch-npu test
  environment.
- A3/CANN 9.1 runtime validation: NOT RUN

## Related Issue

Related to #13924

## Notes

The functional `QuantType.NONE` branch is already present from #13675. This PR
adds focused regression coverage and keeps the user-facing error message
consistent with the supported quantization matrix.


- vLLM main: https://github.com/vllm-project/vllm/commit/ba07e4a48fc951300d97eb506217dd530583dea3
