### PR TITLE
[BugFix] Fix replicated SFA indexer cache metadata under DCP

### DIFF
--- a/tests/ut/attention/test_indexer.py
+++ b/tests/ut/attention/test_indexer.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
+from contextlib import ExitStack
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
@@ -12,7 +13,6 @@ from vllm_ascend.attention.indexer import (
     AscendSFAIndexerBackend,
     AscendSFAIndexerMetadata,
     AscendSFAIndexerMetadataBuilder,
-    compose_indexer_cache_metadata,
 )
 
 _KERNEL_BLOCK_SIZE = 128
@@ -30,13 +30,29 @@ def _make_builder(pcp_size: int = 1, dcp_size: int = 1) -> AscendSFAIndexerMetad
     vllm_config.model_config = SimpleNamespace(
         hf_text_config=SimpleNamespace(index_topk=2048),
         hf_config=SimpleNamespace(),
+        max_model_len=1024,
+    )
+    vllm_config.scheduler_config = SimpleNamespace(
+        max_num_batched_tokens=16,
+        max_num_seqs=4,
     )
     vllm_config.parallel_config.prefill_context_parallel_size = pcp_size
     vllm_config.parallel_config.decode_context_parallel_size = dcp_size
-    with patch(
-        "vllm_ascend.attention.indexer.select_common_block_size",
-        return_value=_KERNEL_BLOCK_SIZE,
-    ):
+    vllm_config.parallel_config.cp_kv_cache_interleave_size = 4
+    with ExitStack() as stack:
+        stack.enter_context(
+            patch(
+                "vllm_ascend.attention.indexer.select_common_block_size",
+                return_value=_KERNEL_BLOCK_SIZE,
+            )
+        )
+        if dcp_size > 1:
+            stack.enter_context(
+                patch(
+                    "vllm_ascend.attention.indexer.get_dcp_group",
+                    return_value=SimpleNamespace(world_size=dcp_size, rank_in_group=0),
+                )
+            )
         return AscendSFAIndexerMetadataBuilder(
             kv_cache_spec,
             layer_names,
@@ -165,71 +181,116 @@ def test_sfa_indexer_metadata_builder_skips_local_reshape_groups_under_dcp(
     assert metadata.group_key_cache_idx is None
 
 
-def test_compose_indexer_cache_metadata_uses_pre_gather_replicated_dcp_view():
-    local_slots = torch.tensor([11, 12, 13], dtype=torch.int32)
-    replicated_slots = torch.tensor([101, 102, 103], dtype=torch.int32)
-    # #15809's PCP+DCP builder may additionally retain the once-gathered PCP
-    # order. The independent indexer must receive the pre-gather replicated
-    # slots; its existing PCP gather performs that reorder exactly once.
-    pcp_ordered_slots = torch.tensor([103, 101, 102, -1], dtype=torch.int32)
-    local_table = torch.tensor([[7, 8]], dtype=torch.int32)
-    replicated_table = torch.tensor([[14, 15, 16, 17]], dtype=torch.int32)
-    seq_lens = torch.tensor([16385], dtype=torch.int32)
-    cum_query_lens = torch.tensor([3], dtype=torch.int32)
-    indexer_metadata = AscendSFAIndexerMetadata(
-        num_actual_tokens=3,
-        slot_mapping=local_slots,
-        seq_lens=seq_lens,
-        cum_query_lens=cum_query_lens,
-        block_table=local_table,
-        sin=torch.empty(3, 1),
-        cos=torch.empty(3, 1),
-        block_size=128,
+def _make_dcp_builder(*, pcp_active: bool = False, dsa_cp_active: bool = False) -> AscendSFAIndexerMetadataBuilder:
+    builder = AscendSFAIndexerMetadataBuilder.__new__(AscendSFAIndexerMetadataBuilder)
+    builder.kernel_block_size = 4
+    builder._pcp_active = pcp_active
+    builder._dcp_active = True
+    builder._dsa_cp_active = dsa_cp_active
+    builder.dcp_size = 2
+    builder.dcp_rank = 0
+    builder.blocks_per_phys_block = 1
+    builder.replicated_view_block_size = 4
+    builder.max_local_block_table_cols = 2
+    builder.block_table_replicated_view_buf = torch.empty((4, 4), dtype=torch.int32)
+    builder.arange_buffer = torch.arange(4, dtype=torch.int32)
+    builder.slot_mapping_replicated_view_buf = torch.empty(16, dtype=torch.int32)
+    if pcp_active:
+        builder.pcp_indexer_slot_mapping_buf = torch.empty(16, dtype=torch.int32)
+    return builder
+
+
+def _make_dcp_common_metadata() -> SimpleNamespace:
+    return SimpleNamespace(
+        num_reqs=1,
+        num_actual_tokens=6,
+        num_input_tokens=6,
+        slot_mapping=torch.tensor([11, 12, 13, 14, 15, 16], dtype=torch.int32),
+        positions=torch.tensor([0, 1, 2, 3, 4, 5], dtype=torch.int64),
+        query_start_loc=torch.tensor([0, 6], dtype=torch.int32),
+        seq_lens=torch.tensor([6], dtype=torch.int32),
+        block_table_tensor=torch.tensor([[10, 11]], dtype=torch.int32),
         group_len=torch.tensor([1]),
         group_key_idx=torch.tensor([2]),
         group_key_cache_idx=torch.tensor([3]),
     )
-    sfa_metadata = SimpleNamespace(
-        dcp_context=object(),
-        dsa_cp_context=None,
-        block_size=128,
-        block_table=replicated_table,
-        slot_mapping=replicated_slots,
-        pcp_slot_mapping=pcp_ordered_slots,
+
+
+@patch("vllm_ascend.attention.indexer.get_ascend_config")
+@patch("vllm_ascend.attention.indexer.get_cos_and_sin_mla")
+def test_sfa_indexer_metadata_builder_owns_replicated_dcp_cache_view(
+    mock_cos_sin,
+    mock_get_ascend_config,
+):
+    mock_get_ascend_config.return_value.c8_reshape_optim_enabled = True
+    mock_cos_sin.return_value = (torch.zeros(6, 1, 1, 8), torch.zeros(6, 1, 1, 8))
+    builder = _make_dcp_builder()
+
+    metadata = builder.build(0, _make_dcp_common_metadata())
+
+    torch.testing.assert_close(
+        metadata.block_table,
+        torch.tensor([[20, 21, 22, 23]], dtype=torch.int32),
     )
-    indexer_cache = (torch.empty(4, 128, 1, 128),)
-
-    result = compose_indexer_cache_metadata(indexer_metadata, sfa_metadata, indexer_cache)
-
-    assert result is not indexer_metadata
-    assert result.block_table is replicated_table
-    assert result.slot_mapping is replicated_slots
-    assert result.slot_mapping is not pcp_ordered_slots
-    assert result.seq_lens is seq_lens
-    assert result.cum_query_lens is cum_query_lens
-    assert result.group_len is None
-    assert result.group_key_idx is None
-    assert result.group_key_cache_idx is None
-    assert indexer_metadata.slot_mapping is local_slots
-
-    pcp_result = compose_indexer_cache_metadata(
-        indexer_metadata,
-        sfa_metadata,
-        indexer_cache,
-        pcp_active=True,
+    torch.testing.assert_close(
+        metadata.slot_mapping,
+        torch.tensor([80, 81, 82, 83, 84, 85], dtype=torch.int32),
     )
-    assert pcp_result.block_table is replicated_table
-    assert pcp_result.slot_mapping is pcp_ordered_slots
-    assert pcp_result.group_len is None
-    assert pcp_result.group_key_idx is None
-    assert pcp_result.group_key_cache_idx is None
+    assert metadata.group_len is None
+    assert metadata.group_key_idx is None
+    assert metadata.group_key_cache_idx is None
 
-    # Non-DCP paths remain identity operations.
-    assert (
-        compose_indexer_cache_metadata(
-            indexer_metadata,
-            SimpleNamespace(dcp_context=None),
-            indexer_cache,
-        )
-        is indexer_metadata
+
+def test_sfa_indexer_metadata_builder_builds_pcp_ordered_dcp_slots_independently():
+    builder = _make_dcp_builder(pcp_active=True)
+    common = _make_dcp_common_metadata()
+    global_common = _make_dcp_common_metadata()
+    common.replace = MagicMock(return_value=global_common)
+    global_batch = SimpleNamespace(
+        num_reqs=1,
+        num_tokens=6,
+        query_start_loc=global_common.query_start_loc,
+        seq_lens=global_common.seq_lens,
+        positions=global_common.positions,
+        is_prefilling_np=torch.tensor([True]).numpy(),
+    )
+    pcp_context = SimpleNamespace(
+        global_batch=global_batch,
+        global_block_tables=(global_common.block_table_tensor,),
+        padded_gather_idx=torch.tensor([2, 0, 1, 0], dtype=torch.int64),
+        gathered_kv_write_mask=torch.tensor([True, True, True, False]),
+    )
+
+    slots = builder._build_slot_mapping(common, pcp_context, 0)
+
+    torch.testing.assert_close(
+        slots,
+        torch.tensor([82, 80, 81, -1], dtype=torch.int32),
+    )
+    common.replace.assert_called_once_with(
+        query_start_loc=global_batch.query_start_loc,
+        seq_lens=global_batch.seq_lens[:1],
+        num_reqs=1,
+        num_actual_tokens=6,
+        num_input_tokens=6,
+        positions=global_batch.positions,
+        block_table_tensor=global_common.block_table_tensor,
+    )
+
+
+@patch("vllm_ascend.attention.indexer.get_tp_group")
+def test_sfa_indexer_metadata_builder_pads_dcp_slots_for_dsa_cp(mock_get_tp_group):
+    mock_get_tp_group.return_value.world_size = 4
+    builder = _make_dcp_builder(dsa_cp_active=True)
+    common = _make_dcp_common_metadata()
+    common.num_actual_tokens = 3
+    common.num_input_tokens = 3
+    common.positions = common.positions[:3]
+    common.query_start_loc = torch.tensor([0, 3], dtype=torch.int32)
+
+    slots = builder._build_slot_mapping(common, None, None)
+
+    torch.testing.assert_close(
+        slots,
+        torch.tensor([80, 81, 82, -1], dtype=torch.int32),
     )

--- a/tests/ut/attention/test_indexer.py
+++ b/tests/ut/attention/test_indexer.py
@@ -12,12 +12,13 @@ from vllm_ascend.attention.indexer import (
     AscendSFAIndexerBackend,
     AscendSFAIndexerMetadata,
     AscendSFAIndexerMetadataBuilder,
+    compose_indexer_cache_metadata,
 )
 
 _KERNEL_BLOCK_SIZE = 128
 
 
-def _make_builder(pcp_size: int = 1) -> AscendSFAIndexerMetadataBuilder:
+def _make_builder(pcp_size: int = 1, dcp_size: int = 1) -> AscendSFAIndexerMetadataBuilder:
     kv_cache_spec = FullAttentionSpec(
         block_size=128,
         num_kv_heads=1,
@@ -26,7 +27,12 @@ def _make_builder(pcp_size: int = 1) -> AscendSFAIndexerMetadataBuilder:
     )
     layer_names = ["model.layers.0.self_attn.indexer.k_cache"]
     vllm_config = MagicMock()
+    vllm_config.model_config = SimpleNamespace(
+        hf_text_config=SimpleNamespace(index_topk=2048),
+        hf_config=SimpleNamespace(),
+    )
     vllm_config.parallel_config.prefill_context_parallel_size = pcp_size
+    vllm_config.parallel_config.decode_context_parallel_size = dcp_size
     with patch(
         "vllm_ascend.attention.indexer.select_common_block_size",
         return_value=_KERNEL_BLOCK_SIZE,
@@ -137,4 +143,93 @@ def test_sfa_indexer_metadata_builder_primes_reshape_optim(
         common.group_key_idx,
         common.group_key_cache_idx,
         _KERNEL_BLOCK_SIZE,
+    )
+
+
+@patch("vllm_ascend.attention.indexer.get_ascend_config")
+@patch("vllm_ascend.attention.indexer.get_cos_and_sin_mla")
+@patch("vllm_ascend.attention.indexer.torch.ops._C_ascend.store_kv_block_metadata", create=True)
+def test_sfa_indexer_metadata_builder_skips_local_reshape_groups_under_dcp(
+    mock_store_kv_block_metadata,
+    mock_cos_sin,
+    mock_get_ascend_config,
+):
+    mock_get_ascend_config.return_value.c8_reshape_optim_enabled = True
+    mock_cos_sin.return_value = (torch.zeros(5, 1, 1, 8), torch.zeros(5, 1, 1, 8))
+
+    metadata = _make_builder(dcp_size=2).build(0, _make_common_metadata())
+
+    mock_store_kv_block_metadata.assert_not_called()
+    assert metadata.group_len is None
+    assert metadata.group_key_idx is None
+    assert metadata.group_key_cache_idx is None
+
+
+def test_compose_indexer_cache_metadata_uses_pre_gather_replicated_dcp_view():
+    local_slots = torch.tensor([11, 12, 13], dtype=torch.int32)
+    replicated_slots = torch.tensor([101, 102, 103], dtype=torch.int32)
+    # #15809's PCP+DCP builder may additionally retain the once-gathered PCP
+    # order. The independent indexer must receive the pre-gather replicated
+    # slots; its existing PCP gather performs that reorder exactly once.
+    pcp_ordered_slots = torch.tensor([103, 101, 102, -1], dtype=torch.int32)
+    local_table = torch.tensor([[7, 8]], dtype=torch.int32)
+    replicated_table = torch.tensor([[14, 15, 16, 17]], dtype=torch.int32)
+    seq_lens = torch.tensor([16385], dtype=torch.int32)
+    cum_query_lens = torch.tensor([3], dtype=torch.int32)
+    indexer_metadata = AscendSFAIndexerMetadata(
+        num_actual_tokens=3,
+        slot_mapping=local_slots,
+        seq_lens=seq_lens,
+        cum_query_lens=cum_query_lens,
+        block_table=local_table,
+        sin=torch.empty(3, 1),
+        cos=torch.empty(3, 1),
+        block_size=128,
+        group_len=torch.tensor([1]),
+        group_key_idx=torch.tensor([2]),
+        group_key_cache_idx=torch.tensor([3]),
+    )
+    sfa_metadata = SimpleNamespace(
+        dcp_context=object(),
+        dsa_cp_context=None,
+        block_size=128,
+        block_table=replicated_table,
+        slot_mapping=replicated_slots,
+        pcp_slot_mapping=pcp_ordered_slots,
+    )
+    indexer_cache = (torch.empty(4, 128, 1, 128),)
+
+    result = compose_indexer_cache_metadata(indexer_metadata, sfa_metadata, indexer_cache)
+
+    assert result is not indexer_metadata
+    assert result.block_table is replicated_table
+    assert result.slot_mapping is replicated_slots
+    assert result.slot_mapping is not pcp_ordered_slots
+    assert result.seq_lens is seq_lens
+    assert result.cum_query_lens is cum_query_lens
+    assert result.group_len is None
+    assert result.group_key_idx is None
+    assert result.group_key_cache_idx is None
+    assert indexer_metadata.slot_mapping is local_slots
+
+    pcp_result = compose_indexer_cache_metadata(
+        indexer_metadata,
+        sfa_metadata,
+        indexer_cache,
+        pcp_active=True,
+    )
+    assert pcp_result.block_table is replicated_table
+    assert pcp_result.slot_mapping is pcp_ordered_slots
+    assert pcp_result.group_len is None
+    assert pcp_result.group_key_idx is None
+    assert pcp_result.group_key_cache_idx is None
+
+    # Non-DCP paths remain identity operations.
+    assert (
+        compose_indexer_cache_metadata(
+            indexer_metadata,
+            SimpleNamespace(dcp_context=None),
+            indexer_cache,
+        )
+        is indexer_metadata
     )

--- a/tests/ut/worker/test_attn_utils_v2.py
+++ b/tests/ut/worker/test_attn_utils_v2.py
@@ -924,3 +924,41 @@ def test_main_entry_allocates_and_reshapes_kvpp_views(monkeypatch, packed):
         make_cache_config(specs), device=torch.device("cpu"), layout=None, kernel_block_sizes=[2]
     )
     assert_attention_cache_views(caches, raw, packed)
+
+
+def test_build_attn_metadata_propagates_pcp_context_to_sfa_indexer(monkeypatch):
+    monkeypatch.setattr(attn_utils, "AscendSFAIndexerMetadataBuilder", _PrefillStateBuilder)
+    builder = _PrefillStateBuilder()
+    attn_group = SimpleNamespace(
+        layer_names=["layer.0.indexer.k_cache"],
+        get_metadata_builder=lambda _: builder,
+    )
+    kv_cache_config = SimpleNamespace(
+        kv_cache_groups=[SimpleNamespace(kv_cache_spec=object())],
+    )
+    is_prefilling = torch.tensor([True])
+    pcp_context = object()
+
+    metadata = attn_utils.build_attn_metadata(
+        attn_groups=[[attn_group]],
+        num_reqs=1,
+        num_tokens=1,
+        query_start_loc_gpu=torch.tensor([0, 1], dtype=torch.int32),
+        query_start_loc_cpu=torch.tensor([0, 1], dtype=torch.int32),
+        max_query_len=1,
+        seq_lens=torch.tensor([1], dtype=torch.int32),
+        max_seq_len=1,
+        block_tables=(torch.zeros((1, 1), dtype=torch.int32),),
+        slot_mappings=(torch.zeros(1, dtype=torch.int64),),
+        kv_cache_config=kv_cache_config,
+        is_prefilling=is_prefilling,
+        pcp_context=pcp_context,
+        seq_lens_np=np.array([1], dtype=np.int32),
+        positions=torch.tensor([0], dtype=torch.int64),
+    )
+
+    assert metadata["layer.0.indexer.k_cache"] is is_prefilling
+    assert builder.extra_kwargs == {
+        "pcp_context": pcp_context,
+        "pcp_cache_group_idx": 0,
+    }

--- a/vllm_ascend/attention/indexer.py
+++ b/vllm_ascend/attention/indexer.py
@@ -1,4 +1,4 @@
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from typing import Any
 
 import scipy  # type: ignore
@@ -23,7 +23,7 @@ from vllm_ascend.device.hardware_profile import HardwareCapability, get_current_
 from vllm_ascend.distributed.utils import all_gather_async
 from vllm_ascend.ops.rotary_embedding import get_cos_and_sin_mla
 from vllm_ascend.ops.triton.rope import rope_forward_triton_siso
-from vllm_ascend.utils import enable_dsa_cp, vllm_version_is
+from vllm_ascend.utils import enable_dsa_cp, enable_sfa_dcp_replicated_indexer, vllm_version_is
 
 if vllm_version_is("0.28.0"):
     from vllm.model_executor.layers.attention.pcp import _gather_prefill_cache_inputs  # type: ignore[import-not-found]
@@ -76,6 +76,52 @@ class AscendSFAIndexerMetadata:
     num_decode_tokens: int = 0
 
 
+def compose_indexer_cache_metadata(
+    indexer_metadata: Any,
+    sfa_metadata: Any,
+    indexer_cache: tuple[torch.Tensor, ...],
+    *,
+    pcp_active: bool = False,
+) -> Any:
+    """Use SFA's retained replicated DCP addresses for the independent cache.
+
+    Common metadata has already been restored to the local SFA KV layout
+    when the independent builder runs. SFA retains the replicated view,
+    including DSA-CP's TP-padded slots. Borrow only those addresses, leaving
+    query ownership and per-forward sequence lengths to the existing path.
+    """
+    if getattr(sfa_metadata, "dcp_context", None) is None:
+        return indexer_metadata
+    if indexer_metadata.block_size <= 0 or indexer_metadata.block_size != sfa_metadata.block_size:
+        raise RuntimeError("Replicated DCP indexer handoff requires matching kernel block sizes.")
+    # Native selection receives these physical tensors directly. A split
+    # block table cannot be handed to a cache with a different block stride.
+    if not indexer_cache or any(cache.shape[1] != sfa_metadata.block_size for cache in indexer_cache):
+        raise RuntimeError("Replicated DCP indexer handoff requires matching physical and kernel block sizes.")
+    if sfa_metadata.block_table.ndim != 2 or sfa_metadata.slot_mapping.ndim != 1:
+        raise RuntimeError("Replicated DCP indexer handoff requires a block table and flat slots.")
+    dsa_context = getattr(sfa_metadata, "dsa_cp_context", None)
+    if dsa_context is not None and sfa_metadata.slot_mapping.numel() != dsa_context.num_tokens_pad:
+        raise RuntimeError("Replicated DCP indexer slots must cover the TP-padded gathered keys.")
+    if pcp_active:
+        slot_mapping = getattr(sfa_metadata, "pcp_slot_mapping", None)
+        if slot_mapping is None or slot_mapping.ndim != 1:
+            raise RuntimeError("Replicated DCP indexer PCP handoff requires flat PCP-ordered slots.")
+    else:
+        slot_mapping = sfa_metadata.slot_mapping
+    # Do not mutate shared target metadata or the SFA fallback used by draft
+    # layers. Local-slot C8 groups are invalid for these replicated addresses;
+    # DCP uses the normal k/scale scatter path instead.
+    return replace(
+        indexer_metadata,
+        block_table=sfa_metadata.block_table,
+        slot_mapping=slot_mapping,
+        group_len=None,
+        group_key_idx=None,
+        group_key_cache_idx=None,
+    )
+
+
 class AscendSFAIndexerBackend(nn.Module, AttentionBackend):
     """Backend and impl for split SFA indexer cache layers - one class per
     indexer family, two interfaces:
@@ -91,8 +137,8 @@ class AscendSFAIndexerBackend(nn.Module, AttentionBackend):
     KV-cache planner can assign an independent physical tensor while sharing
     block ids with the main MLA cache group. Its builder constructs the
     metadata the indexer forward consumes (paged cache view, rope tables,
-    LI C8 reshape-optim fields); SFA only injects the parallel-layout values
-    (sequence lengths, decode count) onto that metadata per forward.
+    LI C8 reshape-optim fields). At the SFA boundary it composes the retained
+    replicated DCP addresses with parallel-layout values (lengths, decode count).
 
     Do not reuse AscendSFAMetadataBuilder here. It inherits vLLM's
     MLACommonMetadataBuilder, whose initializer assumes layer_names[0] points to
@@ -179,8 +225,10 @@ class AscendSFAIndexerBackend(nn.Module, AttentionBackend):
         # Cache-write gathers for parallel layouts: PCP all-gathers the
         # prefill region across the CP group, DSA-CP all-gathers the indexer
         # k across the TP group. Both are no-ops in the base layout.
-        parallel_config = get_current_vllm_config().parallel_config
+        vllm_config = get_current_vllm_config()
+        parallel_config = vllm_config.parallel_config
         self._pcp_active = parallel_config.prefill_context_parallel_size > 1
+        self._dcp_active = enable_sfa_dcp_replicated_indexer(vllm_config)
         self._dsa_cp_active = enable_dsa_cp()
 
     def process_weights_after_loading(self) -> None:
@@ -254,7 +302,7 @@ class AscendSFAIndexerBackend(nn.Module, AttentionBackend):
 
     def _use_c8_reshape_optim(self) -> bool:
         """Whether this indexer can use the LI C8 cache-write operator."""
-        return self.enable_sparse_li_c8 and get_ascend_config().c8_reshape_optim_enabled
+        return self.enable_sparse_li_c8 and not self._dcp_active and get_ascend_config().c8_reshape_optim_enabled
 
     def forward_k(
         self,
@@ -473,6 +521,7 @@ class AscendSFAIndexerMetadataBuilder(AttentionMetadataBuilder[AscendSFAIndexerM
         # Match the logical block size selected for BlockTable.
         self.kernel_block_size = select_common_block_size(kv_cache_spec.block_size, [AscendSFAIndexerBackend])
         self._pcp_active = vllm_config.parallel_config.prefill_context_parallel_size > 1
+        self._dcp_active = enable_sfa_dcp_replicated_indexer(vllm_config)
 
     @classmethod
     def get_cudagraph_support(
@@ -503,7 +552,9 @@ class AscendSFAIndexerMetadataBuilder(AttentionMetadataBuilder[AscendSFAIndexerM
 
         cos, sin = get_cos_and_sin_mla(input_positions, use_cache=True)
 
-        if get_ascend_config().c8_reshape_optim_enabled:
+        # DCP addresses are composed at the SFA boundary. Do not generate
+        # reshape groups from the restored common/local slot mapping.
+        if get_ascend_config().c8_reshape_optim_enabled and not self._dcp_active:
             torch.ops._C_ascend.store_kv_block_metadata(
                 slot_mapping,
                 common_attn_metadata.group_len,
@@ -521,7 +572,7 @@ class AscendSFAIndexerMetadataBuilder(AttentionMetadataBuilder[AscendSFAIndexerM
             sin=sin[:num_input_tokens],
             cos=cos[:num_input_tokens],
             block_size=block_size,
-            group_len=common_attn_metadata.group_len,
-            group_key_idx=common_attn_metadata.group_key_idx,
-            group_key_cache_idx=common_attn_metadata.group_key_cache_idx,
+            group_len=None if self._dcp_active else common_attn_metadata.group_len,
+            group_key_idx=None if self._dcp_active else common_attn_metadata.group_key_idx,
+            group_key_cache_idx=None if self._dcp_active else common_attn_metadata.group_key_cache_idx,
         )

--- a/vllm_ascend/attention/indexer.py
+++ b/vllm_ascend/attention/indexer.py
@@ -302,7 +302,11 @@ class AscendSFAIndexerBackend(nn.Module, AttentionBackend):
 
     def _use_c8_reshape_optim(self) -> bool:
         """Whether this indexer can use the LI C8 cache-write operator."""
-        return self.enable_sparse_li_c8 and not getattr(self, "_dcp_active", False) and get_ascend_config().c8_reshape_optim_enabled
+        return (
+            self.enable_sparse_li_c8
+            and not getattr(self, "_dcp_active", False)
+            and get_ascend_config().c8_reshape_optim_enabled
+        )
 
     def forward_k(
         self,

--- a/vllm_ascend/attention/indexer.py
+++ b/vllm_ascend/attention/indexer.py
@@ -702,9 +702,7 @@ class AscendSFAIndexerMetadataBuilder(AttentionMetadataBuilder[AscendSFAIndexerM
                 local_phys_blocks * total_cp_size + rank_in_replicated_view
             ) * blocks_per_phys_block + local_sub_blocks
 
-        valid_req_mask = (
-            (seq_lens[:num_reqs].to(device=block_table.device) > 0).to(replicated_blocks.dtype).view(-1, 1)
-        )
+        valid_req_mask = (seq_lens[:num_reqs].to(device=block_table.device) > 0).to(replicated_blocks.dtype).view(-1, 1)
         replicated_blocks = replicated_blocks * valid_req_mask
         block_table_replicated_view.copy_(replicated_blocks)
         return block_table_replicated_view

--- a/vllm_ascend/attention/indexer.py
+++ b/vllm_ascend/attention/indexer.py
@@ -1,4 +1,4 @@
-from dataclasses import dataclass, replace
+from dataclasses import dataclass
 from typing import Any
 
 import scipy  # type: ignore
@@ -6,8 +6,9 @@ import torch
 import torch_npu
 from torch import nn
 from vllm.config import VllmConfig, get_current_vllm_config
-from vllm.distributed import get_tp_group
+from vllm.distributed import get_dcp_group, get_tp_group
 from vllm.triton_utils import HAS_TRITON
+from vllm.utils.math_utils import cdiv
 from vllm.v1.attention.backend import (
     AttentionBackend,
     AttentionCGSupport,
@@ -76,52 +77,6 @@ class AscendSFAIndexerMetadata:
     num_decode_tokens: int = 0
 
 
-def compose_indexer_cache_metadata(
-    indexer_metadata: Any,
-    sfa_metadata: Any,
-    indexer_cache: tuple[torch.Tensor, ...],
-    *,
-    pcp_active: bool = False,
-) -> Any:
-    """Use SFA's retained replicated DCP addresses for the independent cache.
-
-    Common metadata has already been restored to the local SFA KV layout
-    when the independent builder runs. SFA retains the replicated view,
-    including DSA-CP's TP-padded slots. Borrow only those addresses, leaving
-    query ownership and per-forward sequence lengths to the existing path.
-    """
-    if getattr(sfa_metadata, "dcp_context", None) is None:
-        return indexer_metadata
-    if indexer_metadata.block_size <= 0 or indexer_metadata.block_size != sfa_metadata.block_size:
-        raise RuntimeError("Replicated DCP indexer handoff requires matching kernel block sizes.")
-    # Native selection receives these physical tensors directly. A split
-    # block table cannot be handed to a cache with a different block stride.
-    if not indexer_cache or any(cache.shape[1] != sfa_metadata.block_size for cache in indexer_cache):
-        raise RuntimeError("Replicated DCP indexer handoff requires matching physical and kernel block sizes.")
-    if sfa_metadata.block_table.ndim != 2 or sfa_metadata.slot_mapping.ndim != 1:
-        raise RuntimeError("Replicated DCP indexer handoff requires a block table and flat slots.")
-    dsa_context = getattr(sfa_metadata, "dsa_cp_context", None)
-    if dsa_context is not None and sfa_metadata.slot_mapping.numel() != dsa_context.num_tokens_pad:
-        raise RuntimeError("Replicated DCP indexer slots must cover the TP-padded gathered keys.")
-    if pcp_active:
-        slot_mapping = getattr(sfa_metadata, "pcp_slot_mapping", None)
-        if slot_mapping is None or slot_mapping.ndim != 1:
-            raise RuntimeError("Replicated DCP indexer PCP handoff requires flat PCP-ordered slots.")
-    else:
-        slot_mapping = sfa_metadata.slot_mapping
-    # Do not mutate shared target metadata or the SFA fallback used by draft
-    # layers. Local-slot C8 groups are invalid for these replicated addresses;
-    # DCP uses the normal k/scale scatter path instead.
-    return replace(
-        indexer_metadata,
-        block_table=sfa_metadata.block_table,
-        slot_mapping=slot_mapping,
-        group_len=None,
-        group_key_idx=None,
-        group_key_cache_idx=None,
-    )
-
-
 class AscendSFAIndexerBackend(nn.Module, AttentionBackend):
     """Backend and impl for split SFA indexer cache layers - one class per
     indexer family, two interfaces:
@@ -137,8 +92,9 @@ class AscendSFAIndexerBackend(nn.Module, AttentionBackend):
     KV-cache planner can assign an independent physical tensor while sharing
     block ids with the main MLA cache group. Its builder constructs the
     metadata the indexer forward consumes (paged cache view, rope tables,
-    LI C8 reshape-optim fields). At the SFA boundary it composes the retained
-    replicated DCP addresses with parallel-layout values (lengths, decode count).
+    LI C8 reshape-optim fields). The indexer builder owns its cache-address
+    layout, including replicated DCP addresses; SFA only injects per-forward
+    parallel-layout values (lengths, decode count).
 
     Do not reuse AscendSFAMetadataBuilder here. It inherits vLLM's
     MLACommonMetadataBuilder, whose initializer assumes layer_names[0] points to
@@ -526,6 +482,57 @@ class AscendSFAIndexerMetadataBuilder(AttentionMetadataBuilder[AscendSFAIndexerM
         self.kernel_block_size = select_common_block_size(kv_cache_spec.block_size, [AscendSFAIndexerBackend])
         self._pcp_active = vllm_config.parallel_config.prefill_context_parallel_size > 1
         self._dcp_active = enable_sfa_dcp_replicated_indexer(vllm_config)
+        self._dsa_cp_active = enable_dsa_cp()
+        if not self._dcp_active:
+            return
+
+        dcp_group = get_dcp_group()
+        self.dcp_size = dcp_group.world_size
+        self.dcp_rank = dcp_group.rank_in_group
+        self.cp_kv_cache_interleave_size = vllm_config.parallel_config.cp_kv_cache_interleave_size
+        if self.cp_kv_cache_interleave_size <= 0:
+            raise RuntimeError(f"Invalid cp_kv_cache_interleave_size: {self.cp_kv_cache_interleave_size}")
+
+        self.replicated_view_block_size = self.kernel_block_size
+        if kv_cache_spec.block_size % self.replicated_view_block_size != 0:
+            raise RuntimeError(
+                "SFA indexer replicated view requires the KV cache block size "
+                f"({kv_cache_spec.block_size}) to be divisible by "
+                f"{self.replicated_view_block_size}."
+            )
+        self.blocks_per_phys_block = kv_cache_spec.block_size // self.replicated_view_block_size
+        max_num_input_tokens = vllm_config.scheduler_config.max_num_batched_tokens
+        max_model_len = vllm_config.model_config.max_model_len
+        self.max_local_block_table_cols = (
+            cdiv(max_model_len, kv_cache_spec.block_size * self.dcp_size) * self.blocks_per_phys_block
+        )
+        max_replicated_block_table_cols = self.max_local_block_table_cols * self.dcp_size
+        max_num_reqs = vllm_config.scheduler_config.max_num_seqs
+        if self._pcp_active:
+            max_num_reqs *= 2
+        max_num_reqs += 1
+        self.block_table_replicated_view_buf = torch.empty(
+            (max_num_reqs, max_replicated_block_table_cols),
+            dtype=torch.int32,
+            device=device,
+        )
+        self.arange_buffer = torch.arange(
+            max_replicated_block_table_cols,
+            dtype=torch.int32,
+            device=device,
+        )
+        self.slot_mapping_replicated_view_buf = torch.empty(
+            (max_num_input_tokens,),
+            dtype=torch.int32,
+            device=device,
+        )
+        if self._pcp_active:
+            pcp_size = vllm_config.parallel_config.prefill_context_parallel_size
+            self.pcp_indexer_slot_mapping_buf = torch.empty(
+                (max_num_input_tokens * pcp_size,),
+                dtype=torch.int32,
+                device=device,
+            )
 
     @classmethod
     def get_cudagraph_support(
@@ -540,24 +547,30 @@ class AscendSFAIndexerMetadataBuilder(AttentionMetadataBuilder[AscendSFAIndexerM
         common_prefix_len: int,
         common_attn_metadata: CommonAttentionMetadata,
         fast_build: bool = False,
+        pcp_context: Any | None = None,
+        pcp_cache_group_idx: int | None = None,
         **kwargs,
     ) -> AscendSFAIndexerMetadata:
         # common_prefix_len / fast_build are unused; kept for API compatibility.
         num_reqs = common_attn_metadata.num_reqs
         num_input_tokens = common_attn_metadata.num_input_tokens
-        if self._pcp_active:
-            # PCP writes cover the gathered prefill region too, which
-            # requires the full slot mapping.
-            slot_mapping = common_attn_metadata.slot_mapping
-        else:
-            slot_mapping = common_attn_metadata.slot_mapping[:num_input_tokens]
+        block_table = common_attn_metadata.block_table_tensor[:num_reqs]
+        slot_mapping = self._build_slot_mapping(common_attn_metadata, pcp_context, pcp_cache_group_idx)
         input_positions = common_attn_metadata.positions[:num_input_tokens].long()
         block_size = self.kernel_block_size
 
         cos, sin = get_cos_and_sin_mla(input_positions, use_cache=True)
 
-        # DCP addresses are composed at the SFA boundary. Do not generate
-        # reshape groups from the restored common/local slot mapping.
+        if self._dcp_active:
+            block_table = self._build_replicated_block_table(
+                common_attn_metadata.block_table_tensor,
+                common_attn_metadata.seq_lens,
+                num_reqs,
+            )
+
+        # DCP addresses are owned by this builder. Do not generate reshape
+        # groups from the DCP-local common metadata when the replicated cache
+        # view is active.
         if get_ascend_config().c8_reshape_optim_enabled and not self._dcp_active:
             torch.ops._C_ascend.store_kv_block_metadata(
                 slot_mapping,
@@ -572,7 +585,7 @@ class AscendSFAIndexerMetadataBuilder(AttentionMetadataBuilder[AscendSFAIndexerM
             slot_mapping=slot_mapping,
             seq_lens=common_attn_metadata.seq_lens[:num_reqs],
             cum_query_lens=common_attn_metadata.query_start_loc[1 : num_reqs + 1],
-            block_table=common_attn_metadata.block_table_tensor[:num_reqs],
+            block_table=block_table,
             sin=sin[:num_input_tokens],
             cos=cos[:num_input_tokens],
             block_size=block_size,
@@ -580,3 +593,200 @@ class AscendSFAIndexerMetadataBuilder(AttentionMetadataBuilder[AscendSFAIndexerM
             group_key_idx=None if self._dcp_active else common_attn_metadata.group_key_idx,
             group_key_cache_idx=None if self._dcp_active else common_attn_metadata.group_key_cache_idx,
         )
+
+    def _build_slot_mapping(
+        self,
+        common_attn_metadata: CommonAttentionMetadata,
+        pcp_context: Any | None,
+        pcp_cache_group_idx: int | None,
+    ) -> torch.Tensor:
+        num_input_tokens = common_attn_metadata.num_input_tokens
+        if not self._dcp_active:
+            if self._pcp_active:
+                # PCP writes cover the gathered prefill region too, which
+                # requires the full slot mapping.
+                return common_attn_metadata.slot_mapping
+            return common_attn_metadata.slot_mapping[:num_input_tokens]
+
+        block_table = self._build_replicated_block_table(
+            common_attn_metadata.block_table_tensor,
+            common_attn_metadata.seq_lens,
+            common_attn_metadata.num_reqs,
+        )
+        if self._pcp_active and pcp_context is not None and bool(pcp_context.global_batch.is_prefilling_np.any()):
+            if pcp_cache_group_idx is None:
+                raise RuntimeError("PCP+DCP indexer metadata requires the PCP cache-group index.")
+            slot_mapping = self._build_pcp_ordered_replicated_slot_mapping(
+                common_attn_metadata,
+                pcp_context,
+                pcp_cache_group_idx,
+            )
+        else:
+            slot_mapping = self._build_replicated_slot_mapping(common_attn_metadata, block_table)
+            if self._pcp_active:
+                return slot_mapping
+
+        if self._dsa_cp_active:
+            num_tokens_pad = self._dsa_cp_padded_token_count(num_input_tokens)
+            if slot_mapping.shape[0] < num_tokens_pad:
+                slot_mapping = nn.functional.pad(slot_mapping, (0, num_tokens_pad - slot_mapping.shape[0]), value=-1)
+            else:
+                slot_mapping = slot_mapping[:num_tokens_pad]
+        return slot_mapping
+
+    def _dsa_cp_padded_token_count(self, num_input_tokens: int) -> int:
+        tp_size = get_tp_group().world_size
+        return ((num_input_tokens + tp_size - 1) // tp_size) * tp_size
+
+    def _get_dcp_local_block_table(self, block_table: torch.Tensor, num_reqs: int) -> torch.Tensor:
+        local_cols = min(block_table.shape[1], self.max_local_block_table_cols)
+        return block_table[:num_reqs, :local_cols]
+
+    def _ensure_replicated_view_buffers(
+        self,
+        num_reqs: int,
+        num_input_tokens: int,
+        local_block_table_cols: int,
+    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+        block_table_cols = local_block_table_cols * self.dcp_size
+        if (
+            self.block_table_replicated_view_buf.shape[0] < num_reqs
+            or self.block_table_replicated_view_buf.shape[1] < block_table_cols
+        ):
+            raise RuntimeError(
+                f"Replicated indexer view buffer is too small: "
+                f"block_table_replicated_view_buf.shape={self.block_table_replicated_view_buf.shape}, "
+                f"num_reqs={num_reqs}, block_table_cols={block_table_cols}"
+            )
+        if self.slot_mapping_replicated_view_buf.shape[0] < num_input_tokens:
+            raise RuntimeError(
+                f"Replicated indexer view buffer is too small: "
+                f"slot_mapping_replicated_view_buf.shape={self.slot_mapping_replicated_view_buf.shape}, "
+                f"num_input_tokens={num_input_tokens}"
+            )
+        return (
+            self.block_table_replicated_view_buf[:num_reqs, :block_table_cols],
+            self.arange_buffer[:block_table_cols],
+            self.slot_mapping_replicated_view_buf[:num_input_tokens],
+        )
+
+    def _build_replicated_block_table(
+        self,
+        block_table: torch.Tensor,
+        seq_lens: torch.Tensor,
+        num_reqs: int,
+    ) -> torch.Tensor:
+        dcp_block_table = self._get_dcp_local_block_table(block_table, num_reqs)
+        local_block_table_cols = dcp_block_table.shape[1]
+        block_table_replicated_view, replicated_col_idx, _ = self._ensure_replicated_view_buffers(
+            num_reqs,
+            0,
+            local_block_table_cols,
+        )
+
+        total_cp_size = self.dcp_size
+        blocks_per_phys_block = self.blocks_per_phys_block
+        local_col_idx = (
+            replicated_col_idx // (total_cp_size * blocks_per_phys_block) * blocks_per_phys_block
+            + replicated_col_idx % blocks_per_phys_block
+        )
+        rank_in_replicated_view = (replicated_col_idx // blocks_per_phys_block) % total_cp_size
+
+        local_logical_blocks = torch.index_select(dcp_block_table, 1, local_col_idx)
+        if blocks_per_phys_block == 1:
+            replicated_blocks = local_logical_blocks * total_cp_size + rank_in_replicated_view
+        else:
+            local_sub_blocks = local_logical_blocks % blocks_per_phys_block
+            local_phys_blocks = local_logical_blocks // blocks_per_phys_block
+            replicated_blocks = (
+                local_phys_blocks * total_cp_size + rank_in_replicated_view
+            ) * blocks_per_phys_block + local_sub_blocks
+
+        valid_req_mask = (
+            (seq_lens[:num_reqs].to(device=block_table.device) > 0).to(replicated_blocks.dtype).view(-1, 1)
+        )
+        replicated_blocks = replicated_blocks * valid_req_mask
+        block_table_replicated_view.copy_(replicated_blocks)
+        return block_table_replicated_view
+
+    def _build_replicated_slot_mapping(
+        self,
+        common_attn_metadata: CommonAttentionMetadata,
+        block_table_replicated_view: torch.Tensor,
+    ) -> torch.Tensor:
+        num_reqs = common_attn_metadata.num_reqs
+        num_input_tokens = common_attn_metadata.num_input_tokens
+        num_actual_tokens = min(common_attn_metadata.num_actual_tokens, num_input_tokens)
+        local_block_table_cols = block_table_replicated_view.shape[1] // self.dcp_size
+        _, _, slot_mapping_replicated_view = self._ensure_replicated_view_buffers(
+            num_reqs,
+            num_input_tokens,
+            local_block_table_cols,
+        )
+        slot_mapping_replicated_view.fill_(-1)
+        if num_actual_tokens == 0:
+            return slot_mapping_replicated_view
+
+        query_lens = (
+            common_attn_metadata.query_start_loc[1 : num_reqs + 1] - common_attn_metadata.query_start_loc[:num_reqs]
+        )
+        req_indices = torch.repeat_interleave(
+            torch.arange(num_reqs, dtype=torch.int32, device=block_table_replicated_view.device),
+            query_lens.to(device=block_table_replicated_view.device),
+            output_size=num_input_tokens,
+        )[:num_actual_tokens]
+        if req_indices.numel() == 0:
+            return slot_mapping_replicated_view
+
+        num_actual_tokens = min(num_actual_tokens, req_indices.shape[0])
+        req_indices = req_indices[:num_actual_tokens]
+        positions = common_attn_metadata.positions[:num_actual_tokens].to(
+            device=block_table_replicated_view.device,
+            dtype=torch.int32,
+        )
+        logical_block_idx = positions // self.replicated_view_block_size
+        block_offsets = positions % self.replicated_view_block_size
+        block_table_indices = req_indices * block_table_replicated_view.shape[1] + logical_block_idx
+        block_numbers = block_table_replicated_view.flatten()[block_table_indices]
+        slot_mapping_replicated_view[:num_actual_tokens] = (
+            block_numbers * self.replicated_view_block_size + block_offsets
+        )
+        return slot_mapping_replicated_view
+
+    def _build_pcp_ordered_replicated_slot_mapping(
+        self,
+        common_attn_metadata: CommonAttentionMetadata,
+        pcp_context: Any,
+        pcp_cache_group_idx: int,
+    ) -> torch.Tensor:
+        global_batch = pcp_context.global_batch
+        num_reqs = global_batch.num_reqs
+        global_common_attn_metadata = common_attn_metadata.replace(
+            query_start_loc=global_batch.query_start_loc,
+            seq_lens=global_batch.seq_lens[:num_reqs],
+            num_reqs=num_reqs,
+            num_actual_tokens=global_batch.num_tokens,
+            num_input_tokens=global_batch.num_tokens,
+            positions=global_batch.positions,
+            block_table_tensor=pcp_context.global_block_tables[pcp_cache_group_idx],
+        )
+        block_table = self._build_replicated_block_table(
+            global_common_attn_metadata.block_table_tensor,
+            global_common_attn_metadata.seq_lens,
+            num_reqs,
+        )
+        global_slot_mapping = self._build_replicated_slot_mapping(global_common_attn_metadata, block_table)
+
+        gather_idx = pcp_context.padded_gather_idx
+        write_mask = pcp_context.gathered_kv_write_mask
+        if gather_idx is None or write_mask is None:
+            raise RuntimeError("PCP+DCP indexer metadata requires the PCP gathered-token layout.")
+        pcp_ordered_slot_mapping = self.pcp_indexer_slot_mapping_buf[: gather_idx.numel()]
+        torch.index_select(
+            global_slot_mapping,
+            0,
+            gather_idx,
+            out=pcp_ordered_slot_mapping,
+        )
+        pcp_ordered_slot_mapping.masked_fill_(~write_mask, -1)
+        return pcp_ordered_slot_mapping

--- a/vllm_ascend/attention/indexer.py
+++ b/vllm_ascend/attention/indexer.py
@@ -302,7 +302,7 @@ class AscendSFAIndexerBackend(nn.Module, AttentionBackend):
 
     def _use_c8_reshape_optim(self) -> bool:
         """Whether this indexer can use the LI C8 cache-write operator."""
-        return self.enable_sparse_li_c8 and not self._dcp_active and get_ascend_config().c8_reshape_optim_enabled
+        return self.enable_sparse_li_c8 and not getattr(self, "_dcp_active", False) and get_ascend_config().c8_reshape_optim_enabled
 
     def forward_k(
         self,

--- a/vllm_ascend/attention/sfa_v1.py
+++ b/vllm_ascend/attention/sfa_v1.py
@@ -21,7 +21,6 @@ from vllm.v1.worker.utils import select_common_block_size
 from vllm_ascend.ascend_config import get_ascend_config
 from vllm_ascend.attention.attention_mask import AttentionMaskBuilder
 from vllm_ascend.attention.attention_v1 import AscendAttentionState
-from vllm_ascend.attention.indexer import compose_indexer_cache_metadata
 from vllm_ascend.attention.utils import (
     MLAPO_MAX_SUPPORTED_TOKENS,
     SFA_QSFA_TILE_SIZE,
@@ -1331,13 +1330,6 @@ class AscendSFAImpl(MLAAttentionImpl):
         sin = attn_metadata.sin
         slot_mapping_sfa = self._get_sfa_kv_slot_mapping(attn_metadata)
         indexer_attn_metadata = self._get_indexer_attn_metadata()
-        if indexer_attn_metadata is not None:
-            indexer_attn_metadata = compose_indexer_cache_metadata(
-                indexer_attn_metadata,
-                attn_metadata,
-                self.indexer.k_cache.kv_cache,
-                pcp_active=self.vllm_config.parallel_config.prefill_context_parallel_size > 1,
-            )
 
         # Inputs and outputs may be padded for CUDA graphs
         num_input_tokens = attn_metadata.num_input_tokens

--- a/vllm_ascend/attention/sfa_v1.py
+++ b/vllm_ascend/attention/sfa_v1.py
@@ -21,6 +21,7 @@ from vllm.v1.worker.utils import select_common_block_size
 from vllm_ascend.ascend_config import get_ascend_config
 from vllm_ascend.attention.attention_mask import AttentionMaskBuilder
 from vllm_ascend.attention.attention_v1 import AscendAttentionState
+from vllm_ascend.attention.indexer import compose_indexer_cache_metadata
 from vllm_ascend.attention.utils import (
     MLAPO_MAX_SUPPORTED_TOKENS,
     SFA_QSFA_TILE_SIZE,
@@ -1330,6 +1331,13 @@ class AscendSFAImpl(MLAAttentionImpl):
         sin = attn_metadata.sin
         slot_mapping_sfa = self._get_sfa_kv_slot_mapping(attn_metadata)
         indexer_attn_metadata = self._get_indexer_attn_metadata()
+        if indexer_attn_metadata is not None:
+            indexer_attn_metadata = compose_indexer_cache_metadata(
+                indexer_attn_metadata,
+                attn_metadata,
+                self.indexer.k_cache.kv_cache,
+                pcp_active=self.vllm_config.parallel_config.prefill_context_parallel_size > 1,
+            )
 
         # Inputs and outputs may be padded for CUDA graphs
         num_input_tokens = attn_metadata.num_input_tokens

--- a/vllm_ascend/worker/v2/attn_utils.py
+++ b/vllm_ascend/worker/v2/attn_utils.py
@@ -45,6 +45,7 @@ from vllm.v1.worker.utils import AttentionGroup
 from vllm_ascend.ascend_config import KVPPConfig, get_ascend_config
 from vllm_ascend.attention.attention_v1 import AscendAttentionState
 from vllm_ascend.attention.dsa_v1 import AscendDSAMetadataBuilder
+from vllm_ascend.attention.indexer import AscendSFAIndexerMetadataBuilder
 from vllm_ascend.attention.sfa_v1 import AscendSFAMetadataBuilder
 from vllm_ascend.attention.utils import (
     AscendCommonAttentionMetadata,
@@ -300,8 +301,9 @@ def build_attn_metadata(
                     num_actual_reqs=num_actual_reqs,
                     common_ratio_to_sas_metadata=common_ratio_to_sas_metadata,
                 )
-            # Only SFA and DSA metadata builders consume PCP context.
-            if pcp_context is not None and (is_sfa_builder or is_dsa_builder):
+            # SFA, its indexer cache builder, and DSA consume PCP context.
+            is_sfa_indexer_builder = isinstance(attn_metadata_builder, AscendSFAIndexerMetadataBuilder)
+            if pcp_context is not None and (is_sfa_builder or is_dsa_builder or is_sfa_indexer_builder):
                 attn_metadata_extra_kwargs.update(
                     pcp_context=pcp_context,
                     pcp_cache_group_idx=i,


### PR DESCRIPTION
## What this PR does

#15669 split the SFA indexer into an independent `AscendSFAIndexerBackend` with its own physical cache and metadata builder. Under replicated SFA DCP, the common attention metadata is restored to the local SFA KV view before the independent indexer metadata is built, while the indexer cache remains physically replicated. That can make the indexer's block table / slot mapping address a different physical layout than its own cache.

This patch keeps ownership at the independent indexer boundary and composes the retained SFA DCP cache addresses before the indexer forward:

- plain DCP / DSA-DCP reuse SFA's retained replicated (or DSA-padded) `slot_mapping` and replicated block table;
- PCP+DCP reuses the `pcp_slot_mapping` produced by #15809, without adding another PCP reorder or collective;
- LI C8 under replicated DCP does not reuse reshape groups derived from the restored local slots; it falls back to the normal k/scale scatter path with the composed replicated slots;
- geometry mismatches fail closed, and shared metadata is not mutated.

No key-domain sharding, GlobalTopK, score-publication ABI, or new collective is introduced.

## Validation

- dependency-light host oracle: 35 cases passed;
- real 2-NPU defect reproduction: for logical target 16384, the pre-fix path mapped to 8192 while the candidate returned 16384;
- production-shaped correctness coverage included B2/B4 at 128K and 256K plus mixed B4 64K/128K/256K/312K;
- PCP2+DCP2 real-NPU HCCL canary: candidate used 4 slots versus the pre-fix local 2-slot view; all four Native LI targets hit the expected 16384/16512 addresses; an intentionally wrong unreordered-slot sensitivity control removed all four targets.

Current upstream already provides dependency-complete CI surfaces for MRV2 PCP+DCP graph execution (#15809) and for replicated DSA-DCP + LI C8 + MTP3 full-decode graph accuracy. Candidate-specific CI is intentionally left to the PR CI rather than a separate overlay environment.

## Current PR-head validation

Current PR head: `24f178d7d06439a19f53c69e728e951a30b1303f`.

- PR E2E `#29228`: pre-commit and dependency-complete CPU UT passed. The run-level `ci-gate` is still blocked because the PR does not yet have the maintainer-only `ready-precise` label, so its selected NPU matrix was not triggered.
- Author-triggered targeted A3 four-card `/e2e` run [#220](https://github.com/vllm-project/vllm-ascend/actions/runs/34362394377) passed on the current PR code for both vLLM refs (`v0.28.0` and `b2f685834a6456197e7033966fdef52a23f1abcd`). It covered:
  - replicated DSA-DCP + LI C8 + MTP3 + FULL_DECODE_ONLY graph accuracy;
  - MRV2 PCP2 + DCP4 replicated-indexer + FULL_DECODE_ONLY graph accuracy.

These results support candidate-specific upstream CPU and targeted A3 NPU correctness only. Formal PR selected-test/ci-gate closure still requires `ready-precise`, and merge still requires the repository's human approval policy.

This is a correctness fix; no performance or production-gain claim is made.

Signed-off-by: Ruiqiu Zheng <191817791+Ruiqiu-Zheng@users.noreply.github.com>

- vLLM main: https://github.com/vllm-project/vllm/commit/a97dacb7106ee49f39f3d1fc6ae1800ff724e01d
