### PR TITLE
[Feature][Profiler] Align NPU schedule and trace annotations

### DIFF
--- a/tests/ut/profiler/test_torch_npu_profiler.py
+++ b/tests/ut/profiler/test_torch_npu_profiler.py
@@ -109,6 +109,7 @@ class TestTorchNPUProfilerWrapper(TestBase):
         mock_profile.assert_called_once()
         profile_kwargs = mock_profile.call_args.kwargs
         self.assertEqual(profile_kwargs["activities"], ["CPU", "NPU"])
+        self.assertIsNone(profile_kwargs["schedule"])
         self.assertTrue(profile_kwargs["profile_memory"])
         self.assertEqual(profile_kwargs["with_modules"], True)
         self.assertEqual(profile_kwargs["on_trace_ready"], mock_trace_handler_instance)
@@ -214,7 +215,7 @@ class TestTorchNPUProfilerWrapper(TestBase):
             str(cm.exception),
         )
 
-    def test_profiler_step_returns_true(self):
+    def test_profiler_step_without_schedule_returns_true(self):
         from vllm_ascend.profiler.torch_npu_profiler import TorchNPUProfilerWrapper
 
         profiler_config = ProfilerConfig(
@@ -222,10 +223,86 @@ class TestTorchNPUProfilerWrapper(TestBase):
             torch_profiler_dir="/path/to/traces",
         )
 
-        with patch.object(TorchNPUProfilerWrapper, "_create_profiler", return_value=MagicMock()):
+        mock_profiler = MagicMock()
+        with patch.object(TorchNPUProfilerWrapper, "_create_profiler", return_value=mock_profiler):
             wrapper = TorchNPUProfilerWrapper(profiler_config, "trace_name")
 
         self.assertTrue(wrapper._profiler_step())
+        mock_profiler.step.assert_not_called()
+
+    @patch("vllm_ascend.profiler.torch_npu_profiler.get_ascend_config")
+    @patch("vllm_ascend.profiler.torch_npu_profiler.torch_npu.profiler._ExperimentalConfig", create=True)
+    @patch("vllm_ascend.profiler.torch_npu_profiler.torch_npu.profiler.profile", create=True)
+    @patch("vllm_ascend.profiler.torch_npu_profiler.torch_npu.profiler.schedule", create=True)
+    @patch("vllm_ascend.profiler.torch_npu_profiler.torch_npu.profiler.tensorboard_trace_handler", create=True)
+    @patch("vllm_ascend.profiler.torch_npu_profiler.torch_npu.profiler.ExportType", create=True)
+    @patch("vllm_ascend.profiler.torch_npu_profiler.torch_npu.profiler.ProfilerLevel", create=True)
+    @patch("vllm_ascend.profiler.torch_npu_profiler.torch_npu.profiler.AiCMetrics", create=True)
+    @patch("vllm_ascend.profiler.torch_npu_profiler.torch_npu.profiler.ProfilerActivity", create=True)
+    def test_create_profiler_with_schedule(
+        self,
+        mock_profiler_activity,
+        mock_aic_metrics,
+        mock_profiler_level,
+        mock_export_type,
+        mock_trace_handler,
+        mock_schedule,
+        mock_profile,
+        mock_experimental_config,
+        mock_get_ascend_config,
+    ):
+        from vllm_ascend.profiler.torch_npu_profiler import TorchNPUProfilerWrapper
+
+        mock_get_ascend_config.side_effect = RuntimeError("Ascend config is not initialized")
+        mock_schedule.return_value = "npu_schedule"
+        mock_profile.return_value = MagicMock()
+        profiler_config = ProfilerConfig(
+            profiler="torch",
+            torch_profiler_dir="/path/to/traces",
+            wait_iterations=2,
+            warmup_iterations=1,
+            active_iterations=3,
+        )
+
+        TorchNPUProfilerWrapper._create_profiler(profiler_config, "trace_name")
+
+        mock_schedule.assert_called_once_with(skip_first=0, wait=2, warmup=1, active=3, repeat=1)
+        self.assertEqual(mock_profile.call_args.kwargs["schedule"], "npu_schedule")
+
+    def test_profiler_step_tracks_non_active_schedule_steps(self):
+        from vllm_ascend.profiler.torch_npu_profiler import TorchNPUProfilerWrapper
+
+        profiler_config = ProfilerConfig(
+            profiler="torch",
+            torch_profiler_dir="/path/to/traces",
+            wait_iterations=2,
+            warmup_iterations=1,
+            active_iterations=3,
+        )
+        mock_profiler = MagicMock()
+        with patch.object(TorchNPUProfilerWrapper, "_create_profiler", return_value=mock_profiler):
+            wrapper = TorchNPUProfilerWrapper(profiler_config, "trace_name")
+
+        self.assertFalse(wrapper._profiler_step())
+        self.assertFalse(wrapper._profiler_step())
+        self.assertTrue(wrapper._profiler_step())
+        self.assertEqual(mock_profiler.step.call_count, 3)
+
+    @patch("vllm_ascend.profiler.torch_npu_profiler.torch.profiler.record_function")
+    def test_annotate_context_manager_uses_torch_record_function(self, mock_record_function):
+        from vllm_ascend.profiler.torch_npu_profiler import TorchNPUProfilerWrapper
+
+        profiler_config = ProfilerConfig(
+            profiler="torch",
+            torch_profiler_dir="/path/to/traces",
+        )
+        with patch.object(TorchNPUProfilerWrapper, "_create_profiler", return_value=MagicMock()):
+            wrapper = TorchNPUProfilerWrapper(profiler_config, "trace_name")
+
+        context = wrapper.annotate_context_manager("execute_context_1(4)_generation_0(0)")
+
+        mock_record_function.assert_called_once_with("execute_context_1(4)_generation_0(0)")
+        self.assertIs(context, mock_record_function.return_value)
 
     def test_step_calls_underlying_start_after_delay_iterations(self):
         """Work matches vLLM WorkerProfiler: first N worker steps defer _start."""

--- a/tests/ut/profiler/test_torch_npu_profiler.py
+++ b/tests/ut/profiler/test_torch_npu_profiler.py
@@ -67,6 +67,8 @@ class TestTorchNPUProfilerWrapper(TestBase):
             torch_profiler_dir="/path/to/traces",
             torch_profiler_with_stack=True,
             torch_profiler_with_memory=True,
+            torch_profiler_record_shapes=True,
+            torch_profiler_with_flops=True,
         )
 
         mock_export_type.Text = "Text"
@@ -110,8 +112,10 @@ class TestTorchNPUProfilerWrapper(TestBase):
         profile_kwargs = mock_profile.call_args.kwargs
         self.assertEqual(profile_kwargs["activities"], ["CPU", "NPU"])
         self.assertIsNone(profile_kwargs["schedule"])
+        self.assertTrue(profile_kwargs["record_shapes"])
         self.assertTrue(profile_kwargs["profile_memory"])
         self.assertEqual(profile_kwargs["with_modules"], True)
+        self.assertTrue(profile_kwargs["with_flops"])
         self.assertEqual(profile_kwargs["on_trace_ready"], mock_trace_handler_instance)
         self.assertEqual(result, mock_profiler_instance)
 
@@ -287,6 +291,34 @@ class TestTorchNPUProfilerWrapper(TestBase):
         self.assertFalse(wrapper._profiler_step())
         self.assertTrue(wrapper._profiler_step())
         self.assertEqual(mock_profiler.step.call_count, 3)
+
+    def test_max_iterations_counts_only_active_schedule_steps(self):
+        from vllm_ascend.profiler.torch_npu_profiler import TorchNPUProfilerWrapper
+
+        profiler_config = ProfilerConfig(
+            profiler="torch",
+            torch_profiler_dir="/path/to/traces",
+            wait_iterations=1,
+            warmup_iterations=1,
+            active_iterations=3,
+            max_iterations=1,
+        )
+        mock_profiler = MagicMock()
+        with patch.object(TorchNPUProfilerWrapper, "_create_profiler", return_value=mock_profiler):
+            wrapper = TorchNPUProfilerWrapper(profiler_config, "trace_name")
+
+        wrapper.start()
+        wrapper.step()  # Remaining warmup step.
+        self.assertEqual(wrapper._profiling_for_iters, 0)
+        mock_profiler.stop.assert_not_called()
+
+        wrapper.step()  # First active step.
+        self.assertEqual(wrapper._profiling_for_iters, 1)
+        mock_profiler.stop.assert_not_called()
+
+        wrapper.step()  # Second active step exceeds max_iterations.
+        self.assertEqual(wrapper._profiling_for_iters, 2)
+        mock_profiler.stop.assert_called_once()
 
     @patch("vllm_ascend.profiler.torch_npu_profiler.torch.profiler.record_function")
     def test_annotate_context_manager_uses_torch_record_function(self, mock_record_function):

--- a/tests/ut/worker/test_worker_v1.py
+++ b/tests/ut/worker/test_worker_v1.py
@@ -641,8 +641,8 @@ class TestNPUWorker(TestBase):
             self.assertIs(worker.profiler, mock_profiler_wrapper.return_value)
             mock_profiler_wrapper.return_value.start.assert_called_once()
 
-    def test_profile_restart_reuses_existing_profiler(self):
-        """[RFC #6954] Restarting profile reuses existing profiler."""
+    def test_profile_restart_recreates_npu_profiler(self):
+        """Restarting recreates the one-shot torch-npu profiler."""
         from vllm_ascend.worker.worker import NPUWorker
 
         profiler_config = ProfilerConfig(
@@ -668,9 +668,13 @@ class TestNPUWorker(TestBase):
             )
 
             worker.profile(is_start=False)
-            worker.profile(is_start=True)  # Restart without new prefix
-            # Should NOT create new profiler, just restart existing
-            mock_wrapper.assert_called_once()
+            worker.profile(is_start=True, profile_prefix="session2")
+
+            self.assertEqual(mock_wrapper.call_count, 2)
+            mock_wrapper.assert_called_with(
+                profiler_config,
+                "session2_dp0_pp0_tp0_dcp0_ep0_rank0",
+            )
             self.assertEqual(mock_profiler.start.call_count, 2)
             mock_profiler.stop.assert_called_once()
 

--- a/tests/ut/worker/test_worker_v1.py
+++ b/tests/ut/worker/test_worker_v1.py
@@ -1313,6 +1313,7 @@ class TestNPUWorker(TestBase):
         worker.profiler.annotate_context_manager.assert_called_once_with(
             "execute_4_context_1(sq3sk13sqsq9sqsk39)_generation_1(sq1sk21sqsq1sqsk21)"
         )
+        cached_reqs.is_context_phase.assert_called_once_with("generation")
 
     @patch("vllm_ascend.worker.worker.compute_iteration_details")
     def test_annotate_profile_skips_annotation_when_schedule_not_running(self, mock_compute_details):

--- a/tests/ut/worker/test_worker_v1.py
+++ b/tests/ut/worker/test_worker_v1.py
@@ -1223,6 +1223,7 @@ class TestNPUWorker(TestBase):
             worker.vllm_config.parallel_config = MagicMock()
             worker.vllm_config.parallel_config.distributed_executor_backend = "ray"
             worker.profiler = MagicMock()
+            worker.profiler.is_running = False
             worker.profiler.step.side_effect = lambda: call_order.append("step")
             worker._pp_send_work = []
 
@@ -1247,6 +1248,85 @@ class TestNPUWorker(TestBase):
             worker.model_runner.execute_model.assert_called_once_with(mock_scheduler_output, None)
             self.assertEqual(call_order, ["step", "execute"])
             self.assertEqual(result, mock_model_output)
+
+    def test_annotate_profile_returns_noop_without_profiler(self):
+        from contextlib import nullcontext
+
+        from vllm_ascend.worker.worker import NPUWorker
+
+        worker = NPUWorker.__new__(NPUWorker)
+        worker.profiler = None
+
+        self.assertIsInstance(worker.annotate_profile(MagicMock()), nullcontext)
+
+    @patch("vllm_ascend.worker.worker.compute_iteration_details")
+    def test_annotate_profile_uses_simple_upstream_annotation(self, mock_compute_details):
+        from vllm_ascend.worker.worker import NPUWorker
+
+        worker = NPUWorker.__new__(NPUWorker)
+        worker.profiler = MagicMock(is_running=True)
+        worker.vllm_config = MagicMock()
+        worker.vllm_config.profiler_config.detailed_trace_annotation = False
+        mock_compute_details.return_value = SimpleNamespace(
+            num_ctx_requests=2,
+            num_ctx_tokens=8,
+            num_generation_requests=3,
+            num_generation_tokens=3,
+        )
+
+        context = worker.annotate_profile(MagicMock())
+
+        worker.profiler.step.assert_called_once()
+        worker.profiler.annotate_context_manager.assert_called_once_with(
+            "execute_context_2(8)_generation_3(3)"
+        )
+        self.assertIs(context, worker.profiler.annotate_context_manager.return_value)
+
+    @patch("vllm_ascend.worker.worker.compute_iteration_details")
+    def test_annotate_profile_uses_detailed_upstream_annotation(self, mock_compute_details):
+        from vllm_ascend.worker.worker import NPUWorker
+
+        worker = NPUWorker.__new__(NPUWorker)
+        worker.profiler = MagicMock(is_running=True)
+        worker.vllm_config = MagicMock()
+        worker.vllm_config.profiler_config.detailed_trace_annotation = True
+        mock_compute_details.return_value = SimpleNamespace(
+            num_ctx_requests=1,
+            num_ctx_tokens=3,
+            num_generation_requests=1,
+            num_generation_tokens=1,
+        )
+        cached_reqs = MagicMock()
+        cached_reqs.req_ids = ["generation"]
+        cached_reqs.num_computed_tokens = [20]
+        cached_reqs.is_context_phase.return_value = False
+        scheduler_output = SimpleNamespace(
+            scheduled_new_reqs=[SimpleNamespace(req_id="context", num_computed_tokens=10)],
+            scheduled_cached_reqs=cached_reqs,
+            num_scheduled_tokens={"context": 3, "generation": 1},
+        )
+
+        worker.annotate_profile(scheduler_output)
+
+        worker.profiler.annotate_context_manager.assert_called_once_with(
+            "execute_4_context_1(sq3sk13sqsq9sqsk39)_generation_1(sq1sk21sqsq1sqsk21)"
+        )
+
+    @patch("vllm_ascend.worker.worker.compute_iteration_details")
+    def test_annotate_profile_skips_annotation_when_schedule_not_running(self, mock_compute_details):
+        from contextlib import nullcontext
+
+        from vllm_ascend.worker.worker import NPUWorker
+
+        worker = NPUWorker.__new__(NPUWorker)
+        worker.profiler = MagicMock(is_running=False)
+
+        context = worker.annotate_profile(MagicMock())
+
+        worker.profiler.step.assert_called_once()
+        mock_compute_details.assert_not_called()
+        worker.profiler.annotate_context_manager.assert_not_called()
+        self.assertIsInstance(context, nullcontext)
 
     @patch("vllm_ascend.worker.worker.get_ascend_config")
     @patch("vllm_ascend.worker.worker.enable_sp", return_value=False)

--- a/tests/ut/worker/test_worker_v1.py
+++ b/tests/ut/worker/test_worker_v1.py
@@ -1277,9 +1277,7 @@ class TestNPUWorker(TestBase):
         context = worker.annotate_profile(MagicMock())
 
         worker.profiler.step.assert_called_once()
-        worker.profiler.annotate_context_manager.assert_called_once_with(
-            "execute_context_2(8)_generation_3(3)"
-        )
+        worker.profiler.annotate_context_manager.assert_called_once_with("execute_context_2(8)_generation_3(3)")
         self.assertIs(context, worker.profiler.annotate_context_manager.return_value)
 
     @patch("vllm_ascend.worker.worker.compute_iteration_details")

--- a/vllm_ascend/profiler/torch_npu_profiler.py
+++ b/vllm_ascend/profiler/torch_npu_profiler.py
@@ -22,6 +22,7 @@ from typing import Any
 import torch
 import torch_npu
 from vllm.config import ProfilerConfig
+from vllm.logger import logger
 from vllm.profiler.wrapper import WorkerProfiler
 
 from vllm_ascend.ascend_config import get_ascend_config
@@ -64,6 +65,12 @@ class TorchNPUProfilerWrapper(WorkerProfiler):
                 active=profiler_config.active_iterations,
                 repeat=1,
             )
+            logger.info_once(
+                "NPU profiler schedule configured: wait=%d, warmup=%d, active=%d",
+                profiler_config.wait_iterations,
+                profiler_config.warmup_iterations,
+                profiler_config.active_iterations,
+            )
 
         experimental_config = torch_npu.profiler._ExperimentalConfig(
             export_type=torch_npu.profiler.ExportType.Text,
@@ -83,11 +90,13 @@ class TorchNPUProfilerWrapper(WorkerProfiler):
                 torch_npu.profiler.ProfilerActivity.NPU,
             ],
             schedule=profiler_schedule,
+            record_shapes=profiler_config.torch_profiler_record_shapes,
             with_stack=False,
             profile_memory=profiler_config.torch_profiler_with_memory,
             # NOTE: torch_npu.profiler.with_modules is equivalent to torch.profiler.with_stack.
             # The with_stack option in torch_npu.profiler introduces significant time overhead.
             with_modules=profiler_config.torch_profiler_with_stack,
+            with_flops=profiler_config.torch_profiler_with_flops,
             experimental_config=experimental_config,
             on_trace_ready=torch_npu.profiler.tensorboard_trace_handler(
                 profiler_config.torch_profiler_dir,

--- a/vllm_ascend/profiler/torch_npu_profiler.py
+++ b/vllm_ascend/profiler/torch_npu_profiler.py
@@ -19,6 +19,7 @@
 from contextlib import suppress
 from typing import Any
 
+import torch
 import torch_npu
 from vllm.config import ProfilerConfig
 from vllm.profiler.wrapper import WorkerProfiler
@@ -31,6 +32,13 @@ class TorchNPUProfilerWrapper(WorkerProfiler):
 
     def __init__(self, profiler_config: ProfilerConfig, trace_name: str) -> None:
         super().__init__(profiler_config)
+        self._uses_schedule = profiler_config.warmup_iterations > 0 or profiler_config.wait_iterations > 0
+        # profiler.start() consumes schedule step 0, so this tracks the
+        # remaining non-active steps advanced by profiler.step().
+        self._warmup_steps_remaining = max(
+            profiler_config.wait_iterations + profiler_config.warmup_iterations - 1,
+            0,
+        )
         self.profiler: Any = self._create_profiler(profiler_config, trace_name)
 
     @staticmethod
@@ -45,6 +53,16 @@ class TorchNPUProfilerWrapper(WorkerProfiler):
         if msmonitor_use_daemon:
             raise RuntimeError(
                 "additional_config.msmonitor_use_daemon and torch profiler cannot be enabled at the same time."
+            )
+
+        profiler_schedule = None
+        if profiler_config.warmup_iterations > 0 or profiler_config.wait_iterations > 0:
+            profiler_schedule = torch_npu.profiler.schedule(
+                skip_first=0,
+                wait=profiler_config.wait_iterations,
+                warmup=profiler_config.warmup_iterations,
+                active=profiler_config.active_iterations,
+                repeat=1,
             )
 
         experimental_config = torch_npu.profiler._ExperimentalConfig(
@@ -64,6 +82,7 @@ class TorchNPUProfilerWrapper(WorkerProfiler):
                 torch_npu.profiler.ProfilerActivity.CPU,
                 torch_npu.profiler.ProfilerActivity.NPU,
             ],
+            schedule=profiler_schedule,
             with_stack=False,
             profile_memory=profiler_config.torch_profiler_with_memory,
             # NOTE: torch_npu.profiler.with_modules is equivalent to torch.profiler.with_stack.
@@ -83,4 +102,12 @@ class TorchNPUProfilerWrapper(WorkerProfiler):
         self.profiler.stop()
 
     def _profiler_step(self) -> bool:
+        if self._uses_schedule:
+            self.profiler.step()
+            if self._warmup_steps_remaining > 0:
+                self._warmup_steps_remaining -= 1
+                return False
         return True
+
+    def annotate_context_manager(self, name: str):
+        return torch.profiler.record_function(name)

--- a/vllm_ascend/worker/worker.py
+++ b/vllm_ascend/worker/worker.py
@@ -21,6 +21,7 @@ import copy
 import gc
 import inspect
 import logging
+from contextlib import nullcontext
 from types import NoneType
 from typing import Any
 
@@ -51,7 +52,7 @@ from vllm.utils.torch_utils import STR_DTYPE_TO_TORCH_DTYPE
 from vllm.v1.core.sched.output import GrammarOutput, SchedulerOutput
 from vllm.v1.kv_cache_interface import KVCacheConfig, KVCacheSpec
 from vllm.v1.outputs import EMPTY_MODEL_RUNNER_OUTPUT, AsyncModelRunnerOutput, DraftTokenIds, ModelRunnerOutput
-from vllm.v1.utils import report_usage_stats
+from vllm.v1.utils import compute_iteration_details, report_usage_stats
 from vllm.v1.worker.gpu_worker import AsyncIntermediateTensors
 from vllm.v1.worker.startup_plan import (
     maybe_apply_startup_plan,
@@ -677,10 +678,8 @@ class NPUWorker(WorkerBase):
                 comm_postprocess=comm_postprocess,
             )
 
-        if self.profiler is not None:
-            self.profiler.step()
-
-        output = self.model_runner.execute_model(scheduler_output, intermediate_tensors)
+        with self.annotate_profile(scheduler_output):
+            output = self.model_runner.execute_model(scheduler_output, intermediate_tensors)
         if isinstance(output, (ModelRunnerOutput, AsyncModelRunnerOutput, NoneType)):
             return output
 
@@ -713,6 +712,97 @@ class NPUWorker(WorkerBase):
         output = copy.copy(EMPTY_MODEL_RUNNER_OUTPUT)
         output.kv_connector_output = kv_connector_output
         return output
+
+    def annotate_profile(self, scheduler_output: SchedulerOutput):
+        """Advance the profiler and annotate this worker iteration."""
+        if self.profiler is None:
+            return nullcontext()
+
+        self.profiler.step()
+        if not self.profiler.is_running:
+            return nullcontext()
+
+        iteration_details = compute_iteration_details(scheduler_output)
+        if self.vllm_config.profiler_config.detailed_trace_annotation:
+            ctx_seq_len_sum = 0
+            ctx_qq_compute = 0
+            ctx_qk_compute = 0
+            gen_seq_len_sum = 0
+            gen_qq_compute = 0
+            gen_qk_compute = 0
+            total_scheduled_tokens = 0
+
+            new_req_ids = {
+                new_req.req_id for new_req in scheduler_output.scheduled_new_reqs
+            }
+            num_computed_tokens_by_req = {
+                new_req.req_id: new_req.num_computed_tokens
+                for new_req in scheduler_output.scheduled_new_reqs
+            }
+            for req_id, num_computed_tokens in zip(
+                scheduler_output.scheduled_cached_reqs.req_ids,
+                scheduler_output.scheduled_cached_reqs.num_computed_tokens,
+            ):
+                num_computed_tokens_by_req[req_id] = num_computed_tokens
+
+            for req_id, num_tokens in scheduler_output.num_scheduled_tokens.items():
+                query_len = num_tokens
+                total_scheduled_tokens += query_len
+                seq_len = num_computed_tokens_by_req.get(req_id, 0) + query_len
+                if (
+                    scheduler_output.scheduled_cached_reqs.is_context_phase(req_id)
+                    or req_id in new_req_ids
+                ):
+                    ctx_seq_len_sum += seq_len
+                    ctx_qq_compute += query_len * query_len
+                    ctx_qk_compute += query_len * seq_len
+                else:
+                    gen_seq_len_sum += seq_len
+                    gen_qq_compute += query_len * query_len
+                    gen_qk_compute += query_len * seq_len
+
+            annotation = "".join(
+                [
+                    "execute_",
+                    str(total_scheduled_tokens),
+                    "_context_",
+                    str(iteration_details.num_ctx_requests),
+                    "(sq",
+                    str(iteration_details.num_ctx_tokens),
+                    "sk",
+                    str(ctx_seq_len_sum),
+                    "sqsq",
+                    str(ctx_qq_compute),
+                    "sqsk",
+                    str(ctx_qk_compute),
+                    ")_generation_",
+                    str(iteration_details.num_generation_requests),
+                    "(sq",
+                    str(iteration_details.num_generation_tokens),
+                    "sk",
+                    str(gen_seq_len_sum),
+                    "sqsq",
+                    str(gen_qq_compute),
+                    "sqsk",
+                    str(gen_qk_compute),
+                    ")",
+                ]
+            )
+        else:
+            annotation = "".join(
+                [
+                    "execute_context_",
+                    str(iteration_details.num_ctx_requests),
+                    "(",
+                    str(iteration_details.num_ctx_tokens),
+                    ")_generation_",
+                    str(iteration_details.num_generation_requests),
+                    "(",
+                    str(iteration_details.num_generation_tokens),
+                    ")",
+                ]
+            )
+        return self.profiler.annotate_context_manager(annotation)
 
     @torch.inference_mode()
     def sample_tokens(self, grammar_output: "GrammarOutput") -> ModelRunnerOutput | AsyncModelRunnerOutput:

--- a/vllm_ascend/worker/worker.py
+++ b/vllm_ascend/worker/worker.py
@@ -1162,7 +1162,13 @@ class NPUWorker(WorkerBase):
             if self.profiler is None:
                 logger.warning("Profiler was not started, nothing to stop.")
                 return
-            self.profiler.stop()
+            try:
+                self.profiler.stop()
+            finally:
+                # A stopped torch-npu profiler cannot collect another trace
+                # when start() is called again. Recreate the wrapper on the
+                # next request so its schedule and trace name are reset too.
+                self.profiler = None
 
     def add_lora(self, lora_request: LoRARequest) -> bool:
         return self.model_runner.add_lora(lora_request)

--- a/vllm_ascend/worker/worker.py
+++ b/vllm_ascend/worker/worker.py
@@ -746,7 +746,7 @@ class NPUWorker(WorkerBase):
                 query_len = num_tokens
                 total_scheduled_tokens += query_len
                 seq_len = num_computed_tokens_by_req.get(req_id, 0) + query_len
-                if scheduler_output.scheduled_cached_reqs.is_context_phase(req_id) or req_id in new_req_ids:
+                if req_id in new_req_ids or scheduler_output.scheduled_cached_reqs.is_context_phase(req_id):
                     ctx_seq_len_sum += seq_len
                     ctx_qq_compute += query_len * query_len
                     ctx_qk_compute += query_len * seq_len

--- a/vllm_ascend/worker/worker.py
+++ b/vllm_ascend/worker/worker.py
@@ -732,12 +732,9 @@ class NPUWorker(WorkerBase):
             gen_qk_compute = 0
             total_scheduled_tokens = 0
 
-            new_req_ids = {
-                new_req.req_id for new_req in scheduler_output.scheduled_new_reqs
-            }
+            new_req_ids = {new_req.req_id for new_req in scheduler_output.scheduled_new_reqs}
             num_computed_tokens_by_req = {
-                new_req.req_id: new_req.num_computed_tokens
-                for new_req in scheduler_output.scheduled_new_reqs
+                new_req.req_id: new_req.num_computed_tokens for new_req in scheduler_output.scheduled_new_reqs
             }
             for req_id, num_computed_tokens in zip(
                 scheduler_output.scheduled_cached_reqs.req_ids,
@@ -749,10 +746,7 @@ class NPUWorker(WorkerBase):
                 query_len = num_tokens
                 total_scheduled_tokens += query_len
                 seq_len = num_computed_tokens_by_req.get(req_id, 0) + query_len
-                if (
-                    scheduler_output.scheduled_cached_reqs.is_context_phase(req_id)
-                    or req_id in new_req_ids
-                ):
+                if scheduler_output.scheduled_cached_reqs.is_context_phase(req_id) or req_id in new_req_ids:
                     ctx_seq_len_sum += seq_len
                     ctx_qq_compute += query_len * query_len
                     ctx_qk_compute += query_len * seq_len


### PR DESCRIPTION
### What this PR does / why we need it?

Refs #9147.

vLLM's `TorchProfilerWrapper` supports scheduled profiling and worker-side
execution annotations, but the Ascend `TorchNPUProfilerWrapper` only advanced
the generic `delay_iterations` / `max_iterations` state machine. As a result,
the same `ProfilerConfig` had different behavior on GPU and Ascend:

- `wait_iterations`, `warmup_iterations`, and `active_iterations` did not
  configure a torch-npu profiler schedule;
- worker iterations were not annotated with context/generation request and
  token summaries;
- `torch_profiler_record_shapes` and `torch_profiler_with_flops` were not
  forwarded to torch-npu;
- restarting online profiling reused a stopped torch-npu profiler, so a second
  profiling session could not reliably produce an independent trace.

This PR aligns those behaviors with upstream vLLM by:

1. creating a `torch_npu.profiler.schedule` from the wait/warmup/active fields;
2. advancing it once per worker execution while excluding non-active schedule
   steps from the generic `max_iterations` counter;
3. wrapping active model execution in the same simple or detailed annotation
   format used by the upstream GPU worker;
4. forwarding record-shape and FLOP options; and
5. recreating the one-shot torch-npu profiler wrapper after `/stop_profile`,
   allowing repeated online profiling sessions and new trace prefixes.

Defaults remain unchanged: when wait and warmup are both zero, no schedule is
created and profiling retains its existing continuous behavior.

### Does this PR introduce _any_ user-facing change?

Yes, for users who explicitly enable the torch profiler. Ascend now honors
`wait_iterations`, `warmup_iterations`, `active_iterations`,
`detailed_trace_annotation`, `torch_profiler_record_shapes`, and
`torch_profiler_with_flops` consistently with upstream vLLM. Repeated
`/start_profile` and `/stop_profile` sessions generate independent traces.

There is no behavior or performance change when profiling is disabled.

### How was this patch tested?

Unit and formatting checks:

```text
pytest -q tests/ut/profiler/test_torch_npu_profiler.py \
  tests/ut/worker/test_worker_v1.py
82 passed

ruff check <four changed files>
All checks passed!
ruff format --check <four changed files>
4 files already formatted
```

Single-card Ascend 910B3 E2E with Qwen3-0.6B:

```shell
export ASCEND_RT_VISIBLE_DEVICES=7

vllm serve /path/to/Qwen3-0.6B \
  --served-model-name qwen3 \
  --tensor-parallel-size 1 \
  --max-model-len 5500 \
  --max-num-batched-tokens 1024 \
  --compilation-config '{"cudagraph_mode":"FULL_DECODE_ONLY"}' \
  --profiler-config '{"profiler":"torch","torch_profiler_dir":"/workspace/traces","torch_profiler_with_stack":false,"ignore_frontend":true,"wait_iterations":1,"warmup_iterations":1,"active_iterations":2}'
```

Results:

- FULL_DECODE_ONLY captured all 35 graph sizes and served requests successfully.
- The generated trace contained exactly `ProfilerStep#2` and
  `ProfilerStep#3`, plus two worker execution annotations.
- Two consecutive `/start_profile` -> request -> `/stop_profile` cycles
  generated two independent valid traces.
- `record_shapes=true` and `with_flops=true` completed successfully; 4,754 of
  6,922 rows in `operator_details.csv` contained input shapes.
- Eager mode served three repeated requests successfully with stable latency.

`torch_profiler_with_stack=true` remains excluded from the E2E command because
torch-npu 2.10.0.post4 has a known native profiler crash tracked by #15697.
That mapping and limitation predate this change; the default is `false`.

- vLLM main: https://github.com/vllm-project/vllm/commit/ba07e4a48fc951300d97eb506217dd530583dea3
