### PR TITLE
[Performance][LoRA] Improve LoRA performance on A2 & A3

### DIFF
--- a/tests/e2e/nightly/single_node/ops/singlecard_ops/triton/test_lora_linear.py
+++ b/tests/e2e/nightly/single_node/ops/singlecard_ops/triton/test_lora_linear.py
@@ -1,0 +1,213 @@
+# SPDX-License-Identifier: Apache-2.0
+
+import gc
+import itertools
+
+import pytest
+import torch
+
+from vllm_ascend.lora.lora_ops import (
+    _LORA_TRITON_BLOCK_K,
+    _LORA_TRITON_K_SPLIT,
+    _LORA_TRITON_MAX_TOKENS,
+    _lora_expand_kernel,
+    _lora_expand_sliced_kernel,
+    _lora_shrink_splitk_kernel,
+)
+from vllm_ascend.ops.triton.triton_utils import init_device_properties_triton
+
+# TP-local Qwen3.5-27B inference shapes. The single-slice case covers the
+# transposed-B path; QKV and QKVZ cover three- and four-slice packed weights.
+PROJECTION_SHAPES = {
+    "o_proj": (1536, (5120,)),
+    "qkv_proj": (5120, (1024, 512, 512)),
+    "qkvz_proj": (5120, (1536, 512, 512, 1536)),
+}
+TOKEN_CASES = [
+    pytest.param(1, "o_proj", id="decode-1"),
+    pytest.param(31, "qkv_proj", id="mtp-31"),
+    pytest.param(128, "qkvz_proj", id="max-tokens-128"),
+]
+
+
+def _ceil_div(value: int, divisor: int) -> int:
+    return (value + divisor - 1) // divisor
+
+
+@pytest.fixture(scope="module", autouse=True)
+def init_triton_device():
+    torch.npu.set_device(0)
+    init_device_properties_triton()
+    yield
+    gc.collect()
+    torch.npu.empty_cache()
+
+
+def _make_packed_weights(
+    slice_rank: int,
+    hidden_size: int,
+    output_slices: tuple[int, ...],
+) -> tuple[torch.Tensor, list[torch.Tensor], torch.Tensor, bool]:
+    a_slices = [torch.randn(slice_rank, hidden_size, dtype=torch.bfloat16, device="npu") * 0.01 for _ in output_slices]
+    b_slices = [
+        torch.randn(output_size, slice_rank, dtype=torch.bfloat16, device="npu") * 0.01 for output_size in output_slices
+    ]
+    packed_a = torch.cat(a_slices)
+
+    if len(output_slices) == 1:
+        return packed_a, b_slices, b_slices[0].contiguous(), True
+
+    total_rank = slice_rank * len(output_slices)
+    total_output = sum(output_slices)
+    packed_b = torch.zeros(total_rank, total_output, dtype=torch.bfloat16, device="npu")
+    rank_start = 0
+    output_start = 0
+    for output_size, b_slice in zip(output_slices, b_slices):
+        packed_b[
+            rank_start : rank_start + slice_rank,
+            output_start : output_start + output_size,
+        ].copy_(b_slice.T)
+        rank_start += slice_rank
+        output_start += output_size
+    return packed_a, b_slices, packed_b, False
+
+
+def _launch_lora_kernels(
+    x: torch.Tensor,
+    packed_a: torch.Tensor,
+    packed_b: torch.Tensor,
+    y: torch.Tensor,
+    adapter_mask: torch.Tensor,
+    output_slices: tuple[int, ...],
+    slice_rank: int,
+    scale: float,
+    b_transposed: bool,
+) -> None:
+    token_count = x.size(0)
+    total_rank = packed_a.size(0)
+    output_size = y.size(1)
+    block_m = 16 if token_count <= 8 else 32
+    block_n = 1024 if token_count <= 8 and total_rank <= 48 else 512
+    workspace = torch.empty(
+        _LORA_TRITON_K_SPLIT,
+        _LORA_TRITON_MAX_TOKENS,
+        total_rank,
+        dtype=torch.float32,
+        device="npu",
+    )
+
+    _lora_shrink_splitk_kernel[(_LORA_TRITON_K_SPLIT, _ceil_div(token_count, block_m))](
+        x,
+        packed_a,
+        workspace,
+        token_count,
+        x.size(1),
+        RANK=total_rank,
+        WORKSPACE_TOKENS=_LORA_TRITON_MAX_TOKENS,
+        BLOCK_M=block_m,
+        BLOCK_K=_LORA_TRITON_BLOCK_K,
+        K_SPLIT=_LORA_TRITON_K_SPLIT,
+    )
+
+    use_sliced_expand = len(output_slices) > 1 and slice_rank >= 32
+    if use_sliced_expand:
+        tile_counts = [_ceil_div(size, block_n) for size in output_slices]
+        tile_ends = list(itertools.accumulate(tile_counts))
+        output_starts = [0, *itertools.accumulate(output_slices)]
+        while len(tile_ends) < 4:
+            tile_ends.append(tile_ends[-1])
+        while len(output_starts) < 5:
+            output_starts.append(output_size)
+        _lora_expand_sliced_kernel[(sum(tile_counts), _ceil_div(token_count, block_m))](
+            workspace,
+            packed_b,
+            y,
+            adapter_mask,
+            token_count,
+            output_size,
+            scale,
+            TOTAL_RANK=total_rank,
+            SLICE_RANK=slice_rank,
+            WORKSPACE_TOKENS=_LORA_TRITON_MAX_TOKENS,
+            BLOCK_M=block_m,
+            BLOCK_N=block_n,
+            K_SPLIT=_LORA_TRITON_K_SPLIT,
+            TILE_END_0=tile_ends[0],
+            TILE_END_1=tile_ends[1],
+            TILE_END_2=tile_ends[2],
+            OUTPUT_START_1=output_starts[1],
+            OUTPUT_START_2=output_starts[2],
+            OUTPUT_START_3=output_starts[3],
+        )
+        return
+
+    _lora_expand_kernel[(_ceil_div(output_size, block_n), _ceil_div(token_count, block_m))](
+        workspace,
+        packed_b,
+        y,
+        adapter_mask,
+        token_count,
+        output_size,
+        scale,
+        RANK=total_rank,
+        WORKSPACE_TOKENS=_LORA_TRITON_MAX_TOKENS,
+        BLOCK_M=block_m,
+        BLOCK_N=block_n,
+        K_SPLIT=_LORA_TRITON_K_SPLIT,
+        B_TRANSPOSED=b_transposed,
+    )
+
+
+@pytest.mark.parametrize("slice_rank", [8, 16, 32, 64])
+@pytest.mark.parametrize("token_count,projection_name", TOKEN_CASES)
+@torch.inference_mode()
+def test_lora_linear_triton_accuracy(
+    slice_rank: int,
+    token_count: int,
+    projection_name: str,
+) -> None:
+    torch.manual_seed(123)
+    hidden_size, output_slices = PROJECTION_SHAPES[projection_name]
+    x = torch.randn(token_count, hidden_size, dtype=torch.bfloat16, device="npu")
+    packed_a, b_slices, packed_b, b_transposed = _make_packed_weights(
+        slice_rank,
+        hidden_size,
+        output_slices,
+    )
+    y_initial = torch.randn(
+        token_count,
+        sum(output_slices),
+        dtype=torch.bfloat16,
+        device="npu",
+    )
+    y = y_initial.clone()
+    adapter_mask = (torch.arange(_LORA_TRITON_MAX_TOKENS, device="npu") % 3 != 1).to(torch.bfloat16)
+    scale = 0.5
+
+    _launch_lora_kernels(
+        x,
+        packed_a,
+        packed_b,
+        y,
+        adapter_mask,
+        output_slices,
+        slice_rank,
+        scale,
+        b_transposed,
+    )
+    torch.npu.synchronize()
+
+    a_slices = packed_a.split(slice_rank)
+    deltas = [(x.float() @ a_slice.float().T) @ b_slice.float().T for a_slice, b_slice in zip(a_slices, b_slices)]
+    expected = y_initial.float() + torch.cat(deltas, dim=1) * adapter_mask[:token_count, None].float() * scale
+    difference = y.float() - expected
+    relative_l2 = torch.linalg.vector_norm(difference) / torch.linalg.vector_norm(expected)
+    assert relative_l2.item() < 0.005
+
+    if token_count > 1:
+        inactive = ~adapter_mask[:token_count].bool()
+        torch.testing.assert_close(y[inactive], y_initial[inactive], rtol=0, atol=0)
+
+    del x, packed_a, packed_b, b_slices, y_initial, y
+    gc.collect()
+    torch.npu.empty_cache()

--- a/tests/ut/lora/test_lora.py
+++ b/tests/ut/lora/test_lora.py
@@ -319,3 +319,64 @@ def test_decode_metadata_refreshes_no_lora(index_mapping, expected_no_lora) -> N
     with patch.object(PunicaWrapperBase, "update_metadata"):
         wrapper.update_metadata(mapping, [], 2, 100)
     assert wrapper.no_lora is expected_no_lora
+
+
+def test_single_lora_mask_follows_token_mapping() -> None:
+    wrapper = object.__new__(PunicaWrapperNPU)
+    wrapper._token_lora_indices = torch.tensor([0, -1, 0, -1])
+    wrapper._single_lora_mask = torch.empty(4, 1, dtype=torch.bfloat16)
+    wrapper.indices_len = [4, 0, 0, 0]
+    with patch.object(PunicaWrapperBase, "_update_base_metadata"):
+        wrapper._update_base_metadata(Mock(), [], 1, 100)
+    torch.testing.assert_close(
+        wrapper._single_lora_mask,
+        torch.tensor([[1], [0], [1], [0]], dtype=torch.bfloat16),
+    )
+
+
+@pytest.mark.parametrize("use_buffer", [False, True])
+def test_add_lora_linear_skips_no_lora_batch(use_buffer: bool) -> None:
+    wrapper = object.__new__(PunicaWrapperNPU)
+    wrapper.no_lora = True
+    wrapper._wrapper_id = 0
+    wrapper.add_shrink = Mock()
+    wrapper.add_expand = Mock()
+    x = torch.randn(2, 4, dtype=torch.bfloat16)
+    y = torch.randn(2, 5, dtype=torch.bfloat16)
+    original = y.clone()
+    lora_a = (torch.randn(1, 1, 2, 4, dtype=torch.bfloat16),)
+    lora_b = (torch.randn(1, 1, 5, 2, dtype=torch.bfloat16),)
+    buffer = (torch.empty(2, 2, dtype=torch.float32),) if use_buffer else None
+
+    with patch("vllm_ascend.lora.punica_npu.lora_linear") as linear:
+        wrapper.add_lora_linear(y, x, lora_a, lora_b, 1.0, (5,), buffer=buffer)
+
+    linear.assert_not_called()
+    wrapper.add_shrink.assert_not_called()
+    wrapper.add_expand.assert_not_called()
+    torch.testing.assert_close(y, original)
+
+
+@pytest.mark.parametrize("add_inputs", [True, False])
+def test_packed_single_lora_matmul(add_inputs: bool) -> None:
+    wrapper = object.__new__(PunicaWrapperNPU)
+    wrapper._single_lora_mask = torch.tensor([[1], [0], [1]], dtype=torch.bfloat16)
+    x = torch.randn(3, 4, dtype=torch.bfloat16)
+    y = torch.randn(3, 5, dtype=torch.bfloat16)
+    original = y.clone()
+    lora_a = tuple(torch.randn(1, 1, 2, 4, dtype=torch.bfloat16) for _ in range(2))
+    lora_b = (
+        torch.randn(1, 1, 3, 2, dtype=torch.bfloat16),
+        torch.randn(1, 1, 2, 2, dtype=torch.bfloat16),
+    )
+    packed_a = torch.cat(lora_a, dim=2)
+    packed_b = torch.zeros(1, 1, 4, 5, dtype=torch.bfloat16)
+    packed_b[0, 0, :2, :3] = lora_b[0][0, 0].T
+    packed_b[0, 0, 2:, 3:] = lora_b[1][0, 0].T
+
+    wrapper._lora_linear_matmul(y, x, lora_a, lora_b, 0.5, (3, 2), packed_a, packed_b, add_inputs)
+    delta = (x @ packed_a[0, 0].T).mul(wrapper._single_lora_mask)
+    expected = delta.mul(0.5) @ packed_b[0, 0]
+    if add_inputs:
+        expected.add_(original)
+    torch.testing.assert_close(y, expected)

--- a/tests/ut/lora/test_punica_npu.py
+++ b/tests/ut/lora/test_punica_npu.py
@@ -62,13 +62,21 @@ def test_punica_init_selects_kernel_backend(device_type, max_lora_rank, expect_t
             "vllm_ascend.lora.punica_npu.get_current_hardware_profile",
             return_value=get_hardware_profile(device_type),
         ),
+        patch(
+            "vllm_ascend.lora.punica_npu.get_ascend_device_type",
+            return_value=device_type,
+        ),
         patch("vllm_ascend.lora.punica_npu.refresh_all_lora_classes") as refresh,
     ):
         wrapper = PunicaWrapperNPU(
             8,
             2,
             torch.device("cpu"),
-            lora_config=SimpleNamespace(max_lora_rank=max_lora_rank),
+            lora_config=SimpleNamespace(
+                max_lora_rank=max_lora_rank,
+                max_loras=2,
+                fully_sharded_loras=False,
+            ),
         )
     refresh.assert_called_once()
     if expect_torch_ops:
@@ -146,15 +154,17 @@ def test_add_lora_embedding_prefill_uses_sgmv_expand() -> None:
     wrapper.bgmv_expand.assert_not_called()
 
 
-def test_add_lora_linear_allocates_fp32_buffer_when_missing() -> None:
+def test_lora_linear_kernel_allocates_fp32_buffer_when_missing() -> None:
     wrapper = _make_wrapper()
+    wrapper._lora_shrink_buffers = {}
+    wrapper._max_num_batched_tokens = 8
     wrapper.add_shrink = Mock()
     wrapper.add_expand = Mock()
     x = torch.ones(3, 8)
     y = torch.zeros(3, 16)
     a = (torch.ones(2, 4, 8),)
     b = (torch.ones(2, 16, 4),)
-    wrapper.add_lora_linear(y, x, a, b, 1.0, (16,))
+    wrapper._lora_linear_kernel(y, x, a, b, 1.0, (16,))
     buffer = wrapper.add_shrink.call_args.args[0]
     assert len(buffer) == 1
     assert buffer[0].shape == (3, 4)

--- a/tests/ut/lora/test_utils.py
+++ b/tests/ut/lora/test_utils.py
@@ -16,7 +16,13 @@
 import vllm.lora.utils as lora_utils
 
 from vllm_ascend.lora.fused_moe import AscendFusedMoE3DWithLoRA, AscendFusedMoEWithLoRA
-from vllm_ascend.lora.utils import refresh_all_lora_classes
+from vllm_ascend.lora.utils import (
+    AscendColumnParallelLinearWithLoRA,
+    AscendMergedColumnParallelLinearWithLoRA,
+    AscendMergedQKVParallelLinearWithLoRA,
+    AscendRowParallelLinearWithLoRA,
+    refresh_all_lora_classes,
+)
 
 
 def test_refresh_all_lora_classes_prepends_ascend_wrappers() -> None:
@@ -26,8 +32,15 @@ def test_refresh_all_lora_classes_prepends_ascend_wrappers() -> None:
         lora_utils._all_lora_classes = (sentinel,)
         refresh_all_lora_classes()
         classes = list(lora_utils._all_lora_classes)
-        assert classes[0] is AscendFusedMoEWithLoRA
-        assert classes[1] is AscendFusedMoE3DWithLoRA
+        expected_prefix = [
+            AscendRowParallelLinearWithLoRA,
+            AscendColumnParallelLinearWithLoRA,
+            AscendMergedColumnParallelLinearWithLoRA,
+            AscendMergedQKVParallelLinearWithLoRA,
+            AscendFusedMoEWithLoRA,
+            AscendFusedMoE3DWithLoRA,
+        ]
+        assert classes[: len(expected_prefix)] == expected_prefix
         assert classes[-1] is sentinel
         # Upstream model_manager still matches the GPU class names.
         assert AscendFusedMoEWithLoRA.__name__ == "FusedMoEWithLoRA"

--- a/vllm_ascend/lora/lora_ops.py
+++ b/vllm_ascend/lora/lora_ops.py
@@ -13,7 +13,18 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import itertools
+
 import torch
+from vllm.forward_context import get_forward_context, is_forward_context_available
+
+try:
+    import triton  # type: ignore[import-untyped]
+    import triton.language as tl  # type: ignore[import-untyped]
+
+    _HAS_TRITON = True
+except ImportError:
+    _HAS_TRITON = False
 
 
 def bgmv_shrink(
@@ -120,3 +131,387 @@ def sgmv_expand_slice(
     return torch.ops._C_ascend.sgmv_expand(
         inputs, lora_b_weights, lora_indices_tensor, seq_len_tensor, output_tensor, slice_offset, slice_size
     )
+
+
+_LORA_TRITON_RANKS = (8, 16, 32, 64)
+_LORA_TRITON_MAX_TOKENS = 128
+_LORA_TRITON_BLOCK_K = 256
+_LORA_TRITON_K_SPLIT = 4
+
+
+if _HAS_TRITON:
+
+    @triton.jit
+    def _lora_shrink_splitk_kernel(
+        x_ptr,
+        a_ptr,
+        workspace_ptr,
+        token_count,
+        hidden_size,
+        RANK: tl.constexpr,
+        WORKSPACE_TOKENS: tl.constexpr,
+        BLOCK_M: tl.constexpr,
+        BLOCK_K: tl.constexpr,
+        K_SPLIT: tl.constexpr,
+    ):
+        split_id = tl.program_id(0)
+        block_m_id = tl.program_id(1)
+        token_offsets = block_m_id * BLOCK_M + tl.arange(0, BLOCK_M)
+        token_mask = token_offsets < token_count
+        k_per_split = tl.cdiv(hidden_size, K_SPLIT)
+        k_start = split_id * k_per_split
+        accum = tl.zeros((BLOCK_M, RANK), dtype=tl.float32)
+        for block_k_id in range(0, tl.cdiv(k_per_split, BLOCK_K)):
+            k_offsets = k_start + block_k_id * BLOCK_K + tl.arange(0, BLOCK_K)
+            k_mask = k_offsets < tl.minimum(k_start + k_per_split, hidden_size)
+            x = tl.load(
+                x_ptr + token_offsets[:, None] * hidden_size + k_offsets[None, :],
+                mask=token_mask[:, None] & k_mask[None, :],
+                other=0.0,
+            )
+            a = tl.load(
+                a_ptr + tl.arange(0, RANK)[:, None] * hidden_size + k_offsets[None, :],
+                mask=k_mask[None, :],
+                other=0.0,
+            )
+            accum += tl.dot(x, tl.trans(a))
+        tl.store(
+            workspace_ptr
+            + split_id * WORKSPACE_TOKENS * RANK
+            + token_offsets[:, None] * RANK
+            + tl.arange(0, RANK)[None, :],
+            accum.to(workspace_ptr.dtype.element_ty),
+            mask=token_mask[:, None],
+        )
+
+    @triton.jit
+    def _lora_expand_kernel(
+        workspace_ptr,
+        b_ptr,
+        y_ptr,
+        adapter_mask_ptr,
+        token_count,
+        output_size,
+        scale,
+        RANK: tl.constexpr,
+        WORKSPACE_TOKENS: tl.constexpr,
+        BLOCK_M: tl.constexpr,
+        BLOCK_N: tl.constexpr,
+        K_SPLIT: tl.constexpr,
+        B_TRANSPOSED: tl.constexpr,
+    ):
+        block_n_id = tl.program_id(0)
+        block_m_id = tl.program_id(1)
+        token_offsets = block_m_id * BLOCK_M + tl.arange(0, BLOCK_M)
+        token_mask = token_offsets < token_count
+        shrink = tl.zeros((BLOCK_M, RANK), dtype=tl.float32)
+        for split_id in range(0, K_SPLIT):
+            shrink += tl.load(
+                workspace_ptr
+                + split_id * WORKSPACE_TOKENS * RANK
+                + token_offsets[:, None] * RANK
+                + tl.arange(0, RANK)[None, :],
+                mask=token_mask[:, None],
+                other=0.0,
+            ).to(tl.float32)
+        adapter_mask = tl.load(
+            adapter_mask_ptr + token_offsets,
+            mask=token_mask,
+            other=0.0,
+        ).to(tl.float32)
+        shrink = shrink * adapter_mask[:, None] * scale
+        output_offsets = block_n_id * BLOCK_N + tl.arange(0, BLOCK_N)
+        output_mask = output_offsets < output_size
+        if B_TRANSPOSED:
+            b = tl.load(
+                b_ptr + output_offsets[None, :] * RANK + tl.arange(0, RANK)[:, None],
+                mask=output_mask[None, :],
+                other=0.0,
+            )
+        else:
+            b = tl.load(
+                b_ptr + tl.arange(0, RANK)[:, None] * output_size + output_offsets[None, :],
+                mask=output_mask[None, :],
+                other=0.0,
+            )
+        delta = tl.dot(shrink.to(b.dtype), b)
+        y_ptrs = y_ptr + token_offsets[:, None] * output_size + output_offsets[None, :]
+        store_mask = token_mask[:, None] & output_mask[None, :]
+        y = tl.load(y_ptrs, mask=store_mask, other=0.0)
+        tl.store(y_ptrs, (y.to(tl.float32) + delta).to(y.dtype), mask=store_mask)
+
+    @triton.jit
+    def _lora_expand_sliced_kernel(
+        workspace_ptr,
+        b_ptr,
+        y_ptr,
+        adapter_mask_ptr,
+        token_count,
+        output_size,
+        scale,
+        TOTAL_RANK: tl.constexpr,
+        SLICE_RANK: tl.constexpr,
+        WORKSPACE_TOKENS: tl.constexpr,
+        BLOCK_M: tl.constexpr,
+        BLOCK_N: tl.constexpr,
+        K_SPLIT: tl.constexpr,
+        TILE_END_0: tl.constexpr,
+        TILE_END_1: tl.constexpr,
+        TILE_END_2: tl.constexpr,
+        OUTPUT_START_1: tl.constexpr,
+        OUTPUT_START_2: tl.constexpr,
+        OUTPUT_START_3: tl.constexpr,
+    ):
+        """Expand up to four packed slices without multiplying zero blocks."""
+        block_n_id = tl.program_id(0)
+        block_m_id = tl.program_id(1)
+        slice_id = tl.where(
+            block_n_id < TILE_END_0,
+            0,
+            tl.where(block_n_id < TILE_END_1, 1, tl.where(block_n_id < TILE_END_2, 2, 3)),
+        )
+        tile_start = tl.where(
+            slice_id == 0,
+            0,
+            tl.where(slice_id == 1, TILE_END_0, tl.where(slice_id == 2, TILE_END_1, TILE_END_2)),
+        )
+        output_start = tl.where(
+            slice_id == 0,
+            0,
+            tl.where(
+                slice_id == 1,
+                OUTPUT_START_1,
+                tl.where(slice_id == 2, OUTPUT_START_2, OUTPUT_START_3),
+            ),
+        )
+        output_end = tl.where(
+            slice_id == 0,
+            OUTPUT_START_1,
+            tl.where(
+                slice_id == 1,
+                OUTPUT_START_2,
+                tl.where(slice_id == 2, OUTPUT_START_3, output_size),
+            ),
+        )
+        token_offsets = block_m_id * BLOCK_M + tl.arange(0, BLOCK_M)
+        token_mask = token_offsets < token_count
+        rank_offsets = tl.arange(0, SLICE_RANK)
+        rank_start = slice_id * SLICE_RANK
+        shrink = tl.zeros((BLOCK_M, SLICE_RANK), dtype=tl.float32)
+        for split_id in range(0, K_SPLIT):
+            shrink += tl.load(
+                workspace_ptr
+                + split_id * WORKSPACE_TOKENS * TOTAL_RANK
+                + token_offsets[:, None] * TOTAL_RANK
+                + rank_start
+                + rank_offsets[None, :],
+                mask=token_mask[:, None],
+                other=0.0,
+            ).to(tl.float32)
+        adapter_mask = tl.load(adapter_mask_ptr + token_offsets, mask=token_mask, other=0.0)
+        shrink = shrink * adapter_mask[:, None].to(tl.float32) * scale
+        output_offsets = output_start + (block_n_id - tile_start) * BLOCK_N + tl.arange(0, BLOCK_N)
+        output_mask = output_offsets < output_end
+        b = tl.load(
+            b_ptr + (rank_start + rank_offsets[:, None]) * output_size + output_offsets[None, :],
+            mask=output_mask[None, :],
+            other=0.0,
+        )
+        delta = tl.dot(shrink.to(b.dtype), b)
+        y_ptrs = y_ptr + token_offsets[:, None] * output_size + output_offsets[None, :]
+        store_mask = token_mask[:, None] & output_mask[None, :]
+        y = tl.load(y_ptrs, mask=store_mask, other=0.0)
+        tl.store(y_ptrs, (y.to(tl.float32) + delta).to(y.dtype), mask=store_mask)
+
+
+def _lora_is_capturing() -> bool:
+    try:
+        return is_forward_context_available() and bool(get_forward_context().capturing)
+    except (AttributeError, RuntimeError):
+        return False
+
+
+def _try_lora_linear_triton(
+    wrapper,
+    y: torch.Tensor,
+    x: torch.Tensor,
+    lora_a_stacked: list[torch.Tensor],
+    lora_b_stacked: list[torch.Tensor],
+    scale: float,
+    output_slices: list[int],
+    packed_lora_a: torch.Tensor | None,
+    packed_lora_b: torch.Tensor | None,
+) -> bool:
+    if not (_HAS_TRITON and _lora_is_capturing()):
+        return False
+    x = x.view(-1, x.shape[-1])
+    y = y.view(-1, y.shape[-1])
+    token_count = x.size(0)
+    if token_count > _LORA_TRITON_MAX_TOKENS or x.dtype != torch.bfloat16 or y.dtype != torch.bfloat16:
+        return False
+
+    if len(lora_a_stacked) > 1:
+        if packed_lora_a is None or packed_lora_b is None or sum(output_slices) != y.size(1):
+            return False
+        a = packed_lora_a[0, 0]
+        b = packed_lora_b[0, 0]
+        b_transposed = False
+    else:
+        a = lora_a_stacked[0][0, 0]
+        if packed_lora_b is not None:
+            b = packed_lora_b[0, 0]
+            b_transposed = False
+        else:
+            b = lora_b_stacked[0][0, 0, : output_slices[0]]
+            b_transposed = True
+
+    if not (x.is_contiguous() and y.is_contiguous() and a.is_contiguous() and b.is_contiguous()):
+        return False
+    rank = a.size(0)
+    slice_rank = lora_b_stacked[0].size(-1)
+    output_size = y.size(1)
+    if slice_rank not in _LORA_TRITON_RANKS or a.dtype != torch.bfloat16 or b.dtype != torch.bfloat16:
+        return False
+    # Large MLP projections cross over to packed matmul sooner than attention
+    # projections. Keep Triton through 128 tokens for attention-sized outputs,
+    # while avoiding the measured regressions on gate/up and down projections.
+    if output_size >= 8192 and token_count > (32 if slice_rank <= 16 else 64):
+        return False
+    if output_size >= 5120 and slice_rank >= 16 and token_count > 64:
+        return False
+    assert wrapper._single_lora_mask is not None
+    workspaces = wrapper._lora_triton_workspaces
+    workspace = workspaces.get(rank)
+    if workspace is None:
+        workspace = torch.empty(
+            (_LORA_TRITON_K_SPLIT, _LORA_TRITON_MAX_TOKENS, rank),
+            dtype=torch.float32,
+            device=x.device,
+        )
+        workspaces[rank] = workspace
+
+    block_m = 16 if token_count <= 8 else 32
+    _lora_shrink_splitk_kernel[(_LORA_TRITON_K_SPLIT, triton.cdiv(token_count, block_m))](
+        x,
+        a,
+        workspace,
+        token_count,
+        x.size(1),
+        RANK=rank,
+        WORKSPACE_TOKENS=_LORA_TRITON_MAX_TOKENS,
+        BLOCK_M=block_m,
+        BLOCK_K=_LORA_TRITON_BLOCK_K,
+        K_SPLIT=_LORA_TRITON_K_SPLIT,
+    )
+    block_n = 1024 if token_count <= 8 and rank <= 48 else 512
+    use_sliced_expand = len(output_slices) > 1 and slice_rank >= 32 and len(output_slices) <= 4
+    if use_sliced_expand:
+        tile_counts = [triton.cdiv(size, block_n) for size in output_slices]
+        tile_ends = list(itertools.accumulate(tile_counts))
+        output_starts = [0, *itertools.accumulate(output_slices)]
+        while len(tile_ends) < 4:
+            tile_ends.append(tile_ends[-1])
+        while len(output_starts) < 5:
+            output_starts.append(output_size)
+        _lora_expand_sliced_kernel[(tile_ends[len(output_slices) - 1], triton.cdiv(token_count, block_m))](
+            workspace,
+            b,
+            y,
+            wrapper._single_lora_mask,
+            token_count,
+            output_size,
+            scale,
+            TOTAL_RANK=rank,
+            SLICE_RANK=slice_rank,
+            WORKSPACE_TOKENS=_LORA_TRITON_MAX_TOKENS,
+            BLOCK_M=block_m,
+            BLOCK_N=block_n,
+            K_SPLIT=_LORA_TRITON_K_SPLIT,
+            TILE_END_0=tile_ends[0],
+            TILE_END_1=tile_ends[1],
+            TILE_END_2=tile_ends[2],
+            OUTPUT_START_1=output_starts[1],
+            OUTPUT_START_2=output_starts[2],
+            OUTPUT_START_3=output_starts[3],
+        )
+        return True
+    _lora_expand_kernel[(triton.cdiv(output_size, block_n), triton.cdiv(token_count, block_m))](
+        workspace,
+        b,
+        y,
+        wrapper._single_lora_mask,
+        token_count,
+        output_size,
+        scale,
+        RANK=rank,
+        WORKSPACE_TOKENS=_LORA_TRITON_MAX_TOKENS,
+        BLOCK_M=block_m,
+        BLOCK_N=block_n,
+        K_SPLIT=_LORA_TRITON_K_SPLIT,
+        B_TRANSPOSED=b_transposed,
+    )
+    return True
+
+
+_LORA_WRAPPERS: dict = {}  # wrapper_id: int -> wrapper: PunicaWrapperNPU
+_LORA_WRAPPER_IDS = itertools.count()
+
+
+@torch.library.custom_op("_vllm_ascend_lora::lora_linear", mutates_args={"y"})
+def lora_linear(
+    wrapper_id: int,
+    y: torch.Tensor,
+    x: torch.Tensor,
+    lora_a_stacked: list[torch.Tensor],
+    lora_b_stacked: list[torch.Tensor],
+    scale: float,
+    output_slices: list[int],
+    packed_lora_a: torch.Tensor | None,
+    packed_lora_b: torch.Tensor | None,
+    add_inputs: bool,
+) -> None:
+    wrapper = _LORA_WRAPPERS[wrapper_id]
+    packed = len(lora_a_stacked) == 1 or (packed_lora_a is not None and packed_lora_b is not None)
+    use_kernel = not wrapper._single_lora_slot or not packed
+    if use_kernel:
+        wrapper._lora_linear_kernel(y, x, lora_a_stacked, lora_b_stacked, scale, output_slices)
+    else:
+        if _try_lora_linear_triton(
+            wrapper,
+            y,
+            x,
+            lora_a_stacked,
+            lora_b_stacked,
+            scale,
+            output_slices,
+            packed_lora_a,
+            packed_lora_b,
+        ):
+            return
+        wrapper._lora_linear_matmul(
+            y,
+            x,
+            lora_a_stacked,
+            lora_b_stacked,
+            scale,
+            output_slices,
+            packed_lora_a,
+            packed_lora_b,
+            add_inputs,
+        )
+
+
+@lora_linear.register_fake
+def _lora_linear_fake(
+    wrapper_id,
+    y,
+    x,
+    lora_a_stacked,
+    lora_b_stacked,
+    scale,
+    output_slices,
+    packed_lora_a,
+    packed_lora_b,
+    add_inputs,
+) -> None:
+    pass

--- a/vllm_ascend/lora/punica_npu.py
+++ b/vllm_ascend/lora/punica_npu.py
@@ -6,7 +6,9 @@ import torch
 from vllm.lora.punica_wrapper.punica_base import PunicaWrapperBase
 
 from vllm_ascend.device.hardware_profile import HardwareCapability, get_current_hardware_profile
+from vllm_ascend.lora.lora_ops import _LORA_WRAPPER_IDS, _LORA_WRAPPERS, lora_linear
 from vllm_ascend.lora.utils import refresh_all_lora_classes
+from vllm_ascend.utils import AscendDeviceType, get_ascend_device_type
 
 
 # The platforms that are compatible with the PyTorch-native implementation can
@@ -21,7 +23,11 @@ class PunicaWrapperNPU(PunicaWrapperBase):
     def __init__(self, max_num_batched_tokens: int, max_batches: int, device: torch.device | str, **kwargs):
         PunicaWrapperBase.__init__(self, max_num_batched_tokens, max_batches, device)
         refresh_all_lora_classes()
+        self._max_num_batched_tokens = max_num_batched_tokens
+        self._lora_shrink_buffers: dict[tuple[int, int], torch.Tensor] = {}
+        self._lora_triton_workspaces: dict[int, torch.Tensor] = {}
         self.lora_config = kwargs.get("lora_config")
+        ascend_device_type = get_ascend_device_type()
         if not get_current_hardware_profile().supports(HardwareCapability.LORA_CUSTOM_OPS) or (
             self.lora_config is not None and self.lora_config.max_lora_rank >= 128
         ):
@@ -48,6 +54,40 @@ class PunicaWrapperNPU(PunicaWrapperBase):
         self.sgmv_expand = sgmv_expand
         self.sgmv_expand_slice = sgmv_expand_slice
         self.sgmv_shrink = sgmv_shrink
+        self._single_lora_slot = (
+            ascend_device_type in {AscendDeviceType.A2, AscendDeviceType.A3}
+            and self.lora_config is not None
+            and self.lora_config.max_loras == 1
+            and not self.lora_config.fully_sharded_loras
+        )
+        self._single_lora_mask = None
+        self._wrapper_id = next(_LORA_WRAPPER_IDS)
+        _LORA_WRAPPERS[self._wrapper_id] = self
+        if self._single_lora_slot:
+            assert self.lora_config is not None
+            lora_dtype = self.lora_config.lora_dtype
+            if not isinstance(lora_dtype, torch.dtype):
+                raise ValueError(f"LoRA dtype must be resolved before creating the Punica wrapper, got {lora_dtype!r}")
+            self._single_lora_mask = torch.empty(
+                (max_num_batched_tokens, 1),
+                dtype=lora_dtype,
+                device=device,
+            )
+
+    def _update_base_metadata(
+        self,
+        mapping,
+        lora_index_to_id: list[int | None],
+        max_loras: int,
+        vocab_size: int,
+    ) -> None:
+        super()._update_base_metadata(mapping, lora_index_to_id, max_loras, vocab_size)
+        if self._single_lora_mask is None:
+            return
+
+        token_count = self.indices_len[0]
+        assert token_count is not None
+        self._single_lora_mask[:token_count].copy_(self._token_lora_indices[:token_count].eq(0).unsqueeze(1))
 
     def update_metadata(
         self,
@@ -328,17 +368,99 @@ class PunicaWrapperNPU(PunicaWrapperBase):
             buffer (Optional[Tuple[torch.Tensor, ...]]): Defaults to None.
         """
 
+        if self.no_lora:
+            return
+
         assert len(lora_a_stacked) == len(lora_b_stacked) == len(output_slices)
 
-        if buffer is None:
-            r = lora_b_stacked[0].size(-1)
-            # We set the buffer to be float32 by default, consistent with the
-            # triton op
-            buffer = tuple(
-                torch.zeros((x.size(0), r), dtype=torch.float32, device=x.device) for _ in range(len(output_slices))
+        if buffer is not None:
+            self.add_shrink(buffer, x, lora_a_stacked, scale, **kwargs)
+            self.add_expand(y, buffer, lora_b_stacked, output_slices, add_inputs=True, **kwargs)
+            return
+
+        lora_linear(
+            self._wrapper_id,
+            y,
+            x,
+            list(lora_a_stacked),
+            list(lora_b_stacked),
+            scale,
+            list(output_slices),
+            kwargs.get("packed_lora_a"),
+            kwargs.get("packed_lora_b"),
+            kwargs.get("add_inputs", True),
+        )
+
+    def _lora_linear_kernel(
+        self,
+        y: torch.Tensor,
+        x: torch.Tensor,
+        lora_a_stacked: tuple[torch.Tensor, ...] | list[torch.Tensor],
+        lora_b_stacked: tuple[torch.Tensor, ...] | list[torch.Tensor],
+        scale: float,
+        output_slices: tuple[int, ...] | list[int],
+    ) -> None:
+        lora_a = tuple(lora_a_stacked)
+        lora_b = tuple(lora_b_stacked)
+        slices = tuple(output_slices)
+
+        r = lora_b[0].size(-1)
+        buffer = self._get_shrink_buffer(len(slices), x.size(0), r, x.device)
+        self.add_shrink(buffer, x, lora_a, scale)
+        self.add_expand(y, buffer, lora_b, slices, add_inputs=True)
+
+    def _get_shrink_buffer(
+        self,
+        n_slices: int,
+        num_tokens: int,
+        rank: int,
+        device: torch.device,
+    ) -> tuple[torch.Tensor, ...]:
+        key = (n_slices, rank)
+        buf = self._lora_shrink_buffers.get(key)
+        if buf is None or buf.shape[1] < num_tokens:
+            alloc_rows = max(num_tokens, self._max_num_batched_tokens)
+            buf = torch.zeros(
+                (n_slices, alloc_rows, rank),
+                dtype=torch.float32,
+                device=device,
             )
-        self.add_shrink(buffer, x, lora_a_stacked, scale, **kwargs)
-        self.add_expand(y, buffer, lora_b_stacked, output_slices, add_inputs=True, **kwargs)
+            self._lora_shrink_buffers[key] = buf
+        return tuple(buf[i][:num_tokens] for i in range(n_slices))
+
+    def _lora_linear_matmul(
+        self,
+        y: torch.Tensor,
+        x: torch.Tensor,
+        lora_a_stacked: tuple[torch.Tensor, ...] | list[torch.Tensor],
+        lora_b_stacked: tuple[torch.Tensor, ...] | list[torch.Tensor],
+        scale: float,
+        output_slices: tuple[int, ...] | list[int],
+        packed_lora_a: torch.Tensor | None,
+        packed_lora_b: torch.Tensor | None,
+        add_inputs: bool,
+    ) -> None:
+        x = x.view(-1, x.shape[-1])
+        y = y.view(-1, y.shape[-1])
+        assert self._single_lora_mask is not None
+        adapter_mask = self._single_lora_mask[: x.size(0)]
+
+        if len(lora_b_stacked) == 1:
+            a_mat = lora_a_stacked[0][0, 0]
+            b_mat = lora_b_stacked[0][0, 0, : output_slices[0]].transpose(0, 1)
+        else:
+            assert packed_lora_a is not None and packed_lora_b is not None
+            a_mat = packed_lora_a[0, 0]
+            b_mat = packed_lora_b[0, 0]
+
+        shrink = torch.matmul(x, a_mat.transpose(0, 1)).mul_(adapter_mask)
+        if scale != 1.0:
+            shrink.mul_(scale)
+        delta = torch.matmul(shrink, b_mat)
+        if add_inputs:
+            y.add_(delta)
+        else:
+            y.copy_(delta)
 
     def add_lora_fused_moe(
         self,

--- a/vllm_ascend/lora/utils.py
+++ b/vllm_ascend/lora/utils.py
@@ -1,19 +1,215 @@
+import torch
 import vllm
+from torch import nn
+from transformers import PretrainedConfig
+from vllm.config import LoRAConfig
+from vllm.lora.layers import (
+    ColumnParallelLinearWithLoRA,
+    MergedColumnParallelLinearWithLoRA,
+    MergedQKVParallelLinearWithLoRA,
+    RowParallelLinearWithLoRA,
+)
+from vllm.lora.layers.base_linear import BaseLinearLayerWithLoRA
+from vllm.lora.layers.utils import _not_fully_sharded_can_replace
+from vllm.model_executor.custom_op import maybe_get_oot_by_class
+from vllm.model_executor.layers.linear import (
+    ColumnParallelLinear,
+    MergedColumnParallelLinear,
+    RowParallelLinear,
+)
+from vllm.platforms import current_platform
 
 from vllm_ascend.lora.fused_moe import (
     AscendFusedMoE3DWithLoRA,
     AscendFusedMoEWithLoRA,
 )
+from vllm_ascend.ops.linear import AscendQKVParallelLinear
+
+
+def _apply_packed_lora(layer, x: torch.Tensor, output: torch.Tensor) -> torch.Tensor:
+    original_shape = output.shape if output.ndim == 3 else None
+    if original_shape is not None and x.ndim == 3:
+        x, output = x.flatten(0, 1), output.flatten(0, 1)
+    lora_output = layer.punica_wrapper.add_lora_linear(
+        output,
+        x,
+        layer.lora_a_stacked,
+        layer.lora_b_stacked,
+        1.0,
+        layer.output_slices,
+        packed_lora_a=getattr(layer, "lora_a_packed", None),
+        packed_lora_b=layer.lora_b_packed,
+    )
+    if not current_platform.can_update_inplace():
+        output = lora_output
+    return output.reshape(original_shape) if original_shape is not None else output
+
+
+class _PackedLoRAAWeightsMixin(MergedColumnParallelLinearWithLoRA):
+    def create_lora_weights(
+        self,
+        max_loras: int,
+        lora_config: LoRAConfig,
+        model_config: PretrainedConfig | None = None,
+    ) -> None:
+        super().create_lora_weights(max_loras, lora_config, model_config)
+        rank = self.lora_a_stacked[0].size(2)
+        self.lora_a_packed = torch.zeros(
+            max_loras,
+            1,
+            self.n_slices * rank,
+            self.input_size,
+            dtype=lora_config.lora_dtype,
+            device=self.device,
+        )
+        self.lora_b_packed = torch.zeros(
+            max_loras,
+            1,
+            self.n_slices * rank,
+            sum(self.output_slices),
+            dtype=lora_config.lora_dtype,
+            device=self.device,
+        )
+
+    def reset_lora(self, index: int) -> None:
+        super().reset_lora(index)
+        self.lora_a_packed[index].zero_()
+        self.lora_b_packed[index].zero_()
+
+    def set_lora(
+        self,
+        index: int,
+        lora_a: torch.Tensor | list[torch.Tensor],
+        lora_b: torch.Tensor | list[torch.Tensor],
+    ) -> None:
+        super().set_lora(index, lora_a, lora_b)
+        rank = self.lora_a_stacked[0].size(2)
+        for slice_index, slice_weight in enumerate(self.lora_a_stacked):
+            packed_slice = self.lora_a_packed[index, 0].narrow(0, slice_index * rank, rank)
+            packed_slice.copy_(slice_weight[index, 0], non_blocking=True)
+        packed_b = self.lora_b_packed[index, 0].zero_()
+        offset = 0
+        for slice_index, slice_weight in enumerate(self.lora_b_stacked):
+            out_size = self.output_slices[slice_index]
+            block = packed_b.narrow(0, slice_index * rank, rank).narrow(1, offset, out_size)
+            block.copy_(
+                slice_weight[index, 0, :out_size].transpose(0, 1),
+                non_blocking=True,
+            )
+            offset += out_size
+
+    def _apply_lora_to_output(self, x: torch.Tensor, output: torch.Tensor) -> torch.Tensor:
+        return _apply_packed_lora(self, x, output)
+
+
+class AscendMergedColumnParallelLinearWithLoRA(_PackedLoRAAWeightsMixin):
+    @classmethod
+    @_not_fully_sharded_can_replace
+    def can_replace_layer(
+        cls,
+        source_layer: nn.Module,
+        lora_config: LoRAConfig,
+        packed_modules_list: list,
+        model_config: PretrainedConfig | None,
+    ) -> bool:
+        return (
+            lora_config.max_loras == 1
+            and type(source_layer) is maybe_get_oot_by_class(MergedColumnParallelLinear)
+            and len(packed_modules_list) == 2
+        )
+
+
+class AscendMergedQKVParallelLinearWithLoRA(_PackedLoRAAWeightsMixin, MergedQKVParallelLinearWithLoRA):
+    @classmethod
+    @_not_fully_sharded_can_replace
+    def can_replace_layer(
+        cls,
+        source_layer: nn.Module,
+        lora_config: LoRAConfig,
+        packed_modules_list: list,
+        model_config: PretrainedConfig | None,
+    ) -> bool:
+        return (
+            lora_config.max_loras == 1
+            and type(source_layer) is AscendQKVParallelLinear
+            and len(packed_modules_list) == 3
+        )
+
+
+class _TransposedLoRABMixin(BaseLinearLayerWithLoRA):
+    """Keep a contiguous [rank, output] B copy for the Triton expand kernel."""
+
+    def create_lora_weights(
+        self,
+        max_loras: int,
+        lora_config: LoRAConfig,
+        model_config: PretrainedConfig | None = None,
+    ) -> None:
+        super().create_lora_weights(max_loras, lora_config, model_config)
+        rank = self.lora_a_stacked[0].size(2)
+        self.lora_b_packed = torch.zeros(
+            max_loras,
+            1,
+            rank,
+            self.output_slices[0],
+            dtype=lora_config.lora_dtype,
+            device=self.device,
+        )
+
+    def reset_lora(self, index: int) -> None:
+        super().reset_lora(index)
+        self.lora_b_packed[index].zero_()
+
+    def set_lora(
+        self,
+        index: int,
+        lora_a: torch.Tensor | list[torch.Tensor],
+        lora_b: torch.Tensor | list[torch.Tensor],
+    ) -> None:
+        super().set_lora(index, lora_a, lora_b)
+        self.lora_b_packed[index, 0].copy_(
+            self.lora_b_stacked[0][index, 0].transpose(0, 1),
+            non_blocking=True,
+        )
+
+    def _apply_lora_to_output(self, x: torch.Tensor, output: torch.Tensor) -> torch.Tensor:
+        return _apply_packed_lora(self, x, output)
+
+
+class _SingleLinearLoRAWrapper(_TransposedLoRABMixin):
+    base_layer_cls: type[nn.Module]
+
+    @classmethod
+    @_not_fully_sharded_can_replace
+    def can_replace_layer(
+        cls,
+        source_layer: nn.Module,
+        lora_config: LoRAConfig,
+        packed_modules_list: list,
+        model_config: PretrainedConfig | None,
+    ) -> bool:
+        return lora_config.max_loras == 1 and type(source_layer) is maybe_get_oot_by_class(cls.base_layer_cls)
+
+
+class AscendRowParallelLinearWithLoRA(_SingleLinearLoRAWrapper, RowParallelLinearWithLoRA):
+    base_layer_cls = RowParallelLinear
+
+
+class AscendColumnParallelLinearWithLoRA(_SingleLinearLoRAWrapper, ColumnParallelLinearWithLoRA):
+    base_layer_cls = ColumnParallelLinear
 
 
 def refresh_all_lora_classes():
     ascend_classes = (
+        AscendRowParallelLinearWithLoRA,
+        AscendColumnParallelLinearWithLoRA,
+        AscendMergedColumnParallelLinearWithLoRA,
+        AscendMergedQKVParallelLinearWithLoRA,
         AscendFusedMoEWithLoRA,
         AscendFusedMoE3DWithLoRA,
     )
-    # vLLM #35077 changed _all_lora_classes from set to ordered tuple.
-    # Append the Ascend classes in a deterministic order.
+    existing_classes = tuple(cls for cls in vllm.lora.utils._all_lora_classes if cls not in ascend_classes)
     vllm.lora.utils._all_lora_classes = (
         *ascend_classes,
-        *vllm.lora.utils._all_lora_classes,
+        *existing_classes,
     )

--- a/vllm_ascend/ops/triton/docs/lora_linear.md
+++ b/vllm_ascend/ops/triton/docs/lora_linear.md
@@ -1,0 +1,79 @@
+# lora_linear
+
+## Description
+
+- **Function**: Computes the dense single-adapter LoRA update for eligible linear layers with a split-K Triton shrink kernel followed by a fused Triton expand kernel. It supports single-slice projections and packed merged projections such as QKV and QKVZ. The serving integration selects this path only for one LoRA slot on Atlas A2/A3; unsupported shapes retain the packed-matmul or Punica fallback.
+- **Formula**:
+    - `workspace[s, :, :] = partial_s(x @ A_packed^T)` for `s in [0, K_SPLIT)`
+    - `shrink = sum_s(workspace[s]) * adapter_mask * scale`
+    - `y = y + shrink @ B_packed`
+    - For merged projections, `A_packed = [A0; A1; ...]` and `B_packed` is block diagonal, so each output slice receives only its corresponding LoRA update.
+- **Algorithm flow**:
+  1. `_lora_shrink_splitk_kernel` partitions the hidden K dimension into `K_SPLIT=4` ranges. Each program processes one K range and one token tile, accumulates `x @ A_packed^T` in FP32, and stores its partial result in a reusable FP32 workspace.
+  2. `_lora_expand_kernel` reduces the four workspace slices, applies the per-token adapter mask and LoRA scale, multiplies by B, and adds the result to y in one kernel. It supports both `[output, rank]` and pre-transposed `[rank, output]` B layouts.
+  3. For two to four packed slices with per-slice rank at least 32, `_lora_expand_sliced_kernel` maps each output tile to its owning slice and reads only the corresponding nonzero block of block-diagonal B.
+  4. The serving wrapper caches workspace by packed rank. Shapes outside the Triton eligibility rules fall back to packed `torch.matmul`; multi-adapter, fully-sharded, embedding, fused-MoE, and other general cases retain Punica SGMV/BGMV.
+- **Supported modes**: Atlas A2 and Atlas A3 in ACL graph capture. Ascend 950 is not enabled by the current LoRA routing.
+
+## Parameters
+
+| Parameter | Input/Output/Attribute | Description | Data type | Data format |
+| --- | --- | --- | --- | --- |
+| `x` | Input | Flattened linear input `[token_count, hidden_size]` | bf16 | ND, contiguous |
+| `A_packed` | Input | Single-slice or rank-concatenated LoRA A weights `[total_rank, hidden_size]` | bf16 | ND, contiguous |
+| `workspace` | Input / Output | Split-K partial results `[K_SPLIT, WORKSPACE_TOKENS, total_rank]` | fp32 | ND, contiguous |
+| `B` / `B_packed` | Input | Single-slice B in `[output_size, rank]` layout, its `[rank, output_size]` transposed copy, or merged block-diagonal B `[total_rank, output_size]` | bf16 | ND, contiguous |
+| `y` | Input / Output | Base linear output `[token_count, output_size]`; LoRA delta is added in place | bf16 | ND, contiguous |
+| `adapter_mask` | Input | Per-token mask of length at least `WORKSPACE_TOKENS`; 1 enables LoRA and 0 preserves the base output | bf16 | ND, contiguous |
+| `token_count` | Input (attribute) | Number of flattened tokens processed by this launch | int32 | scalar |
+| `hidden_size` | Input (attribute) | K dimension shared by x and A | int32 | scalar |
+| `output_size` | Input (attribute) | Total output width of y and B | int32 | scalar |
+| `scale` | Input (attribute) | LoRA scaling factor applied after split-K reduction | fp32 | scalar |
+| `RANK` / `TOTAL_RANK` | Compile-time attribute | A row count; for packed layers, per-slice rank multiplied by slice count | int32 | scalar |
+| `SLICE_RANK` | Compile-time attribute | Rank of one packed output slice for `_lora_expand_sliced_kernel` | int32 | scalar |
+| `WORKSPACE_TOKENS` | Compile-time attribute | Workspace token capacity; currently 128 | int32 | scalar |
+| `BLOCK_M` | Compile-time attribute | Token tile size; 16 for token count at most 8, otherwise 32 | int32 | scalar |
+| `BLOCK_K` | Compile-time attribute | Hidden-dimension tile size for shrink; currently 256 | int32 | scalar |
+| `BLOCK_N` | Compile-time attribute | Output tile size; 1024 for token count at most 8 and total rank at most 48, otherwise 512 | int32 | scalar |
+| `K_SPLIT` | Compile-time attribute | Number of hidden-dimension partitions; currently 4 | int32 | scalar |
+| `B_TRANSPOSED` | Compile-time attribute | Selects B layout: true for `[output, rank]`, false for `[rank, output]` | bool | scalar |
+| `TILE_END_0..2` | Compile-time attribute | Cumulative output-tile boundaries used to map a tile to one of up to four slices | int32 | scalar |
+| `OUTPUT_START_1..3` | Compile-time attribute | Cumulative element offsets of packed output slices | int32 | scalar |
+
+## Constraints
+
+- The serving fast path requires `max_loras == 1`, `fully_sharded_loras == false`, and device type Atlas A2 or A3.
+- x, y, A, and B must be contiguous BF16 tensors on the same NPU.
+- Supported per-slice ranks are 8, 16, 32, and 64.
+- `1 <= token_count <= 128`; the workspace and adapter-mask buffers must have capacity for 128 tokens.
+- Single-slice execution supports B in `[output_size, rank]` form with `B_TRANSPOSED=True` or a pre-transposed `[rank, output_size]` copy with `B_TRANSPOSED=False`.
+- A merged projection must provide both packed A and packed B. Its output-slice sizes must sum to `output_size`.
+- Sliced expand supports two to four slices and requires `SLICE_RANK >= 32`. Smaller ranks use the generic expand kernel with block-diagonal packed B.
+- The production Triton route requires ACL graph capture. Eager/non-captured execution falls back to packed matmul.
+- Large projections fall back to packed matmul when `output_size >= 8192` and token count exceeds 32 for rank 8/16 or 64 for rank 32/64, or when `output_size >= 5120`, rank is at least 16, and token count exceeds 64.
+- The kernel performs residual addition. The serving route uses it for the in-place LoRA update semantics of dense linear layers.
+- FP32 is used for shrink accumulation and split reduction; the final output is stored as BF16.
+
+## Origin and Differences
+
+- **Origin**: Developed specifically for the vllm-ascend dense LoRA linear path. Its mathematical reference is the standard vLLM LoRA computation `(x @ A^T) @ B^T * scale` followed by an in-place addition to the base-layer output.
+- **Differences**:
+    - NPU adaptation for performance: split-K exposes parallelism for small-token, large-hidden shrink shapes; expand fuses partial reduction, adapter masking, scaling, B projection, and residual writeback; FP32 workspace is reused across graph replays.
+    - Modified for vllm-ascend single-slot logic: merged A weights are concatenated and B weights are block diagonal. Sliced expand skips the zero off-diagonal blocks, while a fixed-address token mask preserves mixed base/LoRA batch semantics.
+    - The implementation is shape-aware rather than unconditional: large projections use packed matmul, and general multi-adapter or fully-sharded cases continue to use Punica.
+
+## Test Cases
+
+The single-operator accuracy test uses TP-local Qwen3.5-27B projection shapes:
+
+- single-slice O projection: hidden size 1536 and output size 5120;
+- three-slice QKV projection: hidden size 5120 and output slices `(1024, 512, 512)`;
+- four-slice QKVZ projection: hidden size 5120 and output slices `(1536, 512, 512, 1536)`.
+
+It tests every supported per-slice rank in `{8, 16, 32, 64}` at token counts `{1, 31, 128}`. This covers the single-slice transposed-B path, generic block-diagonal expand for lower ranks, sliced expand for ranks 32/64, the maximum token boundary, mixed base/LoRA masking, scale application, FP32 split reduction, and residual writeback.
+
+The arithmetic accuracy criterion is relative L2 error below 0.5% against a PyTorch FP32 reference. Tokens masked as base-only must remain bit-exact (`rtol=0`, `atol=0`) relative to their original y values.
+
+```bash
+pytest -sv tests/e2e/nightly/single_node/ops/singlecard_ops/triton/test_lora_linear.py
+```

--- a/vllm_ascend/worker/model_runner_v1.py
+++ b/vllm_ascend/worker/model_runner_v1.py
@@ -242,6 +242,7 @@ PerLayerAttnMetadata: TypeAlias = list[AttnMetadataDict] | AttnMetadataDict
 SEQ_LEN_WITH_MAX_PA_WORKSPACE = 6144
 
 
+
 @dataclass
 class GraphCaptureContext:
     stream: torch.npu.Stream
@@ -1555,6 +1556,18 @@ class NPUModelRunner(GPUModelRunner):
             spec_decode_metadata,
             total_num_scheduled_tokens,
         )
+
+    def set_active_loras(
+        self,
+        input_batch,
+        num_scheduled_tokens: np.ndarray,
+        num_sampled_tokens: np.ndarray | None = None,
+        mapping_type=None,
+    ) -> None:
+        if mapping_type is None:
+            super().set_active_loras(input_batch, num_scheduled_tokens, num_sampled_tokens)
+        else:
+            super().set_active_loras(input_batch, num_scheduled_tokens, num_sampled_tokens, mapping_type)
 
     def _build_attn_state(self, num_reqs, num_scheduled_tokens, num_valid_tokens):
         if np.all(self.input_batch.num_computed_tokens_cpu[:num_reqs] == 0):


### PR DESCRIPTION
## What this PR does

This PR optimizes dense LoRA linear execution on Ascend A2 and A3 for single-LoRA-slot serving:

- `max_loras == 1`
- `fully_sharded_loras == false`
- LoRA rank in `{8, 16, 32, 64}`
- BF16 weights and activations for the Triton path
- Up to 128 scheduled tokens for eligible Triton shapes

The implementation uses shape-aware routing between specialized Triton kernels, packed `torch.matmul`, and the existing Punica SGMV/BGMV path.

### 1. Single-adapter masked fast path

When there is only one LoRA slot, all active LoRA tokens share the same adapter weights. 

### 2. Packed weights for merged projections

Merged projections such as QKV and Gate-Up are packed when an adapter is loaded.

### 3. Triton split-K shrink and fused expand

The Triton shrink kernel targets the small-token, large-hidden-dimension shape used by decode and MTP verification.

Current kernel coverage and tuning are:

| Parameter | Value |
|---|---:|
| Supported per-slice ranks | 8, 16, 32, 64 |
| Maximum tokens | 128 |
| `K_SPLIT` | 4 |
| `BLOCK_K` | 256 |
| `BLOCK_M` | 16 for token count ≤8; otherwise 32 |
| `BLOCK_N` | 1024 for small-token packed rank ≤48; otherwise 512 |
| Partial accumulation | FP32 |

### 4. Shape-aware Triton and matmul routing

Scale is folded into the small shrink tensor, and `scale == 1.0` skips the no-op multiplication.

### 5. Packed matmul fallback

Packed `torch.matmul` remains the fallback for non-captured execution, unsupported dtype/layout/rank/token shapes, and large projection crossover shapes.

### 6. Existing Punica paths are preserved

This PR does not remove AscendC SGMV/BGMV. The existing Punica path remains active for:

- multiple LoRA adapters;
- `--fully-sharded-loras`;
- devices other than A2 and A3;
- unpacked or unsupported layers;
- explicit shrink-buffer calls;
- embedding LoRA;
- fused-MoE LoRA;
- other irregular token-to-adapter mappings.

`--fully-sharded-loras` is intentionally excluded because a fused A/B fast path would need to preserve the TP collective boundary between shrink and expand.

## Operator routing

| Condition | Selected implementation |
|---|---|
| No active LoRA in the current batch | Immediate return; no LoRA operator |
| Explicit shrink buffer supplied | Existing `add_shrink` + `add_expand` |
| A2/A3, one LoRA slot, non-fully-sharded, packed, Triton-compatible captured shape | Triton split-K shrink + fused Triton expand |
| Same single-slot packed path, but Triton conditions are not met | Packed `torch.matmul` |
| Large projection crossover shape | Packed `torch.matmul` |
| Multiple adapters | Punica SGMV/BGMV |
| Fully-sharded LoRA | Existing parallel/Punica path |
| Non-A2/A3 or unpacked layer | Existing Punica/custom-op or torch fallback |
| Embedding LoRA | Existing SGMV/BGMV expand |
| Fused-MoE LoRA | Existing BGMV/fused-MoE LoRA path |

## Performance

### Test configuration

- Model: Qwen3.5-27B
- Tensor parallelism: TP4 on four Ascend NPUs
- Dataset: GSM8K
- Input length: approximately 14,265 tokens
- Output length: 1,024 tokens
- Concurrency: 4
- Total requests: 16
- LoRA rank: 8

### Ascend A2

| Metric | No LoRA | LoRA Before |  LoRA After | Before → After |
|---|---:|---:|---:|---:|
| Mean TTFT | 3284 ms | 5677 ms | 3660 ms | **-35.5%** |
| Median TTFT | 2293 ms | 3989 ms | 2596 ms | **-34.9%** |
| Mean TPOT | 22.1 ms | 31.5 ms | 26.2 ms | **-16.8%** |
| Output throughput | 156.4 tok/s | 105.6 tok/s | 132.8 tok/s | **+25.6%** |

The measured A2 no-LoRA mean TTFT varied between 3126 ms and 3916 ms across runs.

### Ascend A3

| Metric | No LoRA | LoRA before | LoRA after | Before → After |
|---|---:|---:|---:|---:|
| Mean TTFT | 2211.7 ms | 4890 ms | 2585 ms | **-47.1%** |
| Median TTFT | 1642 ms | 3309 ms | 1888 ms | **-42.9%** |
| Mean TPOT | 15.9 ms | 24.5 ms | 18.9 ms | **-22.9%** |
| Output throughput | 214.2 tok/s | 134.5 tok/s | 181.2 tok/s | **+34.7%** |

## Precision

GPQA diamond datasets, we add a dummy lora weight (initialized as `randn() * 0.001`) to avoid disturbing the correctness of inference.

| Ground truth from [Qwen/Qwen3.5-27B](https://huggingface.co/Qwen/Qwen3.5-27B) | test result |
|---| ---:|
| 85.5 % | 84.8% ~ 86.87% |

## Scope

The optimized path is limited to Ascend A2/A3, single-slot, non-fully-sharded dense LoRA linear layers. Unsupported configurations retain the existing implementation and correctness semantics.

This includes the single-adapter masked-GEMM infrastructure originally developed from #14170 and the subsequent packed-weight, custom-op, split-K Triton, rank/token coverage, shape-aware fallback, and base-only early-return improvements.

Co-authored-by: liuchenbing <chenliumail@163.com>

- vLLM main: https://github.com/vllm-project/vllm/commit/b2f685834a6456197e7033966fdef52a23f1abcd
