### PR TITLE
[v0.26.0rc][Bugfix]align swiglu limit attr type

### DIFF
--- a/csrc/gmm/grouped_matmul_swiglu_quant/op_host/grouped_matmul_swiglu_quant_tiling.cpp
+++ b/csrc/gmm/grouped_matmul_swiglu_quant/op_host/grouped_matmul_swiglu_quant_tiling.cpp
@@ -140,7 +140,9 @@ ASCENDC_EXTERN_C graphStatus TilingGMMSwigluQuant(gert::TilingContext *context)
     auto attrs = context->GetAttrs();
     float limited = 0.0f;
     if (attrs != nullptr) {
-        if (const double *limitedPtr = attrs->GetAttrPointer<double>(ATTR_INDEX_LIMITED)) {
+        if (const float *limitedPtr = attrs->GetAttrPointer<float>(ATTR_INDEX_LIMITED)) {
+            limited = *limitedPtr;
+        } else if (const double *limitedPtr = attrs->GetAttrPointer<double>(ATTR_INDEX_LIMITED)) {
             limited = static_cast<float>(*limitedPtr);
         }
     }

--- a/csrc/gmm/grouped_matmul_swiglu_quant/op_host/op_api/aclnn_grouped_matmul_swiglu_quant.cpp
+++ b/csrc/gmm/grouped_matmul_swiglu_quant/op_host/op_api/aclnn_grouped_matmul_swiglu_quant.cpp
@@ -452,7 +452,8 @@ static aclnnStatus aclnnGroupedMatmulSwigluQuantGetWorkspaceSizeCommon(
     if (isEnableWeightAssistanceMatrix && weightScale->GetViewShape().GetDimNum() == WEIGHT_SCALE_PERGROUP_DIM_LIMIT) {
         dequantMode = 1;
     }
-    auto ret_0 = l0op::GroupedMatmulSwigluQuant(x, weight, weightScale, xScale, groupList, limited, bias,
+    const float limitedAttr = static_cast<float>(limited);
+    auto ret_0 = l0op::GroupedMatmulSwigluQuant(x, weight, weightScale, xScale, groupList, limitedAttr, bias,
                                                 isEnableWeightAssistanceMatrix, dequantMode, uniqueExecutor.get());
     CHECK_RET(ret_0 != std::tuple(nullptr, nullptr), ACLNN_ERR_INNER_NULLPTR);
     auto out0 = std::get<OUTPUT_IDX_0>(ret_0);
@@ -491,7 +492,7 @@ aclnnStatus aclnnGroupedMatmulSwigluQuantWeightNZGetWorkspaceSize(const aclTenso
 {
     OP_CHECK_COMM_INPUT(workspaceSize, executor);
     L2_DFX_PHASE_1(aclnnGroupedMatmulSwigluQuantWeightNZ,
-                   DFX_IN(x, weight, bias, offset, weightScale, xScale, groupList),
+                   DFX_IN(x, weight, bias, offset, weightScale, xScale, groupList, limited),
                    DFX_OUT(output, outputScale, outputOffset));
     // weight在该场景下强制绑定StorageFormat 和 ViewFormat 为NZ
     CHECK_RET(weight != nullptr, ACLNN_ERR_PARAM_NULLPTR);

--- a/csrc/gmm/grouped_matmul_swiglu_quant/op_host/op_api/grouped_matmul_swiglu_quant.cpp
+++ b/csrc/gmm/grouped_matmul_swiglu_quant/op_host/op_api/grouped_matmul_swiglu_quant.cpp
@@ -20,7 +20,7 @@ OP_TYPE_REGISTER(GroupedMatmulSwigluQuant);
 
 const std::tuple<aclTensor *, aclTensor *>
 GroupedMatmulSwigluQuant(const aclTensor *x, const aclTensor *weight, const aclTensor *perChannelScale,
-                         const aclTensor *perTokenScale, const aclTensor *groupList, double limited,
+                         const aclTensor *perTokenScale, const aclTensor *groupList, float limited,
                          const aclTensor *weightAssistanceMatrix, bool isEnableWeightAssistanceMatrix, int dequantMode,
                          aclOpExecutor *executor)
 {

--- a/csrc/gmm/grouped_matmul_swiglu_quant/op_host/op_api/grouped_matmul_swiglu_quant.h
+++ b/csrc/gmm/grouped_matmul_swiglu_quant/op_host/op_api/grouped_matmul_swiglu_quant.h
@@ -15,7 +15,7 @@
 namespace l0op {
 const std::tuple<aclTensor *, aclTensor *>
 GroupedMatmulSwigluQuant(const aclTensor *x, const aclTensor *weight, const aclTensor *perChannelScale,
-                         const aclTensor *perTokenScale, const aclTensor *groupList, double limited,
+                         const aclTensor *perTokenScale, const aclTensor *groupList, float limited,
                          const aclTensor *weightAssistanceMatrix, bool isEnableWeightAssistanceMatrix, int dequantMode,
                          aclOpExecutor *executor);
 }


### PR DESCRIPTION

### What this PR does / why we need it:

The `limited` (swiglu clamp) attribute is declared as **Float** in the `GroupedMatmulSwigluQuant` OpDef, but the code path was inconsistent with it:

- The L0 API (`l0op::GroupedMatmulSwigluQuant`) declared the parameter as `double`, so the value passed into `OP_ATTR` was dumped as a double, mismatching the OpDef Float attr and breaking static-kernel dump expectations.
- The tiling code read the attr exclusively via `GetAttrPointer<double>`, which returns nullptr when the attr is stored as a float, silently falling back to `limited = 0` (clamp disabled).

Changes:

- `op_api/grouped_matmul_swiglu_quant.{h,cpp}`: change the L0 interface signature `double limited` → `float limited`.
- `op_api/aclnn_grouped_matmul_swiglu_quant.cpp`: cast `limited` to `float` before passing it into the L0 `OP_ATTR` path; add the missing `limited` to the `WeightNZ` `DFX_IN` trace list.
- `op_host/grouped_matmul_swiglu_quant_tiling.cpp`: read the attr as `float` first, with a `double` fallback for robustness.

### Does this PR introduce _any_ user-facing change?:

No. Pure type alignment on the internal attr path; runtime behavior is unchanged when the attr is correctly propagated (previously it could be silently dropped to 0).

### How was this patch tested?:

CI verification only (existing GroupedMatmulSwigluQuant UT/ST covers the attr path).
- vLLM main: https://github.com/vllm-project/vllm/commit/d02df748bf9efd99022f1a062597dc3cb3808485
