### PR TITLE
[v0.26.0rc][Bugfix]Use full vector cores in scatter_nd_update_sk tiling

### DIFF
--- a/csrc/moe/scatter_nd_update_sk/op_host/scatter_nd_update_sk_tiling.cpp
+++ b/csrc/moe/scatter_nd_update_sk/op_host/scatter_nd_update_sk_tiling.cpp
@@ -505,14 +505,8 @@ ge::graphStatus ScatterNdUpdateSkArch22Tiling::Init()
     }
     auto compileInfo = tilingContext_->GetCompileInfo<ScatterNdUpdateSkArch22CompileInfo>();
     OP_CHECK_NULL_WITH_CONTEXT(tilingContext_, compileInfo);
-    coreNum_ = std::min(static_cast<uint64_t>(compileInfo->vectorCoreNum), std::min(info.totalLength, info.indexRow));
-    coreNum_ = coreNum_ == 0 ? 1 : coreNum_;
-
-    // Align coreNum_ to even: SyncAll-based kernels require an even number of
-    // cores per block (see https://gitcode.com/cann/ops-nn/pull/9645).
-    if (coreNum_ % 2 != 0) {
-        coreNum_ += 1;
-    }
+    // Use all available vector cores for full-core scheduling.
+    coreNum_ = static_cast<uint64_t>(compileInfo->vectorCoreNum);
     ubSize_ = compileInfo->ubSize;
     GetDtypeSize();
     SetTilingKeyMode();


### PR DESCRIPTION

### What this PR does / why we need it:

The `scatter_nd_update_sk` arch22 tiling previously clamped `coreNum_` to `min(vectorCoreNum, min(totalLength, indexRow))` and then aligned it up to an even number. When the workload (`totalLength` or `indexRow`) was smaller than the number of available vector cores, this caused the kernel to be scheduled on only a few cores, under-utilizing the device.

This PR removes the clamping and even-alignment logic, so the kernel is always scheduled with **all available vector cores**:

```cpp
// Use all available vector cores for full-core scheduling.
coreNum_ = static_cast<uint64_t>(compileInfo->vectorCoreNum);
```

The existing front/tail block distribution logic in `Tiling4Scatter` / `Tiling4LinearIndex` already handles `coreNum_ > workload` gracefully (front cores each process one block, tail cores process zero), so no other changes are required.

### Does this PR introduce _any_ user-facing change?:

No.

### How was this patch tested?:

CI verification only (existing scatter_nd_update_sk operator UT/ST covers the tiling change).
- vLLM main: https://github.com/vllm-project/vllm/commit/d02df748bf9efd99022f1a062597dc3cb3808485
