### PR TITLE
[Doc][BugFix] Fix max_completion_tokens usage in GLM-5.3-Flash verification example

### DIFF
--- a/docs/source/tutorials/models/GLM5.3-Flash.md
+++ b/docs/source/tutorials/models/GLM5.3-Flash.md
@@ -353,7 +353,7 @@ curl http://<node0_ip>:<port>/v1/completions \
     -d '{
         "model": "glm",
         "prompt": "The future of AI is",
-        "max_completion_tokens": 50,
+        "max_tokens": 50
     }'
 ```
 


### PR DESCRIPTION
### What this PR does / why we need it?

Fixes a broken functional-verification example in the GLM-5.3-Flash tutorial (Section 6):

- `max_completion_tokens` is **silently ignored** by the `/v1/completions` endpoint (verified on vLLM 0.23.0): the request actually runs with the OpenAI default `max_tokens=16`, so any prompt that needs more than 16 tokens is truncated with `finish_reason=length`, which looks like a model-quality problem. Setting it to 50 or 500 makes no difference — the response always contains exactly 16 completion tokens. Only `max_tokens` is honored on this endpoint.
- The trailing comma after `"max_completion_tokens": 50,` is invalid JSON; strict clients reject the request.
- The documented expected output (`completion_tokens: 15, finish_reason: "stop"`) happens to finish naturally within the 16-token default budget, which masked the parameter issue during doc testing; longer or non-English prompts always get truncated.

The one-line fix switches the example to `max_tokens` and removes the trailing comma.

Fixes #15931

### Does this PR introduce _any_ user-facing change?

Documentation-only update, no user-facing change.

### How was this patch tested?

Verified on real hardware (Atlas 800 A3 single node TP16 and Atlas 800 A2 dual node DP2×TP8, GLM-5.3-Flash-w8a8 weights, vLLM 0.23.0 with vllm-ascend):

```
$ curl ... -d '{"model":"glm","prompt":"中国的首都是哪里","max_completion_tokens":50}'
"finish_reason":"length" ... "completion_tokens":16
$ curl ... -d '{"model":"glm","prompt":"中国的首都是哪里","max_completion_tokens":500}'
"finish_reason":"length" ... "completion_tokens":16
```

With `max_tokens` the example generates the documented-length output as expected.
- vLLM main: https://github.com/vllm-project/vllm/commit/e6bfe03ad73a3330cb427885aa90d97a12e1c704
