### PR TITLE
[Ops][Misc] Revert ND PA KV cache write to _npu_reshape_and_cache for A3/A2

### DIFF
--- a/vllm_ascend/device/device_op.py
+++ b/vllm_ascend/device/device_op.py
@@ -40,13 +40,14 @@ else:
 class BaseDeviceAdaptor:
     @classmethod
     def reshape_and_cache(cls, key, value, key_cache, value_cache, slot_mapping):
-        torch_npu.npu_scatter_pa_kv_cache(
-            key=key.contiguous(),
-            value=value.contiguous(),
+        # npu_scatter_pa_kv_cache (#11713) adds host-side overhead that costs
+        # ~9% end-to-end throughput on Atlas A3; see commit message for data.
+        torch_npu._npu_reshape_and_cache(
+            key=key,
+            value=value,
             key_cache=key_cache,
             value_cache=value_cache,
-            slot_mapping=slot_mapping.contiguous(),
-            cache_mode="Norm",
+            slot_indices=slot_mapping,
         )
 
     @classmethod


### PR DESCRIPTION
### What this PR does / why we need it?

Reverts the ND PA KV cache write implementation to use `_npu_reshape_and_cache` instead of `npu_scatter_pa_kv_cache` for A3/A2.
The `npu_scatter_pa_kv_cache` call adds host-side overhead that costs approximately 9% end-to-end throughput on Atlas A3. Reverting to `_npu_reshape_and_cache` avoids this overhead and improves performance.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Tested on Atlas A3/A2 hardware to verify performance improvement and correctness of KV cache writes.

- vLLM main: https://github.com/vllm-project/vllm/commit/b2f685834a6456197e7033966fdef52a23f1abcd
