### PR TITLE
[Feature] Add fault tolerance with retry and MC2 scale-down on Ascend NPU

### DIFF
--- a/.github/workflows/scripts/estimated_times.yaml
+++ b/.github/workflows/scripts/estimated_times.yaml
@@ -132,4 +132,4 @@ estimated_times:
   tests/e2e/pull_request/one_card/test_linear_quantization.py: 60
   tests/e2e/pull_request/one_card/test_gumbel_sampling.py: 110
   tests/e2e/pull_request/one_card/test_model_runner_v1_with_device.py: 70
-  tests/e2e/pull_request/four_card/fault_tolerance/test_fault_tolerance_e2e.py: 1800
+  tests/e2e/pull_request/four_card/fault_tolerance/test_fault_tolerance_e2e.py: 900

--- a/.github/workflows/scripts/estimated_times.yaml
+++ b/.github/workflows/scripts/estimated_times.yaml
@@ -132,4 +132,4 @@ estimated_times:
   tests/e2e/pull_request/one_card/test_linear_quantization.py: 60
   tests/e2e/pull_request/one_card/test_gumbel_sampling.py: 110
   tests/e2e/pull_request/one_card/test_model_runner_v1_with_device.py: 70
-  tests/e2e/fault_tolerance/test_fault_tolerance_e2e.py: 1200
+  tests/e2e/pull_request/four_card/fault_tolerance/test_fault_tolerance_e2e.py: 1200

--- a/.github/workflows/scripts/estimated_times.yaml
+++ b/.github/workflows/scripts/estimated_times.yaml
@@ -132,3 +132,4 @@ estimated_times:
   tests/e2e/pull_request/one_card/test_linear_quantization.py: 60
   tests/e2e/pull_request/one_card/test_gumbel_sampling.py: 110
   tests/e2e/pull_request/one_card/test_model_runner_v1_with_device.py: 70
+  tests/e2e/fault_tolerance/test_fault_tolerance_e2e.py: 1200

--- a/.github/workflows/scripts/estimated_times.yaml
+++ b/.github/workflows/scripts/estimated_times.yaml
@@ -132,4 +132,4 @@ estimated_times:
   tests/e2e/pull_request/one_card/test_linear_quantization.py: 60
   tests/e2e/pull_request/one_card/test_gumbel_sampling.py: 110
   tests/e2e/pull_request/one_card/test_model_runner_v1_with_device.py: 70
-  tests/e2e/pull_request/four_card/fault_tolerance/test_fault_tolerance_e2e.py: 1200
+  tests/e2e/pull_request/four_card/fault_tolerance/test_fault_tolerance_e2e.py: 1800

--- a/.github/workflows/scripts/test_config.yaml
+++ b/.github/workflows/scripts/test_config.yaml
@@ -112,6 +112,8 @@ runner_mapping:
     310p: 310p-4
   tests/e2e/pull_request/eight_card:
     default: a3-8
+  tests/e2e/fault_tolerance:
+    default: a3-4
 
 # === Partition Configuration ===
 # Maps logical test buckets to exact labels from runner_label.json and controls

--- a/.github/workflows/scripts/test_config.yaml
+++ b/.github/workflows/scripts/test_config.yaml
@@ -112,8 +112,6 @@ runner_mapping:
     310p: 310p-4
   tests/e2e/pull_request/eight_card:
     default: a3-8
-  tests/e2e/fault_tolerance:
-    default: a3-4
 
 # === Partition Configuration ===
 # Maps logical test buckets to exact labels from runner_label.json and controls

--- a/tests/e2e/fault_tolerance/test_fault_tolerance_e2e.py
+++ b/tests/e2e/fault_tolerance/test_fault_tolerance_e2e.py
@@ -179,6 +179,7 @@ class FTServerManager:
                         server_host="localhost",
                         server_port=8000 + r,
                         auto_port=False,
+                        env_dict={"ASCEND_RT_VISIBLE_DEVICES": str(r)}
                     )
                     self.servers.append((server, sargs))
                 except Exception:

--- a/tests/e2e/fault_tolerance/test_fault_tolerance_e2e.py
+++ b/tests/e2e/fault_tolerance/test_fault_tolerance_e2e.py
@@ -179,7 +179,7 @@ class FTServerManager:
                         server_host="localhost",
                         server_port=8000 + r,
                         auto_port=False,
-                        env_dict={"ASCEND_RT_VISIBLE_DEVICES": str(r)}
+                        env_dict={"ASCEND_RT_VISIBLE_DEVICES": str(r)},
                     )
                     self.servers.append((server, sargs))
                 except Exception:

--- a/tests/e2e/fault_tolerance/test_fault_tolerance_e2e.py
+++ b/tests/e2e/fault_tolerance/test_fault_tolerance_e2e.py
@@ -112,6 +112,7 @@ def _install_fault_injection(monkeypatch, tmp_path, rank: int, step: int) -> Non
 # Server management
 # ---------------------------------------------------------------------------
 
+
 def _ft_server_args() -> list[str]:
     return [
         "--enforce-eager",
@@ -184,9 +185,7 @@ class FTServerManager:
                     print(f"Failed to start server rank {r}")
                     raise
 
-            thread = threading.Thread(
-                target=start_server, args=(rank, server_args)
-            )
+            thread = threading.Thread(target=start_server, args=(rank, server_args))
             thread.start()
             self.server_threads.append(thread)
 
@@ -194,9 +193,7 @@ class FTServerManager:
             thread.join()
 
         if len(self.servers) != self.dp_size:
-            raise RuntimeError(
-                f"Only {len(self.servers)}/{self.dp_size} servers started"
-            )
+            raise RuntimeError(f"Only {len(self.servers)}/{self.dp_size} servers started")
 
         return self.servers
 
@@ -216,9 +213,7 @@ def _ft_manager() -> FTServerManager:
     )
 
 
-def _server_for_rank(
-    servers: list[tuple[RemoteOpenAIServer, list[str]]], rank: int
-) -> RemoteOpenAIServer:
+def _server_for_rank(servers: list[tuple[RemoteOpenAIServer, list[str]]], rank: int) -> RemoteOpenAIServer:
     """Locate the server for a DP rank."""
     for server, sargs in servers:
         if "--data-parallel-rank" in sargs:
@@ -231,6 +226,7 @@ def _server_for_rank(
 # ---------------------------------------------------------------------------
 # Test primitives
 # ---------------------------------------------------------------------------
+
 
 def _complete(client) -> Any:
     """Issue one completion request; used to drive the serving loop."""
@@ -255,9 +251,7 @@ def _get_ft_status(server: RemoteOpenAIServer) -> dict:
     return resp.json()
 
 
-def _apply_ft(
-    server: RemoteOpenAIServer, instruction: str, params: dict | None = None
-) -> dict:
+def _apply_ft(server: RemoteOpenAIServer, instruction: str, params: dict | None = None) -> dict:
     """POST an FT instruction; assert it is accepted (202) and return body."""
     resp = requests.post(
         server.url_for("fault_tolerance/apply"),
@@ -272,20 +266,14 @@ def _assert_serving_and_healthy(
     servers: tuple[RemoteOpenAIServer, ...],
 ) -> None:
     """Wait until every engine is healthy, then serve one request per server."""
-    healthy = _wait_for_engines(
-        list(servers), match_key="status", match_values={"healthy"}
-    )
+    healthy = _wait_for_engines(list(servers), match_key="status", match_values={"healthy"})
     assert all(healthy), healthy
     _in_parallel(lambda s: _complete(s.get_client()), servers)
 
 
 def _kill_worker_process(server: RemoteOpenAIServer) -> None:
     """SIGKILL only the worker proc, leaving EngineCore and API server alive."""
-    workers = [
-        p
-        for p in psutil.Process(server.proc.pid).children(recursive=True)
-        if "Worker" in " ".join(p.cmdline())
-    ]
+    workers = [p for p in psutil.Process(server.proc.pid).children(recursive=True) if "Worker" in " ".join(p.cmdline())]
     assert len(workers) == 1, f"expected 1 worker proc, found: {workers}"
     workers[0].kill()
 
@@ -334,10 +322,7 @@ def _driving(*servers: RemoteOpenAIServer):
                 _complete(client)
             time.sleep(0.2)
 
-    threads = [
-        threading.Thread(target=_drive, args=(s,), daemon=True)
-        for s in servers
-    ]
+    threads = [threading.Thread(target=_drive, args=(s,), daemon=True) for s in servers]
     for t in threads:
         t.start()
     try:
@@ -348,9 +333,7 @@ def _driving(*servers: RemoteOpenAIServer):
             t.join(timeout=2)
 
 
-def _wait_for_ft_apply_outcome(
-    server: RemoteOpenAIServer, request_id: str, deadline_s: int
-) -> str | None:
+def _wait_for_ft_apply_outcome(server: RemoteOpenAIServer, request_id: str, deadline_s: int) -> str | None:
     """Wait until ``/fault_tolerance/status`` records the FT apply outcome."""
     engine_status = _wait_for_engines(
         [server],
@@ -365,6 +348,7 @@ def _wait_for_ft_apply_outcome(
 # Feature guard
 # ---------------------------------------------------------------------------
 
+
 def has_npu_ft_capability() -> bool:
     """Require at least 4 visible NPUs for DP=4 fault-tolerance tests."""
     if not torch.npu.is_available():
@@ -378,6 +362,7 @@ def has_npu_ft_capability() -> bool:
 # ---------------------------------------------------------------------------
 # Tests
 # ---------------------------------------------------------------------------
+
 
 @pytest.mark.skipif(
     not has_npu_ft_capability(),
@@ -401,9 +386,7 @@ def test_injected_fault_retry_recovers_all_ranks(monkeypatch, tmp_path):
 
     with _ft_manager() as servers:
         assert len(servers) == DP_SIZE
-        all_ranks = tuple(
-            _server_for_rank(servers, r) for r in range(DP_SIZE)
-        )
+        all_ranks = tuple(_server_for_rank(servers, r) for r in range(DP_SIZE))
 
         # 1. All engines healthy and serving.
         _assert_serving_and_healthy(all_ranks)
@@ -419,8 +402,7 @@ def test_injected_fault_retry_recovers_all_ranks(monkeypatch, tmp_path):
 
         for rank, engine_status in enumerate(faulted):
             assert engine_status is not None, (
-                f"rank {rank} did not report UNHEALTHY within "
-                f"{FAULT_DETECTION_DEADLINE_S}s -- it likely hung"
+                f"rank {rank} did not report UNHEALTHY within {FAULT_DETECTION_DEADLINE_S}s -- it likely hung"
             )
 
         # The rank that raised carries the fault info from its own exception.
@@ -481,16 +463,14 @@ def test_worker_kill_survivor_unhealthy_and_dead_rejects_retry():
         # Survivors must report the peer fault as UNHEALTHY.
         for label, result in [("rank 0", s0), ("rank 1", s1), ("rank 2", s2)]:
             assert result is not None, (
-                f"{label} did not report the peer fault within "
-                f"{FAULT_DETECTION_DEADLINE_S}s -- it likely hung"
+                f"{label} did not report the peer fault within {FAULT_DETECTION_DEADLINE_S}s -- it likely hung"
             )
             assert result["status"] == "unhealthy", result
             assert result.get("fault_info"), result
 
         # Victim must report DEAD (its own worker is gone).
         assert victim_faulted is not None, (
-            "victim (rank 3) did not report its worker's death within "
-            f"{FAULT_DETECTION_DEADLINE_S}s"
+            f"victim (rank 3) did not report its worker's death within {FAULT_DETECTION_DEADLINE_S}s"
         )
         assert victim_faulted["status"] == "dead", victim_faulted
 
@@ -498,10 +478,6 @@ def test_worker_kill_survivor_unhealthy_and_dead_rejects_retry():
         request_id = _apply_ft(victim, "retry")["request_id"]
 
         # 5. ...but the DEAD engine must reject it: recovery requires UNHEALTHY.
-        ft_error = _wait_for_ft_apply_outcome(
-            victim, request_id, FAULT_DETECTION_DEADLINE_S
-        )
-        assert ft_error is not None, (
-            "rejection was never recorded in /fault_tolerance/status"
-        )
+        ft_error = _wait_for_ft_apply_outcome(victim, request_id, FAULT_DETECTION_DEADLINE_S)
+        assert ft_error is not None, "rejection was never recorded in /fault_tolerance/status"
         assert "status is DEAD" in ft_error, ft_error

--- a/tests/e2e/fault_tolerance/test_fault_tolerance_e2e.py
+++ b/tests/e2e/fault_tolerance/test_fault_tolerance_e2e.py
@@ -1,0 +1,507 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""End-to-end tests for the fault-tolerance framework on Ascend NPU.
+
+Requires 4 NPUs (DP=4); gated behind ``has_npu_ft_capability()``.
+"""
+
+import contextlib
+import os
+import threading
+import time
+from concurrent.futures import ThreadPoolExecutor
+from typing import Any
+
+import psutil
+import pytest
+import requests
+import torch
+
+from tests.e2e.conftest import RemoteOpenAIServer
+
+MODEL_NAME = os.getenv("MODEL_NAME", "Qwen/Qwen3-30B-A3B")
+DP_SIZE = 4
+
+# Fault-detection timeout budget:
+# - CPU: Gloo DP allreduce timeout (30s) detects the dead peer.
+# - NPU: HCSP operator timeout detects the dead peer.
+# - Deadline (45s): slowest fallback (30s) + margin.
+CPU_DISTRIBUTED_TIMEOUT_S = 30
+FAULT_DETECTION_DEADLINE_S = 45
+
+
+# ---------------------------------------------------------------------------
+# Fault-injection via sitecustomize.py
+# ---------------------------------------------------------------------------
+# Patches ``NPUModelRunner._sync_metadata_across_dp`` to raise on ``rank`` at
+# a chosen step. Gated on VLLM_FT_TEST_INJECT_FAULT.
+#
+# The import hook waits for ``vllm_ascend.worker.model_runner_v1`` to land
+# in sys.modules and for ``NPUModelRunner._sync_metadata_across_dp`` to be
+# defined, then wraps the method with a step-counting wrapper.
+_FAULT_INJECT_SITECUSTOMIZE = """\
+import builtins
+import os
+import sys
+
+_SPEC = os.environ.get("VLLM_FT_TEST_INJECT_FAULT")
+_MODULE = "vllm_ascend.worker.model_runner_v1"
+_CLASS = "NPUModelRunner"
+_METHOD = "_sync_metadata_across_dp"
+
+if _SPEC:
+    _f = dict(kv.split("=", 1) for kv in _SPEC.split(","))
+    _RANK, _STEP = int(_f["rank"]), int(_f["step"])
+    _steps = [0]
+
+    def _patch(m):
+        cls = getattr(m, _CLASS)
+        _orig = getattr(cls, _METHOD)
+
+        def _wrapped(self, *args, **kwargs):
+            result = _orig(self, *args, **kwargs)
+            if self.dp_rank == _RANK:
+                _steps[0] += 1
+                if _steps[0] == _STEP:
+                    raise RuntimeError(
+                        "FT test fault injection (rank=%d step=%d)"
+                        % (_RANK, _STEP)
+                    )
+            return result
+
+        setattr(cls, _METHOD, _wrapped)
+
+    _real_import = builtins.__import__
+
+    def _hook(name, *a, **k):
+        module = _real_import(name, *a, **k)
+        m = sys.modules.get(_MODULE)
+        if (
+            m is not None
+            and hasattr(m, _CLASS)
+            and not getattr(m, "_ft_patched", False)
+        ):
+            cls = getattr(m, _CLASS)
+            if hasattr(cls, _METHOD):
+                m._ft_patched = True
+                _patch(m)
+        return module
+
+    builtins.__import__ = _hook
+"""
+
+
+def _install_fault_injection(monkeypatch, tmp_path, rank: int, step: int) -> None:
+    """Arrange for the DP-sync method to raise on ``rank`` at serving ``step``.
+
+    Writes a ``sitecustomize.py`` and prepends its dir to PYTHONPATH so every
+    vLLM subprocess picks it up; the fault spec is read from the environment.
+    """
+    site_dir = tmp_path / "ft_inject"
+    site_dir.mkdir()
+    (site_dir / "sitecustomize.py").write_text(_FAULT_INJECT_SITECUSTOMIZE)
+    existing = os.environ.get("PYTHONPATH", "")
+    monkeypatch.setenv(
+        "PYTHONPATH",
+        str(site_dir) + (os.pathsep + existing if existing else ""),
+    )
+    monkeypatch.setenv("VLLM_FT_TEST_INJECT_FAULT", f"rank={rank},step={step}")
+
+
+# ---------------------------------------------------------------------------
+# Server management
+# ---------------------------------------------------------------------------
+
+def _ft_server_args() -> list[str]:
+    return [
+        "--enforce-eager",
+        "--dtype",
+        "bfloat16",
+        "--max-model-len",
+        "2048",
+        "--max-num-seqs",
+        "128",
+        "--enable-expert-parallel",
+        "--enable-fault-tolerance",
+        "--cpu-distributed-timeout-seconds",
+        str(CPU_DISTRIBUTED_TIMEOUT_S),
+        "--fault-tolerance-config",
+        '{"engine_recovery_timeout_sec": 120}',
+    ]
+
+
+class FTServerManager:
+    """Manages DP=4 vLLM server instances for fault-tolerance testing.
+
+    Starts one process per DP rank with fixed ports (8000 + rank).
+    """
+
+    def __init__(
+        self,
+        model_name: str,
+        dp_size: int,
+        base_server_args: list[str],
+        tp_size: int = 1,
+    ):
+        self.model_name = model_name
+        self.dp_size = dp_size
+        self.tp_size = tp_size
+        self.base_server_args = base_server_args
+        self.servers: list[tuple[RemoteOpenAIServer, list[str]]] = []
+        self.server_threads: list[threading.Thread] = []
+
+    def __enter__(self) -> list[tuple[RemoteOpenAIServer, list[str]]]:
+        for rank in range(self.dp_size):
+            server_args = self.base_server_args.copy()
+            server_args.extend(
+                [
+                    "--data-parallel-size",
+                    str(self.dp_size),
+                    "--data-parallel-rank",
+                    str(rank),
+                    "--data-parallel-size-local",
+                    "1",
+                    "--tensor-parallel-size",
+                    str(self.tp_size),
+                    "--port",
+                    str(8000 + rank),
+                    "--api-server-count",
+                    "1",
+                ]
+            )
+
+            def start_server(r: int, sargs: list[str]) -> None:
+                try:
+                    server = RemoteOpenAIServer(
+                        self.model_name,
+                        sargs,
+                        server_host="localhost",
+                        server_port=8000 + r,
+                        auto_port=False,
+                    )
+                    self.servers.append((server, sargs))
+                except Exception:
+                    print(f"Failed to start server rank {r}")
+                    raise
+
+            thread = threading.Thread(
+                target=start_server, args=(rank, server_args)
+            )
+            thread.start()
+            self.server_threads.append(thread)
+
+        for thread in self.server_threads:
+            thread.join()
+
+        if len(self.servers) != self.dp_size:
+            raise RuntimeError(
+                f"Only {len(self.servers)}/{self.dp_size} servers started"
+            )
+
+        return self.servers
+
+    def __exit__(self, exc_type, exc_val, exc_tb) -> None:
+        for server, _ in reversed(self.servers):
+            with contextlib.suppress(Exception):
+                server.__exit__(None, None, None)
+        self.servers.clear()
+
+
+def _ft_manager() -> FTServerManager:
+    return FTServerManager(
+        MODEL_NAME,
+        DP_SIZE,
+        base_server_args=_ft_server_args(),
+        tp_size=1,
+    )
+
+
+def _server_for_rank(
+    servers: list[tuple[RemoteOpenAIServer, list[str]]], rank: int
+) -> RemoteOpenAIServer:
+    """Locate the server for a DP rank."""
+    for server, sargs in servers:
+        if "--data-parallel-rank" in sargs:
+            idx = sargs.index("--data-parallel-rank")
+            if int(sargs[idx + 1]) == rank:
+                return server
+    raise AssertionError(f"no server found for DP rank {rank}")
+
+
+# ---------------------------------------------------------------------------
+# Test primitives
+# ---------------------------------------------------------------------------
+
+def _complete(client) -> Any:
+    """Issue one completion request; used to drive the serving loop."""
+    return client.completions.create(
+        model=MODEL_NAME,
+        prompt="Hello, my name is",
+        max_tokens=5,
+        temperature=0.0,
+        timeout=10.0,
+    )
+
+
+def _in_parallel(fn, servers) -> list[Any]:
+    """Run ``fn(server)`` for all servers concurrently; return in order."""
+    with ThreadPoolExecutor(max_workers=len(servers)) as ex:
+        return list(ex.map(fn, servers))
+
+
+def _get_ft_status(server: RemoteOpenAIServer) -> dict:
+    resp = requests.get(server.url_for("fault_tolerance/status"), timeout=10)
+    resp.raise_for_status()
+    return resp.json()
+
+
+def _apply_ft(
+    server: RemoteOpenAIServer, instruction: str, params: dict | None = None
+) -> dict:
+    """POST an FT instruction; assert it is accepted (202) and return body."""
+    resp = requests.post(
+        server.url_for("fault_tolerance/apply"),
+        json={"instruction": instruction, "params": params or {}},
+        timeout=10,
+    )
+    assert resp.status_code == 202, resp.text
+    return resp.json()
+
+
+def _assert_serving_and_healthy(
+    servers: tuple[RemoteOpenAIServer, ...],
+) -> None:
+    """Wait until every engine is healthy, then serve one request per server."""
+    healthy = _wait_for_engines(
+        list(servers), match_key="status", match_values={"healthy"}
+    )
+    assert all(healthy), healthy
+    _in_parallel(lambda s: _complete(s.get_client()), servers)
+
+
+def _kill_worker_process(server: RemoteOpenAIServer) -> None:
+    """SIGKILL only the worker proc, leaving EngineCore and API server alive."""
+    workers = [
+        p
+        for p in psutil.Process(server.proc.pid).children(recursive=True)
+        if "Worker" in " ".join(p.cmdline())
+    ]
+    assert len(workers) == 1, f"expected 1 worker proc, found: {workers}"
+    workers[0].kill()
+
+
+def _wait_for_engines(
+    servers: list[RemoteOpenAIServer],
+    match_key: str,
+    match_values: set[str],
+    deadline_s: int = FAULT_DETECTION_DEADLINE_S,
+) -> list[dict[str, Any] | None]:
+    """Poll ``/fault_tolerance/status`` until each server's engine status matches.
+
+    A server matches when its engine-status dict has ``match_key`` equal to
+    one of ``match_values``. Returns one engine-status dict per server.
+    Servers still unmatched after ``deadline_s`` get None.
+    """
+    results: dict[int, dict[str, Any]] = {}
+    pending = dict(enumerate(servers))
+    start = time.time()
+    while pending and time.time() - start < deadline_s:
+        for i, server in list(pending.items()):
+            with contextlib.suppress(Exception):
+                for engine_status in _get_ft_status(server)["engines"]:
+                    if engine_status.get(match_key) in match_values:
+                        results[i] = engine_status
+                        del pending[i]
+                        break
+        if pending:
+            time.sleep(1.0)
+    return [results.get(i) for i in range(len(servers))]
+
+
+@contextlib.contextmanager
+def _driving(*servers: RemoteOpenAIServer):
+    """Pump completions at each server in the background for the block's duration.
+
+    Keeps every engine stepping into its failed component so a fault surfaces.
+    Errors are expected once faulted and are ignored.
+    """
+    stop = threading.Event()
+
+    def _drive(server):
+        client = server.get_client()
+        while not stop.is_set():
+            with contextlib.suppress(Exception):
+                _complete(client)
+            time.sleep(0.2)
+
+    threads = [
+        threading.Thread(target=_drive, args=(s,), daemon=True)
+        for s in servers
+    ]
+    for t in threads:
+        t.start()
+    try:
+        yield
+    finally:
+        stop.set()
+        for t in threads:
+            t.join(timeout=2)
+
+
+def _wait_for_ft_apply_outcome(
+    server: RemoteOpenAIServer, request_id: str, deadline_s: int
+) -> str | None:
+    """Wait until ``/fault_tolerance/status`` records the FT apply outcome."""
+    engine_status = _wait_for_engines(
+        [server],
+        match_key="last_ft_request_id",
+        match_values={request_id},
+        deadline_s=deadline_s,
+    )[0]
+    return engine_status.get("ft_error") if engine_status else None
+
+
+# ---------------------------------------------------------------------------
+# Feature guard
+# ---------------------------------------------------------------------------
+
+def has_npu_ft_capability() -> bool:
+    """Require at least 4 visible NPUs for DP=4 fault-tolerance tests."""
+    if not torch.npu.is_available():
+        return False
+    try:
+        return torch.npu.device_count() >= DP_SIZE
+    except Exception:
+        return False
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+@pytest.mark.skipif(
+    not has_npu_ft_capability(),
+    reason="Requires at least 4 NPUs for DP=4 fault-tolerance testing",
+)
+def test_injected_fault_retry_recovers_all_ranks(monkeypatch, tmp_path):
+    """An exception injected into _sync_metadata_across_dp drives full
+    retry recovery on all 4 DP ranks.
+
+    Inject a fault at a chosen step on rank 3:
+
+    - Rank 3 raises after allreduce and goes UNHEALTHY.
+    - Ranks 0, 1, 2 detect the now-absent peer via the Gloo DP allreduce
+      timeout and also go UNHEALTHY.
+
+    All 4 being UNHEALTHY is the precondition for ``retry``.  The fault
+    is patched via a generated ``sitecustomize.py``.
+    """
+    fault_step = int(os.getenv("FT_FAULT_STEP", "50"))
+    _install_fault_injection(monkeypatch, tmp_path, rank=3, step=fault_step)
+
+    with _ft_manager() as servers:
+        assert len(servers) == DP_SIZE
+        all_ranks = tuple(
+            _server_for_rank(servers, r) for r in range(DP_SIZE)
+        )
+
+        # 1. All engines healthy and serving.
+        _assert_serving_and_healthy(all_ranks)
+
+        # 2. Drive all ranks so rank 3 accumulates steps and trips the
+        #    injected fault; ranks 0,1,2 then time out on DP allreduce.
+        with _driving(*all_ranks):
+            faulted = _wait_for_engines(
+                list(all_ranks),
+                match_key="status",
+                match_values={"unhealthy"},
+            )
+
+        for rank, engine_status in enumerate(faulted):
+            assert engine_status is not None, (
+                f"rank {rank} did not report UNHEALTHY within "
+                f"{FAULT_DETECTION_DEADLINE_S}s -- it likely hung"
+            )
+
+        # The rank that raised carries the fault info from its own exception.
+        assert faulted[3] is not None
+        assert faulted[3].get("fault_info"), faulted[3]
+
+        # 3. retry all engines.
+        for server in all_ranks:
+            _apply_ft(server, "retry")
+
+        # 4. Recovery completes: all engines return to healthy and serve again.
+        _assert_serving_and_healthy(all_ranks)
+
+
+@pytest.mark.skipif(
+    not has_npu_ft_capability(),
+    reason="Requires at least 4 NPUs for DP=4 fault-tolerance testing",
+)
+def test_worker_kill_survivor_unhealthy_and_dead_rejects_retry():
+    """SIGKILL one Worker; survivors go UNHEALTHY, victim goes DEAD.
+
+    Killing only rank 3's worker leaves all EngineCores alive, so the same
+    fault is seen two ways:
+
+    - Survivors (ranks 0, 1, 2): detect the dead peer via Gloo DP allreduce
+      / HCSP timeout. Their own executor is fine, so ``on_fault`` marks them
+      UNHEALTHY with a ``fault_info``.
+    - Victim (rank 3): detects its own executor failure and marks itself DEAD.
+
+    Recovery is gated on UNHEALTHY: the DEAD engine accepts ``retry`` at the
+    HTTP layer (202 = background dispatch) but rejects it in the engine,
+    recording the reason as ``ft_error``.
+    """
+    with _ft_manager() as servers:
+        assert len(servers) == DP_SIZE
+        survivor0 = _server_for_rank(servers, 0)
+        survivor1 = _server_for_rank(servers, 1)
+        survivor2 = _server_for_rank(servers, 2)
+        victim = _server_for_rank(servers, 3)
+        all_ranks = (survivor0, survivor1, survivor2, victim)
+
+        # 1. Confirm all engines are healthy and serving.
+        _assert_serving_and_healthy(all_ranks)
+
+        # 2. Kill only the victim's worker; all EngineCores stay alive.
+        _kill_worker_process(victim)
+
+        # 3. Drive all engines so each keeps stepping into the failed component.
+        with _driving(*all_ranks):
+            faulted_results = _wait_for_engines(
+                list(all_ranks),
+                match_key="status",
+                match_values={"dead", "unhealthy"},
+            )
+
+        s0, s1, s2, victim_faulted = faulted_results
+
+        # Survivors must report the peer fault as UNHEALTHY.
+        for label, result in [("rank 0", s0), ("rank 1", s1), ("rank 2", s2)]:
+            assert result is not None, (
+                f"{label} did not report the peer fault within "
+                f"{FAULT_DETECTION_DEADLINE_S}s -- it likely hung"
+            )
+            assert result["status"] == "unhealthy", result
+            assert result.get("fault_info"), result
+
+        # Victim must report DEAD (its own worker is gone).
+        assert victim_faulted is not None, (
+            "victim (rank 3) did not report its worker's death within "
+            f"{FAULT_DETECTION_DEADLINE_S}s"
+        )
+        assert victim_faulted["status"] == "dead", victim_faulted
+
+        # 4. retry is accepted at the HTTP layer (202 = background dispatch)...
+        request_id = _apply_ft(victim, "retry")["request_id"]
+
+        # 5. ...but the DEAD engine must reject it: recovery requires UNHEALTHY.
+        ft_error = _wait_for_ft_apply_outcome(
+            victim, request_id, FAULT_DETECTION_DEADLINE_S
+        )
+        assert ft_error is not None, (
+            "rejection was never recorded in /fault_tolerance/status"
+        )
+        assert "status is DEAD" in ft_error, ft_error

--- a/tests/e2e/pull_request/four_card/fault_tolerance/test_fault_tolerance_e2e.py
+++ b/tests/e2e/pull_request/four_card/fault_tolerance/test_fault_tolerance_e2e.py
@@ -34,21 +34,21 @@ FAULT_DETECTION_DEADLINE_S = 45
 # ---------------------------------------------------------------------------
 # Fault-injection via sitecustomize.py
 # ---------------------------------------------------------------------------
-# Patches ``NPUModelRunner._sync_metadata_across_dp`` to raise on ``rank`` at
-# a chosen step. Gated on VLLM_FT_TEST_INJECT_FAULT.
+# Patches ``dp_utils.sync_cudagraph_and_dp_padding`` to raise on ``rank`` after
+# the DP all_reduce at a chosen step. Gated on VLLM_FT_TEST_INJECT_FAULT.
 #
-# The import hook waits for ``vllm_ascend.worker.model_runner_v1`` to land
-# in sys.modules and for ``NPUModelRunner._sync_metadata_across_dp`` to be
-# defined, then wraps the method with a step-counting wrapper.
+# The import hook waits for ``vllm.v1.worker.gpu.dp_utils`` to land in
+# sys.modules and for ``sync_cudagraph_and_dp_padding`` to be defined, then
+# wraps the function with a step-counting wrapper. The wrapper calls the
+# original (so the all_reduce completes) and raises after it returns.
 _FAULT_INJECT_SITECUSTOMIZE = """\
 import builtins
 import os
 import sys
 
 _SPEC = os.environ.get("VLLM_FT_TEST_INJECT_FAULT")
-_MODULE = "vllm_ascend.worker.model_runner_v1"
-_CLASS = "NPUModelRunner"
-_METHOD = "_sync_metadata_across_dp"
+_MODULE = "vllm.v1.worker.gpu.dp_utils"
+_FUNC = "sync_cudagraph_and_dp_padding"
 
 if _SPEC:
     _f = dict(kv.split("=", 1) for kv in _SPEC.split(","))
@@ -56,12 +56,17 @@ if _SPEC:
     _steps = [0]
 
     def _patch(m):
-        cls = getattr(m, _CLASS)
-        _orig = getattr(cls, _METHOD)
+        import inspect
 
-        def _wrapped(self, *args, **kwargs):
-            result = _orig(self, *args, **kwargs)
-            if self.dp_rank == _RANK:
+        _orig = getattr(m, _FUNC)
+        _sig = inspect.signature(_orig)
+
+        def _wrapped(*args, **kwargs):
+            result = _orig(*args, **kwargs)
+            bound = _sig.bind(*args, **kwargs)
+            bound.apply_defaults()
+            dp_rank = bound.arguments.get("dp_rank")
+            if dp_rank == _RANK:
                 _steps[0] += 1
                 if _steps[0] == _STEP:
                     raise RuntimeError(
@@ -70,7 +75,7 @@ if _SPEC:
                     )
             return result
 
-        setattr(cls, _METHOD, _wrapped)
+        setattr(m, _FUNC, _wrapped)
 
     _real_import = builtins.__import__
 
@@ -79,13 +84,11 @@ if _SPEC:
         m = sys.modules.get(_MODULE)
         if (
             m is not None
-            and hasattr(m, _CLASS)
+            and hasattr(m, _FUNC)
             and not getattr(m, "_ft_patched", False)
         ):
-            cls = getattr(m, _CLASS)
-            if hasattr(cls, _METHOD):
-                m._ft_patched = True
-                _patch(m)
+            m._ft_patched = True
+            _patch(m)
         return module
 
     builtins.__import__ = _hook
@@ -93,7 +96,7 @@ if _SPEC:
 
 
 def _install_fault_injection(monkeypatch, tmp_path, rank: int, step: int) -> None:
-    """Arrange for the DP-sync method to raise on ``rank`` at serving ``step``.
+    """Arrange for the DP all_reduce sync to raise on ``rank`` at serving ``step``.
 
     Writes a ``sitecustomize.py`` and prepends its dir to PYTHONPATH so every
     vLLM subprocess picks it up; the fault spec is read from the environment.
@@ -181,7 +184,10 @@ class FTServerManager:
                         server_host="localhost",
                         server_port=8000 + r,
                         auto_port=False,
-                        env_dict={"ASCEND_RT_VISIBLE_DEVICES": str(r)},
+                        env_dict={
+                            "ASCEND_RT_VISIBLE_DEVICES": str(r),
+                            "VLLM_USE_V2_MODEL_RUNNER": "1",
+                        },
                     )
                     self.servers.append((server, sargs))
                 except Exception:
@@ -372,7 +378,7 @@ def has_npu_ft_capability() -> bool:
     reason="Requires at least 4 NPUs for DP=4 fault-tolerance testing",
 )
 def test_injected_fault_retry_recovers_all_ranks(monkeypatch, tmp_path):
-    """An exception injected into _sync_metadata_across_dp drives full
+    """An exception injected after the DP allreduce drives full
     retry recovery on all 4 DP ranks.
 
     Inject a fault at a chosen step on rank 3:

--- a/tests/e2e/pull_request/four_card/fault_tolerance/test_fault_tolerance_e2e.py
+++ b/tests/e2e/pull_request/four_card/fault_tolerance/test_fault_tolerance_e2e.py
@@ -47,8 +47,10 @@ _GOLDEN_PROMPTS = [
 ]
 _GOLDEN_OUTPUTS = [
     " Sarah, and I am 14 years old. I have a question about the equation $x^2 + y^2 = 1$. I know",
-    " Paris. The capital of the United Kingdom is London. The capital of Germany is Berlin. The capital of Spain is Madrid. The capital of Italy is Rome.",
-    " Is it possible to find a single, universal answer to this question, and how do different perspectives approach it?\n\nThe question of the meaning of life is one of",
+    " Paris. The capital of the United Kingdom is London. The capital of Germany is Berlin. "
+    "The capital of Spain is Madrid. The capital of Italy is Rome.",
+    " Is it possible to find a single, universal answer to this question, and how do "
+    "different perspectives approach it?\n\nThe question of the meaning of life is one of",
 ]
 _GOLDEN_MAX_TOKENS = 32
 

--- a/tests/e2e/pull_request/four_card/fault_tolerance/test_fault_tolerance_e2e.py
+++ b/tests/e2e/pull_request/four_card/fault_tolerance/test_fault_tolerance_e2e.py
@@ -27,6 +27,7 @@ DP_SIZE = 4
 # - NPU: HCSP operator timeout detects the dead peer.
 # - Deadline (45s): slowest fallback (30s) + margin.
 CPU_DISTRIBUTED_TIMEOUT_S = 30
+FT_COMMUNICATION_OPS_ABORT_TIMEOUT_MS = 15
 FAULT_DETECTION_DEADLINE_S = 45
 
 
@@ -115,7 +116,6 @@ def _install_fault_injection(monkeypatch, tmp_path, rank: int, step: int) -> Non
 
 def _ft_server_args() -> list[str]:
     return [
-        "--enforce-eager",
         "--dtype",
         "bfloat16",
         "--max-model-len",
@@ -128,6 +128,8 @@ def _ft_server_args() -> list[str]:
         str(CPU_DISTRIBUTED_TIMEOUT_S),
         "--fault-tolerance-config",
         '{"engine_recovery_timeout_sec": 120}',
+        "--additional-config",
+        f'{{"ft_communication_ops_abort_timeout_ms": {FT_COMMUNICATION_OPS_ABORT_TIMEOUT_MS}}}',
     ]
 
 

--- a/tests/e2e/pull_request/four_card/fault_tolerance/test_fault_tolerance_e2e.py
+++ b/tests/e2e/pull_request/four_card/fault_tolerance/test_fault_tolerance_e2e.py
@@ -6,12 +6,9 @@ Requires 4 NPUs (DP=4); gated behind ``has_npu_ft_capability()``.
 """
 
 import contextlib
-import http.server
 import os
 import threading
 import time
-import urllib.error
-import urllib.request
 from concurrent.futures import ThreadPoolExecutor
 from typing import Any
 
@@ -33,17 +30,27 @@ CPU_DISTRIBUTED_TIMEOUT_S = 15
 FT_COMMUNICATION_ABORT_TIMEOUT_S = 10
 FAULT_DETECTION_DEADLINE_S = 45
 
-BENCHMARK_HOME = "./benchmark"
-_GSM8K_CASE = {
-    "case_type": "accuracy",
-    "dataset_path": "vllm-ascend/gsm8k-lite",
-    "request_conf": "vllm_api_general_chat",
-    "dataset_conf": "gsm8k/gsm8k_gen_0_shot_cot_chat_prompt",
-    "max_out_len": 32768,
-    "batch_size": 32,
-    "baseline": 95,
-    "threshold": 5,
-}
+# Golden-output accuracy check, mirroring the pattern in
+# tests/e2e/pull_request/four_card/context_parallel/test_accuracy.py: greedy
+# completions for fixed prompts must be reproduced exactly after retry recovery.
+#
+# The golden outputs are hardcoded (NOT captured during the test): the fault
+# injection is step-triggered while serving, so it could fire mid-request and
+# corrupt a self-captured reference. Generate them by starting a healthy
+# Qwen/Qwen3-30B-A3B server once and issuing the prompts below with
+# temperature=0, max_tokens=_GOLDEN_MAX_TOKENS, then paste the returned texts
+# into _GOLDEN_OUTPUTS.
+_GOLDEN_PROMPTS = [
+    "Hello, my name is",
+    "The capital of France is",
+    "What is the meaning of life?",
+]
+_GOLDEN_OUTPUTS = [
+    " Sarah, and I am 14 years old. I have a question about the equation $x^2 + y^2 = 1$. I know",
+    " Paris. The capital of the United Kingdom is London. The capital of Germany is Berlin. The capital of Spain is Madrid. The capital of Italy is Rome.",
+    " Is it possible to find a single, universal answer to this question, and how do different perspectives approach it?\n\nThe question of the meaning of life is one of",
+]
+_GOLDEN_MAX_TOKENS = 32
 
 
 # ---------------------------------------------------------------------------
@@ -248,107 +255,6 @@ def _server_for_rank(servers: list[tuple[RemoteOpenAIServer, list[str]]], rank: 
 
 
 # ---------------------------------------------------------------------------
-# Round-robin proxy
-# ---------------------------------------------------------------------------
-
-
-class RoundRobinProxy:
-    """Tiny standard-library HTTP proxy that round-robins requests across
-    the DP rank server ports.
-
-    Listens on ``listen_port`` and forwards every request (method, path,
-    headers, body) verbatim to one of ``backend_ports``, chosen by a
-    thread-safe round-robin counter, so requests are spread evenly across
-    the ranks. Responses are passed back unchanged.
-
-    Usage::
-
-        with _ft_manager() as servers:
-            backend_ports = [server.port for server, _ in servers]
-            with RoundRobinProxy(backend_ports=backend_ports, listen_port=8100) as proxy:
-                resp = requests.post(f"{proxy.url}/v1/completions", json={...})
-    """
-
-    def __init__(
-        self,
-        backend_ports: list[int],
-        listen_port: int,
-        host: str = "127.0.0.1",
-    ):
-        self._backend_ports = list(backend_ports)
-        self._host = host
-        self._listen_port = listen_port
-        self._next = 0
-        self._lock = threading.Lock()
-        self._httpd: http.server.ThreadingHTTPServer | None = None
-        self._thread: threading.Thread | None = None
-
-    def __enter__(self) -> "RoundRobinProxy":
-        self._httpd = http.server.ThreadingHTTPServer((self._host, self._listen_port), self._make_handler())
-        self._thread = threading.Thread(target=self._httpd.serve_forever, daemon=True)
-        self._thread.start()
-        return self
-
-    def __exit__(self, *exc) -> None:
-        if self._httpd is not None:
-            self._httpd.shutdown()
-            self._httpd.server_close()
-            self._httpd = None
-        if self._thread is not None:
-            self._thread.join(timeout=2)
-            self._thread = None
-
-    @property
-    def url(self) -> str:
-        return f"http://{self._host}:{self._listen_port}"
-
-    @property
-    def port(self) -> int:
-        """Proxy listen port; makes ``RoundRobinProxy`` interchangeable with a
-        ``RemoteOpenAIServer`` for helpers that only need ``.port``."""
-        return self._listen_port
-
-    def _pick_backend(self) -> int:
-        with self._lock:
-            port = self._backend_ports[self._next % len(self._backend_ports)]
-            self._next += 1
-            return port
-
-    def _make_handler(self):
-        proxy = self
-
-        class Handler(http.server.BaseHTTPRequestHandler):
-            def _forward(self) -> None:
-                length = int(self.headers.get("Content-Length", 0) or 0)
-                body = self.rfile.read(length) if length else b""
-                port = proxy._pick_backend()
-                url = f"http://127.0.0.1:{port}{self.path}"
-                req = urllib.request.Request(url, data=body, method=self.command)
-                for key, value in self.headers.items():
-                    if key.lower() not in ("host", "content-length", "accept-encoding"):
-                        req.add_header(key, value)
-                try:
-                    with urllib.request.urlopen(req, timeout=300) as resp:
-                        status, resp_headers, resp_body = resp.status, dict(resp.headers), resp.read()
-                except urllib.error.HTTPError as exc:
-                    status, resp_headers, resp_body = exc.code, dict(exc.headers), exc.read()
-                self.send_response(status)
-                for key, value in resp_headers.items():
-                    if key.lower() not in ("transfer-encoding", "connection", "content-length"):
-                        self.send_header(key, value)
-                self.send_header("Content-Length", str(len(resp_body)))
-                self.end_headers()
-                self.wfile.write(resp_body)
-
-            do_GET = do_POST = do_PUT = do_DELETE = do_PATCH = _forward
-
-            def log_message(self, *args):  # silence request logging
-                pass
-
-        return Handler
-
-
-# ---------------------------------------------------------------------------
 # Test primitives
 # ---------------------------------------------------------------------------
 
@@ -395,27 +301,32 @@ def _assert_serving_and_healthy(
     _in_parallel(lambda s: _complete(s.get_client()), servers)
 
 
-def _run_gsm8k_eval(server: Any, stage: str) -> float:
-    """Run GSM8K accuracy evaluation using aisbench.
+def _assert_golden_outputs(servers: tuple[RemoteOpenAIServer, ...]) -> None:
+    """Send the golden prompts to every DP rank directly and assert each rank
+    reproduces the expected output exactly.
 
-    ``server`` is any object exposing ``.port`` — either a
-    ``RemoteOpenAIServer`` or a ``RoundRobinProxy``.
-
-    Returns the measured accuracy percentage.
+    Must only be called after retry recovery has fully completed (see
+    ``_assert_serving_and_healthy``), so the golden requests are not sent into
+    a still-faulting cluster.
     """
-
-    os.environ.setdefault("BENCHMARK_HOME", BENCHMARK_HOME)
-    from tools.aisbench import AisbenchRunner
-
-    with AisbenchRunner(
-        model=MODEL_NAME,
-        port=server.port,
-        aisbench_config=_GSM8K_CASE,
-        verify=True,
-    ) as aisbench:
-        accuracy = aisbench.result
-        print(f"[{stage}] GSM8K accuracy: {accuracy:.2f}")
-        return accuracy
+    for server in servers:
+        client = server.get_client()
+        for prompt, golden in zip(_GOLDEN_PROMPTS, _GOLDEN_OUTPUTS):
+            resp = client.completions.create(
+                model=MODEL_NAME,
+                prompt=prompt,
+                max_tokens=_GOLDEN_MAX_TOKENS,
+                temperature=0.0,
+            )
+            text = resp.choices[0].text
+            print(f"[golden] rank {server.port} prompt {prompt!r}:")
+            print(f"  golden: {golden!r}")
+            print(f"  actual: {text!r}")
+            assert text.strip() == golden.strip(), (
+                f"[post-retry] rank {server.port} output for prompt {prompt!r} diverged from golden:\n"
+                f"  golden: {golden}\n"
+                f"  actual: {text}"
+            )
 
 
 def _kill_worker_process(server: RemoteOpenAIServer) -> None:
@@ -528,9 +439,10 @@ def test_injected_fault_retry_recovers_all_ranks(monkeypatch, tmp_path):
     All 4 being UNHEALTHY is the precondition for ``retry``.  The fault
     is patched via a generated ``sitecustomize.py``.
 
-    After recovery, the serving cluster must still meet the GSM8K accuracy
-    standard used by tests/e2e/weekly/single_node/models/test_qwen3_30b_acc.py
-    (baseline=95, threshold=5, i.e. accuracy >= 90%).
+    After retry recovery completes, the serving cluster must reproduce the
+    hardcoded golden outputs exactly (greedy decoding is deterministic, so an
+    exact match verifies correctness without needing an ais_bench benchmark
+    tree).
     """
     fault_step = int(os.getenv("FT_FAULT_STEP", "100"))
     _install_fault_injection(monkeypatch, tmp_path, rank=3, step=fault_step)
@@ -538,46 +450,39 @@ def test_injected_fault_retry_recovers_all_ranks(monkeypatch, tmp_path):
     with _ft_manager() as servers:
         assert len(servers) == DP_SIZE
         all_ranks = tuple(_server_for_rank(servers, r) for r in range(DP_SIZE))
-        backend_ports = [server.port for server, _ in servers]
 
-        # Requests through the round-robin proxy are spread evenly across
-        # the DP rank ports; the proxy stays alive for the whole test so the
-        # GSM8K accuracy evaluation is also driven through it.
-        with RoundRobinProxy(backend_ports=backend_ports, listen_port=8100) as proxy:
-            # 1. All engines healthy and serving.
-            _assert_serving_and_healthy(all_ranks)
+        # 1. All engines healthy and serving.
+        _assert_serving_and_healthy(all_ranks)
 
-            # 2. Drive all ranks so rank 3 accumulates steps and trips the
-            #    injected fault; ranks 0,1,2 then time out on DP allreduce.
-            with _driving(*all_ranks):
-                faulted = _wait_for_engines(
-                    list(all_ranks),
-                    match_key="status",
-                    match_values={"unhealthy"},
-                )
+        # 2. Drive all ranks so rank 3 accumulates steps and trips the
+        #    injected fault; ranks 0,1,2 then time out on DP allreduce.
+        with _driving(*all_ranks):
+            faulted = _wait_for_engines(
+                list(all_ranks),
+                match_key="status",
+                match_values={"unhealthy"},
+            )
 
-            for rank, engine_status in enumerate(faulted):
-                assert engine_status is not None, (
-                    f"rank {rank} did not report UNHEALTHY within {FAULT_DETECTION_DEADLINE_S}s -- it likely hung"
-                )
+        for rank, engine_status in enumerate(faulted):
+            assert engine_status is not None, (
+                f"rank {rank} did not report UNHEALTHY within {FAULT_DETECTION_DEADLINE_S}s -- it likely hung"
+            )
 
-            # The rank that raised carries the fault info from its own exception.
-            assert faulted[3] is not None
-            assert faulted[3].get("fault_info"), faulted[3]
+        # The rank that raised carries the fault info from its own exception.
+        assert faulted[3] is not None
+        assert faulted[3].get("fault_info"), faulted[3]
 
-            # 3. retry all engines.
-            for server in all_ranks:
-                _apply_ft(server, "retry")
+        # 3. retry all engines.
+        for server in all_ranks:
+            _apply_ft(server, "retry")
 
-            # 4. Recovery completes: all engines return to healthy and serve again.
-            _assert_serving_and_healthy(all_ranks)
+        # 4. Recovery completes: all engines return to healthy and serve again.
+        _assert_serving_and_healthy(all_ranks)
 
-            # 5. The recovered cluster must still meet the GSM8K accuracy
-            #    standard (>= 90%); AisbenchRunner raises otherwise. The injected
-            #    fault is a one-shot step guard, so this dataset run does not
-            #    re-trigger it. The evaluation runs through the proxy, which
-            #    spreads the requests across all DP ranks.
-            _run_gsm8k_eval(proxy, "post-retry")
+        # 5. Only now (after retry fully completed) send the golden prompts to
+        #    every DP rank directly. The injected fault is a one-shot step
+        #    guard, so these requests do not re-trigger it.
+        _assert_golden_outputs(all_ranks)
 
 
 @pytest.mark.skipif(

--- a/tests/e2e/pull_request/four_card/fault_tolerance/test_fault_tolerance_e2e.py
+++ b/tests/e2e/pull_request/four_card/fault_tolerance/test_fault_tolerance_e2e.py
@@ -6,9 +6,12 @@ Requires 4 NPUs (DP=4); gated behind ``has_npu_ft_capability()``.
 """
 
 import contextlib
+import http.server
 import os
 import threading
 import time
+import urllib.error
+import urllib.request
 from concurrent.futures import ThreadPoolExecutor
 from typing import Any
 
@@ -23,12 +26,24 @@ MODEL_NAME = os.getenv("MODEL_NAME", "Qwen/Qwen3-30B-A3B")
 DP_SIZE = 4
 
 # Fault-detection timeout budget:
-# - CPU: Gloo DP allreduce timeout  detects the dead peer.
+# - CPU: Gloo DP allreduce timeout detects the dead peer.
 # - NPU: HCSP operator timeout detects the dead peer.
-# - Deadline : slowest fallback + margin.
+# - Deadline: slowest fallback + margin.
 CPU_DISTRIBUTED_TIMEOUT_S = 15
 FT_COMMUNICATION_ABORT_TIMEOUT_S = 10
 FAULT_DETECTION_DEADLINE_S = 45
+
+BENCHMARK_HOME = "./benchmark"
+_GSM8K_CASE = {
+    "case_type": "accuracy",
+    "dataset_path": "vllm-ascend/gsm8k-lite",
+    "request_conf": "vllm_api_general_chat",
+    "dataset_conf": "gsm8k/gsm8k_gen_0_shot_cot_chat_prompt",
+    "max_out_len": 32768,
+    "batch_size": 32,
+    "baseline": 95,
+    "threshold": 5,
+}
 
 
 # ---------------------------------------------------------------------------
@@ -122,7 +137,7 @@ def _ft_server_args() -> list[str]:
         "--dtype",
         "bfloat16",
         "--max-model-len",
-        "2048",
+        "37364",
         "--max-num-seqs",
         "128",
         "--enable-expert-parallel",
@@ -233,6 +248,107 @@ def _server_for_rank(servers: list[tuple[RemoteOpenAIServer, list[str]]], rank: 
 
 
 # ---------------------------------------------------------------------------
+# Round-robin proxy
+# ---------------------------------------------------------------------------
+
+
+class RoundRobinProxy:
+    """Tiny standard-library HTTP proxy that round-robins requests across
+    the DP rank server ports.
+
+    Listens on ``listen_port`` and forwards every request (method, path,
+    headers, body) verbatim to one of ``backend_ports``, chosen by a
+    thread-safe round-robin counter, so requests are spread evenly across
+    the ranks. Responses are passed back unchanged.
+
+    Usage::
+
+        with _ft_manager() as servers:
+            backend_ports = [server.port for server, _ in servers]
+            with RoundRobinProxy(backend_ports=backend_ports, listen_port=8100) as proxy:
+                resp = requests.post(f"{proxy.url}/v1/completions", json={...})
+    """
+
+    def __init__(
+        self,
+        backend_ports: list[int],
+        listen_port: int,
+        host: str = "127.0.0.1",
+    ):
+        self._backend_ports = list(backend_ports)
+        self._host = host
+        self._listen_port = listen_port
+        self._next = 0
+        self._lock = threading.Lock()
+        self._httpd: http.server.ThreadingHTTPServer | None = None
+        self._thread: threading.Thread | None = None
+
+    def __enter__(self) -> "RoundRobinProxy":
+        self._httpd = http.server.ThreadingHTTPServer((self._host, self._listen_port), self._make_handler())
+        self._thread = threading.Thread(target=self._httpd.serve_forever, daemon=True)
+        self._thread.start()
+        return self
+
+    def __exit__(self, *exc) -> None:
+        if self._httpd is not None:
+            self._httpd.shutdown()
+            self._httpd.server_close()
+            self._httpd = None
+        if self._thread is not None:
+            self._thread.join(timeout=2)
+            self._thread = None
+
+    @property
+    def url(self) -> str:
+        return f"http://{self._host}:{self._listen_port}"
+
+    @property
+    def port(self) -> int:
+        """Proxy listen port; makes ``RoundRobinProxy`` interchangeable with a
+        ``RemoteOpenAIServer`` for helpers that only need ``.port``."""
+        return self._listen_port
+
+    def _pick_backend(self) -> int:
+        with self._lock:
+            port = self._backend_ports[self._next % len(self._backend_ports)]
+            self._next += 1
+            return port
+
+    def _make_handler(self):
+        proxy = self
+
+        class Handler(http.server.BaseHTTPRequestHandler):
+            def _forward(self) -> None:
+                length = int(self.headers.get("Content-Length", 0) or 0)
+                body = self.rfile.read(length) if length else b""
+                port = proxy._pick_backend()
+                url = f"http://127.0.0.1:{port}{self.path}"
+                req = urllib.request.Request(url, data=body, method=self.command)
+                for key, value in self.headers.items():
+                    if key.lower() not in ("host", "content-length", "accept-encoding"):
+                        req.add_header(key, value)
+                try:
+                    with urllib.request.urlopen(req, timeout=300) as resp:
+                        status, resp_headers, resp_body = resp.status, dict(resp.headers), resp.read()
+                except urllib.error.HTTPError as exc:
+                    status, resp_headers, resp_body = exc.code, dict(exc.headers), exc.read()
+                self.send_response(status)
+                for key, value in resp_headers.items():
+                    if key.lower() not in ("transfer-encoding", "connection", "content-length"):
+                        self.send_header(key, value)
+                self.send_header("Content-Length", str(len(resp_body)))
+                self.end_headers()
+                self.wfile.write(resp_body)
+
+            do_GET = do_POST = do_PUT = do_DELETE = do_PATCH = _forward
+
+            def log_message(self, *args):  # silence request logging
+                pass
+
+        return Handler
+
+
+# ---------------------------------------------------------------------------
 # Test primitives
 # ---------------------------------------------------------------------------
 
@@ -278,6 +394,29 @@ def _assert_serving_and_healthy(
     healthy = _wait_for_engines(list(servers), match_key="status", match_values={"healthy"})
     assert all(healthy), healthy
     _in_parallel(lambda s: _complete(s.get_client()), servers)
+
+
+def _run_gsm8k_eval(server: Any, stage: str) -> float:
+    """Run GSM8K accuracy evaluation using aisbench.
+
+    ``server`` is any object exposing ``.port`` — either a
+    ``RemoteOpenAIServer`` or a ``RoundRobinProxy``.
+
+    Returns the measured accuracy percentage.
+    """
+
+    os.environ.setdefault("BENCHMARK_HOME", BENCHMARK_HOME)
+    from tools.aisbench import AisbenchRunner
+
+    with AisbenchRunner(
+        model=MODEL_NAME,
+        port=server.port,
+        aisbench_config=_GSM8K_CASE,
+        verify=True,
+    ) as aisbench:
+        accuracy = aisbench.result
+        print(f"[{stage}] GSM8K accuracy: {accuracy:.2f}")
+        return accuracy
 
 
 def _kill_worker_process(server: RemoteOpenAIServer) -> None:
@@ -389,6 +528,10 @@ def test_injected_fault_retry_recovers_all_ranks(monkeypatch, tmp_path):
 
     All 4 being UNHEALTHY is the precondition for ``retry``.  The fault
     is patched via a generated ``sitecustomize.py``.
+
+    After recovery, the serving cluster must still meet the GSM8K accuracy
+    standard used by tests/e2e/weekly/single_node/models/test_qwen3_30b_acc.py
+    (baseline=95, threshold=5, i.e. accuracy >= 90%).
     """
     fault_step = int(os.getenv("FT_FAULT_STEP", "100"))
     _install_fault_injection(monkeypatch, tmp_path, rank=3, step=fault_step)
@@ -396,34 +539,50 @@ def test_injected_fault_retry_recovers_all_ranks(monkeypatch, tmp_path):
     with _ft_manager() as servers:
         assert len(servers) == DP_SIZE
         all_ranks = tuple(_server_for_rank(servers, r) for r in range(DP_SIZE))
+        backend_ports = [server.port for server, _ in servers]
 
-        # 1. All engines healthy and serving.
-        _assert_serving_and_healthy(all_ranks)
+        # Requests through the round-robin proxy are spread evenly across
+        # the DP rank ports; the proxy stays alive for the whole test so the
+        # GSM8K accuracy evaluation is also driven through it.
+        with RoundRobinProxy(backend_ports=backend_ports, listen_port=8100) as proxy:
+            # 1. All engines healthy and serving.
+            _assert_serving_and_healthy(all_ranks)
 
-        # 2. Drive all ranks so rank 3 accumulates steps and trips the
-        #    injected fault; ranks 0,1,2 then time out on DP allreduce.
-        with _driving(*all_ranks):
-            faulted = _wait_for_engines(
-                list(all_ranks),
-                match_key="status",
-                match_values={"unhealthy"},
+            # 2. Drive all ranks so rank 3 accumulates steps and trips the
+            #    injected fault; ranks 0,1,2 then time out on DP allreduce.
+            with _driving(*all_ranks):
+                faulted = _wait_for_engines(
+                    list(all_ranks),
+                    match_key="status",
+                    match_values={"unhealthy"},
+                )
+
+            for rank, engine_status in enumerate(faulted):
+                assert engine_status is not None, (
+                    f"rank {rank} did not report UNHEALTHY within {FAULT_DETECTION_DEADLINE_S}s -- it likely hung"
+                )
+
+            # The rank that raised carries the fault info from its own exception.
+            assert faulted[3] is not None
+            assert faulted[3].get("fault_info"), faulted[3]
+
+            # 3. retry all engines.
+            for server in all_ranks:
+                _apply_ft(server, "retry")
+
+            # 4. Recovery completes: all engines return to healthy and serve again.
+            _assert_serving_and_healthy(all_ranks)
+
+            # 5. The recovered cluster must still meet the GSM8K accuracy
+            #    standard (>= 90%); AisbenchRunner raises otherwise. The injected
+            #    fault is a one-shot step guard, so this dataset run does not
+            #    re-trigger it. The evaluation runs through the proxy, which
+            #    spreads the requests across all DP ranks.
+            recovered_acc = _run_gsm8k_eval(proxy, "post-retry")
+            print(
+                f"[GSM8K acc] recovered={recovered_acc:.2f}% "
+                f"(standard: >= {_GSM8K_CASE['baseline'] - _GSM8K_CASE['threshold']}%)"
             )
-
-        for rank, engine_status in enumerate(faulted):
-            assert engine_status is not None, (
-                f"rank {rank} did not report UNHEALTHY within {FAULT_DETECTION_DEADLINE_S}s -- it likely hung"
-            )
-
-        # The rank that raised carries the fault info from its own exception.
-        assert faulted[3] is not None
-        assert faulted[3].get("fault_info"), faulted[3]
-
-        # 3. retry all engines.
-        for server in all_ranks:
-            _apply_ft(server, "retry")
-
-        # 4. Recovery completes: all engines return to healthy and serve again.
-        _assert_serving_and_healthy(all_ranks)
 
 
 @pytest.mark.skipif(

--- a/tests/e2e/pull_request/four_card/fault_tolerance/test_fault_tolerance_e2e.py
+++ b/tests/e2e/pull_request/four_card/fault_tolerance/test_fault_tolerance_e2e.py
@@ -23,9 +23,9 @@ MODEL_NAME = os.getenv("MODEL_NAME", "Qwen/Qwen3-30B-A3B")
 DP_SIZE = 4
 
 # Fault-detection timeout budget:
-# - CPU: Gloo DP allreduce timeout (30s) detects the dead peer.
+# - CPU: Gloo DP allreduce timeout  detects the dead peer.
 # - NPU: HCSP operator timeout detects the dead peer.
-# - Deadline (45s): slowest fallback (30s) + margin.
+# - Deadline : slowest fallback + margin.
 CPU_DISTRIBUTED_TIMEOUT_S = 15
 FT_COMMUNICATION_ABORT_TIMEOUT_S = 10
 FAULT_DETECTION_DEADLINE_S = 45

--- a/tests/e2e/pull_request/four_card/fault_tolerance/test_fault_tolerance_e2e.py
+++ b/tests/e2e/pull_request/four_card/fault_tolerance/test_fault_tolerance_e2e.py
@@ -578,11 +578,7 @@ def test_injected_fault_retry_recovers_all_ranks(monkeypatch, tmp_path):
             #    fault is a one-shot step guard, so this dataset run does not
             #    re-trigger it. The evaluation runs through the proxy, which
             #    spreads the requests across all DP ranks.
-            recovered_acc = _run_gsm8k_eval(proxy, "post-retry")
-            print(
-                f"[GSM8K acc] recovered={recovered_acc:.2f}% "
-                f"(standard: >= {_GSM8K_CASE['baseline'] - _GSM8K_CASE['threshold']}%)"
-            )
+            _run_gsm8k_eval(proxy, "post-retry")
 
 
 @pytest.mark.skipif(

--- a/tests/e2e/pull_request/four_card/fault_tolerance/test_fault_tolerance_e2e.py
+++ b/tests/e2e/pull_request/four_card/fault_tolerance/test_fault_tolerance_e2e.py
@@ -360,7 +360,6 @@ def _complete(client) -> Any:
         prompt="Hello, my name is",
         max_tokens=5,
         temperature=0.0,
-        timeout=10.0,
     )
 
 

--- a/tests/e2e/pull_request/four_card/fault_tolerance/test_fault_tolerance_e2e.py
+++ b/tests/e2e/pull_request/four_card/fault_tolerance/test_fault_tolerance_e2e.py
@@ -14,6 +14,7 @@ from typing import Any
 
 import psutil
 import pytest
+import regex as re
 import requests
 import torch
 
@@ -30,29 +31,16 @@ CPU_DISTRIBUTED_TIMEOUT_S = 15
 FT_COMMUNICATION_ABORT_TIMEOUT_S = 10
 FAULT_DETECTION_DEADLINE_S = 45
 
-# Golden-output accuracy check, mirroring the pattern in
-# tests/e2e/pull_request/four_card/context_parallel/test_accuracy.py: greedy
-# completions for fixed prompts must be reproduced exactly after retry recovery.
-#
-# The golden outputs are hardcoded (NOT captured during the test): the fault
-# injection is step-triggered while serving, so it could fire mid-request and
-# corrupt a self-captured reference. Generate them by starting a healthy
-# Qwen/Qwen3-30B-A3B server once and issuing the prompts below with
-# temperature=0, max_tokens=_GOLDEN_MAX_TOKENS, then paste the returned texts
-# into _GOLDEN_OUTPUTS.
-_GOLDEN_PROMPTS = [
-    "Hello, my name is",
-    "The capital of France is",
-    "What is the meaning of life?",
+# Post-recovery accuracy check: after retry recovery, every DP rank must
+# answer these factual prompts correctly. Each expected answer is a single
+# word, matched case-insensitively on word boundaries anywhere in the
+# completion, so harmless phrasing variations do not fail the check.
+_ANSWER_CASES = [
+    ("The capital of France is", ("Paris",)),
+    ("The largest planet in our solar system is", ("Jupiter",)),
+    ("The first month of the year is", ("January",)),
 ]
-_GOLDEN_OUTPUTS = [
-    " Sarah, and I am 14 years old. I have a question about the equation $x^2 + y^2 = 1$. I know",
-    " Paris. The capital of the United Kingdom is London. The capital of Germany is Berlin. "
-    "The capital of Spain is Madrid. The capital of Italy is Rome.",
-    " Is it possible to find a single, universal answer to this question, and how do "
-    "different perspectives approach it?\n\nThe question of the meaning of life is one of",
-]
-_GOLDEN_MAX_TOKENS = 32
+_ANSWER_MAX_TOKENS = 16
 
 
 # ---------------------------------------------------------------------------
@@ -303,31 +291,28 @@ def _assert_serving_and_healthy(
     _in_parallel(lambda s: _complete(s.get_client()), servers)
 
 
-def _assert_golden_outputs(servers: tuple[RemoteOpenAIServer, ...]) -> None:
-    """Send the golden prompts to every DP rank directly and assert each rank
-    reproduces the expected output exactly.
+def _assert_correct_answers(servers: tuple[RemoteOpenAIServer, ...]) -> None:
+    """Send factual prompts to every DP rank and assert the answer appears.
 
     Must only be called after retry recovery has fully completed (see
-    ``_assert_serving_and_healthy``), so the golden requests are not sent into
-    a still-faulting cluster.
+    ``_assert_serving_and_healthy``), so the requests are not sent into a
+    still-faulting cluster.
     """
     for server in servers:
         client = server.get_client()
-        for prompt, golden in zip(_GOLDEN_PROMPTS, _GOLDEN_OUTPUTS):
+        for prompt, answers in _ANSWER_CASES:
             resp = client.completions.create(
                 model=MODEL_NAME,
                 prompt=prompt,
-                max_tokens=_GOLDEN_MAX_TOKENS,
+                max_tokens=_ANSWER_MAX_TOKENS,
                 temperature=0.0,
             )
-            text = resp.choices[0].text
-            print(f"[golden] rank {server.port} prompt {prompt!r}:")
-            print(f"  golden: {golden!r}")
-            print(f"  actual: {text!r}")
-            assert text.strip() == golden.strip(), (
-                f"[post-retry] rank {server.port} output for prompt {prompt!r} diverged from golden:\n"
-                f"  golden: {golden}\n"
-                f"  actual: {text}"
+            completion = resp.choices[0].text
+            matched = any(re.search(rf"\b{re.escape(answer)}\b", completion, re.IGNORECASE) for answer in answers)
+            print(f"[accuracy] rank {server.port} prompt {prompt!r}: {completion!r}")
+            assert matched, (
+                f"[post-retry] rank {server.port} answered {prompt!r} incorrectly: "
+                f"expected one of {answers!r}, got {completion!r}"
             )
 
 
@@ -441,10 +426,9 @@ def test_injected_fault_retry_recovers_all_ranks(monkeypatch, tmp_path):
     All 4 being UNHEALTHY is the precondition for ``retry``.  The fault
     is patched via a generated ``sitecustomize.py``.
 
-    After retry recovery completes, the serving cluster must reproduce the
-    hardcoded golden outputs exactly (greedy decoding is deterministic, so an
-    exact match verifies correctness without needing an ais_bench benchmark
-    tree).
+    After retry recovery completes, every rank must answer factual prompts
+    correctly (greedy decoding; case-insensitive whole-word match, not an
+    exact-match golden, so the check is independent of environment numerics).
     """
     fault_step = int(os.getenv("FT_FAULT_STEP", "100"))
     _install_fault_injection(monkeypatch, tmp_path, rank=3, step=fault_step)
@@ -481,10 +465,10 @@ def test_injected_fault_retry_recovers_all_ranks(monkeypatch, tmp_path):
         # 4. Recovery completes: all engines return to healthy and serve again.
         _assert_serving_and_healthy(all_ranks)
 
-        # 5. Only now (after retry fully completed) send the golden prompts to
-        #    every DP rank directly. The injected fault is a one-shot step
+        # 5. Only now (after retry fully completed) send the accuracy prompts
+        #    to every DP rank directly. The injected fault is a one-shot step
         #    guard, so these requests do not re-trigger it.
-        _assert_golden_outputs(all_ranks)
+        _assert_correct_answers(all_ranks)
 
 
 @pytest.mark.skipif(

--- a/tests/e2e/pull_request/four_card/fault_tolerance/test_fault_tolerance_e2e.py
+++ b/tests/e2e/pull_request/four_card/fault_tolerance/test_fault_tolerance_e2e.py
@@ -26,8 +26,8 @@ DP_SIZE = 4
 # - CPU: Gloo DP allreduce timeout (30s) detects the dead peer.
 # - NPU: HCSP operator timeout detects the dead peer.
 # - Deadline (45s): slowest fallback (30s) + margin.
-CPU_DISTRIBUTED_TIMEOUT_S = 30
-FT_COMMUNICATION_ABORT_TIMEOUT_S = 15
+CPU_DISTRIBUTED_TIMEOUT_S = 15
+FT_COMMUNICATION_ABORT_TIMEOUT_S = 10
 FAULT_DETECTION_DEADLINE_S = 45
 
 
@@ -384,7 +384,7 @@ def test_injected_fault_retry_recovers_all_ranks(monkeypatch, tmp_path):
     All 4 being UNHEALTHY is the precondition for ``retry``.  The fault
     is patched via a generated ``sitecustomize.py``.
     """
-    fault_step = int(os.getenv("FT_FAULT_STEP", "50"))
+    fault_step = int(os.getenv("FT_FAULT_STEP", "100"))
     _install_fault_injection(monkeypatch, tmp_path, rank=3, step=fault_step)
 
     with _ft_manager() as servers:

--- a/tests/e2e/pull_request/four_card/fault_tolerance/test_fault_tolerance_e2e.py
+++ b/tests/e2e/pull_request/four_card/fault_tolerance/test_fault_tolerance_e2e.py
@@ -27,7 +27,7 @@ DP_SIZE = 4
 # - NPU: HCSP operator timeout detects the dead peer.
 # - Deadline (45s): slowest fallback (30s) + margin.
 CPU_DISTRIBUTED_TIMEOUT_S = 30
-FT_COMMUNICATION_OPS_ABORT_TIMEOUT_MS = 15
+FT_COMMUNICATION_ABORT_TIMEOUT_S = 15
 FAULT_DETECTION_DEADLINE_S = 45
 
 
@@ -129,7 +129,7 @@ def _ft_server_args() -> list[str]:
         "--fault-tolerance-config",
         '{"engine_recovery_timeout_sec": 120}',
         "--additional-config",
-        f'{{"ft_communication_ops_abort_timeout_ms": {FT_COMMUNICATION_OPS_ABORT_TIMEOUT_MS}}}',
+        f'{{"ft_communication_abort_timeout": {FT_COMMUNICATION_ABORT_TIMEOUT_S}}}',
     ]
 
 

--- a/tests/e2e/pull_request/four_card/fault_tolerance/test_fault_tolerance_e2e.py
+++ b/tests/e2e/pull_request/four_card/fault_tolerance/test_fault_tolerance_e2e.py
@@ -2,10 +2,12 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 """End-to-end tests for the fault-tolerance framework on Ascend NPU.
 
-Requires 4 NPUs (DP=4); gated behind ``has_npu_ft_capability()``.
+Requires 4 NPUs (DP=4). Retry is gated behind ``has_npu_ft_capability()``;
+scale-down additionally behind ``has_npu_scale_down_capability()`` (CANN V3+).
 """
 
 import contextlib
+import json
 import os
 import threading
 import time
@@ -20,7 +22,7 @@ import torch
 
 from tests.e2e.conftest import RemoteOpenAIServer
 
-MODEL_NAME = os.getenv("MODEL_NAME", "Qwen/Qwen3-30B-A3B")
+MODEL_NAME = os.getenv("MODEL_NAME", "vllm-ascend/Qwen3-30B-A3B-W8A8")
 DP_SIZE = 4
 
 # Fault-detection timeout budget:
@@ -30,6 +32,18 @@ DP_SIZE = 4
 CPU_DISTRIBUTED_TIMEOUT_S = 15
 FT_COMMUNICATION_ABORT_TIMEOUT_S = 10
 FAULT_DETECTION_DEADLINE_S = 45
+
+# scale_down re-hosts the dead rank's experts on the survivors and reloads
+# the reassigned weights from disk; give the redistribution + dummy-batch
+# check more headroom than fault detection (still under
+# engine_recovery_timeout_sec=120, the busy-loop's own give-up point).
+SCALE_DOWN_DEADLINE_S = 90
+
+# Qwen3-30B-A3B has 128 routed experts; on EP=4, 48 redundant experts give
+# 44 physical slots per rank, so the 3 surviving ranks still have
+# 3 * 44 = 132 >= 128 slots after one rank is removed (the strict minimum
+# ``check_redundancy_sufficient`` accepts for a 4 -> 3 shrink is 44).
+NUM_REDUNDANT_EXPERTS = 48
 
 # Post-recovery accuracy check: after retry recovery, every DP rank must
 # answer these factual prompts correctly. Each expected answer is a single
@@ -129,10 +143,13 @@ def _install_fault_injection(monkeypatch, tmp_path, rank: int, step: int) -> Non
 # ---------------------------------------------------------------------------
 
 
-def _ft_server_args() -> list[str]:
+def _ft_server_args(extra_args: list[str] | None = None) -> list[str]:
+    # Quantized path end to end: --quantization ascend (W8A8); no --dtype,
+    # the checkpoint's own config decides. MODEL_NAME must point at a W8A8
+    # checkpoint (e.g. vllm-ascend/Qwen3-30B-A3B-W8A8).
     return [
-        "--dtype",
-        "bfloat16",
+        "--quantization",
+        "ascend",
         "--max-model-len",
         "37364",
         "--max-num-seqs",
@@ -145,6 +162,7 @@ def _ft_server_args() -> list[str]:
         '{"engine_recovery_timeout_sec": 120}',
         "--additional-config",
         f'{{"ft_communication_abort_timeout": {FT_COMMUNICATION_ABORT_TIMEOUT_S}}}',
+        *(extra_args or []),
     ]
 
 
@@ -225,11 +243,11 @@ class FTServerManager:
         self.servers.clear()
 
 
-def _ft_manager() -> FTServerManager:
+def _ft_manager(extra_args: list[str] | None = None) -> FTServerManager:
     return FTServerManager(
         MODEL_NAME,
         DP_SIZE,
-        base_server_args=_ft_server_args(),
+        base_server_args=_ft_server_args(extra_args),
         tp_size=1,
     )
 
@@ -266,7 +284,7 @@ def _in_parallel(fn, servers) -> list[Any]:
 
 
 def _get_ft_status(server: RemoteOpenAIServer) -> dict:
-    resp = requests.get(server.url_for("fault_tolerance/status"), timeout=10)
+    resp = requests.get(server.url_for("v1/fault_tolerance/status"), timeout=10)
     resp.raise_for_status()
     return resp.json()
 
@@ -274,7 +292,7 @@ def _get_ft_status(server: RemoteOpenAIServer) -> dict:
 def _apply_ft(server: RemoteOpenAIServer, instruction: str, params: dict | None = None) -> dict:
     """POST an FT instruction; assert it is accepted (202) and return body."""
     resp = requests.post(
-        server.url_for("fault_tolerance/apply"),
+        server.url_for("v1/fault_tolerance/apply"),
         json={"instruction": instruction, "params": params or {}},
         timeout=10,
     )
@@ -294,9 +312,9 @@ def _assert_serving_and_healthy(
 def _assert_correct_answers(servers: tuple[RemoteOpenAIServer, ...]) -> None:
     """Send factual prompts to every DP rank and assert the answer appears.
 
-    Must only be called after retry recovery has fully completed (see
-    ``_assert_serving_and_healthy``), so the requests are not sent into a
-    still-faulting cluster.
+    Must only be called after FT recovery (retry or scale_down) has fully
+    completed (see ``_assert_serving_and_healthy``), so the requests are not
+    sent into a still-faulting cluster.
     """
     for server in servers:
         client = server.get_client()
@@ -311,7 +329,7 @@ def _assert_correct_answers(servers: tuple[RemoteOpenAIServer, ...]) -> None:
             matched = any(re.search(rf"\b{re.escape(answer)}\b", completion, re.IGNORECASE) for answer in answers)
             print(f"[accuracy] rank {server.port} prompt {prompt!r}: {completion!r}")
             assert matched, (
-                f"[post-retry] rank {server.port} answered {prompt!r} incorrectly: "
+                f"[post-recovery] rank {server.port} answered {prompt!r} incorrectly: "
                 f"expected one of {answers!r}, got {completion!r}"
             )
 
@@ -329,7 +347,7 @@ def _wait_for_engines(
     match_values: set[str],
     deadline_s: int = FAULT_DETECTION_DEADLINE_S,
 ) -> list[dict[str, Any] | None]:
-    """Poll ``/fault_tolerance/status`` until each server's engine status matches.
+    """Poll ``/v1/fault_tolerance/status`` until each server's engine status matches.
 
     A server matches when its engine-status dict has ``match_key`` equal to
     one of ``match_values``. Returns one engine-status dict per server.
@@ -379,7 +397,7 @@ def _driving(*servers: RemoteOpenAIServer):
 
 
 def _wait_for_ft_apply_outcome(server: RemoteOpenAIServer, request_id: str, deadline_s: int) -> str | None:
-    """Wait until ``/fault_tolerance/status`` records the FT apply outcome."""
+    """Wait until ``/v1/fault_tolerance/status`` records the FT apply outcome."""
     engine_status = _wait_for_engines(
         [server],
         match_key="last_ft_request_id",
@@ -400,6 +418,23 @@ def has_npu_ft_capability() -> bool:
         return False
     try:
         return torch.npu.device_count() >= DP_SIZE
+    except Exception:
+        return False
+
+
+def has_npu_scale_down_capability() -> bool:
+    """scale_down additionally requires the V3 dispatch op (CANN V3+).
+
+    Mirrors the engine-side precondition in ``WorkerSentinel
+    ._validate_scale_down_preconditions`` so the test skips cleanly on
+    older CANN/torch_npu stacks instead of timing out mid-recovery.
+    """
+    if not has_npu_ft_capability():
+        return False
+    try:
+        import torch_npu
+
+        return hasattr(torch_npu, "npu_moe_distribute_dispatch_v2")
     except Exception:
         return False
 
@@ -472,39 +507,46 @@ def test_injected_fault_retry_recovers_all_ranks(monkeypatch, tmp_path):
 
 
 @pytest.mark.skipif(
-    not has_npu_ft_capability(),
-    reason="Requires at least 4 NPUs for DP=4 fault-tolerance testing",
+    not has_npu_scale_down_capability(),
+    reason=("Requires at least 4 NPUs and npu_moe_distribute_dispatch_v2 (CANN V3+) for DP=4 scale-down testing"),
 )
-def test_worker_kill_survivor_unhealthy_and_dead_rejects_retry():
-    """SIGKILL one Worker; survivors go UNHEALTHY, victim goes DEAD.
+def test_scale_down_removes_dead_rank_and_recovers():
+    """scale_down removes the dead DP rank; survivors keep serving.
 
-    Killing only rank 3's worker leaves all EngineCores alive, so the same
-    fault is seen two ways:
-
-    - Survivors (ranks 0, 1, 2): detect the dead peer via Gloo DP allreduce
-      / HCSP timeout. Their own executor is fine, so ``on_fault`` marks them
-      UNHEALTHY with a ``fault_info``.
-    - Victim (rank 3): detects its own executor failure and marks itself DEAD.
-
-    Recovery is gated on UNHEALTHY: the DEAD engine accepts ``retry`` at the
-    HTTP layer (202 = background dispatch) but rejects it in the engine,
-    recording the reason as ``ft_error``.
+    SIGKILL rank 3's worker: survivors go UNHEALTHY, the victim goes DEAD
+    and rejects ``retry`` (recovery requires UNHEALTHY). ``scale_down``
+    with ``removed_dp_ranks=[3]`` masks the dead rank, redistributes its
+    EPLB experts onto the survivors and reloads the reassigned weights.
+    Rank 3 (not rank 0, the DP store master) is removed so no
+    ``dp_master_ip`` / ``dp_store_port`` params are needed. After recovery
+    every survivor must answer factual prompts correctly.
     """
-    with _ft_manager() as servers:
+    victim_rank = DP_SIZE - 1
+    extra_args = [
+        "--compilation-config",
+        json.dumps(
+            {
+                "cudagraph_mode": "FULL_AND_PIECEWISE",
+                "cudagraph_capture_sizes": [4, 8, 12, 16, 20, 24, 28, 32],
+            }
+        ),
+        "--enable-eplb",
+        "--eplb-config.num_redundant_experts",
+        str(NUM_REDUNDANT_EXPERTS),
+    ]
+    with _ft_manager(extra_args) as servers:
         assert len(servers) == DP_SIZE
-        survivor0 = _server_for_rank(servers, 0)
-        survivor1 = _server_for_rank(servers, 1)
-        survivor2 = _server_for_rank(servers, 2)
-        victim = _server_for_rank(servers, 3)
-        all_ranks = (survivor0, survivor1, survivor2, victim)
+        servers_by_rank = {r: _server_for_rank(servers, r) for r in range(DP_SIZE)}
+        victim = servers_by_rank[victim_rank]
+        survivor_ranks = [r for r in range(DP_SIZE) if r != victim_rank]
+        survivors = tuple(servers_by_rank[r] for r in survivor_ranks)
+        all_ranks = tuple(servers_by_rank[r] for r in range(DP_SIZE))
 
-        # 1. Confirm all engines are healthy and serving.
+        # 1. All engines healthy and serving.
         _assert_serving_and_healthy(all_ranks)
 
-        # 2. Kill only the victim's worker; all EngineCores stay alive.
+        # 2. Kill the victim's worker; survivors detect the peer fault.
         _kill_worker_process(victim)
-
-        # 3. Drive all engines so each keeps stepping into the failed component.
         with _driving(*all_ranks):
             faulted_results = _wait_for_engines(
                 list(all_ranks),
@@ -512,26 +554,45 @@ def test_worker_kill_survivor_unhealthy_and_dead_rejects_retry():
                 match_values={"dead", "unhealthy"},
             )
 
-        s0, s1, s2, victim_faulted = faulted_results
-
-        # Survivors must report the peer fault as UNHEALTHY.
-        for label, result in [("rank 0", s0), ("rank 1", s1), ("rank 2", s2)]:
-            assert result is not None, (
-                f"{label} did not report the peer fault within {FAULT_DETECTION_DEADLINE_S}s -- it likely hung"
+        for rank, engine_status in enumerate(faulted_results):
+            assert engine_status is not None, (
+                f"rank {rank} did not report the fault within {FAULT_DETECTION_DEADLINE_S}s -- it likely hung"
             )
-            assert result["status"] == "unhealthy", result
-            assert result.get("fault_info"), result
 
-        # Victim must report DEAD (its own worker is gone).
-        assert victim_faulted is not None, (
-            f"victim (rank 3) did not report its worker's death within {FAULT_DETECTION_DEADLINE_S}s"
-        )
-        assert victim_faulted["status"] == "dead", victim_faulted
+        # Survivors must report the peer fault as UNHEALTHY with fault info
+        # (UNHEALTHY is the precondition for accepting scale_down)...
+        for rank in survivor_ranks:
+            assert faulted_results[rank]["status"] == "unhealthy", faulted_results[rank]
+            assert faulted_results[rank].get("fault_info"), faulted_results[rank]
+        # ...while the victim is DEAD (its own worker is gone).
+        assert faulted_results[victim_rank]["status"] == "dead", faulted_results[victim_rank]
 
-        # 4. retry is accepted at the HTTP layer (202 = background dispatch)...
+        # 3. The DEAD victim rejects retry: recovery requires UNHEALTHY.
+        #    retry is accepted at the HTTP layer (202 = background dispatch)...
         request_id = _apply_ft(victim, "retry")["request_id"]
-
-        # 5. ...but the DEAD engine must reject it: recovery requires UNHEALTHY.
+        # 4. ...but the rejection is recorded in /v1/fault_tolerance/status.
         ft_error = _wait_for_ft_apply_outcome(victim, request_id, FAULT_DETECTION_DEADLINE_S)
-        assert ft_error is not None, "rejection was never recorded in /fault_tolerance/status"
+        assert ft_error is not None, "rejection was never recorded in /v1/fault_tolerance/status"
         assert "status is DEAD" in ft_error, ft_error
+
+        # 5. scale_down to every survivor: remove the dead rank.
+        for server in survivors:
+            _apply_ft(server, "scale_down", {"removed_dp_ranks": [victim_rank]})
+
+        # 6. Recovery completes: survivors return to healthy and serve again.
+        recovered = _wait_for_engines(
+            list(survivors),
+            match_key="status",
+            match_values={"healthy"},
+            deadline_s=SCALE_DOWN_DEADLINE_S,
+        )
+        for rank, engine_status in zip(survivor_ranks, recovered):
+            assert engine_status is not None, (
+                f"survivor {rank} did not recover within {SCALE_DOWN_DEADLINE_S}s -- "
+                "expert redistribution or weight reload likely failed"
+            )
+        _in_parallel(lambda s: _complete(s.get_client()), survivors)
+
+        # 7. Factual answers on the survivors: the re-hosted experts must
+        #    produce correct completions on the shrunken DP group.
+        _assert_correct_answers(survivors)

--- a/tests/ut/worker/test_worker_v1.py
+++ b/tests/ut/worker/test_worker_v1.py
@@ -691,7 +691,6 @@ class TestNPUWorker(TestBase):
             worker.parallel_config.assigned_physical_gpu_ids = None
             worker.parallel_config.distributed_executor_backend = "ray"
             worker.parallel_config.enable_fault_tolerance = False
-            worker.use_v2_model_runner = False
             worker.vllm_config = MagicMock()
             worker.vllm_config.kv_transfer_config = None
             worker.cache_config = MagicMock()

--- a/tests/ut/worker/test_worker_v1.py
+++ b/tests/ut/worker/test_worker_v1.py
@@ -690,6 +690,8 @@ class TestNPUWorker(TestBase):
             worker.parallel_config.data_parallel_size = 1
             worker.parallel_config.assigned_physical_gpu_ids = None
             worker.parallel_config.distributed_executor_backend = "ray"
+            worker.parallel_config.enable_fault_tolerance = False
+            worker.use_v2_model_runner = False
             worker.vllm_config = MagicMock()
             worker.vllm_config.kv_transfer_config = None
             worker.cache_config = MagicMock()

--- a/vllm_ascend/ascend_config.py
+++ b/vllm_ascend/ascend_config.py
@@ -452,11 +452,11 @@ class AscendConfig:
     msmonitor_use_daemon: bool = False
     enable_transpose_kv_cache_by_block: bool = True
     weight_nz_mode: int = 1
-    # NPU operator timeout (ms) used by fault tolerance retry; 0 = disable.
-    operator_timeout_ms: int = 0
-    # Fault-tolerance comm op abort timeout (ms); 0 = disable. Injected via
-    # additional_config["ft_communication_ops_abort_timeout_ms"].
-    ft_communication_ops_abort_timeout_ms: int = 0
+    # Fault-tolerance comm op abort timeout (seconds); 0 = disable. When fault
+    # tolerance is enabled and > 0, a hung NPU comm op is aborted after this
+    # many seconds. Drives HCCL_EVENT_TIMEOUT / HCCL_EXEC_TIMEOUT (= timeout - 1)
+    # and set_op_timeout_ms(timeout * 1000). Validated to be 0 or >= 2.
+    ft_communication_abort_timeout: int = 0
 
     # ---- sub-configs (no vllm_config dep): pydantic dict→dataclass coercion ----
     ascend_compilation_config: AscendCompilationConfig = dataclasses.field(default_factory=AscendCompilationConfig)
@@ -665,10 +665,9 @@ class AscendConfig:
             logger.warning_once(
                 "MegaMoe is not supported for this model config; additional_config.enable_fused_mc2 will be set to 0."
             )
-        # operator_timeout_ms is a declared AscendConfig field; it is populated
-        # from additional_config via the factory kwargs (see init_ascend_config).
-        # ft_communication_ops_abort_timeout_ms is likewise a declared field
-        # (retry-based fault tolerance comm op abort timeout).
+        # ft_communication_abort_timeout is a declared AscendConfig field; it is
+        # populated from additional_config via the factory kwargs
+        # (see init_ascend_config) and validated by _validate_user_input_ranges.
 
         # mlapo_keep_prefill_weights preconditions: the prefill weights are only
         # freed by MLAPO in the MLA attention path, so the keep switch is only

--- a/vllm_ascend/ascend_config.py
+++ b/vllm_ascend/ascend_config.py
@@ -452,10 +452,9 @@ class AscendConfig:
     msmonitor_use_daemon: bool = False
     enable_transpose_kv_cache_by_block: bool = True
     weight_nz_mode: int = 1
-    # Fault-tolerance comm op abort timeout (seconds); 0 = disable. When fault
-    # tolerance is enabled and > 0, a hung NPU comm op is aborted after this
-    # many seconds. Drives HCCL_EVENT_TIMEOUT / HCCL_EXEC_TIMEOUT (= timeout - 1)
-    # and set_op_timeout_ms(timeout * 1000). Validated to be 0 or >= 2.
+    # ---- fault-tolerance: comm op abort timeout (s); 0 = disable ----
+    # Drives HCCL_EVENT_TIMEOUT / HCCL_EXEC_TIMEOUT (= timeout - 1) and
+    # set_op_timeout_ms(timeout * 1000). Validated to be 0 or >= 2.
     ft_communication_abort_timeout: int = 0
 
     # ---- sub-configs (no vllm_config dep): pydantic dict→dataclass coercion ----
@@ -665,9 +664,6 @@ class AscendConfig:
             logger.warning_once(
                 "MegaMoe is not supported for this model config; additional_config.enable_fused_mc2 will be set to 0."
             )
-        # ft_communication_abort_timeout is a declared AscendConfig field; it is
-        # populated from additional_config via the factory kwargs
-        # (see init_ascend_config) and validated by _validate_user_input_ranges.
 
         # mlapo_keep_prefill_weights preconditions: the prefill weights are only
         # freed by MLAPO in the MLA attention path, so the keep switch is only
@@ -778,6 +774,17 @@ class AscendConfig:
 
         # sparse KV offload vs sparse SFA C8 main cache mutex
         self._validate_sparse_c8_kv_offload_compatibility()
+
+        # ft_communication_abort_timeout only takes effect when fault tolerance
+        # is enabled, so validate it only then: a stray value in additional_config
+        # must not fail startup for non-FT runs.
+        if vc.parallel_config.enable_fault_tolerance and (
+            self.ft_communication_abort_timeout != 0 and self.ft_communication_abort_timeout < 2
+        ):
+            raise ValueError(
+                f"ft_communication_abort_timeout must be 0 (disabled) or an integer of at least "
+                f"2 seconds, got {self.ft_communication_abort_timeout}"
+            )
         return self
 
     def _validate_mc2_comm_alg(self, vllm_config: VllmConfig) -> None:

--- a/vllm_ascend/ascend_config.py
+++ b/vllm_ascend/ascend_config.py
@@ -452,6 +452,8 @@ class AscendConfig:
     msmonitor_use_daemon: bool = False
     enable_transpose_kv_cache_by_block: bool = True
     weight_nz_mode: int = 1
+    # NPU operator timeout (ms) used by fault tolerance retry; 0 = disable.
+    operator_timeout_ms: int = 0
 
     # ---- sub-configs (no vllm_config dep): pydantic dict→dataclass coercion ----
     ascend_compilation_config: AscendCompilationConfig = dataclasses.field(default_factory=AscendCompilationConfig)
@@ -660,6 +662,8 @@ class AscendConfig:
             logger.warning_once(
                 "MegaMoe is not supported for this model config; additional_config.enable_fused_mc2 will be set to 0."
             )
+        # operator_timeout_ms is a declared AscendConfig field; it is populated
+        # from additional_config via the factory kwargs (see init_ascend_config).
 
         # mlapo_keep_prefill_weights preconditions: the prefill weights are only
         # freed by MLAPO in the MLA attention path, so the keep switch is only

--- a/vllm_ascend/ascend_config.py
+++ b/vllm_ascend/ascend_config.py
@@ -454,6 +454,9 @@ class AscendConfig:
     weight_nz_mode: int = 1
     # NPU operator timeout (ms) used by fault tolerance retry; 0 = disable.
     operator_timeout_ms: int = 0
+    # Fault-tolerance comm op abort timeout (ms); 0 = disable. Injected via
+    # additional_config["ft_communication_ops_abort_timeout_ms"].
+    ft_communication_ops_abort_timeout_ms: int = 0
 
     # ---- sub-configs (no vllm_config dep): pydantic dict→dataclass coercion ----
     ascend_compilation_config: AscendCompilationConfig = dataclasses.field(default_factory=AscendCompilationConfig)
@@ -664,6 +667,8 @@ class AscendConfig:
             )
         # operator_timeout_ms is a declared AscendConfig field; it is populated
         # from additional_config via the factory kwargs (see init_ascend_config).
+        # ft_communication_ops_abort_timeout_ms is likewise a declared field
+        # (retry-based fault tolerance comm op abort timeout).
 
         # mlapo_keep_prefill_weights preconditions: the prefill weights are only
         # freed by MLAPO in the MLA attention path, so the keep switch is only

--- a/vllm_ascend/distributed/device_communicators/npu_communicator.py
+++ b/vllm_ascend/distributed/device_communicators/npu_communicator.py
@@ -36,6 +36,9 @@ class _NpuAll2AllManager:
     def query_active_mask(self) -> torch.Tensor:
         return torch.zeros(1, dtype=torch.bool, device="cpu")
 
+    def clean_buffers(self) -> None:
+        """No-op: NPU registers no RDMA buffers or all2all mask state."""
+
 
 class NPUCommunicator(DeviceCommunicatorBase):
     def __init__(

--- a/vllm_ascend/distributed/device_communicators/npu_communicator.py
+++ b/vllm_ascend/distributed/device_communicators/npu_communicator.py
@@ -20,16 +20,10 @@ import torch.distributed as dist
 from vllm.distributed.device_communicators.base_device_communicator import DeviceCommunicatorBase
 
 # elastic_info tensor layout consumed by the MC2 dispatch/combine operators:
-# [is_scaling_down, scaled-down ep world size, shared_expert_rank_num,
-#  num_physical_experts] + table1(ep_world_size) + table2(ep_world_size),
-# where table1 maps an original EP rank to its densified rank (-1 for dead
-# ranks) and table2 maps a densified slot back to the original EP rank.
+# [is_scaling_down, dense ep world size, shared_expert_rank_num,
+#  num_physical_experts] + table1(orig->dense, -1 for dead) + table2(dense->orig).
 _ELASTIC_INFO_HEADER_SIZE = 4
 _ELASTIC_INFO_RANK_TABLE_NUM = 2
-_FLAG_IDX = 0
-_EP_SIZE_IDX = 1
-_SHARED_EXPERT_RANK_NUM_IDX = 2
-_NUM_PHYSICAL_EXPERTS_IDX = 3
 
 
 class _NpuAll2AllManager:
@@ -121,31 +115,24 @@ class _NpuAll2AllManager:
         return table
 
     def _rebuild_elastic_info(self) -> None:
-        """Rebuild elastic_info from the dead set and copy it into the
-        existing device tensor (never reallocates, so captured graphs keep
-        pointing at valid storage)."""
+        """Rebuild elastic_info from the dead set into the existing device
+        tensor (never reallocates, so captured graphs stay valid)."""
         if not self._dead or self._num_physical_experts <= 0:
-            # Keep the flag at 0 so the kernel degrades to a normal dispatch.
-            # A dead set without the shrunk expert count is transient: the
-            # base retry replays the mask before expert redistribution has
-            # produced the new width, and no forward runs in between.
+            # flag=0 -> normal dispatch; transient until redistribution sets
+            # the new expert width (no forward runs in between).
             self._elastic_info_host.zero_()
         else:
             world_size = self._ep_world_size
-            table1 = self.to_densified_rank_table()
+            alive = sorted(set(range(world_size)) - self._dead)
+            table1 = torch.full((world_size,), -1, dtype=torch.int32)
+            table1[alive] = torch.arange(len(alive), dtype=torch.int32)
             table2 = torch.full((world_size,), -1, dtype=torch.int32)
-            for orig_rank in range(world_size):
-                dense_rank = int(table1[orig_rank])
-                if dense_rank >= 0:
-                    table2[dense_rank] = orig_rank
-            staging = self._elastic_info_host
-            staging[_FLAG_IDX] = 1
-            staging[_EP_SIZE_IDX] = world_size - len(self._dead)
-            # Only shared_expert_rank_num=0 deployments are supported.
-            staging[_SHARED_EXPERT_RANK_NUM_IDX] = 0
-            staging[_NUM_PHYSICAL_EXPERTS_IDX] = self._num_physical_experts
-            staging[_ELASTIC_INFO_HEADER_SIZE : _ELASTIC_INFO_HEADER_SIZE + world_size] = table1
-            staging[_ELASTIC_INFO_HEADER_SIZE + world_size :] = table2
+            table2[: len(alive)] = torch.tensor(alive, dtype=torch.int32)
+            self._elastic_info_host.copy_(
+                torch.cat(
+                    [torch.tensor([1, len(alive), 0, self._num_physical_experts], dtype=torch.int32), table1, table2]
+                )
+            )
         self._elastic_info.copy_(self._elastic_info_host, non_blocking=True)
 
 

--- a/vllm_ascend/distributed/device_communicators/npu_communicator.py
+++ b/vllm_ascend/distributed/device_communicators/npu_communicator.py
@@ -44,11 +44,12 @@ class _NpuAll2AllManager:
         self._ep_world_size = ep_world_size
         self._device = device
         self._dead: set[int] = set()
-        self._num_physical_experts: int = 0
+        self._num_local_experts: int = 0
 
         # elastic_info layout: [is_scaling_down, dense ep world size,
         #  shared_expert_rank_num, num_physical_experts] + table1(orig->dense)
-        #  + table2(dense->orig).
+        #  + table2(dense->orig). num_physical_experts is derived from the
+        #  dead set and num_local_experts on every rebuild.
         size = 4 + 2 * ep_world_size
         self._elastic_info_host = torch.zeros(size, dtype=torch.int32)
         if device is None:
@@ -97,10 +98,15 @@ class _NpuAll2AllManager:
         """The device elastic_info tensor for the next MC2 dispatch/combine."""
         return self._elastic_info
 
-    def set_num_physical_experts(self, num_physical_experts: int) -> None:
-        """Shrink the expert-space width after scale-down and rebuild."""
-        self._num_physical_experts = num_physical_experts
-        self._rebuild_elastic_info()
+    def set_num_local_physical_experts(self, num_local_experts: int) -> None:
+        """Record the physical expert slots per EP rank.
+
+        No rebuild here: the shrunk physical-expert count is derived as
+        ``alive_ranks * num_local_experts`` inside ``_rebuild_elastic_info``,
+        which the ``update_mask`` calls of the upstream retry flow trigger, so
+        the next rebuild already reflects this value.
+        """
+        self._num_local_experts = num_local_experts
 
     def _rebuild_elastic_info(self) -> None:
         """Rebuild elastic_info from the dead set into the existing device
@@ -108,14 +114,13 @@ class _NpuAll2AllManager:
 
         world_size = self._ep_world_size
         alive = sorted(set(range(world_size)) - self._dead)
+        num_physical_experts = len(alive) * self._num_local_experts
         table1 = torch.full((world_size,), -1, dtype=torch.int32)
         table1[alive] = torch.arange(len(alive), dtype=torch.int32)
         table2 = torch.full((world_size,), -1, dtype=torch.int32)
         table2[: len(alive)] = torch.tensor(alive, dtype=torch.int32)
         self._elastic_info_host.copy_(
-            torch.cat(
-                [torch.tensor([1, len(alive), 0, self._num_physical_experts], dtype=torch.int32), table1, table2]
-            )
+            torch.cat([torch.tensor([1, len(alive), 0, num_physical_experts], dtype=torch.int32), table1, table2])
         )
         self._elastic_info.copy_(self._elastic_info_host, non_blocking=True)
 

--- a/vllm_ascend/distributed/device_communicators/npu_communicator.py
+++ b/vllm_ascend/distributed/device_communicators/npu_communicator.py
@@ -19,25 +19,134 @@ import torch
 import torch.distributed as dist
 from vllm.distributed.device_communicators.base_device_communicator import DeviceCommunicatorBase
 
+# elastic_info tensor layout consumed by the MC2 dispatch/combine operators:
+# [is_scaling_down, scaled-down ep world size, shared_expert_rank_num,
+#  num_physical_experts] + table1(ep_world_size) + table2(ep_world_size),
+# where table1 maps an original EP rank to its densified rank (-1 for dead
+# ranks) and table2 maps a densified slot back to the original EP rank.
+_ELASTIC_INFO_HEADER_SIZE = 4
+_ELASTIC_INFO_RANK_TABLE_NUM = 2
+_FLAG_IDX = 0
+_EP_SIZE_IDX = 1
+_SHARED_EXPERT_RANK_NUM_IDX = 2
+_NUM_PHYSICAL_EXPERTS_IDX = 3
+
 
 class _NpuAll2AllManager:
-    """No-op all2all_manager for NPU. Used by vLLM main's fault-tolerance
-    check (data_parallel_size > 1 and is_moe); NPU does not register a real
-    one because it uses mc2 / all_gather for MoE communication.
+    """All2All-manager adapter for MC2 fault tolerance.
+
+    Owns the dead-rank mask together with the `elastic_info` tensor the mask
+    is encoded into: the MC2 dispatch/combine operators take `elastic_info`
+    fresh on every call, so this tensor doubles as the mask (there is no
+    kernel-side mask buffer like DeepEP/nixl-ep). The public interface mirrors
+    the upstream All2AllManagerBase mask API so the upstream FT sentinel
+    drives it unchanged; future Ascend operators with FT support are expected
+    to follow the same shape.
     """
 
-    @property
-    def support_fault_tolerance(self) -> bool:
-        return False
+    # Unlike DeepEP/nixl-ep, the MC2 kernels neither detect faults nor set
+    # the mask themselves on timeout — a dead peer surfaces as an aborted op
+    # raising out of the forward, and the mask is only ever written host-side
+    # by FT recovery (scale_down, plus the retry mask replay). A per-step
+    # query_fault() could therefore never observe anything; reporting False
+    # keeps the upstream runners from paying for that query every step.
+    support_fault_tolerance = False
 
-    def query_fault(self) -> torch.Tensor:
-        return torch.zeros(1, dtype=torch.bool, device="cpu")
+    def __init__(self, ep_world_size: int, device: torch.device | None = None) -> None:
+        self._ep_world_size = ep_world_size
+        self._device = device
+        self._dead: set[int] = set()
+        self._num_physical_experts: int = 0
+
+        size = _ELASTIC_INFO_HEADER_SIZE + _ELASTIC_INFO_RANK_TABLE_NUM * ep_world_size
+        self._elastic_info_host = torch.zeros(size, dtype=torch.int32)
+        if device is None:
+            device = torch.device("npu", torch.npu.current_device())
+        self._elastic_info = torch.zeros(size, dtype=torch.int32, device=device)
+
+    def update_mask(self, rank: int, masked: bool = True) -> None:
+        """Mark an EP rank dead/alive and rebuild elastic_info in place."""
+        if masked:
+            self._dead.add(rank)
+        else:
+            self._dead.discard(rank)
+        self._rebuild_elastic_info()
 
     def query_active_mask(self) -> torch.Tensor:
-        return torch.zeros(1, dtype=torch.bool, device="cpu")
+        """Per-EP-rank mask (1=dead, 0=live) as a CPU tensor, matching the
+        upstream mask-buffer convention.
+
+        Built on CPU on purpose: this is called while a fault is being
+        probed, when the NPU may be hung — any device op would fail.
+        """
+        mask = torch.zeros(self._ep_world_size, dtype=torch.int32)
+        for rank in self._dead:
+            mask[rank] = 1
+        return mask
+
+    def query_fault(self) -> torch.Tensor:
+        # NPU counterpart of the upstream per-step fault check. Unlike
+        # DeepEP/nixl-ep there is no in-kernel timeout that flips the mask,
+        # so a fault can never be observed this way — always report no fault.
+        # (Faults surface as aborted HCCL ops raising out of execute_model;
+        # see support_fault_tolerance.)
+        return torch.tensor(False)
 
     def clean_buffers(self) -> None:
-        """No-op: NPU registers no RDMA buffers or all2all mask state."""
+        """No-op, kept for the upstream retry flow which calls it
+        unconditionally.
+
+        Unlike DeepEP/nixl-ep there is no kernel-side mask buffer or RDMA
+        state to clean: the elastic_info tensor is passed fresh to every MC2
+        call, so the mask itself is intentionally left untouched (it survives
+        across recovery rounds via the replayed cumulative dead set).
+        """
+
+    def get_elastic_info(self) -> torch.Tensor:
+        """The device elastic_info tensor for the next MC2 dispatch/combine."""
+        return self._elastic_info
+
+    def set_num_physical_experts(self, num_physical_experts: int) -> None:
+        """Shrink the expert-space width after scale-down and rebuild."""
+        self._num_physical_experts = num_physical_experts
+        self._rebuild_elastic_info()
+
+    def to_densified_rank_table(self) -> torch.Tensor:
+        """Convert the scale-down view (original EP ranks + dead set) into the
+        kernel's view: original EP rank -> densified rank (-1 = dead)."""
+        table = torch.full((self._ep_world_size,), -1, dtype=torch.int32)
+        alive = sorted(set(range(self._ep_world_size)) - self._dead)
+        for dense_rank, orig_rank in enumerate(alive):
+            table[orig_rank] = dense_rank
+        return table
+
+    def _rebuild_elastic_info(self) -> None:
+        """Rebuild elastic_info from the dead set and copy it into the
+        existing device tensor (never reallocates, so captured graphs keep
+        pointing at valid storage)."""
+        if not self._dead or self._num_physical_experts <= 0:
+            # Keep the flag at 0 so the kernel degrades to a normal dispatch.
+            # A dead set without the shrunk expert count is transient: the
+            # base retry replays the mask before expert redistribution has
+            # produced the new width, and no forward runs in between.
+            self._elastic_info_host.zero_()
+        else:
+            world_size = self._ep_world_size
+            table1 = self.to_densified_rank_table()
+            table2 = torch.full((world_size,), -1, dtype=torch.int32)
+            for orig_rank in range(world_size):
+                dense_rank = int(table1[orig_rank])
+                if dense_rank >= 0:
+                    table2[dense_rank] = orig_rank
+            staging = self._elastic_info_host
+            staging[_FLAG_IDX] = 1
+            staging[_EP_SIZE_IDX] = world_size - len(self._dead)
+            # Only shared_expert_rank_num=0 deployments are supported.
+            staging[_SHARED_EXPERT_RANK_NUM_IDX] = 0
+            staging[_NUM_PHYSICAL_EXPERTS_IDX] = self._num_physical_experts
+            staging[_ELASTIC_INFO_HEADER_SIZE : _ELASTIC_INFO_HEADER_SIZE + world_size] = table1
+            staging[_ELASTIC_INFO_HEADER_SIZE + world_size :] = table2
+        self._elastic_info.copy_(self._elastic_info_host, non_blocking=True)
 
 
 class NPUCommunicator(DeviceCommunicatorBase):
@@ -58,4 +167,6 @@ class NPUCommunicator(DeviceCommunicatorBase):
         )
         self.device = torch.npu.current_device()
         self.ca_comm = None
-        self.all2all_manager = _NpuAll2AllManager()
+        # Only the EP group's instance is ever looked up (via the upstream
+        # get_ep_all2all_manager()); the rest stay dormant.
+        self.all2all_manager = _NpuAll2AllManager(dist.get_world_size(cpu_group), device)

--- a/vllm_ascend/distributed/device_communicators/npu_communicator.py
+++ b/vllm_ascend/distributed/device_communicators/npu_communicator.py
@@ -19,12 +19,6 @@ import torch
 import torch.distributed as dist
 from vllm.distributed.device_communicators.base_device_communicator import DeviceCommunicatorBase
 
-# elastic_info tensor layout consumed by the MC2 dispatch/combine operators:
-# [is_scaling_down, dense ep world size, shared_expert_rank_num,
-#  num_physical_experts] + table1(orig->dense, -1 for dead) + table2(dense->orig).
-_ELASTIC_INFO_HEADER_SIZE = 4
-_ELASTIC_INFO_RANK_TABLE_NUM = 2
-
 
 class _NpuAll2AllManager:
     """All2All-manager adapter for MC2 fault tolerance.
@@ -52,7 +46,10 @@ class _NpuAll2AllManager:
         self._dead: set[int] = set()
         self._num_physical_experts: int = 0
 
-        size = _ELASTIC_INFO_HEADER_SIZE + _ELASTIC_INFO_RANK_TABLE_NUM * ep_world_size
+        # elastic_info layout: [is_scaling_down, dense ep world size,
+        #  shared_expert_rank_num, num_physical_experts] + table1(orig->dense)
+        #  + table2(dense->orig).
+        size = 4 + 2 * ep_world_size
         self._elastic_info_host = torch.zeros(size, dtype=torch.int32)
         if device is None:
             device = torch.device("npu", torch.npu.current_device())
@@ -105,34 +102,21 @@ class _NpuAll2AllManager:
         self._num_physical_experts = num_physical_experts
         self._rebuild_elastic_info()
 
-    def to_densified_rank_table(self) -> torch.Tensor:
-        """Convert the scale-down view (original EP ranks + dead set) into the
-        kernel's view: original EP rank -> densified rank (-1 = dead)."""
-        table = torch.full((self._ep_world_size,), -1, dtype=torch.int32)
-        alive = sorted(set(range(self._ep_world_size)) - self._dead)
-        for dense_rank, orig_rank in enumerate(alive):
-            table[orig_rank] = dense_rank
-        return table
-
     def _rebuild_elastic_info(self) -> None:
         """Rebuild elastic_info from the dead set into the existing device
         tensor (never reallocates, so captured graphs stay valid)."""
-        if not self._dead or self._num_physical_experts <= 0:
-            # flag=0 -> normal dispatch; transient until redistribution sets
-            # the new expert width (no forward runs in between).
-            self._elastic_info_host.zero_()
-        else:
-            world_size = self._ep_world_size
-            alive = sorted(set(range(world_size)) - self._dead)
-            table1 = torch.full((world_size,), -1, dtype=torch.int32)
-            table1[alive] = torch.arange(len(alive), dtype=torch.int32)
-            table2 = torch.full((world_size,), -1, dtype=torch.int32)
-            table2[: len(alive)] = torch.tensor(alive, dtype=torch.int32)
-            self._elastic_info_host.copy_(
-                torch.cat(
-                    [torch.tensor([1, len(alive), 0, self._num_physical_experts], dtype=torch.int32), table1, table2]
-                )
+
+        world_size = self._ep_world_size
+        alive = sorted(set(range(world_size)) - self._dead)
+        table1 = torch.full((world_size,), -1, dtype=torch.int32)
+        table1[alive] = torch.arange(len(alive), dtype=torch.int32)
+        table2 = torch.full((world_size,), -1, dtype=torch.int32)
+        table2[: len(alive)] = torch.tensor(alive, dtype=torch.int32)
+        self._elastic_info_host.copy_(
+            torch.cat(
+                [torch.tensor([1, len(alive), 0, self._num_physical_experts], dtype=torch.int32), table1, table2]
             )
+        )
         self._elastic_info.copy_(self._elastic_info_host, non_blocking=True)
 
 

--- a/vllm_ascend/distributed/device_communicators/npu_communicator.py
+++ b/vllm_ascend/distributed/device_communicators/npu_communicator.py
@@ -23,21 +23,13 @@ from vllm.distributed.device_communicators.base_device_communicator import Devic
 class _NpuAll2AllManager:
     """All2All-manager adapter for MC2 fault tolerance.
 
-    Owns the dead-rank mask together with the `elastic_info` tensor the mask
-    is encoded into: the MC2 dispatch/combine operators take `elastic_info`
-    fresh on every call, so this tensor doubles as the mask (there is no
-    kernel-side mask buffer like DeepEP/nixl-ep). The public interface mirrors
-    the upstream All2AllManagerBase mask API so the upstream FT sentinel
-    drives it unchanged; future Ascend operators with FT support are expected
-    to follow the same shape.
+    Owns the dead-rank mask, encoded into the ``elastic_info`` tensor consumed
+    by the MC2 dispatch/combine operators. The public interface mirrors the
+    upstream All2AllManagerBase mask API.
     """
 
-    # Unlike DeepEP/nixl-ep, the MC2 kernels neither detect faults nor set
-    # the mask themselves on timeout — a dead peer surfaces as an aborted op
-    # raising out of the forward, and the mask is only ever written host-side
-    # by FT recovery (scale_down, plus the retry mask replay). A per-step
-    # query_fault() could therefore never observe anything; reporting False
-    # keeps the upstream runners from paying for that query every step.
+    # MC2 kernels do not detect faults themselves; the mask is written
+    # host-side by FT recovery, so a per-step query can never observe one.
     support_fault_tolerance = False
 
     def __init__(self, ep_world_size: int, device: torch.device | None = None) -> None:
@@ -77,35 +69,18 @@ class _NpuAll2AllManager:
         return mask
 
     def query_fault(self) -> torch.Tensor:
-        # NPU counterpart of the upstream per-step fault check. Unlike
-        # DeepEP/nixl-ep there is no in-kernel timeout that flips the mask,
-        # so a fault can never be observed this way — always report no fault.
-        # (Faults surface as aborted HCCL ops raising out of execute_model;
-        # see support_fault_tolerance.)
+        # MC2 has no in-kernel fault detection; faults surface as aborted ops.
         return torch.tensor(False)
 
     def clean_buffers(self) -> None:
-        """No-op, kept for the upstream retry flow which calls it
-        unconditionally.
-
-        Unlike DeepEP/nixl-ep there is no kernel-side mask buffer or RDMA
-        state to clean: the elastic_info tensor is passed fresh to every MC2
-        call, so the mask itself is intentionally left untouched (it survives
-        across recovery rounds via the replayed cumulative dead set).
-        """
+        """No-op, kept for the upstream retry flow which calls it unconditionally."""
 
     def get_elastic_info(self) -> torch.Tensor:
         """The device elastic_info tensor for the next MC2 dispatch/combine."""
         return self._elastic_info
 
     def set_num_local_physical_experts(self, num_local_experts: int) -> None:
-        """Record the physical expert slots per EP rank.
-
-        No rebuild here: the shrunk physical-expert count is derived as
-        ``alive_ranks * num_local_experts`` inside ``_rebuild_elastic_info``,
-        which the ``update_mask`` calls of the upstream retry flow trigger, so
-        the next rebuild already reflects this value.
-        """
+        """Record the physical expert slots per EP rank."""
         self._num_local_experts = num_local_experts
 
     def _rebuild_elastic_info(self) -> None:

--- a/vllm_ascend/envs.py
+++ b/vllm_ascend/envs.py
@@ -92,9 +92,7 @@ env_variables: dict[str, Callable[[], Any]] = {
     # tolerance can detect it and trigger recovery. 0 (default) disables the
     # timeout. Applied via torch_npu.npu.set_op_timeout_ms when fault tolerance
     # is enabled.
-    "FT_COMMUNICATION_OPS_ABORT_TIMEOUT_MS": lambda: int(
-        os.getenv("FT_COMMUNICATION_OPS_ABORT_TIMEOUT_MS", "0")
-    ),
+    "FT_COMMUNICATION_OPS_ABORT_TIMEOUT_MS": lambda: int(os.getenv("FT_COMMUNICATION_OPS_ABORT_TIMEOUT_MS", "0")),
 }
 
 # end-env-vars-definition

--- a/vllm_ascend/envs.py
+++ b/vllm_ascend/envs.py
@@ -87,12 +87,6 @@ env_variables: dict[str, Callable[[], Any]] = {
     # (safe for Ascend 910B/A3). Set to a positive value to override when
     # auto-detection is unavailable or for debugging UB overflow issues.
     "VLLM_ASCEND_ROPE_UB_SIZE_KB": lambda: int(os.getenv("VLLM_ASCEND_ROPE_UB_SIZE_KB") or 0),
-    # Fault-tolerance timeout (in milliseconds) after which a hung NPU operator
-    # (e.g. a communication op) is aborted with a timeout exception, so fault
-    # tolerance can detect it and trigger recovery. 0 (default) disables the
-    # timeout. Applied via torch_npu.npu.set_op_timeout_ms when fault tolerance
-    # is enabled.
-    "FT_COMMUNICATION_OPS_ABORT_TIMEOUT_MS": lambda: int(os.getenv("FT_COMMUNICATION_OPS_ABORT_TIMEOUT_MS", "0")),
 }
 
 # end-env-vars-definition

--- a/vllm_ascend/envs.py
+++ b/vllm_ascend/envs.py
@@ -87,6 +87,14 @@ env_variables: dict[str, Callable[[], Any]] = {
     # (safe for Ascend 910B/A3). Set to a positive value to override when
     # auto-detection is unavailable or for debugging UB overflow issues.
     "VLLM_ASCEND_ROPE_UB_SIZE_KB": lambda: int(os.getenv("VLLM_ASCEND_ROPE_UB_SIZE_KB") or 0),
+    # Fault-tolerance timeout (in milliseconds) after which a hung NPU operator
+    # (e.g. a communication op) is aborted with a timeout exception, so fault
+    # tolerance can detect it and trigger recovery. 0 (default) disables the
+    # timeout. Applied via torch_npu.npu.set_op_timeout_ms when fault tolerance
+    # is enabled.
+    "FT_COMMUNICATION_OPS_ABORT_TIMEOUT_MS": lambda: int(
+        os.getenv("FT_COMMUNICATION_OPS_ABORT_TIMEOUT_MS", "0")
+    ),
 }
 
 # end-env-vars-definition

--- a/vllm_ascend/ops/fused_moe/token_dispatcher.py
+++ b/vllm_ascend/ops/fused_moe/token_dispatcher.py
@@ -27,6 +27,7 @@ import torch
 import torch_npu
 from vllm.config import get_current_vllm_config
 from vllm.distributed.parallel_state import get_ep_group
+from vllm.model_executor.layers.fused_moe.all2all_utils import get_ep_all2all_manager
 
 from vllm_ascend.ascend_config import get_ascend_config
 from vllm_ascend.ascend_forward_context import get_mc2_tokens_capacity
@@ -143,6 +144,11 @@ class TokenDispatcherWithMC2(MoETokenDispatcher[MoEMC2CombineMetadata]):
         # use the real global_bs and do NOT pass mc2_mask.
         self.global_bs = _max_global_bs if should_skip_allreduce_across_dp_group(vllm_config) else 0
 
+        # Fault tolerance: the dead-rank mask is passed to the MC2 operators
+        # as an explicit elastic_info tensor on every call; dead ranks are
+        # excluded purely via elastic_info.
+        self._ft_enabled = vllm_config.parallel_config.enable_fault_tolerance
+
     def refresh_hccl_group(self) -> None:
         """Refresh MC2 communicator metadata after HCCL groups are recreated."""
         device_group = get_mc2_group().device_group
@@ -182,6 +188,8 @@ class TokenDispatcherWithMC2(MoETokenDispatcher[MoEMC2CombineMetadata]):
             "global_bs": self.global_bs,
             "expert_token_nums_type": expert_token_nums_type,
         }
+        if self._ft_enabled:
+            kwargs_mc2["elastic_info"] = get_ep_all2all_manager().get_elastic_info()
         if self.global_bs == 0:
             kwargs_mc2["x_active_mask"] = token_dispatch_input.routing.mc2_mask
 
@@ -294,6 +302,10 @@ class TokenDispatcherWithMC2(MoETokenDispatcher[MoEMC2CombineMetadata]):
             "moe_expert_num": self.moe_expert_num,
             "global_bs": self.global_bs,
         }
+        if self._ft_enabled:
+            # The combine's alltoallv spans the same EP group and must
+            # exclude dead ranks with the identical elastic_info tensor.
+            kwargs_mc2["elastic_info"] = get_ep_all2all_manager().get_elastic_info()
         if self.global_bs == 0:
             kwargs_mc2["x_active_mask"] = combine_metadata.mc2_mask
 

--- a/vllm_ascend/patch/worker/patch_distributed.py
+++ b/vllm_ascend/patch/worker/patch_distributed.py
@@ -22,7 +22,9 @@ from typing import Any, cast
 import torch
 import vllm
 from torch.distributed import Backend
+from torch.distributed.distributed_c10d import _set_pg_timeout
 from vllm.distributed.parallel_state import GroupCoordinator, _get_unique_name, _register_group
+from vllm.distributed.utils import get_cpu_distributed_timeout_or_none
 
 from vllm_ascend.distributed.device_communicators.npu_communicator import NPUCommunicator
 from vllm_ascend.patch.worker._hccl_pg_registry import HcclPgKey, HcclPgRegistry, make_hccl_pg_key
@@ -154,9 +156,6 @@ class GroupCoordinatorPatch(GroupCoordinator):
             raise
 
     def _init_device_groups(self, create_cpu_group: bool) -> None:
-        from torch.distributed.distributed_c10d import _set_pg_timeout
-        from vllm.distributed.utils import get_cpu_distributed_timeout_or_none
-
         timeout = get_cpu_distributed_timeout_or_none()
         reuse_domain = _resolve_reuse_domain(self.group_name)
         self_device_group = None

--- a/vllm_ascend/patch/worker/patch_distributed.py
+++ b/vllm_ascend/patch/worker/patch_distributed.py
@@ -22,7 +22,6 @@ from typing import Any, cast
 import torch
 import vllm
 from torch.distributed import Backend
-from torch.distributed.distributed_c10d import _set_pg_timeout
 from vllm.distributed.parallel_state import GroupCoordinator, _get_unique_name, _register_group
 from vllm.distributed.utils import get_cpu_distributed_timeout_or_none
 
@@ -180,7 +179,7 @@ class GroupCoordinatorPatch(GroupCoordinator):
                     self.rank_in_group = ranks.index(self.rank)
                     self.cpu_group = cpu_group
                     if timeout is not None:
-                        _set_pg_timeout(timeout=timeout, group=cpu_group)
+                        cpu_group.set_timeout(timeout)
                 self_device_group = device_group
 
         if self_device_group is not None:

--- a/vllm_ascend/patch/worker/patch_distributed.py
+++ b/vllm_ascend/patch/worker/patch_distributed.py
@@ -155,7 +155,6 @@ class GroupCoordinatorPatch(GroupCoordinator):
 
     def _init_device_groups(self, create_cpu_group: bool) -> None:
         from torch.distributed.distributed_c10d import _set_pg_timeout
-
         from vllm.distributed.utils import get_cpu_distributed_timeout_or_none
 
         timeout = get_cpu_distributed_timeout_or_none()

--- a/vllm_ascend/patch/worker/patch_distributed.py
+++ b/vllm_ascend/patch/worker/patch_distributed.py
@@ -154,6 +154,11 @@ class GroupCoordinatorPatch(GroupCoordinator):
             raise
 
     def _init_device_groups(self, create_cpu_group: bool) -> None:
+        from torch.distributed.distributed_c10d import _set_pg_timeout
+
+        from vllm.distributed.utils import get_cpu_distributed_timeout_or_none
+
+        timeout = get_cpu_distributed_timeout_or_none()
         reuse_domain = _resolve_reuse_domain(self.group_name)
         self_device_group = None
         for ranks in self.group_ranks:
@@ -176,6 +181,8 @@ class GroupCoordinatorPatch(GroupCoordinator):
                     self.world_size = len(ranks)
                     self.rank_in_group = ranks.index(self.rank)
                     self.cpu_group = cpu_group
+                    if timeout is not None:
+                        _set_pg_timeout(timeout=timeout, group=cpu_group)
                 self_device_group = device_group
 
         if self_device_group is not None:

--- a/vllm_ascend/patch/worker/patch_distributed.py
+++ b/vllm_ascend/patch/worker/patch_distributed.py
@@ -23,7 +23,6 @@ import torch
 import vllm
 from torch.distributed import Backend
 from vllm.distributed.parallel_state import GroupCoordinator, _get_unique_name, _register_group
-from vllm.distributed.utils import get_cpu_distributed_timeout_or_none
 
 from vllm_ascend.distributed.device_communicators.npu_communicator import NPUCommunicator
 from vllm_ascend.patch.worker._hccl_pg_registry import HcclPgKey, HcclPgRegistry, make_hccl_pg_key
@@ -155,7 +154,6 @@ class GroupCoordinatorPatch(GroupCoordinator):
             raise
 
     def _init_device_groups(self, create_cpu_group: bool) -> None:
-        timeout = get_cpu_distributed_timeout_or_none()
         reuse_domain = _resolve_reuse_domain(self.group_name)
         self_device_group = None
         for ranks in self.group_ranks:
@@ -178,8 +176,6 @@ class GroupCoordinatorPatch(GroupCoordinator):
                     self.world_size = len(ranks)
                     self.rank_in_group = ranks.index(self.rank)
                     self.cpu_group = cpu_group
-                    if timeout is not None:
-                        cpu_group.set_timeout(timeout)
                 self_device_group = device_group
 
         if self_device_group is not None:

--- a/vllm_ascend/patch/worker/patch_distributed.py
+++ b/vllm_ascend/patch/worker/patch_distributed.py
@@ -130,6 +130,9 @@ class GroupCoordinatorPatch(GroupCoordinator):
         self.use_cpu_custom_send_recv = False
         self.group_name = group_name
         self.group_ranks = group_ranks
+        # Mirrors upstream GroupCoordinator.__init__ (FT scale-down):
+        # read by the DP allreduce to neutralize dead columns.
+        self.dead_dp_ranks: set[int] = set()
 
         try:
             self._init_device_groups(create_cpu_group=True)

--- a/vllm_ascend/patch/worker/patch_distributed.py
+++ b/vllm_ascend/patch/worker/patch_distributed.py
@@ -130,8 +130,6 @@ class GroupCoordinatorPatch(GroupCoordinator):
         self.use_cpu_custom_send_recv = False
         self.group_name = group_name
         self.group_ranks = group_ranks
-        # Mirrors upstream GroupCoordinator.__init__ (FT scale-down):
-        # read by the DP allreduce to neutralize dead columns.
         self.dead_dp_ranks: set[int] = set()
 
         try:

--- a/vllm_ascend/worker/model_runner_v1.py
+++ b/vllm_ascend/worker/model_runner_v1.py
@@ -2146,10 +2146,10 @@ class NPUModelRunner(GPUModelRunner):
         self.prepare_inputs_event.synchronize()
         try:
             yield
-        except:
+        except Exception as e:
             raise RuntimeError(
                 "prepare_inputs_event record skipped due to fault."
-            )
+            ) from e
         else:
             self.prepare_inputs_event.record()
 

--- a/vllm_ascend/worker/model_runner_v1.py
+++ b/vllm_ascend/worker/model_runner_v1.py
@@ -2134,6 +2134,25 @@ class NPUModelRunner(GPUModelRunner):
         )
         return cut_tokens
 
+    @contextmanager
+    def synchronize_input_prep(self):
+        """Override to skip prepare_input_event synchronize/record after
+        a fault has been detected."""
+
+        if self.prepare_inputs_event is None:
+            yield
+            return
+
+        self.prepare_inputs_event.synchronize()
+        try:
+            yield
+        except:
+            raise RuntimeError(
+                "prepare_inputs_event record skipped due to fault."
+            )
+        else:
+            self.prepare_inputs_event.record()
+
     @torch.inference_mode()
     def execute_model(
         self,

--- a/vllm_ascend/worker/sentinel/eplb_redistribute.py
+++ b/vllm_ascend/worker/sentinel/eplb_redistribute.py
@@ -54,7 +54,7 @@ from vllm.v1.worker.sentinel.eplb_redistribute import (
 )
 
 from vllm_ascend.ops.fused_moe.routed_experts import AscendUnquantizedFusedMoEMethod
-from vllm_ascend.quantization.methods.w8a8_dynamic import (
+from vllm_ascend.quantization.methods.w8a8.w8a8_dynamic import (
     AscendW8A8DynamicFusedMoEMethod,
     scale_from_float_to_int64,
 )

--- a/vllm_ascend/worker/sentinel/eplb_redistribute.py
+++ b/vllm_ascend/worker/sentinel/eplb_redistribute.py
@@ -6,11 +6,13 @@ Device-agnostic placement math is imported from the upstream
 ``vllm.v1.worker.sentinel.eplb_redistribute``; this module only carries the
 Ascend-specific pieces:
 
-- ``build_local_reload_plan``: which local slots received a new logical expert.
 - ``reload_experts_from_disk``: reload reassigned experts from checkpoint and
   write them back in place, mirroring the runtime layout produced by
   ``process_weights_after_loading`` (transpose / NZ cast / per-slot lists /
-  quant scales), so captured graphs keep working.
+  quant scales), so captured graphs keep working. It mirrors the upstream
+  signature (a set of ``(layer, logical)`` reassignments) so the shared
+  sentinel flow can drive it directly; the destination local slot on this rank
+  is recovered from the rebuilt ``logical_to_physical_map``.
 
 The EPLB structures (physical_to_logical / logical_to_physical /
 logical_replica_count) keep the upstream slot model end to end: full width,
@@ -37,6 +39,7 @@ from collections.abc import Callable, Generator
 import torch
 import torch_npu
 from vllm.config import VllmConfig
+from vllm.distributed import get_ep_group
 from vllm.logger import logger
 from vllm.model_executor.model_loader.default_loader import DefaultModelLoader
 
@@ -58,7 +61,6 @@ from vllm_ascend.quantization.methods.w8a8_dynamic import (
 from vllm_ascend.utils import ACL_FORMAT_FRACTAL_NZ, maybe_trans_nz
 
 __all__ = [
-    "build_local_reload_plan",
     "build_orig_to_dense_rank_table",
     "check_redundancy_sufficient",
     "compute_dead_ep_ranks",
@@ -134,46 +136,6 @@ def densify_routing_table_physical_ids(
         )
     dense_ids = dense_rank * num_local_experts + ids % num_local_experts
     routing_table.copy_(dense_ids.to(routing_table.dtype))
-
-
-def build_local_reload_plan(
-    p2l_before: torch.Tensor,
-    p2l_after: torch.Tensor,
-    ep_rank: int,
-    num_local_experts: int,
-) -> dict[int, list[tuple[int, int]]]:
-    """Find this rank's slots whose logical expert changed after redistribution.
-
-    A surviving rank keeps its physical slot block, but some slots may now host
-    a different logical expert. This diffs this rank's block of
-    ``physical_to_logical_map`` before/after and reports the changed slots.
-
-    Args:
-        p2l_before/p2l_after: full ``physical_to_logical_map`` snapshots
-            (``[num_layers, ep_world_size * num_local_experts]``, CPU).
-        ep_rank: this rank's original EP rank; selects the slot block.
-        num_local_experts: physical slots per EP rank.
-
-    Returns:
-        ``{moe_layer_idx: [(local_slot, new_logical_expert_id), ...]}`` of the
-        changed slots, for ``reload_experts_from_disk``.
-    """
-    start = ep_rank * num_local_experts
-    block_before = p2l_before[:, start : start + num_local_experts]
-    block_after = p2l_after[:, start : start + num_local_experts]
-    plan: dict[int, list[tuple[int, int]]] = {}
-    num_layers = p2l_before.shape[0]
-    for layer_idx in range(num_layers):
-        for slot in range(num_local_experts):
-            before = int(block_before[layer_idx, slot])
-            after = int(block_after[layer_idx, slot])
-            if before != after:
-                assert after >= 0, (
-                    f"Layer {layer_idx} slot {slot} on ep_rank {ep_rank} lost "
-                    "its expert without a replacement; redistribution is broken."
-                )
-                plan.setdefault(layer_idx, []).append((slot, after))
-    return plan
 
 
 def _tp_shard_info(layer) -> tuple[int, int]:
@@ -294,30 +256,54 @@ _RELOADERS: dict[type, Callable[[torch.nn.Module, int, dict[str, torch.Tensor]],
 def reload_experts_from_disk(
     model: torch.nn.Module,
     vllm_config: VllmConfig,
-    reload_plan: dict[int, list[tuple[int, int]]],
+    reassignments: set[tuple[int, int]],
 ) -> int:
-    """Reload reassigned (layer, slot, logical) expert weights from disk.
+    """Reload reassigned (layer, logical) expert weights from disk.
 
-    Ascend keeps expert weights in runtime layout (transposed, NZ-cast, split
-    into per-slot lists, with derived quant scales), so the standard
-    ``model.load_weights`` path cannot write them back; checkpoint tensors are
-    read via DefaultModelLoader and converted per quant method, then copied
-    into the existing slot storage in place.
+    Mirrors the upstream ``reload_experts_from_disk`` signature (a set of
+    ``(moe_layer_idx, logical_expert_id)`` reassignments produced by
+    ``redistribute_expert_placement``), so the shared sentinel flow can drive
+    it unchanged. Ascend keeps expert weights in runtime layout (transposed,
+    NZ-cast, split into per-slot lists, with derived quant scales), so the
+    standard ``model.load_weights`` path cannot write them back; checkpoint
+    tensors are read via DefaultModelLoader and converted per quant method,
+    then copied into the existing slot storage in place.
+
+    The destination local slot of each reassigned logical expert is recovered
+    from the freshly rebuilt per-layer ``logical_to_physical_map`` (rebuilt by
+    the upstream flow before this is called). Only reassigned experts whose
+    replica falls in this rank's physical block are reloaded.
 
     Returns:
         Number of (layer, slot) pairs reloaded.
     """
-    if not reload_plan:
+    if not reassignments:
         return 0
 
     moe_layers = list(model.moe_layers)
     routed_layers = [getattr(layer, "routed_experts", layer) for layer in moe_layers]
+    ep_rank = get_ep_group().rank_in_group
 
-    prefixes: dict[str, tuple[int, int]] = {}
-    for layer_idx, assignments in reload_plan.items():
-        layer_name = routed_layers[layer_idx].layer_name
-        for _, logical_id in assignments:
-            prefixes[f"{layer_name}.{logical_id}."] = (layer_idx, logical_id)
+    local_slots: dict[tuple[int, int], int] = {}
+    for layer_idx, logical_id in reassignments:
+        layer_state = getattr(moe_layers[layer_idx], "eplb_state", None)
+        l2p = getattr(layer_state, "logical_to_physical_map", None)
+        if l2p is None:
+            continue
+        num_local = routed_layers[layer_idx].moe_config.num_local_experts
+        start = ep_rank * num_local
+        for physical_id in l2p[logical_id].tolist():
+            if start <= physical_id < start + num_local:
+                local_slots[(layer_idx, logical_id)] = physical_id - start
+                break
+
+    if not local_slots:
+        return 0
+
+    prefixes: dict[str, tuple[int, int]] = {
+        f"{routed_layers[layer_idx].layer_name}.{logical_id}.": (layer_idx, logical_id)
+        for layer_idx, logical_id in local_slots
+    }
 
     loader = DefaultModelLoader(vllm_config.load_config)
     # Produce every expert, not just the ones local at startup.
@@ -341,7 +327,7 @@ def reload_experts_from_disk(
                         yield key, suffix, tensor
                     break
 
-    logger.info("[FT] Reloading experts for %d layer(s) from disk.", len(reload_plan))
+    logger.info("[FT] Reloading %d reassigned (layer, expert) pair(s) on this rank from disk.", len(local_slots))
     for key, suffix, tensor in filtered_iter():
         buckets.setdefault(key, {})[suffix] = tensor
 
@@ -355,7 +341,7 @@ def reload_experts_from_disk(
         )
 
     reloaded = 0
-    for layer_idx, assignments in sorted(reload_plan.items()):
+    for (layer_idx, logical_id), slot in sorted(local_slots.items()):
         routed = routed_layers[layer_idx]
         # Quantized layers carry the AscendFusedMoEMethod wrapper; the actual
         # scheme (the _RELOADERS key) lives in its .quant_method attribute.
@@ -367,10 +353,9 @@ def reload_experts_from_disk(
             raise NotImplementedError(
                 f"[FT] scale_down weight reload is not implemented for quant method {type(quant_method).__name__}."
             )
-        for slot, logical_id in assignments:
-            tensors = buckets[(layer_idx, logical_id)]
-            reloader(routed, slot, tensors)
-            reloaded += 1
+        tensors = buckets[(layer_idx, logical_id)]
+        reloader(routed, slot, tensors)
+        reloaded += 1
 
     logger.info("[FT] Expert weight reload complete: %d (layer, slot) pair(s).", reloaded)
     return reloaded

--- a/vllm_ascend/worker/sentinel/eplb_redistribute.py
+++ b/vllm_ascend/worker/sentinel/eplb_redistribute.py
@@ -59,6 +59,7 @@ from vllm_ascend.utils import ACL_FORMAT_FRACTAL_NZ, maybe_trans_nz
 
 __all__ = [
     "build_local_reload_plan",
+    "build_orig_to_dense_rank_table",
     "check_redundancy_sufficient",
     "compute_dead_ep_ranks",
     "densify_routing_table_physical_ids",
@@ -75,6 +76,21 @@ _W13_WEIGHT_SUFFIXES = ("gate_up_proj.weight", "gate_proj.weight", "up_proj.weig
 _W2_WEIGHT_SUFFIX = "down_proj.weight"
 _W13_SCALE_SUFFIXES = ("gate_up_proj.weight_scale", "gate_proj.weight_scale", "up_proj.weight_scale")
 _W2_SCALE_SUFFIX = "down_proj.weight_scale"
+
+
+def build_orig_to_dense_rank_table(ep_world_size: int, dead_ranks: set[int]) -> torch.Tensor:
+    """Build the orig-rank -> densified-rank mapping table.
+
+    Returns a ``[ep_world_size]`` int32 tensor where ``table[orig_rank]`` is
+    the densified rank (-1 for dead ranks), i.e. the kernel's table1 view of
+    the elastic_info layout. Densified ranks are assigned in ascending
+    original-rank order over the survivors.
+    """
+    table = torch.full((ep_world_size,), -1, dtype=torch.int32)
+    alive = sorted(set(range(ep_world_size)) - dead_ranks)
+    for dense_rank, orig_rank in enumerate(alive):
+        table[orig_rank] = dense_rank
+    return table
 
 
 def densify_routing_table_physical_ids(
@@ -126,17 +142,21 @@ def build_local_reload_plan(
     ep_rank: int,
     num_local_experts: int,
 ) -> dict[int, list[tuple[int, int]]]:
-    """Diff this rank's physical-slot block before/after redistribution.
+    """Find this rank's slots whose logical expert changed after redistribution.
+
+    A surviving rank keeps its physical slot block, but some slots may now host
+    a different logical expert. This diffs this rank's block of
+    ``physical_to_logical_map`` before/after and reports the changed slots.
 
     Args:
-        p2l_before/p2l_after: full-width physical_to_logical_map snapshots
-            (CPU), before and after mark_dead + redistribute.
-        ep_rank: this worker's original EP rank (never rewritten).
+        p2l_before/p2l_after: full ``physical_to_logical_map`` snapshots
+            (``[num_layers, ep_world_size * num_local_experts]``, CPU).
+        ep_rank: this rank's original EP rank; selects the slot block.
         num_local_experts: physical slots per EP rank.
 
     Returns:
-        {moe_layer_idx: [(local_slot, logical_expert_id), ...]} for slots on
-        this rank whose logical expert changed.
+        ``{moe_layer_idx: [(local_slot, new_logical_expert_id), ...]}`` of the
+        changed slots, for ``reload_experts_from_disk``.
     """
     start = ep_rank * num_local_experts
     block_before = p2l_before[:, start : start + num_local_experts]

--- a/vllm_ascend/worker/sentinel/eplb_redistribute.py
+++ b/vllm_ascend/worker/sentinel/eplb_redistribute.py
@@ -1,0 +1,356 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM Ascend project
+"""NPU expert redistribution and weight reload for fault-tolerance scale-down.
+
+Device-agnostic placement math is imported from the upstream
+``vllm.v1.worker.sentinel.eplb_redistribute``; this module only carries the
+Ascend-specific pieces:
+
+- ``build_local_reload_plan``: which local slots received a new logical expert.
+- ``reload_experts_from_disk``: reload reassigned experts from checkpoint and
+  write them back in place, mirroring the runtime layout produced by
+  ``process_weights_after_loading`` (transpose / NZ cast / per-slot lists /
+  quant scales), so captured graphs keep working.
+
+The EPLB structures (physical_to_logical / logical_to_physical /
+logical_replica_count) keep the upstream slot model end to end: full width,
+original physical ids. The one exception is the kernel-facing
+``expert_replica_routing_table`` values: in scale-down mode the MC2 kernels
+override their world view from elastic_info (dense ep size / dense physical
+expert count / own rank = table1[orig]) and route each token via
+``table2[expert_id // num_local]``, while the combine kernel silently drops
+any id >= the shrunk physical expert count — so the ids consumed by the
+kernels must live in the densified space ``dense_rank * num_local + slot``
+(see ``densify_routing_table_physical_ids``). Only the table *values* are
+renumbered; shapes never change and updates are in-place, so captured graphs
+stay valid. Densified rank numbering otherwise lives only in the elastic_info
+tensor (table1/table2, consumed by the kernels) and in the rebuilt gloo cpu
+groups, exactly like upstream.
+
+All functions are deterministic with stable iteration order, so every
+surviving rank running them with the same inputs produces bit-identical
+results — no cross-rank communication during recovery.
+"""
+
+from collections.abc import Callable, Generator
+
+import torch
+import torch_npu
+from vllm.config import VllmConfig
+from vllm.logger import logger
+from vllm.model_executor.model_loader.default_loader import DefaultModelLoader
+
+# Re-exported upstream helpers, kept in one place so the sentinel has a
+# single import site for the redistribution building blocks.
+from vllm.v1.worker.sentinel.eplb_redistribute import (
+    check_redundancy_sufficient,
+    compute_dead_ep_ranks,
+    mark_dead_expert_slots_inplace,
+    rebuild_logical_expert_maps,
+    redistribute_expert_placement,
+)
+
+from vllm_ascend.ops.fused_moe.routed_experts import AscendUnquantizedFusedMoEMethod
+from vllm_ascend.quantization.methods.w8a8_dynamic import (
+    AscendW8A8DynamicFusedMoEMethod,
+    scale_from_float_to_int64,
+)
+from vllm_ascend.utils import ACL_FORMAT_FRACTAL_NZ, maybe_trans_nz
+
+__all__ = [
+    "build_local_reload_plan",
+    "check_redundancy_sufficient",
+    "compute_dead_ep_ranks",
+    "densify_routing_table_physical_ids",
+    "mark_dead_expert_slots_inplace",
+    "rebuild_logical_expert_maps",
+    "redistribute_expert_placement",
+    "reload_experts_from_disk",
+]
+
+# Checkpoint name suffixes (relative to "<layer_name>.<expert_id>.") of the
+# tensors a reload may consume. weight_offset is loaded at startup but never
+# consumed by the MoE apply path, so it is not reloaded here.
+_W13_WEIGHT_SUFFIXES = ("gate_up_proj.weight", "gate_proj.weight", "up_proj.weight")
+_W2_WEIGHT_SUFFIX = "down_proj.weight"
+_W13_SCALE_SUFFIXES = ("gate_up_proj.weight_scale", "gate_proj.weight_scale", "up_proj.weight_scale")
+_W2_SCALE_SUFFIX = "down_proj.weight_scale"
+
+
+def densify_routing_table_physical_ids(
+    routing_table: torch.Tensor,
+    orig_to_dense_rank: torch.Tensor,
+    num_local_experts: int,
+) -> None:
+    """Renumber a routing table's physical ids into the densified id space.
+
+    In scale-down mode the MC2 dispatch kernel computes a token's destination
+    as ``table2[expert_id // num_local]`` and the combine kernel drops any id
+    >= the shrunk physical expert count, so the ids produced by the EPLB
+    mapping must be dense-rank-major: ``dense_rank * num_local + slot``.
+    Keeping original ids only works when the dead ranks happen to be a suffix
+    (then table2 is the identity on the alive prefix); a dead rank in the
+    middle misroutes tokens or crashes the kernel on a -1 rank lookup.
+
+    The update is an in-place ``copy_`` with an unchanged shape, so captured
+    graphs keep pointing at valid storage.
+
+    Args:
+        routing_table: ``expert_replica_routing_table`` of one MoE layer
+            (device, int32), holding original global physical ids.
+        orig_to_dense_rank: ``[ep_world_size]`` original EP rank -> densified
+            rank (-1 for dead ranks), i.e. elastic_info's table1.
+        num_local_experts: physical slots per EP rank (unchanged by
+            scale-down).
+    """
+    ids = routing_table.to(torch.int64)
+    if bool((ids < 0).any()):
+        raise RuntimeError(
+            "[FT] expert replica routing table references empty slots after "
+            "redistribution; every logical expert must have a live replica."
+        )
+    orig_rank = torch.div(ids, num_local_experts, rounding_mode="floor")
+    dense_rank = orig_to_dense_rank.to(device=ids.device, dtype=torch.int64)[orig_rank]
+    if bool((dense_rank < 0).any()):
+        raise RuntimeError(
+            "[FT] expert replica routing table references dead EP ranks after "
+            "redistribution; the placement did not vacate the dead ranks."
+        )
+    dense_ids = dense_rank * num_local_experts + ids % num_local_experts
+    routing_table.copy_(dense_ids.to(routing_table.dtype))
+
+
+def build_local_reload_plan(
+    p2l_before: torch.Tensor,
+    p2l_after: torch.Tensor,
+    ep_rank: int,
+    num_local_experts: int,
+) -> dict[int, list[tuple[int, int]]]:
+    """Diff this rank's physical-slot block before/after redistribution.
+
+    Args:
+        p2l_before/p2l_after: full-width physical_to_logical_map snapshots
+            (CPU), before and after mark_dead + redistribute.
+        ep_rank: this worker's original EP rank (never rewritten).
+        num_local_experts: physical slots per EP rank.
+
+    Returns:
+        {moe_layer_idx: [(local_slot, logical_expert_id), ...]} for slots on
+        this rank whose logical expert changed.
+    """
+    start = ep_rank * num_local_experts
+    block_before = p2l_before[:, start : start + num_local_experts]
+    block_after = p2l_after[:, start : start + num_local_experts]
+    plan: dict[int, list[tuple[int, int]]] = {}
+    num_layers = p2l_before.shape[0]
+    for layer_idx in range(num_layers):
+        for slot in range(num_local_experts):
+            before = int(block_before[layer_idx, slot])
+            after = int(block_after[layer_idx, slot])
+            if before != after:
+                assert after >= 0, (
+                    f"Layer {layer_idx} slot {slot} on ep_rank {ep_rank} lost "
+                    "its expert without a replacement; redistribution is broken."
+                )
+                plan.setdefault(layer_idx, []).append((slot, after))
+    return plan
+
+
+def _tp_shard_info(layer) -> tuple[int, int]:
+    """(tp_rank, tp_size) of the MoE weights of a routed-experts module."""
+    parallel_config = layer.moe_config.moe_parallel_config
+    return parallel_config.tp_rank, parallel_config.tp_size
+
+
+def _shard_row(t: torch.Tensor, tp_rank: int, tp_size: int) -> torch.Tensor:
+    """Take this TP rank's row shard (dim 0) of a full checkpoint tensor."""
+    if tp_size == 1:
+        return t
+    shard = t.shape[0] // tp_size
+    return t.narrow(0, tp_rank * shard, shard)
+
+
+def _shard_col(t: torch.Tensor, tp_rank: int, tp_size: int) -> torch.Tensor:
+    """Take this TP rank's column shard (dim 1) of a full checkpoint tensor."""
+    if tp_size == 1:
+        return t
+    shard = t.shape[1] // tp_size
+    return t.narrow(1, tp_rank * shard, shard)
+
+
+def _gather_w13(
+    tensors: dict[str, torch.Tensor],
+    tp_rank: int,
+    tp_size: int,
+) -> torch.Tensor:
+    """Assemble one expert's w13 ([2I_local, H]) from checkpoint tensors."""
+    fused = tensors.get("gate_up_proj.weight")
+    if fused is not None:
+        half = fused.shape[0] // 2
+        gate, up = fused[:half], fused[half:]
+    else:
+        gate, up = tensors["gate_proj.weight"], tensors["up_proj.weight"]
+    return torch.cat([_shard_row(gate, tp_rank, tp_size), _shard_row(up, tp_rank, tp_size)], dim=0)
+
+
+def _gather_w13_scale(
+    tensors: dict[str, torch.Tensor],
+    tp_rank: int,
+    tp_size: int,
+) -> torch.Tensor:
+    """1-D w13 scale ([2I_local]) from checkpoint tensors."""
+    fused = tensors.get("gate_up_proj.weight_scale")
+    if fused is not None:
+        half = fused.shape[0] // 2
+        gate, up = fused[:half], fused[half:]
+    else:
+        gate = tensors["gate_proj.weight_scale"]
+        up = tensors["up_proj.weight_scale"]
+    return torch.cat([_shard_row(gate, tp_rank, tp_size), _shard_row(up, tp_rank, tp_size)], dim=0).view(-1)
+
+
+def _reload_unquantized(layer, slot: int, tensors: dict[str, torch.Tensor]) -> None:
+    """Mirror AscendUnquantizedFusedMoEMethod.process_weights_after_loading
+    for a single expert slot (ROCm-only padding intentionally skipped)."""
+    if getattr(layer, "w13_bias", None) is not None or getattr(layer, "w2_bias", None) is not None:
+        raise NotImplementedError("[FT] scale_down weight reload does not support MoE expert bias yet.")
+    tp_rank, tp_size = _tp_shard_info(layer)
+    w13_weight_list = getattr(layer, "w13_weight_list", None)
+    target = w13_weight_list[slot] if w13_weight_list is not None else layer.w13_weight
+    device, dtype = target.device, target.dtype
+
+    # [2I, H] -> transpose -> [H, 2I], then NZ cast (whole-tensor policy
+    # function, same as process_weights_after_loading's non-fused path).
+    w13 = _gather_w13(tensors, tp_rank, tp_size).transpose(0, 1).contiguous()
+    w13 = maybe_trans_nz(w13.to(device=device, dtype=dtype))
+    w2 = _shard_col(tensors[_W2_WEIGHT_SUFFIX], tp_rank, tp_size).transpose(0, 1).contiguous()
+    w2 = maybe_trans_nz(w2.to(device=device, dtype=dtype))
+
+    if w13_weight_list is not None:
+        w13_weight_list[slot].copy_(w13)
+        layer.w2_weight_list[slot].copy_(w2)
+    else:
+        # Whole-tensor NZ layout: the slot slice is one expert matrix.
+        layer.w13_weight.data[slot].copy_(w13)
+        layer.w2_weight.data[slot].copy_(w2)
+
+
+def _reload_w8a8_dynamic(layer, slot: int, tensors: dict[str, torch.Tensor]) -> None:
+    """Mirror AscendW8A8DynamicFusedMoEMethod.process_weights_after_loading
+    for a single expert slot (v2 + EPLB always stores per-slot lists)."""
+    tp_rank, tp_size = _tp_shard_info(layer)
+    device = layer.w13_weight_list[slot].device
+
+    w13 = _gather_w13(tensors, tp_rank, tp_size).transpose(0, 1).contiguous()
+    w13 = torch_npu.npu_format_cast(w13.to(device=device), ACL_FORMAT_FRACTAL_NZ)
+    w2 = _shard_col(tensors[_W2_WEIGHT_SUFFIX], tp_rank, tp_size).transpose(0, 1).contiguous()
+    w2 = torch_npu.npu_format_cast(w2.to(device=device), ACL_FORMAT_FRACTAL_NZ)
+    layer.w13_weight_list[slot].copy_(w13)
+    layer.w2_weight_list[slot].copy_(w2)
+
+    w13_scale = _gather_w13_scale(tensors, tp_rank, tp_size)
+    w2_scale = tensors[_W2_SCALE_SUFFIX].view(-1)
+    layer.w13_weight_scale_fp32_list[slot].copy_(w13_scale.to(torch.float32))
+    w2_scale_target = layer.w2_weight_scale_list[slot]
+    layer.w2_weight_scale_list[slot].copy_(w2_scale.to(w2_scale_target.dtype))
+
+    # fused_w*_scale_list only exist when enable_fused_mc2 == 1 (currently
+    # rejected for scale_down); keep the mirror for future support.
+    fused_w1_scale_list = getattr(layer, "fused_w1_scale_list", None)
+    fused_w2_scale_list = getattr(layer, "fused_w2_scale_list", None)
+    if fused_w1_scale_list is not None and fused_w2_scale_list is not None:
+        fused_w1_scale_list[slot].copy_(scale_from_float_to_int64(w13_scale))
+        fused_w2_scale_list[slot].copy_(scale_from_float_to_int64(w2_scale))
+
+
+# Dispatch on the quant method type; register new schemes here following the
+# same pattern.
+_RELOADERS: dict[type, Callable[[torch.nn.Module, int, dict[str, torch.Tensor]], None]] = {
+    AscendUnquantizedFusedMoEMethod: _reload_unquantized,
+    AscendW8A8DynamicFusedMoEMethod: _reload_w8a8_dynamic,
+}
+
+
+def reload_experts_from_disk(
+    model: torch.nn.Module,
+    vllm_config: VllmConfig,
+    reload_plan: dict[int, list[tuple[int, int]]],
+) -> int:
+    """Reload reassigned (layer, slot, logical) expert weights from disk.
+
+    Ascend keeps expert weights in runtime layout (transposed, NZ-cast, split
+    into per-slot lists, with derived quant scales), so the standard
+    ``model.load_weights`` path cannot write them back; checkpoint tensors are
+    read via DefaultModelLoader and converted per quant method, then copied
+    into the existing slot storage in place.
+
+    Returns:
+        Number of (layer, slot) pairs reloaded.
+    """
+    if not reload_plan:
+        return 0
+
+    moe_layers = list(model.moe_layers)
+    routed_layers = [getattr(layer, "routed_experts", layer) for layer in moe_layers]
+
+    prefixes: dict[str, tuple[int, int]] = {}
+    for layer_idx, assignments in reload_plan.items():
+        layer_name = routed_layers[layer_idx].layer_name
+        for _, logical_id in assignments:
+            prefixes[f"{layer_name}.{logical_id}."] = (layer_idx, logical_id)
+
+    loader = DefaultModelLoader(vllm_config.load_config)
+    # Produce every expert, not just the ones local at startup.
+    loader.local_expert_ids = None
+    all_weights = loader.get_all_weights(vllm_config.model_config, model)
+
+    wanted_suffixes = set(_W13_WEIGHT_SUFFIXES + _W13_SCALE_SUFFIXES)
+    wanted_suffixes.add(_W2_WEIGHT_SUFFIX)
+    wanted_suffixes.add(_W2_SCALE_SUFFIX)
+
+    buckets: dict[tuple[int, int], dict[str, torch.Tensor]] = {}
+    matched: set[str] = set()
+
+    def filtered_iter() -> Generator[tuple[tuple[int, int], str, torch.Tensor], None, None]:
+        for name, tensor in all_weights:
+            for prefix, key in prefixes.items():
+                if name.startswith(prefix):
+                    matched.add(prefix)
+                    suffix = name[len(prefix) :]
+                    if suffix in wanted_suffixes:
+                        yield key, suffix, tensor
+                    break
+
+    logger.info("[FT] Reloading experts for %d layer(s) from disk.", len(reload_plan))
+    for key, suffix, tensor in filtered_iter():
+        buckets.setdefault(key, {})[suffix] = tensor
+
+    unmatched = [pair for prefix, pair in prefixes.items() if prefix not in matched]
+    if unmatched:
+        raise RuntimeError(
+            f"[FT] {len(unmatched)} (layer, expert) pair(s) had no matching "
+            f"checkpoint weight, e.g. {unmatched[:5]}. The model's expert "
+            "weights likely use a layout that does not follow "
+            "'<layer_name>.<expert_id>.' (e.g. fused experts)."
+        )
+
+    reloaded = 0
+    for layer_idx, assignments in sorted(reload_plan.items()):
+        routed = routed_layers[layer_idx]
+        # Quantized layers carry the AscendFusedMoEMethod wrapper; the actual
+        # scheme (the _RELOADERS key) lives in its .quant_method attribute.
+        # Unquantized layers hold the bare scheme, so fall back to the object
+        # itself (same idiom as AscendRoutedExperts.quant_type).
+        quant_method = getattr(routed.quant_method, "quant_method", routed.quant_method)
+        reloader = _RELOADERS.get(type(quant_method))
+        if reloader is None:
+            raise NotImplementedError(
+                f"[FT] scale_down weight reload is not implemented for quant method {type(quant_method).__name__}."
+            )
+        for slot, logical_id in assignments:
+            tensors = buckets[(layer_idx, logical_id)]
+            reloader(routed, slot, tensors)
+            reloaded += 1
+
+    logger.info("[FT] Expert weight reload complete: %d (layer, slot) pair(s).", reloaded)
+    return reloaded

--- a/vllm_ascend/worker/sentinel/eplb_redistribute.py
+++ b/vllm_ascend/worker/sentinel/eplb_redistribute.py
@@ -2,36 +2,10 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM Ascend project
 """NPU expert redistribution and weight reload for fault-tolerance scale-down.
 
-Device-agnostic placement math is imported from the upstream
-``vllm.v1.worker.sentinel.eplb_redistribute``; this module only carries the
-Ascend-specific pieces:
-
-- ``reload_experts_from_disk``: reload reassigned experts from checkpoint and
-  write them back in place, mirroring the runtime layout produced by
-  ``process_weights_after_loading`` (transpose / NZ cast / per-slot lists /
-  quant scales), so captured graphs keep working. It mirrors the upstream
-  signature (a set of ``(layer, logical)`` reassignments) so the shared
-  sentinel flow can drive it directly; the destination local slot on this rank
-  is recovered from the rebuilt ``logical_to_physical_map``.
-
-The EPLB structures (physical_to_logical / logical_to_physical /
-logical_replica_count) keep the upstream slot model end to end: full width,
-original physical ids. The one exception is the kernel-facing
-``expert_replica_routing_table`` values: in scale-down mode the MC2 kernels
-override their world view from elastic_info (dense ep size / dense physical
-expert count / own rank = table1[orig]) and route each token via
-``table2[expert_id // num_local]``, while the combine kernel silently drops
-any id >= the shrunk physical expert count — so the ids consumed by the
-kernels must live in the densified space ``dense_rank * num_local + slot``
-(see ``densify_routing_table_physical_ids``). Only the table *values* are
-renumbered; shapes never change and updates are in-place, so captured graphs
-stay valid. Densified rank numbering otherwise lives only in the elastic_info
-tensor (table1/table2, consumed by the kernels) and in the rebuilt gloo cpu
-groups, exactly like upstream.
-
-All functions are deterministic with stable iteration order, so every
-surviving rank running them with the same inputs produces bit-identical
-results — no cross-rank communication during recovery.
+Reuses the upstream placement math and adds the Ascend-specific pieces:
+``reload_experts_from_disk`` (checkpoint reload that mirrors the runtime weight
+layout) and ``densify_routing_table_physical_ids`` (kernel-facing routing id
+renumbering).
 """
 
 from collections.abc import Callable, Generator

--- a/vllm_ascend/worker/sentinel/npu_worker_sentinel.py
+++ b/vllm_ascend/worker/sentinel/npu_worker_sentinel.py
@@ -6,7 +6,6 @@ import torch
 from vllm.distributed import (
     get_ep_group,
 )
-from vllm.logger import init_logger
 from vllm.v1.fault_tolerance.utils import FaultToleranceRequest
 from vllm.v1.worker.sentinel.gpu_worker_sentinel import (
     WorkerSentinel as GPUWorkerSentinel,
@@ -14,8 +13,6 @@ from vllm.v1.worker.sentinel.gpu_worker_sentinel import (
 
 if TYPE_CHECKING:
     from vllm.v1.worker.gpu_worker import Worker
-
-logger = init_logger(__name__)
 
 
 class WorkerSentinel(GPUWorkerSentinel):

--- a/vllm_ascend/worker/sentinel/npu_worker_sentinel.py
+++ b/vllm_ascend/worker/sentinel/npu_worker_sentinel.py
@@ -1,0 +1,103 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+from datetime import timedelta
+from typing import TYPE_CHECKING
+
+import torch
+from torch.distributed.distributed_c10d import _set_pg_timeout
+from vllm.config import set_current_vllm_config
+from vllm.distributed import (
+    get_dp_group,
+    get_ep_group,
+    stateless_destroy_torch_distributed_process_group,
+    stateless_init_torch_distributed_process_group,
+)
+from vllm.logger import init_logger
+from vllm.v1.fault_tolerance.utils import FaultToleranceRequest
+from vllm.v1.serial_utils import run_method
+
+if TYPE_CHECKING:
+    from vllm.v1.worker.gpu_worker import Worker
+
+logger = init_logger(__name__)
+
+
+class WorkerSentinel:
+    """Per-worker sentinel for fault tolerance.
+
+    Handles commands dispatched from EngineCoreSentinel via collective_rpc,
+    including device restart and DP group re-initialization on retry.
+    """
+
+    def __init__(self, worker: "Worker", device: torch.device):
+        self.worker = worker
+        self.device = device
+        self.dp_rank = worker.parallel_config.data_parallel_rank
+        self.dp_size = worker.parallel_config.data_parallel_size
+        self.data_parallel_master_ip = worker.parallel_config.data_parallel_master_ip
+        self.set_dp_gloo_timeout()
+
+    def set_dp_gloo_timeout(self) -> None:
+        timeout = timedelta(seconds=self.worker.vllm_config.parallel_config.cpu_distributed_timeout_seconds)
+        dp_cpu_group = get_dp_group()
+        _set_pg_timeout(timeout=timeout, group=dp_cpu_group.cpu_group)
+
+    def handle_command(self, ft_request: FaultToleranceRequest):
+        """Dispatch an FT command by instruction name."""
+        with set_current_vllm_config(self.worker.vllm_config):
+            return run_method(self, ft_request.instruction, (ft_request,), {})
+
+    def query_mask(self, ft_request: FaultToleranceRequest) -> dict:
+        """Query mask for fault tolerance.
+
+        Ascend's all2all operator does not currently support querying mask.
+        Returns all-zero mask for now; will be updated once the operator
+        supports it.
+        """
+        return {"mask": get_ep_group().world_size * [0]}
+
+    def retry(self, ft_request: FaultToleranceRequest):
+        self._clean_worker_state()
+        torch.accelerator.synchronize()
+        params = ft_request.params
+        if self.dp_size > 1:
+            old_cpu_group = get_dp_group().cpu_group
+            stateless_destroy_torch_distributed_process_group(old_cpu_group)
+            world_size = self.worker.parallel_config.world_size
+            port = params["new_stateless_dp_group_ports"][self.worker.rank % world_size]
+            get_dp_group().cpu_group = stateless_init_torch_distributed_process_group(
+                self.data_parallel_master_ip,
+                port,
+                self.dp_rank,
+                self.dp_size,
+                backend="gloo",
+            )
+
+    def _clean_worker_state(self):
+        import torch_npu
+
+        from vllm_ascend.platform import NPUPlatform
+
+        NPUPlatform.set_device(self.device)
+        torch_npu.npu.stop_device(self.device.index)
+        torch_npu.npu.restart_device(self.device.index)
+        torch_npu.distributed.reinit_process_group(None, False)
+        torch.npu.synchronize()
+        model_runner = self.worker.model_runner
+        model_runner.execute_model_state = None
+        if self.worker.use_v2_model_runner:
+            for req_id in list(model_runner.req_states.req_id_to_index):
+                model_runner._remove_request(req_id)
+        else:
+            model_runner.kv_connector_output = None
+            input_batch = model_runner.input_batch
+            cached_req_ids = list(input_batch.req_id_to_index)
+            for req_id in cached_req_ids:
+                model_runner.requests.pop(req_id, None)
+                model_runner.num_prompt_logprobs.pop(req_id, None)
+                input_batch.remove_request(req_id)
+            input_batch.condense()
+            input_batch.refresh_metadata()
+            input_batch.req_prompt_embeds.clear()
+            model_runner.async_output_copy_stream = torch.cuda.Stream()
+            model_runner.prepare_inputs_event = torch.Event()

--- a/vllm_ascend/worker/sentinel/npu_worker_sentinel.py
+++ b/vllm_ascend/worker/sentinel/npu_worker_sentinel.py
@@ -1,20 +1,16 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
-from datetime import timedelta
 from typing import TYPE_CHECKING
 
 import torch
-from torch.distributed.distributed_c10d import _set_pg_timeout
-from vllm.config import set_current_vllm_config
 from vllm.distributed import (
-    get_dp_group,
     get_ep_group,
-    stateless_destroy_torch_distributed_process_group,
-    stateless_init_torch_distributed_process_group,
 )
 from vllm.logger import init_logger
 from vllm.v1.fault_tolerance.utils import FaultToleranceRequest
-from vllm.v1.serial_utils import run_method
+from vllm.v1.worker.sentinel.gpu_worker_sentinel import (
+    WorkerSentinel as GPUWorkerSentinel,
+)
 
 if TYPE_CHECKING:
     from vllm.v1.worker.gpu_worker import Worker
@@ -22,8 +18,8 @@ if TYPE_CHECKING:
 logger = init_logger(__name__)
 
 
-class WorkerSentinel:
-    """Per-worker sentinel for fault tolerance.
+class WorkerSentinel(GPUWorkerSentinel):
+    """Per-worker sentinel for fault tolerance on Ascend NPU.
 
     Handles commands dispatched from EngineCoreSentinel via collective_rpc,
     including device restart and DP group re-initialization on retry.
@@ -35,17 +31,6 @@ class WorkerSentinel:
         self.dp_rank = worker.parallel_config.data_parallel_rank
         self.dp_size = worker.parallel_config.data_parallel_size
         self.data_parallel_master_ip = worker.parallel_config.data_parallel_master_ip
-        self.set_dp_gloo_timeout()
-
-    def set_dp_gloo_timeout(self) -> None:
-        timeout = timedelta(seconds=self.worker.vllm_config.parallel_config.cpu_distributed_timeout_seconds)
-        dp_cpu_group = get_dp_group()
-        _set_pg_timeout(timeout=timeout, group=dp_cpu_group.cpu_group)
-
-    def handle_command(self, ft_request: FaultToleranceRequest):
-        """Dispatch an FT command by instruction name."""
-        with set_current_vllm_config(self.worker.vllm_config):
-            return run_method(self, ft_request.instruction, (ft_request,), {})
 
     def query_mask(self, ft_request: FaultToleranceRequest) -> dict:
         """Query mask for fault tolerance.
@@ -56,24 +41,7 @@ class WorkerSentinel:
         """
         return {"mask": get_ep_group().world_size * [0]}
 
-    def retry(self, ft_request: FaultToleranceRequest):
-        self._clean_worker_state()
-        torch.accelerator.synchronize()
-        params = ft_request.params
-        if self.dp_size > 1:
-            old_cpu_group = get_dp_group().cpu_group
-            stateless_destroy_torch_distributed_process_group(old_cpu_group)
-            world_size = self.worker.parallel_config.world_size
-            port = params["new_stateless_dp_group_ports"][self.worker.rank % world_size]
-            get_dp_group().cpu_group = stateless_init_torch_distributed_process_group(
-                self.data_parallel_master_ip,
-                port,
-                self.dp_rank,
-                self.dp_size,
-                backend="gloo",
-            )
-
-    def _clean_worker_state(self):
+    def reset_device(self) -> None:
         import torch_npu
 
         from vllm_ascend.platform import NPUPlatform
@@ -83,21 +51,11 @@ class WorkerSentinel:
         torch_npu.npu.restart_device(self.device.index)
         torch_npu.distributed.reinit_process_group(None, False)
         torch.npu.synchronize()
-        model_runner = self.worker.model_runner
-        model_runner.execute_model_state = None
-        if self.worker.use_v2_model_runner:
-            for req_id in list(model_runner.req_states.req_id_to_index):
-                model_runner._remove_request(req_id)
-        else:
-            model_runner.kv_connector_output = None
-            input_batch = model_runner.input_batch
-            cached_req_ids = list(input_batch.req_id_to_index)
-            for req_id in cached_req_ids:
-                model_runner.requests.pop(req_id, None)
-                model_runner.num_prompt_logprobs.pop(req_id, None)
-                input_batch.remove_request(req_id)
-            input_batch.condense()
-            input_batch.refresh_metadata()
-            input_batch.req_prompt_embeds.clear()
-            model_runner.async_output_copy_stream = torch.cuda.Stream()
-            model_runner.prepare_inputs_event = torch.Event()
+
+    def retry(self, ft_request: FaultToleranceRequest):
+        # reset the device first so any hung device-side collectives are
+        # aborted, then run the base class flow (synchronize, clean worker
+        # state, re-initialize the DP group).
+        self.reset_device()
+        super().retry(ft_request)
+

--- a/vllm_ascend/worker/sentinel/npu_worker_sentinel.py
+++ b/vllm_ascend/worker/sentinel/npu_worker_sentinel.py
@@ -58,4 +58,3 @@ class WorkerSentinel(GPUWorkerSentinel):
         # state, re-initialize the DP group).
         self.reset_device()
         super().retry(ft_request)
-

--- a/vllm_ascend/worker/sentinel/npu_worker_sentinel.py
+++ b/vllm_ascend/worker/sentinel/npu_worker_sentinel.py
@@ -3,6 +3,7 @@
 from typing import TYPE_CHECKING
 
 import torch
+import torch_npu
 from vllm.distributed import (
     get_ep_group,
 )
@@ -10,6 +11,8 @@ from vllm.v1.fault_tolerance.utils import FaultToleranceRequest
 from vllm.v1.worker.sentinel.gpu_worker_sentinel import (
     WorkerSentinel as GPUWorkerSentinel,
 )
+
+from vllm_ascend.platform import NPUPlatform
 
 if TYPE_CHECKING:
     from vllm.v1.worker.gpu_worker import Worker
@@ -39,10 +42,6 @@ class WorkerSentinel(GPUWorkerSentinel):
         return {"mask": get_ep_group().world_size * [0]}
 
     def reset_device(self) -> None:
-        import torch_npu
-
-        from vllm_ascend.platform import NPUPlatform
-
         NPUPlatform.set_device(self.device)
         torch_npu.npu.stop_device(self.device.index)
         torch_npu.npu.restart_device(self.device.index)

--- a/vllm_ascend/worker/sentinel/npu_worker_sentinel.py
+++ b/vllm_ascend/worker/sentinel/npu_worker_sentinel.py
@@ -103,6 +103,14 @@ class WorkerSentinel(GPUWorkerSentinel):
         super().retry(ft_request)
         self.worker_faulted = False
 
+    def init_num_local_experts(self) -> None:
+        """Record the per-rank physical expert slot count after model load."""
+        if self.worker.model_runner.eplb_state is None:
+            return
+        eplb_model_state = self._eplb_model_state()
+        num_local_experts = eplb_model_state.physical_to_logical_map.shape[1] // get_ep_group().world_size
+        get_ep_all2all_manager().set_num_local_physical_experts(num_local_experts)
+
     def scale_down(self, ft_request: FaultToleranceRequest):
         """Scale down over the surviving DP ranks, reusing the upstream flow.
 
@@ -112,12 +120,6 @@ class WorkerSentinel(GPUWorkerSentinel):
         and a dummy-batch runnability check on top.
         """
         self._validate_scale_down_preconditions()
-        # Set the per-rank physical slot count before super().scale_down so
-        # elastic_info rebuilds derive the shrunk expert width from it.
-        eplb_model_state = self._eplb_model_state()
-        num_local_experts = eplb_model_state.physical_to_logical_map.shape[1] // get_ep_group().world_size
-        get_ep_all2all_manager().set_num_local_physical_experts(num_local_experts)
-
         super().scale_down(ft_request)
 
         # Verify the redistributed model is runnable before reporting healthy.

--- a/vllm_ascend/worker/sentinel/npu_worker_sentinel.py
+++ b/vllm_ascend/worker/sentinel/npu_worker_sentinel.py
@@ -86,13 +86,7 @@ class WorkerSentinel(GPUWorkerSentinel):
         self.worker_faulted = False
 
     def query_mask(self, ft_request: FaultToleranceRequest) -> dict:
-        """Report the dead-rank mask (upstream convention: 0=live, 1=dead).
-
-        Pure CPU read: on NPU the mask is only ever written host-side during
-        FT recovery, so on a first fault this is all zeros and the
-        orchestrator's retry-vs-scale_down decision must come from its own
-        cluster knowledge.
-        """
+        """Report the dead-rank mask (upstream convention: 0=live, 1=dead)."""
         return {"mask": get_ep_all2all_manager().query_active_mask().tolist()}
 
     def reset_device(self) -> None:
@@ -103,10 +97,8 @@ class WorkerSentinel(GPUWorkerSentinel):
         torch.npu.synchronize()
 
     def retry(self, ft_request: FaultToleranceRequest):
-        # reset the device first so any hung device-side collectives are
-        # aborted, then run the base class flow (synchronize, clean worker
-        # state, re-initialize the DP group). The quarantine is lifted only
-        # after the groups are rebuilt below.
+        # Reset first so hung device collectives are aborted, then run the
+        # base flow and lift the quarantine after the groups are rebuilt.
         self.reset_device()
         super().retry(ft_request)
         self.worker_faulted = False
@@ -120,10 +112,8 @@ class WorkerSentinel(GPUWorkerSentinel):
         and a dummy-batch runnability check on top.
         """
         self._validate_scale_down_preconditions()
-        # Record the per-rank physical slot count first: every elastic_info
-        # rebuild (the update_mask calls inside retry, and the rebuild after
-        # redistribution) derives the shrunk physical-expert width from the
-        # surviving ranks, so no separate width setter is needed downstream.
+        # Set the per-rank physical slot count before super().scale_down so
+        # elastic_info rebuilds derive the shrunk expert width from it.
         eplb_model_state = self._eplb_model_state()
         num_local_experts = eplb_model_state.physical_to_logical_map.shape[1] // get_ep_group().world_size
         get_ep_all2all_manager().set_num_local_physical_experts(num_local_experts)

--- a/vllm_ascend/worker/sentinel/npu_worker_sentinel.py
+++ b/vllm_ascend/worker/sentinel/npu_worker_sentinel.py
@@ -37,7 +37,16 @@ if TYPE_CHECKING:
 
 
 def fault_barrier_wrapper(func: Callable):
-    """Quarantine and reset the worker when a wrapped method faults."""
+    """Barrier between device faults and the async step loop.
+
+    On the first device-touching fault (e.g. an EP-group allreduce failing on a
+    dead peer that poisons the model stream) it quarantines the worker and
+    resets the device immediately, before any tensor teardown on the broken
+    stream can std::terminate the process. While quarantined, wrapped methods
+    short-circuit with an empty output so in-flight async steps drain safely
+    without re-hitting the device; retry lifts the quarantine only after the
+    groups are rebuilt.
+    """
 
     def wrapped(self, *args, **kwargs):
         sentinel = getattr(self, "worker_sentinel", None)
@@ -163,13 +172,19 @@ class WorkerSentinel(GPUWorkerSentinel):
 
         eplb_model_state = self._eplb_model_state()
         # Propagate the new placement into the Ascend routing tables (in-place,
-        # so captured graphs keep pointing at valid storage).
+        # so captured graphs keep pointing at valid storage), then renumber
+        # their ids into the densified space for the MC2 kernels.
         refresh_model_routing_tables(eplb_model_state)
+        self._densify_routing_tables(eplb_model_state)
 
-        # The MC2 kernels consume the routing tables in the densified id space;
-        # renumber the kernel-facing values in place after the refresh. The
-        # dead set is cumulative (accumulated across recovery rounds), so
-        # derive it from the manager's mask rather than this round's ranks.
+    def _densify_routing_tables(self, eplb_model_state) -> None:
+        """Renumber the kernel-facing routing tables into the densified id space.
+
+        The MC2 kernels consume the routing tables in the densified id space,
+        so the kernel-facing values are renumbered in place after the refresh.
+        The dead set is cumulative (accumulated across recovery rounds), so it
+        is derived from the manager's mask rather than this round's ranks.
+        """
         p2l = eplb_model_state.physical_to_logical_map
         ep_world_size = get_ep_group().world_size
         num_local_experts = p2l.shape[1] // ep_world_size

--- a/vllm_ascend/worker/sentinel/npu_worker_sentinel.py
+++ b/vllm_ascend/worker/sentinel/npu_worker_sentinel.py
@@ -1,12 +1,13 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Callable
 
 import torch
 import torch_npu
 from vllm.logger import logger
 from vllm.model_executor.layers.fused_moe.all2all_utils import get_ep_all2all_manager
 from vllm.v1.fault_tolerance.utils import FaultToleranceRequest
+from vllm.v1.outputs import EMPTY_MODEL_RUNNER_OUTPUT
 from vllm.v1.worker.sentinel.gpu_worker_sentinel import (
     WorkerSentinel as GPUWorkerSentinel,
 )
@@ -30,6 +31,31 @@ if TYPE_CHECKING:
     from vllm.v1.worker.gpu_worker import Worker
 
 
+def fault_barrier_wrapper(func: Callable):
+    """Quarantine and reset the worker when a wrapped method faults."""
+
+    def wrapped(self, *args, **kwargs):
+        sentinel = getattr(self, "worker_sentinel", None)
+        if sentinel is not None and sentinel.worker_faulted:
+            return EMPTY_MODEL_RUNNER_OUTPUT
+        try:
+            return func(self, *args, **kwargs)
+        except SystemExit:
+            raise
+        except Exception as exc:
+            if sentinel is not None:
+                sentinel.worker_faulted = True
+                logger.warning("[FT] Quarantining worker %d after fault: %s", self.rank, exc)
+                try:
+                    sentinel.reset_device()
+                except Exception:
+                    logger.exception("[FT] self device reset failed on worker %d.", self.rank)
+                return EMPTY_MODEL_RUNNER_OUTPUT
+            raise
+
+    return wrapped
+
+
 class WorkerSentinel(GPUWorkerSentinel):
     """Per-worker sentinel for fault tolerance on Ascend NPU.
 
@@ -44,6 +70,9 @@ class WorkerSentinel(GPUWorkerSentinel):
         self.dp_rank = worker.parallel_config.data_parallel_rank
         self.dp_size = worker.parallel_config.data_parallel_size
         self.data_parallel_master_ip = worker.parallel_config.data_parallel_master_ip
+        # Set once a device-touching method faults, to keep this worker off the
+        # device until FT recovery rebuilds the groups.
+        self.worker_faulted = False
 
     def query_mask(self, ft_request: FaultToleranceRequest) -> dict:
         """Report the dead-rank mask (upstream convention: 0=live, 1=dead).
@@ -65,9 +94,11 @@ class WorkerSentinel(GPUWorkerSentinel):
     def retry(self, ft_request: FaultToleranceRequest):
         # reset the device first so any hung device-side collectives are
         # aborted, then run the base class flow (synchronize, clean worker
-        # state, re-initialize the DP group).
+        # state, re-initialize the DP group). The quarantine is lifted only
+        # after the groups are rebuilt below.
         self.reset_device()
         super().retry(ft_request)
+        self.worker_faulted = False
 
     def scale_down(self, ft_request: FaultToleranceRequest):
         """Scale down over the surviving DP ranks, mirroring the upstream
@@ -133,25 +164,11 @@ class WorkerSentinel(GPUWorkerSentinel):
             )
 
     def _redistribute_experts(self, dead_ep_ranks: set[int]) -> None:
-        """One-shot expert redistribution after scale-down.
+        """Redistribute experts onto the surviving slots after scale-down.
 
-        Cannot be inherited from the upstream sentinel: the upstream version
-        applies the new placement via `rebuild_model_expert_maps` (GPU expert
-        maps), reloads weights in the GPU runtime layout, and calls
-        `sync_num_dispatchers_for_nixl_ep`. On Ascend the placement must
-        instead be propagated into the Ascend routing tables
-        (`refresh_model_routing_tables`), reassigned weights must be rewritten
-        in the NPU runtime layout (transpose / NZ cast / per-slot lists — the
-        `reload_experts_from_disk` in eplb_redistribute.py), and the MC2
-        expert width must be shrunk via `set_num_physical_experts`. Only the
-        pure placement math is shared (imported from upstream); the apply
-        steps are platform-specific.
-
-        Deterministic, no cross-rank communication: every surviving rank
-        computes bit-identical placements from the shared EPLB model state.
-        The EPLB maps keep the upstream slot model (full width, original
-        physical ids); the densified rank numbering lives only in the
-        elastic_info tensor maintained by the all2all manager.
+        Deterministic and local: every survivor runs the same placement math
+        (imported from upstream), then applies it to the Ascend routing tables,
+        reloads reassigned weights from disk, and shrinks the MC2 expert width.
         """
         eplb_model_state = self._eplb_model_state()
         p2l = eplb_model_state.physical_to_logical_map
@@ -167,18 +184,12 @@ class WorkerSentinel(GPUWorkerSentinel):
         mark_dead_expert_slots_inplace(p2l, dead_ep_ranks, num_local_experts)
         redistribute_expert_placement(p2l, num_logical, num_local_experts)
         rebuild_logical_expert_maps(p2l, l2p, lrc)
-        # Propagate the new placement into the Ascend routing tables; the
-        # table shape is unchanged so this copy_'s into the storage captured
-        # by graphs.
+        # Propagate the new placement into the Ascend routing tables (in-place,
+        # so captured graphs keep pointing at valid storage).
         refresh_model_routing_tables(eplb_model_state)
 
-        # The MC2 kernels require the densified physical-id space while scaled
-        # down (dispatch routes via table2[expert_id // num_local]; combine
-        # silently drops ids >= the shrunk physical expert count). The refresh
-        # above rebuilds the tables with original full-width ids, so renumber
-        # the kernel-facing values in place. Original ids only route correctly
-        # when the dead ranks are a suffix; a dead rank in the middle would
-        # misroute tokens or crash the kernel on a -1 rank lookup.
+        # The MC2 kernels consume the routing tables in the densified id space;
+        # renumber the kernel-facing values in place after the refresh.
         orig_to_dense_rank = get_ep_all2all_manager().to_densified_rank_table()
         for layer in eplb_model_state.model.moe_layers:
             routing_table = getattr(getattr(layer, "eplb_state", None), "expert_replica_routing_table", None)
@@ -193,10 +204,8 @@ class WorkerSentinel(GPUWorkerSentinel):
                 reload_plan,
             )
 
-        # Shrink the physical-expert width the MC2 kernels see so it matches
-        # the surviving slots; this also flips elastic_info into scaling-down
-        # mode (the mask replayed during retry kept the flag at 0 until the
-        # new width was known).
+        # Shrink the physical-expert width to the surviving slots; this also
+        # flips elastic_info into scaling-down mode.
         get_ep_all2all_manager().set_num_physical_experts((ep_world_size - len(dead_ep_ranks)) * num_local_experts)
 
         logger.info(

--- a/vllm_ascend/worker/sentinel/npu_worker_sentinel.py
+++ b/vllm_ascend/worker/sentinel/npu_worker_sentinel.py
@@ -11,6 +11,7 @@ from vllm.v1.outputs import EMPTY_MODEL_RUNNER_OUTPUT
 from vllm.v1.worker.sentinel.gpu_worker_sentinel import (
     WorkerSentinel as GPUWorkerSentinel,
 )
+from vllm.distributed.parallel_state import get_ep_group
 
 from vllm_ascend.platform import NPUPlatform
 from vllm_ascend.ascend_config import get_ascend_config
@@ -18,6 +19,7 @@ from vllm_ascend.distributed.eplb.state import refresh_model_routing_tables
 from vllm_ascend.distributed.parallel_state import get_mc2_group
 from vllm_ascend.worker.sentinel.eplb_redistribute import (
     build_local_reload_plan,
+    build_orig_to_dense_rank_table,
     check_redundancy_sufficient,
     compute_dead_ep_ranks,
     densify_routing_table_physical_ids,
@@ -65,11 +67,8 @@ class WorkerSentinel(GPUWorkerSentinel):
     """
 
     def __init__(self, worker: "Worker", device: torch.device):
-        self.worker = worker
         self.device = device
-        self.dp_rank = worker.parallel_config.data_parallel_rank
-        self.dp_size = worker.parallel_config.data_parallel_size
-        self.data_parallel_master_ip = worker.parallel_config.data_parallel_master_ip
+        self.worker = worker
         # Set once a device-touching method faults, to keep this worker off the
         # device until FT recovery rebuilds the groups.
         self.worker_faulted = False
@@ -175,10 +174,10 @@ class WorkerSentinel(GPUWorkerSentinel):
         l2p = eplb_model_state.logical_to_physical_map
         lrc = eplb_model_state.logical_replica_count
         num_logical = lrc.shape[1]
-        ep_world_size = get_mc2_group().world_size
+        ep_world_size = get_ep_group().world_size
         num_local_experts = p2l.shape[1] // ep_world_size
         # The original EP rank; never rewritten by scale-down.
-        ep_rank = get_mc2_group().rank_in_group
+        ep_rank = get_ep_group().rank_in_group
 
         p2l_before = p2l.cpu().clone()
         mark_dead_expert_slots_inplace(p2l, dead_ep_ranks, num_local_experts)
@@ -189,8 +188,12 @@ class WorkerSentinel(GPUWorkerSentinel):
         refresh_model_routing_tables(eplb_model_state)
 
         # The MC2 kernels consume the routing tables in the densified id space;
-        # renumber the kernel-facing values in place after the refresh.
-        orig_to_dense_rank = get_ep_all2all_manager().to_densified_rank_table()
+        # renumber the kernel-facing values in place after the refresh. The
+        # dead set is cumulative (accumulated across recovery rounds), so
+        # derive it from the manager's mask rather than this round's ranks.
+        active_mask = get_ep_all2all_manager().query_active_mask()
+        dead_ranks = {rank for rank, is_dead in enumerate(active_mask.tolist()) if is_dead}
+        orig_to_dense_rank = build_orig_to_dense_rank_table(ep_world_size, dead_ranks)
         for layer in eplb_model_state.model.moe_layers:
             routing_table = getattr(getattr(layer, "eplb_state", None), "expert_replica_routing_table", None)
             if routing_table is not None:

--- a/vllm_ascend/worker/sentinel/npu_worker_sentinel.py
+++ b/vllm_ascend/worker/sentinel/npu_worker_sentinel.py
@@ -15,9 +15,9 @@ from vllm.v1.worker.sentinel.gpu_worker_sentinel import (
     WorkerSentinel as GPUWorkerSentinel,
 )
 
-from vllm_ascend.platform import NPUPlatform
 from vllm_ascend.ascend_config import get_ascend_config
 from vllm_ascend.distributed.eplb.state import refresh_model_routing_tables
+from vllm_ascend.platform import NPUPlatform
 from vllm_ascend.worker.sentinel.eplb_redistribute import (
     build_orig_to_dense_rank_table,
     densify_routing_table_physical_ids,

--- a/vllm_ascend/worker/sentinel/npu_worker_sentinel.py
+++ b/vllm_ascend/worker/sentinel/npu_worker_sentinel.py
@@ -111,6 +111,14 @@ class WorkerSentinel(GPUWorkerSentinel):
         and a dummy-batch runnability check on top.
         """
         self._validate_scale_down_preconditions()
+        # Record the per-rank physical slot count first: every elastic_info
+        # rebuild (the update_mask calls inside retry, and the rebuild after
+        # redistribution) derives the shrunk physical-expert width from the
+        # surviving ranks, so no separate width setter is needed downstream.
+        eplb_model_state = self._eplb_model_state()
+        num_local_experts = eplb_model_state.physical_to_logical_map.shape[1] // get_ep_group().world_size
+        get_ep_all2all_manager().set_num_local_physical_experts(num_local_experts)
+
         super().scale_down(ft_request)
 
         # Verify the redistributed model is runnable before reporting healthy.
@@ -172,7 +180,3 @@ class WorkerSentinel(GPUWorkerSentinel):
             routing_table = getattr(getattr(layer, "eplb_state", None), "expert_replica_routing_table", None)
             if routing_table is not None:
                 densify_routing_table_physical_ids(routing_table, orig_to_dense_rank, num_local_experts)
-
-        # Shrink the physical-expert width to the surviving slots; this also
-        # flips elastic_info into scaling-down mode.
-        get_ep_all2all_manager().set_num_physical_experts((ep_world_size - len(dead_ep_ranks)) * num_local_experts)

--- a/vllm_ascend/worker/sentinel/npu_worker_sentinel.py
+++ b/vllm_ascend/worker/sentinel/npu_worker_sentinel.py
@@ -1,9 +1,12 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
-from typing import TYPE_CHECKING, Callable
+from collections.abc import Callable
+from typing import TYPE_CHECKING
 
 import torch
 import torch_npu
+import vllm.v1.worker.sentinel.gpu_worker_sentinel as _gpu_worker_sentinel
+from vllm.distributed.parallel_state import get_ep_group
 from vllm.logger import logger
 from vllm.model_executor.layers.fused_moe.all2all_utils import get_ep_all2all_manager
 from vllm.v1.fault_tolerance.utils import FaultToleranceRequest
@@ -11,23 +14,23 @@ from vllm.v1.outputs import EMPTY_MODEL_RUNNER_OUTPUT
 from vllm.v1.worker.sentinel.gpu_worker_sentinel import (
     WorkerSentinel as GPUWorkerSentinel,
 )
-from vllm.distributed.parallel_state import get_ep_group
 
 from vllm_ascend.platform import NPUPlatform
 from vllm_ascend.ascend_config import get_ascend_config
 from vllm_ascend.distributed.eplb.state import refresh_model_routing_tables
-from vllm_ascend.distributed.parallel_state import get_mc2_group
 from vllm_ascend.worker.sentinel.eplb_redistribute import (
-    build_local_reload_plan,
     build_orig_to_dense_rank_table,
-    check_redundancy_sufficient,
-    compute_dead_ep_ranks,
     densify_routing_table_physical_ids,
-    mark_dead_expert_slots_inplace,
-    rebuild_logical_expert_maps,
-    redistribute_expert_placement,
     reload_experts_from_disk,
 )
+
+# Route the reload call inside the inherited upstream
+# GPUWorkerSentinel._redistribute_experts to the Ascend implementation: the
+# upstream reloader writes via model.load_weights, which cannot produce
+# Ascend's runtime expert layout (transpose / NZ / per-slot lists / quant
+# scales). The signatures match (a set of (layer, logical) reassignments), so
+# super() flows pick up the Ascend reloader without any upstream change.
+_gpu_worker_sentinel.reload_experts_from_disk = reload_experts_from_disk
 
 if TYPE_CHECKING:
     from vllm.v1.worker.gpu_worker import Worker
@@ -100,42 +103,19 @@ class WorkerSentinel(GPUWorkerSentinel):
         self.worker_faulted = False
 
     def scale_down(self, ft_request: FaultToleranceRequest):
-        """Scale down over the surviving DP ranks, mirroring the upstream
-        GPUWorkerSentinel.scale_down structure."""
+        """Scale down over the surviving DP ranks, reusing the upstream flow.
+
+        ``super().scale_down`` runs the deterministic dead-rank masking and
+        expert redistribution, dispatching ``retry`` / ``_redistribute_experts``
+        to the Ascend overrides below. Ascend adds its platform preconditions
+        and a dummy-batch runnability check on top.
+        """
         self._validate_scale_down_preconditions()
-        params = ft_request.params
-        tp_size = self.worker.parallel_config.tensor_parallel_size
-        dead_ep_ranks = compute_dead_ep_ranks(params["dead_dp_ranks"], tp_size)
-        eplb_model_state = self._eplb_model_state()
-        ep_world_size = get_mc2_group().world_size
-
-        check_redundancy_sufficient(
-            eplb_model_state.logical_replica_count.shape[1],
-            eplb_model_state.physical_to_logical_map.shape[1] // ep_world_size,
-            ep_world_size,
-            dead_ep_ranks,
-        )
-        # Suppress EPLB before retry so the base flow skips the EPLB group
-        # reinit; the expert placement is fixed by the redistribution below.
-        self.worker.model_runner.eep_eplb_suppressed = True
-        # Device reset + worker-state cleanup + DP gloo group rebuilt with
-        # the densified membership; the base retry also replays the
-        # cumulative dead set into the elastic_info mask via update_mask.
-        self.retry(ft_request)
-
-        self._redistribute_experts(dead_ep_ranks)
+        super().scale_down(ft_request)
 
         # Verify the redistributed model is runnable before reporting healthy.
         self.worker.execute_dummy_batch()
         torch.npu.synchronize()
-
-        logger.info(
-            "[FT] Worker scale_down complete: dp_group_size=%d, "
-            "dp_group_rank=%d, dead_ep_ranks=%s, eplb_suppressed=True",
-            params["dp_group_size"],
-            params["dp_group_rank"],
-            sorted(dead_ep_ranks),
-        )
 
     def _validate_scale_down_preconditions(self) -> None:
         if not self.worker.use_v2_model_runner:
@@ -165,24 +145,15 @@ class WorkerSentinel(GPUWorkerSentinel):
     def _redistribute_experts(self, dead_ep_ranks: set[int]) -> None:
         """Redistribute experts onto the surviving slots after scale-down.
 
-        Deterministic and local: every survivor runs the same placement math
-        (imported from upstream), then applies it to the Ascend routing tables,
-        reloads reassigned weights from disk, and shrinks the MC2 expert width.
+        Reuses the upstream redistribution (mark dead slots, steal spare slots
+        for the missing experts, rebuild the logical maps and reload reassigned
+        weights through the Ascend reloader patched into the shared flow). On
+        top of that, refreshes the Ascend kernel-facing routing tables into the
+        densified id space and shrinks the MC2 physical-expert width.
         """
-        eplb_model_state = self._eplb_model_state()
-        p2l = eplb_model_state.physical_to_logical_map
-        l2p = eplb_model_state.logical_to_physical_map
-        lrc = eplb_model_state.logical_replica_count
-        num_logical = lrc.shape[1]
-        ep_world_size = get_ep_group().world_size
-        num_local_experts = p2l.shape[1] // ep_world_size
-        # The original EP rank; never rewritten by scale-down.
-        ep_rank = get_ep_group().rank_in_group
+        super()._redistribute_experts(dead_ep_ranks)
 
-        p2l_before = p2l.cpu().clone()
-        mark_dead_expert_slots_inplace(p2l, dead_ep_ranks, num_local_experts)
-        redistribute_expert_placement(p2l, num_logical, num_local_experts)
-        rebuild_logical_expert_maps(p2l, l2p, lrc)
+        eplb_model_state = self._eplb_model_state()
         # Propagate the new placement into the Ascend routing tables (in-place,
         # so captured graphs keep pointing at valid storage).
         refresh_model_routing_tables(eplb_model_state)
@@ -191,6 +162,9 @@ class WorkerSentinel(GPUWorkerSentinel):
         # renumber the kernel-facing values in place after the refresh. The
         # dead set is cumulative (accumulated across recovery rounds), so
         # derive it from the manager's mask rather than this round's ranks.
+        p2l = eplb_model_state.physical_to_logical_map
+        ep_world_size = get_ep_group().world_size
+        num_local_experts = p2l.shape[1] // ep_world_size
         active_mask = get_ep_all2all_manager().query_active_mask()
         dead_ranks = {rank for rank, is_dead in enumerate(active_mask.tolist()) if is_dead}
         orig_to_dense_rank = build_orig_to_dense_rank_table(ep_world_size, dead_ranks)
@@ -199,22 +173,6 @@ class WorkerSentinel(GPUWorkerSentinel):
             if routing_table is not None:
                 densify_routing_table_physical_ids(routing_table, orig_to_dense_rank, num_local_experts)
 
-        reload_plan = build_local_reload_plan(p2l_before, p2l.cpu(), ep_rank, num_local_experts)
-        if reload_plan:
-            reload_experts_from_disk(
-                self.worker.model_runner.model,
-                self.worker.vllm_config,
-                reload_plan,
-            )
-
         # Shrink the physical-expert width to the surviving slots; this also
         # flips elastic_info into scaling-down mode.
         get_ep_all2all_manager().set_num_physical_experts((ep_world_size - len(dead_ep_ranks)) * num_local_experts)
-
-        logger.info(
-            "[FT] Expert redistribution: num_logical=%d, ep_world_size=%d, num_local_experts=%d, reloaded_slots=%s",
-            num_logical,
-            ep_world_size,
-            num_local_experts,
-            sum(len(v) for v in reload_plan.values()),
-        )

--- a/vllm_ascend/worker/sentinel/npu_worker_sentinel.py
+++ b/vllm_ascend/worker/sentinel/npu_worker_sentinel.py
@@ -4,15 +4,27 @@ from typing import TYPE_CHECKING
 
 import torch
 import torch_npu
-from vllm.distributed import (
-    get_ep_group,
-)
+from vllm.logger import logger
+from vllm.model_executor.layers.fused_moe.all2all_utils import get_ep_all2all_manager
 from vllm.v1.fault_tolerance.utils import FaultToleranceRequest
 from vllm.v1.worker.sentinel.gpu_worker_sentinel import (
     WorkerSentinel as GPUWorkerSentinel,
 )
 
 from vllm_ascend.platform import NPUPlatform
+from vllm_ascend.ascend_config import get_ascend_config
+from vllm_ascend.distributed.eplb.state import refresh_model_routing_tables
+from vllm_ascend.distributed.parallel_state import get_mc2_group
+from vllm_ascend.worker.sentinel.eplb_redistribute import (
+    build_local_reload_plan,
+    check_redundancy_sufficient,
+    compute_dead_ep_ranks,
+    densify_routing_table_physical_ids,
+    mark_dead_expert_slots_inplace,
+    rebuild_logical_expert_maps,
+    redistribute_expert_placement,
+    reload_experts_from_disk,
+)
 
 if TYPE_CHECKING:
     from vllm.v1.worker.gpu_worker import Worker
@@ -22,7 +34,8 @@ class WorkerSentinel(GPUWorkerSentinel):
     """Per-worker sentinel for fault tolerance on Ascend NPU.
 
     Handles commands dispatched from EngineCoreSentinel via collective_rpc,
-    including device restart and DP group re-initialization on retry.
+    including device restart and DP group re-initialization on retry, and
+    MC2 elastic_info masking + expert redistribution on scale_down.
     """
 
     def __init__(self, worker: "Worker", device: torch.device):
@@ -33,13 +46,14 @@ class WorkerSentinel(GPUWorkerSentinel):
         self.data_parallel_master_ip = worker.parallel_config.data_parallel_master_ip
 
     def query_mask(self, ft_request: FaultToleranceRequest) -> dict:
-        """Query mask for fault tolerance.
+        """Report the dead-rank mask (upstream convention: 0=live, 1=dead).
 
-        Ascend's all2all operator does not currently support querying mask.
-        Returns all-zero mask for now; will be updated once the operator
-        supports it.
+        Pure CPU read: on NPU the mask is only ever written host-side during
+        FT recovery, so on a first fault this is all zeros and the
+        orchestrator's retry-vs-scale_down decision must come from its own
+        cluster knowledge.
         """
-        return {"mask": get_ep_group().world_size * [0]}
+        return {"mask": get_ep_all2all_manager().query_active_mask().tolist()}
 
     def reset_device(self) -> None:
         NPUPlatform.set_device(self.device)
@@ -54,3 +68,141 @@ class WorkerSentinel(GPUWorkerSentinel):
         # state, re-initialize the DP group).
         self.reset_device()
         super().retry(ft_request)
+
+    def scale_down(self, ft_request: FaultToleranceRequest):
+        """Scale down over the surviving DP ranks, mirroring the upstream
+        GPUWorkerSentinel.scale_down structure."""
+        self._validate_scale_down_preconditions()
+        params = ft_request.params
+        tp_size = self.worker.parallel_config.tensor_parallel_size
+        dead_ep_ranks = compute_dead_ep_ranks(params["dead_dp_ranks"], tp_size)
+        eplb_model_state = self._eplb_model_state()
+        ep_world_size = get_mc2_group().world_size
+
+        check_redundancy_sufficient(
+            eplb_model_state.logical_replica_count.shape[1],
+            eplb_model_state.physical_to_logical_map.shape[1] // ep_world_size,
+            ep_world_size,
+            dead_ep_ranks,
+        )
+        # Suppress EPLB before retry so the base flow skips the EPLB group
+        # reinit; the expert placement is fixed by the redistribution below.
+        self.worker.model_runner.eep_eplb_suppressed = True
+        # Device reset + worker-state cleanup + DP gloo group rebuilt with
+        # the densified membership; the base retry also replays the
+        # cumulative dead set into the elastic_info mask via update_mask.
+        self.retry(ft_request)
+
+        self._redistribute_experts(dead_ep_ranks)
+
+        # Verify the redistributed model is runnable before reporting healthy.
+        self.worker.execute_dummy_batch()
+        torch.npu.synchronize()
+
+        logger.info(
+            "[FT] Worker scale_down complete: dp_group_size=%d, "
+            "dp_group_rank=%d, dead_ep_ranks=%s, eplb_suppressed=True",
+            params["dp_group_size"],
+            params["dp_group_rank"],
+            sorted(dead_ep_ranks),
+        )
+
+    def _validate_scale_down_preconditions(self) -> None:
+        if not self.worker.use_v2_model_runner:
+            raise ValueError("[FT] scale_down on Ascend NPU requires the v2 model runner.")
+        model_runner = self.worker.model_runner
+        eplb_config = self.worker.parallel_config.eplb_config
+        if model_runner.eplb_state is None or eplb_config.num_redundant_experts <= 0:
+            raise ValueError(
+                "[FT] scale_down requires EPLB with num_redundant_experts > 0 to re-host the dead rank's experts."
+            )
+        ascend_config = get_ascend_config()
+        if ascend_config.enable_fused_mc2:
+            raise ValueError(
+                "[FT] scale_down is not supported with enable_fused_mc2: the "
+                "fused dispatch_ffn_combine operators take no elastic_info."
+            )
+        if ascend_config.enable_mc2_hierarchy_comm:
+            raise ValueError(
+                "[FT] scale_down (elastic_info) is mutually exclusive with mc2 hierarchy comm (comm_alg='hierarchy')."
+            )
+        if not hasattr(torch_npu, "npu_moe_distribute_dispatch_v2"):
+            raise ValueError(
+                "[FT] scale_down requires npu_moe_distribute_dispatch_v2 "
+                "(aclnn V3+); please upgrade the CANN/torch_npu version."
+            )
+
+    def _redistribute_experts(self, dead_ep_ranks: set[int]) -> None:
+        """One-shot expert redistribution after scale-down.
+
+        Cannot be inherited from the upstream sentinel: the upstream version
+        applies the new placement via `rebuild_model_expert_maps` (GPU expert
+        maps), reloads weights in the GPU runtime layout, and calls
+        `sync_num_dispatchers_for_nixl_ep`. On Ascend the placement must
+        instead be propagated into the Ascend routing tables
+        (`refresh_model_routing_tables`), reassigned weights must be rewritten
+        in the NPU runtime layout (transpose / NZ cast / per-slot lists — the
+        `reload_experts_from_disk` in eplb_redistribute.py), and the MC2
+        expert width must be shrunk via `set_num_physical_experts`. Only the
+        pure placement math is shared (imported from upstream); the apply
+        steps are platform-specific.
+
+        Deterministic, no cross-rank communication: every surviving rank
+        computes bit-identical placements from the shared EPLB model state.
+        The EPLB maps keep the upstream slot model (full width, original
+        physical ids); the densified rank numbering lives only in the
+        elastic_info tensor maintained by the all2all manager.
+        """
+        eplb_model_state = self._eplb_model_state()
+        p2l = eplb_model_state.physical_to_logical_map
+        l2p = eplb_model_state.logical_to_physical_map
+        lrc = eplb_model_state.logical_replica_count
+        num_logical = lrc.shape[1]
+        ep_world_size = get_mc2_group().world_size
+        num_local_experts = p2l.shape[1] // ep_world_size
+        # The original EP rank; never rewritten by scale-down.
+        ep_rank = get_mc2_group().rank_in_group
+
+        p2l_before = p2l.cpu().clone()
+        mark_dead_expert_slots_inplace(p2l, dead_ep_ranks, num_local_experts)
+        redistribute_expert_placement(p2l, num_logical, num_local_experts)
+        rebuild_logical_expert_maps(p2l, l2p, lrc)
+        # Propagate the new placement into the Ascend routing tables; the
+        # table shape is unchanged so this copy_'s into the storage captured
+        # by graphs.
+        refresh_model_routing_tables(eplb_model_state)
+
+        # The MC2 kernels require the densified physical-id space while scaled
+        # down (dispatch routes via table2[expert_id // num_local]; combine
+        # silently drops ids >= the shrunk physical expert count). The refresh
+        # above rebuilds the tables with original full-width ids, so renumber
+        # the kernel-facing values in place. Original ids only route correctly
+        # when the dead ranks are a suffix; a dead rank in the middle would
+        # misroute tokens or crash the kernel on a -1 rank lookup.
+        orig_to_dense_rank = get_ep_all2all_manager().to_densified_rank_table()
+        for layer in eplb_model_state.model.moe_layers:
+            routing_table = getattr(getattr(layer, "eplb_state", None), "expert_replica_routing_table", None)
+            if routing_table is not None:
+                densify_routing_table_physical_ids(routing_table, orig_to_dense_rank, num_local_experts)
+
+        reload_plan = build_local_reload_plan(p2l_before, p2l.cpu(), ep_rank, num_local_experts)
+        if reload_plan:
+            reload_experts_from_disk(
+                self.worker.model_runner.model,
+                self.worker.vllm_config,
+                reload_plan,
+            )
+
+        # Shrink the physical-expert width the MC2 kernels see so it matches
+        # the surviving slots; this also flips elastic_info into scaling-down
+        # mode (the mask replayed during retry kept the flag at 0 until the
+        # new width was known).
+        get_ep_all2all_manager().set_num_physical_experts((ep_world_size - len(dead_ep_ranks)) * num_local_experts)
+
+        logger.info(
+            "[FT] Expert redistribution: num_logical=%d, ep_world_size=%d, num_local_experts=%d, reloaded_slots=%s",
+            num_logical,
+            ep_world_size,
+            num_local_experts,
+            sum(len(v) for v in reload_plan.values()),
+        )

--- a/vllm_ascend/worker/worker.py
+++ b/vllm_ascend/worker/worker.py
@@ -881,6 +881,9 @@ class NPUWorker(WorkerBase):
         with context, set_current_vllm_config(self.vllm_config):
             self.model_runner.load_model()
 
+        if self.worker_sentinel is not None and self.use_v2_model_runner:
+            self.worker_sentinel.init_num_local_experts()
+
         if self.vllm_config.weight_transfer_config is not None:
             from vllm.distributed.weight_transfer.factory import (
                 WeightTransferEngineFactory,

--- a/vllm_ascend/worker/worker.py
+++ b/vllm_ascend/worker/worker.py
@@ -21,6 +21,7 @@ import copy
 import gc
 import inspect
 import logging
+import os
 from types import NoneType
 from typing import Any
 
@@ -400,7 +401,21 @@ class NPUWorker(WorkerBase):
         if self.parallel_config.enable_fault_tolerance:
             import torch_npu
 
-            torch_npu.npu.set_op_timeout_ms(get_ascend_config().ft_communication_ops_abort_timeout_ms)
+            abort_timeout = get_ascend_config().ft_communication_abort_timeout
+            if abort_timeout > 0:
+                # User-provided HCCL timeouts win; otherwise derive them
+                # from the config value. HCCL_EVENT_TIMEOUT must be
+                # greater than HCCL_EXEC_TIMEOUT, hence EXEC defaults to
+                # abort_timeout - 1.
+                os.environ.setdefault("HCCL_EVENT_TIMEOUT", str(abort_timeout))
+                os.environ.setdefault("HCCL_EXEC_TIMEOUT", str(abort_timeout - 1))
+                if int(os.environ["HCCL_EVENT_TIMEOUT"]) <= int(os.environ["HCCL_EXEC_TIMEOUT"]):
+                    raise ValueError(
+                        f"HCCL_EVENT_TIMEOUT ({os.environ['HCCL_EVENT_TIMEOUT']}) "
+                        "must be greater than HCCL_EXEC_TIMEOUT "
+                        f"({os.environ['HCCL_EXEC_TIMEOUT']})"
+                    )
+                torch_npu.npu.set_op_timeout_ms(abort_timeout * 1000)
         if (
             parallel_config.distributed_executor_backend not in ("ray", "external_launcher")
             and parallel_config.data_parallel_backend != "ray"

--- a/vllm_ascend/worker/worker.py
+++ b/vllm_ascend/worker/worker.py
@@ -400,8 +400,7 @@ class NPUWorker(WorkerBase):
         if self.parallel_config.enable_fault_tolerance:
             import torch_npu
 
-            torch_npu.npu.set_op_timeout_ms(
-                get_ascend_config().ft_communication_ops_abort_timeout_ms)
+            torch_npu.npu.set_op_timeout_ms(get_ascend_config().ft_communication_ops_abort_timeout_ms)
         if (
             parallel_config.distributed_executor_backend not in ("ray", "external_launcher")
             and parallel_config.data_parallel_backend != "ray"

--- a/vllm_ascend/worker/worker.py
+++ b/vllm_ascend/worker/worker.py
@@ -40,8 +40,7 @@ from vllm.distributed.kv_transfer import (
     has_kv_transfer_group,
 )
 from vllm.distributed.kv_transfer.kv_connector.v1.base import KVConnectorHandshakeMetadata
-from vllm.distributed.parallel_state import Handle, _groups, get_pp_group, get_tp_group
-from vllm.distributed.utils import get_cpu_distributed_timeout_or_none
+from vllm.distributed.parallel_state import Handle, get_pp_group, get_tp_group
 from vllm.logger import logger
 from vllm.lora.request import LoRARequest
 from vllm.platforms import current_platform
@@ -1256,20 +1255,6 @@ class NPUWorker(WorkerBase):
         )
         init_ascend_model_parallel(self.parallel_config)
         ensure_ec_transfer_initialized(self.vllm_config)
-        self._apply_cpu_distributed_timeout()
-
-    def _apply_cpu_distributed_timeout(self) -> None:
-        # Apply the user-configured CPU (gloo) distributed timeout only after
-        # all process groups exist: passing it at group creation would make the
-        # group-creation barrier itself abort on slow multi-rank startup.
-        timeout = get_cpu_distributed_timeout_or_none()
-        if timeout is None:
-            return
-        for group_ref in _groups.values():
-            group = group_ref()
-            cpu_group = getattr(group, "cpu_group", None) if group is not None else None
-            if cpu_group is not None:
-                cpu_group.set_timeout(timeout)
 
     def get_supported_pooling_tasks(self):
         return self.model_runner.get_supported_pooling_tasks()

--- a/vllm_ascend/worker/worker.py
+++ b/vllm_ascend/worker/worker.py
@@ -407,7 +407,12 @@ class NPUWorker(WorkerBase):
                     "Fault tolerance with Model Runner V2 does not support the "
                     "task queue (TASK_QUEUE_ENABLE); forcing TASK_QUEUE_ENABLE=0."
                 )
-            import torch_npu
+
+            if parallel_config.tensor_parallel_size > 1:
+                # TP>1 relies on collective HCCL comms; disable HCCL's async
+                # error handling so it cannot abort the process out-of-band
+                # during fault-tolerance recovery.
+                os.environ["HCCL_ASYNC_ERROR_HANDLING"] = "0"
 
             abort_timeout = get_ascend_config().ft_communication_abort_timeout
             if abort_timeout > 0:
@@ -423,7 +428,7 @@ class NPUWorker(WorkerBase):
                         "must be greater than HCCL_EXEC_TIMEOUT "
                         f"({os.environ['HCCL_EXEC_TIMEOUT']})"
                     )
-                torch_npu.npu.set_op_timeout_ms(abort_timeout * 1000)
+                torch.npu.set_op_timeout_ms(abort_timeout * 1000)
         if (
             parallel_config.distributed_executor_backend not in ("ray", "external_launcher")
             and parallel_config.data_parallel_backend != "ray"

--- a/vllm_ascend/worker/worker.py
+++ b/vllm_ascend/worker/worker.py
@@ -399,6 +399,14 @@ class NPUWorker(WorkerBase):
         # that each DP group binds to a distinct set of NPUs.
         parallel_config = self.parallel_config
         if self.parallel_config.enable_fault_tolerance:
+            if self.use_v2_model_runner:
+                # Model Runner V2 + fault tolerance task queue
+                # (TASK_QUEUE_ENABLE) hangs abnormally; force it off.
+                os.environ["TASK_QUEUE_ENABLE"] = "0"
+                logger.warning(
+                    "Fault tolerance with Model Runner V2 does not support the "
+                    "task queue (TASK_QUEUE_ENABLE); forcing TASK_QUEUE_ENABLE=0."
+                )
             import torch_npu
 
             abort_timeout = get_ascend_config().ft_communication_abort_timeout

--- a/vllm_ascend/worker/worker.py
+++ b/vllm_ascend/worker/worker.py
@@ -97,6 +97,7 @@ from vllm_ascend.utils import (
     vllm_version_is,
 )
 from vllm_ascend.worker.model_runner_v1 import NPUModelRunner
+from vllm_ascend.worker.sentinel.npu_worker_sentinel import WorkerSentinel
 
 torch._dynamo.trace_rules.clear_lru_cache()  # noqa: E402
 from torch._dynamo.variables import TorchInGraphFunctionVariable  # noqa: E402
@@ -189,6 +190,8 @@ class NPUWorker(WorkerBase):
         if "UnquantizedLinearMethod" in WEIGHT_LOADER_V2_SUPPORTED:
             WEIGHT_LOADER_V2_SUPPORTED.remove("UnquantizedLinearMethod")
 
+        self.worker_sentinel: WorkerSentinel | None = None
+
         self.use_v2_model_runner = self.vllm_config.use_v2_model_runner
         self._pp_send_work: list[Handle] = []
 
@@ -209,6 +212,10 @@ class NPUWorker(WorkerBase):
 
             signal.signal(signal.SIGTERM, signal_handler)
             signal.signal(signal.SIGINT, signal_handler)
+
+    def handle_ft_command(self, ft_request):
+        assert self.worker_sentinel is not None
+        return self.worker_sentinel.handle_command(ft_request)
 
     def uninstall_static_kernel(self):
         import fcntl
@@ -390,6 +397,10 @@ class NPUWorker(WorkerBase):
         # shift self.local_rank by dp_local_rank * tp_pp_world_size so
         # that each DP group binds to a distinct set of NPUs.
         parallel_config = self.parallel_config
+        if self.parallel_config.enable_fault_tolerance:
+            import torch_npu
+
+            torch_npu.npu.set_op_timeout_ms(get_ascend_config().operator_timeout_ms)
         if (
             parallel_config.distributed_executor_backend not in ("ray", "external_launcher")
             and parallel_config.data_parallel_backend != "ray"
@@ -481,6 +492,8 @@ class NPUWorker(WorkerBase):
 
         # Initialize the distributed environment.
         self._init_worker_distributed_environment()
+        if self.parallel_config.enable_fault_tolerance:
+            self.worker_sentinel = WorkerSentinel(worker=self, device=device)
         # Set random seed.
         set_random_seed(self.model_config.seed)
         # Initialize device properties used by triton kernels.

--- a/vllm_ascend/worker/worker.py
+++ b/vllm_ascend/worker/worker.py
@@ -99,7 +99,7 @@ from vllm_ascend.utils import (
     vllm_version_is,
 )
 from vllm_ascend.worker.model_runner_v1 import NPUModelRunner
-from vllm_ascend.worker.sentinel.npu_worker_sentinel import WorkerSentinel
+from vllm_ascend.worker.sentinel.npu_worker_sentinel import WorkerSentinel, fault_barrier_wrapper
 
 torch._dynamo.trace_rules.clear_lru_cache()  # noqa: E402
 from torch._dynamo.variables import TorchInGraphFunctionVariable  # noqa: E402
@@ -789,6 +789,7 @@ class NPUWorker(WorkerBase):
             self.torch_allocated / GiB_bytes,
         )
 
+    @fault_barrier_wrapper
     def execute_model(
         self,
         scheduler_output: "SchedulerOutput",
@@ -858,6 +859,7 @@ class NPUWorker(WorkerBase):
         return output
 
     @torch.inference_mode()
+    @fault_barrier_wrapper
     def sample_tokens(self, grammar_output: "GrammarOutput") -> ModelRunnerOutput | AsyncModelRunnerOutput:
         output = self.model_runner.sample_tokens(grammar_output)
         _attach_profiling_chunk_execution_time(

--- a/vllm_ascend/worker/worker.py
+++ b/vllm_ascend/worker/worker.py
@@ -40,7 +40,8 @@ from vllm.distributed.kv_transfer import (
     has_kv_transfer_group,
 )
 from vllm.distributed.kv_transfer.kv_connector.v1.base import KVConnectorHandshakeMetadata
-from vllm.distributed.parallel_state import Handle, get_pp_group, get_tp_group
+from vllm.distributed.parallel_state import Handle, _groups, get_pp_group, get_tp_group
+from vllm.distributed.utils import get_cpu_distributed_timeout_or_none
 from vllm.logger import logger
 from vllm.lora.request import LoRARequest
 from vllm.platforms import current_platform
@@ -1253,6 +1254,20 @@ class NPUWorker(WorkerBase):
         )
         init_ascend_model_parallel(self.parallel_config)
         ensure_ec_transfer_initialized(self.vllm_config)
+        self._apply_cpu_distributed_timeout()
+
+    def _apply_cpu_distributed_timeout(self) -> None:
+        # Apply the user-configured CPU (gloo) distributed timeout only after
+        # all process groups exist: passing it at group creation would make the
+        # group-creation barrier itself abort on slow multi-rank startup.
+        timeout = get_cpu_distributed_timeout_or_none()
+        if timeout is None:
+            return
+        for group_ref in _groups.values():
+            group = group_ref()
+            cpu_group = getattr(group, "cpu_group", None) if group is not None else None
+            if cpu_group is not None:
+                cpu_group.set_timeout(timeout)
 
     def get_supported_pooling_tasks(self):
         return self.model_runner.get_supported_pooling_tasks()

--- a/vllm_ascend/worker/worker.py
+++ b/vllm_ascend/worker/worker.py
@@ -400,7 +400,8 @@ class NPUWorker(WorkerBase):
         if self.parallel_config.enable_fault_tolerance:
             import torch_npu
 
-            torch_npu.npu.set_op_timeout_ms(get_ascend_config().operator_timeout_ms)
+            torch_npu.npu.set_op_timeout_ms(
+                get_ascend_config().ft_communication_ops_abort_timeout_ms)
         if (
             parallel_config.distributed_executor_backend not in ("ray", "external_launcher")
             and parallel_config.data_parallel_backend != "ray"


### PR DESCRIPTION
### What this PR does / why we need it?

In DP+EP (Data Parallelism + Expert Parallelism) MoE deployments, a dead DP rank
makes the EP all2all on surviving ranks block indefinitely, hanging the whole
cluster. Upstream vLLM introduced a fault-tolerance framework
(vllm-project/vllm#44428) that detects the fault, aborts in-flight requests and
lets an external orchestrator trigger coordinated recovery, but Ascend NPU needs
its own backend.

This PR provides the complete Ascend NPU fault-tolerance backend in two layers:

1. **Retry-based recovery for transient faults** (foundation). Reuses the
   upstream `GPUWorkerSentinel` flow (clean worker state + DP-group
   re-initialization on retry) and adds the NPU-specific pieces upstream cannot
   cover: aborts hung NPU communication ops via `torch.npu.npu.set_op_timeout_ms`
   (new `ft_communication_abort_timeout` ascend config) and applies the CPU
   distributed timeout to DP-sync process groups, so peer failures surface as
   exceptions instead of hanging.

2. **Scale-down recovery for MC2** (this PR's focus). When a rank is confirmed
   dead, retry alone cannot recover - survivors keep routing MoE tokens to the
   dead EP rank and the all2all keeps failing. This mirrors the upstream GPU
   `scale_down` flow while adapting the mask, routing and weight layers to
   Ascend's MC2 all2all backend:
   - `npu_communicator`: turns the no-op MC2 all2all manager into the owner of
     the dead-rank mask, encoded as the MC2 `elastic_info` tensor (flag, dense EP
     size, shared/physical expert counts plus orig-to-dense and dense-to-orig rank
     tables), rebuilt in place so captured graphs stay valid.
   - `npu_worker_sentinel`: adds `scale_down` with precondition validation (v2
     model runner, EPLB redundancy, no `fused_mc2`/hierarchy comm, `dispatch_v2`),
     dead EP-rank masking, expert redistribution with routing-table refresh and
     densification, selective on-disk expert weight reload, MC2 physical-expert
     width shrink, and a dummy-batch runnability check.
   - `eplb_redistribute`: NPU expert redistribution + weight reload mirroring
     `process_weights_after_loading` per slot (transpose, FRACTAL_NZ cast, quant
     scales) for unquantized and W8A8 dynamic schemes, plus
     `densify_routing_table_physical_ids`.
   - `token_dispatcher` / `patch_distributed`: pass `elastic_info` to MC2
     dispatch/combine and carry `dead_dp_ranks` so the DP allreduce neutralizes
     dead columns.
   - Clears a poisoned NPU stream on the first device error
     (`fault_barrier_wrapper`) so teardown cannot crash the worker before
     recovery runs.

### Does this PR introduce _any_ user-facing change?

Yes, when `--enable-fault-tolerance` is used on Ascend NPU:

- A new ascend config `ft_communication_abort_timeout` controls how long a hung
  NPU operator (e.g. a communication op) is allowed to run before being aborted
  with a timeout exception. When `> 0`, it derives `HCCL_EVENT_TIMEOUT` /
  `HCCL_EXEC_TIMEOUT` and calls `torch.npu.set_op_timeout_ms` (default `0`,
  disabled).
- Scale-down recovery now supports MC2 deployments and requires EPLB with
  `num_redundant_experts > 0` and the v2 model runner.
- No API/CLI interface changes beyond the upstream FT flags.

Example startup command for a 4-NPU DP=4 Qwen3-30B-A3B-W8A8 deployment (rank 0):

```bash
# Rank 0
ASCEND_RT_VISIBLE_DEVICES=0 \
HCCL_BUFFSIZE=2048 \
HCCL_EXEC_TIMEOUT=1 \
vllm serve /home/xxxxx/Qwen3-30B-A3B-W8A8/ \
  --tensor-parallel-size 1 \
  --data-parallel-size 4 \
  --trust-remote-code \
  --gpu-memory-utilization 0.9 \
  --max-model-len 1024 \
  --enable-expert-parallel \
  --quantization ascend \
  --max-num-batched-tokens 32 \
  --cpu-distributed-timeout-seconds 30 \
  --enable-fault-tolerance \
  --enable-eplb \
  --compilation-config '{"cudagraph_mode":"FULL_AND_PIECEWISE","cudagraph_capture_sizes":[4,8,12,16,20,24,28,32]}' \
  --fault-tolerance-config '{"engine_recovery_timeout_sec":32000}' \
  --eplb-config '{"num_redundant_experts":64, "use_async": false}' \
  --data-parallel-rank 0 \
  --port 8111 \
  --additional-config '{"ft_communication_abort_timeout": 30}' 

# Ranks 1/2/3 use the same command with:
#   ASCEND_RT_VISIBLE_DEVICES={1,2,3}
#   --data-parallel-rank {1,2,3}
#   --port {8112,8113,8114}
```

### How was this patch tested?
Added DP=4 end-to-end coverage in tests/e2e/pull_request/four_card/fault_tolerance/test_fault_tolerance_e2e.py:
-  test_injected_fault_retry_recovers_all_ranks — injected fault on rank 3 drives all 4 engines UNHEALTHY; retry restores all ranks to HEALTHY and factual-prompt serving resumes.
- test_scale_down_removes_dead_rank_and_recovers — SIGKILL of rank 3's worker marks survivors UNHEALTHY and the victim DEAD (DEAD rejects retry); scale_down re-hosts the dead rank's EPLB experts on the survivors, and all survivors return to HEALTHY and answer factual prompts correctly.

vLLM main: https://github.com/vllm-project/vllm/commit/b2f685834a6456197e7033966fdef52a23f1abcd


- vLLM main: https://github.com/vllm-project/vllm/commit/84030bbe3d74d99bad477a3d2e37a973ccd8865c
