### PR TITLE
[CI] Modify the test case name

### DIFF
--- a/.github/workflows/configs/weekly_config.yaml
+++ b/.github/workflows/configs/weekly_config.yaml
@@ -85,8 +85,8 @@ a3:
         config_file_path: DeepSeek_V3.2T_MTP3_PD.yaml
         config_base_path: tests/e2e/weekly/multi_node/external_dp/config
         size: 4
-      - name: Qwen3.5-122B-A10B-w4a8-128k-1k-TPOT50-90-PD
-        config_file_path: Qwen3.5-122B-A10B-w4a8-128k-1k-TPOT50-90-PD.yaml
+      - name: Qwen3.5-122B-A10B-w4a8-128k-1k-PD
+        config_file_path: Qwen3.5-122B-A10B-w4a8-128k-1k-PD.yaml
         config_base_path: tests/e2e/weekly/multi_node/external_dp/config
         size: 3
       - name: GLM-5.1-W8A8C8-3.5k-1.5k-0-20-PD
@@ -255,8 +255,8 @@ a3:
         config_file_path: Qwen3.5-122B-A10B-w4a8-984k-1k-0-PD.yaml
         config_base_path: tests/e2e/weekly/multi_node/external_dp/config
         size: 2
-      - name: Qwen3.5-122B-A10B-w4a8-16k-1k-TPOT50-0-PD
-        config_file_path: Qwen3.5-122B-A10B-w4a8-16k-1k-TPOT50-0-PD.yaml
+      - name: Qwen3.5-122B-A10B-w4a8-16k-1k-PD
+        config_file_path: Qwen3.5-122B-A10B-w4a8-16k-1k-PD.yaml
         config_base_path: tests/e2e/weekly/multi_node/external_dp/config
         size: 2
   single_node:

--- a/tests/e2e/weekly/multi_node/external_dp/config/Qwen3.5-122B-A10B-w4a8-128k-1k-PD.yaml
+++ b/tests/e2e/weekly/multi_node/external_dp/config/Qwen3.5-122B-A10B-w4a8-128k-1k-PD.yaml
@@ -1,13 +1,13 @@
-test_name: "Qwen3.5-122B-A10B-w4a8-16k-1k-TPOT50-0-PD"
+test_name: "Qwen3.5-122B-A10B-w4a8-128k-1k-PD"
 model: "Eco-Tech/Qwen3.5-122B-A10B-w4a8"
-num_nodes: 2
+num_nodes: 3
 npu_per_node: 16
 
 routing:
   type: "disaggregated_prefill"
   groups:
-    prefiller: [ 0 ]
-    decoder: [ 1 ]
+    prefiller: [ 0, 1]
+    decoder: [ 2 ]
 
 config:
   - node_index: 0
@@ -28,6 +28,15 @@ config:
     tp_size: 2
     dp_address: "${NODE_1_IP}"
 
+  - node_index: 2
+    port_start: 7100
+    dp_rpc_port: 12321
+    dp_size: 8
+    dp_size_local: 8
+    dp_rank_start: 0
+    tp_size: 2
+    dp_address: "${NODE_2_IP}"
+
 env_common: &env_common
   SERVER_PORT: "${PORT}"
   VLLM_RPC_TIMEOUT: "3600000"
@@ -39,16 +48,15 @@ env_common: &env_common
   TASK_QUEUE_ENABLE: "1"
   HCCL_BUFFSIZE: "1024"
   VLLM_USE_V1: "1"
+  VLLM_ASCEND_ENABLE_FLASHCOMM1: "1"
+  ASCEND_BUFFER_POOL: "4:8"
   ASCEND_RT_VISIBLE_DEVICES: "${VISIBLE_DEVICES}"
   VLLM_USE_MODELSCOPE: "true"
 env_prefill: &env_prefill
   <<: *env_common
-  ASCEND_BUFFER_POOL: "4:8"
-  VLLM_ASCEND_ENABLE_FLASHCOMM1: "1"
 
 env_decode: &env_decode
   <<: *env_common
-  VLLM_ASCEND_SKIP_LOW_BLOCKS: "0"
 
 templates:
   - node_index: 0
@@ -76,22 +84,22 @@ templates:
       - --port
       - $SERVER_PORT
       - --max-num-seqs
-      - "32"
+      - "24"
       - --max-model-len
-      - "70000"
+      - "140000"
       - --max-num-batched-tokens
       - "8192"
       - --gpu-memory-utilization
-      - "0.8"
+      - "0.9"
       - --seed
       - "1024"
-      - --no-enable-prefix-caching
+      - --enable-prefix-caching
       - --async-scheduling
       - --enforce-eager
       - --speculative-config
       - '{"method": "qwen3_5_mtp", "num_speculative_tokens": 3, "enforce_eager": true}'
       - --additional-config
-      - '{"enable_cpu_binding": true,"enable_fused_mc2":0}'
+      - '{"enable_cpu_binding": true,"enable_fused_mc2":1}'
       - --profiler-config
       - '{"profiler": "torch", "torch_profiler_dir": "./profiling", "torch_profiler_with_stack": false}'
       - --mm-processor-cache-gb
@@ -102,8 +110,60 @@ templates:
       - "mp"
       - --no-disable-hybrid-kv-cache-manager
       - --kv-transfer-config
-      - '{"kv_connector": "MooncakeConnectorV1", "kv_buffer_device": "npu", "kv_role": "kv_producer", "kv_port": "58010", "engine_id": "0", "kv_connector_extra_config": {"prefill":{"dp_size": 8,"tp_size": 2},"decode":{"dp_size": 8,"tp_size": 2}}}'
+      - '{"kv_connector": "MooncakeConnectorV1","kv_buffer_device": "npu","kv_role": "kv_producer","kv_port": "55010","engine_id": "0","kv_connector_extra_config": {"prefill": {"dp_size": 8,"tp_size": 2},"decode": {"dp_size": 8,"tp_size": 2}}}'
   - node_index: 1
+    envs:
+      <<: *env_prefill
+    server_cmd_template:
+      - --quantization
+      - "ascend"
+      - --allowed-local-media-path
+      - "/"
+      - --trust-remote-code
+      - --data-parallel-size
+      - ${DP_SIZE}
+      - --data-parallel-rank
+      - ${DP_RANK}
+      - --data-parallel-address
+      - ${DP_ADDRESS}
+      - --data-parallel-rpc-port
+      - ${DP_RPC_PORT}
+      - --tensor-parallel-size
+      - ${TP_SIZE}
+      - --enable-expert-parallel
+      - --host
+      - "0.0.0.0"
+      - --port
+      - $SERVER_PORT
+      - --max-num-seqs
+      - "24"
+      - --max-model-len
+      - "140000"
+      - --max-num-batched-tokens
+      - "8192"
+      - --gpu-memory-utilization
+      - "0.9"
+      - --seed
+      - "1024"
+      - --enable-prefix-caching
+      - --async-scheduling
+      - --enforce-eager
+      - --speculative-config
+      - '{"method": "qwen3_5_mtp", "num_speculative_tokens": 3, "enforce_eager": true}'
+      - --additional-config
+      - '{"enable_cpu_binding": true,"enable_fused_mc2":1}'
+      - --profiler-config
+      - '{"profiler": "torch", "torch_profiler_dir": "./profiling", "torch_profiler_with_stack": false}'
+      - --mm-processor-cache-gb
+      - "0"
+      - --mm-encoder-tp-mode
+      - "data"
+      - --distributed-executor-backend
+      - "mp"
+      - --no-disable-hybrid-kv-cache-manager
+      - --kv-transfer-config
+      - '{"kv_connector": "MooncakeConnectorV1","kv_buffer_device": "npu","kv_role": "kv_producer","kv_port": "55010","engine_id": "1","kv_connector_extra_config": {"prefill": {"dp_size": 8,"tp_size": 2},"decode": {"dp_size": 8,"tp_size": 2}}}'
+  - node_index: 2
     envs:
       <<: *env_decode
     server_cmd_template:
@@ -128,23 +188,23 @@ templates:
       - --port
       - $SERVER_PORT
       - --max-num-seqs
-      - "32"
+      - "24"
       - --max-model-len
-      - "18432"
+      - "140000"
       - --max-num-batched-tokens
       - "8192"
       - --gpu-memory-utilization
       - "0.9"
       - --seed
       - "1024"
-      - --no-enable-prefix-caching
+      - --enable-prefix-caching
       - --async-scheduling
       - --compilation-config
-      - '{"cudagraph_capture_sizes":[4,8,12,16,20,24,28,32,36,40,44,48,52,56,60,64,68,72,76,80,84,88,92,96,100,104,108,112,116,120,124,128], "cudagraph_mode":"FULL_DECODE_ONLY"}'
+      - '{"cudagraph_capture_sizes":[4,8,12,16,20,24,28,32,36,40,44,48,52,56,60,64,68,72,76,80,84,88,92,96], "cudagraph_mode":"FULL_DECODE_ONLY"}'
       - --speculative-config
       - '{"method": "qwen3_5_mtp", "num_speculative_tokens": 3}'
       - --additional-config
-      - '{"recompute_scheduler_enable":true,"enable_cpu_binding":true,"enable_fused_mc2":0}'
+      - '{"recompute_scheduler_enable": true, "enable_cpu_binding": true,"enable_fused_mc2":1}'
       - --profiler-config
       - '{"profiler": "torch", "torch_profiler_dir": "./profiling", "torch_profiler_with_stack": false}'
       - --mm-processor-cache-gb
@@ -155,18 +215,18 @@ templates:
       - "mp"
       - --no-disable-hybrid-kv-cache-manager
       - --kv-transfer-config
-      - '{"kv_connector": "MooncakeConnectorV1", "kv_buffer_device": "npu", "kv_role": "kv_consumer", "kv_port": "58010", "engine_id": "1", "kv_connector_extra_config": {"prefill":{"dp_size": 8,"tp_size": 2},"decode":{"dp_size": 8,"tp_size": 2}}}'
+      - '{"kv_connector": "MooncakeConnectorV1","kv_buffer_device": "npu","kv_role": "kv_consumer","kv_port": "55010","engine_id": "2","kv_connector_extra_config": {"prefill": {"dp_size": 8,"tp_size": 2},"decode": {"dp_size": 8,"tp_size": 2}}}'
 
 benchmarks:
   perf:
     case_type: performance
-    dataset_path: vllm-ascend/GSM8K-in16384-bs1024-prefix0-qwen
+    dataset_path: vllm-ascend/GSM8K_prefix90_in131072_bs100_qwen
     request_conf: vllm_api_stream_chat
     dataset_conf: gsm8k/gsm8k_gen_0_shot_cot_str_perf
     trust_remote_code: true
-    num_prompts: 32
+    num_prompts: 64
     max_out_len: 1024
-    batch_size: 8
+    batch_size: 16
     request_rate: 0
-    baseline: 526.2983
+    baseline: 368.5119
     threshold: 0.97

--- a/tests/e2e/weekly/multi_node/external_dp/config/Qwen3.5-122B-A10B-w4a8-16k-1k-PD.yaml
+++ b/tests/e2e/weekly/multi_node/external_dp/config/Qwen3.5-122B-A10B-w4a8-16k-1k-PD.yaml
@@ -1,13 +1,13 @@
-test_name: "Qwen3.5-122B-A10B-w4a8-128k-1k-TPOT50-90-PD"
+test_name: "Qwen3.5-122B-A10B-w4a8-16k-1k-PD"
 model: "Eco-Tech/Qwen3.5-122B-A10B-w4a8"
-num_nodes: 3
+num_nodes: 2
 npu_per_node: 16
 
 routing:
   type: "disaggregated_prefill"
   groups:
-    prefiller: [ 0, 1]
-    decoder: [ 2 ]
+    prefiller: [ 0 ]
+    decoder: [ 1 ]
 
 config:
   - node_index: 0
@@ -28,15 +28,6 @@ config:
     tp_size: 2
     dp_address: "${NODE_1_IP}"
 
-  - node_index: 2
-    port_start: 7100
-    dp_rpc_port: 12321
-    dp_size: 8
-    dp_size_local: 8
-    dp_rank_start: 0
-    tp_size: 2
-    dp_address: "${NODE_2_IP}"
-
 env_common: &env_common
   SERVER_PORT: "${PORT}"
   VLLM_RPC_TIMEOUT: "3600000"
@@ -48,15 +39,16 @@ env_common: &env_common
   TASK_QUEUE_ENABLE: "1"
   HCCL_BUFFSIZE: "1024"
   VLLM_USE_V1: "1"
-  VLLM_ASCEND_ENABLE_FLASHCOMM1: "1"
-  ASCEND_BUFFER_POOL: "4:8"
   ASCEND_RT_VISIBLE_DEVICES: "${VISIBLE_DEVICES}"
   VLLM_USE_MODELSCOPE: "true"
 env_prefill: &env_prefill
   <<: *env_common
+  ASCEND_BUFFER_POOL: "4:8"
+  VLLM_ASCEND_ENABLE_FLASHCOMM1: "1"
 
 env_decode: &env_decode
   <<: *env_common
+  VLLM_ASCEND_SKIP_LOW_BLOCKS: "0"
 
 templates:
   - node_index: 0
@@ -84,22 +76,22 @@ templates:
       - --port
       - $SERVER_PORT
       - --max-num-seqs
-      - "24"
+      - "32"
       - --max-model-len
-      - "140000"
+      - "70000"
       - --max-num-batched-tokens
       - "8192"
       - --gpu-memory-utilization
-      - "0.9"
+      - "0.8"
       - --seed
       - "1024"
-      - --enable-prefix-caching
+      - --no-enable-prefix-caching
       - --async-scheduling
       - --enforce-eager
       - --speculative-config
       - '{"method": "qwen3_5_mtp", "num_speculative_tokens": 3, "enforce_eager": true}'
       - --additional-config
-      - '{"enable_cpu_binding": true,"enable_fused_mc2":1}'
+      - '{"enable_cpu_binding": true,"enable_fused_mc2":0}'
       - --profiler-config
       - '{"profiler": "torch", "torch_profiler_dir": "./profiling", "torch_profiler_with_stack": false}'
       - --mm-processor-cache-gb
@@ -110,60 +102,8 @@ templates:
       - "mp"
       - --no-disable-hybrid-kv-cache-manager
       - --kv-transfer-config
-      - '{"kv_connector": "MooncakeConnectorV1","kv_buffer_device": "npu","kv_role": "kv_producer","kv_port": "55010","engine_id": "0","kv_connector_extra_config": {"prefill": {"dp_size": 8,"tp_size": 2},"decode": {"dp_size": 8,"tp_size": 2}}}'
+      - '{"kv_connector": "MooncakeConnectorV1", "kv_buffer_device": "npu", "kv_role": "kv_producer", "kv_port": "58010", "engine_id": "0", "kv_connector_extra_config": {"prefill":{"dp_size": 8,"tp_size": 2},"decode":{"dp_size": 8,"tp_size": 2}}}'
   - node_index: 1
-    envs:
-      <<: *env_prefill
-    server_cmd_template:
-      - --quantization
-      - "ascend"
-      - --allowed-local-media-path
-      - "/"
-      - --trust-remote-code
-      - --data-parallel-size
-      - ${DP_SIZE}
-      - --data-parallel-rank
-      - ${DP_RANK}
-      - --data-parallel-address
-      - ${DP_ADDRESS}
-      - --data-parallel-rpc-port
-      - ${DP_RPC_PORT}
-      - --tensor-parallel-size
-      - ${TP_SIZE}
-      - --enable-expert-parallel
-      - --host
-      - "0.0.0.0"
-      - --port
-      - $SERVER_PORT
-      - --max-num-seqs
-      - "24"
-      - --max-model-len
-      - "140000"
-      - --max-num-batched-tokens
-      - "8192"
-      - --gpu-memory-utilization
-      - "0.9"
-      - --seed
-      - "1024"
-      - --enable-prefix-caching
-      - --async-scheduling
-      - --enforce-eager
-      - --speculative-config
-      - '{"method": "qwen3_5_mtp", "num_speculative_tokens": 3, "enforce_eager": true}'
-      - --additional-config
-      - '{"enable_cpu_binding": true,"enable_fused_mc2":1}'
-      - --profiler-config
-      - '{"profiler": "torch", "torch_profiler_dir": "./profiling", "torch_profiler_with_stack": false}'
-      - --mm-processor-cache-gb
-      - "0"
-      - --mm-encoder-tp-mode
-      - "data"
-      - --distributed-executor-backend
-      - "mp"
-      - --no-disable-hybrid-kv-cache-manager
-      - --kv-transfer-config
-      - '{"kv_connector": "MooncakeConnectorV1","kv_buffer_device": "npu","kv_role": "kv_producer","kv_port": "55010","engine_id": "1","kv_connector_extra_config": {"prefill": {"dp_size": 8,"tp_size": 2},"decode": {"dp_size": 8,"tp_size": 2}}}'
-  - node_index: 2
     envs:
       <<: *env_decode
     server_cmd_template:
@@ -188,23 +128,23 @@ templates:
       - --port
       - $SERVER_PORT
       - --max-num-seqs
-      - "24"
+      - "32"
       - --max-model-len
-      - "140000"
+      - "18432"
       - --max-num-batched-tokens
       - "8192"
       - --gpu-memory-utilization
       - "0.9"
       - --seed
       - "1024"
-      - --enable-prefix-caching
+      - --no-enable-prefix-caching
       - --async-scheduling
       - --compilation-config
-      - '{"cudagraph_capture_sizes":[4,8,12,16,20,24,28,32,36,40,44,48,52,56,60,64,68,72,76,80,84,88,92,96], "cudagraph_mode":"FULL_DECODE_ONLY"}'
+      - '{"cudagraph_capture_sizes":[4,8,12,16,20,24,28,32,36,40,44,48,52,56,60,64,68,72,76,80,84,88,92,96,100,104,108,112,116,120,124,128], "cudagraph_mode":"FULL_DECODE_ONLY"}'
       - --speculative-config
       - '{"method": "qwen3_5_mtp", "num_speculative_tokens": 3}'
       - --additional-config
-      - '{"recompute_scheduler_enable": true, "enable_cpu_binding": true,"enable_fused_mc2":1}'
+      - '{"recompute_scheduler_enable":true,"enable_cpu_binding":true,"enable_fused_mc2":0}'
       - --profiler-config
       - '{"profiler": "torch", "torch_profiler_dir": "./profiling", "torch_profiler_with_stack": false}'
       - --mm-processor-cache-gb
@@ -215,18 +155,18 @@ templates:
       - "mp"
       - --no-disable-hybrid-kv-cache-manager
       - --kv-transfer-config
-      - '{"kv_connector": "MooncakeConnectorV1","kv_buffer_device": "npu","kv_role": "kv_consumer","kv_port": "55010","engine_id": "2","kv_connector_extra_config": {"prefill": {"dp_size": 8,"tp_size": 2},"decode": {"dp_size": 8,"tp_size": 2}}}'
+      - '{"kv_connector": "MooncakeConnectorV1", "kv_buffer_device": "npu", "kv_role": "kv_consumer", "kv_port": "58010", "engine_id": "1", "kv_connector_extra_config": {"prefill":{"dp_size": 8,"tp_size": 2},"decode":{"dp_size": 8,"tp_size": 2}}}'
 
 benchmarks:
   perf:
     case_type: performance
-    dataset_path: vllm-ascend/GSM8K_prefix90_in131072_bs100_qwen
+    dataset_path: vllm-ascend/GSM8K-in16384-bs1024-prefix0-qwen
     request_conf: vllm_api_stream_chat
     dataset_conf: gsm8k/gsm8k_gen_0_shot_cot_str_perf
     trust_remote_code: true
-    num_prompts: 64
+    num_prompts: 32
     max_out_len: 1024
-    batch_size: 16
+    batch_size: 8
     request_rate: 0
-    baseline: 368.5119
+    baseline: 526.2983
     threshold: 0.97

--- a/tests/e2e/weekly/single_node/configs/Qwen3.6-35B-A3B-w4a8-A3.yaml
+++ b/tests/e2e/weekly/single_node/configs/Qwen3.6-35B-A3B-w4a8-A3.yaml
@@ -107,7 +107,7 @@ test_cases:
     benchmarks:
       perf:
         case_type: performance
-        dataset_path: vllm-ascend/GSM8K_in1007616_bs16_prefix0_qwen
+        dataset_path: vllm-ascend/GSM8K-in1007616-bs16-prefix0-qwen
         request_conf: vllm_api_stream_chat
         dataset_conf: gsm8k/gsm8k_gen_0_shot_cot_str_perf
         num_prompts: 4
@@ -165,7 +165,7 @@ test_cases:
     benchmarks:
       perf:
         case_type: performance
-        dataset_path: vllm-ascend/GSM8K-in1007616-bs16-prefix0-qwen
+        dataset_path: vllm-ascend/GSM8K_prefix90_in131072_bs100_qwen
         request_conf: vllm_api_stream_chat
         dataset_conf: gsm8k/gsm8k_gen_0_shot_cot_str_perf
         num_prompts: 60


### PR DESCRIPTION
### What this PR does / why we need it?
1.Qwen3.5-122B Use case:Container names are formed by concatenating test case names with other specific characters. Kubernetes restricts container names to a maximum of 64 characters. Overly long test case names cause Kubernetes scheduling failures. The current solution is to shorten the test case name length.
2.Qwen3.6-35B Use case: Modify the dataset configuration.

### Does this PR introduce _any_ user-facing change?
NO

### How was this patch tested?
by the running the test

- vLLM main: https://github.com/vllm-project/vllm/commit/b2f685834a6456197e7033966fdef52a23f1abcd
