### PR TITLE
[Backport v0.27.1rc][BugFix] Retain async speculative metadata copies

### DIFF
--- a/tests/ut/worker/test_model_runner_v1.py
+++ b/tests/ut/worker/test_model_runner_v1.py
@@ -1277,6 +1277,7 @@ class TestNPUModelRunnerOutputTokenIds(unittest.TestCase):
     def _build_runner(self):
         runner = NPUModelRunner.__new__(NPUModelRunner)
         runner.device = torch.device("cpu")
+        runner._pending_spec_decode_metadata_copies = deque()
         runner.vllm_config = MagicMock()
         runner.model_config = MagicMock()
         runner.use_compress = False
@@ -1400,6 +1401,36 @@ class TestNPUModelRunnerOutputTokenIds(unittest.TestCase):
         self.assertEqual(spec_decode_metadata.draft_token_ids.tolist(), [-1, -1, -1])
         self.assertEqual(runner.input_ids.gpu.tolist(), [11, 0, 0, 0])
         self.assertEqual(runner.input_ids.cpu.tolist(), [11, -1, -1, -1])
+
+    def test_spec_decode_metadata_keeps_cpu_sources_until_h2d_completes(self):
+        runner = self._build_runner()
+        runner.device = SimpleNamespace(type="npu")
+        sources = tuple(MagicMock() for _ in range(5))
+        device_values = tuple(MagicMock() for _ in range(5))
+        for source, device_value in zip(sources, device_values):
+            source.to.return_value = device_value
+        copy_done = MagicMock()
+        copy_done.query.return_value = False
+        fake_npu = SimpleNamespace(
+            Event=MagicMock(return_value=copy_done),
+            current_stream=MagicMock(),
+        )
+
+        with patch.object(torch, "npu", fake_npu, create=True):
+            result = runner._copy_spec_decode_metadata_to_device(sources)
+
+            self.assertEqual(result, device_values)
+            pending_sources, event = runner._pending_spec_decode_metadata_copies[0]
+            self.assertIs(pending_sources, sources)
+            self.assertIs(event, copy_done)
+            for source in sources:
+                source.to.assert_called_once_with(runner.device, non_blocking=True)
+            fake_npu.current_stream.assert_called_once_with()
+            copy_done.record.assert_called_once_with(fake_npu.current_stream.return_value)
+
+            copy_done.query.return_value = True
+            runner._copy_spec_decode_metadata_to_device(sources)
+        self.assertEqual(len(runner._pending_spec_decode_metadata_copies), 1)
 
 
 class TestNPUModelRunnerDebugger(unittest.TestCase):

--- a/vllm_ascend/worker/model_runner_v1.py
+++ b/vllm_ascend/worker/model_runner_v1.py
@@ -586,6 +586,13 @@ class NPUModelRunner(GPUModelRunner):
         self._pending_encoder_cache_copies: deque[
             tuple[torch.Tensor, torch.npu.Event]
         ] = deque()
+        # Keep the pinned CPU sources for speculative-decode metadata alive
+        # until their asynchronous H2D copies have completed.  Creating the
+        # sources as temporaries in ``_calc_spec_decode_metadata`` lets the
+        # pinned allocator reuse their storage while DMA is still reading it.
+        self._pending_spec_decode_metadata_copies: deque[
+            tuple[tuple[torch.Tensor, ...], torch.npu.Event]
+        ] = deque()
 
         self.sparse_kv_offload_config = self.ascend_config.sparse_kv_offload_config
         self.sparse_kv_offload_enabled = self.sparse_kv_offload_config.enabled
@@ -1591,6 +1598,23 @@ class NPUModelRunner(GPUModelRunner):
         input_ids = self.input_ids.gpu[:num_forward_tokens]
         input_ids.masked_fill_(input_ids == PLACEHOLDER_TOKEN_ID, 0)
 
+    def _copy_spec_decode_metadata_to_device(
+        self, cpu_metadata: tuple[torch.Tensor, ...]
+    ) -> tuple[torch.Tensor, ...]:
+        device_metadata = tuple(
+            value.to(self.device, non_blocking=True) for value in cpu_metadata
+        )
+        if self.device.type == "cpu":
+            return device_metadata
+
+        pending_copies = self._pending_spec_decode_metadata_copies
+        while pending_copies and pending_copies[0][1].query():
+            pending_copies.popleft()
+        copy_done = torch.npu.Event()
+        copy_done.record(torch.npu.current_stream())
+        pending_copies.append((cpu_metadata, copy_done))
+        return device_metadata
+
     def _calc_spec_decode_metadata(
         self,
         num_draft_tokens: np.ndarray,
@@ -1636,12 +1660,23 @@ class NPUModelRunner(GPUModelRunner):
         # [0, 1, 2, 5, 6, 9]
         target_logits_indices += arange
 
-        # TODO: Optimize the CPU -> NPU copy.
-        cu_num_draft_tokens = torch.from_numpy(cu_num_draft_tokens).pin_memory().to(self.device, non_blocking=True)
-        cu_num_sampled_tokens = torch.from_numpy(cu_num_sampled_tokens).pin_memory().to(self.device, non_blocking=True)
-        logits_indices = torch.from_numpy(logits_indices).pin_memory().to(self.device, non_blocking=True)
-        target_logits_indices = torch.from_numpy(target_logits_indices).pin_memory().to(self.device, non_blocking=True)
-        bonus_logits_indices = torch.from_numpy(bonus_logits_indices).pin_memory().to(self.device, non_blocking=True)
+        cpu_metadata = tuple(
+            torch.from_numpy(value).pin_memory()
+            for value in (
+                cu_num_draft_tokens,
+                cu_num_sampled_tokens,
+                logits_indices,
+                target_logits_indices,
+                bonus_logits_indices,
+            )
+        )
+        (
+            cu_num_draft_tokens,
+            cu_num_sampled_tokens,
+            logits_indices,
+            target_logits_indices,
+            bonus_logits_indices,
+        ) = self._copy_spec_decode_metadata_to_device(cpu_metadata)
 
         # Compute the draft token ids.
         # draft_token_indices:      [  1,   2,   3, 105, 106, 208]


### PR DESCRIPTION
### What this PR does / why we need it?

Backports #15719 to `releases/v0.27.1rc`.

Speculative-decode metadata is copied from temporary pinned CPU tensors to NPU with `non_blocking=True`. The Ascend pinned allocator can reuse the source storage before the asynchronous H2D copy completes, corrupting index tensors and causing intermittent `IndexCheck_int64` out-of-range failures under high concurrency.

Keep each batch of pinned CPU sources alive until an NPU event reports that the H2D copies have completed. Event polling is non-blocking, so this does not add a host synchronization point. A focused unit test covers source retention and completed-copy reclamation.

### Does this PR introduce _any_ user-facing change?

No API change. It prevents intermittent speculative-decoding crashes under load.

### How was this patch tested?

- `git diff --check origin/releases/v0.27.1rc...HEAD`
- Added a focused unit test in `tests/ut/worker/test_model_runner_v1.py`.
- The identical mainline fix passed the full CI gate in #15719.
- Mainline NPU validation completed 4 MMMU-Pro Options10 runs at concurrency 128: 6,920/6,920 requests, with zero `IndexCheck` or out-of-range failures. The candidate showed about 1.01% elapsed-time and 1.06% request-latency overhead in the sequential baseline/candidate comparison.
- vLLM main: https://github.com/vllm-project/vllm/commit/ba07e4a48fc951300d97eb506217dd530583dea3
