### PR TITLE
[BugFix] Bind Ascend KV pool store clients to the owning NPU (use device_id instead of local_rank)

### DIFF
--- a/tests/ut/distributed/ascend_store/_mock_deps.py
+++ b/tests/ut/distributed/ascend_store/_mock_deps.py
@@ -56,6 +56,10 @@ if "torch" not in sys.modules and importlib.util.find_spec("torch") is None:
     sys.modules["torch"] = _torch
     sys.modules["torch.distributed"] = _torch.distributed  # type: ignore[attr-defined]
 
+torch_module = sys.modules.get("torch") or importlib.import_module("torch")
+if not hasattr(torch_module, "npu"):
+    torch_module.npu = MagicMock()  # type: ignore[attr-defined]
+
 if "torch_npu" not in sys.modules:
     sys.modules["torch_npu"] = MagicMock()
     sys.modules["torch_npu._inductor"] = MagicMock()
@@ -84,6 +88,7 @@ _vllm_mock_modules = [
     "vllm.model_executor.layers.linear",
     "vllm.model_executor.layers.quantization",
     "vllm.platforms",
+    "vllm.platforms.interface",
     "vllm.utils",
     "vllm.utils.hashing",
     "vllm.utils.math_utils",

--- a/tests/ut/distributed/ascend_store/test_backend.py
+++ b/tests/ut/distributed/ascend_store/test_backend.py
@@ -834,8 +834,9 @@ class TestMemcacheQosInjection(unittest.TestCase):
         with (
             patch.dict(os.environ, {}, clear=True),
             patch.object(MemcacheBackend, "_setup_store"),
+            patch.object(memcache_module.torch.npu, "current_device", return_value=0),
         ):
-            MemcacheBackend(MagicMock(), local_rank=0, extra_config={"qos_priority": 2})
+            MemcacheBackend(MagicMock(), extra_config={"qos_priority": 2})
             self.assertEqual(os.environ.get(self._ENV), "2")
 
 

--- a/tests/ut/distributed/ascend_store/test_backend.py
+++ b/tests/ut/distributed/ascend_store/test_backend.py
@@ -28,6 +28,7 @@ from vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.backend import (
     backend_map,
     get_layerwise_protocol,
 )
+from vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.backend import base as backend_base
 from vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.backend import memcache_backend as memcache_module
 from vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.backend import mooncake_backend as mooncake_module
 from vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.backend.base import (
@@ -70,6 +71,30 @@ class TestBackendABC(unittest.TestCase):
     def test_cannot_instantiate(self):
         with self.assertRaises(TypeError):
             Backend(MagicMock())  # type: ignore[abstract]
+
+
+class TestBackendDeviceBinding(unittest.TestCase):
+    def test_scheduler_device(self):
+        for assigned_ids, expected in (([5], 2), (None, 3)):
+            with self.subTest(assigned_ids=assigned_ids):
+                npu = MagicMock()
+                npu.current_device.return_value = 3
+                parallel_config = SimpleNamespace(assigned_physical_gpu_ids=assigned_ids)
+                with (
+                    patch.object(backend_base.torch, "npu", npu),
+                    patch.object(backend_base, "set_assigned_physical_gpu_ids") as set_ids,
+                    patch.object(
+                        backend_base.current_platform,
+                        "logical_device_id_to_visible_device_id",
+                        return_value=2,
+                    ),
+                ):
+                    backend_base.set_scheduler_device(parallel_config)  # type: ignore[arg-type]
+
+                npu.set_device.assert_called_once_with(expected)
+                if assigned_ids is not None:
+                    set_ids.assert_called_once_with(assigned_ids)
+                    npu.current_device.assert_not_called()
 
 
 # =========================================================================
@@ -300,6 +325,7 @@ class TestMooncakeBackendSetup(unittest.TestCase):
         contribute_memory: bool = True,
     ) -> MooncakeBackend:
         backend = MooncakeBackend.__new__(MooncakeBackend)
+        backend.device_id = 0
         backend.parallel_config = MagicMock()
         backend.config = config
         backend.local_seg = None
@@ -337,13 +363,16 @@ class TestMooncakeBackendSetup(unittest.TestCase):
                     config=_make_mooncake_store_config(),
                     use_fabric_mem=use_fabric_mem,
                 )
+                backend.device_id = 3
                 store = MagicMock()
                 store.setup.return_value = 0
 
-                result = self._setup_store(backend, store)
+                with patch(f"{self._MODULE_PATH}.torch.npu.set_device") as set_device:
+                    result = self._setup_store(backend, store)
 
                 self.assertIs(result, store)
                 self.assertNotIn("tenant_id", store.setup.call_args.kwargs)
+                set_device.assert_called_once_with(3)
 
     def test_setup_forwards_tenant_for_all_memory_paths(self):
         for use_fabric_mem in (False, True):
@@ -423,6 +452,7 @@ class TestMooncakeBackendMethods(unittest.TestCase):
             patch.object(MooncakeBackend, "__init__", lambda self, pc: None),
         ):
             backend = MooncakeBackend.__new__(MooncakeBackend)
+            backend.device_id = 0
             backend.store = MagicMock()
             backend.config = MagicMock()
             backend.local_seg = "127.0.0.1:1234"
@@ -1106,7 +1136,7 @@ class TestMemcacheBackendMethods(unittest.TestCase):
         with patch.object(MemcacheBackend, "__init__", lambda self, pc: None):
             backend = MemcacheBackend.__new__(MemcacheBackend)
             backend.store = MagicMock()
-            backend.local_rank = 0
+            backend.device_id = 0
             # Set internal state to avoid lazy init logic during tests
             backend._lazy_init = False
             backend._store_initialized = True
@@ -1117,6 +1147,29 @@ class TestMemcacheBackendMethods(unittest.TestCase):
         b = self._make_backend()
         b.store.batch_is_exist.return_value = [1]
         self.assertEqual(b.exists(["k1"]), [1])
+
+    def test_setup_uses_captured_device(self):
+        b = self._make_backend()
+        b.device_id = 3
+        b._init_bm = True
+        store = MagicMock()
+        store.init.return_value = 0
+        module_path = "vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.backend.memcache_backend"
+
+        with (
+            patch.object(
+                sys.modules["memcache_hybrid"],
+                "DistributedObjectStore",
+                return_value=store,
+                create=True,
+            ),
+            patch(f"{module_path}.torch.npu.set_device") as set_device,
+            patch(f"{module_path}.time.sleep"),
+        ):
+            self.assertIs(b._setup_store(), store)
+
+        set_device.assert_called_once_with(3)
+        store.init.assert_called_once_with(3, init_bm=True)
 
     def test_register_buffer(self):
         b = self._make_backend()

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/backend/base.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/backend/base.py
@@ -5,7 +5,10 @@ from collections.abc import Iterable
 from numbers import Integral
 from typing import Any
 
+import torch
 from vllm.config import ParallelConfig
+from vllm.platforms import current_platform
+from vllm.platforms.interface import set_assigned_physical_gpu_ids
 
 # QoS range supported by the pooled KV store backends. A larger value
 # means a higher transfer priority.
@@ -52,6 +55,16 @@ def require_aligned_batch_results(
     if len(values) != len(keys):
         raise BatchResultShapeError(f"{operation} returned {len(values)} results for {len(keys)} keys")
     return values
+
+
+def set_scheduler_device(parallel_config: ParallelConfig) -> None:
+    assigned_ids = parallel_config.assigned_physical_gpu_ids
+    if assigned_ids is not None:
+        set_assigned_physical_gpu_ids(assigned_ids)
+        device_id = current_platform.logical_device_id_to_visible_device_id(0)
+    else:
+        device_id = torch.npu.current_device()
+    torch.npu.set_device(device_id)
 
 
 class Backend(ABC):

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/backend/memcache_backend.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/backend/memcache_backend.py
@@ -7,7 +7,6 @@ from typing import Any
 
 import torch
 from vllm.config import ParallelConfig
-from vllm.distributed.parallel_state import get_world_group
 from vllm.logger import logger
 
 from vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.backend.base import (
@@ -15,6 +14,7 @@ from vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.backend.base impor
     QOS_VALUE_MIN,
     Backend,
     parse_qos_from_extra_config,
+    set_scheduler_device,
 )
 
 
@@ -163,14 +163,13 @@ class MemcacheBackend(Backend):
     def __init__(
         self,
         parallel_config: ParallelConfig,
-        local_rank: int | None = None,
         init_bm: bool = True,
         lazy_init: bool = False,
         extra_config: dict[str, Any] | None = None,
     ):
         _inject_device_ub_qos(extra_config)
         _validate_device_ub_qos()
-        self.local_rank = local_rank if local_rank is not None else get_world_group().local_rank
+        self.device_id = torch.npu.current_device()
         self._init_bm = init_bm
         self._lazy_init = lazy_init and _is_device_sdma()
 
@@ -191,7 +190,7 @@ class MemcacheBackend(Backend):
             if self._store_initialized:
                 return
 
-            logger.info("Initializing Memcache store. local_rank=%d", self.local_rank)
+            logger.info("Initializing Memcache store. device_id=%d", self.device_id)
             self.store = self._setup_store()
             self._store_initialized = True
             self._register_buffers_if_needed()
@@ -206,10 +205,11 @@ class MemcacheBackend(Backend):
                 "to run vLLM with MemcacheConnector."
             ) from e
 
+        self.set_device()
         store = DistributedObjectStore()
 
         try:
-            res = store.init(torch.npu.current_device(), init_bm=self._init_bm)
+            res = store.init(self.device_id, init_bm=self._init_bm)
         except ValueError as e:
             logger.error("Configuration loading failed. error=%s. Check memcache config and environment.", e)
             raise
@@ -223,10 +223,8 @@ class MemcacheBackend(Backend):
 
     @classmethod
     def create_scheduler_client(cls, parallel_config: ParallelConfig):
-        # The scheduler is a single metadata client. It is initialized before
-        # the world group exists and must not initialize memcache storage, so
-        # keep the old device_id=0/init_bm=False behavior here.
-        return cls(parallel_config, local_rank=0, init_bm=False)
+        set_scheduler_device(parallel_config)
+        return cls(parallel_config, init_bm=False)
 
     def init_store(self, init_bm: bool = True):
         if self.store is not None:
@@ -237,8 +235,7 @@ class MemcacheBackend(Backend):
         self._register_buffers_if_needed()
 
     def set_device(self):
-        device = torch.device(f"npu:{self.local_rank}")
-        torch.npu.set_device(device)
+        torch.npu.set_device(self.device_id)
 
     def register_buffer(self, ptrs: list[int], sizes: list[int]):
         self._pending_buffers = (list(ptrs), list(sizes))

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/backend/memcache_backend.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/backend/memcache_backend.py
@@ -209,7 +209,7 @@ class MemcacheBackend(Backend):
         store = DistributedObjectStore()
 
         try:
-            res = store.init(self.local_rank, init_bm=self._init_bm)
+            res = store.init(torch.npu.current_device(), init_bm=self._init_bm)
         except ValueError as e:
             logger.error("Configuration loading failed. error=%s. Check memcache config and environment.", e)
             raise

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/backend/mooncake_backend.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/backend/mooncake_backend.py
@@ -12,7 +12,6 @@ import torch
 # Third Party
 from mooncake.store import ReplicateConfig  # type: ignore
 from vllm.config import ParallelConfig
-from vllm.distributed.parallel_state import get_world_group
 from vllm.logger import logger
 from vllm.utils.network_utils import get_ip
 
@@ -23,6 +22,7 @@ from vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.backend.base impor
     Backend,
     parse_qos_from_extra_config,
     require_aligned_batch_results,
+    set_scheduler_device,
 )
 from vllm_ascend.distributed.kv_transfer.utils.mooncake_transfer_engine import global_te
 from vllm_ascend.distributed.parallel_state import get_global_rank
@@ -194,6 +194,7 @@ class MooncakeBackend(Backend):
             raise NotImplementedError(f"MooncakeBackend does not support protocol {self.config.protocol!r}.")
         _inject_store_qos(extra_config)
         _validate_store_qos()
+        self.device_id = torch.npu.current_device()
 
         self.store: Any | None = None
         self.local_seg: str | None = None
@@ -233,6 +234,7 @@ class MooncakeBackend(Backend):
                 "to run vLLM with MooncakeConnector."
             ) from e
 
+        self.set_device()
         store = MooncakeDistributedStore()
         local_hostname = get_ip()
         ssd_kwargs = _ssd_setup_kwargs(self.config)
@@ -300,13 +302,11 @@ class MooncakeBackend(Backend):
 
     @classmethod
     def create_scheduler_client(cls, parallel_config: ParallelConfig):
-        torch.npu.set_device(0)
+        set_scheduler_device(parallel_config)
         return cls(parallel_config, contribute_memory=False)
 
     def set_device(self):
-        local_rank = get_world_group().local_rank
-        device = torch.device(f"npu:{local_rank}")
-        torch.npu.set_device(device)
+        torch.npu.set_device(self.device_id)
 
     def register_buffer(self, ptrs: list[int], lengths: list[int]):
         if self._use_store_independent_te:


### PR DESCRIPTION
### What this PR does / why we need it?
With DP>1, a worker can own NPU 1, 2, or 3 while its process-group local rank stays 0. The Ascend KV pool backends used that group-local rank — or a hard-coded NPU 0 — as the `rankid`/device when creating their Memcache/Mooncake store clients:

- Worker side: `MemcacheBackend` / `MooncakeBackend` fell back to `get_world_group().local_rank`, so every DP shard passed the same rank ids (`0..TP-1`). With DP=4/TP=1 all four shards initialized the store with `rankid=0`.
- Scheduler side: `MemcacheBackend.create_scheduler_client()` hard-coded `local_rank=0`, and Mooncake called `torch.npu.set_device(0)`.

The memcache/HYBM KV pool uses `device_sdma`, so a store instance (and the memory it contributes) is bound to a rank that must correspond to the owning NPU. Duplicated rank ids make the clients collide: the bm group only ever sees ranks `0..TP-1` instead of one distinct rank per NPU, so the vLLM server cannot launch successfully (in our run it started but the first request died with `HCCL watchdog` / `ERR02005 DIST internal error`, and only rank ids `0..3` were registered).

This PR binds each KV pool client to the NPU it actually owns:

- Add `set_scheduler_device(parallel_config)` to `backend/base.py`. When `parallel_config.assigned_physical_gpu_ids` is set, it publishes them via `set_assigned_physical_gpu_ids()` and resolves the shard's visible device with `current_platform.logical_device_id_to_visible_device_id(0)`; otherwise it falls back to the current device. It then calls `torch.npu.set_device(...)`.
- `MemcacheBackend`: drop the `local_rank` argument, capture `self.device_id = torch.npu.current_device()` once, call `self.set_device()` before creating `DistributedObjectStore`, and pass the captured `device_id` to `store.init(...)`. `create_scheduler_client()` resolves the device with `set_scheduler_device()` and still creates a metadata-only client (`init_bm=False`).
- `MooncakeBackend`: capture `self.device_id` the same way, call `self.set_device()` before `MooncakeDistributedStore` setup, and resolve the scheduler device with `set_scheduler_device()`.
- Remove the now-unused `get_world_group()` imports.

Scheduler clients remain metadata-only (`init_bm=False` for Memcache, no contributed memory for Mooncake). With this, each client stays on the NPU owned by its worker / DP shard, so DP=4/TP=1 no longer collides on rank 0 and launcher/inference work normally.

Related: #15968, which extends the same device-binding approach to the transfer-thread / DP-shard device mapping and the Mooncake scheduler path.

<img width="1794" height="332" alt="image" src="https://github.com/user-attachments/assets/a82f9989-c44c-440c-a491-1919fdf749fc" />
  
### Does this PR introduce _any_ user-facing change?
NONE. No launch configuration change. Internally, `MemcacheBackend`'s constructor argument changes from `local_rank` to `device_id`, and the scheduler client device is resolved from `assigned_physical_gpu_ids` (falling back to `torch.npu.current_device()`).

### How was this patch tested?
Unit tests, in `tests/ut/distributed/ascend_store/`:

- New `TestBackendDeviceBinding.test_scheduler_device` covering `assigned_physical_gpu_ids` → visible-device mapping and the `torch.npu.current_device()` fallback.
- `MemcacheBackend._setup_store()` asserted to call `torch.npu.set_device(captured_id)` and `store.init(captured_id, ...)`.
- `MooncakeBackend` setup asserted to call `set_device(captured_id)`.
- Mock deps extended so `torch.npu` and `vllm.platforms.interface` are importable, and the affected Memcache/Mooncake constructor tests updated to `device_id`.

E2E on Ascend A3 (DP=4/TP=4, Memcache KV pool backend, `MMC_LOCAL_CONFIG_PATH` = `dram.size=0GB`):

- Without this patch: server starts, but the first request fails (`EngineCore ... InternalServerError`; `ERR02005 DIST internal error` / `HCCL watchdog`), and the bm group only registers rank ids `0..3`.
- With this patch: `curl /v1/completions` returns a normal completion, and `vllm bench serve` (prefix_repetition, 5 prompts, concurrency 1) reports 5/5 successful requests; the bm group registers distinct rank ids `0..15`.

- vLLM main: vllm-project/vllm@b2f6858
