### PR TITLE
[v0.27.1rc][Performance][KDA] Reduce preprocessing copies and redundant output masks

### DIFF
--- a/csrc/attention/recurrent_kda/op_host/op_api/aclnn_recurrent_kda.cpp
+++ b/csrc/attention/recurrent_kda/op_host/op_api/aclnn_recurrent_kda.cpp
@@ -20,6 +20,7 @@
 #include "opdev/tensor_view_utils.h"
 
 #include <cstring>
+#include <limits>
 
 using namespace op;
 
@@ -110,6 +111,87 @@ static bool ParseLayout(const char *layout, RecurrentKdaLayout &parsed)
     }
     OP_LOGE(ACLNN_ERR_PARAM_INVALID, "npu_recurrent_kda: layout must be BSND or TND.");
     return false;
+}
+
+bool IsSupportedQkvView(const aclTensor *tensor, RecurrentKdaLayout layout)
+{
+    if (tensor == nullptr) {
+        return false;
+    }
+    const size_t expectedRank = layout == RecurrentKdaLayout::TND ? 3 : 4;
+    const auto &strides = tensor->GetViewStrides();
+    if (Rank(tensor) != expectedRank || strides.size() != expectedRank) {
+        return false;
+    }
+    for (size_t i = 0; i < expectedRank; ++i) {
+        if (strides[i] <= 0) {
+            return false;
+        }
+    }
+
+    const size_t tokenDim = layout == RecurrentKdaLayout::TND ? DIM0 : DIM1;
+    const size_t headDim = layout == RecurrentKdaLayout::TND ? DIM1 : DIM2;
+    const size_t featureDim = layout == RecurrentKdaLayout::TND ? DIM2 : DIM3;
+    const int64_t headCount = Dim(tensor, headDim);
+    const int64_t featureCount = Dim(tensor, featureDim);
+    const int64_t tokenStride = strides[tokenDim];
+    const int64_t headStride = strides[headDim];
+    if (strides[featureDim] != 1 || headStride < featureCount) {
+        return false;
+    }
+    const int64_t maxInt64 = std::numeric_limits<int64_t>::max();
+    if (headCount > 1 && headStride > (maxInt64 - featureCount) / (headCount - 1)) {
+        return false;
+    }
+    const int64_t minTokenStride = (headCount - 1) * headStride + featureCount;
+    if (tokenStride < minTokenStride) {
+        return false;
+    }
+    const uint64_t srcGapElements = static_cast<uint64_t>(tokenStride - featureCount);
+    if (srcGapElements > std::numeric_limits<uint32_t>::max() / sizeof(uint16_t)) {
+        return false;
+    }
+
+    if (layout == RecurrentKdaLayout::BSND && Dim(tensor, DIM0) > 1) {
+        const int64_t seqLen = Dim(tensor, DIM1);
+        if (tokenStride > maxInt64 / seqLen || strides[DIM0] != seqLen * tokenStride) {
+            return false;
+        }
+    }
+    return true;
+}
+
+bool CheckQkvMaterializationSafety(
+    const aclTensor *tensor, RecurrentKdaLayout layout, const char *name)
+{
+    const size_t expectedRank = layout == RecurrentKdaLayout::TND ? 3 : 4;
+    const auto &strides = tensor->GetViewStrides();
+    if (Rank(tensor) != expectedRank || strides.size() != expectedRank) {
+        return true;
+    }
+    const size_t tokenDim = layout == RecurrentKdaLayout::TND ? DIM0 : DIM1;
+    const size_t headDim = layout == RecurrentKdaLayout::TND ? DIM1 : DIM2;
+    const size_t featureDim = layout == RecurrentKdaLayout::TND ? DIM2 : DIM3;
+    const int64_t headCount = Dim(tensor, headDim);
+    const int64_t featureCount = Dim(tensor, featureDim);
+    const int64_t tokenStride = strides[tokenDim];
+    const int64_t headStride = strides[headDim];
+    if (strides[featureDim] != 1 || tokenStride <= 0 || headStride <= 0 ||
+        tokenStride < featureCount || headStride < featureCount) {
+        return true;
+    }
+    const int64_t maxInt64 = std::numeric_limits<int64_t>::max();
+    if (headCount > 1 && headStride > (maxInt64 - featureCount) / (headCount - 1)) {
+        OP_LOGE(ACLNN_ERR_PARAM_INVALID, "npu_recurrent_kda: %s head span overflows.", name);
+        return false;
+    }
+    const int64_t minTokenStride = (headCount - 1) * headStride + featureCount;
+    if (tokenStride < minTokenStride) {
+        OP_LOGE(ACLNN_ERR_PARAM_INVALID,
+                "npu_recurrent_kda: %s token/head axis order or overlap is unsupported.", name);
+        return false;
+    }
+    return true;
 }
 
 bool CheckCuSeqlensShape(const aclTensor *cuSeqlens, const char *opName)
@@ -321,6 +403,28 @@ aclnnStatus DataContiguous(const aclTensor *&tensor, aclOpExecutor *executor)
     return ACLNN_SUCCESS;
 }
 
+aclnnStatus DataContiguousIfNeeded(
+    const aclTensor *&tensor, bool needsContiguous, aclOpExecutor *executor)
+{
+    if (!needsContiguous) {
+        return ACLNN_SUCCESS;
+    }
+    return DataContiguous(tensor, executor);
+}
+
+aclnnStatus CreateViewIfNonContiguous(const aclTensor *&tensor, aclOpExecutor *executor)
+{
+    if (tensor == nullptr || IsContiguous(tensor)) {
+        return ACLNN_SUCCESS;
+    }
+    const aclTensor *view = executor->CreateView(
+        tensor, tensor->GetViewShape(), tensor->GetStorageShape(),
+        tensor->GetViewStrides(), tensor->GetViewOffset());
+    CHECK_RET(view != nullptr, ACLNN_ERR_INNER_NULLPTR);
+    tensor = view;
+    return ACLNN_SUCCESS;
+}
+
 void SetTensorOriginalShape(const aclTensor *tensor)
 {
     if (tensor != nullptr) {
@@ -343,12 +447,20 @@ void SetInputOriginalShape(RecurrentKdaParams &params)
     SetTensorOriginalShape(params.numAcceptedTokensOptional);
 }
 
-aclnnStatus PreProcess(RecurrentKdaParams &params, aclOpExecutor *executor)
+aclnnStatus PreProcess(
+    RecurrentKdaParams &params,
+    bool queryNeedsContiguous,
+    bool keyNeedsContiguous,
+    bool valueNeedsContiguous,
+    aclOpExecutor *executor)
 {
     SetInputOriginalShape(params);
-    CHECK_RET(DataContiguous(params.query, executor) == ACLNN_SUCCESS, ACLNN_ERR_INNER_NULLPTR);
-    CHECK_RET(DataContiguous(params.key, executor) == ACLNN_SUCCESS, ACLNN_ERR_INNER_NULLPTR);
-    CHECK_RET(DataContiguous(params.value, executor) == ACLNN_SUCCESS, ACLNN_ERR_INNER_NULLPTR);
+    CHECK_RET(DataContiguousIfNeeded(params.query, queryNeedsContiguous, executor) == ACLNN_SUCCESS,
+              ACLNN_ERR_INNER_NULLPTR);
+    CHECK_RET(DataContiguousIfNeeded(params.key, keyNeedsContiguous, executor) == ACLNN_SUCCESS,
+              ACLNN_ERR_INNER_NULLPTR);
+    CHECK_RET(DataContiguousIfNeeded(params.value, valueNeedsContiguous, executor) == ACLNN_SUCCESS,
+              ACLNN_ERR_INNER_NULLPTR);
     CHECK_RET(DataContiguous(params.gate, executor) == ACLNN_SUCCESS, ACLNN_ERR_INNER_NULLPTR);
     CHECK_RET(DataContiguous(params.beta, executor) == ACLNN_SUCCESS, ACLNN_ERR_INNER_NULLPTR);
     CHECK_RET(DataContiguous(params.cuSeqlensOptional, executor) == ACLNN_SUCCESS, ACLNN_ERR_INNER_NULLPTR);
@@ -416,7 +528,31 @@ aclnnStatus aclnnRecurrentKdaGetWorkspaceSize(
     RecurrentKdaLayout parsedLayout = RecurrentKdaLayout::BSND;
     CHECK_RET(ParseLayout(params.layout, parsedLayout), ACLNN_ERR_PARAM_INVALID);
     CHECK_RET(CheckShape(params, parsedLayout), ACLNN_ERR_PARAM_INVALID);
-    CHECK_RET(PreProcess(params, executorPtr) == ACLNN_SUCCESS, ACLNN_ERR_PARAM_INVALID);
+    CHECK_RET(CheckQkvMaterializationSafety(params.query, parsedLayout, "query") &&
+                  CheckQkvMaterializationSafety(params.key, parsedLayout, "key") &&
+                  CheckQkvMaterializationSafety(params.value, parsedLayout, "value"),
+              ACLNN_ERR_PARAM_INVALID);
+    const bool querySupportsDirect = IsSupportedQkvView(params.query, parsedLayout);
+    const bool keySupportsDirect = IsSupportedQkvView(params.key, parsedLayout);
+    const bool valueSupportsDirect = IsSupportedQkvView(params.value, parsedLayout);
+    const bool queryUsesDirectView = !IsContiguous(params.query) && querySupportsDirect;
+    const bool keyUsesDirectView = !IsContiguous(params.key) && keySupportsDirect;
+    const bool valueUsesDirectView = !IsContiguous(params.value) && valueSupportsDirect;
+    CHECK_RET(PreProcess(params, !querySupportsDirect, !keySupportsDirect, !valueSupportsDirect,
+                         executorPtr) == ACLNN_SUCCESS,
+              ACLNN_ERR_PARAM_INVALID);
+    if (queryUsesDirectView) {
+        CHECK_RET(CreateViewIfNonContiguous(params.query, executorPtr) == ACLNN_SUCCESS,
+                  ACLNN_ERR_INNER_NULLPTR);
+    }
+    if (keyUsesDirectView) {
+        CHECK_RET(CreateViewIfNonContiguous(params.key, executorPtr) == ACLNN_SUCCESS,
+                  ACLNN_ERR_INNER_NULLPTR);
+    }
+    if (valueUsesDirectView) {
+        CHECK_RET(CreateViewIfNonContiguous(params.value, executorPtr) == ACLNN_SUCCESS,
+                  ACLNN_ERR_INNER_NULLPTR);
+    }
 
     aclTensor *initialStateForKernel = params.initialStateRef;
     if (!IsContiguous(initialStateForKernel)) {

--- a/csrc/attention/recurrent_kda/op_host/recurrent_kda_def.cpp
+++ b/csrc/attention/recurrent_kda/op_host/recurrent_kda_def.cpp
@@ -15,21 +15,25 @@ class RecurrentKda : public OpDef {
 public:
     explicit RecurrentKda(const char *name) : OpDef(name)
     {
-        const std::initializer_list<ge::DataType> qkvTypes = {ge::DT_BF16, ge::DT_BF16};
-        const std::initializer_list<ge::DataType> floatTypes = {ge::DT_FLOAT, ge::DT_FLOAT};
+        const std::initializer_list<ge::DataType> qkvTypes = {ge::DT_BF16};
+        const std::initializer_list<ge::DataType> floatTypes = {ge::DT_FLOAT};
         const std::initializer_list<ge::DataType> stateTypes = {ge::DT_BF16, ge::DT_FLOAT};
+        const std::initializer_list<ge::Format> formats = {ge::FORMAT_ND};
 
-        this->Input("query").ParamType(REQUIRED).DataType(qkvTypes).FormatList({ge::FORMAT_ND});
-        this->Input("key").ParamType(REQUIRED).DataType(qkvTypes).FormatList({ge::FORMAT_ND});
-        this->Input("value").ParamType(REQUIRED).DataType(qkvTypes).FormatList({ge::FORMAT_ND});
+        this->Input("query").ParamType(REQUIRED).DataTypeList(qkvTypes).FormatList(formats)
+            .IgnoreContiguous();
+        this->Input("key").ParamType(REQUIRED).DataTypeList(qkvTypes).FormatList(formats)
+            .IgnoreContiguous();
+        this->Input("value").ParamType(REQUIRED).DataTypeList(qkvTypes).FormatList(formats)
+            .IgnoreContiguous();
         this->Input("gate").ParamType(REQUIRED)
             .DataTypeList({ge::DT_FLOAT, ge::DT_BF16, ge::DT_FLOAT16}).FormatList({ge::FORMAT_ND});
         this->Input("beta").ParamType(REQUIRED)
             .DataTypeList({ge::DT_FLOAT, ge::DT_BF16, ge::DT_FLOAT16}).FormatList({ge::FORMAT_ND});
         this->Input("initial_state")
             .ParamType(REQUIRED)
-            .DataType(stateTypes)
-            .FormatList({ge::FORMAT_ND})
+            .DataTypeList(stateTypes)
+            .FormatList(formats)
             .IgnoreContiguous();
         this->Input("cu_seqlens")
             .ParamType(OPTIONAL)
@@ -39,22 +43,22 @@ public:
             .ParamType(OPTIONAL)
             .DataTypeList({ge::DT_INT32, ge::DT_INT64})
             .FormatList({ge::FORMAT_ND});
-        this->Input("A_log").ParamType(OPTIONAL).DataType(floatTypes).FormatList({ge::FORMAT_ND});
-        this->Input("dt_bias").ParamType(OPTIONAL).DataType(floatTypes).FormatList({ge::FORMAT_ND});
+        this->Input("A_log").ParamType(OPTIONAL).DataTypeList(floatTypes).FormatList(formats);
+        this->Input("dt_bias").ParamType(OPTIONAL).DataTypeList(floatTypes).FormatList(formats);
         this->Input("num_accepted_tokens")
             .ParamType(OPTIONAL)
             .DataTypeList({ge::DT_INT32, ge::DT_INT64})
             .FormatList({ge::FORMAT_ND});
-        this->Output("attn_out").ParamType(REQUIRED).DataType(qkvTypes).FormatList({ge::FORMAT_ND});
+        this->Output("attn_out").ParamType(REQUIRED).DataTypeList(qkvTypes).FormatList(formats);
         this->Output("initial_state")
             .ParamType(REQUIRED)
-            .DataType(stateTypes)
-            .FormatList({ge::FORMAT_ND})
+            .DataTypeList(stateTypes)
+            .FormatList(formats)
             .IgnoreContiguous();
         this->Output("final_state")
             .ParamType(REQUIRED)
-            .DataType(stateTypes)
-            .FormatList({ge::FORMAT_ND})
+            .DataTypeList(stateTypes)
+            .FormatList(formats)
             .IgnoreContiguous();
 
         this->Attr("layout").AttrType(OPTIONAL).String("BSND");

--- a/csrc/attention/recurrent_kda/op_host/recurrent_kda_tiling.cpp
+++ b/csrc/attention/recurrent_kda/op_host/recurrent_kda_tiling.cpp
@@ -87,6 +87,20 @@ void CopyStateStrides(const StrideType *src, std::array<int64_t, RKDA_STATE_DIM_
     }
     hasStrides = true;
 }
+
+template <typename StrideType>
+void CopyQkvStrides(const StrideType *src, size_t expectedDimNum,
+                    std::array<int64_t, RKDA_RANK4_QKV_DIM_NUM> &dst, bool &hasStrides)
+{
+    if (src == nullptr || src->GetDimNum() != expectedDimNum ||
+        expectedDimNum > RKDA_RANK4_QKV_DIM_NUM) {
+        return;
+    }
+    for (size_t i = 0; i < expectedDimNum; ++i) {
+        dst[i] = src->GetStride(i);
+    }
+    hasStrides = true;
+}
 } // namespace
 
 RecurrentKdaTilingContext RecurrentKdaTiling::BuildProcessorContext() const
@@ -96,6 +110,12 @@ RecurrentKdaTilingContext RecurrentKdaTiling::BuildProcessorContext() const
     ctx.queryShape = context_->GetInputShape(QUERY_INDEX)->GetOriginShape();
     ctx.keyShape = context_->GetInputShape(KEY_INDEX)->GetOriginShape();
     ctx.valueShape = context_->GetInputShape(VALUE_INDEX)->GetOriginShape();
+    CopyQkvStrides(context_->GetInputStride(QUERY_INDEX), ctx.queryShape.GetDimNum(),
+                   ctx.queryStrides, ctx.hasQueryStrides);
+    CopyQkvStrides(context_->GetInputStride(KEY_INDEX), ctx.keyShape.GetDimNum(),
+                   ctx.keyStrides, ctx.hasKeyStrides);
+    CopyQkvStrides(context_->GetInputStride(VALUE_INDEX), ctx.valueShape.GetDimNum(),
+                   ctx.valueStrides, ctx.hasValueStrides);
     ctx.gateShape = context_->GetInputShape(GATE_INDEX)->GetOriginShape();
     ctx.betaShape = context_->GetInputShape(BETA_INDEX)->GetOriginShape();
     ctx.stateShape = context_->GetInputShape(STATE_INDEX)->GetOriginShape();
@@ -402,6 +422,18 @@ void RecurrentKdaTiling::PrintTilingData()
     OP_LOGD(context_->GetNodeName(), "cuSeqlensDtype: [%u]", tilingData_.cuSeqlensDtype);
     OP_LOGD(context_->GetNodeName(), "ssmStateIndicesDtype: [%u]", tilingData_.ssmStateIndicesDtype);
     OP_LOGD(context_->GetNodeName(), "acceptedTokensDtype: [%u]", tilingData_.acceptedTokensDtype);
+    OP_LOGD(context_->GetNodeName(), "queryTokenStride: [%llu]",
+            static_cast<unsigned long long>(tilingData_.queryTokenStride));
+    OP_LOGD(context_->GetNodeName(), "queryHeadStride: [%llu]",
+            static_cast<unsigned long long>(tilingData_.queryHeadStride));
+    OP_LOGD(context_->GetNodeName(), "keyTokenStride: [%llu]",
+            static_cast<unsigned long long>(tilingData_.keyTokenStride));
+    OP_LOGD(context_->GetNodeName(), "keyHeadStride: [%llu]",
+            static_cast<unsigned long long>(tilingData_.keyHeadStride));
+    OP_LOGD(context_->GetNodeName(), "valueTokenStride: [%llu]",
+            static_cast<unsigned long long>(tilingData_.valueTokenStride));
+    OP_LOGD(context_->GetNodeName(), "valueHeadStride: [%llu]",
+            static_cast<unsigned long long>(tilingData_.valueHeadStride));
 }
 
 ge::graphStatus RecurrentKdaTiling::CalUbSize()

--- a/csrc/attention/recurrent_kda/op_host/recurrent_kda_tiling_processor.h
+++ b/csrc/attention/recurrent_kda/op_host/recurrent_kda_tiling_processor.h
@@ -21,6 +21,7 @@
 #include <array>
 #include <cstddef>
 #include <cstdint>
+#include <limits>
 #include <string>
 
 using RecurrentKdaTilingData = RecurrentKda::RecurrentKdaTilingData;
@@ -81,6 +82,12 @@ struct RecurrentKdaTilingContext {
     ge::DataType cuSeqlensDtype = ge::DT_INT64;
     ge::DataType ssmStateIndicesDtype = ge::DT_INT64;
     ge::DataType acceptedTokensDtype = ge::DT_INT64;
+    std::array<int64_t, RKDA_RANK4_QKV_DIM_NUM> queryStrides = {};
+    std::array<int64_t, RKDA_RANK4_QKV_DIM_NUM> keyStrides = {};
+    std::array<int64_t, RKDA_RANK4_QKV_DIM_NUM> valueStrides = {};
+    bool hasQueryStrides = false;
+    bool hasKeyStrides = false;
+    bool hasValueStrides = false;
     std::array<int64_t, RKDA_STATE_DIM_NUM> stateInStrides = {};
     std::array<int64_t, RKDA_STATE_DIM_NUM> stateOutStrides = {};
     bool hasStateInStrides = false;
@@ -171,6 +178,101 @@ private:
         strides[RKDA_DIM_1] = shape.GetDim(RKDA_DIM_2) * strides[RKDA_DIM_2];
         strides[RKDA_DIM_0] = shape.GetDim(RKDA_DIM_1) * strides[RKDA_DIM_1];
         return strides;
+    }
+
+    std::array<int64_t, RKDA_RANK4_QKV_DIM_NUM> ResolveQkvStrides(
+        const gert::Shape &shape,
+        const std::array<int64_t, RKDA_RANK4_QKV_DIM_NUM> &viewStrides,
+        bool hasStrides) const
+    {
+        if (hasStrides) {
+            return viewStrides;
+        }
+        std::array<int64_t, RKDA_RANK4_QKV_DIM_NUM> strides = {};
+        int64_t denseStride = 1;
+        for (size_t dim = shape.GetDimNum(); dim > 0; --dim) {
+            const size_t index = dim - 1;
+            strides[index] = denseStride;
+            denseStride *= shape.GetDim(index);
+        }
+        return strides;
+    }
+
+    ge::graphStatus ValidateQkvStrides(
+        const gert::Shape &shape,
+        const std::array<int64_t, RKDA_RANK4_QKV_DIM_NUM> &strides,
+        const char *name) const
+    {
+        const size_t rank = shape.GetDimNum();
+        for (size_t i = 0; i < rank; ++i) {
+            OP_CHECK_IF(strides[i] <= 0,
+                        OP_LOGE(ctx_.nodeName, "%s stride[%zu] must be positive, but it is %ld.",
+                                name, i, strides[i]),
+                        return ge::GRAPH_FAILED);
+        }
+
+        const size_t tokenDim = rank == RKDA_RANK3_QKV_DIM_NUM ? RKDA_DIM_0 : RKDA_DIM_1;
+        const size_t headDim = rank == RKDA_RANK3_QKV_DIM_NUM ? RKDA_DIM_1 : RKDA_DIM_2;
+        const size_t featureDim = rank == RKDA_RANK3_QKV_DIM_NUM ? RKDA_DIM_2 : RKDA_DIM_3;
+        const uint64_t headCount = static_cast<uint64_t>(shape.GetDim(headDim));
+        const uint64_t featureCount = static_cast<uint64_t>(shape.GetDim(featureDim));
+        const uint64_t tokenStride = static_cast<uint64_t>(strides[tokenDim]);
+        const uint64_t headStride = static_cast<uint64_t>(strides[headDim]);
+        OP_CHECK_IF(strides[featureDim] != 1 || headStride < featureCount,
+                    OP_LOGE(ctx_.nodeName,
+                            "%s must keep feature elements dense and non-overlapping: "
+                            "feature stride=1 and head stride>=%llu.",
+                            name, static_cast<unsigned long long>(featureCount)),
+                    return ge::GRAPH_FAILED);
+
+        const uint64_t maxUint64 = std::numeric_limits<uint64_t>::max();
+        OP_CHECK_IF(headCount > 1 &&
+                        headStride > (maxUint64 - featureCount) / (headCount - 1),
+                    OP_LOGE(ctx_.nodeName, "%s head stride calculation overflows.", name),
+                    return ge::GRAPH_FAILED);
+        const uint64_t minTokenStride = (headCount - 1) * headStride + featureCount;
+        OP_CHECK_IF(tokenStride < minTokenStride,
+                    OP_LOGE(ctx_.nodeName,
+                            "%s token stride overlaps heads: token stride=%llu, minimum=%llu.",
+                            name, static_cast<unsigned long long>(tokenStride),
+                            static_cast<unsigned long long>(minTokenStride)),
+                    return ge::GRAPH_FAILED);
+
+        const uint64_t srcGapElements = tokenStride - featureCount;
+        OP_CHECK_IF(srcGapElements > std::numeric_limits<uint32_t>::max() / sizeof(uint16_t),
+                    OP_LOGE(ctx_.nodeName,
+                            "%s token gap exceeds DataCopy source-stride range: %llu elements.",
+                            name, static_cast<unsigned long long>(srcGapElements)),
+                    return ge::GRAPH_FAILED);
+
+        if (rank == RKDA_RANK4_QKV_DIM_NUM && shape.GetDim(RKDA_DIM_0) > 1) {
+            const uint64_t seqLen = static_cast<uint64_t>(shape.GetDim(RKDA_DIM_1));
+            OP_CHECK_IF(tokenStride > maxUint64 / seqLen,
+                        OP_LOGE(ctx_.nodeName, "%s batch stride calculation overflows.", name),
+                        return ge::GRAPH_FAILED);
+            const uint64_t expectedBatchStride = seqLen * tokenStride;
+            OP_CHECK_IF(static_cast<uint64_t>(strides[RKDA_DIM_0]) != expectedBatchStride,
+                        OP_LOGE(ctx_.nodeName,
+                                "%s batch stride must equal T * token stride for flattened BSND, "
+                                "but got %llu and expected %llu.",
+                                name, static_cast<unsigned long long>(strides[RKDA_DIM_0]),
+                                static_cast<unsigned long long>(expectedBatchStride)),
+                        return ge::GRAPH_FAILED);
+        }
+        return ge::GRAPH_SUCCESS;
+    }
+
+    ge::graphStatus CheckQkvStrides() const
+    {
+        const auto queryStrides = ResolveQkvStrides(ctx_.queryShape, ctx_.queryStrides, ctx_.hasQueryStrides);
+        const auto keyStrides = ResolveQkvStrides(ctx_.keyShape, ctx_.keyStrides, ctx_.hasKeyStrides);
+        const auto valueStrides = ResolveQkvStrides(ctx_.valueShape, ctx_.valueStrides, ctx_.hasValueStrides);
+        if (ValidateQkvStrides(ctx_.queryShape, queryStrides, "query") != ge::GRAPH_SUCCESS ||
+            ValidateQkvStrides(ctx_.keyShape, keyStrides, "key") != ge::GRAPH_SUCCESS ||
+            ValidateQkvStrides(ctx_.valueShape, valueStrides, "value") != ge::GRAPH_SUCCESS) {
+            return ge::GRAPH_FAILED;
+        }
+        return ge::GRAPH_SUCCESS;
     }
 
     ge::graphStatus ValidateStateStrides(
@@ -402,6 +504,10 @@ private:
                             "state_capacity must equal seq_num."),
                     return ge::GRAPH_FAILED);
 
+        if (CheckQkvStrides() != ge::GRAPH_SUCCESS) {
+            return ge::GRAPH_FAILED;
+        }
+
         if (CheckStateStrides() != ge::GRAPH_SUCCESS) {
             return ge::GRAPH_FAILED;
         }
@@ -437,6 +543,17 @@ private:
         tiling.sBlockNum = static_cast<uint32_t>(stateShape.GetDim(RKDA_DIM_0));
         tiling.ssmStateStride = (ctx_.hasSsmStateIndices && ctx_.ssmStateShape.GetDimNum() == RKDA_METADATA_RANK2) ?
                                 static_cast<uint32_t>(ctx_.ssmStateShape.GetDim(RKDA_DIM_1)) : 0;
+        const auto queryStrides = ResolveQkvStrides(queryShape, ctx_.queryStrides, ctx_.hasQueryStrides);
+        const auto keyStrides = ResolveQkvStrides(ctx_.keyShape, ctx_.keyStrides, ctx_.hasKeyStrides);
+        const auto valueStrides = ResolveQkvStrides(valueShape, ctx_.valueStrides, ctx_.hasValueStrides);
+        const size_t tokenDim = ctx_.layout == RKDA_LAYOUT_TND ? RKDA_DIM_0 : RKDA_DIM_1;
+        const size_t headDim = ctx_.layout == RKDA_LAYOUT_TND ? RKDA_DIM_1 : RKDA_DIM_2;
+        tiling.queryTokenStride = static_cast<uint64_t>(queryStrides[tokenDim]);
+        tiling.queryHeadStride = static_cast<uint64_t>(queryStrides[headDim]);
+        tiling.keyTokenStride = static_cast<uint64_t>(keyStrides[tokenDim]);
+        tiling.keyHeadStride = static_cast<uint64_t>(keyStrides[headDim]);
+        tiling.valueTokenStride = static_cast<uint64_t>(valueStrides[tokenDim]);
+        tiling.valueHeadStride = static_cast<uint64_t>(valueStrides[headDim]);
         const auto stateInStrides = ResolveStateStrides(false);
         const auto stateOutStrides = ResolveStateStrides(true);
         tiling.stateInStride0 = static_cast<uint64_t>(stateInStrides[RKDA_DIM_0]);

--- a/csrc/attention/recurrent_kda/op_kernel/arch35/recurrent_kda.h
+++ b/csrc/attention/recurrent_kda/op_kernel/arch35/recurrent_kda.h
@@ -75,6 +75,12 @@ public:
         stateOutStride1_ = tilingData->stateOutStride1;
         stateOutStride2_ = tilingData->stateOutStride2;
         stateOutStride3_ = tilingData->stateOutStride3;
+        queryTokenStride_ = tilingData->queryTokenStride;
+        queryHeadStride_ = tilingData->queryHeadStride;
+        keyTokenStride_ = tilingData->keyTokenStride;
+        keyHeadStride_ = tilingData->keyHeadStride;
+        valueTokenStride_ = tilingData->valueTokenStride;
+        valueHeadStride_ = tilingData->valueHeadStride;
         scale_ = tilingData->scale;
         lowerBound_ = tilingData->lowerBound;
         hasCuSeqlens_ = (tilingData->hasCuSeqlens == 1);
@@ -497,22 +503,24 @@ private:
         PipeBarrier<PIPE_V>();
     }
 
-    __aicore__ inline void CopyInQKVGate(uint64_t vOffset, uint64_t qkOffset, uint64_t gateOffset, int32_t seqLen,
-                                         uint64_t head)
+    __aicore__ inline void CopyInQKVGate(uint64_t qOffset, uint64_t kOffset, uint64_t vOffset,
+                                         uint64_t gateOffset, int32_t seqLen, uint64_t head)
     {
         LocalTensor<inType> qLocal = qInQueue_.AllocTensor<inType>();
         LocalTensor<inType> kLocal = kInQueue_.AllocTensor<inType>();
         LocalTensor<inType> vLocal = vInQueue_.AllocTensor<inType>();
 
-        DataCopyExtParams qkInParams{static_cast<uint16_t>(seqLen), static_cast<uint32_t>(realK_ * sizeof(inType)),
-                                     static_cast<uint32_t>((NK_ - 1) * realK_ * sizeof(inType)), 0, 0};
+        DataCopyExtParams qInParams{static_cast<uint16_t>(seqLen), static_cast<uint32_t>(realK_ * sizeof(inType)),
+                                    static_cast<uint32_t>((queryTokenStride_ - realK_) * sizeof(inType)), 0, 0};
+        DataCopyExtParams kInParams{static_cast<uint16_t>(seqLen), static_cast<uint32_t>(realK_ * sizeof(inType)),
+                                    static_cast<uint32_t>((keyTokenStride_ - realK_) * sizeof(inType)), 0, 0};
         DataCopyExtParams vInParams{static_cast<uint16_t>(seqLen), static_cast<uint32_t>(realV_ * sizeof(inType)),
-                                    static_cast<uint32_t>((NV_ - 1) * realV_ * sizeof(inType)), 0, 0};
+                                    static_cast<uint32_t>((valueTokenStride_ - realV_) * sizeof(inType)), 0, 0};
         DataCopyPadExtParams<inType> qkPadParams{true, 0, static_cast<uint8_t>(alignK_ - realK_), 0};
         DataCopyPadExtParams<inType> vPadParams{true, 0, static_cast<uint8_t>(alignV_ - realV_), 0};
 
-        DataCopyPad(qLocal, queryGm_[qkOffset], qkInParams, qkPadParams);
-        DataCopyPad(kLocal, keyGm_[qkOffset], qkInParams, qkPadParams);
+        DataCopyPad(qLocal, queryGm_[qOffset], qInParams, qkPadParams);
+        DataCopyPad(kLocal, keyGm_[kOffset], kInParams, qkPadParams);
         DataCopyPad(vLocal, valueGm_[vOffset], vInParams, vPadParams);
         qInQueue_.EnQue<inType>(qLocal);
         kInQueue_.EnQue<inType>(kLocal);
@@ -846,10 +854,12 @@ private:
     __aicore__ inline void ProcessHead(uint64_t batchIdx, int64_t seq0, int64_t seq1,
                                       uint64_t head_i, uint64_t stateSlot)
     {
-        uint64_t vOffset = (static_cast<uint64_t>(seq0) * NV_ + head_i) * realV_;
-        uint64_t qkOffset = (static_cast<uint64_t>(seq0) * NK_ + head_i / (NV_ / NK_)) * realK_;
+        uint64_t qkHead = head_i / (NV_ / NK_);
+        uint64_t qOffset = static_cast<uint64_t>(seq0) * queryTokenStride_ + qkHead * queryHeadStride_;
+        uint64_t kOffset = static_cast<uint64_t>(seq0) * keyTokenStride_ + qkHead * keyHeadStride_;
+        uint64_t vOffset = static_cast<uint64_t>(seq0) * valueTokenStride_ + head_i * valueHeadStride_;
         uint64_t gateOffset = (static_cast<uint64_t>(seq0) * NV_ + head_i) * realK_;
-        CopyInQKVGate(vOffset, qkOffset, gateOffset, static_cast<int32_t>(seq1 - seq0), head_i);
+        CopyInQKVGate(qOffset, kOffset, vOffset, gateOffset, static_cast<int32_t>(seq1 - seq0), head_i);
         if (realV_ == 0) {
             return;
         }
@@ -965,6 +975,12 @@ private:
     uint32_t realV_;
     uint32_t stateCapacity_;
     uint32_t ssmStateStride_;
+    uint64_t queryTokenStride_;
+    uint64_t queryHeadStride_;
+    uint64_t keyTokenStride_;
+    uint64_t keyHeadStride_;
+    uint64_t valueTokenStride_;
+    uint64_t valueHeadStride_;
     uint64_t stateInStride0_;
     uint64_t stateInStride1_;
     uint64_t stateInStride2_;

--- a/csrc/attention/recurrent_kda/op_kernel/recurrent_kda.h
+++ b/csrc/attention/recurrent_kda/op_kernel/recurrent_kda.h
@@ -72,6 +72,12 @@ public:
         stateOutStride1_ = tilingData->stateOutStride1;
         stateOutStride2_ = tilingData->stateOutStride2;
         stateOutStride3_ = tilingData->stateOutStride3;
+        queryTokenStride_ = tilingData->queryTokenStride;
+        queryHeadStride_ = tilingData->queryHeadStride;
+        keyTokenStride_ = tilingData->keyTokenStride;
+        keyHeadStride_ = tilingData->keyHeadStride;
+        valueTokenStride_ = tilingData->valueTokenStride;
+        valueHeadStride_ = tilingData->valueHeadStride;
         scale_ = tilingData->scale;
         lowerBound_ = tilingData->lowerBound;
         hasCuSeqlens_ = (tilingData->hasCuSeqlens == 1);
@@ -500,22 +506,24 @@ private:
         PipeBarrier<PIPE_V>();
     }
 
-    __aicore__ inline void CopyInQKVGate(uint64_t vOffset, uint64_t qkOffset, uint64_t gateOffset, int32_t seqLen,
-                                         uint64_t head)
+    __aicore__ inline void CopyInQKVGate(uint64_t qOffset, uint64_t kOffset, uint64_t vOffset,
+                                         uint64_t gateOffset, int32_t seqLen, uint64_t head)
     {
         LocalTensor<inType> qLocal = qInQueue_.AllocTensor<inType>();
         LocalTensor<inType> kLocal = kInQueue_.AllocTensor<inType>();
         LocalTensor<inType> vLocal = vInQueue_.AllocTensor<inType>();
 
-        DataCopyExtParams qkInParams{static_cast<uint16_t>(seqLen), static_cast<uint32_t>(realK_ * sizeof(inType)),
-                                     static_cast<uint32_t>((NK_ - 1) * realK_ * sizeof(inType)), 0, 0};
+        DataCopyExtParams qInParams{static_cast<uint16_t>(seqLen), static_cast<uint32_t>(realK_ * sizeof(inType)),
+                                    static_cast<uint32_t>((queryTokenStride_ - realK_) * sizeof(inType)), 0, 0};
+        DataCopyExtParams kInParams{static_cast<uint16_t>(seqLen), static_cast<uint32_t>(realK_ * sizeof(inType)),
+                                    static_cast<uint32_t>((keyTokenStride_ - realK_) * sizeof(inType)), 0, 0};
         DataCopyExtParams vInParams{static_cast<uint16_t>(seqLen), static_cast<uint32_t>(realV_ * sizeof(inType)),
-                                    static_cast<uint32_t>((NV_ - 1) * realV_ * sizeof(inType)), 0, 0};
+                                    static_cast<uint32_t>((valueTokenStride_ - realV_) * sizeof(inType)), 0, 0};
         DataCopyPadExtParams<inType> qkPadParams{true, 0, static_cast<uint8_t>(alignK_ - realK_), 0};
         DataCopyPadExtParams<inType> vPadParams{true, 0, static_cast<uint8_t>(alignV_ - realV_), 0};
 
-        DataCopyPad(qLocal, queryGm_[qkOffset], qkInParams, qkPadParams);
-        DataCopyPad(kLocal, keyGm_[qkOffset], qkInParams, qkPadParams);
+        DataCopyPad(qLocal, queryGm_[qOffset], qInParams, qkPadParams);
+        DataCopyPad(kLocal, keyGm_[kOffset], kInParams, qkPadParams);
         DataCopyPad(vLocal, valueGm_[vOffset], vInParams, vPadParams);
         qInQueue_.EnQue<inType>(qLocal);
         kInQueue_.EnQue<inType>(kLocal);
@@ -805,10 +813,12 @@ private:
     __aicore__ inline void ProcessHead(uint64_t batchIdx, int64_t seq0, int64_t seq1,
                                       uint64_t head_i, uint64_t stateSlot)
     {
-        uint64_t vOffset = (static_cast<uint64_t>(seq0) * NV_ + head_i) * realV_;
-        uint64_t qkOffset = (static_cast<uint64_t>(seq0) * NK_ + head_i / (NV_ / NK_)) * realK_;
+        uint64_t qkHead = head_i / (NV_ / NK_);
+        uint64_t qOffset = static_cast<uint64_t>(seq0) * queryTokenStride_ + qkHead * queryHeadStride_;
+        uint64_t kOffset = static_cast<uint64_t>(seq0) * keyTokenStride_ + qkHead * keyHeadStride_;
+        uint64_t vOffset = static_cast<uint64_t>(seq0) * valueTokenStride_ + head_i * valueHeadStride_;
         uint64_t gateOffset = (static_cast<uint64_t>(seq0) * NV_ + head_i) * realK_;
-        CopyInQKVGate(vOffset, qkOffset, gateOffset, static_cast<int32_t>(seq1 - seq0), head_i);
+        CopyInQKVGate(qOffset, kOffset, vOffset, gateOffset, static_cast<int32_t>(seq1 - seq0), head_i);
         if (realV_ == 0) {
             return;
         }
@@ -929,6 +939,12 @@ private:
     uint32_t realV_;
     uint32_t stateCapacity_;
     uint32_t ssmStateStride_;
+    uint64_t queryTokenStride_;
+    uint64_t queryHeadStride_;
+    uint64_t keyTokenStride_;
+    uint64_t keyHeadStride_;
+    uint64_t valueTokenStride_;
+    uint64_t valueHeadStride_;
     uint64_t stateInStride0_;
     uint64_t stateInStride1_;
     uint64_t stateInStride2_;

--- a/csrc/attention/recurrent_kda/op_kernel/recurrent_kda_struct.h
+++ b/csrc/attention/recurrent_kda/op_kernel/recurrent_kda_struct.h
@@ -62,6 +62,12 @@ struct alignas(8) RecurrentKdaTilingData {
     uint64_t stateOutStride1;
     uint64_t stateOutStride2;
     uint64_t stateOutStride3;
+    uint64_t queryTokenStride;
+    uint64_t queryHeadStride;
+    uint64_t keyTokenStride;
+    uint64_t keyHeadStride;
+    uint64_t valueTokenStride;
+    uint64_t valueHeadStride;
 };
 #pragma pack(pop)
 

--- a/tests/e2e/nightly/single_node/ops/singlecard_ops/test_kimi_kda_recurrent_ascendc_npu.py
+++ b/tests/e2e/nightly/single_node/ops/singlecard_ops/test_kimi_kda_recurrent_ascendc_npu.py
@@ -152,9 +152,26 @@ def recurrent_kda_reference(
     return _restore_layout(out_flat.to(q.dtype), v, layout), state.to(state_dtype)
 
 
+def _padded_feature_view(
+    tensor: torch.Tensor,
+    *,
+    padding: int,
+    device: torch.device,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    storage = torch.full(
+        (*tensor.shape[:-1], tensor.shape[-1] + padding),
+        11.0,
+        dtype=tensor.dtype,
+        device=device,
+    )
+    view = storage[..., : tensor.shape[-1]]
+    view.copy_(tensor.to(device))
+    return view, storage, storage[..., tensor.shape[-1] :].clone()
+
+
 @torch.inference_mode()
-def test_kimi_k3_tp16_recurrent_kda_non_contiguous_state_pool():
-    """Preserve a strided cache view while updating only selected Kimi slots."""
+def test_kimi_k3_tp16_recurrent_kda_non_contiguous_qkv_and_state_pool():
+    """Read strided QKV views and update only selected Kimi state slots."""
     torch.manual_seed(20260806)
     device = torch.device("npu")
     batch, heads, dim = 4, 6, 128
@@ -201,13 +218,20 @@ def test_kimi_k3_tp16_recurrent_kda_non_contiguous_state_pool():
     state_before = state_view.clone()
     state_stride = state_view.stride()
     state_storage = state_view.untyped_storage().data_ptr()
+    q_view, q_storage, q_guard = _padded_feature_view(q_cpu, padding=16, device=device)
+    k_view, k_storage, k_guard = _padded_feature_view(k_cpu, padding=32, device=device)
+    v_view, v_storage, v_guard = _padded_feature_view(v_cpu, padding=48, device=device)
+    qkv_views = (q_view, k_view, v_view)
+    qkv_strides = tuple(tensor.stride() for tensor in qkv_views)
+    qkv_storage = tuple(tensor.untyped_storage().data_ptr() for tensor in qkv_views)
     assert not state_view.is_contiguous()
     assert state_view.storage_offset() > 0
+    assert all(not tensor.is_contiguous() for tensor in qkv_views)
 
     out = torch.ops._C_ascend.recurrent_kda(
-        q_cpu.to(device),
-        k_cpu.to(device),
-        v_cpu.to(device),
+        q_view,
+        k_view,
+        v_view,
         raw_gate_cpu.to(device),
         beta_cpu.to(device),
         state_view,
@@ -227,9 +251,14 @@ def test_kimi_k3_tp16_recurrent_kda_non_contiguous_state_pool():
 
     assert state_view.stride() == state_stride
     assert state_view.untyped_storage().data_ptr() == state_storage
+    assert tuple(tensor.stride() for tensor in qkv_views) == qkv_strides
+    assert tuple(tensor.untyped_storage().data_ptr() for tensor in qkv_views) == qkv_storage
     torch.testing.assert_close(out.cpu(), ref_out, rtol=0.02, atol=0.02)
     torch.testing.assert_close(state_view.cpu(), ref_state, rtol=0.02, atol=0.02)
     torch.testing.assert_close(state_pool[1:, 1], guard_layer, rtol=0, atol=0)
+    torch.testing.assert_close(q_storage[..., dim:], q_guard, rtol=0, atol=0)
+    torch.testing.assert_close(k_storage[..., dim:], k_guard, rtol=0, atol=0)
+    torch.testing.assert_close(v_storage[..., dim:], v_guard, rtol=0, atol=0)
     used_slots = set(state_indices_cpu.tolist())
     untouched_slots = [slot for slot in range(state_capacity) if slot not in used_slots]
     torch.testing.assert_close(state_view[untouched_slots], state_before[untouched_slots], rtol=0, atol=0)

--- a/tests/ut/ops/test_kimi_kda.py
+++ b/tests/ut/ops/test_kimi_kda.py
@@ -13,8 +13,6 @@ from vllm_ascend.ops.kimi_kda import (
     AscendKimiK3DeltaAttention,
     _KDAFusedBFGLinear,
     _prepare_beta,
-    _zero_padded_output,
-    _zero_padded_recurrent_output,
 )
 from vllm_ascend.quantization.methods.w4a8.w4a8_mxfp4 import (
     AscendW4A8MXFPDynamicLinearMethod,
@@ -67,31 +65,6 @@ class _RecordingStreamSwitch:
 
     def __exit__(self, *args) -> None:
         self.trace.append(f"exit:{self.stream.name}")
-
-
-def test_zero_padded_recurrent_output_clears_uncovered_tail():
-    output = torch.randn(1, 8, 2, 3)
-    expected = output[:, :5].clone()
-    output[:, 5:] = torch.nan
-
-    actual = _zero_padded_recurrent_output(
-        output,
-        torch.tensor([0, 3, 5, 5], dtype=torch.int32),
-    )
-
-    torch.testing.assert_close(actual[:, :5], expected)
-    assert torch.equal(actual[:, 5:], torch.zeros_like(actual[:, 5:]))
-    assert torch.isfinite(actual).all()
-
-
-def test_zero_padded_output_uses_combined_live_token_count():
-    output = torch.full((1, 8, 1, 1), torch.nan)
-    output[:, :6] = torch.arange(6).view(1, 6, 1, 1)
-
-    actual = _zero_padded_output(output, torch.tensor(6, dtype=torch.int32))
-
-    torch.testing.assert_close(actual[:, :6], output[:, :6])
-    assert torch.equal(actual[:, 6:], torch.zeros_like(actual[:, 6:]))
 
 
 def test_kda_output_norm_uses_checkpoint_epsilon():
@@ -494,3 +467,63 @@ def test_kda_conv_weight_is_packed_once_in_kernel_layout():
         packed,
         source[:, 0, :].transpose(0, 1).to(torch.bfloat16),
     )
+
+
+@pytest.mark.parametrize("mode", ["spec", "decode", "mixed"])
+def test_kda_forward_preserves_live_rows_with_nan_padding(mode):
+    state = torch.zeros(1)
+    conv_meta = SimpleNamespace(
+        query_start_loc=torch.tensor([0, 4]), cache_indices=torch.tensor([0]), num_accepted_tokens=None
+    )
+    metadata = SimpleNamespace(
+        num_actual_tokens=6,
+        num_prefills=0,
+        num_decodes=0 if mode == "spec" else 1,
+        num_decode_tokens=4,
+        spec_sequence_masks=None if mode == "decode" else torch.tensor([True]),
+        spec_token_indx=torch.tensor([0, 2, 4]),
+        non_spec_token_indx=torch.tensor([1, 3, 5]),
+        spec_decode_metadata=SimpleNamespace(spec_causal_conv1d=conv_meta),
+        non_spec_decode_metadata=SimpleNamespace(causal_conv1d=conv_meta),
+        spec_query_start_loc=torch.tensor([0, 2 if mode == "mixed" else 4]),
+        non_spec_query_start_loc=torch.tensor([0, 2 if mode == "mixed" else 4]),
+        spec_state_indices_tensor=torch.tensor([0]),
+        non_spec_state_indices_tensor=torch.tensor([0]),
+    )
+    values = torch.arange(1, 9, dtype=torch.float32).view(8, 1).repeat(1, 6)
+    values[4:] = torch.nan
+    gate = torch.zeros(8, 1, 2)
+    gate[4:] = torch.nan
+
+    def recurrent(q, k, v, raw_gate, beta, recurrent_state, query_start_loc, state_indices, **kwargs):
+        recurrent_state.add_(1)
+        return v.clone()
+
+    attention = SimpleNamespace(
+        prefix="kda",
+        head_dim=2,
+        kv_cache=(torch.zeros(1), state),
+        get_parameter=lambda name: torch.empty(1),
+        _run_causal_conv1d=lambda x, *args, **kwargs: x,
+        _run_recurrent=recurrent,
+        o_norm=lambda x, g: x * torch.sigmoid(g),
+    )
+    output = torch.full((1, 8, 1, 2), torch.nan)
+    with (
+        patch("vllm_ascend.ops.kimi_kda.GDNAttentionMetadata", SimpleNamespace),
+        patch(
+            "vllm_ascend.ops.kimi_kda.get_forward_context",
+            return_value=SimpleNamespace(attn_metadata={"kda": metadata}),
+        ),
+    ):
+        AscendKimiK3DeltaAttention._forward(
+            attention,
+            values,
+            torch.zeros(1, 8, 1, 2),
+            gate,
+            torch.zeros(1, 8, 1),
+            output,
+        )
+    torch.testing.assert_close(output[0, :4, 0], values[:4, :2] * 0.5)
+    torch.testing.assert_close(output[:, 6:], torch.zeros_like(output[:, 6:]))
+    torch.testing.assert_close(state, torch.tensor([2.0 if mode == "mixed" else 1.0]))

--- a/vllm_ascend/ops/kimi_kda.py
+++ b/vllm_ascend/ops/kimi_kda.py
@@ -444,10 +444,12 @@ class AscendKimiK3DeltaAttention(KimiK3DeltaAttention):
         *,
         num_accepted_tokens: torch.Tensor | None = None,
     ) -> torch.Tensor:
+        # Preserve the strided Q/K/V views split from the fused projection;
+        # recurrent KDA consumes their independent token/head strides.
         return torch.ops._C_ascend.recurrent_kda(
-            q.contiguous(),
-            k.contiguous(),
-            v.contiguous(),
+            q,
+            k,
+            v,
             raw_gate.contiguous(),
             beta.contiguous(),
             recurrent_state,

--- a/vllm_ascend/ops/kimi_kda.py
+++ b/vllm_ascend/ops/kimi_kda.py
@@ -150,28 +150,6 @@ class _KDAFusedBFGLinear(MergedColumnParallelLinear):
         param_shard.copy_(fused_weight)
 
 
-def _zero_padded_output(
-    output: torch.Tensor,
-    num_live_tokens: torch.Tensor,
-) -> torch.Tensor:
-    """Clear graph-padding rows using a device-side live-token count."""
-    token_indices = torch.arange(
-        output.shape[1],
-        dtype=num_live_tokens.dtype,
-        device=output.device,
-    )
-    valid_tokens = token_indices < num_live_tokens
-    return torch.where(valid_tokens.view(1, -1, 1, 1), output, 0.0)
-
-
-def _zero_padded_recurrent_output(
-    output: torch.Tensor,
-    query_start_loc: torch.Tensor,
-) -> torch.Tensor:
-    """Clear graph-padding rows skipped by recurrent KDA."""
-    return _zero_padded_output(output, query_start_loc[-1])
-
-
 def _prepare_beta(
     beta: torch.Tensor,
     num_actual_tokens: int,
@@ -612,10 +590,6 @@ class AscendKimiK3DeltaAttention(KimiK3DeltaAttention):
                 attn_metadata.spec_state_indices_tensor,
                 num_accepted_tokens=spec_conv_meta.num_accepted_tokens,
             )
-            core_spec = _zero_padded_recurrent_output(
-                core_spec,
-                attn_metadata.spec_query_start_loc,
-            )
 
         core_non_spec = None
         if mixed_non_spec is not None and mixed_non_spec.shape[0] > 0:
@@ -707,28 +681,11 @@ class AscendKimiK3DeltaAttention(KimiK3DeltaAttention):
                     attn_metadata.non_spec_state_indices_tensor,
                 )
 
-        if core_non_spec is not None:
-            assert attn_metadata.non_spec_query_start_loc is not None
-            core_non_spec = _zero_padded_recurrent_output(
-                core_non_spec,
-                attn_metadata.non_spec_query_start_loc,
-            )
-
         if core_spec is None and core_non_spec is None:
             # Idle DP dummy runs carry graph-shaped metadata with no live work.
             # Do not feed a previous replay's output through the norm gate.
             core_attn_out.zero_()
             return
-
-        num_live_tokens = None
-        if core_spec is not None:
-            assert attn_metadata.spec_query_start_loc is not None
-            num_live_tokens = attn_metadata.spec_query_start_loc[-1]
-        if core_non_spec is not None:
-            assert attn_metadata.non_spec_query_start_loc is not None
-            num_non_spec_tokens = attn_metadata.non_spec_query_start_loc[-1]
-            num_live_tokens = num_non_spec_tokens if num_live_tokens is None else num_live_tokens + num_non_spec_tokens
-        assert num_live_tokens is not None
 
         # Reuse the caller-owned result buffer. FULL graphs can leave rows
         # outside the live spec/non-spec index sets, so define them before the
@@ -748,7 +705,5 @@ class AscendKimiK3DeltaAttention(KimiK3DeltaAttention):
         # The registered Ascend FusedRMSNormGated uses the fused norm-gate
         # kernel while preserving the upstream parameter/loading contract.
         normalized = self.o_norm(core_attn_out[:, :num_actual_tokens], g2)
-        # Mask again after the norm gate: zero * sigmoid(NaN) is still NaN in
-        # static padding rows whose captured gate values are not live.
-        core_attn_out[:, :num_actual_tokens].copy_(_zero_padded_output(normalized, num_live_tokens))
+        core_attn_out[:, :num_actual_tokens].copy_(normalized)
         core_attn_out[:, num_actual_tokens:].zero_()


### PR DESCRIPTION
### What this PR does / why we need it?

Reduce small-operator overhead around Kimi K3 recurrent KDA on `releases/v0.27.1rc` by optimizing preprocessing copies and removing redundant framework padding cleanup after KDA and the output norm gate.

- **Before KDA:** consume supported non-contiguous Q/K/V views from the fused projection directly, eliminating forced contiguous copies. Independent token/head strides flow through ACLNN, tiling, and the A2/A3 and A5 kernels. Unsupported layouts still materialize.
- **After KDA and norm:** delete `_zero_padded_recurrent_output` on spec/non-spec outputs and `_zero_padded_output` after `o_norm`, including the now-unused live-token count calculation. These removals eliminate the corresponding `arange / comparison / where` chains, profiled as `Range / Less / Fill / SelectV2`. Norm output is copied directly into the existing result buffer.
- Preserve state updates, mixed-token index copies, idle/dummy handling, and buffer initialization. No new kernel interface, switch, or replacement mask is needed.

The deleted masks sanitize padding after recurrent state computation; the norm gate operates independently per token/head row. Padding rows inside the graph-shaped region no longer have a zero-value guarantee. Effective token computation is unchanged.

### Does this PR introduce _any_ user-facing change?

Performance optimization of Kimi K3 KDA preprocessing and postprocessing. The Torch operator schema and contiguous-input behavior remain unchanged.

### How was this patch tested?

- Accuracy validation (reported by the project owner): **GPQA Avg@5: 93.03**.

- Added spec/decode/mixed framework regression cases with NaN padding, checking effective output rows, state updates, and output-buffer tail initialization.
- All three cases passed on each branch in an isolated CPU harness executing the actual `_forward` and `_prepare_beta` bodies with mocked kernel/context dependencies (six cases total). This is not a full package or NPU test run.
- Ruff check/format, Python AST parsing, `git diff --check`, and repository forbidden-import, boolean-context-manager, and long-function checks passed.
- The project owner previously bypassed the padding masks and reported successful runtime validation. Full-model/NPU validation and profiling were not rerun for these commits.
- Full `format.sh ci` was attempted on main and stopped during actionlint environment installation; the full lint suite did not complete.
- The direct recurrent-operator regression covers distinct Q/K/V strides, non-contiguous state pools, guard holes, and numerical reference checks.

- vLLM main: https://github.com/vllm-project/vllm/commit/ba07e4a48fc951300d97eb506217dd530583dea3
