### PR TITLE
[Performance][Spec Decode] Release consumed draft tensors before the next forward

### DIFF
--- a/tests/ut/spec_decode/test_eagle_proposer.py
+++ b/tests/ut/spec_decode/test_eagle_proposer.py
@@ -1,6 +1,7 @@
 # ruff: noqa: E501
 import inspect
 import unittest
+import weakref
 from dataclasses import dataclass
 from types import SimpleNamespace
 from typing import Any
@@ -2465,6 +2466,51 @@ class TestRunMergedDraft(TestBase):
 
     def get_param_names(self, sig):
         return [p.name for p in sig.parameters.values()]
+
+    def test_mtp_releases_previous_output_storage_before_next_forward(self):
+        class Draft(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.calls = 0
+                self.storage_refs = []
+
+            def forward(self, input_ids, **kwargs):
+                # Check storage, not Tensor objects: a small view can pin a full output.
+                assert all(ref() is None for ref in self.storage_refs)
+                self.calls += 1
+                output = torch.full((input_ids.numel(), 4), float(self.calls))
+                recycle = output + 10
+                self.storage_refs = [weakref.ref(t.untyped_storage()) for t in (output, recycle)]
+                return output, recycle
+
+            def compute_logits(self, hidden_states):
+                logits = torch.zeros(hidden_states.shape[0], 4)
+                logits[:, self.calls] = 1
+                self.storage_refs.append(weakref.ref(logits.untyped_storage()))
+                return logits
+
+        self.proposer.method = "mtp"
+        self.proposer.model = Draft()
+        self.proposer.supports_mm_inputs = False
+        self.proposer._enable_probabilistic_draft_probs = False
+        # MagicMock records arguments and would itself keep output storage alive.
+        self.proposer.maybe_all_gather_and_unpad = lambda *tensors: tensors
+        with (
+            patch.object(llm_base_proposer, "lmhead_tp_enable", return_value=False),
+            patch.object(llm_base_proposer, "get_ascend_config", return_value=SimpleNamespace(enable_reduce_sample=False)),
+            patch.object(llm_base_proposer, "get_forward_context", return_value=SimpleNamespace(attn_metadata=None)),
+        ):
+            drafts = self.proposer._run_merged_draft(
+                num_input_tokens=16,
+                batch_size=2,
+                token_indices_to_sample=torch.tensor([14, 15]),
+                target_positions=self.proposer.positions[:16],
+                inputs_embeds=None,
+                multi_steps_attn_metadata=None,
+                num_tokens=16,
+            )
+        self.assertEqual(self.proposer.model.calls, 3)
+        self.assertEqual(drafts.tolist(), [[1, 2, 3], [1, 2, 3]])
 
     def test_run_merged_draft_eagle3_decode_prepares_each_forward_input(self):
         self.proposer.model = MockDraftModel(returns_tuple=True)

--- a/vllm_ascend/spec_decode/llm_base_proposer.py
+++ b/vllm_ascend/spec_decode/llm_base_proposer.py
@@ -1275,6 +1275,7 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
 
         ret_hidden_states = self.model(**model_kwargs)
         last_hidden_states, hidden_states = _split_draft_outputs(ret_hidden_states)
+        del ret_hidden_states
 
         # step 1+ skip indexer
         draft_model = getattr(self.model, "model", None)
@@ -1436,6 +1437,9 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
                         logits=logits,
                     )
 
+        # Release sampled logits before the next draft forward.
+        logits = None
+
         # Early exit if there is only one draft token to be generated.
         if self.num_speculative_tokens == 1 or self.parallel_drafting:
             if draft_probs_step0 is not None:
@@ -1467,6 +1471,7 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
         else:
             positions = self.positions[token_indices_to_sample]
         hidden_states = hidden_states[token_indices_to_sample]
+        del last_hidden_states
         token_indices_to_sample = self.arange[:batch_size]
 
         input_batch_size = num_input_tokens if (self.method == "mtp" or self.use_cuda_graph) else batch_size
@@ -1508,6 +1513,8 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
             self.input_ids[:batch_size] = input_ids
             self._set_positions(batch_size, clamped_positions)
             self.hidden_states[:batch_size] = hidden_states.view(batch_size, -1)
+            # Release the previous output storage before the next forward.
+            del hidden_states
             if self.supports_mm_inputs:
                 self.inputs_embeds[:batch_size] = self.model.embed_input_ids(input_ids)
 
@@ -1549,6 +1556,7 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
 
             ret_hidden_states = self.model(**model_kwargs)
             last_hidden_states, hidden_states = _split_draft_outputs(ret_hidden_states)
+            del ret_hidden_states
 
             last_hidden_states, model_positions, hidden_states = self.maybe_all_gather_and_unpad(
                 last_hidden_states, model_positions, hidden_states
@@ -1596,6 +1604,8 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
 
             # TODO(wenlong): get more than one token for tree attention
             hidden_states = hidden_states[:batch_size]
+            del last_hidden_states
+            logits = None
             draft_token_ids_tensor[draft_index + 1] = draft_token_ids
             if draft_probs_list is not None:
                 if draft_probs_step is not None:


### PR DESCRIPTION
### What this PR does / why we need it?

During multi-step drafting, the previous model output remains referenced while the next `self.model(...)` call is evaluated. The returned tuple and output aliases can retain full prefill-sized tensors even after the rows needed for the next step have been selected, overlapping their lifetime with the next forward.

Release consumed output references and sampled logits before the next draft forward. Keep the existing recycle slice, copy it into the persistent input buffer, then drop its reference before executing the model. This adds no extra tensor clone and preserves all drafting steps.

Add a storage-lifetime regression to the existing multi-step proposer tests that also checks the three generated draft tokens.

### Does this PR introduce _any_ user-facing change?

No API or configuration changes are intended. The change allows consumed draft storage to be reused earlier; actual NPU peak-memory savings have not been measured.

### How was this patch tested?

- `bash format.sh ci`: passed.
- Existing source regressions: 5 passed with `pytest --confcutdir=tests/ut/spec_decode tests/ut/spec_decode/test_eagle_aclgraph_source_regression.py tests/ut/spec_decode/test_step3p5_source_regression.py -q`.
- Added `TestRunMergedDraft.test_mtp_releases_previous_output_storage_before_next_forward` in `tests/ut/spec_decode/test_eagle_proposer.py`. Attempted the test locally, but collection was blocked by `ModuleNotFoundError: No module named 'vllm'`; this test still needs to run in the normal UT environment.
- Ascend NPU inference and a before/after peak-memory comparison have not been run.

- vLLM main: https://github.com/vllm-project/vllm/commit/ba07e4a48fc951300d97eb506217dd530583dea3
