### PR TITLE
[Test] Drop remote --headless for vLLM 0.28 hybrid DP nightlies

### DIFF
--- a/tests/e2e/nightly/multi_node/internal_dp/config/GLM-5.1-W8A8C8-A3_128k_90_50.yaml
+++ b/tests/e2e/nightly/multi_node/internal_dp/config/GLM-5.1-W8A8C8-A3_128k_90_50.yaml
@@ -53,7 +53,6 @@ deployment:
       --data-parallel-size 8
       --data-parallel-size-local 4
       --data-parallel-start-rank 4
-      --headless
       --data-parallel-address $MASTER_IP
       --enable-expert-parallel
       --data-parallel-rpc-port 12981

--- a/tests/e2e/nightly/multi_node/internal_dp/config/GLM-5.1-W8A8C8-A3_198k_function.yaml
+++ b/tests/e2e/nightly/multi_node/internal_dp/config/GLM-5.1-W8A8C8-A3_198k_function.yaml
@@ -55,7 +55,6 @@ deployment:
       --data-parallel-size 8
       --data-parallel-size-local 4
       --data-parallel-start-rank 4
-      --headless
       --data-parallel-address $MASTER_IP
       --enable-expert-parallel
       --data-parallel-rpc-port 12980

--- a/tests/e2e/nightly/multi_node/internal_dp/config/GLM5_1-W8A8-A3-dual-nodes.yaml
+++ b/tests/e2e/nightly/multi_node/internal_dp/config/GLM5_1-W8A8-A3-dual-nodes.yaml
@@ -54,7 +54,6 @@ deployment:
       --data-parallel-size-local 1
       --data-parallel-start-rank 1
       --data-parallel-rpc-port 13389
-      --headless
       --data-parallel-address $MASTER_IP
       --enable-expert-parallel
       --seed 1024

--- a/tests/e2e/nightly/multi_node/internal_dp/config/GLM5_2-W8A8-A3-dual-nodes.yaml
+++ b/tests/e2e/nightly/multi_node/internal_dp/config/GLM5_2-W8A8-A3-dual-nodes.yaml
@@ -51,7 +51,6 @@ deployment:
       --data-parallel-size-local 1
       --data-parallel-start-rank 1
       --data-parallel-rpc-port 13389
-      --headless
       --data-parallel-address $MASTER_IP
       --enable-expert-parallel
       --seed 1024

--- a/tests/e2e/nightly/multi_node/internal_dp/config/Kimi-K2_5-W4A8-A2-dual-nodes.yaml
+++ b/tests/e2e/nightly/multi_node/internal_dp/config/Kimi-K2_5-W4A8-A2-dual-nodes.yaml
@@ -50,7 +50,6 @@ deployment:
     server_cmd: >
       vllm serve Eco-Tech/Kimi-K2.5-W4A8
         --host 0.0.0.0
-        --headless
         --port $SERVER_PORT
         --quantization ascend
         --allowed-local-media-path /


### PR DESCRIPTION
### What this PR does / why we need it?

vLLM 0.28 infers hybrid LB whenever `--data-parallel-start-rank` is set (`data_parallel_start_rank is not None`). In that mode the DP handshake requires remote engines **not** to pass `--headless`:

```text
Remote engine must not use --headless in external or hybrid dp lb mode
```

Nightly double-node / multi-node jobs still used the old internal-LB remote command (`--data-parallel-start-rank` + `--headless`), so startup was rejected during handshake.

Drop `--headless` on the remote node so both nodes run hybrid LB (each exposes an API and owns its local ranks). Affected nightly YAMLs:

- `tests/e2e/nightly/multi_node/internal_dp/config/GLM-5.1-W8A8C8-A3_198k_function.yaml`
- `tests/e2e/nightly/multi_node/internal_dp/config/GLM-5.1-W8A8C8-A3_128k_90_50.yaml`
- `tests/e2e/nightly/multi_node/internal_dp/config/GLM5_1-W8A8-A3-dual-nodes.yaml`
- `tests/e2e/nightly/multi_node/internal_dp/config/GLM5_2-W8A8-A3-dual-nodes.yaml`
- `tests/e2e/nightly/multi_node/internal_dp/config/Kimi-K2_5-W4A8-A2-dual-nodes.yaml`

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

- YAML-only change. Inspected vLLM main `EngineArgs.create_engine_config` and `vllm/v1/engine/utils.py` handshake (`remote_should_be_headless`).
- Nightly CI should re-run the five jobs above.

- vLLM main: https://github.com/vllm-project/vllm/commit/b2f685834a6456197e7033966fdef52a23f1abcd
