### PR TITLE
[BugFix][P/D] Fix garbled output in PD disaggregation with DCP + PP parallelism

### DIFF
--- a/vllm_ascend/distributed/kv_transfer/kv_p2p/mooncake_connector.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_p2p/mooncake_connector.py
@@ -3014,7 +3014,7 @@ class MooncakeConnectorWorker:
                     kv_head_groups.append(tuple([kv_head_ids_]))
                 return kv_head_groups
 
-        def get_cp_group_meta(tp_size, pcp_size, dcp_size, port_base):
+        def get_cp_group_meta(tp_size, pcp_size, dcp_size, port_base, pp_size=1):
             # key is kv_head_group, value is cp_groups and which cp_groups to select
             cp_group_meta: dict = {}
             kv_head_groups = get_kv_head_groups(tp_size)
@@ -3026,26 +3026,35 @@ class MooncakeConnectorWorker:
                     cp_group_meta[kv_head_group]["cp_groups"] = []
                     cp_group_meta[kv_head_group]["select_cp_groups_id"] = 0
                 kv_head_group_offset = tp_size // len(kv_head_groups) * kv_head_group_idx
-                for dcp_repeat_idx in range(dcp_repeat_num):
-                    # len(cp_group) == pcp_size * dcp_size
-                    cp_group = []
-                    dcp_repeat_offset = dcp_size * dcp_repeat_idx
-                    for pcp_rank in range(pcp_size):
-                        pcp_rank_offset = tp_size * pcp_rank
-                        for dcp_rank in range(dcp_size):
-                            cp_group.append(
-                                dcp_rank + port_base + pcp_rank_offset + dcp_repeat_offset + kv_head_group_offset
-                            )
-                    cp_group_meta[kv_head_group]["cp_groups"].append(cp_group)
+                for pp_rank in range(pp_size):
+                    pp_rank_offset = pp_rank * pcp_size * tp_size
+                    for dcp_repeat_idx in range(dcp_repeat_num):
+                        # len(cp_group) == pcp_size * dcp_size
+                        cp_group = []
+                        dcp_repeat_offset = dcp_size * dcp_repeat_idx
+                        for pcp_rank in range(pcp_size):
+                            pcp_rank_offset = tp_size * pcp_rank
+                            for dcp_rank in range(dcp_size):
+                                cp_group.append(
+                                    dcp_rank
+                                    + port_base
+                                    + pp_rank_offset
+                                    + pcp_rank_offset
+                                    + dcp_repeat_offset
+                                    + kv_head_group_offset
+                                )
+                        cp_group_meta[kv_head_group]["cp_groups"].append(cp_group)
 
             return cp_group_meta
 
         def get_local_remote_block_port_mappings():
             context_parallel_parameters_check()
             p_node_cp_group_meta = get_cp_group_meta(
-                prefill_tp_size, meta.remote_pcp_size, meta.remote_dcp_size, meta.remote_port
+                prefill_tp_size, meta.remote_pcp_size, meta.remote_dcp_size, meta.remote_port, self._prefill_pp_size
             )
-            d_node_cp_group_meta = get_cp_group_meta(self.tp_size, self.pcp_size, self.dcp_size, self.side_channel_port)
+            d_node_cp_group_meta = get_cp_group_meta(
+                self.tp_size, self.pcp_size, self.dcp_size, self.side_channel_port, self._decode_pp_size
+            )
             local_remote_block_port_mappings: dict[int, list[list[int]]] = {}
             for d_node_head_key in d_node_cp_group_meta:
                 for p_node_head_key in p_node_cp_group_meta:
@@ -3053,23 +3062,26 @@ class MooncakeConnectorWorker:
                         continue
                     d_node_head_group = d_node_cp_group_meta[d_node_head_key]
                     p_node_head_group = p_node_cp_group_meta[p_node_head_key]
-                    for d_cp_group in d_node_head_group["cp_groups"]:
-                        select_cp_groups_id = p_node_head_group["select_cp_groups_id"]
-                        p_cp_groups = p_node_head_group["cp_groups"]
-                        p_cp_group = p_cp_groups[select_cp_groups_id]
-                        p_node_head_group["select_cp_groups_id"] = (
-                            select_cp_groups_id + 1 if select_cp_groups_id + 1 < len(p_cp_groups) else 0
-                        )
-                        for d_idx, d_port in enumerate(d_cp_group):
-                            if d_port not in local_remote_block_port_mappings:
-                                local_remote_block_port_mappings[d_port] = []
-                            p_port_remote_list = []
-                            for p_idx, p_port in enumerate(p_cp_group):
-                                # When Bd == Bp, r_blk = 1, which degenerates to the original `p_idx % Lcp` rule.
-                                # When Bd = r * Bp, all blocks of P CP rank q are mapped to D rank `(q // r) % Lcp`.
-                                if (p_idx // r_blk) % len(d_cp_group) == d_idx:
-                                    p_port_remote_list.append(p_port)
-                            local_remote_block_port_mappings[d_port].append(p_port_remote_list)
+                    d_cp_groups = d_node_head_group["cp_groups"]
+                    p_cp_groups = p_node_head_group["cp_groups"]
+                    p_cp_groups_per_pp = len(p_cp_groups) // self._prefill_pp_size
+                    for d_g_idx, d_cp_group in enumerate(d_cp_groups):
+                        # Map each D CP group to one P CP group per PP rank.
+                        # P CP groups are ordered as [pp0_g0, pp0_g1, ..., pp1_g0, pp1_g1, ...].
+                        # For each PP rank, select the matching dcp_repeat group by round-robin.
+                        for pp_rank in range(self._prefill_pp_size):
+                            p_g_idx = (d_g_idx % p_cp_groups_per_pp) + pp_rank * p_cp_groups_per_pp
+                            p_cp_group = p_cp_groups[p_g_idx]
+                            for d_idx, d_port in enumerate(d_cp_group):
+                                if d_port not in local_remote_block_port_mappings:
+                                    local_remote_block_port_mappings[d_port] = []
+                                p_port_remote_list = []
+                                for p_idx, p_port in enumerate(p_cp_group):
+                                    # When Bd == Bp, r_blk = 1, which degenerates to the original `p_idx % Lcp` rule.
+                                    # When Bd = r * Bp, all blocks of P CP rank q are mapped to D rank `(q // r) % Lcp`.
+                                    if (p_idx // r_blk) % len(d_cp_group) == d_idx:
+                                        p_port_remote_list.append(p_port)
+                                local_remote_block_port_mappings[d_port].append(p_port_remote_list)
 
             logger.info(
                 "p_node_cp_group_meta is:: %s. d_node_cp_group_meta is:: %s. "
@@ -3336,7 +3348,7 @@ class MooncakeConnectorWorker:
                 f"tp_num_need_pulls: {tp_num_need_pulls}, remote_handshake_port_list: {remote_handshake_port_list}"
             )
         else:
-            assert tp_num_need_pulls == len(remote_handshake_port_list[0]), (
+            assert len(remote_handshake_port_list[0]) % tp_num_need_pulls == 0, (
                 f"tp_num_need_pulls: {tp_num_need_pulls}, remote_handshake_port_list: {remote_handshake_port_list}"
             )
 


### PR DESCRIPTION
### What this PR does / why we need it?

model: GLM-5.2

This PR fixes a KV‑cache transfer issue in the Mooncake connector when Pipeline Parallelism (PP) and Decode Context Parallel (DCP) are used together in a PD‑disaggregated service. 

When both PP > 1 and DCP > 1 are enabled, the D‑side workers only pull KV from P‑side PP rank 0. Layers belonging to PP rank 1+ are silently skipped, resulting in garbled output because the D‑side model misses half of its KV cache.

Root cause:
The get_cp_group_meta function in mooncake_connector.py did not iterate over the PP dimension when generating P‑side handshake ports. The generated ports only covered the range for PP rank 0: [port_base, port_base + tp_size * pcp_size). Ports for PP rank 1+ (located at offset pp_rank * pcp_size * tp_size) were never created. As a result, the D‑side never connected to PP rank 1+ workers, and the KV cache for those layers was never transferred.

Fixes (5 changes):

get_cp_group_meta (L3005): Added a pp_size parameter and an outer for pp_rank loop. Port generation now includes pp_rank_offset = pp_rank * pcp_size * tp_size to cover all PP ranks.

get_local_remote_block_port_mappings call sites (L3025‑3028): Pass self._prefill_pp_size to the P‑side call and self._decode_pp_size to the D‑side call.

Mapping logic in get_local_remote_block_port_mappings (L3032‑3052): Replaced the old round‑robin selection (where each D CP group consumed only one P CP group, silently dropping PP rank 1+) with a PP‑aware mapping: each D CP group now maps to one P CP group per PP rank.

Non‑HMA assertion (L3332): Changed tp_num_need_pulls == len(remote_handshake_port_list[0]) to len(remote_handshake_port_list[0]) % tp_num_need_pulls == 0. When PP > 1, each shard has pp_size * tp_num_need_pulls ports, so the strict equality would cause a crash.

PP rank derivation in _get_cp_shard_pulls (L3358): Replaced 0 if remote_pcp_size > 1 else (port - base) // tp_size with (port - base) // (remote_pcp_size * prefill_tp_size). The old formula always returned 0 or ignored the PCP dimension; the new one correctly divides by the stride pcp_size * tp_size (ports per PP rank).

### Does this PR introduce _any_ user-facing change?

No. When pp_size == 1 (the default and most common case), all changes become no‑ops:

The PP‑rank loop runs once with offset 0.

The PP‑aware mapping falls back to the original round‑robin behaviour (because p_cp_groups_per_pp == len(p_cp_groups)).

PP rank derivation always returns 0.

The assertion len % tp_num == 0 degenerates to tp_num == len (same as before).

### How was this patch tested?

Manual testing with a PD‑disaggregated deployment using the glm‑5 model (P: PP=2, TP=8; D: TP=2, DCP=8), verifying that the output is no longer garbled.

Regression tests under PP=1, DCP=1 and PP=2, DCP=1 configurations to ensure no regressions.


- vLLM main: https://github.com/vllm-project/vllm/commit/b2f685834a6456197e7033966fdef52a23f1abcd
