### PR TITLE
[CI][nightly] Add Kimi-K2.6-w4a8-DFlash-A3 spec decode nightly tests

### DIFF
--- a/.github/workflows/configs/nightly_config.yaml
+++ b/.github/workflows/configs/nightly_config.yaml
@@ -232,6 +232,9 @@ a3:
       - name: Kimi-K2.6-w4a8-A3
         os: linux-aarch64-nightly-a3-16
         config_file_path: Kimi-K2.6-w4a8-A3.yaml
+      - name: Kimi-K2.6-w4a8-DFlash-A3
+        os: linux-aarch64-nightly-a3-16
+        config_file_path: Kimi-K2.6-w4a8-DFlash-A3.yaml
       - name: Minimax_m2.7_w8a8_A3
         os: linux-aarch64-nightly-a3-16
         config_file_path: Minimax_m2.7_w8a8_A3.yaml

--- a/tests/e2e/nightly/single_node/models/configs/Kimi-K2.6-w4a8-DFlash-A3.yaml
+++ b/tests/e2e/nightly/single_node/models/configs/Kimi-K2.6-w4a8-DFlash-A3.yaml
@@ -1,0 +1,67 @@
+# ==========================================
+# Kimi-K2.6 W4A8 - DFlash speculative decoding acceptance test
+# ==========================================
+test_cases:
+  - name: "Kimi-K2.6-W4A8-DFlash-A3"
+    model: "Eco-Tech/Kimi-K2.6-w4a8"
+    envs:
+      HCCL_OP_EXPANSION_MODE: "AIV"
+      HCCL_BUFFSIZE: "512"
+      LCCL_DETERMINISTIC: "1"
+      HCCL_DETERMINISTIC: "true"
+      ATB_MATMUL_SHUFFLE_K_ENABLE: "0"
+      CLOSE_MATMUL_K_SHIFT: "1"
+      PYTORCH_NPU_ALLOC_CONF: "expandable_segments:True"
+      OMP_PROC_BIND: "false"
+      OMP_NUM_THREADS: "1"
+      TASK_QUEUE_ENABLE: "1"
+      VLLM_ASCEND_ENABLE_FLASHCOMM1: "1"
+      DYNAMIC_EPLB: "true"
+      SERVER_PORT: "DEFAULT_PORT"
+    server_cmd:
+      - "--quantization"
+      - "ascend"
+      - "--port"
+      - "$SERVER_PORT"
+      - "--allowed-local-media-path"
+      - "/"
+      - "--trust-remote-code"
+      - "--safetensors-load-strategy"
+      - 'prefetch'
+      - "--tensor-parallel-size"
+      - "8"
+      - "--data-parallel-size"
+      - "2"
+      - "--no-enable-prefix-caching"
+      - "--enable-expert-parallel"
+      - "--max-num-seqs"
+      - "24"
+      - "--max-model-len"
+      - "6144"
+      - "--max-num-batched-tokens"
+      - "4096"
+      - "--gpu-memory-utilization"
+      - "0.85"
+      - "--seed"
+      - "42"
+      - "--async-scheduling"
+      - "--compilation-config"
+      - '{"cudagraph_mode":"FULL_DECODE_ONLY"}'
+      - "--additional-config"
+      - '{"eplb_config":{"dynamic_eplb":true},"ascend_compilation_config":{"enable_static_kernel":false},"enable_fused_mc2":1,"scheduler_config":{"enable_balance_scheduling":true},"enable_mlapo":true}'
+      - "--mm-processor-cache-gb"
+      - "0"
+      - "--mm-encoder-tp-mode"
+      - "data"
+      - "--speculative-config"
+      - '{"method": "dflash","model": "z-lab/Kimi-K2.5-DFlash", "num_speculative_tokens": 15}'
+    benchmarks:
+      spec_decode:
+        case_type: spec_decode
+        dataset_path: vllm-ascend/gsm8k-lite
+        request_conf: vllm_api_general_chat
+        dataset_conf: gsm8k/gsm8k_gen_0_shot_cot_chat_prompt
+        max_out_len: 1500
+        batch_size: 32
+        baseline: [0.79, 0.60, 0.45, 0.34, 0.26, 0.20, 0.15, 0.11, 0.08, 0.05, 0.03, 0.01, 0.01, 0.01, 0.00]
+        threshold: 0.05

--- a/tests/e2e/pull_request/one_card/spec_decode/test_dflash.py
+++ b/tests/e2e/pull_request/one_card/spec_decode/test_dflash.py
@@ -1,20 +1,15 @@
 from __future__ import annotations
 
 import pytest
-from transformers import AutoTokenizer
-from vllm import SamplingParams
 from vllm.config import CompilationConfig
-from vllm.v1.metrics.reader import Counter, Vector
 
-from tests.e2e.conftest import VllmRunner
-from tests.e2e.pull_request.one_card.spec_decode.utils import BASELINES, DFLASH, calculate_acceptance_per_pos
+from tests.e2e.pull_request.one_card.spec_decode.utils import DFLASH
+from tests.e2e.pull_request.utils import SPEC_DECODE_PROMPTS, _run_speculative_decoding
 
 MAX_NUM_SEQS = 256
-DYNAMIC_DFLASH_BASELINES = {
-    # DFlash drafts a block in parallel, so changing K changes the block input
-    # shape and its acceptance profile. Do not reuse the K=8 baseline for K=4.
-    ("dflash", 4): [0.8, 0.5, 0.3, 0.2],
-}
+
+EXPECTED_ACCEPTANCE_LENGTH_STATIC = 2.80
+EXPECTED_ACCEPTANCE_LENGTH_DYNAMIC = 2.60
 
 
 @pytest.mark.parametrize("method", DFLASH.keys())
@@ -34,82 +29,44 @@ def test_dflash_acceptance(
     main_model_name = DFLASH[method]["main"]
     spec_model_name = DFLASH[method]["spec"]
 
-    tokenizer = AutoTokenizer.from_pretrained(
-        main_model_name,
-        trust_remote_code=True,
-    )
-    sampling_params = SamplingParams(
-        temperature=0,
-        ignore_eos=False,
-        max_tokens=256,
-    )
-
-    prompts = [{"role": "user", "content": "Hello, your name is"}]
-    prompts = [
-        tokenizer.apply_chat_template(
-            [prompt],
-            tokenize=False,
-            add_generation_prompt=True,
-            enable_thinking=False,
-        )
-        for prompt in prompts
-    ]
-
     speculative_config = {
         "method": "dflash",
         "model": spec_model_name,
         "num_speculative_tokens": num_speculative_tokens,
     }
+    num_prompts = len(SPEC_DECODE_PROMPTS)
     if dynamic_num_speculative_tokens is not None:
         speculative_config["num_speculative_tokens_per_batch_size"] = [
             [1, MAX_NUM_SEQS, dynamic_num_speculative_tokens]
         ]
-        dynamic_capture_size = len(prompts) * (dynamic_num_speculative_tokens + 1)
-        capture_sizes = [dynamic_capture_size, 9, 18]
+        capture_sizes = [
+            num_prompts * (dynamic_num_speculative_tokens + 1),
+            num_prompts * (num_speculative_tokens + 1),
+        ]
         cudagraph_mode = "PIECEWISE"
+        expected_acceptance_length = EXPECTED_ACCEPTANCE_LENGTH_DYNAMIC
     else:
-        capture_sizes = [9, 18]
+        capture_sizes = [num_prompts * (num_speculative_tokens + 1)]
         cudagraph_mode = "FULL_DECODE_ONLY"
+        expected_acceptance_length = EXPECTED_ACCEPTANCE_LENGTH_STATIC
 
-    compilation_config = CompilationConfig(
-        cudagraph_mode=cudagraph_mode,
-        cudagraph_capture_sizes=capture_sizes,
-    )
-
-    with VllmRunner(
-        main_model_name,
-        max_model_len=4096,
-        disable_log_stats=False,
-        tensor_parallel_size=1,
-        max_num_seqs=MAX_NUM_SEQS,
-        distributed_executor_backend="mp",
-        gpu_memory_utilization=0.8,
+    _run_speculative_decoding(
+        model_name=main_model_name,
         speculative_config=speculative_config,
-        compilation_config=compilation_config,
-        enable_prefix_caching=False,
-    ) as llm:
-        outputs = llm.model.generate(prompts, sampling_params)
-        metrics = llm.model.get_metrics()
-
-    for output in outputs:
-        prompt = output.prompt
-        generated_text = output.outputs[0].text
-        output_tokens = output.outputs[0].token_ids
-        print(f"Prompt: {prompt!r}, Generated text: {generated_text!r}")
-        print(f"Output tokens: {output_tokens}")
-
-    acceptance_per_pos = calculate_acceptance_per_pos(metrics, num_speculative_tokens, Counter, Vector)
-    effective_num_speculative_tokens = (
-        num_speculative_tokens if dynamic_num_speculative_tokens is None else dynamic_num_speculative_tokens
+        expected_acceptance_length=expected_acceptance_length,
+        runner_kwargs={
+            "max_model_len": 4096,
+            "tensor_parallel_size": 1,
+            "distributed_executor_backend": "mp",
+            "gpu_memory_utilization": 0.8,
+            "compilation_config": CompilationConfig(
+                cudagraph_mode=cudagraph_mode,
+                cudagraph_capture_sizes=capture_sizes,
+            ),
+            "enable_prefix_caching": False,
+        },
+        example_prompts=SPEC_DECODE_PROMPTS,
+        max_tokens=256,
+        is_moe=False,
+        enable_thinking=False,
     )
-    if dynamic_num_speculative_tokens is None:
-        golden = BASELINES[method][:effective_num_speculative_tokens]
-    else:
-        golden = DYNAMIC_DFLASH_BASELINES[(method, dynamic_num_speculative_tokens)]
-
-    assert len(acceptance_per_pos) == num_speculative_tokens
-    active_acceptance_per_pos = acceptance_per_pos[:effective_num_speculative_tokens]
-    match = all(abs(a - b) < 0.1 for a, b in zip(active_acceptance_per_pos, golden, strict=True))
-    assert match, f"acceptance_per_pos {acceptance_per_pos} does not match golden {golden}"
-    if dynamic_num_speculative_tokens is not None:
-        assert all(rate == 0 for rate in acceptance_per_pos[dynamic_num_speculative_tokens:])

--- a/tests/e2e/pull_request/utils.py
+++ b/tests/e2e/pull_request/utils.py
@@ -246,8 +246,10 @@ def _run_speculative_decoding(
     max_tokens: int = 1024,
     acceptance_length_rtol: float = ACCEPTANCE_LENGTH_RTOL,
     is_moe: bool = True,
+    enable_thinking: bool | None = None,
 ) -> float:
     prompts = list(example_prompts)
+    chat_template_kwargs = {} if enable_thinking is None else {"enable_thinking": enable_thinking}
     with VllmRunner(
         model_name,
         enable_expert_parallel=is_moe,
@@ -263,6 +265,7 @@ def _run_speculative_decoding(
                     [{"role": "user", "content": prompt}],
                     tokenize=False,
                     add_generation_prompt=True,
+                    **chat_template_kwargs,
                 ),
                 add_special_tokens=False,
             )


### PR DESCRIPTION
### What this PR does / why we need it?
Add a nightly test for Kimi-K2.6 acceptance rate per position.

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
Nighly test passed.

- vLLM main: https://github.com/vllm-project/vllm/commit/84030bbe3d74d99bad477a3d2e37a973ccd8865c
