### PR TITLE
[BugFix][CI] Update DeepSeek-V2-Lite DP2+PP2 golden after MoE routing weight dtype change

### DIFF
--- a/tests/e2e/pull_request/four_card/test_pipeline_parallel.py
+++ b/tests/e2e/pull_request/four_card/test_pipeline_parallel.py
@@ -94,6 +94,65 @@ GOLDEN = [
     ),
 ]
 
+# After #15299, routing weights are preserved without intermediate dtype
+# casts, which deterministically changes greedy decoding for the DP2+PP2
+# path of DeepSeek-V2-Lite-Chat. Keep a separate baseline so the TP2+PP2
+# golden above stays unaffected.
+DP_GOLDEN = [
+    (
+        [
+            17464,
+            11,
+            601,
+            1210,
+            317,
+            459,
+            6946,
+            29,
+            32,
+            1568,
+            32092,
+            535,
+            6946,
+            29,
+            285,
+            304,
+            608,
+            245,
+            459,
+            6946,
+            29,
+        ],
+        "Hello, my name is <strong>Alessandro</strong> and I am a <strong>",
+    ),
+    (
+        [
+            549,
+            3680,
+            280,
+            20838,
+            317,
+            6464,
+            11,
+            285,
+            359,
+            487,
+            82,
+            1872,
+            276,
+            330,
+            245,
+            2624,
+            12,
+            73309,
+            279,
+            254,
+            1843,
+        ],
+        "The future of AI is bright, and it’s going to be a game-changer in the world",
+    ),
+]
+
 
 @pytest.mark.parametrize("model", MODELS)
 @pytest.mark.parametrize("tp_size", TENSOR_PARALLELS)
@@ -142,7 +201,7 @@ def test_models_pp2_dp2(model: str, dp_size: int, pp_size: int, distributed_exec
         outputs = vllm_model.generate_greedy(prompts, 16)
         check_outputs_equal(
             outputs_0_lst=outputs,
-            outputs_1_lst=GOLDEN,
+            outputs_1_lst=DP_GOLDEN,
             name_0=f"{model}-dp{dp_size}pp{pp_size}",
             name_1="GOLDEN",
         )


### PR DESCRIPTION
## Issue
`test_models_pp2_dp2[mp/ray-2-2-deepseek-ai/DeepSeek-V2-Lite-Chat]` in `tests/e2e/pull_request/four_card/test_pipeline_parallel.py` fails deterministically on current main snapshot (`c1bb35f`), e.g. in #15846 (two runs, identical diff).

## Root cause
#15299 removed intermediate dtype casts for MoE top-k routing weights (touched `vllm_ascend/ops/fused_moe/token_dispatcher.py` among others). This deterministically shifts numerics on the **DP2+PP2** path of DeepSeek-V2-Lite-Chat: greedy decoding now emits `I am a` (token `608`) instead of `I'm a` (tokens `6, 76`). The TP2+PP2 path is unaffected and still matches the existing golden.

#15299 updated the goldens it knew about (`test_graph_mode.py`), but its CI run did not select `test_pipeline_parallel.py`, so this baseline was missed.

## What this PR does
- introduce a separate `DP_GOLDEN` for the DP2+PP2 test case (prompt 0 updated to the new deterministic output, observed identically across mp/ray backends and repeated runs)
- keep the shared `GOLDEN` untouched for TP2+PP2

## Notes
Prompt 1's DP2 output was not observable in the failure logs (the assert fires on prompt 0 first), so its entry currently keeps the shared value; if CI reports a drift there it can be updated in one line.
- vLLM main: https://github.com/vllm-project/vllm/commit/ba07e4a48fc951300d97eb506217dd530583dea3
