### PR TITLE
[Bugfix][DSA] Honor q_norm_without_weight callable in BaseDeviceAdaptor.apply_dsa_q_rms

### DIFF
--- a/vllm_ascend/device/device_op.py
+++ b/vllm_ascend/device/device_op.py
@@ -609,6 +609,9 @@ class BaseDeviceAdaptor:
     def apply_dsa_q_rms(q, eps, q_norm_without_weight=None):
         """Apply Q RMS norm. Non-A5: triton_q_rms.
         A5: uses q_norm_without_weight callable when provided."""
+        if q_norm_without_weight is not None:
+            return q_norm_without_weight(q)
+
         if triton_q_rms is not None:
             return triton_q_rms(q, eps)
         else:


### PR DESCRIPTION
Sync of #15784 rebased onto current upstream main (cherry-pick applied cleanly, no adaptation needed).

## Summary

`BaseDeviceAdaptor.apply_dsa_q_rms` accepted a `q_norm_without_weight` callable parameter but never invoked it, always falling through to `triton_q_rms`/manual RMS. Honor the callable when provided, so callers can supply a custom weightless Q RMS norm (as the A5 adaptor already does).
- vLLM main: https://github.com/vllm-project/vllm/commit/ba07e4a48fc951300d97eb506217dd530583dea3
