### PR TITLE
[Feature][MRV2] Support DSA PCP with DSpark

### DIFF
--- a/.github/workflows/scripts/test_config.yaml
+++ b/.github/workflows/scripts/test_config.yaml
@@ -192,7 +192,7 @@ estimated_times:
   tests/e2e/pull_request/four_card/_310p/test_vl_model_310p.py: 370
   tests/e2e/pull_request/four_card/context_parallel/test_accuracy.py: 880
   tests/e2e/pull_request/four_card/context_parallel/test_accuracy_v2.py: 590
-  tests/e2e/pull_request/four_card/context_parallel/test_deepseek_v4.py: 310
+  tests/e2e/pull_request/four_card/context_parallel/test_deepseek_v4.py: 520
   tests/e2e/pull_request/four_card/context_parallel/test_prefix_caching_cp.py: 210
   tests/e2e/pull_request/four_card/model_runner_v2/test_deepseek_v4.py: 520
   tests/e2e/pull_request/four_card/rlhf/consistency/test_batch_invariant_tp4.py: 210

--- a/docs/source/user_guide/feature_guide/context_parallel.md
+++ b/docs/source/user_guide/feature_guide/context_parallel.md
@@ -22,7 +22,7 @@ PCP support is experimental and available only with ModelRunner V2. The followin
 | MLA | ✅ Full compatibility | ✅ Full compatibility | ✅ Full compatibility | ✅ Full compatibility | 🟠 Partial compatibility (MTP, eager and `FULL_DECODE_ONLY`) | ❌ No compatibility | ❌ No compatibility |
 | GQA | ✅ Full compatibility | ✅ Full compatibility | ✅ Full compatibility | — Not applicable | 🟠 Partial compatibility (Eagle3, eager and `FULL_DECODE_ONLY`) | ❌ No compatibility | ❌ No compatibility |
 | SFA | ✅ Full compatibility | ✅ Full compatibility | ✅ Full compatibility | ❌ No compatibility | ❌ No compatibility | ❌ No compatibility | ❌ No compatibility |
-| DSA | ✅ Full compatibility | ✅ Full compatibility | ✅ Full compatibility | — Not applicable | 🟠 Partial compatibility (MTP, eager and `FULL_DECODE_ONLY`) | ❌ No compatibility | ❌ No compatibility |
+| DSA | ✅ Full compatibility | ✅ Full compatibility | ✅ Full compatibility | — Not applicable | 🟠 Partial compatibility (MTP and DSpark, eager and `FULL_DECODE_ONLY`) | ❌ No compatibility | ❌ No compatibility |
 
 - ✅ **Full compatibility**: The basic path or feature combination is supported.
 - 🟠 **Partial compatibility**: The basic path or feature combination is supported with the stated limitations.
@@ -66,7 +66,11 @@ Unlike DCP, PCP adds extra ranks: `world_size_with_pcp = prefill_context_paralle
 
 #### Speculative Decoding
 
-MRV2 PCP supports MTP with MLA models and Eagle3 with GQA models. The target model runs with the configured PCP topology, while the draft model is replicated on every PCP rank and runs with a logical PCP size of `1`. Configure PCP only for the target model.
+MRV2 PCP supports MTP with MLA and DSA models, Eagle3 with GQA models, and
+DSpark with DeepSeek-V4 DSA models. The target model runs with the
+configured PCP topology, while the draft model is replicated on every PCP rank
+and runs with a logical PCP size of `1`. Configure PCP only for the target
+model.
 
 For general speculative decoding configuration and model requirements, see [Speculative Decoding](speculative_decoding.md).
 
@@ -105,11 +109,12 @@ For either method, remove `--enforce-eager` and add the following option to use 
 #### Constraints
 
 - PCP is supported only with ModelRunner V2.
-- PCP speculative decoding supports only MTP with MLA models and Eagle3 with GQA models.
+- PCP speculative decoding supports MTP with MLA and DSA models, Eagle3 with
+  GQA models, and DSpark with DeepSeek-V4 DSA models.
 - Draft sampling must use the greedy method.
 - Full graph execution with PCP is limited to `FULL_DECODE_ONLY`.
 - Pipeline parallelism, encoder-decoder models, multimodal inputs, and LoRA are not supported with MRV2 PCP.
-- DSA and SFA draft attention are not supported with PCP speculative decoding.
+- SFA draft attention is not supported with PCP speculative decoding.
 - PCP and DCP cannot be enabled simultaneously.
 - Adaptive verification is not supported with PCP speculative decoding.
 - Dynamic draft lengths are outside the currently validated scope.

--- a/tests/e2e/pull_request/four_card/context_parallel/test_deepseek_v4.py
+++ b/tests/e2e/pull_request/four_card/context_parallel/test_deepseek_v4.py
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-"""DeepSeek-V4 DSA-PCP accuracy and MTP acceptance test for Model Runner V2.
+"""DeepSeek-V4 DSA-PCP tests for Model Runner V2.
 
 Run `pytest tests/e2e/pull_request/four_card/context_parallel/test_deepseek_v4.py`.
 """
@@ -24,103 +24,53 @@ from unittest.mock import patch
 
 import pytest
 from vllm import SamplingParams
-from vllm.outputs import RequestOutput
-from vllm.v1.metrics.reader import Counter, Metric, Vector
+from vllm.v1.metrics.reader import Counter, Vector
 
 from tests.e2e.conftest import VllmRunner, wait_until_npu_memory_free
 from tests.e2e.pull_request.one_card.model_runner_v2.utils import calculate_acceptance_per_pos
+from tests.e2e.pull_request.utils import PROMPTS_SHORT
 
-MODEL = "gdydems/DeepSeek-V4-Flash-w4a8-mtp"
+MTP_MODEL = "gdydems/DeepSeek-V4-Flash-w4a8-mtp"
+DSPARK_MODEL = "UploadWeight/DeepSeek-V4-Flash-DSpark-w4a8-test"
+
 MAX_NUM_SEQS = 4
-NUM_SPECULATIVE_TOKENS = 3
-
-FULL_DECODE_GRAPH_CONFIG = {
-    "cudagraph_mode": "FULL_DECODE_ONLY",
-    "cudagraph_capture_sizes": [MAX_NUM_SEQS, 2 * MAX_NUM_SEQS],
-}
-
-PROMPTS = [
-    "Hello, my name is",
-    "The president of the United States is",
-    "The capital of France is",
-    "The future of AI is",
-    "What is the meaning of life?",
-]
 MAX_TOKENS = 1024
-EXPECTED_OUTPUT_PREFIXES = {
-    "Hello, my name is": "Hello, my name is {name} and I",
-    "What is the meaning of life?": 'What is the meaning of life?",\n    "What is',
+
+MTP_NUM_SPECULATIVE_TOKENS = 3
+DSPARK_NUM_SPECULATIVE_TOKENS = 5
+
+COMMON_ENV = {
+    "VLLM_USE_V2_MODEL_RUNNER": "1",
+    "VLLM_BATCH_INVARIANT": "1",
+    "VLLM_WORKER_MULTIPROC_METHOD": "spawn",
+    "HCCL_BUFFSIZE": "2560",
+    "ATB_MATMUL_SHUFFLE_K_ENABLE": "0",
+    "CLOSE_MATMUL_K_SHIFT": "1",
+    "PYTORCH_NPU_ALLOC_CONF": "expandable_segments:True",
 }
 
-MIN_ACCEPTANCE_RATES = [0.85, 0.65, 0.35]
+MTP_EXPECTED_OUTPUT_PREFIXES = {
+    "The president of the United States is": ("The president of the United States is the head of the executive branch"),
+}
+DSPARK_EXPECTED_OUTPUT_PREFIXES = {
+    "The president of the United States is": ("The president of the United States is the head of the executive branch"),
+}
+
+MTP_MIN_ACCEPTANCE_RATES = [0.85, 0.65, 0.35]
+DSPARK_MIN_ACCEPTANCE_RATES = [0.73, 0.64, 0.55, 0.49, 0.42]
 ACCEPTANCE_RATE_TOLERANCE = 0.03
 
 
-def _assert_output_accuracy(outputs: list[RequestOutput]) -> None:
-    assert len(outputs) == len(PROMPTS), f"Expected {len(PROMPTS)} outputs, got {len(outputs)}"
-    outputs_by_prompt = {output.prompt: output for output in outputs}
-
-    for prompt, expected_prefix in EXPECTED_OUTPUT_PREFIXES.items():
-        assert prompt in outputs_by_prompt, f"Missing output for prompt {prompt!r}"
-        request_output = outputs_by_prompt[prompt]
-        assert len(request_output.outputs) == 1, (
-            f"Expected one completion for prompt {prompt!r}, got {len(request_output.outputs)}"
-        )
-
-        output_text = prompt + request_output.outputs[0].text
-        assert output_text.startswith(expected_prefix), (
-            f"Unexpected output prefix for prompt {prompt!r}: "
-            f"got {output_text[: len(expected_prefix)]!r}, expected {expected_prefix!r}"
-        )
-
-
-def _assert_acceptance_rates(metrics: list[Metric]) -> None:
-    acceptance_rates = calculate_acceptance_per_pos(
-        metrics,
-        NUM_SPECULATIVE_TOKENS,
-        Counter,
-        Vector,
-    )
-    assert len(acceptance_rates) == len(MIN_ACCEPTANCE_RATES), (
-        f"Expected {len(MIN_ACCEPTANCE_RATES)} acceptance rates, got {len(acceptance_rates)}"
-    )
-    for position, (actual, minimum) in enumerate(zip(acceptance_rates, MIN_ACCEPTANCE_RATES, strict=True)):
-        assert actual >= minimum or minimum - actual < ACCEPTANCE_RATE_TOLERANCE, (
-            f"Acceptance rate at draft position {position} is {actual}, below minimum {minimum}"
-        )
-
-
-@pytest.mark.e2e_model(MODEL)
-@pytest.mark.e2e_coverage(
-    arch="moe",
-    feature="dsa_pcp,mtp",
-    parallel="TP,EP,PCP",
-    deploy="pd_mix",
-    hardware="A3",
-    quantization="W4A8",
-    graph_mode="full_decode_only",
-)
-@patch.dict(
-    os.environ,
-    {
-        "VLLM_USE_V2_MODEL_RUNNER": "1",
-        "VLLM_BATCH_INVARIANT": "1",
-        "VLLM_WORKER_MULTIPROC_METHOD": "spawn",
-        "HCCL_BUFFSIZE": "2560",
-        "PYTORCH_NPU_ALLOC_CONF": "expandable_segments:True",
-    },
-)
-@wait_until_npu_memory_free(target_free_percentage=0.8)
-def test_deepseek_v4_dsa_pcp_mtp_full_decode_only() -> None:
-    """Verify output accuracy and MTP acceptance for DSA-PCP graph execution."""
-    sampling_params = SamplingParams(
-        max_tokens=MAX_TOKENS,
-        temperature=0.0,
-        seed=0,
-    )
-
+def _run_test(
+    model: str,
+    minimum_rates: list[float],
+    speculative_config: dict,
+    compilation_config: dict,
+    expected_output_prefixes: dict[str, str],
+) -> None:
+    sampling_params = SamplingParams(max_tokens=MAX_TOKENS, temperature=0.0, seed=0)
     with VllmRunner(
-        MODEL,
+        model,
         max_model_len=8192,
         max_num_seqs=MAX_NUM_SEQS,
         max_num_batched_tokens=1024,
@@ -133,19 +83,101 @@ def test_deepseek_v4_dsa_pcp_mtp_full_decode_only() -> None:
         tokenizer_mode="deepseek_v4",
         block_size=128,
         enforce_eager=False,
-        compilation_config=FULL_DECODE_GRAPH_CONFIG,
+        compilation_config=compilation_config,
         disable_log_stats=False,
-        speculative_config={
-            "num_speculative_tokens": NUM_SPECULATIVE_TOKENS,
-            "method": "mtp",
-        },
+        speculative_config=speculative_config,
         additional_config={
             "enable_dsa_cp": False,
             "enable_prefill_mc2": True,
         },
     ) as runner:
-        outputs = runner.model.generate(PROMPTS, sampling_params)
+        outputs = runner.generate(PROMPTS_SHORT, sampling_params)
+        for prompt, (_, texts) in zip(PROMPTS_SHORT, outputs, strict=True):
+            print(f"Model: {model}, Prompt: {prompt!r}, Outputs: {texts!r}", flush=True)
         metrics = runner.model.get_metrics()
 
-    _assert_output_accuracy(outputs)
-    _assert_acceptance_rates(metrics)
+    assert len(outputs) == len(PROMPTS_SHORT), f"Expected {len(PROMPTS_SHORT)} outputs, got {len(outputs)}"
+    for prompt, (_, texts) in zip(PROMPTS_SHORT, outputs, strict=True):
+        assert len(texts) == 1, f"Expected one completion for prompt {prompt!r}, got {len(texts)}"
+        expected_prefix = expected_output_prefixes.get(prompt)
+        if expected_prefix is not None:
+            assert texts[0].startswith(expected_prefix), (
+                f"Unexpected output prefix for prompt {prompt!r}: "
+                f"got {texts[0][: len(expected_prefix)]!r}, expected {expected_prefix!r}"
+            )
+
+    acceptance_rates = calculate_acceptance_per_pos(
+        metrics,
+        speculative_config["num_speculative_tokens"],
+        Counter,
+        Vector,
+    )
+    assert len(acceptance_rates) == len(minimum_rates), (
+        f"Expected {len(minimum_rates)} acceptance rates, got {len(acceptance_rates)}"
+    )
+    for position, (actual, minimum) in enumerate(zip(acceptance_rates, minimum_rates, strict=True)):
+        assert actual >= minimum or minimum - actual < ACCEPTANCE_RATE_TOLERANCE, (
+            f"Acceptance rate at draft position {position} is {actual}, below minimum {minimum}"
+        )
+
+
+@pytest.mark.e2e_model(MTP_MODEL)
+@pytest.mark.e2e_coverage(
+    arch="moe",
+    feature="dsa_pcp,mtp",
+    parallel="TP,EP,PCP",
+    deploy="pd_mix",
+    hardware="A3",
+    quantization="W4A8",
+    graph_mode="full_decode_only",
+)
+@patch.dict(os.environ, COMMON_ENV)
+@wait_until_npu_memory_free(target_free_percentage=0.8)
+def test_deepseek_v4_dsa_pcp_mtp_full_decode_only() -> None:
+    """Verify output accuracy and MTP acceptance for DSA-PCP graph execution."""
+    _run_test(
+        MTP_MODEL,
+        minimum_rates=MTP_MIN_ACCEPTANCE_RATES,
+        expected_output_prefixes=MTP_EXPECTED_OUTPUT_PREFIXES,
+        speculative_config={
+            "num_speculative_tokens": MTP_NUM_SPECULATIVE_TOKENS,
+            "method": "mtp",
+        },
+        compilation_config={
+            "cudagraph_mode": "FULL_DECODE_ONLY",
+            "cudagraph_capture_sizes": [MAX_NUM_SEQS, 2 * MAX_NUM_SEQS],
+        },
+    )
+
+
+@pytest.mark.e2e_model(DSPARK_MODEL)
+@pytest.mark.e2e_coverage(
+    arch="moe",
+    feature="dsa_pcp,dspark",
+    parallel="TP,EP,PCP",
+    deploy="pd_mix",
+    hardware="A3",
+    quantization="W4A8",
+    graph_mode="full_decode_only",
+)
+@patch.dict(os.environ, COMMON_ENV)
+@wait_until_npu_memory_free(target_free_percentage=0.8)
+def test_deepseek_v4_dsa_pcp_dspark() -> None:
+    """Verify output accuracy and DSpark acceptance for DSA-PCP graph execution."""
+    _run_test(
+        DSPARK_MODEL,
+        minimum_rates=DSPARK_MIN_ACCEPTANCE_RATES,
+        expected_output_prefixes=DSPARK_EXPECTED_OUTPUT_PREFIXES,
+        speculative_config={
+            "num_speculative_tokens": DSPARK_NUM_SPECULATIVE_TOKENS,
+            "method": "dspark",
+            "enable_adaptive_verification": False,
+            "draft_sample_method": "greedy",
+        },
+        compilation_config={
+            "cudagraph_mode": "FULL_DECODE_ONLY",
+            # The target verifies N+1 tokens while the replicated DSpark draft executes N
+            # query tokens per request. Include the 1-, 2-, and 4-request shapes for both.
+            "cudagraph_capture_sizes": [5, 6, 10, 12, 20, 24],
+        },
+    )

--- a/tests/ut/worker/test_mtp_pcp_speculator_v2.py
+++ b/tests/ut/worker/test_mtp_pcp_speculator_v2.py
@@ -96,6 +96,10 @@ def test_draft_runtime_config_preserves_target_worker_topology(
             "replace",
             side_effect=fake_replace,
         ),
+        patch(
+            "vllm_ascend.worker.v2.spec_decode.pcp_utils.replace",
+            side_effect=fake_replace,
+        ),
         patch.object(
             speculator_module.AutoRegressiveSpeculator,
             "__init__",

--- a/tests/ut/worker/test_pcp_manager_v2.py
+++ b/tests/ut/worker/test_pcp_manager_v2.py
@@ -384,6 +384,10 @@ def test_partition_batch_pads_decode_requests_when_tokens_are_already_padded():
             "vllm_ascend.worker.v2.pcp_manager.build_attn_state",
             return_value=local_attn_state,
         ) as build_attn_state,
+        patch(
+            "vllm_ascend.worker.v2.pcp_manager.async_copy_to_gpu",
+            side_effect=_mock_async_copy_to_cpu,
+        ),
     ):
         result = manager.partition_batch(global_batch, padded_num_tokens=4)
 
@@ -750,16 +754,19 @@ def test_pcp_manager_skips_hidden_restore_before_last_pp_rank() -> None:
     parent_restore.assert_not_called()
 
 
-@pytest.mark.parametrize("method", ["mtp", "eagle3"])
-def test_validate_config_allows_supported_speculators(method: str) -> None:
+@pytest.mark.parametrize("method", ["mtp", "eagle3", "dspark"])
+@pytest.mark.parametrize(
+    ("cudagraph_mode", "sparse_mla"),
+    [(CUDAGraphMode.NONE, False), (CUDAGraphMode.NONE, True), (CUDAGraphMode.FULL_DECODE_ONLY, True)],
+)
+def test_validate_config_allows_supported_speculators(
+    method: str, cudagraph_mode: CUDAGraphMode, sparse_mla: bool
+) -> None:
     speculative_config = SimpleNamespace(
         method=method,
         draft_sample_method="greedy",
     )
-    vllm_config = _make_pcp_config(
-        CUDAGraphMode.NONE,
-        sparse_mla=False,
-    )
+    vllm_config = _make_pcp_config(cudagraph_mode, sparse_mla=sparse_mla)
     vllm_config.speculative_config = speculative_config
 
     AscendPCPManager.validate_config(
@@ -771,8 +778,10 @@ def test_validate_config_allows_supported_speculators(method: str) -> None:
 @pytest.mark.parametrize(
     ("method", "draft_sample_method", "error"),
     [
-        ("draft_model", "greedy", "only with MTP and Eagle3"),
+        ("draft_model", "greedy", "supports speculative decoding only with"),
         ("mtp", "random", "requires greedy draft sampling"),
+        ("eagle3", "random", "requires greedy draft sampling"),
+        ("dspark", "random", "requires greedy draft sampling"),
     ],
 )
 def test_validate_config_rejects_unsupported_speculator_options(

--- a/vllm_ascend/attention/context_parallel/dsa_cp.py
+++ b/vllm_ascend/attention/context_parallel/dsa_cp.py
@@ -2264,6 +2264,9 @@ class AscendDSAPCPMetadata(dsa_v1.AscendDSAMetadata):
 class AscendDSAPCPMetadataBuilder(dsa_v1.AscendDSAMetadataBuilder):
     """Build rank-local attention and canonical global cache metadata."""
 
+    # DualChunkSwap expands each prefill into at most two local rows.
+    _request_capacity_factor: ClassVar[int] = 2
+
     def __init__(
         self,
         kv_cache_spec: AscendMLAAttentionSpec,
@@ -2276,14 +2279,6 @@ class AscendDSAPCPMetadataBuilder(dsa_v1.AscendDSAMetadataBuilder):
             layer_names,
             vllm_config,
             device,
-        )
-        # DualChunkSwap can expand each scheduler-global prefill request into
-        # two rank-local rows. Keep this in sync with PCPManager's local input
-        # buffers, which are sized to ``2 * max_num_seqs``. The canonical
-        # global builder below must retain the scheduler-global capacity.
-        max_num_local_reqs = 2 * vllm_config.scheduler_config.max_num_seqs
-        self.start_pos_prefill = self.start_pos_prefill.new_zeros(
-            max_num_local_reqs,
         )
         self._global_metadata_builder = dsa_v1.AscendDSAMetadataBuilder(
             kv_cache_spec,

--- a/vllm_ascend/attention/dsa_v1.py
+++ b/vllm_ascend/attention/dsa_v1.py
@@ -1,7 +1,7 @@
 import math
 from collections.abc import Callable
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any, TypeAlias
+from typing import TYPE_CHECKING, Any, ClassVar, TypeAlias
 
 import torch
 import torch.distributed as dist
@@ -583,6 +583,8 @@ class AscendDSAMetadataBuilder(AttentionMetadataBuilder[AscendDSAMetadata]):
     understand this class
     """
 
+    _request_capacity_factor: ClassVar[int] = 1
+
     def __init__(
         self,
         kv_cache_spec: AscendMLAAttentionSpec,
@@ -667,9 +669,8 @@ class AscendDSAMetadataBuilder(AttentionMetadataBuilder[AscendDSAMetadata]):
         self.cache_group_key = layer_names[0]
         self.hadamard = None
         self._init_hadamard(layer_names)
-        self.start_pos_prefill: torch.Tensor = torch.zeros(
-            scheduler_config.max_num_seqs, dtype=torch.int32, device=self.device
-        )
+        max_num_reqs = scheduler_config.max_num_seqs * self._request_capacity_factor
+        self.start_pos_prefill: torch.Tensor = torch.zeros(max_num_reqs, dtype=torch.int32, device=self.device)
         self.sas_metadata_buffer: torch.Tensor = torch.zeros(
             DSA_METADATA_BUFFER_SIZE, dtype=torch.int32, device=self.device
         )
@@ -681,7 +682,7 @@ class AscendDSAMetadataBuilder(AttentionMetadataBuilder[AscendDSAMetadata]):
         # during graph replay. Full-decode graphs pad the request count beyond
         # max_num_seqs (cudagraph capture sizes plus the FIA dummy request), so
         # size the per-request buffers for the graph-mode maximum.
-        max_qli_reqs = scheduler_config.max_num_seqs
+        max_qli_reqs = max_num_reqs
         compilation_config = self.vllm_config.compilation_config
         if compilation_config.cudagraph_mode != CUDAGraphMode.NONE and compilation_config.cudagraph_capture_sizes:
             max_qli_reqs = max(max_qli_reqs, compilation_config.max_cudagraph_capture_size)

--- a/vllm_ascend/worker/v2/pcp_manager.py
+++ b/vllm_ascend/worker/v2/pcp_manager.py
@@ -123,8 +123,10 @@ class AscendPCPManager(PCPManager):
             raise NotImplementedError("MRV2 PCP does not support LoRA yet.")
         speculative_config = vllm_config.speculative_config
         if speculative_config is not None:
-            if speculative_config.method not in ("mtp", "eagle3"):
-                raise NotImplementedError("Ascend MRV2 PCP supports speculative decoding only with MTP and Eagle3.")
+            if speculative_config.method not in ("mtp", "eagle3", "dspark"):
+                raise NotImplementedError(
+                    "Ascend MRV2 PCP supports speculative decoding only with MTP, Eagle3 and DSpark."
+                )
             if speculative_config.draft_sample_method != "greedy":
                 raise NotImplementedError(
                     "Ascend MRV2 PCP speculative decoding currently requires greedy draft sampling."

--- a/vllm_ascend/worker/v2/spec_decode/autoregressive/speculator.py
+++ b/vllm_ascend/worker/v2/spec_decode/autoregressive/speculator.py
@@ -47,30 +47,16 @@ from vllm_ascend.worker.v2.attn_utils import (
     build_draft_attn_metadata_factory,
 )
 from vllm_ascend.worker.v2.input_batch import AscendInputBatch, AscendInputBuffers
-from vllm_ascend.worker.v2.spec_decode.pcp_utils import disable_target_pcp_for_replicated_draft
+from vllm_ascend.worker.v2.spec_decode.pcp_utils import (
+    disable_target_pcp_for_replicated_draft,
+    prepare_replicated_pcp_config,
+)
 
 if TYPE_CHECKING:
     from vllm_ascend.worker.v2.model_states.default import AscendModelState
     from vllm_ascend.worker.v2.pcp_manager import AscendPCPManager
 
 logger = logging.getLogger(__name__)
-
-
-def _prepare_replicated_pcp_config(
-    vllm_config: VllmConfig,
-) -> tuple[VllmConfig, bool]:
-    """Return the draft execution config and whether target PCP is replicated."""
-    target_parallel_config = vllm_config.parallel_config
-    replicated_pcp = target_parallel_config.prefill_context_parallel_size > 1
-    if replicated_pcp:
-        vllm_config = replace(
-            vllm_config,
-            parallel_config=replace(
-                target_parallel_config,
-                prefill_context_parallel_size=1,
-            ),
-        )
-    return vllm_config, replicated_pcp
 
 
 class AscendAutoRegressiveSpeculator(AutoRegressiveSpeculator):
@@ -95,7 +81,7 @@ class AscendAutoRegressiveSpeculator(AutoRegressiveSpeculator):
         seq_lens_cpu from input_batch), so we replace input_buffers with
         AscendInputBuffers after super().__init__.
         """
-        vllm_config, self.replicated_pcp = _prepare_replicated_pcp_config(vllm_config)
+        vllm_config, self.replicated_pcp = prepare_replicated_pcp_config(vllm_config)
         super().__init__(vllm_config, device)
 
         self.attn_architecture: str | None = None

--- a/vllm_ascend/worker/v2/spec_decode/dspark/speculator.py
+++ b/vllm_ascend/worker/v2/spec_decode/dspark/speculator.py
@@ -18,7 +18,7 @@
 from typing import Any, cast
 
 import torch
-from vllm.config import VllmConfig, get_layers_from_vllm_config
+from vllm.config import VllmConfig, get_layers_from_vllm_config, set_current_vllm_config
 from vllm.config.compilation import CUDAGraphMode
 from vllm.model_executor.layers.attention_layer_base import AttentionLayerBase
 from vllm.v1.attention.backend import AttentionBackend
@@ -37,12 +37,14 @@ from vllm_ascend.worker.v2.attn_utils import (
     build_attn_metadata_wrapper,
     build_draft_attn_metadata_factory,
 )
+from vllm_ascend.worker.v2.spec_decode.pcp_utils import prepare_replicated_pcp_config
 
 
 class AscendDSparkSpeculator(DSparkSpeculator):
     _speculator_name = "DSpark"
 
     def __init__(self, vllm_config: VllmConfig, device: torch.device):
+        vllm_config, self.replicated_pcp = prepare_replicated_pcp_config(vllm_config)
         super().__init__(vllm_config, device)
         self.input_batch: InputBatch | None = None
 
@@ -84,29 +86,31 @@ class AscendDSparkSpeculator(DSparkSpeculator):
         target_input_buffers: Any,
         target_attn_groups: Any,
     ) -> None:
-        super().set_attn(
-            model_state,
-            kv_cache_config,
-            block_tables,
-            target_input_buffers,
-            target_attn_groups,
-        )
-        self._context_slot_mappings = self._context_slot_mappings.to(torch.int32)  # type: ignore[has-type]
-        # npu needs attn_backends to update full graph params in run_fullgraph.
-        attn_backends: dict[str, type[AttentionBackend]] = {}
-        active_layer_names = self.draft_attn_layer_names
-        for kv_cache_group_spec in kv_cache_config.kv_cache_groups:
-            layer_names = kv_cache_group_spec.layer_names
-            if active_layer_names is not None:
-                layer_names = list(active_layer_names.intersection(layer_names))
+        # Initialize the draft attention backend with its PCP=1 config.
+        with set_current_vllm_config(self.attn_vllm_config):
+            super().set_attn(
+                model_state,
+                kv_cache_config,
+                block_tables,
+                target_input_buffers,
+                target_attn_groups,
+            )
+            self._context_slot_mappings = self._context_slot_mappings.to(torch.int32)  # type: ignore[has-type]
+            # npu needs attn_backends to update full graph params in run_fullgraph.
+            attn_backends: dict[str, type[AttentionBackend]] = {}
+            active_layer_names = self.draft_attn_layer_names
+            for kv_cache_group_spec in kv_cache_config.kv_cache_groups:
+                layer_names = kv_cache_group_spec.layer_names
+                if active_layer_names is not None:
+                    layer_names = list(active_layer_names.intersection(layer_names))
 
-            layer_type = cast(type[Any], AttentionLayerBase)
-            attn_layers = get_layers_from_vllm_config(self.vllm_config, layer_type, layer_names)
+                layer_type = cast(type[Any], AttentionLayerBase)
+                attn_layers = get_layers_from_vllm_config(self.vllm_config, layer_type, layer_names)
 
-            for layer_name in layer_names:
-                attn_backends[layer_name] = attn_layers[layer_name].get_attn_backend()
+                for layer_name in layer_names:
+                    attn_backends[layer_name] = attn_layers[layer_name].get_attn_backend()
 
-        self.attn_backends = attn_backends
+            self.attn_backends = attn_backends
 
     def build_draft_attn_metadatas(self, num_reqs_padded, seq_lens_cpu_upper_bound):
         num_tokens_padded = num_reqs_padded * self.num_query_per_req

--- a/vllm_ascend/worker/v2/spec_decode/pcp_utils.py
+++ b/vllm_ascend/worker/v2/spec_decode/pcp_utils.py
@@ -2,14 +2,15 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 # Copyright (c) 2026 Huawei Technologies Co., Ltd. All Rights Reserved.
 
-from collections.abc import Iterator
+from collections.abc import Generator
 from contextlib import contextmanager
 from typing import TYPE_CHECKING, Protocol
 
-from vllm_ascend.worker.v2.pcp_manager import AscendPCPManager
+from vllm.config import VllmConfig, replace
 
 if TYPE_CHECKING:
     from vllm_ascend.worker.v2.model_states.default import AscendModelState
+    from vllm_ascend.worker.v2.pcp_manager import AscendPCPManager
 
 
 class ReplicatedPCPDraftSpeculator(Protocol):
@@ -17,13 +18,13 @@ class ReplicatedPCPDraftSpeculator(Protocol):
 
     replicated_pcp: bool
     model_state: "AscendModelState"
-    pcp_manager: AscendPCPManager | None
+    pcp_manager: "AscendPCPManager | None"
 
 
 @contextmanager
 def disable_target_pcp_for_replicated_draft(
     speculator: ReplicatedPCPDraftSpeculator,
-) -> Iterator[None]:
+) -> Generator[None, None, None]:
     """Keep replicated PCP=1 draft out of target PCP partitioning."""
     target_pcp_manager = speculator.pcp_manager
     if not speculator.replicated_pcp or target_pcp_manager is None:
@@ -41,3 +42,20 @@ def disable_target_pcp_for_replicated_draft(
         yield
     finally:
         model_state.pcp_manager = target_pcp_manager
+
+
+def prepare_replicated_pcp_config(
+    vllm_config: VllmConfig,
+) -> tuple[VllmConfig, bool]:
+    """Return the draft execution config and whether target PCP is replicated."""
+    target_parallel_config = vllm_config.parallel_config
+    replicated_pcp = target_parallel_config.prefill_context_parallel_size > 1
+    if replicated_pcp:
+        vllm_config = replace(
+            vllm_config,
+            parallel_config=replace(
+                target_parallel_config,
+                prefill_context_parallel_size=1,
+            ),
+        )
+    return vllm_config, replicated_pcp


### PR DESCRIPTION
### What this PR does / why we need it?

Support DeepSeek-V4 DSpark with MRV2 PCP by replicating draft execution with PCP=1. Fix DSA request-buffer capacity for PCP-local rows.

### Does this PR introduce _any_ user-facing change?

Enable DSpark with PCP and FULL_DECODE_ONLY graphs. No new configuration options.

### How was this patch tested?

Two rounds on Ascend `02bb90f97` and vLLM `e6bfe03ad`: TP4, DSpark 5 tokens, FULL_DECODE_ONLY, GPQA Diamond first 100 questions at concurrency 100, 64K context and 60K output budget. Each run restarted the service; temperature=0 and seed=0.

| Round | PCP | Completed requests | Correct answers | Output-limit truncations | Acceptance pos 1 | Acceptance pos 2 | Acceptance pos 3 | Acceptance pos 4 | Acceptance pos 5 |
| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
| 1 | 1 | 100/100 | 79/100 | 16 | 85.660% | 68.957% | 53.327% | 39.766% | 28.535% |
| 1 | 2 | 100/100 | 74/100 | 19 | 86.147% | 69.985% | 54.531% | 40.717% | 28.770% |
| 2 | 1 | 100/100 | 75/100 | 16 | 85.801% | 69.148% | 53.385% | 39.368% | 27.631% |
| 2 | 2 | 100/100 | 79/100 | 13 | 85.607% | 68.690% | 52.906% | 39.254% | 28.199% |


- vLLM main: https://github.com/vllm-project/vllm/commit/b2f685834a6456197e7033966fdef52a23f1abcd
