### PR TITLE
[BugFix][KV Transfer] Fix garbled output in PD disaggregation with DCP + PP parallelism

### DIFF
--- a/.github/workflows/_schedule_image_build.yaml
+++ b/.github/workflows/_schedule_image_build.yaml
@@ -532,9 +532,17 @@ jobs:
           SCHEDULE_TAG_PATTERN: ${{ inputs.schedule_tag_pattern }}
           SUFFIX: ${{ env.SUFFIX }}
         run: |
-          DIGESTS=$(printf "$SOURCE_IMAGE@sha256:%s " $(ls ${{ runner.temp }}/digests))
+          set -euo pipefail
 
-          echo "Digests: $DIGESTS"
+          DIGEST_DIR="${{ runner.temp }}/digests"
+
+          # Install skopeo if not present.
+          if ! command -v skopeo >/dev/null 2>&1; then
+            apt-get update -qq && apt-get install -y -qq skopeo
+          fi
+
+          echo "Digests:"
+          ls -la "$DIGEST_DIR"
           echo "Current tags:"
           echo "$TAGS"
 
@@ -548,9 +556,34 @@ jobs:
               continue
             fi
             echo "Creating tag $tag"
-            docker buildx imagetools create \
-              -t "$tag" \
-              $DIGESTS
+
+            # SWR rejects OCI image index (application/vnd.oci.image.index.v1+json)
+            # produced by "docker buildx imagetools create".  To work around this,
+            # copy each single-arch digest to the destination with a per-arch
+            # temp tag, converting to Docker v2 schema2 format via skopeo, then
+            # create a Docker manifest list which SWR accepts.
+            DIGEST_REFS=""
+            for digest_file in "$DIGEST_DIR"/*; do
+              digest=$(basename "$digest_file")
+              short_digest=$(echo "$digest" | cut -c1-12)
+              ARCH_TAG="${tag}-t${short_digest}"
+              echo "  Copying $SOURCE_IMAGE@sha256:$digest → $ARCH_TAG (format v2s2)"
+              skopeo copy \
+                --format v2s2 \
+                "docker://${SOURCE_IMAGE}@sha256:${digest}" \
+                "docker://${ARCH_TAG}"
+              DIGEST_REFS="$DIGEST_REFS $ARCH_TAG"
+            done
+
+            # shellcheck disable=SC2086
+            docker manifest create "$tag" $DIGEST_REFS
+            docker manifest push "$tag"
+
+            # Clean up per-arch temp tags
+            for digest_ref in $DIGEST_REFS; do
+              echo "  Cleaning up $digest_ref"
+              skopeo delete "docker://$digest_ref" || true
+            done
           done
 
       - name: Clean up temp tags
@@ -606,6 +639,14 @@ jobs:
           SOURCE_IMAGE: ${{ inputs.swr_temp_repo }}
         run: |
           set -euo pipefail
+
+          DIGEST_DIR="${{ runner.temp }}/digests"
+
+          # Install skopeo if not present.
+          if ! command -v skopeo >/dev/null 2>&1; then
+            apt-get update -qq && apt-get install -y -qq skopeo
+          fi
+
           SUFFIX=""
           if [ -n "${{ inputs.suffix }}" ]; then
             SUFFIX="-${{ inputs.suffix }}"
@@ -613,12 +654,40 @@ jobs:
           VLLM_SHORT=$(echo "${{ inputs.vllm_commit }}" | cut -c1-7)
           ASCEND_SHORT=$(echo "${{ inputs.vllm_ascend_commit }}" | cut -c1-7)
           TAG="${IMAGE}:vllm-ascend-${VLLM_SHORT}-${ASCEND_SHORT}${SUFFIX}"
-          DIGESTS=$(printf "$SOURCE_IMAGE@sha256:%s " $(ls ${{ runner.temp }}/digests))
-          echo "Digests: $DIGESTS"
+
+          echo "Digests:"
+          ls -la "$DIGEST_DIR"
           echo "Creating multi-arch manifest tag: $TAG"
-          docker buildx imagetools create \
-            -t "$TAG" \
-            $DIGESTS
+
+          # SWR rejects OCI image index produced by "docker buildx imagetools create".
+          # Copy each single-arch digest to a per-arch temp tag in Docker v2 schema2
+          # format via skopeo, then create a Docker manifest list which SWR accepts.
+          merge_and_push() {
+            local dest_tag="$1"
+            local digest_refs=""
+            for digest_file in "$DIGEST_DIR"/*; do
+              digest=$(basename "$digest_file")
+              short_digest=$(echo "$digest" | cut -c1-12)
+              ARCH_TAG="${dest_tag}-t${short_digest}"
+              echo "  Copying $SOURCE_IMAGE@sha256:$digest → $ARCH_TAG (format v2s2)"
+              skopeo copy \
+                --format v2s2 \
+                "docker://${SOURCE_IMAGE}@sha256:${digest}" \
+                "docker://${ARCH_TAG}"
+              digest_refs="$digest_refs $ARCH_TAG"
+            done
+
+            # shellcheck disable=SC2086
+            docker manifest create "$dest_tag" $digest_refs
+            docker manifest push "$dest_tag"
+
+            for digest_ref in $digest_refs; do
+              echo "  Cleaning up $digest_ref"
+              skopeo delete "docker://$digest_ref" || true
+            done
+          }
+
+          merge_and_push "$TAG"
 
           # ===== Daily scenario: also push daily tag =====
           if [ "${{ inputs.build_type }}" = "daily" ]; then
@@ -631,9 +700,7 @@ jobs:
               DAILY_TAG="${IMAGE}:nightly-${PATTERN}-cann${CANN_VERSION}-${DATE}"
             fi
             echo "Creating daily tag: $DAILY_TAG"
-            docker buildx imagetools create \
-              -t "$DAILY_TAG" \
-              $DIGESTS
+            merge_and_push "$DAILY_TAG"
           fi
 
       - name: Clean up temp tags

--- a/.github/workflows/scripts/test_config.yaml
+++ b/.github/workflows/scripts/test_config.yaml
@@ -81,6 +81,7 @@ skip_tests:
 # 560T labels (``linux-aarch64-a3-800i-N``); the files themselves stay in
 # their normal directory-based partitions.
 accuracy_tests:
+  - tests/e2e/pull_request/two_card/model_runner_v2/test_qwen3_6_mtp.py
   - tests/e2e/pull_request/two_card/test_shared_expert_dp.py
   - tests/e2e/pull_request/two_card/lora/test_ilama_lora_tp2.py
   - tests/e2e/pull_request/two_card/lora/test_llama32_lora_tp2.py
@@ -165,6 +166,8 @@ estimated_times:
   tests/e2e/pull_request/two_card/lora/test_qwen3moe_lora.py: 450
   tests/e2e/pull_request/two_card/lora/test_qwen35_densemodel_lora_tp.py: 1590
   tests/e2e/pull_request/two_card/model_runner_v2/test_data_parallel.py: 530
+  # Initial estimate for two models with fixed goldens on MRV2.
+  tests/e2e/pull_request/two_card/model_runner_v2/test_qwen3_6_mtp.py: 600
   tests/e2e/pull_request/two_card/model_runner_v2/test_spec_decode_data_parallel.py: 370
   tests/e2e/pull_request/two_card/spec_decode/test_spec_decode.py: 690
   tests/e2e/pull_request/two_card/test_data_parallel.py: 520

--- a/tests/e2e/pull_request/two_card/model_runner_v2/test_qwen3_6_mtp.py
+++ b/tests/e2e/pull_request/two_card/model_runner_v2/test_qwen3_6_mtp.py
@@ -1,0 +1,209 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM-Ascend project
+
+"""Qwen3.6 BF16 MTP acceptance on MRV2 with fixed goldens on two NPUs.
+
+Use the same 40 MT-Bench prompts, chat formatting, output limit and
+acceptance-length tolerance as vllm-ascend#13960. The fixed goldens use
+the supplied MRV2 measurements with greedy decoding (temperature 0).
+
+Run with:
+    pytest -sv tests/e2e/pull_request/two_card/model_runner_v2/test_qwen3_6_mtp.py
+"""
+
+import os
+from unittest.mock import patch
+
+import pytest
+from vllm import SamplingParams
+from vllm.config import CompilationConfig
+from vllm.inputs import TokensPrompt
+from vllm.v1.metrics.reader import Counter, Metric, Vector
+
+from tests.e2e.conftest import VllmRunner, wait_until_npu_memory_free
+from tests.e2e.pull_request.utils import ACCEPTANCE_LENGTH_RTOL, SPEC_DECODE_PROMPTS
+
+QWEN36_MOE_MODEL = "Qwen/Qwen3.6-35B-A3B"
+QWEN36_DENSE_MODEL = "Qwen/Qwen3.6-27B"
+QWEN36_MOE_EXPECTED_ACCEPTANCE_LENGTH = 3.141271769947347
+QWEN36_MOE_EXPECTED_ACCEPTANCE_PER_POS = (0.8663426488456865, 0.7049817739975699, 0.5699473471040907)
+QWEN36_DENSE_EXPECTED_ACCEPTANCE_LENGTH = 3.1607901975493875
+QWEN36_DENSE_EXPECTED_ACCEPTANCE_PER_POS = (0.8668833875135451, 0.7126781695423856, 0.5812286404934567)
+NUM_SPECULATIVE_TOKENS = 3
+MAX_TOKENS = 1024
+MAX_MODEL_LEN = 4096
+SEED = 42
+TEMPERATURE = 0.0
+
+
+def _read_mtp_counters(metrics: list[Metric]) -> tuple[int, int, list[int]]:
+    num_drafts = 0
+    num_accepted_tokens = 0
+    accepted_per_pos = [0] * NUM_SPECULATIVE_TOKENS
+    for metric in metrics:
+        if metric.name == "vllm:spec_decode_num_drafts":
+            assert isinstance(metric, Counter)
+            num_drafts += metric.value
+        elif metric.name == "vllm:spec_decode_num_accepted_tokens":
+            assert isinstance(metric, Counter)
+            num_accepted_tokens += metric.value
+        elif metric.name == "vllm:spec_decode_num_accepted_tokens_per_pos":
+            assert isinstance(metric, Vector)
+            assert len(metric.values) == NUM_SPECULATIVE_TOKENS, (
+                f"Expected {NUM_SPECULATIVE_TOKENS} MTP positions, got {metric.values}"
+            )
+            for pos, value in enumerate(metric.values):
+                accepted_per_pos[pos] += value
+    return num_drafts, num_accepted_tokens, accepted_per_pos
+
+
+@patch.dict(
+    os.environ,
+    {
+        "VLLM_WORKER_MULTIPROC_METHOD": "spawn",
+        "VLLM_USE_V2_MODEL_RUNNER": "1",
+        "HCCL_BUFFSIZE": "1024",
+        "LCCL_DETERMINISTIC": "1",
+        "HCCL_DETERMINISTIC": "true",
+        "ATB_MATMUL_SHUFFLE_K_ENABLE": "0",
+        "CLOSE_MATMUL_K_SHIFT": "1",
+    },
+)
+@wait_until_npu_memory_free()
+def _run_qwen3_6_mtp(model_name: str, is_moe: bool) -> tuple[float, list[float]]:
+    with VllmRunner(
+        model_name,
+        dtype="bfloat16",
+        tensor_parallel_size=2,
+        enable_expert_parallel=is_moe,
+        distributed_executor_backend="mp",
+        max_model_len=MAX_MODEL_LEN,
+        max_num_seqs=len(SPEC_DECODE_PROMPTS),
+        gpu_memory_utilization=0.9,
+        disable_log_stats=False,
+        enable_prefix_caching=False,
+        async_scheduling=True,
+        seed=SEED,
+        generation_config="vllm",
+        speculative_config={
+            "method": "qwen3_5_mtp",
+            "num_speculative_tokens": NUM_SPECULATIVE_TOKENS,
+        },
+        compilation_config=CompilationConfig(
+            cudagraph_mode="FULL_DECODE_ONLY",
+            cudagraph_capture_sizes=[4, 8, 16, 32, 64, 128, 160],
+        ),
+    ) as vllm_model:
+        assert vllm_model.model.llm_engine.vllm_config.use_v2_model_runner, f"Expected MRV2 for {model_name}"
+        tokenizer = vllm_model.model.get_tokenizer()
+        prompts = [
+            TokensPrompt(
+                prompt_token_ids=tokenizer.encode(
+                    tokenizer.apply_chat_template(
+                        [{"role": "user", "content": prompt}],
+                        tokenize=False,
+                        add_generation_prompt=True,
+                    ),
+                    add_special_tokens=False,
+                )
+            )
+            for prompt in SPEC_DECODE_PROMPTS
+        ]
+        # Use deltas so other engines in this pytest process cannot
+        # contaminate the fixed-golden comparison through old counters.
+        before = _read_mtp_counters(vllm_model.model.get_metrics())
+        outputs = vllm_model.model.generate(
+            prompts,
+            sampling_params=SamplingParams(temperature=TEMPERATURE, max_tokens=MAX_TOKENS, seed=SEED),
+        )
+        after = _read_mtp_counters(vllm_model.model.get_metrics())
+
+    assert len(outputs) == len(prompts), f"Expected {len(prompts)} outputs, got {len(outputs)}"
+    for index, output in enumerate(outputs):
+        assert output.finished and output.outputs and output.outputs[0].token_ids, (
+            f"{model_name}, MRV2, temperature={TEMPERATURE}: prompt {index} returned an unfinished or empty output"
+        )
+    num_drafts = after[0] - before[0]
+    num_accepted_tokens = after[1] - before[1]
+    accepted_per_pos = [a - b for a, b in zip(after[2], before[2])]
+    assert num_drafts > 0, "MTP did not generate any drafts"
+    assert sum(accepted_per_pos) == num_accepted_tokens, "Inconsistent MTP acceptance counters"
+    assert all(0 < count <= num_drafts for count in accepted_per_pos), (
+        f"Invalid acceptance counters: drafts={num_drafts}, accepted_per_pos={accepted_per_pos}"
+    )
+    assert accepted_per_pos == sorted(accepted_per_pos, reverse=True), (
+        f"Acceptance counters must not increase with draft position: {accepted_per_pos}"
+    )
+
+    acceptance_per_pos = [count / num_drafts for count in accepted_per_pos]
+    acceptance_length = 1 + num_accepted_tokens / num_drafts
+    print(
+        f"{model_name}, MRV2, temperature={TEMPERATURE}:\n"
+        f"num_drafts={num_drafts}\n"
+        f"num_accepted_tokens_per_pos={accepted_per_pos}\n"
+        f"acceptance_per_pos={acceptance_per_pos}\n"
+        f"acceptance_len={acceptance_length}"
+    )
+    return acceptance_length, acceptance_per_pos
+
+
+def _check_qwen3_6_mtp(
+    model_name: str,
+    is_moe: bool,
+    expected_acceptance_length: float,
+    expected_acceptance_per_pos: tuple[float, ...],
+) -> None:
+    actual_length, actual_per_pos = _run_qwen3_6_mtp(model_name, is_moe)
+
+    # Follow #13960's relative-error check against fixed goldens. Check each
+    # position as well: the 1D MRoPE input bug already degraded the first draft.
+    assert len(expected_acceptance_per_pos) == len(actual_per_pos) == NUM_SPECULATIVE_TOKENS
+    for name, expected, actual in zip(
+        ["acc_len", *(f"position_{pos + 1}" for pos in range(NUM_SPECULATIVE_TOKENS))],
+        [expected_acceptance_length, *expected_acceptance_per_pos],
+        [actual_length, *actual_per_pos],
+    ):
+        relative_error = abs(actual - expected) / expected
+        assert relative_error <= ACCEPTANCE_LENGTH_RTOL, (
+            f"{model_name}, MRV2, temperature={TEMPERATURE}: {name} does not match the fixed golden; "
+            f"expected={expected:.6f}, actual={actual:.6f}, "
+            f"relative error={relative_error:.2%}, tolerance={ACCEPTANCE_LENGTH_RTOL:.0%}"
+        )
+
+
+@pytest.mark.e2e_model(QWEN36_MOE_MODEL)
+@pytest.mark.e2e_coverage(
+    arch="moe",
+    feature="mtp,aclgraph",
+    parallel="TP,EP",
+    deploy="pd_mix",
+    hardware="A3",
+    quantization="BF16",
+    graph_mode="full_decode_only",
+)
+def test_qwen3_6_35b_a3b_mtp_acceptance_tp2() -> None:
+    _check_qwen3_6_mtp(
+        QWEN36_MOE_MODEL,
+        is_moe=True,
+        expected_acceptance_length=QWEN36_MOE_EXPECTED_ACCEPTANCE_LENGTH,
+        expected_acceptance_per_pos=QWEN36_MOE_EXPECTED_ACCEPTANCE_PER_POS,
+    )
+
+
+@pytest.mark.e2e_model(QWEN36_DENSE_MODEL)
+@pytest.mark.e2e_coverage(
+    arch="dense",
+    feature="mtp,aclgraph",
+    parallel="TP",
+    deploy="pd_mix",
+    hardware="A3",
+    quantization="BF16",
+    graph_mode="full_decode_only",
+)
+def test_qwen3_6_27b_mtp_acceptance_tp2() -> None:
+    _check_qwen3_6_mtp(
+        QWEN36_DENSE_MODEL,
+        is_moe=False,
+        expected_acceptance_length=QWEN36_DENSE_EXPECTED_ACCEPTANCE_LENGTH,
+        expected_acceptance_per_pos=QWEN36_DENSE_EXPECTED_ACCEPTANCE_PER_POS,
+    )

--- a/tests/ut/worker/test_model_runner_v2.py
+++ b/tests/ut/worker/test_model_runner_v2.py
@@ -96,6 +96,40 @@ def test_full_decode_only_keeps_graph_descriptor_request_count():
     np.testing.assert_array_equal(actual[:5], np.array([0, 1, 2, 3, 4], dtype=np.int32))
 
 
+@pytest.mark.parametrize(
+    "decode_query_len, query_lens, num_tokens_padded, descriptor_num_reqs, expected_query_start_loc",
+    [
+        (1, [4], 8, 8, [0, 4, 8]),
+        (4, [4, 5], 16, 4, [0, 4, 9, 16]),
+        (4, [2, 6], 16, 4, [0, 2, 8, 16]),
+        (4, [2, 4], 8, 2, [0, 2, 6, 8]),
+    ],
+    ids=["non-mtp-prefill", "mtp-mixed", "mtp-uniform-average", "mtp-no-request-padding"],
+)
+def test_full_graph_non_uniform_queries_use_mixed_padding(
+    decode_query_len, query_lens, num_tokens_padded, descriptor_num_reqs, expected_query_start_loc
+):
+    runner = NPUModelRunner.__new__(NPUModelRunner)
+    runner.decode_query_len = decode_query_len
+    runner.compilation_config = SimpleNamespace(cudagraph_mode=CUDAGraphMode.FULL)
+    num_reqs = len(query_lens)
+    query_start_loc = np.full(descriptor_num_reqs + 2, sum(query_lens), dtype=np.int32)
+    query_start_loc[: num_reqs + 1] = np.cumsum([0, *query_lens])
+
+    padded_query_start_loc, num_reqs_padded = runner._pad_query_start_loc_for_fia(
+        num_tokens_padded=num_tokens_padded,
+        num_reqs_padded=descriptor_num_reqs,
+        num_reqs=num_reqs,
+        query_start_loc_np=query_start_loc,
+        cudagraph_runtime_mode=CUDAGraphMode.FULL,
+        batch_desc_num_reqs=descriptor_num_reqs,
+    )
+
+    assert num_reqs_padded == num_reqs + 1
+    np.testing.assert_array_equal(padded_query_start_loc[: num_reqs_padded + 1], expected_query_start_loc)
+    assert padded_query_start_loc[num_reqs_padded] == num_tokens_padded
+
+
 def test_sample_tokens_restores_replicated_draft_hidden_states():
     runner = _make_runner(need_timing=False)
     runner.is_last_pp_rank = True

--- a/tests/ut/worker/test_model_runner_v2_mamba.py
+++ b/tests/ut/worker/test_model_runner_v2_mamba.py
@@ -3,7 +3,9 @@ from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
+import numpy as np
 import torch
+from vllm.config.compilation import CUDAGraphMode
 from vllm.v1.kv_cache_interface import (
     FullAttentionSpec,
     KVCacheConfig,
@@ -133,6 +135,49 @@ def test_prepare_inputs_propagates_padded_request_count():
     padded_count = keywords["num_reqs_after_padding"]
     assert isinstance(padded_count, ast.Name)
     assert padded_count.id == "num_reqs_padded"
+
+
+@patch("vllm_ascend.worker.v2.model_states.mamba_hybrid.build_attn_metadata")
+def test_prepare_attn_marks_uniform_full_graph_padding_as_spec(mock_build_attn_metadata):
+    expected_metadata = {"gdn": object()}
+    mock_build_attn_metadata.return_value = expected_metadata
+    state = SimpleNamespace(
+        vllm_config=SimpleNamespace(num_speculative_tokens=3),
+        num_accepted_tokens_gpu=torch.tensor([2, 3], dtype=torch.int32),
+        max_model_len=1024,
+    )
+    input_batch = SimpleNamespace(
+        num_reqs=2,
+        num_reqs_after_padding=4,
+        num_tokens=8,
+        num_tokens_after_padding=16,
+        is_prefilling_np=np.array([False, False]),
+        idx_mapping=torch.tensor([0, 1]),
+        num_draft_tokens_per_req=np.array([3, 3], dtype=np.int32),
+        num_scheduled_tokens=np.array([4, 4], dtype=np.int32),
+        query_start_loc=torch.tensor([0, 4, 8, 12, 16], dtype=torch.int32),
+        query_start_loc_np=np.array([0, 4, 8, 12, 16], dtype=np.int32),
+        seq_lens=None,
+        dcp_local_seq_lens=None,
+        seq_lens_np=np.ones(4, dtype=np.int32),
+        positions=None,
+        attn_state=None,
+    )
+
+    metadata = AscendMambaHybridModelState.prepare_attn(
+        state,
+        input_batch=input_batch,
+        cudagraph_mode=CUDAGraphMode.FULL,
+        block_tables=(),
+        slot_mappings=torch.empty(0, dtype=torch.int64),
+        attn_groups=[],
+        kv_cache_config=MagicMock(),
+    )
+
+    assert metadata is expected_metadata
+    model_metadata = mock_build_attn_metadata.call_args.kwargs["model_specific_attn_metadata"]
+    assert model_metadata.num_decode_draft_tokens_cpu.tolist() == [3, 3, 3, 3]
+    assert model_metadata.num_accepted_tokens.tolist() == [2, 3, 1, 1]
 
 
 @patch(

--- a/vllm_ascend/patch/worker/patch_qwen3_5.py
+++ b/vllm_ascend/patch/worker/patch_qwen3_5.py
@@ -46,6 +46,9 @@ class AscendQwen3NextAttention(Qwen3NextAttention):
     def forward(self, positions: torch.Tensor, hidden_states: torch.Tensor, output: torch.Tensor = None):
         qkv, _ = self.qkv_proj(hidden_states)
         if _uses_multimodal_rope(self):
+            # MRV2 MTP uses 1D text positions; the fused kernel reads three planes.
+            if positions.ndim == 1:
+                positions = positions.unsqueeze(0).expand(3, -1)
             cos_sin = self.rotary_emb.cos_sin_cache[positions]
             if cos_sin.device != qkv.device:
                 cos_sin = cos_sin.to(qkv.device)

--- a/vllm_ascend/worker/v2/aclgraph_utils.py
+++ b/vllm_ascend/worker/v2/aclgraph_utils.py
@@ -287,6 +287,9 @@ class ModelWithContext(nn.Module):
     def map_draft_to_target(self, draft_ids: torch.Tensor):
         return self.original_model.map_draft_to_target(draft_ids)
 
+    def embed_input_ids(self, *args, **kwargs):
+        return self.original_model.embed_input_ids(*args, **kwargs)
+
 
 @contextmanager
 def model_capture_wrapper(speculator, is_draft_model_prefill):

--- a/vllm_ascend/worker/v2/model_runner.py
+++ b/vllm_ascend/worker/v2/model_runner.py
@@ -710,15 +710,27 @@ class NPUModelRunner(GPUModelRunner):
         """
         # TODO: need refactor later, related to vllm PR #34043 this pr delete func
         # relax_for_mixed_batch_cudagraphs, num_reqs no longer equals the actual number of requests.
+        descriptor_num_reqs = batch_desc_num_reqs if batch_desc_num_reqs is not None else num_reqs_padded
+        # This checks query lengths, not request phase: short prefills can also
+        # match. Graph dispatch is responsible for excluding incompatible prefills.
+        has_uniform_decode_query_lens = np.all(np.diff(query_start_loc_np[: num_reqs + 1]) == self.decode_query_len)
+        matches_uniform_decode_graph_shape = (
+            has_uniform_decode_query_lens and num_tokens_padded == descriptor_num_reqs * self.decode_query_len
+        )
         if (
             cudagraph_runtime_mode == CUDAGraphMode.FULL
             and self.compilation_config.cudagraph_mode == CUDAGraphMode.FULL
+            and not matches_uniform_decode_graph_shape
         ):
             num_reqs_padded = num_reqs
         else:
-            num_reqs_padded = batch_desc_num_reqs if batch_desc_num_reqs is not None else num_reqs
+            # Preserve the captured request shape for uniform decode graphs.
+            # GDN full graphs capture metadata at request granularity, so
+            # collapsing all padded tokens into one request changes the graph
+            # topology between capture and replay.
+            num_reqs_padded = descriptor_num_reqs
 
-        if num_tokens_padded == num_reqs_padded * self.decode_query_len:
+        if has_uniform_decode_query_lens and num_tokens_padded == num_reqs_padded * self.decode_query_len:
             # Uniform-batch case: num_reqs must be no greater than num_reqs_padded
             assert num_reqs <= num_reqs_padded
 

--- a/vllm_ascend/worker/v2/model_states/mamba_hybrid.py
+++ b/vllm_ascend/worker/v2/model_states/mamba_hybrid.py
@@ -77,6 +77,15 @@ class AscendMambaHybridModelState(MambaHybridModelState, AscendModelState):
                     num_draft_tokens_per_req,
                     -1,
                 )
+                if cudagraph_mode == CUDAGraphMode.FULL and num_reqs > input_batch.num_reqs and spec_decode_mask.all():
+                    padded_query_lens = np.diff(input_batch.query_start_loc_np[: num_reqs + 1])[input_batch.num_reqs :]
+                    expected_query_len = self.vllm_config.num_speculative_tokens + 1
+                    if np.all(padded_query_lens == expected_query_len):
+                        # Full graph capture represents every padded request as
+                        # a speculative decode request. Keep replay on the same
+                        # pure-spec GDN path so its persistent state metadata is
+                        # refreshed before graph replay.
+                        num_decode_draft_tokens_np[input_batch.num_reqs :] = padded_query_lens - 1
             num_decode_draft_tokens_cpu = torch.from_numpy(num_decode_draft_tokens_np)
 
         model_specific_metadata = MambaHybridAttnMetadata(


### PR DESCRIPTION
…PP parallel and DCP parallel functions are combined.

### What this PR does / why we need it?

This PR fixes a KV‑cache transfer issue in the Mooncake connector when Pipeline Parallelism (PP) and Decode Context Parallel (DCP) are used together in a PD‑disaggregated service.

When both PP > 1 and DCP > 1 are enabled, the D‑side workers only pull KV from P‑side PP rank 0. Layers belonging to PP rank 1+ are silently skipped, resulting in garbled output because the D‑side model misses half of its KV cache.

Root cause:
The get_cp_group_meta function in mooncake_connector.py did not iterate over the PP dimension when generating P‑side handshake ports. The generated ports only covered the range for PP rank 0: [port_base, port_base + tp_size * pcp_size). Ports for PP rank 1+ (located at offset pp_rank * pcp_size * tp_size) were never created. As a result, the D‑side never connected to PP rank 1+ workers, and the KV cache for those layers was never transferred.

Fixes (5 changes):

get_cp_group_meta (L3005): Added a pp_size parameter and an outer for pp_rank loop. Port generation now includes pp_rank_offset = pp_rank * pcp_size * tp_size to cover all PP ranks.

get_local_remote_block_port_mappings call sites (L3025‑3028): Pass self._prefill_pp_size to the P‑side call and self._decode_pp_size to the D‑side call.

Mapping logic in get_local_remote_block_port_mappings (L3032‑3052): Replaced the old round‑robin selection (where each D CP group consumed only one P CP group, silently dropping PP rank 1+) with a PP‑aware mapping: each D CP group now maps to one P CP group per PP rank.

Non‑HMA assertion (L3332): Changed tp_num_need_pulls == len(remote_handshake_port_list[0]) to len(remote_handshake_port_list[0]) % tp_num_need_pulls == 0. When PP > 1, each shard has pp_size * tp_num_need_pulls ports, so the strict equality would cause a crash.

PP rank derivation in _get_cp_shard_pulls (L3358): Replaced 0 if remote_pcp_size > 1 else (port - base) // tp_size with (port - base) // (remote_pcp_size * prefill_tp_size). The old formula always returned 0 or ignored the PCP dimension; the new one correctly divides by the stride pcp_size * tp_size (ports per PP rank).

### Does this PR introduce _any_ user-facing change?

No. When pp_size == 1 (the default and most common case), all changes become no‑ops:

The PP‑rank loop runs once with offset 0.

The PP‑aware mapping falls back to the original round‑robin behaviour (because p_cp_groups_per_pp == len(p_cp_groups)).

PP rank derivation always returns 0.

The assertion len % tp_num == 0 degenerates to tp_num == len (same as before).

### How was this patch tested?

Manual testing with a PD‑disaggregated deployment using the glm‑5 model (P: PP=2, TP=8; D: TP=2, DCP=8), verifying that the output is no longer garbled.

Regression tests under PP=1, DCP=1 and PP=2, DCP=1 configurations to ensure no regressions.


- vLLM main: https://github.com/vllm-project/vllm/commit/b2f685834a6456197e7033966fdef52a23f1abcd
