### PR TITLE
[BugFix][P/D] Register padded hybrid KV cache spans

### DIFF
--- a/tests/ut/kv_offload/test_mooncake_hybrid_connector.py
+++ b/tests/ut/kv_offload/test_mooncake_hybrid_connector.py
@@ -21,6 +21,7 @@ from vllm_ascend.distributed.kv_transfer.kv_p2p.mooncake_hybrid_connector import
     KVCacheRecvingThread,
     MooncakeConnectorScheduler,
     MooncakeConnectorWorker,
+    _get_tensor_transfer_span_bytes,
 )
 
 
@@ -243,6 +244,13 @@ class TestHybridKVCacheRecvingThreadDispatch(unittest.TestCase):
 
 
 class TestMooncakeHybridConnectorRegistration(unittest.TestCase):
+    def test_transfer_span_includes_inter_block_padding(self):
+        backing = torch.empty(18, dtype=torch.uint8)
+        tensor = torch.as_strided(backing, size=(3, 4), stride=(6, 1))
+
+        self.assertEqual(tensor.numel() * tensor.element_size(), 12)
+        self.assertEqual(_get_tensor_transfer_span_bytes(tensor), 18)
+
     def test_hybrid_registration_uses_actual_merged_tensor_ranges(self):
         alignment = 2 * 1024 * 1024
         backing_size = 4 * alignment

--- a/vllm_ascend/distributed/kv_transfer/kv_p2p/mooncake_hybrid_connector.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_p2p/mooncake_hybrid_connector.py
@@ -1773,7 +1773,7 @@ class MooncakeConnectorWorker:
                     if not isinstance(kv_cache_tuple, (tuple, list)):
                         kv_cache_tuple = [kv_cache_tuple]
                     for tensor in kv_cache_tuple:
-                        tensor_nbytes = tensor.element_size() * math.prod(tensor.shape)
+                        tensor_nbytes = _get_tensor_transfer_span_bytes(tensor)
                         if tensor_nbytes == 0:
                             continue
                         tensor_addrs.append(tensor.data_ptr())
@@ -2121,6 +2121,24 @@ def group_concurrent_contiguous(
     dst_groups = [g.tolist() for g in dst_groups]
 
     return src_groups, dst_groups
+
+
+def _get_tensor_transfer_span_bytes(tensor: torch.Tensor) -> int:
+    """Return the byte span touched by block-stride KV transfers.
+
+    Hybrid KV tensors can have padding between blocks, so ``numel()`` does
+    not describe the physical range transferred by the connector. The
+    transfer path copies one full ``stride(0)`` for every block, including
+    the final block.
+    """
+    if tensor.numel() == 0:
+        return 0
+    if tensor.dim() == 0:
+        return tensor.element_size()
+    block_stride = tensor.stride(0)
+    if block_stride <= 0:
+        raise ValueError(f"KV cache block stride must be positive, got {block_stride}.")
+    return tensor.shape[0] * block_stride * tensor.element_size()
 
 
 def string_to_int64_hash(input_str):


### PR DESCRIPTION
### What this PR does / why we need it?

When standardized hybrid KV-cache descriptors are used, `MooncakeConnectorWorker.register_kv_caches` derives each registered region from the runtime tensor views.

The existing code used `tensor.numel() * tensor.element_size()` as the region length. That only covers the logical payload. Some hybrid KV tensors have padding between blocks, so their first-dimension byte stride is larger than the per-block payload. Mooncake later computes block addresses with that stride. A high block can therefore be outside the registered region even though it is inside the backing allocation.

DeepSeek V4 reproduced this with a 4096-byte indexer payload and a 4160-byte block stride. The old calculation registered 114 MiB for 28,743 blocks, while the strided allocation requires 116 MiB after Mooncake alignment. Accessing block 28,738 then failed remote-buffer lookup and led to downstream HCCL/AICPU errors and invalid sampling values.

This change registers `shape[0] * stride(0) * element_size()` bytes for each tensor view and adds a focused regression test for a padded view.

This is complementary to #16086: that PR fixes standardized hybrid descriptor reconstruction and address mapping, while this PR fixes the registration range used by those addresses.

### Does this PR introduce _any_ user-facing change?

No API or configuration change. P/D KV transfer now correctly handles hybrid KV-cache tensors whose block stride includes padding.

### How was this patch tested?

- Added a unit regression test using an `as_strided` tensor whose block stride exceeds its logical payload.
- `python -m py_compile vllm_ascend/distributed/kv_transfer/kv_p2p/mooncake_hybrid_connector.py tests/ut/kv_offload/test_mooncake_hybrid_connector.py`
- `git diff --check origin/main...HEAD`
- Manually validated on Ascend A3 with DeepSeek V4 Flash P/D + DSpark:
  - P: DP4 x TP4; D: DP16 x TP1; four concurrent EvalScope clients.
  - Reproduced the old failure at a high indexer block with the 114 MiB registration.
  - With this patch, the same high-block transfer (including blocks 28,739 through 28,736) completed successfully.
  - Continued for more than 30,000 audited KV transfers with no address OOB, descriptor mismatch, Mooncake transfer failure, NaN, IndexCheck, or EZ9999 error.

The full local pytest target could not be started in the Windows checkout because its vLLM/Ascend test dependencies are not installed; CI is expected to run the added unit test.
- vLLM main: https://github.com/vllm-project/vllm/commit/b2f685834a6456197e7033966fdef52a23f1abcd
