### PR TITLE
[CI][Test] Drop unasserted W8A8 graph-mode session in model_runner_v2 test_basic

### DIFF
--- a/tests/e2e/pull_request/one_card/model_runner_v2/test_basic.py
+++ b/tests/e2e/pull_request/one_card/model_runner_v2/test_basic.py
@@ -297,16 +297,27 @@ def test_mtp_spec_decoding(
     assert len(outputs) == len(prompts)
 
 
-@pytest.mark.parametrize("model", MODELS)
-@pytest.mark.parametrize("max_tokens", [32])
-@pytest.mark.parametrize("enforce_eager", [False])
+# The W8A8 model only serves as a crash smoke test here (no output assertion),
+# so it keeps a single default compilation config to avoid paying a full
+# engine cold start for an unasserted session.
 @pytest.mark.parametrize(
-    "compilation_config",
+    "model, compilation_config",
     [
-        pytest.param({"cudagraph_mode": "FULL_DECODE_ONLY"}, id="full_decode_only"),
-        pytest.param({}, id="default_full_and_piecewise"),
+        pytest.param(
+            "Qwen/Qwen3-0.6B",
+            {"cudagraph_mode": "FULL_DECODE_ONLY"},
+            id="qwen3-0.6b-full_decode_only",
+        ),
+        pytest.param("Qwen/Qwen3-0.6B", {}, id="qwen3-0.6b-default_full_and_piecewise"),
+        pytest.param(
+            "vllm-ascend/DeepSeek-V2-Lite-W8A8",
+            {},
+            id="dsv2-lite-w8a8-default_full_and_piecewise",
+        ),
     ],
 )
+@pytest.mark.parametrize("max_tokens", [32])
+@pytest.mark.parametrize("enforce_eager", [False])
 @patch.dict(os.environ, {"VLLM_USE_V2_MODEL_RUNNER": "1"})
 @wait_until_npu_memory_free(target_free_percentage=0.8)
 def test_qwen3_dense_graph_mode(


### PR DESCRIPTION
## What this PR does / why we need it?

In `test_qwen3_dense_graph_mode` (tests/e2e/pull_request/one_card/model_runner_v2/test_basic.py), the DeepSeek-V2-Lite-W8A8 parametrization returns early **before any assertion** (see the `if model != Qwen/Qwen3-0.6B: return` guard). Its second compilation-config session was therefore a pure engine cold start with no verification value.

This PR converts the two independent parametrize dimensions (`model` x `compilation_config`) into a single joint parametrize list:

- The asserted Qwen3-0.6B sessions (full_decode_only + default_full_and_piecewise) are kept unchanged.
- W8A8 keeps **one** default-config session as a crash smoke test; its duplicate full_decode_only session is dropped.

Net effect: 4 sessions -> 3 sessions in this test, cutting ~2.5 min from the one-card partition wall time with zero loss of assertion coverage.

## Does this PR introduce _any_ user-facing change?

No. CI-only change; test semantics are unchanged.

## How was this patch tested?

- Local machine has no NPU, so e2e execution is delegated to CI (pr_test workflow will run test_basic.py on a2/a3 runners).
- The hosting job's historical peak wall time is ~75 min, well below the 120 min job timeout; this is a net time-reducing change with no timeout risk.

- vLLM main: https://github.com/vllm-project/vllm/commit/b2f685834a6456197e7033966fdef52a23f1abcd
