### PR TITLE
[v0.27.1rc][Performance][Kimi K3] Avoid attention-residual token-count specialization

### DIFF
--- a/tests/e2e/nightly/single_node/ops/singlecard_ops/triton/test_kimi_k3_fusions.py
+++ b/tests/e2e/nightly/single_node/ops/singlecard_ops/triton/test_kimi_k3_fusions.py
@@ -22,7 +22,7 @@ import torch_npu  # noqa: F401
 from vllm.triton_utils import HAS_TRITON
 
 if HAS_TRITON:
-    from vllm_ascend.ops.triton.kimi_k3.attention_residual import apply_attn_res
+    from vllm_ascend.ops.triton.kimi_k3.attention_residual import _apply_attn_res_kernel, apply_attn_res
 
 
 pytestmark = [
@@ -95,3 +95,23 @@ def test_kimi_k3_attention_residual_triton_matches_reference(
         rtol=1e-2,
         atol=1e-2,
     )
+
+
+def test_kimi_k3_attention_residual_reuses_kernel_across_token_counts(monkeypatch):
+    kernels = []
+    original_run = _apply_attn_res_kernel.run
+
+    def record_kernel(*args, **kwargs):
+        kernel = original_run(*args, **kwargs)
+        kernels.append(kernel)
+        return kernel
+
+    monkeypatch.setattr(_apply_attn_res_kernel, "run", record_kernel)
+    # Cover one token, alignment changes, partial cores, and multiple rows/core
+    # while keeping all model dimensions and launch options fixed.
+    for num_tokens in (1, 7, 16, 17, 512):
+        test_kimi_k3_attention_residual_triton_matches_reference(num_tokens, 4, 7)
+
+    assert len(kernels) == 5
+    assert kernels[0] is not None
+    assert all(kernel is kernels[0] for kernel in kernels)

--- a/vllm_ascend/ops/triton/kimi_k3/attention_residual.py
+++ b/vllm_ascend/ops/triton/kimi_k3/attention_residual.py
@@ -16,14 +16,14 @@ from vllm_ascend.ops.triton.triton_utils import (
 )
 
 
-@triton.jit(do_not_specialize=["N"])
+@triton.jit(do_not_specialize=["num_tokens"])
 def _apply_attn_res_kernel(
     block_residual_ptr,
     prefix_sum_ptr,
     norm_w_ptr,
     proj_w_ptr,
     out_ptr,
-    N,
+    num_tokens,
     H: tl.constexpr,
     B: tl.constexpr,
     BLOCK_CAPACITY: tl.constexpr,
@@ -32,12 +32,12 @@ def _apply_attn_res_kernel(
     NB: tl.constexpr,
 ):
     tl.static_assert(NB >= B + 1, "NB must include all block residuals and prefix_sum")
-    block_size = (N - 1) // NUM_CORES + 1
+    block_size = (num_tokens - 1) // NUM_CORES + 1
     pid = tl.program_id(0)
     tok0 = pid * block_size
-    if tok0 >= N:
+    if tok0 >= num_tokens:
         return
-    tok1 = tl.minimum(tok0 + block_size, N)
+    tok1 = tl.minimum(tok0 + block_size, num_tokens)
 
     cols = tl.arange(0, H)
     s_idx = tl.arange(0, NB)
@@ -104,7 +104,7 @@ def apply_attn_res(
         norm_w,
         proj_w,
         out,
-        N=num_tokens,
+        num_tokens=num_tokens,
         H=hidden_size,
         B=num_valid_blocks,
         BLOCK_CAPACITY=block_capacity,

--- a/vllm_ascend/ops/triton/kimi_k3/attention_residual.py
+++ b/vllm_ascend/ops/triton/kimi_k3/attention_residual.py
@@ -16,14 +16,14 @@ from vllm_ascend.ops.triton.triton_utils import (
 )
 
 
-@triton.jit
+@triton.jit(do_not_specialize=["N"])
 def _apply_attn_res_kernel(
     block_residual_ptr,
     prefix_sum_ptr,
     norm_w_ptr,
     proj_w_ptr,
     out_ptr,
-    N: tl.constexpr,
+    N,
     H: tl.constexpr,
     B: tl.constexpr,
     BLOCK_CAPACITY: tl.constexpr,


### PR DESCRIPTION
### What this PR does / why we need it?

Kimi K3's attention-residual kernel currently declares `N = prefix_sum.shape[0]` as `tl.constexpr`, so changing the token count creates another compiled variant even when the model dimensions and launch options are unchanged.

Rename `N` to `num_tokens`, make it a runtime scalar, and add `@triton.jit(do_not_specialize=["num_tokens"])`. The runtime parameter and `do_not_specialize` are both needed: declaring `num_tokens` as `tl.constexpr` still specializes on its value. `num_tokens` only controls the per-core token range; it does not define a tile shape. `B` is the number of valid residual blocks, not batch size. Keep `H`, `B`, `BLOCK_CAPACITY`, `EPS`, `NUM_CORES`, and `NB` compile-time parameters.

The NPU model path in `vllm_ascend/models/kimi_k3.py` calls this operator through `apply_attn_res`. Target branch: `releases/v0.27.1rc`.

### Does this PR introduce _any_ user-facing change?

No API or mathematical changes. Avoid token-count-driven compilation variants for this kernel. Changes to model dimensions, dtype, or compilation options can still require compilation.

### How was this patch tested?

- Added a regression test that executes 1, 7, 16, 17, and 512 tokens with fixed model dimensions, compares each output against the existing PyTorch reference, and asserts all launches return the same compiled kernel object. This covers the value-one case, integer alignment changes, partial cores, and multiple rows per core.
- Passed `ruff check`, `ruff format --check`, Python AST parsing for both changed files, and `git diff --check`.
- NPU execution is pending: the registered test container was stopped on both checked test hosts. No containers or services were started or stopped. Keeping this PR as a draft until hardware validation is available.
- The latest local `bash format.sh ci` attempt was stopped during actionlint environment download; the full local lint run did not complete.

Triton reference: https://triton-lang.org/main/python-api/generated/triton.jit.html

- vLLM main: https://github.com/vllm-project/vllm/commit/ba07e4a48fc951300d97eb506217dd530583dea3
