### PR TITLE
[Feature][Config] Warn about upcoming DSA CP deprecation

### DIFF
--- a/docs/source/user_guide/feature_guide/context_parallel.md
+++ b/docs/source/user_guide/feature_guide/context_parallel.md
@@ -149,7 +149,9 @@ DCP reuses the TP devices and does not increase the world size.
 ### DSA-CP
 
 `enable_dsa_cp` will be deprecated in a future release. Consider trying PCP
-on supported model and deployment configurations. For an existing TP size of
+on supported model and deployment configurations. PCP is currently experimental,
+and support for combining it with some other features is still being adapted.
+For an existing TP size of
 `N > 1`, try `--tensor-parallel-size 1 --prefill-context-parallel-size N`
 to preserve the world size, and remove `enable_dsa_cp` from `additional_config`.
 PCP does not require this switch. With TP size 1, enabling PCP requires additional

--- a/docs/source/user_guide/feature_guide/context_parallel.md
+++ b/docs/source/user_guide/feature_guide/context_parallel.md
@@ -148,6 +148,13 @@ DCP reuses the TP devices and does not increase the world size.
 
 ### DSA-CP
 
+`enable_dsa_cp` will be deprecated in a future release. Consider trying PCP
+on supported model and deployment configurations. For an existing TP size of
+`N > 1`, try `--tensor-parallel-size 1 --prefill-context-parallel-size N`
+to preserve the world size, and remove `enable_dsa_cp` from `additional_config`.
+PCP does not require this switch. With TP size 1, enabling PCP requires additional
+ranks. Check the compatibility and limitations above before migrating.
+
 ```bash
 vllm serve <glm-5.2-model> \
   --tensor-parallel-size <N> \

--- a/docs/source/user_guide/feature_guide/context_parallel.md
+++ b/docs/source/user_guide/feature_guide/context_parallel.md
@@ -148,13 +148,12 @@ DCP reuses the TP devices and does not increase the world size.
 
 ### DSA-CP
 
-`enable_dsa_cp` will be deprecated in a future release. Consider trying PCP
-on supported model and deployment configurations. PCP is currently experimental,
-and support for combining it with some other features is still being adapted.
-For an existing TP size of
-`N > 1`, try `--tensor-parallel-size 1 --prefill-context-parallel-size N`
-to preserve the world size, and remove `enable_dsa_cp` from `additional_config`.
-PCP does not require this switch. With TP size 1, enabling PCP requires additional
+DSA-CP will be fully deprecated once PCP is ready. PCP is currently experimental,
+with support for some feature combinations still in progress.
+
+To try PCP with the same world size, replace TP size `N > 1` with
+`--tensor-parallel-size 1 --prefill-context-parallel-size N` and remove
+`enable_dsa_cp` from `additional_config`. With TP size 1, PCP requires additional
 ranks. Check the compatibility and limitations above before migrating.
 
 ```bash

--- a/vllm_ascend/ascend_config.py
+++ b/vllm_ascend/ascend_config.py
@@ -548,7 +548,7 @@ class AscendConfig:
                     "Remove enable_dsa_cp from additional_config when enabling PCP."
                 )
             logger.warning_once(
-                "enable_dsa_cp will be deprecated in a future release. %s "
+                "enable_dsa_cp will be fully deprecated once PCP is ready. %s "
                 "Check PCP support for your model and deployment configuration.",
                 migration,
             )

--- a/vllm_ascend/ascend_config.py
+++ b/vllm_ascend/ascend_config.py
@@ -531,8 +531,7 @@ class AscendConfig:
             pcp_size = vc.parallel_config.prefill_context_parallel_size
             if pcp_size > 1:
                 migration = (
-                    "Prefill context parallelism is already enabled; remove "
-                    "enable_dsa_cp from additional_config."
+                    "Prefill context parallelism is already enabled; remove enable_dsa_cp from additional_config."
                 )
             elif tp_size > 1:
                 migration = (

--- a/vllm_ascend/ascend_config.py
+++ b/vllm_ascend/ascend_config.py
@@ -526,6 +526,33 @@ class AscendConfig:
             and vc.parallel_config.tensor_parallel_size > 1
         )
 
+        if self.enable_dsa_cp:
+            tp_size = vc.parallel_config.tensor_parallel_size
+            pcp_size = vc.parallel_config.prefill_context_parallel_size
+            if pcp_size > 1:
+                migration = (
+                    "Prefill context parallelism is already enabled; remove "
+                    "enable_dsa_cp from additional_config."
+                )
+            elif tp_size > 1:
+                migration = (
+                    "Consider trying prefill context parallelism with "
+                    f"--tensor-parallel-size 1 --prefill-context-parallel-size {tp_size} "
+                    "to preserve the current world size. Remove enable_dsa_cp from "
+                    "additional_config when enabling PCP."
+                )
+            else:
+                migration = (
+                    "Consider trying prefill context parallelism with "
+                    "--prefill-context-parallel-size greater than 1 (requires additional ranks). "
+                    "Remove enable_dsa_cp from additional_config when enabling PCP."
+                )
+            logger.warning_once(
+                "enable_dsa_cp will be deprecated in a future release. %s "
+                "Check PCP support for your model and deployment configuration.",
+                migration,
+            )
+
         # DSA CP is only applicable to models with an indexer (for example,
         # DeepSeek V3.2/V4). Resolve this while vllm_config is explicitly
         # available so runtime reads do not depend on vLLM's temporary config


### PR DESCRIPTION
### What this PR does / why we need it?

RFC #14002
Warn during configuration initialization when `enable_dsa_cp` is enabled that the feature will be deprecated in a future release. Suggest trying prefill context parallelism on supported model and deployment configurations.

For TP=N (N>1), recommend `--tensor-parallel-size 1 --prefill-context-parallel-size N` to preserve world size. When PCP is already enabled, recommend removing the switch. For TP=1, explain that PCP requires additional ranks. Update the context-parallel guide with the migration instructions.

### Does this PR introduce _any_ user-facing change?

Yes: an enabled `enable_dsa_cp` emits a warning explaining the upcoming deprecation and that PCP does not require this switch. Execution settings are unchanged.

### How was this patch tested?

- Ruff 0.14.0 check passed.
- Python syntax parsing and isolated execution of the warning block passed for disabled DSA-CP, TP=8, TP=2, TP=1, and already-enabled PCP (five cases per branch).
- `git diff --check` passed.
- Full `bash format.sh ci` could not run because pre-commit is unavailable on PATH. No torch/NPU tests were run for this logging/documentation change.


- vLLM main: https://github.com/vllm-project/vllm/commit/ba07e4a48fc951300d97eb506217dd530583dea3
