### PR TITLE
[BugFix] Pass eplb_heat_collection_status to DSpark dummy_run

### DIFF
--- a/vllm_ascend/spec_decode/dspark_proposer.py
+++ b/vllm_ascend/spec_decode/dspark_proposer.py
@@ -379,6 +379,9 @@ class AscendDSparkProposer(AscendDflashProposer):
             aclgraph_runtime_mode=aclgraph_runtime_mode,
             is_draft_model=True,
             draft_attn_metadatas=[],
+            eplb_heat_collection_status=(
+                self.runner.eplb_heat_collection_status if self.runner.dynamic_eplb else False
+            ),
         ):
             if is_profile:
                 self.model.precompute_and_store_context_kv(context_states, context_positions)


### PR DESCRIPTION
Mirror the change in lvvgang:sync_pr15552_dspark_0.26 (from vllm-project/vllm-ascend#15552) on the main branch; llm_base_proposer already passes this flag.

### What this PR does / why we need it?

### Does this PR introduce _any_ user-facing change?

### How was this patch tested?

- vLLM main: https://github.com/vllm-project/vllm/commit/ba07e4a48fc951300d97eb506217dd530583dea3
