### PR TITLE
[Bugfix][MoE] Fix w8a8fp8_dynamic moe quant path

### DIFF
--- a/vllm_ascend/quantization/methods/w8a8/w8a8fp8_dynamic.py
+++ b/vllm_ascend/quantization/methods/w8a8/w8a8fp8_dynamic.py
@@ -18,6 +18,12 @@
 from typing import Any
 
 import torch
+import torch_npu
+from vllm.model_executor.layers.fused_moe.activation import MoEActivation
+
+from vllm_ascend.ops.fused_moe.dataclass.moe_mlp import MoEMlpComputeInput
+from vllm_ascend.ops.fused_moe.moe_utils import cumsum_group_list
+from vllm_ascend.utils import dispose_tensor
 
 from ..base import QuantType
 from ..registry import register_scheme
@@ -102,3 +108,48 @@ class AscendW8A8FP8DynamicFusedMoEMethod(AscendW8A8DynamicFusedMoEMethod):
         param_dict["w2_weight_scale"] = torch.empty(num_experts, hidden_sizes, 1, dtype=torch.float32)
         param_dict["w2_weight_offset"] = torch.empty(num_experts, hidden_sizes, 1, dtype=params_dtype)
         return param_dict
+
+    def apply_gmm1_act_quant(self, mlp_compute_input: MoEMlpComputeInput):
+        # FP8 weights are kept in ND layout (no FRACTAL_NZ cast), so the fused
+        # gmm1+swiglu+quant path must use the FP8-capable v2 kernel instead of
+        # the weight-NZ kernel the int8 W8A8 scheme dispatches to.
+        activation = mlp_compute_input.activation
+        if (
+            not mlp_compute_input.fusion
+            or mlp_compute_input.dynamic_eplb
+            or activation == MoEActivation.SWIGLUOAI_UNINTERLEAVE
+        ):
+            return super().apply_gmm1_act_quant(mlp_compute_input)
+
+        hidden_states = mlp_compute_input.hidden_states
+        hidden_states, pertoken_scale = self._quant_hidden_states(hidden_states, mlp_compute_input.dynamic_scale)
+        w1, w1_scale, _, _ = self._get_mlp_weights(mlp_compute_input.layer)
+        hidden_states, swiglu_out_scale = torch_npu.npu_grouped_matmul_swiglu_quant_v2(
+            x=hidden_states,
+            weight=w1,
+            group_list=cumsum_group_list(mlp_compute_input.group_list, mlp_compute_input.group_list_type, 0),
+            weight_scale=w1_scale,
+            x_scale=pertoken_scale,
+            quant_dtype=torch.float8_e4m3fn,
+            dequant_dtype=torch.float32,
+        )
+        dispose_tensor(mlp_compute_input.hidden_states)
+        return hidden_states, swiglu_out_scale
+
+    def apply_gmm2(self, mlp_compute_input: MoEMlpComputeInput, hidden_states, act_out_scale):
+        # FP8 per-channel scales are stored in float32; deriving output_dtype
+        # from them (as the int8 parent does) would leak a float32 MoE output
+        # into the next add+residual norm, which requires matching dtypes.
+        _, _, w2, w2_scale = self._get_mlp_weights(mlp_compute_input.layer)
+        return torch_npu.npu_grouped_matmul(
+            x=[hidden_states],
+            weight=w2,
+            scale=w2_scale,
+            bias=None,
+            per_token_scale=[act_out_scale],
+            split_item=2,
+            group_list_type=mlp_compute_input.group_list_type,
+            group_type=0,
+            group_list=mlp_compute_input.group_list,
+            output_dtype=self.in_dtype,
+        )[0]


### PR DESCRIPTION
### What this PR does / why we need it?

Add misssing w8a8fp8_dynamic moe quant path from #13773 

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Use qwen3.5-35B-A3B-FP8-dynamic.
<img width="2332" height="105" alt="image" src="https://github.com/user-attachments/assets/38e78785-5fe7-454a-9bfc-2ae240c57ed8" />

- vLLM main: https://github.com/vllm-project/vllm/commit/ba07e4a48fc951300d97eb506217dd530583dea3
