### PR TITLE
[Doc][Getting Started] Make setup and first inference reproducible

### DIFF
--- a/docs/source/developer_guide/contribution/index.md
+++ b/docs/source/developer_guide/contribution/index.md
@@ -22,7 +22,7 @@ python3 -m venv .venv
 source ./.venv/bin/activate
 
 # Clone vllm-ascend and install
-git clone https://github.com/vllm-project/vllm-ascend.git
+git clone --branch main https://github.com/vllm-project/vllm-ascend.git
 cd vllm-ascend
 
 # Install lint requirement and enable pre-commit hook
@@ -39,8 +39,11 @@ After completing "Run lint" setup, you can run CI (Continuous integration) local
 ```bash
 cd ~/vllm-project/
 
-# Run CI needs vLLM installed
-git clone --branch {{ vllm_version }} https://github.com/vllm-project/vllm.git
+# Install the vLLM commit verified by the main-branch plugin checkout.
+VLLM_COMMIT=$(tr -d '[:space:]' < vllm-ascend/.github/vllm-main-verified.commit)
+git init vllm
+git -C vllm fetch --depth 1 https://github.com/vllm-project/vllm.git "$VLLM_COMMIT"
+git -C vllm checkout --detach FETCH_HEAD
 cd vllm
 pip install -r requirements/build.txt
 VLLM_TARGET_DEVICE="empty" pip install .

--- a/docs/source/developer_guide/contribution/testing.md
+++ b/docs/source/developer_guide/contribution/testing.md
@@ -23,7 +23,11 @@ The fastest way to set up a test environment is to use the main branch's contain
         -v $(pwd):/vllm-project \
         -v ~/.cache:/root/.cache \
         -ti $IMAGE bash
+    ```
 
+    Run the remaining commands inside the container:
+
+    ```bash
     # (Optional) Configure mirror to speed up download
     sed -i 's|ports.ubuntu.com|mirrors.huaweicloud.com|g' /etc/apt/sources.list
     pip config set global.index-url https://mirrors.huaweicloud.com/repository/pypi/simple/
@@ -40,7 +44,7 @@ The fastest way to set up a test environment is to use the main branch's contain
     apt-get install -y python3-pip git vim wget net-tools gcc g++ cmake libnuma-dev curl gnupg2
 
     git clone -b {{ vllm_ascend_version }} --depth 1 https://github.com/vllm-project/vllm-ascend.git
-    git clone --depth 1 https://github.com/vllm-project/vllm.git
+    git clone -b {{ vllm_version }} --depth 1 https://github.com/vllm-project/vllm.git
 
     # vllm
     cd $SRC_WORKSPACE/vllm
@@ -63,8 +67,8 @@ The fastest way to set up a test environment is to use the main branch's contain
 
     # Update DEVICE according to your device (/dev/davinci[0-7])
     export DEVICE=/dev/davinci0
-    # Update the vllm-ascend image
-    export IMAGE=quay.io/ascend/vllm-ascend:main
+    # A2 Ubuntu image; use nightly-main-a3 for A3 and add -openeuler for openEuler.
+    export IMAGE=quay.io/ascend/vllm-ascend:nightly-main
     docker run --rm \
         --name vllm-ascend \
         --shm-size=1g \
@@ -98,8 +102,8 @@ The fastest way to set up a test environment is to use the main branch's contain
 === "Multi-cards"
 
     ```bash
-    # Update the vllm-ascend image
-    export IMAGE=quay.io/ascend/vllm-ascend:main
+    # A2 Ubuntu image; use nightly-main-a3 for A3 and add -openeuler for openEuler.
+    export IMAGE=quay.io/ascend/vllm-ascend:nightly-main
     docker run --rm \
         --name vllm-ascend \
         --shm-size=1g \

--- a/docs/source/getting_started/installation/base_environment.inc.md
+++ b/docs/source/getting_started/installation/base_environment.inc.md
@@ -6,7 +6,13 @@
 
     #### Install CANN manually {: #installation-base-environment-install-cann }
 
-    Please refer to [CANN Installation Resources](https://www.hiascend.com/cann/download) or the following code to complete the installation.
+    The official [CANN Installation Resources](https://www.hiascend.com/cann/download) are the authoritative installation reference.
+
+    ???+ important "The example commands are for A2 only"
+
+        The commands below are for reference and install 910B Ops, which applies
+        only to A2. For other hardware, including Ascend 950DT, use the matching
+        Ops package according to the official guide.
 
     The commands below use the default CANN and NNAL installation paths. If you install either component in a non-default directory, source the corresponding `set_env.sh` from the actual installation directory.
 

--- a/docs/source/getting_started/quick_start.md
+++ b/docs/source/getting_started/quick_start.md
@@ -8,7 +8,8 @@ This guide uses Qwen3-0.6B as an example to help you run your first offline infe
 - Python: {{ release_python_version }}
 - Docker
 - Supported hardware:
-{% include "getting_started/installation/supported_hardware.inc.md" %}
+
+{% filter indent(4, true) %}{% include "getting_started/installation/supported_hardware.inc.md" %}{% endfilter %}
 
 ??? note "Software stack included in the vLLM Ascend image"
 

--- a/docs/source/getting_started/quick_start/online/qwen3-0.6b-310p.inc.md
+++ b/docs/source/getting_started/quick_start/online/qwen3-0.6b-310p.inc.md
@@ -30,22 +30,25 @@ You can query the model list:
 
 <!-- doctest: quickstart-300i-duo-online-model-list -->
 ```bash
-curl http://localhost:8000/v1/models | python3 -m json.tool
+curl --fail http://localhost:8000/v1/models
 ```
 
 You can also send a prompt to the model:
 
 <!-- doctest: quickstart-300i-duo-online-completion -->
 ```bash
-curl http://localhost:8000/v1/completions \
+curl --fail http://localhost:8000/v1/completions \
     -H "Content-Type: application/json" \
     -d '{
         "model": "Qwen/Qwen3-0.6B",
         "prompt": "Beijing is a",
-        "max_completion_tokens": 5,
+        "max_tokens": 5,
         "temperature": 0
-    }' | python3 -m json.tool
+    }'
 ```
+
+Confirm that the response contains nonempty generated text in `choices[0].text`.
+An error response or an empty completion does not confirm successful inference.
 
 vLLM is running as a background process. You can use `kill -2 $VLLM_PID` to stop it gracefully, which is similar to pressing `Ctrl+C` for a foreground vLLM process:
 

--- a/docs/source/getting_started/quick_start/online/qwen3-0.6b.inc.md
+++ b/docs/source/getting_started/quick_start/online/qwen3-0.6b.inc.md
@@ -20,22 +20,25 @@ You can query the model list:
 
 <!-- doctest: quickstart-standard-online-model-list -->
 ```bash
-curl http://localhost:8000/v1/models | python3 -m json.tool
+curl --fail http://localhost:8000/v1/models
 ```
 
 You can also send a prompt to the model:
 
 <!-- doctest: quickstart-standard-online-completion -->
 ```bash
-curl http://localhost:8000/v1/completions \
+curl --fail http://localhost:8000/v1/completions \
     -H "Content-Type: application/json" \
     -d '{
         "model": "Qwen/Qwen3-0.6B",
         "prompt": "Beijing is a",
-        "max_completion_tokens": 5,
+        "max_tokens": 5,
         "temperature": 0
-    }' | python3 -m json.tool
+    }'
 ```
+
+Confirm that the response contains nonempty generated text in `choices[0].text`.
+An error response or an empty completion does not confirm successful inference.
 
 vLLM is running as a background process. You can use `kill -2 $VLLM_PID` to stop it gracefully, which is similar to pressing `Ctrl+C` for a foreground vLLM process:
 


### PR DESCRIPTION
### What this PR does / why we need it?

Correct specific setup and first-inference ambiguities while preserving the existing documentation structure:

- Pair the main development checkout with its verified vLLM commit, and pair release CPU test checkouts with matching release tags.
- Identify commands that run inside the CPU test container and use the correct nightly image names for NPU examples.
- Clarify that the manual 910B Ops installation example applies to A2 and refer other hardware to the official CANN guide.
- Use `max_tokens` for completion requests, report HTTP failures with plain curl, and describe the expected nonempty completion.
- Fix the shared hardware table indentation in Quick Start so each product series renders as a separate row.

The existing chapters, hardware tabs, background-serving flow, startup/shutdown log examples, and four doctest stages are retained. No test infrastructure changes or new performance sections are included.

### Does this PR introduce _any_ user-facing change?

Only the documented commands and explanations change. There are no runtime/API changes. The examples retain the existing background-serving and process-lookup commands.

### How was this patch tested?

- `bash format.sh ci`: passed.
- Strict English documentation build via `tools/rtd_build.sh`: passed.
- 27 doctest helper tests passed; all eight online blocks extract and pass Bash syntax checks.
- Verified that the generated Quick Start hardware table contains four separate product-series rows. The original PID lookup and stop commands are retained.
- `git diff --check`: passed.

AI assistance was used for editing and local validation. NPU inference, CANN installation, source builds, and hardware-dependent tests have not been run on this macOS host. No performance measurements are claimed.

- vLLM main: https://github.com/vllm-project/vllm/commit/b2f685834a6456197e7033966fdef52a23f1abcd
