### PR TITLE
[wip]Kimi k3 acl graph for dspark 0.26

### DIFF
--- a/tests/ut/spec_decode/test_dspark_proposer.py
+++ b/tests/ut/spec_decode/test_dspark_proposer.py
@@ -479,22 +479,6 @@ class TestSetPerGroupAttnMetadata(_DSparkProposerTestBase):
         assert proposer._per_group_slot_mappings[gid] is new_slot_mapping
         assert proposer._per_group_block_tables[gid] is not old_block_table
 
-    def test_rejects_block_table_over_request_capacity(self):
-        num_reqs, block_size, max_num_tokens = 2, 5, 256
-        proposer = self._make_proposer(
-            max_num_tokens=max_num_tokens, num_reqs=num_reqs, block_size=block_size
-        )
-
-        with pytest.raises(ValueError, match="exceeds the configured request capacity"):
-            proposer.set_per_group_attn_metadata(
-                7,
-                torch.zeros((num_reqs + 1, 16), dtype=torch.int32),
-                torch.zeros(max_num_tokens, dtype=torch.int32),
-            )
-
-        assert 7 not in proposer._per_group_block_tables
-        assert 7 not in proposer._per_group_slot_mappings
-
 
 class TestPadQueryStartLocForGraph:
     @staticmethod
@@ -535,19 +519,6 @@ class TestPadQueryStartLocForGraph:
         assert query_start_loc.np[: num_metadata_reqs + 1].tolist() == expected
         assert query_start_loc.np[: num_metadata_reqs + 1].max() <= num_input_tokens
         query_start_loc.copy_to_gpu.assert_called_once_with()
-
-    def test_rejects_missing_tail_capacity(self) -> None:
-        proposer = AscendDSparkProposer.__new__(AscendDSparkProposer)
-        proposer.num_query_per_req = 7
-        query_start_loc = self._make_query_start_loc([0, 7], capacity=3)
-
-        with pytest.raises(ValueError, match="no room for the graph-padding tail"):
-            proposer.pad_query_start_loc_for_graph(
-                query_start_loc,
-                num_input_tokens=16,
-                real_num_reqs=1,
-                graph_num_reqs=2,
-            )
 
 
 class TestDSparkGraphDispatch:
@@ -1204,60 +1175,6 @@ class TestInitializeAttnBackendErrors(_DSparkProposerTestBase):
             == 384
         )
 # fmt: on
-
-
-class TestFinalizePendingReject:
-    """``AscendMLAImpl._finalize_pending_reject`` is shared by the eager FIA
-    entry and the FULL-graph replay update path. It must subtract the pending
-    reject counts exactly once per metadata object."""
-
-    @staticmethod
-    def _make_metadata(seq_lens_list, reject, num_reqs, with_event=True):
-        from vllm_ascend.attention.mla_v1 import AscendMLAImpl  # noqa: F401
-
-        return SimpleNamespace(
-            pending_reject_event=(MagicMock() if with_event else None),
-            pending_reject_cpu=torch.tensor(reject, dtype=torch.int32),
-            pending_reject_num_reqs=num_reqs,
-            reject_finalized=False,
-            decode=SimpleNamespace(seq_lens_list=list(seq_lens_list)),
-        )
-
-    def test_subtracts_reject_counts_once(self):
-        from vllm_ascend.attention.mla_v1 import AscendMLAImpl
-
-        # parallel = (L_t + rejected_t) + N; finalize must yield L_t + N.
-        lt, n = 100, 7
-        rejected = [2, 5]
-        seq_lens_list = [lt + rejected[0] + n, lt + rejected[1] + n, 0]
-        metadata = self._make_metadata(seq_lens_list, rejected, num_reqs=2)
-
-        AscendMLAImpl._finalize_pending_reject(metadata)
-
-        assert metadata.decode.seq_lens_list == [lt + n, lt + n, 0]
-        assert metadata.reject_finalized is True
-        metadata.pending_reject_event.synchronize.assert_called_once_with()
-
-    def test_reentry_is_guarded(self):
-        from vllm_ascend.attention.mla_v1 import AscendMLAImpl
-
-        metadata = self._make_metadata([109, 209], [2, 2], num_reqs=2)
-
-        AscendMLAImpl._finalize_pending_reject(metadata)
-        AscendMLAImpl._finalize_pending_reject(metadata)
-
-        assert metadata.decode.seq_lens_list == [107, 207]
-        metadata.pending_reject_event.synchronize.assert_called_once_with()
-
-    def test_no_event_is_noop(self):
-        from vllm_ascend.attention.mla_v1 import AscendMLAImpl
-
-        metadata = self._make_metadata([109, 209], [2, 2], num_reqs=2, with_event=False)
-
-        AscendMLAImpl._finalize_pending_reject(metadata)
-
-        assert metadata.decode.seq_lens_list == [109, 209]
-        assert metadata.reject_finalized is False
 
 
 class TestPrepareParallelDraftSeqLensCPU:

--- a/tests/ut/spec_decode/test_dspark_proposer.py
+++ b/tests/ut/spec_decode/test_dspark_proposer.py
@@ -26,6 +26,7 @@ from unittest.mock import MagicMock, patch
 import numpy as np
 import pytest
 import torch
+from vllm.config import CUDAGraphMode
 from vllm.v1.worker.utils import AttentionGroup
 
 import vllm_ascend.spec_decode.dspark_proposer as dspark_proposer_module
@@ -63,6 +64,7 @@ class _DSparkProposerTestBase:
         block_size: int,
         hf_config: SimpleNamespace | None = None,
         draft_attn_causal: bool | None = None,
+        use_cuda_graph: bool = False,
     ):
         device = torch.device("cpu")
         vllm_config = cls._make_vllm_config(hf_config or SimpleNamespace())
@@ -83,6 +85,11 @@ class _DSparkProposerTestBase:
             proposer.hidden_size = _HIDDEN_SIZE
             proposer.hidden_states = torch.empty(0)
             proposer._dflash_hidden_states = torch.empty(0)
+            proposer._enable_probabilistic_draft_probs = (
+                vllm_config.speculative_config.draft_sample_method == "probabilistic"
+            )
+            proposer._last_draft_probs = None
+            proposer.use_cuda_graph = use_cuda_graph
             proposer.model = (
                 SimpleNamespace(get_draft_attn_causal=lambda: [draft_attn_causal])
                 if draft_attn_causal is not None
@@ -116,8 +123,10 @@ class _DSparkProposerTestBase:
         ]
         proposer._layer_group_idx = [gid]
         block_table = torch.zeros((num_reqs, 16), dtype=torch.int32, device=device)
+        block_table_buffer = torch.zeros((num_reqs + 1, 16), dtype=torch.int32, device=device)
+        block_table_buffer[:num_reqs].copy_(block_table)
         proposer._per_group_block_tables = {gid: block_table}
-        proposer._per_group_block_table_buffers = {gid: block_table}
+        proposer._per_group_block_table_buffers = {gid: block_table_buffer}
         slot = torch.zeros(max_num_tokens, dtype=torch.int32, device=device)
         proposer._per_group_slot_mappings = {gid: slot}
         proposer._per_group_kernel_block_sizes = {gid: block_size}
@@ -133,6 +142,8 @@ class _DSparkProposerTestBase:
         num_reqs,
         block_size,
         seq_len=128,
+        host_seq_len=None,
+        async_metadata=False,
         context=None,
         num_rejected=None,
         with_optional_attrs=False,
@@ -151,11 +162,16 @@ class _DSparkProposerTestBase:
         query_start_loc_cpu = torch.zeros(num_reqs + 1, dtype=torch.int32)
         if context is not None:
             query_start_loc_cpu[num_reqs] = context
+        if host_seq_len is None:
+            host_seq_len = seq_len
+        canonical_seq_lens_cpu = torch.full((num_reqs,), host_seq_len, dtype=torch.int32)
         cad = SimpleNamespace(
             num_reqs=num_reqs,
             query_start_loc=torch.arange(num_reqs + 1, dtype=torch.int32) * block_size,
             query_start_loc_cpu=query_start_loc_cpu,
             seq_lens=torch.full((num_reqs,), seq_len, dtype=torch.int32),
+            _seq_lens_cpu=canonical_seq_lens_cpu,
+            seq_lens_cpu=None if async_metadata else canonical_seq_lens_cpu,
             max_seq_len=seq_len,
         )
         if with_optional_attrs:
@@ -189,6 +205,8 @@ class TestDSparkPositionsFullUnderMultiDp(_DSparkProposerTestBase):
             query_start_loc=torch.arange(num_reqs + 1, dtype=torch.int32) * block_size,
             query_start_loc_cpu=torch.zeros(num_reqs + 1, dtype=torch.int32),
             seq_lens=torch.full((num_reqs,), 128, dtype=torch.int32),
+            _seq_lens_cpu=torch.full((num_reqs,), 128, dtype=torch.int32),
+            seq_lens_cpu=torch.full((num_reqs,), 128, dtype=torch.int32),
             max_seq_len=128,
         )
         proposer.set_inputs_first_pass(
@@ -392,10 +410,20 @@ class TestDSparkInitialization(_DSparkProposerTestBase):
             block_size=_NUM_SPECULATIVE_TOKENS,
             hf_config=hf_config,
         )
-        expected_max_query_tokens = _MAX_BATCH_SIZE * expected_num_query_per_req
+        expected_max_query_tokens = _MAX_BATCH_SIZE * (1 + _NUM_SPECULATIVE_TOKENS)
         assert proposer.sample_from_anchor is expected_sample_from_anchor
         assert proposer.num_query_per_req == expected_num_query_per_req
         assert proposer.max_query_tokens == expected_max_query_tokens
+
+    def test_static_config_preserves_parent_graph_mode(self) -> None:
+        proposer = self._make_proposer(
+            max_num_tokens=_MAX_NUM_TOKENS,
+            num_reqs=_MAX_BATCH_SIZE,
+            block_size=_NUM_SPECULATIVE_TOKENS,
+            use_cuda_graph=True,
+        )
+
+        assert proposer.use_cuda_graph is True
 
 
 # fmt: off
@@ -419,6 +447,22 @@ class TestSetPerGroupAttnMetadata(_DSparkProposerTestBase):
         assert proposer._per_group_block_tables[gid] is block_table
         assert proposer._per_group_slot_mappings[gid] is slot_mapping
 
+    def test_block_table_buffer_keeps_graph_padding_row(self):
+        num_reqs, block_size, max_num_tokens = 4, 5, 256
+        proposer = self._make_proposer(
+            max_num_tokens=max_num_tokens, num_reqs=num_reqs, block_size=block_size
+        )
+        gid = 7
+        block_table = torch.arange(num_reqs * 16, dtype=torch.int32).reshape(num_reqs, 16)
+        slot_mapping = torch.zeros(max_num_tokens, dtype=torch.int32)
+
+        proposer.set_per_group_attn_metadata(gid, block_table, slot_mapping)
+
+        buffer = proposer._per_group_block_table_buffers[gid]
+        assert buffer.shape == (num_reqs + 1, 16)
+        assert torch.equal(buffer[:num_reqs], block_table)
+        assert torch.count_nonzero(buffer[num_reqs]) == 0
+
     def test_overwrites_existing_gid(self):
         num_reqs, block_size, max_num_tokens = 2, 5, 256
         proposer = self._make_proposer(
@@ -435,12 +479,137 @@ class TestSetPerGroupAttnMetadata(_DSparkProposerTestBase):
         assert proposer._per_group_slot_mappings[gid] is new_slot_mapping
         assert proposer._per_group_block_tables[gid] is not old_block_table
 
+    def test_rejects_block_table_over_request_capacity(self):
+        num_reqs, block_size, max_num_tokens = 2, 5, 256
+        proposer = self._make_proposer(
+            max_num_tokens=max_num_tokens, num_reqs=num_reqs, block_size=block_size
+        )
+
+        with pytest.raises(ValueError, match="exceeds the configured request capacity"):
+            proposer.set_per_group_attn_metadata(
+                7,
+                torch.zeros((num_reqs + 1, 16), dtype=torch.int32),
+                torch.zeros(max_num_tokens, dtype=torch.int32),
+            )
+
+        assert 7 not in proposer._per_group_block_tables
+        assert 7 not in proposer._per_group_slot_mappings
+
+
+class TestPadQueryStartLocForGraph:
+    @staticmethod
+    def _make_query_start_loc(values: list[int], capacity: int):
+        host = np.zeros(capacity, dtype=np.int32)
+        host[: len(values)] = values
+        return SimpleNamespace(np=host, copy_to_gpu=MagicMock())
+
+    @pytest.mark.parametrize(
+        ("num_query_per_req", "real_num_reqs", "graph_num_reqs", "num_input_tokens", "expected"),
+        [
+            pytest.param(7, 1, 2, 16, [0, 7, 14, 16], id="virtual-tail"),
+            pytest.param(5, 2, 8, 48, [0, 5, 10, 15, 20, 25, 30, 35, 40, 48], id="request-padding"),
+            pytest.param(7, 1, 3, 16, [0, 7, 14, 16], id="clamped-to-token-budget"),
+        ],
+    )
+    def test_matches_graph_capture_layout(
+        self,
+        num_query_per_req: int,
+        real_num_reqs: int,
+        graph_num_reqs: int,
+        num_input_tokens: int,
+        expected: list[int],
+    ) -> None:
+        proposer = AscendDSparkProposer.__new__(AscendDSparkProposer)
+        proposer.num_query_per_req = num_query_per_req
+        initial = [idx * num_query_per_req for idx in range(real_num_reqs + 1)]
+        query_start_loc = self._make_query_start_loc(initial, graph_num_reqs + 2)
+
+        num_metadata_reqs = proposer.pad_query_start_loc_for_graph(
+            query_start_loc,
+            num_input_tokens,
+            real_num_reqs,
+            graph_num_reqs,
+        )
+
+        assert num_metadata_reqs == len(expected) - 1
+        assert query_start_loc.np[: num_metadata_reqs + 1].tolist() == expected
+        assert query_start_loc.np[: num_metadata_reqs + 1].max() <= num_input_tokens
+        query_start_loc.copy_to_gpu.assert_called_once_with()
+
+    def test_rejects_missing_tail_capacity(self) -> None:
+        proposer = AscendDSparkProposer.__new__(AscendDSparkProposer)
+        proposer.num_query_per_req = 7
+        query_start_loc = self._make_query_start_loc([0, 7], capacity=3)
+
+        with pytest.raises(ValueError, match="no room for the graph-padding tail"):
+            proposer.pad_query_start_loc_for_graph(
+                query_start_loc,
+                num_input_tokens=16,
+                real_num_reqs=1,
+                graph_num_reqs=2,
+            )
+
+
+class TestDSparkGraphDispatch:
+    def test_uses_target_verification_width(self, monkeypatch) -> None:
+        class StopAfterFirstDispatch(RuntimeError):
+            pass
+
+        batch_size = 16
+        num_speculative_tokens = 7
+        num_draft_tokens = batch_size * num_speculative_tokens
+        proposer = AscendSpecDecodeBaseProposer.__new__(AscendSpecDecodeBaseProposer)
+        proposer.method = "dspark"
+        proposer.num_speculative_tokens = num_speculative_tokens
+        proposer.hidden_size = _HIDDEN_SIZE
+        proposer.use_cuda_graph = True
+        proposer.model = SimpleNamespace(combine_hidden_states=lambda hidden_states: hidden_states)
+        proposer.set_inputs_first_pass = MagicMock(
+            return_value=(
+                num_draft_tokens,
+                torch.arange(num_draft_tokens, dtype=torch.int32),
+                SimpleNamespace(),
+                None,
+            )
+        )
+        dispatcher = MagicMock()
+        dispatcher.dispatch.return_value = (
+            CUDAGraphMode.FULL,
+            SimpleNamespace(num_tokens=128, num_reqs=batch_size),
+        )
+        proposer.runner = SimpleNamespace(
+            dcp_manager=None,
+            input_batch=SimpleNamespace(lora_id_to_lora_request={}),
+            cudagraph_dispatcher=dispatcher,
+            _sync_metadata_across_dp=MagicMock(side_effect=StopAfterFirstDispatch),
+        )
+        metadata = SimpleNamespace(batch_size=lambda: batch_size)
+        monkeypatch.setattr(
+            "vllm_ascend.spec_decode.llm_base_proposer.K3DSparkForCausalLM",
+            object,
+        )
+
+        with pytest.raises(StopAfterFirstDispatch):
+            proposer._propose(
+                target_token_ids=torch.zeros(num_draft_tokens, dtype=torch.int64),
+                target_positions=torch.zeros(num_draft_tokens, dtype=torch.int32),
+                target_hidden_states=torch.zeros((num_draft_tokens, _HIDDEN_SIZE)),
+                next_token_ids=torch.zeros(batch_size, dtype=torch.int64),
+                token_indices_to_sample=torch.arange(num_draft_tokens, dtype=torch.int32),
+                common_attn_metadata=metadata,
+                target_model_batch_desc=SimpleNamespace(uniform=True),
+                sampling_metadata=SimpleNamespace(),
+            )
+
+        dispatcher.dispatch.assert_called_once_with(
+            num_tokens=batch_size * (1 + num_speculative_tokens),
+            uniform_decode=True,
+            has_lora=False,
+        )
+
 
 class TestDSparkInitValidation:
-    """``AscendDSparkProposer.__init__`` rejects probabilistic draft sampling
-    (unsupported on the v1 model runner) and, for the greedy path, allocates
-    the DSpark-specific draft/seed buffers and overrides the DFlash
-    query-token / cudagraph defaults."""
+    """Tests DSpark-specific buffers and graph/query-layout overrides."""
 
     @staticmethod
     def _make_vllm_config(
@@ -470,6 +639,7 @@ class TestDSparkInitValidation:
         max_num_tokens,
         dtype,
         device,
+        use_cuda_graph=False,
     ):
         """Replace the heavy DFlash/Eagle base init with a stub that only sets
         the attributes DSpark's ``__init__`` subsequently reads."""
@@ -485,6 +655,12 @@ class TestDSparkInitValidation:
             self.hidden_size = 0
             self.hidden_states = None
             self._dflash_hidden_states = None
+            self._enable_probabilistic_draft_probs = (
+                vllm_config.speculative_config.draft_sample_method
+                == "probabilistic"
+            )
+            self._last_draft_probs = None
+            self.use_cuda_graph = use_cuda_graph
 
         monkeypatch.setattr(AscendDflashProposer, "__init__", _stub)
 
@@ -528,7 +704,7 @@ class TestDSparkInitValidation:
         proposer = AscendDSparkProposer(vllm_config, device)
 
         blk = 1 + num_spec
-        max_query_tokens = max_batch * num_spec
+        max_query_tokens = max_batch * blk
         # DSpark-specific draft / seed buffers.
         assert proposer._dspark_draft_buffer.shape == (max_batch, blk)
         assert proposer._dspark_draft_buffer.dtype == torch.int64
@@ -538,10 +714,10 @@ class TestDSparkInitValidation:
         assert proposer.hidden_size == hidden
         assert proposer.hidden_states.shape == (max_num_tokens, hidden)
         assert proposer._dflash_hidden_states.shape == (max_num_tokens, hidden)
-        # DSpark runs eager only (Ascend cudagraph unsupported on this path).
+        # The parent graph mode is preserved; this stub configures eager mode.
         assert proposer.use_cuda_graph is False
-        # anchor-first: N query tokens per request, no bonus token (unlike
-        # DFlash's 1+N).
+        # Capacity follows the target verification width (1+N), including
+        # anchor-first graph-padding tokens.
         assert proposer.max_query_tokens == max_query_tokens
         assert proposer.positions.shape == (max_query_tokens,)
         assert proposer.positions.dtype == torch.int32
@@ -684,7 +860,31 @@ class TestSetInputsFirstPassOutputs(_DSparkProposerTestBase):
         assert torch.equal(cad.query_start_loc, expected_qsl)
         assert torch.equal(cad.query_start_loc_cpu, expected_qsl)
         # seq_lens grow by block_size when no tokens were rejected.
-        assert torch.equal(cad.seq_lens, torch.full((num_reqs,), 128 + block_size, dtype=torch.int32))
+        expected_seq_lens = torch.full((num_reqs,), 128 + block_size, dtype=torch.int32)
+        assert torch.equal(cad.seq_lens, expected_seq_lens)
+        assert torch.equal(cad._seq_lens_cpu, expected_seq_lens)
+        assert torch.equal(cad.seq_lens_cpu, expected_seq_lens)
+
+    def test_canonical_host_seq_lens_remains_authoritative(self):
+        num_reqs, block_size, max_num_tokens = 4, 5, 256
+        proposer = self._make_proposer(
+            max_num_tokens=max_num_tokens, num_reqs=num_reqs, block_size=block_size
+        )
+
+        _nqt, _ti, cad, _extra = self._invoke_set_inputs_first_pass(
+            proposer,
+            num_reqs=num_reqs,
+            block_size=block_size,
+            seq_len=128,
+            host_seq_len=126,
+            async_metadata=True,
+        )[:4]
+
+        assert torch.equal(
+            cad._seq_lens_cpu,
+            torch.full((num_reqs,), 126 + block_size, dtype=torch.int32),
+        )
+        assert cad.seq_lens_cpu is None
 
 
 class TestSetInputsFirstPassRejectedTokens(_DSparkProposerTestBase):
@@ -703,12 +903,22 @@ class TestSetInputsFirstPassRejectedTokens(_DSparkProposerTestBase):
         )
         rejected = torch.full((num_reqs,), 2, dtype=torch.int32)
         _nqt, _ti, cad, _extra = self._invoke_set_inputs_first_pass(
-            proposer, num_reqs=num_reqs, block_size=block_size, num_rejected=rejected
+            proposer,
+            num_reqs=num_reqs,
+            block_size=block_size,
+            host_seq_len=126,
+            async_metadata=True,
+            num_rejected=rejected,
         )[:4]
         # effective = seq_lens(128) - rejected(2) = 126; then + block_size(5) = 131.
         assert torch.equal(
             cad.seq_lens, torch.full((num_reqs,), 128 - 2 + block_size, dtype=torch.int32)
         )
+        assert torch.equal(
+            cad._seq_lens_cpu,
+            torch.full((num_reqs,), 126 + block_size, dtype=torch.int32),
+        )
+        assert cad.seq_lens_cpu is None
 
     def test_kernel_called_with_has_num_rejected(self, monkeypatch):
         kernel = MagicMock()

--- a/tests/ut/spec_decode/test_dspark_proposer.py
+++ b/tests/ut/spec_decode/test_dspark_proposer.py
@@ -853,23 +853,72 @@ class TestSetInputsFirstPassOutputs(_DSparkProposerTestBase):
         proposer = self._make_proposer(
             max_num_tokens=max_num_tokens, num_reqs=num_reqs, block_size=block_size
         )
+        proposer._draft_uses_mla_backend = True
         _nqt, _ti, cad, _extra = self._invoke_set_inputs_first_pass(
             proposer, num_reqs=num_reqs, block_size=block_size
         )[:4]
         expected_qsl = torch.arange(num_reqs + 1, dtype=torch.int32) * block_size
         assert torch.equal(cad.query_start_loc, expected_qsl)
         assert torch.equal(cad.query_start_loc_cpu, expected_qsl)
-        # seq_lens grow by block_size when no tokens were rejected.
+        # Only the device seq_lens grow by block_size when no tokens were
+        # rejected. The host mirrors (_seq_lens_cpu / seq_lens_cpu) keep their
+        # optimistic value (L_t + rejected_t); _prepare_parallel_draft_seq_lens_cpu
+        # adds exactly one N later, so the draft KV length is not double-counted.
         expected_seq_lens = torch.full((num_reqs,), 128 + block_size, dtype=torch.int32)
         assert torch.equal(cad.seq_lens, expected_seq_lens)
-        assert torch.equal(cad._seq_lens_cpu, expected_seq_lens)
-        assert torch.equal(cad.seq_lens_cpu, expected_seq_lens)
+        expected_host_seq_lens = torch.full((num_reqs,), 128, dtype=torch.int32)
+        assert torch.equal(cad._seq_lens_cpu, expected_host_seq_lens)
+        assert torch.equal(cad.seq_lens_cpu, expected_host_seq_lens)
+
+    @pytest.mark.parametrize(
+        ("backend_kind", "expected_host_seq_len"),
+        [
+            ("mla", 128),
+            ("dsa", 133),
+            ("ordinary", 128),
+        ],
+    )
+    def test_host_seq_lens_follow_backend_contract(
+        self,
+        backend_kind,
+        expected_host_seq_len,
+    ):
+        num_reqs, block_size, max_num_tokens = 4, 5, 256
+        proposer = self._make_proposer(
+            max_num_tokens=max_num_tokens, num_reqs=num_reqs, block_size=block_size
+        )
+        proposer._draft_uses_mla_backend = backend_kind == "mla"
+        proposer._draft_uses_dsa_backend = backend_kind == "dsa"
+        rejected = torch.full((num_reqs,), 2, dtype=torch.int32)
+
+        _nqt, _ti, cad, _extra = self._invoke_set_inputs_first_pass(
+            proposer,
+            num_reqs=num_reqs,
+            block_size=block_size,
+            seq_len=128,
+            host_seq_len=128,
+            num_rejected=rejected,
+        )[:4]
+
+        # Device length is always exact: L_t + N = 128 - 2 + 5.
+        assert torch.equal(
+            cad.seq_lens,
+            torch.full((num_reqs,), 131, dtype=torch.int32),
+        )
+        expected_host = torch.full(
+            (num_reqs,),
+            expected_host_seq_len,
+            dtype=torch.int32,
+        )
+        assert torch.equal(cad._seq_lens_cpu, expected_host)
+        assert torch.equal(cad.seq_lens_cpu, expected_host)
 
     def test_canonical_host_seq_lens_remains_authoritative(self):
         num_reqs, block_size, max_num_tokens = 4, 5, 256
         proposer = self._make_proposer(
             max_num_tokens=max_num_tokens, num_reqs=num_reqs, block_size=block_size
         )
+        proposer._draft_uses_mla_backend = True
 
         _nqt, _ti, cad, _extra = self._invoke_set_inputs_first_pass(
             proposer,
@@ -880,9 +929,11 @@ class TestSetInputsFirstPassOutputs(_DSparkProposerTestBase):
             async_metadata=True,
         )[:4]
 
+        # Host mirror keeps its optimistic value (L_t + rejected_t); the +N is
+        # left to _prepare_parallel_draft_seq_lens_cpu to avoid double counting.
         assert torch.equal(
             cad._seq_lens_cpu,
-            torch.full((num_reqs,), 126 + block_size, dtype=torch.int32),
+            torch.full((num_reqs,), 126, dtype=torch.int32),
         )
         assert cad.seq_lens_cpu is None
 
@@ -901,6 +952,7 @@ class TestSetInputsFirstPassRejectedTokens(_DSparkProposerTestBase):
         proposer = self._make_proposer(
             max_num_tokens=max_num_tokens, num_reqs=num_reqs, block_size=block_size
         )
+        proposer._draft_uses_mla_backend = True
         rejected = torch.full((num_reqs,), 2, dtype=torch.int32)
         _nqt, _ti, cad, _extra = self._invoke_set_inputs_first_pass(
             proposer,
@@ -914,9 +966,10 @@ class TestSetInputsFirstPassRejectedTokens(_DSparkProposerTestBase):
         assert torch.equal(
             cad.seq_lens, torch.full((num_reqs,), 128 - 2 + block_size, dtype=torch.int32)
         )
+        # Host mirror keeps its optimistic value (126) without +N here.
         assert torch.equal(
             cad._seq_lens_cpu,
-            torch.full((num_reqs,), 126 + block_size, dtype=torch.int32),
+            torch.full((num_reqs,), 126, dtype=torch.int32),
         )
         assert cad.seq_lens_cpu is None
 
@@ -995,8 +1048,12 @@ class TestInitializeAttnBackendErrors(_DSparkProposerTestBase):
         for spec in manager_specs:
             spec.block_size = 384
 
-        backend = MagicMock()
-        backend.full_cls_name.return_value = "fake.backend"
+        class FakeBackend:
+            @classmethod
+            def full_cls_name(cls):
+                return "fake.backend"
+
+        backend = FakeBackend
         layers = {}
         for gid in range(2):
             layer = MagicMock()
@@ -1039,6 +1096,8 @@ class TestInitializeAttnBackendErrors(_DSparkProposerTestBase):
         assert set(proposer._per_group_query_slot_mapping_buffers) == {0, 1}
         assert set(proposer._per_group_context_slot_mapping_buffers) == {0, 1}
         assert proposer.kernel_block_size == 128
+        assert proposer._draft_uses_mla_backend is False
+        assert proposer._draft_uses_dsa_backend is False
         assert [
             call.kwargs["kernel_block_size"]
             for call in create_builders.call_args_list
@@ -1058,10 +1117,8 @@ class TestInitializeAttnBackendErrors(_DSparkProposerTestBase):
             del args, kwargs
             group.metadata_builders = [fake_builder]
 
-        backend = MagicMock()
-        backend.full_cls_name.return_value = "fake.backend"
         layer = MagicMock()
-        layer.get_attn_backend.return_value = backend
+        layer.get_attn_backend.return_value = dspark_proposer_module.AscendMLABackend
         monkeypatch.setattr(
             dspark_proposer_module,
             "get_layers_from_vllm_config",
@@ -1100,6 +1157,40 @@ class TestInitializeAttnBackendErrors(_DSparkProposerTestBase):
         proposer.initialize_attn_backend(kv_cache_config)
 
         assert fake_builder.use_mla_rope is dspark_proposer_module.K3_DSPARK_USE_MLA_ROPE
+        assert proposer._draft_uses_mla_backend is True
+        assert proposer._draft_uses_dsa_backend is False
+
+    def test_initialization_detects_dsa_backend(self, monkeypatch):
+        layer = MagicMock()
+        layer.get_attn_backend.return_value = dspark_proposer_module.AscendDSABackend
+        monkeypatch.setattr(
+            dspark_proposer_module,
+            "get_layers_from_vllm_config",
+            lambda *args, **kwargs: {"L0": layer},
+        )
+
+        proposer = self._make_proposer_for_init()
+        proposer.model = SimpleNamespace(
+            get_draft_kv_cache_layer_names=lambda: {"L0"}
+        )
+        proposer.max_query_tokens = 8
+        proposer.max_num_tokens = 16
+        manager_spec = MagicMock()
+        manager_spec.block_size = 128
+        kv_cache_config = SimpleNamespace(
+            kv_cache_groups=[
+                SimpleNamespace(
+                    layer_names=["L0"],
+                    kv_cache_spec=manager_spec,
+                )
+            ]
+        )
+
+        with patch.object(AttentionGroup, "create_metadata_builders"):
+            proposer.initialize_attn_backend(kv_cache_config)
+
+        assert proposer._draft_uses_mla_backend is False
+        assert proposer._draft_uses_dsa_backend is True
 
     def test_kernel_block_size_falls_back_to_cache_spec(self):
         proposer = self._make_proposer_for_init()
@@ -1113,3 +1204,155 @@ class TestInitializeAttnBackendErrors(_DSparkProposerTestBase):
             == 384
         )
 # fmt: on
+
+
+class TestFinalizePendingReject:
+    """``AscendMLAImpl._finalize_pending_reject`` is shared by the eager FIA
+    entry and the FULL-graph replay update path. It must subtract the pending
+    reject counts exactly once per metadata object."""
+
+    @staticmethod
+    def _make_metadata(seq_lens_list, reject, num_reqs, with_event=True):
+        from vllm_ascend.attention.mla_v1 import AscendMLAImpl  # noqa: F401
+
+        return SimpleNamespace(
+            pending_reject_event=(MagicMock() if with_event else None),
+            pending_reject_cpu=torch.tensor(reject, dtype=torch.int32),
+            pending_reject_num_reqs=num_reqs,
+            reject_finalized=False,
+            decode=SimpleNamespace(seq_lens_list=list(seq_lens_list)),
+        )
+
+    def test_subtracts_reject_counts_once(self):
+        from vllm_ascend.attention.mla_v1 import AscendMLAImpl
+
+        # parallel = (L_t + rejected_t) + N; finalize must yield L_t + N.
+        lt, n = 100, 7
+        rejected = [2, 5]
+        seq_lens_list = [lt + rejected[0] + n, lt + rejected[1] + n, 0]
+        metadata = self._make_metadata(seq_lens_list, rejected, num_reqs=2)
+
+        AscendMLAImpl._finalize_pending_reject(metadata)
+
+        assert metadata.decode.seq_lens_list == [lt + n, lt + n, 0]
+        assert metadata.reject_finalized is True
+        metadata.pending_reject_event.synchronize.assert_called_once_with()
+
+    def test_reentry_is_guarded(self):
+        from vllm_ascend.attention.mla_v1 import AscendMLAImpl
+
+        metadata = self._make_metadata([109, 209], [2, 2], num_reqs=2)
+
+        AscendMLAImpl._finalize_pending_reject(metadata)
+        AscendMLAImpl._finalize_pending_reject(metadata)
+
+        assert metadata.decode.seq_lens_list == [107, 207]
+        metadata.pending_reject_event.synchronize.assert_called_once_with()
+
+    def test_no_event_is_noop(self):
+        from vllm_ascend.attention.mla_v1 import AscendMLAImpl
+
+        metadata = self._make_metadata([109, 209], [2, 2], num_reqs=2, with_event=False)
+
+        AscendMLAImpl._finalize_pending_reject(metadata)
+
+        assert metadata.decode.seq_lens_list == [109, 209]
+        assert metadata.reject_finalized is False
+
+
+class TestPrepareParallelDraftSeqLensCPU:
+    @staticmethod
+    def _make_proposer(*, uses_mla: bool, reject_event=None):
+        proposer = AscendDSparkProposer.__new__(AscendDSparkProposer)
+        proposer.parallel_drafting = True
+        proposer.num_query_per_req = 7
+        proposer._draft_uses_mla_backend = uses_mla
+        proposer.runner = SimpleNamespace(
+            num_rejected_tokens_event=reject_event,
+            num_rejected_tokens_cpu=torch.tensor([2, 3], dtype=torch.int32),
+        )
+        return proposer
+
+    @staticmethod
+    def _make_metadata():
+        return SimpleNamespace(
+            # Includes one FULL-graph padding request after the two real ones.
+            num_reqs=3,
+            # Padded target metadata is still optimistic on the host.
+            _seq_lens_cpu=torch.tensor([102, 203, 0], dtype=torch.int32),
+            seq_lens_cpu=torch.tensor([102, 203, 0], dtype=torch.int32),
+            seq_lens_cpu_upper_bound=torch.tensor([102, 203, 0], dtype=torch.int32),
+            # set_inputs_first_pass has already applied reject and added N.
+            seq_lens=torch.tensor([107, 207, 0], dtype=torch.int32),
+            parallel_draft_seq_lens_cpu=None,
+            parallel_draft_num_reject_cpu=None,
+            parallel_draft_num_reject_event=None,
+            parallel_draft_num_reject_num_reqs=0,
+        )
+
+    def test_sync_padded_mla_uses_exact_device_seq_lens(self):
+        proposer = self._make_proposer(uses_mla=True)
+        metadata = self._make_metadata()
+
+        proposer._prepare_parallel_draft_seq_lens_cpu(
+            metadata,
+            batch_size=2,
+            num_draft_tokens_cpu=[7, 7],
+        )
+
+        assert torch.equal(
+            metadata.parallel_draft_seq_lens_cpu,
+            torch.tensor([107, 207, 0], dtype=torch.int32),
+        )
+        # The canonical host mirror remains untouched for other consumers.
+        assert torch.equal(
+            metadata._seq_lens_cpu,
+            torch.tensor([102, 203, 0], dtype=torch.int32),
+        )
+
+    @pytest.mark.parametrize("reject_event", [None, object()])
+    def test_non_mla_does_not_publish_parallel_lengths(self, reject_event):
+        proposer = self._make_proposer(
+            uses_mla=False,
+            reject_event=reject_event,
+        )
+        metadata = self._make_metadata()
+
+        proposer._prepare_parallel_draft_seq_lens_cpu(
+            metadata,
+            batch_size=2,
+            num_draft_tokens_cpu=[7, 7],
+        )
+
+        assert metadata.parallel_draft_seq_lens_cpu is None
+
+
+class TestIsK3DSparkGate:
+    """The K3-only gate for graph-mode draft actions: True only for a DSpark
+    drafter whose draft hf_config is a K3DSparkConfig; False for other
+    backends (DeepSeek V4 DSA, GLM5.2 regular attention) and other methods,
+    so those models keep their original code paths."""
+
+    def test_k3_dspark_detected(self):
+        from vllm_ascend.spec_decode.llm_base_proposer import _is_k3_dspark
+        from vllm_ascend.transformers_utils.configs.kimi_k3 import K3DSparkConfig
+
+        k3_config = K3DSparkConfig.__new__(K3DSparkConfig)
+
+        assert _is_k3_dspark("dspark", k3_config) is True
+
+    def test_non_k3_config_rejected(self):
+        from vllm_ascend.spec_decode.llm_base_proposer import _is_k3_dspark
+
+        assert _is_k3_dspark("dspark", SimpleNamespace()) is False
+        assert _is_k3_dspark("dspark", None) is False
+
+    def test_non_dspark_method_rejected(self):
+        from vllm_ascend.spec_decode.llm_base_proposer import _is_k3_dspark
+        from vllm_ascend.transformers_utils.configs.kimi_k3 import K3DSparkConfig
+
+        k3_config = K3DSparkConfig.__new__(K3DSparkConfig)
+
+        assert _is_k3_dspark("dflash", k3_config) is False
+        assert _is_k3_dspark("mtp", k3_config) is False
+        assert _is_k3_dspark("eagle", k3_config) is False

--- a/tests/ut/spec_decode/test_llm_base_proposer.py
+++ b/tests/ut/spec_decode/test_llm_base_proposer.py
@@ -19,6 +19,7 @@
 from __future__ import annotations
 
 from types import SimpleNamespace
+from unittest.mock import MagicMock
 
 import pytest
 import torch
@@ -113,6 +114,98 @@ class TestDisablePaddedDrafterBatchWithFullGraph:
         )
 
         proposer._raise_if_padded_drafter_batch_disabled_and_full_graph_enabled()
+
+
+class TestDSparkFullGraphSeqLens:
+    def test_preserves_corrected_device_and_host_lengths(self, monkeypatch):
+        class StopAfterSeqLensPadding(RuntimeError):
+            pass
+
+        batch_size = 2
+        num_speculative_tokens = 7
+        metadata = SimpleNamespace(
+            batch_size=lambda: batch_size,
+            num_reqs=batch_size,
+            query_start_loc=torch.tensor([0, 7, 14], dtype=torch.int32),
+            query_start_loc_cpu=torch.tensor([0, 7, 14], dtype=torch.int32),
+            block_table_tensor=torch.ones((batch_size, 4), dtype=torch.int32),
+            seq_lens=torch.tensor([107, 207], dtype=torch.int32),
+            seq_lens_cpu=torch.tensor([108, 208], dtype=torch.int32),
+            _seq_lens_cpu=torch.tensor([109, 209], dtype=torch.int32),
+            num_computed_tokens_cpu=None,
+        )
+        proposer = AscendSpecDecodeBaseProposer.__new__(AscendSpecDecodeBaseProposer)
+        proposer.method = "dspark"
+        proposer.num_speculative_tokens = num_speculative_tokens
+        proposer.hidden_size = 4
+        proposer.use_cuda_graph = True
+        proposer.model = SimpleNamespace(combine_hidden_states=lambda hidden_states: hidden_states)
+        proposer.set_inputs_first_pass = MagicMock(
+            return_value=(
+                batch_size * num_speculative_tokens,
+                torch.arange(batch_size * num_speculative_tokens, dtype=torch.int32),
+                metadata,
+                None,
+            )
+        )
+        dispatcher = MagicMock()
+        dispatcher.dispatch.side_effect = [
+            (
+                CUDAGraphMode.FULL,
+                SimpleNamespace(num_tokens=16, num_reqs=batch_size),
+            ),
+            (
+                CUDAGraphMode.FULL,
+                SimpleNamespace(num_tokens=16, num_reqs=batch_size),
+            ),
+        ]
+        proposer.runner = SimpleNamespace(
+            dcp_manager=None,
+            input_batch=SimpleNamespace(lora_id_to_lora_request={}),
+            cudagraph_dispatcher=dispatcher,
+            _sync_metadata_across_dp=MagicMock(return_value=(16, None, None)),
+            seq_lens=torch.tensor([1, 2], dtype=torch.int32),
+            optimistic_seq_lens_cpu=torch.tensor([3, 4], dtype=torch.int32),
+        )
+        query_start_loc_cpu = torch.zeros(6, dtype=torch.int32)
+        proposer.query_start_loc = SimpleNamespace(
+            gpu=torch.zeros(6, dtype=torch.int32),
+            cpu=query_start_loc_cpu,
+            np=query_start_loc_cpu.numpy(),
+        )
+        proposer.pad_query_start_loc_for_graph = MagicMock(return_value=3)
+        proposer.decode_threshold = 1 + num_speculative_tokens
+        proposer.dcp_size = 1
+
+        captured = {}
+
+        def stop_after_seq_lens_padding(common_attn_metadata, *_args):
+            captured["seq_lens"] = common_attn_metadata.seq_lens.clone()
+            captured["seq_lens_cpu"] = common_attn_metadata.seq_lens_cpu.clone()
+            captured["_seq_lens_cpu"] = common_attn_metadata._seq_lens_cpu.clone()
+            raise StopAfterSeqLensPadding
+
+        proposer._prepare_parallel_draft_seq_lens_cpu = stop_after_seq_lens_padding
+        monkeypatch.setattr(
+            "vllm_ascend.spec_decode.llm_base_proposer.K3DSparkForCausalLM",
+            object,
+        )
+
+        with pytest.raises(StopAfterSeqLensPadding):
+            proposer._propose(
+                target_token_ids=torch.zeros(batch_size, dtype=torch.int64),
+                target_positions=torch.zeros(batch_size, dtype=torch.int32),
+                target_hidden_states=torch.zeros((batch_size, 4)),
+                next_token_ids=torch.zeros(batch_size, dtype=torch.int64),
+                token_indices_to_sample=torch.arange(batch_size, dtype=torch.int32),
+                common_attn_metadata=metadata,
+                target_model_batch_desc=SimpleNamespace(uniform=True),
+                sampling_metadata=SimpleNamespace(),
+            )
+
+        assert torch.equal(captured["seq_lens"], torch.tensor([107, 207, 0], dtype=torch.int32))
+        assert torch.equal(captured["seq_lens_cpu"], torch.tensor([108, 208, 0], dtype=torch.int32))
+        assert torch.equal(captured["_seq_lens_cpu"], torch.tensor([109, 209, 0], dtype=torch.int32))
 
 
 class TestDisableFlashCommV1Context:

--- a/vllm_ascend/attention/mla_v1.py
+++ b/vllm_ascend/attention/mla_v1.py
@@ -989,44 +989,15 @@ class AscendMLAImpl(MLAAttentionImpl):
         num_layers = len(attn_keys)
         if num_layers == 0:
             return
-        if graph_params is None:
-            raise RuntimeError("MLA graph parameters were not initialized before graph replay.")
-
-        captured_attn_params = graph_params.attn_params.get(num_tokens)
-        captured_handles = graph_params.handles.get(num_tokens)
-        captured_events = graph_params.events.get(num_tokens)
-        if not captured_attn_params or not captured_handles or not captured_events:
-            populated_sizes = sorted(
-                size for size, params in graph_params.attn_params.items() if params
-            )
-            raise RuntimeError(
-                "No captured MLA graph parameters for the requested Query T: "
-                f"{num_tokens=}, populated_sizes={populated_sizes}. The graph "
-                "update key must match the Query T used during capture."
-            )
-        if not (
-            len(captured_attn_params) == len(captured_handles) == len(captured_events)
-        ):
-            raise RuntimeError(
-                "Incomplete captured MLA graph parameters for "
-                f"{num_tokens=}: attn_params={len(captured_attn_params)}, "
-                f"handles={len(captured_handles)}, events={len(captured_events)}."
-            )
         if _EXTRA_CTX.is_draft_model:
-            if len(captured_attn_params) % num_layers != 0:
-                raise RuntimeError(
-                    "Captured MLA draft attention count is not aligned with "
-                    f"the runtime layer count for {num_tokens=}: "
-                    f"captured={len(captured_attn_params)}, layers={num_layers}."
-                )
-            attn_keys = attn_keys * (len(captured_attn_params) // num_layers)
+            attn_keys = attn_keys * (len(graph_params.attn_params[num_tokens]) // num_layers)
         attn_count = 0
         with torch.npu.stream(update_stream):
             for key, param, handle, event in zip(
                 attn_keys,
-                captured_attn_params,
-                captured_handles,
-                captured_events,
+                graph_params.attn_params[num_tokens],
+                graph_params.handles[num_tokens],
+                graph_params.events[num_tokens],
             ):
                 (
                     q_nope,
@@ -1062,17 +1033,6 @@ class AscendMLAImpl(MLAAttentionImpl):
                     attn_metadata_current = attn_metadata
 
                 seq_lens_list = attn_metadata_current[key].decode.seq_lens_list
-                # The draft FULL-graph update deliberately consumes the
-                # optimistic host length (L_t + rejected_t + N) as a safe upper
-                # bound, WITHOUT the pending-reject finalize. The rejected_t
-                # over-read only attends to stale draft KV slots that the next
-                # step overwrites; it slightly degrades draft quality but can
-                # never affect the target-verified output. Subtracting the
-                # reject counts here would require a per-step host wait on the
-                # side-stream D2H event, which measurably costs TPOT
-                # (~2-3ms/step on K3 DSpark), so the graph path skips the
-                # finalize. The eager path still finalizes exactly at
-                # ``_forward_decode`` and yields L_t + N there.
                 if speculative_config and speculative_config.use_eagle() and not _EXTRA_CTX.is_draft_model:
                     actual_seq_lengths = attn_metadata_current[key].decode.actual_seq_lengths_q
                     spec_multiple = speculative_config.num_speculative_tokens + 1
@@ -1707,26 +1667,6 @@ class AscendMLAImpl(MLAAttentionImpl):
         x = torch_npu.npu_interleave_rope(x, cos, sin)
         return x.view(B, N, D)
 
-    @staticmethod
-    def _finalize_pending_reject(attn_metadata) -> None:
-        """Subtract the pending reject counts from ``decode.seq_lens_list`` once.
-
-        Shared by the eager ``_forward_decode`` entry and the FULL-graph
-        replay update path (``update_graph_params``). The side-stream D2H of
-        the reject counts was launched right after prepare_inputs_padded, so
-        by the time either consumer runs the copy is typically complete and
-        the event synchronize is effectively a no-op. ``reject_finalized``
-        guards re-entry across draft layers sharing one metadata object.
-        """
-        if attn_metadata.pending_reject_event is None or attn_metadata.reject_finalized:
-            return
-        attn_metadata.pending_reject_event.synchronize()
-        reject = attn_metadata.pending_reject_cpu[: attn_metadata.pending_reject_num_reqs].tolist()
-        seq_lens_list = attn_metadata.decode.seq_lens_list
-        for i in range(attn_metadata.pending_reject_num_reqs):
-            seq_lens_list[i] -= reject[i]
-        attn_metadata.reject_finalized = True
-
     def _forward_decode(
         self,
         q_nope: torch.Tensor,
@@ -1746,7 +1686,13 @@ class AscendMLAImpl(MLAAttentionImpl):
         # object; layers sharing this metadata skip via reject_finalized. The
         # D2H was launched right after prepare_inputs_padded, so by the first
         # attention layer the copy is typically already complete (sync no-op).
-        self._finalize_pending_reject(attn_metadata)
+        if attn_metadata.pending_reject_event is not None and not attn_metadata.reject_finalized:
+            attn_metadata.pending_reject_event.synchronize()
+            reject = attn_metadata.pending_reject_cpu[: attn_metadata.pending_reject_num_reqs].tolist()
+            seq_lens_list = decode_meta.seq_lens_list
+            for i in range(attn_metadata.pending_reject_num_reqs):
+                seq_lens_list[i] -= reject[i]
+            attn_metadata.reject_finalized = True
         # TODO: The CANN package is expected to support num_heads that are not
         # powers of 2 in 2026 Q2. Once supported, all padding operations under
         # `if self.head_padding > 0` in this function can be removed.

--- a/vllm_ascend/attention/mla_v1.py
+++ b/vllm_ascend/attention/mla_v1.py
@@ -989,15 +989,44 @@ class AscendMLAImpl(MLAAttentionImpl):
         num_layers = len(attn_keys)
         if num_layers == 0:
             return
+        if graph_params is None:
+            raise RuntimeError("MLA graph parameters were not initialized before graph replay.")
+
+        captured_attn_params = graph_params.attn_params.get(num_tokens)
+        captured_handles = graph_params.handles.get(num_tokens)
+        captured_events = graph_params.events.get(num_tokens)
+        if not captured_attn_params or not captured_handles or not captured_events:
+            populated_sizes = sorted(
+                size for size, params in graph_params.attn_params.items() if params
+            )
+            raise RuntimeError(
+                "No captured MLA graph parameters for the requested Query T: "
+                f"{num_tokens=}, populated_sizes={populated_sizes}. The graph "
+                "update key must match the Query T used during capture."
+            )
+        if not (
+            len(captured_attn_params) == len(captured_handles) == len(captured_events)
+        ):
+            raise RuntimeError(
+                "Incomplete captured MLA graph parameters for "
+                f"{num_tokens=}: attn_params={len(captured_attn_params)}, "
+                f"handles={len(captured_handles)}, events={len(captured_events)}."
+            )
         if _EXTRA_CTX.is_draft_model:
-            attn_keys = attn_keys * (len(graph_params.attn_params[num_tokens]) // num_layers)
+            if len(captured_attn_params) % num_layers != 0:
+                raise RuntimeError(
+                    "Captured MLA draft attention count is not aligned with "
+                    f"the runtime layer count for {num_tokens=}: "
+                    f"captured={len(captured_attn_params)}, layers={num_layers}."
+                )
+            attn_keys = attn_keys * (len(captured_attn_params) // num_layers)
         attn_count = 0
         with torch.npu.stream(update_stream):
             for key, param, handle, event in zip(
                 attn_keys,
-                graph_params.attn_params[num_tokens],
-                graph_params.handles[num_tokens],
-                graph_params.events[num_tokens],
+                captured_attn_params,
+                captured_handles,
+                captured_events,
             ):
                 (
                     q_nope,

--- a/vllm_ascend/attention/mla_v1.py
+++ b/vllm_ascend/attention/mla_v1.py
@@ -1062,6 +1062,17 @@ class AscendMLAImpl(MLAAttentionImpl):
                     attn_metadata_current = attn_metadata
 
                 seq_lens_list = attn_metadata_current[key].decode.seq_lens_list
+                # The draft FULL-graph update deliberately consumes the
+                # optimistic host length (L_t + rejected_t + N) as a safe upper
+                # bound, WITHOUT the pending-reject finalize. The rejected_t
+                # over-read only attends to stale draft KV slots that the next
+                # step overwrites; it slightly degrades draft quality but can
+                # never affect the target-verified output. Subtracting the
+                # reject counts here would require a per-step host wait on the
+                # side-stream D2H event, which measurably costs TPOT
+                # (~2-3ms/step on K3 DSpark), so the graph path skips the
+                # finalize. The eager path still finalizes exactly at
+                # ``_forward_decode`` and yields L_t + N there.
                 if speculative_config and speculative_config.use_eagle() and not _EXTRA_CTX.is_draft_model:
                     actual_seq_lengths = attn_metadata_current[key].decode.actual_seq_lengths_q
                     spec_multiple = speculative_config.num_speculative_tokens + 1
@@ -1696,6 +1707,26 @@ class AscendMLAImpl(MLAAttentionImpl):
         x = torch_npu.npu_interleave_rope(x, cos, sin)
         return x.view(B, N, D)
 
+    @staticmethod
+    def _finalize_pending_reject(attn_metadata) -> None:
+        """Subtract the pending reject counts from ``decode.seq_lens_list`` once.
+
+        Shared by the eager ``_forward_decode`` entry and the FULL-graph
+        replay update path (``update_graph_params``). The side-stream D2H of
+        the reject counts was launched right after prepare_inputs_padded, so
+        by the time either consumer runs the copy is typically complete and
+        the event synchronize is effectively a no-op. ``reject_finalized``
+        guards re-entry across draft layers sharing one metadata object.
+        """
+        if attn_metadata.pending_reject_event is None or attn_metadata.reject_finalized:
+            return
+        attn_metadata.pending_reject_event.synchronize()
+        reject = attn_metadata.pending_reject_cpu[: attn_metadata.pending_reject_num_reqs].tolist()
+        seq_lens_list = attn_metadata.decode.seq_lens_list
+        for i in range(attn_metadata.pending_reject_num_reqs):
+            seq_lens_list[i] -= reject[i]
+        attn_metadata.reject_finalized = True
+
     def _forward_decode(
         self,
         q_nope: torch.Tensor,
@@ -1715,13 +1746,7 @@ class AscendMLAImpl(MLAAttentionImpl):
         # object; layers sharing this metadata skip via reject_finalized. The
         # D2H was launched right after prepare_inputs_padded, so by the first
         # attention layer the copy is typically already complete (sync no-op).
-        if attn_metadata.pending_reject_event is not None and not attn_metadata.reject_finalized:
-            attn_metadata.pending_reject_event.synchronize()
-            reject = attn_metadata.pending_reject_cpu[: attn_metadata.pending_reject_num_reqs].tolist()
-            seq_lens_list = decode_meta.seq_lens_list
-            for i in range(attn_metadata.pending_reject_num_reqs):
-                seq_lens_list[i] -= reject[i]
-            attn_metadata.reject_finalized = True
+        self._finalize_pending_reject(attn_metadata)
         # TODO: The CANN package is expected to support num_heads that are not
         # powers of 2 in 2026 Q2. Once supported, all padding operations under
         # `if self.head_padding > 0` in this function can be removed.

--- a/vllm_ascend/spec_decode/dspark_proposer.py
+++ b/vllm_ascend/spec_decode/dspark_proposer.py
@@ -5,14 +5,16 @@ from typing import Any
 
 import torch
 from vllm.config import CUDAGraphMode, VllmConfig, get_layers_from_vllm_config
+from vllm.forward_context import get_forward_context
 from vllm.model_executor.layers.attention_layer_base import AttentionLayerBase
 from vllm.v1.attention.backends.utils import CommonAttentionMetadata
 from vllm.v1.kv_cache_interface import UniformTypeKVCacheSpecs
 from vllm.v1.worker.utils import AttentionGroup
 
-from vllm_ascend.ascend_forward_context import set_ascend_forward_context
+from vllm_ascend.ascend_forward_context import _EXTRA_CTX, set_ascend_forward_context
 from vllm_ascend.attention.attention_v1 import AscendAttentionState
 from vllm_ascend.attention.mla_v1 import AscendMLAMetadataBuilder
+from vllm_ascend.attention.utils import AscendCommonAttentionMetadata
 from vllm_ascend.ops.triton.spec_decode.utils import copy_and_expand_dflash_and_dspark_inputs_kernel_single_grid
 from vllm_ascend.spec_decode.dflash_proposer import AscendDflashProposer
 from vllm_ascend.transformers_utils.configs.kimi_k3 import (
@@ -72,10 +74,10 @@ class AscendDSparkProposer(AscendDflashProposer):
             dtype=self.dtype,
             device=self.device,
         )
-        # DSpark runs eager only (Ascend cudagraph unsupported on this path).
-        self.use_cuda_graph = False
-        # Max query tokens depend on whether sampling from anchor or not.
-        self.max_query_tokens = self.max_batch_size * self.num_query_per_req
+        # The inherited DFlash capacity uses the target verification width
+        # (1 + N). Anchor-first DSpark has N real query tokens per request, and
+        # uses the extra capacity for graph padding.
+        self.max_query_tokens = self.max_batch_size * (1 + self.num_speculative_tokens)
         # Position ids for the draft query block [max_query_tokens].
         # Overrides dflash:49; v2 uses input_buffers.positions.
         self.positions = torch.zeros(
@@ -246,8 +248,23 @@ class AscendDSparkProposer(AscendDflashProposer):
         block_table: torch.Tensor,
         slot_mapping: torch.Tensor,
     ) -> None:
+        num_rows = block_table.shape[0]
+        if num_rows > self.max_batch_size:
+            raise ValueError(
+                "DSpark block table exceeds the configured request capacity: "
+                f"{num_rows=} > max_batch_size={self.max_batch_size}."
+            )
         self._per_group_block_tables[gid] = block_table
         self._per_group_slot_mappings[gid] = slot_mapping
+        buffer = self._per_group_block_table_buffers.get(gid)
+        # Anchor-first graph padding can add one virtual request whose tokens
+        # are discarded. Keep one zero block-table row for that metadata tail.
+        buffer_shape = (self.max_batch_size + 1, *block_table.shape[1:])
+        if buffer is None or buffer.shape != buffer_shape:
+            buffer = block_table.new_zeros(buffer_shape)
+            self._per_group_block_table_buffers[gid] = buffer
+        buffer[:num_rows].copy_(block_table)
+        buffer[num_rows:].zero_()
 
     def set_inputs_first_pass(
         self,
@@ -272,10 +289,6 @@ class AscendDSparkProposer(AscendDflashProposer):
         num_sample_total = batch_size * self.num_speculative_tokens
         has_num_rejected = num_rejected_tokens_gpu is not None
         primary_gid = getattr(self, "kv_cache_gid", 0)
-        self._per_group_block_table_buffers = {
-            attn_group.kv_cache_group_id: self._per_group_block_tables[attn_group.kv_cache_group_id]
-            for attn_group in self.draft_attn_groups
-        }
         self._context_slot_mapping_buffers = None
         self._dflash_num_context = int(cad.query_start_loc_cpu[batch_size])
         self._dflash_hidden_states[: self._dflash_num_context] = target_hidden_states[: self._dflash_num_context]
@@ -336,6 +349,15 @@ class AscendDSparkProposer(AscendDflashProposer):
 
         cad.query_start_loc = self.arange_dflash[: batch_size + 1] * self.num_query_per_req
         cad.seq_lens = effective_seq_lens + self.num_query_per_req
+        # The model runner has already corrected this canonical host mirror
+        # with the accepted-token count. Extend it on CPU alongside the device
+        # lengths, without another reject D2H copy or attention-side wait.
+        if cad._seq_lens_cpu is not None:
+            draft_seq_lens_cpu = cad._seq_lens_cpu.clone()
+            draft_seq_lens_cpu[:batch_size].add_(self.num_query_per_req)
+            cad._seq_lens_cpu = draft_seq_lens_cpu
+            if getattr(cad, "seq_lens_cpu", None) is not None:
+                cad.seq_lens_cpu = draft_seq_lens_cpu
         cad.query_start_loc_cpu = (
             torch.from_numpy(self.token_arange_np[: batch_size + 1]).clone() * self.num_query_per_req
         ).to(torch.int32)
@@ -361,6 +383,90 @@ class AscendDSparkProposer(AscendDflashProposer):
 
         return num_query_total, token_indices_to_sample, cad, None
 
+    def pad_query_start_loc_for_graph(
+        self,
+        query_start_loc,
+        num_input_tokens: int,
+        real_num_reqs: int,
+        graph_num_reqs: int,
+        num_query_tokens: int | None = None,
+    ) -> int:
+        """Match DSpark query metadata to the captured attention Query T.
+
+        ``num_input_tokens`` is the target verification graph width.  For the
+        K3 MLA draft, the captured FIA Query T is narrower and is supplied as
+        ``num_query_tokens``.  Other DSpark backends keep using the target
+        width because their captured attention query includes graph padding.
+        """
+        if real_num_reqs < 0 or graph_num_reqs < real_num_reqs:
+            raise ValueError(
+                "DSpark graph metadata requires "
+                f"0 <= real_num_reqs <= graph_num_reqs, got "
+                f"{real_num_reqs=} and {graph_num_reqs=}."
+            )
+
+        if num_query_tokens is None:
+            num_query_tokens = num_input_tokens
+        if not 0 <= num_query_tokens <= num_input_tokens:
+            raise ValueError(
+                "DSpark graph Query T must fit in the target graph token "
+                f"budget, got {num_query_tokens=} and {num_input_tokens=}."
+            )
+
+        capacity = query_start_loc.np.shape[0]
+        if graph_num_reqs + 1 > capacity:
+            raise ValueError(
+                "DSpark query_start_loc buffer is too small for graph "
+                f"metadata: need at least {graph_num_reqs + 1} entries, "
+                f"got {capacity}."
+            )
+
+        last_loc = int(query_start_loc.np[real_num_reqs])
+        if not 0 <= last_loc <= num_query_tokens:
+            raise ValueError(
+                "DSpark query_start_loc is inconsistent with the captured "
+                f"attention Query T: last real offset {last_loc}, "
+                f"{num_query_tokens=}."
+            )
+        num_metadata_reqs = real_num_reqs
+
+        for req_idx in range(real_num_reqs, graph_num_reqs):
+            last_loc = min(last_loc + self.num_query_per_req, num_query_tokens)
+            query_start_loc.np[req_idx + 1] = last_loc
+            num_metadata_reqs += 1
+
+        if last_loc < num_query_tokens:
+            if num_metadata_reqs + 1 >= capacity:
+                raise ValueError(
+                    "DSpark query_start_loc buffer has no room for the "
+                    f"graph-padding tail: need {num_metadata_reqs + 2} "
+                    f"entries, got {capacity}."
+                )
+            query_start_loc.np[num_metadata_reqs + 1] = num_query_tokens
+            num_metadata_reqs += 1
+
+        query_start_loc.copy_to_gpu()
+        return num_metadata_reqs
+
+    def get_graph_query_num_tokens(
+        self,
+        num_input_tokens: int,
+        graph_num_reqs: int,
+    ) -> int:
+        """Return the Query T used to capture this DSpark attention graph."""
+        if not isinstance(self.draft_model_config.hf_config, K3DSparkConfig):
+            return num_input_tokens
+
+        if graph_num_reqs < 0:
+            raise ValueError(f"DSpark graph request count must be non-negative, got {graph_num_reqs=}.")
+        num_query_tokens = graph_num_reqs * self.num_query_per_req
+        if num_query_tokens > num_input_tokens:
+            raise ValueError(
+                "K3 DSpark MLA Query T exceeds its target graph bucket: "
+                f"{num_query_tokens=} > {num_input_tokens=}."
+            )
+        return num_query_tokens
+
     @torch.inference_mode()
     def dummy_run(
         self,
@@ -374,13 +480,38 @@ class AscendDSparkProposer(AscendDflashProposer):
         **kwargs,
     ) -> None:
         num_query_total = num_reqs * self.num_query_per_req
-        num_query_tokens = min(num_query_total if num_reqs > 0 else num_tokens, self.max_query_tokens)
+        if num_reqs > 0 and num_query_total > self.max_query_tokens:
+            raise ValueError(
+                "DSpark graph capture exceeds the allocated query capacity: "
+                f"{num_query_total=} > max_query_tokens={self.max_query_tokens}."
+            )
+        num_query_tokens = num_query_total if num_reqs > 0 else num_tokens
+        if aclgraph_runtime_mode == CUDAGraphMode.FULL and batch_descriptor is not None:
+            num_query_tokens = batch_descriptor.num_tokens
+        if num_reqs > 0 and num_query_tokens > self.max_query_tokens:
+            raise ValueError(
+                "DSpark graph bucket exceeds the allocated query capacity: "
+                f"{num_query_tokens=} > max_query_tokens={self.max_query_tokens}."
+            )
+        num_query_tokens = min(num_query_tokens, self.max_query_tokens)
 
         (
             num_input_tokens,
             num_tokens_across_dp,
             _,
         ) = self.runner._sync_metadata_across_dp(num_query_tokens, is_draft_model=True)
+
+        if not num_query_total <= num_input_tokens <= self.max_query_tokens:
+            raise ValueError(
+                "DSpark synchronized token budget is outside the allocated "
+                f"query range: {num_query_total=} <= {num_input_tokens=} <= "
+                f"max_query_tokens={self.max_query_tokens} is required."
+            )
+
+        graph_query_tokens = self.get_graph_query_num_tokens(
+            num_input_tokens,
+            num_reqs,
+        )
 
         if not self.use_cuda_graph:
             aclgraph_runtime_mode = CUDAGraphMode.NONE
@@ -391,17 +522,68 @@ class AscendDSparkProposer(AscendDflashProposer):
         self.token_indices_to_sample.fill_(0)
         self._pad_draft_buffers(num_query_total, num_input_tokens)
 
+        multi_steps_attn_metadata = []
+        if aclgraph_runtime_mode == CUDAGraphMode.FULL and self.draft_attn_groups:
+            query_start_loc_cpu = (
+                torch.from_numpy(self.token_arange_np[: num_reqs + 1]).clone() * self.num_query_per_req
+            )
+            query_start_loc_cpu.clamp_(max=graph_query_tokens)
+            if int(query_start_loc_cpu[-1]) < graph_query_tokens:
+                query_start_loc_cpu = torch.cat(
+                    (query_start_loc_cpu, query_start_loc_cpu.new_tensor([graph_query_tokens]))
+                )
+            num_metadata_reqs = query_start_loc_cpu.shape[0] - 1
+            query_start_loc = query_start_loc_cpu.to(self.device)
+            seq_lens_cpu = self._adjust_tensor(self.runner.optimistic_seq_lens_cpu, num_metadata_reqs)
+            seq_lens = self._adjust_tensor(self.runner.seq_lens, num_metadata_reqs)
+            causal = self.model.get_draft_attn_causal()[0]
+            per_layer_attn_metadata: dict[str, Any] = {}
+            for attn_group in self.draft_attn_groups:
+                gid = attn_group.kv_cache_group_id
+                common_attn_metadata = AscendCommonAttentionMetadata(
+                    query_start_loc=query_start_loc,
+                    query_start_loc_cpu=query_start_loc_cpu,
+                    seq_lens_cpu=seq_lens_cpu,
+                    _seq_lens_cpu=seq_lens_cpu,
+                    seq_lens_cpu_upper_bound=seq_lens_cpu,
+                    seq_lens=seq_lens,
+                    num_reqs=num_metadata_reqs,
+                    # Keep cache writes limited to real draft queries. The
+                    # graph still executes ``num_input_tokens`` rows; padding
+                    # rows have -1 slot mappings and are discarded.
+                    num_actual_tokens=num_query_total,
+                    num_input_tokens=num_input_tokens,
+                    max_query_len=self.num_query_per_req,
+                    max_seq_len=0,
+                    slot_mapping=self._per_group_query_slot_mapping_buffers[gid][:num_input_tokens],
+                    positions=self.positions,
+                    attn_state=AscendAttentionState.SpecDecoding,
+                    causal=causal,
+                    is_prefilling=torch.zeros(num_metadata_reqs, dtype=torch.bool),
+                    block_table_tensor=self._per_group_block_table_buffers[gid][:num_metadata_reqs],
+                )
+                metadata = attn_group.get_metadata_builder().build_for_graph_capture(
+                    common_attn_metadata,
+                    AscendAttentionState.SpecDecoding,
+                )
+                if hasattr(metadata, "attn_mask") and not causal:
+                    metadata.attn_mask = None
+                metadata.attn_state = AscendAttentionState.SpecDecoding
+                for layer_name in attn_group.layer_names:
+                    per_layer_attn_metadata[layer_name] = metadata
+            multi_steps_attn_metadata.append(per_layer_attn_metadata)
+
         with set_ascend_forward_context(
-            None,
+            multi_steps_attn_metadata[0] if multi_steps_attn_metadata else None,
             self.vllm_config,
             num_tokens=num_input_tokens,
             num_tokens_across_dp=num_tokens_across_dp,
-            num_actual_tokens=num_input_tokens,
+            num_actual_tokens=num_query_total,
             in_profile_run=is_profile,
             batch_descriptor=batch_descriptor,
             aclgraph_runtime_mode=aclgraph_runtime_mode,
             is_draft_model=True,
-            draft_attn_metadatas=[],
+            draft_attn_metadatas=multi_steps_attn_metadata,
         ):
             if is_profile:
                 self.model.precompute_and_store_context_kv(context_states, context_positions)
@@ -419,6 +601,10 @@ class AscendDSparkProposer(AscendDflashProposer):
                     token_indices_to_sample=self.token_indices_to_sample[: num_reqs * self.num_speculative_tokens],
                     target_positions=self._get_positions(num_input_tokens),
                     inputs_embeds=None,
-                    multi_steps_attn_metadata=[],
+                    multi_steps_attn_metadata=multi_steps_attn_metadata,
                     num_tokens=num_input_tokens,
                 )
+
+            forward_context = get_forward_context()
+            if forward_context.cudagraph_runtime_mode == CUDAGraphMode.FULL and not _EXTRA_CTX.capturing:
+                self._update_full_graph_params(forward_context, graph_query_tokens, multi_steps_attn_metadata)

--- a/vllm_ascend/spec_decode/dspark_proposer.py
+++ b/vllm_ascend/spec_decode/dspark_proposer.py
@@ -222,11 +222,6 @@ class AscendDSparkProposer(AscendDflashProposer):
             and issubclass(attn_group.backend, AscendDSABackend)
             for attn_group in self.draft_attn_groups
         )
-        if self._draft_uses_mla_backend and self._draft_uses_dsa_backend:
-            raise RuntimeError(
-                "DSpark does not support mixing MLA and DSA draft attention "
-                "backends because their host sequence-length contracts differ."
-            )
 
         self.kv_cache_gid = self.draft_attn_groups[0].kv_cache_group_id
         self.kernel_block_size = self._per_group_kernel_block_sizes[self.kv_cache_gid]
@@ -272,11 +267,6 @@ class AscendDSparkProposer(AscendDflashProposer):
         slot_mapping: torch.Tensor,
     ) -> None:
         num_rows = block_table.shape[0]
-        if num_rows > self.max_batch_size:
-            raise ValueError(
-                "DSpark block table exceeds the configured request capacity: "
-                f"{num_rows=} > max_batch_size={self.max_batch_size}."
-            )
         self._per_group_block_tables[gid] = block_table
         self._per_group_slot_mappings[gid] = slot_mapping
         buffer = self._per_group_block_table_buffers.get(gid)
@@ -512,36 +502,10 @@ class AscendDSparkProposer(AscendDflashProposer):
         ``num_query_tokens``.  Other DSpark backends keep using the target
         width because their captured attention query includes graph padding.
         """
-        if real_num_reqs < 0 or graph_num_reqs < real_num_reqs:
-            raise ValueError(
-                "DSpark graph metadata requires "
-                f"0 <= real_num_reqs <= graph_num_reqs, got "
-                f"{real_num_reqs=} and {graph_num_reqs=}."
-            )
-
         if num_query_tokens is None:
             num_query_tokens = num_input_tokens
-        if not 0 <= num_query_tokens <= num_input_tokens:
-            raise ValueError(
-                "DSpark graph Query T must fit in the target graph token "
-                f"budget, got {num_query_tokens=} and {num_input_tokens=}."
-            )
-
-        capacity = query_start_loc.np.shape[0]
-        if graph_num_reqs + 1 > capacity:
-            raise ValueError(
-                "DSpark query_start_loc buffer is too small for graph "
-                f"metadata: need at least {graph_num_reqs + 1} entries, "
-                f"got {capacity}."
-            )
 
         last_loc = int(query_start_loc.np[real_num_reqs])
-        if not 0 <= last_loc <= num_query_tokens:
-            raise ValueError(
-                "DSpark query_start_loc is inconsistent with the captured "
-                f"attention Query T: last real offset {last_loc}, "
-                f"{num_query_tokens=}."
-            )
         num_metadata_reqs = real_num_reqs
 
         for req_idx in range(real_num_reqs, graph_num_reqs):
@@ -550,12 +514,6 @@ class AscendDSparkProposer(AscendDflashProposer):
             num_metadata_reqs += 1
 
         if last_loc < num_query_tokens:
-            if num_metadata_reqs + 1 >= capacity:
-                raise ValueError(
-                    "DSpark query_start_loc buffer has no room for the "
-                    f"graph-padding tail: need {num_metadata_reqs + 2} "
-                    f"entries, got {capacity}."
-                )
             query_start_loc.np[num_metadata_reqs + 1] = num_query_tokens
             num_metadata_reqs += 1
 
@@ -571,15 +529,7 @@ class AscendDSparkProposer(AscendDflashProposer):
         if not isinstance(self.draft_model_config.hf_config, K3DSparkConfig):
             return num_input_tokens
 
-        if graph_num_reqs < 0:
-            raise ValueError(f"DSpark graph request count must be non-negative, got {graph_num_reqs=}.")
-        num_query_tokens = graph_num_reqs * self.num_query_per_req
-        if num_query_tokens > num_input_tokens:
-            raise ValueError(
-                "K3 DSpark MLA Query T exceeds its target graph bucket: "
-                f"{num_query_tokens=} > {num_input_tokens=}."
-            )
-        return num_query_tokens
+        return graph_num_reqs * self.num_query_per_req
 
     @torch.inference_mode()
     def dummy_run(
@@ -594,19 +544,9 @@ class AscendDSparkProposer(AscendDflashProposer):
         **kwargs,
     ) -> None:
         num_query_total = num_reqs * self.num_query_per_req
-        if num_reqs > 0 and num_query_total > self.max_query_tokens:
-            raise ValueError(
-                "DSpark graph capture exceeds the allocated query capacity: "
-                f"{num_query_total=} > max_query_tokens={self.max_query_tokens}."
-            )
         num_query_tokens = num_query_total if num_reqs > 0 else num_tokens
         if aclgraph_runtime_mode == CUDAGraphMode.FULL and batch_descriptor is not None:
             num_query_tokens = batch_descriptor.num_tokens
-        if num_reqs > 0 and num_query_tokens > self.max_query_tokens:
-            raise ValueError(
-                "DSpark graph bucket exceeds the allocated query capacity: "
-                f"{num_query_tokens=} > max_query_tokens={self.max_query_tokens}."
-            )
         num_query_tokens = min(num_query_tokens, self.max_query_tokens)
 
         (
@@ -614,13 +554,6 @@ class AscendDSparkProposer(AscendDflashProposer):
             num_tokens_across_dp,
             _,
         ) = self.runner._sync_metadata_across_dp(num_query_tokens, is_draft_model=True)
-
-        if not num_query_total <= num_input_tokens <= self.max_query_tokens:
-            raise ValueError(
-                "DSpark synchronized token budget is outside the allocated "
-                f"query range: {num_query_total=} <= {num_input_tokens=} <= "
-                f"max_query_tokens={self.max_query_tokens} is required."
-            )
 
         graph_query_tokens = self.get_graph_query_num_tokens(
             num_input_tokens,

--- a/vllm_ascend/spec_decode/dspark_proposer.py
+++ b/vllm_ascend/spec_decode/dspark_proposer.py
@@ -13,7 +13,8 @@ from vllm.v1.worker.utils import AttentionGroup
 
 from vllm_ascend.ascend_forward_context import _EXTRA_CTX, set_ascend_forward_context
 from vllm_ascend.attention.attention_v1 import AscendAttentionState
-from vllm_ascend.attention.mla_v1 import AscendMLAMetadataBuilder
+from vllm_ascend.attention.dsa_v1 import AscendDSABackend
+from vllm_ascend.attention.mla_v1 import AscendMLABackend, AscendMLAMetadataBuilder
 from vllm_ascend.attention.utils import AscendCommonAttentionMetadata
 from vllm_ascend.ops.triton.spec_decode.utils import copy_and_expand_dflash_and_dspark_inputs_kernel_single_grid
 from vllm_ascend.spec_decode.dflash_proposer import AscendDflashProposer
@@ -121,6 +122,12 @@ class AscendDSparkProposer(AscendDflashProposer):
         # per-layer context slot mappings as a flat list
         self._context_slot_mapping_buffers: list[torch.Tensor | None] | None = None
 
+        # Populated by initialize_attn_backend. MLA builds the draft KV length
+        # through parallel_draft_seq_lens_cpu, while DSA consumes the canonical
+        # host mirror for max_seqlen_kv; their host-length contracts differ.
+        self._draft_uses_mla_backend = False
+        self._draft_uses_dsa_backend = False
+
     @staticmethod
     def _resolve_kernel_block_size(
         gid: int,
@@ -205,6 +212,22 @@ class AscendDSparkProposer(AscendDflashProposer):
                 f"groups. Missing layers: {self.attn_layer_names}"
             )
 
+        self._draft_uses_mla_backend = any(
+            isinstance(attn_group.backend, type)
+            and issubclass(attn_group.backend, AscendMLABackend)
+            for attn_group in self.draft_attn_groups
+        )
+        self._draft_uses_dsa_backend = any(
+            isinstance(attn_group.backend, type)
+            and issubclass(attn_group.backend, AscendDSABackend)
+            for attn_group in self.draft_attn_groups
+        )
+        if self._draft_uses_mla_backend and self._draft_uses_dsa_backend:
+            raise RuntimeError(
+                "DSpark does not support mixing MLA and DSA draft attention "
+                "backends because their host sequence-length contracts differ."
+            )
+
         self.kv_cache_gid = self.draft_attn_groups[0].kv_cache_group_id
         self.kernel_block_size = self._per_group_kernel_block_sizes[self.kv_cache_gid]
 
@@ -265,6 +288,89 @@ class AscendDSparkProposer(AscendDflashProposer):
             self._per_group_block_table_buffers[gid] = buffer
         buffer[:num_rows].copy_(block_table)
         buffer[num_rows:].zero_()
+
+    def _prepare_parallel_draft_seq_lens_cpu(
+        self,
+        common_attn_metadata: CommonAttentionMetadata,
+        batch_size: int,
+        num_draft_tokens_cpu: list[int] | None,
+    ) -> None:
+        # Only MLA consumes parallel_draft_seq_lens_cpu. DSA gets its max-KV
+        # upper bound from the canonical host mirror, while ordinary attention
+        # consumes the exact device seq_lens for parallel drafting.
+        if not self._draft_uses_mla_backend:
+            return
+
+        super()._prepare_parallel_draft_seq_lens_cpu(
+            common_attn_metadata,
+            batch_size,
+            num_draft_tokens_cpu,
+        )
+
+        # In padded synchronous scheduling, the reject count is available only
+        # in the device-side seq_lens that set_inputs_first_pass has already
+        # corrected to L_t + N. There is no pending-reject event, and the MLA
+        # builder otherwise falls back to the stale host mirror L_t + rejected_t.
+        # Publish an explicit CPU copy for MLA. The blocking D2H is confined to
+        # synchronous scheduling; async+padded keeps its overlapped reject-copy
+        # path and non-padded input preparation already has an exact host value.
+        reject_event = getattr(self.runner, "num_rejected_tokens_event", None)
+        sync_padded = num_draft_tokens_cpu is not None and reject_event is None
+        if sync_padded:
+            common_attn_metadata.parallel_draft_seq_lens_cpu = (
+                common_attn_metadata.seq_lens[: common_attn_metadata.num_reqs]
+                .detach()
+                .to("cpu", copy=True)
+            )
+
+    def _sample_dspark_tokens(
+        self,
+        raw_logits: torch.Tensor,
+    ) -> torch.Tensor:
+        """Apply the Markov correction and sample one DSpark block."""
+        sampling_metadata = self.runner.input_batch.sampling_metadata
+        logits = raw_logits.view(
+            -1,
+            self.num_speculative_tokens,
+            raw_logits.shape[-1],
+        )
+        num_reqs = logits.shape[0]
+        draft_token_ids = self._dspark_draft_buffer[:num_reqs]
+        draft_token_ids[:, 0].copy_(self._dspark_seed_buffer[:num_reqs])
+
+        self._last_draft_probs = None
+        use_probabilistic = (
+            self._dspark_draft_probs is not None
+            and sampling_metadata is not None
+            and not sampling_metadata.all_greedy
+        )
+        draft_probs = None
+        if use_probabilistic:
+            assert self._dspark_draft_probs is not None
+            if logits.shape[-1] != self._dspark_draft_probs.shape[-1]:
+                raise RuntimeError(
+                    "DSpark draft/target vocabulary mismatch for probabilistic "
+                    f"sampling: draft={logits.shape[-1]}, "
+                    f"target={self._dspark_draft_probs.shape[-1]}"
+                )
+            draft_probs = self._dspark_draft_probs[:num_reqs]
+
+        for idx in range(self.num_speculative_tokens):
+            markov_emb = self.model.markov_embed(draft_token_ids[:, idx])
+            logits[:, idx].add_(self.model.markov_bias(markov_emb))
+            if draft_probs is None:
+                next_token_ids = logits[:, idx].argmax(dim=-1)
+            else:
+                next_token_ids, probs = self._sample_from_logits(
+                    logits[:, idx],
+                    sampling_metadata,
+                )
+                assert probs is not None
+                draft_probs[:, idx].copy_(probs)
+            draft_token_ids[:, idx + 1].copy_(next_token_ids)
+
+        self._last_draft_probs = draft_probs
+        return draft_token_ids
 
     def set_inputs_first_pass(
         self,
@@ -349,15 +455,23 @@ class AscendDSparkProposer(AscendDflashProposer):
 
         cad.query_start_loc = self.arange_dflash[: batch_size + 1] * self.num_query_per_req
         cad.seq_lens = effective_seq_lens + self.num_query_per_req
-        # The model runner has already corrected this canonical host mirror
-        # with the accepted-token count. Extend it on CPU alongside the device
-        # lengths, without another reject D2H copy or attention-side wait.
-        if cad._seq_lens_cpu is not None:
-            draft_seq_lens_cpu = cad._seq_lens_cpu.clone()
-            draft_seq_lens_cpu[:batch_size].add_(self.num_query_per_req)
-            cad._seq_lens_cpu = draft_seq_lens_cpu
-            if getattr(cad, "seq_lens_cpu", None) is not None:
-                cad.seq_lens_cpu = draft_seq_lens_cpu
+        # Backend-specific host-length contract:
+        # - MLA must keep the canonical host mirror unchanged. Its parallel
+        #   draft path adds N exactly once and later finalizes pending rejects.
+        # - DSA ignores parallel_draft_seq_lens_cpu and derives max_seqlen_kv
+        #   from the canonical host mirror, so include N there as a safe upper
+        #   bound for its device seqused_kv=L_t+N.
+        # - Ordinary attention consumes device seq_lens while parallel drafting.
+        if self._draft_uses_dsa_backend:
+            host_seq_lens = cad._seq_lens_cpu
+            if host_seq_lens is None:
+                host_seq_lens = getattr(cad, "seq_lens_cpu", None)
+            if host_seq_lens is not None:
+                draft_seq_lens_cpu = host_seq_lens.clone()
+                draft_seq_lens_cpu[:batch_size].add_(self.num_query_per_req)
+                cad._seq_lens_cpu = draft_seq_lens_cpu
+                if getattr(cad, "seq_lens_cpu", None) is not None:
+                    cad.seq_lens_cpu = draft_seq_lens_cpu
         cad.query_start_loc_cpu = (
             torch.from_numpy(self.token_arange_np[: batch_size + 1]).clone() * self.num_query_per_req
         ).to(torch.int32)

--- a/vllm_ascend/spec_decode/llm_base_proposer.py
+++ b/vllm_ascend/spec_decode/llm_base_proposer.py
@@ -1092,9 +1092,7 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
                 # eager mode and must keep the generic dispatch.
                 graph_dispatch_tokens = batch_size * (1 + self.num_speculative_tokens)
             _, batch_descriptor = self.runner.cudagraph_dispatcher.dispatch(
-                num_tokens=graph_dispatch_tokens,
-                uniform_decode=uniform_decode,
-                has_lora=has_lora,
+                num_tokens=graph_dispatch_tokens, uniform_decode=uniform_decode, has_lora=has_lora
             )
             num_input_tokens = batch_descriptor.num_tokens
         else:
@@ -1363,17 +1361,13 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
 
             if self.enable_enpu:
                 self._update_full_graph_params_if_needed(
-                    forward_context,
-                    graph_param_num_tokens,
-                    multi_steps_attn_metadata,
+                    forward_context, graph_param_num_tokens, multi_steps_attn_metadata
                 )
                 draft_token_ids = run_draft()
             else:
                 draft_token_ids = run_draft()
                 self._update_full_graph_params_if_needed(
-                    forward_context,
-                    graph_param_num_tokens,
-                    multi_steps_attn_metadata,
+                    forward_context, graph_param_num_tokens, multi_steps_attn_metadata
                 )
         return draft_token_ids
 

--- a/vllm_ascend/spec_decode/llm_base_proposer.py
+++ b/vllm_ascend/spec_decode/llm_base_proposer.py
@@ -1063,8 +1063,17 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
         uniform_decode = target_model_batch_desc.uniform
 
         if self.use_cuda_graph:
+            graph_dispatch_tokens = num_tokens
+            if self.method == "dspark":
+                # DSpark may run N anchor-first draft queries per request,
+                # while the target graph verifies 1 + N tokens. Graph batch
+                # descriptors use the target width, so dispatch with that
+                # width and retain ``num_tokens`` as the real draft count.
+                graph_dispatch_tokens = batch_size * (1 + self.num_speculative_tokens)
             _, batch_descriptor = self.runner.cudagraph_dispatcher.dispatch(
-                num_tokens=num_tokens, uniform_decode=uniform_decode, has_lora=has_lora
+                num_tokens=graph_dispatch_tokens,
+                uniform_decode=uniform_decode,
+                has_lora=has_lora,
             )
             num_input_tokens = batch_descriptor.num_tokens
         else:
@@ -1085,6 +1094,7 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
             aclgraph_runtime_mode = CUDAGraphMode.NONE
             batch_descriptor = None
 
+        graph_param_num_tokens = num_input_tokens
         if aclgraph_runtime_mode == CUDAGraphMode.FULL:
             # TODO: Due to the inconsistency between the proposer `dispatcher` and model runner, this padding
             # should have been done in model runner but not. For example, at prefill stage, target model
@@ -1094,14 +1104,40 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
             num_reqs = common_attn_metadata.query_start_loc.shape[0]
             self.query_start_loc.gpu[:num_reqs].copy_(common_attn_metadata.query_start_loc)
             self.query_start_loc.cpu[:num_reqs].copy_(common_attn_metadata.query_start_loc_cpu)
-            num_reqs_padded = self.runner._pad_query_start_loc_for_fia(
-                self.query_start_loc,
-                num_input_tokens,
-                batch_descriptor.num_reqs if batch_descriptor.num_reqs is not None else common_attn_metadata.num_reqs,
-                common_attn_metadata.num_reqs,
-                aclgraph_runtime_mode,
-                batch_descriptor.num_reqs,
-            )
+            if self.method == "dspark":
+                graph_num_reqs = (
+                    batch_descriptor.num_reqs
+                    if batch_descriptor.num_reqs is not None
+                    else common_attn_metadata.num_reqs
+                )
+                # K3 MLA preprocesses only the N draft queries from every
+                # graph-padded request, so its captured FIA Query T differs
+                # from the target verification graph width.  Other DSpark
+                # backends retain the target width.
+                graph_param_num_tokens = self.get_graph_query_num_tokens(
+                    num_input_tokens,
+                    graph_num_reqs,
+                )
+                num_reqs_padded = self.pad_query_start_loc_for_graph(
+                    self.query_start_loc,
+                    num_input_tokens,
+                    common_attn_metadata.num_reqs,
+                    graph_num_reqs,
+                    num_query_tokens=graph_param_num_tokens,
+                )
+            else:
+                num_reqs_padded = self.runner._pad_query_start_loc_for_fia(
+                    self.query_start_loc,
+                    num_input_tokens,
+                    (
+                        batch_descriptor.num_reqs
+                        if batch_descriptor.num_reqs is not None
+                        else common_attn_metadata.num_reqs
+                    ),
+                    common_attn_metadata.num_reqs,
+                    aclgraph_runtime_mode,
+                    batch_descriptor.num_reqs,
+                )
             common_attn_metadata.num_reqs = num_reqs_padded
             common_attn_metadata.query_start_loc = self.query_start_loc.gpu[: num_reqs_padded + 1]
             common_attn_metadata.query_start_loc_cpu = self.query_start_loc.cpu[: num_reqs_padded + 1]
@@ -1111,6 +1147,21 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
             )
             if self.method == "dflash":
                 common_attn_metadata.seq_lens = self._adjust_tensor(common_attn_metadata.seq_lens, num_reqs_padded)
+            elif self.method == "dspark":
+                # DSpark already rewrote both device and host sequence lengths
+                # in set_inputs_first_pass. Preserve those values while
+                # extending only the padded tail for full-graph replay.
+                common_attn_metadata.seq_lens = self._adjust_tensor(
+                    common_attn_metadata.seq_lens, num_reqs_padded
+                )
+                if common_attn_metadata.seq_lens_cpu is not None:
+                    common_attn_metadata.seq_lens_cpu = self._adjust_tensor(
+                        common_attn_metadata.seq_lens_cpu, num_reqs_padded
+                    )
+                if common_attn_metadata._seq_lens_cpu is not None:
+                    common_attn_metadata._seq_lens_cpu = self._adjust_tensor(
+                        common_attn_metadata._seq_lens_cpu, num_reqs_padded
+                    )
             else:
                 common_attn_metadata.seq_lens = self._adjust_tensor(self.runner.seq_lens, num_reqs_padded)
                 common_attn_metadata.seq_lens_cpu = self._adjust_tensor(
@@ -1252,6 +1303,11 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
         self.token_indices_to_sample[:token_indices_to_sample_len].copy_(token_indices_to_sample)
         self.token_indices_to_sample[token_indices_to_sample_len:].fill_(0)
 
+        # DSpark context K/V has a request-dependent shape. Update it eagerly;
+        # the fixed query block remains inside the captured graph.
+        if self.method == "dspark":
+            self.build_model_inputs_first_pass(num_input_tokens, self._context_slot_mapping_buffers)
+
         with set_ascend_forward_context(
             multi_steps_attn_metadata[0],
             self.vllm_config,
@@ -1285,11 +1341,19 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
             run_draft: Callable[[], Any] = partial(runnable, **model_inputs)
 
             if self.enable_enpu:
-                self._update_full_graph_params_if_needed(forward_context, num_input_tokens, multi_steps_attn_metadata)
+                self._update_full_graph_params_if_needed(
+                    forward_context,
+                    graph_param_num_tokens,
+                    multi_steps_attn_metadata,
+                )
                 draft_token_ids = run_draft()
             else:
                 draft_token_ids = run_draft()
-                self._update_full_graph_params_if_needed(forward_context, num_input_tokens, multi_steps_attn_metadata)
+                self._update_full_graph_params_if_needed(
+                    forward_context,
+                    graph_param_num_tokens,
+                    multi_steps_attn_metadata,
+                )
         return draft_token_ids
 
     def compute_draft_token_ids(self, hidden_states: torch.Tensor):
@@ -1325,9 +1389,9 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
         model_positions = self._get_positions(num_input_tokens)
         model_kwargs = {"input_ids": model_input_ids, "positions": model_positions, "inputs_embeds": inputs_embeds}
 
-        if self.method in ("dflash", "dspark"):
+        if self.method == "dflash":
             self.build_model_inputs_first_pass(num_input_tokens, self._context_slot_mapping_buffers)
-        else:
+        elif self.method != "dspark":
             if self.pass_hidden_states_to_model:
                 model_hidden_states = self.hidden_states[:num_input_tokens]
                 model_hidden_states, model_positions = self.maybe_pad_and_reduce(model_hidden_states, model_positions)
@@ -2292,6 +2356,14 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
         )
 
         return spec_common_attn_metadata, token_indices, token_indices_to_sample, num_rejected_tokens_gpu
+
+    def get_graph_query_num_tokens(
+        self,
+        num_input_tokens: int,
+        graph_num_reqs: int,
+    ) -> int:
+        """Return the attention Query T used as the graph-parameter key."""
+        return num_input_tokens
 
     # update full-graph params for one spec token
     def _update_full_graph_params(self, forward_context, num_tokens, draft_attn_metadatas=None):

--- a/vllm_ascend/spec_decode/llm_base_proposer.py
+++ b/vllm_ascend/spec_decode/llm_base_proposer.py
@@ -63,6 +63,7 @@ from vllm_ascend.spec_decode.utils import (
     build_parallel_draft_seq_lens_cpu,
     patch_tensor_parallel_group,
 )
+from vllm_ascend.transformers_utils.configs.kimi_k3 import K3DSparkConfig
 from vllm_ascend.utils import check_gdn_layer, enable_sp, lmhead_tp_enable
 
 # Currently we will fix block size to a small one since `num_reqs` can't be too large
@@ -118,6 +119,18 @@ def _is_glm_model(model_config) -> bool:
     hf_text_config = getattr(model_config, "hf_text_config", None)
     model_type = getattr(hf_text_config, "model_type", "") or ""
     return "glm" in str(model_type).lower()
+
+
+def _is_k3_dspark(method: str, draft_hf_config) -> bool:
+    """Whether this proposer is a DSpark drafter for Kimi K3.
+
+    Kimi K3 is currently the only model whose DSpark draft runs in FULL graph
+    mode; DeepSeek V4 and GLM5.2 run their DSpark drafts in eager mode.
+    Graph-mode-only draft actions are gated on this so the other models keep
+    their original code paths by construction, not merely by runtime
+    scheduling.
+    """
+    return method == "dspark" and isinstance(draft_hf_config, K3DSparkConfig)
 
 
 class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
@@ -200,6 +213,12 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
                     "speculative decoding will be added in a future release. "
                 )
             self.use_cuda_graph = False
+
+        # Graph-mode-only draft actions are gated on this flag so models
+        # other than K3 keep their original code paths by construction, not
+        # merely by runtime scheduling. Computed once here -- every per-step
+        # consumer only reads the boolean (see _is_k3_dspark).
+        self._is_k3_dspark = _is_k3_dspark(self.method, draft_hf_config)
 
         # TODO: Remove it when the bug of fx-graph is solved
         self.maybe_eager_context: AbstractContextManager[Any] = nullcontext()
@@ -965,9 +984,9 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
         Three cases (preserving prior behavior except for the padded+async
         deferral): non-padded (``num_draft_tokens_cpu is None``) publishes
         optimistic+query with no reject; padded+async publishes optimistic+query
-        plus the deferred reject fields; padded+non-async leaves
-        ``parallel_draft_seq_lens_cpu`` unset so the builder falls back to the
-        (already-exact) device ``seq_lens``.
+        plus the deferred reject fields; padded+non-async is left to the
+        backend-specific proposer. DSpark MLA publishes an explicit CPU copy of
+        its already-exact device ``seq_lens`` for that last case.
         """
         if not self.parallel_drafting or not hasattr(self, "num_query_per_req"):
             return
@@ -993,7 +1012,7 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
                 common_attn_metadata.parallel_draft_num_reject_cpu = self.runner.num_rejected_tokens_cpu
                 common_attn_metadata.parallel_draft_num_reject_event = reject_event
                 common_attn_metadata.parallel_draft_num_reject_num_reqs = batch_size
-        # else: padded + non-async -> leave unset; builder falls back to device seq_lens.
+        # else: padded + non-async -> leave unset for backend-specific handling.
 
     def _propose(
         self,
@@ -1064,11 +1083,13 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
 
         if self.use_cuda_graph:
             graph_dispatch_tokens = num_tokens
-            if self.method == "dspark":
-                # DSpark may run N anchor-first draft queries per request,
+            if self._is_k3_dspark:
+                # K3 DSpark runs N anchor-first draft queries per request,
                 # while the target graph verifies 1 + N tokens. Graph batch
                 # descriptors use the target width, so dispatch with that
                 # width and retain ``num_tokens`` as the real draft count.
+                # Gated on K3 only: other DSpark models run their drafts in
+                # eager mode and must keep the generic dispatch.
                 graph_dispatch_tokens = batch_size * (1 + self.num_speculative_tokens)
             _, batch_descriptor = self.runner.cudagraph_dispatcher.dispatch(
                 num_tokens=graph_dispatch_tokens,
@@ -1104,7 +1125,7 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
             num_reqs = common_attn_metadata.query_start_loc.shape[0]
             self.query_start_loc.gpu[:num_reqs].copy_(common_attn_metadata.query_start_loc)
             self.query_start_loc.cpu[:num_reqs].copy_(common_attn_metadata.query_start_loc_cpu)
-            if self.method == "dspark":
+            if self._is_k3_dspark:
                 graph_num_reqs = (
                     batch_descriptor.num_reqs
                     if batch_descriptor.num_reqs is not None
@@ -1147,10 +1168,10 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
             )
             if self.method == "dflash":
                 common_attn_metadata.seq_lens = self._adjust_tensor(common_attn_metadata.seq_lens, num_reqs_padded)
-            elif self.method == "dspark":
-                # DSpark already rewrote both device and host sequence lengths
-                # in set_inputs_first_pass. Preserve those values while
-                # extending only the padded tail for full-graph replay.
+            elif self._is_k3_dspark:
+                # K3 DSpark already rewrote both device and host sequence
+                # lengths in set_inputs_first_pass. Preserve those values
+                # while extending only the padded tail for full-graph replay.
                 common_attn_metadata.seq_lens = self._adjust_tensor(
                     common_attn_metadata.seq_lens, num_reqs_padded
                 )

--- a/vllm_ascend/worker/model_runner_v1.py
+++ b/vllm_ascend/worker/model_runner_v1.py
@@ -5002,7 +5002,40 @@ class NPUModelRunner(GPUModelRunner):
         if self.use_aclgraph:
             set_graph_params(capture_sizes)
             if self.speculative_config:
-                set_draft_graph_params(capture_sizes)
+                if self.speculative_config.method == "dspark" and isinstance(
+                    self.drafter,
+                    AscendDSparkProposer,
+                ):
+                    # GraphParams is keyed by the attention operator's Query
+                    # T, not necessarily by the target graph descriptor width.
+                    # In K3 MLA FULL decode graphs these are B*N and B*(N+1)
+                    # respectively.  The draft ACLGraphWrapper captures only
+                    # FULL descriptors, so PIECEWISE sizes must not introduce
+                    # empty graph-parameter slots here.
+                    full_draft_capture_descs = [
+                        desc
+                        for mode, descs in capture_descs
+                        if mode == CUDAGraphMode.FULL
+                        for desc in descs
+                    ]
+                    draft_capture_sizes = {
+                        self.drafter.get_graph_query_num_tokens(
+                            desc.num_tokens,
+                            desc.num_reqs,
+                        )
+                        if desc.uniform and desc.num_reqs is not None
+                        else desc.num_tokens
+                        for desc in full_draft_capture_descs
+                    }
+                    if not draft_capture_sizes:
+                        draft_capture_sizes.update(capture_sizes)
+                    logger.info(
+                        "DSpark draft graph Query-T sizes: %s",
+                        sorted(draft_capture_sizes),
+                    )
+                    set_draft_graph_params(sorted(draft_capture_sizes))
+                else:
+                    set_draft_graph_params(capture_sizes)
 
     def capture_model(self) -> int:
         """Capture NPU graphs and return actual graph pool memory bytes consumed."""


### PR DESCRIPTION
| # | 改动点 | 文件：行号 |
|---|---|---|
| 1 | **总开关**：删 `use_cuda_graph = False` eager 硬锁；draft 输入缓冲容量 B×N → B×(1+N)（图按档位宽度执行，填充行进图靠 slot_mapping=-1 丢弃） | `vllm_ascend/spec_decode/dspark_proposer.py:103-106` |
| 2 | **缓冲固化**：块表改持久 padded 缓冲（`max_batch_size + 1` 行、尾部清零、单点维护），图锁指针，每步只改内容；删掉每步换指针的别名重建 | `vllm_ascend/spec_decode/dspark_proposer.py:288-305`（`set_per_group_attn_metadata`）；删除处在原 `set_inputs_first_pass`（基线约 346 行处，现无） |
| 3 | **键换算**：`get_graph_query_num_tokens`——图参数以 FIA 查询行数（Query T）为键，K3 draft 为 B×N，与档位宽度 B×(1+N) 不同，注册/捕获/更新三处统一用它换算 | `vllm_ascend/spec_decode/dspark_proposer.py:548-556` |
| 4 | **元数据补齐**：`pad_query_start_loc_for_graph` 把 host 侧 `query_start_loc` 逐段补成与捕获布局一致 | `vllm_ascend/spec_decode/dspark_proposer.py:515-546` |
| 5 | **注册档键换算**：`set_draft_graph_params` 时 dspark 只取 FULL 档并用 Query-T 换算尺寸集合 | `vllm_ascend/worker/model_runner_v1.py:5052-5086` |
| 6 | **图捕获**：`dummy_run` 新增 FULL 分支——按与回放同布局构建元数据，真实 B×N 行写 KV（`num_actual_tokens=num_query_total`），填充行 slot_mapping=-1 丢弃；捕获后首次写入图参数 | `vllm_ascend/spec_decode/dspark_proposer.py:560-687`（元数据 597-650、首次更新 :682） |
| 7 | **长度契约分流（修双重计数）**：后端检测标志位（MLA/DSA）；`parallel_draft_seq_lens_cpu` 仅 MLA 发布（N 只加这一次）；DSA 镜像 +N 仅作 `max_seqlen_kv` 上界（真实长度走 device） | `vllm_ascend/spec_decode/dspark_proposer.py:240-248`、`307-340`、`480-492` |
| 8 | **K3 门控**：`_is_k3_dspark` 判定函数 + init 置位一次，per-step 只读布尔值 | `vllm_ascend/spec_decode/llm_base_proposer.py:124-132`、`:221` |
| 9 | **图分发宽度**：K3 按 target 宽度 B×(1+N) 领取批量描述符 | `vllm_ascend/spec_decode/llm_base_proposer.py:1083-1093` |
| 10 | **每步更新键**：`graph_param_num_tokens` 换算 + `pad_query_start_loc_for_graph` 调用；回放前/后按此键更新图参数 | `vllm_ascend/spec_decode/llm_base_proposer.py:1116-1150`、`:1363-1377` |
| 11 | **长度保留**：不覆盖 `set_inputs_first_pass` 算好的 device/host 长度，只对填充尾截齐 | `vllm_ascend/spec_decode/llm_base_proposer.py:1169-1183` |
| 12 | **context slot mapping 前移**：形状随请求变化，图外每步现算；配套调整避免重复构建 | `vllm_ascend/spec_decode/llm_base_proposer.py:1327-1328`、`:1405-1410` |