### PR TITLE
[Cherry-pick][releases/v0.27.1rc][BugFix][KV Pool] Restore TP-mismatch transfer wiring for AscendStoreConnector (from #15835)

### DIFF
--- a/tests/ut/distributed/ascend_store/test_pool_worker.py
+++ b/tests/ut/distributed/ascend_store/test_pool_worker.py
@@ -614,6 +614,8 @@ class TestKVPoolWorkerRegisterAndTransfer(unittest.TestCase):
 
         self.assertEqual(send_thread.call_args.args[2], worker.grouped_block_size)
         self.assertEqual(recv_thread.call_args.args[2], worker.grouped_block_size)
+        self.assertIsNone(send_thread.call_args.kwargs["worker"])
+        self.assertIsNone(recv_thread.call_args.kwargs["worker"])
         event.return_value.wait.assert_called()
 
     def test_register_kv_caches_initializes_layerwise_memcache(self):
@@ -1518,6 +1520,7 @@ class TestKVPoolWorkerTpMismatch(unittest.TestCase):
             config.model_config.hf_text_config.index_topk = 32
         else:
             config.model_config.hf_text_config = MagicMock(spec=[])  # no index_topk
+            config.model_config.hf_text_config.num_hidden_layers = 36
         config.model_config.get_num_layers.return_value = 36
         config.model_config.get_total_num_kv_heads.return_value = num_kv_heads
         config.model_config.max_model_len = 4096
@@ -1610,6 +1613,78 @@ class TestKVPoolWorkerTpMismatch(unittest.TestCase):
         self.assertEqual(worker.local_heads_per_rank, 4)
         self.assertEqual(worker.effective_heads_per_rank, 2)
         self.assertEqual(worker.num_sub_keys, 2)
+
+    def test_tp_mismatch_detected_for_both_roles_and_tp_directions(self):
+        cases = [
+            ("kv_consumer", 2, "prefill_tp_size", 4, 2),
+            ("kv_consumer", 4, "prefill_tp_size", 2, 1),
+            ("kv_producer", 2, "decode_tp_size", 4, 2),
+            ("kv_producer", 4, "decode_tp_size", 2, 1),
+        ]
+        for kv_role, local_tp, peer_key, peer_tp, expected_sub_keys in cases:
+            with self.subTest(kv_role=kv_role, local_tp=local_tp, peer_tp=peer_tp):
+                worker = self._make_worker(
+                    tp_size=local_tp,
+                    kv_role=kv_role,
+                    extra_config={"backend": "mooncake", peer_key: peer_tp},
+                    num_kv_heads=8,
+                )
+                self.assertTrue(worker.tp_mismatch)
+                self.assertEqual(worker.effective_tp_size, 4)
+                self.assertEqual(worker.num_sub_keys, expected_sub_keys)
+
+    @patch("vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.pool_worker.threading.Event")
+    @patch("vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.pool_worker.KVCacheStoreRecvingThread")
+    @patch("vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.pool_worker.KVCacheStoreSendingThread")
+    def test_transfer_threads_receive_worker_when_tp_mismatch(self, send_thread, recv_thread, event):
+        worker = self._make_worker(
+            tp_size=2,
+            kv_role="kv_consumer",
+            extra_config={
+                "backend": "mooncake",
+                "prefill_tp_size": 4,
+                "consumer_is_to_put": True,
+                "load_async": True,
+            },
+            num_kv_heads=8,
+        )
+
+        worker._start_kv_transfer_threads()
+
+        self.assertIs(send_thread.call_args.kwargs["worker"], worker)
+        self.assertIs(recv_thread.call_args.kwargs["worker"], worker)
+        event.return_value.wait.assert_called()
+
+    def test_start_load_kv_sync_dispatches_tp_mismatch_reader(self):
+        worker = self._make_strided_worker()
+        worker.grouped_block_size = [4]
+        worker.m_store = MagicMock()
+        worker._load_kv_tp_mismatch = MagicMock()
+        load_spec = LoadSpec(
+            vllm_cached_tokens=4,
+            kvpool_cached_tokens=8,
+            can_load=True,
+            token_len=8,
+        )
+        request = ReqMeta(
+            req_id="r1",
+            token_len_chunk=8,
+            block_ids_by_group=[[10, 11]],
+            block_hashes=[b"h0", b"h1"],
+            load_spec=load_spec,
+        )
+        metadata = AscendConnectorMetadata(set())
+        metadata.add_request(request)
+
+        worker.start_load_kv(metadata)
+
+        worker._load_kv_tp_mismatch.assert_called_once_with(
+            [b"h0", b"h1"],
+            [10, 11],
+            8,
+            4,
+        )
+        worker.m_store.get.assert_not_called()
 
     def test_register_kv_caches_initializes_tp_mismatch_strides(self):
         worker = self._make_worker(

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/pool_worker.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/pool_worker.py
@@ -582,6 +582,7 @@ class KVPoolWorker:
                     ready_event_sending,
                     self.group_uses_align_state,
                     self.enable_kv_events,
+                    worker=self if self.tp_mismatch else None,
                 )
                 self.kv_send_thread.start()
                 ready_event_sending.wait()
@@ -597,6 +598,7 @@ class KVPoolWorker:
                     ready_event,
                     invalid_block_ids=self._invalid_block_ids,
                     invalid_block_ids_lock=self._invalid_block_ids_lock,
+                    worker=self if self.tp_mismatch else None,
                 )
                 self.kv_recv_thread.start()
                 ready_event.wait()
@@ -894,6 +896,18 @@ class KVPoolWorker:
             if self.load_async:
                 self.kv_recv_thread.add_request(  # type: ignore[union-attr]
                     request,
+                )
+                continue
+
+            if self.tp_mismatch:
+                # TP mismatch is restricted to non-hybrid, single-group KV.
+                group_block_size = self.grouped_block_size[0]
+                mask_num = load_spec.vllm_cached_tokens // group_block_size * group_block_size
+                self._load_kv_tp_mismatch(
+                    request.block_hashes,
+                    request.block_ids_by_group[0],
+                    token_len,
+                    mask_num,
                 )
                 continue
 


### PR DESCRIPTION
Cherry-pick of PR #15835 onto `releases/v0.27.1rc`.

Original PR: #15835
Original author: @lhecust721

---
### What this PR does / why we need it?

This backport restores the production wiring for the TP-mismatch strided KV load/store paths in `AscendStoreConnector`. The specialized split/merge helpers remained present after the KV Pool initialization and load-dispatch refactor in #11444, but their production entry points were no longer connected.

This PR:

- passes the worker to `KVCacheStoreSendingThread` under TP mismatch, restoring strided PUT;
- passes the worker to `KVCacheStoreRecvingThread` under TP mismatch, restoring asynchronous strided GET dispatch;
- routes synchronous TP-mismatch loads through `_load_kv_tp_mismatch()` instead of the regular GET path;
- checks `load_async` before the synchronous mismatch branch so asynchronous loads enter the receiving-thread queue;
- keeps `worker=None` for same-TP configurations, preserving the regular path.

The support boundary is unchanged from #11582: dense GQA with a single KV cache group. MLA, hybrid KV layouts, sparse KV, and layerwise transfer are not enabled by this backport.

Refs #15842.

### Does this PR introduce _any_ user-facing change?

Yes. Existing `AscendStoreConnector` TP-mismatch configurations on v0.27.1rc again use the specialized strided load/store paths. There is no configuration schema or public API change.

### How was this patch tested?

- Cherry-pick applied cleanly to the latest `releases/v0.27.1rc` head.
- Python syntax compilation passed for both changed files.
- `git diff --check` passed.
- The resulting diff contains only the two files from the original PR: 14 production-code lines and 75 unit-test lines.
- The original PR passed targeted unit tests, the repository CPU unit-test workflow, and Ascend A2 E2E coverage for P2/D1 MultiConnector, P2/D1 synchronous and asynchronous AscendStore-only transfer, P1/D2 lower-TP reads, and P2/D2 same-TP regression.
- Release-specific CI and NPU E2E validation remain to be completed on this backport.

- vLLM main: https://github.com/vllm-project/vllm/commit/ba07e4a48fc951300d97eb506217dd530583dea3
