### PR TITLE
[Performance][MRV2] Skip identity EAGLE3 vocab remapping

### DIFF
--- a/vllm_ascend/worker/v2/spec_decode/autoregressive/speculator.py
+++ b/vllm_ascend/worker/v2/spec_decode/autoregressive/speculator.py
@@ -135,6 +135,29 @@ class AscendAutoRegressiveSpeculator(AutoRegressiveSpeculator):
             parallel_config=parallel_config,
         )
 
+    # TODO: Remove this method once vllm-project/vllm#53458 or an
+    # equivalent upstream fix is merged.
+    def _maybe_remove_d2t(self, draft_model: torch.nn.Module) -> None:
+        """Drop the identity d2t mapping of a full-vocab EAGLE3 draft."""
+        if self.method != "eagle3":
+            return
+        target_vocab_size = self.draft_model_config.get_vocab_size()
+        draft_vocab_size = draft_model.config.draft_vocab_size
+        if draft_vocab_size == target_vocab_size:
+            draft_model.draft_id_to_target_id = None
+
+    def load_draft_model(
+        self,
+        target_model: torch.nn.Module,
+        target_attn_layer_names: set[str],
+    ) -> torch.nn.Module:
+        draft_model = super().load_draft_model(
+            target_model,
+            target_attn_layer_names,
+        )
+        self._maybe_remove_d2t(draft_model)
+        return draft_model
+
     @property
     def draft_prefill_attn_groups(self) -> list[list[AttentionGroup]]:
         if self.replicated_pcp:


### PR DESCRIPTION
### What this PR does / why we need it?

For full-vocabulary EAGLE3 draft models, `draft_vocab_size` equals the target vocabulary size and the draft-to-target mapping is identity. Model Runner V2 currently retains the zero-initialized `draft_id_to_target_id` parameter when the checkpoint has no `d2t` weight. As a result, every draft step allocates a target-vocabulary logits tensor and scatters logits back to the same token IDs.

This PR drops the identity mapping after loading a full-vocabulary EAGLE3 draft model, allowing `compute_logits()` to return the original logits directly. This is consistent with the existing V1 `_maybe_remove_d2t()` behavior introduced in [vllm-project/vllm-ascend#14738](https://github.com/vllm-project/vllm-ascend/pull/14738) and with the equivalent upstream optimization proposed in [vllm-project/vllm#53458](https://github.com/vllm-project/vllm/pull/53458).

### Does this PR introduce _any_ user-facing change?

N/A

### How was this patch tested?

```
================= V2 BEFORE FIX ==================     | ================== V2 AFTER FIX ==================     | ================== V1 BASELINE ===================
Successful requests:                     100           | Successful requests:                     100           | Successful requests:                     100
Failed requests:                         0             | Failed requests:                         0             | Failed requests:                         0
Maximum request concurrency:             4             | Maximum request concurrency:             4             | Maximum request concurrency:             4
Benchmark duration (s):                  72.31         | Benchmark duration (s):                  67.41         | Benchmark duration (s):                  67.65
Total input tokens:                      13218         | Total input tokens:                      13218         | Total input tokens:                      13218
Total generated tokens:                  25600         | Total generated tokens:                  25600         | Total generated tokens:                  25600
Request throughput (req/s):              1.38          | Request throughput (req/s):              1.48          | Request throughput (req/s):              1.48
Output token throughput (tok/s):         354.05        | Output token throughput (tok/s):         379.78        | Output token throughput (tok/s):         378.41
Peak output token throughput (tok/s):    140.00        | Peak output token throughput (tok/s):    157.00        | Peak output token throughput (tok/s):    156.00
Peak concurrent requests:                8.00          | Peak concurrent requests:                8.00          | Peak concurrent requests:                7.00
Total token throughput (tok/s):          536.86        | Total token throughput (tok/s):          575.87        | Total token throughput (tok/s):          573.80
---------------Time to First Token----------------     | ---------------Time to First Token----------------     | ---------------Time to First Token----------------
Mean TTFT (ms):                          223.47        | Mean TTFT (ms):                          211.41        | Mean TTFT (ms):                          202.54
Median TTFT (ms):                        198.40        | Median TTFT (ms):                        194.57        | Median TTFT (ms):                        196.01
P99 TTFT (ms):                           430.61        | P99 TTFT (ms):                           328.77        | P99 TTFT (ms):                           323.29
-----Time per Output Token (excl. 1st token)------     | -----Time per Output Token (excl. 1st token)------     | -----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          10.30         | Mean TPOT (ms):                          9.64          | Mean TPOT (ms):                          9.71
Median TPOT (ms):                        10.27         | Median TPOT (ms):                        9.58          | Median TPOT (ms):                        9.63
P99 TPOT (ms):                           11.94         | P99 TPOT (ms):                           11.79         | P99 TPOT (ms):                           11.30
---------------Inter-token Latency----------------     | ---------------Inter-token Latency----------------     | ---------------Inter-token Latency----------------
Mean ITL (ms):                           32.47         | Mean ITL (ms):                           30.25         | Mean ITL (ms):                           30.48
Median ITL (ms):                         28.81         | Median ITL (ms):                         25.65         | Median ITL (ms):                         25.96
P99 ITL (ms):                            142.62        | P99 ITL (ms):                            144.77        | P99 ITL (ms):                            146.82
---------------Speculative Decoding---------------     | ---------------Speculative Decoding---------------     | ---------------Speculative Decoding---------------
Acceptance rate (%):                     71.59         | Acceptance rate (%):                     70.57         | Acceptance rate (%):                     71.31
Acceptance length:                       3.15          | Acceptance length:                       3.12          | Acceptance length:                       3.14
Drafts:                                  8135          | Drafts:                                  8224          | Drafts:                                  8160
Draft tokens:                            24405         | Draft tokens:                            24672         | Draft tokens:                            24480
Accepted tokens:                         17471         | Accepted tokens:                         17412         | Accepted tokens:                         17456
Per-position acceptance (%):                           | Per-position acceptance (%):                           | Per-position acceptance (%):
  Position 0:                            86.63         |   Position 0:                            86.43         |   Position 0:                            86.63
  Position 1:                            70.95         |   Position 1:                            69.66         |   Position 1:                            70.66
  Position 2:                            57.19         |   Position 2:                            55.63         |   Position 2:                            56.63
==================================================     | ==================================================     | ==================================================

```


- vLLM main: https://github.com/vllm-project/vllm/commit/e6bfe03ad73a3330cb427885aa90d97a12e1c704
