### PR TITLE
[Attention][Feature] Integrate Model Runner V2 and DSpark Speculative Decoding for Ascend

### DIFF
--- a/benchmarks/k3_mrv2_kv_zeroer.py
+++ b/benchmarks/k3_mrv2_kv_zeroer.py
@@ -1,0 +1,118 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Microbenchmark the MRV2 Ascend KV block zeroing hot path."""
+
+import argparse
+import json
+import statistics
+import time
+from types import SimpleNamespace
+
+import torch
+from vllm.v1.kv_cache_interface import FullAttentionSpec
+
+from vllm_ascend.ops.triton.triton_utils import init_device_properties_triton
+from vllm_ascend.worker.utils import AscendKVBlockZeroer
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--layers", type=int, default=24, help="Attention layers; each contributes K and V segments")
+    parser.add_argument("--num-blocks", type=int, default=128)
+    parser.add_argument("--blocks-per-step", type=int, default=4)
+    parser.add_argument("--iterations", type=int, default=100)
+    parser.add_argument("--warmup-iterations", type=int, default=20)
+    parser.add_argument("--padding-elements", type=int, default=64)
+    parser.add_argument("--max-p95-us", type=float, default=None, help="Optional regression threshold")
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = _parse_args()
+    if min(args.layers, args.num_blocks, args.blocks_per_step, args.iterations) <= 0:
+        raise ValueError("layers, blocks, and iterations must be positive")
+    if args.blocks_per_step > args.num_blocks:
+        raise ValueError("blocks-per-step cannot exceed num-blocks")
+
+    device = torch.device("npu")
+    init_device_properties_triton()
+    block_size = 128
+    head_size = 64
+    dtype = torch.bfloat16
+    payload_elements = block_size * head_size
+    stride_elements = payload_elements + args.padding_elements
+    layer_names = [f"layer.{idx}" for idx in range(args.layers)]
+    raw_buffers: list[torch.Tensor] = []
+    static_forward_context = {}
+
+    for layer_name in layer_names:
+        components = []
+        for _ in range(2):
+            raw = torch.empty(
+                64 + args.num_blocks * stride_elements,
+                dtype=dtype,
+                device=device,
+            )
+            component = torch.as_strided(
+                raw,
+                (args.num_blocks, block_size, 1, head_size),
+                (stride_elements, head_size, head_size, 1),
+                storage_offset=64,
+            )
+            raw_buffers.append(raw)
+            components.append(component)
+        static_forward_context[layer_name] = SimpleNamespace(kv_cache=tuple(components))
+
+    spec = FullAttentionSpec(
+        block_size=block_size,
+        num_kv_heads=1,
+        head_size=head_size,
+        dtype=dtype,
+    )
+    group = SimpleNamespace(
+        kv_cache_spec=spec,
+        kv_cache_group_id=0,
+        layer_names=layer_names,
+    )
+    zeroer = AscendKVBlockZeroer(device, pin_memory=True)
+    zeroer.init_meta(
+        [group],
+        [[block_size]],
+        "auto",
+        set(),
+        static_forward_context,
+    )
+
+    block_ids = list(range(args.blocks_per_step))
+    for _ in range(args.warmup_iterations):
+        zeroer.zero_block_ids(block_ids)
+    torch.npu.synchronize()
+
+    samples_us = []
+    for iteration in range(args.iterations):
+        start_block = iteration % (args.num_blocks - args.blocks_per_step + 1)
+        block_ids = list(range(start_block, start_block + args.blocks_per_step))
+        start = time.perf_counter_ns()
+        zeroer.zero_block_ids(block_ids)
+        torch.npu.synchronize()
+        samples_us.append((time.perf_counter_ns() - start) / 1000)
+
+    sorted_samples = sorted(samples_us)
+    p95_index = min(len(sorted_samples) - 1, int(len(sorted_samples) * 0.95))
+    result = {
+        "layers": args.layers,
+        "segments": args.layers * 2,
+        "num_blocks": args.num_blocks,
+        "blocks_per_step": args.blocks_per_step,
+        "iterations": args.iterations,
+        "mean_us": statistics.fmean(samples_us),
+        "p50_us": statistics.median(samples_us),
+        "p95_us": sorted_samples[p95_index],
+    }
+    print(json.dumps(result, indent=2, sort_keys=True))
+    if args.max_p95_us is not None and result["p95_us"] > args.max_p95_us:
+        raise SystemExit(f"p95 {result['p95_us']:.2f} us exceeds {args.max_p95_us:.2f} us")
+
+
+if __name__ == "__main__":
+    main()

--- a/docs/source/tutorials/models/Kimi-K3.md
+++ b/docs/source/tutorials/models/Kimi-K3.md
@@ -124,6 +124,96 @@ For an installation outside Docker, follow the
 the selected main checkout and its verified vLLM commit instead of the older
 release versions in the generic examples.
 
+### 4.3 Model Runner V2 Target-Only Validation
+
+The Model Runner V2 gates below target vLLM `v0.27.1` at commit
+`6e448d0ea9bf3d88d898b65449ca6dc2aec170ac`. Verify the source checkout before
+building the runtime image:
+
+```shell
+test "$(git -C /vllm-workspace/vllm rev-parse HEAD)" = \
+  "6e448d0ea9bf3d88d898b65449ca6dc2aec170ac"
+```
+
+Set the following environment variable before starting a target-only MRV2
+functional test:
+
+```shell
+export VLLM_USE_V2_MODEL_RUNNER=1
+```
+
+Omit `--speculative-config` from the launch command. The bounded functional
+configuration uses `--max-model-len 2048`, `--max-num-seqs 4`,
+`--max-num-batched-tokens 512`, `--mamba-cache-mode align`, and prefix caching.
+Use `--enforce-eager` for the eager baseline, or
+`--compilation-config '{"cudagraph_mode":"FULL_DECODE_ONLY"}'` for ACL Graph.
+
+The target-only regression starts separate eager and ACL Graph engines with the
+same seed and requires identical token IDs for block-boundary, exact-prefix and
+partial-prefix requests. The automated ACL Graph test installs a worker-local
+counter around `ModelAclGraphManager.run_fullgraph` and requires every worker
+to replay at least once; merely configuring or capturing `FULL_DECODE_ONLY` is
+not accepted as graph evidence.
+
+Run the metadata, NPU zeroing, and target functional gates from the repository
+root:
+
+```shell
+pytest -sv tests/ut/worker/test_model_runner_v2_mamba.py
+pytest -sv tests/ut/worker/test_kv_block_zeroer.py
+pytest -sv tests/e2e/pull_request/one_card/model_runner_v2/test_kv_block_zeroer_npu.py
+pytest -sv tests/e2e/pull_request/four_card/test_kimi_k3.py::test_k3_mrv2_without_draft
+python benchmarks/k3_mrv2_kv_zeroer.py --layers 24 --blocks-per-step 4
+```
+
+The functional test uses a reduced dummy target to exercise the runtime shape
+and cache lifecycle. It does not establish checkpoint loading or model
+accuracy. Before declaring the target gate complete, repeat eager and ACL Graph
+parity with the full real checkpoint, record the vLLM/vLLM Ascend commits,
+image digest, CANN and torch-npu versions, and retain the graph replay log and
+worker replay count together with the zeroer benchmark result.
+
+This target-only scope does not establish long-context capacity, P/D support,
+or MRV2 DSpARK correctness. Keep using MRV1 for production DSpARK until the
+separate draft gates are completed.
+
+### 4.4 Model Runner V2 MLA DSpARK Eager Validation
+
+The MLA eager gate keeps both the target and draft in eager mode. The MLA draft
+declares a raw-prefix-sum auxiliary-hidden-state contract when it is loaded;
+the K3 target validates the requested layer boundaries and hidden width before
+selecting that stream. The speculator then validates the aggregate runtime
+shape, dtype, and device without reading NPU tensor values, and delegates
+context/query preparation, Markov sampling, and state commit/rollback to the
+upstream MRV2 `DSparkSpeculator`.
+
+Run the contract tests and the four-card dummy functional comparison:
+
+```shell
+pytest -sv tests/ut/models/test_dspark_aux.py
+pytest -sv tests/ut/spec_decode/test_dspark_speculator.py
+pytest -sv tests/e2e/pull_request/four_card/test_kimi_k3.py::test_k3_mrv2_mla_dspark_eager
+```
+
+The functional test starts independent target-only and MLA DSpARK eager
+engines with the same seed. It compares exact token IDs across block boundaries
+and cold/repeated/reset requests with prefix caching enabled, and requires the
+draft-token metric to be non-zero so speculative decoding cannot be bypassed
+silently. The target-only oracle must report a real prefix-cache hit. vLLM
+0.27.1 does not report a reusable prefix-cache hit for the same request while
+DSpARK is enabled, so the draft run validates deterministic output but does not
+claim draft + prefix-cache state reuse.
+
+This reduced dummy test does not validate checkpoint loading, QuaRot, draft
+acceptance patterns, or model accuracy. Before accepting the MLA eager gate,
+repeat it with the full target and MLA draft checkpoints and retain evidence
+for zero, partial, and full acceptance, block crossing, abort/request reuse,
+and deterministic parity with target-only eager. Prefix-cache state reuse while
+DSpARK is enabled also remains a separate follow-up gate. GQA DSpARK and draft
+ACL Graph remain separate follow-up scopes. Multimodal draft inputs are also
+deferred for this bring-up because vLLM 0.27.1 keeps DFlash multimodal capability
+disabled.
+
 ## 5 Online Service Deployment
 
 ### 5.1 Four-Node Online Deployment

--- a/docs/source/tutorials/models/Kimi-K3.md
+++ b/docs/source/tutorials/models/Kimi-K3.md
@@ -126,14 +126,11 @@ release versions in the generic examples.
 
 ### 4.3 Model Runner V2 Target-Only Validation
 
-The Model Runner V2 gates below target vLLM `v0.27.1` at commit
-`6e448d0ea9bf3d88d898b65449ca6dc2aec170ac`. Verify the source checkout before
-building the runtime image:
-
-```shell
-test "$(git -C /vllm-workspace/vllm rev-parse HEAD)" = \
-  "6e448d0ea9bf3d88d898b65449ca6dc2aec170ac"
-```
+Use the vLLM main revision paired with this vLLM Ascend main checkout.
+Earlier dependency validation used vLLM `v0.27.1` at `6e448d0`; those
+results are historical and do not qualify this main-based integration.
+The integration uses main's `layers`, `layer_stride`, and `block_stride`
+cache descriptors and retains main's MRV2 DP synchronization interfaces.
 
 Set the following environment variable before starting a target-only MRV2
 functional test:
@@ -209,10 +206,34 @@ acceptance patterns, or model accuracy. Before accepting the MLA eager gate,
 repeat it with the full target and MLA draft checkpoints and retain evidence
 for zero, partial, and full acceptance, block crossing, abort/request reuse,
 and deterministic parity with target-only eager. Prefix-cache state reuse while
-DSpARK is enabled also remains a separate follow-up gate. GQA DSpARK and draft
-ACL Graph remain separate follow-up scopes. Multimodal draft inputs are also
-deferred for this bring-up because vLLM 0.27.1 keeps DFlash multimodal capability
-disabled.
+DSpARK is enabled also remains a separate follow-up gate.
+
+### 4.5 Model Runner V2 GQA DSpARK ACL Graph Integration
+
+GQA drafts consume materialized target auxiliary hidden states. For QuaRot
+targets, pass rotation metadata to the BF16 draft loader before weight sharing
+is decided, so FC, embedding, and LM head use the correct representation.
+The loader rejects unintended sharing of rotated target embedding/LM-head
+weights. MLA drafts retain their raw-prefix-sum contract.
+
+Use `VLLM_USE_V2_MODEL_RUNNER=1`, target compilation mode
+`{"cudagraph_mode":"FULL_DECODE_ONLY"}`, and `enforce_eager=false` in the
+DSpark speculative configuration. Set the target and draft context limits to
+the intended workload (for example, both to `135000` for long-context tests).
+The GQA graph updater validates backend selection, padded query lengths, and
+captured parameter/handle/event counts before submitting replay updates.
+
+This integration keeps the full target layers and routed experts. It includes
+no runtime expert reduction or reduced-layer checkpoint remapping. Synthetic
+small-model tests are not full-checkpoint accuracy results.
+
+Run `tests/ut/spec_decode/test_dspark_graph_contract.py` in addition to the
+contract and cache tests above. Hardware qualification of this main-based
+integration is pending. The preceding four-node full-expert integration
+completed target/draft graph capture but stalled on the first inference;
+it produced no valid acceptance result. Capture success does not establish
+successful runtime replay, and this integration does not claim to fix that
+distributed hang.
 
 ## 5 Online Service Deployment
 

--- a/tests/e2e/pull_request/four_card/test_kimi_k3.py
+++ b/tests/e2e/pull_request/four_card/test_kimi_k3.py
@@ -11,6 +11,7 @@ Random weights cannot validate checkpoint loading, QuaRot or acceptance rates.
 import json
 from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
+from types import MethodType
 
 import pytest
 import requests
@@ -314,8 +315,8 @@ def k3_models(tmp_path_factory: pytest.TempPathFactory) -> dict[str, str]:
 
 
 @pytest.fixture(autouse=True)
-def k3_runtime(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setenv("VLLM_USE_V2_MODEL_RUNNER", "0")
+def k3_runtime(monkeypatch: pytest.MonkeyPatch, request: pytest.FixtureRequest) -> None:
+    monkeypatch.setenv("VLLM_USE_V2_MODEL_RUNNER", getattr(request, "param", "0"))
     monkeypatch.setenv("VLLM_WORKER_MULTIPROC_METHOD", "spawn")
     monkeypatch.setenv("HCCL_OP_EXPANSION_MODE", "AIV")
     monkeypatch.setenv("HCCL_BUFFSIZE", "512")
@@ -404,6 +405,152 @@ def test_k3_mla_block5_tp4(k3_models: dict[str, str]) -> None:
         drafts = [m for m in llm.get_metrics() if m.name == "vllm:spec_decode_num_drafts"]
         assert drafts and all(isinstance(m, Counter) for m in drafts)
         assert sum(m.value for m in drafts) > 0, "Requests bypassed speculative decoding"
+
+
+def _token_ids(outputs) -> tuple[tuple[int, ...], ...]:
+    return tuple(tuple(output.outputs[0].token_ids) for output in outputs)
+
+
+def _install_full_graph_replay_counter(worker) -> bool:
+    manager = worker.model_runner.cudagraph_manager
+    assert manager is not None
+    original_run_fullgraph = manager.run_fullgraph
+    manager._k3_test_replay_count = 0
+
+    def tracked_run_fullgraph(self, desc):
+        self._k3_test_replay_count += 1
+        return original_run_fullgraph(desc)
+
+    manager.run_fullgraph = MethodType(tracked_run_fullgraph, manager)
+    return True
+
+
+def _get_full_graph_replay_count(worker) -> int:
+    manager = worker.model_runner.cudagraph_manager
+    assert manager is not None
+    return manager._k3_test_replay_count
+
+
+def _run_k3_mrv2_mla_dspark_eager(
+    k3_models: dict[str, str],
+    *,
+    variant: str,
+    with_draft: bool,
+) -> dict[str, tuple[tuple[int, ...], ...]]:
+    args = _engine_args(k3_models, variant)
+    args["max_model_len"] = PREFIX_CACHE_MODEL_LEN
+    args["enforce_eager"] = True
+    args["compilation_config"] = {"cudagraph_mode": "NONE"}
+    if not with_draft:
+        del args["speculative_config"]
+
+    with VllmRunner(k3_models["target"], **args) as runner:
+        llm = runner.model
+        boundary = _generate(
+            llm,
+            [_prompt(length, salt=i * 137) for i, length in enumerate((127, 128, 129, 769))],
+        )
+
+        prefix = _prompt(PREFIX_CACHE_TOKENS, salt=421)
+        assert llm.reset_prefix_cache()
+        cold = _generate(llm, [prefix])[0]
+        warm = _generate(llm, [prefix])[0]
+        assert llm.reset_prefix_cache()
+        reset = _generate(llm, [prefix])[0]
+        assert _token_ids([cold, warm, reset]) == (_token_ids([cold])[0],) * 3
+        assert cold.num_cached_tokens == 0
+        assert reset.num_cached_tokens == 0
+        if not with_draft:
+            # Prefix-cache hit/reuse is a target-state Gate 1 requirement. The
+            # vLLM 0.27.1 DSpark path recreates the aligned page instead of
+            # reporting a reusable hit, so Gate 2 validates deterministic
+            # draft execution across the same cold/warm/reset traffic without
+            # claiming support for draft + prefix-cache state reuse.
+            assert warm.num_cached_tokens > 0
+
+        if with_draft:
+            drafts = [m for m in llm.get_metrics() if m.name == "vllm:spec_decode_num_drafts"]
+            assert drafts and sum(m.value for m in drafts) > 0, "Requests bypassed MLA DSpark"
+
+        return {
+            "boundary": _token_ids(boundary),
+            "prefix": _token_ids([cold, warm, reset]),
+        }
+
+
+@pytest.mark.parametrize("k3_runtime", ["1"], indirect=True, ids=["mrv2"])
+@pytest.mark.parametrize("variant", ["mla", "mla_block5"])
+def test_k3_mrv2_mla_dspark_eager(k3_models: dict[str, str], variant: str) -> None:
+    no_spec = _run_k3_mrv2_mla_dspark_eager(k3_models, variant=variant, with_draft=False)
+    mla_dspark = _run_k3_mrv2_mla_dspark_eager(k3_models, variant=variant, with_draft=True)
+
+    assert mla_dspark == no_spec
+
+
+def _run_k3_mrv2_target(k3_models: dict[str, str], *, enforce_eager: bool) -> dict[str, tuple[tuple[int, ...], ...]]:
+    args = _engine_args(k3_models, "mla_block5")
+    del args["speculative_config"]
+    args["max_model_len"] = PREFIX_CACHE_MODEL_LEN
+    args["enforce_eager"] = enforce_eager
+    args["compilation_config"] = {"cudagraph_mode": "FULL_DECODE_ONLY", "cudagraph_capture_sizes": [1, 2, 4]}
+    with VllmRunner(k3_models["target"], **args) as runner:
+        llm = runner.model
+        if not enforce_eager:
+            assert all(llm.collective_rpc(_install_full_graph_replay_counter))
+        boundary = _generate(llm, [_prompt(length, salt=i * 137) for i, length in enumerate((127, 128, 129, 769))])
+        # Cross the aligned 1536-token hybrid-cache page and verify that the
+        # restored recurrent state matches both the cold and reset paths.
+        prefix = _prompt(PREFIX_CACHE_TOKENS, salt=421)
+        assert llm.reset_prefix_cache()
+        cold = _generate(llm, [prefix])[0]
+        warm = _generate(llm, [prefix])[0]
+        assert cold.num_cached_tokens == 0
+        assert warm.num_cached_tokens > 0
+        assert cold.outputs[0].token_ids == warm.outputs[0].token_ids
+        assert llm.reset_prefix_cache()
+        reset = _generate(llm, [prefix])[0]
+        assert reset.num_cached_tokens == 0
+        assert cold.outputs[0].token_ids == reset.outputs[0].token_ids
+
+        # Exercise a partial prefix hit rather than only an identical-request
+        # cache hit. The suffix-B output must match its cold/reset oracle even
+        # after suffix-A populated the shared physical prefix blocks.
+        common_prefix = _prompt(1536, salt=811)["prompt_token_ids"]
+        suffix_a = _prompt(32, salt=1201)["prompt_token_ids"]
+        suffix_b = _prompt(32, salt=1601)["prompt_token_ids"]
+        partial_a = {"prompt_token_ids": [*common_prefix, *suffix_a]}
+        partial_b = {"prompt_token_ids": [*common_prefix, *suffix_b]}
+        assert llm.reset_prefix_cache()
+        partial_cold = _generate(llm, [partial_b])[0]
+        assert partial_cold.num_cached_tokens == 0
+        assert llm.reset_prefix_cache()
+        _generate(llm, [partial_a])
+        partial_warm = _generate(llm, [partial_b])[0]
+        assert partial_warm.num_cached_tokens > 0
+        assert partial_cold.outputs[0].token_ids == partial_warm.outputs[0].token_ids
+        assert llm.reset_prefix_cache()
+        partial_reset = _generate(llm, [partial_b])[0]
+        assert partial_reset.num_cached_tokens == 0
+        assert partial_cold.outputs[0].token_ids == partial_reset.outputs[0].token_ids
+
+        result = {
+            "boundary": _token_ids(boundary),
+            "exact_prefix": _token_ids([cold, warm, reset]),
+            "partial_prefix": _token_ids([partial_cold, partial_warm, partial_reset]),
+        }
+        if not enforce_eager:
+            replay_counts = llm.collective_rpc(_get_full_graph_replay_count)
+            assert replay_counts and all(count > 0 for count in replay_counts)
+        return result
+
+
+@pytest.mark.parametrize("k3_runtime", ["1"], indirect=True, ids=["mrv2"])
+def test_k3_mrv2_without_draft(k3_models: dict[str, str], monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("VLLM_ALLOW_INSECURE_SERIALIZATION", "1")
+    eager = _run_k3_mrv2_target(k3_models, enforce_eager=True)
+    aclgraph = _run_k3_mrv2_target(k3_models, enforce_eager=False)
+
+    assert eager == aclgraph
 
 
 def _serve_args(args: dict) -> list[str]:

--- a/tests/e2e/pull_request/one_card/model_runner_v2/test_kv_block_zeroer_npu.py
+++ b/tests/e2e/pull_request/one_card/model_runner_v2/test_kv_block_zeroer_npu.py
@@ -1,0 +1,144 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+"""Ascend NPU coverage for hybrid KV block zeroing."""
+
+from types import SimpleNamespace
+
+import pytest
+import torch
+from vllm.v1.core.block_pool import BlockPool
+from vllm.v1.core.single_type_kv_cache_manager import get_manager_for_kv_cache_spec
+from vllm.v1.kv_cache_interface import FullAttentionSpec
+
+from vllm_ascend.core.kv_cache_interface import (
+    AscendMLAAttentionSpec,
+    register_ascend_kv_cache_specs,
+)
+from vllm_ascend.ops.triton.triton_utils import init_device_properties_triton
+from vllm_ascend.worker.utils import AscendKVBlockZeroer
+
+
+@pytest.mark.parametrize("ratio", [1, 3])
+@pytest.mark.parametrize("padded", [False, True])
+def test_zero_split_kv_blocks_preserves_other_blocks_and_padding(ratio, padded):
+    device = torch.device("npu")
+    init_device_properties_triton()
+    num_blocks, kernel_bs = 4, 128
+    spec = FullAttentionSpec(block_size=kernel_bs * ratio, num_kv_heads=1, head_size=64, dtype=torch.bfloat16)
+    caches = []
+    expected_caches = []
+    raw_buffers = []
+    expected_buffers = []
+    for width, dtype in ((512, torch.bfloat16), (64, torch.bfloat16), (32, torch.int8)):
+        payload = kernel_bs * width
+        stride = payload + (128 if padded else 0)
+        raw = torch.full((128 + num_blocks * ratio * stride,), 7, dtype=dtype, device=device)
+        expected = raw.clone()
+        shape, strides = (num_blocks * ratio, kernel_bs, 1, width), (stride, width, width, 1)
+        caches.append(torch.as_strided(raw, shape, strides, storage_offset=128))
+        expected_caches.append(torch.as_strided(expected, shape, strides, storage_offset=128))
+        raw_buffers.append(raw)
+        expected_buffers.append(expected)
+    caches.append(torch.empty(num_blocks * ratio, kernel_bs, 1, 0, dtype=torch.bfloat16, device=device))
+    group = SimpleNamespace(kv_cache_spec=spec, kv_cache_group_id=0, layer_names=["attn", "shared"])
+    zeroer = AscendKVBlockZeroer(device, pin_memory=True)
+    zeroer.init_meta(
+        [group],
+        [[kernel_bs]],
+        "auto",
+        set(),
+        {name: SimpleNamespace(kv_cache=tuple(caches)) for name in group.layer_names},
+    )
+    for block_ids in ([0], [1, 3]):
+        zeroer.zero_block_ids(block_ids)
+        for cache in expected_caches:
+            for block_id in block_ids:
+                cache[block_id * ratio : (block_id + 1) * ratio].zero_()
+        torch.npu.synchronize()
+        for actual, expected in zip(raw_buffers, expected_buffers):
+            torch.testing.assert_close(actual, expected, rtol=0, atol=0)
+
+
+def test_zero_hybrid_split_views_sharing_one_allocation():
+    device = torch.device("npu")
+    init_device_properties_triton()
+    num_blocks, block_size = 4, 128
+    state_elements = 1024
+    key_elements, value_elements = num_blocks * block_size * 512, num_blocks * block_size * 64
+    raw = torch.full((state_elements + key_elements + value_elements,), 7, dtype=torch.bfloat16, device=device)
+    expected = raw.clone()
+
+    def views(buffer):
+        k = buffer[state_elements : state_elements + key_elements].view(num_blocks, block_size, 1, 512)
+        v = buffer[state_elements + key_elements :].view(num_blocks, block_size, 1, 64)
+        return k, v
+
+    spec = AscendMLAAttentionSpec(block_size=block_size, num_kv_heads=1, head_size=576, dtype=torch.bfloat16)
+    group = SimpleNamespace(kv_cache_spec=spec, kv_cache_group_id=0, layer_names=["attn"])
+    zeroer = AscendKVBlockZeroer(device, pin_memory=True)
+    zeroer.init_meta([group], [[block_size]], "auto", set(), {"attn": SimpleNamespace(kv_cache=views(raw))})
+    zeroer.zero_block_ids([1, 3])
+    for cache in views(expected):
+        cache[1].zero_()
+        cache[3].zero_()
+    torch.npu.synchronize()
+    torch.testing.assert_close(raw, expected, rtol=0, atol=0)
+
+
+def test_abort_reallocate_zeroes_reused_blocks_before_replacement_reads():
+    device = torch.device("npu")
+    init_device_properties_triton()
+    register_ascend_kv_cache_specs()
+    # Keep exactly two allocatable blocks (plus the null block) so both
+    # supported upstream allocator orders must reuse the aborted request.
+    num_blocks, block_size = 3, 128
+    spec = AscendMLAAttentionSpec(
+        block_size=block_size,
+        num_kv_heads=1,
+        head_size=64,
+        dtype=torch.bfloat16,
+    )
+    block_pool = BlockPool(num_blocks, enable_caching=False, hash_block_size=block_size)
+    manager = get_manager_for_kv_cache_spec(
+        spec,
+        max_in_flight_tokens=256,
+        max_model_len=4096,
+        block_pool=block_pool,
+        enable_caching=False,
+        kv_cache_group_id=0,
+        scheduler_block_size=block_size,
+        needs_kv_cache_zeroing=True,
+    )
+
+    key_cache = torch.zeros(num_blocks, block_size, 1, 48, dtype=torch.bfloat16, device=device)
+    value_cache = torch.zeros(num_blocks, block_size, 1, 16, dtype=torch.bfloat16, device=device)
+    group = SimpleNamespace(kv_cache_spec=spec, kv_cache_group_id=0, layer_names=["attn"])
+    zeroer = AscendKVBlockZeroer(device, pin_memory=True)
+    zeroer.init_meta(
+        [group],
+        [[block_size]],
+        "auto",
+        set(),
+        {"attn": SimpleNamespace(kv_cache=(key_cache, value_cache))},
+    )
+
+    original = manager.allocate_new_blocks("aborted", 129, 129)
+    original_ids = manager.take_new_block_ids()
+    assert original_ids == [block.block_id for block in original]
+    zeroer.zero_block_ids(original_ids)
+    for block_id in original_ids:
+        key_cache[block_id].fill_(7)
+        value_cache[block_id].fill_(7)
+
+    manager.free("aborted")
+    replacement = manager.allocate_new_blocks("replacement", 129, 129)
+    reused_ids = manager.take_new_block_ids()
+    assert {block.block_id for block in replacement} == set(original_ids)
+    assert set(reused_ids) == set(original_ids)
+
+    zeroer.zero_block_ids(reused_ids)
+    torch.npu.synchronize()
+    for block_id in reused_ids:
+        torch.testing.assert_close(key_cache[block_id], torch.zeros_like(key_cache[block_id]), rtol=0, atol=0)
+        torch.testing.assert_close(value_cache[block_id], torch.zeros_like(value_cache[block_id]), rtol=0, atol=0)

--- a/tests/e2e/pull_request/one_card/spec_decode/test_prepare_dflash_inputs_v0271.py
+++ b/tests/e2e/pull_request/one_card/spec_decode/test_prepare_dflash_inputs_v0271.py
@@ -1,0 +1,139 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Validate v0.27.1 DFlash semantics and the pinned-main signature shim."""
+
+import torch
+from vllm.v1.attention.backends.utils import PAD_SLOT_ID
+
+from vllm_ascend.utils import vllm_version_is
+from vllm_ascend.worker.v2.spec_decode.dflash.speculator import (
+    _prepare_dflash_inputs_kernel_ascend,
+)
+
+
+def _run_prepare(*, positions: list[int], block_table_values: list[int]):
+    device = torch.device("npu")
+    max_num_reqs = 4
+    max_num_tokens = 16
+    num_speculative_steps = 3
+
+    out_input_ids = torch.full((max_num_tokens,), -1, dtype=torch.int32, device=device)
+    out_query_positions = torch.full((max_num_tokens,), -1, dtype=torch.int64, device=device)
+    out_query_start_loc = torch.full((max_num_reqs + 1,), -1, dtype=torch.int32, device=device)
+    out_seq_lens = torch.full((max_num_reqs,), -1, dtype=torch.int32, device=device)
+    out_query_slot_mapping = torch.full((max_num_tokens,), -2, dtype=torch.int64, device=device)
+    out_context_positions = torch.full((max_num_tokens,), -1, dtype=torch.int64, device=device)
+    out_context_slot_mapping = torch.full((max_num_tokens,), -2, dtype=torch.int64, device=device)
+    out_sample_indices = torch.full(
+        (max_num_reqs * num_speculative_steps,),
+        -1,
+        dtype=torch.int64,
+        device=device,
+    )
+    out_sample_pos = torch.full_like(out_sample_indices, -1)
+    out_sample_idx_mapping = torch.full(
+        out_sample_indices.shape,
+        -1,
+        dtype=torch.int32,
+        device=device,
+    )
+    out_temperature = torch.zeros(max_num_reqs, dtype=torch.float32, device=device)
+    out_seeds = torch.zeros(max_num_reqs, dtype=torch.int64, device=device)
+
+    target_positions = torch.tensor(positions, dtype=torch.int64, device=device)
+    target_query_start_loc = torch.tensor([0, 4], dtype=torch.int32, device=device)
+    idx_mapping = torch.tensor([2], dtype=torch.int32, device=device)
+    last_sampled = torch.tensor([0, 0, 99, 0], dtype=torch.int64, device=device)
+    next_prefill_tokens = torch.zeros_like(last_sampled)
+    num_sampled = torch.tensor([1], dtype=torch.int32, device=device)
+    num_rejected = torch.tensor([2], dtype=torch.int32, device=device)
+    temperature = torch.tensor([0.0, 0.0, 1.0, 0.0], dtype=torch.float32, device=device)
+    seeds = torch.tensor([0, 0, 17, 0], dtype=torch.int64, device=device)
+    block_table = torch.tensor([block_table_values], dtype=torch.int32, device=device)
+
+    args = (
+        out_input_ids,
+        out_query_positions,
+        out_query_start_loc,
+        out_seq_lens,
+        out_query_slot_mapping,
+        out_context_positions,
+        out_context_slot_mapping,
+        out_sample_indices,
+        out_sample_pos,
+        out_sample_idx_mapping,
+        out_temperature,
+        out_seeds,
+        target_positions,
+        target_query_start_loc,
+        idx_mapping,
+        last_sampled,
+        next_prefill_tokens,
+        num_sampled,
+        num_rejected,
+        temperature,
+        seeds,
+        block_table,
+        len(block_table_values),
+        123,
+        4,
+        num_speculative_steps,
+        num_speculative_steps,
+        max_num_reqs,
+        max_num_tokens,
+        128,
+    )
+    if vllm_version_is("0.27.1"):
+        _prepare_dflash_inputs_kernel_ascend[(1, 1)](
+            *args,
+            SAMPLE_FROM_ANCHOR=True,
+            PAD_SLOT_ID=PAD_SLOT_ID,
+            BLOCK_SIZE=16,
+        )
+    else:
+        _prepare_dflash_inputs_kernel_ascend[(1, 1)](
+            *args,
+            0,
+            SAMPLE_FROM_ANCHOR=True,
+            PAD_SLOT_ID=PAD_SLOT_ID,
+            CP_SIZE=1,
+            CP_INTERLEAVE=1,
+            BLOCK_SIZE=16,
+        )
+    torch.npu.synchronize()
+
+    return {
+        "input_ids": out_input_ids.cpu(),
+        "query_positions": out_query_positions.cpu(),
+        "query_slots": out_query_slot_mapping.cpu(),
+        "context_positions": out_context_positions.cpu(),
+        "context_slots": out_context_slot_mapping.cpu(),
+    }
+
+
+def test_rejected_context_suffix_is_inert() -> None:
+    out = _run_prepare(
+        positions=[10, 11, 12, 13],
+        block_table_values=[0, 0, 7, 8, 9, 10, 11, 12],
+    )
+
+    assert out["context_positions"][:4].tolist() == [10, 11, 0, 0]
+    assert out["context_slots"][:4].tolist() == [30, 31, PAD_SLOT_ID, PAD_SLOT_ID]
+    assert out["input_ids"][:3].tolist() == [99, 123, 123]
+    assert out["query_positions"][:3].tolist() == [12, 13, 14]
+    assert out["query_slots"][:3].tolist() == [32, 33, 34]
+
+
+def test_null_block_is_never_writable() -> None:
+    out = _run_prepare(
+        positions=[2, 3, 4, 5],
+        block_table_values=[0, 0, 7, 8, 9, 10, 11, 12],
+    )
+
+    assert out["context_slots"][:4].tolist() == [
+        PAD_SLOT_ID,
+        PAD_SLOT_ID,
+        PAD_SLOT_ID,
+        PAD_SLOT_ID,
+    ]
+    assert out["query_slots"][:3].tolist() == [PAD_SLOT_ID, PAD_SLOT_ID, PAD_SLOT_ID]

--- a/tests/e2e/pull_request/one_card/spec_decode/test_prepare_dflash_inputs_v0271.py
+++ b/tests/e2e/pull_request/one_card/spec_decode/test_prepare_dflash_inputs_v0271.py
@@ -1,11 +1,10 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
-"""Validate v0.27.1 DFlash semantics and the pinned-main signature shim."""
+"""Validate rejected-context and null-block semantics on the main DFlash API."""
 
 import torch
 from vllm.v1.attention.backends.utils import PAD_SLOT_ID
 
-from vllm_ascend.utils import vllm_version_is
 from vllm_ascend.worker.v2.spec_decode.dflash.speculator import (
     _prepare_dflash_inputs_kernel_ascend,
 )
@@ -83,23 +82,15 @@ def _run_prepare(*, positions: list[int], block_table_values: list[int]):
         max_num_tokens,
         128,
     )
-    if vllm_version_is("0.27.1"):
-        _prepare_dflash_inputs_kernel_ascend[(1, 1)](
-            *args,
-            SAMPLE_FROM_ANCHOR=True,
-            PAD_SLOT_ID=PAD_SLOT_ID,
-            BLOCK_SIZE=16,
-        )
-    else:
-        _prepare_dflash_inputs_kernel_ascend[(1, 1)](
-            *args,
-            0,
-            SAMPLE_FROM_ANCHOR=True,
-            PAD_SLOT_ID=PAD_SLOT_ID,
-            CP_SIZE=1,
-            CP_INTERLEAVE=1,
-            BLOCK_SIZE=16,
-        )
+    _prepare_dflash_inputs_kernel_ascend[(1, 1)](
+        *args,
+        0,
+        SAMPLE_FROM_ANCHOR=True,
+        PAD_SLOT_ID=PAD_SLOT_ID,
+        CP_SIZE=1,
+        CP_INTERLEAVE=1,
+        BLOCK_SIZE=16,
+    )
     torch.npu.synchronize()
 
     return {

--- a/tests/ut/models/test_dspark_aux.py
+++ b/tests/ut/models/test_dspark_aux.py
@@ -1,0 +1,133 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from types import SimpleNamespace
+
+import pytest
+import torch
+from torch import nn
+
+from vllm_ascend.models.dspark_aux import (
+    DSparkAuxHiddenContract,
+    DSparkAuxHiddenFormat,
+    build_k3_mla_aux_hidden_contract,
+)
+from vllm_ascend.models.kimi_k3 import AscendKimiLinearModel
+
+
+def _contract(**overrides) -> DSparkAuxHiddenContract:
+    values = {
+        "format": DSparkAuxHiddenFormat.RAW_PREFIX_SUM,
+        "layer_ids": (1, 5),
+        "capture_point": "post_layer_raw_prefix_sum",
+        "target_hidden_size": 8,
+        "dtype": torch.bfloat16,
+    }
+    values.update(overrides)
+    return DSparkAuxHiddenContract(**values)
+
+
+def test_build_k3_mla_contract_converts_checkpoint_layer_ids() -> None:
+    config = SimpleNamespace(
+        target_layer_ids=[0, 4],
+        target_num_hidden_layers=5,
+        num_target_layers=2,
+        target_hidden_size=8,
+    )
+
+    contract = build_k3_mla_aux_hidden_contract(config, torch.bfloat16)
+
+    assert contract.format == DSparkAuxHiddenFormat.RAW_PREFIX_SUM
+    assert contract.layer_ids == (1, 5)
+    assert contract.capture_point == "post_layer_raw_prefix_sum"
+    assert contract.packed_hidden_size == 16
+
+
+def test_build_k3_mla_contract_rejects_layer_count_mismatch() -> None:
+    config = SimpleNamespace(
+        target_layer_ids=[0, 4],
+        num_target_layers=3,
+        target_hidden_size=8,
+    )
+
+    with pytest.raises(ValueError, match="num_target_layers=3"):
+        build_k3_mla_aux_hidden_contract(config, torch.bfloat16)
+
+
+def test_build_k3_mla_contract_rejects_layer_past_declared_target() -> None:
+    config = SimpleNamespace(
+        target_layer_ids=[0, 4],
+        target_num_hidden_layers=4,
+        num_target_layers=2,
+        target_hidden_size=8,
+    )
+
+    with pytest.raises(ValueError, match="exceed the declared 4 target layers"):
+        build_k3_mla_aux_hidden_contract(config, torch.bfloat16)
+
+
+def test_aux_contract_rejects_format_capture_point_mismatch() -> None:
+    with pytest.raises(ValueError, match="must use capture point"):
+        _contract(capture_point="pre_layer_materialized").validate_definition()
+
+
+def test_kimi_target_applies_raw_aux_contract() -> None:
+    model = AscendKimiLinearModel.__new__(AscendKimiLinearModel)
+    nn.Module.__init__(model)
+    model.config = SimpleNamespace(hidden_size=8, num_hidden_layers=5)
+    model.aux_hidden_state_layers = (1, 5)
+    model.dspark_aux_capture_materialized = True
+
+    model.configure_dspark_aux_hidden_state_contract(_contract())
+
+    assert not model.dspark_aux_capture_materialized
+
+
+def test_kimi_target_rejects_aux_layer_mismatch() -> None:
+    model = AscendKimiLinearModel.__new__(AscendKimiLinearModel)
+    nn.Module.__init__(model)
+    model.config = SimpleNamespace(hidden_size=8, num_hidden_layers=5)
+    model.aux_hidden_state_layers = (1, 4)
+
+    with pytest.raises(ValueError, match="do not match"):
+        model.configure_dspark_aux_hidden_state_contract(_contract())
+
+
+def test_kimi_target_rejects_aux_layer_past_model_boundary() -> None:
+    model = AscendKimiLinearModel.__new__(AscendKimiLinearModel)
+    nn.Module.__init__(model)
+    model.config = SimpleNamespace(hidden_size=8, num_hidden_layers=4)
+    model.aux_hidden_state_layers = (1, 5)
+
+    with pytest.raises(ValueError, match="exceed the target's 4 layer boundaries"):
+        model.configure_dspark_aux_hidden_state_contract(_contract())
+
+
+def test_aux_contract_accepts_per_layer_and_packed_runtime_states() -> None:
+    contract = _contract()
+    per_layer = [
+        torch.zeros(3, 8, dtype=torch.bfloat16),
+        torch.zeros(3, 8, dtype=torch.bfloat16),
+    ]
+    packed = [torch.zeros(3, 16, dtype=torch.bfloat16)]
+
+    contract.validate_runtime(per_layer, num_target_tokens=3, target_device=torch.device("cpu"))
+    contract.validate_runtime(packed, num_target_tokens=3, target_device=torch.device("cpu"))
+
+
+@pytest.mark.parametrize(
+    ("states", "match"),
+    [
+        (None, "requires raw_prefix_sum"),
+        ([torch.zeros(2, 16, dtype=torch.bfloat16)], "3 are required"),
+        ([torch.zeros(3, 15, dtype=torch.bfloat16)], "width is 15"),
+        ([torch.zeros(3, 16, dtype=torch.float32)], "dtype"),
+    ],
+)
+def test_aux_contract_rejects_invalid_runtime_states(states, match: str) -> None:
+    with pytest.raises(ValueError, match=match):
+        _contract().validate_runtime(
+            states,
+            num_target_tokens=3,
+            target_device=torch.device("cpu"),
+        )

--- a/tests/ut/models/test_kimi_k3_adapter.py
+++ b/tests/ut/models/test_kimi_k3_adapter.py
@@ -295,6 +295,7 @@ def test_kimi_model_selects_materialized_or_raw_dspark_aux_stream(monkeypatch):
         intermediate_tensors=None,
         inputs_embeds=torch.tensor([[1.0]]),
     )
+    assert raw_aux[0].ndim == 2
     torch.testing.assert_close(raw_aux[0], torch.tensor([[11.0]]))
 
 

--- a/tests/ut/models/test_kimi_k3_adapter.py
+++ b/tests/ut/models/test_kimi_k3_adapter.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
+import json
 from types import MethodType, SimpleNamespace
 from unittest.mock import patch
 
@@ -15,6 +16,7 @@ from vllm_ascend.models.kimi_k3 import (
 )
 from vllm_ascend.models.kimi_k3_dspark import (
     AscendK3DSparkForCausalLM,
+    _get_target_rotation_path,
 )
 
 
@@ -62,6 +64,34 @@ def test_k3_dspark_reports_draft_attention_causality():
 
     model.config = SimpleNamespace()
     assert model.get_draft_attn_causal() == [False, False, False]
+
+
+def test_k3_dspark_recovers_target_quarot_rotation_path(tmp_path):
+    rotation_filename = "global_rotation.safetensors"
+    description = {
+        "optional": {
+            "quarot": {
+                "rotation_map": {
+                    "global_rotation": rotation_filename,
+                }
+            }
+        }
+    }
+    (tmp_path / "quant_model_description.json").write_text(
+        json.dumps(description),
+        encoding="utf-8",
+    )
+    vllm_config = SimpleNamespace(
+        model_config=SimpleNamespace(model=str(tmp_path)),
+    )
+
+    with patch(
+        "vllm_ascend.models.kimi_k3_dspark.get_rotation_path",
+        return_value=None,
+    ):
+        rotation_path = _get_target_rotation_path(vllm_config)
+
+    assert rotation_path == tmp_path / rotation_filename
 
 
 def test_kimi_mixed_kda_gate_weights_use_upstream_packed_loader(monkeypatch):

--- a/tests/ut/patch/platform/test_patch_speculative_config_dspark.py
+++ b/tests/ut/patch/platform/test_patch_speculative_config_dspark.py
@@ -27,6 +27,7 @@ def test_legacy_qwen3_dspark_config_uses_qwen3_loader():
     assert normalized.architectures == ["Qwen3DSparkModel"]
     assert normalized.mask_token_id == 163824
     assert normalized.target_layer_ids == [7, 23, 51, 67, 83]
+    assert normalized.dspark_aux_hidden_state_format == "materialized"
     assert normalized.block_size == 7
 
 

--- a/tests/ut/spec_decode/test_dspark_graph_contract.py
+++ b/tests/ut/spec_decode/test_dspark_graph_contract.py
@@ -6,10 +6,10 @@ from types import SimpleNamespace
 
 import pytest
 import torch
+from vllm.v1.worker.gpu.spec_decode.dflash.cudagraph import DFlashCudaGraphManager
 
 import vllm_ascend.worker.v2.spec_decode.dflash.aclgraph as aclgraph_module
 from vllm_ascend.worker.v2.spec_decode.dflash.aclgraph import DFlashAclGraphManager
-from vllm.v1.worker.gpu.spec_decode.dflash.cudagraph import DFlashCudaGraphManager
 from vllm_ascend.worker.v2.spec_decode.dspark.speculator import AscendDSparkSpeculator
 
 

--- a/tests/ut/spec_decode/test_dspark_graph_contract.py
+++ b/tests/ut/spec_decode/test_dspark_graph_contract.py
@@ -1,0 +1,143 @@
+# Copyright (c) 2026 Huawei Technologies Co., Ltd. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from contextlib import contextmanager
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+import vllm_ascend.worker.v2.spec_decode.dflash.aclgraph as aclgraph_module
+from vllm_ascend.worker.v2.spec_decode.dflash.aclgraph import DFlashAclGraphManager
+from vllm.v1.worker.gpu.spec_decode.dflash.cudagraph import DFlashCudaGraphManager
+from vllm_ascend.worker.v2.spec_decode.dspark.speculator import AscendDSparkSpeculator
+
+
+class _BackendA:
+    pass
+
+
+class _BackendB:
+    pass
+
+
+def _speculator(**attributes):
+    speculator = AscendDSparkSpeculator.__new__(AscendDSparkSpeculator)
+    for name, value in attributes.items():
+        setattr(speculator, name, value)
+    return speculator
+
+
+def test_single_draft_graph_backend_is_selected_explicitly():
+    speculator = _speculator(attn_backends={"draft.0": _BackendA, "draft.1": _BackendA})
+
+    assert speculator.get_draft_graph_backend() is _BackendA
+
+
+@pytest.mark.parametrize("attn_backends", [{}, {"draft.0": _BackendA, "draft.1": _BackendB}])
+def test_unsupported_draft_graph_backend_mapping_fails_before_replay(attn_backends):
+    speculator = _speculator(attn_backends=attn_backends)
+
+    with pytest.raises((RuntimeError, NotImplementedError), match="DSpark ACL graph"):
+        speculator.get_draft_graph_backend()
+
+
+def test_draft_metadata_uses_padded_query_token_contract():
+    speculator = _speculator(num_query_per_req=7)
+    metadata = {"draft.0": SimpleNamespace(actual_seq_lengths_q=[7, 14, 21, 28])}
+
+    speculator._validate_draft_attn_metadata(metadata, num_reqs_padded=4)
+
+
+def test_draft_metadata_rejects_stale_unpadded_lengths():
+    speculator = _speculator(num_query_per_req=7)
+    metadata = {"draft.0": SimpleNamespace(actual_seq_lengths_q=[7, 14, 14, 14])}
+
+    with pytest.raises(RuntimeError, match="query-length mismatch"):
+        speculator._validate_draft_attn_metadata(metadata, num_reqs_padded=4)
+
+
+def test_graph_param_cardinality_accepts_complete_capture():
+    graph_params = SimpleNamespace(
+        attn_params={28: [object(), object()]},
+        handles={28: [object(), object()]},
+        events={28: [object(), object()]},
+    )
+
+    assert DFlashAclGraphManager._validate_graph_param_cardinality(graph_params, 28) == 2
+
+
+@pytest.mark.parametrize(
+    "attn_count,handle_count,event_count",
+    [(0, 0, 0), (2, 1, 2), (2, 2, 1)],
+)
+def test_graph_param_cardinality_rejects_incomplete_capture(
+    attn_count,
+    handle_count,
+    event_count,
+):
+    graph_params = SimpleNamespace(
+        attn_params={28: [object()] * attn_count},
+        handles={28: [object()] * handle_count},
+        events={28: [object()] * event_count},
+    )
+
+    with pytest.raises(RuntimeError, match="captured no|cardinality mismatch"):
+        DFlashAclGraphManager._validate_graph_param_cardinality(graph_params, 28)
+
+
+def test_replay_installs_forward_context_before_accessing_extra_ctx(monkeypatch):
+    class _ContextProxy:
+        active = False
+
+        def __getattr__(self, name):
+            if not self.active:
+                raise AssertionError("forward context accessed before installation")
+            return self.__dict__.get(name, False)
+
+        def __setattr__(self, name, value):
+            if name != "active" and not self.active:
+                raise AssertionError("forward context accessed before installation")
+            object.__setattr__(self, name, value)
+
+    proxy = _ContextProxy()
+
+    @contextmanager
+    def _set_forward_context(*args, **kwargs):
+        proxy.active = True
+        try:
+            yield
+        finally:
+            proxy.active = False
+
+    graph_params = SimpleNamespace(
+        attn_params={7: [object()]},
+        handles={7: [object()]},
+        events={7: [object()]},
+    )
+    speculator = SimpleNamespace(
+        num_query_per_req=7,
+        input_batch=SimpleNamespace(seq_lens_cpu_upper_bound=object()),
+        build_draft_attn_metadatas=lambda *args: {"draft.0": object()},
+        get_draft_graph_backend=lambda: object(),
+        dp_size=1,
+        model_state=SimpleNamespace(attn_metadata={}),
+        speculative_config=object(),
+    )
+    manager = DFlashAclGraphManager.__new__(DFlashAclGraphManager)
+    manager.speculator = speculator
+    manager.update_stream = SimpleNamespace(wait_stream=lambda stream: None)
+    manager.device = torch.device("cpu")
+    manager.vllm_config = object()
+
+    monkeypatch.setattr(aclgraph_module, "_EXTRA_CTX", proxy)
+    monkeypatch.setattr(aclgraph_module, "set_forward_context", _set_forward_context)
+    monkeypatch.setattr(aclgraph_module, "get_forward_context", lambda: object())
+    monkeypatch.setattr(aclgraph_module, "get_draft_graph_params", lambda: graph_params)
+    monkeypatch.setattr(aclgraph_module, "update_full_graph_params", lambda *args, **kwargs: None)
+    monkeypatch.setattr(torch.npu, "current_stream", lambda: object())
+    monkeypatch.setattr(DFlashCudaGraphManager, "run_fullgraph", lambda self, desc: "replayed")
+
+    desc = SimpleNamespace(num_tokens=7, num_reqs=1, cg_mode=object())
+    assert manager.run_fullgraph(desc) == "replayed"
+    assert proxy.active is False

--- a/tests/ut/spec_decode/test_dspark_speculator.py
+++ b/tests/ut/spec_decode/test_dspark_speculator.py
@@ -15,7 +15,7 @@
 # limitations under the License.
 # This file is a part of the vllm-ascend project.
 #
-"""Unit tests for ``AscendDSparkSpeculator.load_draft_model`` fc rotation."""
+"""Unit tests for Ascend DSpark model loading and target contracts."""
 
 from __future__ import annotations
 
@@ -26,6 +26,10 @@ import pytest
 import torch
 from vllm.v1.worker.gpu.spec_decode.dspark.speculator import DSparkSpeculator
 
+from vllm_ascend.models.dspark_aux import (
+    DSparkAuxHiddenContract,
+    DSparkAuxHiddenFormat,
+)
 from vllm_ascend.worker.v2.spec_decode.dspark.speculator import (
     AscendDSparkSpeculator,
 )
@@ -41,6 +45,7 @@ def _spec(vllm_config: SimpleNamespace) -> AscendDSparkSpeculator:
     ``self.vllm_config`` and the patched parent call."""
     spec = AscendDSparkSpeculator.__new__(AscendDSparkSpeculator)
     spec.vllm_config = vllm_config
+    spec.aux_hidden_contract = None
     return spec
 
 
@@ -68,7 +73,7 @@ def _no_call(*args, **kwargs):
 
 
 class TestLoadDraftModel:
-    """``load_draft_model`` rotates fc for a QuaRot target and is a no-op otherwise."""
+    """Cover QuaRot post-load handling and Aux Hidden negotiation."""
 
     @pytest.fixture
     def captured(self, monkeypatch):
@@ -98,3 +103,44 @@ class TestLoadDraftModel:
         monkeypatch.setattr(_ROT_MATRIX, _no_call)
         draft = _spec(_bf16_config()).load_draft_model(MagicMock(), set())
         assert torch.equal(draft.model.fc.weight.data, captured["before"])
+
+    def test_negotiates_draft_declared_aux_hidden_contract(self, monkeypatch):
+        contract = DSparkAuxHiddenContract(
+            format=DSparkAuxHiddenFormat.RAW_PREFIX_SUM,
+            layer_ids=(1,),
+            capture_point="post_layer_raw_prefix_sum",
+            target_hidden_size=_HIDDEN,
+            dtype=torch.bfloat16,
+        )
+        draft = _fake_draft()
+        draft.get_required_dspark_aux_hidden_state_contract = lambda: contract
+        monkeypatch.setattr(
+            DSparkSpeculator,
+            "load_draft_model",
+            lambda *_args: draft,
+        )
+        target = MagicMock()
+
+        loaded = _spec(_bf16_config()).load_draft_model(target, set())
+
+        assert loaded is draft
+        target.configure_dspark_aux_hidden_state_contract.assert_called_once_with(contract)
+
+    def test_rejects_target_without_required_aux_capability(self, monkeypatch):
+        contract = DSparkAuxHiddenContract(
+            format=DSparkAuxHiddenFormat.RAW_PREFIX_SUM,
+            layer_ids=(1,),
+            capture_point="post_layer_raw_prefix_sum",
+            target_hidden_size=_HIDDEN,
+            dtype=torch.bfloat16,
+        )
+        draft = _fake_draft()
+        draft.get_required_dspark_aux_hidden_state_contract = lambda: contract
+        monkeypatch.setattr(
+            DSparkSpeculator,
+            "load_draft_model",
+            lambda *_args: draft,
+        )
+
+        with pytest.raises(ValueError, match="does not expose"):
+            _spec(_bf16_config()).load_draft_model(SimpleNamespace(), set())

--- a/tests/ut/spec_decode/test_dspark_speculator.py
+++ b/tests/ut/spec_decode/test_dspark_speculator.py
@@ -31,8 +31,7 @@ from vllm_ascend.models.dspark_aux import (
     DSparkAuxHiddenContract,
     DSparkAuxHiddenFormat,
 )
-from vllm_ascend.models.qwen3_dspark import AscendQwen3DSparkForCausalLM
-from vllm_ascend.models.qwen3_dspark import _get_draft_rotation_path
+from vllm_ascend.models.qwen3_dspark import AscendQwen3DSparkForCausalLM, _get_draft_rotation_path
 from vllm_ascend.worker.v2.spec_decode.dspark.speculator import (
     DSPARK_AUX_HIDDEN_FORMAT_MATERIALIZED,
     DSPARK_AUX_HIDDEN_FORMAT_RAW,
@@ -41,6 +40,8 @@ from vllm_ascend.worker.v2.spec_decode.dspark.speculator import (
 
 _HIDDEN = 8
 _FC_IN = 5 * _HIDDEN  # concatenated aux hidden states
+
+
 def _spec(vllm_config: SimpleNamespace) -> AscendDSparkSpeculator:
     """Bypass the heavy ``__init__``; ``load_draft_model`` only reads
     ``self.vllm_config`` and the patched parent call."""
@@ -135,9 +136,7 @@ class TestLoadDraftModel:
     def test_configures_capture_before_loading_draft(self, monkeypatch):
         events = []
         target = SimpleNamespace(
-            set_dspark_aux_capture_materialized=lambda enabled: events.append(
-                ("capture", enabled)
-            )
+            set_dspark_aux_capture_materialized=lambda enabled: events.append(("capture", enabled))
         )
 
         def _load(self, target_model, target_attn_layer_names):
@@ -147,9 +146,7 @@ class TestLoadDraftModel:
         monkeypatch.setattr(DSparkSpeculator, "load_draft_model", _load)
         spec = _spec(_bf16_config())
         spec.draft_model_config = SimpleNamespace(
-            hf_config=SimpleNamespace(
-                dspark_aux_hidden_state_format=DSPARK_AUX_HIDDEN_FORMAT_MATERIALIZED
-            )
+            hf_config=SimpleNamespace(dspark_aux_hidden_state_format=DSPARK_AUX_HIDDEN_FORMAT_MATERIALIZED)
         )
 
         spec.load_draft_model(target, set())
@@ -238,9 +235,7 @@ def test_process_weight_orthogonal_basis_equivalence():
     from vllm_ascend.models.qwen3_dspark import process_weight
 
     generator = torch.Generator().manual_seed(7)
-    q, _ = torch.linalg.qr(
-        torch.randn(_HIDDEN, _HIDDEN, dtype=torch.float64, generator=generator)
-    )
+    q, _ = torch.linalg.qr(torch.randn(_HIDDEN, _HIDDEN, dtype=torch.float64, generator=generator))
     x = torch.randn(3, 5, _HIDDEN, dtype=torch.float64, generator=generator)
     weight = torch.randn(_HIDDEN, _FC_IN, dtype=torch.float64, generator=generator)
     x_rotated = x @ q
@@ -256,10 +251,7 @@ def test_process_weight_orthogonal_basis_equivalence():
 
 class TestAuxHiddenStateFormatContract:
     def test_qwen3_gqa_draft_declares_materialized_format(self):
-        assert (
-            AscendQwen3DSparkForCausalLM.dspark_aux_hidden_state_format
-            == DSPARK_AUX_HIDDEN_FORMAT_MATERIALIZED
-        )
+        assert AscendQwen3DSparkForCausalLM.dspark_aux_hidden_state_format == DSPARK_AUX_HIDDEN_FORMAT_MATERIALIZED
 
     @pytest.mark.parametrize(
         ("aux_hidden_format", "expected_materialized"),

--- a/tests/ut/spec_decode/test_dspark_speculator.py
+++ b/tests/ut/spec_decode/test_dspark_speculator.py
@@ -19,6 +19,7 @@
 
 from __future__ import annotations
 
+from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import MagicMock
 
@@ -30,16 +31,16 @@ from vllm_ascend.models.dspark_aux import (
     DSparkAuxHiddenContract,
     DSparkAuxHiddenFormat,
 )
+from vllm_ascend.models.qwen3_dspark import AscendQwen3DSparkForCausalLM
+from vllm_ascend.models.qwen3_dspark import _get_draft_rotation_path
 from vllm_ascend.worker.v2.spec_decode.dspark.speculator import (
+    DSPARK_AUX_HIDDEN_FORMAT_MATERIALIZED,
+    DSPARK_AUX_HIDDEN_FORMAT_RAW,
     AscendDSparkSpeculator,
 )
 
 _HIDDEN = 8
 _FC_IN = 5 * _HIDDEN  # concatenated aux hidden states
-# Patch where load_draft_model looks it up (the speculator module binding).
-_ROT_MATRIX = "vllm_ascend.worker.v2.spec_decode.dspark.speculator.get_rotation_matrix"
-
-
 def _spec(vllm_config: SimpleNamespace) -> AscendDSparkSpeculator:
     """Bypass the heavy ``__init__``; ``load_draft_model`` only reads
     ``self.vllm_config`` and the patched parent call."""
@@ -68,10 +69,6 @@ def _bf16_config() -> SimpleNamespace:
     return SimpleNamespace(quant_config=None, model_config=SimpleNamespace())
 
 
-def _no_call(*args, **kwargs):
-    raise AssertionError("get_rotation_matrix must not be called without a rotation path")
-
-
 class TestLoadDraftModel:
     """Cover QuaRot post-load handling and Aux Hidden negotiation."""
 
@@ -90,17 +87,7 @@ class TestLoadDraftModel:
         monkeypatch.setattr(DSparkSpeculator, "load_draft_model", _load)
         return out
 
-    def test_rotates_fc_for_quarot_target(self, captured, monkeypatch):
-        # R = 2*I -> W @ R == 2*W, an expectation independent of process_weight.
-        monkeypatch.setattr(_ROT_MATRIX, lambda path: torch.eye(_HIDDEN) * 2.0)
-        draft = _spec(_quarot_config()).load_draft_model(MagicMock(), set())
-        before = captured["before"]
-        assert draft is captured["draft"]
-        assert torch.allclose(draft.model.fc.weight.data, 2.0 * before, atol=1e-6)
-        assert not torch.allclose(draft.model.fc.weight.data, before)
-
     def test_noop_for_bf16_target(self, captured, monkeypatch):
-        monkeypatch.setattr(_ROT_MATRIX, _no_call)
         draft = _spec(_bf16_config()).load_draft_model(MagicMock(), set())
         assert torch.equal(draft.model.fc.weight.data, captured["before"])
 
@@ -144,3 +131,203 @@ class TestLoadDraftModel:
 
         with pytest.raises(ValueError, match="does not expose"):
             _spec(_bf16_config()).load_draft_model(SimpleNamespace(), set())
+
+    def test_configures_capture_before_loading_draft(self, monkeypatch):
+        events = []
+        target = SimpleNamespace(
+            set_dspark_aux_capture_materialized=lambda enabled: events.append(
+                ("capture", enabled)
+            )
+        )
+
+        def _load(self, target_model, target_attn_layer_names):
+            events.append(("load", None))
+            return _fake_draft()
+
+        monkeypatch.setattr(DSparkSpeculator, "load_draft_model", _load)
+        spec = _spec(_bf16_config())
+        spec.draft_model_config = SimpleNamespace(
+            hf_config=SimpleNamespace(
+                dspark_aux_hidden_state_format=DSPARK_AUX_HIDDEN_FORMAT_MATERIALIZED
+            )
+        )
+
+        spec.load_draft_model(target, set())
+
+        assert events == [("capture", True), ("load", None)]
+
+    def test_injects_target_rotation_before_draft_load(self, monkeypatch):
+        draft_hf_config = SimpleNamespace(
+            architectures=["Qwen3DSparkModel"],
+            model_type="qwen3",
+            dspark_aux_hidden_state_format=DSPARK_AUX_HIDDEN_FORMAT_MATERIALIZED,
+        )
+        target_embed = object()
+        target_head = object()
+        target = SimpleNamespace(
+            model=SimpleNamespace(embed_tokens=target_embed),
+            lm_head=target_head,
+            set_dspark_aux_capture_materialized=lambda enabled: None,
+        )
+        draft = SimpleNamespace(
+            model=SimpleNamespace(embed_tokens=object()),
+            lm_head=object(),
+            has_own_embed_tokens=True,
+            has_own_lm_head=True,
+            dspark_aux_hidden_state_format=DSPARK_AUX_HIDDEN_FORMAT_MATERIALIZED,
+        )
+
+        def _load(self, target_model, target_attn_layer_names):
+            assert draft_hf_config._ascend_target_rotation_path == "/rotation"
+            return draft
+
+        monkeypatch.setattr(DSparkSpeculator, "load_draft_model", _load)
+        monkeypatch.setattr(
+            "vllm_ascend.worker.v2.spec_decode.dspark.speculator.get_rotation_path",
+            lambda config: "/rotation",
+        )
+        spec = _spec(_quarot_config())
+        spec.draft_model_config = SimpleNamespace(hf_config=draft_hf_config)
+
+        assert spec.load_draft_model(target, set()) is draft
+        assert not hasattr(draft_hf_config, "_ascend_target_rotation_path")
+
+    def test_rejects_shared_quarot_embedding(self, monkeypatch):
+        draft_hf_config = SimpleNamespace(
+            architectures=["Qwen3DSparkModel"],
+            model_type="qwen3",
+            dspark_aux_hidden_state_format=DSPARK_AUX_HIDDEN_FORMAT_MATERIALIZED,
+        )
+        shared_embed = object()
+        target = SimpleNamespace(
+            model=SimpleNamespace(embed_tokens=shared_embed),
+            lm_head=object(),
+            set_dspark_aux_capture_materialized=lambda enabled: None,
+        )
+        draft = SimpleNamespace(
+            model=SimpleNamespace(embed_tokens=shared_embed),
+            lm_head=object(),
+            has_own_embed_tokens=False,
+            has_own_lm_head=True,
+            dspark_aux_hidden_state_format=DSPARK_AUX_HIDDEN_FORMAT_MATERIALIZED,
+        )
+        monkeypatch.setattr(
+            DSparkSpeculator,
+            "load_draft_model",
+            lambda self, target_model, target_attn_layer_names: draft,
+        )
+        monkeypatch.setattr(
+            "vllm_ascend.worker.v2.spec_decode.dspark.speculator.get_rotation_path",
+            lambda config: "/rotation",
+        )
+        spec = _spec(_quarot_config())
+        spec.draft_model_config = SimpleNamespace(hf_config=draft_hf_config)
+
+        with pytest.raises(RuntimeError, match="must not share target embed_tokens"):
+            spec.load_draft_model(target, set())
+
+
+def test_injected_rotation_path_does_not_require_draft_quant_config():
+    config = SimpleNamespace(_ascend_target_rotation_path="/rotation")
+    vllm_config = SimpleNamespace(quant_config=None)
+
+    assert _get_draft_rotation_path(vllm_config, config) == Path("/rotation")
+
+
+def test_process_weight_orthogonal_basis_equivalence():
+    from vllm_ascend.models.qwen3_dspark import process_weight
+
+    generator = torch.Generator().manual_seed(7)
+    q, _ = torch.linalg.qr(
+        torch.randn(_HIDDEN, _HIDDEN, dtype=torch.float64, generator=generator)
+    )
+    x = torch.randn(3, 5, _HIDDEN, dtype=torch.float64, generator=generator)
+    weight = torch.randn(_HIDDEN, _FC_IN, dtype=torch.float64, generator=generator)
+    x_rotated = x @ q
+
+    expected = torch.nn.functional.linear(x.reshape(3, _FC_IN), weight)
+    fused_weight = process_weight(weight, q)
+    actual = torch.nn.functional.linear(x_rotated.reshape(3, _FC_IN), fused_weight)
+
+    # process_weight intentionally performs the fusion in FP32 even when this
+    # test builds the reference in FP64.
+    torch.testing.assert_close(actual, expected, atol=2e-6, rtol=3e-6)
+
+
+class TestAuxHiddenStateFormatContract:
+    def test_qwen3_gqa_draft_declares_materialized_format(self):
+        assert (
+            AscendQwen3DSparkForCausalLM.dspark_aux_hidden_state_format
+            == DSPARK_AUX_HIDDEN_FORMAT_MATERIALIZED
+        )
+
+    @pytest.mark.parametrize(
+        ("aux_hidden_format", "expected_materialized"),
+        [
+            (DSPARK_AUX_HIDDEN_FORMAT_MATERIALIZED, True),
+            (DSPARK_AUX_HIDDEN_FORMAT_RAW, False),
+        ],
+    )
+    def test_configures_target_capture_mode(
+        self,
+        aux_hidden_format,
+        expected_materialized,
+    ):
+        set_capture_mode = MagicMock()
+        target = SimpleNamespace(
+            set_dspark_aux_capture_materialized=set_capture_mode,
+        )
+        draft = SimpleNamespace(
+            dspark_aux_hidden_state_format=aux_hidden_format,
+        )
+
+        actual = AscendDSparkSpeculator._configure_target_aux_hidden_state_format(
+            target,
+            draft,
+        )
+
+        assert actual == aux_hidden_format
+        set_capture_mode.assert_called_once_with(expected_materialized)
+
+    @pytest.mark.parametrize(
+        "config",
+        [
+            SimpleNamespace(architectures=["Qwen3DSparkModel"]),
+            SimpleNamespace(architectures=["DSparkDraftModel"], model_type="qwen3"),
+            SimpleNamespace(model_type="qwen3"),
+        ],
+    )
+    def test_qwen3_config_declares_materialized(self, config):
+        set_capture_mode = MagicMock()
+        target = SimpleNamespace(
+            set_dspark_aux_capture_materialized=set_capture_mode,
+        )
+
+        actual = AscendDSparkSpeculator._configure_target_aux_hidden_state_format(
+            target,
+            config,
+        )
+
+        assert actual == DSPARK_AUX_HIDDEN_FORMAT_MATERIALIZED
+        set_capture_mode.assert_called_once_with(True)
+
+    def test_undeclared_format_preserves_existing_target_behavior(self):
+        set_capture_mode = MagicMock()
+        target = SimpleNamespace(
+            set_dspark_aux_capture_materialized=set_capture_mode,
+        )
+
+        actual = AscendDSparkSpeculator._configure_target_aux_hidden_state_format(
+            target,
+            SimpleNamespace(),
+        )
+
+        assert actual is None
+        set_capture_mode.assert_not_called()
+
+    def test_rejects_unknown_format(self):
+        with pytest.raises(ValueError, match="Unsupported DSpark auxiliary"):
+            AscendDSparkSpeculator._configure_target_aux_hidden_state_format(
+                SimpleNamespace(),
+                SimpleNamespace(dspark_aux_hidden_state_format="unknown"),
+            )

--- a/tests/ut/worker/test_attn_utils_v2.py
+++ b/tests/ut/worker/test_attn_utils_v2.py
@@ -18,7 +18,7 @@ from vllm.v1.worker.gpu import attn_utils as upstream_attn_utils
 from vllm.v1.worker.utils import AttentionGroup
 
 from vllm_ascend.attention import dsa_v1
-from vllm_ascend.attention.attention_v1 import AscendAttentionBackend
+from vllm_ascend.attention.attention_v1 import AscendAttentionBackend, AscendAttentionState
 from vllm_ascend.attention.dsa_v1 import (
     AscendDSAC4Backend,
     AscendDSAC4StateBackend,
@@ -228,6 +228,32 @@ def test_main_dsv4_materializes_real_planner_geometry_once(monkeypatch):
     assert tensor_raw_caches[mtp_name].storage_offset() == (
         base_offset + tuple_stride + small_spec.page_size_bytes * num_blocks
     )
+def test_build_draft_attn_metadata_forwards_ascend_context(monkeypatch):
+    captured_kwargs = {}
+
+    def raw_build_attn_metadata(*_args, **kwargs):
+        captured_kwargs.update(kwargs)
+        return "metadata"
+
+    monkeypatch.setattr(
+        attn_utils._BUILD_ATTN_METADATA_MODULE,
+        "build_attn_metadata",
+        raw_build_attn_metadata,
+    )
+    positions = torch.arange(8, dtype=torch.int32)
+    is_prefilling = torch.tensor([False, False])
+
+    with attn_utils.build_draft_attn_metadata_factory(
+        positions,
+        pad=5,
+        is_prefilling=is_prefilling,
+    ):
+        metadata = attn_utils._BUILD_ATTN_METADATA_MODULE.build_attn_metadata()
+
+    assert metadata == "metadata"
+    torch.testing.assert_close(captured_kwargs["positions"], positions[:5])
+    assert captured_kwargs["is_prefilling"] is is_prefilling
+    assert captured_kwargs["attn_state"] is AscendAttentionState.SpecDecoding
 
 
 @pytest.mark.parametrize(

--- a/tests/ut/worker/test_attn_utils_v2.py
+++ b/tests/ut/worker/test_attn_utils_v2.py
@@ -228,6 +228,8 @@ def test_main_dsv4_materializes_real_planner_geometry_once(monkeypatch):
     assert tensor_raw_caches[mtp_name].storage_offset() == (
         base_offset + tuple_stride + small_spec.page_size_bytes * num_blocks
     )
+
+
 def test_build_draft_attn_metadata_forwards_ascend_context(monkeypatch):
     captured_kwargs = {}
 

--- a/tests/ut/worker/test_kv_block_zeroer.py
+++ b/tests/ut/worker/test_kv_block_zeroer.py
@@ -1,0 +1,206 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+import torch
+from vllm.v1.core.block_pool import BlockPool
+from vllm.v1.core.single_type_kv_cache_manager import get_manager_for_kv_cache_spec
+from vllm.v1.kv_cache_interface import FullAttentionSpec, MambaSpec, SlidingWindowSpec
+
+from vllm_ascend.attention.mla_v1 import AscendMLABackend
+from vllm_ascend.core.kv_cache_interface import (
+    AscendMLAAttentionSpec,
+    AscendSFAIndexerCacheSpec,
+    register_ascend_kv_cache_specs,
+)
+from vllm_ascend.worker.utils import AscendKVBlockZeroer
+from vllm_ascend.worker.v2.model_runner import NPUModelRunner
+
+
+def _group(spec, names, group_id=0):
+    return SimpleNamespace(kv_cache_spec=spec, layer_names=names, kv_cache_group_id=group_id)
+
+
+def _init_zeroer(groups, caches, kernel_sizes, excluded=None):
+    zeroer = AscendKVBlockZeroer(torch.device("cpu"), pin_memory=False)
+    zeroer.init_meta(
+        groups,
+        kernel_sizes,
+        "auto",
+        set() if excluded is None else excluded,
+        {name: SimpleNamespace(kv_cache=cache) for name, cache in caches.items()},
+    )
+    return zeroer
+
+
+def test_mla_backend_accepts_upstream_cache_dtype_keyword():
+    assert AscendMLABackend.get_kv_cache_block_dim(128, 1, 576, cache_dtype_str="auto") == 0
+    assert AscendMLABackend.get_kv_cache_shape(2, 128, 1, 576, cache_dtype_str="auto") == (2, 128, 1, 576)
+
+
+@pytest.mark.parametrize("spec_cls", [AscendMLAAttentionSpec, AscendSFAIndexerCacheSpec])
+@pytest.mark.parametrize("needs_zeroing", [False, True])
+def test_ascend_attention_managers_record_new_blocks_for_zeroing(spec_cls, needs_zeroing):
+    register_ascend_kv_cache_specs()
+    spec = spec_cls(block_size=384, num_kv_heads=1, head_size=64, dtype=torch.bfloat16)
+    block_pool = BlockPool(3, enable_caching=False, hash_block_size=384)
+    manager = get_manager_for_kv_cache_spec(
+        spec,
+        max_in_flight_tokens=512,
+        max_model_len=4096,
+        block_pool=block_pool,
+        enable_caching=False,
+        kv_cache_group_id=0,
+        scheduler_block_size=384,
+        needs_kv_cache_zeroing=needs_zeroing,
+    )
+    blocks = manager.allocate_new_blocks("request", 385, 385)
+    assert len(blocks) == 2
+    assert manager.take_new_block_ids() == ([block.block_id for block in blocks] if needs_zeroing else [])
+    assert manager.take_new_block_ids() == []
+
+    # Aborting/freeing a request makes its physical blocks immediately
+    # reusable. The scheduler must report those IDs again so the worker clears
+    # stale KV data before the replacement request first reads them.
+    manager.free("request")
+    reused_blocks = manager.allocate_new_blocks("replacement", 385, 385)
+    reused_ids = [block.block_id for block in reused_blocks]
+    assert set(reused_ids) == {block.block_id for block in blocks}
+    assert manager.take_new_block_ids() == (reused_ids if needs_zeroing else [])
+
+
+def test_zeroer_keeps_upstream_sliding_window_attention_in_scope():
+    spec = SlidingWindowSpec(
+        block_size=4,
+        num_kv_heads=1,
+        head_size=2,
+        dtype=torch.float32,
+        sliding_window=8,
+    )
+    cache = torch.empty(3, 4, 1, 2)
+    zeroer = _init_zeroer([_group(spec, ["attn"])], {"attn": (cache,)}, [[4]])
+    assert zeroer._meta is not None
+
+
+def test_mixed_mla_gqa_pages_skip_empty_shared_and_mamba_views():
+    mla_spec = AscendMLAAttentionSpec(block_size=384, num_kv_heads=1, head_size=576, dtype=torch.bfloat16)
+    gqa_spec = FullAttentionSpec(block_size=128, num_kv_heads=2, head_size=64, dtype=torch.bfloat16)
+    mamba_spec = MambaSpec(block_size=384, shapes=((2, 4),), dtypes=(torch.float32,))
+    k = torch.empty(6, 128, 1, 512, dtype=torch.bfloat16)
+    rope = torch.empty(6, 128, 1, 64, dtype=torch.bfloat16)
+    gqa_k = torch.empty(2, 128, 2, 64, dtype=torch.int8)
+    gqa_v = torch.empty(2, 128, 2, 64, dtype=torch.bfloat16)
+    groups = [
+        _group(mla_spec, ["mla", "shared", "excluded", "no_rope"]),
+        _group(gqa_spec, ["gqa"], 1),
+        _group(mamba_spec, ["mamba"], 2),
+        _group(gqa_spec, ["unallocated"], 3),
+    ]
+    zeroer = _init_zeroer(
+        groups,
+        {
+            "mla": (k, rope),
+            "shared": (k, rope),
+            "no_rope": (k, torch.empty(6, 128, 1, 0)),
+            "gqa": (gqa_k, gqa_v),
+        },
+        [[128], [128], [384]],
+        excluded={"excluded"},
+    )
+    addrs, sizes, strides, max_chunks, chunk_size, num_segments = zeroer._meta
+    assert addrs.tolist() == [cache.data_ptr() for cache in (k, rope, gqa_k, gqa_v)]
+    assert sizes.tolist() == [384 * 512 // 2, 384 * 64 // 2, 128 * 2 * 64 // 4, 128 * 2 * 64 // 2]
+    assert torch.equal(sizes, strides)
+    assert num_segments == 4
+    assert max_chunks * chunk_size == max(sizes.tolist())
+
+
+@pytest.mark.parametrize("ratio", [1, 3])
+def test_strided_views_keep_payload_separate_from_scheduler_stride(ratio):
+    spec = FullAttentionSpec(block_size=4 * ratio, num_kv_heads=1, head_size=2, dtype=torch.float32)
+    raw = torch.empty(2 * ratio * 24 + 4, dtype=torch.float32)
+    # Distinct components share storage, with a leading offset and guard holes.
+    k = torch.as_strided(raw, (2 * ratio, 4, 1, 2), (24, 2, 2, 1), storage_offset=4)
+    v = torch.as_strided(raw, (2 * ratio, 4, 1, 2), (24, 2, 2, 1), storage_offset=12)
+    zeroer = _init_zeroer([_group(spec, ["attn"])], {"attn": (k, v)}, [[4]])
+    addrs, sizes, strides, _, _, num_segments = zeroer._meta
+    assert addrs.tolist() == [cache.data_ptr() + i * 24 * 4 for cache in (k, v) for i in range(ratio)]
+    assert sizes.tolist() == [8] * (2 * ratio)
+    assert strides.tolist() == [24 * ratio] * (2 * ratio)
+    assert num_segments == 2 * ratio
+
+
+def test_compressed_cache_uses_physical_block_size():
+    spec = AscendMLAAttentionSpec(block_size=128, num_kv_heads=1, head_size=8, dtype=torch.bfloat16, compress_ratio=4)
+    cache = torch.empty(2, 32, 1, 8, dtype=torch.bfloat16)
+    zeroer = _init_zeroer([_group(spec, ["attn"])], {"attn": (cache,)}, [[128]])
+    assert zeroer._meta[1].tolist() == [32 * 8 // 2]
+
+
+def test_zeroer_rejects_incomplete_virtual_scheduler_blocks():
+    spec = FullAttentionSpec(block_size=12, num_kv_heads=1, head_size=2, dtype=torch.float32)
+    cache = torch.empty(5, 4, 1, 2)
+    with pytest.raises(AssertionError, match="divisible by virtual block ratio"):
+        _init_zeroer([_group(spec, ["attn"])], {"attn": (cache,)}, [[4]])
+
+
+def test_zeroer_empty_cache_is_noop():
+    zeroer = _init_zeroer([], {}, [])
+    assert zeroer._meta is None
+    with patch("vllm_ascend.worker.utils._zero_kv_blocks_kernel") as kernel:
+        zeroer.zero_block_ids([0])
+        zeroer.zero_block_ids([])
+        kernel.__getitem__.assert_not_called()
+
+
+@pytest.mark.parametrize(
+    "cache",
+    [torch.empty(2, 1, 1, 1, dtype=torch.int8), torch.empty(2, 4, 2, 2).transpose(1, 2)],
+    ids=["unaligned-payload", "noncontiguous-inner-dimensions"],
+)
+def test_zeroer_rejects_unsupported_component_layout(cache):
+    spec = FullAttentionSpec(block_size=4, num_kv_heads=1, head_size=2, dtype=torch.float32)
+    with pytest.raises(AssertionError):
+        _init_zeroer([_group(spec, ["attn"])], {"attn": (cache,)}, [[4]])
+
+
+def test_zeroer_reuses_block_id_buffers_and_dispatches_all_segments():
+    spec = FullAttentionSpec(block_size=4, num_kv_heads=1, head_size=2, dtype=torch.float32)
+    k, v = torch.empty(3, 4, 1, 2), torch.empty(3, 4, 1, 2)
+    zeroer = _init_zeroer([_group(spec, ["attn"])], {"attn": (k, v)}, [[4]])
+    ids = zeroer._ids_gpu
+    with (
+        patch("vllm_ascend.worker.utils._zero_kv_blocks_kernel") as kernel,
+        patch("vllm_ascend.worker.utils.get_vectorcore_num", return_value=8),
+    ):
+        zeroer.zero_block_ids([])
+        kernel.__getitem__.assert_not_called()
+        zeroer.warmup(3)
+        zeroer.zero_block_ids([1, 2])
+        assert zeroer._ids_gpu is ids
+        assert ids[:2].tolist() == [1, 2]
+        args, kwargs = kernel.__getitem__.return_value.call_args
+        assert args[4] == 2
+        assert kwargs["N_SEGS"] == 2
+        assert kwargs["MAX_CHUNKS"] == 1
+
+
+def test_mrv2_initializes_ascend_zeroer_on_the_upstream_attribute():
+    group = object()
+    runner = SimpleNamespace(
+        device=torch.device("cpu"),
+        attn_groups=[[group]],
+        kernel_block_sizes=[128],
+        cache_config=SimpleNamespace(cache_dtype="auto"),
+        compilation_config=SimpleNamespace(static_forward_context={}),
+    )
+    with patch("vllm_ascend.worker.v2.model_runner.AscendKVBlockZeroer") as zeroer_cls:
+        NPUModelRunner._init_kv_zero_meta(runner)
+    assert runner.kv_block_zeroer is zeroer_cls.return_value
+    kwargs = runner.kv_block_zeroer.init_meta.call_args.kwargs
+    assert list(kwargs["attn_groups_iter"]) == [group]
+    assert kwargs["kernel_block_sizes"] == [[128]]
+    assert kwargs["static_forward_context"] is runner.compilation_config.static_forward_context

--- a/tests/ut/worker/test_kv_block_zeroer.py
+++ b/tests/ut/worker/test_kv_block_zeroer.py
@@ -134,7 +134,7 @@ def test_strided_views_keep_payload_separate_from_scheduler_stride(ratio):
 
 
 def test_compressed_cache_uses_physical_block_size():
-    spec = AscendMLAAttentionSpec(block_size=128, num_kv_heads=1, head_size=8, dtype=torch.bfloat16, compress_ratio=4)
+    spec = AscendMLAAttentionSpec(block_size=128, num_kv_heads=1, head_size=8, dtype=torch.bfloat16, tokens_per_state=4)
     cache = torch.empty(2, 32, 1, 8, dtype=torch.bfloat16)
     zeroer = _init_zeroer([_group(spec, ["attn"])], {"attn": (cache,)}, [[128]])
     assert zeroer._meta[1].tolist() == [32 * 8 // 2]

--- a/tests/ut/worker/test_model_runner_v2_mamba.py
+++ b/tests/ut/worker/test_model_runner_v2_mamba.py
@@ -1,6 +1,5 @@
 import ast
 from contextlib import nullcontext
-from dataclasses import replace
 from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
@@ -89,75 +88,39 @@ def _group(spec: MambaSpec):
     )
 
 
-def test_validate_dense_and_packed_kv_cache_tensor_layouts():
-    attention_spec = FullAttentionSpec(block_size=4, num_kv_heads=1, head_size=1, dtype=torch.float16)
-    mamba_spec = MambaSpec(block_size=4, shapes=((4,),), dtypes=(torch.float32,))
-    assert attention_spec.page_size_bytes == mamba_spec.page_size_bytes == 16
-
-    dense = KVCacheConfig(
-        num_blocks=3,
-        kv_cache_tensors=[KVCacheTensor(size=48, shared_by=["attn", "mamba"])],
-        kv_cache_groups=[
-            KVCacheGroupSpec(layer_names=["attn"], kv_cache_spec=attention_spec),
-            KVCacheGroupSpec(layer_names=["mamba"], kv_cache_spec=mamba_spec),
-        ],
+def _layout_config(tensors, *, same_group=False):
+    spec = FullAttentionSpec(block_size=4, num_kv_heads=1, head_size=1, dtype=torch.float16)
+    groups = (
+        [KVCacheGroupSpec(layer_names=["attn", "other"], kv_cache_spec=spec)]
+        if same_group
+        else [KVCacheGroupSpec(layer_names=[name], kv_cache_spec=spec) for name in ("attn", "other")]
     )
-    validate_kv_cache_tensor_layouts(dense)
+    return KVCacheConfig(num_blocks=3, kv_cache_tensors=tensors, kv_cache_groups=groups)
 
-    packed = replace(
-        dense,
-        kv_cache_tensors=[
-            KVCacheTensor(size=96, shared_by=["attn"], offset=0, block_stride=32),
-            KVCacheTensor(size=96, shared_by=["mamba"], offset=16, block_stride=32),
-        ],
-    )
-    validate_kv_cache_tensor_layouts(packed)
+
+def test_validate_main_layer_views_and_cross_group_aliases():
+    # Main permits hybrid groups to overlay the same backing.
+    aliases = [_make_kv_cache_tensor(48, [name], 16, layer_stride=48) for name in ("attn", "other")]
+    validate_kv_cache_tensor_layouts(_layout_config(aliases))
+    # Layers in one group use separate contiguous regions in the backing.
+    packed = [_make_kv_cache_tensor(96, ["attn", "other"], 16, layer_stride=48)]
+    validate_kv_cache_tensor_layouts(_layout_config(packed, same_group=True))
 
 
 @pytest.mark.parametrize(
     ("tensors", "error"),
     [
-        ([KVCacheTensor(size=47, shared_by=["attn"])], "dense layout size"),
-        ([KVCacheTensor(size=48, shared_by=["attn"], offset=1)], "offset without a packed"),
-        ([KVCacheTensor(size=48, shared_by=["missing"])], "unknown layer"),
-        (
-            [
-                KVCacheTensor(size=48, shared_by=["attn"]),
-                KVCacheTensor(size=48, shared_by=["attn"]),
-            ],
-            "multiple storage owners",
-        ),
-        ([KVCacheTensor(size=64, shared_by=["attn"], block_stride=16)], "packed layout size"),
-        ([KVCacheTensor(size=96, shared_by=["attn"], offset=20, block_stride=32)], "page range"),
-        (
-            [
-                KVCacheTensor(size=96, shared_by=["attn"], offset=0, block_stride=32),
-                KVCacheTensor(size=96, shared_by=["mamba"], offset=8, block_stride=32),
-            ],
-            "overlaps",
-        ),
-        (
-            [
-                KVCacheTensor(size=96, shared_by=["attn"], block_stride=32),
-                KVCacheTensor(size=144, shared_by=["mamba"], block_stride=48),
-            ],
-            "packed backing",
-        ),
+        ([_make_kv_cache_tensor(47, ["attn"], 16)], "exceeds the backing"),
+        ([_make_kv_cache_tensor(48, ["attn"], 16, offset=-1)], "nonnegative"),
+        ([_make_kv_cache_tensor(48, ["missing"], 16)], "unknown layer"),
+        ([_make_kv_cache_tensor(48, ["attn", "attn"], 16)], "multiple storage owners"),
+        ([_make_kv_cache_tensor(48, ["attn"], 8)], "block stride"),
+        ([_make_kv_cache_tensor(48, ["attn", "other"], 16, layer_stride=0)], "overlaps"),
     ],
 )
 def test_validate_kv_cache_tensor_layouts_rejects_invalid_descriptions(tensors, error):
-    attention_spec = FullAttentionSpec(block_size=4, num_kv_heads=1, head_size=1, dtype=torch.float16)
-    mamba_spec = MambaSpec(block_size=4, shapes=((4,),), dtypes=(torch.float32,))
-    config = KVCacheConfig(
-        num_blocks=3,
-        kv_cache_tensors=tensors,
-        kv_cache_groups=[
-            KVCacheGroupSpec(layer_names=["attn"], kv_cache_spec=attention_spec),
-            KVCacheGroupSpec(layer_names=["mamba"], kv_cache_spec=mamba_spec),
-        ],
-    )
     with pytest.raises(ValueError, match=error):
-        validate_kv_cache_tensor_layouts(config)
+        validate_kv_cache_tensor_layouts(_layout_config(tensors, same_group=True))
 
 
 def test_mamba_model_state_inherits_upstream_state_management():

--- a/tests/ut/worker/test_model_runner_v2_mamba.py
+++ b/tests/ut/worker/test_model_runner_v2_mamba.py
@@ -1,8 +1,11 @@
 import ast
+from contextlib import nullcontext
+from dataclasses import replace
 from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
+import pytest
 import torch
 from vllm.v1.kv_cache_interface import (
     FullAttentionSpec,
@@ -10,6 +13,7 @@ from vllm.v1.kv_cache_interface import (
     KVCacheGroupSpec,
     KVCacheTensor,
     MambaSpec,
+    UniformTypeKVCacheSpecs,
 )
 from vllm.v1.worker.gpu.model_states.mamba_hybrid import MambaHybridModelState
 
@@ -18,6 +22,8 @@ from vllm_ascend.worker.v2.attn_utils import (
     _allocate_kv_cache,
     _reshape_kv_cache_v2,
     get_kv_cache_spec,
+    normalize_mamba_kv_cache_config,
+    validate_kv_cache_tensor_layouts,
 )
 from vllm_ascend.worker.v2.model_runner import NPUModelRunner
 from vllm_ascend.worker.v2.model_states import init_asecnd_model_state
@@ -83,10 +89,183 @@ def _group(spec: MambaSpec):
     )
 
 
+def test_validate_dense_and_packed_kv_cache_tensor_layouts():
+    attention_spec = FullAttentionSpec(block_size=4, num_kv_heads=1, head_size=1, dtype=torch.float16)
+    mamba_spec = MambaSpec(block_size=4, shapes=((4,),), dtypes=(torch.float32,))
+    assert attention_spec.page_size_bytes == mamba_spec.page_size_bytes == 16
+
+    dense = KVCacheConfig(
+        num_blocks=3,
+        kv_cache_tensors=[KVCacheTensor(size=48, shared_by=["attn", "mamba"])],
+        kv_cache_groups=[
+            KVCacheGroupSpec(layer_names=["attn"], kv_cache_spec=attention_spec),
+            KVCacheGroupSpec(layer_names=["mamba"], kv_cache_spec=mamba_spec),
+        ],
+    )
+    validate_kv_cache_tensor_layouts(dense)
+
+    packed = replace(
+        dense,
+        kv_cache_tensors=[
+            KVCacheTensor(size=96, shared_by=["attn"], offset=0, block_stride=32),
+            KVCacheTensor(size=96, shared_by=["mamba"], offset=16, block_stride=32),
+        ],
+    )
+    validate_kv_cache_tensor_layouts(packed)
+
+
+@pytest.mark.parametrize(
+    ("tensors", "error"),
+    [
+        ([KVCacheTensor(size=47, shared_by=["attn"])], "dense layout size"),
+        ([KVCacheTensor(size=48, shared_by=["attn"], offset=1)], "offset without a packed"),
+        ([KVCacheTensor(size=48, shared_by=["missing"])], "unknown layer"),
+        (
+            [
+                KVCacheTensor(size=48, shared_by=["attn"]),
+                KVCacheTensor(size=48, shared_by=["attn"]),
+            ],
+            "multiple storage owners",
+        ),
+        ([KVCacheTensor(size=64, shared_by=["attn"], block_stride=16)], "packed layout size"),
+        ([KVCacheTensor(size=96, shared_by=["attn"], offset=20, block_stride=32)], "page range"),
+        (
+            [
+                KVCacheTensor(size=96, shared_by=["attn"], offset=0, block_stride=32),
+                KVCacheTensor(size=96, shared_by=["mamba"], offset=8, block_stride=32),
+            ],
+            "overlaps",
+        ),
+        (
+            [
+                KVCacheTensor(size=96, shared_by=["attn"], block_stride=32),
+                KVCacheTensor(size=144, shared_by=["mamba"], block_stride=48),
+            ],
+            "packed backing",
+        ),
+    ],
+)
+def test_validate_kv_cache_tensor_layouts_rejects_invalid_descriptions(tensors, error):
+    attention_spec = FullAttentionSpec(block_size=4, num_kv_heads=1, head_size=1, dtype=torch.float16)
+    mamba_spec = MambaSpec(block_size=4, shapes=((4,),), dtypes=(torch.float32,))
+    config = KVCacheConfig(
+        num_blocks=3,
+        kv_cache_tensors=tensors,
+        kv_cache_groups=[
+            KVCacheGroupSpec(layer_names=["attn"], kv_cache_spec=attention_spec),
+            KVCacheGroupSpec(layer_names=["mamba"], kv_cache_spec=mamba_spec),
+        ],
+    )
+    with pytest.raises(ValueError, match=error):
+        validate_kv_cache_tensor_layouts(config)
+
+
 def test_mamba_model_state_inherits_upstream_state_management():
     assert issubclass(AscendMambaHybridModelState, MambaHybridModelState)
     assert AscendMambaHybridModelState.preprocess_state is MambaHybridModelState.preprocess_state
     assert AscendMambaHybridModelState.postprocess_state is MambaHybridModelState.postprocess_state
+    assert AscendMambaHybridModelState._get_mamba_group_info is MambaHybridModelState._get_mamba_group_info
+
+
+@pytest.mark.parametrize("wrapped", [False, True])
+@pytest.mark.parametrize("prefix_caching", [False, True])
+def test_mamba_worker_groups_reserve_speculative_block_table_entries(wrapped, prefix_caching):
+    spec = MambaSpec(
+        block_size=384,
+        shapes=((10, 6), (2, 2)),
+        dtypes=(torch.float16, torch.float32),
+        num_speculative_blocks=7,
+        mamba_cache_mode="align",
+    )
+    attention_specs = {
+        name: FullAttentionSpec(block_size=384, num_kv_heads=1, head_size=head_size, dtype=torch.float16)
+        for name, head_size in (("target", 8), ("draft", 16))
+    }
+    attention_spec = UniformTypeKVCacheSpecs.from_specs(attention_specs)
+    assert attention_spec is not None
+    groups = [KVCacheGroupSpec(layer_names=list(attention_specs), kv_cache_spec=attention_spec)]
+    for group_id in range(2):
+        layer_names = [f"mamba.{group_id}.{layer_id}" for layer_id in range(2)]
+        group_spec = UniformTypeKVCacheSpecs.from_specs(dict.fromkeys(layer_names, spec)) if wrapped else spec
+        assert group_spec is not None
+        groups.append(KVCacheGroupSpec(layer_names=layer_names, kv_cache_spec=group_spec))
+    config = KVCacheConfig(num_blocks=3, kv_cache_tensors=[], kv_cache_groups=groups)
+    runner = object.__new__(NPUModelRunner)
+    runner.max_model_len = 4096
+    runner.is_encoder_decoder = False
+    runner.dcp_size = 1
+    runner.dcp_rank = 0
+    runner.cp_interleave = 1
+    runner.max_num_reqs = 4
+    runner.max_num_tokens = 512
+    runner.device = torch.device("cpu")
+    runner.cache_config = SimpleNamespace(
+        enable_prefix_caching=prefix_caching,
+        mamba_cache_mode="align",
+    )
+    # Newer MRV2 delegates per-group block-table sizing to the cache spec,
+    # which reads cache and DCP settings from the full vLLM config.
+    runner.vllm_config = SimpleNamespace(
+        cache_config=runner.cache_config,
+        parallel_config=SimpleNamespace(decode_context_parallel_size=1),
+    )
+    runner.model_state = MagicMock()
+    runner.model_state.get_additional_cg_support.return_value = []
+    # Newer upstream initialize_kv_cache() reads the optional speculator while
+    # constructing adaptive-verification metadata. These placeholders cover
+    # only the arguments evaluated before the mocked BlockTables constructor;
+    # this minimal runner has no drafter and never uses their contents.
+    runner.speculator = None
+    runner.req_states = MagicMock()
+    runner.input_buffers = MagicMock()
+    runner.vocab_size = 128
+
+    class BlockTablesReached(Exception):
+        pass
+
+    with (
+        patch("vllm_ascend.worker.v2.model_runner.graph_manager_wrapper", return_value=nullcontext()),
+        patch("vllm.v1.worker.gpu.model_runner.init_attn_backend", return_value=([], MagicMock(), [128, 384, 384])),
+        patch("vllm.v1.worker.gpu.model_runner.BlockTables", side_effect=BlockTablesReached) as block_tables,
+        pytest.raises(BlockTablesReached),
+    ):
+        runner.initialize_kv_cache(config)
+
+    # Keep upstream in control of the exact align-mode width. Across supported
+    # vLLM revisions it may reserve either the active state slot or the full
+    # position-indexed row when prefix caching is disabled. Both must retain
+    # every speculative state slot, and all Mamba groups must agree.
+    widths = block_tables.call_args.kwargs["max_num_blocks_per_group"]
+    minimum_mamba_width = (11 if prefix_caching else 1) + spec.num_speculative_blocks
+    assert widths[0] == 11
+    assert widths[1] == widths[2]
+    assert widths[1] >= minimum_mamba_width
+    worker_groups = runner.kv_cache_config.kv_cache_groups
+    assert worker_groups[0].kv_cache_spec == attention_spec
+    assert worker_groups[1].kv_cache_spec == worker_groups[2].kv_cache_spec == spec
+    # No mutation of the config shared with the scheduler/other workers.
+    assert isinstance(config.kv_cache_groups[1].kv_cache_spec, UniformTypeKVCacheSpecs) == wrapped
+    state = object.__new__(AscendMambaHybridModelState)
+    state._mamba_spec = None
+    state._mamba_group_ids = []
+    assert state._get_mamba_group_info(runner.kv_cache_config) == ([1, 2], spec)
+    assert state._get_mamba_group_info(runner.kv_cache_config) == ([1, 2], spec)
+
+
+def test_mamba_normalization_preserves_distinct_per_layer_state_layouts():
+    specs = {
+        "first": _mamba_spec(),
+        "second": MambaSpec(block_size=16, shapes=((4, 3), (2, 2)), dtypes=(torch.float16, torch.float32)),
+    }
+    group_spec = UniformTypeKVCacheSpecs.from_specs(specs)
+    assert group_spec is not None
+    config = KVCacheConfig(
+        num_blocks=3,
+        kv_cache_tensors=[],
+        kv_cache_groups=[KVCacheGroupSpec(layer_names=list(specs), kv_cache_spec=group_spec)],
+    )
+    normalized = normalize_mamba_kv_cache_config(config)
+    assert normalized.kv_cache_groups[0].kv_cache_spec is group_spec
 
 
 def test_mrv2_advertises_standardized_shared_kv_backing():

--- a/vllm_ascend/attention/mla_v1.py
+++ b/vllm_ascend/attention/mla_v1.py
@@ -96,7 +96,7 @@ class AscendMLABackend(AttentionBackend):
         block_size: int,
         num_kv_heads: int,
         head_size: int,
-        cache_type: str = "",
+        cache_dtype_str: str = "auto",
     ) -> tuple[int, ...]:
         return num_blocks, block_size, num_kv_heads, head_size
 

--- a/vllm_ascend/core/kv_cache_interface.py
+++ b/vllm_ascend/core/kv_cache_interface.py
@@ -225,15 +225,25 @@ class AscendSlidingWindowMLASpec(SlidingWindowMLASpec):
         )
 
 
+class AscendFullAttentionManager(FullAttentionManager):
+    """Keep Ascend full-attention specs in the scheduler's zeroing lifecycle."""
+
+    def __init__(self, kv_cache_spec: KVCacheSpec, **kwargs) -> None:
+        super().__init__(kv_cache_spec, **kwargs)
+        # Upstream's exact-type whitelist omits custom MLA/indexer specs.
+        # The Ascend zeroer supports both; retain the config-level opt-in.
+        self._record_new_block_ids = kwargs.get("needs_kv_cache_zeroing", False)
+
+
 def register_ascend_kv_cache_specs() -> None:
     KVCacheSpecRegistry.register(
         kvcache_spec_cls=AscendMLAAttentionSpec,
-        manager_class=FullAttentionManager,
+        manager_class=AscendFullAttentionManager,
         uniform_type_base_spec=FullAttentionSpec,
     )
     KVCacheSpecRegistry.register(
         kvcache_spec_cls=AscendSFAIndexerCacheSpec,
-        manager_class=FullAttentionManager,
+        manager_class=AscendFullAttentionManager,
         uniform_type_base_spec=FullAttentionSpec,
     )
     KVCacheSpecRegistry.register(

--- a/vllm_ascend/models/dspark_aux.py
+++ b/vllm_ascend/models/dspark_aux.py
@@ -1,0 +1,135 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Target-to-draft auxiliary-hidden-state contracts for DSpark."""
+
+from dataclasses import dataclass
+from enum import Enum
+
+import torch
+
+
+class DSparkAuxHiddenFormat(str, Enum):
+    """Semantic representation of target auxiliary hidden states."""
+
+    MATERIALIZED = "materialized"
+    RAW_PREFIX_SUM = "raw_prefix_sum"
+
+    @property
+    def capture_point(self) -> str:
+        if self is DSparkAuxHiddenFormat.MATERIALIZED:
+            return "pre_layer_materialized"
+        return "post_layer_raw_prefix_sum"
+
+
+@dataclass(frozen=True)
+class DSparkAuxHiddenContract:
+    """Static contract negotiated when a target and DSpark draft are loaded."""
+
+    format: DSparkAuxHiddenFormat
+    layer_ids: tuple[int, ...]
+    capture_point: str
+    target_hidden_size: int
+    dtype: torch.dtype
+
+    @property
+    def packed_hidden_size(self) -> int:
+        return len(self.layer_ids) * self.target_hidden_size
+
+    def validate_definition(self) -> None:
+        if not self.layer_ids:
+            raise ValueError("DSpark auxiliary hidden contract requires at least one target layer")
+        if len(set(self.layer_ids)) != len(self.layer_ids):
+            raise ValueError(f"DSpark auxiliary hidden layer IDs must be unique: {self.layer_ids}")
+        if any(layer_id <= 0 for layer_id in self.layer_ids):
+            raise ValueError(f"DSpark auxiliary hidden layer IDs must be positive boundaries: {self.layer_ids}")
+        if self.target_hidden_size <= 0:
+            raise ValueError("DSpark target hidden size must be positive")
+        if self.capture_point != self.format.capture_point:
+            raise ValueError(
+                f"DSpark {self.format.value} auxiliary hidden states must use capture point "
+                f"{self.format.capture_point!r}, got {self.capture_point!r}"
+            )
+
+    def validate_runtime(
+        self,
+        aux_hidden_states: list[torch.Tensor] | None,
+        *,
+        num_target_tokens: int,
+        target_device: torch.device,
+    ) -> None:
+        """Validate shapes and placement without synchronizing device data.
+
+        PCP/PP restoration can pack several selected layers into one tensor, so
+        validate the aggregate feature width instead of requiring one tensor per
+        layer.
+        """
+        if not aux_hidden_states:
+            raise ValueError(
+                f"DSpark draft requires {self.format.value} auxiliary hidden states from target layers {self.layer_ids}"
+            )
+
+        packed_hidden_size = 0
+        for index, hidden_state in enumerate(aux_hidden_states):
+            if hidden_state.ndim != 2:
+                raise ValueError(f"DSpark auxiliary hidden state {index} must be 2-D, got {hidden_state.shape}")
+            if hidden_state.shape[0] < num_target_tokens:
+                raise ValueError(
+                    f"DSpark auxiliary hidden state {index} has {hidden_state.shape[0]} token rows, "
+                    f"but {num_target_tokens} are required"
+                )
+            if hidden_state.dtype != self.dtype:
+                raise ValueError(
+                    f"DSpark auxiliary hidden state {index} has dtype {hidden_state.dtype}, expected {self.dtype}"
+                )
+            if hidden_state.device != target_device:
+                raise ValueError(
+                    f"DSpark auxiliary hidden state {index} is on {hidden_state.device}, expected {target_device}"
+                )
+            packed_hidden_size += hidden_state.shape[-1]
+
+        if packed_hidden_size != self.packed_hidden_size:
+            raise ValueError(
+                f"DSpark auxiliary hidden width is {packed_hidden_size}, "
+                f"expected {self.packed_hidden_size} from layers {self.layer_ids}"
+            )
+
+
+def build_k3_mla_aux_hidden_contract(config, dtype: torch.dtype) -> DSparkAuxHiddenContract:
+    """Build the raw-prefix-sum contract declared by a K3 MLA drafter."""
+    target_layer_ids = getattr(config, "dspark_target_layer_ids", None) or getattr(
+        config,
+        "target_layer_ids",
+        None,
+    )
+    if not target_layer_ids:
+        raise ValueError("K3 MLA DSpark config must declare target_layer_ids")
+
+    # DSpark checkpoint IDs name zero-based target layers. vLLM captures model
+    # boundary IDs, where the output of layer i is boundary i + 1.
+    layer_ids = tuple(int(layer_id) + 1 for layer_id in target_layer_ids)
+    target_num_hidden_layers = getattr(config, "target_num_hidden_layers", None)
+    if target_num_hidden_layers is not None:
+        target_num_hidden_layers = int(target_num_hidden_layers)
+        if target_num_hidden_layers <= 0:
+            raise ValueError("K3 MLA DSpark target_num_hidden_layers must be positive")
+        if any(layer_id > target_num_hidden_layers for layer_id in layer_ids):
+            raise ValueError(
+                f"K3 MLA DSpark target_layer_ids={tuple(target_layer_ids)} exceed "
+                f"the declared {target_num_hidden_layers} target layers"
+            )
+    num_target_layers = int(getattr(config, "num_target_layers", len(layer_ids)))
+    if num_target_layers != len(layer_ids):
+        raise ValueError(
+            f"K3 MLA DSpark num_target_layers={num_target_layers} does not match "
+            f"target_layer_ids={tuple(target_layer_ids)}"
+        )
+
+    contract = DSparkAuxHiddenContract(
+        format=DSparkAuxHiddenFormat.RAW_PREFIX_SUM,
+        layer_ids=layer_ids,
+        capture_point=DSparkAuxHiddenFormat.RAW_PREFIX_SUM.capture_point,
+        target_hidden_size=int(config.target_hidden_size),
+        dtype=dtype,
+    )
+    contract.validate_definition()
+    return contract

--- a/vllm_ascend/models/kimi_k3.py
+++ b/vllm_ascend/models/kimi_k3.py
@@ -78,6 +78,10 @@ from vllm.sequence import IntermediateTensors
 from vllm.triton_utils import HAS_TRITON
 from vllm.utils.math_utils import cdiv
 
+from vllm_ascend.models.dspark_aux import (
+    DSparkAuxHiddenContract,
+    DSparkAuxHiddenFormat,
+)
 from vllm_ascend.ops.kimi_kda import AscendKimiK3DeltaAttention  # type: ignore[import-untyped]
 from vllm_ascend.utils import get_rotation_path
 
@@ -537,6 +541,51 @@ class AscendKimiLinearModel(UpstreamKimiLinearModel):
     # prefix-sum stream used by upstream vLLM, so keep that as the default.
     dspark_aux_capture_materialized = False
 
+    def _capture_raw_dspark_aux_hidden_state(
+        self,
+        aux_hidden_states: list[torch.Tensor],
+        layer_idx: int,
+        hidden_states: torch.Tensor,
+    ) -> list[torch.Tensor]:
+        """Capture the vLLM 0.27.1 K3 AttnRes auxiliary stream.
+
+        Ascend decoder layers return the running prefix with the pending MLP
+        output already folded into ``hidden_states``.  Their ``residual`` is a
+        three-dimensional bank of committed AttnRes blocks, unlike the
+        two-dimensional residual expected by ``EagleModelMixin``.  Reusing
+        ``_maybe_add_hidden_state`` would therefore broadcast the block bank
+        into the auxiliary tensor instead of producing the 2-D stream consumed
+        by the K3 MLA drafter.
+        """
+        if layer_idx in self.aux_hidden_state_layers:
+            aux_hidden_states.append(hidden_states)
+        return aux_hidden_states
+
+    def configure_dspark_aux_hidden_state_contract(
+        self,
+        contract: DSparkAuxHiddenContract,
+    ) -> None:
+        """Apply a draft-declared auxiliary-hidden-state representation."""
+        contract.validate_definition()
+        num_hidden_layers = int(self.config.num_hidden_layers)
+        if any(layer_id > num_hidden_layers for layer_id in contract.layer_ids):
+            raise ValueError(
+                f"DSpark auxiliary hidden layer IDs {contract.layer_ids} exceed "
+                f"the target's {num_hidden_layers} layer boundaries"
+            )
+        configured_layers = tuple(self.aux_hidden_state_layers)
+        if configured_layers != contract.layer_ids:
+            raise ValueError(
+                f"Target auxiliary layers {configured_layers} do not match "
+                f"the DSpark draft contract {contract.layer_ids}"
+            )
+        if self.config.hidden_size != contract.target_hidden_size:
+            raise ValueError(
+                f"Target hidden size {self.config.hidden_size} does not match "
+                f"the DSpark draft contract {contract.target_hidden_size}"
+            )
+        self.dspark_aux_capture_materialized = contract.format == DSparkAuxHiddenFormat.MATERIALIZED
+
     def __init__(self, *, vllm_config: VllmConfig, prefix: str = "") -> None:
         nn.Module.__init__(self)
         config = vllm_config.model_config.hf_text_config
@@ -664,11 +713,10 @@ class AscendKimiLinearModel(UpstreamKimiLinearModel):
         if self.dspark_aux_capture_materialized:
             aux_hidden_states: list[torch.Tensor] = []
         else:
-            aux_hidden_states = self._maybe_add_hidden_state(
+            aux_hidden_states = self._capture_raw_dspark_aux_hidden_state(
                 [],
                 self.start_layer,
                 hidden_states,
-                residual,
             )
         attn_res_block_num = cdiv(
             self.end_layer,
@@ -703,11 +751,10 @@ class AscendKimiLinearModel(UpstreamKimiLinearModel):
                 residual=residual,
             )
             if not self.dspark_aux_capture_materialized and (layer_idx + 1) in self.aux_hidden_state_layers:
-                self._maybe_add_hidden_state(
+                self._capture_raw_dspark_aux_hidden_state(
                     aux_hidden_states,
                     layer_idx + 1,
                     hidden_states,
-                    residual,
                 )
 
         if not get_pp_group().is_last_rank:
@@ -778,6 +825,12 @@ class AscendKimiLinearForCausalLM(UpstreamKimiLinearForCausalLM):
 
     def set_dspark_aux_capture_materialized(self, enabled: bool) -> None:
         self.model.dspark_aux_capture_materialized = enabled
+
+    def configure_dspark_aux_hidden_state_contract(
+        self,
+        contract: DSparkAuxHiddenContract,
+    ) -> None:
+        self.model.configure_dspark_aux_hidden_state_contract(contract)
 
 
 class AscendKimiK3MultiModalProjector(KimiK25MultiModalProjector):
@@ -877,3 +930,9 @@ class AscendKimiK3ForConditionalGeneration(UpstreamKimiK3ForConditionalGeneratio
 
     def set_dspark_aux_capture_materialized(self, enabled: bool) -> None:
         self.language_model.set_dspark_aux_capture_materialized(enabled)
+
+    def configure_dspark_aux_hidden_state_contract(
+        self,
+        contract: DSparkAuxHiddenContract,
+    ) -> None:
+        self.language_model.configure_dspark_aux_hidden_state_contract(contract)

--- a/vllm_ascend/models/kimi_k3.py
+++ b/vllm_ascend/models/kimi_k3.py
@@ -589,9 +589,9 @@ class AscendKimiLinearModel(UpstreamKimiLinearModel):
     def __init__(self, *, vllm_config: VllmConfig, prefix: str = "") -> None:
         nn.Module.__init__(self)
         config = vllm_config.model_config.hf_text_config
+        parallel_config = vllm_config.parallel_config
         self.config = config
         self.vocab_size = config.vocab_size
-        parallel_config = vllm_config.parallel_config
         # vLLM's generic MoE SP switch currently requires DP > 1. K3 also
         # needs the same rank-local token layout for the TP/EP, DP=1 topology
         # that FlashComm used before the standard SP operators were available.
@@ -832,6 +832,9 @@ class AscendKimiLinearForCausalLM(UpstreamKimiLinearForCausalLM):
     ) -> None:
         self.model.configure_dspark_aux_hidden_state_contract(contract)
 
+    def set_aux_hidden_state_layers(self, layers: tuple[int, ...]) -> None:
+        self.model._set_aux_hidden_state_layers(layers)
+
 
 class AscendKimiK3MultiModalProjector(KimiK25MultiModalProjector):
     """Kimi projector with the optional ModelSlim output rotation."""
@@ -936,3 +939,6 @@ class AscendKimiK3ForConditionalGeneration(UpstreamKimiK3ForConditionalGeneratio
         contract: DSparkAuxHiddenContract,
     ) -> None:
         self.language_model.configure_dspark_aux_hidden_state_contract(contract)
+
+    def set_aux_hidden_state_layers(self, layers: tuple[int, ...]) -> None:
+        self.language_model.set_aux_hidden_state_layers(layers)

--- a/vllm_ascend/models/kimi_k3_dspark.py
+++ b/vllm_ascend/models/kimi_k3_dspark.py
@@ -33,6 +33,10 @@ from vllm.models.kimi_k3.nvidia.dspark_mla import (
     K3DSparkModel as UpstreamK3DSparkModel,
 )
 
+from vllm_ascend.models.dspark_aux import (
+    DSparkAuxHiddenContract,
+    build_k3_mla_aux_hidden_contract,
+)
 from vllm_ascend.models.kimi_k3 import (
     AscendKimiMLAAttention,
 )
@@ -245,6 +249,10 @@ class AscendK3DSparkForCausalLM(UpstreamK3DSparkForCausalLM):
         self.draft_model_config = vllm_config.speculative_config.draft_model_config
         assert self.draft_model_config is not None
         self.config = self.draft_model_config.hf_config
+        self._aux_hidden_contract = build_k3_mla_aux_hidden_contract(
+            self.config,
+            vllm_config.model_config.dtype,
+        )
         target_layer_num = vllm_config.model_config.get_num_layers(vllm_config.parallel_config)
         self.model = AscendK3DSparkModel(
             vllm_config=vllm_config,
@@ -275,6 +283,11 @@ class AscendK3DSparkForCausalLM(UpstreamK3DSparkForCausalLM):
     def get_draft_attn_causal(self) -> list[bool]:
         causal = _uses_causal_draft_attention(self.config)
         return [causal] * len(self.model.layers)
+
+    def get_required_dspark_aux_hidden_state_contract(
+        self,
+    ) -> DSparkAuxHiddenContract:
+        return self._aux_hidden_contract
 
     def load_weights(
         self,

--- a/vllm_ascend/models/kimi_k3_dspark.py
+++ b/vllm_ascend/models/kimi_k3_dspark.py
@@ -76,9 +76,7 @@ def _get_target_rotation_path(vllm_config: VllmConfig) -> Path | None:
     try:
         with description_path.open(encoding="utf-8") as description_file:
             description = json.load(description_file)
-        relative_path = description["optional"]["quarot"]["rotation_map"][
-            "global_rotation"
-        ]
+        relative_path = description["optional"]["quarot"]["rotation_map"]["global_rotation"]
     except (OSError, KeyError, TypeError, json.JSONDecodeError):
         return None
     return target_model_path / relative_path

--- a/vllm_ascend/models/kimi_k3_dspark.py
+++ b/vllm_ascend/models/kimi_k3_dspark.py
@@ -2,7 +2,9 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 """Kimi K3 MLA DSpark draft model for Ascend."""
 
+import json
 from collections.abc import Iterable
+from pathlib import Path
 
 import torch
 from torch import nn
@@ -58,6 +60,28 @@ def _uses_causal_draft_attention(config) -> bool:
     if isinstance(dflash_config, dict) and "causal" in dflash_config:
         return bool(dflash_config["causal"])
     return bool(getattr(config, "full_attention_causal", False))
+
+
+def _get_target_rotation_path(vllm_config: VllmConfig) -> Path | None:
+    rotation_path = get_rotation_path(vllm_config)
+    if rotation_path is not None:
+        return rotation_path
+
+    # MRV2 replaces vllm_config.quant_config with the draft model's quant
+    # config before constructing the DSpark model. A non-quantized draft then
+    # loses the target model's QuaRot metadata even though model_config still
+    # points at the target checkpoint. Recover that target-only metadata.
+    target_model_path = Path(vllm_config.model_config.model)
+    description_path = target_model_path / "quant_model_description.json"
+    try:
+        with description_path.open(encoding="utf-8") as description_file:
+            description = json.load(description_file)
+        relative_path = description["optional"]["quarot"]["rotation_map"][
+            "global_rotation"
+        ]
+    except (OSError, KeyError, TypeError, json.JSONDecodeError):
+        return None
+    return target_model_path / relative_path
 
 
 class AscendK3DSparkDecoderLayer(UpstreamK3DSparkDecoderLayer):
@@ -264,7 +288,7 @@ class AscendK3DSparkForCausalLM(UpstreamK3DSparkForCausalLM):
             self.config.draft_vocab_size,
             scale=getattr(self.config, "logit_scale", 1.0),
         )
-        self.rotation_path = get_rotation_path(vllm_config)
+        self.rotation_path = _get_target_rotation_path(vllm_config)
         self.target_model_path = vllm_config.model_config.model
         if self.rotation_path is not None:
             target_config = vllm_config.model_config.hf_text_config

--- a/vllm_ascend/models/qwen3_dspark.py
+++ b/vllm_ascend/models/qwen3_dspark.py
@@ -24,6 +24,19 @@ TARGET_LM_HEAD_WEIGHT_NAMES = (
 )
 
 
+def _get_draft_rotation_path(vllm_config: VllmConfig, config) -> Path | None:
+    injected_rotation_path = getattr(
+        config,
+        "_ascend_target_rotation_path",
+        None,
+    )
+    if injected_rotation_path is not None:
+        return Path(injected_rotation_path)
+    if vllm_config.quant_config is None:
+        return None
+    return get_rotation_path(vllm_config)
+
+
 # Process the first linear weight with rotation matrix, if the target model uses rotary quantization
 def process_weight(linear_weight: torch.Tensor, rotation_weight: torch.Tensor):
     assert linear_weight.shape[1] % rotation_weight.shape[0] == 0, (
@@ -68,12 +81,16 @@ class DSparkConfidenceHead(nn.Module):
 
 
 class AscendQwen3DSparkForCausalLM(Qwen3DSparkForCausalLM):
+    # Qwen3 GQA DSpark consumes the materialized input to each selected
+    # target layer instead of Kimi K3's raw/prefix-sum residual stream.
+    dspark_aux_hidden_state_format = "materialized"
+
     def __init__(self, *, vllm_config: VllmConfig, prefix: str = "") -> None:
         super().__init__(vllm_config=vllm_config, prefix=prefix)
 
         config = self.config
         self.enable_confidence_head = bool(getattr(config, "enable_confidence_head", False))
-        self.rotation_path = get_rotation_path(vllm_config) if vllm_config.quant_config is not None else None
+        self.rotation_path = _get_draft_rotation_path(vllm_config, self.config)
         self.target_model_path = Path(vllm_config.model_config.model)
 
     @staticmethod

--- a/vllm_ascend/patch/platform/patch_speculative_config.py
+++ b/vllm_ascend/patch/platform/patch_speculative_config.py
@@ -34,6 +34,7 @@ def _normalize_legacy_qwen3_dspark_config(hf_config: PretrainedConfig) -> Pretra
                 "architectures": ["Qwen3DSparkModel"],
                 "mask_token_id": dflash_config["mask_token_id"],
                 "target_layer_ids": dflash_config["target_layer_ids"],
+                "dspark_aux_hidden_state_format": "materialized",
             }
         )
     return hf_config

--- a/vllm_ascend/worker/utils.py
+++ b/vllm_ascend/worker/utils.py
@@ -1,15 +1,19 @@
 from collections.abc import Iterable, Iterator
 from contextlib import contextmanager
-from itertools import product as iprod
+from math import prod
 from typing import Any
 
 import torch
 from vllm.triton_utils import tl, triton
 from vllm.utils.math_utils import largest_power_of_2_divisor
-from vllm.v1.kv_cache_interface import FullAttentionSpec
+from vllm.v1.kv_cache_interface import AttentionSpec
 from vllm.v1.worker.utils import AttentionGroup, KVBlockZeroer
 
+from vllm_ascend.core.kv_cache_interface import get_storage_block_size
 from vllm_ascend.ops.triton.triton_utils import get_vectorcore_num
+
+ZERO_BLOCK_SIZE = 8192
+INITIAL_BLOCK_ID_CAPACITY = 8192
 
 
 @contextmanager
@@ -30,19 +34,19 @@ def disable_compilation(model: torch.nn.Module) -> Iterator[None]:
 @triton.jit
 def _zero_kv_blocks_kernel(
     seg_addrs_ptr,
+    seg_page_sizes_ptr,
+    seg_page_strides_ptr,
     block_ids_ptr,
     n_blocks,
     N_SEGS: tl.constexpr,
-    PAGE_SIZE_EL: tl.constexpr,
+    MAX_CHUNKS: tl.constexpr,
     BLOCK_SIZE: tl.constexpr,
     GRID_SIZE: tl.constexpr,
 ):
     """Zero KV cache blocks across all segments in a single launch.
 
-    Each segment is a contiguous region of one block's data.  For backends
-    where blocks are outermost (block_dim=0) there is one segment per
-    buffer.  For backends where K/V is outermost (block_dim=1) there are
-    two segments per buffer (one for K, one for V).
+    Each segment is a contiguous region of one scheduler block's data.
+    Separate sizes and strides preserve padding and other hybrid cache views.
 
     seg_addrs_ptr holds absolute byte addresses (int64) for each segment,
     allowing segments to live in different CUDA allocations.
@@ -50,20 +54,21 @@ def _zero_kv_blocks_kernel(
     Programs are mapped as (block_index, seg_index, chunk_index).
     """
     pid = tl.program_id(0)
-    chunks = PAGE_SIZE_EL // BLOCK_SIZE
-    work_per_block = N_SEGS * chunks
+    work_per_block = N_SEGS * MAX_CHUNKS
     total_work = n_blocks * work_per_block
     for work_idx in range(pid, total_work, GRID_SIZE):
         block_index = work_idx // work_per_block
         remainder = work_idx % work_per_block
-        seg_index = remainder // chunks
-        chunk_index = remainder % chunks
+        seg_index = remainder // MAX_CHUNKS
+        chunk_index = remainder % MAX_CHUNKS
         block_id = tl.load(block_ids_ptr + block_index)
         seg_addr = tl.load(seg_addrs_ptr + seg_index)
+        page_size_el = tl.load(seg_page_sizes_ptr + seg_index)
+        page_stride_el = tl.load(seg_page_strides_ptr + seg_index)
         ptr = tl.cast(seg_addr, tl.pointer_type(tl.int32))
-        offset = block_id.to(tl.int64) * PAGE_SIZE_EL + chunk_index.to(tl.int64) * BLOCK_SIZE
-        cols = tl.arange(0, BLOCK_SIZE).to(tl.int64)
-        tl.store(ptr + offset + cols, tl.zeros([BLOCK_SIZE], dtype=tl.int32))
+        offset = block_id.to(tl.int64) * page_stride_el
+        cols = chunk_index.to(tl.int64) * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE).to(tl.int64)
+        tl.store(ptr + offset + cols, tl.zeros([BLOCK_SIZE], dtype=tl.int32), mask=cols < page_size_el)
 
 
 class AscendKVBlockZeroer(KVBlockZeroer):
@@ -77,7 +82,7 @@ class AscendKVBlockZeroer(KVBlockZeroer):
     def __init__(self, device: torch.device, pin_memory: bool) -> None:
         self.device = device
         self.pin_memory = pin_memory
-        self._meta: tuple[torch.Tensor, int, int, int] | None = None
+        self._meta: tuple[torch.Tensor, torch.Tensor, torch.Tensor, int, int, int] | None = None
         self._id_cap: int = 0
         self._ids_pinned: torch.Tensor | None = None
         self._ids_gpu: torch.Tensor | None = None
@@ -98,61 +103,79 @@ class AscendKVBlockZeroer(KVBlockZeroer):
 
         Block IDs from the scheduler reference logical blocks whose size
         may differ from the kernel block size (virtual block splitting).
-        PAGE_SIZE_EL accounts for this ratio so that
-        ``block_id * PAGE_SIZE_EL`` lands at the correct offset.
+        Per-segment page strides account for this ratio. The payload size
+        excludes padding, which may belong to another hybrid cache view.
 
         Only AttentionSpec layers are processed; Mamba layers are skipped.
         """
         seen_ptrs: set[int] = set()
         seg_addrs: list[int] = []
-        page_size_el: int | None = None
+        seg_page_sizes: list[int] = []
+        seg_page_strides: list[int] = []
 
         for group in attn_groups_iter:
             spec = group.kv_cache_spec
-            if not isinstance(spec, FullAttentionSpec):
+            # Match upstream's zeroing scope so installing the Ascend zeroer
+            # does not silently exclude sliding-window attention groups.
+            if not isinstance(spec, AttentionSpec):
                 continue
             if group.kv_cache_group_id >= len(kernel_block_sizes):
                 continue
             kernel_bs = kernel_block_sizes[group.kv_cache_group_id][0]
-            ratio = spec.block_size // kernel_bs
-            block_dim = 0
+            storage_bs = get_storage_block_size(spec)
+            # Compressed caches are reshaped with one physical block per
+            # scheduler block, rather than the uncompressed kernel size.
+            if storage_bs != spec.block_size:
+                kernel_bs = storage_bs
+            assert storage_bs % kernel_bs == 0
+            ratio = storage_bs // kernel_bs
 
             for layer_name in group.layer_names:
                 if layer_name in runner_only_attn_layers:
                     continue
                 kv_tuple = static_forward_context[layer_name].kv_cache
-                assert len(kv_tuple) == 2, "K and V are not stored separately"
                 for kv in kv_tuple:
-                    block_dim = 0
+                    # No-RoPE MLA can expose an empty second component.
+                    if kv.numel() == 0:
+                        continue
                     dp = kv.data_ptr()
                     if dp in seen_ptrs:
                         continue
                     seen_ptrs.add(dp)
 
-                    el = kv.element_size()
-                    cur_bytes = kv.stride(block_dim) * el
-                    assert cur_bytes % 4 == 0
-                    kernel_block_el = cur_bytes // 4
-                    cur_page_el = kernel_block_el * ratio
-                    if page_size_el is None:
-                        page_size_el = cur_page_el
+                    assert kv[0].is_contiguous(), "KV blocks must have contiguous inner dimensions"
+                    stride_bytes = kv.stride(0) * kv.element_size()
+                    payload_bytes = prod(kv.shape[1:]) * kv.element_size()
+                    assert kv.shape[0] % ratio == 0, (
+                        f"KV cache block count {kv.shape[0]} must be divisible by virtual block ratio {ratio}"
+                    )
+                    assert stride_bytes >= payload_bytes
+                    assert stride_bytes % 4 == 0 and payload_bytes % 4 == 0 and dp % 4 == 0
+                    storage = kv.untyped_storage()
+                    storage_start = storage.data_ptr()
+                    storage_end = storage_start + storage.nbytes()
+                    payload_end = dp + (kv.shape[0] - 1) * stride_bytes + payload_bytes
+                    assert storage_start <= dp and payload_end <= storage_end, (
+                        "KV cache component payload exceeds its backing storage"
+                    )
+                    if stride_bytes == payload_bytes:
+                        # Coalesce contiguous virtual blocks into one segment.
+                        seg_addrs.append(dp)
+                        seg_page_sizes.append(payload_bytes * ratio // 4)
+                        seg_page_strides.append(stride_bytes * ratio // 4)
                     else:
-                        assert page_size_el == cur_page_el, f"Non-uniform page sizes: {page_size_el} vs {cur_page_el}"
+                        for sub_block in range(ratio):
+                            seg_addrs.append(dp + sub_block * stride_bytes)
+                            seg_page_sizes.append(payload_bytes // 4)
+                            seg_page_strides.append(stride_bytes * ratio // 4)
 
-                    block_stride_bytes = cur_bytes
-                    outer_dims = [d for d in range(block_dim) if kv.stride(d) * el > block_stride_bytes]
-                    outer_strides = [kv.stride(d) * el for d in outer_dims]
-                    for outer in iprod(*(range(kv.shape[d]) for d in outer_dims)):
-                        off_bytes = sum(i * s for i, s in zip(outer, outer_strides))
-                        seg_addrs.append(dp + off_bytes)
-
-        if not seg_addrs or page_size_el is None:
+        if not seg_addrs:
             self._meta = None
             return
 
-        # _zero_kv_blocks_kernel will use int64 zeros, to meet the UB size, we use blk_size=64B/8B=8192
-        blk_size = min(largest_power_of_2_divisor(page_size_el), 8192)
-        self._id_cap = 8192
+        # Bound each int32 store to 32 KiB of UB space.
+        blk_size = min(min(largest_power_of_2_divisor(size) for size in seg_page_sizes), ZERO_BLOCK_SIZE)
+        self._id_cap = INITIAL_BLOCK_ID_CAPACITY
         self._ids_pinned = torch.empty(
             self._id_cap,
             dtype=torch.int64,
@@ -161,7 +184,9 @@ class AscendKVBlockZeroer(KVBlockZeroer):
         self._ids_gpu = torch.empty(self._id_cap, dtype=torch.int64, device=self.device)
         self._meta = (
             torch.tensor(seg_addrs, dtype=torch.uint64, device=self.device),
-            page_size_el,
+            torch.tensor(seg_page_sizes, dtype=torch.int64, device=self.device),
+            torch.tensor(seg_page_strides, dtype=torch.int64, device=self.device),
+            max(seg_page_sizes) // blk_size,
             blk_size,
             len(seg_addrs),
         )
@@ -170,7 +195,7 @@ class AscendKVBlockZeroer(KVBlockZeroer):
         """Zero the KV cache memory for the given block IDs."""
         if not block_ids or self._meta is None:
             return
-        seg_addrs, page_size_el, blk_size, n_segs = self._meta
+        seg_addrs, seg_page_sizes, seg_page_strides, max_chunks, blk_size, n_segs = self._meta
         n_blocks = len(block_ids)
         if n_blocks > self._id_cap:
             self._id_cap = n_blocks * 2
@@ -184,17 +209,18 @@ class AscendKVBlockZeroer(KVBlockZeroer):
         self._ids_pinned[:n_blocks].numpy()[:] = block_ids
         idx = self._ids_gpu[:n_blocks]
         idx.copy_(self._ids_pinned[:n_blocks], non_blocking=True)
-        chunks = page_size_el // blk_size
-        total_work = n_blocks * n_segs * chunks
+        total_work = n_blocks * n_segs * max_chunks
         grid = min(total_work, get_vectorcore_num()) if total_work > 0 else 0
         if grid == 0:
             return
         _zero_kv_blocks_kernel[(grid,)](
             seg_addrs,
+            seg_page_sizes,
+            seg_page_strides,
             idx,
             n_blocks,
             N_SEGS=n_segs,
-            PAGE_SIZE_EL=page_size_el,
+            MAX_CHUNKS=max_chunks,
             BLOCK_SIZE=blk_size,
             GRID_SIZE=grid,
         )

--- a/vllm_ascend/worker/v2/attn_utils.py
+++ b/vllm_ascend/worker/v2/attn_utils.py
@@ -69,6 +69,104 @@ if TYPE_CHECKING:
     from vllm_ascend.worker.v2.pcp_manager import AscendPCPAttentionContext
 
 
+def normalize_mamba_kv_cache_config(kv_cache_config: KVCacheConfig) -> KVCacheConfig:
+    """Expose identical Mamba specs to upstream MRV2 sizing and state handling."""
+    groups = []
+    for group in kv_cache_config.kv_cache_groups:
+        spec = group.kv_cache_spec
+        if isinstance(spec, UniformTypeKVCacheSpecs):
+            inner_specs = list(spec.kv_cache_specs.values())
+            if (
+                inner_specs
+                and isinstance(inner_specs[0], MambaSpec)
+                and all(inner == inner_specs[0] for inner in inner_specs)
+            ):
+                group = replace(group, kv_cache_spec=inner_specs[0])
+        groups.append(group)
+    # Preserve per-layer attention layouts and the caller's worker config.
+    return replace(kv_cache_config, kv_cache_groups=groups)
+
+
+def validate_kv_cache_tensor_layouts(kv_cache_config: KVCacheConfig) -> None:
+    """Validate the byte layout consumed by upstream MRV2 allocation.
+
+    ``KVCacheTensor`` describes raw byte storage, while attention backends bind
+    typed and possibly strided views later.  Reject inconsistent descriptions
+    before allocation so an invalid offset or stride cannot surface as a cache
+    alias or an out-of-bounds graph replay.
+    """
+    if kv_cache_config.num_blocks <= 0:
+        raise ValueError("KV cache num_blocks must be positive")
+
+    specs_by_layer: dict[str, KVCacheSpec] = {}
+    for group in kv_cache_config.kv_cache_groups:
+        group_spec = group.kv_cache_spec
+        if isinstance(group_spec, UniformTypeKVCacheSpecs):
+            for layer_name in group.layer_names:
+                specs_by_layer[layer_name] = group_spec.kv_cache_specs[layer_name]
+        else:
+            specs_by_layer.update(dict.fromkeys(group.layer_names, group_spec))
+
+    owners: set[str] = set()
+    packed_backing: tuple[int, int] | None = None
+    packed_ranges: list[tuple[int, int, str]] = []
+    for tensor_idx, kv_tensor in enumerate(kv_cache_config.kv_cache_tensors):
+        label = f"KV cache tensor {tensor_idx}"
+        if kv_tensor.size <= 0:
+            raise ValueError(f"{label} size must be positive")
+        if not kv_tensor.shared_by:
+            raise ValueError(f"{label} must own at least one layer")
+
+        duplicate_owners = owners.intersection(kv_tensor.shared_by)
+        if duplicate_owners:
+            raise ValueError(f"KV cache layers have multiple storage owners: {sorted(duplicate_owners)}")
+        owners.update(kv_tensor.shared_by)
+
+        try:
+            page_sizes = {specs_by_layer[layer_name].page_size_bytes for layer_name in kv_tensor.shared_by}
+        except KeyError as exc:
+            raise ValueError(f"{label} references unknown layer {exc.args[0]!r}") from exc
+        if len(page_sizes) != 1:
+            raise ValueError(f"{label} shares layers with different page sizes: {sorted(page_sizes)}")
+        page_size = page_sizes.pop()
+
+        if kv_tensor.block_stride == 0:
+            if kv_tensor.offset != 0:
+                raise ValueError(f"{label} has an offset without a packed block stride")
+            expected_size = kv_cache_config.num_blocks * page_size
+            if kv_tensor.size != expected_size:
+                raise ValueError(f"{label} size {kv_tensor.size} does not match dense layout size {expected_size}")
+            continue
+
+        if kv_tensor.block_stride < page_size:
+            raise ValueError(f"{label} block stride {kv_tensor.block_stride} is smaller than page size {page_size}")
+        if kv_tensor.offset < 0 or kv_tensor.offset + page_size > kv_tensor.block_stride:
+            raise ValueError(
+                f"{label} page range [{kv_tensor.offset}, {kv_tensor.offset + page_size}) "
+                f"exceeds packed block stride {kv_tensor.block_stride}"
+            )
+        expected_size = kv_cache_config.num_blocks * kv_tensor.block_stride
+        if kv_tensor.size != expected_size:
+            raise ValueError(f"{label} size {kv_tensor.size} does not match packed layout size {expected_size}")
+
+        backing = (kv_tensor.size, kv_tensor.block_stride)
+        if packed_backing is None:
+            packed_backing = backing
+        elif backing != packed_backing:
+            raise ValueError(
+                f"{label} packed backing {backing} does not match the first packed backing {packed_backing}"
+            )
+
+        page_end = kv_tensor.offset + page_size
+        for other_start, other_end, other_label in packed_ranges:
+            if kv_tensor.offset < other_end and other_start < page_end:
+                raise ValueError(
+                    f"{label} page range [{kv_tensor.offset}, {page_end}) overlaps "
+                    f"{other_label} page range [{other_start}, {other_end}) in the packed backing"
+                )
+        packed_ranges.append((kv_tensor.offset, page_end, label))
+
+
 def get_kv_cache_spec(vllm_config: VllmConfig) -> dict[str, KVCacheSpec]:
     """Build Ascend-specific KV cache specs for v2 worker patching."""
     from vllm.model_executor.models.deepseek_v2 import DeepseekV32IndexerCache
@@ -1077,11 +1175,13 @@ def build_attn_metadata_wrapper():
 
 @contextmanager
 def build_draft_attn_metadata_factory(positions, pad, is_prefilling):
-    """Wrap build_attn_metadata to forward rotary positions for the draft block.
+    """Wrap build_attn_metadata with Ascend draft-model context.
 
     The generic (Ascend) ``build_attn_metadata`` reads ``positions`` inside the
     DSA/MLA ``build_decode_metadata`` for cos/sin, but the flat upstream
-    speculator path does not forward them. Must run inside
+    speculator path does not forward them or the Ascend attention state. The
+    latter must be ``SpecDecoding`` so MLA uses the token-major speculative
+    path instead of treating draft tokens as independent requests. Must run inside
     ``build_attn_metadata_wrapper()``.
     """
     raw = _BUILD_ATTN_METADATA_MODULE.build_attn_metadata  # cache
@@ -1089,6 +1189,7 @@ def build_draft_attn_metadata_factory(positions, pad, is_prefilling):
     def build_attn_metadata(*args, **kwargs):
         kwargs["positions"] = positions[:pad]
         kwargs["is_prefilling"] = is_prefilling
+        kwargs["attn_state"] = AscendAttentionState.SpecDecoding
         return raw(*args, **kwargs)
 
     try:

--- a/vllm_ascend/worker/v2/attn_utils.py
+++ b/vllm_ascend/worker/v2/attn_utils.py
@@ -88,83 +88,52 @@ def normalize_mamba_kv_cache_config(kv_cache_config: KVCacheConfig) -> KVCacheCo
 
 
 def validate_kv_cache_tensor_layouts(kv_cache_config: KVCacheConfig) -> None:
-    """Validate the byte layout consumed by upstream MRV2 allocation.
+    """Validate main's per-layer views without rejecting hybrid group aliases.
 
-    ``KVCacheTensor`` describes raw byte storage, while attention backends bind
-    typed and possibly strided views later.  Reject inconsistent descriptions
-    before allocation so an invalid offset or stride cannot surface as a cache
-    alias or an out-of-bounds graph replay.
+    Descriptors use offset, layer_stride and block_stride into a shared byte
+    backing. Different cache groups may intentionally overlay the same bytes;
+    layers within a group must have disjoint storage.
     """
     if kv_cache_config.num_blocks <= 0:
         raise ValueError("KV cache num_blocks must be positive")
 
     specs_by_layer: dict[str, KVCacheSpec] = {}
-    for group in kv_cache_config.kv_cache_groups:
-        group_spec = group.kv_cache_spec
-        if isinstance(group_spec, UniformTypeKVCacheSpecs):
-            for layer_name in group.layer_names:
-                specs_by_layer[layer_name] = group_spec.kv_cache_specs[layer_name]
-        else:
-            specs_by_layer.update(dict.fromkeys(group.layer_names, group_spec))
+    groups_by_layer: dict[str, int] = {}
+    for group_id, group in enumerate(kv_cache_config.kv_cache_groups):
+        spec = group.kv_cache_spec
+        for name in group.layer_names:
+            specs_by_layer[name] = spec.kv_cache_specs[name] if isinstance(spec, UniformTypeKVCacheSpecs) else spec
+            groups_by_layer[name] = group_id
 
     owners: set[str] = set()
-    packed_backing: tuple[int, int] | None = None
-    packed_ranges: list[tuple[int, int, str]] = []
-    for tensor_idx, kv_tensor in enumerate(kv_cache_config.kv_cache_tensors):
+    regions: dict[int, list[tuple[int, int, str]]] = {}
+    for tensor_idx, tensor in enumerate(kv_cache_config.kv_cache_tensors):
         label = f"KV cache tensor {tensor_idx}"
-        if kv_tensor.size <= 0:
+        if tensor.size <= 0:
             raise ValueError(f"{label} size must be positive")
-        if not kv_tensor.shared_by:
+        layers = get_kv_cache_tensor_layers(tensor)
+        if not layers:
             raise ValueError(f"{label} must own at least one layer")
-
-        duplicate_owners = owners.intersection(kv_tensor.shared_by)
-        if duplicate_owners:
-            raise ValueError(f"KV cache layers have multiple storage owners: {sorted(duplicate_owners)}")
-        owners.update(kv_tensor.shared_by)
-
-        try:
-            page_sizes = {specs_by_layer[layer_name].page_size_bytes for layer_name in kv_tensor.shared_by}
-        except KeyError as exc:
-            raise ValueError(f"{label} references unknown layer {exc.args[0]!r}") from exc
-        if len(page_sizes) != 1:
-            raise ValueError(f"{label} shares layers with different page sizes: {sorted(page_sizes)}")
-        page_size = page_sizes.pop()
-
-        if kv_tensor.block_stride == 0:
-            if kv_tensor.offset != 0:
-                raise ValueError(f"{label} has an offset without a packed block stride")
-            expected_size = kv_cache_config.num_blocks * page_size
-            if kv_tensor.size != expected_size:
-                raise ValueError(f"{label} size {kv_tensor.size} does not match dense layout size {expected_size}")
-            continue
-
-        if kv_tensor.block_stride < page_size:
-            raise ValueError(f"{label} block stride {kv_tensor.block_stride} is smaller than page size {page_size}")
-        if kv_tensor.offset < 0 or kv_tensor.offset + page_size > kv_tensor.block_stride:
-            raise ValueError(
-                f"{label} page range [{kv_tensor.offset}, {kv_tensor.offset + page_size}) "
-                f"exceeds packed block stride {kv_tensor.block_stride}"
-            )
-        expected_size = kv_cache_config.num_blocks * kv_tensor.block_stride
-        if kv_tensor.size != expected_size:
-            raise ValueError(f"{label} size {kv_tensor.size} does not match packed layout size {expected_size}")
-
-        backing = (kv_tensor.size, kv_tensor.block_stride)
-        if packed_backing is None:
-            packed_backing = backing
-        elif backing != packed_backing:
-            raise ValueError(
-                f"{label} packed backing {backing} does not match the first packed backing {packed_backing}"
-            )
-
-        page_end = kv_tensor.offset + page_size
-        for other_start, other_end, other_label in packed_ranges:
-            if kv_tensor.offset < other_end and other_start < page_end:
-                raise ValueError(
-                    f"{label} page range [{kv_tensor.offset}, {page_end}) overlaps "
-                    f"{other_label} page range [{other_start}, {other_end}) in the packed backing"
-                )
-        packed_ranges.append((kv_tensor.offset, page_end, label))
+        if tensor.offset < 0 or tensor.layer_stride < 0:
+            raise ValueError(f"{label} offset and layer stride must be nonnegative")
+        for layer_idx, name in enumerate(layers):
+            if name in owners:
+                raise ValueError(f"KV cache layer {name} has multiple storage owners")
+            owners.add(name)
+            if name not in specs_by_layer:
+                raise ValueError(f"{label} references unknown layer {name!r}")
+            page_size = specs_by_layer[name].page_size_bytes
+            if tensor.block_stride < page_size:
+                raise ValueError(f"{label} block stride is smaller than page size")
+            start = tensor.offset + layer_idx * tensor.layer_stride
+            end = start + (kv_cache_config.num_blocks - 1) * tensor.block_stride + page_size
+            if end > tensor.size:
+                raise ValueError(f"{label} layer {name} exceeds the backing allocation")
+            group_regions = regions.setdefault(groups_by_layer[name], [])
+            for other_start, other_end, other_name in group_regions:
+                if start < other_end and other_start < end:
+                    raise ValueError(f"{label} layer {name} overlaps {other_name} within one cache group")
+            group_regions.append((start, end, name))
 
 
 def get_kv_cache_spec(vllm_config: VllmConfig) -> dict[str, KVCacheSpec]:

--- a/vllm_ascend/worker/v2/model_runner.py
+++ b/vllm_ascend/worker/v2/model_runner.py
@@ -58,9 +58,13 @@ from vllm_ascend.core.profiling_chunk_predictor import (
 )
 from vllm_ascend.ops.rotary_embedding import set_cos_and_sin, update_cos_sin
 from vllm_ascend.utils import lmhead_tp_enable, set_potential_max_tokens
-from vllm_ascend.worker.utils import disable_compilation
+from vllm_ascend.worker.utils import AscendKVBlockZeroer, disable_compilation
 from vllm_ascend.worker.v2.aclgraph_utils import ModelAclGraphManager
-from vllm_ascend.worker.v2.attn_utils import build_attn_state
+from vllm_ascend.worker.v2.attn_utils import (
+    build_attn_state,
+    normalize_mamba_kv_cache_config,
+    validate_kv_cache_tensor_layouts,
+)
 from vllm_ascend.worker.v2.eplb import AscendEPLBController
 from vllm_ascend.worker.v2.input_batch import AscendInputBatch, AscendInputBuffers
 from vllm_ascend.worker.v2.pcp_manager import AscendPCPManager
@@ -240,6 +244,10 @@ class NPUModelRunner(GPUModelRunner):
         return output
 
     def initialize_kv_cache(self, kv_cache_config: KVCacheConfig) -> None:
+        # Upstream sizes speculative Mamba block tables using the bare spec.
+        # K3 DSpark worker configs retain uniform per-layer group wrappers.
+        kv_cache_config = normalize_mamba_kv_cache_config(kv_cache_config)
+        validate_kv_cache_tensor_layouts(kv_cache_config)
         with graph_manager_wrapper(self):
             super().initialize_kv_cache(kv_cache_config)
             if self.pcp_manager is not None:
@@ -250,6 +258,18 @@ class NPUModelRunner(GPUModelRunner):
                     self.speculator.pcp_manager = self.pcp_manager
         if self.model_config.enable_return_routed_experts:
             self.init_routed_experts_capturer()
+
+    def _init_kv_zero_meta(self) -> None:
+        # The upstream zeroer only handles a single tensor per layer. Ascend
+        # binds separate K/V views, including unequal MLA cache components.
+        self.kv_block_zeroer = AscendKVBlockZeroer(self.device, pin_memory=True)
+        self.kv_block_zeroer.init_meta(
+            attn_groups_iter=(group for groups in self.attn_groups for group in groups),
+            kernel_block_sizes=[[block_size] for block_size in self.kernel_block_sizes],
+            cache_dtype=self.cache_config.cache_dtype,
+            runner_only_attn_layers=set(),
+            static_forward_context=self.compilation_config.static_forward_context,
+        )
 
     @torch.inference_mode()
     def execute_model(

--- a/vllm_ascend/worker/v2/spec_decode/dflash/aclgraph.py
+++ b/vllm_ascend/worker/v2/spec_decode/dflash/aclgraph.py
@@ -16,6 +16,7 @@ from vllm.v1.worker.utils import AttentionGroup
 
 from vllm_ascend.ascend_forward_context import _EXTRA_CTX
 from vllm_ascend.compilation.acl_graph import (
+    get_draft_graph_params,
     set_draft_graph_params,
     update_full_graph_params,
 )
@@ -82,10 +83,25 @@ class DFlashAclGraphManager(DFlashCudaGraphManager):
         """Override run_fullgraph to update full graph params in run_fullgraph."""
         num_tokens = desc.num_tokens
 
+        if self.speculator is None:
+            raise RuntimeError("Draft ACL graph manager has no bound speculator.")
+        if self.update_stream is None:
+            raise RuntimeError("Draft ACL graph manager has no bound update stream.")
+        expected_num_tokens = desc.num_reqs * self.speculator.num_query_per_req
+        if num_tokens != expected_num_tokens:
+            raise RuntimeError(
+                "Draft ACL graph descriptor mismatch: "
+                f"num_tokens={num_tokens}, num_reqs={desc.num_reqs}, "
+                f"num_query_per_req={self.speculator.num_query_per_req}."
+            )
+
         draft_attn_metadatas = self.speculator.build_draft_attn_metadatas(
             desc.num_reqs,
             self.speculator.input_batch.seq_lens_cpu_upper_bound,
         )
+        graph_params = get_draft_graph_params()
+        self._validate_graph_param_cardinality(graph_params, num_tokens)
+        draft_backend = self.speculator.get_draft_graph_backend()
         self.update_stream.wait_stream(torch.npu.current_stream())
         ret = super().run_fullgraph(desc)
 
@@ -93,6 +109,11 @@ class DFlashAclGraphManager(DFlashCudaGraphManager):
         # calculate num_tokens_across_dp.
         num_tokens_across_dp = torch.full([self.speculator.dp_size], num_tokens, device=self.device)
 
+        # ``sample_tokens`` invokes the proposer after the target forward
+        # context has already exited.  _EXTRA_CTX is a proxy to that context,
+        # so it must never be read before installing the draft context here.
+        # The new context owns these flags and is discarded on exit; restoring
+        # values through the proxy after exit would fail for the same reason.
         with set_forward_context(
             self.speculator.model_state.attn_metadata,
             self.vllm_config,
@@ -102,16 +123,13 @@ class DFlashAclGraphManager(DFlashCudaGraphManager):
             batch_descriptor=None,  # Full graph model don't need batch_descriptor
             slot_mapping=None,
         ):
-            # decide to update draft graph params
+            # Keep the existing ExternalEvent/task-update submission protocol;
+            # only make the draft context explicit and scoped.
             _EXTRA_CTX.is_draft_model = True
-
             _EXTRA_CTX.is_draft_model_prefill = False
-
             forward_context = get_forward_context()
-
             update_full_graph_params(
-                # FIXME(Ronald1995): support hybrid attn backend
-                list(self.speculator.attn_backends.values())[0],
+                draft_backend,
                 self.update_stream,
                 forward_context,
                 num_tokens,
@@ -120,3 +138,29 @@ class DFlashAclGraphManager(DFlashCudaGraphManager):
                 draft_attn_metadatas=draft_attn_metadatas,
             )
         return ret
+
+    @staticmethod
+    def _validate_graph_param_cardinality(graph_params: Any, num_tokens: int) -> int:
+        """Prevent ``zip`` in backend updaters from silently dropping tasks."""
+        if graph_params is None:
+            raise RuntimeError("Draft ACL graph parameters have not been initialized.")
+
+        captured_params = graph_params.attn_params.get(num_tokens)
+        handles = graph_params.handles.get(num_tokens)
+        events = graph_params.events.get(num_tokens)
+        if captured_params is None or handles is None or events is None:
+            raise RuntimeError(
+                f"Draft ACL graph has no captured parameter bucket for {num_tokens} tokens."
+            )
+        counts = (len(captured_params), len(handles), len(events))
+        if counts[0] == 0:
+            raise RuntimeError(
+                f"Draft ACL graph captured no attention update tasks for {num_tokens} tokens."
+            )
+        if len(set(counts)) != 1:
+            raise RuntimeError(
+                "Draft ACL graph update cardinality mismatch for "
+                f"{num_tokens} tokens: params={counts[0]}, handles={counts[1]}, "
+                f"events={counts[2]}."
+            )
+        return counts[0]

--- a/vllm_ascend/worker/v2/spec_decode/dflash/aclgraph.py
+++ b/vllm_ascend/worker/v2/spec_decode/dflash/aclgraph.py
@@ -101,7 +101,13 @@ class DFlashAclGraphManager(DFlashCudaGraphManager):
         )
         graph_params = get_draft_graph_params()
         self._validate_graph_param_cardinality(graph_params, num_tokens)
-        draft_backend = self.speculator.get_draft_graph_backend()
+        if hasattr(self.speculator, "get_draft_graph_backend"):
+            draft_backend = self.speculator.get_draft_graph_backend()
+        else:
+            backends = set(self.speculator.attn_backends.values())
+            if len(backends) != 1:
+                raise NotImplementedError("Draft ACL graph requires one attention backend.")
+            draft_backend = next(iter(backends))
         self.update_stream.wait_stream(torch.npu.current_stream())
         ret = super().run_fullgraph(desc)
 
@@ -149,14 +155,10 @@ class DFlashAclGraphManager(DFlashCudaGraphManager):
         handles = graph_params.handles.get(num_tokens)
         events = graph_params.events.get(num_tokens)
         if captured_params is None or handles is None or events is None:
-            raise RuntimeError(
-                f"Draft ACL graph has no captured parameter bucket for {num_tokens} tokens."
-            )
+            raise RuntimeError(f"Draft ACL graph has no captured parameter bucket for {num_tokens} tokens.")
         counts = (len(captured_params), len(handles), len(events))
         if counts[0] == 0:
-            raise RuntimeError(
-                f"Draft ACL graph captured no attention update tasks for {num_tokens} tokens."
-            )
+            raise RuntimeError(f"Draft ACL graph captured no attention update tasks for {num_tokens} tokens.")
         if len(set(counts)) != 1:
             raise RuntimeError(
                 "Draft ACL graph update cardinality mismatch for "

--- a/vllm_ascend/worker/v2/spec_decode/dflash/speculator.py
+++ b/vllm_ascend/worker/v2/spec_decode/dflash/speculator.py
@@ -218,6 +218,7 @@ def _prepare_dflash_inputs_kernel_ascend(
 
     nrejected = tl.load(num_rejected_ptr + req_idx)
     valid_ctx_end = ctx_end - nrejected
+    num_valid_ctx = valid_ctx_end - ctx_start
 
     nsampled = tl.load(num_sampled_ptr + req_idx)
     if nsampled > 0:
@@ -232,11 +233,20 @@ def _prepare_dflash_inputs_kernel_ascend(
     # --- Context positions / slots ---
     for j in range(0, num_ctx):
         ctx_pos_idx = ctx_start + j
-        ctx_pos = tl.load(target_positions_ptr + ctx_pos_idx)
+        is_valid_ctx = j < num_valid_ctx
+        ctx_pos = tl.load(target_positions_ptr + ctx_pos_idx, mask=is_valid_ctx, other=0)
         ctx_block_num = ctx_pos // block_size
         ctx_block_num = tl.minimum(ctx_block_num, block_table_stride - 1)
-        ctx_block_id = tl.load(block_table_ptr + req_idx * block_table_stride + ctx_block_num).to(tl.int64)
-        ctx_slot = ctx_block_id * block_size + (ctx_pos % block_size)
+        ctx_block_id = tl.load(
+            block_table_ptr + req_idx * block_table_stride + ctx_block_num,
+            mask=is_valid_ctx,
+            other=0,
+        ).to(tl.int64)
+        ctx_slot = tl.where(
+            is_valid_ctx & (ctx_block_id != 0),
+            ctx_block_id * block_size + (ctx_pos % block_size),
+            PAD_SLOT_ID,
+        )
         tl.store(out_context_positions_ptr + ctx_pos_idx, ctx_pos)
         tl.store(out_context_slot_mapping_ptr + ctx_pos_idx, ctx_slot)
 
@@ -252,7 +262,7 @@ def _prepare_dflash_inputs_kernel_ascend(
         q_block_num = query_pos // block_size
         q_block_num = tl.minimum(q_block_num, block_table_stride - 1)
         q_block_id = tl.load(block_table_ptr + req_idx * block_table_stride + q_block_num).to(tl.int64)
-        q_slot = q_block_id * block_size + (query_pos % block_size)
+        q_slot = tl.where(q_block_id != 0, q_block_id * block_size + (query_pos % block_size), PAD_SLOT_ID)
 
         tl.store(out_input_ids_ptr + query_idx, input_id)
         clamped_query_pos = tl.minimum(query_pos, max_model_len - 1)

--- a/vllm_ascend/worker/v2/spec_decode/dspark/speculator.py
+++ b/vllm_ascend/worker/v2/spec_decode/dspark/speculator.py
@@ -27,6 +27,7 @@ from vllm.v1.worker.gpu.spec_decode.dspark.speculator import (
     DSparkSpeculator,
 )
 
+from vllm_ascend.models.dspark_aux import DSparkAuxHiddenContract
 from vllm_ascend.models.qwen3_dspark import process_weight
 from vllm_ascend.utils import (
     get_rotation_matrix,
@@ -44,6 +45,7 @@ class AscendDSparkSpeculator(DSparkSpeculator):
     def __init__(self, vllm_config: VllmConfig, device: torch.device):
         super().__init__(vllm_config, device)
         self.input_batch: InputBatch | None = None
+        self.aux_hidden_contract: DSparkAuxHiddenContract | None = None
 
     def load_draft_model(
         self,
@@ -63,6 +65,27 @@ class AscendDSparkSpeculator(DSparkSpeculator):
             fc = model.model.fc
             with torch.no_grad():
                 fc.weight.data.copy_(process_weight(fc.weight.data.cpu(), rotation_weight))
+
+        get_contract = getattr(
+            model,
+            "get_required_dspark_aux_hidden_state_contract",
+            None,
+        )
+        if get_contract is not None:
+            contract = get_contract()
+            configure_target = getattr(
+                target_model,
+                "configure_dspark_aux_hidden_state_contract",
+                None,
+            )
+            if configure_target is None:
+                raise ValueError(
+                    f"DSpark draft {type(model).__name__} requires auxiliary hidden "
+                    f"format {contract.format.value}, but target {type(target_model).__name__} "
+                    "does not expose the DSpark auxiliary-hidden-state contract capability"
+                )
+            configure_target(contract)
+            self.aux_hidden_contract = contract
         return model
 
     def init_cudagraph_manager(self, cudagraph_mode: CUDAGraphMode) -> None:
@@ -174,6 +197,12 @@ class AscendDSparkSpeculator(DSparkSpeculator):
     ) -> torch.Tensor:
         self.input_batch = input_batch
         assert self.input_batch is not None
+        if self.aux_hidden_contract is not None:
+            self.aux_hidden_contract.validate_runtime(
+                aux_hidden_states,
+                num_target_tokens=input_batch.num_tokens,
+                target_device=last_hidden_states.device,
+            )
         sync_state = dp_sync
         with (
             build_attn_metadata_wrapper(),

--- a/vllm_ascend/worker/v2/spec_decode/dspark/speculator.py
+++ b/vllm_ascend/worker/v2/spec_decode/dspark/speculator.py
@@ -20,23 +20,32 @@ from typing import Any, cast
 import torch
 from vllm.config import VllmConfig, get_layers_from_vllm_config
 from vllm.config.compilation import CUDAGraphMode
+from vllm.logger import init_logger
 from vllm.model_executor.layers.attention_layer_base import AttentionLayerBase
 from vllm.v1.attention.backend import AttentionBackend
 from vllm.v1.worker.gpu.input_batch import InputBatch
+from vllm.v1.worker.gpu.spec_decode.eagle.utils import get_target_lm_head
 from vllm.v1.worker.gpu.spec_decode.dspark.speculator import (
     DSparkSpeculator,
 )
 
 from vllm_ascend.models.dspark_aux import DSparkAuxHiddenContract
-from vllm_ascend.models.qwen3_dspark import process_weight
 from vllm_ascend.utils import (
-    get_rotation_matrix,
     get_rotation_path,
 )
 from vllm_ascend.worker.v2.attn_utils import (
     build_attn_metadata_wrapper,
     build_draft_attn_metadata_factory,
 )
+
+logger = init_logger(__name__)
+
+DSPARK_AUX_HIDDEN_FORMAT_RAW = "raw"
+DSPARK_AUX_HIDDEN_FORMAT_MATERIALIZED = "materialized"
+_VALID_DSPARK_AUX_HIDDEN_FORMATS = {
+    DSPARK_AUX_HIDDEN_FORMAT_RAW,
+    DSPARK_AUX_HIDDEN_FORMAT_MATERIALIZED,
+}
 
 
 class AscendDSparkSpeculator(DSparkSpeculator):
@@ -46,25 +55,83 @@ class AscendDSparkSpeculator(DSparkSpeculator):
         super().__init__(vllm_config, device)
         self.input_batch: InputBatch | None = None
         self.aux_hidden_contract: DSparkAuxHiddenContract | None = None
+        config = self.draft_model_config.hf_config
+        dflash_config = getattr(config, "dflash_config", {}) or {}
+        logger.warning(
+            "[dspark/config] top_sample_from_anchor=%s "
+            "nested_sample_from_anchor=%s runtime_sample_from_anchor=%s "
+            "num_query_per_req=%s target_layer_ids=%s mask_token_id=%s "
+            "ptd_token_id=%s rope_parameters=%s",
+            getattr(config, "sample_from_anchor", None),
+            dflash_config.get("sample_from_anchor"),
+            self.sample_from_anchor,
+            self.num_query_per_req,
+            getattr(config, "target_layer_ids", None),
+            getattr(config, "mask_token_id", None),
+            getattr(config, "ptd_token_id", None),
+            getattr(config, "rope_parameters", None),
+        )
 
     def load_draft_model(
         self,
         target_model: torch.nn.Module,
         target_attn_layer_names: set[str],
     ) -> torch.nn.Module:
-        model = super().load_draft_model(target_model, target_attn_layer_names)
-        # Upstream load_dspark_model overrides the drafter's quant_config with
-        # get_draft_quant_config (None for a bf16 drafter), so the drafter's
-        # __init__ derives rotation_path=None and its fc projection is loaded
-        # unrotated. The target is QuaRot-quantized, so the aux hidden states it
-        # feeds the drafter are in rotated space; fc must be rotated (W @ R) to
-        # project them back to model space.
+        draft_model_config = getattr(self, "draft_model_config", None)
+        draft_hf_config = getattr(draft_model_config, "hf_config", None)
+        configured_format = self._configure_target_aux_hidden_state_format(
+            target_model,
+            draft_hf_config,
+        )
+        # Upstream intentionally clears the target quant config before it
+        # builds a BF16 draft. Pass only the target QuaRot metadata through the
+        # draft config so the Ascend model loader can align FC, embedding and
+        # lm_head before upstream decides whether to share target weights.
         rotation_path = get_rotation_path(self.vllm_config)
-        if rotation_path is not None and hasattr(model.model, "fc"):
-            rotation_weight = get_rotation_matrix(rotation_path)
-            fc = model.model.fc
-            with torch.no_grad():
-                fc.weight.data.copy_(process_weight(fc.weight.data.cpu(), rotation_weight))
+        injected_rotation = rotation_path is not None and draft_hf_config is not None
+        if injected_rotation:
+            draft_hf_config._ascend_target_rotation_path = str(rotation_path)
+        try:
+            model = super().load_draft_model(target_model, target_attn_layer_names)
+        finally:
+            if injected_rotation:
+                delattr(draft_hf_config, "_ascend_target_rotation_path")
+
+        model_format = getattr(model, "dspark_aux_hidden_state_format", None)
+        if configured_format is None:
+            self._configure_target_aux_hidden_state_format(target_model, model)
+        elif model_format is not None and model_format != configured_format:
+            raise ValueError(
+                "DSpark auxiliary hidden-state format mismatch between config "
+                f"({configured_format!r}) and model ({model_format!r})."
+            )
+
+        if rotation_path is not None and self._is_qwen3_gqa_draft(draft_hf_config):
+            target_language_model = (
+                target_model.get_language_model()
+                if hasattr(target_model, "get_language_model")
+                else target_model
+            )
+            target_inner = target_language_model.model
+            target_lm_head = get_target_lm_head(target_model, target_language_model)
+            draft_inner = model.model
+            embed_shared = getattr(draft_inner, "embed_tokens", None) is getattr(
+                target_inner, "embed_tokens", None
+            )
+            lm_head_shared = getattr(model, "lm_head", None) is target_lm_head
+            logger.warning(
+                "[dspark/quarot-check] rotation_path=%s embed_shared=%s "
+                "lm_head_shared=%s has_own_embed=%s has_own_lm_head=%s",
+                rotation_path,
+                embed_shared,
+                lm_head_shared,
+                getattr(model, "has_own_embed_tokens", False),
+                getattr(model, "has_own_lm_head", False),
+            )
+            if embed_shared:
+                raise RuntimeError("QuaRot GQA DSpark must not share target embed_tokens.")
+            if lm_head_shared:
+                raise RuntimeError("QuaRot GQA DSpark must not share target lm_head.")
 
         get_contract = getattr(
             model,
@@ -87,6 +154,73 @@ class AscendDSparkSpeculator(DSparkSpeculator):
             configure_target(contract)
             self.aux_hidden_contract = contract
         return model
+
+    @staticmethod
+    def _is_qwen3_gqa_draft(config: Any) -> bool:
+        if config is None:
+            return False
+        architectures = getattr(config, "architectures", ()) or ()
+        return getattr(config, "model_type", None) == "qwen3" or any(
+            architecture in ("Qwen3DSparkModel", "DSparkDraftModel")
+            for architecture in architectures
+        )
+
+    @staticmethod
+    def _configure_target_aux_hidden_state_format(
+        target_model: torch.nn.Module,
+        format_provider: Any,
+    ) -> str | None:
+        """Apply a draft-declared auxiliary-hidden-state representation."""
+        aux_hidden_format = getattr(
+            format_provider,
+            "dspark_aux_hidden_state_format",
+            None,
+        )
+        if aux_hidden_format is None:
+            architectures = getattr(format_provider, "architectures", ()) or ()
+            model_type = getattr(format_provider, "model_type", None)
+            if model_type == "qwen3" or (
+                "Qwen3DSparkModel" in architectures
+                or "DSparkDraftModel" in architectures
+            ):
+                aux_hidden_format = DSPARK_AUX_HIDDEN_FORMAT_MATERIALIZED
+        if aux_hidden_format is None:
+            return None
+        if aux_hidden_format not in _VALID_DSPARK_AUX_HIDDEN_FORMATS:
+            raise ValueError(
+                "Unsupported DSpark auxiliary hidden-state format "
+                f"{aux_hidden_format!r}; expected one of "
+                f"{sorted(_VALID_DSPARK_AUX_HIDDEN_FORMATS)}."
+            )
+
+        set_capture_mode = getattr(
+            target_model,
+            "set_dspark_aux_capture_materialized",
+            None,
+        )
+        if set_capture_mode is None:
+            get_language_model = getattr(target_model, "get_language_model", None)
+            if callable(get_language_model):
+                set_capture_mode = getattr(
+                    get_language_model(),
+                    "set_dspark_aux_capture_materialized",
+                    None,
+                )
+        if set_capture_mode is None:
+            raise RuntimeError(
+                "DSpark auxiliary hidden-state format "
+                f"{aux_hidden_format!r} was resolved, but target model "
+                f"{type(target_model).__name__} has no capture-mode setter."
+            )
+
+        materialized = aux_hidden_format == DSPARK_AUX_HIDDEN_FORMAT_MATERIALIZED
+        set_capture_mode(materialized)
+        logger.info(
+            "DSpark auxiliary hidden-state contract: draft=%s, target_capture=%s.",
+            aux_hidden_format,
+            "materialized" if materialized else "raw",
+        )
+        return aux_hidden_format
 
     def init_cudagraph_manager(self, cudagraph_mode: CUDAGraphMode) -> None:
         if self.speculative_config.enforce_eager:
@@ -120,7 +254,10 @@ class AscendDSparkSpeculator(DSparkSpeculator):
         for kv_cache_group_spec in kv_cache_config.kv_cache_groups:
             layer_names = kv_cache_group_spec.layer_names
             if active_layer_names is not None:
-                layer_names = list(active_layer_names.intersection(layer_names))
+                # Preserve the cache-group order. ``draft_attn_layer_names`` is
+                # a set, so iterating its intersection would make graph task
+                # registration depend on hash order.
+                layer_names = [name for name in layer_names if name in active_layer_names]
 
             layer_type = cast(type[Any], AttentionLayerBase)
             attn_layers = get_layers_from_vllm_config(self.vllm_config, layer_type, layer_names)
@@ -129,6 +266,39 @@ class AscendDSparkSpeculator(DSparkSpeculator):
                 attn_backends[layer_name] = attn_layers[layer_name].get_attn_backend()
 
         self.attn_backends = attn_backends
+        if active_layer_names is not None:
+            missing_layers = active_layer_names.difference(attn_backends)
+            if missing_layers:
+                raise RuntimeError(
+                    "DSpark attention layers were not mapped to KV-cache "
+                    f"groups: {sorted(missing_layers)}."
+                )
+
+    def get_draft_graph_backend(self) -> type[AttentionBackend]:
+        """Return the single backend supported by the first DSpark graph phase.
+
+        Eager execution may support a wider set of draft layouts, but the
+        current ACL graph updater owns one captured parameter bucket. Refuse an
+        empty or hybrid mapping instead of silently selecting the first dict
+        entry and updating captured tasks with the wrong backend.
+        """
+        attn_backends = getattr(self, "attn_backends", None) or {}
+        if not attn_backends:
+            raise RuntimeError("DSpark ACL graph requires at least one active draft attention backend.")
+
+        backend_layers: dict[type[AttentionBackend], list[str]] = {}
+        for layer_name, backend in attn_backends.items():
+            backend_layers.setdefault(backend, []).append(layer_name)
+        if len(backend_layers) != 1:
+            details = ", ".join(
+                f"{getattr(backend, '__name__', repr(backend))}={sorted(layer_names)}"
+                for backend, layer_names in backend_layers.items()
+            )
+            raise NotImplementedError(
+                "DSpark ACL graph currently supports one GQA attention backend; "
+                f"got {details}."
+            )
+        return next(iter(backend_layers))
 
     def build_draft_attn_metadatas(self, num_reqs_padded, seq_lens_cpu_upper_bound):
         num_tokens_padded = num_reqs_padded * self.num_query_per_req
@@ -152,7 +322,9 @@ class AscendDSparkSpeculator(DSparkSpeculator):
                 step=self.num_query_per_req,
                 causal=self._group_causal,
             )
-        return [self._update_draft_attn_metadata(attn_metadata, num_reqs_padded)]
+        attn_metadata = self._update_draft_attn_metadata(attn_metadata, num_reqs_padded)
+        self._validate_draft_attn_metadata(attn_metadata, num_reqs_padded)
+        return [attn_metadata]
 
     def _update_draft_attn_metadata(self, attn_metadata, num_reqs_padded):
         """Rebuild ``actual_seq_lengths_q`` from the padded request count,
@@ -173,6 +345,30 @@ class AscendDSparkSpeculator(DSparkSpeculator):
         for metadata in attn_metadata.values():
             metadata.actual_seq_lengths_q = query_lens_list
         return attn_metadata
+
+    def _validate_draft_attn_metadata(self, attn_metadata, num_reqs_padded):
+        """Validate the GQA metadata contract before a graph is submitted."""
+        if not attn_metadata:
+            raise RuntimeError("DSpark ACL graph produced no draft attention metadata.")
+
+        expected_query_lens = [
+            (i + 1) * self.num_query_per_req for i in range(num_reqs_padded)
+        ]
+        expected_num_tokens = num_reqs_padded * self.num_query_per_req
+        for layer_name, metadata in attn_metadata.items():
+            actual_query_lens = list(getattr(metadata, "actual_seq_lengths_q", ()))
+            if actual_query_lens != expected_query_lens:
+                raise RuntimeError(
+                    "DSpark ACL graph query-length mismatch for "
+                    f"{layer_name}: expected {expected_query_lens}, got "
+                    f"{actual_query_lens}."
+                )
+            if actual_query_lens[-1] != expected_num_tokens:
+                raise RuntimeError(
+                    "DSpark ACL graph metadata does not cover the padded "
+                    f"query tokens for {layer_name}: expected "
+                    f"{expected_num_tokens}, got {actual_query_lens[-1]}."
+                )
 
     def propose(
         self,

--- a/vllm_ascend/worker/v2/spec_decode/dspark/speculator.py
+++ b/vllm_ascend/worker/v2/spec_decode/dspark/speculator.py
@@ -24,10 +24,10 @@ from vllm.logger import init_logger
 from vllm.model_executor.layers.attention_layer_base import AttentionLayerBase
 from vllm.v1.attention.backend import AttentionBackend
 from vllm.v1.worker.gpu.input_batch import InputBatch
-from vllm.v1.worker.gpu.spec_decode.eagle.utils import get_target_lm_head
 from vllm.v1.worker.gpu.spec_decode.dspark.speculator import (
     DSparkSpeculator,
 )
+from vllm.v1.worker.gpu.spec_decode.eagle.utils import get_target_lm_head
 
 from vllm_ascend.models.dspark_aux import DSparkAuxHiddenContract
 from vllm_ascend.utils import (
@@ -108,16 +108,12 @@ class AscendDSparkSpeculator(DSparkSpeculator):
 
         if rotation_path is not None and self._is_qwen3_gqa_draft(draft_hf_config):
             target_language_model = (
-                target_model.get_language_model()
-                if hasattr(target_model, "get_language_model")
-                else target_model
+                target_model.get_language_model() if hasattr(target_model, "get_language_model") else target_model
             )
             target_inner = target_language_model.model
             target_lm_head = get_target_lm_head(target_model, target_language_model)
             draft_inner = model.model
-            embed_shared = getattr(draft_inner, "embed_tokens", None) is getattr(
-                target_inner, "embed_tokens", None
-            )
+            embed_shared = getattr(draft_inner, "embed_tokens", None) is getattr(target_inner, "embed_tokens", None)
             lm_head_shared = getattr(model, "lm_head", None) is target_lm_head
             logger.warning(
                 "[dspark/quarot-check] rotation_path=%s embed_shared=%s "
@@ -161,8 +157,7 @@ class AscendDSparkSpeculator(DSparkSpeculator):
             return False
         architectures = getattr(config, "architectures", ()) or ()
         return getattr(config, "model_type", None) == "qwen3" or any(
-            architecture in ("Qwen3DSparkModel", "DSparkDraftModel")
-            for architecture in architectures
+            architecture in ("Qwen3DSparkModel", "DSparkDraftModel") for architecture in architectures
         )
 
     @staticmethod
@@ -179,10 +174,7 @@ class AscendDSparkSpeculator(DSparkSpeculator):
         if aux_hidden_format is None:
             architectures = getattr(format_provider, "architectures", ()) or ()
             model_type = getattr(format_provider, "model_type", None)
-            if model_type == "qwen3" or (
-                "Qwen3DSparkModel" in architectures
-                or "DSparkDraftModel" in architectures
-            ):
+            if model_type == "qwen3" or ("Qwen3DSparkModel" in architectures or "DSparkDraftModel" in architectures):
                 aux_hidden_format = DSPARK_AUX_HIDDEN_FORMAT_MATERIALIZED
         if aux_hidden_format is None:
             return None
@@ -270,8 +262,7 @@ class AscendDSparkSpeculator(DSparkSpeculator):
             missing_layers = active_layer_names.difference(attn_backends)
             if missing_layers:
                 raise RuntimeError(
-                    "DSpark attention layers were not mapped to KV-cache "
-                    f"groups: {sorted(missing_layers)}."
+                    f"DSpark attention layers were not mapped to KV-cache groups: {sorted(missing_layers)}."
                 )
 
     def get_draft_graph_backend(self) -> type[AttentionBackend]:
@@ -294,10 +285,7 @@ class AscendDSparkSpeculator(DSparkSpeculator):
                 f"{getattr(backend, '__name__', repr(backend))}={sorted(layer_names)}"
                 for backend, layer_names in backend_layers.items()
             )
-            raise NotImplementedError(
-                "DSpark ACL graph currently supports one GQA attention backend; "
-                f"got {details}."
-            )
+            raise NotImplementedError(f"DSpark ACL graph currently supports one GQA attention backend; got {details}.")
         return next(iter(backend_layers))
 
     def build_draft_attn_metadatas(self, num_reqs_padded, seq_lens_cpu_upper_bound):
@@ -351,9 +339,7 @@ class AscendDSparkSpeculator(DSparkSpeculator):
         if not attn_metadata:
             raise RuntimeError("DSpark ACL graph produced no draft attention metadata.")
 
-        expected_query_lens = [
-            (i + 1) * self.num_query_per_req for i in range(num_reqs_padded)
-        ]
+        expected_query_lens = [(i + 1) * self.num_query_per_req for i in range(num_reqs_padded)]
         expected_num_tokens = num_reqs_padded * self.num_query_per_req
         for layer_name, metadata in attn_metadata.items():
             actual_query_lens = list(getattr(metadata, "actual_seq_lengths_q", ()))


### PR DESCRIPTION
### What this PR does / why we need it?

Kimi K3 MRV2 requires the target hybrid-cache/state foundation together with DSpark auxiliary-state negotiation, QuaRot-aware loading, and draft graph updates. This is a self-contained integration against vllm-ascend main (`8bd1d5a7` at assembly), combining the dependencies from #15708 (including its latest QuaRot fix, `aeea673a`) with the cleaned GQA/ACL Graph adaptation from #15807. Reviewers do not need to apply either PR separately.

Included:
- Worker-local Mamba cache normalization and Ascend MLA/indexer cache zeroing, including split/unequal K/V payloads, padding and physical block sizes.
- MLA DSpark raw-prefix-sum auxiliary-state contracts and rejected-context/null-block protection during DFlash input preparation.
- GQA materialized auxiliary states and QuaRot metadata propagation before loading/sharing FC, embedding and LM-head weights; reject unintended rotated-target weight sharing.
- Target FULL_DECODE_ONLY integration and GQA DSpark graph metadata/backend/parameter-count validation with explicit draft forward context.
- Focused unit tests, NPU cache/input tests, small-model eager/graph and MLA speculative parity tests, and validation documentation.

Main integration resolutions:
- Preserve main's DSpark `dp_sync` argument and synchronization path.
- Retain main's DFlash CP-aware kernel signature and apply rejected-context/PAD-slot protection to that implementation.
- Adapt cache validation/tests to main's `layers`, `layer_stride`, `block_stride` and `tokens_per_state` APIs. Permit intentional aliases between hybrid cache groups while checking per-layer bounds and same-group overlap.
- Preserve main's confidence-head and allocator changes rather than restoring v0.27.1-only compatibility branches.
- Keep the shared graph manager usable by DFlash speculators that do not expose the DSpark-specific backend selector.

No reduced-expert implementation or reduced-layer PR #15103 is included. Full checkpoint layer and expert counts remain unchanged. Existing synthetic small-model E2E fixtures are test-only. Original dependency authorship and sign-offs are retained. Existing #15708/#15807 are left unchanged.

### Does this PR introduce _any_ user-facing change?

Yes. It consolidates Kimi K3 MRV2 target and MLA/GQA DSpark paths into one main-based branch. Enable `VLLM_USE_V2_MODEL_RUNNER=1`; use target `--compilation-config '{"cudagraph_mode":"FULL_DECODE_ONLY"}'` and DSpark `enforce_eager=false` for graph validation. Configure target/draft context limits for the workload and available memory.

This is a draft integration, not production or multi-node acceptance sign-off. MLA draft graph qualification, multi-backend draft graphs, P/D, and full-model accuracy/performance validation remain outside the established results.

### How was this patch tested?

Completed on this integrated main-based tree:
- `ruff check` on all 25 changed Python files: passed.
- `ruff format --check` on all 25 changed Python files: passed.
- Python compilation of changed Python files: passed.
- `git diff --check`: passed.
- Eight dependency-free checks executing the actual layout-validator AST: valid same-group disjoint views, valid cross-group aliases, out-of-bounds, negative offset, unknown owner, duplicate owner, insufficient stride, and same-group overlap: passed. These are byte-geometry checks only, not vLLM/NPU integration tests.

Attempted but unavailable locally:
- `pytest tests/ut/spec_decode/test_dspark_graph_contract.py -q` stops in conftest because this Windows host has no torch installation.
- `bash format.sh ci` stops because pre-commit is unavailable. The full hook suite has not passed.
- NPU E2E and full checkpoint inference were not run on this new main-based tree.

Historical validation is not attributed to this new head: the preceding dependency-based four-node full-layer/full-expert integration completed target and draft graph capture but stalled on the first real inference, with persistent device-stream completion waits on all 64 workers. No valid acceptance result was obtained. This PR does not claim to resolve that hang. Earlier single-node reduced-expert results are not full-expert accuracy evidence.

Before ready-for-review: run the focused cache/aux/graph unit suites and NPU E2E against the paired current vLLM main, then validate full-checkpoint target-only and speculative token parity and completed multi-node requests. The old vLLM v0.27.1 baseline is historical, not the semantic target of this main API integration.
- vLLM main: https://github.com/vllm-project/vllm/commit/e6bfe03ad73a3330cb427885aa90d97a12e1c704
