### PR TITLE
[0.27.1][BugFix] Fix kimi k3 dspark kv grouping when --no-enable-prefix-caching

### DIFF
--- a/tests/ut/patch/platform/test_prefix_cache_cp_patches.py
+++ b/tests/ut/patch/platform/test_prefix_cache_cp_patches.py
@@ -382,6 +382,37 @@ def test_kimi_k3_gqa_mixed_groups_use_expected_physical_layout(monkeypatch) -> N
     assert sum(tensor.size for tensor in tensors) == available_memory
 
 
+def test_kimi_k3_none_mamba_uses_separate_scheduler_block_size() -> None:
+    page_size = 940032
+    specs = _make_kimi_k3_dspark_kv_cache_specs(block_size=768, page_size=page_size)
+    for name, spec in list(specs.items()):
+        if isinstance(spec, MambaSpec):
+            specs[name] = replace(
+                spec,
+                block_size=200000,
+                shapes=((6, 4608), (12, 128, 128)),
+                mamba_cache_mode="none",
+                num_speculative_blocks=3,
+            )
+        elif name.startswith("model.layers."):
+            specs[name] = replace(spec, num_kv_heads=2)
+    groups = _get_kimi_k3_dspark_mixed_kv_cache_groups(specs)
+    assert groups is not None
+    assert [len(g.layer_names) for g in groups] == [29, 23, 23, 23]
+    assert [g.kv_cache_spec.block_size for g in groups] == [768, 200000, 200000, 200000]
+    config = _make_vllm_config(enable_prefix_caching=False, dcp=1, block_size=768)
+    config.cache_config.mamba_cache_mode = "none"
+    assert {g.kv_cache_spec.max_num_blocks_per_req(config, 200000) for g in groups[1:]} == {4}
+
+
+def test_kimi_k3_mixed_attention_still_requires_same_block_size() -> None:
+    specs = _make_kimi_k3_dspark_kv_cache_specs()
+    assert _get_kimi_k3_dspark_mixed_kv_cache_groups(specs) is not None
+    name = "model.layers.93.self_attn.attn"
+    specs[name] = replace(specs[name], block_size=192)
+    assert _get_kimi_k3_dspark_mixed_kv_cache_groups(specs) is None
+
+
 def test_kimi_k3_gqa_mixed_grouping_falls_back_on_unrecognized_layer() -> None:
     specs = _make_kimi_k3_dspark_kv_cache_specs()
     specs["unrecognized.layer"] = next(iter(specs.values()))

--- a/vllm_ascend/patch/platform/patch_kv_cache_utils.py
+++ b/vllm_ascend/patch/platform/patch_kv_cache_utils.py
@@ -126,8 +126,11 @@ def _get_kimi_k3_dspark_mixed_kv_cache_groups(
     ):
         return None
 
-    all_specs = [*target_attention_specs.values(), *draft_attention_specs.values(), *mamba_specs.values()]
-    if len({spec.block_size for spec in all_specs}) != 1 or len({spec.page_size_bytes for spec in all_specs}) != 1:
+    attention_specs = [*target_attention_specs.values(), *draft_attention_specs.values()]
+    all_specs = [*attention_specs, *mamba_specs.values()]
+    # Only attention layers share a scheduler block table. Mamba keeps its
+    # own groups and may use max_model_len as block_size when cache_mode=none.
+    if len({spec.block_size for spec in attention_specs}) != 1 or len({spec.page_size_bytes for spec in all_specs}) != 1:
         return None
 
     first_mamba_spec = next(iter(mamba_specs.values()))

--- a/vllm_ascend/patch/platform/patch_kv_cache_utils.py
+++ b/vllm_ascend/patch/platform/patch_kv_cache_utils.py
@@ -130,7 +130,10 @@ def _get_kimi_k3_dspark_mixed_kv_cache_groups(
     all_specs = [*attention_specs, *mamba_specs.values()]
     # Only attention layers share a scheduler block table. Mamba keeps its
     # own groups and may use max_model_len as block_size when cache_mode=none.
-    if len({spec.block_size for spec in attention_specs}) != 1 or len({spec.page_size_bytes for spec in all_specs}) != 1:
+    if (
+        len({spec.block_size for spec in attention_specs}) != 1
+        or len({spec.page_size_bytes for spec in all_specs}) != 1
+    ):
         return None
 
     first_mamba_spec = next(iter(mamba_specs.values()))


### PR DESCRIPTION
### What this PR does / why we need it?
This PR is cherry-picked from #16146.

This PR aims to fix kimi k3 dspark kv grouping when not enabling prefix cache. The problem is that patch_mamba_config.py aligns ssm to k, which is from only target model without draft model. Since kimi k3 dspark may use gqa, kv cache layout thus can be problematic. That is, when aligning, mamba considers mla without gqa, so finally v in gqa can overlap ssm in mamba. Example is shown below:

```
Mamba: |   Conv   |               SSM               | Padding |
MLA:   | Padding  |            K(latent)            |  RoPE   |
GQA:   |    Padding     |        K         |        V         |
```

When enabling prefix cache, kimi k3 has its own kv grouping logic where no tensor is shared by mamba and gqa. So we just fall back into it.

### Does this PR introduce _any_ user-facing change?
N/A

### How was this patch tested?
by ci

- vLLM main: https://github.com/vllm-project/vllm/commit/ba07e4a48fc951300d97eb506217dd530583dea3
