### PR TITLE
[BugFix][AscendStore] Fix DSV4 Phase-1 offload KV events for conductor

### DIFF
--- a/tests/ut/distributed/ascend_store/_mock_deps.py
+++ b/tests/ut/distributed/ascend_store/_mock_deps.py
@@ -125,19 +125,64 @@ _events_mod.KVConnectorKVEvents = type("KVConnectorKVEvents", (), {})  # type: i
 
 
 class _FakeAggregator:
-    def __init__(self, *args, **kwargs):
-        self._mock = MagicMock()
+    """Minimal Counter-based stand-in for KVEventAggregator."""
 
-    def __getattr__(self, name):
-        return getattr(self._mock, name)
+    def __init__(self, num_workers: int = 1, *args, **kwargs):
+        from collections import Counter
+
+        self._event_counter: Counter = Counter()
+        self._num_workers = max(int(num_workers) if num_workers else 1, 1)
+
+    def add_events(self, events):
+        self._event_counter.update(events)
+
+    def get_common_events(self):
+        return [event for event, count in self._event_counter.items() if count == self._num_workers]
+
+    def get_all_events(self):
+        return list(self._event_counter.elements())
+
+    def clear_events(self):
+        self._event_counter.clear()
+
+    def increment_workers(self, count: int = 1):
+        self._num_workers += count
+
+    def reset_workers(self):
+        self._num_workers = 1
+
+    def get_number_of_workers(self):
+        return self._num_workers
 
 
 _events_mod.KVEventAggregator = _FakeAggregator  # type: ignore[attr-defined]
-_events_mod.BlockStored = type(  # type: ignore[attr-defined]
-    "BlockStored",
-    (),
-    {"__init__": lambda self, **kwargs: self.__dict__.update(kwargs)},
-)
+
+
+class _FakeBlockStored:
+    def __init__(self, **kwargs):
+        self.__dict__.update(kwargs)
+
+    def __hash__(self):
+        return hash(
+            (
+                tuple(getattr(self, "block_hashes", ()) or ()),
+                getattr(self, "parent_block_hash", None),
+                tuple(getattr(self, "token_ids", ()) or ()),
+                getattr(self, "block_size", None),
+                getattr(self, "lora_id", None),
+                getattr(self, "medium", None),
+                getattr(self, "group_idx", None),
+                getattr(self, "kv_cache_spec_kind", None),
+            )
+        )
+
+    def __eq__(self, other):
+        if not isinstance(other, _FakeBlockStored):
+            return NotImplemented
+        return self.__dict__ == other.__dict__
+
+
+_events_mod.BlockStored = _FakeBlockStored  # type: ignore[attr-defined]
 
 _kv_cache_utils_mod: Any = sys.modules["vllm.v1.core.kv_cache_utils"] if _MOCK_VLLM_DEPS else types.SimpleNamespace()
 _kv_cache_utils_mod.BlockHash = bytes  # type: ignore[attr-defined]

--- a/tests/ut/distributed/ascend_store/test_ascend_store_connector.py
+++ b/tests/ut/distributed/ascend_store/test_ascend_store_connector.py
@@ -21,7 +21,7 @@ from unittest.mock import MagicMock, patch
 
 # isort: off
 import tests.ut.distributed.ascend_store._mock_deps  # noqa: F401, E402
-from vllm.distributed.kv_events import KVCacheEvent
+from vllm.distributed.kv_events import KVCacheEvent, BlockStored
 from vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.ascend_store_connector import (
     AscendStoreConnector,
     AscendStoreKVEvents,
@@ -49,14 +49,63 @@ class TestAscendStoreKVEvents(unittest.TestCase):
         self.assertEqual(result, mock_events)
 
     def test_aggregate(self):
+        # Union semantics: aggregate keeps unique events from get_all_events,
+        # not the intersection from get_common_events.
         ev = self._make_events()
-        common = [MagicMock()]
-        ev._aggregator.get_common_events.return_value = common
+        unique = [MagicMock(), MagicMock()]
+        ev._aggregator.get_all_events.return_value = unique
         result = ev.aggregate()
         self.assertIs(result, ev)
         ev._aggregator.clear_events.assert_called()
-        ev._aggregator.add_events.assert_called_with(common)
+        ev._aggregator.add_events.assert_called_with(unique)
         ev._aggregator.reset_workers.assert_called()
+        ev._aggregator.get_common_events.assert_not_called()
+
+    def test_aggregate_union_across_workers(self):
+        """MLA put_step shards events: each worker emits a disjoint subset."""
+        ev = AscendStoreKVEvents(num_workers=1)
+
+        def _evt(h):
+            return BlockStored(
+                block_hashes=[h],
+                parent_block_hash=None,
+                token_ids=[1],
+                block_size=16,
+                lora_id=None,
+                medium="cpu",
+                lora_name=None,
+            )
+
+        # Simulate 4 TP ranks each contributing one unique event.
+        for i in range(4):
+            if i > 0:
+                ev.increment_workers(1)
+            ev.add_events([_evt(f"h{i}")])
+
+        # Intersection would drop all (count==1 < num_workers==4).
+        self.assertEqual(len(ev._aggregator.get_common_events()), 0)
+
+        ev.aggregate()
+        events = ev.get_all_events()
+        self.assertEqual(len(events), 4)
+        self.assertEqual(ev.get_number_of_workers(), 1)
+
+    def test_aggregate_dedupes_duplicate_events(self):
+        ev = AscendStoreKVEvents(num_workers=1)
+        evt = BlockStored(
+            block_hashes=["h0"],
+            parent_block_hash=None,
+            token_ids=[1, 2],
+            block_size=16,
+            lora_id=None,
+            medium="cpu",
+            lora_name=None,
+        )
+        ev.add_events([evt, evt])
+        ev.increment_workers(1)
+        ev.add_events([evt])
+        ev.aggregate()
+        self.assertEqual(len(ev.get_all_events()), 1)
 
     def test_increment_workers(self):
         ev = self._make_events()
@@ -238,7 +287,6 @@ class TestAscendStoreConnector(unittest.TestCase):
         # With events
         events = _mock_events(num_workers=1)
         mock_event = MagicMock()
-        events._aggregator.get_common_events.return_value = [mock_event]
         events._aggregator.get_all_events.return_value = [mock_event]
         connector._kv_cache_events = events
         result = list(connector.take_events())

--- a/tests/ut/distributed/ascend_store/test_kv_transfer.py
+++ b/tests/ut/distributed/ascend_store/test_kv_transfer.py
@@ -274,7 +274,7 @@ class TestKVCacheStoreSendingThread(unittest.TestCase):
         self.assertEqual(events[1].block_size, 64)
         self.assertEqual(events[1].token_ids, list(range(64, 128)))
 
-    def test_handle_request_skips_kv_event_for_non_main_group(self):
+    def test_handle_request_emits_kv_event_for_non_main_group(self):
         t, store = self._make_thread([0], enable_kv_event=True)
         req = ReqMeta(
             req_id="r1",
@@ -289,9 +289,10 @@ class TestKVCacheStoreSendingThread(unittest.TestCase):
         t.add_stored_request("r1")
         t.request_queue.put(req)
         t._handle_request(req)
-        # Put still happens; Phase-1 event is skipped for non-main group.
+        events = t.get_kv_events()
         self.assertEqual(len(store.put_calls), 1)
-        self.assertEqual(len(t.get_kv_events()), 0)
+        self.assertEqual(len(events), 1)
+        self.assertEqual(events[0].kv_cache_spec_kind, "sliding_window_mla")
 
     def test_handle_request_consumer_role(self):
         t, store = self._make_thread([0], kv_role="kv_consumer")

--- a/tests/ut/distributed/ascend_store/test_kv_transfer.py
+++ b/tests/ut/distributed/ascend_store/test_kv_transfer.py
@@ -233,12 +233,65 @@ class TestKVCacheStoreSendingThread(unittest.TestCase):
             current_event=None,
             token_ids=list(range(16)),
             original_block_size=16,
+            kv_cache_spec_kinds=["mla_attention"],
         )
         t.add_stored_request("r1")
         t.request_queue.put(req)
         t._handle_request(req)
         events = t.get_kv_events()
         self.assertEqual(len(events), 1)
+        self.assertEqual(events[0].medium, "cpu")
+        self.assertEqual(events[0].kv_cache_spec_kind, "mla_attention")
+        self.assertEqual(events[0].group_idx, 0)
+        self.assertEqual(events[0].block_size, 16)
+        self.assertEqual(events[0].token_ids, list(range(16)))
+
+    def test_handle_request_kv_event_uses_effective_block_size(self):
+        """DSV4 MLA compress_ratio: storage start/end is shrunk, Phase-1 must
+        emit conductor/HBM-aligned effective block_size and token window."""
+        t, store = self._make_thread([0, 0], enable_kv_event=True)
+        t.token_database.group_cache_families = {"kv": {0: "c4"}, "state": {}}
+        # Fine-grained hashes so get_block_hashes(..., 64, ...) can combine.
+        fine_hashes = [f"h{i}".encode() for i in range(8)]
+        req = ReqMeta(
+            req_id="r1",
+            token_len_chunk=128,
+            block_ids=[0, 1],
+            block_hashes=fine_hashes,  # type: ignore[arg-type]
+            current_event=None,
+            token_ids=list(range(128)),
+            original_block_size=16,
+            kv_cache_spec_kinds=["mla_attention"],
+        )
+        t.add_stored_request("r1")
+        t.request_queue.put(req)
+        t._handle_request(req)
+        events = t.get_kv_events()
+        self.assertEqual(len(store.put_calls), 1)
+        self.assertEqual(len(events), 2)
+        self.assertEqual(events[0].block_size, 64)
+        self.assertEqual(events[0].token_ids, list(range(64)))
+        self.assertEqual(events[1].block_size, 64)
+        self.assertEqual(events[1].token_ids, list(range(64, 128)))
+
+    def test_handle_request_skips_kv_event_for_non_main_group(self):
+        t, store = self._make_thread([0], enable_kv_event=True)
+        req = ReqMeta(
+            req_id="r1",
+            token_len_chunk=16,
+            block_ids=[0],
+            block_hashes=[b"h0"],  # type: ignore[arg-type]
+            current_event=None,
+            token_ids=list(range(16)),
+            original_block_size=16,
+            kv_cache_spec_kinds=["sliding_window_mla"],
+        )
+        t.add_stored_request("r1")
+        t.request_queue.put(req)
+        t._handle_request(req)
+        # Put still happens; Phase-1 event is skipped for non-main group.
+        self.assertEqual(len(store.put_calls), 1)
+        self.assertEqual(len(t.get_kv_events()), 0)
 
     def test_handle_request_consumer_role(self):
         t, store = self._make_thread([0], kv_role="kv_consumer")

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/ascend_store_connector.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/ascend_store_connector.py
@@ -48,11 +48,16 @@ class AscendStoreKVEvents(KVConnectorKVEvents):
 
     def aggregate(self) -> "AscendStoreKVEvents":
         """
-        Aggregate KV events and retain only common events.
+        Aggregate KV events across TP workers.
+
+        AscendStore shards puts via ``put_step`` (especially MLA where
+        ``put_step == tp_size``), so each ``BlockStored`` is emitted by
+        exactly one worker. Retain the unique union rather than the
+        intersection required by ``get_common_events``.
         """
-        common_events = self._aggregator.get_common_events()
+        unique_events = list(dict.fromkeys(self._aggregator.get_all_events()))
         self._aggregator.clear_events()
-        self._aggregator.add_events(common_events)
+        self._aggregator.add_events(unique_events)
         self._aggregator.reset_workers()
         return self
 

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/config_data.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/config_data.py
@@ -882,6 +882,9 @@ class ReqMeta:
     # TODO: add lora_request which used for gen lora_id/lora_name in kv event
     token_ids: list[int] | None = None
     original_block_size: list[int] | int | None = None
+    # Wire-format KVCacheSpecKind names per group; used by Phase-1 emitters to
+    # filter Phase-1 BlockStored events to main attention groups only.
+    kv_cache_spec_kinds: list[str] | None = None
 
     event_id: int | None = None
 
@@ -901,6 +904,7 @@ class ReqMeta:
         num_prompt_tokens: int | None = None,
         token_ids: list[int] | None = None,
         original_block_size: list[int] | int | None = None,
+        kv_cache_spec_kinds: list[str] | None = None,
         block_ids: list[int] | list[list[int]] | None = None,
         event_id: int | None = None,
         save_end_token: int | None = None,
@@ -941,6 +945,7 @@ class ReqMeta:
         self.num_prompt_tokens = num_prompt_tokens
         self.token_ids = token_ids
         self.original_block_size = original_block_size
+        self.kv_cache_spec_kinds = kv_cache_spec_kinds
         self.event_id = event_id
         self.last_block_gva = last_block_gva
         self.partial_block_index = partial_block_index
@@ -992,6 +997,7 @@ class ReqMeta:
         discard_partial_chunks: bool = True,
         original_block_size: list[int] | int | None = None,
         kv_cache_group_families: list[str] | None = None,
+        kv_cache_spec_kinds: list[str] | None = None,
     ) -> ReqMeta | None:
         """Create the request metadata from a request tracker."""
         if block_hashes is None:
@@ -1079,6 +1085,7 @@ class ReqMeta:
             gva_block_offset=tracker.gva_block_offset,
             kv_cache_group_ids=list(range(len(tracker.allocated_block_ids_by_group))),
             kv_cache_families_by_group=kv_cache_group_families,
+            kv_cache_spec_kinds=kv_cache_spec_kinds,
         )
 
 

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/kv_transfer.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/kv_transfer.py
@@ -15,24 +15,6 @@ from vllm.v1.core.kv_cache_utils import maybe_convert_block_hash
 
 from vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.backend.backend import Backend
 
-# Main-attention kinds aligned with kv_conductor is_main_attention_kind.
-_MAIN_ATTENTION_KINDS = frozenset(
-    {
-        "full_attention",
-        "mla_attention",
-        "sink_full_attention",
-    }
-)
-
-
-def _is_main_attention_kind(kind: str | None) -> bool:
-    """Return True for main attention groups (or when kind is unspecified)."""
-    if kind is None:
-        return True
-    normalized = kind.replace("_", "").lower()
-    return normalized in {k.replace("_", "") for k in _MAIN_ATTENTION_KINDS}
-
-
 # isort: off
 from vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.config_data import (
     ChunkedTokenDatabase,
@@ -841,8 +823,7 @@ class KVCacheStoreSendingThread(KVTransferThread):
             spec_kind = (
                 spec_kinds[group_id] if spec_kinds is not None and group_id < len(spec_kinds) else None
             )
-            emit_kv_event = self.enable_kv_event and _is_main_attention_kind(spec_kind)
-            if emit_kv_event:
+            if self.enable_kv_event:
                 group_block_hashes = get_block_hashes(
                     req_meta.block_hashes,
                     effective_block_size,
@@ -867,10 +848,10 @@ class KVCacheStoreSendingThread(KVTransferThread):
                 )
                 addrs.append(addr)
                 sizes.append(size)
-                # Phase-1 offload event for main attention only. Map storage
-                # (start, end) back to the effective token window so
-                # conductor/HBM block_size and tokens_hash stay aligned.
-                if emit_kv_event:
+                # Phase-1 offload event. Map storage (start, end) back to the
+                # effective token window so conductor/HBM block_size and
+                # tokens_hash stay aligned.
+                if self.enable_kv_event:
                     storage_block_size = (
                         req_meta.original_block_size[group_id]
                         if isinstance(req_meta.original_block_size, list)

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/kv_transfer.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/kv_transfer.py
@@ -15,6 +15,24 @@ from vllm.v1.core.kv_cache_utils import maybe_convert_block_hash
 
 from vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.backend.backend import Backend
 
+# Main-attention kinds aligned with kv_conductor is_main_attention_kind.
+_MAIN_ATTENTION_KINDS = frozenset(
+    {
+        "full_attention",
+        "mla_attention",
+        "sink_full_attention",
+    }
+)
+
+
+def _is_main_attention_kind(kind: str | None) -> bool:
+    """Return True for main attention groups (or when kind is unspecified)."""
+    if kind is None:
+        return True
+    normalized = kind.replace("_", "").lower()
+    return normalized in {k.replace("_", "") for k in _MAIN_ATTENTION_KINDS}
+
+
 # isort: off
 from vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.config_data import (
     ChunkedTokenDatabase,
@@ -813,11 +831,21 @@ class KVCacheStoreSendingThread(KVTransferThread):
             addrs = []
             sizes = []
             stored_events: list[BlockStored] = []
+            # MLA compress_ratio (cache_family cN) shrinks storage addressing
+            # (start/end) by N while prefix hashes / conductor / HBM events
+            # stay on the effective token window (block_size * N).
+            cache_family_ratio = max(infer_cache_family_ratio(cache_family), 1)
+            effective_block_size = group_block_size * cache_family_ratio
             all_hashes = []
-            if self.enable_kv_event:
+            spec_kinds = req_meta.kv_cache_spec_kinds
+            spec_kind = (
+                spec_kinds[group_id] if spec_kinds is not None and group_id < len(spec_kinds) else None
+            )
+            emit_kv_event = self.enable_kv_event and _is_main_attention_kind(spec_kind)
+            if emit_kv_event:
                 group_block_hashes = get_block_hashes(
                     req_meta.block_hashes,
-                    group_block_size,
+                    effective_block_size,
                     getattr(self.token_database, "hash_block_size", group_block_size),
                 )
                 all_hashes = [maybe_convert_block_hash(bh) for bh in group_block_hashes]
@@ -839,14 +867,27 @@ class KVCacheStoreSendingThread(KVTransferThread):
                 )
                 addrs.append(addr)
                 sizes.append(size)
-                if self.enable_kv_event:
-                    token_ids = req_meta.token_ids[start : ends[index]] if req_meta.token_ids is not None else None
-                    block_size = (
+                # Phase-1 offload event for main attention only. Map storage
+                # (start, end) back to the effective token window so
+                # conductor/HBM block_size and tokens_hash stay aligned.
+                if emit_kv_event:
+                    storage_block_size = (
                         req_meta.original_block_size[group_id]
                         if isinstance(req_meta.original_block_size, list)
                         else req_meta.original_block_size
                     )
-                    if block_size is not None:
+                    if storage_block_size is not None:
+                        token_start = start * cache_family_ratio
+                        token_end = ends[index] * cache_family_ratio
+                        # Skip incomplete effective windows (conductor needs a
+                        # full registered block_size worth of tokens).
+                        if token_end - token_start != effective_block_size:
+                            continue
+                        token_ids = (
+                            req_meta.token_ids[token_start:token_end]
+                            if req_meta.token_ids is not None
+                            else []
+                        )
                         block_idx = start // group_block_size
                         if block_idx >= len(all_hashes):
                             continue
@@ -856,10 +897,12 @@ class KVCacheStoreSendingThread(KVTransferThread):
                             block_hashes=[current_hash],
                             parent_block_hash=parent_hash,
                             token_ids=token_ids,
-                            block_size=block_size,
+                            block_size=effective_block_size,
                             lora_id=None,
                             medium="cpu",
                             lora_name=None,
+                            group_idx=group_id,
+                            kv_cache_spec_kind=spec_kind,
                         )
                         stored_events.append(stored_event)
                         logger.debug("Added kv cache event '%s' to kv cache events queue", stored_event)

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/pool_scheduler.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/pool_scheduler.py
@@ -19,6 +19,7 @@ from vllm.v1.kv_cache_interface import (
     MambaSpec,
     SlidingWindowSpec,
     UniformTypeKVCacheSpecs,
+    get_kv_cache_spec_kind,
 )
 from vllm.v1.outputs import KVConnectorOutput
 from vllm.v1.request import Request
@@ -108,6 +109,7 @@ class KVPoolScheduler:
             vllm_config.speculative_config.num_speculative_tokens if vllm_config.speculative_config else 0
         )
         self.original_block_size = self._infer_group_block_sizes(vllm_config, kv_cache_config)
+        self.kv_cache_spec_kinds = self._infer_group_spec_kinds(vllm_config, kv_cache_config)
         cp_scale = self.pcp_size * self.dcp_size
         self.grouped_block_size = [block_size * cp_scale for block_size in self.original_block_size]
         requested_hash_block_size = (
@@ -405,6 +407,22 @@ class KVPoolScheduler:
                 kv_cache_spec = next(iter(kv_cache_spec.kv_cache_specs.values()))
             block_sizes.append(kv_cache_spec.block_size)
         return block_sizes
+
+    def _infer_group_spec_kinds(
+        self,
+        vllm_config: "VllmConfig",
+        kv_cache_config: KVCacheConfig | None,
+    ) -> list[str]:
+        """Wire-format KVCacheSpecKind names per group for Phase-1 events."""
+        if kv_cache_config is None or not self.use_hybrid:
+            # Non-hybrid: single full/MLA group; kind is optional for events.
+            return ["full_attention"]
+
+        kinds: list[str] = []
+        for kv_cache_group in kv_cache_config.kv_cache_groups:
+            kind = get_kv_cache_spec_kind(kv_cache_group.kv_cache_spec)
+            kinds.append(kind.value if hasattr(kind, "value") else str(kind))
+        return kinds
 
     def _get_group_block_size(self, group_id: int) -> int:
         if group_id >= len(self.grouped_block_size):
@@ -711,6 +729,7 @@ class KVPoolScheduler:
             discard_partial_chunks=self._discard_partial_chunks,
             original_block_size=self.original_block_size,
             kv_cache_group_families=self.kv_cache_group_families,
+            kv_cache_spec_kinds=self.kv_cache_spec_kinds,
         )
 
     def _process_new_request(
@@ -914,6 +933,7 @@ class KVPoolScheduler:
             discard_partial_chunks=self._discard_partial_chunks,
             original_block_size=self.original_block_size,
             kv_cache_group_families=self.kv_cache_group_families,
+            kv_cache_spec_kinds=self.kv_cache_spec_kinds,
         )
 
     def build_connector_meta(self, scheduler_output: SchedulerOutput) -> KVConnectorMetadata:


### PR DESCRIPTION
Aggregate MLA TP-sharded BlockStored events by unique union, emit only main-attention groups with conductor-aligned effective block_size (MLA compress_ratio), so flash non-HBM offload can match pool confirmations.

### What this PR does / why we need it?

### Does this PR introduce _any_ user-facing change?

### How was this patch tested?

- vLLM main: https://github.com/vllm-project/vllm/commit/fe784ff22e630a31fd798f392b01e0a75c18f047
