### PR TITLE
 [Performance][Cherry-pick][DSV4] Compute compressor metadata once per cache group per sub…

### DIFF
--- a/tests/ut/attention/test_dsa_v1.py
+++ b/tests/ut/attention/test_dsa_v1.py
@@ -21,6 +21,7 @@ import numpy as np
 import pytest
 import torch
 from vllm.config import CUDAGraphMode
+from vllm.forward_context import override_forward_context
 from vllm.v1.attention.backend import AttentionCGSupport
 
 from vllm_ascend.attention.context_parallel.dsa_cp import (
@@ -108,6 +109,17 @@ def _mock_dsa_kv_plan(**method_returns) -> MagicMock:
     for name, value in method_returns.items():
         getattr(plan, name).return_value = value
     return plan
+
+
+def _make_forward_context():
+    from vllm.forward_context import ForwardContext
+
+    return ForwardContext(
+        no_compile_layers={},
+        attn_metadata={},
+        slot_mapping={},
+        additional_kwargs={},
+    )
 
 
 def _make_vllm_config(num_speculative_tokens: int | None = None) -> SimpleNamespace:
@@ -613,6 +625,7 @@ def test_dsa_cp_legacy_compressor_waits_for_device_local_metadata():
     metadata = SimpleNamespace(
         compressor_metadata=None,
         device_local_metadata_group_id=23,
+        cache_group_key="model.layers.0.self_attn.attn",
         full_compress_cos=torch.ones((1, 1, 1, 2)),
         full_compress_sin=torch.zeros((1, 1, 1, 2)),
         num_compressed_tokens=1,
@@ -629,7 +642,9 @@ def test_dsa_cp_legacy_compressor_waits_for_device_local_metadata():
     with (
         patch("vllm_ascend.attention.context_parallel.dsa_cp.wait_for_device_metadata") as wait,
         patch("vllm_ascend.attention.context_parallel.dsa_cp.get_dsa_attn_kv_plan", return_value=plan),
+        patch("vllm_ascend.attention.dsa_v1.get_dsa_attn_kv_plan", return_value=plan),
         patch.object(torch.ops._C_ascend, "compressor_metadata", create=True, return_value=(1, 2, 3)),
+        override_forward_context(_make_forward_context()),
     ):
         assert impl._compute_compressor_metadata(metadata) == (1, 2, 3)
 

--- a/tests/ut/attention/test_dsv4_block_geometry.py
+++ b/tests/ut/attention/test_dsv4_block_geometry.py
@@ -5,6 +5,7 @@ from types import SimpleNamespace
 
 import pytest
 import torch
+from vllm.forward_context import ForwardContext, override_forward_context
 
 from vllm_ascend.attention.context_parallel.dsa_cp import AscendDSACPImpl
 from vllm_ascend.models.deepseek_v4.compressor import Compressor
@@ -27,6 +28,7 @@ def test_compressor_metadata_uses_physical_storage_geometry(
     query_start_loc = torch.tensor([0, 4], dtype=torch.int32)
     start_pos = torch.tensor([508], dtype=torch.int32)
     metadata = SimpleNamespace(
+        cache_group_key="model.layers.0.self_attn.attn",
         full_compress_cos=torch.zeros((8, 1, 1, 64), dtype=torch.bfloat16),
         full_compress_sin=torch.zeros((8, 1, 1, 64), dtype=torch.bfloat16),
         query_start_loc=query_start_loc,
@@ -54,6 +56,10 @@ def test_compressor_metadata_uses_physical_storage_geometry(
         lambda vllm_config: plan,
     )
     monkeypatch.setattr(
+        "vllm_ascend.attention.dsa_v1.get_dsa_attn_kv_plan",
+        lambda vllm_config: plan,
+    )
+    monkeypatch.setattr(
         "vllm_ascend.attention.context_parallel.dsa_cp.get_dsa_attn_kv_plan",
         lambda vllm_config: plan,
     )
@@ -67,7 +73,14 @@ def test_compressor_metadata_uses_physical_storage_geometry(
     owner.compress_ratio = compress_ratio
     owner.vllm_config = SimpleNamespace()
 
-    result = getattr(owner, method_name)(metadata)
+    forward_context = ForwardContext(
+        no_compile_layers={},
+        attn_metadata={},
+        slot_mapping={},
+        additional_kwargs={},
+    )
+    with override_forward_context(forward_context):
+        result = getattr(owner, method_name)(metadata)
 
     assert result is expected
     args = captured["args"]

--- a/tests/ut/attention/test_dsv4_compressor_metadata_cache.py
+++ b/tests/ut/attention/test_dsv4_compressor_metadata_cache.py
@@ -1,0 +1,75 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM Ascend project
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import torch
+from vllm.forward_context import ForwardContext, override_forward_context
+
+from vllm_ascend.attention.dsa_v1 import (
+    get_or_compute_compressor_metadata,
+    reset_compressor_metadata_cache,
+)
+
+
+def _make_forward_context() -> ForwardContext:
+    return ForwardContext(
+        no_compile_layers={},
+        attn_metadata={},
+        slot_mapping={},
+        additional_kwargs={},
+    )
+
+
+def test_reuses_by_cache_group_and_resets_between_substeps():
+    metadata = SimpleNamespace(
+        cache_group_key="model.layers.0.self_attn.attn",
+        full_compress_cos=torch.zeros((2, 1, 1, 4)),
+        full_compress_sin=torch.zeros((2, 1, 1, 4)),
+        query_start_loc=torch.tensor([0, 2], dtype=torch.int32),
+        start_pos=torch.tensor([0], dtype=torch.int32),
+        block_table=torch.tensor([[0]], dtype=torch.int32),
+        storage_block_size=32,
+        num_compressed_tokens=1,
+        num_actual_reqs=1,
+    )
+    same_group_metadata = SimpleNamespace(**vars(metadata))
+    other_group_metadata = SimpleNamespace(
+        **{
+            **vars(metadata),
+            "cache_group_key": "model.layers.0.self_attn.indexer.k_cache",
+        }
+    )
+    outputs = [(torch.full((1,), value),) * 3 for value in range(4)]
+
+    kv_plan = MagicMock()
+    kv_plan.get_dsa_compressor_slot_mapping_format.return_value = 0
+    vllm_config = MagicMock()
+
+    with (
+        patch(
+            "vllm_ascend.attention.dsa_v1.get_dsa_attn_kv_plan",
+            return_value=kv_plan,
+        ),
+        patch.object(
+            torch.ops._C_ascend,
+            "compressor_metadata",
+            create=True,
+            side_effect=outputs,
+        ) as metadata_op,
+    ):
+        with override_forward_context(_make_forward_context()):
+            first = get_or_compute_compressor_metadata(metadata, 4, vllm_config)
+            reused = get_or_compute_compressor_metadata(same_group_metadata, 4, vllm_config)
+            isolated = get_or_compute_compressor_metadata(other_group_metadata, 4, vllm_config)
+            reset_compressor_metadata_cache()
+            next_substep = get_or_compute_compressor_metadata(metadata, 4, vllm_config)
+        with override_forward_context(_make_forward_context()):
+            next_forward = get_or_compute_compressor_metadata(metadata, 4, vllm_config)
+
+    assert first is reused
+    assert isolated is not first
+    assert next_substep is not first
+    assert next_forward is not first
+    assert metadata_op.call_count == 4

--- a/tests/ut/models/test_deepseek_v4_compressor.py
+++ b/tests/ut/models/test_deepseek_v4_compressor.py
@@ -42,6 +42,7 @@ class TestCompressorMetadata:
         start_pos = torch.tensor([1, 3], dtype=torch.int32)
         block_table = torch.tensor([[0], [1]], dtype=torch.int32)
         metadata = SimpleNamespace(
+            cache_group_key="model.layers.0.self_attn.attn",
             full_compress_cos=full_cos,
             full_compress_sin=full_sin,
             query_start_loc=query_start_loc,
@@ -61,6 +62,14 @@ class TestCompressorMetadata:
                 dsa_attn_kv_plan,
                 "get_dsa_attn_kv_plan",
                 return_value=plan,
+            ),
+            patch(
+                "vllm_ascend.attention.dsa_v1.get_dsa_attn_kv_plan",
+                return_value=plan,
+            ),
+            patch(
+                "vllm_ascend.attention.dsa_v1.get_forward_context",
+                return_value=SimpleNamespace(additional_kwargs={}),
             ),
             patch.object(
                 torch.ops._C_ascend,

--- a/vllm_ascend/attention/context_parallel/dsa_cp.py
+++ b/vllm_ascend/attention/context_parallel/dsa_cp.py
@@ -123,6 +123,9 @@ class AscendDSAReqMetadata:
     full_compress_cos: torch.Tensor = None
     start_pos: torch.Tensor = None
     num_actual_reqs: int | None = None
+    # Every layer of a cache group receives the same builder output, so this
+    # key lets the compressor metadata be computed once per group per substep.
+    cache_group_key: str = ""
     sas_metadata: torch.Tensor = None
     qli_metadata: torch.Tensor = None
     compressor_metadata: dsa_v1.CompressorMetadataOutput | None = None
@@ -218,6 +221,10 @@ class AscendDSACPMetadataBuilder(AttentionMetadataBuilder[AscendDSAMetadata]):
         self.seq_lens: torch.Tensor = None
         self.seq_lens_cpu: torch.Tensor = None
         self.compressor_ratio = getattr(kv_cache_spec, "compress_ratio", 0)
+        if not layer_names:
+            raise ValueError("DSV4 compressor metadata builder requires at least one layer name")
+        # vLLM assigns the builder result to every layer in an attention group.
+        self.cache_group_key = layer_names[0]
         hf_config = self.model_config.hf_config
 
         self.hadamard = None
@@ -702,6 +709,7 @@ class AscendDSACPMetadataBuilder(AttentionMetadataBuilder[AscendDSAMetadata]):
             start_pos=start_pos,
             sas_metadata=sas_metadata,
             qli_metadata=None,
+            cache_group_key=self.cache_group_key,
             cu_cmp_seqlen_list=None,
             ori_win_left=ori_win_left,
             ori_win_right=ori_win_right,
@@ -1002,6 +1010,7 @@ class AscendDSACPMetadataBuilder(AttentionMetadataBuilder[AscendDSAMetadata]):
             start_pos=self.start_pos_prefill[:num_reqs],
             num_compressed_tokens=num_compressed_tokens,
             num_actual_reqs=num_actual_reqs,
+            cache_group_key=self.cache_group_key,
             sas_metadata=sas_metadata,
             qli_metadata=qli_metadata,
             device_local_metadata_group_id=device_local_metadata_group_id,
@@ -1438,30 +1447,10 @@ class AscendDSACPImpl(AttentionImplBase[Any]):
                 metadata.device_local_metadata_group_id,
             )
 
-        assert metadata.full_compress_cos is not None
-        assert metadata.full_compress_sin is not None
-        assert metadata.num_compressed_tokens is not None
-        assert metadata.start_pos is not None
-        assert metadata.num_actual_reqs is not None
-        full_compress_cos = metadata.full_compress_cos.view(
-            metadata.full_compress_cos.shape[0],
-            metadata.full_compress_cos.shape[-1],
-        )
-        full_compress_sin = metadata.full_compress_sin.view(
-            metadata.full_compress_sin.shape[0],
-            metadata.full_compress_sin.shape[-1],
-        )
-        return torch.ops._C_ascend.compressor_metadata(
-            full_compress_cos,
-            full_compress_sin,
-            metadata.query_start_loc,
-            metadata.start_pos,
-            metadata.block_table,
-            metadata.storage_block_size,
-            get_dsa_attn_kv_plan(self.vllm_config).get_dsa_compressor_slot_mapping_format(),
+        return dsa_v1.get_or_compute_compressor_metadata(
+            metadata,
             self.compress_ratio,
-            metadata.num_compressed_tokens,
-            metadata.num_actual_reqs,
+            self.vllm_config,
         )
 
     def process_weights_after_loading(self, act_dtype: torch.dtype):

--- a/vllm_ascend/attention/dsa_v1.py
+++ b/vllm_ascend/attention/dsa_v1.py
@@ -8,6 +8,7 @@ import torch.distributed as dist
 import torch_npu
 from vllm.config import CUDAGraphMode, VllmConfig
 from vllm.distributed import get_tensor_model_parallel_world_size
+from vllm.forward_context import get_forward_context
 from vllm.triton_utils import HAS_TRITON
 from vllm.v1.attention.backend import (
     AttentionBackend,
@@ -75,6 +76,73 @@ CompressorMetadataOutput: TypeAlias = tuple[torch.Tensor, torch.Tensor, torch.Te
 _DSV4_DSA_OVERLAP_STREAM = None
 CompressorForwardOutput = tuple[torch.Tensor, torch.Tensor]
 CompressorOverlapOutput = tuple[CompressorForwardOutput, torch.npu.Event]
+
+_COMPRESSOR_METADATA_CACHE_KEY = "dsv4_compressor_metadata_cache"
+
+
+def reset_compressor_metadata_cache() -> None:
+    """Drop the cached compressor metadata before a composite forward enters its next substep."""
+    try:
+        forward_context = get_forward_context()
+    except AssertionError:
+        # No active forward context (e.g. draft-model unit tests): no cache to reset.
+        return
+    forward_context.additional_kwargs.pop(_COMPRESSOR_METADATA_CACHE_KEY, None)
+
+
+def get_or_compute_compressor_metadata(
+    metadata: Any,
+    compress_ratio: int,
+    vllm_config: VllmConfig,
+) -> CompressorMetadataOutput:
+    """Compute the DSV4 compressor metadata once per cache group in the current substep.
+
+    DSV4 runs one :class:`AscendCompressor` forward per attention layer, but every
+    layer in a cache group consumes the same compressor metadata. The outputs are
+    therefore memoized on the current forward context so the device-side
+    ``compressor_metadata`` operator runs only once per group.
+    """
+    cache_group_key = getattr(metadata, "cache_group_key", "")
+    if not cache_group_key:
+        raise ValueError(
+            "DSV4 compressor metadata requires a cache group key; the AscendDSAReqMetadata builder did not set one"
+        )
+    forward_context = get_forward_context()
+    cache: dict[str, CompressorMetadataOutput] = forward_context.additional_kwargs.setdefault(
+        _COMPRESSOR_METADATA_CACHE_KEY,
+        {},
+    )
+    cached_metadata = cache.get(cache_group_key)
+    if cached_metadata is not None:
+        return cached_metadata
+
+    assert metadata.full_compress_cos is not None
+    assert metadata.full_compress_sin is not None
+    assert metadata.num_compressed_tokens is not None
+    assert metadata.start_pos is not None
+    assert metadata.num_actual_reqs is not None
+    full_compress_cos = metadata.full_compress_cos.view(
+        metadata.full_compress_cos.shape[0],
+        metadata.full_compress_cos.shape[-1],
+    )
+    full_compress_sin = metadata.full_compress_sin.view(
+        metadata.full_compress_sin.shape[0],
+        metadata.full_compress_sin.shape[-1],
+    )
+    computed_metadata = torch.ops._C_ascend.compressor_metadata(
+        full_compress_cos,
+        full_compress_sin,
+        metadata.query_start_loc,
+        metadata.start_pos,
+        metadata.block_table,
+        metadata.storage_block_size,
+        get_dsa_attn_kv_plan(vllm_config).get_dsa_compressor_slot_mapping_format(),
+        compress_ratio,
+        metadata.num_compressed_tokens,
+        metadata.num_actual_reqs,
+    )
+    cache[cache_group_key] = computed_metadata
+    return computed_metadata
 
 
 def build_compressor_metadata_out(
@@ -275,6 +343,9 @@ class AscendDSAReqMetadata:
     full_compress_cos: torch.Tensor = None
     start_pos: torch.Tensor | None = None
     num_actual_reqs: int | None = None
+    # Every layer of a cache group receives the same builder output, so this
+    # key lets the compressor metadata be computed once per group per substep.
+    cache_group_key: str = ""
     sas_metadata: torch.Tensor = None
     qli_metadata: torch.Tensor = None
     compressor_metadata: CompressorMetadataOutput | None = None
@@ -583,6 +654,10 @@ class AscendDSAMetadataBuilder(AttentionMetadataBuilder[AscendDSAMetadata]):
         self.seq_lens: torch.Tensor = None
 
         self.compressor_ratio = getattr(kv_cache_spec, "compress_ratio", 0)
+        if not layer_names:
+            raise ValueError("DSV4 compressor metadata builder requires at least one layer name")
+        # vLLM assigns the builder result to every layer in an attention group.
+        self.cache_group_key = layer_names[0]
         self.hadamard = None
         self._init_hadamard(layer_names)
         self.start_pos_prefill: torch.Tensor = torch.zeros(
@@ -1088,6 +1163,7 @@ class AscendDSAMetadataBuilder(AttentionMetadataBuilder[AscendDSAMetadata]):
             full_compress_cos=full_compress_cos,
             start_pos=self.start_pos_prefill[:num_reqs],
             num_actual_reqs=num_actual_reqs,
+            cache_group_key=self.cache_group_key,
             sas_metadata=sas_metadata,
             qli_metadata=qli_metadata,
             attn_mask=None,
@@ -1306,6 +1382,7 @@ class AscendDSAMetadataBuilder(AttentionMetadataBuilder[AscendDSAMetadata]):
             cos=cos,
             start_pos=self.seq_lens[:num_reqs] - seq_lens_q,
             num_actual_reqs=num_reqs,
+            cache_group_key=self.cache_group_key,
             sas_metadata=sas_metadata,
             qli_metadata=None,
             attn_mask=None,

--- a/vllm_ascend/models/deepseek_v4/compressor.py
+++ b/vllm_ascend/models/deepseek_v4/compressor.py
@@ -177,7 +177,8 @@ class Compressor(nn.Module):
         self,
         metadata: typing.Any,
     ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
-        from vllm_ascend.attention.dsa_attn_kv_plan import get_dsa_attn_kv_plan
+        # Imported lazily to avoid a circular import at module load time.
+        from vllm_ascend.attention.dsa_v1 import get_or_compute_compressor_metadata
 
         precomputed = getattr(metadata, "compressor_metadata", None)
         if precomputed is not None:
@@ -186,31 +187,7 @@ class Compressor(nn.Module):
             wait_for_device_metadata(DeviceMetadataStage.COMPRESSOR, group_id)
             return precomputed
 
-        assert metadata.full_compress_cos is not None
-        assert metadata.full_compress_sin is not None
-        assert metadata.num_compressed_tokens is not None
-        assert metadata.start_pos is not None
-        assert metadata.num_actual_reqs is not None
-        full_compress_cos = metadata.full_compress_cos.view(
-            metadata.full_compress_cos.shape[0],
-            metadata.full_compress_cos.shape[-1],
-        )
-        full_compress_sin = metadata.full_compress_sin.view(
-            metadata.full_compress_sin.shape[0],
-            metadata.full_compress_sin.shape[-1],
-        )
-        return torch.ops._C_ascend.compressor_metadata(
-            full_compress_cos,
-            full_compress_sin,
-            metadata.query_start_loc,
-            metadata.start_pos,
-            metadata.block_table,
-            metadata.storage_block_size,
-            get_dsa_attn_kv_plan(self.vllm_config).get_dsa_compressor_slot_mapping_format(),
-            self.compress_ratio,
-            metadata.num_compressed_tokens,
-            metadata.num_actual_reqs,
-        )
+        return get_or_compute_compressor_metadata(metadata, self.compress_ratio, self.vllm_config)
 
     def forward(
         self,

--- a/vllm_ascend/spec_decode/llm_base_proposer.py
+++ b/vllm_ascend/spec_decode/llm_base_proposer.py
@@ -1532,6 +1532,13 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
                 multi_steps_attn_metadata[draft_index + 1] if multi_steps_attn_metadata else None
             )
 
+            if self.use_compress:
+                # The compressor metadata cached for the previous draft substep
+                # is stale now; drop it before running the next one.
+                from vllm_ascend.attention.dsa_v1 import reset_compressor_metadata_cache
+
+                reset_compressor_metadata_cache()
+
             model_kwargs = {
                 "input_ids": model_input_ids,
                 "positions": model_positions,


### PR DESCRIPTION
Backport of #14994 to main.

DSV4 runs one AscendCompressor forward per attention layer, but every layer
in a cache group consumes the same compressor metadata. This PR:

- Adds get_or_compute_compressor_metadata in dsa_v1.py, memoizing the
  device-side compressor_metadata operator outputs on the current forward
  context keyed by cache group, so it runs only once per group per substep.
- Adds reset_compressor_metadata_cache and calls it in _run_merged_draft when
  a merged speculative draft forward advances to its next substep.
- Threads a cache_group_key (derived from the builder's first layer name)
  through AscendDSAReqMetadata in both dsa_v1.py and the CP variant dsa_cp.py,
  and routes both eager fallback paths through the shared helper.

Note: main has already refactored the v0.26 prefill/decode metadata split
into a unified AscendDSAReqMetadata and moved the eager fallback into
AscendCompressor._compute_metadata, so the cache key no longer needs the
metadata-type component from the original PR; everything else is a 1:1 port.

Test: new UT tests/ut/attention/test_dsv4_compressor_metadata_cache.py
verifies same-group reuse, cross-group isolation, reset between substeps,
and fresh-context isolation (operator invoked exactly 4 times).

- vLLM main: https://github.com/vllm-project/vllm/commit/ba07e4a48fc951300d97eb506217dd530583dea3
