### PR TITLE
[v0.27.1rc][Performance][MoE] Overlap shared-expert collectives and routed projections

### DIFF
--- a/.github/workflows/pr_test.yaml
+++ b/.github/workflows/pr_test.yaml
@@ -46,7 +46,7 @@ jobs:
     container:
       image: quay.io/ascend-ci/vllm-ascend:lint
     outputs:
-      main_commit: ${{ steps.vllm.outputs.main_commit }}
+      release_tag: ${{ steps.vllm.outputs.release_tag }}
     steps:
       - name: Validate PR title prefix
         run: |
@@ -84,11 +84,13 @@ jobs:
         id: vllm
         run: |
           main_commit="$(tr -d '[:space:]' < .github/vllm-main-verified.commit)"
+          release_tag="$(tr -d '[:space:]' < .github/vllm-release-tag.commit)"
           [[ "${main_commit}" =~ ^[0-9a-f]{7,40}$ ]] || {
             echo "::error file=.github/vllm-main-verified.commit::invalid vLLM main commit: ${main_commit}"
             exit 1
           }
           echo "main_commit=${main_commit}" >> "$GITHUB_OUTPUT"
+          echo "release_tag=${release_tag}" >> "$GITHUB_OUTPUT"
 
       - name: cp problem matchers
         run: |
@@ -516,7 +518,7 @@ jobs:
       fail-fast: false
       matrix:
         vllm_version:
-          - ${{ needs.pre-commit.outputs.main_commit }}
+          - ${{ needs.pre-commit.outputs.release_tag }}
     uses: ./.github/workflows/_selected_tests.yaml
     with:
       vllm: ${{ matrix.vllm_version }}
@@ -543,7 +545,7 @@ jobs:
     strategy:
       matrix:
         vllm_version:
-          - ${{ needs.pre-commit.outputs.main_commit }}
+          - ${{ needs.pre-commit.outputs.release_tag }}
     uses: ./.github/workflows/_selected_tests_upstream.yaml
     with:
       vllm: ${{ matrix.vllm_version }}
@@ -567,7 +569,7 @@ jobs:
     strategy:
       matrix:
         vllm_version:
-          - ${{ needs.pre-commit.outputs.main_commit }}
+          - ${{ needs.pre-commit.outputs.release_tag }}
     uses: ./.github/workflows/_selected_tests.yaml
     with:
       vllm: ${{ matrix.vllm_version }}

--- a/tests/e2e/pull_request/eight_card/model_runner_v2/test_glm5_2.py
+++ b/tests/e2e/pull_request/eight_card/model_runner_v2/test_glm5_2.py
@@ -26,7 +26,7 @@ from tests.e2e.pull_request.utils import _run_speculative_decoding
 MODEL = "Eco-Tech/GLM-5.2-w4a8"
 DRAFT_MODEL = "RedHatAI/GLM-5.2-speculator.dspark"
 EXPECTED_ACCEPTANCE_LENGTH = 3.0
-DSPARK_EXPECTED_ACCEPTANCE_LENGTH = 3.85
+DSPARK_EXPECTED_ACCEPTANCE_LENGTH = 3.5
 
 
 @pytest.mark.e2e_model(MODEL)
@@ -104,5 +104,5 @@ def test_glm5_2_dspark_eager() -> None:
             "enable_prefix_caching": False,
             "async_scheduling": False,
         },
-        acceptance_length_rtol=0.1,
+        acceptance_length_rtol=0.11,
     )

--- a/tests/e2e/pull_request/eight_card/model_runner_v2/test_glm5_2.py
+++ b/tests/e2e/pull_request/eight_card/model_runner_v2/test_glm5_2.py
@@ -26,7 +26,7 @@ from tests.e2e.pull_request.utils import _run_speculative_decoding
 MODEL = "Eco-Tech/GLM-5.2-w4a8"
 DRAFT_MODEL = "RedHatAI/GLM-5.2-speculator.dspark"
 EXPECTED_ACCEPTANCE_LENGTH = 3.0
-DSPARK_EXPECTED_ACCEPTANCE_LENGTH = 3.5
+DSPARK_EXPECTED_ACCEPTANCE_LENGTH = 3.85
 
 
 @pytest.mark.e2e_model(MODEL)

--- a/tests/ut/_310p/fused_moe/test_shared_fused_moe_310.py
+++ b/tests/ut/_310p/fused_moe/test_shared_fused_moe_310.py
@@ -21,6 +21,8 @@ from vllm_ascend.ops.fused_moe.shared_experts import AscendSharedExperts, FusedM
 def _build_runner() -> AscendMoERunner310:
     runner = AscendMoERunner310.__new__(AscendMoERunner310)
     nn.Module.__init__(runner)
+    runner.routed_input_transform = None
+    runner.routed_output_transform = None
     return runner
 
 
@@ -101,6 +103,8 @@ def test_runner_310_installs_specialized_comm():
     runner.gate = None
     routed_experts = SimpleNamespace(quant_config=None, quant_method=None)
     runner.ascend_shared_experts = SimpleNamespace(multistream_overlap=True)
+    upstream_forward_entry = object()
+    runner._select_forward = MagicMock(return_value=upstream_forward_entry)
     comm_method = object()
 
     with (
@@ -118,6 +122,8 @@ def test_runner_310_installs_specialized_comm():
 
         assert routed_experts.quant_method is None
         assert runner.ascend_shared_experts.multistream_overlap is False
+        assert runner._forward_entry is upstream_forward_entry
+        runner._select_forward.assert_called_once_with()
         assert fused_moe_310_module._MoECommMethods[MoECommType.ALLGATHER] is comm_method
         parent_init.assert_called_once()
 
@@ -230,7 +236,8 @@ def test_forward_impl_310_returns_current_runner_contract(monkeypatch, has_share
     routed_out = torch.randn(2, 4)
     shared_out = torch.randn(2, 4)
     ascend_shared_experts = SimpleNamespace(
-        prepare_input_before_routed_experts=MagicMock(return_value=(hidden_states, None)),
+        multistream_overlap=False,
+        local_input_from_gathered=MagicMock(return_value=hidden_states),
         forward=MagicMock(return_value=shared_out),
     )
     routed_events = FusedMoEEvents(

--- a/tests/ut/models/test_kimi_k3_adapter.py
+++ b/tests/ut/models/test_kimi_k3_adapter.py
@@ -2,7 +2,7 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
 from types import MethodType, SimpleNamespace
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import torch
 from safetensors.torch import save_file
@@ -16,6 +16,24 @@ from vllm_ascend.models.kimi_k3 import (
 from vllm_ascend.models.kimi_k3_dspark import (
     AscendK3DSparkForCausalLM,
 )
+
+
+def test_kimi_moe_leaves_routed_input_transform_to_runner():
+    moe = kimi_k3.AscendKimiMoE.__new__(kimi_k3.AscendKimiMoE)
+    nn.Module.__init__(moe)
+    hidden_states = torch.randn(4, 8)
+    router_logits = torch.randn(4, 16)
+    output = torch.randn(4, 8)
+    moe.gate = MagicMock(return_value=(router_logits, None))
+    moe.experts = MagicMock(return_value=output)
+
+    result = moe.forward(hidden_states)
+
+    moe.experts.assert_called_once()
+    call_kwargs = moe.experts.call_args.kwargs
+    torch.testing.assert_close(call_kwargs["hidden_states"], hidden_states)
+    torch.testing.assert_close(call_kwargs["router_logits"], router_logits)
+    torch.testing.assert_close(result, output)
 
 
 def test_ascend_attn_res_matches_canonical_k3_math():

--- a/tests/ut/ops/test_fused_moe.py
+++ b/tests/ut/ops/test_fused_moe.py
@@ -11,6 +11,7 @@ from vllm.config import VllmConfig, set_current_vllm_config
 from vllm.model_executor.layers.activation import SituAndMul
 
 from vllm_ascend.ascend_forward_context import MoECommType
+from vllm_ascend.device.hardware import AscendDeviceType
 from vllm_ascend.ops.fused_moe import fused_moe as fused_moe_module
 from vllm_ascend.ops.fused_moe import routed_experts as routed_experts_module
 from vllm_ascend.ops.fused_moe import shared_experts as shared_experts_module
@@ -977,6 +978,125 @@ def test_w4a8_mxfp_shared_situ_uses_situ_mx_quant(monkeypatch):
 
 
 @pytest.mark.parametrize(
+    "device_type",
+    [
+        AscendDeviceType.A3,
+        AscendDeviceType.A5,
+    ],
+)
+def test_k3_w4a8_mxfp_multistream_schedule_on_a3_and_a5(monkeypatch, device_type):
+    quantized_input = torch.ones(4, 4, dtype=torch.float8_e4m3fn)
+    input_scale = torch.ones(4, 1)
+    gate_up_out = torch.randn(4, 4, dtype=torch.bfloat16)
+    quantized_activation = torch.ones(4, 2, dtype=torch.float8_e4m3fn)
+    activation_scale = torch.ones(4, 1)
+    shared_out = torch.randn(4, 2, dtype=torch.bfloat16)
+    reduced_out = torch.randn(2, 2, dtype=torch.bfloat16)
+    operation_order = []
+
+    def gate_up(*_args):
+        operation_order.append("shared_gate_up")
+        return gate_up_out, None
+
+    def down(*_args):
+        operation_order.append("shared_down")
+        return shared_out, None
+
+    gate_up_proj = MagicMock(side_effect=gate_up)
+    gate_up_proj.weight_scale = torch.ones(1)
+    down_proj = MagicMock(side_effect=down)
+    down_proj.weight_scale = torch.ones(1)
+    shared_experts = _make_quantized_situ_shared_experts(QuantType.W4A8MXFP, gate_up_proj, down_proj)
+    shared_experts.multistream_overlap = True
+    shared_experts.parallel_mode = MagicMock(return_value=SharedExpertParallelMode.SEQUENCE_PARALLEL_ONLY)
+
+    events = FusedMoEEvents(
+        before_routed_experts=MagicMock(),
+        before_dispatch=MagicMock(),
+        before_gmm2=MagicMock(),
+        before_combine=MagicMock(),
+        after_routed_finalize=MagicMock(),
+    )
+    event_names = {
+        events.before_routed_experts: "before_routed_experts",
+        events.before_dispatch: "before_dispatch",
+        events.before_gmm2: "before_gmm2",
+        events.before_combine: "before_combine",
+        events.after_routed_finalize: "after_routed_finalize",
+    }
+    main_stream = MagicMock()
+    auxiliary_stream = MagicMock()
+    stream_state = {"current": main_stream}
+
+    @contextmanager
+    def switch_stream(stream, enabled):
+        previous_stream = stream_state["current"]
+        if enabled:
+            stream_state["current"] = stream
+        try:
+            yield
+        finally:
+            stream_state["current"] = previous_stream
+
+    def dynamic_quant(_states, **_kwargs):
+        operation_order.append("dynamic_quant")
+        return quantized_input, input_scale
+
+    def activation(**_kwargs):
+        operation_order.append("shared_activation")
+        return quantized_activation, activation_scale
+
+    def reduce_scatter(_states):
+        operation_order.append("reduce_scatter")
+        return reduced_out
+
+    auxiliary_stream.wait_event.side_effect = lambda event: operation_order.append(f"wait_{event_names[event]}")
+    shared_experts._pad_and_reduce_scatter = MagicMock(side_effect=reduce_scatter)
+    monkeypatch.setattr(shared_experts_module, "has_lora", lambda _: False)
+    if hasattr(shared_experts_module, "get_current_hardware_profile"):
+        monkeypatch.setattr(
+            shared_experts_module,
+            "get_current_hardware_profile",
+            lambda: SimpleNamespace(supports=lambda _: device_type == AscendDeviceType.A5),
+        )
+    else:
+        monkeypatch.setattr(shared_experts_module, "get_ascend_device_type", lambda: device_type)
+    monkeypatch.setattr(shared_experts_module, "npu_stream_switch", switch_stream)
+    monkeypatch.setattr(shared_experts_module, "shared_experts_calculation_stream", lambda: auxiliary_stream)
+    monkeypatch.setattr(shared_experts_module.torch.npu, "current_stream", lambda: stream_state["current"])
+    monkeypatch.setattr(shared_experts_module.torch_npu, "npu_dynamic_mx_quant", dynamic_quant, raising=False)
+    monkeypatch.setattr(
+        shared_experts_module.torch.ops,
+        "_C_ascend",
+        SimpleNamespace(situ_mx_quant=MagicMock(side_effect=activation)),
+    )
+
+    result = shared_experts.forward(
+        torch.randn(4, 4, dtype=torch.bfloat16),
+        events,
+        input_is_gathered=True,
+        defer_output_wait=True,
+    )
+
+    assert result is reduced_out
+    assert operation_order == [
+        "wait_before_routed_experts",
+        "dynamic_quant",
+        "wait_before_dispatch",
+        "shared_gate_up",
+        "wait_before_gmm2",
+        "shared_activation",
+        "wait_before_combine",
+        "shared_down",
+        "wait_after_routed_finalize",
+        "reduce_scatter",
+    ]
+    main_stream.wait_stream.assert_not_called()
+    shared_experts.wait_for_output()
+    main_stream.wait_stream.assert_called_once_with(auxiliary_stream)
+
+
+@pytest.mark.parametrize(
     (
         "weights_replicated",
         "native_sequence_parallel",
@@ -1086,9 +1206,10 @@ def test_sequence_parallel_only_gathers_unpads_pads_and_reduce_scatters(monkeypa
         (SharedExpertParallelMode.SEQUENCE_PARALLEL_ONLY, True, True),
         (SharedExpertParallelMode.SEQUENCE_PARALLEL_ONLY, False, False),
         (SharedExpertParallelMode.SEQUENCE_PARALLEL_SEDP, True, False),
+        (SharedExpertParallelMode.TENSOR_PARALLEL, True, False),
     ],
 )
-def test_prepare_shared_expert_input_only_starts_sp_tp_all_gather(
+def test_early_all_gather_only_runs_for_sp_with_tp_sharded_weights(
     monkeypatch,
     mode,
     multistream_overlap,
@@ -1099,14 +1220,14 @@ def test_prepare_shared_expert_input_only_starts_sp_tp_all_gather(
     shared_experts.parallel_mode = MagicMock(return_value=mode)
     hidden_states = torch.randn(2, 4)
     gathered_states = torch.randn(4, 4)
-    shared_experts._gather_sp_input = MagicMock(return_value=gathered_states)
-    default_stream = MagicMock()
+    all_gather = MagicMock(return_value=gathered_states)
+    main_stream = MagicMock()
     auxiliary_stream = MagicMock()
     input_ready = MagicMock()
     all_gather_done = MagicMock()
-    default_stream.record_event.return_value = input_ready
+    main_stream.record_event.return_value = input_ready
     auxiliary_stream.record_event.return_value = all_gather_done
-    stream_state = {"current": default_stream}
+    stream_state = {"current": main_stream}
 
     @contextmanager
     def switch_stream(stream, enabled):
@@ -1118,27 +1239,217 @@ def test_prepare_shared_expert_input_only_starts_sp_tp_all_gather(
         finally:
             stream_state["current"] = previous_stream
 
+    monkeypatch.setattr(shared_experts_module, "tensor_model_parallel_all_gather", all_gather)
     monkeypatch.setattr(shared_experts_module, "npu_stream_switch", switch_stream)
     monkeypatch.setattr(shared_experts_module, "shared_experts_calculation_stream", lambda: auxiliary_stream)
     monkeypatch.setattr(shared_experts_module.torch.npu, "current_stream", lambda: stream_state["current"])
 
-    result, done_event = shared_experts.prepare_input_before_routed_experts(hidden_states)
+    result, done_event = shared_experts.start_input_all_gather(hidden_states)
 
     if starts_all_gather:
         assert result is gathered_states
         assert done_event is all_gather_done
-        default_stream.record_event.assert_called_once_with()
+        main_stream.record_event.assert_called_once_with()
         auxiliary_stream.wait_event.assert_called_once_with(input_ready)
-        shared_experts._gather_sp_input.assert_called_once_with(hidden_states)
+        all_gather.assert_called_once_with(hidden_states, dim=0)
         auxiliary_stream.record_event.assert_called_once_with()
     else:
         assert result is hidden_states
         assert done_event is None
-        default_stream.record_event.assert_not_called()
-        shared_experts._gather_sp_input.assert_not_called()
+        main_stream.record_event.assert_not_called()
+        all_gather.assert_not_called()
 
 
-def test_sp_multistream_down_projection_and_reduce_scatter_wait_for_routed_finalize(
+@pytest.mark.parametrize("hidden_dim_unpadded", [0, 3])
+def test_sp_multistream_custom_op_fake_returns_local_token_shape(hidden_dim_unpadded):
+    routed_states = torch.randn(2, 4)
+    gathered_shared_states = torch.randn(8, 6)
+
+    shared_out, routed_out = fused_moe_module._ascend_moe_forward_shared_sp_fake(
+        routed_states,
+        router_logits=torch.randn(2, 4),
+        shared_experts_input=gathered_shared_states,
+        input_ids=None,
+        layer_name="layer",
+        hidden_dim_unpadded=hidden_dim_unpadded,
+    )
+
+    assert shared_out.shape == torch.Size([2, 6])
+    expected_routed_width = hidden_dim_unpadded or routed_states.shape[-1]
+    assert routed_out.shape == torch.Size([2, expected_routed_width])
+
+
+@pytest.mark.parametrize(
+    ("mode", "multistream_overlap", "has_routed_input_transform", "uses_sp_custom_op"),
+    [
+        (SharedExpertParallelMode.SEQUENCE_PARALLEL_ONLY, True, True, True),
+        (SharedExpertParallelMode.SEQUENCE_PARALLEL_ONLY, True, False, False),
+        (SharedExpertParallelMode.SEQUENCE_PARALLEL_ONLY, False, True, False),
+        (SharedExpertParallelMode.SEQUENCE_PARALLEL_SEDP, True, True, False),
+        (SharedExpertParallelMode.TENSOR_PARALLEL, True, True, False),
+    ],
+)
+def test_runner_selects_sp_multistream_custom_op(
+    monkeypatch,
+    mode,
+    multistream_overlap,
+    has_routed_input_transform,
+    uses_sp_custom_op,
+):
+    upstream_forward_entry = object()
+    moe_config = SimpleNamespace(hidden_dim=4, ep_size=1)
+    routed_experts = SimpleNamespace(
+        quant_type=QuantType.NONE,
+        quant_method=object(),
+        return_with_event=False,
+    )
+    shared_executor = SimpleNamespace(
+        multistream_overlap=multistream_overlap,
+        parallel_mode=MagicMock(return_value=mode),
+    )
+
+    def init_base_runner(
+        runner,
+        layer_name,
+        config,
+        _router,
+        experts,
+        _enable_dbo,
+        gate,
+        shared_experts,
+        _shared_expert_gate,
+        routed_input_transform,
+        routed_output_transform,
+        routed_scaling_factor,
+    ):
+        nn.Module.__init__(runner)
+        runner.layer_name = layer_name
+        runner.moe_config = config
+        runner.routed_experts = experts
+        runner._shared_experts = shared_experts
+        runner._gate = gate
+        runner.routed_input_transform = routed_input_transform
+        runner.routed_output_transform = routed_output_transform
+        runner.routed_scaling_factor = routed_scaling_factor
+        runner._forward_entry = upstream_forward_entry
+
+    monkeypatch.setattr(fused_moe_module.MoERunner, "__init__", init_base_runner)
+    monkeypatch.setattr(fused_moe_module, "AscendSharedExperts", MagicMock(return_value=shared_executor))
+    monkeypatch.setattr(fused_moe_module, "get_tp_group", MagicMock(return_value=object()))
+    monkeypatch.setattr(fused_moe_module, "get_dp_group", MagicMock(return_value=object()))
+    monkeypatch.setattr(fused_moe_module, "setup_moe_comm_method", MagicMock())
+    monkeypatch.setattr(fused_moe_module, "get_moe_comm_method", MagicMock(return_value=None))
+
+    runner = AscendMoERunner(
+        "model.layers.0.mlp",
+        moe_config,
+        router=object(),
+        routed_experts=routed_experts,
+        shared_experts=object(),
+        routed_input_transform=object() if has_routed_input_transform else None,
+    )
+
+    if uses_sp_custom_op:
+        assert runner._forward_entry is torch.ops.vllm.ascend_moe_forward_shared_sp
+    else:
+        assert runner._forward_entry is upstream_forward_entry
+
+
+def test_sp_multistream_all_gather_starts_before_routed_input_transform(monkeypatch):
+    runner = AscendMoERunner.__new__(AscendMoERunner)
+    hidden_states = torch.randn(4, 4)
+    gathered_states = torch.randn(8, 4)
+    routed_states = torch.randn(4, 2)
+    all_gather_done = MagicMock()
+    operation_order = []
+    current_stream = MagicMock()
+    current_stream.wait_event.side_effect = lambda event: operation_order.append("wait_all_gather")
+
+    def start_all_gather(states):
+        operation_order.append("all_gather")
+        assert states is hidden_states
+        return gathered_states, all_gather_done
+
+    def latent_down(states):
+        operation_order.append("latent_down")
+        assert states is hidden_states
+        return routed_states, None
+
+    runner.ascend_shared_experts = SimpleNamespace(
+        multistream_overlap=True,
+        parallel_mode=MagicMock(return_value=SharedExpertParallelMode.SEQUENCE_PARALLEL_ONLY),
+        start_input_all_gather=MagicMock(side_effect=start_all_gather),
+    )
+    runner.routed_input_transform = MagicMock(side_effect=latent_down)
+    monkeypatch.setattr(fused_moe_module.torch.npu, "current_stream", lambda: current_stream)
+
+    result, shared_input = runner.apply_routed_input_transform(hidden_states)
+
+    assert result is routed_states
+    assert shared_input is gathered_states
+    assert operation_order == ["all_gather", "latent_down", "wait_all_gather"]
+    current_stream.wait_event.assert_called_once_with(all_gather_done)
+
+
+def test_runner_without_routed_input_transform_keeps_original_shared_input_path():
+    runner = AscendMoERunner.__new__(AscendMoERunner)
+    hidden_states = torch.randn(4, 4)
+    runner._shared_experts = object()
+    runner.routed_input_transform = None
+    runner.ascend_shared_experts = SimpleNamespace(
+        multistream_overlap=True,
+        parallel_mode=MagicMock(return_value=SharedExpertParallelMode.SEQUENCE_PARALLEL_ONLY),
+        start_input_all_gather=MagicMock(),
+    )
+
+    routed_input, shared_input = runner.apply_routed_input_transform(hidden_states)
+
+    assert routed_input is hidden_states
+    assert shared_input is hidden_states
+    runner.ascend_shared_experts.start_input_all_gather.assert_not_called()
+
+
+def test_sp_multistream_reduce_scatter_overlaps_routed_output_transform():
+    runner = AscendMoERunner.__new__(AscendMoERunner)
+    latent_states = torch.randn(4, 2)
+    full_states = torch.randn(4, 4)
+    operation_order = []
+
+    def latent_up(states):
+        operation_order.append("latent_up")
+        assert states is latent_states
+        return full_states, None
+
+    runner.routed_output_transform = MagicMock(side_effect=latent_up)
+    runner.ascend_shared_experts = SimpleNamespace(
+        multistream_overlap=True,
+        parallel_mode=MagicMock(return_value=SharedExpertParallelMode.SEQUENCE_PARALLEL_ONLY),
+        wait_for_output=MagicMock(side_effect=lambda: operation_order.append("join_shared_output")),
+    )
+
+    result = runner.apply_routed_output_transform(latent_states)
+
+    assert result is full_states
+    assert operation_order == ["latent_up", "join_shared_output"]
+
+
+def test_runner_without_routed_output_transform_does_not_defer_shared_output_join():
+    runner = AscendMoERunner.__new__(AscendMoERunner)
+    fused_output = torch.randn(4, 4)
+    runner.routed_output_transform = None
+    runner.ascend_shared_experts = SimpleNamespace(
+        multistream_overlap=True,
+        parallel_mode=MagicMock(return_value=SharedExpertParallelMode.SEQUENCE_PARALLEL_ONLY),
+        wait_for_output=MagicMock(),
+    )
+
+    result = runner.apply_routed_output_transform(fused_output)
+
+    assert result is fused_output
+    runner.ascend_shared_experts.wait_for_output.assert_not_called()
+
+
+def test_sp_multistream_down_projection_overlaps_combine_and_reduce_scatter_waits_for_finalize(
     monkeypatch,
 ):
     shared_experts = AscendSharedExperts.__new__(AscendSharedExperts)
@@ -1154,10 +1465,20 @@ def test_sp_multistream_down_projection_and_reduce_scatter_wait_for_routed_final
     part1_out = torch.randn(4, 8)
     shared_out = torch.randn(4, 4)
     reduced_out = torch.randn(2, 4)
+    operation_order = []
     shared_experts.part1 = MagicMock(return_value=part1_out)
-    shared_experts.part2 = MagicMock(return_value=shared_out)
+
+    def run_down_projection(*_args):
+        operation_order.append("down_projection")
+        return shared_out
+
+    def run_reduce_scatter(*_args):
+        operation_order.append("reduce_scatter")
+        return reduced_out
+
+    shared_experts.part2 = MagicMock(side_effect=run_down_projection)
     shared_experts._gather_sp_input = MagicMock()
-    shared_experts._pad_and_reduce_scatter = MagicMock(return_value=reduced_out)
+    shared_experts._pad_and_reduce_scatter = MagicMock(side_effect=run_reduce_scatter)
     default_stream = MagicMock()
     auxiliary_stream = MagicMock()
     stream_state = {"current": default_stream}
@@ -1182,20 +1503,47 @@ def test_sp_multistream_down_projection_and_reduce_scatter_wait_for_routed_final
     monkeypatch.setattr(shared_experts_module, "shared_experts_calculation_stream", lambda: auxiliary_stream)
     monkeypatch.setattr(shared_experts_module.torch.npu, "current_stream", lambda: stream_state["current"])
 
+    def record_wait(event):
+        if event is events.before_combine:
+            operation_order.append("wait_before_combine")
+        elif event is events.after_routed_finalize:
+            operation_order.append("wait_after_routed_finalize")
+
+    auxiliary_stream.wait_event.side_effect = record_wait
+
     result = shared_experts.forward(
         hidden_states,
         events,
         input_is_gathered=True,
+        defer_output_wait=True,
     )
 
     assert result is reduced_out
     shared_experts._gather_sp_input.assert_not_called()
-    auxiliary_stream.wait_event.assert_any_call(events.after_routed_finalize)
-    assert not any(
-        event_wait.args == (events.before_combine,) for event_wait in auxiliary_stream.wait_event.call_args_list
-    )
+    wait_calls = auxiliary_stream.wait_event.call_args_list
+    assert wait_calls[-2].args[0] is events.before_combine
+    assert wait_calls[-1].args[0] is events.after_routed_finalize
+    assert operation_order == [
+        "wait_before_combine",
+        "down_projection",
+        "wait_after_routed_finalize",
+        "reduce_scatter",
+    ]
     shared_experts.part2.assert_called_once_with(hidden_states, part1_out)
     shared_experts._pad_and_reduce_scatter.assert_called_once_with(shared_out)
+    default_stream.wait_stream.assert_not_called()
+
+    shared_experts.wait_for_output()
+
+    default_stream.wait_stream.assert_called_once_with(auxiliary_stream)
+
+    default_stream.wait_stream.reset_mock()
+    shared_experts.forward(
+        hidden_states,
+        events,
+        input_is_gathered=True,
+        defer_output_wait=False,
+    )
     default_stream.wait_stream.assert_called_once_with(auxiliary_stream)
 
 
@@ -1299,13 +1647,15 @@ def test_set_lora_context_updates_experts(has_shared_experts):
 def test_forward_impl_returns_current_runner_contract(monkeypatch, has_shared_experts):
     runner = AscendMoERunner.__new__(AscendMoERunner)
     nn.Module.__init__(runner)
+    runner.routed_input_transform = None
+    runner.routed_output_transform = None
     hidden_states = torch.randn(2, 4)
     router_logits = torch.randn(2, 3)
     input_ids = torch.tensor([11, 22])
     routed_out = torch.randn(2, 4)
     shared_out = torch.randn(2, 4)
     ascend_shared_experts = SimpleNamespace(
-        prepare_input_before_routed_experts=MagicMock(return_value=(hidden_states, None)),
+        multistream_overlap=False,
         forward=MagicMock(return_value=shared_out),
     )
     routed_events = FusedMoEEvents(
@@ -1333,7 +1683,6 @@ def test_forward_impl_returns_current_runner_contract(monkeypatch, has_shared_ex
     )
 
     if has_shared_experts:
-        ascend_shared_experts.prepare_input_before_routed_experts.assert_called_once_with(hidden_states)
         runner.routed_experts.forward_impl.assert_called_once_with(
             hidden_states=hidden_states,
             router_logits=router_logits,
@@ -1356,7 +1705,7 @@ def test_forward_impl_keeps_full_width_input_for_shared_experts(monkeypatch):
     runner = AscendMoERunner.__new__(AscendMoERunner)
     nn.Module.__init__(runner)
     routed_hidden_states = torch.randn(2, 4)
-    shared_hidden_states = torch.randn(2, 8)
+    shared_hidden_states = torch.randn(4, 8)
     router_logits = torch.randn(2, 3)
     routed_out = torch.randn(2, 4)
     shared_out = torch.randn(2, 8)
@@ -1368,12 +1717,13 @@ def test_forward_impl_keeps_full_width_input_for_shared_experts(monkeypatch):
         before_combine=None,
     )
     runner.routed_experts = SimpleNamespace(forward_impl=MagicMock(return_value=(routed_out, routed_events)))
-    shared_input_all_gather_done = MagicMock()
-    prepared_shared_hidden_states = torch.randn(4, 8)
+    runner.routed_input_transform = object()
+    runner.routed_output_transform = object()
+    num_tokens = 3
+    prepared_shared_hidden_states = shared_hidden_states[:num_tokens]
     runner.ascend_shared_experts = SimpleNamespace(
-        prepare_input_before_routed_experts=MagicMock(
-            return_value=(prepared_shared_hidden_states, shared_input_all_gather_done),
-        ),
+        multistream_overlap=True,
+        parallel_mode=MagicMock(return_value=SharedExpertParallelMode.SEQUENCE_PARALLEL_ONLY),
         forward=MagicMock(return_value=shared_out),
     )
     runner._sequence_parallel_context = MagicMock(return_value=nullcontext())
@@ -1389,6 +1739,7 @@ def test_forward_impl_keeps_full_width_input_for_shared_experts(monkeypatch):
         "current_stream",
         lambda: current_stream,
     )
+    monkeypatch.setattr(fused_moe_module, "_EXTRA_CTX", SimpleNamespace(num_tokens=num_tokens))
 
     result = runner._forward_impl(
         routed_hidden_states,
@@ -1401,13 +1752,15 @@ def test_forward_impl_keeps_full_width_input_for_shared_experts(monkeypatch):
         router_logits=router_logits,
         input_ids=None,
     )
-    runner.ascend_shared_experts.prepare_input_before_routed_experts.assert_called_once_with(shared_hidden_states)
-    current_stream.wait_event.assert_called_once_with(shared_input_all_gather_done)
+    current_stream.wait_event.assert_not_called()
     assert routed_events.after_routed_finalize is current_stream.record_event.return_value
-    runner.ascend_shared_experts.forward.assert_called_once_with(
-        prepared_shared_hidden_states,
-        routed_events,
-        input_is_gathered=True,
-    )
+    runner.ascend_shared_experts.forward.assert_called_once()
+    call_args = runner.ascend_shared_experts.forward.call_args
+    torch.testing.assert_close(call_args.args[0], prepared_shared_hidden_states)
+    assert call_args.args[1] is routed_events
+    assert call_args.kwargs == {
+        "input_is_gathered": True,
+        "defer_output_wait": True,
+    }
     assert result[0] is shared_out
     assert result[1] is routed_out

--- a/tests/ut/test_platform.py
+++ b/tests/ut/test_platform.py
@@ -1792,30 +1792,16 @@ class TestNPUPlatform(TestBase):
             (
                 True,
                 True,
-                False,
                 "vllm_ascend.attention.mla_v1.AscendMLABackend",
             ),
             (
-                False,
-                True,
-                False,
-                "vllm_ascend.attention.attention_v1.AscendAttentionBackend",
-            ),
-            (
-                True,
-                False,
-                True,
-                "vllm_ascend.attention.mla_v1.AscendMLABackend",
-            ),
-            (
-                False,
                 False,
                 True,
                 "vllm_ascend.attention.attention_v1.AscendAttentionBackend",
             ),
         )
-        for use_mla, use_pcp, use_dcp, expected_backend in cases:
-            with self.subTest(use_mla=use_mla, use_pcp=use_pcp, use_dcp=use_dcp):
+        for use_mla, use_pcp, expected_backend in cases:
+            with self.subTest(use_mla=use_mla, use_pcp=use_pcp):
                 attn_selector_config = AttentionSelectorConfig(
                     dtype=torch.float16,
                     head_size=0,
@@ -1824,22 +1810,9 @@ class TestNPUPlatform(TestBase):
                     use_mla=use_mla,
                     use_sparse=False,
                     use_pcp=use_pcp,
-                    use_dcp=use_dcp,
                 )
                 result = self.platform.get_attn_backend_cls("ascend", attn_selector_config)
                 self.assertEqual(result, expected_backend)
-
-    def test_get_attn_backend_cls_rejects_pcp_and_dcp(self):
-        attn_selector_config = AttentionSelectorConfig(
-            dtype=torch.float16,
-            head_size=0,
-            kv_cache_dtype=None,
-            block_size=128,
-            use_pcp=True,
-            use_dcp=True,
-        )
-        with self.assertRaisesRegex(NotImplementedError, "does not support PCP and DCP simultaneously"):
-            self.platform.get_attn_backend_cls("ascend", attn_selector_config)
 
     def test_get_attn_backend_cls_selects_sfa_pcp_backend(self):
         attn_selector_config = AttentionSelectorConfig(

--- a/vllm_ascend/_310p/fused_moe/fused_moe.py
+++ b/vllm_ascend/_310p/fused_moe/fused_moe.py
@@ -137,4 +137,8 @@ class AscendMoERunner310(AscendMoERunner):
         ascend_shared_experts = getattr(self, "ascend_shared_experts", None)
         if ascend_shared_experts is not None:
             ascend_shared_experts.multistream_overlap = False
+            # The parent may have selected the SP-multistream custom op before
+            # 310P disables the unsupported feature. Restore the upstream entry
+            # so its fake output contract matches the single-stream execution.
+            self._forward_entry = self._select_forward()
         _MoECommMethods[MoECommType.ALLGATHER] = AllGatherCommImpl310(self.moe_config)

--- a/vllm_ascend/ops/fused_moe/fused_moe.py
+++ b/vllm_ascend/ops/fused_moe/fused_moe.py
@@ -24,6 +24,8 @@ from vllm.distributed import (
 )
 from vllm.model_executor.layers.fused_moe import FusedMoEConfig, FusedMoERouter
 from vllm.model_executor.layers.fused_moe.layer import MoERunner
+from vllm.model_executor.layers.fused_moe.runner.moe_runner import _moe_forward_shared
+from vllm.utils.torch_utils import direct_register_custom_op
 
 from vllm_ascend.ascend_forward_context import _EXTRA_CTX, MoECommType
 from vllm_ascend.distributed.parallel_state import get_mc2_group
@@ -34,6 +36,45 @@ from vllm_ascend.ops.fused_moe.shared_experts import (
     SharedExpertParallelMode,
 )
 from vllm_ascend.utils import vllm_version_is
+
+
+def _ascend_moe_forward_shared_sp_fake(
+    hidden_states: torch.Tensor,
+    router_logits: torch.Tensor,
+    shared_experts_input: torch.Tensor | None,
+    input_ids: torch.Tensor | None,
+    layer_name: object,
+    hidden_dim_unpadded: int,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Infer the local SP outputs of the shared-expert custom op.
+
+    The explicit shared input contains all gathered tokens, while the real
+    shared output has already been reduce-scattered back to the routed input's
+    local token count.  The upstream fake uses the shared input's token count,
+    which is only correct before the early all-gather optimization.
+    """
+    del router_logits, input_ids, layer_name
+    assert shared_experts_input is not None
+    shared_out = shared_experts_input.new_empty(
+        (*hidden_states.shape[:-1], shared_experts_input.shape[-1]),
+    )
+    if hidden_dim_unpadded > 0:
+        fused_out = hidden_states.new_empty(
+            (*hidden_states.shape[:-1], hidden_dim_unpadded),
+        )
+    else:
+        fused_out = torch.empty_like(hidden_states)
+    return shared_out, fused_out
+
+
+# Keep the gathered shared input as an explicit graph dependency, but expose
+# the SP-local shared output shape to torch.compile/ACL graph tracing.
+direct_register_custom_op(
+    op_name="ascend_moe_forward_shared_sp",
+    op_func=_moe_forward_shared,
+    fake_impl=_ascend_moe_forward_shared_sp_fake,
+    tags=(torch.Tag.needs_fixed_stride_order,),
+)
 
 
 class AscendMoERunner(MoERunner):  # type: ignore[no-redef]
@@ -85,6 +126,8 @@ class AscendMoERunner(MoERunner):  # type: ignore[no-redef]
                 self.quant_type,
                 self._quant_method,
             )
+            if self._can_overlap_sp_shared_with(self.routed_input_transform):
+                self._forward_entry = torch.ops.vllm.ascend_moe_forward_shared_sp
 
         setup_moe_comm_method(self.moe_config)
         alltoall_comm = get_moe_comm_method(MoECommType.ALLTOALL)
@@ -113,6 +156,21 @@ class AscendMoERunner(MoERunner):  # type: ignore[no-redef]
         """Ascend uses its own forward_impl path, not the FlashInfer Cutlass
         chunked path. Always return False to stay on forward_impl."""
         return False
+
+    def _can_overlap_sp_shared_with(self, routed_transform: object | None) -> bool:
+        """Limit SP shared-expert overlap changes to routed transforms.
+
+        Kimi-K3 is currently the only Ascend model that supplies these latent
+        transforms.  Keep the guard capability-based so every model without
+        them stays on the original single-stream synchronization path.
+        """
+        shared_experts = getattr(self, "ascend_shared_experts", None)
+        return (
+            routed_transform is not None
+            and shared_experts is not None
+            and shared_experts.multistream_overlap
+            and shared_experts.parallel_mode() is SharedExpertParallelMode.SEQUENCE_PARALLEL_ONLY
+        )
 
     @property
     def _fused_output_is_reduced(self) -> bool:
@@ -213,6 +271,32 @@ class AscendMoERunner(MoERunner):  # type: ignore[no-redef]
         if self.ascend_shared_experts is not None:
             self.ascend_shared_experts.set_lora_context(lora_context)
 
+    def apply_routed_input_transform(
+        self,
+        hidden_states: torch.Tensor,
+    ) -> tuple[torch.Tensor, torch.Tensor | None]:
+        """Start the SP shared-input gather before the latent down projection."""
+        gathered_input = hidden_states
+        all_gather_done = None
+        shared_experts = self.ascend_shared_experts
+        if self._can_overlap_sp_shared_with(self.routed_input_transform):
+            assert shared_experts is not None
+            gathered_input, all_gather_done = shared_experts.start_input_all_gather(hidden_states)
+        routed_input, shared_input = super().apply_routed_input_transform(hidden_states)
+        if all_gather_done is not None:
+            torch.npu.current_stream().wait_event(all_gather_done)
+            shared_input = gathered_input
+        return routed_input, shared_input
+
+    def apply_routed_output_transform(self, fused_output: torch.Tensor) -> torch.Tensor:
+        """Run the latent up projection before joining the SP shared output."""
+        fused_output = super().apply_routed_output_transform(fused_output)
+        shared_experts = self.ascend_shared_experts
+        if self._can_overlap_sp_shared_with(self.routed_output_transform):
+            assert shared_experts is not None
+            shared_experts.wait_for_output()
+        return fused_output
+
     if vllm_version_is("0.27.1"):
 
         def _forward_impl(
@@ -230,8 +314,12 @@ class AscendMoERunner(MoERunner):  # type: ignore[no-redef]
                         router_logits=router_logits,
                         input_ids=input_ids,
                     )
-                shared_expert_input, shared_input_all_gather_done = (
-                    self.ascend_shared_experts.prepare_input_before_routed_experts(shared_hidden_states)
+                # The runner input transform provides a padded gathered tensor
+                # in SP multistream mode. Trim the shared-MLP view before use.
+                shared_input_is_gathered = self._can_overlap_sp_shared_with(self.routed_input_transform)
+                defer_shared_output_wait = self._can_overlap_sp_shared_with(self.routed_output_transform)
+                shared_expert_input = (
+                    shared_hidden_states[: _EXTRA_CTX.num_tokens] if shared_input_is_gathered else shared_hidden_states
                 )
                 if self.is_internal_router:
                     gate = self.gate
@@ -249,8 +337,6 @@ class AscendMoERunner(MoERunner):  # type: ignore[no-redef]
                     before_routed_experts = torch.npu.current_stream().record_event()
                     after_routed_experts = None
 
-                if shared_input_all_gather_done is not None:
-                    torch.npu.current_stream().wait_event(shared_input_all_gather_done)
                 routed_out, fused_moe_events = self.routed_experts.forward_impl(
                     hidden_states=hidden_states,
                     router_logits=router_logits,
@@ -258,13 +344,14 @@ class AscendMoERunner(MoERunner):  # type: ignore[no-redef]
                 )
                 fused_moe_events.before_routed_experts = before_routed_experts
                 fused_moe_events.after_routed_experts = after_routed_experts
-                if shared_input_all_gather_done is not None:
+                if shared_input_is_gathered:
                     fused_moe_events.after_routed_finalize = torch.npu.current_stream().record_event()
 
                 shared_out = self.ascend_shared_experts.forward(
                     shared_expert_input,
                     fused_moe_events,
-                    input_is_gathered=shared_input_all_gather_done is not None,
+                    input_is_gathered=shared_input_is_gathered,
+                    defer_output_wait=defer_shared_output_wait,
                 )
                 return shared_out, routed_out
 
@@ -293,8 +380,11 @@ class AscendMoERunner(MoERunner):  # type: ignore[no-redef]
                         router_logits=router_logits,
                         input_ids=input_ids,
                     )
-                shared_expert_input, shared_input_all_gather_done = (
-                    self.ascend_shared_experts.prepare_input_before_routed_experts(shared_hidden_states)
+                # See the v0.27.1 branch above for the input-shape contract.
+                shared_input_is_gathered = self._can_overlap_sp_shared_with(self.routed_input_transform)
+                defer_shared_output_wait = self._can_overlap_sp_shared_with(self.routed_output_transform)
+                shared_expert_input = (
+                    shared_hidden_states[: _EXTRA_CTX.num_tokens] if shared_input_is_gathered else shared_hidden_states
                 )
                 if self.is_internal_router:
                     gate = self.gate
@@ -316,8 +406,6 @@ class AscendMoERunner(MoERunner):  # type: ignore[no-redef]
                     before_routed_experts = torch.npu.current_stream().record_event()
                     after_routed_experts = None
 
-                if shared_input_all_gather_done is not None:
-                    torch.npu.current_stream().wait_event(shared_input_all_gather_done)
                 routed_out, fused_moe_events = self.routed_experts.forward_impl(
                     hidden_states=hidden_states,
                     router_logits=router_logits,
@@ -325,12 +413,13 @@ class AscendMoERunner(MoERunner):  # type: ignore[no-redef]
                 )
                 fused_moe_events.before_routed_experts = before_routed_experts
                 fused_moe_events.after_routed_experts = after_routed_experts
-                if shared_input_all_gather_done is not None:
+                if shared_input_is_gathered:
                     fused_moe_events.after_routed_finalize = torch.npu.current_stream().record_event()
 
                 shared_out = self.ascend_shared_experts.forward(
                     shared_expert_input,
                     fused_moe_events,
-                    input_is_gathered=shared_input_all_gather_done is not None,
+                    input_is_gathered=shared_input_is_gathered,
+                    defer_output_wait=defer_shared_output_wait,
                 )
                 return shared_out, routed_out

--- a/vllm_ascend/ops/fused_moe/shared_experts.py
+++ b/vllm_ascend/ops/fused_moe/shared_experts.py
@@ -243,34 +243,40 @@ class AscendSharedExperts:
             shared_out = F.pad(shared_out, (0, 0, 0, pad_size))
         return tensor_model_parallel_reduce_scatter(shared_out, dim=0)
 
-    def prepare_input_before_routed_experts(
+    def start_input_all_gather(
         self,
         hidden_states: torch.Tensor,
     ) -> tuple[torch.Tensor, torch.npu.Event | None]:
-        """Start the SP-only input all-gather on the shared-expert stream."""
+        """Start an SP gather that can overlap the routed input transform."""
         if not (self.multistream_overlap and self.parallel_mode() is SharedExpertParallelMode.SEQUENCE_PARALLEL_ONLY):
             return hidden_states, None
 
         input_ready = torch.npu.current_stream().record_event()
         with npu_stream_switch(shared_experts_calculation_stream(), enabled=True):
             torch.npu.current_stream().wait_event(input_ready)
-            hidden_states = self._gather_sp_input(hidden_states)
+            # Keep TP padding across the custom-op boundary; the shared MLP
+            # trims it before computation.
+            hidden_states = tensor_model_parallel_all_gather(hidden_states, dim=0)
             all_gather_done = torch.npu.current_stream().record_event()
         return hidden_states, all_gather_done
+
+    def wait_for_output(self) -> None:
+        """Join a deferred SP shared-output collective on the current stream."""
+        torch.npu.current_stream().wait_stream(shared_experts_calculation_stream())
 
     def forward(
         self,
         hidden_states: torch.Tensor,
         fused_moe_evts: FusedMoEEvents,
         input_is_gathered: bool = False,
+        defer_output_wait: bool = False,
     ):
         mode = self.parallel_mode()
         local_dp_metadata = None
-        down_projection_ready = (
-            fused_moe_evts.after_routed_finalize
-            if self.multistream_overlap and mode is SharedExpertParallelMode.SEQUENCE_PARALLEL_ONLY
-            else fused_moe_evts.before_combine
-        )
+        # The down projection only depends on the shared-expert activation and
+        # should overlap the routed-expert combine.  The later shared-output
+        # collective is the operation that must wait for routed finalization.
+        down_projection_ready = fused_moe_evts.before_combine
 
         def maybe_wait_event(evt: torch.npu.Event | None):
             if evt is not None:
@@ -406,8 +412,11 @@ class AscendSharedExperts:
                 maybe_wait_event(fused_moe_evts.after_routed_finalize)
                 shared_out = self._pad_and_reduce_scatter(shared_out)
 
-        # Make sure the default stream waits for the shared experts stream to finish.
-        if self.multistream_overlap:
+        # Defer only when a routed output transform can overlap this collective;
+        # otherwise preserve the original join point for non-latent models.
+        if self.multistream_overlap and (
+            mode is not SharedExpertParallelMode.SEQUENCE_PARALLEL_ONLY or not defer_output_wait
+        ):
             torch.npu.current_stream().wait_stream(shared_experts_calculation_stream())
 
         if mode is SharedExpertParallelMode.SHARED_EXPERT_DATA_PARALLEL_ONLY:

--- a/vllm_ascend/patch/worker/patch_v2/patch_dspark.py
+++ b/vllm_ascend/patch/worker/patch_v2/patch_dspark.py
@@ -69,9 +69,10 @@ def _load_dspark_model_with_target_quant(target_model, vllm_config):
         dspark_utils.get_pp_group = lambda: single_rank_pp_group
 
         def should_share(eagle, flag, draft, target):
-            # The last PP rank has no target embedding. Keep the draft's own
-            # embedding instead of replacing it with PPMissingLayer.
-            if flag == "has_own_embed_tokens":
+            # A PP rank without the relevant target layer receives a
+            # PPMissingLayer. Never ask upstream to compare/share its absent
+            # weight; retain the draft's own layer instead.
+            if not hasattr(target, "weight"):
                 return False
             return original_should_share(eagle, flag, draft, target)
 

--- a/vllm_ascend/patch/worker/patch_v2/patch_dspark.py
+++ b/vllm_ascend/patch/worker/patch_v2/patch_dspark.py
@@ -61,6 +61,7 @@ def _load_dspark_model_with_target_quant(target_model, vllm_config):
     bypass_pp_guard = spec_pp_support is not None
     original_get_pp_group = dspark_utils.get_pp_group
     original_should_share = eagle_utils._should_share
+    original_dspark_should_share = dspark_utils._should_share
     if inherits_target_quant:
         model_utils.get_draft_quant_config = lambda _vllm_config: vllm_config.quant_config
     if bypass_pp_guard:
@@ -77,6 +78,7 @@ def _load_dspark_model_with_target_quant(target_model, vllm_config):
             return original_should_share(eagle, flag, draft, target)
 
         eagle_utils._should_share = should_share
+        dspark_utils._should_share = should_share
     try:
         # get_model also reads the config PP size; keep the draft unsharded.
         with bypass_upstream_spec_pp_guard(vllm_config, spec_pp_support):
@@ -87,6 +89,7 @@ def _load_dspark_model_with_target_quant(target_model, vllm_config):
         if bypass_pp_guard:
             dspark_utils.get_pp_group = original_get_pp_group
             eagle_utils._should_share = original_should_share
+            dspark_utils._should_share = original_dspark_should_share
 
 
 # The speculator binds ``load_dspark_model`` by name at import time, so both

--- a/vllm_ascend/platform.py
+++ b/vllm_ascend/platform.py
@@ -235,7 +235,7 @@ class NPUPlatform(Platform):
         key = (attn_selector_config.use_mla, attn_selector_config.use_sparse)
         backend_key = (*key, use_compress)
 
-        if attn_selector_config.use_pcp and attn_selector_config.use_dcp:
+        if attn_selector_config.use_pcp and getattr(attn_selector_config, "use_dcp", False):
             raise NotImplementedError("Ascend MRV2 does not support PCP and DCP simultaneously yet.")
 
         if not attn_selector_config.use_pcp and _validate_fa3_backend(key, attn_selector_config):


### PR DESCRIPTION
## What this PR does

Backport #15252 to `releases/v0.27.1rc`. For the SP-only shared-expert path with MoE multistream enabled, it restores three overlaps:

1. shared-input TP `all_gather` with routed latent-down;
2. shared down projection with routed combine;
3. shared-output `reduce_scatter` with routed latent-up.

`AscendMoERunner.apply_routed_input_transform` reaches this path for Kimi K3. Other parallel modes and multistream-off behavior retain their existing paths.

## Ordering and correctness

The shared-expert stream waits for main-stream input readiness before `all_gather`; the main stream waits for the gather before consuming its result. The shared down projection starts at the routed-combine boundary. The shared output launches after routed finalize and is joined only after routed latent-up.

The backport keeps the gathered tensor as an explicit custom-op input with the real SP-local fake output shape, trims TP padding only for shared-MLP computation, preserves the FP32 router-input path, joins shared output before upstream FP16 in-place scaling, and retains the 310P multistream-disabled fallback plus A3/A5 quantized argument contracts.

## Release-branch differences

This is the manual backport of #15252 commits `65a6d70fb9bf6c27a77137cb0cd5c4012416cba3`, `b1d1c138a09dab2c2a7fe616b0617853b5878d63`, `508d7df190acaea5bff8d159f7c35a42c54da88b`, and `8e68e06afa9937b92abaa29615c66dbf40e4e152`.

It additionally contains the v0.27.1 CI-selection commit `da4846002da04346772c12774418bc2cc8d40ed4`, the release-only `AttentionSelectorConfig` compatibility fix, and a DSpark PP-missing fix that keeps target layers unshared when pipeline parallelism omits them.

## Does this PR introduce any user-facing change?

No API or configuration change. The runtime schedules supported SP-only shared-expert work asynchronously when MoE multistream is enabled.

## How was this patch tested?

- Backported focused MoE/Kimi-K3, graph-shape, quantized-contract, event-ordering, and 310P fallback coverage from #15252.
- v0.27.1 CI is running on the current head; runner-network failures were retriggered separately from code failures.

- vLLM main: https://github.com/vllm-project/vllm/commit/ba07e4a48fc951300d97eb506217dd530583dea3
