### PR TITLE
[Feature][Model] Fix per-request metadata buffer sizing for DSA-CP under full cudagraph padding

### DIFF
--- a/tests/e2e/pull_request/four_card/context_parallel/test_accuracy.py
+++ b/tests/e2e/pull_request/four_card/context_parallel/test_accuracy.py
@@ -71,6 +71,21 @@ DEEPSEEK_V4_PROMPTS = [
 DEEPSEEK_V4_GOLDEN = ["Hello, my name is {name} and I", 'What is the meaning of life?",\n    "What is']
 DEEPSEEK_V4_MODEL = "gdydems/DeepSeek-V4-Flash-w4a8-mtp"
 
+# max_num_seqs deliberately smaller than the cudagraph capture bucket so that
+# FULL-decode graph padding pushes the draft-path num_reqs beyond max_num_seqs.
+CONCURRENT_MAX_NUM_SEQS = 4
+CONCURRENT_CAPTURE_SIZES = [16]
+CONCURRENT_PROMPTS = [
+    "The capital of France is",
+    "Hello, my name is",
+    "What is the meaning of life?",
+    "The president of United States is",
+    "Write a short story about a robot.",
+    "Explain quantum computing simply.",
+    "List three primary colors.",
+    "Describe a rainy day in Paris.",
+]
+
 
 @dataclass(frozen=True)
 class AccuracyCase:
@@ -174,6 +189,10 @@ FULL_FEATURE_MODEL_CASES = [
             "additional_config": {
                 "enable_dsa_cp": True,
             },
+            "speculative_config": {
+                "num_speculative_tokens": 3,
+                "method": "mtp",
+            },
         },
     ),
 ]
@@ -242,3 +261,59 @@ def test_deepseek_v4_dsa_cp_prefill_decode_accuracy() -> None:
 @pytest.mark.parametrize("case", FULL_FEATURE_MODEL_CASES, ids=lambda case: case.name)
 def test_models_dcp_full_feature_accuracy(case: AccuracyCase) -> None:
     _run_accuracy_case(case)
+
+
+@patch.dict(
+    os.environ,
+    {
+        "HCCL_BUFFSIZE": "768",
+        "PYTORCH_NPU_ALLOC_CONF": "expandable_segments:True",
+    },
+)
+@wait_until_npu_memory_free(target_free_percentage=0.8)
+def test_models_dcp_full_graph_concurrent_requests() -> None:
+    """Accuracy guard for concurrent requests under FULL-decode aclgraph.
+
+    Regression test for the DSA-CP per-request metadata buffers: in
+    FULL_DECODE_ONLY graph mode the draft path receives ``num_reqs`` padded to
+    the cudagraph capture bucket (plus the FIA dummy request), which exceeds
+    ``max_num_seqs`` here (CONCURRENT_CAPTURE_SIZES=[16] vs
+    CONCURRENT_MAX_NUM_SEQS=4). Buffers sized by ``max_num_seqs`` get their
+    ``[:num_reqs]`` views truncated — copy_() then fails with a shape mismatch
+    (EZ1007) or triton kernels write past the buffer end and corrupt adjacent
+    device memory (EZ9999 MTE illegal GM address).
+
+    With MTP(num_speculative_tokens=3) each decode step of 4 concurrent
+    requests yields 16 tokens, so the batch is padded to the 16-token capture
+    bucket and every draft step exercises the padded path.
+    """
+    runner_kwargs: dict[str, Any] = {
+        "max_model_len": 8192,
+        "max_num_seqs": CONCURRENT_MAX_NUM_SEQS,
+        "max_num_batched_tokens": 4096,
+        "dtype": "auto",
+        "tensor_parallel_size": 4,
+        "decode_context_parallel_size": 1,
+        "enable_expert_parallel": True,
+        "gpu_memory_utilization": 0.9,
+        "quantization": "ascend",
+        "tokenizer_mode": "deepseek_v4",
+        "block_size": 128,
+        "compilation_config": {
+            "cudagraph_mode": "FULL_DECODE_ONLY",
+            "cudagraph_capture_sizes": CONCURRENT_CAPTURE_SIZES,
+        },
+        "additional_config": {
+            "enable_dsa_cp": True,
+        },
+        "speculative_config": {
+            "num_speculative_tokens": 3,
+            "method": "mtp",
+        },
+    }
+    with VllmRunner("gdydems/DeepSeek-V4-Flash-w4a8-mtp", **runner_kwargs) as runner:
+        outputs = runner.generate_greedy(CONCURRENT_PROMPTS, 5)
+
+    assert len(outputs) == len(CONCURRENT_PROMPTS)
+    for _, output_str in outputs:
+        assert output_str, "Concurrent request produced an empty output"

--- a/vllm_ascend/attention/context_parallel/dsa_cp.py
+++ b/vllm_ascend/attention/context_parallel/dsa_cp.py
@@ -61,6 +61,9 @@ if TYPE_CHECKING:
 # Legacy DSA-CP implementation (TP/SP group)
 # =============================================================================
 
+# Fixed-size contract required by the underlying _C_ascend ops (must be exactly 1024).
+SAS_METADATA_SIZE = 1024
+
 
 def hadamard_transform_ref(
     x: torch.Tensor,
@@ -252,29 +255,31 @@ class AscendDSACPMetadataBuilder(AttentionMetadataBuilder[AscendDSAMetadata]):
                     torch.bfloat16
                 ),
             )
-        self.start_pos_prefill = torch.zeros(scheduler_config.max_num_seqs, dtype=torch.int32, device=self.device)
-        self.req_sas_metadata = torch.zeros(1024, dtype=torch.int32, device=self.device)
-        self.req_qli_metadata = torch.zeros(1024, dtype=torch.int32, device=self.device)
         # Full-decode graphs pad the request count beyond max_num_seqs
-        # (cudagraph capture sizes plus the FIA dummy request), so size the
-        # per-request QLI buffers for the graph-mode maximum.
-        max_qli_reqs = scheduler_config.max_num_seqs
+        # (cudagraph capture sizes plus the FIA dummy request), so size all
+        # per-request buffers for the graph-mode maximum. Otherwise the
+        # [:num_reqs] views taken below get truncated, copy_() into them
+        # fails with shape mismatches, or triton kernels write past the
+        # buffer end and corrupt adjacent device memory.
         compilation_config = self.vllm_config.compilation_config
+        max_padded_reqs = scheduler_config.max_num_seqs
         if compilation_config.cudagraph_mode != CUDAGraphMode.NONE and compilation_config.cudagraph_capture_sizes:
-            max_qli_reqs = max(max_qli_reqs, compilation_config.max_cudagraph_capture_size)
+            max_padded_reqs = max(max_padded_reqs, compilation_config.max_cudagraph_capture_size)
         # +1 holds the FIA dummy request inserted by mixed-batch padding.
-        self.qli_seqused_k = torch.zeros(max_qli_reqs + 1, dtype=torch.int32, device=self.device)
-        self.qli_cmp_residual_k = torch.zeros(max_qli_reqs + 1, dtype=torch.int32, device=self.device)
+        max_padded_reqs += 1
+        self.start_pos_prefill = torch.zeros(max_padded_reqs, dtype=torch.int32, device=self.device)
+        self.req_sas_metadata = torch.zeros(SAS_METADATA_SIZE, dtype=torch.int32, device=self.device)
+        self.req_qli_metadata = torch.zeros(SAS_METADATA_SIZE, dtype=torch.int32, device=self.device)
+        self.qli_seqused_k = torch.zeros(max_padded_reqs, dtype=torch.int32, device=self.device)
+        self.qli_cmp_residual_k = torch.zeros(max_padded_reqs, dtype=torch.int32, device=self.device)
         self._device_metadata_enabled = False
         self._device_metadata_tasks: tuple[DeviceMetadataTask, ...] = ()
         self.cu_seqlens_ori_kv = torch.tensor([], device=self.device)
         self.cu_seqlens_cmp_kv = torch.tensor([], device=self.device)
         self.seqused_q = torch.tensor([], device=self.device)
         self._zero_i32 = torch.tensor([0], device=self.device, dtype=torch.int32)
-        self.local_query_start_loc = torch.zeros(
-            scheduler_config.max_num_seqs + 1, dtype=torch.int32, device=self.device
-        )
-        self.local_seq_lens = torch.zeros(scheduler_config.max_num_seqs, dtype=torch.int32, device=self.device)
+        self.local_query_start_loc = torch.zeros(max_padded_reqs + 1, dtype=torch.int32, device=self.device)
+        self.local_seq_lens = torch.zeros(max_padded_reqs, dtype=torch.int32, device=self.device)
 
         self.speculative_config = vllm_config.speculative_config
         self.decode_threshold = 1
@@ -292,12 +297,16 @@ class AscendDSACPMetadataBuilder(AttentionMetadataBuilder[AscendDSAMetadata]):
                 for _ in range(spec_token_num)
             ]
             self.spec_local_query_start_loc = [
-                torch.zeros(scheduler_config.max_num_seqs + 1, dtype=torch.int32, device=self.device)
-                for _ in range(spec_token_num)
+                torch.zeros(max_padded_reqs + 1, dtype=torch.int32, device=self.device) for _ in range(spec_token_num)
             ]
             self.spec_local_seq_lens = [
-                torch.zeros(scheduler_config.max_num_seqs, dtype=torch.int32, device=self.device)
-                for _ in range(spec_token_num)
+                torch.zeros(max_padded_reqs, dtype=torch.int32, device=self.device) for _ in range(spec_token_num)
+            ]
+            self.spec_sas_metadata = [
+                torch.zeros(SAS_METADATA_SIZE, dtype=torch.int32, device=self.device) for _ in range(spec_token_num)
+            ]
+            self.spec_start_pos = [
+                torch.zeros(max_padded_reqs, dtype=torch.int32, device=self.device) for _ in range(spec_token_num)
             ]
             self.decode_threshold += spec_token_num
             assert self.decode_threshold <= 16, (
@@ -429,6 +438,7 @@ class AscendDSACPMetadataBuilder(AttentionMetadataBuilder[AscendDSAMetadata]):
         **kwargs,
     ) -> AscendDSAMetadata:
         assert self.compressor_ratio <= 1, "vLLM-Ascend only support SWA-layer for Deepseek-V4 now."
+        # NOTE(Csrayz): num_reqs here is the padded token count from graph dispatch
         num_reqs = common_attn_metadata.num_reqs
         num_input_tokens = common_attn_metadata.num_input_tokens
         # Cross-kv-cache-group metadata cache. The spec-decode proposer passes
@@ -462,9 +472,10 @@ class AscendDSACPMetadataBuilder(AttentionMetadataBuilder[AscendDSAMetadata]):
                 treat_short_extends_as_decodes=False,
             )
             input_positions = common_attn_metadata.positions[:num_input_tokens].long()
-            # Draft steps update positions independently. Reusing the global RoPE
-            # cache can let later draft steps overwrite step-0 metadata.
-            cos, sin = get_cos_and_sin_dsa(input_positions, use_cache=False)
+            # Use per-draft-index RoPE buffer so tensor addresses stay stable
+            # across graph capture/replay; the per-step cache below then lets
+            # sibling kv-cache groups reuse the same stable tensors.
+            cos, sin = get_cos_and_sin_dsa(input_positions, use_cache=True, draft_index=draft_index)
             if metadata_cache is not None:
                 metadata_cache.update(
                     num_decodes=num_decodes,
@@ -492,6 +503,13 @@ class AscendDSACPMetadataBuilder(AttentionMetadataBuilder[AscendDSAMetadata]):
             self.seq_lens_cpu = self.seq_lens.cpu()
             if metadata_cache is not None:
                 metadata_cache["seq_lens_cpu"] = self.seq_lens_cpu
+        # In aclgraph mode num_reqs is the padded request count; keep the
+        # tensor's batch dim stable at num_reqs across capture and replay.
+        num_real_reqs = self.seq_lens_cpu.shape[0]
+        if num_real_reqs < num_reqs:
+            self.seq_lens_cpu = F.pad(self.seq_lens_cpu, (0, num_reqs - num_real_reqs))
+        else:
+            self.seq_lens_cpu = self.seq_lens_cpu[:num_reqs]
 
         slot_mapping = common_attn_metadata.slot_mapping[:num_input_tokens]
 
@@ -549,19 +567,25 @@ class AscendDSACPMetadataBuilder(AttentionMetadataBuilder[AscendDSAMetadata]):
 
         if metadata_cache is not None and "local_query_start_loc" in metadata_cache:
             # Hit: local token metadata computed by a sibling kv-cache group
-            # of the same draft step. Values are identical across groups, so
-            # the cached (cloned) tensors are reused directly.
+            # of the same draft step. Values are identical across groups; copy
+            # them into this builder's stable per-draft buffers so the returned
+            # views keep fixed addresses across aclgraph capture/replay.
             local_start = metadata_cache["local_start"]
             local_end_with_pad = metadata_cache["local_end_with_pad"]
             tokens_per_rank = metadata_cache["tokens_per_rank"]
             num_tokens_pad = metadata_cache["num_tokens_pad"]
-            local_query_start_loc = metadata_cache["local_query_start_loc"]
-            local_seq_lens = metadata_cache["local_seq_lens"]
             max_local_query_len = metadata_cache["max_local_query_len"]
             max_local_seq_lens = metadata_cache["max_local_seq_lens"]
             local_cos = metadata_cache["local_cos"]
             local_sin = metadata_cache["local_sin"]
-            start_pos = metadata_cache["start_pos"]
+            self.spec_local_query_start_loc[draft_index - 1][: num_reqs + 1].copy_(
+                metadata_cache["local_query_start_loc"]
+            )
+            self.spec_local_seq_lens[draft_index - 1][:num_reqs].copy_(metadata_cache["local_seq_lens"])
+            self.spec_start_pos[draft_index - 1][:num_reqs].copy_(metadata_cache["start_pos"])
+            local_query_start_loc = self.spec_local_query_start_loc[draft_index - 1][: num_reqs + 1]
+            local_seq_lens = self.spec_local_seq_lens[draft_index - 1][:num_reqs]
+            start_pos = self.spec_start_pos[draft_index - 1][:num_reqs]
         else:
             (
                 local_start,
@@ -579,8 +603,11 @@ class AscendDSACPMetadataBuilder(AttentionMetadataBuilder[AscendDSAMetadata]):
                 local_seq_lens=self.spec_local_seq_lens[draft_index - 1],
                 is_noncausal=is_noncausal,
             )
-            local_query_start_loc = local_query_start_loc.clone()
-            local_seq_lens = local_seq_lens.clone()
+            # NOTE: no .clone() here. ACL graph capture bakes the addresses of
+            # these tensors into the draft graph, so every replay must read the
+            # freshly built values from the same (stable) buffer addresses.
+            # Returning a fresh clone would leave the graph reading stale
+            # capture-time metadata and cause illegal device memory accesses.
             local_cos = cos.pad_to(num_tokens_pad)[local_start:local_end_with_pad]
             local_sin = sin.pad_to(num_tokens_pad)[local_start:local_end_with_pad]
 
@@ -595,21 +622,24 @@ class AscendDSACPMetadataBuilder(AttentionMetadataBuilder[AscendDSAMetadata]):
             max_local_query_len = max(1, int(local_seq_lens_q_cpu.max().item()))
             max_local_seq_lens = max(1, int(local_seq_lens_cpu.max().item()))
 
-            start_pos = self.seq_lens[:num_reqs] - seq_lens_q
+            start_pos = self.spec_start_pos[draft_index - 1][:num_reqs]
+            start_pos.copy_(self.seq_lens[:num_reqs] - seq_lens_q)
 
             if metadata_cache is not None:
+                # Store value snapshots: the persistent buffers are refilled on
+                # every step, so sibling groups must copy the values now.
                 metadata_cache.update(
                     local_start=local_start,
                     local_end_with_pad=local_end_with_pad,
                     tokens_per_rank=tokens_per_rank,
                     num_tokens_pad=num_tokens_pad,
-                    local_query_start_loc=local_query_start_loc,
-                    local_seq_lens=local_seq_lens,
+                    local_query_start_loc=local_query_start_loc.clone(),
+                    local_seq_lens=local_seq_lens.clone(),
                     max_local_query_len=max_local_query_len,
                     max_local_seq_lens=max_local_seq_lens,
                     local_cos=local_cos,
                     local_sin=local_sin,
-                    start_pos=start_pos,
+                    start_pos=start_pos.clone(),
                 )
 
         dspark_swa_indices = None
@@ -700,6 +730,11 @@ class AscendDSACPMetadataBuilder(AttentionMetadataBuilder[AscendDSAMetadata]):
                     sas_head_dim=head_dim,
                     sas_metadata=sas_metadata,
                 )
+        # Cache sas_metadata in the per-draft-index buffer so the tensor
+        # address stays stable across aclgraph capture/replay, regardless of
+        # whether it came from the device metadata kernel or a sibling group.
+        self.spec_sas_metadata[draft_index - 1][:SAS_METADATA_SIZE].copy_(sas_metadata[:SAS_METADATA_SIZE])
+        sas_metadata = self.spec_sas_metadata[draft_index - 1]
 
         cp_metadata = DSACPMetadata(
             local_query_start_loc=local_query_start_loc,
@@ -1258,8 +1293,8 @@ class AscendDSACPMetadataBuilder(AttentionMetadataBuilder[AscendDSAMetadata]):
 
             metadata = metadata_op(**kw)
         self.common_ratio_to_sas_metadata[cache_key] = metadata
-        self.req_sas_metadata[:1024] = metadata
-        return self.req_sas_metadata[:1024]
+        self.req_sas_metadata[:SAS_METADATA_SIZE] = metadata
+        return self.req_sas_metadata[:SAS_METADATA_SIZE]
 
     def _build_qli_metadata(
         self,
@@ -1308,8 +1343,8 @@ class AscendDSACPMetadataBuilder(AttentionMetadataBuilder[AscendDSAMetadata]):
                 device=str(self.seqused_q.device),
             )
         self.common_ratio_to_sas_metadata[cache_key] = metadata
-        self.req_qli_metadata[:1024] = metadata
-        return self.req_qli_metadata[:1024]
+        self.req_qli_metadata[:SAS_METADATA_SIZE] = metadata
+        return self.req_qli_metadata[:SAS_METADATA_SIZE]
 
     def build_for_graph_capture(
         self,
@@ -1492,6 +1527,18 @@ class AscendDSACPImpl(AttentionImplBase[Any]):
             )
         if self.enable_dsa_cp_full_o_proj:
             self._enable_o_proj_full_weight_switch()
+
+    @staticmethod
+    def update_graph_params(
+        update_stream,
+        forward_context,
+        num_tokens,
+        vllm_config=None,
+        speculative_config=None,
+        draft_attn_metadatas=None,
+    ):
+        # DSA-CP does not need to update graph params.
+        pass
 
     @staticmethod
     def _get_weight_switch_method(layer: torch.nn.Module) -> WeightSwitchMixin:


### PR DESCRIPTION
### What this PR does / why we need it?

This PR re-applies the DSA-CP + MTP aclgraph support for DeepSeek V4 that was reverted from main in #16181 (revert of #12599), together with a fix for the crash that motivated scrutiny of the original feature: serving concurrent requests with `cudagraph_mode=FULL_DECODE_ONLY` failed with `aclnnInplaceCopy` shape-mismatch errors (EZ1007) or illegal device memory accesses (EZ9999).

**Root cause of the crash**

In FULL-decode graph mode, the DSA-CP draft path receives `num_reqs` as the *padded* request count — the cudagraph capture bucket size plus the FIA dummy request from mixed-batch padding — which can exceed `scheduler_config.max_num_seqs`. The per-request metadata buffers were sized by `max_num_seqs`, so:

1. `[:num_reqs]` views of these buffers get silently truncated and `copy_()` into them fails with shape mismatches — e.g. `--max-num-seqs 6` with 3 concurrent MTP requests pads 12 tokens to bucket 16, producing `Shape [16] vs [6] do not meet the broadcast condition (EZ1007)`;
2. triton kernels receiving the whole buffer write past its end, corrupting adjacent device memory (`EZ9999: MTE accesses an invalid GM address`).

**Fix**

Compute one graph-mode-aware capacity up front and size all per-request buffers with it:

    max_padded_reqs = max(max_num_seqs, max_cudagraph_capture_size) + 1  # +1: FIA dummy request

This covers the step-0 buffers (`start_pos_prefill`, `local_query_start_loc`, `local_seq_lens`), the draft buffers (`spec_local_query_start_loc`, `spec_local_seq_lens`, `spec_start_pos`), and the QLI buffers (`qli_seqused_k`, `qli_cmp_residual_k`) with a single capacity source. All usage sites are `[:num_reqs]` slices or whole-buffer kernel inputs, so the change is a pure capacity gain with negligible (int32-level) memory overhead.

The re-applied feature is fully adapted to current main: it fuses with the sequence-parallel prefill rework (#15549), the dynamic DSA indexer quant_mode (#16224) and the DSA PCP + DSpark support (#15958) already on main.

The feature enables aclgraph capture/replay for DSA-CP with MTP=1 and MTP=3, including stable per-draft-index metadata buffers (`spec_sas_metadata`, `spec_start_pos`, `spec_local_*`, per-draft RoPE cache) so tensor addresses stay fixed across graph capture and replay.

### Does this PR introduce _any_ user-facing change?

Yes, it re-enables DSA-CP + MTP with FULL_DECODE_ONLY graphs for DeepSeek V4 (`enable_dsa_cp: true` + `speculative_config` + `cudagraph_mode: FULL_DECODE_ONLY`), which was available before the revert. Users with `max_num_seqs` smaller than the max cudagraph capture size no longer hit EZ1007 / EZ9999 errors under concurrent load.

The gain show below:
    when use dsv4+mtp 3+eager:

<img width="371" height="509" alt="c98d2620e0c57e8a2de08fd8281e6903" src="https://github.com/user-attachments/assets/78d1eeb8-e0ae-4421-b555-84ce5d6b8987" />

    when use dsv4+ mtp 3 + graph:
<img width="374" height="508" alt="74786d0aebc590d420bac3bfbf436f32" src="https://github.com/user-attachments/assets/7f3eb4d5-7bef-4b83-97f0-e9c825c2486e" />

GMS8K accuracy evaluation for MTP+eager and MTP+graph is attached below.

    dsv4-flash+mtp3+eager
    Overall report table: 
    +---------+-----------+----------+----------+-------+---------+---------+
    | Model   | Dataset   | Metric   | Subset   |   Num |   Score | Cat.0   |
    +=========+===========+==========+==========+=======+=========+=========+
    | dsv4   | gsm8k     | mean_acc | main     |  1318 |  0.9734 | default |
    +---------+-----------+----------+----------+-------+---------+---------+ 
    dsv4-flash+mtp3+graph
    Overall report table: 
    +---------+-----------+----------+----------+-------+---------+---------+
    | Model   | Dataset   | Metric   | Subset   |   Num |   Score | Cat.0   |
    +=========+===========+==========+==========+=======+=========+=========+
    | dsv4    | gsm8k     | mean_acc | main     |  1319 |  0.9742 | default |
    +---------+-----------+----------+----------+-------+---------+---------+ 
    glm5.2-w4a8c8 + mtp 5 +graph
    Overall report table: 
    +---------+-----------+----------+----------+-------+---------+---------+
    | Model   | Dataset   | Metric   | Subset   |   Num |   Score | Cat.0   |
    +=========+===========+==========+==========+=======+=========+=========+
    | glm5.2    | gsm8k     | mean_acc | main     |  1319 |   0.978 | default |
    +---------+-----------+----------+----------+-------+---------+---------+ 
