### PR TITLE
[BugFix][Sampling] Validate stop and allowed token ids

### DIFF
--- a/tests/ut/patch/platform/test_patch_stop_token_ids_validation.py
+++ b/tests/ut/patch/platform/test_patch_stop_token_ids_validation.py
@@ -1,0 +1,69 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for the stop_token_ids vocabulary validation patch.
+
+Out-of-vocab stop token ids crash the engine on CANN 9.1.x (IndexCheck
+kernel traps on the OOB logits index). See vllm-ascend issue #15200.
+"""
+
+from unittest.mock import MagicMock
+
+import pytest
+from vllm.sampling_params import SamplingParams, VLLMValidationError
+
+import vllm_ascend.patch.platform.patch_stop_token_ids_validation  # noqa: F401
+
+
+def _make_model_config(vocab_size: int) -> MagicMock:
+    model_config = MagicMock()
+    model_config.get_vocab_size.return_value = vocab_size
+    return model_config
+
+
+@pytest.mark.parametrize(
+    ("stop_token_ids", "vocab_size", "should_raise"),
+    [
+        # valid ids (boundaries included)
+        ([0], 129280, False),
+        ([127999, 129279], 129280, False),
+        ([], 129280, False),
+        (None, 129280, False),
+        # out-of-vocab high / negative
+        ([129280], 129280, True),
+        ([151645], 129280, True),  # the id from vllm-ascend issue #15200
+        ([-1], 129280, True),
+        ([1, 151645, 2], 129280, True),
+    ],
+)
+def test_stop_token_ids_vocab_validation(stop_token_ids, vocab_size, should_raise):
+    model_config = _make_model_config(vocab_size)
+    params = SamplingParams(stop_token_ids=stop_token_ids)
+    params._all_stop_token_ids = set(stop_token_ids or ())
+
+    if should_raise:
+        with pytest.raises(VLLMValidationError, match="stop_token_ids"):
+            params._validate_stop_token_ids(model_config)
+    else:
+        params._validate_stop_token_ids(model_config)
+
+
+def test_verify_calls_validation():
+    model_config = _make_model_config(129280)
+    params = SamplingParams(stop_token_ids=[151645])
+    params._all_stop_token_ids = {151645}
+
+    # verify() delegates through the patched _validate_stop_token_ids; the
+    # other validators are no-ops on this params object, so the first real
+    # failure must be the stop_token_ids check.
+    with pytest.raises(VLLMValidationError, match="out-of-vocab"):
+        params.verify(model_config, None, None, None)
+
+
+def test_patch_is_idempotent_when_upstream_has_fix():
+    # When the bundled vLLM already ships _validate_stop_token_ids, the
+    # patch must not override it.
+    assert hasattr(SamplingParams, "_validate_stop_token_ids")
+    model_config = _make_model_config(100)
+    params = SamplingParams(stop_token_ids=[150])
+    params._all_stop_token_ids = {150}
+    with pytest.raises(VLLMValidationError):
+        params._validate_stop_token_ids(model_config)

--- a/tests/ut/patch/platform/test_patch_stop_token_ids_validation.py
+++ b/tests/ut/patch/platform/test_patch_stop_token_ids_validation.py
@@ -1,8 +1,10 @@
 # SPDX-License-Identifier: Apache-2.0
-"""Tests for the stop_token_ids vocabulary validation patch.
+"""Tests for the vocabulary validation patch (stop_token_ids + allowed_token_ids).
 
 Out-of-vocab stop token ids crash the engine on CANN 9.1.x (IndexCheck
-kernel traps on the OOB logits index). See vllm-ascend issue #15200.
+kernel traps on the OOB logits index). allowed_token_ids has the same
+hazard via the InputBatch mask. See vllm-ascend issue #15200 and the
+upstream fix vllm#54196.
 """
 
 from unittest.mock import MagicMock
@@ -46,16 +48,56 @@ def test_stop_token_ids_vocab_validation(stop_token_ids, vocab_size, should_rais
         params._validate_stop_token_ids(model_config)
 
 
-def test_verify_calls_validation():
-    model_config = _make_model_config(129280)
-    params = SamplingParams(stop_token_ids=[151645])
-    params._all_stop_token_ids = {151645}
+@pytest.mark.parametrize(
+    ("allowed_token_ids", "vocab_size", "should_raise"),
+    [
+        # valid ids (boundaries included)
+        ([0], 129280, False),
+        ([127999, 129279], 129280, False),
+        (None, 129280, False),
+        # empty / out-of-vocab high / negative
+        ([], 129280, True),
+        ([129280], 129280, True),
+        ([151645], 129280, True),
+        ([-1], 129280, True),
+        ([1, 151645, 2], 129280, True),
+        # id within a larger tokenizer vocab but past the model vocab
+        ([1500], 1000, True),
+    ],
+)
+def test_allowed_token_ids_vocab_validation(allowed_token_ids, vocab_size, should_raise):
+    model_config = _make_model_config(vocab_size)
+    params = SamplingParams(allowed_token_ids=allowed_token_ids)
 
-    # verify() delegates through the patched _validate_stop_token_ids; the
-    # other validators are no-ops on this params object, so the first real
-    # failure must be the stop_token_ids check.
-    with pytest.raises(VLLMValidationError, match="out-of-vocab"):
+    if should_raise:
+        with pytest.raises(VLLMValidationError, match="allowed_token_ids"):
+            params._validate_allowed_token_ids(model_config)
+    else:
+        params._validate_allowed_token_ids(model_config)
+
+
+@pytest.mark.parametrize(
+    ("stop_token_ids", "allowed_token_ids", "match"),
+    [
+        ([151645], None, "stop_token_ids"),
+        (None, [151645], "allowed_token_ids"),
+    ],
+)
+def test_verify_calls_validation(stop_token_ids, allowed_token_ids, match):
+    model_config = _make_model_config(129280)
+    params = SamplingParams(stop_token_ids=stop_token_ids, allowed_token_ids=allowed_token_ids)
+
+    # verify() delegates through the patched validators; the other
+    # validators are no-ops on this params object, so the failure must come
+    # from the patched checks.
+    with pytest.raises(VLLMValidationError, match=match):
         params.verify(model_config, None, None, None)
+
+
+def test_verify_accepts_in_vocab_ids():
+    model_config = _make_model_config(129280)
+    params = SamplingParams(stop_token_ids=[0, 129279], allowed_token_ids=[1, 2])
+    params.verify(model_config, None, None, None)
 
 
 def test_patch_is_idempotent_when_upstream_has_fix():

--- a/tests/ut/patch/platform/test_patch_stop_token_ids_validation.py
+++ b/tests/ut/patch/platform/test_patch_stop_token_ids_validation.py
@@ -18,6 +18,7 @@ import vllm_ascend.patch.platform.patch_stop_token_ids_validation  # noqa: F401
 def _make_model_config(vocab_size: int) -> MagicMock:
     model_config = MagicMock()
     model_config.get_vocab_size.return_value = vocab_size
+    model_config.is_diffusion = False
     return model_config
 
 
@@ -97,7 +98,10 @@ def test_verify_calls_validation(stop_token_ids, allowed_token_ids, match):
 def test_verify_accepts_in_vocab_ids():
     model_config = _make_model_config(129280)
     params = SamplingParams(stop_token_ids=[0, 129279], allowed_token_ids=[1, 2])
-    params.verify(model_config, None, None, None)
+    tokenizer = MagicMock()
+    tokenizer.__len__.return_value = 129280
+    tokenizer.get_vocab_size.return_value = 129280
+    params.verify(model_config, None, None, tokenizer)
 
 
 def test_patch_is_idempotent_when_upstream_has_fix():

--- a/vllm_ascend/patch/__init__.py
+++ b/vllm_ascend/patch/__init__.py
@@ -1168,3 +1168,31 @@
 #       Remove this patch once vllm-ascend's bundled PyTorch >= 2.13.0
 #       (which, like upstream, allows eps >= 0 for inference).
 #
+# ** 34a. File: platform/patch_stop_token_ids_validation.py**
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+#   1. `vllm.sampling_params.SamplingParams.verify`
+#      `vllm.sampling_params.SamplingParams._validate_stop_token_ids`
+#    Why:
+#       Upstream vLLM (before #54196) does not validate stop_token_ids
+#       against the vocabulary. Out-of-vocab stop token ids flow into
+#       all_stop_token_ids and are later used as logits indices on the
+#       device side (min_tokens / EOS masking does logits.index_put_).
+#       On CANN 9.1.x the inserted IndexCheck kernel traps on the OOB index
+#       and the whole engine dies with an unrecoverable vector core exception;
+#       on older CANN the write silently corrupts logits of neighboring
+#       requests in the same batch. A single client request can therefore
+#       crash a production instance (vllm-ascend issue #15200).
+#    How：
+#       Monkey-patch SamplingParams.verify to run a vocabulary-range check on
+#       stop_token_ids (mirroring upstream _validate_logit_bias) and reject
+#       invalid requests with a 400 before they reach the engine. The patch
+#       self-disables once the bundled vLLM already ships
+#       `_validate_stop_token_ids`.
+#    Related PR (if no, explain why):
+#       https://github.com/vllm-project/vllm/pull/54196 (merged into vLLM main;
+#       not yet in the vLLM commit pinned by vllm-ascend main as of this patch)
+#    Future Plan:
+#       Remove this patch once the vLLM commit pinned by vllm-ascend main
+#       contains vllm#54196; until then the hasattr guard keeps it a no-op
+#       on fixed builds.
+#

--- a/vllm_ascend/patch/__init__.py
+++ b/vllm_ascend/patch/__init__.py
@@ -1172,22 +1172,30 @@
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 #   1. `vllm.sampling_params.SamplingParams.verify`
 #      `vllm.sampling_params.SamplingParams._validate_stop_token_ids`
+#      `vllm.sampling_params.SamplingParams._validate_allowed_token_ids`
 #    Why:
 #       Upstream vLLM (before #54196) does not validate stop_token_ids
-#       against the vocabulary. Out-of-vocab stop token ids flow into
-#       all_stop_token_ids and are later used as logits indices on the
-#       device side (min_tokens / EOS masking does logits.index_put_).
+#       against the vocabulary, and validates allowed_token_ids against
+#       len(tokenizer) instead of the model vocab. Both fields are
+#       client-supplied ids used as column indices into the logits tensor
+#       on the device side (min_tokens / EOS masking does logits.index_put_
+#       on all_stop_token_ids; the allowed_token_ids mask in InputBatch is
+#       sized by model_config.get_vocab_size() and the ids are written as
+#       mask[req_index][allowed_token_ids]). For models whose tokenizer
+#       knows more ids than the language model, gap ids pass the
+#       tokenizer-based check yet still index out of bounds.
 #       On CANN 9.1.x the inserted IndexCheck kernel traps on the OOB index
 #       and the whole engine dies with an unrecoverable vector core exception;
 #       on older CANN the write silently corrupts logits of neighboring
 #       requests in the same batch. A single client request can therefore
 #       crash a production instance (vllm-ascend issue #15200).
 #    How：
-#       Monkey-patch SamplingParams.verify to run a vocabulary-range check on
-#       stop_token_ids (mirroring upstream _validate_logit_bias) and reject
-#       invalid requests with a 400 before they reach the engine. The patch
-#       self-disables once the bundled vLLM already ships
-#       `_validate_stop_token_ids`.
+#       Monkey-patch SamplingParams.verify to run vocabulary-range checks on
+#       both stop_token_ids and allowed_token_ids (mirroring upstream
+#       _validate_logit_bias) and reject invalid requests with a 400 before
+#       they reach the engine. The patch self-disables once the bundled vLLM
+#       already ships `_validate_stop_token_ids` (the two validators landed
+#       in vllm#54196 together, so the single hasattr check covers both).
 #    Related PR (if no, explain why):
 #       https://github.com/vllm-project/vllm/pull/54196 (merged into vLLM main;
 #       not yet in the vLLM commit pinned by vllm-ascend main as of this patch)

--- a/vllm_ascend/patch/platform/__init__.py
+++ b/vllm_ascend/patch/platform/__init__.py
@@ -42,6 +42,7 @@ import vllm_ascend.patch.platform.patch_dyntra_lb_core  # noqa
 
 import vllm_ascend.patch.platform.patch_kv_cache_coordinator  # noqa
 import vllm_ascend.patch.platform.patch_speculative_config  # noqa
+import vllm_ascend.patch.platform.patch_stop_token_ids_validation  # noqa
 
 import vllm_ascend.patch.platform.patch_eplb  # noqa
 import vllm_ascend.patch.platform.patch_fused_moe  # noqa

--- a/vllm_ascend/patch/platform/patch_stop_token_ids_validation.py
+++ b/vllm_ascend/patch/platform/patch_stop_token_ids_validation.py
@@ -17,13 +17,19 @@
 
 from vllm.sampling_params import SamplingParams, VLLMValidationError
 
-# Upstream vLLM (as of 0.23.0) validates logit_bias and allowed_token_ids
-# against the vocabulary but not stop_token_ids. Out-of-vocab stop token ids
-# flow into all_stop_token_ids and are later used as logits indices on the
-# device side (min_tokens / EOS masking does logits.index_put_). On CANN
-# 9.1.x the inserted IndexCheck kernel traps on the OOB index and the whole
-# engine dies with an unrecoverable vector core exception; on older CANN the
-# write silently corrupts logits of neighboring requests in the same batch.
+# Upstream vLLM (before #54196) validates logit_bias against the model
+# vocabulary but validates stop_token_ids not at all and allowed_token_ids
+# against len(tokenizer). Both fields end up as column indices into the
+# logits tensor on the device side (min_tokens / EOS masking does
+# logits.index_put_ on all_stop_token_ids; the allowed_token_ids mask in
+# InputBatch is sized by model_config.get_vocab_size() and the ids are
+# written as mask[req_index][allowed_token_ids]). For models whose
+# tokenizer knows more ids than the language model (multimodal placeholder
+# tokens), gap ids pass the tokenizer-based check yet still index out of
+# bounds. On CANN 9.1.x the inserted IndexCheck kernel traps on the OOB
+# index and the whole engine dies with an unrecoverable vector core
+# exception; on older CANN the write silently corrupts logits of
+# neighboring requests in the same batch (vllm-ascend issue #15200).
 #
 # Upstream fix: https://github.com/vllm-project/vllm/pull/54196
 # Downstream issue: https://github.com/vllm-project/vllm-ascend/issues/15200
@@ -31,12 +37,11 @@ from vllm.sampling_params import SamplingParams, VLLMValidationError
 
 def _validate_stop_token_ids(self, model_config) -> None:
     """Validate stop_token_ids are within vocabulary range."""
-    stop_token_ids = self.stop_token_ids
-    if not stop_token_ids:
+    if not self.stop_token_ids:
         return
 
     vocab_size = model_config.get_vocab_size()
-    invalid_token_ids = [token_id for token_id in stop_token_ids if token_id < 0 or token_id >= vocab_size]
+    invalid_token_ids = [token_id for token_id in self.stop_token_ids if token_id < 0 or token_id >= vocab_size]
 
     if invalid_token_ids:
         raise VLLMValidationError(
@@ -47,16 +52,41 @@ def _validate_stop_token_ids(self, model_config) -> None:
         )
 
 
-# Only patch when the bundled vLLM does not already contain the upstream fix;
-# once the upstream PR lands in a vLLM release used here, this patch becomes
-# a no-op and can be dropped.
+def _validate_allowed_token_ids(self, model_config) -> None:
+    allowed_token_ids = self.allowed_token_ids
+    if allowed_token_ids is None:
+        return
+
+    if len(allowed_token_ids) == 0:
+        raise VLLMValidationError(
+            "allowed_token_ids is not None and empty!",
+            parameter="allowed_token_ids",
+            value=allowed_token_ids,
+        )
+
+    vocab_size = model_config.get_vocab_size()
+    invalid_token_ids = [token_id for token_id in allowed_token_ids if token_id < 0 or token_id >= vocab_size]
+    if invalid_token_ids:
+        raise VLLMValidationError(
+            "allowed_token_ids contains out-of-vocab token id!",
+            parameter="allowed_token_ids",
+            value=invalid_token_ids,
+        )
+
+
+# Only patch when the bundled vLLM does not already contain the upstream
+# fix. The guard checks both validators from vllm#54196: if the bundled vLLM
+# ships either one, it ships both (they landed in the same commit), and the
+# patch becomes a no-op that can be dropped.
 if not hasattr(SamplingParams, "_validate_stop_token_ids"):
     SamplingParams._validate_stop_token_ids = _validate_stop_token_ids
+    SamplingParams._validate_allowed_token_ids = _validate_allowed_token_ids
 
     _orig_verify = SamplingParams.verify
 
     def _verify(self, model_config, *args, **kwargs):
         _validate_stop_token_ids(self, model_config)
+        _validate_allowed_token_ids(self, model_config)
         return _orig_verify(self, model_config, *args, **kwargs)
 
     SamplingParams.verify = _verify

--- a/vllm_ascend/patch/platform/patch_stop_token_ids_validation.py
+++ b/vllm_ascend/patch/platform/patch_stop_token_ids_validation.py
@@ -1,0 +1,62 @@
+#
+# Copyright (c) 2025 Huawei Technologies Co., Ltd. All Rights Reserved.
+# This file is a part of the vllm-ascend project.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+from vllm.sampling_params import SamplingParams, VLLMValidationError
+
+# Upstream vLLM (as of 0.23.0) validates logit_bias and allowed_token_ids
+# against the vocabulary but not stop_token_ids. Out-of-vocab stop token ids
+# flow into all_stop_token_ids and are later used as logits indices on the
+# device side (min_tokens / EOS masking does logits.index_put_). On CANN
+# 9.1.x the inserted IndexCheck kernel traps on the OOB index and the whole
+# engine dies with an unrecoverable vector core exception; on older CANN the
+# write silently corrupts logits of neighboring requests in the same batch.
+#
+# Upstream fix: https://github.com/vllm-project/vllm/pull/54196
+# Downstream issue: https://github.com/vllm-project/vllm-ascend/issues/15200
+
+
+def _validate_stop_token_ids(self, model_config) -> None:
+    """Validate stop_token_ids are within vocabulary range."""
+    stop_token_ids = self.stop_token_ids
+    if not stop_token_ids:
+        return
+
+    vocab_size = model_config.get_vocab_size()
+    invalid_token_ids = [token_id for token_id in stop_token_ids if token_id < 0 or token_id >= vocab_size]
+
+    if invalid_token_ids:
+        raise VLLMValidationError(
+            f"token_id(s) {invalid_token_ids} in stop_token_ids contain "
+            f"out-of-vocab token ids. Vocabulary size: {vocab_size}",
+            parameter="stop_token_ids",
+            value=invalid_token_ids,
+        )
+
+
+# Only patch when the bundled vLLM does not already contain the upstream fix;
+# once the upstream PR lands in a vLLM release used here, this patch becomes
+# a no-op and can be dropped.
+if not hasattr(SamplingParams, "_validate_stop_token_ids"):
+    SamplingParams._validate_stop_token_ids = _validate_stop_token_ids
+
+    _orig_verify = SamplingParams.verify
+
+    def _verify(self, model_config, *args, **kwargs):
+        _validate_stop_token_ids(self, model_config)
+        return _orig_verify(self, model_config, *args, **kwargs)
+
+    SamplingParams.verify = _verify


### PR DESCRIPTION
## What this PR does / why we need it?

Backport PR #15339 to `releases/v0.27.1rc`. Validate client-supplied `stop_token_ids` and `allowed_token_ids` against the model vocabulary before device-side logits indexing, preventing out-of-bounds failures on Ascend.

## Does this PR introduce any user-facing change?

Invalid token ids are rejected during request validation.

## How was this patch tested?

Cherry-picked the two commits from PR #15339 onto `releases/v0.27.1rc` and verified `git diff --check`.

- vLLM main: https://github.com/vllm-project/vllm/commit/ba07e4a48fc951300d97eb506217dd530583dea3
