### PR TITLE
[Feature][Kernel] Add opt-in Ascend950 AddRmsNormBias fusion

### DIFF
--- a/csrc/build_aclnn.sh
+++ b/csrc/build_aclnn.sh
@@ -206,6 +206,7 @@ elif [[ "$SOC_VERSION" =~ ^ascend950 ]]; then
     setup_catlass_dependency
 
     CUSTOM_OPS_ARRAY=(
+        "add_rms_norm_bias"
         "moe_gating_top_k_hash"
         "inplace_partial_rotary_mul"
         "kv_compress_epilog"

--- a/csrc/moe/add_rms_norm_bias/op_host/add_rms_norm_bias_def.cpp
+++ b/csrc/moe/add_rms_norm_bias/op_host/add_rms_norm_bias_def.cpp
@@ -65,6 +65,7 @@ public:
 
         this->AICore().AddConfig("ascend910b");
         this->AICore().AddConfig("ascend910_93");
+        this->AICore().AddConfig("ascend950");
     }
 };
 OP_ADD(AddRmsNormBias);

--- a/csrc/moe/add_rms_norm_bias/op_host/add_rms_norm_bias_infershape.cpp
+++ b/csrc/moe/add_rms_norm_bias/op_host/add_rms_norm_bias_infershape.cpp
@@ -13,7 +13,6 @@
  * \brief
  */
 #include "tiling_base/error_log.h"
-#include "util/shape_util.h"
 #include "register/op_impl_registry.h"
 
 static constexpr int IDX_0 = 0;
@@ -21,7 +20,6 @@ static constexpr int IDX_1 = 1;
 static constexpr int IDX_2 = 2;
 
 using namespace ge;
-using namespace Ops::Base;
 
 namespace ops {
 
@@ -47,8 +45,12 @@ static ge::graphStatus InferShape4AddRmsNormBias(gert::InferShapeContext* contex
     size_t xDimNum = x1Shape->GetDimNum();
     size_t gammaDimNum = gammaShape->GetDimNum();
 
-    if (IsUnknownRank(*x1Shape) || IsUnknownRank(*gammaShape)) {
-        SetUnknownRank(*rstdShape);
+    // Keep standalone custom packages independent of private Ops::Base symbols.
+    const bool xUnknown = xDimNum == 1 && x1Shape->GetDim(0) == -2;
+    const bool gammaUnknown = gammaDimNum == 1 && gammaShape->GetDim(0) == -2;
+    if (xUnknown || gammaUnknown) {
+        rstdShape->SetDimNum(1);
+        rstdShape->SetDim(0, -2);
         OP_LOGD(context, "End to do InferShape4AddRmsNormBias with unknown rank.");
         return GRAPH_SUCCESS;
     }

--- a/csrc/moe/add_rms_norm_bias/op_host/add_rms_norm_bias_tiling.cpp
+++ b/csrc/moe/add_rms_norm_bias/op_host/add_rms_norm_bias_tiling.cpp
@@ -402,6 +402,19 @@ static ge::graphStatus Tiling4AddRmsNormBias(gert::TilingContext* context)
     uint32_t dtype_key;
     uint32_t data_per_block;
     ge::DataType data_type = SetDataTypeParameters(context, dtype_key, data_per_block);
+    if (addRmsNormBiasSocVersion == platform_ascendc::SocVersion::ASCEND950) {
+        // Initial A5 row kernel: aligned widths that fit the UB, including GLM's 6144.
+        const uint64_t required = uint64_t(num_col) * (24 + 2 * (dtype_key == DTYPE_KEY_FP32 ? 4 : 2));
+        if (num_col == 0 || num_col % 16 != 0 || num_col > 6144 || required + 1024 > ub_size) {
+            OP_LOGE(context, "A5 AddRmsNormBias requires aligned width <=6144 fitting UB.");
+            return ge::GRAPH_FAILED;
+        }
+        SetTilingParameters(&tiling, num_row, num_col, num_col, block_factor,
+            latsBlockFactor, 1, num_col, epsilon);
+        SaveTilingData(context, &tiling, dtype_key, 5);
+        SetWorkspaceSize(context);
+        return ge::GRAPH_SUCCESS;
+    }
     uint32_t mode_key = MODE_NORMAL;
     uint32_t row_factor = 64;
     uint32_t ub_factor = betaDesc == nullptr ? ((dtype_key == DTYPE_KEY_FP32) ? UB_FACTOR_B32 : UB_FACTOR_B16) : ((dtype_key == DTYPE_KEY_FP32) ? UB_FACTOR_B32_WITH_BETA : UB_FACTOR_B16_WITH_BETA);

--- a/csrc/moe/add_rms_norm_bias/op_kernel/add_rms_norm_bias.cpp
+++ b/csrc/moe/add_rms_norm_bias/op_kernel/add_rms_norm_bias.cpp
@@ -12,11 +12,15 @@
  * \file add_rms_norm_bias.cpp
  * \brief
  */
+#if defined(__NPU_ARCH__) && __NPU_ARCH__ == 3510
+#include "add_rms_norm_bias_a5.h"
+#else
 #include "add_rms_norm_bias.h"
 #include "add_rms_norm_bias_split_d.h"
 #include "add_rms_norm_bias_merge_n.h"
 #include "add_rms_norm_bias_multi_n.h"
 #include "add_rms_norm_bias_single_n.h"
+#endif
 
 using namespace AscendC;
 
@@ -32,6 +36,11 @@ extern "C" __global__ __aicore__ void add_rms_norm_bias(
 {
     TPipe pipe;
     GET_TILING_DATA(tilingData, tiling);
+#if defined(__NPU_ARCH__) && __NPU_ARCH__ == 3510
+    if (TILING_KEY_IS(15)) { GENERAL_OP_IMPL(KernelAddRmsNormBiasA5, half); }
+    else if (TILING_KEY_IS(25)) { GENERAL_OP_IMPL(KernelAddRmsNormBiasA5, float); }
+    else if (TILING_KEY_IS(35)) { GENERAL_OP_IMPL(KernelAddRmsNormBiasA5, bfloat16_t); }
+#else
     if (TILING_KEY_IS(10)) {
         GENERAL_OP_IMPL(KernelAddRmsNormBias, half);
     } else if (TILING_KEY_IS(20)) {
@@ -69,4 +78,5 @@ extern "C" __global__ __aicore__ void add_rms_norm_bias(
     } else if (TILING_KEY_IS(34)) {
         GENERAL_OP_IMPL(KernelAddRmsNormBiasMultiN, bfloat16_t);
     }
+#endif
 }

--- a/csrc/moe/add_rms_norm_bias/op_kernel/add_rms_norm_bias_a5.h
+++ b/csrc/moe/add_rms_norm_bias/op_kernel/add_rms_norm_bias_a5.h
@@ -1,0 +1,97 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// Licensed under CANN Open Software License Agreement Version 2.0.
+// Row-strided fusion follows sgl-kernel-npu/norm/add_rmsnorm_bias.py:
+// round the residual addition, reduce in FP32, then fuse affine and bias.
+#ifndef ADD_RMS_NORM_BIAS_A5_H_
+#define ADD_RMS_NORM_BIAS_A5_H_
+#include "kernel_operator.h"
+using namespace AscendC;
+
+template <typename T> class KernelAddRmsNormBiasA5 {
+public:
+    __aicore__ inline explicit KernelAddRmsNormBiasA5(TPipe* p) : pipe(p) {}
+    __aicore__ inline void Init(GM_ADDR x1, GM_ADDR x2, GM_ADDR gamma,
+        GM_ADDR beta, GM_ADDR y, GM_ADDR rstd, GM_ADDR x,
+        const AddRMSNormBiasTilingData* t) {
+        rows=t->num_row; cols=t->num_col; eps=t->epsilon;
+        hasBias=!t->nullptr_beta;
+        in1.SetGlobalBuffer((__gm__ T*)x1);
+        in2.SetGlobalBuffer((__gm__ T*)x2);
+        weight.SetGlobalBuffer((__gm__ T*)gamma);
+        bias.SetGlobalBuffer((__gm__ T*)beta);
+        out.SetGlobalBuffer((__gm__ T*)y);
+        residual.SetGlobalBuffer((__gm__ T*)x);
+        inv.SetGlobalBuffer((__gm__ float*)rstd);
+        pipe->InitBuffer(fp, cols*6*sizeof(float));
+        pipe->InitBuffer(raw, cols*2*sizeof(T));
+    }
+    template<HardEvent E> __aicore__ inline void Sync() {
+        auto e=static_cast<event_t>(pipe->FetchEventID(E));
+        SetFlag<E>(e); WaitFlag<E>(e);
+    }
+    __aicore__ inline void ToFloat(LocalTensor<float> d, LocalTensor<T> s) {
+        if constexpr (std::is_same<T,float>::value) {
+            Adds(d,s,0.0f,cols);
+        } else {
+            Cast(d,s,RoundMode::CAST_NONE,cols);
+        }
+        PipeBarrier<PIPE_V>();
+    }
+    __aicore__ inline void FromFloat(LocalTensor<T> d, LocalTensor<float> s) {
+        if constexpr (std::is_same<T,float>::value) {
+            Adds(d,s,0.0f,cols);
+        } else {
+            Cast(d,s,RoundMode::CAST_RINT,cols);
+        }
+        PipeBarrier<PIPE_V>();
+    }
+    __aicore__ inline void Process() {
+        auto sum=fp.Get<float>(); auto other=sum[cols];
+        auto w=sum[2*cols]; auto b=sum[3*cols];
+        auto square=sum[4*cols]; auto tmp=sum[5*cols];
+        auto a=raw.Get<T>(); auto r=a[cols];
+        DataCopy(a,weight,cols); Sync<HardEvent::MTE2_V>();
+        ToFloat(w,a); Sync<HardEvent::V_MTE2>();
+        if(hasBias) {
+            DataCopy(a,bias,cols); Sync<HardEvent::MTE2_V>();
+            ToFloat(b,a); Sync<HardEvent::V_MTE2>();
+        }
+        for(uint32_t row=GetBlockIdx(); row<rows; row+=GetBlockNum()) {
+            uint64_t offset=static_cast<uint64_t>(row)*cols;
+            DataCopy(a,in1[offset],cols); DataCopy(r,in2[offset],cols);
+            Sync<HardEvent::MTE2_V>();
+            ToFloat(sum,a); ToFloat(other,r);
+            Add(sum,sum,other,cols); PipeBarrier<PIPE_V>();
+            FromFloat(a,sum); ToFloat(sum,a);
+            Sync<HardEvent::V_MTE3>(); DataCopy(residual[offset],a,cols);
+            Mul(square,sum,sum,cols); PipeBarrier<PIPE_V>();
+            ReduceSum(other,square,tmp,cols); PipeBarrier<PIPE_V>();
+            Muls(other,other,1.0f/cols,1); PipeBarrier<PIPE_V>();
+            Adds(other,other,eps,1); PipeBarrier<PIPE_V>();
+            Sqrt(other,other,1); PipeBarrier<PIPE_V>();
+            Duplicate(tmp,1.0f,1); PipeBarrier<PIPE_V>();
+            Div(other,tmp,other,1); PipeBarrier<PIPE_V>();
+            Sync<HardEvent::V_MTE3>();
+            DataCopyExtParams scalarCopy{1,sizeof(float),0,0,0};
+            DataCopyPad(inv[row],other,scalarCopy);
+            Sync<HardEvent::V_S>();
+            float scale=other.GetValue(0);
+            Sync<HardEvent::S_V>();
+            Muls(sum,sum,scale,cols); PipeBarrier<PIPE_V>();
+            Mul(sum,sum,w,cols); PipeBarrier<PIPE_V>();
+            if(hasBias) { Add(sum,sum,b,cols); PipeBarrier<PIPE_V>(); }
+            Sync<HardEvent::MTE3_V>();
+            FromFloat(a,sum); Sync<HardEvent::V_MTE3>();
+            DataCopy(out[offset],a,cols);
+            Sync<HardEvent::MTE3_MTE2>();
+            Sync<HardEvent::V_MTE2>();
+        }
+    }
+private:
+    TPipe* pipe;
+    TBuf<TPosition::VECCALC> fp,raw;
+    GlobalTensor<T> in1,in2,weight,bias,out,residual;
+    GlobalTensor<float> inv;
+    uint32_t rows,cols; float eps; bool hasBias;
+};
+#endif

--- a/tests/e2e/nightly/single_node/ops/singlecard_ops/test_add_rms_norm_bias.py
+++ b/tests/e2e/nightly/single_node/ops/singlecard_ops/test_add_rms_norm_bias.py
@@ -5,6 +5,8 @@ import numpy as np
 import pytest
 import torch
 
+from vllm_ascend.utils import AscendDeviceType, bootstrap_custom_op_env, get_ascend_device_type
+
 seed = 45
 random.seed(seed)
 np.random.seed(seed)
@@ -70,6 +72,10 @@ def npu_add_rms_norm_bias_golden(input_x1, input_x2, input_gamma, input_beta, ke
     return yOut, rstdOut, xOut
 
 
+@pytest.mark.skipif(
+    get_ascend_device_type() == AscendDeviceType.A5,
+    reason="A5 has a separate aligned-width kernel and FP32 affine reference below.",
+)
 @pytest.mark.parametrize(
     "row",
     [1, 16, 64, 77, 128, 255, 1000],
@@ -137,3 +143,30 @@ def test_quant_fpx_linear(row: int, col: int, dtype, atol, rtol, kernelType):
     gc.collect()
     torch.npu.empty_cache()
     torch.npu.reset_peak_memory_stats()
+
+
+@pytest.mark.skipif(get_ascend_device_type() != AscendDeviceType.A5, reason="Requires Ascend A5")
+@pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float16, torch.float32])
+@pytest.mark.parametrize("width", [16, 128, 1024, 6144])
+@pytest.mark.parametrize("with_bias", [False, True])
+def test_a5_add_rms_norm_bias_outputs(dtype, width, with_bias):
+    bootstrap_custom_op_env(include_vendor_lib=True)
+    import vllm_ascend.vllm_ascend_C  # noqa: F401
+
+    generator = torch.Generator().manual_seed(45)
+    x = torch.randn(3, width, dtype=dtype, generator=generator)
+    residual = torch.randn(3, width, dtype=dtype, generator=generator)
+    weight = torch.randn(width, dtype=dtype, generator=generator)
+    bias = torch.randn(width, dtype=dtype, generator=generator) if with_bias else None
+    y, rstd, summed = torch.ops._C_ascend.npu_add_rms_norm_bias(
+        x.npu(), residual.npu(), weight.npu(), bias.npu() if bias is not None else None, 1e-6
+    )
+    rounded_sum = (x.float() + residual.float()).to(dtype).float()
+    expected_rstd = torch.rsqrt(rounded_sum.square().mean(-1, keepdim=True) + 1e-6)
+    expected = rounded_sum * expected_rstd * weight.float()
+    if bias is not None:
+        expected += bias.float()
+    tolerance = {torch.bfloat16: 0.008, torch.float16: 0.001, torch.float32: 2e-5}[dtype]
+    torch.testing.assert_close(summed.cpu(), rounded_sum.to(dtype), atol=0, rtol=0)
+    torch.testing.assert_close(rstd.cpu(), expected_rstd, atol=2e-6, rtol=2e-5)
+    torch.testing.assert_close(y.cpu(), expected.to(dtype), atol=tolerance, rtol=tolerance)

--- a/tests/e2e/nightly/single_node/ops/singlecard_ops/test_add_rms_norm_bias.py
+++ b/tests/e2e/nightly/single_node/ops/singlecard_ops/test_add_rms_norm_bias.py
@@ -151,7 +151,7 @@ def test_quant_fpx_linear(row: int, col: int, dtype, atol, rtol, kernelType):
 @pytest.mark.parametrize("with_bias", [False, True])
 def test_a5_add_rms_norm_bias_outputs(dtype, width, with_bias):
     bootstrap_custom_op_env(include_vendor_lib=True)
-    import vllm_ascend.vllm_ascend_C  # noqa: F401
+    import vllm_ascend.vllm_ascend_C  # type: ignore[import-untyped]  # noqa: F401
 
     generator = torch.Generator().manual_seed(45)
     x = torch.randn(3, width, dtype=dtype, generator=generator)

--- a/tests/ut/ops/test_layernorm.py
+++ b/tests/ut/ops/test_layernorm.py
@@ -1,3 +1,4 @@
+import sys
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -6,11 +7,62 @@ from vllm.config import set_current_vllm_config
 from vllm.model_executor.layers.layernorm import RMSNorm
 from vllm.third_party.flash_linear_attention.ops.kda import FusedRMSNormGated
 
-from vllm_ascend.ops.layernorm import AscendFusedRMSNormGated
-from vllm_ascend.utils import enable_custom_op
+from vllm_ascend.ops.layernorm import AscendFusedRMSNormGated, _enable_a5_add_rms_norm_bias
+from vllm_ascend.utils import AscendDeviceType, enable_custom_op
 from vllm_ascend.utils import is_310p as is_310p_hw
 
 enable_custom_op()
+
+
+@pytest.mark.parametrize("width", [16, 128, 1024, 6144])
+def test_a5_add_rms_norm_bias_loads_extension_only_when_supported(width):
+    tensor = MagicMock(shape=(3, width))
+    with (
+        patch("vllm_ascend.envs.VLLM_ASCEND_ENABLE_ADD_RMS_NORM_BIAS", True),
+        patch("vllm_ascend.ops.layernorm.get_ascend_device_type", return_value=AscendDeviceType.A5),
+        patch("vllm.envs.VLLM_BATCH_INVARIANT", False),
+        patch("vllm_ascend.ops.layernorm.bootstrap_custom_op_env") as bootstrap,
+        patch.dict(sys.modules, {"vllm_ascend.vllm_ascend_C": MagicMock()}),
+    ):
+        assert _enable_a5_add_rms_norm_bias(tensor)
+        bootstrap.assert_called_once_with(include_vendor_lib=True)
+
+
+@pytest.mark.parametrize(
+    "enabled, device, invariant, width",
+    [
+        (False, AscendDeviceType.A5, False, 6144),
+        (True, AscendDeviceType.A2, False, 6144),
+        (True, AscendDeviceType.A5, True, 6144),
+        (True, AscendDeviceType.A5, False, 0),
+        (True, AscendDeviceType.A5, False, 15),
+        (True, AscendDeviceType.A5, False, 6145),
+        (True, AscendDeviceType.A5, False, 8192),
+    ],
+)
+def test_a5_add_rms_norm_bias_keeps_existing_path(enabled, device, invariant, width):
+    tensor = MagicMock(shape=(3, width))
+    with (
+        patch("vllm_ascend.envs.VLLM_ASCEND_ENABLE_ADD_RMS_NORM_BIAS", enabled),
+        patch("vllm_ascend.ops.layernorm.get_ascend_device_type", return_value=device),
+        patch("vllm.envs.VLLM_BATCH_INVARIANT", invariant),
+        patch("vllm_ascend.ops.layernorm.bootstrap_custom_op_env") as bootstrap,
+    ):
+        assert not _enable_a5_add_rms_norm_bias(tensor)
+        bootstrap.assert_not_called()
+
+
+def test_a5_add_rms_norm_bias_reports_missing_extension():
+    tensor = MagicMock(shape=(3, 6144))
+    with (
+        patch("vllm_ascend.envs.VLLM_ASCEND_ENABLE_ADD_RMS_NORM_BIAS", True),
+        patch("vllm_ascend.ops.layernorm.get_ascend_device_type", return_value=AscendDeviceType.A5),
+        patch("vllm.envs.VLLM_BATCH_INVARIANT", False),
+        patch("vllm_ascend.ops.layernorm.bootstrap_custom_op_env"),
+        patch.dict(sys.modules, {"vllm_ascend.vllm_ascend_C": None}),
+        pytest.raises(ImportError),
+    ):
+        _enable_a5_add_rms_norm_bias(tensor)
 
 
 @pytest.fixture

--- a/tests/ut/ops/test_layernorm.py
+++ b/tests/ut/ops/test_layernorm.py
@@ -52,6 +52,18 @@ def test_a5_add_rms_norm_bias_keeps_existing_path(enabled, device, invariant, wi
         bootstrap.assert_not_called()
 
 
+def test_a5_add_rms_norm_bias_keeps_existing_path_for_scalar():
+    tensor = MagicMock(shape=())
+    with (
+        patch("vllm_ascend.envs.VLLM_ASCEND_ENABLE_ADD_RMS_NORM_BIAS", True),
+        patch("vllm_ascend.ops.layernorm.get_ascend_device_type", return_value=AscendDeviceType.A5),
+        patch("vllm.envs.VLLM_BATCH_INVARIANT", False),
+        patch("vllm_ascend.ops.layernorm.bootstrap_custom_op_env") as bootstrap,
+    ):
+        assert not _enable_a5_add_rms_norm_bias(tensor)
+        bootstrap.assert_not_called()
+
+
 def test_a5_add_rms_norm_bias_reports_missing_extension():
     tensor = MagicMock(shape=(3, 6144))
     with (

--- a/vllm_ascend/envs.py
+++ b/vllm_ascend/envs.py
@@ -28,6 +28,9 @@ from typing import Any
 # begin-env-vars-definition
 
 env_variables: dict[str, Callable[[], Any]] = {
+    # Opt-in A5 AddRmsNormBias row fusion: 0 (default) disables, 1 enables.
+    # Non-sensitive; the default retains the existing path.
+    "VLLM_ASCEND_ENABLE_ADD_RMS_NORM_BIAS": lambda: bool(int(os.getenv("VLLM_ASCEND_ENABLE_ADD_RMS_NORM_BIAS", "0"))),
     # max compile thread number for package building. Usually, it is set to
     # the number of CPU cores. If not set, the default value is None, which
     # means all number of CPU cores will be used.

--- a/vllm_ascend/ops/layernorm.py
+++ b/vllm_ascend/ops/layernorm.py
@@ -42,7 +42,7 @@ def _enable_a5_add_rms_norm_bias(x: torch.Tensor) -> bool:
 
     if vllm_envs.VLLM_BATCH_INVARIANT:
         return False
-    if x.shape[-1] == 0 or x.shape[-1] > 6144 or x.shape[-1] % 16:
+    if not x.shape or x.shape[-1] == 0 or x.shape[-1] > 6144 or x.shape[-1] % 16:
         return False
     bootstrap_custom_op_env(include_vendor_lib=True)
     # Explicit opt-in must report a missing build instead of silently benchmarking

--- a/vllm_ascend/ops/layernorm.py
+++ b/vllm_ascend/ops/layernorm.py
@@ -21,10 +21,35 @@ from vllm.config import get_current_vllm_config
 from vllm.model_executor.layers.layernorm import GemmaRMSNorm, RMSNorm, RMSNormGated
 from vllm.third_party.flash_linear_attention.ops.kda import FusedRMSNormGated
 
+from vllm_ascend import envs
 from vllm_ascend.device.device_op import DeviceOperator
 from vllm_ascend.ops.triton.kda.kda import rms_norm_gated
 from vllm_ascend.ops.triton.layernorm_gated import layer_norm_fwd_npu
-from vllm_ascend.utils import enable_custom_op
+from vllm_ascend.utils import (
+    AscendDeviceType,
+    bootstrap_custom_op_env,
+    enable_custom_op,
+    get_ascend_device_type,
+)
+
+
+def _enable_a5_add_rms_norm_bias(x: torch.Tensor) -> bool:
+    if not envs.VLLM_ASCEND_ENABLE_ADD_RMS_NORM_BIAS:
+        return False
+    if get_ascend_device_type() != AscendDeviceType.A5:
+        return False
+    import vllm.envs as vllm_envs
+
+    if vllm_envs.VLLM_BATCH_INVARIANT:
+        return False
+    if x.shape[-1] == 0 or x.shape[-1] > 6144 or x.shape[-1] % 16:
+        return False
+    bootstrap_custom_op_env(include_vendor_lib=True)
+    # Explicit opt-in must report a missing build instead of silently benchmarking
+    # the baseline. Keep the global custom-op enablement unchanged on A5.
+    import vllm_ascend.vllm_ascend_C  # noqa: F401
+
+    return True
 
 
 class AscendRMSNorm(RMSNorm):
@@ -69,7 +94,7 @@ class AscendRMSNorm(RMSNorm):
         import torch_npu
 
         if residual is not None:
-            if enable_custom_op():
+            if _enable_a5_add_rms_norm_bias(x) or enable_custom_op():
                 x, _, residual = torch.ops._C_ascend.npu_add_rms_norm_bias(
                     x, residual, self.weight, self.bias, self.variance_epsilon
                 )
@@ -95,7 +120,7 @@ class AscendGemmaRMSNorm(GemmaRMSNorm):
         import torch_npu
 
         if residual is not None:
-            if enable_custom_op():
+            if _enable_a5_add_rms_norm_bias(x) or enable_custom_op():
                 x, _, residual = torch.ops._C_ascend.npu_add_rms_norm_bias(
                     x, residual, 1.0 + self.weight, None, self.variance_epsilon
                 )

--- a/vllm_ascend/ops/layernorm.py
+++ b/vllm_ascend/ops/layernorm.py
@@ -47,7 +47,7 @@ def _enable_a5_add_rms_norm_bias(x: torch.Tensor) -> bool:
     bootstrap_custom_op_env(include_vendor_lib=True)
     # Explicit opt-in must report a missing build instead of silently benchmarking
     # the baseline. Keep the global custom-op enablement unchanged on A5.
-    import vllm_ascend.vllm_ascend_C  # noqa: F401
+    import vllm_ascend.vllm_ascend_C  # type: ignore[import-untyped]  # noqa: F401
 
     return True
 


### PR DESCRIPTION
### What this PR does / why we need it?

Add an opt-in Ascend950 implementation of AddRmsNormBias. The existing residual RMSNorm path issues a separate bias addition when norm bias is present; the new AscendC row kernel performs residual addition, RMS normalization, weight multiplication, and optional bias addition in one launch.

- Build and register the operator for Ascend950, with dedicated FP16, BF16, and FP32 tiling keys.
- Support aligned hidden widths up to 6144 that fit the UB allocation. Preserve the residual output and FP32 reciprocal RMS output.
- Round the residual sum to the input dtype before the FP32 reduction. Perform normalization, weight multiplication, and bias addition in FP32 before the final cast; this is not bitwise equivalent to the separate-op path.
- Avoid private shape-helper symbols when loading the standalone custom operator package.
- Add guarded RMSNorm/GemmaRMSNorm dispatch without enabling all A5 custom operators globally.
- Add dispatch unit tests and an A5-specific numerical reference to the existing operator system tests.

The implementation follows the row scheduling and fused affine calculation in [sgl-kernel-npu AddRMSNormBias](https://github.com/sgl-project/sgl-kernel-npu/blob/69d392bd11f280babcef113fcef9cc4756a95fc6/python/sgl_kernel_npu/sgl_kernel_npu/norm/add_rmsnorm_bias.py). Its optional quantized-output branch is not included here.

### Does this PR introduce _any_ user-facing change?

`VLLM_ASCEND_ENABLE_ADD_RMS_NORM_BIAS=1` opts into the A5 path. It defaults to `0`; unsupported widths, non-A5 devices, and batch-invariant execution retain the existing dispatch. An explicitly enabled but missing extension reports a load error.

This PR does not change MC2 selection or include machine-specific examples, benchmark scratch scripts, Claude settings, or fleet-monitor files.

### How was this patch tested?

The kernel and host implementation were built and installed for Ascend950 on the original development baseline. Eighteen dtype/row-count cases and twenty-four dtype/width/optional-bias cases passed (42 total), checking the normalized result, exact rounded residual output, and FP32 reciprocal RMS. The main correctness matrix also compared against `torch_npu.npu_add_rms_norm` followed by bias addition within dtype-specific tolerances.

BF16, hidden width 6144, NPU-event timings around graph replay (median microseconds):

| Rows | Separate operators | Fused operator |
| ---: | ---: | ---: |
| 1 | 3.701 | 3.407 |
| 32 | 8.039 | 6.636 |
| 128 | 9.531 | 8.632 |
| 1024 | 25.782 | 35.067 |
| 4096 | 114.544 | 147.439 |

**Draft:** large-row performance regresses, so the feature remains disabled by default. End-to-end accuracy comparison is still running. The source changes have been ported to current upstream main; full integration/NPU testing of that rebased tree remains pending. The container-specific `maybe_chunk_residual` call was not carried into upstream main.

Ruff and Python syntax checks cover the changed Python files. The repository-wide `bash format.sh ci` was attempted but stalled while installing its markdownlint environment; full lint and the newly integrated pytest cases remain pending.

Reproduction on an Ascend950 development environment:

```bash
cd csrc
bash build.sh --pkg --ops=add_rms_norm_bias --soc=ascend950
cd ..
# Install the generated custom operator package for this checkout first.
pytest tests/ut/ops/test_layernorm.py -k a5_add_rms_norm_bias
pytest tests/e2e/nightly/single_node/ops/singlecard_ops/test_add_rms_norm_bias.py -k a5_add_rms_norm_bias
```

- vLLM main: https://github.com/vllm-project/vllm/commit/b2f685834a6456197e7033966fdef52a23f1abcd
