### PR TITLE
[BugFix] Fix Eagle3 draft acceptance rate regression with QuaRot on v0.27.1

### DIFF
--- a/vllm_ascend/models/__init__.py
+++ b/vllm_ascend/models/__init__.py
@@ -78,3 +78,6 @@ def register_model():
         "Glm5NextMTPModel",
         "vllm_ascend.models.glm5next.mtp:Glm5NextMTP",
     )
+    ModelRegistry.register_model(
+        "LlamaForCausalLMEagle3", "vllm_ascend.models.llama_eagle3:AscendEagle3LlamaForCausalLM"
+    )


### PR DESCRIPTION
What this PR does / why we need it?
Fixes the regression that breaks QuaRot (rotary quantization) + EAGLE3 speculative decoding on vLLM v0.27.1 + vllm-ascend main, where the draft acceptance rate dropped from ~26% to ~0.01%.

Root cause

When a user's EAGLE3 draft checkpoint declares architectures: ["LlamaForCausalLMEagle3"] (the Qwen3 EAGLE3 naming), the model resolution path loads the upstream Eagle3LlamaForCausalLM instead of AscendEagle3LlamaForCausalLM:

vLLM's built-in registry already maps "LlamaForCausalLMEagle3" to the upstream class (vllm/model_executor/models/registry.py:629).
ModelRegistry._normalize_arch returns the architecture as-is when the key already exists in the registry, so it never falls through to the Eagle3LlamaForCausalLM alias.
vllm-ascend only registered the single key Eagle3LlamaForCausalLM, so the LlamaForCausalLMEagle3 path is completely bypassed.
The upstream class has no QuaRot anti-rotation logic in load_weights; the draft fc weights (stored in the rotated basis) are loaded verbatim. Mismatched basis → the draft projects corrupted hidden states → every sampled token is rejected → acceptance rate ≈ 0.
This is a leftover gap from PR #10896 which migrated the rotary-quantization handling from global monkey-patching (patch_draft_quarot.py) to model-class registration, but only registered the Eagle3LlamaForCausalLM alias.

Fix

Register the missing architecture alias so both names map to the Ascend class:

ModelRegistry.register_model(
    "LlamaForCausalLMEagle3", "vllm_ascend.models.llama_eagle3:AscendEagle3LlamaForCausalLM"
)
AscendEagle3LlamaForCausalLM inherits the upstream class and only performs the anti-rotation (fc → W @ Q3ᵀ, embed_tokens → @ Qᵀ loaded from the target) when is_quarot_used is true; its non-QuaRot behavior is byte-identical to upstream.

Does this PR introduce any user-facing change?
No. 

How was this patch tested?
NPU (Ascend 910B) real inference: Qwen3-30B-A3B w8a8-quarot-eagle3 target + Qwen3-30B-A3B-EAGLE3 draft with --quantization ascend and --speculative_config '{"method": "eagle3", "num_speculative_tokens": 4}'.
Before: draft acceptance rate ≈ 0.01%
After: acceptance rate recovered to the normal level (~26%)
Static resolution check: reproduced vLLM v0.27.1's _normalize_arch / resolve_model_cls logic locally; after the fix LlamaForCausalLMEagle3 resolves to AscendEagle3LlamaForCausalLM instead of the upstream class.
Syntax check: python -m py_compile vllm_ascend/models/__init__.py passed.

- vLLM main: https://github.com/vllm-project/vllm/commit/e6bfe03ad73a3330cb427885aa90d97a12e1c704
