### PR TITLE
[Doc][BugFix] Fix A5 (950DT) container device files in Quick Start

### DIFF
--- a/docs/source/getting_started/quick_start/ascend_image/atlas-950dt.inc.md
+++ b/docs/source/getting_started/quick_start/ascend_image/atlas-950dt.inc.md
@@ -37,7 +37,8 @@
             --shm-size=1g \
             --device /dev/davinci0 \
             --device /dev/davinci_manager \
-            --device /dev/devmm_svm \
+            --device /dev/ummu \
+            --device /dev/uburma \
             --device /dev/hisi_hdc \
             -v /usr/local/dcmi:/usr/local/dcmi \
             -v /usr/local/Ascend/driver/tools/hccn_tool:/usr/local/Ascend/driver/tools/hccn_tool \
@@ -62,7 +63,8 @@
             --shm-size=1g \
             --device /dev/davinci0 \
             --device /dev/davinci_manager \
-            --device /dev/devmm_svm \
+            --device /dev/ummu \
+            --device /dev/uburma \
             --device /dev/hisi_hdc \
             -v /usr/local/dcmi:/usr/local/dcmi \
             -v /usr/local/Ascend/driver/tools/hccn_tool:/usr/local/Ascend/driver/tools/hccn_tool \


### PR DESCRIPTION
### What this PR does / why we need it?

The Quick Start guide's **950DT (A5)** container creation command used the A2/A3 device file `/dev/devmm_svm`, which **does not exist on A5 hardware**, so creating the container fails on a real A5 (Ascend 950DT) host. This PR replaces it with the A5-specific `/dev/ummu` and `/dev/uburma` (in both the Ubuntu and openEuler code blocks).

The corrected device set matches the 950DT container commands already used across the model tutorials, e.g.:
- `docs/source/tutorials/models/Qwen3.5-27B-Qwen3.6-27B.md` (lines 167-168)
- `docs/source/tutorials/models/Qwen3.8-27B.md`
- `docs/source/tutorials/models/DeepSeek-V3.1.md`

where A5 = `davinci*` + `davinci_manager` + `hisi_hdc` + `ummu` + `uburma` (no `devmm_svm`).

Fixes #15535

### Does this PR introduce _any_ user-facing change?

No code change. Documentation only: corrects the device files in the Quick Start "950DT" container command so it matches A5 hardware.

### How was this patch tested?

Documentation-only change. Verified the device set against 8 in-repo model tutorials that already use `ummu`/`uburma` for A5/950DT and do not use `devmm_svm`. The changed file (`*.inc.md`) is excluded from `markdownlint` by the pre-commit config; the parent `quick_start.md` is unchanged.

- vLLM main: https://github.com/vllm-project/vllm/commit/e6bfe03ad73a3330cb427885aa90d97a12e1c704
