### PR TITLE
[Performance][Attention] Optimize long cached prefill with BNSD on A2

### DIFF
--- a/docs/source/user_guide/feature_guide/bnsd_prefill.md
+++ b/docs/source/user_guide/feature_guide/bnsd_prefill.md
@@ -1,0 +1,71 @@
+# BNSD long-prefill attention
+
+!!! warning
+
+    This optimization is experimental, disabled by default, and currently
+    limited to Atlas A2 hardware.
+
+## Overview
+
+Cached prefill attention normally sends query tensors to Fused Infer
+Attention (FIA) in TND layout. For one long prefill request, BNSD can use a
+more efficient FIA tiling path while retaining the paged KV cache in its
+native NHD layout.
+
+When a scheduler step mixes decode requests with one eligible long prefill
+request, vLLM Ascend keeps the short decode slice in TND and sends only the
+prefill slice through BNSD. Unsupported shapes and modes continue to use the
+existing TND path.
+
+## Enable the optimization
+
+Add the following option to `--additional-config`:
+
+```json
+{
+  "enable_prefill_bnsd": true
+}
+```
+
+For example:
+
+```bash
+vllm serve /path/to/model \
+  --enable-chunked-prefill \
+  --additional-config '{"enable_prefill_bnsd":true}'
+```
+
+## Eligibility and fallback
+
+The BNSD path is selected only when all of the following are true:
+
+- Atlas A2 hardware;
+- BF16 query and paged KV cache;
+- causal decoder attention without sliding-window attention or sinks;
+- 256-dimensional attention heads;
+- exactly one prefill request with at least 4096 query tokens in the current
+  scheduler step; and
+- cached prefill or chunked prefill using the standard 128-token KV block
+  size.
+
+All other cases automatically retain the existing TND implementation. The
+optimization does not change the KV-cache layout.
+
+## Reference benchmark
+
+The following reference measurements were collected on Atlas A2 with an
+experimental prototype based on vLLM Ascend commit `f4a08bddd` and CANN
+9.0.1. An operator benchmark compared an approximately 7680-token prefill
+query attending to a 100000-token paged KV cache:
+
+| Path | Median latency |
+| --- | ---: |
+| TND query + NHD paged KV | 62.7079 ms |
+| BNSD query + NHD paged KV | 54.4916 ms |
+
+The BNSD query path reduced operator latency by 13.10%. A mixed batch with
+query lengths `[7680, 4, 4, 4]`, including query reorder and output placement,
+improved from 66.1986 ms to 55.4271 ms (16.27%).
+
+Measure the effect with the target model and traffic distribution before
+enabling this experimental option in production.

--- a/docs/source/user_guide/feature_guide/bnsd_prefill.md
+++ b/docs/source/user_guide/feature_guide/bnsd_prefill.md
@@ -53,10 +53,12 @@ optimization does not change the KV-cache layout.
 
 ## Reference benchmark
 
-The following reference measurements were collected on Atlas A2 with an
-experimental prototype based on vLLM Ascend commit `f4a08bddd` and CANN
-9.0.1. An operator benchmark compared an approximately 7680-token prefill
-query attending to a 100000-token paged KV cache:
+The following reference measurements were collected with Qwen3.8-27B on
+Atlas A2 using tensor parallel size 2 and an experimental prototype based on
+vLLM Ascend commit `f4a08bddd` and CANN 9.0.1. The profiled attention shape
+had 12 query heads, 2 KV heads, and a head dimension of 256. An operator
+benchmark compared an approximately 7680-token prefill query attending to a
+100000-token paged KV cache:
 
 | Path | Median latency |
 | --- | ---: |

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -309,6 +309,7 @@ nav:
         - user_guide/feature_guide/pipeline_parallel.md
         - user_guide/feature_guide/dynamic_chunk_pipeline_parallel.md
         - user_guide/feature_guide/flash_attention.md
+        - user_guide/feature_guide/bnsd_prefill.md
         - user_guide/feature_guide/short_request_first.md
         - user_guide/feature_guide/batch_job_aware_scheduler.md
         - user_guide/feature_guide/rl.md

--- a/tests/ut/_310p/attention/test_attention_v1_310.py
+++ b/tests/ut/_310p/attention/test_attention_v1_310.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 import torch
@@ -67,7 +68,13 @@ class TestAscendAttentionBackendImpl310(TestBase):
         self.config_patcher = patch(
             "vllm_ascend.attention.attention_v1.get_current_vllm_config", return_value=self.mock_vllm_config
         )
+        self.ascend_config_patcher = patch(
+            "vllm_ascend.attention.attention_v1.get_ascend_config",
+            return_value=SimpleNamespace(enable_prefill_bnsd=False),
+        )
         self.config_patcher.start()
+        self.ascend_config_patcher.start()
+        self.addCleanup(self.ascend_config_patcher.stop)
         self.addCleanup(self.config_patcher.stop)
         self.impl = AscendAttentionBackendImpl310(
             num_heads=8,

--- a/tests/ut/attention/test_attention_v1.py
+++ b/tests/ut/attention/test_attention_v1.py
@@ -332,15 +332,21 @@ class TestAscendAttentionBackendImpl(TestBase):
         self.config_patcher = patch(
             "vllm_ascend.attention.attention_v1.get_current_vllm_config", return_value=self.mock_vllm_config
         )
+        self.ascend_config_patcher = patch(
+            "vllm_ascend.attention.attention_v1.get_ascend_config",
+            return_value=SimpleNamespace(enable_prefill_bnsd=False),
+        )
         self.utils_config_patcher = patch(
             "vllm_ascend.attention.utils.get_current_vllm_config", return_value=self.mock_vllm_config
         )
         self.config_patcher.start()
+        self.ascend_config_patcher.start()
         self.utils_config_patcher.start()
         needs_layer_aware_fia_graph_replay.cache_clear()
         self.addCleanup(needs_layer_aware_fia_graph_replay.cache_clear)
         self.addCleanup(self.utils_config_patcher.stop)
         self.addCleanup(self.config_patcher.stop)
+        self.addCleanup(self.ascend_config_patcher.stop)
 
         self.impl = AscendAttentionBackendImpl(
             num_heads=8,
@@ -633,6 +639,78 @@ class TestAscendAttentionBackendImpl(TestBase):
 
         mock_npu_fused_infer_attention_score.assert_called_once()
         assert output.shape == (10, 8, 64)
+
+    @patch("vllm_ascend.attention.attention_v1.BNSD_PREFILL_MIN_QUERY_TOKENS", 8)
+    @patch("vllm_ascend.attention.attention_v1.get_current_hardware_profile")
+    @patch("vllm_ascend.attention.attention_v1.DeviceOperator.npu_fused_infer_attention_score")
+    def test_bnsd_prefill_keeps_decode_in_tnd(
+        self,
+        mock_fia,
+        mock_hardware_profile,
+    ):
+        impl = self.impl
+        impl.enable_prefill_bnsd = True
+        impl.pcp_enabled = False
+        impl.attn_type = attn_module.AttentionType.DECODER
+        impl.num_heads = 12
+        impl.num_kv_heads = 2
+        impl.head_size = 256
+        impl.key_cache = torch.empty(4, 128, 2, 256, dtype=torch.bfloat16)
+        impl.value_cache = torch.empty_like(impl.key_cache)
+
+        query = torch.randn(20, 12, 256, dtype=torch.bfloat16)
+        key = impl.key_cache.view(4, 128, -1)
+        value = impl.value_cache.view(4, 128, -1)
+        output = torch.empty_like(query)
+        metadata = AscendMetadata(
+            attn_mask=torch.zeros(8, 8, dtype=torch.bool),
+            attn_state=AscendAttentionState.ChunkedPrefill,
+            num_actual_tokens=20,
+            num_decode_tokens=12,
+            num_prefills=1,
+            num_decodes=3,
+            block_tables=torch.zeros(4, 2, dtype=torch.int32),
+            seq_lens_list=[100, 101, 102, 110],
+            actual_seq_lengths_q=[4, 8, 12, 20],
+        )
+        mock_hardware_profile.return_value = get_hardware_profile(AscendDeviceType.A2)
+
+        def fake_fia(**kwargs):
+            fill_value = 2 if kwargs["input_layout"] == "BNSD" else 1
+            return torch.full_like(kwargs["query"], fill_value), None
+
+        mock_fia.side_effect = fake_fia
+
+        use_bnsd = impl._can_use_bnsd_prefill(query, key, value, 128, metadata.block_tables, metadata)
+        result = impl._forward_fia_chunked_prefill_split(
+            query,
+            key,
+            value,
+            key,
+            value,
+            128,
+            metadata.block_tables,
+            metadata,
+            output,
+            use_bnsd_prefill=use_bnsd,
+        )
+
+        self.assertTrue(use_bnsd)
+        self.assertEqual(mock_fia.call_count, 2)
+        decode_call, prefill_call = mock_fia.call_args_list
+        self.assertEqual(decode_call.kwargs["input_layout"], "TND")
+        self.assertEqual(tuple(decode_call.kwargs["query"].shape), (12, 12, 256))
+        self.assertEqual(prefill_call.kwargs["input_layout"], "BNSD")
+        self.assertEqual(tuple(prefill_call.kwargs["query"].shape), (1, 12, 8, 256))
+        self.assertEqual(prefill_call.kwargs["actual_seq_lengths"], [8])
+        self.assertEqual(prefill_call.kwargs["pre_tokens"], 2147483647)
+        self.assertEqual(prefill_call.kwargs["next_tokens"], 0)
+        self.assertEqual(prefill_call.kwargs["inner_precise"], 0)
+        self.assertTrue(torch.all(result[:12] == 1))
+        self.assertTrue(torch.all(result[12:20] == 2))
+
+        metadata.num_prefills = 2
+        self.assertFalse(impl._can_use_bnsd_prefill(query, key, value, 128, metadata.block_tables, metadata))
 
     @patch("vllm_ascend.attention.attention_v1._EXTRA_CTX")
     @patch("vllm_ascend.attention.attention_v1.DeviceOperator.reshape_and_cache")

--- a/tests/ut/device/test_hardware_profile.py
+++ b/tests/ut/device/test_hardware_profile.py
@@ -45,7 +45,11 @@ _STANDARD_CAPABILITIES = frozenset(
 )
 
 _EXPECTED_CAPABILITIES = {
-    AscendDeviceType.A2: _STANDARD_CAPABILITIES | {HardwareCapability.NPU_TOP_K_TOP_P},
+    AscendDeviceType.A2: _STANDARD_CAPABILITIES
+    | {
+        HardwareCapability.BNSD_PREFILL,
+        HardwareCapability.NPU_TOP_K_TOP_P,
+    },
     AscendDeviceType.A3: _STANDARD_CAPABILITIES
     | {
         HardwareCapability.CANN_MEGAMOE,

--- a/tests/ut/test_ascend_config.py
+++ b/tests/ut/test_ascend_config.py
@@ -209,6 +209,7 @@ class TestAscendConfig(TestBase):
         # No additional config given, check the default value here.
         ascend_config = init_ascend_config(test_vllm_config)
         self.assertFalse(ascend_config.multistream_overlap_shared_expert)
+        self.assertFalse(ascend_config.enable_prefill_bnsd)
         self.assertFalse(ascend_config.enable_kv_nz)
         self.assertEqual(ascend_config.weight_nz_mode, 1)
         self.assertEqual(ascend_config.mega_moe_max_tokens, 65536)
@@ -991,6 +992,13 @@ class TestTopLevelSwitchTypeValidation(TestBase):
         vc = VllmConfig()
         vc.additional_config = {"enable_prefill_mc2": "false"}
         self.assertFalse(init_ascend_config(vc).enable_prefill_mc2)
+
+    @_clean_up
+    @patch("vllm_ascend.platform.NPUPlatform.check_and_update_config")
+    def test_enable_prefill_bnsd_string_true_enables(self, mock_fix):
+        vc = VllmConfig()
+        vc.additional_config = {"enable_prefill_bnsd": "true"}
+        self.assertTrue(init_ascend_config(vc).enable_prefill_bnsd)
 
     @_clean_up
     @patch("vllm_ascend.platform.NPUPlatform.check_and_update_config")

--- a/vllm_ascend/ascend_config.py
+++ b/vllm_ascend/ascend_config.py
@@ -252,6 +252,7 @@ class AscendConfig:
             "enable_cpu_binding": true,
             "multistream_dsv4_dsa_overlap": true,
             "enable_prefill_mc2": false,
+            "enable_prefill_bnsd": false,
             "multistream_overlap_shared_expert": false,
             "enable_kv_nz": false,
             "enable_mc2_hierarchy_comm": false,
@@ -387,6 +388,9 @@ class AscendConfig:
     enable_cpu_binding: bool = True
     multistream_dsv4_dsa_overlap: bool = True
     enable_prefill_mc2: bool = False
+    # Experimental A2 optimization. Eligible long cached-prefill queries use
+    # BNSD while the paged KV cache remains in its native NHD layout.
+    enable_prefill_bnsd: bool = False
     multistream_overlap_shared_expert: bool = False
     enable_kv_nz: bool = False
     enable_mc2_hierarchy_comm: bool = False  # deprecated, will be replaced by mc2_comm_alg = "hierarchy"

--- a/vllm_ascend/attention/attention_v1.py
+++ b/vllm_ascend/attention/attention_v1.py
@@ -41,6 +41,7 @@ from vllm.v1.attention.ops.pcp import _gather_prefill_cache_inputs  # type: igno
 from vllm.v1.core.sched.output import SchedulerOutput
 from vllm.v1.kv_cache_interface import AttentionSpec, CrossAttentionSpec
 
+from vllm_ascend.ascend_config import get_ascend_config
 from vllm_ascend.ascend_forward_context import _EXTRA_CTX
 from vllm_ascend.attention.attention_mask import AttentionMaskBuilder
 from vllm_ascend.attention.utils import (
@@ -68,6 +69,7 @@ from vllm_ascend.utils import weak_ref_tensors
 
 # default max value of sliding window size
 SWA_INT_MAX = 2147483647
+BNSD_PREFILL_MIN_QUERY_TOKENS = 4096
 _ATTN_KEYS_BUFFER = None
 
 
@@ -499,6 +501,7 @@ class AscendAttentionBackendImpl(AttentionImpl):
         self.enable_c8_quant = self.vllm_config.quant_config is not None and getattr(
             self.vllm_config.quant_config, "enable_c8_quant", False
         )
+        self.enable_prefill_bnsd = get_ascend_config().enable_prefill_bnsd
         self._use_layer_aware_fia_graph_replay = needs_layer_aware_fia_graph_replay()
         self._use_max_workspace_for_fia_graph = self._use_layer_aware_fia_graph_replay
         self.sinks = sinks
@@ -1440,13 +1443,22 @@ class AscendAttentionBackendImpl(AttentionImpl):
                     sparse_mode=4,
                 )
             else:
+                use_bnsd_prefill = self._can_use_bnsd_prefill(
+                    query,
+                    key,
+                    value,
+                    block_size,
+                    block_table,
+                    attn_metadata,
+                )
                 # ChunkedPrefill mixing prefill+decode: split into a per-phase
-                # FIA call each (A5 only).
+                # FIA call each. A2 also uses the split for eligible BNSD
+                # prefill queries.
                 # NOTE: Batch-invariant execution also requires prefill and
                 # decode to be processed separately, regardless of the device
                 # generation or attention state. Outside batch-invariant mode,
                 # preserve the existing A5 behavior for performance optimization.
-                if (
+                if use_bnsd_prefill or (
                     (
                         envs_vllm.VLLM_BATCH_INVARIANT
                         or (
@@ -1458,7 +1470,16 @@ class AscendAttentionBackendImpl(AttentionImpl):
                     and attn_metadata.num_prefills > 0
                 ):
                     return self._forward_fia_chunked_prefill_split(
-                        query, key, value, key, passed_value, block_size, block_table, attn_metadata, output
+                        query,
+                        key,
+                        value,
+                        key,
+                        passed_value,
+                        block_size,
+                        block_table,
+                        attn_metadata,
+                        output,
+                        use_bnsd_prefill=use_bnsd_prefill,
                     )
                 attn_output, _ = DeviceOperator.npu_fused_infer_attention_score(
                     query=query,
@@ -1487,6 +1508,51 @@ class AscendAttentionBackendImpl(AttentionImpl):
         output[:num_tokens] = attn_output[:num_tokens]
         return output
 
+    def _can_use_bnsd_prefill(
+        self,
+        query: torch.Tensor,
+        key: torch.Tensor,
+        value: torch.Tensor,
+        block_size: int,
+        block_table: torch.Tensor | None,
+        attn_metadata: AscendMetadata,
+    ) -> bool:
+        """Return whether the current cached-prefill slice can use BNSD FIA.
+
+        BNSD needs a regular sequence dimension, so this optimization is
+        deliberately limited to one long prefill request. Decode requests in
+        the same scheduler step remain on the compact TND path.
+        """
+        if (
+            not self.enable_prefill_bnsd
+            or not get_current_hardware_profile().supports(HardwareCapability.BNSD_PREFILL)
+            or self.pcp_enabled
+            or self.attn_type != AttentionType.DECODER
+            or self.head_size != 256
+            or attn_metadata.attn_state
+            not in (AscendAttentionState.PrefillCacheHit, AscendAttentionState.ChunkedPrefill)
+            or attn_metadata.num_prefills != 1
+            or block_table is None
+            or block_size != AscendAttentionBackend.get_supported_kernel_block_sizes()[0]
+            or query.dtype != torch.bfloat16
+            or key.dtype != torch.bfloat16
+            or value.dtype != torch.bfloat16
+        ):
+            return False
+
+        num_tokens = int(attn_metadata.actual_seq_lengths_q[-1])
+        num_prefill_tokens = num_tokens - attn_metadata.num_decode_tokens
+        return (
+            num_prefill_tokens >= BNSD_PREFILL_MIN_QUERY_TOKENS
+            and query.ndim == 3
+            and query.shape[1:] == (self.num_heads, self.head_size)
+            and key.ndim == 3
+            and key.shape[1:] == (block_size, self.num_kv_heads * self.head_size)
+            and value.shape == key.shape
+            and len(attn_metadata.seq_lens_list) > attn_metadata.num_decodes
+            and block_table.shape[0] > attn_metadata.num_decodes
+        )
+
     def _forward_fia_chunked_prefill_split(
         self,
         query: torch.Tensor,
@@ -1498,6 +1564,8 @@ class AscendAttentionBackendImpl(AttentionImpl):
         block_table: torch.Tensor,
         attn_metadata: AscendMetadata,
         output: torch.Tensor,
+        *,
+        use_bnsd_prefill: bool = False,
     ) -> torch.Tensor:
         """ChunkedPrefill with mixed prefill/decode: run decode and prefill in
         separate FIA calls. split_decodes_and_prefills has reordered the batch
@@ -1542,13 +1610,26 @@ class AscendAttentionBackendImpl(AttentionImpl):
             prefill_seq_qlen = [
                 actual_seq_qlen[i] - num_decode_tokens for i in range(num_decodes, len(actual_seq_qlen))
             ]
+            prefill_query = query[num_decode_tokens:num_tokens]
+            input_layout = "TND"
+            prefill_layout_kwargs = {}
+            if use_bnsd_prefill:
+                prefill_query = prefill_query.transpose(0, 1).unsqueeze(0).contiguous()
+                input_layout = "BNSD"
+                # Keep the causal-window contract explicit for BNSD FIA.
+                prefill_layout_kwargs = {
+                    "pre_tokens": SWA_INT_MAX,
+                    "next_tokens": 0,
+                    "inner_precise": 0,
+                }
+
             prefill_out, _ = DeviceOperator.npu_fused_infer_attention_score(
-                query=query[num_decode_tokens:num_tokens],
+                query=prefill_query,
                 key=key,
                 value=value,
                 atten_mask=attn_metadata.attn_mask,
                 block_table=block_table[num_decodes:],
-                input_layout="TND",
+                input_layout=input_layout,
                 block_size=block_size,
                 actual_seq_lengths=prefill_seq_qlen,
                 actual_seq_lengths_kv=seq_lens_list[num_decodes:],
@@ -1563,8 +1644,11 @@ class AscendAttentionBackendImpl(AttentionImpl):
                 attn_metadata=attn_metadata,
                 is_prefill_no_cache=False,
                 sparse_mode=3,
+                **prefill_layout_kwargs,
             )
             n_prefill = num_tokens - num_decode_tokens
+            if use_bnsd_prefill:
+                prefill_out = prefill_out.squeeze(0).transpose(0, 1).contiguous()
             output[num_decode_tokens:num_tokens] = prefill_out.view(n_prefill, self.num_heads, self.head_size)
         return output
 

--- a/vllm_ascend/device/hardware_profile.py
+++ b/vllm_ascend/device/hardware_profile.py
@@ -20,6 +20,7 @@ class HardwareCapability(Enum):
     ATB_EXTENSIONS = auto()
     ATB_WARMUP = auto()
     BGMV_SGMV_META_REGISTRATION = auto()
+    BNSD_PREFILL = auto()
     CANN_MEGAMOE = auto()
     CHUNKED_PREFILL_PHASE_SPLIT = auto()
     CLUSTER_CPU_TOPOLOGY = auto()
@@ -166,7 +167,11 @@ _HARDWARE_PROFILES: Mapping[AscendDeviceType, HardwareProfile] = MappingProxyTyp
             weight_layout_policy=WeightLayoutPolicy.CONFIGURABLE,
             moe_comm_policy=MoECommPolicy.CAPACITY_AND_EXPERT_DENSITY,
             quantization_backend_family=QuantizationBackendFamily.STANDARD,
-            capabilities=_STANDARD_CAPABILITIES | {HardwareCapability.NPU_TOP_K_TOP_P},
+            capabilities=_STANDARD_CAPABILITIES
+            | {
+                HardwareCapability.BNSD_PREFILL,
+                HardwareCapability.NPU_TOP_K_TOP_P,
+            },
         ),
         AscendDeviceType.A3: HardwareProfile(
             _device_type=AscendDeviceType.A3,


### PR DESCRIPTION
### What this PR does / why we need it?

This PR adds an experimental, opt-in A2 attention path for long cached-prefill queries.

The core contribution is a selective mixed-layout strategy:

- keep short decode requests in compact TND;
- route one eligible long cached-prefill query through BNSD;
- retain the native paged NHD KV cache instead of converting it to HND; and
- fall back to the existing TND implementation for unsupported hardware, shapes, dtypes, or batch composition.

The path is guarded by `enable_prefill_bnsd` and is disabled by default. It currently requires Atlas A2, BF16, 256-dimensional heads, a 128-token paged-KV block size, and exactly one cached/chunked prefill query of at least 4096 tokens in the scheduler step. PCP, sliding-window attention, sinks, and non-decoder attention retain the existing path.

#### Reference measurements

The measurements below were collected with Qwen3.8-27B on Atlas A2 using tensor parallel size 2 and an experimental prototype based on vLLM Ascend commit `f4a08bddd` and CANN 9.0.1. The profiled attention shape had 12 query heads, 2 KV heads, and a head dimension of 256. 

Single-operator benchmark, approximately 7680 query tokens attending to a 100000-token paged KV cache:

| Path | Median latency | Change |
| --- | ---: | ---: |
| TND query + NHD paged KV | 62.7079 ms | baseline |
| BNSD query + NHD paged KV | 54.4916 ms | -13.10% |

Mixed batch with query lengths `[7680, 4, 4, 4]`, including query reorder and output placement:

| Path | Median latency | Change |
| --- | ---: | ---: |
| Mixed TND | 66.1986 ms | baseline |
| Long prefill BNSD + short decode TND | 55.4271 ms | -16.27% |

The long-prefill output had maximum absolute error `1.2207e-4` and relative L2 error `5.8668e-4`; the short decode slices matched exactly in the prototype test.

Service A/B with 40 requests at concurrency 8, 100000 input tokens per request (80000 shared-prefix tokens + 20000 unique tokens), and 16 output tokens:

| Metric | Existing path | BNSD prefill | Change |
| --- | ---: | ---: | ---: |
| Mean queue time | 18.573 s | 18.132 s | -2.37% |
| Mean prefill time | 14.703 s | 14.446 s | -1.75% |
| Mean TTFT | 36.372 s | 35.588 s | -2.16% |
| Mean E2E latency | 58.024 s | 56.967 s | -1.82% |

Both service runs had identical prefix-cache counters and zero preemptions.

### Does this PR introduce _any_ user-facing change?

Yes. It adds the optional `enable_prefill_bnsd` field to `--additional-config`:

```bash
--additional-config '{"enable_prefill_bnsd":true}'
```

The option is disabled by default and unsupported cases automatically use the existing TND path.

### How was this patch tested?

- Added unit coverage for configuration parsing and default behavior.
- Added hardware-profile coverage confirming that the capability is A2-only.
- Added attention-path coverage confirming that decode remains TND, the eligible long prefill uses BNSD, output slices are restored correctly, and multiple prefills fall back.
- Ran Ruff 0.14.0 check/format on all changed Python files.
- Ran Python `compileall` on the changed implementation and tests.
- Ran `git diff --check`.
- Ran the Atlas A2 prototype operator, mixed-batch correctness, and service A/B measurements documented above.

- vLLM main: https://github.com/vllm-project/vllm/commit/84030bbe3d74d99bad477a3d2e37a973ccd8865c
