### PR TITLE
[Cherry-pick][Bugfix]Use full vector cores in scatter_nd_update_sk tiling

### DIFF
--- a/csrc/moe/scatter_nd_update_sk/op_host/scatter_nd_update_sk_tiling.cpp
+++ b/csrc/moe/scatter_nd_update_sk/op_host/scatter_nd_update_sk_tiling.cpp
@@ -505,14 +505,8 @@ ge::graphStatus ScatterNdUpdateSkArch22Tiling::Init()
     }
     auto compileInfo = tilingContext_->GetCompileInfo<ScatterNdUpdateSkArch22CompileInfo>();
     OP_CHECK_NULL_WITH_CONTEXT(tilingContext_, compileInfo);
-    coreNum_ = std::min(static_cast<uint64_t>(compileInfo->vectorCoreNum), std::min(info.totalLength, info.indexRow));
-    coreNum_ = coreNum_ == 0 ? 1 : coreNum_;
-
-    // Align coreNum_ to even: SyncAll-based kernels require an even number of
-    // cores per block (see https://gitcode.com/cann/ops-nn/pull/9645).
-    if (coreNum_ % 2 != 0) {
-        coreNum_ += 1;
-    }
+    // Use all available vector cores for full-core scheduling.
+    coreNum_ = static_cast<uint64_t>(compileInfo->vectorCoreNum);
     ubSize_ = compileInfo->ubSize;
     GetDtypeSize();
     SetTilingKeyMode();


### PR DESCRIPTION
### What this PR does / why we need it:
Cherry-pick of #15901 to main.

The previous tiling clamped `coreNum_` to `min(totalLength, indexRow)` and aligned it up to an even number, which under-utilized the device when the workload was small. This PR removes the clamping and alignment so the kernel is always scheduled with all available vector cores; the front/tail block distribution logic already handles `coreNum_ > workload` gracefully.

Backport of #15901 (merged into releases/v0.26.0rc).

- vLLM main: https://github.com/vllm-project/vllm/commit/b2f685834a6456197e7033966fdef52a23f1abcd
