### PR TITLE
[Misc] Remove olora tensor parallel size from finegrained_tp_config

### DIFF
--- a/tests/ut/attention/test_dsa_v1.py
+++ b/tests/ut/attention/test_dsa_v1.py
@@ -1608,7 +1608,6 @@ def test_a5_bf16_o_proj_uses_transpose_batchmatmul():
 
     with (
         patch("vllm_ascend.attention.dsa_v1.oproj_tp_enable", return_value=False),
-        patch("vllm_ascend.attention.dsa_v1.olora_tp_enable", return_value=False),
         patch("vllm_ascend.attention.dsa_v1.torch_npu.npu_transpose_batchmatmul", return_value=projected) as batched,
         patch("vllm_ascend.attention.dsa_v1.torch_npu.npu_dynamic_mx_quant") as quant,
     ):

--- a/tests/ut/spec_decode/test_speculators_vwn_eagle3.py
+++ b/tests/ut/spec_decode/test_speculators_vwn_eagle3.py
@@ -135,7 +135,6 @@ def _mock_npu_env():
         lmhead_tensor_parallel_size=0,
         embedding_tensor_parallel_size=0,
         oproj_tensor_parallel_size=0,
-        olora_tensor_parallel_size=0,
         mlp_tensor_parallel_size=0,
     )
     with (

--- a/vllm_ascend/ascend_config.py
+++ b/vllm_ascend/ascend_config.py
@@ -314,8 +314,7 @@ class AscendConfig:
                 "oproj_tensor_parallel_size": 0,
                 "lmhead_tensor_parallel_size": 0,
                 "embedding_tensor_parallel_size": 0,
-                "mlp_tensor_parallel_size": 0,
-                "olora_tensor_parallel_size": 0
+                "mlp_tensor_parallel_size": 0
             },
             "scheduler_config": {
                 "enable_balance_scheduling": false,
@@ -942,7 +941,7 @@ class DynamicSpecConfig:
 class FinegrainedTPConfig:
     """Configuration Object for ``additional_config["finegrained_tp_config"]``.
 
-    Migrated to ``@config`` (pydantic dataclass). 5 int fields get lax coercion
+    Migrated to ``@config`` (pydantic dataclass). 4 int fields get lax coercion
     ('2'→2). vllm_config-dependent preconditions (TP/eager/kv_consumer/is_moe/
     data_parallel divisibility) are validated in ``_validate_preconditions()``,
     a plain method invoked explicitly by ``init_ascend_config`` (Plan B:
@@ -954,7 +953,6 @@ class FinegrainedTPConfig:
     lmhead_tensor_parallel_size: int = 0
     embedding_tensor_parallel_size: int = 0
     mlp_tensor_parallel_size: int = 0
-    olora_tensor_parallel_size: int = 0
 
     @model_validator(mode="after")
     def _validate_sizes(self):
@@ -963,7 +961,6 @@ class FinegrainedTPConfig:
             "lmhead_tensor_parallel_size",
             "embedding_tensor_parallel_size",
             "mlp_tensor_parallel_size",
-            "olora_tensor_parallel_size",
         )
         self.max_finegrained_tp_size = 1
         for field_name in size_fields:
@@ -1001,16 +998,6 @@ class FinegrainedTPConfig:
                 raise AssertionError(
                     "oproj_tensor_parallel_size is only supported in pd scenario and can only be used in D node."
                 )
-        if self.olora_tensor_parallel_size > 0:
-            enabled_configs.append(f"olora_tensor_parallel_size={self.olora_tensor_parallel_size}")
-            # dummy_run does not run the entire attention module in eager mode,
-            # so the o_lora tp split can only be used in graph mode.
-            if vc.model_config and vc.model_config.enforce_eager:
-                raise AssertionError("olora_tensor_parallel_size is only supported in graph mode")
-            if vc.kv_transfer_config is None or not vc.kv_transfer_config.is_kv_consumer:
-                raise AssertionError(
-                    "olora_tensor_parallel_size is only supported in pd scenario and can only be used in D node."
-                )
         if self.lmhead_tensor_parallel_size > 0:
             enabled_configs.append(f"lmhead_tensor_parallel_size={self.lmhead_tensor_parallel_size}")
         if self.embedding_tensor_parallel_size > 0:
@@ -1022,7 +1009,6 @@ class FinegrainedTPConfig:
             self.lmhead_tensor_parallel_size,
             self.embedding_tensor_parallel_size,
             self.mlp_tensor_parallel_size,
-            self.olora_tensor_parallel_size,
         ]
         for module_tp_size in module_tp_sizes:
             # If it is a dense model, then expert parallel is not needed,

--- a/vllm_ascend/attention/context_parallel/dsa_cp.py
+++ b/vllm_ascend/attention/context_parallel/dsa_cp.py
@@ -44,10 +44,7 @@ from vllm_ascend.ops.linear import AscendUnquantizedLinearMethod
 from vllm_ascend.ops.rope_dsv4 import RopeDataProxy, get_cos_and_sin_dsa, get_full_cos_and_sin_dsa
 from vllm_ascend.ops.triton.dsa_cp import build_local_metadata_triton
 from vllm_ascend.quantization.methods import AscendW8A8DynamicLinearMethod
-from vllm_ascend.utils import (
-    enable_dsa_cp_full_o_proj,
-    olora_tp_enable,
-)
+from vllm_ascend.utils import enable_dsa_cp_full_o_proj
 from vllm_ascend.weight_switch import WeightSwitchConfig, WeightSwitchMixin, WeightSwitchState
 from vllm_ascend.worker.device_metadata import (
     DeviceMetadataStage,
@@ -1766,22 +1763,19 @@ class AscendDSACPImpl(AttentionImplBase[Any]):
                 local_output = self._apply_wo_b(o, full_gather_wo_a_enabled)
             else:
                 o_proj_input = o_proj_input.view(num_tokens, o_proj_groups, -1)
-                if olora_tp_enable():
-                    o_proj_input = self.wo_a(o_proj_input)
-                else:
-                    # wo_a = self.wo_a.weight.view(o_proj_groups, self.o_lora_rank, -1)
-                    # o = torch.einsum("tgd,grd->tgr", o, wo_a)
-                    # A5 BF16 uses the same 3D [groups, hidden, rank] layout.
-                    o_proj_input = torch_npu.npu_transpose_batchmatmul(
-                        o_proj_input,
-                        self._get_batched_wo_a_weight(o_proj_groups),
-                        bias=None,
-                        scale=None,
-                        perm_x1=(1, 0, 2),
-                        perm_x2=(0, 1, 2),
-                        perm_y=(1, 0, 2),
-                        batch_split_factor=1,
-                    )
+                # wo_a = self.wo_a.weight.view(o_proj_groups, self.o_lora_rank, -1)
+                # o = torch.einsum("tgd,grd->tgr", o, wo_a)
+                # A5 BF16 uses the same 3D [groups, hidden, rank] layout.
+                o_proj_input = torch_npu.npu_transpose_batchmatmul(
+                    o_proj_input,
+                    self._get_batched_wo_a_weight(o_proj_groups),
+                    bias=None,
+                    scale=None,
+                    perm_x1=(1, 0, 2),
+                    perm_x2=(0, 1, 2),
+                    perm_y=(1, 0, 2),
+                    batch_split_factor=1,
+                )
                 o_proj_input = o_proj_input.reshape(num_tokens, -1)
                 local_output = self._apply_wo_b(o_proj_input, full_gather_wo_a_enabled)
 

--- a/vllm_ascend/attention/dsa_v1.py
+++ b/vllm_ascend/attention/dsa_v1.py
@@ -48,7 +48,6 @@ from vllm_ascend.quantization.methods import AscendW8A8DynamicLinearMethod
 from vllm_ascend.utils import (
     get_potential_max_tokens,
     npu_stream_switch,
-    olora_tp_enable,
     oproj_tp_enable,
 )
 from vllm_ascend.worker.device_metadata import (
@@ -1590,7 +1589,7 @@ class AscendDSAImpl(AttentionImplBase[Any]):
         o_proj_input = o_proj_input.view(num_tokens, self.n_local_groups, group_hidden_dim)
         # A5 (Ascend950) uses an FP8-quantized o_proj path (dynamic MX quant
         # + quantized batch matmul). Preserve it as-is: it predates and is
-        # orthogonal to the OTP / olora_tp paths below, so it must win first.
+        # orthogonal to the OTP path below, so it must win first.
         use_a5_quant_o_proj = self.support_fp8_attention and _has_weight_scale(self.wo_a)
         if use_a5_quant_o_proj:
             o = o_proj_input
@@ -1676,9 +1675,6 @@ class AscendDSAImpl(AttentionImplBase[Any]):
                 )
             dist.reduce_scatter_tensor(self._oproj_rs_out_buf, o_proj_output, group=oproj_group.device_group)
             output[...] = self._oproj_rs_out_buf[:num_tokens]
-        elif olora_tp_enable():
-            o_proj_input = self.wo_a(o_proj_input)
-            output[...] = self.wo_b(o_proj_input)
         else:
             # A5 BF16 wo_a is reshaped to [groups, hidden, rank] at load time,
             # matching the A3 layout expected by npu_transpose_batchmatmul.

--- a/vllm_ascend/models/deepseek_v4/model.py
+++ b/vllm_ascend/models/deepseek_v4/model.py
@@ -88,8 +88,6 @@ from vllm_ascend.utils import (
     enable_dsa_cp,
     extract_dsv4_layer_index,
     get_dsv4_compress_ratio,
-    olora_tp_enable,
-    oproj_tp_enable,
 )
 from vllm_ascend.worker.v2.pp_utils import (
     PPTransportDataType,
@@ -536,9 +534,10 @@ class DeepseekV4Attention(nn.Module):
             prefix=f"{prefix}.wo_a",
             return_bias=False,
         )
-        # DSA paths that bypass the Linear method use
-        # npu_transpose_batchmatmul, whose weight must remain ND.
-        self.wo_a.skip_weight_nz_conversion = oproj_tp_enable() or not olora_tp_enable()
+        # Every DSA o_proj path consumes wo_a.weight directly via
+        # npu_transpose_batchmatmul / npu_transpose_quant_batchmatmul,
+        # so the weight must remain ND.
+        self.wo_a.skip_weight_nz_conversion = True
         self.wo_b = RowParallelLinear(
             self.n_groups * config.o_lora_rank,
             self.dim,

--- a/vllm_ascend/utils.py
+++ b/vllm_ascend/utils.py
@@ -829,10 +829,6 @@ def oproj_tp_enable() -> bool:
     return get_ascend_config().finegrained_tp_config.oproj_tensor_parallel_size > 0
 
 
-def olora_tp_enable() -> bool:
-    return get_ascend_config().finegrained_tp_config.olora_tensor_parallel_size > 1
-
-
 def mlp_tp_enable() -> bool:
     return get_ascend_config().finegrained_tp_config.mlp_tensor_parallel_size > 0
 


### PR DESCRIPTION
### What this PR does / why we need it?

**TL;DR**: removes `olora_tensor_parallel_size` (oLoRA TP) from `finegrained_tp_config` — an unused knob with zero in-repo consumers. `mlp_tensor_parallel_size` and every other component are untouched. Verified by symbol census (all 20 base references removed, zero remaining), behavior-equivalence analysis for the #15834 consumer, and UT on a matching-vllm A3 container identical to the pristine base. The 0.27.x release line is already cut and keeps the key; main is the 0.28.x line.

This PR removes the oLoRA TP sub-feature as part of the config cleanup plan tracked in #5304. The knob has no in-tree consumer — no e2e config, CI workflow, doc example or test enables it — and it never had its own process group (it is only a boolean gate over the `wo_a`/`wo_b` forward). The default `npu_transpose_batchmatmul` path is kept and dedented, so nothing else changes at runtime.

**Removed**
- `FinegrainedTPConfig.olora_tensor_parallel_size` field, validation block, `_validate_sizes` / `module_tp_sizes` entries and docstring example (5 → 4 int fields)
- `olora_tp_enable()` in `utils.py`
- The olora branches in `AscendDSAImpl._forward_o_proj` and `AscendDSACPImpl.forward` (default path kept and dedented)
- The consumer #15834 added to `DeepseekV4Attention`: `wo_a.skip_weight_nz_conversion` becomes unconditionally `True`. Equivalence: the old expression is False only when olora TP is enabled with oproj disabled — a configuration this PR makes unconstructible — and every remaining `wo_a` path feeds the raw weight to `npu_transpose_*_batchmatmul`, which requires ND (same pattern as `compressor.py`)

**Kept unchanged**
- `mlp_tensor_parallel_size` with its full MLP TP machinery (`_MLP_TP` group, `MLPColumnParallelOp` / `MLPRowParallelOp`, dispatch branches, `is_moe_layer()`)
- `oproj` / `lmhead` / `embedding` TP with their groups, helpers and the shared `_create_or_get_group` cache
- The model-arch parameter `o_lora_rank` (unrelated, despite the name)
- All other `wo_a`/`wo_b` consumers (A5 quantized path, oproj TP incl. the #14814 weight-switch machinery)

oLoRA TP was never documented, so no doc changes are needed; the olora mock/patch lines are dropped from the two touched test files (they would AttributeError otherwise).

**Completeness**: every reference to the removed feature at the base commit (`git grep` census, 20 occurrences / 19 lines) is deleted by this diff — including the "o_lora tp split" spelling variant used in a comment inside the removed validation block. Post-change, a repo-wide case-insensitive sweep (code / docs / `.po` / e2e / CI) finds zero references under any spelling (`olora`, `oloratp`, …); every near-name survivor belongs to unrelated families: `o_lora_rank` — the DeepSeek-V4 architecture parameter from the HF config that shapes `wo_a`/`wo_b`, kept like `q_lora_rank` — and the standard LoRA adapter feature (`no_lora`, `lora_id_to_lora_request`, "no-LoRA" comments, `*_lora_tp*` e2e filenames). Reproduce: `git grep -i -E 'olora|o.lora' <head>` and classify the hits.

**Rollout / timing**: the 0.27.x line is already cut (`releases/v0.27.1rc`) and keeps the key for its users; main is the 0.28.x line, so merging now lands the removal in 0.28.x as intended.

### Does this PR introduce _any_ user-facing change?

Yes — removal of one configuration key. `FinegrainedTPConfig` is a pydantic `@config` class with `extra="forbid"`, so a deployment still passing `"olora_tensor_parallel_size"` (even set to `0`) fails fast at startup with a `ValidationError` naming the unknown key. Migration: drop the key from `finegrained_tp_config`; all other keys — including `mlp_tensor_parallel_size` — are unaffected.

### How was this patch tested?

On an Atlas 800I A3 container with the matching vllm (0.28.1rc1.dev42), in the UT-designed CPU-mocked harness (`tests/ut/conftest.py`): all directly-touched UT files pass **156/156**, incl. `tests/ut/model_executor/test_deepseek_v4.py` which covers the `DeepseekV4Attention` change; regression over `tests/ut/{ops,quantization,distributed}` gives **1063 passed / 15 skipped / 11 failed**, with the 11 failures byte-identical to the pristine base re-run in the same container (the known `test_fused_moe.py` breakage on current main, #15499) — i.e. zero regression. The same change was verified with identical results at the original branch point (146/146 direct). `ruff check` / `ruff format --check` / `py_compile` green on all changed files.

- vLLM main: https://github.com/vllm-project/vllm/commit/ba07e4a48fc951300d97eb506217dd530583dea3
