### PR TITLE
[Feature][MRV1][MRV2] Refactor Host-Side Parameter Updates for ACL Graph Replay.

### DIFF
--- a/tests/ut/attention/test_attention_v1.py
+++ b/tests/ut/attention/test_attention_v1.py
@@ -785,65 +785,12 @@ class TestAscendAttentionBackendImpl(TestBase):
     @patch("vllm_ascend.attention.attention_v1.torch.npu.stream")
     @patch("vllm_ascend.attention.attention_v1.torch.npu.graph_task_update_begin")
     @patch("vllm_ascend.attention.attention_v1.torch.npu.graph_task_update_end")
-    @patch("torch_npu.npu_fused_infer_attention_score")
-    @patch("vllm_ascend.attention.attention_v1.get_graph_params")
-    @patch("vllm_ascend.attention.attention_v1._EXTRA_CTX")
-    @patch("vllm_ascend.attention.attention_v1.using_paged_attention", return_value=False)
-    @patch("vllm_ascend.attention.attention_v1.needs_layer_aware_fia_graph_replay", return_value=False)
-    @patch("vllm_ascend.attention.attention_v1._ATTN_KEYS_BUFFER", new=[])
-    def test_update_graph_params(
-        self,
-        mock_needs_layer_aware_fia_graph_replay,
-        mock_using_paged_attention,
-        mock_EXTRA_CTX,
-        mock_get_graph_params,
-        mock_fia,
-        mock_graph_task_update_end,
-        mock_graph_task_update_begin,
-        mock_stream,
-    ):
-        """Test behavior when _ATTN_KEYS_BUFFER is [] after dummy_run."""
-
-        mock_EXTRA_CTX.sinks = False
-        mock_EXTRA_CTX.is_draft_model = False
-
-        param: list[MagicMock | None] = [MagicMock()] * 22
-        param[16] = None  # sliding_window
-        param[17] = None  # c8_k_aq_scale
-        param[21] = None  # layer_name
-
-        mock_get_graph_params.return_value.attn_params = {1: [tuple(param)] * 3}
-        mock_get_graph_params.return_value.handles = {1: [MagicMock()] * 3}
-        mock_get_graph_params.return_value.events = {1: [MagicMock()] * 3}
-
-        attn_metadata_keys = [
-            "model.layers.10.self_attn.attn",
-            "model.layers.2.self_attn.attn",
-            "model.layers.5.self_attn.attn",
-        ]
-        forward_context = MagicMock()
-        forward_context.attn_metadata = {key: MagicMock() for key in attn_metadata_keys}
-        # breakpoint()
-        self.impl.update_graph_params(self.mock_stream, forward_context, 1, self.mock_vllm_config)
-
-        expected = [
-            "model.layers.2.self_attn.attn",
-            "model.layers.5.self_attn.attn",
-            "model.layers.10.self_attn.attn",
-        ]
-        self.assertEqual(attn_module._ATTN_KEYS_BUFFER, expected)
-        self.assertEqual(mock_fia.out.call_count, 3)
-
-    @patch("vllm_ascend.attention.attention_v1.torch.npu.stream")
-    @patch("vllm_ascend.attention.attention_v1.torch.npu.graph_task_update_begin")
-    @patch("vllm_ascend.attention.attention_v1.torch.npu.graph_task_update_end")
     @patch("vllm_ascend.attention.attention_v1.torch_npu._npu_paged_attention")
     @patch("vllm_ascend.attention.attention_v1.torch_npu._npu_paged_attention_get_workspace", return_value=MagicMock())
     @patch("vllm_ascend.attention.attention_v1.get_graph_params")
     @patch("vllm_ascend.attention.attention_v1._EXTRA_CTX")
     @patch("vllm_ascend.attention.attention_v1.using_paged_attention", return_value=True)
     @patch("vllm_ascend.attention.attention_v1.needs_layer_aware_fia_graph_replay", return_value=False)
-    @patch("vllm_ascend.attention.attention_v1._ATTN_KEYS_BUFFER", new=[])
     def test_update_graph_params_handles_captured_paged_attention_params(
         self,
         mock_needs_layer_aware_fia_graph_replay,

--- a/tests/ut/attention/test_attention_v1.py
+++ b/tests/ut/attention/test_attention_v1.py
@@ -19,7 +19,6 @@ from vllm_ascend.attention.context_parallel.attention_cp import (
 )
 from vllm_ascend.attention.utils import (
     AscendCommonAttentionMetadata,
-    PagedAttentionGraphParam,
     cache_graph_workspace,
     needs_layer_aware_fia_graph_replay,
     using_paged_attention,
@@ -781,70 +780,3 @@ class TestAscendAttentionBackendImpl(TestBase):
         mock_reshape_and_cache.assert_called_once()
 
         assert output.shape == (10, 8, 64)
-
-    @patch("vllm_ascend.attention.attention_v1.torch.npu.stream")
-    @patch("vllm_ascend.attention.attention_v1.torch.npu.graph_task_update_begin")
-    @patch("vllm_ascend.attention.attention_v1.torch.npu.graph_task_update_end")
-    @patch("vllm_ascend.attention.attention_v1.torch_npu._npu_paged_attention")
-    @patch("vllm_ascend.attention.attention_v1.torch_npu._npu_paged_attention_get_workspace", return_value=MagicMock())
-    @patch("vllm_ascend.attention.attention_v1.get_graph_params")
-    @patch("vllm_ascend.attention.attention_v1._EXTRA_CTX")
-    @patch("vllm_ascend.attention.attention_v1.using_paged_attention", return_value=True)
-    @patch("vllm_ascend.attention.attention_v1.needs_layer_aware_fia_graph_replay", return_value=False)
-    def test_update_graph_params_handles_captured_paged_attention_params(
-        self,
-        mock_needs_layer_aware_fia_graph_replay,
-        mock_using_paged_attention,
-        mock_EXTRA_CTX,
-        mock_get_graph_params,
-        mock_get_workspace,
-        mock_paged_attention,
-        mock_graph_task_update_end,
-        mock_graph_task_update_begin,
-        mock_stream,
-    ):
-        mock_EXTRA_CTX.sinks = False
-        mock_EXTRA_CTX.is_draft_model = False
-
-        query = MagicMock()
-        key_cache = MagicMock()
-        value_cache = MagicMock()
-        block_table = MagicMock()
-        output = MagicMock()
-        captured_seq_lens = MagicMock()
-        current_seq_lens = MagicMock()
-        pa_param = PagedAttentionGraphParam(
-            (
-                query,
-                key_cache,
-                value_cache,
-                8,
-                8,
-                1.0,
-                block_table,
-                captured_seq_lens,
-                output,
-            ),
-            "model.layers.0.self_attn.attn",
-        )
-
-        mock_get_graph_params.return_value.attn_params = {1: [pa_param]}
-        mock_get_graph_params.return_value.handles = {1: [MagicMock()]}
-        mock_get_graph_params.return_value.events = {1: [MagicMock()]}
-
-        forward_context = MagicMock()
-        forward_context.attn_metadata = {
-            "model.layers.0.self_attn.attn": MagicMock(
-                seq_lens=current_seq_lens,
-                block_tables=block_table,
-                seq_lens_list=[10],
-            ),
-        }
-
-        self.impl.update_graph_params(self.mock_stream, forward_context, 1, self.mock_vllm_config)
-
-        mock_get_workspace.assert_called_once()
-        mock_paged_attention.assert_called_once()
-        self.assertEqual(mock_paged_attention.call_args.kwargs["context_lens"], current_seq_lens)
-        mock_graph_task_update_begin.assert_called_once()
-        mock_graph_task_update_end.assert_called_once()

--- a/tests/ut/compilation/test_acl_graph.py
+++ b/tests/ut/compilation/test_acl_graph.py
@@ -375,7 +375,7 @@ class TestACLGraphWrapper(TestBase):
                 self.mock_get_ascend_config.return_value.ascend_compilation_config.enable_super_kernel = enabled
 
                 mock_npu_graph = MagicMock()
-                mock_torch.npu.NPUGraph.return_value = mock_npu_graph
+                self.mock_updatable_graph.return_value = mock_npu_graph
                 mock_graph_context = MagicMock()
                 mock_torch.npu.graph.return_value = mock_graph_context
                 mock_graph_context.__enter__ = Mock(return_value=None)

--- a/tests/ut/compilation/test_acl_graph.py
+++ b/tests/ut/compilation/test_acl_graph.py
@@ -12,6 +12,7 @@
 # limitations under the License.
 # This file is a part of the vllm-ascend project.
 #
+import contextlib
 import weakref
 from unittest.mock import MagicMock, Mock, patch
 
@@ -47,7 +48,8 @@ from vllm_ascend.compilation.acl_graph import (
 from vllm_ascend.device_allocator.sleep_mem_optimized import AclGraphSleepWakeupManager
 
 
-def test_update_full_graph_params_dispatches_draft_metadata_by_keyword():
+@patch("vllm_ascend.compilation.acl_graph.use_updatable_graph", return_value=False)
+def test_update_full_graph_params_dispatches_draft_metadata_by_keyword(mock_use_updatable):
     impl_cls = MagicMock()
     attn_backend = MagicMock()
     attn_backend.get_impl_cls.return_value = impl_cls
@@ -122,6 +124,12 @@ class TestACLGraphWrapper(TestBase):
         self.mock_get_ascend_config = self.get_ascend_config_patcher.start()
         self.addCleanup(self.get_ascend_config_patcher.stop)
         self.mock_get_ascend_config.return_value.ascend_compilation_config.enable_super_kernel = False
+
+        self.exit_stack = contextlib.ExitStack()
+        self.addCleanup(self.exit_stack.close)
+        self.mock_updatable_graph = self.exit_stack.enter_context(
+            patch("vllm_ascend.compilation.acl_graph.UpdatableGraph")
+        )
 
         # Mock VllmConfig
         self.mock_vllm_config = MagicMock(spec=VllmConfig)
@@ -284,7 +292,7 @@ class TestACLGraphWrapper(TestBase):
 
         # Mock torch.npu.NPUGraph
         mock_npu_graph = MagicMock()
-        mock_torch.npu.NPUGraph.return_value = mock_npu_graph
+        self.mock_updatable_graph.return_value = mock_npu_graph
 
         # Mock torch.npu.graph context manager
         mock_graph_context = MagicMock()
@@ -316,7 +324,7 @@ class TestACLGraphWrapper(TestBase):
 
         # Verify graph capture happened
         mock_validate_cudagraph_capturing_enabled.assert_called_once()
-        mock_torch.npu.NPUGraph.assert_called_once()
+        self.mock_updatable_graph.assert_called_once()
         mock_torch.npu.graph.assert_called_once_with(mock_npu_graph, pool=self.mock_graph_pool)
         self.mock_runnable.assert_called_once_with(test_tensor, "arg2")
 
@@ -422,7 +430,7 @@ class TestACLGraphWrapper(TestBase):
 
         # Mock torch.npu.NPUGraph
         mock_npu_graph = MagicMock()
-        mock_torch.npu.NPUGraph.return_value = mock_npu_graph
+        self.mock_updatable_graph.return_value = mock_npu_graph
 
         # Mock torch.npu.graph context manager
         mock_graph_context = MagicMock()
@@ -454,7 +462,7 @@ class TestACLGraphWrapper(TestBase):
 
         # Verify graph capture happened during first call
         mock_validate_cudagraph_capturing_enabled.assert_called_once()
-        mock_torch.npu.NPUGraph.assert_called_once()
+        self.mock_updatable_graph.assert_called_once()
         mock_torch.npu.graph.assert_called_once()
 
         # Reset mock to track second call
@@ -501,7 +509,7 @@ class TestACLGraphWrapper(TestBase):
 
         # Mock torch.npu.NPUGraph
         mock_npu_graph = MagicMock()
-        mock_torch.npu.NPUGraph.return_value = mock_npu_graph
+        self.mock_updatable_graph.return_value = mock_npu_graph
 
         # Mock torch.npu.graph context manager
         mock_graph_context = MagicMock()
@@ -562,7 +570,7 @@ class TestACLGraphWrapper(TestBase):
 
         # Mock torch.npu.NPUGraph
         mock_npu_graph = MagicMock()
-        mock_torch.npu.NPUGraph.return_value = mock_npu_graph
+        self.mock_updatable_graph.return_value = mock_npu_graph
 
         # Mock torch.npu.graph context manager
         mock_graph_context = MagicMock()
@@ -633,7 +641,7 @@ class TestACLGraphWrapper(TestBase):
 
         # Mock torch.npu.NPUGraph
         mock_npu_graph = MagicMock()
-        mock_torch.npu.NPUGraph.return_value = mock_npu_graph
+        self.mock_updatable_graph.return_value = mock_npu_graph
 
         # Mock torch.npu.graph context manager
         mock_graph_context = MagicMock()
@@ -675,7 +683,7 @@ class TestACLGraphWrapper(TestBase):
 
         # Verify graph capture happened
         mock_validate_cudagraph_capturing_enabled.assert_called_once()
-        mock_torch.npu.NPUGraph.assert_called_once()
+        self.mock_updatable_graph.assert_called_once()
         mock_torch.npu.graph.assert_called_once_with(mock_npu_graph, pool=self.mock_graph_pool)
 
         # Should return the original output (not weak ref) since weak_ref_output is not enabled
@@ -712,7 +720,7 @@ class TestACLGraphWrapper(TestBase):
 
         # Mock torch.npu.NPUGraph
         mock_npu_graph = MagicMock()
-        mock_torch.npu.NPUGraph.return_value = mock_npu_graph
+        self.mock_updatable_graph.return_value = mock_npu_graph
 
         # Mock torch.npu.graph context manager
         mock_graph_context = MagicMock()
@@ -749,7 +757,7 @@ class TestACLGraphWrapper(TestBase):
 
         # Verify graph capture happened
         mock_validate_cudagraph_capturing_enabled.assert_called_once()
-        mock_torch.npu.NPUGraph.assert_called_once()
+        self.mock_updatable_graph.assert_called_once()
         mock_torch.npu.graph.assert_called_once_with(mock_npu_graph, pool=self.mock_graph_pool)
 
         # Should return the weak ref output when weak_ref_output option is enabled
@@ -778,7 +786,7 @@ class TestACLGraphWrapper(TestBase):
         with patch("vllm_ascend.compilation.acl_graph.torch") as mock_torch:
             # Mock torch.npu.NPUGraph
             mock_npu_graph = MagicMock()
-            mock_torch.npu.NPUGraph.return_value = mock_npu_graph
+            self.mock_updatable_graph.return_value = mock_npu_graph
 
             # Mock torch.npu.graph context manager
             mock_graph_context = MagicMock()

--- a/tests/ut/spec_decode/test_dspark_proposer.py
+++ b/tests/ut/spec_decode/test_dspark_proposer.py
@@ -154,7 +154,9 @@ def test_dspark_device_metadata_executor_forward_lifecycle(has_task: bool):
     proposer.parallel_drafting = True
     proposer.token_indices_to_sample = torch.zeros(2, dtype=torch.int32)
     proposer.enable_enpu = False
+    proposer.draft_attn_groups = [MagicMock()]
     proposer._update_full_graph_params_if_needed = MagicMock()
+    proposer._maybe_update_metadata = MagicMock()
     proposer.set_inputs_first_pass = MagicMock()
     proposer.build_draft_attn_metadata = MagicMock()
 

--- a/tests/ut/spec_decode/test_eagle_proposer.py
+++ b/tests/ut/spec_decode/test_eagle_proposer.py
@@ -603,6 +603,7 @@ class TestEagleProposerDummyRun(TestBase):
         self.proposer.model = MagicMock()
         self.proposer._runnable = MagicMock()
         self.proposer.update_stream = MagicMock()
+        self.proposer.draft_attn_groups = [MagicMock()]
 
     def tearDown(self):
         self.mock_get_ascend_config.stop()

--- a/tests/ut/spec_decode/test_eagle_proposer.py
+++ b/tests/ut/spec_decode/test_eagle_proposer.py
@@ -592,6 +592,11 @@ class TestEagleProposerDummyRun(TestBase):
         self.mock_dp_group = patch("vllm_ascend.ascend_forward_context.get_dp_group", return_value=mock_dp_group)
         self.mock_dp_group.start()
 
+        self.mock_use_updatable_graph = patch(
+            "vllm_ascend.spec_decode.llm_base_proposer.use_updatable_graph", return_value=False
+        )
+        self.mock_use_updatable_graph.start()
+
         # Set the current vllm config
         set_current_vllm_config(self.vllm_config)
         self.proposer = AscendEagleProposer(vllm_config=self.vllm_config, device=self.device, runner=self.runner)
@@ -605,6 +610,7 @@ class TestEagleProposerDummyRun(TestBase):
         self.mock_supports_multimodal_inputs.stop()
         self.mock_tp_world_size.stop()
         self.mock_dp_group.stop()
+        self.mock_use_updatable_graph.stop()
         # Clear the current vllm config
         set_current_vllm_config(None)
 
@@ -649,6 +655,7 @@ class TestEagleProposerDummyRun(TestBase):
         mock_get_context.return_value = mock_return_context
         mock_get_context_2.return_value = mock_return_context
         self.proposer.use_cuda_graph = True
+        self.proposer.draft_attn_groups = [MagicMock()]
         # cpu does not support `torch.ops.vllm.maybe_pad_and_reduce`
         with set_current_vllm_config(self.vllm_config):
             self.proposer.dummy_run(num_tokens=64, in_graph_capturing=True, aclgraph_runtime_mode=CUDAGraphMode.FULL)
@@ -843,6 +850,11 @@ class TestEagleProposerPropose:
         set_current_vllm_config(self.vllm_config)
         self.proposer = AscendEagleProposer(vllm_config=self.vllm_config, device=self.device, runner=self.runner)
 
+        self.mock_use_updatable_graph = patch(
+            "vllm_ascend.spec_decode.llm_base_proposer.use_updatable_graph", return_value=False
+        )
+        self.mock_use_updatable_graph.start()
+
         yield
 
         self.mock_cpugpubuffer.stop()
@@ -850,6 +862,7 @@ class TestEagleProposerPropose:
         self.mock_tp_world_size.stop()
         self.mock_dp_group.stop()
         self.mock_get_ascend_config.stop()
+        self.mock_use_updatable_graph.stop()
         # Clear the current vllm config
         set_current_vllm_config(None)
         clear_ascend_config()

--- a/vllm_ascend/attention/attention_v1.py
+++ b/vllm_ascend/attention/attention_v1.py
@@ -50,11 +50,6 @@ from vllm_ascend.attention.utils import (
     split_decodes_and_prefills,
     using_paged_attention,
 )
-from vllm_ascend.compilation.acl_graph import (
-    get_draft_graph_params,
-    get_draft_graph_prefill_params,
-    get_graph_params,
-)
 from vllm_ascend.compilation.updatable_graph import (
     get_capture_resource,
     register_task,
@@ -559,9 +554,6 @@ class AscendAttentionBackendImpl(AttentionImpl):
         # for that path.
         self._layer_name: str | None = None
 
-    def get_update_condition(self):
-        return (self.sinks, self.head_size)
-
     def _graph_metadata_layer_name(self, layer: AttentionLayer | None = None) -> str | None:
         layer_name = layer.layer_name if layer is not None else self._layer_name
         # KV-sharing layers replay with the target layer's metadata instead of
@@ -577,96 +569,7 @@ class AscendAttentionBackendImpl(AttentionImpl):
         speculative_config=None,
         draft_attn_metadatas=None,
     ):
-        if using_paged_attention(num_tokens, vllm_config):
-            # Paged Attention update logic
-            if _EXTRA_CTX.is_draft_model:
-                if _EXTRA_CTX.is_draft_model_prefill:
-                    graph_params = get_draft_graph_prefill_params()
-                else:
-                    graph_params = get_draft_graph_params()
-            else:
-                graph_params = get_graph_params()
-            with torch.npu.stream(update_stream):
-                # The workspace size depends only on shapes and seq_lens, which
-                # are shared by all layers within one graph-param update pass,
-                # so one get_workspace call per pass is sufficient. Reuse the
-                # workspace across layers and re-query only when any
-                # size-relevant input changes. This mirrors the FIA path, which already
-                # reuses graph_params.workspaces[num_tokens], and removes the
-                # redundant per-layer get_workspace calls (each backed by a
-                # ~36-54MB buffer allocation) per decode step.
-                step_ws_key = None
-                workspace = None
-                for key, param, handle, event in zip(
-                    forward_context.attn_metadata,
-                    graph_params.attn_params[num_tokens],
-                    graph_params.handles[num_tokens],
-                    graph_params.events[num_tokens],
-                ):
-                    (
-                        query,
-                        key_cache,
-                        value_cache,
-                        num_kv_heads,
-                        num_heads,
-                        scale,
-                        block_table,
-                        seq_lens,
-                        output,
-                    ) = param
-                    seq_lens = forward_context.attn_metadata[key].seq_lens
-
-                    # The key covers every size-relevant input, so models
-                    # with heterogeneous layer configs simply trigger a
-                    # re-query instead of reusing a wrong-sized workspace.
-                    ws_key = (
-                        seq_lens.data_ptr(),
-                        tuple(seq_lens.shape),
-                        query.shape,
-                        query.dtype,
-                        key_cache.shape,
-                        key_cache.dtype,
-                        value_cache.shape,
-                        value_cache.dtype,
-                        block_table.shape if block_table is not None else None,
-                        block_table.dtype if block_table is not None else None,
-                        output.shape,
-                        output.dtype,
-                        num_kv_heads,
-                        num_heads,
-                        scale,
-                    )
-                    if step_ws_key != ws_key:
-                        workspace = torch_npu._npu_paged_attention_get_workspace(
-                            query=query,
-                            key_cache=key_cache,
-                            value_cache=value_cache,
-                            num_kv_heads=num_kv_heads,
-                            num_heads=num_heads,
-                            scale_value=scale,
-                            block_table=block_table,
-                            context_lens=seq_lens,
-                            out=output,
-                        )
-                        step_ws_key = ws_key
-                    torch.npu.graph_task_update_begin(update_stream, handle)
-                    torch_npu._npu_paged_attention(
-                        query=query,
-                        key_cache=key_cache,
-                        value_cache=value_cache,
-                        num_kv_heads=num_kv_heads,
-                        num_heads=num_heads,
-                        scale_value=scale,
-                        block_table=block_table,
-                        context_lens=seq_lens,
-                        out=output,
-                        workspace=workspace,
-                    )
-                    torch.npu.graph_task_update_end(update_stream)
-                    event.record(update_stream)
-        else:
-            # FIA use updatable graph
-            return
+        raise NotImplementedError("FIA and PA should be use UpdatableGraph.")
 
     def process_weights_after_loading(self, act_dtype: torch.dtype):
         super().process_weights_after_loading(act_dtype)

--- a/vllm_ascend/attention/attention_v1.py
+++ b/vllm_ascend/attention/attention_v1.py
@@ -44,7 +44,6 @@ from vllm_ascend.ascend_forward_context import _EXTRA_CTX
 from vllm_ascend.attention.attention_mask import AttentionMaskBuilder
 from vllm_ascend.attention.utils import (
     AscendCommonAttentionMetadata,
-    PagedAttentionGraphParam,
     enable_dcp,
     needs_layer_aware_fia_graph_replay,
     notify_kv_cache_written,
@@ -55,7 +54,6 @@ from vllm_ascend.compilation.acl_graph import (
     get_draft_graph_params,
     get_draft_graph_prefill_params,
     get_graph_params,
-    update_graph_params_workspaces,
 )
 from vllm_ascend.compilation.updatable_graph import (
     get_capture_resource,
@@ -64,7 +62,7 @@ from vllm_ascend.compilation.updatable_graph import (
 from vllm_ascend.device.device_op import DeviceOperator
 from vllm_ascend.device.hardware_profile import HardwareCapability, get_current_hardware_profile
 from vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.attention_fence import record_attention_compute_start
-from vllm_ascend.utils import vllm_version_is, weak_ref_tensors
+from vllm_ascend.utils import vllm_version_is
 
 if vllm_version_is("0.28.0"):
     from vllm.model_executor.layers.attention.pcp import _gather_prefill_cache_inputs  # type: ignore[import-not-found]
@@ -75,6 +73,7 @@ else:
 SWA_INT_MAX = 2147483647
 _FIA_WORKSPACE_KEY = "npu_fused_infer_attention_score.workspace"
 _FIA_V2_WORKSPACE_KEY = "npu_fused_infer_attention_score_v2.workspace"
+_PA_WORKSPACE_KEY = "npu_paged_attention.workspace"
 
 
 @register_backend(AttentionBackendEnum.CUSTOM, "ASCEND")
@@ -495,6 +494,18 @@ class FIAV2ParamProvider:
         }
 
 
+@dataclass(frozen=True, slots=True)
+class PAParamProvider:
+    layer_name: str | None
+
+    def resolve(self, attn_metadata) -> dict[str, Any]:
+        metadata = attn_metadata[self.layer_name]
+        return {
+            "context_lens": metadata.seq_lens,
+            "block_table": metadata.block_tables,
+        }
+
+
 class AscendAttentionBackendImpl(AttentionImpl):
     def __init__(
         self,
@@ -816,51 +827,9 @@ class AscendAttentionBackendImpl(AttentionImpl):
         attn_metadata: AscendMetadata,
         output: torch.Tensor | None = None,
     ):
-        graph_params = get_graph_params()
-        num_tokens = query.shape[0]
-        if _EXTRA_CTX.capturing:
-            # Get workspace from cache or calculate it if not present.
-            workspace = graph_params.workspaces.get(num_tokens)
-            if workspace is None:
-                workspace = torch_npu._npu_paged_attention_get_workspace(
-                    query=query,
-                    key_cache=self.key_cache,
-                    value_cache=self.value_cache,
-                    num_kv_heads=self.num_kv_heads,
-                    num_heads=self.num_heads,
-                    scale_value=self.scale,
-                    block_table=attn_metadata.block_tables,
-                    context_lens=attn_metadata.seq_lens,
-                    out=output,
-                )
-                update_graph_params_workspaces(num_tokens, workspace)
-
-            # Handle graph capturing mode
-            stream = torch_npu.npu.current_stream()
-
-            event = torch.npu.ExternalEvent()
-            event.wait(stream)
-            event.reset(stream)
-            graph_params.events[num_tokens].append(event)
-            graph_params.attn_params[num_tokens].append(
-                PagedAttentionGraphParam(
-                    (
-                        weak_ref_tensors(query),
-                        weak_ref_tensors(self.key_cache),
-                        weak_ref_tensors(self.value_cache),
-                        self.num_kv_heads,
-                        self.num_heads,
-                        self.scale,
-                        attn_metadata.block_tables,
-                        attn_metadata.seq_lens,
-                        weak_ref_tensors(output),
-                    ),
-                    self._graph_metadata_layer_name() if self._use_layer_aware_fia_graph_replay else None,
-                )
-            )
-
-            torch.npu.graph_task_group_begin(stream)
-            torch_npu._npu_paged_attention(
+        workspace = get_capture_resource(
+            _PA_WORKSPACE_KEY,
+            lambda: torch_npu._npu_paged_attention_get_workspace(
                 query=query,
                 key_cache=self.key_cache,
                 value_cache=self.value_cache,
@@ -870,11 +839,25 @@ class AscendAttentionBackendImpl(AttentionImpl):
                 block_table=attn_metadata.block_tables,
                 context_lens=attn_metadata.seq_lens,
                 out=output,
-                workspace=workspace,
-            )
-            handle = torch.npu.graph_task_group_end(stream)
-            graph_params.handles[num_tokens].append(handle)
-            return output
+            ),
+        )
+        register_task(
+            torch_npu._npu_paged_attention,
+            {
+                "query": query,
+                "key_cache": self.key_cache,
+                "value_cache": self.value_cache,
+                "num_kv_heads": self.num_kv_heads,
+                "num_heads": self.num_heads,
+                "scale_value": self.scale,
+                "block_table": attn_metadata.block_tables,
+                "context_lens": attn_metadata.seq_lens,
+                "out": output,
+                "workspace": workspace,
+            },
+            PAParamProvider(self._layer_name),
+        )
+        return output
 
     def _get_fia_params(self, key: torch.Tensor, value: torch.Tensor, attn_metadata: AscendMetadata, kv_cache=None):
         # PrefillNoCache doesn't need key_cache, but other modes do

--- a/vllm_ascend/attention/attention_v1.py
+++ b/vllm_ascend/attention/attention_v1.py
@@ -617,6 +617,7 @@ class AscendAttentionBackendImpl(AttentionImpl):
             attn_mask = None
             sparse_mode = 0
 
+        use_max_workspace = self._use_max_workspace_for_fia_graph
         workspace = get_capture_resource(
             _FIA_WORKSPACE_KEY,
             lambda: torch_npu._npu_fused_infer_attention_score_get_max_workspace(
@@ -637,6 +638,7 @@ class AscendAttentionBackendImpl(AttentionImpl):
                 sparse_mode=sparse_mode,
                 **extra_args,
             ),
+            use_max_workspace,
         )
         register_task(
             torch_npu.npu_fused_infer_attention_score.out,
@@ -677,6 +679,7 @@ class AscendAttentionBackendImpl(AttentionImpl):
         actual_seq_lengths_q = attn_metadata.actual_seq_lengths_q
         softmax_lse = torch.empty(1, dtype=query.dtype, device=query.device)
         output_view = output[: attn_metadata.num_actual_tokens]
+        use_max_workspace = self._use_max_workspace_for_fia_graph
         workspace = get_capture_resource(
             _FIA_V2_WORKSPACE_KEY,
             lambda: torch_npu._npu_fused_infer_attention_score_v2_get_max_workspace(
@@ -697,6 +700,7 @@ class AscendAttentionBackendImpl(AttentionImpl):
                 next_tokens=0,
                 learnable_sink=self.sinks,
             ),
+            use_max_workspace,
         )
         register_task(
             torch_npu.npu_fused_infer_attention_score_v2.out,

--- a/vllm_ascend/attention/attention_v1.py
+++ b/vllm_ascend/attention/attention_v1.py
@@ -45,20 +45,21 @@ from vllm_ascend.attention.attention_mask import AttentionMaskBuilder
 from vllm_ascend.attention.utils import (
     AscendCommonAttentionMetadata,
     PagedAttentionGraphParam,
-    cache_graph_workspace,
     enable_dcp,
     needs_layer_aware_fia_graph_replay,
     notify_kv_cache_written,
     split_decodes_and_prefills,
-    update_paged_attention_graph_param,
     using_paged_attention,
 )
 from vllm_ascend.compilation.acl_graph import (
     get_draft_graph_params,
     get_draft_graph_prefill_params,
     get_graph_params,
-    update_draft_graph_params_workspaces,
     update_graph_params_workspaces,
+)
+from vllm_ascend.compilation.updatable_graph import (
+    get_capture_resource,
+    register_task,
 )
 from vllm_ascend.device.device_op import DeviceOperator
 from vllm_ascend.device.hardware_profile import HardwareCapability, get_current_hardware_profile
@@ -72,7 +73,8 @@ else:
 
 # default max value of sliding window size
 SWA_INT_MAX = 2147483647
-_ATTN_KEYS_BUFFER = None
+_FIA_WORKSPACE_KEY = "npu_fused_infer_attention_score.workspace"
+_FIA_V2_WORKSPACE_KEY = "npu_fused_infer_attention_score_v2.workspace"
 
 
 @register_backend(AttentionBackendEnum.CUSTOM, "ASCEND")
@@ -459,6 +461,40 @@ class AscendAttentionMetadataBuilder(AttentionMetadataBuilder[AscendMetadata]):
         return attn_metadata
 
 
+@dataclass(frozen=True, slots=True)
+class FIAParamProvider:
+    layer_name: str | None
+    sliding_window: int | None
+    is_draft_model: bool = False
+
+    def resolve(self, attn_metadata) -> dict[str, Any]:
+        metadata = attn_metadata[self.layer_name]
+
+        if self.is_draft_model or not self.sliding_window:
+            return {
+                "actual_seq_lengths": metadata.actual_seq_lengths_q,
+                "actual_seq_lengths_kv": metadata.seq_lens_list,
+                "block_table": metadata.block_tables,
+            }
+        else:
+            return {
+                "actual_seq_lengths": metadata.actual_seq_lengths_q,
+                "actual_seq_lengths_kv": metadata.seq_lens_list,
+            }
+
+
+@dataclass(frozen=True, slots=True)
+class FIAV2ParamProvider:
+    layer_name: str | None
+
+    def resolve(self, attn_metadata) -> dict[str, Any]:
+        metadata = attn_metadata[self.layer_name]
+        return {
+            "actual_seq_qlen": metadata.actual_seq_lengths_q,
+            "actual_seq_kvlen": metadata.seq_lens_list,
+        }
+
+
 class AscendAttentionBackendImpl(AttentionImpl):
     def __init__(
         self,
@@ -512,6 +548,9 @@ class AscendAttentionBackendImpl(AttentionImpl):
         # for that path.
         self._layer_name: str | None = None
 
+    def get_update_condition(self):
+        return (self.sinks, self.head_size)
+
     def _graph_metadata_layer_name(self, layer: AttentionLayer | None = None) -> str | None:
         layer_name = layer.layer_name if layer is not None else self._layer_name
         # KV-sharing layers replay with the target layer's metadata instead of
@@ -527,7 +566,6 @@ class AscendAttentionBackendImpl(AttentionImpl):
         speculative_config=None,
         draft_attn_metadatas=None,
     ):
-        use_layer_aware_replay = needs_layer_aware_fia_graph_replay()
         if using_paged_attention(num_tokens, vllm_config):
             # Paged Attention update logic
             if _EXTRA_CTX.is_draft_model:
@@ -615,312 +653,9 @@ class AscendAttentionBackendImpl(AttentionImpl):
                     )
                     torch.npu.graph_task_update_end(update_stream)
                     event.record(update_stream)
-        elif _EXTRA_CTX.sinks:
-            # FIA update logic
-            if _EXTRA_CTX.is_draft_model:
-                graph_params = get_draft_graph_params()
-                attn_metadata = draft_attn_metadatas
-                draft_attn_key_steps = [
-                    (draft_step, key)
-                    for draft_step, per_step_metadata in enumerate(attn_metadata)
-                    for key in per_step_metadata
-                ]
-                attn_keys = [key for _, key in draft_attn_key_steps]
-            else:
-                graph_params = get_graph_params()
-                attn_metadata = forward_context.attn_metadata
-                attn_keys = list(attn_metadata.keys())
-            # For Qwen3-next, since the kv_cache_config has already categorized
-            # linear_attn and self_attn, the attn_metadata is first arranged with
-            # self_attn followed by linear_attn. Therefore, using zip directly
-            # filters out the update operations for linear_attn.
-            # TODO: We use a new variable `attn_keys` to ensure the loop count is
-            # correct after get by `zip` because of the new structure of the attn_metadata
-            # when running with the merged full eagle-graph. Should check it with Qwen3-next.
-            num_layers = len(attn_keys)
-            if num_layers == 0:
-                return
-            captured_attn_params = graph_params.attn_params[num_tokens]
-            handles = graph_params.handles[num_tokens]
-            events = graph_params.events[num_tokens]
-            graph_param_count = len(captured_attn_params)
-            workspace = graph_params.workspaces.get(num_tokens)
-            if _EXTRA_CTX.is_draft_model:
-                if graph_param_count > len(draft_attn_key_steps):
-                    repeat_count = cdiv(graph_param_count, len(draft_attn_key_steps))
-                    draft_attn_key_steps = (draft_attn_key_steps * repeat_count)[:graph_param_count]
-                else:
-                    draft_attn_key_steps = draft_attn_key_steps[:graph_param_count]
-                attn_keys = [key for _, key in draft_attn_key_steps]
-            elif use_layer_aware_replay:
-                # One graph size can contain captured FIA ops from all layers.
-                # Repeat attn keys to match the captured op count, then use the
-                # stored layer name in each op param to resolve the exact
-                # metadata entry during replay.
-                attn_keys = [attn_keys[index % num_layers] for index in range(graph_param_count)]
-            attn_count = 0
-            with torch.npu.stream(update_stream):
-                for key, param, handle, event in zip(
-                    attn_keys,
-                    captured_attn_params,
-                    handles,
-                    events,
-                ):
-                    (
-                        query,
-                        key_cache,
-                        value,
-                        block_tables,
-                        attn_mask,
-                        block_size,
-                        seq_lens,
-                        num_kv_heads,
-                        num_heads,
-                        scale,
-                        sliding_window,
-                        sinks,
-                        attn_output,
-                        softmax_lse,
-                        layer_name,
-                    ) = param
-
-                    if _EXTRA_CTX.is_draft_model:
-                        draft_step, key = draft_attn_key_steps[attn_count]
-                        seq_lens = attn_metadata[draft_step][key].seq_lens_list
-                        actual_seq_lengths_q = attn_metadata[draft_step][key].actual_seq_lengths_q
-                        attn_count = attn_count + 1
-                    else:
-                        metadata_key = layer_name if layer_name is not None and layer_name in attn_metadata else key
-                        seq_lens = attn_metadata[metadata_key].seq_lens_list
-                        actual_seq_lengths_q = attn_metadata[metadata_key].actual_seq_lengths_q
-
-                    torch.npu.graph_task_update_begin(update_stream, handle)
-                    torch_npu.npu_fused_infer_attention_score_v2.out(
-                        query=query,
-                        key=key_cache,
-                        value=value,
-                        block_table=block_tables,
-                        atten_mask=attn_mask,
-                        input_layout="TND",
-                        block_size=block_size,
-                        actual_seq_qlen=actual_seq_lengths_q,
-                        actual_seq_kvlen=seq_lens,
-                        num_key_value_heads=num_kv_heads,
-                        num_query_heads=num_heads,
-                        sparse_mode=4 if sliding_window is not None else 3,
-                        pre_tokens=sliding_window if sliding_window is not None else SWA_INT_MAX,
-                        next_tokens=0,
-                        softmax_scale=scale,
-                        learnable_sink=sinks,
-                        workspace=workspace,
-                        out=[attn_output, softmax_lse],
-                    )
-                    torch.npu.graph_task_update_end(update_stream)
-                    event.record(update_stream)
         else:
-            # FIA update logic
-            if _EXTRA_CTX.is_draft_model:
-                if _EXTRA_CTX.is_draft_model_prefill:
-                    graph_params = get_draft_graph_prefill_params()
-                else:
-                    graph_params = get_draft_graph_params()
-                attn_metadata = draft_attn_metadatas
-                draft_attn_key_steps = [
-                    (draft_step, key)
-                    for draft_step, per_step_metadata in enumerate(attn_metadata)
-                    for key in per_step_metadata
-                ]
-                attn_keys = [key for _, key in draft_attn_key_steps]
-            else:
-                graph_params = get_graph_params()
-                attn_metadata = forward_context.attn_metadata
-                # Only standard (FIA) attention layers have captured graph
-                # params here; linear/GDN layers (GDNAttentionMetadata) are
-                # updated separately by update_conv1d_graph_params. So we filter by `seq_lens_list`
-                attn_keys = [k for k in attn_metadata if hasattr(attn_metadata[k], "seq_lens_list")]
-                if not use_layer_aware_replay:
-                    # In some speculative methods (such as DFlash), the order of
-                    # attn_keys in the Target model will be disrupted instead of
-                    # increasing by layer index, so need regular expressions to
-                    # reorder the attn_keys and store the results in
-                    # _ATTN_KEYS_BUFFER.
-                    attn_keys_length = len(graph_params.attn_params[num_tokens])
-                    global _ATTN_KEYS_BUFFER
-                    if attn_keys_length == 0:
-                        return
-                    if not _ATTN_KEYS_BUFFER or len(_ATTN_KEYS_BUFFER) != attn_keys_length:
-                        import regex as re
-
-                        def extract_layer_index(key: str) -> int:
-                            match = re.search(r"(?:^|\.)layers\.(\d+)(?:\.|$)", key)
-                            return int(match.group(1)) if match else 0
-
-                        def is_direct_target_attn_key(key: str) -> bool:
-                            return (
-                                re.search(
-                                    r"(?:^|\.)layers\.(\d+)\.self_attn\.attn$",
-                                    key,
-                                )
-                                is not None
-                            )
-
-                        attn_keys_to_order = attn_keys[:attn_keys_length]
-                        if getattr(speculative_config, "method", None) == "mtp":
-                            # Step3.5 MTP can expose draft KV-cache groups in the
-                            # target runtime metadata.  The target FULL graph only
-                            # captures direct base-model self-attention handles, so
-                            # select that target key domain instead of depending on
-                            # the current draft module name.
-                            direct_target_attn_keys = [key for key in attn_keys if is_direct_target_attn_key(key)]
-                            if len(direct_target_attn_keys) >= attn_keys_length:
-                                attn_keys_to_order = direct_target_attn_keys
-
-                        attn_keys_tmp = attn_keys_to_order
-                        attn_keys_tmp.sort(key=extract_layer_index)
-                        _ATTN_KEYS_BUFFER = attn_keys_tmp[:attn_keys_length]
-                    attn_keys[:attn_keys_length] = _ATTN_KEYS_BUFFER
-            # For Qwen3-next, since the kv_cache_config has already categorized
-            # linear_attn and self_attn, the attn_metadata is first arranged with
-            # self_attn followed by linear_attn. Therefore, using zip directly
-            # filters out the update operations for linear_attn.
-            # TODO: We use a new variable `attn_keys` to ensure the loop count is
-            # correct after get by `zip` because of the new structure of the attn_metadata
-            # when running with the merged full eagle-graph. Should check it with Qwen3-next.
-            num_layers = len(attn_keys)
-            if num_layers == 0:
-                return
-            captured_attn_params = graph_params.attn_params[num_tokens]
-            handles = graph_params.handles[num_tokens]
-            events = graph_params.events[num_tokens]
-            graph_param_count = len(captured_attn_params)
-            workspace = graph_params.workspaces.get(num_tokens)
-            if _EXTRA_CTX.is_draft_model:
-                if graph_param_count > len(draft_attn_key_steps):
-                    repeat_count = cdiv(graph_param_count, len(draft_attn_key_steps))
-                    draft_attn_key_steps = (draft_attn_key_steps * repeat_count)[:graph_param_count]
-                else:
-                    draft_attn_key_steps = draft_attn_key_steps[:graph_param_count]
-                attn_keys = [key for _, key in draft_attn_key_steps]
-            elif use_layer_aware_replay:
-                # Keep the replay loop length aligned with captured FIA ops;
-                # layer-specific metadata lookup below prevents global/sliding
-                # window layers from accidentally sharing the same metadata.
-                attn_keys = [attn_keys[index % num_layers] for index in range(graph_param_count)]
-            attn_count = 0
-            layer_count = 0
-            with torch.npu.stream(update_stream):
-                for key, param, handle, event in zip(
-                    attn_keys,
-                    captured_attn_params,
-                    handles,
-                    events,
-                ):
-                    if isinstance(param, PagedAttentionGraphParam):
-                        if _EXTRA_CTX.is_draft_model:
-                            draft_step, key = draft_attn_key_steps[attn_count]
-                            block_table = attn_metadata[draft_step][key].block_tables
-                            seq_lens = attn_metadata[draft_step][key].seq_lens
-                            attn_count = attn_count + 1
-                        else:
-                            layer_name = param.layer_name
-                            metadata_key = layer_name if layer_name is not None and layer_name in attn_metadata else key
-                            block_table = attn_metadata[metadata_key].block_tables
-                            seq_lens = attn_metadata[metadata_key].seq_lens
-                        update_paged_attention_graph_param(
-                            update_stream,
-                            handle,
-                            event,
-                            param,
-                            block_table,
-                            seq_lens,
-                        )
-                        continue
-                    (
-                        query,
-                        key_cache,
-                        value,
-                        block_tables,
-                        attn_mask,
-                        block_size,
-                        seq_lens,
-                        query_start_loc,
-                        num_kv_heads,
-                        num_heads,
-                        scale,
-                        attn_output,
-                        softmax_lse,
-                        sparse_mode,
-                        pre_tokens,
-                        next_tokens,
-                        sliding_window,
-                        c8_k_aq_scale,
-                        c8_k_aq_offset,
-                        c8_v_aq_scale,
-                        c8_v_aq_offset,
-                        layer_name,
-                    ) = param
-
-                    if _EXTRA_CTX.is_draft_model:
-                        draft_step, key = draft_attn_key_steps[attn_count]
-                        metadata = attn_metadata[draft_step][key]
-                        seq_lens = metadata.seq_lens_list
-                        actual_seq_lengths_q = metadata.actual_seq_lengths_q
-                        block_tables = metadata.block_tables
-                        attn_count = attn_count + 1
-                        if not metadata.causal:
-                            sparse_mode = 0
-                    else:
-                        metadata_key = layer_name if layer_name is not None and layer_name in attn_metadata else key
-                        seq_lens = attn_metadata[metadata_key].seq_lens_list
-                        actual_seq_lengths_q = attn_metadata[metadata_key].actual_seq_lengths_q
-                        # NOTE:
-                        # For models with sliding-window attention on the FIA full-graph replay path,
-                        # rebinding `block_tables` to the latest metadata tensor causes corrupted /
-                        # repeated outputs in our repro on Ascend NPU.
-                        #
-                        # Keep the captured block_tables tensor on this affected path.
-                        # Non-SWA models preserve the original behavior and continue to refresh
-                        # block_tables from attn_metadata.
-                        if not sliding_window:
-                            block_tables = attn_metadata[metadata_key].block_tables
-                    layer_count += 1
-
-                    torch.npu.graph_task_update_begin(update_stream, handle)
-                    input_layout = "TND"
-                    extra_args = {}
-                    if c8_k_aq_scale is not None:
-                        extra_args = {
-                            "key_antiquant_scale": c8_k_aq_scale,
-                            "value_antiquant_scale": c8_v_aq_scale,
-                            "key_antiquant_mode": 0,
-                            "value_antiquant_mode": 0,
-                            "inner_precise": 1,
-                        }
-                        input_layout = "BNSD"
-                        sparse_mode = 0
-                    torch_npu.npu_fused_infer_attention_score.out(
-                        query=query,
-                        key=key_cache,
-                        value=value,
-                        block_table=block_tables,
-                        atten_mask=attn_mask,
-                        input_layout=input_layout,
-                        block_size=block_size,
-                        actual_seq_lengths=actual_seq_lengths_q,
-                        actual_seq_lengths_kv=seq_lens,
-                        num_key_value_heads=num_kv_heads,
-                        num_heads=num_heads,
-                        scale=scale,
-                        sparse_mode=sparse_mode,
-                        pre_tokens=pre_tokens,
-                        next_tokens=next_tokens,
-                        **extra_args,
-                        workspace=workspace,
-                        out=[attn_output, softmax_lse],
-                    )
-                    torch.npu.graph_task_update_end(update_stream)
-
-                    event.record(update_stream)
+            # FIA use updatable graph
+            return
 
     def process_weights_after_loading(self, act_dtype: torch.dtype):
         super().process_weights_after_loading(act_dtype)
@@ -937,13 +672,6 @@ class AscendAttentionBackendImpl(AttentionImpl):
         key, value, block_size, block_table, actual_seq_lengths_kv = self._get_fia_params(key, value, attn_metadata)
 
         num_tokens = attn_metadata.actual_seq_lengths_q[-1]
-        if _EXTRA_CTX.is_draft_model:
-            if _EXTRA_CTX.is_draft_model_prefill:
-                graph_params = get_draft_graph_prefill_params()
-            else:
-                graph_params = get_draft_graph_params()
-        else:
-            graph_params = get_graph_params()
         actual_seq_lengths_q = attn_metadata.actual_seq_lengths_q
         softmax_lse = torch.empty(1, dtype=query.dtype, device=query.device)
         input_layout = "TND"
@@ -951,6 +679,7 @@ class AscendAttentionBackendImpl(AttentionImpl):
         sparse_mode = 4 if self.sliding_window else 3 if attn_metadata.causal else 0
         pre_tokens = self.sliding_window or SWA_INT_MAX
         next_tokens = 0 if self.sliding_window else SWA_INT_MAX
+        output_view = output[: attn_metadata.num_actual_tokens]
 
         extra_args = {}
         if self.enable_c8_quant and layer is not None:
@@ -973,13 +702,10 @@ class AscendAttentionBackendImpl(AttentionImpl):
             output = output.unsqueeze(2)
             attn_mask = None
             sparse_mode = 0
-        use_max_workspace = self._use_max_workspace_for_fia_graph
-        workspace = graph_params.workspaces.get(num_tokens)
-        should_update_workspace_cache = False
-        if use_max_workspace:
-            # Some models mix attention layer shapes under the same graph size.
-            # During capture, keep the largest required workspace for that size.
-            candidate_workspace = torch_npu._npu_fused_infer_attention_score_get_max_workspace(
+
+        workspace = get_capture_resource(
+            _FIA_WORKSPACE_KEY,
+            lambda: torch_npu._npu_fused_infer_attention_score_get_max_workspace(
                 query=query,
                 key=key,
                 value=value,
@@ -991,110 +717,36 @@ class AscendAttentionBackendImpl(AttentionImpl):
                 actual_seq_lengths_kv=actual_seq_lengths_kv,
                 num_key_value_heads=self.num_kv_heads,
                 num_heads=self.num_heads,
-                sparse_mode=sparse_mode,
                 pre_tokens=pre_tokens,
                 next_tokens=next_tokens,
                 scale=self.scale,
-                **extra_args,
-            )
-            workspace = cache_graph_workspace(
-                graph_params,
-                num_tokens,
-                candidate_workspace,
-                use_max_workspace=use_max_workspace,
-            )
-            should_update_workspace_cache = True
-        elif workspace is None:
-            workspace = torch_npu._npu_fused_infer_attention_score_get_max_workspace(
-                query=query,
-                key=key,
-                value=value,
-                atten_mask=attn_mask,
-                block_table=block_table,
-                input_layout=input_layout,
-                block_size=block_size,
-                actual_seq_lengths=actual_seq_lengths_q,
-                actual_seq_lengths_kv=actual_seq_lengths_kv,
-                num_key_value_heads=self.num_kv_heads,
-                num_heads=self.num_heads,
                 sparse_mode=sparse_mode,
-                pre_tokens=pre_tokens,
-                next_tokens=next_tokens,
-                scale=self.scale,
                 **extra_args,
-            )
-            should_update_workspace_cache = True
-        if should_update_workspace_cache:
-            if _EXTRA_CTX.is_draft_model:
-                update_draft_graph_params_workspaces(num_tokens, workspace)
-            else:
-                update_graph_params_workspaces(num_tokens, workspace)
-
-        # Handle graph capturing mode
-        stream = torch_npu.npu.current_stream()
-
-        event = torch.npu.ExternalEvent()
-        event.wait(stream)
-        event.reset(stream)
-        graph_params.events[num_tokens].append(event)
-        attn_params = (
-            weak_ref_tensors(query),
-            weak_ref_tensors(key),
-            weak_ref_tensors(value),
-            weak_ref_tensors(block_table),
-            weak_ref_tensors(attn_mask) if attn_mask is not None else None,
-            block_size,
-            actual_seq_lengths_kv,
-            actual_seq_lengths_q,
-            self.num_kv_heads,
-            self.num_heads,
-            self.scale,
-            weak_ref_tensors(output),
-            weak_ref_tensors(softmax_lse),
-            sparse_mode,
-            pre_tokens,
-            next_tokens,
-            self.sliding_window,
+            ),
         )
-        if self.enable_c8_quant and layer is not None:
-            attn_params = attn_params + (
-                weak_ref_tensors(layer._c8_k_aq_scale_nz_bnsd),
-                None,
-                weak_ref_tensors(layer._c8_v_aq_scale_nz_bnsd),
-                None,
-            )  # type: ignore
-        else:
-            attn_params = attn_params + (None, None, None, None)  # type: ignore
-        layer_name = self._graph_metadata_layer_name(layer) if self._use_layer_aware_fia_graph_replay else None
-        attn_params = attn_params + (layer_name,)  # type: ignore
-        graph_params.attn_params[num_tokens].append(attn_params)
-
-        torch.npu.graph_task_group_begin(stream)
-        torch_npu.npu_fused_infer_attention_score.out(
-            query=query,
-            key=key,
-            value=value,
-            atten_mask=attn_mask,
-            block_table=block_table,
-            input_layout=input_layout,
-            block_size=block_size,
-            actual_seq_lengths=actual_seq_lengths_q,
-            actual_seq_lengths_kv=actual_seq_lengths_kv,
-            num_key_value_heads=self.num_kv_heads,
-            num_heads=self.num_heads,
-            scale=self.scale,
-            sparse_mode=sparse_mode,
-            pre_tokens=pre_tokens,
-            next_tokens=next_tokens,
-            workspace=workspace,
-            out=[output, softmax_lse],
-            **extra_args,
+        register_task(
+            torch_npu.npu_fused_infer_attention_score.out,
+            {
+                "query": query,
+                "key": key,
+                "value": value,
+                "atten_mask": attn_mask,
+                "block_table": block_table,
+                "input_layout": input_layout,
+                "block_size": block_size,
+                "actual_seq_lengths": actual_seq_lengths_q,
+                "actual_seq_lengths_kv": actual_seq_lengths_kv,
+                "num_key_value_heads": self.num_kv_heads,
+                "num_heads": self.num_heads,
+                "pre_tokens": pre_tokens,
+                "next_tokens": next_tokens,
+                "scale": self.scale,
+                "sparse_mode": sparse_mode,
+                "workspace": workspace,
+                "out": [output_view, softmax_lse],
+            },
+            FIAParamProvider(self._layer_name, self.sliding_window, _EXTRA_CTX.is_draft_model),
         )
-
-        output = output.view(num_tokens, self.num_heads, self.head_size)
-
-        handle = torch.npu.graph_task_group_end(stream)
-        graph_params.handles[num_tokens].append(handle)
         return output, num_tokens
 
     def full_graph_fia_v2(
@@ -1108,20 +760,12 @@ class AscendAttentionBackendImpl(AttentionImpl):
         key, value, block_size, block_table, actual_seq_lengths_kv = self._get_fia_params(key, value, attn_metadata)
         actual_seq_lengths_kv = attn_metadata.seq_lens
         num_tokens = attn_metadata.actual_seq_lengths_q[-1]
-        if _EXTRA_CTX.is_draft_model:
-            graph_params = get_draft_graph_params()
-        else:
-            graph_params = get_graph_params()
-
         actual_seq_lengths_q = attn_metadata.actual_seq_lengths_q
         softmax_lse = torch.empty(1, dtype=query.dtype, device=query.device)
-        use_max_workspace = self._use_max_workspace_for_fia_graph
-        workspace = graph_params.workspaces.get(num_tokens)
-        should_update_workspace_cache = False
-        if use_max_workspace:
-            # See full_graph_fia: this path needs the max workspace across layer
-            # variants sharing the same graph size.
-            candidate_workspace = torch_npu._npu_fused_infer_attention_score_v2_get_max_workspace(
+        output_view = output[: attn_metadata.num_actual_tokens]
+        workspace = get_capture_resource(
+            _FIA_V2_WORKSPACE_KEY,
+            lambda: torch_npu._npu_fused_infer_attention_score_v2_get_max_workspace(
                 query=query,
                 key=key,
                 value=value,
@@ -1138,89 +782,32 @@ class AscendAttentionBackendImpl(AttentionImpl):
                 pre_tokens=self.sliding_window if self.sliding_window is not None else SWA_INT_MAX,
                 next_tokens=0,
                 learnable_sink=self.sinks,
-            )
-            workspace = cache_graph_workspace(
-                graph_params,
-                num_tokens,
-                candidate_workspace,
-                use_max_workspace=use_max_workspace,
-            )
-            should_update_workspace_cache = True
-        elif workspace is None:
-            workspace = torch_npu._npu_fused_infer_attention_score_v2_get_max_workspace(
-                query=query,
-                key=key,
-                value=value,
-                atten_mask=attn_metadata.attn_mask,
-                block_table=block_table,
-                input_layout="TND",
-                block_size=block_size,
-                actual_seq_qlen=actual_seq_lengths_q,
-                actual_seq_kvlen=actual_seq_lengths_kv,
-                num_key_value_heads=self.num_kv_heads,
-                softmax_scale=self.scale,
-                num_query_heads=self.num_heads,
-                sparse_mode=4 if self.sliding_window is not None else 3,
-                pre_tokens=self.sliding_window if self.sliding_window is not None else SWA_INT_MAX,
-                next_tokens=0,
-                learnable_sink=self.sinks,
-            )
-            should_update_workspace_cache = True
-        if should_update_workspace_cache:
-            if _EXTRA_CTX.is_draft_model:
-                update_draft_graph_params_workspaces(num_tokens, workspace)
-            else:
-                update_graph_params_workspaces(num_tokens, workspace)
-
-        # Handle graph capturing mode
-        stream = torch_npu.npu.current_stream()
-
-        event = torch.npu.ExternalEvent()
-        event.wait(stream)
-        event.reset(stream)
-        graph_params.events[num_tokens].append(event)
-        graph_params.attn_params[num_tokens].append(
-            (
-                weak_ref_tensors(query),
-                weak_ref_tensors(key),
-                weak_ref_tensors(value),
-                weak_ref_tensors(block_table),
-                weak_ref_tensors(attn_metadata.attn_mask),
-                block_size,
-                actual_seq_lengths_kv,
-                self.num_kv_heads,
-                self.num_heads,
-                self.scale,
-                self.sliding_window,
-                self.sinks,
-                weak_ref_tensors(output),
-                weak_ref_tensors(softmax_lse),
-                self._graph_metadata_layer_name() if self._use_layer_aware_fia_graph_replay else None,
-            )
+            ),
         )
-        torch.npu.graph_task_group_begin(stream)
-        torch_npu.npu_fused_infer_attention_score_v2.out(
-            query=query,
-            key=key,
-            value=value,
-            atten_mask=attn_metadata.attn_mask,
-            block_table=block_table,
-            input_layout="TND",
-            block_size=block_size,
-            actual_seq_qlen=actual_seq_lengths_q,
-            actual_seq_kvlen=actual_seq_lengths_kv,
-            num_key_value_heads=self.num_kv_heads,
-            num_query_heads=self.num_heads,
-            sparse_mode=4 if self.sliding_window is not None else 3,
-            pre_tokens=self.sliding_window if self.sliding_window is not None else SWA_INT_MAX,
-            next_tokens=0,
-            softmax_scale=self.scale,
-            learnable_sink=self.sinks,
-            workspace=workspace,
-            out=[output, softmax_lse],
+        register_task(
+            torch_npu.npu_fused_infer_attention_score_v2.out,
+            {
+                "query": query,
+                "key": key,
+                "value": value,
+                "atten_mask": attn_metadata.attn_mask,
+                "block_table": block_table,
+                "input_layout": "TND",
+                "block_size": block_size,
+                "actual_seq_qlen": actual_seq_lengths_q,
+                "actual_seq_kvlen": actual_seq_lengths_kv,
+                "num_key_value_heads": self.num_kv_heads,
+                "num_query_heads": self.num_heads,
+                "sparse_mode": 4 if self.sliding_window is not None else 3,
+                "pre_tokens": self.sliding_window if self.sliding_window is not None else SWA_INT_MAX,
+                "next_tokens": 0,
+                "softmax_scale": self.scale,
+                "learnable_sink": self.sinks,
+                "workspace": workspace,
+                "out": [output_view, softmax_lse],
+            },
+            FIAV2ParamProvider(self._layer_name),
         )
-        handle = torch.npu.graph_task_group_end(stream)
-        graph_params.handles[num_tokens].append(handle)
         return output, num_tokens
 
     def full_graph_pa(
@@ -1760,8 +1347,7 @@ class AscendAttentionBackendImpl(AttentionImpl):
             shape = [num_tokens, num_heads * head_size]
         """
         assert output is not None, "Output tensor must be provided."
-        if self._use_layer_aware_fia_graph_replay:
-            self._layer_name = layer.layer_name
+        self._layer_name = layer.layer_name
 
         if output_scale is not None or output_block_scale is not None:
             raise NotImplementedError("fused output quantization is not yet supported for AscendAttentionBackendImpl")

--- a/vllm_ascend/attention/utils.py
+++ b/vllm_ascend/attention/utils.py
@@ -5,7 +5,6 @@ from typing import Any
 
 import torch
 import torch.nn.functional as F
-import torch_npu
 from vllm.config import VllmConfig, get_current_vllm_config
 from vllm.distributed.kv_transfer import get_kv_transfer_group, has_kv_transfer_group, is_v1_kv_transfer_group
 from vllm.forward_context import ForwardContext, get_forward_context
@@ -89,53 +88,6 @@ class PagedAttentionGraphParam:
 
     def __iter__(self):
         return iter(self.params)
-
-
-def update_paged_attention_graph_param(
-    update_stream,
-    handle,
-    event,
-    param: PagedAttentionGraphParam,
-    block_table: torch.Tensor,
-    seq_lens: torch.Tensor,
-) -> None:
-    (
-        query,
-        key_cache,
-        value_cache,
-        num_kv_heads,
-        num_heads,
-        scale,
-        _captured_block_table,
-        _captured_seq_lens,
-        output,
-    ) = param.params
-    workspace = torch_npu._npu_paged_attention_get_workspace(
-        query=query,
-        key_cache=key_cache,
-        value_cache=value_cache,
-        num_kv_heads=num_kv_heads,
-        num_heads=num_heads,
-        scale_value=scale,
-        block_table=block_table,
-        context_lens=seq_lens,
-        out=output,
-    )
-    torch.npu.graph_task_update_begin(update_stream, handle)
-    torch_npu._npu_paged_attention(
-        query=query,
-        key_cache=key_cache,
-        value_cache=value_cache,
-        num_kv_heads=num_kv_heads,
-        num_heads=num_heads,
-        scale_value=scale,
-        block_table=block_table,
-        context_lens=seq_lens,
-        out=output,
-        workspace=workspace,
-    )
-    torch.npu.graph_task_update_end(update_stream)
-    event.record(update_stream)
 
 
 def cache_graph_workspace(

--- a/vllm_ascend/compilation/acl_graph.py
+++ b/vllm_ascend/compilation/acl_graph.py
@@ -23,7 +23,12 @@ from vllm.platforms import current_platform
 from vllm_ascend.ascend_config import get_ascend_config
 from vllm_ascend.ascend_forward_context import _EXTRA_CTX
 
-from ..utils import weak_ref_tensors
+from ..utils import use_updatable_graph, weak_ref_tensors
+from .updatable_graph import (
+    ContextSource,
+    SharedSource,
+    UpdatableGraph,
+)
 
 _acl_graph_wrappers: weakref.WeakSet[Any] = weakref.WeakSet()
 _STREAM_RESOURCE_ERROR_CODE = "207008"
@@ -105,6 +110,7 @@ class ACLGraphWrapper:
         *,
         use_eagle: bool = False,
         enable_enpu: bool = False,
+        update_stream: torch.npu.Stream | None = None,
     ):
         self.runnable = runnable
         self.vllm_config = vllm_config
@@ -131,7 +137,19 @@ class ACLGraphWrapper:
         self.concrete_aclgraph_entries: dict[BatchDescriptor, ACLGraphEntry] = {}
         self.enable_enpu = enable_enpu
         self.use_eagle = use_eagle
+        self.update_stream = update_stream
+        self.attn_backend = None
+        self.draft_attn_metadata_updates: list[dict[str, Any]] = []
         _acl_graph_wrappers.add(self)
+
+    def set_update_stream(self, update_stream):
+        self.update_stream = update_stream
+
+    def set_attn_backend(self, attn_backend):
+        self.attn_backend = attn_backend
+
+    def set_draft_attn_metadata_updates(self, update_params: list[dict[str, Any]]):
+        self.draft_attn_metadata_updates = update_params
 
     def __getattr__(self, key: str):
         # allow accessing the attributes of the runnable.
@@ -179,7 +197,7 @@ class ACLGraphWrapper:
 
             input_addresses = [x.data_ptr() for x in args if isinstance(x, torch.Tensor)]
             entry.input_addresses = input_addresses
-            aclgraph = torch.npu.NPUGraph()
+            aclgraph = UpdatableGraph()
 
             with ExitStack() as stack:
                 if self.aclgraph_options.gc_disable:
@@ -288,8 +306,29 @@ class ACLGraphWrapper:
         need_sync = self.runtime_mode == CUDAGraphMode.FULL and not is_draft_eagle
         if not self.enable_enpu and need_sync:
             torch.npu.current_stream().synchronize()
-        entry.aclgraph.replay()
+        if self.runtime_mode == CUDAGraphMode.FULL and use_updatable_graph(
+            self.attn_backend, batch_descriptor.num_tokens, self.vllm_config
+        ):
+            self._updatable_graph_replay(forward_context, entry.aclgraph)
+        else:
+            entry.aclgraph.replay()
         return entry.output
+
+    def _updatable_graph_replay(
+        self,
+        forward_context,
+        graph: UpdatableGraph,
+    ):
+        if _EXTRA_CTX.is_draft_model:
+            resolved_tasks = graph.resolve_tasks(SharedSource(self.draft_attn_metadata_updates))
+        else:
+            resolved_tasks = graph.resolve_tasks(ContextSource(forward_context.attn_metadata))
+        if self.enable_enpu:
+            graph.update(self.update_stream, resolved_tasks)
+            graph.replay()
+        else:
+            graph.replay()
+            graph.update(self.update_stream, resolved_tasks)
 
 
 def weak_ref_workspaces(params):
@@ -310,6 +349,9 @@ def update_full_graph_params(
     speculative_config=None,
     draft_attn_metadatas=None,
 ):
+    if use_updatable_graph(attn_backend, num_tokens, vllm_config):
+        return
+
     # vLLM >= 0.27.1 (main) makes get_current_vllm_config() raise
     # AssertionError outside set_current_vllm_config(); the SFA backend
     # resolution in get_impl_cls() needs the config.

--- a/vllm_ascend/compilation/acl_graph.py
+++ b/vllm_ascend/compilation/acl_graph.py
@@ -139,7 +139,7 @@ class ACLGraphWrapper:
         self.use_eagle = use_eagle
         self.update_stream = update_stream
         self.attn_backend = None
-        self.draft_attn_metadata_updates: list[dict[str, Any]] = []
+        self.draft_model_metadata: list[dict[str, Any]] = []
         _acl_graph_wrappers.add(self)
 
     def set_update_stream(self, update_stream):
@@ -148,8 +148,9 @@ class ACLGraphWrapper:
     def set_attn_backend(self, attn_backend):
         self.attn_backend = attn_backend
 
-    def set_draft_attn_metadata_updates(self, update_params: list[dict[str, Any]]):
-        self.draft_attn_metadata_updates = update_params
+    def update_draft_model_metadata(self, draft_model_metadata: list[dict[str, Any]]):
+        # This has been prepared for the update full graph of MRV1.
+        self.draft_model_metadata = draft_model_metadata
 
     def __getattr__(self, key: str):
         # allow accessing the attributes of the runnable.
@@ -306,9 +307,7 @@ class ACLGraphWrapper:
         need_sync = self.runtime_mode == CUDAGraphMode.FULL and not is_draft_eagle
         if not self.enable_enpu and need_sync:
             torch.npu.current_stream().synchronize()
-        if self.runtime_mode == CUDAGraphMode.FULL and use_updatable_graph(
-            self.attn_backend, batch_descriptor.num_tokens, self.vllm_config
-        ):
+        if self.runtime_mode == CUDAGraphMode.FULL and use_updatable_graph(self.attn_backend):
             self._updatable_graph_replay(forward_context, entry.aclgraph)
         else:
             entry.aclgraph.replay()
@@ -319,8 +318,9 @@ class ACLGraphWrapper:
         forward_context,
         graph: UpdatableGraph,
     ):
+        assert self.update_stream is not None
         if _EXTRA_CTX.is_draft_model:
-            resolved_tasks = graph.resolve_tasks(SharedSource(self.draft_attn_metadata_updates))
+            resolved_tasks = graph.resolve_tasks(SharedSource(self.draft_model_metadata))
         else:
             resolved_tasks = graph.resolve_tasks(ContextSource(forward_context.attn_metadata))
         if self.enable_enpu:
@@ -349,7 +349,7 @@ def update_full_graph_params(
     speculative_config=None,
     draft_attn_metadatas=None,
 ):
-    if use_updatable_graph(attn_backend, num_tokens, vllm_config):
+    if use_updatable_graph(attn_backend):
         return
 
     # vLLM >= 0.27.1 (main) makes get_current_vllm_config() raise

--- a/vllm_ascend/compilation/updatable_graph.py
+++ b/vllm_ascend/compilation/updatable_graph.py
@@ -1,0 +1,168 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from collections.abc import Callable, Hashable, Sequence
+from contextvars import ContextVar, Token
+from dataclasses import dataclass, replace
+from typing import Any, Protocol
+
+import torch
+
+from vllm_ascend.utils import weak_ref_tensors
+
+Params = dict[str, Any]
+
+
+class ParamProvider(Protocol):
+    def resolve(self, context) -> Params: ...
+
+
+class ParamSource(Protocol):
+    def get(
+        self,
+        provider: ParamProvider,
+    ) -> Sequence[Params]: ...
+
+
+@dataclass(frozen=True, slots=True)
+class ContextSource:
+    context: Any
+
+    def get(
+        self,
+        provider: ParamProvider,
+    ) -> Sequence[Params]:
+        return (provider.resolve(self.context),)
+
+
+@dataclass(frozen=True, slots=True)
+class SharedSource:
+    params: Sequence[Params]
+
+    def get(
+        self,
+        _provider: ParamProvider,
+    ) -> Sequence[Params]:
+        return self.params
+
+
+_ACTIVE_GRAPH: ContextVar["UpdatableGraph | None"] = ContextVar("capturing_updatable_graph", default=None)
+
+
+@dataclass(frozen=True, slots=True)
+class GraphUpdateTask:
+    operation: Callable[..., Any]
+    kwargs: dict[str, Any]
+    provider: ParamProvider
+    provider_index: int
+    handle: Any
+    event: Any
+
+    def bind(self, params: Params) -> "GraphUpdateTask":
+        runtime_kwargs = {**self.kwargs, **params}
+        return replace(self, kwargs=runtime_kwargs)
+
+    def apply(self, update_stream) -> None:
+        torch.npu.graph_task_update_begin(update_stream, self.handle)
+        self.operation(**self.kwargs)
+        torch.npu.graph_task_update_end(update_stream)
+        self.event.record(update_stream)
+
+
+class UpdatableGraph(torch.npu.NPUGraph):
+    def __init__(self) -> None:
+        super().__init__()
+        self.tasks: list[GraphUpdateTask] = []
+        self.provider_sizes: dict[ParamProvider, int] = {}
+        self.capture_resources: dict[Hashable, Any] = {}
+        self.capture_token: Token[UpdatableGraph | None] | None = None
+
+    def capture_begin(self, pool=None, capture_error_mode: str = "global") -> None:
+        super().capture_begin(pool=pool, capture_error_mode=capture_error_mode)
+        assert self.capture_token is None
+        self.capture_token = _ACTIVE_GRAPH.set(self)
+
+    def capture_end(self) -> None:
+        try:
+            super().capture_end()
+        finally:
+            assert self.capture_token is not None
+            _ACTIVE_GRAPH.reset(self.capture_token)
+            self.capture_token = None
+            self.capture_resources = weak_ref_tensors(self.capture_resources)
+
+    def get_capture_resource(
+        self,
+        key: Hashable,
+        factory: Callable[[], Any],
+    ) -> Any:
+        if key not in self.capture_resources:
+            self.capture_resources[key] = factory()
+        return self.capture_resources[key]
+
+    def register_task(
+        self,
+        operation: Callable[..., Any],
+        kwargs: dict[str, Any],
+        provider: ParamProvider,
+    ) -> None:
+        stream = torch.npu.current_stream()
+        event = torch.npu.ExternalEvent()
+        event.wait(stream)
+        event.reset(stream)
+        torch.npu.graph_task_group_begin(stream)
+        operation(**kwargs)
+        handle = torch.npu.graph_task_group_end(stream)
+        weak_kwargs = weak_ref_tensors(kwargs)
+        provider_index = self.provider_sizes.get(provider, 0)
+        self.provider_sizes[provider] = provider_index + 1
+        self.tasks.append(
+            GraphUpdateTask(
+                operation,
+                weak_kwargs,
+                provider,
+                provider_index,
+                handle,
+                event,
+            )
+        )
+
+    def resolve_tasks(
+        self,
+        source: ParamSource,
+    ) -> tuple[GraphUpdateTask, ...]:
+        params_by_provider = {provider: source.get(provider) for provider in self.provider_sizes}
+        for provider, size in self.provider_sizes.items():
+            assert len(params_by_provider[provider]) == size
+        return tuple(task.bind(params_by_provider[task.provider][task.provider_index]) for task in self.tasks)
+
+    def update(
+        self,
+        update_stream,
+        resolved_tasks: tuple[GraphUpdateTask, ...],
+    ) -> None:
+        with torch.npu.stream(update_stream):
+            for task in resolved_tasks:
+                task.apply(update_stream)
+
+
+def register_task(
+    operation: Callable[..., Any],
+    kwargs: dict[str, Any],
+    provider: ParamProvider,
+) -> None:
+    graph = _ACTIVE_GRAPH.get()
+    if graph is None:
+        operation(**kwargs)
+    else:
+        graph.register_task(operation, kwargs, provider)
+
+
+def get_capture_resource(
+    key: Hashable,
+    factory: Callable[[], Any],
+) -> Any:
+    graph = _ACTIVE_GRAPH.get()
+    if graph is None:
+        return factory()
+    return graph.get_capture_resource(key, factory)

--- a/vllm_ascend/compilation/updatable_graph.py
+++ b/vllm_ascend/compilation/updatable_graph.py
@@ -7,6 +7,7 @@ from dataclasses import dataclass, replace
 from typing import Any, Protocol
 
 import torch
+from vllm.logger import logger
 
 from vllm_ascend.utils import weak_ref_tensors
 
@@ -141,6 +142,7 @@ class UpdatableGraph(torch.npu.NPUGraph):
         update_stream,
         resolved_tasks: tuple[GraphUpdateTask, ...],
     ) -> None:
+        logger.debug_once("Updating host-side attention metadata with UpdatableGraph.")
         with torch.npu.stream(update_stream):
             for task in resolved_tasks:
                 task.apply(update_stream)

--- a/vllm_ascend/compilation/updatable_graph.py
+++ b/vllm_ascend/compilation/updatable_graph.py
@@ -7,6 +7,7 @@ from dataclasses import dataclass, replace
 from typing import Any, Protocol
 
 import torch
+import torch_npu
 from vllm.logger import logger
 
 from vllm_ascend.utils import weak_ref_tensors
@@ -50,7 +51,7 @@ class SharedSource:
 _ACTIVE_GRAPH: ContextVar["UpdatableGraph | None"] = ContextVar("capturing_updatable_graph", default=None)
 
 
-@dataclass(frozen=True, slots=True)
+@dataclass(slots=True)
 class GraphUpdateTask:
     operation: Callable[..., Any]
     kwargs: dict[str, Any]
@@ -58,12 +59,22 @@ class GraphUpdateTask:
     provider_index: int
     handle: Any
     event: Any
+    # This is specially designed for PA.
+    updated_workspace: bool = False
 
     def bind(self, params: Params) -> "GraphUpdateTask":
         runtime_kwargs = {**self.kwargs, **params}
         return replace(self, kwargs=runtime_kwargs)
 
     def apply(self, update_stream) -> None:
+        if self.operation == torch_npu._npu_paged_attention and not self.updated_workspace:
+            # The workspace is only updated on the first layer.
+            self.updated_workspace = True
+            workspace_kwargs = self.kwargs.copy()
+            workspace_kwargs.pop("workspace")
+            workspace = torch_npu._npu_paged_attention_get_workspace(**workspace_kwargs)
+            self.kwargs["workspace"] = workspace
+
         torch.npu.graph_task_update_begin(update_stream, self.handle)
         self.operation(**self.kwargs)
         torch.npu.graph_task_update_end(update_stream)
@@ -96,9 +107,20 @@ class UpdatableGraph(torch.npu.NPUGraph):
         self,
         key: Hashable,
         factory: Callable[[], Any],
+        use_max_workspace: bool = False,
     ) -> Any:
+        if use_max_workspace:
+            # Some models mix attention layer shapes under the same graph size.
+            # During capture, keep the largest required workspace for that size.
+            candidate_workspace = factory()
         if key not in self.capture_resources:
             self.capture_resources[key] = factory()
+        if (
+            use_max_workspace
+            and candidate_workspace.numel() * candidate_workspace.element_size()
+            > self.capture_resources[key].numel() * self.capture_resources[key].element_size()
+        ):
+            self.capture_resources[key] = candidate_workspace
         return self.capture_resources[key]
 
     def register_task(
@@ -163,8 +185,9 @@ def register_task(
 def get_capture_resource(
     key: Hashable,
     factory: Callable[[], Any],
+    use_max_workspace: bool = False,
 ) -> Any:
     graph = _ACTIVE_GRAPH.get()
     if graph is None:
         return factory()
-    return graph.get_capture_resource(key, factory)
+    return graph.get_capture_resource(key, factory, use_max_workspace)

--- a/vllm_ascend/spec_decode/llm_base_proposer.py
+++ b/vllm_ascend/spec_decode/llm_base_proposer.py
@@ -619,22 +619,24 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
             )
 
     def set_update_stream(self, update_stream):
-        update_stream_setter = getattr(self._runnable, "set_update_stream", None)
-        if callable(update_stream_setter):
-            update_stream_setter(update_stream)
+        if hasattr(self._runnable, "set_update_stream"):
+            self._runnable.set_update_stream(update_stream)
+        self.update_stream = update_stream
 
-    def _build_draft_attn_metadata_updates(self, multi_steps_attn_metadata):
-        update_params = []
-        for per_layer_metadata in multi_steps_attn_metadata:
-            metadata = next(iter(per_layer_metadata.values()))
-            update_params.append(
-                {
-                    "actual_seq_lengths": metadata.actual_seq_lengths_q,
-                    "actual_seq_lengths_kv": metadata.seq_lens_list,
-                    "block_table": metadata.block_tables,
-                }
-            )
-        return update_params
+    def _maybe_update_metadata(self, att_backend, aclgraph_runtime_mode, multi_steps_attn_metadata):
+        if use_updatable_graph(att_backend):
+            update_params = []
+            for per_layer_metadata in multi_steps_attn_metadata:
+                metadata = next(iter(per_layer_metadata.values()))
+                update_params.append(
+                    {
+                        "actual_seq_lengths": metadata.actual_seq_lengths_q,
+                        "actual_seq_lengths_kv": metadata.seq_lens_list,
+                        "block_table": metadata.block_tables,
+                    }
+                )
+            self._runnable.update_draft_model_metadata(update_params)  # type: ignore
+            self._runnable.set_attn_backend(att_backend)  # type: ignore
 
     def _maybe_share_topk_indices(self, target_language_model: nn.Module) -> None:
         if hasattr(target_language_model.model, "topk_indices_buffer"):
@@ -820,12 +822,12 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
 
         self.token_indices_to_sample.fill_(0)
 
-        if aclgraph_runtime_mode == CUDAGraphMode.FULL and use_updatable_graph(
-            self.draft_attn_groups[0].backend, num_tokens, self.vllm_config
-        ):
-            update_params = self._build_draft_attn_metadata_updates(multi_steps_attn_metadata)
-            self._runnable.set_draft_attn_metadata_updates(update_params)  # type: ignore
-            self._runnable.set_attn_backend(self.draft_attn_groups[0].backend)  # type: ignore
+        if aclgraph_runtime_mode == CUDAGraphMode.FULL:
+            self._maybe_update_metadata(
+                self.draft_attn_groups[0].backend,
+                aclgraph_runtime_mode,
+                multi_steps_attn_metadata,
+            )
 
         with set_ascend_forward_context(
             multi_steps_attn_metadata[0] if multi_steps_attn_metadata else None,
@@ -1159,12 +1161,12 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
         self.token_indices_to_sample[:token_indices_to_sample_len].copy_(token_indices_to_sample)
         self.token_indices_to_sample[token_indices_to_sample_len:].fill_(0)
 
-        if aclgraph_runtime_mode == CUDAGraphMode.FULL and use_updatable_graph(
-            self.draft_attn_groups[0].backend, num_tokens, self.vllm_config
-        ):
-            update_params = self._build_draft_attn_metadata_updates(multi_steps_attn_metadata)
-            self._runnable.set_draft_attn_metadata_updates(update_params)  # type: ignore
-            self._runnable.set_attn_backend(self.draft_attn_groups[0].backend)  # type: ignore
+        if aclgraph_runtime_mode == CUDAGraphMode.FULL:
+            self._maybe_update_metadata(
+                self.draft_attn_groups[0].backend,
+                aclgraph_runtime_mode,
+                multi_steps_attn_metadata,
+            )
 
         active_device_metadata_executor = (
             getattr(self.runner, "device_metadata_executor", None) if self.method == "dspark" else None

--- a/vllm_ascend/spec_decode/llm_base_proposer.py
+++ b/vllm_ascend/spec_decode/llm_base_proposer.py
@@ -278,7 +278,7 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
         # since final block table tensor is not ready in __init__, it is delayed until dummy_run
         self.block_table_tensor_clone: torch.Tensor | None = None
 
-        self._runnable = self._run_merged_draft
+        self._runnable: Any = self._run_merged_draft
         if self.uses_mrope:
             self.mrope_positions = torch.zeros((3, self.max_num_tokens + 1), dtype=torch.int32, device=device)
         elif self.uses_xdrope_dim > 0 and self.draft_uses_xdrope_dim > 0:
@@ -618,6 +618,22 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
                 enable_enpu=self.enable_enpu,
             )
 
+    def set_update_stream(self, update_stream):
+        self._runnable.set_update_stream(update_stream)  # type: ignore
+
+    def _build_draft_attn_metadata_updates(self, multi_steps_attn_metadata):
+        update_params = []
+        for per_layer_metadata in multi_steps_attn_metadata:
+            metadata = next(iter(per_layer_metadata.values()))
+            update_params.append(
+                {
+                    "actual_seq_lengths": metadata.actual_seq_lengths_q,
+                    "actual_seq_lengths_kv": metadata.seq_lens_list,
+                    "block_table": metadata.block_tables,
+                }
+            )
+        return update_params
+
     def _maybe_share_topk_indices(self, target_language_model: nn.Module) -> None:
         if hasattr(target_language_model.model, "topk_indices_buffer"):
             if hasattr(self.model.model, "topk_indices_buffer"):
@@ -801,6 +817,11 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
             inputs_embeds = None
 
         self.token_indices_to_sample.fill_(0)
+
+        if aclgraph_runtime_mode == CUDAGraphMode.FULL:
+            update_params = self._build_draft_attn_metadata_updates(multi_steps_attn_metadata)
+            self._runnable.set_draft_attn_metadata_updates(update_params)  # type: ignore
+            self._runnable.set_attn_backend(self.draft_attn_groups[0].backend)  # type: ignore
 
         with set_ascend_forward_context(
             multi_steps_attn_metadata[0] if multi_steps_attn_metadata else None,
@@ -1133,6 +1154,11 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
         token_indices_to_sample_len = token_indices_to_sample.shape[0]
         self.token_indices_to_sample[:token_indices_to_sample_len].copy_(token_indices_to_sample)
         self.token_indices_to_sample[token_indices_to_sample_len:].fill_(0)
+
+        if aclgraph_runtime_mode == CUDAGraphMode.FULL:
+            update_params = self._build_draft_attn_metadata_updates(multi_steps_attn_metadata)
+            self._runnable.set_draft_attn_metadata_updates(update_params)  # type: ignore
+            self._runnable.set_attn_backend(self.draft_attn_groups[0].backend)  # type: ignore
 
         active_device_metadata_executor = (
             getattr(self.runner, "device_metadata_executor", None) if self.method == "dspark" else None

--- a/vllm_ascend/spec_decode/llm_base_proposer.py
+++ b/vllm_ascend/spec_decode/llm_base_proposer.py
@@ -65,7 +65,7 @@ from vllm_ascend.spec_decode.utils import (
     _maybe_eager_context,
     patch_tensor_parallel_group,
 )
-from vllm_ascend.utils import check_gdn_layer, enable_sp, lmhead_tp_enable, vllm_version_is
+from vllm_ascend.utils import check_gdn_layer, enable_sp, lmhead_tp_enable, use_updatable_graph, vllm_version_is
 from vllm_ascend.worker.device_metadata import DeviceMetadataTask, DeviceMetadataTaskProvider
 
 # Currently we will fix block size to a small one since `num_reqs` can't be too large
@@ -619,7 +619,9 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
             )
 
     def set_update_stream(self, update_stream):
-        self._runnable.set_update_stream(update_stream)  # type: ignore
+        update_stream_setter = getattr(self._runnable, "set_update_stream", None)
+        if callable(update_stream_setter):
+            update_stream_setter(update_stream)
 
     def _build_draft_attn_metadata_updates(self, multi_steps_attn_metadata):
         update_params = []
@@ -818,7 +820,9 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
 
         self.token_indices_to_sample.fill_(0)
 
-        if aclgraph_runtime_mode == CUDAGraphMode.FULL:
+        if aclgraph_runtime_mode == CUDAGraphMode.FULL and use_updatable_graph(
+            self.draft_attn_groups[0].backend, num_tokens, self.vllm_config
+        ):
             update_params = self._build_draft_attn_metadata_updates(multi_steps_attn_metadata)
             self._runnable.set_draft_attn_metadata_updates(update_params)  # type: ignore
             self._runnable.set_attn_backend(self.draft_attn_groups[0].backend)  # type: ignore
@@ -1155,7 +1159,9 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
         self.token_indices_to_sample[:token_indices_to_sample_len].copy_(token_indices_to_sample)
         self.token_indices_to_sample[token_indices_to_sample_len:].fill_(0)
 
-        if aclgraph_runtime_mode == CUDAGraphMode.FULL:
+        if aclgraph_runtime_mode == CUDAGraphMode.FULL and use_updatable_graph(
+            self.draft_attn_groups[0].backend, num_tokens, self.vllm_config
+        ):
             update_params = self._build_draft_attn_metadata_updates(multi_steps_attn_metadata)
             self._runnable.set_draft_attn_metadata_updates(update_params)  # type: ignore
             self._runnable.set_attn_backend(self.draft_attn_groups[0].backend)  # type: ignore

--- a/vllm_ascend/utils.py
+++ b/vllm_ascend/utils.py
@@ -975,7 +975,7 @@ def weak_ref_tensor(tensor: Any) -> Any:
     The new tensor will share the same data as the original tensor,
     but will not keep the original tensor alive.
     """
-    if isinstance(tensor, torch.Tensor):
+    if isinstance(tensor, torch.Tensor) and tensor.device.type == "npu":
         return torch_npu._C._weak_ref_tensor(tensor)
     else:
         return tensor
@@ -1000,7 +1000,7 @@ def weak_ref_tensors(tensors: Any) -> Any:
     if isinstance(tensors, tuple):
         return tuple(weak_ref_tensors(tensor) for tensor in tensors)
     if isinstance(tensors, dict):
-        return {key: (weak_ref_tensors(tensor) if key != "context_lens" else tensor) for key, tensor in tensors.items()}
+        return {key: weak_ref_tensors(tensor) for key, tensor in tensors.items()}
     if isinstance(tensors, IntermediateTensors):
         return IntermediateTensors(weak_ref_tensors(tensors.tensors))
     return tensors
@@ -1651,8 +1651,6 @@ def get_rotation_matrix(rotation_path: Path | None) -> torch.Tensor:
 
 def use_updatable_graph(
     attn_backend,
-    num_tokens,
-    vllm_config,
 ) -> bool:
     from vllm_ascend.attention.attention_v1 import AscendAttentionBackend
 

--- a/vllm_ascend/utils.py
+++ b/vllm_ascend/utils.py
@@ -981,12 +981,10 @@ def weak_ref_tensor(tensor: Any) -> Any:
         return tensor
 
 
-def weak_ref_tensors(
-    tensors: torch.Tensor | list[torch.Tensor] | tuple[torch.Tensor],
-) -> torch.Tensor | list[Any] | tuple[Any] | Any:
+def weak_ref_tensors(tensors: Any) -> Any:
     """
-    Convenience function to create weak references to tensors,
-    for single tensor, list of tensors or tuple of tensors.
+    Recursively replace tensors with weak references while preserving containers
+    and non-tensor values.
 
     This function should be used in the following scenario:
     When a tensor is created during graph capture, and it's held by a method
@@ -998,14 +996,14 @@ def weak_ref_tensors(
     if isinstance(tensors, torch.Tensor):
         return weak_ref_tensor(tensors)
     if isinstance(tensors, list):
-        return [weak_ref_tensor(t) for t in tensors]
+        return [weak_ref_tensors(tensor) for tensor in tensors]
     if isinstance(tensors, tuple):
-        return tuple(weak_ref_tensor(t) for t in tensors)
-    # For IntermediateTensors used in pipeline parallelism
+        return tuple(weak_ref_tensors(tensor) for tensor in tensors)
+    if isinstance(tensors, dict):
+        return {key: weak_ref_tensors(tensor) for key, tensor in tensors.items()}
     if isinstance(tensors, IntermediateTensors):
-        ret = IntermediateTensors({key: weak_ref_tensor(val) for key, val in tensors.tensors.items()})
-        return ret
-    raise ValueError("Invalid type for tensors")
+        return IntermediateTensors(weak_ref_tensors(tensors.tensors))
+    return tensors
 
 
 def npu_stream_switch(target_stream: torch.npu.Stream, *, enabled: bool = True):
@@ -1649,3 +1647,19 @@ def get_rotation_matrix(rotation_path: Path | None) -> torch.Tensor:
             rotation_path,
         )
         raise e
+
+
+def use_updatable_graph(
+    attn_backend,
+    num_tokens,
+    vllm_config,
+) -> bool:
+    from vllm_ascend.attention.attention_v1 import AscendAttentionBackend
+    from vllm_ascend.attention.utils import using_paged_attention
+
+    head_size = vllm_config.model_config.get_head_size()
+    return (
+        attn_backend is not None
+        and issubclass(attn_backend, AscendAttentionBackend)
+        and not using_paged_attention(num_tokens, vllm_config, head_size)
+    )

--- a/vllm_ascend/utils.py
+++ b/vllm_ascend/utils.py
@@ -1000,7 +1000,7 @@ def weak_ref_tensors(tensors: Any) -> Any:
     if isinstance(tensors, tuple):
         return tuple(weak_ref_tensors(tensor) for tensor in tensors)
     if isinstance(tensors, dict):
-        return {key: weak_ref_tensors(tensor) for key, tensor in tensors.items()}
+        return {key: (weak_ref_tensors(tensor) if key != "context_lens" else tensor) for key, tensor in tensors.items()}
     if isinstance(tensors, IntermediateTensors):
         return IntermediateTensors(weak_ref_tensors(tensors.tensors))
     return tensors
@@ -1655,11 +1655,5 @@ def use_updatable_graph(
     vllm_config,
 ) -> bool:
     from vllm_ascend.attention.attention_v1 import AscendAttentionBackend
-    from vllm_ascend.attention.utils import using_paged_attention
 
-    head_size = vllm_config.model_config.get_head_size()
-    return (
-        attn_backend is not None
-        and issubclass(attn_backend, AscendAttentionBackend)
-        and not using_paged_attention(num_tokens, vllm_config, head_size)
-    )
+    return attn_backend is not None and issubclass(attn_backend, AscendAttentionBackend)

--- a/vllm_ascend/worker/model_runner_v1.py
+++ b/vllm_ascend/worker/model_runner_v1.py
@@ -4145,7 +4145,11 @@ class NPUModelRunner(GPUModelRunner):
             self.update_stream = torch.npu.Stream()
 
             if self.drafter is not None:
-                self.drafter.set_update_stream(self.update_stream)
+                update_stream_setter = getattr(self.drafter, "set_update_stream", None)
+                if callable(update_stream_setter):
+                    update_stream_setter(self.update_stream)
+                else:
+                    self.drafter.update_stream = self.update_stream
 
         with _torch_cuda_wrapper():
             if (

--- a/vllm_ascend/worker/model_runner_v1.py
+++ b/vllm_ascend/worker/model_runner_v1.py
@@ -3034,6 +3034,8 @@ class NPUModelRunner(GPUModelRunner):
         assert self.model is not None
         forward_context = get_forward_context()
         assert forward_context is not None
+        if forward_context.cudagraph_runtime_mode == CUDAGraphMode.FULL:
+            self.model.set_attn_backend(self.attn_backend)
 
         model_inputs: dict[str, Any] = {
             "input_ids": input_ids,
@@ -4143,7 +4145,7 @@ class NPUModelRunner(GPUModelRunner):
             self.update_stream = torch.npu.Stream()
 
             if self.drafter is not None:
-                self.drafter.update_stream = self.update_stream
+                self.drafter.set_update_stream(self.update_stream)
 
         with _torch_cuda_wrapper():
             if (
@@ -4171,6 +4173,7 @@ class NPUModelRunner(GPUModelRunner):
                     runtime_mode=CUDAGraphMode.FULL,
                     use_eagle=self.use_eagle,
                     enable_enpu=self.enable_enpu,
+                    update_stream=self.update_stream,
                 )
 
         if self.compilation_config.cudagraph_mode != CUDAGraphMode.NONE:

--- a/vllm_ascend/worker/model_runner_v1.py
+++ b/vllm_ascend/worker/model_runner_v1.py
@@ -4143,11 +4143,10 @@ class NPUModelRunner(GPUModelRunner):
 
         if cudagraph_mode.has_full_cudagraphs():
             self.update_stream = torch.npu.Stream()
-
+            
             if self.drafter is not None:
-                update_stream_setter = getattr(self.drafter, "set_update_stream", None)
-                if callable(update_stream_setter):
-                    update_stream_setter(self.update_stream)
+                if hasattr(self.drafter, "set_update_stream"):
+                    self.drafter.set_update_stream(self.update_stream)
                 else:
                     self.drafter.update_stream = self.update_stream
 

--- a/vllm_ascend/worker/v2/aclgraph_utils.py
+++ b/vllm_ascend/worker/v2/aclgraph_utils.py
@@ -159,11 +159,15 @@ class ModelAclGraphManager(ModelCudaGraphManager):
             attn_backend = _get_graph_update_backend(self.model_runner.attn_groups)
         attn_metadata = self.model_runner.model_state.attn_metadata
 
-        if use_updatable_graph(attn_backend, num_tokens, self.vllm_config):
+        if use_updatable_graph(attn_backend):
             return self._updatable_graph_replay(desc, attn_metadata)
         else:
-            self.update_stream.wait_stream(torch.npu.current_stream())
-            ret = super().run_fullgraph(desc)
+            # This will be removed once the refactoring is fully complete.
+            return self._graph_relay(attn_backend, desc, num_tokens, attn_metadata)
+
+    def _graph_relay(self, attn_backend, desc, num_tokens, attn_metadata):
+        self.update_stream.wait_stream(torch.npu.current_stream())
+        ret = super().run_fullgraph(desc)
 
         # refer to vllm.v1.worker.gpu.dp_utils.sync_cudagraph_and_dp_padding to
         # calculate num_tokens_across_dp.

--- a/vllm_ascend/worker/v2/aclgraph_utils.py
+++ b/vllm_ascend/worker/v2/aclgraph_utils.py
@@ -38,9 +38,16 @@ from vllm.v1.worker.gpu.model_states.interface import ModelState
 from vllm.v1.worker.utils import AttentionGroup
 
 from vllm_ascend.ascend_forward_context import _EXTRA_CTX
-from vllm_ascend.compilation.acl_graph import set_graph_params, update_full_graph_params
+from vllm_ascend.compilation.acl_graph import (
+    set_graph_params,
+    update_full_graph_params,
+)
 from vllm_ascend.compilation.breakable_aclgraph import BreakableACLGraphWrapper
-from vllm_ascend.utils import vllm_version_is
+from vllm_ascend.compilation.updatable_graph import (
+    ContextSource,
+    UpdatableGraph,
+)
+from vllm_ascend.utils import use_updatable_graph, vllm_version_is
 from vllm_ascend.worker.v2.input_batch import AscendInputBatch
 from vllm_ascend.worker.v2.utils import communicator_switch
 
@@ -148,8 +155,14 @@ class ModelAclGraphManager(ModelCudaGraphManager):
         num_tokens = desc.num_tokens
         logger.info_once("run_fullgraph with num_tokens=%s", num_tokens)
         assert self.update_stream is not None
-        self.update_stream.wait_stream(torch.npu.current_stream())
-        ret = super().run_fullgraph(desc)
+        attn_backend = _get_graph_update_backend(self.model_runner.attn_groups)
+        attn_metadata = self.model_runner.model_state.attn_metadata
+
+        if use_updatable_graph(attn_backend, num_tokens, self.vllm_config):
+            return self._updatable_graph_replay(desc, attn_metadata)
+        else:
+            self.update_stream.wait_stream(torch.npu.current_stream())
+            ret = super().run_fullgraph(desc)
 
         # refer to vllm.v1.worker.gpu.dp_utils.sync_cudagraph_and_dp_padding to
         # calculate num_tokens_across_dp.
@@ -163,7 +176,7 @@ class ModelAclGraphManager(ModelCudaGraphManager):
         with (
             set_current_vllm_config(self.vllm_config),
             set_forward_context(
-                self.model_runner.model_state.attn_metadata,
+                attn_metadata,
                 self.vllm_config,
                 num_tokens=num_tokens,
                 cudagraph_runtime_mode=desc.cg_mode,
@@ -173,7 +186,6 @@ class ModelAclGraphManager(ModelCudaGraphManager):
             ),
         ):
             forward_context = get_forward_context()
-            attn_backend = _get_graph_update_backend(self.model_runner.attn_groups)
             update_full_graph_params(
                 # FIXME(Ronald1995): support hybrid attn backend
                 attn_backend,
@@ -183,6 +195,15 @@ class ModelAclGraphManager(ModelCudaGraphManager):
                 self.vllm_config,
                 self.model_runner.speculative_config,
             )
+        return ret
+
+    def _updatable_graph_replay(self, desc, attn_metadata):
+        graph = self.graphs[desc]
+        assert isinstance(graph, UpdatableGraph)
+        resolved_tasks = graph.resolve_tasks(ContextSource(attn_metadata))
+        self.update_stream.wait_stream(torch.npu.current_stream())
+        ret = super().run_fullgraph(desc)
+        graph.update(self.update_stream, resolved_tasks)
         return ret
 
     def capture(

--- a/vllm_ascend/worker/v2/aclgraph_utils.py
+++ b/vllm_ascend/worker/v2/aclgraph_utils.py
@@ -155,7 +155,8 @@ class ModelAclGraphManager(ModelCudaGraphManager):
         num_tokens = desc.num_tokens
         logger.info_once("run_fullgraph with num_tokens=%s", num_tokens)
         assert self.update_stream is not None
-        attn_backend = _get_graph_update_backend(self.model_runner.attn_groups)
+        with set_current_vllm_config(self.vllm_config):
+            attn_backend = _get_graph_update_backend(self.model_runner.attn_groups)
         attn_metadata = self.model_runner.model_state.attn_metadata
 
         if use_updatable_graph(attn_backend, num_tokens, self.vllm_config):

--- a/vllm_ascend/worker/v2/spec_decode/autoregressive/aclgraph.py
+++ b/vllm_ascend/worker/v2/spec_decode/autoregressive/aclgraph.py
@@ -141,22 +141,25 @@ class AutoRegressiveAclGraphManager(SpeculatorCudaGraphManager):
         assert self.update_stream is not None
 
         attn_backend = self.speculator.attn_backend
-        attn_metadata = self.speculator.model_state.attn_metadata
         draft_vllm_config = self.speculator.draft_vllm_config
+
+        if use_updatable_graph(attn_backend):
+            return self._updatable_graph_replay(desc)
+        else:
+            # This will be removed once the refactoring is fully complete.
+            return self._graph_replay(desc, attn_backend, num_tokens, draft_vllm_config)
+
+    def _graph_replay(self, desc, attn_backend, num_tokens, draft_vllm_config):
+        self.update_stream.wait_stream(torch.npu.current_stream())
+        ret = super().run_fullgraph(desc)
+        # Mirror vLLM's DP graph-replay token-count metadata.
+        num_tokens_across_dp = torch.full([self.speculator.dp_size], num_tokens)
+        attn_metadata = self.speculator.model_state.attn_metadata
         draft_attn_metadatas = self.speculator.build_draft_attn_metadatas(
             desc.num_reqs,
             desc.num_tokens,
             self.is_draft_model_prefill,
         )
-
-        if use_updatable_graph(attn_backend, num_tokens, draft_vllm_config):
-            return self._updatable_graph_replay(desc)
-        else:
-            self.update_stream.wait_stream(torch.npu.current_stream())
-            ret = super().run_fullgraph(desc)
-
-        # Mirror vLLM's DP graph-replay token-count metadata.
-        num_tokens_across_dp = torch.full([self.speculator.dp_size], num_tokens)
         # sfa_v1.py:AscendSFABackend.get_impl_cls reaches
         # sfa_cp.py:resolve_sfa_impl, whose SFA CP selector reads the current
         # ModelConfig. Publish the draft config because set_forward_context()
@@ -202,6 +205,6 @@ class AutoRegressiveAclGraphManager(SpeculatorCudaGraphManager):
         )
         resolved_tasks = graph.resolve_tasks(SharedSource(fia_params))
         self.update_stream.wait_stream(torch.npu.current_stream())
-        output = super().run_fullgraph(desc)
+        ret = super().run_fullgraph(desc)
         graph.update(self.update_stream, resolved_tasks)
-        return output
+        return ret

--- a/vllm_ascend/worker/v2/spec_decode/autoregressive/aclgraph.py
+++ b/vllm_ascend/worker/v2/spec_decode/autoregressive/aclgraph.py
@@ -26,6 +26,11 @@ from vllm_ascend.compilation.acl_graph import (
     set_draft_graph_prefill_params,
     update_full_graph_params,
 )
+from vllm_ascend.compilation.updatable_graph import (
+    SharedSource,
+    UpdatableGraph,
+)
+from vllm_ascend.utils import use_updatable_graph
 from vllm_ascend.worker.v2.aclgraph_utils import (
     collect_sorted_captured_token_sizes,
     model_capture_wrapper,
@@ -133,14 +138,22 @@ class AutoRegressiveAclGraphManager(SpeculatorCudaGraphManager):
             )
         else:
             logger.info_once("AutoRegressiveAclGraphManager: draft run_fullgraph with num_tokens=%s", num_tokens)
+        assert self.update_stream is not None
 
+        attn_backend = self.speculator.attn_backend
+        attn_metadata = self.speculator.model_state.attn_metadata
+        draft_vllm_config = self.speculator.draft_vllm_config
         draft_attn_metadatas = self.speculator.build_draft_attn_metadatas(
             desc.num_reqs,
             desc.num_tokens,
             self.is_draft_model_prefill,
         )
-        self.update_stream.wait_stream(torch.npu.current_stream())
-        ret = super().run_fullgraph(desc)
+
+        if use_updatable_graph(attn_backend, num_tokens, draft_vllm_config):
+            return self._updatable_graph_replay(desc)
+        else:
+            self.update_stream.wait_stream(torch.npu.current_stream())
+            ret = super().run_fullgraph(desc)
 
         # Mirror vLLM's DP graph-replay token-count metadata.
         num_tokens_across_dp = torch.full([self.speculator.dp_size], num_tokens)
@@ -150,11 +163,10 @@ class AutoRegressiveAclGraphManager(SpeculatorCudaGraphManager):
         # does not update it.
         # TODO: Remove this explicit current-config scope once ACL graph replay
         # passes VllmConfig directly through the graph-update interfaces.
-        draft_vllm_config = self.speculator.draft_vllm_config
         with (
             set_current_vllm_config(draft_vllm_config),
             set_forward_context(
-                self.speculator.model_state.attn_metadata,
+                attn_metadata,
                 draft_vllm_config,
                 num_tokens=num_tokens,
                 cudagraph_runtime_mode=desc.cg_mode,
@@ -168,7 +180,6 @@ class AutoRegressiveAclGraphManager(SpeculatorCudaGraphManager):
             _EXTRA_CTX.is_draft_model_prefill = self.is_draft_model_prefill
 
             forward_context = get_forward_context()
-            attn_backend = self.speculator.attn_backend
             assert attn_backend is not None, "Speculator attention backend is not initialized"
             update_full_graph_params(
                 # FIXME(Ronald1995): support hybrid attn backend
@@ -181,3 +192,16 @@ class AutoRegressiveAclGraphManager(SpeculatorCudaGraphManager):
                 draft_attn_metadatas=draft_attn_metadatas,
             )
         return ret
+
+    def _updatable_graph_replay(self, desc):
+        graph = self.graphs[desc]
+        assert isinstance(graph, UpdatableGraph)
+        fia_params = self.speculator.build_fia_params(
+            desc.num_reqs,
+            self.is_draft_model_prefill,
+        )
+        resolved_tasks = graph.resolve_tasks(SharedSource(fia_params))
+        self.update_stream.wait_stream(torch.npu.current_stream())
+        output = super().run_fullgraph(desc)
+        graph.update(self.update_stream, resolved_tasks)
+        return output

--- a/vllm_ascend/worker/v2/spec_decode/autoregressive/speculator.py
+++ b/vllm_ascend/worker/v2/spec_decode/autoregressive/speculator.py
@@ -198,6 +198,8 @@ class AscendAutoRegressiveSpeculator(AutoRegressiveSpeculator):
         if self.speculative_config.enforce_eager:
             cudagraph_mode = CUDAGraphMode.NONE
         super().init_cudagraph_manager(cudagraph_mode)
+        assert self.prefill_cudagraph_manager is not None
+        assert self.decode_cudagraph_manager is not None
         # The Ascend graph managers are patched onto the upstream module and
         # created by super().init_cudagraph_manager without a speculator ref.
         # They need this speculator to update full-graph params, so set it here.
@@ -590,6 +592,42 @@ class AscendAutoRegressiveSpeculator(AutoRegressiveSpeculator):
             decode_metadata.seq_lens_list = seq_lens_list
             decode_metadata.actual_seq_lengths_q = query_lens_list
             metadata.seq_lens_cpu.copy_(next_seq_lens_cpu)
+
+    def build_fia_params(
+        self,
+        num_reqs_padded: int,
+        is_draft_model_prefill: bool,
+    ) -> list[dict[str, Any]]:
+        metadata = next(
+            metadata
+            for layer_name, metadata in self.model_state.attn_metadata.items()
+            if layer_name in self.draft_attn_layer_names
+        )
+        if is_draft_model_prefill:
+            return [
+                {
+                    "actual_seq_lengths": metadata.actual_seq_lengths_q,
+                    "actual_seq_lengths_kv": metadata.seq_lens_list,
+                    "block_table": metadata.block_tables,
+                }
+            ]
+        assert self.input_batch is not None
+        num_reqs = self.input_batch.num_reqs
+        query_start_loc = list(range(1, num_reqs_padded + 1))
+        fia_params: list[dict[str, Any]] = []
+        for step in range(1, self.num_speculative_steps):
+            seq_lens = [
+                min(int(seq_len) + step, self.max_model_len) for seq_len in self.input_batch.seq_lens_np[:num_reqs]
+            ]
+            seq_lens.extend([0] * (num_reqs_padded - num_reqs))
+            fia_params.append(
+                {
+                    "actual_seq_lengths": query_start_loc,
+                    "actual_seq_lengths_kv": seq_lens,
+                    "block_table": metadata.block_tables,
+                }
+            )
+        return fia_params
 
     def _calc_next_seq_lens_cpu(self, seq_lens_cpu, num_reqs, num_reqs_padded, step):
         # NOTE(drslark) to achieve fully alignment with vllm, `num_rejected` should be subtracted from `seq_lens`

--- a/vllm_ascend/worker/v2/spec_decode/dflash/aclgraph.py
+++ b/vllm_ascend/worker/v2/spec_decode/dflash/aclgraph.py
@@ -19,6 +19,11 @@ from vllm_ascend.compilation.acl_graph import (
     set_draft_graph_params,
     update_full_graph_params,
 )
+from vllm_ascend.compilation.updatable_graph import (
+    ContextSource,
+    UpdatableGraph,
+)
+from vllm_ascend.utils import use_updatable_graph
 from vllm_ascend.worker.v2.aclgraph_utils import collect_sorted_captured_token_sizes, model_capture_wrapper
 from vllm_ascend.worker.v2.utils import communicator_switch
 
@@ -81,14 +86,20 @@ class DFlashAclGraphManager(DFlashCudaGraphManager):
     def run_fullgraph(self, desc: BatchExecutionDescriptor) -> torch.Tensor | tuple[torch.Tensor, list[torch.Tensor]]:
         """Override run_fullgraph to update full graph params in run_fullgraph."""
         num_tokens = desc.num_tokens
-
+        attn_backend = list(self.speculator.attn_backends.values())[0]
         draft_attn_metadatas = self.speculator.build_draft_attn_metadatas(
             desc.num_reqs,
             self.speculator.input_batch.seq_lens_cpu_upper_bound,
         )
+        if use_updatable_graph(attn_backend):
+            return self._updatable_graph_replay(desc, draft_attn_metadatas)
+        else:
+            # This will be removed once the refactoring is fully complete.
+            return self._graph_replay(desc, attn_backend, num_tokens, draft_attn_metadatas)
+
+    def _graph_replay(self, desc, attn_backend, num_tokens, draft_attn_metadatas):
         self.update_stream.wait_stream(torch.npu.current_stream())
         ret = super().run_fullgraph(desc)
-
         # refer to vllm.v1.worker.gpu.dp_utils.sync_cudagraph_and_dp_padding to
         # calculate num_tokens_across_dp.
         # DPMetadata validates these counts on the host. An NPU tensor would
@@ -113,7 +124,7 @@ class DFlashAclGraphManager(DFlashCudaGraphManager):
 
             update_full_graph_params(
                 # FIXME(Ronald1995): support hybrid attn backend
-                list(self.speculator.attn_backends.values())[0],
+                attn_backend,
                 self.update_stream,
                 forward_context,
                 num_tokens,
@@ -121,4 +132,13 @@ class DFlashAclGraphManager(DFlashCudaGraphManager):
                 self.speculator.speculative_config,
                 draft_attn_metadatas=draft_attn_metadatas,
             )
+        return ret
+
+    def _updatable_graph_replay(self, desc, draft_attn_metadatas):
+        graph = self.graphs[desc]
+        assert isinstance(graph, UpdatableGraph)
+        resolved_tasks = graph.resolve_tasks(ContextSource(draft_attn_metadatas[0]))
+        self.update_stream.wait_stream(torch.npu.current_stream())
+        ret = super().run_fullgraph(desc)
+        graph.update(self.update_stream, resolved_tasks)
         return ret

--- a/vllm_ascend/worker/v2/spec_decode/dflash/speculator.py
+++ b/vllm_ascend/worker/v2/spec_decode/dflash/speculator.py
@@ -155,6 +155,42 @@ class AscendDFlashSpeculator(DFlashSpeculator):
                 is_profile=is_profile,
             )
 
+    def build_fia_params(
+        self,
+        num_reqs_padded: int,
+        is_draft_model_prefill: bool,
+    ) -> list[dict[str, Any]]:
+        metadata = next(
+            metadata
+            for layer_name, metadata in self.model_state.attn_metadata.items()
+            if layer_name in self.draft_attn_layer_names
+        )
+        if is_draft_model_prefill:
+            return [
+                {
+                    "actual_seq_lengths": metadata.actual_seq_lengths_q,
+                    "actual_seq_lengths_kv": metadata.seq_lens_list,
+                    "block_table": metadata.block_tables,
+                }
+            ]
+        assert self.input_batch is not None
+        num_reqs = self.input_batch.num_reqs
+        query_start_loc = list(range(1, num_reqs_padded + 1))
+        fia_params: list[dict[str, Any]] = []
+        for step in range(1, self.num_speculative_steps):
+            seq_lens = [
+                min(int(seq_len) + step, self.max_model_len) for seq_len in self.input_batch.seq_lens_np[:num_reqs]
+            ]
+            seq_lens.extend([0] * (num_reqs_padded - num_reqs))
+            fia_params.append(
+                {
+                    "actual_seq_lengths": query_start_loc,
+                    "actual_seq_lengths_kv": seq_lens,
+                    "block_table": metadata.block_tables,
+                }
+            )
+        return fia_params
+
 
 # main2main compat: upstream ``_prepare_dflash_inputs_kernel`` added four
 # ``temperature``/``seeds`` parameters and corresponding stores (see

--- a/vllm_ascend/worker/v2/utils.py
+++ b/vllm_ascend/worker/v2/utils.py
@@ -5,6 +5,7 @@ from vllm.compilation import breakable_cudagraph
 from vllm.logger import logger
 
 from vllm_ascend.compilation.acl_graph import get_draft_graph_params, get_graph_params, weak_ref_workspaces
+from vllm_ascend.compilation.updatable_graph import UpdatableGraph
 from vllm_ascend.utils import weak_ref_tensor, weak_ref_tensors
 
 
@@ -17,7 +18,7 @@ def torch_cuda_wrapper():
         torch.cuda.default_stream = torch.npu.default_stream
         torch.cuda.current_stream = torch.npu.current_stream
         torch.cuda.graph_pool_handle = torch.npu.graph_pool_handle
-        torch.cuda.CUDAGraph = torch.npu.NPUGraph
+        torch.cuda.CUDAGraph = UpdatableGraph
         torch.cuda.graph = torch_npu_graph_wrapper
         torch.cuda.synchronize = torch.npu.synchronize
         torch.cuda.set_stream = torch.npu.set_stream


### PR DESCRIPTION
**What this PR does / why we need it?**
Implements the `UpdatableGraph` design discussed in https://github.com/vllm-project/vllm-ascend/issues/13058.
Refactors the `FIA` and `Speculative Decoding` to work with the new `UpdatableGraph` design.

Manually validated on A3 with the following scenarios:
- FIA: Qwen3-0.6B with MRV1 and MRV2
- MTP: Qwen3.5-27B with MRV1 and MRV2

Manually validated on A5 with the following scenarios:
- FIA: Qwen3-0.6B with MRV1 and MRV2
- MTP: Qwen3.5-9B with MRV1 and MRV2
- PA: gemma4 with MRV1 and MRV2
 
**Does this PR introduce any user-facing change?**
No.

**How was this patch tested?**
Temporarily validated on some model.


- vLLM main: https://github.com/vllm-project/vllm/commit/b2f685834a6456197e7033966fdef52a23f1abcd
