### PR TITLE
[BugFix][Attention] Backport DSA-CP sequence-parallel FP8 fix to v0.27.1rc

### DIFF
--- a/tests/ut/attention/test_sfa_o_proj_tp.py
+++ b/tests/ut/attention/test_sfa_o_proj_tp.py
@@ -54,6 +54,7 @@ class TestAscendSFAOProjTPParams(TestBase):
             self.weight = torch.nn.Parameter(torch.randn(4, 3), requires_grad=False)
             self.weight_scale = torch.nn.Parameter(torch.randn(2, 3), requires_grad=False)
             self.quant_method = linear_method
+            self.reduce_results = True
 
     def setUp(self):
         AscendSFADSACPImpl.o_proj_full_pools.clear()
@@ -114,6 +115,28 @@ class TestAscendSFAOProjTPParams(TestBase):
         self.assertEqual(impl.o_proj.weight_scale.data_ptr(), original_scale_ptr)
         tp_group.all_gather.assert_called_once()
         self.assertTrue(torch.equal(output, gathered_output[:3]))
+
+    def test_o_proj_full_weight_stages_local_result_for_upstream_sp(self):
+        impl = self._make_impl()
+        impl._enable_o_proj_tp_full_weight_switch()
+        impl.enable_dsa_cp_with_o_proj_tp = True
+        impl.o_proj.reduce_results = False
+        local_output = torch.tensor([[3.0, 4.0, 5.0], [6.0, 7.0, 8.0]])
+        impl._apply_o_proj_full_weight = MagicMock(return_value=local_output)
+        tp_group = SimpleNamespace(rank_in_group=1, all_gather=MagicMock())
+
+        with patch("vllm_ascend.attention.context_parallel.sfa_cp.get_tp_group", return_value=tp_group):
+            output = impl._finalize_o_proj(
+                attn_output=torch.randn(2, 8),
+                output=torch.full((3, 3), -1.0),
+                gather_full_o_proj=True,
+            )
+
+        tp_group.all_gather.assert_not_called()
+        torch.testing.assert_close(
+            output,
+            torch.tensor([[0.0, 0.0, 0.0], [0.0, 0.0, 0.0], [3.0, 4.0, 5.0]]),
+        )
 
     def test_prepare_native_hidden_states_slices_replicated_token_state(self):
         impl = self._make_impl()

--- a/tests/ut/quantization/methods/test_fp8_block.py
+++ b/tests/ut/quantization/methods/test_fp8_block.py
@@ -124,19 +124,27 @@ class TestAscendFp8BlockLinearMethod(TestBase):
         scheme.mxfp8_method.tp_weight_output_repeat_specs = output_repeat
 
         self.assertTrue(scheme.supports_tp_weight_switch)
-        self.assertEqual(scheme.tp_weight_gather_specs, input_gather)
-        self.assertEqual(scheme.tp_weight_output_gather_specs, output_gather)
-        self.assertEqual(scheme.tp_weight_repeat_specs, input_repeat)
-        self.assertEqual(scheme.tp_weight_output_repeat_specs, output_repeat)
+        self.assertEqual(
+            scheme.get_tp_weight_switch_specs(input_sharded=True),
+            (input_gather, input_repeat),
+        )
+        self.assertEqual(
+            scheme.get_tp_weight_switch_specs(input_sharded=False),
+            (output_gather, output_repeat),
+        )
 
     def test_tp_weight_switch_specs_cover_dense_fallback(self):
         scheme = self.build_scheme(is_950=False)
 
         self.assertTrue(scheme.supports_tp_weight_switch)
-        self.assertEqual(scheme.tp_weight_gather_specs, (TPWeightGatherSpec("weight", gather_dim=1),))
-        self.assertEqual(scheme.tp_weight_output_gather_specs, (TPWeightGatherSpec("weight"),))
-        self.assertEqual(scheme.tp_weight_repeat_specs, ())
-        self.assertEqual(scheme.tp_weight_output_repeat_specs, ())
+        self.assertEqual(
+            scheme.get_tp_weight_switch_specs(input_sharded=True),
+            ((TPWeightGatherSpec("weight", gather_dim=1),), ()),
+        )
+        self.assertEqual(
+            scheme.get_tp_weight_switch_specs(input_sharded=False),
+            ((TPWeightGatherSpec("weight"),), ()),
+        )
 
     def test_pergroup_param_declares_block_scale_and_loader_hints(self):
         scheme = self.build_scheme(block_size=(128, 64))

--- a/tests/ut/quantization/methods/test_fp8_block.py
+++ b/tests/ut/quantization/methods/test_fp8_block.py
@@ -28,6 +28,7 @@ from vllm_ascend.quantization.methods.w8a8.fp8_block import (
     AscendFp8BlockLinearMethod,
     resolve_block_scales,
 )
+from vllm_ascend.quantization.tp_weight_switch import TPWeightGatherSpec, TPWeightRepeatSpec
 
 MODULE = "vllm_ascend.quantization.methods.w8a8.fp8_block"
 
@@ -110,6 +111,32 @@ class TestAscendFp8BlockLinearMethod(TestBase):
         weight = scheme.get_weight(512, 256, torch.bfloat16)["weight"]
         self.assertEqual(weight.shape, (256, 512))
         self.assertEqual(weight.dtype, torch.float8_e4m3fn)
+
+    def test_tp_weight_switch_specs_follow_mxfp8_execution_method(self):
+        scheme = self.build_scheme(is_950=True)
+        input_gather = (TPWeightGatherSpec("input_weight"),)
+        output_gather = (TPWeightGatherSpec("output_weight", gather_dim=1),)
+        input_repeat = (TPWeightRepeatSpec("input_scale"),)
+        output_repeat = (TPWeightRepeatSpec("output_scale"),)
+        scheme.mxfp8_method.tp_weight_gather_specs = input_gather
+        scheme.mxfp8_method.tp_weight_output_gather_specs = output_gather
+        scheme.mxfp8_method.tp_weight_repeat_specs = input_repeat
+        scheme.mxfp8_method.tp_weight_output_repeat_specs = output_repeat
+
+        self.assertTrue(scheme.supports_tp_weight_switch)
+        self.assertEqual(scheme.tp_weight_gather_specs, input_gather)
+        self.assertEqual(scheme.tp_weight_output_gather_specs, output_gather)
+        self.assertEqual(scheme.tp_weight_repeat_specs, input_repeat)
+        self.assertEqual(scheme.tp_weight_output_repeat_specs, output_repeat)
+
+    def test_tp_weight_switch_specs_cover_dense_fallback(self):
+        scheme = self.build_scheme(is_950=False)
+
+        self.assertTrue(scheme.supports_tp_weight_switch)
+        self.assertEqual(scheme.tp_weight_gather_specs, (TPWeightGatherSpec("weight", gather_dim=1),))
+        self.assertEqual(scheme.tp_weight_output_gather_specs, (TPWeightGatherSpec("weight"),))
+        self.assertEqual(scheme.tp_weight_repeat_specs, ())
+        self.assertEqual(scheme.tp_weight_output_repeat_specs, ())
 
     def test_pergroup_param_declares_block_scale_and_loader_hints(self):
         scheme = self.build_scheme(block_size=(128, 64))

--- a/vllm_ascend/attention/context_parallel/sfa_cp.py
+++ b/vllm_ascend/attention/context_parallel/sfa_cp.py
@@ -528,14 +528,26 @@ class AscendSFADSACPImpl(AscendSFAImpl):
             )
             try:
                 local_output = self._apply_o_proj_full_weight(attn_output)
-                full_output = get_tp_group().all_gather(local_output.contiguous(), dim=0)
-                if full_output.shape[0] < output.shape[0] or full_output.shape[1:] != output.shape[1:]:
-                    raise RuntimeError(
-                        "SFA DSA-CP gathered output does not match the replicated "
-                        f"model state, got {tuple(full_output.shape)} and expected "
-                        f"{tuple(output.shape)}."
-                    )
-                output[...] = full_output[: output.shape[0]]
+                tp_group = get_tp_group()
+                if not self.o_proj.reduce_results:
+                    # The decoder's sequence-parallel path will reduce-scatter
+                    # this tensor. Place each rank's complete local projection in
+                    # its token slot so that collective scatters without summing
+                    # duplicate, already-complete outputs.
+                    local_start = tp_group.rank_in_group * local_output.shape[0]
+                    local_end = min(local_start + local_output.shape[0], output.shape[0])
+                    output.zero_()
+                    if local_end > local_start:
+                        output[local_start:local_end] = local_output[: local_end - local_start]
+                else:
+                    full_output = tp_group.all_gather(local_output.contiguous(), dim=0)
+                    if full_output.shape[0] < output.shape[0] or full_output.shape[1:] != output.shape[1:]:
+                        raise RuntimeError(
+                            "SFA DSA-CP gathered output does not match the replicated "
+                            f"model state, got {tuple(full_output.shape)} and expected "
+                            f"{tuple(output.shape)}."
+                        )
+                    output[...] = full_output[: output.shape[0]]
             finally:
                 linear_method.switch_tp_weight(
                     self.o_proj,

--- a/vllm_ascend/quantization/methods/w8a8/fp8_block.py
+++ b/vllm_ascend/quantization/methods/w8a8/fp8_block.py
@@ -151,7 +151,9 @@ class AscendFp8BlockLinearMethod(AscendLinearScheme):
         input_sharded: bool,
     ) -> tuple[tuple[TPWeightGatherSpec, ...], tuple[TPWeightRepeatSpec, ...]]:
         if self.mxfp8_method is not None:
-            return self.mxfp8_method.get_tp_weight_switch_specs(input_sharded=input_sharded)
+            if input_sharded:
+                return self.mxfp8_method.tp_weight_gather_specs, self.mxfp8_method.tp_weight_repeat_specs
+            return self.mxfp8_method.tp_weight_output_gather_specs, self.mxfp8_method.tp_weight_output_repeat_specs
         gather_dim = 1 if input_sharded else 0
         return (TPWeightGatherSpec("weight", gather_dim=gather_dim),), ()
 

--- a/vllm_ascend/quantization/methods/w8a8/fp8_block.py
+++ b/vllm_ascend/quantization/methods/w8a8/fp8_block.py
@@ -145,29 +145,15 @@ class AscendFp8BlockLinearMethod(AscendLinearScheme):
 
     supports_tp_weight_switch = True
 
-    @property
-    def tp_weight_gather_specs(self) -> tuple[TPWeightGatherSpec, ...]:
+    def get_tp_weight_switch_specs(
+        self,
+        *,
+        input_sharded: bool,
+    ) -> tuple[tuple[TPWeightGatherSpec, ...], tuple[TPWeightRepeatSpec, ...]]:
         if self.mxfp8_method is not None:
-            return self.mxfp8_method.tp_weight_gather_specs
-        return (TPWeightGatherSpec("weight", gather_dim=1),)
-
-    @property
-    def tp_weight_output_gather_specs(self) -> tuple[TPWeightGatherSpec, ...]:
-        if self.mxfp8_method is not None:
-            return self.mxfp8_method.tp_weight_output_gather_specs
-        return (TPWeightGatherSpec("weight"),)
-
-    @property
-    def tp_weight_repeat_specs(self) -> tuple[TPWeightRepeatSpec, ...]:
-        if self.mxfp8_method is not None:
-            return self.mxfp8_method.tp_weight_repeat_specs
-        return ()
-
-    @property
-    def tp_weight_output_repeat_specs(self) -> tuple[TPWeightRepeatSpec, ...]:
-        if self.mxfp8_method is not None:
-            return self.mxfp8_method.tp_weight_output_repeat_specs
-        return ()
+            return self.mxfp8_method.get_tp_weight_switch_specs(input_sharded=input_sharded)
+        gather_dim = 1 if input_sharded else 0
+        return (TPWeightGatherSpec("weight", gather_dim=gather_dim),), ()
 
     def __init__(self, weight_block_size: tuple[int, int]):
         self.block_n, self.block_k = weight_block_size

--- a/vllm_ascend/quantization/methods/w8a8/fp8_block.py
+++ b/vllm_ascend/quantization/methods/w8a8/fp8_block.py
@@ -45,7 +45,13 @@ from vllm.utils.math_utils import cdiv
 from vllm_ascend.quantization.utils import get_dynamic_mx_quant_scale_alg
 from vllm_ascend.utils import FP8_METHOD, is_950, maybe_trans_nz
 
-from ..base import AscendLinearScheme, AscendMoEScheme, QuantType
+from ..base import (
+    AscendLinearScheme,
+    AscendMoEScheme,
+    QuantType,
+    TPWeightGatherSpec,
+    TPWeightRepeatSpec,
+)
 from ..registry import register_scheme
 from .w8a8_mxfp8 import AscendW8A8MXFP8DynamicFusedMoEMethod, AscendW8A8MXFP8DynamicLinearMethod
 
@@ -136,6 +142,32 @@ class AscendFp8BlockLinearMethod(AscendLinearScheme):
     resolves those tiles and then either re-quantizes to MXFP8 (Ascend 950) or
     keeps the model dtype (everything else).
     """
+
+    supports_tp_weight_switch = True
+
+    @property
+    def tp_weight_gather_specs(self) -> tuple[TPWeightGatherSpec, ...]:
+        if self.mxfp8_method is not None:
+            return self.mxfp8_method.tp_weight_gather_specs
+        return (TPWeightGatherSpec("weight", gather_dim=1),)
+
+    @property
+    def tp_weight_output_gather_specs(self) -> tuple[TPWeightGatherSpec, ...]:
+        if self.mxfp8_method is not None:
+            return self.mxfp8_method.tp_weight_output_gather_specs
+        return (TPWeightGatherSpec("weight"),)
+
+    @property
+    def tp_weight_repeat_specs(self) -> tuple[TPWeightRepeatSpec, ...]:
+        if self.mxfp8_method is not None:
+            return self.mxfp8_method.tp_weight_repeat_specs
+        return ()
+
+    @property
+    def tp_weight_output_repeat_specs(self) -> tuple[TPWeightRepeatSpec, ...]:
+        if self.mxfp8_method is not None:
+            return self.mxfp8_method.tp_weight_output_repeat_specs
+        return ()
 
     def __init__(self, weight_block_size: tuple[int, int]):
         self.block_n, self.block_k = weight_block_size

--- a/vllm_ascend/quantization/tp_weight_switch.py
+++ b/vllm_ascend/quantization/tp_weight_switch.py
@@ -105,6 +105,16 @@ class TPWeightSwitchMixin:
     tp_weight_output_repeat_specs: ClassVar[tuple[TPWeightRepeatSpec, ...]] = ()
     supports_tp_weight_switch: ClassVar[bool] = False
 
+    def get_tp_weight_switch_specs(
+        self,
+        *,
+        input_sharded: bool,
+    ) -> tuple[tuple[TPWeightGatherSpec, ...], tuple[TPWeightRepeatSpec, ...]]:
+        """Return the tensor specs for the layer's TP-sharded axis."""
+        if input_sharded:
+            return self.tp_weight_gather_specs, self.tp_weight_repeat_specs
+        return self.tp_weight_output_gather_specs, self.tp_weight_output_repeat_specs
+
     @staticmethod
     def split_tensor_for_tp(
         tensor: torch.Tensor,
@@ -155,14 +165,8 @@ class TPWeightSwitchMixin:
                 f"got input_size={input_size}, input_size_per_partition={input_size_per_partition}, "
                 f"output_size={output_size}, output_size_per_partition={output_size_per_partition}."
             )
-        if input_sharded:
-            gather_specs = self.tp_weight_gather_specs
-            repeat_specs = self.tp_weight_repeat_specs
-            shard_axis = "input"
-        else:
-            gather_specs = self.tp_weight_output_gather_specs
-            repeat_specs = self.tp_weight_output_repeat_specs
-            shard_axis = "output"
+        gather_specs, repeat_specs = self.get_tp_weight_switch_specs(input_sharded=input_sharded)
+        shard_axis = "input" if input_sharded else "output"
         if not gather_specs and not repeat_specs:
             raise RuntimeError(
                 f"{type(self).__name__} does not declare TP weight switch specs for a {shard_axis}-sharded layer."


### PR DESCRIPTION
### What this PR does / why we need it?

SFA DSA-CP computes a complete o_proj result for each rank's local token shard after temporarily gathering the full TP weight. When the upstream decoder enables sequence-parallel MoE, o_proj.reduce_results is false because the decoder owns the following reduce-scatter. Gathering every local result into a replicated full tensor before that reduce-scatter causes the already-complete values to be summed once more across TP ranks.

This PR:

- teaches AscendFp8BlockLinearMethod to participate in TP full-weight switching while keeping the FP8 wrapper as the layer's execution method;
- reuses the internal A5 MXFP8 implementation's TP weight-layout specifications, including weight scales;
- stages each rank's complete local projection only in its token slot when the upstream decoder owns the reduce-scatter, avoiding the redundant SFA all-gather and duplicate summation;
- preserves the existing replicated-output path when reduce_results is true;
- adds regression coverage for the sequence-parallel handoff and FP8 TP weight-switch specifications.

### Does this PR introduce _any_ user-facing change?

Yes. DSA context parallelism can use block FP8 o_proj weights together with upstream sequence-parallel MoE without duplicate TP reduction. No configuration or public API changes are introduced.

### How was this patch tested?

    pytest -q tests/ut/attention/test_sfa_o_proj_tp.py tests/ut/quantization/methods/test_fp8_block.py
    # 30 passed, 14 warnings in 0.33s

    python -m compileall -q vllm_ascend/attention/context_parallel/sfa_cp.py vllm_ascend/quantization/methods/w8a8/fp8_block.py tests/ut/attention/test_sfa_o_proj_tp.py tests/ut/quantization/methods/test_fp8_block.py

The issue and duplicate TP reduction were reproduced on a two-node Ascend A5 setup with DP=2, TP=8, EP=16, block FP8 weights, and enable_dsa_cp=true. A final two-node run of this exact patch is pending.

- vLLM main: https://github.com/vllm-project/vllm/commit/ba07e4a48fc951300d97eb506217dd530583dea3
