### PR TITLE
[Model][Performance] Optimize DeepSeek V4 vision operators

### DIFF
--- a/.github/workflows/scripts/test_config.yaml
+++ b/.github/workflows/scripts/test_config.yaml
@@ -214,6 +214,7 @@ estimated_times:
   tests/e2e/pull_request/four_card/test_minimax_m3.py: 300
   tests/e2e/pull_request/four_card/test_kimi_k3.py: 360
   tests/e2e/pull_request/one_card/test_attention_v1_precision.py: 540
+  tests/e2e/pull_request/one_card/test_deepseek_v4_vision_precision.py: 180
   tests/e2e/pull_request/one_card/test_mla_precision.py: 190
   tests/e2e/pull_request/one_card/test_sfa_v1_precision.py: 120
   tests/e2e/pull_request/one_card/test_eplb_map_to_physical_npu.py: 30

--- a/tests/e2e/pull_request/one_card/test_deepseek_v4_vision_precision.py
+++ b/tests/e2e/pull_request/one_card/test_deepseek_v4_vision_precision.py
@@ -1,0 +1,218 @@
+import json
+import os
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+import torch
+import torch.nn.functional as F
+import torch_npu  # noqa: F401
+from safetensors.torch import load_file
+from vllm.config import VllmConfig, set_current_vllm_config
+
+from vllm_ascend.models.deepseek_v4.vision import (
+    DeepseekV4VisionAttention,
+    DeepseekV4VisionBlock,
+    DeepseekV4ViT,
+    get_vision_cos_sin,
+)
+from vllm_ascend.utils import register_ascend_customop
+
+VISION_DIM = 1024
+VISION_HEADS = 16
+VISION_INTER_DIM = 2816
+RMS_NORM_EPS = 1e-6
+
+
+@pytest.fixture(scope="module", autouse=True)
+def register_ascend_vision_ops():
+    register_ascend_customop()
+    with set_current_vllm_config(VllmConfig()):
+        yield
+
+
+@pytest.fixture
+def vision_config():
+    return SimpleNamespace(
+        vision_dim=VISION_DIM,
+        vision_n_heads=VISION_HEADS,
+        vision_inter_dim=VISION_INTER_DIM,
+    )
+
+
+def _new_bf16_module(module_cls, config):
+    original_dtype = torch.get_default_dtype()
+    try:
+        torch.set_default_dtype(torch.bfloat16)
+        module = module_cls(config)
+    finally:
+        torch.set_default_dtype(original_dtype)
+    return module.eval().npu()
+
+
+def _reference_rms_norm(x: torch.Tensor, weight: torch.Tensor) -> torch.Tensor:
+    dtype = x.dtype
+    x_fp32 = x.float()
+    normalized = x_fp32 * torch.rsqrt(x_fp32.square().mean(-1, keepdim=True) + RMS_NORM_EPS)
+    return (weight * normalized).to(dtype)
+
+
+def _reference_apply_rotary(x: torch.Tensor, cos: torch.Tensor, sin: torch.Tensor) -> torch.Tensor:
+    dtype = x.dtype
+    x1, x2 = x.float().chunk(2, dim=-1)
+    return torch.cat((x1 * cos - x2 * sin, x2 * cos + x1 * sin), dim=-1).to(dtype)
+
+
+def _reference_attention(
+    attention: DeepseekV4VisionAttention,
+    x: torch.Tensor,
+    cos: torch.Tensor,
+    sin: torch.Tensor,
+) -> torch.Tensor:
+    num_tokens = x.size(0)
+    q, k, v = (
+        tensor.view(num_tokens, attention.n_heads, attention.head_dim) for tensor in attention.wqkv(x).chunk(3, dim=-1)
+    )
+    q = _reference_apply_rotary(q, cos, sin)
+    k = _reference_apply_rotary(k, cos, sin)
+    output = F.scaled_dot_product_attention(
+        q.transpose(0, 1),
+        k.transpose(0, 1),
+        v.transpose(0, 1),
+    )
+    return attention.wo(output.transpose(0, 1).reshape(num_tokens, -1))
+
+
+def _reference_mlp(block: DeepseekV4VisionBlock, x: torch.Tensor) -> torch.Tensor:
+    gate, up = block.mlp.w1(x).chunk(2, dim=-1)
+    return block.mlp.w2(F.silu(gate) * up)
+
+
+def _reference_block(
+    block: DeepseekV4VisionBlock,
+    x: torch.Tensor,
+    cos: torch.Tensor,
+    sin: torch.Tensor,
+) -> torch.Tensor:
+    attention_input = _reference_rms_norm(x, block.norm1.weight)
+    residual = x + _reference_attention(block.attn, attention_input, cos, sin)
+    mlp_input = _reference_rms_norm(residual, block.norm2.weight)
+    return residual + _reference_mlp(block, mlp_input)
+
+
+def _assert_vision_close(
+    actual: torch.Tensor,
+    expected: torch.Tensor,
+    *,
+    max_abs_error: float,
+    mean_abs_error: float,
+    min_cosine_similarity: float,
+) -> None:
+    actual_fp32 = actual.float().reshape(-1)
+    expected_fp32 = expected.float().reshape(-1)
+    error = (actual_fp32 - expected_fp32).abs()
+    cosine_similarity = F.cosine_similarity(actual_fp32, expected_fp32, dim=0)
+
+    max_error = error.max().item()
+    mean_error = error.mean().item()
+    cosine = cosine_similarity.item()
+    metrics = f"max_abs_error={max_error}, mean_abs_error={mean_error}, cosine_similarity={cosine}"
+    print(metrics)
+
+    assert max_error <= max_abs_error, metrics
+    assert mean_error <= mean_abs_error, metrics
+    assert cosine >= min_cosine_similarity, metrics
+
+
+@pytest.mark.parametrize("grid", [(4, 4), (16, 24), (48, 72)])
+def test_fused_attention_matches_original_formula(vision_config, grid):
+    torch.manual_seed(7)
+    attention = _new_bf16_module(DeepseekV4VisionAttention, vision_config)
+    num_tokens = grid[0] * grid[1]
+    x = torch.randn(num_tokens, VISION_DIM, dtype=torch.bfloat16, device="npu")
+    cos, sin = get_vision_cos_sin(grid[0], grid[1], attention.head_dim // 2, 10000.0)
+    cos = cos.npu()
+    sin = sin.npu()
+
+    with torch.inference_mode():
+        expected = _reference_attention(attention, x, cos, sin)
+        actual = attention(x, cos, sin)
+    torch.npu.synchronize()
+
+    _assert_vision_close(
+        actual,
+        expected,
+        max_abs_error=0.03125,
+        mean_abs_error=0.002,
+        min_cosine_similarity=0.9999,
+    )
+
+
+@pytest.mark.parametrize("grid", [(4, 4), (16, 24), (48, 72)])
+def test_fused_vision_block_matches_original_formula(vision_config, grid):
+    torch.manual_seed(17)
+    block = _new_bf16_module(DeepseekV4VisionBlock, vision_config)
+    num_tokens = grid[0] * grid[1]
+    x = torch.randn(num_tokens, VISION_DIM, dtype=torch.bfloat16, device="npu")
+    cos, sin = get_vision_cos_sin(grid[0], grid[1], VISION_DIM // VISION_HEADS // 2, 10000.0)
+    cos = cos.npu()
+    sin = sin.npu()
+
+    with torch.inference_mode():
+        expected = _reference_block(block, x, cos, sin)
+        actual = block(x.clone(), cos, sin)
+    torch.npu.synchronize()
+
+    _assert_vision_close(
+        actual,
+        expected,
+        max_abs_error=0.0625,
+        mean_abs_error=0.004,
+        min_cosine_similarity=0.9999,
+    )
+
+
+def test_real_weights_full_vit_matches_original_formula():
+    model_path = os.getenv("DEEPSEEK_V4_VISION_MODEL_PATH")
+    if not model_path:
+        pytest.skip("DEEPSEEK_V4_VISION_MODEL_PATH is not set")
+    assert model_path is not None
+
+    model_root = Path(model_path)
+    config = SimpleNamespace(**json.loads((model_root / "config.json").read_text()))
+    checkpoint = load_file(model_root / "quant_model_weights-00078-of-00078.safetensors")
+    vision_weights = {
+        name.removeprefix("vision."): tensor for name, tensor in checkpoint.items() if name.startswith("vision.")
+    }
+    model = _new_bf16_module(DeepseekV4ViT, config)
+    model.load_state_dict(vision_weights, strict=True)
+
+    torch.manual_seed(29)
+    grid = (16, 24)
+    patches = torch.randn(
+        grid[0] * grid[1],
+        3,
+        config.vision_patch_size,
+        config.vision_patch_size,
+        dtype=torch.bfloat16,
+        device="npu",
+    )
+
+    with torch.inference_mode():
+        expected = model.patch_embed(patches)
+        cos, sin = get_vision_cos_sin(grid[0], grid[1], model.rope_dim, model.rope_theta)
+        cos = cos.npu()
+        sin = sin.npu()
+        for block in model.blocks:
+            expected = _reference_block(block, expected, cos, sin)
+        expected = _reference_rms_norm(expected, model.norm.weight)
+        actual = model(patches, *grid)
+    torch.npu.synchronize()
+
+    _assert_vision_close(
+        actual,
+        expected,
+        max_abs_error=0.125,
+        mean_abs_error=0.005,
+        min_cosine_similarity=0.9999,
+    )

--- a/tests/ut/models/test_deepseek_v4_vision_preprocess.py
+++ b/tests/ut/models/test_deepseek_v4_vision_preprocess.py
@@ -158,3 +158,13 @@ def test_hf_tokenizer_call_is_thread_safe():
         competing_call.result()
 
     assert all(torch.equal(output, torch.tensor([[1]])) for output in outputs)
+
+
+def test_hf_processor_accepts_base_class_call_signature():
+    info = _ConcurrentStubInfo()
+    info.tokenizer = _NonThreadSafeTokenizer()
+    processor = DeepseekV4VLMultiModalProcessor(info, None)
+
+    output = processor._call_hf_processor("prompt", {"images": []}, {})
+
+    assert torch.equal(output["input_ids"], torch.tensor([[1]]))

--- a/vllm_ascend/models/deepseek_v4/mm_preprocess.py
+++ b/vllm_ascend/models/deepseek_v4/mm_preprocess.py
@@ -390,9 +390,11 @@ class DeepseekV4VLMultiModalProcessor(BaseMultiModalProcessor[DeepseekV4VLProces
         prompt: str,
         mm_data: Mapping[str, object],
         mm_kwargs: Mapping[str, object],
-        tok_kwargs: Mapping[str, object],
+        tok_kwargs: Mapping[str, object] | None = None,
     ) -> BatchFeature:
-        """Combine the local image transform with v0.27 tokenization."""
+        """Combine the local image transform with vLLM tokenization."""
+        if tok_kwargs is None:
+            tok_kwargs = {}
         processor = self.info.get_hf_processor(**mm_kwargs)
         processed = processor(
             text=prompt,

--- a/vllm_ascend/models/deepseek_v4/vision.py
+++ b/vllm_ascend/models/deepseek_v4/vision.py
@@ -12,6 +12,10 @@ from functools import lru_cache
 import torch
 import torch.nn.functional as F
 from torch import nn
+from vllm.model_executor.layers.activation import SiluAndMul
+from vllm.model_executor.layers.attention import MMEncoderAttention
+from vllm.model_executor.layers.layernorm import RMSNorm
+from vllm.model_executor.layers.rotary_embedding.common import ApplyRotaryEmb
 
 
 @lru_cache(8)
@@ -22,25 +26,6 @@ def get_vision_cos_sin(n_h: int, n_w: int, dim: int, theta: float) -> tuple[torc
     freqs = torch.stack([hpos, wpos], dim=-1).reshape(-1, 2, 1).float()
     freqs = (freqs * inv_freq).flatten(1)
     return freqs.cos().unsqueeze(1), freqs.sin().unsqueeze(1)
-
-
-def apply_rotary(x: torch.Tensor, cos: torch.Tensor, sin: torch.Tensor) -> torch.Tensor:
-    dtype = x.dtype
-    x1, x2 = x.float().chunk(2, dim=-1)
-    return torch.cat([x1 * cos - x2 * sin, x2 * cos + x1 * sin], dim=-1).to(dtype)
-
-
-class DeepseekV4RMSNorm(nn.Module):
-    def __init__(self, dim: int, eps: float = 1e-6):
-        super().__init__()
-        self.eps = eps
-        self.weight = nn.Parameter(torch.ones(dim, dtype=torch.float32))
-
-    def forward(self, x: torch.Tensor) -> torch.Tensor:
-        dtype = x.dtype
-        x = x.float()
-        x = x * torch.rsqrt(x.square().mean(-1, keepdim=True) + self.eps)
-        return (self.weight * x).to(dtype)
 
 
 class DeepseekV4PatchEmbed(nn.Module):
@@ -59,14 +44,24 @@ class DeepseekV4VisionAttention(nn.Module):
         self.head_dim = config.vision_dim // config.vision_n_heads
         self.wqkv = nn.Linear(config.vision_dim, 3 * config.vision_dim)
         self.wo = nn.Linear(config.vision_dim, config.vision_dim)
+        self.apply_rotary_emb = ApplyRotaryEmb(
+            enforce_enable=True,
+            is_neox_style=True,
+            enable_fp32_compute=True,
+        )
+        self.attn = MMEncoderAttention(
+            num_heads=self.n_heads,
+            head_size=self.head_dim,
+            scale=self.head_dim**-0.5,
+        )
 
     def forward(self, x: torch.Tensor, cos: torch.Tensor, sin: torch.Tensor) -> torch.Tensor:
         n = x.size(0)
         q, k, v = (t.view(n, self.n_heads, self.head_dim) for t in self.wqkv(x).chunk(3, dim=-1))
-        q = apply_rotary(q, cos, sin)
-        k = apply_rotary(k, cos, sin)
-        o = F.scaled_dot_product_attention(q.transpose(0, 1), k.transpose(0, 1), v.transpose(0, 1))
-        return self.wo(o.transpose(0, 1).reshape(n, -1))
+        qk = self.apply_rotary_emb(torch.stack((q, k)), cos.squeeze(1), sin.squeeze(1))
+        q, k = qk.unbind()
+        o = self.attn(q.unsqueeze(0), k.unsqueeze(0), v.unsqueeze(0))
+        return self.wo(o.squeeze(0).reshape(n, -1))
 
 
 class DeepseekV4VisionMLP(nn.Module):
@@ -74,23 +69,23 @@ class DeepseekV4VisionMLP(nn.Module):
         super().__init__()
         self.w1 = nn.Linear(config.vision_dim, 2 * config.vision_inter_dim, bias=False)
         self.w2 = nn.Linear(config.vision_inter_dim, config.vision_dim, bias=False)
+        self.act_fn = SiluAndMul()
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
-        gate, up = self.w1(x).chunk(2, dim=-1)
-        return self.w2(F.silu(gate) * up)
+        return self.w2(self.act_fn(self.w1(x)))
 
 
 class DeepseekV4VisionBlock(nn.Module):
     def __init__(self, config):
         super().__init__()
-        self.norm1 = DeepseekV4RMSNorm(config.vision_dim)
+        self.norm1 = RMSNorm(config.vision_dim, eps=1e-6, dtype=torch.float32)
         self.attn = DeepseekV4VisionAttention(config)
-        self.norm2 = DeepseekV4RMSNorm(config.vision_dim)
+        self.norm2 = RMSNorm(config.vision_dim, eps=1e-6, dtype=torch.float32)
         self.mlp = DeepseekV4VisionMLP(config)
 
     def forward(self, x: torch.Tensor, cos: torch.Tensor, sin: torch.Tensor) -> torch.Tensor:
-        x = x + self.attn(self.norm1(x), cos, sin)
-        return x + self.mlp(self.norm2(x))
+        residual = x + self.attn(self.norm1(x), cos, sin)
+        return residual + self.mlp(self.norm2(residual))
 
 
 class DeepseekV4ViT(nn.Module):
@@ -102,7 +97,7 @@ class DeepseekV4ViT(nn.Module):
         self.rope_theta = config.vision_rope_theta
         self.patch_embed = DeepseekV4PatchEmbed(config)
         self.blocks = nn.ModuleList([DeepseekV4VisionBlock(config) for _ in range(config.vision_n_layers)])
-        self.norm = DeepseekV4RMSNorm(config.vision_dim)
+        self.norm = RMSNorm(config.vision_dim, eps=1e-6, dtype=torch.float32)
 
     def forward(self, patches: torch.Tensor, n_vit_h: int, n_vit_w: int) -> torch.Tensor:
         x = self.patch_embed(patches)


### PR DESCRIPTION
### What this PR does / why we need it?

This PR optimizes the DeepSeek V4 vision transformer by replacing hand-written operator compositions with standard vLLM layers:

- use `ApplyRotaryEmb` for vision RoPE while retaining FP32 computation;
- use `MMEncoderAttention` for vision attention;
- use `SiluAndMul` for the gated MLP;
- use vLLM `RMSNorm` with FP32 weights;
- keep the DeepSeek V4 multimodal processor override compatible with the base-class call signature;
- add numerical-equivalence coverage for attention, a complete vision block, and the full 32-layer real-weight ViT.

The change reduces Python-level small-operator composition in the ViT path while preserving the original numerical behavior.

### Does this PR introduce _any_ user-facing change?

No API or configuration change. DeepSeek V4 vision serving uses the same model and launch arguments, with a faster ViT implementation.

### How was this patch tested?

- DeepSeek V4 multimodal preprocessing unit tests: `4 passed`.
- ViT numerical-equivalence tests: `7 passed` across 4x4, 16x24, and 48x72 image-token grids.
- Full 32-layer real-weight ViT comparison:
  - max absolute error: `0.01953125`
  - mean absolute error: `0.0007206165`
  - cosine similarity: `0.9999631643`
- Real serving smoke with DP4/TP4 and expert parallelism: service initialized successfully in `FULL_DECODE_ONLY` graph mode and passed a real-image request.
- MMMU-Pro image subset: `1730/1730` requests passed at concurrency 128; no indexer out-of-bounds error, worker failure, or traceback was observed.
- Controlled 128-request A/B runs at concurrency 128, with identical service configuration and warmup:
  - baseline: `23.8163 s`, `23.1940 s` (mean `23.5052 s`)
  - candidate: `22.2728 s`, `16.6807 s` (mean `19.4767 s`)
  - mean elapsed time reduced by `17.1%`; mean per-run request throughput increased by `23.2%`
- `ruff check`, `ruff format --check`, and `git diff --check` passed.

- vLLM main: https://github.com/vllm-project/vllm/commit/e6bfe03ad73a3330cb427885aa90d97a12e1c704
