### PR TITLE
[0.27.1rc][BugFix][Attention] Support native non-power-of-two MLA heads

### DIFF
--- a/tests/ut/attention/test_mla_v1.py
+++ b/tests/ut/attention/test_mla_v1.py
@@ -1232,8 +1232,8 @@ class TestAscendMLAImpl(TestBase):
             **kwargs,
         )
         self.assertEqual(impl.num_heads, 20)
-        self.assertEqual(impl.num_heads_padded, 32)  # next power of 2
-        self.assertEqual(impl.head_padding, 12)  # 32 - 20
+        self.assertEqual(impl.num_heads_padded, 32)
+        self.assertEqual(impl.head_padding, 12)
 
     def test_q_proj_and_k_up_proj(self):
         batch_size = 4
@@ -1644,7 +1644,7 @@ class TestAscendMLAImpl(TestBase):
     @patch("vllm_ascend.attention.mla_v1.DeviceOperator")
     @patch("torch_npu.npu_fused_infer_attention_score")
     def test_forward_prefill_non_power_of_two_heads(self, mock_fia, mock_device_operator, mock_get_current_vllm_config):
-        """Test prefill with non-power-of-2 heads uses concat instead of query_rope/key_rope kwargs."""
+        """Test prefill passes RoPE tensors for non-power-of-two heads."""
         mock_get_current_vllm_config.return_value = MagicMock()
         num_heads = 20
         kwargs = {
@@ -1702,11 +1702,13 @@ class TestAscendMLAImpl(TestBase):
 
         result = impl._forward_prefill(q_nope, q_pe, k_nope, k_pe, value, kv_c_and_k_pe_cache, attn_metadata)
 
-        # FIA should be called without query_rope/key_rope when head_padding > 0
         mock_fia.assert_called_once()
+        call_args = mock_fia.call_args
         call_kwargs = mock_fia.call_args.kwargs
-        self.assertNotIn("query_rope", call_kwargs)
-        self.assertNotIn("key_rope", call_kwargs)
+        self.assertEqual(call_args.args[0].shape, q_nope.shape)
+        self.assertEqual(call_args.args[1].shape, k_nope.shape)
+        self.assertEqual(call_kwargs["query_rope"].shape, q_pe.shape)
+        self.assertEqual(call_kwargs["key_rope"].shape, k_pe.shape)
         self.assertEqual(call_kwargs.get("num_heads"), num_heads)
         self.assertEqual(result.shape, (batch_size, num_heads * impl.v_head_dim))
 
@@ -2059,9 +2061,12 @@ class TestAscendMLAImpl(TestBase):
         out, lse = impl._compute_prefill_context(q_nope, q_pe, kv_cache, 32, meta, prefix_out, prefix_lse)
 
         mock_fia.assert_called_once()
+        call_args = mock_fia.call_args
         call_kwargs = mock_fia.call_args.kwargs
-        self.assertNotIn("query_rope", call_kwargs)
-        self.assertNotIn("key_rope", call_kwargs)
+        self.assertEqual(call_args.args[0].shape, q_nope.shape)
+        self.assertEqual(call_args.args[1].shape[-1], impl.qk_nope_head_dim)
+        self.assertEqual(call_kwargs["query_rope"].shape, q_pe.shape)
+        self.assertEqual(call_kwargs["key_rope"].shape[-1], impl.qk_rope_head_dim)
         self.assertEqual(out.shape, prefix_out.shape)
 
     @patch("vllm_ascend.ascend_forward_context.get_forward_context")
@@ -2315,7 +2320,7 @@ class TestAscendMLAImpl(TestBase):
     def test_forward_decode_non_power_of_two_heads(
         self, mock_npu_fused_infer_attention_score_v2, mock_get_forward_context, mock_get_current_vllm_config
     ):
-        """Test decode with non-power-of-2 heads pads to next power of 2 and slices output."""
+        """Test speculative decode passes native non-power-of-two head shapes."""
         mock_get_current_vllm_config.return_value = MagicMock()
         num_heads = 20
         kwargs = {
@@ -2368,9 +2373,8 @@ class TestAscendMLAImpl(TestBase):
         impl.enable_kv_nz = True
         impl.fa_quant_layer = False
 
-        # Return padded output so slice logic works
         mock_npu_fused_infer_attention_score_v2.return_value = [
-            torch.randn(impl.num_heads_padded, B, impl.kv_lora_rank),
+            torch.randn(num_heads, B, impl.kv_lora_rank),
             None,
         ]
         mock_get_forward_context.return_value = MagicMock(capturing=False)
@@ -2380,10 +2384,13 @@ class TestAscendMLAImpl(TestBase):
         self.assertEqual(result.shape[1], num_heads)
         self.assertEqual(result.shape[2], HD)
 
-        # Verify num_query_heads passed to FIA is padded
+        # Verify v2 receives the model's native head count and unpadded Q.
         mock_npu_fused_infer_attention_score_v2.assert_called_once()
+        call_args = mock_npu_fused_infer_attention_score_v2.call_args
         call_kwargs = mock_npu_fused_infer_attention_score_v2.call_args.kwargs
-        self.assertEqual(call_kwargs.get("num_query_heads"), impl.num_heads_padded)
+        self.assertEqual(call_args.args[0].shape, (B, num_heads, impl.qk_nope_head_dim))
+        self.assertEqual(call_kwargs["query_rope"].shape, (B, num_heads, impl.qk_rope_head_dim))
+        self.assertEqual(call_kwargs.get("num_query_heads"), num_heads)
 
     @patch("vllm_ascend.attention.mla_v1.get_current_vllm_config")
     @patch("vllm_ascend.ascend_forward_context.get_forward_context")
@@ -2391,7 +2398,7 @@ class TestAscendMLAImpl(TestBase):
     def test_forward_decode_non_power_of_two_heads_normal(
         self, mock_npu_fused_infer_attention_score_v2, mock_get_forward_context, mock_get_current_vllm_config
     ):
-        """Test normal decode (BNSD_NBSD) with non-power-of-2 heads pads q and slices output."""
+        """Test normal decode passes native non-power-of-two head shapes."""
         mock_get_current_vllm_config.return_value = MagicMock()
         num_heads = 20
         kwargs = {
@@ -2447,7 +2454,7 @@ class TestAscendMLAImpl(TestBase):
         impl.speculative_config = None
 
         mock_npu_fused_infer_attention_score_v2.return_value = [
-            torch.randn(impl.num_heads_padded, B, 1, impl.kv_lora_rank),
+            torch.randn(num_heads, B, 1, impl.kv_lora_rank),
             None,
         ]
         mock_get_forward_context.return_value = MagicMock(capturing=False)
@@ -2458,8 +2465,11 @@ class TestAscendMLAImpl(TestBase):
         self.assertEqual(result.shape[2], HD)
 
         mock_npu_fused_infer_attention_score_v2.assert_called_once()
+        call_args = mock_npu_fused_infer_attention_score_v2.call_args
         call_kwargs = mock_npu_fused_infer_attention_score_v2.call_args.kwargs
-        self.assertEqual(call_kwargs.get("num_query_heads"), impl.num_heads_padded)
+        self.assertEqual(call_args.args[0].shape, (B, num_heads, 1, impl.qk_nope_head_dim))
+        self.assertEqual(call_kwargs["query_rope"].shape, (B, num_heads, 1, impl.qk_rope_head_dim))
+        self.assertEqual(call_kwargs.get("num_query_heads"), num_heads)
 
     @patch("vllm_ascend.ascend_forward_context.get_forward_context")
     @patch("torch_npu.npu_fused_infer_attention_score_v2")

--- a/vllm_ascend/attention/mla_v1.py
+++ b/vllm_ascend/attention/mla_v1.py
@@ -1236,9 +1236,6 @@ class AscendMLAImpl(MLAAttentionImpl):
         out_list = [prefix_output.reshape(num_tokens * H, D)]
         lse_list = [prefix_lse.reshape(num_tokens * H)]
 
-        if self.head_padding > 0:
-            query = torch.cat((q_nope, q_pe), dim=-1)
-
         common_kwargs = {
             "num_heads": self.num_heads,
             "num_key_value_heads": self.num_heads,
@@ -1286,13 +1283,10 @@ class AscendMLAImpl(MLAAttentionImpl):
             actual_seq_lengths_kv = prefill_metadata.chunked_context.chunk_actual_seq_lengths_kv_list[i]
             common_kwargs["actual_seq_lengths_kv"] = actual_seq_lengths_kv
 
-            if self.head_padding > 0:
-                key = torch.cat((k_nope, k_pe), dim=-1)
-            else:
-                common_kwargs["query_rope"] = q_pe
-                common_kwargs["key_rope"] = k_pe.contiguous()
-                query = q_nope
-                key = k_nope
+            common_kwargs["query_rope"] = q_pe
+            common_kwargs["key_rope"] = k_pe.contiguous()
+            query = q_nope
+            key = k_nope
 
             chunk_out, chunk_lse = torch_npu.npu_fused_infer_attention_score(
                 query, key.contiguous(), v.contiguous(), **common_kwargs
@@ -1356,13 +1350,9 @@ class AscendMLAImpl(MLAAttentionImpl):
         }
         record_attention_compute_start()
 
-        if self.head_padding > 0:
-            query = torch.cat((q_nope, q_pe), dim=-1)
-            key = torch.cat((k_nope, k_pe), dim=-1)
-        else:
-            common_kwargs["query_rope"] = q_pe
-            common_kwargs["key_rope"] = k_pe.contiguous()
-            query, key = q_nope, k_nope
+        common_kwargs["query_rope"] = q_pe
+        common_kwargs["key_rope"] = k_pe.contiguous()
+        query, key = q_nope, k_nope
 
         attn_output, attn_lse = torch_npu.npu_fused_infer_attention_score(
             query, key.contiguous(), value.contiguous(), **common_kwargs
@@ -1511,9 +1501,6 @@ class AscendMLAImpl(MLAAttentionImpl):
     ) -> torch.Tensor:
         decode_meta = attn_metadata.decode
         assert decode_meta is not None
-        # TODO: The CANN package is expected to support num_heads that are not
-        # powers of 2 in 2026 Q2. Once supported, all padding operations under
-        # `if self.head_padding > 0` in this function can be removed.
         num_tokens = q_nope.size(0)
         # shape of knope/k_pe for npu graph mode should be:
         # [num_blocks, num_kv_heads, block_size, self.kv_lora_rank/self.qk_rope_head_dim]
@@ -1557,11 +1544,8 @@ class AscendMLAImpl(MLAAttentionImpl):
             # Input shape: [num_tokens, num_heads, dim]
             q_nope = q_nope.view(num_tokens, self.num_heads, -1).contiguous()
             q_pe = q_pe.view(num_tokens, self.num_heads, -1)
-            if self.head_padding > 0:
-                q_pe = F.pad(q_pe, (0, 0, 0, self.head_padding), "constant", 0)
-                q_nope = F.pad(q_nope, (0, 0, 0, self.head_padding), "constant", 0)
             # Output shape: [num_heads, num_tokens, dim]
-            attn_output_shape = (self.num_heads_padded, num_tokens, self.kv_lora_rank)
+            attn_output_shape = (self.num_heads, num_tokens, self.kv_lora_rank)
             if not attn_metadata.causal:
                 # K3's DSpark draft block is bidirectional. With FIA this is
                 # sparse_mode=0 and no mask; a default mask here would hide the
@@ -1582,20 +1566,14 @@ class AscendMLAImpl(MLAAttentionImpl):
                 input_layout = "BNSD"
                 q_nope = q_nope.view(num_tokens, self.num_heads, 1, -1).contiguous()
                 q_pe = q_pe.view(num_tokens, self.num_heads, 1, -1)
-                if self.head_padding > 0:
-                    q_pe = F.pad(q_pe, (0, 0, 0, 0, 0, self.head_padding), "constant", 0)
-                    q_nope = F.pad(q_nope, (0, 0, 0, 0, 0, self.head_padding), "constant", 0)
                 dequant_scale_q_nope = dequant_scale_q_nope.view(num_tokens, self.num_heads, 1)
-                attn_output_shape = (num_tokens, self.num_heads_padded, 1, self.kv_lora_rank)
+                attn_output_shape = (num_tokens, self.num_heads, 1, self.kv_lora_rank)
             else:
                 input_layout = "BSND_NBSD"
                 q_nope = q_nope.view(num_tokens, 1, self.num_heads, -1).contiguous()
                 q_pe = q_pe.view(num_tokens, 1, self.num_heads, -1).contiguous()
-                if self.head_padding > 0:
-                    q_pe = F.pad(q_pe, (0, 0, 0, self.head_padding), "constant", 0)
-                    q_nope = F.pad(q_nope, (0, 0, 0, self.head_padding), "constant", 0)
                 dequant_scale_q_nope = dequant_scale_q_nope.view(num_tokens, 1, self.num_heads)
-                attn_output_shape = (self.num_heads_padded, num_tokens, 1, self.kv_lora_rank)
+                attn_output_shape = (self.num_heads, num_tokens, 1, self.kv_lora_rank)
         else:
             # The output layout is set to NBSD to eliminate the need for a
             # transpose operation after attention.
@@ -1604,26 +1582,20 @@ class AscendMLAImpl(MLAAttentionImpl):
                 input_layout = "BSND_NBSD"
                 q_nope = q_nope.view(num_tokens, 1, self.num_heads, -1).contiguous()
                 q_pe = q_pe.view(num_tokens, 1, self.num_heads, -1)
-                if self.head_padding > 0:
-                    q_pe = F.pad(q_pe, (0, 0, 0, self.head_padding), "constant", 0)
-                    q_nope = F.pad(q_nope, (0, 0, 0, self.head_padding), "constant", 0)
             else:
                 # Input shape: [num_tokens, num_heads, seq_len, dim]
                 input_layout = "BNSD_NBSD"
                 q_nope = q_nope.view(num_tokens, self.num_heads, 1, -1).contiguous()
                 q_pe = q_pe.view(num_tokens, self.num_heads, 1, -1)
-                if self.head_padding > 0:
-                    q_pe = F.pad(q_pe, (0, 0, 0, 0, 0, self.head_padding), "constant", 0)
-                    q_nope = F.pad(q_nope, (0, 0, 0, 0, 0, self.head_padding), "constant", 0)
             # Output shape: [num_heads, num_tokens, seq_len, dim]
-            attn_output_shape = (self.num_heads_padded, num_tokens, 1, self.kv_lora_rank)
+            attn_output_shape = (self.num_heads, num_tokens, 1, self.kv_lora_rank)
             sparse_mode = 0
             attn_mask = None
 
         common_kwargs = {
             "query_rope": q_pe,
             "key_rope": k_pe,
-            "num_query_heads": self.num_heads_padded,
+            "num_query_heads": self.num_heads,
             "num_key_value_heads": self.num_kv_heads,
             "input_layout": input_layout,
             "atten_mask": attn_mask,
@@ -1667,7 +1639,7 @@ class AscendMLAImpl(MLAAttentionImpl):
                 weak_ref_tensors(k_nope),
                 weak_ref_tensors(q_pe),
                 weak_ref_tensors(k_pe),
-                self.num_heads_padded,
+                self.num_heads,
                 self.num_kv_heads,
                 input_layout,
                 weak_ref_tensors(attn_mask) if attn_mask is not None else None,
@@ -1708,8 +1680,6 @@ class AscendMLAImpl(MLAAttentionImpl):
         else:
             attn_output, _ = torch_npu.npu_fused_infer_attention_score_v2(q_nope, k_nope, k_nope, **common_kwargs)
 
-        if self.head_padding > 0:
-            attn_output = attn_output[: self.num_heads]
         return self._v_up_proj(attn_output)
 
     def reorg_decode_q(self, decode_q_nope, decode_q_pe):


### PR DESCRIPTION
### What this PR does / why we need it?

Backports #15558 to `releases/v0.27.1rc`.

Fused attention now receives the model's native non-power-of-two MLA head count in both prefill and decode. This removes Q-head padding, output slicing, and the prefill combined Q/K fallback while preserving the release branch's existing RoPE behavior.

### Does this PR introduce _any_ user-facing change?

No API change. Models with non-power-of-two MLA head counts use native head shapes internally.

### How was this patch tested?

- `git diff --check upstream/releases/v0.27.1rc...HEAD`
- `python -m py_compile vllm_ascend/attention/mla_v1.py tests/ut/attention/test_mla_v1.py`
- Targeted pytest/ruff and Ascend NPU runtime validation were not available in the local Windows environment; CI verification is required.

- vLLM main: https://github.com/vllm-project/vllm/commit/ba07e4a48fc951300d97eb506217dd530583dea3
