### PR TITLE
[Performance] Prioritize SAS metadata before QLI

### DIFF
--- a/.github/workflows/scripts/test_config.yaml
+++ b/.github/workflows/scripts/test_config.yaml
@@ -110,6 +110,7 @@ estimated_times:
   tests/e2e/pull_request/one_card/_310p/test_spec_decode_mtp_310p.py: 340
   tests/e2e/pull_request/one_card/_310p/test_vl_model_310p.py: 370
   tests/e2e/pull_request/one_card/aclgraph/test_aclgraph_batch_invariant.py: 550
+  tests/e2e/pull_request/one_card/aclgraph/test_device_metadata.py: 30
   tests/e2e/pull_request/one_card/compile/test_graphex_norm_quant_fusion.py: 170
   tests/e2e/pull_request/one_card/compile/test_graphex_qknorm_rope_fusion.py: 170
   tests/e2e/pull_request/one_card/compile/test_norm_quant_fusion.py: 210

--- a/tests/e2e/pull_request/one_card/aclgraph/test_device_metadata.py
+++ b/tests/e2e/pull_request/one_card/aclgraph/test_device_metadata.py
@@ -1,0 +1,77 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM Ascend project
+
+import pytest
+import torch
+import torch_npu  # noqa: F401
+from vllm.forward_context import BatchDescriptor
+
+from vllm_ascend.worker.device_metadata import DeviceMetadataExecutor, DeviceMetadataStage, DeviceMetadataTask
+
+
+@pytest.mark.parametrize("full_graph", [False, True])
+@pytest.mark.parametrize("consumer_order", [(0, 1), (1, 0)])
+def test_metadata_order_and_buffer_reuse(full_graph, consumer_order):
+    torch.npu.set_device(0)
+    executor = DeviceMetadataExecutor()
+    stream = torch.npu.Stream()
+    source = torch.zeros(16, device="npu")
+    prepared = torch.empty_like(source)
+    metadata = [torch.empty_like(source) for _ in range(3)]
+    outputs = [torch.empty_like(source) for _ in range(3)]
+    calls = []
+    snapshots = []
+    descriptor = BatchDescriptor(num_tokens=16, num_reqs=16) if full_graph else None
+    graph = torch.npu.NPUGraph() if full_graph else None
+
+    def prepare():
+        calls.append("prepare")
+        prepared.copy_(source)
+
+    def build(index):
+        calls.append(index)
+        torch.add(prepared, index + 1, out=metadata[index])
+
+    tasks = (
+        DeviceMetadataTask(DeviceMetadataStage.INDEXER, lambda: build(2), 2),
+        DeviceMetadataTask(DeviceMetadataStage.ATTENTION, lambda: build(0), 0),
+        DeviceMetadataTask(DeviceMetadataStage.ATTENTION, lambda: build(1), 1),
+        DeviceMetadataTask(DeviceMetadataStage.COMPRESSOR, prepare, 0),
+    )
+
+    def consume():
+        for index in consumer_order:
+            executor.wait(DeviceMetadataStage.ATTENTION, index)
+            outputs[index].copy_(metadata[index])
+        executor.wait(DeviceMetadataStage.INDEXER, 2)
+        outputs[2].copy_(metadata[2])
+
+    with torch.npu.stream(stream):
+        stream.wait_stream(torch.npu.default_stream())
+        executor.submit(tasks, descriptor)
+        assert calls == ["prepare", 0, 1, 2]
+        # Capture without a recording warmup: the next submission must be able
+        # to reorder producers while retaining the captured per-group events.
+        if graph is not None:
+            with torch.npu.graph(graph, stream=stream):
+                consume()
+        else:
+            consume()
+        executor.release()
+
+        for step in range(20):
+            calls.clear()
+            source.fill_(step)
+            executor.submit(tasks, descriptor)
+            assert calls == ["prepare", *consumer_order, 2]
+            if graph is not None:
+                graph.replay()
+            else:
+                consume()
+            snapshots.append([output.clone() for output in outputs])
+            executor.release()
+
+    torch.npu.synchronize()
+    for step, snapshot in enumerate(snapshots):
+        for index, actual in enumerate(snapshot):
+            torch.testing.assert_close(actual.cpu(), torch.full((16,), float(step + index + 1)), rtol=0, atol=0)

--- a/tests/ut/attention/test_dsa_v1.py
+++ b/tests/ut/attention/test_dsa_v1.py
@@ -326,7 +326,7 @@ def test_draft_swa_metadata_rejects_rows_above_buffer_capacity():
 @pytest.mark.parametrize(
     ("compressor_ratio", "expected_stages"),
     [
-        (4, list(DeviceMetadataStage)),
+        (4, [DeviceMetadataStage.COMPRESSOR, DeviceMetadataStage.INDEXER, DeviceMetadataStage.ATTENTION]),
         (128, [DeviceMetadataStage.COMPRESSOR, DeviceMetadataStage.ATTENTION]),
     ],
 )
@@ -458,7 +458,18 @@ def test_full_graph_compressor_metadata_uses_capture_bucket_extent():
         "expected_stages",
     ),
     [
-        (4, False, 3, None, [DeviceMetadataStage.COMPRESSOR, *list(DeviceMetadataStage)]),
+        (
+            4,
+            False,
+            3,
+            None,
+            [
+                DeviceMetadataStage.COMPRESSOR,
+                DeviceMetadataStage.COMPRESSOR,
+                DeviceMetadataStage.INDEXER,
+                DeviceMetadataStage.ATTENTION,
+            ],
+        ),
         (
             128,
             False,
@@ -466,7 +477,18 @@ def test_full_graph_compressor_metadata_uses_capture_bucket_extent():
             None,
             [DeviceMetadataStage.COMPRESSOR, DeviceMetadataStage.COMPRESSOR, DeviceMetadataStage.ATTENTION],
         ),
-        (4, True, 4, 1, [DeviceMetadataStage.COMPRESSOR, *list(DeviceMetadataStage)]),
+        (
+            4,
+            True,
+            4,
+            1,
+            [
+                DeviceMetadataStage.COMPRESSOR,
+                DeviceMetadataStage.COMPRESSOR,
+                DeviceMetadataStage.INDEXER,
+                DeviceMetadataStage.ATTENTION,
+            ],
+        ),
     ],
 )
 def test_dsa_cp_device_metadata_tasks(

--- a/tests/ut/worker/test_device_metadata.py
+++ b/tests/ut/worker/test_device_metadata.py
@@ -61,8 +61,8 @@ def executor_env(monkeypatch):
     allocations: list[str] = []
     model_stream = _FakeStream("model", calls)
     metadata_stream = _FakeStream("metadata", calls)
-    event_names = iter(("inputs", "reusable", "compressor", "indexer", "attention", "indexer-2"))
-    external_event_names = iter(f"external-{index}" for index in range(6))
+    event_names = iter(("inputs", "reusable", "compressor", "attention", "indexer", "extra-0", "extra-1", "extra-2"))
+    external_event_names = iter(f"external-{index}" for index in range(12))
 
     def make_stream():
         allocations.append("stream")
@@ -122,8 +122,8 @@ def test_stream_lifecycle_and_stage_frontiers(executor_env):
         "inputs",
         "reusable",
         "compressor",
-        "indexer",
         "attention",
+        "indexer",
     ]
 
     assert calls == [
@@ -131,10 +131,10 @@ def test_stream_lifecycle_and_stage_frontiers(executor_env):
         ("metadata", "wait", "inputs"),
         ("task", "compressor"),
         ("metadata", "record", "compressor"),
-        ("task", "indexer"),
-        ("metadata", "record", "indexer"),
         ("task", "attention"),
         ("metadata", "record", "attention"),
+        ("task", "indexer"),
+        ("metadata", "record", "indexer"),
     ]
     executor.wait(DeviceMetadataStage.INDEXER, 2)
     executor.wait(DeviceMetadataStage.INDEXER, 2)
@@ -167,12 +167,12 @@ def test_external_events_are_reused_per_batch_descriptor(executor_env):
     executor.wait(DeviceMetadataStage.INDEXER, 2)
     executor.wait(DeviceMetadataStage.INDEXER, 2)
     assert calls[-2:] == [
-        ("model", "external_wait", "external-1"),
-        ("model", "reset", "external-1"),
+        ("model", "external_wait", "external-2"),
+        ("model", "reset", "external-2"),
     ]
-    assert calls.count(("model", "external_wait", "external-1")) == 1
-    assert calls.count(("model", "reset", "external-1")) == 1
-    assert calls.index(("metadata", "record", "external-1")) < calls.index(("model", "external_wait", "external-1"))
+    assert calls.count(("model", "external_wait", "external-2")) == 1
+    assert calls.count(("model", "reset", "external-2")) == 1
+    assert calls.index(("metadata", "record", "external-2")) < calls.index(("model", "external_wait", "external-2"))
     executor.release()
     assert not executor.uses_external_events
     executor.submit(_tasks(calls), descriptor)
@@ -182,7 +182,8 @@ def test_external_events_are_reused_per_batch_descriptor(executor_env):
     assert allocations[-3:] == ["external-3", "external-4", "external-5"]
 
 
-def test_external_event_frontiers_must_remain_stable(executor_env):
+@pytest.mark.parametrize("changed_task", ["removed", "added", "replaced"])
+def test_external_event_frontiers_must_remain_stable(executor_env, changed_task):
     executor, calls, allocations = executor_env
     descriptor = BatchDescriptor(num_tokens=4, num_reqs=4)
 
@@ -191,12 +192,77 @@ def test_external_event_frontiers_must_remain_stable(executor_env):
     calls.clear()
     allocations_before = list(allocations)
 
+    tasks = _tasks(calls)[:-1]
+    if changed_task == "added":
+        tasks = _tasks(calls)
+    if changed_task != "removed":
+        tasks += (DeviceMetadataTask(DeviceMetadataStage.ATTENTION, lambda: None, 99),)
     with pytest.raises(RuntimeError, match="frontiers changed"):
-        executor.submit(_tasks(calls)[:-1], descriptor)
+        executor.submit(tasks, descriptor)
 
     assert calls == []
     assert allocations == allocations_before
     assert not executor.submission_in_flight
+
+
+@pytest.mark.parametrize("consumer_order", [(10, 20), (20, 10)])
+@pytest.mark.parametrize("full_graph", [False, True])
+def test_sas_order_follows_first_consumption(executor_env, consumer_order, full_graph):
+    executor, calls, allocations = executor_env
+    compressor = DeviceMetadataStage.COMPRESSOR
+    attention = DeviceMetadataStage.ATTENTION
+    indexer = DeviceMetadataStage.INDEXER
+    descriptor = BatchDescriptor(num_tokens=4, num_reqs=4) if full_graph else None
+
+    def task(stage, group_id):
+        return DeviceMetadataTask(stage, lambda: calls.append(("task", stage, group_id)), group_id)
+
+    tasks = (task(indexer, 1), task(attention, 10), task(compressor, 10), task(attention, 20), task(compressor, 20))
+    executor.submit(tasks, descriptor)
+    assert [call[1:] for call in calls if call[0] == "task"] == [
+        (compressor, 10),
+        (compressor, 20),
+        (attention, 10),
+        (attention, 20),
+        (indexer, 1),
+    ]
+    for group_id in consumer_order:
+        executor.wait(attention, group_id)
+        executor.wait(attention, group_id)
+    executor.release()
+    allocations_before = list(allocations)
+    calls.clear()
+
+    executor.submit(tasks, descriptor)
+    assert allocations == allocations_before
+    assert [call[1:] for call in calls if call[0] == "task"] == [
+        (compressor, 10),
+        (compressor, 20),
+        *((attention, group_id) for group_id in consumer_order),
+        (indexer, 1),
+    ]
+    first_sas = calls.index(("task", attention, consumer_order[0]))
+    ready_event = calls[first_sas + 1][2]
+    assert calls[first_sas + 1][:2] == ("metadata", "record")
+    assert first_sas < calls.index(("task", indexer, 1))
+    executor.wait(attention, consumer_order[0])
+    executor.wait(attention, consumer_order[0])
+    wait_kind = "external_wait" if full_graph else "wait"
+    assert calls.count(("model", wait_kind, ready_event)) == 1
+    executor.release()
+    calls.clear()
+
+    # A new graph shape reuses the order and keeps unseen SAS groups at the tail.
+    next_descriptor = BatchDescriptor(num_tokens=8, num_reqs=8) if full_graph else None
+    executor.submit((task(attention, 30), *tasks), next_descriptor)
+    assert [call[1:] for call in calls if call[0] == "task"] == [
+        (compressor, 10),
+        (compressor, 20),
+        *((attention, group_id) for group_id in consumer_order),
+        (attention, 30),
+        (indexer, 1),
+    ]
+    executor.release()
 
 
 def test_submit_failure_keeps_partial_submission_in_flight(executor_env):

--- a/vllm_ascend/worker/device_metadata.py
+++ b/vllm_ascend/worker/device_metadata.py
@@ -24,8 +24,8 @@ from vllm.forward_context import BatchDescriptor, get_forward_context, is_forwar
 
 class DeviceMetadataStage(IntEnum):
     COMPRESSOR = 0
-    INDEXER = 1
-    ATTENTION = 2
+    ATTENTION = 1
+    INDEXER = 2
 
 
 @dataclass(frozen=True, slots=True)
@@ -50,12 +50,14 @@ class DeviceMetadataExecutor:
         self._inputs_ready = torch.npu.Event()
         self._stage_ready: dict[tuple[DeviceMetadataStage, int], torch.npu.Event] = {}
         self._external_stage_ready: dict[tuple[BatchDescriptor, DeviceMetadataStage, int], torch.npu.ExternalEvent] = {}
-        self._external_frontiers: dict[BatchDescriptor, tuple[tuple[DeviceMetadataStage, int], ...]] = {}
+        self._external_frontiers: dict[BatchDescriptor, set[tuple[DeviceMetadataStage, int]]] = {}
         self._buffer_reusable = torch.npu.Event()
         self._has_reuse_fence = False
         self._submission_in_flight = False
         self._waited_stages: set[tuple[DeviceMetadataStage, int]] = set()
         self._batch_descriptor: BatchDescriptor | None = None
+        # Reuse each SAS group's first-consumption order across batch shapes.
+        self._attention_order: dict[int, int] = {}
 
     @property
     def submission_in_flight(self) -> bool:
@@ -72,10 +74,19 @@ class DeviceMetadataExecutor:
     ) -> None:
         if self._submission_in_flight:
             raise RuntimeError("The previous device metadata submission has not been released")
-        ordered_tasks = tuple(sorted(tasks, key=lambda task: task.stage))
+        ordered_tasks = sorted(
+            tasks,
+            key=lambda task: (
+                task.stage,
+                self._attention_order.get(task.group_id, len(self._attention_order))
+                if task.stage == DeviceMetadataStage.ATTENTION
+                else 0,
+            ),
+        )
         if not ordered_tasks:
             raise ValueError("At least one device metadata task is required")
-        submitted_frontiers = tuple(dict.fromkeys((task.stage, task.group_id) for task in ordered_tasks))
+        # Graph waits bind to event keys, independently of producer order.
+        submitted_frontiers = {(task.stage, task.group_id) for task in ordered_tasks}
         expected_frontiers = self._external_frontiers.get(batch_descriptor) if batch_descriptor is not None else None
         if expected_frontiers is not None and expected_frontiers != submitted_frontiers:
             raise RuntimeError("Device metadata frontiers changed for an existing full-graph batch descriptor")
@@ -123,6 +134,8 @@ class DeviceMetadataExecutor:
                 event.wait(stream)
                 event.reset(stream)
             self._waited_stages.add(frontier)
+            if stage == DeviceMetadataStage.ATTENTION:
+                self._attention_order.setdefault(group_id, len(self._attention_order))
 
     def release(self) -> None:
         if not self._submission_in_flight:


### PR DESCRIPTION
### What this PR does / why we need it?

Refs #15280. Follow-up to #15443.

The metadata stream currently builds QLI metadata before SAS metadata. An HCA-first model such as DeepSeek V4 Pro can therefore wait behind QLI work that its first attention layer does not consume. SAS groups also follow builder order, which may differ from their consumption order.

This PR changes `DeviceMetadataExecutor` to:

- Submit compressor tasks first, SAS tasks next, and QLI tasks last.
- Record each SAS group's first consumption in the existing `wait()` path and reuse that order across subsequent batches. The first submission retains the original SAS order; QLI is placed last immediately.
- Validate the task-key set for FULL graphs while allowing producer order to change. Per-group events, persistent buffers, and the existing buffer-reuse fence are retained.

Runtime changes are confined to the executor.

### Does this PR introduce _any_ user-facing change?

No API or configuration change. This changes task ordering in the existing asynchronous metadata path.

### How was this patch tested?

Validated rebased commit `61800b4c4`:

- **138 focused CPU unit tests passed**, covering executor ordering and lifecycle, group-specific waits, graph task-set validation, DSA/DSA-CP builders, compressor/indexer consumers, DSpark, and the model-runner graph-event handoff.
- **4 real Ascend NPU tests passed**, covering both SAS consumption orders in eager and FULL graph execution, capture without warmup, producer reordering after capture, and repeated buffer reuse. The graph cases perform 40 replays in total.
- `bash format.sh ci`: passed.
- Full `tools/mypy.sh 1 <version>` checks for Python **3.10, 3.11, and 3.12**: passed across `vllm_ascend`, `examples`, and `tests`.

CPU test command:

```bash
pytest -q \
  tests/ut/worker/test_device_metadata.py \
  tests/ut/attention/test_dsa_v1.py \
  tests/ut/attention/test_dsa_cp.py \
  tests/ut/spec_decode/test_dspark_proposer.py \
  tests/ut/models/test_deepseek_v4_compressor.py \
  tests/ut/models/test_deepseek_v4_indexer.py \
  tests/ut/worker/test_model_runner_v1.py::TestDeviceMetadataFullGraphEvents
```

NPU test command:

```bash
pytest -q tests/e2e/pull_request/one_card/aclgraph/test_device_metadata.py
```

End-to-end TPOT/throughput impact, including indexer-first workloads, has not yet been measured.

- vLLM main: https://github.com/vllm-project/vllm/commit/84030bbe3d74d99bad477a3d2e37a973ccd8865c
