### PR TITLE
[BugFix][KV Pool] Store only reachable blocks in layerwise KV pool transfer

### DIFF
--- a/tests/ut/distributed/ascend_store/test_coordinator.py
+++ b/tests/ut/distributed/ascend_store/test_coordinator.py
@@ -94,6 +94,32 @@ class _FakeCompressedManager:
         return computed, len(computed[0]) * logical_block_size
 
 
+class _FakePrefixManager:
+    """FA manager: contiguous prefix walk over externally cached blocks."""
+
+    @classmethod
+    def find_longest_cache_hit(
+        cls,
+        block_hashes,
+        max_length,
+        kv_cache_group_ids,
+        block_pool,
+        kv_cache_spec,
+        drop_eagle_block=False,
+        alignment_tokens=16,
+        **kwargs,
+    ):
+        computed: tuple[list[object], ...] = tuple([] for _ in kv_cache_group_ids)
+        max_blocks = max_length // kv_cache_spec.block_size
+        for block_hash in list(block_hashes)[:max_blocks]:
+            cached = block_pool.get_cached_block(block_hash, kv_cache_group_ids)
+            if not cached:
+                break
+            for blocks, block in zip(computed, cached):
+                blocks.append(block)
+        return computed, len(computed[0]) * kv_cache_spec.block_size
+
+
 class TestAscendStoreCoordinator(unittest.TestCase):
     def test_compressed_group_hits_on_effective_granularity(self):
         block_hashes = _hashes(128)
@@ -255,6 +281,81 @@ class TestAscendStoreCoordinator(unittest.TestCase):
                 coord.load_mask(_hashes(16), 2048),
                 (cached_mask,),
             )
+
+
+class TestFindReachableHitTokens(unittest.TestCase):
+    """The shared driver behind the scheduler/worker coordinator lookups."""
+
+    def test_passes_mask_allowed_hashes_to_query_callback(self):
+        coord = AscendStoreCoordinator(
+            [KVCacheGroupSpec(["layer.0"], _sliding_spec(block_size=128, sliding_window=256))],
+            scheduler_block_size=256,
+            hash_block_size=128,
+            group_block_sizes=[128],
+            group_cache_families=["c1"],
+        )
+        calls: list[tuple[int, list, list | None]] = []
+
+        def query_group_hits(group_id, group_block_hashes, lookup_mask):
+            calls.append((group_id, list(group_block_hashes), list(lookup_mask) if lookup_mask is not None else None))
+            return []
+
+        with patch(
+            "vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.coordinator._reachable_block_mask",
+            return_value=[False, True],
+        ):
+            hit = coord.find_reachable_hit_tokens(_hashes(2), 256, query_group_hits)
+
+        self.assertEqual(hit, 0)
+        self.assertEqual(calls, [(0, _hashes(2), [False, True])])
+
+    def test_hit_length_derived_from_callback_hits(self):
+        with patch(
+            "vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.coordinator._get_manager_class",
+            return_value=_FakePrefixManager,
+        ):
+            coord = AscendStoreCoordinator(
+                [KVCacheGroupSpec(["layer.0"], _full_spec(128))],
+                scheduler_block_size=256,
+                hash_block_size=128,
+                group_block_sizes=[128],
+                group_cache_families=["c4"],
+            )
+        block_hashes = _hashes(4)
+        received: list[list] = []
+
+        def query_group_hits(group_id, group_block_hashes, lookup_mask):
+            received.append(list(group_block_hashes))
+            self.assertIsNone(lookup_mask)
+            return list(group_block_hashes[:3])
+
+        with patch.object(coord, "find_longest_cache_hit", wraps=coord.find_longest_cache_hit) as derive:
+            hit = coord.find_reachable_hit_tokens(block_hashes, 384, query_group_hits)
+
+        # Only whole hash blocks within token_len are queried (384 // 128 = 3).
+        self.assertEqual(received, [_hashes(3)])
+        self.assertEqual(hit, 384)
+        derive.assert_called_once()
+        self.assertFalse(derive.call_args.kwargs["apply_eagle"])
+
+    def test_no_hits_returns_zero_without_deriving(self):
+        with patch(
+            "vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.coordinator._get_manager_class",
+            return_value=_FakePrefixManager,
+        ):
+            coord = AscendStoreCoordinator(
+                [KVCacheGroupSpec(["layer.0"], _full_spec(128))],
+                scheduler_block_size=256,
+                hash_block_size=128,
+                group_block_sizes=[128],
+                group_cache_families=["c4"],
+            )
+
+        with patch.object(coord, "find_longest_cache_hit") as derive:
+            hit = coord.find_reachable_hit_tokens(_hashes(2), 256, lambda *args: [])
+
+        self.assertEqual(hit, 0)
+        derive.assert_not_called()
 
 
 if __name__ == "__main__":

--- a/tests/ut/distributed/ascend_store/test_metadata.py
+++ b/tests/ut/distributed/ascend_store/test_metadata.py
@@ -34,6 +34,7 @@ from vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.metadata import (
     get_group_cache_family,
     infer_cache_transfer_granularity,
     infer_group_block_sizes,
+    masked_block_runs,
     uses_hybrid_kv_cache,
 )
 
@@ -76,6 +77,25 @@ class TestCacheLayoutHelpers(unittest.TestCase):
 
     def test_infer_cache_transfer_granularity(self):
         self.assertEqual(infer_cache_transfer_granularity([16, 32], 32, [0, 1]), 32)
+
+
+class TestMaskedBlockRuns(unittest.TestCase):
+    def test_none_mask_returns_single_run(self):
+        self.assertEqual(masked_block_runs(None, 1, 5), [(1, 5)])
+
+    def test_sparse_mask_splits_into_runs(self):
+        mask = [False, True, False, True, True]
+        self.assertEqual(masked_block_runs(mask, 0, 5), [(1, 2), (3, 5)])
+
+    def test_empty_range_returns_no_runs(self):
+        self.assertEqual(masked_block_runs([True, True], 2, 2), [])
+        self.assertEqual(masked_block_runs(None, 3, 1), [])
+
+    def test_blocks_beyond_mask_length_are_allowed(self):
+        self.assertEqual(masked_block_runs([False, True], 0, 4), [(1, 4)])
+
+    def test_all_disallowed_mask_returns_no_runs(self):
+        self.assertEqual(masked_block_runs([False, False], 0, 2), [])
 
 
 class TestKeyMetadata(unittest.TestCase):

--- a/tests/ut/distributed/ascend_store/test_pool_scheduler.py
+++ b/tests/ut/distributed/ascend_store/test_pool_scheduler.py
@@ -19,8 +19,11 @@ import unittest
 from unittest.mock import MagicMock, patch
 
 import pytest
+import torch
+from vllm.v1.kv_cache_interface import FullAttentionSpec, KVCacheGroupSpec, SlidingWindowSpec
 
 import tests.ut.distributed.ascend_store._mock_deps  # noqa: F401, E402
+from vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.coordinator import AscendStoreCoordinator
 from vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.metadata import (
     LoadSpec,
     RequestTracker,
@@ -961,6 +964,209 @@ class TestKVPoolSchedulerUpdateStateAfterAllocBranches(unittest.TestCase):
         scheduler.load_specs["r1"] = LoadSpec(0, 32, can_load=False)
         scheduler.update_state_after_alloc(MagicMock(request_id="r1"), MagicMock(), 0)
         self.assertTrue(scheduler.load_specs["r1"].can_load)
+
+
+class _PrefixHitManager:
+    """FA manager whose find_longest_cache_hit returns (blocks, hit_length)."""
+
+    @classmethod
+    def find_longest_cache_hit(
+        cls,
+        block_hashes,
+        max_length,
+        kv_cache_group_ids,
+        block_pool,
+        kv_cache_spec,
+        drop_eagle_block=False,
+        alignment_tokens=16,
+        **kwargs,
+    ):
+        computed: tuple[list, ...] = tuple([] for _ in kv_cache_group_ids)
+        max_blocks = max_length // kv_cache_spec.block_size
+        for block_hash in list(block_hashes)[:max_blocks]:
+            cached = block_pool.get_cached_block(block_hash, kv_cache_group_ids)
+            if not cached:
+                break
+            for blocks, block in zip(computed, cached):
+                blocks.append(block)
+        return computed, len(computed[0]) * kv_cache_spec.block_size
+
+
+class _SparseSWAHitManager(_PrefixHitManager):
+    """SWA manager: only segment-tail blocks are reachable/hit."""
+
+    @classmethod
+    def reachable_block_mask(
+        cls,
+        start_block,
+        end_block,
+        alignment_tokens,
+        kv_cache_spec,
+        use_eagle,
+        retention_interval=None,
+        **kwargs,
+    ):
+        if alignment_tokens is None:
+            return None
+        per_segment = max(alignment_tokens // kv_cache_spec.block_size, 1)
+        return [(idx + 1) % per_segment == 0 for idx in range(start_block, end_block)]
+
+    @classmethod
+    def find_longest_cache_hit(
+        cls,
+        block_hashes,
+        max_length,
+        kv_cache_group_ids,
+        block_pool,
+        kv_cache_spec,
+        drop_eagle_block=False,
+        alignment_tokens=16,
+        **kwargs,
+    ):
+        # Right-to-left search for a cached run ending on an aligned boundary.
+        block_size = kv_cache_spec.block_size
+        max_num_blocks = max_length // block_size
+        computed: tuple[list, ...] = tuple([None] * max_num_blocks for _ in kv_cache_group_ids)
+        for i in range(max_num_blocks - 1, -1, -1):
+            cached = block_pool.get_cached_block(block_hashes[i], kv_cache_group_ids)
+            if not cached:
+                continue
+            if (i + 1) * block_size % alignment_tokens != 0:
+                continue
+            for blocks, block in zip(computed, cached):
+                blocks[i] = block
+            return computed, (i + 1) * block_size
+        return computed, 0
+
+
+class TestKVPoolSchedulerLayerwiseReachableLookup(unittest.TestCase):
+    """_get_layerwise_hit_tokens with the reachability coordinator.
+
+    Mirrors the DSV4 layout: a full-attention group plus a sliding-window
+    group whose pooled blocks are stored sparsely (segment tails only).
+    """
+
+    def setUp(self):
+        patcher = patch(
+            "vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.coordinator._get_manager_class",
+            side_effect=self._manager_for_spec,
+        )
+        patcher.start()
+        self.addCleanup(patcher.stop)
+
+    @staticmethod
+    def _manager_for_spec(spec):
+        if getattr(spec, "sliding_window", None) is not None:
+            return _SparseSWAHitManager
+        return _PrefixHitManager
+
+    def _make_coordinator(self):
+        return AscendStoreCoordinator(
+            [
+                KVCacheGroupSpec(
+                    ["layer.0"],
+                    FullAttentionSpec(block_size=16, num_kv_heads=1, head_size=1, dtype=torch.float32),
+                ),
+                KVCacheGroupSpec(
+                    ["layer.1"],
+                    SlidingWindowSpec(
+                        block_size=16, num_kv_heads=1, head_size=1, dtype=torch.float32, sliding_window=16
+                    ),
+                ),
+            ],
+            scheduler_block_size=32,
+            hash_block_size=16,
+            group_block_sizes=[16, 16],
+            group_cache_families=["default", "c1"],
+        )
+
+    @patch("vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.pool_scheduler.LookupKeyClient")
+    def _make_scheduler(self, mock_client_cls):
+        scheduler = KVPoolScheduler(make_config(extra_config={"backend": "memcache"}), use_layerwise=True)
+        scheduler.cache_coordinator = self._make_coordinator()
+        scheduler.grouped_block_size = [16, 16]
+        scheduler.kv_cache_group_ids = [0, 1]
+        return scheduler
+
+    @staticmethod
+    def _key_info(hit: bool):
+        info = MagicMock()
+        info.size.return_value = 64 if hit else 0
+        info.gva_list.return_value = [0x1000] if hit else []
+        return info
+
+    def _stub_pool(self, scheduler, num_blocks: int, pool_layout: dict[int, list[int]]):
+        """Mock batch_get_key_info so a block exists iff it is in pool_layout.
+
+        Layerwise hit-check keys use the multi-group format model@group@hash@rank,
+        so the stub decodes the group and block index from each key.
+        """
+        hash_hex_by_idx = {f"{idx:02x}" * 32: idx for idx in range(num_blocks)}
+
+        def get_key_info(keys):
+            infos = []
+            for key in keys:
+                parts = key.split("@")
+                group_id = int(parts[1])
+                block_idx = hash_hex_by_idx[parts[2]]
+                infos.append(self._key_info(block_idx in pool_layout.get(group_id, [])))
+            return infos
+
+        scheduler.store_scheduler.batch_get_key_info.side_effect = get_key_info
+
+    @staticmethod
+    def _request(num_blocks: int):
+        request = MagicMock()
+        request.request_id = "r1"
+        request.block_hashes = [bytes([idx]) * 32 for idx in range(num_blocks)]
+        return request
+
+    def test_sparse_swa_storage_still_yields_full_hit(self):
+        scheduler = self._make_scheduler()
+        # 64 tokens = 4 blocks per group. The SWA group only stores the tail
+        # of each 32-token segment (block 1 and block 3); the full-attention
+        # group stores everything.
+        self._stub_pool(scheduler, 4, {0: [0, 1, 2, 3], 1: [1, 3]})
+
+        hit = scheduler._get_layerwise_hit_tokens(self._request(4), 64, 0)
+
+        self.assertEqual(hit, 64)
+        queried_keys = scheduler.store_scheduler.batch_get_key_info.call_args_list
+        # Only the 4 FA keys + 2 sparsely-stored SWA keys are queried.
+        self.assertEqual(sum(len(call.args[0]) for call in queried_keys), 6)
+
+    def test_hit_stops_where_stored_tail_is_missing(self):
+        scheduler = self._make_scheduler()
+        # SWA group stored block 1 (tail of the first segment) but block 3
+        # (tail of the second segment) is missing -> hit cannot extend past
+        # the first 32 tokens.
+        self._stub_pool(scheduler, 4, {0: [0, 1, 2, 3], 1: [1]})
+
+        hit = scheduler._get_layerwise_hit_tokens(self._request(4), 64, 0)
+
+        self.assertEqual(hit, 32)
+
+    def test_no_pooled_blocks_returns_zero(self):
+        scheduler = self._make_scheduler()
+        self._stub_pool(scheduler, 2, {})
+
+        hit = scheduler._get_layerwise_hit_tokens(self._request(2), 32, 0)
+
+        self.assertEqual(hit, 0)
+
+    def test_without_coordinator_falls_back_to_contiguous(self):
+        scheduler = self._make_scheduler()
+        scheduler.cache_coordinator = None
+        infos = [self._key_info(True), self._key_info(False)]
+
+        def get_key_info(keys):
+            return infos[: len(keys)]
+
+        scheduler.store_scheduler.batch_get_key_info.side_effect = get_key_info
+
+        hit = scheduler._get_layerwise_hit_tokens(self._request(2), 32, 0)
+
+        self.assertEqual(hit, 16)
 
 
 if __name__ == "__main__":

--- a/tests/ut/distributed/ascend_store/test_pool_scheduler.py
+++ b/tests/ut/distributed/ascend_store/test_pool_scheduler.py
@@ -189,6 +189,33 @@ class TestKVPoolScheduler(unittest.TestCase):
         self.assertTrue(load_spec.can_load)
 
     @patch("vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.pool_scheduler.LookupKeyClient")
+    def test_layerwise_mtp_hit_on_final_block_boundary_not_trimmed(self, mock_client_cls):
+        scheduler = KVPoolScheduler(
+            self._make_config(block_size=16, extra_config={"backend": "memcache"}),
+            use_layerwise=True,
+        )
+        scheduler.use_eagle = True
+        scheduler.cache_transfer_granularity = 16
+        scheduler._get_layerwise_hit_tokens = MagicMock(return_value=96)
+
+        request = MagicMock()
+        request.prompt_token_ids = list(range(100))
+        request.num_tokens = 101
+        request.request_id = "r1"
+        request.block_hashes = [b"h"] * 7
+
+        need, is_async = scheduler.get_num_new_matched_tokens(request, 0)
+
+        # The hit (96) stops exactly on the final block's start boundary
+        # ((101 - 1) // 16 * 16 = 96) and must be loaded as-is instead of
+        # being trimmed back by one whole lcm block.
+        self.assertEqual(need, 96)
+        self.assertFalse(is_async)
+        load_spec = scheduler.load_specs["r1"]
+        self.assertEqual(load_spec.kvpool_cached_tokens, 96)
+        self.assertEqual(load_spec.kvpool_store_skip_tokens, 96)
+
+    @patch("vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.pool_scheduler.LookupKeyClient")
     def test_get_num_new_matched_tokens_full_hbm_hit_skips_external_lookup(self, mock_client_cls):
         scheduler = KVPoolScheduler(self._make_config(block_size=16), use_layerwise=False)
         request = MagicMock()

--- a/tests/ut/distributed/ascend_store/test_pool_worker.py
+++ b/tests/ut/distributed/ascend_store/test_pool_worker.py
@@ -1830,5 +1830,169 @@ class TestKVPoolWorkerTpMismatch(unittest.TestCase):
                 send_thread.dec_stored_request.assert_called_once_with("r1")
 
 
+class TestKVPoolWorkerReachableMasks(unittest.TestCase):
+    """Layerwise reachable-mask filtering on the save/load paths."""
+
+    def _make_worker(self):
+        worker = make_worker(self, extra_config={"backend": "memcache"}, use_layerwise=True)
+        worker.layerwise_offload = True
+        worker.num_kv_cache_groups = 1
+        worker.grouped_block_size = [16]
+        worker.kv_cache_group_families = ["default"]
+        worker.group_block_len = {0: [64]}
+        worker.group_num_layers = {0: 1}
+        worker.hash_block_size = 16
+        worker.page_size_bytes = 64
+        worker.head_or_tp_rank = 0
+        worker._allocated_gvas = {}
+        worker.m_store = MagicMock()
+        return worker
+
+    @staticmethod
+    def _make_request(**overrides):
+        block_ids = overrides.pop("block_ids", [10, 11, 12, 13])
+        store_masks = overrides.pop("store_masks", None)
+        load_masks = overrides.pop("load_masks", None)
+        params = dict(
+            req_id="r1",
+            token_len_chunk=64,
+            save_start_token=0,
+            save_end_token=64,
+            target_token_len=64,
+            block_hashes=["h0", "h1", "h2", "h3"],
+            can_save=True,
+            block_ids_np=np.asarray(block_ids, dtype=np.int64),
+            block_ids_by_group_np=[np.asarray(block_ids, dtype=np.int64)],
+        )
+        params.update(overrides)
+        request = ReqMeta(**params)
+        if store_masks is not None:
+            request.store_masks = store_masks
+        if load_masks is not None:
+            request.load_masks = load_masks
+        return request
+
+    def test_compute_reachable_store_masks_fallbacks(self):
+        worker = self._make_worker()
+        request = self._make_request()
+        self.assertIsNone(worker._compute_reachable_store_masks(request))
+
+        worker.cache_coordinator = object()
+        self.assertIsNone(worker._compute_reachable_store_masks(self._make_request(save_end_token=60)))
+
+        worker.token_database.store_mask = MagicMock(side_effect=AssertionError("unaligned"))
+        self.assertIsNone(worker._compute_reachable_store_masks(request))
+
+        expected = ([False, True],)
+        worker.token_database.store_mask = MagicMock(return_value=expected)
+        self.assertEqual(worker._compute_reachable_store_masks(request), expected)
+
+    def test_alloc_gvas_for_save_respects_store_mask(self):
+        worker = self._make_worker()
+        worker.m_store.batch_alloc.return_value = [101, 103]
+        request = self._make_request(store_masks=([False, True, False, True],))
+
+        worker._alloc_gvas_for_save([request])
+
+        keys = worker.m_store.batch_alloc.call_args.args[0]
+        self.assertEqual(keys, ["llama-7b@h1@0", "llama-7b@h3@0"])
+        self.assertEqual(request.save_keys, ["llama-7b@h1@0", "llama-7b@h3@0"])
+        self.assertEqual(request.block_gvas_by_group_np[0].tolist(), [0, 101, 0, 103])
+
+    def test_alloc_gvas_for_save_without_mask_allocates_all(self):
+        worker = self._make_worker()
+        worker.m_store.batch_alloc.return_value = [101, 102, 103, 104]
+        request = self._make_request()
+
+        worker._alloc_gvas_for_save([request])
+
+        keys = worker.m_store.batch_alloc.call_args.args[0]
+        self.assertEqual(len(keys), 4)
+        self.assertEqual(request.block_gvas_by_group_np[0].tolist(), [101, 102, 103, 104])
+
+    def test_process_save_for_layer_batch_splits_masked_runs(self):
+        worker = self._make_worker()
+        request = self._make_request(store_masks=([False, True, False, True],))
+
+        worker._process_save_for_layer_batch([request], 0)
+
+        ranges = worker.layer_save_tasks[0][0].block_ranges
+        self.assertEqual(
+            [(r.start_block, r.end_block, r.partial_block_index) for r in ranges],
+            [(1, 2, None), (3, 4, None)],
+        )
+
+    def test_process_save_for_layer_batch_mask_and_partial_ride_last_run(self):
+        worker = self._make_worker()
+        request = self._make_request(
+            save_end_token=64,
+            target_token_len=66,
+            block_ids=[10, 11, 12, 13, 14],
+            store_masks=([False, True, False, True],),
+        )
+
+        worker._process_save_for_layer_batch([request], 0)
+
+        ranges = worker.layer_save_tasks[0][0].block_ranges
+        self.assertEqual(
+            [(r.start_block, r.end_block, r.partial_block_index) for r in ranges],
+            [(1, 2, None), (3, 4, 4)],
+        )
+
+    def test_process_save_for_layer_batch_fully_masked_skips_request(self):
+        worker = self._make_worker()
+        request = self._make_request(store_masks=([False, False, False, False],))
+
+        worker._process_save_for_layer_batch([request], 0)
+
+        self.assertEqual(worker.layer_save_tasks[0], [])
+
+    def test_prepare_load_gvas_queries_only_masked_blocks(self):
+        worker = self._make_worker()
+        worker.cache_coordinator = object()
+        worker.token_database.load_mask = MagicMock(return_value=([False, True, False, True],))
+        key_info = MagicMock()
+        key_info.size.return_value = 64
+        key_info.gva_list.return_value = [201]
+        worker.m_store.batch_get_key_info.return_value = [key_info, key_info]
+        worker.m_store.batch_add_lease.return_value = [0, 0]
+        request = self._make_request(
+            can_save=None,
+            load_spec=LoadSpec(
+                vllm_cached_tokens=0,
+                kvpool_cached_tokens=64,
+                can_load=True,
+            ),
+        )
+
+        worker._prepare_load_gvas([request])
+
+        queried_keys = worker.m_store.batch_get_key_info.call_args.args[0]
+        self.assertEqual(queried_keys, ["llama-7b@h1@0", "llama-7b@h3@0"])
+        self.assertEqual(request.load_masks, ([False, True, False, True],))
+        self.assertEqual(request.load_block_gvas_by_group_np[0].tolist(), [0, 201, 0, 201])
+
+    def test_process_load_for_layer_batch_respects_load_mask(self):
+        worker = self._make_worker()
+        request = self._make_request(
+            can_save=None,
+            load_spec=LoadSpec(
+                vllm_cached_tokens=0,
+                kvpool_cached_tokens=64,
+                can_load=True,
+            ),
+            load_masks=([False, True, False, True],),
+            partial_load_gva_per_group=[0],
+        )
+
+        worker._process_load_for_layer_batch([request], 0)
+
+        ranges = worker.layer_load_tasks[0][0].block_ranges
+        self.assertEqual(
+            [(r.start_block, r.end_block, r.partial_block_index) for r in ranges],
+            [(1, 2, None), (3, 4, None)],
+        )
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/ut/distributed/ascend_store/test_pool_worker.py
+++ b/tests/ut/distributed/ascend_store/test_pool_worker.py
@@ -90,6 +90,34 @@ def make_worker(
     return KVPoolWorker(config, use_layerwise=use_layerwise)
 
 
+class _SparseSWAHitManager:
+    """SWA manager: right-to-left search for a cached aligned segment tail."""
+
+    @classmethod
+    def find_longest_cache_hit(
+        cls,
+        block_hashes,
+        max_length,
+        kv_cache_group_ids,
+        block_pool,
+        kv_cache_spec,
+        drop_eagle_block=False,
+        alignment_tokens=16,
+        **kwargs,
+    ):
+        block_size = kv_cache_spec.block_size
+        max_num_blocks = max_length // block_size
+        for block_idx in range(max_num_blocks - 1, -1, -1):
+            cached = block_pool.get_cached_block(block_hashes[block_idx], kv_cache_group_ids)
+            if not cached:
+                continue
+            if (block_idx + 1) * block_size % alignment_tokens != 0:
+                continue
+            computed: tuple[list, ...] = tuple([] for _ in kv_cache_group_ids)
+            return computed, (block_idx + 1) * block_size
+        return tuple([] for _ in kv_cache_group_ids), 0
+
+
 class TestKVPoolWorkerHelpers(unittest.TestCase):
     """Test the pure helper methods on KVPoolWorker without full init."""
 
@@ -218,41 +246,99 @@ class TestKVPoolWorkerHelpers(unittest.TestCase):
         hits = [[16, 32, 48], [32, 48], [16, 32], [32, 48, 64]]
         self.assertEqual(32, cls._max_intersection_hit_position(hits))
 
-    def test_external_coordinator_lookup_uses_only_lookup_mask(self):
-        cls = self._make_worker_class()
+    def _make_sparse_swa_coordinator(self):
+        import torch
+        from vllm.v1.kv_cache_interface import KVCacheGroupSpec, SlidingWindowSpec
+
+        from vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.coordinator import AscendStoreCoordinator
+
+        with patch(
+            "vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.coordinator._get_manager_class",
+            return_value=_SparseSWAHitManager,
+        ):
+            return AscendStoreCoordinator(
+                [
+                    KVCacheGroupSpec(
+                        ["layer.0"],
+                        SlidingWindowSpec(
+                            block_size=128, num_kv_heads=1, head_size=1, dtype=torch.float32, sliding_window=256
+                        ),
+                    )
+                ],
+                scheduler_block_size=256,
+                hash_block_size=128,
+                group_block_sizes=[128],
+                group_cache_families=["c1"],
+            )
+
+    @staticmethod
+    def _make_lookup_worker(cls, coordinator):
         worker = object.__new__(cls)
         worker.hash_block_size = 128
         worker.num_kv_cache_groups = 1
-        worker.cache_coordinator = MagicMock()
-        worker.cache_coordinator.lcm_block_size = 128
-        worker.cache_coordinator.lookup_mask.return_value = ([True],)
-        worker.cache_coordinator.store_mask.return_value = ([False],)
-        worker.cache_coordinator.find_longest_cache_hit.return_value = ((), 128)
+        worker.cache_coordinator = coordinator
         worker.m_store = MagicMock()
+        worker.token_database = MagicMock()
+
+        def process_token_key_strings(token_len, block_hashes, mask_num, kv_cache_group_id, chunk_filter):
+            return [
+                (start, start + 128, f"key{start // 128}", f"h{start // 128}".encode())
+                for start in range(mask_num, token_len, 128)
+                if chunk_filter(start)
+            ]
+
+        worker.token_database.process_token_key_strings.side_effect = process_token_key_strings
+        return worker
+
+    def test_external_coordinator_lookup_uses_only_lookup_mask(self):
+        cls = self._make_worker_class()
+        worker = self._make_lookup_worker(cls, self._make_sparse_swa_coordinator())
         worker.m_store.exists.return_value = [1]
 
-        worker.token_database = MagicMock()
-        worker.token_database.get_block_size.return_value = 128
-        worker.token_database.group_cache_families = {"kv": {0: "default"}}
-        worker.token_database.process_token_key_strings.side_effect = lambda *args, chunk_filter, **kwargs: (
-            [(0, 128, "key", "ab" * 32)] if chunk_filter(0) else []
-        )
+        with (
+            patch(
+                "vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.coordinator._reachable_block_mask",
+                return_value=[False, True],
+            ),
+            patch.object(worker.cache_coordinator, "store_mask") as store_mask,
+        ):
+            hit = worker._lookup_with_coordinator(
+                256,
+                [b"h0", b"h1"],
+                [0],
+                use_layerwise=False,
+                include_all_ranks=False,
+            )
 
-        hit = worker._lookup_with_coordinator(
-            128,
-            [b"h0"],
-            [0],
-            use_layerwise=False,
-            include_all_ranks=False,
-        )
-
-        self.assertEqual(hit, 128)
-        worker.cache_coordinator.lookup_mask.assert_called_once_with(128)
-        worker.cache_coordinator.store_mask.assert_not_called()
-        worker.m_store.exists.assert_called_once_with(["key"])
-        worker.cache_coordinator.find_longest_cache_hit.assert_called_once()
-        self.assertFalse(worker.cache_coordinator.find_longest_cache_hit.call_args.kwargs["apply_eagle"])
+        # Only the reachable tail block is queried; its presence covers the
+        # whole segment, so the hit still spans the full token length.
+        self.assertEqual(hit, 256)
+        worker.m_store.exists.assert_called_once_with(["key1"])
+        store_mask.assert_not_called()
         worker.token_database.process_tokens.assert_not_called()
+
+    def test_external_coordinator_lookup_preseeds_hbm_hits(self):
+        cls = self._make_worker_class()
+        worker = self._make_lookup_worker(cls, self._make_sparse_swa_coordinator())
+        worker.m_store.exists.return_value = [1]
+
+        with patch(
+            "vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.coordinator._reachable_block_mask",
+            return_value=[True, True],
+        ):
+            hit = worker._lookup_with_coordinator(
+                256,
+                [b"h0", b"h1"],
+                [0],
+                use_layerwise=False,
+                include_all_ranks=False,
+                hbm_hit_tokens=128,
+            )
+
+        # The locally computed block is preseeded and never queried; only the
+        # tail block beyond the HBM hit goes to the pool.
+        self.assertEqual(hit, 256)
+        worker.m_store.exists.assert_called_once_with(["key1"])
 
     def test_layerwise_multi_group_layout_includes_mtp(self):
         import torch

--- a/tests/ut/distributed/ascend_store/test_pool_worker.py
+++ b/tests/ut/distributed/ascend_store/test_pool_worker.py
@@ -1464,6 +1464,10 @@ class TestKVPoolWorkerProcessLayerData(unittest.TestCase):
         )
 
     def test_evicted_allocated_gva_is_reallocated(self):
+        from vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.pool_worker import (
+            LAYERWISE_READ_LEASE_TTL_MS,
+        )
+
         worker = self._make_gva_worker()
         key = worker._make_layerwise_full_key(0, "h0")
         worker._allocated_gvas[key] = 101
@@ -1473,7 +1477,7 @@ class TestKVPoolWorkerProcessLayerData(unittest.TestCase):
 
         worker._alloc_gvas_for_save([request])
 
-        worker.m_store.batch_alloc.assert_called_once_with([key], [64])
+        worker.m_store.batch_alloc.assert_called_once_with([key], [64], LAYERWISE_READ_LEASE_TTL_MS)
         self.assertEqual(worker._allocated_gvas[key], 202)
         self.assertEqual(request.block_gvas_by_group_np[0].tolist(), [202])
 

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/backend/base.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/backend/base.py
@@ -85,7 +85,7 @@ class Backend(ABC):
     def batch_get_key_info(self, keys: list[str]):
         raise NotImplementedError(f"{type(self).__name__} does not support batch_get_key_info")
 
-    def batch_alloc(self, keys: list[str], sizes: list[int]) -> list[int]:
+    def batch_alloc(self, keys: list[str], sizes: list[int], lease_ttl_ms: int = 0) -> list[int]:
         raise NotImplementedError(f"{type(self).__name__} does not support batch_alloc")
 
     def batch_add_lease(self, keys: list[str], lease_ttl_ms: int = 0) -> list[int]:

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/backend/memcache_backend.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/backend/memcache_backend.py
@@ -277,7 +277,7 @@ class MemcacheBackend(Backend):
     def batch_alloc(self, keys: list[str], sizes: list[int], lease_ttl_ms: int = 0) -> list[int]:
         self.ensure_initialized()
         assert self.store is not None
-        return self.store.batch_alloc(keys, sizes, lease_ttl_ms)
+        return self.store.batch_alloc(keys, sizes, 1, lease_ttl_ms)
 
     def batch_add_lease(self, keys: list[str], lease_ttl_ms: int = 0) -> list[int]:
         assert self.store is not None

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/backend/memcache_backend.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/backend/memcache_backend.py
@@ -274,10 +274,10 @@ class MemcacheBackend(Backend):
         assert self.store is not None
         return self.store.batch_get_key_info(keys)
 
-    def batch_alloc(self, keys: list[str], sizes: list[int]) -> list[int]:
+    def batch_alloc(self, keys: list[str], sizes: list[int], lease_ttl_ms: int = 0) -> list[int]:
         self.ensure_initialized()
         assert self.store is not None
-        return self.store.batch_alloc(keys, sizes)
+        return self.store.batch_alloc(keys, sizes, lease_ttl_ms)
 
     def batch_add_lease(self, keys: list[str], lease_ttl_ms: int = 0) -> list[int]:
         assert self.store is not None

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/coordinator.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/coordinator.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from collections.abc import Callable, Iterable, Sequence
 from dataclasses import replace
 from importlib import import_module
 from typing import Any, cast
@@ -18,10 +19,16 @@ from vllm.v1.kv_cache_interface import (
 
 from vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.metadata import (
     block_hash_to_bytes,
+    get_block_hashes,
 )
 
 _CACHE_MISSING = object()
 _MANAGER_CLASS_CACHE_ATTR = "_manager_class_cache"
+
+# Per-group pool query used by the shared reachable hit lookup: returns the
+# subset of ``group_block_hashes`` present in the pool (all replicas valid).
+# A None ``lookup_mask`` means the group has no reachability limits.
+GroupHitQuery = Callable[[int, Sequence[BlockHash | str], Sequence[bool] | None], Iterable[BlockHash | str]]
 
 
 class ExternalCachedBlockPool:
@@ -205,6 +212,50 @@ class AscendStoreCoordinator:
             if mask is not None:
                 assert len(mask) == num_chunks
         return tuple(None if mask is None or all(mask) else mask for _, mask in masks)
+
+    def find_reachable_hit_tokens(
+        self,
+        block_hashes: list[BlockHash],
+        token_len: int,
+        query_group_hits: GroupHitQuery,
+        *,
+        log_context: str = "reachable_lookup",
+    ) -> int:
+        """Reachability-aware external hit lookup shared by both transfer paths.
+
+        Queries, per group, only the blocks the group's lookup mask allows —
+        the subset the save paths persist for reachability-limited groups —
+        and derives the hit length via find_longest_cache_hit so sparsely
+        stored pools still yield correct prefix hits. Both the scheduler-side
+        layerwise lookup and the worker-side non-layerwise lookup delegate
+        here so the hit semantics cannot drift between them.
+
+        ``query_group_hits(group_id, group_block_hashes, lookup_mask)`` must
+        return the subset of ``group_block_hashes`` present in the pool for
+        that group, using whichever key layout and query backend the caller
+        owns.
+        """
+        aligned_len = cdiv(token_len, self.lcm_block_size) * self.lcm_block_size
+        lookup_masks = self.lookup_mask(aligned_len)
+        exists: set[tuple[int, bytes]] = set()
+        block_hashes_to_check = block_hashes[: token_len // self.hash_block_size]
+
+        for group_id, group_block_size in enumerate(self.group_effective_block_sizes):
+            group_block_hashes = get_block_hashes(block_hashes_to_check, group_block_size, self.hash_block_size)
+            hits = query_group_hits(group_id, group_block_hashes, lookup_masks[group_id])
+            exists.update((group_id, block_hash_to_bytes(hit)) for hit in hits)
+
+        if not exists:
+            logger.debug("%s: token_len=%d no pooled blocks found", log_context, token_len)
+            return 0
+        _, hit_length = self.find_longest_cache_hit(
+            block_hashes,
+            token_len,
+            ExternalCachedBlockPool(self.hash_block_size, exists),
+            apply_eagle=False,
+        )
+        logger.debug("%s: token_len=%d hit_tokens=%d", log_context, token_len, hit_length)
+        return hit_length
 
     def block_hashes_for_spec(self, block_hashes: list[BlockHash], spec: KVCacheSpec) -> BlockHashList:
         return block_hashes

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/metadata.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/metadata.py
@@ -741,6 +741,34 @@ def get_partial_block_index(
     return None
 
 
+def masked_block_runs(
+    mask: Sequence[bool] | None,
+    start_block: int,
+    end_block: int,
+) -> list[tuple[int, int]]:
+    """Split [start_block, end_block) into maximal runs of mask-allowed blocks.
+
+    A None mask (or blocks at or beyond the mask length) disables filtering,
+    so callers never transfer fewer blocks than the mask actually covers.
+    """
+    if end_block <= start_block:
+        return []
+    if mask is None:
+        return [(start_block, end_block)]
+    runs: list[tuple[int, int]] = []
+    run_start: int | None = None
+    for block_idx in range(start_block, end_block):
+        allowed = block_idx >= len(mask) or mask[block_idx]
+        if allowed and run_start is None:
+            run_start = block_idx
+        elif not allowed and run_start is not None:
+            runs.append((run_start, block_idx))
+            run_start = None
+    if run_start is not None:
+        runs.append((run_start, end_block))
+    return runs
+
+
 class _LazyGroupedBlockHashList(Sequence[BlockHash | str]):
     def __init__(self, block_hashes: Sequence[BlockHash | str], scale_factor: int) -> None:
         self._block_hashes = block_hashes
@@ -1052,6 +1080,11 @@ class ReqMeta:
     load_block_gvas_by_group_np: list[np.ndarray] | None = None
     partial_save_gva_per_group: list[int] = field(default_factory=list)
     partial_load_gva_per_group: list[int] = field(default_factory=list)
+    # Per-group reachable masks for the layerwise transfer, computed once per
+    # scheduler step (None = no filtering, e.g. full-attention groups or when
+    # the coordinator is unavailable).
+    store_masks: tuple[Sequence[bool] | None, ...] | None = None
+    load_masks: tuple[Sequence[bool] | None, ...] | None = None
 
     @staticmethod
     def from_request_tracker(

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/pool_scheduler.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/pool_scheduler.py
@@ -1,5 +1,6 @@
 import importlib
 import math
+from collections.abc import Sequence
 from typing import Any, cast
 
 import vllm.envs as envs
@@ -27,10 +28,7 @@ from vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.backend import (
     backend_map,
     get_layerwise_protocol,
 )
-from vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.coordinator import (
-    AscendStoreCoordinator,
-    ExternalCachedBlockPool,
-)
+from vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.coordinator import AscendStoreCoordinator
 from vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.layerwise_cache_layout import (
     build_layerwise_cache_layout,
     build_layerwise_reuse_layout,
@@ -45,7 +43,6 @@ from vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.metadata import (
     PoolKey,
     ReqMeta,
     RequestTracker,
-    block_hash_to_bytes,
     block_hash_to_str,
     get_block_hashes,
     get_group_block_size,
@@ -386,27 +383,20 @@ class KVPoolScheduler:
     ) -> int:
         """Reachability-aware hit check for hybrid models.
 
-        Mirrors the non-layerwise coordinator lookup: only the blocks the KV
-        cache managers consider reachable (sliding-window / compressor-state
-        tails) are queried for reachability-limited groups — those groups are
-        stored sparsely by the layerwise save path — and the final hit length
-        is derived by find_longest_cache_hit so it matches the store-side
-        reachable mask semantics.
+        Only the blocks the KV cache managers consider reachable (sliding-
+        window / compressor-state tails) are queried for reachability-limited
+        groups — those groups are stored sparsely by the layerwise save path —
+        and the hit length is derived by the coordinator lookup shared with
+        the non-layerwise path, so it matches the store-side mask semantics.
         """
         coordinator = self.cache_coordinator
         assert coordinator is not None
-        aligned_len = (
-            (token_len + coordinator.lcm_block_size - 1) // coordinator.lcm_block_size * coordinator.lcm_block_size
-        )
-        lookup_masks = coordinator.lookup_mask(aligned_len)
-        num_hash_blocks = token_len // self.hash_block_size
-        block_hashes_to_check = request.block_hashes[:num_hash_blocks]
-        exists: set[tuple[int, bytes]] = set()
 
-        for group_id in range(len(self.grouped_block_size)):
-            effective_block_size = get_group_block_size(self.grouped_block_size, group_id)
-            group_block_hashes = get_block_hashes(block_hashes_to_check, effective_block_size, self.hash_block_size)
-            lookup_mask = lookup_masks[group_id] if lookup_masks is not None and group_id < len(lookup_masks) else None
+        def query_group_hits(
+            group_id: int,
+            group_block_hashes: Sequence[BlockHash | str],
+            lookup_mask: Sequence[bool] | None,
+        ) -> list[BlockHash]:
             keys_by_block: list[list[str]] = []
             allowed_hashes: list[BlockHash] = []
             for block_idx, block_hash in enumerate(group_block_hashes):
@@ -416,8 +406,7 @@ class KVPoolScheduler:
                 allowed_hashes.append(block_hash)
             all_keys = [key for block_keys in keys_by_block for key in block_keys]
             if not all_keys:
-                continue
-
+                return []
             key_infos = self.store_scheduler.batch_get_key_info(all_keys)
             if len(key_infos) != len(all_keys):
                 logger.error(
@@ -425,36 +414,23 @@ class KVPoolScheduler:
                     len(all_keys),
                     len(key_infos),
                 )
-                continue
-
+                return []
             # A block is hit only when ALL ranks' keys return valid GVA
+            hits: list[BlockHash] = []
             offset = 0
             for block_hash, block_keys in zip(allowed_hashes, keys_by_block):
                 block_infos = key_infos[offset : offset + len(block_keys)]
                 offset += len(block_keys)
                 if all(ki.size() and ki.size() > 0 for ki in block_infos):
-                    exists.add((group_id, block_hash_to_bytes(block_hash)))
+                    hits.append(block_hash)
+            return hits
 
-        if not exists:
-            logger.debug(
-                "hit_check: req=%s token_len=%d no pooled blocks found",
-                request.request_id,
-                token_len,
-            )
-            return 0
-        _, hit_length = coordinator.find_longest_cache_hit(
+        return coordinator.find_reachable_hit_tokens(
             request.block_hashes,
             token_len,
-            ExternalCachedBlockPool(self.hash_block_size, exists),
-            apply_eagle=False,
+            query_group_hits,
+            log_context=f"hit_check: req={request.request_id}",
         )
-        logger.debug(
-            "hit_check: req=%s token_len=%d reachable_lookup hit_tokens=%d",
-            request.request_id,
-            token_len,
-            hit_length,
-        )
-        return hit_length
 
     def _lookup_layerwise_contiguous(
         self,

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/pool_scheduler.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/pool_scheduler.py
@@ -27,6 +27,10 @@ from vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.backend import (
     backend_map,
     get_layerwise_protocol,
 )
+from vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.coordinator import (
+    AscendStoreCoordinator,
+    ExternalCachedBlockPool,
+)
 from vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.layerwise_cache_layout import (
     build_layerwise_cache_layout,
     build_layerwise_reuse_layout,
@@ -41,6 +45,7 @@ from vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.metadata import (
     PoolKey,
     ReqMeta,
     RequestTracker,
+    block_hash_to_bytes,
     block_hash_to_str,
     get_block_hashes,
     get_group_block_size,
@@ -137,6 +142,7 @@ class KVPoolScheduler:
         self.cache_transfer_granularity = infer_cache_transfer_granularity(
             self.grouped_block_size, self.lcm_block_size, self.kv_cache_group_ids
         )
+        self.cache_coordinator = self._build_cache_coordinator()
         # request_id -> full_token_ids
         self._request_trackers: dict[str, RequestTracker] = {}
         self._preempted_req_ids: set[str] = set()
@@ -331,6 +337,20 @@ class KVPoolScheduler:
         num_hit_blocks = query_start_block + num_queried_hit_blocks
         return num_hit_blocks * self._block_size
 
+    def _build_cache_coordinator(self) -> AscendStoreCoordinator | None:
+        """Build the hybrid cache-hit/mask coordinator (mirrors the worker)."""
+        if self.kv_cache_config is None or not self.use_hybrid:
+            return None
+        return AscendStoreCoordinator(
+            self.kv_cache_config.kv_cache_groups,
+            scheduler_block_size=self.cache_transfer_granularity,
+            hash_block_size=self.hash_block_size,
+            group_block_sizes=self.grouped_block_size,
+            group_cache_families=self.kv_cache_group_families,
+            use_eagle=self.use_eagle,
+            retention_interval=self.retention_interval,
+        )
+
     def _make_layerwise_hit_check_keys(self, group_id: int, block_hash_hex: str) -> list[str]:
         """All-rank keys for scheduler-side hit check, built by the
         backend's protocol module.
@@ -354,12 +374,99 @@ class KVPoolScheduler:
         token_len: int,
         num_computed_tokens: int,
     ) -> int:
+        self._get_or_create_request_tracker(request.request_id)
+        if self.cache_coordinator is not None:
+            return self._lookup_layerwise_with_coordinator(request, token_len)
+        return self._lookup_layerwise_contiguous(request, token_len, num_computed_tokens)
+
+    def _lookup_layerwise_with_coordinator(
+        self,
+        request: "Request",
+        token_len: int,
+    ) -> int:
+        """Reachability-aware hit check for hybrid models.
+
+        Mirrors the non-layerwise coordinator lookup: only the blocks the KV
+        cache managers consider reachable (sliding-window / compressor-state
+        tails) are queried for reachability-limited groups — those groups are
+        stored sparsely by the layerwise save path — and the final hit length
+        is derived by find_longest_cache_hit so it matches the store-side
+        reachable mask semantics.
+        """
+        coordinator = self.cache_coordinator
+        assert coordinator is not None
+        aligned_len = (
+            (token_len + coordinator.lcm_block_size - 1) // coordinator.lcm_block_size * coordinator.lcm_block_size
+        )
+        lookup_masks = coordinator.lookup_mask(aligned_len)
+        num_hash_blocks = token_len // self.hash_block_size
+        block_hashes_to_check = request.block_hashes[:num_hash_blocks]
+        exists: set[tuple[int, bytes]] = set()
+
+        for group_id in range(len(self.grouped_block_size)):
+            effective_block_size = get_group_block_size(self.grouped_block_size, group_id)
+            group_block_hashes = get_block_hashes(block_hashes_to_check, effective_block_size, self.hash_block_size)
+            lookup_mask = lookup_masks[group_id] if lookup_masks is not None and group_id < len(lookup_masks) else None
+            keys_by_block: list[list[str]] = []
+            allowed_hashes: list[BlockHash] = []
+            for block_idx, block_hash in enumerate(group_block_hashes):
+                if lookup_mask is not None and not (block_idx < len(lookup_mask) and lookup_mask[block_idx]):
+                    continue
+                keys_by_block.append(self._make_layerwise_hit_check_keys(group_id, block_hash_to_str(block_hash)))
+                allowed_hashes.append(block_hash)
+            all_keys = [key for block_keys in keys_by_block for key in block_keys]
+            if not all_keys:
+                continue
+
+            key_infos = self.store_scheduler.batch_get_key_info(all_keys)
+            if len(key_infos) != len(all_keys):
+                logger.error(
+                    "KV pool batch_get_key_info returned unexpected number of results: expected=%d, actual=%d",
+                    len(all_keys),
+                    len(key_infos),
+                )
+                continue
+
+            # A block is hit only when ALL ranks' keys return valid GVA
+            offset = 0
+            for block_hash, block_keys in zip(allowed_hashes, keys_by_block):
+                block_infos = key_infos[offset : offset + len(block_keys)]
+                offset += len(block_keys)
+                if all(ki.size() and ki.size() > 0 for ki in block_infos):
+                    exists.add((group_id, block_hash_to_bytes(block_hash)))
+
+        if not exists:
+            logger.debug(
+                "hit_check: req=%s token_len=%d no pooled blocks found",
+                request.request_id,
+                token_len,
+            )
+            return 0
+        _, hit_length = coordinator.find_longest_cache_hit(
+            request.block_hashes,
+            token_len,
+            ExternalCachedBlockPool(self.hash_block_size, exists),
+            apply_eagle=False,
+        )
+        logger.debug(
+            "hit_check: req=%s token_len=%d reachable_lookup hit_tokens=%d",
+            request.request_id,
+            token_len,
+            hit_length,
+        )
+        return hit_length
+
+    def _lookup_layerwise_contiguous(
+        self,
+        request: "Request",
+        token_len: int,
+        num_computed_tokens: int,
+    ) -> int:
         # In layerwise mode, always query from block 0 because the remote
         # pool stores per-layer data that may not match local prefix cache.
         num_hash_blocks = token_len // self.hash_block_size
         block_hashes_to_check = request.block_hashes[:num_hash_blocks]
         hits_per_group: list[int] = []
-        self._get_or_create_request_tracker(request.request_id)
 
         for group_id in range(len(self.grouped_block_size)):
             effective_block_size = get_group_block_size(self.grouped_block_size, group_id)

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/pool_scheduler.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/pool_scheduler.py
@@ -616,7 +616,12 @@ class KVPoolScheduler:
             # rewrite during MTP draft/verify steps. Partial hits that stop on
             # an interior block boundary carry a valid mamba state snapshot
             # at that boundary and can be loaded as-is.
-            hit_reaches_final_block = num_external_hit_tokens > (request.num_tokens - self.lcm_block_size)
+            # The final granularity block starts at the lcm-aligned boundary
+            # containing the last token; num_tokens - lcm_block_size equals
+            # that boundary only for lcm-aligned prompts and over-trims
+            # unaligned prompts whose hit stops exactly on the boundary.
+            final_block_start = (request.num_tokens - 1) // self.lcm_block_size * self.lcm_block_size
+            hit_reaches_final_block = num_external_hit_tokens > final_block_start
             if hit_reaches_final_block:
                 num_external_hit_tokens = max(
                     num_computed_tokens,

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/pool_worker.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/pool_worker.py
@@ -36,10 +36,7 @@ from vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.backend import (
 from vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.backend.base import (
     require_aligned_batch_results,
 )
-from vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.coordinator import (
-    AscendStoreCoordinator,
-    ExternalCachedBlockPool,
-)
+from vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.coordinator import AscendStoreCoordinator
 from vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.kv_transfer import (
     KVCacheStoreKeyLayerRecvingThread,
     KVCacheStoreKeyLayerSendingThread,
@@ -69,7 +66,6 @@ from vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.metadata import (
     LayerMultiBlockReqMeta,
     LayerTransferTask,
     ReqMeta,
-    block_hash_to_bytes,
     block_hash_to_str,
     get_block_hashes,
     get_group_block_size,
@@ -2765,28 +2761,20 @@ class KVPoolWorker:
             return None
         if sorted(kv_cache_group_ids) != list(range(self.num_kv_cache_groups)):
             return None
+        coordinator = self.cache_coordinator
 
-        exists: set[tuple[int, bytes]] = set()
-        aligned_len = (
-            (token_len + self.cache_coordinator.lcm_block_size - 1)
-            // self.cache_coordinator.lcm_block_size
-            * self.cache_coordinator.lcm_block_size
-        )
-        lookup_masks = self.cache_coordinator.lookup_mask(aligned_len)
-
-        for group_id in kv_cache_group_ids:
-            keys: list[str] = []
-            chunk_hashes: list[BlockHash | str] = []
-            variant_counts: list[int] = []
-            group_block_size = self.token_database.get_block_size(group_id)
+        def query_group_hits(
+            group_id: int,
+            group_block_hashes: Sequence[BlockHash | str],
+            lookup_mask: Sequence[bool] | None,
+        ) -> list[BlockHash | str]:
+            group_block_size = coordinator.group_effective_block_sizes[group_id]
+            present: list[BlockHash | str] = []
             if hbm_hit_tokens:
-                grouped_hashes = get_block_hashes(block_hashes, group_block_size, self.token_database.hash_block_size)
-                exists.update(
-                    (group_id, block_hash_to_bytes(chunk_hash))
-                    for chunk_hash in grouped_hashes[: hbm_hit_tokens // group_block_size]
-                )
+                # Blocks already computed locally are present by construction;
+                # the pool only has to confirm the blocks beyond them.
+                present.extend(group_block_hashes[: hbm_hit_tokens // group_block_size])
             lookup_start = hbm_hit_tokens // group_block_size * group_block_size
-            lookup_mask = lookup_masks[group_id] if lookup_masks is not None and group_id < len(lookup_masks) else None
 
             def chunk_filter(
                 start: int,
@@ -2796,6 +2784,9 @@ class KVPoolWorker:
                 chunk_idx = start // group_block_size
                 return lookup_mask is None or (chunk_idx < len(lookup_mask) and lookup_mask[chunk_idx])
 
+            keys: list[str] = []
+            chunk_hashes: list[BlockHash | str] = []
+            variant_counts: list[int] = []
             for _, _, key_string, chunk_hash in self.token_database.process_token_key_strings(
                 token_len,
                 block_hashes,
@@ -2808,39 +2799,31 @@ class KVPoolWorker:
                 chunk_hashes.append(chunk_hash)
                 variant_counts.append(len(variants))
 
-            if not keys:
-                continue
-            res = self.m_store.exists(keys)  # type: ignore[assignment]
-            offset = 0
-            for chunk_hash, count in zip(chunk_hashes, variant_counts, strict=True):
-                values = res[offset : offset + count]  # type: ignore[index]
-                if values and all(value == 1 for value in values):
-                    exists.add((group_id, block_hash_to_bytes(chunk_hash)))
-                offset += count
+            if keys:
+                res = self.m_store.exists(keys)  # type: ignore[assignment]
+                offset = 0
+                for chunk_hash, count in zip(chunk_hashes, variant_counts, strict=True):
+                    values = res[offset : offset + count]  # type: ignore[index]
+                    if values and all(value == 1 for value in values):
+                        present.append(chunk_hash)
+                    offset += count
 
             logger.debug(
-                "KV pool coordinator lookup group=%d token_len=%d keys=%d exists_chunks=%d/%d sample_keys=%s",
+                "KV pool coordinator lookup group=%d token_len=%d keys=%d exists_chunks=%d sample_keys=%s",
                 group_id,
                 token_len,
                 len(keys),
-                sum(1 for group, _ in exists if group == group_id),
-                len(chunk_hashes),
+                len(present),
                 keys[:3],
             )
+            return present
 
-        _, hit_length = self.cache_coordinator.find_longest_cache_hit(
+        return coordinator.find_reachable_hit_tokens(
             block_hashes,
             token_len,
-            ExternalCachedBlockPool(self.hash_block_size, exists),
-            apply_eagle=False,
+            query_group_hits,
+            log_context="KV pool coordinator lookup",
         )
-        logger.debug(
-            "KV pool coordinator lookup final token_len=%d groups=%s hit=%d",
-            token_len,
-            kv_cache_group_ids,
-            hit_length,
-        )
-        return hit_length
 
     def lookup_scheduler(
         self,

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/pool_worker.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/pool_worker.py
@@ -4,7 +4,7 @@ import importlib
 import math
 import threading
 import time
-from collections.abc import Callable, Generator
+from collections.abc import Callable, Generator, Sequence
 from typing import Any
 
 import numpy as np
@@ -82,6 +82,7 @@ from vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.metadata import (
     is_block_key_layerwise,
     is_kv_save_role,
     make_layerwise_block_key,
+    masked_block_runs,
     uses_hybrid_kv_cache,
     validate_mooncake_layerwise_topology,
 )
@@ -1122,16 +1123,35 @@ class KVPoolWorker:
                 save_start_block = max(save_start_block, hit_full_blocks)
             if partial_block_index is None:
                 partial_block_index = request.partial_block_index
-            if save_start_block >= save_end_block and partial_block_index is None:
-                continue
-            request_block_ranges.append(
-                LayerBlockRange(
-                    request=request,
-                    start_block=save_start_block,
-                    end_block=save_end_block,
-                    partial_block_index=partial_block_index,
-                )
+            group_store_mask = (
+                request.store_masks[group_id]
+                if request.store_masks is not None and group_id < len(request.store_masks)
+                else None
             )
+            block_runs = masked_block_runs(group_store_mask, save_start_block, save_end_block)
+            if not block_runs and partial_block_index is None:
+                continue
+            for run_idx, (run_start_block, run_end_block) in enumerate(block_runs):
+                # The trailing partial block rides on the last run (or on its
+                # own zero-length range) so it is transferred exactly once.
+                is_last_run = run_idx == len(block_runs) - 1
+                request_block_ranges.append(
+                    LayerBlockRange(
+                        request=request,
+                        start_block=run_start_block,
+                        end_block=run_end_block,
+                        partial_block_index=partial_block_index if is_last_run else None,
+                    )
+                )
+            if not block_runs and partial_block_index is not None:
+                request_block_ranges.append(
+                    LayerBlockRange(
+                        request=request,
+                        start_block=partial_block_index,
+                        end_block=partial_block_index,
+                        partial_block_index=partial_block_index,
+                    )
+                )
         if request_block_ranges:
             self.layer_save_tasks[layer_id].append(
                 LayerTransferTask(
@@ -1213,16 +1233,35 @@ class KVPoolWorker:
                 partial_block_index = None
             if partial_block_index is not None and partial_block_index < load_start_block:
                 partial_block_index = None
-            if load_start_block >= full_blocks and partial_block_index is None:
-                continue
-            request_block_ranges.append(
-                LayerBlockRange(
-                    request=request,
-                    start_block=load_start_block,
-                    end_block=full_blocks,
-                    partial_block_index=partial_block_index,
-                )
+            group_load_mask = (
+                request.load_masks[group_id]
+                if request.load_masks is not None and group_id < len(request.load_masks)
+                else None
             )
+            block_runs = masked_block_runs(group_load_mask, load_start_block, full_blocks)
+            if not block_runs and partial_block_index is None:
+                continue
+            for run_idx, (run_start_block, run_end_block) in enumerate(block_runs):
+                # The trailing partial block rides on the last run (or on its
+                # own zero-length range) so it is transferred exactly once.
+                is_last_run = run_idx == len(block_runs) - 1
+                request_block_ranges.append(
+                    LayerBlockRange(
+                        request=request,
+                        start_block=run_start_block,
+                        end_block=run_end_block,
+                        partial_block_index=partial_block_index if is_last_run else None,
+                    )
+                )
+            if not block_runs and partial_block_index is not None:
+                request_block_ranges.append(
+                    LayerBlockRange(
+                        request=request,
+                        start_block=partial_block_index,
+                        end_block=partial_block_index,
+                        partial_block_index=partial_block_index,
+                    )
+                )
         if request_block_ranges:
             self.layer_load_tasks[layer_id].append(
                 LayerTransferTask(
@@ -1331,31 +1370,41 @@ class KVPoolWorker:
                     )
                     hit_full_blocks = pool_hit_tokens // effective_block_size
                     save_start_block = max(save_start_block, hit_full_blocks)
+                group_store_mask = (
+                    request.store_masks[group_id]
+                    if request.store_masks is not None and group_id < len(request.store_masks)
+                    else None
+                )
+                end_limit = min(save_end_block, len(group_block_hashes))
+                candidate_blocks = [
+                    block_idx
+                    for block_idx in range(save_start_block, end_limit)
+                    if group_store_mask is None or block_idx >= len(group_store_mask) or group_store_mask[block_idx]
+                ]
                 candidate_keys = [
                     self._make_layerwise_full_key(
                         group_id,
                         block_hash_to_str(group_block_hashes[block_idx]),
                     )
-                    for block_idx in range(
-                        save_start_block,
-                        min(save_end_block, len(group_block_hashes)),
-                    )
+                    for block_idx in candidate_blocks
                 ]
                 self._refresh_allocated_gvas(candidate_keys)
                 # Skip blocks that are still present and readable in MemCache.
-                while save_start_block < save_end_block and save_start_block < len(group_block_hashes):
-                    key = self._make_layerwise_full_key(
-                        group_id, block_hash_to_str(group_block_hashes[save_start_block])
-                    )
+                # Only a leading run of already-allocated blocks is skipped so
+                # the readable-blob write failure semantics stay unchanged.
+                allocated_prefix = 0
+                for block_idx in candidate_blocks:
+                    key = self._make_layerwise_full_key(group_id, block_hash_to_str(group_block_hashes[block_idx]))
                     if key in self._allocated_gvas:
-                        save_start_block += 1
+                        allocated_prefix += 1
                     else:
                         break
+                transfer_blocks = candidate_blocks[allocated_prefix:]
 
                 block_gvas: list[int] = []
                 new_keys: list[str] = []
                 new_positions: list[int] = []
-                for blk_idx in range(save_start_block, min(save_end_block, len(group_block_hashes))):
+                for blk_idx in transfer_blocks:
                     key = self._make_layerwise_full_key(group_id, block_hash_to_str(group_block_hashes[blk_idx]))
                     cached = self._allocated_gvas.get(key)
                     if cached is not None:
@@ -1423,7 +1472,7 @@ class KVPoolWorker:
 
                 logger.debug(
                     "alloc_gvas: req=%s group=%d eff_bs=%d save_blocks=[%d,%d) "
-                    "new_keys=%d cached_keys=%d alloc_size=%d",
+                    "new_keys=%d cached_keys=%d masked=%s alloc_size=%d",
                     request.req_id,
                     group_id,
                     effective_block_size,
@@ -1431,14 +1480,15 @@ class KVPoolWorker:
                     save_end_block,
                     len(new_keys),
                     len(block_gvas) - len(new_keys),
+                    group_store_mask is not None,
                     alloc_size,
                 )
 
-                # Pad block_gvas to match block_ids length (fill 0 for blocks before save_start)
+                # Pad block_gvas to match block_ids length (fill 0 for non-transferred blocks)
                 full_gvas = [0] * len(block_ids_by_group)
-                for i, gva in enumerate(block_gvas):
-                    if save_start_block + i < len(full_gvas):
-                        full_gvas[save_start_block + i] = gva
+                for blk_idx, gva in zip(transfer_blocks, block_gvas):
+                    if blk_idx < len(full_gvas):
+                        full_gvas[blk_idx] = gva
 
                 all_group_gvas.append(np.asarray(full_gvas, dtype=np.int64))
                 all_group_block_ids.append(np.asarray(block_ids_by_group, dtype=np.int64))
@@ -1479,6 +1529,7 @@ class KVPoolWorker:
                     request.req_id,
                 )
             block_hashes = request.block_hashes
+            request.load_masks = self._compute_reachable_load_masks(request, cached_tokens)
 
             all_group_load_gvas: list[np.ndarray] = []
             all_group_load_keys: list[str] = []
@@ -1519,11 +1570,21 @@ class KVPoolWorker:
                     all_group_load_gvas.append(np.zeros(full_len, dtype=np.int64))
                     continue
 
-                keys = [
-                    self._make_layerwise_full_key(group_id, block_hash_to_str(group_block_hashes[i]))
-                    for i in range(load_start_block, full_blocks)
+                group_load_mask = (
+                    request.load_masks[group_id]
+                    if request.load_masks is not None and group_id < len(request.load_masks)
+                    else None
+                )
+                block_indices = [
+                    block_idx
+                    for block_idx in range(load_start_block, full_blocks)
+                    if group_load_mask is None or block_idx >= len(group_load_mask) or group_load_mask[block_idx]
                 ]
-                block_indices = list(range(load_start_block, full_blocks))
+                keys = [
+                    self._make_layerwise_full_key(group_id, block_hash_to_str(group_block_hashes[block_idx]))
+                    for block_idx in block_indices
+                ]
+                has_partial_key = False
                 if partial_block_index is not None:
                     keys.append(
                         self._make_layerwise_partial_key(
@@ -1534,6 +1595,7 @@ class KVPoolWorker:
                         )
                     )
                     block_indices.append(partial_block_index)
+                    has_partial_key = True
                 if not keys:
                     all_group_load_gvas.append(np.zeros(full_len, dtype=np.int64))
                     continue
@@ -1646,15 +1708,18 @@ class KVPoolWorker:
                     sum(1 for r in lease_results if r != 0),
                 )
 
-                # Pad to match block_ids_by_group length, with 0s before load_start_block
+                # Pad to match block_ids_by_group length, filling only the
+                # positions whose keys were actually queried (the trailing
+                # partial key is excluded from the per-position fill).
                 full_gvas = [0] * full_len
-                normal_gva_count = full_blocks - load_start_block
-                for i, gva in enumerate(gvas[:normal_gva_count]):
-                    if load_start_block + i < len(full_gvas):
-                        full_gvas[load_start_block + i] = gva
+                full_key_count = len(block_indices) - (1 if has_partial_key else 0)
+                for gva_index in range(full_key_count):
+                    block_idx = block_indices[gva_index]
+                    if block_idx < len(full_gvas):
+                        full_gvas[block_idx] = gvas[gva_index]
                 all_group_load_gvas.append(np.asarray(full_gvas, dtype=np.int64))
-                if partial_block_index is not None and len(gvas) > normal_gva_count:
-                    request.partial_load_gva_per_group[group_id] = gvas[normal_gva_count]
+                if has_partial_key and gvas:
+                    request.partial_load_gva_per_group[group_id] = gvas[-1]
 
             if all_group_load_gvas:
                 request.load_keys = all_group_load_keys
@@ -2014,6 +2079,48 @@ class KVPoolWorker:
                         if task.group_id == group_id:
                             task.shared_block_data = shared
 
+    def _compute_reachable_store_masks(
+        self,
+        request: ReqMeta,
+    ) -> tuple[Sequence[bool] | None, ...] | None:
+        """Per-group reachable-store masks for the layerwise save path.
+
+        Mirrors the non-layerwise store path (KVCacheStoreSendingThread):
+        for reachability-limited groups (sliding window / compressor state)
+        only the blocks the KV cache managers consider reachable are
+        persisted, instead of the full sequence. Falls back to None (store
+        everything) when the coordinator is unavailable or the save extent
+        is not aligned.
+        """
+        if self.cache_coordinator is None:
+            return None
+        if request.save_end_token <= 0:
+            return None
+        if request.save_end_token % self.cache_transfer_granularity != 0:
+            return None
+        try:
+            return self.token_database.store_mask(request.save_end_token, request.num_prompt_tokens)
+        except AssertionError:
+            return None
+
+    def _compute_reachable_load_masks(
+        self,
+        request: ReqMeta,
+        cached_tokens: int,
+    ) -> tuple[Sequence[bool] | None, ...] | None:
+        """Per-group load masks for the layerwise load path.
+
+        Mirrors the non-layerwise load path: only the blocks the KV cache
+        managers need for a hit of ``cached_tokens`` are fetched, which is a
+        subset of the blocks persisted by the reachable store masks.
+        """
+        if self.cache_coordinator is None or cached_tokens <= 0:
+            return None
+        try:
+            return self.token_database.load_mask(request.block_hashes, cached_tokens)
+        except AssertionError:
+            return None
+
     def process_layer_data(self, requests: list[ReqMeta]) -> None:
         if not requests:
             return
@@ -2023,6 +2130,8 @@ class KVPoolWorker:
         self.layer_load_tasks = [[] for _ in range(self.num_layers)]
         if self.backend_name == "mooncake" and self.use_block_key_layerwise:
             self._prepare_mooncake_layerwise_sessions(requests)
+        for request in requests:
+            request.store_masks = self._compute_reachable_store_masks(request)
         for physical_layer in range(self.num_layers):
             group_layers = self.physical_layer_to_group_layers.get(physical_layer, [(0, physical_layer)])
             for group_id, layer_idx_in_group in group_layers:

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/pool_worker.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/pool_worker.py
@@ -1366,7 +1366,9 @@ class KVPoolWorker:
                         block_gvas.append(0)
 
                 if new_keys:
-                    new_gvas = self.m_store.batch_alloc(new_keys, [alloc_size] * len(new_keys))
+                    new_gvas = self.m_store.batch_alloc(
+                        new_keys, [alloc_size] * len(new_keys), LAYERWISE_READ_LEASE_TTL_MS
+                    )
                     if any(gva <= 0 for gva in new_gvas):
                         logger.error(
                             "alloc_gvas FAIL: req=%s group=%d alloc_size=%d new_keys=%d gvas_sample=%s zero_count=%d",
@@ -1401,6 +1403,7 @@ class KVPoolWorker:
                         allocated = self.m_store.batch_alloc(
                             [partial_key],
                             [alloc_size],
+                            LAYERWISE_READ_LEASE_TTL_MS,
                         )
                         partial_gva = allocated[0] if allocated else 0
                         if partial_gva > 0:


### PR DESCRIPTION
## What this PR does / why we need it?

The layerwise KV pool transfer path stores **every** KV block of reachability-limited groups (sliding-window raw KV and compressor-state caches) to the external pool, while the non-layerwise path only stores blocks the KV cache managers consider reachable (segment-tail windows). For DeepSeek-V4-Flash (block_size=32, 43+1 layers, 6 KV cache groups) on 910C, a single 131072-token request allocates **91,168 pool keys (~45.6 GB DRAM)**, 98% of which sits in state/SWA groups whose reachable subset is only ~1.4 GB — a ~32x redundancy that floods the pool and the interconnect (~1.8 GB/s of writes during prefill).

This PR aligns the layerwise path with the non-layerwise reachable-store semantics on all three sides, reusing the existing `AscendStoreCoordinator` masks:

- **Save** (`_alloc_gvas_for_save` / `_process_save_for_layer_batch`): per-group store masks are computed once per scheduler step; keys are allocated and transfer ranges generated only for reachable blocks (the trailing partial block rides the last mask-allowed run).
- **Hit check** (`_get_layerwise_hit_tokens`): only reachable blocks are queried per group, and the hit length is derived via `coordinator.find_longest_cache_hit`, so sparse storage still yields correct prefix hits (a contiguous walk would report 0 hits).
- **Load** (`_prepare_load_gvas` / `_process_load_for_layer_batch`): key info is fetched only for the load-mask subset, so blocks that are deliberately not pooled no longer trigger the multi-group load failure path; GVA positions are filled per queried block index.

Full-attention groups (mask=None), the trailing partial block, and the non-hybrid / single-group fallbacks keep their previous behavior. Measured effect: a 131072-token request drops from ~45.6 GB to ~1.4 GB of pool DRAM with identical hit semantics.

**Note**: this PR also includes the two commits from #15830 (`feat(kv_pool): pass lease TTL to memcache batch_alloc` and `fix(kv_pool): align MTP final-block trim to lcm block boundary`); it supersedes both #15830 and the closed #15672, so a single review covers all three changes.

## Does this PR introduce _any_ user-facing change?

Yes: layerwise mode with a hybrid KV cache layout (e.g. DSV4 compressed + SWA groups) now persists only reachable blocks to the external KV pool, drastically reducing pool memory usage and write bandwidth. Cache-hit behavior is unchanged.

## How was this patch tested?

- Unit tests added/updated (all pass; 3 pre-existing environment failures on a no-vllm/no-npu Windows box are unrelated — verified failing on a pristine tree):
  - `tests/ut/distributed/ascend_store/test_metadata.py`: `masked_block_runs` helper (sparse/None/empty/out-of-range masks)
  - `tests/ut/distributed/ascend_store/test_pool_worker.py`: mask-driven key allocation, multi-run transfer ranges, partial-block riding the last run, load-mask key queries, load range splitting
  - `tests/ut/distributed/ascend_store/test_pool_scheduler.py`: reachability-aware hit check (sparse SWA storage still yields full hits, hit stops where a stored tail is missing, no-pool → 0, non-hybrid fallback unchanged)
- Command: `python -m pytest -sv tests/ut/distributed/ascend_store/`
- NPU e2e validation is in progress on an Ascend cluster (draft until verified): plan is to re-run the DSV4-Flash layerwise deployment and compare the `alloc_gvas` key counts per group against the reachable subset (expected drop: group-4 state cache 65536 → ~128 keys per 131072-token request), plus long-context hit-rate and accuracy checks.

- vLLM main: https://github.com/vllm-project/vllm/commit/b2f685834a6456197e7033966fdef52a23f1abcd
