### PR TITLE
[MRV2][Performance][Kernel] Optimize V2 slot mappings on Ascend

### DIFF
--- a/benchmarks/ops/compare_slot_mapping_cases.sh
+++ b/benchmarks/ops/compare_slot_mapping_cases.sh
@@ -1,0 +1,108 @@
+#!/usr/bin/env bash
+# Compare upstream and Ascend slot-mapping kernels one case per msprof process.
+#
+# Usage:
+#   bash benchmarks/ops/compare_slot_mapping_cases.sh \
+#     /home/lingmutian/tmp/slot_mapping_compare_cases.json \
+#     /home/lingmutian/profile_dir/slot_mapping_compare
+
+set -euo pipefail
+
+readonly SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+readonly REPO_ROOT="$(cd -- "${SCRIPT_DIR}/../.." && pwd)"
+readonly DEFAULT_INPUT_FILE="/home/lingmutian/tmp/slot_mapping_compare_cases.json"
+readonly DEFAULT_PROFILE_ROOT="/home/lingmutian/profile_dir/slot_mapping_compare"
+readonly KERNEL_NAME="_compute_slot_mappings_kernel"
+
+input_file="${1:-${DEFAULT_INPUT_FILE}}"
+profile_root="${2:-${DEFAULT_PROFILE_ROOT}}"
+python_bin="${PYTHON_BIN:-python}"
+
+if [[ ! -f "${input_file}" ]]; then
+    echo "Input file does not exist: ${input_file}" >&2
+    exit 1
+fi
+
+mkdir -p "${profile_root}"
+result_file="${profile_root}/task_duration_us.tsv"
+summary_file="${profile_root}/summary.tsv"
+printf 'case\timplementation\tgrid\ttask_duration_us\tmsprof_log\n' > "${result_file}"
+
+mapfile -t case_names < <("${python_bin}" - "${input_file}" <<'PY'
+import json
+import sys
+
+for case in json.load(open(sys.argv[1], encoding="utf-8")):
+    print(case["name"])
+PY
+)
+
+cd "${REPO_ROOT}"
+for case_name in "${case_names[@]}"; do
+    for implementation in upstream ascend; do
+        if [[ "${implementation}" == "upstream" ]]; then
+            wrapper="benchmarks/ops/slot_mapping_compare_wrappers.py:launch_upstream"
+        else
+            wrapper="benchmarks/ops/slot_mapping_compare_wrappers.py:launch_ascend"
+        fi
+
+        profile_dir="${profile_root}/${implementation}_${case_name}"
+        log_file="${profile_root}/${implementation}_${case_name}.log"
+        echo "Profiling ${implementation}/${case_name}"
+        msprof op \
+            --output="${profile_dir}" \
+            --aic-metrics=MemoryDetail,Occupancy,PipeUtilization,Roofline \
+            --kernel-name="${KERNEL_NAME}" \
+            --application="${python_bin} benchmarks/ops/benchmark_wrapper.py \
+                --input-file ${input_file} \
+                --wrapper ${wrapper} \
+                --mode wrapper \
+                --kernel ${KERNEL_NAME} \
+                --case-name ${case_name} \
+                --device npu:0 \
+                --warmup 20 \
+                --profiling-rounds 100" 2>&1 | tee "${log_file}"
+
+        task_duration_us="$(grep -E 'Task Duration\(us\):' "${log_file}" | tail -n 1 | awk '{print $3}')"
+        grid="$("${python_bin}" - "${input_file}" "${case_name}" <<'PY'
+import json
+import sys
+
+for case in json.load(open(sys.argv[1], encoding="utf-8")):
+    if case["name"] == sys.argv[2]:
+        print("x".join(map(str, case["grid"])))
+        break
+PY
+)"
+        if [[ -z "${task_duration_us}" ]]; then
+            echo "Task Duration(us) missing for ${implementation}/${case_name}" >&2
+            exit 1
+        fi
+        printf '%s\t%s\t%s\t%s\t%s\n' \
+            "${case_name}" "${implementation}" "${grid}" "${task_duration_us}" "${log_file}" \
+            >> "${result_file}"
+    done
+done
+
+echo "Wrote ${result_file}"
+awk -F '\t' '
+    NR == 1 { next }
+    $2 == "upstream" {
+        upstream[$1] = $4
+        grid[$1] = $3
+        case_order[++num_cases] = $1
+    }
+    $2 == "ascend" { ascend[$1] = $4; grid[$1] = $3 }
+    END {
+        print "case\tgrid\tupstream_us\tascend_us\tspeedup"
+        for (index = 1; index <= num_cases; index++) {
+            case_name = case_order[index]
+            if (case_name in ascend && ascend[case_name] != 0) {
+                printf "%s\t%s\t%.6f\t%.6f\t%.2fx\n", \
+                    case_name, grid[case_name], upstream[case_name], \
+                    ascend[case_name], upstream[case_name] / ascend[case_name]
+            }
+        }
+    }
+' "${result_file}" > "${summary_file}"
+echo "Wrote ${summary_file}"

--- a/benchmarks/ops/generate_slot_mapping_compare_cases.py
+++ b/benchmarks/ops/generate_slot_mapping_compare_cases.py
@@ -1,0 +1,144 @@
+#!/usr/bin/env python3
+"""Generate varied single-op cases for slot-mapping comparisons.
+
+Example:
+    python benchmarks/ops/generate_slot_mapping_compare_cases.py \
+        --output /home/lingmutian/tmp/slot_mapping_compare_cases.json
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+BLOCK_SIZE = 128
+TRITON_BLOCK_SIZE = 1024
+PHYSICAL_BLOCK_UPPER_BOUND = 320
+
+
+def tensor(
+    shape: list[int],
+    dtype: str,
+    initializer: str | None = None,
+    **kwargs: int,
+) -> dict[str, object]:
+    spec: dict[str, object] = {"shape": shape, "dtype": dtype, "device": "npu:0"}
+    if initializer is not None:
+        spec["initializer"] = initializer
+    spec.update(kwargs)
+    return spec
+
+
+def next_power_of_2(value: int) -> int:
+    return 1 << (value - 1).bit_length()
+
+
+def make_case(
+    name: str,
+    num_reqs: int,
+    tokens_per_request: int,
+    *,
+    max_num_tokens: int | None = None,
+    pos_start: int = 0,
+    cp_size: int = 1,
+    cp_rank: int = 0,
+    cp_interleave: int = 1,
+) -> dict[str, object]:
+    total_tokens = num_reqs * tokens_per_request
+    max_num_tokens = total_tokens if max_num_tokens is None else max_num_tokens
+    max_position = pos_start + total_tokens - 1
+    block_table_width = max_position // BLOCK_SIZE + 1
+    window_size = next_power_of_2((TRITON_BLOCK_SIZE + BLOCK_SIZE - 1) // BLOCK_SIZE + 1)
+
+    pointee = tensor(
+        [num_reqs, block_table_width],
+        "torch.int32",
+        "randint",
+        low=0,
+        high=PHYSICAL_BLOCK_UPPER_BOUND,
+    )
+    return {
+        "name": name,
+        "kernel": "_compute_slot_mappings_kernel",
+        "grid": [1, num_reqs + 1],
+        "launch_config": {
+            "num_reqs": num_reqs,
+            "tokens_per_request": tokens_per_request,
+            "max_num_tokens": max_num_tokens,
+            "pos_start": pos_start,
+            "block_table_width": block_table_width,
+            "cp_size": cp_size,
+        },
+        "arguments": {
+            "max_num_tokens": max_num_tokens,
+            "idx_mapping": tensor([num_reqs], "torch.int32", "arange"),
+            "query_start_loc": tensor(
+                [num_reqs + 1],
+                "torch.int32",
+                "arange",
+                start=0,
+                step=tokens_per_request,
+            ),
+            "pos": tensor([total_tokens], "torch.int64", "arange", start=pos_start),
+            "block_table_ptrs": {
+                "shape": [1],
+                "dtype": "torch.uint64",
+                "device": "npu:0",
+                "initializer": "data_ptrs",
+                "pointees": [pointee],
+            },
+            "block_table_strides": tensor([1], "torch.int64", "full", value=block_table_width),
+            "block_sizes": tensor([1], "torch.int32", "full", value=BLOCK_SIZE),
+            # These are consumed only by the current upstream V2 reference
+            # kernel. The Ascend wrapper ignores them.
+            "kernel_block_sizes": tensor([1], "torch.int32", "full", value=BLOCK_SIZE),
+            "slot_mapping_enabled": tensor([1], "torch.bool", "ones"),
+            "slot_mappings": tensor([1, max_num_tokens], "torch.int32"),
+            "slot_mappings_stride": max_num_tokens,
+            "cp_rank": cp_rank,
+            "CP_SIZE": cp_size,
+            "CP_INTERLEAVE": cp_interleave,
+            "PAD_ID": -1,
+            "TRITON_BLOCK_SIZE": TRITON_BLOCK_SIZE,
+            "BLOCK_TABLE_WINDOW_SIZE": window_size,
+        },
+    }
+
+
+def make_cases() -> list[dict[str, object]]:
+    cases = [
+        make_case("decode-1", 1, 1),
+        make_case("decode-40", 40, 1),
+        make_case("decode-64", 64, 1),
+        make_case("decode-256", 256, 1),
+        make_case("decode-1024", 1024, 1),
+        make_case("tile-1", 1, TRITON_BLOCK_SIZE),
+        make_case("tile-8", 8, TRITON_BLOCK_SIZE),
+        make_case("tile-64", 64, TRITON_BLOCK_SIZE),
+        make_case("tile-256", 256, TRITON_BLOCK_SIZE),
+        make_case("tile-1024", 1024, TRITON_BLOCK_SIZE),
+        make_case("cross-block-1x1024", 1, TRITON_BLOCK_SIZE, pos_start=BLOCK_SIZE - 1),
+        make_case("cross-tile-1x1025", 1, TRITON_BLOCK_SIZE + 1, pos_start=BLOCK_SIZE - 1),
+        make_case("long-1x8192", 1, 8192),
+        make_case("long-64x8192", 64, 8192),
+        make_case("long-64x32768", 64, 32768),
+        make_case("captured-tail", 8, 9, max_num_tokens=8192),
+        make_case("cp2-tile-64-rank0", 64, TRITON_BLOCK_SIZE, cp_size=2),
+        make_case("cp4-tile-64-rank2", 64, TRITON_BLOCK_SIZE, cp_size=4, cp_rank=2),
+    ]
+    return cases
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--output", type=Path, required=True, help="Destination JSON file")
+    args = parser.parse_args()
+
+    cases = make_cases()
+    args.output.write_text(json.dumps(cases, indent=2) + "\n", encoding="utf-8")
+    print(f"Wrote {len(cases)} cases to {args.output}")
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/ops/slot_mapping_compare_wrappers.py
+++ b/benchmarks/ops/slot_mapping_compare_wrappers.py
@@ -1,0 +1,100 @@
+"""Launch adapters for upstream and Ascend slot-mapping kernel benchmarks."""
+
+from __future__ import annotations
+
+import torch
+from vllm.v1.worker.gpu.block_table import (
+    _compute_slot_mappings_kernel as upstream_compute_slot_mappings_kernel,
+)
+
+from vllm_ascend.ops.triton.v2.block_table.compute_slot_mappings import (
+    _compute_slot_mappings_kernel as ascend_compute_slot_mappings_kernel,
+)
+
+
+def _grid(block_table_ptrs: torch.Tensor, idx_mapping: torch.Tensor) -> tuple[int, int]:
+    return block_table_ptrs.numel(), idx_mapping.numel() + 1
+
+
+def launch_ascend(
+    max_num_tokens: int,
+    idx_mapping: torch.Tensor,
+    query_start_loc: torch.Tensor,
+    pos: torch.Tensor,
+    block_table_ptrs: torch.Tensor,
+    block_table_strides: torch.Tensor,
+    block_sizes: torch.Tensor,
+    kernel_block_sizes: torch.Tensor,
+    slot_mapping_enabled: torch.Tensor,
+    slot_mappings: torch.Tensor,
+    slot_mappings_stride: int,
+    cp_rank: int,
+    CP_SIZE: int,
+    CP_INTERLEAVE: int,
+    PAD_ID: int,
+    TRITON_BLOCK_SIZE: int,
+    BLOCK_TABLE_WINDOW_SIZE: int,
+) -> None:
+    """Launch the Ascend implementation; upstream-only tensors are ignored."""
+    del kernel_block_sizes, slot_mapping_enabled
+    ascend_compute_slot_mappings_kernel[_grid(block_table_ptrs, idx_mapping)](
+        max_num_tokens,
+        idx_mapping,
+        query_start_loc,
+        pos,
+        block_table_ptrs,
+        block_table_strides,
+        block_sizes,
+        slot_mappings,
+        slot_mappings_stride,
+        cp_rank,
+        CP_SIZE=CP_SIZE,
+        CP_INTERLEAVE=CP_INTERLEAVE,
+        PAD_ID=PAD_ID,
+        TRITON_BLOCK_SIZE=TRITON_BLOCK_SIZE,
+        BLOCK_TABLE_WINDOW_SIZE=BLOCK_TABLE_WINDOW_SIZE,
+    )
+
+
+def launch_upstream(
+    max_num_tokens: int,
+    idx_mapping: torch.Tensor,
+    query_start_loc: torch.Tensor,
+    pos: torch.Tensor,
+    block_table_ptrs: torch.Tensor,
+    block_table_strides: torch.Tensor,
+    block_sizes: torch.Tensor,
+    kernel_block_sizes: torch.Tensor,
+    slot_mapping_enabled: torch.Tensor,
+    slot_mappings: torch.Tensor,
+    slot_mappings_stride: int,
+    cp_rank: int,
+    CP_SIZE: int,
+    CP_INTERLEAVE: int,
+    PAD_ID: int,
+    TRITON_BLOCK_SIZE: int,
+    BLOCK_TABLE_WINDOW_SIZE: int,
+) -> None:
+    """Launch the upstream reference across its supported signatures."""
+    del BLOCK_TABLE_WINDOW_SIZE
+    kernel_args = (
+        max_num_tokens,
+        idx_mapping,
+        query_start_loc,
+        pos,
+        block_table_ptrs,
+        block_table_strides,
+        block_sizes,
+    )
+    if "kernel_block_sizes" in upstream_compute_slot_mappings_kernel.arg_names:
+        kernel_args += (kernel_block_sizes, slot_mapping_enabled)
+    upstream_compute_slot_mappings_kernel[_grid(block_table_ptrs, idx_mapping)](
+        *kernel_args,
+        slot_mappings,
+        slot_mappings_stride,
+        cp_rank,
+        CP_SIZE=CP_SIZE,
+        CP_INTERLEAVE=CP_INTERLEAVE,
+        PAD_ID=PAD_ID,
+        TRITON_BLOCK_SIZE=TRITON_BLOCK_SIZE,
+    )

--- a/tests/e2e/nightly/single_node/ops/singlecard_ops/triton/test_compute_slot_mapping.py
+++ b/tests/e2e/nightly/single_node/ops/singlecard_ops/triton/test_compute_slot_mapping.py
@@ -1,0 +1,125 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import pytest
+import torch
+from vllm.triton_utils import triton
+from vllm.v1.worker.gpu.block_table import (
+    _compute_slot_mappings_kernel as ref_compute_slot_mappings_kernel,
+)
+
+from vllm_ascend.ops.triton.v2.block_table.compute_slot_mappings import (
+    _compute_slot_mappings_kernel as ascend_compute_slot_mappings_kernel,
+)
+from vllm_ascend.worker.v2.block_table import (
+    AscendBlockTables,
+)
+
+
+@pytest.mark.parametrize(
+    ("cp_size", "cp_rank", "cp_interleave"),
+    [
+        pytest.param(1, 0, 1, id="cp1"),
+        pytest.param(2, 1, 2, id="cp2_interleaved"),
+        pytest.param(4, 2, 1, id="cp4_interleaved"),
+    ],
+)
+def test_compute_slot_mapping_npu_kernel_cp(cp_size: int, cp_rank: int, cp_interleave: int) -> None:
+    """Check the Ascend V2 kernel against the upstream kernel."""
+    device = "npu"
+    max_num_tokens = 8192
+    idx_mapping = torch.tensor([2, 0], dtype=torch.int32, device=device)
+    query_start_loc = torch.tensor([0, 5, 10], dtype=torch.int32, device=device)
+    positions = torch.tensor(
+        [0, 1, 63, 64, 127, 0, 2, 64, 128, 255],
+        dtype=torch.int64,
+        device=device,
+    )
+
+    num_groups = 2
+    block_tables = [torch.randint(0, 320, (3, 320), dtype=torch.int32, device=device) for _ in range(num_groups)]
+    block_table_ptrs = torch.tensor(
+        [table.data_ptr() for table in block_tables],
+        dtype=torch.uint64,
+        device=device,
+    )
+    block_table_strides = torch.tensor(
+        [table.stride(0) for table in block_tables],
+        dtype=torch.int64,
+        device=device,
+    )
+    block_sizes = torch.tensor([64, 128], dtype=torch.int32, device=device)
+    slot_mappings = torch.zeros((num_groups, max_num_tokens), dtype=torch.int32, device=device)
+    ref_slot_mappings = torch.zeros_like(slot_mappings)
+
+    kernel_args = (
+        max_num_tokens,
+        idx_mapping,
+        query_start_loc,
+        positions,
+        block_table_ptrs,
+        block_table_strides,
+        block_sizes,
+    )
+    grid = (num_groups, idx_mapping.shape[0] + 1)
+    kernel_kwargs = {
+        "CP_SIZE": cp_size,
+        "CP_INTERLEAVE": cp_interleave,
+        "PAD_ID": -1,
+        "TRITON_BLOCK_SIZE": 1024,
+    }
+    ascend_compute_slot_mappings_kernel[grid](
+        *kernel_args,
+        slot_mappings,
+        slot_mappings.stride(0),
+        cp_rank,
+        **kernel_kwargs,
+        BLOCK_TABLE_PAD_SIZE=triton.next_power_of_2(max(table.stride(0) for table in block_tables)),
+    )
+    ref_compute_slot_mappings_kernel[grid](
+        *kernel_args,
+        ref_slot_mappings,
+        ref_slot_mappings.stride(0),
+        cp_rank,
+        **kernel_kwargs,
+    )
+
+    torch.testing.assert_close(slot_mappings, ref_slot_mappings)
+
+
+def test_ascend_block_tables_compute_slot_mappings_out() -> None:
+    """Exercise the V2 override, including its current ``out`` argument."""
+    device = torch.device("npu")
+    block_table = torch.tensor(
+        [[10, 11, 0, 0], [20, 21, 0, 0], [30, 31, 0, 0]],
+        dtype=torch.int32,
+        device=device,
+    )
+    # This is a method-level test. Constructing BlockTables also exercises the
+    # unrelated UvaBuffer lifecycle, which is covered independently upstream.
+    block_tables = object.__new__(AscendBlockTables)
+    block_tables.num_kv_cache_groups = 1
+    block_tables.slot_mappings = torch.empty((1, 12), dtype=torch.int32, device=device)
+    block_tables.block_table_ptrs = torch.tensor([block_table.data_ptr()], dtype=torch.uint64, device=device)
+    block_tables.block_table_strides = torch.tensor([block_table.stride(0)], dtype=torch.int64, device=device)
+    block_tables.block_sizes_tensor = torch.tensor([4], dtype=torch.int32, device=device)
+    block_tables.cp_rank = 0
+    block_tables.cp_size = 1
+    block_tables.cp_interleave = 1
+    block_tables._block_table_pad_size = triton.next_power_of_2(block_table.stride(0))
+
+    out = torch.full((1, 12), 777, dtype=torch.int32, device=device)
+    result = block_tables.compute_slot_mappings(
+        torch.tensor([2, 0], dtype=torch.int32, device=device),
+        torch.tensor([0, 3, 6], dtype=torch.int32, device=device),
+        torch.tensor([0, 3, 4, 0, 4, 7], dtype=torch.int64, device=device),
+        num_tokens_padded=8,
+        out=out,
+    )
+
+    assert result.data_ptr() == out.data_ptr()
+    torch.testing.assert_close(
+        result.cpu(),
+        torch.tensor([[120, 123, 124, 40, 44, 47, -1, -1]], dtype=torch.int32),
+    )
+    torch.testing.assert_close(out[:, 8:].cpu(), torch.full((1, 4), -1, dtype=torch.int32))

--- a/tests/e2e/nightly/single_node/ops/singlecard_ops/triton/test_compute_slot_mapping.py
+++ b/tests/e2e/nightly/single_node/ops/singlecard_ops/triton/test_compute_slot_mapping.py
@@ -28,12 +28,22 @@ def test_compute_slot_mapping_npu_kernel_cp(cp_size: int, cp_rank: int, cp_inter
     """Check the Ascend V2 kernel against the upstream kernel."""
     device = "npu"
     max_num_tokens = 8192
-    idx_mapping = torch.tensor([2, 0], dtype=torch.int32, device=device)
-    query_start_loc = torch.tensor([0, 5, 10], dtype=torch.int32, device=device)
-    positions = torch.tensor(
-        [0, 1, 63, 64, 127, 0, 2, 64, 128, 255],
-        dtype=torch.int64,
+    # Empty requests use -1 as their mapping sentinel. The Ascend kernel must
+    # skip that row rather than resolving it while staging a block-table window.
+    idx_mapping = torch.tensor([2, -1, 0], dtype=torch.int32, device=device)
+    # Each non-empty request crosses a 1024-token tile boundary and starts one
+    # token before a block boundary. This exercises the window's largest span.
+    tokens_per_request = 1025
+    query_start_loc = torch.tensor(
+        [0, tokens_per_request, tokens_per_request, 2 * tokens_per_request],
+        dtype=torch.int32,
         device=device,
+    )
+    positions = torch.cat(
+        (
+            torch.arange(63, 63 + tokens_per_request, dtype=torch.int64, device=device),
+            torch.arange(127, 127 + tokens_per_request, dtype=torch.int64, device=device),
+        )
     )
 
     num_groups = 2
@@ -49,6 +59,8 @@ def test_compute_slot_mapping_npu_kernel_cp(cp_size: int, cp_rank: int, cp_inter
         device=device,
     )
     block_sizes = torch.tensor([64, 128], dtype=torch.int32, device=device)
+    min_block_size = min(block_sizes.tolist())
+    block_table_window_size = triton.next_power_of_2((1024 + min_block_size - 1) // min_block_size + 1)
     slot_mappings = torch.zeros((num_groups, max_num_tokens), dtype=torch.int32, device=device)
     ref_slot_mappings = torch.zeros_like(slot_mappings)
 
@@ -74,7 +86,7 @@ def test_compute_slot_mapping_npu_kernel_cp(cp_size: int, cp_rank: int, cp_inter
         slot_mappings.stride(0),
         cp_rank,
         **kernel_kwargs,
-        BLOCK_TABLE_PAD_SIZE=triton.next_power_of_2(max(table.stride(0) for table in block_tables)),
+        BLOCK_TABLE_WINDOW_SIZE=block_table_window_size,
     )
     ref_compute_slot_mappings_kernel[grid](
         *kernel_args,
@@ -106,7 +118,7 @@ def test_ascend_block_tables_compute_slot_mappings_out() -> None:
     block_tables.cp_rank = 0
     block_tables.cp_size = 1
     block_tables.cp_interleave = 1
-    block_tables._block_table_pad_size = triton.next_power_of_2(block_table.stride(0))
+    block_tables._block_table_window_size = 512
 
     out = torch.full((1, 12), 777, dtype=torch.int32, device=device)
     result = block_tables.compute_slot_mappings(

--- a/vllm_ascend/ops/triton/v2/block_table/compute_slot_mappings.py
+++ b/vllm_ascend/ops/triton/v2/block_table/compute_slot_mappings.py
@@ -1,0 +1,74 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from vllm.triton_utils import tl, triton
+from vllm.v1.worker.gpu.block_table import _load_ptr
+
+
+@triton.jit
+def _compute_slot_mappings_kernel(
+    max_num_tokens,
+    idx_mapping,
+    query_start_loc,
+    pos,
+    block_table_ptrs,
+    block_table_strides,
+    block_sizes,
+    slot_mappings_ptr,
+    slot_mappings_stride,
+    cp_rank,
+    CP_SIZE: tl.constexpr,
+    CP_INTERLEAVE: tl.constexpr,
+    PAD_ID: tl.constexpr,
+    TRITON_BLOCK_SIZE: tl.constexpr,
+    BLOCK_TABLE_PAD_SIZE: tl.constexpr,
+):
+    group_id = tl.program_id(0)
+    batch_idx = tl.program_id(1)
+    slot_mapping_ptr = slot_mappings_ptr + group_id * slot_mappings_stride
+
+    if batch_idx == tl.num_programs(1) - 1:
+        actual_num_tokens = tl.load(query_start_loc + batch_idx)
+        for i in range(actual_num_tokens, max_num_tokens, TRITON_BLOCK_SIZE):
+            offset = i + tl.arange(0, TRITON_BLOCK_SIZE)
+            tl.store(slot_mapping_ptr + offset, PAD_ID, mask=offset < max_num_tokens)
+        return
+
+    block_table_ptr = _load_ptr(block_table_ptrs + group_id, tl.int32)
+    block_table_stride = tl.load(block_table_strides + group_id)
+    block_size = tl.load(block_sizes + group_id)
+    req_state_idx = tl.load(idx_mapping + batch_idx)
+    start_idx = tl.load(query_start_loc + batch_idx)
+    end_idx = tl.load(query_start_loc + batch_idx + 1)
+
+    lane_offsets = tl.arange(0, TRITON_BLOCK_SIZE)
+    # BLOCK_TABLE_PAD_SIZE is a compile-time upper bound for every group's row.
+    # The runtime stride mask keeps loads within the current group's row.
+    block_table_offsets = tl.arange(0, BLOCK_TABLE_PAD_SIZE)
+    block_table_values = tl.load(
+        block_table_ptr + req_state_idx * block_table_stride + block_table_offsets,
+        mask=block_table_offsets < block_table_stride,
+        other=0,
+    ).to(tl.float32)
+
+    for i in range(start_idx, end_idx, TRITON_BLOCK_SIZE):
+        offset = i + lane_offsets
+        valid = offset < end_idx
+        positions = tl.load(pos + offset, mask=valid, other=0).to(tl.int32)
+        block_indices = positions // (block_size * CP_SIZE)
+        # block_offset = positions % (block_size * CP_SIZE). Replacing the
+        # remainder with multiply/subtract avoids scalar fallback on Ascend.
+        block_offsets = positions - (block_size * CP_SIZE) * block_indices
+        block_numbers = tl.gather(block_table_values, block_indices, 0).to(tl.int32)
+
+        if CP_SIZE == 1:
+            slot_ids = block_numbers * block_size + block_offsets
+        else:
+            is_local = block_offsets // CP_INTERLEAVE % CP_SIZE == cp_rank
+            rounds = block_offsets // (CP_INTERLEAVE * CP_SIZE)
+            remainder = block_offsets % CP_INTERLEAVE
+            local_offsets = rounds * CP_INTERLEAVE + remainder
+            slot_ids = block_numbers * block_size + local_offsets
+            slot_ids = tl.where(is_local, slot_ids, PAD_ID)
+
+        tl.store(slot_mapping_ptr + offset, slot_ids, mask=valid)

--- a/vllm_ascend/ops/triton/v2/block_table/compute_slot_mappings.py
+++ b/vllm_ascend/ops/triton/v2/block_table/compute_slot_mappings.py
@@ -21,7 +21,7 @@ def _compute_slot_mappings_kernel(
     CP_INTERLEAVE: tl.constexpr,
     PAD_ID: tl.constexpr,
     TRITON_BLOCK_SIZE: tl.constexpr,
-    BLOCK_TABLE_PAD_SIZE: tl.constexpr,
+    BLOCK_TABLE_WINDOW_SIZE: tl.constexpr,
 ):
     group_id = tl.program_id(0)
     batch_idx = tl.program_id(1)
@@ -34,41 +34,50 @@ def _compute_slot_mappings_kernel(
             tl.store(slot_mapping_ptr + offset, PAD_ID, mask=offset < max_num_tokens)
         return
 
-    block_table_ptr = _load_ptr(block_table_ptrs + group_id, tl.int32)
-    block_table_stride = tl.load(block_table_strides + group_id)
-    block_size = tl.load(block_sizes + group_id)
-    req_state_idx = tl.load(idx_mapping + batch_idx)
     start_idx = tl.load(query_start_loc + batch_idx)
     end_idx = tl.load(query_start_loc + batch_idx + 1)
 
-    lane_offsets = tl.arange(0, TRITON_BLOCK_SIZE)
-    # BLOCK_TABLE_PAD_SIZE is a compile-time upper bound for every group's row.
-    # The runtime stride mask keeps loads within the current group's row.
-    block_table_offsets = tl.arange(0, BLOCK_TABLE_PAD_SIZE)
-    block_table_values = tl.load(
-        block_table_ptr + req_state_idx * block_table_stride + block_table_offsets,
-        mask=block_table_offsets < block_table_stride,
-        other=0,
-    ).to(tl.float32)
+    # An empty request can use -1 as its idx_mapping sentinel. Do not resolve
+    # its block-table row: there are no slot IDs to produce for this program.
+    if start_idx < end_idx:
+        block_table_ptr = _load_ptr(block_table_ptrs + group_id, tl.int32)
+        block_table_stride = tl.load(block_table_strides + group_id)
+        block_size = tl.load(block_sizes + group_id)
+        req_state_idx = tl.load(idx_mapping + batch_idx)
 
-    for i in range(start_idx, end_idx, TRITON_BLOCK_SIZE):
-        offset = i + lane_offsets
-        valid = offset < end_idx
-        positions = tl.load(pos + offset, mask=valid, other=0).to(tl.int32)
-        block_indices = positions // (block_size * CP_SIZE)
-        # block_offset = positions % (block_size * CP_SIZE). Replacing the
-        # remainder with multiply/subtract avoids scalar fallback on Ascend.
-        block_offsets = positions - (block_size * CP_SIZE) * block_indices
-        block_numbers = tl.gather(block_table_values, block_indices, 0).to(tl.int32)
+        lane_offsets = tl.arange(0, TRITON_BLOCK_SIZE)
+        block_table_offsets = tl.arange(0, BLOCK_TABLE_WINDOW_SIZE)
+        for i in range(start_idx, end_idx, TRITON_BLOCK_SIZE):
+            offset = i + lane_offsets
+            valid = offset < end_idx
+            positions = tl.load(pos + offset, mask=valid, other=0).to(tl.int32)
+            block_indices = positions // (block_size * CP_SIZE)
+            # block_offset = positions % (block_size * CP_SIZE). Replacing the
+            # remainder with multiply/subtract avoids scalar fallback on Ascend.
+            block_offsets = positions - (block_size * CP_SIZE) * block_indices
 
-        if CP_SIZE == 1:
-            slot_ids = block_numbers * block_size + block_offsets
-        else:
-            is_local = block_offsets // CP_INTERLEAVE % CP_SIZE == cp_rank
-            rounds = block_offsets // (CP_INTERLEAVE * CP_SIZE)
-            remainder = block_offsets % CP_INTERLEAVE
-            local_offsets = rounds * CP_INTERLEAVE + remainder
-            slot_ids = block_numbers * block_size + local_offsets
-            slot_ids = tl.where(is_local, slot_ids, PAD_ID)
+            # Stage only the contiguous portion of this request row used by
+            # the current token tile. The window bound is selected at launch
+            # from the smallest group block size.
+            valid_block_indices = tl.where(valid, block_indices, 2147483647)
+            block_idx_base = tl.min(valid_block_indices, axis=0)
+            window_offsets = block_idx_base + block_table_offsets
+            block_table_window = tl.load(
+                block_table_ptr + req_state_idx * block_table_stride + window_offsets,
+                mask=window_offsets < block_table_stride,
+                other=0,
+            ).to(tl.float32)
+            relative_block_indices = tl.where(valid, block_indices - block_idx_base, 0)
+            block_numbers = tl.gather(block_table_window, relative_block_indices, 0).to(tl.int32)
 
-        tl.store(slot_mapping_ptr + offset, slot_ids, mask=valid)
+            if CP_SIZE == 1:
+                slot_ids = block_numbers * block_size + block_offsets
+            else:
+                is_local = block_offsets // CP_INTERLEAVE % CP_SIZE == cp_rank
+                rounds = block_offsets // (CP_INTERLEAVE * CP_SIZE)
+                remainder = block_offsets % CP_INTERLEAVE
+                local_offsets = rounds * CP_INTERLEAVE + remainder
+                slot_ids = block_numbers * block_size + local_offsets
+                slot_ids = tl.where(is_local, slot_ids, PAD_ID)
+
+            tl.store(slot_mapping_ptr + offset, slot_ids, mask=valid)

--- a/vllm_ascend/ops/triton/v2/block_table/docs/compute_slot_mappings.md
+++ b/vllm_ascend/ops/triton/v2/block_table/docs/compute_slot_mappings.md
@@ -1,0 +1,133 @@
+# _compute_slot_mappings_kernel
+
+## Description
+
+- **Location**: `vllm_ascend/ops/triton/v2/block_table/compute_slot_mappings.py`
+  — `_compute_slot_mappings_kernel`, launched by
+  `AscendBlockTables.compute_slot_mappings`.
+- **Function**: Computes the physical KV-cache slot ID for every scheduled
+  token in MRV2. KV cache uses block-based physical storage, while each token
+  is identified by its logical position in a request. The request's
+  `block_table` maps the logical block index to a physical cache block; this
+  kernel combines that physical block number with the token's in-block offset
+  to produce the slot ID consumed by attention and cache-write operators. It
+  supports multiple KV-cache groups and context parallelism (CP), and fills
+  the unused tail of each output row with `PAD_ID`.
+- **Formula**: For a token at logical position `p`, let
+  `slice_size = block_size * CP_SIZE`,
+  `block_index = p // slice_size`, and
+  `block_offset = p % slice_size`. The physical block is read from the
+  request's block table. When `CP_SIZE == 1`, the output is
+  `physical_block * block_size + block_offset`. With CP enabled, only offsets
+  assigned to `cp_rank` are retained; their rank-local offset is
+  `(block_offset // (CP_INTERLEAVE * CP_SIZE)) * CP_INTERLEAVE +
+  block_offset % CP_INTERLEAVE`. Other ranks' offsets produce `PAD_ID`.
+- **Context-parallel mapping**: With `CP_SIZE > 1`, one virtual slice contains
+  `CP_SIZE` physical blocks and has size `block_size * CP_SIZE`. For a logical
+  position `p`:
+  1. `block_index = p // (block_size * CP_SIZE)` selects the virtual slice and
+     therefore the block-table entry.
+  2. `block_offset = p % (block_size * CP_SIZE)` selects a position inside the
+     virtual slice.
+  3. `(block_offset // CP_INTERLEAVE) % CP_SIZE` identifies the rank that owns
+     the position. Positions owned by another rank are represented by
+     `PAD_ID` on the current rank.
+  4. Complete interleave rounds and the remainder within one interleave segment
+     are combined into a contiguous rank-local offset. The final slot ID is
+     `physical_block * block_size + local_offset`.
+- **Algorithm flow**:
+  1. Launch a two-dimensional grid over KV-cache groups and requests, plus one
+     padding program per group.
+  2. Resolve the selected request through `idx_mapping`, then read its token
+     interval from `query_start_loc`.
+  3. Load the selected request's block-table row once with a contiguous GM
+     load, then process the interval in `TRITON_BLOCK_SIZE` tiles. Convert
+     positions to INT32, calculate block indices and offsets, and gather the
+     physical block number from the staged row.
+  4. Calculate slot IDs directly for non-CP execution. For CP execution,
+     convert virtual offsets to rank-local offsets and replace non-local slots
+     with `PAD_ID`.
+  5. The extra request program fills `[actual_num_tokens, max_num_tokens)` with
+     `PAD_ID` for each KV-cache group.
+- **Supported modes**: Atlas A2, Atlas A3, and Ascend 950. The kernel is used
+  by `AscendBlockTables.compute_slot_mappings` in the MRV2 model runner and
+  supports eager and graph-capture execution with a fixed grid and compile-time
+  CP attributes.
+
+## Parameters
+
+> [!NOTE]
+> All parameters are required.
+
+| Parameter | Input/Output/Attribute | Description | Data type | Data format |
+| --- | --- | --- | --- | --- |
+| `max_num_tokens` | Input | Number of allocated entries in each output row; entries after the actual token count are padded. | INT | scalar |
+| `idx_mapping` | Input | Maps each scheduled request index to a row in every group's block table; shape `[num_reqs]`. | INT32 | ND |
+| `query_start_loc` | Input | Prefix offsets delimiting each request's token interval; shape `[num_reqs + 1]`. The last value is the actual token count. | INT32 | ND |
+| `pos` | Input | Logical sequence position for every scheduled token; shape `[actual_num_tokens]`. Values are converted to INT32 inside the kernel. | INT64 | ND |
+| `block_table_ptrs` | Input | Device pointer table containing one INT32 block-table base address per KV-cache group; shape `[num_groups]`. | UINT64 | ND |
+| `block_table_strides` | Input | Row stride, in elements, of each group's block table; shape `[num_groups]`. | INT64 | ND |
+| `block_sizes` | Input | Physical KV-cache block size for each group; shape `[num_groups]`. | INT32 | ND |
+| `slot_mappings_ptr` | Output | Physical slot IDs, with one row per KV-cache group; shape `[num_groups, max_num_tokens]`. | INT32 | ND |
+| `slot_mappings_stride` | Input (attribute) | Row stride, in elements, of `slot_mappings_ptr`. | INT | scalar |
+| `cp_rank` | Input (attribute) | Rank of the current device in the context-parallel group. | INT | scalar |
+| `CP_SIZE` | Attribute | Number of ranks in the context-parallel group. | constexpr INT | scalar |
+| `CP_INTERLEAVE` | Attribute | Number of consecutive token positions assigned to one CP rank before interleaving to the next rank. | constexpr INT | scalar |
+| `PAD_ID` | Attribute | Value written for padding and token positions owned by another CP rank; production uses `PAD_SLOT_ID`. | constexpr INT | scalar |
+| `TRITON_BLOCK_SIZE` | Attribute | Number of token positions processed per loop tile; production uses 1024. | constexpr INT | scalar |
+| `BLOCK_TABLE_PAD_SIZE` | Attribute | Power-of-two upper bound for the allocated row stride. The load is masked by the runtime row stride. | constexpr INT | scalar |
+
+## Constraints
+
+- The launch grid must be `(num_groups, num_reqs + 1)`. The final program on
+  the request axis is reserved for output padding.
+- `idx_mapping` and `query_start_loc` must be INT32. `pos` is supplied as INT64
+  by MRV2, and every position must fit in INT32 because the optimized kernel
+  explicitly narrows it before index arithmetic.
+- Each `block_table_ptrs` entry must be a valid device address for an INT32
+  two-dimensional block table and must remain alive for the duration of the
+  launch. `block_table_strides` and `block_sizes` must describe the matching
+  group in the same order.
+- `query_start_loc` must be non-decreasing, start at zero, and end at a value no
+  greater than `max_num_tokens`. Every value in `idx_mapping` and every derived
+  block index must be within the corresponding block-table bounds.
+- `CP_SIZE >= 1`, `0 <= cp_rank < CP_SIZE`, and `CP_INTERLEAVE >= 1`.
+- `slot_mappings_ptr` must be INT32 with at least `max_num_tokens` entries per
+  group. `TRITON_BLOCK_SIZE` must be a positive compile-time constant.
+- Every derived block index must be smaller than its group's runtime row stride,
+  which in turn must not exceed `BLOCK_TABLE_PAD_SIZE`.
+- Graph capture requires the number of groups, request capacity, output
+  capacity, and compile-time CP attributes to remain compatible with the
+  captured launch.
+
+## Origin and Differences
+
+- **Origin**: Adapted from
+  `vllm.v1.worker.gpu.block_table._compute_slot_mappings_kernel`, the upstream
+  vLLM kernel used by the MRV2 block-table path.
+- **Differences**:
+    - Converts logical positions from INT64 to INT32 before block-index,
+    block-offset, and address calculations, reducing INT64 scalar arithmetic
+    on Ascend NPU.
+    - Stages one complete request row with a contiguous masked GM load and uses
+    `tl.gather` for token-to-block lookup, avoiding per-token non-contiguous GM
+    loads.
+    - Replaces the INT32 remainder used for the block offset with
+    multiply/subtract to avoid scalar fallback on Ascend.
+    - Preserves the upstream launch grid, CP mapping, padding behavior, and
+    optional `out` semantics.
+    - The kernel is launched by the Ascend-specific
+    `AscendBlockTables.compute_slot_mappings` override and writes to the
+    existing INT32 slot-mapping buffer required by the Ascend KV-cache path.
+
+## Test Cases
+
+The single-operator test compares the Ascend kernel bit-for-bit with the
+upstream MRV2 kernel for two KV-cache groups and CP configurations
+`(size, rank, interleave) = (1, 0, 1), (2, 1, 2), (4, 2, 1)`. It also exercises
+the `AscendBlockTables.compute_slot_mappings(..., out=...)` override and checks
+the returned view, physical slot IDs, and padded tail.
+
+```bash
+pytest -sv tests/e2e/nightly/single_node/ops/singlecard_ops/triton/test_compute_slot_mapping.py
+```

--- a/vllm_ascend/ops/triton/v2/block_table/docs/compute_slot_mappings.md
+++ b/vllm_ascend/ops/triton/v2/block_table/docs/compute_slot_mappings.md
@@ -40,10 +40,10 @@
      padding program per group.
   2. Resolve the selected request through `idx_mapping`, then read its token
      interval from `query_start_loc`.
-  3. Load the selected request's block-table row once with a contiguous GM
-     load, then process the interval in `TRITON_BLOCK_SIZE` tiles. Convert
-     positions to INT32, calculate block indices and offsets, and gather the
-     physical block number from the staged row.
+  3. For each `TRITON_BLOCK_SIZE` token tile, load only the contiguous
+     block-table window covering that tile. Convert positions to INT32,
+     calculate block indices and offsets, and gather the physical block number
+     from the staged window.
   4. Calculate slot IDs directly for non-CP execution. For CP execution,
      convert virtual offsets to rank-local offsets and replace non-local slots
      with `PAD_ID`.
@@ -75,7 +75,7 @@
 | `CP_INTERLEAVE` | Attribute | Number of consecutive token positions assigned to one CP rank before interleaving to the next rank. | constexpr INT | scalar |
 | `PAD_ID` | Attribute | Value written for padding and token positions owned by another CP rank; production uses `PAD_SLOT_ID`. | constexpr INT | scalar |
 | `TRITON_BLOCK_SIZE` | Attribute | Number of token positions processed per loop tile; production uses 1024. | constexpr INT | scalar |
-| `BLOCK_TABLE_PAD_SIZE` | Attribute | Power-of-two upper bound for the allocated row stride. The load is masked by the runtime row stride. | constexpr INT | scalar |
+| `BLOCK_TABLE_WINDOW_SIZE` | Attribute | Power-of-two number of adjacent block-table entries staged for one token tile. | constexpr INT | scalar |
 
 ## Constraints
 
@@ -89,13 +89,17 @@
   launch. `block_table_strides` and `block_sizes` must describe the matching
   group in the same order.
 - `query_start_loc` must be non-decreasing, start at zero, and end at a value no
-  greater than `max_num_tokens`. Every value in `idx_mapping` and every derived
-  block index must be within the corresponding block-table bounds.
+  greater than `max_num_tokens`. An empty request may use `-1` as its
+  `idx_mapping` sentinel; it is not dereferenced. Every non-empty request's
+  `idx_mapping` and every derived block index must be within the corresponding
+  block-table bounds.
 - `CP_SIZE >= 1`, `0 <= cp_rank < CP_SIZE`, and `CP_INTERLEAVE >= 1`.
 - `slot_mappings_ptr` must be INT32 with at least `max_num_tokens` entries per
   group. `TRITON_BLOCK_SIZE` must be a positive compile-time constant.
-- Every derived block index must be smaller than its group's runtime row stride,
-  which in turn must not exceed `BLOCK_TABLE_PAD_SIZE`.
+- For each token tile, the span from its minimum to maximum derived block index
+  must be smaller than `BLOCK_TABLE_WINDOW_SIZE`. Normal MRV2 positions are
+  contiguous within a request, so the launch-side window calculation satisfies
+  this bound.
 - Graph capture requires the number of groups, request capacity, output
   capacity, and compile-time CP attributes to remain compatible with the
   captured launch.
@@ -109,9 +113,9 @@
     - Converts logical positions from INT64 to INT32 before block-index,
     block-offset, and address calculations, reducing INT64 scalar arithmetic
     on Ascend NPU.
-    - Stages one complete request row with a contiguous masked GM load and uses
-    `tl.gather` for token-to-block lookup, avoiding per-token non-contiguous GM
-    loads.
+    - Stages only the contiguous block-table window needed by each token tile
+    with a masked GM load, then uses `tl.gather` for token-to-block lookup.
+    This bounds UB usage independently of a request's total context length.
     - Replaces the INT32 remainder used for the block offset with
     multiply/subtract to avoid scalar fallback on Ascend.
     - Preserves the upstream launch grid, CP mapping, padding behavior, and

--- a/vllm_ascend/worker/v2/block_table.py
+++ b/vllm_ascend/worker/v2/block_table.py
@@ -17,7 +17,13 @@
 # This file is a part of the vllm-ascend project.
 #
 import torch
+from vllm.triton_utils import triton
+from vllm.v1.attention.backends.utils import PAD_SLOT_ID
 from vllm.v1.worker.gpu.block_table import BlockTables
+
+from vllm_ascend.ops.triton.v2.block_table.compute_slot_mappings import (
+    _compute_slot_mappings_kernel,
+)
 
 
 class AscendBlockTables(BlockTables):
@@ -48,6 +54,13 @@ class AscendBlockTables(BlockTables):
             cp_rank,
             cp_interleave,
         )
+        # The kernel block-table row can be wider than
+        # max_num_blocks_per_group when one KV block maps to multiple kernel
+        # blocks. Use the allocated row stride so the staged row is complete.
+        max_block_table_stride = max(block_table.gpu.stride(0) for block_table in self.block_tables)
+        # tl.arange needs a compile-time power-of-two size. This value is
+        # passed as a constexpr and covers every KV cache group's row.
+        self._block_table_pad_size = triton.next_power_of_2(max_block_table_stride)
         # because we will override these attribute, delete these attribute to
         # make sure it's collected by python gc immediately.
         del self.slot_mappings
@@ -59,3 +72,33 @@ class AscendBlockTables(BlockTables):
             dtype=torch.int32,
             device=self.device,
         )
+
+    def compute_slot_mappings(
+        self,
+        idx_mapping: torch.Tensor,
+        query_start_loc: torch.Tensor,
+        positions: torch.Tensor,
+        num_tokens_padded: int,
+        out: torch.Tensor | None = None,
+    ) -> torch.Tensor:
+        num_reqs = idx_mapping.shape[0]
+        num_groups = self.num_kv_cache_groups
+        slot_mappings = self.slot_mappings if out is None else out
+        _compute_slot_mappings_kernel[(num_groups, num_reqs + 1)](
+            slot_mappings.shape[1],
+            idx_mapping,
+            query_start_loc,
+            positions,
+            self.block_table_ptrs,
+            self.block_table_strides,
+            self.block_sizes_tensor,
+            slot_mappings,
+            slot_mappings.stride(0),
+            self.cp_rank,
+            CP_SIZE=self.cp_size,
+            CP_INTERLEAVE=self.cp_interleave,
+            PAD_ID=PAD_SLOT_ID,
+            TRITON_BLOCK_SIZE=1024,
+            BLOCK_TABLE_PAD_SIZE=self._block_table_pad_size,
+        )
+        return slot_mappings[:, :num_tokens_padded]

--- a/vllm_ascend/worker/v2/block_table.py
+++ b/vllm_ascend/worker/v2/block_table.py
@@ -54,13 +54,12 @@ class AscendBlockTables(BlockTables):
             cp_rank,
             cp_interleave,
         )
-        # The kernel block-table row can be wider than
-        # max_num_blocks_per_group when one KV block maps to multiple kernel
-        # blocks. Use the allocated row stride so the staged row is complete.
-        max_block_table_stride = max(block_table.gpu.stride(0) for block_table in self.block_tables)
-        # tl.arange needs a compile-time power-of-two size. This value is
-        # passed as a constexpr and covers every KV cache group's row.
-        self._block_table_pad_size = triton.next_power_of_2(max_block_table_stride)
+        # Each token tile spans at most ceil(1024 / block_size) adjacent block
+        # indices. Use the smallest group's block size to form one constexpr
+        # window that is safe for every group, without staging a whole row.
+        min_block_size = min(block_sizes)
+        window_size = (1024 + min_block_size - 1) // min_block_size + 1
+        self._block_table_window_size = triton.next_power_of_2(window_size)
         # because we will override these attribute, delete these attribute to
         # make sure it's collected by python gc immediately.
         del self.slot_mappings
@@ -99,6 +98,6 @@ class AscendBlockTables(BlockTables):
             CP_INTERLEAVE=self.cp_interleave,
             PAD_ID=PAD_SLOT_ID,
             TRITON_BLOCK_SIZE=1024,
-            BLOCK_TABLE_PAD_SIZE=self._block_table_pad_size,
+            BLOCK_TABLE_WINDOW_SIZE=self._block_table_window_size,
         )
         return slot_mappings[:, :num_tokens_padded]


### PR DESCRIPTION
### What this PR does / why we need it?

MRv2 slot mapping originally performs per-token indirect block-table reads. On Ascend, these reads and INT64 arithmetic create scalar overhead. Staging an entire request block-table row avoids the indirect GM reads but can exceed UB capacity for long-context rows.

This PR adds an Ascend-specific V2 implementation under `vllm_ascend/ops/triton/v2/block_table/compute_slot_mappings.py`. It:

- uses INT32 position arithmetic and multiply/subtract instead of remainder;
- loads only the contiguous block-table window required by each 1024-token tile, then performs token-to-block lookup with `tl.gather`;
- skips empty requests before reading `idx_mapping`, so the `-1` empty-request sentinel is not dereferenced; and
- adds reproducible single-op generators and an `msprof` comparison script for upstream and Ascend implementations.

### Does this PR introduce _any_ user-facing change?

No. This is an internal Ascend MRv2 kernel optimization.

### How was this patch tested?

- `bash format.sh`
- `bash format.sh ci`
- `SHELLCHECK_OPTS="--exclude=SC2046,SC2006,SC2086" pre-commit run --all-files --hook-stage manual --show-diff-on-failure`
- Static validation:
  - `python -m compileall -q benchmarks/ops/generate_slot_mapping_compare_cases.py benchmarks/ops/slot_mapping_compare_wrappers.py`
  - `bash -n benchmarks/ops/compare_slot_mapping_cases.sh`
- Ascend NPU single-op performance collection, one independent `msprof op` process per implementation and case:

  ```bash
  python benchmarks/ops/generate_slot_mapping_compare_cases.py \
    --output /home/lingmutian/tmp/slot_mapping_compare_cases.json

  bash benchmarks/ops/compare_slot_mapping_cases.sh \
    /home/lingmutian/tmp/slot_mapping_compare_cases.json \
    /home/lingmutian/profile_dir/slot_mapping_compare
  ```

  Values below are `msprof` `Task Duration(us)`:

| Case | Grid | Upstream (us) | Ascend (us) | Speedup |
| --- | --- | ---: | ---: | ---: |
| decode-1 | 1x2 | 114.838 | 4.100 | 28.01x |
| decode-40 | 1x41 | 117.058 | 6.100 | 19.19x |
| decode-64 | 1x65 | 229.715 | 7.420 | 30.96x |
| decode-256 | 1x257 | 793.344 | 16.060 | 49.40x |
| decode-1024 | 1x1025 | 2935.641 | 49.459 | 59.36x |
| tile-1 | 1x2 | 114.578 | 3.960 | 28.93x |
| tile-8 | 1x9 | 114.458 | 3.600 | 31.79x |
| tile-64 | 1x65 | 229.535 | 6.880 | 33.36x |
| tile-256 | 1x257 | 793.764 | 15.080 | 52.64x |
| tile-1024 | 1x1025 | 2933.861 | 39.959 | 73.42x |
| cross-block-1x1024 | 1x2 | 114.958 | 4.080 | 28.18x |
| cross-tile-1x1025 | 1x2 | 210.756 | 5.640 | 37.37x |
| long-1x8192 | 1x2 | 786.524 | 11.340 | 69.36x |
| long-64x8192 | 1x65 | 1573.349 | 20.780 | 75.72x |
| long-64x32768 | 1x65 | 6180.936 | 70.079 | 88.20x |
| captured-tail | 1x9 | 114.838 | 3.780 | 30.38x |
| cp2-tile-64-rank0 | 1x65 | 497.510 | 43.659 | 11.40x |
| cp4-tile-64-rank2 | 1x65 | 492.550 | 44.299 | 11.12x |

The 18-case collection confirms both kernels launch successfully for all tested shapes. It measures performance only; the NPU numerical pytest comparison after the final window change was not rerun in this session.
- vLLM main: https://github.com/vllm-project/vllm/commit/b2f685834a6456197e7033966fdef52a23f1abcd
