### PR TITLE
[BugFix][Attention] Fix DSA-CP with sequence-parallel FP8

### DIFF
--- a/tests/ut/attention/test_sfa_o_proj_weight_switch.py
+++ b/tests/ut/attention/test_sfa_o_proj_weight_switch.py
@@ -55,6 +55,7 @@ class TestAscendSFAOProjWeightSwitch(TestBase):
             self.weight = torch.nn.Parameter(torch.randn(4, 3), requires_grad=False)
             self.weight_scale = torch.nn.Parameter(torch.randn(2, 3), requires_grad=False)
             self.quant_method = linear_method
+            self.reduce_results = True
 
     def setUp(self):
         AscendSFADSACPImpl.o_proj_full_pools.clear()
@@ -109,7 +110,10 @@ class TestAscendSFAOProjWeightSwitch(TestBase):
         impl.enable_dsa_cp_full_o_proj = True
         gathered_output = torch.cat((torch.ones(2, 3), torch.full((2, 3), 2.0)))
         tp_group = SimpleNamespace(all_gather=MagicMock(return_value=gathered_output))
-        with patch("vllm_ascend.attention.context_parallel.sfa_cp.get_tp_group", return_value=tp_group):
+        with patch(
+            "vllm_ascend.attention.context_parallel.sfa_cp.get_tp_group",
+            return_value=tp_group,
+        ):
             output = impl._finalize_o_proj(
                 attn_output=torch.randn(2, 8),
                 output=torch.empty(3, 3),
@@ -120,6 +124,28 @@ class TestAscendSFAOProjWeightSwitch(TestBase):
         self.assertEqual(impl.o_proj.weight_scale.data_ptr(), original_scale_ptr)
         tp_group.all_gather.assert_called_once()
         self.assertTrue(torch.equal(output, gathered_output[:3]))
+
+    def test_o_proj_full_weight_stages_local_result_for_upstream_sp(self):
+        impl = self._make_impl()
+        impl._enable_o_proj_full_weight_switch()
+        impl.enable_dsa_cp_full_o_proj = True
+        impl.o_proj.reduce_results = False
+        local_output = torch.tensor([[3.0, 4.0, 5.0], [6.0, 7.0, 8.0]])
+        impl._apply_o_proj_full_weight = MagicMock(return_value=local_output)
+        tp_group = SimpleNamespace(rank_in_group=1, all_gather=MagicMock())
+
+        with patch("vllm_ascend.attention.context_parallel.sfa_cp.get_tp_group", return_value=tp_group):
+            output = impl._finalize_o_proj(
+                attn_output=torch.randn(2, 8),
+                output=torch.full((3, 3), -1.0),
+                gather_full_o_proj=True,
+            )
+
+        tp_group.all_gather.assert_not_called()
+        torch.testing.assert_close(
+            output,
+            torch.tensor([[0.0, 0.0, 0.0], [0.0, 0.0, 0.0], [3.0, 4.0, 5.0]]),
+        )
 
     def test_prepare_native_hidden_states_slices_replicated_token_state(self):
         impl = self._make_impl()

--- a/tests/ut/quantization/methods/test_fp8_block.py
+++ b/tests/ut/quantization/methods/test_fp8_block.py
@@ -16,6 +16,7 @@
 #
 
 import unittest
+from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 import torch
@@ -27,6 +28,11 @@ from vllm_ascend.quantization.methods.w8a8.fp8_block import (
     AscendFp8BlockFusedMoEMethod,
     AscendFp8BlockLinearMethod,
     resolve_block_scales,
+)
+from vllm_ascend.weight_switch import (
+    WeightSwitchConfig,
+    WeightSwitchGatherSpec,
+    WeightSwitchRepeatSpec,
 )
 
 MODULE = "vllm_ascend.quantization.methods.w8a8.fp8_block"
@@ -105,11 +111,64 @@ class TestAscendFp8BlockLinearMethod(TestBase):
             scheme = AscendFp8BlockLinearMethod(block_size)
         return scheme
 
+    @staticmethod
+    def _get_weight_switch_specs(scheme, input_sharded):
+        layer = SimpleNamespace(
+            input_size=2,
+            input_size_per_partition=1 if input_sharded else 2,
+            output_size=2,
+            output_size_per_partition=2 if input_sharded else 1,
+        )
+        config = WeightSwitchConfig(group=object(), world_size=2, rank=0)
+        gather_specs, repeat_specs, _ = scheme._get_weight_switch_specs(layer, config)
+        return gather_specs, repeat_specs
+
     def test_get_weight_is_fp8(self):
         scheme = self.build_scheme()
         weight = scheme.get_weight(512, 256, torch.bfloat16)["weight"]
         self.assertEqual(weight.shape, (256, 512))
         self.assertEqual(weight.dtype, torch.float8_e4m3fn)
+
+    def test_weight_switch_specs_follow_mxfp8_execution_method(self):
+        scheme = self.build_scheme(is_950=True, block_size=(4, 32))
+        input_gather = (WeightSwitchGatherSpec("input_weight"),)
+        output_gather = (WeightSwitchGatherSpec("output_weight", gather_dim=1),)
+        input_repeat = (WeightSwitchRepeatSpec("input_scale"),)
+        output_repeat = (WeightSwitchRepeatSpec("output_scale"),)
+        scheme.mxfp8_method.weight_switch_gather_specs = input_gather
+        scheme.mxfp8_method.weight_switch_output_gather_specs = output_gather
+        scheme.mxfp8_method.weight_switch_repeat_specs = input_repeat
+        scheme.mxfp8_method.weight_switch_output_repeat_specs = output_repeat
+        layer, _, _ = self._make_layer()
+        with patch(f"{MODULE}._mx_quantize") as mock_quantize:
+            mock_quantize.return_value = (
+                torch.zeros(8, 64, dtype=torch.float8_e4m3fn),
+                torch.zeros(8, 2, dtype=torch.uint8),
+            )
+            scheme.process_weights_after_loading(layer)
+
+        self.assertTrue(scheme.supports_weight_switch)
+        self.assertEqual(
+            self._get_weight_switch_specs(scheme, input_sharded=True),
+            (input_gather, input_repeat),
+        )
+        self.assertEqual(
+            self._get_weight_switch_specs(scheme, input_sharded=False),
+            (output_gather, output_repeat),
+        )
+
+    def test_weight_switch_specs_cover_dense_fallback(self):
+        scheme = self.build_scheme(is_950=False)
+
+        self.assertTrue(scheme.supports_weight_switch)
+        self.assertEqual(
+            self._get_weight_switch_specs(scheme, input_sharded=True),
+            ((WeightSwitchGatherSpec("weight", gather_dim=1),), ()),
+        )
+        self.assertEqual(
+            self._get_weight_switch_specs(scheme, input_sharded=False),
+            ((WeightSwitchGatherSpec("weight"),), ()),
+        )
 
     def test_pergroup_param_declares_block_scale_and_loader_hints(self):
         scheme = self.build_scheme(block_size=(128, 64))
@@ -190,10 +249,17 @@ class TestAscendFp8BlockLinearMethod(TestBase):
     def test_falls_back_when_reduction_dim_is_not_mx_aligned(self):
         scheme = self.build_scheme(is_950=True, block_size=(4, 32))
         layer, weight, scale_inv = self._make_layer(out_features=8, in_features=48, block=(4, 32))
-
         with patch(f"{MODULE}.maybe_trans_nz", side_effect=lambda tensor: tensor):
             scheme.process_weights_after_loading(layer)
 
+        self.assertEqual(
+            self._get_weight_switch_specs(scheme, input_sharded=True),
+            ((WeightSwitchGatherSpec("weight", gather_dim=1),), ()),
+        )
+        self.assertEqual(
+            self._get_weight_switch_specs(scheme, input_sharded=False),
+            ((WeightSwitchGatherSpec("weight"),), ()),
+        )
         self.assertIsNone(scheme.mxfp8_method)
         self.assertEqual(layer.weight.dtype, torch.bfloat16)
         expected = reference_resolve(weight, scale_inv, 4, 32, torch.bfloat16)

--- a/vllm_ascend/attention/context_parallel/sfa_cp.py
+++ b/vllm_ascend/attention/context_parallel/sfa_cp.py
@@ -593,14 +593,25 @@ class AscendSFADSACPImpl(OProjWeightSwitchMixin, AscendSFAImpl):
         if gather_full_o_proj:
             with self._use_full_o_proj_weights():
                 local_output = self._apply_o_proj_full_weight(attn_output)
-                full_output = get_tp_group().all_gather(local_output.contiguous(), dim=0)
-                if full_output.shape[0] < output.shape[0] or full_output.shape[1:] != output.shape[1:]:
-                    raise RuntimeError(
-                        "SFA DSA-CP gathered output does not match the replicated "
-                        f"model state, got {tuple(full_output.shape)} and expected "
-                        f"{tuple(output.shape)}."
-                    )
-                output[...] = full_output[: output.shape[0]]
+                tp_group = get_tp_group()
+                if not self.o_proj.reduce_results:
+                    # The decoder's sequence-parallel path will reduce-scatter
+                    # this tensor. Place each rank's complete local projection in
+                    # its token slot so the collective does not sum duplicates.
+                    local_start = tp_group.rank_in_group * local_output.shape[0]
+                    local_end = min(local_start + local_output.shape[0], output.shape[0])
+                    output.zero_()
+                    if local_end > local_start:
+                        output[local_start:local_end] = local_output[: local_end - local_start]
+                else:
+                    full_output = tp_group.all_gather(local_output.contiguous(), dim=0)
+                    if full_output.shape[0] < output.shape[0] or full_output.shape[1:] != output.shape[1:]:
+                        raise RuntimeError(
+                            "SFA DSA-CP gathered output does not match the replicated "
+                            f"model state, got {tuple(full_output.shape)} and expected "
+                            f"{tuple(output.shape)}."
+                        )
+                    output[...] = full_output[: output.shape[0]]
             return output
 
         send = (

--- a/vllm_ascend/quantization/methods/w8a8/fp8_block.py
+++ b/vllm_ascend/quantization/methods/w8a8/fp8_block.py
@@ -45,7 +45,14 @@ from vllm.utils.math_utils import cdiv
 from vllm_ascend.quantization.utils import get_dynamic_mx_quant_scale_alg
 from vllm_ascend.utils import FP8_METHOD, is_950, maybe_trans_nz
 
-from ..base import AscendLinearScheme, AscendMoEScheme, QuantType
+from ..base import (
+    AscendLinearScheme,
+    AscendMoEScheme,
+    QuantType,
+    WeightSwitchConfig,
+    WeightSwitchGatherSpec,
+    WeightSwitchRepeatSpec,
+)
 from ..registry import register_scheme
 from .w8a8_mxfp8 import AscendW8A8MXFP8DynamicFusedMoEMethod, AscendW8A8MXFP8DynamicLinearMethod
 
@@ -136,6 +143,36 @@ class AscendFp8BlockLinearMethod(AscendLinearScheme):
     resolves those tiles and then either re-quantizes to MXFP8 (Ascend 950) or
     keeps the model dtype (everything else).
     """
+
+    supports_weight_switch = True
+
+    # Dense post-processing keeps weight in [output, input] layout.
+    weight_switch_gather_specs = (WeightSwitchGatherSpec("weight", gather_dim=1),)
+    weight_switch_output_gather_specs = (WeightSwitchGatherSpec("weight"),)
+
+    def _get_weight_switch_specs(
+        self,
+        layer: torch.nn.Module,
+        config: WeightSwitchConfig,
+    ) -> tuple[
+        tuple[WeightSwitchGatherSpec, ...],
+        tuple[WeightSwitchRepeatSpec, ...],
+        str,
+    ]:
+        gather_specs, repeat_specs, shard_axis = super()._get_weight_switch_specs(layer, config)
+        if self.mxfp8_method is None:
+            return gather_specs, repeat_specs, shard_axis
+        if shard_axis == "input":
+            return (
+                self.mxfp8_method.weight_switch_gather_specs,
+                self.mxfp8_method.weight_switch_repeat_specs,
+                shard_axis,
+            )
+        return (
+            self.mxfp8_method.weight_switch_output_gather_specs,
+            self.mxfp8_method.weight_switch_output_repeat_specs,
+            shard_axis,
+        )
 
     def __init__(self, weight_block_size: tuple[int, int]):
         self.block_n, self.block_k = weight_block_size


### PR DESCRIPTION
### What this PR does / why we need it?

SFA DSA-CP computes a complete o_proj result for each rank's local token shard after temporarily gathering the full TP weight. When the upstream decoder enables sequence-parallel MoE, o_proj.reduce_results is false because the decoder owns the following reduce-scatter. Gathering every local result into a replicated full tensor before that reduce-scatter causes the already-complete values to be summed once more across TP ranks.

This PR:

- teaches AscendFp8BlockLinearMethod to participate in TP full-weight switching while keeping the FP8 wrapper as the layer's execution method;
- reuses the internal A5 MXFP8 implementation's TP weight-layout specifications, including weight scales;
- stages each rank's complete local projection only in its token slot when the upstream decoder owns the reduce-scatter, avoiding the redundant SFA all-gather and duplicate summation;
- preserves the existing replicated-output path when reduce_results is true;
- adds regression coverage for the sequence-parallel handoff and FP8 TP weight-switch specifications.

### Does this PR introduce _any_ user-facing change?

Yes. DSA context parallelism can use block FP8 o_proj weights together with upstream sequence-parallel MoE without duplicate TP reduction. No configuration or public API changes are introduced.

### How was this patch tested?

    pytest -q tests/ut/attention/test_sfa_o_proj_tp.py tests/ut/quantization/methods/test_fp8_block.py
    # 30 passed, 14 warnings in 0.33s

    python -m compileall -q vllm_ascend/attention/context_parallel/sfa_cp.py vllm_ascend/quantization/methods/w8a8/fp8_block.py tests/ut/attention/test_sfa_o_proj_tp.py tests/ut/quantization/methods/test_fp8_block.py

The issue and duplicate TP reduction were reproduced on a two-node Ascend A5 setup with DP=2, TP=8, EP=16, block FP8 weights, and enable_dsa_cp=true. A final two-node run of this exact patch is pending.

- vLLM main: https://github.com/vllm-project/vllm/commit/e6bfe03ad73a3330cb427885aa90d97a12e1c704
