### PR TITLE
CI: tolerate pending pods in multi-node nightly readiness loop

### DIFF
--- a/.github/workflows/_e2e_nightly_multi_node.yaml
+++ b/.github/workflows/_e2e_nightly_multi_node.yaml
@@ -340,7 +340,7 @@ jobs:
             for ((i=1; i<SIZE; i++)); do
               POD="${LWS_NAME}-0-${i}"
               PHASE=$(kubectl get pod "$POD" -n "$NAMESPACE" -o jsonpath='{.status.phase}' 2>/dev/null || echo "NotFound")
-              READY=$(kubectl get pod "$POD" -n "$NAMESPACE" -o jsonpath='{.status.containerStatuses[*].ready}' 2>/dev/null)
+              READY=$(kubectl get pod "$POD" -n "$NAMESPACE" -o jsonpath='{.status.containerStatuses[*].ready}' 2>/dev/null || true)
               echo "Worker [$POD] phase=$PHASE ready=$READY"
               if [[ "$PHASE" != "Running" || "$READY" != "true" ]]; then
                 ALL_READY=false
@@ -349,7 +349,7 @@ jobs:
             done
 
             LEADER_PHASE=$(kubectl get pod "$LEADER_POD" -n "$NAMESPACE" -o jsonpath='{.status.phase}' 2>/dev/null || echo "NotFound")
-            LEADER_READY=$(kubectl get pod "$LEADER_POD" -n "$NAMESPACE" -o jsonpath='{.status.containerStatuses[*].ready}' 2>/dev/null)
+            LEADER_READY=$(kubectl get pod "$LEADER_POD" -n "$NAMESPACE" -o jsonpath='{.status.containerStatuses[*].ready}' 2>/dev/null || true)
             echo "Leader [$LEADER_POD] phase=$LEADER_PHASE ready=$LEADER_READY"
             if [[ "$LEADER_PHASE" != "Running" || "$LEADER_READY" != "true" ]]; then
               ALL_READY=false


### PR DESCRIPTION
## What this fixes

The multi-node nightly pod-ready loop runs with set -euo pipefail. Immediately after applying a LeaderWorkerSet, worker or leader pods may not exist yet. In that normal pending window, the ready-field kubectl get pod exits non-zero and aborts the step instead of polling.

This was reproduced in workflow run 34126577054, job 101758309384: the step exited about one second after kubectl apply, before any pod/model work began.

## Change

Allow the two readiness lookups to return an empty value while pods are pending. Phase lookup already maps NotFound, and the existing loop then sleeps and retries until the 1200-second deadline.

## Validation

- YAML parse passed
- git diff --check passed
- Existing phase/timeout/error semantics are unchanged
- The change only affects the expected transient NotFound path
- vLLM main: https://github.com/vllm-project/vllm/commit/e6bfe03ad73a3330cb427885aa90d97a12e1c704
