### PR TITLE
[0.27.1][BugFix][Feat] Fix  _prepare_prefill_topk_scores_kernel op

### DIFF
--- a/vllm_ascend/models/minimax_m3/ops/msa_m3_triton.py
+++ b/vllm_ascend/models/minimax_m3/ops/msa_m3_triton.py
@@ -35,6 +35,16 @@ else:
     get_aicore_num = _get_aicore_num
     init_device_properties_triton = _init_device_properties_triton
 
+get_vectorcore_num: Callable[[], Any] | None
+try:
+    from vllm_ascend.ops.triton.triton_utils import (
+        get_vectorcore_num as _get_vectorcore_num,
+    )
+except ImportError:
+    get_vectorcore_num = None
+else:
+    get_vectorcore_num = _get_vectorcore_num
+
 # Data-layout constants.
 SPARSE_BLOCK_SIZE = 128
 SCORE_BLOCK_STRIDE_ALIGNMENT = 16
@@ -46,6 +56,11 @@ PREFILL_SCORE_QUERY_TILE_SIZE = 96
 # available; 32 is only a fallback when device-property discovery is unavailable.
 DECODE_SCORE_FALLBACK_PROGRAM_COUNT = 32
 DECODE_SCORE_MAX_CHUNK_COUNT = 256
+
+# Prefill prepare is a Vector/AIV workload. Keep the logical grid close to the
+# detected Vector Core count; each program processes a contiguous query range
+# for one (batch, head) group and only writes contiguous block segments.
+PREFILL_PREPARE_FALLBACK_VECTORCORE_COUNT = 64
 
 _FP8_DTYPES = (torch.float8_e4m3fn, torch.float8_e5m2)
 
@@ -136,6 +151,26 @@ def _detected_aicore_count() -> int:
     try:
         init_device_properties_triton()
         return max(0, int(get_aicore_num()))
+    except Exception:
+        return 0
+
+
+@lru_cache(maxsize=1)
+def _detected_vectorcore_count() -> int:
+    """Returns the detected Ascend Vector Core count, or zero on fallback."""
+    if get_vectorcore_num is None or init_device_properties_triton is None:
+        return 0
+    try:
+        detected = int(get_vectorcore_num())
+        if detected > 0:
+            return detected
+    except AssertionError:
+        pass
+    except Exception:
+        return 0
+    try:
+        init_device_properties_triton()
+        return max(0, int(get_vectorcore_num()))
     except Exception:
         return 0
 
@@ -539,109 +574,55 @@ def _prepare_prefill_topk_scores_kernel(
     score_token_stride,
     score_block_stride,
     sparse_block_size: tl.constexpr,
-    BLOCK_SIZE_Q: tl.constexpr,
+    MAX_QUERY_LEN: tl.constexpr,
+    PROGRAMS_PER_BATCH_HEAD: tl.constexpr,
     BLOCK_SIZE_FORCE: tl.constexpr,
-    BLOCK_SIZE_TAIL: tl.constexpr,
 ):
-    """Applies init/local priorities and fills the invalid score tail."""
-    tl.static_assert(sparse_block_size >= BLOCK_SIZE_Q)
-
-    query_tile_id = tl.program_id(0)
+    """Applies init/local priorities with contiguous block stores."""
+    query_program_id = tl.program_id(0)
     batch_head_id = tl.program_id(1)
     batch_id = batch_head_id // index_head_count
     head_id = batch_head_id % index_head_count
 
+    # Programs are divided across each (batch, head) group. Each program owns
+    # one contiguous query range; query is a scalar loop dimension, while the
+    # vector dimension is always the contiguous score block dimension.
+    base_queries: tl.constexpr = MAX_QUERY_LEN // PROGRAMS_PER_BATCH_HEAD
+    extra_programs: tl.constexpr = MAX_QUERY_LEN % PROGRAMS_PER_BATCH_HEAD
+    query_count = base_queries + tl.where(query_program_id < extra_programs, 1, 0)
+    query_start = query_program_id * base_queries + tl.minimum(query_program_id, extra_programs)
+
     sequence_start = tl.load(query_start_offsets_ptr + batch_id)
     sequence_end = tl.load(query_start_offsets_ptr + batch_id + 1)
     query_length = sequence_end - sequence_start
-    query_tile_start = query_tile_id * BLOCK_SIZE_Q
-    if query_tile_start >= query_length:
-        return
-
-    query_lane_offsets = tl.arange(0, BLOCK_SIZE_Q)
-    query_offsets = query_tile_start + query_lane_offsets
-    query_mask = query_offsets < query_length
-    token_indices = sequence_start + query_offsets
     prefix_length = tl.load(prefix_lengths_ptr + batch_id)
 
-    valid_block_counts = (prefix_length + query_offsets + sparse_block_size) // sparse_block_size
-    valid_block_counts = tl.minimum(
-        valid_block_counts,
-        score_block_count,
-    )
+    block_offsets = tl.arange(0, BLOCK_SIZE_FORCE)
+    safe_last_block = tl.maximum(score_block_count - 1, 0)
 
-    # Because BLOCK_SIZE_Q <= sparse_block_size, one query tile contains at
-    # most two consecutive valid-block counts.
-    min_valid_block_count = (prefix_length + query_tile_start + sparse_block_size) // sparse_block_size
-    min_valid_block_count = tl.minimum(
-        min_valid_block_count,
-        score_block_count,
-    )
-    max_valid_block_count = tl.minimum(
-        min_valid_block_count + 1,
-        score_block_count,
-    )
+    for query_inner in tl.range(0, query_count):
+        query_offset = query_start + query_inner
+        query_valid = query_offset < query_length
+        safe_query_offset = tl.where(query_valid, query_offset, 0)
+        token_index = sequence_start + safe_query_offset
 
-    score_row_ptrs = score_ptr + head_id * score_head_stride + token_indices[:, None] * score_token_stride
-    forced_block_offsets = tl.arange(0, BLOCK_SIZE_FORCE)
+        valid_block_count = (prefix_length + safe_query_offset + sparse_block_size) // sparse_block_size
+        valid_block_count = tl.minimum(tl.maximum(valid_block_count, 0), score_block_count)
+        local_start = tl.maximum(valid_block_count - local_block_count, 0)
+        row_base = score_ptr + head_id * score_head_stride + token_index * score_token_stride
 
-    if init_block_count > 0:
-        init_mask = (
-            query_mask[:, None]
-            & (forced_block_offsets[None, :] < init_block_count)
-            & (forced_block_offsets[None, :] < valid_block_counts[:, None])
-        )
-        tl.store(
-            score_row_ptrs + forced_block_offsets[None, :] * score_block_stride,
-            1e30,
-            mask=init_mask,
-        )
+        if init_block_count > 0:
+            init_count = tl.minimum(init_block_count, valid_block_count)
+            init_block_ids = tl.minimum(block_offsets, safe_last_block)
+            init_mask = query_valid & (block_offsets < init_count)
+            tl.store(row_base + init_block_ids * score_block_stride, 1e30, mask=init_mask)
 
-    rows_with_min_count = query_mask & (valid_block_counts == min_valid_block_count)
-    rows_with_max_count = query_mask & (valid_block_counts > min_valid_block_count)
-
-    if local_block_count > 0:
-        min_local_start = tl.maximum(
-            0,
-            min_valid_block_count - local_block_count,
-        )
-        min_local_count = min_valid_block_count - min_local_start
-        min_local_blocks = min_local_start + forced_block_offsets
-        tl.store(
-            score_row_ptrs + min_local_blocks[None, :] * score_block_stride,
-            1e29,
-            mask=(rows_with_min_count[:, None] & (forced_block_offsets[None, :] < min_local_count)),
-        )
-
-        max_local_start = tl.maximum(
-            0,
-            max_valid_block_count - local_block_count,
-        )
-        max_local_count = max_valid_block_count - max_local_start
-        max_local_blocks = max_local_start + forced_block_offsets
-        tl.store(
-            score_row_ptrs + max_local_blocks[None, :] * score_block_stride,
-            1e29,
-            mask=(rows_with_max_count[:, None] & (forced_block_offsets[None, :] < max_local_count)),
-        )
-
-    tail_lane_offsets = tl.arange(0, BLOCK_SIZE_TAIL)
-    tail_block_count = score_block_count - min_valid_block_count
-    for tail_offset in tl.range(
-        0,
-        tail_block_count,
-        BLOCK_SIZE_TAIL,
-    ):
-        block_ids = min_valid_block_count + tail_offset + tail_lane_offsets
-        block_mask = block_ids < score_block_count
-        row_mask = rows_with_min_count[:, None] | (
-            rows_with_max_count[:, None] & (block_ids[None, :] >= max_valid_block_count)
-        )
-        tl.store(
-            score_row_ptrs + block_ids[None, :] * score_block_stride,
-            float("-inf"),
-            mask=row_mask & block_mask[None, :],
-        )
+        if local_block_count > 0:
+            local_count = valid_block_count - local_start
+            local_block_ids = local_start + block_offsets
+            safe_local_block_ids = tl.minimum(local_block_ids, safe_last_block)
+            local_mask = query_valid & (block_offsets < local_count)
+            tl.store(row_base + safe_local_block_ids * score_block_stride, 1e29, mask=local_mask)
 
 
 @triton.heuristics({"BLOCK_SIZE_T": lambda args: triton.next_power_of_2(args["topk"])})
@@ -1215,8 +1196,9 @@ def minimax_m3_index_score(
         max_block_count,
         SCORE_BLOCK_STRIDE_ALIGNMENT,
     )
-    score = torch.empty(
+    score = torch.full(
         (index_head_count, total_query_tokens, score_block_stride),
+        float("-inf"),
         dtype=torch.float32,
         device=idx_q.device,
     )
@@ -1268,21 +1250,15 @@ def minimax_m3_index_topk(
     batch_size = cu_seqlens_q.shape[0] - 1
 
     force_tile_size = triton.next_power_of_2(max(1, init_blocks, local_blocks))
-    total_query_rows = max(
-        1,
-        max_query_len * batch_size * index_head_count,
+    batch_head_count = max(1, batch_size * index_head_count)
+    detected_vectorcore_count = _detected_vectorcore_count()
+    target_program_count = (
+        detected_vectorcore_count if detected_vectorcore_count > 0 else PREFILL_PREPARE_FALLBACK_VECTORCORE_COUNT
     )
-    required_query_tile_size = triton.cdiv(total_query_rows, 128)
-    base_query_tile_size = min(
-        64,
-        triton.next_power_of_2(required_query_tile_size),
-    )
-    finalize_query_tile_size = max(8, base_query_tile_size)
-    finalize_grid = (
-        triton.cdiv(max_query_len, finalize_query_tile_size),
-        batch_size * index_head_count,
-    )
-    _prepare_prefill_topk_scores_kernel[finalize_grid](
+    programs_per_batch_head = max(1, triton.cdiv(target_program_count, batch_head_count))
+    programs_per_batch_head = min(programs_per_batch_head, max(1, max_query_len))
+    prepare_grid = (programs_per_batch_head, batch_head_count)
+    _prepare_prefill_topk_scores_kernel[prepare_grid](
         score,
         cu_seqlens_q,
         prefix_lens,
@@ -1294,10 +1270,14 @@ def minimax_m3_index_topk(
         score.stride(1),
         score.stride(2),
         sparse_block_size=SPARSE_BLOCK_SIZE,
-        BLOCK_SIZE_Q=finalize_query_tile_size,
+        MAX_QUERY_LEN=max(1, max_query_len),
+        PROGRAMS_PER_BATCH_HEAD=programs_per_batch_head,
         BLOCK_SIZE_FORCE=force_tile_size,
-        BLOCK_SIZE_TAIL=16,
     )
+
+    total_query_rows = max(1, max_query_len * batch_size * index_head_count)
+    required_query_tile_size = triton.cdiv(total_query_rows, 128)
+    base_query_tile_size = min(64, triton.next_power_of_2(required_query_tile_size))
 
     selected_count = min(topk, score_block_count)
     score_rows = score[:, :total_query_tokens, :score_block_count]


### PR DESCRIPTION
### What this PR does / why we need it?

This PR fixes the MiniMax-M3 prefill index top-k score preparation path on Ascend A3.

On A3 with Triton-Ascend 3.2.2, the previous `_prepare_prefill_topk_scores_kernel` could fail during sustained MiniMax-M3 serving workloads such as TerminalBench.

Two device-side failure modes were observed during investigation:

* The original query-tiled 2-D masked tail-store implementation could trigger an MTE/SMMU fault with `The DDR address of the MTE instruction is out of range`.
* A follow-up implementation that converted the stores to query-direction 1-D stores could trigger a Vector Core timeout/trap during real serving workloads.

The original implementation vectorized score updates across the query dimension, while the score tensor layout is:

```text
[num_index_heads, total_query_tokens, score_blocks]
```

where `score_blocks` is the contiguous dimension.

This PR changes the prefill score preparation to follow the tensor layout directly:

* Initialize the score buffer to `-inf`, so invalid/padded score blocks no longer need a separate tail-fill path.
* Keep the existing prefill QK score computation unchanged.
* Treat one `(query, index_head)` row as the logical preparation unit.
* Apply init/local forced priorities using block-contiguous stores along the last dimension.
* Keep query handling as task scheduling rather than using query as the vectorized memory-access dimension.
* Use an AIV-oriented program mapping so large/ragged prefills do not create one launched program per `(query, head)` and exceed the Ascend `coreDim <= 65535` launch limit.
* Preserve the existing public operator APIs and priority semantics:

  * init blocks: `1e30`
  * local blocks: `1e29`
  * local priority overrides init priority when they overlap
  * invalid blocks remain `-inf`

This removes the dynamic invalid-tail store path and avoids both the previous `[query, block]` masked GM store pattern and query-direction strided Vector stores.

The issue was reproduced on MiniMax-M3 running on Ascend A3 with DP=2 / TP=8 across 16 devices under sustained TerminalBench workloads.

The workaround is based on behavior observed with Triton-Ascend 3.2.2. The exact compiler/backend root cause has not been proven, so the implementation should be re-evaluated after Triton-Ascend upgrades.

### Does this PR introduce *any* user-facing change?

No.

The public APIs, model behavior, output layout, top-k semantics, and sparse-attention semantics are unchanged.

This PR only changes the internal Triton implementation and task mapping used by MiniMax-M3 prefill index-score preparation on Ascend.

### How was this patch tested?

The patch was validated with standalone correctness cases, TerminalBench-style workload sweeps, and real MiniMax-M3 serving workloads on Ascend A3.

Correctness coverage includes:

* sparse-block boundaries: query lengths `127`, `128`, and `129`
* ragged query batches
* long invalid score tails
* init/local overlap
* `2048` / `2049` prefill boundary cases
* large ragged prefill workloads
* block counts matching the production workload range, including `480` and `528`

The regression tests verify the complete prefill index path:

```text
index score
→ score preparation
→ torch.topk
→ invalid-index masking
```

Representative TerminalBench-style end-to-end results with 528 score blocks:

```text
q=2048, prefix=0:
baseline  p50 = 2392.265 us
patched   p50 =  803.281 us

q=2048, prefix=32768:
baseline  p50 = 2006.960 us
patched   p50 =  847.873 us

q=2048, prefix=65512:
baseline  p50 = 1628.907 us
patched   p50 = 1537.166 us

q=4096, prefix=32768:
baseline  p50 = 1362.001 us
patched   p50 = 1315.651 us

q=8192, prefix=32768:
baseline  p50 = 2416.103 us
patched   p50 = 2336.767 us

q=32768, prefix=0:
baseline  p50 = 4760.416 us
patched   p50 = 4365.349 us
```

A large ragged TerminalBench-style workload also passed:

```text
query lengths:
[2048, 2048, 4096, 8192, 16384]

prefix lengths:
[0, 8192, 16384, 32768, 0]

total query tokens:
32768

score blocks:
528

baseline  p50 = 4809.989 us
patched   p50 = 4567.960 us
```

This case previously exposed the `coreDim` limitation for the direct one-query-per-program A5-style launch (`81920 > 65535`). The patched task mapping completes successfully.

Additional regression guards were added for the failure boundaries and large/ragged workloads. Large TerminalBench-style cases are kept as nightly/stability guards rather than regular lightweight CI cases.

- vLLM main: https://github.com/vllm-project/vllm/commit/ba07e4a48fc951300d97eb506217dd530583dea3
