### PR TITLE
[BugFix][MRV2] Separate speculative PP sequence bounds from exact lengths

### DIFF
--- a/tests/ut/attention/test_dsa_v1.py
+++ b/tests/ut/attention/test_dsa_v1.py
@@ -937,6 +937,52 @@ def test_build_classifies_short_speculative_extends_as_decodes(
     assert metadata.num_prefills == 0
 
 
+@pytest.mark.parametrize("has_exact_cpu_lengths", [False, True])
+@pytest.mark.parametrize("use_upper_bound", [False, True])
+def test_build_uses_mrv2_upper_bound_for_planning_only(has_exact_cpu_lengths, use_upper_bound):
+    builder = AscendDSAMetadataBuilder.__new__(AscendDSAMetadataBuilder)
+    builder.set_num_actual_tokens = MagicMock()
+    builder.num_actual_tokens = 8
+    builder.decode_threshold = 4
+    builder.compressor_ratio = 4
+    builder.model_config = SimpleNamespace(get_head_size=lambda: 512)
+    builder.metadata_cls = SimpleNamespace
+    builder.hadamard = None
+    builder.build_req_metadata = MagicMock()
+    seq_lens = torch.tensor([106, 204], dtype=torch.int32)
+    upper_bound = torch.tensor([108, 208], dtype=torch.int32)
+    common = SimpleNamespace(
+        num_reqs=2,
+        num_actual_tokens=8,
+        num_input_tokens=8,
+        seq_lens=seq_lens,
+        _seq_lens_cpu=seq_lens if has_exact_cpu_lengths else None,
+        seq_lens_cpu=None,
+        positions=torch.arange(8),
+        block_table_tensor=torch.zeros((2, 1), dtype=torch.int32),
+        attn_state=None,
+    )
+    with (
+        patch("vllm_ascend.attention.dsa_v1.split_decodes_and_prefills", return_value=(2, 0, 8, 0)),
+        patch("vllm_ascend.attention.dsa_v1.get_cos_and_sin_dsa", return_value=(torch.ones(8), torch.zeros(8))),
+        patch.object(seq_lens, "cpu", return_value=seq_lens) as copy_to_cpu,
+    ):
+        cache = {}
+        for _ in range(2):
+            builder.build(
+                common_prefix_len=0,
+                common_attn_metadata=common,
+                common_ratio_to_sas_metadata=cache,
+                seq_lens_cpu_upper_bound=upper_bound if use_upper_bound else None,
+            )
+
+    # Exact kernel lengths never change, even when planning uses an upper bound.
+    torch.testing.assert_close(builder.seq_lens, seq_lens)
+    expected_cpu = upper_bound if use_upper_bound and not has_exact_cpu_lengths else seq_lens
+    torch.testing.assert_close(builder.build_req_metadata.call_args.kwargs["seq_lens_cpu"], expected_cpu)
+    assert copy_to_cpu.call_count == int(not has_exact_cpu_lengths and not use_upper_bound)
+
+
 def test_build_req_metadata_preserves_zero_max_sequence_lengths():
     builder = _make_builder(compressor_ratio=1)
     builder.common_ratio_to_sas_metadata = {}

--- a/tests/ut/worker/test_attn_utils_v2.py
+++ b/tests/ut/worker/test_attn_utils_v2.py
@@ -1,6 +1,6 @@
 from types import SimpleNamespace
 from typing import Any, cast
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 import numpy as np
 import pytest
@@ -18,7 +18,10 @@ from vllm.v1.worker.gpu import attn_utils as upstream_attn_utils
 from vllm.v1.worker.utils import AttentionGroup
 
 from vllm_ascend.attention import dsa_v1
-from vllm_ascend.attention.attention_v1 import AscendAttentionBackend
+from vllm_ascend.attention.attention_v1 import (
+    AscendAttentionBackend,
+    AscendAttentionMetadataBuilder,
+)
 from vllm_ascend.attention.dsa_v1 import (
     AscendDSAC4Backend,
     AscendDSAC4StateBackend,
@@ -619,12 +622,14 @@ def test_dsv4_backends_declare_role_specific_logical_sizes(
         ("pcp_capture", CUDAGraphMode.NONE, True, 2, 8),
     ],
 )
+@pytest.mark.parametrize("cpu_lengths_are_upper_bounds", [False, True])
 def test_mrv2_builds_shared_dsa_metadata_for_each_execution_mode(
     caller,
     cudagraph_mode,
     for_capture,
     pcp_size,
     expected_input_tokens,
+    cpu_lengths_are_upper_bounds,
 ):
     layer_names, specs, calls, attn_groups, kv_cache_config = _make_dsa_metadata_groups()
     block_tables = (
@@ -659,6 +664,8 @@ def test_mrv2_builds_shared_dsa_metadata_for_each_execution_mode(
             slot_mappings=slot_mappings,
             kv_cache_config=kv_cache_config,
             seq_lens_np=np.array([2, 3], dtype=np.int32),
+            seq_lens_cpu_upper_bound=torch.tensor([4, 5], dtype=torch.int32),
+            seq_lens_cpu_is_upper_bound=cpu_lengths_are_upper_bounds,
             positions=torch.arange(5, dtype=torch.int32),
             dcp_local_seq_lens=dcp_local_seq_lens[:2],
         )
@@ -681,6 +688,8 @@ def test_mrv2_builds_shared_dsa_metadata_for_each_execution_mode(
             num_scheduled_tokens=torch.tensor([2, 3, 0, 0], dtype=torch.int32),
             seq_lens=torch.tensor([2, 3, 0, 0], dtype=torch.int32),
             seq_lens_np=np.array([2, 3, 0, 0], dtype=np.int32),
+            seq_lens_cpu_upper_bound=torch.tensor([4, 5, 0, 0], dtype=torch.int32),
+            seq_lens_cpu_is_upper_bound=cpu_lengths_are_upper_bounds,
             is_prefilling_np=np.array([True, True, False, False]),
             dcp_local_seq_lens=dcp_local_seq_lens,
             positions=torch.arange(8, dtype=torch.int32),
@@ -701,6 +710,13 @@ def test_mrv2_builds_shared_dsa_metadata_for_each_execution_mode(
     for call in calls:
         common_metadata = call["common_attn_metadata"]
         assert common_metadata.num_actual_tokens == 5
+        if cpu_lengths_are_upper_bounds:
+            assert common_metadata.seq_lens_cpu is None
+        else:
+            assert common_metadata.seq_lens_cpu is not None
+        torch.testing.assert_close(
+            common_metadata.seq_lens_cpu_upper_bound[:2], torch.tensor([4, 5], dtype=torch.int32)
+        )
         assert common_metadata.num_input_tokens == expected_input_tokens
         assert call["for_cudagraph_capture"] is for_capture
         assert call["num_actual_reqs"] == 2
@@ -757,3 +773,83 @@ def test_build_attn_metadata_propagates_prefill_state():
     )
 
     assert metadata["layer.0"] is is_prefilling
+
+
+@pytest.mark.parametrize("cpu_length_source", ["exact", "upper_bound", "legacy_draft"])
+@pytest.mark.parametrize("has_upper_bound", [False, True])
+def test_build_attn_metadata_keeps_exact_lengths_separate_from_upper_bounds(cpu_length_source, has_upper_bound):
+    builder = SimpleNamespace(build=lambda **kwargs: kwargs["common_attn_metadata"])
+    attn_group = SimpleNamespace(layer_names=["layer.0"], get_metadata_builder=lambda _: builder)
+    seq_lens = torch.tensor([106, 1024, 264, 0], dtype=torch.int32)
+    upper_bound = torch.tensor([108, 1024, 264, 0], dtype=torch.int32)
+    metadata = attn_utils.build_attn_metadata(
+        attn_groups=[[attn_group]],
+        num_reqs=4,
+        num_tokens=524,
+        query_start_loc_gpu=torch.tensor([0, 4, 516, 524, 524], dtype=torch.int32),
+        query_start_loc_cpu=torch.tensor([0, 4, 516, 524, 524], dtype=torch.int32),
+        max_query_len=512,
+        seq_lens=seq_lens,
+        max_seq_len=2048,
+        block_tables=(torch.zeros((4, 1), dtype=torch.int32),),
+        slot_mappings=torch.zeros((1, 524), dtype=torch.int64),
+        kv_cache_config=SimpleNamespace(kv_cache_groups=[SimpleNamespace(kv_cache_spec=object())]),
+        seq_lens_np=None if cpu_length_source == "legacy_draft" else seq_lens.numpy(),
+        seq_lens_cpu_upper_bound=upper_bound if has_upper_bound else None,
+        seq_lens_cpu_is_upper_bound=cpu_length_source == "upper_bound",
+    )["layer.0"]
+
+    torch.testing.assert_close(metadata.seq_lens, seq_lens)
+    if cpu_length_source == "exact":
+        torch.testing.assert_close(metadata.seq_lens_cpu, seq_lens)
+    elif cpu_length_source == "upper_bound":
+        assert metadata.seq_lens_cpu is None
+        assert metadata._seq_lens_cpu is None
+    else:
+        torch.testing.assert_close(metadata.seq_lens_cpu, torch.full_like(seq_lens, 2048))
+    expected_bound = (
+        upper_bound
+        if has_upper_bound
+        else seq_lens
+        if cpu_length_source == "exact"
+        else torch.full_like(seq_lens, 2048)
+    )
+    torch.testing.assert_close(metadata.seq_lens_cpu_upper_bound, expected_bound)
+
+
+@pytest.mark.parametrize("cpu_lengths_are_upper_bounds", [False, True])
+def test_fia_consumes_exact_device_lengths_for_speculative_pp(cpu_lengths_are_upper_bounds):
+    builder = AscendAttentionMetadataBuilder.__new__(AscendAttentionMetadataBuilder)
+    builder.pcp_enabled = False
+    builder.device = torch.device("cpu")
+    builder.kv_cache_spec = None
+    builder.speculative_config = None
+    builder.model_config = SimpleNamespace(runner_type="generate")
+    builder.attn_mask_builder = MagicMock()
+    builder.metadata_cls = SimpleNamespace
+    builder._split_decodes_and_prefills = MagicMock(return_value=(2, 0, 8, 0))
+    builder._build_backend_metadata = MagicMock(return_value={})
+    seq_lens = torch.tensor([106, 204], dtype=torch.int32)
+    upper_bound = torch.tensor([108, 208], dtype=torch.int32)
+    group = SimpleNamespace(layer_names=["layer.0"], get_metadata_builder=lambda _: builder)
+
+    with patch.object(torch.Tensor, "pin_memory", lambda tensor: tensor):
+        metadata = attn_utils.build_attn_metadata(
+            attn_groups=[[group]],
+            num_reqs=2,
+            num_tokens=8,
+            query_start_loc_gpu=torch.tensor([0, 4, 8], dtype=torch.int32),
+            query_start_loc_cpu=torch.tensor([0, 4, 8], dtype=torch.int32),
+            max_query_len=4,
+            seq_lens=seq_lens,
+            max_seq_len=512,
+            block_tables=(torch.zeros((2, 1), dtype=torch.int32),),
+            slot_mappings=torch.zeros((1, 8), dtype=torch.int64),
+            kv_cache_config=SimpleNamespace(kv_cache_groups=[SimpleNamespace(kv_cache_spec=object())]),
+            seq_lens_np=(upper_bound if cpu_lengths_are_upper_bounds else seq_lens).numpy(),
+            seq_lens_cpu_upper_bound=upper_bound,
+            seq_lens_cpu_is_upper_bound=cpu_lengths_are_upper_bounds,
+        )["layer.0"]
+
+    assert metadata.seq_lens_list == [106, 204]
+    torch.testing.assert_close(metadata.seq_lens, seq_lens)

--- a/tests/ut/worker/test_model_runner_v2.py
+++ b/tests/ut/worker/test_model_runner_v2.py
@@ -176,3 +176,88 @@ def test_prepare_inputs_preserves_pcp_tokens_and_forwards_graph_padding():
     assert padded_num_tokens.attr == "num_tokens"
     assert isinstance(padded_num_tokens.value, ast.Name)
     assert padded_num_tokens.value.id == "batch_desc"
+
+
+@pytest.mark.parametrize("num_rejected", [0, 1, 2, 3])
+def test_spec_pp_non_last_keeps_scheduler_upper_bounds(num_rejected):
+    runner = _make_seq_len_runner(spec_pp=True, last_rank=False, has_speculator=False)
+    runner.req_states.num_computed_tokens_np[:] = 104
+    device_counts = np.array([104 - num_rejected, 0, 0], dtype=np.int32)
+    runner._copy_num_computed_tokens_to_cpu.side_effect = lambda: np.copyto(
+        runner.num_computed_tokens_cpu, device_counts
+    )
+    output = _make_seq_len_output({"decode": 4}, ["decode"])
+
+    NPUModelRunner._update_seq_lens_cpu(runner, output, ["decode"])
+
+    runner._copy_num_computed_tokens_to_cpu.assert_not_called()
+    runner.num_computed_tokens_event.synchronize.assert_not_called()
+    assert runner.input_buffers.seq_lens_cpu[0] == 108
+    assert runner.req_states.num_computed_tokens_np[0] == 104
+
+
+@pytest.mark.parametrize("use_pcp", [False, True])
+def test_spec_pp_mixed_chunk_decode_and_new_request_counts(use_pcp):
+    runner = _make_seq_len_runner(spec_pp=True, last_rank=False, has_speculator=False)
+    runner.pcp_manager = object() if use_pcp else None
+    runner.req_states.num_computed_tokens_np[:] = [104, 512, 256]
+    # The saved copy predates an immediate prefill chunk and a new request.
+    runner.num_computed_tokens_cpu[:] = [100, 256, 999]
+    device_counts = np.array([102, 512, 256], dtype=np.int32)
+    runner._copy_num_computed_tokens_to_cpu.side_effect = lambda: np.copyto(
+        runner.num_computed_tokens_cpu, device_counts
+    )
+    output = _make_seq_len_output({"prefill": 512, "new": 8, "decode": 4}, ["decode", "prefill"])
+
+    NPUModelRunner._update_seq_lens_cpu(runner, output, ["prefill", "new", "decode"])
+
+    np.testing.assert_array_equal(runner.input_buffers.seq_lens_cpu, [1024, 264, 106 if use_pcp else 108])
+    np.testing.assert_array_equal(
+        runner.req_states.num_computed_tokens_np, device_counts if use_pcp else [104, 512, 256]
+    )
+    assert runner._copy_num_computed_tokens_to_cpu.call_count == int(use_pcp)
+    assert runner.num_computed_tokens_event.synchronize.call_count == int(use_pcp)
+
+
+@pytest.mark.parametrize(
+    "spec_pp,last_rank,has_speculator,expected",
+    [(True, True, True, 106), (False, True, True, 106), (False, False, False, 108)],
+    ids=["pp-last", "no-pp-speculative", "no-speculative"],
+)
+def test_seq_len_update_preserves_other_paths(spec_pp, last_rank, has_speculator, expected):
+    runner = _make_seq_len_runner(spec_pp, last_rank, has_speculator)
+    runner.req_states.num_computed_tokens_np[0] = 104
+    runner.num_computed_tokens_cpu[0] = 102
+    output = _make_seq_len_output({"decode": 4}, ["decode"])
+
+    NPUModelRunner._update_seq_lens_cpu(runner, output, ["decode"])
+
+    assert runner.input_buffers.seq_lens_cpu[0] == expected
+    runner._copy_num_computed_tokens_to_cpu.assert_not_called()
+    assert runner.num_computed_tokens_event.synchronize.call_count == int(has_speculator)
+
+
+def _make_seq_len_runner(spec_pp, last_rank, has_speculator):
+    computed_tokens = np.zeros(3, dtype=np.int32)
+    return SimpleNamespace(
+        use_spec_pp=spec_pp,
+        is_last_pp_rank=last_rank,
+        speculator=object() if has_speculator else None,
+        pcp_manager=None,
+        req_states=SimpleNamespace(
+            req_id_to_index={"decode": 0, "prefill": 1, "new": 2},
+            num_computed_tokens_cpu=computed_tokens,
+            num_computed_tokens_np=computed_tokens,
+        ),
+        num_computed_tokens_cpu=np.zeros(3, dtype=np.int32),
+        num_computed_tokens_event=SimpleNamespace(synchronize=Mock()),
+        _copy_num_computed_tokens_to_cpu=Mock(),
+        input_buffers=SimpleNamespace(seq_lens_cpu=np.zeros(3, dtype=np.int32)),
+    )
+
+
+def _make_seq_len_output(scheduled, cached):
+    return SimpleNamespace(
+        num_scheduled_tokens=scheduled,
+        scheduled_cached_reqs=SimpleNamespace(req_ids=cached),
+    )

--- a/vllm_ascend/attention/dsa_v1.py
+++ b/vllm_ascend/attention/dsa_v1.py
@@ -835,6 +835,9 @@ class AscendDSAMetadataBuilder(AttentionMetadataBuilder[AscendDSAMetadata]):
                 seq_lens_cpu = common_attn_metadata._seq_lens_cpu
             elif common_attn_metadata.seq_lens_cpu is not None:
                 seq_lens_cpu = common_attn_metadata.seq_lens_cpu
+            elif kwargs.get("seq_lens_cpu_upper_bound") is not None:
+                # MRV2 only needs a planning maximum here; kernels use self.seq_lens.
+                seq_lens_cpu = kwargs["seq_lens_cpu_upper_bound"]
             else:
                 seq_lens_cpu = common_attn_metadata.seq_lens.cpu()
             self.common_ratio_to_sas_metadata["seq_lens_cpu"] = seq_lens_cpu

--- a/vllm_ascend/worker/v2/attn_utils.py
+++ b/vllm_ascend/worker/v2/attn_utils.py
@@ -197,6 +197,7 @@ def build_attn_metadata(
     # extra attributes for ascend npus.
     seq_lens_np: np.ndarray | None = None,
     seq_lens_cpu_upper_bound: torch.Tensor | None = None,
+    seq_lens_cpu_is_upper_bound: bool = False,
     num_computed_tokens_cpu: torch.Tensor | None = None,
     positions: torch.Tensor | None = None,
     attn_state: Any | None = None,
@@ -210,15 +211,19 @@ def build_attn_metadata(
     causal: bool | Mapping[int, bool] = True,
 ) -> dict[str, Any]:
     """Build attention metadata for Ascend NPUs."""
-    # TODO(Ronald1995): optimize AscendCommonAttentionMetadata.
-    # seq_lens_np is used for ascend npus, it maybe None in spec_decode case,
-    # we fill it with max_seq_len in case `attn_metadata_builder.build` raise
-    # an error.
-    if seq_lens_np is None:
-        seq_lens_np = np.full(num_reqs, max_seq_len, dtype=np.int32)
-    seq_lens_cpu = torch.from_numpy(seq_lens_np)[:num_reqs]
+    # As in upstream MRV2, optimistic CPU counts must not become exact lengths.
+    seq_lens_cpu = None
+    if not seq_lens_cpu_is_upper_bound:
+        # Keep the existing draft/capture fallback outside speculative PP.
+        if seq_lens_np is None:
+            seq_lens_np = np.full(num_reqs, max_seq_len, dtype=np.int32)
+        seq_lens_cpu = torch.from_numpy(seq_lens_np)[:num_reqs]
     if seq_lens_cpu_upper_bound is None:
-        seq_lens_cpu_upper_bound = seq_lens_cpu
+        seq_lens_cpu_upper_bound = (
+            seq_lens_cpu
+            if seq_lens_cpu is not None
+            else torch.full((num_reqs,), max_seq_len, dtype=torch.int32, device="cpu")
+        )
 
     # Upstream speculative-decoding callers do not provide Ascend's separate
     # scheduled-token and padded-input-token counts. Without these fields,
@@ -292,6 +297,7 @@ def build_attn_metadata(
                 attn_metadata_extra_kwargs.update(
                     num_actual_reqs=num_actual_reqs,
                     common_ratio_to_sas_metadata=common_ratio_to_sas_metadata,
+                    seq_lens_cpu_upper_bound=seq_lens_cpu_upper_bound,
                 )
                 if pcp_context is not None:
                     attn_metadata_extra_kwargs.update(

--- a/vllm_ascend/worker/v2/input_batch.py
+++ b/vllm_ascend/worker/v2/input_batch.py
@@ -74,6 +74,8 @@ class AscendInputBatch(InputBatch):
     # attn_state is used to build attention metadata.
     attn_state: AscendAttentionState | None = None
     is_dummy: bool = False
+    # Non-last speculative PP ranks only have optimistic CPU counts.
+    seq_lens_cpu_is_upper_bound: bool = False
 
     @classmethod
     def make_dummy(

--- a/vllm_ascend/worker/v2/model_runner.py
+++ b/vllm_ascend/worker/v2/model_runner.py
@@ -512,6 +512,7 @@ class NPUModelRunner(GPUModelRunner):
             prompt_lens=prompt_lens,
             # extra attributes for ascend npus.
             seq_lens_np=self.input_buffers.seq_lens_np,
+            seq_lens_cpu_is_upper_bound=(self.use_spec_pp and not self.is_last_pp_rank and self.pcp_manager is None),
             attn_state=attn_state,
         )
 
@@ -672,10 +673,13 @@ class NPUModelRunner(GPUModelRunner):
     ):
         num_scheduled_tokens = scheduler_output.num_scheduled_tokens
 
-        # MTP needs D2H copy to get reverted num_computed_tokens after rejection.
-        # req_states.num_computed_tokens_cpu shares storage with its NumPy view,
-        # so this update also corrects the num_computed_tokens_np used by PCP.
-        if self.speculator is not None:
+        # PCP partitions tokens using CPU counts. Ordinary speculative PP
+        # keeps scheduler upper bounds and uses device seq_lens for attention.
+        refresh_pp_counts = self.use_spec_pp and not self.is_last_pp_rank and self.pcp_manager is not None
+        if refresh_pp_counts:
+            self._copy_num_computed_tokens_to_cpu()
+
+        if self.speculator is not None or refresh_pp_counts:
             self.num_computed_tokens_event.synchronize()
             for req_id in scheduler_output.scheduled_cached_reqs.req_ids:
                 req_index = self.req_states.req_id_to_index[req_id]

--- a/vllm_ascend/worker/v2/model_states/default.py
+++ b/vllm_ascend/worker/v2/model_states/default.py
@@ -90,6 +90,8 @@ class AscendModelState(DefaultModelState):
             dcp_local_seq_lens=input_batch.dcp_local_seq_lens,
             # extra attributes for ascend npus.
             seq_lens_np=input_batch.seq_lens_np,
+            seq_lens_cpu_upper_bound=input_batch.seq_lens_cpu_upper_bound,
+            seq_lens_cpu_is_upper_bound=input_batch.seq_lens_cpu_is_upper_bound,
             positions=input_batch.positions,
             attn_state=input_batch.attn_state,
             pcp_context=pcp_context,

--- a/vllm_ascend/worker/v2/model_states/mamba_hybrid.py
+++ b/vllm_ascend/worker/v2/model_states/mamba_hybrid.py
@@ -98,6 +98,8 @@ class AscendMambaHybridModelState(MambaHybridModelState, AscendModelState):
             kv_cache_config=kv_cache_config,
             dcp_local_seq_lens=input_batch.dcp_local_seq_lens,
             seq_lens_np=input_batch.seq_lens_np,
+            seq_lens_cpu_upper_bound=input_batch.seq_lens_cpu_upper_bound,
+            seq_lens_cpu_is_upper_bound=input_batch.seq_lens_cpu_is_upper_bound,
             positions=input_batch.positions,
             attn_state=input_batch.attn_state,
             model_specific_attn_metadata=model_specific_metadata,


### PR DESCRIPTION
### What this PR does / why we need it?

Split the sequence-length correctness fix out of #15747 so it can be reviewed independently of the GLM-5.2 DSpark PP adaptation. This branch is based on upstream main and does not depend on #15747.

After speculative rejection, a non-last PP stage can have corrected device token counts but optimistic scheduler counts on the CPU. Passing the latter as exact attention lengths can make host-length consumers such as FIA attend past the valid KV range.

- Mark ordinary non-last speculative PP CPU lengths as upper bounds, and do not expose them as exact `seq_lens_cpu` in common attention metadata.
- Pass the upper bounds through MRV2 model states. DSA uses them only for host-side planning; its per-request device lengths remain unchanged.
- Let FIA use its existing exact-device-length fallback when exact CPU lengths are unavailable.
- Retain the existing last-stage/speculator synchronization and refresh CPU counts for non-last PP + PCP, where CPU counts are needed to partition tokens.
- Preserve non-PP/non-speculative and draft/capture fallback behavior. No PP broadcast protocol, model forward, or backend-selection changes.

### Does this PR introduce _any_ user-facing change?

No new configuration. This corrects sequence-length metadata for speculative PP.

This is not a claim to fix the previously observed PD accuracy difference: in a normal pure-PD deployment with PP only on the prefiller and PP=1 on the decoder, the prefiller does not continue speculative decode after handing off the first token.

Performance is not yet measured. FIA still needs exact CPU lengths and can synchronize when building metadata; this PR does not claim to eliminate that wait. DSA can use host upper bounds for planning without that length copy in the updated branch.

### How was this patch tested?

- Added CPU regression cases in `tests/ut/worker/test_model_runner_v2.py`, `tests/ut/worker/test_attn_utils_v2.py`, and `tests/ut/attention/test_dsa_v1.py`: rejected counts, mixed chunk/decode/new requests, PCP, exact-vs-upper-bound metadata, and DSA/FIA consumers.
- Reused the existing container's CPU-only PyTorch environment: 29 isolated regression cases passed. The harness executes unmodified AST-extracted production and test function bodies with hardware imports and external metadata containers stubbed. This is not a full repository-import pytest run or an NPU graph/runtime test.
- Ruff check, Ruff format check, and `git diff --check` passed for the changed files.
- `bash format.sh ci` could not run because `pre-commit` is not installed locally; no dependencies or service environments were reinstalled.
- NPU accuracy and throughput have not been rerun for this split branch. Earlier colocated PP counter-mismatch observations do not establish an accuracy improvement for this implementation.

- vLLM main: https://github.com/vllm-project/vllm/commit/e6bfe03ad73a3330cb427885aa90d97a12e1c704
