### PR TITLE
[CI][v0.27.1rc] add cann ops-transformer packages for A2/A3/A5 images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,6 +28,27 @@ ARG PIP_TRUSTED_HOST=""
 
 WORKDIR /workspace
 
+# Note: Install CANN 910B (A2) ops-transformer package
+ARG TARGETPLATFORM
+RUN ARCH=${TARGETPLATFORM:-$(uname -m)}; \
+    case "$ARCH" in \
+        "linux/arm64"|"aarch64") \
+            OPS_TRANSFORMER_URL="https://ascend-cann-open.obs.cn-north-4.myhuaweicloud.com/CANN/temp_ops-transformer/cann-910b-ops-transformer_9.2.0_linux-aarch64.run"; \
+            OPS_TRANSFORMER_EXP_URL="https://ascend-cann-open.obs.cn-north-4.myhuaweicloud.com/CANN/temp_ops-transformer/260904/cann-ops-transformer-experimental_910b_linux-aarch64.run" ;; \
+        "linux/amd64"|"x86_64") \
+            OPS_TRANSFORMER_URL="https://ascend-cann-open.obs.cn-north-4.myhuaweicloud.com/CANN/temp_ops-transformer/cann-910b-ops-transformer_9.2.0_linux-x86_64.run"; \
+            OPS_TRANSFORMER_EXP_URL="https://ascend-cann-open.obs.cn-north-4.myhuaweicloud.com/CANN/temp_ops-transformer/260907/build_out/cann-ops-transformer-experimental_910b_linux-x86_64.run" ;; \
+        *) echo "Skipping unsupported architecture: $ARCH" && exit 0 ;; \
+    esac && \
+    wget --quiet "$OPS_TRANSFORMER_URL" -O /tmp/cann-910b-ops-transformer.run && \
+    chmod +x /tmp/cann-910b-ops-transformer.run && \
+    /tmp/cann-910b-ops-transformer.run --full --quiet --install-for-all && \
+    rm -f /tmp/cann-910b-ops-transformer.run && \
+    wget --quiet "$OPS_TRANSFORMER_EXP_URL" -O /tmp/cann-ops-transformer-experimental_910b.run && \
+    chmod +x /tmp/cann-ops-transformer-experimental_910b.run && \
+    /tmp/cann-ops-transformer-experimental_910b.run --full --quiet --install-for-all && \
+    rm -f /tmp/cann-ops-transformer-experimental_910b.run
+
 # Install clang-15 (for triton-ascend) and Mooncake
 ARG MOONCAKE_TAG=0.3.11.post1
 RUN if [ -n "$APTMIRROR" ]; then \

--- a/Dockerfile
+++ b/Dockerfile
@@ -46,7 +46,7 @@ RUN ARCH=${TARGETPLATFORM:-$(uname -m)}; \
     rm -f /tmp/cann-910b-ops-transformer.run && \
     wget --quiet "$OPS_TRANSFORMER_EXP_URL" -O /tmp/cann-ops-transformer-experimental_910b.run && \
     chmod +x /tmp/cann-ops-transformer-experimental_910b.run && \
-    /tmp/cann-ops-transformer-experimental_910b.run --full --quiet --install-for-all && \
+    /tmp/cann-ops-transformer-experimental_910b.run --quiet --install-for-all --force && \
     rm -f /tmp/cann-ops-transformer-experimental_910b.run
 
 # Install clang-15 (for triton-ascend) and Mooncake

--- a/Dockerfile.a3
+++ b/Dockerfile.a3
@@ -49,7 +49,7 @@ RUN ARCH=${TARGETPLATFORM:-$(uname -m)}; \
     rm -f /tmp/cann-A3-ops-transformer.run && \
     wget --quiet "$OPS_TRANSFORMER_EXP_URL" -O /tmp/cann-ops-transformer-experimental_910_93.run && \
     chmod +x /tmp/cann-ops-transformer-experimental_910_93.run && \
-    /tmp/cann-ops-transformer-experimental_910_93.run --full --quiet --install-for-all && \
+    /tmp/cann-ops-transformer-experimental_910_93.run --quiet --install-for-all --force && \
     rm -f /tmp/cann-ops-transformer-experimental_910_93.run
 
 # Install clang-15 (for triton-ascend) and Mooncake

--- a/Dockerfile.a3
+++ b/Dockerfile.a3
@@ -31,6 +31,27 @@ ENV DEBIAN_FRONTEND=noninteractive
 
 WORKDIR /workspace
 
+# Note: Install CANN A3 ops-transformer package
+ARG TARGETPLATFORM
+RUN ARCH=${TARGETPLATFORM:-$(uname -m)}; \
+    case "$ARCH" in \
+        "linux/arm64"|"aarch64") \
+            OPS_TRANSFORMER_URL="https://ascend-cann-open.obs.cn-north-4.myhuaweicloud.com/CANN/temp_ops-transformer/cann-A3-ops-transformer_9.2.0_linux-aarch64.run"; \
+            OPS_TRANSFORMER_EXP_URL="https://ascend-cann-open.obs.cn-north-4.myhuaweicloud.com/CANN/temp_ops-transformer/260904/cann-ops-transformer-experimental_910_93_linux-aarch64.run" ;; \
+        "linux/amd64"|"x86_64") \
+            OPS_TRANSFORMER_URL="https://ascend-cann-open.obs.cn-north-4.myhuaweicloud.com/CANN/temp_ops-transformer/cann-A3-ops-transformer_9.2.0_linux-x86_64.run"; \
+            OPS_TRANSFORMER_EXP_URL="https://ascend-cann-open.obs.cn-north-4.myhuaweicloud.com/CANN/temp_ops-transformer/260907/build_out/cann-ops-transformer-experimental_910_93_linux-x86_64.run" ;; \
+        *) echo "Skipping unsupported architecture: $ARCH" && exit 0 ;; \
+    esac && \
+    wget --quiet "$OPS_TRANSFORMER_URL" -O /tmp/cann-A3-ops-transformer.run && \
+    chmod +x /tmp/cann-A3-ops-transformer.run && \
+    /tmp/cann-A3-ops-transformer.run --full --quiet --install-for-all && \
+    rm -f /tmp/cann-A3-ops-transformer.run && \
+    wget --quiet "$OPS_TRANSFORMER_EXP_URL" -O /tmp/cann-ops-transformer-experimental_910_93.run && \
+    chmod +x /tmp/cann-ops-transformer-experimental_910_93.run && \
+    /tmp/cann-ops-transformer-experimental_910_93.run --full --quiet --install-for-all && \
+    rm -f /tmp/cann-ops-transformer-experimental_910_93.run
+
 # Install clang-15 (for triton-ascend) and Mooncake
 ARG MOONCAKE_TAG=0.3.11.post1
 RUN if [ -n "$APTMIRROR" ]; then \

--- a/Dockerfile.a3.openEuler
+++ b/Dockerfile.a3.openEuler
@@ -49,7 +49,7 @@ RUN ARCH=${TARGETPLATFORM:-$(uname -m)}; \
     rm -f /tmp/cann-A3-ops-transformer.run && \
     wget --quiet "$OPS_TRANSFORMER_EXP_URL" -O /tmp/cann-ops-transformer-experimental_910_93.run && \
     chmod +x /tmp/cann-ops-transformer-experimental_910_93.run && \
-    /tmp/cann-ops-transformer-experimental_910_93.run --full --quiet --install-for-all && \
+    /tmp/cann-ops-transformer-experimental_910_93.run --quiet --install-for-all --force && \
     rm -f /tmp/cann-ops-transformer-experimental_910_93.run
 
 # Install clang (for triton-ascend) and Mooncake

--- a/Dockerfile.a3.openEuler
+++ b/Dockerfile.a3.openEuler
@@ -31,6 +31,27 @@ WORKDIR /workspace
 
 SHELL ["/bin/bash", "-c"]
 
+# Note: Install CANN A3 ops-transformer package
+ARG TARGETPLATFORM
+RUN ARCH=${TARGETPLATFORM:-$(uname -m)}; \
+    case "$ARCH" in \
+        "linux/arm64"|"aarch64") \
+            OPS_TRANSFORMER_URL="https://ascend-cann-open.obs.cn-north-4.myhuaweicloud.com/CANN/temp_ops-transformer/cann-A3-ops-transformer_9.2.0_linux-aarch64.run"; \
+            OPS_TRANSFORMER_EXP_URL="https://ascend-cann-open.obs.cn-north-4.myhuaweicloud.com/CANN/temp_ops-transformer/260904/cann-ops-transformer-experimental_910_93_linux-aarch64.run" ;; \
+        "linux/amd64"|"x86_64") \
+            OPS_TRANSFORMER_URL="https://ascend-cann-open.obs.cn-north-4.myhuaweicloud.com/CANN/temp_ops-transformer/cann-A3-ops-transformer_9.2.0_linux-x86_64.run"; \
+            OPS_TRANSFORMER_EXP_URL="https://ascend-cann-open.obs.cn-north-4.myhuaweicloud.com/CANN/temp_ops-transformer/260907/build_out/cann-ops-transformer-experimental_910_93_linux-x86_64.run" ;; \
+        *) echo "Skipping unsupported architecture: $ARCH" && exit 0 ;; \
+    esac && \
+    wget --quiet "$OPS_TRANSFORMER_URL" -O /tmp/cann-A3-ops-transformer.run && \
+    chmod +x /tmp/cann-A3-ops-transformer.run && \
+    /tmp/cann-A3-ops-transformer.run --full --quiet --install-for-all && \
+    rm -f /tmp/cann-A3-ops-transformer.run && \
+    wget --quiet "$OPS_TRANSFORMER_EXP_URL" -O /tmp/cann-ops-transformer-experimental_910_93.run && \
+    chmod +x /tmp/cann-ops-transformer-experimental_910_93.run && \
+    /tmp/cann-ops-transformer-experimental_910_93.run --full --quiet --install-for-all && \
+    rm -f /tmp/cann-ops-transformer-experimental_910_93.run
+
 # Install clang (for triton-ascend) and Mooncake
 ARG MOONCAKE_TAG=0.3.11.post1
 RUN yum update -y && \

--- a/Dockerfile.a5
+++ b/Dockerfile.a5
@@ -31,6 +31,21 @@ ENV DEBIAN_FRONTEND=noninteractive
 
 WORKDIR /workspace
 
+# Note: Install CANN 950 (A5) ops-transformer package
+ARG TARGETPLATFORM
+RUN ARCH=${TARGETPLATFORM:-$(uname -m)}; \
+    case "$ARCH" in \
+        "linux/arm64"|"aarch64") \
+            OPS_TRANSFORMER_URL="https://ascend-cann-open.obs.cn-north-4.myhuaweicloud.com/CANN/temp_ops-transformer/cann-950-ops-transformer_9.2.0_linux-aarch64.run" ;; \
+        "linux/amd64"|"x86_64") \
+            OPS_TRANSFORMER_URL="https://ascend-cann-open.obs.cn-north-4.myhuaweicloud.com/CANN/temp_ops-transformer/cann-950-ops-transformer_9.2.0_linux-x86_64.run" ;; \
+        *) echo "Skipping unsupported architecture: $ARCH" && exit 0 ;; \
+    esac && \
+    wget --quiet "$OPS_TRANSFORMER_URL" -O /tmp/cann-950-ops-transformer.run && \
+    chmod +x /tmp/cann-950-ops-transformer.run && \
+    /tmp/cann-950-ops-transformer.run --full --quiet --install-for-all && \
+    rm -f /tmp/cann-950-ops-transformer.run
+
 # Install clang-15 (for triton-ascend) and Mooncake
 ARG MOONCAKE_TAG=0.3.11.post1
 RUN if [ -n "$APTMIRROR" ]; then \

--- a/Dockerfile.a5.openEuler
+++ b/Dockerfile.a5.openEuler
@@ -31,6 +31,21 @@ WORKDIR /workspace
 
 SHELL ["/bin/bash", "-c"]
 
+# Note: Install CANN 950 (A5) ops-transformer package
+ARG TARGETPLATFORM
+RUN ARCH=${TARGETPLATFORM:-$(uname -m)}; \
+    case "$ARCH" in \
+        "linux/arm64"|"aarch64") \
+            OPS_TRANSFORMER_URL="https://ascend-cann-open.obs.cn-north-4.myhuaweicloud.com/CANN/temp_ops-transformer/cann-950-ops-transformer_9.2.0_linux-aarch64.run" ;; \
+        "linux/amd64"|"x86_64") \
+            OPS_TRANSFORMER_URL="https://ascend-cann-open.obs.cn-north-4.myhuaweicloud.com/CANN/temp_ops-transformer/cann-950-ops-transformer_9.2.0_linux-x86_64.run" ;; \
+        *) echo "Skipping unsupported architecture: $ARCH" && exit 0 ;; \
+    esac && \
+    wget --quiet "$OPS_TRANSFORMER_URL" -O /tmp/cann-950-ops-transformer.run && \
+    chmod +x /tmp/cann-950-ops-transformer.run && \
+    /tmp/cann-950-ops-transformer.run --full --quiet --install-for-all && \
+    rm -f /tmp/cann-950-ops-transformer.run
+
 # Install clang (for triton-ascend) and Mooncake
 ARG MOONCAKE_TAG=0.3.11.post1
 RUN yum update -y && \

--- a/Dockerfile.openEuler
+++ b/Dockerfile.openEuler
@@ -31,6 +31,27 @@ WORKDIR /workspace
 
 SHELL ["/bin/bash", "-c"]
 
+# Note: Install CANN 910B (A2) ops-transformer package
+ARG TARGETPLATFORM
+RUN ARCH=${TARGETPLATFORM:-$(uname -m)}; \
+    case "$ARCH" in \
+        "linux/arm64"|"aarch64") \
+            OPS_TRANSFORMER_URL="https://ascend-cann-open.obs.cn-north-4.myhuaweicloud.com/CANN/temp_ops-transformer/cann-910b-ops-transformer_9.2.0_linux-aarch64.run"; \
+            OPS_TRANSFORMER_EXP_URL="https://ascend-cann-open.obs.cn-north-4.myhuaweicloud.com/CANN/temp_ops-transformer/260904/cann-ops-transformer-experimental_910b_linux-aarch64.run" ;; \
+        "linux/amd64"|"x86_64") \
+            OPS_TRANSFORMER_URL="https://ascend-cann-open.obs.cn-north-4.myhuaweicloud.com/CANN/temp_ops-transformer/cann-910b-ops-transformer_9.2.0_linux-x86_64.run"; \
+            OPS_TRANSFORMER_EXP_URL="https://ascend-cann-open.obs.cn-north-4.myhuaweicloud.com/CANN/temp_ops-transformer/260907/build_out/cann-ops-transformer-experimental_910b_linux-x86_64.run" ;; \
+        *) echo "Skipping unsupported architecture: $ARCH" && exit 0 ;; \
+    esac && \
+    wget --quiet "$OPS_TRANSFORMER_URL" -O /tmp/cann-910b-ops-transformer.run && \
+    chmod +x /tmp/cann-910b-ops-transformer.run && \
+    /tmp/cann-910b-ops-transformer.run --full --quiet --install-for-all && \
+    rm -f /tmp/cann-910b-ops-transformer.run && \
+    wget --quiet "$OPS_TRANSFORMER_EXP_URL" -O /tmp/cann-ops-transformer-experimental_910b.run && \
+    chmod +x /tmp/cann-ops-transformer-experimental_910b.run && \
+    /tmp/cann-ops-transformer-experimental_910b.run --full --quiet --install-for-all && \
+    rm -f /tmp/cann-ops-transformer-experimental_910b.run
+
 # Install clang (for triton-ascend) and Mooncake
 ARG MOONCAKE_TAG=0.3.11.post1
 RUN yum update -y && \

--- a/Dockerfile.openEuler
+++ b/Dockerfile.openEuler
@@ -49,7 +49,7 @@ RUN ARCH=${TARGETPLATFORM:-$(uname -m)}; \
     rm -f /tmp/cann-910b-ops-transformer.run && \
     wget --quiet "$OPS_TRANSFORMER_EXP_URL" -O /tmp/cann-ops-transformer-experimental_910b.run && \
     chmod +x /tmp/cann-ops-transformer-experimental_910b.run && \
-    /tmp/cann-ops-transformer-experimental_910b.run --full --quiet --install-for-all && \
+    /tmp/cann-ops-transformer-experimental_910b.run --quiet --install-for-all --force && \
     rm -f /tmp/cann-ops-transformer-experimental_910b.run
 
 # Install clang (for triton-ascend) and Mooncake


### PR DESCRIPTION

### What this PR does / why we need it?
Add ops-transformer packages to the A2/A3/A5 Docker images to ensure consistent operator transformation capabilities across all supported architectures (both X86 and ARM64):
• A5 (950) images: operator package cann-950-ops-transformer_9.2.0
• A2 (910b) images: operator package cann-910b-ops-transformer_9.2.0 + experimental package cann-ops-transformer-experimental_910b
• A3 (910_93) images: operator package cann-A3-ops-transformer_9.2.0 + experimental package cann-ops-transformer-experimental_910_93
This covers both ubuntu22.04 and openEuler24.03 Docker images.

### Does this PR introduce _any_ user-facing change?
No. This change only affects the internal build process for the A2/A3/A5 Docker images. No user-facing functionality or interfaces are modified.

### How was this patch tested?
Verified that the A2/A3/A5 Docker images (Ubuntu and openEuler) build successfully with the respective ops-transformer packages included for both X86 and ARM64 architectures.

- vLLM main: https://github.com/vllm-project/vllm/commit/ba07e4a48fc951300d97eb506217dd530583dea3
