### PR TITLE
[BugFix][Frontend] Backport vLLM #54548 sparse multimodal placeholder masks

### DIFF
--- a/tests/ut/patch/platform/test_mm_placeholder_mask.py
+++ b/tests/ut/patch/platform/test_mm_placeholder_mask.py
@@ -2,20 +2,22 @@
 
 import asyncio
 from types import SimpleNamespace
-from unittest.mock import patch
+from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
 import torch
 from vllm.entrypoints.scale_out.derender.serving import ServingDerender
 from vllm.entrypoints.scale_out.render.serving import ServingRender
+from vllm.entrypoints.scale_out.token_in_token_out import serving as upstream_serving
 from vllm.entrypoints.scale_out.token_in_token_out.protocol import GenerateRequest, MultiModalFeatures
 from vllm.entrypoints.scale_out.token_in_token_out.serving import ServingTokens
 from vllm.inputs import mm_input
 from vllm.multimodal.inputs import MultiModalKwargsItems, PlaceholderRange
 
 from vllm_ascend.patch.platform.patch_mm_placeholder_mask import (
-    _wrap_serve_tokens,
     install_mm_placeholder_mask_patch,
+    rebuild_mm_placeholders,
+    serve_tokens,
 )
 
 
@@ -78,84 +80,176 @@ def test_fastapi_request_schema_preserves_embedding_mask():
         assert "is_embed" in schema["components"]["schemas"]["PlaceholderRangeInfo"]["properties"]
 
 
-async def _upstream_handler(self, request, raw_request=None):
-    await asyncio.sleep(0)
-    return mm_input(
-        prompt_token_ids=request.token_ids,
-        mm_kwargs=MultiModalKwargsItems({}),
-        mm_hashes=request.features.mm_hashes,
-        mm_placeholders={"image": [PlaceholderRange(offset=0, length=4)]},
+def make_request(mask=None, **kwargs):
+    install_mm_placeholder_mask_patch()
+    return GenerateRequest.model_validate(
+        {
+            "token_ids": [1, 2, 3, 4],
+            "sampling_params": {"max_tokens": 8},
+            "features": {
+                "mm_hashes": {"image": ["test"]},
+                "mm_placeholders": {"image": [{"offset": 0, "length": 4, "is_embed": mask}]},
+            },
+            **kwargs,
+        }
     )
 
 
+def make_serving():
+    async def full_response(request, result, *args):
+        await asyncio.sleep(0)
+        return result
+
+    return SimpleNamespace(
+        _check_model=AsyncMock(return_value=None),
+        engine_client=SimpleNamespace(
+            errored=False,
+            vllm_config=SimpleNamespace(scheduler_config=SimpleNamespace(max_num_seqs=4)),
+            generate=Mock(side_effect=lambda engine_input, *args, **kwargs: engine_input),
+        ),
+        _maybe_get_adapters=Mock(return_value=None),
+        models=SimpleNamespace(model_name=lambda _: "test"),
+        _base_request_id=lambda *a: "test",
+        force_no_detokenize=False,
+        _log_inputs=Mock(),
+        _get_data_parallel_rank=Mock(return_value=2),
+        _get_session_id_from_headers=Mock(return_value="session-test"),
+        serve_tokens_full_generator=full_response,
+        serve_tokens_stream_generator=Mock(side_effect=lambda request, result, *args: result),
+        create_error_response=lambda error: error,
+        online_renderer=SimpleNamespace(preprocess_completion=AsyncMock(return_value=({"type": "token"},))),
+    )
+
+
+@pytest.mark.parametrize("mask", [None, [True, False, True, True]])
+def test_rebuild_mm_placeholders_restores_is_embed(mask):
+    request = make_request(mask)
+    features = MultiModalFeatures.model_validate_json(request.features.model_dump_json())
+    (placeholder,) = rebuild_mm_placeholders(features.mm_placeholders)["image"]
+    assert placeholder.offset == 0
+    assert placeholder.length == 4
+    if mask is None:
+        assert placeholder.is_embed is None
+    else:
+        assert torch.equal(placeholder.is_embed, torch.tensor(mask, dtype=torch.bool))
+        assert placeholder.is_embed.device.type == "cpu"
+    assert placeholder.get_num_embeds() == (4 if mask is None else sum(mask))
+
+
 def test_concurrent_requests_rebuild_their_own_embedding_masks():
-    install_mm_placeholder_mask_patch()
-    original_builder = _upstream_handler.__globals__["mm_input"]
-    wrapped = _wrap_serve_tokens(_upstream_handler)
+    original_builder = upstream_serving.mm_input
+    serving = make_serving()
 
     async def run():
-        requests = [
-            SimpleNamespace(
-                token_ids=[1, 2, 3, 4],
-                features=MultiModalFeatures.model_validate(
-                    {
-                        "mm_hashes": {"image": [str(i)]},
-                        "mm_placeholders": {"image": [{"offset": 0, "length": 4, "is_embed": mask}]},
-                    }
-                ),
-            )
-            for i, mask in enumerate(([True, False, True, True], [False, True, False, False], None))
-        ]
-        return await asyncio.gather(*(wrapped(None, request) for request in requests))
+        requests = [make_request(mask) for mask in ([True, False, True, True], [False, True, False, False], None)]
+        return await asyncio.gather(*(ServingTokens.serve_tokens(serving, request) for request in requests))
 
     results = asyncio.run(run())
     assert [r["mm_placeholders"]["image"][0].get_num_embeds() for r in results] == [3, 1, 4]
     assert results[0]["mm_placeholders"]["image"][0].is_embed.dtype == torch.bool
-    assert _upstream_handler.__globals__["mm_input"] is original_builder
+    assert upstream_serving.mm_input is original_builder
 
 
-@pytest.mark.parametrize("content_parts", [None, [{"type": "image_url", "url": "image.png"}]])
-def test_text_and_content_parts_use_the_original_handler(content_parts):
-    async def original(self, request, raw_request):
-        return request
-
-    request = SimpleNamespace(features=None if content_parts is None else object(), content_parts=content_parts)
-    assert asyncio.run(_wrap_serve_tokens(original)(None, request)) is request
-
-
-def test_real_handler_passes_mask_to_engine_input_builder():
-    install_mm_placeholder_mask_patch()
-    request = GenerateRequest.model_validate(
-        {
-            "token_ids": [1, 2, 3, 4],
-            "sampling_params": {},
-            "features": {
-                "mm_hashes": {"image": ["test"]},
-                "mm_placeholders": {"image": [{"offset": 0, "length": 4, "is_embed": [True, False, True, True]}]},
-            },
-        }
+def test_text_uses_original_preprocessing():
+    serving = make_serving()
+    request = make_request(features=None)
+    assert asyncio.run(serve_tokens(serving, request)) == {"type": "token"}
+    serving.online_renderer.preprocess_completion.assert_awaited_once_with(
+        request, prompt_input=request.token_ids, prompt_embeds=None, skip_mm_cache=True
     )
 
-    async def check_model(request):
-        return None
 
-    serving = SimpleNamespace(
-        _check_model=check_model,
-        engine_client=SimpleNamespace(
-            errored=False, vllm_config=SimpleNamespace(scheduler_config=SimpleNamespace(max_num_seqs=4))
-        ),
-        _maybe_get_adapters=lambda *a, **k: None,
-        models=SimpleNamespace(model_name=lambda _: "test"),
-        _base_request_id=lambda *a: "test",
+@pytest.mark.skipif("content_parts" not in GenerateRequest.model_fields, reason="v0.27.1 has no content_parts")
+def test_content_parts_uses_original_rendering():
+    serving = make_serving()
+    serving.model_config = object()
+    serving.online_renderer.renderer = SimpleNamespace(
+        render_cmpl_async=AsyncMock(return_value=({"type": "multimodal"},))
+    )
+    request = make_request(features=None, content_parts=[{"type": "image_url", "url": "image.png"}])
+    tracker = Mock()
+    tracker.resolve_items = AsyncMock(return_value=({"image": ["pixels"]}, {"image": ["image-id"]}))
+    with patch("vllm.entrypoints.chat_utils.AsyncMultiModalItemTracker", return_value=tracker):
+        assert asyncio.run(serve_tokens(serving, request)) == {"type": "multimodal"}
+    tracker.create_parser.return_value.parse_image.assert_called_once_with("image.png", None)
+    serving.online_renderer.renderer.render_cmpl_async.assert_awaited_once_with(
+        [
+            {
+                "prompt_token_ids": request.token_ids,
+                "multi_modal_data": {"image": ["pixels"]},
+                "multi_modal_uuids": {"image": ["image-id"]},
+            }
+        ]
     )
 
-    class ReachedInputBuilder(Exception):
-        pass
 
-    def capture(**kwargs):
-        assert kwargs["mm_placeholders"]["image"][0].get_num_embeds() == 3
-        raise ReachedInputBuilder
+@pytest.mark.parametrize("stream", [False, True])
+def test_engine_handoff_preserves_routing_and_output_kind(stream):
+    from vllm.sampling_params import RequestOutputKind
 
-    original = getattr(ServingTokens.serve_tokens, "__wrapped__", ServingTokens.serve_tokens)
-    with patch.dict(original.__globals__, mm_input=capture), pytest.raises(ReachedInputBuilder):
-        asyncio.run(ServingTokens.serve_tokens(serving, request))
+    serving = make_serving()
+    request = make_request([True, False, True, True], stream=stream)
+    old_output_kind = request.sampling_params.output_kind
+    result = asyncio.run(ServingTokens.serve_tokens(serving, request))
+    assert result["mm_placeholders"]["image"][0].get_num_embeds() == 3
+    assert result["mm_kwargs"]["image"] == [None]
+    kwargs = serving.engine_client.generate.call_args.kwargs
+    assert kwargs["data_parallel_rank"] == 2
+    if "content_parts" in GenerateRequest.model_fields:
+        assert kwargs["session_id"] == "session-test"
+        assert request.sampling_params.output_kind == (
+            RequestOutputKind.DELTA if stream else RequestOutputKind.FINAL_ONLY
+        )
+    else:
+        assert "session_id" not in kwargs
+        assert request.sampling_params.output_kind == (RequestOutputKind.DELTA if stream else old_output_kind)
+
+
+def test_model_error_does_not_schedule_request():
+    serving = make_serving()
+    serving._check_model.return_value = "model error"
+    assert asyncio.run(serve_tokens(serving, make_request())) == "model error"
+    serving.engine_client.generate.assert_not_called()
+
+
+def test_sampling_validation_does_not_schedule_request():
+    serving = make_serving()
+    request = make_request(sampling_params={"n": 5, "max_tokens": 8})
+    assert "max_num_seqs" in asyncio.run(serve_tokens(serving, request))
+    serving.engine_client.generate.assert_not_called()
+
+
+def test_default_max_tokens_and_no_detokenize_are_preserved():
+    serving = make_serving()
+    serving.model_config = SimpleNamespace(max_model_len=128)
+    serving.default_sampling_params = {"max_tokens": 23}
+    serving.override_max_tokens = None
+    serving._extract_prompt_len = lambda _: 4
+    serving.force_no_detokenize = True
+    request = make_request(sampling_params={})
+    asyncio.run(serve_tokens(serving, request))
+    assert request.sampling_params.max_tokens == 23
+    assert request.sampling_params.detokenize is False
+
+
+def test_serialized_embedding_data_reaches_engine():
+    from vllm.entrypoints.scale_out.token_in_token_out.mm_serde import encode_mm_kwargs_item
+    from vllm.multimodal.inputs import MultiModalBatchedField, MultiModalFieldElem, MultiModalKwargsItem
+
+    serving = make_serving()
+    request = make_request([True, False, True, True])
+    pixels = torch.arange(12).reshape(3, 4)
+    item = MultiModalKwargsItem({"pixel_values": MultiModalFieldElem(data=pixels, field=MultiModalBatchedField())})
+    request.features.kwargs_data = {"image": [encode_mm_kwargs_item(item)]}
+    result = asyncio.run(serve_tokens(serving, request))
+    assert torch.equal(result["mm_kwargs"]["image"][0]["pixel_values"].data, pixels)
+    assert result["mm_placeholders"]["image"][0].get_num_embeds() == 3
+
+
+def test_generation_exception_does_not_affect_next_request():
+    serving = make_serving()
+    serving.engine_client.generate.side_effect = RuntimeError("generation failed")
+    with pytest.raises(RuntimeError, match="generation failed"):
+        asyncio.run(serve_tokens(serving, make_request([True, False, True, True])))
+    result = asyncio.run(serve_tokens(make_serving(), make_request([False, True, False, False])))
+    assert result["mm_placeholders"]["image"][0].get_num_embeds() == 1

--- a/tests/ut/patch/platform/test_mm_placeholder_mask.py
+++ b/tests/ut/patch/platform/test_mm_placeholder_mask.py
@@ -1,0 +1,161 @@
+# SPDX-License-Identifier: Apache-2.0
+
+import asyncio
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+import torch
+from vllm.entrypoints.scale_out.derender.serving import ServingDerender
+from vllm.entrypoints.scale_out.render.serving import ServingRender
+from vllm.entrypoints.scale_out.token_in_token_out.protocol import GenerateRequest, MultiModalFeatures
+from vllm.entrypoints.scale_out.token_in_token_out.serving import ServingTokens
+from vllm.inputs import mm_input
+from vllm.multimodal.inputs import MultiModalKwargsItems, PlaceholderRange
+
+from vllm_ascend.patch.platform.patch_mm_placeholder_mask import (
+    _wrap_serve_tokens,
+    install_mm_placeholder_mask_patch,
+)
+
+
+@pytest.mark.parametrize("serving", [ServingRender, ServingDerender])
+@pytest.mark.parametrize("mask", [None, [True, False, True, True]])
+def test_render_json_preserves_sparse_and_dense_placeholders(serving, mask):
+    install_mm_placeholder_mask_patch()
+    engine_input = mm_input(
+        prompt_token_ids=[1, 2, 3, 4, 5],
+        mm_kwargs=MultiModalKwargsItems({}),
+        mm_hashes={"image": ["image-0"]},
+        mm_placeholders={
+            "image": [PlaceholderRange(offset=1, length=4, is_embed=None if mask is None else torch.tensor(mask))]
+        },
+    )
+    features = serving._extract_mm_features(engine_input)
+    request = GenerateRequest.model_validate_json(
+        GenerateRequest(token_ids=[1, 2, 3, 4, 5], sampling_params={}, features=features).model_dump_json()
+    )
+    assert request.features.mm_placeholders["image"][0].is_embed == mask
+    assert serving._extract_mm_features({"type": "token", "prompt_token_ids": [1]}) is None
+
+
+def test_installation_is_idempotent():
+    install_mm_placeholder_mask_patch()
+    render = ServingRender._extract_mm_features
+    serve = ServingTokens.serve_tokens
+    install_mm_placeholder_mask_patch()
+    assert ServingRender._extract_mm_features is render
+    assert ServingTokens.serve_tokens is serve
+    assert "is_embed" in GenerateRequest.model_json_schema()["$defs"]["PlaceholderRangeInfo"]["properties"]
+
+
+def test_fastapi_request_schema_preserves_embedding_mask():
+    from fastapi import FastAPI
+    from fastapi.testclient import TestClient
+
+    install_mm_placeholder_mask_patch()
+    app = FastAPI()
+
+    @app.post("/generate")
+    def generate(request: GenerateRequest):
+        return request.features
+
+    with TestClient(app) as client:
+        response = client.post(
+            "/generate",
+            json={
+                "token_ids": [1, 2, 3, 4],
+                "sampling_params": {},
+                "features": {
+                    "mm_hashes": {"image": ["test"]},
+                    "mm_placeholders": {"image": [{"offset": 0, "length": 4, "is_embed": [True, False, True, True]}]},
+                },
+            },
+        )
+        assert response.status_code == 200
+        assert response.json()["mm_placeholders"]["image"][0]["is_embed"] == [True, False, True, True]
+        schema = client.get("/openapi.json").json()
+        assert "is_embed" in schema["components"]["schemas"]["PlaceholderRangeInfo"]["properties"]
+
+
+async def _upstream_handler(self, request, raw_request=None):
+    await asyncio.sleep(0)
+    return mm_input(
+        prompt_token_ids=request.token_ids,
+        mm_kwargs=MultiModalKwargsItems({}),
+        mm_hashes=request.features.mm_hashes,
+        mm_placeholders={"image": [PlaceholderRange(offset=0, length=4)]},
+    )
+
+
+def test_concurrent_requests_rebuild_their_own_embedding_masks():
+    install_mm_placeholder_mask_patch()
+    original_builder = _upstream_handler.__globals__["mm_input"]
+    wrapped = _wrap_serve_tokens(_upstream_handler)
+
+    async def run():
+        requests = [
+            SimpleNamespace(
+                token_ids=[1, 2, 3, 4],
+                features=MultiModalFeatures.model_validate(
+                    {
+                        "mm_hashes": {"image": [str(i)]},
+                        "mm_placeholders": {"image": [{"offset": 0, "length": 4, "is_embed": mask}]},
+                    }
+                ),
+            )
+            for i, mask in enumerate(([True, False, True, True], [False, True, False, False], None))
+        ]
+        return await asyncio.gather(*(wrapped(None, request) for request in requests))
+
+    results = asyncio.run(run())
+    assert [r["mm_placeholders"]["image"][0].get_num_embeds() for r in results] == [3, 1, 4]
+    assert results[0]["mm_placeholders"]["image"][0].is_embed.dtype == torch.bool
+    assert _upstream_handler.__globals__["mm_input"] is original_builder
+
+
+@pytest.mark.parametrize("content_parts", [None, [{"type": "image_url", "url": "image.png"}]])
+def test_text_and_content_parts_use_the_original_handler(content_parts):
+    async def original(self, request, raw_request):
+        return request
+
+    request = SimpleNamespace(features=None if content_parts is None else object(), content_parts=content_parts)
+    assert asyncio.run(_wrap_serve_tokens(original)(None, request)) is request
+
+
+def test_real_handler_passes_mask_to_engine_input_builder():
+    install_mm_placeholder_mask_patch()
+    request = GenerateRequest.model_validate(
+        {
+            "token_ids": [1, 2, 3, 4],
+            "sampling_params": {},
+            "features": {
+                "mm_hashes": {"image": ["test"]},
+                "mm_placeholders": {"image": [{"offset": 0, "length": 4, "is_embed": [True, False, True, True]}]},
+            },
+        }
+    )
+
+    async def check_model(request):
+        return None
+
+    serving = SimpleNamespace(
+        _check_model=check_model,
+        engine_client=SimpleNamespace(
+            errored=False, vllm_config=SimpleNamespace(scheduler_config=SimpleNamespace(max_num_seqs=4))
+        ),
+        _maybe_get_adapters=lambda *a, **k: None,
+        models=SimpleNamespace(model_name=lambda _: "test"),
+        _base_request_id=lambda *a: "test",
+    )
+
+    class ReachedInputBuilder(Exception):
+        pass
+
+    def capture(**kwargs):
+        assert kwargs["mm_placeholders"]["image"][0].get_num_embeds() == 3
+        raise ReachedInputBuilder
+
+    original = getattr(ServingTokens.serve_tokens, "__wrapped__", ServingTokens.serve_tokens)
+    with patch.dict(original.__globals__, mm_input=capture), pytest.raises(ReachedInputBuilder):
+        asyncio.run(ServingTokens.serve_tokens(serving, request))

--- a/vllm_ascend/patch/__init__.py
+++ b/vllm_ascend/patch/__init__.py
@@ -27,6 +27,14 @@
 # ----------------------------------------------------------------------------------
 
 # What's Patched and how it works:
+#
+# platform/patch_mm_placeholder_mask.py backports
+# https://github.com/vllm-project/vllm/pull/54548. It preserves sparse
+# PlaceholderRange.is_embed masks through render/derender serialization and
+# token-input reconstruction. Installation runs after platform/config imports,
+# rebuilds nested request schemas, and skips versions with native is_embed.
+# Remove this compatibility patch once every supported vLLM version preserves
+# the mask. The request-local input builder leaves concurrent requests isolated.
 # --------------------------------
 # * Platform Patch:
 # =================

--- a/vllm_ascend/patch/__init__.py
+++ b/vllm_ascend/patch/__init__.py
@@ -34,7 +34,8 @@
 # token-input reconstruction. Installation runs after platform/config imports,
 # rebuilds nested request schemas, and skips versions with native is_embed.
 # Remove this compatibility patch once every supported vLLM version preserves
-# the mask. The request-local input builder leaves concurrent requests isolated.
+# the mask. The placeholder builder and serving method follow the upstream fix;
+# no function cloning or request-scoped module-global overrides are used.
 # --------------------------------
 # * Platform Patch:
 # =================

--- a/vllm_ascend/patch/platform/patch_mm_placeholder_mask.py
+++ b/vllm_ascend/patch/platform/patch_mm_placeholder_mask.py
@@ -1,8 +1,19 @@
 # SPDX-License-Identifier: Apache-2.0
-"""Compatibility backport of vllm-project/vllm#54548."""
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Compatibility backport of vllm-project/vllm#54548.
 
+The placeholder builder follows upstream commit 60fe831acefe. The serving method
+backports its call site onto the supported vLLM main pin ba07e4a48, with v0.27.1
+content-parts, output-kind and session-ID differences gated explicitly.
+"""
+
+from collections.abc import Mapping
 from functools import wraps
-from types import FunctionType
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from vllm.entrypoints.scale_out.token_in_token_out.protocol import PlaceholderRangeInfo
+    from vllm.multimodal.inputs import PlaceholderRange
 
 
 def _wrap_extract_features(original, placeholder_type):
@@ -27,44 +38,149 @@ def _wrap_extract_features(original, placeholder_type):
     return extract
 
 
-def _wrap_serve_tokens(original):
-    @wraps(original)
-    async def serve(self, request, raw_request=None):
-        if request.features is None or getattr(request, "content_parts", None):
-            return await original(self, request, raw_request)
+def rebuild_mm_placeholders(
+    mm_placeholders: Mapping[str, list["PlaceholderRangeInfo"]],
+) -> dict[str, list["PlaceholderRange"]]:
+    """Convert rendered placeholders back to ranges, as in vLLM #54548."""
+    import torch
+    from vllm.multimodal.inputs import PlaceholderRange
 
-        import torch
-        from vllm.multimodal.inputs import PlaceholderRange
+    return {
+        modality: [
+            PlaceholderRange(
+                offset=p.offset,
+                length=p.length,
+                is_embed=None if p.is_embed is None else torch.tensor(p.is_embed, dtype=torch.bool),
+            )
+            for p in ranges
+        ]
+        for modality, ranges in mm_placeholders.items()
+    }
 
-        original_mm_input = original.__globals__["mm_input"]
 
-        def mm_input(**kwargs):
-            kwargs["mm_placeholders"] = {
-                modality: [
-                    PlaceholderRange(
-                        offset=p.offset,
-                        length=p.length,
-                        is_embed=None if p.is_embed is None else torch.tensor(p.is_embed, dtype=torch.bool),
-                    )
-                    for p in ranges
-                ]
-                for modality, ranges in request.features.mm_placeholders.items()
-            }
-            return original_mm_input(**kwargs)
+async def serve_tokens(self, request, raw_request=None):
+    # Keep imports lazy: this patch module can load during platform discovery,
+    # before vLLM config and serving modules have finished initializing.
+    import msgspec
+    from vllm.entrypoints.chat_utils import AsyncMultiModalItemTracker
+    from vllm.entrypoints.openai.engine.protocol import RequestResponseMetadata
+    from vllm.entrypoints.scale_out.token_in_token_out.mm_serde import decode_mm_kwargs_item
+    from vllm.entrypoints.scale_out.token_in_token_out.serving import logger
+    from vllm.entrypoints.serve.utils.api_utils import get_max_tokens
+    from vllm.inputs import TokensPrompt, mm_input
+    from vllm.multimodal.inputs import MultiModalKwargsItems
+    from vllm.sampling_params import RequestOutputKind
 
-        # Bind only this request's input builder without mutating module globals
-        # across concurrent awaits or copying the version-specific async handler.
-        scoped = FunctionType(
-            original.__code__,
-            dict(original.__globals__, mm_input=mm_input),
-            original.__name__,
-            original.__defaults__,
-            original.__closure__,
+    from vllm_ascend.utils import vllm_version_is
+
+    is_v0271 = vllm_version_is("0.27.1")
+    error_check_ret = await self._check_model(request)
+    if error_check_ret is not None:
+        logger.error("Error with model %s", error_check_ret)
+        return error_check_ret
+
+    # Preserve upstream validation before constructing or scheduling inputs.
+    if self.engine_client.errored:
+        raise self.engine_client.dead_error
+
+    lora_request = self._maybe_get_adapters(request, supports_default_mm_loras=True)
+    model_name = self.models.model_name(lora_request)
+    request_id = f"generate-tokens-{self._base_request_id(raw_request, request.request_id)}"
+    request_metadata = RequestResponseMetadata(request_id=request_id)
+    if raw_request:
+        raw_request.state.request_metadata = request_metadata
+
+    sampling_params = request.sampling_params
+    max_num_seqs = self.engine_client.vllm_config.scheduler_config.max_num_seqs
+    if sampling_params.n > max_num_seqs:
+        return self.create_error_response(
+            f"sampling_params.n must be at most the server's max_num_seqs ({max_num_seqs}), got {sampling_params.n}."
         )
-        scoped.__kwdefaults__ = original.__kwdefaults__
-        return await scoped(self, request, raw_request)
+    try:
+        msgspec.msgpack.encode(sampling_params)
+    except (OverflowError, TypeError, ValueError) as e:
+        return self.create_error_response(e)
 
-    return serve
+    if not is_v0271 and request.content_parts:
+        tracker = AsyncMultiModalItemTracker(self.model_config)
+        mm_parser = tracker.create_parser()
+        for part in request.content_parts:
+            ptype = part.get("type", "")
+            url = part.get("url")
+            uuid = part.get("uuid")
+            if ptype == "image_url":
+                mm_parser.parse_image(url, uuid)
+            elif ptype == "audio_url":
+                mm_parser.parse_audio(url, uuid)
+            elif ptype == "video_url":
+                mm_parser.parse_video(url, uuid)
+        mm_data, mm_uuids = await tracker.resolve_items()
+        prompt = TokensPrompt(prompt_token_ids=request.token_ids)
+        if mm_data:
+            prompt["multi_modal_data"] = mm_data
+        if mm_uuids:
+            prompt["multi_modal_uuids"] = mm_uuids
+        (engine_input,) = await self.online_renderer.renderer.render_cmpl_async([prompt])
+    elif features := request.features:
+        mm_placeholders = rebuild_mm_placeholders(features.mm_placeholders)
+
+        # Deserialize tensor data when present; None means an encoder-cache hit.
+        mm_kwargs = {}
+        if features.kwargs_data is not None:
+            for modality, items in features.kwargs_data.items():
+                mm_kwargs[modality] = [decode_mm_kwargs_item(item) if item is not None else None for item in items]
+        else:
+            for modality, hashes in features.mm_hashes.items():
+                mm_kwargs[modality] = [None] * len(hashes)
+
+        engine_input = mm_input(
+            prompt_token_ids=request.token_ids,
+            mm_kwargs=MultiModalKwargsItems(mm_kwargs),
+            mm_hashes=features.mm_hashes,
+            mm_placeholders=mm_placeholders,
+            cache_salt=request.cache_salt,
+        )
+    else:
+        (engine_input,) = await self.online_renderer.preprocess_completion(
+            request, prompt_input=request.token_ids, prompt_embeds=None, skip_mm_cache=True
+        )
+
+    # Retain upstream defaults, logging, routing and response generators.
+    if not request.is_sampling_param_provided("max_tokens"):
+        sampling_params.max_tokens = get_max_tokens(
+            max_model_len=self.model_config.max_model_len,
+            max_tokens=None,
+            input_length=self._extract_prompt_len(engine_input),
+            default_sampling_params=self.default_sampling_params,
+            override_max_tokens=self.override_max_tokens,
+        )
+
+    if self.force_no_detokenize:
+        sampling_params.detokenize = False
+    if request.stream:
+        sampling_params.output_kind = RequestOutputKind.DELTA
+    elif not is_v0271:
+        sampling_params.output_kind = RequestOutputKind.FINAL_ONLY
+
+    self._log_inputs(request_id, engine_input, params=sampling_params, lora_request=lora_request)
+    trace_headers = None if raw_request is None else await self._get_trace_headers(raw_request.headers)
+    data_parallel_rank = self._get_data_parallel_rank(raw_request)
+    # Session routing is not part of the v0.27.1 engine-client interface.
+    session_kwargs = {} if is_v0271 else {"session_id": self._get_session_id_from_headers(raw_request)}
+    result_generator = self.engine_client.generate(
+        engine_input,
+        sampling_params,
+        request_id,
+        lora_request=lora_request,
+        trace_headers=trace_headers,
+        priority=request.priority,
+        data_parallel_rank=data_parallel_rank,
+        **session_kwargs,
+    )
+    assert result_generator is not None
+    if request.stream:
+        return self.serve_tokens_stream_generator(request, result_generator, request_id, model_name, request_metadata)
+    return await self.serve_tokens_full_generator(request, result_generator, request_id, model_name, request_metadata)
 
 
 def install_mm_placeholder_mask_patch() -> None:
@@ -87,4 +203,4 @@ def install_mm_placeholder_mask_patch() -> None:
         serving._extract_mm_features = staticmethod(
             _wrap_extract_features(serving._extract_mm_features, placeholder_type)
         )
-    ServingTokens.serve_tokens = _wrap_serve_tokens(ServingTokens.serve_tokens)
+    ServingTokens.serve_tokens = serve_tokens

--- a/vllm_ascend/patch/platform/patch_mm_placeholder_mask.py
+++ b/vllm_ascend/patch/platform/patch_mm_placeholder_mask.py
@@ -1,0 +1,90 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Compatibility backport of vllm-project/vllm#54548."""
+
+from functools import wraps
+from types import FunctionType
+
+
+def _wrap_extract_features(original, placeholder_type):
+    @wraps(original)
+    def extract(engine_input):
+        features = original(engine_input)
+        if features is None:
+            return None
+        features.mm_placeholders = {
+            modality: [
+                placeholder_type(
+                    offset=p.offset,
+                    length=p.length,
+                    is_embed=None if p.is_embed is None else p.is_embed.tolist(),
+                )
+                for p in ranges
+            ]
+            for modality, ranges in engine_input["mm_placeholders"].items()
+        }
+        return features
+
+    return extract
+
+
+def _wrap_serve_tokens(original):
+    @wraps(original)
+    async def serve(self, request, raw_request=None):
+        if request.features is None or getattr(request, "content_parts", None):
+            return await original(self, request, raw_request)
+
+        import torch
+        from vllm.multimodal.inputs import PlaceholderRange
+
+        original_mm_input = original.__globals__["mm_input"]
+
+        def mm_input(**kwargs):
+            kwargs["mm_placeholders"] = {
+                modality: [
+                    PlaceholderRange(
+                        offset=p.offset,
+                        length=p.length,
+                        is_embed=None if p.is_embed is None else torch.tensor(p.is_embed, dtype=torch.bool),
+                    )
+                    for p in ranges
+                ]
+                for modality, ranges in request.features.mm_placeholders.items()
+            }
+            return original_mm_input(**kwargs)
+
+        # Bind only this request's input builder without mutating module globals
+        # across concurrent awaits or copying the version-specific async handler.
+        scoped = FunctionType(
+            original.__code__,
+            dict(original.__globals__, mm_input=mm_input),
+            original.__name__,
+            original.__defaults__,
+            original.__closure__,
+        )
+        scoped.__kwdefaults__ = original.__kwdefaults__
+        return await scoped(self, request, raw_request)
+
+    return serve
+
+
+def install_mm_placeholder_mask_patch() -> None:
+    # Run after platform registration, not during config/plugin module imports.
+    from pydantic.fields import FieldInfo
+    from vllm.entrypoints.scale_out.derender.serving import ServingDerender
+    from vllm.entrypoints.scale_out.render.serving import ServingRender
+    from vllm.entrypoints.scale_out.token_in_token_out import protocol
+    from vllm.entrypoints.scale_out.token_in_token_out.serving import ServingTokens
+
+    placeholder_type = protocol.PlaceholderRangeInfo
+    if "is_embed" in placeholder_type.model_fields:
+        return
+
+    # Preserve class identities already imported by serving modules and routers.
+    placeholder_type.model_fields["is_embed"] = FieldInfo(annotation=list[bool] | None, default=None)
+    for model in (placeholder_type, protocol.MultiModalFeatures, protocol.GenerateRequest):
+        model.model_rebuild(force=True)
+    for serving in (ServingRender, ServingDerender):
+        serving._extract_mm_features = staticmethod(
+            _wrap_extract_features(serving._extract_mm_features, placeholder_type)
+        )
+    ServingTokens.serve_tokens = _wrap_serve_tokens(ServingTokens.serve_tokens)

--- a/vllm_ascend/platform.py
+++ b/vllm_ascend/platform.py
@@ -311,6 +311,10 @@ class NPUPlatform(Platform):
 
         register_deepseek_v4_vision_config_convertor()
 
+        from vllm_ascend.patch.platform.patch_mm_placeholder_mask import install_mm_placeholder_mask_patch
+
+        install_mm_placeholder_mask_patch()
+
         # For online serving, "ascend" quantization method is not a choice natively,
         # so we need to add "ascend" quantization method to quantization methods list
         # and the user can enable quantization using "vllm serve --quantization ascend".


### PR DESCRIPTION
### What this PR does / why we need it?

Backports the sparse multimodal placeholder-mask fix from https://github.com/vllm-project/vllm/pull/54548 (upstream author Hotragn, reviewed source head `60fe831acefe1778b99b5e0198581a3236d4c1c1`) into an Ascend compatibility patch for supported vLLM versions that do not yet carry it.

Render output currently serializes placeholder offset and length but loses `PlaceholderRange.is_embed`. For sparse placeholders, reconstructing a dense range in `/inference/v1/generate` can assign image embeddings to separator positions. A real DeepSeek V4 Vision request reproduced a 320-embedding versus 344-position shape mismatch through this route.

The patch adds the optional JSON mask field, rebuilds nested request schemas, preserves masks during render serialization, and reconstructs CPU boolean masks for token-input requests. It also covers the duplicated feature extraction in `ServingDerender`.

The serving method is a direct source backport: `rebuild_mm_placeholders` follows the upstream implementation, and its call site is applied to the supported vLLM main pin `ba07e4a48`. The three existing v0.27.1 differences (content-parts support, non-streaming output kind, and session routing) are gated explicitly. There is no `FunctionType`, `ContextVar`, source rewriting, or request-scoped module-global override. Unrelated features introduced between the supported pin and the upstream PR base are not pulled into this backport.

Installation occurs in the platform registration hook, after global/config imports and before API router construction. Versions with the native `is_embed` protocol field are left untouched. Remove this compatibility patch once all supported vLLM versions carry the upstream fix.

This PR is based directly on `main` and is independent of #15783. It does not include model-runner, operator, evaluation-helper, or local numerical-stability changes.

### Does this PR introduce _any_ user-facing change?

Yes. On affected vLLM versions, rendered multimodal features retain the optional `is_embed` mask through JSON serialization and token-input reconstruction. Dense placeholders remain supported when the mask is absent. Text-only and content-parts requests retain the supported version's preprocessing behavior.

### How was this patch tested?

- `python -m pytest -q tests/ut/patch/platform/test_mm_placeholder_mask.py`: 17 passed, 1 skipped against a clean vLLM 0.27.1 checkout (`6e448d0ea9bf3d88d898b65449ca6dc2aec170ac`, `VLLM_VERSION=0.27.1`). The skip is the content-parts test because that version has no such request field.
- 18 tests passed against the pinned vLLM main reference `ba07e4a48fc951300d97eb506217dd530583dea3` (`VLLM_VERSION=0.28.0`), using `--noconftest` to isolate this frontend suite from an unrelated missing `attention.pcp` import in the full Ascend test setup.
- Coverage includes render/derender JSON round trips, dense/sparse masks, serialized tensors and cache hits, idempotent installation, concurrent requests, text/content-parts preprocessing, FastAPI schemas, engine-client handoff, streaming/non-streaming output kind, routing, sampling validation/defaults, and generation-error isolation. Engine calls are mocked; these are frontend unit tests.
- The placeholder-builder body matches the upstream AST. The serving body was also compared with the supported pin to check that differences are limited to mask reconstruction and the explicit release compatibility branches.
- A fresh CLI process using the clean vLLM 0.27.1 checkout successfully ran `vllm serve --help`; the platform hook installed the direct serving backport, and the actual token-input router's OpenAPI schema retained `is_embed`.
- Prior real-weight token-input teacher-forcing controls returned HTTP 200 after a direct local vLLM mask fix. That is evidence for the defect/fix semantics, not a real-NPU end-to-end test of this new Ascend compatibility wrapper. The wrapper itself has the frontend/handler checks above; no full-model numerical or performance sign-off is claimed.
- Formatting and local hooks passed with gitleaks skipped because its downloaded binary cannot execute on this ARM64 host (`Exec format error`), and actionlint skipped because no workflow files changed. Remote CI remains the merge gate.

- vLLM main: https://github.com/vllm-project/vllm/commit/ba07e4a48fc951300d97eb506217dd530583dea3
