### PR TITLE
[BugFix][Spec Decode] Recompute draft DP counts during profiling

### DIFF
--- a/.github/workflows/scripts/test_config.yaml
+++ b/.github/workflows/scripts/test_config.yaml
@@ -196,6 +196,7 @@ estimated_times:
   tests/e2e/pull_request/four_card/context_parallel/test_deepseek_v4.py: 520
   tests/e2e/pull_request/four_card/context_parallel/test_prefix_caching_cp.py: 210
   tests/e2e/pull_request/four_card/model_runner_v2/test_deepseek_v4.py: 520
+  tests/e2e/pull_request/four_card/model_runner_v2/test_spec_decode_data_parallel.py: 600
   tests/e2e/pull_request/four_card/rlhf/consistency/test_batch_invariant_tp4.py: 210
   tests/e2e/pull_request/four_card/spec_decode/test_mtp_qwen3_next.py: 730
   tests/e2e/pull_request/four_card/spec_decode/test_dspark_deepseekv4.py: 1280

--- a/tests/e2e/pull_request/four_card/model_runner_v2/test_spec_decode_data_parallel.py
+++ b/tests/e2e/pull_request/four_card/model_runner_v2/test_spec_decode_data_parallel.py
@@ -59,8 +59,8 @@ PROMPTS = [
 def test_deepseek_v4_dspark_spec_decoding_dp4_full_graph() -> None:
     with DPVllmRunner(
         DEEPSEEK_V4_DSPARK_MODEL,
-        data_parallel_size=4,
-        tensor_parallel_size=1,
+        data_parallel_size=2,
+        tensor_parallel_size=2,
         max_model_len=4096,
         max_num_seqs=2,
         max_num_batched_tokens=512,

--- a/tests/e2e/pull_request/four_card/model_runner_v2/test_spec_decode_data_parallel.py
+++ b/tests/e2e/pull_request/four_card/model_runner_v2/test_spec_decode_data_parallel.py
@@ -1,0 +1,93 @@
+# Copyright (c) 2026 Huawei Technologies Co., Ltd. All Rights Reserved.
+# Copyright 2026 The vLLM team.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# This file is a part of the vllm-ascend project.
+
+"""DSpark speculative decoding under DP with Model Runner V2."""
+
+import os
+from unittest.mock import patch
+
+import pytest
+
+from tests.e2e.conftest import DPVllmRunner, wait_until_npu_memory_free
+
+DEEPSEEK_V4_DSPARK_MODEL = os.environ.get(
+    "DEEPSEEK_V4_DSPARK_MODEL_PATH",
+    "UploadWeight/DeepSeek-V4-Flash-DSpark-w4a8-test",
+)
+
+PROMPTS = [
+    "Hello, my name is",
+    "The president of the United States is",
+    "The capital of France is",
+    "The future of AI is",
+]
+
+
+@pytest.mark.e2e_model(DEEPSEEK_V4_DSPARK_MODEL)
+@pytest.mark.e2e_coverage(
+    arch="moe",
+    feature="dspark",
+    parallel="DP,EP",
+    deploy="pd_mix",
+    hardware="A3",
+    quantization="W4A8",
+    graph_mode="full_decode_only",
+)
+@patch.dict(
+    os.environ,
+    {
+        "VLLM_USE_V2_MODEL_RUNNER": "1",
+        "VLLM_WORKER_MULTIPROC_METHOD": "spawn",
+        "PYTORCH_NPU_ALLOC_CONF": "expandable_segments:True",
+        "HCCL_BUFFSIZE": "2048",
+    },
+)
+@wait_until_npu_memory_free(target_free_percentage=0.8)
+def test_deepseek_v4_dspark_spec_decoding_dp4_full_graph() -> None:
+    with DPVllmRunner(
+        DEEPSEEK_V4_DSPARK_MODEL,
+        data_parallel_size=4,
+        tensor_parallel_size=1,
+        max_model_len=4096,
+        max_num_seqs=2,
+        max_num_batched_tokens=512,
+        enable_expert_parallel=True,
+        tokenizer_mode="deepseek_v4",
+        block_size=128,
+        distributed_executor_backend="mp",
+        gpu_memory_utilization=0.8,
+        quantization="ascend",
+        enforce_eager=False,
+        async_scheduling=True,
+        enable_prefix_caching=False,
+        speculative_config={
+            "method": "dspark",
+            "num_speculative_tokens": 5,
+            "enforce_eager": True,
+        },
+        compilation_config={
+            "cudagraph_mode": "FULL_DECODE_ONLY",
+            "cudagraph_capture_sizes": [6, 12],
+        },
+        additional_config={
+            "enable_dsa_cp": False,
+            "enable_fused_mc2": 0,
+        },
+    ) as vllm_model:
+        outputs = vllm_model.generate_greedy(PROMPTS, max_tokens=32)
+
+    assert len(outputs) == len(PROMPTS)
+    assert all(output_ids and output_text.strip() for output_ids, output_text in outputs)

--- a/tests/e2e/pull_request/four_card/model_runner_v2/test_spec_decode_data_parallel.py
+++ b/tests/e2e/pull_request/four_card/model_runner_v2/test_spec_decode_data_parallel.py
@@ -68,7 +68,7 @@ def test_deepseek_v4_dspark_spec_decoding_dp4_full_graph() -> None:
         tokenizer_mode="deepseek_v4",
         block_size=128,
         distributed_executor_backend="mp",
-        gpu_memory_utilization=0.8,
+        gpu_memory_utilization=0.93,
         quantization="ascend",
         enforce_eager=False,
         async_scheduling=True,

--- a/vllm_ascend/worker/v2/spec_decode/dflash/speculator.py
+++ b/vllm_ascend/worker/v2/spec_decode/dflash/speculator.py
@@ -132,6 +132,8 @@ class AscendDFlashSpeculator(DFlashSpeculator):
             # Profiling runs the draft with its own query token count, which
             # can differ from the target batch. Let forward_context coordinate
             # the actual draft counts instead of reusing the target DP state.
+            # TODO: Remove this guard once main2main includes upstream vLLM
+            # #54856 (facd9a74a1), which resets the profiling DP counts.
             sync_state = None
         with build_attn_metadata_wrapper():
             return super().propose(

--- a/vllm_ascend/worker/v2/spec_decode/dflash/speculator.py
+++ b/vllm_ascend/worker/v2/spec_decode/dflash/speculator.py
@@ -128,6 +128,11 @@ class AscendDFlashSpeculator(DFlashSpeculator):
     ) -> torch.Tensor:
         self.input_batch = input_batch
         sync_state = num_tokens_across_dp if vllm_version_is("0.28.0") else dp_sync
+        if dummy_run and skip_attn_for_dummy_run:
+            # Profiling runs the draft with its own query token count, which
+            # can differ from the target batch. Let forward_context coordinate
+            # the actual draft counts instead of reusing the target DP state.
+            sync_state = None
         with build_attn_metadata_wrapper():
             return super().propose(
                 input_batch,

--- a/vllm_ascend/worker/v2/spec_decode/dspark/speculator.py
+++ b/vllm_ascend/worker/v2/spec_decode/dspark/speculator.py
@@ -180,6 +180,11 @@ class AscendDSparkSpeculator(DSparkSpeculator):
         self.input_batch = input_batch
         assert self.input_batch is not None
         sync_state = num_tokens_across_dp if vllm_version_is("0.28.0") else dp_sync
+        if dummy_run and skip_attn_for_dummy_run:
+            # Profiling runs the draft with its own query token count, which
+            # can differ from the target batch. Let forward_context coordinate
+            # the actual draft counts instead of reusing the target DP state.
+            sync_state = None
         with (
             build_attn_metadata_wrapper(),
             build_draft_attn_metadata_factory(

--- a/vllm_ascend/worker/v2/spec_decode/dspark/speculator.py
+++ b/vllm_ascend/worker/v2/spec_decode/dspark/speculator.py
@@ -184,6 +184,8 @@ class AscendDSparkSpeculator(DSparkSpeculator):
             # Profiling runs the draft with its own query token count, which
             # can differ from the target batch. Let forward_context coordinate
             # the actual draft counts instead of reusing the target DP state.
+            # TODO: Remove this guard once main2main includes upstream vLLM
+            # #54856 (facd9a74a1), which resets the profiling DP counts.
             sync_state = None
         with (
             build_attn_metadata_wrapper(),


### PR DESCRIPTION
### What this PR does / why we need it?

Fix DP token-count reuse during the initial memory profiling pass of the V2 DSpark and DFlash speculators. A target-model DP synchronization describes the token counts of that particular forward pass. Reusing it for a draft forward with a different input length causes engine initialization to fail.

Upstream vLLM already fixes the profiling argument in [#54856](https://github.com/vllm-project/vllm/pull/54856) (`facd9a74a1`). However, Ascend main currently pins `.github/vllm-main-verified.commit` to `b2f685834a6456197e7033966fdef52a23f1abcd`, which predates that fix and still forwards the target counts. This adaptation covers the current verified baseline and older affected vLLM revisions. With the upstream fix present, the parent already ignores the profiling DP state.

**TODO (main2main cleanup):** Once vLLM-Ascend's main2main integration and verified vLLM baseline include upstream [vllm-project/vllm#54856](https://github.com/vllm-project/vllm/pull/54856) (`facd9a74a1cd1b9fed324cdc2cceb8d54fdad3d0`), remove the temporary profiling guards from both `AscendDSparkSpeculator.propose()` and `AscendDFlashSpeculator.propose()` and rely on the upstream profiling path.

The call chain is:

1. `profile_run()` calls `_dummy_run(..., skip_attn=True, is_profile=True)`.
2. The target forward coordinates its per-rank token counts and produces `dp_sync`.
3. The runner passes this state to the draft `propose()` with `dummy_run=True` and `skip_attn_for_dummy_run=True`.
4. The parallel drafter computes its own query length. DFlash uses `num_reqs * (K + 1)`; DSpark with `sample_from_anchor=True` uses `num_reqs * K`.
5. The upstream profiling branch calls `_generate_draft()` with that draft length but forwards `dp_sync.num_tokens_across_dp` from the target.
6. `set_forward_context()` passes these inconsistent values to `DPMetadata.make()`, whose local token-count assertion fails.

This was observed on A5 with DP4 and DSpark: 64 requests and K=5 produced 320 draft tokens while the reused target count was 384, resulting in `AssertionError: 384 320`. DFlash can hit the same issue even though its query length is K+1: a 4096-token profiling batch with 64 requests and K=5 has only 384 draft query tokens. Matching lengths in a uniform decode batch do not guarantee matching lengths during memory profiling.

Both Ascend wrappers now pass `None` as the synchronization state only when `dummy_run and skip_attn_for_dummy_run`. This lets `set_forward_context()` coordinate the actual draft token counts across DP ranks. It does not disable DP synchronization or mutate the target state. Normal inference and graph warmup keep their existing state forwarding.

Eagle3 and MTP do not need this adjustment: their shared autoregressive path preserves the target batch shape for the first draft step and performs a fresh DP synchronization for the later one-token decode steps. This change does not address graph-padding index handling.

### Does this PR introduce _any_ user-facing change?

V2 DSpark/DFlash DP deployments can complete memory profiling when the target and draft input lengths differ. No CLI or configuration changes are required.

### How was this patch tested?

- Reproduced the DSpark `384 320` assertion on A5, then verified that the profiling guard allows startup to proceed. The local DeepSeek-V4-Flash-DSpark V2 DP4/EP deployment subsequently completed a real chat request and all 1319 GSM8K requests with zero failed requests. That runtime checkout also contained separate FP8 operator compatibility fixes; those are outside this PR.
- Executed the upstream DFlash and autoregressive `propose()` functions in an isolated CPU check with model kernels and collectives mocked. With 64 requests and K=5, a 4096-token target forwarded stale counts to DFlash's 384-token draft; Eagle3/MTP reused counts only for their shape-preserving first step and synchronized the later step independently. This is not a DFlash end-to-end NPU test.
- No test files are included in this PR.

Local runtime validation used vLLM `e6bfe03ad73a3330cb427885aa90d97a12e1c704`.

Local guard/existing DSpark checks: **26 passed** on Ascend `3d27bd866` with its verified vLLM revision `b2f685834a6456197e7033966fdef52a23f1abcd`. These checks cover both wrappers, target counts 384/4096, with/without DP state, and profiling versus ordinary/graph-warmup calls. They were run locally and are not part of the PR. The isolated test environment used the image's NPU Triton import compatibility shim.

The two changed files pass Ruff lint and formatting checks. Full repository hook validation remains incomplete locally because the actionlint environment is still downloading its Go toolchain; this is separate from the Python checks above.

- vLLM main: https://github.com/vllm-project/vllm/commit/b2f685834a6456197e7033966fdef52a23f1abcd
