### PR TITLE
[bugfix] fix stuck without dp padding

### DIFF
--- a/tests/e2e/pull_request/one_card/test_model_runner_v1_with_device.py
+++ b/tests/e2e/pull_request/one_card/test_model_runner_v1_with_device.py
@@ -495,12 +495,16 @@ def test_stateful_handoff_preserves_decode_graph(
     assert mode == expected_mode
     assert descriptor.uniform == (expected_mode == CUDAGraphMode.FULL)
     if dp_size > 1:
-        padded_num_tokens = num_tokens
-        for capture_size in cudagraph_capture_sizes:
-            if num_tokens <= capture_size:
-                padded_num_tokens = capture_size
-                break
-        assert descriptor.num_tokens == padded_num_tokens
         expected_tokens_across_dp = torch.full((dp_size,), 32, dtype=torch.int32)
-        expected_tokens_across_dp[0] = padded_num_tokens
-        torch.testing.assert_close(tokens_across_dp, expected_tokens_across_dp)
+        if mode != CUDAGraphMode.NONE:
+            assert descriptor.num_tokens == 32
+            torch.testing.assert_close(tokens_across_dp, expected_tokens_across_dp)
+        else:
+            padded_num_tokens = num_tokens
+            for capture_size in cudagraph_capture_sizes:
+                if num_tokens <= capture_size:
+                    padded_num_tokens = capture_size
+                    break
+            assert descriptor.num_tokens == padded_num_tokens
+            expected_tokens_across_dp[0] = padded_num_tokens
+            torch.testing.assert_close(tokens_across_dp, expected_tokens_across_dp)

--- a/vllm_ascend/worker/model_runner_v1.py
+++ b/vllm_ascend/worker/model_runner_v1.py
@@ -788,7 +788,7 @@ class NPUModelRunner(GPUModelRunner):
         comm_method = select_moe_comm_method(max_tokens_across_dp, self.vllm_config)
         is_finegrained_tp = self.ascend_config.finegrained_tp_config.max_finegrained_tp_size > 1
         use_mega_moe = comm_method == MoECommType.FUSED_MC2 and is_mega_moe_supported()
-        # There are three cases where padding between DPs is required:
+        # There are 5 cases where padding between DPs is required:
         # 1. comm_method == ALLGATHER, ensure the input tensor shape of allgather is consistent;
         # 2. comm_method == MC2, reduce communication and computation through active_mask to enhance performance;
         # 3. when finegrained_tp is open, we need to ensure num_tokens remains consistent within finegrained_tp_group.
@@ -796,7 +796,11 @@ class NPUModelRunner(GPUModelRunner):
         # 4. when use mega_moe, op cannot support dynamic bs now,
         #    we need to do allreduce and pad token across dp every step.
         #    TODO(zzzzwwjj): remove it when op can support dynamic bs.
-        if comm_method in {MoECommType.ALLGATHER, MoECommType.MC2} or is_finegrained_tp or use_mega_moe:
+        # 5. FIXME(zzzzwwjj): currently, there are some bugs can lead to worker crashes when not do dp_padding in
+        #    graph mode. Therefore, dp_padding is currently enforced in graph mode.
+        if (synced_cudagraph_mode != CUDAGraphMode.NONE or
+                comm_method in {MoECommType.ALLGATHER, MoECommType.MC2} or
+                is_finegrained_tp or use_mega_moe):
             num_tokens_after_padding = torch.tensor(
                 [max_tokens_across_dp] * self.dp_size, device="cpu", dtype=torch.int32
             )


### PR DESCRIPTION
### What this PR does / why we need it?

Currently, there are some bugs can lead to worker crashes when not do dp_padding in graph mode. Therefore, dp_padding is currently enforced in graph mode.

In the graph mode scenario, due to the small number of tokens and the support of the dispatch/combine/fused_mc2 operator for avoiding additional communication/computation caused by padding tokens through `active_mask`, dp padding does not cause significant performance degradation.

### Does this PR introduce _any_ user-facing change?

None.

### How was this patch tested?

- vLLM main: https://github.com/vllm-project/vllm/commit/b2f685834a6456197e7033966fdef52a23f1abcd
