### PR TITLE
[BugFix][KDA] Allocate Post-WU workspace for padded chunks

### DIFF
--- a/csrc/attention/chunk_kda_fwd/op_host/chunk_kda_fwd_tiling.cpp
+++ b/csrc/attention/chunk_kda_fwd/op_host/chunk_kda_fwd_tiling.cpp
@@ -268,7 +268,11 @@ ge::graphStatus Tiling4ChunkKdaFwd(gert::TilingContext *context)
 
     const uint64_t postWuScratchOffset = AlignWorkspace(cursor);
     if (!arch35Options.fusePostWu && !arch35Options.fusePostWuIntoFwdH) {
-        cursor = postWuScratchOffset + tokenHeads * shape.kDim * sizeof(float);
+        // WScratchOffset stores each chunk with chunkSize rows, including
+        // padding for short sequences. Packed token counts underallocate this
+        // region and let full-chunk writes overwrite the following workspace.
+        cursor = postWuScratchOffset + hChunkCount * shape.vHeads * chunkSize *
+            shape.kDim * sizeof(float);
     }
 
     const uint64_t fwdHWorkspaceBaseOffset = AlignWorkspace(cursor);

--- a/tests/e2e/nightly/single_node/ops/singlecard_ops/test_chunk_kda_aclnn.py
+++ b/tests/e2e/nightly/single_node/ops/singlecard_ops/test_chunk_kda_aclnn.py
@@ -575,6 +575,7 @@ def test_chunk_kda_fwd_padded_workspace_matches_reference(seq_count, fixed_lengt
             output_final_state=True,
         )
         _assert_close(f"sequence {seq} output", actual[0][:, start:end], reference.o, rtol=5e-2, atol=5e-4)
+        assert reference.final_state is not None
         _assert_close(
             f"sequence {seq} final state",
             actual[1][seq : seq + 1],

--- a/tests/e2e/nightly/single_node/ops/singlecard_ops/test_chunk_kda_aclnn.py
+++ b/tests/e2e/nightly/single_node/ops/singlecard_ops/test_chunk_kda_aclnn.py
@@ -516,6 +516,75 @@ def _canonical_chunk_indices(cu_seqlens, chunk_size):
     ]
 
 
+@pytest.mark.parametrize("disable_recompute", [False, True])
+@pytest.mark.parametrize("seq_count,fixed_length", [(127, None), (128, None), (1, 80), (1, 129)])
+def test_chunk_kda_fwd_padded_workspace_matches_reference(seq_count, fixed_length, disable_recompute):
+    """Full chunks must not overwrite U seeds when other chunks contain padding."""
+    torch.manual_seed(1000 + seq_count)
+    heads, head_dim, chunk_size = 6, 128, 64
+    lengths = (
+        [fixed_length] if fixed_length is not None else [16, 32, 64] * (seq_count // 3) + [16, 32, 64][: seq_count % 3]
+    )
+    cu_seqlens = [0]
+    for length in lengths:
+        cu_seqlens.append(cu_seqlens[-1] + length)
+    shape = (1, cu_seqlens[-1], heads, head_dim)
+    q = torch.nn.functional.normalize(torch.randn(shape), dim=-1).to(torch.bfloat16)
+    k = torch.nn.functional.normalize(torch.randn(shape), dim=-1).to(torch.bfloat16)
+    v = (torch.randn(shape) * 0.1).to(torch.bfloat16)
+    raw_gate = torch.randn(shape) * 0.1
+    beta = torch.sigmoid(torch.randn(shape[:-1]))
+    initial_state = torch.zeros((seq_count, heads, head_dim, head_dim), dtype=torch.float32)
+    metadata = cu_seqlens if fixed_length is None else None
+
+    outputs = torch.ops._C_ascend.chunk_kda_fwd(
+        q.npu(),
+        k.npu(),
+        v.npu(),
+        raw_gate.npu(),
+        beta.npu(),
+        head_dim**-0.5,
+        chunk_size,
+        initial_state=initial_state.npu(),
+        output_final_state=True,
+        cu_seqlens=metadata,
+        chunk_indices=_canonical_chunk_indices(metadata, chunk_size),
+        safe_gate=True,
+        lower_bound=-5.0,
+        use_gate_in_kernel=True,
+        A_log=torch.zeros(heads, device="npu", dtype=torch.float32),
+        dt_bias=torch.zeros(heads * head_dim, device="npu", dtype=torch.float32),
+        disable_recompute=disable_recompute,
+        state_v_first=True,
+    )
+    actual = _snapshot_outputs(outputs)
+    for name, output in zip(CHUNK_KDA_OUTPUT_NAMES, actual):
+        if output is not None:
+            assert torch.isfinite(output).all(), name
+
+    gate = _gate_cumsum_reference(-5.0 * torch.sigmoid(raw_gate), chunk_size, cu_seqlens)
+    for seq, (start, end) in enumerate(zip(cu_seqlens[:-1], cu_seqlens[1:])):
+        reference = chunk_kda_forward_reference(
+            q[:, start:end],
+            k[:, start:end],
+            v[:, start:end],
+            gate[:, start:end],
+            beta[:, start:end],
+            head_dim**-0.5,
+            chunk_size,
+            output_final_state=True,
+        )
+        _assert_close(f"sequence {seq} output", actual[0][:, start:end], reference.o, rtol=5e-2, atol=5e-4)
+        _assert_close(
+            f"sequence {seq} final state",
+            actual[1][seq : seq + 1],
+            reference.final_state.transpose(-1, -2),
+            rtol=5e-2,
+            atol=3e-3,
+        )
+    _cleanup_npu()
+
+
 def _run_chunk_kda_fwd_a5_case(
     layout,
     tokens,


### PR DESCRIPTION
### What this PR does / why we need it?

`chunk_kda_fwd` allocates Post-WU scratch using the packed token count, but `WScratchOffset` addresses it using `total_chunks * chunk_size`. When sequences contain tails, full-chunk Cube writes can overrun this allocation and corrupt the U seed buffer that is still in use. This produces NaN outputs/states and can lead to all-invalid speculative sampling rows (`valid_sampled_tokens_count=0`).

For example, 127 sequences alternating between 16, 32 and 64 tokens contain 4,720 tokens. With six heads and K=128, the old allocation is 14,499,840 bytes, while the padded layout requires 24,969,216 bytes. Allocate scratch using the padded chunk count, matching both the generic and A5 addressing. This also covers fixed-length inputs with a partial final chunk.

Add regression coverage for 127/128 variable-length sequences and fixed lengths 80/129, with both recompute modes, comparing outputs and final states against an independent CPU reference.

### Does this PR introduce _any_ user-facing change?

Fixes incorrect KDA outputs and downstream sampling errors for affected sequence batches. No API or configuration change.

### How was this patch tested?

On Ascend A3 with CANN 9.1.0:

- Replayed the same saved failing operator inputs twice before and after rebuilding only the tiling library. Before: U contained 22,612 NaNs and 316 Infs. After: all 12 returned tensors were finite; inputs were unchanged.
- New regression matrix: 8 passed. Restoring the old library makes `[127-None-True]` fail; the fixed library was restored afterward.
- Full `test_chunk_kda_aclnn.py`: 21 passed, 5 A5-specific cases skipped.
- `bash format.sh ci` and `git diff --check` passed.

Full-service validation on a single A3 node uses TP16/EP16, a 16-expert Kimi K3 target, GQA DSpark with 7 speculative tokens, prefix caching disabled, and `max_num_seqs=256`. All three phases reached 128 concurrent running requests and passed: 128 short requests with 256 output tokens, 512 mixed 16/32/64-token prompts with 128 output tokens, and another 256 mixed requests after removing the diagnostic hooks. Total: 896/896 HTTP 200 responses and 131,072 output tokens, with no missing/nonfinite selected logprobs or service errors. Each of the 16 ranks recorded 718 steps and 73,631 request rows during the first two phases: valid counts stayed in 1–8, with zero undiscarded count-zero rows and no unconsumed trace steps. Every phase ended with no running/waiting requests; final health returned 200.

The before/after service runs use the same separate sampler-sort memory fix; the standalone operator tests directly exercise this KDA change. These pruned-weight runs validate the reported count-zero/service-failure behavior, not model accuracy.

The NPU-tested sources are byte-identical to the files in this PR. The release branch advanced from `91b905364` to `9a3a8fdeb` during validation with Docker/CI-only changes.

- vLLM main: https://github.com/vllm-project/vllm/commit/ba07e4a48fc951300d97eb506217dd530583dea3
