### PR TITLE
[BugFix][Quantization] Pad odd MXFP4 MoE weight scale dimensions

### DIFF
--- a/tests/ut/quantization/methods/test_w4a4_mxfp4.py
+++ b/tests/ut/quantization/methods/test_w4a4_mxfp4.py
@@ -118,6 +118,29 @@ class TestAscendW4A4MXFP4MoEMethod(TestBase):
             self.assertEqual(result["w13_weight_scale"].dtype, torch.uint8)
             self.assertEqual(result["w2_weight_scale"].dtype, torch.uint8)
 
+    def test_process_weights_preserves_scales_with_odd_group_counts(self):
+        for group_counts in [(4, 11), (3, 8), (3, 11), (4, 8)]:
+            with self.subTest(group_counts=group_counts):
+                layer = nn.Module()
+                original_scales = {}
+                for name, groups in zip(("w13", "w2"), group_counts):
+                    weight = torch.randint(0, 255, (2, 8, groups * 16), dtype=torch.uint8)
+                    scale = torch.randint(1, 255, (2, 8, groups), dtype=torch.uint8)
+                    setattr(layer, f"{name}_weight", nn.Parameter(weight, requires_grad=False))
+                    setattr(layer, f"{name}_weight_scale", nn.Parameter(scale.clone(), requires_grad=False))
+                    original_scales[name] = scale
+
+                self.scheme.process_weights_after_loading(layer)
+
+                for name, original in original_scales.items():
+                    groups = original.shape[-1]
+                    actual = getattr(layer, f"{name}_weight_scale")
+                    self.assertEqual(actual.shape, (2, (groups + 1) // 2, 8, 2))
+                    restored = actual.transpose(1, 2).flatten(-2)
+                    torch.testing.assert_close(restored[..., :groups], original)
+                    if groups % 2:
+                        self.assertEqual(torch.count_nonzero(restored[..., -1]).item(), 0)
+
     def test_process_weights_transposes_weights(self):
         layer = nn.Module()
         layer.w13_weight = nn.Parameter(torch.randint(0, 255, (8, 256, 64), dtype=torch.uint8), requires_grad=False)

--- a/vllm_ascend/quantization/methods/w4a4/w4a4_mxfp4.py
+++ b/vllm_ascend/quantization/methods/w4a4/w4a4_mxfp4.py
@@ -251,8 +251,14 @@ class AscendW4A4MXFP4DynamicFusedMoEMethod(AscendMoEScheme):
         _rename_packed_weight_parameter(layer, "w2_weight")
 
         g_num, n_size, k_size = layer.w13_weight_scale.shape
+        if k_size % 2 != 0:
+            layer.w13_weight_scale.data = F.pad(layer.w13_weight_scale.data, (0, 1), value=0)
+            k_size += 1
         layer.w13_weight_scale.data = layer.w13_weight_scale.data.reshape(g_num, n_size, k_size // 2, 2)
         g_num, n_size, k_size = layer.w2_weight_scale.shape
+        if k_size % 2 != 0:
+            layer.w2_weight_scale.data = F.pad(layer.w2_weight_scale.data, (0, 1), value=0)
+            k_size += 1
         layer.w2_weight_scale.data = layer.w2_weight_scale.data.reshape(g_num, n_size, k_size // 2, 2)
         # The A5 MXFP4 fused grouped-matmul-swiglu op relies on the
         # transpose stride to interpret packed FP4 weights as logical K.


### PR DESCRIPTION
### What this PR does / why we need it?

Gemma4 MoE W4A4 MXFP4 loading with TP=2 fails when the down-projection weight scale has shape `[128, 2816, 11]`: the current reshape truncates the odd group count and attempts `[128, 2816, 5, 2]`.

Pad an odd final scale dimension with one zero before pairing scales for both `w13` and `w2`, following the existing linear method. The production change adds six lines and preserves the existing transpose layout and even-dimension behavior.

The unchecked reshape dates back to #7877. #12201 addressed the analogous linear case but left the MoE path unchanged.

### Does this PR introduce _any_ user-facing change?

Yes. MXFP4 MoE checkpoints with odd scale group counts can pass this weight-scale reshape during loading. No CLI or configuration changes.

### How was this patch tested?

- Added `test_process_weights_preserves_scales_with_odd_group_counts` in `tests/ut/quantization/methods/test_w4a4_mxfp4.py`, covering odd/even combinations, preserved scale values, and zero padding.
- CPU isolation validation extracted the actual production post-loading method and added regression test via Python AST, avoiding unavailable vLLM/NPU imports. Three odd-dimension cases failed before the fix; all four combinations passed after it. The exact reported scale shape also passed and became `[128, 6, 2816, 2]` after transpose.
- Ruff check, Ruff format check, and `git diff --check` passed for the changed files.
- Full pytest was not run because pytest is unavailable locally. `bash format.sh ci` was attempted but blocked by missing pre-commit.
- NPU kernels and real-weight server startup/inference have not been validated; hardware validation remains needed.

- vLLM main: https://github.com/vllm-project/vllm/commit/b2f685834a6456197e7033966fdef52a23f1abcd
