### PR TITLE
[BugFix][Spec Decode] Bound runtime dummy sampling by request capacity

### DIFF
--- a/docs/source/user_guide/feature_guide/speculative_decoding.md
+++ b/docs/source/user_guide/feature_guide/speculative_decoding.md
@@ -38,6 +38,12 @@ All speculative decoding methods are configured through the `speculative_config`
 - **`draft_tensor_parallel_size`** (int, optional): Tensor parallelism size for the draft model. Can only be `1` or the same as the target model's tensor parallel size.
 - **`disable_padded_drafter_batch`** (bool, default: `False`): Disable input padding for speculative decoding. If set to `True`, speculative input batches can contain sequences of different lengths, which may only be supported by certain attention backends. **Note:** Only effective with `eagle`, `eagle3`, `mtp`, `dflash`, `draft_model`, and `extract_hidden_states` methods.
 
+Runtime dummy batches can accompany real requests on other DP ranks. Their
+forward token capacity still follows DP padding, but their simulated sampling
+batch is bounded by `max_num_seqs`, including outside memory profiling. Thus a
+64K/128K token prefill does not create thousands of dummy logits rows merely
+because MTP3 is enabled.
+
 **Offline inference** — pass `speculative_config` as a Python dict to `LLM()`:
 
 ```python

--- a/tests/ut/spec_decode/test_eagle_proposer.py
+++ b/tests/ut/spec_decode/test_eagle_proposer.py
@@ -21,6 +21,7 @@ from vllm_ascend.attention.attention_v1 import AscendAttentionState
 from vllm_ascend.attention.utils import AscendCommonAttentionMetadata
 from vllm_ascend.spec_decode.draft_proposer import AscendDraftModelProposer
 from vllm_ascend.spec_decode.eagle_proposer import AscendEagleProposer
+from vllm_ascend.spec_decode.step3p5 import AscendStep3p5MTPProposer
 from vllm_ascend.spec_decode.utils import SlidingWindowAdapter
 from vllm_ascend.utils import enable_custom_op
 from vllm_ascend.worker.dcp_utils import DCPSpecDecodeFirstPassInputs
@@ -522,6 +523,7 @@ class TestEagleProposerDummyRun(TestBase):
         self.runner.dcp_size = 1
         self.runner.dcp_manager = None
         self.runner.pin_memory = False
+        self.runner.max_num_reqs = 32
         self.runner.dynamic_eplb = True
         self.runner.eplb_heat_collection_status = True
         self.runner._sync_metadata_across_dp.return_value = (8, torch.tensor([8]), CUDAGraphMode.NONE)
@@ -605,6 +607,28 @@ class TestEagleProposerDummyRun(TestBase):
         self.mock_dp_group.stop()
         # Clear the current vllm config
         set_current_vllm_config(None)
+
+    def test_long_dummy_bounds_sampling_after_dp_padding(self):
+        self.proposer.num_speculative_tokens = 3
+        self.proposer.extra_slots_per_request = 1
+        self.proposer.use_cuda_graph = False
+        for cls in (AscendEagleProposer, AscendStep3p5MTPProposer):
+            for num_tokens, is_profile in ((65536, False), (131072, False), (131072, True)):
+                with (
+                    self.subTest(proposer=cls.__name__, num_tokens=num_tokens, is_profile=is_profile),
+                    patch(f"{cls.dummy_run.__module__}.set_ascend_forward_context"),
+                    patch(
+                        f"{cls.dummy_run.__module__}.get_forward_context",
+                        return_value=SimpleNamespace(cudagraph_runtime_mode=CUDAGraphMode.NONE),
+                    ),
+                ):
+                    self.runner._sync_metadata_across_dp.return_value = (num_tokens, None, CUDAGraphMode.NONE)
+                    # An idle DP starts small and is padded to a peer's long prefill.
+                    cls.dummy_run(self.proposer, num_tokens=4, is_profile=is_profile)
+                    call = self.proposer._runnable.call_args.kwargs
+                    self.assertEqual(call["num_input_tokens"], num_tokens)
+                    self.assertEqual(call["batch_size"], self.runner.max_num_reqs)
+                    self.assertEqual(call["token_indices_to_sample"].numel(), self.runner.max_num_reqs)
 
     # cpu does not support parallel-group, let alone `sp`
     @patch("vllm_ascend.ascend_forward_context.get_forward_context")

--- a/vllm_ascend/spec_decode/llm_base_proposer.py
+++ b/vllm_ascend/spec_decode/llm_base_proposer.py
@@ -779,10 +779,11 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
 
         model_positions = self._get_positions(num_tokens)
 
-        batch_size = max(num_tokens // (self.num_speculative_tokens + 1), 1)
-        # TODO: temporarily hack here, we should find out batch_size for profile_run
-        if is_profile:
-            batch_size = min(batch_size, self.runner.max_num_reqs)
+        # Limit dummy requests to avoid oversized logits after DP padding.
+        batch_size = min(
+            max(num_tokens // (self.num_speculative_tokens + 1), 1),
+            self.runner.max_num_reqs,
+        )
 
         if self.supports_mm_inputs:
             mm_embeds, is_mm_embed = (None, None)

--- a/vllm_ascend/spec_decode/step3p5.py
+++ b/vllm_ascend/spec_decode/step3p5.py
@@ -239,9 +239,10 @@ class AscendStep3p5MTPProposer(AscendEagleProposer):
                 pin_memory=self.runner.pin_memory,
             )
 
-        batch_size = max(num_tokens // (self.num_speculative_tokens + 1), 1)
-        if is_profile:
-            batch_size = min(batch_size, self.runner.max_num_reqs)
+        batch_size = min(
+            max(num_tokens // (self.num_speculative_tokens + 1), 1),
+            self.runner.max_num_reqs,
+        )
 
         if aclgraph_runtime_mode == CUDAGraphMode.FULL and len(self.runner.attn_groups) > 0:
             num_computed_tokens_cpu = self.runner.input_batch.num_computed_tokens_cpu_tensor[:num_reqs]


### PR DESCRIPTION
### What this PR does / why we need it?

Runtime dummy batches can inherit a large token count from DP padding while accompanying a peer's prefill. With MTP3 and 65,536 padded tokens, the decode-style estimate produces 16,384 sampling rows even when the runner supports only 64 requests. The existing request limit applies only during memory profiling, so runtime logits gathering can still OOM.

Apply the same request limit to runtime dummy sampling in the base and Step3.5 proposers. Keep the DP-padded forward token capacity unchanged. Add a regression to the existing proposer tests covering 64K/128K runtime batches and profiling, plus a short documentation note.

### Does this PR introduce _any_ user-facing change?

No API or configuration changes. Runtime dummy sampling stays within the configured request capacity, avoiding oversized logits allocations.

### How was this patch tested?

- `bash format.sh ci`: passed.
- Existing source regressions: 5 passed with `pytest --confcutdir=tests/ut/spec_decode tests/ut/spec_decode/test_eagle_aclgraph_source_regression.py tests/ut/spec_decode/test_step3p5_source_regression.py -q`.
- Added `TestEagleProposerDummyRun.test_long_dummy_bounds_sampling_after_dp_padding` in `tests/ut/spec_decode/test_eagle_proposer.py`. Attempted the test locally, but collection was blocked by `ModuleNotFoundError: No module named 'vllm'`; this test still needs to run in the normal UT environment.
- Ascend NPU inference and the 128K workload have not been validated on hardware.

- vLLM main: https://github.com/vllm-project/vllm/commit/ba07e4a48fc951300d97eb506217dd530583dea3
