### PR TITLE
[Doc] Sync GLM-5 tutorial deployment guidance

### DIFF
--- a/docs/source/tutorials/models/GLM5.md
+++ b/docs/source/tutorials/models/GLM5.md
@@ -6,7 +6,7 @@ This document applies to both `GLM-5` and `GLM-5.1`. Unless otherwise specified,
 
 [GLM-5](https://huggingface.co/zai-org/GLM-5) uses a Mixture-of-Experts (MoE) architecture and targets complex systems engineering and long-horizon agentic tasks.
 
-The `GLM-5` model is first supported in `vllm-ascend:v0.17.0rc1`, and all **v0.17.0rc1 and later versions** can run stably. To use the latest features (e.g., PD separation, MTP), it is recommended to use the latest release candidate or official version.
+The `GLM-5` model is first supported in `vllm-ascend:v0.17.0rc1`(for Ascend950DT, the model is supported from `vllm-ascend:v0.23.0rc1`), and all **v0.17.0rc1 and later versions** can run stably. To use the latest features (e.g., PD separation, MTP), it is recommended to use the latest release candidate or official version.
 
 This document will show the main verification steps of the model, including supported features, feature configuration, environment preparation, single-node and multi-node deployment, accuracy and performance evaluation.
 
@@ -20,12 +20,12 @@ Refer to [Feature Guide](../../user_guide/feature_guide/index.md) to get the fea
 
 ### 3.1 Model Weight
 
-- `GLM-5`(BF16 version): [Download model weight](https://www.modelscope.cn/models/ZhipuAI/GLM-5).
-- `GLM-5-w4a8`(Quantized version): [Download model weight](https://modelscope.cn/models/Eco-Tech/GLM-5-w4a8).
+- `GLM-5-w4a8`(Quantized version): [Download model weight](https://www.modelscope.cn/models/Eco-Tech/GLM-5-w4a8).
 - `GLM-5-w8a8`(Quantized version): [Download model weight](https://www.modelscope.cn/models/Eco-Tech/GLM-5-w8a8).
-- `GLM-5.1`(BF16 version): [Download model weight](https://huggingface.co/zai-org/GLM-5.1).
 - `GLM-5.1-w4a8`(Quantized version): [Download model weight](https://modelers.cn/models/Eco-Tech/GLM-5.1-w4a8).
 - `GLM-5.1-w8a8`(Quantized version): [Download model weight](https://modelers.cn/models/Eco-Tech/GLM-5.1-w8a8).
+- `GLM-5.1-w8a8c8`(Quantized version): [Download model weight](https://modelers.cn/models/Eco-Tech/GLM-5.1-w8a8c8-MTP). The weights have been verified on Atlas 800 A3 and are recommended for use.
+- `GLM-5.1-w4a4`(Ascend950DT mxfp4 Quantized): [Download model weight](https://www.modelscope.cn/models/Eco-Tech/GLM-5.1-w4a4c8-mxfp4). The weights have been verified on Ascend 950DT and are recommended for use.
 
 It is recommended to download the model weight to the shared directory of multiple nodes, such as `/root/.cache/`
 
@@ -245,6 +245,65 @@ If you want to deploy multi-node environment, you need to set up environment on 
     --speculative-config '{"num_speculative_tokens": 3, "method": "deepseek_mtp", "enforce_eager": true}'
     ```
 
+=== "Ascend950DT series"
+
+    - Quantized model `glm-5-w4a4` can be deployed on 1 Ascend950DT (96GB × 8) .
+
+    Run the following script to execute online inference.
+
+    Common Issues Tip: If you encounter issues, Refer to [Public FAQs](../../faqs.md).
+
+    ```shell
+    #!/usr/bin/env bash
+    source /root/.bashrc
+    export PROMETHEUS_MULTIPROC_DIR=/dev/shm/vllm_metrics && mkdir -p $PROMETHEUS_MULTIPROC_DIR
+    export HCCL_DFS_CONFIG="task_exception:off,inconsistent_check:off"
+    export ASCEND_RT_VISIBLE_DEVICES=0,1,2,3,4,5,6,7
+    export PYTORCH_NPU_ALLOC_CONF=expandable_segments:True
+
+    # this obtained through ifconfig
+    # nic_name is the network interface name corresponding to local_ip of the current node
+    nic_name="xxx"
+    local_ip="xxx"
+
+    export HCCL_IF_IP=$local_ip
+    export GLOO_SOCKET_IFNAME=$nic_name
+    export TP_SOCKET_IFNAME=$nic_name
+    export HCCL_SOCKET_IFNAME=$nic_name
+    export OMP_PROC_BIND=false
+    export OMP_NUM_THREADS=100
+    export HCCL_BUFFSIZE=400
+    export HCCL_OP_EXPANSION_MODE="AIV"
+    export VLLM_ASCEND_ENABLE_FLASHCOMM1=1
+    export VLLM_ASCEND_ENABLE_PREFETCH_MLP=1
+    export HCCL_INTRA_PCIE_ENABLE=1
+    export HCCL_INTRA_ROCE_ENABLE=0
+    export DYNAMIC_EPLB="true"
+
+    vllm serve /root/.cache/modelscope/hub/models/vllm-ascend/GLM5-w4a4 \
+    --host 0.0.0.0 \
+    --port 8077 \
+    --data-parallel-size 1 \
+    --tensor-parallel-size 8 \
+    --seed 1024 \
+    --served-model-name glm-5 \
+    --enable-expert-parallel \
+    --max-num-seqs 128 \
+    --max-model-len 202752 \
+    --max-num-batched-tokens 8192 \
+    --trust-remote-code \
+    --enable-prefix-caching \
+    --gpu-memory-utilization 0.95 \
+    --quantization ascend \
+    --enable-auto-tool-choice \
+    --tool-call-parser glm47 \
+    --reasoning-parser glm45 \
+    --compilation-config '{"cudagraph_mode": "FULL_DECODE_ONLY"}' \
+    --hf-overrides '{"use_index_cache": true, "index_topk_freq": 4}' \
+    --speculative-config '{"num_speculative_tokens": 3, "method": "deepseek_mtp", "enforce_eager": true}' \
+    --additional-config '{"enable_cpu_binding": "True", "multistream_overlap_shared_expert": "True", "enable_sparse_c8": "True", "enable_dsa_cp": true, "eplb_config": {"dynamic_eplb": true, "expert_heat_collection_interval": 50, "algorithm_execution_interval": 5, "eplb_policy_type": 2, "num_redundant_experts": 0 }}'
+    ```
+
 **Notice:**
 The parameters are explained as follows:
 
@@ -258,99 +317,117 @@ Common Issues Tip: If you encounter issues, Refer to [Public FAQs](../../faqs.md
 
 === "A3 series"
 
-    - `glm-5-bf16` and `glm-5.1-bf16`: require at least 2 Atlas 800 A3 (64GB × 16).
-
+    **High-Throughput Scenario (DP8 TP4)**
+    
+    - `glm-5.1-w8a8c8`: can be deployed on 2 Atlas 800 A3 (128GB × 8) for high-throughput scenarios.
+    
     Run the following scripts on two nodes respectively.
-
+    
     **node 0**
-
+    
     ```shell
     # this obtained through ifconfig
     # nic_name is the network interface name corresponding to local_ip of the current node
     nic_name="xxx"
     local_ip="xxx"
-
-    # The value of node0_ip must be consistent with the value of local_ip set in node0 (master node)
-    node0_ip="xxxx"
-
     export HCCL_OP_EXPANSION_MODE="AIV"
-
+    export HCCL_TRANSFER_TIMEOUT=600
+    export HCCL_EXEC_TIMEOUT=3600
+    export HCCL_CONNECT_TIMEOUT=3600
     export HCCL_IF_IP=$local_ip
     export GLOO_SOCKET_IFNAME=$nic_name
     export TP_SOCKET_IFNAME=$nic_name
     export HCCL_SOCKET_IFNAME=$nic_name
     export OMP_PROC_BIND=false
     export OMP_NUM_THREADS=1
-    export HCCL_BUFFSIZE=200
-    export VLLM_ASCEND_BALANCE_SCHEDULING=1
+    export HCCL_BUFFSIZE=400
     export PYTORCH_NPU_ALLOC_CONF=expandable_segments:True
+    export VLLM_ASCEND_ENABLE_MLAPO=1
     export VLLM_ASCEND_ENABLE_FLASHCOMM1=1
-
-    vllm serve /root/.cache/modelscope/hub/models/vllm-ascend/GLM5-bf16 \
+    export VLLM_ASCEND_ENABLE_FUSED_MC2=1
+    vllm serve /root/.cache/modelscope/hub/models/vllm-ascend/GLM-5.1-W8A8C8-MTP \
     --host 0.0.0.0 \
     --port 8077 \
-    --data-parallel-size 2 \
-    --data-parallel-size-local 1 \
-    --data-parallel-address $node0_ip \
-    --data-parallel-rpc-port 12890 \
-    --tensor-parallel-size 16 \
+    --data-parallel-size 8 \
+    --data-parallel-size-local 4 \
+    --data-parallel-address $local_ip \
+    --enable-expert-parallel \
+    --data-parallel-rpc-port 12980 \
+    --tensor-parallel-size 4 \
+    --hf-overrides '{"use_index_cache": true, "index_topk_freq": 4}' \
     --seed 1024 \
     --served-model-name glm-5 \
-    --enable-expert-parallel \
-    --max-num-seqs 16 \
-    --max-model-len 8192 \
-    --max-num-batched-tokens 4096 \
+    --tool-call-parser glm47 \
+    --reasoning-parser glm45 \
+    --enable-auto-tool-choice \
     --trust-remote-code \
-    --gpu-memory-utilization 0.95 \
+    --gpu-memory-utilization 0.92 \
+    --quantization ascend \
+    --enable-chunked-prefill \
+    --enable-prefix-caching \
+    --async-scheduling \
+    --additional-config '{"enable_dsa_cp": true, "enable_sparse_sfa_c8": true, "enable_sparse_li_c8": true, "enable_balance_scheduling": true, "fuse_muls_add": true}' \
     --compilation-config '{"cudagraph_mode": "FULL_DECODE_ONLY"}' \
-    --speculative-config '{"num_speculative_tokens": 3, "method": "deepseek_mtp", "enforce_eager": true}'
+    --speculative-config '{"num_speculative_tokens": 3, "method": "deepseek_mtp","enforce_eager":true}'
     ```
-
+    
     **node 1**
-
+    
     ```shell
     # this obtained through ifconfig
     # nic_name is the network interface name corresponding to local_ip of the current node
     nic_name="xxx"
     local_ip="xxx"
-
-    # The value of node0_ip must be consistent with the value of local_ip set in node0 (master node)
+    # IP of node 0 (the data parallel master node), must be consistent with the local_ip of node 0
     node0_ip="xxxx"
-
+    
     export HCCL_OP_EXPANSION_MODE="AIV"
-
+    export HCCL_TRANSFER_TIMEOUT=600
+    export HCCL_EXEC_TIMEOUT=3600
+    export HCCL_CONNECT_TIMEOUT=3600
     export HCCL_IF_IP=$local_ip
     export GLOO_SOCKET_IFNAME=$nic_name
     export TP_SOCKET_IFNAME=$nic_name
     export HCCL_SOCKET_IFNAME=$nic_name
     export OMP_PROC_BIND=false
     export OMP_NUM_THREADS=1
-    export HCCL_BUFFSIZE=200
-    export VLLM_ASCEND_BALANCE_SCHEDULING=1
+    export HCCL_BUFFSIZE=400
     export PYTORCH_NPU_ALLOC_CONF=expandable_segments:True
+    export VLLM_ASCEND_ENABLE_MLAPO=1
     export VLLM_ASCEND_ENABLE_FLASHCOMM1=1
-
-    vllm serve /root/.cache/modelscope/hub/models/vllm-ascend/GLM5-bf16 \
+    export VLLM_ASCEND_ENABLE_FUSED_MC2=1
+    vllm serve /root/.cache/modelscope/hub/models/vllm-ascend/GLM-5.1-W8A8C8-MTP \
     --host 0.0.0.0 \
     --port 8077 \
     --headless \
-    --data-parallel-size 2 \
-    --data-parallel-size-local 1 \
-    --data-parallel-start-rank 1 \
+    --data-parallel-size 8 \
+    --data-parallel-size-local 4 \
+    --data-parallel-start-rank 4 \
     --data-parallel-address $node0_ip \
-    --data-parallel-rpc-port 12890 \
-    --tensor-parallel-size 16 \
+    --enable-expert-parallel \
+    --data-parallel-rpc-port 12980 \
+    --tensor-parallel-size 4 \
+    --hf-overrides '{"use_index_cache": true, "index_topk_freq": 4}' \
     --seed 1024 \
     --served-model-name glm-5 \
-    --enable-expert-parallel \
-    --max-num-seqs 16 \
-    --max-model-len 8192 \
-    --max-num-batched-tokens 4096 \
+    --tool-call-parser glm47 \
+    --reasoning-parser glm45 \
+    --enable-auto-tool-choice \
     --trust-remote-code \
-    --gpu-memory-utilization 0.95 \
+    --gpu-memory-utilization 0.92 \
+    --quantization ascend \
+    --enable-chunked-prefill \
+    --enable-prefix-caching \
+    --async-scheduling \
+    --additional-config '{"enable_dsa_cp": true, "enable_sparse_sfa_c8": true, "enable_sparse_li_c8": true, "enable_balance_scheduling": true, "fuse_muls_add": true}' \
     --compilation-config '{"cudagraph_mode": "FULL_DECODE_ONLY"}' \
-    --speculative-config '{"num_speculative_tokens": 3, "method": "deepseek_mtp", "enforce_eager": true}'
+    --speculative-config '{"num_speculative_tokens": 3, "method": "deepseek_mtp","enforce_eager":true}'
     ```
+    
+    **Notice:**
+    
+    - When testing with a prefix cache hit rate > 0, keep `--enable-prefix-caching` (as in the scripts above); when the hit rate is 0, replace it with `--no-enable-prefix-caching`.
+    - `VLLM_ASCEND_ENABLE_FUSED_MC2=1` conflicts with `"multistream_overlap_shared_expert": true` — the runtime automatically disables `multistream_overlap_shared_expert` when fused MC2 is enabled.
 
 === "A2 series"
 
@@ -612,124 +689,553 @@ vllm serve /root/.cache/modelscope/hub/models/vllm-ascend/GLM5-w8a8 \
 --speculative-config '{"num_speculative_tokens": 3, "method": "deepseek_mtp", "enforce_eager": true}'
 ```
 
+Key Parameter Descriptions for multi-node deployment:
+
+In addition to all single-node parameters described in [Single-Node Online Deployment](#51-single-node-online-deployment), the following parameters are specific to multi-node deployment:
+
+**Network and data parallel configuration:**
+
+- `HCCL_IF_IP`, `GLOO_SOCKET_IFNAME`, `TP_SOCKET_IFNAME`, `HCCL_SOCKET_IFNAME`: Network interface configuration for multi-node communication. Set `nic_name` to the network interface name (obtained via `ifconfig`) and `local_ip` to the current node's IP address. These must be correctly configured on each node for successful multi-node communication.
+- `--data-parallel-size`: Total number of data parallel ranks across all nodes. For 2-node deployment, typically set to `2`.
+- `--data-parallel-size-local`: Number of data parallel ranks on the current node. Usually set to `1` (one DP rank per node).
+- `--data-parallel-address`: IP address of the data parallel master node (node 0). Must match the `local_ip` of the master node.
+- `--data-parallel-rpc-port`: RPC port for data parallel master communication. Must be the same across all nodes.
+- `--headless`: Indicates this is a non-master node. Do not use on node 0.
+- `--data-parallel-start-rank`: Starting rank offset for data parallel ranks on this node. Node 0 uses `0`; node 1 uses the number of DP ranks on node 0 (e.g., `1` for DP2, `4` for DP8).
+
+**Multi-node performance tuning:**
+
+- For low-latency multi-node scenarios, keep `--data-parallel-size-local 1` to minimize cross-node communication.
+- `--max-num-seqs` should be tuned based on available KV cache memory after model loading. For the w8a8c8 198K high-throughput scenario on A3, `6` is recommended; for the 198K low-latency scenario, `16` is recommended. For w4a8 on A2 multi-node with long context, start with `2` and increase if memory permits.
+- All nodes in a multi-node deployment must use identical `--tensor-parallel-size`, `--enable-expert-parallel`, and model weight path configurations.
+
+**w8a8c8-specific `--additional-config` fields:**
+
+- `"enable_dsa_cp": true`: Enables DSA context parallelism to accelerate long-context prefill.
+- `"enable_sparse_sfa_c8": true` / `"enable_sparse_li_c8": true`: Sparse attention optimizations of the C8 quantized model.
+- `"enable_balance_scheduling": true`: Improves output throughput and reduces TPOT in the v1 scheduler. Not recommended when Prefill-Decode is separated.
+- `"fuse_muls_add": true`: Fuses multiply-add operations.
+- `"multistream_overlap_shared_expert": true`: Overlaps shared-expert computation on an additional stream. Automatically disabled when `VLLM_ASCEND_ENABLE_FUSED_MC2=1`.
+
 ### 5.3 Prefill-Decode Disaggregation
 
-We'd like to show the deployment guide of `GLM-5` on multi-node environment with 1P1D for better performance. *Prefill-Decode Disaggregation* refers to the separation of the prefill stage and the decode stage across different nodes to improve throughput and latency.
+We'd like to show the deployment guide of `GLM-5` on multi-node environment with Prefill-Decode (PD) disaggregation for better performance. *Prefill-Decode Disaggregation* refers to the separation of the prefill stage and the decode stage across different nodes to improve throughput and latency.
+
+In the PD disaggregation scenario, Mooncake is used as the KV cache transfer connector between the prefill and decode nodes. Please refer to [KV Cache Pool (Ascend Store) Deployment Guide](https://github.com/vllm-project/vllm-ascend/blob/main/docs/source/user_guide/feature_guide/kv_pool.md) for the Mooncake configuration.
+
+#### 5.3.1 Prefill-Decode Disaggregation (Ascend950DT series)
 
 Before you start, please
 
-1. prepare the script `launch_online_dp.py` on each node:
+prepare the script `launch_online_dp.py` on each node:
 
-    ```python
-    import argparse
-    import multiprocessing
-    import os
-    import subprocess
-    import sys
+```python
+import argparse
+import multiprocessing
+import os
+import subprocess
+import sys
+def parse_args():
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--dp-size",
+        type=int,
+        required=True,
+        help="Data parallel size."
+    )
+    parser.add_argument(
+        "--tp-size",
+        type=int,
+        default=1,
+        help="Tensor parallel size."
+    )
+    parser.add_argument(
+        "--dp-size-local",
+        type=int,
+        default=-1,
+        help="Local data parallel size."
+    )
+    parser.add_argument(
+        "--dp-rank-start",
+        type=int,
+        default=0,
+        help="Starting rank for data parallel."
+    )
+    parser.add_argument(
+        "--dp-address",
+        type=str,
+        required=True,
+        help="IP address for data parallel master node."
+    )
+    parser.add_argument(
+        "--dp-rpc-port",
+        type=str,
+        default=12345,
+        help="Port for data parallel master node."
+    )
+    parser.add_argument(
+        "--vllm-start-port",
+        type=int,
+        default=9000,
+        help="Starting port for the engine."
+    )
+    return parser.parse_args()
+args = parse_args()
+dp_size = args.dp_size
+tp_size = args.tp_size
+dp_size_local = args.dp_size_local
+if dp_size_local == -1:
+    dp_size_local = dp_size
+dp_rank_start = args.dp_rank_start
+dp_address = args.dp_address
+dp_rpc_port = args.dp_rpc_port
+vllm_start_port = args.vllm_start_port
+def run_command(visible_devices, dp_rank, vllm_engine_port):
+    command = [
+        "bash",
+        "./run_dp_template.sh",
+        visible_devices,
+        str(vllm_engine_port),
+        str(dp_size),
+        str(dp_rank),
+        dp_address,
+        dp_rpc_port,
+        str(tp_size),
+    ]
+    subprocess.run(command, check=True)
+if __name__ == "__main__":
+    template_path = "./run_dp_template.sh"
+    if not os.path.exists(template_path):
+        print(f"Template file {template_path} does not exist.")
+        sys.exit(1)
+    processes = []
+    num_cards = dp_size_local * tp_size
+    for i in range(dp_size_local):
+        dp_rank = dp_rank_start + i
+        vllm_engine_port = vllm_start_port + i
+        visible_devices = ",".join(str(x) for x in range(i * tp_size, (i + 1) * tp_size))
+        process = multiprocessing.Process(target=run_command,
+                                        args=(visible_devices, dp_rank,
+                                                vllm_engine_port))
+        processes.append(process)
+        process.start()
+    for process in processes:
+        process.join()
+```
 
-    def parse_args():
-        parser = argparse.ArgumentParser()
-        parser.add_argument(
-            "--dp-size",
-            type=int,
-            required=True,
-            help="Data parallel size."
-        )
-        parser.add_argument(
-            "--tp-size",
-            type=int,
-            default=1,
-            help="Tensor parallel size."
-        )
-        parser.add_argument(
-            "--dp-size-local",
-            type=int,
-            default=-1,
-            help="Local data parallel size."
-        )
-        parser.add_argument(
-            "--dp-rank-start",
-            type=int,
-            default=0,
-            help="Starting rank for data parallel."
-        )
-        parser.add_argument(
-            "--dp-address",
-            type=str,
-            required=True,
-            help="IP address for data parallel master node."
-        )
-        parser.add_argument(
-            "--dp-rpc-port",
-            type=str,
-            default=12345,
-            help="Port for data parallel master node."
-        )
-        parser.add_argument(
-            "--vllm-start-port",
-            type=int,
-            default=9000,
-            help="Starting port for the engine."
-        )
-        return parser.parse_args()
-
-    args = parse_args()
-    dp_size = args.dp_size
-    tp_size = args.tp_size
-    dp_size_local = args.dp_size_local
-    if dp_size_local == -1:
-        dp_size_local = dp_size
-    dp_rank_start = args.dp_rank_start
-    dp_address = args.dp_address
-    dp_rpc_port = args.dp_rpc_port
-    vllm_start_port = args.vllm_start_port
-
-    def run_command(visible_devices, dp_rank, vllm_engine_port):
-        command = [
-            "bash",
-            "./run_dp_template.sh",
-            visible_devices,
-            str(vllm_engine_port),
-            str(dp_size),
-            str(dp_rank),
-            dp_address,
-            dp_rpc_port,
-            str(tp_size),
-        ]
-        subprocess.run(command, check=True)
-
-    if __name__ == "__main__":
-        template_path = "./run_dp_template.sh"
-        if not os.path.exists(template_path):
-            print(f"Template file {template_path} does not exist.")
-            sys.exit(1)
-
-        processes = []
-        num_cards = dp_size_local * tp_size
-        for i in range(dp_size_local):
-            dp_rank = dp_rank_start + i
-            vllm_engine_port = vllm_start_port + i
-            visible_devices = ",".join(str(x) for x in range(i * tp_size, (i + 1) * tp_size))
-            process = multiprocessing.Process(target=run_command,
-                                            args=(visible_devices, dp_rank,
-                                                    vllm_engine_port))
-            processes.append(process)
-            process.start()
-
-        for process in processes:
-            process.join()
-
-    ```
-
-2. prepare the script `run_dp_template.sh` on each node.
+1. prepare the script `run_dp_template.sh` on each node.
 
     1. Prefill node 0
 
         ```shell
+        #!/usr/bin/env bash
+        source /root/.bashrc
+        export PROMETHEUS_MULTIPROC_DIR=/dev/shm/vllm_metrics && mkdir -p $PROMETHEUS_MULTIPROC_DIR
+        export HCCL_DFS_CONFIG="task_exception:off,inconsistent_check:off"
+
+        # this obtained through ifconfig
+        # nic_name is the network interface name corresponding to local_ip of the current node
+        nic_name="xxx"
+        local_ip="xxx"
+
+        export HCCL_IF_IP=$local_ip
+        export GLOO_SOCKET_IFNAME=$nic_name
+        export TP_SOCKET_IFNAME=$nic_name
+        export HCCL_SOCKET_IFNAME=$nic_name
+        export HCCL_ALGO=level0:fullmesh
+        export VLLM_RPC_TIMEOUT=3600000
+        export VLLM_EXECUTE_MODEL_TIMEOUT_SECONDS=30000
+        export HCCL_EXEC_TIMEOUT=204
+        export HCCL_CONNECT_TIMEOUT=180
+        export HCCL_BUFFSIZE=300
+        export VLLM_ASCEND_ENABLE_FLASHCOMM1=1
+        export OMP_PROC_BIND=false
+        export OMP_NUM_THREADS=10
+        export PYTORCH_NPU_ALLOC_CONF=expandable_segments:True
+        export ASCEND_LOCAL_COMM_RES='{"version":"1.3"}'
+        export ASCEND_RT_VISIBLE_DEVICES=$1
+
+        vllm serve /root/.cache/modelscope/hub/models/vllm-ascend/GLM5-w4a4 \
+            --host 0.0.0.0 \
+            --port $2 \
+            --data-parallel-size $3 \
+            --tensor-parallel-size $7 \
+            --max-model-len 135000 \
+            --max-num-batched-tokens 8192 \
+            --served-model-name glm-5 \
+            --gpu-memory-utilization 0.95 \
+            --enable-expert-parallel \
+            --max-num-seqs 8 \
+            --enable-prefix-caching \
+            --trust-remote-code \
+            --enforce-eager \
+            --quantization ascend \
+            --enable-auto-tool-choice \
+            --tool-call-parser glm47 \
+            --reasoning-parser glm45 \
+            --speculative-config '{"num_speculative_tokens": 1, "method": "deepseek_mtp", "enforce_eager": true}' \
+            --hf-overrides '{"use_index_cache": true, "index_topk_freq": 4}' \
+            --kv-transfer-config \
+            '{"kv_connector": "MooncakeConnectorV1",
+            "kv_role": "kv_producer",
+            "kv_port": "30100",
+            "engine_id": "1",
+            "kv_connector_extra_config": {
+                        "prefill": {
+                                "dp_size": 1,
+                                "tp_size": 8
+                        },
+                        "decode": {
+                                "dp_size": 16,
+                                "tp_size": 1
+                        },
+                        "ascend_local_comm_res_path": "/etc/hixlep"
+                }
+            }' \
+            --additional-config '{"enable_cpu_binding": "True", "multistream_overlap_shared_expert": "True", "recompute_scheduler_enable": "True", "enable_sparse_c8": "True", "enable_dsa_cp": true }'
+        ```
+
+    2. Prefill node 1
+
+        ```shell
+        #!/usr/bin/env bash
+        source /root/.bashrc
+        export PROMETHEUS_MULTIPROC_DIR=/dev/shm/vllm_metrics && mkdir -p $PROMETHEUS_MULTIPROC_DIR
+        export HCCL_DFS_CONFIG="task_exception:off,inconsistent_check:off"
+
+        # this obtained through ifconfig
+        # nic_name is the network interface name corresponding to local_ip of the current node
+        nic_name="xxx"
+        local_ip="xxx"
+
+        export HCCL_IF_IP=$local_ip
+        export GLOO_SOCKET_IFNAME=$nic_name
+        export TP_SOCKET_IFNAME=$nic_name
+        export HCCL_SOCKET_IFNAME=$nic_name
+        export HCCL_ALGO=level0:fullmesh
+        export VLLM_RPC_TIMEOUT=3600000
+        export VLLM_EXECUTE_MODEL_TIMEOUT_SECONDS=30000
+        export HCCL_EXEC_TIMEOUT=204
+        export HCCL_CONNECT_TIMEOUT=180
+        export HCCL_BUFFSIZE=300
+        export VLLM_ASCEND_ENABLE_FLASHCOMM1=1
+        export OMP_PROC_BIND=false
+        export OMP_NUM_THREADS=10
+        export PYTORCH_NPU_ALLOC_CONF=expandable_segments:True
+        export ASCEND_LOCAL_COMM_RES='{"version":"1.3"}'
+        export ASCEND_RT_VISIBLE_DEVICES=$1
+
+        vllm serve /root/.cache/modelscope/hub/models/vllm-ascend/GLM5-w4a4 \
+            --host 0.0.0.0 \
+            --port $2 \
+            --data-parallel-size $3 \
+            --tensor-parallel-size $7 \
+            --max-model-len 135000 \
+            --max-num-batched-tokens 8192 \
+            --served-model-name glm-5 \
+            --gpu-memory-utilization 0.95 \
+            --enable-expert-parallel \
+            --max-num-seqs 8 \
+            --enable-prefix-caching \
+            --trust-remote-code \
+            --enforce-eager \
+            --quantization ascend \
+            --enable-auto-tool-choice \
+            --tool-call-parser glm47 \
+            --reasoning-parser glm45 \
+            --speculative-config '{"num_speculative_tokens": 1, "method": "deepseek_mtp", "enforce_eager": true}' \
+            --hf-overrides '{"use_index_cache": true, "index_topk_freq": 4}' \
+            --kv-transfer-config \
+            '{"kv_connector": "MooncakeConnectorV1",
+            "kv_role": "kv_producer",
+            "kv_port": "30100",
+            "engine_id": "1",
+            "kv_connector_extra_config": {
+                        "prefill": {
+                                "dp_size": 1,
+                                "tp_size": 8
+                        },
+                        "decode": {
+                                "dp_size": 16,
+                                "tp_size": 1
+                        },
+                        "ascend_local_comm_res_path": "/etc/hixlep"
+                }
+            }' \
+            --additional-config '{"enable_cpu_binding": "True", "multistream_overlap_shared_expert": "True", "recompute_scheduler_enable": "True", "enable_sparse_c8": "True", "enable_dsa_cp": true }'
+        ```
+
+    3. Decode node 0
+
+        ```shell
+        #!/usr/bin/env bash
+        source /root/.bashrc
+        export PROMETHEUS_MULTIPROC_DIR=/dev/shm/vllm_metrics && mkdir -p $PROMETHEUS_MULTIPROC_DIR
+        export HCCL_DFS_CONFIG="task_exception:off,inconsistent_check:off"
+
+        # this obtained through ifconfig
+        # nic_name is the network interface name corresponding to local_ip of the current node
+        nic_name="xxx"
+        local_ip="xxx"
+
+        export HCCL_IF_IP=$local_ip
+        export GLOO_SOCKET_IFNAME=$nic_name
+        export TP_SOCKET_IFNAME=$nic_name
+        export HCCL_SOCKET_IFNAME=$nic_name
+        export HCCL_ALGO=level0:fullmesh
+        export VLLM_RPC_TIMEOUT=3600000
+        export VLLM_EXECUTE_MODEL_TIMEOUT_SECONDS=30000
+        export HCCL_EXEC_TIMEOUT=200
+        export HCCL_CONNECT_TIMEOUT=1800
+        export HCCL_BUFFSIZE=1200
+        export OMP_PROC_BIND=false
+        export OMP_NUM_THREADS=10
+        export PYTORCH_NPU_ALLOC_CONF=expandable_segments:True
+        export ASCEND_LOCAL_COMM_RES='{"version":"1.3"}'
+        export ASCEND_RT_VISIBLE_DEVICES=$1
+
+        vllm serve /root/.cache/modelscope/hub/models/vllm-ascend/GLM5-w4a4 \
+            --host 0.0.0.0 \
+            --port $2 \
+            --data-parallel-size $3 \
+            --data-parallel-rank $4 \
+            --data-parallel-address $5 \
+            --data-parallel-rpc-port $6 \
+            --tensor-parallel-size $7 \
+            --max-model-len 135000 \
+            --max-num-batched-tokens 240 \
+            --served-model-name glm-5 \
+            --gpu-memory-utilization 0.95 \
+            --enable-expert-parallel \
+            --max-num-seqs 60 \
+            --enable-prefix-caching \
+            --trust-remote-code \
+            --quantization ascend \
+            --enable-auto-tool-choice \
+            --tool-call-parser glm47 \
+            --reasoning-parser glm45 \
+            --compilation-config '{"cudagraph_mode":"FULL_DECODE_ONLY"}' \
+            --speculative-config '{"num_speculative_tokens": 3, "method": "deepseek_mtp", "enforce_eager": true}' \
+            --hf-overrides '{"use_index_cache": true, "index_topk_freq": 4}' \
+            --kv-transfer-config \
+            '{"kv_connector": "MooncakeConnectorV1",
+            "kv_role": "kv_consumer",
+            "kv_port": "30300",
+            "engine_id": "3",
+            "kv_connector_extra_config": {
+                        "prefill": {
+                                "dp_size": 1,
+                                "tp_size": 8
+                        },
+                        "decode": {
+                                "dp_size": 16,
+                                "tp_size": 1
+                        },
+                        "ascend_local_comm_res_path": "/etc/hixlep"
+                }
+            }' \
+            --additional-config '{"enable_cpu_binding": "True", "multistream_overlap_shared_expert": "True", "recompute_scheduler_enable": "True", "enable_sparse_c8": "True", "finegrained_tp_config": {"lmhead_tensor_parallel_size":8}}'
+        ```
+
+    4. Decode node 1
+
+        ```shell
+        #!/usr/bin/env bash
+        source /root/.bashrc
+        export PROMETHEUS_MULTIPROC_DIR=/dev/shm/vllm_metrics && mkdir -p $PROMETHEUS_MULTIPROC_DIR
+        export HCCL_DFS_CONFIG="task_exception:off,inconsistent_check:off"
+
+        # this obtained through ifconfig
+        # nic_name is the network interface name corresponding to local_ip of the current node
+        nic_name="xxx"
+        local_ip="xxx"
+
+        export HCCL_IF_IP=$local_ip
+        export GLOO_SOCKET_IFNAME=$nic_name
+        export TP_SOCKET_IFNAME=$nic_name
+        export HCCL_SOCKET_IFNAME=$nic_name
+        export HCCL_ALGO=level0:fullmesh
+        export VLLM_RPC_TIMEOUT=3600000
+        export VLLM_EXECUTE_MODEL_TIMEOUT_SECONDS=30000
+        export HCCL_EXEC_TIMEOUT=200
+        export HCCL_CONNECT_TIMEOUT=1800
+        export HCCL_BUFFSIZE=1200
+        export OMP_PROC_BIND=false
+        export OMP_NUM_THREADS=10
+        export PYTORCH_NPU_ALLOC_CONF=expandable_segments:True
+        export ASCEND_LOCAL_COMM_RES='{"version":"1.3"}'
+        export ASCEND_RT_VISIBLE_DEVICES=$1
+
+        vllm serve /root/.cache/modelscope/hub/models/vllm-ascend/GLM5-w4a4 \
+            --host 0.0.0.0 \
+            --port $2 \
+            --data-parallel-size $3 \
+            --data-parallel-rank $4 \
+            --data-parallel-address $5 \
+            --data-parallel-rpc-port $6 \
+            --tensor-parallel-size $7 \
+            --max-model-len 202752 \
+            --max-num-batched-tokens 240 \
+            --served-model-name glm-5 \
+            --gpu-memory-utilization 0.95 \
+            --enable-expert-parallel \
+            --max-num-seqs 60 \
+            --enable-prefix-caching \
+            --trust-remote-code \
+            --quantization ascend \
+            --enable-auto-tool-choice \
+            --tool-call-parser glm47 \
+            --reasoning-parser glm45 \
+            --compilation-config '{"cudagraph_mode":"FULL_DECODE_ONLY"}' \
+            --speculative-config '{"num_speculative_tokens": 3, "method": "deepseek_mtp", "enforce_eager": true}' \
+            --hf-overrides '{"use_index_cache": true, "index_topk_freq": 4}' \
+            --kv-transfer-config \
+            '{"kv_connector": "MooncakeConnectorV1",
+            "kv_role": "kv_consumer",
+            "kv_port": "30300",
+            "engine_id": "3",
+            "kv_connector_extra_config": {
+                        "prefill": {
+                                "dp_size": 1,
+                                "tp_size": 8
+                        },
+                        "decode": {
+                                "dp_size": 16,
+                                "tp_size": 1
+                        },
+                        "ascend_local_comm_res_path": "/etc/hixlep"
+                }
+            }' \
+            --additional-config '{"enable_cpu_binding": "True", "multistream_overlap_shared_expert": "True", "recompute_scheduler_enable": "True", "enable_sparse_c8": "True", "finegrained_tp_config": {"lmhead_tensor_parallel_size":8}}'
+        ```
+
+Once the preparation is done, you can start the server with the following command on each node:
+
+1. Prefill node 0
+
+    ```shell
+    # change ip to your own
+    python launch_online_dp.py --dp-size 1 --tp-size 8 --dp-size-local 1 --dp-rank-start 0 --dp-address $node_p0_ip --dp-rpc-port 10521 --vllm-start-port 6700
+    ```
+
+2. Prefill node 1
+
+    ```shell
+    # change ip to your own
+    python launch_online_dp.py --dp-size 1 --tp-size 8 --dp-size-local 1 --dp-rank-start 0 --dp-address $node_p1_ip --dp-rpc-port 10521 --vllm-start-port 6700
+    ```
+
+3. Decode node 0
+
+    ```shell
+    # change ip to your own
+    python launch_online_dp.py --dp-size 16 --tp-size 1 --dp-size-local 8 --dp-rank-start 0 --dp-address $node_d0_ip --dp-rpc-port 10523 --vllm-start-port 6721
+    ```
+
+4. Decode node 1
+
+    ```shell
+    # change ip to your own
+    python launch_online_dp.py --dp-size 16 --tp-size 1 --dp-size-local 8 --dp-rank-start 8 --dp-address $node_d0_ip --dp-rpc-port 10523 --vllm-start-port 6721
+    ```
+
+#### 5.3.2 Prefill-Decode Disaggregation (A3 series)
+
+The high-throughput (198K context) scenario is validated on 4 Atlas 800 A3 (128GB × 8): 2 prefill nodes (`PP2 TP16`, 78 layers partitioned as `41/37`, one PP rank per node) and 2 decode nodes (`DP8 TP4`, 4 DP ranks per node). The same scripts serve both the high-throughput and low-latency cases.
+
+Before you start, please
+
+prepare the script `launch_online_dp.py` on each node:
+
+```python
+import argparse
+import multiprocessing
+import os
+import subprocess
+import sys
+
+def parse_args():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--dp-size", type=int, required=True, help="Data parallel size.")
+    parser.add_argument("--tp-size", type=int, default=1, help="Tensor parallel size.")
+    parser.add_argument("--pp-size", type=int, default=1, help="Pipeline parallel size.")
+    parser.add_argument("--dp-size-local", type=int, default=-1, help="Local data parallel size.")
+    parser.add_argument("--dp-rank-start", type=int, default=0, help="Starting rank for data parallel.")
+    parser.add_argument("--dp-address", type=str, required=True, help="IP address for data parallel master node.")
+    parser.add_argument("--dp-rpc-port", type=str, default="12321", help="Port for data parallel master node.")
+    parser.add_argument("--vllm-start-port", type=int, default=8000, help="Starting port for the engine.")
+    return parser.parse_args()
+
+args = parse_args()
+dp_size = args.dp_size
+tp_size = args.tp_size
+pp_size = args.pp_size
+dp_size_local = args.dp_size_local
+if dp_size_local == -1:
+    dp_size_local = dp_size
+dp_rank_start = args.dp_rank_start
+dp_address = args.dp_address
+dp_rpc_port = args.dp_rpc_port
+vllm_start_port = args.vllm_start_port
+gpus_per_dp_rank = tp_size * pp_size
+
+def run_command(visible_devices, dp_rank, vllm_engine_port):
+    command = [
+        "bash",
+        "./run_dp_template.sh",
+        visible_devices,
+        str(vllm_engine_port),
+        str(dp_size),
+        str(dp_rank),
+        dp_address,
+        dp_rpc_port,
+        str(tp_size),
+        str(pp_size),
+    ]
+    subprocess.run(command, check=True)
+
+if __name__ == "__main__":
+    template_path = "./run_dp_template.sh"
+    if not os.path.exists(template_path):
+        print(f"Template file {template_path} does not exist.")
+        sys.exit(1)
+
+    processes = []
+    num_cards = dp_size_local * gpus_per_dp_rank
+
+    for i in range(dp_size_local):
+        dp_rank = dp_rank_start + i
+        vllm_engine_port = vllm_start_port + i
+        visible_devices = ",".join(str(x) for x in range(i * gpus_per_dp_rank, (i + 1) * gpus_per_dp_rank))
+        process = multiprocessing.Process(
+            target=run_command,
+            args=(visible_devices, dp_rank, vllm_engine_port)
+        )
+        processes.append(process)
+        process.start()
+
+    for process in processes:
+        process.join()
+```
+
+1. prepare the script `run_dp_template.sh` on each node.
+
+    1. Prefill node 0
+
+        The prefill script selects the node via `node_rank`: set `node_rank=0` on prefill node 0 (PP master node, engine port `9081`) and `node_rank=1` on prefill node 1 (non-master node, `--headless`, no API server).
+
+        ```shell
         nic_name="xxxx" # change to your own nic name
         local_ip="xxxx" # change to your own ip
+        # pp=2
+        export VLLM_PP_LAYER_PARTITION="41,37"
+        # prefill node 0: node_rank=0, prefill node 1: node_rank=1
+        node_rank=0
 
         export HCCL_OP_EXPANSION_MODE="AIV"
+        export HCCL_TRANSFER_TIMEOUT=600
+        export HCCL_EXEC_TIMEOUT=3600
+        export HCCL_CONNECT_TIMEOUT=3600
 
         export HCCL_IF_IP=$local_ip
         export GLOO_SOCKET_IFNAME=$nic_name
@@ -739,45 +1245,38 @@ Before you start, please
         export OMP_PROC_BIND=false
         export OMP_NUM_THREADS=1
         export PYTORCH_NPU_ALLOC_CONF=expandable_segments:True
-        export HCCL_BUFFSIZE=256
+        export HCCL_BUFFSIZE=400
 
-        export ASCEND_AGGREGATE_ENABLE=1
-        export ASCEND_TRANSPORT_PRINT=1
         export ACL_OP_INIT_MODE=1
         export ASCEND_A3_ENABLE=1
-        # Timeout (in seconds) for automatically releasing the prefiller’s KV cache for a particular request.
-        export VLLM_MOONCAKE_ABORT_REQUEST_TIMEOUT=480
 
-        export ASCEND_RT_VISIBLE_DEVICES=$1
         export VLLM_ASCEND_ENABLE_FLASHCOMM1=1
-
         export VLLM_ASCEND_ENABLE_FUSED_MC2=1
         export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/local/lib
 
-        vllm serve /root/.cache/modelscope/hub/models/vllm-ascend/GLM5-w8a8 \
+        vllm serve /root/.cache/modelscope/hub/models/vllm-ascend/GLM-5.1-W8A8C8-MTP \
             --host 0.0.0.0 \
-            --port $2 \
-            --data-parallel-size $3 \
-            --data-parallel-rank $4 \
-            --data-parallel-address $5 \
-            --data-parallel-rpc-port $6 \
-            --tensor-parallel-size $7 \
+            --port 9081 \
+            --pipeline-parallel-size 2 \
+            --distributed-executor-backend mp \
+            --master-addr $local_ip \
+            --master-port 7060 \
+            --nnodes 2 \
+            --node-rank $node_rank \
+            --tensor-parallel-size 16 \
             --enable-expert-parallel \
-            --speculative-config '{"num_speculative_tokens": 1, "method":"deepseek_mtp", "enforce_eager": true}' \
-            --profiler-config \
-            '{"profiler": "torch",
-            "torch_profiler_dir": "./vllm_profile",
-            "torch_profiler_with_stack": false}' \
+            --speculative-config '{"num_speculative_tokens": 1, "method":"deepseek_mtp","enforce_eager":true}' \
             --seed 1024 \
             --served-model-name glm-5 \
-            --max-model-len 131072 \
-            --additional-config '{"enable_dsa_cp": true}' \
-            --max-num-batched-tokens 4096 \
+            --max-model-len 202752 \
+            --additional-config '{"fuse_muls_add":true, "recompute_scheduler_enable" : false, "multistream_overlap_shared_expert": true, "enable_dsa_cp":true, "enable_sparse_sfa_c8": true, "enable_sparse_li_c8": true, "c8_enable_reshape_optim":true}' \
+            --max-num-batched-tokens 16384 \
             --trust-remote-code \
+            --enable-prefix-caching \
             --max-num-seqs 64 \
-            --enable-chunked-prefill \
             --quantization ascend \
-            --gpu-memory-utilization 0.95 \
+            --gpu-memory-utilization 0.92 \
+            --hf-overrides '{"use_index_cache": true, "index_topk_freq": 4}' \
             --enforce-eager \
             --enable-auto-tool-choice \
             --tool-call-parser glm47 \
@@ -786,19 +1285,13 @@ Before you start, please
             '{"kv_connector": "MooncakeConnectorV1",
             "kv_role": "kv_producer",
             "kv_port": "30000",
+            "engine_id": "0",
             "kv_connector_extra_config": {
-                        "use_ascend_direct": true,
-                        "prefill": {
-                                "dp_size": 2,
-                                "tp_size": 16
-                        },
-                        "decode": {
-                                "dp_size": 16,
-                                "tp_size": 4
-                        }
-                }
-            }'
-
+                "use_ascend_direct": true,
+                "prefill": {"dp_size": 1, "pp_size": 2, "tp_size": 16, "pp_layer_partition": "41,37"},
+                "decode": {"dp_size": 8, "tp_size": 4}
+            }
+        }'
         ```
 
     2. Prefill node 1
@@ -806,8 +1299,17 @@ Before you start, please
         ```shell
         nic_name="xxxx" # change to your own nic name
         local_ip="xxxx" # change to your own ip
+        # IP of prefill node 0 (the PP master node), must be consistent with the local_ip of prefill node 0
+        node_p0_ip="xxxx"
+        # pp=2
+        export VLLM_PP_LAYER_PARTITION="41,37"
+        # prefill node 0: node_rank=0, prefill node 1: node_rank=1
+        node_rank=1
 
         export HCCL_OP_EXPANSION_MODE="AIV"
+        export HCCL_TRANSFER_TIMEOUT=600
+        export HCCL_EXEC_TIMEOUT=3600
+        export HCCL_CONNECT_TIMEOUT=3600
 
         export HCCL_IF_IP=$local_ip
         export GLOO_SOCKET_IFNAME=$nic_name
@@ -817,47 +1319,38 @@ Before you start, please
         export OMP_PROC_BIND=false
         export OMP_NUM_THREADS=1
         export PYTORCH_NPU_ALLOC_CONF=expandable_segments:True
-        export HCCL_BUFFSIZE=256
+        export HCCL_BUFFSIZE=400
 
-        export ASCEND_AGGREGATE_ENABLE=1
-        export ASCEND_TRANSPORT_PRINT=1
         export ACL_OP_INIT_MODE=1
         export ASCEND_A3_ENABLE=1
-        # Timeout (in seconds) for automatically releasing the prefiller’s KV cache for a particular request.
-        export VLLM_MOONCAKE_ABORT_REQUEST_TIMEOUT=480
-
-        export ASCEND_RT_VISIBLE_DEVICES=$1
-        export PYTORCH_NPU_ALLOC_CONF=expandable_segments:True
 
         export VLLM_ASCEND_ENABLE_FLASHCOMM1=1
-
         export VLLM_ASCEND_ENABLE_FUSED_MC2=1
         export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/local/lib
 
-        vllm serve /root/.cache/modelscope/hub/models/vllm-ascend/GLM5-w8a8 \
+        vllm serve /root/.cache/modelscope/hub/models/vllm-ascend/GLM-5.1-W8A8C8-MTP \
             --host 0.0.0.0 \
-            --port $2 \
-            --data-parallel-size $3 \
-            --data-parallel-rank $4 \
-            --data-parallel-address $5 \
-            --data-parallel-rpc-port $6 \
-            --tensor-parallel-size $7 \
+            --pipeline-parallel-size 2 \
+            --distributed-executor-backend mp \
+            --master-addr $node_p0_ip \
+            --master-port 7060 \
+            --nnodes 2 \
+            --node-rank $node_rank \
+            --headless \
+            --tensor-parallel-size 16 \
             --enable-expert-parallel \
-            --speculative-config '{"num_speculative_tokens": 1, "method":"deepseek_mtp", "enforce_eager": true}' \
-            --profiler-config \
-            '{"profiler": "torch",
-            "torch_profiler_dir": "./vllm_profile",
-            "torch_profiler_with_stack": false}' \
+            --speculative-config '{"num_speculative_tokens": 1, "method":"deepseek_mtp","enforce_eager":true}' \
             --seed 1024 \
             --served-model-name glm-5 \
-            --max-model-len 131072 \
-            --additional-config '{"enable_dsa_cp": true}' \
-            --max-num-batched-tokens 4096 \
+            --max-model-len 202752 \
+            --additional-config '{"fuse_muls_add":true, "recompute_scheduler_enable" : false, "multistream_overlap_shared_expert": true, "enable_dsa_cp":true, "enable_sparse_sfa_c8": true, "enable_sparse_li_c8": true, "c8_enable_reshape_optim":true}' \
+            --max-num-batched-tokens 16384 \
             --trust-remote-code \
+            --enable-prefix-caching \
             --max-num-seqs 64 \
-            --enable-chunked-prefill \
-            --gpu-memory-utilization 0.95 \
             --quantization ascend \
+            --gpu-memory-utilization 0.92 \
+            --hf-overrides '{"use_index_cache": true, "index_topk_freq": 4}' \
             --enforce-eager \
             --enable-auto-tool-choice \
             --tool-call-parser glm47 \
@@ -866,27 +1359,31 @@ Before you start, please
             '{"kv_connector": "MooncakeConnectorV1",
             "kv_role": "kv_producer",
             "kv_port": "30000",
+            "engine_id": "0",
             "kv_connector_extra_config": {
-                        "use_ascend_direct": true,
-                        "prefill": {
-                                "dp_size": 2,
-                                "tp_size": 16
-                        },
-                        "decode": {
-                                "dp_size": 16,
-                                "tp_size": 4
-                        }
-                }
-            }'
+                "use_ascend_direct": true,
+                "prefill": {"dp_size": 1, "pp_size": 2, "tp_size": 16, "pp_layer_partition": "41,37"},
+                "decode": {"dp_size": 8, "tp_size": 4}
+            }
+        }'
         ```
 
-    3. Decode node 0
+    3. Decode node 0 (ranks 0–3)
+
+        Launch one instance per DP rank via positional parameters: `$1` = visible devices, `$2` = engine port, `$3` = data-parallel-size, `$4` = data-parallel-rank, `$5` = data-parallel-address, `$6` = data-parallel-rpc-port, `$7` = tensor-parallel-size. Prepare `run_dp_template.sh` on decode node 0 with the content below.
 
         ```shell
         nic_name="xxxx" # change to your own nic name
         local_ip="xxxx" # change to your own ip
 
+        # Each DP rank uses an independent engine ID to avoid KV route confusion.
+        # $4 = data-parallel-rank. The rank offset within a node is 0 to 3, and the corresponding engine ID is 100 to 103.
+        ENGINE_ID=$((100 + $4))
+
         export HCCL_OP_EXPANSION_MODE="AIV"
+        export HCCL_TRANSFER_TIMEOUT=600
+        export HCCL_EXEC_TIMEOUT=3600
+        export HCCL_CONNECT_TIMEOUT=3600
 
         export HCCL_IF_IP=$local_ip
         export GLOO_SOCKET_IFNAME=$nic_name
@@ -900,23 +1397,16 @@ Before you start, please
         export PYTORCH_NPU_ALLOC_CONF=expandable_segments:True
         export HCCL_BUFFSIZE=256
 
-
-        export ASCEND_AGGREGATE_ENABLE=1
-        export ASCEND_TRANSPORT_PRINT=1
         export ACL_OP_INIT_MODE=1
         export ASCEND_A3_ENABLE=1
-        # Timeout (in seconds) for automatically releasing the prefiller’s KV cache for a particular request.
-        export VLLM_MOONCAKE_ABORT_REQUEST_TIMEOUT=480
-
         export TASK_QUEUE_ENABLE=1
-
         export ASCEND_RT_VISIBLE_DEVICES=$1
 
         export VLLM_ASCEND_ENABLE_FUSED_MC2=1
         export VLLM_ASCEND_ENABLE_MLAPO=1
         export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/local/lib
 
-        vllm serve /root/.cache/modelscope/hub/models/vllm-ascend/GLM5-w8a8 \
+        vllm serve /root/.cache/modelscope/hub/models/vllm-ascend/GLM-5.1-W8A8C8-MTP \
             --host 0.0.0.0 \
             --port $2 \
             --data-parallel-size $3 \
@@ -925,20 +1415,18 @@ Before you start, please
             --data-parallel-rpc-port $6 \
             --tensor-parallel-size $7 \
             --enable-expert-parallel \
-            --speculative-config '{"num_speculative_tokens": 3,  "method":"deepseek_mtp", "enforce_eager": true}' \
-            --profiler-config \
-            '{"profiler": "torch",
-            "torch_profiler_dir": "./vllm_profile",
-            "torch_profiler_with_stack": false}' \
+            --speculative-config '{"num_speculative_tokens": 3,  "method":"deepseek_mtp","enforce_eager":true}' \
             --seed 1024 \
             --served-model-name glm-5 \
-            --max-model-len 200000 \
-            --max-num-batched-tokens 32 \
+            --max-model-len 202752 \
+            --max-num-batched-tokens 164 \
             --compilation-config '{"cudagraph_mode":"FULL_DECODE_ONLY"}' \
-            --additional-config '{"recompute_scheduler_enable": true}' \
+            --additional-config '{"fuse_muls_add":true, "recompute_scheduler_enable":true, "multistream_overlap_shared_expert":true, "enable_sparse_sfa_c8": true, "enable_sparse_li_c8": true}' \
             --trust-remote-code \
-            --max-num-seqs 8 \
+            --max-num-seqs 32 \
             --gpu-memory-utilization 0.92 \
+            --hf-overrides '{"use_index_cache": true, "index_topk_freq": 4}' \
+            --async-scheduling \
             --quantization ascend \
             --enable-auto-tool-choice \
             --tool-call-parser glm47 \
@@ -946,304 +1434,124 @@ Before you start, please
             --kv-transfer-config \
             '{"kv_connector": "MooncakeConnectorV1",
             "kv_role": "kv_consumer",
-            "kv_port": "30100",
+            "kv_port": "30200",
+            "engine_id": "'"$ENGINE_ID"'",
             "kv_connector_extra_config": {
-                        "use_ascend_direct": true,
-                        "prefill": {
-                                "dp_size": 2,
-                                "tp_size": 16
-                        },
-                        "decode": {
-                                "dp_size": 16,
-                                "tp_size": 4
-                        }
-                }
-            }'
+                "use_ascend_direct": true,
+                "prefill": {"dp_size": 1, "pp_size": 2, "tp_size": 16, "pp_layer_partition": "41,37"},
+                "decode": {"dp_size": 8, "tp_size": 4}
+            }
+        }'
         ```
 
-    4. Decode node 1
+    4. Decode node 1 (ranks 4–7)
 
-         ```shell
-         nic_name="xxxx" # change to your own nic name
-         local_ip="xxxx" # change to your own ip
+        Prepare `run_dp_template.sh` on decode node 1 with the content below.
 
-         export HCCL_OP_EXPANSION_MODE="AIV"
+        ```shell
+        nic_name="xxxx" # change to your own nic name
+        local_ip="xxxx" # change to your own ip
 
-         export HCCL_IF_IP=$local_ip
-         export GLOO_SOCKET_IFNAME=$nic_name
-         export TP_SOCKET_IFNAME=$nic_name
-         export HCCL_SOCKET_IFNAME=$nic_name
+        # Each DP rank uses an independent engine ID to avoid KV route confusion.
+        # $4 = data-parallel-rank. The rank offset within a node is 0 to 3, and the corresponding engine ID is 100 to 103.
+        ENGINE_ID=$((100 + $4))
 
-         #Mooncake
-         export OMP_PROC_BIND=false
-         export OMP_NUM_THREADS=1
+        export HCCL_OP_EXPANSION_MODE="AIV"
+        export HCCL_TRANSFER_TIMEOUT=600
+        export HCCL_EXEC_TIMEOUT=3600
+        export HCCL_CONNECT_TIMEOUT=3600
 
-         export PYTORCH_NPU_ALLOC_CONF=expandable_segments:True
-         export HCCL_BUFFSIZE=256
+        export HCCL_IF_IP=$local_ip
+        export GLOO_SOCKET_IFNAME=$nic_name
+        export TP_SOCKET_IFNAME=$nic_name
+        export HCCL_SOCKET_IFNAME=$nic_name
 
-         export ASCEND_AGGREGATE_ENABLE=1
-         export ASCEND_TRANSPORT_PRINT=1
-         export ACL_OP_INIT_MODE=1
-         export ASCEND_A3_ENABLE=1
-         # Timeout (in seconds) for automatically releasing the prefiller’s KV cache for a particular request.
-         export VLLM_MOONCAKE_ABORT_REQUEST_TIMEOUT=480
+        #Mooncake
+        export OMP_PROC_BIND=false
+        export OMP_NUM_THREADS=1
 
-         export TASK_QUEUE_ENABLE=1
+        export PYTORCH_NPU_ALLOC_CONF=expandable_segments:True
+        export HCCL_BUFFSIZE=256
 
-         export ASCEND_RT_VISIBLE_DEVICES=$1
+        export ACL_OP_INIT_MODE=1
+        export ASCEND_A3_ENABLE=1
+        export TASK_QUEUE_ENABLE=1
+        export ASCEND_RT_VISIBLE_DEVICES=$1
 
-         export VLLM_ASCEND_ENABLE_FUSED_MC2=1
-         export VLLM_ASCEND_ENABLE_MLAPO=1
-         export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/local/lib
+        export VLLM_ASCEND_ENABLE_FUSED_MC2=1
+        export VLLM_ASCEND_ENABLE_MLAPO=1
+        export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/local/lib
 
-         vllm serve /root/.cache/modelscope/hub/models/vllm-ascend/GLM5-w8a8 \
-             --host 0.0.0.0 \
-             --port $2 \
-             --data-parallel-size $3 \
-             --data-parallel-rank $4 \
-             --data-parallel-address $5 \
-             --data-parallel-rpc-port $6 \
-             --tensor-parallel-size $7 \
-             --enable-expert-parallel \
-             --speculative-config '{"num_speculative_tokens": 3,  "method":"deepseek_mtp", "enforce_eager": true}' \
-             --profiler-config \
-             '{"profiler": "torch",
-             "torch_profiler_dir": "./vllm_profile",
-             "torch_profiler_with_stack": false}' \
-             --seed 1024 \
-             --served-model-name glm-5 \
-             --max-model-len 200000 \
-             --max-num-batched-tokens 32 \
-             --compilation-config '{"cudagraph_mode":"FULL_DECODE_ONLY"}' \
-             --additional-config '{"recompute_scheduler_enable": true}' \
-             --trust-remote-code \
-             --max-num-seqs 8 \
-             --gpu-memory-utilization 0.92 \
-             --quantization ascend \
-             --enable-auto-tool-choice \
-             --tool-call-parser glm47 \
-             --reasoning-parser glm45 \
-             --kv-transfer-config \
-             '{"kv_connector": "MooncakeConnectorV1",
-             "kv_role": "kv_consumer",
-             "kv_port": "30100",
-             "kv_connector_extra_config": {
-                         "use_ascend_direct": true,
-                         "prefill": {
-                                 "dp_size": 2,
-                                 "tp_size": 16
-                         },
-                         "decode": {
-                                 "dp_size": 16,
-                                 "tp_size": 4
-                         }
-                 }
-             }'
-         ```
-
-    5. Decode node 2
-
-         ```shell
-         nic_name="xxxx" # change to your own nic name
-         local_ip="xxxx" # change to your own ip
-
-         export HCCL_OP_EXPANSION_MODE="AIV"
-
-         export HCCL_IF_IP=$local_ip
-         export GLOO_SOCKET_IFNAME=$nic_name
-         export TP_SOCKET_IFNAME=$nic_name
-         export HCCL_SOCKET_IFNAME=$nic_name
-
-         #Mooncake
-         export OMP_PROC_BIND=false
-         export OMP_NUM_THREADS=1
-
-         export PYTORCH_NPU_ALLOC_CONF=expandable_segments:True
-         export HCCL_BUFFSIZE=256
-
-         export ASCEND_AGGREGATE_ENABLE=1
-         export ASCEND_TRANSPORT_PRINT=1
-         export ACL_OP_INIT_MODE=1
-         export ASCEND_A3_ENABLE=1
-         # Timeout (in seconds) for automatically releasing the prefiller’s KV cache for a particular request.
-         export VLLM_MOONCAKE_ABORT_REQUEST_TIMEOUT=480
-
-         export TASK_QUEUE_ENABLE=1
-
-         export ASCEND_RT_VISIBLE_DEVICES=$1
-
-         export VLLM_ASCEND_ENABLE_FUSED_MC2=1
-         export VLLM_ASCEND_ENABLE_MLAPO=1
-         export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/local/lib
-
-         vllm serve /root/.cache/modelscope/hub/models/vllm-ascend/GLM5-w8a8 \
-             --host 0.0.0.0 \
-             --port $2 \
-             --data-parallel-size $3 \
-             --data-parallel-rank $4 \
-             --data-parallel-address $5 \
-             --data-parallel-rpc-port $6 \
-             --tensor-parallel-size $7 \
-             --enable-expert-parallel \
-             --speculative-config '{"num_speculative_tokens": 3,  "method":"deepseek_mtp", "enforce_eager": true}' \
-             --profiler-config \
-             '{"profiler": "torch",
-             "torch_profiler_dir": "./vllm_profile",
-             "torch_profiler_with_stack": false}' \
-             --seed 1024 \
-             --served-model-name glm-5 \
-             --max-model-len 200000 \
-             --max-num-batched-tokens 32 \
-             --compilation-config '{"cudagraph_mode":"FULL_DECODE_ONLY"}' \
-             --additional-config '{"recompute_scheduler_enable": true}' \
-             --trust-remote-code \
-             --max-num-seqs 8 \
-             --gpu-memory-utilization 0.92 \
-             --quantization ascend \
-             --enable-auto-tool-choice \
-             --tool-call-parser glm47 \
-             --reasoning-parser glm45 \
-             --kv-transfer-config \
-             '{"kv_connector": "MooncakeConnectorV1",
-             "kv_role": "kv_consumer",
-             "kv_port": "30100",
-             "kv_connector_extra_config": {
-                         "use_ascend_direct": true,
-                         "prefill": {
-                                 "dp_size": 2,
-                                 "tp_size": 16
-                         },
-                         "decode": {
-                                 "dp_size": 16,
-                                 "tp_size": 4
-                         }
-                 }
-             }'
-         ```
-
-    6. Decode node 3
-
-         ```shell
-         nic_name="xxxx" # change to your own nic name
-         local_ip="xxxx" # change to your own ip
-
-         export HCCL_OP_EXPANSION_MODE="AIV"
-
-         export HCCL_IF_IP=$local_ip
-         export GLOO_SOCKET_IFNAME=$nic_name
-         export TP_SOCKET_IFNAME=$nic_name
-         export HCCL_SOCKET_IFNAME=$nic_name
-
-         #Mooncake
-         export OMP_PROC_BIND=false
-         export OMP_NUM_THREADS=1
-
-         export PYTORCH_NPU_ALLOC_CONF=expandable_segments:True
-         export HCCL_BUFFSIZE=256
-
-         export ASCEND_AGGREGATE_ENABLE=1
-         export ASCEND_TRANSPORT_PRINT=1
-         export ACL_OP_INIT_MODE=1
-         export ASCEND_A3_ENABLE=1
-         # Timeout (in seconds) for automatically releasing the prefiller’s KV cache for a particular request.
-         export VLLM_MOONCAKE_ABORT_REQUEST_TIMEOUT=480
-
-         export TASK_QUEUE_ENABLE=1
-
-         export ASCEND_RT_VISIBLE_DEVICES=$1
-
-         export VLLM_ASCEND_ENABLE_FUSED_MC2=1
-         export VLLM_ASCEND_ENABLE_MLAPO=1
-         export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/local/lib
-
-         vllm serve /root/.cache/modelscope/hub/models/vllm-ascend/GLM5-w8a8 \
-             --host 0.0.0.0 \
-             --port $2 \
-             --data-parallel-size $3 \
-             --data-parallel-rank $4 \
-             --data-parallel-address $5 \
-             --data-parallel-rpc-port $6 \
-             --tensor-parallel-size $7 \
-             --enable-expert-parallel \
-             --speculative-config '{"num_speculative_tokens": 3,  "method":"deepseek_mtp", "enforce_eager": true}' \
-             --profiler-config \
-             '{"profiler": "torch",
-             "torch_profiler_dir": "./vllm_profile",
-             "torch_profiler_with_stack": false}' \
-             --seed 1024 \
-             --served-model-name glm-5 \
-             --max-model-len 200000 \
-             --max-num-batched-tokens 32 \
-             --compilation-config '{"cudagraph_mode":"FULL_DECODE_ONLY"}' \
-             --additional-config '{"recompute_scheduler_enable": true}' \
-             --trust-remote-code \
-             --max-num-seqs 8 \
-             --gpu-memory-utilization 0.92 \
-             --quantization ascend \
-             --enable-auto-tool-choice \
-             --tool-call-parser glm47 \
-             --reasoning-parser glm45 \
-             --kv-transfer-config \
-             '{"kv_connector": "MooncakeConnectorV1",
-             "kv_role": "kv_consumer",
-             "kv_port": "30100",
-             "kv_connector_extra_config": {
-                         "use_ascend_direct": true,
-                         "prefill": {
-                                 "dp_size": 2,
-                                 "tp_size": 16
-                         },
-                         "decode": {
-                                 "dp_size": 16,
-                                 "tp_size": 4
-                         }
-                 }
-             }'
-         ```
+        vllm serve /root/.cache/modelscope/hub/models/vllm-ascend/GLM-5.1-W8A8C8-MTP \
+            --host 0.0.0.0 \
+            --port $2 \
+            --data-parallel-size $3 \
+            --data-parallel-rank $4 \
+            --data-parallel-address $5 \
+            --data-parallel-rpc-port $6 \
+            --tensor-parallel-size $7 \
+            --enable-expert-parallel \
+            --speculative-config '{"num_speculative_tokens": 3,  "method":"deepseek_mtp","enforce_eager":true}' \
+            --seed 1024 \
+            --served-model-name glm-5 \
+            --max-model-len 202752 \
+            --max-num-batched-tokens 164 \
+            --compilation-config '{"cudagraph_mode":"FULL_DECODE_ONLY"}' \
+            --additional-config '{"fuse_muls_add":true, "recompute_scheduler_enable":true, "multistream_overlap_shared_expert":true, "enable_sparse_sfa_c8": true, "enable_sparse_li_c8": true}' \
+            --trust-remote-code \
+            --max-num-seqs 32 \
+            --gpu-memory-utilization 0.92 \
+            --hf-overrides '{"use_index_cache": true, "index_topk_freq": 4}' \
+            --async-scheduling \
+            --quantization ascend \
+            --enable-auto-tool-choice \
+            --tool-call-parser glm47 \
+            --reasoning-parser glm45 \
+            --kv-transfer-config \
+            '{"kv_connector": "MooncakeConnectorV1",
+            "kv_role": "kv_consumer",
+            "kv_port": "30200",
+            "engine_id": "'"$ENGINE_ID"'",
+            "kv_connector_extra_config": {
+                "use_ascend_direct": true,
+                "prefill": {"dp_size": 1, "pp_size": 2, "tp_size": 16, "pp_layer_partition": "41,37"},
+                "decode": {"dp_size": 8, "tp_size": 4}
+            }
+        }'
+        ```
 
 Once the preparation is done, you can start the server with the following command on each node:
 
 1. Prefill node 0
 
     ```shell
-    # change ip to your own
-    python launch_online_dp.py --dp-size 2 --tp-size 16 --dp-size-local 1 --dp-rank-start 0 --dp-address $node_p0_ip --dp-rpc-port 10521 --vllm-start-port 6700
+    bash run_dp_template.sh
     ```
 
 2. Prefill node 1
 
     ```shell
-    # change ip to your own
-    python launch_online_dp.py --dp-size 2 --tp-size 16 --dp-size-local 1 --dp-rank-start 1 --dp-address $node_p0_ip --dp-rpc-port 10521 --vllm-start-port 6700
+    bash run_dp_template.sh
     ```
 
 3. Decode node 0
 
     ```shell
     # change ip to your own
-    python launch_online_dp.py --dp-size 16 --tp-size 4 --dp-size-local 4 --dp-rank-start 0 --dp-address $node_d0_ip --dp-rpc-port 10523 --vllm-start-port 6721
+    python launch_online_dp.py --dp-size 8 --tp-size 4 --pp-size 1 --dp-size-local 4 --dp-rank-start 0 --dp-address $node_d0_ip --dp-rpc-port 12321 --vllm-start-port 8000
     ```
 
 4. Decode node 1
 
     ```shell
     # change ip to your own
-    python launch_online_dp.py --dp-size 16 --tp-size 4 --dp-size-local 4 --dp-rank-start 4 --dp-address $node_d0_ip --dp-rpc-port 10523 --vllm-start-port 6721
+    python launch_online_dp.py --dp-size 8 --tp-size 4 --pp-size 1 --dp-size-local 4 --dp-rank-start 4 --dp-address $node_d0_ip --dp-rpc-port 12321 --vllm-start-port 8000
     ```
 
-5. Decode node 2
+**Notice:**
 
-    ```shell
-    # change ip to your own
-    python launch_online_dp.py --dp-size 16 --tp-size 4 --dp-size-local 4 --dp-rank-start 8 --dp-address $node_d0_ip --dp-rpc-port 10523 --vllm-start-port 6721
-    ```
-
-6. Decode node 3
-
-    ```shell
-    # change ip to your own
-    python launch_online_dp.py --dp-size 16 --tp-size 4 --dp-size-local 4 --dp-rank-start 12 --dp-address $node_d0_ip --dp-rpc-port 10523 --vllm-start-port 6721
-    ```
+- When testing with a prefix cache hit rate > 0, add `--enable-prefix-caching` on the prefill nodes (as in the scripts above); when the hit rate is 0, use `--no-enable-prefix-caching` instead.
+- `"recompute_scheduler_enable"` is set to `false` on prefill nodes and `true` on decode nodes in this scenario.
 
 ### 5.4 Request Forwarding
 
@@ -1339,23 +1647,71 @@ Refer to [vllm benchmark](https://docs.vllm.ai/en/latest/benchmarking/) for more
 
 ### 9.1 Recommended Configurations
 
-> **Note**: The following configurations are validated in specific test environments and are for reference only. The optimal configuration depends on factors such as maximum input/output length, prefix cache hit rate, precision requirements, and deployment machine ratios. It is recommended to refer to Section 9.2 for tuning based on actual conditions.
+> **Note**: The following configurations are validated in specific test environments and are for reference only. The optimal configuration depends on factors such as maximum input/output length, prefix cache hit rate, precision requirements, and deployment machine ratios. It is recommended to refer to [Tuning Guidelines](#92-tuning-guidelines) for tuning based on actual conditions.
 
-#### Table 1: Scenario Overview
+The tables below provide recommended parameter configurations for the `GLM-5.1-w8a8c8` quantized model on Atlas 800 A3, covering three deployment scenarios:
 
-|Scenario|Deployment Mode|Total NPUs|Weight Version|Key Considerations|
-|--------|---------------|-----------|---------------|-------------------|
-|High Throughput|1P1D deployment|32 (A3)|GLM5-w8a8/GLM5.1-w8a8|dp4 tp8 on P nodes and dp8 dp4 on D nodes to balanced latency and throughput|
-|Low Latency|1P1D deployment|32 (A3)|GLM5-w8a8/GLM5.1-w8a8|dp4 tp8 on both P and D nodes to reduce latency|
+- **Dual-Node Co-Located 198K High Throughput**: `DP8 TP4`, see [Multi-node Deployment](#52-multi-node-deployment).
+- **Dual-Node Co-Located 198K Low Latency**: `DP2 TP16`, see [Multi-node Deployment](#52-multi-node-deployment).
+- **Prefill-Decode Disaggregation 198K (PP2)**: prefill `PP2 TP16` + decode `DP8 TP4`, see [Prefill-Decode Disaggregation (A3 series)](#532-prefill-decode-disaggregation-a3-series).
+- **Prefill-Decode Disaggregation 198K (Ascend950DT)**: prefill `TP8` (DSA CP 8) + decode `DP16 TP1`, see [Prefill-Decode Disaggregation (Ascend950DT series)](#531-prefill-decode-disaggregation-ascend950dt-series).
 
-> `*Total NPUs` indicates the total number of NPUs used across all nodes.
+Test cases use the notation `input/output`, e.g., `128k/1k` means 128K input tokens and 1K output tokens; `@50%/90%` marks the prefix cache hit rate. When the prefix cache hit rate is > 0, add `--enable-prefix-caching`; when the hit rate is 0, add `--no-enable-prefix-caching` instead (for the PD scenario, this applies to the prefill nodes).
 
-#### Table 2: Detailed Node Configuration
+#### 9.1.1 Table 1: Detailed Node Configuration
 
-|Scenario|Configuration|NPUs|TP|DP|Max Num Seqs|Max Num Batched Tokens|Max Model Len|MTP Speculation Num|
-|--------|-------------|-----|--|--|------------|----------------------|--------------|--------------------|
-|High Throughput (A3)|1P1D deployment|32|P:8 D:4|P:4 D:8|P:64 D:128|P:4096 D:32|P:133120 D:150000|3|
-|Low Latency (A3)|1P1D deployment|32|4|8|P:64 D:128|P:4096 D:32|P:133120 D:150000|3|
+> The TP/DP columns show the values **per node** as configured in the Deployment scripts (a co-located node hosting 4 DP ranks of TP4 uses 16 NPUs; a PD prefill node hosting 1 DP rank of TP16 uses 16 NPUs; a PD decode node hosting 4 DP ranks of TP4 uses 16 NPUs; an Ascend950DT node hosting 8 cards). The 198K PD scenario prefill side uses `PP2 TP16` with the layer partition `41,37`. All A3 scenarios use the `GLM-5.1-w8a8c8` weights; the Ascend950DT scenarios use the `GLM-5.1-w4a4` weights.
+>
+> When testing with a prefix cache hit rate > 0, keep `--enable-prefix-caching` (as in the deployment scripts); when the hit rate is 0, replace it with `--no-enable-prefix-caching`.
+
+|Scenario|Weight Version|Configuration|NPUs|TP|DP|Max Num Seqs|Max Num Batched Tokens|Max Model Len|MTP Spec Num|
+|--------|--------------|-------------|-----|--|--|------------|----------------------|--------------|-------------|
+|Dual-Node Co-Located 198K High Throughput (A3)|w8a8c8|Dual-Node Co-Located Node (0/1)|16|4|4|6|4096|202752|3|
+|Dual-Node Co-Located 198K Low Latency (A3)|w8a8c8|Dual-Node Co-Located Node (0/1)|16|16|1|16|4096|202752|3|
+|PD 198K High Throughput (A3)|w8a8c8|PD — Server-P Node (PP2)|16|16|1|64|16384|202752|1|
+|PD 198K High Throughput (A3)|w8a8c8|PD — Server-D Node|16|4|4|32|164|202752|3|
+|PD 198K High Throughput (Ascend950DT)|w4a4|PD — Server-P Node (DSA CP 8)|8|8|1|20|8192|202752|1|
+|PD 198K High Throughput (Ascend950DT)|w4a4|PD — Server-D Node|8|1|8|60|240|202752|3|
+|PD 198K Low Latency (Ascend950DT)|w4a4|PD — Server-P Node (DSA CP 8)|8|8|1|20|8192|202752|1|
+|PD 198K Low Latency (Ascend950DT)|w4a4|PD — Server-D Node|8|1|8|60|240|202752|3|
+
+#### 9.1.2 Table 2: Optimizations Requiring Explicit Enablement
+
+The following optimizations must be explicitly enabled to take effect. They apply to the A3 series (w8a8c8) as indicated:
+
+|Optimization|Scenario|Enablement|Principle (Benefits)|Notes|
+|------------|--------|----------|---------------------|-----|
+|FlashComm_v1|A3 prefill nodes / co-located nodes|`export VLLM_ASCEND_ENABLE_FLASHCOMM1=1`|Splits AllReduce into Reduce-Scatter and All-Gather, improving prefill throughput and reducing communication latency|Not available when `layer_sharding` includes `o_proj`|
+|Fused MC2|A3 prefill nodes|`export VLLM_ASCEND_ENABLE_FUSED_MC2=1`|Replaces ALLTOALL+MC2 with the `dispatch_ffn_combine`/`dispatch_gmm_combine_decode` operators, reducing MoE communication overhead and improving MoE inference performance|`dispatch_ffn_combine` only for w8a8, EP≤32, non-MTP, non-dynamic-EPLB; conflicts with `multistream_overlap_shared_expert` (the latter is auto-disabled)|
+|MLAPO|A3 co-located high-throughput / PD decode nodes|`export VLLM_ASCEND_ENABLE_MLAPO=1`|Fuses the MLA preprocess operations, significantly improving decode performance|Consumes more NPU memory; in PD scenarios enable on decode nodes only|
+|DSA CP|A3 prefill nodes; long context (≥128K)|`--additional-config '{"enable_dsa_cp": true}'`|DSA context parallelism accelerates long-context prefill, reducing TTFT for long prompts|In the reference configs, enabled on co-located nodes and PD prefill nodes|
+|Balance Scheduling|A3 single-node / co-located / non-PD scenarios|`--additional-config '{"enable_balance_scheduling": true}'`|Improves output throughput and reduces TPOT in the v1 scheduler|TTFT may degrade; not recommended when Prefill-Decode is separated|
+|Sparse SFA C8|A3 (w8a8c8); long-context prefill|`--additional-config '{"enable_sparse_sfa_c8": true}'`|Sparse Flash Attention skips unnecessary attention computation of the C8 quantized model, accelerating long-context prefill|Experimental in v0.23.0. In the reference configs, enabled in the high-throughput and PD scenarios; disabled in the low-latency scenario|
+|Sparse LI C8|A3 (w8a8c8)|`--additional-config '{"enable_sparse_li_c8": true}'`|Sparse attention optimization reduces computation of the C8 quantized model, improving throughput|Independent of `enable_sparse_sfa_c8`; the reference low-latency config disables both|
+|Recompute Scheduler|A3 decode nodes|`--additional-config '{"recompute_scheduler_enable": true}'`|Recomputes KV cache on prefill nodes when decode KV cache is insufficient, avoiding decode-side OOM and improving throughput|Set to `false` on prefill nodes|
+|Multistream Overlap Shared Expert|A3|`--additional-config '{"multistream_overlap_shared_expert": true}'`|Overlaps shared-expert computation on an additional stream, hiding its latency and improving decode performance|Auto-disabled when `VLLM_ASCEND_ENABLE_FUSED_MC2=1`|
+
+> For complete startup commands and detailed parameter descriptions, please refer to the deployment examples and Key Parameter Descriptions in [Online Service Deployment](#5-online-service-deployment).
+
+#### 9.1.3 Table 3: Performance-Related Parameter Tuning Guide
+
+|Parameter|Low Latency|High Throughput|Long Context|Description|
+|---------|-----------|---------------|-------------|-----------|
+|`--max-num-seqs`|Lower (16)|Higher (6–64)|Higher (32–64)|Limits concurrent sequences. Lower values reduce scheduling latency; higher values increase throughput.|
+|`--max-model-len`|198K|Longer (128K–198K)|Maximum (198K)|Maximum context length. Must accommodate your longest input+output. Larger values consume more KV cache memory.|
+|`--max-num-batched-tokens`|Lower (4096)|Higher for prefill (4096–16384)|Higher for prefill (16384); small on decode nodes (close to `max-num-seqs`)|Controls batch size per step. Lower values reduce per-step latency; higher values improve prefill throughput.|
+|`--gpu-memory-utilization`|0.92|0.92|0.92|NPU memory fraction. The reference configs in this document use 0.92. Reduce if OOM.|
+|`--enable-chunked-prefill`|Enable (co-located)|Enable (co-located)|Enable (co-located)|Splits long prompts into chunks to prevent prefill from blocking decode. PD prefill nodes use `--enforce-eager` instead.|
+|`num_speculative_tokens` (MTP)|3|3|3 (decode)|MTP speculation count. Higher values improve decode throughput at the cost of memory for the draft model KV cache. In the reference PD configs, prefill nodes use `1` in both scenarios; decode nodes use `3` in both scenarios.|
+|`cudagraph_mode`|FULL_DECODE_ONLY|FULL_DECODE_ONLY (co-located / decode nodes)|FULL_DECODE_ONLY (co-located / decode nodes)|Graph capture for the decode phase only. PD prefill nodes use `--enforce-eager` instead.|
+
+### 9.2 Tuning Guidelines
+
+For general performance tuning methods, refer to the [Public Performance Tuning Documentation](../../developer_guide/performance_and_debug/optimization_and_tuning.md).
+
+For detailed feature descriptions and configuration options, refer to the [Feature Guide](../../user_guide/support_matrix/feature_matrix.md).
+
+For environment variable descriptions and constraints, refer to [envs.py](https://github.com/vllm-project/vllm-ascend/blob/main/vllm_ascend/envs.py).
 
 ## 10 FAQ
 


### PR DESCRIPTION
  ---
  Title: [Doc] Sync GLM-5 tutorial deployment guidance

  Body:

  Update the GLM-5 tutorial with the latest deployment guidance:

  - Point the weight list at the verified GLM-5.1-w8a8c8 (Atlas 800 A3) and GLM-5.1-w4a4 (Ascend950DT) weights and drop
  the BF16 entries.
  - Add Ascend950DT single-node (w4a4) and Prefill-Decode Disaggregation (PD) deployment scripts; restructure the A3 PD
  section into a PP2 TP16 (41/37) prefill + DP8 TP4 decode layout.
  - Add multi-node key parameter descriptions, prefix-cache hit rate and fused-MC2 notices, and rewrite the performance   tuning section (9.1 Recommended Configurations / 9.2 Tuning Guidelines).                                                - Use num_speculative_tokens=1 on PD prefill nodes (MTP=3 on decode and co-located engines only) and align the tuning
  tables.

  ### What this PR does / why we need it?
  Documentation-only update of `docs/source/tutorials/models/GLM5.md` on the
  v0.26.0rc release branch. The tutorial still described the earlier
  BF16/w8a8-based deployments, while the validated production guidance has
  moved to the GLM-5.1-w8a8c8 (Atlas 800 A3) and GLM-5.1-w4a4                                                             (Ascend950DT) quantized weights. This PR aligns the deployment scripts                                                  (single-node, dual-node co-located, Prefill-Decode Disaggregation),                                                     parameter descriptions and performance tables with that guidance, and                                                   corrects the MTP configuration on PD prefill nodes                                                                      (`num_speculative_tokens=1`).

  ### Does this PR introduce _any_ user-facing change?
  No. Documentation-only change.

  ### How was this patch tested?
  - Ran `markdownlint --config .markdownlint.yaml docs/source/tutorials/models/GLM5.md` locally — clean.
  - The docs build / link check runs in CI on this PR (the file only uses
    links that exist on the `releases/v0.26.0rc` branch).                                                               
  ---
- vLLM main: https://github.com/vllm-project/vllm/commit/d02df748bf9efd99022f1a062597dc3cb3808485
