### PR TITLE
[0.27.1rc][Test][Model] Add Kimi K3 A3 nightly coverage

### DIFF
--- a/.github/workflows/configs/nightly_config.yaml
+++ b/.github/workflows/configs/nightly_config.yaml
@@ -94,6 +94,9 @@ a2:
 a3:
   multi_node:
     test_config:
+      - name: kimi-k3-w4a8-a3
+        config_file_path: Kimi-K3-W4A8-A3.yaml
+        size: 4
       - name: multi-node-deepseek-v3.2-W8A8-EP
         config_file_path: DeepSeek-V3_2-W8A8-EP.yaml
         config_base_path: tests/e2e/nightly/multi_node/internal_dp/config

--- a/.github/workflows/configs/nightly_config.yaml
+++ b/.github/workflows/configs/nightly_config.yaml
@@ -217,9 +217,6 @@ a3:
       - name: deepseek-r1-0528-w8a8-prefix-cache
         os: linux-aarch64-nightly-a3-16
         config_file_path: Prefix-Cache-DeepSeek-R1-0528-W8A8.yaml
-      - name: glm-4.7-w8a8
-        os: linux-aarch64-nightly-a3-16
-        config_file_path: GLM-4.7.yaml
       - name: qwen3-vl-235b-a22b-instruct-w8a8
         os: linux-aarch64-nightly-a3-16
         config_file_path: Qwen3-VL-235B-A22B-Instruct-W8A8.yaml
@@ -330,9 +327,6 @@ a3-560t:
       - name: deepseek-r1-0528-w8a8-prefix-cache
         os: linux-aarch64-a3-16-cn12-001
         config_file_path: Prefix-Cache-DeepSeek-R1-0528-W8A8.yaml
-      - name: glm-4.7-w8a8
-        os: linux-aarch64-a3-16-cn12-001
-        config_file_path: GLM-4.7.yaml
       - name: qwen3-vl-235b-a22b-instruct-w8a8
         os: linux-aarch64-a3-16-cn12-001
         config_file_path: Qwen3-VL-235B-A22B-Instruct-W8A8.yaml

--- a/.github/workflows/misc/model_dataset_list.json
+++ b/.github/workflows/misc/model_dataset_list.json
@@ -336,6 +336,7 @@
             "Eco-Tech/GLM-5.2-w8a8",
             "Eco-Tech/GLM-5.two-w8a8",
             "Eco-Tech/Kimi-K2.5-W4A8",
+            "Eco-Tech/Kimi-K3-w4a8",
             "Eco-Tech/Kimi-K2.6-w4a8",
             "Eco-Tech/Kimi-K2.7-Code-w4a8",
             "Eco-Tech/MiniMax-M2.5-w8a8-QuaRot",

--- a/tests/e2e/nightly/multi_node/internal_dp/config/Kimi-K3-W4A8-A3.yaml
+++ b/tests/e2e/nightly/multi_node/internal_dp/config/Kimi-K3-W4A8-A3.yaml
@@ -1,0 +1,156 @@
+test_name: "test Kimi-K3-W4A8 A3 four-node mixed deployment"
+model: "Eco-Tech/Kimi-K3-w4a8"
+num_nodes: 4
+npu_per_node: 16
+
+env_common: &env_common
+  VLLM_USE_MODELSCOPE: true
+  HCCL_BUFFSIZE: 800
+  PYTORCH_NPU_ALLOC_CONF: expandable_segments:True
+  OMP_PROC_BIND: false
+  OMP_NUM_THREADS: 1
+  TASK_QUEUE_ENABLE: 1
+  VLLM_ENGINE_READY_TIMEOUT_S: 7200
+  SERVER_PORT: 8080
+
+deployment:
+  - envs:
+      <<: *env_common
+    server_cmd: >
+      env -u HCCL_OP_EXPANSION_MODE vllm serve Eco-Tech/Kimi-K3-w4a8
+        --host 0.0.0.0
+        --port $SERVER_PORT
+        --quantization ascend
+        --allowed-local-media-path /
+        --trust-remote-code
+        --tokenizer-mode kimi_k3
+        --tensor-parallel-size 16
+        --data-parallel-size 4
+        --data-parallel-size-local 1
+        --data-parallel-start-rank 0
+        --data-parallel-address $LOCAL_IP
+        --data-parallel-rpc-port 13389
+        --enable-expert-parallel
+        --enable-prefix-caching
+        --max-num-seqs 16
+        --max-model-len 131027
+        --max-num-batched-tokens 8192
+        --gpu-memory-utilization 0.9
+        --compilation-config '{"cudagraph_mode":"FULL_DECODE_ONLY"}'
+        --additional-config '{"enable_cpu_binding":true,"enable_flashcomm1":true}'
+        --mm-processor-cache-gb 0
+        --mm-encoder-tp-mode data
+        --limit-mm-per-prompt '{"vision_chunk":2}'
+        --enable-auto-tool-choice
+        --reasoning-parser kimi_k3
+        --tool-call-parser kimi_k3
+
+  - envs:
+      <<: *env_common
+    server_cmd: >
+      env -u HCCL_OP_EXPANSION_MODE vllm serve Eco-Tech/Kimi-K3-w4a8
+        --host 0.0.0.0
+        --headless
+        --port $SERVER_PORT
+        --quantization ascend
+        --allowed-local-media-path /
+        --trust-remote-code
+        --tokenizer-mode kimi_k3
+        --tensor-parallel-size 16
+        --data-parallel-size 4
+        --data-parallel-size-local 1
+        --data-parallel-start-rank 1
+        --data-parallel-address $MASTER_IP
+        --data-parallel-rpc-port 13389
+        --enable-expert-parallel
+        --enable-prefix-caching
+        --max-num-seqs 16
+        --max-model-len 131027
+        --max-num-batched-tokens 8192
+        --gpu-memory-utilization 0.9
+        --compilation-config '{"cudagraph_mode":"FULL_DECODE_ONLY"}'
+        --additional-config '{"enable_cpu_binding":true,"enable_flashcomm1":true}'
+        --mm-processor-cache-gb 0
+        --mm-encoder-tp-mode data
+        --limit-mm-per-prompt '{"vision_chunk":2}'
+        --enable-auto-tool-choice
+        --reasoning-parser kimi_k3
+        --tool-call-parser kimi_k3
+
+  - envs:
+      <<: *env_common
+    server_cmd: >
+      env -u HCCL_OP_EXPANSION_MODE vllm serve Eco-Tech/Kimi-K3-w4a8
+        --host 0.0.0.0
+        --headless
+        --port $SERVER_PORT
+        --quantization ascend
+        --allowed-local-media-path /
+        --trust-remote-code
+        --tokenizer-mode kimi_k3
+        --tensor-parallel-size 16
+        --data-parallel-size 4
+        --data-parallel-size-local 1
+        --data-parallel-start-rank 2
+        --data-parallel-address $MASTER_IP
+        --data-parallel-rpc-port 13389
+        --enable-expert-parallel
+        --enable-prefix-caching
+        --max-num-seqs 16
+        --max-model-len 131027
+        --max-num-batched-tokens 8192
+        --gpu-memory-utilization 0.9
+        --compilation-config '{"cudagraph_mode":"FULL_DECODE_ONLY"}'
+        --additional-config '{"enable_cpu_binding":true,"enable_flashcomm1":true}'
+        --mm-processor-cache-gb 0
+        --mm-encoder-tp-mode data
+        --limit-mm-per-prompt '{"vision_chunk":2}'
+        --enable-auto-tool-choice
+        --reasoning-parser kimi_k3
+        --tool-call-parser kimi_k3
+
+  - envs:
+      <<: *env_common
+    server_cmd: >
+      env -u HCCL_OP_EXPANSION_MODE vllm serve Eco-Tech/Kimi-K3-w4a8
+        --host 0.0.0.0
+        --headless
+        --port $SERVER_PORT
+        --quantization ascend
+        --allowed-local-media-path /
+        --trust-remote-code
+        --tokenizer-mode kimi_k3
+        --tensor-parallel-size 16
+        --data-parallel-size 4
+        --data-parallel-size-local 1
+        --data-parallel-start-rank 3
+        --data-parallel-address $MASTER_IP
+        --data-parallel-rpc-port 13389
+        --enable-expert-parallel
+        --enable-prefix-caching
+        --max-num-seqs 16
+        --max-model-len 131027
+        --max-num-batched-tokens 8192
+        --gpu-memory-utilization 0.9
+        --compilation-config '{"cudagraph_mode":"FULL_DECODE_ONLY"}'
+        --additional-config '{"enable_cpu_binding":true,"enable_flashcomm1":true}'
+        --mm-processor-cache-gb 0
+        --mm-encoder-tp-mode data
+        --limit-mm-per-prompt '{"vision_chunk":2}'
+        --enable-auto-tool-choice
+        --reasoning-parser kimi_k3
+        --tool-call-parser kimi_k3
+
+benchmarks:
+  perf_16k_prefix0:
+    case_type: performance
+    dataset_path: vllm-ascend/GSM8K_prefix0_in16384_bs200_kimi
+    request_conf: vllm_api_stream_chat
+    dataset_conf: gsm8k/gsm8k_gen_0_shot_cot_str_perf
+    num_prompts: 16
+    max_out_len: 1024
+    batch_size: 4
+    request_rate: 0
+    baseline: 40
+    threshold: 0.95
+    tpot_threshold: 90

--- a/tests/e2e/nightly/multi_node/internal_dp/config/Kimi-K3-W4A8-A3.yaml
+++ b/tests/e2e/nightly/multi_node/internal_dp/config/Kimi-K3-W4A8-A3.yaml
@@ -33,7 +33,7 @@ deployment:
         --enable-expert-parallel
         --enable-prefix-caching
         --max-num-seqs 16
-        --max-model-len 130k
+        --max-model-len 133120
         --max-num-batched-tokens 8192
         --gpu-memory-utilization 0.9
         --compilation-config '{"cudagraph_mode":"FULL_DECODE_ONLY"}'
@@ -65,7 +65,7 @@ deployment:
         --enable-expert-parallel
         --enable-prefix-caching
         --max-num-seqs 16
-        --max-model-len 130k
+        --max-model-len 133120
         --max-num-batched-tokens 8192
         --gpu-memory-utilization 0.9
         --compilation-config '{"cudagraph_mode":"FULL_DECODE_ONLY"}'
@@ -97,7 +97,7 @@ deployment:
         --enable-expert-parallel
         --enable-prefix-caching
         --max-num-seqs 16
-        --max-model-len 130k
+        --max-model-len 133120
         --max-num-batched-tokens 8192
         --gpu-memory-utilization 0.9
         --compilation-config '{"cudagraph_mode":"FULL_DECODE_ONLY"}'
@@ -129,7 +129,7 @@ deployment:
         --enable-expert-parallel
         --enable-prefix-caching
         --max-num-seqs 16
-        --max-model-len 130k
+        --max-model-len 133120
         --max-num-batched-tokens 8192
         --gpu-memory-utilization 0.9
         --compilation-config '{"cudagraph_mode":"FULL_DECODE_ONLY"}'

--- a/tests/e2e/nightly/multi_node/internal_dp/config/Kimi-K3-W4A8-A3.yaml
+++ b/tests/e2e/nightly/multi_node/internal_dp/config/Kimi-K3-W4A8-A3.yaml
@@ -33,7 +33,7 @@ deployment:
         --enable-expert-parallel
         --enable-prefix-caching
         --max-num-seqs 16
-        --max-model-len 131027
+        --max-model-len 130k
         --max-num-batched-tokens 8192
         --gpu-memory-utilization 0.9
         --compilation-config '{"cudagraph_mode":"FULL_DECODE_ONLY"}'
@@ -65,7 +65,7 @@ deployment:
         --enable-expert-parallel
         --enable-prefix-caching
         --max-num-seqs 16
-        --max-model-len 131027
+        --max-model-len 130k
         --max-num-batched-tokens 8192
         --gpu-memory-utilization 0.9
         --compilation-config '{"cudagraph_mode":"FULL_DECODE_ONLY"}'
@@ -97,7 +97,7 @@ deployment:
         --enable-expert-parallel
         --enable-prefix-caching
         --max-num-seqs 16
-        --max-model-len 131027
+        --max-model-len 130k
         --max-num-batched-tokens 8192
         --gpu-memory-utilization 0.9
         --compilation-config '{"cudagraph_mode":"FULL_DECODE_ONLY"}'
@@ -129,7 +129,7 @@ deployment:
         --enable-expert-parallel
         --enable-prefix-caching
         --max-num-seqs 16
-        --max-model-len 131027
+        --max-model-len 130k
         --max-num-batched-tokens 8192
         --gpu-memory-utilization 0.9
         --compilation-config '{"cudagraph_mode":"FULL_DECODE_ONLY"}'

--- a/tests/e2e/nightly/multi_node/internal_dp/config/Kimi-K3-W4A8-A3.yaml
+++ b/tests/e2e/nightly/multi_node/internal_dp/config/Kimi-K3-W4A8-A3.yaml
@@ -50,7 +50,6 @@ deployment:
     server_cmd: >
       env -u HCCL_OP_EXPANSION_MODE vllm serve Eco-Tech/Kimi-K3-w4a8
         --host 0.0.0.0
-        --headless
         --port $SERVER_PORT
         --quantization ascend
         --allowed-local-media-path /
@@ -82,7 +81,6 @@ deployment:
     server_cmd: >
       env -u HCCL_OP_EXPANSION_MODE vllm serve Eco-Tech/Kimi-K3-w4a8
         --host 0.0.0.0
-        --headless
         --port $SERVER_PORT
         --quantization ascend
         --allowed-local-media-path /
@@ -114,7 +112,6 @@ deployment:
     server_cmd: >
       env -u HCCL_OP_EXPANSION_MODE vllm serve Eco-Tech/Kimi-K3-w4a8
         --host 0.0.0.0
-        --headless
         --port $SERVER_PORT
         --quantization ascend
         --allowed-local-media-path /


### PR DESCRIPTION
### What this PR does / why we need it?

Backports the current Kimi K3 A3 nightly performance coverage from #14923 to the `releases/v0.27.1rc` branch.

This adds the four-node A3 DP4/TP16 mixed-deployment configuration for `Eco-Tech/Kimi-K3-w4a8`, registers it in the nightly matrix and ModelScope pre-download list, and runs the 16K no-prefix-cache performance case with an output-throughput baseline of 40 and a TPOT threshold of 90 ms.

The release branch already contains the Kimi K3 Ascend model implementation and supporting parser/quantization paths, so no product code changes are required. This PR intentionally contains no GPQA accuracy case or benchmark-result persistence changes.

### Does this PR introduce any user-facing change?

No.

### How was this patch tested?

- Parsed the updated nightly matrix, model/dataset list, and new benchmark YAML.
- Verified the test resolves to a four-node configuration containing only `perf_16k_prefix0`.
- Verified the Kimi K3 model, parser, quantization, and regression-test support already exist on `releases/v0.27.1rc`.
- Verified the branch is automatically mergeable with `releases/v0.27.1rc`.
- NPU runtime verification remains pending a targeted `/nightly kimi-k3-w4a8-a3` run on the A3 CI cluster.

- vLLM main: https://github.com/vllm-project/vllm/commit/ba07e4a48fc951300d97eb506217dd530583dea3
