### PR TITLE
[Feature][Model] Add GLM-Next KV cache management

### DIFF
--- a/tests/e2e/pull_request/one_card/test_model_runner_v1_with_device.py
+++ b/tests/e2e/pull_request/one_card/test_model_runner_v1_with_device.py
@@ -451,6 +451,10 @@ def test_stateful_handoff_preserves_decode_graph(
         max_cudagraph_capture_size=32,
         compile_sizes=[],
     )
+    runner.model_config = SimpleNamespace(
+        is_encoder_decoder=False,
+        hf_text_config=SimpleNamespace(to_dict=lambda: {}),
+    )
     runner.vllm_config = SimpleNamespace(
         parallel_config=runner.parallel_config,
         compilation_config=runner.compilation_config,
@@ -458,8 +462,8 @@ def test_stateful_handoff_preserves_decode_graph(
         observability_config=SimpleNamespace(cudagraph_metrics=False),
         num_speculative_tokens=num_spec_tokens,
         lora_config=None,
+        model_config=runner.model_config,
     )
-    runner.model_config = SimpleNamespace(is_encoder_decoder=False)
     runner.uniform_decode_query_len = 1 + num_spec_tokens
     runner.input_batch = SimpleNamespace(
         num_computed_tokens_cpu=np.array(computed),

--- a/tests/ut/models/test_glm5next_cache_config.py
+++ b/tests/ut/models/test_glm5next_cache_config.py
@@ -1,0 +1,202 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Tests for GLM-Next cache grouping, physical layout, and capacity accounting."""
+
+from types import SimpleNamespace
+
+import pytest
+import torch
+from vllm.v1.core.single_type_kv_cache_manager import (
+    register_all_kvcache_specs,
+)
+from vllm.v1.kv_cache_interface import (
+    KVCacheGroupSpec,
+    KVCacheTensor,
+    MambaSpec,
+    MLAAttentionSpec,
+)
+
+from vllm_ascend.core.kv_cache_interface import AscendIndexerKPoolStateSpec
+from vllm_ascend.models.glm5next.cache_config import (
+    _get_glm5_next_cache_layout,
+    get_glm5_next_kv_cache_config,
+    get_glm5_next_kv_cache_groups,
+    get_glm5_next_max_memory_usage,
+    get_glm5_next_pool_bytes_per_block,
+)
+from vllm_ascend.utils import get_kv_cache_tensor_layers, vllm_version_is
+
+
+def _ratio_kwargs(ratio: int) -> dict[str, int]:
+    return {"compress_ratio": ratio} if vllm_version_is("0.28.0") else {"tokens_per_state": ratio}
+
+
+def make_config():
+    return SimpleNamespace(
+        model_config=SimpleNamespace(max_model_len=2048),
+        parallel_config=SimpleNamespace(
+            decode_context_parallel_size=1,
+            prefill_context_parallel_size=1,
+        ),
+        scheduler_config=SimpleNamespace(disable_hybrid_kv_cache_manager=False),
+        max_in_flight_tokens=32,
+        cache_config=SimpleNamespace(
+            num_gpu_blocks_override=None,
+            mamba_cache_mode="none",
+            enable_prefix_caching=False,
+        ),
+    )
+
+
+def make_specs(pool: int = 16):
+    specs = {
+        "model.layers.3.attn": MLAAttentionSpec(
+            block_size=512,
+            num_kv_heads=1,
+            head_size=512,
+            dtype=torch.bfloat16,
+            model_version="glm5_next",
+        ),
+        "model.layers.3.indexer.k_cache": MLAAttentionSpec(
+            block_size=512,
+            num_kv_heads=1,
+            head_size=128,
+            dtype=torch.bfloat16,
+            model_version="glm5_next",
+            **_ratio_kwargs(pool),
+        ),
+        "model.layers.3.indexer.state_cache": AscendIndexerKPoolStateSpec(
+            block_size=pool,
+            sliding_window=pool,
+            num_kv_heads=1,
+            head_size=256,
+            dtype=torch.float32,
+            model_version="glm5_next",
+            indexes_kv_by_block_stride=True,
+        ),
+    }
+    for layer_idx in range(3):
+        specs[f"model.layers.{layer_idx}.linear_attn"] = MambaSpec(
+            block_size=512,
+            shapes=((3, 16), (1, 16, 16)),
+            dtypes=(torch.bfloat16, torch.float32),
+        )
+    return specs
+
+
+@pytest.fixture(autouse=True)
+def register_cache_specs():
+    # Match production: vLLM registers built-in specs before the Ascend hook.
+    register_all_kvcache_specs(None)
+
+
+@pytest.mark.parametrize("pool", [4, 16])
+def test_groups_share_block_ids_and_pack_two_page_classes(pool):
+    config = make_config()
+    specs = make_specs(pool)
+    groups = get_glm5_next_kv_cache_groups(config, dict(reversed(list(specs.items()))))
+    layout = _get_glm5_next_cache_layout(groups)
+    assert layout is not None
+    assert groups[0].layer_names == [
+        "model.layers.3.attn",
+        "model.layers.3.indexer.k_cache",
+    ]
+    assert len(groups) == 5  # full, state, and three interleaved KDA groups
+    assert layout.main_slot_count == layout.small_slot_count == 1
+
+    bytes_per_block = layout.main_page_size + layout.small_page_size
+    budget = 20 * bytes_per_block
+    plan = get_glm5_next_kv_cache_config(config, groups, budget)
+    assert plan.num_blocks == 20
+    assert len(plan.kv_cache_tensors) == 2
+    assert all(isinstance(tensor, KVCacheTensor) for tensor in plan.kv_cache_tensors)
+    assert {tensor.size for tensor in plan.kv_cache_tensors} == {
+        20 * layout.main_page_size,
+        20 * layout.small_page_size,
+    }
+    if vllm_version_is("0.28.0"):
+        assert all(tensor.block_stride == 0 for tensor in plan.kv_cache_tensors)
+    else:
+        assert all(
+            tensor.offset == 0 and tensor.layer_stride == 0 and tensor.block_stride == tensor.size // plan.num_blocks
+            for tensor in plan.kv_cache_tensors
+        )
+
+    placements = {
+        layer_name: tensor for tensor in plan.kv_cache_tensors for layer_name in get_kv_cache_tensor_layers(tensor)
+    }
+    main = placements[layout.mla_names[0]]
+    indexer = placements[layout.indexer_names[0]]
+    state = placements[layout.state_names[0]]
+    assert main.offset == 0
+    assert indexer.offset == 0
+    assert state is indexer
+    assert set(get_kv_cache_tensor_layers(main)) == {
+        layout.mla_names[0],
+        *(group.layer_names[0] for group in layout.mamba_groups),
+    }
+    assert set(get_kv_cache_tensor_layers(indexer)) == {
+        layout.indexer_names[0],
+        layout.state_names[0],
+    }
+
+    # Scheduler groups consume disjoint IDs from the shared global BlockPool.
+    required_blocks = sum(
+        (group.kv_cache_spec.max_memory_usage_bytes(config) + group.kv_cache_spec.page_size_bytes - 1)
+        // group.kv_cache_spec.page_size_bytes
+        for group in groups
+    )
+    assert get_glm5_next_pool_bytes_per_block(groups) == bytes_per_block
+    assert get_glm5_next_max_memory_usage(config, groups) == required_blocks * bytes_per_block
+
+
+def test_standalone_mtp_layout_has_no_mamba_groups():
+    specs = {name: spec for name, spec in make_specs().items() if not isinstance(spec, MambaSpec)}
+    groups = get_glm5_next_kv_cache_groups(make_config(), specs)
+    layout = _get_glm5_next_cache_layout(groups)
+    assert len(groups) == 2
+    assert layout is not None
+    assert layout.mamba_groups == ()
+
+
+def test_pipeline_projection_supports_a_mamba_only_worker():
+    config = make_config()
+    groups = get_glm5_next_kv_cache_groups(config, make_specs())
+    local_mamba_name = groups[2].layer_names[0]
+    projected_groups = [
+        KVCacheGroupSpec(
+            [local_mamba_name] if group is groups[2] else [],
+            group.kv_cache_spec,
+        )
+        for group in groups
+    ]
+
+    layout = _get_glm5_next_cache_layout(projected_groups)
+    assert layout is not None
+    assert layout.mla_names == layout.indexer_names == layout.state_names == ()
+    assert layout.main_slot_count == 1
+    assert layout.small_slot_count == 0
+
+    budget = 10 * layout.main_page_size
+    plan = get_glm5_next_kv_cache_config(config, projected_groups, available_memory=budget)
+    assert plan.num_blocks == 10
+    assert len(plan.kv_cache_tensors) == 1
+    assert get_kv_cache_tensor_layers(plan.kv_cache_tensors[0]) == [local_mamba_name]
+
+
+def test_missing_paired_cache_is_rejected():
+    specs = make_specs()
+    del specs["model.layers.3.indexer.state_cache"]
+    with pytest.raises(ValueError, match="requires"):
+        get_glm5_next_kv_cache_groups(make_config(), specs)
+
+
+def test_misaligned_logical_block_is_rejected():
+    specs = make_specs(pool=16)
+    object.__setattr__(
+        specs["model.layers.3.indexer.k_cache"],
+        "compress_ratio" if vllm_version_is("0.28.0") else "tokens_per_state",
+        15,
+    )
+    with pytest.raises(ValueError, match="divisible"):
+        get_glm5_next_kv_cache_groups(make_config(), specs)

--- a/tests/ut/models/test_glm5next_kv_cache.py
+++ b/tests/ut/models/test_glm5next_kv_cache.py
@@ -1,0 +1,195 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""GLM-Next cache specs and compressed-cache addressing."""
+
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+import torch
+from vllm.v1.core.single_type_kv_cache_manager import SlidingWindowManager
+from vllm.v1.kv_cache_interface import MLAAttentionSpec
+from vllm.v1.kv_cache_spec_registry import KVCacheSpecRegistry
+
+from vllm_ascend.attention.indexer_kpool import (
+    AscendIndexerKPoolBackend,
+    AscendIndexerKPoolMetadataBuilder,
+    AscendIndexerKPoolStateBackend,
+    select_indexer_block_size,
+)
+from vllm_ascend.attention.utils import AscendCommonAttentionMetadata
+from vllm_ascend.core.kv_cache_interface import (
+    AscendIndexerKPoolStateSpec,
+    AscendMLAAttentionSpec,
+    get_kv_cache_compression_ratio,
+    register_ascend_kv_cache_specs,
+)
+from vllm_ascend.models.glm5next.kv_cache import (
+    Glm5NextIndexerCache,
+    Glm5NextStateCache,
+    format_indexer_kpool_slot_mapping,
+)
+from vllm_ascend.utils import vllm_version_is
+
+
+def _ratio_kwargs(ratio: int) -> dict[str, int]:
+    return {"compress_ratio": ratio} if vllm_version_is("0.28.0") else {"tokens_per_state": ratio}
+
+
+def test_state_uses_sliding_pages_and_full_precision():
+    register_ascend_kv_cache_specs()
+    spec = AscendIndexerKPoolStateSpec(
+        block_size=4,
+        sliding_window=4,
+        num_kv_heads=1,
+        head_size=256,
+        dtype=torch.float32,
+    )
+    assert spec.page_size_bytes == 4096
+    assert KVCacheSpecRegistry.get_manager_class(spec) is SlidingWindowManager
+    assert spec.max_admission_blocks_per_request(16, 1024) > 1
+    context_parallel_config = SimpleNamespace(
+        model_config=SimpleNamespace(max_model_len=1024),
+        parallel_config=SimpleNamespace(
+            decode_context_parallel_size=2,
+            prefill_context_parallel_size=2,
+        ),
+    )
+    assert spec.max_memory_usage_bytes(context_parallel_config) == spec.page_size_bytes
+
+
+@pytest.mark.parametrize(
+    ("dtype", "block_size", "sliding_window"),
+    [
+        (torch.bfloat16, 4, 4),
+        (torch.float32, 8, 4),
+    ],
+)
+def test_invalid_state_layout_is_rejected(dtype, block_size, sliding_window):
+    with pytest.raises(ValueError):
+        AscendIndexerKPoolStateSpec(
+            block_size=block_size,
+            sliding_window=sliding_window,
+            num_kv_heads=1,
+            head_size=256,
+            dtype=dtype,
+        )
+
+
+def test_completed_pool_slots_preserve_logical_block_padding():
+    slots = torch.tensor([0, 14, 15, 16, 127, 128, 143, -1])
+    positions = torch.tensor([0, 14, 15, 16, 127, 128, 143, 15])
+    actual = format_indexer_kpool_slot_mapping(slots, positions, 128, 16)
+    assert actual.tolist() == [-1, -1, 0, -1, 7, -1, 8, -1]
+
+
+@pytest.mark.parametrize("ratio", [0, 1, 3])
+def test_invalid_pool_geometry_is_rejected(ratio):
+    with pytest.raises(ValueError):
+        format_indexer_kpool_slot_mapping(torch.tensor([0]), torch.tensor([0]), 128, ratio)
+
+
+@pytest.mark.parametrize(
+    ("storage_block_size", "expected"),
+    [(16, (16, 1)), (1024, (1024, 1)), (2048, (1024, 2)), (1536, (768, 2))],
+)
+def test_indexer_block_size_selection(storage_block_size, expected):
+    assert select_indexer_block_size(storage_block_size) == expected
+
+
+@pytest.mark.parametrize("storage_block_size", [0, 7, 17])
+def test_invalid_indexer_block_size_is_rejected(storage_block_size):
+    with pytest.raises(ValueError):
+        select_indexer_block_size(storage_block_size)
+
+
+def test_model_cache_layers_publish_source_compatible_specs():
+    current_config = SimpleNamespace(
+        parallel_config=SimpleNamespace(pipeline_parallel_size=2),
+        compilation_config=SimpleNamespace(static_forward_context={}),
+    )
+    cache_config = SimpleNamespace(block_size=256)
+    with patch(
+        "vllm_ascend.models.glm5next.kv_cache.get_current_vllm_config",
+        return_value=current_config,
+    ):
+        indexer = Glm5NextIndexerCache(
+            head_dim=128,
+            dtype=torch.bfloat16,
+            cache_role="indexer",
+            cache_config=cache_config,
+            prefix="model.layers.0.indexer.k_cache",
+            compress_ratio=16,
+        )
+        state = Glm5NextStateCache(
+            state_dim=256,
+            dtype=torch.float32,
+            compress_ratio=16,
+            cache_config=cache_config,
+            prefix="model.layers.0.indexer.state_cache",
+        )
+
+    indexer_spec = indexer.get_kv_cache_spec(None)
+    state_spec = state.get_kv_cache_spec(None)
+    assert len(indexer.kv_cache) == len(state.kv_cache) == 2
+    assert isinstance(indexer_spec, AscendMLAAttentionSpec)
+    assert indexer_spec.block_size == 256
+    assert indexer_spec.storage_block_size == 16
+    assert get_kv_cache_compression_ratio(indexer_spec) == 16
+    assert indexer_spec.model_version == "glm5_next"
+    assert indexer_spec.indexes_kv_by_block_stride
+    assert state_spec.block_size == state_spec.sliding_window == 16
+    assert state_spec.head_size == 256
+    assert state_spec.dtype == torch.float32
+    assert state_spec.model_version == "glm5_next"
+    assert state_spec.indexes_kv_by_block_stride
+    assert indexer.get_attn_backend() is AscendIndexerKPoolBackend
+    assert state.get_attn_backend() is AscendIndexerKPoolStateBackend
+    assert set(current_config.compilation_config.static_forward_context) == {
+        indexer.prefix,
+        state.prefix,
+    }
+
+
+def test_indexer_metadata_preserves_raw_request_boundaries():
+    config = SimpleNamespace(
+        scheduler_config=SimpleNamespace(
+            max_num_batched_tokens=16,
+            max_num_seqs=2,
+        ),
+        model_config=SimpleNamespace(max_model_len=512),
+    )
+    builder = AscendIndexerKPoolMetadataBuilder(
+        MLAAttentionSpec(
+            block_size=256,
+            num_kv_heads=1,
+            head_size=128,
+            dtype=torch.bfloat16,
+            model_version="glm5_next",
+            **_ratio_kwargs(16),
+        ),
+        ["model.layers.0.indexer.k_cache"],
+        config,
+        torch.device("cpu"),
+    )
+    common = AscendCommonAttentionMetadata(
+        query_start_loc=torch.tensor([0, 2, 5], dtype=torch.int32),
+        query_start_loc_cpu=torch.tensor([0, 2, 5], dtype=torch.int32),
+        seq_lens=torch.tensor([18, 35], dtype=torch.int32),
+        _seq_lens_cpu=torch.tensor([18, 35], dtype=torch.int32),
+        num_reqs=2,
+        num_actual_tokens=5,
+        max_query_len=3,
+        num_input_tokens=5,
+        max_seq_len=35,
+        block_table_tensor=torch.tensor([[0, -1], [1, 2]], dtype=torch.int32),
+        slot_mapping=torch.tensor([16, 17, 32, 33, 34]),
+        positions=torch.tensor([16, 17, 32, 33, 34]),
+    )
+
+    metadata = builder.build(0, common)
+
+    assert metadata.cum_query_lens.tolist() == [2, 5]
+    assert metadata.raw_seq_lens.tolist() == [18, 35]
+    assert metadata.seq_lens.tolist() == [1, 2]
+    assert metadata.num_actual_tokens == 5

--- a/tests/ut/patch/platform/test_patch_mamba_block_aligned_split.py
+++ b/tests/ut/patch/platform/test_patch_mamba_block_aligned_split.py
@@ -24,7 +24,11 @@ from vllm_ascend.patch.platform.patch_mamba_block_aligned_split import (
 from vllm_ascend.utils import vllm_version_is
 
 
-def _scheduler(*, is_kv_consumer: bool | None):
+def _scheduler(
+    *,
+    is_kv_consumer: bool | None,
+    uses_sparse_index_kpool: bool = False,
+):
     kv_transfer_config = None if is_kv_consumer is None else SimpleNamespace(is_kv_consumer=is_kv_consumer)
     # vLLM main added `mamba_has_prefill_checkpoint_blocks` (gated by
     # MambaSpec.num_prefill_checkpoint_blocks) to the boundary split; v0.28.0
@@ -32,9 +36,17 @@ def _scheduler(*, is_kv_consumer: bool | None):
     scheduler_kwargs: dict = {}
     if not vllm_version_is("0.28.0"):
         scheduler_kwargs["mamba_has_prefill_checkpoint_blocks"] = False
+    indexer_config = {"index_topk": 2048, "index_kpool": 4} if uses_sparse_index_kpool else {}
     return SimpleNamespace(
-        vllm_config=SimpleNamespace(kv_transfer_config=kv_transfer_config),
+        vllm_config=SimpleNamespace(
+            kv_transfer_config=kv_transfer_config,
+            model_config=SimpleNamespace(
+                hf_config=SimpleNamespace(),
+                hf_text_config=SimpleNamespace(**indexer_config),
+            ),
+        ),
         cache_config=SimpleNamespace(block_size=384),
+        block_size=128,
         use_eagle=True,
         max_num_scheduled_tokens=8192,
         scheduler_config=SimpleNamespace(long_prefill_token_threshold=0),
@@ -114,6 +126,58 @@ def test_producer_decode_fast_path_remains_unsplit():
     result = _mamba_block_aligned_split(
         _scheduler(is_kv_consumer=False),
         _request(num_computed_tokens=380),
+        num_new_tokens=8,
+    )
+
+    assert result == 8
+
+
+def test_sparse_index_kpool_prefill_uses_resolved_common_block_size():
+    result = _mamba_block_aligned_split(
+        _scheduler(is_kv_consumer=False, uses_sparse_index_kpool=True),
+        _request(
+            num_computed_tokens=128,
+            num_prompt_tokens=500,
+            num_tokens=500,
+        ),
+        num_new_tokens=200,
+    )
+
+    assert result == 128
+
+
+def test_sparse_index_kpool_stops_at_last_cacheable_boundary():
+    result = _mamba_block_aligned_split(
+        _scheduler(is_kv_consumer=False, uses_sparse_index_kpool=True),
+        _request(
+            num_computed_tokens=220,
+            num_prompt_tokens=500,
+            num_tokens=500,
+        ),
+        num_new_tokens=100,
+    )
+
+    assert result == 36
+
+
+def test_sparse_index_kpool_does_not_round_small_chunk_to_zero():
+    result = _mamba_block_aligned_split(
+        _scheduler(is_kv_consumer=False, uses_sparse_index_kpool=True),
+        _request(
+            num_computed_tokens=128,
+            num_prompt_tokens=500,
+            num_tokens=500,
+        ),
+        num_new_tokens=64,
+    )
+
+    assert result == 64
+
+
+def test_sparse_index_kpool_pd_consumer_still_preserves_verifier_window():
+    result = _mamba_block_aligned_split(
+        _scheduler(is_kv_consumer=True, uses_sparse_index_kpool=True),
+        _request(),
         num_new_tokens=8,
     )
 

--- a/tests/ut/patch/platform/test_patch_mamba_config.py
+++ b/tests/ut/patch/platform/test_patch_mamba_config.py
@@ -1,0 +1,65 @@
+# Copyright (c) 2026 Huawei Technologies Co., Ltd. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from types import SimpleNamespace
+
+import pytest
+
+from vllm_ascend.patch.platform.patch_mamba_config import (
+    _get_sparse_index_kpool,
+)
+
+
+def _model_config(**text_config):
+    return SimpleNamespace(
+        hf_text_config=SimpleNamespace(**text_config),
+        hf_config=SimpleNamespace(),
+    )
+
+
+def test_sparse_index_kpool_detection_is_model_agnostic():
+    model_config = _model_config(
+        model_type="another_hybrid_model",
+        index_topk=2048,
+        index_kpool=4,
+    )
+
+    assert _get_sparse_index_kpool(model_config) == 4
+
+
+def test_dense_model_with_index_kpool_field_uses_generic_layout():
+    model_config = _model_config(
+        model_type="glm5_next",
+        index_topk=None,
+        index_kpool=4,
+    )
+
+    assert _get_sparse_index_kpool(model_config) is None
+
+
+def test_sparse_indexer_without_kpool_uses_generic_layout():
+    model_config = _model_config(index_topk=2048)
+
+    assert _get_sparse_index_kpool(model_config) is None
+
+
+@pytest.mark.parametrize("index_kpool", [None, 0, 1, "4"])
+def test_active_sparse_index_kpool_requires_valid_ratio(index_kpool):
+    model_config = _model_config(
+        index_topk=2048,
+        index_kpool=index_kpool,
+    )
+
+    with pytest.raises(ValueError, match="integer greater than 1"):
+        _get_sparse_index_kpool(model_config)

--- a/tests/ut/patch/platform/test_prefix_cache_cp_patches.py
+++ b/tests/ut/patch/platform/test_prefix_cache_cp_patches.py
@@ -9,7 +9,10 @@ import pytest
 import torch
 import vllm.v1.core.kv_cache_utils as vllm_kv_cache_utils
 from vllm.v1.core.block_pool import BlockPool
-from vllm.v1.core.kv_cache_utils import generate_scheduler_kv_cache_config
+from vllm.v1.core.kv_cache_utils import (
+    BlockHashListWithBlockSize,
+    generate_scheduler_kv_cache_config,
+)
 from vllm.v1.core.single_type_kv_cache_manager import (
     FullAttentionManager,
     SlidingWindowManager,
@@ -27,7 +30,10 @@ from vllm.v1.kv_cache_interface import (
 from vllm.v1.kv_cache_spec_registry import KVCacheSpecRegistry
 
 import vllm_ascend.patch.platform.patch_kv_cache_utils as kv_cache_utils_patch
-from vllm_ascend.core.kv_cache_interface import AscendMLAAttentionSpec
+from vllm_ascend.core.kv_cache_interface import (
+    AscendIndexerKPoolStateSpec,
+    AscendMLAAttentionSpec,
+)
 from vllm_ascend.patch.platform.patch_kv_cache_coordinator import (
     AscendHybridKVCacheCoordinator,
     _is_deepseek_v4_kv_cache_spec,
@@ -183,13 +189,14 @@ def _make_vllm_config(
     enable_prefix_caching: bool,
     dcp: int,
     block_size: int = 16,
+    prefix_match_unit: int | None = None,
 ) -> SimpleNamespace:
     return SimpleNamespace(
         cache_config=SimpleNamespace(
             block_size=block_size,
             enable_prefix_caching=enable_prefix_caching,
             mamba_cache_mode="align",
-            prefix_match_unit=None,
+            prefix_match_unit=prefix_match_unit,
         ),
         parallel_config=SimpleNamespace(
             decode_context_parallel_size=dcp,
@@ -280,6 +287,115 @@ def test_resolve_kv_cache_block_sizes_with_cp_hybrid_groups(
     expected_scheduler_block_size = math.lcm(16, 32) * 2
     assert scheduler_block_size == expected_scheduler_block_size
     assert hash_block_size == expected_hash_block_size
+
+
+@pytest.mark.parametrize(
+    ("full_block_size", "prefix_match_unit", "expected_hash_block_size"),
+    [
+        pytest.param(128, None, 16, id="default-prefix-match-unit"),
+        pytest.param(384, None, 16, id="non-power-of-two-full-block"),
+        pytest.param(384, 8, 8, id="configured-prefix-match-unit"),
+    ],
+)
+def test_glm5_next_hashes_use_state_granularity_after_engine_min_block_update(
+    full_block_size: int,
+    prefix_match_unit: int | None,
+    expected_hash_block_size: int,
+) -> None:
+    main_spec = MLAAttentionSpec(
+        block_size=full_block_size,
+        num_kv_heads=1,
+        head_size=512,
+        dtype=torch.bfloat16,
+        model_version="glm5_next",
+    )
+    indexer_spec = MLAAttentionSpec(
+        block_size=full_block_size,
+        num_kv_heads=1,
+        head_size=128,
+        dtype=torch.bfloat16,
+        model_version="glm5_next",
+        **_ratio_kwargs(16),
+    )
+    state_spec = AscendIndexerKPoolStateSpec(
+        block_size=16,
+        sliding_window=16,
+        num_kv_heads=1,
+        head_size=256,
+        dtype=torch.float32,
+        model_version="glm5_next",
+        cache_role="indexer_state",
+    )
+    full_group_spec = UniformTypeKVCacheSpecs.from_specs({"layer.main": main_spec, "layer.indexer": indexer_spec})
+    state_group_spec = UniformTypeKVCacheSpecs.from_specs({"layer.state": state_spec})
+    mamba_spec = MambaSpec(
+        block_size=full_block_size,
+        shapes=((1,),),
+        dtypes=(torch.float32,),
+        mamba_cache_mode="align",
+    )
+    mamba_group_spec = UniformTypeKVCacheSpecs.from_specs({"layer.mamba": mamba_spec})
+    assert full_group_spec is not None
+    assert state_group_spec is not None
+    assert mamba_group_spec is not None
+
+    worker_config = KVCacheConfig(
+        num_blocks=10,
+        kv_cache_tensors=[],
+        kv_cache_groups=[
+            KVCacheGroupSpec(
+                layer_names=["layer.main", "layer.indexer"],
+                kv_cache_spec=full_group_spec,
+            ),
+            KVCacheGroupSpec(
+                layer_names=["layer.state"],
+                kv_cache_spec=state_group_spec,
+            ),
+            KVCacheGroupSpec(
+                layer_names=["layer.mamba"],
+                kv_cache_spec=mamba_group_spec,
+            ),
+        ],
+    )
+    scheduler_config = generate_scheduler_kv_cache_config([worker_config])
+    scheduler_full_spec = scheduler_config.kv_cache_groups[0].kv_cache_spec
+    assert isinstance(scheduler_full_spec, MLAAttentionSpec)
+    assert scheduler_full_spec.head_size == main_spec.head_size
+    ratio_field = "compress_ratio" if vllm_version_is("0.28.0") else "tokens_per_state"
+    assert getattr(scheduler_full_spec, ratio_field) == 1
+
+    vllm_config = _make_vllm_config(
+        enable_prefix_caching=True,
+        dcp=1,
+        block_size=full_block_size,
+        prefix_match_unit=prefix_match_unit,
+    )
+    # Match EngineCore: the global block size becomes the smallest unwrapped
+    # scheduler group size, which is the indexer-state granularity here.
+    vllm_config.cache_config.block_size = min(
+        group.kv_cache_spec.block_size for group in scheduler_config.kv_cache_groups
+    )
+    assert vllm_config.cache_config.block_size == 16
+    scheduler_block_size, hash_block_size = _ascend_resolve_kv_cache_block_sizes(
+        scheduler_config,
+        vllm_config,
+    )
+    assert (scheduler_block_size, hash_block_size) == (
+        full_block_size,
+        expected_hash_block_size,
+    )
+
+    hashes_per_full_block = full_block_size // hash_block_size
+    base_hashes = [index.to_bytes(2, "little") for index in range(2 * hashes_per_full_block)]
+    full_group_hashes = BlockHashListWithBlockSize(
+        base_hashes,
+        hash_block_size,
+        scheduler_full_spec.block_size,
+    )
+    assert len(full_group_hashes) == 2
+    # vLLM hashes are chained across prefix blocks, so the last state-sized
+    # hash in a full block is already that full block's hash.
+    assert full_group_hashes[0] == base_hashes[hashes_per_full_block - 1]
 
 
 def test_deepseek_v4_groups_use_logical_sizes_and_full_attention_manager() -> None:

--- a/tests/ut/worker/test_glm5next_pooled_cache.py
+++ b/tests/ut/worker/test_glm5next_pooled_cache.py
@@ -1,0 +1,268 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""CPU tests for GLM-Next model-runner pooled cache views."""
+
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import torch
+from vllm.v1.core.single_type_kv_cache_manager import (
+    register_all_kvcache_specs,
+)
+from vllm.v1.kv_cache_interface import MambaSpec
+
+from vllm_ascend.core.kv_cache_interface import (
+    AscendIndexerKPoolStateSpec,
+    AscendMLAAttentionSpec,
+)
+from vllm_ascend.models.glm5next.cache_config import (
+    get_glm5_next_kv_cache_config,
+    get_glm5_next_kv_cache_groups,
+    get_glm5_next_pool_bytes_per_block,
+)
+from vllm_ascend.utils import get_kv_cache_tensor_layers, vllm_version_is
+from vllm_ascend.worker.model_runner_v1 import NPUModelRunner
+
+MAIN = "model.layers.1.attn"
+INDEXER = "model.layers.1.indexer.k_cache"
+STATE = "model.layers.1.indexer.state_cache"
+MAMBA = "model.layers.0.linear_attn"
+
+
+def _ratio_kwargs(ratio: int) -> dict[str, int]:
+    return {"compress_ratio": ratio} if vllm_version_is("0.28.0") else {"tokens_per_state": ratio}
+
+
+class _AttentionBackend:
+    @staticmethod
+    def get_kv_cache_shape(
+        num_blocks,
+        block_size,
+        num_kv_heads,
+        head_size,
+        **_kwargs,
+    ):
+        return num_blocks, block_size, num_kv_heads, head_size
+
+
+class _StateBackend:
+    @staticmethod
+    def get_kv_cache_shape(
+        num_blocks,
+        block_size,
+        _num_kv_heads,
+        head_size,
+        **_kwargs,
+    ):
+        return num_blocks, block_size, head_size
+
+
+def _make_config():
+    return SimpleNamespace(
+        model_config=SimpleNamespace(max_model_len=64),
+        parallel_config=SimpleNamespace(
+            decode_context_parallel_size=1,
+            prefill_context_parallel_size=1,
+        ),
+        scheduler_config=SimpleNamespace(disable_hybrid_kv_cache_manager=False),
+        max_in_flight_tokens=8,
+        cache_config=SimpleNamespace(
+            num_gpu_blocks_override=None,
+            mamba_cache_mode="none",
+            enable_prefix_caching=False,
+        ),
+        kv_transfer_config=None,
+        compilation_config=SimpleNamespace(static_forward_context={}),
+    )
+
+
+def _make_specs(main_head_size=4):
+    return {
+        MAIN: AscendMLAAttentionSpec(
+            block_size=8,
+            num_kv_heads=1,
+            head_size=main_head_size,
+            dtype=torch.bfloat16,
+            model_version="glm5_next",
+            indexes_kv_by_block_stride=True,
+        ),
+        INDEXER: AscendMLAAttentionSpec(
+            block_size=8,
+            num_kv_heads=1,
+            head_size=4,
+            dtype=torch.bfloat16,
+            model_version="glm5_next",
+            indexes_kv_by_block_stride=True,
+            **_ratio_kwargs(2),
+        ),
+        STATE: AscendIndexerKPoolStateSpec(
+            block_size=2,
+            sliding_window=2,
+            num_kv_heads=1,
+            head_size=3,
+            dtype=torch.float32,
+            model_version="glm5_next",
+            indexes_kv_by_block_stride=True,
+        ),
+        MAMBA: MambaSpec(
+            block_size=8,
+            shapes=((2, 2), (1, 2, 2)),
+            dtypes=(torch.bfloat16, torch.float32),
+        ),
+    }
+
+
+def _make_runner(config, main_cache_dims=(4, 0)):
+    runner = NPUModelRunner.__new__(NPUModelRunner)
+    runner.device = torch.device("cpu")
+    runner.vllm_config = config
+    runner.compilation_config = config.compilation_config
+    runner.runner_only_attn_layers = set()
+    runner.shared_kv_cache_layers = {}
+    runner.kv_caches = []
+    runner.use_sparse = False
+    # GLM-Next exposes its layout through KV specs and does not define the
+    # legacy ``compress_ratios`` config used to derive this runner flag.
+    runner.use_compress = False
+    runner.use_hybrid_blocks = True
+    runner.sparse_kv_offload_enabled = False
+    runner.sparse_kv_offload_config = SimpleNamespace(enabled=False)
+    runner.tp_rank = 0
+    runner.attn_backend = _AttentionBackend
+    # The runner must consume the descriptor/spec contract without inspecting
+    # a model type.
+    runner.model_config = SimpleNamespace()
+
+    specs = _make_specs()
+    attn_groups = [
+        SimpleNamespace(
+            backend=_AttentionBackend,
+            kv_cache_spec=specs[MAIN],
+            layer_names=[MAIN],
+        ),
+        SimpleNamespace(
+            backend=_AttentionBackend,
+            kv_cache_spec=specs[INDEXER],
+            layer_names=[INDEXER],
+        ),
+        SimpleNamespace(
+            backend=_StateBackend,
+            kv_cache_spec=specs[STATE],
+            layer_names=[STATE],
+        ),
+        SimpleNamespace(
+            backend=None,
+            kv_cache_spec=specs[MAMBA],
+            layer_names=[MAMBA],
+        ),
+    ]
+    runner._kv_cache_spec_attn_group_iterator = lambda: iter(attn_groups)
+    runner._get_attention_kv_cache_dims = lambda _name, _spec: main_cache_dims
+    return runner
+
+
+def _make_plan(num_blocks=3, main_head_size=4):
+    # Match production: vLLM registers built-in specs before the Ascend hook.
+    register_all_kvcache_specs(None)
+    config = _make_config()
+    groups = get_glm5_next_kv_cache_groups(config, _make_specs(main_head_size))
+    bytes_per_block = get_glm5_next_pool_bytes_per_block(groups)
+    plan = get_glm5_next_kv_cache_config(
+        config,
+        groups,
+        num_blocks * bytes_per_block,
+    )
+    return config, groups, plan
+
+
+def test_glm5_next_runner_allocates_contiguous_slot_backings():
+    config, _, plan = _make_plan()
+    runner = _make_runner(config)
+
+    raw_caches = runner._allocate_kv_cache_tensors(plan)
+    assert raw_caches[MAIN] is raw_caches[MAMBA]
+    assert raw_caches[INDEXER] is raw_caches[STATE]
+    assert raw_caches[MAIN] is not raw_caches[INDEXER]
+
+    caches = runner._reshape_kv_cache_tensors(plan, raw_caches)
+    descriptors = {
+        name: descriptor for descriptor in plan.kv_cache_tensors for name in get_kv_cache_tensor_layers(descriptor)
+    }
+    main_cache, main_rope_cache = caches[MAIN]
+    (indexer_cache,) = caches[INDEXER]
+    (state_cache,) = caches[STATE]
+    assert main_cache.shape == (3, 8, 1, 4)
+    assert main_rope_cache.shape == (3, 8, 1, 0)
+    assert main_cache.is_contiguous()
+    assert indexer_cache.shape == (3, 4, 1, 4)
+    assert state_cache.shape == (3, 2, 3)
+    assert [cache.shape for cache in caches[MAMBA]] == [
+        (3, 2, 2),
+        (3, 1, 2, 2),
+    ]
+
+    for name, cache in ((INDEXER, indexer_cache), (STATE, state_cache)):
+        page_size = descriptors[name].size // plan.num_blocks
+        assert cache.stride(0) * cache.element_size() == page_size
+        assert cache.data_ptr() == raw_caches[name].data_ptr()
+    assert all(cache.is_contiguous() for cache in caches[MAMBA])
+
+    mamba_second_offset = caches[MAMBA][0].numel() * caches[MAMBA][0].element_size()
+    assert caches[MAMBA][1].data_ptr() - raw_caches[MAMBA].data_ptr() == mamba_second_offset
+    mamba_payload_size = sum(cache.numel() * cache.element_size() for cache in caches[MAMBA])
+    assert mamba_payload_size < descriptors[MAMBA].size
+
+    state_cache[2].fill_(7)
+    state_payload_size = state_cache[0].numel() * state_cache.element_size()
+    state_padding = 2 * (descriptors[STATE].size // plan.num_blocks) + state_payload_size
+    assert raw_caches[STATE][state_padding].item() == 0
+
+
+def test_glm5_next_runner_splits_main_mla_components_within_each_page():
+    config, _, plan = _make_plan(main_head_size=6)
+    runner = _make_runner(config, main_cache_dims=(4, 2))
+
+    raw_caches = runner._allocate_kv_cache_tensors(plan)
+    caches = runner._reshape_kv_cache_tensors(plan, raw_caches)
+
+    kv_c_cache, k_pe_cache = caches[MAIN]
+    assert kv_c_cache.shape == (3, 8, 1, 4)
+    assert k_pe_cache.shape == (3, 8, 1, 2)
+    page_size = next(
+        descriptor.size // plan.num_blocks
+        for descriptor in plan.kv_cache_tensors
+        if MAIN in get_kv_cache_tensor_layers(descriptor)
+    )
+    assert kv_c_cache.stride(0) * kv_c_cache.element_size() == page_size
+    assert k_pe_cache.stride(0) * k_pe_cache.element_size() == page_size
+    assert k_pe_cache.data_ptr() - raw_caches[MAIN].data_ptr() == kv_c_cache[0].numel() * kv_c_cache.element_size()
+
+
+def test_standalone_mtp_uses_existing_compressed_cache_allocator():
+    config = _make_config()
+    specs = {name: spec for name, spec in _make_specs().items() if not isinstance(spec, MambaSpec)}
+    groups = get_glm5_next_kv_cache_groups(config, specs)
+    bytes_per_block = get_glm5_next_pool_bytes_per_block(groups)
+    plan = get_glm5_next_kv_cache_config(config, groups, 3 * bytes_per_block)
+
+    raw_caches = _make_runner(config)._allocate_kv_cache_tensors(plan)
+
+    assert set(raw_caches) == {MAIN, INDEXER, STATE}
+    assert raw_caches[INDEXER] is raw_caches[STATE]
+
+
+def test_glm5_next_initialize_passes_all_pooled_views_to_cache_binding():
+    config, _, plan = _make_plan()
+    runner = _make_runner(config)
+    runner.model_config = SimpleNamespace(hf_text_config=SimpleNamespace(model_type="glm5_next"))
+
+    with patch("vllm.v1.worker.utils.bind_kv_cache") as bind_kv_cache:
+        caches = runner.initialize_kv_cache_tensors(plan)
+
+    assert set(caches) == {MAIN, INDEXER, STATE, MAMBA}
+    bind_kv_cache.assert_called_once_with(
+        caches,
+        runner.compilation_config.static_forward_context,
+        runner.kv_caches,
+        1,
+    )

--- a/tests/ut/worker/test_model_runner_v1.py
+++ b/tests/ut/worker/test_model_runner_v1.py
@@ -18,6 +18,7 @@ from vllm.v1.kv_cache_interface import (
     KVCacheGroupSpec,
     KVCacheTensor,
     MambaSpec,
+    MLAAttentionSpec,
     UniformTypeKVCacheSpecs,
 )
 from vllm.v1.utils import CpuGpuBuffer
@@ -26,8 +27,16 @@ from vllm.v1.worker.gpu_model_runner import GPUModelRunner
 
 from vllm_ascend.attention.mla_v1 import AscendMLABackend
 from vllm_ascend.attention.utils import get_sfa_qsfa_packed_head_dim
-from vllm_ascend.core.kv_cache_interface import AscendMLAAttentionSpec, AscendSFAIndexerCacheSpec
+from vllm_ascend.core.kv_cache_interface import (
+    AscendIndexerKPoolStateSpec,
+    AscendMLAAttentionSpec,
+    AscendSFAIndexerCacheSpec,
+)
 from vllm_ascend.device.hardware_profile import get_hardware_profile
+from vllm_ascend.models.glm5next.kv_cache import (
+    Glm5NextIndexerCache,
+    Glm5NextStateCache,
+)
 from vllm_ascend.patch.platform.patch_kv_cache_utils import (
     _get_kv_cache_config_deepseek_v4_main,
 )
@@ -438,6 +447,106 @@ class TestNPUModelRunnerKVCache(unittest.TestCase):
 
         self.assertEqual(k_cache_raw.numel(), kv_cache_spec.page_size_bytes)
         self.assertEqual(v_cache_raw.numel(), kv_cache_spec.page_size_bytes)
+
+    @patch("vllm_ascend.worker.model_runner_v1.get_layers_from_vllm_config")
+    def test_mla_spec_preserves_block_stride_layout_contract(
+        self,
+        mock_get_layers,
+    ):
+        runner = self._build_runner()
+        runner.shared_kv_cache_layers = {}
+
+        layer_name = "model.layers.1.self_attn.attn"
+        source_spec = MLAAttentionSpec(
+            block_size=128,
+            num_kv_heads=1,
+            head_size=576,
+            dtype=torch.bfloat16,
+        )
+        attn_module = MLAAttention.__new__(MLAAttention)
+        torch.nn.Module.__init__(attn_module)
+        attn_module.impl = SimpleNamespace(fa_quant_layer=False)
+        attn_module.model_version = "glm5_next"
+        attn_module.indexes_kv_by_block_stride = True
+        attn_module.get_kv_cache_spec = MagicMock(return_value=source_spec)
+        mock_get_layers.return_value = {layer_name: attn_module}
+
+        spec = runner.get_kv_cache_spec()[layer_name]
+
+        self.assertIsInstance(spec, AscendMLAAttentionSpec)
+        self.assertEqual(spec.model_version, attn_module.model_version)
+        self.assertTrue(spec.indexes_kv_by_block_stride)
+
+    @patch("vllm_ascend.worker.model_runner_v1.has_ec_transfer", return_value=False)
+    @patch("vllm_ascend.worker.model_runner_v1.get_layers_from_vllm_config")
+    def test_mamba_alignment_excludes_auxiliary_glm_caches(
+        self,
+        mock_get_layers,
+        _mock_has_ec_transfer,
+    ):
+        class FakeMamba:
+            def __init__(self, spec):
+                self.spec = spec
+
+            def get_kv_cache_spec(self, _vllm_config):
+                return self.spec
+
+        runner = self._build_runner()
+        runner.shared_kv_cache_layers = {}
+
+        main_spec = AscendMLAAttentionSpec(
+            block_size=8,
+            num_kv_heads=1,
+            head_size=4,
+            dtype=torch.bfloat16,
+            model_version="glm5_next",
+            indexes_kv_by_block_stride=True,
+        )
+        indexer_spec = AscendMLAAttentionSpec(
+            block_size=8,
+            num_kv_heads=1,
+            head_size=4,
+            dtype=torch.bfloat16,
+            model_version="glm5_next",
+            indexes_kv_by_block_stride=True,
+            **_ratio_kwargs(2),
+        )
+        state_spec = AscendIndexerKPoolStateSpec(
+            block_size=2,
+            sliding_window=2,
+            num_kv_heads=1,
+            head_size=3,
+            dtype=torch.float32,
+        )
+        mamba_spec = MambaSpec(
+            block_size=8,
+            shapes=((128,),),
+            dtypes=(torch.float32,),
+        )
+
+        main_module = SimpleNamespace(get_kv_cache_spec=lambda _config: main_spec)
+        indexer_module = Glm5NextIndexerCache.__new__(Glm5NextIndexerCache)
+        torch.nn.Module.__init__(indexer_module)
+        indexer_module.get_kv_cache_spec = lambda _config: indexer_spec
+        state_module = Glm5NextStateCache.__new__(Glm5NextStateCache)
+        torch.nn.Module.__init__(state_module)
+        state_module.get_kv_cache_spec = lambda _config: state_spec
+        mock_get_layers.return_value = {
+            "model.layers.1.attn": main_module,
+            "model.layers.1.indexer.k_cache": indexer_module,
+            "model.layers.1.indexer.state_cache": state_module,
+            "model.layers.0.linear_attn": FakeMamba(mamba_spec),
+        }
+
+        with patch("vllm_ascend.worker.model_runner_v1.MambaBase", FakeMamba):
+            specs = runner.get_kv_cache_spec()
+
+        self.assertEqual(
+            specs["model.layers.1.attn"].page_size_padded,
+            mamba_spec.page_size_bytes,
+        )
+        self.assertIsNone(specs["model.layers.1.indexer.k_cache"].page_size_padded)
+        self.assertIsNone(specs["model.layers.1.indexer.state_cache"].page_size_padded)
 
     @patch("vllm_ascend.worker.model_runner_v1.get_layers_from_vllm_config")
     def test_mla_rope_modes_and_cache_layers_use_separate_metadata_groups(self, mock_get_layers):

--- a/vllm_ascend/attention/indexer_kpool.py
+++ b/vllm_ascend/attention/indexer_kpool.py
@@ -1,0 +1,387 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Independent pooled-indexer and compressor-state metadata for GLM-Next."""
+
+from dataclasses import dataclass
+
+import torch
+from vllm.config import VllmConfig
+from vllm.utils.math_utils import cdiv
+from vllm.v1.attention.backend import (
+    AttentionBackend,
+    AttentionCGSupport,
+    AttentionMetadataBuilder,
+    CommonAttentionMetadata,
+    MultipleOf,
+)
+from vllm.v1.kv_cache_interface import MLAAttentionSpec
+
+from vllm_ascend.core.kv_cache_interface import (
+    AscendIndexerKPoolStateSpec,
+    get_kv_cache_compression_ratio,
+    get_storage_block_size,
+)
+from vllm_ascend.models.glm5next.kv_cache import (
+    format_indexer_kpool_slot_mapping,
+)
+
+GLM5_NEXT_SFA_KERNEL_BLOCK_SIZE = 128
+INDEXER_KPOOL_MAX_BLOCK_SIZE = 1024
+INDEXER_KPOOL_BLOCK_ALIGNMENT = 16
+
+
+def select_indexer_block_size(storage_block_size: int) -> tuple[int, int]:
+    """Select a CANN-compatible physical block size for the indexer cache.
+
+    ``pool_key_indexer`` requires the ``PA_BBND`` block dimension to be a
+    multiple of 16 and no larger than 1024. GLM-Next's logical attention block
+    can be much larger than 1024 after compression, so split one storage block
+    into several CANN-compatible sub-blocks when necessary.
+
+    Returns ``(block_size, blocks_per_logical_block)``.
+    """
+    if storage_block_size <= 0:
+        raise ValueError(f"Indexer KPool storage block size must be positive, got {storage_block_size}.")
+    if storage_block_size <= INDEXER_KPOOL_MAX_BLOCK_SIZE and storage_block_size % INDEXER_KPOOL_BLOCK_ALIGNMENT == 0:
+        return storage_block_size, 1
+    max_candidate = min(storage_block_size, INDEXER_KPOOL_MAX_BLOCK_SIZE)
+    max_candidate -= max_candidate % INDEXER_KPOOL_BLOCK_ALIGNMENT
+    for candidate in range(
+        max_candidate,
+        INDEXER_KPOOL_BLOCK_ALIGNMENT - 1,
+        -INDEXER_KPOOL_BLOCK_ALIGNMENT,
+    ):
+        if storage_block_size % candidate == 0:
+            return candidate, storage_block_size // candidate
+    raise ValueError(
+        "Indexer KPool storage block size "
+        f"{storage_block_size} cannot be split into a block size that is a "
+        f"multiple of {INDEXER_KPOOL_BLOCK_ALIGNMENT} and no larger than "
+        f"{INDEXER_KPOOL_MAX_BLOCK_SIZE}."
+    )
+
+
+@dataclass
+class AscendIndexerKPoolMetadata:
+    """Metadata for compressed indexer cache writes and top-k reads."""
+
+    block_table: torch.Tensor
+    slot_mapping: torch.Tensor
+    seq_lens: torch.Tensor
+    seq_lens_cpu: torch.Tensor
+    positions: torch.Tensor
+    block_size: int
+    compress_ratio: int
+    cache_role: str = "indexer"
+    cum_query_lens: torch.Tensor | None = None
+    raw_seq_lens: torch.Tensor | None = None
+    num_actual_tokens: int = 0
+
+
+class AscendIndexerKPoolMetadataBuilder(AttentionMetadataBuilder):
+    """Build pool-level addressing for the compressed indexer cache."""
+
+    @classmethod
+    def get_cudagraph_support(
+        cls,
+        vllm_config: VllmConfig,
+        kv_cache_spec,
+    ) -> AttentionCGSupport:
+        # This cache-only builder still participates in graph capability
+        # reduction. Its decode metadata uses persistent buffers refreshed in
+        # place, so it must not disable the main model's uniform decode graph.
+        return AttentionCGSupport.UNIFORM_BATCH
+
+    def __init__(
+        self,
+        kv_cache_spec: MLAAttentionSpec,
+        layer_names: list[str],
+        vllm_config: VllmConfig,
+        device: torch.device,
+    ) -> None:
+        if not isinstance(kv_cache_spec, MLAAttentionSpec):
+            raise TypeError(
+                f"Ascend Indexer KPool backend requires MLAAttentionSpec, got {type(kv_cache_spec).__name__}."
+            )
+        compress_ratio = get_kv_cache_compression_ratio(kv_cache_spec)
+        if compress_ratio <= 1:
+            raise ValueError(f"Ascend Indexer KPool cache requires compress_ratio > 1, got {compress_ratio}.")
+        if not layer_names or any(not name.endswith(".indexer.k_cache") for name in layer_names):
+            raise ValueError(f"Invalid Indexer KPool cache layer names: {layer_names}.")
+        super().__init__(kv_cache_spec, layer_names, vllm_config, device)
+        self.logical_block_size = kv_cache_spec.block_size
+        self.storage_block_size = get_storage_block_size(kv_cache_spec)
+        self.compress_ratio = compress_ratio
+        if self.logical_block_size % GLM5_NEXT_SFA_KERNEL_BLOCK_SIZE:
+            raise ValueError(
+                "GLM-Next logical block size must be divisible by the SFA "
+                f"kernel block size: logical={self.logical_block_size}, "
+                f"kernel={GLM5_NEXT_SFA_KERNEL_BLOCK_SIZE}."
+            )
+        self.kernel_blocks_per_logical_block = self.logical_block_size // GLM5_NEXT_SFA_KERNEL_BLOCK_SIZE
+        self.indexer_block_size, self.indexer_blocks_per_logical_block = select_indexer_block_size(
+            self.storage_block_size
+        )
+        scheduler_config = vllm_config.scheduler_config
+        # ACLGraph replay keeps the addresses captured on the first run. The
+        # derived compressed metadata therefore needs persistent storage that
+        # is refreshed in place on every builder invocation.
+        self._slot_mapping_buffer = torch.empty(
+            scheduler_config.max_num_batched_tokens,
+            dtype=torch.int64,
+            device=device,
+        )
+        self._seq_lens_buffer = torch.empty(
+            scheduler_config.max_num_seqs,
+            dtype=torch.int32,
+            device=device,
+        )
+        self._cum_query_lens_buffer = torch.empty(
+            scheduler_config.max_num_seqs,
+            dtype=torch.int32,
+            device=device,
+        )
+        self._raw_seq_lens_buffer = torch.empty(
+            scheduler_config.max_num_seqs,
+            dtype=torch.int32,
+            device=device,
+        )
+        max_logical_blocks = cdiv(
+            vllm_config.model_config.max_model_len,
+            self.logical_block_size,
+        )
+        self._block_table_buffer = torch.empty(
+            scheduler_config.max_num_seqs,
+            max_logical_blocks * self.indexer_blocks_per_logical_block,
+            dtype=torch.int32,
+            device=device,
+        )
+
+    def build(
+        self,
+        common_prefix_len: int,
+        common_attn_metadata: CommonAttentionMetadata,
+        fast_build: bool = False,
+        **kwargs,
+    ) -> AscendIndexerKPoolMetadata:
+        del common_prefix_len, fast_build, kwargs
+        num_reqs = common_attn_metadata.num_reqs
+        num_input_tokens = common_attn_metadata.num_input_tokens
+        positions = common_attn_metadata.positions[:num_input_tokens].long()
+        slot_mapping = self._slot_mapping_buffer[:num_input_tokens]
+        slot_mapping.copy_(
+            format_indexer_kpool_slot_mapping(
+                common_attn_metadata.slot_mapping[:num_input_tokens],
+                positions,
+                self.logical_block_size,
+                self.compress_ratio,
+            )
+        )
+        seq_lens = self._seq_lens_buffer[:num_reqs]
+        torch.div(
+            common_attn_metadata.seq_lens[:num_reqs],
+            self.compress_ratio,
+            rounding_mode="floor",
+            out=seq_lens,
+        )
+        cum_query_lens = self._cum_query_lens_buffer[:num_reqs]
+        cum_query_lens.copy_(common_attn_metadata.query_start_loc[: num_reqs + 1][1:])
+        raw_seq_lens = self._raw_seq_lens_buffer[:num_reqs]
+        raw_seq_lens.copy_(common_attn_metadata.seq_lens[:num_reqs])
+        if common_attn_metadata._seq_lens_cpu is not None:
+            seq_lens_cpu = common_attn_metadata._seq_lens_cpu[:num_reqs]
+        elif common_attn_metadata.seq_lens_cpu is not None:
+            seq_lens_cpu = common_attn_metadata.seq_lens_cpu[:num_reqs]
+        else:
+            seq_lens_cpu = common_attn_metadata.seq_lens[:num_reqs].to("cpu")
+        seq_lens_cpu = torch.div(
+            seq_lens_cpu,
+            self.compress_ratio,
+            rounding_mode="floor",
+        )
+        expanded_block_table = common_attn_metadata.block_table_tensor[:num_reqs]
+        split = self.kernel_blocks_per_logical_block
+        if expanded_block_table.shape[1] % split:
+            raise ValueError(
+                "GLM-Next indexer received a partially expanded SFA block "
+                f"table: width={expanded_block_table.shape[1]}, split={split}."
+            )
+        logical_width = expanded_block_table.shape[1] // split
+        expanded_width = logical_width * self.indexer_blocks_per_logical_block
+        if expanded_width > self._block_table_buffer.shape[1]:
+            raise ValueError(
+                "GLM-Next indexer block table exceeds its persistent buffer: "
+                f"required={expanded_width}, capacity="
+                f"{self._block_table_buffer.shape[1]}."
+            )
+        block_table = self._block_table_buffer[:num_reqs, :expanded_width]
+        # The common full-group table is expanded for the C128 SFA kernel:
+        # scheduler block N becomes [split*N, ..., split*N+split-1]. The
+        # compressed indexer owns one physical page per scheduler block, so it
+        # must recover N rather than treating the SFA sub-blocks as pages.
+        base = torch.div(
+            expanded_block_table[:, ::split],
+            split,
+            rounding_mode="floor",
+        )
+        k = self.indexer_blocks_per_logical_block
+        if k == 1:
+            block_table.copy_(base)
+        else:
+            base_repeated = base.repeat_interleave(k, dim=1)
+            offsets = (
+                torch.arange(
+                    expanded_width,
+                    dtype=torch.int32,
+                    device=base.device,
+                )
+                % k
+            )
+            valid = base_repeated >= 0
+            block_table.copy_(
+                torch.where(
+                    valid,
+                    base_repeated * k + offsets,
+                    torch.full_like(base_repeated, -1),
+                )
+            )
+        return AscendIndexerKPoolMetadata(
+            block_table=block_table,
+            slot_mapping=slot_mapping,
+            seq_lens=seq_lens,
+            seq_lens_cpu=seq_lens_cpu,
+            positions=positions,
+            block_size=self.indexer_block_size,
+            compress_ratio=self.compress_ratio,
+            cum_query_lens=cum_query_lens,
+            raw_seq_lens=raw_seq_lens,
+            num_actual_tokens=common_attn_metadata.num_actual_tokens,
+        )
+
+
+class AscendIndexerKPoolBackend(AttentionBackend):
+    """Cache-only backend for the compressed indexer keys."""
+
+    @staticmethod
+    def get_impl_cls():
+        return None
+
+    @staticmethod
+    def get_name() -> str:
+        return "ASCEND_INDEXER_KPOOL"
+
+    @staticmethod
+    def get_supported_kernel_block_sizes() -> list[int | MultipleOf]:
+        # The scheduler manages logical token blocks; the physical cache uses
+        # storage_block_size, split into CANN-compatible sub-blocks when passed
+        # to pool_key_indexer.
+        return [MultipleOf(1)]
+
+    @staticmethod
+    def get_builder_cls() -> type[AscendIndexerKPoolMetadataBuilder]:
+        return AscendIndexerKPoolMetadataBuilder
+
+    @staticmethod
+    def get_kv_cache_shape(
+        num_blocks: int,
+        block_size: int,
+        num_kv_heads: int,
+        head_size: int,
+        cache_type: str = "",
+    ) -> tuple[int, ...]:
+        del cache_type
+        if num_kv_heads != 1:
+            raise ValueError(f"Indexer KPool cache requires one KV head, got {num_kv_heads}.")
+        return (num_blocks, block_size, num_kv_heads, head_size)
+
+
+@dataclass
+class AscendIndexerKPoolStateMetadata:
+    """Addressing required to update the compressor state cache."""
+
+    block_table: torch.Tensor
+    slot_mapping: torch.Tensor
+    block_size: int
+    cache_role: str
+
+
+class AscendIndexerKPoolStateMetadataBuilder(AttentionMetadataBuilder):
+    """Build independent metadata for the GLM-Next compressor state."""
+
+    @classmethod
+    def get_cudagraph_support(
+        cls,
+        vllm_config: VllmConfig,
+        kv_cache_spec,
+    ) -> AttentionCGSupport:
+        # Full-graph state writes use the fixed-shape sentinel path. Do not let
+        # the base class default NEVER downgrade FULL_DECODE_ONLY for the main
+        # model merely because this cache-only builder is in the cache group.
+        return AttentionCGSupport.UNIFORM_BATCH
+
+    def __init__(
+        self,
+        kv_cache_spec: AscendIndexerKPoolStateSpec,
+        layer_names: list[str],
+        vllm_config: VllmConfig,
+        device: torch.device,
+    ) -> None:
+        if not isinstance(kv_cache_spec, AscendIndexerKPoolStateSpec):
+            raise TypeError(
+                "Ascend Indexer KPool state backend requires "
+                f"AscendIndexerKPoolStateSpec, got {type(kv_cache_spec).__name__}."
+            )
+        super().__init__(kv_cache_spec, layer_names, vllm_config, device)
+        self.block_size = kv_cache_spec.block_size
+        self.cache_role = kv_cache_spec.cache_role
+
+    def build(
+        self,
+        common_prefix_len: int,
+        common_attn_metadata: CommonAttentionMetadata,
+        fast_build: bool = False,
+        **kwargs,
+    ) -> AscendIndexerKPoolStateMetadata:
+        del common_prefix_len, fast_build, kwargs
+        num_reqs = common_attn_metadata.num_reqs
+        num_input_tokens = common_attn_metadata.num_input_tokens
+        return AscendIndexerKPoolStateMetadata(
+            block_table=common_attn_metadata.block_table_tensor[:num_reqs],
+            slot_mapping=common_attn_metadata.slot_mapping[:num_input_tokens],
+            block_size=self.block_size,
+            cache_role=self.cache_role,
+        )
+
+
+class AscendIndexerKPoolStateBackend(AttentionBackend):
+    """Cache-only backend for the GLM-Next compressor state."""
+
+    @staticmethod
+    def get_impl_cls():
+        return None
+
+    @staticmethod
+    def get_name() -> str:
+        return "ASCEND_INDEXER_KPOOL_STATE"
+
+    @staticmethod
+    def get_supported_kernel_block_sizes() -> list[int | MultipleOf]:
+        # The state page follows index_kpool and is independent of SFA C128.
+        return [MultipleOf(1)]
+
+    @staticmethod
+    def get_builder_cls() -> type[AscendIndexerKPoolStateMetadataBuilder]:
+        return AscendIndexerKPoolStateMetadataBuilder
+
+    @staticmethod
+    def get_kv_cache_shape(
+        num_blocks: int,
+        block_size: int,
+        num_kv_heads: int,
+        head_size: int,
+        cache_type: str = "",
+    ) -> tuple[int, ...]:
+        del cache_type
+        if num_kv_heads != 1:
+            raise ValueError(f"Indexer KPool state cache requires one KV head, got {num_kv_heads}.")
+        return (num_blocks, block_size, head_size)

--- a/vllm_ascend/attention/utils.py
+++ b/vllm_ascend/attention/utils.py
@@ -22,18 +22,6 @@ from vllm_ascend.utils import (
 SFA_QSFA_TILE_SIZE = 128
 MLAPO_MAX_SUPPORTED_TOKENS = 1024
 
-_GLM5_NEXT_KPOOL_CACHE_TYPES = frozenset({"Glm5NextIndexerCache", "Glm5NextTailCache"})
-
-
-def is_glm5_next_kpool_cache(attn_module: Any) -> bool:
-    """Return True for GLM-5.3-Flash kpool indexer / tail cache layers.
-
-    Those classes subclass DeepseekV32IndexerCache but keep their own
-    ``compress_ratio`` / ``KpoolTailSpec`` layouts. The DeepSeek V3.2 SFA
-    rewrite must not replace them with ``AscendSFAIndexerCacheSpec``.
-    """
-    return type(attn_module).__name__ in _GLM5_NEXT_KPOOL_CACHE_TYPES
-
 
 def get_or_register_attention_buffer(
     vllm_config: VllmConfig,

--- a/vllm_ascend/core/kv_cache_interface.py
+++ b/vllm_ascend/core/kv_cache_interface.py
@@ -1,8 +1,8 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
+import copy
 from dataclasses import dataclass, replace
-from typing import Any
 
 import torch
 from typing_extensions import Self
@@ -20,6 +20,13 @@ from vllm.v1.kv_cache_interface import (
 from vllm.v1.kv_cache_spec_registry import KVCacheSpecRegistry
 
 from vllm_ascend.utils import vllm_version_is
+
+
+def get_kv_cache_compression_ratio(kv_cache_spec: KVCacheSpec) -> int:
+    """Return the MLA compression ratio across vLLM cache-spec APIs."""
+    if vllm_version_is("0.28.0"):
+        return kv_cache_spec.compress_ratio
+    return kv_cache_spec.tokens_per_state
 
 
 def get_storage_block_size(kv_cache_spec: KVCacheSpec) -> int:
@@ -49,6 +56,10 @@ class AscendMLAAttentionSpec(MLAAttentionSpec):
     # indexer spec.
     cache_sparse_sfa_c8: bool = False
     store_on_host: bool = False
+    # Ascend kernels consume padded pages through an explicit physical block
+    # stride. vLLM main removed this field from AttentionSpec, but it remains
+    # part of the Ascend runner/backend contract.
+    indexes_kv_by_block_stride: bool = False
 
     @property
     def storage_block_size(self) -> int:
@@ -86,7 +97,8 @@ class AscendMLAAttentionSpec(MLAAttentionSpec):
                 spec.cache_sparse_sfa_c8,
                 spec.store_on_host,
                 spec.alignment,
-                spec.compress_ratio if vllm_version_is("0.28.0") else spec.tokens_per_state,
+                get_kv_cache_compression_ratio(spec),
+                spec.indexes_kv_by_block_stride,
             )
             for spec in specs
         }
@@ -99,11 +111,6 @@ class AscendMLAAttentionSpec(MLAAttentionSpec):
         )
         first_spec = specs[0]
         merged = super().merge(specs)
-        # vLLM #51718 removed AttentionSpec.indexes_kv_by_block_stride on main;
-        # only carry it through on the legacy lane.
-        merged_kwargs: dict[str, Any] = {}
-        if vllm_version_is("0.28.0"):
-            merged_kwargs["indexes_kv_by_block_stride"] = first_spec.indexes_kv_by_block_stride
         return replace(
             merged,
             scale_dim=first_spec.scale_dim,
@@ -111,7 +118,7 @@ class AscendMLAAttentionSpec(MLAAttentionSpec):
             alignment=first_spec.alignment,
             cache_sparse_sfa_c8=first_spec.cache_sparse_sfa_c8,
             store_on_host=first_spec.store_on_host,
-            **merged_kwargs,
+            indexes_kv_by_block_stride=first_spec.indexes_kv_by_block_stride,
         )
 
     def max_memory_usage_bytes(self, vllm_config: VllmConfig) -> int:
@@ -197,6 +204,7 @@ class AscendSlidingWindowMLASpec(SlidingWindowMLASpec):
     alignment: int | None = None  # Default to None for no padding.
     compress_ratio: int = 1
     model_version: str | None = None
+    indexes_kv_by_block_stride: bool = False
 
     def __post_init__(self):
         pass
@@ -241,6 +249,38 @@ class AscendSlidingWindowMLASpec(SlidingWindowMLASpec):
         )
 
 
+@dataclass(frozen=True, kw_only=True)
+class AscendIndexerKPoolStateSpec(AscendSlidingWindowMLASpec):
+    """Paged FP32 state used by an indexer K-pool compressor."""
+
+    cache_role: str = "indexer_state"
+
+    def __post_init__(self) -> None:
+        super().__post_init__()
+        if self.dtype != torch.float32:
+            raise ValueError(f"Indexer K-pool compressor state must use FP32, got {self.dtype}.")
+        if self.block_size != self.sliding_window:
+            raise ValueError(
+                "Indexer K-pool compressor state requires block_size == "
+                f"sliding_window, got {self.block_size} and {self.sliding_window}."
+            )
+
+    @classmethod
+    def merge(cls, specs: list[Self]) -> Self:
+        assert all(isinstance(spec, cls) for spec in specs)
+        assert all(spec == specs[0] for spec in specs[1:]), (
+            "All indexer K-pool compressor-state layers in one cache group must have the same layout and cache role."
+        )
+        return copy.deepcopy(specs[0])
+
+    def max_memory_usage_bytes(self, vllm_config: VllmConfig) -> int:
+        del vllm_config
+        # The state group keeps only the current incomplete pool. Since its
+        # sliding window and block size are identical, one page per request is
+        # sufficient on every context-parallel rank.
+        return self.page_size_bytes
+
+
 def register_ascend_kv_cache_specs() -> None:
     KVCacheSpecRegistry.register(
         kvcache_spec_cls=AscendMLAAttentionSpec,
@@ -258,11 +298,8 @@ def register_ascend_kv_cache_specs() -> None:
         uniform_type_base_spec=SlidingWindowMLASpec,
     )
 
-    # Imported lazily so this module stays independent of any single model.
-    from vllm_ascend.models.glm5next.kv_cache import KpoolTailManager, KpoolTailSpec
-
     KVCacheSpecRegistry.register(
-        kvcache_spec_cls=KpoolTailSpec,
-        manager_class=KpoolTailManager,
-        uniform_type_base_spec=KpoolTailSpec,
+        kvcache_spec_cls=AscendIndexerKPoolStateSpec,
+        manager_class=SlidingWindowManager,
+        uniform_type_base_spec=SlidingWindowMLASpec,
     )

--- a/vllm_ascend/models/glm5next/attention.py
+++ b/vllm_ascend/models/glm5next/attention.py
@@ -2,7 +2,6 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
 import torch
-import torch.nn.functional as F
 from torch import nn
 from vllm.config import (
     CacheConfig,
@@ -18,188 +17,25 @@ from vllm.model_executor.layers.linear import (
     ReplicatedLinear,
     RowParallelLinear,
 )
-from vllm.model_executor.layers.mla import MLAModules, MultiHeadLatentAttentionWrapper
+from vllm.model_executor.layers.mla import (
+    MLAModules,
+    MultiHeadLatentAttentionWrapper,
+)
 from vllm.model_executor.layers.quantization.base_config import QuantizationConfig
 from vllm.model_executor.layers.rotary_embedding import RotaryEmbedding, get_rope
 from vllm.model_executor.models.deepseek_v2 import (
     DeepSeekV2FusedQkvAProjLinear,
-    DeepseekV32IndexerCache,
     yarn_get_mscale,
 )
-from vllm.model_executor.utils import maybe_disable_graph_partition
-from vllm.platforms import current_platform
-from vllm.v1.kv_cache_interface import MLAAttentionSpec
 
 from vllm_ascend.models.glm5next.config import Glm5NextConfig
-from vllm_ascend.models.glm5next.kv_cache import KpoolTailSpec
-from vllm_ascend.models.glm5next.ops.kpool_compress import fwht128_quant_fp8
-from vllm_ascend.models.glm5next.sparse_attn_indexer_kpool import SparseAttnIndexerKpool
-from vllm_ascend.utils import vllm_version_is
-
-# Paged MQA page sizes the kpool tail cache aligns against. Upstream reads this
-# from `vllm.utils.deep_gemm`, which is a CUDA-only module on Ascend.
-PAGED_MQA_PAGE_SIZES = (32, 64)
-
-# Shared torch.compile config for the indexer's small-kernel leaves. The MLA
-# indexer runs under breakable-CG (CompilationMode.NONE), which blocks FX-graph
-# fusion of the surrounding eager ops; carving each cluster into its own
-# @torch.compile leaf (backend==inductor) still fuses them. Matches the
-# grouped_topk / _cast_sigmoid leaf pattern.
-_INDEXER_COMPILE = dict(
-    dynamic=True,
-    backend=current_platform.simple_compile_backend,
-    options=maybe_disable_graph_partition(current_platform.simple_compile_backend),
+from vllm_ascend.models.glm5next.kv_cache import (
+    Glm5NextIndexerCache,
+    Glm5NextStateCache,
 )
-
-
-@torch.compile(**_INDEXER_COMPILE)
-def _fused_indexer_k_norm(
-    x: torch.Tensor, weight: torch.Tensor, bias: torch.Tensor, dim: int, eps: float
-) -> torch.Tensor:
-    # Fuse fp32 cast + layer_norm + cast-back (was 3 kernels) into one.
-    return F.layer_norm(x.float(), (dim,), weight, bias, eps).type_as(x)
-
-
-@torch.compile(**_INDEXER_COMPILE)
-def _fused_indexer_weight_scale(weights: torch.Tensor, q_scale: torch.Tensor, scale: float) -> torch.Tensor:
-    # Fuse the weight-scaling muls (was 2 kernels) into one. `scale` folds
-    # softmax_scale (head_dim**-0.5) and n_head**-0.5 into a single constant.
-    return (weights.unsqueeze(-1) * q_scale * scale).squeeze(-1)
-
-
-@torch.compile(**_INDEXER_COMPILE)
-def _pad_indexer_heads(x: torch.Tensor, pad: int) -> torch.Tensor:
-    # DeepGEMM MQA-logits needs num_heads in {32,64}; zero-pad the head dim.
-    # Fuse new_zeros + cat (was 2 kernels) into one. Pad values are zero (exact
-    # in fp8 e4m3 and zero-weight in the logits sum), so numerically a no-op.
-    return torch.cat([x, x.new_zeros(x.shape[0], pad, *x.shape[2:])], dim=1)
-
-
-class Glm5NextIndexerCache(DeepseekV32IndexerCache):
-    """Indexer K cache that stores kpool-compressed entries.
-
-    Setting ``compress_ratio`` / ``tokens_per_state`` (= index_kpool) on the KV
-    cache spec makes vLLM's indexer metadata builder emit pool-granular
-    ``slot_mapping`` / ``seq_lens`` / ``cu_seq_lens`` / ``page_table`` for free,
-    and shrinks the cache allocation store one state per ``index_kpool`` tokens.
-    The pool *content* (softmax-weighted sum vs keep-every-Nth) is computed by
-    the kpool compress kernel inside the indexer op — the cache only provides
-    the addressing, which is identical for both schemes.
-
-    The indexer shares one block with the co-located MLA (a single
-    ``MLAAttentionSpec`` / block_table), so ``block_size`` is the model-wide
-    ``cache_config.block_size``. DeepGEMM's paged-MQA kernel
-    (``csrc/apis/attention.hpp``) requires ``block_kv`` to be exactly 32 or
-    64, so the storage block is virtually split into pool pages of the
-    largest such size that tiles it (``storage_kernel_block_size``); this
-    needs ``block_size`` to be a multiple of ``index_kpool * 32`` (512 for
-    ``index_kpool = 16``). A smaller block (e.g. the default 64) silently
-    collapses ``storage_block_size`` (64 // 16 = 4) and only fails later at
-    the opaque C++ assert; ``get_kv_cache_spec`` guards this up front
-    instead.
-    """
-
-    def __init__(
-        self,
-        *,
-        head_dim: int,
-        dtype: torch.dtype,
-        prefix: str,
-        cache_config,
-        index_kpool: int,
-    ):
-        super().__init__(head_dim=head_dim, dtype=dtype, prefix=prefix, cache_config=cache_config)
-        assert index_kpool > 1, "Glm5NextIndexerCache expects index_kpool > 1"
-        # Keep chunked-prefill boundaries aligned to complete pools.
-        assert cache_config.block_size % index_kpool == 0, (
-            "Glm5NextIndexerCache: cache_config.block_size "
-            f"({cache_config.block_size}) must be a multiple of index_kpool "
-            f"({index_kpool}) so chunked-prefill boundaries stay pool-aligned."
-        )
-        self._index_kpool = index_kpool
-
-    def get_kv_cache_spec(self, vllm_config: VllmConfig):
-        from dataclasses import replace
-
-        spec = super().get_kv_cache_spec(vllm_config)
-        # vLLM #51718 renamed MLAAttentionSpec.compress_ratio to
-        # AttentionSpec.tokens_per_state on main; both express kpool compression.
-        assert isinstance(spec, MLAAttentionSpec)
-        if vllm_version_is("0.28.0"):
-            spec = replace(spec, compress_ratio=self._index_kpool)
-        else:
-            spec = replace(spec, tokens_per_state=self._index_kpool)
-
-        # DeepGEMM paged-MQA takes block_kv in {32, 64}; the storage block
-        # (= block_size // index_kpool) is virtually split into pool pages of
-        # the largest such size that tiles it, so it must be a multiple of 32.
-        storage_block_size = spec.block_size // self._index_kpool
-        assert spec.block_size % self._index_kpool == 0 and storage_block_size % 32 == 0, (
-            "Glm5NextIndexerCache: kpool indexer requires cache block_size to "
-            f"be a multiple of index_kpool * 32 ({self._index_kpool * 32}) so "
-            "that DeepGEMM paged-MQA pool pages (32 or 64 entries) tile the "
-            f"storage block, got block_size={spec.block_size} -> "
-            f"storage_block_size={storage_block_size}."
-        )
-        max_page_size = max(PAGED_MQA_PAGE_SIZES)
-        min_page_size = min(PAGED_MQA_PAGE_SIZES)
-        if storage_block_size <= max_page_size:
-            page_size = storage_block_size
-        elif storage_block_size % max_page_size == 0:
-            page_size = max_page_size
-        else:
-            page_size = min_page_size
-        return replace(
-            spec,
-            storage_block_size=page_size * self._index_kpool,
-        )
-
-
-class Glm5NextTailCache(DeepseekV32IndexerCache):
-    """Paged circular buffer for the kpool indexer's in-progress (tail) pool.
-
-    Holds the trailing incomplete pool's raw K + gate score: one block of
-    ``index_kpool`` slots per request, overwritten in place by ``pos % kpool``
-    as decode/spec-decode advances. Prefill seeds it (instead of discarding the
-    tail raw K+gate); the connector transfers it across PD; decode reads it to
-    compress the boundary pool correctly. ``KpoolTailSpec`` /
-    ``KpoolTailManager`` provide the no-prune, 1-block/req allocation that lets
-    the in-progress pool survive across steps and across transfer.
-
-    Stores raw bf16 K (``head_dim``) as the "K" half of each block and the
-    bf16 gate score (``head_dim``) as the "V" half -- not the fp8-compressed
-    entry, which lives in ``Glm5NextIndexerCache``.
-    """
-
-    def __init__(
-        self,
-        *,
-        head_dim: int,
-        dtype: torch.dtype,
-        prefix: str,
-        cache_config,
-        index_kpool: int,
-    ):
-        super().__init__(head_dim=head_dim, dtype=dtype, prefix=prefix, cache_config=cache_config)
-        assert index_kpool > 1, "Glm5NextTailCache expects index_kpool > 1"
-        self._index_kpool = index_kpool
-
-    def get_kv_cache_spec(self, vllm_config: VllmConfig):
-        # The two head slots form [K, gate score] in the generic
-        # [block, head, state, content] cache view.
-        return KpoolTailSpec(
-            block_size=self._index_kpool,
-            num_kv_heads=2,
-            head_size=self.head_dim,
-            head_size_v=0,
-            dtype=torch.bfloat16,
-            sliding_window=self._index_kpool,
-        )
-
-    def get_attn_backend(self):
-        from vllm.v1.attention.backends.mla.indexer import KpoolTailBackend
-
-        return KpoolTailBackend
+from vllm_ascend.models.glm5next.sparse_attn_indexer_kpool import (
+    SparseAttnIndexerKpool,
+)
 
 
 class Indexer(nn.Module):
@@ -226,6 +62,8 @@ class Indexer(nn.Module):
         assert config.index_n_heads is not None
         assert config.index_head_dim is not None
         assert config.index_kpool is not None
+        assert cache_config is not None
+        assert topk_indices_buffer is not None
         self.topk_tokens = config.index_topk
         self.n_head = config.index_n_heads  # 64
         self.head_dim = config.index_head_dim  # 128
@@ -236,7 +74,7 @@ class Indexer(nn.Module):
         # kpool
         self.index_kpool_compress_ape = nn.Parameter(torch.zeros(self.index_kpool, self.head_dim, dtype=torch.float32))
         # Keep the checkpoint name ``index_kpool_compress_gate`` without a
-        # ``.weight`` suffix. F.linear consumes its [head_dim, hidden_size] shape.
+        # ``.weight`` suffix. torch.mm consumes its [head_dim, hidden_size] shape.
         self.index_kpool_compress_gate = nn.Parameter(torch.empty(self.head_dim, hidden_size, dtype=torch.bfloat16))
 
         # no tensor parallel, just replicated
@@ -259,35 +97,31 @@ class Indexer(nn.Module):
         )
         self.k_norm = LayerNorm(self.head_dim, eps=1e-6)
         self.softmax_scale = self.head_dim**-0.5
-
-        # Hadamard-128 rotation of the indexer query is fused with the FP8
-        # quant (see forward: fwht128_quant_fp8) -- no precomputed matrix.
-
-        self.scale_fmt = "ue8m0"
-        self.quant_block_size = 128  # TODO: get from config
+        self.scale_fmt = None
+        self.quant_block_size = self.head_dim
         self.topk_indices_buffer = topk_indices_buffer
-        self._wp_fp32: torch.Tensor | None = None
+        # FP32 weight copies for the fp32 K/gate/weights projections. Cached
+        # lazily after the checkpoint weights are loaded so the quantitative
+        # work of the first forward matches the last.
+        self._wk_weight_f32: torch.Tensor | None = None
+        self._gate_weight_f32: torch.Tensor | None = None
 
-        # NOTE: (zyongye) we use fp8 naive cache,
-        #       where we store value in fp8 and scale in fp32
-        #       per self.quant_block_size element
+        # Completed pools store BF16 vectors without quantization scales.
         self.k_cache = Glm5NextIndexerCache(
-            head_dim=self.head_dim + self.head_dim // self.quant_block_size * 4,
-            dtype=torch.uint8,
-            prefix=f"{prefix}.k_cache",
-            cache_config=cache_config,
-            index_kpool=self.index_kpool,
-        )
-        # Paged tail cache (in-progress pool's raw K + gate score). Written by
-        # prefill (seeds the boundary pool) and decode (per-step stash); read by
-        # the decode kernel to compress the boundary pool. Transferred across PD
-        # so the decode side sees the prefill tail. See KpoolTailSpec/Manager.
-        self.tail_cache = Glm5NextTailCache(
             head_dim=self.head_dim,
             dtype=torch.bfloat16,
-            prefix=f"{prefix}.tail_cache",
+            cache_role="indexer",
+            prefix=f"{prefix}.k_cache",
             cache_config=cache_config,
-            index_kpool=self.index_kpool,
+            compress_ratio=self.index_kpool,
+        )
+        # Absolute-position FP32 K/gate pages retain the incomplete pool.
+        self.state_cache = Glm5NextStateCache(
+            state_dim=2 * self.head_dim,
+            dtype=torch.float32,
+            prefix=f"{prefix}.compressor.state_cache",
+            cache_config=cache_config,
+            compress_ratio=self.index_kpool,
         )
         self.max_model_len = vllm_config.model_config.max_model_len
         self.prefix = prefix
@@ -303,73 +137,67 @@ class Indexer(nn.Module):
             self.max_model_len,
             self.max_total_seq_len,
             self.topk_indices_buffer,
-            tail_cache=self.tail_cache,
+            tail_cache=self.state_cache,
         )
 
-    def forward(self, hidden_states: torch.Tensor, qr: torch.Tensor, positions, rotary_emb) -> torch.Tensor:
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+        qr: torch.Tensor,
+        positions,
+        rotary_emb,
+    ) -> torch.Tensor:
+        # Match glm-next-0806's kpool contract: the scoring chain consumes a
+        # raw bf16 Q (no FWHT/fp8 rotation), an fp32 K that survives the norm
+        # and the compressed-K insertion, raw head weights scaled only by the
+        # softmax/head factors, and an fp32 gate. FP32 K/gate keep near-tie
+        # pool rankings stable on long-context tasks.
         q, _ = self.wq_b(qr)
         q = q.view(-1, self.n_head, self.head_dim)
 
-        # Compute the head gate in fp32; bf16 error can change near-tie pool
-        # rankings on long-context tasks. Cache it after weights are loaded.
-        kw, _ = self.wk_weights_proj(hidden_states)
-        k = kw[:, : self.head_dim]
-        if self._wp_fp32 is None:
-            self._wp_fp32 = self.wk_weights_proj.weight.data[self.head_dim :, :].t().contiguous().float()
-        weights = torch.mm(hidden_states.float(), self._wp_fp32)
-
-        k = _fused_indexer_k_norm(k, self.k_norm.weight, self.k_norm.bias, self.head_dim, self.k_norm.eps)
+        hidden_f32 = hidden_states.float()
+        if self._wk_weight_f32 is None:
+            self._wk_weight_f32 = self.wk_weights_proj.weight.detach().float()
+            self._gate_weight_f32 = self.index_kpool_compress_gate.detach().float()
+        kw = torch.mm(hidden_f32, self._wk_weight_f32.t())
+        weights = kw[:, self.head_dim :].to(torch.bfloat16)
+        k = self.k_norm(kw[:, : self.head_dim])
 
         if self.rope_dim > 0:
             q_pe, q_nope = torch.split(q, [self.rope_dim, self.head_dim - self.rope_dim], dim=-1)
-            k_pe, k_nope = torch.split(k, [self.rope_dim, self.head_dim - self.rope_dim], dim=-1)
-
+            k_pe, k_nope = torch.split(
+                k,
+                [self.rope_dim, self.head_dim - self.rope_dim],
+                dim=-1,
+            )
+            # RoPE runs on the bf16 half; the nope half keeps fp32 so the cache
+            # write matches the FP32 state the compressor reads back.
+            k_pe = k_pe.to(torch.bfloat16)
             q_pe, k_pe = rotary_emb(positions, q_pe, k_pe.unsqueeze(1))
             # Note: RoPE (NeoX) can introduce extra leading dimensions during
-            # compilation so we need to reshape back to token-flattened shapes
+            # compilation so we need to reshape back to token-flattened shapes.
             q_pe = q_pe.reshape(-1, self.n_head, self.rope_dim)
-            k_pe = k_pe.reshape(-1, 1, self.rope_dim)
-
+            k_pe = k_pe.reshape(-1, 1, self.rope_dim).float()
             # `rotary_emb` is shape-preserving; `q_pe` is already
             # [num_tokens, n_head, rope_dim].
             q = torch.cat([q_pe, q_nope], dim=-1)
-            # `k_pe` is [num_tokens, 1, rope_dim] (MQA).
+            # `k_pe` is [num_tokens, 1, rope_dim] (MQA); keep the pe rounded to
+            # bf16 but embed it back into the fp32 K row.
             k = torch.cat([k_pe.squeeze(-2), k_nope], dim=-1)
         # else: qk_rope_head_dim=0 — no rope component. q is already
         # [num_tokens, n_head, head_dim] and k is [num_tokens, head_dim] (all
         # nope), so skip the rope split / rotary / cat entirely; otherwise the
         # split/reshape would build 0-element tensors (breaks dynamo tracing).
 
-        # Rotate Q into the cached K basis before computing fp8 MQA logits.
-        # Fusing the fp32 FWHT and quantization avoids an intermediate HBM
-        # round-trip and bf16 matrix-rounding bias.
-        assert self.head_dim == 128 and self.quant_block_size == 128
-        assert self.scale_fmt == "ue8m0"
-        q = q.view(-1, self.head_dim)
-        q_fp8, q_scale = fwht128_quant_fp8(q)
-        q_fp8 = q_fp8.view(-1, self.n_head, self.head_dim)
-        q_scale = q_scale.view(-1, self.n_head, 1)
-
-        weights = _fused_indexer_weight_scale(weights, q_scale, self.softmax_scale * self.n_head**-0.5)
-
-        # kpool: per-token gate score driving the softmax-weighted pool. Computed
-        # from the same hidden_states that produced `k`, so it stays token-aligned.
-        # F.linear(x, gate) = x @ gate.T  with gate [head_dim, hidden_size].
-        gate_score = F.linear(hidden_states, self.index_kpool_compress_gate)
-
-        # DeepGEMM's MQA-logits kernels (fp8_mqa_logits /
-        # fp8_fp4_paged_mqa_logits) require num_heads in {32, 64}; this
-        # checkpoint uses index_n_heads=16. Zero-pad q and the per-head
-        # weights: logits are a weights-weighted sum over heads, so
-        # zero-weight padded heads contribute exactly nothing.
-        if self.n_head < 32:
-            pad = 32 - self.n_head
-            q_fp8 = _pad_indexer_heads(q_fp8, pad)
-            weights = _pad_indexer_heads(weights, pad)
+        q = q.to(torch.bfloat16)
+        weights = weights * (self.softmax_scale * self.n_head**-0.5)
+        gate_weight_f32 = self._gate_weight_f32
+        assert gate_weight_f32 is not None
+        gate_score = torch.mm(hidden_f32, gate_weight_f32.t())
 
         return self.indexer_op(
             hidden_states,
-            q_fp8,
+            q,
             k,
             weights,
             gate_score=gate_score,
@@ -556,6 +384,13 @@ class Glm5NextMLAAttention(nn.Module):
             skip_topk=False,
             fuse_qkv_rmsnorm=True,
         )
+        # The pluggable MLA wrapper owns the AttentionLayerBase registered in
+        # the static forward context. Publish GLM-Next's cache contract on that
+        # layer, matching the dedicated cache layer used by the source branch,
+        # so the model runner can remain model agnostic.
+        mla_cache_layer = self.mla_attn.mla_attn
+        mla_cache_layer.model_version = "glm5_next"
+        mla_cache_layer.indexes_kv_by_block_stride = True
 
     def forward(self, hidden_states: torch.Tensor, positions: torch.Tensor) -> torch.Tensor:
         # The wrapper also runs the sparse indexer before MLA attention.

--- a/vllm_ascend/models/glm5next/cache_config.py
+++ b/vllm_ascend/models/glm5next/cache_config.py
@@ -1,0 +1,458 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""GLM-Next cache groups and source-compatible physical pool layout.
+
+The main MLA cache and compressed indexer cache share scheduler block IDs,
+while compressor state and every KDA/Mamba group allocate IDs independently.
+Physical storage uses standard unpacked KV cache descriptors with two page-size
+classes: main MLA/KDA pages and compressed-indexer/state pages.
+"""
+
+from dataclasses import dataclass
+
+from vllm.config import VllmConfig
+from vllm.model_executor.models.utils import extract_layer_index
+from vllm.v1.core.kv_cache_utils import (
+    create_kv_cache_group_specs,
+    may_override_num_blocks,
+)
+from vllm.v1.kv_cache_interface import (
+    KVCacheConfig,
+    KVCacheGroupSpec,
+    KVCacheSpec,
+    KVCacheTensor,
+    MambaSpec,
+    MLAAttentionSpec,
+    SlidingWindowMLASpec,
+    UniformTypeKVCacheSpecs,
+)
+
+from vllm_ascend.core.kv_cache_interface import get_kv_cache_compression_ratio
+from vllm_ascend.utils import vllm_version_is
+
+
+@dataclass(frozen=True)
+class _Glm5NextCacheLayout:
+    full_group: KVCacheGroupSpec
+    state_group: KVCacheGroupSpec
+    mamba_groups: tuple[KVCacheGroupSpec, ...]
+    mla_names: tuple[str, ...]
+    indexer_names: tuple[str, ...]
+    state_names: tuple[str, ...]
+    main_page_size: int
+    small_page_size: int
+    main_slot_count: int
+    small_slot_count: int
+
+
+def _is_glm5_next_spec(spec: KVCacheSpec) -> bool:
+    return getattr(spec, "model_version", None) == "glm5_next"
+
+
+def _unpadded_page_size(spec: KVCacheSpec) -> int:
+    if hasattr(spec, "unpadded_page_size_bytes"):
+        return spec.unpadded_page_size_bytes
+    if hasattr(spec, "real_page_size_bytes"):
+        return spec.real_page_size_bytes
+    return spec.page_size_bytes
+
+
+def _sorted_layer_names(layer_names: list[str]) -> tuple[str, ...]:
+    try:
+        return tuple(sorted(layer_names, key=extract_layer_index))
+    except ValueError:
+        # Synthetic layer names used by callers or tests need not contain an
+        # integer model-layer index. Preserve their registration order.
+        return tuple(layer_names)
+
+
+def _layer_indices(layer_names: tuple[str, ...]) -> tuple[int, ...] | None:
+    try:
+        return tuple(extract_layer_index(name) for name in layer_names)
+    except ValueError:
+        return None
+
+
+def _is_glm5_next_main_spec(spec: KVCacheSpec) -> bool:
+    return isinstance(spec, MLAAttentionSpec) and _is_glm5_next_spec(spec) and get_kv_cache_compression_ratio(spec) == 1
+
+
+def _is_glm5_next_indexer_spec(spec: KVCacheSpec) -> bool:
+    return isinstance(spec, MLAAttentionSpec) and _is_glm5_next_spec(spec) and get_kv_cache_compression_ratio(spec) > 1
+
+
+def _is_glm5_next_state_spec(spec: KVCacheSpec) -> bool:
+    return (
+        isinstance(spec, SlidingWindowMLASpec)
+        and _is_glm5_next_spec(spec)
+        and getattr(spec, "cache_role", None) == "indexer_state"
+    )
+
+
+def _align_glm5_next_cache_specs(kv_cache_spec: dict[str, KVCacheSpec]) -> None:
+    """Align GLM-Next specs into two physical page-size classes in-place."""
+
+    main_specs = [spec for spec in kv_cache_spec.values() if _is_glm5_next_main_spec(spec)]
+    indexer_specs = [spec for spec in kv_cache_spec.values() if _is_glm5_next_indexer_spec(spec)]
+    state_specs = [spec for spec in kv_cache_spec.values() if _is_glm5_next_state_spec(spec)]
+    mamba_specs = [spec for spec in kv_cache_spec.values() if isinstance(spec, MambaSpec)]
+
+    if not main_specs and not indexer_specs and not state_specs:
+        return
+    if not main_specs or not indexer_specs or not state_specs:
+        raise ValueError("GLM-Next cache layout requires main MLA, compressed indexer, and compressor-state specs.")
+
+    main_candidates = (*main_specs, *mamba_specs)
+    main_page_size = max(
+        max(spec.page_size_bytes for spec in main_candidates),
+        max(_unpadded_page_size(spec) for spec in main_candidates),
+    )
+    small_candidates = (*indexer_specs, *state_specs)
+    small_page_size = max(
+        max(spec.page_size_bytes for spec in small_candidates),
+        max(_unpadded_page_size(spec) for spec in small_candidates),
+    )
+
+    for spec in main_candidates:
+        object.__setattr__(spec, "page_size_padded", main_page_size)
+    for spec in small_candidates:
+        object.__setattr__(spec, "page_size_padded", small_page_size)
+
+
+def _create_glm5_next_attention_groups(
+    kv_cache_spec: dict[str, KVCacheSpec],
+) -> list[KVCacheGroupSpec]:
+    """Create the shared full-history group and separate state group."""
+
+    main_names = _sorted_layer_names([name for name, spec in kv_cache_spec.items() if _is_glm5_next_main_spec(spec)])
+    indexer_names = _sorted_layer_names(
+        [name for name, spec in kv_cache_spec.items() if _is_glm5_next_indexer_spec(spec)]
+    )
+    state_names = _sorted_layer_names([name for name, spec in kv_cache_spec.items() if _is_glm5_next_state_spec(spec)])
+
+    classified_names = {*main_names, *indexer_names, *state_names}
+    if classified_names != set(kv_cache_spec):
+        raise ValueError("GLM-Next KV cache specs contain an unsupported cache role.")
+    if not (len(main_names) == len(indexer_names) == len(state_names) > 0):
+        raise ValueError(
+            "Every GLM-Next MLA layer requires one main MLA, compressed indexer, and compressor-state cache."
+        )
+
+    main_indices = _layer_indices(main_names)
+    if main_indices is not None and (
+        main_indices != _layer_indices(indexer_names) or main_indices != _layer_indices(state_names)
+    ):
+        raise ValueError("GLM-Next MLA, indexer, and state cache layer indices do not match.")
+
+    full_block_sizes = {kv_cache_spec[name].block_size for name in (*main_names, *indexer_names)}
+    if len(full_block_sizes) != 1:
+        raise ValueError("GLM-Next main MLA and compressed indexer caches must use one logical block size.")
+
+    for main_name, indexer_name, state_name in zip(main_names, indexer_names, state_names):
+        main_spec = kv_cache_spec[main_name]
+        indexer_spec = kv_cache_spec[indexer_name]
+        state_spec = kv_cache_spec[state_name]
+        assert isinstance(main_spec, MLAAttentionSpec)
+        assert isinstance(indexer_spec, MLAAttentionSpec)
+        assert isinstance(state_spec, SlidingWindowMLASpec)
+
+        compress_ratio = get_kv_cache_compression_ratio(indexer_spec)
+        if main_spec.block_size % compress_ratio:
+            raise ValueError(
+                "GLM-Next logical block size must be divisible by the indexer "
+                f"compression ratio: block_size={main_spec.block_size}, "
+                f"compress_ratio={compress_ratio}."
+            )
+        if state_spec.block_size != compress_ratio or state_spec.sliding_window != compress_ratio:
+            raise ValueError(
+                f"GLM-Next indexer state block/window size must equal the paired compression ratio {compress_ratio}."
+            )
+
+    # Main and indexer caches deliberately share scheduler block IDs. Keep a
+    # main spec first because the scheduler unwraps the first nested spec and
+    # must select FullAttentionManager for this combined group.
+    full_names = [
+        name for main_name, indexer_name in zip(main_names, indexer_names) for name in (main_name, indexer_name)
+    ]
+    full_specs = {name: kv_cache_spec[name] for name in full_names}
+    full_uniform_spec = UniformTypeKVCacheSpecs.from_specs(full_specs)
+    if full_uniform_spec is None:
+        raise ValueError(
+            "GLM-Next main MLA and compressed indexer caches must have uniform full-attention block-table semantics."
+        )
+
+    state_specs = {name: kv_cache_spec[name] for name in state_names}
+    state_uniform_spec = UniformTypeKVCacheSpecs.from_specs(state_specs)
+    if state_uniform_spec is None:
+        raise ValueError("GLM-Next compressor-state caches must have uniform sliding-window block-table semantics.")
+
+    return [
+        KVCacheGroupSpec(full_names, full_uniform_spec),
+        KVCacheGroupSpec(list(state_names), state_uniform_spec),
+    ]
+
+
+def _get_glm5_next_cache_layout(
+    kv_cache_groups: list[KVCacheGroupSpec],
+) -> _Glm5NextCacheLayout | None:
+    """Recognize validated GLM-Next groups and derive physical slot counts."""
+
+    if not kv_cache_groups:
+        return None
+
+    full_groups: list[KVCacheGroupSpec] = []
+    state_groups: list[KVCacheGroupSpec] = []
+    mamba_groups: list[KVCacheGroupSpec] = []
+    for group in kv_cache_groups:
+        group_spec = group.kv_cache_spec
+        if isinstance(group_spec, MambaSpec):
+            mamba_groups.append(group)
+            continue
+        if not isinstance(group_spec, UniformTypeKVCacheSpecs):
+            continue
+
+        values = list(group_spec.kv_cache_specs.values())
+        if (
+            values
+            and all(isinstance(spec, MLAAttentionSpec) and _is_glm5_next_spec(spec) for spec in values)
+            and any(_is_glm5_next_main_spec(spec) for spec in values)
+            and any(_is_glm5_next_indexer_spec(spec) for spec in values)
+        ):
+            full_groups.append(group)
+        elif values and all(_is_glm5_next_state_spec(spec) for spec in values):
+            state_groups.append(group)
+
+    has_glm5_next_group = bool(full_groups or state_groups)
+    if not has_glm5_next_group:
+        return None
+    if len(full_groups) != 1 or len(state_groups) != 1:
+        raise ValueError(
+            "GLM-Next requires exactly one combined main/indexer group and one compressor-state KV cache group."
+        )
+    if len(full_groups) + len(state_groups) + len(mamba_groups) != len(kv_cache_groups):
+        raise ValueError("GLM-Next KV cache groups contain an unsupported cache spec.")
+
+    full_group = full_groups[0]
+    state_group = state_groups[0]
+    assert isinstance(full_group.kv_cache_spec, UniformTypeKVCacheSpecs)
+    assert isinstance(state_group.kv_cache_spec, UniformTypeKVCacheSpecs)
+    full_specs = full_group.kv_cache_spec.kv_cache_specs
+    state_specs = state_group.kv_cache_spec.kv_cache_specs
+    mla_names = _sorted_layer_names(
+        [name for name in full_group.layer_names if _is_glm5_next_main_spec(full_specs[name])]
+    )
+    indexer_names = _sorted_layer_names(
+        [name for name in full_group.layer_names if _is_glm5_next_indexer_spec(full_specs[name])]
+    )
+    state_names = _sorted_layer_names(state_group.layer_names)
+    if not (len(mla_names) == len(indexer_names) == len(state_names)):
+        raise ValueError("Every GLM-Next MLA layer must own one compressed indexer and one compressor-state cache.")
+    mla_indices = _layer_indices(mla_names)
+    if mla_indices is not None and (
+        mla_indices != _layer_indices(indexer_names) or mla_indices != _layer_indices(state_names)
+    ):
+        raise ValueError("GLM-Next MLA, indexer, and state cache layer indices do not match.")
+
+    # Pipeline-parallel projection keeps empty groups with their global spec.
+    # Derive the two canonical page classes from the retained specs, while the
+    # slot counts below use only this worker's projected layer names.
+    main_page_sizes = {spec.page_size_bytes for spec in full_specs.values() if _is_glm5_next_main_spec(spec)} | {
+        group.kv_cache_spec.page_size_bytes for group in mamba_groups
+    }
+    small_page_sizes = {spec.page_size_bytes for spec in full_specs.values() if _is_glm5_next_indexer_spec(spec)} | {
+        spec.page_size_bytes for spec in state_specs.values()
+    }
+    if len(main_page_sizes) != 1 or len(small_page_sizes) != 1:
+        raise ValueError("GLM-Next cache specs were not aligned to two physical page sizes.")
+
+    main_slot_count = max(
+        (
+            len(mla_names),
+            *(len(group.layer_names) for group in mamba_groups),
+        )
+    )
+    return _Glm5NextCacheLayout(
+        full_group=full_group,
+        state_group=state_group,
+        mamba_groups=tuple(mamba_groups),
+        mla_names=mla_names,
+        indexer_names=indexer_names,
+        state_names=state_names,
+        main_page_size=next(iter(main_page_sizes)),
+        small_page_size=next(iter(small_page_sizes)),
+        main_slot_count=main_slot_count,
+        small_slot_count=len(indexer_names),
+    )
+
+
+def _group_glm5_next_mamba_layer_names(
+    kv_cache_spec: dict[str, KVCacheSpec],
+    mamba_specs: dict[str, MambaSpec],
+) -> list[list[str]]:
+    """Recover recurrent runs without depending on spec insertion order."""
+
+    layer_is_mamba: dict[int, bool] = {}
+    mamba_name_by_index: dict[int, str] = {}
+    for name in kv_cache_spec:
+        try:
+            layer_idx = extract_layer_index(name)
+        except ValueError as exc:
+            raise ValueError(
+                f"GLM-Next Mamba grouping requires layer names with numeric indices, got {name!r}."
+            ) from exc
+
+        is_mamba = name in mamba_specs
+        previous_kind = layer_is_mamba.setdefault(layer_idx, is_mamba)
+        if previous_kind != is_mamba:
+            raise ValueError(
+                f"A GLM-Next model layer cannot contain both Mamba and MLA cache specs: layer index {layer_idx}."
+            )
+        if is_mamba:
+            if layer_idx in mamba_name_by_index:
+                raise ValueError(
+                    f"A GLM-Next model layer must own exactly one Mamba cache spec: layer index {layer_idx}."
+                )
+            mamba_name_by_index[layer_idx] = name
+
+    max_run_length = 0
+    run_length = 0
+    previous_layer_idx: int | None = None
+    for layer_idx in sorted(layer_is_mamba):
+        is_consecutive = previous_layer_idx is not None and layer_idx == previous_layer_idx + 1
+        if layer_is_mamba[layer_idx]:
+            run_length = run_length + 1 if is_consecutive else 1
+            max_run_length = max(max_run_length, run_length)
+        else:
+            run_length = 0
+        previous_layer_idx = layer_idx
+
+    if max_run_length == 0:
+        raise ValueError("GLM-Next Mamba specs were provided but no Mamba layers were found.")
+
+    sorted_mamba_names = [mamba_name_by_index[index] for index in sorted(mamba_name_by_index)]
+    return [sorted_mamba_names[offset::max_run_length] for offset in range(max_run_length)]
+
+
+def _create_mamba_groups(
+    mamba_specs: dict[str, MambaSpec],
+    grouped_layer_names: list[list[str]],
+) -> list[KVCacheGroupSpec]:
+    sorted_groups = [list(_sorted_layer_names(layer_names)) for layer_names in grouped_layer_names]
+    return create_kv_cache_group_specs(mamba_specs, sorted_groups)
+
+
+def get_glm5_next_kv_cache_groups(
+    vllm_config: VllmConfig,
+    kv_cache_spec: dict[str, KVCacheSpec],
+) -> list[KVCacheGroupSpec]:
+    """Build GLM-Next scheduler groups and align their physical page sizes."""
+
+    if not any(_is_glm5_next_spec(spec) for spec in kv_cache_spec.values()):
+        raise ValueError("Expected GLM-Next cache specs.")
+
+    scheduler_config = getattr(vllm_config, "scheduler_config", None)
+    if getattr(scheduler_config, "disable_hybrid_kv_cache_manager", False):
+        raise ValueError("GLM-Next's paired MLA/indexer and sliding state layout requires the hybrid KV cache manager.")
+
+    _align_glm5_next_cache_specs(kv_cache_spec)
+    mamba_specs = {name: spec for name, spec in kv_cache_spec.items() if isinstance(spec, MambaSpec)}
+    attention_specs = {name: spec for name, spec in kv_cache_spec.items() if not isinstance(spec, MambaSpec)}
+    groups = _create_glm5_next_attention_groups(attention_specs)
+    if not mamba_specs:
+        # The standalone MTP runner has the same attention/state pairing but
+        # no recurrent groups.
+        return groups
+
+    grouped_names = _group_glm5_next_mamba_layer_names(kv_cache_spec, mamba_specs)
+    groups.extend(_create_mamba_groups(mamba_specs, grouped_names))
+    return groups
+
+
+def get_glm5_next_pool_bytes_per_block(groups: list[KVCacheGroupSpec]) -> int:
+    """Return physical bytes represented by one global block ID."""
+
+    layout = _get_glm5_next_cache_layout(groups)
+    if layout is None:
+        raise ValueError("Expected GLM-Next cache groups.")
+    return layout.main_slot_count * layout.main_page_size + layout.small_slot_count * layout.small_page_size
+
+
+def get_glm5_next_kv_cache_config(
+    vllm_config: VllmConfig,
+    groups: list[KVCacheGroupSpec],
+    available_memory: int,
+) -> KVCacheConfig:
+    """Describe one standard unpacked tensor per physical cache slot."""
+
+    layout = _get_glm5_next_cache_layout(groups)
+    if layout is None:
+        raise ValueError("Expected GLM-Next cache groups.")
+
+    bytes_per_block = get_glm5_next_pool_bytes_per_block(groups)
+    num_blocks = may_override_num_blocks(vllm_config, max(available_memory // bytes_per_block, 0))
+    tensors: list[KVCacheTensor] = []
+
+    def make_tensor(size: int, layer_names: list[str], page_size: int) -> KVCacheTensor:
+        if vllm_version_is("0.28.0"):
+            return KVCacheTensor(size=size, shared_by=layer_names)
+        return KVCacheTensor(
+            size=size,
+            layers=layer_names,
+            offset=0,
+            layer_stride=0,
+            block_stride=page_size,
+        )
+
+    # Layers in independent scheduler groups can reuse the same physical slot
+    # because their block IDs are allocated independently. A standard unpacked
+    # descriptor lets the existing model-runner allocator create one backing
+    # tensor per slot without a model-specific allocation path.
+    for slot in range(layout.main_slot_count):
+        shared_by: list[str] = []
+        if slot < len(layout.mla_names):
+            shared_by.append(layout.mla_names[slot])
+        for group in layout.mamba_groups:
+            if slot < len(group.layer_names):
+                shared_by.append(group.layer_names[slot])
+        tensors.append(
+            make_tensor(
+                layout.main_page_size * num_blocks,
+                shared_by,
+                layout.main_page_size,
+            )
+        )
+
+    for indexer_name, state_name in zip(layout.indexer_names, layout.state_names):
+        tensors.append(
+            make_tensor(
+                layout.small_page_size * num_blocks,
+                [indexer_name, state_name],
+                layout.small_page_size,
+            )
+        )
+
+    return KVCacheConfig(
+        num_blocks=num_blocks,
+        kv_cache_tensors=tensors,
+        kv_cache_groups=groups,
+    )
+
+
+def get_glm5_next_max_memory_usage(
+    vllm_config: VllmConfig,
+    groups: list[KVCacheGroupSpec],
+) -> int:
+    """Return capacity for GLM-Next's shared global block-id pool."""
+
+    layout = _get_glm5_next_cache_layout(groups)
+    if layout is None:
+        raise ValueError("Expected GLM-Next cache groups.")
+    # Scheduler groups allocate disjoint IDs from the shared global BlockPool.
+    # One request therefore needs enough IDs for every group even though one
+    # physical tensor slot can be reused by layers from different groups.
+    blocks = sum(
+        (group.kv_cache_spec.max_memory_usage_bytes(vllm_config) + group.kv_cache_spec.page_size_bytes - 1)
+        // group.kv_cache_spec.page_size_bytes
+        for group in groups
+    )
+    return blocks * get_glm5_next_pool_bytes_per_block(groups)

--- a/vllm_ascend/models/glm5next/kv_cache.py
+++ b/vllm_ascend/models/glm5next/kv_cache.py
@@ -1,168 +1,169 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
-"""KV cache spec and manager for the GLM-5.3-Flash kpool indexer tail.
+"""KV cache layers and metadata helpers for the GLM-Next pooled indexer."""
 
-The kpool indexer compresses whole pools of ``index_kpool`` tokens into one
-cached vector. The incomplete pool at the end of a sequence has no compressed
-form yet, so its raw K plus gate score lives in a separate one-block scratch
-cache. That block is overwritten in place by ``pos % kpool``, which makes it
-per-request transient state rather than a shareable prefix.
+from typing import Any
 
-Neither the spec nor the manager exists upstream while the GLM-5.3-Flash
-architecture lives downstream, so both are defined here. They are registered
-from ``vllm_ascend.core.kv_cache_interface.register_ascend_kv_cache_specs``,
-which vLLM invokes through the ``register_custom_kv_cache_specs`` platform hook
-after the built-in specs are in place.
-"""
+import torch
+from torch import nn
+from vllm.config import CacheConfig, VllmConfig, get_current_vllm_config
+from vllm.model_executor.layers.attention_layer_base import AttentionLayerBase
+from vllm.v1.kv_cache_interface import KVCacheSpec
 
-from collections.abc import Sequence
-from dataclasses import dataclass
-from typing import ClassVar
-
-from vllm.config import VllmConfig
-from vllm.v1.core.block_pool import BlockPool
-from vllm.v1.core.kv_cache_utils import BlockHashList, KVCacheBlock
-from vllm.v1.core.single_type_kv_cache_manager import FullAttentionManager
-from vllm.v1.kv_cache_interface import KVCacheSpec, SlidingWindowSpec
-from vllm.v1.request import Request
+from vllm_ascend.core.kv_cache_interface import (
+    AscendIndexerKPoolStateSpec,
+    AscendMLAAttentionSpec,
+)
+from vllm_ascend.utils import vllm_version_is
 
 
-class KpoolTailManager(FullAttentionManager):
-    """Fixed 1-block-per-request circular buffer for ``KpoolTailSpec``.
+def is_glm5_next_cache_spec(spec: KVCacheSpec) -> bool:
+    return getattr(spec, "model_version", None) == "glm5_next"
 
-    The tail cache holds the incomplete pool's raw K + gate score: exactly one
-    block of ``kpool`` slots per request, overwritten in place by ``pos % kpool``
-    as decode/spec-decode advances. Prefill seeds it; the connector transfers it
-    across PD; decode reads it to compress the boundary pool correctly.
 
-    This manager allocates that single block on first admission and reuses it
-    for the request's whole lifetime. It never skips, never prunes, never
-    prefix-caches. The no-prune guarantee is load-bearing:
-    ``SlidingWindowManager.remove_skipped_blocks`` would evict the in-progress
-    pool's earlier tokens mid-pool, before completion and before PD transfer,
-    which is fatal. Because the block is circularly reused, allocation is
-    independent of sequence length and of MTP size (MTP > kpool still fits in
-    one block, since completed pools flush mid-step).
-    """
+def format_indexer_kpool_slot_mapping(
+    slot_mapping: torch.Tensor,
+    positions: torch.Tensor,
+    logical_block_size: int,
+    compress_ratio: int,
+) -> torch.Tensor:
+    """Map completed token pools onto the compressed indexer cache."""
+    if compress_ratio <= 1 or logical_block_size <= 0 or logical_block_size % compress_ratio:
+        raise ValueError(
+            f"logical_block_size={logical_block_size} must be divisible by compress_ratio={compress_ratio}."
+        )
+    valid = (slot_mapping >= 0) & (torch.remainder(positions + 1, compress_ratio) == 0)
+    safe_slots = slot_mapping.clamp_min(0)
+    block_ids = torch.div(safe_slots, logical_block_size, rounding_mode="floor")
+    offsets = torch.remainder(safe_slots, logical_block_size)
+    compressed_slots = block_ids * (logical_block_size // compress_ratio) + torch.div(
+        offsets,
+        compress_ratio,
+        rounding_mode="floor",
+    )
+    return torch.where(valid, compressed_slots, torch.full_like(compressed_slots, -1))
 
-    supports_fine_grained_hash_lookup: ClassVar[bool] = False
 
-    @classmethod
-    def find_longest_cache_hit(
-        cls,
-        block_hashes: BlockHashList,
-        max_length: int,
-        kv_cache_group_ids: list[int],
-        block_pool: BlockPool,
-        kv_cache_spec: KVCacheSpec,
-        drop_eagle_block: bool,
-        alignment_tokens: int,
-        dcp_world_size: int = 1,
-        pcp_world_size: int = 1,
-    ) -> tuple[tuple[list[KVCacheBlock], ...], int]:
-        # Tail state is per-request transient (circularly overwritten), so it is
-        # neither shareable nor a stable function of a shareable prefix.
-        return tuple([] for _ in range(len(kv_cache_group_ids))), 0
+class Glm5NextIndexerCache(nn.Module, AttentionLayerBase):
+    """Independently allocated compressed-K cache for the GLM-Next indexer."""
 
-    def cache_blocks(
+    # Auxiliary caches use the GLM-specific small-page class instead of the
+    # generic attention/Mamba page-size class.
+    align_kv_cache_with_mamba = False
+
+    def __init__(
         self,
-        request: Request,
-        num_tokens: int,
-        retention_interval: int | None = None,
+        *,
+        head_dim: int,
+        dtype: torch.dtype,
+        cache_role: str,
+        cache_config: CacheConfig,
+        prefix: str,
+        compress_ratio: int,
     ) -> None:
-        # Never hash tail blocks into the prefix cache.
-        return
+        super().__init__()
+        if compress_ratio <= 1 or cache_config.block_size % compress_ratio:
+            raise ValueError(
+                "GLM-Next indexer cache requires block_size divisible by a "
+                f"compress_ratio greater than one, got {cache_config.block_size} "
+                f"and {compress_ratio}."
+            )
+        self.head_dim = head_dim
+        self.dtype = dtype
+        self.cache_role = cache_role
+        self.cache_config = cache_config
+        self.compress_ratio = compress_ratio
+        self.prefix = prefix
+        current_config = get_current_vllm_config()
+        self.kv_cache = [torch.tensor([]) for _ in range(current_config.parallel_config.pipeline_parallel_size)]
+        static_context = current_config.compilation_config.static_forward_context
+        if prefix in static_context:
+            raise ValueError(f"Duplicate layer name: {prefix}")
+        static_context[prefix] = self
 
-    def get_num_common_prefix_blocks(self, running_request_id: str) -> int:
-        return 0
+    def get_kv_cache_spec(self, vllm_config: VllmConfig) -> KVCacheSpec:
+        del vllm_config
+        ratio_kwargs: dict[str, Any] = (
+            {"compress_ratio": self.compress_ratio}
+            if vllm_version_is("0.28.0")
+            else {"tokens_per_state": self.compress_ratio}
+        )
+        return AscendMLAAttentionSpec(
+            block_size=self.cache_config.block_size,
+            num_kv_heads=1,
+            head_size=self.head_dim,
+            dtype=self.dtype,
+            cache_dtype_str=None,
+            model_version="glm5_next",
+            indexes_kv_by_block_stride=True,
+            **ratio_kwargs,
+        )
 
-    def get_num_skipped_tokens(self, num_computed_tokens: int) -> int:
-        # The single block holds the in-progress pool for the whole request; no
-        # token is ever out of window.
-        return 0
+    def get_attn_backend(self):
+        from vllm_ascend.attention.indexer_kpool import (
+            AscendIndexerKPoolBackend,
+        )
 
-    def remove_skipped_blocks(
+        return AscendIndexerKPoolBackend
+
+    def forward(self): ...
+
+
+class Glm5NextStateCache(nn.Module, AttentionLayerBase):
+    """Paged FP32 ``[K, gate]`` state for incomplete GLM-Next pools."""
+
+    align_kv_cache_with_mamba = False
+
+    def __init__(
         self,
-        request_id: str,
-        processed_computed_tokens: int,
-        num_prompt_tokens: int | None = None,
+        *,
+        state_dim: int,
+        dtype: torch.dtype,
+        compress_ratio: int,
+        cache_config: CacheConfig,
+        prefix: str,
     ) -> None:
-        # Never prune mid-request; the block is freed on request completion.
-        return
+        super().__init__()
+        if dtype != torch.float32:
+            raise ValueError(f"GLM-Next compressor state must use torch.float32, got {dtype}.")
+        if compress_ratio <= 1:
+            raise ValueError(
+                f"GLM-Next compressor state requires compress_ratio greater than one, got {compress_ratio}."
+            )
+        self.state_dim = state_dim
+        self.dtype = dtype
+        self.prefix = prefix
+        self.compress_ratio = compress_ratio
+        self.block_size = compress_ratio
+        self.sliding_window = compress_ratio
+        self.cache_config = cache_config
+        self.cache_role = "indexer_state"
+        current_config = get_current_vllm_config()
+        self.kv_cache = [torch.tensor([]) for _ in range(current_config.parallel_config.pipeline_parallel_size)]
+        static_context = current_config.compilation_config.static_forward_context
+        if prefix in static_context:
+            raise ValueError(f"Duplicate layer name: {prefix}")
+        static_context[prefix] = self
 
-    def get_num_blocks_to_allocate(
-        self,
-        request_id: str,
-        num_tokens: int,
-        new_computed_blocks: Sequence[KVCacheBlock],
-        total_computed_tokens: int,
-        num_local_computed_tokens: int,
-        num_tokens_main_model: int,
-        apply_admission_cap: bool = False,
-    ) -> int:
-        # Exactly one block per request, reused circularly; never grow.
-        return max(1 - len(self.req_to_blocks.get(request_id, ())), 0)
+    def get_kv_cache_spec(self, vllm_config: VllmConfig) -> KVCacheSpec:
+        del vllm_config
+        return AscendIndexerKPoolStateSpec(
+            block_size=self.block_size,
+            num_kv_heads=1,
+            head_size=self.state_dim,
+            dtype=self.dtype,
+            sliding_window=self.sliding_window,
+            cache_dtype_str=None,
+            model_version="glm5_next",
+            cache_role=self.cache_role,
+            indexes_kv_by_block_stride=True,
+        )
 
-    def allocate_new_blocks(self, request_id: str, num_tokens: int, num_tokens_main_model: int) -> list[KVCacheBlock]:
-        # Cap at one block regardless of num_tokens; the kernel reuses its slots
-        # via pos % kpool. No partial-hit CoW path (find_longest_cache_hit never
-        # hits, so _partial_hit_reqs is always empty).
-        req_blocks = self.req_to_blocks[request_id]
-        if len(req_blocks) >= 1:
-            return []
-        new_blocks = self.block_pool.get_new_blocks(1)
-        req_blocks.extend(new_blocks)
-        if self._record_new_block_ids:
-            self.new_block_ids.extend(b.block_id for b in new_blocks)
-        return new_blocks
+    def get_attn_backend(self):
+        from vllm_ascend.attention.indexer_kpool import (
+            AscendIndexerKPoolStateBackend,
+        )
 
-    def add_local_computed_blocks(
-        self,
-        request_id: str,
-        new_computed_blocks: Sequence[KVCacheBlock],
-        num_local_computed_tokens: int,
-        num_external_computed_tokens: int,
-    ) -> None:
-        # The tail never has local prefix-cache hits (find_longest_cache_hit
-        # returns none); external (PD-transferred) tokens are handled by
-        # allocate_external_computed_blocks below.
-        return
+        return AscendIndexerKPoolStateBackend
 
-    def allocate_external_computed_blocks(
-        self,
-        request_id: str,
-        num_local_computed_tokens: int,
-        num_external_computed_tokens: int,
-    ) -> None:
-        # The tail is a fixed 1-block circular buffer; PD-transferred (external)
-        # tokens do not grow it -- the kernel reuses the single block's slots via
-        # pos % kpool. The base FullAttention path would allocate
-        # cdiv(num_external, block_size) blocks (one per kpool tokens), which
-        # both wastes blocks and mismatches the producer's 1-block transfer,
-        # tripping the NIXL reconcile block-count assert. Cap at one block,
-        # matching allocate_new_blocks and the producer.
-        req_blocks = self.req_to_blocks[request_id]
-        if len(req_blocks) >= 1:
-            return
-        new_blocks = self.block_pool.get_new_blocks(1)
-        req_blocks.extend(new_blocks)
-        if self._record_new_block_ids:
-            self.new_block_ids.extend(b.block_id for b in new_blocks)
-
-
-@dataclass(frozen=True, kw_only=True)
-class KpoolTailSpec(SlidingWindowSpec):
-    """One-block circular scratch cache for a kpool indexer's raw tail."""
-
-    def max_admission_blocks_per_request(self, max_in_flight_tokens: int, max_model_len: int) -> int:
-        return 1
-
-    def max_num_blocks_per_req(self, vllm_config: VllmConfig, max_len: int) -> int:
-        return 1
-
-    def is_uniform_with_collection(self, kv_cache_specs: dict[str, KVCacheSpec]) -> bool:
-        return all(isinstance(spec, KpoolTailSpec) for spec in kv_cache_specs.values())
-
-    @property
-    def participates_in_prefix_caching(self) -> bool:
-        return False
+    def forward(self): ...

--- a/vllm_ascend/models/glm5next/multimodal.py
+++ b/vllm_ascend/models/glm5next/multimodal.py
@@ -600,13 +600,13 @@ class Glm5NextProcessingInfo(Glm4vProcessingInfo):
     """
 
     @cached_property
-    def _glm5_hf_processor(self):
+    def _glm5_next_hf_processor(self):
         from vllm_ascend.models.glm5next.processor import Glm5NextProcessor
 
         return Glm5NextProcessor.from_pretrained(self.ctx.model_config.model)
 
     def get_hf_processor(self, **kwargs: object):
-        return self._glm5_hf_processor
+        return self._glm5_next_hf_processor
 
     def _processor_pixel_budget(self, proc) -> tuple[int, int]:
         from vllm_ascend.models.glm5next.processor import _pixel_budget

--- a/vllm_ascend/models/glm5next/sparse_attn_indexer_kpool.py
+++ b/vllm_ascend/models/glm5next/sparse_attn_indexer_kpool.py
@@ -40,7 +40,7 @@ class SparseAttnIndexerKpool(CustomOp):
         self,
         k_cache,
         quant_block_size: int,
-        scale_fmt: str,
+        scale_fmt: str | None,
         topk_tokens: int,
         head_dim: int,
         max_model_len: int,

--- a/vllm_ascend/patch/platform/__init__.py
+++ b/vllm_ascend/patch/platform/__init__.py
@@ -48,3 +48,54 @@ import vllm_ascend.patch.platform.patch_eplb  # noqa
 import vllm_ascend.patch.platform.patch_fused_moe  # noqa
 import vllm_ascend.patch.platform.patch_dp_device_ids  # noqa
 import vllm_ascend.patch.platform.patch_glm5next_config  # noqa
+
+# ** File: platform/patch_kv_cache_utils.py **
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+#   1. `vllm.v1.core.kv_cache_utils`
+#    Why:
+#       vLLM's generic KV-cache planner cannot represent GLM-Next's cache
+#       topology, where MLA and compressed indexer caches share block IDs while
+#       indexer-state and Mamba caches use independent groups.
+#    How:
+#       Use GLM-Next-specific grouping, tensor layout, and memory accounting.
+#       Other models continue to use the original vLLM implementation.
+#    Related PR (if no, explain why):
+#       https://github.com/vllm-project/vllm/pull/53906
+#       https://github.com/vllm-project/vllm/pull/55219
+#    Future Plan:
+#       Remove this patch when upstream's generic KV-cache layout supports the
+#       Ascend GLM-Next cache topology.
+#
+# ** File: platform/patch_mamba_config.py **
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+#   1. `vllm.model_executor.models.config.HybridAttentionMambaModelConfig.verify_and_update_config`
+#    Why:
+#       GLM-Next's compressed indexer requires both Ascend C128 block alignment
+#       and C16 alignment after applying `index_kpool`. The generic Mamba
+#       configuration does not satisfy these requirements.
+#    How:
+#       Detect sparse index-kpool models, align the attention block size, and
+#       pad the Mamba page using the complete recurrent-state size.
+#    Related PR (if no, explain why):
+#       https://github.com/vllm-project/vllm/pull/53906
+#       https://github.com/vllm-project/vllm/pull/55449
+#    Future Plan:
+#       Remove this patch when vLLM supports backend-specific block and page
+#       alignment constraints.
+#
+# ** File: platform/patch_mamba_block_aligned_split.py **
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+#   1. `vllm.v1.core.sched.scheduler.Scheduler._mamba_block_aligned_split`
+#    Why:
+#       For sparse index-kpool models, upstream splits prefill chunks using the
+#       Mamba block size instead of the resolved common cache-group boundary,
+#       which can produce incorrect cache-state mappings.
+#    How:
+#       Align sparse index-kpool prefill chunks to the scheduler block size while
+#       preserving small chunks and the existing PD speculative-window behavior.
+#    Related PR (if no, explain why):
+#       No upstream PR currently covers this Ascend-specific behavior.
+#       Related issue: https://github.com/vllm-project/vllm/issues/54392
+#    Future Plan:
+#       Remove this patch when upstream supports per-group or backend-defined
+#       prefill boundaries.

--- a/vllm_ascend/patch/platform/patch_kv_cache_utils.py
+++ b/vllm_ascend/patch/platform/patch_kv_cache_utils.py
@@ -22,12 +22,21 @@ from vllm.v1.kv_cache_interface import (
     get_kv_cache_spec_kind,
 )
 
+from vllm_ascend.models.glm5next.cache_config import (
+    _get_glm5_next_cache_layout,
+    get_glm5_next_kv_cache_config,
+    get_glm5_next_kv_cache_groups,
+    get_glm5_next_max_memory_usage,
+    get_glm5_next_pool_bytes_per_block,
+)
+from vllm_ascend.models.glm5next.kv_cache import is_glm5_next_cache_spec
 from vllm_ascend.utils import vllm_version_is
 
 _KIMI_K3_TARGET_LAYER_PREFIX = "language_model.model.layers."
 _KIMI_K3_DRAFT_LAYER_PREFIX = "model.layers."
 _orig_resolve_kv_cache_block_sizes = vllm.v1.core.kv_cache_utils.resolve_kv_cache_block_sizes
 _orig_get_kv_cache_groups_uniform_page_size = vllm.v1.core.kv_cache_utils._get_kv_cache_groups_uniform_page_size
+_orig_get_kv_cache_groups = vllm.v1.core.kv_cache_utils.get_kv_cache_groups
 _orig_get_kv_cache_config_from_groups = vllm.v1.core.kv_cache_utils.get_kv_cache_config_from_groups
 _orig_max_memory_usage_bytes_from_groups = vllm.v1.core.kv_cache_utils._max_memory_usage_bytes_from_groups
 _orig_pool_bytes_per_block = vllm.v1.core.kv_cache_utils._pool_bytes_per_block
@@ -74,7 +83,7 @@ def _ascend_resolve_kv_cache_block_sizes(
     This restriction is correct for CUDA but not for Ascend, which implements
     context parallelism for MLA and SWA-MLA layers independently.
 
-    For multiple KV cache groups with CP, compute scheduler_block_size as
+    For multiple KV cache groups with DCP, compute scheduler_block_size as
     lcm(group_block_sizes) * dcp to maintain alignment.
     """
     cache_config = vllm_config.cache_config
@@ -85,11 +94,11 @@ def _ascend_resolve_kv_cache_block_sizes(
         bs = cache_config.block_size * dcp
         return bs, bs
 
+    group_block_sizes = [group.kv_cache_spec.block_size for group in groups]
     if dcp != 1:
         # Ascend supports CP with multiple KV cache groups; compute
         # scheduler_block_size using the LCM of all group block sizes
-        # multiplied by the CP factors for proper alignment.
-        group_block_sizes = [g.kv_cache_spec.block_size for g in groups]
+        # multiplied by DCP for proper alignment.
         scheduler_block_size = math.lcm(*group_block_sizes) * dcp
         if not cache_config.enable_prefix_caching:
             return scheduler_block_size, scheduler_block_size
@@ -491,6 +500,8 @@ def _ascend_pool_bytes_per_block(kv_cache_groups: list[KVCacheGroupSpec]) -> int
     layout, so using the upstream value changes ``num_blocks`` during the
     re-plan and leaves ranks inconsistent.
     """
+    if _get_glm5_next_cache_layout(kv_cache_groups) is not None:
+        return get_glm5_next_pool_bytes_per_block(kv_cache_groups)
     if not _is_deepseek_v4_groups(kv_cache_groups):
         return _orig_pool_bytes_per_block(kv_cache_groups)
 
@@ -503,6 +514,8 @@ def _ascend_max_memory_usage_bytes_from_groups(
     kv_cache_groups: list[KVCacheGroupSpec],
 ) -> int:
     """Keep the pre-#51718 DSV4 admission formula for its shared tuples."""
+    if _get_glm5_next_cache_layout(kv_cache_groups) is not None:
+        return get_glm5_next_max_memory_usage(vllm_config, kv_cache_groups)
     if vllm_version_is("0.28.0") or not _is_deepseek_v4_groups(kv_cache_groups):
         return _orig_max_memory_usage_bytes_from_groups(vllm_config, kv_cache_groups)
 
@@ -522,12 +535,23 @@ def _ascend_max_memory_usage_bytes_from_groups(
     )
 
 
+def _get_glm5_next_kv_cache_groups(
+    vllm_config: VllmConfig,
+    kv_cache_spec: dict[str, KVCacheSpec],
+) -> list[KVCacheGroupSpec]:
+    if any(is_glm5_next_cache_spec(spec) for spec in kv_cache_spec.values()):
+        return get_glm5_next_kv_cache_groups(vllm_config, kv_cache_spec)
+    return _orig_get_kv_cache_groups(vllm_config, kv_cache_spec)
+
+
 def _ascend_get_kv_cache_config_from_groups(
     vllm_config: VllmConfig,
     kv_cache_groups: list[KVCacheGroupSpec],
     available_memory: int,
 ) -> KVCacheConfig:
     """Restore Ascend's DSV4 shared-tuple planner removed by vLLM #51718."""
+    if _get_glm5_next_cache_layout(kv_cache_groups) is not None:
+        return get_glm5_next_kv_cache_config(vllm_config, kv_cache_groups, available_memory)
     if vllm_version_is("0.28.0") or not _is_deepseek_v4_groups(kv_cache_groups):
         return _orig_get_kv_cache_config_from_groups(vllm_config, kv_cache_groups, available_memory)
 
@@ -553,6 +577,7 @@ vllm.v1.core.kv_cache_utils._get_kv_cache_groups_uniform_page_size = _get_kv_cac
 # main uses _ascend_get_kv_cache_config_from_groups and the stride-aware planner.
 if vllm_version_is("0.28.0"):
     vllm.v1.core.kv_cache_utils._get_kv_cache_config_packed = _get_kv_cache_config_deepseek_v4
+vllm.v1.core.kv_cache_utils.get_kv_cache_groups = _get_glm5_next_kv_cache_groups
 KVCacheConfig.has_mamba_layers = property(  # type: ignore[assignment]
     _kv_cache_config_has_mamba_layers
 )

--- a/vllm_ascend/patch/platform/patch_mamba_block_aligned_split.py
+++ b/vllm_ascend/patch/platform/patch_mamba_block_aligned_split.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Keep speculative verifier windows intact on PD decode consumers.
+"""Apply Ascend-specific Mamba chunk-boundary handling.
 
 A newly admitted KV-consumer request can have one prompt token left after the
 external cache hit. The waiting scheduler pads that token to a ``1 + K``
@@ -20,8 +20,10 @@ speculative verifier window before Mamba alignment is applied. If the window
 starts mid-block, the alignment split can shorten its physical width while the
 request still advertises all ``K`` speculative placeholders.
 
-Decode consumers preserve the complete verifier window. Producers continue to
-use the upstream Mamba boundary logic unchanged.
+Decode consumers preserve the complete verifier window. Sparse index-kpool
+producers align against the resolved common cache-group boundary because their
+physical indexer-state block is smaller than the Mamba checkpoint interval.
+Other models retain the upstream behavior.
 """
 
 import functools
@@ -29,6 +31,10 @@ import inspect
 
 from vllm.v1.core.sched.scheduler import Scheduler
 from vllm.v1.request import Request
+
+from vllm_ascend.patch.platform.patch_mamba_config import (
+    _get_sparse_index_kpool,
+)
 
 _EXPECTED_PARAMETERS = (
     "self",
@@ -49,9 +55,28 @@ def _mamba_block_aligned_split(
     num_new_local_computed_tokens: int = 0,
     num_external_computed_tokens: int = 0,
 ) -> int:
-    """Bypass Mamba splitting on KV consumers and preserve it elsewhere."""
+    """Preserve PD windows and align sparse index-kpool cache groups."""
     kv_transfer_config = self.vllm_config.kv_transfer_config
     if kv_transfer_config is not None and kv_transfer_config.is_kv_consumer:
+        return num_new_tokens
+
+    if _get_sparse_index_kpool(self.vllm_config.model_config) is not None:
+        num_computed_tokens = request.num_computed_tokens + num_new_local_computed_tokens + num_external_computed_tokens
+        if num_computed_tokens < max(
+            request.num_prompt_tokens,
+            request.num_tokens - 1,
+        ):
+            block_size = self.block_size
+            last_cache_position = request.num_tokens - request.num_tokens % block_size
+            if self.use_eagle:
+                last_cache_position = max(last_cache_position - block_size, 0)
+            scheduled_end = num_computed_tokens + num_new_tokens
+            if scheduled_end < last_cache_position:
+                chunked_tokens = num_new_tokens // block_size * block_size
+                if chunked_tokens > 0:
+                    num_new_tokens = chunked_tokens
+            elif num_computed_tokens < last_cache_position < scheduled_end:
+                num_new_tokens = last_cache_position - num_computed_tokens
         return num_new_tokens
 
     return _original_mamba_block_aligned_split(

--- a/vllm_ascend/patch/platform/patch_mamba_config.py
+++ b/vllm_ascend/patch/platform/patch_mamba_config.py
@@ -9,6 +9,21 @@ from vllm.utils.math_utils import cdiv
 from vllm.utils.torch_utils import STR_DTYPE_TO_TORCH_DTYPE, get_dtype_size
 
 
+def _get_sparse_index_kpool(model_config) -> int | None:
+    """Return the active sparse index-kpool ratio, if configured."""
+    for config_name in ("hf_text_config", "hf_config"):
+        config = getattr(model_config, config_name, None)
+        if config is None or getattr(config, "index_topk", None) is None:
+            continue
+        if not hasattr(config, "index_kpool"):
+            continue
+        index_kpool = config.index_kpool
+        if not isinstance(index_kpool, int) or index_kpool <= 1:
+            raise ValueError("Sparse index-kpool models require index_kpool to be an integer greater than 1.")
+        return index_kpool
+    return None
+
+
 def _using_kv_store(vllm_config) -> bool:
     """
     Check whether AscendStoreConnector is used.
@@ -68,6 +83,7 @@ def verify_and_update_config(cls, vllm_config) -> None:
     for shape, dtype in zip(mamba_shapes, mamba_dtypes):
         mamba_sizes.append(math.prod(shape) * get_dtype_size(dtype))
     ssm_block_page_size, conv_block_page_size = max(mamba_sizes), min(mamba_sizes)
+    mamba_raw_page_size = sum(mamba_sizes)
 
     # Pure linear attention models (e.g. bailing 2.5) have only SSM state,
     # no conv block. Detected by a single 3-D mamba shape (ssm only, no conv).
@@ -91,31 +107,54 @@ def verify_and_update_config(cls, vllm_config) -> None:
         attn_single_token_k_page_size = attn_head_size * attn_num_kv_heads * get_dtype_size(kv_cache_dtype)
         attn_token_page_size = 2 * attn_head_size * attn_num_kv_heads * get_dtype_size(kv_cache_dtype)
 
-    attn_block_size = kernel_block_size * cdiv(ssm_block_page_size, kernel_block_size * attn_single_token_k_page_size)
-    assert attn_single_token_k_page_size * attn_block_size == ssm_block_page_size, (
-        "Cannot align ssm_page_size and attn_page_size."
-    )
-
-    # override attention block size if either (a) the
-    # user has not set it or (b) the user has set it
-    # too small.
-    if cache_config.block_size is None or cache_config.block_size < attn_block_size:
-        cache_config.block_size = attn_block_size
-        logger.info(
-            "Setting attention block size to %d tokens to ensure that attention page size is >= mamba page size.",
-            attn_block_size,
+    index_kpool = _get_sparse_index_kpool(model_config)
+    if index_kpool is not None:
+        # The compressed indexer storage block is consumed by a CANN kernel
+        # whose block size must be a multiple of 16. Keep the scheduler block
+        # C128-aligned while making block_size / index_kpool C16-aligned too.
+        alignment_tokens = math.lcm(kernel_block_size, index_kpool * 16)
+        min_block_size = cdiv(mamba_raw_page_size, attn_token_page_size)
+        requested_block_size = cache_config.block_size or kernel_block_size
+        attn_block_size = alignment_tokens * cdiv(max(requested_block_size, min_block_size), alignment_tokens)
+        if cache_config.block_size != attn_block_size:
+            cache_config.block_size = attn_block_size
+            logger.info(
+                "Setting attention block size to %d tokens to align MLA, "
+                "recurrent-state, and compressed indexer cache pages.",
+                attn_block_size,
+            )
+    else:
+        attn_block_size = kernel_block_size * cdiv(
+            ssm_block_page_size,
+            kernel_block_size * attn_single_token_k_page_size,
         )
+        assert attn_single_token_k_page_size * attn_block_size == ssm_block_page_size, (
+            "Cannot align ssm_page_size and attn_page_size."
+        )
+
+        # Override attention block size if it is unset or too small.
+        if cache_config.block_size is None or cache_config.block_size < attn_block_size:
+            cache_config.block_size = attn_block_size
+            logger.info(
+                "Setting attention block size to %d tokens to ensure that attention page size is >= mamba page size.",
+                attn_block_size,
+            )
 
     # compute new attention page size
     attn_page_size = cache_config.block_size * attn_token_page_size
 
-    # pad mamba page size for conv_blocks
-    if (
-        cache_config.mamba_page_size_padded is None
-        or cache_config.mamba_page_size_padded != attn_page_size + conv_block_page_size
-    ):
-        cache_config.mamba_page_size_padded = attn_page_size + conv_block_page_size
-        mamba_padding_pct = 100 * conv_block_page_size / cache_config.mamba_page_size_padded
+    # Sparse index-kpool models pack the complete recurrent state into the
+    # same large-page class as attention. Preserve the generic Ascend SSM+conv
+    # layout for other hybrid models.
+    target_mamba_page_size = (
+        max(attn_page_size, mamba_raw_page_size) if index_kpool is not None else attn_page_size + conv_block_page_size
+    )
+    if cache_config.mamba_page_size_padded is None or cache_config.mamba_page_size_padded != target_mamba_page_size:
+        cache_config.mamba_page_size_padded = target_mamba_page_size
+        padding_bytes = (
+            target_mamba_page_size - mamba_raw_page_size if index_kpool is not None else conv_block_page_size
+        )
+        mamba_padding_pct = 100 * padding_bytes / target_mamba_page_size
         logger.info(
             "Padding mamba page size by %.2f%% to ensure "
             "that mamba page size and attention page size are "

--- a/vllm_ascend/worker/model_runner_v1.py
+++ b/vllm_ascend/worker/model_runner_v1.py
@@ -141,7 +141,6 @@ from vllm_ascend.attention.mla_v1 import AscendMLABackend
 from vllm_ascend.attention.utils import (
     AscendCommonAttentionMetadata,
     get_sfa_qsfa_packed_head_dim,
-    is_glm5_next_kpool_cache,
     using_paged_attention,
 )
 
@@ -170,7 +169,6 @@ from vllm_ascend.eplb.core.eplb_device_transfer_loader import D2DExpertWeightLoa
 from vllm_ascend.eplb.core.eplb_worker import EplbProcess
 from vllm_ascend.eplb.eplb_updator import EplbUpdator
 from vllm_ascend.model_executor.offloader import create_offloader
-from vllm_ascend.models.glm5next.kv_cache import KpoolTailSpec
 from vllm_ascend.ops.fused_moe.force_eplb import build_force_eplb_topk
 from vllm_ascend.ops.rotary_embedding import set_cos_and_sin, update_cos_sin
 from vllm_ascend.ops.triton.spec_decode.ngram import triton_ngram_spec_decode
@@ -207,7 +205,6 @@ from vllm_ascend.utils import (
     is_score_encoder_cache_manager,
     kv_cache_spec_uses_sparse_sfa_c8,
     lmhead_tp_enable,
-    model_uses_kpool_indexer,
     set_potential_max_tokens,
     should_skip_allreduce_across_dp_group,
     vllm_version_is,
@@ -249,6 +246,7 @@ from vllm_ascend.core.kv_cache_interface import (
     AscendMLAAttentionSpec,
     AscendSFAIndexerCacheSpec,
     AscendSlidingWindowMLASpec,
+    get_kv_cache_compression_ratio,
 )
 
 # if true, allow tensor initialization and casting with internal format (e.g., NZ)
@@ -4305,14 +4303,15 @@ class NPUModelRunner(GPUModelRunner):
                             layer_kv_cache_spec[layer_name] = spec
         return layer_kv_cache_spec
 
-    def _is_glm5_next_kpool_layer(self, layer_name: str, spec=None) -> bool:
-        compilation_config = getattr(self, "compilation_config", None)
-        if compilation_config is None:
-            compilation_config = getattr(self.vllm_config, "compilation_config", None)
-        static_ctx = getattr(compilation_config, "static_forward_context", {}) if compilation_config else {}
-        if is_glm5_next_kpool_cache(static_ctx.get(layer_name)):
-            return True
-        return isinstance(spec, KpoolTailSpec)
+    def _uses_page_strided_kv_layout(self, kv_cache_spec: KVCacheSpec) -> bool:
+        """Whether a cache spec requires one block-strided backing tensor."""
+        return isinstance(
+            kv_cache_spec,
+            (AscendMLAAttentionSpec, AscendSlidingWindowMLASpec),
+        ) and (
+            self.use_compress
+            or getattr(kv_cache_spec, "indexes_kv_by_block_stride", False)
+        )
 
     def _get_attention_kv_cache_dims(self, layer_name: str, kv_cache_spec: AttentionSpec) -> tuple[int, int]:
         if isinstance(kv_cache_spec, AscendMLAAttentionSpec):
@@ -4443,6 +4442,10 @@ class NPUModelRunner(GPUModelRunner):
         # standardized descriptors, whose ``size`` is the size of one common
         # backing allocation rather than the size of an individual layer.
         use_legacy_shared_by_layout = vllm_version_is("0.28.0")
+        is_glm5_next = any(
+            getattr(spec, "model_version", None) == "glm5_next"
+            for spec in layer_kv_cache_spec.values()
+        )
         is_dsv4_main = not use_legacy_shared_by_layout and any(
             getattr(spec, "model_version", None) == "deepseek_v4"
             for spec in layer_kv_cache_spec.values()
@@ -4472,6 +4475,34 @@ class NPUModelRunner(GPUModelRunner):
                 "MooncakePullConnector",
             }
         )
+
+        # GLM-Next emits one descriptor for each physical cache slot. Layers
+        # listed by a descriptor deliberately alias that slot even when they
+        # belong to different scheduler groups (for example MLA and Mamba, or
+        # the compressed indexer and its state cache). This differs from the
+        # generic main layout, which treats descriptor layers as independent
+        # regions within one common backing.
+        if is_glm5_next:
+            for descriptor in kv_cache_config.kv_cache_tensors:
+                shared_layers = get_kv_cache_tensor_layers(descriptor)
+                if not shared_layers:
+                    raise ValueError("GLM-Next KV cache descriptor has no layers.")
+                if not use_legacy_shared_by_layout:
+                    expected_size = kv_cache_config.num_blocks * descriptor.block_stride
+                    if (
+                        descriptor.offset != 0
+                        or descriptor.layer_stride != 0
+                        or descriptor.block_stride <= 0
+                        or descriptor.size != expected_size
+                        or any(
+                            layer_kv_cache_spec[layer_name].page_size_bytes != descriptor.block_stride
+                            for layer_name in shared_layers
+                        )
+                    ):
+                        raise ValueError("Invalid GLM-Next shared-slot KV cache descriptor geometry.")
+                backing = self._allocate_int8_cache_tensor(descriptor.size, alignment)
+                for layer_name in shared_layers:
+                    kv_cache_raw_tensors[layer_name] = backing
 
         # The restored DSV4 planner on main emits multiple descriptors into a
         # single shared-tuple backing. Its memory budget is computed for that
@@ -4538,6 +4569,7 @@ class NPUModelRunner(GPUModelRunner):
         if (
             not use_legacy_shared_by_layout
             and not is_dsv4_main
+            and not is_glm5_next
             and self.hybrid_with_attn_and_mamba
             and supports_shared_backing_with_kv_transfer
             and not self.use_sparse
@@ -4571,9 +4603,12 @@ class NPUModelRunner(GPUModelRunner):
         for kv_cache_tensor in kv_cache_config.kv_cache_tensors:
             shared_layers = get_kv_cache_tensor_layers(kv_cache_tensor)
             use_mamba = False
+            use_compressed_cache = False
             for layer_name in shared_layers:
                 if isinstance(layer_kv_cache_spec[layer_name], MambaSpec):
                     use_mamba = True
+                if self._uses_page_strided_kv_layout(layer_kv_cache_spec[layer_name]):
+                    use_compressed_cache = True
             for idx in range(len(shared_layers)):
                 layer_name = shared_layers[idx]
                 # Single tensor path for: mamba, hybrid attn-mamba, or cache_only_layers
@@ -4582,7 +4617,6 @@ class NPUModelRunner(GPUModelRunner):
                     or self.hybrid_with_attn_and_mamba
                     or "cache_only_layers" in layer_name
                     or is_hidden_state_cache_spec(layer_kv_cache_spec.get(layer_name))
-                    or self._is_glm5_next_kpool_layer(layer_name, layer_kv_cache_spec.get(layer_name))
                 ) and layer_name not in kv_cache_raw_tensors:
                     # Check if shared_by contains both MambaSpec and HiddenStateCacheSpec.
                     # If so, they must use separate physical memory to avoid corruption:
@@ -4647,7 +4681,7 @@ class NPUModelRunner(GPUModelRunner):
                                 tensor = self._align_memory(tensor, alignment)[: layer_size]
                             kv_cache_raw_tensors[layer_name_inner] = tensor
 
-                elif "attn" in layer_name and self.use_compress and layer_name not in kv_cache_raw_tensors:
+                elif use_compressed_cache and layer_name not in kv_cache_raw_tensors:
                     if self.vllm_config.kv_transfer_config is None:
                         tensor = torch.zeros(kv_cache_tensor.size,
                                                 dtype=torch.int8,
@@ -4901,15 +4935,14 @@ class NPUModelRunner(GPUModelRunner):
 
                 # TODO: remove this after the OOM issue is located and fixed, otherwise, some model may
                 # encounter OOM issue
-                if self.use_compress and isinstance(current_kv_cache_spec,
-                                                    (AscendMLAAttentionSpec, AscendSlidingWindowMLASpec)):
+                if self._uses_page_strided_kv_layout(current_kv_cache_spec):
                     kv_tensor = kv_cache_raw_tensors[layer_name]
                     sum_page_size_bytes = kv_tensor.numel()
                     num_blocks = sum_page_size_bytes // current_kv_cache_spec.page_size_bytes
                     assert num_blocks == kv_cache_config.num_blocks, \
                         f"num_blocks: {num_blocks} should be equal to " \
                         f"kv_cache_config.num_blocks: {kv_cache_config.num_blocks}"
-                    kv_cache_shape = self.attn_backend.get_kv_cache_shape(
+                    kv_cache_shape = attn_backend.get_kv_cache_shape(
                         num_blocks, current_kv_cache_spec.storage_block_size,
                         current_kv_cache_spec.num_kv_heads,
                         current_kv_cache_spec.head_size)
@@ -4917,15 +4950,36 @@ class NPUModelRunner(GPUModelRunner):
                     kv_cache_dtype_list = [current_kv_cache_spec.dtype]
                     overlap_full_kv_cache = False
 
+                    # A page-strided MLA cache still exposes its latent KV and
+                    # RoPE components as separate logical tensors. They share
+                    # one standard backing allocation, but the attention
+                    # implementation addresses them independently.
+                    if (
+                        isinstance(current_kv_cache_spec, AscendMLAAttentionSpec)
+                        and get_kv_cache_compression_ratio(current_kv_cache_spec) == 1
+                    ):
+                        k_dim, v_dim = self._get_attention_kv_cache_dims(
+                            layer_name, current_kv_cache_spec
+                        )
+                        cache_prefix = kv_cache_shape[:-1]
+                        kv_cache_shape_list = [
+                            (*cache_prefix, k_dim),
+                            (*cache_prefix, v_dim),
+                        ]
+                        kv_cache_dtype_list = [
+                            current_kv_cache_spec.dtype,
+                            current_kv_cache_spec.dtype,
+                        ]
+
                     if hasattr(current_kv_cache_spec, "scale_dim") and current_kv_cache_spec.scale_dim != 0:
                         indexer_k_shape = kv_cache_shape
-                        indexer_scale_shape = self.attn_backend.get_kv_cache_shape(
+                        indexer_scale_shape = attn_backend.get_kv_cache_shape(
                                                 num_blocks, current_kv_cache_spec.storage_block_size,
                                                 current_kv_cache_spec.num_kv_heads,
                                                 current_kv_cache_spec.scale_dim
                                                 )
                         if get_current_hardware_profile().supports(HardwareCapability.DSV4_COMPRESSED_CACHE):
-                            indexer_full_shape = self.attn_backend.get_kv_cache_shape(
+                            indexer_full_shape = attn_backend.get_kv_cache_shape(
                                 num_blocks, current_kv_cache_spec.storage_block_size,
                                 current_kv_cache_spec.num_kv_heads,
                                 current_kv_cache_spec.head_size
@@ -4992,54 +5046,6 @@ class NPUModelRunner(GPUModelRunner):
                             .view(indexer_scale_cache_shape)
                         )
                         kv_caches[layer_name] = (indexer_k_cache, indexer_scale_cache)
-                elif self._is_glm5_next_kpool_layer(layer_name, current_kv_cache_spec):
-                    # glm5_next_kpool_reshape: indexer is K-only; tail is packed K||score.
-                    raw_tensor = kv_cache_raw_tensors[layer_name]
-                    if isinstance(raw_tensor, tuple):
-                        raw_tensor = raw_tensor[0] if len(raw_tensor) == 1 else torch.cat(
-                            [t.reshape(-1) for t in raw_tensor if t is not None]
-                        )
-                    assert raw_tensor is not None
-                    page_size_bytes = current_kv_cache_spec.page_size_bytes
-                    assert raw_tensor.numel() % page_size_bytes == 0, (
-                        f"kpool cache numel {raw_tensor.numel()} not divisible by "
-                        f"page_size_bytes {page_size_bytes} for {layer_name}"
-                    )
-                    num_blocks = raw_tensor.numel() // page_size_bytes
-                    assert num_blocks >= kv_cache_config.num_blocks
-                    storage_block_size = getattr(
-                        current_kv_cache_spec, "storage_block_size", current_kv_cache_spec.block_size
-                    )
-                    try:
-                        kv_cache_shape = attn_backend.get_kv_cache_shape(
-                            num_blocks,
-                            storage_block_size,
-                            current_kv_cache_spec.num_kv_heads,
-                            current_kv_cache_spec.head_size,
-                            cache_dtype_str=getattr(current_kv_cache_spec, "cache_dtype_str", "auto") or "auto",
-                        )
-                    except TypeError:
-                        kv_cache_shape = attn_backend.get_kv_cache_shape(
-                            num_blocks,
-                            storage_block_size,
-                            current_kv_cache_spec.num_kv_heads,
-                            current_kv_cache_spec.head_size,
-                        )
-                    raw_typed = raw_tensor.view(current_kv_cache_spec.dtype)
-                    page_size_padded = getattr(current_kv_cache_spec, "page_size_padded", None)
-                    if page_size_padded is not None:
-                        dtype_size = get_dtype_size(current_kv_cache_spec.dtype)
-                        page_stride = page_size_padded // dtype_size
-                        strides = [1] * len(kv_cache_shape)
-                        for dim_idx in range(len(kv_cache_shape) - 2, -1, -1):
-                            strides[dim_idx] = strides[dim_idx + 1] * kv_cache_shape[dim_idx + 1]
-                        strides[0] = page_stride
-                        kv_caches[layer_name] = torch.as_strided(
-                            raw_typed, size=kv_cache_shape, stride=tuple(strides)
-                        )
-                    else:
-                        kv_caches[layer_name] = raw_typed.view(kv_cache_shape)
-                    continue
                 elif isinstance(current_kv_cache_spec, AttentionSpec):
                     # cache_only_layers (extract_hidden_states) are allocated
                     # as a single tensor by the branch at the top of
@@ -5612,11 +5618,19 @@ class NPUModelRunner(GPUModelRunner):
                     # evenly divide. Ascend binds KV as block-first views
                     # and indexes padded pages by runtime block stride, so
                     # unify_kv_cache_spec_page_size may pad them.
-                    # vLLM #51718 removed AttentionSpec.indexes_kv_by_block_stride
-                    # on main; pass it only on the legacy lane.
-                    mla_spec_kwargs: dict[str, Any] = {}
-                    if vllm_version_is("0.28.0"):
-                        mla_spec_kwargs["indexes_kv_by_block_stride"] = model_uses_kpool_indexer(self.model_config)
+                    model_version = getattr(spec, "model_version", None) or getattr(
+                        attn_module, "model_version", None
+                    )
+                    indexes_kv_by_block_stride = bool(
+                        getattr(spec, "indexes_kv_by_block_stride", False)
+                        or getattr(attn_module, "indexes_kv_by_block_stride", False)
+                    )
+                    compression_ratio = get_kv_cache_compression_ratio(spec)
+                    ratio_kwargs: dict[str, Any] = (
+                        {"compress_ratio": compression_ratio}
+                        if vllm_version_is("0.28.0")
+                        else {"tokens_per_state": compression_ratio}
+                    )
                     kv_cache_spec[layer_name] = AscendMLAAttentionSpec(
                         block_size=spec.block_size,
                         num_kv_heads=spec.num_kv_heads,
@@ -5624,21 +5638,13 @@ class NPUModelRunner(GPUModelRunner):
                         dtype=dtype,
                         cache_dtype_str=cache_dtype_str,
                         non_causal_multi_token_decode=spec.non_causal_multi_token_decode,
-                        **mla_spec_kwargs,
+                        model_version=model_version,
+                        indexes_kv_by_block_stride=indexes_kv_by_block_stride,
+                        **ratio_kwargs,
                     )
                     attn_layer_names.add(layer_name)
 
             elif isinstance(attn_module, DeepseekV32IndexerCache):
-                # GLM-5.3-Flash kpool indexer/tail caches subclass the DeepSeek
-                # V3.2 indexer cache but keep compress_ratio / KpoolTailSpec.
-                if is_glm5_next_kpool_cache(attn_module):
-                    if spec := attn_module.get_kv_cache_spec(self.vllm_config):
-                        # Indexer/tail pages do not evenly divide the MLA page.
-                        # Ascend indexes KV by block stride, so opt in to padding.
-                        if isinstance(spec, AttentionSpec) and vllm_version_is("0.28.0"):
-                            spec = replace(spec, indexes_kv_by_block_stride=True)
-                        kv_cache_spec[layer_name] = spec
-                    continue
                 # TODO: This mirrors upstream's separated KV/indexer specs for
                 # SFA, but keeps Ascend-specific shape/block-size accounting.
                 # Remove this special case once the generic vLLM spec/backend
@@ -5680,7 +5686,9 @@ class NPUModelRunner(GPUModelRunner):
 
             elif spec := attn_module.get_kv_cache_spec(self.vllm_config):
                 kv_cache_spec[layer_name] = spec
-                if isinstance(spec, AttentionSpec):
+                if isinstance(spec, AttentionSpec) and getattr(
+                    attn_module, "align_kv_cache_with_mamba", True
+                ):
                     attn_layer_names.add(layer_name)
 
         if len(mamba_layers) > 0:

--- a/vllm_ascend/worker/v2/attn_utils.py
+++ b/vllm_ascend/worker/v2/attn_utils.py
@@ -49,7 +49,6 @@ from vllm_ascend.attention.sfa_v1 import AscendSFAMetadataBuilder
 from vllm_ascend.attention.utils import (
     AscendCommonAttentionMetadata,
     get_sfa_qsfa_packed_head_dim,
-    is_glm5_next_kpool_cache,
 )
 from vllm_ascend.core.kv_cache_interface import (
     AscendMLAAttentionSpec,
@@ -134,10 +133,6 @@ def get_kv_cache_spec(vllm_config: VllmConfig) -> dict[str, KVCacheSpec]:
                 cache_sparse_sfa_c8=cache_sparse_sfa_c8,
             )
         if isinstance(attn_module, DeepseekV32IndexerCache):
-            # GLM-5.3-Flash kpool indexer/tail caches keep their own spec.
-            if is_glm5_next_kpool_cache(attn_module):
-                kv_cache_spec[layer_name] = spec
-                continue
             cache_sparse_li_c8 = get_ascend_config().is_sparse_li_c8_layer(layer_name)
             kv_cache_spec[layer_name] = AscendSFAIndexerCacheSpec(
                 block_size=vllm_config.cache_config.block_size,


### PR DESCRIPTION
### What this PR does / why we need it?
Refs #15665  
This PR adds GLM-Next KV cache management for the pooled sparse indexer on Ascend.

It:
- introduces coordinated cache specs and allocation for MLA, compressed indexer keys, compressor state, and recurrent groups;
- adds Ascend indexer cache metadata and pooled-cache write/indexer operators;
- aligns block-table, slot-mapping, prefix-hash, and Mamba split behavior with the pooled cache layout;
- prevents speculative-width prefill tails from being dispatched as decode and corrupting MTP recurrent state;
- keeps the implementation compatible with the vLLM 0.28 cache interfaces used by the current environment.

### Does this PR introduce _any_ user-facing change?

Yes. GLM-Next models can use the Ascend-managed pooled KV cache layout, including prefix-cache-safe block hashing and stateful prefill/decode transitions.

### How was this patch tested?

- git diff --check upstream/main...HEAD
- Ruff on all changed Python files
- 177 focused unit tests covering MLA/PCP conflict resolution, GLM-Next cache configuration, pooled cache views, indexer state compression, lightning indexer, GDN metadata, and model-runner behavior
- BF16 smoke test on 16 Ascend NPUs with Transformers 5.14.1 and vLLM 0.27.1:
  - service startup and KV cache allocation succeeded;
  - /health, /v1/models, basic completion, repeated requests, and four concurrent requests returned HTTP 200;
  - a 4,101-token prompt returned HTTP 200;
  - the first 8,201-token request entered the 8,192-token cold graph-compilation path; manual validation was stopped before that compilation completed.

- vLLM main: https://github.com/vllm-project/vllm/commit/b2f685834a6456197e7033966fdef52a23f1abcd
