### PR TITLE
[Feature][Kimi K3] Add opt-in reduced-expert functional debugging

### DIFF
--- a/docs/source/tutorials/models/Kimi-K3.md
+++ b/docs/source/tutorials/models/Kimi-K3.md
@@ -414,6 +414,24 @@ general tuning methods.
 
 ## 10 FAQ
 
+### Can I reduce routed experts for a low-memory functional smoke test?
+
+Set `VLLM_ASCEND_KIMI_K3_MAX_LOADED_EXPERTS` before constructing the model.
+The default `0` preserves all checkpoint experts. For example, `16` keeps
+routed experts `[0, 16)` in every MoE layer, slices router and correction-bias
+rows consistently, and skips loading the remaining routed-expert weights.
+The requested count must be at least the routing top-k, no larger than the
+checkpoint expert count, and divisible by the expert-parallel world size.
+For example, `16` is not valid for EP64.
+
+This is a functional debugging option, not an accuracy-preserving model
+compression method. It changes routing and generated output. Reduced-expert
+GSM8K scores or draft acceptance rates do not qualify the full-expert model.
+Target layers, shared experts, checkpoint files and the original configuration
+remain unchanged; only the runtime model configuration is copied and capped.
+Keep the option unset for full-model validation and production runs. This
+option is independent of the MRV2/DSpark adaptation and does not require it.
+
 For common environment, installation, and general parameter issues, refer to
 the [Public FAQ](../../faqs.md). This section covers Kimi-K3-specific questions.
 

--- a/tests/ut/models/test_kimi_k3_adapter.py
+++ b/tests/ut/models/test_kimi_k3_adapter.py
@@ -4,6 +4,7 @@
 from types import MethodType, SimpleNamespace
 from unittest.mock import patch
 
+import pytest
 import torch
 from safetensors.torch import save_file
 from torch import nn
@@ -16,6 +17,45 @@ from vllm_ascend.models.kimi_k3 import (
 from vllm_ascend.models.kimi_k3_dspark import (
     AscendK3DSparkForCausalLM,
 )
+
+
+@pytest.mark.parametrize(
+    ("requested", "expected"),
+    [("0", 896), ("16", 16)],
+)
+def test_kimi_expert_reduction_count(monkeypatch, requested, expected):
+    monkeypatch.setattr(
+        kimi_k3.envs_ascend,
+        "VLLM_ASCEND_KIMI_K3_MAX_LOADED_EXPERTS",
+        requested,
+    )
+    assert kimi_k3._get_kimi_k3_num_loaded_experts(896, 8, 16) == expected
+
+
+@pytest.mark.parametrize("requested", ["bad", "7", "15", "897"])
+def test_kimi_expert_reduction_rejects_invalid_counts(monkeypatch, requested):
+    monkeypatch.setattr(
+        kimi_k3.envs_ascend,
+        "VLLM_ASCEND_KIMI_K3_MAX_LOADED_EXPERTS",
+        requested,
+    )
+    with pytest.raises(ValueError, match="MAX_LOADED_EXPERTS"):
+        kimi_k3._get_kimi_k3_num_loaded_experts(896, 8, 16)
+
+
+@pytest.mark.parametrize(
+    ("name", "expected"),
+    [
+        ("model.layers.1.block_sparse_moe.experts.15.gate_proj.weight", 15),
+        (
+            "language_model.model.layers.2.block_sparse_moe.experts.16.down_proj.weight",
+            16,
+        ),
+        ("model.layers.1.block_sparse_moe.gate.weight", None),
+    ],
+)
+def test_kimi_expert_id_parsing(name, expected):
+    assert kimi_k3._get_expert_id_from_weight_name(name) == expected
 
 
 def test_ascend_attn_res_matches_canonical_k3_math():

--- a/vllm_ascend/envs.py
+++ b/vllm_ascend/envs.py
@@ -71,6 +71,11 @@ env_variables: dict[str, Callable[[], Any]] = {
     # Control the aclrtMemcpyBatchAsync compile path for KV cache offloading.
     # "1": force enable, "0": force disable, None: auto-detect from CANN headers.
     "VLLM_ASCEND_ENABLE_BATCH_MEMCPY": lambda: os.getenv("VLLM_ASCEND_ENABLE_BATCH_MEMCPY", None),
+    # Number of Kimi K3 routed experts to instantiate and load for functional
+    # debugging only; not sensitive. 0 (default) loads every checkpoint expert.
+    # Nonzero values must be >= routing top-k, <= checkpoint expert count,
+    # and divisible by the expert parallel world size.
+    "VLLM_ASCEND_KIMI_K3_MAX_LOADED_EXPERTS": lambda: os.getenv("VLLM_ASCEND_KIMI_K3_MAX_LOADED_EXPERTS", "0"),
 }
 
 # end-env-vars-definition

--- a/vllm_ascend/models/kimi_k3.py
+++ b/vllm_ascend/models/kimi_k3.py
@@ -19,6 +19,7 @@ from vllm.distributed import (
     get_tensor_model_parallel_world_size,
 )
 from vllm.forward_context import get_forward_context, is_forward_context_available
+from vllm.logger import init_logger
 from vllm.model_executor.layers.fused_moe import FusedMoEFactory
 from vllm.model_executor.layers.fused_moe.router.gate_linear import GateLinear
 from vllm.model_executor.layers.layernorm import RMSNorm
@@ -78,8 +79,11 @@ from vllm.sequence import IntermediateTensors
 from vllm.triton_utils import HAS_TRITON
 from vllm.utils.math_utils import cdiv
 
+import vllm_ascend.envs as envs_ascend
 from vllm_ascend.ops.kimi_kda import AscendKimiK3DeltaAttention  # type: ignore[import-untyped]
 from vllm_ascend.utils import get_rotation_path
+
+logger = init_logger(__name__)
 
 if HAS_TRITON:
     from vllm_ascend.ops.triton.kimi_k3.attention_residual import (  # type: ignore[import-untyped]
@@ -87,6 +91,49 @@ if HAS_TRITON:
     )
 else:
     apply_attn_res = None  # type: ignore[assignment]
+
+
+def _get_kimi_k3_num_loaded_experts(
+    total_num_experts: int,
+    num_experts_per_token: int,
+    expert_parallel_size: int,
+) -> int:
+    """Return a valid routed-expert count for functional debug loading."""
+    requested_raw = envs_ascend.VLLM_ASCEND_KIMI_K3_MAX_LOADED_EXPERTS
+    try:
+        requested = int(requested_raw)
+    except (TypeError, ValueError) as exc:
+        raise ValueError(
+            "VLLM_ASCEND_KIMI_K3_MAX_LOADED_EXPERTS must be an integer in "
+            f"[0, {total_num_experts}], got {requested_raw!r}"
+        ) from exc
+    if requested == 0:
+        return total_num_experts
+    if not num_experts_per_token <= requested <= total_num_experts:
+        raise ValueError(
+            "VLLM_ASCEND_KIMI_K3_MAX_LOADED_EXPERTS must be 0 or in "
+            f"[{num_experts_per_token}, {total_num_experts}], got {requested}"
+        )
+    if requested % expert_parallel_size != 0:
+        raise ValueError(
+            "VLLM_ASCEND_KIMI_K3_MAX_LOADED_EXPERTS must be divisible by "
+            f"expert parallel size {expert_parallel_size}, got {requested}"
+        )
+    return requested
+
+
+def _get_expert_id_from_weight_name(weight_name: str) -> int | None:
+    """Extract a routed-expert ID from an inner or multimodal checkpoint key."""
+    expert_prefix = ".experts."
+    prefix_idx = weight_name.find(expert_prefix)
+    if prefix_idx < 0:
+        return None
+    expert_id_start = prefix_idx + len(expert_prefix)
+    expert_id_end = weight_name.find(".", expert_id_start)
+    if expert_id_end < 0:
+        return None
+    expert_id_text = weight_name[expert_id_start:expert_id_end]
+    return int(expert_id_text) if expert_id_text.isdecimal() else None
 
 
 def _apply_ascend_attn_res(
@@ -540,9 +587,35 @@ class AscendKimiLinearModel(UpstreamKimiLinearModel):
     def __init__(self, *, vllm_config: VllmConfig, prefix: str = "") -> None:
         nn.Module.__init__(self)
         config = vllm_config.model_config.hf_text_config
+        parallel_config = vllm_config.parallel_config
+        assert config.num_experts is not None
+        assert config.num_experts_per_token is not None
+        self.num_checkpoint_experts = config.num_experts
+        expert_parallel_size = 1
+        if parallel_config.enable_expert_parallel:
+            expert_parallel_size = (
+                parallel_config.tensor_parallel_size
+                * parallel_config.data_parallel_size
+                * parallel_config.prefill_context_parallel_size
+            )
+        self.num_loaded_experts = _get_kimi_k3_num_loaded_experts(
+            self.num_checkpoint_experts,
+            config.num_experts_per_token,
+            expert_parallel_size,
+        )
+        if self.num_loaded_experts != self.num_checkpoint_experts:
+            config = copy(config)
+            config.num_experts = self.num_loaded_experts
+            logger.warning_once(
+                "Kimi K3 expert-reduced functional mode is enabled: loading "
+                "routed experts [0, %d) out of %d for every MoE layer. Router "
+                "and correction-bias rows are reduced consistently. Generated "
+                "results are not model-quality valid.",
+                self.num_loaded_experts,
+                self.num_checkpoint_experts,
+            )
         self.config = config
         self.vocab_size = config.vocab_size
-        parallel_config = vllm_config.parallel_config
         # vLLM's generic MoE SP switch currently requires DP > 1. K3 also
         # needs the same rank-local token layout for the TP/EP, DP=1 topology
         # that FlashComm used before the standard SP operators were available.
@@ -599,8 +672,14 @@ class AscendKimiLinearModel(UpstreamKimiLinearModel):
         assert config.num_attention_heads % world_size == 0, "num_attention_heads must be divisible by world_size"
 
     def load_weights(self, weights):
-        """Route mixed-precision KDA gates through vLLM's packed loader."""
+        """Route KDA gates and consistently reduce routed-expert weights."""
         params_dict = dict(self.named_parameters())
+        num_checkpoint_experts = getattr(self, "num_checkpoint_experts", None)
+        num_loaded_experts = getattr(
+            self,
+            "num_loaded_experts",
+            num_checkpoint_experts,
+        )
         gate_mapping = (
             (".b_proj.weight", ".fused_bfg_proj.weight", 0),
             (".f_a_proj.weight", ".fused_bfg_proj.f_a_weight", None),
@@ -611,6 +690,19 @@ class AscendKimiLinearModel(UpstreamKimiLinearModel):
         def remap_mixed_gate_weights():
             for args in weights:
                 name, loaded_weight = args[:2]
+                expert_id = _get_expert_id_from_weight_name(name)
+                if expert_id is not None and num_loaded_experts is not None and expert_id >= num_loaded_experts:
+                    continue
+                if (
+                    num_loaded_experts is not None
+                    and num_loaded_experts != num_checkpoint_experts
+                    and (
+                        name.endswith(".block_sparse_moe.gate.weight")
+                        or name.endswith(".block_sparse_moe.gate.e_score_correction_bias")
+                    )
+                ):
+                    loaded_weight = loaded_weight[:num_loaded_experts]
+                    args = (name, loaded_weight, *args[2:])
                 for source, target, shard_id in gate_mapping:
                     if source not in name:
                         continue


### PR DESCRIPTION
### What this PR does / why we need it?

Full Kimi K3 routed-expert weights can exceed the memory available for a functional smoke test. This PR extracts the previously implemented runtime expert-reduction option into a standalone main-based change, independent of MRV2/DSpark adaptation in #15951 and #15807.

`VLLM_ASCEND_KIMI_K3_MAX_LOADED_EXPERTS=0` (default) keeps all checkpoint experts. A positive count N:
- copies the runtime model config and instantiates routed experts `[0, N)`;
- skips checkpoint weights for routed expert IDs >= N;
- slices router gate and expert-score correction-bias rows consistently;
- validates that N is at least routing top-k, at most the checkpoint count, and divisible by expert-parallel world size;
- emits a warning that generated output is not model-quality-valid.

For an 896-expert checkpoint on EP16, N=16 is a functional debug configuration. N=16 is invalid on EP64. Target layer count, shared experts, source checkpoint files, and the original config are not reduced. No layer remapping, auxiliary-hidden-state contract, QuaRot fix, cache-lifecycle change, or graph adaptation is included.

The patch is based directly on main `deacd420`; it does not require #15708, #15807, or #15951. Only the model, centralized environment variable, focused tests, and usage documentation change.

### Does this PR introduce _any_ user-facing change?

Yes: one explicit opt-in environment variable for low-memory functional debugging. The default keeps full-expert behavior. The option changes model routing and generated output; it is not accuracy-preserving pruning. Reduced-expert GSM8K scores and speculative acceptance rates must not be used as full-model acceptance evidence. Leave it unset for production and full-model validation.

### How was this patch tested?

On this branch:
- Ruff lint and formatting checks on all three changed Python files: passed.
- Python compilation and `git diff --check`: passed.
- Nine restored helper test cases passed through AST-isolated execution of the actual helper functions and original parametrized tests: default/count validation, invalid counts, and checkpoint expert-ID parsing. This bypasses model imports and does not test NPU allocation or weight loading.

Unavailable locally:
- Full `pytest tests/ut/models/test_kimi_k3_adapter.py -q` collection stops because torch is not installed on this Windows host.
- `bash format.sh ci` stops because pre-commit is not installed.
- No new NPU/full-model inference run was performed on this rebased branch. Prior reduced-expert smoke tests are historical and not validation of this exact head.

Submitted as draft pending full adapter tests and NPU loading validation. The full-expert MRV2 integration and deployed service configurations remain unchanged.
- vLLM main: https://github.com/vllm-project/vllm/commit/e6bfe03ad73a3330cb427885aa90d97a12e1c704
