### PR TITLE
[CI][Misc] Remove Qwen3-32B nightly accuracy tests

### DIFF
--- a/.github/workflows/configs/nightly_config.yaml
+++ b/.github/workflows/configs/nightly_config.yaml
@@ -293,15 +293,6 @@ a3:
       - name: Qwen3-30B-QuaRot
         os: linux-aarch64-nightly-a3-2
         config_file_path: Qwen3-30B-QuaRot-eagle3.yaml
-      # Qwen3-32B V1/V2 exit-scenario accuracy guards (AIME W8A8 + GPQA bf16):
-      # nightly-only, reusing the same pytest files (V1 vs V2 direct compare).
-      - name: qwen3-32b-w8a8-aime2024-acc
-        os: linux-aarch64-nightly-a3-4
-        tests: tests/e2e/nightly/test_qwen3_32b_w8a8_aime2024_accuracy.py
-      - name: qwen3-32b-bf16-gpqa-acc
-        os: linux-aarch64-nightly-a3-4
-        tests: tests/e2e/nightly/test_qwen3_32b_bf16_gpqa_accuracy.py
-        testcase_timeout: 240
 
 a3-560t:
   single_node:
@@ -382,15 +373,6 @@ a3-560t:
       - name: Qwen3-30B-QuaRot
         os: linux-aarch64-a3-2-cn12-001
         config_file_path: Qwen3-30B-QuaRot-eagle3.yaml
-      # Qwen3-32B V1/V2 exit-scenario accuracy guards (AIME W8A8 + GPQA bf16):
-      # nightly-only, reusing the same pytest files (V1 vs V2 direct compare).
-      - name: qwen3-32b-w8a8-aime2024-acc
-        os: linux-aarch64-a3-4-cn12-001
-        tests: tests/e2e/nightly/test_qwen3_32b_w8a8_aime2024_accuracy.py
-      - name: qwen3-32b-bf16-gpqa-acc
-        os: linux-aarch64-a3-4-cn12-001
-        tests: tests/e2e/nightly/test_qwen3_32b_bf16_gpqa_accuracy.py
-        testcase_timeout: 240
 
 310p:
   single_node:


### PR DESCRIPTION
### What this PR does / why we need it?
del test_qwen3_32b_bf16_gpqa_accuracy.py and test_qwen3_32b_w8a8_aime2024_accuracy.py in nightly_config.yaml
### Does this PR introduce _any_ user-facing change?
No
### How was this patch tested?
This is a cleanup PR that removes tests; no new tests are required.
- vLLM main: https://github.com/vllm-project/vllm/commit/b2f685834a6456197e7033966fdef52a23f1abcd
