### PR TITLE
[Kernel] Skip padding rows in BF16 dequant_situ_quant via optional group_index and round-robin expert assignment

### DIFF
--- a/csrc/moe/dequant_situ_quant/op_host/dequant_situ_quant_tiling.cpp
+++ b/csrc/moe/dequant_situ_quant/op_host/dequant_situ_quant_tiling.cpp
@@ -375,9 +375,18 @@ ge::graphStatus DequantSituQuantTiling::CheckInputShapesBF16()
     OP_CHECK_IF(context_->GetOptionalInputShape(INDEX_IN_QUANT_OFFSET) != nullptr,
                 OP_LOGE(context_->GetNodeName(), "quant_offset must be absent for bfloat16 x"),
                 return ge::GRAPH_FAILED);
-    OP_CHECK_IF(context_->GetOptionalInputShape(INDEX_IN_GROUP_INDEX) != nullptr,
-                OP_LOGE(context_->GetNodeName(), "group_index must be absent for bfloat16 x"),
-                return ge::GRAPH_FAILED);
+
+    // group_index: optional for bfloat16 — enables per-expert row skipping
+    auto groupIndexShapePtr = context_->GetOptionalInputShape(INDEX_IN_GROUP_INDEX);
+    hasGroupIndex_ = (groupIndexShapePtr != nullptr);
+    expertNum_ = 1;
+    if (hasGroupIndex_) {
+        const gert::Shape groupIndexShape = groupIndexShapePtr->GetStorageShape();
+        OP_CHECK_IF(groupIndexShape.GetDimNum() != 1 || groupIndexShape.GetDim(0) <= 0,
+                    OP_LOGE(context_->GetNodeName(), "group_index must be a non-empty 1-D tensor"),
+                    return ge::GRAPH_FAILED);
+        expertNum_ = static_cast<uint32_t>(groupIndexShape.GetDim(0));
+    }
 
     // check output shapes
     auto yShapePtr = context_->GetOutputShape(0);
@@ -410,8 +419,8 @@ ge::graphStatus DequantSituQuantTiling::CheckInputShapesBF16()
     tilingData.set_quantScaleIsEmpty(1);
     tilingData.set_quantOffsetIsEmpty(1);
     tilingData.set_quantIsOne(0);
-    tilingData.set_expertNum(1);
-    tilingData.set_hasGroupIndex(0);
+    tilingData.set_expertNum(expertNum_);
+    tilingData.set_hasGroupIndex(hasGroupIndex_ ? 1 : 0);
     tilingData.set_hasActivationScale(0);
     tilingData.set_isPreDequantized(1);
     tilingData.set_inputWidth(static_cast<uint32_t>(inDimy));

--- a/csrc/moe/dequant_situ_quant/op_kernel/dequant_situ_quant.h
+++ b/csrc/moe/dequant_situ_quant/op_kernel/dequant_situ_quant.h
@@ -755,9 +755,12 @@ public:
             if (hasBias_) {
                 biasGm_.SetGlobalBuffer((__gm__ float*)bias, expertNum_ * inputWidth_);
             }
-            if (hasGroupIndex_) {
-                groupIndexGm_.SetGlobalBuffer((__gm__ int64_t*)groupIndex, expertNum_);
-            }
+        }
+        if (hasGroupIndex_) {
+            groupIndexGm_.SetGlobalBuffer((__gm__ int64_t*)groupIndex, expertNum_);
+            groupIndexGm32_.SetGlobalBuffer((__gm__ int32_t*)groupIndex, expertNum_ * 2);
+            pipe_->InitBuffer(groupIndexQue_, 1,
+                static_cast<uint32_t>(expertNum_ * sizeof(int64_t)));
         }
         yGm_.SetGlobalBuffer((__gm__ int8_t*)y, rowLen_ * outputWidth_);
         scaleGm_.SetGlobalBuffer((__gm__ float*)scale, rowLen_);
@@ -785,7 +788,42 @@ public:
         }
 
         if constexpr (!std::is_same_v<XType, int32_t>) {
-            ProcessGroup(0, rowLen_, 0);
+            if (hasGroupIndex_) {
+                // Bulk read group_index into local memory (1 DataCopy vs N GM reads)
+                LocalTensor<int32_t> groupIndexRaw = groupIndexQue_.AllocTensor<int32_t>();
+                DataCopyExtParams giParams{1,
+                    static_cast<uint32_t>(expertNum_ * sizeof(int64_t)), 0, 0, 0};
+                DataCopyPadExtParams<int32_t> giPadParams{false, 0, 0, 0};
+                DataCopyPad(groupIndexRaw, groupIndexGm32_, giParams, giPadParams);
+                groupIndexQue_.EnQue(groupIndexRaw);
+                groupIndexRaw = groupIndexQue_.DeQue<int32_t>();
+                LocalTensor<int64_t> groupIndexLocal =
+                    groupIndexRaw.ReinterpretCast<int64_t>();
+
+                // Round-robin expert assignment (cut_group pattern):
+                // Block b owns experts {b, b+usedCoreNum_, b+2*usedCoreNum_, ...}.
+                // Each block processes ALL rows of its owned experts (no ceil-division),
+                // spreading N active experts across N distinct blocks instead of
+                // concentrating all work on block 0.
+                int64_t groupOffset = 0;
+                int64_t cuGroupIdx = blockIdx_;
+                for (int64_t expertIdx = 0; expertIdx < expertNum_; ++expertIdx) {
+                    const int64_t requestedRows = groupIndexLocal.GetValue(expertIdx);
+                    if (expertIdx == cuGroupIdx && requestedRows > 0) {
+                        for (int64_t localRow = 0; localRow < requestedRows; ++localRow) {
+                            const int64_t rowIdx = groupOffset + localRow;
+                            CopyInRow(rowIdx);
+                            ComputeRow(rowIdx);
+                            CopyOutRow(rowIdx);
+                        }
+                        cuGroupIdx += usedCoreNum_;
+                    }
+                    groupOffset += requestedRows;
+                }
+                groupIndexQue_.FreeTensor(groupIndexRaw);
+            } else {
+                ProcessGroup(0, rowLen_, 0);
+            }
             return;
         }
 
@@ -1050,10 +1088,12 @@ private:
     TQue<QuePosition::VECIN, 1> weightScaleQueue_;
     TQue<QuePosition::VECIN, 1> biasQueue_;
     TQue<QuePosition::VECOUT, 1> outQueue_;
+    TQue<QuePosition::VECIN, 1> groupIndexQue_;
     TBuf<TPosition::VECCALC> tmpBuf_;
     TBuf<TPosition::VECCALC> dequantBuf_;
     LocalTensor<float> weightScaleLocal_;
     LocalTensor<float> biasLocal_;
+    GlobalTensor<int32_t> groupIndexGm32_;
 };
 
 } // namespace DequantSituQuantOps

--- a/vllm_ascend/ops/fused_moe/moe_mlp.py
+++ b/vllm_ascend/ops/fused_moe/moe_mlp.py
@@ -234,6 +234,7 @@ def _w4a8_situ_apply_mlp(
             dst_type=SITU_MX_DST_TYPE_E4M3FN,
         )
     else:
+        # group_index with round-robin block assignment skips padding rows
         hidden_states, situ_out_scale = torch.ops._C_ascend.dequant_situ_quant(
             x=gate_up_out,
             weight_scale=None,
@@ -241,7 +242,7 @@ def _w4a8_situ_apply_mlp(
             bias=None,
             quant_scale=None,
             quant_offset=None,
-            group_index=None,
+            group_index=cumsum_group_list(group_list, group_list_type, 1),
             beta=activation.beta,
             linear_beta=activation.linear_beta,
             activate_left=True,


### PR DESCRIPTION
### What this PR does / why we need it?

The BF16 path of `dequant_situ_quant` (W4A8 SiTU activation in fused MoE) always
processes the full padded row buffer, while the INT32 path already accepts an
optional `group_index` to skip padding rows. In a Kimi K3 W4A8 decode profile
(TP8/DP2, 56 local experts per rank) the BF16 call receives a 256-row buffer
holding only 8 real tokens and spends 23.9 us per call, of which 10.0 us is
vector compute on padding rows.

This PR makes `group_index` optional for bfloat16 `x`:

- **Tiling**: accept an optional 1-D `group_index` for BF16 (previously rejected
  with "group_index must be absent for bfloat16 x") and propagate
  `expertNum` / `hasGroupIndex` in the tiling data.
- **Kernel**: bulk-read `group_index` once via `DataCopyPad` into local memory,
  then assign whole experts round-robin to AI Vector cores (block b owns experts
  {b, b+usedCoreNum, b+2*usedCoreNum, ...} and processes all rows of its
  experts). This spreads active experts across distinct blocks; a naive
  per-expert ceil-division instead piles every expert's rows onto the
  low-numbered blocks and exposes a 15.8 us dispatch/sync tail behind the
  end-of-kernel barrier.
- **Python**: pass `cumsum_group_list(group_list, group_list_type, 1)` on the
  W4A8 SiTU path, mirroring the INT32 path.

Measured on the same decode profile (median of 5088 calls): Duration
23.9 us -> 19.84 us (-17%), aiv_vec 10.0 us -> 0.65 us, aiv_scalar
2.54 us -> 1.83 us, dispatch/sync gap 5.1 us -> 7.47 us. Rows processed drop
from 256 to 8. End-to-end throughput is unchanged, as the operator accounts
for ~5% of decode step time.

Unprocessed padding rows are left untouched; they are never read downstream
(the grouped GEMM boundaries derived from `group_list` cover only real
tokens), which is the same semantics the INT32 path has always had.

### Does this PR introduce _any_ user-facing change?

No. The op signature is unchanged (`group_index` was already an optional
input; it is now accepted for bfloat16 `x` where it previously failed the
tiling check).
### How was this patch tested?

- vLLM main: https://github.com/vllm-project/vllm/commit/d02df748bf9efd99022f1a062597dc3cb3808485
