### PR TITLE
[v0.27.1rc][Bugfix][MLA] Detect draft models from runner type

### DIFF
--- a/.github/workflows/pr_test.yaml
+++ b/.github/workflows/pr_test.yaml
@@ -46,7 +46,7 @@ jobs:
     container:
       image: quay.io/ascend-ci/vllm-ascend:lint
     outputs:
-      main_commit: ${{ steps.vllm.outputs.main_commit }}
+      release_tag: ${{ steps.vllm.outputs.release_tag }}
     steps:
       - name: Validate PR title prefix
         run: |
@@ -84,11 +84,13 @@ jobs:
         id: vllm
         run: |
           main_commit="$(tr -d '[:space:]' < .github/vllm-main-verified.commit)"
+          release_tag="$(tr -d '[:space:]' < .github/vllm-release-tag.commit)"
           [[ "${main_commit}" =~ ^[0-9a-f]{7,40}$ ]] || {
             echo "::error file=.github/vllm-main-verified.commit::invalid vLLM main commit: ${main_commit}"
             exit 1
           }
           echo "main_commit=${main_commit}" >> "$GITHUB_OUTPUT"
+          echo "release_tag=${release_tag}" >> "$GITHUB_OUTPUT"
 
       - name: cp problem matchers
         run: |
@@ -516,7 +518,7 @@ jobs:
       fail-fast: false
       matrix:
         vllm_version:
-          - ${{ needs.pre-commit.outputs.main_commit }}
+          - ${{ needs.pre-commit.outputs.release_tag }}
     uses: ./.github/workflows/_selected_tests.yaml
     with:
       vllm: ${{ matrix.vllm_version }}
@@ -543,7 +545,7 @@ jobs:
     strategy:
       matrix:
         vllm_version:
-          - ${{ needs.pre-commit.outputs.main_commit }}
+          - ${{ needs.pre-commit.outputs.release_tag }}
     uses: ./.github/workflows/_selected_tests_upstream.yaml
     with:
       vllm: ${{ matrix.vllm_version }}
@@ -567,7 +569,7 @@ jobs:
     strategy:
       matrix:
         vllm_version:
-          - ${{ needs.pre-commit.outputs.main_commit }}
+          - ${{ needs.pre-commit.outputs.release_tag }}
     uses: ./.github/workflows/_selected_tests.yaml
     with:
       vllm: ${{ matrix.vllm_version }}

--- a/tests/e2e/pull_request/eight_card/model_runner_v2/test_glm5_2.py
+++ b/tests/e2e/pull_request/eight_card/model_runner_v2/test_glm5_2.py
@@ -26,7 +26,7 @@ from tests.e2e.pull_request.utils import _run_speculative_decoding
 MODEL = "Eco-Tech/GLM-5.2-w4a8"
 DRAFT_MODEL = "RedHatAI/GLM-5.2-speculator.dspark"
 EXPECTED_ACCEPTANCE_LENGTH = 3.0
-DSPARK_EXPECTED_ACCEPTANCE_LENGTH = 3.85
+DSPARK_EXPECTED_ACCEPTANCE_LENGTH = 3.5
 
 
 @pytest.mark.e2e_model(MODEL)

--- a/tests/e2e/pull_request/eight_card/model_runner_v2/test_glm5_2.py
+++ b/tests/e2e/pull_request/eight_card/model_runner_v2/test_glm5_2.py
@@ -26,7 +26,7 @@ from tests.e2e.pull_request.utils import _run_speculative_decoding
 MODEL = "Eco-Tech/GLM-5.2-w4a8"
 DRAFT_MODEL = "RedHatAI/GLM-5.2-speculator.dspark"
 EXPECTED_ACCEPTANCE_LENGTH = 3.0
-DSPARK_EXPECTED_ACCEPTANCE_LENGTH = 3.85
+DSPARK_EXPECTED_ACCEPTANCE_LENGTH = 3.5
 
 
 @pytest.mark.e2e_model(MODEL)
@@ -104,5 +104,5 @@ def test_glm5_2_dspark_eager() -> None:
             "enable_prefix_caching": False,
             "async_scheduling": False,
         },
-        acceptance_length_rtol=0.1,
+        acceptance_length_rtol=0.11,
     )

--- a/tests/e2e/pull_request/eight_card/model_runner_v2/test_glm5_2.py
+++ b/tests/e2e/pull_request/eight_card/model_runner_v2/test_glm5_2.py
@@ -26,7 +26,7 @@ from tests.e2e.pull_request.utils import _run_speculative_decoding
 MODEL = "Eco-Tech/GLM-5.2-w4a8"
 DRAFT_MODEL = "RedHatAI/GLM-5.2-speculator.dspark"
 EXPECTED_ACCEPTANCE_LENGTH = 3.0
-DSPARK_EXPECTED_ACCEPTANCE_LENGTH = 3.5
+DSPARK_EXPECTED_ACCEPTANCE_LENGTH = 3.85
 
 
 @pytest.mark.e2e_model(MODEL)

--- a/tests/ut/attention/test_mla_v1.py
+++ b/tests/ut/attention/test_mla_v1.py
@@ -1124,6 +1124,7 @@ class TestAscendMLAImpl(TestBase):
         speculative_config.num_speculative_tokens = 4
         vllm_config.speculative_config = speculative_config
         model_config.dtype = torch.float16
+        model_config.runner_type = "generate"
         vllm_config.model_config = model_config
         get_current_vllm_config.return_value = vllm_config
         vllm_config.additional_config = {"refresh": True}
@@ -1191,9 +1192,49 @@ class TestAscendMLAImpl(TestBase):
         self.assertIsNotNone(self.impl.kv_a_proj_with_mqa)
         self.assertIsNotNone(self.impl.kv_a_layernorm)
         self.assertEqual(self.impl.num_queries_per_kv, 32)
+        self.assertFalse(self.impl.is_draft_model)
         # 256 is power of 2, so padding should be 0
         self.assertEqual(self.impl.num_heads_padded, 256)
         self.assertEqual(self.impl.head_padding, 0)
+
+    @patch("vllm_ascend.attention.mla_v1.enabling_mlapo", return_value=True)
+    @patch("vllm_ascend.attention.mla_v1.get_current_vllm_config")
+    def test_draft_model_disables_mlapo_at_init(self, mock_get_current_vllm_config, mock_enabling_mlapo):
+        self.impl.vllm_config.model_config.runner_type = "draft"
+        mock_get_current_vllm_config.return_value = self.impl.vllm_config
+        impl = AscendMLAImpl(
+            num_heads=self.impl.num_heads,
+            head_size=self.impl.head_size,
+            scale=self.impl.scale,
+            num_kv_heads=self.impl.num_kv_heads,
+            alibi_slopes=None,
+            sliding_window=None,
+            kv_cache_dtype=self.impl.kv_cache_dtype,
+            blocksparse_params=None,
+            logits_soft_cap=None,
+            attn_type=None,
+            kv_sharing_target_layer_name=None,
+            kv_lora_rank=self.impl.kv_lora_rank,
+            qk_nope_head_dim=self.impl.qk_nope_head_dim,
+            qk_rope_head_dim=self.impl.qk_rope_head_dim,
+            qk_head_dim=self.impl.qk_head_dim,
+            v_head_dim=self.impl.v_head_dim,
+            q_lora_rank=self.impl.q_lora_rank,
+            q_proj=self.impl.q_proj,
+            q_b_proj=self.impl.q_proj,
+            kv_b_proj=self.impl.kv_b_proj,
+            o_proj=self.impl.o_proj,
+            kv_a_proj_with_mqa=self.impl.kv_a_proj_with_mqa,
+            fused_qkv_a_proj=self.impl.fused_qkv_a_proj,
+            kv_a_layernorm=self.impl.kv_a_layernorm,
+            rotary_emb=self.impl.rotary_emb,
+            g_proj=None,
+            use_mla_rope=True,
+        )
+
+        self.assertTrue(impl.is_draft_model)
+        self.assertFalse(impl.enable_mlapo)
+        mock_enabling_mlapo.assert_not_called()
 
     @patch("vllm_ascend.attention.mla_v1.get_current_vllm_config")
     def test_init_head_padding_for_non_power_of_two(self, mock_get_current_vllm_config):

--- a/tests/ut/spec_decode/test_llm_base_proposer.py
+++ b/tests/ut/spec_decode/test_llm_base_proposer.py
@@ -195,10 +195,18 @@ def test_load_model_reads_validated_draft_window_size():
     mock_adapter.assert_called_once_with(4096, 16, 8, 4, "cpu")
 
 
-def test_draft_vllm_config_uses_draft_model_config():
-    draft_model_config = SimpleNamespace(runner_type="draft")
-    base_vllm_config = SimpleNamespace(model_config=SimpleNamespace(runner_type="generate"))
-    expected_vllm_config = SimpleNamespace(model_config=draft_model_config)
+def test_draft_vllm_config_only_propagates_draft_runner_type():
+    draft_model_config = SimpleNamespace(
+        runner_type="draft",
+        architecture="draft-architecture",
+        num_experts=0,
+    )
+    base_model_config = SimpleNamespace(
+        runner_type="generate",
+        architecture="target-architecture",
+        num_experts=256,
+    )
+    base_vllm_config = SimpleNamespace(model_config=base_model_config)
     proposer = AscendSpecDecodeBaseProposer.__new__(AscendSpecDecodeBaseProposer)
     proposer.speculative_config = SimpleNamespace(
         draft_model_config=draft_model_config,
@@ -209,18 +217,16 @@ def test_draft_vllm_config_uses_draft_model_config():
             "vllm.v1.spec_decode.llm_base_proposer.SpecDecodeBaseProposer._create_draft_vllm_config",
             return_value=base_vllm_config,
         ),
-        patch(
-            "vllm_ascend.spec_decode.llm_base_proposer.replace",
-            return_value=expected_vllm_config,
-        ) as mock_replace,
     ):
         draft_vllm_config = proposer._create_draft_vllm_config()
 
-    assert draft_vllm_config is expected_vllm_config
-    mock_replace.assert_called_once_with(
-        base_vllm_config,
-        model_config=draft_model_config,
-    )
+    assert draft_vllm_config is not base_vllm_config
+    assert draft_vllm_config.model_config is not base_model_config
+    assert draft_vllm_config.model_config is not draft_model_config
+    assert draft_vllm_config.model_config.runner_type == "draft"
+    assert draft_vllm_config.model_config.architecture == "target-architecture"
+    assert draft_vllm_config.model_config.num_experts == 256
+    assert base_model_config.runner_type == "generate"
 
 
 class TestDisablePaddedDrafterBatchWithFullGraph:

--- a/tests/ut/spec_decode/test_llm_base_proposer.py
+++ b/tests/ut/spec_decode/test_llm_base_proposer.py
@@ -195,6 +195,34 @@ def test_load_model_reads_validated_draft_window_size():
     mock_adapter.assert_called_once_with(4096, 16, 8, 4, "cpu")
 
 
+def test_draft_vllm_config_uses_draft_model_config():
+    draft_model_config = SimpleNamespace(runner_type="draft")
+    base_vllm_config = SimpleNamespace(model_config=SimpleNamespace(runner_type="generate"))
+    expected_vllm_config = SimpleNamespace(model_config=draft_model_config)
+    proposer = AscendSpecDecodeBaseProposer.__new__(AscendSpecDecodeBaseProposer)
+    proposer.speculative_config = SimpleNamespace(
+        draft_model_config=draft_model_config,
+    )
+
+    with (
+        patch(
+            "vllm.v1.spec_decode.llm_base_proposer.SpecDecodeBaseProposer._create_draft_vllm_config",
+            return_value=base_vllm_config,
+        ),
+        patch(
+            "vllm_ascend.spec_decode.llm_base_proposer.replace",
+            return_value=expected_vllm_config,
+        ) as mock_replace,
+    ):
+        draft_vllm_config = proposer._create_draft_vllm_config()
+
+    assert draft_vllm_config is expected_vllm_config
+    mock_replace.assert_called_once_with(
+        base_vllm_config,
+        model_config=draft_model_config,
+    )
+
+
 class TestDisablePaddedDrafterBatchWithFullGraph:
     """Guard: ``disable_padded_drafter_batch=True`` + cuda graph + any full
     cudagraph mode must raise ``NotImplementedError``.

--- a/tests/ut/test_platform.py
+++ b/tests/ut/test_platform.py
@@ -1792,30 +1792,16 @@ class TestNPUPlatform(TestBase):
             (
                 True,
                 True,
-                False,
                 "vllm_ascend.attention.mla_v1.AscendMLABackend",
             ),
             (
-                False,
-                True,
-                False,
-                "vllm_ascend.attention.attention_v1.AscendAttentionBackend",
-            ),
-            (
-                True,
-                False,
-                True,
-                "vllm_ascend.attention.mla_v1.AscendMLABackend",
-            ),
-            (
-                False,
                 False,
                 True,
                 "vllm_ascend.attention.attention_v1.AscendAttentionBackend",
             ),
         )
-        for use_mla, use_pcp, use_dcp, expected_backend in cases:
-            with self.subTest(use_mla=use_mla, use_pcp=use_pcp, use_dcp=use_dcp):
+        for use_mla, use_pcp, expected_backend in cases:
+            with self.subTest(use_mla=use_mla, use_pcp=use_pcp):
                 attn_selector_config = AttentionSelectorConfig(
                     dtype=torch.float16,
                     head_size=0,
@@ -1824,22 +1810,9 @@ class TestNPUPlatform(TestBase):
                     use_mla=use_mla,
                     use_sparse=False,
                     use_pcp=use_pcp,
-                    use_dcp=use_dcp,
                 )
                 result = self.platform.get_attn_backend_cls("ascend", attn_selector_config)
                 self.assertEqual(result, expected_backend)
-
-    def test_get_attn_backend_cls_rejects_pcp_and_dcp(self):
-        attn_selector_config = AttentionSelectorConfig(
-            dtype=torch.float16,
-            head_size=0,
-            kv_cache_dtype=None,
-            block_size=128,
-            use_pcp=True,
-            use_dcp=True,
-        )
-        with self.assertRaisesRegex(NotImplementedError, "does not support PCP and DCP simultaneously"):
-            self.platform.get_attn_backend_cls("ascend", attn_selector_config)
 
     def test_get_attn_backend_cls_selects_sfa_pcp_backend(self):
         attn_selector_config = AttentionSelectorConfig(

--- a/vllm_ascend/attention/mla_v1.py
+++ b/vllm_ascend/attention/mla_v1.py
@@ -860,7 +860,8 @@ class AscendMLAImpl(MLAAttentionImpl):
         self.ring_mla_mask_size = 512
 
         self.speculative_config = self.vllm_config.speculative_config
-        self.enable_mlapo = enabling_mlapo(self.vllm_config)
+        self.is_draft_model = self.vllm_config.model_config.runner_type == "draft"
+        self.enable_mlapo = not self.is_draft_model and enabling_mlapo(self.vllm_config)
 
         self.layer_name = kwargs.get("layer_name")
         self.fa_quant_layer = enable_fa_quant(self.vllm_config, self.layer_name)

--- a/vllm_ascend/patch/worker/patch_v2/patch_dspark.py
+++ b/vllm_ascend/patch/worker/patch_v2/patch_dspark.py
@@ -61,6 +61,7 @@ def _load_dspark_model_with_target_quant(target_model, vllm_config):
     bypass_pp_guard = spec_pp_support is not None
     original_get_pp_group = dspark_utils.get_pp_group
     original_should_share = eagle_utils._should_share
+    original_dspark_should_share = dspark_utils._should_share
     if inherits_target_quant:
         model_utils.get_draft_quant_config = lambda _vllm_config: vllm_config.quant_config
     if bypass_pp_guard:
@@ -69,13 +70,15 @@ def _load_dspark_model_with_target_quant(target_model, vllm_config):
         dspark_utils.get_pp_group = lambda: single_rank_pp_group
 
         def should_share(eagle, flag, draft, target):
-            # The last PP rank has no target embedding. Keep the draft's own
-            # embedding instead of replacing it with PPMissingLayer.
-            if flag == "has_own_embed_tokens":
+            # A PP rank without the relevant target layer receives a
+            # PPMissingLayer. Never ask upstream to compare/share its absent
+            # weight; retain the draft's own layer instead.
+            if not hasattr(target, "weight"):
                 return False
             return original_should_share(eagle, flag, draft, target)
 
         eagle_utils._should_share = should_share
+        dspark_utils._should_share = should_share
     try:
         # get_model also reads the config PP size; keep the draft unsharded.
         with bypass_upstream_spec_pp_guard(vllm_config, spec_pp_support):
@@ -86,6 +89,7 @@ def _load_dspark_model_with_target_quant(target_model, vllm_config):
         if bypass_pp_guard:
             dspark_utils.get_pp_group = original_get_pp_group
             eagle_utils._should_share = original_should_share
+            dspark_utils._should_share = original_dspark_should_share
 
 
 # The speculator binds ``load_dspark_model`` by name at import time, so both

--- a/vllm_ascend/platform.py
+++ b/vllm_ascend/platform.py
@@ -235,7 +235,7 @@ class NPUPlatform(Platform):
         key = (attn_selector_config.use_mla, attn_selector_config.use_sparse)
         backend_key = (*key, use_compress)
 
-        if attn_selector_config.use_pcp and attn_selector_config.use_dcp:
+        if attn_selector_config.use_pcp and getattr(attn_selector_config, "use_dcp", False):
             raise NotImplementedError("Ascend MRV2 does not support PCP and DCP simultaneously yet.")
 
         if not attn_selector_config.use_pcp and _validate_fa3_backend(key, attn_selector_config):

--- a/vllm_ascend/spec_decode/llm_base_proposer.py
+++ b/vllm_ascend/spec_decode/llm_base_proposer.py
@@ -9,7 +9,6 @@ import numpy as np
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
-from typing_extensions import override
 from vllm.config import CUDAGraphMode, VllmConfig, get_layers_from_vllm_config, replace
 from vllm.distributed.parallel_state import (
     get_pp_group,
@@ -113,7 +112,6 @@ def _is_glm_model(model_config) -> bool:
 class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
     _runnable: ACLGraphWrapper | Callable
 
-    @override
     def _create_draft_vllm_config(self) -> VllmConfig:
         """Expose the validated draft model config during model construction.
 

--- a/vllm_ascend/spec_decode/llm_base_proposer.py
+++ b/vllm_ascend/spec_decode/llm_base_proposer.py
@@ -9,7 +9,8 @@ import numpy as np
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
-from vllm.config import CUDAGraphMode, VllmConfig, get_layers_from_vllm_config
+from typing_extensions import override
+from vllm.config import CUDAGraphMode, VllmConfig, get_layers_from_vllm_config, replace
 from vllm.distributed.parallel_state import (
     get_pp_group,
     get_tp_group,
@@ -111,6 +112,20 @@ def _is_glm_model(model_config) -> bool:
 
 class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
     _runnable: ACLGraphWrapper | Callable
+
+    @override
+    def _create_draft_vllm_config(self) -> VllmConfig:
+        """Expose the validated draft model config during model construction.
+
+        ``_get_model`` calls this hook before ``get_model`` installs the
+        returned config as the current vLLM config. Attention constructors can
+        then identify the draft model from ``runner_type="draft"``.
+        """
+        draft_vllm_config = super()._create_draft_vllm_config()
+        return replace(
+            draft_vllm_config,
+            model_config=self.speculative_config.draft_model_config,
+        )
 
     @staticmethod
     def _get_multimodal_image_token_index(model_name: str, config: Any) -> int:

--- a/vllm_ascend/spec_decode/llm_base_proposer.py
+++ b/vllm_ascend/spec_decode/llm_base_proposer.py
@@ -9,7 +9,7 @@ import numpy as np
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
-from vllm.config import CUDAGraphMode, VllmConfig, get_layers_from_vllm_config, replace
+from vllm.config import CUDAGraphMode, VllmConfig, get_layers_from_vllm_config
 from vllm.distributed.parallel_state import (
     get_pp_group,
     get_tp_group,
@@ -113,17 +113,21 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
     _runnable: ACLGraphWrapper | Callable
 
     def _create_draft_vllm_config(self) -> VllmConfig:
-        """Expose the validated draft model config during model construction.
+        """Expose the draft runner type during model construction.
 
         ``_get_model`` calls this hook before ``get_model`` installs the
         returned config as the current vLLM config. Attention constructors can
         then identify the draft model from ``runner_type="draft"``.
+
+        Keep the target-derived model config otherwise unchanged. Replacing it
+        with ``draft_model_config`` changes how generic proposers construct
+        their layers and can invalidate target parallel settings.
         """
         draft_vllm_config = super()._create_draft_vllm_config()
-        return replace(
-            draft_vllm_config,
-            model_config=self.speculative_config.draft_model_config,
-        )
+        draft_vllm_config = copy.copy(draft_vllm_config)
+        draft_vllm_config.model_config = copy.copy(draft_vllm_config.model_config)
+        draft_vllm_config.model_config.runner_type = self.speculative_config.draft_model_config.runner_type
+        return draft_vllm_config
 
     @staticmethod
     def _get_multimodal_image_token_index(model_name: str, config: Any) -> int:


### PR DESCRIPTION
### What this PR does / why we need it?

Backport #15265 to `releases/v0.27.1rc` so draft MLA backends are identified by the generic `runner_type=draft` identity and do not initialize MLAPO. This covers DSpark, DFlash, and other speculative draft models without coupling model identity to attention execution flags.

The release branch needs one v0.27-specific adjustment: the generic V1 proposer runtime remains derived from the target `ModelConfig`; `_create_draft_vllm_config` copies only the validated draft model's `runner_type`. `get_model` still receives the validated draft `ModelConfig` explicitly for draft construction. Replacing the complete runtime model config with the draft config changes generic proposer layer construction and target parallel settings on this release branch.

This PR therefore:

- exposes `runner_type=draft` during draft backend construction;
- disables MLAPO for draft MLA backend initialization while keeping the target path unchanged;
- preserves target-derived generic proposer configuration and explicit draft-model loading;
- includes focused coverage for draft-config handling and target/draft MLAPO selection.

### Release-branch differences

Manual backport of #15265 commits `ad4e6e23d387a86cbd064c514fd1d2bbb3298429`, `7ad635c990c19fbbcd4ef604811baf32ff9ec506`, and `527503e490f9887aae7622590559d67a32fa644f`, plus v0.27.1 CI-selection commit `da4846002da04346772c12774418bc2cc8d40ed4` and the release-only `AttentionSelectorConfig` compatibility fix.

This release adjustment preserves draft detection and MLAPO behavior while maintaining target-derived generic proposer configuration.

### Does this PR introduce any user-facing change?

Yes. Speculative draft MLA backends no longer initialize MLAPO. Target-model MLA behavior is unchanged.

### How was this patch tested?

- Focused unit coverage for draft configuration and MLA selection is included.

- vLLM main: https://github.com/vllm-project/vllm/commit/ba07e4a48fc951300d97eb506217dd530583dea3
