### PR TITLE
[0.27.1rc][CI] Enable fused MC2 for Qwen3.5-397B-A17B W8A8 MTP A3 nightly

### DIFF
--- a/tests/e2e/nightly/single_node/models/configs/Qwen3.5-397B-A17B-W8A8-mtp-A3.yaml
+++ b/tests/e2e/nightly/single_node/models/configs/Qwen3.5-397B-A17B-W8A8-mtp-A3.yaml
@@ -35,7 +35,7 @@ test_cases:
       - "--gpu-memory-utilization"
       - "0.9"
       - "--additional-config"
-      - '{"enable_cpu_binding":true,"enable_fused_mc2":0}'
+      - '{"enable_cpu_binding":true,"enable_fused_mc2":1}'
       - "--speculative_config"
       - '{"method": "qwen3_5_mtp", "num_speculative_tokens": 5, "enforce_eager": true}'
       - "--compilation-config"


### PR DESCRIPTION
### What this PR does / why we need it?

Backports #15914 to `releases/v0.27.1rc`.

Enable `enable_fused_mc2` in the Qwen3.5-397B-A17B W8A8 MTP A3 nightly case so the test covers the fused MC2 communication path.

- Update `tests/e2e/nightly/single_node/models/configs/Qwen3.5-397B-A17B-W8A8-mtp-A3.yaml`
- Change `enable_fused_mc2` from `0` to `1`

### Does this PR introduce _any_ user-facing change?

No. This is a nightly test config change only.

### How was this patch tested?

Config-only change. Cherry-picked from #15914 (`88e28bf497c0904221a5040f7fe49a3d3b423aad`). Nightly CI on the 0.27.1rc branch will validate the updated case.

Made with [Cursor](https://cursor.com)
- vLLM main: https://github.com/vllm-project/vllm/commit/ba07e4a48fc951300d97eb506217dd530583dea3
