### PR TITLE
[Feature][MRV2] Adapt PCP for data parallelism

### DIFF
--- a/tests/ut/worker/test_attn_utils_v2.py
+++ b/tests/ut/worker/test_attn_utils_v2.py
@@ -647,8 +647,7 @@ def test_dsv4_backends_declare_role_specific_logical_sizes(
         ("model_state", CUDAGraphMode.NONE, False, 1, 5),
         ("model_state", CUDAGraphMode.FULL, False, 1, 8),
         ("pcp_capture", CUDAGraphMode.NONE, True, 2, 8),
-        ("pcp_dummy", CUDAGraphMode.NONE, False, 2, 8),
-        ("pcp_dummy", CUDAGraphMode.FULL, True, 2, 8),
+        ("pcp_runtime", CUDAGraphMode.NONE, False, 2, 8),
     ],
 )
 def test_mrv2_builds_shared_dsa_metadata_for_each_execution_mode(

--- a/tests/ut/worker/test_attn_utils_v2.py
+++ b/tests/ut/worker/test_attn_utils_v2.py
@@ -647,6 +647,8 @@ def test_dsv4_backends_declare_role_specific_logical_sizes(
         ("model_state", CUDAGraphMode.NONE, False, 1, 5),
         ("model_state", CUDAGraphMode.FULL, False, 1, 8),
         ("pcp_capture", CUDAGraphMode.NONE, True, 2, 8),
+        ("pcp_dummy", CUDAGraphMode.NONE, False, 2, 8),
+        ("pcp_dummy", CUDAGraphMode.FULL, True, 2, 8),
     ],
 )
 def test_mrv2_builds_shared_dsa_metadata_for_each_execution_mode(
@@ -666,7 +668,7 @@ def test_mrv2_builds_shared_dsa_metadata_for_each_execution_mode(
         [2, 1, 0, 0],
         dtype=torch.int32,
     )
-    pcp_context = object() if caller == "pcp_capture" else None
+    pcp_context = object() if pcp_size > 1 else None
     pcp_manager = (
         SimpleNamespace(
             build_attention_context=MagicMock(return_value=pcp_context),
@@ -748,7 +750,7 @@ def test_mrv2_builds_shared_dsa_metadata_for_each_execution_mode(
     if pcp_context is not None:
         assert [call["pcp_cache_group_idx"] for call in calls] == [0, 1]
         assert pcp_manager is not None
-        pcp_manager.build_attention_context.assert_called_once_with(input_batch)
+        pcp_manager.build_attention_context.assert_called_once_with(input_batch, block_tables, slot_mappings)
     else:
         assert all(call["pcp_cache_group_idx"] is None for call in calls)
 

--- a/tests/ut/worker/test_model_runner_v2.py
+++ b/tests/ut/worker/test_model_runner_v2.py
@@ -7,9 +7,8 @@ import numpy as np
 import pytest
 import torch
 from vllm.config import CUDAGraphMode
-from vllm.v1.worker.gpu.model_runner import BatchReqState, GPUModelRunner
+from vllm.v1.worker.gpu.model_runner import GPUModelRunner
 
-from vllm_ascend.worker.v2 import model_runner as runner_module
 from vllm_ascend.worker.v2.input_batch import AscendInputBatch, AscendInputBuffers
 from vllm_ascend.worker.v2.model_runner import NPUModelRunner
 from vllm_ascend.worker.v2.pcp_manager import AscendPCPManager
@@ -219,98 +218,6 @@ def test_prepare_inputs_preserves_pcp_tokens_and_forwards_graph_padding():
     assert padded_num_tokens.value.id == "batch_desc"
 
 
-@pytest.mark.parametrize(
-    "dp_size,use_pcp,scheduled,prefilling,dispatch_tokens,padded_tokens",
-    [
-        (2, True, [80, 48], [True, True], 64, 64),
-        (2, True, [18, 1], [True, False], 11, 11),
-        (2, True, [1, 1], [False, False], 2, 4),
-        (1, True, [18, 1], [True, False], 11, 11),
-        (2, False, [18, 1], [True, False], 19, 19),
-    ],
-)
-def test_pcp_dp_dispatch_preserves_full_inputs_before_partition(
-    dp_size, use_pcp, scheduled, prefilling, dispatch_tokens, padded_tokens
-):
-    runner = _make_runner()
-    runner.dp_size = dp_size
-    runner.device = torch.device("cpu")
-    runner.max_num_reqs = 2
-    runner.use_dcp = runner.use_pp = False
-    runner.model_config = SimpleNamespace(rswa_window=None)
-    runner.model_state = SimpleNamespace(num_new_sampled_tokens_per_step=1)
-    runner.eplb = Mock()
-    runner._update_seq_lens_cpu = Mock()
-    runner.input_buffers = AscendInputBuffers(2, 128, runner.device)
-    runner.input_buffers.input_ids.copy_(torch.arange(128, dtype=torch.int32))
-    runner.input_buffers.positions.copy_(torch.arange(128))
-    runner.req_states = SimpleNamespace(
-        num_computed_tokens_np=np.array([64, 0], dtype=np.int32),
-        num_computed_tokens=SimpleNamespace(gpu=torch.tensor([64, 0], dtype=torch.int32)),
-        prefill_len=SimpleNamespace(gpu=torch.tensor([128, 128], dtype=torch.int32)),
-        all_token_ids=SimpleNamespace(gpu=torch.zeros((2, 128), dtype=torch.int32)),
-        next_prefill_tokens=torch.zeros(2, dtype=torch.int32),
-        last_sampled_tokens=torch.zeros(2, dtype=torch.int32),
-        draft_tokens=torch.empty((2, 0), dtype=torch.int32),
-    )
-    runner.pcp_manager = AscendPCPManager(2, 0, runner.device) if use_pcp else None
-    state = BatchReqState(
-        req_ids=["a", "b"],
-        num_scheduled_tokens=np.array(scheduled, dtype=np.int32),
-        num_tokens=sum(scheduled),
-        idx_mapping_np=np.array([1, 0], dtype=np.intp),
-        prefill_len_np=np.array([128, 128], dtype=np.int32),
-        num_computed_prefill_tokens_np=np.array([0, 64], dtype=np.int32),
-        is_prefilling_np=np.array(prefilling),
-        has_prefill=any(prefilling),
-    )
-    scheduler_output = SimpleNamespace(scheduled_spec_decode_tokens={}, has_structured_output_requests=False)
-    actual_dispatch_tokens = (
-        runner.pcp_manager.get_num_tokens_for_dispatch(state.num_scheduled_tokens, state.is_prefilling_np)
-        if use_pcp
-        else state.num_tokens
-    )
-    assert actual_dispatch_tokens == dispatch_tokens
-
-    def copy_to_cpu(value, out=None, device=None):
-        value = torch.as_tensor(value)
-        if out is not None:
-            out.copy_(value)
-            return out
-        return value
-
-    # Stub device kernels, but execute the actual prepare_inputs all the way
-    # to its PCP boundary. Token views and request offsets must agree there.
-    with (
-        patch.object(runner_module, "async_copy_to_gpu", side_effect=copy_to_cpu),
-        patch.object(runner_module, "build_attn_state", return_value=None),
-        patch.object(runner_module, "prepare_prefill_inputs"),
-        patch.object(runner_module, "prepare_pos_seq_lens"),
-        patch.object(runner_module, "combine_sampled_and_draft_tokens", return_value=torch.tensor([0, 1])),
-        patch.object(runner_module, "update_cos_sin"),
-        patch.object(
-            runner_module.vllm_model_runner.pcp,
-            "maybe_partition_pcp_batch",
-            side_effect=lambda manager, batch, **kwargs: batch,
-        ) as partition,
-    ):
-        batch = runner.prepare_inputs(
-            scheduler_output,
-            state,
-            SimpleNamespace(num_tokens=padded_tokens, num_reqs=2, cg_mode=CUDAGraphMode.NONE),
-        )
-
-    partition.assert_called_once_with(runner.pcp_manager, batch, padded_num_tokens=padded_tokens)
-    expected_size = sum(scheduled) if state.has_prefill else padded_tokens
-    assert batch.num_tokens == sum(scheduled)
-    assert batch.num_tokens_after_padding == expected_size
-    assert batch.input_ids.tolist() == list(range(expected_size))
-    assert batch.positions.tolist() == list(range(expected_size))
-    assert batch.is_padding.shape == (expected_size,)
-    np.testing.assert_array_equal(batch.query_start_loc_np, [0, scheduled[0], sum(scheduled)])
-    assert state.num_tokens == sum(scheduled)
-
-
 @pytest.mark.parametrize("num_reqs,num_tokens", [(4, 4), (2, 6)])
 def test_pcp_dummy_refreshes_captured_buffers_after_real_batch(num_reqs, num_tokens):
     runner = _make_runner()
@@ -323,7 +230,6 @@ def test_pcp_dummy_refreshes_captured_buffers_after_real_batch(num_reqs, num_tok
         name: getattr(manager.input_buffers, name)
         for name in ("input_ids", "positions", "is_padding", "query_start_loc", "seq_lens")
     }
-    pointers = {name: value.data_ptr() for name, value in captured.items()}
     for name, value in captured.items():
         value.fill_(False if name == "is_padding" else 99)
     manager.input_buffers.seq_lens_np.fill(99)
@@ -333,7 +239,6 @@ def test_pcp_dummy_refreshes_captured_buffers_after_real_batch(num_reqs, num_tok
     block_tables, slots = runner.prepare_dummy_attn(dummy)
 
     for name, value in captured.items():
-        assert value.data_ptr() == pointers[name]
         expected = getattr(dummy, name)
         torch.testing.assert_close(value[: len(expected)], expected)
     np.testing.assert_array_equal(manager.input_buffers.seq_lens_np[:num_reqs], dummy.seq_lens_np)
@@ -342,9 +247,6 @@ def test_pcp_dummy_refreshes_captured_buffers_after_real_batch(num_reqs, num_tok
     assert slots.data_ptr() == manager._gathered_kv_slot_mappings.data_ptr()
     assert slots.shape == (1, 2 * num_tokens)
     assert torch.all(slots == -1)
-    context = manager.build_attention_context(dummy, block_tables, slots)
-    assert context.global_batch is dummy
-    assert context.global_slot_mappings.shape == (1, num_tokens)
 
 
 def test_prepare_dummy_attn_without_pcp_uses_upstream():

--- a/tests/ut/worker/test_model_runner_v2.py
+++ b/tests/ut/worker/test_model_runner_v2.py
@@ -7,9 +7,12 @@ import numpy as np
 import pytest
 import torch
 from vllm.config import CUDAGraphMode
-from vllm.v1.worker.gpu.model_runner import GPUModelRunner
+from vllm.v1.worker.gpu.model_runner import BatchReqState, GPUModelRunner
 
+from vllm_ascend.worker.v2 import model_runner as runner_module
+from vllm_ascend.worker.v2.input_batch import AscendInputBatch, AscendInputBuffers
 from vllm_ascend.worker.v2.model_runner import NPUModelRunner
+from vllm_ascend.worker.v2.pcp_manager import AscendPCPManager
 
 
 def _make_runner(need_timing: bool = True):
@@ -214,3 +217,140 @@ def test_prepare_inputs_preserves_pcp_tokens_and_forwards_graph_padding():
     assert padded_num_tokens.attr == "num_tokens"
     assert isinstance(padded_num_tokens.value, ast.Name)
     assert padded_num_tokens.value.id == "batch_desc"
+
+
+@pytest.mark.parametrize(
+    "dp_size,use_pcp,scheduled,prefilling,dispatch_tokens,padded_tokens",
+    [
+        (2, True, [80, 48], [True, True], 64, 64),
+        (2, True, [18, 1], [True, False], 11, 11),
+        (2, True, [1, 1], [False, False], 2, 4),
+        (1, True, [18, 1], [True, False], 11, 11),
+        (2, False, [18, 1], [True, False], 19, 19),
+    ],
+)
+def test_pcp_dp_dispatch_preserves_full_inputs_before_partition(
+    dp_size, use_pcp, scheduled, prefilling, dispatch_tokens, padded_tokens
+):
+    runner = _make_runner()
+    runner.dp_size = dp_size
+    runner.device = torch.device("cpu")
+    runner.max_num_reqs = 2
+    runner.use_dcp = runner.use_pp = False
+    runner.model_config = SimpleNamespace(rswa_window=None)
+    runner.model_state = SimpleNamespace(num_new_sampled_tokens_per_step=1)
+    runner.eplb = Mock()
+    runner._update_seq_lens_cpu = Mock()
+    runner.input_buffers = AscendInputBuffers(2, 128, runner.device)
+    runner.input_buffers.input_ids.copy_(torch.arange(128, dtype=torch.int32))
+    runner.input_buffers.positions.copy_(torch.arange(128))
+    runner.req_states = SimpleNamespace(
+        num_computed_tokens_np=np.array([64, 0], dtype=np.int32),
+        num_computed_tokens=SimpleNamespace(gpu=torch.tensor([64, 0], dtype=torch.int32)),
+        prefill_len=SimpleNamespace(gpu=torch.tensor([128, 128], dtype=torch.int32)),
+        all_token_ids=SimpleNamespace(gpu=torch.zeros((2, 128), dtype=torch.int32)),
+        next_prefill_tokens=torch.zeros(2, dtype=torch.int32),
+        last_sampled_tokens=torch.zeros(2, dtype=torch.int32),
+        draft_tokens=torch.empty((2, 0), dtype=torch.int32),
+    )
+    runner.pcp_manager = AscendPCPManager(2, 0, runner.device) if use_pcp else None
+    state = BatchReqState(
+        req_ids=["a", "b"],
+        num_scheduled_tokens=np.array(scheduled, dtype=np.int32),
+        num_tokens=sum(scheduled),
+        idx_mapping_np=np.array([1, 0], dtype=np.intp),
+        prefill_len_np=np.array([128, 128], dtype=np.int32),
+        num_computed_prefill_tokens_np=np.array([0, 64], dtype=np.int32),
+        is_prefilling_np=np.array(prefilling),
+        has_prefill=any(prefilling),
+    )
+    scheduler_output = SimpleNamespace(scheduled_spec_decode_tokens={}, has_structured_output_requests=False)
+    actual_dispatch_tokens = (
+        runner.pcp_manager.get_num_tokens_for_dispatch(state.num_scheduled_tokens, state.is_prefilling_np)
+        if use_pcp
+        else state.num_tokens
+    )
+    assert actual_dispatch_tokens == dispatch_tokens
+
+    def copy_to_cpu(value, out=None, device=None):
+        value = torch.as_tensor(value)
+        if out is not None:
+            out.copy_(value)
+            return out
+        return value
+
+    # Stub device kernels, but execute the actual prepare_inputs all the way
+    # to its PCP boundary. Token views and request offsets must agree there.
+    with (
+        patch.object(runner_module, "async_copy_to_gpu", side_effect=copy_to_cpu),
+        patch.object(runner_module, "build_attn_state", return_value=None),
+        patch.object(runner_module, "prepare_prefill_inputs"),
+        patch.object(runner_module, "prepare_pos_seq_lens"),
+        patch.object(runner_module, "combine_sampled_and_draft_tokens", return_value=torch.tensor([0, 1])),
+        patch.object(runner_module, "update_cos_sin"),
+        patch.object(
+            runner_module.vllm_model_runner.pcp,
+            "maybe_partition_pcp_batch",
+            side_effect=lambda manager, batch, **kwargs: batch,
+        ) as partition,
+    ):
+        batch = runner.prepare_inputs(
+            scheduler_output,
+            state,
+            SimpleNamespace(num_tokens=padded_tokens, num_reqs=2, cg_mode=CUDAGraphMode.NONE),
+        )
+
+    partition.assert_called_once_with(runner.pcp_manager, batch, padded_num_tokens=padded_tokens)
+    expected_size = sum(scheduled) if state.has_prefill else padded_tokens
+    assert batch.num_tokens == sum(scheduled)
+    assert batch.num_tokens_after_padding == expected_size
+    assert batch.input_ids.tolist() == list(range(expected_size))
+    assert batch.positions.tolist() == list(range(expected_size))
+    assert batch.is_padding.shape == (expected_size,)
+    np.testing.assert_array_equal(batch.query_start_loc_np, [0, scheduled[0], sum(scheduled)])
+    assert state.num_tokens == sum(scheduled)
+
+
+@pytest.mark.parametrize("num_reqs,num_tokens", [(4, 4), (2, 6)])
+def test_pcp_dummy_refreshes_captured_buffers_after_real_batch(num_reqs, num_tokens):
+    runner = _make_runner()
+    runner.input_buffers = AscendInputBuffers(4, 8, torch.device("cpu"))
+    manager = AscendPCPManager(2, 1, torch.device("cpu"), max_num_reqs=4, max_num_tokens=8)
+    runner.pcp_manager = manager
+    manager._local_block_tables = (torch.full((8, 2), 99, dtype=torch.int32),)
+    manager._gathered_kv_slot_mappings = torch.full((1, 16), 99, dtype=torch.int64)
+    captured = {
+        name: getattr(manager.input_buffers, name)
+        for name in ("input_ids", "positions", "is_padding", "query_start_loc", "seq_lens")
+    }
+    pointers = {name: value.data_ptr() for name, value in captured.items()}
+    for name, value in captured.items():
+        value.fill_(False if name == "is_padding" else 99)
+    manager.input_buffers.seq_lens_np.fill(99)
+    with patch("vllm_ascend.worker.v2.input_batch.update_cos_sin"):
+        dummy = AscendInputBatch.make_dummy(num_reqs, num_tokens, runner.input_buffers)
+
+    block_tables, slots = runner.prepare_dummy_attn(dummy)
+
+    for name, value in captured.items():
+        assert value.data_ptr() == pointers[name]
+        expected = getattr(dummy, name)
+        torch.testing.assert_close(value[: len(expected)], expected)
+    np.testing.assert_array_equal(manager.input_buffers.seq_lens_np[:num_reqs], dummy.seq_lens_np)
+    assert block_tables[0].data_ptr() == manager._local_block_tables[0].data_ptr()
+    assert torch.count_nonzero(block_tables[0]) == 0
+    assert slots.data_ptr() == manager._gathered_kv_slot_mappings.data_ptr()
+    assert slots.shape == (1, 2 * num_tokens)
+    assert torch.all(slots == -1)
+    context = manager.build_attention_context(dummy, block_tables, slots)
+    assert context.global_batch is dummy
+    assert context.global_slot_mappings.shape == (1, num_tokens)
+
+
+def test_prepare_dummy_attn_without_pcp_uses_upstream():
+    runner = _make_runner()
+    runner.pcp_manager = None
+    dummy = object()
+    with patch.object(GPUModelRunner, "prepare_dummy_attn", return_value=((), None)) as parent:
+        assert runner.prepare_dummy_attn(dummy) == ((), None)
+    parent.assert_called_once_with(dummy)

--- a/tests/ut/worker/test_mtp_pcp_speculator_v2.py
+++ b/tests/ut/worker/test_mtp_pcp_speculator_v2.py
@@ -327,11 +327,15 @@ def test_graph_prefill_builds_draft_metadata(replicated_pcp: bool) -> None:
 
 
 @pytest.mark.parametrize(
-    ("speculator_cls", "parent_cls"),
-    [(AscendMTPSpeculator, MTPSpeculator), (AscendEagleSpeculator, EagleSpeculator)],
+    ("speculator_cls", "parent_cls", "replicated_pcp", "batch_kind"),
+    [
+        (AscendMTPSpeculator, MTPSpeculator, True, "prefill"),
+        (AscendMTPSpeculator, MTPSpeculator, True, "decode"),
+        (AscendMTPSpeculator, MTPSpeculator, True, "idle"),
+        (AscendMTPSpeculator, MTPSpeculator, False, "prefill"),
+        (AscendEagleSpeculator, EagleSpeculator, True, "prefill"),
+    ],
 )
-@pytest.mark.parametrize("replicated_pcp", [False, True])
-@pytest.mark.parametrize("batch_kind", ["prefill", "decode", "idle"])
 def test_propose_sync_follows_draft_token_layout(speculator_cls, parent_cls, replicated_pcp, batch_kind) -> None:
     speculator = object.__new__(speculator_cls)
     speculator.replicated_pcp = replicated_pcp

--- a/tests/ut/worker/test_mtp_pcp_speculator_v2.py
+++ b/tests/ut/worker/test_mtp_pcp_speculator_v2.py
@@ -9,12 +9,16 @@ from unittest.mock import MagicMock, patch
 import numpy as np
 import pytest
 import torch
+from vllm.config import CUDAGraphMode
+from vllm.v1.worker.gpu import dp_utils
+from vllm.v1.worker.gpu.spec_decode.eagle.speculator import EagleSpeculator
 from vllm.v1.worker.gpu.spec_decode.mtp.speculator import MTPSpeculator
 
 from vllm_ascend.worker.v2.input_batch import AscendInputBatch
 from vllm_ascend.worker.v2.spec_decode.autoregressive import (
     speculator as speculator_module,
 )
+from vllm_ascend.worker.v2.spec_decode.eagle.speculator import AscendEagleSpeculator
 from vllm_ascend.worker.v2.spec_decode.mtp.speculator import (
     AscendMTPSpeculator,
 )
@@ -322,25 +326,56 @@ def test_graph_prefill_builds_draft_metadata(replicated_pcp: bool) -> None:
     )
 
 
-def test_propose_disables_target_pcp_manager_for_replicated_draft() -> None:
-    speculator = object.__new__(AscendMTPSpeculator)
-    speculator.replicated_pcp = True
+@pytest.mark.parametrize(
+    ("speculator_cls", "parent_cls"),
+    [(AscendMTPSpeculator, MTPSpeculator), (AscendEagleSpeculator, EagleSpeculator)],
+)
+@pytest.mark.parametrize("replicated_pcp", [False, True])
+@pytest.mark.parametrize("batch_kind", ["prefill", "decode", "idle"])
+def test_propose_sync_follows_draft_token_layout(speculator_cls, parent_cls, replicated_pcp, batch_kind) -> None:
+    speculator = object.__new__(speculator_cls)
+    speculator.replicated_pcp = replicated_pcp
     speculator.input_batch = None
     speculator.pcp_manager = MagicMock()
     speculator.model_state = SimpleNamespace(
         pcp_manager=speculator.pcp_manager,
     )
     input_batch = _make_padded_input_batch()
+    input_batch.has_prefill = batch_kind == "prefill"
+    input_batch.is_dummy = batch_kind == "idle"
+    if batch_kind != "prefill":
+        input_batch.num_tokens_after_padding = 2
+    num_tokens = input_batch.num_tokens_after_padding
+    target_num_tokens = num_tokens // 2 if replicated_pcp and input_batch.has_prefill else num_tokens
+    target_sync = SimpleNamespace(
+        eager=True,
+        uniform_token_count=None,
+        num_tokens_across_dp=torch.tensor([target_num_tokens, target_num_tokens]),
+    )
     expected = object()
 
     def parent_propose(*args, **kwargs):
         assert args[0] is input_batch
-        assert speculator.model_state.pcp_manager is None
+        assert (speculator.model_state.pcp_manager is None) is replicated_pcp
+        # Exercise upstream's real reuse checks; only the collective is mocked.
+        with patch.object(dp_utils, "sync_cudagraph_and_dp_padding") as sync:
+            sync.return_value = (SimpleNamespace(cg_mode=CUDAGraphMode.NONE), object())
+            dp_utils.dispatch_cg_and_sync_dp(
+                None,
+                input_batch.num_reqs,
+                num_tokens,
+                None,
+                dp_size=2,
+                dp_rank=0,
+                need_eager=True,
+                dp_sync=args[11],
+            )
+        assert sync.call_count == int(replicated_pcp)
         return expected
 
     with (
         patch.object(
-            MTPSpeculator,
+            parent_cls,
             "propose",
             side_effect=parent_propose,
         ),
@@ -358,6 +393,7 @@ def test_propose_disables_target_pcp_manager_for_replicated_draft() -> None:
         actual = speculator.propose(
             input_batch,
             *[MagicMock() for _ in range(10)],
+            dp_sync=target_sync,
         )
 
     assert actual is expected

--- a/tests/ut/worker/test_mtp_pcp_speculator_v2.py
+++ b/tests/ut/worker/test_mtp_pcp_speculator_v2.py
@@ -326,6 +326,7 @@ def test_graph_prefill_builds_draft_metadata(replicated_pcp: bool) -> None:
     )
 
 
+@pytest.mark.skipif(speculator_module.vllm_version_is("0.28.0"), reason="DPSyncState is a main2main interface")
 @pytest.mark.parametrize(
     ("speculator_cls", "parent_cls", "replicated_pcp", "batch_kind"),
     [
@@ -403,3 +404,19 @@ def test_propose_sync_follows_draft_token_layout(speculator_cls, parent_cls, rep
     assert actual is expected
     assert speculator.input_batch is input_batch
     assert speculator.model_state.pcp_manager is speculator.pcp_manager
+
+
+def test_propose_preserves_v028_dp_token_counts() -> None:
+    speculator = object.__new__(AscendMTPSpeculator)
+    speculator.replicated_pcp = True
+    input_batch = object()
+    token_counts = torch.tensor([4, 8])
+    with (
+        patch.object(speculator_module, "vllm_version_is", return_value=True),
+        patch.object(speculator_module, "disable_target_pcp_for_replicated_draft", return_value=nullcontext()),
+        patch.object(speculator_module, "build_attn_metadata_wrapper", return_value=nullcontext()),
+        patch.object(speculator_module, "torch_gather_wrapper", return_value=nullcontext()),
+        patch.object(MTPSpeculator, "propose") as parent,
+    ):
+        speculator.propose(input_batch, *[MagicMock() for _ in range(10)], token_counts, dp_sync=object())
+    assert parent.call_args.args[11] is token_counts

--- a/tests/ut/worker/test_pcp_manager_v2.py
+++ b/tests/ut/worker/test_pcp_manager_v2.py
@@ -61,12 +61,14 @@ def _make_pcp_config(
     *,
     sparse_mla: bool = True,
     pipeline_parallel_size: int = 1,
+    data_parallel_size: int = 1,
 ):
     hf_text_config = SimpleNamespace(index_topk=2048) if sparse_mla else SimpleNamespace()
     return SimpleNamespace(
         parallel_config=SimpleNamespace(
             prefill_context_parallel_size=2,
             pipeline_parallel_size=pipeline_parallel_size,
+            data_parallel_size=data_parallel_size,
         ),
         model_config=SimpleNamespace(
             use_mla=True,
@@ -980,3 +982,68 @@ def test_partition_batch_clears_padded_dcp_local_seq_lens() -> None:
         result.dcp_local_seq_lens,
         torch.tensor([4, 5, 0, 0, 0, 0, 0, 0], dtype=torch.int32),
     )
+
+
+@pytest.mark.parametrize("sparse_mla", [False, True])
+@pytest.mark.parametrize("cudagraph_mode", list(CUDAGraphMode))
+def test_validate_config_pcp_dp_graph_modes(sparse_mla, cudagraph_mode):
+    config = _make_pcp_config(cudagraph_mode, sparse_mla=sparse_mla, data_parallel_size=2)
+    if cudagraph_mode in (CUDAGraphMode.NONE, CUDAGraphMode.FULL_DECODE_ONLY):
+        AscendPCPManager.validate_config(config, supports_mm_inputs=False)
+    else:
+        with pytest.raises(NotImplementedError, match=r"PCP\+DP supports eager mode or FULL_DECODE_ONLY"):
+            AscendPCPManager.validate_config(config, supports_mm_inputs=False)
+
+
+@pytest.mark.parametrize(
+    "pcp_size,scheduled,prefilling,expected",
+    [
+        (2, [80, 48], [True, True], 64),
+        (2, [18], [True], 10),
+        (2, [18, 1], [True, False], 11),
+        (4, [18, 3], [True, False], 9),
+        (4, [1], [True], 1),
+        (2, [1, 3], [False, False], 4),
+    ],
+)
+def test_dispatch_size_accounts_for_pcp_padding_and_replicated_decode(pcp_size, scheduled, prefilling, expected):
+    manager = AscendPCPManager(pcp_size, 0, torch.device("cpu"))
+    scheduled = np.array(scheduled, dtype=np.int32)
+    original = scheduled.copy()
+
+    actual = manager.get_num_tokens_for_dispatch(scheduled, np.array(prefilling))
+
+    assert actual == expected
+    np.testing.assert_array_equal(scheduled, original)
+    assert manager._global_batch is None
+    assert manager._padded_gather_idx is None
+    assert manager._hidden_restore_idx is None
+
+
+@pytest.mark.parametrize("pcp_rank", [0, 1])
+@pytest.mark.parametrize("has_stale_batch", [False, True])
+def test_dummy_attention_context_uses_current_batch(pcp_rank, has_stale_batch):
+    manager = AscendPCPManager(2, pcp_rank, torch.device("cpu"))
+    saved_batch = _make_global_pcp_batch() if has_stale_batch else None
+    manager._global_batch = saved_batch
+    manager._hidden_restore_idx = torch.tensor([99]) if has_stale_batch else None
+    saved_indices = manager._hidden_restore_idx
+    manager._block_tables = SimpleNamespace(gather_block_tables=MagicMock())
+    manager._global_batch_slot_mappings = torch.full((2, 32), 99, dtype=torch.int64)
+    dummy = _make_local_pcp_batch()
+    dummy.is_dummy = True
+    dummy.num_tokens = 4  # Exercise padding: the layout stride must still be 6.
+    block_tables = (torch.zeros((2, 1), dtype=torch.int32),) * 2
+    slot_mappings = torch.arange(24, dtype=torch.int64).reshape(2, 12)
+
+    context = manager.build_attention_context(dummy, block_tables, slot_mappings)
+
+    assert context.global_batch is dummy
+    assert context.global_block_tables is block_tables
+    start = pcp_rank * 6
+    torch.testing.assert_close(context.global_slot_mappings, slot_mappings[:, start : start + 6])
+    gathered_hidden = torch.arange(12).reshape(12, 1)
+    torch.testing.assert_close(gathered_hidden[context.hidden_restore_idx], gathered_hidden[start : start + 6])
+    assert manager._global_batch is saved_batch
+    assert manager._hidden_restore_idx is saved_indices
+    manager._block_tables.gather_block_tables.assert_not_called()

--- a/tests/ut/worker/test_pcp_manager_v2.py
+++ b/tests/ut/worker/test_pcp_manager_v2.py
@@ -984,40 +984,22 @@ def test_partition_batch_clears_padded_dcp_local_seq_lens() -> None:
     )
 
 
-@pytest.mark.parametrize("sparse_mla", [False, True])
-@pytest.mark.parametrize("cudagraph_mode", list(CUDAGraphMode))
-def test_validate_config_pcp_dp_graph_modes(sparse_mla, cudagraph_mode):
-    config = _make_pcp_config(cudagraph_mode, sparse_mla=sparse_mla, data_parallel_size=2)
-    if cudagraph_mode in (CUDAGraphMode.NONE, CUDAGraphMode.FULL_DECODE_ONLY):
+@pytest.mark.parametrize(
+    "dp_size,cudagraph_mode,allowed",
+    [
+        (2, CUDAGraphMode.NONE, True),
+        (2, CUDAGraphMode.FULL_DECODE_ONLY, True),
+        (2, CUDAGraphMode.PIECEWISE, False),
+        (1, CUDAGraphMode.PIECEWISE, True),
+    ],
+)
+def test_validate_config_pcp_dp_graph_modes(dp_size, cudagraph_mode, allowed):
+    config = _make_pcp_config(cudagraph_mode, sparse_mla=False, data_parallel_size=dp_size)
+    if allowed:
         AscendPCPManager.validate_config(config, supports_mm_inputs=False)
     else:
         with pytest.raises(NotImplementedError, match=r"PCP\+DP supports eager mode or FULL_DECODE_ONLY"):
             AscendPCPManager.validate_config(config, supports_mm_inputs=False)
-
-
-@pytest.mark.parametrize(
-    "pcp_size,scheduled,prefilling,expected",
-    [
-        (2, [80, 48], [True, True], 64),
-        (2, [18], [True], 10),
-        (2, [18, 1], [True, False], 11),
-        (4, [18, 3], [True, False], 9),
-        (4, [1], [True], 1),
-        (2, [1, 3], [False, False], 4),
-    ],
-)
-def test_dispatch_size_accounts_for_pcp_padding_and_replicated_decode(pcp_size, scheduled, prefilling, expected):
-    manager = AscendPCPManager(pcp_size, 0, torch.device("cpu"))
-    scheduled = np.array(scheduled, dtype=np.int32)
-    original = scheduled.copy()
-
-    actual = manager.get_num_tokens_for_dispatch(scheduled, np.array(prefilling))
-
-    assert actual == expected
-    np.testing.assert_array_equal(scheduled, original)
-    assert manager._global_batch is None
-    assert manager._padded_gather_idx is None
-    assert manager._hidden_restore_idx is None
 
 
 @pytest.mark.parametrize("pcp_rank", [0, 1])

--- a/vllm_ascend/worker/v2/model_runner.py
+++ b/vllm_ascend/worker/v2/model_runner.py
@@ -534,6 +534,11 @@ class NPUModelRunner(GPUModelRunner):
 
         return input_batch
 
+    def prepare_dummy_attn(self, input_batch: AscendInputBatch) -> tuple[tuple[torch.Tensor, ...], torch.Tensor]:
+        if self.pcp_manager is None:
+            return super().prepare_dummy_attn(input_batch)
+        return self.pcp_manager.prepare_dummy_attn(input_batch)
+
     def _lmhead_tp_max_num_logits(self) -> int:
         """Logits row capacity shared by every rank of the lmhead-TP group.
 

--- a/vllm_ascend/worker/v2/model_states/default.py
+++ b/vllm_ascend/worker/v2/model_states/default.py
@@ -68,7 +68,11 @@ class AscendModelState(DefaultModelState):
         query_start_loc_cpu = torch.from_numpy(input_batch.query_start_loc_np)
         is_prefilling = torch.from_numpy(input_batch.is_prefilling_np)
         max_query_len = input_batch.num_scheduled_tokens.max().item()
-        pcp_context = self.pcp_manager.build_attention_context(input_batch) if self.pcp_manager is not None else None
+        pcp_context = (
+            self.pcp_manager.build_attention_context(input_batch, block_tables, slot_mappings)
+            if self.pcp_manager is not None
+            else None
+        )
         # attn_metadata is needed when update_full_graph_params, but no way can get it now.
         # Temporarily store it in model_state.
         self.attn_metadata = build_attn_metadata(

--- a/vllm_ascend/worker/v2/pcp_manager.py
+++ b/vllm_ascend/worker/v2/pcp_manager.py
@@ -133,6 +133,11 @@ class AscendPCPManager(PCPManager):
                 )
         is_sparse_mla = hasattr(model_config.hf_text_config, "index_topk")
         cudagraph_mode = vllm_config.compilation_config.cudagraph_mode
+        if parallel_config.data_parallel_size > 1 and cudagraph_mode not in {
+            CUDAGraphMode.NONE,
+            CUDAGraphMode.FULL_DECODE_ONLY,
+        }:
+            raise NotImplementedError("MRV2 PCP+DP supports eager mode or FULL_DECODE_ONLY CUDA graphs only.")
         if is_sparse_mla and cudagraph_mode not in {
             CUDAGraphMode.NONE,
             CUDAGraphMode.FULL_DECODE_ONLY,
@@ -354,6 +359,22 @@ class AscendPCPManager(PCPManager):
         restored_hidden_states = self.restore_hidden_states(hidden_states[:local_num_tokens_padded])
         hidden_states[: restored_hidden_states.shape[0]].copy_(restored_hidden_states)
 
+    def prepare_dummy_attn(self, input_batch: AscendInputBatch) -> tuple[tuple[torch.Tensor, ...], torch.Tensor]:
+        # Runtime dummy inputs use the runner buffers, whereas FULL graphs
+        # capture PCP-local storage. Refresh that storage after a real batch.
+        input_buffers = self.input_buffers
+        num_tokens = input_batch.num_tokens_after_padding
+        num_reqs = input_batch.num_reqs_after_padding
+        for name in ("input_ids", "positions", "is_padding"):
+            getattr(input_buffers, name)[:num_tokens].copy_(getattr(input_batch, name))
+        input_buffers.query_start_loc[: num_reqs + 1].copy_(input_batch.query_start_loc)
+        input_buffers.seq_lens[:num_reqs].copy_(input_batch.seq_lens)
+        input_buffers.seq_lens_np[:num_reqs] = input_batch.seq_lens_np[:num_reqs]
+        return (
+            self.get_dummy_block_tables(num_reqs),
+            self.get_dummy_slot_mappings(num_tokens),
+        )
+
     def get_dummy_block_tables(self, num_reqs: int) -> tuple[torch.Tensor, ...]:
         """Return capture views backed by the persistent PCP-local tables.
 
@@ -415,34 +436,33 @@ class AscendPCPManager(PCPManager):
 
     def build_attention_context(
         self,
-        capture_batch: AscendInputBatch | None = None,
+        input_batch: AscendInputBatch | None = None,
+        block_tables: tuple[torch.Tensor, ...] | None = None,
+        slot_mappings: torch.Tensor | None = None,
     ) -> AscendPCPAttentionContext:
-        """Build the PCP context consumed by attention metadata builders.
-
-        At runtime the global batch partitioned by ``partition_batch`` is the
-        authoritative view. Graph capture (vLLM #53869) never partitions a
-        batch, so callers pass the capture-only dummy batch laid out on the
-        same persistent input buffers.
-        """
-        global_batch = self._global_batch
-        if global_batch is None:
-            global_batch = capture_batch
-        assert global_batch is not None
-        # Only duck-typed attributes are consumed downstream, so callers may
-        # pass batch stand-ins (e.g. UT SimpleNamespace or the capture dummy).
-        hidden_restore_idx = self._hidden_restore_idx
-        if hidden_restore_idx is None:
-            # Graph capture (vLLM #53515/#53869) never partitions a batch, so
-            # _build_batch_layout did not fill _hidden_restore_idx. Runtime
-            # prepare_attn rebuilds this metadata every step, so an identity
-            # placeholder is sufficient for the capture-only context.
-            hidden_restore_idx = torch.arange(
-                global_batch.num_tokens_after_padding,
-                dtype=torch.int64,
-                device=self.device,
+        """Build PCP context for the current real, capture, or idle DP batch."""
+        if input_batch is not None and input_batch.is_dummy:
+            # Both capture and runtime dummy batches bypass partition_batch().
+            # Saved layout state may be absent or belong to a previous request.
+            assert block_tables is not None
+            assert slot_mappings is not None
+            num_tokens = input_batch.num_tokens_after_padding
+            restore_start = self.pcp_rank * num_tokens
+            return AscendPCPAttentionContext(
+                global_batch=input_batch,
+                global_block_tables=block_tables,
+                global_slot_mappings=slot_mappings.view(slot_mappings.shape[0], self.pcp_world_size, num_tokens)[
+                    :, self.pcp_rank
+                ],
+                hidden_restore_idx=torch.arange(restore_start, restore_start + num_tokens, device=self.device),
             )
+
+        global_batch = self._global_batch
+        hidden_restore_idx = self._hidden_restore_idx
+        assert global_batch is not None
         assert self._block_tables is not None
         assert self._global_batch_slot_mappings is not None
+        assert hidden_restore_idx is not None
         return AscendPCPAttentionContext(
             global_batch=global_batch,
             global_block_tables=self._block_tables.gather_block_tables(

--- a/vllm_ascend/worker/v2/pcp_manager.py
+++ b/vllm_ascend/worker/v2/pcp_manager.py
@@ -359,6 +359,10 @@ class AscendPCPManager(PCPManager):
         restored_hidden_states = self.restore_hidden_states(hidden_states[:local_num_tokens_padded])
         hidden_states[: restored_hidden_states.shape[0]].copy_(restored_hidden_states)
 
+    # TODO(wzx0726): Once the paired vLLM includes https://github.com/vllm-project/vllm/pull/53867,
+    # adapt its PCP prepare_inputs_to_capture path to create AscendInputBatch
+    # directly in persistent PCP buffers, then remove this method and the
+    # NPUModelRunner.prepare_dummy_attn override after capture/idle replay validation.
     def prepare_dummy_attn(self, input_batch: AscendInputBatch) -> tuple[tuple[torch.Tensor, ...], torch.Tensor]:
         # Runtime dummy inputs use the runner buffers, whereas FULL graphs
         # capture PCP-local storage. Refresh that storage after a real batch.

--- a/vllm_ascend/worker/v2/spec_decode/autoregressive/speculator.py
+++ b/vllm_ascend/worker/v2/spec_decode/autoregressive/speculator.py
@@ -255,7 +255,12 @@ class AscendAutoRegressiveSpeculator(AutoRegressiveSpeculator):
         generate_draft.
         """
         self.input_batch = input_batch
-        sync_state = num_tokens_across_dp if vllm_version_is("0.28.0") else dp_sync
+        if vllm_version_is("0.28.0"):
+            sync_state = num_tokens_across_dp
+        else:
+            # Replicated drafts use global tokens, unlike the PCP-local target.
+            # Every DP rank must take the draft sync, including decode and idle ranks.
+            sync_state = None if self.replicated_pcp else dp_sync
         # wrap build_attn_metadata to use Ascend attention metadata building.
         # so we can call super().propose() directly.
         with (


### PR DESCRIPTION
### What this PR does / why we need it?

Add Ascend MRV2 handling for PCP combined with DP, reusing the upstream PCP dispatch sizing and input partitioning paths.

When a DP replica becomes idle, its dummy batch bypasses PCP partitioning. Saved PCP attention state may be absent or belong to the preceding real batch. Runtime dummy inputs use runner buffers, while decode graphs capture persistent PCP buffers.

- Build dummy PCP attention contexts from the current batch, block tables and rank-local slot mappings, including the DSA metadata path.
- Refresh persistent PCP buffers before dummy execution. Keep the implementation in `AscendPCPManager`; `NPUModelRunner.prepare_dummy_attn` delegates or takes the existing non-PCP path.
- Synchronize replicated speculative drafts independently of the target's PCP-local DP state, with every DP replica participating, including idle and decode replicas.
- Restrict PCP+DP graph configuration to eager or `FULL_DECODE_ONLY`.

Upstream validation dependency: https://github.com/vllm-project/vllm/pull/54523, merged as [7c2f1ff4958eaf0818405e9192c71608fe4a16b1](https://github.com/vllm-project/vllm/commit/7c2f1ff4958eaf0818405e9192c71608fe4a16b1), moves the PCP+DP restriction from common `ParallelConfig` validation to CUDA/ROCm platform checks. This PR relies on that change and contains no Ascend validator bypass or Pydantic schema rebuilding.

Related upstream PR: https://github.com/vllm-project/vllm/pull/53867 ([Feature][PCP] Support decode-only FULL CUDA graphs).

Once the paired vLLM includes #53867, adapt its PCP `prepare_inputs_to_capture` entry point to create `AscendInputBatch` directly in persistent PCP buffers. After capture and real-to-idle replay validation, remove `AscendPCPManager.prepare_dummy_attn` and the runner override, as tracked by `TODO(wzx0726)`. The Ascend dummy attention-context handling and replicated-draft DP synchronization remain necessary.

### Does this PR introduce _any_ user-facing change?

Adds Ascend-side MRV2 handling for PCP combined with DP. No new CLI options or environment variables are introduced.

Rebased onto Ascend main `ad86348b0cb2324d643df6a496f2d9c3879e4481`. The draft conflict resolution preserves vLLM 0.28.0 `num_tokens_across_dp` forwarding and applies fresh synchronization for replicated drafts on the main2main `dp_sync` interface.

**Compatibility and remaining validation:**

- The previously tested baseline was Ascend `b1c91857c16bde10c2fa7f5d7548b7666a86d4bb` with vLLM `e6bfe03ad73a3330cb427885aa90d97a12e1c704`.
- Removing the validator bypass requires vLLM #54523. Ascend main currently pins `b2f685834a6456197e7033966fdef52a23f1abcd`, which predates that change and still rejects PCP+DP. The local vLLM checkout remains at the user-selected `7c2f1ff4958eaf0818405e9192c71608fe4a16b1`. This PR does not change the main2main pin or reintroduce the bypass.
- Compatibility work against that newer revision is still pending, including the added `prepare_dummy_attn` argument and removal of `InputBatch.max_seq_len_np`. The current branch is not yet validated to run against that revision.
- Multi-card Attention/MLA/DSA inference, real-to-idle DP transitions during `FULL_DECODE_ONLY` replay, speculative-decoding numerical correctness, and EP/TP combinations require model-level validation on the final paired sources.

### How was this patch tested?

The latest rebase onto `ad86348b0` resolves an append-location conflict in `test_pcp_manager_v2.py`, retaining both the main DCP padding regression and this PR's tests. AST comparison confirms that all main tests and the final PR tests are preserved, and the other changed files match the automatic merge. Ruff lint/format, syntax parsing, and `git diff --check` passed. Runtime tests were not rerun for this conflict-only update.

For the preceding rebase onto `f8481287a`, **6 targeted candidate-method cases passed** in an isolated process in the Ascend container: five main2main draft-sync cases and one mocked v0.28.0 argument-routing case. The exact candidate `propose` method was loaded into the installed runtime classes; native dependencies and the rest of the runtime remained at their installed versions. This is method-level regression evidence, not full rebased-source or dual-version runtime validation.

All eight changed Python files passed Ruff lint/format checks, syntax parsing, and `git diff --check`. Full unit-suite and model validation on the final paired sources remain pending.

The runtime adaptation suite previously passed on the earlier baseline in an isolated Ascend-container test directory, using CPU tensors and mocks for device kernels:

```bash
python3 -m pytest -q tests/ut/worker/test_pcp_manager_v2.py tests/ut/worker/test_model_runner_v2.py tests/ut/worker/test_attn_utils_v2.py tests/ut/worker/test_mtp_pcp_speculator_v2.py
```

- **75 passed** (14 existing `torch.jit` deprecation warnings). This is prior-baseline evidence, not a test result for vLLM `7c2f1ff`.
- Covers missing/stale dummy PCP state, rank-local mappings, persistent buffer contents and storage, DSA metadata forwarding, non-PCP fallback, graph restrictions, and replicated draft DP synchronization.
- The removed validator bypass's dedicated tests are also removed; the existing unrelated platform test is retained.
- For the removal, targeted Ruff lint/format checks, Python syntax checks and `git diff --check` passed. No runtime tests were rerun against the upgraded vLLM. The local `format.sh ci` entry point remains unavailable because its shell lacks `pre-commit`.

- vLLM main: https://github.com/vllm-project/vllm/commit/b2f685834a6456197e7033966fdef52a23f1abcd
