### PR TITLE
[BugFix] Fix duplicate SFA-CP prefill output reduction

### DIFF
--- a/tests/e2e/pull_request/four_card/context_parallel/test_sfa_cp_sp.py
+++ b/tests/e2e/pull_request/four_card/context_parallel/test_sfa_cp_sp.py
@@ -1,0 +1,69 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import os
+from unittest.mock import patch
+
+import pytest
+from vllm import SamplingParams
+
+from tests.e2e.conftest import DPVllmRunner, wait_until_npu_memory_free
+
+SFA_CP_MODEL = os.environ.get("SFA_CP_TEST_MODEL", "vllm-ascend/DeepSeek-V3.2-W8A8-Pruning")
+
+
+@pytest.mark.e2e_model(SFA_CP_MODEL)
+@pytest.mark.e2e_coverage(
+    arch="moe",
+    feature="dsa_cp",
+    parallel="TP,DP,EP",
+    deploy="pd_mix",
+    hardware="A3",
+    quantization="W8A8",
+    graph_mode="eager,full_decode_only",
+)
+@patch.dict(
+    os.environ,
+    {
+        "HCCL_BUFFSIZE": "768",
+        "PYTORCH_NPU_ALLOC_CONF": "expandable_segments:True",
+    },
+)
+@wait_until_npu_memory_free(target_free_percentage=0.8)
+@pytest.mark.parametrize("runner_version", ["0", "1"])
+@pytest.mark.parametrize("enforce_eager", [True, False], ids=["eager", "full_decode"])
+def test_sfa_cp_sp_prefill_decode_accuracy(
+    runner_version: str, enforce_eager: bool, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("VLLM_USE_V2_MODEL_RUNNER", runner_version)
+    prompt_lengths = [1, 3, 4095, 4096, 4097]
+    generated_tokens: dict[bool, list[list[int]]] = {}
+    for enable_dsa_cp in (False, True):
+        mode_tokens = []
+        with DPVllmRunner(
+            SFA_CP_MODEL,
+            max_model_len=8192,
+            max_num_seqs=4,
+            max_num_batched_tokens=8192,
+            dtype="auto",
+            data_parallel_size=2,
+            tensor_parallel_size=2,
+            enable_expert_parallel=True,
+            gpu_memory_utilization=0.9,
+            quantization="ascend",
+            block_size=128,
+            enforce_eager=enforce_eager,
+            compilation_config={"cudagraph_mode": "FULL_DECODE_ONLY", "cudagraph_capture_sizes": [4]},
+            additional_config={"enable_dsa_cp": enable_dsa_cp, "enable_flashcomm1": True},
+        ) as runner:
+            for prompt_length in prompt_lengths:
+                prompt_tokens = [(index % 1000) + 100 for index in range(prompt_length)]
+                outputs = runner.generate(
+                    [prompt_tokens], SamplingParams(temperature=0.0, max_tokens=8, ignore_eos=True)
+                )
+                output_ids = outputs[0][0][0]
+                assert output_ids[:prompt_length] == prompt_tokens
+                assert len(output_ids) == prompt_length + 8
+                mode_tokens.append(output_ids[prompt_length:])
+        generated_tokens[enable_dsa_cp] = mode_tokens
+    assert generated_tokens[True] == generated_tokens[False]

--- a/tests/ut/attention/test_cp_output_reduction.py
+++ b/tests/ut/attention/test_cp_output_reduction.py
@@ -1,0 +1,73 @@
+# SPDX-License-Identifier: Apache-2.0
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+import torch
+
+from vllm_ascend.attention.context_parallel.common_cp import write_cp_output
+from vllm_ascend.attention.context_parallel.sfa_cp import AscendSFADSACPImpl
+from vllm_ascend.quantization.tp_weight_switch import TPWeightSwitchMixin
+
+
+@pytest.mark.parametrize("tp_size", [2, 4, 16])
+@pytest.mark.parametrize("num_tokens", [1, 3, 16, 17])
+@pytest.mark.parametrize("reduce_results", [False, True])
+def test_sfa_cp_full_weight_output_matches_decoder_contract(
+    tp_size: int, num_tokens: int, reduce_results: bool
+) -> None:
+    expected = torch.arange(num_tokens * 4, dtype=torch.float32).reshape(num_tokens, 4) + 1
+    padded = torch.nn.functional.pad(expected, (0, 0, 0, -num_tokens % tp_size))
+    rank_outputs = []
+    for rank, local_output in enumerate(padded.chunk(tp_size)):
+        group = SimpleNamespace(rank_in_group=rank, all_gather=MagicMock(return_value=padded))
+        method = MagicMock(spec=TPWeightSwitchMixin)
+        impl = AscendSFADSACPImpl.__new__(AscendSFADSACPImpl)
+        impl.enable_dsa_cp_with_o_proj_tp = True
+        impl.o_proj = SimpleNamespace(reduce_results=reduce_results)
+        impl.o_proj_tp_weight_state = object()
+        impl._get_o_proj_linear_method = MagicMock(return_value=method)
+        impl._apply_o_proj_full_weight = MagicMock(return_value=local_output)
+        output = torch.full_like(expected, float("nan"))
+        with patch("vllm_ascend.attention.context_parallel.common_cp.get_tp_group", return_value=group):
+            actual = impl._finalize_o_proj(local_output, output, gather_full_o_proj=True)
+        assert actual is output
+        assert method.switch_tp_weight.call_args.kwargs["use_full_weight"] is False
+        if reduce_results:
+            torch.testing.assert_close(output, expected)
+            group.all_gather.assert_called_once()
+        else:
+            group.all_gather.assert_not_called()
+        rank_outputs.append(torch.nn.functional.pad(output, (0, 0, 0, -num_tokens % tp_size)))
+
+    if not reduce_results:
+        # Model the upstream SUM followed by token scatter, including empty ranks.
+        reduced = torch.stack(rank_outputs).sum(0)
+        residual = padded * 0.25
+        for actual, reference, local_residual in zip(
+            reduced.chunk(tp_size), padded.chunk(tp_size), residual.chunk(tp_size)
+        ):
+            torch.testing.assert_close(actual + local_residual, reference + local_residual)
+
+
+def test_cp_output_reused_buffer_clears_other_ranks_tokens() -> None:
+    group = SimpleNamespace(rank_in_group=1)
+    output = torch.full((5, 2), 100.0)
+    with patch("vllm_ascend.attention.context_parallel.common_cp.get_tp_group", return_value=group):
+        write_cp_output(torch.ones(3, 2), output, reduce_results=False)
+        torch.testing.assert_close(output[:3], torch.zeros(3, 2))
+        torch.testing.assert_close(output[3:], torch.ones(2, 2))
+
+
+def test_sfa_cp_restores_tp_weight_when_projection_fails() -> None:
+    impl = AscendSFADSACPImpl.__new__(AscendSFADSACPImpl)
+    impl.enable_dsa_cp_with_o_proj_tp = True
+    impl.o_proj = SimpleNamespace(reduce_results=False)
+    impl.o_proj_tp_weight_state = object()
+    method = MagicMock(spec=TPWeightSwitchMixin)
+    impl._get_o_proj_linear_method = MagicMock(return_value=method)
+    impl._apply_o_proj_full_weight = MagicMock(side_effect=RuntimeError("projection failed"))
+    with pytest.raises(RuntimeError, match="projection failed"):
+        impl._finalize_o_proj(torch.ones(2, 2), torch.empty(4, 2), True)
+    assert method.switch_tp_weight.call_args.kwargs["use_full_weight"] is False

--- a/tests/ut/attention/test_sfa_o_proj_tp.py
+++ b/tests/ut/attention/test_sfa_o_proj_tp.py
@@ -54,6 +54,8 @@ class TestAscendSFAOProjTPParams(TestBase):
             self.weight = torch.nn.Parameter(torch.randn(4, 3), requires_grad=False)
             self.weight_scale = torch.nn.Parameter(torch.randn(2, 3), requires_grad=False)
             self.quant_method = linear_method
+            # Mirror RowParallelLinear default: full-weight path gathers output.
+            self.reduce_results = True
 
     def setUp(self):
         AscendSFADSACPImpl.o_proj_full_pools.clear()

--- a/tests/ut/attention/test_sfa_o_proj_tp.py
+++ b/tests/ut/attention/test_sfa_o_proj_tp.py
@@ -105,7 +105,18 @@ class TestAscendSFAOProjTPParams(TestBase):
         impl.enable_dsa_cp_with_o_proj_tp = True
         gathered_output = torch.cat((torch.ones(2, 3), torch.full((2, 3), 2.0)))
         tp_group = SimpleNamespace(all_gather=MagicMock(return_value=gathered_output))
-        with patch("vllm_ascend.attention.context_parallel.sfa_cp.get_tp_group", return_value=tp_group):
+        # _finalize_o_proj gathers via common_cp.write_cp_output, which binds
+        # its own get_tp_group reference: patch both namespaces.
+        with (
+            patch(
+                "vllm_ascend.attention.context_parallel.sfa_cp.get_tp_group",
+                return_value=tp_group,
+            ),
+            patch(
+                "vllm_ascend.attention.context_parallel.common_cp.get_tp_group",
+                return_value=tp_group,
+            ),
+        ):
             output = impl._finalize_o_proj(
                 attn_output=torch.randn(2, 8),
                 output=torch.empty(3, 3),

--- a/vllm_ascend/attention/context_parallel/common_cp.py
+++ b/vllm_ascend/attention/context_parallel/common_cp.py
@@ -3,9 +3,26 @@ from typing import Any
 import torch
 import torch.distributed as dist
 import torch_npu
-from vllm.distributed import get_dcp_group
+from vllm.distributed import get_dcp_group, get_tp_group
 
 from vllm_ascend.distributed.utils import get_decode_context_model_parallel_world_size
+
+
+def write_cp_output(
+    local_output: torch.Tensor,
+    output: torch.Tensor,
+    reduce_results: bool,
+) -> None:
+    """Return complete tokens or disjoint contributions for the caller's TP sum."""
+    tp_group = get_tp_group()
+    if reduce_results:
+        full_output = tp_group.all_gather(local_output.contiguous(), dim=0)
+        output.copy_(full_output[: output.shape[0]])
+    else:
+        output.zero_()
+        start = tp_group.rank_in_group * local_output.shape[0]
+        count = max(0, min(local_output.shape[0], output.shape[0] - start))
+        output[start : start + count].copy_(local_output[:count])
 
 
 def get_dcp_local_seq_lens(

--- a/vllm_ascend/attention/context_parallel/sfa_cp.py
+++ b/vllm_ascend/attention/context_parallel/sfa_cp.py
@@ -17,6 +17,7 @@ from vllm_ascend.attention.context_parallel.common_cp import (
     DCPImplMixin,
     DCPMetadataBuilderMixin,
     get_dcp_local_seq_lens,
+    write_cp_output,
 )
 from vllm_ascend.attention.sfa_v1 import (
     AscendSFAImpl,
@@ -528,14 +529,7 @@ class AscendSFADSACPImpl(AscendSFAImpl):
             )
             try:
                 local_output = self._apply_o_proj_full_weight(attn_output)
-                full_output = get_tp_group().all_gather(local_output.contiguous(), dim=0)
-                if full_output.shape[0] < output.shape[0] or full_output.shape[1:] != output.shape[1:]:
-                    raise RuntimeError(
-                        "SFA DSA-CP gathered output does not match the replicated "
-                        f"model state, got {tuple(full_output.shape)} and expected "
-                        f"{tuple(output.shape)}."
-                    )
-                output[...] = full_output[: output.shape[0]]
+                write_cp_output(local_output, output, self.o_proj.reduce_results)
             finally:
                 linear_method.switch_tp_weight(
                     self.o_proj,


### PR DESCRIPTION
### What this PR does / why we need it?
This PR is independently based on the latest `main` and fixes the V3.2 SFA-CP full-weight prefill output being summed again by the upstream sequence-parallel decoder. After upstream MoE SP was introduced by `#13946`, the decoder applies SUM reduce-scatter to attention output. SFA-CP full-weight prefill already produces the same complete output on every TP rank, so passing it to that SUM scales it by TP size and changes the attention/residual balance.

The fix follows `o_proj.reduce_results`: when the caller performs the outer reduction, clear the full-shaped output buffer and write only this rank's token interval; otherwise retain all-gather for a complete output. Decode, DeepSeek V4/DSA-CP, V2 metadata, SFA-DCP, and MLA-CP communication paths are outside this PR.

### Does this PR introduce _any_ user-facing change?

No API change. SFA-CP sequence-parallel prefill now returns the output layout expected by the upstream decoder, restoring numerical behavior.

### How was this patch tested?

- Added unit coverage for TP sizes 2/4/16, token counts 1/3/16/17, both `reduce_results` modes, output-buffer reuse, and TP weight restoration on projection failure.
- Added a four-card V3.2 E2E matrix covering V1/V2 runners and eager/FULL_DECODE_ONLY, with CP on/off comparison while SP remains enabled. Prompt lengths are 1/3/4095/4096/4097 and each request generates eight tokens.
- Local static validation passed: `ruff-check`, `ruff-format`, `markdownlint`, Python AST parsing, and `git diff --check`.

- vLLM main: https://github.com/vllm-project/vllm/commit/ba07e4a48fc951300d97eb506217dd530583dea3
