### PR TITLE
[BugFix]Fix eagle external hit trim condition to apply without layerwise mode

### DIFF
--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/pool_scheduler.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/pool_scheduler.py
@@ -505,7 +505,7 @@ class KVPoolScheduler:
             return 0, False
 
         store_skip_tokens = num_external_hit_tokens
-        if self.use_layerwise and self.use_eagle:
+        if self.use_eagle:
             # Keep the draft model's recomputation zone intact: the
             # generation-point hidden states must be freshly computed, and the
             # local prefix-cache path already drops its trailing block


### PR DESCRIPTION
### What this PR does / why we need it?
The draft model's recomputation zone trimming of the external KV pool hit is required whenever EAGLE speculative decoding is enabled, not only when layerwise mode is also active. Change the condition from `use_layerwise and use_eagle` to `use_eagle` so that (local + external) never covers the last block whose KV the engine rewrites during MTP draft/verify steps.

### Does this PR introduce _any_ user-facing change?
NA

### How was this patch tested?
···
KV_CONFIG='{
  "kv_connector":"AscendStoreConnector",
  "kv_role":"kv_both",
  "kv_load_failure_policy":"recompute",
  "kv_connector_extra_config":{
    "backend":"mooncake",
    "lookup_rpc_port":"11301"
  }
}'

python3 -m vllm.entrypoints.cli.main serve "$MODEL" \
  --served-model-name minimax-m3 \
  --host 0.0.0.0 \
  --port 8000 \
  --trust-remote-code \
  --language-model-only \
  --quantization ascend \
  --max-model-len 131072 \
  --tensor-parallel-size 4 \
  --pipeline-parallel-size 2 \
  --data-parallel-size 2 \
  --api_server_count 1 \
  --max-num-batched-tokens 32768 \
  --long-prefill-token-threshold 4096 \
  --enable-expert-parallel \
  --max-num-seqs 16 \
  --distributed-executor-backend mp \
  --gpu-memory-utilization 0.92 \
  --reasoning-parser minimax_m3 \
  --speculative-config \
    "{\"model\":\"$DRAFT_MODEL\",\"method\":\"eagle3\",\"num_speculative_tokens\":3}" \
  --compilation-config \
    '{"cudagraph_mode":"FULL_DECODE_ONLY"}' \
  --additional-config \
    '{"enable_cpu_binding":true,"ascend_compilation_config":{"enable_static_kernel":false,"fuse_norm_quant":false},"multistream_overlap_shared_expert":true,"enable_shared_expert_dp":true,"weight_nz_mode":2,"enable_reduce_sample":true}' \
  --kv-transfer-config "$KV_CONFIG"
···
- vLLM main: https://github.com/vllm-project/vllm/commit/b2f685834a6456197e7033966fdef52a23f1abcd
