### PR TITLE
[v0.26.0rc][BugFix][P/D] Register padded hybrid KV cache spans

### DIFF
--- a/tests/ut/kv_offload/test_mooncake_hybrid_connector.py
+++ b/tests/ut/kv_offload/test_mooncake_hybrid_connector.py
@@ -20,6 +20,8 @@ from vllm_ascend.distributed.kv_transfer.kv_p2p.mooncake_hybrid_connector import
     MAX_REQUESTS_PER_PEER_HANDLER,
     KVCacheRecvingThread,
     MooncakeConnectorScheduler,
+    MooncakeConnectorWorker,
+    _get_tensor_transfer_span_bytes,
 )
 
 
@@ -294,3 +296,47 @@ class TestMooncakeHybridConnectorScheduler(unittest.TestCase):
         self.assertIsNotNone(params)
         self.assertEqual(params["remote_block_ids"], ([0], [100, 101]))
         self.assertEqual(params["num_prompt_blocks"], 2)
+
+
+class TestMooncakeHybridConnectorRegistration(unittest.TestCase):
+    def test_transfer_span_includes_inter_block_padding(self):
+        backing = torch.empty(18, dtype=torch.uint8)
+        tensor = torch.as_strided(backing, size=(3, 4), stride=(6, 1))
+
+        self.assertEqual(tensor.numel() * tensor.element_size(), 12)
+        self.assertEqual(_get_tensor_transfer_span_bytes(tensor), 18)
+
+    def test_registration_expands_for_inter_block_padding(self):
+        layer_name = "model.layers.0.self_attn"
+        backing = torch.empty(18, dtype=torch.uint8)
+        tensor = torch.as_strided(backing, size=(3, 4), stride=(6, 1))
+
+        worker = MooncakeConnectorWorker.__new__(MooncakeConnectorWorker)
+        worker.vllm_config = types.SimpleNamespace(
+            model_config=types.SimpleNamespace(
+                is_deepseek_mla=False,
+                hf_text_config=types.SimpleNamespace(),
+            )
+        )
+        worker.kv_cache_config = types.SimpleNamespace(
+            num_blocks=3,
+            kv_cache_groups=[types.SimpleNamespace(layer_names=[layer_name])],
+            kv_cache_tensors=[types.SimpleNamespace(size=12, shared_by=[layer_name])],
+        )
+        worker.use_hybrid = True
+        worker.use_mamba = False
+        worker.use_compress = True
+
+        class RegistrationCaptured(Exception):
+            pass
+
+        with (
+            patch(
+                "vllm_ascend.distributed.kv_transfer.kv_p2p.mooncake_hybrid_connector.global_te.register_buffer",
+                side_effect=RegistrationCaptured,
+            ) as register_buffer,
+            self.assertRaises(RegistrationCaptured),
+        ):
+            worker.register_kv_caches({layer_name: (tensor,)})
+
+        register_buffer.assert_called_once_with([tensor.data_ptr()], [18])

--- a/vllm_ascend/distributed/kv_transfer/kv_p2p/mooncake_hybrid_connector.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_p2p/mooncake_hybrid_connector.py
@@ -1663,6 +1663,7 @@ class MooncakeConnectorWorker:
                 if not kv_cache_tensor.shared_by:
                     continue
                 share_tensor_addr = []
+                share_tensor_ends = []
                 share_tensor_stride = []
                 cur_tensor_group_idx = []
                 for layer_name in kv_cache_tensor.shared_by:
@@ -1675,14 +1676,17 @@ class MooncakeConnectorWorker:
                         if tensor_addr in share_tensor_addr or tensor_addr in self.kv_caches_base_addr:
                             continue
                         share_tensor_addr.append(tensor_addr)
+                        share_tensor_ends.append(tensor_addr + _get_tensor_transfer_span_bytes(single_tensor))
                         share_tensor_stride.append(single_tensor.stride(0) * single_tensor.element_size())
                 cur_tensor_group_idx = sorted(list(set(cur_tensor_group_idx)))
-                self.kv_caches_base_addr.append(min(share_tensor_addr))
+                registration_base = min(share_tensor_addr)
+                self.kv_caches_base_addr.append(registration_base)
                 self.addr_group_idx.append(cur_tensor_group_idx)  # type: ignore[arg-type]
                 self.block_stride_per_addr.append(share_tensor_stride[0])
                 self.block_len_per_addr.append(share_tensor_stride[0])
-                ptrs.append(min(share_tensor_addr))
-                lengths.append(kv_cache_tensor.size)
+                ptrs.append(registration_base)
+                runtime_span = max(share_tensor_ends) - registration_base
+                lengths.append(max(kv_cache_tensor.size, runtime_span))
         else:
             raise TypeError("Mooncake connector does not support this type kv_cache now.")
 
@@ -2058,3 +2062,15 @@ def get_prefill_pp_indices(
         start_layer = sum(partitions[:pp_rank])
         end_layer = start_layer + partitions[pp_rank]
         return (start_layer, end_layer)
+
+
+def _get_tensor_transfer_span_bytes(tensor: torch.Tensor) -> int:
+    """Return the byte span used by block-stride KV transfers."""
+    if tensor.numel() == 0:
+        return 0
+    if tensor.dim() == 0:
+        return tensor.element_size()
+    block_stride = tensor.stride(0)
+    if block_stride <= 0:
+        raise ValueError(f"KV cache block stride must be positive, got {block_stride}.")
+    return tensor.shape[0] * block_stride * tensor.element_size()


### PR DESCRIPTION
### What this PR does / why we need it?

This is the `releases/v0.26.0rc` adaptation of #16129.

The v0.26 connector normally registers `kv_cache_tensor.size`, which remains the lower bound in this patch. For 0.26-derived deployments that expose padded runtime KV tensor views, however, the physical span addressed by block-stride transfers can exceed that configured logical size.

The connector now records each runtime tensor's end as:

```text
data_ptr + shape[0] * stride(0) * element_size
```

and registers the larger of:

- the existing `kv_cache_tensor.size`; and
- the runtime span from the lowest tensor address to the highest tensor end.

This preserves the native v0.26 layout while preventing high block IDs from falling outside Mooncake's registered region when a hybrid KV tensor includes inter-block padding.

The observed DeepSeek V4 indexer layout had a 4096-byte payload and a 4160-byte block stride. Registering only the logical payload caused a high-block remote-buffer lookup failure, followed by HCCL/AICPU and sampling failures.

### Does this PR introduce _any_ user-facing change?

No API or configuration change. Hybrid P/D KV transfer registration now covers padded runtime tensor layouts.

### How was this patch tested?

- Added unit coverage for a padded `as_strided` tensor.
- Added connector-level coverage verifying that a configured 12-byte region is expanded to its 18-byte runtime stride span.
- `python -m py_compile vllm_ascend/distributed/kv_transfer/kv_p2p/mooncake_hybrid_connector.py tests/ut/kv_offload/test_mooncake_hybrid_connector.py`
- `git diff --check`
- The root cause and stride-span correction were validated on an Ascend A3 DeepSeek V4 P/D + DSpark deployment based on the v0.26 nightly image; the same high-block transfer succeeded and pressure testing completed more than 30,000 audited transfers without OOB, transfer failure, NaN, IndexCheck, or EZ9999.

The focused pytest target could not start in the Windows checkout because the matching vLLM test dependency set is incomplete (`cbor2` is missing); CI is expected to run the added tests.
- vLLM main: https://github.com/vllm-project/vllm/commit/d02df748bf9efd99022f1a062597dc3cb3808485
