### PR TITLE
[Bugfix][P/D] Fix D-node first token falling back to eager

### DIFF
--- a/vllm_ascend/core/recompute_scheduler.py
+++ b/vllm_ascend/core/recompute_scheduler.py
@@ -724,11 +724,13 @@ class RecomputeScheduler(Scheduler):
                     # Pad new decode requests to uniform spec decoding size to
                     # preserve full cudagraph for this step.
                     # Not for diffusion where draft tokens can't be padded.
+                    # No scheduled_running_reqs check: disaggregated D nodes never mix long prefills, so padding
+                    # always pays off; that check only helps colocated P/D, where prefill_scheduled still guards us.
                     if (
                         (self.num_spec_tokens > 0 and self.dynamic_sd_lookup is None)
                         and self.num_sampled_tokens_per_step > 0
                         and num_new_tokens == 1
-                        and (scheduled_running_reqs and not prefill_scheduled)
+                        and not prefill_scheduled
                     ):
                         num_new_tokens = 1 + self.num_spec_tokens
                         if num_new_tokens > token_budget or num_computed_tokens + num_new_tokens > self.max_model_len:


### PR DESCRIPTION
### What this PR does / why we need it?
On a PD-disaggregated decode node, the first-token recompute request always falls back to eager execution instead of replaying the full cudagraph, **adding ~50ms to TTFT.**
This PR removes the `scheduled_running_reqs` check when deciding whether to pad new decode requests to the uniform speculative decoding size in `RecomputeScheduler`. This ensures that first-token recompute requests on disaggregated decode nodes do not fall back to eager execution, allowing padding to always pay off since disaggregated decode nodes never mix long prefills.
### Does this PR introduce _any_ user-facing change?
no
### How was this patch tested?
Tested on a PD-disaggregated deployment, DeepSeek-V4-Flash prefill TP=4 DP=1, decode TP=1 DP=4, num_speculative_tokens=7, input=16k, output=150, concurrency=50.
| request rate | TTFT | TPOT |
| --- | --- | --- |
| 0.3 | 655.81 | 8.45 |
| 0.6 |  707.71 | 8.63 |
| 0.8 |  712.3 | 8.71 |

| request rate |  TTFT | TPOT |
| --- | --- | --- |
| 0.3 | 579.52 | 8.21 |
| 0.6 |  608.54 | 8.24 |
| 0.8 |  635.94 | 8.24 |
- vLLM main: https://github.com/vllm-project/vllm/commit/b2f685834a6456197e7033966fdef52a23f1abcd
