### PR TITLE
[Bugfix][DeepSeekV4] Prefix MTP e_proj/h_proj for compressed-tensors matching

### DIFF
--- a/tests/ut/models/test_deepseek_v4_mtp.py
+++ b/tests/ut/models/test_deepseek_v4_mtp.py
@@ -5,6 +5,7 @@ from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 import pytest
+from vllm.config import set_current_vllm_config
 from vllm.model_executor.layers.linear import LinearBase, UnquantizedLinearMethod
 
 from tests.ut.quantization.conftest_quantization import COMPRESSED_TENSORS_W8A8_CONFIG
@@ -24,9 +25,13 @@ class _MockTPGroup:
 @pytest.fixture(autouse=True)
 def _mock_tp_group():
     """ReplicatedLinear/ParallelLMHead query the TP group during __init__,
-    but parallel state is not initialized on CPU test runners."""
+    and CustomOp construction requires a current vllm config; neither is
+    initialized on CPU test runners."""
     mock = _MockTPGroup()
+    mock_config = MagicMock()
+    mock_config.compilation_config.custom_ops = ["all"]
     with (
+        set_current_vllm_config(mock_config),
         patch("vllm_ascend.ops.linear_op.get_tp_group", return_value=mock),
         patch("vllm.distributed.parallel_state.get_tp_group", return_value=mock),
         patch("vllm_ascend.ops.vocab_parallel_embedding.get_tp_group", return_value=mock),

--- a/tests/ut/models/test_deepseek_v4_mtp.py
+++ b/tests/ut/models/test_deepseek_v4_mtp.py
@@ -1,0 +1,87 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM Ascend project
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+from vllm.model_executor.layers.linear import ReplicatedLinear, UnquantizedLinearMethod
+
+from tests.ut.quantization.conftest_quantization import COMPRESSED_TENSORS_W8A8_CONFIG
+from vllm_ascend.models.deepseek_v4.mtp import DeepSeekMultiTokenPredictorLayer
+from vllm_ascend.ops.linear import AscendUnquantizedLinearMethod
+from vllm_ascend.quantization.configs.compressed_tensors_config import AscendCompressedTensorsConfig
+from vllm_ascend.quantization.method_adapters import AscendLinearMethod
+
+
+def _make_mtp_layer(prefix: str) -> DeepSeekMultiTokenPredictorLayer:
+    vllm_config = SimpleNamespace(
+        speculative_config=SimpleNamespace(
+            draft_model_config=SimpleNamespace(
+                hf_config=SimpleNamespace(
+                    hidden_size=128,
+                    rms_norm_eps=1e-6,
+                    hc_eps=1e-6,
+                    hc_mult=2,
+                    vocab_size=100,
+                )
+            )
+        ),
+        use_v2_model_runner=False,
+        quant_config=None,
+        scheduler_config=SimpleNamespace(max_num_batched_tokens=16),
+    )
+    return DeepSeekMultiTokenPredictorLayer(vllm_config, prefix=prefix)
+
+
+def test_mtp_projections_propagate_prefix() -> None:
+    with patch("vllm_ascend.models.deepseek_v4.mtp.DeepseekV2DecoderLayer") as mock_decoder_layer:
+        mock_decoder_layer.return_value = MagicMock()
+        layer = _make_mtp_layer("model.mtp.0")
+
+    assert layer.e_proj.prefix == "model.mtp.0.e_proj"
+    assert layer.h_proj.prefix == "model.mtp.0.h_proj"
+
+
+def test_mtp_projection_prefixes_match_compressed_tensors_ignore_rules() -> None:
+    quant_config = AscendCompressedTensorsConfig.from_config(
+        {
+            **COMPRESSED_TENSORS_W8A8_CONFIG,
+            "ignore": ["re:^model\\.mtp\\..*"],
+        }
+    )
+    layer_prefix = "model.mtp.0.e_proj"
+
+    with patch("vllm_ascend.quantization.method_adapters.AscendLinearMethod.__init__", return_value=None):
+        prefixed_layer = ReplicatedLinear(
+            128,
+            128,
+            bias=False,
+            return_bias=False,
+            quant_config=quant_config,
+            prefix=layer_prefix,
+        )
+        empty_prefix_layer = ReplicatedLinear(
+            128,
+            128,
+            bias=False,
+            return_bias=False,
+            quant_config=quant_config,
+            prefix="",
+        )
+
+    prefixed_method = quant_config.get_quant_method(prefixed_layer, layer_prefix)
+    empty_prefix_method = quant_config.get_quant_method(empty_prefix_layer, "")
+
+    assert isinstance(prefixed_method, AscendUnquantizedLinearMethod)
+    assert isinstance(empty_prefix_method, AscendLinearMethod)
+    assert not isinstance(empty_prefix_method, UnquantizedLinearMethod)
+
+
+def test_mtp_projection_prefixes_are_not_empty() -> None:
+    with patch("vllm_ascend.models.deepseek_v4.mtp.DeepseekV2DecoderLayer") as mock_decoder_layer:
+        mock_decoder_layer.return_value = MagicMock()
+        layer = _make_mtp_layer("model.mtp.1")
+
+    for projection in (layer.e_proj, layer.h_proj):
+        assert projection.prefix
+        assert projection.prefix.startswith("model.mtp.1.")

--- a/tests/ut/models/test_deepseek_v4_mtp.py
+++ b/tests/ut/models/test_deepseek_v4_mtp.py
@@ -4,13 +4,34 @@
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
-from vllm.model_executor.layers.linear import ReplicatedLinear, UnquantizedLinearMethod
+import pytest
+from vllm.model_executor.layers.linear import LinearBase, UnquantizedLinearMethod
 
 from tests.ut.quantization.conftest_quantization import COMPRESSED_TENSORS_W8A8_CONFIG
 from vllm_ascend.models.deepseek_v4.mtp import DeepSeekMultiTokenPredictorLayer
 from vllm_ascend.ops.linear import AscendUnquantizedLinearMethod
 from vllm_ascend.quantization.configs.compressed_tensors_config import AscendCompressedTensorsConfig
 from vllm_ascend.quantization.method_adapters import AscendLinearMethod
+
+
+class _MockTPGroup:
+    """Minimal TP=1 group stand-in for get_tp_group() on CPU runners."""
+
+    rank_in_group = 0
+    world_size = 1
+
+
+@pytest.fixture(autouse=True)
+def _mock_tp_group():
+    """ReplicatedLinear/ParallelLMHead query the TP group during __init__,
+    but parallel state is not initialized on CPU test runners."""
+    mock = _MockTPGroup()
+    with (
+        patch("vllm_ascend.ops.linear_op.get_tp_group", return_value=mock),
+        patch("vllm.distributed.parallel_state.get_tp_group", return_value=mock),
+        patch("vllm_ascend.ops.vocab_parallel_embedding.get_tp_group", return_value=mock),
+    ):
+        yield
 
 
 def _make_mtp_layer(prefix: str) -> DeepSeekMultiTokenPredictorLayer:
@@ -51,26 +72,8 @@ def test_mtp_projection_prefixes_match_compressed_tensors_ignore_rules() -> None
     )
     layer_prefix = "model.mtp.0.e_proj"
 
-    with patch("vllm_ascend.quantization.method_adapters.AscendLinearMethod.__init__", return_value=None):
-        prefixed_layer = ReplicatedLinear(
-            128,
-            128,
-            bias=False,
-            return_bias=False,
-            quant_config=quant_config,
-            prefix=layer_prefix,
-        )
-        empty_prefix_layer = ReplicatedLinear(
-            128,
-            128,
-            bias=False,
-            return_bias=False,
-            quant_config=quant_config,
-            prefix="",
-        )
-
-    prefixed_method = quant_config.get_quant_method(prefixed_layer, layer_prefix)
-    empty_prefix_method = quant_config.get_quant_method(empty_prefix_layer, "")
+    prefixed_method = quant_config.get_quant_method(MagicMock(spec=LinearBase), layer_prefix)
+    empty_prefix_method = quant_config.get_quant_method(MagicMock(spec=LinearBase), "")
 
     assert isinstance(prefixed_method, AscendUnquantizedLinearMethod)
     assert isinstance(empty_prefix_method, AscendLinearMethod)

--- a/vllm_ascend/models/deepseek_v4/mtp.py
+++ b/vllm_ascend/models/deepseek_v4/mtp.py
@@ -62,10 +62,20 @@ class DeepSeekMultiTokenPredictorLayer(nn.Module):
         quant_config = vllm_config.quant_config
 
         self.e_proj = ReplicatedLinear(
-            config.hidden_size, config.hidden_size, bias=False, quant_config=quant_config, return_bias=False
+            config.hidden_size,
+            config.hidden_size,
+            bias=False,
+            quant_config=quant_config,
+            return_bias=False,
+            prefix=f"{prefix}.e_proj",
         )
         self.h_proj = ReplicatedLinear(
-            config.hidden_size, config.hidden_size, bias=False, quant_config=quant_config, return_bias=False
+            config.hidden_size,
+            config.hidden_size,
+            bias=False,
+            quant_config=quant_config,
+            return_bias=False,
+            prefix=f"{prefix}.h_proj",
         )
 
         self.enorm = RMSNorm(config.hidden_size, eps=config.rms_norm_eps)


### PR DESCRIPTION
## Summary
- pass explicit `prefix=` values to DeepSeek V4 MTP `e_proj` and `h_proj` `ReplicatedLinear` layers in `vllm_ascend/models/deepseek_v4/mtp.py`
- add unit tests verifying prefix propagation and compressed-tensors ignore matching for MTP draft projections
- align with upstream vLLM fix in https://github.com/vllm-project/vllm/pull/44821

Without the prefixes, compressed-tensors receives an empty `layer_name` while constructing the draft model and cannot match artifact-side ignore/target rules for BF16 MTP blocks.

## Test plan
- [ ] `python -m py_compile vllm_ascend/models/deepseek_v4/mtp.py tests/ut/models/test_deepseek_v4_mtp.py`
- [ ] `python -m pytest tests/ut/models/test_deepseek_v4_mtp.py -q`

- vLLM main: https://github.com/vllm-project/vllm/commit/b2f685834a6456197e7033966fdef52a23f1abcd
