### PR TITLE
[CI] Add --profile switch to /nightly command for profiling artifact export

### DIFF
--- a/.github/workflows/_e2e_nightly_multi_node.yaml
+++ b/.github/workflows/_e2e_nightly_multi_node.yaml
@@ -83,6 +83,11 @@ on:
         type: boolean
         default: false
         description: enable Pod AOP pipeline on failure
+      profile_enabled:
+        required: false
+        type: boolean
+        default: false
+        description: force-enable the torch profiler and export profiling artifacts
       bisect_good_commit:
         required: false
         type: string
@@ -299,6 +304,7 @@ jobs:
             -D benchmark_job_name="$benchmark_job_name" \
             -D runner="$runner" \
             -D aop_multi_enabled="${{ inputs.aop_multi_enabled }}" \
+            -D profile_enabled="${{ inputs.profile_enabled }}" \
             -D good_table="/root/.cache/vllm-ascend/${{ inputs.vllm_ascend_branch || 'main' }}/${{ inputs.test_frequency }}/good_table.csv" \
             -D openlibing_secret="$OPENLIBING_SECRET" \
             -D vllm_ascend_branch="${{ inputs.vllm_ascend_branch }}" \
@@ -453,6 +459,24 @@ jobs:
             ls -la "$SRC" 2>/dev/null || echo "Directory does not exist"
           fi
 
+      - name: Fetch profiling results from PVC
+        if: ${{ always() && inputs.profile_enabled }}
+        run: |
+          set -euo pipefail
+          mkdir -p /tmp/profile_results
+          PVC_SRC="/root/.cache/profile_output/${{ steps.vars.outputs.benchmark_job_name }}"
+          echo "Fetching profiling results from PVC at $PVC_SRC..."
+          if [ -d "$PVC_SRC" ] && [ "$(ls -A "$PVC_SRC" 2>/dev/null)" ]; then
+            cp -r "$PVC_SRC"/. /tmp/profile_results/
+            echo "Profiling results fetched successfully from PVC:"
+            ls -la /tmp/profile_results/
+            rm -rf "${PVC_SRC:?}"/*
+            echo "PVC profiling contents cleaned up"
+          else
+            echo "Warning: No profiling results found in PVC at $PVC_SRC"
+            ls -la "$PVC_SRC" 2>/dev/null || echo "Directory does not exist"
+          fi
+
       - name: Post process
         if: always()
         run: |
@@ -563,3 +587,41 @@ jobs:
           if-no-files-found: warn
           retention-days: 90
           compression-level: 0
+
+      - name: Set profiling artifact timestamp
+        if: ${{ always() && inputs.profile_enabled }}
+        id: profile_ts
+        run: echo "artifact_ts=$(date -u +%Y%m%dT%H%M%SZ)" >> $GITHUB_OUTPUT
+
+      - name: Package profiling results
+        if: ${{ always() && inputs.profile_enabled }}
+        run: |
+          if [ -d /tmp/profile_results ] && [ "$(ls -A /tmp/profile_results 2>/dev/null)" ]; then
+            tar -czf /tmp/profile-results.tar.gz -C /tmp/profile_results .
+            echo "Profiling results packaged:"
+            du -sh /tmp/profile-results.tar.gz
+          else
+            echo "Warning: No profiling results found in /tmp/profile_results"
+          fi
+
+      - name: Upload profiling results (OBS)
+        if: ${{ always() && inputs.profile_enabled }}
+        continue-on-error: true
+        uses: ascend-gha-runners/artifact/upload@v0.3
+        with:
+          access_key: ${{ secrets.OBS_ACCESS_KEY_ID }}
+          secret_key: ${{ secrets.OBS_SECRET_ACCESS_KEY }}
+          name: nightly-test-profiling-${{ inputs.name || inputs.config_file_path }}-${{ steps.profile_ts.outputs.artifact_ts }}
+          path: /tmp/profile-results.tar.gz
+          if-no-files-found: warn
+          retention-days: 14
+
+      - name: Upload profiling results (GitHub Artifacts)
+        if: ${{ always() && inputs.profile_enabled }}
+        continue-on-error: true
+        uses: actions/upload-artifact@v7
+        with:
+          name: nightly-test-profiling-${{ steps.vars.outputs.benchmark_job_name }}-${{ steps.profile_ts.outputs.artifact_ts }}
+          path: /tmp/profile-results.tar.gz
+          if-no-files-found: warn
+          retention-days: 14

--- a/.github/workflows/_e2e_nightly_single_node.yaml
+++ b/.github/workflows/_e2e_nightly_single_node.yaml
@@ -78,6 +78,11 @@ on:
         type: boolean
         default: false
         description: enable AOP hooks (capture / classify / skip-or-process)
+      profile_enabled:
+        required: false
+        type: boolean
+        default: false
+        description: force-enable the torch profiler and export profiling artifacts
       bisect_good_commit:
         required: false
         type: string
@@ -286,6 +291,19 @@ jobs:
             echo "Error: Either 'tests' or 'config_file_path' must be provided."
             exit 1
           fi
+
+      - name: Enable profiling
+        if: ${{ inputs.profile_enabled }}
+        env:
+          BENCHMARK_JOB_NAME: ${{ inputs.vllm_ascend_branch }}-${{ inputs.name }}
+        run: |
+          PROFILE_DIR="/vllm-workspace/vllm-ascend/profile_output/${BENCHMARK_JOB_NAME}"
+          {
+            echo "VLLM_ASCEND_FORCE_PROFILE=true"
+            echo "VLLM_ASCEND_PROFILE_DIR=${PROFILE_DIR}"
+            echo "VLLM_TORCH_PROFILER_WITH_STACK=1"
+          } >> "$GITHUB_ENV"
+          echo "Profiling enabled, profile output dir: ${PROFILE_DIR}"
 
       - name: Run Pytest (py-driven)
         id: pytest-driven
@@ -498,3 +516,42 @@ jobs:
           if-no-files-found: warn
           retention-days: 90
           compression-level: 0
+
+      - name: Set profiling artifact timestamp
+        if: ${{ always() && inputs.profile_enabled }}
+        id: profile_ts
+        run: echo "artifact_ts=$(date -u +%Y%m%dT%H%M%SZ)" >> $GITHUB_OUTPUT
+
+      - name: Package profiling output
+        if: ${{ always() && inputs.profile_enabled }}
+        run: |
+          PROFILE_DIR="/vllm-workspace/vllm-ascend/profile_output"
+          if [ -d "$PROFILE_DIR" ] && [ "$(ls -A "$PROFILE_DIR" 2>/dev/null)" ]; then
+            tar -czf /tmp/profile-output.tar.gz -C "$PROFILE_DIR" .
+            echo "Profiling output packaged:"
+            du -sh /tmp/profile-output.tar.gz
+          else
+            echo "Warning: No profiling output found in $PROFILE_DIR"
+          fi
+
+      - name: Upload profiling artifacts (OBS)
+        if: ${{ always() && inputs.profile_enabled }}
+        continue-on-error: true
+        uses: ascend-gha-runners/artifact/upload@v0.3
+        with:
+          access_key: ${{ secrets.OBS_ACCESS_KEY_ID }}
+          secret_key: ${{ secrets.OBS_SECRET_ACCESS_KEY }}
+          name: nightly-test-profiling-${{ inputs.name }}-${{ steps.profile_ts.outputs.artifact_ts }}
+          path: /tmp/profile-output.tar.gz
+          if-no-files-found: warn
+          retention-days: 14
+
+      - name: Upload profiling artifacts (GitHub Artifacts)
+        if: ${{ always() && inputs.profile_enabled }}
+        continue-on-error: true
+        uses: actions/upload-artifact@v7
+        with:
+          name: nightly-test-profiling-${{ inputs.vllm_ascend_branch }}-${{ inputs.name }}-${{ steps.profile_ts.outputs.artifact_ts }}
+          path: /tmp/profile-output.tar.gz
+          if-no-files-found: warn
+          retention-days: 14

--- a/.github/workflows/_e2e_nightly_single_node_560t.yaml
+++ b/.github/workflows/_e2e_nightly_single_node_560t.yaml
@@ -78,6 +78,11 @@ on:
         type: boolean
         default: false
         description: enable AOP hooks (capture / classify / skip-or-process)
+      profile_enabled:
+        required: false
+        type: boolean
+        default: false
+        description: force-enable the torch profiler and export profiling artifacts
       bisect_good_commit:
         required: false
         type: string
@@ -280,6 +285,19 @@ jobs:
             exit 1
           fi
 
+      - name: Enable profiling
+        if: ${{ inputs.profile_enabled }}
+        env:
+          BENCHMARK_JOB_NAME: ${{ inputs.vllm_ascend_branch }}-${{ inputs.name }}
+        run: |
+          PROFILE_DIR="/vllm-workspace/vllm-ascend/profile_output/${BENCHMARK_JOB_NAME}"
+          {
+            echo "VLLM_ASCEND_FORCE_PROFILE=true"
+            echo "VLLM_ASCEND_PROFILE_DIR=${PROFILE_DIR}"
+            echo "VLLM_TORCH_PROFILER_WITH_STACK=1"
+          } >> "$GITHUB_ENV"
+          echo "Profiling enabled, profile output dir: ${PROFILE_DIR}"
+
       - name: Run Pytest (py-driven)
         id: pytest-driven
         if: ${{ inputs.tests != '' }}
@@ -479,3 +497,42 @@ jobs:
           if-no-files-found: warn
           retention-days: 90
           compression-level: 0
+
+      - name: Set profiling artifact timestamp
+        if: ${{ always() && inputs.profile_enabled }}
+        id: profile_ts
+        run: echo "artifact_ts=$(date -u +%Y%m%dT%H%M%SZ)" >> $GITHUB_OUTPUT
+
+      - name: Package profiling output
+        if: ${{ always() && inputs.profile_enabled }}
+        run: |
+          PROFILE_DIR="/vllm-workspace/vllm-ascend/profile_output"
+          if [ -d "$PROFILE_DIR" ] && [ "$(ls -A "$PROFILE_DIR" 2>/dev/null)" ]; then
+            tar -czf /tmp/profile-output.tar.gz -C "$PROFILE_DIR" .
+            echo "Profiling output packaged:"
+            du -sh /tmp/profile-output.tar.gz
+          else
+            echo "Warning: No profiling output found in $PROFILE_DIR"
+          fi
+
+      - name: Upload profiling artifacts (OBS)
+        if: ${{ always() && inputs.profile_enabled }}
+        continue-on-error: true
+        uses: ascend-gha-runners/artifact/upload@v0.3
+        with:
+          access_key: ${{ secrets.OBS_ACCESS_KEY_ID }}
+          secret_key: ${{ secrets.OBS_SECRET_ACCESS_KEY }}
+          name: nightly-test-profiling-${{ inputs.name }}-${{ steps.profile_ts.outputs.artifact_ts }}
+          path: /tmp/profile-output.tar.gz
+          if-no-files-found: warn
+          retention-days: 14
+
+      - name: Upload profiling artifacts (GitHub Artifacts)
+        if: ${{ always() && inputs.profile_enabled }}
+        continue-on-error: true
+        uses: actions/upload-artifact@v7
+        with:
+          name: nightly-test-profiling-${{ inputs.vllm_ascend_branch }}-${{ inputs.name }}-${{ steps.profile_ts.outputs.artifact_ts }}
+          path: /tmp/profile-output.tar.gz
+          if-no-files-found: warn
+          retention-days: 14

--- a/.github/workflows/pr_nightly_command.yml
+++ b/.github/workflows/pr_nightly_command.yml
@@ -48,6 +48,7 @@ jobs:
       dispatch_a5: ${{ steps.resolve.outputs.dispatch_a5 }}
       vllm_ascend_ref: ${{ steps.resolve.outputs.vllm_ascend_ref }}
       aop_enabled: ${{ steps.resolve.outputs.aop_enabled }}
+      profile_enabled: ${{ steps.resolve.outputs.profile_enabled }}
       bisect_args_json: ${{ steps.resolve.outputs.bisect_args_json }}
       command: ${{ steps.resolve.outputs.command }}
     steps:
@@ -132,6 +133,7 @@ jobs:
           BRANCH="main"
           TEST_CASES=""
           AOP_ENABLED="false"
+          PROFILE_ENABLED="false"
           IS_A3_560T="false"
           NEXT_IS_BRANCH=0
           NEXT_IS_GOOD_COMMIT=0
@@ -198,6 +200,12 @@ jobs:
                 exit 1
               fi
               AOP_ENABLED="true"
+            elif [ "$WORD" = "--profile" ]; then
+              if [ -z "$TEST_CASES" ]; then
+                echo "ERROR: --profile must appear after at least one test case"
+                exit 1
+              fi
+              PROFILE_ENABLED="true"
             elif [ "$WORD" = "--a3-560t" ]; then
               IS_A3_560T="true"
             elif [ "$WORD" = "--good-commit" ]; then
@@ -285,6 +293,7 @@ jobs:
             echo "test_cases=$TEST_CASES"
             echo "branch=$BRANCH"
             echo "aop_enabled=$AOP_ENABLED"
+            echo "profile_enabled=$PROFILE_ENABLED"
             echo "bisect_good_commit=$BISECT_GOOD_COMMIT"
             echo "bisect_bad_commit=$BISECT_BAD_COMMIT"
             echo "bisect_fail_confirm_retries=$BISECT_FAIL_CONFIRM_RETRIES"
@@ -372,6 +381,7 @@ jobs:
             -f skip_build_image=true \
             -f vllm_ascend_ref='${{ needs.authorize.outputs.vllm_ascend_ref }}' \
             -f aop_enabled='${{ needs.authorize.outputs.aop_enabled }}' \
+            -f profile_enabled='${{ needs.authorize.outputs.profile_enabled }}' \
             -f bisect_args_json="$BISECT_ARGS_JSON"
           sleep 8
           A2_RUN_ID=$(gh api "repos/$REPO/actions/workflows/schedule_nightly_test_a2.yaml/runs?per_page=1" \
@@ -415,6 +425,7 @@ jobs:
             -f skip_build_image=true \
             -f vllm_ascend_ref='${{ needs.authorize.outputs.vllm_ascend_ref }}' \
             -f aop_enabled='${{ needs.authorize.outputs.aop_enabled }}' \
+            -f profile_enabled='${{ needs.authorize.outputs.profile_enabled }}' \
             -f bisect_args_json="$BISECT_ARGS_JSON"
           sleep 8
           A3_RUN_ID=$(gh api "repos/$REPO/actions/workflows/schedule_nightly_test_a3.yaml/runs?per_page=1" \
@@ -458,6 +469,7 @@ jobs:
             -f skip_build_image=true \
             -f vllm_ascend_ref='${{ needs.authorize.outputs.vllm_ascend_ref }}' \
             -f aop_enabled='${{ needs.authorize.outputs.aop_enabled }}' \
+            -f profile_enabled='${{ needs.authorize.outputs.profile_enabled }}' \
             -f bisect_args_json="$BISECT_ARGS_JSON"
           sleep 8
           A3_560T_RUN_ID=$(gh api "repos/$REPO/actions/workflows/schedule_nightly_test_a3_560t.yaml/runs?per_page=1" \
@@ -499,7 +511,8 @@ jobs:
             -f request_id="$REQUEST_ID" \
             -f skip_build_image=true \
             -f vllm_ascend_ref='${{ needs.authorize.outputs.vllm_ascend_ref }}' \
-            -f aop_enabled='${{ needs.authorize.outputs.aop_enabled }}'
+            -f aop_enabled='${{ needs.authorize.outputs.aop_enabled }}' \
+            -f profile_enabled='${{ needs.authorize.outputs.profile_enabled }}'
           sleep 8
           A5_RUN_ID=$(gh api "repos/$REPO/actions/workflows/schedule_nightly_test_a5.yaml/runs?per_page=1" \
             --jq '.workflow_runs[0].id')
@@ -540,7 +553,8 @@ jobs:
             -f request_id="$REQUEST_ID" \
             -f skip_build_image=true \
             -f vllm_ascend_ref='${{ needs.authorize.outputs.vllm_ascend_ref }}' \
-            -f aop_enabled='${{ needs.authorize.outputs.aop_enabled }}'
+            -f aop_enabled='${{ needs.authorize.outputs.aop_enabled }}' \
+            -f profile_enabled='${{ needs.authorize.outputs.profile_enabled }}'
           sleep 8
           _310P_RUN_ID=$(gh api "repos/$REPO/actions/workflows/schedule_nightly_test_310p.yaml/runs?per_page=1" \
             --jq '.workflow_runs[0].id')

--- a/.github/workflows/schedule_nightly_test_310p.yaml
+++ b/.github/workflows/schedule_nightly_test_310p.yaml
@@ -53,6 +53,11 @@ on:
         required: false
         default: false
         type: boolean
+      profile_enabled:
+        description: 'Enable torch profiler and export profiling artifacts'
+        required: false
+        default: false
+        type: boolean
       build_type:
         description: 'Build type: daily or release.'
         required: false
@@ -226,6 +231,7 @@ jobs:
       request_id: ${{ inputs.request_id || '' }}
       vllm_ascend_ref: ${{ inputs.vllm_ascend_ref || '' }}
       aop_single_enabled: ${{ inputs.aop_enabled }}
+      profile_enabled: ${{ inputs.profile_enabled }}
 
 
   merge-benchmark-artifacts:

--- a/.github/workflows/schedule_nightly_test_a2.yaml
+++ b/.github/workflows/schedule_nightly_test_a2.yaml
@@ -52,6 +52,11 @@ on:
         required: false
         default: false
         type: boolean
+      profile_enabled:
+        description: 'Enable torch profiler and export profiling artifacts'
+        required: false
+        default: false
+        type: boolean
       build_type:
         description: 'Build type: daily or release.'
         required: false
@@ -65,8 +70,6 @@ on:
         required: false
         default: '{"cann_version":"9.1.0_20260731131545","base_image_date":"auto"}'
         type: string
-      bisect_good_commit:
-        description: 'explicit good commit for bisect (overrides good_table lookup)'
       bisect_args_json:
         description: 'JSON object containing optional bisect parameters'
         required: false
@@ -230,6 +233,7 @@ jobs:
       name: ${{ matrix.test_config.name }}
       vllm_ascend_ref: ${{ inputs.vllm_ascend_ref || needs.parse-trigger.outputs.ref }}
       aop_multi_enabled: ${{ inputs.aop_enabled }}
+      profile_enabled: ${{ inputs.profile_enabled }}
       bisect_good_commit: ${{ fromJSON(inputs.bisect_args_json || '{}').good_commit || '' }}
       bisect_bad_commit: ${{ fromJSON(inputs.bisect_args_json || '{}').bad_commit || 'HEAD' }}
       bisect_fail_confirm_retries: ${{ fromJSON(inputs.bisect_args_json || '{}').fail_confirm_retries || '' }}
@@ -296,6 +300,7 @@ jobs:
       request_id: ${{ inputs.request_id || '' }}
       vllm_ascend_ref: ${{ inputs.vllm_ascend_ref || needs.parse-trigger.outputs.ref }}
       aop_single_enabled: ${{ inputs.aop_enabled }}
+      profile_enabled: ${{ inputs.profile_enabled }}
       bisect_good_commit: ${{ fromJSON(inputs.bisect_args_json || '{}').good_commit || '' }}
       bisect_bad_commit: ${{ fromJSON(inputs.bisect_args_json || '{}').bad_commit || 'HEAD' }}
       bisect_fail_confirm_retries: ${{ fromJSON(inputs.bisect_args_json || '{}').fail_confirm_retries || '' }}

--- a/.github/workflows/schedule_nightly_test_a3.yaml
+++ b/.github/workflows/schedule_nightly_test_a3.yaml
@@ -53,6 +53,11 @@ on:
         required: false
         default: false
         type: boolean
+      profile_enabled:
+        description: 'Enable torch profiler and export profiling artifacts'
+        required: false
+        default: false
+        type: boolean
       build_type:
         description: 'Build type: daily or release.'
         required: false
@@ -66,8 +71,6 @@ on:
         required: false
         default: '{"cann_version":"9.1.0_20260731131545","base_image_date":"auto"}'
         type: string
-      bisect_good_commit:
-        description: 'explicit good commit for bisect (overrides good_table lookup)'
       bisect_args_json:
         description: 'JSON object containing optional bisect parameters'
         required: false
@@ -228,6 +231,7 @@ jobs:
       name: ${{ matrix.test_config.name }}
       vllm_ascend_ref: ${{ inputs.vllm_ascend_ref || needs.parse-trigger.outputs.ref }}
       aop_multi_enabled: ${{ inputs.aop_enabled }}
+      profile_enabled: ${{ inputs.profile_enabled }}
       bisect_good_commit: ${{ fromJSON(inputs.bisect_args_json || '{}').good_commit || '' }}
       bisect_bad_commit: ${{ fromJSON(inputs.bisect_args_json || '{}').bad_commit || 'HEAD' }}
       bisect_fail_confirm_retries: ${{ fromJSON(inputs.bisect_args_json || '{}').fail_confirm_retries || '' }}
@@ -278,6 +282,7 @@ jobs:
       name: ${{ matrix.test_config.name }}
       vllm_ascend_ref: ${{ inputs.vllm_ascend_ref || needs.parse-trigger.outputs.ref }}
       aop_multi_enabled: ${{ inputs.aop_enabled }}
+      profile_enabled: ${{ inputs.profile_enabled }}
       bisect_good_commit: ${{ fromJSON(inputs.bisect_args_json || '{}').good_commit || '' }}
       bisect_bad_commit: ${{ fromJSON(inputs.bisect_args_json || '{}').bad_commit || 'HEAD' }}
       bisect_fail_confirm_retries: ${{ fromJSON(inputs.bisect_args_json || '{}').fail_confirm_retries || '' }}
@@ -332,6 +337,7 @@ jobs:
       request_id: ${{ inputs.request_id || '' }}
       vllm_ascend_ref: ${{ inputs.vllm_ascend_ref || '' }}
       aop_single_enabled: ${{ inputs.aop_enabled }}
+      profile_enabled: ${{ inputs.profile_enabled }}
       bisect_good_commit: ${{ fromJSON(inputs.bisect_args_json || '{}').good_commit || '' }}
       bisect_bad_commit: ${{ fromJSON(inputs.bisect_args_json || '{}').bad_commit || 'HEAD' }}
       bisect_fail_confirm_retries: ${{ fromJSON(inputs.bisect_args_json || '{}').fail_confirm_retries || '' }}
@@ -376,6 +382,7 @@ jobs:
       request_id: ${{ inputs.request_id || '' }}
       vllm_ascend_ref: ${{ inputs.vllm_ascend_ref || '' }}
       aop_single_enabled: ${{ inputs.aop_enabled }}
+      profile_enabled: ${{ inputs.profile_enabled }}
       bisect_good_commit: ${{ fromJSON(inputs.bisect_args_json || '{}').good_commit || '' }}
       bisect_bad_commit: ${{ fromJSON(inputs.bisect_args_json || '{}').bad_commit || 'HEAD' }}
       bisect_fail_confirm_retries: ${{ fromJSON(inputs.bisect_args_json || '{}').fail_confirm_retries || '' }}

--- a/.github/workflows/schedule_nightly_test_a3_560t.yaml
+++ b/.github/workflows/schedule_nightly_test_a3_560t.yaml
@@ -52,6 +52,11 @@ on:
         required: false
         default: false
         type: boolean
+      profile_enabled:
+        description: 'Enable torch profiler and export profiling artifacts'
+        required: false
+        default: false
+        type: boolean
       build_type:
         description: 'Build type: daily or release.'
         required: false
@@ -65,8 +70,6 @@ on:
         required: false
         default: '{"cann_version":"9.1.0_20260731131545","base_image_date":"auto"}'
         type: string
-      bisect_good_commit:
-        description: 'explicit good commit for bisect (overrides good_table lookup)'
       bisect_args_json:
         description: 'JSON object containing optional bisect parameters'
         required: false
@@ -216,6 +219,7 @@ jobs:
       request_id: ${{ inputs.request_id || '' }}
       vllm_ascend_ref: ${{ inputs.vllm_ascend_ref || '' }}
       aop_single_enabled: ${{ inputs.aop_enabled }}
+      profile_enabled: ${{ inputs.profile_enabled }}
       bisect_good_commit: ${{ fromJSON(inputs.bisect_args_json || '{}').good_commit || '' }}
       bisect_bad_commit: ${{ fromJSON(inputs.bisect_args_json || '{}').bad_commit || 'HEAD' }}
       bisect_fail_confirm_retries: ${{ fromJSON(inputs.bisect_args_json || '{}').fail_confirm_retries || '' }}
@@ -260,6 +264,7 @@ jobs:
       request_id: ${{ inputs.request_id || '' }}
       vllm_ascend_ref: ${{ inputs.vllm_ascend_ref || '' }}
       aop_single_enabled: ${{ inputs.aop_enabled }}
+      profile_enabled: ${{ inputs.profile_enabled }}
       bisect_good_commit: ${{ fromJSON(inputs.bisect_args_json || '{}').good_commit || '' }}
       bisect_bad_commit: ${{ fromJSON(inputs.bisect_args_json || '{}').bad_commit || 'HEAD' }}
       bisect_fail_confirm_retries: ${{ fromJSON(inputs.bisect_args_json || '{}').fail_confirm_retries || '' }}

--- a/.github/workflows/schedule_nightly_test_a5.yaml
+++ b/.github/workflows/schedule_nightly_test_a5.yaml
@@ -51,6 +51,11 @@ on:
         required: false
         default: false
         type: boolean
+      profile_enabled:
+        description: 'Enable torch profiler and export profiling artifacts'
+        required: false
+        default: false
+        type: boolean
       build_type:
         description: 'Build type: daily or release.'
         required: false
@@ -64,8 +69,6 @@ on:
         required: false
         default: '{"cann_version":"9.1.0_20260731131545","base_image_date":"auto"}'
         type: string
-      bisect_good_commit:
-        description: 'explicit good commit for bisect (overrides good_table lookup)'
       bisect_args_json:
         description: 'JSON object containing optional bisect parameters'
         required: false
@@ -223,6 +226,7 @@ jobs:
       name: ${{ matrix.test_config.name }}
       vllm_ascend_ref: ${{ inputs.vllm_ascend_ref || needs.parse-trigger.outputs.ref }}
       aop_multi_enabled: ${{ inputs.aop_enabled }}
+      profile_enabled: ${{ inputs.profile_enabled }}
       bisect_good_commit: ${{ fromJSON(inputs.bisect_args_json || '{}').good_commit || '' }}
       bisect_bad_commit: ${{ fromJSON(inputs.bisect_args_json || '{}').bad_commit || 'HEAD' }}
       bisect_fail_confirm_retries: ${{ fromJSON(inputs.bisect_args_json || '{}').fail_confirm_retries || '' }}
@@ -277,6 +281,7 @@ jobs:
       request_id: ${{ inputs.request_id || '' }}
       vllm_ascend_ref: ${{ inputs.vllm_ascend_ref || '' }}
       aop_single_enabled: ${{ inputs.aop_enabled }}
+      profile_enabled: ${{ inputs.profile_enabled }}
       bisect_good_commit: ${{ fromJSON(inputs.bisect_args_json || '{}').good_commit || '' }}
       bisect_bad_commit: ${{ fromJSON(inputs.bisect_args_json || '{}').bad_commit || 'HEAD' }}
       bisect_fail_confirm_retries: ${{ fromJSON(inputs.bisect_args_json || '{}').fail_confirm_retries || '' }}

--- a/tests/e2e/nightly/multi_node/external_dp/scripts/runtime.py
+++ b/tests/e2e/nightly/multi_node/external_dp/scripts/runtime.py
@@ -35,6 +35,29 @@ from tests.e2e.nightly.multi_node.scripts.utils import get_net_interface
 
 logger = logging.getLogger(__name__)
 
+
+def _inject_force_profiler_to_args(rendered_args: list[str]) -> list[str]:
+    """Inject --profiler-config into server command args when profiling is forced."""
+    if os.environ.get("VLLM_ASCEND_FORCE_PROFILE", "").lower() not in ("true", "1"):
+        return rendered_args
+    profile_dir = os.environ.get("VLLM_ASCEND_PROFILE_DIR", "")
+    if not profile_dir:
+        return rendered_args
+    with_stack = os.environ.get("VLLM_TORCH_PROFILER_WITH_STACK", "1").lower() not in ("0", "false", "f")
+    profiler_config = {
+        "profiler": "torch",
+        "torch_profiler_dir": profile_dir,
+        "torch_profiler_with_stack": with_stack,
+    }
+    args = list(rendered_args)
+    if "--profiler-config" in args:
+        idx = args.index("--profiler-config")
+        del args[idx : idx + 2]
+    args += ["--profiler-config", json.dumps(profiler_config)]
+    logger.info("Injected --profiler-config into external DP server args")
+    return args
+
+
 SERVER_READY_TIMEOUT_SECONDS = 3600
 KV_POOL_READY_TIMEOUT_SECONDS = 300
 MOONCAKE_EVICTION_HIGH_WATERMARK_RATIO = 0.9
@@ -340,6 +363,7 @@ class ServerCommandBuilder:
             )
             for arg in template.server_cmd_template
         ]
+        rendered_args = _inject_force_profiler_to_args(rendered_args)
         cmd = ["vllm", "serve", self.config.model, *rendered_args]
 
         env = {key: str(value) for key, value in rendered_env.items()}

--- a/tests/e2e/nightly/multi_node/internal_dp/scripts/multi_node_config.py
+++ b/tests/e2e/nightly/multi_node/internal_dp/scripts/multi_node_config.py
@@ -1,5 +1,7 @@
+import json
 import logging
 import os
+import shlex
 import subprocess
 from dataclasses import dataclass
 from typing import Any
@@ -20,6 +22,27 @@ logger = logging.getLogger(__name__)
 
 DEFAULT_CONFIG_BASE_PATH = "tests/e2e/nightly/multi_node/internal_dp/config/"
 DEFAULT_SERVER_PORT = 8080
+
+
+def _inject_force_profiler_to_cmd(cmd: str) -> str:
+    """Inject --profiler-config into a server_cmd string when profiling is forced."""
+    if os.environ.get("VLLM_ASCEND_FORCE_PROFILE", "").lower() not in ("true", "1"):
+        return cmd
+    profile_dir = os.environ.get("VLLM_ASCEND_PROFILE_DIR", "")
+    if not profile_dir:
+        return cmd
+    with_stack = os.environ.get("VLLM_TORCH_PROFILER_WITH_STACK", "1").lower() not in ("0", "false", "f")
+    profiler_config = {
+        "profiler": "torch",
+        "torch_profiler_dir": profile_dir,
+        "torch_profiler_with_stack": with_stack,
+    }
+    parts = shlex.split(cmd)
+    if "--profiler-config" in parts:
+        idx = parts.index("--profiler-config")
+        del parts[idx : idx + 2]
+    parts += ["--profiler-config", json.dumps(profiler_config)]
+    return " ".join(shlex.quote(p) for p in parts)
 
 
 @dataclass(frozen=True)
@@ -201,7 +224,7 @@ class MultiNodeConfig:
         ).build()
         logger.info("Node %d envs: %s", self.cur_index, self.envs)
 
-        self.server_cmd = self._expand_env(self.cur_node.server_cmd)
+        self.server_cmd = _inject_force_profiler_to_cmd(self._expand_env(self.cur_node.server_cmd))
 
     def _resolve_cur_index(self) -> int:
         return resolve_current_node_index([node.ip for node in self.nodes])

--- a/tests/e2e/nightly/multi_node/scripts/lws.yaml.jinja2
+++ b/tests/e2e/nightly/multi_node/scripts/lws.yaml.jinja2
@@ -47,6 +47,12 @@ spec:
                 value: {{ vllm_ascend_ref | default("main") }}
               - name: AOP_MULTI_ENABLED
                 value: "{{ aop_multi_enabled | default("false") }}"
+{% if profile_enabled | default("false") | lower == "true" %}
+              - name: VLLM_ASCEND_FORCE_PROFILE
+                value: "true"
+              - name: VLLM_ASCEND_PROFILE_DIR
+                value: "/root/.cache/profile_output/{{ benchmark_job_name | default("") }}"
+{% endif %}
               - name: GOOD_TABLE
                 value: "{{ good_table | default("/root/.cache/vllm-ascend/nightly/good_table.csv") }}"
               - name: BISECT_GOOD_COMMIT
@@ -148,6 +154,12 @@ spec:
                 value: {{ runner | default("linux-aarch64-a3-800t-0") }}
               - name: AOP_MULTI_ENABLED
                 value: "{{ aop_multi_enabled | default("false") }}"
+{% if profile_enabled | default("false") | lower == "true" %}
+              - name: VLLM_ASCEND_FORCE_PROFILE
+                value: "true"
+              - name: VLLM_ASCEND_PROFILE_DIR
+                value: "/root/.cache/profile_output/{{ benchmark_job_name | default("") }}"
+{% endif %}
               - name: GOOD_TABLE
                 value: "{{ good_table | default("/root/.cache/vllm-ascend/nightly/good_table.csv") }}"
               - name: BISECT_GOOD_COMMIT

--- a/tests/e2e/nightly/single_node/models/scripts/test_single_node.py
+++ b/tests/e2e/nightly/single_node/models/scripts/test_single_node.py
@@ -381,6 +381,36 @@ def _parse_json_flag(cmd_list: list[str], flag: str) -> dict[str, Any]:
         return {}
 
 
+def _inject_force_profiler(server_cmd: list[str]) -> list[str]:
+    """Inject --profiler-config into a serve command when profiling is forced.
+
+    Reads VLLM_ASCEND_FORCE_PROFILE (enabled by the nightly --profile switch) and
+    VLLM_ASCEND_PROFILE_DIR. Any existing --profiler-config is replaced so the
+    forced profiler output lands in the expected directory.
+    """
+    if os.environ.get("VLLM_ASCEND_FORCE_PROFILE", "").lower() not in ("true", "1"):
+        return server_cmd
+    profile_dir = os.environ.get("VLLM_ASCEND_PROFILE_DIR", "")
+    if not profile_dir:
+        logger.warning(
+            "VLLM_ASCEND_FORCE_PROFILE is set but VLLM_ASCEND_PROFILE_DIR is empty, skipping profiler injection"
+        )
+        return server_cmd
+    with_stack = os.environ.get("VLLM_TORCH_PROFILER_WITH_STACK", "1").lower() not in ("0", "false", "f")
+    profiler_config = {
+        "profiler": "torch",
+        "torch_profiler_dir": profile_dir,
+        "torch_profiler_with_stack": with_stack,
+    }
+    cmd = list(server_cmd)
+    if "--profiler-config" in cmd:
+        idx = cmd.index("--profiler-config")
+        del cmd[idx : idx + 2]
+    cmd += ["--profiler-config", json.dumps(profiler_config)]
+    logger.info("Injected --profiler-config into serve command: %s", profiler_config)
+    return cmd
+
+
 def _extract_features(server_cmd: list[str] | str, envs: dict[str, Any]) -> list[str]:
     """Extract enabled feature names from server_cmd and environment variables."""
     if isinstance(server_cmd, str):
@@ -588,10 +618,11 @@ async def test_single_node(config: SingleNodeConfig) -> None:
             subprocess.call(command)
     kv_pool_manager = create_single_node_kv_pool_manager(config.kv_pool, config.name)
     if config.service_mode == "epd":
+        epd_server_cmds = [_inject_force_profiler(cmd) for cmd in config.epd_server_cmds]
         with (
             kv_pool_manager,
             RemoteEPDServer(
-                vllm_serve_args=config.epd_server_cmds,
+                vllm_serve_args=epd_server_cmds,
                 env_dict={**config.envs, **kv_pool_manager.server_envs},
             ) as _,
             DisaggEpdProxy(proxy_args=config.epd_proxy_args, env_dict=config.envs) as proxy,
@@ -605,7 +636,7 @@ async def test_single_node(config: SingleNodeConfig) -> None:
         kv_pool_manager,
         RemoteOpenAIServer(
             model=config.model,
-            vllm_serve_args=config.server_cmd,
+            vllm_serve_args=_inject_force_profiler(config.server_cmd),
             server_port=config.server_port,
             env_dict={**config.envs, **kv_pool_manager.server_envs},
             auto_port=False,


### PR DESCRIPTION
### What this PR does / why we need it?

Introduce a --profile flag to the /nightly slash command that force-enables the torch profiler and uploads profiling output as artifacts for performance debugging.

Key changes:
- Add --profile argument parsing in pr_nightly_command.yml, propagated as profile_enabled through all SOC nightly workflows (A2, A3, A3-560T, A5, 310P) and their reusable workflows
- Inject --profiler-config into server commands via VLLM_ASCEND_FORCE_PROFILE env var in test_single_node.py, multi_node_config.py, and runtime.py
- Package profiling output as tar.gz and upload to both OBS and GitHub Artifacts with 14-day retention
- Support multi-node profiling via PVC fetch (same pattern as benchmark results)
- Pass VLLM_ASCEND_FORCE_PROFILE and VLLM_ASCEND_PROFILE_DIR env vars to pods via lws.yaml.jinja2

### Does this PR introduce _any_ user-facing change?

### How was this patch tested?

- vLLM main: https://github.com/vllm-project/vllm/commit/e6bfe03ad73a3330cb427885aa90d97a12e1c704
