### PR TITLE
[Cherry-pick][Bugfix] Align swiglu limit attr type

### DIFF
--- a/csrc/gmm/grouped_matmul_swiglu_quant/op_host/grouped_matmul_swiglu_quant_tiling.cpp
+++ b/csrc/gmm/grouped_matmul_swiglu_quant/op_host/grouped_matmul_swiglu_quant_tiling.cpp
@@ -140,7 +140,9 @@ ASCENDC_EXTERN_C graphStatus TilingGMMSwigluQuant(gert::TilingContext *context)
     auto attrs = context->GetAttrs();
     float limited = 0.0f;
     if (attrs != nullptr) {
-        if (const double *limitedPtr = attrs->GetAttrPointer<double>(ATTR_INDEX_LIMITED)) {
+        if (const float *limitedPtr = attrs->GetAttrPointer<float>(ATTR_INDEX_LIMITED)) {
+            limited = *limitedPtr;
+        } else if (const double *limitedPtr = attrs->GetAttrPointer<double>(ATTR_INDEX_LIMITED)) {
             limited = static_cast<float>(*limitedPtr);
         }
     }

--- a/csrc/gmm/grouped_matmul_swiglu_quant/op_host/op_api/aclnn_grouped_matmul_swiglu_quant.cpp
+++ b/csrc/gmm/grouped_matmul_swiglu_quant/op_host/op_api/aclnn_grouped_matmul_swiglu_quant.cpp
@@ -452,7 +452,8 @@ static aclnnStatus aclnnGroupedMatmulSwigluQuantGetWorkspaceSizeCommon(
     if (isEnableWeightAssistanceMatrix && weightScale->GetViewShape().GetDimNum() == WEIGHT_SCALE_PERGROUP_DIM_LIMIT) {
         dequantMode = 1;
     }
-    auto ret_0 = l0op::GroupedMatmulSwigluQuant(x, weight, weightScale, xScale, groupList, limited, bias,
+    const float limitedAttr = static_cast<float>(limited);
+    auto ret_0 = l0op::GroupedMatmulSwigluQuant(x, weight, weightScale, xScale, groupList, limitedAttr, bias,
                                                 isEnableWeightAssistanceMatrix, dequantMode, uniqueExecutor.get());
     CHECK_RET(ret_0 != std::tuple(nullptr, nullptr), ACLNN_ERR_INNER_NULLPTR);
     auto out0 = std::get<OUTPUT_IDX_0>(ret_0);
@@ -491,7 +492,7 @@ aclnnStatus aclnnGroupedMatmulSwigluQuantWeightNZGetWorkspaceSize(const aclTenso
 {
     OP_CHECK_COMM_INPUT(workspaceSize, executor);
     L2_DFX_PHASE_1(aclnnGroupedMatmulSwigluQuantWeightNZ,
-                   DFX_IN(x, weight, bias, offset, weightScale, xScale, groupList),
+                   DFX_IN(x, weight, bias, offset, weightScale, xScale, groupList, limited),
                    DFX_OUT(output, outputScale, outputOffset));
     // weight在该场景下强制绑定StorageFormat 和 ViewFormat 为NZ
     CHECK_RET(weight != nullptr, ACLNN_ERR_PARAM_NULLPTR);

--- a/csrc/gmm/grouped_matmul_swiglu_quant/op_host/op_api/grouped_matmul_swiglu_quant.cpp
+++ b/csrc/gmm/grouped_matmul_swiglu_quant/op_host/op_api/grouped_matmul_swiglu_quant.cpp
@@ -20,7 +20,7 @@ OP_TYPE_REGISTER(GroupedMatmulSwigluQuant);
 
 const std::tuple<aclTensor *, aclTensor *>
 GroupedMatmulSwigluQuant(const aclTensor *x, const aclTensor *weight, const aclTensor *perChannelScale,
-                         const aclTensor *perTokenScale, const aclTensor *groupList, double limited,
+                         const aclTensor *perTokenScale, const aclTensor *groupList, float limited,
                          const aclTensor *weightAssistanceMatrix, bool isEnableWeightAssistanceMatrix, int dequantMode,
                          aclOpExecutor *executor)
 {

--- a/csrc/gmm/grouped_matmul_swiglu_quant/op_host/op_api/grouped_matmul_swiglu_quant.h
+++ b/csrc/gmm/grouped_matmul_swiglu_quant/op_host/op_api/grouped_matmul_swiglu_quant.h
@@ -15,7 +15,7 @@
 namespace l0op {
 const std::tuple<aclTensor *, aclTensor *>
 GroupedMatmulSwigluQuant(const aclTensor *x, const aclTensor *weight, const aclTensor *perChannelScale,
-                         const aclTensor *perTokenScale, const aclTensor *groupList, double limited,
+                         const aclTensor *perTokenScale, const aclTensor *groupList, float limited,
                          const aclTensor *weightAssistanceMatrix, bool isEnableWeightAssistanceMatrix, int dequantMode,
                          aclOpExecutor *executor);
 }


### PR DESCRIPTION
### What this PR does / why we need it:
Cherry-pick of #15933 to main.

Cast `limited` to float before passing it into the L0 OP_ATTR path for GroupedMatmulSwigluQuant, matching the OpDef Float attr and static-kernel dump expectations. Also read the attr as float in tiling with a double fallback.

Backport of #15933 (merged into releases/v0.26.0rc).

- vLLM main: https://github.com/vllm-project/vllm/commit/b2f685834a6456197e7033966fdef52a23f1abcd
