### PR TITLE
[Bugfix] Fix Gemma4 MoE W4A4 MXFP4 loading with TP1, TP2, and TP4

### DIFF
--- a/tests/ut/quantization/methods/w4a4/test_w4a4_mxfp4.py
+++ b/tests/ut/quantization/methods/w4a4/test_w4a4_mxfp4.py
@@ -2,6 +2,7 @@ from unittest.mock import MagicMock, Mock, patch
 
 import torch
 import torch.nn as nn
+from vllm.model_executor.layers.linear import RowParallelLinear
 
 from tests.ut.base import TestBase
 from tests.ut.quantization.conftest_quantization import create_mock_ascend_config, create_mock_vllm_config
@@ -58,6 +59,22 @@ class TestAscendW4A4MXFP4LinearMethod(TestBase):
         self.assertEqual(layer.weight.shape, (128, 128))
         self.assertEqual(layer.weight_scale.shape[0], 4)
 
+    def test_process_weights_preserves_unaligned_tp_group_phase(self):
+        layer = RowParallelLinear.__new__(RowParallelLinear)
+        nn.Module.__init__(layer)
+        original_weight = torch.randint(1, 255, (2, 264), dtype=torch.uint8)
+        layer.weight = nn.Parameter(original_weight.clone(), requires_grad=False)
+        layer.weight_scale = nn.Parameter(torch.randint(1, 255, (2, 17), dtype=torch.uint8), requires_grad=False)
+        layer.tp_rank = 3
+        layer.input_size_per_partition = 528
+
+        self.scheme.process_weights_after_loading(layer)
+
+        self.assertEqual(layer.mxfp4_tp_padding, (16, 0))
+        self.assertEqual(layer.weight.shape, (272, 2))
+        torch.testing.assert_close(layer.weight[:8], torch.zeros(8, 2, dtype=torch.uint8))
+        torch.testing.assert_close(layer.weight[8:], original_weight.transpose(0, 1))
+
     @patch("vllm_ascend.quantization.methods.w4a4.w4a4_mxfp4.torch_npu")
     def test_apply_3d_input(self, mock_npu):
         mock_npu.npu_dynamic_mx_quant.return_value = (
@@ -72,6 +89,21 @@ class TestAscendW4A4MXFP4LinearMethod(TestBase):
         with patch.object(self.scheme, "group_size", 32):
             output = self.scheme.apply(layer, x)
         self.assertEqual(output.shape[0], 32)
+
+    @patch("vllm_ascend.quantization.methods.w4a4.w4a4_mxfp4.torch_npu")
+    def test_apply_pads_activation_with_weight_group_phase(self, mock_npu):
+        mock_npu.npu_dynamic_mx_quant.return_value = (torch.empty(2, 272, dtype=torch.uint8), torch.empty(2, 17))
+        mock_npu.npu_quant_matmul.return_value = torch.empty(2, 4)
+        layer = MagicMock()
+        layer.mxfp4_tp_padding = (16, 0)
+        x = torch.randn(2, 528)
+
+        self.scheme.apply(layer, x)
+
+        padded_x = mock_npu.npu_dynamic_mx_quant.call_args.args[0]
+        self.assertEqual(padded_x.shape, (2, 544))
+        torch.testing.assert_close(padded_x[:, :16], torch.zeros(2, 16))
+        torch.testing.assert_close(padded_x[:, 16:], x)
 
 
 class TestAscendW4A4MXFP4MoEMethod(TestBase):
@@ -141,6 +173,20 @@ class TestAscendW4A4MXFP4MoEMethod(TestBase):
             self.assertEqual(weight_view.shape[0], self.num_experts)
             self.assertEqual(weight_view.untyped_storage().data_ptr(), source.untyped_storage().data_ptr())
 
+    def test_process_weights_pads_odd_scale_groups(self):
+        layer = nn.Module()
+        layer.w13_weight = nn.Parameter(torch.randint(0, 255, (8, 256, 64), dtype=torch.uint8), requires_grad=False)
+        layer.w2_weight = nn.Parameter(torch.randint(0, 255, (8, 128, 128), dtype=torch.uint8), requires_grad=False)
+        layer.w13_weight_scale = nn.Parameter(
+            torch.randint(0, 255, (8, 256, 11), dtype=torch.uint8), requires_grad=False
+        )
+        layer.w2_weight_scale = nn.Parameter(
+            torch.randint(0, 255, (8, 128, 11), dtype=torch.uint8), requires_grad=False
+        )
+        self.scheme.process_weights_after_loading(layer)
+        self.assertEqual(layer.w13_weight_scale.shape, (8, 6, 256, 2))
+        self.assertEqual(layer.w2_weight_scale.shape, (8, 6, 128, 2))
+
     @patch("vllm_ascend.quantization.methods.w4a4.w4a4_mxfp4.torch_npu")
     @patch("vllm_ascend.quantization.methods.w4a4.w4a4_mxfp4._EXTRA_CTX")
     def test_apply_full_params(self, mock_ctx, mock_npu):
@@ -180,3 +226,30 @@ class TestAscendW4A4MXFP4MoEMethod(TestBase):
             shared_experts_input=None,
         )
         mock_comm.fused_experts.assert_called_once()
+
+    @patch("vllm_ascend.quantization.methods.w4a4.w4a4_mxfp4.torch_npu")
+    def test_apply_gmm1_passes_mxfp4_dtypes(self, mock_npu):
+        layer = nn.Module()
+        layer.w13_weight = nn.Parameter(torch.randint(0, 255, (8, 64, 256), dtype=torch.uint8), requires_grad=False)
+        layer.w13_weight_scale = nn.Parameter(
+            torch.randint(0, 255, (8, 64, 128, 2), dtype=torch.uint8), requires_grad=False
+        )
+        mock_npu.float4_e2m1fn_x2 = torch.uint8
+        mock_npu.float8_e8m0fnu = torch.uint8
+        mock_npu.npu_dynamic_mx_quant.return_value = (
+            torch.randint(0, 255, (4, self.hidden_size), dtype=torch.uint8),
+            torch.randint(0, 255, (4, 4), dtype=torch.uint8),
+        )
+        mock_npu.npu_grouped_matmul.return_value = [torch.randn(4, self.intermediate_size, dtype=torch.bfloat16)]
+        mlp_compute_input = Mock()
+        mlp_compute_input.hidden_states = torch.randn(4, self.hidden_size, dtype=torch.bfloat16)
+        mlp_compute_input.dynamic_scale = None
+        mlp_compute_input.layer = layer
+        mlp_compute_input.group_list = torch.tensor([4], dtype=torch.int64)
+        mlp_compute_input.group_list_type = 0
+
+        self.scheme.apply_gmm1(mlp_compute_input)
+
+        kwargs = mock_npu.npu_grouped_matmul.call_args.kwargs
+        self.assertEqual(kwargs["x_dtype"], mock_npu.float4_e2m1fn_x2)
+        self.assertEqual(kwargs["weight_dtype"], mock_npu.float4_e2m1fn_x2)

--- a/tests/ut/quantization/methods/w8a8/test_w8a8_mxfp8.py
+++ b/tests/ut/quantization/methods/w8a8/test_w8a8_mxfp8.py
@@ -3,6 +3,7 @@ from unittest.mock import Mock, patch
 
 import torch
 import torch.nn as nn
+from vllm.model_executor.layers.linear import RowParallelLinear
 
 from tests.ut.base import TestBase
 from tests.ut.quantization.conftest_quantization import (
@@ -115,6 +116,22 @@ class TestAscendW8A8MXFP8LinearMethod(TestBase):
             self.assertTrue(layer.weight.data.is_contiguous())
             self.assertTrue(layer.weight_scale.data.is_contiguous())
 
+    def test_process_weights_preserves_unaligned_tp_group_phase(self):
+        layer = RowParallelLinear.__new__(RowParallelLinear)
+        nn.Module.__init__(layer)
+        original_weight = torch.randn(2, 528).to(torch.float8_e4m3fn)
+        layer.weight = nn.Parameter(original_weight.clone(), requires_grad=False)
+        layer.weight_scale = nn.Parameter(torch.randint(0, 255, (2, 17), dtype=torch.uint8), requires_grad=False)
+        layer.tp_rank = 3
+        layer.input_size_per_partition = 528
+
+        self.scheme.process_weights_after_loading(layer)
+
+        self.assertEqual(layer.mxfp8_tp_padding, (16, 0))
+        self.assertEqual(layer.weight.shape, (544, 2))
+        torch.testing.assert_close(layer.weight[:16], torch.zeros(16, 2, dtype=torch.float8_e4m3fn))
+        torch.testing.assert_close(layer.weight[16:], original_weight.transpose(0, 1))
+
     @patch("vllm_ascend.quantization.methods.w8a8.w8a8_mxfp8.torch_npu")
     def test_apply(self, mock_torch_npu):
         dynamic_scale = torch.randint(0, 255, (32, 8), dtype=torch.uint8)
@@ -136,6 +153,26 @@ class TestAscendW8A8MXFP8LinearMethod(TestBase):
         self.assertEqual(call_kwargs["bias"].dtype, torch.float32)
         self.assertEqual(call_kwargs["group_sizes"], [1, 1, self.scheme.group_size])
         self.assertEqual(call_kwargs["output_dtype"], torch.float16)
+
+    @patch("vllm_ascend.quantization.methods.w8a8.w8a8_mxfp8.torch_npu")
+    def test_apply_pads_activation_with_weight_group_phase(self, mock_torch_npu):
+        mock_torch_npu.npu_dynamic_mx_quant.return_value = (
+            torch.empty(2, 544, dtype=torch.float8_e4m3fn),
+            torch.empty(2, 17),
+        )
+        mock_torch_npu.npu_quant_matmul.return_value = torch.empty(2, 4)
+        layer = nn.Module()
+        layer.mxfp8_tp_padding = (16, 0)
+        layer.weight = nn.Parameter(torch.empty(544, 4, dtype=torch.float8_e4m3fn), requires_grad=False)
+        layer.weight_scale = nn.Parameter(torch.empty(9, 4, 2, dtype=torch.uint8), requires_grad=False)
+        x = torch.randn(2, 528)
+
+        self.scheme.apply(layer, x)
+
+        padded_x = mock_torch_npu.npu_dynamic_mx_quant.call_args.args[0]
+        self.assertEqual(padded_x.shape, (2, 544))
+        torch.testing.assert_close(padded_x[:, :16], torch.zeros(2, 16))
+        torch.testing.assert_close(padded_x[:, 16:], x)
 
 
 class TestAscendW8A8MXFP8MoEMethod(TestBase):

--- a/tests/ut/quantization/test_method_adapters.py
+++ b/tests/ut/quantization/test_method_adapters.py
@@ -10,8 +10,27 @@ from vllm_ascend.quantization.method_adapters import (
     AscendFusedMoEMethod,
     AscendKVCacheMethod,
     AscendLinearMethod,
+    _make_mx_scale_weight_loader,
 )
 from vllm_ascend.quantization.methods.base import AscendAttentionScheme, AscendLinearScheme, AscendMoEScheme
+
+
+def test_mx_scale_weight_loader_preserves_group_phase():
+    weight_loader = MagicMock()
+    param = torch.nn.Parameter(torch.empty(2, 17), requires_grad=False)
+    param.input_dim = 1
+    loader = _make_mx_scale_weight_loader(
+        weight_loader,
+        tp_rank=3,
+        input_size_per_partition=528,
+        group_size=32,
+    )
+    loaded_weight = torch.arange(2 * 66, dtype=torch.float32).reshape(2, 66)
+
+    loader(param, loaded_weight)
+
+    weight_loader.assert_not_called()
+    torch.testing.assert_close(param, loaded_weight[:, 49:66])
 
 
 class TestAscendLinearMethod(TestBase):

--- a/tests/ut/quantization/test_method_adapters.py
+++ b/tests/ut/quantization/test_method_adapters.py
@@ -11,6 +11,7 @@ from vllm_ascend.quantization.method_adapters import (
     AscendKVCacheMethod,
     AscendLinearMethod,
     _make_mx_scale_weight_loader,
+    _make_padded_mx_scale_weight_loader,
 )
 from vllm_ascend.quantization.methods.base import AscendAttentionScheme, AscendLinearScheme, AscendMoEScheme
 
@@ -31,6 +32,23 @@ def test_mx_scale_weight_loader_preserves_group_phase():
 
     weight_loader.assert_not_called()
     torch.testing.assert_close(param, loaded_weight[:, 49:66])
+
+
+def test_padded_mx_scale_weight_loader_supports_tp4_mxfp8():
+    def weight_loader(param, loaded_weight):
+        shard_size = param.shape[param.input_dim]
+        start_idx = 3 * shard_size
+        param.data.copy_(loaded_weight.narrow(param.input_dim, start_idx, shard_size))
+
+    param = torch.nn.Parameter(torch.empty(2, 17), requires_grad=False)
+    param.input_dim = 1
+    loader = _make_padded_mx_scale_weight_loader(weight_loader, tp_size=4)
+    loaded_weight = torch.arange(2 * 66, dtype=torch.float32).reshape(2, 66)
+
+    loader(param, loaded_weight)
+
+    expected = torch.cat((loaded_weight[:, 51:66], torch.zeros(2, 2)), dim=1)
+    torch.testing.assert_close(param, expected)
 
 
 class TestAscendLinearMethod(TestBase):

--- a/tests/ut/quantization/test_method_adapters.py
+++ b/tests/ut/quantization/test_method_adapters.py
@@ -33,6 +33,24 @@ def test_mx_scale_weight_loader_preserves_group_phase():
     torch.testing.assert_close(param, loaded_weight[:, 49:66])
 
 
+def test_mx_scale_weight_loader_accepts_pre_sharded_scale():
+    weight_loader = MagicMock()
+    param = torch.nn.Parameter(torch.empty(2, 17), requires_grad=False)
+    param.input_dim = 1
+    loader = _make_mx_scale_weight_loader(
+        weight_loader,
+        tp_rank=3,
+        input_size_per_partition=528,
+        group_size=32,
+    )
+    loaded_weight = torch.arange(2 * 17, dtype=torch.float32).reshape(2, 17)
+
+    loader(param, loaded_weight)
+
+    weight_loader.assert_not_called()
+    torch.testing.assert_close(param, loaded_weight)
+
+
 class TestAscendLinearMethod(TestBase):
     def setUp(self):
         self.mock_scheme = MagicMock(spec=AscendLinearScheme)

--- a/tests/ut/quantization/test_method_adapters.py
+++ b/tests/ut/quantization/test_method_adapters.py
@@ -11,7 +11,6 @@ from vllm_ascend.quantization.method_adapters import (
     AscendKVCacheMethod,
     AscendLinearMethod,
     _make_mx_scale_weight_loader,
-    _make_padded_mx_scale_weight_loader,
 )
 from vllm_ascend.quantization.methods.base import AscendAttentionScheme, AscendLinearScheme, AscendMoEScheme
 
@@ -32,23 +31,6 @@ def test_mx_scale_weight_loader_preserves_group_phase():
 
     weight_loader.assert_not_called()
     torch.testing.assert_close(param, loaded_weight[:, 49:66])
-
-
-def test_padded_mx_scale_weight_loader_supports_tp4_mxfp8():
-    def weight_loader(param, loaded_weight):
-        shard_size = param.shape[param.input_dim]
-        start_idx = 3 * shard_size
-        param.data.copy_(loaded_weight.narrow(param.input_dim, start_idx, shard_size))
-
-    param = torch.nn.Parameter(torch.empty(2, 17), requires_grad=False)
-    param.input_dim = 1
-    loader = _make_padded_mx_scale_weight_loader(weight_loader, tp_size=4)
-    loaded_weight = torch.arange(2 * 66, dtype=torch.float32).reshape(2, 66)
-
-    loader(param, loaded_weight)
-
-    expected = torch.cat((loaded_weight[:, 51:66], torch.zeros(2, 2)), dim=1)
-    torch.testing.assert_close(param, expected)
 
 
 class TestAscendLinearMethod(TestBase):

--- a/vllm_ascend/quantization/method_adapters.py
+++ b/vllm_ascend/quantization/method_adapters.py
@@ -63,34 +63,6 @@ def _make_mx_scale_weight_loader(
     return mx_scale_weight_loader
 
 
-def _make_padded_mx_scale_weight_loader(weight_loader, tp_size: int):
-    """Pad MX scales so the upstream loader can shard them evenly.
-
-    Some MX schemes (for example W8A8 MXFP8) create one local scale for
-    every partial group, so the sum of the local scale counts can be a few
-    entries larger than the unsharded checkpoint tensor.  Pad those missing
-    tail entries before delegating to the standard TP loader.
-    """
-
-    def mx_scale_weight_loader(param: torch.nn.Parameter, loaded_weight: torch.Tensor):
-        input_dim = getattr(param, "input_dim", None)
-        if input_dim is not None:
-            expected_size = param.shape[input_dim] * tp_size
-            loaded_size = loaded_weight.shape[input_dim]
-            padding = expected_size - loaded_size
-            if 0 < padding < tp_size:
-                padded_shape = list(loaded_weight.shape)
-                padded_shape[input_dim] = expected_size
-                padded_weight = loaded_weight.new_zeros(padded_shape)
-                index = [slice(None)] * loaded_weight.ndim
-                index[input_dim] = slice(0, loaded_size)
-                padded_weight[tuple(index)] = loaded_weight
-                loaded_weight = padded_weight
-        return weight_loader(param, loaded_weight)
-
-    return mx_scale_weight_loader
-
-
 class AscendLinearMethod(LinearMethodBase):
     """Linear method for Ascend quantization.
 
@@ -199,20 +171,16 @@ class AscendLinearMethod(LinearMethodBase):
                 or is_mx_quant_type(self.quant_method)
             ):
                 param.input_dim = 1
-            if isinstance(layer, RowParallelLinear):
-                if getattr(self.quant_method, "supports_unaligned_tp_groups", False):
-                    assert hasattr(self.quant_method, "group_size")
-                    param.weight_loader = _make_mx_scale_weight_loader(
-                        weight_loader,
-                        layer.tp_rank,
-                        input_size_per_partition,
-                        self.quant_method.group_size,
-                    )
-                elif is_mx_quant_type(self.quant_method):
-                    # Preserve the established loading behavior for MX schemes
-                    # that do not implement group-phase-aware weight/activation
-                    # padding themselves (notably W8A8 MXFP8).
-                    param.weight_loader = _make_padded_mx_scale_weight_loader(weight_loader, layer.tp_size)
+            if isinstance(layer, RowParallelLinear) and getattr(
+                self.quant_method, "supports_unaligned_tp_groups", False
+            ):
+                assert hasattr(self.quant_method, "group_size")
+                param.weight_loader = _make_mx_scale_weight_loader(
+                    weight_loader,
+                    layer.tp_rank,
+                    input_size_per_partition,
+                    self.quant_method.group_size,
+                )
 
     def process_weights_after_loading(self, layer: torch.nn.Module) -> None:
         if hasattr(self.quant_method, "process_weights_after_loading"):

--- a/vllm_ascend/quantization/method_adapters.py
+++ b/vllm_ascend/quantization/method_adapters.py
@@ -48,6 +48,13 @@ def _make_mx_scale_weight_loader(
     """Load scales without losing the global MX group phase at TP boundaries."""
 
     def mx_scale_weight_loader(param: torch.nn.Parameter, loaded_weight: torch.Tensor):
+        # Some checkpoint loaders provide an already sharded tensor. Accept an
+        # exact local shape before applying any global TP offset to avoid
+        # slicing the same shard twice.
+        if loaded_weight.shape == param.shape:
+            param.data.copy_(loaded_weight)
+            return None
+
         input_dim = getattr(param, "input_dim", None)
         if input_dim is not None and input_size_per_partition % group_size != 0:
             global_start = tp_rank * input_size_per_partition

--- a/vllm_ascend/quantization/method_adapters.py
+++ b/vllm_ascend/quantization/method_adapters.py
@@ -39,6 +39,30 @@ def _forwardable_weight_attrs(extra_weight_attrs: dict) -> dict:
     return {key: value for key, value in extra_weight_attrs.items() if key not in _VLLM_PARAMETER_CTOR_ATTRS}
 
 
+def _make_mx_scale_weight_loader(
+    weight_loader,
+    tp_rank: int,
+    input_size_per_partition: int,
+    group_size: int,
+):
+    """Load scales without losing the global MX group phase at TP boundaries."""
+
+    def mx_scale_weight_loader(param: torch.nn.Parameter, loaded_weight: torch.Tensor):
+        input_dim = getattr(param, "input_dim", None)
+        if input_dim is not None and input_size_per_partition % group_size != 0:
+            global_start = tp_rank * input_size_per_partition
+            # A TP boundary can split an MX group. Start from the scale of
+            # that shared boundary group instead of evenly chunking scales.
+            scale_start = global_start // group_size
+            scale_count = param.shape[input_dim]
+            loaded_weight = loaded_weight.narrow(input_dim, scale_start, scale_count)
+            param.data.copy_(loaded_weight)
+            return None
+        return weight_loader(param, loaded_weight)
+
+    return mx_scale_weight_loader
+
+
 class AscendLinearMethod(LinearMethodBase):
     """Linear method for Ascend quantization.
 
@@ -147,6 +171,16 @@ class AscendLinearMethod(LinearMethodBase):
                 or is_mx_quant_type(self.quant_method)
             ):
                 param.input_dim = 1
+            if isinstance(layer, RowParallelLinear) and getattr(
+                self.quant_method, "supports_unaligned_tp_groups", False
+            ):
+                assert hasattr(self.quant_method, "group_size")
+                param.weight_loader = _make_mx_scale_weight_loader(
+                    weight_loader,
+                    layer.tp_rank,
+                    input_size_per_partition,
+                    self.quant_method.group_size,
+                )
 
     def process_weights_after_loading(self, layer: torch.nn.Module) -> None:
         if hasattr(self.quant_method, "process_weights_after_loading"):

--- a/vllm_ascend/quantization/method_adapters.py
+++ b/vllm_ascend/quantization/method_adapters.py
@@ -63,6 +63,34 @@ def _make_mx_scale_weight_loader(
     return mx_scale_weight_loader
 
 
+def _make_padded_mx_scale_weight_loader(weight_loader, tp_size: int):
+    """Pad MX scales so the upstream loader can shard them evenly.
+
+    Some MX schemes (for example W8A8 MXFP8) create one local scale for
+    every partial group, so the sum of the local scale counts can be a few
+    entries larger than the unsharded checkpoint tensor.  Pad those missing
+    tail entries before delegating to the standard TP loader.
+    """
+
+    def mx_scale_weight_loader(param: torch.nn.Parameter, loaded_weight: torch.Tensor):
+        input_dim = getattr(param, "input_dim", None)
+        if input_dim is not None:
+            expected_size = param.shape[input_dim] * tp_size
+            loaded_size = loaded_weight.shape[input_dim]
+            padding = expected_size - loaded_size
+            if 0 < padding < tp_size:
+                padded_shape = list(loaded_weight.shape)
+                padded_shape[input_dim] = expected_size
+                padded_weight = loaded_weight.new_zeros(padded_shape)
+                index = [slice(None)] * loaded_weight.ndim
+                index[input_dim] = slice(0, loaded_size)
+                padded_weight[tuple(index)] = loaded_weight
+                loaded_weight = padded_weight
+        return weight_loader(param, loaded_weight)
+
+    return mx_scale_weight_loader
+
+
 class AscendLinearMethod(LinearMethodBase):
     """Linear method for Ascend quantization.
 
@@ -171,16 +199,20 @@ class AscendLinearMethod(LinearMethodBase):
                 or is_mx_quant_type(self.quant_method)
             ):
                 param.input_dim = 1
-            if isinstance(layer, RowParallelLinear) and getattr(
-                self.quant_method, "supports_unaligned_tp_groups", False
-            ):
-                assert hasattr(self.quant_method, "group_size")
-                param.weight_loader = _make_mx_scale_weight_loader(
-                    weight_loader,
-                    layer.tp_rank,
-                    input_size_per_partition,
-                    self.quant_method.group_size,
-                )
+            if isinstance(layer, RowParallelLinear):
+                if getattr(self.quant_method, "supports_unaligned_tp_groups", False):
+                    assert hasattr(self.quant_method, "group_size")
+                    param.weight_loader = _make_mx_scale_weight_loader(
+                        weight_loader,
+                        layer.tp_rank,
+                        input_size_per_partition,
+                        self.quant_method.group_size,
+                    )
+                elif is_mx_quant_type(self.quant_method):
+                    # Preserve the established loading behavior for MX schemes
+                    # that do not implement group-phase-aware weight/activation
+                    # padding themselves (notably W8A8 MXFP8).
+                    param.weight_loader = _make_padded_mx_scale_weight_loader(weight_loader, layer.tp_size)
 
     def process_weights_after_loading(self, layer: torch.nn.Module) -> None:
         if hasattr(self.quant_method, "process_weights_after_loading"):

--- a/vllm_ascend/quantization/methods/w4a4/w4a4_mxfp4.py
+++ b/vllm_ascend/quantization/methods/w4a4/w4a4_mxfp4.py
@@ -21,6 +21,7 @@ import torch
 import torch.nn.functional as F
 import torch_npu
 from vllm.config import get_current_vllm_config
+from vllm.model_executor.layers.linear import RowParallelLinear
 from vllm.utils.math_utils import cdiv
 
 from vllm_ascend.ascend_config import get_ascend_config
@@ -85,6 +86,8 @@ class AscendW4A4MXFP4DynamicLinearMethod(AscendLinearScheme):
         WeightSwitchGatherSpec("weight_scale", gather_dim=1),
     )
     supports_weight_switch = True
+    # Row-parallel shards may start halfway through a global MX group.
+    supports_unaligned_tp_groups = True
 
     def __init__(self):
         vllm_config = get_current_vllm_config()
@@ -113,6 +116,14 @@ class AscendW4A4MXFP4DynamicLinearMethod(AscendLinearScheme):
         original_shape = x.shape
         if x.dim() > 2:
             x = x.view(-1, x.shape[-1])
+        # Read only an explicitly installed value. MagicMock-based CPU tests
+        # synthesize missing attributes and cannot be unpacked as a pair.
+        prefix_padding, suffix_padding = vars(layer).get("mxfp4_tp_padding", (0, 0))
+        if prefix_padding or suffix_padding:
+            # Apply the same padding as the weight so activation and weight MX
+            # groups cover identical K ranges. The padded zeros contribute
+            # nothing to GEMM, while keeping both operands' K dimensions equal.
+            x = F.pad(x, (prefix_padding, suffix_padding), mode="constant", value=0)
         quantized_x, dynamic_scale = torch_npu.npu_dynamic_mx_quant(
             x, dst_type=torch_npu.float4_e2m1fn_x2, round_mode="round"
         )
@@ -149,6 +160,28 @@ class AscendW4A4MXFP4DynamicLinearMethod(AscendLinearScheme):
         """
 
         _rename_packed_weight_parameter(layer, "weight")
+
+        # Row parallelism may split K in the middle of a globally quantized MX
+        # group. Prefix padding restores that group's original phase; suffix
+        # padding completes the final group. apply() pads activations at the
+        # same positions, so these zero-valued entries do not change the GEMM.
+        prefix_padding = suffix_padding = 0
+        if isinstance(layer, RowParallelLinear):
+            global_start = layer.tp_rank * layer.input_size_per_partition
+            prefix_padding = global_start % self.group_size
+            suffix_padding = -(prefix_padding + layer.input_size_per_partition) % self.group_size
+            # Packed FP4 stores two logical K values per byte, so logical
+            # padding is halved when applied to the packed weight tensor.
+            if prefix_padding % 2 != 0 or suffix_padding % 2 != 0:
+                raise ValueError("MXFP4 packed weight padding must be divisible by 2")
+            if prefix_padding or suffix_padding:
+                layer.weight.data = F.pad(
+                    layer.weight.data,
+                    (prefix_padding // 2, suffix_padding // 2),
+                    mode="constant",
+                    value=0,
+                )
+        layer.mxfp4_tp_padding = (prefix_padding, suffix_padding)
 
         n_dim, k_dim = layer.weight_scale.data.shape
         # Shape should be padded if it cannot be divided by 2
@@ -251,8 +284,17 @@ class AscendW4A4MXFP4DynamicFusedMoEMethod(AscendMoEScheme):
         _rename_packed_weight_parameter(layer, "w2_weight")
 
         g_num, n_size, k_size = layer.w13_weight_scale.shape
+        # The NPU scale layout packs two adjacent MX scales together. Append
+        # one neutral entry when a valid local shard contains an odd count.
+        if k_size % 2 != 0:
+            layer.w13_weight_scale.data = F.pad(layer.w13_weight_scale.data, (0, 1), mode="constant", value=0)
+            k_size += 1
         layer.w13_weight_scale.data = layer.w13_weight_scale.data.reshape(g_num, n_size, k_size // 2, 2)
         g_num, n_size, k_size = layer.w2_weight_scale.shape
+        # Apply the same pair-alignment rule independently to the down weight.
+        if k_size % 2 != 0:
+            layer.w2_weight_scale.data = F.pad(layer.w2_weight_scale.data, (0, 1), mode="constant", value=0)
+            k_size += 1
         layer.w2_weight_scale.data = layer.w2_weight_scale.data.reshape(g_num, n_size, k_size // 2, 2)
         # The A5 MXFP4 fused grouped-matmul-swiglu op relies on the
         # transpose stride to interpret packed FP4 weights as logical K.
@@ -289,6 +331,8 @@ class AscendW4A4MXFP4DynamicFusedMoEMethod(AscendMoEScheme):
         hidden_states, pertoken_scale = self._quant_hidden_states(hidden_states, mlp_compute_input.dynamic_scale)
         layer = mlp_compute_input.layer
         assert layer is not None
+        # Packed FP4 tensors use uint8 storage. Pass their logical dtype so the
+        # operator does not dispatch them as an unsupported uint8/uint8 pair.
         hidden_states = torch_npu.npu_grouped_matmul(
             x=[hidden_states],
             weight=[layer.w13_weight],
@@ -301,6 +345,8 @@ class AscendW4A4MXFP4DynamicFusedMoEMethod(AscendMoEScheme):
             output_dtype=torch.bfloat16,
             scale_dtype=torch_npu.float8_e8m0fnu,
             per_token_scale_dtype=torch_npu.float8_e8m0fnu,
+            x_dtype=torch_npu.float4_e2m1fn_x2,
+            weight_dtype=torch_npu.float4_e2m1fn_x2,
         )[0]
         dispose_tensor(mlp_compute_input.hidden_states)
         return hidden_states

--- a/vllm_ascend/quantization/methods/w8a8/w8a8_mxfp8.py
+++ b/vllm_ascend/quantization/methods/w8a8/w8a8_mxfp8.py
@@ -22,6 +22,7 @@ import torch.nn.functional as F
 import torch_npu
 from vllm.config import get_current_vllm_config
 from vllm.logger import logger
+from vllm.model_executor.layers.linear import RowParallelLinear
 from vllm.utils.math_utils import cdiv
 
 from vllm_ascend.ascend_config import get_ascend_config
@@ -61,6 +62,7 @@ class AscendW8A8MXFP8DynamicLinearMethod(AscendLinearScheme):
         WeightSwitchGatherSpec("weight_scale", gather_dim=1),
     )
     supports_weight_switch = True
+    supports_unaligned_tp_groups = True
 
     def __init__(self):
         vllm_config = get_current_vllm_config()
@@ -95,6 +97,9 @@ class AscendW8A8MXFP8DynamicLinearMethod(AscendLinearScheme):
             original_shape = x.shape
             if x.dim() > 2:
                 x = x.view(-1, x.shape[-1])
+            prefix_padding, suffix_padding = vars(layer).get("mxfp8_tp_padding", (0, 0))
+            if prefix_padding or suffix_padding:
+                x = F.pad(x, (prefix_padding, suffix_padding), mode="constant", value=0)
             quantized_x, pertoken_scale = torch_npu.npu_dynamic_mx_quant(
                 x,
                 dst_type=torch.float8_e4m3fn,
@@ -145,13 +150,28 @@ class AscendW8A8MXFP8DynamicLinearMethod(AscendLinearScheme):
         if getattr(layer, "_mxfp8_transformed", False):
             return
 
-        # Store original shapes for RL weight reloading
-        # Only store on first call (when shapes are in original format)
+        # Store the unpadded shapes expected by the checkpoint loader.
         if not hasattr(layer, "_mxfp8_original_shapes"):
             layer._mxfp8_original_shapes = {
                 "weight": tuple(layer.weight.data.shape),
                 "weight_scale": tuple(layer.weight_scale.data.shape),
             }
+
+        prefix_padding = suffix_padding = 0
+        if isinstance(layer, RowParallelLinear):
+            global_start = layer.tp_rank * layer.input_size_per_partition
+            prefix_padding = global_start % self.group_size
+            suffix_padding = -(prefix_padding + layer.input_size_per_partition) % self.group_size
+        layer.mxfp8_tp_padding = (prefix_padding, suffix_padding)
+
+        padded_weight = layer.weight.data
+        if prefix_padding or suffix_padding:
+            padded_weight = F.pad(
+                padded_weight,
+                (prefix_padding, suffix_padding),
+                mode="constant",
+                value=0,
+            )
 
         n_dim, k_dim = layer.weight_scale.data.shape
         # Shape should be padded if it cannot be divided by 2
@@ -164,11 +184,11 @@ class AscendW8A8MXFP8DynamicLinearMethod(AscendLinearScheme):
 
         if not hasattr(layer, "_mxfp8_weight_buf"):
             # First call: allocate the persistent transformed buffers.
-            layer._mxfp8_weight_buf = layer.weight.data.transpose(0, 1).contiguous()
+            layer._mxfp8_weight_buf = padded_weight.transpose(0, 1).contiguous()
             layer._mxfp8_scale_buf = target_scale.contiguous()
         else:
             # Subsequent calls (RL reload path): copy in place to keep data_ptr stable.
-            layer._mxfp8_weight_buf.copy_(layer.weight.data.transpose(0, 1).contiguous())
+            layer._mxfp8_weight_buf.copy_(padded_weight.transpose(0, 1).contiguous())
             layer._mxfp8_scale_buf.copy_(target_scale.contiguous())
 
         layer.weight.data = layer._mxfp8_weight_buf


### PR DESCRIPTION
# [Bugfix] Fix MXFP4 MoE scale layout and dtype handling

### What this PR does / why we need it?

This PR fixes several general compatibility issues in the Ascend W4A4 MXFP4 path.

#### Explicit MXFP4 dtype interpretation for grouped matmul

MXFP4 activations and weights are physically stored as `torch.uint8`. Without explicit logical dtype arguments, `npu_grouped_matmul` may interpret them as an unsupported `DT_UINT8`/`DT_UINT8` pair.

This PR explicitly passes:

~~~python
x_dtype=torch_npu.float4_e2m1fn_x2
weight_dtype=torch_npu.float4_e2m1fn_x2
~~~

The tensors are not converted or copied. These arguments tell the NPU operator to interpret the packed `uint8` data as MXFP4.

#### Support odd MXFP4 scale group counts

The existing scale conversion assumes that the final scale dimension is even before reshaping it into pairs:

~~~text
[G, N, K] -> [G, N, K // 2, 2]
~~~

Some valid tensor shapes produce an odd number of scale groups. Reshaping these scales directly causes a tensor shape mismatch.

This PR pads the final scale dimension with one zero when necessary before applying the existing paired layout conversion.

Existing checkpoints with an even number of scale groups continue to use the original path.

#### Support uneven row-parallel MX scale shards

Row-parallel MX scale parameters use a ceil-divided local group count. When the global number of scale groups is not divisible by the tensor-parallel size, the final shard can contain fewer valid groups than the allocated local parameter.

This PR adds an Ascend MX scale loader wrapper that pads the global scale tensor before delegating to the existing row-parallel weight loader.

Padding is applied only when:

~~~python
0 < padding < tp_size
~~~

This limits the behavior to the natural remainder introduced by tensor-parallel ceil division. Unexpected checkpoint shape mismatches are not hidden and continue to fail through the existing loader.

The compatibility logic applies only to:

- Ascend row-parallel linear layers
- MX quantization methods
- Per-group scale parameters

The generic vLLM weight loader remains unchanged.

### Does this PR introduce _any_ user-facing change?

Yes.

W4A4 MXFP4 models can now load and execute correctly when they use:

- Packed MXFP4 tensors requiring explicit logical dtype metadata
- An odd number of scale groups
- Scale dimensions that are not evenly divisible across tensor-parallel ranks

There are no API, command-line interface, or configuration changes.

### How was this patch tested?

Unit tests were added for:

- Odd MXFP4 MoE scale group padding
- Explicit MXFP4 logical dtype arguments passed to grouped matmul
- Uneven tensor-parallel MX scale padding

Static validation was performed with:

~~~bash
git diff --check
~~~

The unit tests could not be executed in the local development environment because PyTorch and an Ascend NPU runtime are unavailable.

The relevant tests can be run in a configured vLLM-Ascend development environment with:

~~~bash
pytest -q tests/ut/quantization/methods/test_w4a4_mxfp4.py
pytest -q tests/ut/quantization/test_method_adapters.py \
  -k mx_scale_weight_loader
~~~

End-to-end validation should cover W4A4 MXFP4 model loading and inference with multiple tensor-parallel configurations, including configurations where scale groups cannot be divided evenly across ranks.

- vLLM main: https://github.com/vllm-project/vllm/commit/b2f685834a6456197e7033966fdef52a23f1abcd
