### PR TITLE
[Performance][Model] Offload Qwen3 image patchify and dtype conversion to NPU

### DIFF
--- a/vllm_ascend/ascend_config.py
+++ b/vllm_ascend/ascend_config.py
@@ -258,6 +258,7 @@ class AscendConfig:
             "enable_reduce_sample": false,
             "enable_dsa_cp": false,
             "enable_force_eplb": false,
+            "enable_qwen3_preprocess_on_npu": false,
             "draft_window_size": null,
             "mix_placement": false,
             "pa_shape_list": [],
@@ -393,6 +394,7 @@ class AscendConfig:
     enable_reduce_sample: bool = False
     enable_dsa_cp: bool = False
     enable_force_eplb: bool = False
+    enable_qwen3_preprocess_on_npu: bool = False
     draft_window_size: int | None = None
     mix_placement: bool = False
     pa_shape_list: list[Any] = dataclasses.field(default_factory=list)

--- a/vllm_ascend/patch/platform/__init__.py
+++ b/vllm_ascend/patch/platform/__init__.py
@@ -48,3 +48,4 @@ import vllm_ascend.patch.platform.patch_fused_moe  # noqa
 import vllm_ascend.patch.platform.patch_dp_device_ids  # noqa
 import vllm_ascend.patch.platform.patch_vision  # noqa
 import vllm_ascend.patch.platform.patch_glm5next_config  # noqa
+import vllm_ascend.patch.platform.patch_qwen3_preprocess  # noqa

--- a/vllm_ascend/patch/platform/patch_qwen3_preprocess.py
+++ b/vllm_ascend/patch/platform/patch_qwen3_preprocess.py
@@ -1,0 +1,229 @@
+# Copyright (c) 2026 Huawei Technologies Co., Ltd. All Rights Reserved.
+# This file is a part of the vllm-ascend project.
+
+"""Qwen3-VL family image patchify and dtype conversion offload."""
+
+from collections.abc import Mapping
+from contextvars import ContextVar
+from typing import Any
+
+import torch
+from transformers import BatchFeature
+from transformers.image_transforms import group_images_by_shape, reorder_images
+from transformers.image_utils import SizeDict
+from transformers.models.qwen2_vl.image_processing_qwen2_vl import (
+    Qwen2VLImageProcessor,
+    smart_resize,
+)
+from vllm.model_executor.models.qwen3_vl import Qwen3VLMultiModalProcessor
+from vllm.multimodal.inputs import MultiModalFieldConfig
+from vllm.multimodal.parse import MultiModalDataItems
+from vllm.multimodal.processing.context import InputProcessingContext
+
+from vllm_ascend.ascend_config import get_ascend_config
+
+_ORIGINAL_POSTPROCESS_OUTPUT = InputProcessingContext._postprocess_output
+_ORIGINAL_APPLY_HF_PROCESSOR_MAIN = Qwen3VLMultiModalProcessor._apply_hf_processor_main
+_ORIGINAL_GET_MM_FIELDS_CONFIG = Qwen3VLMultiModalProcessor._get_mm_fields_config
+_ORIGINAL_IMAGE_PREPROCESS = Qwen2VLImageProcessor._preprocess
+_VISUAL_PIXEL_KEYS = {"pixel_values"}
+_SUPPORTED_MODEL_TYPES = {
+    "qwen3_vl",
+    "qwen3_vl_moe",
+    "qwen3_5",
+    "qwen3_5_moe",
+}
+_NPU_PREPROCESS_ACTIVE = ContextVar("qwen3_npu_preprocess_active", default=False)
+
+
+def _is_npu_preprocess_enabled() -> bool:
+    return get_ascend_config().enable_qwen3_preprocess_on_npu
+
+
+def _is_supported_context(context: InputProcessingContext) -> bool:
+    model_type = getattr(context.model_config.hf_config, "model_type", None)
+    return model_type in _SUPPORTED_MODEL_TYPES
+
+
+def _is_supported_processor(processor: Qwen3VLMultiModalProcessor) -> bool:
+    model_type = getattr(processor.info.get_hf_config(), "model_type", None)
+    return model_type in _SUPPORTED_MODEL_TYPES
+
+
+def _apply_hf_processor_main_with_npu_preprocess(
+    self: Qwen3VLMultiModalProcessor,
+    mm_items: MultiModalDataItems,
+    hf_processor_mm_kwargs: Mapping[str, object],
+) -> BatchFeature:
+    # The offload is deliberately image-only. A mixed image/video request keeps
+    # the upstream contract until video patchify is implemented as well.
+    enabled = (
+        _is_npu_preprocess_enabled()
+        and _is_supported_processor(self)
+        and mm_items.get_count("video", strict=False) == 0
+    )
+    token = _NPU_PREPROCESS_ACTIVE.set(enabled)
+    try:
+        return _ORIGINAL_APPLY_HF_PROCESSOR_MAIN(self, mm_items, hf_processor_mm_kwargs)
+    finally:
+        _NPU_PREPROCESS_ACTIVE.reset(token)
+
+
+def _preprocess_with_npu_preprocess(
+    self: Qwen2VLImageProcessor,
+    images: list[torch.Tensor],
+    do_resize: bool,
+    size,
+    resample,
+    do_rescale: bool,
+    rescale_factor: float,
+    do_normalize: bool,
+    image_mean: float | list[float] | None,
+    image_std: float | list[float] | None,
+    patch_size: int,
+    temporal_patch_size: int,
+    merge_size: int,
+    disable_grouping: bool | None,
+    return_tensors,
+    **kwargs,
+) -> BatchFeature:
+    if not _NPU_PREPROCESS_ACTIVE.get():
+        return _ORIGINAL_IMAGE_PREPROCESS(
+            self,
+            images,
+            do_resize=do_resize,
+            size=size,
+            resample=resample,
+            do_rescale=do_rescale,
+            rescale_factor=rescale_factor,
+            do_normalize=do_normalize,
+            image_mean=image_mean,
+            image_std=image_std,
+            patch_size=patch_size,
+            temporal_patch_size=temporal_patch_size,
+            merge_size=merge_size,
+            disable_grouping=disable_grouping,
+            return_tensors=return_tensors,
+            **kwargs,
+        )
+
+    grouped_images, grouped_images_index = group_images_by_shape(images, disable_grouping=disable_grouping)
+    resized_images_grouped = {}
+    for shape, stacked_images in grouped_images.items():
+        if do_resize:
+            height, width = stacked_images.shape[-2:]
+            resized_height, resized_width = smart_resize(
+                height,
+                width,
+                factor=patch_size * merge_size,
+                min_pixels=size.shortest_edge,
+                max_pixels=size.longest_edge,
+            )
+            stacked_images = self.resize(
+                image=stacked_images,
+                size=SizeDict(height=resized_height, width=resized_width),
+                resample=resample,
+            )
+        resized_images_grouped[shape] = stacked_images
+
+    resized_images = reorder_images(resized_images_grouped, grouped_images_index)
+    grouped_images, grouped_images_index = group_images_by_shape(resized_images, disable_grouping=disable_grouping)
+    processed_images_grouped = {}
+    processed_grids = {}
+    for shape, stacked_images in grouped_images.items():
+        processed_images = self.rescale_and_normalize(
+            stacked_images,
+            do_rescale,
+            rescale_factor,
+            do_normalize,
+            image_mean,
+            image_std,
+        )
+        batch_size, _, resized_height, resized_width = processed_images.shape
+        grid_h = resized_height // patch_size
+        grid_w = resized_width // patch_size
+
+        # Preserve one row per image for shape-group reordering. The final cat
+        # below produces the flat CHW transport contract expected by vLLM's
+        # MultiModalFlatField and the Worker-side patchify implementation.
+        processed_images_grouped[shape] = processed_images.flatten(1)
+        processed_grids[shape] = [[1, grid_h, grid_w]] * batch_size
+
+    processed_images = reorder_images(processed_images_grouped, grouped_images_index)
+    processed_grids_ordered = reorder_images(processed_grids, grouped_images_index)
+    pixel_values = torch.cat(processed_images, dim=0)
+    image_grid_thw = torch.tensor(processed_grids_ordered, dtype=torch.long)
+
+    return BatchFeature(
+        data={
+            "pixel_values": pixel_values,
+            "image_grid_thw": image_grid_thw,
+        },
+        tensor_type=return_tensors,
+    )
+
+
+def _get_mm_fields_config_with_npu_preprocess(
+    self: Qwen3VLMultiModalProcessor,
+    hf_inputs: BatchFeature,
+    hf_processor_mm_kwargs: Mapping[str, object],
+) -> Mapping[str, MultiModalFieldConfig]:
+    configs = dict(_ORIGINAL_GET_MM_FIELDS_CONFIG(self, hf_inputs, hf_processor_mm_kwargs))
+    pixel_values = hf_inputs.get("pixel_values")
+    image_grid_thw = hf_inputs.get("image_grid_thw")
+    if (
+        not _is_npu_preprocess_enabled()
+        or not _is_supported_processor(self)
+        or not isinstance(pixel_values, torch.Tensor)
+        or pixel_values.ndim != 1
+        or not isinstance(image_grid_thw, torch.Tensor)
+    ):
+        return configs
+
+    vision_config = self.info.get_hf_config().vision_config
+    channels = int(vision_config.in_channels)
+    patch_size = int(vision_config.patch_size)
+    size_per_image = image_grid_thw[:, 1:].prod(-1) * channels * patch_size * patch_size
+    configs["pixel_values"] = MultiModalFieldConfig.flat_from_sizes("image", size_per_image)
+    return configs
+
+
+def _postprocess_output_with_npu_preprocess(
+    self: InputProcessingContext,
+    output,
+):
+    if not _is_npu_preprocess_enabled() or not _is_supported_context(self) or not _NPU_PREPROCESS_ACTIVE.get():
+        return _ORIGINAL_POSTPROCESS_OUTPUT(self, output)
+
+    keep_on_device = self.model_config.get_multimodal_config().mm_tensor_ipc == "torch_shm"
+
+    def postprocess(value: Any, *, keep_visual_dtype: bool = False):
+        if isinstance(value, dict):
+            return {
+                key: postprocess(
+                    item,
+                    keep_visual_dtype=(keep_visual_dtype or key in _VISUAL_PIXEL_KEYS),
+                )
+                for key, item in value.items()
+            }
+        if isinstance(value, list):
+            return [postprocess(item, keep_visual_dtype=keep_visual_dtype) for item in value]
+        if isinstance(value, tuple):
+            return tuple(postprocess(item, keep_visual_dtype=keep_visual_dtype) for item in value)
+        if not isinstance(value, torch.Tensor):
+            return value
+
+        tensor = value
+        if tensor.is_floating_point() and not keep_visual_dtype:
+            tensor = tensor.to(dtype=self.model_config.dtype)
+        if not tensor.is_cpu and not keep_on_device:
+            tensor = tensor.cpu()
+        return tensor
+
+    return postprocess(output)
+
+
+InputProcessingContext._postprocess_output = _postprocess_output_with_npu_preprocess
+Qwen3VLMultiModalProcessor._apply_hf_processor_main = _apply_hf_processor_main_with_npu_preprocess
+Qwen3VLMultiModalProcessor._get_mm_fields_config = _get_mm_fields_config_with_npu_preprocess
+Qwen2VLImageProcessor._preprocess = _preprocess_with_npu_preprocess

--- a/vllm_ascend/patch/worker/__init__.py
+++ b/vllm_ascend/patch/worker/__init__.py
@@ -34,6 +34,7 @@ if get_current_hardware_profile().supports(HardwareCapability.STANDARD_WORKER_PA
     import vllm_ascend.patch.worker.patch_qwen3_5  # noqa
     import vllm_ascend.patch.worker.patch_qwen3_dflash  # noqa
     import vllm_ascend.patch.worker.patch_qwen3vl  # noqa
+    import vllm_ascend.patch.worker.patch_qwen3_preprocess  # noqa
 else:
     import vllm_ascend.patch.worker.patch_idex_310  # noqa
 import vllm_ascend.patch.worker.patch_rejection_sampler  # noqa

--- a/vllm_ascend/patch/worker/patch_qwen3_preprocess.py
+++ b/vllm_ascend/patch/worker/patch_qwen3_preprocess.py
@@ -1,0 +1,159 @@
+# Copyright (c) 2026 Huawei Technologies Co., Ltd. All Rights Reserved.
+# This file is a part of the vllm-ascend project.
+
+"""Worker-side Qwen3-VL family patchify and dtype conversion offload."""
+
+import torch
+from vllm.model_executor.models.qwen3_vl import (
+    Qwen3VLForConditionalGeneration,
+)
+
+from vllm_ascend.ascend_config import get_ascend_config
+
+_ORIGINAL_PARSE_IMAGE_INPUT = Qwen3VLForConditionalGeneration._parse_and_validate_image_input
+_ORIGINAL_PROCESS_IMAGE_INPUT = Qwen3VLForConditionalGeneration._process_image_input
+
+
+def _is_npu_preprocess_enabled() -> bool:
+    return get_ascend_config().enable_qwen3_preprocess_on_npu
+
+
+def _parse_and_validate_image_input_with_npu_preprocess(self, **kwargs: object):
+    pixel_values = kwargs.get("pixel_values")
+    if _is_npu_preprocess_enabled() and isinstance(pixel_values, torch.Tensor) and pixel_values.ndim == 1:
+        # The upstream TensorSchema requires post-patchify 2-D input. Offload
+        # intentionally transports flat pre-patchify CHW data, so retain the
+        # same keys in a plain dict and validate them in _patchify_on_npu.
+        return {
+            "type": "pixel_values",
+            "pixel_values": pixel_values,
+            "image_grid_thw": kwargs.get("image_grid_thw"),
+        }
+    return _ORIGINAL_PARSE_IMAGE_INPUT(self, **kwargs)
+
+
+def _patchify_on_npu(
+    self: Qwen3VLForConditionalGeneration,
+    flat_images: torch.Tensor,
+    image_grid_thw: torch.Tensor,
+) -> torch.Tensor:
+    vision_config = self.config.vision_config
+    channels = int(vision_config.in_channels)
+    patch_size = int(vision_config.patch_size)
+    merge_size = int(vision_config.spatial_merge_size)
+    temporal_patch_size = int(vision_config.temporal_patch_size)
+
+    if image_grid_thw is None or image_grid_thw.ndim != 2:
+        raise ValueError("image_grid_thw must have shape [num_images, 3]")
+    grid_rows = image_grid_thw.tolist()
+    if any(int(grid_t) != 1 for grid_t, _, _ in grid_rows):
+        raise ValueError("preprocessing offload currently supports images only")
+
+    patch_batches: list[torch.Tensor] = []
+    offset = 0
+    image_index = 0
+    while image_index < len(grid_rows):
+        _, grid_h_raw, grid_w_raw = grid_rows[image_index]
+        grid_h, grid_w = int(grid_h_raw), int(grid_w_raw)
+        if grid_h % merge_size or grid_w % merge_size:
+            raise ValueError(
+                f"image grid must be divisible by spatial_merge_size: grid=({grid_h}, {grid_w}), merge={merge_size}"
+            )
+
+        # Batch consecutive images with the same resized shape. This is the
+        # common 5/10-image case and avoids launching one patchify sequence per
+        # image while preserving the original request order without gathers.
+        run_end = image_index + 1
+        while run_end < len(grid_rows):
+            _, next_h, next_w = grid_rows[run_end]
+            if (int(next_h), int(next_w)) != (grid_h, grid_w):
+                break
+            run_end += 1
+        batch_size = run_end - image_index
+
+        height = grid_h * patch_size
+        width = grid_w * patch_size
+        image_numel = channels * height * width
+        batch_end = offset + batch_size * image_numel
+        if batch_end > flat_images.numel():
+            raise ValueError("pixel_values is shorter than image_grid_thw describes")
+
+        images = flat_images[offset:batch_end].reshape(batch_size, channels, height, width)
+        patches = images.reshape(
+            batch_size,
+            channels,
+            grid_h // merge_size,
+            merge_size,
+            patch_size,
+            grid_w // merge_size,
+            merge_size,
+            patch_size,
+        )
+        # Match Transformers Qwen2VLImageProcessor.patchify exactly:
+        # [B, gh/m, gw/m, m, m, C, patch_h, patch_w], followed by temporal
+        # replication for still images. Ascend Copy only accepts tensors with
+        # at most 8 dimensions, so collapse patch_h/patch_w before inserting
+        # the temporal dimension instead of constructing a 9-D view.
+        patches = patches.permute(0, 2, 5, 3, 6, 1, 4, 7)
+        patches = patches.reshape(
+            batch_size,
+            grid_h // merge_size,
+            grid_w // merge_size,
+            merge_size,
+            merge_size,
+            channels,
+            patch_size * patch_size,
+        )
+        patches = (
+            patches.unsqueeze(6)
+            .expand(
+                -1,
+                -1,
+                -1,
+                -1,
+                -1,
+                -1,
+                temporal_patch_size,
+                -1,
+            )
+            .reshape(
+                batch_size * grid_h * grid_w,
+                channels * temporal_patch_size * patch_size * patch_size,
+            )
+            .contiguous()
+        )
+        patch_batches.append(patches)
+        offset = batch_end
+        image_index = run_end
+
+    if offset != flat_images.numel():
+        raise ValueError(
+            "pixel_values has trailing data not described by image_grid_thw: "
+            f"consumed={offset}, total={flat_images.numel()}"
+        )
+    return torch.cat(patch_batches, dim=0)
+
+
+def _process_image_input_with_npu_preprocess(
+    self: Qwen3VLForConditionalGeneration,
+    image_input,
+) -> tuple[torch.Tensor, ...]:
+    pixel_values = image_input.get("pixel_values")
+    if (
+        not _is_npu_preprocess_enabled()
+        or image_input.get("type") != "pixel_values"
+        or not isinstance(pixel_values, torch.Tensor)
+        or pixel_values.ndim != 1
+    ):
+        return _ORIGINAL_PROCESS_IMAGE_INPUT(self, image_input)
+
+    patches = _patchify_on_npu(self, pixel_values, image_input["image_grid_thw"])
+    patched_input = dict(image_input)
+    patched_input["pixel_values"] = patches
+    # Reuse upstream processing for the runtime target dtype conversion,
+    # data-parallel vision dispatch, and per-image embedding split.
+    return _ORIGINAL_PROCESS_IMAGE_INPUT(self, patched_input)
+
+
+Qwen3VLForConditionalGeneration._parse_and_validate_image_input = _parse_and_validate_image_input_with_npu_preprocess
+Qwen3VLForConditionalGeneration._process_image_input = _process_image_input_with_npu_preprocess


### PR DESCRIPTION
### What this PR does / why we need it?

This PR offloads Qwen3-family image patchification and dtype conversion from CPU to NPU to accelerate.

- Keeps image resize, rescale, and normalization on CPU.
- Sends flattened normalized FP32 CHW pixels through the existing multimodal transport.
- Reconstructs the Hugging Face Qwen patch layout on NPU, batching consecutive images with the same resized shape.
- Reuses the upstream `.type(self.visual.dtype)` path after patchification, so the target dtype is selected dynamically.
- Limits the opt-in path to Qwen3-VL/Qwen3.5 image-only requests; unsupported models and video requests retain the upstream behavior.
- Adds the opt-in `additional_config.enable_qwen3_preprocess_on_npu` switch. It is disabled by default.

### Does this PR introduce _any_ user-facing change?

Yes. Qwen3-VL and Qwen3.5 image requests can opt in to NPU patchification and dtype conversion with `--additional-config '{"enable_qwen3_preprocess_on_npu":true}'`. The feature is disabled by default.

### How was this patch tested?

- Manually tested Qwen3.5-35B image inference on Ascend A2. Results show the offload can shorten image preprocess dramatically. Accuracy test with aisbench and textvqa dataset is conducted, as well as md5 output after dtype conversion on CPU and NPU are compared to show this PR does not influence precision.
- Verified that the disabled path retains the upstream preprocessing contract.

- vLLM main: https://github.com/vllm-project/vllm/commit/ba07e4a48fc951300d97eb506217dd530583dea3
