### PR TITLE
[Test][Misc] Check DSV4 700 TPS nightly boundary

### DIFF
--- a/.github/workflows/configs/nightly_config.yaml
+++ b/.github/workflows/configs/nightly_config.yaml
@@ -106,6 +106,10 @@ a3:
         config_file_path: DeepSeek-V4-Pro-w4a8-prefix-cache-PD.yaml
         config_base_path: tests/e2e/nightly/multi_node/external_dp/config
         size: 4
+      - name: ryk-dsv4pro-700-boundary
+        config_file_path: ryk-dsv4pro-700-boundary.yaml
+        config_base_path: tests/e2e/nightly/multi_node/external_dp/config
+        size: 4
       - name: GLM-5.1-w8a8c8-128k-1k-90-50-PD
         config_file_path: GLM-5.1-W8A8C8-128k-1k-90-50-PD.yaml
         config_base_path: tests/e2e/nightly/multi_node/external_dp/config

--- a/tests/e2e/nightly/multi_node/external_dp/config/ryk-dsv4pro-700-boundary.yaml
+++ b/tests/e2e/nightly/multi_node/external_dp/config/ryk-dsv4pro-700-boundary.yaml
@@ -1,0 +1,349 @@
+# Diagnostic-only test of the vllm-ascend source actually installed by
+# the 2026-09-03 approximately 707 TPS community Nightly run.
+# Keep all server and workload parameters identical to the official case.
+# A short 48 -> 40 -> 32 -> 48 sequence stays below the one-hour barrier
+# while retaining two batch-size-48 measurements for drift control.
+test_name: "ryk-dsv4pro-700-boundary"
+model: "Eco-Tech/DeepSeek-V4-Pro-w4a8-mtp"
+num_nodes: 4
+npu_per_node: 16
+
+routing:
+  type: "disaggregated_prefill"
+  groups:
+    prefiller: [ 0, 1 ]
+    decoder: [ 2, 3 ]
+
+config:
+  - node_index: 0
+    port_start: 7100
+    dp_rpc_port: 12321
+    dp_size: 4
+    dp_size_local: 2
+    dp_rank_start: 0
+    tp_size: 8
+    dp_address: "${NODE_0_IP}"
+
+  - node_index: 1
+    port_start: 7100
+    dp_rpc_port: 12321
+    dp_size: 4
+    dp_size_local: 2
+    dp_rank_start: 2
+    tp_size: 8
+    dp_address: "${NODE_0_IP}"
+
+  - node_index: 2
+    port_start: 7100
+    dp_rpc_port: 12321
+    dp_size: 16
+    dp_size_local: 8
+    dp_rank_start: 0
+    tp_size: 2
+    dp_address: "${NODE_2_IP}"
+
+  - node_index: 3
+    port_start: 7100
+    dp_rpc_port: 12321
+    dp_size: 16
+    dp_size_local: 8
+    dp_rank_start: 8
+    tp_size: 2
+    dp_address: "${NODE_2_IP}"
+
+env_common: &env_common
+  VLLM_USE_MODELSCOPE: "true"
+  SERVER_PORT: "${PORT}"
+  ASCEND_RT_VISIBLE_DEVICES: "${VISIBLE_DEVICES}"
+  VLLM_RPC_TIMEOUT: "3600000"
+  VLLM_EXECUTE_MODEL_TIMEOUT_SECONDS: "30000"
+  HCCL_EXEC_TIMEOUT: "204"
+  OMP_PROC_BIND: "false"
+  OMP_NUM_THREADS: "10"
+  PYTORCH_NPU_ALLOC_CONF: "expandable_segments:True"
+  TASK_QUEUE_ENABLE: "1"
+  HCCL_OP_EXPANSION_MODE: "AIV"
+
+env_prefill: &env_prefill
+  <<: *env_common
+  HCCL_CONNECT_TIMEOUT: "6000"
+  HCCL_BUFFSIZE: "1024"
+  VLLM_ASCEND_ENABLE_FLASHCOMM1: "1"
+  VLLM_PREFIX_CACHE_RETENTION_INTERVAL: "4096"
+
+env_decode: &env_decode
+  <<: *env_common
+  HCCL_CONNECT_TIMEOUT: "1200"
+  HCCL_BUFFSIZE: "1800"
+
+templates:
+  - node_index: 0
+    envs:
+      <<: *env_prefill
+    server_cmd_template:
+      - --host
+      - "0.0.0.0"
+      - --port
+      - $SERVER_PORT
+      - --data-parallel-size
+      - ${DP_SIZE}
+      - --data-parallel-rank
+      - ${DP_RANK}
+      - --data-parallel-address
+      - ${DP_ADDRESS}
+      - --data-parallel-rpc-port
+      - ${DP_RPC_PORT}
+      - --tensor-parallel-size
+      - ${TP_SIZE}
+      - --enable-expert-parallel
+      - --seed
+      - "1024"
+      - --max-model-len
+      - "204800"
+      - --max-num-batched-tokens
+      - "4096"
+      - --max-num-seqs
+      - "16"
+      - --no-disable-hybrid-kv-cache-manager
+      - --tokenizer-mode
+      - "deepseek_v4"
+      - --tool-call-parser
+      - "deepseek_v4"
+      - --enable-auto-tool-choice
+      - --reasoning-parser
+      - "deepseek_v4"
+      - --model-loader-extra-config
+      - '{"enable_multithread_load": true, "num_threads": 128}'
+      - --trust-remote-code
+      - --gpu-memory-utilization
+      - "0.94"
+      - --quantization
+      - "ascend"
+      - --block-size
+      - "32"
+      - --enforce-eager
+      - --speculative-config
+      - '{"num_speculative_tokens": 1,"method": "mtp"}'
+      - --additional-config
+      - '{"enable_cpu_binding": true, "enable_dsa_cp": true,"enable_fused_mc2":1}'
+      - --kv-transfer-config
+      - '{"kv_connector": "MooncakeHybridConnector", "kv_role": "kv_producer", "kv_port": "30100", "engine_id": "1", "kv_connector_extra_config": {"prefill": {"dp_size": 4, "tp_size": 8}, "decode": {"dp_size": 16, "tp_size": 2}}}'
+
+  - node_index: 1
+    envs:
+      <<: *env_prefill
+    server_cmd_template:
+      - --host
+      - "0.0.0.0"
+      - --port
+      - $SERVER_PORT
+      - --data-parallel-size
+      - ${DP_SIZE}
+      - --data-parallel-rank
+      - ${DP_RANK}
+      - --data-parallel-address
+      - ${DP_ADDRESS}
+      - --data-parallel-rpc-port
+      - ${DP_RPC_PORT}
+      - --tensor-parallel-size
+      - ${TP_SIZE}
+      - --enable-expert-parallel
+      - --seed
+      - "1024"
+      - --max-model-len
+      - "204800"
+      - --max-num-batched-tokens
+      - "4096"
+      - --max-num-seqs
+      - "16"
+      - --no-disable-hybrid-kv-cache-manager
+      - --tokenizer-mode
+      - "deepseek_v4"
+      - --tool-call-parser
+      - "deepseek_v4"
+      - --enable-auto-tool-choice
+      - --reasoning-parser
+      - "deepseek_v4"
+      - --model-loader-extra-config
+      - '{"enable_multithread_load": true, "num_threads": 128}'
+      - --trust-remote-code
+      - --gpu-memory-utilization
+      - "0.94"
+      - --quantization
+      - "ascend"
+      - --block-size
+      - "32"
+      - --enforce-eager
+      - --speculative-config
+      - '{"num_speculative_tokens": 1,"method": "mtp"}'
+      - --additional-config
+      - '{"enable_cpu_binding": true, "enable_dsa_cp": true,"enable_fused_mc2":1}'
+      - --kv-transfer-config
+      - '{"kv_connector": "MooncakeHybridConnector", "kv_role": "kv_producer", "kv_port": "30100", "engine_id": "1", "kv_connector_extra_config": {"prefill": {"dp_size": 4, "tp_size": 8}, "decode": {"dp_size": 16, "tp_size": 2}}}'
+
+  - node_index: 2
+    envs:
+      <<: *env_decode
+    server_cmd_template:
+      - --host
+      - "0.0.0.0"
+      - --port
+      - $SERVER_PORT
+      - --data-parallel-size
+      - ${DP_SIZE}
+      - --data-parallel-rank
+      - ${DP_RANK}
+      - --data-parallel-address
+      - ${DP_ADDRESS}
+      - --data-parallel-rpc-port
+      - ${DP_RPC_PORT}
+      - --tensor-parallel-size
+      - ${TP_SIZE}
+      - --enable-expert-parallel
+      - --seed
+      - "1024"
+      - --max-model-len
+      - "204800"
+      - --max-num-batched-tokens
+      - "120"
+      - --max-num-seqs
+      - "30"
+      - --async-scheduling
+      - --block-size
+      - "32"
+      - --no-enable-prefix-caching
+      - --tokenizer-mode
+      - "deepseek_v4"
+      - --tool-call-parser
+      - "deepseek_v4"
+      - --enable-auto-tool-choice
+      - --reasoning-parser
+      - "deepseek_v4"
+      - --no-disable-hybrid-kv-cache-manager
+      - --model-loader-extra-config
+      - '{"enable_multithread_load": true, "num_threads": 128}'
+      - --trust-remote-code
+      - --speculative-config
+      - '{"num_speculative_tokens": 3,"method": "mtp"}'
+      - --gpu-memory-utilization
+      - "0.95"
+      - --quantization
+      - "ascend"
+      - --compilation-config
+      - '{"cudagraph_mode": "FULL_DECODE_ONLY"}'
+      - --kv-transfer-config
+      - '{"kv_connector": "MooncakeHybridConnector", "kv_role": "kv_consumer", "kv_port": "30800", "engine_id": "8", "kv_connector_extra_config": {"prefill": {"dp_size": 4, "tp_size": 8}, "decode": {"dp_size": 16, "tp_size": 2}}}'
+      - --additional-config
+      - '{"ascend_compilation_config":{"enable_npugraph_ex":true,"enable_static_kernel":false},"enable_cpu_binding":true,"multistream_overlap_shared_expert":true,"recompute_scheduler_enable":true}'
+
+  - node_index: 3
+    envs:
+      <<: *env_decode
+    server_cmd_template:
+      - --host
+      - "0.0.0.0"
+      - --port
+      - $SERVER_PORT
+      - --data-parallel-size
+      - ${DP_SIZE}
+      - --data-parallel-rank
+      - ${DP_RANK}
+      - --data-parallel-address
+      - ${DP_ADDRESS}
+      - --data-parallel-rpc-port
+      - ${DP_RPC_PORT}
+      - --tensor-parallel-size
+      - ${TP_SIZE}
+      - --enable-expert-parallel
+      - --seed
+      - "1024"
+      - --max-model-len
+      - "204800"
+      - --max-num-batched-tokens
+      - "120"
+      - --max-num-seqs
+      - "30"
+      - --async-scheduling
+      - --block-size
+      - "32"
+      - --no-enable-prefix-caching
+      - --tokenizer-mode
+      - "deepseek_v4"
+      - --tool-call-parser
+      - "deepseek_v4"
+      - --enable-auto-tool-choice
+      - --reasoning-parser
+      - "deepseek_v4"
+      - --no-disable-hybrid-kv-cache-manager
+      - --model-loader-extra-config
+      - '{"enable_multithread_load": true, "num_threads": 128}'
+      - --trust-remote-code
+      - --speculative-config
+      - '{"num_speculative_tokens": 3,"method": "mtp"}'
+      - --gpu-memory-utilization
+      - "0.95"
+      - --quantization
+      - "ascend"
+      - --compilation-config
+      - '{"cudagraph_mode": "FULL_DECODE_ONLY"}'
+      - --kv-transfer-config
+      - '{"kv_connector": "MooncakeHybridConnector", "kv_role": "kv_consumer", "kv_port": "30800", "engine_id": "8", "kv_connector_extra_config": {"prefill": {"dp_size": 4, "tp_size": 8}, "decode": {"dp_size": 16, "tp_size": 2}}}'
+      - --additional-config
+      - '{"ascend_compilation_config":{"enable_npugraph_ex":true,"enable_static_kernel":false},"enable_cpu_binding":true,"multistream_overlap_shared_expert":true,"recompute_scheduler_enable":true}'
+
+benchmarks:
+  perf_TPOT50_128k_1_prefix_warmup:
+    case_type: performance
+    dataset_path: vllm-ascend/GSM8K-in128k-bs512-prefix90-ds
+    request_conf: vllm_api_stream_chat
+    dataset_conf: gsm8k/gsm8k_gen_0_shot_cot_str_perf
+    num_prompts: 4
+    max_out_len: 1
+    batch_size: 4
+    request_rate: 0
+    baseline: 0
+    threshold: 0.95
+  perf_TPOT50_128k_1_prefix90_bs48_r1:
+    case_type: performance
+    dataset_path: vllm-ascend/GSM8K-in128k-bs512-prefix90-ds
+    request_conf: vllm_api_stream_chat
+    dataset_conf: gsm8k/gsm8k_gen_0_shot_cot_str_perf
+    num_prompts: 192
+    max_out_len: 1024
+    batch_size: 48
+    request_rate: 1
+    baseline: 0
+    threshold: 0.95
+  perf_TPOT50_128k_1_prefix90_bs40:
+    case_type: performance
+    dataset_path: vllm-ascend/GSM8K-in128k-bs512-prefix90-ds
+    request_conf: vllm_api_stream_chat
+    dataset_conf: gsm8k/gsm8k_gen_0_shot_cot_str_perf
+    num_prompts: 192
+    max_out_len: 1024
+    batch_size: 40
+    request_rate: 1
+    baseline: 0
+    threshold: 0.95
+  perf_TPOT50_128k_1_prefix90_bs32:
+    case_type: performance
+    dataset_path: vllm-ascend/GSM8K-in128k-bs512-prefix90-ds
+    request_conf: vllm_api_stream_chat
+    dataset_conf: gsm8k/gsm8k_gen_0_shot_cot_str_perf
+    num_prompts: 192
+    max_out_len: 1024
+    batch_size: 32
+    request_rate: 1
+    baseline: 0
+    threshold: 0.95
+  perf_TPOT50_128k_1_prefix90_bs48_r2:
+    case_type: performance
+    dataset_path: vllm-ascend/GSM8K-in128k-bs512-prefix90-ds
+    request_conf: vllm_api_stream_chat
+    dataset_conf: gsm8k/gsm8k_gen_0_shot_cot_str_perf
+    num_prompts: 192
+    max_out_len: 1024
+    batch_size: 48
+    request_rate: 1
+    baseline: 0
+    threshold: 0.95


### PR DESCRIPTION
### What this PR does / why we need it?

This draft PR is a temporary four-node experiment carrier for locating the second DeepSeek-V4-Pro W4A8 prefix-cache PD Nightly performance regression. It must not be merged.

The historical endpoint must be defined by the source actually installed inside the CI container, not by the workflow repository HEAD:

- September 3: workflow HEAD `3546357838389aa7201d9b44e234f831e98b2fd4`, installed vllm-ascend `42e039a90215a0c111330a7081178cd1207cc14d`, vLLM `6e448d0e`, Output TPS `707.5901`.
- September 4: workflow HEAD `748acedf`, installed vllm-ascend `93c3fd643747468efa276b6c15c8b9c5df0f1a3b`, vLLM `6e448d0e`, Output TPS `647.9569`.

This branch is therefore intentionally based on the exact installed last-known-good vllm-ascend source:

`42e039a90215a0c111330a7081178cd1207cc14d`

The diagnostic case is:

`ryk-dsv4pro-700-boundary`

It keeps the official service topology, model, dataset, server arguments, 192 prompts, 128K input / 1K output, 90% repeated prefix, and request rate 1. The workload is:

1. Four-request warmup.
2. Batch size 48, round 1.
3. Batch size 40.
4. Batch size 32.
5. Batch size 48, round 2.

The two batch-size-48 measurements provide beginning/end drift control. The 40 and 32 points retain a compact view of the concurrency curve without repeating the six-leg mirrored sweep from PR #15932. Four formal measurements should also remain safely below the one-hour external-DP follower barrier that invalidated the final legs of that earlier sweep.

Diagnostic thresholds are non-blocking (`baseline: 0`) so every completed measurement is retained. The primary gate question is:

> Does vllm-ascend `42e039a9` recover the approximately 700 token/s plateau when run in the current community CI software environment?

Interpretation:

- Both 48-concurrency measurements complete 192/192 near 700 with no more than 3% spread: the second-stage source boundary is supported; continue controlled endpoint validation and then bisect `42e039a9..93c3fd64`.
- Both 48-concurrency measurements complete 192/192 near 650: do not blame that source interval yet; compare the September 3 historical image/environment because current vLLM, CI image, CANN/runtime, dependencies, or hardware placement may have drifted.
- The 40 and 32 points describe the concurrency curve and latency trade-off; single measurements at those settings are not sufficient by themselves to select a permanent Nightly concurrency.
- Infrastructure, startup, or partial-request failures are invalid measurements and must not be classified as bad-source results.

This PR does not reproduce the complete September 3 environment: the historical endpoint used vLLM `6e448d0e`, while the current CI environment may install a newer vLLM. It therefore provides a code-in-current-environment gate, not final causal proof.

It does not investigate the earlier approximately 869-to-700 cross-stack gap, and it does not propose a permanent Nightly concurrency or baseline change.

Requested trigger:

`/nightly ryk-dsv4pro-700-boundary`

### Does this PR introduce any user-facing change?

No. Temporary diagnostic Nightly coverage only; do not merge.

### How was this patch tested?

- Confirmed the diagnostic commit parent is exactly `42e039a90215a0c111330a7081178cd1207cc14d`.
- Parsed the registry and diagnostic YAML with PyYAML.
- Asserted the benchmark order is exactly warmup, 48, 40, 32, 48.
- Compared all non-benchmark YAML sections with the official case; they are equal except for `test_name`.
- Ran `git diff --check`.
- No NPU execution was performed locally; community Nightly CI is the experiment.
- vLLM main: https://github.com/vllm-project/vllm/commit/b2f685834a6456197e7033966fdef52a23f1abcd
