### PR TITLE
[BugFix][MRV2] Align Gumbel sampling with upstream logits cache

### DIFF
--- a/tests/e2e/pull_request/one_card/test_gumbel_sampling.py
+++ b/tests/e2e/pull_request/one_card/test_gumbel_sampling.py
@@ -9,6 +9,7 @@
 
 import pytest
 import torch
+from vllm.v1.worker.gpu.spec_decode.dspark.speculator import DSparkSpeculator
 
 from vllm_ascend.worker.v2.sample.gumbel import apply_temperature, gumbel_sample
 from vllm_ascend.worker.v2.spec_decode.rejection_sampler_utils import rejection_sample
@@ -586,6 +587,27 @@ class TestGumbelSampling:
                 True,
                 logits_cache=torch.empty(1, 1, 31, device=DEVICE),
             )
+
+    def test_dspark_uses_ascend_gumbel(self):
+        """Exercise the inherited DSpark entry point with real NPU sampling."""
+        assert DSparkSpeculator._sample_logits.__globals__["gumbel_sample"] is gumbel_sample
+        speculator = DSparkSpeculator.__new__(DSparkSpeculator)
+        speculator._d2t_scatter_index = None
+        speculator.temperature = torch.tensor([0.5, 1.5], device=DEVICE)
+        speculator.seeds = torch.tensor([3, 7], dtype=torch.int64, device=DEVICE)
+        speculator._step_cols = torch.arange(2, dtype=torch.int32, device=DEVICE)
+        speculator.draft_logits = torch.zeros(2, 2, 1031, device=DEVICE)
+        speculator.use_fp64_gumbel = False
+        logits = torch.randn(2, 1031, device=DEVICE)
+        idx_mapping = torch.tensor([1, 0], dtype=torch.int32, device=DEVICE)
+        sample_pos = torch.tensor([8, 12], dtype=torch.int32, device=DEVICE)
+
+        sampled = speculator._sample_logits(logits, idx_mapping, sample_pos, step=1)
+
+        assert sampled.shape == (2,)
+        assert ((sampled >= 0) & (sampled < logits.shape[-1])).all()
+        torch.testing.assert_close(speculator.draft_logits[idx_mapping.long(), 1], logits, rtol=0, atol=0)
+        assert (speculator.draft_logits[:, 0] == 0).all()
 
     @pytest.mark.parametrize("temp", [0.5, 2.0])
     @pytest.mark.parametrize("vocab_size", [31, 1031])

--- a/tests/e2e/pull_request/one_card/test_gumbel_sampling.py
+++ b/tests/e2e/pull_request/one_card/test_gumbel_sampling.py
@@ -11,6 +11,7 @@ import pytest
 import torch
 
 from vllm_ascend.worker.v2.sample.gumbel import apply_temperature, gumbel_sample
+from vllm_ascend.worker.v2.spec_decode.rejection_sampler_utils import rejection_sample
 
 DEVICE = "npu"
 
@@ -313,7 +314,7 @@ class TestGumbelSampling:
 
     def test_gumbel_sample_apply_temperature_true_nonzero(self):
         """apply_temperature=True with temp>0 must divide logits by temperature
-        before adding Gumbel noise. Verify via processed_logits output."""
+        before adding Gumbel noise, while caching the unscaled logits."""
         torch.manual_seed(77)
         num_tokens, num_reqs, vocab_size = 4, 4, 32000
         logits = torch.randn(num_tokens, vocab_size, dtype=torch.float32, device=DEVICE)
@@ -322,30 +323,39 @@ class TestGumbelSampling:
         seed = torch.randint(0, 2**31, (num_reqs,), dtype=torch.int64, device=DEVICE)
         pos = torch.arange(num_tokens, dtype=torch.int32, device=DEVICE)
 
-        # Use processed_logits to verify temperature was applied
-        out_logits = torch.zeros(num_reqs, vocab_size, dtype=torch.float32, device=DEVICE)
-        gumbel_sample(
+        # Cache writes must not change the temperature-scaled samples.
+        out_logits = torch.zeros(num_reqs, 1, vocab_size, dtype=torch.float32, device=DEVICE)
+        sampled = gumbel_sample(
             logits,
             expanded_idx_mapping,
             temperature,
             seed,
             pos,
             apply_temperature=True,
-            output_processed_logits=out_logits,
+            logits_cache=out_logits,
+        )
+        expected_sampled = gumbel_sample(
+            logits / temperature[:, None],
+            expanded_idx_mapping,
+            temperature,
+            seed,
+            pos,
+            apply_temperature=False,
         )
         torch.npu.synchronize()
+        assert torch.equal(sampled, expected_sampled)
 
         for tok in range(num_tokens):
             req = expanded_idx_mapping[tok].item()
             temp = temperature[req].item()
-            expected = logits[tok].float() / temp
-            assert torch.allclose(out_logits[req].float(), expected, atol=1e-4, rtol=1e-4), (
-                f"processed_logits mismatch at token {tok} (req {req}, temp={temp:.3f}): "
-                f"max_diff={(out_logits[req].float() - expected).abs().max().item():.6f}"
+            expected = logits[tok].float()
+            assert torch.allclose(out_logits[req, 0].float(), expected, atol=1e-4, rtol=1e-4), (
+                f"logits_cache mismatch at token {tok} (req {req}, temp={temp:.3f}): "
+                f"max_diff={(out_logits[req, 0].float() - expected).abs().max().item():.6f}"
             )
 
     def test_gumbel_sample_apply_temperature_false_nonzero(self):
-        """apply_temperature=False with temp>0: processed_logits must contain
+        """apply_temperature=False with temp>0: logits_cache must contain
         raw logits (no temperature division), but Gumbel noise is still added
         to sampling."""
         torch.manual_seed(78)
@@ -356,7 +366,7 @@ class TestGumbelSampling:
         seed = torch.randint(0, 2**31, (num_reqs,), dtype=torch.int64, device=DEVICE)
         pos = torch.arange(num_tokens, dtype=torch.int32, device=DEVICE)
 
-        out_logits = torch.zeros(num_reqs, vocab_size, dtype=torch.float32, device=DEVICE)
+        out_logits = torch.zeros(num_reqs, 1, vocab_size, dtype=torch.float32, device=DEVICE)
         gumbel_sample(
             logits,
             expanded_idx_mapping,
@@ -364,7 +374,7 @@ class TestGumbelSampling:
             seed,
             pos,
             apply_temperature=False,
-            output_processed_logits=out_logits,
+            logits_cache=out_logits,
         )
         torch.npu.synchronize()
 
@@ -372,17 +382,17 @@ class TestGumbelSampling:
             req = expanded_idx_mapping[tok].item()
             # Without temperature application, stored logits should match raw logits
             expected = logits[tok].float()
-            assert torch.allclose(out_logits[req].float(), expected, atol=1e-4, rtol=1e-4), (
-                f"processed_logits should be raw logits when apply_temperature=False: "
-                f"max_diff={(out_logits[req].float() - expected).abs().max().item():.6f}"
+            assert torch.allclose(out_logits[req, 0].float(), expected, atol=1e-4, rtol=1e-4), (
+                f"logits_cache should be raw logits when apply_temperature=False: "
+                f"max_diff={(out_logits[req, 0].float() - expected).abs().max().item():.6f}"
             )
 
-    def test_gumbel_sample_processed_logits_req_state_idx(self):
-        """Processed logits must be stored at req_state_idx position, not token_idx.
+    def test_gumbel_sample_logits_cache_req_state_idx(self):
+        """Cached logits must be stored at req_state_idx position, not token_idx.
 
         This tests the EAGLE speculative decoding scenario where the idx_mapping
         is non-contiguous (e.g., active requests [2,5,7,0] out of 8 slots).
-        The buffer is shaped [max_num_reqs, vocab_size] and the kernel must store
+        The buffer is shaped [max_num_reqs, 1, vocab_size] and the kernel must store
         at the correct request slot.
         """
         torch.manual_seed(200)
@@ -397,7 +407,7 @@ class TestGumbelSampling:
         seed = torch.randint(0, 2**31, (max_num_reqs,), dtype=torch.int64, device=DEVICE)
         pos = torch.arange(num_tokens, dtype=torch.int32, device=DEVICE)
 
-        out_logits = torch.zeros(max_num_reqs, vocab_size, dtype=torch.float32, device=DEVICE)
+        out_logits = torch.zeros(max_num_reqs, 1, vocab_size, dtype=torch.float32, device=DEVICE)
         gumbel_sample(
             logits,
             expanded_idx_mapping,
@@ -405,15 +415,15 @@ class TestGumbelSampling:
             seed,
             pos,
             apply_temperature=True,
-            output_processed_logits=out_logits,
+            logits_cache=out_logits,
         )
         torch.npu.synchronize()
 
         for tok in range(num_tokens):
             req = expanded_idx_mapping[tok].item()
             temp = temperature[req].item()
-            expected = logits[tok].float() / temp
-            actual = out_logits[req]
+            expected = logits[tok].float()
+            actual = out_logits[req, 0]
             assert torch.allclose(actual.float(), expected, atol=1e-4, rtol=1e-4), (
                 f"Req {req} (tok={tok}, temp={temp:.3f}): max_diff={(actual.float() - expected).abs().max().item():.6f}"
             )
@@ -424,8 +434,8 @@ class TestGumbelSampling:
             if req not in used_reqs:
                 assert (out_logits[req] == 0).all(), f"Unused request slot {req} should be all zeros"
 
-    def test_gumbel_sample_processed_logits_col(self):
-        """output_processed_logits_col selects which column (draft step) to write.
+    def test_gumbel_sample_logits_cache_col(self):
+        """logits_cache_col selects which column (draft step) to write.
 
         Simulates EAGLE with buffer [max_num_reqs, num_steps, vocab_size].
         """
@@ -453,15 +463,14 @@ class TestGumbelSampling:
             seed,
             pos,
             apply_temperature=True,
-            output_processed_logits=draft_logits,
-            output_processed_logits_col=col_tensor,
+            logits_cache=draft_logits,
+            logits_cache_col=col_tensor,
         )
         torch.npu.synchronize()
 
         for tok in range(num_tokens):
             req = expanded_idx_mapping[tok].item()
-            temp = temperature[req].item()
-            expected = logits[tok].float() / temp
+            expected = logits[tok].float()
             # Data should be at draft_logits[req, 1, :]  (column 1)
             actual = draft_logits[req, 1, :]
             assert torch.allclose(actual.float(), expected, atol=1e-4, rtol=1e-4), (
@@ -471,12 +480,10 @@ class TestGumbelSampling:
             assert (draft_logits[req, 0, :] == 0).all(), f"Col 0 should be zeros for req {req}"
             assert (draft_logits[req, 2, :] == 0).all(), f"Col 2 should be zeros for req {req}"
 
-    def test_gumbel_sample_processed_logits_mixed_temp(self):
-        """Processed logits with mixed temperature (1:1 token-to-request mapping):
-        - temp=0: stored logits should be raw (no scaling)
-        - temp>0 with apply_temperature=True: stored logits should be logits/temp
+    def test_gumbel_sample_logits_cache_mixed_temp(self):
+        """Cached logits must remain unscaled for both greedy and random requests.
 
-        Note: In practice, output_processed_logits is only used by EAGLE
+        Note: In practice, logits_cache is only used by EAGLE
         speculative decoding, which always has 1:1 token-to-request mapping.
         Multiple tokens per request would cause a write race (undefined order).
         """
@@ -492,7 +499,7 @@ class TestGumbelSampling:
         seed = torch.randint(0, 2**31, (num_reqs,), dtype=torch.int64, device=DEVICE)
         pos = torch.arange(num_tokens, dtype=torch.int32, device=DEVICE)
 
-        out_logits = torch.zeros(num_reqs, vocab_size, dtype=torch.float32, device=DEVICE)
+        out_logits = torch.zeros(num_reqs, 1, vocab_size, dtype=torch.float32, device=DEVICE)
         gumbel_sample(
             logits,
             expanded_idx_mapping,
@@ -500,21 +507,130 @@ class TestGumbelSampling:
             seed,
             pos,
             apply_temperature=True,
-            output_processed_logits=out_logits,
+            logits_cache=out_logits,
         )
         torch.npu.synchronize()
 
         for tok in range(num_tokens):
             req = expanded_idx_mapping[tok].item()
             temp = temperature[req].item()
-            if temp == 0.0:
-                expected = logits[tok].float()
-            else:
-                expected = logits[tok].float() / temp
-            actual = out_logits[req]
+            expected = logits[tok].float()
+            actual = out_logits[req, 0]
             assert torch.allclose(actual.float(), expected, atol=1e-4, rtol=1e-4), (
                 f"Req {req} (tok={tok}, temp={temp:.3f}): max_diff={(actual.float() - expected).abs().max().item():.6f}"
             )
+
+    @pytest.mark.parametrize("per_token_col", [False, True])
+    @pytest.mark.parametrize("dtype", [torch.float32, torch.bfloat16])
+    def test_gumbel_sample_strided_logits_cache(self, per_token_col, dtype):
+        """Cache raw logits at mapped request/step slots, preserving padding."""
+        torch.manual_seed(202)
+        vocab_size = 1031
+        logits = torch.randn(4, vocab_size, dtype=dtype, device=DEVICE)
+        mapping = torch.tensor([2, 0, 2, -1], dtype=torch.int32, device=DEVICE)
+        if not per_token_col:
+            mapping[2] = 1
+        # Exercise non-contiguous index inputs as used by expanded batches.
+        mapping = torch.stack((mapping, mapping), dim=1)[:, 0]
+        pos = torch.arange(8, dtype=torch.int32, device=DEVICE)[::2]
+        temperature = torch.tensor([0.0, 0.5, 1.5], device=DEVICE)
+        seed = torch.arange(3, dtype=torch.int64, device=DEVICE)
+        cols = torch.tensor([0, 0, 2, 0, 1, 0, 2, 0], dtype=torch.int32, device=DEVICE)[::2]
+        if not per_token_col:
+            cols = torch.tensor(1, dtype=torch.int32, device=DEVICE)
+        storage = torch.full((3, 6, vocab_size + 17), 42, dtype=dtype, device=DEVICE)
+        cache = storage[:, ::2, :]
+        expected = storage.clone()
+        for token, req in enumerate(mapping.cpu().tolist()):
+            if req >= 0:
+                col = cols[token].item() if per_token_col else cols.item()
+                expected[req, 2 * col, :vocab_size] = logits[token]
+
+        gumbel_sample(
+            logits,
+            mapping,
+            temperature,
+            seed,
+            pos,
+            apply_temperature=True,
+            is_drafting=True,
+            logits_cache=cache,
+            logits_cache_col=cols,
+        )
+        torch.testing.assert_close(storage, expected, rtol=0, atol=0)
+
+    def test_gumbel_sample_draft_noise(self):
+        """Draft sampling uses the upstream position salt for an independent stream."""
+        logits = torch.zeros(16, 1031, device=DEVICE)
+        mapping = torch.arange(16, dtype=torch.int32, device=DEVICE)
+        temperature = torch.ones(16, device=DEVICE)
+        seed = torch.arange(16, dtype=torch.int64, device=DEVICE)
+        pos = torch.arange(16, dtype=torch.int32, device=DEVICE)
+        draft_noise_salt = 1 << 30
+        draft = gumbel_sample(logits, mapping, temperature, seed, pos, True, is_drafting=True)
+        shifted = gumbel_sample(logits, mapping, temperature, seed, pos + draft_noise_salt, True, is_drafting=False)
+        target = gumbel_sample(logits, mapping, temperature, seed, pos, True)
+        assert torch.equal(draft, shifted)
+        assert not torch.equal(draft, target)
+
+    def test_gumbel_sample_rejects_narrow_cache(self):
+        logits = torch.zeros(1, 32, device=DEVICE)
+        mapping = torch.zeros(1, dtype=torch.int32, device=DEVICE)
+        with pytest.raises(AssertionError, match="is narrower"):
+            gumbel_sample(
+                logits,
+                mapping,
+                torch.ones(1, device=DEVICE),
+                mapping,
+                mapping,
+                True,
+                logits_cache=torch.empty(1, 1, 31, device=DEVICE),
+            )
+
+    @pytest.mark.parametrize("temp", [0.5, 2.0])
+    @pytest.mark.parametrize("vocab_size", [31, 1031])
+    def test_cached_draft_rejection_temperature(self, temp, vocab_size):
+        """Raw cached drafts and pre-scaled drafts must verify/resample identically."""
+        torch.manual_seed(203)
+        num_reqs, num_steps = 32, 2
+        mapping = torch.arange(num_reqs, dtype=torch.int32, device=DEVICE)
+        temperature = torch.full((num_reqs,), temp, device=DEVICE)
+        seed = torch.arange(num_reqs, dtype=torch.int64, device=DEVICE)
+        draft_logits = torch.randn(num_reqs, vocab_size, device=DEVICE)
+        cache = torch.empty(num_reqs, num_steps, vocab_size, device=DEVICE)
+        draft_tokens = torch.zeros(num_reqs, num_steps + 1, dtype=torch.int64, device=DEVICE)
+        for step in range(num_steps):
+            draft_tokens[:, step + 1] = gumbel_sample(
+                draft_logits,
+                mapping,
+                temperature,
+                seed,
+                mapping + step,
+                True,
+                is_drafting=True,
+                logits_cache=cache,
+                logits_cache_col=torch.tensor(step, dtype=torch.int32, device=DEVICE),
+            )
+        inputs = dict(
+            target_logits=torch.randn(num_reqs * (num_steps + 1), vocab_size, device=DEVICE),
+            draft_sampled=draft_tokens.flatten(),
+            cu_num_logits=torch.arange(num_reqs + 1, dtype=torch.int32, device=DEVICE) * (num_steps + 1),
+            pos=torch.arange(num_reqs * (num_steps + 1), dtype=torch.int32, device=DEVICE),
+            idx_mapping=mapping,
+            expanded_idx_mapping=mapping.repeat_interleave(num_steps + 1),
+            expanded_local_pos=torch.arange(num_steps + 1, dtype=torch.int32, device=DEVICE).repeat(num_reqs),
+            seed=seed,
+            num_speculative_steps=num_steps,
+        )
+        sampled, counts = rejection_sample(**inputs, draft_logits=cache, temperature=temperature)
+        expected, expected_counts = rejection_sample(
+            **inputs, draft_logits=cache / temp, temperature=torch.ones_like(temperature)
+        )
+        assert torch.equal(counts, expected_counts)
+        # Output slots after the first rejection are unspecified.
+        valid = torch.arange(num_steps + 1, device=DEVICE)[None, :] < counts[:, None]
+        assert torch.equal(sampled[valid], expected[valid])
+        assert (counts < num_steps + 1).any(), "Exercise the residual resampling path"
 
     def test_gumbel_sample_single_token(self):
         """Single token with temperature > 0 should work."""

--- a/tests/ut/patch/worker/test_patch_v2_gumbel.py
+++ b/tests/ut/patch/worker/test_patch_v2_gumbel.py
@@ -1,0 +1,62 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import importlib
+from unittest.mock import MagicMock, create_autospec
+
+import pytest
+import torch
+from vllm.v1.worker.gpu.sample import gumbel, sampler
+from vllm.v1.worker.gpu.spec_decode import speculator as base_speculator
+from vllm.v1.worker.gpu.spec_decode.dspark import speculator as dspark_speculator
+
+from vllm_ascend.patch.worker.patch_v2 import patch_triton
+from vllm_ascend.worker.v2.sample.gumbel import gumbel_sample
+
+
+@pytest.mark.parametrize("consumer", [gumbel, sampler, base_speculator, dspark_speculator])
+def test_gumbel_patch_rebinds_preimported_consumers(monkeypatch, consumer):
+    # Simulate a consumer retaining its original `from ... import` binding.
+    stale_gumbel = MagicMock()
+    monkeypatch.setattr(consumer, "gumbel_sample", stale_gumbel)
+
+    importlib.reload(patch_triton)
+
+    assert consumer.gumbel_sample is gumbel_sample
+    stale_gumbel.assert_not_called()
+
+
+@pytest.mark.parametrize("probabilistic", [False, True])
+def test_dspark_sample_logits_dispatch(monkeypatch, probabilistic):
+    speculator = dspark_speculator.DSparkSpeculator.__new__(dspark_speculator.DSparkSpeculator)
+    speculator.model = MagicMock()
+    speculator.model.map_draft_to_target.side_effect = lambda tokens: tokens + 10
+    speculator._d2t_scatter_index = None
+    speculator.temperature = torch.tensor([0.5, 1.5])
+    speculator.seeds = torch.tensor([3, 7])
+    speculator._step_cols = torch.arange(2, dtype=torch.int32)
+    speculator.draft_logits = torch.empty(2, 2, 3) if probabilistic else None
+    speculator.use_fp64_gumbel = False
+    logits = torch.tensor([[1.0, 3.0, 2.0], [4.0, 2.0, 1.0]])
+    idx_mapping = torch.tensor([1, 0], dtype=torch.int32)
+    sample_pos = torch.tensor([8, 12])
+    sampled = torch.tensor([2, 1])
+    sample = create_autospec(gumbel_sample, return_value=sampled)
+    monkeypatch.setattr(dspark_speculator, "gumbel_sample", sample)
+
+    result = speculator._sample_logits(logits, idx_mapping, sample_pos, step=1)
+
+    if probabilistic:
+        assert result is sampled
+        sample.assert_called_once()
+        args, kwargs = sample.call_args
+        assert args[0] is logits
+        assert args[1] is idx_mapping
+        torch.testing.assert_close(args[4], sample_pos - 1)
+        assert kwargs["apply_temperature"] is True
+        assert kwargs["logits_cache"] is speculator.draft_logits
+        torch.testing.assert_close(kwargs["logits_cache_col"], speculator._step_cols[1])
+        assert kwargs["use_fp64"] is False
+    else:
+        sample.assert_not_called()
+        torch.testing.assert_close(result, logits.argmax(dim=-1) + 10)

--- a/vllm_ascend/ops/triton/v2/spec_decode/resample.py
+++ b/vllm_ascend/ops/triton/v2/spec_decode/resample.py
@@ -103,6 +103,7 @@ def _resample_kernel(
                         mask=vocab_mask,
                         other=float("-inf"),
                     ).to(tl.float32)
+                    draft_block_logits = draft_block_logits / temperature
                     draft_lse = tl.load(draft_rejected_logsumexp_ptr + req_idx)
                     draft_prob = tl.exp(draft_block_logits - draft_lse)
                     # NPU: upstream #46665 computes this residual in log space
@@ -263,6 +264,7 @@ def _categorical_finalize_kernel(
             mask=valid_token_mask & is_random_residual & has_total_mass,
             other=float("-inf"),
         ).to(tl.float32)
+        draft_block_logits = draft_block_logits / tl.where(temperature != 0.0, temperature, 1.0)
         draft_lse = tl.load(
             draft_rejected_logsumexp_ptr + req_idx, mask=is_random_residual & has_total_mass, other=0.0
         ).to(tl.float32)
@@ -321,6 +323,9 @@ def resample(
     written to ``sampled[req_idx, num_sampled[req_idx]]`` and ``num_sampled`` is
     advanced by one. Greedy non-bonus rows preserve the target argmax already
     written by the verification kernel and only advance ``num_sampled``.
+
+    ``draft_logits`` contains raw cached logits; draft logsumexp statistics
+    must include temperature scaling, as in the verification path.
 
     ``target_logits`` and full ``draft_logits`` support fp16, bf16, and fp32;
     probability-mass arithmetic is fp32. Their vocabulary dimension must be

--- a/vllm_ascend/patch/worker/patch_v2/patch_triton.py
+++ b/vllm_ascend/patch/worker/patch_v2/patch_triton.py
@@ -5,6 +5,7 @@ from vllm.v1.worker.gpu import structured_outputs
 from vllm.v1.worker.gpu.sample import bad_words, gumbel, logprob, penalties, prompt_logprob, sampler, states
 from vllm.v1.worker.gpu.spec_decode import rejection_sampler, rejection_sampler_utils
 from vllm.v1.worker.gpu.spec_decode.dflash import speculator as dflash_speculator
+from vllm.v1.worker.gpu.spec_decode.dspark import speculator as dspark_speculator
 from vllm.v1.worker.gpu.spec_decode.eagle import speculator
 
 from vllm_ascend.ops.triton.v2.apply_grammar_bitmask import _apply_grammar_bitmask_kernel
@@ -33,6 +34,7 @@ states.apply_min_p = apply_min_p
 penalties.bincount = bincount
 speculator.gumbel_sample = gumbel_sample
 base_speculator.gumbel_sample = gumbel_sample
+dspark_speculator.gumbel_sample = gumbel_sample
 bad_words.apply_bad_words = apply_bad_words
 gumbel.gumbel_sample = gumbel_sample
 gumbel.apply_temperature = apply_temperature

--- a/vllm_ascend/worker/v2/sample/gumbel.py
+++ b/vllm_ascend/worker/v2/sample/gumbel.py
@@ -80,7 +80,8 @@ def apply_temperature(
     do_not_specialize=[
         "local_argmax_stride",
         "local_max_stride",
-        "processed_logits_stride",
+        "logits_cache_stride_0",
+        "logits_cache_stride_1",
         "logits_stride",
         "vocab_size",
         "num_blocks",
@@ -91,9 +92,10 @@ def _gumbel_sample_kernel(
     local_argmax_stride,
     local_max_ptr,
     local_max_stride,
-    processed_logits_ptr,
-    processed_logits_stride,
-    processed_logits_col_ptr,
+    logits_cache_ptr,
+    logits_cache_stride_0,
+    logits_cache_stride_1,
+    logits_cache_col_ptr,
     logits_ptr,
     logits_stride,
     expanded_idx_mapping_ptr,
@@ -104,12 +106,14 @@ def _gumbel_sample_kernel(
     num_blocks,
     BLOCK_SIZE: tl.constexpr,
     APPLY_TEMPERATURE: tl.constexpr,
+    IS_DRAFTING: tl.constexpr,
     PER_TOKEN_COL: tl.constexpr,
 ):
     token_idx = tl.program_id(0).to(tl.int64)
 
     req_state_idx = tl.load(expanded_idx_mapping_ptr + token_idx).to(tl.int64)
-    temp = tl.load(temp_ptr + req_state_idx).to(tl.float32)
+    is_valid_req = req_state_idx >= 0
+    temp = tl.load(temp_ptr + req_state_idx, mask=is_valid_req, other=0.0).to(tl.float32)
 
     for block_idx in range(num_blocks):
         block = block_idx * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
@@ -121,31 +125,35 @@ def _gumbel_sample_kernel(
         )
         logits = logits.to(tl.float32)
 
-        block_temp = temp
-        if block_temp != 0.0 and APPLY_TEMPERATURE:
-            logits = logits / block_temp
-
-        if processed_logits_ptr is not None:
-            # Store the temperature-applied logits.
-            if processed_logits_col_ptr is not None:
+        if logits_cache_ptr is not None:
+            # Cache logits before temperature scaling; rejection sampling applies
+            # the same temperature on load, allowing low-precision caches.
+            if logits_cache_col_ptr is not None:
                 if PER_TOKEN_COL:
-                    col = tl.load(processed_logits_col_ptr + token_idx)
+                    col = tl.load(logits_cache_col_ptr + token_idx)
                 else:
-                    col = tl.load(processed_logits_col_ptr)
+                    col = tl.load(logits_cache_col_ptr)
             else:
                 col = 0
             tl.store(
-                processed_logits_ptr + req_state_idx * processed_logits_stride + col * vocab_size + block,
+                logits_cache_ptr + req_state_idx * logits_cache_stride_0 + col * logits_cache_stride_1 + block,
                 logits,
-                mask=mask,
+                mask=mask & is_valid_req,
             )
 
-        if block_temp != 0.0:
+        if temp != 0.0 and APPLY_TEMPERATURE:
+            logits = logits / temp
+
+        if temp != 0.0:
             # Calculate the seed for gumbel noise.
             seed = tl.load(seeds_ptr + req_state_idx)
             # NOTE(Ronald1995): change pos's dtype to tl.int32, because triton-ascend's
             # compiler doesn't support uint64 of pos arg.
             pos = tl.load(pos_ptr + token_idx).to(tl.int32)
+            if IS_DRAFTING:
+                # Keep draft and target noise independent, as in upstream.
+                DRAFT_NOISE_SALT: tl.constexpr = 1 << 30
+                pos += DRAFT_NOISE_SALT
             gumbel_seed = tl.randint(seed, pos)
 
             # NOTE(Ronald1995): r is tl.float64 in vllm, change it to tl.float32,
@@ -171,13 +179,23 @@ def gumbel_sample(
     seed: torch.Tensor,  # [max_num_reqs]
     pos: torch.Tensor,  # [num_tokens]
     apply_temperature: bool,
-    output_processed_logits: torch.Tensor | None = None,
-    output_processed_logits_col: torch.Tensor | None = None,
+    is_drafting: bool = False,  # The verified vLLM revision does not pass this yet.
+    logits_cache: torch.Tensor | None = None,  # [max_num_reqs, num_cols, vocab_size]
+    logits_cache_col: torch.Tensor | None = None,  # scalar or [num_tokens]
     use_fp64: bool = False,
 ) -> torch.Tensor:
     if use_fp64:
         raise NotImplementedError("FP64 Gumbel sampling is not supported on NPU.")
+    expanded_idx_mapping = expanded_idx_mapping.contiguous()
+    pos = pos.contiguous()
+    if logits_cache_col is not None:
+        logits_cache_col = logits_cache_col.contiguous()
     num_tokens, vocab_size = logits.shape
+    if logits_cache is not None:
+        assert logits_cache.size(-1) >= vocab_size, (
+            f"draft logits cache vocab dim ({logits_cache.size(-1)}) is narrower "
+            f"than the sampled logits ({vocab_size}). Cached logits would be truncated."
+        )
     BLOCK_SIZE = 1024
     num_blocks = triton.cdiv(vocab_size, BLOCK_SIZE)
     local_argmax = torch.empty(
@@ -192,15 +210,16 @@ def gumbel_sample(
         dtype=torch.float32,
         device=logits.device,
     )
-    per_token_col = output_processed_logits_col is not None and output_processed_logits_col.dim() > 0
+    per_token_col = logits_cache_col is not None and logits_cache_col.dim() > 0
     _gumbel_sample_kernel[(num_tokens,)](
         local_argmax,
         local_argmax.stride(0),
         local_max,
         local_max.stride(0),
-        output_processed_logits,
-        output_processed_logits.stride(0) if output_processed_logits is not None else 0,
-        output_processed_logits_col,
+        logits_cache,
+        logits_cache.stride(0) if logits_cache is not None else 0,
+        logits_cache.stride(1) if logits_cache is not None else 0,
+        logits_cache_col,
         logits,
         logits.stride(0),
         expanded_idx_mapping,
@@ -211,6 +230,7 @@ def gumbel_sample(
         num_blocks,
         BLOCK_SIZE=BLOCK_SIZE,
         APPLY_TEMPERATURE=apply_temperature,
+        IS_DRAFTING=is_drafting,
         PER_TOKEN_COL=per_token_col,
     )
     # NOTE(woosuk): Use int64 for later indexing.

--- a/vllm_ascend/worker/v2/spec_decode/rejection_sampler_utils.py
+++ b/vllm_ascend/worker/v2/spec_decode/rejection_sampler_utils.py
@@ -172,6 +172,8 @@ def _probabilistic_rejection_kernel(
                         + i * draft_logits_stride_1
                         + draft_sampled
                     ).to(tl.float32)
+                    # Match the temperature-scaled block statistics.
+                    draft_logit = draft_logit / temp
                     draft_lse = _compute_global_lse(
                         draft_local_max_ptr,
                         draft_local_max_stride,


### PR DESCRIPTION
### What this PR does / why we need it?

Upstream MRv2 draft sampling passes `logits_cache` and `logits_cache_col`, but the Ascend Gumbel override still exposes `output_processed_logits`, causing keyword-argument failures. Align the cache arguments and accept the newer `is_drafting` argument, defaulting to `False` for the currently verified vLLM revision.

Cache logits before temperature scaling and use both cache strides. Scale cached draft logits in verification and both categorical resampling stages to match upstream block statistics. Preserve the optimized resample implementation from main. Honor the upstream draft-noise position salt when `is_drafting=True`.

Explicitly bind DSpark's imported `gumbel_sample` to the Ascend implementation so probabilistic drafting uses the NPU operator even when DSpark is imported before the worker patches. DSpark's greedy path continues to use argmax.

### Does this PR introduce _any_ user-facing change?

Fixes MRv2 draft sampling with the upstream cache interface and non-unit temperatures, including DSpark's probabilistic path. No new configuration options. FP64 sampling remains unsupported on NPU.

### How was this patch tested?

**Dual-version integration validation is currently blocked on vLLM v0.28.0 by pre-existing repository startup incompatibilities.** The table below tests the same PR commit, `3e5ab18982a695fd5dcdc97117bba4b1599c7e5b`, with separate upstream checkouts and verified source paths.

| vLLM baseline | CPU regression | Real A3 NPU regression | Full mypy (Python 3.10 / 3.11 / 3.12) |
| --- | --- | --- | --- |
| `.github/vllm-main-verified.commit`: [`e6bfe03ad73a`](https://github.com/vllm-project/vllm/commit/e6bfe03ad73a3330cb427885aa90d97a12e1c704) | 6 passed | 68 passed: 41 Gumbel/DSpark + 27 resample | All passed |
| `v0.28.0` / `releases/v0.28.0`: [`2cf0a6915ce5`](https://github.com/vllm-project/vllm/commit/2cf0a6915ce544dc493a0990f2ea38d81601128a) | Collection blocked | Collection blocked | All passed |

Commands run separately with each upstream checkout on `PYTHONPATH`:

```bash
python -m pytest -q tests/ut/patch/worker/test_patch_v2_gumbel.py
python -m pytest -q tests/e2e/pull_request/one_card/test_gumbel_sampling.py tests/e2e/nightly/single_node/ops/singlecard_ops/triton/test_resample.py
for python_version in 3.10 3.11 3.12; do
    tools/mypy.sh 1 "$python_version"
done
```

The NPU environment used Ascend A3 and `triton-ascend==3.2.2`. Coverage includes raw caches, scalar/per-token columns, strided/BF16 caches, invalid requests, draft noise separation, DSpark dispatch, and temperature equivalence across single-block and cross-block resampling.

On v0.28.0, standard CPU and NPU collection fails before executing these tests: `vllm_ascend/patch/platform/patch_use_v2_model_runner.py` accesses the absent `VllmConfig._get_v1_model_runner_unsupported_features`. The same NPU collection failure was reproduced on the unchanged PR base `b0c49dc7a884d3d343f6a556380f11b74191c3e8`; this PR does not modify that patch. Separately loading the existing worker Triton patch also encounters the absent `vllm.v1.attention.ops.pcp`, imported by unchanged `vllm_ascend/attention/attention_v1.py`.

Supplemental **isolated kernel validation** on v0.28.0 passed **67 tests, with 1 deselected**, using the same two NPU files with `--noconftest -k 'not test_dspark_uses_ascend_gumbel'`. This bypasses repository-wide patch initialization and excludes the DSpark patch-binding integration case. It validates the kernels on 0.28, but **does not establish DSpark integration or a passing dual-version integration matrix**.

- `bash format.sh ci` passed on this unchanged PR commit.
- CPU UT routes to CPU; the Gumbel PR test routes to A2 single-card CI. Manual hardware validation used A3, not A2.
- These are focused compatibility checks, not the full community NPU suite. At verification time, upstream `.github/vllm-release-tag.commit` still named `v0.27.1`; the supplemental release check above explicitly uses the requested `v0.28.0`.

- vLLM main: https://github.com/vllm-project/vllm/commit/b2f685834a6456197e7033966fdef52a23f1abcd
