### PR TITLE
[Bugfix][Backport v0.27.1rc] Backport #15266

### DIFF
--- a/tests/ut/attention/test_mla_v1.py
+++ b/tests/ut/attention/test_mla_v1.py
@@ -1124,7 +1124,6 @@ class TestAscendMLAImpl(TestBase):
         speculative_config.num_speculative_tokens = 4
         vllm_config.speculative_config = speculative_config
         model_config.dtype = torch.float16
-        model_config.runner_type = "generate"
         vllm_config.model_config = model_config
         get_current_vllm_config.return_value = vllm_config
         vllm_config.additional_config = {"refresh": True}
@@ -1200,7 +1199,7 @@ class TestAscendMLAImpl(TestBase):
     @patch("vllm_ascend.attention.mla_v1.enabling_mlapo", return_value=True)
     @patch("vllm_ascend.attention.mla_v1.get_current_vllm_config")
     def test_draft_model_disables_mlapo_at_init(self, mock_get_current_vllm_config, mock_enabling_mlapo):
-        self.impl.vllm_config.model_config.runner_type = "draft"
+        self.impl.vllm_config.additional_config["_ascend_is_draft_model"] = True
         mock_get_current_vllm_config.return_value = self.impl.vllm_config
         impl = AscendMLAImpl(
             num_heads=self.impl.num_heads,

--- a/tests/ut/attention/test_mla_v1.py
+++ b/tests/ut/attention/test_mla_v1.py
@@ -1124,6 +1124,7 @@ class TestAscendMLAImpl(TestBase):
         speculative_config.num_speculative_tokens = 4
         vllm_config.speculative_config = speculative_config
         model_config.dtype = torch.float16
+        model_config.runner_type = "generate"
         vllm_config.model_config = model_config
         get_current_vllm_config.return_value = vllm_config
         vllm_config.additional_config = {"refresh": True}
@@ -1191,9 +1192,49 @@ class TestAscendMLAImpl(TestBase):
         self.assertIsNotNone(self.impl.kv_a_proj_with_mqa)
         self.assertIsNotNone(self.impl.kv_a_layernorm)
         self.assertEqual(self.impl.num_queries_per_kv, 32)
+        self.assertFalse(self.impl.is_draft_model)
         # 256 is power of 2, so padding should be 0
         self.assertEqual(self.impl.num_heads_padded, 256)
         self.assertEqual(self.impl.head_padding, 0)
+
+    @patch("vllm_ascend.attention.mla_v1.enabling_mlapo", return_value=True)
+    @patch("vllm_ascend.attention.mla_v1.get_current_vllm_config")
+    def test_draft_model_disables_mlapo_at_init(self, mock_get_current_vllm_config, mock_enabling_mlapo):
+        self.impl.vllm_config.model_config.runner_type = "draft"
+        mock_get_current_vllm_config.return_value = self.impl.vllm_config
+        impl = AscendMLAImpl(
+            num_heads=self.impl.num_heads,
+            head_size=self.impl.head_size,
+            scale=self.impl.scale,
+            num_kv_heads=self.impl.num_kv_heads,
+            alibi_slopes=None,
+            sliding_window=None,
+            kv_cache_dtype=self.impl.kv_cache_dtype,
+            blocksparse_params=None,
+            logits_soft_cap=None,
+            attn_type=None,
+            kv_sharing_target_layer_name=None,
+            kv_lora_rank=self.impl.kv_lora_rank,
+            qk_nope_head_dim=self.impl.qk_nope_head_dim,
+            qk_rope_head_dim=self.impl.qk_rope_head_dim,
+            qk_head_dim=self.impl.qk_head_dim,
+            v_head_dim=self.impl.v_head_dim,
+            q_lora_rank=self.impl.q_lora_rank,
+            q_proj=self.impl.q_proj,
+            q_b_proj=self.impl.q_proj,
+            kv_b_proj=self.impl.kv_b_proj,
+            o_proj=self.impl.o_proj,
+            kv_a_proj_with_mqa=self.impl.kv_a_proj_with_mqa,
+            fused_qkv_a_proj=self.impl.fused_qkv_a_proj,
+            kv_a_layernorm=self.impl.kv_a_layernorm,
+            rotary_emb=self.impl.rotary_emb,
+            g_proj=None,
+            use_mla_rope=True,
+        )
+
+        self.assertTrue(impl.is_draft_model)
+        self.assertFalse(impl.enable_mlapo)
+        mock_enabling_mlapo.assert_not_called()
 
     @patch("vllm_ascend.attention.mla_v1.get_current_vllm_config")
     def test_init_head_padding_for_non_power_of_two(self, mock_get_current_vllm_config):

--- a/tests/ut/spec_decode/test_llm_base_proposer.py
+++ b/tests/ut/spec_decode/test_llm_base_proposer.py
@@ -43,6 +43,34 @@ NON_FULL_CUDAGRAPH_MODES = [
 ]
 
 
+def test_draft_vllm_config_uses_draft_model_config():
+    draft_model_config = SimpleNamespace(runner_type="draft")
+    base_vllm_config = SimpleNamespace(model_config=SimpleNamespace(runner_type="generate"))
+    expected_vllm_config = SimpleNamespace(model_config=draft_model_config)
+    proposer = AscendSpecDecodeBaseProposer.__new__(AscendSpecDecodeBaseProposer)
+    proposer.speculative_config = SimpleNamespace(
+        draft_model_config=draft_model_config,
+    )
+
+    with (
+        patch(
+            "vllm.v1.spec_decode.llm_base_proposer.SpecDecodeBaseProposer._create_draft_vllm_config",
+            return_value=base_vllm_config,
+        ),
+        patch(
+            "vllm_ascend.spec_decode.llm_base_proposer.replace",
+            return_value=expected_vllm_config,
+        ) as mock_replace,
+    ):
+        draft_vllm_config = proposer._create_draft_vllm_config()
+
+    assert draft_vllm_config is expected_vllm_config
+    mock_replace.assert_called_once_with(
+        base_vllm_config,
+        model_config=draft_model_config,
+    )
+
+
 class TestMultimodalImageTokenIndex:
     @pytest.mark.parametrize(
         "model_name",

--- a/tests/ut/spec_decode/test_llm_base_proposer.py
+++ b/tests/ut/spec_decode/test_llm_base_proposer.py
@@ -43,14 +43,17 @@ NON_FULL_CUDAGRAPH_MODES = [
 ]
 
 
-def test_draft_vllm_config_uses_draft_model_config():
-    draft_model_config = SimpleNamespace(runner_type="draft")
-    base_vllm_config = SimpleNamespace(model_config=SimpleNamespace(runner_type="generate"))
-    expected_vllm_config = SimpleNamespace(model_config=draft_model_config)
-    proposer = AscendSpecDecodeBaseProposer.__new__(AscendSpecDecodeBaseProposer)
-    proposer.speculative_config = SimpleNamespace(
-        draft_model_config=draft_model_config,
+def test_draft_vllm_config_marks_draft_without_replacing_model_config():
+    target_model_config = SimpleNamespace(runner_type="generate")
+    base_vllm_config = SimpleNamespace(
+        model_config=target_model_config,
+        additional_config={"existing": "value"},
     )
+    expected_vllm_config = SimpleNamespace(
+        model_config=target_model_config,
+        additional_config={"existing": "value", "_ascend_is_draft_model": True},
+    )
+    proposer = AscendSpecDecodeBaseProposer.__new__(AscendSpecDecodeBaseProposer)
 
     with (
         patch(
@@ -67,7 +70,7 @@ def test_draft_vllm_config_uses_draft_model_config():
     assert draft_vllm_config is expected_vllm_config
     mock_replace.assert_called_once_with(
         base_vllm_config,
-        model_config=draft_model_config,
+        additional_config={"existing": "value", "_ascend_is_draft_model": True},
     )
 
 

--- a/vllm_ascend/attention/mla_v1.py
+++ b/vllm_ascend/attention/mla_v1.py
@@ -860,7 +860,8 @@ class AscendMLAImpl(MLAAttentionImpl):
         self.ring_mla_mask_size = 512
 
         self.speculative_config = self.vllm_config.speculative_config
-        self.enable_mlapo = enabling_mlapo(self.vllm_config)
+        self.is_draft_model = self.vllm_config.model_config.runner_type == "draft"
+        self.enable_mlapo = not self.is_draft_model and enabling_mlapo(self.vllm_config)
 
         self.layer_name = kwargs.get("layer_name")
         self.fa_quant_layer = enable_fa_quant(self.vllm_config, self.layer_name)

--- a/vllm_ascend/attention/mla_v1.py
+++ b/vllm_ascend/attention/mla_v1.py
@@ -860,7 +860,8 @@ class AscendMLAImpl(MLAAttentionImpl):
         self.ring_mla_mask_size = 512
 
         self.speculative_config = self.vllm_config.speculative_config
-        self.is_draft_model = self.vllm_config.model_config.runner_type == "draft"
+        additional_config = self.vllm_config.additional_config or {}
+        self.is_draft_model = bool(additional_config.get("_ascend_is_draft_model", False))
         self.enable_mlapo = not self.is_draft_model and enabling_mlapo(self.vllm_config)
 
         self.layer_name = kwargs.get("layer_name")

--- a/vllm_ascend/spec_decode/llm_base_proposer.py
+++ b/vllm_ascend/spec_decode/llm_base_proposer.py
@@ -9,7 +9,6 @@ import numpy as np
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
-from typing_extensions import override
 from vllm.config import CUDAGraphMode, VllmConfig, get_layers_from_vllm_config, replace
 from vllm.distributed.parallel_state import (
     get_pp_group,
@@ -113,7 +112,6 @@ def _is_glm_model(model_config) -> bool:
 class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
     _runnable: ACLGraphWrapper | Callable
 
-    @override
     def _create_draft_vllm_config(self) -> VllmConfig:
         """Expose the validated draft model config during model construction.
 

--- a/vllm_ascend/spec_decode/llm_base_proposer.py
+++ b/vllm_ascend/spec_decode/llm_base_proposer.py
@@ -9,7 +9,8 @@ import numpy as np
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
-from vllm.config import CUDAGraphMode, VllmConfig, get_layers_from_vllm_config
+from typing_extensions import override
+from vllm.config import CUDAGraphMode, VllmConfig, get_layers_from_vllm_config, replace
 from vllm.distributed.parallel_state import (
     get_pp_group,
     get_tp_group,
@@ -111,6 +112,20 @@ def _is_glm_model(model_config) -> bool:
 
 class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
     _runnable: ACLGraphWrapper | Callable
+
+    @override
+    def _create_draft_vllm_config(self) -> VllmConfig:
+        """Expose the validated draft model config during model construction.
+
+        ``_get_model`` calls this hook before ``get_model`` installs the
+        returned config as the current vLLM config. Attention constructors can
+        then identify the draft model from ``runner_type="draft"``.
+        """
+        draft_vllm_config = super()._create_draft_vllm_config()
+        return replace(
+            draft_vllm_config,
+            model_config=self.speculative_config.draft_model_config,
+        )
 
     @staticmethod
     def _get_multimodal_image_token_index(model_name: str, config: Any) -> int:

--- a/vllm_ascend/spec_decode/llm_base_proposer.py
+++ b/vllm_ascend/spec_decode/llm_base_proposer.py
@@ -113,16 +113,19 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
     _runnable: ACLGraphWrapper | Callable
 
     def _create_draft_vllm_config(self) -> VllmConfig:
-        """Expose the validated draft model config during model construction.
+        """Mark the cloned config while constructing a draft model.
 
-        ``_get_model`` calls this hook before ``get_model`` installs the
-        returned config as the current vLLM config. Attention constructors can
-        then identify the draft model from ``runner_type="draft"``.
+        The release vLLM loader relies on ``vllm_config.model_config`` still
+        referring to the target config so that draft attention layers receive
+        distinct prefixes. Carry only the Ascend-specific marker needed by
+        attention constructors instead of replacing the model config.
         """
         draft_vllm_config = super()._create_draft_vllm_config()
+        additional_config = dict(draft_vllm_config.additional_config or {})
+        additional_config["_ascend_is_draft_model"] = True
         return replace(
             draft_vllm_config,
-            model_config=self.speculative_config.draft_model_config,
+            additional_config=additional_config,
         )
 
     @staticmethod


### PR DESCRIPTION
## Summary

Backport #15266 to `releases/v0.27.1rc`.

The three source commits were applied in their original order. The branch-sync merge commit was intentionally excluded. The 0.26-to-0.27.1 test-path conflict was resolved by preserving the 0.27.1 test file and carrying only the draft-model tests and implementation changes.

## Validation

- Ruff check passed for all changed Python files.
- Ruff format check passed for all changed Python files.
- Python compileall passed for all changed Python files.
- Targeted pytest collection is unavailable in the local Windows environment because the vLLM package is not installed.
- No NPU tests were run.
- vLLM main: https://github.com/vllm-project/vllm/commit/ba07e4a48fc951300d97eb506217dd530583dea3
