### PR TITLE
[Refactor][Attention] Unify SFA cache slot mapping

### DIFF
--- a/tests/ut/attention/test_sfa_cp.py
+++ b/tests/ut/attention/test_sfa_cp.py
@@ -188,7 +188,7 @@ def test_sfa_builder_cache_slot_layout(pcp_enabled: bool, c8_reshape_optim_enabl
     torch.testing.assert_close(common.slot_mapping, slots)
     assert metadata.num_input_tokens == 2
     if c8_reshape_optim_enabled:
-        torch.testing.assert_close(store_metadata.call_args.args[0], slots[:2])
+        torch.testing.assert_close(store_metadata.call_args.args[0], expected_slots)
     else:
         store_metadata.assert_not_called()
     impl_cls = AscendSFAPCPImpl if pcp_enabled else AscendSFAImpl

--- a/tests/ut/attention/test_sfa_cp.py
+++ b/tests/ut/attention/test_sfa_cp.py
@@ -4,6 +4,7 @@ from dataclasses import fields
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
+import pytest
 import torch
 
 from vllm_ascend.attention.attention_v1 import AscendAttentionState
@@ -142,6 +143,57 @@ def test_sfa_pcp_resolution_for_mrv2_config() -> None:
         ),
     ):
         assert resolve_sfa_impl(vllm_config) is AscendSFAPCPImpl
+
+
+@pytest.mark.parametrize("pcp_enabled", [False, True])
+@pytest.mark.parametrize("c8_reshape_optim_enabled", [False, True])
+def test_sfa_builder_cache_slot_layout(pcp_enabled: bool, c8_reshape_optim_enabled: bool) -> None:
+    builder = AscendSFAMetadataBuilder.__new__(AscendSFAMetadataBuilder)
+    builder.pcp_enabled = pcp_enabled
+    builder.kernel_block_size = 128
+    builder.model_config = MagicMock()
+    builder.model_config.get_head_size.return_value = 64
+    builder.attn_mask_builder = MagicMock()
+    builder.metadata_cls = AscendSFAMetadata
+    # The same oversized buffer represents PCP ranks or MTP buffer capacity.
+    slots = torch.tensor([4, 5, 8, 9], dtype=torch.int64)
+    common = SimpleNamespace(
+        num_reqs=1,
+        num_actual_tokens=2,
+        num_input_tokens=2,
+        block_table_tensor=torch.zeros((1, 1), dtype=torch.int32),
+        slot_mapping=slots,
+        positions=torch.arange(2),
+        query_start_loc=torch.tensor([0, 2], dtype=torch.int32),
+        seq_lens=torch.tensor([2], dtype=torch.int32),
+        _seq_lens_cpu=torch.tensor([2], dtype=torch.int32),
+        attn_state=AscendAttentionState.ChunkedPrefill,
+        causal=True,
+        group_len=torch.empty(1, dtype=torch.int32),
+        group_key_idx=torch.empty(1, dtype=torch.int32),
+        group_key_cache_idx=torch.empty(1, dtype=torch.int32),
+    )
+    with (
+        patch("vllm_ascend.attention.sfa_v1.get_cos_and_sin_mla", return_value=(torch.ones(2), torch.ones(2))),
+        patch(
+            "vllm_ascend.attention.sfa_v1.get_ascend_config",
+            return_value=SimpleNamespace(c8_reshape_optim_enabled=c8_reshape_optim_enabled),
+        ),
+        patch("torch.ops._C_ascend.store_kv_block_metadata", create=True) as store_metadata,
+    ):
+        metadata = builder.build(0, common)
+
+    expected_slots = slots if pcp_enabled else slots[:2]
+    torch.testing.assert_close(metadata.slot_mapping, expected_slots)
+    torch.testing.assert_close(common.slot_mapping, slots)
+    assert metadata.num_input_tokens == 2
+    if c8_reshape_optim_enabled:
+        torch.testing.assert_close(store_metadata.call_args.args[0], slots[:2])
+    else:
+        store_metadata.assert_not_called()
+    impl_cls = AscendSFAPCPImpl if pcp_enabled else AscendSFAImpl
+    impl = impl_cls.__new__(impl_cls)
+    assert impl._get_sfa_kv_slot_mapping(metadata) is metadata.slot_mapping
 
 
 def test_sfa_pcp_gathers_main_kv_before_base_cache_write() -> None:

--- a/vllm_ascend/attention/context_parallel/sfa_cp.py
+++ b/vllm_ascend/attention/context_parallel/sfa_cp.py
@@ -147,13 +147,6 @@ class AscendSFAPCPImpl(OProjWeightSwitchMixin, AscendSFAImpl):
         output.copy_(partial_output)
         return output
 
-    def _get_sfa_kv_slot_mapping(
-        self,
-        attn_metadata: M,
-    ) -> torch.Tensor:
-        assert attn_metadata.pcp_slot_mapping is not None
-        return attn_metadata.pcp_slot_mapping
-
     def exec_kv(
         self,
         kv_no_split: torch.Tensor,

--- a/vllm_ascend/attention/sfa_v1.py
+++ b/vllm_ascend/attention/sfa_v1.py
@@ -156,6 +156,7 @@ class AscendSFAMetadata:
     # |-------------------- seq_len ---------------------|
     #                                   |-- query_len ---|
     num_actual_tokens: int  # Number of tokens excluding padding.
+    # Cache-write layout: full PCP ranks, or input tokens with DSA-CP padding.
     slot_mapping: torch.Tensor
     seq_lens: torch.Tensor
     seq_lens_cpu: torch.Tensor
@@ -166,7 +167,6 @@ class AscendSFAMetadata:
 
     # For logging.
     num_input_tokens: int = 0  # Number of tokens including padding.
-    pcp_slot_mapping: torch.Tensor | None = None
     # The dimension of the attention heads
     head_dim: int | None = None
     attn_mask: torch.Tensor = None
@@ -328,8 +328,11 @@ class AscendSFAMetadataBuilder(MLACommonMetadataBuilder[AscendSFAMetadata]):
         num_actual_tokens = common_attn_metadata.num_actual_tokens
         num_input_tokens = common_attn_metadata.num_input_tokens
         block_table = common_attn_metadata.block_table_tensor[:num_reqs]
-        pcp_slot_mapping = common_attn_metadata.slot_mapping
-        slot_mapping = pcp_slot_mapping[:num_input_tokens]
+        # PCP cache writes gather prefill tokens and need the full rank layout.
+        # Other paths may receive an oversized persistent buffer from MTP.
+        slot_mapping = common_attn_metadata.slot_mapping
+        if not self.pcp_enabled:
+            slot_mapping = slot_mapping[:num_input_tokens]
         input_positions = common_attn_metadata.positions[:num_input_tokens].long()
 
         block_size = self.kernel_block_size
@@ -360,7 +363,7 @@ class AscendSFAMetadataBuilder(MLACommonMetadataBuilder[AscendSFAMetadata]):
 
         if get_ascend_config().c8_reshape_optim_enabled:
             torch.ops._C_ascend.store_kv_block_metadata(
-                slot_mapping,
+                slot_mapping[:num_input_tokens] if self.pcp_enabled else slot_mapping,
                 common_attn_metadata.group_len,
                 common_attn_metadata.group_key_idx,
                 common_attn_metadata.group_key_cache_idx,
@@ -374,7 +377,6 @@ class AscendSFAMetadataBuilder(MLACommonMetadataBuilder[AscendSFAMetadata]):
             seq_lens=seq_lens,
             seq_lens_cpu=seq_lens_cpu,
             slot_mapping=slot_mapping,
-            pcp_slot_mapping=pcp_slot_mapping,
             head_dim=self.model_config.get_head_size(),
             attn_mask=self.attn_mask_builder.get_attention_mask(common_attn_metadata.causal, self.model_config),
             attn_state=common_attn_metadata.attn_state,
@@ -1638,15 +1640,10 @@ class AscendSFAImpl(MLAAttentionImpl):
 
         if self.has_indexer:
             assert k_li is not None
-            if self.vllm_config.parallel_config.prefill_context_parallel_size > 1:
-                assert attn_metadata.pcp_slot_mapping is not None
-                indexer_cache_slot_mapping = attn_metadata.pcp_slot_mapping
-            else:
-                indexer_cache_slot_mapping = slot_mapping_li
             self._write_indexer_cache(
                 k_li,
                 k_li_scale,
-                indexer_cache_slot_mapping,
+                slot_mapping_li,
                 kv_cache,
                 attn_metadata,
             )

--- a/vllm_ascend/attention/sfa_v1.py
+++ b/vllm_ascend/attention/sfa_v1.py
@@ -363,7 +363,7 @@ class AscendSFAMetadataBuilder(MLACommonMetadataBuilder[AscendSFAMetadata]):
 
         if get_ascend_config().c8_reshape_optim_enabled:
             torch.ops._C_ascend.store_kv_block_metadata(
-                slot_mapping[:num_input_tokens] if self.pcp_enabled else slot_mapping,
+                slot_mapping,
                 common_attn_metadata.group_len,
                 common_attn_metadata.group_key_idx,
                 common_attn_metadata.group_key_cache_idx,


### PR DESCRIPTION
### What this PR does / why we need it?

Use `AscendSFAMetadata.slot_mapping` for both SFA and indexer cache writes. PCP keeps the complete rank layout needed after gathering prefill tokens, so the separate `pcp_slot_mapping` field and PCP-specific mapping selection can be removed.

For other execution modes, keep truncating persistent MTP buffers to `num_input_tokens` before the existing DSA-CP padding. Build C8 block metadata from the same mapping so PCP prefill cache writes cover the full gathered token layout. This refactor assumes PCP and DSA-CP are mutually exclusive.

### Does this PR introduce _any_ user-facing change?

PCP prefill with the C8 reshape optimization now builds block metadata for the full gathered token layout. Configuration interfaces are unchanged.

### How was this patch tested?

- Added four parametrized cases covering PCP/full mapping versus ordinary/MTP truncation, with C8 block metadata enabled and disabled, including the full PCP mapping passed to the metadata operator. Existing tests cover DSA-CP padding and PCP cache gathering.
- Passed repository-pinned Ruff lint/format, codespell, typos, Python AST parsing, and `git diff --check` for the changed files.
- Full `bash format.sh ci` was attempted but interrupted while initializing the actionlint environment; the full hook suite remains pending.
- Runtime tests are pending: the two registered remote container endpoints attempted for validation refused connections. The workspace requires Torch tests to run remotely.
- Targeted command: `pytest -q tests/ut/attention/test_sfa_cp.py tests/ut/attention/test_sfa_v1.py`.
- Draft pending targeted tests and attention correctness / multi-rank validation; graph-mode coverage is also recommended.

- vLLM main: https://github.com/vllm-project/vllm/commit/e6bfe03ad73a3330cb427885aa90d97a12e1c704
