### PR TITLE
[Feature][A5] Support fused RMSNorm cast on Ascend 950

### DIFF
--- a/csrc/build_aclnn.sh
+++ b/csrc/build_aclnn.sh
@@ -233,6 +233,7 @@ elif [[ "$SOC_VERSION" =~ ^ascend950 ]]; then
         "k2q_csr"
         "sparse_attention_score"
         "mla_prolog_v3"
+        "rms_norm_cast"
     )
 
     CUSTOM_OPS=$(IFS=';'; echo "${CUSTOM_OPS_ARRAY[*]}")

--- a/csrc/moe/rms_norm_cast/op_host/rms_norm_cast_def.cpp
+++ b/csrc/moe/rms_norm_cast/op_host/rms_norm_cast_def.cpp
@@ -34,6 +34,12 @@ public:
         this->Attr("epsilon").AttrType(OPTIONAL).Float(1e-6f);
         this->AICore().AddConfig("ascend910b");
         this->AICore().AddConfig("ascend910_93");
+        OpAICoreConfig regbase_config;
+        regbase_config.DynamicCompileStaticFlag(true)
+            .DynamicRankSupportFlag(true)
+            .DynamicShapeSupportFlag(true)
+            .ExtendCfgInfo("opFile.value", "rms_norm_cast");
+        this->AICore().AddConfig("ascend950", regbase_config);
     }
 };
 OP_ADD(RmsNormCast);

--- a/csrc/moe/rms_norm_cast/op_host/rms_norm_cast_tiling.cpp
+++ b/csrc/moe/rms_norm_cast/op_host/rms_norm_cast_tiling.cpp
@@ -55,7 +55,12 @@ ge::graphStatus Tiling4RmsNormCast(gert::TilingContext* context)
     const auto dtype = context->GetInputDesc(0)->GetDataType();
     OP_CHECK_IF(dtype != ge::DT_FLOAT16 && dtype != ge::DT_BF16,
                 OP_LOGE(context, "x only supports float16 and bfloat16"), return ge::GRAPH_FAILED);
-    context->SetTilingKey(dtype == ge::DT_FLOAT16 ? FP16_KEY : BF16_KEY);
+    const auto soc_version = platform.GetSocVersion();
+    const uint32_t tiling_key =
+        soc_version == platform_ascendc::SocVersion::ASCEND950
+            ? 0
+            : (dtype == ge::DT_FLOAT16 ? FP16_KEY : BF16_KEY);
+    context->SetTilingKey(tiling_key);
     context->SetBlockDim(used_core_num);
 
     RmsNormCastTilingData tiling;

--- a/csrc/moe/rms_norm_cast/op_kernel/rms_norm_cast.cpp
+++ b/csrc/moe/rms_norm_cast/op_kernel/rms_norm_cast.cpp
@@ -2,7 +2,11 @@
  * Copyright (c) 2026 Huawei Technologies Co., Ltd.
  * Licensed under CANN Open Software License Agreement Version 2.0.
  */
+#if defined(__DAV_C310__)
+#include "rms_norm_cast_arch35.h"
+#else
 #include "rms_norm_cast.h"
+#endif
 
 using namespace AscendC;
 
@@ -18,6 +22,15 @@ extern "C" __global__ __aicore__ void rms_norm_cast(
     GM_ADDR workspace, GM_ADDR tiling)
 {
     TPipe pipe;
+#if defined(__DAV_C310__)
+    KERNEL_TASK_TYPE_DEFAULT(KERNEL_TYPE_MIX_AIV_1_0);
+    GET_TILING_DATA_WITH_STRUCT(RmsNormCastTilingData, tiling_data_in,
+                                tiling);
+    const RmsNormCastTilingData* __restrict tiling_data = &tiling_data_in;
+    RmsNormCastArch35::KernelRmsNormCast<DTYPE_X> op(&pipe);
+    op.Init(x, gamma, y, y_fp32, tiling_data);
+    op.Process();
+#else
     GET_TILING_DATA(tiling_data, tiling);
     if (TILING_KEY_IS(1)) {
         RUN_RMS_NORM_CAST(half);
@@ -26,4 +39,5 @@ extern "C" __global__ __aicore__ void rms_norm_cast(
         RUN_RMS_NORM_CAST(bfloat16_t);
 #endif
     }
+#endif
 }

--- a/csrc/moe/rms_norm_cast/op_kernel/rms_norm_cast_arch35.h
+++ b/csrc/moe/rms_norm_cast/op_kernel/rms_norm_cast_arch35.h
@@ -1,0 +1,227 @@
+/**
+ * Copyright (c) 2026 Huawei Technologies Co., Ltd.
+ * Licensed under CANN Open Software License Agreement Version 2.0.
+ */
+#ifndef VLLM_ASCEND_RMS_NORM_CAST_ARCH35_KERNEL_H
+#define VLLM_ASCEND_RMS_NORM_CAST_ARCH35_KERNEL_H
+
+#include "kernel_operator.h"
+
+namespace RmsNormCastArch35 {
+using namespace AscendC;
+using namespace AscendC::MicroAPI;
+
+constexpr uint32_t B16_PER_BLOCK = 16;
+constexpr uint32_t VECTOR_LENGTH = AscendC::VECTOR_REG_WIDTH / sizeof(float);
+
+constexpr CastTrait CAST_B16_TO_FP32 = {
+    RegLayout::ZERO,
+    SatMode::UNKNOWN,
+    MaskMergeMode::ZEROING,
+    RoundMode::UNKNOWN,
+};
+
+constexpr CastTrait CAST_FP32_TO_B16 = {
+    RegLayout::ZERO,
+    SatMode::NO_SAT,
+    MaskMergeMode::ZEROING,
+    RoundMode::CAST_RINT,
+};
+
+template <typename T>
+__simd_vf__ void RmsNormCastVF(__local_mem__ T* x, __local_mem__ T* gamma,
+                               __local_mem__ T* y,
+                               __local_mem__ float* yFp32,
+                               uint32_t numCol, float invNumCol,
+                               float epsilon)
+{
+    RegTensor<float> sum;
+    MaskReg fullMask = CreateMask<float, MaskPattern::ALL>();
+    MaskReg firstMask = CreateMask<float, MaskPattern::VL1>();
+    Duplicate(sum, 0.0f);
+
+    uint32_t remaining = numCol;
+    const uint16_t repeats = CeilDivision(numCol, VECTOR_LENGTH);
+    for (uint16_t i = 0; i < repeats; ++i) {
+        MaskReg mask = UpdateMask<float>(remaining);
+        RegTensor<T> xB16;
+        RegTensor<float> xFp32;
+        RegTensor<float> square;
+        DataCopy<T, LoadDist::DIST_UNPACK_B16>(xB16,
+                                               x + i * VECTOR_LENGTH);
+        Cast<float, T, CAST_B16_TO_FP32>(xFp32, xB16, mask);
+        Mul(square, xFp32, xFp32, mask);
+        Add(sum, sum, square, fullMask);
+    }
+
+    ReduceSum(sum, sum, fullMask);
+    Muls(sum, sum, invNumCol, firstMask);
+    Adds(sum, sum, epsilon, firstMask);
+    Sqrt(sum, sum, firstMask);
+    RegTensor<float> one;
+    RegTensor<float> rstdScalar;
+    RegTensor<float> rstd;
+    Duplicate(one, 1.0f, firstMask);
+    Div(rstdScalar, one, sum, firstMask);
+    Duplicate<float, HighLowPart::LOWEST, MaskMergeMode::ZEROING>(
+        rstd, rstdScalar, fullMask);
+
+    remaining = numCol;
+    for (uint16_t i = 0; i < repeats; ++i) {
+        MaskReg mask = UpdateMask<float>(remaining);
+        RegTensor<T> xB16;
+        RegTensor<T> gammaB16;
+        RegTensor<T> yB16;
+        RegTensor<float> xFp32;
+        RegTensor<float> gammaFp32;
+        RegTensor<float> normalized;
+        RegTensor<float> widened;
+        const uint32_t offset = i * VECTOR_LENGTH;
+        DataCopy<T, LoadDist::DIST_UNPACK_B16>(xB16, x + offset);
+        DataCopy<T, LoadDist::DIST_UNPACK_B16>(gammaB16,
+                                               gamma + offset);
+        Cast<float, T, CAST_B16_TO_FP32>(xFp32, xB16, mask);
+        Cast<float, T, CAST_B16_TO_FP32>(gammaFp32, gammaB16, mask);
+        Mul(normalized, xFp32, rstd, mask);
+        Mul(normalized, normalized, gammaFp32, mask);
+        Cast<T, float, CAST_FP32_TO_B16>(yB16, normalized, mask);
+        DataCopy<T, StoreDist::DIST_PACK_B32>(y + offset, yB16, mask);
+
+        // HashTopK must consume exactly the low-precision RMSNorm result
+        // widened to FP32, rather than the unrounded FP32 intermediate.
+        Cast<float, T, CAST_B16_TO_FP32>(widened, yB16, mask);
+        DataCopy<float, StoreDist::DIST_NORM>(yFp32 + offset, widened,
+                                              mask);
+    }
+}
+
+template <typename T>
+class KernelRmsNormCast {
+public:
+    __aicore__ inline explicit KernelRmsNormCast(TPipe* pipe) : pipe_(pipe) {}
+
+    __aicore__ inline void Init(GM_ADDR x, GM_ADDR gamma, GM_ADDR y,
+                                GM_ADDR yFp32,
+                                const RmsNormCastTilingData* tiling)
+    {
+        numRow_ = tiling->num_row;
+        numCol_ = tiling->num_col;
+        numColAligned_ = tiling->num_col_aligned;
+        rowsPerCore_ = tiling->rows_per_core;
+        invNumCol_ = tiling->inv_num_col;
+        epsilon_ = tiling->epsilon;
+        const uint32_t rowBegin = GetBlockIdx() * rowsPerCore_;
+        rowBegin_ = rowBegin;
+        rowEnd_ = rowBegin + rowsPerCore_ < numRow_
+                      ? rowBegin + rowsPerCore_
+                      : numRow_;
+
+        xGm_.SetGlobalBuffer((__gm__ T*)x, numRow_ * numCol_);
+        gammaGm_.SetGlobalBuffer((__gm__ T*)gamma, numCol_);
+        yGm_.SetGlobalBuffer((__gm__ T*)y, numRow_ * numCol_);
+        yFp32Gm_.SetGlobalBuffer((__gm__ float*)yFp32,
+                                 numRow_ * numCol_);
+
+        pipe_->InitBuffer(xBuf_, numColAligned_ * sizeof(T));
+        pipe_->InitBuffer(gammaBuf_, numColAligned_ * sizeof(T));
+        pipe_->InitBuffer(yBuf_, numColAligned_ * sizeof(T));
+        pipe_->InitBuffer(yFp32Buf_, numColAligned_ * sizeof(float));
+    }
+
+    __aicore__ inline void Process()
+    {
+        if (rowBegin_ >= numRow_) {
+            return;
+        }
+        LocalTensor<T> gammaLocal = gammaBuf_.Get<T>();
+        CopyIn(gammaLocal, gammaGm_, numCol_);
+        SyncMte2ToVector();
+
+        for (uint32_t row = rowBegin_; row < rowEnd_; ++row) {
+            LocalTensor<T> xLocal = xBuf_.Get<T>();
+            LocalTensor<T> yLocal = yBuf_.Get<T>();
+            LocalTensor<float> yFp32Local = yFp32Buf_.Get<float>();
+            const uint32_t offset = row * numCol_;
+            CopyIn(xLocal, xGm_[offset], numCol_);
+            SyncMte2ToVector();
+            RmsNormCastVF<T>((__local_mem__ T*)xLocal.GetPhyAddr(),
+                             (__local_mem__ T*)gammaLocal.GetPhyAddr(),
+                             (__local_mem__ T*)yLocal.GetPhyAddr(),
+                             (__local_mem__ float*)yFp32Local.GetPhyAddr(),
+                             numCol_, invNumCol_, epsilon_);
+            SyncVectorToMte3();
+            CopyOut(yGm_[offset], yLocal, numCol_);
+            CopyOut(yFp32Gm_[offset], yFp32Local, numCol_);
+            SyncMte3ToMte2();
+        }
+    }
+
+private:
+    template <typename U>
+    __aicore__ inline void CopyIn(LocalTensor<U> dst, GlobalTensor<U> src,
+                                  uint32_t count)
+    {
+        DataCopyExtParams params{
+            1, static_cast<uint32_t>(count * sizeof(U)), 0, 0, 0};
+        const uint32_t aligned =
+            CeilDivision(count, static_cast<uint32_t>(32 / sizeof(U))) *
+            (32 / sizeof(U));
+        DataCopyPadExtParams<U> pad{true, 0,
+                                    static_cast<uint8_t>(aligned - count),
+                                    static_cast<U>(0)};
+        DataCopyPad(dst, src, params, pad);
+    }
+
+    template <typename U>
+    __aicore__ inline void CopyOut(GlobalTensor<U> dst, LocalTensor<U> src,
+                                   uint32_t count)
+    {
+        DataCopyExtParams params{
+            1, static_cast<uint32_t>(count * sizeof(U)), 0, 0, 0};
+        DataCopyPad(dst, src, params);
+    }
+
+    __aicore__ inline void SyncMte2ToVector()
+    {
+        event_t event = static_cast<event_t>(
+            GetTPipePtr()->FetchEventID(HardEvent::MTE2_V));
+        SetFlag<HardEvent::MTE2_V>(event);
+        WaitFlag<HardEvent::MTE2_V>(event);
+    }
+
+    __aicore__ inline void SyncVectorToMte3()
+    {
+        event_t event = static_cast<event_t>(
+            GetTPipePtr()->FetchEventID(HardEvent::V_MTE3));
+        SetFlag<HardEvent::V_MTE3>(event);
+        WaitFlag<HardEvent::V_MTE3>(event);
+    }
+
+    __aicore__ inline void SyncMte3ToMte2()
+    {
+        event_t event = static_cast<event_t>(
+            GetTPipePtr()->FetchEventID(HardEvent::MTE3_MTE2));
+        SetFlag<HardEvent::MTE3_MTE2>(event);
+        WaitFlag<HardEvent::MTE3_MTE2>(event);
+    }
+
+    TPipe* pipe_;
+    TBuf<TPosition::VECCALC> xBuf_;
+    TBuf<TPosition::VECCALC> gammaBuf_;
+    TBuf<TPosition::VECCALC> yBuf_;
+    TBuf<TPosition::VECCALC> yFp32Buf_;
+    GlobalTensor<T> xGm_;
+    GlobalTensor<T> gammaGm_;
+    GlobalTensor<T> yGm_;
+    GlobalTensor<float> yFp32Gm_;
+    uint32_t numRow_;
+    uint32_t numCol_;
+    uint32_t numColAligned_;
+    uint32_t rowsPerCore_;
+    uint32_t rowBegin_;
+    uint32_t rowEnd_;
+    float invNumCol_;
+    float epsilon_;
+};
+}  // namespace RmsNormCastArch35
+#endif

--- a/tests/e2e/nightly/single_node/ops/singlecard_ops/test_rms_norm_cast.py
+++ b/tests/e2e/nightly/single_node/ops/singlecard_ops/test_rms_norm_cast.py
@@ -4,6 +4,7 @@
 import pytest
 import torch
 import torch_npu
+import vllm_ascend.vllm_ascend_C  # type: ignore[import-untyped]  # noqa: F401
 
 
 def _tolerances(dtype: torch.dtype) -> tuple[float, float]:

--- a/vllm_ascend/models/deepseek_v4/model.py
+++ b/vllm_ascend/models/deepseek_v4/model.py
@@ -84,9 +84,12 @@ from vllm_ascend.ops.dsa import AscendDeepseekSparseAttention, DSAModules
 from vllm_ascend.ops.rope_dsv4 import ComplexExpRotaryEmbedding
 from vllm_ascend.ops.triton.mul_add import muls_add_triton
 from vllm_ascend.utils import (
+    AscendDeviceType,
+    bootstrap_custom_op_env,
     enable_custom_op,
     enable_dsa_cp,
     extract_dsv4_layer_index,
+    get_ascend_device_type,
     get_dsv4_compress_ratio,
     olora_tp_enable,
     oproj_tp_enable,
@@ -733,6 +736,17 @@ class DeepseekV2DecoderLayer(nn.Module):
 
     def rms_norm_cast(self, hidden_states: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
         """Normalize once and provide the exact FP32 routing input."""
+        if get_ascend_device_type() == AscendDeviceType.A5:
+            # A5 only enables a vetted subset of custom operators. Load the
+            # extension lazily after device initialization for this op.
+            bootstrap_custom_op_env()
+            import vllm_ascend.vllm_ascend_C  # type: ignore[import-untyped]  # noqa: F401, PLC0415
+
+            return torch.ops._C_ascend.npu_rms_norm_cast(
+                hidden_states,
+                self.post_attention_layernorm.weight,
+                self.post_attention_layernorm.variance_epsilon,
+            )
         if enable_custom_op():
             return torch.ops._C_ascend.npu_rms_norm_cast(
                 hidden_states,


### PR DESCRIPTION
## What this PR does

This is the Ascend 950 follow-up to #15426.

- adds a RegBase/MicroAPI implementation of rms_norm_cast for Ascend 950
- keeps the low-precision RMSNorm output and widens that rounded value to FP32 for HashTopK routing
- adds Ascend 950 dynamic compilation and build-list configuration while preserving the existing A2/A3 paths
- lazily registers the custom operator for the DeepSeek-V4 A5 path
- makes the standalone operator test explicitly load the extension

The A5 kernel follows the reduction and vectorization approach used by the upstream add_rms_norm_cast reference, without the unneeded add input and with both low-precision and FP32 outputs.

## Validation

Validated on an Ascend950DT_9582 machine:

- targeted Ascend 950 custom-op package build: passed for FP16 and BF16 kernels
- PyTorch extension build: passed
- single-operator tests: **8 passed**
  - eager: FP16/BF16 with token counts 1, 16, and 128
  - NPU graph capture/replay: FP16/BF16 with token count 16
  - hidden size 7168, epsilon 1e-6
- ruff, formatting, codespell, typos, Python package/import/context checks, bash -n, logger, long-function, and symbolic-meta checks: passed

- vLLM main: https://github.com/vllm-project/vllm/commit/ba07e4a48fc951300d97eb506217dd530583dea3
