### PR TITLE
[Feature][Sampling] Triton categorical alternative for RFC #14130

### DIFF
--- a/.github/workflows/scripts/test_config.yaml
+++ b/.github/workflows/scripts/test_config.yaml
@@ -226,6 +226,9 @@ estimated_times:
   tests/e2e/pull_request/one_card/test_w8a8_dynamic.py: 30
   tests/e2e/pull_request/one_card/test_w8a8_static.py: 40
   tests/e2e/pull_request/one_card/test_gumbel_sampling.py: 110
+  tests/e2e/pull_request/one_card/test_categorical_sampling.py: 180
+  tests/e2e/pull_request/one_card/test_gumbel_sampling_heavy_tail.py: 180
+  tests/e2e/pull_request/one_card/model_runner_v2/test_categorical_sampling.py: 180
   tests/e2e/pull_request/one_card/test_model_runner_v1_with_device.py: 70
 
 # === Runner Mapping ===

--- a/benchmarks/benchmark_categorical_sampling.py
+++ b/benchmarks/benchmark_categorical_sampling.py
@@ -1,0 +1,152 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Compare native categorical sampling with the unchanged Ascend Triton path.
+
+Example: python benchmarks/benchmark_categorical_sampling.py --output sampling.csv
+Graph timings amortize launch/event overhead over repeated captured calls. Eager
+timings include Python dispatch and allocations. Inputs and compilation are not
+timed. Different algorithms need not produce identical random token streams.
+"""
+
+import argparse
+import csv
+import statistics
+import time
+from collections.abc import Callable
+from pathlib import Path
+
+import torch
+import torch_npu  # noqa: F401
+
+from vllm_ascend.utils import enable_categorical_sample_op
+from vllm_ascend.worker.v2.sample.gumbel import _fallback_gumbel_sample, gumbel_sample
+
+DTYPES = {"fp16": torch.float16, "bf16": torch.bfloat16, "fp32": torch.float32}
+
+
+def capture(fn: Callable[[], torch.Tensor], repeats: int) -> tuple[torch.npu.NPUGraph, list[torch.Tensor]]:
+    for _ in range(10):
+        fn()
+    torch.npu.synchronize()
+    graph = torch.npu.NPUGraph()
+    with torch.npu.graph(graph):
+        outputs = [fn() for _ in range(repeats)]
+    for _ in range(5):
+        graph.replay()
+    torch.npu.synchronize()
+    return graph, outputs
+
+
+def measure(functions: dict[str, Callable[[], torch.Tensor]], repeats: int, rounds: int) -> dict[str, float]:
+    captured = {name: capture(fn, repeats) for name, fn in functions.items()}
+    graph_samples: dict[str, list[float]] = {name: [] for name in functions}
+    eager_samples: dict[str, list[float]] = {name: [] for name in functions}
+    for round_idx in range(rounds):
+        names = list(functions)
+        if round_idx % 2:
+            names.reverse()
+        for name in names:
+            start = torch.npu.Event(enable_timing=True)
+            end = torch.npu.Event(enable_timing=True)
+            start.record()
+            captured[name][0].replay()
+            end.record()
+            end.synchronize()
+            graph_samples[name].append(start.elapsed_time(end) * 1000 / repeats)
+            torch.npu.synchronize()
+            begin = time.perf_counter()
+            for _ in range(repeats):
+                functions[name]()
+            torch.npu.synchronize()
+            eager_samples[name].append((time.perf_counter() - begin) * 1e6 / repeats)
+    result = {}
+    for name in functions:
+        result[f"{name}_graph_us"] = statistics.median(graph_samples[name])
+        quartiles = statistics.quantiles(graph_samples[name], n=4)
+        result[f"{name}_graph_q25_us"] = quartiles[0]
+        result[f"{name}_graph_q75_us"] = quartiles[2]
+        result[f"{name}_eager_us"] = statistics.median(eager_samples[name])
+    result["graph_speedup"] = result["triton_graph_us"] / result["categorical_graph_us"]
+    result["eager_speedup"] = result["triton_eager_us"] / result["categorical_eager_us"]
+    return result
+
+
+def benchmark_case(batch: int, vocab: int, dtype: torch.dtype, scenario: str, args: argparse.Namespace) -> dict:
+    torch.manual_seed(args.seed)
+    logits = torch.randn(batch, vocab, dtype=dtype, device="npu")
+    mapping_dtype = torch.int64 if scenario == "int64_mapping" else torch.int32
+    mapping = torch.arange(batch, dtype=mapping_dtype, device="npu")
+    temperature = torch.full((batch,), 0.0 if scenario == "greedy" else 0.7, device="npu")
+    seeds = torch.arange(batch, dtype=torch.int64, device="npu") + args.seed
+    positions = torch.arange(batch, dtype=torch.int64, device="npu")
+    cache = None
+    columns = None
+    if scenario in ("cache", "strided_cache", "draft"):
+        cache = torch.empty(batch, 4, vocab + 16, dtype=dtype, device="npu")
+        if scenario == "strided_cache":
+            cache = cache[:, ::2, :]
+        columns = torch.ones(batch, dtype=torch.int32, device="npu")
+    kwargs = dict(
+        apply_temperature=scenario != "no_temperature",
+        is_drafting=scenario == "draft",
+        logits_cache=cache,
+        logits_cache_col=columns,
+    )
+    tensors = (logits, mapping, temperature, seeds, positions)
+    functions = {
+        "triton": lambda: _fallback_gumbel_sample(*tensors, **kwargs),
+        "categorical": lambda: gumbel_sample(*tensors, **kwargs),
+    }
+    if args.include_fp64:
+        functions["categorical_fp64"] = lambda: gumbel_sample(*tensors, **kwargs, use_fp64=True)
+    for fn in functions.values():
+        output = fn()
+        assert output.shape == (batch,)
+        assert bool(((output >= 0) & (output < vocab)).all())
+        if scenario == "greedy":
+            torch.testing.assert_close(output.long(), logits.argmax(dim=-1))
+        if cache is not None:
+            torch.testing.assert_close(cache[:, 1, :vocab], logits)
+    return measure(functions, args.repeats, args.rounds)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--batches", nargs="+", type=int, default=[1, 4, 16, 64, 256, 512])
+    parser.add_argument("--vocabs", nargs="+", type=int, default=[4096, 32000, 65536, 128256, 151936, 262144])
+    parser.add_argument("--dtypes", nargs="+", choices=DTYPES, default=list(DTYPES))
+    parser.add_argument(
+        "--scenarios",
+        nargs="+",
+        choices=["random", "greedy", "cache", "strided_cache", "draft", "int64_mapping", "no_temperature"],
+        default=["random"],
+    )
+    parser.add_argument("--repeats", type=int, default=32)
+    parser.add_argument("--rounds", type=int, default=11)
+    parser.add_argument("--seed", type=int, default=17)
+    parser.add_argument("--include-fp64", action="store_true")
+    parser.add_argument("--reverse", action="store_true", help="Reverse case order for a second independent run")
+    parser.add_argument("--output", type=Path, required=True)
+    args = parser.parse_args()
+    if args.repeats < 1 or args.rounds < 2 or min(args.batches + args.vocabs) < 1:
+        parser.error("positive shapes/repeats and at least two rounds are required")
+    if not enable_categorical_sample_op():
+        raise RuntimeError("the native categorical operator is unavailable; benchmarking fallback is invalid")
+    cases = [(b, v, d, s) for s in args.scenarios for d in args.dtypes for b in args.batches for v in args.vocabs]
+    if args.reverse:
+        cases.reverse()
+    with args.output.open("w", newline="") as output_file:
+        writer = None
+        for index, (batch, vocab, dtype, scenario) in enumerate(cases, 1):
+            row = {"batch": batch, "vocab": vocab, "dtype": dtype, "scenario": scenario, "seed": args.seed}
+            row.update(benchmark_case(batch, vocab, DTYPES[dtype], scenario, args))
+            if writer is None:
+                writer = csv.DictWriter(output_file, fieldnames=list(row))
+                writer.writeheader()
+            writer.writerow(row)
+            output_file.flush()
+            print(f"[{index}/{len(cases)}] {row}", flush=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/csrc/build_aclnn.sh
+++ b/csrc/build_aclnn.sh
@@ -106,6 +106,7 @@ elif [[ "$SOC_VERSION" =~ ^ascend910b ]]; then
         "moe_gating_top_k_hash"
         "add_rms_norm_bias"
         "rms_norm_cast"
+        "categorical_sample"
         "transpose_kv_cache_by_block"
         "copy_and_expand_eagle_inputs"
         "causal_conv1d"
@@ -162,6 +163,7 @@ elif [[ "$SOC_VERSION" =~ ^ascend910_93 ]]; then
         "moe_gating_top_k_hash"
         "add_rms_norm_bias"
         "rms_norm_cast"
+        "categorical_sample"
         "transpose_kv_cache_by_block"
         "copy_and_expand_eagle_inputs"
         "causal_conv1d"
@@ -206,6 +208,7 @@ elif [[ "$SOC_VERSION" =~ ^ascend950 ]]; then
     setup_catlass_dependency
 
     CUSTOM_OPS_ARRAY=(
+        "categorical_sample"
         "moe_gating_top_k_hash"
         "inplace_partial_rotary_mul"
         "kv_compress_epilog"

--- a/csrc/cmake/func.cmake
+++ b/csrc/cmake/func.cmake
@@ -79,6 +79,7 @@ function(op_add_subdirectory OP_LIST OP_DIR_LIST)
         file(GLOB OP_HOST_CMAKE_FILES
         "${CMAKE_CURRENT_SOURCE_DIR}/gmm/**/op_host/CMakeLists.txt"
         "${CMAKE_CURRENT_SOURCE_DIR}/gmm/**/CMakeLists.txt"
+        "${CMAKE_CURRENT_SOURCE_DIR}/sampling/**/op_host/CMakeLists.txt"
         )
         if(BUILD_OPEN_PROJECT AND (NOT BUILD_OPS_RTY_KERNEL))
             file(GLOB CANNDEV_OPS_HOST_CMAKE_FILES

--- a/csrc/sampling/categorical_sample/categorical_sample_torch_adpt.h
+++ b/csrc/sampling/categorical_sample/categorical_sample_torch_adpt.h
@@ -1,0 +1,166 @@
+/*
+ * Copyright (c) Huawei Technologies Co., Ltd. 2026. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+#ifndef CATEGORICAL_SAMPLE_TORCH_ADPT_H
+#define CATEGORICAL_SAMPLE_TORCH_ADPT_H
+
+namespace vllm_ascend {
+namespace {
+constexpr int64_t CATEGORICAL_SAMPLE_MAX_VOCAB_SIZE = 1'048'576;
+
+void check_categorical_sample_metadata(
+    const at::Tensor& tensor,
+    const at::Tensor& processed_logits,
+    c10::ScalarType dtype,
+    c10::string_view name)
+{
+    TORCH_CHECK(tensor.is_privateuseone(), name, " must be an NPU tensor");
+    TORCH_CHECK(tensor.device() == processed_logits.device(), name, " must be on the same device as processed_logits");
+    TORCH_CHECK(tensor.dim() == 1, name, " must be 1D");
+    TORCH_CHECK(tensor.is_contiguous(), name, " must be contiguous");
+    TORCH_CHECK(tensor.scalar_type() == dtype, name, " has an invalid dtype");
+}
+}  // namespace
+
+std::tuple<at::Tensor, at::Tensor> npu_categorical_sample(
+    const at::Tensor& processed_logits,
+    const at::Tensor& expanded_idx_mapping,
+    const at::Tensor& temperature,
+    const at::Tensor& seed,
+    const at::Tensor& pos,
+    bool return_lse,
+    bool apply_temperature,
+    const c10::optional<at::Tensor>& logits_cache,
+    const c10::optional<at::Tensor>& logits_cache_col,
+    bool use_fp64)
+{
+    TORCH_CHECK(processed_logits.is_privateuseone(), "processed_logits must be an NPU tensor");
+    TORCH_CHECK(processed_logits.dim() == 2, "processed_logits must be 2D");
+    TORCH_CHECK(
+        processed_logits.scalar_type() == at::kHalf || processed_logits.scalar_type() == at::kBFloat16 ||
+            processed_logits.scalar_type() == at::kFloat,
+        "processed_logits must have dtype float16, bfloat16, or float32");
+    TORCH_CHECK(processed_logits.size(0) > 0, "processed_logits must contain at least one row");
+    TORCH_CHECK(
+        processed_logits.size(1) > 0 && processed_logits.size(1) <= CATEGORICAL_SAMPLE_MAX_VOCAB_SIZE,
+        "processed_logits vocabulary size must be in [1, ", CATEGORICAL_SAMPLE_MAX_VOCAB_SIZE, "]");
+    TORCH_CHECK(processed_logits.stride(1) == 1, "processed_logits vocabulary dimension must be contiguous");
+    TORCH_CHECK(
+        processed_logits.stride(0) == 0 || processed_logits.stride(0) >= processed_logits.size(1),
+        "processed_logits row stride is invalid");
+
+    check_categorical_sample_metadata(expanded_idx_mapping, processed_logits, at::kInt, "expanded_idx_mapping");
+    check_categorical_sample_metadata(temperature, processed_logits, at::kFloat, "temperature");
+    check_categorical_sample_metadata(seed, processed_logits, at::kLong, "seed");
+    check_categorical_sample_metadata(pos, processed_logits, at::kLong, "pos");
+    TORCH_CHECK(
+        expanded_idx_mapping.size(0) == processed_logits.size(0),
+        "expanded_idx_mapping length must equal the number of rows");
+    TORCH_CHECK(pos.size(0) == processed_logits.size(0), "pos length must equal the number of rows");
+    TORCH_CHECK(temperature.size(0) > 0, "temperature must contain at least one request");
+    TORCH_CHECK(seed.size(0) == temperature.size(0), "seed and temperature must have the same length");
+
+    int64_t logitsCacheStride = 0;
+    int64_t logitsCacheColStride = 0;
+    if (logits_cache.has_value()) {
+        const at::Tensor& logitsCache = logits_cache.value();
+        TORCH_CHECK(logitsCache.is_privateuseone(), "logits_cache must be an NPU tensor");
+        TORCH_CHECK(
+            logitsCache.device() == processed_logits.device(),
+            "logits_cache must be on the same device as processed_logits");
+        TORCH_CHECK(
+            logitsCache.scalar_type() == at::kFloat || logitsCache.scalar_type() == at::kHalf ||
+                logitsCache.scalar_type() == at::kBFloat16,
+            "logits_cache must have dtype float16, bfloat16, or float32");
+        TORCH_CHECK(
+            logitsCache.dim() == 2 || logitsCache.dim() == 3,
+            "logits_cache must be 2D or 3D");
+        TORCH_CHECK(
+            logitsCache.size(0) == temperature.size(0),
+            "logits_cache request dimension must equal the temperature length");
+        TORCH_CHECK(
+            logitsCache.size(-1) >= processed_logits.size(1),
+            "logits_cache vocabulary dimension is narrower than the input vocabulary size");
+        TORCH_CHECK(
+            logitsCache.stride(-1) == 1,
+            "logits_cache vocabulary dimension must be contiguous");
+        if (logitsCache.dim() == 3) {
+            TORCH_CHECK(
+                logitsCache.size(1) > 0,
+                "logits_cache must contain at least one cache column");
+            TORCH_CHECK(
+                logitsCache.stride(1) >= processed_logits.size(1) && logitsCache.stride(1) <= UINT32_MAX,
+                "logits_cache column stride is invalid");
+        }
+        logitsCacheColStride = logitsCache.dim() == 3 ? logitsCache.stride(1) : logitsCache.size(-1);
+        const int64_t cacheRowElements =
+            logitsCache.dim() == 3 ? (logitsCache.size(1) - 1) * logitsCacheColStride + processed_logits.size(1)
+                                             : processed_logits.size(1);
+        TORCH_CHECK(
+            logitsCache.stride(0) >= cacheRowElements && logitsCache.stride(0) <= UINT32_MAX,
+            "logits_cache request stride is invalid");
+        logitsCacheStride = logitsCache.stride(0);
+
+        if (logits_cache_col.has_value()) {
+            const at::Tensor& logitsCacheCol = logits_cache_col.value();
+            TORCH_CHECK(
+                logitsCacheCol.is_privateuseone(),
+                "logits_cache_col must be an NPU tensor");
+            TORCH_CHECK(
+                logitsCacheCol.device() == processed_logits.device(),
+                "logits_cache_col must be on the same device as processed_logits");
+            TORCH_CHECK(
+                logitsCacheCol.scalar_type() == at::kInt,
+                "logits_cache_col must have dtype int32");
+            TORCH_CHECK(
+                logitsCacheCol.dim() == 0 || logitsCacheCol.dim() == 1,
+                "logits_cache_col must be a scalar or 1D");
+            TORCH_CHECK(logitsCacheCol.is_contiguous(), "logits_cache_col must be contiguous");
+            TORCH_CHECK(
+                logitsCacheCol.dim() == 0 ||
+                    logitsCacheCol.size(0) == processed_logits.size(0),
+                "a per-token logits_cache_col must have one entry per logits row");
+        }
+    } else {
+        TORCH_CHECK(
+            !logits_cache_col.has_value(),
+            "logits_cache_col requires logits_cache");
+    }
+
+    const auto rowOptions = processed_logits.options();
+    at::Tensor sampledTokenIds = at::empty({processed_logits.size(0)}, rowOptions.dtype(at::kLong));
+    // The ACLNN executor rejects zero-storage outputs. Always pass a real LSE
+    // workspace, then preserve the public return_lse=False contract below.
+    at::Tensor lseWorkspace = at::empty({processed_logits.size(0)}, rowOptions.dtype(at::kFloat));
+    int64_t rowStride = processed_logits.stride(0);
+
+    EXEC_NPU_CMD(
+        aclnnCategoricalSample,
+        processed_logits,
+        expanded_idx_mapping,
+        temperature,
+        seed,
+        pos,
+        logits_cache,
+        logits_cache_col,
+        rowStride,
+        logitsCacheStride,
+        apply_temperature,
+        return_lse,
+        use_fp64,
+        logitsCacheColStride,
+        sampledTokenIds,
+        lseWorkspace);
+    at::Tensor lse = return_lse ? lseWorkspace : at::empty({0}, rowOptions.dtype(at::kFloat));
+    return std::make_tuple(sampledTokenIds, lse);
+}
+}  // namespace vllm_ascend
+
+#endif

--- a/csrc/sampling/categorical_sample/op_host/CMakeLists.txt
+++ b/csrc/sampling/categorical_sample/op_host/CMakeLists.txt
@@ -1,0 +1,28 @@
+# -----------------------------------------------------------------------------------------------------------
+# Copyright (c) 2026 Huawei Technologies Co., Ltd.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+
+add_op_to_compiled_list()
+
+if(BUILD_OPEN_PROJECT)
+    target_sources(op_host_aclnn PRIVATE categorical_sample_def.cpp)
+endif()
+
+add_ops_compile_options(
+    OP_NAME CategoricalSample
+    OPTIONS --cce-auto-sync=off
+            -Wno-deprecated-declarations
+)
+
+if(NOT BUILD_OPS_RTY_KERNEL)
+    add_modules_sources(OPTYPE categorical_sample ACLNNTYPE aclnn)
+    target_include_directories(${OPHOST_NAME}_tiling_obj PRIVATE
+        ${CMAKE_CURRENT_SOURCE_DIR}
+    )
+endif()

--- a/csrc/sampling/categorical_sample/op_host/categorical_sample_def.cpp
+++ b/csrc/sampling/categorical_sample/op_host/categorical_sample_def.cpp
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) Huawei Technologies Co., Ltd. 2026. All rights reserved.
+ */
+
+#include "register/op_def_registry.h"
+
+namespace ops {
+class CategoricalSample : public OpDef {
+public:
+    explicit CategoricalSample(const char* name) : OpDef(name)
+    {
+        this->Input("processedLogits")
+            .ParamType(REQUIRED)
+            .DataType({ge::DT_FLOAT, ge::DT_FLOAT, ge::DT_FLOAT, ge::DT_FLOAT16, ge::DT_FLOAT16, ge::DT_FLOAT16, ge::DT_BF16, ge::DT_BF16, ge::DT_BF16})
+            .Format({ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND})
+            .UnknownShapeFormat({ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND})
+            .IgnoreContiguous();
+        this->Input("expandedIdxMapping")
+            .ParamType(REQUIRED)
+            .DataType({ge::DT_INT32, ge::DT_INT32, ge::DT_INT32, ge::DT_INT32, ge::DT_INT32, ge::DT_INT32, ge::DT_INT32, ge::DT_INT32, ge::DT_INT32})
+            .Format({ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND})
+            .UnknownShapeFormat({ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND});
+        this->Input("temperature")
+            .ParamType(REQUIRED)
+            .DataType({ge::DT_FLOAT, ge::DT_FLOAT, ge::DT_FLOAT, ge::DT_FLOAT, ge::DT_FLOAT, ge::DT_FLOAT, ge::DT_FLOAT, ge::DT_FLOAT, ge::DT_FLOAT})
+            .Format({ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND})
+            .UnknownShapeFormat({ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND});
+        this->Input("seed")
+            .ParamType(REQUIRED)
+            .DataType({ge::DT_INT64, ge::DT_INT64, ge::DT_INT64, ge::DT_INT64, ge::DT_INT64, ge::DT_INT64, ge::DT_INT64, ge::DT_INT64, ge::DT_INT64})
+            .Format({ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND})
+            .UnknownShapeFormat({ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND});
+        this->Input("pos")
+            .ParamType(REQUIRED)
+            .DataType({ge::DT_INT64, ge::DT_INT64, ge::DT_INT64, ge::DT_INT64, ge::DT_INT64, ge::DT_INT64, ge::DT_INT64, ge::DT_INT64, ge::DT_INT64})
+            .Format({ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND})
+            .UnknownShapeFormat({ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND});
+        this->Input("logitsCache")
+            .ParamType(OPTIONAL)
+            .DataType({ge::DT_FLOAT, ge::DT_FLOAT16, ge::DT_BF16, ge::DT_FLOAT, ge::DT_FLOAT16, ge::DT_BF16, ge::DT_FLOAT, ge::DT_FLOAT16, ge::DT_BF16})
+            .Format({ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND})
+            .UnknownShapeFormat({ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND})
+            .IgnoreContiguous();
+        this->Input("logitsCacheCol")
+            .ParamType(OPTIONAL)
+            .DataType({ge::DT_INT32, ge::DT_INT32, ge::DT_INT32, ge::DT_INT32, ge::DT_INT32, ge::DT_INT32, ge::DT_INT32, ge::DT_INT32, ge::DT_INT32})
+            .Format({ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND})
+            .UnknownShapeFormat({ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND});
+
+        this->Output("sampledTokenIds")
+            .ParamType(REQUIRED)
+            .DataType({ge::DT_INT64, ge::DT_INT64, ge::DT_INT64, ge::DT_INT64, ge::DT_INT64, ge::DT_INT64, ge::DT_INT64, ge::DT_INT64, ge::DT_INT64})
+            .Format({ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND})
+            .UnknownShapeFormat({ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND});
+        this->Output("lse")
+            .ParamType(REQUIRED)
+            .DataType({ge::DT_FLOAT, ge::DT_FLOAT, ge::DT_FLOAT, ge::DT_FLOAT, ge::DT_FLOAT, ge::DT_FLOAT, ge::DT_FLOAT, ge::DT_FLOAT, ge::DT_FLOAT})
+            .Format({ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND})
+            .UnknownShapeFormat({ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND});
+        this->Attr("rowStride").Int();
+        this->Attr("logitsCacheStride").Int();
+        this->Attr("applyTemperature").Bool();
+        this->Attr("returnLse").Bool();
+        this->Attr("useFp64").Bool();
+        this->Attr("logitsCacheColStride").Int();
+
+        this->AICore().AddConfig("ascend910b");
+        this->AICore().AddConfig("ascend910_93");
+        this->AICore().AddConfig("ascend950");
+    }
+};
+
+OP_ADD(CategoricalSample);
+}  // namespace ops

--- a/csrc/sampling/categorical_sample/op_host/categorical_sample_infershape.cpp
+++ b/csrc/sampling/categorical_sample/op_host/categorical_sample_infershape.cpp
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) Huawei Technologies Co., Ltd. 2026. All rights reserved.
+ */
+
+#include "register/op_impl_registry.h"
+#include "log/log.h"
+
+namespace ops {
+namespace {
+constexpr size_t PROCESSED_LOGITS_INDEX = 0;
+constexpr size_t SAMPLED_TOKEN_IDS_INDEX = 0;
+constexpr size_t LSE_INDEX = 1;
+}  // namespace
+
+static ge::graphStatus InferShapeCategoricalSample(gert::InferShapeContext* context)
+{
+    const gert::Shape* logitsShape = context->GetInputShape(PROCESSED_LOGITS_INDEX);
+    OP_CHECK_NULL_WITH_CONTEXT(context, logitsShape);
+    if (logitsShape->GetDimNum() != 2) {
+        return ge::GRAPH_FAILED;
+    }
+
+    const int64_t numRows = logitsShape->GetDim(0);
+    gert::Shape* sampledTokenIdsShape = context->GetOutputShape(SAMPLED_TOKEN_IDS_INDEX);
+    OP_CHECK_NULL_WITH_CONTEXT(context, sampledTokenIdsShape);
+    sampledTokenIdsShape->SetDimNum(1);
+    sampledTokenIdsShape->SetDim(0, numRows);
+
+    gert::Shape* lseShape = context->GetOutputShape(LSE_INDEX);
+    OP_CHECK_NULL_WITH_CONTEXT(context, lseShape);
+    lseShape->SetDimNum(1);
+    // ACLNN requires every output to own non-null storage. Keep the custom-op
+    // workspace row-shaped even when the public torch wrapper discards LSE.
+    lseShape->SetDim(0, numRows);
+    return ge::GRAPH_SUCCESS;
+}
+
+IMPL_OP_INFERSHAPE(CategoricalSample).InferShape(InferShapeCategoricalSample);
+}  // namespace ops

--- a/csrc/sampling/categorical_sample/op_host/categorical_sample_tiling.cpp
+++ b/csrc/sampling/categorical_sample/op_host/categorical_sample_tiling.cpp
@@ -1,0 +1,228 @@
+/*
+ * Copyright (c) Huawei Technologies Co., Ltd. 2026. All rights reserved.
+ */
+
+#include "categorical_sample_tiling.h"
+
+#include <algorithm>
+
+#include "register/op_def_registry.h"
+#include "tiling/platform/platform_ascendc.h"
+#include "tiling_base/error_log.h"
+
+namespace optiling {
+namespace {
+constexpr size_t PROCESSED_LOGITS_INDEX = 0;
+constexpr size_t EXPANDED_IDX_MAPPING_INDEX = 1;
+constexpr size_t TEMPERATURE_INDEX = 2;
+constexpr size_t SEED_INDEX = 3;
+constexpr size_t POS_INDEX = 4;
+constexpr size_t LOGITS_CACHE_INDEX = 5;
+constexpr size_t LOGITS_CACHE_COL_INDEX = 6;
+constexpr size_t SAMPLED_TOKEN_IDS_INDEX = 0;
+constexpr size_t LSE_INDEX = 1;
+
+constexpr uint32_t MAX_VOCAB_SIZE = 1'048'576;
+constexpr uint32_t MAX_TILE_ELEMENTS = 4096;
+constexpr uint32_t TILE_ALIGNMENT = 256;
+
+uint32_t AlignUp(uint32_t value, uint32_t alignment)
+{
+    return (value + alignment - 1) / alignment * alignment;
+}
+
+uint32_t CeilDiv(uint32_t lhs, uint32_t rhs)
+{
+    return (lhs + rhs - 1) / rhs;
+}
+
+bool IsOneDimensional(const gert::StorageShape* shape)
+{
+    return shape != nullptr && shape->GetOriginShape().GetDimNum() == 1;
+}
+}  // namespace
+
+static ge::graphStatus CategoricalSampleTilingFunc(gert::TilingContext* context)
+{
+    const gert::StorageShape* logitsShape = context->GetInputShape(PROCESSED_LOGITS_INDEX);
+    const gert::StorageShape* mappingShape = context->GetInputShape(EXPANDED_IDX_MAPPING_INDEX);
+    const gert::StorageShape* temperatureShape = context->GetInputShape(TEMPERATURE_INDEX);
+    const gert::StorageShape* seedShape = context->GetInputShape(SEED_INDEX);
+    const gert::StorageShape* posShape = context->GetInputShape(POS_INDEX);
+    const gert::StorageShape* logitsCacheShape =
+        context->GetOptionalInputShape(LOGITS_CACHE_INDEX);
+    const gert::StorageShape* logitsCacheColShape =
+        context->GetOptionalInputShape(LOGITS_CACHE_COL_INDEX);
+    OP_CHECK_NULL_WITH_CONTEXT(context, logitsShape);
+    OP_CHECK_NULL_WITH_CONTEXT(context, mappingShape);
+    OP_CHECK_NULL_WITH_CONTEXT(context, temperatureShape);
+    OP_CHECK_NULL_WITH_CONTEXT(context, seedShape);
+    OP_CHECK_NULL_WITH_CONTEXT(context, posShape);
+
+    const gert::Shape& logitsOriginShape = logitsShape->GetOriginShape();
+    if (logitsOriginShape.GetDimNum() != 2) {
+        OP_LOGE(context->GetNodeName(), "processedLogits must be 2D.");
+        return ge::GRAPH_FAILED;
+    }
+    const int64_t numRows = logitsOriginShape.GetDim(0);
+    const int64_t vocabSize = logitsOriginShape.GetDim(1);
+    if (numRows <= 0 || numRows > UINT32_MAX || vocabSize <= 0 || vocabSize > MAX_VOCAB_SIZE) {
+        OP_LOGE(context->GetNodeName(), "processedLogits shape is outside the supported range.");
+        return ge::GRAPH_FAILED;
+    }
+    if (!IsOneDimensional(mappingShape) || !IsOneDimensional(temperatureShape) || !IsOneDimensional(seedShape) ||
+        !IsOneDimensional(posShape)) {
+        OP_LOGE(context->GetNodeName(), "sampling metadata tensors must be 1D.");
+        return ge::GRAPH_FAILED;
+    }
+    if (mappingShape->GetOriginShape().GetDim(0) != numRows || posShape->GetOriginShape().GetDim(0) != numRows ||
+        temperatureShape->GetOriginShape().GetDim(0) <= 0 ||
+        seedShape->GetOriginShape().GetDim(0) != temperatureShape->GetOriginShape().GetDim(0)) {
+        OP_LOGE(context->GetNodeName(), "sampling metadata shapes are inconsistent.");
+        return ge::GRAPH_FAILED;
+    }
+
+    auto attrs = context->GetAttrs();
+    OP_CHECK_NULL_WITH_CONTEXT(context, attrs);
+    const int64_t* rowStride = attrs->GetInt(0);
+    const int64_t* logitsCacheStride = attrs->GetInt(1);
+    const bool* applyTemperature = attrs->GetBool(2);
+    const bool* returnLse = attrs->GetBool(3);
+    const bool* useFp64 = attrs->GetBool(4);
+    const int64_t* logitsCacheColStride = attrs->GetInt(5);
+    OP_CHECK_NULL_WITH_CONTEXT(context, rowStride);
+    OP_CHECK_NULL_WITH_CONTEXT(context, logitsCacheStride);
+    OP_CHECK_NULL_WITH_CONTEXT(context, applyTemperature);
+    OP_CHECK_NULL_WITH_CONTEXT(context, returnLse);
+    OP_CHECK_NULL_WITH_CONTEXT(context, useFp64);
+    OP_CHECK_NULL_WITH_CONTEXT(context, logitsCacheColStride);
+    if ((*rowStride != 0 && *rowStride < vocabSize) || *rowStride > UINT32_MAX) {
+        OP_LOGE(context->GetNodeName(), "processedLogits row stride is invalid.");
+        return ge::GRAPH_FAILED;
+    }
+
+    uint32_t logitsCacheNumCols = 0;
+    bool logitsCacheColPerToken = false;
+    if (logitsCacheShape != nullptr) {
+        const gert::Shape& cacheShape = logitsCacheShape->GetOriginShape();
+        if ((cacheShape.GetDimNum() != 2 && cacheShape.GetDimNum() != 3) ||
+            cacheShape.GetDim(0) != temperatureShape->GetOriginShape().GetDim(0) ||
+            cacheShape.GetDim(cacheShape.GetDimNum() - 1) < vocabSize) {
+            OP_LOGE(context->GetNodeName(), "logitsCache shape is inconsistent.");
+            return ge::GRAPH_FAILED;
+        }
+        const int64_t numCols = cacheShape.GetDimNum() == 3 ? cacheShape.GetDim(1) : 1;
+        if (numCols <= 0 || numCols > UINT32_MAX || *logitsCacheStride < vocabSize ||
+            *logitsCacheStride > UINT32_MAX || *logitsCacheColStride < vocabSize ||
+            *logitsCacheColStride > UINT32_MAX) {
+            OP_LOGE(context->GetNodeName(), "logitsCache stride or column count is invalid.");
+            return ge::GRAPH_FAILED;
+        }
+        logitsCacheNumCols = static_cast<uint32_t>(numCols);
+
+        if (logitsCacheColShape != nullptr) {
+            const gert::Shape& colShape = logitsCacheColShape->GetOriginShape();
+            if (colShape.GetDimNum() == 0) {
+                logitsCacheColPerToken = false;
+            } else if (colShape.GetDimNum() == 1 && colShape.GetDim(0) == numRows) {
+                logitsCacheColPerToken = true;
+            } else {
+                OP_LOGE(context->GetNodeName(), "logitsCacheCol must be scalar or one value per row.");
+                return ge::GRAPH_FAILED;
+            }
+        }
+    } else if (logitsCacheColShape != nullptr) {
+        OP_LOGE(context->GetNodeName(), "logitsCacheCol requires logitsCache.");
+        return ge::GRAPH_FAILED;
+    }
+
+    const gert::StorageShape* sampledIdsShape = context->GetOutputShape(SAMPLED_TOKEN_IDS_INDEX);
+    const gert::StorageShape* lseShape = context->GetOutputShape(LSE_INDEX);
+    OP_CHECK_NULL_WITH_CONTEXT(context, sampledIdsShape);
+    OP_CHECK_NULL_WITH_CONTEXT(context, lseShape);
+    if (!IsOneDimensional(sampledIdsShape) || sampledIdsShape->GetOriginShape().GetDim(0) != numRows ||
+        !IsOneDimensional(lseShape) || lseShape->GetOriginShape().GetDim(0) != numRows) {
+        OP_LOGE(context->GetNodeName(), "categorical sample output shapes are inconsistent.");
+        return ge::GRAPH_FAILED;
+    }
+
+    auto platformInfo = context->GetPlatformInfo();
+    OP_CHECK_NULL_WITH_CONTEXT(context, platformInfo);
+    auto platform = platform_ascendc::PlatformAscendC(platformInfo);
+    uint32_t coreNum = platform.GetCoreNumAiv();
+    if (coreNum == 0) {
+        OP_LOGE(context->GetNodeName(), "failed to get AIV core count.");
+        return ge::GRAPH_FAILED;
+    }
+
+    auto logitsDesc = context->GetInputDesc(PROCESSED_LOGITS_INDEX);
+    OP_CHECK_NULL_WITH_CONTEXT(context, logitsDesc);
+    uint64_t tilingKey = 0;
+    switch (logitsDesc->GetDataType()) {
+        case ge::DT_FLOAT:
+            tilingKey = 1;
+            break;
+        case ge::DT_FLOAT16:
+            tilingKey = 2;
+            break;
+        case ge::DT_BF16:
+            tilingKey = 3;
+            break;
+        default:
+            OP_LOGE(context->GetNodeName(), "unsupported processedLogits dtype.");
+            return ge::GRAPH_FAILED;
+    }
+
+    const uint32_t vocab = static_cast<uint32_t>(vocabSize);
+    const uint32_t tileElements = std::min(MAX_TILE_ELEMENTS, AlignUp(vocab, TILE_ALIGNMENT));
+    CategoricalSampleTilingData tilingData;
+    tilingData.set_numRows(static_cast<uint32_t>(numRows));
+    tilingData.set_vocabSize(vocab);
+    tilingData.set_numRequests(static_cast<uint32_t>(temperatureShape->GetOriginShape().GetDim(0)));
+    tilingData.set_rowStride(static_cast<uint32_t>(*rowStride));
+    tilingData.set_logitsCacheStride(static_cast<uint32_t>(*logitsCacheStride));
+    tilingData.set_logitsCacheColStride(static_cast<uint32_t>(*logitsCacheColStride));
+    uint32_t cacheDtype = 0;
+    if (logitsCacheShape != nullptr) {
+        auto cacheDesc = context->GetOptionalInputDesc(LOGITS_CACHE_INDEX);
+        OP_CHECK_NULL_WITH_CONTEXT(context, cacheDesc);
+        switch (cacheDesc->GetDataType()) {
+            case ge::DT_FLOAT: cacheDtype = 0; break;
+            case ge::DT_FLOAT16: cacheDtype = 1; break;
+            case ge::DT_BF16: cacheDtype = 2; break;
+            default: return ge::GRAPH_FAILED;
+        }
+    }
+    tilingData.set_logitsCacheDtype(cacheDtype);
+    tilingData.set_logitsCacheNumCols(logitsCacheNumCols);
+    tilingData.set_tileElements(tileElements);
+    tilingData.set_tileCount(CeilDiv(vocab, tileElements));
+    tilingData.set_hasLogitsCache(logitsCacheShape != nullptr ? 1U : 0U);
+    tilingData.set_hasLogitsCacheCol(logitsCacheColShape != nullptr ? 1U : 0U);
+    tilingData.set_logitsCacheColPerToken(logitsCacheColPerToken ? 1U : 0U);
+    tilingData.set_applyTemperature(*applyTemperature ? 1U : 0U);
+    tilingData.set_returnLse(*returnLse ? 1U : 0U);
+    tilingData.set_useFp64(*useFp64 ? 1U : 0U);
+
+    size_t* workspaceSize = context->GetWorkspaceSizes(1);
+    OP_CHECK_NULL_WITH_CONTEXT(context, workspaceSize);
+    *workspaceSize = 0;
+    context->SetBlockDim(std::min(coreNum, static_cast<uint32_t>(numRows)));
+    context->SetTilingKey(tilingKey);
+
+    auto rawTilingData = context->GetRawTilingData();
+    OP_CHECK_NULL_WITH_CONTEXT(context, rawTilingData);
+    tilingData.SaveToBuffer(rawTilingData->GetData(), rawTilingData->GetCapacity());
+    rawTilingData->SetDataSize(tilingData.GetDataSize());
+    return ge::GRAPH_SUCCESS;
+}
+
+static ge::graphStatus TilingParseForCategoricalSample(gert::TilingParseContext*)
+{
+    return ge::GRAPH_SUCCESS;
+}
+
+IMPL_OP_OPTILING(CategoricalSample)
+    .Tiling(CategoricalSampleTilingFunc)
+    .TilingParse<CategoricalSampleCompileInfo>(TilingParseForCategoricalSample);
+}  // namespace optiling

--- a/csrc/sampling/categorical_sample/op_host/categorical_sample_tiling.h
+++ b/csrc/sampling/categorical_sample/op_host/categorical_sample_tiling.h
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) Huawei Technologies Co., Ltd. 2026. All rights reserved.
+ */
+
+#ifndef CATEGORICAL_SAMPLE_TILING_H
+#define CATEGORICAL_SAMPLE_TILING_H
+
+#include "register/tilingdata_base.h"
+
+namespace optiling {
+BEGIN_TILING_DATA_DEF(CategoricalSampleTilingData)
+    TILING_DATA_FIELD_DEF(uint32_t, numRows);
+    TILING_DATA_FIELD_DEF(uint32_t, vocabSize);
+    TILING_DATA_FIELD_DEF(uint32_t, numRequests);
+    TILING_DATA_FIELD_DEF(uint32_t, rowStride);
+    TILING_DATA_FIELD_DEF(uint32_t, logitsCacheStride);
+    TILING_DATA_FIELD_DEF(uint32_t, logitsCacheColStride);
+    TILING_DATA_FIELD_DEF(uint32_t, logitsCacheDtype);
+    TILING_DATA_FIELD_DEF(uint32_t, logitsCacheNumCols);
+    TILING_DATA_FIELD_DEF(uint32_t, tileElements);
+    TILING_DATA_FIELD_DEF(uint32_t, tileCount);
+    TILING_DATA_FIELD_DEF(uint32_t, hasLogitsCache);
+    TILING_DATA_FIELD_DEF(uint32_t, hasLogitsCacheCol);
+    TILING_DATA_FIELD_DEF(uint32_t, logitsCacheColPerToken);
+    TILING_DATA_FIELD_DEF(uint32_t, applyTemperature);
+    TILING_DATA_FIELD_DEF(uint32_t, returnLse);
+    TILING_DATA_FIELD_DEF(uint32_t, useFp64);
+END_TILING_DATA_DEF;
+
+REGISTER_TILING_DATA_CLASS(CategoricalSample, CategoricalSampleTilingData)
+
+struct CategoricalSampleCompileInfo {};
+}  // namespace optiling
+
+#endif

--- a/csrc/sampling/categorical_sample/op_kernel/categorical_sample.cpp
+++ b/csrc/sampling/categorical_sample/op_kernel/categorical_sample.cpp
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) Huawei Technologies Co., Ltd. 2026. All rights reserved.
+ */
+
+#include "categorical_sample.h"
+
+#if !defined(ENABLE_ASSERT) || !defined(ENABLE_ASSERT_DUMP_SIZE)
+// CANN still detects these precompile feature markers and uses them to reserve
+// and initialize the assert dump workspace, but some A2, A3, and A5 AscendC
+// headers do not expose the legacy ENABLE_ASSERT* helper macros.
+// Keep the marker names identical to the compiler's kernel-info inference
+// contract so AssertPrint remains available in both eager and graph launches.
+#if defined(__CHECK_FEATURE_AT_PRECOMPILE)
+#define CATEGORICAL_SAMPLE_ENABLE_ASSERT()                   \
+    auto __enable_feature_for_compile_assert = 1;           \
+    auto __enable_feature_for_compile_assertBufSize = 1024
+#else
+#define CATEGORICAL_SAMPLE_ENABLE_ASSERT()
+#endif
+#else
+#define CATEGORICAL_SAMPLE_ENABLE_ASSERT() \
+    ENABLE_ASSERT();                       \
+    ENABLE_ASSERT_DUMP_SIZE()
+#endif
+
+extern "C" __global__ __aicore__ void categorical_sample(
+    GM_ADDR processedLogits,
+    GM_ADDR expandedIdxMapping,
+    GM_ADDR temperature,
+    GM_ADDR seed,
+    GM_ADDR pos,
+    GM_ADDR logitsCache,
+    GM_ADDR logitsCacheCol,
+    GM_ADDR sampledTokenIds,
+    GM_ADDR lse,
+    GM_ADDR workspace,
+    GM_ADDR tiling)
+{
+    REGISTER_TILING_DEFAULT(CategoricalSample::CategoricalSampleTilingData);
+    CATEGORICAL_SAMPLE_ENABLE_ASSERT();
+    GET_TILING_DATA(tilingData, tiling);
+    KERNEL_TASK_TYPE_DEFAULT(KERNEL_TYPE_AIV_ONLY);
+    AscendC::TPipe pipe;
+
+    if (TILING_KEY_IS(1)) {
+        CategoricalSample::CategoricalSampleKernel<float> op;
+        op.Init(processedLogits, expandedIdxMapping, temperature, seed, pos, logitsCache,
+                logitsCacheCol, sampledTokenIds, lse, &tilingData, &pipe);
+        op.Process();
+    } else if (TILING_KEY_IS(2)) {
+        CategoricalSample::CategoricalSampleKernel<half> op;
+        op.Init(processedLogits, expandedIdxMapping, temperature, seed, pos, logitsCache,
+                logitsCacheCol, sampledTokenIds, lse, &tilingData, &pipe);
+        op.Process();
+    } else if (TILING_KEY_IS(3)) {
+        CategoricalSample::CategoricalSampleKernel<bfloat16_t> op;
+        op.Init(processedLogits, expandedIdxMapping, temperature, seed, pos, logitsCache,
+                logitsCacheCol, sampledTokenIds, lse, &tilingData, &pipe);
+        op.Process();
+    }
+}

--- a/csrc/sampling/categorical_sample/op_kernel/categorical_sample.h
+++ b/csrc/sampling/categorical_sample/op_kernel/categorical_sample.h
@@ -607,6 +607,7 @@ private:
 
     __aicore__ inline int64_t SelectPositiveInfinity(uint32_t row, float rank)
     {
+        int64_t lastIndex = 0;
         for (uint32_t tile = 0; tile < tileCount_; ++tile) {
             const uint32_t validElements = TileLength(tile);
             const uint32_t vectorElements = TileVectorLength(tile);
@@ -614,14 +615,17 @@ private:
             PipeVToS();
             for (uint32_t index = 0; index < validElements; ++index) {
                 if (logitsFloat.GetValue(index) == POS_INFINITY) {
+                    lastIndex = static_cast<int64_t>(tile) * tileElements_ + index;
                     if (rank < 1.0f) {
-                        return static_cast<int64_t>(tile) * tileElements_ + index;
+                        return lastIndex;
                     }
                     rank -= 1.0f;
                 }
             }
         }
-        return 0;
+        // The FP32 midpoint draw can round up to 1.0. Keep its endpoint
+        // on the positive-infinity support instead of returning token zero.
+        return lastIndex;
     }
 
     __aicore__ inline int64_t SelectPositiveInfinityFp64(uint32_t row, uint64_t rank)

--- a/csrc/sampling/categorical_sample/op_kernel/categorical_sample.h
+++ b/csrc/sampling/categorical_sample/op_kernel/categorical_sample.h
@@ -343,38 +343,16 @@ private:
         LocalTensor<float> nanValues = BuildNanIndicator(logitsFloat, vectorElements);
         LocalTensor<float> scalar = scalarBuf_.Get<float>();
 
-        if (validElements != vectorElements) {
-            PipeVToS();
-            bool hasNan = false;
-            for (uint32_t index = 0; index < validElements; ++index) {
-                hasNan = hasNan || nanValues.GetValue(index) != 0.0f;
-            }
-            CATEGORICAL_SAMPLE_CHECK(!hasNan, "CategoricalSample processed logits must not contain NaN\n");
-            float tileMax = NEG_INFINITY;
-            for (uint32_t index = 0; index < validElements; ++index) {
-                const float value = logitsFloat.GetValue(index);
-                if (value > tileMax) {
-                    tileMax = value;
-                    firstMaxIndex = index;
-                }
-            }
-            return tileMax;
-        }
-
-        ReduceMax(scalar[8], nanValues, work, vectorElements);
+        ReduceMax(scalar[8], nanValues, work, validElements);
         PipeVToS();
         CATEGORICAL_SAMPLE_CHECK(
             scalar.GetValue(8) == 0.0f, "CategoricalSample processed logits must not contain NaN\n");
-        ReduceMax(scalar, logitsFloat, work, vectorElements);
+        // ReduceMax returns the first maximum's index, including partial tiles.
+        ReduceMax(scalar, logitsFloat, work, validElements, needFirstMaxIndex);
         PipeVToS();
         const float tileMax = scalar.GetValue(0);
         if (needFirstMaxIndex) {
-            for (uint32_t index = 0; index < validElements; ++index) {
-                if (logitsFloat.GetValue(index) == tileMax) {
-                    firstMaxIndex = index;
-                    break;
-                }
-            }
+            firstMaxIndex = scalar.ReinterpretCast<uint32_t>().GetValue(1);
         }
         return tileMax;
     }

--- a/csrc/sampling/categorical_sample/op_kernel/categorical_sample.h
+++ b/csrc/sampling/categorical_sample/op_kernel/categorical_sample.h
@@ -1,0 +1,807 @@
+/*
+ * Copyright (c) Huawei Technologies Co., Ltd. 2026. All rights reserved.
+ */
+
+#ifndef CATEGORICAL_SAMPLE_H
+#define CATEGORICAL_SAMPLE_H
+
+#include "kernel_operator.h"
+
+namespace CategoricalSample {
+using namespace AscendC;
+
+constexpr float POS_INFINITY = __builtin_inff();
+constexpr float NEG_INFINITY = -__builtin_inff();
+// Standard Philox4x32-10 multipliers and Weyl key increments.
+constexpr uint32_t PHILOX_M0 = 0xD2511F53U;
+constexpr uint32_t PHILOX_M1 = 0xCD9E8D57U;
+constexpr uint32_t PHILOX_W0 = 0x9E3779B9U;
+constexpr uint32_t PHILOX_W1 = 0xBB67AE85U;
+constexpr float UINT24_TO_UNIT = 1.0f / 16777216.0f;
+constexpr uint32_t VECTOR_ALIGNMENT_ELEMENTS = 256;
+constexpr int32_t FP64_WEIGHT_FRACTION_BITS = 42;
+constexpr int32_t FP32_ABS_MASK = 0x7FFFFFFF;
+constexpr int32_t FP32_EXP_MASK = 0x7F800000;
+
+#define CATEGORICAL_SAMPLE_CHECK(condition, message) \
+    do {                                             \
+        if (!(condition)) {                         \
+            AscendC::AssertPrint(message);           \
+            AscendC::Trap();                         \
+        }                                            \
+    } while (0)
+
+struct CategoricalSampleTilingData {
+    uint32_t numRows;
+    uint32_t vocabSize;
+    uint32_t numRequests;
+    uint32_t rowStride;
+    uint32_t logitsCacheStride;
+    uint32_t logitsCacheColStride;
+    uint32_t logitsCacheDtype;
+    uint32_t logitsCacheNumCols;
+    uint32_t tileElements;
+    uint32_t tileCount;
+    uint32_t hasLogitsCache;
+    uint32_t hasLogitsCacheCol;
+    uint32_t logitsCacheColPerToken;
+    uint32_t applyTemperature;
+    uint32_t returnLse;
+    uint32_t useFp64;
+};
+
+__aicore__ inline uint32_t MinU32(uint32_t lhs, uint32_t rhs)
+{
+    return lhs < rhs ? lhs : rhs;
+}
+
+__aicore__ inline uint32_t AlignUpU32(uint32_t value, uint32_t alignment)
+{
+    return (value + alignment - 1) / alignment * alignment;
+}
+
+__aicore__ inline void PipeVToS()
+{
+    event_t eventId = static_cast<event_t>(GetTPipePtr()->FetchEventID(HardEvent::V_S));
+    SetFlag<HardEvent::V_S>(eventId);
+    WaitFlag<HardEvent::V_S>(eventId);
+}
+
+__aicore__ inline void PipeSToV()
+{
+    event_t eventId = static_cast<event_t>(GetTPipePtr()->FetchEventID(HardEvent::S_V));
+    SetFlag<HardEvent::S_V>(eventId);
+    WaitFlag<HardEvent::S_V>(eventId);
+}
+
+__aicore__ inline uint32_t MulHi(uint32_t lhs, uint32_t rhs)
+{
+    return static_cast<uint32_t>((static_cast<uint64_t>(lhs) * static_cast<uint64_t>(rhs)) >> 32U);
+}
+
+__aicore__ inline uint32_t MulLo(uint32_t lhs, uint32_t rhs)
+{
+    return static_cast<uint32_t>(static_cast<uint64_t>(lhs) * static_cast<uint64_t>(rhs));
+}
+
+__aicore__ inline void PhiloxRandom(int64_t seed, int64_t position, uint32_t& random0, uint32_t& random1)
+{
+    uint32_t counter0 = static_cast<uint32_t>(position);
+    uint32_t counter1 = static_cast<uint32_t>(static_cast<uint64_t>(position) >> 32U);
+    uint32_t counter2 = 0;
+    uint32_t counter3 = 0;
+    uint32_t key0 = static_cast<uint32_t>(seed);
+    uint32_t key1 = static_cast<uint32_t>(static_cast<uint64_t>(seed) >> 32U);
+
+    for (uint32_t round = 0; round < 10; ++round) {
+        const uint32_t hi0 = MulHi(PHILOX_M0, counter0);
+        const uint32_t lo0 = MulLo(PHILOX_M0, counter0);
+        const uint32_t hi1 = MulHi(PHILOX_M1, counter2);
+        const uint32_t lo1 = MulLo(PHILOX_M1, counter2);
+        const uint32_t next0 = hi1 ^ counter1 ^ key0;
+        const uint32_t next1 = lo1;
+        const uint32_t next2 = hi0 ^ counter3 ^ key1;
+        const uint32_t next3 = lo0;
+        counter0 = next0;
+        counter1 = next1;
+        counter2 = next2;
+        counter3 = next3;
+        key0 += PHILOX_W0;
+        key1 += PHILOX_W1;
+    }
+
+    random0 = counter0;
+    random1 = counter1;
+}
+
+__aicore__ inline int32_t PhiloxRandom24(int64_t seed, int64_t position)
+{
+    uint32_t random0 = 0;
+    uint32_t random1 = 0;
+    PhiloxRandom(seed, position, random0, random1);
+    return static_cast<int32_t>(random0 >> 8U);
+}
+
+__aicore__ inline uint64_t PhiloxRandom64(int64_t seed, int64_t position)
+{
+    uint32_t random0 = 0;
+    uint32_t random1 = 0;
+    PhiloxRandom(seed, position, random0, random1);
+    return (static_cast<uint64_t>(random1) << 32U) | static_cast<uint64_t>(random0);
+}
+
+__aicore__ inline uint64_t MulHigh64(uint64_t lhs, uint64_t rhs)
+{
+    const uint64_t lhsLow = static_cast<uint32_t>(lhs);
+    const uint64_t lhsHigh = lhs >> 32U;
+    const uint64_t rhsLow = static_cast<uint32_t>(rhs);
+    const uint64_t rhsHigh = rhs >> 32U;
+    const uint64_t lowProduct = lhsLow * rhsLow;
+    const uint64_t middle = lhsHigh * rhsLow + (lowProduct >> 32U);
+    const uint64_t middleLow = middle & 0xFFFFFFFFULL;
+    const uint64_t middleHigh = middle >> 32U;
+    const uint64_t upperMiddle = middleLow + lhsLow * rhsHigh;
+    return lhsHigh * rhsHigh + middleHigh + (upperMiddle >> 32U);
+}
+
+template <typename T>
+class CategoricalSampleKernel {
+public:
+    __aicore__ inline CategoricalSampleKernel() {}
+
+    __aicore__ inline void Init(
+        GM_ADDR processedLogits,
+        GM_ADDR expandedIdxMapping,
+        GM_ADDR temperature,
+        GM_ADDR seed,
+        GM_ADDR pos,
+        GM_ADDR logitsCache,
+        GM_ADDR logitsCacheCol,
+        GM_ADDR sampledTokenIds,
+        GM_ADDR lse,
+        CategoricalSampleTilingData* tilingData,
+        TPipe* pipe)
+    {
+        numRows_ = tilingData->numRows;
+        vocabSize_ = tilingData->vocabSize;
+        numRequests_ = tilingData->numRequests;
+        rowStride_ = tilingData->rowStride;
+        logitsCacheStride_ = tilingData->logitsCacheStride;
+        logitsCacheColStride_ = tilingData->logitsCacheColStride;
+        logitsCacheDtype_ = tilingData->logitsCacheDtype;
+        logitsCacheNumCols_ = tilingData->logitsCacheNumCols;
+        tileElements_ = tilingData->tileElements;
+        tileCount_ = tilingData->tileCount;
+        hasLogitsCache_ = tilingData->hasLogitsCache != 0;
+        hasLogitsCacheCol_ = tilingData->hasLogitsCacheCol != 0;
+        logitsCacheColPerToken_ = tilingData->logitsCacheColPerToken != 0;
+        applyTemperature_ = tilingData->applyTemperature != 0;
+        returnLse_ = tilingData->returnLse != 0;
+        useFp64_ = tilingData->useFp64 != 0;
+        pipe_ = pipe;
+
+        processedLogitsGm_.SetGlobalBuffer(
+            reinterpret_cast<__gm__ T*>(processedLogits), (numRows_ - 1) * rowStride_ + vocabSize_);
+        expandedIdxMappingGm_.SetGlobalBuffer(reinterpret_cast<__gm__ int32_t*>(expandedIdxMapping), numRows_);
+        temperatureGm_.SetGlobalBuffer(reinterpret_cast<__gm__ float*>(temperature), numRequests_);
+        seedGm_.SetGlobalBuffer(reinterpret_cast<__gm__ int64_t*>(seed), numRequests_);
+        posGm_.SetGlobalBuffer(reinterpret_cast<__gm__ int64_t*>(pos), numRows_);
+        logitsCacheGm_ = logitsCache;
+        if (hasLogitsCacheCol_) {
+            logitsCacheColGm_.SetGlobalBuffer(
+                reinterpret_cast<__gm__ int32_t*>(logitsCacheCol),
+                logitsCacheColPerToken_ ? numRows_ : 1);
+        }
+        sampledTokenIdsGm_.SetGlobalBuffer(reinterpret_cast<__gm__ int64_t*>(sampledTokenIds), numRows_);
+        if (returnLse_) {
+            lseGm_.SetGlobalBuffer(reinterpret_cast<__gm__ float*>(lse), numRows_);
+        }
+
+        pipe_->InitBuffer(inputQueue_, 1, tileElements_ * sizeof(T));
+        pipe_->InitBuffer(logitsFloatBuf_, tileElements_ * sizeof(float));
+        pipe_->InitBuffer(workBuf_, tileElements_ * sizeof(float));
+        pipe_->InitBuffer(nanValuesBuf_, tileElements_ * sizeof(float));
+        pipe_->InitBuffer(nanMaskBuf_, tileElements_ * sizeof(uint8_t));
+        pipe_->InitBuffer(scalarBuf_, 64);
+        pipe_->InitBuffer(scalarIntBuf_, 32);
+        pipe_->InitBuffer(tileSumsBuf_, AlignUpU32(tileCount_ * sizeof(float), 32));
+        pipe_->InitBuffer(tileMassesBuf_, AlignUpU32(tileCount_ * sizeof(uint64_t), 32));
+        pipe_->InitBuffer(sampledOutputBuf_, 32);
+        pipe_->InitBuffer(lseOutputBuf_, 32);
+    }
+
+    __aicore__ inline void Process()
+    {
+        const uint32_t coreIndex = GetBlockIdx();
+        const uint32_t coreCount = GetBlockNum();
+        for (uint32_t row = coreIndex; row < numRows_; row += coreCount) {
+            ProcessRow(row);
+        }
+    }
+
+private:
+    __aicore__ inline uint32_t TileLength(uint32_t tileIndex) const
+    {
+        const uint32_t tileOffset = tileIndex * tileElements_;
+        return MinU32(tileElements_, vocabSize_ - tileOffset);
+    }
+
+    __aicore__ inline uint32_t TileVectorLength(uint32_t tileIndex) const
+    {
+        return AlignUpU32(TileLength(tileIndex), VECTOR_ALIGNMENT_ELEMENTS);
+    }
+
+    template <typename CacheT>
+    __aicore__ inline void WriteLogitsCacheTileTyped(
+        LocalTensor<float> logitsFloat, uint32_t row, uint32_t tileIndex, uint32_t validElements)
+    {
+        if (!hasLogitsCache_) {
+            return;
+        }
+        const uint64_t cacheOffset = static_cast<uint64_t>(activeRequestIndex_) * logitsCacheStride_ +
+            static_cast<uint64_t>(activeLogitsCacheCol_) * logitsCacheColStride_ +
+            static_cast<uint64_t>(tileIndex) * tileElements_;
+        GlobalTensor<CacheT> cache;
+        cache.SetGlobalBuffer(reinterpret_cast<__gm__ CacheT*>(logitsCacheGm_));
+        LocalTensor<CacheT> values;
+        if constexpr (IsSameType<CacheT, float>::value) {
+            values = logitsFloat;
+        } else {
+            values = workBuf_.Get<CacheT>();
+            Cast(values, logitsFloat, RoundMode::CAST_RINT, AlignUpU32(validElements, VECTOR_ALIGNMENT_ELEMENTS));
+        }
+        PipeBarrier<PIPE_ALL>();
+        DataCopyPad(
+            cache[cacheOffset],
+            values,
+            DataCopyExtParams(1, validElements * static_cast<uint32_t>(sizeof(CacheT)), 0, 0, 0));
+        PipeBarrier<PIPE_ALL>();
+    }
+
+    __aicore__ inline LocalTensor<float> LoadTile(uint32_t row, uint32_t tileIndex, bool writeCache = false)
+    {
+        const uint32_t validElements = TileLength(tileIndex);
+        const uint32_t vectorElements = TileVectorLength(tileIndex);
+        const uint64_t gmOffset = static_cast<uint64_t>(row) * rowStride_ +
+            static_cast<uint64_t>(tileIndex) * tileElements_;
+        LocalTensor<T> inputLocal = inputQueue_.AllocTensor<T>();
+        DataCopyExtParams copyParams{1, validElements * static_cast<uint32_t>(sizeof(T)), 0, 0, 0};
+        DataCopyPadExtParams<T> padParams{false, 0, 0, static_cast<T>(0)};
+        DataCopyPad(inputLocal, processedLogitsGm_[gmOffset], copyParams, padParams);
+        inputQueue_.EnQue(inputLocal);
+        inputLocal = inputQueue_.DeQue<T>();
+
+        LocalTensor<float> logitsFloat = logitsFloatBuf_.Get<float>();
+        if constexpr (IsSameType<T, float>::value) {
+            Adds(logitsFloat, inputLocal, 0.0f, vectorElements);
+        } else {
+            Cast(logitsFloat, inputLocal, RoundMode::CAST_NONE, vectorElements);
+        }
+        inputQueue_.FreeTensor(inputLocal);
+        PipeBarrier<PIPE_V>();
+        if (writeCache) {
+            // Store raw logits before scaling; the rejection sampler applies temperature on load.
+            if (logitsCacheDtype_ == 0) {
+                WriteLogitsCacheTileTyped<float>(logitsFloat, row, tileIndex, validElements);
+            } else if (logitsCacheDtype_ == 1) {
+                WriteLogitsCacheTileTyped<half>(logitsFloat, row, tileIndex, validElements);
+            } else {
+                WriteLogitsCacheTileTyped<bfloat16_t>(logitsFloat, row, tileIndex, validElements);
+            }
+        }
+        if (applyTemperature_ && activeTemperature_ != 0.0f) {
+            LocalTensor<float> divisor = workBuf_.Get<float>();
+            Duplicate(divisor, activeTemperature_, vectorElements);
+            PipeBarrier<PIPE_V>();
+            Div(logitsFloat, logitsFloat, divisor, vectorElements);
+            PipeBarrier<PIPE_V>();
+        }
+        return logitsFloat;
+    }
+
+    __aicore__ inline LocalTensor<float> BuildNanIndicator(LocalTensor<float> logitsFloat, uint32_t vectorElements)
+    {
+        LocalTensor<float> nanValues = nanValuesBuf_.Get<float>();
+        LocalTensor<uint8_t> nanMask = nanMaskBuf_.Get<uint8_t>();
+        LocalTensor<int32_t> logitsBits = logitsFloat.ReinterpretCast<int32_t>();
+        LocalTensor<int32_t> workBits = workBuf_.Get<int32_t>();
+
+        Duplicate(workBits, FP32_EXP_MASK, vectorElements);
+        PipeBarrier<PIPE_V>();
+        // C220 implements Level-2 And with 16-bit lanes for compatibility.
+        And(workBits, logitsBits, workBits, static_cast<int32_t>(2 * vectorElements));
+        PipeBarrier<PIPE_V>();
+        Compares(nanMask, workBits, FP32_EXP_MASK, CMPMODE::EQ, vectorElements);
+        PipeBarrier<PIPE_V>();
+        Duplicate(nanValues, 1.0f, vectorElements);
+        PipeBarrier<PIPE_V>();
+        Select(nanValues, nanMask, nanValues, 0.0f, SELMODE::VSEL_TENSOR_SCALAR_MODE, vectorElements);
+
+        Duplicate(workBits, FP32_ABS_MASK, vectorElements);
+        PipeBarrier<PIPE_V>();
+        And(workBits, logitsBits, workBits, static_cast<int32_t>(2 * vectorElements));
+        PipeBarrier<PIPE_V>();
+        Compares(nanMask, workBits, FP32_EXP_MASK, CMPMODE::EQ, vectorElements);
+        PipeBarrier<PIPE_V>();
+        LocalTensor<float> infinityValues = workBuf_.Get<float>();
+        Duplicate(infinityValues, 1.0f, vectorElements);
+        PipeBarrier<PIPE_V>();
+        Select(infinityValues, nanMask, infinityValues, 0.0f, SELMODE::VSEL_TENSOR_SCALAR_MODE, vectorElements);
+        PipeBarrier<PIPE_V>();
+        Sub(nanValues, nanValues, infinityValues, vectorElements);
+        PipeBarrier<PIPE_V>();
+        return nanValues;
+    }
+
+    __aicore__ inline float TileMax(
+        uint32_t row, uint32_t tileIndex, bool needFirstMaxIndex, uint32_t& firstMaxIndex)
+    {
+        const uint32_t validElements = TileLength(tileIndex);
+        const uint32_t vectorElements = TileVectorLength(tileIndex);
+        LocalTensor<float> logitsFloat = LoadTile(row, tileIndex);
+        LocalTensor<float> work = workBuf_.Get<float>();
+        LocalTensor<float> nanValues = BuildNanIndicator(logitsFloat, vectorElements);
+        LocalTensor<float> scalar = scalarBuf_.Get<float>();
+
+        if (validElements != vectorElements) {
+            PipeVToS();
+            bool hasNan = false;
+            for (uint32_t index = 0; index < validElements; ++index) {
+                hasNan = hasNan || nanValues.GetValue(index) != 0.0f;
+            }
+            CATEGORICAL_SAMPLE_CHECK(!hasNan, "CategoricalSample processed logits must not contain NaN\n");
+            float tileMax = NEG_INFINITY;
+            for (uint32_t index = 0; index < validElements; ++index) {
+                const float value = logitsFloat.GetValue(index);
+                if (value > tileMax) {
+                    tileMax = value;
+                    firstMaxIndex = index;
+                }
+            }
+            return tileMax;
+        }
+
+        ReduceMax(scalar[8], nanValues, work, vectorElements);
+        PipeVToS();
+        CATEGORICAL_SAMPLE_CHECK(
+            scalar.GetValue(8) == 0.0f, "CategoricalSample processed logits must not contain NaN\n");
+        ReduceMax(scalar, logitsFloat, work, vectorElements);
+        PipeVToS();
+        const float tileMax = scalar.GetValue(0);
+        if (needFirstMaxIndex) {
+            for (uint32_t index = 0; index < validElements; ++index) {
+                if (logitsFloat.GetValue(index) == tileMax) {
+                    firstMaxIndex = index;
+                    break;
+                }
+            }
+        }
+        return tileMax;
+    }
+
+    __aicore__ inline float ComputeTileExpSum(
+        uint32_t row, uint32_t tileIndex, float rowMax, bool writeCache)
+    {
+        const uint32_t validElements = TileLength(tileIndex);
+        const uint32_t vectorElements = TileVectorLength(tileIndex);
+        LocalTensor<float> logitsFloat = LoadTile(row, tileIndex, writeCache);
+        LocalTensor<float> work = workBuf_.Get<float>();
+        LocalTensor<float> scalar = scalarBuf_.Get<float>();
+        Adds(logitsFloat, logitsFloat, -rowMax, vectorElements);
+        PipeBarrier<PIPE_V>();
+        Exp(logitsFloat, logitsFloat, vectorElements);
+        PipeBarrier<PIPE_V>();
+        if (validElements != vectorElements) {
+            PipeVToS();
+            float tileSum = 0.0f;
+            for (uint32_t index = 0; index < validElements; ++index) {
+                tileSum += logitsFloat.GetValue(index);
+            }
+            return tileSum;
+        }
+
+        ReduceSum(scalar, logitsFloat, work, vectorElements);
+        PipeVToS();
+        return scalar.GetValue(0);
+    }
+
+    __aicore__ inline float ComputeAllExpSums(uint32_t row, float rowMax, bool writeCache)
+    {
+        LocalTensor<float> tileSums = tileSumsBuf_.Get<float>();
+        float total = 0.0f;
+        for (uint32_t tile = 0; tile < tileCount_; ++tile) {
+            const float tileSum = ComputeTileExpSum(row, tile, rowMax, writeCache);
+            tileSums.SetValue(tile, tileSum);
+            total += tileSum;
+        }
+        return total;
+    }
+
+    __aicore__ inline uint64_t FloatToFixedMass(float value)
+    {
+        if (value <= 0.0f) {
+            return 0;
+        }
+        LocalTensor<float> scalar = scalarBuf_.Get<float>();
+        scalar.SetValue(0, value);
+        const uint32_t bits = scalar.ReinterpretCast<uint32_t>().GetValue(0);
+        const uint32_t exponent = (bits >> 23U) & 0xFFU;
+        const uint64_t mantissa = exponent == 0 ? (bits & 0x7FFFFFU) : ((bits & 0x7FFFFFU) | 0x800000U);
+        const int32_t binaryExponent = exponent == 0 ? -149 : static_cast<int32_t>(exponent) - 150;
+        const int32_t shift = binaryExponent + FP64_WEIGHT_FRACTION_BITS;
+        if (shift >= 0) {
+            return mantissa << static_cast<uint32_t>(shift);
+        }
+        const uint32_t rightShift = static_cast<uint32_t>(-shift);
+        if (rightShift >= 64U) {
+            return 0;
+        }
+        return (mantissa + (1ULL << (rightShift - 1U))) >> rightShift;
+    }
+
+    __aicore__ inline uint64_t ComputeTileFixedMass(
+        uint32_t row, uint32_t tileIndex, float rowMax, bool writeCache)
+    {
+        const uint32_t validElements = TileLength(tileIndex);
+        const uint32_t vectorElements = TileVectorLength(tileIndex);
+        LocalTensor<float> logitsFloat = LoadTile(row, tileIndex, writeCache);
+        Adds(logitsFloat, logitsFloat, -rowMax, vectorElements);
+        PipeBarrier<PIPE_V>();
+        Exp(logitsFloat, logitsFloat, vectorElements);
+        PipeVToS();
+
+        uint64_t tileMass = 0;
+        for (uint32_t index = 0; index < validElements; ++index) {
+            tileMass += FloatToFixedMass(logitsFloat.GetValue(index));
+        }
+        return tileMass;
+    }
+
+    __aicore__ inline uint64_t ComputeAllFixedMasses(uint32_t row, float rowMax, bool writeCache)
+    {
+        LocalTensor<uint64_t> tileMasses = tileMassesBuf_.Get<uint64_t>();
+        uint64_t totalMass = 0;
+        for (uint32_t tile = 0; tile < tileCount_; ++tile) {
+            const uint64_t tileMass = ComputeTileFixedMass(row, tile, rowMax, writeCache);
+            tileMasses.SetValue(tile, tileMass);
+            totalMass += tileMass;
+        }
+        return totalMass;
+    }
+
+    __aicore__ inline float ComputeLse(float rowMax, float expSum)
+    {
+        LocalTensor<float> scalar = scalarBuf_.Get<float>();
+        scalar.SetValue(0, expSum);
+        PipeSToV();
+        Ln(scalar, scalar, 1);
+        PipeVToS();
+        return rowMax + scalar.GetValue(0);
+    }
+
+    __aicore__ inline float IntToFloat(int32_t value)
+    {
+        LocalTensor<float> scalar = scalarBuf_.Get<float>();
+        LocalTensor<int32_t> scalarInt = scalarIntBuf_.Get<int32_t>();
+        scalarInt.SetValue(0, value);
+        PipeSToV();
+        Cast(scalar, scalarInt, RoundMode::CAST_NONE, 1);
+        PipeVToS();
+        return scalar.GetValue(0);
+    }
+
+    __aicore__ inline float Uniform(int64_t seed, int64_t position)
+    {
+        LocalTensor<float> scalar = scalarBuf_.Get<float>();
+        LocalTensor<int32_t> scalarInt = scalarIntBuf_.Get<int32_t>();
+        scalarInt.SetValue(0, PhiloxRandom24(seed, position));
+        PipeSToV();
+        Cast(scalar, scalarInt, RoundMode::CAST_NONE, 1);
+        PipeBarrier<PIPE_V>();
+        Adds(scalar, scalar, 0.5f, 1);
+        PipeBarrier<PIPE_V>();
+        Muls(scalar, scalar, UINT24_TO_UNIT, 1);
+        PipeVToS();
+        return scalar.GetValue(0);
+    }
+
+    __aicore__ inline int64_t SelectCategorical(uint32_t row, float rowMax, float uniform, float total)
+    {
+        LocalTensor<float> tileSums = tileSumsBuf_.Get<float>();
+        const float target = uniform * total;
+        float prefix = 0.0f;
+        uint32_t selectedTile = tileCount_ - 1;
+        for (uint32_t tile = 0; tile < tileCount_; ++tile) {
+            const float nextPrefix = prefix + tileSums.GetValue(tile);
+            if (target <= nextPrefix || tile + 1 == tileCount_) {
+                selectedTile = tile;
+                break;
+            }
+            prefix = nextPrefix;
+        }
+
+        const uint32_t validElements = TileLength(selectedTile);
+        const uint32_t vectorElements = TileVectorLength(selectedTile);
+        LocalTensor<float> logitsFloat = LoadTile(row, selectedTile);
+        Adds(logitsFloat, logitsFloat, -rowMax, vectorElements);
+        PipeBarrier<PIPE_V>();
+        Exp(logitsFloat, logitsFloat, vectorElements);
+        PipeVToS();
+
+        float cumulative = prefix;
+        int64_t fallback = static_cast<int64_t>(selectedTile) * tileElements_;
+        for (uint32_t index = 0; index < validElements; ++index) {
+            const float weight = logitsFloat.GetValue(index);
+            if (weight > 0.0f) {
+                fallback = static_cast<int64_t>(selectedTile) * tileElements_ + index;
+            }
+            cumulative += weight;
+            if (cumulative >= target) {
+                return static_cast<int64_t>(selectedTile) * tileElements_ + index;
+            }
+        }
+        return fallback;
+    }
+
+    __aicore__ inline int64_t SelectCategoricalFp64(
+        uint32_t row, float rowMax, uint64_t random, uint64_t totalMass)
+    {
+        LocalTensor<uint64_t> tileMasses = tileMassesBuf_.Get<uint64_t>();
+        const uint64_t target = MulHigh64(random, totalMass);
+        uint64_t prefix = 0;
+        uint32_t selectedTile = tileCount_ - 1;
+        for (uint32_t tile = 0; tile < tileCount_; ++tile) {
+            const uint64_t nextPrefix = prefix + tileMasses.GetValue(tile);
+            if (target < nextPrefix || tile + 1 == tileCount_) {
+                selectedTile = tile;
+                break;
+            }
+            prefix = nextPrefix;
+        }
+
+        const uint32_t validElements = TileLength(selectedTile);
+        const uint32_t vectorElements = TileVectorLength(selectedTile);
+        LocalTensor<float> logitsFloat = LoadTile(row, selectedTile);
+        Adds(logitsFloat, logitsFloat, -rowMax, vectorElements);
+        PipeBarrier<PIPE_V>();
+        Exp(logitsFloat, logitsFloat, vectorElements);
+        PipeVToS();
+
+        uint64_t cumulative = prefix;
+        int64_t fallback = static_cast<int64_t>(selectedTile) * tileElements_;
+        for (uint32_t index = 0; index < validElements; ++index) {
+            const uint64_t mass = FloatToFixedMass(logitsFloat.GetValue(index));
+            if (mass > 0) {
+                fallback = static_cast<int64_t>(selectedTile) * tileElements_ + index;
+            }
+            cumulative += mass;
+            if (cumulative > target) {
+                return static_cast<int64_t>(selectedTile) * tileElements_ + index;
+            }
+        }
+        return fallback;
+    }
+
+    __aicore__ inline int32_t CountPositiveInfinity(uint32_t row, int64_t& firstIndex, bool writeCache)
+    {
+        int32_t count = 0;
+        firstIndex = 0;
+        bool foundFirst = false;
+        for (uint32_t tile = 0; tile < tileCount_; ++tile) {
+            const uint32_t validElements = TileLength(tile);
+            const uint32_t vectorElements = TileVectorLength(tile);
+            LocalTensor<float> logitsFloat = LoadTile(row, tile, writeCache);
+            PipeVToS();
+            for (uint32_t index = 0; index < validElements; ++index) {
+                if (logitsFloat.GetValue(index) == POS_INFINITY) {
+                    if (!foundFirst) {
+                        firstIndex = static_cast<int64_t>(tile) * tileElements_ + index;
+                        foundFirst = true;
+                    }
+                    ++count;
+                }
+            }
+        }
+        return count;
+    }
+
+    __aicore__ inline int64_t SelectPositiveInfinity(uint32_t row, float rank)
+    {
+        for (uint32_t tile = 0; tile < tileCount_; ++tile) {
+            const uint32_t validElements = TileLength(tile);
+            const uint32_t vectorElements = TileVectorLength(tile);
+            LocalTensor<float> logitsFloat = LoadTile(row, tile);
+            PipeVToS();
+            for (uint32_t index = 0; index < validElements; ++index) {
+                if (logitsFloat.GetValue(index) == POS_INFINITY) {
+                    if (rank < 1.0f) {
+                        return static_cast<int64_t>(tile) * tileElements_ + index;
+                    }
+                    rank -= 1.0f;
+                }
+            }
+        }
+        return 0;
+    }
+
+    __aicore__ inline int64_t SelectPositiveInfinityFp64(uint32_t row, uint64_t rank)
+    {
+        for (uint32_t tile = 0; tile < tileCount_; ++tile) {
+            const uint32_t validElements = TileLength(tile);
+            const uint32_t vectorElements = TileVectorLength(tile);
+            LocalTensor<float> logitsFloat = LoadTile(row, tile);
+            PipeVToS();
+            for (uint32_t index = 0; index < validElements; ++index) {
+                if (logitsFloat.GetValue(index) == POS_INFINITY) {
+                    if (rank == 0) {
+                        return static_cast<int64_t>(tile) * tileElements_ + index;
+                    }
+                    --rank;
+                }
+            }
+        }
+        return 0;
+    }
+
+    __aicore__ inline void WriteProcessedLogitsRow(uint32_t row)
+    {
+        if (!hasLogitsCache_) {
+            return;
+        }
+        for (uint32_t tile = 0; tile < tileCount_; ++tile) {
+            LoadTile(row, tile, true);
+        }
+    }
+
+    __aicore__ inline void WriteRow(uint32_t row, int64_t sampledIndex, float lseValue)
+    {
+        LocalTensor<int64_t> sampledOutput = sampledOutputBuf_.Get<int64_t>();
+        LocalTensor<float> lseOutput = lseOutputBuf_.Get<float>();
+        sampledOutput.SetValue(0, sampledIndex);
+        if (returnLse_) {
+            lseOutput.SetValue(0, lseValue);
+        }
+
+        PipeBarrier<PIPE_ALL>();
+        DataCopyPad(sampledTokenIdsGm_[row], sampledOutput, DataCopyExtParams(1, sizeof(int64_t), 0, 0, 0));
+        if (returnLse_) {
+            DataCopyPad(lseGm_[row], lseOutput, DataCopyExtParams(1, sizeof(float), 0, 0, 0));
+        }
+        PipeBarrier<PIPE_ALL>();
+    }
+
+    __aicore__ inline void WritePaddingRow(uint32_t row)
+    {
+        WriteRow(row, 0, 0.0f);
+    }
+
+    __aicore__ inline void ProcessRow(uint32_t row)
+    {
+        const int32_t requestIndex = expandedIdxMappingGm_.GetValue(row);
+        if (requestIndex == -1) {
+            WritePaddingRow(row);
+            return;
+        }
+        CATEGORICAL_SAMPLE_CHECK(
+            requestIndex >= 0 && static_cast<uint32_t>(requestIndex) < numRequests_,
+            "CategoricalSample expanded index mapping is outside request state\n");
+
+        activeRequestIndex_ = static_cast<uint32_t>(requestIndex);
+        activeLogitsCacheCol_ = 0;
+        if (hasLogitsCacheCol_) {
+            activeLogitsCacheCol_ =
+                logitsCacheColGm_.GetValue(logitsCacheColPerToken_ ? row : 0);
+        }
+        CATEGORICAL_SAMPLE_CHECK(
+            !hasLogitsCache_ ||
+                (activeLogitsCacheCol_ >= 0 &&
+                 static_cast<uint32_t>(activeLogitsCacheCol_) < logitsCacheNumCols_),
+            "CategoricalSample output processed logits column is outside cache bounds\n");
+        activeTemperature_ = temperatureGm_.GetValue(requestIndex);
+        const bool isGreedy = activeTemperature_ == 0.0f;
+        float rowMax = NEG_INFINITY;
+        int64_t firstMaxIndex = 0;
+        for (uint32_t tile = 0; tile < tileCount_; ++tile) {
+            uint32_t tileFirstMaxIndex = 0;
+            const float tileMax = TileMax(row, tile, isGreedy, tileFirstMaxIndex);
+            if (tileMax > rowMax) {
+                rowMax = tileMax;
+                firstMaxIndex = static_cast<int64_t>(tile) * tileElements_ + tileFirstMaxIndex;
+            }
+        }
+        CATEGORICAL_SAMPLE_CHECK(
+            rowMax != NEG_INFINITY, "CategoricalSample processed logits row must not be all -inf\n");
+
+        if (rowMax == POS_INFINITY) {
+            int64_t firstIndex = 0;
+            const int32_t infCount = CountPositiveInfinity(row, firstIndex, hasLogitsCache_);
+            int64_t sampledIndex = firstIndex;
+            if (!isGreedy) {
+                if (useFp64_) {
+                    const uint64_t random = PhiloxRandom64(seedGm_.GetValue(requestIndex), posGm_.GetValue(row));
+                    const uint64_t rank = MulHigh64(random, static_cast<uint64_t>(infCount));
+                    sampledIndex = SelectPositiveInfinityFp64(row, rank);
+                } else {
+                    const float uniform = Uniform(seedGm_.GetValue(requestIndex), posGm_.GetValue(row));
+                    const float rank = uniform * IntToFloat(infCount);
+                    sampledIndex = SelectPositiveInfinity(row, rank);
+                }
+            }
+            WriteRow(row, sampledIndex, POS_INFINITY);
+            return;
+        }
+
+        int64_t sampledIndex = 0;
+        float expSum = 0.0f;
+        if (isGreedy) {
+            sampledIndex = firstMaxIndex;
+            if (returnLse_) {
+                expSum = ComputeAllExpSums(row, rowMax, hasLogitsCache_);
+            } else {
+                WriteProcessedLogitsRow(row);
+            }
+        } else if (useFp64_) {
+            if (returnLse_) {
+                expSum = ComputeAllExpSums(row, rowMax, hasLogitsCache_);
+            }
+            const uint64_t totalMass =
+                ComputeAllFixedMasses(row, rowMax, hasLogitsCache_ && !returnLse_);
+            const uint64_t random = PhiloxRandom64(seedGm_.GetValue(requestIndex), posGm_.GetValue(row));
+            sampledIndex = SelectCategoricalFp64(row, rowMax, random, totalMass);
+        } else {
+            expSum = ComputeAllExpSums(row, rowMax, hasLogitsCache_);
+            const float uniform = Uniform(seedGm_.GetValue(requestIndex), posGm_.GetValue(row));
+            sampledIndex = SelectCategorical(row, rowMax, uniform, expSum);
+        }
+
+        const float lseValue = returnLse_ ? ComputeLse(rowMax, expSum) : 0.0f;
+        WriteRow(row, sampledIndex, lseValue);
+    }
+
+private:
+    TPipe* pipe_ = nullptr;
+    TQue<QuePosition::VECIN, 1> inputQueue_;
+    TBuf<QuePosition::VECCALC> logitsFloatBuf_;
+    TBuf<QuePosition::VECCALC> workBuf_;
+    TBuf<QuePosition::VECCALC> nanValuesBuf_;
+    TBuf<QuePosition::VECCALC> nanMaskBuf_;
+    TBuf<QuePosition::VECCALC> scalarBuf_;
+    TBuf<QuePosition::VECCALC> scalarIntBuf_;
+    TBuf<QuePosition::VECCALC> tileSumsBuf_;
+    TBuf<QuePosition::VECCALC> tileMassesBuf_;
+    TBuf<QuePosition::VECCALC> sampledOutputBuf_;
+    TBuf<QuePosition::VECCALC> lseOutputBuf_;
+
+    GlobalTensor<T> processedLogitsGm_;
+    GlobalTensor<int32_t> expandedIdxMappingGm_;
+    GlobalTensor<float> temperatureGm_;
+    GlobalTensor<int64_t> seedGm_;
+    GlobalTensor<int64_t> posGm_;
+    GM_ADDR logitsCacheGm_ = nullptr;
+    GlobalTensor<int32_t> logitsCacheColGm_;
+    GlobalTensor<int64_t> sampledTokenIdsGm_;
+    GlobalTensor<float> lseGm_;
+
+    uint32_t numRows_ = 0;
+    uint32_t vocabSize_ = 0;
+    uint32_t numRequests_ = 0;
+    uint32_t rowStride_ = 0;
+    uint32_t logitsCacheStride_ = 0;
+    uint32_t logitsCacheColStride_ = 0;
+    uint32_t logitsCacheDtype_ = 0;
+    uint32_t logitsCacheNumCols_ = 0;
+    uint32_t tileElements_ = 0;
+    uint32_t tileCount_ = 0;
+    uint32_t activeRequestIndex_ = 0;
+    int32_t activeLogitsCacheCol_ = 0;
+    float activeTemperature_ = 1.0f;
+    bool hasLogitsCache_ = false;
+    bool hasLogitsCacheCol_ = false;
+    bool logitsCacheColPerToken_ = false;
+    bool applyTemperature_ = false;
+    bool returnLse_ = false;
+    bool useFp64_ = false;
+};
+}  // namespace CategoricalSample
+
+#endif

--- a/csrc/torch_binding.cpp
+++ b/csrc/torch_binding.cpp
@@ -59,6 +59,7 @@
 #include "moe/dequant_situ_quant/dequant_situ_quant_torch_adpt.h"
 #include "moe/situ_mx_quant/situ_mx_quant_torch_adpt.h"
 #include "attention/mla_prolog_v3/mla_prolog_v3_torch_adpt.h"
+#include "sampling/categorical_sample/categorical_sample_torch_adpt.h"
 #include <c10/core/Device.h>
 #include <c10/core/Scalar.h>
 #include <c10/util/Exception.h>
@@ -3116,6 +3117,15 @@ TORCH_LIBRARY_EXPAND(CONCAT(_C, _ascend), ops)
         " -> (Tensor y, Tensor y_fp32)"
     );
     ops.impl("npu_rms_norm_cast", torch::kPrivateUse1, &vllm_ascend::npu_rms_norm_cast);
+
+    ops.def(
+        "npu_categorical_sample("
+        "Tensor processed_logits, Tensor expanded_idx_mapping, Tensor temperature, Tensor seed, Tensor pos, "
+        "bool return_lse=False, bool apply_temperature=False, "
+        "Tensor(a!)? logits_cache=None, Tensor? logits_cache_col=None, bool use_fp64=False"
+        ") -> (Tensor sampled_token_ids, Tensor lse)"
+    );
+    ops.impl("npu_categorical_sample", torch::kPrivateUse1, &vllm_ascend::npu_categorical_sample);
 
     ops.def("npu_sign_bits_pack(Tensor input, int size) -> Tensor");
     ops.impl("npu_sign_bits_pack", torch::kPrivateUse1, &vllm_ascend::npu_sign_bits_pack);

--- a/csrc/torch_binding_meta.cpp
+++ b/csrc/torch_binding_meta.cpp
@@ -528,6 +528,35 @@ std::tuple<at::Tensor, at::Tensor> npu_rms_norm_cast_meta(
     return {y, y_fp32};
 }
 
+std::tuple<at::Tensor, at::Tensor> npu_categorical_sample_meta(
+    const at::Tensor& processed_logits,
+    const at::Tensor& expanded_idx_mapping,
+    const at::Tensor& temperature,
+    const at::Tensor& seed,
+    const at::Tensor& pos,
+    bool return_lse,
+    bool apply_temperature,
+    const c10::optional<at::Tensor>& logits_cache,
+    const c10::optional<at::Tensor>& logits_cache_col,
+    bool use_fp64)
+{
+    (void)apply_temperature;
+    (void)logits_cache;
+    (void)logits_cache_col;
+    (void)use_fp64;
+    TORCH_CHECK(processed_logits.dim() == 2, "processed_logits must be 2D");
+    TORCH_CHECK(expanded_idx_mapping.dim() == 1, "expanded_idx_mapping must be 1D");
+    TORCH_CHECK(temperature.dim() == 1, "temperature must be 1D");
+    TORCH_CHECK(seed.dim() == 1, "seed must be 1D");
+    TORCH_CHECK(pos.dim() == 1, "pos must be 1D");
+    auto numRows = processed_logits.sym_size(0);
+    c10::SymDimVector rowShape = {numRows};
+    c10::SymDimVector lseShape = {return_lse ? numRows : c10::SymInt(0)};
+    at::Tensor sampledTokenIds = at::empty_symint(rowShape, processed_logits.options().dtype(at::kLong));
+    at::Tensor lse = at::empty_symint(lseShape, processed_logits.options().dtype(at::kFloat));
+    return std::make_tuple(sampledTokenIds, lse);
+}
+
 at::Tensor npu_sign_bits_pack_meta(const at::Tensor& input,
                                    const int64_t size) {
     auto ySize = ceil_div(input.sym_size(0), 8);
@@ -2121,6 +2150,7 @@ TORCH_LIBRARY_IMPL_EXPAND(CONCAT(_C, _ascend), Meta, ops) {
     // Add_Rms_Norm_Bias
     ops.impl("npu_add_rms_norm_bias", &vllm_ascend::meta::npu_add_rms_norm_bias_meta);
     ops.impl("npu_rms_norm_cast", &vllm_ascend::meta::npu_rms_norm_cast_meta);
+    ops.impl("npu_categorical_sample", &vllm_ascend::meta::npu_categorical_sample_meta);
     // transpose_kv_cache_by_block
     ops.impl("transpose_kv_cache_by_block", &vllm_ascend::meta::transpose_kv_cache_by_block_meta);
     // npu_sign_bits_pack

--- a/docs/source/developer_guide/Design_Documents/categorical_sampling.md
+++ b/docs/source/developer_guide/Design_Documents/categorical_sampling.md
@@ -11,7 +11,7 @@ The integration supports the `logits_cache` contract used by both the verified v
 The sampling path has four layers with distinct ownership:
 
 1. The MRV2 sampler and speculators own processed logits, request mappings, temperatures, seeds, positions, and optional logits cache storage.
-2. The Python wrapper preserves the upstream release contract, normalizes only non-strided metadata, and dispatches the native operator.
+2. The Python wrapper preserves the upstream release contract, normalizes metadata layout and index dtypes, and dispatches the native operator.
 3. The Torch binding and host tiling validate static tensor and platform properties and create the launch description.
 4. AscendC validates row data, performs greedy or categorical selection, writes the optional cache, and returns sampled token IDs.
 

--- a/docs/source/developer_guide/Design_Documents/categorical_sampling.md
+++ b/docs/source/developer_guide/Design_Documents/categorical_sampling.md
@@ -1,6 +1,6 @@
 # MRV2 categorical sampling on Ascend
 
-NPU Model Runner V2 uses an AscendC categorical operator for ordinary random sampling. The operator preserves the sampler's request-level seed and position model while avoiding a full-vocabulary random tensor and per-token host synchronization.
+NPU Model Runner V2 uses an AscendC categorical operator for ordinary random sampling. The operator preserves the sampler's request-level seed and position model and replaces per-vocabulary Gumbel noise generation with a row-local random draw. Like the existing Triton path, normal execution requires no per-token host synchronization.
 
 This page describes the first integration stage and its contributor-facing contracts. The broader design in [RFC #14130](https://github.com/vllm-project/vllm-ascend/issues/14130) also proposes routing speculative rejection resampling through this operator in a follow-up change.
 
@@ -32,7 +32,7 @@ Each logits row maps to request state through `expanded_idx_mapping`. A mapping 
 
 Temperature zero is the greedy sentinel and selects the first maximum. For a nonzero temperature, the operator optionally applies temperature scaling, finds the row maximum, computes stable weights `exp(logit - max)`, and selects the first token whose cumulative weight crosses a stateless uniform draw. Logits may be FP16, BF16, or FP32; reductions use FP32, while the optional cache retains its supplied dtype.
 
-The default path uses a 32-bit random draw and FP32 weight accumulation. `use_fp64=True` selects a higher-precision path based on a 64-bit Philox-derived draw and 64-bit fixed-point masses. It does not change input or output dtypes and does not imply FP64 vector arithmetic on the NPU. The purpose of this mode is to preserve tail resolution for precision-sensitive categorical distributions.
+The default path uses a Philox-derived FP32 uniform draw and FP32 weight accumulation. `use_fp64=True` selects a higher-precision path based on a 64-bit Philox-derived draw and 64-bit fixed-point masses. It does not change input or output dtypes and does not imply FP64 vector arithmetic on the NPU. The purpose of this mode is to preserve tail resolution for precision-sensitive categorical distributions.
 
 Ordinary MRV2 sampling invokes the wrapper after logits processing. Speculators use the same wrapper when producing draft tokens and may write request-indexed raw logits into a two-dimensional cache or into a selected scalar/per-token column of a three-dimensional cache. Rejection and bonus-token resampling remain in the existing Ascend rejection-sampler implementation and do not call this operator in this integration stage.
 
@@ -60,7 +60,7 @@ The implementation preserves these layout rules:
 - The logits cache is FP16, BF16, or FP32 and has shape `[requests, vocab]` or `[requests, columns, vocab]`.
 - The supported vocabulary range is from 1 through 1,048,576 entries.
 
-The Python wrapper makes the expanded mapping, logical positions, and optional cache-column metadata contiguous. Positions are normalized to int64 for the native operator; drafting applies the upstream position salt. Cache columns use their actual stride, and a cache vocabulary dimension wider than the sampled logits is supported. It does not silently copy or cast logits, temperature, seed, or cache tensors.
+The Python wrapper makes the expanded mapping, logical positions, and optional cache-column metadata contiguous. Mappings are normalized to int32 and positions to int64 for the native operator; drafting applies the upstream position salt. Cache columns use their actual stride, and a cache vocabulary dimension wider than the sampled logits is supported. It does not silently copy or cast logits, temperature, seed, or cache tensors.
 
 ## Hardware registration
 

--- a/docs/source/developer_guide/Design_Documents/categorical_sampling.md
+++ b/docs/source/developer_guide/Design_Documents/categorical_sampling.md
@@ -1,6 +1,6 @@
 # MRV2 categorical sampling on Ascend
 
-NPU Model Runner V2 uses an AscendC categorical operator for ordinary random sampling. The operator preserves the sampler's request-level seed and position model while avoiding a full-vocabulary random tensor, host synchronization, and per-token host synchronization.
+NPU Model Runner V2 uses an AscendC categorical operator for ordinary random sampling. The operator preserves the sampler's request-level seed and position model while avoiding a full-vocabulary random tensor and per-token host synchronization.
 
 This page describes the first integration stage and its contributor-facing contracts. The broader design in [RFC #14130](https://github.com/vllm-project/vllm-ascend/issues/14130) also proposes routing speculative rejection resampling through this operator in a follow-up change.
 

--- a/docs/source/developer_guide/Design_Documents/categorical_sampling.md
+++ b/docs/source/developer_guide/Design_Documents/categorical_sampling.md
@@ -1,0 +1,89 @@
+# MRV2 categorical sampling on Ascend
+
+NPU Model Runner V2 uses an AscendC categorical operator for ordinary random sampling. The operator preserves the sampler's request-level seed and position model while avoiding a full-vocabulary random tensor, host synchronization, and per-token host synchronization.
+
+This page describes the first integration stage and its contributor-facing contracts. The broader design in [RFC #14130](https://github.com/vllm-project/vllm-ascend/issues/14130) also proposes routing speculative rejection resampling through this operator in a follow-up change.
+
+The integration supports the `logits_cache` contract used by both the verified vLLM main revision and v0.28.0. The cache stores logits before temperature scaling in its supplied FP16, BF16, or FP32 dtype. The rejection sampler applies temperature when reading this cache.
+
+## Mental model
+
+The sampling path has four layers with distinct ownership:
+
+1. The MRV2 sampler and speculators own processed logits, request mappings, temperatures, seeds, positions, and optional logits cache storage.
+2. The Python wrapper preserves the upstream release contract, normalizes only non-strided metadata, and dispatches the native operator.
+3. The Torch binding and host tiling validate static tensor and platform properties and create the launch description.
+4. AscendC validates row data, performs greedy or categorical selection, writes the optional cache, and returns sampled token IDs.
+
+The operator samples a categorical distribution directly from stable exponential weights. It does not materialize Gumbel noise for every vocabulary entry, and its random state is derived only from the mapped request seed and the row's logical position.
+
+```mermaid
+flowchart LR
+    A["MRV2 sampler or speculator"] --> B["Upstream-compatible Python wrapper"]
+    B --> C["Torch binding and ACLNN host tiling"]
+    C --> D["AscendC row sampler"]
+    D --> E["Sampled token IDs"]
+    D --> F["Optional logits cache"]
+```
+
+## Sampling flow
+
+Each logits row maps to request state through `expanded_idx_mapping`. A mapping value of `-1` denotes an ACLGraph padding row: it returns token `0` and does not read request metadata, consume random state, or write the cache. Every other mapping must address valid temperature and seed state.
+
+Temperature zero is the greedy sentinel and selects the first maximum. For a nonzero temperature, the operator optionally applies temperature scaling, finds the row maximum, computes stable weights `exp(logit - max)`, and selects the first token whose cumulative weight crosses a stateless uniform draw. Logits may be FP16, BF16, or FP32; reductions use FP32, while the optional cache retains its supplied dtype.
+
+The default path uses a 32-bit random draw and FP32 weight accumulation. `use_fp64=True` selects a higher-precision path based on a 64-bit Philox-derived draw and 64-bit fixed-point masses. It does not change input or output dtypes and does not imply FP64 vector arithmetic on the NPU. The purpose of this mode is to preserve tail resolution for precision-sensitive categorical distributions.
+
+Ordinary MRV2 sampling invokes the wrapper after logits processing. Speculators use the same wrapper when producing draft tokens and may write request-indexed raw logits into a two-dimensional cache or into a selected scalar/per-token column of a three-dimensional cache. Rejection and bonus-token resampling remain in the existing Ascend rejection-sampler implementation and do not call this operator in this integration stage.
+
+## Validation and exceptional values
+
+Validation is split according to where information is available:
+
+- The Torch binding checks devices, dtypes, ranks, shapes, contiguous vocabulary dimensions, supported strides, and cache layout.
+- Host tiling independently validates static shapes, attributes, dtype selection, vocabulary bounds, and available vector cores.
+- AscendC checks data-dependent request mappings, cache columns, NaNs, and rows containing only negative infinity before externally visible row writes.
+
+Positive infinity is valid. A categorical row containing positive infinities samples uniformly among those positions; a greedy row selects the first positive infinity. Its log-sum-exp result is positive infinity. Padding rows are not inspected, so padding storage may contain otherwise invalid logits.
+
+Device-side failures use a static diagnostic followed by a trap. This keeps eager and ACLGraph behavior aligned and avoids diagnostic output tensors or a normal-path device-to-host synchronization.
+
+## Layout and size constraints
+
+The implementation preserves these layout rules:
+
+- The vocabulary dimension is contiguous.
+- A normal row stride is at least the vocabulary size; a zero row stride is accepted for broadcast logits.
+- Arbitrary overlapping nonzero row layouts are rejected.
+- Mapping and position tensors contain one value per logits row.
+- Optional cache columns are selected by one scalar `int32` value or one `int32` value per row.
+- The logits cache is FP16, BF16, or FP32 and has shape `[requests, vocab]` or `[requests, columns, vocab]`.
+- The supported vocabulary range is from 1 through 1,048,576 entries.
+
+The Python wrapper makes the expanded mapping, logical positions, and optional cache-column metadata contiguous. Positions are normalized to int64 for the native operator; drafting applies the upstream position salt. Cache columns use their actual stride, and a cache vocabulary dimension wider than the sampled logits is supported. It does not silently copy or cast logits, temperature, seed, or cache tensors.
+
+## Hardware registration
+
+A2 and A3 register the operator through the general custom-operator initialization path. A5 keeps the global custom-operator gate disabled because unrelated operator coverage is incomplete, but loads this ACLNN operator from the packaged custom OPP library and registers the same Torch schema. When `enable_categorical_sample_op()` reports the operator unavailable, the wrapper falls back to the existing Ascend Triton sampler with the same logits-cache contract. Native execution errors are propagated rather than caught and retried.
+
+All three device generations share the operator schema, kernel behavior, and mandatory correctness suite. Their build and loading paths remain localized so platform-specific initialization does not leak into the sampling algorithm.
+
+## Invariants and current limits
+
+Changes to this path must preserve these invariants:
+
+1. A request's sample depends on its logits, mapped temperature and seed, and logical position, not unrelated batch rows or ACLGraph padding.
+2. Greedy and padding rows do not advance mutable random state.
+3. Invalid row data fails before sampled-token, LSE, or cache writes for that row.
+4. The production path contains no host `.item()`, full-vocabulary random tensor, or exception-driven algorithm fallback.
+5. A2, A3, and A5 expose the same public behavior despite different registration paths.
+
+FP64 speculative rejection resampling is outside this integration stage and remains unsupported by the existing Ascend rejection sampler. Non-FP64 rejection resampling continues to use its existing Triton implementation.
+
+## Extension and debugging anchors
+
+When changing the upstream sampler contract, update the Python wrapper, cache semantics, native schema, and cross-version tests together. Cache writes must remain before temperature scaling, and cache dtype and strides must be preserved.
+
+For registration failures, first distinguish the A2/A3 general initializer from the A5 packaged custom OPP path, then verify that the native extension, operator package, and Torch schema come from the same build. For numerical errors, separate logits processing, request mapping, random key construction, and categorical selection before comparing distributions.
+
+Repository test placement and CI registration rules are documented in the [testing guide](../contribution/testing.md). General ACLNN operator construction is documented in [Adding a custom aclnn operation](add_custom_aclnn_op.md).

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -338,6 +338,7 @@ nav:
         - developer_guide/Design_Documents/ACL_Graph.md
         - developer_guide/Design_Documents/KV_Cache_Pool_Guide.md
         - developer_guide/Design_Documents/add_custom_aclnn_op.md
+        - developer_guide/Design_Documents/categorical_sampling.md
         - developer_guide/Design_Documents/context_parallel.md
         - developer_guide/Design_Documents/balance_schedule_refactor.md
         - developer_guide/Design_Documents/dynamic_chunked_pipeline_parallel.md

--- a/tests/e2e/pull_request/one_card/model_runner_v2/test_categorical_sampling.py
+++ b/tests/e2e/pull_request/one_card/model_runner_v2/test_categorical_sampling.py
@@ -1,0 +1,47 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+#
+# Copyright (c) 2026 Huawei Technologies Co., Ltd. All Rights Reserved.
+
+import os
+from unittest.mock import patch
+
+import pytest
+from vllm import SamplingParams
+
+from tests.e2e.conftest import VllmRunner
+
+MODEL = "Qwen/Qwen3-0.6B"
+
+
+@pytest.mark.e2e_model(MODEL)
+@pytest.mark.e2e_coverage(
+    arch="dense",
+    feature="",
+    parallel="",
+    deploy="pd_mix",
+    hardware="",
+    quantization="BF16",
+    graph_mode="eager",
+)
+@patch.dict(os.environ, {"VLLM_USE_V2_MODEL_RUNNER": "1"})
+def test_model_runner_v2_random_sampling() -> None:
+    sampling_params = SamplingParams(
+        temperature=0.7,
+        seed=17,
+        max_tokens=8,
+        ignore_eos=True,
+    )
+    prompts = ["The capital of France is", "A short story begins with"]
+
+    with VllmRunner(
+        MODEL,
+        max_model_len=256,
+        max_num_seqs=len(prompts),
+        enforce_eager=True,
+        use_fp64_gumbel=True,
+    ) as runner:
+        outputs = runner.model.generate(prompts, sampling_params=sampling_params)
+
+    assert len(outputs) == len(prompts)
+    assert all(len(output.outputs[0].token_ids) == sampling_params.max_tokens for output in outputs)

--- a/tests/e2e/pull_request/one_card/model_runner_v2/test_categorical_sampling.py
+++ b/tests/e2e/pull_request/one_card/model_runner_v2/test_categorical_sampling.py
@@ -38,6 +38,7 @@ def test_model_runner_v2_random_sampling() -> None:
         MODEL,
         max_model_len=256,
         max_num_seqs=len(prompts),
+        gpu_memory_utilization=0.2,
         enforce_eager=True,
         use_fp64_gumbel=True,
     ) as runner:

--- a/tests/e2e/pull_request/one_card/sampling_utils.py
+++ b/tests/e2e/pull_request/one_card/sampling_utils.py
@@ -1,0 +1,25 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+"""Helpers for loading ACLNN custom operators in real-device sampling tests."""
+
+import pytest
+import torch
+
+from vllm_ascend.utils import enable_categorical_sample_op
+
+
+def require_categorical_sampling_operator() -> None:
+    """Load the categorical sampler through the platform's supported path.
+
+    A2/A3 use the general lazy custom-op initializer. A5 deliberately keeps
+    that initializer disabled because its complete direct-kernel set is not
+    supported. Its ACLNN operators are nevertheless supported through the
+    packaged custom OPP and native Torch registration module, which mirrors
+    the established A5 operator-test loading path.
+    """
+    if not enable_categorical_sample_op():
+        pytest.fail("npu_categorical_sample requires the categorical custom operator")
+
+    if not hasattr(torch.ops._C_ascend, "npu_categorical_sample"):
+        pytest.fail("the installed extension does not register npu_categorical_sample")

--- a/tests/e2e/pull_request/one_card/test_categorical_sampling.py
+++ b/tests/e2e/pull_request/one_card/test_categorical_sampling.py
@@ -575,9 +575,10 @@ _ASSERTION_SUBPROCESS = textwrap.dedent(
             False,
         )
 
+    sample()
+    torch.npu.synchronize()
+    print("valid categorical warmup passed", flush=True)
     if execution == "aclgraph":
-        sample()
-        torch.npu.synchronize()
         graph = torch.npu.NPUGraph()
         with torch.npu.graph(graph):
             graph_outputs = sample()
@@ -628,7 +629,13 @@ def test_categorical_sampling_asserts_invalid_device_values(
     )
     output = f"{result.stdout}\n{result.stderr}"
     assert result.returncode != 0, f"{case}/{execution} unexpectedly succeeded"
-    assert expected_message in output, output
+    assert "valid categorical warmup passed" in output, output
+    if backend == "native":
+        assert expected_message in output, output
+    else:
+        # Triton's device_assert traps but C220 does not flush its message.
+        # Require the device trap, not an arbitrary import/compile failure.
+        assert "error code is 507035" in output and "trap error" in output, output
 
 
 @dataclass(frozen=True)

--- a/tests/e2e/pull_request/one_card/test_categorical_sampling.py
+++ b/tests/e2e/pull_request/one_card/test_categorical_sampling.py
@@ -1,0 +1,679 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+"""Production correctness tests for the Ascend categorical sampling operator.
+
+The operator is intentionally tested on a real NPU.  The three groups below
+cover its stateless RNG semantics, FP32 accumulation accuracy, and sampled
+distribution under ACLGraph replay.
+"""
+
+from __future__ import annotations
+
+import math
+import struct
+import subprocess
+import sys
+import textwrap
+from dataclasses import dataclass
+
+import pytest
+import torch
+import torch_npu  # noqa: F401  # Registers the NPU and ACLGraph APIs.
+
+from tests.e2e.pull_request.one_card.sampling_utils import require_categorical_sampling_operator
+
+DEVICE = torch.device("npu")
+MAX_VOCAB_SIZE = 1_048_576
+STATISTICAL_ALPHA = 0.001
+STATISTICAL_BATCH_SIZE = 256
+STATISTICAL_SAMPLE_COUNT = 131_072
+
+UINT32_MASK = (1 << 32) - 1
+PHILOX_M0 = 0xD2511F53
+PHILOX_M1 = 0xCD9E8D57
+PHILOX_W0 = 0x9E3779B9
+PHILOX_W1 = 0xBB67AE85
+
+
+def _run_categorical_sampling(
+    logits: torch.Tensor,
+    mapping: torch.Tensor,
+    temperature: torch.Tensor,
+    seed: torch.Tensor,
+    pos: torch.Tensor,
+    return_lse: bool = False,
+    apply_temperature: bool = False,
+    logits_cache: torch.Tensor | None = None,
+    logits_cache_col: torch.Tensor | None = None,
+    use_fp64: bool = False,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    return torch.ops._C_ascend.npu_categorical_sample(
+        logits,
+        mapping,
+        temperature,
+        seed,
+        pos,
+        return_lse,
+        apply_temperature,
+        logits_cache,
+        logits_cache_col,
+        use_fp64,
+    )
+
+
+@pytest.fixture(scope="module", autouse=True)
+def _require_categorical_sampling_operator() -> None:
+    require_categorical_sampling_operator()
+
+
+def _to_npu(value: torch.Tensor) -> torch.Tensor:
+    return value.to(DEVICE)
+
+
+def _float32(value: float) -> float:
+    """Round a Python float exactly as an IEEE FP32 scalar operation does."""
+    return struct.unpack("=f", struct.pack("=f", value))[0]
+
+
+def _mul_hi(lhs: int, rhs: int) -> int:
+    return ((lhs * rhs) >> 32) & UINT32_MASK
+
+
+def _mul_lo(lhs: int, rhs: int) -> int:
+    return (lhs * rhs) & UINT32_MASK
+
+
+def _philox_words(seed: int, position: int) -> tuple[int, int]:
+    counter0 = position & UINT32_MASK
+    counter1 = (position >> 32) & UINT32_MASK
+    counter2 = 0
+    counter3 = 0
+    key0 = seed & UINT32_MASK
+    key1 = (seed >> 32) & UINT32_MASK
+
+    for _ in range(10):
+        hi0 = _mul_hi(PHILOX_M0, counter0)
+        lo0 = _mul_lo(PHILOX_M0, counter0)
+        hi1 = _mul_hi(PHILOX_M1, counter2)
+        lo1 = _mul_lo(PHILOX_M1, counter2)
+        counter0 = (hi1 ^ counter1 ^ key0) & UINT32_MASK
+        counter1 = lo1
+        counter2 = (hi0 ^ counter3 ^ key1) & UINT32_MASK
+        counter3 = lo0
+        key0 = (key0 + PHILOX_W0) & UINT32_MASK
+        key1 = (key1 + PHILOX_W1) & UINT32_MASK
+
+    return counter0, counter1
+
+
+def _philox_uniform(seed: int, position: int) -> float:
+    """CPU definition of the operator's Philox4x32-10 FP32 draw."""
+    counter0, _ = _philox_words(seed, position)
+
+    random24 = counter0 >> 8
+    shifted = _float32(_float32(float(random24)) + 0.5)
+    return _float32(shifted * (1.0 / (1 << 24)))
+
+
+def _philox_random64(seed: int, position: int) -> int:
+    random0, random1 = _philox_words(seed, position)
+    return (random1 << 32) | random0
+
+
+def _uniform_support_choice(support: list[int], seed: int, position: int) -> int:
+    """Select from equal weights using the kernel's inclusive CDF semantics."""
+    target = _float32(_philox_uniform(seed, position) * len(support))
+    cumulative = 0.0
+    for token_id in support:
+        cumulative = _float32(cumulative + 1.0)
+        if cumulative >= target:
+            return token_id
+    return support[-1]
+
+
+def _assert_tensor_equal(actual: torch.Tensor, expected: torch.Tensor) -> None:
+    torch.testing.assert_close(actual.cpu(), expected, rtol=0, atol=0)
+
+
+@pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16, torch.float32])
+def test_categorical_sampling_stateless_philox_matches_cpu_reference(dtype: torch.dtype) -> None:
+    """Seed and logical position fully define sampling, including padding."""
+    supports = [
+        [0, 3, 7, 19, 32],
+        [1, 2, 5, 8, 13, 21, 31],
+        [4, 9, 16],
+        [0, 3, 7, 19, 32],
+        [1, 2, 5, 8, 13, 21, 31],
+        [4, 9, 16],
+        [],
+        [0, 3, 7, 19, 32],
+    ]
+    mapping_cpu = torch.tensor([0, 1, 2, 0, 1, 2, -1, 0], dtype=torch.int32)
+    seed_values = [0x0123456789ABCDEF, -37, (1 << 40) + 17]
+    positions = [0, 1, 2, (1 << 32) + 3, (1 << 32) + 9, 99, 123, (1 << 40) + 5]
+
+    logits_cpu = torch.full((len(supports), 33), -float("inf"), dtype=dtype)
+    for row, support in enumerate(supports):
+        if support:
+            logits_cpu[row, support] = 0
+
+    outputs = _run_categorical_sampling(
+        _to_npu(logits_cpu),
+        _to_npu(mapping_cpu),
+        _to_npu(torch.ones(3, dtype=torch.float32)),
+        _to_npu(torch.tensor(seed_values, dtype=torch.int64)),
+        _to_npu(torch.tensor(positions, dtype=torch.int64)),
+    )
+    expected = []
+    for row, request_index in enumerate(mapping_cpu.tolist()):
+        if request_index == -1:
+            expected.append(0)
+        else:
+            expected.append(_uniform_support_choice(supports[row], seed_values[request_index], positions[row]))
+
+    _assert_tensor_equal(outputs[0], torch.tensor(expected, dtype=torch.int64))
+    assert outputs[1].numel() == 0
+
+
+def test_categorical_sampling_fp64_resolves_sub_fp32_probability_interval() -> None:
+    """FP64 mode must resolve a winner inside an interval narrower than 2^-24."""
+    seed_value = 0x0123456789ABCDEF
+    position = 482_600
+    num_rare_tokens = 32_768
+    vocab_size = num_rare_tokens + 1
+    rare_logit = -26.0 * math.log(2.0)
+    logits = torch.full((1, vocab_size), rare_logit, dtype=torch.float32, device=DEVICE)
+    logits[0, 0] = 0.0
+
+    sampled = _run_categorical_sampling(
+        logits,
+        torch.tensor([0], dtype=torch.int32, device=DEVICE),
+        torch.ones(1, dtype=torch.float32, device=DEVICE),
+        torch.tensor([seed_value], dtype=torch.int64, device=DEVICE),
+        torch.tensor([position], dtype=torch.int64, device=DEVICE),
+        use_fp64=True,
+    )[0]
+
+    # The kernel represents exp(logit - max) with 42 fractional bits.  Each
+    # rare token therefore has mass 2^16 while the dominant token has 2^42.
+    dominant_mass = 1 << 42
+    rare_mass = 1 << 16
+    total_mass = dominant_mass + num_rare_tokens * rare_mass
+    random64 = _philox_random64(seed_value, position)
+    target = (random64 * total_mass) >> 64
+    expected = 1 + (target - dominant_mass) // rare_mass
+
+    # Quantizing the same draw to a 24-bit midpoint lands two probability
+    # intervals away. This makes the assertion sensitive to actual precision,
+    # instead of merely checking that the use_fp64 branch runs.
+    random24_midpoint = ((random64 >> 40) << 40) + (1 << 39)
+    fp32_grid_target = (random24_midpoint * total_mass) >> 64
+    fp32_grid_choice = 1 + (fp32_grid_target - dominant_mass) // rare_mass
+    assert expected == 2310
+    assert fp32_grid_choice == 2312
+    _assert_tensor_equal(sampled, torch.tensor([expected], dtype=torch.int64))
+
+
+@pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16, torch.float32])
+def test_categorical_sampling_greedy_accepted_special_values_are_exact(dtype: torch.dtype) -> None:
+    logits_cpu = torch.full((3, 33), -4.0, dtype=dtype)
+    logits_cpu[0, [5, 17]] = 3
+    logits_cpu[1, [7, 21]] = float("inf")
+    logits_cpu[2] = float("nan")  # Padding rows do not inspect logits.
+    mapping = torch.tensor([0, 1, -1], dtype=torch.int32)
+    temperature = torch.zeros(2, dtype=torch.float32)
+    pos = torch.arange(3, dtype=torch.int64)
+
+    first = _run_categorical_sampling(
+        _to_npu(logits_cpu),
+        _to_npu(mapping),
+        _to_npu(temperature),
+        _to_npu(torch.tensor([11, 22], dtype=torch.int64)),
+        _to_npu(pos),
+    )
+    second = _run_categorical_sampling(
+        _to_npu(logits_cpu),
+        _to_npu(mapping),
+        _to_npu(temperature),
+        _to_npu(torch.tensor([101, 202], dtype=torch.int64)),
+        _to_npu(pos + 1000),
+    )
+    expected_tokens = torch.tensor([5, 7, 0], dtype=torch.int64)
+
+    for outputs in (first, second):
+        _assert_tensor_equal(outputs[0], expected_tokens)
+        assert outputs[1].numel() == 0
+
+
+def test_categorical_sampling_is_invariant_to_batch_layout() -> None:
+    vocab_size = 33
+    logits = torch.zeros((4, vocab_size), dtype=torch.float32, device=DEVICE)
+    mapping = torch.tensor([0, 1, 2, 0], dtype=torch.int32, device=DEVICE)
+    temperature = torch.ones(4, dtype=torch.float32, device=DEVICE)
+    seed = torch.tensor([101, 202, 303, 404], dtype=torch.int64, device=DEVICE)
+    pos = torch.tensor([5, 7, 11, 13], dtype=torch.int64, device=DEVICE)
+
+    baseline = _run_categorical_sampling(logits, mapping, temperature, seed, pos)[0]
+    repeated = _run_categorical_sampling(logits, mapping, temperature, seed, pos)[0]
+
+    order = torch.tensor([2, 0, 3, 1], dtype=torch.int64, device=DEVICE)
+    inverse = torch.argsort(order)
+    permuted = _run_categorical_sampling(
+        logits.index_select(0, order),
+        mapping.index_select(0, order),
+        temperature,
+        seed,
+        pos.index_select(0, order),
+    )[0].index_select(0, inverse)
+
+    unrelated_logits = torch.cat((torch.full((1, vocab_size), 1.0, device=DEVICE), logits), dim=0)
+    unrelated_mapping = torch.cat((torch.tensor([3], dtype=torch.int32, device=DEVICE), mapping), dim=0)
+    unrelated_pos = torch.cat((torch.tensor([17], dtype=torch.int64, device=DEVICE), pos), dim=0)
+    with_unrelated_request = _run_categorical_sampling(
+        unrelated_logits,
+        unrelated_mapping,
+        temperature,
+        seed,
+        unrelated_pos,
+    )[0][1:]
+
+    padded_logits = torch.cat((logits, torch.zeros((3, vocab_size), device=DEVICE)), dim=0)
+    padded_mapping = torch.cat((mapping, torch.full((3,), -1, dtype=torch.int32, device=DEVICE)), dim=0)
+    padded_pos = torch.cat((pos, torch.arange(3, dtype=torch.int64, device=DEVICE)), dim=0)
+    with_padding = _run_categorical_sampling(padded_logits, padded_mapping, temperature, seed, padded_pos)[0][:4]
+
+    torch.npu.synchronize()
+    for actual in (repeated, permuted, with_unrelated_request, with_padding):
+        _assert_tensor_equal(actual, baseline.cpu())
+
+
+@pytest.mark.parametrize("use_fp64", [False, True])
+def test_categorical_sampling_supports_zero_stride_logits(use_fp64: bool) -> None:
+    """A broadcast row remains a view and is sampled as independent logical rows."""
+    vocab_size = 257
+    num_rows = 8
+    base_logits = torch.arange(vocab_size, dtype=torch.float32, device=DEVICE).unsqueeze(0)
+    logits = base_logits.expand(num_rows, vocab_size)
+    assert logits.stride() == (0, 1)
+    assert logits.untyped_storage().nbytes() == base_logits.untyped_storage().nbytes()
+
+    sampled = _run_categorical_sampling(
+        logits,
+        torch.arange(num_rows, dtype=torch.int32, device=DEVICE),
+        torch.zeros(num_rows, dtype=torch.float32, device=DEVICE),
+        torch.arange(num_rows, dtype=torch.int64, device=DEVICE),
+        torch.arange(num_rows, dtype=torch.int64, device=DEVICE),
+        use_fp64=use_fp64,
+    )[0]
+
+    _assert_tensor_equal(sampled, torch.full((num_rows,), vocab_size - 1, dtype=torch.int64))
+
+
+def test_categorical_sampling_rejects_nonzero_overlapping_row_stride() -> None:
+    """Only a zero-stride broadcast is allowed; arbitrary overlapping rows are not."""
+    num_rows = 2
+    vocab_size = 17
+    backing = torch.arange(vocab_size + num_rows - 1, dtype=torch.float32, device=DEVICE)
+    logits = torch.as_strided(backing, (num_rows, vocab_size), (1, 1))
+    assert 0 < logits.stride(0) < vocab_size
+
+    with pytest.raises(RuntimeError, match="processed_logits row stride is invalid"):
+        _run_categorical_sampling(
+            logits,
+            torch.arange(num_rows, dtype=torch.int32, device=DEVICE),
+            torch.zeros(num_rows, dtype=torch.float32, device=DEVICE),
+            torch.arange(num_rows, dtype=torch.int64, device=DEVICE),
+            torch.arange(num_rows, dtype=torch.int64, device=DEVICE),
+        )
+
+
+def test_categorical_sampling_aclgraph_replay_matches_eager_position_sequence() -> None:
+    batch_size = 8
+    logits = torch.zeros((batch_size, 20), dtype=torch.float32, device=DEVICE)
+    mapping = torch.tensor([0, 1, 0, 2, 1, 2, 0, 1], dtype=torch.int32, device=DEVICE)
+    temperature = torch.ones(3, dtype=torch.float32, device=DEVICE)
+    seed = torch.tensor([101, 202, 303], dtype=torch.int64, device=DEVICE)
+    pos = torch.arange(batch_size, dtype=torch.int64, device=DEVICE)
+
+    for _ in range(2):
+        _run_categorical_sampling(logits, mapping, temperature, seed, pos)
+    torch.npu.synchronize()
+    graph = torch.npu.NPUGraph()
+    with torch.npu.graph(graph):
+        graph_outputs = _run_categorical_sampling(logits, mapping, temperature, seed, pos)
+    torch.npu.synchronize()
+
+    position_sequence = [torch.arange(batch_size, dtype=torch.int64) + offset for offset in (0, 1009, (1 << 32) + 27)]
+    eager_results = []
+    for positions in position_sequence:
+        pos.copy_(_to_npu(positions))
+        eager_results.append(_run_categorical_sampling(logits, mapping, temperature, seed, pos)[0].cpu())
+
+    for _ in range(2):
+        replay_results = []
+        for positions in position_sequence:
+            pos.copy_(_to_npu(positions))
+            graph.replay()
+            replay_results.append(graph_outputs[0].cpu())
+        for actual, expected in zip(replay_results, eager_results, strict=True):
+            _assert_tensor_equal(actual, expected)
+
+
+def test_categorical_sampling_aclgraph_padding_count_does_not_change_real_samples() -> None:
+    real_rows = 4
+    vocab_size = 20
+    real_logits = torch.zeros((real_rows, vocab_size), dtype=torch.float32, device=DEVICE)
+    real_mapping = torch.tensor([0, 1, 0, 2], dtype=torch.int32, device=DEVICE)
+    real_pos = torch.tensor([5, 7, 11, 13], dtype=torch.int64, device=DEVICE)
+    temperature = torch.ones(3, dtype=torch.float32, device=DEVICE)
+    seed = torch.tensor([101, 202, 303], dtype=torch.int64, device=DEVICE)
+    retained_graph_state = []
+    real_outputs = []
+
+    for padding_rows in (0, 7):
+        logits = torch.cat(
+            (real_logits, torch.zeros((padding_rows, vocab_size), dtype=torch.float32, device=DEVICE)),
+            dim=0,
+        )
+        mapping = torch.cat(
+            (real_mapping, torch.full((padding_rows,), -1, dtype=torch.int32, device=DEVICE)),
+            dim=0,
+        )
+        pos = torch.cat(
+            (real_pos, torch.arange(padding_rows, dtype=torch.int64, device=DEVICE)),
+            dim=0,
+        )
+        for _ in range(2):
+            _run_categorical_sampling(logits, mapping, temperature, seed, pos)
+        torch.npu.synchronize()
+        graph = torch.npu.NPUGraph()
+        with torch.npu.graph(graph):
+            outputs = _run_categorical_sampling(logits, mapping, temperature, seed, pos)
+        graph.replay()
+        real_outputs.append(outputs[0][:real_rows].cpu())
+        retained_graph_state.append((graph, outputs, logits, mapping, pos))
+
+    _assert_tensor_equal(real_outputs[1], real_outputs[0])
+
+
+@pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16, torch.float32])
+def test_categorical_sampling_lse_matches_fp64_reference(dtype: torch.dtype) -> None:
+    vocab_size = 4097
+    logits_fp32 = torch.empty((4, vocab_size), dtype=torch.float32)
+    logits_fp32[0] = torch.linspace(-12.0, 4.0, vocab_size)
+    logits_fp32[1] = -float("inf")
+    logits_fp32[1, [0, 20, 2048, 4096]] = torch.tensor([2.0, -1.0, 0.5, 2.0])
+    logits_fp32[2] = torch.linspace(-80.0, 0.0, vocab_size)
+    logits_fp32[2, 3333] = 18.0
+    logits_fp32[3] = torch.sin(torch.arange(vocab_size, dtype=torch.float32) * 0.013) * 7.0
+    logits_cpu = logits_fp32.to(dtype)
+
+    outputs = _run_categorical_sampling(
+        _to_npu(logits_cpu),
+        torch.arange(4, dtype=torch.int32, device=DEVICE),
+        torch.ones(4, dtype=torch.float32, device=DEVICE),
+        torch.tensor([11, 22, 33, 44], dtype=torch.int64, device=DEVICE),
+        torch.arange(4, dtype=torch.int64, device=DEVICE),
+        True,
+    )
+    expected_lse = torch.logsumexp(logits_cpu.to(torch.float64), dim=-1)
+    tolerance = 1e-5 if dtype == torch.float32 else 1e-3
+
+    torch.testing.assert_close(
+        outputs[1].cpu().to(torch.float64),
+        expected_lse,
+        rtol=tolerance,
+        atol=tolerance,
+    )
+
+
+@pytest.mark.parametrize("vocab_size", [1, 20, 33, 4097, MAX_VOCAB_SIZE])
+def test_categorical_sampling_lse_vocabulary_boundaries(vocab_size: int) -> None:
+    logits = torch.zeros((1, vocab_size), dtype=torch.float32, device=DEVICE)
+    outputs = _run_categorical_sampling(
+        logits,
+        torch.zeros(1, dtype=torch.int32, device=DEVICE),
+        torch.ones(1, dtype=torch.float32, device=DEVICE),
+        torch.tensor([12345], dtype=torch.int64, device=DEVICE),
+        torch.tensor([67890], dtype=torch.int64, device=DEVICE),
+        True,
+    )
+
+    assert 0 <= int(outputs[0].cpu()) < vocab_size
+    torch.testing.assert_close(
+        outputs[1].cpu().to(torch.float64),
+        torch.tensor([math.log(vocab_size)], dtype=torch.float64),
+        rtol=1e-5,
+        atol=1e-5,
+    )
+
+
+@pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16, torch.float32])
+def test_categorical_sampling_positive_infinity_lse_and_padding(dtype: torch.dtype) -> None:
+    logits = torch.tensor(
+        [
+            [0.0, float("inf"), -1.0, float("inf")],
+            [float("nan"), float("nan"), float("nan"), float("nan")],
+        ],
+        dtype=dtype,
+        device=DEVICE,
+    )
+    outputs = _run_categorical_sampling(
+        logits,
+        torch.tensor([0, -1], dtype=torch.int32, device=DEVICE),
+        torch.ones(1, dtype=torch.float32, device=DEVICE),
+        torch.tensor([3], dtype=torch.int64, device=DEVICE),
+        torch.tensor([11, 13], dtype=torch.int64, device=DEVICE),
+        True,
+    )
+    tokens, lse = (output.cpu() for output in outputs)
+
+    assert int(tokens[0]) in (1, 3)
+    assert int(tokens[1]) == 0
+    assert math.isinf(float(lse[0])) and float(lse[0]) > 0
+    assert float(lse[1]) == 0.0
+
+
+_ASSERTION_SUBPROCESS = textwrap.dedent(
+    """
+    import sys
+
+    import torch
+    import torch_npu  # noqa: F401
+
+    from vllm_ascend.utils import enable_categorical_sample_op
+
+    if not enable_categorical_sample_op():
+        raise RuntimeError("the categorical custom operator is unavailable")
+
+    case, execution = sys.argv[1:3]
+    device = torch.device("npu")
+    logits = torch.tensor([[0.0, 1.0, -1.0, 2.0]], dtype=torch.float32, device=device)
+    mapping = torch.zeros(1, dtype=torch.int32, device=device)
+    temperature = torch.ones(1, dtype=torch.float32, device=device)
+    seed = torch.ones(1, dtype=torch.int64, device=device)
+    pos = torch.zeros(1, dtype=torch.int64, device=device)
+    cache = None
+    cache_col = None
+    if case == "cache_column":
+        cache = torch.full((1, 2, 4), 17.0, dtype=torch.float32, device=device)
+        cache_col = torch.zeros((), dtype=torch.int32, device=device)
+
+    def sample():
+        return torch.ops._C_ascend.npu_categorical_sample(
+            logits,
+            mapping,
+            temperature,
+            seed,
+            pos,
+            False,
+            False,
+            cache,
+            cache_col,
+            False,
+        )
+
+    if execution == "aclgraph":
+        sample()
+        torch.npu.synchronize()
+        graph = torch.npu.NPUGraph()
+        with torch.npu.graph(graph):
+            graph_outputs = sample()
+        torch.npu.synchronize()
+
+    if case == "nan":
+        logits[0, 0] = float("nan")
+    elif case == "all_negative_infinity":
+        logits.fill_(-float("inf"))
+    elif case == "mapping":
+        mapping.fill_(-2)
+    elif case == "cache_column":
+        cache_col.fill_(2)
+    else:
+        raise AssertionError(f"unknown case: {case}")
+
+    if execution == "eager":
+        sample()
+    else:
+        graph.replay()
+    torch.npu.synchronize()
+    """
+)
+
+
+@pytest.mark.parametrize("execution", ["eager", "aclgraph"])
+@pytest.mark.parametrize(
+    "case,expected_message",
+    [
+        ("nan", "CategoricalSample processed logits must not contain NaN"),
+        ("all_negative_infinity", "CategoricalSample processed logits row must not be all -inf"),
+        ("mapping", "CategoricalSample expanded index mapping is outside request state"),
+        ("cache_column", "CategoricalSample output processed logits column is outside cache bounds"),
+    ],
+)
+def test_categorical_sampling_asserts_invalid_device_values(
+    execution: str,
+    case: str,
+    expected_message: str,
+) -> None:
+    result = subprocess.run(
+        [sys.executable, "-c", _ASSERTION_SUBPROCESS, case, execution],
+        capture_output=True,
+        text=True,
+        timeout=120,
+    )
+    output = f"{result.stdout}\n{result.stderr}"
+    assert result.returncode != 0, f"{case}/{execution} unexpectedly succeeded"
+    assert expected_message in output, output
+
+
+@dataclass(frozen=True)
+class CategoricalSamplingDistributionCase:
+    name: str
+    logits: torch.Tensor
+    expected_probabilities: torch.Tensor
+
+
+def _categorical_sampling_distribution_cases() -> list[CategoricalSamplingDistributionCase]:
+    uniform_logits = torch.zeros(20, dtype=torch.float32)
+    uniform_probabilities = torch.full((20,), 1 / 20, dtype=torch.float64)
+
+    skewed_probabilities = torch.tensor([0.70, 0.20, 0.09, 0.01], dtype=torch.float64)
+    skewed_logits = skewed_probabilities.log().to(torch.float32)
+    skewed_reference = torch.softmax(skewed_logits.to(torch.float64), dim=0)
+
+    masked_logits = torch.full((33,), -float("inf"), dtype=torch.float32)
+    masked_indices = torch.tensor([1, 7, 18, 31], dtype=torch.int64)
+    masked_values = torch.tensor([0.50, 0.30, 0.15, 0.05], dtype=torch.float64)
+    masked_logits[masked_indices] = masked_values.log().to(torch.float32)
+    masked_reference = torch.zeros(33, dtype=torch.float64)
+    masked_reference[masked_indices] = torch.softmax(masked_logits[masked_indices].to(torch.float64), dim=0)
+
+    positive_infinity_logits = torch.zeros(20, dtype=torch.float32)
+    positive_infinity_indices = torch.tensor([0, 5, 11, 19], dtype=torch.int64)
+    positive_infinity_logits[positive_infinity_indices] = float("inf")
+    positive_infinity_reference = torch.zeros(20, dtype=torch.float64)
+    positive_infinity_reference[positive_infinity_indices] = 0.25
+
+    return [
+        CategoricalSamplingDistributionCase("uniform", uniform_logits, uniform_probabilities),
+        CategoricalSamplingDistributionCase("skewed", skewed_logits, skewed_reference),
+        CategoricalSamplingDistributionCase("masked", masked_logits, masked_reference),
+        CategoricalSamplingDistributionCase("positive_infinity", positive_infinity_logits, positive_infinity_reference),
+    ]
+
+
+def _merge_small_expected_buckets(
+    observed: torch.Tensor,
+    expected: torch.Tensor,
+    minimum_expected: float = 5.0,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    large = expected >= minimum_expected
+    merged_observed = observed[large]
+    merged_expected = expected[large]
+    if bool((~large).any()):
+        small_expected = expected[~large].sum()
+        if float(small_expected) < minimum_expected:
+            raise AssertionError("sample count is too small for a valid chi-squared test")
+        merged_observed = torch.cat((merged_observed, observed[~large].sum().reshape(1)))
+        merged_expected = torch.cat((merged_expected, small_expected.reshape(1)))
+    return merged_observed, merged_expected
+
+
+def _chi_squared_p_value(observed: torch.Tensor, probabilities: torch.Tensor) -> tuple[float, float]:
+    positive = probabilities > 0
+    observed_support = observed[positive].to(torch.float64)
+    expected_support = probabilities[positive] * observed.sum()
+    observed_support, expected_support = _merge_small_expected_buckets(observed_support, expected_support)
+    statistic = float((((observed_support - expected_support) ** 2) / expected_support).sum())
+    degrees_of_freedom = observed_support.numel() - 1
+    p_value = float(
+        torch.special.gammaincc(
+            torch.tensor(degrees_of_freedom / 2, dtype=torch.float64),
+            torch.tensor(statistic / 2, dtype=torch.float64),
+        )
+    )
+    return statistic, p_value
+
+
+def _collect_categorical_sampling_distribution_with_aclgraph(logits_row: torch.Tensor) -> torch.Tensor:
+    vocab_size = logits_row.numel()
+    logits = logits_row.repeat(STATISTICAL_BATCH_SIZE, 1).to(DEVICE)
+    mapping = torch.zeros(STATISTICAL_BATCH_SIZE, dtype=torch.int32, device=DEVICE)
+    temperature = torch.ones(1, dtype=torch.float32, device=DEVICE)
+    seed = torch.tensor([0x0123456789ABCDEF], dtype=torch.int64, device=DEVICE)
+    pos = torch.arange(STATISTICAL_BATCH_SIZE, dtype=torch.int64, device=DEVICE)
+
+    for _ in range(2):
+        _run_categorical_sampling(logits, mapping, temperature, seed, pos)
+    torch.npu.synchronize()
+    graph = torch.npu.NPUGraph()
+    with torch.npu.graph(graph):
+        graph_outputs = _run_categorical_sampling(logits, mapping, temperature, seed, pos)
+    torch.npu.synchronize()
+
+    samples = torch.empty(STATISTICAL_SAMPLE_COUNT, dtype=torch.int64, device=DEVICE)
+    replay_count = STATISTICAL_SAMPLE_COUNT // STATISTICAL_BATCH_SIZE
+    for replay in range(replay_count):
+        graph.replay()
+        offset = replay * STATISTICAL_BATCH_SIZE
+        samples[offset : offset + STATISTICAL_BATCH_SIZE].copy_(graph_outputs[0])
+        pos.add_(STATISTICAL_BATCH_SIZE)
+    torch.npu.synchronize()
+    samples_cpu = samples.cpu()
+    assert bool(((samples_cpu >= 0) & (samples_cpu < vocab_size)).all()), "sampled token is out of range"
+    return torch.bincount(samples_cpu, minlength=vocab_size)
+
+
+@pytest.mark.parametrize("case", _categorical_sampling_distribution_cases(), ids=lambda case: case.name)
+def test_categorical_sampling_aclgraph_distribution(case: CategoricalSamplingDistributionCase) -> None:
+    observed = _collect_categorical_sampling_distribution_with_aclgraph(case.logits)
+    masked = case.expected_probabilities == 0
+    assert int(observed[masked].sum()) == 0, f"{case.name}: sampled a zero-probability token"
+
+    statistic, p_value = _chi_squared_p_value(observed, case.expected_probabilities)
+    assert p_value >= STATISTICAL_ALPHA, (
+        f"{case.name}: chi-squared distribution check failed: "
+        f"statistic={statistic:.6f}, p_value={p_value:.6g}, alpha={STATISTICAL_ALPHA}"
+    )

--- a/tests/e2e/pull_request/one_card/test_categorical_sampling.py
+++ b/tests/e2e/pull_request/one_card/test_categorical_sampling.py
@@ -807,3 +807,32 @@ def test_triton_philox_endpoint_and_first_max(use_fp64, infinity):
     )
     assert result[0][1].item() == 1
     assert result[0][2].item() == 0
+
+
+def test_triton_fp64_rare_probability_interval():
+    logits = torch.full((1, 32769), -26.0 * math.log(2.0), device=DEVICE)
+    logits[0, 0] = 0.0
+    result = _compare_triton_native(
+        logits,
+        torch.zeros(1, dtype=torch.int32, device=DEVICE),
+        torch.ones(1, device=DEVICE),
+        torch.tensor([0x0123456789ABCDEF], device=DEVICE),
+        torch.tensor([482600], device=DEVICE),
+        return_lse=False,
+        apply_temperature=False,
+        use_fp64=True,
+    )
+    assert result[0].item() > 0
+
+
+@pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16, torch.float32])
+def test_triton_raw_cache_bits(dtype):
+    logits = torch.tensor([[-0.0, 0.0, 1.0625, -2.25]], dtype=dtype, device=DEVICE)
+    mapping = torch.zeros(1, dtype=torch.int32, device=DEVICE)
+    args = logits, mapping, torch.zeros(1, device=DEVICE), mapping.long(), mapping.long(), False, False
+    native_cache = torch.empty((1, 4), dtype=dtype, device=DEVICE)
+    triton_cache = torch.empty_like(native_cache)
+    torch.ops._C_ascend.npu_categorical_sample(*args, logits_cache=native_cache)
+    categorical_sample(*args, logits_cache=triton_cache)
+    bit_dtype = torch.int32 if dtype == torch.float32 else torch.int16
+    assert torch.equal(triton_cache.cpu().view(bit_dtype), native_cache.cpu().view(bit_dtype))

--- a/tests/e2e/pull_request/one_card/test_categorical_sampling.py
+++ b/tests/e2e/pull_request/one_card/test_categorical_sampling.py
@@ -583,6 +583,9 @@ _ASSERTION_SUBPROCESS = textwrap.dedent(
         with torch.npu.graph(graph):
             graph_outputs = sample()
         torch.npu.synchronize()
+        graph.replay()
+        torch.npu.synchronize()
+        print("valid categorical graph replay passed", flush=True)
 
     if case == "nan":
         logits[0, 0] = float("nan")
@@ -630,6 +633,8 @@ def test_categorical_sampling_asserts_invalid_device_values(
     output = f"{result.stdout}\n{result.stderr}"
     assert result.returncode != 0, f"{case}/{execution} unexpectedly succeeded"
     assert "valid categorical warmup passed" in output, output
+    if execution == "aclgraph":
+        assert "valid categorical graph replay passed" in output, output
     if backend == "native":
         assert expected_message in output, output
     else:

--- a/tests/e2e/pull_request/one_card/test_categorical_sampling.py
+++ b/tests/e2e/pull_request/one_card/test_categorical_sampling.py
@@ -635,7 +635,9 @@ def test_categorical_sampling_asserts_invalid_device_values(
     else:
         # Triton's device_assert traps but C220 does not flush its message.
         # Require the device trap, not an arbitrary import/compile failure.
-        assert "error code is 507035" in output and "trap error" in output, output
+        # ACLGraph may wrap the vector-core failure in a model-stream error.
+        assert any(f"error code is {code}" in output for code in (507035, 507011)), output
+        assert "exception of aivec error" in output, output
 
 
 @dataclass(frozen=True)
@@ -843,3 +845,58 @@ def test_triton_raw_cache_bits(dtype):
     categorical_sample(*args, logits_cache=triton_cache)
     bit_dtype = torch.int32 if dtype == torch.float32 else torch.int16
     assert torch.equal(triton_cache.cpu().view(bit_dtype), native_cache.cpu().view(bit_dtype))
+
+
+@pytest.mark.parametrize(
+    "case",
+    [
+        "rank",
+        "dtype",
+        "empty",
+        "vocab_stride",
+        "row_overlap",
+        "mapping_dtype",
+        "mapping_length",
+        "seed_length",
+        "temperature_dtype",
+        "pos_dtype",
+        "cache_width",
+        "cache_overlap",
+        "col_without_cache",
+    ],
+)
+def test_triton_matches_native_metadata_rejection(case):
+    logits = torch.zeros(2, 33, device=DEVICE)
+    mapping = torch.arange(2, dtype=torch.int32, device=DEVICE)
+    temperature = torch.ones(2, device=DEVICE)
+    seeds, pos = mapping.long(), mapping.long()
+    cache = col = None
+    if case == "rank":
+        logits = logits[0]
+    elif case == "dtype":
+        logits = logits.to(torch.int32)
+    elif case == "empty":
+        logits = logits[:0]
+    elif case == "vocab_stride":
+        logits = logits[:, ::2]
+    elif case == "row_overlap":
+        logits = logits.as_strided((2, 33), (1, 1))
+    elif case == "mapping_dtype":
+        mapping = mapping.long()
+    elif case == "mapping_length":
+        mapping = mapping[:1]
+    elif case == "seed_length":
+        seeds = seeds[:1]
+    elif case == "temperature_dtype":
+        temperature = temperature.half()
+    elif case == "pos_dtype":
+        pos = pos.int()
+    elif case == "cache_width":
+        cache = torch.empty(2, 32, device=DEVICE)
+    elif case == "cache_overlap":
+        cache = torch.empty(1, 33, device=DEVICE).expand(2, -1)
+    elif case == "col_without_cache":
+        col = torch.zeros((), dtype=torch.int32, device=DEVICE)
+    for operator in (torch.ops._C_ascend.npu_categorical_sample, categorical_sample):
+        with pytest.raises(RuntimeError):
+            operator(logits, mapping, temperature, seeds, pos, False, False, cache, col)

--- a/tests/e2e/pull_request/one_card/test_categorical_sampling.py
+++ b/tests/e2e/pull_request/one_card/test_categorical_sampling.py
@@ -475,6 +475,33 @@ def test_categorical_sampling_positive_infinity_lse_and_padding(dtype: torch.dty
     assert float(lse[1]) == 0.0
 
 
+@pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16, torch.float32])
+@pytest.mark.parametrize("execution", ["eager", "aclgraph"])
+def test_categorical_sampling_positive_infinity_rounded_uniform_endpoint(dtype: torch.dtype, execution: str) -> None:
+    """A draw rounded to 1.0 must not select a token outside the support."""
+    seed_value, position = 17, 1_217_933
+    assert _philox_uniform(seed_value, position) == 1.0
+    supports = [[5], [3, 17], [5, 10, 31]]
+    logits = torch.zeros((len(supports), 33), dtype=dtype, device=DEVICE)
+    for row, support in enumerate(supports):
+        logits[row, support] = float("inf")
+    inputs = (
+        logits,
+        torch.zeros(len(supports), dtype=torch.int32, device=DEVICE),
+        torch.ones(1, dtype=torch.float32, device=DEVICE),
+        torch.tensor([seed_value], dtype=torch.int64, device=DEVICE),
+        torch.full((len(supports),), position, dtype=torch.int64, device=DEVICE),
+    )
+    outputs = _run_categorical_sampling(*inputs)
+    if execution == "aclgraph":
+        torch.npu.synchronize()
+        graph = torch.npu.NPUGraph()
+        with torch.npu.graph(graph):
+            outputs = _run_categorical_sampling(*inputs)
+        graph.replay()
+    _assert_tensor_equal(outputs[0], torch.tensor([support[-1] for support in supports], dtype=torch.int64))
+
+
 _ASSERTION_SUBPROCESS = textwrap.dedent(
     """
     import sys

--- a/tests/e2e/pull_request/one_card/test_categorical_sampling.py
+++ b/tests/e2e/pull_request/one_card/test_categorical_sampling.py
@@ -806,6 +806,9 @@ def test_triton_cache_and_graph_replay(dtype, use_fp64):
     torch.npu.synchronize()
     for _ in range(3):
         pos.add_(1)
+        logits[0].copy_(logits[0].roll(1))
+        native_cache.fill_(-123.0)
+        triton_cache.fill_(-123.0)
         expected = torch.ops._C_ascend.npu_categorical_sample(*args, logits_cache=native_cache, **kwargs)
         graph.replay()
         torch.testing.assert_close(actual[0], expected[0], rtol=0, atol=0)

--- a/tests/e2e/pull_request/one_card/test_categorical_sampling.py
+++ b/tests/e2e/pull_request/one_card/test_categorical_sampling.py
@@ -544,7 +544,11 @@ _ASSERTION_SUBPROCESS = textwrap.dedent(
     if not enable_categorical_sample_op():
         raise RuntimeError("the categorical custom operator is unavailable")
 
-    case, execution = sys.argv[1:3]
+    case, execution, backend = sys.argv[1:4]
+    if backend == "triton":
+        from vllm_ascend.ops.triton.categorical_sample import categorical_sample as operator
+    else:
+        operator = torch.ops._C_ascend.npu_categorical_sample
     device = torch.device("npu")
     logits = torch.tensor([[0.0, 1.0, -1.0, 2.0]], dtype=torch.float32, device=device)
     mapping = torch.zeros(1, dtype=torch.int32, device=device)
@@ -558,7 +562,7 @@ _ASSERTION_SUBPROCESS = textwrap.dedent(
         cache_col = torch.zeros((), dtype=torch.int32, device=device)
 
     def sample():
-        return torch.ops._C_ascend.npu_categorical_sample(
+        return operator(
             logits,
             mapping,
             temperature,
@@ -599,6 +603,7 @@ _ASSERTION_SUBPROCESS = textwrap.dedent(
 )
 
 
+@pytest.mark.parametrize("backend", ["native", "triton"])
 @pytest.mark.parametrize("execution", ["eager", "aclgraph"])
 @pytest.mark.parametrize(
     "case,expected_message",
@@ -610,12 +615,13 @@ _ASSERTION_SUBPROCESS = textwrap.dedent(
     ],
 )
 def test_categorical_sampling_asserts_invalid_device_values(
+    backend: str,
     execution: str,
     case: str,
     expected_message: str,
 ) -> None:
     result = subprocess.run(
-        [sys.executable, "-c", _ASSERTION_SUBPROCESS, case, execution],
+        [sys.executable, "-c", _ASSERTION_SUBPROCESS, case, execution, backend],
         capture_output=True,
         text=True,
         timeout=120,

--- a/tests/e2e/pull_request/one_card/test_categorical_sampling.py
+++ b/tests/e2e/pull_request/one_card/test_categorical_sampling.py
@@ -22,6 +22,7 @@ import torch
 import torch_npu  # noqa: F401  # Registers the NPU and ACLGraph APIs.
 
 from tests.e2e.pull_request.one_card.sampling_utils import require_categorical_sampling_operator
+from vllm_ascend.ops.triton.categorical_sample import categorical_sample
 
 DEVICE = torch.device("npu")
 MAX_VOCAB_SIZE = 1_048_576
@@ -733,3 +734,70 @@ def test_categorical_sampling_aclgraph_distribution(case: CategoricalSamplingDis
         f"{case.name}: chi-squared distribution check failed: "
         f"statistic={statistic:.6f}, p_value={p_value:.6g}, alpha={STATISTICAL_ALPHA}"
     )
+
+
+def _compare_triton_native(logits, mapping, temperature, seed, pos, **kwargs):
+    expected = torch.ops._C_ascend.npu_categorical_sample(logits, mapping, temperature, seed, pos, **kwargs)
+    actual = categorical_sample(logits, mapping, temperature, seed, pos, **kwargs)
+    torch.testing.assert_close(actual[0], expected[0], rtol=0, atol=0)
+    torch.testing.assert_close(actual[1], expected[1], rtol=0, atol=0)
+    return actual
+
+
+@pytest.mark.parametrize("use_fp64", [False, True])
+@pytest.mark.parametrize("vocab", [1, 33, 256, 4096, 4097, 32768, 151936, 1_048_576])
+def test_triton_same_input_matches_native(vocab, use_fp64):
+    generator = torch.Generator().manual_seed(17)
+    logits = torch.randn(8, vocab, generator=generator, dtype=torch.float32).to("npu")
+    mapping = torch.tensor([0, 1, 2, 3, 0, 1, 2, -1], dtype=torch.int32, device="npu")
+    temperature = torch.tensor([0.0, 0.7, 1.0, -2.0], device="npu")
+    seeds = torch.tensor([17, -37, (1 << 40) + 17, -(1 << 63)], dtype=torch.int64, device="npu")
+    pos = torch.tensor([0, 1, 99, (1 << 32) + 3, (1 << 40) + 5, -1, -(1 << 63), 0], device="npu")
+    _compare_triton_native(
+        logits, mapping, temperature, seeds, pos, return_lse=True, apply_temperature=True, use_fp64=use_fp64
+    )
+
+
+@pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16, torch.float32])
+@pytest.mark.parametrize("use_fp64", [False, True])
+def test_triton_cache_and_graph_replay(dtype, use_fp64):
+    logits = torch.arange(33, device="npu", dtype=torch.float32).to(dtype).expand(4, -1)
+    mapping = torch.tensor([0, 1, 0, -1], dtype=torch.int32, device="npu")
+    temperature = torch.tensor([0.7, 0.0], device="npu")
+    seed = torch.tensor([17, -37], device="npu")
+    pos = torch.tensor([0, 1, (1 << 40) + 3, 0], device="npu")
+    col = torch.tensor([0, 0, 1, -1], dtype=torch.int32, device="npu")
+    native_cache = torch.full((2, 3, 48), -123.0, dtype=dtype, device="npu")
+    triton_cache = native_cache.clone()
+    kwargs = dict(return_lse=False, apply_temperature=True, logits_cache_col=col, use_fp64=use_fp64)
+    args = logits, mapping, temperature, seed, pos
+    # Warm up compilation before capture.
+    categorical_sample(*args, logits_cache=triton_cache, **kwargs)
+    graph = torch.npu.NPUGraph()
+    with torch.npu.graph(graph):
+        actual = categorical_sample(*args, logits_cache=triton_cache, **kwargs)
+    for _ in range(3):
+        pos.add_(1)
+        expected = torch.ops._C_ascend.npu_categorical_sample(*args, logits_cache=native_cache, **kwargs)
+        graph.replay()
+        torch.testing.assert_close(actual[0], expected[0], rtol=0, atol=0)
+        torch.testing.assert_close(triton_cache, native_cache, rtol=0, atol=0)
+        assert actual[1].numel() == 0
+
+
+@pytest.mark.parametrize("use_fp64", [False, True])
+@pytest.mark.parametrize("infinity", [False, True])
+def test_triton_philox_endpoint_and_first_max(use_fp64, infinity):
+    # This seed/position rounds the FP32 draw to 1.0. For +inf logits
+    # the last supported token must win, never the default token zero.
+    logits = torch.full((3, 8193), -float("inf"), device="npu")
+    logits[:, [1, 4096, 8192]] = float("inf") if infinity else 0.0
+    mapping = torch.tensor([0, 1, -1], dtype=torch.int32, device="npu")
+    temperature = torch.tensor([1.0, 0.0], device="npu")
+    seeds = torch.tensor([17, -37], device="npu")
+    pos = torch.tensor([1_217_933, 0, 0], device="npu")
+    result = _compare_triton_native(
+        logits, mapping, temperature, seeds, pos, return_lse=True, apply_temperature=False, use_fp64=use_fp64
+    )
+    assert result[0][1].item() == 1
+    assert result[0][2].item() == 0

--- a/tests/e2e/pull_request/one_card/test_categorical_sampling.py
+++ b/tests/e2e/pull_request/one_card/test_categorical_sampling.py
@@ -765,10 +765,13 @@ def _compare_triton_native(logits, mapping, temperature, seed, pos, **kwargs):
 
 
 @pytest.mark.parametrize("use_fp64", [False, True])
+@pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16, torch.float32])
 @pytest.mark.parametrize("vocab", [1, 33, 256, 4096, 4097, 32768, 151936, 1_048_576])
-def test_triton_same_input_matches_native(vocab, use_fp64):
+def test_triton_same_input_matches_native(vocab, dtype, use_fp64):
     generator = torch.Generator().manual_seed(17)
-    logits = torch.randn(8, vocab, generator=generator, dtype=torch.float32).to("npu")
+    logits = torch.randn(8, vocab + 13, generator=generator, dtype=torch.float32).to(device="npu", dtype=dtype)[
+        :, :vocab
+    ]
     mapping = torch.tensor([0, 1, 2, 3, 0, 1, 2, -1], dtype=torch.int32, device="npu")
     temperature = torch.tensor([0.0, 0.7, 1.0, -2.0], device="npu")
     seeds = torch.tensor([17, -37, (1 << 40) + 17, -(1 << 63)], dtype=torch.int64, device="npu")
@@ -845,15 +848,16 @@ def test_triton_fp64_rare_probability_interval():
 
 
 @pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16, torch.float32])
-def test_triton_raw_cache_bits(dtype):
+@pytest.mark.parametrize("cache_dtype", [torch.float16, torch.bfloat16, torch.float32])
+def test_triton_raw_cache_bits(dtype, cache_dtype):
     logits = torch.tensor([[-0.0, 0.0, 1.0625, -2.25]], dtype=dtype, device=DEVICE)
     mapping = torch.zeros(1, dtype=torch.int32, device=DEVICE)
     args = logits, mapping, torch.zeros(1, device=DEVICE), mapping.long(), mapping.long(), False, False
-    native_cache = torch.empty((1, 4), dtype=dtype, device=DEVICE)
+    native_cache = torch.empty((1, 4), dtype=cache_dtype, device=DEVICE)
     triton_cache = torch.empty_like(native_cache)
     torch.ops._C_ascend.npu_categorical_sample(*args, logits_cache=native_cache)
     categorical_sample(*args, logits_cache=triton_cache)
-    bit_dtype = torch.int32 if dtype == torch.float32 else torch.int16
+    bit_dtype = torch.int32 if cache_dtype == torch.float32 else torch.int16
     assert torch.equal(triton_cache.cpu().view(bit_dtype), native_cache.cpu().view(bit_dtype))
 
 

--- a/tests/e2e/pull_request/one_card/test_categorical_sampling.py
+++ b/tests/e2e/pull_request/one_card/test_categorical_sampling.py
@@ -246,6 +246,35 @@ def test_categorical_sampling_greedy_accepted_special_values_are_exact(dtype: to
         assert outputs[1].numel() == 0
 
 
+@pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16, torch.float32])
+@pytest.mark.parametrize("vocab_size", [33, 256, 4096, 4097, 151936])
+@pytest.mark.parametrize("execution", ["eager", "aclgraph"])
+def test_categorical_sampling_greedy_first_max_across_tiles(
+    dtype: torch.dtype, vocab_size: int, execution: str
+) -> None:
+    """Vector argmax must preserve ties and exclude padded tail elements."""
+    logits = torch.full((5, vocab_size), -4.0, dtype=dtype, device=DEVICE)
+    logits[0, -1] = -1.0
+    logits[1, [vocab_size // 2, vocab_size - 1]] = -1.0
+    logits[3, [63, 64] if vocab_size > 64 else [0, 32]] = -1.0
+    logits[4, [4095, 4096] if vocab_size > 4096 else [0, vocab_size - 1]] = -1.0
+    inputs = (
+        logits,
+        torch.arange(5, dtype=torch.int32, device=DEVICE),
+        torch.zeros(5, dtype=torch.float32, device=DEVICE),
+        torch.arange(5, dtype=torch.int64, device=DEVICE),
+        torch.arange(5, dtype=torch.int64, device=DEVICE),
+    )
+    outputs = _run_categorical_sampling(*inputs)
+    if execution == "aclgraph":
+        torch.npu.synchronize()
+        graph = torch.npu.NPUGraph()
+        with torch.npu.graph(graph):
+            outputs = _run_categorical_sampling(*inputs)
+        graph.replay()
+    _assert_tensor_equal(outputs[0], logits.cpu().argmax(dim=-1))
+
+
 def test_categorical_sampling_is_invariant_to_batch_layout() -> None:
     vocab_size = 33
     logits = torch.zeros((4, vocab_size), dtype=torch.float32, device=DEVICE)

--- a/tests/e2e/pull_request/one_card/test_categorical_sampling.py
+++ b/tests/e2e/pull_request/one_card/test_categorical_sampling.py
@@ -787,10 +787,15 @@ def test_triton_cache_and_graph_replay(dtype, use_fp64):
     kwargs = dict(return_lse=False, apply_temperature=True, logits_cache_col=col, use_fp64=use_fp64)
     args = logits, mapping, temperature, seed, pos
     # Warm up compilation before capture.
-    categorical_sample(*args, logits_cache=triton_cache, **kwargs)
+    warmup = categorical_sample(*args, logits_cache=triton_cache, **kwargs)
+    expected = torch.ops._C_ascend.npu_categorical_sample(*args, logits_cache=native_cache, **kwargs)
+    torch.testing.assert_close(warmup[0], expected[0], rtol=0, atol=0)
+    torch.testing.assert_close(triton_cache, native_cache, rtol=0, atol=0)
+    torch.npu.synchronize()
     graph = torch.npu.NPUGraph()
     with torch.npu.graph(graph):
         actual = categorical_sample(*args, logits_cache=triton_cache, **kwargs)
+    torch.npu.synchronize()
     for _ in range(3):
         pos.add_(1)
         expected = torch.ops._C_ascend.npu_categorical_sample(*args, logits_cache=native_cache, **kwargs)

--- a/tests/e2e/pull_request/one_card/test_gumbel_sampling.py
+++ b/tests/e2e/pull_request/one_card/test_gumbel_sampling.py
@@ -607,7 +607,7 @@ class TestGumbelSampling:
                 logits,
                 mapping,
                 torch.ones(1, device=DEVICE),
-                mapping,
+                mapping.to(torch.int64),
                 mapping,
                 True,
                 logits_cache=torch.empty(1, 1, 31, device=DEVICE),

--- a/tests/e2e/pull_request/one_card/test_gumbel_sampling.py
+++ b/tests/e2e/pull_request/one_card/test_gumbel_sampling.py
@@ -290,7 +290,8 @@ class TestGumbelSampling:
                 f"Token {tok} (temp=0) should be greedy: got {sampled[tok].item()}, expected {greedy[tok].item()}"
             )
 
-    def test_gumbel_sample_expanded_idx_mapping(self):
+    @pytest.mark.parametrize("mapping_dtype", [torch.int32, torch.int64])
+    def test_gumbel_sample_expanded_idx_mapping(self, mapping_dtype):
         """Multiple tokens mapping to the same request must work correctly."""
         torch.manual_seed(99)
         num_tokens = 6
@@ -299,7 +300,7 @@ class TestGumbelSampling:
 
         logits = torch.randn(num_tokens, vocab_size, dtype=torch.float32, device=DEVICE)
         # tokens 0,1,2 -> req 0; tokens 3,4,5 -> req 1
-        expanded_idx_mapping = torch.tensor([0, 0, 0, 1, 1, 1], dtype=torch.int32, device=DEVICE)
+        expanded_idx_mapping = torch.tensor([0, 0, 0, 1, 1, 1], dtype=mapping_dtype, device=DEVICE)
         temperature = torch.zeros(num_reqs, dtype=torch.float32, device=DEVICE)
         seed = torch.randint(0, 2**31, (num_reqs,), dtype=torch.int64, device=DEVICE)
         pos = torch.arange(num_tokens, dtype=torch.int32, device=DEVICE)

--- a/tests/e2e/pull_request/one_card/test_gumbel_sampling.py
+++ b/tests/e2e/pull_request/one_card/test_gumbel_sampling.py
@@ -11,10 +11,17 @@ import pytest
 import torch
 from vllm.v1.worker.gpu.spec_decode.dspark.speculator import DSparkSpeculator
 
+from tests.e2e.pull_request.one_card.sampling_utils import require_categorical_sampling_operator
+from vllm_ascend.worker.v2.sample import gumbel as gumbel_module
 from vllm_ascend.worker.v2.sample.gumbel import apply_temperature, gumbel_sample
 from vllm_ascend.worker.v2.spec_decode.rejection_sampler_utils import rejection_sample
 
 DEVICE = "npu"
+
+
+@pytest.fixture(scope="module", autouse=True)
+def _require_categorical_sampling_operator():
+    require_categorical_sampling_operator()
 
 
 def _ref_apply_temperature(
@@ -34,6 +41,23 @@ def _ref_apply_temperature(
 
 
 class TestGumbelSampling:
+    def test_fallback_when_operator_is_unavailable(self, monkeypatch):
+        monkeypatch.setattr(gumbel_module, "enable_categorical_sample_op", lambda: False)
+        logits = torch.arange(32, dtype=torch.float32, device=DEVICE).view(1, -1)
+        cache = torch.zeros(1, 1, 32, device=DEVICE)
+        mapping = torch.zeros(1, dtype=torch.int32, device=DEVICE)
+        sampled = gumbel_sample(
+            logits,
+            mapping,
+            torch.zeros(1, device=DEVICE),
+            mapping.to(torch.int64),
+            mapping,
+            True,
+            logits_cache=cache,
+        )
+        assert sampled.item() == 31
+        torch.testing.assert_close(cache[0, 0], logits[0])
+
     @pytest.mark.parametrize(
         "num_tokens,vocab_size",
         [
@@ -522,8 +546,9 @@ class TestGumbelSampling:
             )
 
     @pytest.mark.parametrize("per_token_col", [False, True])
-    @pytest.mark.parametrize("dtype", [torch.float32, torch.bfloat16])
-    def test_gumbel_sample_strided_logits_cache(self, per_token_col, dtype):
+    @pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+    @pytest.mark.parametrize("cache_dtype", [torch.float32, torch.float16, torch.bfloat16])
+    def test_gumbel_sample_strided_logits_cache(self, per_token_col, dtype, cache_dtype):
         """Cache raw logits at mapped request/step slots, preserving padding."""
         torch.manual_seed(202)
         vocab_size = 1031
@@ -539,7 +564,7 @@ class TestGumbelSampling:
         cols = torch.tensor([0, 0, 2, 0, 1, 0, 2, 0], dtype=torch.int32, device=DEVICE)[::2]
         if not per_token_col:
             cols = torch.tensor(1, dtype=torch.int32, device=DEVICE)
-        storage = torch.full((3, 6, vocab_size + 17), 42, dtype=dtype, device=DEVICE)
+        storage = torch.full((3, 6, vocab_size + 17), 42, dtype=cache_dtype, device=DEVICE)
         cache = storage[:, ::2, :]
         expected = storage.clone()
         for token, req in enumerate(mapping.cpu().tolist()):
@@ -577,7 +602,7 @@ class TestGumbelSampling:
     def test_gumbel_sample_rejects_narrow_cache(self):
         logits = torch.zeros(1, 32, device=DEVICE)
         mapping = torch.zeros(1, dtype=torch.int32, device=DEVICE)
-        with pytest.raises(AssertionError, match="is narrower"):
+        with pytest.raises(RuntimeError, match="is narrower"):
             gumbel_sample(
                 logits,
                 mapping,

--- a/tests/e2e/pull_request/one_card/test_gumbel_sampling_heavy_tail.py
+++ b/tests/e2e/pull_request/one_card/test_gumbel_sampling_heavy_tail.py
@@ -1,0 +1,78 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+"""Heavy-tail accuracy coverage for the AscendC-backed Gumbel wrapper."""
+
+import math
+
+import pytest
+import torch
+import torch_npu  # noqa: F401  # Registers the NPU custom-device APIs.
+
+from tests.e2e.pull_request.one_card.sampling_utils import require_categorical_sampling_operator
+from vllm_ascend.worker.v2.sample.gumbel import gumbel_sample
+
+DEVICE = torch.device("npu")
+VOCAB_SIZE = 200_000
+NUM_SAMPLES = 131_072
+SAMPLE_CHUNK_SIZE = 4_096
+HEAD_LOG_GAP = 18.0
+Z_TOLERANCE = 10.0
+
+
+@pytest.fixture(scope="module", autouse=True)
+def _require_categorical_sampling_operator() -> None:
+    require_categorical_sampling_operator()
+
+
+def _make_heavy_tailed_counts() -> torch.Tensor:
+    generator = torch.Generator().manual_seed(1234)
+    counts = torch.randint(1, 4, (VOCAB_SIZE,), generator=generator, dtype=torch.int64)
+    counts[0] = round(math.exp(HEAD_LOG_GAP))
+    return counts
+
+
+def _z_score(observed: int, expected: float, num_trials: int) -> float:
+    probability = expected / num_trials
+    return (observed - expected) / math.sqrt(num_trials * probability * (1.0 - probability))
+
+
+def _sample_broadcast_logits(logits_1d: torch.Tensor, use_fp64: bool) -> torch.Tensor:
+    sampled_chunks = []
+    temperature = torch.ones(1, dtype=torch.float32, device=DEVICE)
+    seed = torch.tensor([0xABCD], dtype=torch.int64, device=DEVICE)
+    for start in range(0, NUM_SAMPLES, SAMPLE_CHUNK_SIZE):
+        chunk_size = min(SAMPLE_CHUNK_SIZE, NUM_SAMPLES - start)
+        logits = logits_1d.unsqueeze(0).expand(chunk_size, VOCAB_SIZE)
+        assert logits.stride() == (0, 1)
+        sampled_chunks.append(
+            gumbel_sample(
+                logits,
+                torch.zeros(chunk_size, dtype=torch.int32, device=DEVICE),
+                temperature,
+                seed,
+                torch.arange(start, start + chunk_size, dtype=torch.int64, device=DEVICE),
+                apply_temperature=True,
+                use_fp64=use_fp64,
+            )
+        )
+    return torch.cat(sampled_chunks)
+
+
+@pytest.mark.parametrize("use_fp64", [False, True])
+def test_heavy_tail_sampling_matches_target_distribution(use_fp64: bool) -> None:
+    """The aggregate tail remains reachable beyond the naive FP32 Gumbel cap."""
+    counts = _make_heavy_tailed_counts()
+    total = counts.sum().item()
+    logits = counts.to(torch.float64).log().to(torch.float32).to(DEVICE)
+
+    sampled = _sample_broadcast_logits(logits, use_fp64)
+    tail_count = torch.count_nonzero(sampled != 0).item()
+    tail_probability = (total - counts[0].item()) / total
+    z_score = _z_score(tail_count, NUM_SAMPLES * tail_probability, NUM_SAMPLES)
+
+    assert sampled.min().item() >= 0
+    assert sampled.max().item() < VOCAB_SIZE
+    assert abs(z_score) < Z_TOLERANCE, (
+        f"sampled tail mass {tail_count / NUM_SAMPLES:.3e} != target {tail_probability:.3e} (z={z_score:.2f})"
+    )

--- a/tests/ut/test_utils.py
+++ b/tests/ut/test_utils.py
@@ -15,6 +15,8 @@
 
 import math
 import os
+import sys
+import types
 from types import SimpleNamespace
 from unittest import mock
 
@@ -38,6 +40,7 @@ class TestUtils(TestBase):
         utils.enable_dsa_cp.cache_clear()
         utils.enable_dsa_cp_full_o_proj.cache_clear()
         utils.enable_pcp_o_proj_weight_sharding.cache_clear()
+        utils._CATEGORICAL_SAMPLE_OP_ENABLED = None
 
     def test_nd_to_nz_2d(self):
         # can be divided by 16
@@ -125,6 +128,43 @@ class TestUtils(TestBase):
         with mock.patch("builtins.__import__") as mock_import_module:
             mock_import_module.side_effect = ImportError("import error")
             self.assertFalse(utils.enable_custom_op())
+
+    def test_enable_categorical_sample_op_uses_general_path_on_a2_a3(self):
+        torch.ops._C_ascend.npu_categorical_sample = object()
+        self.addCleanup(delattr, torch.ops._C_ascend, "npu_categorical_sample")
+
+        with (
+            mock.patch(
+                "vllm_ascend.utils.get_ascend_device_type",
+                return_value=utils.AscendDeviceType.A3,
+            ),
+            mock.patch("vllm_ascend.utils.enable_custom_op", return_value=True) as enable_general,
+            mock.patch("vllm_ascend.utils.bootstrap_custom_op_env") as bootstrap,
+        ):
+            self.assertTrue(utils.enable_categorical_sample_op())
+
+        enable_general.assert_called_once_with()
+        bootstrap.assert_not_called()
+
+    def test_enable_categorical_sample_op_uses_acl_nn_path_on_a5(self):
+        torch.ops._C_ascend.npu_categorical_sample = object()
+        self.addCleanup(delattr, torch.ops._C_ascend, "npu_categorical_sample")
+        native_module = types.ModuleType("vllm_ascend.vllm_ascend_C")
+
+        with (
+            mock.patch(
+                "vllm_ascend.utils.get_ascend_device_type",
+                return_value=utils.AscendDeviceType.A5,
+            ),
+            mock.patch("vllm_ascend.utils.enable_custom_op") as enable_general,
+            mock.patch("vllm_ascend.utils.bootstrap_custom_op_env") as bootstrap,
+            mock.patch.dict(sys.modules, {"vllm_ascend.vllm_ascend_C": native_module}),
+        ):
+            self.assertTrue(utils.enable_categorical_sample_op())
+            self.assertTrue(utils.enable_categorical_sample_op())
+
+        enable_general.assert_not_called()
+        bootstrap.assert_called_once_with(include_vendor_lib=True)
 
     def test_find_hccl_library(self):
         with mock.patch.dict(os.environ, {"HCCL_SO_PATH": "/path/to/hccl/libhccl.so"}):

--- a/vllm_ascend/ops/triton/categorical_sample.py
+++ b/vllm_ascend/ops/triton/categorical_sample.py
@@ -294,7 +294,16 @@ def categorical_sample(
     logits_cache_col: torch.Tensor | None = None,
     use_fp64: bool = False,
 ) -> tuple[torch.Tensor, torch.Tensor]:
-    """Sample with the native categorical interface, without calling native code."""
+    """Sample with the native categorical interface, without calling native code.
+
+    ``use_fp64`` selects the native 42-fractional-bit integer-mass algorithm,
+    not floating-point double precision. FP32 sums preserve the C220 native
+    tile/repeat/CDF ordering. Cache entries contain raw, unscaled logits.
+
+    Invalid device values trigger Triton's device assertion; its runtime
+    diagnostic text differs from the AscendC assertion. No device values are
+    copied to the host for validation, so the call can be captured in ACLGraph.
+    """
     logits = processed_logits
     float_dtypes = (torch.float16, torch.bfloat16, torch.float32)
     if logits.device.type != "npu" or logits.ndim != 2 or logits.dtype not in float_dtypes:

--- a/vllm_ascend/ops/triton/categorical_sample.py
+++ b/vllm_ascend/ops/triton/categorical_sample.py
@@ -191,12 +191,17 @@ def _categorical_kernel(
             if FP64:
                 # C220 has no vector uint64 select. Sum 16-bit limbs in
                 # uint32 (4096 * 65535 fits), then combine scalar uint64s.
-                low, high = _fixed_mass_words(weights)
-                tile_mass = (
-                    tl.sum(low & 0xFFFF, 0).to(tl.uint64)
-                    + (tl.sum((low >> 16) & 0xFFFF, 0).to(tl.uint64) << 16)
-                    + (tl.sum(high, 0).to(tl.uint64) << 32)
-                )
+                # Bound conversion temporaries without changing native's
+                # 4096-element FP32 tiles or their accumulation order.
+                tile_mass = tl.full((), 0, tl.uint64)
+                for start in range(0, BLOCK, 256):
+                    chunk = tl.gather(weights, start + tl.arange(0, 256), axis=0)
+                    low, high = _fixed_mass_words(chunk)
+                    tile_mass += (
+                        tl.sum(low & 0xFFFF, 0).to(tl.uint64)
+                        + (tl.sum((low >> 16) & 0xFFFF, 0).to(tl.uint64) << 16)
+                        + (tl.sum(high, 0).to(tl.uint64) << 32)
+                    )
                 masses_low = tl.where(tile_ids == tile, tile_mass.to(tl.uint32), masses_low)
                 masses_high = tl.where(tile_ids == tile, (tile_mass >> 32).to(tl.uint32), masses_high)
                 total_mass += tile_mass

--- a/vllm_ascend/ops/triton/categorical_sample.py
+++ b/vllm_ascend/ops/triton/categorical_sample.py
@@ -115,17 +115,15 @@ def _categorical_kernel(
         if RETURN_LSE:
             tl.store(lse + row, 0.0)
         return
-    tl.device_assert(
-        (request >= 0) & (request < REQUESTS), "CategoricalSample expanded index mapping is outside request state"
-    )
+    if (request < 0) | (request >= REQUESTS):
+        tl.device_assert(False, "CategoricalSample expanded index mapping is outside request state")
     temperature = tl.load(temperatures + request)
     column = tl.full((), 0, tl.int32)
     if cache is not None:
         if cache_col is not None:
             column = tl.load(cache_col + tl.where(PER_ROW_COL, row, 0))
-        tl.device_assert(
-            (column >= 0) & (column < COLS), "CategoricalSample output processed logits column is outside cache bounds"
-        )
+        if (column < 0) | (column >= COLS):
+            tl.device_assert(False, "CategoricalSample output processed logits column is outside cache bounds")
     offsets = tl.arange(0, BLOCK)
     row_offset = row * row_stride
     row_max = tl.full((), -float("inf"), tl.float32)
@@ -135,16 +133,15 @@ def _categorical_kernel(
         indices = tile * TILE + offsets
         values = _load_logits(logits, row_offset, indices, VOCAB, temperature, APPLY)
         valid = (offsets < TILE) & (indices < VOCAB)
-        tl.device_assert(
-            tl.sum((valid & (values != values)).to(tl.int32), 0) == 0,
-            "CategoricalSample processed logits must not contain NaN",
-        )
+        if tl.sum((valid & (values != values)).to(tl.int32), 0) != 0:
+            tl.device_assert(False, "CategoricalSample processed logits must not contain NaN")
         values = tl.where(valid, values, -float("inf"))
         maximum = tl.max(values, 0)
         index = tl.min(tl.where(valid & (values == maximum), indices, VOCAB), 0)
         first_max = tl.where(maximum > row_max, index, first_max)
         row_max = tl.maximum(row_max, maximum)
-    tl.device_assert(row_max != -float("inf"), "CategoricalSample processed logits row must not be all -inf")
+    if row_max == -float("inf"):
+        tl.device_assert(False, "CategoricalSample processed logits row must not be all -inf")
 
     total = tl.full((), 0.0, tl.float32)
     total_mass = tl.full((), 0, tl.uint64)

--- a/vllm_ascend/ops/triton/categorical_sample.py
+++ b/vllm_ascend/ops/triton/categorical_sample.py
@@ -180,7 +180,12 @@ def _categorical_kernel(
                     for index in range(length):
                         tile_sum += _element(weights, index)
                 else:
-                    tile_sum = tl.sum(weights, 0)
+                    # C220 calcount ReduceSum reduces each 64-float repeat,
+                    # then accumulates repeat results in order (get_acc_val).
+                    # A single tl.sum uses a different floating-point tree.
+                    repeats = tl.sum(tl.reshape(weights, (BLOCK // 64, 64)), 1)
+                    for repeat in range(length // 64):
+                        tile_sum += _element(repeats, repeat)
                 sums = tl.where(tile_ids == tile, tile_sum, sums)
                 total += tile_sum
             if FP64:

--- a/vllm_ascend/ops/triton/categorical_sample.py
+++ b/vllm_ascend/ops/triton/categorical_sample.py
@@ -74,8 +74,10 @@ def _element(values, index):
 def _load_logits(logits, row_offset, offsets, vocab, temperature, APPLY: tl.constexpr):
     values = tl.load(logits + row_offset + offsets, offsets < vocab, other=-float("inf")).to(tl.float32)
     if logits.dtype.element_ty == tl.float32:
-        # Native FP32 LoadTile uses Adds(0); preserve its signed-zero behavior.
-        values = values + 0.0
+        # Native FP32 LoadTile uses Adds(0), normalizing -0. Triton's float
+        # optimizer can eliminate an add-zero before a cache dtype cast.
+        bits = values.to(tl.int32, bitcast=True)
+        values = tl.where(bits == -0x80000000, 0, bits).to(tl.float32, bitcast=True)
     if APPLY:
         if temperature != 0:
             values = values / temperature
@@ -157,7 +159,8 @@ def _categorical_kernel(
         valid = (offsets < TILE) & (indices < VOCAB)
         raw = tl.load(logits + row_offset + indices, valid, other=-float("inf")).to(tl.float32)
         if logits.dtype.element_ty == tl.float32:
-            raw = raw + 0.0
+            bits = raw.to(tl.int32, bitcast=True)
+            raw = tl.where(bits == -0x80000000, 0, bits).to(tl.float32, bitcast=True)
         if cache is not None:
             tl.store(
                 cache + request.to(tl.int64) * cache_stride + column.to(tl.int64) * col_stride + indices, raw, valid

--- a/vllm_ascend/ops/triton/categorical_sample.py
+++ b/vllm_ascend/ops/triton/categorical_sample.py
@@ -203,7 +203,9 @@ def _categorical_kernel(
         target = uniform * total
         prefix = tl.full((), 0.0, tl.float32)
     selected_tile = tl.full((), TILES - 1, tl.int32)
-    for tile in range(TILES):
+    tile = tl.full((), 0, tl.int32)
+    selected = tl.full((), False, tl.int1)
+    while (tile < TILES) & ~selected:
         if FP64:
             next_prefix = prefix + _element(masses, tile)
             selected = target < next_prefix
@@ -212,14 +214,18 @@ def _categorical_kernel(
             selected = target <= next_prefix
         if selected | (tile + 1 == TILES):
             selected_tile = tile
-            break
-        prefix = next_prefix
+            selected = tl.full((), True, tl.int1)
+        else:
+            prefix = next_prefix
+        tile += 1
     indices = selected_tile * TILE + offsets
     values = _load_logits(logits, row_offset, indices, VOCAB, temperature, APPLY)
     weights = tl.exp(values - row_max)
     length = tl.minimum(TILE, VOCAB - selected_tile * TILE)
     chosen = selected_tile * TILE
-    for index in range(length):
+    index = tl.full((), 0, tl.int32)
+    selected = tl.full((), False, tl.int1)
+    while (index < length) & ~selected:
         weight = _element(weights, index)
         if FP64:
             mass = _fixed_mass(weight)
@@ -232,7 +238,7 @@ def _categorical_kernel(
             selected = prefix >= target
         if selected:
             chosen = selected_tile * TILE + index
-            break
+        index += 1
     tl.store(output + row, chosen)
 
 

--- a/vllm_ascend/ops/triton/categorical_sample.py
+++ b/vllm_ascend/ops/triton/categorical_sample.py
@@ -73,6 +73,9 @@ def _element(values, index):
 @triton.jit
 def _load_logits(logits, row_offset, offsets, vocab, temperature, APPLY: tl.constexpr):
     values = tl.load(logits + row_offset + offsets, offsets < vocab, other=-float("inf")).to(tl.float32)
+    if logits.dtype.element_ty == tl.float32:
+        # Native FP32 LoadTile uses Adds(0); preserve its signed-zero behavior.
+        values = values + 0.0
     if APPLY:
         if temperature != 0:
             values = values / temperature
@@ -154,6 +157,8 @@ def _categorical_kernel(
         indices = tile * TILE + offsets
         valid = (offsets < TILE) & (indices < VOCAB)
         raw = tl.load(logits + row_offset + indices, valid, other=-float("inf")).to(tl.float32)
+        if logits.dtype.element_ty == tl.float32:
+            raw = raw + 0.0
         if cache is not None:
             tl.store(
                 cache + request.to(tl.int64) * cache_stride + column.to(tl.int64) * col_stride + indices, raw, valid
@@ -184,7 +189,7 @@ def _categorical_kernel(
                 low, high = _fixed_mass_words(weights)
                 tile_mass = (
                     tl.sum(low & 0xFFFF, 0).to(tl.uint64)
-                    + (tl.sum(low >> 16, 0).to(tl.uint64) << 16)
+                    + (tl.sum((low >> 16) & 0xFFFF, 0).to(tl.uint64) << 16)
                     + (tl.sum(high, 0).to(tl.uint64) << 32)
                 )
                 masses_low = tl.where(tile_ids == tile, tile_mass.to(tl.uint32), masses_low)

--- a/vllm_ascend/ops/triton/categorical_sample.py
+++ b/vllm_ascend/ops/triton/categorical_sample.py
@@ -104,13 +104,17 @@ def _categorical_kernel(
         if RETURN_LSE:
             tl.store(lse + row, 0.0)
         return
-    tl.device_assert((request >= 0) & (request < REQUESTS), "invalid categorical request index")
+    tl.device_assert(
+        (request >= 0) & (request < REQUESTS), "CategoricalSample expanded index mapping is outside request state"
+    )
     temperature = tl.load(temperatures + request)
     column = tl.full((), 0, tl.int32)
     if cache is not None:
         if cache_col is not None:
             column = tl.load(cache_col + tl.where(PER_ROW_COL, row, 0))
-        tl.device_assert((column >= 0) & (column < COLS), "invalid categorical cache column")
+        tl.device_assert(
+            (column >= 0) & (column < COLS), "CategoricalSample output processed logits column is outside cache bounds"
+        )
     offsets = tl.arange(0, BLOCK)
     row_offset = row * row_stride
     row_max = tl.full((), -float("inf"), tl.float32)
@@ -120,13 +124,16 @@ def _categorical_kernel(
         indices = tile * TILE + offsets
         values = _load_logits(logits, row_offset, indices, VOCAB, temperature, APPLY)
         valid = (offsets < TILE) & (indices < VOCAB)
-        tl.device_assert(tl.sum((valid & (values != values)).to(tl.int32), 0) == 0, "NaN categorical logits")
+        tl.device_assert(
+            tl.sum((valid & (values != values)).to(tl.int32), 0) == 0,
+            "CategoricalSample processed logits must not contain NaN",
+        )
         values = tl.where(valid, values, -float("inf"))
         maximum = tl.max(values, 0)
         index = tl.min(tl.where(valid & (values == maximum), indices, VOCAB), 0)
         first_max = tl.where(maximum > row_max, index, first_max)
         row_max = tl.maximum(row_max, maximum)
-    tl.device_assert(row_max != -float("inf"), "categorical row has no probability mass")
+    tl.device_assert(row_max != -float("inf"), "CategoricalSample processed logits row must not be all -inf")
 
     total = tl.full((), 0.0, tl.float32)
     total_mass = tl.full((), 0, tl.uint64)
@@ -207,7 +214,9 @@ def _categorical_kernel(
     selected = tl.full((), False, tl.int1)
     while (tile < TILES) & ~selected:
         if FP64:
-            next_prefix = prefix + _element(masses, tile)
+            # Ascend's gather does not accept uint64; only one nonzero lane
+            # participates, so this reduction is an exact integer lookup.
+            next_prefix = prefix + tl.sum(tl.where(tile_ids == tile, masses, 0), 0)
             selected = target < next_prefix
         else:
             next_prefix = prefix + _element(sums, tile)

--- a/vllm_ascend/ops/triton/categorical_sample.py
+++ b/vllm_ascend/ops/triton/categorical_sample.py
@@ -44,17 +44,25 @@ def _mul_high64(lhs, rhs):
 
 
 @triton.jit
-def _fixed_mass(weight):
+def _fixed_mass_words(weight):
     # exp(logit - max) is in [0, 1]. Scale its exact FP32 significand
     # by 2^42 and round half up, as FloatToFixedMass does in AscendC.
     bits = weight.to(tl.uint32, bitcast=True)
     exponent = (bits >> 23) & 255
-    mantissa = ((bits & 0x7FFFFF) | tl.where(exponent == 0, 0, 0x800000)).to(tl.uint64)
+    mantissa = (bits & 0x7FFFFF) | tl.where(exponent == 0, 0, 0x800000)
     shift = tl.where(exponent == 0, -107, exponent.to(tl.int32) - 108)
-    right = tl.minimum(tl.maximum(-shift, 1), 63)
-    rounded = (mantissa + (tl.full((), 1, tl.uint64) << (right - 1))) >> right
-    mass = tl.where(shift >= 0, mantissa << tl.maximum(shift, 0), rounded)
-    return tl.where((weight > 0) & (shift > -64), mass, 0).to(tl.uint64)
+    right = tl.minimum(tl.maximum(-shift, 1), 24)
+    rounded = (mantissa + (1 << (right - 1))) >> right
+    low = tl.where(shift >= 0, mantissa << tl.maximum(shift, 0), rounded)
+    low = tl.where((weight > 0) & (shift >= -24), low, 0).to(tl.uint32)
+    high = tl.where(shift > 0, mantissa >> tl.minimum(32 - shift, 31), 0).to(tl.uint32)
+    return low, high
+
+
+@triton.jit
+def _fixed_mass(weight):
+    low, high = _fixed_mass_words(weight)
+    return low.to(tl.uint64) | (high.to(tl.uint64) << 32)
 
 
 @triton.jit
@@ -139,7 +147,8 @@ def _categorical_kernel(
     total_mass = tl.full((), 0, tl.uint64)
     infinity_count = tl.full((), 0, tl.int32)
     sums = tl.full((SUM_BLOCK,), 0.0, tl.float32)
-    masses = tl.full((SUM_BLOCK,), 0, tl.uint64)
+    masses_low = tl.full((SUM_BLOCK,), 0, tl.uint32)
+    masses_high = tl.full((SUM_BLOCK,), 0, tl.uint32)
     tile_ids = tl.arange(0, SUM_BLOCK)
     for tile in range(TILES):
         indices = tile * TILE + offsets
@@ -170,9 +179,16 @@ def _categorical_kernel(
                 sums = tl.where(tile_ids == tile, tile_sum, sums)
                 total += tile_sum
             if FP64:
-                fixed = _fixed_mass(weights)
-                tile_mass = tl.sum(fixed, 0)
-                masses = tl.where(tile_ids == tile, tile_mass, masses)
+                # C220 has no vector uint64 select. Sum 16-bit limbs in
+                # uint32 (4096 * 65535 fits), then combine scalar uint64s.
+                low, high = _fixed_mass_words(weights)
+                tile_mass = (
+                    tl.sum(low & 0xFFFF, 0).to(tl.uint64)
+                    + (tl.sum(low >> 16, 0).to(tl.uint64) << 16)
+                    + (tl.sum(high, 0).to(tl.uint64) << 32)
+                )
+                masses_low = tl.where(tile_ids == tile, tile_mass.to(tl.uint32), masses_low)
+                masses_high = tl.where(tile_ids == tile, (tile_mass >> 32).to(tl.uint32), masses_high)
                 total_mass += tile_mass
 
     if RETURN_LSE:
@@ -214,9 +230,9 @@ def _categorical_kernel(
     selected = tl.full((), False, tl.int1)
     while (tile < TILES) & ~selected:
         if FP64:
-            # Ascend's gather does not accept uint64; only one nonzero lane
-            # participates, so this reduction is an exact integer lookup.
-            next_prefix = prefix + tl.sum(tl.where(tile_ids == tile, masses, 0), 0)
+            low = tl.sum(tl.where(tile_ids == tile, masses_low, 0), 0).to(tl.uint64)
+            high = tl.sum(tl.where(tile_ids == tile, masses_high, 0), 0).to(tl.uint64)
+            next_prefix = prefix + (low | (high << 32))
             selected = target < next_prefix
         else:
             next_prefix = prefix + _element(sums, tile)

--- a/vllm_ascend/ops/triton/categorical_sample.py
+++ b/vllm_ascend/ops/triton/categorical_sample.py
@@ -115,6 +115,8 @@ def _categorical_kernel(
         if RETURN_LSE:
             tl.store(lse + row, 0.0)
         return
+    # Keep assertion machinery off the valid path: unconditional scalar
+    # device_assert calls break ACLGraph/native-op interleaving on C220.
     if (request < 0) | (request >= REQUESTS):
         tl.device_assert(False, "CategoricalSample expanded index mapping is outside request state")
     temperature = tl.load(temperatures + request)

--- a/vllm_ascend/ops/triton/categorical_sample.py
+++ b/vllm_ascend/ops/triton/categorical_sample.py
@@ -1,0 +1,328 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+"""Triton counterpart of the AscendC categorical sampler.
+
+This is an explicit, opt-in operator entry point; importing it does not change
+the model runner's backend. The RNG and fixed-point mode follow the native
+operator, not the Gumbel-max implementation in worker/v2/sample/gumbel.py.
+"""
+
+import torch
+from vllm.triton_utils import tl, triton
+
+
+@triton.jit
+def _philox(seed, position):
+    c0 = position.to(tl.uint32)
+    c1 = (position.to(tl.uint64) >> 32).to(tl.uint32)
+    c2 = tl.full((), 0, tl.uint32)
+    c3 = tl.full((), 0, tl.uint32)
+    k0 = seed.to(tl.uint32)
+    k1 = (seed.to(tl.uint64) >> 32).to(tl.uint32)
+    for _ in tl.static_range(10):
+        hi0 = tl.umulhi(c0, 0xD2511F53)
+        hi1 = tl.umulhi(c2, 0xCD9E8D57)
+        lo0 = c0 * 0xD2511F53
+        lo1 = c2 * 0xCD9E8D57
+        c0, c1, c2, c3 = hi1 ^ c1 ^ k0, lo1, hi0 ^ c3 ^ k1, lo0
+        k0 += 0x9E3779B9
+        k1 += 0xBB67AE85
+    return c0, c1
+
+
+@triton.jit
+def _mul_high64(lhs, rhs):
+    lhs_low = lhs & 0xFFFFFFFF
+    rhs_low = rhs & 0xFFFFFFFF
+    lhs_high = lhs >> 32
+    rhs_high = rhs >> 32
+    low_product = lhs_low * rhs_low
+    middle = lhs_high * rhs_low + (low_product >> 32)
+    upper_middle = (middle & 0xFFFFFFFF) + lhs_low * rhs_high
+    return lhs_high * rhs_high + (middle >> 32) + (upper_middle >> 32)
+
+
+@triton.jit
+def _fixed_mass(weight):
+    # exp(logit - max) is in [0, 1]. Scale its exact FP32 significand
+    # by 2^42 and round half up, as FloatToFixedMass does in AscendC.
+    bits = weight.to(tl.uint32, bitcast=True)
+    exponent = (bits >> 23) & 255
+    mantissa = ((bits & 0x7FFFFF) | tl.where(exponent == 0, 0, 0x800000)).to(tl.uint64)
+    shift = tl.where(exponent == 0, -107, exponent.to(tl.int32) - 108)
+    right = tl.minimum(tl.maximum(-shift, 1), 63)
+    rounded = (mantissa + (tl.full((), 1, tl.uint64) << (right - 1))) >> right
+    mass = tl.where(shift >= 0, mantissa << tl.maximum(shift, 0), rounded)
+    return tl.where((weight > 0) & (shift > -64), mass, 0).to(tl.uint64)
+
+
+@triton.jit
+def _element(values, index):
+    return tl.sum(tl.gather(values, tl.full((1,), index, tl.int32), axis=0), axis=0)
+
+
+@triton.jit
+def _load_logits(logits, row_offset, offsets, vocab, temperature, APPLY: tl.constexpr):
+    values = tl.load(logits + row_offset + offsets, offsets < vocab, other=-float("inf")).to(tl.float32)
+    if APPLY:
+        if temperature != 0:
+            values = values / temperature
+    return values
+
+
+@triton.jit
+def _categorical_kernel(
+    logits,
+    mapping,
+    temperatures,
+    seeds,
+    positions,
+    cache,
+    cache_col,
+    output,
+    lse,
+    row_stride: tl.constexpr,
+    cache_stride: tl.constexpr,
+    col_stride: tl.constexpr,
+    VOCAB: tl.constexpr,
+    REQUESTS: tl.constexpr,
+    COLS: tl.constexpr,
+    PER_ROW_COL: tl.constexpr,
+    APPLY: tl.constexpr,
+    RETURN_LSE: tl.constexpr,
+    FP64: tl.constexpr,
+    TILE: tl.constexpr,
+    BLOCK: tl.constexpr,
+    TILES: tl.constexpr,
+    SUM_BLOCK: tl.constexpr,
+):
+    row = tl.program_id(0).to(tl.int64)
+    request = tl.load(mapping + row)
+    if request == -1:
+        tl.store(output + row, 0)
+        if RETURN_LSE:
+            tl.store(lse + row, 0.0)
+        return
+    tl.device_assert((request >= 0) & (request < REQUESTS), "invalid categorical request index")
+    temperature = tl.load(temperatures + request)
+    column = tl.full((), 0, tl.int32)
+    if cache is not None:
+        if cache_col is not None:
+            column = tl.load(cache_col + tl.where(PER_ROW_COL, row, 0))
+        tl.device_assert((column >= 0) & (column < COLS), "invalid categorical cache column")
+    offsets = tl.arange(0, BLOCK)
+    row_offset = row * row_stride
+    row_max = tl.full((), -float("inf"), tl.float32)
+    first_max = tl.full((), 0, tl.int32)
+    # Validate the entire row before writing any raw-logit cache entries.
+    for tile in range(TILES):
+        indices = tile * TILE + offsets
+        values = _load_logits(logits, row_offset, indices, VOCAB, temperature, APPLY)
+        valid = (offsets < TILE) & (indices < VOCAB)
+        tl.device_assert(tl.sum((valid & (values != values)).to(tl.int32), 0) == 0, "NaN categorical logits")
+        values = tl.where(valid, values, -float("inf"))
+        maximum = tl.max(values, 0)
+        index = tl.min(tl.where(valid & (values == maximum), indices, VOCAB), 0)
+        first_max = tl.where(maximum > row_max, index, first_max)
+        row_max = tl.maximum(row_max, maximum)
+    tl.device_assert(row_max != -float("inf"), "categorical row has no probability mass")
+
+    total = tl.full((), 0.0, tl.float32)
+    total_mass = tl.full((), 0, tl.uint64)
+    infinity_count = tl.full((), 0, tl.int32)
+    sums = tl.full((SUM_BLOCK,), 0.0, tl.float32)
+    masses = tl.full((SUM_BLOCK,), 0, tl.uint64)
+    tile_ids = tl.arange(0, SUM_BLOCK)
+    for tile in range(TILES):
+        indices = tile * TILE + offsets
+        valid = (offsets < TILE) & (indices < VOCAB)
+        raw = tl.load(logits + row_offset + indices, valid, other=-float("inf")).to(tl.float32)
+        if cache is not None:
+            tl.store(
+                cache + request.to(tl.int64) * cache_stride + column.to(tl.int64) * col_stride + indices, raw, valid
+            )
+        values = raw
+        if APPLY:
+            if temperature != 0:
+                values = values / temperature
+        if row_max == float("inf"):
+            infinity_count += tl.sum((valid & (values == float("inf"))).to(tl.int32), 0)
+        elif (temperature != 0) | RETURN_LSE:
+            weights = tl.where(valid, tl.exp(values - row_max), 0.0)
+            if (not FP64) or RETURN_LSE:
+                length = tl.minimum(TILE, VOCAB - tile * TILE)
+                tile_sum = tl.full((), 0.0, tl.float32)
+                if length % 256 != 0:
+                    # Native unaligned tails and selected CDFs accumulate in
+                    # token order. A parallel cumsum changes FP32 boundaries.
+                    for index in range(length):
+                        tile_sum += _element(weights, index)
+                else:
+                    tile_sum = tl.sum(weights, 0)
+                sums = tl.where(tile_ids == tile, tile_sum, sums)
+                total += tile_sum
+            if FP64:
+                fixed = _fixed_mass(weights)
+                tile_mass = tl.sum(fixed, 0)
+                masses = tl.where(tile_ids == tile, tile_mass, masses)
+                total_mass += tile_mass
+
+    if RETURN_LSE:
+        tl.store(lse + row, tl.where(row_max == float("inf"), row_max, row_max + tl.log(total)))
+    if temperature == 0:
+        tl.store(output + row, first_max)
+        return
+
+    random0, random1 = _philox(tl.load(seeds + request), tl.load(positions + row))
+    uniform = ((random0 >> 8).to(tl.float32) + 0.5) * (1.0 / 16777216.0)
+    random64 = (random1.to(tl.uint64) << 32) | random0.to(tl.uint64)
+    if row_max == float("inf"):
+        if FP64:
+            rank = _mul_high64(random64, infinity_count.to(tl.uint64)).to(tl.int32)
+        else:
+            rank = (uniform * infinity_count.to(tl.float32)).to(tl.int32)
+            rank = tl.minimum(rank, infinity_count - 1)
+        seen = tl.full((), 0, tl.int32)
+        chosen = tl.full((), 0, tl.int32)
+        for tile in range(TILES):
+            indices = tile * TILE + offsets
+            values = _load_logits(logits, row_offset, indices, VOCAB, temperature, APPLY)
+            support = (offsets < TILE) & (indices < VOCAB) & (values == float("inf"))
+            cumulative = tl.cumsum(support.to(tl.int32), 0) + seen
+            candidate = tl.min(tl.where(support & (cumulative == rank + 1), indices, VOCAB), 0)
+            chosen = tl.where(candidate < VOCAB, candidate, chosen)
+            seen += tl.sum(support.to(tl.int32), 0)
+        tl.store(output + row, chosen)
+        return
+
+    if FP64:
+        target = _mul_high64(random64, total_mass)
+        prefix = tl.full((), 0, tl.uint64)
+    else:
+        target = uniform * total
+        prefix = tl.full((), 0.0, tl.float32)
+    selected_tile = tl.full((), TILES - 1, tl.int32)
+    for tile in range(TILES):
+        if FP64:
+            next_prefix = prefix + _element(masses, tile)
+            selected = target < next_prefix
+        else:
+            next_prefix = prefix + _element(sums, tile)
+            selected = target <= next_prefix
+        if selected | (tile + 1 == TILES):
+            selected_tile = tile
+            break
+        prefix = next_prefix
+    indices = selected_tile * TILE + offsets
+    values = _load_logits(logits, row_offset, indices, VOCAB, temperature, APPLY)
+    weights = tl.exp(values - row_max)
+    length = tl.minimum(TILE, VOCAB - selected_tile * TILE)
+    chosen = selected_tile * TILE
+    for index in range(length):
+        weight = _element(weights, index)
+        if FP64:
+            mass = _fixed_mass(weight)
+            chosen = tl.where(mass > 0, selected_tile * TILE + index, chosen)
+            prefix += mass
+            selected = prefix > target
+        else:
+            chosen = tl.where(weight > 0, selected_tile * TILE + index, chosen)
+            prefix += weight
+            selected = prefix >= target
+        if selected:
+            chosen = selected_tile * TILE + index
+            break
+    tl.store(output + row, chosen)
+
+
+def categorical_sample(
+    processed_logits: torch.Tensor,
+    expanded_idx_mapping: torch.Tensor,
+    temperature: torch.Tensor,
+    seed: torch.Tensor,
+    pos: torch.Tensor,
+    return_lse: bool,
+    apply_temperature: bool,
+    logits_cache: torch.Tensor | None = None,
+    logits_cache_col: torch.Tensor | None = None,
+    use_fp64: bool = False,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Sample with the native categorical interface, without calling native code."""
+    logits = processed_logits
+    float_dtypes = (torch.float16, torch.bfloat16, torch.float32)
+    if logits.device.type != "npu" or logits.ndim != 2 or logits.dtype not in float_dtypes:
+        raise RuntimeError("processed_logits must be a 2D NPU float16, bfloat16, or float32 tensor")
+    rows, vocab = logits.shape
+    if not 0 < rows <= 0xFFFFFFFF or not 0 < vocab <= 1_048_576:
+        raise RuntimeError("invalid categorical logits shape")
+    if logits.stride(1) != 1 or not (logits.stride(0) == 0 or vocab <= logits.stride(0) <= 0xFFFFFFFF):
+        raise RuntimeError("invalid categorical logits strides")
+    for name, tensor, dtype in (
+        ("expanded_idx_mapping", expanded_idx_mapping, torch.int32),
+        ("temperature", temperature, torch.float32),
+        ("seed", seed, torch.int64),
+        ("pos", pos, torch.int64),
+    ):
+        if tensor.device != logits.device or tensor.ndim != 1 or tensor.dtype != dtype or not tensor.is_contiguous():
+            raise RuntimeError(f"{name} must be contiguous 1D {dtype} on the logits device")
+    if expanded_idx_mapping.numel() != rows or pos.numel() != rows:
+        raise RuntimeError("mapping and pos must have one entry per row")
+    requests = temperature.numel()
+    if requests == 0 or seed.numel() != requests:
+        raise RuntimeError("seed and temperature must have the same nonzero length")
+    cache_stride, col_stride, cols = 0, 0, 1
+    if logits_cache is not None:
+        cache = logits_cache
+        if cache.device != logits.device or cache.ndim not in (2, 3) or cache.dtype not in float_dtypes:
+            raise RuntimeError("logits_cache must be 2D or 3D floating point on the logits device")
+        if cache.shape[0] != requests or cache.shape[-1] < vocab or cache.stride(-1) != 1:
+            raise RuntimeError("invalid logits_cache shape or vocabulary stride")
+        cols = cache.shape[1] if cache.ndim == 3 else 1
+        col_stride = cache.stride(1) if cache.ndim == 3 else cache.shape[-1]
+        cache_stride = cache.stride(0)
+        if cols == 0 or not vocab <= col_stride <= 0xFFFFFFFF:
+            raise RuntimeError("invalid logits_cache column stride")
+        if not (cols - 1) * col_stride + vocab <= cache_stride <= 0xFFFFFFFF:
+            raise RuntimeError("invalid logits_cache request stride")
+    if logits_cache_col is not None:
+        col = logits_cache_col
+        if logits_cache is None:
+            raise RuntimeError("logits_cache_col requires logits_cache")
+        if col.device != logits.device or col.dtype != torch.int32 or not col.is_contiguous():
+            raise RuntimeError("logits_cache_col must be contiguous int32 on the logits device")
+        if col.ndim != 0 and (col.ndim != 1 or col.numel() != rows):
+            raise RuntimeError("logits_cache_col must be scalar or have one entry per row")
+    sampled = torch.empty(rows, dtype=torch.int64, device=logits.device)
+    lse = torch.empty(rows if return_lse else 0, dtype=torch.float32, device=logits.device)
+    tile = min(4096, triton.cdiv(vocab, 256) * 256)
+    tiles = triton.cdiv(vocab, tile)
+    _categorical_kernel[(rows,)](
+        logits,
+        expanded_idx_mapping,
+        temperature,
+        seed,
+        pos,
+        logits_cache,
+        logits_cache_col,
+        sampled,
+        lse,
+        logits.stride(0),
+        cache_stride,
+        col_stride,
+        vocab,
+        requests,
+        cols,
+        logits_cache_col is not None and logits_cache_col.ndim == 1,
+        apply_temperature,
+        return_lse,
+        use_fp64,
+        tile,
+        triton.next_power_of_2(tile),
+        tiles,
+        triton.next_power_of_2(tiles),
+        enable_fp_fusion=False,
+        debug=True,
+        multibuffer=False,
+    )
+    return sampled, lse

--- a/vllm_ascend/utils.py
+++ b/vllm_ascend/utils.py
@@ -65,6 +65,7 @@ ACL_FORMAT_FRACTAL_ND = 2
 ACL_FORMAT_FRACTAL_NZ = 29
 
 _CUSTOM_OP_ENABLED = None
+_CATEGORICAL_SAMPLE_OP_ENABLED = None
 _DEVICE_PRINT_OP_REGISTERED = False
 _CURRENT_STREAM = None
 _GLOBAL_STREAM = None
@@ -472,6 +473,41 @@ def enable_custom_op():
                 e,
             )
     return _CUSTOM_OP_ENABLED
+
+
+def enable_categorical_sample_op() -> bool:
+    """Register the categorical sampler through the device-specific path.
+
+    A2/A3 use the general custom-op initializer. A5 keeps that global gate
+    disabled while custom-op coverage is incomplete, but supports ACLNN
+    operators packaged in ``_cann_ops_custom``. Importing the native extension
+    here registers the categorical Torch operator without enabling any A5
+    custom-op call sites guarded by :func:`enable_custom_op`.
+    """
+    global _CATEGORICAL_SAMPLE_OP_ENABLED
+
+    if _CATEGORICAL_SAMPLE_OP_ENABLED is not None:
+        return _CATEGORICAL_SAMPLE_OP_ENABLED
+
+    if get_ascend_device_type() != AscendDeviceType.A5:
+        _CATEGORICAL_SAMPLE_OP_ENABLED = enable_custom_op() and hasattr(torch.ops._C_ascend, "npu_categorical_sample")
+        return _CATEGORICAL_SAMPLE_OP_ENABLED
+
+    try:
+        if not torch.compiler.is_compiling():
+            bootstrap_custom_op_env(include_vendor_lib=True)
+        import vllm_ascend.vllm_ascend_C  # type: ignore  # noqa: F401
+
+        _CATEGORICAL_SAMPLE_OP_ENABLED = hasattr(torch.ops._C_ascend, "npu_categorical_sample")
+    except ImportError as error:
+        _CATEGORICAL_SAMPLE_OP_ENABLED = False
+        logger.warning(
+            "Failed to register the A5 categorical sampling operator. "
+            "Build and install the categorical custom OPP before using MRV2 sampling. error=%s",
+            error,
+        )
+
+    return _CATEGORICAL_SAMPLE_OP_ENABLED
 
 
 def find_hccl_library() -> str:

--- a/vllm_ascend/worker/v2/sample/gumbel.py
+++ b/vllm_ascend/worker/v2/sample/gumbel.py
@@ -267,7 +267,7 @@ def gumbel_sample(
             use_fp64,
         )
 
-    expanded_idx_mapping = expanded_idx_mapping.contiguous()
+    expanded_idx_mapping = expanded_idx_mapping.to(torch.int32).contiguous()
     pos = pos.to(torch.int64).contiguous()
     if is_drafting:
         # Use the same draft/target random-stream separation as upstream.

--- a/vllm_ascend/worker/v2/sample/gumbel.py
+++ b/vllm_ascend/worker/v2/sample/gumbel.py
@@ -20,6 +20,8 @@
 import torch
 from vllm.triton_utils import tl, triton
 
+from vllm_ascend.utils import enable_categorical_sample_op
+
 
 @triton.jit(do_not_specialize=["logits_stride", "vocab_size"])
 def _temperature_kernel(
@@ -172,7 +174,7 @@ def _gumbel_sample_kernel(
         tl.store(local_max_ptr + token_idx * local_max_stride + block_idx, value)
 
 
-def gumbel_sample(
+def _fallback_gumbel_sample(
     logits: torch.Tensor,  # [num_tokens, vocab_size]
     expanded_idx_mapping: torch.Tensor,  # [num_tokens]
     temperature: torch.Tensor,  # [max_num_reqs]
@@ -237,3 +239,53 @@ def gumbel_sample(
     max_block_idx = local_max.argmax(dim=-1, keepdim=True)
     sampled = local_argmax.gather(dim=-1, index=max_block_idx).view(-1)
     return sampled
+
+
+def gumbel_sample(
+    logits: torch.Tensor,
+    expanded_idx_mapping: torch.Tensor,
+    temperature: torch.Tensor,
+    seed: torch.Tensor,
+    pos: torch.Tensor,
+    apply_temperature: bool,
+    is_drafting: bool = False,
+    logits_cache: torch.Tensor | None = None,
+    logits_cache_col: torch.Tensor | None = None,
+    use_fp64: bool = False,
+) -> torch.Tensor:
+    if not enable_categorical_sample_op():
+        return _fallback_gumbel_sample(
+            logits,
+            expanded_idx_mapping,
+            temperature,
+            seed,
+            pos,
+            apply_temperature,
+            is_drafting,
+            logits_cache,
+            logits_cache_col,
+            use_fp64,
+        )
+
+    expanded_idx_mapping = expanded_idx_mapping.contiguous()
+    pos = pos.to(torch.int64).contiguous()
+    if is_drafting:
+        # Use the same draft/target random-stream separation as upstream.
+        draft_noise_salt = 1 << 30
+        pos = pos + draft_noise_salt
+    if logits_cache_col is not None:
+        logits_cache_col = logits_cache_col.contiguous()
+
+    sampled_token_ids, _ = torch.ops._C_ascend.npu_categorical_sample(
+        logits,
+        expanded_idx_mapping,
+        temperature,
+        seed,
+        pos,
+        False,
+        apply_temperature,
+        logits_cache,
+        logits_cache_col,
+        use_fp64,
+    )
+    return sampled_token_ids


### PR DESCRIPTION
### What this PR does / why we need it?

Related to RFC #14130. This is a Triton inverse-CDF categorical implementation offered as an alternative to the AscendC implementation in #14141. We would like maintainers to choose the implementation to take forward; this is not a proposal to merge both backends by default.

**Draft comparison prototype, not yet an independently mergeable alternative:** this branch starts from #14141 at `9efde94ac47ead9a4cd65e175e0679d4ff647890` and retains its AscendC implementation as the parity-test reference. Consequently, the diff against `main` currently includes the inherited native implementation and integration. Review the [Triton-only delta](https://github.com/freyfwt/vllm-ascend/compare/9efde94ac47ead9a4cd65e175e0679d4ff647890...e441a1264f040421aeb70f39962ffdeb680f9db6), which changes only the new operator and the existing categorical test file.

- Add the explicit `categorical_sample` entry point in `vllm_ascend/ops/triton/categorical_sample.py`. The implementation does not call the AscendC categorical operator.
- Reproduce its Philox4x32-10 seed/position mapping, FP32 tile/repeat/CDF accumulation order, first-maximum tie breaking, and `use_fp64` integer-mass algorithm with 42 fractional bits. The latter is not IEEE FP64 vector arithmetic.
- Preserve raw, unscaled logits-cache writes, FP16/BF16/FP32 conversions, padding, broadcast/strided logits, positive-infinity selection, and optional LSE. This follows the revised cache contract in #14141 rather than the RFC's original cache wording.
- Keep data-dependent validation on device, including ACLGraph replay. Assertions are entered only on invalid branches, and FP32 negative-zero normalization is explicit to preserve cache bits across dtype casts.

The review question is whether to proceed with AscendC (#14141) or this Triton implementation, considering correctness, maintainability, deployment dependencies, and performance. If Triton is selected, this draft still needs removal of the inherited native production implementation, independent test-oracle handling, and MRV2 dispatch integration before it can be merged instead of #14141. Rejection/bonus resampling remains outside this prototype's scope.

### Does this PR introduce _any_ user-facing change?

The Triton delta adds an opt-in operator entry point, with no new configuration or automatic backend switch. The inherited #14141 code still selects AscendC in the MRV2 production path; importing the Triton module does not change that routing.

Tested token and LSE values match the native reference exactly. Invalid inputs are rejected, but Triton's device-error diagnostic text is not identical to AscendC's. The tests establish equivalence on the tested stack, not a cross-hardware bitwise guarantee.

### How was this patch tested?

Tested revision: `e441a1264f040421aeb70f39962ffdeb680f9db6`, with the matching AscendC reference built for comparisons.

- Real Ascend A3: **89 Triton-specific cases passed per vLLM version**, with no failures or skips. Verified-main ran as 28 cache/metadata cases plus 61 numerical/error cases; release ran the full 89-case selection.
  - `vllm-main-verified`: `b2f685834a6456197e7033966fdef52a23f1abcd`.
  - `vllm-release-tag`: `v0.28.0` (`2cf0a6915ce544dc493a0990f2ea38d81601128a`).
- The 48 dtype/precision/vocabulary combinations, with vocabularies from 1 to 1,048,576, require zero-error token and LSE comparisons. Additional cases cover rare-probability selection, Philox endpoints, nine cache dtype combinations, cache bits, changing logits/cache contents during graph replay, and eager/graph invalid-input rejection.
- Additional A3 diagnostics passed for batch sizes 1/40/41/64/256 in both precision modes, and cache subnormals, rounding boundaries, overflow, and infinities.
- `bash format.sh ci` passed. Full `tools/mypy.sh 1` checks passed for Python 3.10, 3.11, and 3.12 across source, examples, and tests in the dedicated static-analysis environment.

Reproduce the Triton-specific suite on the corresponding vLLM checkout and an Ascend environment with the native reference available:

```bash
python -m pytest -xv tests/e2e/pull_request/one_card/test_categorical_sampling.py -k triton --tb=short
```

Runtime stack: CANN 9.1.0, PyTorch 2.10.0, torch_npu 2.10.0.post4.dev20260715, triton-ascend 3.2.2.

**Remaining merge gates:** A2/A5 validation, independent MRV2 integration and model-level validation, and paired performance measurements of this new Triton implementation versus AscendC. No speedup claim is made here: the benchmark results in #14141 compare AscendC with the former Gumbel-max Triton path, not this implementation.

- vLLM main: https://github.com/vllm-project/vllm/commit/b2f685834a6456197e7033966fdef52a23f1abcd
