### PR TITLE
[v0.27.1rc][BugFix][SpecDecode] Keep DSpark draft pointers in bounds

### DIFF
--- a/tests/e2e/nightly/single_node/ops/singlecard_ops/triton/test_copy_and_expand_dflash_dspark.py
+++ b/tests/e2e/nightly/single_node/ops/singlecard_ops/triton/test_copy_and_expand_dflash_dspark.py
@@ -94,25 +94,37 @@ def copy_and_expand_dflash_dspark_ref(
     }
 
 
-# (batch_size, ctx_lens, num_spec, sample_from_anchor, has_num_rejected)
+# (batch_size, ctx_lens, num_spec, sample_from_anchor,
+#  has_num_rejected, check_request_window)
 CONFIGS = [
-    (1, [4], 3, False, False),
+    (1, [4], 3, False, False, False),
     # Regression for a partial query tile: inactive lanes must not construct
-    # out-of-range request or token pointers before their memory masks apply.
-    (29, [4] * 29, 3, True, False),
-    (64, [4] * 64, 3, False, False),
-    (256, [4] * 256, 3, False, False),
-    (1, [2048], 3, False, False),
-    (4, [1024] * 4, 3, False, False),
-    (8, [512] * 8, 3, False, False),
-    (64, [4] * 64, 3, True, False),
-    (64, [4] * 64, 3, False, True),
-    (8, [512] * 8, 3, True, True),
+    # out-of-range pointers. Block ID zero is a valid allocation and must pass
+    # the request-window guard rather than being treated as a padding sentinel.
+    (29, [4] * 29, 3, True, False, True),
+    (64, [4] * 64, 3, False, False, False),
+    (256, [4] * 256, 3, False, False, False),
+    (1, [2048], 3, False, False, False),
+    (4, [1024] * 4, 3, False, False, False),
+    (8, [512] * 8, 3, False, False, False),
+    (64, [4] * 64, 3, True, False, False),
+    (64, [4] * 64, 3, False, True, False),
+    (8, [512] * 8, 3, True, True, False),
 ]
 
 
-@pytest.mark.parametrize("batch_size,ctx_lens,num_spec,sample_from_anchor,has_num_rejected", CONFIGS)
-def test_copy_and_expand_dflash_dspark(batch_size, ctx_lens, num_spec, sample_from_anchor, has_num_rejected):
+@pytest.mark.parametrize(
+    "batch_size,ctx_lens,num_spec,sample_from_anchor,has_num_rejected,check_request_window",
+    CONFIGS,
+)
+def test_copy_and_expand_dflash_dspark(
+    batch_size,
+    ctx_lens,
+    num_spec,
+    sample_from_anchor,
+    has_num_rejected,
+    check_request_window,
+):
     init_device_properties_triton()
     device = "npu"
     torch.manual_seed(0)
@@ -127,6 +139,8 @@ def test_copy_and_expand_dflash_dspark(batch_size, ctx_lens, num_spec, sample_fr
     total_ctx = int(query_start_loc[-1].item())
 
     history = torch.randint(0, 100, (batch_size,), dtype=torch.int32, device=device)
+    if check_request_window:
+        history[0] = 0
     seq_lens = ctx + history
     target_positions = torch.cat(
         [
@@ -141,6 +155,10 @@ def test_copy_and_expand_dflash_dspark(batch_size, ctx_lens, num_spec, sample_fr
     )
     max_blocks = int((seq_lens.max() + num_query_per_req + KV_BLOCK_SIZE) // KV_BLOCK_SIZE) + 2
     block_table = torch.randint(1, 10000, (batch_size, max_blocks), dtype=torch.int32, device=device)
+    if check_request_window:
+        block_table[0, 0] = 0
+    num_blocks_per_row = torch.full((batch_size,), max_blocks, dtype=torch.int32, device=device)
+    request_window_ok = torch.ones(batch_size, dtype=torch.bool, device=device)
 
     if has_num_rejected:
         num_rejected_tokens = torch.minimum(
@@ -201,6 +219,10 @@ def test_copy_and_expand_dflash_dspark(batch_size, ctx_lens, num_spec, sample_fr
         HAS_NUM_REJECTED=has_num_rejected,
         SAMPLE_FROM_ANCHOR=sample_from_anchor,
         TILE_SIZE=_COPY_EXPAND_TILE_SIZE,
+        num_blocks_per_row_ptr=num_blocks_per_row,
+        request_window_ok_ptr=request_window_ok,
+        padding_slot_id=-1,
+        CHECK_REQUEST_WINDOW=check_request_window,
     )
 
     torch.testing.assert_close(out_input_ids, ref["out_input_ids"])

--- a/tests/e2e/nightly/single_node/ops/singlecard_ops/triton/test_copy_and_expand_dflash_dspark.py
+++ b/tests/e2e/nightly/single_node/ops/singlecard_ops/triton/test_copy_and_expand_dflash_dspark.py
@@ -97,6 +97,9 @@ def copy_and_expand_dflash_dspark_ref(
 # (batch_size, ctx_lens, num_spec, sample_from_anchor, has_num_rejected)
 CONFIGS = [
     (1, [4], 3, False, False),
+    # Regression for a partial query tile: inactive lanes must not construct
+    # out-of-range request or token pointers before their memory masks apply.
+    (29, [4] * 29, 3, True, False),
     (64, [4] * 64, 3, False, False),
     (256, [4] * 256, 3, False, False),
     (1, [2048], 3, False, False),

--- a/vllm_ascend/ops/triton/spec_decode/utils.py
+++ b/vllm_ascend/ops/triton/spec_decode/utils.py
@@ -95,6 +95,10 @@ def copy_and_expand_dflash_and_dspark_inputs_kernel(
     HAS_NUM_REJECTED: tl.constexpr = False,
     SAMPLE_FROM_ANCHOR: tl.constexpr = False,
     TILE_SIZE: tl.constexpr = 256,
+    num_blocks_per_row_ptr=0,  # [num_reqs], or null when checking is disabled
+    request_window_ok_ptr=0,  # [num_reqs], or null when checking is disabled
+    padding_slot_id=-1,
+    CHECK_REQUEST_WINDOW: tl.constexpr = False,
 ):
     # Grid-stride kernel: launch grid is capped at the vector-core count by
     # the caller (grid = min(cdiv(total_work, TILE_SIZE), num_vectorcore)),
@@ -140,11 +144,23 @@ def copy_and_expand_dflash_and_dspark_inputs_kernel(
 
         seq_len = tl.load(seq_lens_ptr + req_idx, mask=mask, other=0)
         effective_seq_len = seq_len - num_rejected
-        last_pos = tl.load(target_positions_ptr + valid_ctx_end - 1, mask=mask, other=0)
+        if CHECK_REQUEST_WINDOW:
+            request_window_ok = tl.load(request_window_ok_ptr + req_idx, mask=mask, other=0).to(tl.int1)
+            valid_ctx = request_window_ok & (valid_ctx_end > 0)
+            safe_last_ctx_idx = tl.where(valid_ctx, valid_ctx_end - 1, 0)
+            last_pos = tl.load(
+                target_positions_ptr + safe_last_ctx_idx,
+                mask=mask & valid_ctx,
+                other=0,
+            )
+        else:
+            last_pos = tl.load(target_positions_ptr + valid_ctx_end - 1, mask=mask, other=0)
 
         # RoPE position id of the query token, derived from the last context
         # token's position. Written to out_query_positions for position embeddings.
         query_pos = last_pos + 1 + q_idx
+        if CHECK_REQUEST_WINDOW:
+            query_pos = tl.where(request_window_ok, query_pos, 0)
         tl.store(out_query_positions_ptr + offs, query_pos, mask=mask)
 
         # Linear KV-cache token index used to look up the physical slot via the
@@ -156,10 +172,36 @@ def copy_and_expand_dflash_and_dspark_inputs_kernel(
         # identical, so this only changes behaviour for multimodal inputs.
         query_kv_slot_pos = effective_seq_len + q_idx
         block_num_q = query_kv_slot_pos // block_size
-        block_id_q = tl.load(block_table_ptr + req_idx * block_table_stride + block_num_q, mask=mask, other=0).to(
-            tl.int64
-        )
-        slot_q = block_id_q * block_size + (query_kv_slot_pos % block_size)
+        if CHECK_REQUEST_WINDOW:
+            num_blocks_per_row = tl.load(num_blocks_per_row_ptr + req_idx, mask=mask, other=0)
+            block_in_range = (
+                request_window_ok
+                & (query_kv_slot_pos >= 0)
+                & (block_num_q >= 0)
+                & (block_num_q < num_blocks_per_row)
+                & (block_num_q < block_table_stride)
+            )
+            # Select an in-row address before pointer arithmetic. Masking only
+            # the load is insufficient when block_num_q already crosses rows.
+            safe_block_num_q = tl.where(block_in_range, block_num_q, 0)
+            block_id_q = tl.load(
+                block_table_ptr + req_idx * block_table_stride + safe_block_num_q,
+                mask=mask & block_in_range,
+                other=0,
+            ).to(tl.int64)
+            slot_valid = block_in_range & (block_id_q != 0)
+            slot_q = tl.where(
+                slot_valid,
+                block_id_q * block_size + (query_kv_slot_pos % block_size),
+                padding_slot_id,
+            )
+        else:
+            block_id_q = tl.load(
+                block_table_ptr + req_idx * block_table_stride + block_num_q,
+                mask=mask,
+                other=0,
+            ).to(tl.int64)
+            slot_q = block_id_q * block_size + (query_kv_slot_pos % block_size)
         tl.store(out_query_slot_mapping_ptr + offs, slot_q, mask=mask)
 
         bonus = tl.load(next_token_ids_ptr + req_idx, mask=mask, other=0)

--- a/vllm_ascend/ops/triton/spec_decode/utils.py
+++ b/vllm_ascend/ops/triton/spec_decode/utils.py
@@ -117,10 +117,11 @@ def copy_and_expand_dflash_and_dspark_inputs_kernel(
     while block_start < total_input_tokens:
         offs = block_start + tl.arange(0, TILE_SIZE)
         mask = offs < total_input_tokens
-        pos = tl.load(target_positions_ptr + offs, mask=mask)
-        tl.store(out_context_positions_ptr + offs, pos, mask=mask)
-        slot = tl.load(context_slot_mapping_ptr + offs, mask=mask)
-        tl.store(out_context_slot_mapping_ptr + offs, slot, mask=mask)
+        safe_offs = tl.where(mask, offs, 0)
+        pos = tl.load(target_positions_ptr + safe_offs, mask=mask)
+        tl.store(out_context_positions_ptr + safe_offs, pos, mask=mask)
+        slot = tl.load(context_slot_mapping_ptr + safe_offs, mask=mask)
+        tl.store(out_context_slot_mapping_ptr + safe_offs, slot, mask=mask)
         block_start += block_start_step
 
     # --- Part 2: query block expand ---
@@ -132,8 +133,12 @@ def copy_and_expand_dflash_and_dspark_inputs_kernel(
         offs = block_start + tl.arange(0, TILE_SIZE)
         mask = offs < num_query_total
 
-        req_idx = offs // num_query_per_req
-        q_idx = offs % num_query_per_req
+        # Ascend SIMT can still lower masked indirect accesses after pointer
+        # arithmetic. Keep every inactive lane inside row/token zero before
+        # constructing any input or output address.
+        safe_offs = tl.where(mask, offs, 0)
+        req_idx = safe_offs // num_query_per_req
+        q_idx = safe_offs % num_query_per_req
 
         ctx_end = tl.load(query_start_loc_ptr + req_idx + 1, mask=mask, other=0)
         if HAS_NUM_REJECTED:
@@ -144,24 +149,22 @@ def copy_and_expand_dflash_and_dspark_inputs_kernel(
 
         seq_len = tl.load(seq_lens_ptr + req_idx, mask=mask, other=0)
         effective_seq_len = seq_len - num_rejected
+        valid_ctx = (valid_ctx_end > 0) & (valid_ctx_end <= total_input_tokens)
         if CHECK_REQUEST_WINDOW:
             request_window_ok = tl.load(request_window_ok_ptr + req_idx, mask=mask, other=0).to(tl.int1)
-            valid_ctx = request_window_ok & (valid_ctx_end > 0)
-            safe_last_ctx_idx = tl.where(valid_ctx, valid_ctx_end - 1, 0)
-            last_pos = tl.load(
-                target_positions_ptr + safe_last_ctx_idx,
-                mask=mask & valid_ctx,
-                other=0,
-            )
-        else:
-            last_pos = tl.load(target_positions_ptr + valid_ctx_end - 1, mask=mask, other=0)
+            valid_ctx = valid_ctx & request_window_ok
+        safe_last_ctx_idx = tl.where(valid_ctx, valid_ctx_end - 1, 0)
+        last_pos = tl.load(
+            target_positions_ptr + safe_last_ctx_idx,
+            mask=mask & valid_ctx,
+            other=0,
+        )
 
         # RoPE position id of the query token, derived from the last context
         # token's position. Written to out_query_positions for position embeddings.
         query_pos = last_pos + 1 + q_idx
-        if CHECK_REQUEST_WINDOW:
-            query_pos = tl.where(request_window_ok, query_pos, 0)
-        tl.store(out_query_positions_ptr + offs, query_pos, mask=mask)
+        query_pos = tl.where(valid_ctx, query_pos, 0)
+        tl.store(out_query_positions_ptr + safe_offs, query_pos, mask=mask)
 
         # Linear KV-cache token index used to look up the physical slot via the
         # block_table. This is kept separate from query_pos for multimodal
@@ -202,19 +205,19 @@ def copy_and_expand_dflash_and_dspark_inputs_kernel(
                 other=0,
             ).to(tl.int64)
             slot_q = block_id_q * block_size + (query_kv_slot_pos % block_size)
-        tl.store(out_query_slot_mapping_ptr + offs, slot_q, mask=mask)
+        tl.store(out_query_slot_mapping_ptr + safe_offs, slot_q, mask=mask)
 
         bonus = tl.load(next_token_ids_ptr + req_idx, mask=mask, other=0)
         in_id = tl.where(q_idx == 0, bonus, parallel_drafting_token_id)
-        tl.store(out_input_ids_ptr + offs, in_id, mask=mask)
+        tl.store(out_input_ids_ptr + safe_offs, in_id, mask=mask)
 
         if SAMPLE_FROM_ANCHOR:
             sample_out_idx = req_idx * num_speculative_tokens + q_idx
-            tl.store(out_token_indices_ptr + sample_out_idx, offs, mask=mask)
+            tl.store(out_token_indices_ptr + sample_out_idx, safe_offs, mask=mask)
         else:
             sample_mask = mask & (q_idx > 0)
             sample_out_idx = req_idx * num_speculative_tokens + (q_idx - 1)
-            tl.store(out_token_indices_ptr + sample_out_idx, offs, mask=sample_mask)
+            tl.store(out_token_indices_ptr + sample_out_idx, safe_offs, mask=sample_mask)
 
         block_start += block_start_step
 

--- a/vllm_ascend/ops/triton/spec_decode/utils.py
+++ b/vllm_ascend/ops/triton/spec_decode/utils.py
@@ -192,9 +192,8 @@ def copy_and_expand_dflash_and_dspark_inputs_kernel(
                 mask=mask & block_in_range,
                 other=0,
             ).to(tl.int64)
-            slot_valid = block_in_range & (block_id_q != 0)
             slot_q = tl.where(
-                slot_valid,
+                block_in_range,
                 block_id_q * block_size + (query_kv_slot_pos % block_size),
                 padding_slot_id,
             )

--- a/vllm_ascend/patch/platform/patch_speculative_config.py
+++ b/vllm_ascend/patch/platform/patch_speculative_config.py
@@ -1,8 +1,12 @@
+import functools
+
 from transformers import DeepseekV2Config, PretrainedConfig
 from vllm.config.speculative import SpeculativeConfig
+from vllm.v1.core.sched.scheduler import Scheduler
 
 _orig_post_init = SpeculativeConfig.__post_init__
 _orig_hf_config_override = SpeculativeConfig.hf_config_override
+_orig_scheduler_init = Scheduler.__init__
 
 
 # Transformers 5.14 inherited a hidden_size % num_heads check from Llama in
@@ -50,5 +54,38 @@ def _dspark_post_init(self):
             draft_hf_config.ptd_token_id = getattr(draft_hf_config, "mask_token_id", None)  # type: ignore
 
 
+def _num_drafter_query_tokens(self: SpeculativeConfig) -> int:
+    """Return the configured per-request query width of the drafter."""
+    num_query_tokens = self.num_speculative_tokens
+    assert num_query_tokens is not None
+    if self.use_dflash():
+        return num_query_tokens + 1
+    if not self.use_dspark():
+        return num_query_tokens
+
+    assert self.draft_model_config is not None
+    sample_from_anchor = getattr(
+        self.draft_model_config.hf_config,
+        "sample_from_anchor",
+        True,
+    )
+    return num_query_tokens + int(not sample_from_anchor)
+
+
+@functools.wraps(_orig_scheduler_init)
+def _scheduler_init(self: Scheduler, *args, **kwargs) -> None:
+    _orig_scheduler_init(self, *args, **kwargs)
+    speculative_config = self.vllm_config.speculative_config
+    if speculative_config is not None and speculative_config.use_dspark():
+        # This remains the configured maximum even when the per-batch K or the
+        # per-request verification length is reduced dynamically. Those values
+        # trim consumed drafts after the full parallel query has written KV.
+        self.num_lookahead_tokens = _num_drafter_query_tokens(speculative_config)
+
+
 SpeculativeConfig.hf_config_override = staticmethod(_normalize_legacy_qwen3_dspark_config)
 SpeculativeConfig.__post_init__ = _dspark_post_init
+SpeculativeConfig.num_drafter_query_tokens = property(  # type: ignore[attr-defined]
+    _num_drafter_query_tokens
+)
+Scheduler.__init__ = _scheduler_init

--- a/vllm_ascend/spec_decode/dspark_proposer.py
+++ b/vllm_ascend/spec_decode/dspark_proposer.py
@@ -95,7 +95,6 @@ class AscendDSparkProposer(AscendDflashProposer):
         # references here because K3 draft layers can span multiple cache
         # groups with different logical block sizes.
         self._per_group_block_tables: dict[int, torch.Tensor] = {}
-        self._per_group_block_tables_cpu: dict[int, torch.Tensor] = {}
         self._per_group_slot_mappings: dict[int, torch.Tensor] = {}
         self._per_group_num_blocks_per_row: dict[int, torch.Tensor] = {}
         self._per_group_num_blocks_per_row_cpu: dict[int, torch.Tensor] = {}
@@ -110,8 +109,6 @@ class AscendDSparkProposer(AscendDflashProposer):
         self._per_group_context_slot_mapping_buffers: dict[int, torch.Tensor] = {}
         self._context_slot_mapping_buffers: list[torch.Tensor | None] | None = None
         self._request_window_ok = torch.zeros(self.max_batch_size, dtype=torch.bool, device=device)
-        self._row_indices = torch.arange(self.max_batch_size, dtype=torch.int64, device=device)
-        self._row_indices_cpu = torch.arange(self.max_batch_size, dtype=torch.int64)
         self._last_valid_draft_counts_cpu: list[int] | None = None
 
     def _compute_confidence(
@@ -225,7 +222,6 @@ class AscendDSparkProposer(AscendDflashProposer):
         slot_mapping: torch.Tensor,
         num_blocks_per_row: torch.Tensor | None = None,
         num_blocks_per_row_cpu: torch.Tensor | None = None,
-        block_table_cpu: torch.Tensor | None = None,
     ) -> None:
         self._per_group_block_tables[gid] = block_table
         self._per_group_slot_mappings[gid] = slot_mapping
@@ -242,14 +238,8 @@ class AscendDSparkProposer(AscendDflashProposer):
                 block_table.shape[1],
                 dtype=torch.int32,
             )
-        if block_table_cpu is None:
-            block_table_cpu = torch.ones(
-                block_table.shape,
-                dtype=torch.int32,
-            )
         self._per_group_num_blocks_per_row[gid] = num_blocks_per_row
         self._per_group_num_blocks_per_row_cpu[gid] = num_blocks_per_row_cpu
-        self._per_group_block_tables_cpu[gid] = block_table_cpu
 
     def mask_invalid_draft_output(self, draft_token_ids: torch.Tensor) -> torch.Tensor:
         """Turn drafts from unsafe request windows into scheduler placeholders."""
@@ -318,23 +308,10 @@ class AscendDSparkProposer(AscendDflashProposer):
                 block_size,
                 rounding_mode="floor",
             )
-            first_block = torch.div(
-                effective_seq_lens[:batch_size],
-                block_size,
-                rounding_mode="floor",
-            )
-            last_block = required_blocks - 1
-            safe_first_block = first_block.clamp(min=0, max=block_table.shape[1] - 1)
-            safe_last_block = last_block.clamp(min=0, max=block_table.shape[1] - 1)
-            row_indices = self._row_indices[:batch_size]
-            first_block_ids = block_table[row_indices, safe_first_block.to(torch.int64)]
-            last_block_ids = block_table[row_indices, safe_last_block.to(torch.int64)]
             if self.num_query_per_req > block_size:
                 request_window_ok.zero_()
             request_window_ok.logical_and_(required_blocks <= valid_blocks)
             request_window_ok.logical_and_(valid_blocks <= block_table.stride(0))
-            request_window_ok.logical_and_(first_block_ids != 0)
-            request_window_ok.logical_and_(last_block_ids != 0)
 
         host_seq_lens = cad._seq_lens_cpu
         if host_seq_lens is None:
@@ -349,30 +326,16 @@ class AscendDSparkProposer(AscendDflashProposer):
                 gid = attn_group.kv_cache_group_id
                 block_size = self._per_group_kernel_block_sizes[gid]
                 block_table = self._per_group_block_table_buffers[gid]
-                block_table_cpu = self._per_group_block_tables_cpu[gid]
                 valid_blocks_cpu = self._per_group_num_blocks_per_row_cpu[gid][:batch_size]
                 required_blocks_cpu = torch.div(
                     host_window_end + block_size - 1,
                     block_size,
                     rounding_mode="floor",
                 )
-                first_block_cpu = torch.div(
-                    host_seq_lens[:batch_size],
-                    block_size,
-                    rounding_mode="floor",
-                )
-                last_block_cpu = required_blocks_cpu - 1
-                safe_first_block_cpu = first_block_cpu.clamp(min=0, max=block_table_cpu.shape[1] - 1)
-                safe_last_block_cpu = last_block_cpu.clamp(min=0, max=block_table_cpu.shape[1] - 1)
-                row_indices_cpu = self._row_indices_cpu[:batch_size]
-                first_block_ids_cpu = block_table_cpu[row_indices_cpu, safe_first_block_cpu.to(torch.int64)]
-                last_block_ids_cpu = block_table_cpu[row_indices_cpu, safe_last_block_cpu.to(torch.int64)]
                 if self.num_query_per_req > block_size:
                     host_window_ok.zero_()
                 host_window_ok.logical_and_(required_blocks_cpu <= valid_blocks_cpu)
                 host_window_ok.logical_and_(valid_blocks_cpu <= block_table.stride(0))
-                host_window_ok.logical_and_(first_block_ids_cpu != 0)
-                host_window_ok.logical_and_(last_block_ids_cpu != 0)
             self._last_valid_draft_counts_cpu = torch.where(
                 host_window_ok,
                 self.num_speculative_tokens,

--- a/vllm_ascend/spec_decode/dspark_proposer.py
+++ b/vllm_ascend/spec_decode/dspark_proposer.py
@@ -93,7 +93,10 @@ class AscendDSparkProposer(AscendDflashProposer):
         # references here because K3 draft layers can span multiple cache
         # groups with different logical block sizes.
         self._per_group_block_tables: dict[int, torch.Tensor] = {}
+        self._per_group_block_tables_cpu: dict[int, torch.Tensor] = {}
         self._per_group_slot_mappings: dict[int, torch.Tensor] = {}
+        self._per_group_num_blocks_per_row: dict[int, torch.Tensor] = {}
+        self._per_group_num_blocks_per_row_cpu: dict[int, torch.Tensor] = {}
         # Per-gid logical block size used to expand slot mappings. The KV
         # manager's physical page can be larger when hybrid cache groups share
         # one allocation, so kv_cache_spec.block_size is not interchangeable
@@ -104,6 +107,10 @@ class AscendDSparkProposer(AscendDflashProposer):
         self._per_group_query_slot_mapping_buffers: dict[int, torch.Tensor] = {}
         self._per_group_context_slot_mapping_buffers: dict[int, torch.Tensor] = {}
         self._context_slot_mapping_buffers: list[torch.Tensor | None] | None = None
+        self._request_window_ok = torch.zeros(self.max_batch_size, dtype=torch.bool, device=device)
+        self._row_indices = torch.arange(self.max_batch_size, dtype=torch.int64, device=device)
+        self._row_indices_cpu = torch.arange(self.max_batch_size, dtype=torch.int64)
+        self._last_valid_draft_counts_cpu: list[int] | None = None
 
     def _compute_confidence(
         self,
@@ -214,9 +221,45 @@ class AscendDSparkProposer(AscendDflashProposer):
         gid: int,
         block_table: torch.Tensor,
         slot_mapping: torch.Tensor,
+        num_blocks_per_row: torch.Tensor | None = None,
+        num_blocks_per_row_cpu: torch.Tensor | None = None,
+        block_table_cpu: torch.Tensor | None = None,
     ) -> None:
         self._per_group_block_tables[gid] = block_table
         self._per_group_slot_mappings[gid] = slot_mapping
+        if num_blocks_per_row is None:
+            num_blocks_per_row = torch.full(
+                (block_table.shape[0],),
+                block_table.shape[1],
+                dtype=torch.int32,
+                device=block_table.device,
+            )
+        if num_blocks_per_row_cpu is None:
+            num_blocks_per_row_cpu = torch.full(
+                (block_table.shape[0],),
+                block_table.shape[1],
+                dtype=torch.int32,
+            )
+        if block_table_cpu is None:
+            block_table_cpu = torch.ones(
+                block_table.shape,
+                dtype=torch.int32,
+            )
+        self._per_group_num_blocks_per_row[gid] = num_blocks_per_row
+        self._per_group_num_blocks_per_row_cpu[gid] = num_blocks_per_row_cpu
+        self._per_group_block_tables_cpu[gid] = block_table_cpu
+
+    def mask_invalid_draft_output(self, draft_token_ids: torch.Tensor) -> torch.Tensor:
+        """Turn drafts from unsafe request windows into scheduler placeholders."""
+        num_reqs = draft_token_ids.shape[0]
+        valid_rows = self._request_window_ok[:num_reqs].unsqueeze(1)
+        draft_token_ids.masked_fill_(~valid_rows, -1)
+        if self._last_draft_probs is not None:
+            self._last_draft_probs[:num_reqs].masked_fill_(~valid_rows.unsqueeze(2), 0)
+        return draft_token_ids
+
+    def get_last_valid_draft_counts_cpu(self) -> list[int] | None:
+        return self._last_valid_draft_counts_cpu
 
     def set_inputs_first_pass(
         self,
@@ -249,6 +292,95 @@ class AscendDSparkProposer(AscendDflashProposer):
         self._dflash_num_context = int(cad.query_start_loc_cpu[batch_size])
         self._dflash_hidden_states[: self._dflash_num_context] = target_hidden_states[: self._dflash_num_context]
 
+        effective_seq_lens = cad.seq_lens
+        if has_num_rejected:
+            effective_seq_lens = effective_seq_lens - num_rejected_tokens_gpu
+
+        max_model_len = self.vllm_config.model_config.max_model_len
+        window_end = effective_seq_lens[:batch_size] + self.num_query_per_req
+        request_window_ok = self._request_window_ok[:batch_size]
+        request_window_ok.copy_((effective_seq_lens[:batch_size] >= 0) & (window_end <= max_model_len))
+        ctx_end = cad.query_start_loc[1 : batch_size + 1]
+        if has_num_rejected:
+            request_window_ok.logical_and_(ctx_end > num_rejected_tokens_gpu[:batch_size])
+        else:
+            request_window_ok.logical_and_(ctx_end > 0)
+
+        for attn_group in self.draft_attn_groups:
+            gid = attn_group.kv_cache_group_id
+            block_size = self._per_group_kernel_block_sizes[gid]
+            block_table = self._per_group_block_table_buffers[gid]
+            valid_blocks = self._per_group_num_blocks_per_row[gid][:batch_size]
+            required_blocks = torch.div(
+                window_end + block_size - 1,
+                block_size,
+                rounding_mode="floor",
+            )
+            first_block = torch.div(
+                effective_seq_lens[:batch_size],
+                block_size,
+                rounding_mode="floor",
+            )
+            last_block = required_blocks - 1
+            safe_first_block = first_block.clamp(min=0, max=block_table.shape[1] - 1)
+            safe_last_block = last_block.clamp(min=0, max=block_table.shape[1] - 1)
+            row_indices = self._row_indices[:batch_size]
+            first_block_ids = block_table[row_indices, safe_first_block.to(torch.int64)]
+            last_block_ids = block_table[row_indices, safe_last_block.to(torch.int64)]
+            if self.num_query_per_req > block_size:
+                request_window_ok.zero_()
+            request_window_ok.logical_and_(required_blocks <= valid_blocks)
+            request_window_ok.logical_and_(valid_blocks <= block_table.stride(0))
+            request_window_ok.logical_and_(first_block_ids != 0)
+            request_window_ok.logical_and_(last_block_ids != 0)
+
+        host_seq_lens = cad._seq_lens_cpu
+        if host_seq_lens is None:
+            host_seq_lens = getattr(cad, "seq_lens_cpu", None)
+        host_window_ok = None
+        if host_seq_lens is not None:
+            host_window_end = host_seq_lens[:batch_size] + self.num_query_per_req
+            host_window_ok = (host_seq_lens[:batch_size] >= 0) & (host_window_end <= max_model_len)
+            host_ctx_lens = cad.query_start_loc_cpu[1 : batch_size + 1] - cad.query_start_loc_cpu[:batch_size]
+            host_window_ok.logical_and_(host_ctx_lens > 0)
+            for attn_group in self.draft_attn_groups:
+                gid = attn_group.kv_cache_group_id
+                block_size = self._per_group_kernel_block_sizes[gid]
+                block_table = self._per_group_block_table_buffers[gid]
+                block_table_cpu = self._per_group_block_tables_cpu[gid]
+                valid_blocks_cpu = self._per_group_num_blocks_per_row_cpu[gid][:batch_size]
+                required_blocks_cpu = torch.div(
+                    host_window_end + block_size - 1,
+                    block_size,
+                    rounding_mode="floor",
+                )
+                first_block_cpu = torch.div(
+                    host_seq_lens[:batch_size],
+                    block_size,
+                    rounding_mode="floor",
+                )
+                last_block_cpu = required_blocks_cpu - 1
+                safe_first_block_cpu = first_block_cpu.clamp(min=0, max=block_table_cpu.shape[1] - 1)
+                safe_last_block_cpu = last_block_cpu.clamp(min=0, max=block_table_cpu.shape[1] - 1)
+                row_indices_cpu = self._row_indices_cpu[:batch_size]
+                first_block_ids_cpu = block_table_cpu[row_indices_cpu, safe_first_block_cpu.to(torch.int64)]
+                last_block_ids_cpu = block_table_cpu[row_indices_cpu, safe_last_block_cpu.to(torch.int64)]
+                if self.num_query_per_req > block_size:
+                    host_window_ok.zero_()
+                host_window_ok.logical_and_(required_blocks_cpu <= valid_blocks_cpu)
+                host_window_ok.logical_and_(valid_blocks_cpu <= block_table.stride(0))
+                host_window_ok.logical_and_(first_block_ids_cpu != 0)
+                host_window_ok.logical_and_(last_block_ids_cpu != 0)
+            self._last_valid_draft_counts_cpu = torch.where(
+                host_window_ok,
+                self.num_speculative_tokens,
+                0,
+            ).tolist()
+        else:
+            # Production metadata always has a host mirror. Be conservative
+            # for compatibility callers that omit it.
+            self._last_valid_draft_counts_cpu = [0] * batch_size
+
         token_indices_to_sample = torch.empty(
             num_sample_total,
             dtype=torch.int32,
@@ -279,6 +411,8 @@ class AscendDSparkProposer(AscendDflashProposer):
                 # Block table
                 block_table_ptr=gid_block_table,
                 block_table_stride=gid_block_table.stride(0),
+                num_blocks_per_row_ptr=self._per_group_num_blocks_per_row[gid],
+                request_window_ok_ptr=request_window_ok,
                 # Metadata
                 query_start_loc_ptr=cad.query_start_loc,
                 seq_lens_ptr=cad.seq_lens,
@@ -290,29 +424,40 @@ class AscendDSparkProposer(AscendDflashProposer):
                 num_speculative_tokens=self.num_speculative_tokens,
                 total_input_tokens=self._dflash_num_context,
                 batch_size=batch_size,
+                padding_slot_id=-1,
                 HAS_NUM_REJECTED=has_num_rejected,
                 SAMPLE_FROM_ANCHOR=self.sample_from_anchor,
+                CHECK_REQUEST_WINDOW=True,
             )
         # to compute self._context_slot_mapping_buffers from dict to list
         self._context_slot_mapping_buffers = [
             self._per_group_context_slot_mapping_buffers[gidx] for gidx in self._layer_group_idx
         ]
 
-        effective_seq_lens = cad.seq_lens
-        if has_num_rejected:
-            effective_seq_lens = effective_seq_lens - num_rejected_tokens_gpu
-
         cad.query_start_loc = self.arange_dflash[: batch_size + 1] * self.num_query_per_req
-        cad.seq_lens = effective_seq_lens + self.num_query_per_req
+        expanded_seq_lens = effective_seq_lens + self.num_query_per_req
+        cad.seq_lens = torch.where(
+            request_window_ok,
+            expanded_seq_lens,
+            torch.ones_like(expanded_seq_lens),
+        )
         # The model runner has already corrected this canonical host mirror
         # with the accepted-token count. Extend it on CPU alongside the device
         # lengths, without another reject D2H copy or attention-side wait.
         if cad._seq_lens_cpu is not None:
             draft_seq_lens_cpu = cad._seq_lens_cpu.clone()
-            draft_seq_lens_cpu[:batch_size].add_(self.num_query_per_req)
+            expanded_seq_lens_cpu = draft_seq_lens_cpu[:batch_size] + self.num_query_per_req
+            if host_window_ok is None:
+                draft_seq_lens_cpu[:batch_size].fill_(1)
+            else:
+                draft_seq_lens_cpu[:batch_size] = torch.where(
+                    host_window_ok,
+                    expanded_seq_lens_cpu,
+                    torch.ones_like(expanded_seq_lens_cpu),
+                )
             cad._seq_lens_cpu = draft_seq_lens_cpu
             if getattr(cad, "seq_lens_cpu", None) is not None:
-                cad.seq_lens_cpu = draft_seq_lens_cpu
+                cad.seq_lens_cpu = draft_seq_lens_cpu.clone()
         cad.query_start_loc_cpu = (
             torch.from_numpy(self.token_arange_np[: batch_size + 1]).clone() * self.num_query_per_req
         ).to(torch.int32)
@@ -325,7 +470,13 @@ class AscendDSparkProposer(AscendDflashProposer):
         cad.num_actual_tokens = num_query_total
         cad.num_input_tokens = num_query_total
         cad.max_query_len = self.num_query_per_req
-        cad.max_seq_len = cad.max_seq_len + self.num_query_per_req
+        if cad._seq_lens_cpu is not None:
+            cad.max_seq_len = int(cad._seq_lens_cpu[:batch_size].max().item())
+        else:
+            cad.max_seq_len = min(
+                cad.max_seq_len + self.num_query_per_req,
+                max_model_len,
+            )
         cad.slot_mapping = self._per_group_query_slot_mapping_buffers[primary_gid][:num_query_total]
         cad.positions = self.positions  # this would be sliced in attention backend
         if hasattr(self.model, "get_draft_attn_causal"):

--- a/vllm_ascend/spec_decode/dspark_proposer.py
+++ b/vllm_ascend/spec_decode/dspark_proposer.py
@@ -37,10 +37,12 @@ class AscendDSparkProposer(AscendDflashProposer):
         super().__init__(vllm_config, device, runner=runner)
         assert vllm_config.speculative_config is not None
         self.sample_from_anchor = getattr(self.draft_model_config.hf_config, "sample_from_anchor", True)
-        if self.sample_from_anchor:
-            self.num_query_per_req = self.num_speculative_tokens
-        else:
-            self.num_query_per_req = 1 + self.num_speculative_tokens
+        # Keep this at the configured maximum. Per-batch dynamic K and
+        # confidence-based per-request verification lengths only trim the
+        # drafts consumed after this parallel query has written its KV slots.
+        self.num_query_per_req = (
+            vllm_config.speculative_config.num_drafter_query_tokens  # type: ignore[attr-defined]
+        )
 
         blk = 1 + self.num_speculative_tokens
         self._dspark_draft_buffer = torch.zeros((self.max_batch_size, blk), dtype=torch.int64, device=device)
@@ -293,7 +295,7 @@ class AscendDSparkProposer(AscendDflashProposer):
         self._dflash_hidden_states[: self._dflash_num_context] = target_hidden_states[: self._dflash_num_context]
 
         effective_seq_lens = cad.seq_lens
-        if has_num_rejected:
+        if num_rejected_tokens_gpu is not None:
             effective_seq_lens = effective_seq_lens - num_rejected_tokens_gpu
 
         max_model_len = self.vllm_config.model_config.max_model_len
@@ -301,7 +303,7 @@ class AscendDSparkProposer(AscendDflashProposer):
         request_window_ok = self._request_window_ok[:batch_size]
         request_window_ok.copy_((effective_seq_lens[:batch_size] >= 0) & (window_end <= max_model_len))
         ctx_end = cad.query_start_loc[1 : batch_size + 1]
-        if has_num_rejected:
+        if num_rejected_tokens_gpu is not None:
             request_window_ok.logical_and_(ctx_end > num_rejected_tokens_gpu[:batch_size])
         else:
             request_window_ok.logical_and_(ctx_end > 0)

--- a/vllm_ascend/worker/block_table.py
+++ b/vllm_ascend/worker/block_table.py
@@ -85,7 +85,10 @@ class BlockTable:
         if self.dcp_world_size > 1:
             duplicate_size += num_speculative_tokens
         self.block_table = self._make_buffer(max_num_reqs * duplicate_size, logical_table_size, dtype=torch.int32)
-        self.num_blocks_per_row = np.zeros(max_num_reqs, dtype=np.int32)
+        self.num_blocks_per_row_buffer = self._make_buffer(max_num_reqs, dtype=torch.int32)
+        # Keep the existing NumPy interface for the input-batch update path,
+        # while also maintaining a device mirror for DSpark slot validation.
+        self.num_blocks_per_row = self.num_blocks_per_row_buffer.np
         # MTP slot preparation appends up to num_speculative_tokens - 1
         # draft positions for every request beyond the scheduler token limit.
         num_mtp_draft_slots = max(num_speculative_tokens - 1, 0) * self.max_num_reqs
@@ -277,10 +280,13 @@ class BlockTable:
 
     def commit_block_table(self, num_reqs: int) -> None:
         self.block_table.copy_to_gpu(num_reqs)
+        self.num_blocks_per_row_buffer.copy_to_gpu(num_reqs)
 
     def clear(self) -> None:
         self.block_table.fill_(0)
         self.block_table.cpu.fill_(0)
+        self.num_blocks_per_row.fill(0)
+        self.num_blocks_per_row_buffer.gpu.zero_()
 
     def _convert_physical_to_logical_blocks(self, physical_blocks: np.ndarray) -> np.ndarray:
         """Convert physical block IDs to logical block IDs."""
@@ -304,6 +310,12 @@ class BlockTable:
         if num_reqs is not None:
             return self.block_table.gpu[:num_reqs]
         return self.block_table.gpu
+
+    def get_num_blocks_per_row_device(self, num_reqs: int | None = None) -> torch.Tensor:
+        """Return the device-side count of valid block-table entries per row."""
+        if num_reqs is not None:
+            return self.num_blocks_per_row_buffer.gpu[:num_reqs]
+        return self.num_blocks_per_row_buffer.gpu
 
     def get_cpu_tensor(self) -> torch.Tensor:
         """Returns the CPU tensor of the block table."""

--- a/vllm_ascend/worker/model_runner_v1.py
+++ b/vllm_ascend/worker/model_runner_v1.py
@@ -3451,18 +3451,15 @@ class NPUModelRunner(GPUModelRunner):
                 num_blocks_per_row_cpu = blk_table.num_blocks_per_row_buffer.cpu[
                     :num_reqs_padded
                 ]
-                block_table_cpu = blk_table.get_cpu_tensor()[:num_reqs_padded]
                 if num_reqs_padded > num_reqs:
                     num_blocks_per_row[num_reqs:].zero_()
                     num_blocks_per_row_cpu[num_reqs:].zero_()
-                    block_table_cpu[num_reqs:].zero_()
                 self.drafter.set_per_group_attn_metadata(
                     kv_cache_gid,
                     cm.block_table_tensor,
                     cm.slot_mapping,
                     num_blocks_per_row,
                     num_blocks_per_row_cpu,
-                    block_table_cpu,
                 )
             elif self.speculative_config and isinstance(
                 self.drafter, AscendStep3p5MTPProposer

--- a/vllm_ascend/worker/model_runner_v1.py
+++ b/vllm_ascend/worker/model_runner_v1.py
@@ -3455,6 +3455,7 @@ class NPUModelRunner(GPUModelRunner):
                 if num_reqs_padded > num_reqs:
                     num_blocks_per_row[num_reqs:].zero_()
                     num_blocks_per_row_cpu[num_reqs:].zero_()
+                    block_table_cpu[num_reqs:].zero_()
                 self.drafter.set_per_group_attn_metadata(
                     kv_cache_gid,
                     cm.block_table_tensor,

--- a/vllm_ascend/worker/model_runner_v1.py
+++ b/vllm_ascend/worker/model_runner_v1.py
@@ -1727,6 +1727,7 @@ class NPUModelRunner(GPUModelRunner):
         # is never used when the drafter does not produce fresh probabilities.
         self._draft_probs = None
         self._draft_prob_req_ids = None
+        self._draft_boundary_k_by_req_id = None
 
         if not self.drafter:
             # Speculative decoding is not enabled.
@@ -1925,6 +1926,15 @@ class NPUModelRunner(GPUModelRunner):
                 num_scheduled_tokens=num_scheduled_tokens,
                 num_rejected_tokens_gpu=num_rejected_tokens_gpu,
             )
+            if isinstance(self.drafter, AscendDSparkProposer):
+                draft_token_ids = self.drafter.mask_invalid_draft_output(
+                    draft_token_ids
+                )
+                valid_counts = self.drafter.get_last_valid_draft_counts_cpu()
+                if valid_counts is not None:
+                    self._draft_boundary_k_by_req_id = dict(
+                        zip(self.input_batch.req_ids, valid_counts)
+                    )
             if hasattr(self.drafter, "take_last_draft_probs"):
                 draft_probs = self.drafter.take_last_draft_probs()
                 if draft_probs is not None:
@@ -2018,16 +2028,25 @@ class NPUModelRunner(GPUModelRunner):
         out = super().take_draft_token_ids()
         if out is None:
             return None
+        boundary_k_by_req_id = getattr(
+            self, "_draft_boundary_k_by_req_id", None
+        )
         dynamic_spec = getattr(self.drafter, "dynamic_spec", None)
-        if dynamic_spec is None:
+        if dynamic_spec is None and boundary_k_by_req_id is None:
             return out
-        per_req_k = dynamic_spec.num_verify_tokens
-        if per_req_k is None:
-            return out
-        per_req_k = [
-            max(0, min(int(k), self.num_spec_tokens))
-            for k in per_req_k
-        ]
+        dynamic_k = (
+            dynamic_spec.num_verify_tokens
+            if dynamic_spec is not None
+            else None
+        )
+        per_req_k = []
+        for idx, req_id in enumerate(out.req_ids):
+            k = self.num_spec_tokens
+            if dynamic_k is not None:
+                k = min(k, int(dynamic_k[idx]))
+            if boundary_k_by_req_id is not None:
+                k = min(k, int(boundary_k_by_req_id.get(req_id, 0)))
+            per_req_k.append(max(0, k))
         cut_tokens = DraftTokenIds(
             req_ids=out.req_ids,
             draft_token_ids=[
@@ -2629,6 +2648,16 @@ class NPUModelRunner(GPUModelRunner):
                     draft_ids_list = draft_token_ids
                     draft_req_ids = self.input_batch.req_ids
                 if draft_ids_list and draft_req_ids:
+                    boundary_k_by_req_id = getattr(
+                        self, "_draft_boundary_k_by_req_id", None
+                    )
+                    if boundary_k_by_req_id is not None:
+                        draft_ids_list = [
+                            tokens[: boundary_k_by_req_id.get(req_id, 0)]
+                            for req_id, tokens in zip(
+                                draft_req_ids, draft_ids_list
+                            )
+                        ]
                     draft_by_req_id = dict(zip(draft_req_ids, draft_ids_list))
                     output_spec_token_ids = [
                         draft_by_req_id.get(req_id, [])
@@ -3414,7 +3443,29 @@ class NPUModelRunner(GPUModelRunner):
                 cm.block_table_tensor, cm.slot_mapping = _get_block_table_and_slot_mapping(
                     kv_cache_gid
                 )
-            if self.speculative_config and isinstance(self.drafter, (AscendStep3p5MTPProposer, AscendDSparkProposer)):
+            if self.speculative_config and isinstance(self.drafter, AscendDSparkProposer):
+                blk_table = self.input_batch.block_table[kv_cache_gid]
+                num_blocks_per_row = blk_table.get_num_blocks_per_row_device(
+                    num_reqs_padded
+                )
+                num_blocks_per_row_cpu = blk_table.num_blocks_per_row_buffer.cpu[
+                    :num_reqs_padded
+                ]
+                block_table_cpu = blk_table.get_cpu_tensor()[:num_reqs_padded]
+                if num_reqs_padded > num_reqs:
+                    num_blocks_per_row[num_reqs:].zero_()
+                    num_blocks_per_row_cpu[num_reqs:].zero_()
+                self.drafter.set_per_group_attn_metadata(
+                    kv_cache_gid,
+                    cm.block_table_tensor,
+                    cm.slot_mapping,
+                    num_blocks_per_row,
+                    num_blocks_per_row_cpu,
+                    block_table_cpu,
+                )
+            elif self.speculative_config and isinstance(
+                self.drafter, AscendStep3p5MTPProposer
+            ):
                 # step3p5 MTP draft layers span multiple KV cache groups; capture
                 # each group's block table / slot mapping so the proposer can
                 # build per-step attention metadata for the active MTP layer.


### PR DESCRIPTION
### What this PR does / why we need it?

Kimi-K3 DSpark can hit an invalid GM address while expanding a partial Triton query tile during long, no-prefix-cache decoding. The kernel used memory masks, but it constructed indirect request, token, and output addresses from every `TILE_SIZE` lane before those masks applied. On Ascend, inactive lanes can therefore still form out-of-range request pointers or `target_positions[-1]`.

This PR fixes the address construction and keeps the surrounding DSpark KV-window invariants explicit:

- Clamp inactive context/query lanes to index zero before constructing any indirect pointer.
- Validate `valid_ctx_end` before loading the final target position in both guarded and unguarded kernel paths.
- Derive the configured DSpark query width once and use it for Scheduler lookahead (`K` for anchor sampling, `K + 1` for the bonus-anchor layout).
- Validate each real request's full draft window against its authoritative per-row block count and use PAD slots only if that invariant is already broken.
- Treat KV block ID zero as a valid allocation; zero is not used as a padding sentinel.
- Clear graph-padding valid-block counts on both CPU and device so dummy rows cannot be treated as requests.

The window guard is a last-resort invariant check. Healthy requests retain their configured draft width and acceptance behavior; the direct fix prevents inactive Triton lanes from constructing invalid addresses rather than reducing speculative acceptance.

### Does this PR introduce _any_ user-facing change?

No API or configuration change. DSpark draft preparation now keeps masked-lane pointer arithmetic in bounds and rejects only windows that do not own the required KV blocks.

### How was this patch tested?

- Added an NPU regression case for the observed partial-tile shape: 29 requests, K=3, anchor sampling, 4 context tokens per request, and a valid block ID zero.
- `python -m compileall -q` on the changed runtime and test files.
- `python -m ruff check` on the changed runtime and test files.
- `python -m ruff format --check` on the changed runtime and test files.
- `git diff --check` across the PR range.

The NPU regression is selected for CI. It was not executed on the local Windows environment because vLLM/NPU runtime dependencies are unavailable there.

- vLLM main: https://github.com/vllm-project/vllm/commit/ba07e4a48fc951300d97eb506217dd530583dea3
