### PR TITLE
[Ops][310P] Run MTP speculative decoding under ACL graph capture

### DIFF
--- a/vllm_ascend/_310p/attention/attention_mask.py
+++ b/vllm_ascend/_310p/attention/attention_mask.py
@@ -70,6 +70,20 @@ class AttentionMaskBuilder310:
         return mask
 
     @classmethod
+    def build_splitfuse_mask_nz_from_host(cls, q_list: list, c_list: list, device: torch.device):
+        """
+        Same mask as get_splitfuse_mask, but takes host-side query/context length
+        lists so it can run in the metadata builder (outside any graph capture);
+        get_splitfuse_mask's query_start_loc/seq_lens D2H reads are illegal there.
+        """
+        if cls.chunked_prefill_attn_mask is None:
+            cls.chunked_prefill_attn_mask = cls.gen_causal_additive_mask(cls.max_seqlen, device)
+        pos_list = [p for ql, cl in zip(q_list, c_list) for p in range(cl - ql, cl)]
+        position = torch.tensor(pos_list, dtype=torch.int32, device=device)
+        splitfuse_mask = cls.chunked_prefill_attn_mask.index_select(0, position)
+        return torch_npu.npu_format_cast(nd_to_nz_spec(splitfuse_mask).contiguous(), ACL_FORMAT_FRACTAL_NZ)
+
+    @classmethod
     def get_splitfuse_mask(cls, attn_metadata: AscendMetadata, device: torch.device):
         """
         Generates and formats the attention mask for SplitFuse (chunked prefill) decoding.

--- a/vllm_ascend/_310p/attention/attention_v1.py
+++ b/vllm_ascend/_310p/attention/attention_v1.py
@@ -31,6 +31,7 @@ from vllm_ascend._310p.attention.attention_mask import (
 from vllm_ascend._310p.attention.metadata_builder import (
     AscendAttentionMetadataBuilder310,
     get_query_lens_cpu,
+    get_splitfuse_mask_nz,
 )
 from vllm_ascend.attention.attention_v1 import (
     AscendAttentionBackend,
@@ -219,7 +220,15 @@ class AscendAttentionBackendImpl310(AscendAttentionBackendImpl):
         Returns:
             The output tensor after flash attention.
         """
-        real_tokens = int(attn_metadata.seq_lens.sum().item())
+        # seq_lens.sum().item() is a synchronous D2H copy, which ACL
+        # forbids inside a graph capture (the drafter is captured whole under FULL).
+        # num_actual_tokens is the same quantity already available on the host -- the
+        # sibling splitfuse path below reads it the same way.
+        _nat = getattr(attn_metadata, "num_actual_tokens", None)
+        if _nat is not None:
+            real_tokens = int(_nat)
+        else:
+            real_tokens = int(attn_metadata.seq_lens.sum().item())
         seq_len = attn_metadata.seq_lens
         aligned_tokens = int(query.shape[0])
         delta = aligned_tokens - real_tokens
@@ -289,8 +298,11 @@ class AscendAttentionBackendImpl310(AscendAttentionBackendImpl):
             )
             return output
 
-        # Generate the specific mask for splitfuse
-        mask = AttentionMaskBuilder310.get_splitfuse_mask(attn_metadata, query.device)
+        # Prefer the mask precomputed in the metadata builder (capture-safe);
+        # building it here does sync copies that abort an ACL graph capture.
+        mask = get_splitfuse_mask_nz(attn_metadata)
+        if mask is None:
+            mask = AttentionMaskBuilder310.get_splitfuse_mask(attn_metadata, query.device)
         torch_npu._npu_paged_attention_splitfuse(
             query=query,
             key_cache=self.key_cache,

--- a/vllm_ascend/_310p/attention/metadata_builder.py
+++ b/vllm_ascend/_310p/attention/metadata_builder.py
@@ -34,11 +34,21 @@ from vllm_ascend.attention.attention_v1 import (
 from vllm_ascend.attention.utils import AscendCommonAttentionMetadata
 
 QUERY_LENS_CPU_ATTR = "query_lens_cpu"
+SPLITFUSE_MASK_NZ_ATTR = "splitfuse_mask_nz"
+
+# Batches at or below this token count may be graph-captured (spec-decode /
+# decode sizes); their mask must live in a stable-address buffer the builder
+# refreshes before every replay. Larger (eager-only) batches skip the copy.
+_MASK_PERSISTENT_MAX_TOKENS = 64
 
 
 def set_query_lens_cpu(attn_metadata: AscendMetadata, query_lens_cpu: torch.Tensor) -> None:
     """Attach host qLens for ATB splitfuse without extending upstream AscendMetadata."""
     setattr(attn_metadata, QUERY_LENS_CPU_ATTR, query_lens_cpu)
+
+
+def get_splitfuse_mask_nz(attn_metadata: AscendMetadata) -> torch.Tensor | None:
+    return getattr(attn_metadata, SPLITFUSE_MASK_NZ_ATTR, None)
 
 
 def get_query_lens_cpu(attn_metadata: AscendMetadata) -> torch.Tensor | None:
@@ -84,6 +94,8 @@ class AscendAttentionMetadataBuilder310(AscendAttentionMetadataBuilder):
         if device.type != "cpu":
             max_num_seqs = vllm_config.scheduler_config.max_num_seqs
             self._query_lens_cpu_buffer = torch.empty(max_num_seqs, dtype=torch.int32, device="cpu", pin_memory=True)
+        # Stable-address NZ mask buffers, one per captured batch size (see build()).
+        self._splitfuse_mask_bufs: dict[int, torch.Tensor] = {}
 
     def _fill_query_lens_cpu(
         self, num_reqs: int, query_start_loc_cpu: torch.Tensor, is_drafting: bool = False
@@ -144,6 +156,29 @@ class AscendAttentionMetadataBuilder310(AscendAttentionMetadataBuilder):
 
         if is_compressed_mask_supported():
             attn_metadata.attn_mask = AttentionMaskBuilder310.get_compressed_splitfuse_mask(self.device)
+        else:
+            # Build the per-step splitfuse mask here, outside the forward: the
+            # forward-time get_splitfuse_mask does sync D2H/H2D copies that abort
+            # an ACL graph capture. For capture-sized batches the mask content is
+            # copied into a stable-address buffer so replays see fresh values.
+            q_list = get_query_lens_cpu(attn_metadata).tolist()
+            num_tokens = int(sum(q_list))
+            seq_lens_cpu = common_attn_metadata.seq_lens_cpu
+            if seq_lens_cpu is None:
+                # Capture dummy_run path: build() runs before the captured region,
+                # so this D2H is legal; mask content is refreshed by real builds.
+                seq_lens_cpu = attn_metadata.seq_lens.cpu()
+            c_list = seq_lens_cpu[:num_reqs].tolist()
+            mask_nz = AttentionMaskBuilder310.build_splitfuse_mask_nz_from_host(q_list, c_list, self.device)
+            if num_tokens <= _MASK_PERSISTENT_MAX_TOKENS:
+                buf = self._splitfuse_mask_bufs.get(num_tokens)
+                if buf is None:
+                    buf = mask_nz
+                    self._splitfuse_mask_bufs[num_tokens] = buf
+                else:
+                    buf.copy_(mask_nz)
+                mask_nz = buf
+            setattr(attn_metadata, SPLITFUSE_MASK_NZ_ATTR, mask_nz)
 
         return attn_metadata
 

--- a/vllm_ascend/_310p/model_runner_310p.py
+++ b/vllm_ascend/_310p/model_runner_310p.py
@@ -66,6 +66,22 @@ _NGRAM_GRAPH_UNIFORM_DECODE_QUERY_LEN = 1
 _ATTENTION_BLOCK_SIZE_LIMIT = 128 * 128
 
 
+def _is_stream_capturing() -> bool:
+    # Runtime truth first: the context flags are not set during the drafter's
+    # capture, so they cannot be relied on here.
+    try:
+        if torch.npu.is_current_stream_capturing():
+            return True
+    except Exception:
+        pass
+    try:
+        from vllm_ascend.ascend_forward_context import _EXTRA_CTX
+
+        return bool(getattr(_EXTRA_CTX, "capturing", False))
+    except Exception:
+        return False
+
+
 class NPUModelRunner310(NPUModelRunner):
     """
     310P model runner with a distinct ACL graph capture/replay contract from 910B:
@@ -642,6 +658,12 @@ class NPUModelRunner310(NPUModelRunner):
             and not self.enable_enpu
             and forward_context.cudagraph_runtime_mode == CUDAGraphMode.FULL
             and not forward_context.capturing
+            # the capture flag is set on _EXTRA_CTX in the v2 aclgraph
+            # path (worker/v2/aclgraph_utils.py:171). If only that one is set this
+            # guard passes and we call stream.synchronize() inside an ACL capture ->
+            # "Not allow to synchronize captured-stream" (plog 107027), which surfaces
+            # later as the 107030 memcpy failure. Check both flags.
+            and not _is_stream_capturing()
             and hasattr(self, "update_stream")
         )
 

--- a/vllm_ascend/_310p/quantization/modelslim_config.py
+++ b/vllm_ascend/_310p/quantization/modelslim_config.py
@@ -26,6 +26,7 @@ from vllm.model_executor.layers.linear import LinearBase
 from vllm.model_executor.layers.quantization import register_quantization_config
 from vllm.model_executor.layers.quantization.base_config import QuantizeMethodBase
 from vllm.model_executor.layers.vocab_parallel_embedding import (
+    ParallelLMHead,
     VocabParallelEmbedding,
 )
 
@@ -130,6 +131,21 @@ class AscendModelSlimConfig310(AscendModelSlimConfig):
 
         elif isinstance(layer, VocabParallelEmbedding):
             from vllm_ascend._310p.ops.vocab_parallel_embedding import AscendUnquantizedEmbeddingMethod310
+
+            # A ParallelLMHead is mathematically a linear layer; when the checkpoint
+            # quantizes it (lm_head.weight != FLOAT), route it to the linear scheme so
+            # the int8 weight + deq_scale/input_scale params are created and loaded.
+            if isinstance(layer, ParallelLMHead) and not self.is_layer_skipped_ascend(
+                prefix, getattr(self, "packed_modules_mapping", {})
+            ):
+                scheme = create_scheme_for_layer(
+                    quant_description=self.quant_description,
+                    prefix=prefix,
+                    layer_type="linear",
+                    packed_modules_mapping=getattr(self, "packed_modules_mapping", {}),
+                )
+                logger.debug("Select AscendLinearMethod for %s (layer=%s)", prefix, "ParallelLMHead")
+                return AscendLinearMethod(scheme)
 
             logger.debug(
                 "Select AscendUnquantizedEmbeddingMethod310 for %s (layer=%s)", prefix, "VocabParallelEmbedding"

--- a/vllm_ascend/compilation/acl_graph.py
+++ b/vllm_ascend/compilation/acl_graph.py
@@ -33,6 +33,13 @@ _STREAM_RESOURCE_ERROR_MARKERS = (
 _OLD_HDK_CAPTURE_ERROR_MARKERS = ("alloc sq cq fail",)
 
 
+def _is_stream_capturing() -> bool:
+    try:
+        return bool(torch.npu.is_current_stream_capturing())
+    except Exception:
+        return False
+
+
 def _is_stream_resource_capture_error(exc: RuntimeError) -> bool:
     message = str(exc)
     lowered_message = message.lower()
@@ -261,7 +268,13 @@ class ACLGraphWrapper:
         # When FULL + EAGLE draft (merge path), replay does not need this barrier.
         is_draft_eagle = _EXTRA_CTX.is_draft_model and self.use_eagle
         need_sync = self.runtime_mode == CUDAGraphMode.FULL and not is_draft_eagle
-        if not self.enable_enpu and need_sync:
+        # never synchronize a stream that is being captured -- ACL
+        # rejects it ("Not allow to synchronize captured-stream", plog 107027) and
+        # it surfaces later as a 107030 memcpy failure. This replay-ordering
+        # barrier is only meaningful outside capture anyway. The existing
+        # `is_draft_eagle` exemption does not cover MTP, whose drafter replays
+        # from inside the target's capture region.
+        if not self.enable_enpu and need_sync and not _is_stream_capturing():
             torch.npu.current_stream().synchronize()
         entry.aclgraph.replay()
         return entry.output

--- a/vllm_ascend/worker/model_runner_v1.py
+++ b/vllm_ascend/worker/model_runner_v1.py
@@ -3682,10 +3682,15 @@ class NPUModelRunner(GPUModelRunner):
                 self.dcp_manager.query_lens_full.copy_to_gpu()
         if cudagraph_runtime_mode is None:
             cudagraph_runtime_mode = _cudagraph_mode
-        else:
-            assert cudagraph_runtime_mode == _cudagraph_mode, (
-                f"Cudagraph runtime mode mismatch in dummy_run. "
-                f"Expected {_cudagraph_mode}, but got {cudagraph_runtime_mode}."
+        elif cudagraph_runtime_mode != _cudagraph_mode:
+            # with spec decode the batch descriptor carries draft-token
+            # slots, so the dispatcher does not recognise the padded size and returns
+            # NONE while capture_model is deliberately capturing PIECEWISE. The caller
+            # is the authority during capture -- honour it instead of asserting.
+            logger.warning(
+                "dummy_run cudagraph mode: dispatcher=%s caller=%s; using caller",
+                _cudagraph_mode,
+                cudagraph_runtime_mode,
             )
         num_tokens_padded = batch_desc.num_tokens
         num_reqs_padded = batch_desc.num_reqs if batch_desc.num_reqs is not None else num_reqs


### PR DESCRIPTION
### What this does

Makes MTP speculative decoding runnable under ACL graph capture on 310P. Four separate
host round-trips / ordering assumptions aborted the capture with
`107030 the current capture mode does not support this operation` (a `107027`
"Not allow to synchronize captured-stream" underneath):

| site | problem | fix |
|---|---|---|
| `compilation/acl_graph.py` | the FULL replay barrier calls `stream.synchronize()`; its only exemption is `is_draft_model and use_eagle`, which MTP doesn't satisfy — so it ran *inside* the capture | skip the barrier whenever the stream is actually capturing |
| `_310p/model_runner_310p.py` | the update-stream guard checked `forward_context.capturing`, but the v2 aclgraph path sets the flag on `_EXTRA_CTX` — guard passed, `synchronize()` ran inside capture | check both flags |
| `_310p/attention/attention_v1.py` | `seq_lens.sum().item()` is a synchronous D2H | read `num_actual_tokens`, the same quantity already on the host |
| `_310p/attention/attention_mask.py`, `metadata_builder.py` | the splitfuse mask was built in the forward with `.cpu()`/`.tolist()` + H2D | build it in `AscendAttentionMetadataBuilder310.build()` (host side, before the captured region); for ≤64-token batches `copy_` the content into a stable-address per-size buffer so replays read fresh values from the address the graph captured |

The capture dummy path has `seq_lens_cpu=None`, where the D2H fallback in `build()` is legal
because `build()` runs before the captured region. The forward keeps its old path when the
precomputed attribute is absent.

Also included: `get_quant_method` sent every `VocabParallelEmbedding` — `ParallelLMHead`
among them — to the unquantized embedding method, so a checkpoint with a quantized
`lm_head` failed to load (`no module or parameter named 'lm_head.deq_scale'`). A quantized
head is now routed to the linear W8A8 scheme. This is a precondition for the numbers below:
the drafter reads the head once per draft step, so a float head dominates draft cost.
Unquantized heads are unaffected.

### Measured

Qwen3.5-9B W8A8, 310P, BS=1, real prompts, greedy:

| config | ms/token |
|---|---|
| MTP k=2, PIECEWISE | 43.33 |
| MTP k=2, FULL_DECODE_ONLY | **40.04** |
| MTP k=3, FULL_DECODE_ONLY | **37.86** |

Output text is identical to the eager runs, so the replayed mask content is correct.

### Effect outside 310P

Two touched files are not 310P-gated, and both changes are inert elsewhere:

- `_is_stream_capturing()` returns `False` outside a capture, so the replay barrier behaves
  exactly as before on every existing path.
- The `dummy_run` change softens an `assert` into a warning for one case: spec-decode draft
  slots make the dispatcher not recognise the padded batch descriptor, so it returns `NONE`
  while `capture_model` is deliberately capturing `PIECEWISE`. The caller is the authority
  during capture. Without spec decode the two always agree and the branch is unreachable.

### History

This content was previously #14566, which I closed as superseded by #13122. #13122 has since
been rebuilt on a clean base as a kernel-only PR (its diff touches no runner, graph or
attention files), so none of this survived there. Reopening it standalone.

### Gates run locally

`python -m py_compile` on all six touched files and `codespell` with the repo's `-L` ignore
list — both clean. `ruff` / `typos` not run (no Linux toolchain on the prep machine). Opening
as a draft: the numbers are from a local 310P box and CI has not built this yet.

- vLLM main: https://github.com/vllm-project/vllm/commit/b2f685834a6456197e7033966fdef52a23f1abcd
