### PR TITLE
[Doc][Misc] Use English comments in GLM-5 and GLM-5.2 model tutorials

### DIFF
--- a/docs/source/tutorials/models/GLM5.2.md
+++ b/docs/source/tutorials/models/GLM5.2.md
@@ -16,8 +16,8 @@ Refer to [feature guide](../../user_guide/feature_guide/index.md) to get the fea
 
 ### 3.1 Model Weight
 
-- `GLM-5.2-w8a8c8`: requires 2 Atlas 800 A3 (128GB × 8) node.[Download model weight](https://modelers.cn/models/Eco-Tech/GLM-5.2-w8a8c8).
-- `GLM-5.2-w4a8c8` (experimental): requires 1 Atlas 800 A3 (128GB × 8) node or 2 Atlas 800 A2 (64GB × 8) node. This experimental feature has known accuracy issues in Prefill-Decode (PD) disaggregation scenarios. [Download model weight](https://www.modelscope.cn/models/Eco-Tech/GLM-5.2-w4a8c8).
+- `GLM-5.2-w8a8c8`: requires 2 Atlas 800 A3 (128GB × 8) node.[Download model weight](https://modelers.cn/models/Eco-Tech/GLM-5.2-w8a8c8). The weights have been verified on Atlas 800 A3 and are recommended for use.
+- `GLM-5.2-w4a8c8` (experimental): requires 1 Atlas 800 A3 (128GB × 8) node or 2 Atlas 800 A2 (64GB × 8) node. This experimental feature has known accuracy issues in Prefill-Decode (PD) disaggregation scenarios. [Download model weight](https://www.modelscope.cn/models/Eco-Tech/GLM-5.2-w4a8c8). The weights have been verified on Atlas 800 A2 and are recommended for use.
 - You can use [msmodelslim](https://gitcode.com/Ascend/msmodelslim) to quantize the model directly.
 
 It is recommended to download the model weight to the shared directory of multiple nodes, such as `/root/.cache/`

--- a/docs/source/tutorials/models/GLM5.2.md
+++ b/docs/source/tutorials/models/GLM5.2.md
@@ -362,7 +362,6 @@ Before you start, please
     dp_address = args.dp_address
     dp_rpc_port = args.dp_rpc_port
     vllm_start_port = args.vllm_start_port
-    # 一个 DP 副本占 tp×pp 张连续卡（pp=1 时退化为现状的 tp）
     gpus_per_dp_rank = tp_size * pp_size
 
     def run_command(visible_devices, dp_rank, vllm_engine_port):
@@ -560,8 +559,8 @@ Before you start, please
         nic_name="xxxx" # change to your own nic name
         local_ip="xxxx" # change to your own ip
 
-        # 每个 DP rank 使用独立的 engine_id,避免 KV 路由混淆
-        # $4 = data-parallel-rank; 节点内 rank 偏移 0-3 → engine_id 100-103
+        # Each DP rank uses an independent engine ID to avoid KV route confusion.
+        # $4 = data-parallel-rank. The rank offset within a node is 0 to 3, and the corresponding engine ID is 100 to 103.
         ENGINE_ID=$((100 + $4))
 
         export HCCL_OP_EXPANSION_MODE="AIV"
@@ -634,8 +633,8 @@ Before you start, please
         nic_name="xxxx" # change to your own nic name
         local_ip="xxxx" # change to your own ip
 
-        # 每个 DP rank 使用独立的 engine_id,避免 KV 路由混淆
-        # $4 = data-parallel-rank; 节点内 rank 偏移 0-3 → engine_id 100-103
+        # Each DP rank uses an independent engine ID to avoid KV route confusion.
+        # $4 = data-parallel-rank. The rank offset within a node is 0 to 3, and the corresponding engine ID is 100 to 103.
         ENGINE_ID=$((100 + $4))
 
         export HCCL_OP_EXPANSION_MODE="AIV"

--- a/docs/source/tutorials/models/GLM5.md
+++ b/docs/source/tutorials/models/GLM5.md
@@ -24,8 +24,8 @@ Refer to [feature guide](../../user_guide/feature_guide/index.md) to get the fea
 - `GLM-5-w8a8`(Quantized version): [Download model weight](https://www.modelscope.cn/models/Eco-Tech/GLM-5-w8a8).
 - `GLM-5.1-w4a8`(Quantized version): [Download model weight](https://modelers.cn/models/Eco-Tech/GLM-5.1-w4a8).
 - `GLM-5.1-w8a8`(Quantized version): [Download model weight](https://modelers.cn/models/Eco-Tech/GLM-5.1-w8a8).
-- `GLM-5.1-w8a8c8`(Quantized version): [Download model weight](https://modelers.cn/models/Eco-Tech/GLM-5.1-w8a8c8-MTP).
-- `GLM-5.1-w4a4`(Ascend950DT mxfp4 Quantized): [Download model weight](https://www.modelscope.cn/models/Eco-Tech/GLM-5.1-w4a4c8-mxfp4).
+- `GLM-5.1-w8a8c8`(Quantized version): [Download model weight](https://modelers.cn/models/Eco-Tech/GLM-5.1-w8a8c8-MTP). The weights have been verified on Atlas 800 A3 and are recommended for use.
+- `GLM-5.1-w4a4`(Ascend950DT mxfp4 Quantized): [Download model weight](https://www.modelscope.cn/models/Eco-Tech/GLM-5.1-w4a4c8-mxfp4). The weights have been verified on Ascend 950DT and are recommended for use.
 
 It is recommended to download the model weight to the shared directory of multiple nodes, such as `/root/.cache/`
 

--- a/docs/source/tutorials/models/GLM5.md
+++ b/docs/source/tutorials/models/GLM5.md
@@ -24,7 +24,7 @@ Refer to [feature guide](../../user_guide/feature_guide/index.md) to get the fea
 - `GLM-5-w8a8`(Quantized version): [Download model weight](https://www.modelscope.cn/models/Eco-Tech/GLM-5-w8a8).
 - `GLM-5.1-w4a8`(Quantized version): [Download model weight](https://modelers.cn/models/Eco-Tech/GLM-5.1-w4a8).
 - `GLM-5.1-w8a8`(Quantized version): [Download model weight](https://modelers.cn/models/Eco-Tech/GLM-5.1-w8a8).
-- `GLM-5.1-w8a8c8`(Quantized version for Atlas 800 A3): [Download model weight](https://modelers.cn/models/Eco-Tech/GLM-5.1-w8a8c8-MTP).
+- `GLM-5.1-w8a8c8`(Quantized version): [Download model weight](https://modelers.cn/models/Eco-Tech/GLM-5.1-w8a8c8-MTP).
 - `GLM-5.1-w4a4`(Ascend950DT mxfp4 Quantized): [Download model weight](https://www.modelscope.cn/models/Eco-Tech/GLM-5.1-w4a4c8-mxfp4).
 
 It is recommended to download the model weight to the shared directory of multiple nodes, such as `/root/.cache/`
@@ -1089,7 +1089,6 @@ dp_rank_start = args.dp_rank_start
 dp_address = args.dp_address
 dp_rpc_port = args.dp_rpc_port
 vllm_start_port = args.vllm_start_port
-# 一个 DP 副本占 tp×pp 张连续卡（pp=1 时退化为现状的 tp）
 gpus_per_dp_rank = tp_size * pp_size
 
 def run_command(visible_devices, dp_rank, vllm_engine_port):
@@ -1289,8 +1288,8 @@ if __name__ == "__main__":
         nic_name="xxxx" # change to your own nic name
         local_ip="xxxx" # change to your own ip
 
-        # 每个 DP rank 使用独立的 engine_id,避免 KV 路由混淆
-        # $4 = data-parallel-rank; 节点内 rank 偏移 0-3 → engine_id 100-103
+        # Each DP rank uses an independent engine ID to avoid KV route confusion.
+        # $4 = data-parallel-rank. The rank offset within a node is 0 to 3, and the corresponding engine ID is 100 to 103.
         ENGINE_ID=$((100 + $4))
 
         export HCCL_OP_EXPANSION_MODE="AIV"
@@ -1365,8 +1364,8 @@ if __name__ == "__main__":
         nic_name="xxxx" # change to your own nic name
         local_ip="xxxx" # change to your own ip
 
-        # 每个 DP rank 使用独立的 engine_id,避免 KV 路由混淆
-        # $4 = data-parallel-rank; 节点内 rank 偏移 0-3 → engine_id 100-103
+        # Each DP rank uses an independent engine ID to avoid KV route confusion.
+        # $4 = data-parallel-rank. The rank offset within a node is 0 to 3, and the corresponding engine ID is 100 to 103.
         ENGINE_ID=$((100 + $4))
 
         export HCCL_OP_EXPANSION_MODE="AIV"


### PR DESCRIPTION
 ### What this PR does / why we need it?
  Replace Chinese comments inside code examples of the GLM-5 and GLM-5.2
  deployment tutorials with English, matching the project's language
  convention. Also drop the "Atlas 800 A3" qualifier from the                                                             `GLM-5.1-w8a8c8` model link, as it is already stated by the surrounding                                                 text and the recommended-config tables below.                                                                         
  - `GLM5.md`: translate/remove Chinese comments in deployment scripts
  - `GLM5.2.md`: same fix, plus one leftover Chinese comment
  - No other files changed; based on latest `releases/v0.23.0`                                                          
  ### Does this PR introduce _any_ user-facing change?
  No. Documentation-only cleanup of tutorial comments (language switch,
  no content change).                                                                                                   
  ### How was this patch tested?
  Both files verified free of CJK characters (`grep -P '[\x{4e00}-\x{9fff}]'`
  returns nothing); documentation-only change, no tests added.

- vLLM main: https://github.com/vllm-project/vllm/commit/ee0da84ab9e04ac7610e28580af62c365e898389
