### PR TITLE
[0.26.0rc][Doc][Misc] Standardize DeepSeek-V4 served model names

### DIFF
--- a/docs/source/tutorials/models/DeepSeek-V4-Flash.md
+++ b/docs/source/tutorials/models/DeepSeek-V4-Flash.md
@@ -200,7 +200,7 @@ Single-node deployment completes both Prefill and Decode within the same node. T
     vllm serve /root/.cache/modelscope/hub/models/UploadWeight/DeepSeek-V4-Flash-DSpark-w4a8-test \
         --max-model-len 800000 \
         --max-num-batched-tokens 8192 \
-        --served-model-name dsv4-dspark \
+        --served-model-name dsv4 \
         --gpu-memory-utilization 0.9 \
         --max-num-seqs 32 \
         --data-parallel-size 1 \
@@ -294,10 +294,9 @@ Single-node deployment completes both Prefill and Decode within the same node. T
         --model-loader-extra-config='{"enable_multithread_load": true, "num_threads": 128}' \
         --quantization ascend \
         --port 8900 \
-        --block-size 128 \
+        --block-size 32 \
         --speculative-config '{"method":"dspark","num_speculative_tokens":7,"enforce_eager":true}' \
         --compilation-config '{"cudagraph_mode": "FULL_DECODE_ONLY"}' \
-        --async-scheduling \
         --additional-config '{
             "ascend_compilation_config": {
                 "enable_npugraph_ex": true,
@@ -673,7 +672,7 @@ Before you start, please:
             --tensor-parallel-size $7 \
             --enable-expert-parallel \
             --seed 1024 \
-            --served-model-name dsv4-spark \
+            --served-model-name dsv4 \
             --max-model-len 1048576 \
             --max-num-batched-tokens 8192 \
             --max-num-seqs 16 \
@@ -1085,7 +1084,7 @@ Before you start, please:
        --tensor-parallel-size $7 \
        --enable-expert-parallel \
        --seed 1024 \
-       --served-model-name deepseek_v4 \
+       --served-model-name dsv4 \
        --max-model-len 200000 \
        --max-num-batched-tokens 4096 \
        --max-num-seqs 32 \
@@ -1157,7 +1156,7 @@ Before you start, please:
        --tensor-parallel-size $7 \
        --enable-expert-parallel \
        --seed 1024 \
-       --served-model-name deepseek_v4 \
+       --served-model-name dsv4 \
        --max-model-len 200000 \
        --max-num-batched-tokens 256 \
        --max-num-seqs 32 \

--- a/docs/source/tutorials/models/DeepSeek-V4-Pro.md
+++ b/docs/source/tutorials/models/DeepSeek-V4-Pro.md
@@ -447,7 +447,7 @@ The quantized model `DeepSeek-V4-Pro-w4a8-mtp` requires at least 2 Atlas 800 A3 
       --data-parallel-start-rank 0 \
       --tensor-parallel-size 16 \
       --enable-expert-parallel \
-      --served-model-name dsv4-pro \
+      --served-model-name dsv4 \
       --max-model-len 135000 \
       --max-num-batched-tokens 4096 \
       --max-num-seqs 16 \
@@ -510,7 +510,7 @@ The quantized model `DeepSeek-V4-Pro-w4a8-mtp` requires at least 2 Atlas 800 A3 
       --data-parallel-start-rank 1 \
       --tensor-parallel-size 16 \
       --enable-expert-parallel \
-      --served-model-name dsv4-pro \
+      --served-model-name dsv4 \
       --max-model-len 135000 \
       --max-num-batched-tokens 4096 \
       --max-num-seqs 16 \
@@ -751,7 +751,7 @@ Before you start, please:
         --tensor-parallel-size $7 \
         --enable-expert-parallel \
         --seed 1024 \
-        --served-model-name auto \
+        --served-model-name dsv4 \
         --max-model-len 131072 \
         --max-num-batched-tokens 4096 \
         --max-num-seqs 16 \
@@ -821,7 +821,7 @@ Before you start, please:
         --tensor-parallel-size $7 \
         --enable-expert-parallel \
         --seed 1024 \
-        --served-model-name auto \
+        --served-model-name dsv4 \
         --max-model-len 131072 \
         --max-num-batched-tokens 120 \
         --max-num-seqs 60 \
@@ -921,7 +921,7 @@ Before you start, please:
         --tensor-parallel-size $7 \
         --enable-expert-parallel \
         --seed 1024 \
-        --served-model-name dsv4-pro \
+        --served-model-name dsv4 \
         --max-model-len 150000 \
         --max-num-batched-tokens 4096 \
         --max-num-seqs 16 \
@@ -984,7 +984,7 @@ Before you start, please:
         --tensor-parallel-size $7 \
         --enable-expert-parallel \
         --seed 1024 \
-        --served-model-name dsv4-pro \
+        --served-model-name dsv4 \
         --max-model-len 150000 \
         --max-num-batched-tokens 96 \
         --max-num-seqs 8 \
@@ -1349,7 +1349,7 @@ Before you start, please:
      --tensor-parallel-size $7 \
      --enable-expert-parallel \
      --seed 1024 \
-     --served-model-name auto \
+     --served-model-name dsv4 \
      --max-model-len 150000 \
      --max-num-batched-tokens 4096 \
      --max-num-seqs 16 \
@@ -1421,7 +1421,7 @@ Before you start, please:
       --tensor-parallel-size $7 \
       --enable-expert-parallel \
       --seed 1024 \
-      --served-model-name auto \
+      --served-model-name dsv4 \
       --max-model-len 150000 \
       --max-num-batched-tokens 256 \
       --max-num-seqs 32 \


### PR DESCRIPTION
### What this PR does / why we need it?

This PR standardizes the `--served-model-name` parameter to `dsv4` across the DeepSeek-V4-Flash and DeepSeek-V4-Pro deployment examples. It also updates the block size for the A3 single-node DSpark example from 128 to 32 and removes the redundant `--async-scheduling` option since compatible vLLM configurations enable it automatically.

### Does this PR introduce _any_ user-facing change?

No (documentation only).

### How was this patch tested?

- Verified all 26 `--served-model-name` entries in the two documents now use `dsv4`.
- Verified tokenizer, tool-call, and reasoning parser values remain `deepseek_v4`.
- Ran `git diff --check` and verified Markdown code fences remain balanced.

- vLLM main: https://github.com/vllm-project/vllm/commit/d02df748bf9efd99022f1a062597dc3cb3808485