### PR TITLE
[Doc][Misc] Standardize DeepSeek-V4 served model names

### DIFF
--- a/docs/source/tutorials/models/DeepSeek-V4-Flash.md
+++ b/docs/source/tutorials/models/DeepSeek-V4-Flash.md
@@ -199,7 +199,7 @@ Single-node deployment completes both Prefill and Decode within the same node. T
     vllm serve /root/.cache/modelscope/hub/models/UploadWeight/DeepSeek-V4-Flash-DSpark-w4a8-test \
         --max-model-len 800000 \
         --max-num-batched-tokens 8192 \
-        --served-model-name dsv4-dspark \
+        --served-model-name dsv4 \
         --gpu-memory-utilization 0.9 \
         --max-num-seqs 32 \
         --data-parallel-size 1 \
@@ -665,7 +665,7 @@ Before you start, please:
             --tensor-parallel-size $7 \
             --enable-expert-parallel \
             --seed 1024 \
-            --served-model-name dsv4-spark \
+            --served-model-name dsv4 \
             --max-model-len 1048576 \
             --max-num-batched-tokens 8192 \
             --max-num-seqs 16 \

--- a/docs/source/tutorials/models/DeepSeek-V4-Pro.md
+++ b/docs/source/tutorials/models/DeepSeek-V4-Pro.md
@@ -447,7 +447,7 @@ The quantized model `DeepSeek-V4-Pro-w4a8-mtp` requires at least 2 Atlas 800 A3 
       --data-parallel-start-rank 0 \
       --tensor-parallel-size 16 \
       --enable-expert-parallel \
-      --served-model-name dsv4-pro \
+      --served-model-name dsv4 \
       --max-model-len 135000 \
       --max-num-batched-tokens 4096 \
       --max-num-seqs 16 \
@@ -510,7 +510,7 @@ The quantized model `DeepSeek-V4-Pro-w4a8-mtp` requires at least 2 Atlas 800 A3 
       --data-parallel-start-rank 1 \
       --tensor-parallel-size 16 \
       --enable-expert-parallel \
-      --served-model-name dsv4-pro \
+      --served-model-name dsv4 \
       --max-model-len 135000 \
       --max-num-batched-tokens 4096 \
       --max-num-seqs 16 \
@@ -749,7 +749,7 @@ Before you start, please:
         --tensor-parallel-size $7 \
         --enable-expert-parallel \
         --seed 1024 \
-        --served-model-name auto \
+        --served-model-name dsv4 \
         --max-model-len 131072 \
         --max-num-batched-tokens 4096 \
         --max-num-seqs 16 \
@@ -819,7 +819,7 @@ Before you start, please:
         --tensor-parallel-size $7 \
         --enable-expert-parallel \
         --seed 1024 \
-        --served-model-name auto \
+        --served-model-name dsv4 \
         --max-model-len 131072 \
         --max-num-batched-tokens 120 \
         --max-num-seqs 60 \
@@ -918,7 +918,7 @@ Before you start, please:
         --tensor-parallel-size $7 \
         --enable-expert-parallel \
         --seed 1024 \
-        --served-model-name dsv4-pro \
+        --served-model-name dsv4 \
         --max-model-len 150000 \
         --max-num-batched-tokens 4096 \
         --max-num-seqs 16 \
@@ -981,7 +981,7 @@ Before you start, please:
         --tensor-parallel-size $7 \
         --enable-expert-parallel \
         --seed 1024 \
-        --served-model-name dsv4-pro \
+        --served-model-name dsv4 \
         --max-model-len 150000 \
         --max-num-batched-tokens 96 \
         --max-num-seqs 8 \


### PR DESCRIPTION
### What this PR does / why we need it?

This PR standardizes the `--served-model-name` parameter to `dsv4` across the DeepSeek-V4-Flash and DeepSeek-V4-Pro deployment examples. This keeps the API-facing model name consistent across all deployment configurations while preserving the parser-specific `deepseek_v4` values.

### Does this PR introduce _any_ user-facing change?

No (documentation only).

### How was this patch tested?

- Verified all 22 `--served-model-name` entries in the two documents now use `dsv4`.
- Verified tokenizer, tool-call, and reasoning parser values remain `deepseek_v4`.
- Ran `git diff --check` and verified Markdown code fences remain balanced.

- vLLM main: https://github.com/vllm-project/vllm/commit/e6bfe03ad73a3330cb427885aa90d97a12e1c704