### PR TITLE
[0.27.1rc][Feature][Model] Enable MiniMax-M3 FP8 MSA and index top-k on A5

### DIFF
--- a/csrc/attention/sparse_attention_score/sparse_attention_score_torch_adpt.h
+++ b/csrc/attention/sparse_attention_score/sparse_attention_score_torch_adpt.h
@@ -138,7 +138,8 @@ at::Tensor npu_sparse_attention_score(
     const c10::optional<at::Tensor> &actualSeqLengthsKv,
     c10::string_view qInputLayout, c10::string_view kvInputLayout,
     int64_t numKeyValueHeads, double scaleValue, int64_t blockSize, int64_t topK,
-    int64_t innerPrecise)
+    int64_t innerPrecise,
+    const c10::optional<at::ScalarType> &attentionOutDtype)
 {
     TORCH_CHECK(std::string(qInputLayout) == "TND",
                 "npu_sparse_attention_score only supports query TND layout");
@@ -146,9 +147,12 @@ at::Tensor npu_sparse_attention_score(
                 qDequantScale, kDequantScale, vDequantScale,
                 actualSeqLengths, actualSeqLengthsKv, numKeyValueHeads, blockSize, topK, innerPrecise);
 
-    at::ScalarType outDtype = (query.scalar_type() == at::kFloat8_e4m3fn)
-                                  ? at::kHalf
-                                  : query.scalar_type();
+    at::ScalarType outDtype = query.scalar_type();
+    if (query.scalar_type() == at::kFloat8_e4m3fn) {
+        outDtype = attentionOutDtype.value_or(at::kBFloat16);
+        TORCH_CHECK(outDtype == at::kHalf || outDtype == at::kBFloat16,
+                    "attention_out_dtype must be float16 or bfloat16 for float8_e4m3fn input.");
+    }
     at::Tensor attentionOut = at::empty(query.sizes(), query.options().dtype(outDtype));
     at::Tensor softmaxLse;
 

--- a/csrc/torch_binding.cpp
+++ b/csrc/torch_binding.cpp
@@ -1903,7 +1903,18 @@ at::Tensor npu_sparse_attention_score_prefill(
                                        "than 0, but shape[", i, "] is ", query.size(i));
     }
 
-    at::Tensor output = at::empty(query.sizes(), query.options().dtype(query.dtype()));
+    at::ScalarType out_dtype = query.scalar_type();
+    if (query.scalar_type() == at::kFloat8_e4m3fn) {
+        out_dtype = at::kBFloat16;
+    }
+    at::Tensor output = at::empty(query.sizes(), query.options().dtype(out_dtype));
+    // MinimaxSparseAttentionSplitKv always exposes softmaxLse as its second
+    // ACLNN output. Prefill does not consume it, so keep the flag disabled and
+    // pass the empty FP32 placeholder required by the operator interface.
+    at::Tensor softmax_lse = at::empty({0}, query.options().dtype(at::kFloat));
+    bool softmax_lse_flag = false;
+    std::string input_layout = "TND";
+    char *input_layout_ptr = const_cast<char *>(input_layout.c_str());
 
     EXEC_NPU_CMD(
         aclnnMinimaxSparseAttentionSplitKv,
@@ -1921,7 +1932,10 @@ at::Tensor npu_sparse_attention_score_prefill(
         block_size,
         top_k,
         inner_precise,
-        output
+        softmax_lse_flag,
+        input_layout_ptr,
+        output,
+        softmax_lse
     );
 
     return output;
@@ -2688,7 +2702,8 @@ TORCH_LIBRARY_EXPAND(CONCAT(_C, _ascend), ops)
         "Tensor? actual_seq_lengths=None, Tensor? actual_seq_lengths_kv=None, "
         "str q_input_layout=\"TND\", str kv_input_layout=\"BNSD\", "
         "int num_key_value_heads=1, float scale_value=1.0, "
-        "int block_size=128, int top_k=16, int inner_precise=0) -> Tensor"
+        "int block_size=128, int top_k=16, int inner_precise=0, "
+        "ScalarType? attention_out_dtype=None) -> Tensor"
     );
     ops.impl("npu_sparse_attention_score", torch::kPrivateUse1,
              &vllm_ascend::npu_sparse_attention_score);

--- a/csrc/torch_binding_meta.cpp
+++ b/csrc/torch_binding_meta.cpp
@@ -317,13 +317,17 @@ at::Tensor npu_sparse_attention_score_meta(
     const c10::optional<at::Tensor> &actual_seq_lengths_kv,
     c10::string_view q_input_layout, c10::string_view kv_input_layout,
     int64_t num_key_value_heads, double scale_value, int64_t block_size,
-    int64_t top_k, int64_t inner_precise)
+    int64_t top_k, int64_t inner_precise,
+    const c10::optional<at::ScalarType> &attention_out_dtype)
 {
     TORCH_CHECK(std::string(q_input_layout) == "TND",
                 "npu_sparse_attention_score only supports query TND layout");
-    at::ScalarType out_dtype = (query.scalar_type() == at::kFloat8_e4m3fn)
-                                   ? at::kHalf
-                                   : query.scalar_type();
+    at::ScalarType out_dtype = query.scalar_type();
+    if (query.scalar_type() == at::kFloat8_e4m3fn) {
+        out_dtype = attention_out_dtype.value_or(at::kBFloat16);
+        TORCH_CHECK(out_dtype == at::kHalf || out_dtype == at::kBFloat16,
+                    "attention_out_dtype must be float16 or bfloat16 for float8_e4m3fn input.");
+    }
     return at::empty_symint(query.sym_sizes(),
                             query.options().dtype(out_dtype).device(c10::kMeta));
 }
@@ -1412,7 +1416,11 @@ at::Tensor npu_sparse_attention_score_prefill_meta(
     (void)inner_precise;
     (void)actual_seq_lengths;
     (void)actual_seq_lengths_kv;
-    return at::empty_like(query);
+    at::ScalarType out_dtype = query.scalar_type();
+    if (query.scalar_type() == at::kFloat8_e4m3fn) {
+        out_dtype = at::kBFloat16;
+    }
+    return at::empty_symint(query.sym_sizes(), query.options().dtype(out_dtype).device(c10::kMeta));
 }
 
 void npu_scatter_nd_update_v2_meta(

--- a/tests/e2e/nightly/single_node/ops/singlecard_ops/triton/test_rope.py
+++ b/tests/e2e/nightly/single_node/ops/singlecard_ops/triton/test_rope.py
@@ -3,7 +3,10 @@ import gc
 import pytest
 import torch
 
-from vllm_ascend.ops.triton.rope import rope_forward_triton, rope_forward_triton_siso
+from vllm_ascend.ops.triton.rope import (
+    rope_forward_triton,
+    rope_forward_triton_siso,
+)
 
 IS_NEOX_STYLE = [True, False]
 DTYPES = [torch.bfloat16, torch.float16]
@@ -31,6 +34,12 @@ SEEDS = [0]
 DEVICES = [f"npu:{0}"]
 DEFAULT_ATOL = 1e-3
 DEFAULT_RTOL = 1e-3
+FP8_E4M3_MAX = 448.0
+FP8_ROPE_CASES = [
+    pytest.param(1, 2, 1, 128, 128, id="single-token-full-rope"),
+    pytest.param(17, 8, 1, 128, 64, id="partial-rope"),
+    pytest.param(1024, 8, 1, 128, 128, id="multi-row-grid"),
+]
 
 
 def rotate_neox(x: torch.Tensor) -> torch.Tensor:
@@ -101,6 +110,34 @@ def _rope_siso_pytorch_native(query, cos, sin, rope_dim, is_neox_style) -> tuple
     else:
         query = query_rot.to(orig_dtype)
     return query
+
+
+def _rope_fp8_pytorch_native(
+    query: torch.Tensor,
+    key: torch.Tensor,
+    cos_sin_cache: torch.Tensor,
+    positions: torch.Tensor,
+    rope_dim: int,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """PyTorch reference for NeoX RoPE with a direct E4M3 store."""
+    half = rope_dim // 2
+    cos_sin = cos_sin_cache.index_select(0, positions).to(torch.float32)
+    cos = cos_sin[:, :half].unsqueeze(-2)
+    sin = cos_sin[:, half:rope_dim].unsqueeze(-2)
+
+    def apply_rope(tensor: torch.Tensor) -> torch.Tensor:
+        tensor = tensor.to(torch.float32)
+        first = tensor[..., :half]
+        second = tensor[..., half:rope_dim]
+        rotated = torch.cat(
+            (first * cos - second * sin, second * cos + first * sin),
+            dim=-1,
+        )
+        if rope_dim < tensor.shape[-1]:
+            rotated = torch.cat((rotated, tensor[..., rope_dim:]), dim=-1)
+        return rotated.clamp(-FP8_E4M3_MAX, FP8_E4M3_MAX).to(torch.float8_e4m3fn)
+
+    return apply_rope(query), apply_rope(key)
 
 
 @pytest.mark.parametrize("is_neox_style", IS_NEOX_STYLE)
@@ -181,6 +218,78 @@ def test_rotary_embedding_triton_kernel_with_cos_sin_cache(
     # Compare the results.
     torch.testing.assert_close(q_trt.view(q_gold.size()), q_gold, atol=DEFAULT_ATOL, rtol=DEFAULT_RTOL)
     torch.testing.assert_close(k_trt.view(k_gold.size()), k_gold, atol=DEFAULT_ATOL, rtol=DEFAULT_RTOL)
+    gc.collect()
+    torch.npu.empty_cache()
+    torch.npu.reset_peak_memory_stats()
+
+
+@pytest.mark.parametrize(
+    "num_tokens,num_q_heads,num_k_heads,head_size,rotary_dim",
+    FP8_ROPE_CASES,
+)
+@pytest.mark.parametrize("device", DEVICES)
+@torch.inference_mode()
+def test_rotary_embedding_triton_kernel_fp8(
+    num_tokens: int,
+    num_q_heads: int,
+    num_k_heads: int,
+    head_size: int,
+    rotary_dim: int,
+    device: str,
+) -> None:
+    torch.manual_seed(0)
+    torch.set_default_device(device)
+
+    max_positions = max(num_tokens, 32)
+    inv_freq = 1.0 / (10000 ** (torch.arange(0, rotary_dim, 2, dtype=torch.float32, device=device) / rotary_dim))
+    freqs = torch.outer(
+        torch.arange(max_positions, dtype=torch.float32, device=device),
+        inv_freq,
+    )
+    cos_sin_cache = torch.cat((freqs.cos(), freqs.sin()), dim=-1).to(torch.bfloat16)
+    positions = torch.arange(num_tokens, dtype=torch.int64, device=device)
+
+    query = torch.randn(num_tokens, num_q_heads, head_size, dtype=torch.bfloat16, device=device)
+    key = torch.randn(num_tokens, num_k_heads, head_size, dtype=torch.bfloat16, device=device)
+    # Position zero has cos=1 and sin=0, so these values exercise the
+    # fixed-scale E4M3 clipping path without changing the expected sign.
+    query[0, 0, 0] = FP8_E4M3_MAX * 2
+    key[0, 0, 0] = -FP8_E4M3_MAX * 2
+
+    expected_query, expected_key = _rope_fp8_pytorch_native(
+        query,
+        key,
+        cos_sin_cache,
+        positions,
+        rotary_dim,
+    )
+    actual_query, actual_key = rope_forward_triton(
+        query,
+        key,
+        cos_sin_cache=cos_sin_cache,
+        positions=positions,
+        rope_dim=rotary_dim,
+        out_dtype=torch.float8_e4m3fn,
+    )
+
+    assert actual_query.dtype == torch.float8_e4m3fn
+    assert actual_key.dtype == torch.float8_e4m3fn
+    assert actual_query.shape == query.shape
+    assert actual_key.shape == key.shape
+    assert actual_query[0, 0, 0].to(torch.float32) == FP8_E4M3_MAX
+    assert actual_key[0, 0, 0].to(torch.float32) == -FP8_E4M3_MAX
+    torch.testing.assert_close(
+        actual_query.to(torch.float32),
+        expected_query.to(torch.float32),
+        atol=0.125,
+        rtol=0.125,
+    )
+    torch.testing.assert_close(
+        actual_key.to(torch.float32),
+        expected_key.to(torch.float32),
+        atol=0.125,
+        rtol=0.125,
+    )
     gc.collect()
     torch.npu.empty_cache()
     torch.npu.reset_peak_memory_stats()

--- a/tests/ut/models/minimax_m3/test_msa_m3.py
+++ b/tests/ut/models/minimax_m3/test_msa_m3.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 
 import inspect
 from dataclasses import dataclass
+from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
@@ -17,7 +18,12 @@ from vllm.v1.kv_cache_interface import FullAttentionSpec
 from vllm_ascend.core.kv_cache_interface import AscendSFAIndexerCacheSpec
 from vllm_ascend.models.minimax_m3 import MiniMaxM3SparseAttention
 from vllm_ascend.models.minimax_m3 import msa_m3 as msa_m3_module
-from vllm_ascend.models.minimax_m3.minimax_m3 import _scatter_index_cache
+from vllm_ascend.models.minimax_m3.minimax_m3 import (
+    _cast_for_cache,
+    _resolve_layer_kv_cache_dtype,
+    _resolve_layer_kv_cache_dtypes,
+    _scatter_index_cache,
+)
 from vllm_ascend.models.minimax_m3.msa_m3 import (
     AscendMiniMaxM3IndexerBackend,
     AscendMiniMaxM3IndexerCache,
@@ -45,6 +51,7 @@ from vllm_ascend.models.minimax_m3.ops.msa_m3_npu import (
     _index_score_topk_candidates,
     _minimax_m3_index_decode,
     _minimax_m3_index_score,
+    _minimax_m3_sparse_attn_a5,
     minimax_m3_index_decode,
     minimax_m3_index_prefill,
     minimax_m3_index_tp_block_parallel_decode,
@@ -205,6 +212,87 @@ def test_indexer_cache_uses_sfa_indexer_spec(mock_get_vllm_config: MagicMock) ->
         num_kv_heads=1,
         head_size=128,
     ) == (4, 128, 128)
+
+
+@patch(
+    "vllm_ascend.models.minimax_m3.minimax_m3.kv_cache_dtype_str_to_dtype",
+    return_value=torch.bfloat16,
+)
+def test_m3_kv_cache_dtype_skip_layers_keeps_gqa_bf16_and_msa_fp8(
+    mock_kv_dtype: MagicMock,
+) -> None:
+    cache_config = SimpleNamespace(
+        cache_dtype="fp8",
+        kv_cache_dtype_skip_layers=["0", "1", "2"],
+    )
+    model_config = SimpleNamespace(dtype=torch.bfloat16)
+
+    assert _resolve_layer_kv_cache_dtype(cache_config, "model.layers.0.self_attn") == "auto"
+    assert _resolve_layer_kv_cache_dtype(cache_config, "model.layers.2.self_attn") == "auto"
+    assert _resolve_layer_kv_cache_dtype(cache_config, "model.layers.3.self_attn") == "fp8"
+    assert _resolve_layer_kv_cache_dtype(cache_config, "model.layers.59.self_attn") == "fp8"
+    assert _resolve_layer_kv_cache_dtypes(
+        cache_config,
+        "model.layers.0.self_attn",
+        model_config,
+    ) == ("auto", torch.bfloat16)
+    assert _resolve_layer_kv_cache_dtypes(
+        cache_config,
+        "model.layers.2.self_attn",
+        model_config,
+    ) == ("auto", torch.bfloat16)
+    assert _resolve_layer_kv_cache_dtypes(
+        cache_config,
+        "model.layers.3.self_attn",
+        model_config,
+    ) == ("fp8", torch.float8_e4m3fn)
+    assert _resolve_layer_kv_cache_dtypes(
+        cache_config,
+        "model.layers.59.self_attn",
+        model_config,
+    ) == ("fp8", torch.float8_e4m3fn)
+    assert mock_kv_dtype.call_count == 2
+
+
+def test_m3_fixed_scale_fp8_cache_cast_clamps_e4m3_range() -> None:
+    source = torch.tensor([-500.0, -1.0, 1.0, 500.0], dtype=torch.float32)
+    cache = torch.empty(1, dtype=torch.float8_e4m3fn)
+
+    actual = _cast_for_cache(source, cache)
+
+    assert actual.dtype == torch.float8_e4m3fn
+    assert torch.equal(actual.float(), torch.tensor([-448.0, -1.0, 1.0, 448.0]))
+
+
+@patch("vllm_ascend.models.minimax_m3.msa_m3.get_current_vllm_config")
+def test_m3_indexer_cache_spec_follows_resolved_fp8_dtype(mock_get_vllm_config: MagicMock) -> None:
+    mock_get_vllm_config.return_value = SimpleNamespace(
+        compilation_config=SimpleNamespace(static_forward_context={}),
+    )
+    vllm_config = SimpleNamespace(cache_config=SimpleNamespace(block_size=128))
+    index_cache = AscendMiniMaxM3IndexerCache(
+        head_dim=128,
+        prefix="model.layers.3.self_attn.attn.index_cache",
+        kv_cache_dtype="fp8",
+        kv_cache_torch_dtype=torch.float8_e4m3fn,
+    )
+
+    spec = index_cache.get_kv_cache_spec(vllm_config)
+
+    assert spec.dtype == torch.float8_e4m3fn
+    assert spec.cache_dtype_str == "fp8"
+
+
+def test_a5_decode_topk_keeps_fused_postprocess_fast_path() -> None:
+    source_path = Path(msa_m3_module.__file__).with_name("ops") / "msa_m3_triton_a5.py"
+    source = source_path.read_text(encoding="utf-8")
+    decode_source = source[source.index("def minimax_m3_index_decode(") :]
+
+    assert "_decode_index_score_pad_tail_kernel" not in source
+    assert "score = torch.full(" in decode_source
+    assert "_, topk_idx_raw = torch.topk(score, k=topk" in decode_source
+    assert "_index_topk_postprocess_kernel" in decode_source
+    assert "return topk_idx, select_num_idx" in decode_source
 
 
 @patch("vllm_ascend.models.minimax_m3.msa_m3.get_forward_context")
@@ -511,6 +599,7 @@ def test_a5_indexer_forward_keeps_original_decode_path() -> None:
         decode=decode,
     )
     expected = torch.zeros(1, 1, 2, dtype=torch.int32)
+    expected_select_num_idx = torch.ones(1, 1, dtype=torch.int32)
     tp_group = SimpleNamespace(world_size=4, rank_in_group=0)
 
     with (
@@ -531,14 +620,15 @@ def test_a5_indexer_forward_keeps_original_decode_path() -> None:
         patch.object(
             msa_m3_module,
             "minimax_m3_index_decode",
-            return_value=expected,
+            return_value=(expected, expected_select_num_idx),
             create=True,
         ) as mock_decode,
     ):
-        actual, prefill = impl.forward(torch.zeros(1, 4))
+        actual, prefill, select_num_idx = impl.forward(torch.zeros(1, 4))
 
     assert actual is expected
     assert prefill is None
+    assert select_num_idx is expected_select_num_idx
     mock_decode.assert_called_once()
     decode_args = mock_decode.call_args.args
     assert torch.equal(decode_args[0], torch.zeros(1, 1, 4))
@@ -614,10 +704,11 @@ def test_a5_indexer_forward_keeps_original_prefill_path() -> None:
             create=True,
         ) as mock_topk,
     ):
-        decode, actual = impl.forward(torch.zeros(1, 4))
+        decode, actual, select_num_idx = impl.forward(torch.zeros(1, 4))
 
     assert decode is None
     assert actual is expected
+    assert select_num_idx is None
     mock_score.assert_called_once()
     score_args = mock_score.call_args.args
     assert torch.equal(score_args[0], torch.zeros(1, 1, 4))
@@ -1393,10 +1484,11 @@ def test_indexer_speculative_decode_uses_tp_block_parallel_path(
         "vllm_ascend.models.minimax_m3.msa_m3.minimax_m3_index_tp_block_parallel_decode",
         return_value=expected,
     ) as mock_tp_block_parallel:
-        actual, prefill = impl.forward(torch.zeros(2, 4))
+        actual, prefill, select_num_idx = impl.forward(torch.zeros(2, 4))
 
     assert actual is expected
     assert prefill is None
+    assert select_num_idx is None
     mock_tp_block_parallel.assert_called_once()
     call_kwargs = mock_tp_block_parallel.call_args.kwargs
     assert mock_tp_block_parallel.call_args.args[2] is decode.tp_score
@@ -1500,12 +1592,13 @@ def test_sparse_impl_forward_dispatches_decode_and_prefill_paths(
     output = torch.zeros_like(query)
     decode_topk = torch.tensor([[0, 1]], dtype=torch.int32)
     prefill_topk = torch.tensor([[2, 3]], dtype=torch.int32)
+    decode_select_num_idx = torch.tensor([[2]], dtype=torch.int32)
 
     result = impl.forward(
         layer,
         query,
         kv_cache,
-        (decode_topk, prefill_topk),
+        (decode_topk, prefill_topk, decode_select_num_idx),
         output,
     )
 
@@ -1514,6 +1607,8 @@ def test_sparse_impl_forward_dispatches_decode_and_prefill_paths(
     mock_sparse_attn_prefill.assert_called_once()
     assert mock_sparse_attn_decode.call_args.args[0].shape == (1, 2, 4)
     assert mock_sparse_attn_decode.call_args.kwargs["block_size"] == 128
+    assert mock_sparse_attn_decode.call_args.kwargs["select_num_idx"] is decode_select_num_idx
+    assert "query_lens" not in mock_sparse_attn_decode.call_args.kwargs
     assert mock_sparse_attn_prefill.call_args.args[0].shape == (2, 2, 4)
 
 
@@ -1586,3 +1681,82 @@ def test_m3_impls_provide_update_graph_params_protocol():
             "speculative_config",
         ]
         assert params["speculative_config"].default is None
+
+
+@patch.object(torch.ops._C_ascend, "npu_sparse_attention_score", create=True)
+def test_sparse_attn_decode_npu_uses_fp8_inputs_and_reused_scale(
+    mock_sparse_attention_score: MagicMock,
+) -> None:
+    q = torch.tensor([[[500.0, -500.0, 1.0, -1.0]]], dtype=torch.bfloat16)
+    kv_cache = torch.zeros(2, 1, 128, 1, 4, dtype=torch.float8_e4m3fn)
+    topk_idx = torch.tensor([[[0]]], dtype=torch.int32)
+    select_num_idx = torch.ones(1, 1, dtype=torch.int32)
+    block_table = torch.zeros(1, 1, dtype=torch.int32)
+    seq_lens = torch.ones(1, dtype=torch.int32)
+    dequant_scale = torch.ones((1, 1, 1, 1), dtype=torch.float32)
+    output = torch.empty_like(q)
+    mock_sparse_attention_score.return_value = torch.ones_like(output)
+
+    minimax_m3_sparse_attn_decode_npu(
+        q,
+        kv_cache,
+        topk_idx,
+        block_table,
+        seq_lens,
+        num_kv_heads=1,
+        sm_scale=0.5,
+        output=output,
+        decode_query_len=1,
+        select_num_idx=select_num_idx,
+        dequant_scale=dequant_scale,
+    )
+
+    args = mock_sparse_attention_score.call_args.args
+    kwargs = mock_sparse_attention_score.call_args.kwargs
+    assert args[0].dtype == torch.float8_e4m3fn
+    assert args[1].dtype == torch.float8_e4m3fn
+    assert args[2].dtype == torch.float8_e4m3fn
+    assert kwargs["select_num_idx"] is select_num_idx
+    assert kwargs["actual_seq_lengths"].dtype == torch.int32
+    assert torch.equal(kwargs["actual_seq_lengths"], torch.ones_like(seq_lens))
+    assert kwargs["q_dequant_scale"] is dequant_scale
+    assert kwargs["k_dequant_scale"] is dequant_scale
+    assert kwargs["v_dequant_scale"] is dequant_scale
+    assert kwargs["attention_out_dtype"] == torch.bfloat16
+
+
+@patch.object(torch.ops._C_ascend, "npu_sparse_attention_score_prefill", create=True)
+@patch("vllm_ascend.models.minimax_m3.ops.msa_m3_npu._npu_k2q_csr")
+def test_sparse_attn_prefill_a5_uses_fp8_inputs(
+    mock_k2q_csr: MagicMock,
+    mock_sparse_attention_score_prefill: MagicMock,
+) -> None:
+    q = torch.tensor([[[500.0, -500.0, 1.0, -1.0]]], dtype=torch.bfloat16)
+    kv_cache = torch.zeros(2, 1, 128, 1, 4, dtype=torch.float8_e4m3fn)
+    topk_idx = torch.tensor([[[0]]], dtype=torch.int32)
+    block_table = torch.zeros(1, 1, dtype=torch.int32)
+    cu_seqlens_q = torch.tensor([0, 1], dtype=torch.int32)
+    seq_lens = torch.ones(1, dtype=torch.int32)
+    output = torch.empty_like(q)
+    csr = torch.zeros(1, dtype=torch.int32)
+    mock_k2q_csr.return_value = (csr, csr, csr)
+    mock_sparse_attention_score_prefill.return_value = torch.ones_like(output)
+
+    _minimax_m3_sparse_attn_a5(
+        q,
+        kv_cache,
+        topk_idx,
+        block_table,
+        cu_seqlens_q,
+        seq_lens,
+        num_kv_heads=1,
+        sm_scale=0.5,
+        output=output,
+        block_size=128,
+    )
+
+    args = mock_sparse_attention_score_prefill.call_args.args
+    assert args[0].dtype == torch.float8_e4m3fn
+    assert args[1].dtype == torch.float8_e4m3fn
+    assert args[2].dtype == torch.float8_e4m3fn
+    assert args[11] == 4

--- a/tests/ut/ops/test_register_custom_ops.py
+++ b/tests/ut/ops/test_register_custom_ops.py
@@ -78,3 +78,24 @@ def test_sp_ep_fake_shapes_follow_uneven_local_chunks(monkeypatch):
 
     assert gathered.shape == (8, 4)
     assert reduced.shape == (3, 4)
+
+
+def test_rope_fake_uses_requested_output_dtype():
+    positions = torch.arange(2)
+    query = torch.empty(2, 128, dtype=torch.bfloat16)
+    key = torch.empty(2, 64, dtype=torch.bfloat16)
+
+    query_out, key_out = custom_ops._rope_forward_oot_impl_fake(
+        positions,
+        query,
+        key,
+        torch.empty(16, 64, dtype=torch.bfloat16),
+        64,
+        64,
+        out_dtype=torch.float8_e4m3fn,
+    )
+
+    assert query_out.shape == query.shape
+    assert key_out.shape == key.shape
+    assert query_out.dtype == torch.float8_e4m3fn
+    assert key_out.dtype == torch.float8_e4m3fn

--- a/tests/ut/ops/test_rotary_embedding.py
+++ b/tests/ut/ops/test_rotary_embedding.py
@@ -21,7 +21,11 @@ import pytest
 import torch
 from vllm.model_executor.layers.rotary_embedding import RotaryEmbedding, YaRNScalingRotaryEmbedding
 
-from vllm_ascend.ops.rotary_embedding import AscendRotaryEmbedding, AscendYaRNRotaryEmbedding
+from vllm_ascend.ops.rotary_embedding import (
+    AscendRotaryEmbedding,
+    AscendYaRNRotaryEmbedding,
+    rope_forward_oot,
+)
 
 HEAD_SIZE = 64
 ROTARY_DIM = 64
@@ -57,6 +61,44 @@ def check_parent_init_signature_has_not_changed(parent_func, child_func):
         f"{parent_func.__name__} removed parameter(s): {removed}. "
         f"Check whether {child_func.__name__} needs to forward them."
     )
+
+
+class TestRopeForwardOOT:
+    @patch("vllm_ascend.ops.rotary_embedding.rope_forward_triton", create=True)
+    def test_fp8_dispatch_preserves_index_head_inference(self, mock_rope_triton):
+        positions = torch.arange(SEQ_LEN, dtype=torch.long)
+        query = torch.empty(SEQ_LEN, 2 * 96, dtype=torch.bfloat16)
+        key = torch.empty(SEQ_LEN, 96, dtype=torch.bfloat16)
+        cos_sin_cache = torch.empty(MAX_POS, ROTARY_DIM, dtype=torch.bfloat16)
+        query_fp8 = torch.empty(SEQ_LEN, 2, 96, dtype=torch.float8_e4m3fn)
+        key_fp8 = torch.empty(SEQ_LEN, 1, 96, dtype=torch.float8_e4m3fn)
+        mock_rope_triton.return_value = query_fp8, key_fp8
+
+        with patch("vllm_ascend.ops.rotary_embedding.HAS_TRITON", True):
+            query_out, key_out = rope_forward_oot(
+                positions,
+                query,
+                key,
+                cos_sin_cache,
+                HEAD_SIZE,
+                ROTARY_DIM,
+                True,
+                out_dtype=torch.float8_e4m3fn,
+            )
+
+        query_arg, key_arg = mock_rope_triton.call_args.args
+        assert query_arg.shape == (SEQ_LEN, 2, 96)
+        assert key_arg.shape == (SEQ_LEN, 1, 96)
+        kwargs = mock_rope_triton.call_args.kwargs
+        assert kwargs["cos_sin_cache"] is cos_sin_cache
+        assert kwargs["positions"] is positions
+        assert kwargs["rope_dim"] == ROTARY_DIM
+        assert kwargs["is_neox_style"] is True
+        assert kwargs["out_dtype"] == torch.float8_e4m3fn
+        assert query_out.shape == query.shape
+        assert key_out.shape == key.shape
+        assert query_out.dtype == torch.float8_e4m3fn
+        assert key_out.dtype == torch.float8_e4m3fn
 
 
 @pytest.fixture(autouse=True)
@@ -161,6 +203,32 @@ class TestAscendEmbeddingForwardOOT:
 
     @patch("torch.ops.vllm.npu_rotary_embedding")
     @patch("vllm_ascend.ascend_forward_context.get_forward_context")
+    def test_fp8_output_delegates_to_npu_op(self, mock_get_forward_context, mock_npu_op, make_embedding):
+        """The public OOT custom op owns FP8 backend dispatch."""
+        mock_get_forward_context.return_value = MagicMock()
+        mock_get_forward_context.return_value.is_draft_model = False
+        expected_output = (torch.empty(SEQ_LEN, NUM_HEADS * HEAD_SIZE, dtype=torch.float8_e4m3fn),) * 2
+        mock_npu_op.return_value = expected_output
+
+        emb = make_embedding()
+        positions, query, key = _make_tensors()
+
+        result = emb.forward_oot(positions, query, key, out_dtype=torch.float8_e4m3fn)
+
+        mock_npu_op.assert_called_once_with(
+            positions,
+            query,
+            key,
+            emb.cos_sin_cache,
+            HEAD_SIZE,
+            ROTARY_DIM,
+            emb.is_neox_style,
+            out_dtype=torch.float8_e4m3fn,
+        )
+        assert result is expected_output
+
+    @patch("torch.ops.vllm.npu_rotary_embedding")
+    @patch("vllm_ascend.ascend_forward_context.get_forward_context")
     def test_neox_style_override_true(self, mock_get_forward_context, mock_npu_op, make_embedding):
         """is_neox_style_override=True wins over self.is_neox_style=False."""
         mock_get_forward_context.return_value = MagicMock()
@@ -227,7 +295,7 @@ class TestAscendYaRNRotaryEmbeddingForwardOOT:
 
         result = emb.forward_oot(positions, query, key)
 
-        mock_delegate.assert_called_once_with(emb, positions, query, key, None, None)
+        mock_delegate.assert_called_once_with(emb, positions, query, key, None, None, None)
         assert result is expected
 
     @patch("vllm_ascend.ops.rotary_embedding.AscendRotaryEmbedding.forward_oot")
@@ -268,7 +336,7 @@ class TestAscendYaRNRotaryEmbeddingForwardOOT:
 
         emb.forward_oot(positions, query, key, offsets=offsets, is_neox_style_override=False)
 
-        mock_delegate.assert_called_once_with(emb, positions, query, key, offsets, False)
+        mock_delegate.assert_called_once_with(emb, positions, query, key, offsets, False, None)
 
     def test_parent_init_signature_has_not_changed(self):
         """

--- a/tests/ut/test_platform.py
+++ b/tests/ut/test_platform.py
@@ -127,7 +127,8 @@ class TestNPUPlatform(TestBase):
     def test_minimax_m3_mixed_kv_cache_auto_config_is_strictly_scoped(self):
         test_cases = (
             (AscendDeviceType.A3, "MiniMaxM3SparseForCausalLM", "fp8"),
-            (AscendDeviceType.A5, "OtherForCausalLM", "fp8"),
+            (AscendDeviceType.A5, "MiniMaxM2ForCausalLM", "fp8"),
+            (AscendDeviceType.A5, "LlamaForCausalLM", "fp8"),
             (AscendDeviceType.A5, "MiniMaxM3SparseForCausalLM", "auto"),
             (AscendDeviceType.A5, "MiniMaxM3SparseForCausalLM", "bfloat16"),
         )

--- a/tests/ut/test_platform.py
+++ b/tests/ut/test_platform.py
@@ -14,6 +14,7 @@ from vllm_ascend.ascend_forward_context import MoECommType, override_mrv2_in_pro
 from vllm_ascend.device.hardware_profile import get_hardware_profile
 from vllm_ascend.platform import (
     NPUPlatform,
+    _configure_minimax_m3_a5_mixed_kv_cache,
     _setup_compile_backend,
     _validate_eplb_config,
     _validate_sfa_dcp_kv_sp,
@@ -96,6 +97,92 @@ class TestNPUPlatform(TestBase):
         self.assertEqual(NPUPlatform.simple_compile_backend, "eager")
         self.assertEqual(NPUPlatform.ray_device_key, "NPU")
         self.assertEqual(NPUPlatform.device_control_env_var, "ASCEND_RT_VISIBLE_DEVICES")
+
+    @patch(
+        "vllm_ascend.platform.get_current_hardware_profile",
+        return_value=get_hardware_profile(AscendDeviceType.A5),
+    )
+    def test_a5_minimax_m3_fp8_automatically_keeps_gqa_cache_bf16(self, _mock_profile):
+        vllm_config = SimpleNamespace(
+            model_config=SimpleNamespace(
+                architecture="MiniMaxM3SparseForCausalLM",
+                hf_text_config=SimpleNamespace(
+                    num_hidden_layers=5,
+                    sparse_attention_config={"sparse_attention_freq": [0, 0, 0, 1, 1]},
+                ),
+            ),
+            cache_config=SimpleNamespace(
+                cache_dtype="fp8",
+                kv_cache_dtype_skip_layers=[],
+            ),
+        )
+
+        _configure_minimax_m3_a5_mixed_kv_cache(vllm_config)
+
+        self.assertEqual(
+            vllm_config.cache_config.kv_cache_dtype_skip_layers,
+            ["0", "1", "2"],
+        )
+
+    def test_minimax_m3_mixed_kv_cache_auto_config_is_strictly_scoped(self):
+        test_cases = (
+            (AscendDeviceType.A3, "MiniMaxM3SparseForCausalLM", "fp8"),
+            (AscendDeviceType.A5, "OtherForCausalLM", "fp8"),
+            (AscendDeviceType.A5, "MiniMaxM3SparseForCausalLM", "auto"),
+            (AscendDeviceType.A5, "MiniMaxM3SparseForCausalLM", "bfloat16"),
+        )
+        for device_type, architecture, cache_dtype in test_cases:
+            with self.subTest(
+                device_type=device_type,
+                architecture=architecture,
+                cache_dtype=cache_dtype,
+            ):
+                vllm_config = SimpleNamespace(
+                    model_config=SimpleNamespace(
+                        architecture=architecture,
+                        hf_text_config=SimpleNamespace(
+                            num_hidden_layers=5,
+                            sparse_attention_config={"sparse_attention_freq": [0, 0, 0, 1, 1]},
+                        ),
+                    ),
+                    cache_config=SimpleNamespace(
+                        cache_dtype=cache_dtype,
+                        kv_cache_dtype_skip_layers=[],
+                    ),
+                )
+                with patch(
+                    "vllm_ascend.platform.get_current_hardware_profile",
+                    return_value=get_hardware_profile(device_type),
+                ):
+                    _configure_minimax_m3_a5_mixed_kv_cache(vllm_config)
+
+                self.assertEqual(vllm_config.cache_config.kv_cache_dtype_skip_layers, [])
+
+    @patch(
+        "vllm_ascend.platform.get_current_hardware_profile",
+        return_value=get_hardware_profile(AscendDeviceType.A5),
+    )
+    def test_a5_minimax_m3_fp8_preserves_explicit_cache_skip_layers(self, _mock_profile):
+        vllm_config = SimpleNamespace(
+            model_config=SimpleNamespace(
+                architecture="MiniMaxM3SparseForConditionalGeneration",
+                hf_text_config=SimpleNamespace(
+                    num_hidden_layers=5,
+                    sparse_attention_config={"sparse_attention_freq": [0, 0, 0, 1, 1]},
+                ),
+            ),
+            cache_config=SimpleNamespace(
+                cache_dtype="fp8_e4m3",
+                kv_cache_dtype_skip_layers=[4, "sliding_window"],
+            ),
+        )
+
+        _configure_minimax_m3_a5_mixed_kv_cache(vllm_config)
+
+        self.assertEqual(
+            vllm_config.cache_config.kv_cache_dtype_skip_layers,
+            ["4", "sliding_window", "0", "1", "2"],
+        )
 
     @patch("vllm_ascend.platform.enable_sp", return_value=False)
     @patch("vllm_ascend.platform.enable_sfa_dcp_replicated_indexer", return_value=True)

--- a/tests/ut/worker/test_worker_v1.py
+++ b/tests/ut/worker/test_worker_v1.py
@@ -1743,6 +1743,52 @@ class TestNPUWorker(TestBase):
             worker.model_runner.initialize_kv_cache.assert_called_once_with(mock_kv_cache_config)
             worker.model_runner._init_kv_zero_meta.assert_called_once_with()
 
+    @patch("vllm_ascend.worker.worker.ensure_kv_transfer_initialized")
+    def test_initialize_from_config_initializes_kv_block_zeroer_for_mrv1_mamba_eagle3(self, mock_ensure_kv_transfer):
+        """MRV1 keeps the original Mamba plus multi-step Eagle3 zeroing path."""
+        from vllm_ascend.worker.worker import NPUWorker
+
+        with patch.object(NPUWorker, "__init__", lambda x, **kwargs: None):
+            worker = NPUWorker()
+            worker.model_runner = MagicMock()
+            worker.vllm_config = MagicMock()
+            worker.vllm_config.speculative_config.method = "eagle3"
+            worker.vllm_config.speculative_config.num_speculative_tokens = 2
+            worker.vllm_config.model_config.enable_sleep_mode = False
+            worker.use_v2_model_runner = False
+
+            mock_kv_cache_config = MagicMock()
+            mock_kv_cache_config.needs_kv_cache_zeroing = True
+            mock_kv_cache_config.has_mamba_layers = True
+
+            worker.initialize_from_config(mock_kv_cache_config)
+
+            worker.model_runner.initialize_kv_cache.assert_called_once_with(mock_kv_cache_config)
+            worker.model_runner._init_kv_zero_meta.assert_called_once_with()
+
+    @patch("vllm_ascend.worker.worker.ensure_kv_transfer_initialized")
+    def test_initialize_from_config_skips_mrv1_zeroer_for_mixed_precision_only(self, mock_ensure_kv_transfer):
+        """MRV1 mixed-precision attention must not enter the Mamba zeroer."""
+        from vllm_ascend.worker.worker import NPUWorker
+
+        with patch.object(NPUWorker, "__init__", lambda x, **kwargs: None):
+            worker = NPUWorker()
+            worker.model_runner = MagicMock()
+            worker.vllm_config = MagicMock()
+            worker.vllm_config.speculative_config.method = "eagle3"
+            worker.vllm_config.speculative_config.num_speculative_tokens = 2
+            worker.vllm_config.model_config.enable_sleep_mode = False
+            worker.use_v2_model_runner = False
+
+            mock_kv_cache_config = MagicMock()
+            mock_kv_cache_config.needs_kv_cache_zeroing = True
+            mock_kv_cache_config.has_mamba_layers = False
+
+            worker.initialize_from_config(mock_kv_cache_config)
+
+            worker.model_runner.initialize_kv_cache.assert_called_once_with(mock_kv_cache_config)
+            worker.model_runner._init_kv_zero_meta.assert_not_called()
+
     @patch("vllm_ascend.worker.worker.get_ascend_config")
     @patch("vllm_ascend.worker.worker.enable_sp", return_value=False)
     @patch("vllm_ascend.worker.worker.get_pp_group")

--- a/vllm_ascend/_310p/ops/rotary_embedding.py
+++ b/vllm_ascend/_310p/ops/rotary_embedding.py
@@ -266,7 +266,10 @@ class AscendRotaryEmbedding310(AscendRotaryEmbedding):
         key: torch.Tensor,
         offsets: torch.Tensor | None = None,
         is_neox_style_override: bool | None = None,
+        out_dtype: torch.dtype | None = None,
     ):
+        if out_dtype is not None:
+            raise NotImplementedError(f"Unsupported RoPE output dtype on 310P: {out_dtype}")
         is_neox_style = self.is_neox_style
         if is_neox_style_override is not None:
             is_neox_style = is_neox_style_override

--- a/vllm_ascend/models/minimax_m3/minimax_m3.py
+++ b/vllm_ascend/models/minimax_m3/minimax_m3.py
@@ -81,6 +81,7 @@ from vllm.model_executor.models.utils import (
     AutoWeightsLoader,
     PPMissingLayer,
     WeightsMapper,
+    extract_layer_index,
     is_pp_missing_parameter,
     make_empty_intermediate_tensors_factory,
     make_layers,
@@ -115,6 +116,49 @@ from vllm_ascend.worker.v2.pp_utils import (
 from vllm_ascend.worker.v2.pp_utils import (
     make_empty_intermediate_tensors as make_pp_empty_intermediate_tensors,
 )
+
+_FP8_E4M3_MAX = 448.0
+
+
+def _resolve_layer_kv_cache_dtype(
+    cache_config: CacheConfig | None,
+    prefix: str,
+) -> str:
+    """Resolve the per-layer KV dtype using vLLM's skip-layer semantics."""
+    if cache_config is None:
+        return "auto"
+
+    kv_cache_dtype = cache_config.cache_dtype
+    skip_layers = getattr(cache_config, "kv_cache_dtype_skip_layers", None)
+    if skip_layers and str(extract_layer_index(prefix)) in skip_layers:
+        kv_cache_dtype = "auto"
+    return kv_cache_dtype
+
+
+def _resolve_layer_kv_cache_dtypes(
+    cache_config: CacheConfig | None,
+    prefix: str,
+    model_config: ModelConfig,
+) -> tuple[str, torch.dtype]:
+    """Resolve MiniMax-M3's semantic and physical per-layer KV dtypes."""
+    kv_cache_dtype = _resolve_layer_kv_cache_dtype(cache_config, prefix)
+    if kv_cache_dtype in ("fp8", "fp8_e4m3"):
+        # vLLM represents generic FP8 KV storage as uint8. MiniMax-M3's
+        # fixed-scale sparse-attention and indexer paths consume native E4M3
+        # tensors, so preserve that physical dtype at the cache-spec boundary.
+        kv_cache_torch_dtype = torch.float8_e4m3fn
+    else:
+        kv_cache_torch_dtype = kv_cache_dtype_str_to_dtype(kv_cache_dtype, model_config)
+    return kv_cache_dtype, kv_cache_torch_dtype
+
+
+def _cast_for_cache(tensor: torch.Tensor, cache: torch.Tensor) -> torch.Tensor:
+    """Cast fixed-scale MiniMax-M3 KV values to the physical cache dtype."""
+    if tensor.dtype == cache.dtype:
+        return tensor
+    if cache.dtype == torch.float8_e4m3fn:
+        tensor = tensor.clamp(min=-_FP8_E4M3_MAX, max=_FP8_E4M3_MAX)
+    return tensor.to(cache.dtype)
 
 
 def _scatter_index_cache(
@@ -260,8 +304,11 @@ class MiniMaxM3SparseAttention(nn.Module, AttentionLayerBase):
 
         vllm_config = get_current_vllm_config()
         self.layer_name = f"{prefix}.attn"
-        self.kv_cache_dtype = cache_config.cache_dtype if cache_config is not None else "auto"
-        self.kv_cache_torch_dtype = kv_cache_dtype_str_to_dtype(self.kv_cache_dtype, vllm_config.model_config)
+        self.kv_cache_dtype, self.kv_cache_torch_dtype = _resolve_layer_kv_cache_dtypes(
+            cache_config,
+            prefix,
+            vllm_config.model_config,
+        )
         self.attn_backend = AscendMiniMaxM3SparseBackend
         self.impl = AscendMiniMaxM3SparseImpl(
             self.num_heads,
@@ -285,6 +332,8 @@ class MiniMaxM3SparseAttention(nn.Module, AttentionLayerBase):
             init_blocks=sparse_cfg.get("sparse_init_block", 0),
             local_blocks=sparse_cfg.get("sparse_local_block", 0),
             cache_config=cache_config,
+            kv_cache_dtype=self.kv_cache_dtype,
+            kv_cache_torch_dtype=self.kv_cache_torch_dtype,
         )
 
         compilation_config = vllm_config.compilation_config
@@ -326,6 +375,8 @@ class MiniMaxM3SparseAttention(nn.Module, AttentionLayerBase):
         num_tokens = main_meta.num_actual_tokens
         k_insert = key[:num_tokens].view(-1, self.num_kv_heads, self.head_dim)
         v_insert = value[:num_tokens].view(-1, self.num_kv_heads, self.head_dim)
+        k_insert = _cast_for_cache(k_insert, key_cache)
+        v_insert = _cast_for_cache(v_insert, value_cache)
         DeviceOperator.reshape_and_cache(
             k_insert,
             v_insert,
@@ -393,7 +444,15 @@ class MiniMaxM3SparseAttention(nn.Module, AttentionLayerBase):
             )
 
         index_q, index_k = self._index_qk_norm(index_q, index_k)
-        index_q, index_k = self.rotary_emb(positions, index_q, index_k)
+        if self.indexer.index_cache.dtype == torch.float8_e4m3fn:
+            index_q, index_k = self.rotary_emb(
+                positions,
+                index_q,
+                index_k,
+                out_dtype=torch.float8_e4m3fn,
+            )
+        else:
+            index_q, index_k = self.rotary_emb(positions, index_q, index_k)
 
         return q, k, v, index_q, index_k
 

--- a/vllm_ascend/models/minimax_m3/msa_m3.py
+++ b/vllm_ascend/models/minimax_m3/msa_m3.py
@@ -169,11 +169,14 @@ class AscendMiniMaxM3IndexerCache(nn.Module, AttentionLayerBase):
         head_dim: int,
         prefix: str,
         cache_config: CacheConfig | None = None,
+        kv_cache_dtype: str = "auto",
+        kv_cache_torch_dtype: torch.dtype = torch.bfloat16,
     ) -> None:
         super().__init__()
         self.kv_cache = torch.tensor([])
         self.head_dim = head_dim
-        self.dtype = torch.bfloat16
+        self.dtype = kv_cache_torch_dtype
+        self.kv_cache_dtype = kv_cache_dtype
         self.prefix = prefix
         self.cache_config = cache_config
         compilation_config = get_current_vllm_config().compilation_config
@@ -187,6 +190,7 @@ class AscendMiniMaxM3IndexerCache(nn.Module, AttentionLayerBase):
             num_kv_heads=1,
             head_size=self.head_dim,
             dtype=self.dtype,
+            cache_dtype_str=self.kv_cache_dtype,
         )
 
     def forward(self) -> None: ...
@@ -397,6 +401,8 @@ class AscendMiniMaxM3IndexerImpl(nn.Module):
         init_blocks: int = 0,
         local_blocks: int = 0,
         cache_config: CacheConfig | None = None,
+        kv_cache_dtype: str = "auto",
+        kv_cache_torch_dtype: torch.dtype = torch.bfloat16,
     ) -> None:
         super().__init__()
         self.num_kv_heads = num_kv_heads
@@ -411,6 +417,8 @@ class AscendMiniMaxM3IndexerImpl(nn.Module):
             head_dim=index_head_dim,
             prefix=f"{prefix}.index_cache",
             cache_config=cache_config,
+            kv_cache_dtype=kv_cache_dtype,
+            kv_cache_torch_dtype=kv_cache_torch_dtype,
         )
 
     def _decode_topk_tp_sharded(
@@ -472,10 +480,14 @@ class AscendMiniMaxM3IndexerImpl(nn.Module):
     def forward(
         self,
         index_query: torch.Tensor,
-    ) -> tuple[torch.Tensor | None, torch.Tensor | None]:
+    ) -> tuple[
+        torch.Tensor | None,
+        torch.Tensor | None,
+        torch.Tensor | None,
+    ]:
         attn_metadata = get_forward_context().attn_metadata
         if not isinstance(attn_metadata, dict):
-            return None, None
+            return None, None, None
         index_md = attn_metadata[self.index_cache.prefix]
         assert isinstance(index_md, AscendMiniMaxM3IndexerMetadata)
         num_tokens = index_md.num_actual_tokens
@@ -485,6 +497,7 @@ class AscendMiniMaxM3IndexerImpl(nn.Module):
 
         decode_topk: torch.Tensor | None = None
         prefill_topk: torch.Tensor | None = None
+        decode_select_num_idx: torch.Tensor | None = None
         if index_md.num_decodes > 0:
             d = index_md.decode
             assert d is not None
@@ -538,7 +551,7 @@ class AscendMiniMaxM3IndexerImpl(nn.Module):
                         tp_rank,
                     )
                 else:
-                    decode_topk = minimax_m3_index_decode(
+                    decode_topk, decode_select_num_idx = minimax_m3_index_decode(
                         decode_iq,
                         kv,
                         d.block_table,
@@ -592,7 +605,7 @@ class AscendMiniMaxM3IndexerImpl(nn.Module):
                     self.init_blocks,
                     self.local_blocks,
                 )
-        return decode_topk, prefill_topk
+        return decode_topk, prefill_topk, decode_select_num_idx
 
     @staticmethod
     def update_graph_params(
@@ -627,6 +640,8 @@ class AscendMiniMaxM3Indexer(nn.Module):
         init_blocks: int = 0,
         local_blocks: int = 0,
         cache_config: CacheConfig | None = None,
+        kv_cache_dtype: str = "auto",
+        kv_cache_torch_dtype: torch.dtype = torch.bfloat16,
     ) -> None:
         super().__init__()
         self.impl = AscendMiniMaxM3IndexerImpl(
@@ -640,6 +655,8 @@ class AscendMiniMaxM3Indexer(nn.Module):
             init_blocks=init_blocks,
             local_blocks=local_blocks,
             cache_config=cache_config,
+            kv_cache_dtype=kv_cache_dtype,
+            kv_cache_torch_dtype=kv_cache_torch_dtype,
         )
 
     @property
@@ -649,7 +666,11 @@ class AscendMiniMaxM3Indexer(nn.Module):
     def forward(
         self,
         index_query: torch.Tensor,
-    ) -> tuple[torch.Tensor | None, torch.Tensor | None]:
+    ) -> tuple[
+        torch.Tensor | None,
+        torch.Tensor | None,
+        torch.Tensor | None,
+    ]:
         return self.impl(index_query)
 
 
@@ -853,13 +874,18 @@ class AscendMiniMaxM3SparseImpl(AttentionImplBase[AscendMiniMaxM3SparseMetadata]
         self.kv_cache_dtype = kv_cache_dtype
         self.topk_blocks = topk_blocks
         self.block_size = sparse_block_size
+        self._dequant_scale: torch.Tensor | None = None
 
     def forward(
         self,
         layer: AttentionLayer,
         query: torch.Tensor,
         kv_cache: torch.Tensor,
-        topk_idx: tuple[torch.Tensor | None, torch.Tensor | None],
+        topk_idx: tuple[
+            torch.Tensor | None,
+            torch.Tensor | None,
+            torch.Tensor | None,
+        ],
         output: torch.Tensor,
     ) -> torch.Tensor:
         attn_metadata = get_forward_context().attn_metadata
@@ -867,7 +893,7 @@ class AscendMiniMaxM3SparseImpl(AttentionImplBase[AscendMiniMaxM3SparseMetadata]
             return output
         main_md = attn_metadata[layer.layer_name]
         assert isinstance(main_md, AscendMiniMaxM3SparseMetadata)
-        decode_topk, prefill_topk = topk_idx
+        decode_topk, prefill_topk, decode_select_num_idx = topk_idx
 
         num_decode_tokens = main_md.num_decode_tokens
         num_tokens = main_md.num_actual_tokens
@@ -878,6 +904,12 @@ class AscendMiniMaxM3SparseImpl(AttentionImplBase[AscendMiniMaxM3SparseMetadata]
         if main_md.num_decodes > 0:
             d = main_md.decode
             assert d is not None and decode_topk is not None
+            if self.kv_cache_dtype.startswith("fp8") and self._dequant_scale is None:
+                self._dequant_scale = torch.ones(
+                    (1, 1, 1, 1),
+                    dtype=torch.float32,
+                    device=query.device,
+                )
             minimax_m3_sparse_attn_decode(
                 q[:num_decode_tokens],
                 kv_cache,
@@ -889,6 +921,8 @@ class AscendMiniMaxM3SparseImpl(AttentionImplBase[AscendMiniMaxM3SparseMetadata]
                 out[:num_decode_tokens],
                 d.decode_query_len,
                 block_size=self.block_size,
+                select_num_idx=decode_select_num_idx,
+                dequant_scale=self._dequant_scale,
             )
 
         if main_md.num_prefills > 0:

--- a/vllm_ascend/models/minimax_m3/ops/msa_m3_npu.py
+++ b/vllm_ascend/models/minimax_m3/ops/msa_m3_npu.py
@@ -18,6 +18,7 @@ _SPARSE_ATTN_INNER_PRECISE = 4
 _MSA_INDEX_BLOCK_SIZE = 128
 _MSA_SCORE_BLOCK_ALIGNMENT = 16
 _ASCEND_DEVICE_TYPE = get_ascend_device_type()
+_FP8_E4M3_MAX = 448.0
 
 if _ASCEND_DEVICE_TYPE != AscendDeviceType.A5:
     from vllm_ascend.models.minimax_m3.ops.msa_m3_triton import (
@@ -123,6 +124,10 @@ def _split_main_kv_cache(
 
 def _select_num_idx_from_topk(topk_idx: torch.Tensor) -> torch.Tensor:
     return (topk_idx >= 0).sum(dim=-1).to(dtype=torch.int32)
+
+
+def _to_fp8_e4m3(tensor: torch.Tensor) -> torch.Tensor:
+    return tensor.clamp(min=-_FP8_E4M3_MAX, max=_FP8_E4M3_MAX).to(torch.float8_e4m3fn)
 
 
 def _build_cu_block_lens(
@@ -535,6 +540,12 @@ def _minimax_m3_sparse_attn_a5(
     block_size: int,
 ) -> None:
     key, value = _split_main_kv_cache(kv_cache)
+    inner_precise = 1
+    if key.dtype == torch.float8_e4m3fn:
+        if value.dtype != torch.float8_e4m3fn:
+            raise TypeError("MiniMax-M3 FP8 sparse attention requires both K and V caches in E4M3")
+        q = _to_fp8_e4m3(q)
+        inner_precise = _SPARSE_ATTN_INNER_PRECISE
     cu_block_lens = _build_cu_block_lens(seq_lens, block_size)
     k2q_row_ptr, k2q_q_indices, k2q_slot_indices = _npu_k2q_csr(
         topk_idx,
@@ -562,7 +573,7 @@ def _minimax_m3_sparse_attn_a5(
         sm_scale,
         block_size,
         topk_idx.shape[-1],
-        1,
+        inner_precise,
         actual_seq_lengths=q_lens_t,
         actual_seq_lengths_kv=kv_lens_t,
     )
@@ -614,6 +625,9 @@ def minimax_m3_sparse_attn_decode(
     output: torch.Tensor,
     decode_query_len: int,
     block_size: int = 128,
+    *,
+    select_num_idx: torch.Tensor | None = None,
+    dequant_scale: torch.Tensor | None = None,
 ) -> None:
     """Run sparse decode through the AscendC sparse-attention operator."""
     if q.shape[0] != seq_lens.shape[0] * decode_query_len:
@@ -621,13 +635,29 @@ def minimax_m3_sparse_attn_decode(
 
     key, value = _split_main_kv_cache(kv_cache)
     query_lens = torch.full_like(seq_lens, decode_query_len, dtype=torch.int32)
+    if select_num_idx is None:
+        select_num_idx = _select_num_idx_from_topk(topk_idx)
+
+    op_kwargs: dict[str, Any] = {}
+    if key.dtype == torch.float8_e4m3fn:
+        if value.dtype != torch.float8_e4m3fn:
+            raise TypeError("MiniMax-M3 FP8 sparse attention requires both K and V caches in E4M3")
+        q = _to_fp8_e4m3(q)
+        if dequant_scale is None:
+            dequant_scale = torch.ones((1, 1, 1, 1), dtype=torch.float32, device=q.device)
+        op_kwargs = {
+            "q_dequant_scale": dequant_scale,
+            "k_dequant_scale": dequant_scale,
+            "v_dequant_scale": dequant_scale,
+            "attention_out_dtype": torch.bfloat16,
+        }
     out = torch.ops._C_ascend.npu_sparse_attention_score(
         q,
         key,
         value,
         topk_idx,
         block_table,
-        select_num_idx=_select_num_idx_from_topk(topk_idx),
+        select_num_idx=select_num_idx,
         actual_seq_lengths=query_lens,
         actual_seq_lengths_kv=seq_lens,
         num_key_value_heads=num_kv_heads,
@@ -635,5 +665,6 @@ def minimax_m3_sparse_attn_decode(
         block_size=block_size,
         top_k=topk_idx.shape[-1],
         inner_precise=_SPARSE_ATTN_INNER_PRECISE,
+        **op_kwargs,
     )
     output.copy_(out)

--- a/vllm_ascend/models/minimax_m3/ops/msa_m3_triton_a5.py
+++ b/vllm_ascend/models/minimax_m3/ops/msa_m3_triton_a5.py
@@ -277,8 +277,8 @@ def _decode_qk_score_kernel(
 
     Visible-range metadata is scalar because each program owns exactly one
     flattened query. Fully visible pages skip the token-position mask; at most
-    one causal boundary page uses it. Invalid score-tail entries are written by
-    ``_decode_index_score_pad_tail_kernel`` after this launch.
+    one causal boundary page uses it. The score buffer is pre-filled with
+    ``-inf``, so unwritten tail entries are already masked.
     """
     query_id = tl.program_id(0)
     chunk_id = tl.program_id(1)
@@ -367,65 +367,27 @@ def _decode_qk_score_kernel(
 
 
 # ---------------------------------------------------------------------------
-# Pad unwritten score tail with -inf so torch.topk ignores [num_blocks, max_block).
-# _decode_qk_score_kernel only writes [0, row_num_blocks); torch.empty leaves
-# the rest as garbage. Per-token num_blocks matches the top-k invalid mask.
-# Split-K over max_block with a shape-constant chunk count (cudagraph-safe).
-# ---------------------------------------------------------------------------
-@triton.jit(do_not_specialize=["decode_query_len", "max_block", "chunk_blocks"])
-def _decode_index_score_pad_tail_kernel(
-    score_ptr,  # [num_idx_heads, total_q, score_block_stride] fp32
-    seq_lens,  # [num_reqs]
-    block_size: tl.constexpr,  # sparse block size (128)
-    max_block,
-    decode_query_len,
-    chunk_blocks,  # max_block split count per chunk (shape-constant)
-    stride_s_h,
-    stride_s_b,
-    stride_s_k,
-    BLOCK_SIZE_K: tl.constexpr,
-):
-    pid_b = tl.program_id(0)  # flattened query-token id
-    pid_h = tl.program_id(1)
-    pid_chunk = tl.program_id(2)
-    req_id = pid_b // decode_query_len
-    q_offset = pid_b - req_id * decode_query_len
-
-    seq_len = tl.load(seq_lens + req_id)
-    query_pos = seq_len - decode_query_len + q_offset
-    kv_len = tl.maximum(query_pos + 1, 0)
-    num_blocks = (kv_len + block_size - 1) // block_size
-
-    chunk_start = pid_chunk * chunk_blocks
-    chunk_end = tl.minimum(chunk_start + chunk_blocks, max_block)
-    fill_start = tl.maximum(chunk_start, num_blocks)
-    if fill_start >= chunk_end:
-        return
-
-    num_to_fill = chunk_end - fill_start
-    off_k = tl.arange(0, BLOCK_SIZE_K)
-    for i in tl.range(0, num_to_fill, BLOCK_SIZE_K):
-        blk = fill_start + i + off_k
-        store_mask = (i + off_k) < num_to_fill
-        s_ptrs = score_ptr + pid_h * stride_s_h + pid_b * stride_s_b + blk * stride_s_k
-        tl.store(s_ptrs, float("-inf"), mask=store_mask)
-
-
-# ---------------------------------------------------------------------------
 # Decode top-k: torch.topk on scores, then mask invalid block ids per token.
 # Forced init/local blocks are already encoded in the scores.
 # ---------------------------------------------------------------------------
 @triton.heuristics({"BLOCK_SIZE_T": lambda args: triton.next_power_of_2(args["topk"])})
 @triton.jit(do_not_specialize=["decode_query_len"])
-def _topk_index_mask_invalid_kernel(
-    ti_ptr,  # [num_idx_heads, total_q, topk] int32 in/out
+def _index_topk_postprocess_kernel(
+    ti_in_ptr,  # [num_idx_heads, total_q, topk] int64 input
+    ti_out_ptr,  # [num_idx_heads, total_q, topk] int32 output
+    select_num_idx_ptr,  # [num_idx_heads, total_q] int32 output
     seq_lens,  # [num_reqs]
     block_size: tl.constexpr,  # sparse block size (128)
     topk: tl.constexpr,
     decode_query_len,
-    stride_ti_h,
-    stride_ti_b,
-    stride_ti_t,
+    stride_in_h,
+    stride_in_b,
+    stride_in_t,
+    stride_out_h,
+    stride_out_b,
+    stride_out_t,
+    stride_select_h,
+    stride_select_b,
     BLOCK_SIZE_T: tl.constexpr,
 ):
     pid_b = tl.program_id(0)  # flattened query-token id
@@ -441,13 +403,16 @@ def _topk_index_mask_invalid_kernel(
     num_blocks = (kv_len + block_size - 1) // block_size
 
     off_t = tl.arange(0, BLOCK_SIZE_T)
-    ti_ptrs = ti_ptr + pid_h * stride_ti_h + pid_b * stride_ti_b + off_t * stride_ti_t
+    ti_in_ptrs = ti_in_ptr + pid_h * stride_in_h + pid_b * stride_in_b + off_t * stride_in_t
     store_mask = off_t < topk
-    idx = tl.load(ti_ptrs, mask=store_mask, other=0)
+    idx = tl.load(ti_in_ptrs, mask=store_mask, other=0)
     valid_slot = off_t < tl.minimum(topk, num_blocks)
     valid_idx = (idx >= 0) & (idx < num_blocks)
     masked_idx = tl.where(valid_slot & valid_idx, idx, -1)
-    tl.store(ti_ptrs, masked_idx.to(ti_ptr.dtype.element_ty), mask=store_mask)
+    ti_out_ptrs = ti_out_ptr + pid_h * stride_out_h + pid_b * stride_out_b + off_t * stride_out_t
+    tl.store(ti_out_ptrs, masked_idx.to(tl.int32), mask=store_mask)
+    valid_count = tl.sum((valid_slot & valid_idx).to(tl.int32))
+    tl.store(select_num_idx_ptr + pid_h * stride_select_h + pid_b * stride_select_b, valid_count)
 
 
 # ---------------------------------------------------------------------------
@@ -778,10 +743,11 @@ def minimax_m3_index_decode(
     max_decode_query_len: int | None = None,
     out: torch.Tensor | None = None,
     sm_scale=None,
-) -> torch.Tensor:
+) -> tuple[torch.Tensor, torch.Tensor]:
     """Decode index block-score + top-k (torch.topk + invalid-index mask).
 
-    Returns topk_idx [num_kv_heads, total_q, topk] (0-indexed block ids, -1 pad).
+    Returns ``(topk_idx, select_num_idx)``. Invalid block IDs are ``-1`` and
+    ``select_num_idx`` contains the number of valid IDs for each head/query.
     When ``out`` ([num_kv_heads, >=total_q, topk]) is given, writes into
     ``out[:, :total_q, :]`` (stable address for cudagraph) instead of allocating.
     """
@@ -796,12 +762,13 @@ def minimax_m3_index_decode(
     max_block = triton.cdiv(max_seq_len, SPARSE_BLOCK_SIZE)
     del sm_scale
 
-    # Keep score strides 16-divisible to avoid Triton recompiles. The score
-    # kernel writes only visible blocks; the existing pad-tail kernel below
-    # initializes the remaining entries to -inf.
-    score_block_stride = round_up(max_block, 16)
-    score = torch.empty(
+    # Pre-fill the tail so torch.topk can run directly on one contiguous tensor
+    # without a separate pad kernel. Keep the stride 16-divisible and at least
+    # topk wide so the output shape is stable for short sequences.
+    score_block_stride = round_up(max(max_block, topk), 16)
+    score = torch.full(
         (num_idx_heads, total_q, score_block_stride),
+        float("-inf"),
         dtype=torch.float32,
         device=idx_q.device,
     )
@@ -841,46 +808,40 @@ def minimax_m3_index_decode(
         BLOCK_SIZE_K=SPARSE_BLOCK_SIZE,
         NUM_CHUNKS=num_kv_chunks,
     )
-    # Chunk count `pad_target` is shape-constant (cudagraph-safe)
-    TOPK_TARGET_GRID = 64
-    MAX_NUM_TOPK_CHUNKS = 16
-    pad_target = max(1, min(MAX_NUM_TOPK_CHUNKS, TOPK_TARGET_GRID // max(1, batch * num_idx_heads)))
-    pad_chunk_blocks = (max_block + pad_target - 1) // pad_target
-    _decode_index_score_pad_tail_kernel[(batch, num_idx_heads, pad_target)](
-        score,
-        seq_lens,
-        SPARSE_BLOCK_SIZE,
-        max_block,
-        decode_query_len,
-        pad_chunk_blocks,
-        score.stride(0),
-        score.stride(1),
-        score.stride(2),
-        BLOCK_SIZE_K=2048,
-    )
-
-    score_rows = score[:, :total_q, :max_block]
-    _, topk_idx_raw = torch.topk(score_rows, k=min(topk, max_block), dim=-1)
+    _, topk_idx_raw = torch.topk(score, k=topk, dim=-1)
     if out is not None:
         topk_idx = out[:, :total_q, :]
-        topk_idx.copy_(topk_idx_raw)
     else:
-        if max_block < topk:
-            topk_idx = torch.empty(num_idx_heads, total_q, topk, dtype=torch.int32, device=idx_q.device)
-            topk_idx[..., :max_block].copy_(topk_idx_raw.to(torch.int32))
-        else:
-            topk_idx = topk_idx_raw.to(torch.int32)
-    _topk_index_mask_invalid_kernel[(batch, num_idx_heads)](
+        topk_idx = torch.empty(
+            num_idx_heads,
+            total_q,
+            topk,
+            dtype=torch.int32,
+            device=idx_q.device,
+        )
+    select_num_idx = torch.empty(
+        (num_idx_heads, total_q),
+        dtype=torch.int32,
+        device=idx_q.device,
+    )
+    _index_topk_postprocess_kernel[(batch, num_idx_heads)](
+        topk_idx_raw,
         topk_idx,
+        select_num_idx,
         seq_lens,
         SPARSE_BLOCK_SIZE,
         topk,
         decode_query_len,
+        topk_idx_raw.stride(0),
+        topk_idx_raw.stride(1),
+        topk_idx_raw.stride(2),
         topk_idx.stride(0),
         topk_idx.stride(1),
         topk_idx.stride(2),
+        select_num_idx.stride(0),
+        select_num_idx.stride(1),
     )
-    return topk_idx
+    return topk_idx, select_num_idx
 
 
 # ---------------------------------------------------------------------------

--- a/vllm_ascend/ops/register_custom_ops.py
+++ b/vllm_ascend/ops/register_custom_ops.py
@@ -160,7 +160,13 @@ def _rope_forward_oot_impl_fake(
     head_dim: int,
     rotary_dim: int,
     is_neox_style: bool = True,
+    offsets: torch.Tensor | None = None,
+    out_dtype: torch.dtype | None = None,
 ) -> tuple[torch.Tensor, torch.Tensor]:
+    if out_dtype is not None and out_dtype != torch.float8_e4m3fn:
+        raise NotImplementedError(f"Unsupported RoPE output dtype: {out_dtype}")
+    if out_dtype is not None:
+        return torch.empty_like(query, dtype=out_dtype), torch.empty_like(key, dtype=out_dtype)
     return query, key
 
 

--- a/vllm_ascend/ops/rotary_embedding.py
+++ b/vllm_ascend/ops/rotary_embedding.py
@@ -161,12 +161,27 @@ def rope_forward_oot(
     rotary_dim: int,
     is_neox_style: bool,
     offsets: torch.Tensor | None = None,
+    out_dtype: torch.dtype | None = None,
 ) -> tuple[torch.Tensor, torch.Tensor]:
+    if out_dtype == torch.float8_e4m3fn and key is None:
+        raise ValueError("float8_e4m3fn RoPE output requires a key tensor")
     query_shape, key_shape = query.shape, key.shape
     if offsets is not None:
         raise NotImplementedError("Batched rotary embedding is currently not supported on NPU.")
+    if out_dtype is not None and out_dtype != torch.float8_e4m3fn:
+        raise NotImplementedError(f"Unsupported RoPE output dtype: {out_dtype}")
     if HAS_TRITON:
         num_tokens = query.shape[0]
+        if out_dtype == torch.float8_e4m3fn:
+            query_width = query.numel() // num_tokens
+            key_width = key.numel() // num_tokens
+            if query_width % head_size != 0 or key_width % head_size != 0:
+                head_size = key_width
+                if query_width % head_size != 0:
+                    raise ValueError(
+                        f"Cannot infer the FP8 RoPE head size from query_width={query_width}, key_width={key_width}"
+                    )
+            rotary_dim = min(rotary_dim, head_size)
         query, key = rope_forward_triton(
             query.view(num_tokens, -1, head_size),
             key.view(num_tokens, -1, head_size),
@@ -174,8 +189,11 @@ def rope_forward_oot(
             positions=positions,
             rope_dim=rotary_dim,
             is_neox_style=is_neox_style,
+            out_dtype=out_dtype,
         )
     else:
+        if out_dtype == torch.float8_e4m3fn:
+            raise RuntimeError("float8_e4m3fn RoPE output requires Triton")
         # npu_mrope handles both full and partial rotary internally:
         # it splits query into queryRot[..., :rotary_dim] and queryPass[..., rotary_dim:],
         # where rotary_dim is inferred from cos_sin_cache.shape[-1].
@@ -217,6 +235,7 @@ class AscendRotaryEmbedding(RotaryEmbedding):
         key: torch.Tensor,
         offsets: torch.Tensor | None = None,
         is_neox_style_override: bool | None = None,
+        out_dtype: torch.dtype | None = None,
     ):
         is_neox_style = self.is_neox_style
         if is_neox_style_override is not None:
@@ -225,9 +244,19 @@ class AscendRotaryEmbedding(RotaryEmbedding):
         if is_draft_model and self.use_mtp and enable_sp():
             tp_group = get_tp_group()
             positions = torch.ops.vllm.all_gather(positions.contiguous(), 0, tp_group.world_size, tp_group.unique_name)
-        return torch.ops.vllm.npu_rotary_embedding(
-            positions, query, key, self.cos_sin_cache, self.head_size, self.rotary_dim, is_neox_style
+
+        rope_args = (
+            positions,
+            query,
+            key,
+            self.cos_sin_cache,
+            self.head_size,
+            self.rotary_dim,
+            is_neox_style,
         )
+        if out_dtype is None:
+            return torch.ops.vllm.npu_rotary_embedding(*rope_args)
+        return torch.ops.vllm.npu_rotary_embedding(*rope_args, out_dtype=out_dtype)
 
 
 class AscendYaRNRotaryEmbedding(YaRNScalingRotaryEmbedding):
@@ -271,8 +300,17 @@ class AscendYaRNRotaryEmbedding(YaRNScalingRotaryEmbedding):
         key: torch.Tensor,
         offsets: torch.Tensor | None = None,
         is_neox_style_override: bool | None = None,
+        out_dtype: torch.dtype | None = None,
     ):
-        return AscendRotaryEmbedding.forward_oot(self, positions, query, key, offsets, is_neox_style_override)
+        return AscendRotaryEmbedding.forward_oot(
+            self,
+            positions,
+            query,
+            key,
+            offsets,
+            is_neox_style_override,
+            out_dtype,
+        )
 
 
 class AscendDeepseekScalingRotaryEmbedding(DeepseekScalingRotaryEmbedding):

--- a/vllm_ascend/ops/triton/docs/rope.md
+++ b/vllm_ascend/ops/triton/docs/rope.md
@@ -28,6 +28,32 @@ Source: `vllm_ascend/ops/triton/rope.py` (host wrapper: `rope_forward_triton`).
   6. Kernel side: repeat the same tiled loop for the K heads (`n_kh`), then advance to the next row.
 - **Supported modes**: Atlas A2, Atlas A3, and Ascend 950.
 
+### FP8 E4M3 output variant
+
+- **Function**: When `rope_forward_triton` is called with `out_dtype=torch.float8_e4m3fn`, it dispatches to `_triton_rope_fp8`. This variant applies NeoX-style RoPE to bf16 Q/K and writes separate fixed-scale E4M3 outputs, avoiding an intermediate rotated bf16 tensor in the MiniMax-M3 sparse index path. For partial rotary, the non-rotary tail is copied through the same FP8 conversion.
+- **Formula**: For `half = rope_dim // 2`:
+
+    ```text
+    x1 = x[..., :half]
+    x2 = x[..., half:rope_dim]
+    r1 = x1 * cos(m) - x2 * sin(m)
+    r2 = x2 * cos(m) + x1 * sin(m)
+
+    quant_fp8(v) = cast_float8_e4m3fn(clamp(v, -448, 448))
+    out[..., :rope_dim] = quant_fp8(cat((r1, r2), dim=-1))
+    out[..., rope_dim:] = quant_fp8(x[..., rope_dim:])
+    ```
+
+    The rotation is evaluated in fp32 before the fixed-scale E4M3 conversion.
+- **Algorithm flow** (processed row by row, independently):
+  1. The Ascend `rope_forward_oot` dispatcher selects the Triton path for `out_dtype=torch.float8_e4m3fn`; `rope_forward_triton` then requires `cos_sin_cache`, `positions`, and an explicit `rope_dim`, and `_rope_forward_triton_fp8` makes Q/K contiguous and validates or allocates contiguous E4M3 output buffers.
+  2. The host computes `pass_dim = head_dim - rope_dim`, pads the rotary half and pass-through tail independently to powers of two, and selects Q/K head tiles as `min(next_power_of_2(num_heads), 16)`.
+  3. It launches `min(num_tokens, max(get_vectorcore_num() * 8, 256))` persistent programs; each program strides over token rows by the number of launched programs.
+  4. For each row, the kernel indexes `cos_sin_cache` with `positions[row_idx]`, loads the cosine and sine halves, and converts them to fp32.
+  5. It processes Q heads in `BLOCK_QH` tiles, rotates in fp32, clamps each result to `[-448, 448]`, and stores directly as E4M3. A non-rotary tail is clipped and converted in the same way.
+  6. It repeats the operation for K using `BLOCK_KH`, then advances to the next token row.
+- **Supported modes**: Ascend 950 (A5). Atlas A2 and Atlas A3 do not support this FP8 execution path.
+
 ## Parameters
 
 > [!NOTE]
@@ -56,6 +82,33 @@ Source: `vllm_ascend/ops/triton/rope.py` (host wrapper: `rope_forward_triton`).
 | `IS_NEOX_STYLE` | Input (attribute) | `True` for half-split (NeoX) rotation, `False` for interleaved (GPT-J) rotation, compile-time `constexpr` | bool | scalar |
 | `USE_COS_SIN` | Input (attribute) | `True` to read `cos_sin_ptr` + `pos_ptr`, `False` to read `cos_ptr`/`sin_ptr`, compile-time `constexpr` | bool | scalar |
 
+### FP8 E4M3 output variant
+
+| Parameter | Input/Output/Attribute | Description | Data type | Data format |
+| --- | --- | --- | --- | --- |
+| `q_ptr` | Input | Query tensor `[num_tokens, n_qh, hd]`, contiguous | bf16 | ND |
+| `q_row_stride` | Input (attribute) | Row stride of `q` (`q.stride(0)`, normally `n_qh * hd`) | int32 | scalar |
+| `k_ptr` | Input | Key tensor `[num_tokens, n_kh, hd]`, contiguous | bf16 | ND |
+| `k_row_stride` | Input (attribute) | Row stride of `k` (`k.stride(0)`, normally `n_kh * hd`) | int32 | scalar |
+| `q_out_ptr` | Output | Rotated and quantized query tensor `[num_tokens, n_qh, hd]`, contiguous | float8_e4m3fn | ND |
+| `q_out_row_stride` | Input (attribute) | Row stride of `q_out` (`q_out.stride(0)`) | int32 | scalar |
+| `k_out_ptr` | Output | Rotated and quantized key tensor `[num_tokens, n_kh, hd]`, contiguous | float8_e4m3fn | ND |
+| `k_out_row_stride` | Input (attribute) | Row stride of `k_out` (`k_out.stride(0)`) | int32 | scalar |
+| `cos_sin_ptr` | Input | Raw rotation cache `[max_position_embeddings, rope_dim]`; each row is `[cos, sin]` | bf16 | ND |
+| `cos_sin_row_stride` | Input (attribute) | Row stride of `cos_sin_cache` | int32 | scalar |
+| `pos_ptr` | Input | Token positions `[num_tokens]` used to index `cos_sin_cache` | int64 | ND |
+| `num_tokens` | Input (attribute) | Number of token rows to process | int32 | scalar |
+| `n_qh` | Input (attribute) | Number of query heads, compile-time `constexpr` | int32 | scalar |
+| `n_kh` | Input (attribute) | Number of key heads, compile-time `constexpr` | int32 | scalar |
+| `hd` | Input (attribute) | Head dimension, compile-time `constexpr` | int32 | scalar |
+| `rope_dim` | Input (attribute) | Even rotary dimension no larger than `hd`, compile-time `constexpr` | int32 | scalar |
+| `pad_half` | Input (attribute) | `next_power_of_2(rope_dim // 2)`, compile-time `constexpr` | int32 | scalar |
+| `pad_pass` | Input (attribute) | `next_power_of_2(pass_dim)` for a non-empty tail, otherwise `1`; compile-time `constexpr` | int32 | scalar |
+| `pass_dim` | Input (attribute) | Non-rotary tail width `hd - rope_dim`, compile-time `constexpr` | int32 | scalar |
+| `BLOCK_QH` | Input (attribute) | Query-head tile `min(next_power_of_2(n_qh), 16)`, compile-time `constexpr` | int32 | scalar |
+| `BLOCK_KH` | Input (attribute) | Key-head tile `min(next_power_of_2(n_kh), 16)`, compile-time `constexpr` | int32 | scalar |
+| `FP8_MAX` | Input (attribute) | E4M3 finite-range clipping bound, fixed to `448.0`, compile-time `constexpr` | fp32 | scalar |
+
 ## Constraints
 
 - `q` and `k` must be 3-D `[num_tokens, num_heads, head_dim]`. Already-contiguous inputs are modified in place. For a non-contiguous input, the wrapper creates and rotates a contiguous copy instead, so the caller's original view is unchanged and the returned tensor must be used.
@@ -67,12 +120,32 @@ Source: `vllm_ascend/ops/triton/rope.py` (host wrapper: `rope_forward_triton`).
 - Rotation is computed in fp32 and cast back to the input dtype on store; `q` and `k` must share the same dtype and head dimension.
 - `num_tokens` is dynamic (the grid is capped by the vector-core count and the kernel strides over rows), so the kernel is graph-mode friendly: the launch grid does not depend on runtime tensor values, and no host synchronization occurs inside.
 
+### FP8 E4M3 output variant
+
+- The FP8 path is selected only by calling `rope_forward_triton(..., out_dtype=torch.float8_e4m3fn)`. Other non-`None` output dtypes are rejected.
+- Q and K must be 3-D tensors with the same `num_tokens` and `head_dim`. The validated model path and test coverage use bf16 inputs.
+- Outputs are out of place. Caller-provided `q_out` and `k_out` must be contiguous `torch.float8_e4m3fn` tensors with shapes matching Q and K; otherwise the wrapper allocates them.
+- Only NeoX-style half-split rotation is supported. Passing `is_neox_style=False` raises `NotImplementedError`.
+- The FP8 path requires `cos_sin_cache` together with `positions`; the pre-selected `cos`/`sin` mode is not supported.
+- `rope_dim` must be explicit, even, greater than zero, and no larger than `head_dim`. A non-rotary tail is still clipped and converted to E4M3.
+- Each position must be in `[0, cos_sin_cache.shape[0])`. Each cache row contains `rope_dim // 2` cosine values followed by the same number of sine values.
+- Conversion uses a fixed scale of `1.0`: values are clipped to `[-448, 448]` and cast directly to `torch.float8_e4m3fn`; no dynamic scale is calculated or returned.
+- Q/K head tiles are capped at `16` to bound UB usage. Masks suppress padded heads and padded rotary or pass-through lanes.
+- The launch grid depends only on tensor shapes and the vector-core count, and the kernel performs no data-dependent host synchronization, so it is compatible with the graph-capture path used by MiniMax-M3.
+
 ## Origin and Differences
 
 - **Origin**: Developed for vllm-ascend as the Triton implementation of the vLLM `RotaryEmbedding.forward` / `rotary_embedding` custom op; it replaces `torch_npu.npu_mrope` in `rope_forward_oot` when Triton is available.
 - **Differences**:
     - NPU adaptation for performance: a persistent grid of `min(num_tokens, get_vectorcore_num())` programs with an inner row-stride loop instead of one program per token, plus head tiling via `BLOCK_SIZE_HEAD` (reduced to `16` for `head_dim >= 256`) to keep every load/store block inside UB; Q and K are rotated in the same kernel and written in place, avoiding the extra allocations of the native path;
     - Modified for a specific vllm-ascend logic or different input parameters: accepts both the `cos_sin_cache` + `positions` form used by `rope_forward_oot` and the pre-selected `cos`/`sin` form used by fused attention paths (`USE_COS_SIN`), supports `rope_dim != head_dim` partial rotary with the pass-through tail, and handles NeoX and GPT-J layouts in one kernel through `IS_NEOX_STYLE`.
+
+### FP8 E4M3 output variant
+
+- **Origin**: Developed from `_triton_rope` to support the MiniMax-M3 sparse index path with a native E4M3 index cache.
+- **Differences**:
+    - NPU adaptation for performance: fuses RoPE and fixed-scale E4M3 conversion into the output stores, uses separate Q/K head tiles capped at `16`, and launches up to `max(get_vectorcore_num() * 8, 256)` programs to expose enough row parallelism on A5;
+    - Modified for a specific vllm-ascend logic or different input parameters: writes separate FP8 outputs instead of updating bf16 Q/K in place, accepts only `cos_sin_cache` + `positions`, supports only NeoX layout, clips the rotated values and partial-RoPE tail to the E4M3 finite range, and uses a fixed quantization scale of `1.0`.
 
 ## Test Cases
 
@@ -83,4 +156,12 @@ Source: `vllm_ascend/ops/triton/rope.py` (host wrapper: `rope_forward_triton`).
 
 ```bash
 pytest -sv tests/e2e/nightly/single_node/ops/singlecard_ops/triton/test_rope.py -k "not siso"
+```
+
+### FP8 E4M3 output variant
+
+`test_rotary_embedding_triton_kernel_fp8` in the same test file compares `rope_forward_triton(..., out_dtype=torch.float8_e4m3fn)` against a PyTorch-native fp32-accumulating reference followed by clipping and E4M3 conversion. It covers `(num_tokens, num_q_heads, num_k_heads, head_size, rotary_dim)` values of `(1, 2, 1, 128, 128)`, `(17, 8, 1, 128, 64)`, and `(1024, 8, 1, 128, 128)`, spanning single-token decode, partial rotary, a non-power-of-two token count, and multi-row prefill. The position-zero case injects values outside the E4M3 finite range to verify saturation to `+448` and `-448`. Accuracy comparison uses `atol=rtol=0.125` after converting actual and reference E4M3 tensors to fp32.
+
+```bash
+pytest -sv tests/e2e/nightly/single_node/ops/singlecard_ops/triton/test_rope.py -k "fp8"
 ```

--- a/vllm_ascend/ops/triton/rope.py
+++ b/vllm_ascend/ops/triton/rope.py
@@ -19,6 +19,21 @@ from vllm.triton_utils import tl, triton
 
 from vllm_ascend.ops.triton.triton_utils import get_vectorcore_num
 
+_FP8_E4M3_MAX = 448.0
+
+
+def _fp8_rope_head_block(n_heads: int, cap: int = 16) -> int:
+    """Size the FP8 RoPE head tile to the actual MiniMax-M3 head count."""
+    if n_heads <= 0:
+        return 1
+    return min(triton.next_power_of_2(n_heads), cap)
+
+
+@triton.jit
+def _store_fp8_e4m3(dst_ptr, offsets, vals_fp32, mask, FP8_MAX: tl.constexpr):
+    vals = tl.minimum(tl.maximum(vals_fp32, -FP8_MAX), FP8_MAX)
+    tl.store(dst_ptr + offsets, vals.to(dst_ptr.dtype.element_ty), mask=mask)
+
 
 @triton.jit
 def _triton_rope(
@@ -253,6 +268,145 @@ def _triton_rope_siso(
         tl.store(qk_start_ptr + second_half_offsets, new_qk_tile_2, mask=second_mask)
 
 
+@triton.jit
+def _triton_rope_fp8(
+    q_ptr,
+    q_row_stride,
+    k_ptr,
+    k_row_stride,
+    q_out_ptr,
+    q_out_row_stride,
+    k_out_ptr,
+    k_out_row_stride,
+    cos_sin_ptr,
+    cos_sin_row_stride,
+    pos_ptr,
+    num_tokens,
+    n_qh: tl.constexpr,
+    n_kh: tl.constexpr,
+    hd: tl.constexpr,
+    rope_dim: tl.constexpr,
+    pad_half: tl.constexpr,
+    pad_pass: tl.constexpr,
+    pass_dim: tl.constexpr,
+    BLOCK_QH: tl.constexpr,
+    BLOCK_KH: tl.constexpr,
+    FP8_MAX: tl.constexpr,
+):
+    """NeoX RoPE with a direct fixed-scale E4M3 output store."""
+    pid = tl.program_id(0).to(tl.int64)
+    row_block_size = tl.num_programs(0)
+    half: tl.constexpr = rope_dim // 2
+    cos_offsets = tl.arange(0, pad_half)
+    cos_mask = cos_offsets < half
+
+    for row_idx in tl.range(pid, num_tokens, row_block_size):
+        pos_idx = tl.load(pos_ptr + row_idx).to(tl.int64)
+        cos_start_ptr = cos_sin_ptr + pos_idx * cos_sin_row_stride
+        cos_row = tl.load(cos_start_ptr + cos_offsets, mask=cos_mask, other=0).to(tl.float32)
+        sin_row = tl.load(cos_start_ptr + half + cos_offsets, mask=cos_mask, other=0).to(tl.float32)
+
+        q_row = q_ptr + row_idx * q_row_stride
+        q_out_row = q_out_ptr + row_idx * q_out_row_stride
+        for q_base in tl.range(0, n_qh, BLOCK_QH):
+            q_heads = tl.arange(0, BLOCK_QH)
+            head_ok = (q_base + q_heads)[:, None] < n_qh
+            base = q_row + q_base * hd
+            out_base = q_out_row + q_base * hd
+
+            half_offs = tl.arange(0, pad_half)
+            half_mask = head_ok & (half_offs[None, :] < half)
+            x1 = tl.load(
+                base + q_heads[:, None] * hd + half_offs[None, :],
+                mask=half_mask,
+                other=0,
+            ).to(tl.float32)
+            x2 = tl.load(
+                base + q_heads[:, None] * hd + half + half_offs[None, :],
+                mask=half_mask,
+                other=0,
+            ).to(tl.float32)
+            _store_fp8_e4m3(
+                out_base,
+                q_heads[:, None] * hd + half_offs[None, :],
+                x1 * cos_row - x2 * sin_row,
+                half_mask,
+                FP8_MAX,
+            )
+            _store_fp8_e4m3(
+                out_base,
+                q_heads[:, None] * hd + half + half_offs[None, :],
+                x2 * cos_row + x1 * sin_row,
+                half_mask,
+                FP8_MAX,
+            )
+            if pass_dim > 0:
+                pass_offs = tl.arange(0, pad_pass)
+                pass_mask = head_ok & (pass_offs[None, :] < pass_dim)
+                pass_vals = tl.load(
+                    base + q_heads[:, None] * hd + rope_dim + pass_offs[None, :],
+                    mask=pass_mask,
+                    other=0,
+                ).to(tl.float32)
+                _store_fp8_e4m3(
+                    out_base,
+                    q_heads[:, None] * hd + rope_dim + pass_offs[None, :],
+                    pass_vals,
+                    pass_mask,
+                    FP8_MAX,
+                )
+
+        k_row = k_ptr + row_idx * k_row_stride
+        k_out_row = k_out_ptr + row_idx * k_out_row_stride
+        for k_base in tl.range(0, n_kh, BLOCK_KH):
+            k_heads = tl.arange(0, BLOCK_KH)
+            head_ok = (k_base + k_heads)[:, None] < n_kh
+            base = k_row + k_base * hd
+            out_base = k_out_row + k_base * hd
+
+            half_offs = tl.arange(0, pad_half)
+            half_mask = head_ok & (half_offs[None, :] < half)
+            x1 = tl.load(
+                base + k_heads[:, None] * hd + half_offs[None, :],
+                mask=half_mask,
+                other=0,
+            ).to(tl.float32)
+            x2 = tl.load(
+                base + k_heads[:, None] * hd + half + half_offs[None, :],
+                mask=half_mask,
+                other=0,
+            ).to(tl.float32)
+            _store_fp8_e4m3(
+                out_base,
+                k_heads[:, None] * hd + half_offs[None, :],
+                x1 * cos_row - x2 * sin_row,
+                half_mask,
+                FP8_MAX,
+            )
+            _store_fp8_e4m3(
+                out_base,
+                k_heads[:, None] * hd + half + half_offs[None, :],
+                x2 * cos_row + x1 * sin_row,
+                half_mask,
+                FP8_MAX,
+            )
+            if pass_dim > 0:
+                pass_offs = tl.arange(0, pad_pass)
+                pass_mask = head_ok & (pass_offs[None, :] < pass_dim)
+                pass_vals = tl.load(
+                    base + k_heads[:, None] * hd + rope_dim + pass_offs[None, :],
+                    mask=pass_mask,
+                    other=0,
+                ).to(tl.float32)
+                _store_fp8_e4m3(
+                    out_base,
+                    k_heads[:, None] * hd + rope_dim + pass_offs[None, :],
+                    pass_vals,
+                    pass_mask,
+                    FP8_MAX,
+                )
+
+
 def rope_forward_triton(
     q: torch.Tensor,
     k: torch.Tensor,
@@ -262,7 +416,31 @@ def rope_forward_triton(
     positions: torch.Tensor = None,
     rope_dim: int = -1,
     is_neox_style: bool = True,
+    out_dtype: torch.dtype | None = None,
+    q_out: torch.Tensor | None = None,
+    k_out: torch.Tensor | None = None,
 ) -> tuple[torch.Tensor, torch.Tensor]:
+    """Apply RoPE and optionally write fixed-scale E4M3 outputs."""
+    if out_dtype is not None:
+        if out_dtype != torch.float8_e4m3fn:
+            raise NotImplementedError(f"Unsupported RoPE output dtype: {out_dtype}")
+        if cos_sin_cache is None or positions is None:
+            raise ValueError("FP8 RoPE output requires cos_sin_cache and positions")
+        if rope_dim == -1:
+            raise ValueError("FP8 RoPE output requires rope_dim")
+        return _rope_forward_triton_fp8(
+            q,
+            k,
+            cos_sin_cache=cos_sin_cache,
+            positions=positions,
+            rope_dim=rope_dim,
+            is_neox_style=is_neox_style,
+            q_out=q_out,
+            k_out=k_out,
+        )
+    if q_out is not None or k_out is not None:
+        raise ValueError("q_out and k_out require an FP8 output dtype")
+
     if not q.is_contiguous():
         q = q.contiguous()
     if not k.is_contiguous():
@@ -429,3 +607,67 @@ def rope_forward_triton_siso(
             "Please check whether you call rope_forward_triton correctly."
         )
     return qk
+
+
+def _rope_forward_triton_fp8(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    cos_sin_cache: torch.Tensor,
+    positions: torch.Tensor,
+    rope_dim: int,
+    is_neox_style: bool = True,
+    q_out: torch.Tensor | None = None,
+    k_out: torch.Tensor | None = None,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Apply NeoX RoPE and write fixed-scale float8_e4m3fn outputs."""
+    q = q.contiguous()
+    k = k.contiguous()
+    num_tokens, n_q_head, head_dim = q.shape
+    n_kv_head = k.shape[1]
+    if k.shape[0] != num_tokens or k.shape[2] != head_dim:
+        raise ValueError("q and k must share token and head dimensions")
+
+    fp8_dtype = torch.float8_e4m3fn
+    q_out = torch.empty_like(q, dtype=fp8_dtype) if q_out is None else q_out
+    k_out = torch.empty_like(k, dtype=fp8_dtype) if k_out is None else k_out
+    if q_out.dtype != fp8_dtype or k_out.dtype != fp8_dtype:
+        raise TypeError("q_out and k_out must use torch.float8_e4m3fn")
+    if not q_out.is_contiguous() or not k_out.is_contiguous():
+        raise ValueError("q_out and k_out must be contiguous")
+    if not is_neox_style:
+        raise NotImplementedError("FP8 RoPE currently supports NeoX style only")
+    if positions.shape[0] != num_tokens:
+        raise ValueError("positions and q must contain the same number of tokens")
+    if rope_dim > head_dim or rope_dim % 2 != 0:
+        raise ValueError("rope_dim must be even and no larger than head_dim")
+
+    pass_dim = head_dim - rope_dim
+    pad_half = triton.next_power_of_2(rope_dim // 2)
+    pad_pass = triton.next_power_of_2(pass_dim) if pass_dim > 0 else 1
+    vector_cores = get_vectorcore_num()
+    grid = min(num_tokens, max(vector_cores * 8, 256))
+    _triton_rope_fp8[(grid,)](
+        q,
+        q.stride(0),
+        k,
+        k.stride(0),
+        q_out,
+        q_out.stride(0),
+        k_out,
+        k_out.stride(0),
+        cos_sin_cache,
+        cos_sin_cache.stride(0),
+        positions,
+        num_tokens,
+        n_q_head,
+        n_kv_head,
+        head_dim,
+        rope_dim,
+        pad_half,
+        pad_pass,
+        pass_dim,
+        BLOCK_QH=_fp8_rope_head_block(n_q_head),
+        BLOCK_KH=_fp8_rope_head_block(n_kv_head),
+        FP8_MAX=_FP8_E4M3_MAX,
+    )
+    return q_out, k_out

--- a/vllm_ascend/platform.py
+++ b/vllm_ascend/platform.py
@@ -637,22 +637,17 @@ def _configure_minimax_m3_a5_mixed_kv_cache(vllm_config: VllmConfig) -> None:
     sparse_freq = sparse_config.get("sparse_attention_freq") or []
     sparse_layer_ids = {layer_idx for layer_idx, freq in enumerate(sparse_freq) if freq != 0}
     gqa_layer_ids = [
-        str(layer_idx)
-        for layer_idx in range(text_config.num_hidden_layers)
-        if layer_idx not in sparse_layer_ids
+        str(layer_idx) for layer_idx in range(text_config.num_hidden_layers) if layer_idx not in sparse_layer_ids
     ]
     if not gqa_layer_ids:
         return
 
-    skip_layers = list(
-        dict.fromkeys(str(layer) for layer in (cache_config.kv_cache_dtype_skip_layers or []))
-    )
+    skip_layers = list(dict.fromkeys(str(layer) for layer in (cache_config.kv_cache_dtype_skip_layers or [])))
     known_skip_layers = set(skip_layers)
     skip_layers.extend(layer for layer in gqa_layer_ids if layer not in known_skip_layers)
     cache_config.kv_cache_dtype_skip_layers = skip_layers
     logger.info_once(
-        "Using BF16 KV cache for MiniMax-M3 GQA layers %s on Ascend A5; "
-        "other layers retain the configured %s policy.",
+        "Using BF16 KV cache for MiniMax-M3 GQA layers %s on Ascend A5; other layers retain the configured %s policy.",
         ", ".join(gqa_layer_ids),
         cache_config.cache_dtype,
     )

--- a/vllm_ascend/platform.py
+++ b/vllm_ascend/platform.py
@@ -76,6 +76,12 @@ logger.info_once(
 _CUSTOM_OP_REGISTERED = False
 # Delete after the driver is released; temporarily hard-coded to 4
 MAX_REDUCED_CAPTURE_SIZES = 4
+_MINIMAX_M3_ARCHITECTURES = frozenset(
+    {
+        "MiniMaxM3SparseForCausalLM",
+        "MiniMaxM3SparseForConditionalGeneration",
+    }
+)
 
 
 class NPUPlatform(Platform):
@@ -613,6 +619,45 @@ class NPUPlatform(Platform):
         }
 
 
+def _configure_minimax_m3_a5_mixed_kv_cache(vllm_config: VllmConfig) -> None:
+    """Keep MiniMax-M3 GQA KV cache in BF16 on the A5 FP8 path."""
+    model_config = vllm_config.model_config
+    cache_config = vllm_config.cache_config
+    if (
+        model_config is None
+        or cache_config is None
+        or model_config.architecture not in _MINIMAX_M3_ARCHITECTURES
+        or cache_config.cache_dtype not in ("fp8", "fp8_e4m3")
+        or not get_current_hardware_profile().supports(HardwareCapability.FP8_ATTENTION)
+    ):
+        return
+
+    text_config = model_config.hf_text_config
+    sparse_config = getattr(text_config, "sparse_attention_config", None) or {}
+    sparse_freq = sparse_config.get("sparse_attention_freq") or []
+    sparse_layer_ids = {layer_idx for layer_idx, freq in enumerate(sparse_freq) if freq != 0}
+    gqa_layer_ids = [
+        str(layer_idx)
+        for layer_idx in range(text_config.num_hidden_layers)
+        if layer_idx not in sparse_layer_ids
+    ]
+    if not gqa_layer_ids:
+        return
+
+    skip_layers = list(
+        dict.fromkeys(str(layer) for layer in (cache_config.kv_cache_dtype_skip_layers or []))
+    )
+    known_skip_layers = set(skip_layers)
+    skip_layers.extend(layer for layer in gqa_layer_ids if layer not in known_skip_layers)
+    cache_config.kv_cache_dtype_skip_layers = skip_layers
+    logger.info_once(
+        "Using BF16 KV cache for MiniMax-M3 GQA layers %s on Ascend A5; "
+        "other layers retain the configured %s policy.",
+        ", ".join(gqa_layer_ids),
+        cache_config.cache_dtype,
+    )
+
+
 def _fix_incompatible_config(vllm_config: VllmConfig) -> None:
     """
     Check and correct parameters in VllmConfig that are incompatible with Ascend NPU.
@@ -646,6 +691,8 @@ def _fix_incompatible_config(vllm_config: VllmConfig) -> None:
                 "Parameter is not supported on Ascend NPU. parameter=calculate_kv_scales, action: resetting to False."
             )
             vllm_config.cache_config.calculate_kv_scales = False
+
+        _configure_minimax_m3_a5_mixed_kv_cache(vllm_config)
 
     # ==================== 3. MultiModal Config ====================
     multimodal_config = getattr(model_config, "multimodal_config", None) if model_config else None

--- a/vllm_ascend/worker/worker.py
+++ b/vllm_ascend/worker/worker.py
@@ -1032,16 +1032,18 @@ class NPUWorker(WorkerBase):
 
         # MRV2's scheduler emits new_block_ids_to_zero whenever this flag is
         # set, so its worker-side consumer must use the same condition. Keep the
-        # narrower Eagle3 condition for MRV1, where zeroing was introduced only
-        # for the multi-step speculative-decode reuse issue.
+        # narrower Mamba + Eagle3 condition for MRV1, where zeroing was
+        # introduced only to prevent a recycled Mamba block from exposing stale
+        # values when reused by full attention during multi-step speculation.
         speculative_config = self.vllm_config.speculative_config
-        needs_mrv1_eagle_zeroing = (
-            speculative_config is not None
+        needs_mrv1_mamba_eagle_zeroing = (
+            kv_cache_config.has_mamba_layers
+            and speculative_config is not None
             and speculative_config.method == "eagle3"
             and speculative_config.num_speculative_tokens > 1
         )
         should_init_kv_zeroer = kv_cache_config.needs_kv_cache_zeroing and (
-            self.use_v2_model_runner or needs_mrv1_eagle_zeroing
+            self.use_v2_model_runner or needs_mrv1_mamba_eagle_zeroing
         )
         # Keep bookkeeping buffers outside the sleep-mode KV-cache pool so they
         # survive sleep/wake cycles.


### PR DESCRIPTION
### What this PR does / why we need it?

Backports #15371 to `releases/v0.27.1rc` and makes the MiniMax-M3 A5 mixed-cache policy automatic.

Users only need:

```bash
--kv-cache-dtype fp8
```

When the resolved model is MiniMax-M3, the device supports the A5 FP8-attention path, and the global KV cache dtype is FP8, the platform derives the dense GQA layers from `sparse_attention_freq` and keeps their KV cache in the model dtype (BF16). MSA and index caches continue to use native FP8 E4M3. No `--kv-cache-dtype-skip-layers` argument is required.

The policy is applied before workers start, so the generic GQA attention layers, MiniMax-M3 sparse cache specs, and KV-cache allocation observe the same configuration. Explicit user skip-layer settings are preserved.

Source PR: #15371  
Backport commit: `7bf3aebd667eb05d76dbce0a97c64e60c944a64e`  
Automatic GQA policy commit: `efe126225a7f96954a9ef06cef1ecf665167a804`

The FP8 prefill path requires the updated CANN operator implementation from [ops-transformer PR 10268](https://gitcode.com/cann/ops-transformer/pull/10268).

### Does this PR introduce _any_ user-facing change?

Yes. MiniMax-M3 on Ascend A5 automatically uses BF16 KV cache for GQA layers and native FP8 E4M3 for MSA/index caches when `--kv-cache-dtype fp8` is selected.

### How was this patch tested?

- Added unit coverage for automatic A5 + MiniMax-M3 + FP8 selection, strict non-A5/non-MiniMax/non-FP8 gating, and preservation of explicit skip-layer settings.
- `git diff --check origin/releases/v0.27.1rc...HEAD`
- Compiled all changed Python files with `python -m compileall`.
- The #15371 patch itself retains the merged patch's stable patch ID: `7e75a3dbac940a957c974ee53715f34420ae117d`.
- The original PR was manually built and launched on Ascend A5 with MiniMax-M3 MXFP8, TP4/DP2, and EAGLE3; `GET /health` and `POST /v1/chat/completions` returned HTTP 200.
- The new automatic selection has not been rerun on Ascend hardware locally; CI verification is required.

### Co-authors

- NengXu001 (`xuneng1998@gmail.com`): Added FP8 sparse-attention KV cache support.
- yuxingcyx (`yuxingchen.math@gmail.com`): Added FP8 index-cache, RoPE, and index-score support.

- vLLM main: https://github.com/vllm-project/vllm/commit/ba07e4a48fc951300d97eb506217dd530583dea3
