### PR TITLE
[BugFix][Doc] Avoid bisect module shadowing in RTD build

### DIFF
--- a/tools/generate_zh_docs.py
+++ b/tools/generate_zh_docs.py
@@ -6,7 +6,7 @@ the .po files in docs/source/locale/zh_CN/LC_MESSAGES/ to produce
 Chinese markdown files under docs/source/zh/.
 
 Usage:
-    python tools/generate_zh_docs.py
+    python -m tools.generate_zh_docs
 """
 
 import sys

--- a/tools/rtd_build.sh
+++ b/tools/rtd_build.sh
@@ -53,7 +53,7 @@ if [ "$DOCS_LANG" = "zh" ]; then
     # mkdocs so the generated sources exist when mkdocs scans
     # DOCS_DIR.
     echo "[rtd-build] Generating Chinese sources from .po files..."
-    python tools/generate_zh_docs.py
+    python -m tools.generate_zh_docs
 
     # Mirror shared static assets into the Chinese DOCS_DIR. mkdocs resolves
     # `extra_css` and other static paths relative to DOCS_DIR, so anything


### PR DESCRIPTION
### What this PR does / why we need it?

The Chinese Read the Docs build failed in [build #34446759](https://app.readthedocs.org/projects/vllm-ascend-cn/builds/34446759/) with:

```text
ImportError: cannot import name 'bisect' from 'bisect' (.../tools/bisect/__init__.py)
```

`tools/rtd_build.sh` invoked the Chinese documentation generator by file path:

```bash
python tools/generate_zh_docs.py
```

That puts the repository's `tools/` directory first on `sys.path`. After enough translation patterns are compiled, the `regex` package shrinks its cache and imports `random`. Python's `random` module imports `bisect`, but the repository package `tools/bisect` is resolved instead of the standard-library module, causing the build to fail.

Run the generator as a module so the repository root, rather than `tools/`, is the import root:

```bash
python -m tools.generate_zh_docs
```

The usage example in `tools/generate_zh_docs.py` is updated to match.

### Does this PR introduce _any_ user-facing change?

No. This only fixes the Chinese documentation build entry point.

### How was this patch tested?

- Reproduced build #34446759 from commit `a00d01b214d1c0a4bfd4a68a78c5f7b6540b08b1`: the original file-path invocation exits with the same `bisect` import error.
- Re-ran the same failing source tree with the module invocation; Chinese source generation and the full strict MkDocs build completed successfully.
- Ran on the latest `main` base:

  ```bash
  pytest -q tests/ut/_tools/test_generate_zh_docs.py --confcutdir=tests/ut/_tools
  DOCS_LANG=zh SITE_DIR=/tmp/vllm-ascend-site bash tools/rtd_build.sh
  ```

  Results: 7 tests passed; the strict Chinese documentation build passed.

- Ran `bash format.sh ci`: all available checks passed except `gitleaks-offline-scan`, whose fallback could not run on the local macOS host because it downloads a Linux x86-64 binary.

- vLLM main: https://github.com/vllm-project/vllm/commit/b2f685834a6456197e7033966fdef52a23f1abcd
