### PR TITLE
[BugFix][MRV2] Use PCP-local graph capture buffers on v0.28.0

### DIFF
--- a/tests/e2e/pull_request/four_card/context_parallel/sfa_trace_worker.py
+++ b/tests/e2e/pull_request/four_card/context_parallel/sfa_trace_worker.py
@@ -1,0 +1,158 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Temporary, deliberately synchronizing SFA diagnostic worker; not production."""
+
+import hashlib
+import inspect
+import json
+
+import torch
+
+from vllm_ascend.worker.worker import NPUWorker
+
+
+class SFATraceWorker(NPUWorker):
+    def load_model(self):
+        super().load_model()
+        self.trace_step = 0
+        self.trace_batch = None
+        self.trace_captures = []
+        self.trace_buffers = {}
+        state = self.model_runner.model_state
+        original = state.prepare_attn
+        signature = inspect.signature(original)
+
+        def prepare(*args, **kwargs):
+            bound = signature.bind(*args, **kwargs)
+            metadata = original(*args, **kwargs)
+            batch = bound.arguments["input_batch"]
+            if bound.arguments.get("for_capture", False):
+                self.trace_captures.append(metadata)
+            elif not getattr(batch, "is_dummy", False):
+                self.trace_batch = (batch, metadata)
+            return metadata
+
+        state.prepare_attn = prepare
+        for name, module in self.model_runner.get_model().named_modules():
+            if name.endswith((".self_attn", ".mlp", ".input_layernorm", ".post_attention_layernorm")):
+                module.register_forward_hook(self._hook(name))
+
+    def _hook(self, name):
+        def snapshot(module, inputs, output):
+            values = output if isinstance(output, tuple) else (output,)
+            for index, value in enumerate(values):
+                if not isinstance(value, torch.Tensor) or value.ndim != 2 or value.shape[0] not in (2, 4):
+                    continue
+                key = (name, index, tuple(value.shape))
+                if key not in self.trace_buffers:
+                    self.trace_buffers[key] = torch.empty_like(value)
+                # This copy is recorded in the graph; host reads occur only after execution.
+                self.trace_buffers[key].copy_(value)
+
+        return snapshot
+
+    def _tensor(self, value):
+        cpu = value.detach().cpu().contiguous()
+        return {
+            "shape": list(value.shape),
+            "ptr": value.data_ptr(),
+            "values": cpu.flatten()[:64].tolist(),
+            "sha256": hashlib.sha256(cpu.view(torch.uint8).numpy().tobytes()).hexdigest(),
+        }
+
+    def _metadata(self, metadata):
+        if not metadata:
+            return {}
+        first = next(iter(metadata.values()))
+        if isinstance(first, dict):
+            first = next(iter(first.values()))
+        fields = (
+            "slot_mapping",
+            "pcp_slot_mapping",
+            "block_table",
+            "seq_lens",
+            "positions",
+            "cos",
+            "sin",
+            "query_start_loc",
+            "cum_query_lens",
+            "seq_lens_cpu",
+            "actual_seq_lengths_query",
+            "actual_seq_lengths_key",
+            "num_actual_tokens",
+            "num_decode_tokens",
+            "num_decodes",
+        )
+        return {
+            name: self._tensor(value) if isinstance(value, torch.Tensor) else value
+            for name in fields
+            if (value := getattr(first, name, None)) is not None
+        }
+
+    def execute_model(self, scheduler_output):
+        result = super().execute_model(scheduler_output)
+        if self.trace_batch is None or self.trace_step >= 5:
+            return result
+        batch, metadata = self.trace_batch
+        self.trace_batch = None
+        self.trace_step += 1
+        batch_fields = (
+            "input_ids",
+            "positions",
+            "seq_lens",
+            "query_start_loc",
+            "cum_query_lens",
+            "seq_lens_cpu",
+            "logits_indices",
+            "idx_mapping",
+            "num_reqs",
+            "num_tokens",
+            "num_tokens_after_padding",
+            "req_ids",
+        )
+        batch_record = {
+            name: self._tensor(value) if isinstance(value, torch.Tensor) else value
+            for name in batch_fields
+            if (value := getattr(batch, name, None)) is not None
+        }
+        print(
+            "SFA_RUNTIME_TRACE "
+            + json.dumps(
+                {
+                    "rank": self.rank,
+                    "step": self.trace_step,
+                    "batch": batch_record,
+                    "runtime": self._metadata(metadata),
+                    "captures": [self._metadata(item) for item in self.trace_captures],
+                },
+                default=str,
+            ),
+            flush=True,
+        )
+        # Prefill snapshots are intentionally omitted: only small decode-shaped copies are captured.
+        if batch.num_tokens <= 4:
+            for (name, index, shape), value in self.trace_buffers.items():
+                cpu = value.detach().cpu().contiguous()
+                rows = [
+                    {
+                        "sha256": hashlib.sha256(row.view(torch.uint8).numpy().tobytes()).hexdigest(),
+                        "first": row.float()[:8].tolist(),
+                        "norm": row.float().norm().item(),
+                    }
+                    for row in cpu
+                ]
+                print(
+                    "SFA_LAYER_TRACE "
+                    + json.dumps(
+                        {
+                            "rank": self.rank,
+                            "step": self.trace_step,
+                            "module": name,
+                            "output_index": index,
+                            "shape": shape,
+                            "rows": rows,
+                        }
+                    ),
+                    flush=True,
+                )
+        return result

--- a/tests/e2e/pull_request/four_card/context_parallel/sfa_trace_worker.py
+++ b/tests/e2e/pull_request/four_card/context_parallel/sfa_trace_worker.py
@@ -19,6 +19,7 @@ class SFATraceWorker(NPUWorker):
         self.trace_captures = []
         self.trace_buffers = {}
         self.trace_counters = {}
+        self.trace_rows = torch.arange(4, device=self.device)
         state = self.model_runner.model_state
         original = state.prepare_attn
         signature = inspect.signature(original)
@@ -49,9 +50,11 @@ class SFATraceWorker(NPUWorker):
                     self.trace_buffers[key] = value.new_zeros((4, value.shape[1]))
                     self.trace_counters[key] = value.new_zeros((), dtype=torch.int64)
                 # This copy is recorded in the graph; host reads occur only after execution.
-                self.trace_buffers[key].zero_()
-                first_rows = value[:4]
-                self.trace_buffers[key][: first_rows.shape[0]].copy_(first_rows)
+                # Keep both copy operands shape-four even when the compiled graph
+                # receives fewer tokens. A dynamic slice may be specialized by
+                # the no-guards compiler; repeated last rows are diagnostic padding.
+                rows = self.trace_rows.clamp_max(value.shape[0] - 1)
+                self.trace_buffers[key].copy_(torch.index_select(value, 0, rows))
                 self.trace_counters[key].add_(1)
 
         return snapshot

--- a/tests/e2e/pull_request/four_card/context_parallel/sfa_trace_worker.py
+++ b/tests/e2e/pull_request/four_card/context_parallel/sfa_trace_worker.py
@@ -18,6 +18,7 @@ class SFATraceWorker(NPUWorker):
         self.trace_batch = None
         self.trace_captures = []
         self.trace_buffers = {}
+        self.trace_counters = {}
         state = self.model_runner.model_state
         original = state.prepare_attn
         signature = inspect.signature(original)
@@ -41,13 +42,17 @@ class SFATraceWorker(NPUWorker):
         def snapshot(module, inputs, output):
             values = output if isinstance(output, tuple) else (output,)
             for index, value in enumerate(values):
-                if not isinstance(value, torch.Tensor) or value.ndim != 2 or value.shape[0] not in (2, 4):
+                if not isinstance(value, torch.Tensor) or value.ndim != 2:
                     continue
-                key = (name, index, tuple(value.shape))
+                key = (name, index)
                 if key not in self.trace_buffers:
-                    self.trace_buffers[key] = torch.empty_like(value)
+                    self.trace_buffers[key] = value.new_zeros((4, value.shape[1]))
+                    self.trace_counters[key] = value.new_zeros((), dtype=torch.int64)
                 # This copy is recorded in the graph; host reads occur only after execution.
-                self.trace_buffers[key].copy_(value)
+                self.trace_buffers[key].zero_()
+                first_rows = value[:4]
+                self.trace_buffers[key][: first_rows.shape[0]].copy_(first_rows)
+                self.trace_counters[key].add_(1)
 
         return snapshot
 
@@ -91,7 +96,7 @@ class SFATraceWorker(NPUWorker):
 
     def execute_model(self, scheduler_output):
         result = super().execute_model(scheduler_output)
-        if self.trace_batch is None or self.trace_step >= 5:
+        if self.trace_batch is None or self.trace_step >= 12:
             return result
         batch, metadata = self.trace_batch
         self.trace_batch = None
@@ -109,6 +114,9 @@ class SFATraceWorker(NPUWorker):
             "num_tokens",
             "num_tokens_after_padding",
             "req_ids",
+            "is_prefilling_np",
+            "num_scheduled_tokens",
+            "num_computed_tokens_np",
         )
         batch_record = {
             name: self._tensor(value) if isinstance(value, torch.Tensor) else value
@@ -130,8 +138,8 @@ class SFATraceWorker(NPUWorker):
             flush=True,
         )
         # Prefill snapshots are intentionally omitted: only small decode-shaped copies are captured.
-        if batch.num_tokens <= 4:
-            for (name, index, shape), value in self.trace_buffers.items():
+        if not batch.is_prefilling_np.any():
+            for (name, index), value in self.trace_buffers.items():
                 cpu = value.detach().cpu().contiguous()
                 rows = [
                     {
@@ -149,7 +157,8 @@ class SFATraceWorker(NPUWorker):
                             "step": self.trace_step,
                             "module": name,
                             "output_index": index,
-                            "shape": shape,
+                            "shape": list(value.shape),
+                            "updates": int(self.trace_counters[(name, index)].item()),
                             "rows": rows,
                         }
                     ),

--- a/tests/e2e/pull_request/four_card/context_parallel/test_accuracy_v2.py
+++ b/tests/e2e/pull_request/four_card/context_parallel/test_accuracy_v2.py
@@ -19,9 +19,10 @@
 Run `pytest tests/e2e/pull_request/four_card/context_parallel/test_accuracy_v2.py`.
 """
 
+import json
 import os
 from collections.abc import Sequence
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from typing import Any, cast
 from unittest.mock import patch
 
@@ -224,6 +225,75 @@ DSV3_2_SFA_PCP_DCP_CASE = AccuracyCase(
 def test_dsv3_2_sfa_pcp_model_runner_v2_graph_accuracy() -> None:
     """Guard MRV2 SFA PCP full-decode-only graph accuracy."""
     _run_accuracy_case(DSV3_2_SFA_PCP_CASE)
+
+
+@pytest.mark.e2e_model(DSV3_2_MODEL)
+@pytest.mark.parametrize("graph_mode", ["FULL_DECODE_ONLY", "NONE"])
+@pytest.mark.parametrize("collect_logits", [False, True], ids=["original_sampling", "raw_logits"])
+@patch.dict(
+    os.environ,
+    {
+        "VLLM_USE_V2_MODEL_RUNNER": "1",
+        "VLLM_BATCH_INVARIANT": "1",
+        "VLLM_WORKER_MULTIPROC_METHOD": "spawn",
+        "HCCL_BUFFSIZE": "768",
+        "PYTORCH_NPU_ALLOC_CONF": "expandable_segments:True",
+    },
+)
+@wait_until_npu_memory_free(target_free_percentage=0.8)
+def test_dsv3_2_sfa_pcp_graph_diagnostic(graph_mode: str, collect_logits: bool) -> None:
+    """Compare one graph variable, preserving the original accuracy assertions.
+
+    Score collection is a separate axis so its effect on the original greedy
+    path remains observable. Each case creates a fresh model and KV cache.
+    """
+    runner_kwargs = dict(DSV3_2_SFA_PCP_CASE.runner_kwargs)
+    runner_kwargs["compilation_config"] = {**FULL_DECODE_GRAPH, "cudagraph_mode": graph_mode}
+    if collect_logits:
+        runner_kwargs["logprobs_mode"] = "raw_logits"
+    case = replace(DSV3_2_SFA_PCP_CASE, runner_kwargs=runner_kwargs)
+    original_generate = VllmRunner.generate_greedy
+
+    def logged_generate(runner, prompts, max_tokens):
+        if not collect_logits:
+            outputs = original_generate(runner, prompts, max_tokens)
+            records = [
+                {"prompt": prompt, "full_token_ids": ids, "full_text": text}
+                for prompt, (ids, text) in zip(prompts, outputs, strict=True)
+            ]
+        else:
+            scored_outputs = runner.generate_greedy_logprobs(prompts, max_tokens, 5)
+            outputs = []
+            records = []
+            for prompt, scored_output in zip(prompts, scored_outputs, strict=True):
+                ids, text, steps = scored_output[:3]
+                token_records = []
+                for token_id, scores in zip(ids, steps, strict=True):
+                    top = sorted(scores.items(), key=lambda item: item[1].logprob, reverse=True)[:5]
+                    token_records.append(
+                        {
+                            "sampled_token_id": token_id,
+                            "top_k_raw_logits": [
+                                {"token_id": tid, "logit": score.logprob, "text": score.decoded_token}
+                                for tid, score in top
+                            ],
+                            "top1_top2_margin": top[0][1].logprob - top[1][1].logprob if len(top) >= 2 else None,
+                        }
+                    )
+                records.append({"prompt": prompt, "generated_token_ids": ids, "text": text, "steps": token_records})
+                outputs.append((ids, prompt + text))
+        print(
+            "SFA_PCP_DIAGNOSTIC "
+            + json.dumps(
+                {"graph_mode": graph_mode, "collect_logits": collect_logits, "requests": records},
+                ensure_ascii=False,
+            ),
+            flush=True,
+        )
+        return outputs
+
+    with patch.object(VllmRunner, "generate_greedy", logged_generate):
+        _run_accuracy_case(case)
 
 
 @pytest.mark.e2e_model(DSV3_2_MODEL)

--- a/tests/e2e/pull_request/four_card/context_parallel/test_accuracy_v2.py
+++ b/tests/e2e/pull_request/four_card/context_parallel/test_accuracy_v2.py
@@ -241,7 +241,9 @@ def test_dsv3_2_sfa_pcp_model_runner_v2_graph_accuracy() -> None:
     },
 )
 @wait_until_npu_memory_free(target_free_percentage=0.8)
-def test_dsv3_2_sfa_pcp_graph_diagnostic(graph_mode: str, collect_logits: bool) -> None:
+def test_dsv3_2_sfa_pcp_graph_diagnostic(
+    graph_mode: str, collect_logits: bool, input_variant: str = "original"
+) -> None:
     """Compare one graph variable, preserving the original accuracy assertions.
 
     Score collection is a separate axis so its effect on the original greedy
@@ -251,7 +253,16 @@ def test_dsv3_2_sfa_pcp_graph_diagnostic(graph_mode: str, collect_logits: bool) 
     runner_kwargs["compilation_config"] = {**FULL_DECODE_GRAPH, "cudagraph_mode": graph_mode}
     if collect_logits:
         runner_kwargs["logprobs_mode"] = "raw_logits"
+    if input_variant == "pcp1":
+        runner_kwargs["prefill_context_parallel_size"] = 1
     case = replace(DSV3_2_SFA_PCP_CASE, runner_kwargs=runner_kwargs)
+    if input_variant == "third_prompt_only":
+        # Retain the existing golden for the selected prompt verbatim.
+        case = replace(
+            case,
+            prompts=case.prompts[2:3],
+            expected_outputs=tuple(expected[2:3] for expected in DSV3_2_SFA_PCP_GOLDENS),
+        )
     original_generate = VllmRunner.generate_greedy
 
     def logged_generate(runner, prompts, max_tokens):
@@ -285,7 +296,12 @@ def test_dsv3_2_sfa_pcp_graph_diagnostic(graph_mode: str, collect_logits: bool) 
         print(
             "SFA_PCP_DIAGNOSTIC "
             + json.dumps(
-                {"graph_mode": graph_mode, "collect_logits": collect_logits, "requests": records},
+                {
+                    "graph_mode": graph_mode,
+                    "collect_logits": collect_logits,
+                    "input_variant": input_variant,
+                    "requests": records,
+                },
                 ensure_ascii=False,
             ),
             flush=True,
@@ -294,6 +310,13 @@ def test_dsv3_2_sfa_pcp_graph_diagnostic(graph_mode: str, collect_logits: bool) 
 
     with patch.object(VllmRunner, "generate_greedy", logged_generate):
         _run_accuracy_case(case)
+
+
+@pytest.mark.e2e_model(DSV3_2_MODEL)
+@pytest.mark.parametrize("input_variant", ["original", "pcp1", "third_prompt_only"])
+def test_dsv3_2_sfa_pcp_layout_diagnostic(input_variant: str) -> None:
+    """Vary only PCP or prompt batch against the fixed graph/scored reference."""
+    test_dsv3_2_sfa_pcp_graph_diagnostic("FULL_DECODE_ONLY", True, input_variant)
 
 
 @pytest.mark.e2e_model(DSV3_2_MODEL)

--- a/tests/e2e/pull_request/four_card/context_parallel/test_accuracy_v2.py
+++ b/tests/e2e/pull_request/four_card/context_parallel/test_accuracy_v2.py
@@ -19,9 +19,10 @@
 Run `pytest tests/e2e/pull_request/four_card/context_parallel/test_accuracy_v2.py`.
 """
 
+import json
 import os
 from collections.abc import Sequence
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from typing import Any, cast
 from unittest.mock import patch
 
@@ -339,3 +340,40 @@ def test_eagle3_gqa_spec_decode_with_pcp() -> None:
             "num_speculative_tokens": 3,
         },
     )
+
+
+@pytest.mark.e2e_model(DSV3_2_MODEL)
+@pytest.mark.parametrize("third_only", [False, True], ids=["batch", "third_only"])
+@patch.dict(
+    os.environ,
+    {
+        "VLLM_USE_V2_MODEL_RUNNER": "1",
+        "VLLM_BATCH_INVARIANT": "1",
+        "VLLM_WORKER_MULTIPROC_METHOD": "spawn",
+        "HCCL_BUFFSIZE": "768",
+        "PYTORCH_NPU_ALLOC_CONF": "expandable_segments:True",
+    },
+)
+@wait_until_npu_memory_free(target_free_percentage=0.8)
+def test_dsv3_2_sfa_pcp_tensor_diagnostic(third_only: bool) -> None:
+    """Temporary observer; preserve the original sampling and golden assertions."""
+    case = DSV3_2_SFA_PCP_CASE
+    kwargs = dict(case.runner_kwargs)
+    kwargs["worker_cls"] = "tests.e2e.pull_request.four_card.context_parallel.sfa_trace_worker.SFATraceWorker"
+    case = replace(case, runner_kwargs=kwargs)
+    if third_only:
+        case = replace(
+            case, prompts=[case.prompts[2]], expected_outputs=tuple([goldens[2]] for goldens in DSV3_2_SFA_PCP_GOLDENS)
+        )
+    original = VllmRunner.generate_greedy
+
+    def generate(runner, prompts, max_tokens):
+        outputs = original(runner, prompts, max_tokens)
+        print(
+            "SFA_TRACE_OUTPUT " + json.dumps({"third_only": third_only, "outputs": outputs}, ensure_ascii=False),
+            flush=True,
+        )
+        return outputs
+
+    with patch.object(VllmRunner, "generate_greedy", generate):
+        _run_accuracy_case(case)

--- a/tests/e2e/pull_request/four_card/context_parallel/test_accuracy_v2.py
+++ b/tests/e2e/pull_request/four_card/context_parallel/test_accuracy_v2.py
@@ -19,10 +19,9 @@
 Run `pytest tests/e2e/pull_request/four_card/context_parallel/test_accuracy_v2.py`.
 """
 
-import json
 import os
 from collections.abc import Sequence
-from dataclasses import dataclass, replace
+from dataclasses import dataclass
 from typing import Any, cast
 from unittest.mock import patch
 
@@ -225,98 +224,6 @@ DSV3_2_SFA_PCP_DCP_CASE = AccuracyCase(
 def test_dsv3_2_sfa_pcp_model_runner_v2_graph_accuracy() -> None:
     """Guard MRV2 SFA PCP full-decode-only graph accuracy."""
     _run_accuracy_case(DSV3_2_SFA_PCP_CASE)
-
-
-@pytest.mark.e2e_model(DSV3_2_MODEL)
-@pytest.mark.parametrize("graph_mode", ["FULL_DECODE_ONLY", "NONE"])
-@pytest.mark.parametrize("collect_logits", [False, True], ids=["original_sampling", "raw_logits"])
-@patch.dict(
-    os.environ,
-    {
-        "VLLM_USE_V2_MODEL_RUNNER": "1",
-        "VLLM_BATCH_INVARIANT": "1",
-        "VLLM_WORKER_MULTIPROC_METHOD": "spawn",
-        "HCCL_BUFFSIZE": "768",
-        "PYTORCH_NPU_ALLOC_CONF": "expandable_segments:True",
-    },
-)
-@wait_until_npu_memory_free(target_free_percentage=0.8)
-def test_dsv3_2_sfa_pcp_graph_diagnostic(
-    graph_mode: str, collect_logits: bool, input_variant: str = "original"
-) -> None:
-    """Compare one graph variable, preserving the original accuracy assertions.
-
-    Score collection is a separate axis so its effect on the original greedy
-    path remains observable. Each case creates a fresh model and KV cache.
-    """
-    runner_kwargs = dict(DSV3_2_SFA_PCP_CASE.runner_kwargs)
-    runner_kwargs["compilation_config"] = {**FULL_DECODE_GRAPH, "cudagraph_mode": graph_mode}
-    if collect_logits:
-        runner_kwargs["logprobs_mode"] = "raw_logits"
-    if input_variant == "pcp1":
-        runner_kwargs["prefill_context_parallel_size"] = 1
-    case = replace(DSV3_2_SFA_PCP_CASE, runner_kwargs=runner_kwargs)
-    if input_variant == "third_prompt_only":
-        # Retain the existing golden for the selected prompt verbatim.
-        case = replace(
-            case,
-            prompts=case.prompts[2:3],
-            expected_outputs=tuple(expected[2:3] for expected in DSV3_2_SFA_PCP_GOLDENS),
-        )
-    original_generate = VllmRunner.generate_greedy
-
-    def logged_generate(runner, prompts, max_tokens):
-        if not collect_logits:
-            outputs = original_generate(runner, prompts, max_tokens)
-            records = [
-                {"prompt": prompt, "full_token_ids": ids, "full_text": text}
-                for prompt, (ids, text) in zip(prompts, outputs, strict=True)
-            ]
-        else:
-            scored_outputs = runner.generate_greedy_logprobs(prompts, max_tokens, 5)
-            outputs = []
-            records = []
-            for prompt, scored_output in zip(prompts, scored_outputs, strict=True):
-                ids, text, steps = scored_output[:3]
-                token_records = []
-                for token_id, scores in zip(ids, steps, strict=True):
-                    top = sorted(scores.items(), key=lambda item: item[1].logprob, reverse=True)[:5]
-                    token_records.append(
-                        {
-                            "sampled_token_id": token_id,
-                            "top_k_raw_logits": [
-                                {"token_id": tid, "logit": score.logprob, "text": score.decoded_token}
-                                for tid, score in top
-                            ],
-                            "top1_top2_margin": top[0][1].logprob - top[1][1].logprob if len(top) >= 2 else None,
-                        }
-                    )
-                records.append({"prompt": prompt, "generated_token_ids": ids, "text": text, "steps": token_records})
-                outputs.append((ids, prompt + text))
-        print(
-            "SFA_PCP_DIAGNOSTIC "
-            + json.dumps(
-                {
-                    "graph_mode": graph_mode,
-                    "collect_logits": collect_logits,
-                    "input_variant": input_variant,
-                    "requests": records,
-                },
-                ensure_ascii=False,
-            ),
-            flush=True,
-        )
-        return outputs
-
-    with patch.object(VllmRunner, "generate_greedy", logged_generate):
-        _run_accuracy_case(case)
-
-
-@pytest.mark.e2e_model(DSV3_2_MODEL)
-@pytest.mark.parametrize("input_variant", ["original", "pcp1", "third_prompt_only"])
-def test_dsv3_2_sfa_pcp_layout_diagnostic(input_variant: str) -> None:
-    """Vary only PCP or prompt batch against the fixed graph/scored reference."""
-    test_dsv3_2_sfa_pcp_graph_diagnostic("FULL_DECODE_ONLY", True, input_variant)
 
 
 @pytest.mark.e2e_model(DSV3_2_MODEL)

--- a/tests/e2e/pull_request/four_card/context_parallel/test_accuracy_v2.py
+++ b/tests/e2e/pull_request/four_card/context_parallel/test_accuracy_v2.py
@@ -348,6 +348,7 @@ def test_eagle3_gqa_spec_decode_with_pcp() -> None:
     os.environ,
     {
         "VLLM_USE_V2_MODEL_RUNNER": "1",
+        "VLLM_DISABLE_COMPILE_CACHE": "1",
         "VLLM_BATCH_INVARIANT": "1",
         "VLLM_WORKER_MULTIPROC_METHOD": "spawn",
         "HCCL_BUFFSIZE": "768",

--- a/tests/ut/worker/v2/test_pcp_graph_capture_buffers.py
+++ b/tests/ut/worker/v2/test_pcp_graph_capture_buffers.py
@@ -1,0 +1,58 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from contextlib import nullcontext
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+from vllm_ascend.worker.v2 import aclgraph_utils
+
+
+@pytest.mark.parametrize("release", [True, False], ids=["v028", "main"])
+@pytest.mark.parametrize("use_pcp", [True, False], ids=["pcp", "no_pcp"])
+def test_graph_capture_reads_runtime_input_buffers(monkeypatch, release, use_pcp):
+    """Replay must observe PCP's current inputs and padding, not global rows."""
+
+    def make_buffers():
+        return SimpleNamespace(
+            input_ids=torch.full((4,), -1, dtype=torch.int32),
+            positions=torch.full((4,), -1, dtype=torch.int64),
+            seq_lens=torch.full((4,), -1, dtype=torch.int32),
+            is_padding=torch.ones(4, dtype=torch.bool),
+        )
+
+    global_buffers = make_buffers()
+    local_buffers = make_buffers()
+    pcp_manager = SimpleNamespace(_input_buffers=local_buffers) if use_pcp else None
+    graph_manager = aclgraph_utils.ModelAclGraphManager.__new__(aclgraph_utils.ModelAclGraphManager)
+    graph_manager.model_runner = SimpleNamespace(pcp_manager=pcp_manager)
+    captured = {}
+
+    def record_capture(self, model, model_state, input_buffers, *args, **kwargs):
+        captured["inputs"] = vars(input_buffers).copy()
+        captured["kwargs"] = kwargs
+
+    monkeypatch.setattr(aclgraph_utils.ModelCudaGraphManager, "capture", record_capture)
+    monkeypatch.setattr(aclgraph_utils, "vllm_version_is", lambda version: release)
+    monkeypatch.setattr(aclgraph_utils, "communicator_switch", nullcontext)
+    # Restore the capture helper after the production wrapper replaces it.
+    monkeypatch.setattr(aclgraph_utils.cudagraph_utils, "prepare_inputs_to_capture", lambda *args, **kwargs: None)
+
+    # Before #53515 the upstream runner passes global inputs even with PCP.
+    caller_buffers = global_buffers if release or not use_pcp else local_buffers
+    graph_manager.capture(torch.nn.Identity(), object(), caller_buffers, None, object(), [], object())
+
+    runtime_buffers = local_buffers if use_pcp else global_buffers
+    runtime_buffers.input_ids.copy_(torch.tensor([41, 42, 43, 0], dtype=torch.int32))
+    runtime_buffers.positions.copy_(torch.tensor([11, 12, 13, 0]))
+    runtime_buffers.seq_lens.copy_(torch.tensor([12, 13, 14, 0], dtype=torch.int32))
+    runtime_buffers.is_padding.copy_(torch.tensor([False, False, False, True]))
+    for name, runtime_tensor in vars(runtime_buffers).items():
+        assert captured["inputs"][name].data_ptr() == runtime_tensor.data_ptr(), name
+        torch.testing.assert_close(captured["inputs"][name], runtime_tensor)
+    if release:
+        assert "pcp_manager" not in captured["kwargs"]
+    else:
+        assert captured["kwargs"]["pcp_manager"] is pcp_manager

--- a/vllm_ascend/worker/v2/aclgraph_utils.py
+++ b/vllm_ascend/worker/v2/aclgraph_utils.py
@@ -205,6 +205,12 @@ class ModelAclGraphManager(ModelCudaGraphManager):
         model = ModelWithContext(model)
         pcp_manager = getattr(self.model_runner, "pcp_manager", None)
         if pcp_manager is not None:
+            if vllm_version_is("0.28.0"):
+                # Release capture_model still passes the global buffers. PCP
+                # prepares the persistent local buffers for graph replay.
+                # Main already selects these buffers in the upstream runner.
+                assert pcp_manager._input_buffers is not None
+                input_buffers = pcp_manager._input_buffers
             cudagraph_utils.prepare_inputs_to_capture = partial(
                 _prepare_pcp_inputs_to_capture,
                 pcp_manager=pcp_manager,


### PR DESCRIPTION
### What this PR does / why we need it?

v0.28.0 sends global input buffers into MRV2 graph capture, whereas PCP runtime prepares persistent local input buffers. Main already selects PCP-local buffers upstream (#53515). This six-line candidate explicitly selects the PCP-local buffers on v0.28.0 before capture. It includes a regression for capture/runtime tensor identity and padding updates across PCP/non-PCP and release/main contracts.

**This is a partial fix under investigation, not a resolved SFA PCP accuracy fix.** It changes the observed release third-prompt output from `Rund compasses` to `Rund596庄稼` and makes all reported token/top-5-logit records match main in controlled diagnostic observations. It does not satisfy the unchanged release golden `Rund959arki` or make the complete original target pass. Keep this PR draft.

### Does this PR introduce _any_ user-facing change?

Only the release PCP capture buffer source changes. Main retains its upstream-selected buffers. Investigation resumed: temporary tensor/metadata tracing is reintroduced on head `17e5b5467322b99a6263b7ce093960662e7933fc`. These synchronizing test-only observers will be removed before any final fix is proposed. No golden, allowed-output, assertion, skip, upgrade-pointer or unrelated CPU collection-error changes. No changes to #16009, #15627, or baseline #16175; no labels or merge requested.

### How was this patch tested?

- Isolated actual capture method with real CPU tensors and a recording backend: unpatched1failed/3passed, patched4passed. This isolates module initialization and NPU capture; it is not a full UT or numerical hardware test.
- [No-production-patch diagnostics34356957326](https://github.com/vllm-project/vllm-ascend/actions/runs/34356957326): main graph passes; release graph fails at prompt3 (`compasses`). Release eager cannot generate because of a separate missing `input_buffers` attribute, so that is not an accuracy result.
- [Original target with candidate34360230703](https://github.com/vllm-project/vllm-ascend/actions/runs/34360230703): main1passed209.77s; release1failed208.26s at prompt2 (`ERIChiretailhallenging`), aborting the comparison before prompt3.
- [Candidate logits34362432893](https://github.com/vllm-project/vllm-ascend/actions/runs/34362432893): main1passed, release1failed. All three token sequences and reported top-5 logits match between lanes. Relative to unpatched release, the first changed reported logit step is prompt3 generationstep4: token29490 (`596`)14.1875 exceeds token20410 (` compass`)13.5625 and golden token32716 (`959`)12.9375.
- [PCP/batch controls34364655334](https://github.com/vllm-project/vllm-ascend/actions/runs/34364655334): with graph/scored observation fixed, both PCP1 and PCP2/single-third-prompt produce `Rund959arki`; original PCP2/three-prompt batch produces `Rund596庄稼`. The first reported logit difference appears at generationstep2, before the sampled-token difference atstep4. This happens in both versions. PCP1 also changes the resulting process/EP group topology and fails prompt2, so it is not a passing original-target baseline.
- These diagnostic/candidate runs used heads e53e/f780/8a09 rebased onto fixed Ascend `9e1cab90c0a8ec49369eb9aa1e8f387dbe5e4f1d`. Empty baseline #16175 uses033198/f5f691 and reports main3/3passed, release0/3passed at prompt2. It is not the same Ascend tree. Actual vLLM anchors are main `b2f685834a6456197e7033966fdef52a23f1abcd` and release `2cf0a6915ce544dc493a0990f2ea38d81601128a`; main is not #16009's a97dacb. Distinct runners and missing immutable model/tokenizer/image fingerprints preclude a strict environment-equivalence claim.
- Ruff/check/format, isolated assertion checks and git diff checks passed. Full `bash format.sh ci` was run; Windows `/bin/bash`, shellcheck/python3 availability and an earlier memory-allocation failure prevent full local verification. No hook configuration was weakened.
- Final head `fa440ba895f26ee6b658230fe018a42ed44030b9` after removing diagnostics: [main original target](https://github.com/vllm-project/vllm-ascend/actions/runs/34367675957/job/102521588745)1passed207.34s; [release original target](https://github.com/vllm-project/vllm-ascend/actions/runs/34367675957/job/102521588852)1failed208.00s, prompt3 actual `Rund596庄稼` versus expected `Rund959arki`. Actual checkoutfa440ba89 and rebasebase9e1cab90 verified in both logs. **The full precision issue remains unresolved.** Full-file validation has not been triggered because both original target lanes have not passed.

Remaining blocker: no intermediate-tensor/operator trace identifies the remaining PCP2 multiple-request numerical discrepancy, and no matched-environment positive reference for the full release golden is established. Existing token/logit evidence does not justify further arithmetic changes or a root-cause-closure claim.

- Continued investigation: `test_dsv3_2_sfa_pcp_tensor_diagnostic` compares original batch versus third-prompt-only with unchanged sampling/goldens. It records decode layer output hashes/norms and captured/runtime metadata values/pointers. CPU observer checks and Ruff passed; hardware neutrality and results are pending.

- [Tensor diagnostic34431178636](https://github.com/vllm-project/vllm-ascend/actions/runs/34431178636): original token behavior preserved in both lanes (batchthird596 / singlethird959), but layer snapshots remained warmup values and are NOT valid evidence of runtime equality. Actual request admission was staggered: third prefill mixed with earlier requests decoding; third firstdecode is workerstep4 in batch versusstep2 alone. Head `c583a3d126646b78d1a15f6fadc5f9c7d8990404` corrects the temporary observer to record all compiled shapes, adds device update counts, extends collection to12 executions, omits mixed/prefill snapshot readouts and disables diagnostic compilecache reuse. No new production modification. Root cause remains open.

- [Corrected observer34433161210](https://github.com/vllm-project/vllm-ascend/actions/runs/34433161210): single-third output preserved and snapshot counters/hashes update, but both batch cases died before generation due to a diagnostic copy shape mismatch (4x7168 versus3x7168) in compiled execution. This is not numerical root-cause evidence. Head `a1a084e05cfb3cb46adaaee5b476fb327e84968d` replaces dynamic copy extents with a fixed-four-row index selection; production patch unchanged.

- vLLM main: https://github.com/vllm-project/vllm/commit/b2f685834a6456197e7033966fdef52a23f1abcd


**Current blocker (2026-09-10):** unchanged head `a1a084e05cfb3cb46adaaee5b476fb327e84968d` could not initialize the model in either [run34434623808](https://github.com/vllm-project/vllm-ascend/actions/runs/34434623808) or its single [unchanged-head retry34435808925](https://github.com/vllm-project/vllm-ascend/actions/runs/34435808925). Both lanes fail in ModelScope `ModelFileSystemCache.save_model_meta` with `OSError: [Errno 122] Disk quota exceeded`, before worker/model generation. Thus the latest observer shape correction has no NPU validation and there is still no valid paired layer trace. Automatic retries paused pending runner model-cache quota recovery. No original-target dual-lane pass, no full-file validation, and no numerical root-cause closure claimed. This PR remains a draft investigation with a partial capture-buffer correction and temporary diagnostics.
