### PR TITLE
Support layerwise KV pool for Kimi-K3

### DIFF
--- a/vllm_ascend/ops/kimi_kda.py
+++ b/vllm_ascend/ops/kimi_kda.py
@@ -27,6 +27,13 @@ from vllm.v1.attention.backend import AttentionBackend
 from vllm.v1.attention.backends.gdn_attn import GDNAttentionMetadata
 from vllm.v1.attention.backends.utils import PAD_SLOT_ID
 
+from vllm_ascend.attention.utils import (
+    maybe_save_kv_layer_to_connector,
+    wait_for_kv_layer_from_connector,
+)
+from vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.attention_fence import (
+    record_attention_compute_start,
+)
 from vllm_ascend.ops.gdn_attn_builder import AscendGDNAttentionBackend
 from vllm_ascend.ops.triton.fla.utils import clear_ssm_states
 
@@ -337,6 +344,12 @@ class AscendKimiK3DeltaAttention(KimiK3DeltaAttention):
         attn_metadata = attn_metadata_raw[self.prefix]
         assert isinstance(attn_metadata, GDNAttentionMetadata)
 
+        # Layerwise KV pool: block until this layer's KV/state blocks finish
+        # loading before any kernel touches conv_state / recurrent_state.
+        # The layer name also routes the per-layer mamba state D2D copy.
+        wait_for_kv_layer_from_connector(self.prefix)
+        record_attention_compute_start()
+
         num_actual_tokens = attn_metadata.num_actual_tokens
         mixed_qkv = mixed_qkv[:num_actual_tokens]
         g1 = g1[:, :num_actual_tokens]
@@ -508,6 +521,9 @@ class AscendKimiK3DeltaAttention(KimiK3DeltaAttention):
             # Idle DP dummy runs carry graph-shaped metadata with no live work.
             # Do not feed a previous replay's output through the norm gate.
             core_attn_out.zero_()
+            # Pair with the wait hook above so the worker's layer counter
+            # stays in sync even for idle runs.
+            maybe_save_kv_layer_to_connector("", [])
             return
 
         num_live_tokens = None
@@ -542,3 +558,8 @@ class AscendKimiK3DeltaAttention(KimiK3DeltaAttention):
         # static padding rows whose captured gate values are not live.
         core_attn_out[:, :num_actual_tokens].copy_(_zero_padded_output(normalized, num_live_tokens))
         core_attn_out[:, num_actual_tokens:].zero_()
+        # Layerwise KV pool: this layer's states are written (kernels are
+        # enqueued on the current stream). Record the save event and advance
+        # the worker's layer counter. The layer name is empty because the
+        # worker advances via its current_layer counter (same as GDN path).
+        maybe_save_kv_layer_to_connector("", [])


### PR DESCRIPTION
## Description
This PR adds layerwise KV pool support for Kimi K3 hybrid models that combine KDA (Kimi Delta Attention, gated DeltaNet linear attention) layers with no-RoPE MLA layers. 

## Changes
- KDA forward ( vllm_ascend/ops/kimi_kda.py ) : Add wait_for_kv_layer_from_connector(self.prefix) at the start of _forward() (after metadata lookup, before any kernel touches conv_state / recurrent_state ) and record_attention_compute_start() right after it. Add maybe_save_kv_layer_to_connector("", []) at the method exit after the state write kernels are enqueued, and in the idle-DP early-return branch so the worker's current_layer counter stays in sync even for dummy runs. KDA layers do not go through the @maybe_transfer_kv_layer decorator, so they must explicitly call these hooks to participate in layerwise KV transfer — the call pattern is aligned 1:1 with the GDN path in ops/gdn.py .

## Testing
  - Service starts successfully with use_layerwise=true 
  - KV cache hit confirmed on repeated requests, hit token count matches the shared prefix
  - Layerwise on/off output logprob consistency (correctness baseline)

- vLLM main: https://github.com/vllm-project/vllm/commit/ba07e4a48fc951300d97eb506217dd530583dea3
