### PR TITLE
[BugFix][MoE] Avoid pre-AllGather W8A8 quantization on A3

### DIFF
--- a/tests/ut/device/test_hardware_profile.py
+++ b/tests/ut/device/test_hardware_profile.py
@@ -45,7 +45,11 @@ _STANDARD_CAPABILITIES = frozenset(
 )
 
 _EXPECTED_CAPABILITIES = {
-    AscendDeviceType.A2: _STANDARD_CAPABILITIES | {HardwareCapability.NPU_TOP_K_TOP_P},
+    AscendDeviceType.A2: _STANDARD_CAPABILITIES
+    | {
+        HardwareCapability.MOE_PRE_ALLGATHER_W8A8_QUANTIZATION,
+        HardwareCapability.NPU_TOP_K_TOP_P,
+    },
     AscendDeviceType.A3: _STANDARD_CAPABILITIES
     | {
         HardwareCapability.CANN_MEGAMOE,
@@ -61,6 +65,7 @@ _EXPECTED_CAPABILITIES = {
             HardwareCapability.FUSED_SWIGLU_TUNING_ARGS,
             HardwareCapability.GDN_COMPATIBILITY,
             HardwareCapability.IRQ_CPU_RESERVATION,
+            HardwareCapability.MOE_PRE_ALLGATHER_W8A8_QUANTIZATION,
             HardwareCapability.RC_DEVICE_DISCOVERY,
             HardwareCapability.RUNTIME_CUSTOM_OPS,
         }
@@ -84,6 +89,7 @@ _EXPECTED_CAPABILITIES = {
             HardwareCapability.MLAPO_NATIVE_WEIGHTS,
             HardwareCapability.MOE_DISPATCH_EXTRA_ARGS,
             HardwareCapability.MOE_DISPATCH_SHARED_EXPERT_ARGS,
+            HardwareCapability.MOE_PRE_ALLGATHER_W8A8_QUANTIZATION,
             HardwareCapability.NPUGRAPH_EX,
             HardwareCapability.REDUCED_CUDAGRAPH_CAPTURE_SIZES,
             HardwareCapability.STANDARD_MAMBA_PATCH,

--- a/tests/ut/ops/test_prepare_finalize.py
+++ b/tests/ut/ops/test_prepare_finalize.py
@@ -5,11 +5,14 @@ import torch
 from vllm.model_executor.layers.fused_moe import FusedMoEConfig
 from vllm.model_executor.models.utils import sequence_parallel_chunk_impl
 
+from vllm_ascend.device.hardware import AscendDeviceType
+from vllm_ascend.device.hardware_profile import get_hardware_profile
 from vllm_ascend.ops.fused_moe.prepare_finalize import (
     PrepareAndFinalizeWithAll2All,
     PrepareAndFinalizeWithAllGather,
     PrepareAndFinalizeWithMC2,
 )
+from vllm_ascend.quantization.quant_type import QuantType
 
 
 class TestPrepareAndFinalize(unittest.TestCase):
@@ -247,3 +250,34 @@ class TestPrepareAndFinalize(unittest.TestCase):
 
         result_with_tp = layer.finalize(h_out, reduce_results=True)
         self.assertEqual(result_with_tp.shape[0], 3)
+
+    @patch("vllm_ascend.ops.fused_moe.prepare_finalize.get_current_hardware_profile")
+    @patch("vllm_ascend.ops.fused_moe.prepare_finalize.torch_npu.npu_dynamic_quant")
+    def test_allgather_w8a8_prequant_depends_on_hardware(self, mock_dynamic_quant, mock_hardware_profile):
+        self.moe_config.is_sequence_parallel = True
+        layer = PrepareAndFinalizeWithAllGather(self.moe_config)
+        hidden_states = torch.randn(3, 8)
+        router_logits = torch.randn(3, 2)
+        quantized_hidden_states = torch.randint(-128, 127, hidden_states.shape, dtype=torch.int8)
+        pertoken_scale = torch.rand(3)
+        mock_dynamic_quant.return_value = (quantized_hidden_states, pertoken_scale)
+
+        with patch.object(
+            torch.ops.vllm,
+            "maybe_all_gather_and_maybe_unpad",
+            side_effect=lambda tensor: tensor,
+        ):
+            mock_hardware_profile.return_value = get_hardware_profile(AscendDeviceType.A2)
+            a2_output = layer.prepare(hidden_states, router_logits, quant_type=QuantType.W8A8)
+
+            mock_dynamic_quant.assert_called_once_with(hidden_states)
+            self.assertIs(a2_output.hidden_states, quantized_hidden_states)
+            self.assertIs(a2_output.pertoken_scale, pertoken_scale)
+
+            mock_dynamic_quant.reset_mock()
+            mock_hardware_profile.return_value = get_hardware_profile(AscendDeviceType.A3)
+            a3_output = layer.prepare(hidden_states, router_logits, quant_type=QuantType.W8A8)
+
+            mock_dynamic_quant.assert_not_called()
+            self.assertIs(a3_output.hidden_states, hidden_states)
+            self.assertIsNone(a3_output.pertoken_scale)

--- a/vllm_ascend/device/hardware_profile.py
+++ b/vllm_ascend/device/hardware_profile.py
@@ -44,6 +44,7 @@ class HardwareCapability(Enum):
     MC2_HIERARCHY_COMM = auto()
     MOE_DISPATCH_EXTRA_ARGS = auto()
     MOE_DISPATCH_SHARED_EXPERT_ARGS = auto()
+    MOE_PRE_ALLGATHER_W8A8_QUANTIZATION = auto()
     NPUGRAPH_EX = auto()
     NPU_TOP_K_TOP_P = auto()
     PAGED_ATTENTION = auto()
@@ -166,7 +167,11 @@ _HARDWARE_PROFILES: Mapping[AscendDeviceType, HardwareProfile] = MappingProxyTyp
             weight_layout_policy=WeightLayoutPolicy.CONFIGURABLE,
             moe_comm_policy=MoECommPolicy.CAPACITY_AND_EXPERT_DENSITY,
             quantization_backend_family=QuantizationBackendFamily.STANDARD,
-            capabilities=_STANDARD_CAPABILITIES | {HardwareCapability.NPU_TOP_K_TOP_P},
+            capabilities=_STANDARD_CAPABILITIES
+            | {
+                HardwareCapability.MOE_PRE_ALLGATHER_W8A8_QUANTIZATION,
+                HardwareCapability.NPU_TOP_K_TOP_P,
+            },
         ),
         AscendDeviceType.A3: HardwareProfile(
             _device_type=AscendDeviceType.A3,
@@ -203,6 +208,7 @@ _HARDWARE_PROFILES: Mapping[AscendDeviceType, HardwareProfile] = MappingProxyTyp
                     HardwareCapability.FUSED_SWIGLU_TUNING_ARGS,
                     HardwareCapability.GDN_COMPATIBILITY,
                     HardwareCapability.IRQ_CPU_RESERVATION,
+                    HardwareCapability.MOE_PRE_ALLGATHER_W8A8_QUANTIZATION,
                     HardwareCapability.RC_DEVICE_DISCOVERY,
                     HardwareCapability.RUNTIME_CUSTOM_OPS,
                 }
@@ -237,6 +243,7 @@ _HARDWARE_PROFILES: Mapping[AscendDeviceType, HardwareProfile] = MappingProxyTyp
                     HardwareCapability.MLAPO_NATIVE_WEIGHTS,
                     HardwareCapability.MOE_DISPATCH_EXTRA_ARGS,
                     HardwareCapability.MOE_DISPATCH_SHARED_EXPERT_ARGS,
+                    HardwareCapability.MOE_PRE_ALLGATHER_W8A8_QUANTIZATION,
                     HardwareCapability.NPUGRAPH_EX,
                     HardwareCapability.REDUCED_CUDAGRAPH_CAPTURE_SIZES,
                     HardwareCapability.STANDARD_MAMBA_PATCH,

--- a/vllm_ascend/ops/fused_moe/prepare_finalize.py
+++ b/vllm_ascend/ops/fused_moe/prepare_finalize.py
@@ -30,6 +30,7 @@ from vllm.model_executor.layers.fused_moe import FusedMoEConfig
 from vllm.model_executor.models.utils import sequence_parallel_chunk
 
 from vllm_ascend.ascend_forward_context import _EXTRA_CTX
+from vllm_ascend.device.hardware_profile import HardwareCapability, get_current_hardware_profile
 from vllm_ascend.lora.fused_moe import prepare_lora_indices
 from vllm_ascend.ops.fused_moe.dataclass.prepare_finalize import MoEPrepareOutput
 from vllm_ascend.quantization.quant_type import QuantType
@@ -401,7 +402,11 @@ class PrepareAndFinalizeWithAllGather(PrepareAndFinalize):
         self, hidden_states: torch.Tensor, router_logits: torch.Tensor, quant_type=QuantType.NONE
     ) -> MoEPrepareOutput:
         pertoken_scale = None
-        if quant_type == QuantType.W8A8:
+        # A3 routing must receive BF16 input and quantize after AllGather.
+        # Pre-quantized INT8 input can corrupt subsequent MoE computation.
+        if quant_type == QuantType.W8A8 and get_current_hardware_profile().supports(
+            HardwareCapability.MOE_PRE_ALLGATHER_W8A8_QUANTIZATION
+        ):
             hidden_states, pertoken_scale = torch_npu.npu_dynamic_quant(hidden_states)
         elif quant_type in (QuantType.W8A8MXFP, QuantType.W4A8MXFP):
             hidden_states, pertoken_scale = torch_npu.npu_dynamic_mx_quant(


### PR DESCRIPTION
### What this PR does / why we need it?

On Ascend A3, the AllGather + sequence-parallel W8A8 path currently quantizes each rank's hidden states before EP AllGather, then calls MoE routing with an INT8 tensor, per-token scales, and `quant_mode=-1`. In DeepSeek-V4 W8A8 validation this path can corrupt subsequent MoE computation and produce garbled output.

This PR keeps A3 hidden states in BF16 through EP AllGather. MoE routing then performs dynamic quantization internally with `quant_mode=1`. The existing pre-AllGather W8A8 communication optimization remains enabled for A2, A5, and 310P through a hardware capability, and the MXFP8/MXFP4 paths are unchanged.

The A3 fallback increases the gathered activation payload from INT8 to BF16, but correctness takes priority until the pre-quantized routing path is safe on A3.

### Does this PR introduce _any_ user-facing change?

No API or configuration change. A3 AllGather W8A8 inference uses the safe BF16-gather path instead of pre-gather INT8 quantization.

### How was this patch tested?

- Unit tests:
  - `python -m pytest -q tests/ut/device/test_hardware_profile.py tests/ut/ops/test_prepare_finalize.py`
  - Result: `19 passed`
- Lint and format:
  - `uvx ruff@0.14.0 check vllm_ascend/device/hardware_profile.py vllm_ascend/ops/fused_moe/prepare_finalize.py tests/ut/device/test_hardware_profile.py tests/ut/ops/test_prepare_finalize.py`
  - `uvx ruff@0.14.0 format --check vllm_ascend/device/hardware_profile.py vllm_ascend/ops/fused_moe/prepare_finalize.py tests/ut/device/test_hardware_profile.py tests/ut/ops/test_prepare_finalize.py`
  - Result: passed
- A3 manual validation:
  - Model: DeepSeek-V4-Flash-w8a8-mtp
  - Topology: TP8, DP2, EP16, sequence parallel, AllGather/ReduceScatter, eager mode
  - Original pre-quantized path produced garbled output.
  - Gathering BF16 and letting routing quantize internally produced correct deterministic responses in repeated runs.
  - Additional isolation showed that AllGather of INT8 + scale was numerically correct, while invoking the A3 pre-quantized routing path could trigger corruption even when its returned tensors were discarded.

A full rerun against the latest main source is currently blocked on the validation image before MoE execution because its CANN `libopapi.so` does not provide `aclnnHcPre`. The targeted tests and the A3 isolation experiments use the same fix logic and hardware.

- vLLM main: https://github.com/vllm-project/vllm/commit/e6bfe03ad73a3330cb427885aa90d97a12e1c704
