### PR TITLE
[CI] Normalize generic A3 runner labels

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -5,9 +5,9 @@ self-hosted-runner:
     - linux-aarch64-310p-1
     - linux-aarch64-310p-2
     - linux-aarch64-310p-4
-    - linux-aarch64-a3-2-
-    - linux-aarch64-a3-4-
-    - linux-aarch64-a3-8-
+    - linux-aarch64-a3-2
+    - linux-aarch64-a3-4
+    - linux-aarch64-a3-8
     - linux-aarch64-a3-800i-2
     - linux-aarch64-a3-800i-4
     - linux-aarch64-a3-800i-8

--- a/.github/workflows/scripts/runner_label.json
+++ b/.github/workflows/scripts/runner_label.json
@@ -23,19 +23,19 @@
         "image_tag": "9.1.0-a3-ubuntu22.04-py3.12",
         "csrc_cache_target": "a3-arm64-ubuntu"
     },
-    "linux-aarch64-a3-2-": {
+    "linux-aarch64-a3-2": {
         "chip": "a3",
         "npu_num": 2,
         "image_tag": "9.1.0-a3-ubuntu22.04-py3.12",
         "csrc_cache_target": "a3-arm64-ubuntu"
     },
-    "linux-aarch64-a3-4-": {
+    "linux-aarch64-a3-4": {
         "chip": "a3",
         "npu_num": 4,
         "image_tag": "9.1.0-a3-ubuntu22.04-py3.12",
         "csrc_cache_target": "a3-arm64-ubuntu"
     },
-    "linux-aarch64-a3-8-": {
+    "linux-aarch64-a3-8": {
         "chip": "a3",
         "npu_num": 8,
         "image_tag": "9.1.0-a3-ubuntu22.04-py3.12",

--- a/.github/workflows/scripts/select_tests.py
+++ b/.github/workflows/scripts/select_tests.py
@@ -111,16 +111,16 @@ _ALL_TESTS_ROOTS = ("tests/ut", "tests/e2e/pull_request")
 # --all-tests runs keep collecting CPU UT coverage.
 _SKIP_CPU_UT = False
 
-# Generic ``linux-aarch64-a3-N-`` labels are mixed pools of 560T and 752T
+# Generic ``linux-aarch64-a3-N`` labels are mixed pools of 560T and 752T
 # machines (i.e. random machine class). When accuracy tests are selected (or
 # the full suite runs), reroute those partitions to the dedicated 560T labels.
 # Accuracy tests are exactly the files listed in ``accuracy_tests`` in
 # test_config.yaml; they must run on 560T machines (800i labels), so 752T
 # machines are not started for runs that include them.
 _A3_560T_LABEL_MAP = {
-    "linux-aarch64-a3-2-": "linux-aarch64-a3-800i-2",
-    "linux-aarch64-a3-4-": "linux-aarch64-a3-800i-4",
-    "linux-aarch64-a3-8-": "linux-aarch64-a3-800i-8",
+    "linux-aarch64-a3-2": "linux-aarch64-a3-800i-2",
+    "linux-aarch64-a3-4": "linux-aarch64-a3-800i-4",
+    "linux-aarch64-a3-8": "linux-aarch64-a3-800i-8",
 }
 
 # Populated by _load_runner_mapping(). Ordered list of

--- a/.github/workflows/scripts/test_config.yaml
+++ b/.github/workflows/scripts/test_config.yaml
@@ -260,10 +260,10 @@ partition:
     count: 5
   a3-2:
     runner_label: linux-aarch64-a3-2
-    count: 2
+    count: 4
   a3-4:
     runner_label: linux-aarch64-a3-4
-    count: 2
+    count: 4
   a3-8:
     runner_label: linux-aarch64-a3-8
     count: 1

--- a/.github/workflows/scripts/test_config.yaml
+++ b/.github/workflows/scripts/test_config.yaml
@@ -259,13 +259,13 @@ partition:
     runner_label: linux-aarch64-a2b3-1
     count: 5
   a3-2:
-    runner_label: linux-aarch64-a3-2-
+    runner_label: linux-aarch64-a3-2
     count: 2
   a3-4:
-    runner_label: linux-aarch64-a3-4-
+    runner_label: linux-aarch64-a3-4
     count: 2
   a3-8:
-    runner_label: linux-aarch64-a3-8-
+    runner_label: linux-aarch64-a3-8
     count: 1
   cpu-0:
     runner_label: linux-amd64-cpu-8-hk


### PR DESCRIPTION
### What this PR does / why we need it?

Replace the transitional generic A3 runner labels with their stable equivalents:

- `linux-aarch64-a3-2-` -> `linux-aarch64-a3-2`
- `linux-aarch64-a3-4-` -> `linux-aarch64-a3-4`
- `linux-aarch64-a3-8-` -> `linux-aarch64-a3-8`

Keep the actionlint label inventory, runner metadata, test partitions, and accuracy-test rerouting map consistent. Dedicated `800i`/`800t` labels and `*-cn12-001` labels are unchanged.

### Does this PR introduce _any_ user-facing change?

No. This only updates CI runner label routing.

### How was this patch tested?

CI: https://github.com/vllm-project/vllm-ascend/actions/runs/34432115245/job/102783061705?pr=16138#step:1:2
Result:
<img width="1363" height="581" alt="image" src="https://github.com/user-attachments/assets/0083e3d0-d214-4163-9c7f-5a3755b384c6" />


- vLLM main: https://github.com/vllm-project/vllm/commit/b2f685834a6456197e7033966fdef52a23f1abcd
