### PR TITLE
[BugFix][MRV2][Spec Decode] Support draft enforce_eager in MRV2

### DIFF
--- a/vllm_ascend/worker/v2/spec_decode/autoregressive/speculator.py
+++ b/vllm_ascend/worker/v2/spec_decode/autoregressive/speculator.py
@@ -185,6 +185,8 @@ class AscendAutoRegressiveSpeculator(AutoRegressiveSpeculator):
         return attn_metadata, slot_mappings
 
     def init_cudagraph_manager(self, cudagraph_mode: CUDAGraphMode) -> None:
+        if self.speculative_config.enforce_eager:
+            cudagraph_mode = CUDAGraphMode.NONE
         super().init_cudagraph_manager(cudagraph_mode)
         # The Ascend graph managers are patched onto the upstream module and
         # created by super().init_cudagraph_manager without a speculator ref.

--- a/vllm_ascend/worker/v2/spec_decode/dflash/speculator.py
+++ b/vllm_ascend/worker/v2/spec_decode/dflash/speculator.py
@@ -58,6 +58,8 @@ class AscendDFlashSpeculator(DFlashSpeculator):
         super().__init__(vllm_config, device)
 
     def init_cudagraph_manager(self, cudagraph_mode: CUDAGraphMode) -> None:
+        if self.speculative_config.enforce_eager:
+            cudagraph_mode = CUDAGraphMode.NONE
         super().init_cudagraph_manager(cudagraph_mode)
         # The Ascend graph manager is patched onto the upstream module and
         # created by super().init_cudagraph_manager without a speculator ref.

--- a/vllm_ascend/worker/v2/spec_decode/dspark/speculator.py
+++ b/vllm_ascend/worker/v2/spec_decode/dspark/speculator.py
@@ -66,6 +66,8 @@ class AscendDSparkSpeculator(DSparkSpeculator):
         return model
 
     def init_cudagraph_manager(self, cudagraph_mode: CUDAGraphMode) -> None:
+        if self.speculative_config.enforce_eager:
+            cudagraph_mode = CUDAGraphMode.NONE
         super().init_cudagraph_manager(cudagraph_mode)
         # The Ascend graph manager is patched onto the upstream module and
         # created by super().init_cudagraph_manager without a speculator ref.


### PR DESCRIPTION
### What this PR does / why we need it?

MRV2 initializes speculative draft graph managers with the target model's resolved graph mode, but it does not honor `speculative_config.enforce_eager`. As a result, setting `enforce_eager=true` still captures and replays draft graphs when the target model uses ACLGraph.

This patch forces only the draft graph mode to `NONE` when `speculative_config.enforce_eager` is enabled. The target model's graph mode remains unchanged. The behavior is applied to:

- EAGLE/EAGLE3 and MTP through `AscendAutoRegressiveSpeculator`
- DFlash
- DSpark

### Does this PR introduce _any_ user-facing change?

Yes. Under MRV2, `speculative_config.enforce_eager=true` now keeps the speculative draft model in eager mode while allowing the target model to continue using ACLGraph. Omitting the option, or setting it to `false`, preserves the existing behavior.

### How was this patch tested?


- vLLM main: https://github.com/vllm-project/vllm/commit/e6bfe03ad73a3330cb427885aa90d97a12e1c704
