### PR TITLE
[0.27.1rc][BugFix][DSpark] Rebind PP weight-sharing guard

### DIFF
--- a/vllm_ascend/patch/worker/patch_v2/patch_dspark.py
+++ b/vllm_ascend/patch/worker/patch_v2/patch_dspark.py
@@ -61,6 +61,7 @@ def _load_dspark_model_with_target_quant(target_model, vllm_config):
     bypass_pp_guard = spec_pp_support is not None
     original_get_pp_group = dspark_utils.get_pp_group
     original_should_share = eagle_utils._should_share
+    original_should_share_ds = getattr(dspark_utils, "_should_share", None)
     if inherits_target_quant:
         model_utils.get_draft_quant_config = lambda _vllm_config: vllm_config.quant_config
     if bypass_pp_guard:
@@ -76,6 +77,12 @@ def _load_dspark_model_with_target_quant(target_model, vllm_config):
             return original_should_share(eagle, flag, draft, target)
 
         eagle_utils._should_share = should_share
+        # ``dspark/utils.py`` imports ``_should_share`` at module top level,
+        # so rebinding only the definer is not visible to its loader; rebind
+        # the caller namespace too when present (same concern as
+        # ``load_dspark_model`` below).
+        if original_should_share_ds is not None:
+            dspark_utils._should_share = should_share
     try:
         # get_model also reads the config PP size; keep the draft unsharded.
         with bypass_upstream_spec_pp_guard(vllm_config, spec_pp_support):
@@ -86,6 +93,8 @@ def _load_dspark_model_with_target_quant(target_model, vllm_config):
         if bypass_pp_guard:
             dspark_utils.get_pp_group = original_get_pp_group
             eagle_utils._should_share = original_should_share
+            if original_should_share_ds is not None:
+                dspark_utils._should_share = original_should_share_ds
 
 
 # The speculator binds ``load_dspark_model`` by name at import time, so both


### PR DESCRIPTION
### What this PR does / why we need it?

vLLM v0.27.1 imports `_should_share` into the DSpark utility module at module scope. The existing Ascend PP wrapper only rebinds `eagle_utils._should_share`, so the DSpark loader keeps calling the original function and tries to access `PPMissingLayer.weight` on non-local pipeline stages.

Rebind the guarded helper in the DSpark caller namespace while the draft model loads, then restore both module bindings in `finally`. The `getattr` guard keeps compatibility with vLLM revisions that do not expose the local binding.

This is the release-branch equivalent of #15522. The failure was reproduced by the DSpark PP accuracy job in #15907.

### Does this PR introduce any user-facing change?

DSpark speculative decoding with pipeline parallelism can initialize on stages that contain `PPMissingLayer` placeholders. There is no API or configuration change.

### How was this patch tested?

- `python -m py_compile vllm_ascend/patch/worker/patch_v2/patch_dspark.py`
- `python -m ruff check vllm_ascend/patch/worker/patch_v2/patch_dspark.py`
- `python -m ruff format --check vllm_ascend/patch/worker/patch_v2/patch_dspark.py`
- `git diff --check origin/releases/v0.27.1rc...HEAD`

- vLLM main: https://github.com/vllm-project/vllm/commit/ba07e4a48fc951300d97eb506217dd530583dea3


CI coverage selection includes `tests/e2e/pull_request/eight_card/model_runner_v2/test_spec_pp_accuracy.py`. The hardware matrix is waiting for a maintainer to add the `ready-precise` label.
