### PR TITLE
[Ops][Feature] Support Ascend 950 and upgrade batch invariant ops to 2.0.0

### DIFF
--- a/Dockerfile.a5
+++ b/Dockerfile.a5
@@ -71,6 +71,7 @@ ENV SOC_VERSION=$SOC_VERSION \
 COPY . /vllm-workspace/vllm-ascend/
 
 RUN export PIP_EXTRA_INDEX_URL="${ASCEND_INDEX_URL}" && \
+    export VLLM_BATCH_INVARIANT=1 && \
     source /usr/local/Ascend/ascend-toolkit/set_env.sh && \
     source /usr/local/Ascend/nnal/atb/set_env.sh && \
     python3 -m pip install -e /vllm-workspace/vllm-ascend/ --extra-index-url ${PYTORCH_INDEX_URL} && \

--- a/Dockerfile.a5.openEuler
+++ b/Dockerfile.a5.openEuler
@@ -64,6 +64,7 @@ ENV SOC_VERSION=$SOC_VERSION \
 COPY . /vllm-workspace/vllm-ascend/
 
 RUN export PIP_EXTRA_INDEX_URL="${ASCEND_INDEX_URL}" && \
+    export VLLM_BATCH_INVARIANT=1 && \
     source /usr/local/Ascend/ascend-toolkit/set_env.sh && \
     source /usr/local/Ascend/nnal/atb/set_env.sh && \
     python3 -m pip install -e /vllm-workspace/vllm-ascend/ --extra-index-url ${PYTORCH_INDEX_URL} && \

--- a/csrc/build_batch_invariant_ops.sh
+++ b/csrc/build_batch_invariant_ops.sh
@@ -28,6 +28,9 @@ case "${SOC_ARG}" in
     ascend910_93)
         BATCH_INVARIANT_DEVICE="A3"
         ;;
+    ascend950*)
+        BATCH_INVARIANT_DEVICE="950"
+        ;;
     *)
         log "Warning: batch_invariant not available for SOC_ARG=${SOC_ARG}; skipping"
         exit 0
@@ -50,8 +53,8 @@ case "${ARCH_INFO}" in
 esac
 
 # download and install run package
-BATCH_INVARIANT_RUN_URL="https://vllm-ascend.obs.cn-north-4.myhuaweicloud.com/vllm-ascend/cann-ops-batch_invariant-${BATCH_INVARIANT_DEVICE}-1.0.0-linux.${ARCH_SUFFIX}.run"
-BATCH_INVARIANT_RUN_FILE="cann-ops-batch_invariant-${BATCH_INVARIANT_DEVICE}-1.0.0-linux.${ARCH_SUFFIX}.run"
+BATCH_INVARIANT_RUN_URL="https://vllm-ascend.obs.cn-north-4.myhuaweicloud.com/vllm-ascend/cann-ops-batch_invariant-${BATCH_INVARIANT_DEVICE}-2.0.0-linux.${ARCH_SUFFIX}.run"
+BATCH_INVARIANT_RUN_FILE="cann-ops-batch_invariant-${BATCH_INVARIANT_DEVICE}-2.0.0-linux.${ARCH_SUFFIX}.run"
 
 log "Downloading batch_invariant run package..."
 unset ASCEND_CUSTOM_OPP_PATH
@@ -70,8 +73,8 @@ fi
 rm -f "${BATCH_INVARIANT_RUN_FILE}"
 
 # download and install whl package
-BATCH_INVARIANT_WHL_URL="https://vllm-ascend.obs.cn-north-4.myhuaweicloud.com/vllm-ascend/batch_invariant-torch_ops_extension-1.0.0.zip"
-BATCH_INVARIANT_WHL_FILE="batch_invariant-torch_ops_extension-1.0.0.zip"
+BATCH_INVARIANT_WHL_URL="https://vllm-ascend.obs.cn-north-4.myhuaweicloud.com/vllm-ascend/batch_invariant-torch_ops_extension-2.0.0.zip"
+BATCH_INVARIANT_WHL_FILE="batch_invariant-torch_ops_extension-2.0.0.zip"
 
 log "Downloading batch_invariant whl package..."
 if curl --max-time 3 -sS -k -O "${BATCH_INVARIANT_WHL_URL}" >/dev/null 2>&1 && [[ -f "${BATCH_INVARIANT_WHL_FILE}" ]]; then

--- a/csrc/build_batch_invariant_ops.sh
+++ b/csrc/build_batch_invariant_ops.sh
@@ -58,7 +58,7 @@ BATCH_INVARIANT_RUN_FILE="cann-ops-batch_invariant-${BATCH_INVARIANT_DEVICE}-2.0
 
 log "Downloading batch_invariant run package..."
 unset ASCEND_CUSTOM_OPP_PATH
-if curl --max-time 60 -sS -k -O "${BATCH_INVARIANT_RUN_URL}" && [[ -f "${BATCH_INVARIANT_RUN_FILE}" ]]; then
+if curl --max-time 120 -sS -k -O "${BATCH_INVARIANT_RUN_URL}" && [[ -f "${BATCH_INVARIANT_RUN_FILE}" ]]; then
     chmod +x "${BATCH_INVARIANT_RUN_FILE}"
     log "Running installer: ${BATCH_INVARIANT_RUN_FILE}"
     if "./${BATCH_INVARIANT_RUN_FILE}"; then
@@ -77,7 +77,7 @@ BATCH_INVARIANT_WHL_URL="https://vllm-ascend.obs.cn-north-4.myhuaweicloud.com/vl
 BATCH_INVARIANT_WHL_FILE="batch_invariant-torch_ops_extension-2.0.0.zip"
 
 log "Downloading batch_invariant whl package..."
-if curl --max-time 3 -sS -k -O "${BATCH_INVARIANT_WHL_URL}" >/dev/null 2>&1 && [[ -f "${BATCH_INVARIANT_WHL_FILE}" ]]; then
+if curl --max-time 5 -sS -k -O "${BATCH_INVARIANT_WHL_URL}" >/dev/null 2>&1 && [[ -f "${BATCH_INVARIANT_WHL_FILE}" ]]; then
     if python -m zipfile -e "${BATCH_INVARIANT_WHL_FILE}" . >/dev/null 2>&1; then
         if [[ -d "torch_ops_extension/batch_invariant_ops" ]]; then
             cd torch_ops_extension/batch_invariant_ops

--- a/docs/source/user_guide/feature_guide/batch_invariance.md
+++ b/docs/source/user_guide/feature_guide/batch_invariance.md
@@ -23,11 +23,11 @@ Batch invariance is crucial for several use cases:
 
 ## Hardware Requirements
 
-Batch invariance supports Ascend Atlas A2, A3, and Ascend 950 (Atlas A5) NPUs.
+Batch invariance supports Ascend Atlas A2, A3, and Ascend 950 NPUs.
 
 ## Software Requirements
 
-Batch invariance requires custom operators for Atlas A2, A3, and Ascend 950 (Atlas A5) products. Set `VLLM_BATCH_INVARIANT=1` before building vllm-ascend from source to build and install the required operator packages.
+Batch invariance requires custom operators for Atlas A2, A3, and Ascend 950 products. Set `VLLM_BATCH_INVARIANT=1` before building vllm-ascend from source to build and install the required operator packages.
 
 The `batch_invariant_ops` build and installation process consists of two stages as in the [build_batch_invariant_ops.sh](https://github.com/vllm-project/vllm-ascend/blob/main/csrc/build_batch_invariant_ops.sh), which must run in order:
 
@@ -74,7 +74,7 @@ cd <vllm-ascend-source-dir>
 bash csrc/build_batch_invariant_ops.sh ascend910_93
 ```
 
-**Ascend 950 (Atlas A5):**
+**Ascend 950:**
 
 ```bash
 cd <vllm-ascend-source-dir>

--- a/docs/source/user_guide/feature_guide/batch_invariance.md
+++ b/docs/source/user_guide/feature_guide/batch_invariance.md
@@ -23,7 +23,7 @@ Batch invariance is crucial for several use cases:
 
 ## Hardware Requirements
 
-Batch invariance supports Ascend Atlas A2, A3, and Ascend 950 NPUs.
+Batch invariance supports Atlas A2, A3, and Ascend 950 products.
 
 ## Software Requirements
 

--- a/docs/source/user_guide/feature_guide/batch_invariance.md
+++ b/docs/source/user_guide/feature_guide/batch_invariance.md
@@ -23,12 +23,11 @@ Batch invariance is crucial for several use cases:
 
 ## Hardware Requirements
 
-Batch invariance currently requires Ascend Atlas A2 and A3 inference products NPUs.
-We will support Ascend 950 Products and other NPUs in the future.
+Batch invariance supports Ascend Atlas A2, A3, and Ascend 950 (Atlas A5) NPUs.
 
 ## Software Requirements
 
-Batch invariance requires custom operators for Atlas A2 and A3 inference products. Set `VLLM_BATCH_INVARIANT=1` before building vllm-ascend from source to build and install the required operator packages.
+Batch invariance requires custom operators for Atlas A2, A3, and Ascend 950 (Atlas A5) products. Set `VLLM_BATCH_INVARIANT=1` before building vllm-ascend from source to build and install the required operator packages.
 
 The `batch_invariant_ops` build and installation process consists of two stages as in the [build_batch_invariant_ops.sh](https://github.com/vllm-project/vllm-ascend/blob/main/csrc/build_batch_invariant_ops.sh), which must run in order:
 
@@ -75,9 +74,16 @@ cd <vllm-ascend-source-dir>
 bash csrc/build_batch_invariant_ops.sh ascend910_93
 ```
 
+**Ascend 950 (Atlas A5):**
+
+```bash
+cd <vllm-ascend-source-dir>
+bash csrc/build_batch_invariant_ops.sh ascend950
+```
+
 ### Use Docker images
 
-The A2 and A3 Docker images build vllm-ascend from source with `VLLM_BATCH_INVARIANT=1`, so the image build installs both the AscendC operator run package and the `batch_invariant_ops` wheel. This build-time environment variable is not retained as a runtime setting. Set `VLLM_BATCH_INVARIANT=1` when starting the server or running offline inference to enable batch invariance.
+The A2, A3, and A5 (Ascend 950) Docker images for Ubuntu and openEuler build vllm-ascend from source with `VLLM_BATCH_INVARIANT=1`, so the image build installs both the AscendC operator run package and the `batch_invariant_ops` wheel. This build-time environment variable is not retained as a runtime setting. Set `VLLM_BATCH_INVARIANT=1` when starting the server or running offline inference to enable batch invariance.
 
 ### Quick Check
 
@@ -106,8 +112,7 @@ export VLLM_BATCH_INVARIANT=1
 To start a vLLM server with batch invariance enabled:
 
 ```bash
-VLLM_BATCH_INVARIANT=1 vllm serve Qwen/Qwen3-8B \
-  --compilation-config '{"cudagraph_mode": "PIECEWISE"}'
+VLLM_BATCH_INVARIANT=1 vllm serve Qwen/Qwen3-8B
 ```
 
 Then use the OpenAI-compatible client:
@@ -158,7 +163,6 @@ sampling_params = SamplingParams(
 llm = LLM(
     model="Qwen/Qwen3-8B",
     tensor_parallel_size=1,
-    compilation_config={"cudagraph_mode": "PIECEWISE"},
 )
 
 # Outputs will be deterministic regardless of batch size
@@ -190,8 +194,9 @@ When batch invariance is enabled, vLLM:
 
 !!! note
 
-    The batch invariance attention operators currently do not support
-    `FULL`,`FULL_DECODE_ONLY` cudagraph mode.
+    With the 2.0.0 operator run package, batch invariance supports graph execution,
+    including `FULL` and `FULL_DECODE_ONLY` cudagraph modes. The examples above
+    use the default graph configuration without overriding `cudagraph_mode`.
 
 !!! note
 
@@ -202,7 +207,6 @@ When batch invariance is enabled, vLLM:
 The batch invariance feature is under active development. Planned improvements include:
 
 - Support for additional NPUs series
-- Support `FULL`,`FULL_DECODE_ONLY` cudagraph mode with batch invariance attention operators
 - Expanded model coverage
 - Performance optimizations
 - Additional testing and validation

--- a/docs/source/user_guide/feature_guide/batch_invariance.md
+++ b/docs/source/user_guide/feature_guide/batch_invariance.md
@@ -83,7 +83,7 @@ bash csrc/build_batch_invariant_ops.sh ascend950
 
 ### Use Docker images
 
-The A2, A3, and A5 (Ascend 950) Docker images for Ubuntu and openEuler build vllm-ascend from source with `VLLM_BATCH_INVARIANT=1`, so the image build installs both the AscendC operator run package and the `batch_invariant_ops` wheel. This build-time environment variable is not retained as a runtime setting. Set `VLLM_BATCH_INVARIANT=1` when starting the server or running offline inference to enable batch invariance.
+The A2, A3, and Ascend 950 Docker images for Ubuntu and openEuler build vllm-ascend from source with `VLLM_BATCH_INVARIANT=1`, so the image build installs both the AscendC operator run package and the `batch_invariant_ops` wheel. This build-time environment variable is not retained as a runtime setting. Set `VLLM_BATCH_INVARIANT=1` when starting the server or running offline inference to enable batch invariance.
 
 ### Quick Check
 

--- a/docs/source/user_guide/feature_guide/batch_invariance.md
+++ b/docs/source/user_guide/feature_guide/batch_invariance.md
@@ -194,12 +194,6 @@ When batch invariance is enabled, vLLM:
 
 !!! note
 
-    With the 2.0.0 operator run package, batch invariance supports graph execution,
-    including `FULL` and `FULL_DECODE_ONLY` cudagraph modes. The examples above
-    use the default graph configuration without overriding `cudagraph_mode`.
-
-!!! note
-
     Enabling batch invariance may impact performance compared to the default non-deterministic mode. This trade-off is intentional to guarantee reproducibility.
 
 ## Future Improvements

--- a/tests/e2e/pull_request/four_card/rlhf/consistency/test_batch_invariant_tp4.py
+++ b/tests/e2e/pull_request/four_card/rlhf/consistency/test_batch_invariant_tp4.py
@@ -106,7 +106,7 @@ def _extract_step_logprobs(request_output):
     deploy="pd_mix",
     hardware="A2",
     quantization="BF16",
-    graph_mode="piecewise",
+    graph_mode="full_and_piecewise",
 )
 @pytest.mark.model(
     model_name=DEFAULT_MODEL,
@@ -118,7 +118,6 @@ def _extract_step_logprobs(request_output):
     enable_prefix_caching=False,
     distributed_executor_backend="mp",
     compilation_config={
-        "cudagraph_mode": "PIECEWISE",
         "cudagraph_capture_sizes": [1, 32, 64],
     },
     extra_kwargs={
@@ -127,6 +126,7 @@ def _extract_step_logprobs(request_output):
     },
 )
 def test_logprobs_bitwise_batch_invariance_bs1_vs_bsN(vllm_runner, monkeypatch: pytest.MonkeyPatch):
+    """Verify bitwise token/logprob invariance across batch sizes with the default graph configuration."""
     seed = int(os.getenv("VLLM_TEST_SEED", "12345"))
     random.seed(seed)
     tp_size = int(os.getenv("VLLM_TEST_TP_SIZE", "4"))

--- a/tests/ut/test_batch_invariant.py
+++ b/tests/ut/test_batch_invariant.py
@@ -29,9 +29,11 @@ class TestBatchInvariant:
 
     @patch("vllm_ascend.batch_invariant.HAS_TRITON", False)
     @patch("vllm_ascend.batch_invariant.HAS_ASCENDC_BATCH_INVARIANT", True)
-    def test_reduce_sum_uses_batch_invariant_operator_for_npu_tensor(self):
+    @pytest.mark.parametrize("dtype", [torch.float16, torch.float32, torch.bfloat16])
+    def test_reduce_sum_uses_batch_invariant_operator_for_npu_tensor(self, dtype):
         x = MagicMock(spec=torch.Tensor)
         x.device.type = "npu"
+        x.dtype = dtype
         expected = MagicMock(spec=torch.Tensor)
 
         with patch.object(
@@ -56,6 +58,31 @@ class TestBatchInvariant:
             result = batch_invariant.reduce_sum(x, dim=-1, keepdim=True)
 
         native_sum.assert_called_once_with(x, -1, True)
+        assert result is expected
+
+    @pytest.mark.parametrize(
+        "dtype", [torch.bool, torch.uint8, torch.int8, torch.int16, torch.int32, torch.int64, torch.float64]
+    )
+    @pytest.mark.parametrize("dim,keepdim", [(-1, False), (0, True), (None, False)])
+    def test_reduce_sum_uses_native_operator_for_unsupported_npu_dtype(self, dtype, dim, keepdim):
+        x = MagicMock(spec=torch.Tensor)
+        x.device.type = "npu"
+        x.dtype = dtype
+        x.dim.return_value = 2
+        expected = MagicMock(spec=torch.Tensor)
+
+        with (
+            patch("vllm_ascend.batch_invariant.torch_sum", return_value=expected) as native_sum,
+            patch.object(
+                batch_invariant.torch.ops.batch_invariant_ops,
+                "npu_reduce_sum_batch_invariant",
+                create=True,
+            ) as custom_sum,
+        ):
+            result = batch_invariant.reduce_sum(x, dim=dim, keepdim=keepdim)
+
+        native_sum.assert_called_once_with(x, dim, keepdim)
+        custom_sum.assert_not_called()
         assert result is expected
 
     def test_override_envs_for_invariance(self):

--- a/vllm_ascend/batch_invariant.py
+++ b/vllm_ascend/batch_invariant.py
@@ -62,14 +62,17 @@ def add_rms_norm(
     return x_, None, residual_
 
 
+_SUPPORTED_DTYPES = (torch.float16, torch.float32, torch.bfloat16)
+
+
 def reduce_sum(x: torch.Tensor, dim: int | None = None, keepdim: bool = False) -> torch.Tensor:
     """npu_reduce_sum_batch_invariant requires dim to be specified, but torch.sum
     doesn't require it, so we set dim to -1 by default if dim is None and x.dim()==1.
     """
     dim = -1 if dim is None and x.dim() == 1 else dim
-    if x.device.type == "npu" and dim is not None:
+    if x.device.type == "npu" and dim is not None and x.dtype in _SUPPORTED_DTYPES:
         return torch.ops.batch_invariant_ops.npu_reduce_sum_batch_invariant(x, dim, keepdim)
-    # cpu tensor can't use npu_reduce_sum_batch_invariant, so we use torch.sum instead.
+    # CPU tensors and unsupported dtypes/dimensions use the saved native torch.sum.
     return torch_sum(x, dim, keepdim)
 
 


### PR DESCRIPTION
### What this PR does / why we need it?

ref to https://github.com/vllm-project/vllm-ascend/issues/10072

Upgrade the batch invariance operator run package and PyTorch extension archive to 2.0.0. Map ascend950 variants to the 950 package and enable operator installation during both Ubuntu and openEuler A5 image builds.

Document Ascend 950 installation and graph support. Remove the forced PIECEWISE configuration from the online/offline examples and the TP4 batch invariance test, preserving its capture sizes and updating the graph coverage annotation.

Restrict the custom reduce-sum operator to FP16, FP32, and BF16. Other dtypes fall back to the saved native torch.sum implementation, avoiding recursive calls through the patched Tensor.sum. Add parameterized regression tests for supported and unsupported NPU dtypes.

### Does this PR introduce _any_ user-facing change?
A5 source-built images install the batch invariance operators. Users still set VLLM_BATCH_INVARIANT=1 at inference time. Examples and the TP4 consistency test use the default graph configuration.

### How was this patch tested?
- pytest -sv tests/e2e/pull_request/four_card/rlhf/consistency/test_batch_invariant_tp4.py
```
======================================================================= warnings summary ========================================================================
../../../../../usr/local/python3.11.10/lib/python3.11/site-packages/torch/jit/_script.py:362: 14 warnings
  /usr/local/python3.11.10/lib/python3.11/site-packages/torch/jit/_script.py:362: DeprecationWarning: `torch.jit.script_method` is deprecated. Please switch to `torch.compile` or `torch.export`.
    warnings.warn(

tests/e2e/pull_request/four_card/rlhf/consistency/test_batch_invariant_tp4.py:111
  /mnt/share/w00899129/vllm_code_0908/vllm-ascend/tests/e2e/pull_request/four_card/rlhf/consistency/test_batch_invariant_tp4.py:111: PytestUnknownMarkWarning: Unknown pytest.mark.model - is this a typo?  You can register custom marks to avoid this warning - for details, see https://docs.pytest.org/en/stable/how-to/mark.html
    @pytest.mark.model(

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
=========================================================== 1 passed, 15 warnings in 94.14s (0:01:34) ===========================================================
[root@C02A09-OS1 vllm-ascend]# /usr/local/python3.11.10/lib/python3.11/multiprocessing/resource_tracker.py:254: UserWarning: resource_tracker: There appear to be 1 leaked shared_memory objects to clean up at shutdown
  warnings.warn('resource_tracker: There appear to be %d '
```
- VLLM_BATCH_INVARIANT=1 pip install -v -e . --no-build-isolation --no-deps --extra-index-url=https://triton-ascend.osinfra.cn/pypi/simple --trusted-host triton-ascend.osinfra.cn 
   Enable VLLM_BATCH_INVARIANT=1 on A5, install vllm-ascend, and after installation run test_batch_invariant_tp4.py to verify success.
- Build the image with Dockerfile, and verification is OK.


- vLLM main: https://github.com/vllm-project/vllm/commit/b2f685834a6456197e7033966fdef52a23f1abcd
