### PR TITLE
[Cherry-pick][Refactor] Move negate_sin of inplace_partial_rotary_mul down to kernel

### DIFF
--- a/csrc/attention/inplace_partial_rotary_mul/op_host/inplace_partial_rotary_mul_a3_tiling.cpp
+++ b/csrc/attention/inplace_partial_rotary_mul/op_host/inplace_partial_rotary_mul_a3_tiling.cpp
@@ -99,6 +99,7 @@ private:
     int64_t ubFactor_ = 0;
     int64_t start_=0;
     int64_t blockFactor_=0;
+    int64_t negateSin_ = 0;
     gert::TilingContext* context_ = nullptr;
     RopeRegbaseTilingData tilingData_;
 };
@@ -135,6 +136,7 @@ void InplacePartialRotaryMulTiling::FillTilingData()
     tilingData_.set_ubFactor(ubFactor_);
     tilingData_.set_start(start_);
     tilingData_.set_blockFactor(blockFactor_);
+    tilingData_.set_negateSin(negateSin_);
 }
 void InplacePartialRotaryMulTiling::PrintTilingData() const
 {
@@ -307,6 +309,7 @@ ge::graphStatus InplacePartialRotaryMulTiling::CheckInput()
     auto sliceData = static_cast<const int64_t *>(sliceListAttr->GetData());
     start_ = sliceData[0];
     end_ = sliceData[1];
+    negateSin_ = *(attrs->GetAttrPointer<bool>(2)) ? 1 : 0;
     OPS_LOG_I(context_->GetNodeName(), "end_ %ld, end_ %ld",start_, end_);
 
     headDim_ = end_ - start_;
@@ -558,6 +561,7 @@ ge::graphStatus InplacePartialRotaryMulTiling::DoTiling()
         }
         tilingData_.set_allHeadDim(allHeadDim_);
         tilingData_.set_start(start_);
+        tilingData_.set_negateSin(negateSin_);
         OPS_ERR_IF(TilingSplit() != ge::GRAPH_SUCCESS,
                 OPS_LOG_E(context_->GetNodeName(), "TilingSplit fail."), return ge::GRAPH_FAILED);
 

--- a/csrc/attention/inplace_partial_rotary_mul/op_host/inplace_partial_rotary_mul_def.cpp
+++ b/csrc/attention/inplace_partial_rotary_mul/op_host/inplace_partial_rotary_mul_def.cpp
@@ -44,6 +44,7 @@ public:
             .UnknownShapeFormat({ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND});
         this->Attr("mode").AttrType(OPTIONAL).Int(0);
         this->Attr("partial_slice").AttrType(OPTIONAL).ListInt({0, 0});
+        this->Attr("negate_sin").AttrType(OPTIONAL).Bool(false);
 
         this->AICore().AddConfig("ascend910b");
         this->AICore().AddConfig("ascend910_93");

--- a/csrc/attention/inplace_partial_rotary_mul/op_host/inplace_partial_rotary_mul_proto.cpp
+++ b/csrc/attention/inplace_partial_rotary_mul/op_host/inplace_partial_rotary_mul_proto.cpp
@@ -57,6 +57,7 @@ REG_OP(InplacePartialRotaryMul)
     .OUTPUT(x, TensorType({DT_FLOAT16, DT_FLOAT, DT_BFLOAT16, DT_FLOAT16, DT_BFLOAT16}))
     .ATTR(mode, Int, 0)
     .ATTR(partial_slice, ListInt, {0, 0})
+    .ATTR(negate_sin, Bool, false)
     .OP_END_FACTORY_REG(InplacePartialRotaryMul)
 
 } // namespace ge

--- a/csrc/attention/inplace_partial_rotary_mul/op_host/inplace_partial_rotary_mul_tiling.cpp
+++ b/csrc/attention/inplace_partial_rotary_mul/op_host/inplace_partial_rotary_mul_tiling.cpp
@@ -78,6 +78,11 @@ ge::graphStatus Tiling4RotaryPositionEmbedding(gert::TilingContext *context)
     }
     if (socVersion == platform_ascendc::SocVersion::ASCEND950)
     {
+        auto attrs = context->GetAttrs();
+        if (attrs != nullptr && *(attrs->GetAttrPointer<bool>(2))) {
+            OPS_LOG_E(context, "negate_sin is not supported on Ascend950.");
+            return ge::GRAPH_FAILED;
+        }
         std::vector<std::unique_ptr<RopeRegBaseTilingClass>> regBaseTilingCases;
         regBaseTilingCases.push_back(std::unique_ptr<RopeRegBaseTilingClass>(new RopeRegBaseTilingClassAAndB(context)));
         regBaseTilingCases.push_back(std::unique_ptr<RopeRegBaseTilingClass>(new RopeRegBaseTilingClassAB(context)));

--- a/csrc/attention/inplace_partial_rotary_mul/op_host/inplace_partial_rotary_mul_tiling.h
+++ b/csrc/attention/inplace_partial_rotary_mul/op_host/inplace_partial_rotary_mul_tiling.h
@@ -91,6 +91,7 @@ TILING_DATA_FIELD_DEF(int64_t, ubCalcBTail);
 TILING_DATA_FIELD_DEF(int64_t, ubCalcNNum);
 TILING_DATA_FIELD_DEF(int64_t, ubCalcNLoop);
 TILING_DATA_FIELD_DEF(int64_t, ubCalcNTail);
+TILING_DATA_FIELD_DEF(int64_t, negateSin);
 
 END_TILING_DATA_DEF;
 

--- a/csrc/attention/inplace_partial_rotary_mul/op_kernel/inplace_partial_rotary_mul.h
+++ b/csrc/attention/inplace_partial_rotary_mul/op_kernel/inplace_partial_rotary_mul.h
@@ -37,7 +37,7 @@ public:
     __aicore__ inline void CopyInDataR(LocalTensor<R> &xUb, GlobalTensor<R> &xGm, int64_t blockCout, int64_t blockLen, int64_t gmOffset, int64_t ubOffset);
     __aicore__ inline void SetGatherSrcOffset(LocalTensor<int32_t> &idsUb, int64_t count);
     __aicore__ inline void ComputeMul(LocalTensor<float> &dtsUb, LocalTensor<float> & src0Ub, LocalTensor<float> &src1Ub, int64_t onceA, int64_t numHead,int64_t headDim);
-    __aicore__ inline void  InterleavedInversion(int64_t count,LocalTensor<float> &ub);
+    __aicore__ inline void  InterleavedInversion(int64_t count,LocalTensor<float> &ub, bool negateSin = false);
     __aicore__ inline void DataCopyOut(LocalTensor<T> &yUb, GlobalTensor<T> &xGm, int64_t blockCout, int64_t blockLen, int64_t gmOffset, int64_t ubOffset);
 private:
     TPipe* pipe_;
@@ -195,15 +195,17 @@ __aicore__ inline void InplacePartialRotaryMulABA<T, isBrc, R>::ComputeMul(Local
     PipeBarrier<PIPE_V>();
 }
 template <typename T, bool isBrc, typename R>
-__aicore__ inline void InplacePartialRotaryMulABA<T, isBrc, R>::InterleavedInversion(int64_t count,LocalTensor<float> &ub)
+__aicore__ inline void InplacePartialRotaryMulABA<T, isBrc, R>::InterleavedInversion(int64_t count,LocalTensor<float> &ub, bool negateSin)
 {
-    // 做奇数位的*-1
+    // Negate the odd positions by default; when negateSin is set, negate the
+    // even positions instead (complement of the default 0x5555 mask), which is
+    // equivalent to negating sin up front as in the legacy Python-side path
     SetMaskNorm();
     int64_t fp32Mask = 64;
     int64_t repeatTimes = count / 64;
     int64_t remain = count % 64;
-    uint64_t fullMask = 0x5555555555555555; //0101010101010101
-    uint64_t tailMask = 0x55;
+    uint64_t fullMask = negateSin ? 0xAAAAAAAAAAAAAAAA : 0x5555555555555555; //0101010101010101
+    uint64_t tailMask = negateSin ? 0xAA : 0x55;
     SetVectorMask<float, MaskMode::NORMAL>(0, fullMask);
     Muls<float, false>(ub, ub, -1.0f, MASK_PLACEHOLDER, repeatTimes, {1,1,8,8});
     if (remain != 0) {
@@ -283,7 +285,7 @@ __aicore__ inline void InplacePartialRotaryMulABA<T, isBrc, R>::Process()
         ComputeMul(xUbFp32 , xUbFp32, r2UbFp32, ubSize, numHead_,headDim_);
         r1Que_.FreeTensor(r1Ub);
         r2Que_.FreeTensor(r2Ub);
-        InterleavedInversion(xtotalNum, xUbFp32);
+        InterleavedInversion(xtotalNum, xUbFp32, tiling_->negateSin != 0);
         // 做最后的Add
         Add(yUbFp32, yUbFp32, xUbFp32, xtotalNum);
         xQue_.FreeTensor(xUb);

--- a/csrc/attention/inplace_partial_rotary_mul/op_kernel/rotate_interleaved_common.h
+++ b/csrc/attention/inplace_partial_rotary_mul/op_kernel/rotate_interleaved_common.h
@@ -115,7 +115,8 @@ __aicore__ inline void SetGatherSrcOffset(LocalTensor<int32_t> &gatherOffset, in
 }
 
 // count < 256 * 64 and count % 8 == 0
-__aicore__ inline void InterleavedInversion(LocalTensor<float> &srcInversion, int32_t count, bool isOffset = false)
+__aicore__ inline void InterleavedInversion(LocalTensor<float> &srcInversion, int32_t count, bool negateSin = false,
+                                            bool isOffset = false)
 {
     SetMaskNorm();
 
@@ -123,9 +124,12 @@ __aicore__ inline void InterleavedInversion(LocalTensor<float> &srcInversion, in
     const int32_t repeatTimes = count / mask;
     const int32_t remainder = count % mask;
 
-    // Define masks based on the 'isOffset' flag
-    const uint64_t fullMask = isOffset ? 0xAAAAAAAAAAAAAAAA : 0x5555555555555555;
-    const uint64_t partialMask = isOffset ? 0xAA : 0x55;
+    // negateSin: negate the complementary (even) positions, which is equivalent
+    // to negating sin before the default interleaved inversion (legacy -sin path);
+    // otherwise define masks based on the 'isOffset' flag
+    const uint64_t fullMask =
+        negateSin ? 0xAAAAAAAAAAAAAAAA : (isOffset ? 0xAAAAAAAAAAAAAAAA : 0x5555555555555555);
+    const uint64_t partialMask = negateSin ? 0xAA : (isOffset ? 0xAA : 0x55);
 
     // Apply the mask and multiplication for the full
     SetVectorMask<float, MaskMode::NORMAL>(0, fullMask);

--- a/csrc/attention/inplace_partial_rotary_mul/op_kernel/rotate_interleaved_split_bs.h
+++ b/csrc/attention/inplace_partial_rotary_mul/op_kernel/rotate_interleaved_split_bs.h
@@ -268,7 +268,7 @@ __aicore__ inline void InterleavedSplitBS<T>::Compute(uint32_t seqIdx, uint32_t 
 
     Mul(x, x, cos, calcTotalNum);
     inQueCos.FreeTensor(cos);
-    InterleavedInversion(x, calcTotalNum);
+    InterleavedInversion(x, calcTotalNum, tiling_->negateSin != 0);
     Add(y, y, x, calcTotalNum);
     inQueX.FreeTensor(x);
     outQueY.EnQue(y);
@@ -303,7 +303,7 @@ __aicore__ inline void InterleavedSplitBS<T>::ComputeCastFp32(uint32_t seqIdx, u
     inQueCos.FreeTensor(cos);
 
     Mul(tmp32BSBuf1, tmp32BSBuf1, tmp32Buf2, calcTotalNum);
-    InterleavedInversion(tmp32BSBuf1, calcTotalNum);
+    InterleavedInversion(tmp32BSBuf1, calcTotalNum, tiling_->negateSin != 0);
     Add(tmp32Buf3, tmp32Buf3, tmp32BSBuf1, calcTotalNum);
 
     LocalTensor<T> y = outQueY.AllocTensor<T>();

--- a/csrc/attention/inplace_partial_rotary_mul/op_kernel/rotate_interleaved_split_bs_pad.h
+++ b/csrc/attention/inplace_partial_rotary_mul/op_kernel/rotate_interleaved_split_bs_pad.h
@@ -277,7 +277,7 @@ __aicore__ inline void InterleavedSplitBSPad<T>::Compute(uint32_t seqIdx, uint32
     Mul(x, x, cos, calcTotalNum);
 
     inQueCos.FreeTensor(cos);
-    InterleavedInversion(x, calcTotalNum);
+    InterleavedInversion(x, calcTotalNum, tiling_->negateSin != 0);
     Add(yTensor, yTensor, x, calcTotalNum);
 
     inQueX.FreeTensor(x);
@@ -315,7 +315,7 @@ __aicore__ inline void InterleavedSplitBSPad<T>::ComputeCastFp32(uint32_t seqIdx
     inQueCos.FreeTensor(cos);
 
     Mul(tmp32BsPadBuf1, tmp32BsPadBuf1, tmp32Buf2, calcTotalNum);
-    InterleavedInversion(tmp32BsPadBuf1, calcTotalNum);
+    InterleavedInversion(tmp32BsPadBuf1, calcTotalNum, tiling_->negateSin != 0);
     Add(tmp32Buf3, tmp32Buf3, tmp32BsPadBuf1, calcTotalNum);
 
     LocalTensor<T> y = outQueY.AllocTensor<T>();

--- a/csrc/attention/inplace_partial_rotary_mul/op_kernel/rotate_interleaved_split_bsn.h
+++ b/csrc/attention/inplace_partial_rotary_mul/op_kernel/rotate_interleaved_split_bsn.h
@@ -267,7 +267,7 @@ __aicore__ inline void InterleavedSplitBSN<T>::Compute(uint32_t batchIdx, uint32
 
     Mul(x, x, cos, calcTotalNum);
     inQueCos.FreeTensor(cos);
-    InterleavedInversion(x, calcTotalNum);
+    InterleavedInversion(x, calcTotalNum, tiling_->negateSin != 0);
     Add(y, y, x, calcTotalNum);
     inQueX.FreeTensor(x);
     outQueY.EnQue(y);
@@ -301,7 +301,7 @@ __aicore__ inline void InterleavedSplitBSN<T>::ComputeCastFp32(uint32_t batchIdx
     inQueCos.FreeTensor(cos);
 
     Mul(tmp32BSNBuf1, tmp32BSNBuf1, tmp32Buf2, calcTotalNum);
-    InterleavedInversion(tmp32BSNBuf1, calcTotalNum);
+    InterleavedInversion(tmp32BSNBuf1, calcTotalNum, tiling_->negateSin != 0);
     Add(tmp32Buf3, tmp32Buf3, tmp32BSNBuf1, calcTotalNum);
 
     LocalTensor<T> y = outQueY.AllocTensor<T>();

--- a/csrc/attention/inplace_partial_rotary_mul/op_kernel/rotate_interleaved_split_bsn_pad.h
+++ b/csrc/attention/inplace_partial_rotary_mul/op_kernel/rotate_interleaved_split_bsn_pad.h
@@ -274,7 +274,7 @@ __aicore__ inline void InterleavedSplitBSNPad<T>::Compute(uint32_t batchIdx, uin
 
     Mul(xTensor, xTensor, cos, calcTotalNum);
     inQueCos.FreeTensor(cos);
-    InterleavedInversion(xTensor, calcTotalNum);
+    InterleavedInversion(xTensor, calcTotalNum, tiling_->negateSin != 0);
     Add(yTensor, yTensor, xTensor, calcTotalNum);
     inQueX.FreeTensor(xTensor);
     outQueY.EnQue(yTensor);
@@ -308,7 +308,7 @@ InterleavedSplitBSNPad<T>::ComputeCastFp32(uint32_t batchIdx, uint32_t seqIdx, u
     inQueCos.FreeTensor(cos);
 
     Mul(tmp32Buf1, tmp32Buf1, tmp32Buf2, totalCount);
-    InterleavedInversion(tmp32Buf1, totalCount);
+    InterleavedInversion(tmp32Buf1, totalCount, tiling_->negateSin != 0);
     Add(tmp32Buf3, tmp32Buf3, tmp32Buf1, totalCount);
 
     LocalTensor<T> y = outQueY.AllocTensor<T>();

--- a/csrc/attention/inplace_partial_rotary_mul/op_kernel/rotate_interleaved_split_s.h
+++ b/csrc/attention/inplace_partial_rotary_mul/op_kernel/rotate_interleaved_split_s.h
@@ -265,7 +265,7 @@ __aicore__ inline void InterleavedSplitS<T>::Compute(uint32_t loopIdx, LocalTens
 
     Mul(x, x, cos, calcTotalNum);
     inQueCos.FreeTensor(cos);
-    InterleavedInversion(x, calcTotalNum);
+    InterleavedInversion(x, calcTotalNum, tiling_->negateSin != 0);
     Add(y, y, x, calcTotalNum);
     inQueX.FreeTensor(x);
     outQueY.EnQue(y);
@@ -300,7 +300,7 @@ __aicore__ inline void InterleavedSplitS<T>::ComputeCastFp32(uint32_t loopIdx, L
     inQueCos.FreeTensor(cos);
 
     Mul(tmp32Buf1, tmp32Buf1, tmp32Buf2, calcTotalNum);
-    InterleavedInversion(tmp32Buf1, calcTotalNum);
+    InterleavedInversion(tmp32Buf1, calcTotalNum, tiling_->negateSin != 0);
     Add(tmp32Buf3, tmp32Buf3, tmp32Buf1, calcTotalNum);
 
     LocalTensor<T> yTensor = outQueY.AllocTensor<T>();

--- a/csrc/attention/inplace_partial_rotary_mul/op_kernel/rotate_interleaved_split_s_pad.h
+++ b/csrc/attention/inplace_partial_rotary_mul/op_kernel/rotate_interleaved_split_s_pad.h
@@ -279,7 +279,7 @@ __aicore__ inline void InterleavedSplitSPad<T>::Compute(uint32_t loopIdx, LocalT
 
     Mul(x, x, cos, totalCount);
     inQueCos.FreeTensor(cos);
-    InterleavedInversion(x, totalCount);
+    InterleavedInversion(x, totalCount, tiling_->negateSin != 0);
     Add(y, y, x, totalCount);
     inQueX.FreeTensor(x);
     outQueY.EnQue(y);
@@ -315,7 +315,7 @@ InterleavedSplitSPad<T>::ComputeCastFp32(uint32_t loopIdx, LocalTensor<uint32_t>
     inQueCos.FreeTensor(cos);
 
     Mul(tmp32SPadBuf1, tmp32SPadBuf1, tmp32SPadBuf2, totalCount);
-    InterleavedInversion(tmp32SPadBuf1, totalCount);
+    InterleavedInversion(tmp32SPadBuf1, totalCount, tiling_->negateSin != 0);
     Add(tmp32Buf3, tmp32Buf3, tmp32SPadBuf1, totalCount);
 
     LocalTensor<T> y = outQueY.AllocTensor<T>();

--- a/csrc/torch_binding.cpp
+++ b/csrc/torch_binding.cpp
@@ -1533,8 +1533,7 @@ void inplace_partial_rotary_mul_npu(at::Tensor & x, const at::Tensor &r1, const 
     }
     auto origin_dim_num = x.dim();
     TORCH_CHECK(origin_dim_num == BSND_DIM_NUM, "Input tensor x's dim num should be 4, actual ", origin_dim_num, ".");
-    const at::Tensor &sin = negate_sin ? at::neg(r2) : r2;
-    EXEC_NPU_CMD(aclnnInplacePartialRotaryMul, x, r1, sin, it->second, partial_slice);
+    EXEC_NPU_CMD(aclnnInplacePartialRotaryMul, x, r1, r2, it->second, partial_slice, negate_sin);
 }
 
 std::tuple<at::Tensor, at::Tensor> npu_rms_norm_dynamic_quant_npu(

--- a/csrc/torch_binding.cpp
+++ b/csrc/torch_binding.cpp
@@ -1516,7 +1516,7 @@ std::tuple<at::Tensor, at::Tensor, at::Tensor> npu_hc_pre_v2_npu(
     return run_hc_pre_fusion(x, hc_fn, hc_scale, hc_base, hc_mult, hc_sinkhorn_iters, norm_eps, hc_eps);
 }
 
-void inplace_partial_rotary_mul_npu(at::Tensor & x, const at::Tensor &r1, const at::Tensor &r2, c10::string_view rotary_mode, at::IntArrayRef partial_slice)
+void inplace_partial_rotary_mul_npu(at::Tensor & x, const at::Tensor &r1, const at::Tensor &r2, c10::string_view rotary_mode, at::IntArrayRef partial_slice, bool negate_sin)
 {
     constexpr int BSND_DIM_NUM = 4;
     static const std::unordered_map<std::string, int> mode_map = {
@@ -1533,7 +1533,8 @@ void inplace_partial_rotary_mul_npu(at::Tensor & x, const at::Tensor &r1, const 
     }
     auto origin_dim_num = x.dim();
     TORCH_CHECK(origin_dim_num == BSND_DIM_NUM, "Input tensor x's dim num should be 4, actual ", origin_dim_num, ".");
-    EXEC_NPU_CMD(aclnnInplacePartialRotaryMul, x, r1, r2, it->second, partial_slice);
+    const at::Tensor &sin = negate_sin ? at::neg(r2) : r2;
+    EXEC_NPU_CMD(aclnnInplacePartialRotaryMul, x, r1, sin, it->second, partial_slice);
 }
 
 std::tuple<at::Tensor, at::Tensor> npu_rms_norm_dynamic_quant_npu(
@@ -3378,7 +3379,7 @@ TORCH_LIBRARY_EXPAND(CONCAT(_C, _ascend), ops)
 
     ops.def(
         "inplace_partial_rotary_mul("
-            "Tensor(a!) x, Tensor r1, Tensor r2, str rotary_mode, int[] partial_slice"
+            "Tensor(a!) x, Tensor r1, Tensor r2, str rotary_mode, int[] partial_slice, bool negate_sin=False"
         ") -> ()"
     );
     ops.impl("inplace_partial_rotary_mul", torch::kPrivateUse1, &vllm_ascend::inplace_partial_rotary_mul_npu);

--- a/csrc/torch_binding_meta.cpp
+++ b/csrc/torch_binding_meta.cpp
@@ -1213,7 +1213,8 @@ void inplace_partial_rotary_mul_meta(
     const at::Tensor &r1,
     const at::Tensor &r2,
     c10::string_view rotary_mode,
-    at::IntArrayRef partial_slice)
+    at::IntArrayRef partial_slice,
+    bool negate_sin)
 {
     auto origin_dim_num = x.dim();
     return;

--- a/tests/e2e/nightly/single_node/ops/singlecard_ops/test_inplace_partial_rotary_mul.py
+++ b/tests/e2e/nightly/single_node/ops/singlecard_ops/test_inplace_partial_rotary_mul.py
@@ -1,0 +1,106 @@
+import gc
+
+import pytest
+import torch
+
+from vllm_ascend.utils import enable_custom_op
+
+enable_custom_op()
+
+NOPE_DIM = 128  # start of partial_slice
+HEAD_DIM = 192  # end of partial_slice (rotation range [NOPE, HEAD))
+ROPE_DIM = HEAD_DIM - NOPE_DIM
+NUM_HEADS = 16
+
+
+def golden_inplace_partial_rotary_mul(
+    x: torch.Tensor, cos: torch.Tensor, sin: torch.Tensor, negate_sin: bool = False
+) -> torch.Tensor:
+    """CPU golden for interleave mode: y[j] = x[j]*cos[j] +/- x[j^1]*sin[j].
+
+    The sin term is negated on even positions (kernel default mask 0x5555,
+    standard interleave RoPE).
+    x: (T, 1, H, D); cos/sin: (T, 1, 1, R) fp32, indexed element-wise,
+    last dim equals the rotation span R.
+    negate_sin=True is equivalent to passing -sin (legacy path).
+    """
+    x32 = x.float()
+    c = cos.float()
+    s = sin.float()
+    if negate_sin:
+        s = -s
+    x_rot = x32[..., NOPE_DIM:]
+    # swap even/odd positions: x_swap[j] = x[j^1]
+    x_swap = torch.empty_like(x_rot)
+    x_swap[..., 0::2] = x_rot[..., 1::2]
+    x_swap[..., 1::2] = x_rot[..., 0::2]
+    # negate the sin term on even positions (kernel default mask 0x5555)
+    sin_term = x_swap * s
+    sin_term[..., 0::2] *= -1
+    y = x32.clone()
+    y[..., NOPE_DIM:] = x_rot * c + sin_term
+    return y
+
+
+@pytest.mark.parametrize(
+    "num_tokens",
+    [1, 16, 128, 1000],
+)
+@pytest.mark.parametrize(
+    "dtype, atol, rtol",
+    [
+        (torch.float16, 2e-3, 2e-3),
+        (torch.bfloat16, 8e-3, 8e-3),
+        (torch.float32, 1e-5, 1e-5),
+    ],
+)
+def test_inplace_partial_rotary_mul(num_tokens: int, dtype, atol, rtol):
+    torch.manual_seed(0)
+
+    # x: (T, 1, H, D); cos/sin: (T, 1, 1, R) fp32, no repeat_interleave
+    x = torch.randn(num_tokens, 1, NUM_HEADS, HEAD_DIM, dtype=dtype)
+    base = torch.randn(num_tokens, 1, 1, ROPE_DIM, dtype=torch.float32)
+    cos = torch.cos(base)
+    sin = torch.sin(base)
+
+    # ---- 1. positive sin: negate_sin=False ----
+    out = x.clone().npu()
+    torch.ops._C_ascend.inplace_partial_rotary_mul(
+        out,
+        cos.npu(),
+        sin.npu(),
+        rotary_mode="interleave",
+        partial_slice=[NOPE_DIM, HEAD_DIM],
+        negate_sin=False,
+    )
+    ref = golden_inplace_partial_rotary_mul(x, cos, sin, negate_sin=False)
+    torch.testing.assert_close(out.cpu(), ref.to(dtype), atol=atol, rtol=rtol)
+
+    # ---- 2. negative sin: raw sin + negate_sin=True ----
+    out_neg = x.clone().npu()
+    torch.ops._C_ascend.inplace_partial_rotary_mul(
+        out_neg,
+        cos.npu(),
+        sin.npu(),
+        rotary_mode="interleave",
+        partial_slice=[NOPE_DIM, HEAD_DIM],
+        negate_sin=True,
+    )
+    ref_neg = golden_inplace_partial_rotary_mul(x, cos, sin, negate_sin=True)
+    torch.testing.assert_close(out_neg.cpu(), ref_neg.to(dtype), atol=atol, rtol=rtol)
+
+    # ---- 3. cross check: negate_sin=True equals -sin input (legacy), bit-wise ----
+    out_neg2 = x.clone().npu()
+    torch.ops._C_ascend.inplace_partial_rotary_mul(
+        out_neg2,
+        cos.npu(),
+        (-sin).npu(),
+        rotary_mode="interleave",
+        partial_slice=[NOPE_DIM, HEAD_DIM],
+        negate_sin=False,
+    )
+    assert torch.equal(out_neg.cpu(), out_neg2.cpu())
+
+    gc.collect()
+    torch.npu.empty_cache()
+    torch.npu.reset_peak_memory_stats()

--- a/vllm_ascend/attention/context_parallel/dsa_cp.py
+++ b/vllm_ascend/attention/context_parallel/dsa_cp.py
@@ -2078,9 +2078,10 @@ class AscendDSACPImpl(AttentionImplBase[Any]):
         torch.ops._C_ascend.inplace_partial_rotary_mul(
             local_attn_output.unsqueeze(1),
             cp_metadata.local_cos[layer_name],
-            -cp_metadata.local_sin[layer_name],
+            cp_metadata.local_sin[layer_name],
             rotary_mode="interleave",
             partial_slice=[self.nope_head_dim, self.head_dim],
+            negate_sin=True,
         )
 
         if self.tp_size == 1 or skip_all_to_all:

--- a/vllm_ascend/attention/dsa_v1.py
+++ b/vllm_ascend/attention/dsa_v1.py
@@ -1767,9 +1767,10 @@ class AscendDSAImpl(AttentionImplBase[Any]):
         torch.ops._C_ascend.inplace_partial_rotary_mul(
             o_proj_input[:actual_tokens].unsqueeze(1),
             cos[:actual_tokens],
-            -sin[:actual_tokens],
+            sin[:actual_tokens],
             rotary_mode="interleave",
             partial_slice=[self.nope_head_dim, self.head_dim],
+            negate_sin=True,
         )
 
         # o


### PR DESCRIPTION
### What this PR does / why we need it:
Cherry-pick of #15940 to main.

- Add `negate_sin` attribute to op proto/def and pass it to kernel via tiling data (910B/910_93 path)
- Negate sin in-kernel by switching the `InterleavedInversion` mask from 0x5555 to 0xAAAA with zero extra instructions
- Reject `negate_sin=true` on Ascend950 whose shared common path is not modified
- Remove the Python-side `at::neg(r2)` in torch_binding, all call sites now pass the original sin tensor
- Add single-card precision test covering both positive and negative sin, plus bit-wise equivalence between `negate_sin=true` and `-sin` input

Backport of #15940 (submitted to releases/v0.26.0rc).

- vLLM main: https://github.com/vllm-project/vllm/commit/b2f685834a6456197e7033966fdef52a23f1abcd
