### PR TITLE
[Doc][Misc] Sync GLM5 and GLM-5.2 tutorials from releases/v0.26.0rc

### DIFF
--- a/docs/source/tutorials/models/GLM5.2.md
+++ b/docs/source/tutorials/models/GLM5.2.md
@@ -12,30 +12,24 @@ Refer to [Supported Features List](../../user_guide/support_matrix/supported_mod
 
 Refer to [Feature Guide](../../user_guide/feature_guide/index.md) to get the feature's configuration.
 
-## 3 Prerequisites
-
-### 3.1 Model Weight
+## 3 Model Weight
 
 - `GLM-5.2`(BF16 version): requires 2 Atlas 800 A3 (128GB × 8) node or 4 Atlas 800 A2 (64GB × 8) node.[Download model weight](https://www.modelscope.cn/models/ZhipuAI/GLM-5.2).
 - `GLM-5.2-w8a8`: requires 1 Atlas 800 A3 (128GB × 8) node or 2 Atlas 800 A2 (64GB × 8) node.[Download model weight](https://www.modelscope.cn/models/Eco-Tech/GLM-5.2-w8a8).
-- `GLM-5.2-w4a8c8`: requires 1 Atlas 800 A3 (128GB × 8) node or 2 Atlas 800 A2 (64GB × 8) node.[Download model weight](https://www.modelscope.cn/models/Eco-Tech/GLM-5.2-w4a8c8).
+- `GLM-5.2-w8a8c8`(Quantized version for Atlas 800 A3): requires 2 Atlas 800 A3 (64GB × 16) node or 4 Atlas 800 A2 (64GB × 8) node.[Download model weight](https://modelers.cn/models/Eco-Tech/GLM-5.2-w8a8c8).
+- `GLM-5.2-w4a8c8`: requires 1 Atlas 800 A3 (128GB × 8) node or 2 Atlas 800 A2 (64GB × 8) node.[Download model weight](https://modelscope.cn/models/Eco-Tech/GLM-5.2-w4a8c8).
 - You can use [msmodelslim](https://gitcode.com/Ascend/msmodelslim) to quantize the model directly.
 
 It is recommended to download the model weight to the shared directory of multiple nodes, such as `/root/.cache/`
 
-### 3.2 Verify Multi-node Communication (Optional)
-
-If you want to deploy multi-node environment, you need to verify multi-node communication according to [verify multi-node communication environment](../../getting_started/installation.md#installation-multi-node-interconnect).
-
 ## 4 Installation
 
-### 4.1 Docker Image Installation
-
 - You can use our official docker image to run GLM-5.2 directly.
+- [KV Cache Pool (Ascend Store) Deployment Guide](https://docs.vllm.ai/projects/ascend/zh-cn/latest/user_guide/feature_guide/kv_pool.html)
 
 === "A3 series"
 
-    Start the docker image on each node.
+    Start the docker image on your each node.
 
     ```shell
 
@@ -111,39 +105,23 @@ If you want to deploy multi-node environment, you need to verify multi-node comm
 
 If you want to deploy multi-node environment, you need to set up environment on each node.
 
-### 4.2 Source Code Installation
-
-If you don't want to use the docker image as above, you can also build all from source:
-
-- Install `vllm-ascend` from source, refer to [installation](../../getting_started/installation.md).
-
 ## 5 Deployment
-
-The deployment scenarios validated for this release are organized by context window size (below 1M / 1M), hardware (Atlas 800 A3 / A2), and deployment mode (single-node, multi-node co-located, Prefill-Decode disaggregation). All startup scripts below are the verified reference commands; key parameters are explained after each scenario.
 
 ### 5.1 Context Below 1M
 
-#### 5.1.1 Atlas 800 A3
-
-##### 5.1.1.1 Single-Node Deployment
+#### 5.1.1 Single-node Deployment
 
 - Quantized model `GLM-5.2-w4a8c8` can be deployed on 1 Atlas 800 A3 (64GB × 16) .
 
 Run the following script to execute online inference.
 
 ```shell
-export HCCL_OP_EXPANSION_MODE="AIV"
-export HCCL_TRANSFER_TIMEOUT=600
-export HCCL_EXEC_TIMEOUT=3600
-export HCCL_CONNECT_TIMEOUT=3600
-export OMP_PROC_BIND=false
-export OMP_NUM_THREADS=1
 export HCCL_BUFFSIZE=200
+export HCCL_OP_EXPANSION_MODE="AIV"
 export PYTORCH_NPU_ALLOC_CONF=expandable_segments:True
 vllm serve /root/.cache/modelscope/hub/models/vllm-ascend/GLM-5.2-w4a8c8 \
 --host 0.0.0.0 \
 --port 8077 \
---safetensors-load-strategy prefetch \
 --api-server-count 1 \
 --data-parallel-size 2 \
 --enable-expert-parallel \
@@ -160,173 +138,949 @@ vllm serve /root/.cache/modelscope/hub/models/vllm-ascend/GLM-5.2-w4a8c8 \
 --gpu-memory-utilization 0.92 \
 --quantization ascend \
 --compilation-config '{"cudagraph_mode": "FULL_DECODE_ONLY"}' \
---additional-config '{"enable_dsa_cp": true,"enable_sparse_li_c8": true,"enable_balance_scheduling": true,"multistream_overlap_shared_expert":true,"enable_fused_mc2":0}' \
+--additional-config '{"enable_dsa_cp": true,"enable_sparse_sfa_c8": false, "enable_sparse_li_c8": true,"enable_balance_scheduling": true,"multistream_overlap_shared_expert":true, "enable_flashcomm1": true, "enable_fused_mc2": 0}' \
 --speculative-config '{"num_speculative_tokens": 3, "method": "deepseek_mtp","enforce_eager":true}'
 
+```
+
+**Notice:**
+The parameters are explained as follows:
+
+- For single-node deployment, we recommend using `dp1tp16` and turn off expert parallel in low-latency scenarios.
+
+#### 5.1.2 Multi-node Deployment
+
+If you want to deploy multi-node environment, you need to verify multi-node communication according to [verify multi-node communication environment](../../getting_started/installation.md#installation-multi-node-interconnect).
+
+=== "A3 series"
+
+    - `GLM-5.2-w4a8c8`: can be deployed on 2 Atlas 800 A3 (64GB × 16).
+
+    Run the following scripts on two nodes respectively.
+
+    **node 0**
+
+    ```shell
+    # this obtained through ifconfig
+    # nic_name is the network interface name corresponding to local_ip of the current node
+    nic_name="xxx"
+    local_ip="xxx"
+
+    # The value of node0_ip must be consistent with the value of local_ip set in node0 (master node)
+    node0_ip="xxxx"
+
+    export HCCL_BUFFSIZE=400
+    export HCCL_IF_IP=$local_ip
+    export HCCL_OP_EXPANSION_MODE="AIV"
+    export HCCL_SOCKET_IFNAME=$nic_name
+    export GLOO_SOCKET_IFNAME=$nic_name
+    export PYTORCH_NPU_ALLOC_CONF=expandable_segments:True
+
+    vllm serve /root/.cache/modelscope/hub/models/vllm-ascend/GLM-5.2-w4a8c8 \
+    --host 0.0.0.0 \
+    --port 8077 \
+    --api-server-count 1 \
+    --data-parallel-size 4 \
+    --data-parallel-start-rank 0 \
+    --data-parallel-size-local 2 \
+    --data-parallel-address $node0_ip \
+    --data-parallel-rpc-port 12980 \
+    --tensor-parallel-size 8 \
+    --enable-expert-parallel \
+    --seed 1024 \
+    --served-model-name glm-52 \
+    --tool-call-parser glm47 \
+    --reasoning-parser glm45 \
+    --enable-auto-tool-choice \
+    --max-num-seqs 16 \
+    --max-model-len 66000 \
+    --max-num-batched-tokens 8192 \
+    --trust-remote-code \
+    --gpu-memory-utilization 0.90 \
+    --quantization ascend \
+    --compilation-config '{"cudagraph_mode": "FULL_DECODE_ONLY"}' \
+    --additional-config '{"enable_dsa_cp": true,"enable_sparse_sfa_c8": false, "enable_sparse_li_c8": true,"enable_balance_scheduling": true,"fuse_muls_add":true,"multistream_overlap_shared_expert":true,"c8_enable_reshape_optim":false,    "enable_reduce_sample": "True", "enable_flashcomm1": true, "enable_fused_mc2": 1}'  \
+    --speculative-config '{"num_speculative_tokens": 3, "method": "deepseek_mtp","enforce_eager":true}'
+    ```
+
+    **node 1**
+
+    ```shell
+    # this obtained through ifconfig
+    # nic_name is the network interface name corresponding to local_ip of the current node
+    nic_name="xxx"
+    local_ip="xxx"
+
+    # The value of node0_ip must be consistent with the value of local_ip set in node0 (master node)
+    node0_ip="xxxx"
+
+    export HCCL_BUFFSIZE=400
+    export HCCL_IF_IP=$local_ip
+    export HCCL_OP_EXPANSION_MODE="AIV"
+    export HCCL_SOCKET_IFNAME=$nic_name
+    export GLOO_SOCKET_IFNAME=$nic_name
+    export PYTORCH_NPU_ALLOC_CONF=expandable_segments:True
+
+    vllm serve /root/.cache/modelscope/hub/models/vllm-ascend/GLM-5.2-w4a8c8 \
+    --host 0.0.0.0 \
+    --port 8077 \
+    --headless \
+    --data-parallel-size 4 \
+    --data-parallel-start-rank 2 \
+    --data-parallel-size-local 2 \
+    --data-parallel-address $node0_ip \
+    --data-parallel-rpc-port 12980 \
+    --tensor-parallel-size 8 \
+    --enable-expert-parallel \
+    --seed 1024 \
+    --served-model-name glm-52 \
+    --tool-call-parser glm47 \
+    --reasoning-parser glm45 \
+    --enable-auto-tool-choice \
+    --max-num-seqs 16 \
+    --max-model-len 66000 \
+    --max-num-batched-tokens 8192 \
+    --trust-remote-code \
+    --gpu-memory-utilization 0.90 \
+    --quantization ascend \
+    --compilation-config '{"cudagraph_mode": "FULL_DECODE_ONLY"}' \
+    --additional-config '{"enable_dsa_cp": true,"enable_sparse_sfa_c8": false, "enable_sparse_li_c8": true,"enable_balance_scheduling": true,"fuse_muls_add":true,"multistream_overlap_shared_expert":true,"c8_enable_reshape_optim":false,     "enable_reduce_sample": "True", "enable_flashcomm1": true, "enable_fused_mc2": 1}'  \
+    --speculative-config '{"num_speculative_tokens": 3, "method": "deepseek_mtp","enforce_eager":true}'
+    ```
+
+=== "A2 series"
+
+    - `GLM-5.2-w4a8c8`: can be deployed on 2 Atlas 800 A2 (64GB × 32).
+
+    **node 0**
+
+    ```shell
+    # this obtained through ifconfig
+    # nic_name is the network interface name corresponding to local_ip of the current node
+    nic_name="xxx"
+    local_ip="xxx"
+
+    # The value of node0_ip must be consistent with the value of local_ip set in node0 (master node)
+    node0_ip="xxx"
+
+    export VLLM_EXECUTE_MODEL_TIMEOUT_SECONDS=3000
+    export HCCL_IF_IP=$local_ip
+    export HCCL_OP_EXPANSION_MODE="AIV"
+    export HCCL_SOCKET_IFNAME=$nic_name
+    export GLOO_SOCKET_IFNAME=$nic_name
+    export PYTORCH_NPU_ALLOC_CONF=expandable_segments:True
+
+    vllm serve /root/.cache/modelscope/hub/models/vllm-ascend/GLM-5.2-w4a8c8 \
+    --max_model_len 40000 \
+    --max-num-batched-tokens 4096 \
+    --served-model-name glm-52 \
+    --seed 1024 \
+    --gpu-memory-utilization 0.95 \
+    --api-server-count 1 \
+    --max-num-seqs 16 \
+    --data-parallel-size 2 \
+    --data-parallel-size-local 1 \
+    --data-parallel-address $node0_ip \
+    --data-parallel-rpc-port 13389 \
+    --tensor-parallel-size 8 \
+    --enable-expert-parallel \
+    --quantization ascend \
+    --port 7000 \
+    --safetensors-load-strategy 'prefetch' \
+    --block-size 128 \
+    --additional-config '{"multistream_overlap_shared_expert": true}' \
+    --compilation-config '{"cudagraph_mode": "FULL_DECODE_ONLY"}' \
+    --speculative-config '{"num_speculative_tokens": 5, "method": "deepseek_mtp", "enforce_eager": true}'
+    ```
+
+    **node 1**
+
+    ```shell
+    # this obtained through ifconfig
+    # nic_name is the network interface name corresponding to local_ip of the current node
+    nic_name="xxx"
+    local_ip="xxx"
+
+    # The value of node0_ip must be consistent with the value of local_ip set in node0 (master node)
+    node0_ip="xxx"
+
+    export VLLM_EXECUTE_MODEL_TIMEOUT_SECONDS=3000
+    export HCCL_IF_IP=$local_ip
+    export HCCL_OP_EXPANSION_MODE="AIV"
+    export HCCL_SOCKET_IFNAME=$nic_name
+    export GLOO_SOCKET_IFNAME=$nic_name
+    export PYTORCH_NPU_ALLOC_CONF=expandable_segments:True
+
+    vllm serve /root/.cache/modelscope/hub/models/vllm-ascend/GLM-5.2-w4a8c8 \
+    --max_model_len 40000 \
+    --max-num-batched-tokens 4096 \
+    --served-model-name glm-52 \
+    --seed 1024 \
+    --gpu-memory-utilization 0.95 \
+    --max-num-seqs 16 \
+    --headless \
+    --data-parallel-size 2 \
+    --data-parallel-size-local 1 \
+    --data-parallel-start-rank 1 \
+    --data-parallel-address $node0_ip \
+    --data-parallel-rpc-port 13389 \
+    --tensor-parallel-size 8 \
+    --enable-expert-parallel \
+    --quantization ascend \
+    --port 7000 \
+    --safetensors-load-strategy 'prefetch' \
+    --block-size 128 \
+    --additional-config '{"multistream_overlap_shared_expert": true}' \
+    --compilation-config '{"cudagraph_mode": "FULL_DECODE_ONLY"}' \
+    --speculative-config '{"num_speculative_tokens": 5, "method": "deepseek_mtp", "enforce_eager": true}'
+    ```
+
+#### 5.1.3 Prefill-Decode Disaggregation
+
+We'd like to show the deployment guide of `GLM-5.2` on multi-node environment with 1P1D for better performance.
+
+In the PD disaggregation scenario, Mooncake is used as the KV cache transfer connector between the prefill and decode nodes. Please refer to [KV Cache Pool (Ascend Store) Deployment Guide](https://github.com/vllm-project/vllm-ascend/blob/main/docs/source/user_guide/feature_guide/kv_pool.md) for the Mooncake configuration.
+
+##### 5.1.3.1 Deployment on 4 Atlas 800 A3
+
+Prefill-Decode disaggregation with the `GLM-5.2-w8a8c8` weights can be deployed on 4 Atlas 800 A3 (64GB × 16).
+
+Before you start, please
+
+1. prepare the script `launch_online_dp.py` on each node:
+
+    ```python
+    import argparse
+    import multiprocessing
+    import os
+    import subprocess
+    import sys
+
+    def parse_args():
+        parser = argparse.ArgumentParser()
+        parser.add_argument("--dp-size", type=int, required=True, help="Data parallel size.")
+        parser.add_argument("--tp-size", type=int, default=1, help="Tensor parallel size.")
+        parser.add_argument("--pp-size", type=int, default=1, help="Pipeline parallel size.")
+        parser.add_argument("--dp-size-local", type=int, default=-1, help="Local data parallel size.")
+        parser.add_argument("--dp-rank-start", type=int, default=0, help="Starting rank for data parallel.")
+        parser.add_argument("--dp-address", type=str, required=True, help="IP address for data parallel master node.")
+        parser.add_argument("--dp-rpc-port", type=str, default="12321", help="Port for data parallel master node.")
+        parser.add_argument("--vllm-start-port", type=int, default=8000, help="Starting port for the engine.")
+        return parser.parse_args()
+
+    args = parse_args()
+    dp_size = args.dp_size
+    tp_size = args.tp_size
+    pp_size = args.pp_size
+    dp_size_local = args.dp_size_local
+    if dp_size_local == -1:
+        dp_size_local = dp_size
+    dp_rank_start = args.dp_rank_start
+    dp_address = args.dp_address
+    dp_rpc_port = args.dp_rpc_port
+    vllm_start_port = args.vllm_start_port
+    gpus_per_dp_rank = tp_size * pp_size
+
+    def run_command(visible_devices, dp_rank, vllm_engine_port):
+        command = [
+            "bash",
+            "./run_dp_template.sh",
+            visible_devices,
+            str(vllm_engine_port),
+            str(dp_size),
+            str(dp_rank),
+            dp_address,
+            dp_rpc_port,
+            str(tp_size),
+            str(pp_size),
+        ]
+        subprocess.run(command, check=True)
+
+    if __name__ == "__main__":
+        template_path = "./run_dp_template.sh"
+        if not os.path.exists(template_path):
+            print(f"Template file {template_path} does not exist.")
+            sys.exit(1)
+
+        processes = []
+        num_cards = dp_size_local * gpus_per_dp_rank
+
+        for i in range(dp_size_local):
+            dp_rank = dp_rank_start + i
+            vllm_engine_port = vllm_start_port + i
+            visible_devices = ",".join(str(x) for x in range(i * gpus_per_dp_rank, (i + 1) * gpus_per_dp_rank))
+            process = multiprocessing.Process(
+                target=run_command,
+                args=(visible_devices, dp_rank, vllm_engine_port)
+            )
+            processes.append(process)
+            process.start()
+
+        for process in processes:
+            process.join()
+
+    ```
+
+2. prepare the script `run_dp_template.sh` on each node.
+
+    1. Prefill node 0
+
+        ```shell
+        nic_name="xxxx" # change to your own nic name
+        local_ip="xxxx" # change to your own ip
+
+        export VLLM_PP_LAYER_PARTITION="41,37"
+        export HCCL_BUFFSIZE=400
+        export HCCL_IF_IP=$local_ip
+        export HCCL_OP_EXPANSION_MODE="AIV"
+        export HCCL_SOCKET_IFNAME=$nic_name
+        export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/local/lib
+        export GLOO_SOCKET_IFNAME=$nic_name
+        export PYTORCH_NPU_ALLOC_CONF=expandable_segments:True
+
+        vllm serve <MODEL_PATH> \
+            --host 0.0.0.0 \
+            --port $2 \
+            --tensor-parallel-size 16 \
+            --enable-expert-parallel \
+            --pipeline-parallel-size 2 \
+            --distributed-executor-backend mp \
+            --master-addr $local_ip \
+            --master-port 7060 \
+            --nnodes 2 \
+            --node-rank 0 \
+            --speculative-config '{"num_speculative_tokens": 1, "method":"deepseek_mtp","enforce_eager":true}' \
+            --seed 1024 \
+            --served-model-name glm-5 \
+            --max-model-len 202752 \
+            --safetensors-load-strategy 'prefetch' \
+            --additional-config '{"fuse_muls_add":true, "enable_dsa_cp":true, "enable_sparse_li_c8": true, "enable_flashcomm1": true, "enable_fused_mc2": 1}' \
+            --max-num-batched-tokens 16384 \
+            --trust-remote-code \
+            --enable-prefix-caching \
+            --max-num-seqs 64 \
+            --quantization ascend \
+            --gpu-memory-utilization 0.85 \
+            --api-server-count 1 \
+            --enforce-eager \
+            --enable-auto-tool-choice \
+            --tool-call-parser glm47 \
+            --reasoning-parser glm45 \
+            --kv-transfer-config '{
+                "kv_connector": "MooncakeConnectorV1",
+                "kv_role": "kv_producer",
+                "kv_port": "30000",
+                "engine_id": "0",
+                "kv_connector_extra_config": {
+                    "use_ascend_direct": true,
+                    "prefill": {"dp_size": 1, "pp_size": 2, "tp_size": 16, "pp_layer_partition": "41,37"},
+                    "decode": { "dp_size": 16, "tp_size": 2}
+                }
+            }'
+
+        ```
+
+    2. Prefill node 1
+
+        ```shell
+        nic_name="xxxx" # change to your own nic name
+        local_ip="xxxx" # change to your own ip
+
+        # The value of node_p0_ip must be consistent with the value of local_ip set in prefill node 0 (p0, PP master node)
+        node_p0_ip="xxxx"
+
+        export VLLM_PP_LAYER_PARTITION="41,37"
+        export HCCL_BUFFSIZE=400
+        export HCCL_IF_IP=$local_ip
+        export HCCL_OP_EXPANSION_MODE="AIV"
+        export HCCL_SOCKET_IFNAME=$nic_name
+        export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/local/lib
+        export GLOO_SOCKET_IFNAME=$nic_name
+        export PYTORCH_NPU_ALLOC_CONF=expandable_segments:True
+
+        vllm serve <MODEL_PATH> \
+            --host 0.0.0.0 \
+            --port $2 \
+            --tensor-parallel-size 16 \
+            --enable-expert-parallel \
+            --pipeline-parallel-size 2 \
+            --distributed-executor-backend mp \
+            --master-addr $node_p0_ip \
+            --master-port 7060 \
+            --nnodes 2 \
+            --node-rank 1 \
+            --speculative-config '{"num_speculative_tokens": 1, "method":"deepseek_mtp","enforce_eager":true}' \
+            --seed 1024 \
+            --served-model-name glm-5 \
+            --max-model-len 202752 \
+            --safetensors-load-strategy 'prefetch' \
+            --additional-config '{"fuse_muls_add":true, "enable_dsa_cp":true, "enable_sparse_li_c8": true, "enable_flashcomm1": true, "enable_fused_mc2": 1}' \
+            --max-num-batched-tokens 16384 \
+            --trust-remote-code \
+            --enable-prefix-caching \
+            --max-num-seqs 64 \
+            --quantization ascend \
+            --gpu-memory-utilization 0.85 \
+            --headless \
+            --enforce-eager \
+            --enable-auto-tool-choice \
+            --tool-call-parser glm47 \
+            --reasoning-parser glm45 \
+            --kv-transfer-config '{
+                "kv_connector": "MooncakeConnectorV1",
+                "kv_role": "kv_producer",
+                "kv_port": "30000",
+                "engine_id": "0",
+                "kv_connector_extra_config": {
+                    "use_ascend_direct": true,
+                    "prefill": {"dp_size": 1, "pp_size": 2, "tp_size": 16, "pp_layer_partition": "41,37"},
+                    "decode": { "dp_size": 16, "tp_size": 2}
+                }
+            }'
+        ```
+
+    3. Decode node 0
+
+        ```shell
+        nic_name="xxxx" # change to your own nic name
+        local_ip="xxxx" # change to your own ip
+
+        # d0: api server on this node; d1: --headless
+        server_role_args="--api-server-count 1"
+
+        export HCCL_BUFFSIZE=256
+        export HCCL_IF_IP=$local_ip
+        export HCCL_OP_EXPANSION_MODE="AIV"
+        export HCCL_SOCKET_IFNAME=$nic_name
+        export ASCEND_RT_VISIBLE_DEVICES=$1
+        export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/local/lib
+        export GLOO_SOCKET_IFNAME=$nic_name
+        export PYTORCH_NPU_ALLOC_CONF=expandable_segments:True
+
+        vllm serve <MODEL_PATH> \
+            --host 0.0.0.0 \
+            --port $2 \
+            --data-parallel-size $3 \
+            --data-parallel-rank $4 \
+            --data-parallel-address $5 \
+            --data-parallel-rpc-port $6 \
+            --tensor-parallel-size $7 \
+            --enable-expert-parallel \
+            --seed 1024 \
+            --served-model-name glm-5 \
+            --max-model-len 202752 \
+            --safetensors-load-strategy 'prefetch' \
+            --max-num-batched-tokens 192 \
+            --compilation-config '{"cudagraph_mode":"FULL_DECODE_ONLY"}' \
+            --speculative-config '{"num_speculative_tokens": 5,  "method":"deepseek_mtp","enforce_eager":true}' \
+            --additional-config '{"fuse_muls_add":true, "recompute_scheduler_enable":true, "enable_sparse_sfa_c8": true, "enable_sparse_li_c8": true, "enable_fused_mc2": 1, "enable_mlapo": true}' \
+            --trust-remote-code \
+            --max-num-seqs 32 \
+            --gpu-memory-utilization 0.90 \
+            ${server_role_args} \
+            --async-scheduling \
+            --quantization ascend \
+            --enable-auto-tool-choice \
+            --tool-call-parser glm47 \
+            --reasoning-parser glm45 \
+            --kv-transfer-config '{
+                "kv_connector": "MooncakeConnectorV1",
+                "kv_role": "kv_consumer",
+                "kv_port": "30200",
+                "engine_id": "2",
+                "kv_connector_extra_config": {
+                    "use_ascend_direct": true,
+                    "prefill": {"dp_size": 1, "pp_size": 2, "tp_size": 16, "pp_layer_partition": "41,37"},
+                    "decode": { "dp_size": 16, "tp_size": 2}
+                }
+            }'
+        ```
+
+    4. Decode node 1
+
+        ```shell
+        nic_name="xxxx" # change to your own nic name
+        local_ip="xxxx" # change to your own ip
+
+        # d0: api server on this node; d1: --headless
+        server_role_args="--headless"
+
+        export HCCL_BUFFSIZE=256
+        export HCCL_IF_IP=$local_ip
+        export HCCL_OP_EXPANSION_MODE="AIV"
+        export HCCL_SOCKET_IFNAME=$nic_name
+        export ASCEND_RT_VISIBLE_DEVICES=$1
+        export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/local/lib
+        export GLOO_SOCKET_IFNAME=$nic_name
+        export PYTORCH_NPU_ALLOC_CONF=expandable_segments:True
+
+        vllm serve <MODEL_PATH> \
+            --host 0.0.0.0 \
+            --port $2 \
+            --data-parallel-size $3 \
+            --data-parallel-rank $4 \
+            --data-parallel-address $5 \
+            --data-parallel-rpc-port $6 \
+            --tensor-parallel-size $7 \
+            --enable-expert-parallel \
+            --seed 1024 \
+            --served-model-name glm-5 \
+            --max-model-len 202752 \
+            --safetensors-load-strategy 'prefetch' \
+            --max-num-batched-tokens 192 \
+            --compilation-config '{"cudagraph_mode":"FULL_DECODE_ONLY"}' \
+            --speculative-config '{"num_speculative_tokens": 5,  "method":"deepseek_mtp","enforce_eager":true}' \
+            --additional-config '{"fuse_muls_add":true, "recompute_scheduler_enable":true, "enable_sparse_sfa_c8": true, "enable_sparse_li_c8": true, "enable_fused_mc2": 1, "enable_mlapo": true}' \
+            --trust-remote-code \
+            --max-num-seqs 32 \
+            --gpu-memory-utilization 0.90 \
+            ${server_role_args} \
+            --async-scheduling \
+            --quantization ascend \
+            --enable-auto-tool-choice \
+            --tool-call-parser glm47 \
+            --reasoning-parser glm45 \
+            --kv-transfer-config '{
+                "kv_connector": "MooncakeConnectorV1",
+                "kv_role": "kv_consumer",
+                "kv_port": "30200",
+                "engine_id": "2",
+                "kv_connector_extra_config": {
+                    "use_ascend_direct": true,
+                    "prefill": {"dp_size": 1, "pp_size": 2, "tp_size": 16, "pp_layer_partition": "41,37"},
+                    "decode": { "dp_size": 16, "tp_size": 2}
+                }
+            }'
+        ```
+
+Once the preparation is done, you can start the server with the following command on each node:
+
+1. Prefill node 0
+
+    ```shell
+    bash run_dp_template.sh
+    ```
+
+2. Prefill node 1
+
+    ```shell
+    bash run_dp_template.sh
+    ```
+
+3. Decode node 0
+
+    ```shell
+    # change ip to your own
+    python launch_online_dp.py --dp-size 16 --tp-size 2 --pp-size 1 --dp-size-local 8 --dp-rank-start 0 --dp-address $node_d0_ip --dp-rpc-port 16600 --vllm-start-port 9900
+    ```
+
+4. Decode node 1
+
+    ```shell
+    # change ip to your own
+    python launch_online_dp.py --dp-size 16 --tp-size 2 --pp-size 1 --dp-size-local 8 --dp-rank-start 8 --dp-address $node_d0_ip --dp-rpc-port 16600 --vllm-start-port 9900
+    ```
+
+To set up request forwarding, run the following script on any machine. You can get the proxy program in the repository's examples: [load_balance_proxy_server_example.py](https://github.com/vllm-project/vllm-ascend/blob/main/examples/disaggregated_prefill_v1/load_balance_proxy_server_example.py)
+
+```shell
+unset http_proxy
+unset https_proxy
+
+python load_balance_proxy_server_example.py \
+    --port 8000 \
+    --host 0.0.0.0 \
+    --prefiller-hosts \
+      $node_p0_ip \
+    --prefiller-ports \
+      9081 \
+    --decoder-hosts \
+      $node_d0_ip \
+      $node_d0_ip \
+      $node_d0_ip \
+      $node_d0_ip \
+      $node_d0_ip \
+      $node_d0_ip \
+      $node_d0_ip \
+      $node_d0_ip \
+    --decoder-ports \
+      9900 9901 9902 9903 9904 9905 9906 9907
 ```
 
 Key Parameter Descriptions:
 
 Only the key parameters specific to this model/scenario are described below. `max-model-len` and `max-num-seqs` need to be set according to the actual usage scenario.
 
-**Model-specific parameters:**
+**PP2 prefill node-specific configurations (p0/p1):**
 
-- `--enable-expert-parallel`: Must be enabled for the MoE architecture of GLM-5.2.
-- `--quantization ascend`: Enables Ascend quantization for the w4a8c8 quantized weights.
-- `--data-parallel-size 2` / `--tensor-parallel-size 8`: DP2 TP8 parallelism layout, recommended to balance memory capacity and compute efficiency for the w4a8c8 weights. For low-latency scenarios, use `dp1tp16` instead and turn off expert parallel, at the cost of lower throughput.
-- `--tool-call-parser glm47` / `--reasoning-parser glm45` / `--enable-auto-tool-choice`: Enable function calling for GLM-5.2.
-- `--speculative-config '{"num_speculative_tokens": 3, "method": "deepseek_mtp", "enforce_eager": true}'`: Enables Multi-Token Prediction (MTP) speculative decoding with the DeepSeek-style MTP draft head of GLM-5.2. `num_speculative_tokens` (3-5) controls how many tokens are speculated per step; `enforce_eager: true` is required because GLM-5.2 does not support graph-mode speculative decoding.
-- `--compilation-config '{"cudagraph_mode": "FULL_DECODE_ONLY"}'`: Enables graph capture for the decode phase only, improving decode performance by reducing kernel launch overhead.
-- `additional_config.enable_fused_mc2=0`: Disables the fused `dispatch_ffn_combine`/`mega_moe` operators in this scenario because they conflict with `multistream_overlap_shared_expert`; turn them on in multi-node scenarios where they are beneficial.
+- `VLLM_PP_LAYER_PARTITION="41,37"` / `--pipeline-parallel-size 2` / `--nnodes 2` / `--node-rank`: The prefill engine is split as PP2 over the two prefill nodes — the 78 layers are partitioned as `41/37`. `--node-rank` is `0` on prefill node 0 (p0) and `1` on prefill node 1 (p1).
+- `--distributed-executor-backend mp` / `--master-addr` / `--master-port 7060`: PP runs over two nodes with the `mp` executor (no Ray required). `--master-addr` is `$local_ip` on prefill node 0 (p0, PP master) and `$node_p0_ip` on prefill node 1 (p1).
+- `enable_fused_mc2`: Enables the fused `dispatch_ffn_combine`/`mega_moe` operators.
+- `enable_flashcomm1`: Enables FlashComm optimization to reduce communication and computation overhead on prefill nodes.
+- `--enforce-eager`: The prefill side runs in eager mode (the `FULL_DECODE_ONLY` graph capture is used on the decode side instead).
+- `--speculative-config '{"num_speculative_tokens": 1, ...}'`: Minimal MTP speculation during prefill (decode nodes use a higher count, see below).
+- `fuse_muls_add` / `enable_dsa_cp` / `enable_sparse_sfa_c8` / `enable_sparse_li_c8`: Mul-Add fusion, DSA context parallelism for long-context prefill, the SFA/LI sparse attention optimizations and the reshape optimization of the C8 quantized model.
 
-**`--additional-config` fields (Ascend-specific optimizations):**
+**Decode node-specific configurations (d0/d1):**
 
-- `"enable_dsa_cp": true`: Enables DSA context parallelism to accelerate long-context prefill. With DSA-CP enabled, `layer_sharding` cannot include `o_proj`.
-- `"enable_sparse_li_c8": true`: Sparse attention optimizations of the C8 quantized model. `enable_sparse_li_c8` accelerates the layer-index (LI) sparse attention and is recommended to keep `true`; If the GPU memory is insufficient due to a long sequence length, you are advised to enable `enable_sparse_sfa_c8`.
-- `"enable_balance_scheduling": true`: Balance scheduling improves output throughput and reduces TPOT in the v1 scheduler. This config field replaces the removed environment setting; TTFT may degrade in some scenarios, and it is not recommended when Prefill-Decode is separated.
-- `"multistream_overlap_shared_expert": true`: Overlaps shared-expert computation on an additional stream, improving decode efficiency.
+- `enable_mlapo`: MLAPO fusion on decode nodes for memory-bandwidth-bound token generation.
+- `--max-num-batched-tokens 192`: Small batch token limit on decode nodes — decode processes one target token plus the 5 speculated MTP tokens per sequence per step (`(5 + 1) × 32`).
+- `--speculative-config '{"num_speculative_tokens": 5, ...}'`: Higher MTP speculation count on decode nodes to maximize decode throughput.
+- `recompute_scheduler_enable=true`: Enables the recomputation scheduler. When the decode node KV cache is insufficient, requests are sent back to the prefill node to recompute the KV cache.
+- `--async-scheduling`: Async scheduling on the decode side.
 
-##### 5.1.1.2 Multi-Node Co-Located Deployment
+**Mooncake KV transfer configuration (`--kv-transfer-config`):**
 
-- `GLM-5.2-w4a8c8`: can be deployed on 2 Atlas 800 A3 (64GB × 16).
+- `"kv_connector": "MooncakeConnectorV1"`: Uses Mooncake as the KV cache transfer connector between prefill and decode nodes.
+- `"kv_role": "kv_producer"` / `"kv_consumer"`: `kv_producer` on prefill nodes, `kv_consumer` on decode nodes.
+- `"kv_port"`: Port for Mooncake KV transfer communication. Use different port ranges for prefill (`30000`) and decode (`30200`) node groups.
+- `"use_ascend_direct": true`: Enables Ascend direct transfer for KV cache, reducing latency.
+- `"engine_id"`: Fixed engine id of the Mooncake connector per role group: `0` for the prefill engine (shared by the two PP ranks) and `2` for the decode engines.
+- `"prefill"` / `"decode"` sections: Specify the parallelism of the prefill and decode node groups respectively. These must match the actual deployment topology (`prefill: dp_size 1, pp_size 2, tp_size 16, pp_layer_partition "41,37"`, `decode: dp_size 16, tp_size 2`).
 
-Run the following scripts on two nodes respectively.
+**Request forwarding (proxy):**
 
-**node 0**
+- The proxy program can be found in [load_balance_proxy_server_example.py](https://github.com/vllm-project/vllm-ascend/blob/main/examples/disaggregated_prefill_v1/load_balance_proxy_server_example.py).
 
-```shell
-# this obtained through ifconfig
-# nic_name is the network interface name corresponding to local_ip of the current node
-nic_name="xxx"
-local_ip="xxx"
+Please refer to [envs.py](https://github.com/vllm-project/vllm-ascend/blob/main/vllm_ascend/envs.py) for further explanation and restrictions of the environment variables above.
 
-# The value of node0_ip must be consistent with the value of local_ip set in node0 (master node)
-node0_ip="xxxx"
+##### 5.1.3.2 Deployment on 8 Atlas 800 A2
 
-export HCCL_OP_EXPANSION_MODE="AIV"
+On Atlas 800 A2, where each node exposes 8 cards, the same global P/D topology (Prefill `DP4 TP8`, Decode `DP8 TP4`) is split across 8 nodes: 4 prefill nodes hosting 1 DP rank each (8 cards per rank), and 4 decode nodes hosting 2 DP ranks each (4 cards per rank). The `launch_online_dp.py` above is reused as-is. The prefill side enables FlashComm1 and DSA CP; the decode side enables MLAPO and `DYNAMIC_EPLB` with a `FULL_DECODE_ONLY` graph. Both sides enable prefix caching and MTP (`num_speculative_tokens=3`). All IPs, NIC names, ports and weight paths below are placeholders.
+
+`run_dp_template.sh` for the prefill nodes:
+
+```bash
+#!/usr/bin/bash
+nic_name="<NIC_NAME>"
+local_ip="<CURRENT_NODE_IP>"
+
+export HCCL_BUFFSIZE=256
 export HCCL_IF_IP=$local_ip
-export GLOO_SOCKET_IFNAME=$nic_name
-export TP_SOCKET_IFNAME=$nic_name
+export HCCL_INTRA_ROCE_ENABLE=1
+export HCCL_OP_EXPANSION_MODE="AIV"
 export HCCL_SOCKET_IFNAME=$nic_name
-export HCCL_TRANSFER_TIMEOUT=600
-export HCCL_EXEC_TIMEOUT=3600
-export HCCL_CONNECT_TIMEOUT=3600
-export OMP_PROC_BIND=false
-export OMP_NUM_THREADS=1
-export HCCL_BUFFSIZE=400
+export ASCEND_RT_VISIBLE_DEVICES=$1
+export LD_LIBRARY_PATH=/usr/local/python3.11.10/lib:/usr/local/lib:$LD_LIBRARY_PATH
+export GLOO_SOCKET_IFNAME=$nic_name
+export MOONCAKE_CONFIG_PATH="/mnt/share/scripts/mooncake.json"
 export PYTORCH_NPU_ALLOC_CONF=expandable_segments:True
+export PYTHONHASHSEED=0
 
-vllm serve /root/.cache/modelscope/hub/models/vllm-ascend/GLM-5.2-w4a8c8 \
---host 0.0.0.0 \
---port 8077 \
---safetensors-load-strategy prefetch \
---api-server-count 1 \
---data-parallel-size 4 \
---data-parallel-start-rank 0 \
---data-parallel-size-local 2 \
---data-parallel-address $node0_ip \
---data-parallel-rpc-port 12980 \
---tensor-parallel-size 8 \
---enable-expert-parallel \
---seed 1024 \
---served-model-name glm-52 \
---tool-call-parser glm47 \
---reasoning-parser glm45 \
---enable-auto-tool-choice \
---max-num-seqs 16 \
---max-model-len 66000 \
---max-num-batched-tokens 8192 \
---trust-remote-code \
---gpu-memory-utilization 0.90 \
---quantization ascend \
---compilation-config '{"cudagraph_mode": "FULL_DECODE_ONLY"}' \
---additional-config '{"enable_dsa_cp": true,"enable_sparse_li_c8": true,"enable_balance_scheduling": true,"enable_fused_mc2":1}'  \
---speculative-config '{"num_speculative_tokens": 3, "method": "deepseek_mtp","enforce_eager":true}'
+vllm serve /root/.cache/modelscope/hub/models/vllm-ascend/GLM-5.2-w8a8c8 \
+    --host 0.0.0.0 \
+    --port $2 \
+    --data-parallel-size $3 \
+    --data-parallel-rank $4 \
+    --data-parallel-address $5 \
+    --data-parallel-rpc-port $6 \
+    --tensor-parallel-size $7 \
+    --enable-expert-parallel \
+    --enable-prefix-caching \
+    --seed 1024 \
+    --enable-chunked-prefill \
+    --served-model-name glm-5 \
+    --max-model-len 200000 \
+    --max-num-batched-tokens 8192 \
+    --trust-remote-code \
+    --max-num-seqs 512 \
+    --gpu-memory-utilization 0.92 \
+    --safetensors-load-strategy prefetch \
+    --quantization ascend \
+    --enforce-eager \
+    --enable-auto-tool-choice \
+    --tool-call-parser glm47 \
+    --reasoning-parser glm45 \
+    --kv-transfer-config \
+    '{
+    "kv_connector": "MultiConnector",
+    "kv_role": "kv_producer",
+    "kv_load_failure_policy": "recompute",
+    "kv_connector_extra_config": {
+        "connectors": [
+            {
+                "kv_connector": "MooncakeConnectorV1",
+                "kv_role": "kv_producer",
+                "kv_port": "30000",
+                "kv_connector_extra_config": {
+                    "prefill": {
+                        "dp_size": 4,
+                        "tp_size": 8
+                    },
+                    "decode": {
+                        "dp_size": 8,
+                        "tp_size": 4
+                    }
+                }
+            },
+            {
+                "kv_connector": "AscendStoreConnector",
+                "kv_role": "kv_producer",
+                "kv_connector_extra_config": {
+                    "lookup_rpc_port":"0",
+                    "backend": "mooncake"
+                }
+            }
+        ]
+    }
+    }' \
+    --additional-config '{"enable_flashcomm1": true, "enable_dsa_cp": true, "ascend_compilation_config": {"enable_npugraph_ex": true, "enable_static_kernel": false}, "fuse_muls_add": true, "multistream_overlap_shared_expert": true, "enable_mc2_hierarchy_comm": false, "enable_sparse_sfa_c8": true, "enable_sparse_li_c8": true, "enable_cpu_binding": true, "recompute_scheduler_enable": false, "enable_mlapo": true}' \
+    --profiler-config \
+    '{
+        "profiler": "torch",
+        "torch_profiler_dir": "/mnt/share/xxx/prof",
+        "torch_profiler_with_stack": false
+    }' \
+    --speculative-config '{"num_speculative_tokens": 1, "method":"deepseek_mtp", "enforce_eager":true}'
 ```
 
-**node 1**
+`run_dp_template.sh` for the decode nodes:
 
-```shell
-# this obtained through ifconfig
-# nic_name is the network interface name corresponding to local_ip of the current node
-nic_name="xxx"
-local_ip="xxx"
+```bash
+#!/usr/bin/bash
 
-# The value of node0_ip must be consistent with the value of local_ip set in node0 (master node)
-node0_ip="xxxx"
+nic_name="<NIC_NAME>"
+local_ip="<CURRENT_NODE_IP>"
 
-export HCCL_OP_EXPANSION_MODE="AIV"
+export HCCL_BUFFSIZE=2560
 export HCCL_IF_IP=$local_ip
-export GLOO_SOCKET_IFNAME=$nic_name
-export TP_SOCKET_IFNAME=$nic_name
+export HCCL_INTRA_ROCE_ENABLE=1
+export HCCL_OP_EXPANSION_MODE="AIV"
 export HCCL_SOCKET_IFNAME=$nic_name
-export HCCL_TRANSFER_TIMEOUT=600
-export HCCL_EXEC_TIMEOUT=3600
-export HCCL_CONNECT_TIMEOUT=3600
-export OMP_PROC_BIND=false
-export OMP_NUM_THREADS=1
-export HCCL_BUFFSIZE=400
+export ASCEND_RT_VISIBLE_DEVICES=$1
+export LD_LIBRARY_PATH=/usr/local/python3.11.10/lib:/usr/local/lib:$LD_LIBRARY_PATH
+export GLOO_SOCKET_IFNAME=$nic_name
+export MOONCAKE_CONFIG_PATH="/mnt/share/scripts/mooncake.json"
 export PYTORCH_NPU_ALLOC_CONF=expandable_segments:True
+export PYTHONHASHSEED=0
 
-vllm serve /root/.cache/modelscope/hub/models/vllm-ascend/GLM-5.2-w4a8c8 \
---host 0.0.0.0 \
---port 8077 \
---headless \
---safetensors-load-strategy prefetch \
---data-parallel-size 4 \
---data-parallel-start-rank 2 \
---data-parallel-size-local 2 \
---data-parallel-address $node0_ip \
---data-parallel-rpc-port 12980 \
---tensor-parallel-size 8 \
---enable-expert-parallel \
---seed 1024 \
---served-model-name glm-52 \
---tool-call-parser glm47 \
---reasoning-parser glm45 \
---enable-auto-tool-choice \
---max-num-seqs 16 \
---max-model-len 66000 \
---max-num-batched-tokens 8192 \
---trust-remote-code \
---gpu-memory-utilization 0.90 \
---quantization ascend \
---compilation-config '{"cudagraph_mode": "FULL_DECODE_ONLY"}' \
---additional-config '{"enable_dsa_cp": true,"enable_sparse_li_c8": true,"enable_balance_scheduling": true,"enable_fused_mc2":1}'  \
---speculative-config '{"num_speculative_tokens": 3, "method": "deepseek_mtp","enforce_eager":true}'
+vllm serve /root/.cache/modelscope/hub/models/vllm-ascend/GLM-5.2-w8a8c8 \
+    --host 0.0.0.0 \
+    --port $2 \
+    --data-parallel-size $3 \
+    --data-parallel-rank $4 \
+    --data-parallel-address $5 \
+    --data-parallel-rpc-port $6 \
+    --tensor-parallel-size $7 \
+    --enable-expert-parallel \
+    --enable-prefix-caching \
+    --seed 1024 \
+    --served-model-name glm-5 \
+    --max-model-len 200000 \
+    --max-num-batched-tokens 256 \
+    --trust-remote-code \
+    --max-num-seqs 256 \
+    --gpu-memory-utilization 0.92 \
+    --safetensors-load-strategy prefetch \
+    --quantization ascend \
+    --enable-auto-tool-choice \
+    --tool-call-parser glm47 \
+    --reasoning-parser glm45 \
+    --kv-transfer-config \
+    '{
+    "kv_connector": "MultiConnector",
+    "kv_role": "kv_consumer",
+    "kv_load_failure_policy": "recompute",
+    "kv_connector_extra_config": {
+        "connectors": [
+            {
+                "kv_connector": "MooncakeConnectorV1",
+                "kv_role": "kv_consumer",
+                "kv_port": "30100",
+                "kv_connector_extra_config": {
+                    "prefill": {
+                        "dp_size": 4,
+                        "tp_size": 8
+                    },
+                    "decode": {
+                        "dp_size": 8,
+                        "tp_size": 4
+                    }
+                }
+            },
+            {
+                "kv_connector": "AscendStoreConnector",
+                "kv_role": "kv_consumer",
+                "kv_connector_extra_config": {
+                    "lookup_rpc_port":"0",
+                    "load_async": true,
+                    "backend": "mooncake"
+                }
+            }
+        ]
+    }
+    }' \
+     --compilation-config \
+    '{
+        "cudagraph_mode": "FULL_DECODE_ONLY",
+        "cudagraph_capture_sizes": [4,8,16,24,32,40,48,56,64,96,128,160,192,224,256,298,320,352,384]
+    }' \
+    --profiler-config \
+    '{
+        "profiler": "torch",
+        "torch_profiler_dir": "/mnt/share/xxx/prof",
+        "torch_profiler_with_stack": false
+    }' \
+    --additional-config '{"enable_flashcomm1": false, "enable_dsa_cp": false, "ascend_compilation_config": {"enable_npugraph_ex": true, "enable_static_kernel": false}, "fuse_muls_add": true, "multistream_overlap_shared_expert": true, "enable_mc2_hierarchy_comm": false, "enable_sparse_sfa_c8": true, "enable_sparse_li_c8": true, "enable_cpu_binding": true, "recompute_scheduler_enable": true, "enable_mlapo": true}' \
+    --speculative-config '{"num_speculative_tokens": 3, "method":"deepseek_mtp", "enforce_eager":true}'
 ```
 
-Key Parameter Descriptions (in addition to [Single-Node Deployment](#5111-single-node-deployment)):
+Once the preparation is done, start the server with the following commands:
 
-**Multi-node network and data parallel configuration:**
+1. Prefill nodes — run on `$node_p0_ip`, `$node_p1_ip`, `$node_p2_ip`, `$node_p3_ip` with `--dp-rank-start` `0/1/2/3`:
 
-- `HCCL_IF_IP`, `GLOO_SOCKET_IFNAME`, `TP_SOCKET_IFNAME`, `HCCL_SOCKET_IFNAME`: Network interface configuration for multi-node communication. Set `nic_name` to the network interface name (obtained via `ifconfig`) and `local_ip` to the current node's IP address. These must be correctly configured on each node for successful multi-node communication.
-- `--data-parallel-size 4`: Total number of data parallel ranks across all nodes (2 ranks per node in this scenario).
-- `--data-parallel-size-local 2`: Number of data parallel ranks on the current node.
-- `--data-parallel-start-rank`: Starting rank offset for data parallel ranks on this node. Node 0 uses `0`, node 1 uses `2`.
-- `--data-parallel-address`: IP address of the data parallel master node (node 0). Must match the `local_ip` of the master node.
-- `--data-parallel-rpc-port 12980`: RPC port for data parallel master communication. Must be the same across all nodes.
-- `--headless`: Indicates a non-master node (used on node 1). Do not use on node 0.
+    ```shell
+    python launch_online_dp.py --dp-size 4 --tp-size 8 --dp-size-local 1 --dp-rank-start 0 --dp-address $node_p0_ip --dp-rpc-port 16591 --vllm-start-port 9081
+    python launch_online_dp.py --dp-size 4 --tp-size 8 --dp-size-local 1 --dp-rank-start 1 --dp-address $node_p0_ip --dp-rpc-port 16591 --vllm-start-port 9081
+    python launch_online_dp.py --dp-size 4 --tp-size 8 --dp-size-local 1 --dp-rank-start 2 --dp-address $node_p0_ip --dp-rpc-port 16591 --vllm-start-port 9081
+    python launch_online_dp.py --dp-size 4 --tp-size 8 --dp-size-local 1 --dp-rank-start 3 --dp-address $node_p0_ip --dp-rpc-port 16591 --vllm-start-port 9081
+    ```
+
+2. Decode nodes — run on `$node_d0_ip`, `$node_d1_ip`, `$node_d2_ip`, `$node_d3_ip` with `--dp-rank-start` `0/2/4/6`:
+
+    ```shell
+    python launch_online_dp.py --dp-size 8 --tp-size 4 --dp-size-local 2 --dp-rank-start 0 --dp-address $node_d0_ip --dp-rpc-port 16600 --vllm-start-port 9900
+    python launch_online_dp.py --dp-size 8 --tp-size 4 --dp-size-local 2 --dp-rank-start 2 --dp-address $node_d0_ip --dp-rpc-port 16600 --vllm-start-port 9900
+    python launch_online_dp.py --dp-size 8 --tp-size 4 --dp-size-local 2 --dp-rank-start 4 --dp-address $node_d0_ip --dp-rpc-port 16600 --vllm-start-port 9900
+    python launch_online_dp.py --dp-size 8 --tp-size 4 --dp-size-local 2 --dp-rank-start 6 --dp-address $node_d0_ip --dp-rpc-port 16600 --vllm-start-port 9900
+    ```
+
+For request forwarding on this 8-node A2 layout, use 4 prefiller hosts (1 endpoint each) and 4 decoder hosts (2 endpoints each) in the Request Forwarding command below.
+
+To set up request forwarding, run the following script on any machine. You can get the proxy program in the repository's examples: [load_balance_proxy_server_example.py](https://github.com/vllm-project/vllm-ascend/blob/main/examples/disaggregated_prefill_v1/load_balance_proxy_server_example.py)
+
+```shell
+unset http_proxy
+unset https_proxy
+
+python load_balance_proxy_server_example.py \
+    --port 8000 \
+    --host 0.0.0.0 \
+    --prefiller-hosts \
+      $node_p0_ip \
+      $node_p1_ip \
+      $node_p2_ip \
+      $node_p3_ip \
+    --prefiller-ports \
+      9081 9081 \
+      9081 9081 \
+    --decoder-hosts \
+      $node_d0_ip \
+      $node_d0_ip \
+      $node_d1_ip \
+      $node_d1_ip \
+      $node_d2_ip \
+      $node_d2_ip \
+      $node_d3_ip \
+      $node_d3_ip \
+    --decoder-ports \
+      9900 9901 9900 9901 \
+      9900 9901 9900 9901
+```
 
 **Notice:**
-This scenario enables `additional_config.enable_fused_mc2=1` (fused `dispatch_ffn_combine`/`mega_moe` operators). Fused MC2 conflicts with `multistream_overlap_shared_expert` — the two optimizations must not be enabled at the same time (the runtime forcibly disables `multistream_overlap_shared_expert` when fused MC2 is on).
 
-##### 5.1.1.3 Prefill-Decode Disaggregation
+Some configurations for optimization are shown below:
 
-We'd like to show the deployment guide of `GLM-5.2` on multi-node environment with 1P1D for better performance.
+- `enable_flashcomm1`: Enable FlashComm optimization to reduce communication and computation overhead on prefill node. With FlashComm enabled, layer_sharding list cannot include o_proj as an element.
+- `enable_fused_mc2`: Enable the dispatch_ffn_combine/mega_moe fused operator.
 
-Prefill-Decode disaggregation can be deployed on 4 Atlas 800 A3 (64GB × 16).
+Please refer to the following python file for further explanation and restrictions of the environment variables above: [envs.py](https://github.com/vllm-project/vllm-ascend/blob/main/vllm_ascend/envs.py)
 
-**Deployment topology:**
+### 5.2 1M Context Configuration
 
-|Node group|Nodes|Parallelism|Engine ports|
-|----------|-----|-----------|------------|
-|Prefill|2 (node 0/1)|`DP4 TP8` (2 ranks per node)|9081/9082 per node|
-|Decode|2 (node 0/1)|`DP32 TP1` (16 ranks per node)|9900-9915 per node|
+#### 5.2.1 Single-Node 1M Deployment
+
+- Quantized model `GLM-5.2-w4a8c8` can be deployed on 1 Atlas 800 A3 (64GB × 16) for the 1M context.
+
+Recommended command:
+
+```shell
+export HCCL_BUFFSIZE=768
+export HCCL_OP_EXPANSION_MODE="AIV"
+export PYTORCH_NPU_ALLOC_CONF=expandable_segments:True
+
+vllm serve <MODEL_PATH> \
+  --seed 1024 \
+  --host 0.0.0.0 \
+  --port 9000 \
+  --served-model-name glm-52 \
+  --max-model-len 1024000 \
+  --max-num-batched-tokens 16384 \
+  --gpu-memory-utilization 0.80 \
+  --api-server-count 1 \
+  --max-num-seqs 32 \
+  --data-parallel-size 1 \
+  --pipeline-parallel-size 1 \
+  --tensor-parallel-size 16 \
+  --prefill-context-parallel-size 1 \
+  --decode-context-parallel-size 16 \
+  --cp-kv-cache-interleave-size 128 \
+  --compilation-config '{"cudagraph_mode": "FULL_DECODE_ONLY", "cudagraph_capture_sizes": [4, 16, 128]}' \
+  --additional-config '{"enable_flashcomm1": true, "enable_dsa_cp": true, "ascend_compilation_config": {"enable_npugraph_ex": true, "enable_static_kernel": false}, "fuse_muls_add": true, "multistream_overlap_shared_expert": true, "enable_mc2_hierarchy_comm": false, "enable_sparse_sfa_c8": true, "enable_sparse_li_c8": true, "enable_cpu_binding": true, "recompute_scheduler_enable": false, "weight_nz_mode": 1}' \
+  --speculative-config '{"num_speculative_tokens": 3, "method": "deepseek_mtp", "enforce_eager": true}' \
+  --quantization ascend \
+  --enable-expert-parallel \
+  --safetensors-load-strategy prefetch
+```
+
+#### 5.2.2 Dual-Node Co-Located 1M Deployment
+
+- `GLM-5.2-w4a8c8` can be deployed on 2 Atlas 800 A3 (64GB × 16) for the 1M context.
+
+Recommended command for both co-located nodes:
+
+```shell
+nic_name="<NIC_NAME>"
+local_ip="<CURRENT_NODE_IP>"
+node_0_ip="<NODE0_IP>"
+# Node 0: data_parallel_start_rank=0, server_role_args="--api-server-count 1"
+# Node 1: data_parallel_start_rank=2, server_role_args="--headless"
+data_parallel_start_rank=0
+server_role_args="--api-server-count 1"
+
+export HCCL_BUFFSIZE=768
+export HCCL_IF_IP=$local_ip
+export HCCL_OP_EXPANSION_MODE="AIV"
+export HCCL_SOCKET_IFNAME=$nic_name
+export GLOO_SOCKET_IFNAME=$nic_name
+export PYTORCH_NPU_ALLOC_CONF=expandable_segments:True
+
+vllm serve <MODEL_PATH> \
+  --seed 1024 \
+  --host 0.0.0.0 \
+  --port 9000 \
+  --served-model-name glm-52 \
+  --max-model-len 1024000 \
+  --max-num-batched-tokens 16384 \
+  --gpu-memory-utilization 0.75 \
+  ${server_role_args} \
+  --max-num-seqs 8 \
+  --data-parallel-size 4 \
+  --data-parallel-size-local 2 \
+  --data-parallel-start-rank $data_parallel_start_rank \
+  --data-parallel-address $node_0_ip \
+  --data-parallel-rpc-port 16591 \
+  --pipeline-parallel-size 1 \
+  --tensor-parallel-size 8 \
+  --prefill-context-parallel-size 1 \
+  --decode-context-parallel-size 8 \
+  --cp-kv-cache-interleave-size 128 \
+  --compilation-config '{"cudagraph_mode": "FULL_DECODE_ONLY"}' \
+  --additional-config '{"enable_flashcomm1": true, "enable_dsa_cp": true, "ascend_compilation_config": {"enable_npugraph_ex": true, "enable_static_kernel": false}, "fuse_muls_add": true, "multistream_overlap_shared_expert": true, "enable_mc2_hierarchy_comm": false, "enable_sparse_sfa_c8": true, "enable_sparse_li_c8": true, "enable_cpu_binding": true, "recompute_scheduler_enable": false, "weight_nz_mode": 1}' \
+  --speculative-config '{"num_speculative_tokens": 3, "method": "deepseek_mtp", "enforce_eager": true}' \
+  --quantization ascend \
+  --enable-expert-parallel \
+  --safetensors-load-strategy prefetch
+```
+
+#### 5.2.3 PD Disaggregation 1M Deployment
+
+PD disaggregation for the 1M context with the `GLM-5.2-w8a8c8` weights can be deployed on 4 Atlas 800 A3 (64GB × 16).
 
 Before you start, please
 
-1. prepare the script `launch_online_dp.py` on each node:
+prepare the script `launch_online_dp.py` on each node (used by the prefill and decode nodes below to pass the engine port and DP parameters):
 
     ```python
     import argparse
@@ -426,311 +1180,285 @@ Before you start, please
 
         for process in processes:
             process.join()
-
     ```
 
-2. prepare the script `run_dp_template.sh` on each node.
+prepare the script `run_dp_template.sh` on each node.
 
-    1. Prefill node 0
+1. Prefill node 0
 
-        ```shell
-        nic_name="xxxx" # change to your own nic name
-        local_ip="xxxx" # change to your own ip
+    ```shell
+    nic_name="<NIC_NAME>" # change to your own nic name
+    local_ip="<CURRENT_PREFILL_NODE_IP>" # change to your own ip
+    # p0: api server on this node; p1: --headless
+    server_role_args="--api-server-count 1"
 
-        export HCCL_OP_EXPANSION_MODE="AIV"
-        export HCCL_IF_IP=$local_ip
-        export GLOO_SOCKET_IFNAME=$nic_name
-        export TP_SOCKET_IFNAME=$nic_name
-        export HCCL_SOCKET_IFNAME=$nic_name
-        export HCCL_TRANSFER_TIMEOUT=600
-        export HCCL_EXEC_TIMEOUT=3600
-        export HCCL_CONNECT_TIMEOUT=3600
-        export OMP_PROC_BIND=false
-        export OMP_NUM_THREADS=1
-        export PYTORCH_NPU_ALLOC_CONF=expandable_segments:True
-        export HCCL_BUFFSIZE=400
-        export ACL_OP_INIT_MODE=1
-        export ASCEND_A3_ENABLE=1
-        export ASCEND_RT_VISIBLE_DEVICES=$1
-        export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/local/lib
+    export VLLM_EXECUTE_MODEL_TIMEOUT_SECONDS=30000
+    export HCCL_BUFFSIZE=400
+    export HCCL_IF_IP=$local_ip
+    export HCCL_OP_EXPANSION_MODE="AIV"
+    export HCCL_SOCKET_IFNAME=$nic_name
+    export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/local/lib
+    export GLOO_SOCKET_IFNAME=$nic_name
+    export PYTORCH_NPU_ALLOC_CONF=expandable_segments:True
+    export MF_GROUP_JOIN_MAX_TIMEOUT=1200
 
-        vllm serve /root/.cache/modelscope/hub/models/vllm-ascend/GLM-5.2-w4a8c8 \
-            --host 0.0.0.0 \
-            --port $2 \
-            --safetensors-load-strategy prefetch \
-            --data-parallel-size $3 \
-            --data-parallel-rank $4 \
-            --data-parallel-address $5 \
-            --data-parallel-rpc-port $6 \
-            --tensor-parallel-size $7 \
-            --enable-expert-parallel \
-            --speculative-config '{"num_speculative_tokens":1, "method":"deepseek_mtp","enforce_eager":true}' \
-            --seed 1024 \
-            --served-model-name glm-5 \
-            --max-model-len 133120 \
-            --additional-config '{"enable_dsa_cp":true,"enable_sparse_li_c8": true,"enable_fused_mc2":1}' \
-            --max-num-batched-tokens 8192 \
-            --trust-remote-code \
-            --max-num-seqs 64 \
-            --quantization ascend \
-            --gpu-memory-utilization 0.92 \
-            --enforce-eager \
-            --enable-auto-tool-choice \
-            --tool-call-parser glm47 \
-            --reasoning-parser glm45 \
-            --kv-transfer-config \
-            '{"kv_connector": "MooncakeConnectorV1",
+    vllm serve <MODEL_PATH> \
+        --host 0.0.0.0 \
+        --port $2 \
+        --data-parallel-size $3 \
+        --data-parallel-rank $4 \
+        --data-parallel-address $5 \
+        --data-parallel-rpc-port $6 \
+        --tensor-parallel-size $7 \
+        --enable-expert-parallel \
+        --prefill-context-parallel-size 1 \
+        --decode-context-parallel-size 16 \
+        --cp-kv-cache-interleave-size 128 \
+        --speculative-config '{"num_speculative_tokens": 1, "method":"deepseek_mtp","enforce_eager":true}' \
+        --seed 1024 \
+        --served-model-name glm-5 \
+        --max-model-len 1048576 \
+        --safetensors-load-strategy 'prefetch' \
+        --additional-config '{"fuse_muls_add":true, "multistream_overlap_shared_expert": true, "enable_dsa_cp":true, "enable_sparse_sfa_c8": true, "enable_sparse_li_c8": true, "c8_enable_reshape_optim":true, "mega_moe_max_tokens": 8192, "enable_flashcomm1": true, "enable_fused_mc2": 1}' \
+        --max-num-batched-tokens 8192 \
+        --trust-remote-code \
+        --enable-prefix-caching \
+        --max-num-seqs 64 \
+        --quantization ascend \
+        --gpu-memory-utilization 0.85 \
+        ${server_role_args} \
+        --enforce-eager \
+        --enable-auto-tool-choice \
+        --tool-call-parser glm47 \
+        --reasoning-parser glm45 \
+        --kv-transfer-config '{
+            "kv_connector": "MooncakeConnectorV1",
             "kv_role": "kv_producer",
             "kv_port": "30000",
             "engine_id": "0",
             "kv_connector_extra_config": {
-                        "use_ascend_direct": true,
-                        "prefill": {
-                                "dp_size": 4,
-                                "tp_size": 8
-                        },
-                        "decode": {
-                                "dp_size": 32,
-                                "tp_size": 1
-                        }
-                }
-            }'
+                "use_ascend_direct": true,
+                "prefill": {"dp_size": 2, "tp_size": 16},
+                "decode": { "dp_size": 4, "tp_size": 8}
+            }
+        }'
+    ```
 
-        ```
+2. Prefill node 1
 
-    2. Prefill node 1
+    DP rank `1`, engine port `9082`. Same script as p0 with `server_role_args="--headless"` (non-master node, no API server); `--data-parallel-address` (`$5`) still points to prefill node 0 (DP master node).
 
-        ```shell
-        nic_name="xxxx" # change to your own nic name
-        local_ip="xxxx" # change to your own ip
+    ```shell
+    nic_name="<NIC_NAME>" # change to your own nic name
+    local_ip="<CURRENT_PREFILL_NODE_IP>" # change to your own ip
+    # p0: api server on this node; p1: --headless
+    server_role_args="--headless"
 
-        export HCCL_OP_EXPANSION_MODE="AIV"
-        export HCCL_IF_IP=$local_ip
-        export GLOO_SOCKET_IFNAME=$nic_name
-        export TP_SOCKET_IFNAME=$nic_name
-        export HCCL_SOCKET_IFNAME=$nic_name
-        export HCCL_TRANSFER_TIMEOUT=600
-        export HCCL_EXEC_TIMEOUT=3600
-        export HCCL_CONNECT_TIMEOUT=3600
-        export OMP_PROC_BIND=false
-        export OMP_NUM_THREADS=1
-        export PYTORCH_NPU_ALLOC_CONF=expandable_segments:True
-        export HCCL_BUFFSIZE=400
-        export ACL_OP_INIT_MODE=1
-        export ASCEND_A3_ENABLE=1
-        export ASCEND_RT_VISIBLE_DEVICES=$1
-        export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/local/lib
+    export VLLM_EXECUTE_MODEL_TIMEOUT_SECONDS=30000
+    export HCCL_BUFFSIZE=400
+    export HCCL_IF_IP=$local_ip
+    export HCCL_OP_EXPANSION_MODE="AIV"
+    export HCCL_SOCKET_IFNAME=$nic_name
+    export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/local/lib
+    export GLOO_SOCKET_IFNAME=$nic_name
+    export PYTORCH_NPU_ALLOC_CONF=expandable_segments:True
+    export MF_GROUP_JOIN_MAX_TIMEOUT=1200
 
-        vllm serve /root/.cache/modelscope/hub/models/vllm-ascend/GLM-5.2-w4a8c8 \
-            --host 0.0.0.0 \
-            --port $2 \
-            --safetensors-load-strategy prefetch \
-            --data-parallel-size $3 \
-            --data-parallel-rank $4 \
-            --data-parallel-address $5 \
-            --data-parallel-rpc-port $6 \
-            --tensor-parallel-size $7 \
-            --enable-expert-parallel \
-            --speculative-config '{"num_speculative_tokens":1, "method":"deepseek_mtp","enforce_eager":true}' \
-            --seed 1024 \
-            --served-model-name glm-5 \
-            --max-model-len 133120 \
-            --additional-config '{"enable_dsa_cp":true, "enable_sparse_li_c8": true,"enable_fused_mc2":1}' \
-            --max-num-batched-tokens 8192 \
-            --trust-remote-code \
-            --max-num-seqs 64 \
-            --quantization ascend \
-            --gpu-memory-utilization 0.92 \
-            --enforce-eager \
-            --enable-auto-tool-choice \
-            --tool-call-parser glm47 \
-            --reasoning-parser glm45 \
-            --kv-transfer-config \
-            '{"kv_connector": "MooncakeConnectorV1",
+    vllm serve <MODEL_PATH> \
+        --host 0.0.0.0 \
+        --port $2 \
+        --data-parallel-size $3 \
+        --data-parallel-rank $4 \
+        --data-parallel-address $5 \
+        --data-parallel-rpc-port $6 \
+        --tensor-parallel-size $7 \
+        --enable-expert-parallel \
+        --prefill-context-parallel-size 1 \
+        --decode-context-parallel-size 16 \
+        --cp-kv-cache-interleave-size 128 \
+        --speculative-config '{"num_speculative_tokens": 1, "method":"deepseek_mtp","enforce_eager":true}' \
+        --seed 1024 \
+        --served-model-name glm-5 \
+        --max-model-len 1048576 \
+        --safetensors-load-strategy 'prefetch' \
+        --additional-config '{"fuse_muls_add":true, "multistream_overlap_shared_expert": true, "enable_dsa_cp":true, "enable_sparse_sfa_c8": true, "enable_sparse_li_c8": true, "c8_enable_reshape_optim":true, "mega_moe_max_tokens": 8192, "enable_flashcomm1": true, "enable_fused_mc2": 1}' \
+        --max-num-batched-tokens 8192 \
+        --trust-remote-code \
+        --enable-prefix-caching \
+        --max-num-seqs 64 \
+        --quantization ascend \
+        --gpu-memory-utilization 0.85 \
+        ${server_role_args} \
+        --enforce-eager \
+        --enable-auto-tool-choice \
+        --tool-call-parser glm47 \
+        --reasoning-parser glm45 \
+        --kv-transfer-config '{
+            "kv_connector": "MooncakeConnectorV1",
             "kv_role": "kv_producer",
             "kv_port": "30000",
             "engine_id": "0",
             "kv_connector_extra_config": {
-                        "use_ascend_direct": true,
-                        "prefill": {
-                                "dp_size": 4,
-                                "tp_size": 8
-                        },
-                        "decode": {
-                                "dp_size": 32,
-                                "tp_size": 1
-                        }
-                }
-            }'
-        ```
+                "use_ascend_direct": true,
+                "prefill": {"dp_size": 2, "tp_size": 16},
+                "decode": { "dp_size": 4, "tp_size": 8}
+            }
+        }'
+    ```
 
-    3. Decode node 0
+3. Decode node 0
 
-        ```shell
-        nic_name="xxxx" # change to your own nic name
-        local_ip="xxxx" # change to your own ip
+    ```shell
+    nic_name="<NIC_NAME>" # change to your own nic name
+    local_ip="<CURRENT_DECODE_NODE_IP>" # change to your own ip
 
-        export HCCL_OP_EXPANSION_MODE="AIV"
-        export HCCL_IF_IP=$local_ip
-        export GLOO_SOCKET_IFNAME=$nic_name
-        export TP_SOCKET_IFNAME=$nic_name
-        export HCCL_SOCKET_IFNAME=$nic_name
-        export HCCL_TRANSFER_TIMEOUT=600
-        export HCCL_EXEC_TIMEOUT=3600
-        export HCCL_CONNECT_TIMEOUT=3600
-        #Mooncake
-        export OMP_PROC_BIND=false
-        export OMP_NUM_THREADS=1
-        export PYTORCH_NPU_ALLOC_CONF=expandable_segments:True
-        export HCCL_BUFFSIZE=256
-        export ACL_OP_INIT_MODE=1
-        export ASCEND_A3_ENABLE=1
-        export TASK_QUEUE_ENABLE=1
-        export ASCEND_RT_VISIBLE_DEVICES=$1
-        export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/local/lib
+    # d0: api server on this node; d1: --headless
+    server_role_args="--api-server-count 1"
 
-        vllm serve /root/.cache/modelscope/hub/models/vllm-ascend/GLM-5.2-w4a8c8 \
-            --host 0.0.0.0 \
-            --port $2 \
-            --safetensors-load-strategy prefetch \
-            --data-parallel-size $3 \
-            --data-parallel-rank $4 \
-            --data-parallel-address $5 \
-            --data-parallel-rpc-port $6 \
-            --tensor-parallel-size $7 \
-            --enable-expert-parallel \
-            --seed 1024 \
-            --served-model-name glm-5 \
-            --max-model-len 133120 \
-            --max-num-batched-tokens 164 \
-            --compilation-config '{"cudagraph_mode":"FULL_DECODE_ONLY"}' \
-            --speculative-config '{"num_speculative_tokens": 5,  "method":"deepseek_mtp","enforce_eager":true}' \
-            --additional-config '{"recompute_scheduler_enable":true,"enable_sparse_li_c8":true,"enable_fused_mc2":1}' \
-            --trust-remote-code \
-            --max-num-seqs 32 \
-            --gpu-memory-utilization 0.92 \
-            --quantization ascend \
-            --enable-auto-tool-choice \
-            --tool-call-parser glm47 \
-            --reasoning-parser glm45 \
-            --kv-transfer-config \
-            '{"kv_connector": "MooncakeConnectorV1",
+    export VLLM_EXECUTE_MODEL_TIMEOUT_SECONDS=30000
+    export HCCL_BUFFSIZE=400
+    export HCCL_IF_IP=$local_ip
+    export HCCL_OP_EXPANSION_MODE="AIV"
+    export HCCL_SOCKET_IFNAME=$nic_name
+    export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/local/lib
+    export GLOO_SOCKET_IFNAME=$nic_name
+    export PYTORCH_NPU_ALLOC_CONF=expandable_segments:True
+    export MF_GROUP_JOIN_MAX_TIMEOUT=1200
+
+    vllm serve <MODEL_PATH> \
+        --host 0.0.0.0 \
+        --port $2 \
+        --data-parallel-size $3 \
+        --data-parallel-rank $4 \
+        --data-parallel-address $5 \
+        --data-parallel-rpc-port $6 \
+        --tensor-parallel-size $7 \
+        --enable-expert-parallel \
+        --prefill-context-parallel-size 1 \
+        --decode-context-parallel-size 8 \
+        --cp-kv-cache-interleave-size 128 \
+        --seed 1024 \
+        --served-model-name glm-5 \
+        --max-model-len 1048576 \
+        --safetensors-load-strategy 'prefetch' \
+        --max-num-batched-tokens 192 \
+        --compilation-config '{"cudagraph_mode":"FULL_DECODE_ONLY"}' \
+        --speculative-config '{"num_speculative_tokens": 5,  "method":"deepseek_mtp","enforce_eager":true}' \
+        --additional-config '{"fuse_muls_add":true, "recompute_scheduler_enable":true, "multistream_overlap_shared_expert":true, "enable_sparse_sfa_c8": true, "enable_sparse_li_c8": true, "enable_fused_mc2": 1, "enable_mlapo": true}' \
+        --trust-remote-code \
+        --max-num-seqs 32 \
+        --gpu-memory-utilization 0.90 \
+        ${server_role_args} \
+        --async-scheduling \
+        --quantization ascend \
+        --enable-auto-tool-choice \
+        --tool-call-parser glm47 \
+        --reasoning-parser glm45 \
+        --kv-transfer-config '{
+            "kv_connector": "MooncakeConnectorV1",
             "kv_role": "kv_consumer",
-            "kv_port": "30100",
-            "engine_id": "1",
+            "kv_port": "30200",
+            "engine_id": "2",
             "kv_connector_extra_config": {
-                        "use_ascend_direct": true,
-                        "prefill": {
-                                "dp_size": 4,
-                                "tp_size": 8
-                        },
-                        "decode": {
-                                "dp_size": 32,
-                                "tp_size": 1
-                        }
-                }
-            }'
-        ```
+                "use_ascend_direct": true,
+                "prefill": {"dp_size": 2, "tp_size": 16},
+                "decode": { "dp_size": 4, "tp_size": 8}
+            }
+        }'
+    ```
 
-    4. Decode node 1
+4. Decode node 1
 
-        ```shell
-        nic_name="xxxx" # change to your own nic name
-        local_ip="xxxx" # change to your own ip
+    ```shell
+    nic_name="<NIC_NAME>" # change to your own nic name
+    local_ip="<CURRENT_DECODE_NODE_IP>" # change to your own ip
 
-        export HCCL_OP_EXPANSION_MODE="AIV"
-        export HCCL_IF_IP=$local_ip
-        export GLOO_SOCKET_IFNAME=$nic_name
-        export TP_SOCKET_IFNAME=$nic_name
-        export HCCL_SOCKET_IFNAME=$nic_name
-        export HCCL_TRANSFER_TIMEOUT=600
-        export HCCL_EXEC_TIMEOUT=3600
-        export HCCL_CONNECT_TIMEOUT=3600
-        #Mooncake
-        export OMP_PROC_BIND=false
-        export OMP_NUM_THREADS=1
-        export PYTORCH_NPU_ALLOC_CONF=expandable_segments:True
-        export HCCL_BUFFSIZE=256
-        export ACL_OP_INIT_MODE=1
-        export ASCEND_A3_ENABLE=1
-        export TASK_QUEUE_ENABLE=1
-        export ASCEND_RT_VISIBLE_DEVICES=$1
-        export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/local/lib
+    # d0: api server on this node; d1: --headless
+    server_role_args="--headless"
 
-        vllm serve /root/.cache/modelscope/hub/models/vllm-ascend/GLM-5.2-w4a8c8 \
-            --host 0.0.0.0 \
-            --port $2 \
-            --safetensors-load-strategy prefetch \
-            --data-parallel-size $3 \
-            --data-parallel-rank $4 \
-            --data-parallel-address $5 \
-            --data-parallel-rpc-port $6 \
-            --tensor-parallel-size $7 \
-            --enable-expert-parallel \
-            --seed 1024 \
-            --served-model-name glm-5 \
-            --max-model-len 133120 \
-            --max-num-batched-tokens 164 \
-            --compilation-config '{"cudagraph_mode":"FULL_DECODE_ONLY"}' \
-            --speculative-config '{"num_speculative_tokens": 5,  "method":"deepseek_mtp","enforce_eager":true}' \
-            --additional-config '{"recompute_scheduler_enable":true,"enable_sparse_li_c8":true,"enable_fused_mc2":1}' \
-            --trust-remote-code \
-            --max-num-seqs 32 \
-            --gpu-memory-utilization 0.92 \
-            --quantization ascend \
-            --enable-auto-tool-choice \
-            --tool-call-parser glm47 \
-            --reasoning-parser glm45 \
-            --kv-transfer-config \
-            '{"kv_connector": "MooncakeConnectorV1",
+    export VLLM_EXECUTE_MODEL_TIMEOUT_SECONDS=30000
+    export HCCL_BUFFSIZE=400
+    export HCCL_IF_IP=$local_ip
+    export HCCL_OP_EXPANSION_MODE="AIV"
+    export HCCL_SOCKET_IFNAME=$nic_name
+    export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/local/lib
+    export GLOO_SOCKET_IFNAME=$nic_name
+    export PYTORCH_NPU_ALLOC_CONF=expandable_segments:True
+    export MF_GROUP_JOIN_MAX_TIMEOUT=1200
+
+    vllm serve <MODEL_PATH> \
+        --host 0.0.0.0 \
+        --port $2 \
+        --data-parallel-size $3 \
+        --data-parallel-rank $4 \
+        --data-parallel-address $5 \
+        --data-parallel-rpc-port $6 \
+        --tensor-parallel-size $7 \
+        --enable-expert-parallel \
+        --prefill-context-parallel-size 1 \
+        --decode-context-parallel-size 8 \
+        --cp-kv-cache-interleave-size 128 \
+        --seed 1024 \
+        --served-model-name glm-5 \
+        --max-model-len 1048576 \
+        --safetensors-load-strategy 'prefetch' \
+        --max-num-batched-tokens 192 \
+        --compilation-config '{"cudagraph_mode":"FULL_DECODE_ONLY"}' \
+        --speculative-config '{"num_speculative_tokens": 5,  "method":"deepseek_mtp","enforce_eager":true}' \
+        --additional-config '{"fuse_muls_add":true, "recompute_scheduler_enable":true, "multistream_overlap_shared_expert":true, "enable_sparse_sfa_c8": true, "enable_sparse_li_c8": true, "enable_fused_mc2": 1, "enable_mlapo": true}' \
+        --trust-remote-code \
+        --max-num-seqs 32 \
+        --gpu-memory-utilization 0.90 \
+        ${server_role_args} \
+        --async-scheduling \
+        --quantization ascend \
+        --enable-auto-tool-choice \
+        --tool-call-parser glm47 \
+        --reasoning-parser glm45 \
+        --kv-transfer-config '{
+            "kv_connector": "MooncakeConnectorV1",
             "kv_role": "kv_consumer",
-            "kv_port": "30100",
-            "engine_id": "1",
+            "kv_port": "30200",
+            "engine_id": "2",
             "kv_connector_extra_config": {
-                        "use_ascend_direct": true,
-                        "prefill": {
-                                "dp_size": 4,
-                                "tp_size": 8
-                        },
-                        "decode": {
-                                "dp_size": 32,
-                                "tp_size": 1
-                        }
-                }
-            }'
-        ```
+                "use_ascend_direct": true,
+                "prefill": {"dp_size": 2, "tp_size": 16},
+                "decode": { "dp_size": 4, "tp_size": 8}
+            }
+        }'
+    ```
 
-Once the preparation is done, you can start the server with the following command on each node:
+Once the preparation is done, start the server on each node:
 
 1. Prefill node 0
 
     ```shell
     # change ip to your own
-    python launch_online_dp.py --dp-size 4 --tp-size 8  --dp-size-local 2 --dp-rank-start 0 --dp-address $node_p0_ip --dp-rpc-port 16591 --vllm-start-port 9081
+    python launch_online_dp.py --dp-size 2 --tp-size 16 --dp-size-local 1 --dp-rank-start 0 --dp-address $node_p0_ip --dp-rpc-port 16591 --vllm-start-port 9081
     ```
 
 2. Prefill node 1
 
     ```shell
     # change ip to your own
-    python launch_online_dp.py --dp-size 4 --tp-size 8  --dp-size-local 2 --dp-rank-start 2 --dp-address $node_p0_ip --dp-rpc-port 16591 --vllm-start-port 9081
+    python launch_online_dp.py --dp-size 2 --tp-size 16 --dp-size-local 1 --dp-rank-start 1 --dp-address $node_p0_ip --dp-rpc-port 16591 --vllm-start-port 9082
     ```
 
 3. Decode node 0
 
     ```shell
     # change ip to your own
-    python launch_online_dp.py --dp-size 32 --tp-size 1 --dp-size-local 16 --dp-rank-start 0 --dp-address $node_d0_ip --dp-rpc-port 16600 --vllm-start-port 9900
+    python launch_online_dp.py --dp-size 4 --tp-size 8 --dp-size-local 2 --dp-rank-start 0 --dp-address $node_d0_ip --dp-rpc-port 16600 --vllm-start-port 9900
     ```
 
 4. Decode node 1
 
     ```shell
     # change ip to your own
-    python launch_online_dp.py --dp-size 32 --tp-size 1 --dp-size-local 16 --dp-rank-start 16 --dp-address $node_d0_ip --dp-rpc-port 16600 --vllm-start-port 9900
+    python launch_online_dp.py --dp-size 4 --tp-size 8 --dp-size-local 2 --dp-rank-start 2 --dp-address $node_d0_ip --dp-rpc-port 16600 --vllm-start-port 9900
     ```
 
-To set up request forwarding, run the following script on any machine. You can get the proxy program in the repository's examples: [load_balance_proxy_server_example.py](https://github.com/vllm-project/vllm-ascend/blob/main/examples/disaggregated_prefill_v1/load_balance_proxy_server_example.py)
+To set up request forwarding, run the following script on any machine.
 
 ```shell
 unset http_proxy
@@ -741,828 +1469,36 @@ python load_balance_proxy_server_example.py \
     --host 0.0.0.0 \
     --prefiller-hosts \
       $node_p0_ip \
-      $node_p0_ip \
-      $node_p1_ip \
-      $node_p1_ip \
     --prefiller-ports \
-      9081 9082 \
-      9081 9082 \
+      9081 \
     --decoder-hosts \
       $node_d0_ip \
       $node_d0_ip \
-      $node_d0_ip \
-      $node_d0_ip \
-      $node_d0_ip \
-      $node_d0_ip \
-      $node_d0_ip \
-      $node_d0_ip \
-      $node_d0_ip \
-      $node_d0_ip \
-      $node_d0_ip \
-      $node_d0_ip \
-      $node_d0_ip \
-      $node_d0_ip \
-      $node_d0_ip \
-      $node_d0_ip \
-      $node_d1_ip \
-      $node_d1_ip \
-      $node_d1_ip \
-      $node_d1_ip \
-      $node_d1_ip \
-      $node_d1_ip \
-      $node_d1_ip \
-      $node_d1_ip \
-      $node_d1_ip \
-      $node_d1_ip \
-      $node_d1_ip \
-      $node_d1_ip \
-      $node_d1_ip \
-      $node_d1_ip \
-      $node_d1_ip \
-      $node_d1_ip \
     --decoder-ports \
-      9900 9901 9902 9903 9904 9905 9906 9907 9908 9909 9910 9911 9912 9913 9914 9915 \
-      9900 9901 9902 9903 9904 9905 9906 9907 9908 9909 9910 9911 9912 9913 9914 9915
+      9900 9901
 ```
 
-Key Parameter Descriptions (in addition to [Single-Node Deployment](#5111-single-node-deployment) and [Multi-Node Co-Located Deployment](#5112-multi-node-co-located-deployment)):
+Key Parameter Descriptions (in addition to [Prefill-Decode Disaggregation](#513-prefill-decode-disaggregation) and [Single-Node 1M Deployment](#521-single-node-1m-deployment)):
 
-**`launch_online_dp.py` parameters:**
+The `run_dp_template.sh` templates use the positional parameters passed by `launch_online_dp.py`: `$1` = visible devices, `$2` = engine port, `$3` = data-parallel-size, `$4` = data-parallel-rank, `$5` = data-parallel-address, `$6` = data-parallel-rpc-port, `$7` = tensor-parallel-size.
 
-|Parameter|Type|Required|Default|Description|
-|---------|----|--------|-------|-----------|
-|`--dp-size`|int|Yes|-|Data parallel size (total number of DP ranks across all nodes).|
-|`--tp-size`|int|No|1|Tensor parallel size within each DP rank.|
-|`--dp-size-local`|int|No|(same as `--dp-size`)|Number of DP ranks on the current node. If not set, defaults to `--dp-size`.|
-|`--dp-rank-start`|int|No|0|Starting rank offset for data parallel ranks on this node.|
-|`--dp-address`|str|Yes|-|IP address of the data parallel master node (node 0).|
-|`--dp-rpc-port`|str|No|12345|RPC port for data parallel master communication.|
-|`--vllm-start-port`|int|No|9000|Starting port for each vLLM engine instance on this node. Each DP rank's engine port = `vllm_start_port` + local rank index.|
+**1M-specific environment variables (both prefiller and decoder nodes):**
 
-**Prefill node-specific configurations:**
-
-- `additional_config.enable_fused_mc2=1`: Enables the `dispatch_ffn_combine`/`mega_moe` fused operators. Note: fused MC2 conflicts with `multistream_overlap_shared_expert`.
-- `ACL_OP_INIT_MODE=1` / `ASCEND_A3_ENABLE=1`: A3-specific optimizations for operator initialization and communication aggregation.
-- `--speculative-config '{"num_speculative_tokens": 1, ...}'`: Minimal MTP speculation during prefill (decode nodes use a higher count, see below).
-
-**Decode node-specific configurations:**
-
-- `--max-num-batched-tokens 164`: Small batch token limit on decode nodes — decode processes one token per sequence per step, so batch tokens should be close to `max-num-seqs`.
-- `--speculative-config '{"num_speculative_tokens": 5, ...}'`: Higher MTP speculation count on decode nodes to maximize decode throughput.
-- `--additional-config '{"recompute_scheduler_enable": true}'`: Enables the recomputation scheduler. When the decode node KV cache is insufficient, requests are sent back to the prefill node to recompute the KV cache. Recommended on both prefill and decode nodes in PD scenarios.
-
-**Mooncake KV transfer configuration (`--kv-transfer-config`):**
-
-- `"kv_connector": "MooncakeConnectorV1"`: Uses Mooncake as the KV cache transfer connector between prefill and decode nodes.
-- `"kv_role": "kv_producer"` / `"kv_consumer"`: `kv_producer` on prefill nodes, `kv_consumer` on decode nodes.
-- `"kv_port"`: Port for Mooncake KV transfer communication. Use different port ranges for prefill (`30000`) and decode (`30100`) node groups.
-- `"use_ascend_direct": true`: Enables Ascend direct transfer for KV cache, reducing latency.
-- `"prefill"` / `"decode"` sections: Specify the `dp_size` and `tp_size` of the prefill and decode node groups respectively. These must match the actual deployment topology (`prefill: dp4 tp8`, `decode: dp32 tp1`).
-
-**Request forwarding (proxy):**
-
-- The proxy command maps every prefill engine endpoint (4 prefiller hosts × 2 ports per node) and every decode engine endpoint (32 decoder hosts/ports) to a single entry point on port `8000`.
-- The proxy program can be found in [load_balance_proxy_server_example.py](https://github.com/vllm-project/vllm-ascend/blob/main/examples/disaggregated_prefill_v1/load_balance_proxy_server_example.py).
-
-Please refer to [envs.py](https://github.com/vllm-project/vllm-ascend/blob/main/vllm_ascend/envs.py) for further explanation and restrictions of the environment variables above.
-
-##### 5.1.1.4 Multi-Node Deployment over RoCE
-
-This section describes the additional configuration for A3 deployments that use RoCE between physical nodes, such as deployments across SuperPods. Apply these settings in addition to the corresponding A3 deployment commands above.
-
-1. **Logical SuperPod configuration**
-
-    Set a unique `HCCL_LOGIC_SUPERPOD_ID` for each physical node. All vLLM processes on the same physical node must use the same value.
-
-2. **Expert Parallel communication configuration**
-
-    The supported MC2 communication mode depends on whether the Expert Parallel (EP) communication domain spans physical nodes:
-
-    - If the EP communication domain is contained within a physical node, no change to the existing configuration is required. Fused MC2 remains supported.
-    - If the EP communication domain spans physical nodes, Fused MC2 is not supported. Hierarchical MC2 communication over RoCE is required and must be enabled by adding `"mc2_comm_alg": "hierarchy"` to `--additional-config`.
-
-**Example**
-
-For the 1P1D (2+2) scenario, configure the logical SuperPod ID as follows:
-
-| Physical node | Configuration |
-|---------------|---------------|
-| Prefill node 0 | `export HCCL_LOGIC_SUPERPOD_ID=0` |
-| Prefill node 1 | `export HCCL_LOGIC_SUPERPOD_ID=1` |
-| Decode node 0 | `export HCCL_LOGIC_SUPERPOD_ID=2` |
-| Decode node 1 | `export HCCL_LOGIC_SUPERPOD_ID=3` |
-
-Apply the following Fused MC2 setting on every node:
-
-```shell
---additional-config '{..., "enable_fused_mc2": 0, "mc2_comm_alg": "hierarchy"}'
-```
-
-Merge `"mc2_comm_alg": "hierarchy"` into the existing `--additional-config` JSON object. The following pattern uses `...` to represent the existing fields:
-
-```text
---additional-config '{..., "mc2_comm_alg": "hierarchy"}'
-```
-
-#### 5.1.2 Atlas 800 A2
-
-##### 5.1.2.1 Multi-Node Co-Located Deployment
-
-- `GLM-5.2-w4a8c8`: can be deployed on 2 Atlas 800 A2 (64GB × 8). A single Atlas 800 A2 node (8 × 64GB) cannot fit the w4a8c8 weights, so the 2-node deployment is the minimum configuration for the A2 series.
-
-**node 0**
-
-```shell
-# this obtained through ifconfig
-# nic_name is the network interface name corresponding to local_ip of the current node
-nic_name="xxx"
-local_ip="xxx"
-
-# The value of node0_ip must be consistent with the value of local_ip set in node0 (master node)
-node0_ip="xxx"
-
-export HCCL_OP_EXPANSION_MODE="AIV"
-export HCCL_IF_IP=$local_ip
-export GLOO_SOCKET_IFNAME=$nic_name
-export TP_SOCKET_IFNAME=$nic_name
-export HCCL_SOCKET_IFNAME=$nic_name
-export VLLM_RPC_TIMEOUT=360000
-export VLLM_EXECUTE_MODEL_TIMEOUT_SECONDS=30000
-export HCCL_EXEC_TIMEOUT=200
-export HCCL_CONNECT_TIMEOUT=120
-export OMP_PROC_BIND=false
-export OMP_NUM_THREADS=10
-export PYTORCH_NPU_ALLOC_CONF=expandable_segments:True
-export ACL_OP_INIT_MODE=1
-export TASK_QUEUE_ENABLE=1
-export CPU_AFFINITY_CONF=1
-export VLLM_ENGINE_READY_TIMEOUT_S=1200
-
-vllm serve /root/.cache/modelscope/hub/models/vllm-ascend/GLM-5.2-w4a8c8 \
---max_model_len 40000 \
---max-num-batched-tokens 4096 \
---served-model-name glm-52 \
---seed 1024 \
---gpu-memory-utilization 0.95 \
---api-server-count 1 \
---max-num-seqs 16 \
---data-parallel-size 2 \
---data-parallel-size-local 1 \
---data-parallel-address $node0_ip \
---data-parallel-rpc-port 13389 \
---tensor-parallel-size 8 \
---enable-expert-parallel \
---quantization ascend \
---port 7000 \
---safetensors-load-strategy 'prefetch' \
---additional-config '{"multistream_overlap_shared_expert": true}' \
---compilation-config '{"cudagraph_mode": "FULL_DECODE_ONLY"}' \
---speculative-config '{"num_speculative_tokens": 5, "method": "deepseek_mtp", "enforce_eager": true}'
-```
-
-**node 1**
-
-```shell
-# this obtained through ifconfig
-# nic_name is the network interface name corresponding to local_ip of the current node
-nic_name="xxx"
-local_ip="xxx"
-
-# The value of node0_ip must be consistent with the value of local_ip set in node0 (master node)
-node0_ip="xxx"
-
-export HCCL_OP_EXPANSION_MODE="AIV"
-export HCCL_IF_IP=$local_ip
-export GLOO_SOCKET_IFNAME=$nic_name
-export TP_SOCKET_IFNAME=$nic_name
-export HCCL_SOCKET_IFNAME=$nic_name
-export VLLM_RPC_TIMEOUT=360000
-export VLLM_EXECUTE_MODEL_TIMEOUT_SECONDS=30000
-export HCCL_EXEC_TIMEOUT=200
-export HCCL_CONNECT_TIMEOUT=120
-export OMP_PROC_BIND=false
-export OMP_NUM_THREADS=10
-export PYTORCH_NPU_ALLOC_CONF=expandable_segments:True
-export ACL_OP_INIT_MODE=1
-export TASK_QUEUE_ENABLE=1
-export CPU_AFFINITY_CONF=1
-export VLLM_ENGINE_READY_TIMEOUT_S=1200
-
-vllm serve /root/.cache/modelscope/hub/models/vllm-ascend/GLM-5.2-w4a8c8 \
---max_model_len 40000 \
---max-num-batched-tokens 4096 \
---served-model-name glm-52 \
---seed 1024 \
---gpu-memory-utilization 0.95 \
---max-num-seqs 16 \
---headless \
---data-parallel-size 2 \
---data-parallel-size-local 1 \
---data-parallel-start-rank 1 \
---data-parallel-address $node0_ip \
---data-parallel-rpc-port 13389 \
---tensor-parallel-size 8 \
---enable-expert-parallel \
---quantization ascend \
---port 7000 \
---safetensors-load-strategy 'prefetch' \
---block-size 128 \
---additional-config '{"multistream_overlap_shared_expert": true}' \
---compilation-config '{"cudagraph_mode": "FULL_DECODE_ONLY"}' \
---speculative-config '{"num_speculative_tokens": 5, "method": "deepseek_mtp", "enforce_eager": true}'
-```
-
-Key Parameter Descriptions (in addition to [Single-Node Deployment](#5111-single-node-deployment) and [Multi-Node Co-Located Deployment](#5112-multi-node-co-located-deployment)):
-
-The A2 series uses a different optimization stack than A3; DSA-CP is not used here.
-
-**A2-specific environment variables:**
-
-- `CPU_AFFINITY_CONF=1`: Enables CPU core affinity binding for worker processes.
-- `ACL_OP_INIT_MODE=1`: ACL operator initialization mode to speed up operator compilation.
-- `VLLM_RPC_TIMEOUT=360000` / `VLLM_EXECUTE_MODEL_TIMEOUT_SECONDS=3000` / `HCCL_EXEC_TIMEOUT=200` / `HCCL_CONNECT_TIMEOUT=120` / `VLLM_ENGINE_READY_TIMEOUT_S=1200`: Timeout settings for multi-node startup and model execution on the slower A2 platform. Increase them if the engine fails to become ready in time.
-
-##### 5.1.2.2 Prefill-Decode Disaggregation
-
-On Atlas 800 A2, where each node exposes 8 cards, the same global P/D topology (Prefill `DP4 TP8`, Decode `DP8 TP4`) is split across 8 nodes: 4 prefill nodes hosting 1 DP rank each (8 cards per rank), and 4 decode nodes hosting 2 DP ranks each (4 cards per rank). The `launch_online_dp.py` above is reused as-is. The prefill side uses DSA CP; the decode side enables MLAPO and `DYNAMIC_EPLB` with a `FULL_DECODE_ONLY` graph. Both sides enable prefix caching and MTP (`num_speculative_tokens=1` on prefill, `3` on decode). All IPs, NIC names, ports and weight paths below are placeholders.
-
-Please refer to the [KV Cache Pool (Ascend Store) Deployment Guide](https://docs.vllm.ai/projects/ascend/zh-cn/latest/user_guide/feature_guide/kv_pool.html) for the KV Cache Pool startup method and the Mooncake configuration file.
-
-`run_dp_template.sh` for the prefill nodes:
-
-```bash
-#!/usr/bin/bash
-nic_name="<NIC_NAME>"
-local_ip="<CURRENT_NODE_IP>"
-
-export HCCL_IF_IP=$local_ip
-export GLOO_SOCKET_IFNAME=$nic_name
-export TP_SOCKET_IFNAME=$nic_name
-export HCCL_SOCKET_IFNAME=$nic_name
-export OMP_PROC_BIND=false
-export OMP_NUM_THREADS=10
-export PYTORCH_NPU_ALLOC_CONF=expandable_segments:True
-export HCCL_BUFFSIZE=256
-export TASK_QUEUE_ENABLE=1
-export HCCL_OP_EXPANSION_MODE="AIV"
-export VLLM_USE_V1=1
-export ASCEND_RT_VISIBLE_DEVICES=$1
-export LD_LIBRARY_PATH=/usr/local/python3.11.10/lib:/usr/local/lib:$LD_LIBRARY_PATH
-export ASCEND_AGGREGATE_ENABLE=1
-export ASCEND_TRANSPORT_PRINT=1
-export PYTHONHASHSEED=0
-export MOONCAKE_CONFIG_PATH="/mnt/share/scripts/mooncake.json"
-export HCCL_INTRA_ROCE_ENABLE=1
-export ACL_OP_INIT_MODE=1
-
-vllm serve /root/.cache/modelscope/hub/models/vllm-ascend/GLM-5.2-w4a8c8 \
-    --host 0.0.0.0 \
-    --port $2 \
-    --data-parallel-size $3 \
-    --data-parallel-rank $4 \
-    --data-parallel-address $5 \
-    --data-parallel-rpc-port $6 \
-    --tensor-parallel-size $7 \
-    --enable-expert-parallel \
-    --enable-prefix-caching \
-    --seed 1024 \
-    --enable-chunked-prefill \
-    --served-model-name glm-5 \
-    --max-model-len 256000 \
-    --max-num-batched-tokens 8192 \
-    --trust-remote-code \
-    --max-num-seqs 256 \
-    --gpu-memory-utilization 0.95 \
-    --safetensors-load-strategy prefetch \
-    --quantization ascend \
-    --enforce-eager \
-    --enable-auto-tool-choice \
-    --tool-call-parser glm47 \
-    --reasoning-parser glm45 \
-    --kv-transfer-config \
-    '{
-    "kv_connector": "MultiConnector",
-    "kv_role": "kv_producer",
-    "kv_load_failure_policy": "recompute",
-    "kv_connector_extra_config": {
-        "connectors": [
-            {
-                "kv_connector": "MooncakeConnectorV1",
-                "kv_role": "kv_producer",
-                "kv_port": "30000",
-                "kv_connector_extra_config": {
-                    "prefill": {
-                        "dp_size": 4,
-                        "tp_size": 8
-                    },
-                    "decode": {
-                        "dp_size": 8,
-                        "tp_size": 4
-                    }
-                }
-            },
-            {
-                "kv_connector": "AscendStoreConnector",
-                "kv_role": "kv_producer",
-                "kv_connector_extra_config": {
-                    "lookup_rpc_port":"0",
-                    "backend": "mooncake"
-                }
-            }
-        ]
-    }
-    }' \
-    --additional-config '{"enable_dsa_cp": true, "multistream_overlap_shared_expert": true, "enable_sparse_sfa_c8": true, "enable_sparse_li_c8": true}' \
-    --speculative-config '{"num_speculative_tokens": 1, "method":"deepseek_mtp", "enforce_eager":true}'
-```
-
-`run_dp_template.sh` for the decode nodes:
-
-```bash
-#!/usr/bin/bash
-
-nic_name="<NIC_NAME>"
-local_ip="<CURRENT_NODE_IP>"
-
-export HCCL_IF_IP=$local_ip
-export GLOO_SOCKET_IFNAME=$nic_name
-export TP_SOCKET_IFNAME=$nic_name
-export HCCL_SOCKET_IFNAME=$nic_name
-export VLLM_HOST_IP=$local_ip
-export HCCL_IF_IP=$local_ip
-export GLOO_SOCKET_IFNAME=$nic_name
-export TP_SOCKET_IFNAME=$nic_name
-export HCCL_SOCKET_IFNAME=$nic_name
-export OMP_PROC_BIND=false
-export OMP_NUM_THREADS=10
-export PYTORCH_NPU_ALLOC_CONF=expandable_segments:True
-export HCCL_BUFFSIZE=2560
-export TASK_QUEUE_ENABLE=1
-export HCCL_OP_EXPANSION_MODE="AIV"
-export VLLM_USE_V1=1
-export ASCEND_RT_VISIBLE_DEVICES=$1
-export LD_LIBRARY_PATH=/usr/local/python3.11.10/lib:/usr/local/lib:$LD_LIBRARY_PATH
-export PYTHONHASHSEED=0
-export MOONCAKE_CONFIG_PATH="/mnt/share/scripts/mooncake.json"
-export HCCL_INTRA_ROCE_ENABLE=1
-export ACL_OP_INIT_MODE=1
-
-vllm serve /root/.cache/modelscope/hub/models/vllm-ascend/GLM-5.2-w4a8c8 \
-    --host 0.0.0.0 \
-    --port $2 \
-    --data-parallel-size $3 \
-    --data-parallel-rank $4 \
-    --data-parallel-address $5 \
-    --data-parallel-rpc-port $6 \
-    --tensor-parallel-size $7 \
-    --enable-expert-parallel \
-    --enable-prefix-caching \
-    --seed 1024 \
-    --served-model-name glm-5 \
-    --max-model-len 256000 \
-    --max-num-batched-tokens 256 \
-    --trust-remote-code \
-    --max-num-seqs 128 \
-    --gpu-memory-utilization 0.95 \
-    --safetensors-load-strategy prefetch \
-    --quantization ascend \
-    --enable-auto-tool-choice \
-    --tool-call-parser glm47 \
-    --reasoning-parser glm45 \
-    --kv-transfer-config \
-    '{
-    "kv_connector": "MultiConnector",
-    "kv_role": "kv_consumer",
-    "kv_load_failure_policy": "recompute",
-    "kv_connector_extra_config": {
-        "connectors": [
-            {
-                "kv_connector": "MooncakeConnectorV1",
-                "kv_role": "kv_consumer",
-                "kv_port": "30100",
-                "kv_connector_extra_config": {
-                    "prefill": {
-                        "dp_size": 4,
-                        "tp_size": 8
-                    },
-                    "decode": {
-                        "dp_size": 8,
-                        "tp_size": 4
-                    }
-                }
-            },
-            {
-                "kv_connector": "AscendStoreConnector",
-                "kv_role": "kv_consumer",
-                "kv_connector_extra_config": {
-                    "lookup_rpc_port":"0",
-                    "load_async": true,
-                    "backend": "mooncake"
-                }
-            }
-        ]
-    }
-    }' \
-     --compilation-config \
-    '{
-        "cudagraph_mode": "FULL_DECODE_ONLY",
-    }' \
-    --additional-config '{"multistream_overlap_shared_expert": true, "enable_sparse_sfa_c8": true, "enable_sparse_li_c8": true, "recompute_scheduler_enable": true, "enable_mlapo": true}' \
-    --speculative-config '{"num_speculative_tokens": 3, "method":"deepseek_mtp", "enforce_eager":true}'
-```
-
-Once the preparation is done, start the server with the following commands:
-
-1. Prefill nodes — run on `$node_p0_ip`, `$node_p1_ip`, `$node_p2_ip`, `$node_p3_ip` with `--dp-rank-start` `0/1/2/3`:
-
-    ```shell
-    python launch_online_dp.py --dp-size 4 --tp-size 8 --dp-size-local 1 --dp-rank-start 0 --dp-address $node_p0_ip --dp-rpc-port 16591 --vllm-start-port 9081
-    python launch_online_dp.py --dp-size 4 --tp-size 8 --dp-size-local 1 --dp-rank-start 1 --dp-address $node_p0_ip --dp-rpc-port 16591 --vllm-start-port 9081
-    python launch_online_dp.py --dp-size 4 --tp-size 8 --dp-size-local 1 --dp-rank-start 2 --dp-address $node_p0_ip --dp-rpc-port 16591 --vllm-start-port 9081
-    python launch_online_dp.py --dp-size 4 --tp-size 8 --dp-size-local 1 --dp-rank-start 3 --dp-address $node_p0_ip --dp-rpc-port 16591 --vllm-start-port 9081
-    ```
-
-2. Decode nodes — run on `$node_d0_ip`, `$node_d1_ip`, `$node_d2_ip`, `$node_d3_ip` with `--dp-rank-start` `0/2/4/6`:
-
-    ```shell
-    python launch_online_dp.py --dp-size 8 --tp-size 4 --dp-size-local 2 --dp-rank-start 0 --dp-address $node_d0_ip --dp-rpc-port 16600 --vllm-start-port 9900
-    python launch_online_dp.py --dp-size 8 --tp-size 4 --dp-size-local 2 --dp-rank-start 2 --dp-address $node_d0_ip --dp-rpc-port 16600 --vllm-start-port 9900
-    python launch_online_dp.py --dp-size 8 --tp-size 4 --dp-size-local 2 --dp-rank-start 4 --dp-address $node_d0_ip --dp-rpc-port 16600 --vllm-start-port 9900
-    python launch_online_dp.py --dp-size 8 --tp-size 4 --dp-size-local 2 --dp-rank-start 6 --dp-address $node_d0_ip --dp-rpc-port 16600 --vllm-start-port 9900
-    ```
-
-For request forwarding on this 8-node A2 layout, use 4 prefiller hosts (1 endpoint each) and 4 decoder hosts (2 endpoints each) in the Request Forwarding command below.
-
-To set up request forwarding, run the following script on any machine. You can get the proxy program in the repository's examples: [load_balance_proxy_server_example.py](https://github.com/vllm-project/vllm-ascend/blob/main/examples/disaggregated_prefill_v1/load_balance_proxy_server_example.py)
-
-```shell
-unset http_proxy
-unset https_proxy
-
-python load_balance_proxy_server_example.py \
-    --port 8000 \
-    --host 0.0.0.0 \
-    --prefiller-hosts \
-      $node_p0_ip \
-      $node_p1_ip \
-      $node_p2_ip \
-      $node_p3_ip \
-    --prefiller-ports \
-      9081 9081 \
-      9081 9081 \
-    --decoder-hosts \
-      $node_d0_ip \
-      $node_d0_ip \
-      $node_d1_ip \
-      $node_d1_ip \
-      $node_d2_ip \
-      $node_d2_ip \
-      $node_d3_ip \
-      $node_d3_ip \
-    --decoder-ports \
-      9900 9901 9900 9901 \
-      9900 9901 9900 9901
-```
-
-Key Parameter Descriptions (in addition to [Prefill-Decode Disaggregation](#5113-prefill-decode-disaggregation)):
-
-This 8-node A2 layout splits the global P/D topology across 8 Atlas 800 A2 nodes: 4 prefill nodes hosting 1 DP rank each (8 cards per rank, `DP4 TP8`) and 4 decode nodes hosting 2 DP ranks each (4 cards per rank, `DP8 TP4`). The `launch_online_dp.py` script is the same as in [Prefill-Decode Disaggregation](#5113-prefill-decode-disaggregation).
-
-**Prefill node-specific configurations (A2):**
-
-- `--additional-config '{"enable_sparse_sfa_c8": true, "enable_sparse_li_c8": true, ...}'`: Both SFA C8 optimizations are enabled in this scenario (vs. `enable_sparse_sfa_c8: false` in the A3 co-located scenarios).
-
-**Decode node-specific configurations (A2):**
-
-- `additional_config.enable_mlapo=true`: MLAPO fusion on decode nodes for memory-bandwidth-bound token generation.
-- `--max-num-batched-tokens 256`: Small batch token limit on decode nodes.
-
-**Multi-connector KV transfer configuration (`--kv-transfer-config`):**
-
-- `"kv_connector": "MultiConnector"`: Combines multiple KV transfer connectors.
-- `MooncakeConnectorV1`: Mooncake KV cache transfer between prefill and decode nodes (same role as in [Prefill-Decode Disaggregation](#5113-prefill-decode-disaggregation)).
-- `AscendStoreConnector`: The KV Cache Pool (Ascend Store) connector, available since v0.23.0 — see the [KV Cache Pool (Ascend Store) Deployment Guide](https://docs.vllm.ai/projects/ascend/zh-cn/latest/user_guide/feature_guide/kv_pool.html).
-- `"kv_load_failure_policy": "recompute"`: When a KV block fails to load from the KV pool, the request falls back to recomputation instead of failing.
-- `"load_async": true` (decode side): Asynchronously loads KV cache from the pool on decode nodes.
-- `"backend": "mooncake"`: The Ascend Store backend used by the connector.
-
-**Environment variables for the A2 PD scenario:**
-
-- `VLLM_USE_V1=1`: Forces the v1 scheduler.
-- `ASCEND_AGGREGATE_ENABLE=1` / `ASCEND_TRANSPORT_PRINT=1`: Communication aggregation and transport debug printing.
-- `PYTHONHASHSEED=0`: Fixed hash seed for reproducible distributed scheduling.
-- `MOONCAKE_CONFIG_PATH="/mnt/share/scripts/mooncake.json"`: Path to the Mooncake configuration file (must exist on each node).
-- `HCCL_INTRA_ROCE_ENABLE=1`: Enables HCCL intra-node communication over RoCE.
-- `ACL_OP_INIT_MODE=1`: ACL operator initialization mode.
-- `VLLM_HOST_IP=$local_ip`: Host IP advertised by the decode engine for cross-node communication.
-
-Please refer to [envs.py](https://github.com/vllm-project/vllm-ascend/blob/main/vllm_ascend/envs.py) for further explanation and restrictions of the environment variables above.
-
-### 5.2 1M Context Deployment
-
-Recommended configurations for serving `GLM-5.2` with a 1M context window on Atlas 800 A3 (64GB x 16) and quantized GLM-5.2(W4A8C8) weights:
-
-| Mode | Hardware | Parallelism | Context |
-| ---- | -------- | ----------- | ------- |
-| Single-node co-located | 1 Atlas 800 A3 (64GB x 16) | `DP1 PP1 TP16 PCP1 DCP16` | `1024000` |
-| Dual-node co-located | 2 Atlas 800 A3 (64GB x 16) | `DP4 PP1 TP8 PCP1 DCP8` | `1024000` |
-| 1P1D PD disaggregation | 1 prefiller with 2 A3 nodes + 1 decoder with 2 A3 nodes | Prefill `DP4 PP1 TP8 PCP1 DCP8`, Decode `DP4 PP1 TP8 PCP1 DCP8` | `1024000` |
-
-The 1M context scenarios are validated on Atlas 800 A3 only; the A2 series is not validated for 1M context.
-
-!!! warning
-    DCP and Sparse Flash Attention C8 (`enable_sparse_sfa_c8`, also referred to as `sfa_c8`) are experimental features in v0.23.0. Enabling them together has known issues in this release, including performance degradation, and is not recommended. The following 1M deployment examples enable DCP and leave `enable_sparse_sfa_c8` disabled.
-
-#### 5.2.1 Single-Node 1M Deployment
-
-Recommended command:
-
-```shell
-export HCCL_OP_EXPANSION_MODE="AIV"
-export OMP_PROC_BIND=false
-export OMP_NUM_THREADS=20
-export HCCL_BUFFSIZE=768
-export HCCL_TRANSFER_TIMEOUT=600
-export HCCL_EXEC_TIMEOUT=3600
-export HCCL_CONNECT_TIMEOUT=3600
-export PYTORCH_NPU_ALLOC_CONF=expandable_segments:True
-export VLLM_WORKER_MULTIPROC_METHOD=spawn
-export TASK_QUEUE_ENABLE=1
-
-vllm serve <MODEL_PATH> \
-  --seed 1024 \
-  --host 0.0.0.0 \
-  --port 9000 \
-  --served-model-name glm-52 \
-  --max-model-len 1024000 \
-  --max-num-batched-tokens 16384 \
-  --gpu-memory-utilization 0.80 \
-  --api-server-count 1 \
-  --max-num-seqs 32 \
-  --data-parallel-size 1 \
-  --pipeline-parallel-size 1 \
-  --tensor-parallel-size 16 \
-  --prefill-context-parallel-size 1 \
-  --decode-context-parallel-size 16 \
-  --cp-kv-cache-interleave-size 128 \
-  --compilation-config '{"cudagraph_mode": "FULL_DECODE_ONLY", "cudagraph_capture_sizes": [4, 16, 128]}' \
-  --additional-config '{"enable_dsa_cp": true, "ascend_compilation_config": {"enable_npugraph_ex": true}, "multistream_overlap_shared_expert": true, "enable_sparse_li_c8": true, "enable_cpu_binding": true,"weight_nz_mode":1}' \
-  --speculative-config '{"num_speculative_tokens": 3, "method": "deepseek_mtp", "enforce_eager": true}' \
-  --quantization ascend \
-  --enable-expert-parallel \
-  --safetensors-load-strategy prefetch
-```
-
-Key Parameter Descriptions (in addition to [Single-Node Deployment](#5111-single-node-deployment)):
-
-**1M-specific environment variables:**
-
-- `additional_config.weight_nz_mode=1`: Enables NZ format memory layout for the C8 quantized tensors, required for the 1M context deployment.
-- `VLLM_WORKER_MULTIPROC_METHOD=spawn`: Uses the spawn start method for multi-process workers (required in this scenario).
-
-**1M-specific vllm serve parameters:**
-
-- `--data-parallel-size 1` / `--pipeline-parallel-size 1` / `--tensor-parallel-size 16`: Single-node parallelism layout `DP1 PP1 TP16`.
-- `--prefill-context-parallel-size 1` / `--decode-context-parallel-size 16`: Decode context parallelism (DCP) of 16 for the decode phase; prefill uses PCP 1.
-- `--cp-kv-cache-interleave-size 128`: KV cache interleave size for context parallelism.
-
-#### 5.2.2 Dual-Node Co-Located 1M Deployment
-
-Recommended command for both co-located nodes:
-
-```shell
-nic_name="<NIC_NAME>"
-local_ip="<CURRENT_NODE_IP>"
-node_0_ip="<NODE0_IP>"
-# Node 0: data_parallel_start_rank=0, server_role_args="--api-server-count 1"
-# Node 1: data_parallel_start_rank=2, server_role_args="--headless"
-data_parallel_start_rank=0
-server_role_args="--api-server-count 1"
-
-export HCCL_IF_IP=$local_ip
-export GLOO_SOCKET_IFNAME=$nic_name
-export TP_SOCKET_IFNAME=$nic_name
-export HCCL_SOCKET_IFNAME=$nic_name
-export HCCL_OP_EXPANSION_MODE="AIV"
-export OMP_PROC_BIND=false
-export OMP_NUM_THREADS=20
-export HCCL_BUFFSIZE=768
-export HCCL_TRANSFER_TIMEOUT=600
-export HCCL_EXEC_TIMEOUT=3600
-export HCCL_CONNECT_TIMEOUT=3600
-export PYTORCH_NPU_ALLOC_CONF=expandable_segments:True
-export VLLM_WORKER_MULTIPROC_METHOD=spawn
-export TASK_QUEUE_ENABLE=1
-
-vllm serve <MODEL_PATH> \
-  --seed 1024 \
-  --host 0.0.0.0 \
-  --port 9000 \
-  --served-model-name glm-52 \
-  --max-model-len 1024000 \
-  --max-num-batched-tokens 16384 \
-  --gpu-memory-utilization 0.75 \
-  ${server_role_args} \
-  --max-num-seqs 8 \
-  --data-parallel-size 4 \
-  --data-parallel-size-local 2 \
-  --data-parallel-start-rank $data_parallel_start_rank \
-  --data-parallel-address $node_0_ip \
-  --data-parallel-rpc-port 16591 \
-  --pipeline-parallel-size 1 \
-  --tensor-parallel-size 8 \
-  --prefill-context-parallel-size 1 \
-  --decode-context-parallel-size 8 \
-  --cp-kv-cache-interleave-size 128 \
-  --compilation-config '{"cudagraph_mode": "FULL_DECODE_ONLY"}' \
-  --additional-config '{"enable_dsa_cp": true, "ascend_compilation_config": {"enable_npugraph_ex": true}, "multistream_overlap_shared_expert": true,"enable_sparse_li_c8": true, "enable_cpu_binding": true,"weight_nz_mode":1}' \
-  --speculative-config '{"num_speculative_tokens": 3, "method": "deepseek_mtp", "enforce_eager": true}' \
-  --quantization ascend \
-  --enable-expert-parallel \
-  --safetensors-load-strategy prefetch
-```
-
-Key Parameter Descriptions (in addition to [Single-Node 1M Deployment](#521-single-node-1m-deployment)):
-
-**Multi-node configuration:**
-
-- `--data-parallel-size 4` / `--data-parallel-size-local 2` / `--data-parallel-start-rank`: Node 0 uses `data_parallel_start_rank=0` with `server_role_args="--api-server-count 1"`; node 1 uses `data_parallel_start_rank=2` with `server_role_args="--headless"`.
-- `--data-parallel-address $node_0_ip` / `--data-parallel-rpc-port 16591`: Data parallel master node IP and RPC port, identical on both nodes.
-- `--tensor-parallel-size 8` / `--decode-context-parallel-size 8`: `DP4 TP8 DCP8` layout — each node hosts 2 DP ranks × TP8.
-
-#### 5.2.3 PD Disaggregation 1M Deployment
-
-Recommended command for both prefiller nodes:
-
-```shell
-nic_name="<NIC_NAME>"
-local_ip="<CURRENT_PREFILL_NODE_IP>"
-node_p0_ip="<PREFILL_NODE0_IP>"
-# Prefiller node 0: data_parallel_start_rank=0, server_role_args="--api-server-count 1"
-# Prefiller node 1: data_parallel_start_rank=2, server_role_args="--headless"
-data_parallel_start_rank=0
-server_role_args="--api-server-count 1"
-
-export HCCL_IF_IP=$local_ip
-export GLOO_SOCKET_IFNAME=$nic_name
-export TP_SOCKET_IFNAME=$nic_name
-export HCCL_SOCKET_IFNAME=$nic_name
-
-export HCCL_OP_EXPANSION_MODE="AIV"
-export OMP_PROC_BIND=false
-export OMP_NUM_THREADS=20
-export HCCL_BUFFSIZE=768
-export HCCL_TRANSFER_TIMEOUT=600
-export HCCL_EXEC_TIMEOUT=3600
-export HCCL_CONNECT_TIMEOUT=3600
-export PYTORCH_NPU_ALLOC_CONF=expandable_segments:True
-export VLLM_WORKER_MULTIPROC_METHOD=spawn
-export TASK_QUEUE_ENABLE=1
-export VLLM_MOONCAKE_ABORT_REQUEST_TIMEOUT=480
-
-vllm serve <MODEL_PATH> \
-  --seed 1024 \
-  --host 0.0.0.0 \
-  --port 9081 \
-  --served-model-name glm-52 \
-  --max-model-len 1024000 \
-  --max-num-batched-tokens 16384 \
-  --gpu-memory-utilization 0.75 \
-  ${server_role_args} \
-  --max-num-seqs 8 \
-  --data-parallel-size 4 \
-  --data-parallel-size-local 2 \
-  --data-parallel-start-rank $data_parallel_start_rank \
-  --data-parallel-address $node_p0_ip \
-  --data-parallel-rpc-port 16591 \
-  --pipeline-parallel-size 1 \
-  --tensor-parallel-size 8 \
-  --prefill-context-parallel-size 1 \
-  --decode-context-parallel-size 8 \
-  --cp-kv-cache-interleave-size 128 \
-  --enforce-eager \
-  --additional-config '{"enable_dsa_cp": true, "ascend_compilation_config": {"enable_npugraph_ex": true}, "multistream_overlap_shared_expert": true,"enable_sparse_li_c8": true, "enable_cpu_binding": true, "recompute_scheduler_enable": true,"weight_nz_mode":1}' \
-  --speculative-config '{"num_speculative_tokens": 1, "method": "deepseek_mtp", "enforce_eager": true}' \
-  --quantization ascend \
-  --enable-expert-parallel \
-  --safetensors-load-strategy prefetch \
-  --kv-transfer-config \
-  '{"kv_connector": "MooncakeConnectorV1",
-    "kv_role": "kv_producer",
-    "kv_port": "30000",
-    "engine_id": "0",
-    "kv_connector_extra_config": {
-      "use_ascend_direct": true,
-      "prefill": {
-        "dp_size": 4,
-        "tp_size": 8
-      },
-      "decode": {
-        "dp_size": 4,
-        "tp_size": 8
-      }
-    }
-  }'
-```
-
-Recommended command for both decoder nodes:
-
-```shell
-nic_name="<NIC_NAME>"
-local_ip="<CURRENT_DECODE_NODE_IP>"
-node_d0_ip="<DECODE_NODE0_IP>"
-# Decoder node 0: data_parallel_start_rank=0, server_role_args="--api-server-count 1"
-# Decoder node 1: data_parallel_start_rank=2, server_role_args="--headless"
-data_parallel_start_rank=0
-server_role_args="--api-server-count 1"
-
-export HCCL_IF_IP=$local_ip
-export GLOO_SOCKET_IFNAME=$nic_name
-export TP_SOCKET_IFNAME=$nic_name
-export HCCL_SOCKET_IFNAME=$nic_name
-export HCCL_OP_EXPANSION_MODE="AIV"
-export OMP_PROC_BIND=false
-export OMP_NUM_THREADS=20
-export HCCL_BUFFSIZE=768
-export HCCL_TRANSFER_TIMEOUT=600
-export HCCL_EXEC_TIMEOUT=3600
-export HCCL_CONNECT_TIMEOUT=3600
-export PYTORCH_NPU_ALLOC_CONF=expandable_segments:True
-export VLLM_WORKER_MULTIPROC_METHOD=spawn
-export TASK_QUEUE_ENABLE=1
-export VLLM_MOONCAKE_ABORT_REQUEST_TIMEOUT=480
-
-vllm serve <MODEL_PATH> \
-  --seed 1024 \
-  --host 0.0.0.0 \
-  --port 9900 \
-  --served-model-name glm-52 \
-  --max-model-len 1024000 \
-  --max-num-batched-tokens 128 \
-  --gpu-memory-utilization 0.93 \
-  ${server_role_args} \
-  --max-num-seqs 32 \
-  --data-parallel-size 4 \
-  --data-parallel-size-local 2 \
-  --data-parallel-start-rank $data_parallel_start_rank \
-  --data-parallel-address $node_d0_ip \
-  --data-parallel-rpc-port 16600 \
-  --pipeline-parallel-size 1 \
-  --tensor-parallel-size 8 \
-  --prefill-context-parallel-size 1 \
-  --decode-context-parallel-size 8 \
-  --cp-kv-cache-interleave-size 128 \
-  --compilation-config '{"cudagraph_mode": "FULL_DECODE_ONLY"}' \
-  --additional-config '{"ascend_compilation_config": {"enable_npugraph_ex": true},"multistream_overlap_shared_expert": true,"enable_sparse_li_c8": true, "enable_cpu_binding": true, "recompute_scheduler_enable": true,"weight_nz_mode":1}' \
-  --speculative-config '{"num_speculative_tokens": 3, "method": "deepseek_mtp", "enforce_eager": true}' \
-  --quantization ascend \
-  --enable-expert-parallel \
-  --safetensors-load-strategy prefetch \
-  --kv-transfer-config \
-  '{"kv_connector": "MooncakeConnectorV1",
-    "kv_role": "kv_consumer",
-    "kv_port": "30100",
-    "engine_id": "1",
-    "kv_connector_extra_config": {
-      "use_ascend_direct": true,
-      "prefill": {
-        "dp_size": 4,
-        "tp_size": 8
-      },
-      "decode": {
-        "dp_size": 4,
-        "tp_size": 8
-      }
-    }
-  }'
-```
-
-Recommended proxy command:
-
-```shell
-unset http_proxy
-unset https_proxy
-
-python load_balance_proxy_server_example.py \
-  --host 0.0.0.0 \
-  --port 8000 \
-  --prefiller-hosts <PREFILL_NODE0_IP> \
-  --prefiller-ports 9081 \
-  --decoder-hosts <DECODE_NODE0_IP> \
-  --decoder-ports 9900
-```
-
-Key Parameter Descriptions (in addition to [Prefill-Decode Disaggregation](#5113-prefill-decode-disaggregation) and [Single-Node 1M Deployment](#521-single-node-1m-deployment)):
+- `VLLM_EXECUTE_MODEL_TIMEOUT_SECONDS=30000` / `MF_GROUP_JOIN_MAX_TIMEOUT=1200`: Timeout settings for the slow multi-node startup and model execution of the 1M context scenario. Increase them if the engine fails to become ready in time.
 
 **Prefill nodes (1M):**
 
-- `--additional-config '{"recompute_scheduler_enable": true, ...}'`: The recompute scheduler is enabled on both prefill and decode nodes in this scenario.
-- `--kv-transfer-config`: Mooncake connector as `kv_producer` with `prefill: dp4 tp8` / `decode: dp4 tp8` (matching the 1M P/D topology, in contrast to `dp32 tp1` decode in the sub-1M PD scenario).
+- `--speculative-config '{"num_speculative_tokens": 1, ...}'`: Minimal MTP speculation during prefill.
+- `mega_moe_max_tokens=8192`: Per-rank token capacity after dispatch in the fused MC2/MegaMoe path.
+- `--kv-transfer-config`: Mooncake connector as `kv_producer` with `prefill: dp2 tp16` / `decode: dp4 tp8`.
 
 **Decode nodes (1M):**
 
-- `--max-num-batched-tokens 128`: Decode nodes store the large 1M KV cache received from prefill nodes.
-- `--kv-transfer-config`: Mooncake connector as `kv_consumer` (`kv_port: 30100`).
+- `--max-num-batched-tokens 192`: Small batch token limit on decode nodes — decode nodes store the large 1M KV cache received from prefill nodes.
+- `enable_mlapo`: MLAPO fusion on decode nodes for memory-bandwidth-bound token generation.
+- `--kv-transfer-config`: Mooncake connector as `kv_consumer` (`kv_port: 30200`).
+
+Please refer to [envs.py](https://github.com/vllm-project/vllm-ascend/blob/main/vllm_ascend/envs.py) for further explanation and restrictions of the environment variables above.
 
 ## 6 Functional Verification
 
@@ -1579,19 +1515,55 @@ curl http://<node0_ip>:<port>/v1/completions \
     }'
 ```
 
+Expected Result:
+
+The service returns HTTP 200 OK. The JSON response contains the `choices` field with the generated text, along with usage statistics:
+
+```json
+{
+    "id": "chatcmpl-90e6de0720743e72",
+    "object": "text_completion",
+    "created": 1784891079,
+    "model": "glm-52",
+    "choices": [
+        {
+            "index": 0,
+            "text": "here,and it's not just about chatbots. It's about AI agents",
+            "logprobs":null,
+            "finish_reason”:"length",
+            "stop_reason":null,
+            "token_ids":null,
+            "prompt_logprobs":null,
+            "prompt_token_ids":null,
+            "routed_experts":null
+        }
+    ],
+    "service_tier":null,
+    "system fingerprint":"vllm-0.26.0-tp16-ep-2a76151d",
+    "usage":{
+        "prompt tokens :5,
+        "total tokens :21,
+        "completion tokens":16,
+        "prompt tokens details :null
+        },
+        "ky transfer params":null
+    }
+}
+```
+
 ## 7 Accuracy Evaluation
 
-Here are two accuracy evaluation methods.
-
-### 7.1 Using AISBench
+### Using AISBench
 
 1. Refer to [Using AISBench](../../developer_guide/evaluation/using_ais_bench.md) for details.
 
 2. After execution, you can get the result.
 
-### 7.2 Using Language Model Evaluation Harness
-
-Not tested yet.
+| dataset | version | metric | mode | vllm-api-general-chat | note |
+| ----- | ----- | ----- | ----- | ----- | ----- |
+| AIME2026 | - | accuracy | gen | 93.33 | 4 Atlas 800 A3 (64GB × 16) |
+| GPQA | - | accuracy | gen | 90.4 | 8 Atlas 800 A3 (64GB × 16) |
+| GPQA | - | accuracy | gen | 91.92 | 8 Atlas 800 A2 (64GB × 8) |
 
 ## 8 Performance Evaluation
 
@@ -1603,67 +1575,40 @@ Refer to [Using AISBench for performance evaluation](../../developer_guide/evalu
 
 Refer to [vllm benchmark](https://docs.vllm.ai/en/latest/benchmarking/) for more details.
 
-## 9 Performance Tuning
-
-### 9.1 Recommended Configurations
-
-> **Note**: The following configurations are validated in specific test environments and are for reference only. The optimal configuration depends on factors such as maximum input/output length, prefix cache hit rate, precision requirements, and deployment machine ratios. It is recommended to refer to [Tuning Guidelines](#92-tuning-guidelines) for tuning based on actual conditions.
-
-The tables below provide recommended parameter configurations for different deployment scenarios. All scenarios are categorized by use case (Low Latency, High Throughput, Long Context) and correspond to the deployment modes documented in [Deployment](#5-deployment).
-
-#### 9.1.1 Table 1: Scenario Overview
-
-> `*Total NPUs` indicates the total number of NPUs used across all nodes. 1 node = 1 Atlas 800 A3 server (64GB × 16 NPUs) or 1 Atlas 800 A2 server (64GB × 8 NPUs).
-
-|Scenario|Deployment Mode|*Total NPUs|Weight Version|Key Considerations|
-|--------|---------------|-----------|--------------|------------------|
-|Low Latency<br>(64k input)|Dual-Node Co-Located (A3), [Multi-Node Co-Located Deployment](#5112-multi-node-co-located-deployment)|32 (A3)|w4a8c8|dp2 tp16, MTP3, max-num-seqs 8, max-model-len 135000, DSA CP|
-|Low Latency<br>(128k input)|Dual-Node Co-Located (A3), [Multi-Node Co-Located Deployment](#5112-multi-node-co-located-deployment)|32 (A3)|w4a8c8|dp2 tp16, MTP3, max-num-seqs 8, max-model-len 135000, DSA CP|
-|High Throughput<br>(64k input)|Dual-Node Co-Located (A3), [Multi-Node Co-Located Deployment](#5112-multi-node-co-located-deployment)|32 (A3)|w4a8c8|dp4 tp8, fused MC2, MTP3, max-num-seqs 16, max-model-len 66000, DSA CP|
-|High Throughput|PD Disaggregation (A3), [Prefill-Decode Disaggregation](#5113-prefill-decode-disaggregation)|4 nodes (A3)|w4a8c8|P: dp4 tp8 (max-num-seqs 64, max-num-batched-tokens 8192, MTP1); D: dp32 tp1 (max-num-seqs 32, max-num-batched-tokens 164, MTP5), max-model-len 133120, dedicated P/D nodes, Mooncake KV transfer|
-|Long Context<br>(1M)|PD Disaggregation (A3), [PD Disaggregation 1M Deployment](#523-pd-disaggregation-1m-deployment)|4 nodes (A3)|w4a8c8|P/D: dp4 tp8, DCP8, max-model-len 1040000, Mooncake KV transfer|
-
-#### 9.1.2 Table 2: Detailed Node Configuration
-
-> The TP/DP columns show the values **per node** as configured in the Deployment scripts (a node hosting 2 DP ranks of TP8, or 1 DP rank of TP16, uses 16 NPUs).
-
 **Notice:**
 `max-model-len` and `max-num-seqs` need to be set according to the actual usage scenario. For other settings, please refer to the **[Deployment](#5-deployment)** chapter.
 
-|Scenario|Configuration|NPUs (per node)|TP|DP (per node)|Max Num Seqs|Max Num Batched Tokens|Max Model Len|MTP Spec Num|
-|--------|-------------|-----|--|--|------------|----------------------|--------------|-------------|
-|Low Latency 64k (A3)|Dual-Node (per node), [Multi-Node Co-Located Deployment](#5112-multi-node-co-located-deployment)|16|16|1|8|8192|135000|3|
-|Low Latency 128k (A3)|Dual-Node (per node), [Multi-Node Co-Located Deployment](#5112-multi-node-co-located-deployment)|16|16|1|8|8192|135000|3|
-|High Throughput 64k (A3)|Dual-Node (per node), [Multi-Node Co-Located Deployment](#5112-multi-node-co-located-deployment)|16|8|2|16|8192|66000|3|
-|High Throughput (A3)|PD — Server-P Node, [Prefill-Decode Disaggregation](#5113-prefill-decode-disaggregation)|16|8|2|64|8192|133120|1|
-|High Throughput (A3)|PD — Server-D Node, [Prefill-Decode Disaggregation](#5113-prefill-decode-disaggregation)|16|1|16|32|164|133120|5|
-|Long Context 1M (A3)|PD — Server-P Node, [PD Disaggregation 1M Deployment](#523-pd-disaggregation-1m-deployment)|16|8|2|8|16384|1040000|1|
-|Long Context 1M (A3)|PD — Server-D Node, [PD Disaggregation 1M Deployment](#523-pd-disaggregation-1m-deployment)|16|8|2|32|128|1040000|3|
+## 9 Performance Tuning
 
-> On PD decode nodes, `--max-num-batched-tokens` is configured as `(MTP Spec Num + 1) × Max Num Seqs` — each sequence generates one target token plus the speculated MTP tokens per decode step.
->
-> For complete startup commands and detailed parameter descriptions, please refer to the deployment examples and Key Parameter Descriptions in [Deployment](#5-deployment).
+### 9.1 Tested Performance Cases
 
-#### 9.1.3 Table 3: Performance-Related Parameter Tuning Guide
+#### Table 1: Prefill-Only Test Cases
 
-|Parameter|Low Latency|High Throughput|Long Context|Description|
-|---------|-----------|---------------|-------------|-----------|
-|`--max-num-batched-tokens`|Lower (4096–8192)|Higher for prefill (8192)|Higher for prefill (16384)|Controls batch size per step. Lower values reduce per-step latency; higher values improve prefill throughput.|
-|`--gpu-memory-utilization`|0.92–0.95|0.90–0.95|0.75–0.93|NPU memory fraction. 1M scenarios must reserve memory for the huge KV cache, so use lower values (0.75–0.80 on prefill/co-located).|
-|`num_speculative_tokens` (MTP)|3–5|3–5|1 (prefill) / 3 (decode)|MTP speculation count. Higher values improve decode throughput at the cost of memory for the draft model KV cache. Use `1` on prefill nodes in PD mode.|
-|`enable_dsa_cp`|Optional|Enable (prefill nodes)|Enable (prefill nodes)|DSA context parallelism accelerates long-context prefill.|
-|`enable_sparse_sfa_c8` / `enable_sparse_li_c8`|`false` / `true`|`true` / `true` (PD)|`false` / `true`|`enable_sparse_sfa_c8` is an experimental SFA optimization for the C8 quantized model; do not combine it with DCP in v0.23.0 because of known issues. `enable_sparse_li_c8` is independent and remains recommended.|
-|`enable_balance_scheduling`|Enable (single-node)|Enable|Disable in PD mode|Improves output throughput and reduces TPOT in the v1 scheduler. TTFT may degrade in some scenarios; not recommended when Prefill-Decode is separated.|
-|`additional_config.enable_mlapo`|—|1 (A2 P/D nodes)|—|Fusion operator that significantly improves performance but consumes more NPU memory. On A3 used on decode nodes only.|
-|`cudagraph_mode`|FULL_DECODE_ONLY|FULL_DECODE_ONLY (decode)|FULL_DECODE_ONLY (decode)|Graph capture for the decode phase only. Prefill nodes in PD mode use `--enforce-eager` instead.|
+|Scenario|Configuration|NPUs|TP|DP|PP|Max Model Len|MTP Speculation Num|
+|--------|-------------|-----|--|--|--|-------------------|--------------------|
+|Decode-only|Server-P Node|32 (A3)|16|1|2|198k|1|
+|Decode-only|Server-D Node|32 (A3)|16|2|1|198k|5|
+|Prefill-only|Server-P Node|32 (A3)|16|1|2|198k|1|
+|Prefill-only|Server-D Node|32 (A3)|16|2|1|198k|5|
+|high concurrency|Server-P Node|32 (A3)|16|1|2|198k|1|
+|high concurrency|Server-D Node|32 (A3)|16|2|1|198k|5|
+|high concurrency(1M)|Server-P Node|32 (A3)|2|16|-|198k|1|
+|high concurrency(1M)|Server-D Node|32 (A3)|4|8|-|198k|5|
 
-### 9.2 Tuning Guidelines
+### 9.2 Recommended Configurations
 
-For general performance tuning methods, refer to the [Public Performance Tuning Documentation](../../developer_guide/performance_and_debug/optimization_and_tuning.md).
+#### Table 2: Optimizations Requiring Explicit Enablement
 
-For detailed feature descriptions and configuration options, refer to the [Feature Matrix](../../user_guide/support_matrix/feature_matrix.md).
-
-For environment variable descriptions and constraints, refer to [envs.py](https://github.com/vllm-project/vllm-ascend/blob/main/vllm_ascend/envs.py).
+|Optimization|Scenario|Enablement|Principle (Benefits)|Notes|
+|------------|--------|----------|---------------------|-----|
+|FlashComm_v1|A3 prefill nodes / co-located nodes|`--additional-config '{"enable_flashcomm1": true}'`|Splits AllReduce into Reduce-Scatter and All-Gather, improving prefill throughput and reducing communication latency|Not available when `layer_sharding` includes `o_proj`|
+|Fused MC2|A3 prefill nodes|`--additional-config '{"enable_fused_mc2": 1}'`|Replaces ALLTOALL+MC2 with the `dispatch_ffn_combine`/`dispatch_gmm_combine_decode` operators, reducing MoE communication overhead and improving MoE inference performance|`dispatch_ffn_combine` only for w8a8, EP≤32, non-MTP, non-dynamic-EPLB; conflicts with `multistream_overlap_shared_expert` (the latter is auto-disabled)|
+|MLAPO|A3 co-located / PD decode nodes; A2 P/D nodes|`--additional-config '{"enable_mlapo": true}'`|Fuses the MLA preprocess operations, significantly improving decode performance|Consumes more NPU memory; in PD scenarios enable on decode nodes only|
+|DSA CP|A3 prefill nodes; long context|`--additional-config '{"enable_dsa_cp": true}'`|DSA context parallelism accelerates long-context prefill, reducing TTFT for long prompts|In the reference configs, enabled on co-located nodes and PD prefill nodes; PD decode nodes use decode context parallelism instead|
+|Sparse SFA C8|A3 (w8a8c8); long-context prefill|`--additional-config '{"enable_sparse_sfa_c8": true}'`|Sparse Flash Attention skips unnecessary attention computation of the C8 quantized model, accelerating long-context prefill|Experimental in v0.23.0. On the w8a8c8 weights it can be combined with DCP/context parallelism (as in the reference configs in this document); on the w4a8c8 weights enabling both together has known issues and is not recommended|
+|Sparse LI C8|A3 (w8a8c8)|`--additional-config '{"enable_sparse_li_c8": true}'`|Sparse attention optimization reduces computation of the C8 quantized model, improving throughput|Independent of `enable_sparse_sfa_c8`|
+|Recompute Scheduler|A3 decode nodes|`--additional-config '{"recompute_scheduler_enable": true}'`|Recomputes KV cache on prefill nodes when decode KV cache is insufficient, avoiding decode-side OOM and improving throughput|Set to `false` on prefill nodes|
+|Multistream Overlap Shared Expert|A3|`--additional-config '{"multistream_overlap_shared_expert": true}'`|Overlaps shared-expert computation on an additional stream, hiding its latency and improving decode performance|Auto-disabled when `enable_fused_mc2=1`|
 
 ## 10 FAQ
 

--- a/docs/source/tutorials/models/GLM5.2.md
+++ b/docs/source/tutorials/models/GLM5.2.md
@@ -16,7 +16,7 @@ Refer to [Feature Guide](../../user_guide/feature_guide/index.md) to get the fea
 
 - `GLM-5.2`(BF16 version): requires 2 Atlas 800 A3 (128GB × 8) node or 4 Atlas 800 A2 (64GB × 8) node.[Download model weight](https://www.modelscope.cn/models/ZhipuAI/GLM-5.2).
 - `GLM-5.2-w8a8`: requires 1 Atlas 800 A3 (128GB × 8) node or 2 Atlas 800 A2 (64GB × 8) node.[Download model weight](https://www.modelscope.cn/models/Eco-Tech/GLM-5.2-w8a8).
-- `GLM-5.2-w8a8c8`(Quantized version for Atlas 800 A3): requires 2 Atlas 800 A3 (64GB × 16) node or 4 Atlas 800 A2 (64GB × 8) node.[Download model weight](https://modelers.cn/models/Eco-Tech/GLM-5.2-w8a8c8).
+- `GLM-5.2-w8a8c8`(Quantized version): requires 2 Atlas 800 A3 (64GB × 16) node or 4 Atlas 800 A2 (64GB × 8) node.[Download model weight](https://modelers.cn/models/Eco-Tech/GLM-5.2-w8a8c8). The weights have been verified and are recommended for use.
 - `GLM-5.2-w4a8c8`: requires 1 Atlas 800 A3 (128GB × 8) node or 2 Atlas 800 A2 (64GB × 8) node.[Download model weight](https://modelscope.cn/models/Eco-Tech/GLM-5.2-w4a8c8).
 - You can use [msmodelslim](https://gitcode.com/Ascend/msmodelslim) to quantize the model directly.
 

--- a/docs/source/tutorials/models/GLM5.md
+++ b/docs/source/tutorials/models/GLM5.md
@@ -24,8 +24,8 @@ Refer to [feature guide](../../user_guide/feature_guide/index.md) to get the fea
 - `GLM-5-w8a8`(Quantized version): [Download model weight](https://www.modelscope.cn/models/Eco-Tech/GLM-5-w8a8).
 - `GLM-5.1-w4a8`(Quantized version): [Download model weight](https://modelers.cn/models/Eco-Tech/GLM-5.1-w4a8).
 - `GLM-5.1-w8a8`(Quantized version): [Download model weight](https://modelers.cn/models/Eco-Tech/GLM-5.1-w8a8).
-- `GLM-5.1-w8a8c8`(Quantized version): [Download model weight](https://modelers.cn/models/Eco-Tech/GLM-5.1-w8a8c8-MTP).
-- `GLM-5.1-w4a4`(Ascend950DT mxfp4 Quantized): [Download model weight](https://www.modelscope.cn/models/Eco-Tech/GLM-5.1-w4a4c8-mxfp4).
+- `GLM-5.1-w8a8c8`(Quantized version): [Download model weight](https://modelers.cn/models/Eco-Tech/GLM-5.1-w8a8c8-MTP). The weights have been verified on Atlas 800 A3 and are recommended for use.
+- `GLM-5.1-w4a4`(Ascend950DT mxfp4 Quantized): [Download model weight](https://www.modelscope.cn/models/Eco-Tech/GLM-5.1-w4a4c8-mxfp4). The weights have been verified on Ascend 950DT and are recommended for use.
 
 It is recommended to download the model weight to the shared directory of multiple nodes, such as `/root/.cache/`
 

--- a/docs/source/tutorials/models/GLM5.md
+++ b/docs/source/tutorials/models/GLM5.md
@@ -6,26 +6,26 @@ This document applies to both `GLM-5` and `GLM-5.1`. Unless otherwise specified,
 
 [GLM-5](https://huggingface.co/zai-org/GLM-5) uses a Mixture-of-Experts (MoE) architecture and targets complex systems engineering and long-horizon agentic tasks.
 
-The `GLM-5` model is first supported in `vllm-ascend:v0.17.0rc1`, and all **v0.17.0rc1 and later versions** can run stably. To use the latest features (e.g., PD separation, MTP), it is recommended to use the latest release candidate or official version. The version of transformers need to be upgraded to 5.2.0 or later versions.
+The `GLM-5` model is first supported in `vllm-ascend:v0.17.0rc1`(for Ascend950DT, the model is supported from `vllm-ascend:v0.23.0rc1`), and all **v0.17.0rc1 and later versions** can run stably. To use the latest features (e.g., PD separation, MTP), it is recommended to use the latest release candidate or official version. The version of transformers need to be upgraded to 5.2.0 or later versions.
 
 This document will show the main verification steps of the model, including supported features, feature configuration, environment preparation, single-node and multi-node deployment, accuracy and performance evaluation.
 
 ## 2 Supported Features
 
-Refer to [Supported Features List](../../user_guide/support_matrix/supported_models.md) to get the model's supported feature matrix.
+Refer to [supported features](../../user_guide/support_matrix/supported_models.md) to get the model's supported feature matrix.
 
-Refer to [Feature Guide](../../user_guide/feature_guide/index.md) to get the feature's configuration.
+Refer to [feature guide](../../user_guide/feature_guide/index.md) to get the feature's configuration.
 
 ## 3 Prerequisites
 
 ### 3.1 Model Weight
 
-- `GLM-5`(BF16 version): [Download model weight](https://www.modelscope.cn/models/ZhipuAI/GLM-5).
 - `GLM-5-w4a8`(Quantized version): [Download model weight](https://www.modelscope.cn/models/Eco-Tech/GLM-5-w4a8).
 - `GLM-5-w8a8`(Quantized version): [Download model weight](https://www.modelscope.cn/models/Eco-Tech/GLM-5-w8a8).
-- `GLM-5.1`(BF16 version): [Download model weight](https://huggingface.co/zai-org/GLM-5.1).
 - `GLM-5.1-w4a8`(Quantized version): [Download model weight](https://modelers.cn/models/Eco-Tech/GLM-5.1-w4a8).
 - `GLM-5.1-w8a8`(Quantized version): [Download model weight](https://modelers.cn/models/Eco-Tech/GLM-5.1-w8a8).
+- `GLM-5.1-w8a8c8`(Quantized version for Atlas 800 A3): [Download model weight](https://modelers.cn/models/Eco-Tech/GLM-5.1-w8a8c8-MTP).
+- `GLM-5.1-w4a4`(Ascend950DT mxfp4 Quantized): [Download model weight](https://www.modelscope.cn/models/Eco-Tech/GLM-5.1-w4a4c8-mxfp4).
 
 It is recommended to download the model weight to the shared directory of multiple nodes, such as `/root/.cache/`
 
@@ -38,6 +38,46 @@ If multi-node deployment is required, please follow the [Verify Multi-node Commu
 ### 4.1 Docker Image Installation
 
 You can use our official docker image to run GLM-5/5.1 directly.
+
+=== "Ascend950DT series"
+
+    Start the docker image on each node.
+
+    ```shell
+
+    export IMAGE=quay.io/ascend/vllm-ascend:{{ vllm_ascend_version }}-a5
+    export NAME=vllm-ascend
+
+    docker run --rm \
+    --name $NAME \
+    --net=host \
+    --shm-size=1g \
+    --device /dev/davinci0 \
+    --device /dev/davinci1 \
+    --device /dev/davinci2 \
+    --device /dev/davinci3 \
+    --device /dev/davinci4 \
+    --device /dev/davinci5 \
+    --device /dev/davinci6 \
+    --device /dev/davinci7 \
+    --device /dev/davinci_manager \
+    --device /dev/hisi_hdc \
+    --device /dev/ummu \
+    --device /dev/uburma \
+    -v /usr/local/Ascend/driver:/usr/local/Ascend/driver \
+    -v /etc/ascend_install.info:/etc/ascend_install.info \
+    -v /etc/hccl_rootinfo.json:/etc/hccl_rootinfo.json \
+    -v /etc/hixlep/:/etc/hixlep/ \
+    -v /root/.cache:/root/.cache \
+    -v /usr/local/sbin:/usr/local/sbin \
+    -v /usr/local/dcmi:/usr/local/dcmi \
+    -v /usr/local/bin/npu-smi:/usr/local/bin/npu-smi \
+    -v /usr/local/sbin/npu-smi:/usr/local/sbin/npu-smi \
+    -v /usr/bin/urma_admin:/usr/bin/urma_admin \
+    -v /lib/route.conf:/lib/route.conf \
+    -v /usr/lib64:/usr/lib64 \
+    -itd $IMAGE bash
+    ```
 
 === "A3 series"
 
@@ -115,9 +155,9 @@ You can use our official docker image to run GLM-5/5.1 directly.
         -it $IMAGE bash
     ```
 
-If you want to deploy multi-node environment, you need to set up environment on each node.
+    If you want to deploy multi-node environment, you need to set up environment on each node.
 
-To verify the successful installation of the environment, please refer to [installation](../../getting_started/installation.md).
+    To verify the successful installation of the environment, please refer to [installation](../../getting_started/installation.md).
 
 ### 4.2 Source Code Installation
 
@@ -131,22 +171,73 @@ If you want to deploy multi-node environment, you need to set up environment on 
 
 ### 5.1 Single-Node Online Deployment
 
-=== "A3 series"
+=== "Ascend950DT series"
 
-    - Quantized model `glm-5-w4a8` and `glm-5.1-w4a8` can be deployed on 1 Atlas 800 A3 (64GB × 16) .
+    - Quantized model `glm-5-w4a4` can be deployed on 1 Ascend950DT (96GB × 8) .
 
     Run the following script to execute online inference.
 
-    Common Issues Tip: If you encounter issues, Refer to [Public FAQs](../../faqs.md).
+    Common Issues Tip: If you encounter issues, Refer to [FAQs](../../faqs.md).
+
+    ```shell
+    #!/usr/bin/env bash
+    source /root/.bashrc
+    # this obtained through ifconfig
+    # nic_name is the network interface name corresponding to local_ip of the current node
+    nic_name="xxx"
+    local_ip="xxx"
+
+    export HCCL_BUFFSIZE=400
+    export HCCL_IF_IP=$local_ip
+    export HCCL_INTRA_ROCE_ENABLE=0
+    export HCCL_OP_EXPANSION_MODE="AIV"
+    export HCCL_SOCKET_IFNAME=$nic_name
+    export ASCEND_RT_VISIBLE_DEVICES=0,1,2,3,4,5,6,7
+    export DYNAMIC_EPLB="true"
+    export GLOO_SOCKET_IFNAME=$nic_name
+    export PYTORCH_NPU_ALLOC_CONF=expandable_segments:True
+    export PROMETHEUS_MULTIPROC_DIR=/dev/shm/vllm_metrics && mkdir -p $PROMETHEUS_MULTIPROC_DIR
+    export HCCL_DFS_CONFIG="task_exception:off,inconsistent_check:off"
+    export VLLM_ASCEND_ENABLE_PREFETCH_MLP=1
+
+    vllm serve /root/.cache/modelscope/hub/models/vllm-ascend/GLM5-w4a4 \
+    --host 0.0.0.0 \
+    --port 8077 \
+    --data-parallel-size 1 \
+    --tensor-parallel-size 8 \
+    --seed 1024 \
+    --served-model-name glm-5 \
+    --enable-expert-parallel \
+    --max-num-seqs 128 \
+    --max-model-len 202752 \
+    --max-num-batched-tokens 8192 \
+    --trust-remote-code \
+    --enable-prefix-caching \
+    --gpu-memory-utilization 0.95 \
+    --quantization ascend \
+    --enable-auto-tool-choice \
+    --tool-call-parser glm47 \
+    --reasoning-parser glm45 \
+    --compilation-config '{"cudagraph_mode": "FULL_DECODE_ONLY"}' \
+    --hf-overrides '{"use_index_cache": true, "index_topk_freq": 4}' \
+    --speculative-config '{"num_speculative_tokens": 3, "method": "deepseek_mtp", "enforce_eager": true}' \
+    --additional-config '{"enable_cpu_binding": "True", "multistream_overlap_shared_expert": "True", "enable_sparse_c8": "True", "enable_dsa_cp": true, "eplb_config": {"dynamic_eplb": true, "expert_heat_collection_interval": 50, "algorithm_execution_interval": 5, "eplb_policy_type": 2, "num_redundant_experts": 0}, "enable_flashcomm1": true}'
+    ```
+
+=== "A3 series"
+
+    - Quantized model `glm-5-w4a8` and `glm-5.1-w4a8` can be deployed on 1 Atlas 800 A3 (128GB × 8) .
+
+    Run the following script to execute online inference.
+
+    Common Issues Tip: If you encounter issues, Refer to [FAQs](../../faqs.md).
 
     ```shell
     # The version of transformers needs to be upgraded to 5.2.0.
     # pip install transformers==5.2.0 --upgrade
 
-    export HCCL_OP_EXPANSION_MODE="AIV"
-    export OMP_PROC_BIND=false
-    export OMP_NUM_THREADS=1
     export HCCL_BUFFSIZE=200
+    export HCCL_OP_EXPANSION_MODE="AIV"
     export PYTORCH_NPU_ALLOC_CONF=expandable_segments:True
 
     vllm serve /root/.cache/modelscope/hub/models/vllm-ascend/GLM5-w4a8 \
@@ -165,40 +256,9 @@ If you want to deploy multi-node environment, you need to set up environment on 
     --quantization ascend \
     --enable-chunked-prefill \
     --enable-prefix-caching \
-    --additional-config '{"multistream_overlap_shared_expert":true,"scheduler_config":{"enable_balance_scheduling":true}}' \
+    --additional-config '{"multistream_overlap_shared_expert": true, "enable_balance_scheduling": true, "enable_flashcomm1": true}' \
     --compilation-config '{"cudagraph_mode": "FULL_DECODE_ONLY"}' \
-    --speculative-config '{"num_speculative_tokens": 3, "method": "deepseek_mtp", "enforce_eager": true}'
-    ```
-
-    - Quantized model `glm-5-w8a8` and `glm-5.1-w8a8` can be deployed on 1 Atlas 800 A3 (64GB × 16) .
-
-    Run the following script to execute online inference.
-
-    ```shell
-    export HCCL_OP_EXPANSION_MODE="AIV"
-    export OMP_PROC_BIND=false
-    export OMP_NUM_THREADS=1
-    export HCCL_BUFFSIZE=200
-    export PYTORCH_NPU_ALLOC_CONF=expandable_segments:True
-
-    vllm serve /root/.cache/modelscope/hub/models/vllm-ascend/GLM5-w8a8 \
-    --host 0.0.0.0 \
-    --port 8077 \
-    --data-parallel-size 1 \
-    --tensor-parallel-size 16 \
-    --enable-expert-parallel \
-    --seed 1024 \
-    --served-model-name glm-5 \
-    --max-num-seqs 16 \
-    --max-model-len 40960 \
-    --max-num-batched-tokens 4096 \
-    --trust-remote-code \
-    --gpu-memory-utilization 0.95 \
-    --quantization ascend \
-    --enable-chunked-prefill \
-    --enable-prefix-caching \
-    --additional-config '{"multistream_overlap_shared_expert":true,"scheduler_config":{"enable_balance_scheduling":true},"enable_mlapo":true}' \
-    --compilation-config '{"cudagraph_mode": "FULL_DECODE_ONLY"}' \
+    --hf-overrides '{"use_index_cache": true, "index_topk_freq": 4}' \
     --speculative-config '{"num_speculative_tokens": 3, "method": "deepseek_mtp", "enforce_eager": true}'
     ```
 
@@ -208,13 +268,11 @@ If you want to deploy multi-node environment, you need to set up environment on 
 
     Run the following script to execute online inference.
 
-    Common Issues Tip: If you encounter issues, Refer to [Public FAQs](../../faqs.md).
+    Common Issues Tip: If you encounter issues, Refer to [FAQs](../../faqs.md).
 
     ```shell
-    export HCCL_OP_EXPANSION_MODE="AIV"
-    export OMP_PROC_BIND=false
-    export OMP_NUM_THREADS=1
     export HCCL_BUFFSIZE=200
+    export HCCL_OP_EXPANSION_MODE="AIV"
     export PYTORCH_NPU_ALLOC_CONF=expandable_segments:True
 
     vllm serve /root/.cache/modelscope/hub/models/vllm-ascend/GLM5-w4a8 \
@@ -234,7 +292,8 @@ If you want to deploy multi-node environment, you need to set up environment on 
     --enable-chunked-prefill \
     --enable-prefix-caching \
     --compilation-config '{"cudagraph_mode": "FULL_DECODE_ONLY"}' \
-    --additional-config '{"multistream_overlap_shared_expert":true,"scheduler_config":{"enable_balance_scheduling":true}}' \
+    --additional-config '{"multistream_overlap_shared_expert": true, "enable_balance_scheduling": true, "enable_flashcomm1": true}' \
+    --hf-overrides '{"use_index_cache": true, "index_topk_freq": 4}' \
     --speculative-config '{"num_speculative_tokens": 3, "method": "deepseek_mtp", "enforce_eager": true}'
     ```
 
@@ -250,29 +309,32 @@ Only the key parameters specific to this model/scenario are described below. `ma
 - `--speculative-config '{"num_speculative_tokens": 3, "method": "deepseek_mtp", "enforce_eager": true}'`: Enables Multi-Token Prediction (MTP) speculative decoding with GLM-5's DeepSeek-style MTP draft model. `num_speculative_tokens` (3-5) controls how many tokens are speculated per step; `enforce_eager: true` is required because GLM-5 does not support graph-mode speculative decoding.
 - `--enable-chunked-prefill` / `--enable-prefix-caching`: Recommended for long-context and multi-user scenarios — chunked prefill splits long prompts to improve TTFT, prefix caching reuses KV cache for shared prefixes (e.g., system prompts).
 - `--compilation-config '{"cudagraph_mode": "FULL_DECODE_ONLY"}'`: Enables graph capture for the decode phase only, improving decode performance by reducing kernel launch overhead.
-- `--additional-config '{"multistream_overlap_shared_expert": true}'`: Overlaps shared-expert computation on an additional stream. Note: automatically disabled when `additional_config.enable_fused_mc2=1`, as the two optimizations conflict.
+- `--additional-config '{"multistream_overlap_shared_expert": true}'`: Overlaps shared-expert computation on an additional stream. Note: automatically disabled when `"enable_fused_mc2": true`, as the two optimizations conflict.
 
-**Key environment variables:**
+**Key `--additional-config` fields:**
 
-- `additional_config.enable_mlapo=true`: Enables the MLA preprocess fusion operator (MlaPreprocessOperation). Enabled by default for w8a8 models — significantly improves Decode performance but consumes more NPU memory; set `additional_config.enable_mlapo=false` if memory is a priority. Recommended for w8a8; w4a8 may not benefit.
-- `additional_config.scheduler_config.enable_balance_scheduling=true`: Enables balance scheduling to improve output throughput and reduce TPOT in the v1 scheduler.
+- `"enable_flashcomm1": true`: Enables FlashComm optimization to reduce communication overhead (mainly benefits the prefill path). With FlashComm enabled, `layer_sharding` cannot include `o_proj`.
+- `"enable_mlapo": true`: Enables the MLA preprocess fusion operator (MlaPreprocessOperation). Enabled by default for w8a8 models — significantly improves Decode performance but consumes more NPU memory; set `"enable_mlapo": false` if memory is a priority. Recommended for w8a8; w4a8 may not benefit.
+- `"enable_balance_scheduling": true`: Enables balance scheduling to improve output throughput and reduce TPOT in the v1 scheduler.
 
 **Performance tuning notes for single-node:**
 
 - For low-latency scenarios, use `dp1tp16` (data-parallel-size 1, tensor-parallel-size 16) and consider reducing `--max-num-seqs` and `--max-num-batched-tokens`.
 - For high-throughput scenarios, increase `--max-num-seqs` and enable `--enable-prefix-caching`.
-- For long-context scenarios (e.g., 200k), use w8a8 weight (more memory for KV cache) and set `--max-model-len` to the desired context length. Consider enabling `--enable-chunked-prefill`.
-- If you encounter OOM, reduce `--gpu-memory-utilization`, `--max-num-seqs`, or `--max-model-len`. Disabling `additional_config.enable_mlapo` can also reduce memory usage (at the cost of performance).
+- For long-context scenarios (e.g., 200K), use w4a8 weight (more memory for KV cache) and set `--max-model-len` to the desired context length. Consider enabling `--enable-chunked-prefill`.
+- If you encounter OOM, reduce `--gpu-memory-utilization`, `--max-num-seqs`, or `--max-model-len`. Disabling `"enable_mlapo"` can also reduce memory usage (at the cost of performance).
 
 ### 5.2 Multi-node Deployment
 
 If you want to deploy multi-node environment, you need to verify multi-node communication according to [verify multi-node communication environment](../../getting_started/installation.md#installation-multi-node-interconnect).
 
-Common Issues Tip: If you encounter issues, Refer to [Public FAQs](../../faqs.md).
+Common Issues Tip: If you encounter issues, Refer to [FAQs](../../faqs.md).
 
 === "A3 series"
 
-    - `glm-5-bf16` and `glm-5.1-bf16`: require at least 2 Atlas 800 A3 (64GB × 16).
+    **High-Throughput Scenario (DP8 TP4)**
+
+    - `glm-5.1-w8a8c8`: can be deployed on 2 Atlas 800 A3 (128GB × 8) for high-throughput scenarios.
 
     Run the following scripts on two nodes respectively.
 
@@ -283,38 +345,36 @@ Common Issues Tip: If you encounter issues, Refer to [Public FAQs](../../faqs.md
     # nic_name is the network interface name corresponding to local_ip of the current node
     nic_name="xxx"
     local_ip="xxx"
-
-    # The value of node0_ip must be consistent with the value of local_ip set in node0 (master node)
-    node0_ip="xxxx"
-
-    export HCCL_OP_EXPANSION_MODE="AIV"
+    export HCCL_BUFFSIZE=400
     export HCCL_IF_IP=$local_ip
-    export GLOO_SOCKET_IFNAME=$nic_name
-    export TP_SOCKET_IFNAME=$nic_name
+    export HCCL_OP_EXPANSION_MODE="AIV"
     export HCCL_SOCKET_IFNAME=$nic_name
-    export OMP_PROC_BIND=false
-    export OMP_NUM_THREADS=1
-    export HCCL_BUFFSIZE=200
+    export GLOO_SOCKET_IFNAME=$nic_name
     export PYTORCH_NPU_ALLOC_CONF=expandable_segments:True
-
-    vllm serve /root/.cache/modelscope/hub/models/vllm-ascend/GLM5-bf16 --additional-config '{"scheduler_config":{"enable_balance_scheduling":true}}' \
+    vllm serve /root/.cache/modelscope/hub/models/vllm-ascend/GLM-5.1-W8A8C8-MTP \
     --host 0.0.0.0 \
     --port 8077 \
-    --data-parallel-size 2 \
-    --data-parallel-size-local 1 \
-    --data-parallel-address $node0_ip \
-    --data-parallel-rpc-port 12890 \
-    --tensor-parallel-size 16 \
+    --data-parallel-size 8 \
+    --data-parallel-size-local 4 \
+    --data-parallel-address $local_ip \
+    --enable-expert-parallel \
+    --data-parallel-rpc-port 12980 \
+    --tensor-parallel-size 4 \
+    --hf-overrides '{"use_index_cache": true, "index_topk_freq": 4}' \
     --seed 1024 \
     --served-model-name glm-5 \
-    --enable-expert-parallel \
-    --max-num-seqs 16 \
-    --max-model-len 8192 \
-    --max-num-batched-tokens 4096 \
+    --tool-call-parser glm47 \
+    --reasoning-parser glm45 \
+    --enable-auto-tool-choice \
     --trust-remote-code \
-    --gpu-memory-utilization 0.95 \
+    --gpu-memory-utilization 0.92 \
+    --quantization ascend \
+    --enable-chunked-prefill \
+    --enable-prefix-caching \
+    --async-scheduling \
+    --additional-config '{"enable_dsa_cp": true, "enable_sparse_sfa_c8": true, "enable_sparse_li_c8": true, "enable_balance_scheduling": true, "fuse_muls_add": true, "enable_flashcomm1": true, "enable_fused_mc2": true, "enable_mlapo": true}' \
     --compilation-config '{"cudagraph_mode": "FULL_DECODE_ONLY"}' \
-    --speculative-config '{"num_speculative_tokens": 3, "method": "deepseek_mtp", "enforce_eager": true}'
+    --speculative-config '{"num_speculative_tokens": 3, "method": "deepseek_mtp","enforce_eager":true}'
     ```
 
     **node 1**
@@ -324,41 +384,47 @@ Common Issues Tip: If you encounter issues, Refer to [Public FAQs](../../faqs.md
     # nic_name is the network interface name corresponding to local_ip of the current node
     nic_name="xxx"
     local_ip="xxx"
-
-    # The value of node0_ip must be consistent with the value of local_ip set in node0 (master node)
+    # IP of node 0 (the data parallel master node), must be consistent with the local_ip of node 0
     node0_ip="xxxx"
 
-    export HCCL_OP_EXPANSION_MODE="AIV"
+    export HCCL_BUFFSIZE=400
     export HCCL_IF_IP=$local_ip
-    export GLOO_SOCKET_IFNAME=$nic_name
-    export TP_SOCKET_IFNAME=$nic_name
+    export HCCL_OP_EXPANSION_MODE="AIV"
     export HCCL_SOCKET_IFNAME=$nic_name
-    export OMP_PROC_BIND=false
-    export OMP_NUM_THREADS=1
-    export HCCL_BUFFSIZE=200
+    export GLOO_SOCKET_IFNAME=$nic_name
     export PYTORCH_NPU_ALLOC_CONF=expandable_segments:True
-
-    vllm serve /root/.cache/modelscope/hub/models/vllm-ascend/GLM5-bf16 --additional-config '{"scheduler_config":{"enable_balance_scheduling":true}}' \
+    vllm serve /root/.cache/modelscope/hub/models/vllm-ascend/GLM-5.1-W8A8C8-MTP \
     --host 0.0.0.0 \
     --port 8077 \
     --headless \
-    --data-parallel-size 2 \
-    --data-parallel-size-local 1 \
-    --data-parallel-start-rank 1 \
+    --data-parallel-size 8 \
+    --data-parallel-size-local 4 \
+    --data-parallel-start-rank 4 \
     --data-parallel-address $node0_ip \
-    --data-parallel-rpc-port 12890 \
-    --tensor-parallel-size 16 \
+    --enable-expert-parallel \
+    --data-parallel-rpc-port 12980 \
+    --tensor-parallel-size 4 \
+    --hf-overrides '{"use_index_cache": true, "index_topk_freq": 4}' \
     --seed 1024 \
     --served-model-name glm-5 \
-    --enable-expert-parallel \
-    --max-num-seqs 16 \
-    --max-model-len 8192 \
-    --max-num-batched-tokens 4096 \
+    --tool-call-parser glm47 \
+    --reasoning-parser glm45 \
+    --enable-auto-tool-choice \
     --trust-remote-code \
-    --gpu-memory-utilization 0.95 \
+    --gpu-memory-utilization 0.92 \
+    --quantization ascend \
+    --enable-chunked-prefill \
+    --enable-prefix-caching \
+    --async-scheduling \
+    --additional-config '{"enable_dsa_cp": true, "enable_sparse_sfa_c8": true, "enable_sparse_li_c8": true, "enable_balance_scheduling": true, "fuse_muls_add": true, "enable_flashcomm1": true, "enable_fused_mc2": true, "enable_mlapo": true}' \
     --compilation-config '{"cudagraph_mode": "FULL_DECODE_ONLY"}' \
-    --speculative-config '{"num_speculative_tokens": 3, "method": "deepseek_mtp", "enforce_eager": true}'
+    --speculative-config '{"num_speculative_tokens": 3, "method": "deepseek_mtp","enforce_eager":true}'
     ```
+
+    **Notice:**
+
+    - When testing with a prefix cache hit rate > 0, keep `--enable-prefix-caching` (as in the scripts above); when the hit rate is 0, replace it with `--no-enable-prefix-caching`.
+    - `"enable_fused_mc2": true` conflicts with `"multistream_overlap_shared_expert": true` — the runtime automatically disables `multistream_overlap_shared_expert` when fused MC2 is enabled.
 
 === "A2 series"
 
@@ -375,14 +441,11 @@ Common Issues Tip: If you encounter issues, Refer to [Public FAQs](../../faqs.md
     # The value of node0_ip must be consistent with the value of local_ip set in node0 (master node)
     node0_ip="xxx"
 
-    export HCCL_OP_EXPANSION_MODE="AIV"
-    export HCCL_IF_IP=$local_ip
-    export GLOO_SOCKET_IFNAME=$nic_name
-    export TP_SOCKET_IFNAME=$nic_name
-    export HCCL_SOCKET_IFNAME=$nic_name
-    export OMP_PROC_BIND=false
-    export OMP_NUM_THREADS=1
     export HCCL_BUFFSIZE=200
+    export HCCL_IF_IP=$local_ip
+    export HCCL_OP_EXPANSION_MODE="AIV"
+    export HCCL_SOCKET_IFNAME=$nic_name
+    export GLOO_SOCKET_IFNAME=$nic_name
     export PYTORCH_NPU_ALLOC_CONF=expandable_segments:True
 
     vllm serve /root/.cache/modelscope/hub/models/vllm-ascend/GLM5-w4a8 \
@@ -403,7 +466,8 @@ Common Issues Tip: If you encounter issues, Refer to [Public FAQs](../../faqs.md
     --trust-remote-code \
     --gpu-memory-utilization 0.95 \
     --compilation-config '{"cudagraph_mode": "FULL_DECODE_ONLY"}' \
-    --additional-config '{"multistream_overlap_shared_expert":true,"scheduler_config":{"enable_balance_scheduling":true}}' \
+    --additional-config '{"multistream_overlap_shared_expert": true, "enable_balance_scheduling": true, "enable_flashcomm1": true}' \
+    --hf-overrides '{"use_index_cache": true, "index_topk_freq": 4}' \
     --speculative-config '{"num_speculative_tokens": 3, "method": "deepseek_mtp", "enforce_eager": true}'
     ```
 
@@ -418,14 +482,11 @@ Common Issues Tip: If you encounter issues, Refer to [Public FAQs](../../faqs.md
     # The value of node0_ip must be consistent with the value of local_ip set in node0 (master node)
     node0_ip="xxx"
 
-    export HCCL_OP_EXPANSION_MODE="AIV"
-    export HCCL_IF_IP=$local_ip
-    export GLOO_SOCKET_IFNAME=$nic_name
-    export TP_SOCKET_IFNAME=$nic_name
-    export HCCL_SOCKET_IFNAME=$nic_name
-    export OMP_PROC_BIND=false
-    export OMP_NUM_THREADS=1
     export HCCL_BUFFSIZE=200
+    export HCCL_IF_IP=$local_ip
+    export HCCL_OP_EXPANSION_MODE="AIV"
+    export HCCL_SOCKET_IFNAME=$nic_name
+    export GLOO_SOCKET_IFNAME=$nic_name
     export PYTORCH_NPU_ALLOC_CONF=expandable_segments:True
 
     vllm serve /root/.cache/modelscope/hub/models/vllm-ascend/GLM5-w4a8 \
@@ -448,165 +509,10 @@ Common Issues Tip: If you encounter issues, Refer to [Public FAQs](../../faqs.md
     --trust-remote-code \
     --gpu-memory-utilization 0.95 \
     --compilation-config '{"cudagraph_mode": "FULL_DECODE_ONLY"}' \
-    --additional-config '{"multistream_overlap_shared_expert":true,"scheduler_config":{"enable_balance_scheduling":true}}' \
+    --additional-config '{"multistream_overlap_shared_expert": true, "enable_balance_scheduling": true, "enable_flashcomm1": true}' \
+    --hf-overrides '{"use_index_cache": true, "index_topk_freq": 4}' \
     --speculative-config '{"num_speculative_tokens": 3, "method": "deepseek_mtp", "enforce_eager": true}'
     ```
-
-- For bf16 weight, use this script on each node to enable [Multi Token Prediction (MTP)](../../user_guide/feature_guide/speculative_decoding.md).
-
-```shell
-python adjust_weight.py "path_of_bf16_weight"
-```
-
-```python
-# adjust_weight.py
-from safetensors.torch import safe_open, save_file
-import torch
-import json
-import os
-import sys
-
-target_keys = ["model.embed_tokens.weight", "lm_head.weight"]
-
-def get_tensor_info(file_path):
-   with safe_open(file_path, framework="pt", device="cpu") as f:
-         tensor_names = f.keys()
-         tensor_dict = {}
-         for name in tensor_names:
-            tensor = f.get_tensor(name)
-            tensor_dict[name] = tensor
-         return tensor_dict
-
-
-if __name__ == "__main__":
-   directory_path = sys.argv[1]
-   json_name = "model.safetensors.index.json"
-   json_path = os.path.join(directory_path, json_name)
-   with open(json_path, 'r', encoding='utf-8') as f:
-         json_data = json.load(f)
-   weight_map = json_data.get('weight_map', {})
-   file_list = []
-   for key in target_keys:
-         safetensor_file = weight_map.get(key)
-         file_list.append(directory_path + safetensor_file)
-
-   new_dict = {}
-   for file_path in file_list:
-         tensor_dict = get_tensor_info(file_path)
-         for key in target_keys:
-            if key in tensor_dict:
-               if key == "model.embed_tokens.weight":
-                     new_key = "model.layers.78.embed_tokens.weight"
-               elif key == "lm_head.weight":
-                     new_key = "model.layers.78.shared_head.head.weight"
-               new_dict[new_key] = tensor_dict[key]
-
-   new_file_name = os.path.join(directory_path, "mtp-others.safetensors")
-   new_keys = ["model.layers.78.embed_tokens.weight", "model.layers.78.shared_head.head.weight"]
-   save_file(tensors=new_dict, filename=new_file_name)
-   for key in new_keys:
-         json_data["weight_map"][key] = "mtp-others.safetensors"
-   with open(json_path, 'w', encoding='utf-8') as f:
-         json.dump(json_data, f, indent=2)
-```
-
-- `glm-5-w8a8`: require 2 Atlas 800 A3 (64GB × 16).
-
-Run the following scripts on two nodes respectively.
-
-**node 0**
-
-```shell
-# this obtained through ifconfig
-# nic_name is the network interface name corresponding to local_ip of the current node
-nic_name="xxx"
-local_ip="xxx"
-
-# The value of node0_ip must be consistent with the value of local_ip set in node0 (master node)
-node0_ip="xxxx"
-
-export HCCL_OP_EXPANSION_MODE="AIV"
-
-export HCCL_IF_IP=$local_ip
-export GLOO_SOCKET_IFNAME=$nic_name
-export TP_SOCKET_IFNAME=$nic_name
-export HCCL_SOCKET_IFNAME=$nic_name
-export OMP_PROC_BIND=false
-export OMP_NUM_THREADS=1
-export HCCL_BUFFSIZE=200
-export PYTORCH_NPU_ALLOC_CONF=expandable_segments:True
-
-vllm serve /root/.cache/modelscope/hub/models/vllm-ascend/GLM5-w8a8 \
---host 0.0.0.0 \
---port 8077 \
---data-parallel-size 2 \
---data-parallel-size-local 1 \
---data-parallel-address $node0_ip \
---data-parallel-rpc-port 12890 \
---tensor-parallel-size 16 \
---seed 1024 \
---served-model-name glm-5 \
---enable-expert-parallel \
---max-num-seqs 16 \
---max-model-len 200000 \
---max-num-batched-tokens 4096 \
---trust-remote-code \
---gpu-memory-utilization 0.95 \
---quantization ascend \
---enable-chunked-prefill \
---enable-prefix-caching \
---compilation-config '{"cudagraph_mode": "FULL_DECODE_ONLY"}' \
---additional-config '{"multistream_overlap_shared_expert":true,"scheduler_config":{"enable_balance_scheduling":true},"enable_mlapo":true}' \
---speculative-config '{"num_speculative_tokens": 3, "method": "deepseek_mtp", "enforce_eager": true}'
-```
-
-**node 1**
-
-```shell
-# this obtained through ifconfig
-# nic_name is the network interface name corresponding to local_ip of the current node
-nic_name="xxx"
-local_ip="xxx"
-
-# The value of node0_ip must be consistent with the value of local_ip set in node0 (master node)
-node0_ip="xxxx"
-
-export HCCL_OP_EXPANSION_MODE="AIV"
-
-export HCCL_IF_IP=$local_ip
-export GLOO_SOCKET_IFNAME=$nic_name
-export TP_SOCKET_IFNAME=$nic_name
-export HCCL_SOCKET_IFNAME=$nic_name
-export OMP_PROC_BIND=false
-export OMP_NUM_THREADS=1
-export HCCL_BUFFSIZE=200
-export PYTORCH_NPU_ALLOC_CONF=expandable_segments:True
-
-vllm serve /root/.cache/modelscope/hub/models/vllm-ascend/GLM5-w8a8 \
---host 0.0.0.0 \
---port 8077 \
---headless \
---data-parallel-size 2 \
---data-parallel-size-local 1 \
---data-parallel-start-rank 1 \
---data-parallel-address $node0_ip \
---data-parallel-rpc-port 12890 \
---tensor-parallel-size 16 \
---seed 1024 \
---served-model-name glm-5 \
---enable-expert-parallel \
---max-num-seqs 16 \
---max-model-len 200000 \
---max-num-batched-tokens 4096 \
---trust-remote-code \
---gpu-memory-utilization 0.95 \
---quantization ascend \
---enable-chunked-prefill \
---enable-prefix-caching \
---compilation-config '{"cudagraph_mode": "FULL_DECODE_ONLY"}' \
---additional-config '{"multistream_overlap_shared_expert":true,"scheduler_config":{"enable_balance_scheduling":true},"enable_mlapo":true}' \
---speculative-config '{"num_speculative_tokens": 3, "method": "deepseek_mtp", "enforce_eager": true}'
-```
 
 Key Parameter Descriptions for multi-node deployment:
 
@@ -614,292 +520,283 @@ In addition to all single-node parameters described in [Single-Node Online Deplo
 
 **Network and data parallel configuration:**
 
-- `HCCL_IF_IP`, `GLOO_SOCKET_IFNAME`, `TP_SOCKET_IFNAME`, `HCCL_SOCKET_IFNAME`: Network interface configuration for multi-node communication. Set `nic_name` to the network interface name (obtained via `ifconfig`) and `local_ip` to the current node's IP address. These must be correctly configured on each node for successful multi-node communication.
+- `HCCL_IF_IP`, `GLOO_SOCKET_IFNAME`, `HCCL_SOCKET_IFNAME`: Network interface configuration for multi-node communication. Set `nic_name` to the network interface name (obtained via `ifconfig`) and `local_ip` to the current node's IP address. These must be correctly configured on each node for successful multi-node communication.
 - `--data-parallel-size`: Total number of data parallel ranks across all nodes. For 2-node deployment, typically set to `2`.
 - `--data-parallel-size-local`: Number of data parallel ranks on the current node. Usually set to `1` (one DP rank per node).
 - `--data-parallel-address`: IP address of the data parallel master node (node 0). Must match the `local_ip` of the master node.
 - `--data-parallel-rpc-port`: RPC port for data parallel master communication. Must be the same across all nodes.
 - `--headless`: Indicates this is a non-master node. Do not use on node 0.
-- `--data-parallel-start-rank`: Starting rank offset for data parallel ranks on this node. Node 0 uses `0`, node 1 uses `1`.
+- `--data-parallel-start-rank`: Starting rank offset for data parallel ranks on this node. Node 0 uses `0`; node 1 uses the number of DP ranks on node 0 (e.g., `1` for DP2, `4` for DP8).
 
 **Multi-node performance tuning:**
 
 - For low-latency multi-node scenarios, keep `--data-parallel-size-local 1` to minimize cross-node communication.
-- `--max-num-seqs` should be tuned based on available KV cache memory after model loading. For w8a8 on A3 multi-node, `16` is recommended. For w4a8 on A2 multi-node with long context, start with `2` and increase if memory permits.
+- `--max-num-seqs` should be tuned based on available KV cache memory after model loading. For the w8a8c8 198K high-throughput scenario on A3, `6` is recommended; for the 198K low-latency scenario, `16` is recommended. For w4a8 on A2 multi-node with long context, start with `2` and increase if memory permits.
 - All nodes in a multi-node deployment must use identical `--tensor-parallel-size`, `--enable-expert-parallel`, and model weight path configurations.
+
+**w8a8c8-specific `--additional-config` fields:**
+
+- `"enable_dsa_cp": true`: Enables DSA context parallelism to accelerate long-context prefill.
+- `"enable_sparse_sfa_c8": true` / `"enable_sparse_li_c8": true`: Sparse attention optimizations of the C8 quantized model.
+- `"enable_balance_scheduling": true`: Improves output throughput and reduces TPOT in the v1 scheduler. Not recommended when Prefill-Decode is separated.
+- `"fuse_muls_add": true`: Fuses multiply-add operations.
+- `"multistream_overlap_shared_expert": true`: Overlaps shared-expert computation on an additional stream. Automatically disabled when `"enable_fused_mc2": true`.
 
 ### 5.3 Prefill-Decode Disaggregation
 
-We'd like to show the deployment guide of `GLM-5` on multi-node environment with 1P1D for better performance. *Prefill-Decode Disaggregation* refers to the separation of the prefill stage and the decode stage across different nodes to improve throughput and latency.
+We'd like to show the deployment guide of `GLM-5` on multi-node environment with Prefill-Decode (PD) disaggregation for better performance. *Prefill-Decode Disaggregation* refers to the separation of the prefill stage and the decode stage across different nodes to improve throughput and latency.
+
+In the PD disaggregation scenario, Mooncake is used as the KV cache transfer connector between the prefill and decode nodes. Please refer to [KV Cache Pool (Ascend Store) Deployment Guide](https://github.com/vllm-project/vllm-ascend/blob/main/docs/source/user_guide/feature_guide/kv_pool.md) for the Mooncake configuration.
+
+#### 5.3.1 Prefill-Decode Disaggregation (Ascend950DT series)
 
 Before you start, please
 
-1. prepare the script `launch_online_dp.py` on each node:
+prepare the script `launch_online_dp.py` on each node:
 
-    ```python
-    import argparse
-    import multiprocessing
-    import os
-    import subprocess
-    import sys
+```python
+import argparse
+import multiprocessing
+import os
+import subprocess
+import sys
+def parse_args():
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--dp-size",
+        type=int,
+        required=True,
+        help="Data parallel size."
+    )
+    parser.add_argument(
+        "--tp-size",
+        type=int,
+        default=1,
+        help="Tensor parallel size."
+    )
+    parser.add_argument(
+        "--dp-size-local",
+        type=int,
+        default=-1,
+        help="Local data parallel size."
+    )
+    parser.add_argument(
+        "--dp-rank-start",
+        type=int,
+        default=0,
+        help="Starting rank for data parallel."
+    )
+    parser.add_argument(
+        "--dp-address",
+        type=str,
+        required=True,
+        help="IP address for data parallel master node."
+    )
+    parser.add_argument(
+        "--dp-rpc-port",
+        type=str,
+        default=12345,
+        help="Port for data parallel master node."
+    )
+    parser.add_argument(
+        "--vllm-start-port",
+        type=int,
+        default=9000,
+        help="Starting port for the engine."
+    )
+    return parser.parse_args()
+args = parse_args()
+dp_size = args.dp_size
+tp_size = args.tp_size
+dp_size_local = args.dp_size_local
+if dp_size_local == -1:
+    dp_size_local = dp_size
+dp_rank_start = args.dp_rank_start
+dp_address = args.dp_address
+dp_rpc_port = args.dp_rpc_port
+vllm_start_port = args.vllm_start_port
+def run_command(visible_devices, dp_rank, vllm_engine_port):
+    command = [
+        "bash",
+        "./run_dp_template.sh",
+        visible_devices,
+        str(vllm_engine_port),
+        str(dp_size),
+        str(dp_rank),
+        dp_address,
+        dp_rpc_port,
+        str(tp_size),
+    ]
+    subprocess.run(command, check=True)
+if __name__ == "__main__":
+    template_path = "./run_dp_template.sh"
+    if not os.path.exists(template_path):
+        print(f"Template file {template_path} does not exist.")
+        sys.exit(1)
+    processes = []
+    num_cards = dp_size_local * tp_size
+    for i in range(dp_size_local):
+        dp_rank = dp_rank_start + i
+        vllm_engine_port = vllm_start_port + i
+        visible_devices = ",".join(str(x) for x in range(i * tp_size, (i + 1) * tp_size))
+        process = multiprocessing.Process(target=run_command,
+                                        args=(visible_devices, dp_rank,
+                                                vllm_engine_port))
+        processes.append(process)
+        process.start()
+    for process in processes:
+        process.join()
+```
 
-    def parse_args():
-        parser = argparse.ArgumentParser()
-        parser.add_argument(
-            "--dp-size",
-            type=int,
-            required=True,
-            help="Data parallel size."
-        )
-        parser.add_argument(
-            "--tp-size",
-            type=int,
-            default=1,
-            help="Tensor parallel size."
-        )
-        parser.add_argument(
-            "--dp-size-local",
-            type=int,
-            default=-1,
-            help="Local data parallel size."
-        )
-        parser.add_argument(
-            "--dp-rank-start",
-            type=int,
-            default=0,
-            help="Starting rank for data parallel."
-        )
-        parser.add_argument(
-            "--dp-address",
-            type=str,
-            required=True,
-            help="IP address for data parallel master node."
-        )
-        parser.add_argument(
-            "--dp-rpc-port",
-            type=str,
-            default=12345,
-            help="Port for data parallel master node."
-        )
-        parser.add_argument(
-            "--vllm-start-port",
-            type=int,
-            default=9000,
-            help="Starting port for the engine."
-        )
-        return parser.parse_args()
-
-    args = parse_args()
-    dp_size = args.dp_size
-    tp_size = args.tp_size
-    dp_size_local = args.dp_size_local
-    if dp_size_local == -1:
-        dp_size_local = dp_size
-    dp_rank_start = args.dp_rank_start
-    dp_address = args.dp_address
-    dp_rpc_port = args.dp_rpc_port
-    vllm_start_port = args.vllm_start_port
-
-    def run_command(visible_devices, dp_rank, vllm_engine_port):
-        command = [
-            "bash",
-            "./run_dp_template.sh",
-            visible_devices,
-            str(vllm_engine_port),
-            str(dp_size),
-            str(dp_rank),
-            dp_address,
-            dp_rpc_port,
-            str(tp_size),
-        ]
-        subprocess.run(command, check=True)
-
-    if __name__ == "__main__":
-        template_path = "./run_dp_template.sh"
-        if not os.path.exists(template_path):
-            print(f"Template file {template_path} does not exist.")
-            sys.exit(1)
-
-        processes = []
-        num_cards = dp_size_local * tp_size
-        for i in range(dp_size_local):
-            dp_rank = dp_rank_start + i
-            vllm_engine_port = vllm_start_port + i
-            visible_devices = ",".join(str(x) for x in range(i * tp_size, (i + 1) * tp_size))
-            process = multiprocessing.Process(target=run_command,
-                                            args=(visible_devices, dp_rank,
-                                                    vllm_engine_port))
-            processes.append(process)
-            process.start()
-
-        for process in processes:
-            process.join()
-
-    ```
-
-2. prepare the script `run_dp_template.sh` on each node.
+1. prepare the script `run_dp_template.sh` on each node.
 
     1. Prefill node 0
 
         ```shell
-        nic_name="xxxx" # change to your own nic name
-        local_ip="xxxx" # change to your own ip
+        #!/usr/bin/env bash
+        source /root/.bashrc
+        # this obtained through ifconfig
+        # nic_name is the network interface name corresponding to local_ip of the current node
+        nic_name="xxx"
+        local_ip="xxx"
 
-        export HCCL_OP_EXPANSION_MODE="AIV"
+        export VLLM_EXECUTE_MODEL_TIMEOUT_SECONDS=30000
+        export HCCL_BUFFSIZE=300
         export HCCL_IF_IP=$local_ip
-        export GLOO_SOCKET_IFNAME=$nic_name
-        export TP_SOCKET_IFNAME=$nic_name
         export HCCL_SOCKET_IFNAME=$nic_name
-        export OMP_PROC_BIND=false
-        export OMP_NUM_THREADS=1
-        export PYTORCH_NPU_ALLOC_CONF=expandable_segments:True
-        export HCCL_BUFFSIZE=256
-        export ASCEND_AGGREGATE_ENABLE=1
-        export ASCEND_TRANSPORT_PRINT=1
-        export ACL_OP_INIT_MODE=1
-        export ASCEND_A3_ENABLE=1
-        # Timeout (in seconds) for automatically releasing the prefiller’s KV cache for a particular request.
-        export VLLM_MOONCAKE_ABORT_REQUEST_TIMEOUT=480
         export ASCEND_RT_VISIBLE_DEVICES=$1
-        export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/local/lib
+        export GLOO_SOCKET_IFNAME=$nic_name
+        export PYTORCH_NPU_ALLOC_CONF=expandable_segments:True
+        export PROMETHEUS_MULTIPROC_DIR=/dev/shm/vllm_metrics && mkdir -p $PROMETHEUS_MULTIPROC_DIR
+        export HCCL_DFS_CONFIG="task_exception:off,inconsistent_check:off"
+        export HCCL_ALGO=level0:fullmesh
+        export ASCEND_LOCAL_COMM_RES='{"version":"1.3"}'
 
-        vllm serve /root/.cache/modelscope/hub/models/vllm-ascend/GLM5-w8a8 \
+        vllm serve /root/.cache/modelscope/hub/models/vllm-ascend/GLM5-w4a4 \
             --host 0.0.0.0 \
             --port $2 \
             --data-parallel-size $3 \
-            --data-parallel-rank $4 \
-            --data-parallel-address $5 \
-            --data-parallel-rpc-port $6 \
             --tensor-parallel-size $7 \
-            --enable-expert-parallel \
-            --speculative-config '{"num_speculative_tokens": 1, "method":"deepseek_mtp", "enforce_eager": true}' \
-            --seed 1024 \
+            --max-model-len 135000 \
+            --max-num-batched-tokens 8192 \
             --served-model-name glm-5 \
-            --max-model-len 131072 \
-            --additional-config '{"enable_dsa_cp": true,"enable_fused_mc2":1}' \
-            --max-num-batched-tokens 4096 \
-            --trust-remote-code \
-            --max-num-seqs 64 \
-            --enable-chunked-prefill \
-            --quantization ascend \
             --gpu-memory-utilization 0.95 \
+            --enable-expert-parallel \
+            --max-num-seqs 8 \
+            --enable-prefix-caching \
+            --trust-remote-code \
             --enforce-eager \
+            --quantization ascend \
             --enable-auto-tool-choice \
             --tool-call-parser glm47 \
             --reasoning-parser glm45 \
+            --speculative-config '{"num_speculative_tokens": 1, "method": "deepseek_mtp", "enforce_eager": true}' \
+            --hf-overrides '{"use_index_cache": true, "index_topk_freq": 4}' \
             --kv-transfer-config \
             '{"kv_connector": "MooncakeConnectorV1",
             "kv_role": "kv_producer",
-            "kv_port": "30000",
+            "kv_port": "30100",
+            "engine_id": "1",
             "kv_connector_extra_config": {
-                        "use_ascend_direct": true,
                         "prefill": {
-                                "dp_size": 2,
-                                "tp_size": 16
+                                "dp_size": 1,
+                                "tp_size": 8
                         },
                         "decode": {
                                 "dp_size": 16,
-                                "tp_size": 4
-                        }
+                                "tp_size": 1
+                        },
+                        "ascend_local_comm_res_path": "/etc/hixlep"
                 }
-            }'
-
+            }' \
+            --additional-config '{"enable_cpu_binding": "True", "multistream_overlap_shared_expert": "True", "recompute_scheduler_enable": "True", "enable_sparse_c8": "True", "enable_dsa_cp": true, "enable_flashcomm1": true}'
         ```
 
     2. Prefill node 1
 
         ```shell
-        nic_name="xxxx" # change to your own nic name
-        local_ip="xxxx" # change to your own ip
+        #!/usr/bin/env bash
+        source /root/.bashrc
+        # this obtained through ifconfig
+        # nic_name is the network interface name corresponding to local_ip of the current node
+        nic_name="xxx"
+        local_ip="xxx"
 
-        export HCCL_OP_EXPANSION_MODE="AIV"
+        export VLLM_EXECUTE_MODEL_TIMEOUT_SECONDS=30000
+        export HCCL_BUFFSIZE=300
         export HCCL_IF_IP=$local_ip
-        export GLOO_SOCKET_IFNAME=$nic_name
-        export TP_SOCKET_IFNAME=$nic_name
         export HCCL_SOCKET_IFNAME=$nic_name
-        export OMP_PROC_BIND=false
-        export OMP_NUM_THREADS=1
-        export PYTORCH_NPU_ALLOC_CONF=expandable_segments:True
-        export HCCL_BUFFSIZE=256
-        export ASCEND_AGGREGATE_ENABLE=1
-        export ASCEND_TRANSPORT_PRINT=1
-        export ACL_OP_INIT_MODE=1
-        export ASCEND_A3_ENABLE=1
-        # Timeout (in seconds) for automatically releasing the prefiller’s KV cache for a particular request.
-        export VLLM_MOONCAKE_ABORT_REQUEST_TIMEOUT=480
         export ASCEND_RT_VISIBLE_DEVICES=$1
+        export GLOO_SOCKET_IFNAME=$nic_name
         export PYTORCH_NPU_ALLOC_CONF=expandable_segments:True
-        export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/local/lib
+        export PROMETHEUS_MULTIPROC_DIR=/dev/shm/vllm_metrics && mkdir -p $PROMETHEUS_MULTIPROC_DIR
+        export HCCL_DFS_CONFIG="task_exception:off,inconsistent_check:off"
+        export HCCL_ALGO=level0:fullmesh
+        export ASCEND_LOCAL_COMM_RES='{"version":"1.3"}'
 
-        vllm serve /root/.cache/modelscope/hub/models/vllm-ascend/GLM5-w8a8 \
+        vllm serve /root/.cache/modelscope/hub/models/vllm-ascend/GLM5-w4a4 \
             --host 0.0.0.0 \
             --port $2 \
             --data-parallel-size $3 \
-            --data-parallel-rank $4 \
-            --data-parallel-address $5 \
-            --data-parallel-rpc-port $6 \
             --tensor-parallel-size $7 \
-            --enable-expert-parallel \
-            --speculative-config '{"num_speculative_tokens": 1, "method":"deepseek_mtp", "enforce_eager": true}' \
-            --seed 1024 \
+            --max-model-len 135000 \
+            --max-num-batched-tokens 8192 \
             --served-model-name glm-5 \
-            --max-model-len 131072 \
-            --additional-config '{"enable_dsa_cp": true,"enable_fused_mc2":1}' \
-            --max-num-batched-tokens 4096 \
-            --trust-remote-code \
-            --max-num-seqs 64 \
-            --enable-chunked-prefill \
             --gpu-memory-utilization 0.95 \
-            --quantization ascend \
+            --enable-expert-parallel \
+            --max-num-seqs 8 \
+            --enable-prefix-caching \
+            --trust-remote-code \
             --enforce-eager \
+            --quantization ascend \
             --enable-auto-tool-choice \
             --tool-call-parser glm47 \
             --reasoning-parser glm45 \
+            --speculative-config '{"num_speculative_tokens": 1, "method": "deepseek_mtp", "enforce_eager": true}' \
+            --hf-overrides '{"use_index_cache": true, "index_topk_freq": 4}' \
             --kv-transfer-config \
             '{"kv_connector": "MooncakeConnectorV1",
             "kv_role": "kv_producer",
-            "kv_port": "30000",
+            "kv_port": "30100",
+            "engine_id": "1",
             "kv_connector_extra_config": {
-                        "use_ascend_direct": true,
                         "prefill": {
-                                "dp_size": 2,
-                                "tp_size": 16
+                                "dp_size": 1,
+                                "tp_size": 8
                         },
                         "decode": {
                                 "dp_size": 16,
-                                "tp_size": 4
-                        }
+                                "tp_size": 1
+                        },
+                        "ascend_local_comm_res_path": "/etc/hixlep"
                 }
-            }'
+            }' \
+            --additional-config '{"enable_cpu_binding": "True", "multistream_overlap_shared_expert": "True", "recompute_scheduler_enable": "True", "enable_sparse_c8": "True", "enable_dsa_cp": true, "enable_flashcomm1": true}'
         ```
 
     3. Decode node 0
 
         ```shell
-        nic_name="xxxx" # change to your own nic name
-        local_ip="xxxx" # change to your own ip
+        #!/usr/bin/env bash
+        source /root/.bashrc
+        # this obtained through ifconfig
+        # nic_name is the network interface name corresponding to local_ip of the current node
+        nic_name="xxx"
+        local_ip="xxx"
 
-        export HCCL_OP_EXPANSION_MODE="AIV"
+        export VLLM_EXECUTE_MODEL_TIMEOUT_SECONDS=30000
+        export HCCL_BUFFSIZE=1200
         export HCCL_IF_IP=$local_ip
-        export GLOO_SOCKET_IFNAME=$nic_name
-        export TP_SOCKET_IFNAME=$nic_name
         export HCCL_SOCKET_IFNAME=$nic_name
-        #Mooncake
-        export OMP_PROC_BIND=false
-        export OMP_NUM_THREADS=1
-        export PYTORCH_NPU_ALLOC_CONF=expandable_segments:True
-        export HCCL_BUFFSIZE=256
-        export ASCEND_AGGREGATE_ENABLE=1
-        export ASCEND_TRANSPORT_PRINT=1
-        export ACL_OP_INIT_MODE=1
-        export ASCEND_A3_ENABLE=1
-        # Timeout (in seconds) for automatically releasing the prefiller’s KV cache for a particular request.
-        export VLLM_MOONCAKE_ABORT_REQUEST_TIMEOUT=480
-        export TASK_QUEUE_ENABLE=1
         export ASCEND_RT_VISIBLE_DEVICES=$1
-        export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/local/lib
+        export GLOO_SOCKET_IFNAME=$nic_name
+        export PYTORCH_NPU_ALLOC_CONF=expandable_segments:True
+        export PROMETHEUS_MULTIPROC_DIR=/dev/shm/vllm_metrics && mkdir -p $PROMETHEUS_MULTIPROC_DIR
+        export HCCL_DFS_CONFIG="task_exception:off,inconsistent_check:off"
+        export HCCL_ALGO=level0:fullmesh
+        export ASCEND_LOCAL_COMM_RES='{"version":"1.3"}'
 
-        vllm serve /root/.cache/modelscope/hub/models/vllm-ascend/GLM5-w8a8 \
+        vllm serve /root/.cache/modelscope/hub/models/vllm-ascend/GLM5-w4a4 \
             --host 0.0.0.0 \
             --port $2 \
             --data-parallel-size $3 \
@@ -907,239 +804,105 @@ Before you start, please
             --data-parallel-address $5 \
             --data-parallel-rpc-port $6 \
             --tensor-parallel-size $7 \
-            --enable-expert-parallel \
-            --speculative-config '{"num_speculative_tokens": 3,  "method":"deepseek_mtp", "enforce_eager": true}' \
-            --seed 1024 \
+            --max-model-len 135000 \
+            --max-num-batched-tokens 240 \
             --served-model-name glm-5 \
-            --max-model-len 200000 \
-            --max-num-batched-tokens 32 \
-            --compilation-config '{"cudagraph_mode":"FULL_DECODE_ONLY"}' \
-            --additional-config '{"recompute_scheduler_enable": true,"enable_fused_mc2":1,"enable_mlapo":true}' \
+            --gpu-memory-utilization 0.95 \
+            --enable-expert-parallel \
+            --max-num-seqs 60 \
+            --enable-prefix-caching \
             --trust-remote-code \
-            --max-num-seqs 8 \
-            --gpu-memory-utilization 0.92 \
             --quantization ascend \
             --enable-auto-tool-choice \
             --tool-call-parser glm47 \
             --reasoning-parser glm45 \
+            --compilation-config '{"cudagraph_mode":"FULL_DECODE_ONLY"}' \
+            --speculative-config '{"num_speculative_tokens": 3, "method": "deepseek_mtp", "enforce_eager": true}' \
+            --hf-overrides '{"use_index_cache": true, "index_topk_freq": 4}' \
             --kv-transfer-config \
             '{"kv_connector": "MooncakeConnectorV1",
             "kv_role": "kv_consumer",
-            "kv_port": "30100",
+            "kv_port": "30300",
+            "engine_id": "3",
             "kv_connector_extra_config": {
-                        "use_ascend_direct": true,
                         "prefill": {
-                                "dp_size": 2,
-                                "tp_size": 16
+                                "dp_size": 1,
+                                "tp_size": 8
                         },
                         "decode": {
                                 "dp_size": 16,
-                                "tp_size": 4
-                        }
+                                "tp_size": 1
+                        },
+                        "ascend_local_comm_res_path": "/etc/hixlep"
                 }
-            }'
+            }' \
+            --additional-config '{"enable_cpu_binding": "True", "multistream_overlap_shared_expert": "True", "recompute_scheduler_enable": "True", "enable_sparse_c8": "True", "finegrained_tp_config": {"lmhead_tensor_parallel_size":8}}'
         ```
 
     4. Decode node 1
 
-         ```shell
-         nic_name="xxxx" # change to your own nic name
-         local_ip="xxxx" # change to your own ip
+        ```shell
+        #!/usr/bin/env bash
+        source /root/.bashrc
+        # this obtained through ifconfig
+        # nic_name is the network interface name corresponding to local_ip of the current node
+        nic_name="xxx"
+        local_ip="xxx"
 
-         export HCCL_OP_EXPANSION_MODE="AIV"
-         export HCCL_IF_IP=$local_ip
-         export GLOO_SOCKET_IFNAME=$nic_name
-         export TP_SOCKET_IFNAME=$nic_name
-         export HCCL_SOCKET_IFNAME=$nic_name
-         #Mooncake
-         export OMP_PROC_BIND=false
-         export OMP_NUM_THREADS=1
-         export PYTORCH_NPU_ALLOC_CONF=expandable_segments:True
-         export HCCL_BUFFSIZE=256
-         export ASCEND_AGGREGATE_ENABLE=1
-         export ASCEND_TRANSPORT_PRINT=1
-         export ACL_OP_INIT_MODE=1
-         export ASCEND_A3_ENABLE=1
-         # Timeout (in seconds) for automatically releasing the prefiller’s KV cache for a particular request.
-         export VLLM_MOONCAKE_ABORT_REQUEST_TIMEOUT=480
-         export TASK_QUEUE_ENABLE=1
-         export ASCEND_RT_VISIBLE_DEVICES=$1
-         export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/local/lib
+        export VLLM_EXECUTE_MODEL_TIMEOUT_SECONDS=30000
+        export HCCL_BUFFSIZE=1200
+        export HCCL_IF_IP=$local_ip
+        export HCCL_SOCKET_IFNAME=$nic_name
+        export ASCEND_RT_VISIBLE_DEVICES=$1
+        export GLOO_SOCKET_IFNAME=$nic_name
+        export PYTORCH_NPU_ALLOC_CONF=expandable_segments:True
+        export PROMETHEUS_MULTIPROC_DIR=/dev/shm/vllm_metrics && mkdir -p $PROMETHEUS_MULTIPROC_DIR
+        export HCCL_DFS_CONFIG="task_exception:off,inconsistent_check:off"
+        export HCCL_ALGO=level0:fullmesh
+        export ASCEND_LOCAL_COMM_RES='{"version":"1.3"}'
 
-         vllm serve /root/.cache/modelscope/hub/models/vllm-ascend/GLM5-w8a8 \
-             --host 0.0.0.0 \
-             --port $2 \
-             --data-parallel-size $3 \
-             --data-parallel-rank $4 \
-             --data-parallel-address $5 \
-             --data-parallel-rpc-port $6 \
-             --tensor-parallel-size $7 \
-             --enable-expert-parallel \
-             --speculative-config '{"num_speculative_tokens": 3,  "method":"deepseek_mtp", "enforce_eager": true}' \
-             --seed 1024 \
-             --served-model-name glm-5 \
-             --max-model-len 200000 \
-             --max-num-batched-tokens 32 \
-             --compilation-config '{"cudagraph_mode":"FULL_DECODE_ONLY"}' \
-             --additional-config '{"recompute_scheduler_enable": true,"enable_fused_mc2":1,"enable_mlapo":true}' \
-             --trust-remote-code \
-             --max-num-seqs 8 \
-             --gpu-memory-utilization 0.92 \
-             --quantization ascend \
-             --enable-auto-tool-choice \
-             --tool-call-parser glm47 \
-             --reasoning-parser glm45 \
-             --kv-transfer-config \
-             '{"kv_connector": "MooncakeConnectorV1",
-             "kv_role": "kv_consumer",
-             "kv_port": "30100",
-             "kv_connector_extra_config": {
-                         "use_ascend_direct": true,
-                         "prefill": {
-                                 "dp_size": 2,
-                                 "tp_size": 16
-                         },
-                         "decode": {
-                                 "dp_size": 16,
-                                 "tp_size": 4
-                         }
-                 }
-             }'
-         ```
-
-    5. Decode node 2
-
-         ```shell
-         nic_name="xxxx" # change to your own nic name
-         local_ip="xxxx" # change to your own ip
-
-         export HCCL_OP_EXPANSION_MODE="AIV"
-         export HCCL_IF_IP=$local_ip
-         export GLOO_SOCKET_IFNAME=$nic_name
-         export TP_SOCKET_IFNAME=$nic_name
-         export HCCL_SOCKET_IFNAME=$nic_name
-         #Mooncake
-         export OMP_PROC_BIND=false
-         export OMP_NUM_THREADS=1
-         export PYTORCH_NPU_ALLOC_CONF=expandable_segments:True
-         export HCCL_BUFFSIZE=256
-         export ASCEND_AGGREGATE_ENABLE=1
-         export ASCEND_TRANSPORT_PRINT=1
-         export ACL_OP_INIT_MODE=1
-         export ASCEND_A3_ENABLE=1
-         # Timeout (in seconds) for automatically releasing the prefiller’s KV cache for a particular request.
-         export VLLM_MOONCAKE_ABORT_REQUEST_TIMEOUT=480
-         export TASK_QUEUE_ENABLE=1
-         export ASCEND_RT_VISIBLE_DEVICES=$1
-         export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/local/lib
-
-         vllm serve /root/.cache/modelscope/hub/models/vllm-ascend/GLM5-w8a8 \
-             --host 0.0.0.0 \
-             --port $2 \
-             --data-parallel-size $3 \
-             --data-parallel-rank $4 \
-             --data-parallel-address $5 \
-             --data-parallel-rpc-port $6 \
-             --tensor-parallel-size $7 \
-             --enable-expert-parallel \
-             --speculative-config '{"num_speculative_tokens": 3,  "method":"deepseek_mtp", "enforce_eager": true}' \
-             --seed 1024 \
-             --served-model-name glm-5 \
-             --max-model-len 200000 \
-             --max-num-batched-tokens 32 \
-             --compilation-config '{"cudagraph_mode":"FULL_DECODE_ONLY"}' \
-             --additional-config '{"recompute_scheduler_enable": true,"enable_fused_mc2":1,"enable_mlapo":true}' \
-             --trust-remote-code \
-             --max-num-seqs 8 \
-             --gpu-memory-utilization 0.92 \
-             --quantization ascend \
-             --enable-auto-tool-choice \
-             --tool-call-parser glm47 \
-             --reasoning-parser glm45 \
-             --kv-transfer-config \
-             '{"kv_connector": "MooncakeConnectorV1",
-             "kv_role": "kv_consumer",
-             "kv_port": "30100",
-             "kv_connector_extra_config": {
-                         "use_ascend_direct": true,
-                         "prefill": {
-                                 "dp_size": 2,
-                                 "tp_size": 16
-                         },
-                         "decode": {
-                                 "dp_size": 16,
-                                 "tp_size": 4
-                         }
-                 }
-             }'
-         ```
-
-    6. Decode node 3
-
-         ```shell
-         nic_name="xxxx" # change to your own nic name
-         local_ip="xxxx" # change to your own ip
-
-         export HCCL_OP_EXPANSION_MODE="AIV"
-         export HCCL_IF_IP=$local_ip
-         export GLOO_SOCKET_IFNAME=$nic_name
-         export TP_SOCKET_IFNAME=$nic_name
-         export HCCL_SOCKET_IFNAME=$nic_name
-         #Mooncake
-         export OMP_PROC_BIND=false
-         export OMP_NUM_THREADS=1
-         export PYTORCH_NPU_ALLOC_CONF=expandable_segments:True
-         export HCCL_BUFFSIZE=256
-         export ASCEND_AGGREGATE_ENABLE=1
-         export ASCEND_TRANSPORT_PRINT=1
-         export ACL_OP_INIT_MODE=1
-         export ASCEND_A3_ENABLE=1
-         # Timeout (in seconds) for automatically releasing the prefiller’s KV cache for a particular request.
-         export VLLM_MOONCAKE_ABORT_REQUEST_TIMEOUT=480
-         export TASK_QUEUE_ENABLE=1
-         export ASCEND_RT_VISIBLE_DEVICES=$1
-         export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/local/lib
-
-         vllm serve /root/.cache/modelscope/hub/models/vllm-ascend/GLM5-w8a8 \
-             --host 0.0.0.0 \
-             --port $2 \
-             --data-parallel-size $3 \
-             --data-parallel-rank $4 \
-             --data-parallel-address $5 \
-             --data-parallel-rpc-port $6 \
-             --tensor-parallel-size $7 \
-             --enable-expert-parallel \
-             --speculative-config '{"num_speculative_tokens": 3,  "method":"deepseek_mtp", "enforce_eager": true}' \
-             --seed 1024 \
-             --served-model-name glm-5 \
-             --max-model-len 200000 \
-             --max-num-batched-tokens 32 \
-             --compilation-config '{"cudagraph_mode":"FULL_DECODE_ONLY"}' \
-             --additional-config '{"recompute_scheduler_enable": true,"enable_fused_mc2":1,"enable_mlapo":true}' \
-             --trust-remote-code \
-             --max-num-seqs 8 \
-             --gpu-memory-utilization 0.92 \
-             --quantization ascend \
-             --enable-auto-tool-choice \
-             --tool-call-parser glm47 \
-             --reasoning-parser glm45 \
-             --kv-transfer-config \
-             '{"kv_connector": "MooncakeConnectorV1",
-             "kv_role": "kv_consumer",
-             "kv_port": "30100",
-             "kv_connector_extra_config": {
-                         "use_ascend_direct": true,
-                         "prefill": {
-                                 "dp_size": 2,
-                                 "tp_size": 16
-                         },
-                         "decode": {
-                                 "dp_size": 16,
-                                 "tp_size": 4
-                         }
-                 }
-             }'
-         ```
+        vllm serve /root/.cache/modelscope/hub/models/vllm-ascend/GLM5-w4a4 \
+            --host 0.0.0.0 \
+            --port $2 \
+            --data-parallel-size $3 \
+            --data-parallel-rank $4 \
+            --data-parallel-address $5 \
+            --data-parallel-rpc-port $6 \
+            --tensor-parallel-size $7 \
+            --max-model-len 202752 \
+            --max-num-batched-tokens 240 \
+            --served-model-name glm-5 \
+            --gpu-memory-utilization 0.95 \
+            --enable-expert-parallel \
+            --max-num-seqs 60 \
+            --enable-prefix-caching \
+            --trust-remote-code \
+            --quantization ascend \
+            --enable-auto-tool-choice \
+            --tool-call-parser glm47 \
+            --reasoning-parser glm45 \
+            --compilation-config '{"cudagraph_mode":"FULL_DECODE_ONLY"}' \
+            --speculative-config '{"num_speculative_tokens": 3, "method": "deepseek_mtp", "enforce_eager": true}' \
+            --hf-overrides '{"use_index_cache": true, "index_topk_freq": 4}' \
+            --kv-transfer-config \
+            '{"kv_connector": "MooncakeConnectorV1",
+            "kv_role": "kv_consumer",
+            "kv_port": "30300",
+            "engine_id": "3",
+            "kv_connector_extra_config": {
+                        "prefill": {
+                                "dp_size": 1,
+                                "tp_size": 8
+                        },
+                        "decode": {
+                                "dp_size": 16,
+                                "tp_size": 1
+                        },
+                        "ascend_local_comm_res_path": "/etc/hixlep"
+                }
+            }' \
+            --additional-config '{"enable_cpu_binding": "True", "multistream_overlap_shared_expert": "True", "recompute_scheduler_enable": "True", "enable_sparse_c8": "True", "finegrained_tp_config": {"lmhead_tensor_parallel_size":8}}'
+        ```
 
 Once the preparation is done, you can start the server with the following command on each node:
 
@@ -1147,47 +910,392 @@ Once the preparation is done, you can start the server with the following comman
 
     ```shell
     # change ip to your own
-    python launch_online_dp.py --dp-size 2 --tp-size 16 --dp-size-local 1 --dp-rank-start 0 --dp-address $node_p0_ip --dp-rpc-port 10521 --vllm-start-port 6700
+    python launch_online_dp.py --dp-size 1 --tp-size 8 --dp-size-local 1 --dp-rank-start 0 --dp-address $node_p0_ip --dp-rpc-port 10521 --vllm-start-port 6700
     ```
 
 2. Prefill node 1
 
     ```shell
     # change ip to your own
-    python launch_online_dp.py --dp-size 2 --tp-size 16 --dp-size-local 1 --dp-rank-start 1 --dp-address $node_p0_ip --dp-rpc-port 10521 --vllm-start-port 6700
+    python launch_online_dp.py --dp-size 1 --tp-size 8 --dp-size-local 1 --dp-rank-start 0 --dp-address $node_p1_ip --dp-rpc-port 10521 --vllm-start-port 6700
     ```
 
 3. Decode node 0
 
     ```shell
     # change ip to your own
-    python launch_online_dp.py --dp-size 16 --tp-size 4 --dp-size-local 4 --dp-rank-start 0 --dp-address $node_d0_ip --dp-rpc-port 10523 --vllm-start-port 6721
+    python launch_online_dp.py --dp-size 16 --tp-size 1 --dp-size-local 8 --dp-rank-start 0 --dp-address $node_d0_ip --dp-rpc-port 10523 --vllm-start-port 6721
     ```
 
 4. Decode node 1
 
     ```shell
     # change ip to your own
-    python launch_online_dp.py --dp-size 16 --tp-size 4 --dp-size-local 4 --dp-rank-start 4 --dp-address $node_d0_ip --dp-rpc-port 10523 --vllm-start-port 6721
+    python launch_online_dp.py --dp-size 16 --tp-size 1 --dp-size-local 8 --dp-rank-start 8 --dp-address $node_d0_ip --dp-rpc-port 10523 --vllm-start-port 6721
     ```
 
-5. Decode node 2
+#### 5.3.2 Prefill-Decode Disaggregation (A3 series)
+
+The high-throughput (198K context) scenario is validated on 4 Atlas 800 A3 (128GB × 8): 2 prefill nodes (`PP2 TP16`, 78 layers partitioned as `41/37`, one PP rank per node) and 2 decode nodes (`DP8 TP4`, 4 DP ranks per node). The same scripts serve both the high-throughput and low-latency cases.
+
+Before you start, please
+
+prepare the script `launch_online_dp.py` on each node:
+
+```python
+import argparse
+import multiprocessing
+import os
+import subprocess
+import sys
+
+def parse_args():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--dp-size", type=int, required=True, help="Data parallel size.")
+    parser.add_argument("--tp-size", type=int, default=1, help="Tensor parallel size.")
+    parser.add_argument("--pp-size", type=int, default=1, help="Pipeline parallel size.")
+    parser.add_argument("--dp-size-local", type=int, default=-1, help="Local data parallel size.")
+    parser.add_argument("--dp-rank-start", type=int, default=0, help="Starting rank for data parallel.")
+    parser.add_argument("--dp-address", type=str, required=True, help="IP address for data parallel master node.")
+    parser.add_argument("--dp-rpc-port", type=str, default="12321", help="Port for data parallel master node.")
+    parser.add_argument("--vllm-start-port", type=int, default=8000, help="Starting port for the engine.")
+    return parser.parse_args()
+
+args = parse_args()
+dp_size = args.dp_size
+tp_size = args.tp_size
+pp_size = args.pp_size
+dp_size_local = args.dp_size_local
+if dp_size_local == -1:
+    dp_size_local = dp_size
+dp_rank_start = args.dp_rank_start
+dp_address = args.dp_address
+dp_rpc_port = args.dp_rpc_port
+vllm_start_port = args.vllm_start_port
+# 一个 DP 副本占 tp×pp 张连续卡（pp=1 时退化为现状的 tp）
+gpus_per_dp_rank = tp_size * pp_size
+
+def run_command(visible_devices, dp_rank, vllm_engine_port):
+    command = [
+        "bash",
+        "./run_dp_template.sh",
+        visible_devices,
+        str(vllm_engine_port),
+        str(dp_size),
+        str(dp_rank),
+        dp_address,
+        dp_rpc_port,
+        str(tp_size),
+        str(pp_size),
+    ]
+    subprocess.run(command, check=True)
+
+if __name__ == "__main__":
+    template_path = "./run_dp_template.sh"
+    if not os.path.exists(template_path):
+        print(f"Template file {template_path} does not exist.")
+        sys.exit(1)
+
+    processes = []
+    num_cards = dp_size_local * gpus_per_dp_rank
+
+    for i in range(dp_size_local):
+        dp_rank = dp_rank_start + i
+        vllm_engine_port = vllm_start_port + i
+        visible_devices = ",".join(str(x) for x in range(i * gpus_per_dp_rank, (i + 1) * gpus_per_dp_rank))
+        process = multiprocessing.Process(
+            target=run_command,
+            args=(visible_devices, dp_rank, vllm_engine_port)
+        )
+        processes.append(process)
+        process.start()
+
+    for process in processes:
+        process.join()
+```
+
+1. prepare the script `run_dp_template.sh` on each node.
+
+    1. Prefill node 0
+
+        The prefill script selects the node via `node_rank`: set `node_rank=0` on prefill node 0 (PP master node, engine port `9081`) and `node_rank=1` on prefill node 1 (non-master node, `--headless`, no API server).
+
+        ```shell
+        nic_name="xxxx" # change to your own nic name
+        local_ip="xxxx" # change to your own ip
+        # pp=2
+        # prefill node 0: node_rank=0, prefill node 1: node_rank=1
+        node_rank=0
+
+        export VLLM_PP_LAYER_PARTITION="41,37"
+        export HCCL_BUFFSIZE=400
+        export HCCL_IF_IP=$local_ip
+        export HCCL_OP_EXPANSION_MODE="AIV"
+        export HCCL_SOCKET_IFNAME=$nic_name
+        export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/local/lib
+        export GLOO_SOCKET_IFNAME=$nic_name
+        export PYTORCH_NPU_ALLOC_CONF=expandable_segments:True
+
+        vllm serve /root/.cache/modelscope/hub/models/vllm-ascend/GLM-5.1-W8A8C8-MTP \
+            --host 0.0.0.0 \
+            --port 9081 \
+            --pipeline-parallel-size 2 \
+            --distributed-executor-backend mp \
+            --master-addr $local_ip \
+            --master-port 7060 \
+            --nnodes 2 \
+            --node-rank $node_rank \
+            --tensor-parallel-size 16 \
+            --enable-expert-parallel \
+            --speculative-config '{"num_speculative_tokens": 1, "method":"deepseek_mtp","enforce_eager":true}' \
+            --seed 1024 \
+            --served-model-name glm-5 \
+            --max-model-len 202752 \
+            --additional-config '{"fuse_muls_add": true, "recompute_scheduler_enable": false, "multistream_overlap_shared_expert": true, "enable_dsa_cp": true, "enable_sparse_sfa_c8": true, "enable_sparse_li_c8": true, "c8_enable_reshape_optim": true, "enable_flashcomm1": true, "enable_fused_mc2": true}' \
+            --max-num-batched-tokens 16384 \
+            --trust-remote-code \
+            --enable-prefix-caching \
+            --max-num-seqs 64 \
+            --quantization ascend \
+            --gpu-memory-utilization 0.92 \
+            --hf-overrides '{"use_index_cache": true, "index_topk_freq": 4}' \
+            --enforce-eager \
+            --enable-auto-tool-choice \
+            --tool-call-parser glm47 \
+            --reasoning-parser glm45 \
+            --kv-transfer-config \
+            '{"kv_connector": "MooncakeConnectorV1",
+            "kv_role": "kv_producer",
+            "kv_port": "30000",
+            "engine_id": "0",
+            "kv_connector_extra_config": {
+                "use_ascend_direct": true,
+                "prefill": {"dp_size": 1, "pp_size": 2, "tp_size": 16, "pp_layer_partition": "41,37"},
+                "decode": {"dp_size": 8, "tp_size": 4}
+            }
+        }'
+        ```
+
+    2. Prefill node 1
+
+        ```shell
+        nic_name="xxxx" # change to your own nic name
+        local_ip="xxxx" # change to your own ip
+        # IP of prefill node 0 (the PP master node), must be consistent with the local_ip of prefill node 0
+        node_p0_ip="xxxx"
+        # pp=2
+        # prefill node 0: node_rank=0, prefill node 1: node_rank=1
+        node_rank=1
+
+        export VLLM_PP_LAYER_PARTITION="41,37"
+        export HCCL_BUFFSIZE=400
+        export HCCL_IF_IP=$local_ip
+        export HCCL_OP_EXPANSION_MODE="AIV"
+        export HCCL_SOCKET_IFNAME=$nic_name
+        export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/local/lib
+        export GLOO_SOCKET_IFNAME=$nic_name
+        export PYTORCH_NPU_ALLOC_CONF=expandable_segments:True
+
+        vllm serve /root/.cache/modelscope/hub/models/vllm-ascend/GLM-5.1-W8A8C8-MTP \
+            --host 0.0.0.0 \
+            --pipeline-parallel-size 2 \
+            --distributed-executor-backend mp \
+            --master-addr $node_p0_ip \
+            --master-port 7060 \
+            --nnodes 2 \
+            --node-rank $node_rank \
+            --headless \
+            --tensor-parallel-size 16 \
+            --enable-expert-parallel \
+            --speculative-config '{"num_speculative_tokens": 1, "method":"deepseek_mtp","enforce_eager":true}' \
+            --seed 1024 \
+            --served-model-name glm-5 \
+            --max-model-len 202752 \
+            --additional-config '{"fuse_muls_add": true, "recompute_scheduler_enable": false, "multistream_overlap_shared_expert": true, "enable_dsa_cp": true, "enable_sparse_sfa_c8": true, "enable_sparse_li_c8": true, "c8_enable_reshape_optim": true, "enable_flashcomm1": true, "enable_fused_mc2": true}' \
+            --max-num-batched-tokens 16384 \
+            --trust-remote-code \
+            --enable-prefix-caching \
+            --max-num-seqs 64 \
+            --quantization ascend \
+            --gpu-memory-utilization 0.92 \
+            --hf-overrides '{"use_index_cache": true, "index_topk_freq": 4}' \
+            --enforce-eager \
+            --enable-auto-tool-choice \
+            --tool-call-parser glm47 \
+            --reasoning-parser glm45 \
+            --kv-transfer-config \
+            '{"kv_connector": "MooncakeConnectorV1",
+            "kv_role": "kv_producer",
+            "kv_port": "30000",
+            "engine_id": "0",
+            "kv_connector_extra_config": {
+                "use_ascend_direct": true,
+                "prefill": {"dp_size": 1, "pp_size": 2, "tp_size": 16, "pp_layer_partition": "41,37"},
+                "decode": {"dp_size": 8, "tp_size": 4}
+            }
+        }'
+        ```
+
+    3. Decode node 0 (ranks 0–3)
+
+        Launch one instance per DP rank via positional parameters: `$1` = visible devices, `$2` = engine port, `$3` = data-parallel-size, `$4` = data-parallel-rank, `$5` = data-parallel-address, `$6` = data-parallel-rpc-port, `$7` = tensor-parallel-size. Prepare `run_dp_template.sh` on decode node 0 with the content below.
+
+        ```shell
+        nic_name="xxxx" # change to your own nic name
+        local_ip="xxxx" # change to your own ip
+
+        # 每个 DP rank 使用独立的 engine_id,避免 KV 路由混淆
+        # $4 = data-parallel-rank; 节点内 rank 偏移 0-3 → engine_id 100-103
+        ENGINE_ID=$((100 + $4))
+
+        #Mooncake
+
+        export HCCL_BUFFSIZE=256
+        export HCCL_IF_IP=$local_ip
+        export HCCL_OP_EXPANSION_MODE="AIV"
+        export HCCL_SOCKET_IFNAME=$nic_name
+        export ASCEND_RT_VISIBLE_DEVICES=$1
+        export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/local/lib
+        export GLOO_SOCKET_IFNAME=$nic_name
+        export PYTORCH_NPU_ALLOC_CONF=expandable_segments:True
+
+        vllm serve /root/.cache/modelscope/hub/models/vllm-ascend/GLM-5.1-W8A8C8-MTP \
+            --host 0.0.0.0 \
+            --port $2 \
+            --data-parallel-size $3 \
+            --data-parallel-rank $4 \
+            --data-parallel-address $5 \
+            --data-parallel-rpc-port $6 \
+            --tensor-parallel-size $7 \
+            --enable-expert-parallel \
+            --speculative-config '{"num_speculative_tokens": 3,  "method":"deepseek_mtp","enforce_eager":true}' \
+            --seed 1024 \
+            --served-model-name glm-5 \
+            --max-model-len 202752 \
+            --max-num-batched-tokens 164 \
+            --compilation-config '{"cudagraph_mode":"FULL_DECODE_ONLY"}' \
+            --additional-config '{"fuse_muls_add": true, "recompute_scheduler_enable": true, "multistream_overlap_shared_expert": true, "enable_sparse_sfa_c8": true, "enable_sparse_li_c8": true, "enable_fused_mc2": true, "enable_mlapo": true}' \
+            --trust-remote-code \
+            --max-num-seqs 32 \
+            --gpu-memory-utilization 0.92 \
+            --hf-overrides '{"use_index_cache": true, "index_topk_freq": 4}' \
+            --async-scheduling \
+            --quantization ascend \
+            --enable-auto-tool-choice \
+            --tool-call-parser glm47 \
+            --reasoning-parser glm45 \
+            --kv-transfer-config \
+            '{"kv_connector": "MooncakeConnectorV1",
+            "kv_role": "kv_consumer",
+            "kv_port": "30200",
+            "engine_id": "'"$ENGINE_ID"'",
+            "kv_connector_extra_config": {
+                "use_ascend_direct": true,
+                "prefill": {"dp_size": 1, "pp_size": 2, "tp_size": 16, "pp_layer_partition": "41,37"},
+                "decode": {"dp_size": 8, "tp_size": 4}
+            }
+        }'
+        ```
+
+    4. Decode node 1 (ranks 4–7)
+
+        Prepare `run_dp_template.sh` on decode node 1 with the content below.
+
+        ```shell
+        nic_name="xxxx" # change to your own nic name
+        local_ip="xxxx" # change to your own ip
+
+        # 每个 DP rank 使用独立的 engine_id,避免 KV 路由混淆
+        # $4 = data-parallel-rank; 节点内 rank 偏移 0-3 → engine_id 100-103
+        ENGINE_ID=$((100 + $4))
+
+        #Mooncake
+
+        export HCCL_BUFFSIZE=256
+        export HCCL_IF_IP=$local_ip
+        export HCCL_OP_EXPANSION_MODE="AIV"
+        export HCCL_SOCKET_IFNAME=$nic_name
+        export ASCEND_RT_VISIBLE_DEVICES=$1
+        export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/local/lib
+        export GLOO_SOCKET_IFNAME=$nic_name
+        export PYTORCH_NPU_ALLOC_CONF=expandable_segments:True
+
+        vllm serve /root/.cache/modelscope/hub/models/vllm-ascend/GLM-5.1-W8A8C8-MTP \
+            --host 0.0.0.0 \
+            --port $2 \
+            --data-parallel-size $3 \
+            --data-parallel-rank $4 \
+            --data-parallel-address $5 \
+            --data-parallel-rpc-port $6 \
+            --tensor-parallel-size $7 \
+            --enable-expert-parallel \
+            --speculative-config '{"num_speculative_tokens": 3,  "method":"deepseek_mtp","enforce_eager":true}' \
+            --seed 1024 \
+            --served-model-name glm-5 \
+            --max-model-len 202752 \
+            --max-num-batched-tokens 164 \
+            --compilation-config '{"cudagraph_mode":"FULL_DECODE_ONLY"}' \
+            --additional-config '{"fuse_muls_add": true, "recompute_scheduler_enable": true, "multistream_overlap_shared_expert": true, "enable_sparse_sfa_c8": true, "enable_sparse_li_c8": true, "enable_fused_mc2": true, "enable_mlapo": true}' \
+            --trust-remote-code \
+            --max-num-seqs 32 \
+            --gpu-memory-utilization 0.92 \
+            --hf-overrides '{"use_index_cache": true, "index_topk_freq": 4}' \
+            --async-scheduling \
+            --quantization ascend \
+            --enable-auto-tool-choice \
+            --tool-call-parser glm47 \
+            --reasoning-parser glm45 \
+            --kv-transfer-config \
+            '{"kv_connector": "MooncakeConnectorV1",
+            "kv_role": "kv_consumer",
+            "kv_port": "30200",
+            "engine_id": "'"$ENGINE_ID"'",
+            "kv_connector_extra_config": {
+                "use_ascend_direct": true,
+                "prefill": {"dp_size": 1, "pp_size": 2, "tp_size": 16, "pp_layer_partition": "41,37"},
+                "decode": {"dp_size": 8, "tp_size": 4}
+            }
+        }'
+        ```
+
+Once the preparation is done, you can start the server with the following command on each node:
+
+1. Prefill node 0
+
+    ```shell
+    bash run_dp_template.sh
+    ```
+
+2. Prefill node 1
+
+    ```shell
+    bash run_dp_template.sh
+    ```
+
+3. Decode node 0
 
     ```shell
     # change ip to your own
-    python launch_online_dp.py --dp-size 16 --tp-size 4 --dp-size-local 4 --dp-rank-start 8 --dp-address $node_d0_ip --dp-rpc-port 10523 --vllm-start-port 6721
+    python launch_online_dp.py --dp-size 8 --tp-size 4 --pp-size 1 --dp-size-local 4 --dp-rank-start 0 --dp-address $node_d0_ip --dp-rpc-port 12321 --vllm-start-port 8000
     ```
 
-6. Decode node 3
+4. Decode node 1
 
     ```shell
     # change ip to your own
-    python launch_online_dp.py --dp-size 16 --tp-size 4 --dp-size-local 4 --dp-rank-start 12 --dp-address $node_d0_ip --dp-rpc-port 10523 --vllm-start-port 6721
+    python launch_online_dp.py --dp-size 8 --tp-size 4 --pp-size 1 --dp-size-local 4 --dp-rank-start 4 --dp-address $node_d0_ip --dp-rpc-port 12321 --vllm-start-port 8000
     ```
 
-### 5.4 Request Forwarding
+**Notice:**
+
+- When testing with a prefix cache hit rate > 0, add `--enable-prefix-caching` on the prefill nodes (as in the scripts above); when the hit rate is 0, use `--no-enable-prefix-caching` instead.
+- `"recompute_scheduler_enable"` is set to `false` on prefill nodes and `true` on decode nodes in this scenario.
+
+#### 5.3.3 Request Forwarding and Key Parameter Descriptions
 
 To set up request forwarding, run the following script on any machine. You can get the proxy program in the repository's examples: [load_balance_proxy_server_example.py](https://github.com/vllm-project/vllm-ascend/blob/main/examples/disaggregated_prefill_v1/load_balance_proxy_server_example.py)
+
+**Ascend950DT series:**
 
 ```shell
 unset http_proxy
@@ -1197,33 +1305,58 @@ python load_balance_proxy_server_example.py \
     --port 8000 \
     --host 0.0.0.0 \
     --prefiller-hosts \
-       $node_p0_ip \
-       $node_p1_ip \
+    $node_p0_ip \
+    $node_p1_ip \
     --prefiller-ports \
-       6700 \
-       6700 \
+    6700 \
+    6700 \
     --decoder-hosts \
-      $node_d0_ip \
-      $node_d0_ip \
-      $node_d0_ip \
-      $node_d0_ip \
-      $node_d1_ip \
-      $node_d1_ip \
-      $node_d1_ip \
-      $node_d1_ip \
-      $node_d2_ip \
-      $node_d2_ip \
-      $node_d2_ip \
-      $node_d2_ip \
-      $node_d3_ip \
-      $node_d3_ip \
-      $node_d3_ip \
-      $node_d3_ip \
+    $node_d0_ip \
+    $node_d0_ip \
+    $node_d0_ip \
+    $node_d0_ip \
+    $node_d0_ip \
+    $node_d0_ip \
+    $node_d0_ip \
+    $node_d0_ip \
+    $node_d1_ip \
+    $node_d1_ip \
+    $node_d1_ip \
+    $node_d1_ip \
+    $node_d1_ip \
+    $node_d1_ip \
+    $node_d1_ip \
+    $node_d1_ip \
     --decoder-ports \
-      6721 6722 6723 6724 \
-      6721 6722 6723 6724 \
-      6721 6722 6723 6724 \
-      6721 6722 6723 6724
+    6721 6722 6723 6724 6725 6726 6727 6728 \
+    6721 6722 6723 6724 6725 6726 6727 6728
+```
+
+**A3 series:**
+
+```shell
+unset http_proxy
+unset https_proxy
+
+python load_balance_proxy_server_example.py \
+    --port 9000 \
+    --host 0.0.0.0 \
+    --prefiller-hosts \
+    $node_p0_ip \
+    --prefiller-ports \
+    9081 \
+    --decoder-hosts \
+    $node_d0_ip \
+    $node_d0_ip \
+    $node_d0_ip \
+    $node_d0_ip \
+    $node_d1_ip \
+    $node_d1_ip \
+    $node_d1_ip \
+    $node_d1_ip \
+    --decoder-ports \
+    8000 8001 8002 8003 \
+    8000 8001 8002 8003
 ```
 
 Key Parameter Descriptions for PD separation deployment:
@@ -1240,27 +1373,24 @@ In addition to the single-node and multi-node parameters described above, the fo
 
 **Prefill node-specific configurations:**
 
-- `additional_config.enable_fused_mc2=1`: Enables fused MC2 operators (`dispatch_ffn_combine`/`mega_moe`) to optimize MoE communication. Constraints: `dispatch_ffn_combine` only for w8a8 and EP≤32; `mega_moe` works for w8a8/w4a8/bf16 with EP≤64. Both are incompatible with MTP and dynamic EPLB.
-- `--additional-config '{"enable_dsa_cp": true}'`: Enables DSA context parallelism on prefill nodes to accelerate long-context prefill. Required for handling prompts up to 128k tokens.
+- `--additional-config '{"enable_fused_mc2": true}'`: Enables fused MC2 operators (`dispatch_ffn_combine`/`mega_moe`) to optimize MoE communication. Constraints: `dispatch_ffn_combine` only for w8a8 and EP≤32; `mega_moe` works for w8a8/w4a8/bf16 with EP≤64. Both are incompatible with MTP and dynamic EPLB.
+- `--additional-config '{"enable_dsa_cp": true}'`: Enables DSA context parallelism on prefill nodes to accelerate long-context prefill. Required for handling prompts up to 128K tokens.
 
 **Decode node-specific configurations:**
 
-- `additional_config.enable_mlapo=true`: Enables MLA preprocess operation fusion on decode nodes to significantly improve decode performance. Consumes more NPU memory. In PD scenarios, enable MLAPO only on decode nodes.
-- `--max-num-batched-tokens 32`: Small batch token limit on decode nodes — decode processes one token per sequence per step, so batch tokens should be close to `max-num-seqs`.
-- `--additional-config '{"recompute_scheduler_enable": true}'`: Enables the recomputation scheduler. When decode node KV cache is insufficient, requests are sent back to prefill nodes for KV cache recomputation. Recommended on both prefill and decode nodes in PD scenarios.
+- `--additional-config '{"enable_mlapo": true}'`: Enables MLA preprocess operation fusion on decode nodes to significantly improve decode performance. Consumes more NPU memory. In PD scenarios, enable MLAPO only on decode nodes.
+- On decode nodes, keep `--max-num-batched-tokens` close to `--max-num-seqs` — decode processes one token per sequence per step (`164` in the A3 scenario, `240` in the Ascend950DT scenario, see the scripts above).
+- `--additional-config '{"recompute_scheduler_enable": true}'`: Enables the recomputation scheduler. When decode node KV cache is insufficient, requests are sent back to prefill nodes for KV cache recomputation. In this deployment: `true` on decode nodes; on prefill nodes `true` in the Ascend950DT scenario and `false` in the A3 scenario (see the scripts above).
 
 **Common PD environment variables:**
 
-- `ASCEND_AGGREGATE_ENABLE=1`, `ASCEND_A3_ENABLE=1`: A3-specific optimizations for communication aggregation.
-- `ACL_OP_INIT_MODE=1`: ACL operator initialization mode.
-- `VLLM_MOONCAKE_ABORT_REQUEST_TIMEOUT=480`: Timeout (in seconds) for automatically releasing the prefill node's KV cache when a request is aborted.
 - `LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/local/lib`: Required for Mooncake library loading.
 
 **MTP in PD scenarios:**
 
-- Prefill nodes typically use `"num_speculative_tokens": 1` for MTP (minimal speculation during prefill).
-- Decode nodes use `"num_speculative_tokens": 3` for MTP to maximize decode throughput.
-- Both prefill and decode nodes must use the same `"method": "deepseek_mtp"` and `"enforce_eager": true`.
+- Prefill nodes use `"num_speculative_tokens": 3` in the A3 scenario and `1` in the Ascend950DT scenario (see the scripts above).
+- Decode nodes use `"num_speculative_tokens": 3` in both scenarios to maximize decode throughput.
+- All prefill and decode nodes must use the same `"method": "deepseek_mtp"` and `"enforce_eager": true`.
 
 For further explanation and restrictions of the environment variables above, refer to: [envs.py](https://github.com/vllm-project/vllm-ascend/blob/main/vllm_ascend/envs.py).
 
@@ -1309,36 +1439,47 @@ Refer to [vllm benchmark](https://docs.vllm.ai/en/latest/benchmarking/) for more
 
 > **Note**: The following configurations are validated in specific test environments and are for reference only. The optimal configuration depends on factors such as maximum input/output length, prefix cache hit rate, precision requirements, and deployment machine ratios. It is recommended to refer to [Tuning Guidelines](#92-tuning-guidelines) for tuning based on actual conditions.
 
-The tables below provide recommended parameter configurations for different deployment scenarios. All scenarios are categorized by use case (High Throughput, Low Latency, Long Context) and correspond to the deployment modes documented in [Online Service Deployment](#5-online-service-deployment).
+The tables below provide recommended parameter configurations for the `GLM-5.1-w8a8c8` quantized model on Atlas 800 A3, covering three deployment scenarios:
 
-#### 9.1.1 Table 1: Scenario Overview
+- **Dual-Node Co-Located 198K High Throughput**: `DP8 TP4`, see [Multi-node Deployment](#52-multi-node-deployment).
+- **Dual-Node Co-Located 198K Low Latency**: `DP2 TP16`, see [Multi-node Deployment](#52-multi-node-deployment).
+- **Prefill-Decode Disaggregation 198K (PP2)**: prefill `PP2 TP16` + decode `DP8 TP4`, see [Prefill-Decode Disaggregation (A3 series)](#532-prefill-decode-disaggregation-a3-series).
+- **Prefill-Decode Disaggregation 198K (Ascend950DT)**: prefill `TP8` (DSA CP 8) + decode `DP16 TP1`, see [Prefill-Decode Disaggregation (Ascend950DT series)](#531-prefill-decode-disaggregation-ascend950dt-series).
 
-> `*Total NPUs` indicates the total number of NPUs used across all nodes. 1 node = 1 Atlas 800 A3 server (64GB × 16 NPUs) or 1 Atlas 800 A2 server (64GB × 8 NPUs).
+Test cases use the notation `input/output`, e.g., `128k/1k` means 128K input tokens and 1K output tokens; `@50%/90%` marks the prefix cache hit rate. When the prefix cache hit rate is > 0, add `--enable-prefix-caching`; when the hit rate is 0, add `--no-enable-prefix-caching` instead (for the PD scenario, this applies to the prefill nodes).
 
-|Scenario|Deployment Mode|*Total NPUs|Weight Version|Key Considerations|
-|--------|---------------|-----------|--------------|------------------|
-|Low Latency<br>(64k input)|PD Disaggregation, [Prefill-Decode Disaggregation](#53-prefill-decode-disaggregation)|4 nodes (A3)|w8a8c8|P: dp4 tp8 (max-num-seqs 64, max-num-batched-tokens 8192); D: dp8 tp4 (max-num-seqs 32, max-num-batched-tokens 164); MTP3, max-model-len 202752, Mooncake KV transfer|
-|Low Latency<br>(128k input)|PD Disaggregation, [Prefill-Decode Disaggregation](#53-prefill-decode-disaggregation)|4 nodes (A3)|w8a8c8|P: dp4 tp8 (max-num-seqs 64, max-num-batched-tokens 8192); D: dp8 tp4 (max-num-seqs 32, max-num-batched-tokens 164); MTP3, max-model-len 202752, Mooncake KV transfer|
-|High Throughput<br>(64k input)|PD Disaggregation, [Prefill-Decode Disaggregation](#53-prefill-decode-disaggregation)|4 nodes (A3)|w8a8c8|P: dp4 tp8 (max-num-seqs 64, max-num-batched-tokens 8192); D: dp8 tp4 (max-num-seqs 32, max-num-batched-tokens 164); MTP3, max-model-len 202752, Mooncake KV transfer|
-|High Throughput<br>(128k input)|PD Disaggregation, [Prefill-Decode Disaggregation](#53-prefill-decode-disaggregation)|4 nodes (A3)|w8a8c8|P: dp4 tp8 (max-num-seqs 64, max-num-batched-tokens 8192); D: dp8 tp4 (max-num-seqs 32, max-num-batched-tokens 164); MTP3, max-model-len 202752, Mooncake KV transfer|
-|Long Context<br>(198k input)|PD Disaggregation, [Prefill-Decode Disaggregation](#53-prefill-decode-disaggregation)|4 nodes (A3)|w8a8c8|P: dp4 tp8 (max-num-seqs 64, max-num-batched-tokens 8192); D: dp8 tp4 (max-num-seqs 32, max-num-batched-tokens 164); MTP3, max-model-len 202752, Mooncake KV transfer|
+#### 9.1.1 Table 1: Detailed Node Configuration
 
-#### 9.1.2 Table 2: Detailed Node Configuration
+> The TP/DP columns show the values **per node** as configured in the Deployment scripts (a co-located node hosting 4 DP ranks of TP4 uses 16 NPUs; a PD prefill node hosting 1 DP rank of TP16 uses 16 NPUs; a PD decode node hosting 4 DP ranks of TP4 uses 16 NPUs; an Ascend950DT node hosting 8 cards). The 198K PD scenario prefill side uses `PP2 TP16` with the layer partition `41,37`. All A3 scenarios use the `GLM-5.1-w8a8c8` weights; the Ascend950DT scenarios use the `GLM-5.1-w4a4` weights.
+>
+> When testing with a prefix cache hit rate > 0, keep `--enable-prefix-caching` (as in the deployment scripts); when the hit rate is 0, replace it with `--no-enable-prefix-caching`.
 
-> The TP/DP columns show the values **per node** as configured in the Deployment scripts (a prefill node hosting 2 DP ranks of TP8 uses 16 NPUs; a decode node hosting 4 DP ranks of TP4 uses 16 NPUs).
+|Scenario|Weight Version|Configuration|NPUs|TP|DP|Max Num Seqs|Max Num Batched Tokens|Max Model Len|MTP Spec Num|
+|--------|--------------|-------------|-----|--|--|------------|----------------------|--------------|-------------|
+|Dual-Node Co-Located 198K High Throughput (A3)|w8a8c8|Dual-Node Co-Located Node (0/1)|16|4|4|6|4096|202752|3|
+|Dual-Node Co-Located 198K Low Latency (A3)|w8a8c8|Dual-Node Co-Located Node (0/1)|16|16|1|16|4096|202752|3|
+|PD 198K High Throughput (A3)|w8a8c8|PD — Server-P Node (PP2)|16|16|1|64|16384|202752|3|
+|PD 198K High Throughput (A3)|w8a8c8|PD — Server-D Node|16|4|4|32|164|202752|3|
+|PD 198K High Throughput (Ascend950DT)|w4a4|PD — Server-P Node (DSA CP 8)|8|8|1|20|8192|202752|3|
+|PD 198K High Throughput (Ascend950DT)|w4a4|PD — Server-D Node|8|1|8|60|240|202752|3|
+|PD 198K Low Latency (Ascend950DT)|w4a4|PD — Server-P Node (DSA CP 8)|8|8|1|20|8192|202752|3|
+|PD 198K Low Latency (Ascend950DT)|w4a4|PD — Server-D Node|8|1|8|60|240|202752|3|
 
-|Scenario|Configuration|NPUs|TP|DP|Max Num Seqs|Max Num Batched Tokens|Max Model Len|MTP Spec Num|
-|--------|-------------|-----|--|--|------------|----------------------|--------------|-------------|
-|Low Latency 64k (A3)|PD — Server-P Node|16|8|2|64|8192|202752|3|
-|Low Latency 64k (A3)|PD — Server-D Node|16|4|4|32|164|202752|3|
-|Low Latency 128k (A3)|PD — Server-P Node|16|8|2|64|8192|202752|3|
-|Low Latency 128k (A3)|PD — Server-D Node|16|4|4|32|164|202752|3|
-|High Throughput 64k (A3)|PD — Server-P Node|16|8|2|64|8192|202752|3|
-|High Throughput 64k (A3)|PD — Server-D Node|16|4|4|32|164|202752|3|
-|High Throughput 128k (A3)|PD — Server-P Node|16|8|2|64|8192|202752|3|
-|High Throughput 128k (A3)|PD — Server-D Node|16|4|4|32|164|202752|3|
-|Long Context 198k (A3)|PD — Server-P Node|16|8|2|64|8192|202752|3|
-|Long Context 198k (A3)|PD — Server-D Node|16|4|4|32|164|202752|3|
+#### 9.1.2 Table 2: Optimizations Requiring Explicit Enablement
+
+The following optimizations must be explicitly enabled to take effect. They apply to the A3 series (w8a8c8) as indicated:
+
+|Optimization|Scenario|Enablement|Principle (Benefits)|Notes|
+|------------|--------|----------|---------------------|-----|
+|FlashComm_v1|A3 prefill nodes / co-located nodes|`--additional-config '{"enable_flashcomm1": true}'`|Splits AllReduce into Reduce-Scatter and All-Gather, improving prefill throughput and reducing communication latency|Not available when `layer_sharding` includes `o_proj`|
+|Fused MC2|A3 prefill nodes|`--additional-config '{"enable_fused_mc2": true}'`|Replaces ALLTOALL+MC2 with the `dispatch_ffn_combine`/`dispatch_gmm_combine_decode` operators, reducing MoE communication overhead and improving MoE inference performance|`dispatch_ffn_combine` only for w8a8, EP≤32, non-MTP, non-dynamic-EPLB; conflicts with `multistream_overlap_shared_expert` (the latter is auto-disabled)|
+|MLAPO|A3 co-located high-throughput / PD decode nodes|`--additional-config '{"enable_mlapo": true}'`|Fuses the MLA preprocess operations, significantly improving decode performance|Consumes more NPU memory; in PD scenarios enable on decode nodes only|
+|DSA CP|A3 prefill nodes; long context (≥128K)|`--additional-config '{"enable_dsa_cp": true}'`|DSA context parallelism accelerates long-context prefill, reducing TTFT for long prompts|In the reference configs, enabled on co-located nodes and PD prefill nodes|
+|Balance Scheduling|A3 single-node / co-located / non-PD scenarios|`--additional-config '{"enable_balance_scheduling": true}'`|Improves output throughput and reduces TPOT in the v1 scheduler|TTFT may degrade; not recommended when Prefill-Decode is separated|
+|Sparse SFA C8|A3 (w8a8c8); long-context prefill|`--additional-config '{"enable_sparse_sfa_c8": true}'`|Sparse Flash Attention skips unnecessary attention computation of the C8 quantized model, accelerating long-context prefill|Experimental in v0.23.0. In the reference configs, enabled in the high-throughput and PD scenarios; disabled in the low-latency scenario|
+|Sparse LI C8|A3 (w8a8c8)|`--additional-config '{"enable_sparse_li_c8": true}'`|Sparse attention optimization reduces computation of the C8 quantized model, improving throughput|Independent of `enable_sparse_sfa_c8`; the reference low-latency config disables both|
+|Recompute Scheduler|A3 decode nodes|`--additional-config '{"recompute_scheduler_enable": true}'`|Recomputes KV cache on prefill nodes when decode KV cache is insufficient, avoiding decode-side OOM and improving throughput|Set to `false` on prefill nodes|
+|Multistream Overlap Shared Expert|A3|`--additional-config '{"multistream_overlap_shared_expert": true}'`|Overlaps shared-expert computation on an additional stream, hiding its latency and improving decode performance|Auto-disabled when `"enable_fused_mc2": true`|
 
 > For complete startup commands and detailed parameter descriptions, please refer to the deployment examples and Key Parameter Descriptions in [Online Service Deployment](#5-online-service-deployment).
 
@@ -1346,26 +1487,25 @@ The tables below provide recommended parameter configurations for different depl
 
 |Parameter|Low Latency|High Throughput|Long Context|Description|
 |---------|-----------|---------------|-------------|-----------|
-|`--max-num-seqs`|Lower (4–8)|Higher (16–64)|Controlled (2–8)|Limits concurrent sequences. Lower values reduce scheduling latency; higher values increase throughput.|
-|`--max-model-len`|Shorter (32k–40k)|Longer (128k–200k)|Maximum (128k–200k)|Maximum context length. Must accommodate your longest input+output. Larger values consume more KV cache memory.|
-|`--max-num-batched-tokens`|Lower (2048–4096)|Higher (4096–8192)|Higher for prefill (4096)|Controls batch size per step. Lower values reduce per-step latency; higher values improve prefill throughput.|
-|`--gpu-memory-utilization`|0.92–0.95|0.95|0.92–0.95|NPU memory fraction. Higher values leave more memory for KV cache. Reduce if OOM.|
-|`--enable-chunked-prefill`|Enable|Enable|Enable|Splits long prompts into chunks to prevent prefill from blocking decode. Recommended in all scenarios.|
-|`--enable-prefix-caching`|Optional|Enable|Optional|Reuses KV cache for shared prefixes (e.g., system prompts). Improves throughput when cache hit rate is high but may reduce available KV cache memory.|
-|`num_speculative_tokens`|3|3|3|MTP speculation count. Higher values improve decode throughput at the cost of memory for draft model KV cache. Use `1` on prefill nodes in PD mode.|
-|`additional_config.enable_mlapo`|1 (w8a8)|1 (w8a8)|0 or 1|Enables MLA fusion on w8a8 models. Improves decode performance but consumes more NPU memory. Disable for long-context if memory is insufficient.|
+|`--max-num-seqs`|Lower (16)|Higher (6–64)|Higher (32–64)|Limits concurrent sequences. Lower values reduce scheduling latency; higher values increase throughput.|
+|`--max-model-len`|198K|Longer (128K–198K)|Maximum (198K)|Maximum context length. Must accommodate your longest input+output. Larger values consume more KV cache memory.|
+|`--max-num-batched-tokens`|Lower (4096)|Higher for prefill (4096–16384)|Higher for prefill (16384); small on decode nodes (close to `max-num-seqs`)|Controls batch size per step. Lower values reduce per-step latency; higher values improve prefill throughput.|
+|`--gpu-memory-utilization`|0.92|0.92|0.92|NPU memory fraction. The reference configs in this document use 0.92. Reduce if OOM.|
+|`--enable-chunked-prefill`|Enable (co-located)|Enable (co-located)|Enable (co-located)|Splits long prompts into chunks to prevent prefill from blocking decode. PD prefill nodes use `--enforce-eager` instead.|
+|`num_speculative_tokens` (MTP)|3|3|3|MTP speculation count. Higher values improve decode throughput at the cost of memory for the draft model KV cache. In the reference PD configs, prefill nodes use `1`; decode nodes use `3`.|
+|`cudagraph_mode`|FULL_DECODE_ONLY|FULL_DECODE_ONLY (co-located / decode nodes)|FULL_DECODE_ONLY (co-located / decode nodes)|Graph capture for the decode phase only. PD prefill nodes use `--enforce-eager` instead.|
 
 ### 9.2 Tuning Guidelines
 
 For general performance tuning methods, refer to the [Public Performance Tuning Documentation](../../developer_guide/performance_and_debug/optimization_and_tuning.md).
 
-For detailed feature descriptions and configuration options, refer to the [Feature Matrix](../../user_guide/support_matrix/feature_matrix.md).
+For detailed feature descriptions and configuration options, refer to the [Feature Guide](../../user_guide/support_matrix/feature_matrix.md).
 
 For environment variable descriptions and constraints, refer to [envs.py](https://github.com/vllm-project/vllm-ascend/blob/main/vllm_ascend/envs.py).
 
 ## 10 FAQ
 
-- Common Issues Tip: If you encounter issues, Refer to [Public FAQs](../../faqs.md).
+- Common Issues Tip: If you encounter issues, Refer to [FAQs](../../faqs.md).
 
 - **Q: How to solve ValueError: Tokenizer class TokenizersBackend does not exist or is not currently imported?**
 

--- a/docs/source/tutorials/models/GLM5.md
+++ b/docs/source/tutorials/models/GLM5.md
@@ -24,7 +24,7 @@ Refer to [feature guide](../../user_guide/feature_guide/index.md) to get the fea
 - `GLM-5-w8a8`(Quantized version): [Download model weight](https://www.modelscope.cn/models/Eco-Tech/GLM-5-w8a8).
 - `GLM-5.1-w4a8`(Quantized version): [Download model weight](https://modelers.cn/models/Eco-Tech/GLM-5.1-w4a8).
 - `GLM-5.1-w8a8`(Quantized version): [Download model weight](https://modelers.cn/models/Eco-Tech/GLM-5.1-w8a8).
-- `GLM-5.1-w8a8c8`(Quantized version for Atlas 800 A3): [Download model weight](https://modelers.cn/models/Eco-Tech/GLM-5.1-w8a8c8-MTP).
+- `GLM-5.1-w8a8c8`(Quantized version): [Download model weight](https://modelers.cn/models/Eco-Tech/GLM-5.1-w8a8c8-MTP).
 - `GLM-5.1-w4a4`(Ascend950DT mxfp4 Quantized): [Download model weight](https://www.modelscope.cn/models/Eco-Tech/GLM-5.1-w4a4c8-mxfp4).
 
 It is recommended to download the model weight to the shared directory of multiple nodes, such as `/root/.cache/`
@@ -972,7 +972,6 @@ dp_rank_start = args.dp_rank_start
 dp_address = args.dp_address
 dp_rpc_port = args.dp_rpc_port
 vllm_start_port = args.vllm_start_port
-# 一个 DP 副本占 tp×pp 张连续卡（pp=1 时退化为现状的 tp）
 gpus_per_dp_rank = tp_size * pp_size
 
 def run_command(visible_devices, dp_rank, vllm_engine_port):
@@ -1144,8 +1143,8 @@ if __name__ == "__main__":
         nic_name="xxxx" # change to your own nic name
         local_ip="xxxx" # change to your own ip
 
-        # 每个 DP rank 使用独立的 engine_id,避免 KV 路由混淆
-        # $4 = data-parallel-rank; 节点内 rank 偏移 0-3 → engine_id 100-103
+        # Each DP rank uses an independent engine ID to avoid KV route confusion.
+        # $4 = data-parallel-rank. The rank offset within a node is 0 to 3, and the corresponding engine ID is 100 to 103.
         ENGINE_ID=$((100 + $4))
 
         #Mooncake
@@ -1205,8 +1204,8 @@ if __name__ == "__main__":
         nic_name="xxxx" # change to your own nic name
         local_ip="xxxx" # change to your own ip
 
-        # 每个 DP rank 使用独立的 engine_id,避免 KV 路由混淆
-        # $4 = data-parallel-rank; 节点内 rank 偏移 0-3 → engine_id 100-103
+        # Each DP rank uses an independent engine ID to avoid KV route confusion.
+        # $4 = data-parallel-rank. The rank offset within a node is 0 to 3, and the corresponding engine ID is 100 to 103.
         ENGINE_ID=$((100 + $4))
 
         #Mooncake

--- a/docs/source/tutorials/models/GLM5.md
+++ b/docs/source/tutorials/models/GLM5.md
@@ -1387,7 +1387,7 @@ In addition to the single-node and multi-node parameters described above, the fo
 
 **MTP in PD scenarios:**
 
-- Prefill nodes use `"num_speculative_tokens": 3` in the A3 scenario and `1` in the Ascend950DT scenario (see the scripts above).
+- Prefill nodes use `"num_speculative_tokens": 1` in both scenarios (see the scripts above).
 - Decode nodes use `"num_speculative_tokens": 3` in both scenarios to maximize decode throughput.
 - All prefill and decode nodes must use the same `"method": "deepseek_mtp"` and `"enforce_eager": true`.
 
@@ -1457,11 +1457,11 @@ Test cases use the notation `input/output`, e.g., `128k/1k` means 128K input tok
 |--------|--------------|-------------|-----|--|--|------------|----------------------|--------------|-------------|
 |Dual-Node Co-Located 198K High Throughput (A3)|w8a8c8|Dual-Node Co-Located Node (0/1)|16|4|4|6|4096|202752|3|
 |Dual-Node Co-Located 198K Low Latency (A3)|w8a8c8|Dual-Node Co-Located Node (0/1)|16|16|1|16|4096|202752|3|
-|PD 198K High Throughput (A3)|w8a8c8|PD — Server-P Node (PP2)|16|16|1|64|16384|202752|3|
+|PD 198K High Throughput (A3)|w8a8c8|PD — Server-P Node (PP2)|16|16|1|64|16384|202752|1|
 |PD 198K High Throughput (A3)|w8a8c8|PD — Server-D Node|16|4|4|32|164|202752|3|
-|PD 198K High Throughput (Ascend950DT)|w4a4|PD — Server-P Node (DSA CP 8)|8|8|1|20|8192|202752|3|
+|PD 198K High Throughput (Ascend950DT)|w4a4|PD — Server-P Node (DSA CP 8)|8|8|1|20|8192|202752|1|
 |PD 198K High Throughput (Ascend950DT)|w4a4|PD — Server-D Node|8|1|8|60|240|202752|3|
-|PD 198K Low Latency (Ascend950DT)|w4a4|PD — Server-P Node (DSA CP 8)|8|8|1|20|8192|202752|3|
+|PD 198K Low Latency (Ascend950DT)|w4a4|PD — Server-P Node (DSA CP 8)|8|8|1|20|8192|202752|1|
 |PD 198K Low Latency (Ascend950DT)|w4a4|PD — Server-D Node|8|1|8|60|240|202752|3|
 
 #### 9.1.2 Table 2: Optimizations Requiring Explicit Enablement


### PR DESCRIPTION
  ### What this PR does / why we need it?
  Replace `docs/source/tutorials/models/GLM5.md` and `GLM5.2.md` with their                                                                                                                                                                                                               `releases/v0.26.0rc` versions, **verbatim** (generated format untouched).                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                       `releases/v0.26.0rc` carries the restructured GLM-5.2 tutorial (1824-line
  rewrite) and updated GLM-5 tutorial content, while `main` still holds the
  older versions. This PR syncs both files from the release branch so the                                                                                                                                                                                                                 published guides match the v0.26.0 documentation:                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                               - `GLM5.2.md`: whole-file sync, +1824-line restructure from v0.26.0rc
  - `GLM5.md`: whole-file sync, +304-line config/env updates from v0.26.0rc
  - No other files changed; based on latest `main`                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                ### Does this PR introduce _any_ user-facing change?
  No. Documentation-only update (model tutorials), which the contributing guide
  does not treat as a user-facing change.

  ### How was this patch tested?
  No tests added — the change is a verbatim documentation sync, and both files
  were verified byte-identical to their `releases/v0.26.0rc` counterparts
  (`git diff` between the branch and `base/releases/v0.26.0rc` is empty). The                                                                                                                                                                                                             source files pass the docs CI (markdownlint) on the release branch they were                                                                                                                                                                                                            copied from; this PR's CI run will re-verify on top of `main`.

- vLLM main: https://github.com/vllm-project/vllm/commit/e6bfe03ad73a3330cb427885aa90d97a12e1c704
