### PR TITLE
[CI] Test A2 HK runner label

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -33,3 +33,4 @@ self-hosted-runner:
     - linux-aarch64-a2b3-4
     - linux-aarch64-a2b3-8
     - linux-aarch64-a2b1-8
+    - linux-aarch64-a2-2-hk-001

--- a/.github/workflows/configs/nightly_config.yaml
+++ b/.github/workflows/configs/nightly_config.yaml
@@ -37,7 +37,7 @@ a2:
         os: linux-aarch64-a2b3-2
         config_file_path: Qwen3.8-27B-w8a8-A2.yaml
       - name: rejection-sample
-        os: linux-aarch64-a2b3-1
+        os: linux-aarch64-a2-2-hk-001
         tests: tests/e2e/nightly/single_node/ops/singlecard_ops/triton/test_rejection_sample.py
   multi_node:
     test_config:

--- a/.github/workflows/scripts/runner_label.json
+++ b/.github/workflows/scripts/runner_label.json
@@ -94,6 +94,12 @@
         "image_tag": "9.1.0-910b-ubuntu22.04-py3.12",
         "csrc_cache_target": "a2-arm64-ubuntu"
     },
+    "linux-aarch64-a2-2-hk-001": {
+        "chip": "a2",
+        "npu_num": 2,
+        "image_tag": "9.1.0-910b-ubuntu22.04-py3.12",
+        "csrc_cache_target": "a2-arm64-ubuntu"
+    },
     "linux-aarch64-a2b3-4": {
         "chip": "a2",
         "npu_num": 4,


### PR DESCRIPTION
### What this PR does / why we need it?

Temporarily validates the new `linux-aarch64-a2-2-hk-001` A2 runner label with the model-free `rejection-sample` nightly test.

This PR:

- registers the new runner as an A2 two-card target in `runner_label.json`, using the existing A2 image and csrc cache target;
- adds the label to actionlint's self-hosted runner inventory;
- routes only the A2 nightly `rejection-sample` test to the new runner.

The test exercises runner scheduling, the container environment, CANN/NPU availability, and Triton operator execution without requiring a model or tokenizer cache. The routing change is intended only for temporary runner validation.

### Does this PR introduce _any_ user-facing change?

No. This only changes CI runner metadata and test routing.

### How was this patch tested?

- Parsed `runner_label.json` and the modified YAML files in the repository virtual environment.
- Ran `resolve_nightly_tests.py --mode=matrix` and confirmed that `rejection-sample` resolves to `linux-aarch64-a2-2-hk-001`.
- Ran `resolve_nightly_tests.py --mode=dispatch` with the PR matrix and `TEST_CASES=rejection-sample`; it emitted `dispatch_a2=true` and all other hardware dispatch flags as `false`.
- Ran `select_tests.py --runner-label-override linux-aarch64-a2-2-hk-001` and confirmed `npu_type=a2`, `num_npus=2`, the A2 image tag, and the A2 csrc cache target.
- Ran `git diff --check`.
- Ran `bash format.sh ci`: all formatting and lint hooks passed except the local gitleaks hook. Its repository fallback requires a Linux executable and cannot run in the local macOS arm64 environment; this PR changes only runner metadata and a runner-label string.
- NPU execution is intentionally pending and can be triggered manually with `/nightly rejection-sample`.

- vLLM main: https://github.com/vllm-project/vllm/commit/b2f685834a6456197e7033966fdef52a23f1abcd
