### PR TITLE
[Bugfix] Backport vLLM PR Prevent negative external block allocation- #52707

### DIFF
--- a/tests/ut/patch/platform/test_prefix_cache_cp_patches.py
+++ b/tests/ut/patch/platform/test_prefix_cache_cp_patches.py
@@ -155,6 +155,19 @@ def test_resolve_kv_cache_block_sizes_with_cp_hybrid_groups(
     assert hash_block_size == expected_hash_block_size
 
 
+def test_negative_get_new_blocks_does_not_corrupt_free_queue() -> None:
+    block_pool = BlockPool(
+        num_gpu_blocks=10,
+        enable_caching=True,
+        hash_block_size=4,
+    )
+    num_free_blocks = block_pool.get_num_free_blocks()
+
+    assert block_pool.get_new_blocks(-2) == []
+    assert block_pool.get_num_free_blocks() == num_free_blocks
+    assert len(block_pool.free_block_queue.get_all_free_blocks()) == num_free_blocks
+
+
 @pytest.mark.parametrize(
     ("spec_factory", "dcp", "pcp", "enable_caching", "expected"),
     [

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/ascend_store_connector.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/ascend_store_connector.py
@@ -173,12 +173,6 @@ class AscendStoreConnector(KVConnectorBase_V1, SupportsHMA):
         """
         if self.connector_scheduler is not None:
             self.connector_scheduler.update_connector_output(connector_output)
-            self.connector_scheduler.update_finished_sending(
-                connector_output.finished_sending
-            )
-            self.connector_scheduler.update_finished_recving(
-                connector_output.finished_recving
-            )
 
         # Get the KV events
         kv_cache_events = connector_output.kv_cache_events

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/ascend_store_connector.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/ascend_store_connector.py
@@ -173,6 +173,12 @@ class AscendStoreConnector(KVConnectorBase_V1, SupportsHMA):
         """
         if self.connector_scheduler is not None:
             self.connector_scheduler.update_connector_output(connector_output)
+            self.connector_scheduler.update_finished_sending(
+                connector_output.finished_sending
+            )
+            self.connector_scheduler.update_finished_recving(
+                connector_output.finished_recving
+            )
 
         # Get the KV events
         kv_cache_events = connector_output.kv_cache_events

--- a/vllm_ascend/patch/__init__.py
+++ b/vllm_ascend/patch/__init__.py
@@ -252,6 +252,22 @@
 #    Future Plan:
 #       Remove this patch once upstream vLLM supports hybrid KV cache + CP for
 #       non-CUDA backends, or exposes a platform hook for this behavior.
+#   2. `vllm.v1.core.block_pool.BlockPool.get_new_blocks`
+#    Why:
+#       vLLM PR #52707 fixed a path where external computed-token allocation
+#       could request a negative number of KV blocks after speculative
+#       over-allocation. In affected vLLM versions this inflates the free-list
+#       counter without popping linked-list entries, which can later crash in
+#       `FreeKVCacheBlockQueue.popleft_n`.
+#    How：
+#       Monkey-patch `BlockPool.get_new_blocks` to return an empty list for
+#       negative allocation requests, preserving the existing zero-allocation
+#       behavior and keeping the free-list counter unchanged.
+#    Related PR (if no, explain why):
+#       https://github.com/vllm-project/vllm/pull/52707
+#    Future Plan:
+#       Remove this patch once the supported vLLM version contains PR #52707
+#       or an equivalent allocator-side guard.
 #
 # ** 10ab. File: worker/patch_v2/patch_attn_utils.py**
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/vllm_ascend/patch/platform/patch_kv_cache_utils.py
+++ b/vllm_ascend/patch/platform/patch_kv_cache_utils.py
@@ -78,6 +78,8 @@ def _filter_queue_insert_blocks(blocks: list[KVCacheBlock], where: str) -> list[
 
 
 _orig_block_pool_free_blocks = BlockPool.free_blocks
+_orig_block_pool_get_new_blocks = BlockPool.get_new_blocks
+_negative_get_new_blocks_warned = False
 
 
 def _ascend_free_blocks(
@@ -92,6 +94,27 @@ def _ascend_free_blocks(
             continue
         filtered_blocks.append(block)
     _orig_block_pool_free_blocks(self, filtered_blocks, prepend)
+
+
+def _ascend_get_new_blocks(
+    self: BlockPool,
+    num_blocks: int,
+) -> list[KVCacheBlock]:
+    # Backport vLLM PR #52707 at the allocator boundary: a negative allocation
+    # request must not inflate FreeKVCacheBlockQueue.num_free_blocks.
+    if num_blocks < 0:
+        global _negative_get_new_blocks_warned
+        if not _negative_get_new_blocks_warned:
+            _negative_get_new_blocks_warned = True
+            logger.warning(
+                "SWA_BLOCK_DIAG negative_get_new_blocks "
+                "where=BlockPool.get_new_blocks requested_num_blocks=%d "
+                "num_free_blocks=%d",
+                num_blocks,
+                self.get_num_free_blocks(),
+            )
+        return []
+    return _orig_block_pool_get_new_blocks(self, num_blocks)
 
 
 _orig_free_queue_prepend_n = FreeKVCacheBlockQueue.prepend_n
@@ -337,7 +360,9 @@ def _get_kv_cache_config_deepseek_v4(
 
 
 BlockPool.free_blocks = _ascend_free_blocks
+BlockPool.get_new_blocks = _ascend_get_new_blocks
 vllm.v1.core.block_pool.BlockPool.free_blocks = _ascend_free_blocks
+vllm.v1.core.block_pool.BlockPool.get_new_blocks = _ascend_get_new_blocks
 FreeKVCacheBlockQueue.prepend_n = _ascend_free_queue_prepend_n
 FreeKVCacheBlockQueue.append_n = _ascend_free_queue_append_n
 vllm.v1.core.kv_cache_utils.FreeKVCacheBlockQueue.prepend_n = _ascend_free_queue_prepend_n


### PR DESCRIPTION
### What this PR does / why we need it?
This PR backport [#52707](https://github.com/vllm-project/vllm/pull/52707) to prevent negative external block allocation that cause `num_free_blocks` overflow.

### Does this PR introduce _any_ user-facing change?

### How was this patch tested?

- vLLM main: https://github.com/vllm-project/vllm/commit/ee0da84ab9e04ac7610e28580af62c365e898389
