### PR TITLE
[v0.26.0rc][BugFix][SpecDecode] Guard DSpark at max model length

### DIFF
--- a/tests/e2e/nightly/single_node/ops/singlecard_ops/triton/test_parallel_draft_max_model_len.py
+++ b/tests/e2e/nightly/single_node/ops/singlecard_ops/triton/test_parallel_draft_max_model_len.py
@@ -1,0 +1,84 @@
+import torch
+from vllm.v1.spec_decode.utils import PADDING_SLOT_ID
+
+from vllm_ascend.ops.triton.spec_decode.utils import (
+    copy_and_expand_dflash_and_dspark_inputs_kernel_single_grid,
+)
+from vllm_ascend.ops.triton.triton_utils import init_device_properties_triton
+
+
+def test_dspark_disables_a_whole_query_window_past_max_model_len():
+    init_device_properties_triton()
+    device = "npu"
+    block_size = 4
+    num_query_per_req = 5
+    num_speculative_tokens = 5
+    batch_size = 2
+
+    # Request 0 fits exactly: 3 + 5 == max_model_len. Request 1 does not:
+    # 6 + 5 > max_model_len, so every draft slot in its non-causal block must
+    # be padding rather than preserving a partial in-range prefix.
+    next_token_ids = torch.tensor([42, 43], dtype=torch.int64, device=device)
+    target_positions = torch.tensor([2, 5], dtype=torch.int32, device=device)
+    context_slot_mapping = torch.tensor([41, 121], dtype=torch.int32, device=device)
+    block_table = torch.tensor([[10, 20], [30, 40]], dtype=torch.int32, device=device)
+    query_start_loc = torch.tensor([0, 1, 2], dtype=torch.int32, device=device)
+    seq_lens = torch.tensor([3, 6], dtype=torch.int32, device=device)
+    request_window_ok = torch.tensor([True, False], dtype=torch.bool, device=device)
+
+    num_query_total = batch_size * num_query_per_req
+    input_ids = torch.empty(num_query_total, dtype=torch.int64, device=device)
+    context_positions = torch.empty(batch_size, dtype=torch.int32, device=device)
+    query_positions = torch.empty(num_query_total, dtype=torch.int32, device=device)
+    context_slots = torch.empty(batch_size, dtype=torch.int32, device=device)
+    query_slots = torch.empty(num_query_total, dtype=torch.int32, device=device)
+    token_indices = torch.empty(
+        batch_size * num_speculative_tokens,
+        dtype=torch.int32,
+        device=device,
+    )
+
+    copy_and_expand_dflash_and_dspark_inputs_kernel_single_grid[1,](
+        next_token_ids_ptr=next_token_ids,
+        target_positions_ptr=target_positions,
+        context_slot_mapping_ptr=context_slot_mapping,
+        out_input_ids_ptr=input_ids,
+        out_context_positions_ptr=context_positions,
+        out_query_positions_ptr=query_positions,
+        out_context_slot_mapping_ptr=context_slots,
+        out_query_slot_mapping_ptr=query_slots,
+        out_token_indices_ptr=token_indices,
+        block_table_ptr=block_table,
+        block_table_stride=block_table.stride(0),
+        query_start_loc_ptr=query_start_loc,
+        seq_lens_ptr=seq_lens,
+        num_rejected_tokens_ptr=0,
+        parallel_drafting_token_id=0,
+        block_size=block_size,
+        num_query_per_req=num_query_per_req,
+        num_speculative_tokens=num_speculative_tokens,
+        total_input_tokens=batch_size,
+        batch_size=batch_size,
+        request_window_ok_ptr=request_window_ok,
+        padding_slot_id=PADDING_SLOT_ID,
+        HAS_NUM_REJECTED=False,
+        SAMPLE_FROM_ANCHOR=True,
+        CHECK_REQUEST_WINDOW=True,
+    )
+
+    torch.npu.synchronize()
+    torch.testing.assert_close(
+        input_ids.cpu(),
+        torch.tensor([42, 0, 0, 0, 0, 43, 0, 0, 0, 0], dtype=torch.int64),
+    )
+    torch.testing.assert_close(context_positions.cpu(), target_positions.cpu())
+    torch.testing.assert_close(context_slots.cpu(), context_slot_mapping.cpu())
+    torch.testing.assert_close(
+        query_positions.cpu(),
+        torch.tensor([3, 4, 5, 6, 7, 0, 0, 0, 0, 0], dtype=torch.int32),
+    )
+    torch.testing.assert_close(
+        query_slots.cpu(),
+        torch.tensor([43, 80, 81, 82, 83, -1, -1, -1, -1, -1], dtype=torch.int32),
+    )
+    torch.testing.assert_close(token_indices.cpu(), torch.arange(10, dtype=torch.int32))

--- a/tests/ut/spec_decode/test_dspark_proposer.py
+++ b/tests/ut/spec_decode/test_dspark_proposer.py
@@ -44,6 +44,7 @@ _NUM_SPECULATIVE_TOKENS = 3
 _MAX_BATCH_SIZE = 2
 _MAX_NUM_TOKENS = 8
 _HIDDEN_SIZE = 16
+_MAX_MODEL_LEN = 2048
 
 
 @pytest.mark.parametrize(
@@ -245,7 +246,8 @@ class _DSparkProposerTestBase:
         """Build the minimal config consumed by the DSpark initializer."""
         draft_model_config = SimpleNamespace(hf_config=hf_config, get_hidden_size=lambda: _HIDDEN_SIZE)
         return SimpleNamespace(
-            speculative_config=SimpleNamespace(draft_sample_method="greedy", draft_model_config=draft_model_config)
+            speculative_config=SimpleNamespace(draft_sample_method="greedy", draft_model_config=draft_model_config),
+            model_config=SimpleNamespace(max_model_len=_MAX_MODEL_LEN),
         )
 
     @classmethod
@@ -255,6 +257,7 @@ class _DSparkProposerTestBase:
         max_num_tokens: int,
         num_reqs: int,
         block_size: int,
+        max_model_len: int = _MAX_MODEL_LEN,
         hf_config: SimpleNamespace | None = None,
         draft_attn_causal: bool | None = None,
     ):
@@ -268,10 +271,13 @@ class _DSparkProposerTestBase:
             runner: object | None = None,
         ) -> None:
             del runner
+            proposer.runner = SimpleNamespace(num_rejected_tokens_event=None)
             proposer.draft_model_config = vllm_config.speculative_config.draft_model_config
             proposer.num_speculative_tokens = block_size
+            proposer.parallel_drafting = True
             proposer.max_batch_size = num_reqs
             proposer.max_num_tokens = max_num_tokens
+            proposer.max_model_len = max_model_len
             proposer.dtype = torch.float32
             proposer.device = device
             proposer.hidden_size = _HIDDEN_SIZE
@@ -350,6 +356,10 @@ class _DSparkProposerTestBase:
             query_start_loc=torch.arange(num_reqs + 1, dtype=torch.int32) * block_size,
             query_start_loc_cpu=query_start_loc_cpu,
             seq_lens=torch.full((num_reqs,), seq_len, dtype=torch.int32),
+            _seq_lens_cpu=torch.full((num_reqs,), seq_len, dtype=torch.int32),
+            seq_lens_cpu=torch.full((num_reqs,), seq_len, dtype=torch.int32),
+            seq_lens_cpu_upper_bound=None,
+            parallel_draft_seq_lens_cpu=None,
             max_seq_len=seq_len,
         )
         if with_optional_attrs:
@@ -383,6 +393,8 @@ class TestDSparkPositionsFullUnderMultiDp(_DSparkProposerTestBase):
             query_start_loc=torch.arange(num_reqs + 1, dtype=torch.int32) * block_size,
             query_start_loc_cpu=torch.zeros(num_reqs + 1, dtype=torch.int32),
             seq_lens=torch.full((num_reqs,), 128, dtype=torch.int32),
+            _seq_lens_cpu=torch.full((num_reqs,), 128, dtype=torch.int32),
+            seq_lens_cpu=torch.full((num_reqs,), 128, dtype=torch.int32),
             max_seq_len=128,
         )
         proposer.set_inputs_first_pass(
@@ -740,6 +752,8 @@ class TestDSparkInitValidation:
         assert proposer.positions.shape == (max_query_tokens,)
         assert proposer.positions.dtype == torch.int32
         assert proposer._slot_mapping_buffer.shape == (max_query_tokens,)
+        assert torch.all(proposer._request_window_ok)
+        assert torch.all(proposer._request_window_ok_cpu)
         # per-group bookkeeping dicts start empty / None.
         assert proposer._per_group_block_tables == {}
         assert proposer._per_group_slot_mappings == {}
@@ -820,6 +834,9 @@ class TestSetInputsFirstPassOutputs(_DSparkProposerTestBase):
         kwargs = kernel[1,].call_args.kwargs
         assert proposer.draft_attn_groups[0].kv_cache_spec.block_size == 384
         assert kwargs["block_size"] == 128
+        assert kwargs["request_window_ok_ptr"].data_ptr() == proposer._request_window_ok.data_ptr()
+        assert kwargs["padding_slot_id"] == -1
+        assert kwargs["CHECK_REQUEST_WINDOW"] is True
 
     def test_cad_rewritten_to_cross_attention_shape(self):
         num_reqs, block_size, max_num_tokens = 4, 5, 256
@@ -879,6 +896,41 @@ class TestSetInputsFirstPassOutputs(_DSparkProposerTestBase):
         assert torch.equal(cad.query_start_loc_cpu, expected_qsl)
         # seq_lens grow by block_size when no tokens were rejected.
         assert torch.equal(cad.seq_lens, torch.full((num_reqs,), 128 + block_size, dtype=torch.int32))
+
+    def test_over_limit_request_disables_whole_dspark_window(self):
+        num_reqs, block_size, max_num_tokens = 2, 5, 32
+        max_model_len = 130
+        proposer = self._make_proposer(
+            max_num_tokens=max_num_tokens,
+            num_reqs=num_reqs,
+            block_size=block_size,
+            max_model_len=max_model_len,
+        )
+
+        _, _, cad, _ = self._invoke_set_inputs_first_pass(
+            proposer,
+            num_reqs=num_reqs,
+            block_size=block_size,
+            seq_len=128,
+        )[:4]
+
+        assert torch.equal(cad.seq_lens, torch.ones(num_reqs, dtype=torch.int32))
+        assert not torch.any(proposer._request_window_ok[:num_reqs])
+        assert not torch.any(proposer._request_window_ok_cpu[:num_reqs])
+        assert cad.max_seq_len == max_model_len
+
+        proposer._prepare_parallel_draft_seq_lens_cpu(cad, num_reqs, None)
+        assert torch.equal(cad.parallel_draft_seq_lens_cpu, torch.ones(num_reqs, dtype=torch.int32))
+
+    def test_over_limit_draft_outputs_are_padding(self):
+        proposer = self._make_proposer(max_num_tokens=32, num_reqs=2, block_size=5)
+        proposer._request_window_ok[:2] = torch.tensor([True, False])
+        draft_token_ids = torch.arange(10, dtype=torch.int64).view(2, 5)
+
+        output = proposer.mask_invalid_draft_output(draft_token_ids)
+
+        assert torch.equal(output[0], torch.arange(5, dtype=torch.int64))
+        assert torch.equal(output[1], torch.full((5,), -1, dtype=torch.int64))
 
 
 class TestSetInputsFirstPassRejectedTokens(_DSparkProposerTestBase):

--- a/vllm_ascend/ops/triton/spec_decode/utils.py
+++ b/vllm_ascend/ops/triton/spec_decode/utils.py
@@ -92,8 +92,11 @@ def copy_and_expand_dflash_and_dspark_inputs_kernel_single_grid(
     num_speculative_tokens,  # tl.int32
     total_input_tokens,  # tl.int32
     batch_size,  # tl.int32
+    request_window_ok_ptr=0,  # [num_reqs], or null when checking is disabled
+    padding_slot_id=-1,  # tl.int32
     HAS_NUM_REJECTED: tl.constexpr = False,
     SAMPLE_FROM_ANCHOR: tl.constexpr = False,
+    CHECK_REQUEST_WINDOW: tl.constexpr = False,
 ):
     for req_idx in range(0, batch_size):
         ctx_start = tl.load(query_start_loc_ptr + req_idx)
@@ -117,18 +120,37 @@ def copy_and_expand_dflash_and_dspark_inputs_kernel_single_grid(
 
         seq_len = tl.load(seq_lens_ptr + req_idx)
         effective_seq_len = seq_len - num_rejected
-        last_pos = tl.load(target_positions_ptr + valid_ctx_end - 1)
+        if CHECK_REQUEST_WINDOW:
+            request_window_ok = tl.load(request_window_ok_ptr + req_idx).to(tl.int1)
+            valid_ctx = request_window_ok & (valid_ctx_end > 0)
+            safe_last_ctx_idx = tl.where(valid_ctx, valid_ctx_end - 1, 0)
+            last_pos = tl.load(target_positions_ptr + safe_last_ctx_idx, mask=valid_ctx, other=0)
+        else:
+            last_pos = tl.load(target_positions_ptr + valid_ctx_end - 1)
 
         for q_idx in range(0, num_query_per_req):
             query_pos = last_pos + 1 + q_idx
             query_out_idx = req_idx * num_query_per_req + q_idx
-
+            if CHECK_REQUEST_WINDOW:
+                query_pos = tl.where(request_window_ok, query_pos, 0)
             tl.store(out_query_positions_ptr + query_out_idx, query_pos)
 
             query_cache_pos = effective_seq_len + q_idx
             block_num_q = query_cache_pos // block_size
-            block_id_q = tl.load(block_table_ptr + req_idx * block_table_stride + block_num_q).to(tl.int64)
+            if CHECK_REQUEST_WINDOW:
+                # Select a valid address before pointer arithmetic. A masked
+                # load alone is insufficient once block_num_q crosses rows.
+                safe_block_num_q = tl.where(request_window_ok, block_num_q, 0)
+                block_id_q = tl.load(
+                    block_table_ptr + req_idx * block_table_stride + safe_block_num_q,
+                    mask=request_window_ok,
+                    other=0,
+                ).to(tl.int64)
+            else:
+                block_id_q = tl.load(block_table_ptr + req_idx * block_table_stride + block_num_q).to(tl.int64)
             slot_q = block_id_q * block_size + (query_cache_pos % block_size)
+            if CHECK_REQUEST_WINDOW:
+                slot_q = tl.where(request_window_ok, slot_q, padding_slot_id)
             tl.store(out_query_slot_mapping_ptr + query_out_idx, slot_q)
 
             if q_idx == 0:

--- a/vllm_ascend/spec_decode/dspark_proposer.py
+++ b/vllm_ascend/spec_decode/dspark_proposer.py
@@ -8,6 +8,7 @@ from vllm.config import CUDAGraphMode, VllmConfig, get_layers_from_vllm_config
 from vllm.model_executor.layers.attention_layer_base import AttentionLayerBase
 from vllm.v1.attention.backends.utils import CommonAttentionMetadata
 from vllm.v1.kv_cache_interface import UniformTypeKVCacheSpecs
+from vllm.v1.spec_decode.utils import PADDING_SLOT_ID
 from vllm.v1.worker.utils import AttentionGroup
 
 from vllm_ascend.ascend_forward_context import set_ascend_forward_context
@@ -119,6 +120,11 @@ class AscendDSparkProposer(AscendDflashProposer):
 
         # per-layer context slot mappings as a flat list
         self._context_slot_mapping_buffers: list[torch.Tensor | None] | None = None
+        # DSpark runs a request's draft block as one non-causal forward. If
+        # any query in that block would cross max_model_len, the whole block
+        # must be disabled rather than keeping only its in-range prefix.
+        self._request_window_ok = torch.ones(self.max_batch_size, dtype=torch.bool, device=device)
+        self._request_window_ok_cpu = torch.ones(self.max_batch_size, dtype=torch.bool)
 
     @staticmethod
     def _resolve_kernel_block_size(
@@ -260,6 +266,31 @@ class AscendDSparkProposer(AscendDflashProposer):
         self._per_group_block_tables[gid] = block_table
         self._per_group_slot_mappings[gid] = slot_mapping
 
+    def mask_invalid_draft_output(self, draft_token_ids: torch.Tensor) -> torch.Tensor:
+        """Replace drafts from over-limit request windows with placeholders."""
+        valid_rows = self._request_window_ok[: draft_token_ids.shape[0]].unsqueeze(1)
+        draft_token_ids.masked_fill_(~valid_rows, PADDING_SLOT_ID)
+        return draft_token_ids
+
+    def _prepare_parallel_draft_seq_lens_cpu(
+        self,
+        common_attn_metadata: CommonAttentionMetadata,
+        batch_size: int,
+        num_draft_tokens_cpu: list[int] | None,
+    ) -> None:
+        """Keep MLA's host KV lengths safe for disabled DSpark windows."""
+        super()._prepare_parallel_draft_seq_lens_cpu(
+            common_attn_metadata,
+            batch_size,
+            num_draft_tokens_cpu,
+        )
+        seq_lens = common_attn_metadata.parallel_draft_seq_lens_cpu
+        if seq_lens is not None:
+            seq_lens[:batch_size].masked_fill_(
+                ~self._request_window_ok_cpu[:batch_size],
+                1,
+            )
+
     def set_inputs_first_pass(
         self,
         target_token_ids: torch.Tensor,
@@ -290,6 +321,36 @@ class AscendDSparkProposer(AscendDflashProposer):
         self._context_slot_mapping_buffers = None
         self._dflash_num_context = int(cad.query_start_loc_cpu[batch_size])
         self._dflash_hidden_states[: self._dflash_num_context] = target_hidden_states[: self._dflash_num_context]
+
+        effective_seq_lens = cad.seq_lens
+        if has_num_rejected:
+            effective_seq_lens = effective_seq_lens - num_rejected_tokens_gpu
+
+        # Build matching device and host masks without introducing a hot-path
+        # CPU-to-NPU copy. The model runner has already corrected the host
+        # mirror for DeepSeek V4 async scheduling.
+        host_seq_lens = getattr(cad, "_seq_lens_cpu", None)
+        if host_seq_lens is None:
+            host_seq_lens = getattr(cad, "seq_lens_cpu", None)
+        request_window_ok_cpu = self._request_window_ok_cpu[:batch_size]
+        if host_seq_lens is None:
+            request_window_ok_cpu.fill_(True)
+        else:
+            request_window_ok_cpu.copy_(
+                (host_seq_lens[:batch_size] >= 0)
+                & (host_seq_lens[:batch_size] + self.num_query_per_req <= self.max_model_len)
+            )
+
+        request_window_ok = self._request_window_ok[:batch_size]
+        request_window_ok.copy_(
+            (effective_seq_lens[:batch_size] >= 0)
+            & (effective_seq_lens[:batch_size] + self.num_query_per_req <= self.max_model_len)
+        )
+        ctx_end = cad.query_start_loc[1 : batch_size + 1]
+        if has_num_rejected:
+            request_window_ok.logical_and_(ctx_end > num_rejected_tokens_gpu[:batch_size])
+        else:
+            request_window_ok.logical_and_(ctx_end > 0)
 
         token_indices_to_sample = torch.empty(
             num_sample_total,
@@ -333,20 +394,24 @@ class AscendDSparkProposer(AscendDflashProposer):
                 num_speculative_tokens=self.num_speculative_tokens,
                 total_input_tokens=self._dflash_num_context,
                 batch_size=batch_size,
+                request_window_ok_ptr=request_window_ok,
+                padding_slot_id=PADDING_SLOT_ID,
                 HAS_NUM_REJECTED=has_num_rejected,
                 SAMPLE_FROM_ANCHOR=self.sample_from_anchor,
+                CHECK_REQUEST_WINDOW=True,
             )
         # to compute self._context_slot_mapping_buffers from dict to list
         self._context_slot_mapping_buffers = [
             self._per_group_context_slot_mapping_buffers[gidx] for gidx in self._layer_group_idx
         ]
 
-        effective_seq_lens = cad.seq_lens
-        if has_num_rejected:
-            effective_seq_lens = effective_seq_lens - num_rejected_tokens_gpu
-
         cad.query_start_loc = self.arange_dflash[: batch_size + 1] * self.num_query_per_req
-        cad.seq_lens = effective_seq_lens + self.num_query_per_req
+        expanded_seq_lens = effective_seq_lens + self.num_query_per_req
+        cad.seq_lens = torch.where(
+            request_window_ok,
+            expanded_seq_lens,
+            torch.ones_like(expanded_seq_lens),
+        )
         cad.query_start_loc_cpu = (
             torch.from_numpy(self.token_arange_np[: batch_size + 1]).clone() * self.num_query_per_req
         ).to(torch.int32)
@@ -359,7 +424,7 @@ class AscendDSparkProposer(AscendDflashProposer):
         cad.num_actual_tokens = num_query_total
         cad.num_input_tokens = num_query_total
         cad.max_query_len = self.num_query_per_req
-        cad.max_seq_len = cad.max_seq_len + self.num_query_per_req
+        cad.max_seq_len = min(cad.max_seq_len + self.num_query_per_req, self.max_model_len)
         cad.slot_mapping = self._per_group_query_slot_mapping_buffers[primary_gid][:num_query_total]
         cad.positions = self.positions  # this would be sliced in attention backend
         if hasattr(self.model, "get_draft_attn_causal"):

--- a/vllm_ascend/worker/model_runner_v1.py
+++ b/vllm_ascend/worker/model_runner_v1.py
@@ -1715,6 +1715,8 @@ class NPUModelRunner(GPUModelRunner):
                     else None
                 ),
             )
+            if isinstance(self.drafter, AscendDSparkProposer):
+                draft_token_ids = self.drafter.mask_invalid_draft_output(draft_token_ids)
             if get_pp_group().world_size > 1 and hasattr(
                 self.drafter, "take_last_draft_probs"
             ):


### PR DESCRIPTION
### What this PR does / why we need it?

On the v0.26 DSpark path, `set_inputs_first_pass` always expands a fixed parallel draft block. When

```
effective_seq_len + num_query_per_req > max_model_len
```

the expansion kernel computes a block-table address for query tokens beyond the model limit. Clamping only the tail is not correct for DSpark because the draft block is evaluated jointly (and is non-causal for DeepSeek V4); an invalid tail can contaminate the drafts that appear to remain in range.

This patch adds a request-level boundary fallback:

- compute device and host validity masks for the complete DSpark query window;
- if any query would exceed `max_model_len`, disable the whole DSpark block for that request;
- use safe metadata for the disabled row (position `0`, sequence length `1`);
- write `PADDING_SLOT_ID` (`-1`) for all of its draft KV slots, selecting block-table column zero before masked pointer arithmetic;
- replace every returned draft token for that request with `-1`, so the scheduler uses the target-model token only;
- leave the shared DFlash kernel path unchanged unless the new DSpark-only check is enabled.

Related to #15880, which addresses broader DSpark pointer/window validation on v0.27.1rc. This PR is a focused v0.26.0rc fix for the max-model-length boundary.

### Does this PR introduce _any_ user-facing change?

No API or configuration change. DSpark now falls back to target-only decoding for a request when its complete parallel draft window cannot fit within `max_model_len`.

### How was this patch tested?

- `python -m pytest -q tests/ut/spec_decode/test_dspark_proposer.py`
  - 44 passed on an Ascend A3 runtime using `quay.io/ascend/vllm-ascend:nightly-releases-v0.26.0rc-a3`.
- NPU regression input from `tests/e2e/nightly/single_node/ops/singlecard_ops/triton/test_parallel_draft_max_model_len.py`:
  - exact-boundary request (`3 + 5 == 8`) kept slots `[43, 80, 81, 82, 83]`;
  - over-limit request (`6 + 5 > 8`) produced positions `[0, 0, 0, 0, 0]` and slots `[-1, -1, -1, -1, -1]`;
  - PASS on the same Ascend A3 container.
- Shared-kernel DFlash compatibility smoke on NPU, omitting all new optional arguments: PASS.
- `pre-commit run ruff-check --files ...`: passed.
- `pre-commit run ruff-format --files ...`: passed.
- `python -m compileall -q ...`: passed.

- vLLM main: https://github.com/vllm-project/vllm/commit/d02df748bf9efd99022f1a062597dc3cb3808485

### Short-sequence performance validation

Tested on Ascend A3 with DeepSeek V4 Flash P/D (P: DP4/TP4; D: DP16/TP1), DSpark5, DSA-CP, Mooncake, task queue enabled. The workload used 512 requests at concurrency 256, random input/output lengths 128 (211 actual input tokens after the chat template), infinite request rate, and one warmup followed by five measured runs.

Five-run medians:

| Metric | Without this PR | Optimized guard | Delta |
| --- | ---: | ---: | ---: |
| Output throughput | 4368.50 tok/s | 4417.94 tok/s | +1.13% |
| Mean TPOT | 36.940 ms | 36.988 ms | +0.13% |
| Median TPOT | 37.039 ms | 37.285 ms | +0.67% |
| Mean ITL | 78.916 ms | 79.375 ms | +0.58% |

The sub-1% latency differences are within run-to-run variance; the optimized guard shows no measurable short-sequence regression.

A same-process Ascend kernel microbenchmark (batch 256, draft width 5, 1,000 launches per sample, 14 interleaved samples) measured 212.724 us with the CHECK_REQUEST_WINDOW=False specialization, versus 212.738 us for the earlier duplicated fast kernel (-0.007%). The guarded specialization measured 220.662 us (+3.731%), so the CPU batch predicate and tl.constexpr specialization keep that cost off ordinary short-sequence batches.