### PR TITLE
[Test][Misc] Add DSV4 Pro performance bisect carrier

### DIFF
--- a/.github/workflows/configs/nightly_config.yaml
+++ b/.github/workflows/configs/nightly_config.yaml
@@ -106,6 +106,10 @@ a3:
         config_file_path: DeepSeek-V4-Pro-w4a8-prefix-cache-PD.yaml
         config_base_path: tests/e2e/nightly/multi_node/external_dp/config
         size: 4
+      - name: ryk-dsv4pro-825-bisect
+        config_file_path: ryk-dsv4pro-825-bisect.yaml
+        config_base_path: tests/e2e/nightly/multi_node/external_dp/config
+        size: 4
       - name: GLM-5.1-w8a8c8-128k-1k-90-50-PD
         config_file_path: GLM-5.1-W8A8C8-128k-1k-90-50-PD.yaml
         config_base_path: tests/e2e/nightly/multi_node/external_dp/config

--- a/tests/e2e/nightly/multi_node/external_dp/config/ryk-dsv4pro-825-bisect.yaml
+++ b/tests/e2e/nightly/multi_node/external_dp/config/ryk-dsv4pro-825-bisect.yaml
@@ -1,0 +1,315 @@
+# Diagnostic-only carrier for the first-stage DSV4 Pro performance bisect.
+# Keep the official P4096 / concurrency-48 workload unchanged.  The 869.13
+# baseline with threshold 0.95 classifies >=825.67 TPS as PASS, leaving a wide
+# margin between the historical ~860 good state and the ~723 main bad state.
+test_name: "ryk-dsv4pro-825-bisect"
+model: "Eco-Tech/DeepSeek-V4-Pro-w4a8-mtp"
+num_nodes: 4
+npu_per_node: 16
+
+routing:
+  type: "disaggregated_prefill"
+  groups:
+    prefiller: [ 0, 1 ]
+    decoder: [ 2, 3 ]
+
+config:
+  - node_index: 0
+    port_start: 7100
+    dp_rpc_port: 12321
+    dp_size: 4
+    dp_size_local: 2
+    dp_rank_start: 0
+    tp_size: 8
+    dp_address: "${NODE_0_IP}"
+
+  - node_index: 1
+    port_start: 7100
+    dp_rpc_port: 12321
+    dp_size: 4
+    dp_size_local: 2
+    dp_rank_start: 2
+    tp_size: 8
+    dp_address: "${NODE_0_IP}"
+
+  - node_index: 2
+    port_start: 7100
+    dp_rpc_port: 12321
+    dp_size: 16
+    dp_size_local: 8
+    dp_rank_start: 0
+    tp_size: 2
+    dp_address: "${NODE_2_IP}"
+
+  - node_index: 3
+    port_start: 7100
+    dp_rpc_port: 12321
+    dp_size: 16
+    dp_size_local: 8
+    dp_rank_start: 8
+    tp_size: 2
+    dp_address: "${NODE_2_IP}"
+
+env_common: &env_common
+  VLLM_USE_MODELSCOPE: "true"
+  SERVER_PORT: "${PORT}"
+  ASCEND_RT_VISIBLE_DEVICES: "${VISIBLE_DEVICES}"
+  VLLM_RPC_TIMEOUT: "3600000"
+  VLLM_EXECUTE_MODEL_TIMEOUT_SECONDS: "30000"
+  HCCL_EXEC_TIMEOUT: "204"
+  OMP_PROC_BIND: "false"
+  OMP_NUM_THREADS: "10"
+  PYTORCH_NPU_ALLOC_CONF: "expandable_segments:True"
+  TASK_QUEUE_ENABLE: "1"
+  HCCL_OP_EXPANSION_MODE: "AIV"
+
+env_prefill: &env_prefill
+  <<: *env_common
+  HCCL_CONNECT_TIMEOUT: "6000"
+  HCCL_BUFFSIZE: "1024"
+  VLLM_ASCEND_ENABLE_FLASHCOMM1: "1"
+  VLLM_PREFIX_CACHE_RETENTION_INTERVAL: "4096"
+
+env_decode: &env_decode
+  <<: *env_common
+  HCCL_CONNECT_TIMEOUT: "1200"
+  HCCL_BUFFSIZE: "1800"
+
+templates:
+  - node_index: 0
+    envs:
+      <<: *env_prefill
+    server_cmd_template:
+      - --host
+      - "0.0.0.0"
+      - --port
+      - $SERVER_PORT
+      - --data-parallel-size
+      - ${DP_SIZE}
+      - --data-parallel-rank
+      - ${DP_RANK}
+      - --data-parallel-address
+      - ${DP_ADDRESS}
+      - --data-parallel-rpc-port
+      - ${DP_RPC_PORT}
+      - --tensor-parallel-size
+      - ${TP_SIZE}
+      - --enable-expert-parallel
+      - --seed
+      - "1024"
+      - --max-model-len
+      - "204800"
+      - --max-num-batched-tokens
+      - "4096"
+      - --max-num-seqs
+      - "16"
+      - --no-disable-hybrid-kv-cache-manager
+      - --tokenizer-mode
+      - "deepseek_v4"
+      - --tool-call-parser
+      - "deepseek_v4"
+      - --enable-auto-tool-choice
+      - --reasoning-parser
+      - "deepseek_v4"
+      - --model-loader-extra-config
+      - '{"enable_multithread_load": true, "num_threads": 128}'
+      - --trust-remote-code
+      - --gpu-memory-utilization
+      - "0.94"
+      - --quantization
+      - "ascend"
+      - --block-size
+      - "32"
+      - --enforce-eager
+      - --speculative-config
+      - '{"num_speculative_tokens": 1,"method": "mtp"}'
+      - --additional-config
+      - '{"enable_cpu_binding": true, "enable_dsa_cp": true,"enable_fused_mc2":1}'
+      - --kv-transfer-config
+      - '{"kv_connector": "MooncakeHybridConnector", "kv_role": "kv_producer", "kv_port": "30100", "engine_id": "1", "kv_connector_extra_config": {"prefill": {"dp_size": 4, "tp_size": 8}, "decode": {"dp_size": 16, "tp_size": 2}}}'
+
+  - node_index: 1
+    envs:
+      <<: *env_prefill
+    server_cmd_template:
+      - --host
+      - "0.0.0.0"
+      - --port
+      - $SERVER_PORT
+      - --data-parallel-size
+      - ${DP_SIZE}
+      - --data-parallel-rank
+      - ${DP_RANK}
+      - --data-parallel-address
+      - ${DP_ADDRESS}
+      - --data-parallel-rpc-port
+      - ${DP_RPC_PORT}
+      - --tensor-parallel-size
+      - ${TP_SIZE}
+      - --enable-expert-parallel
+      - --seed
+      - "1024"
+      - --max-model-len
+      - "204800"
+      - --max-num-batched-tokens
+      - "4096"
+      - --max-num-seqs
+      - "16"
+      - --no-disable-hybrid-kv-cache-manager
+      - --tokenizer-mode
+      - "deepseek_v4"
+      - --tool-call-parser
+      - "deepseek_v4"
+      - --enable-auto-tool-choice
+      - --reasoning-parser
+      - "deepseek_v4"
+      - --model-loader-extra-config
+      - '{"enable_multithread_load": true, "num_threads": 128}'
+      - --trust-remote-code
+      - --gpu-memory-utilization
+      - "0.94"
+      - --quantization
+      - "ascend"
+      - --block-size
+      - "32"
+      - --enforce-eager
+      - --speculative-config
+      - '{"num_speculative_tokens": 1,"method": "mtp"}'
+      - --additional-config
+      - '{"enable_cpu_binding": true, "enable_dsa_cp": true,"enable_fused_mc2":1}'
+      - --kv-transfer-config
+      - '{"kv_connector": "MooncakeHybridConnector", "kv_role": "kv_producer", "kv_port": "30100", "engine_id": "1", "kv_connector_extra_config": {"prefill": {"dp_size": 4, "tp_size": 8}, "decode": {"dp_size": 16, "tp_size": 2}}}'
+
+  - node_index: 2
+    envs:
+      <<: *env_decode
+    server_cmd_template:
+      - --host
+      - "0.0.0.0"
+      - --port
+      - $SERVER_PORT
+      - --data-parallel-size
+      - ${DP_SIZE}
+      - --data-parallel-rank
+      - ${DP_RANK}
+      - --data-parallel-address
+      - ${DP_ADDRESS}
+      - --data-parallel-rpc-port
+      - ${DP_RPC_PORT}
+      - --tensor-parallel-size
+      - ${TP_SIZE}
+      - --enable-expert-parallel
+      - --seed
+      - "1024"
+      - --max-model-len
+      - "204800"
+      - --max-num-batched-tokens
+      - "120"
+      - --max-num-seqs
+      - "30"
+      - --async-scheduling
+      - --block-size
+      - "32"
+      - --no-enable-prefix-caching
+      - --tokenizer-mode
+      - "deepseek_v4"
+      - --tool-call-parser
+      - "deepseek_v4"
+      - --enable-auto-tool-choice
+      - --reasoning-parser
+      - "deepseek_v4"
+      - --no-disable-hybrid-kv-cache-manager
+      - --model-loader-extra-config
+      - '{"enable_multithread_load": true, "num_threads": 128}'
+      - --trust-remote-code
+      - --speculative-config
+      - '{"num_speculative_tokens": 3,"method": "mtp"}'
+      - --gpu-memory-utilization
+      - "0.95"
+      - --quantization
+      - "ascend"
+      - --compilation-config
+      - '{"cudagraph_mode": "FULL_DECODE_ONLY"}'
+      - --kv-transfer-config
+      - '{"kv_connector": "MooncakeHybridConnector", "kv_role": "kv_consumer", "kv_port": "30800", "engine_id": "8", "kv_connector_extra_config": {"prefill": {"dp_size": 4, "tp_size": 8}, "decode": {"dp_size": 16, "tp_size": 2}}}'
+      - --additional-config
+      - '{"ascend_compilation_config":{"enable_npugraph_ex":true,"enable_static_kernel":false},"enable_cpu_binding":true,"multistream_overlap_shared_expert":true,"recompute_scheduler_enable":true}'
+
+  - node_index: 3
+    envs:
+      <<: *env_decode
+    server_cmd_template:
+      - --host
+      - "0.0.0.0"
+      - --port
+      - $SERVER_PORT
+      - --data-parallel-size
+      - ${DP_SIZE}
+      - --data-parallel-rank
+      - ${DP_RANK}
+      - --data-parallel-address
+      - ${DP_ADDRESS}
+      - --data-parallel-rpc-port
+      - ${DP_RPC_PORT}
+      - --tensor-parallel-size
+      - ${TP_SIZE}
+      - --enable-expert-parallel
+      - --seed
+      - "1024"
+      - --max-model-len
+      - "204800"
+      - --max-num-batched-tokens
+      - "120"
+      - --max-num-seqs
+      - "30"
+      - --async-scheduling
+      - --block-size
+      - "32"
+      - --no-enable-prefix-caching
+      - --tokenizer-mode
+      - "deepseek_v4"
+      - --tool-call-parser
+      - "deepseek_v4"
+      - --enable-auto-tool-choice
+      - --reasoning-parser
+      - "deepseek_v4"
+      - --no-disable-hybrid-kv-cache-manager
+      - --model-loader-extra-config
+      - '{"enable_multithread_load": true, "num_threads": 128}'
+      - --trust-remote-code
+      - --speculative-config
+      - '{"num_speculative_tokens": 3,"method": "mtp"}'
+      - --gpu-memory-utilization
+      - "0.95"
+      - --quantization
+      - "ascend"
+      - --compilation-config
+      - '{"cudagraph_mode": "FULL_DECODE_ONLY"}'
+      - --kv-transfer-config
+      - '{"kv_connector": "MooncakeHybridConnector", "kv_role": "kv_consumer", "kv_port": "30800", "engine_id": "8", "kv_connector_extra_config": {"prefill": {"dp_size": 4, "tp_size": 8}, "decode": {"dp_size": 16, "tp_size": 2}}}'
+      - --additional-config
+      - '{"ascend_compilation_config":{"enable_npugraph_ex":true,"enable_static_kernel":false},"enable_cpu_binding":true,"multistream_overlap_shared_expert":true,"recompute_scheduler_enable":true}'
+
+benchmarks:
+  perf_TPOT50_128k_1_prefix_warmup:
+    case_type: performance
+    dataset_path: vllm-ascend/GSM8K-in128k-bs512-prefix90-ds
+    request_conf: vllm_api_stream_chat
+    dataset_conf: gsm8k/gsm8k_gen_0_shot_cot_str_perf
+    num_prompts: 4
+    max_out_len: 1
+    batch_size: 4
+    request_rate: 0
+    baseline: 0
+    threshold: 0.95
+  perf_TPOT50_128k_1_prefix90:
+    case_type: performance
+    dataset_path: vllm-ascend/GSM8K-in128k-bs512-prefix90-ds
+    request_conf: vllm_api_stream_chat
+    dataset_conf: gsm8k/gsm8k_gen_0_shot_cot_str_perf
+    num_prompts: 192
+    max_out_len: 1024
+    batch_size: 48
+    request_rate: 1
+    baseline: 869.13
+    threshold: 0.95

--- a/tests/ut/tools/bisect/test_auto_bisect.py
+++ b/tests/ut/tools/bisect/test_auto_bisect.py
@@ -3,7 +3,7 @@ from pathlib import Path
 
 import pytest
 
-from tools.bisect.auto_bisect import Bisector, _parse_args, _resolve_num_nodes
+from tools.bisect.auto_bisect import Bisector, _freeze_config, _parse_args, _resolve_num_nodes
 from tools.bisect.config import SCENE_MULTI, BisectInput, BisectOptions
 
 
@@ -165,3 +165,33 @@ def test_resolve_num_nodes_fails_when_multi_node_yaml_has_no_node_count(tmp_path
 
     with pytest.raises(SystemExit, match="Could not determine --num-nodes"):
         _resolve_num_nodes(args, tmp_path)
+
+
+def test_freeze_config_copies_yaml_outside_repo(tmp_path: Path):
+    repo = tmp_path / "repo"
+    source = repo / "configs" / "case.yaml"
+    source.parent.mkdir(parents=True)
+    source.write_text("num_nodes: 4\n", encoding="utf-8")
+    args = argparse.Namespace(
+        config_base_path="configs",
+        config_yaml="case.yaml",
+        work_dir=str(tmp_path / "cache"),
+        node_index=2,
+    )
+
+    frozen_base = _freeze_config(args, repo)
+
+    assert frozen_base == str(tmp_path / "cache" / "frozen_configs" / "node_2")
+    assert (Path(frozen_base) / "case.yaml").read_text(encoding="utf-8") == "num_nodes: 4\n"
+
+
+def test_freeze_config_rejects_path_traversal(tmp_path: Path):
+    args = argparse.Namespace(
+        config_base_path="configs",
+        config_yaml="../case.yaml",
+        work_dir=str(tmp_path / "cache"),
+        node_index=0,
+    )
+
+    with pytest.raises(SystemExit, match="must stay below"):
+        _freeze_config(args, tmp_path)

--- a/tools/bisect/USAGE_zh.md
+++ b/tools/bisect/USAGE_zh.md
@@ -9,6 +9,10 @@
 
 二分以 **commit 为最小单位**,每一轮复用现有 nightly 入口(单机 `test_single_node.py` / 多机 `test_multi_node.py`)**完整运行整个 YAML 文件的所有用例**,保证复现环境与 nightly 一致。
 
+启动二分时会先把所选 YAML 复制到 `BISECT_WORK_DIR/frozen_configs/`。后续 checkout
+只切换候选实现，不切换实验定义；因此候选 commit 即使早于该 nightly YAML 的合入，
+仍会运行 PR 头选择的同一份配置。
+
 > 注意:nightly 无法精确到单个 case 粒度,所以本工具**按整个 YAML 文件判定好坏**(文件内任一 case 失败即判 FAIL),不能只跑某一个 case。
 
 ---

--- a/tools/bisect/auto_bisect.py
+++ b/tools/bisect/auto_bisect.py
@@ -29,6 +29,7 @@ commit is read from the nightly status table unless ``--good-commit`` is given.
 import argparse
 import logging
 import os
+import shutil
 import time
 from pathlib import Path
 
@@ -405,10 +406,42 @@ def _resolve_num_nodes(args: argparse.Namespace, repo_dir: Path) -> int:
     )
 
 
+def _freeze_config(args: argparse.Namespace, repo_dir: Path) -> str | None:
+    """Copy the selected YAML outside the Git checkout before bisecting.
+
+    Candidate commits may predate the nightly case itself.  Keeping
+    ``CONFIG_BASE_PATH`` inside the repository would then make those trials
+    fail collection instead of measuring the candidate implementation.  Each
+    node gets an independent cached copy so all rounds execute the exact YAML
+    selected at the PR head.
+    """
+    if not args.config_base_path:
+        return None
+
+    config_rel = Path(args.config_yaml)
+    if config_rel.is_absolute() or ".." in config_rel.parts:
+        raise SystemExit(f"--config-yaml must stay below CONFIG_BASE_PATH: {args.config_yaml!r}")
+
+    source_base = Path(args.config_base_path)
+    if not source_base.is_absolute():
+        source_base = repo_dir / source_base
+    source = source_base / config_rel
+    if not source.is_file():
+        raise SystemExit(f"Cannot freeze missing bisect config: {source}")
+
+    frozen_base = Path(args.work_dir) / "frozen_configs" / f"node_{args.node_index}"
+    frozen = frozen_base / config_rel
+    frozen.parent.mkdir(parents=True, exist_ok=True)
+    shutil.copy2(source, frozen)
+    logger.info("Frozen bisect config %s -> %s", source, frozen)
+    return str(frozen_base)
+
+
 def main(argv: list[str] | None = None) -> int:
     args = _parse_args(argv)
     repo_dir = Path(args.repo_dir)
     num_nodes = _resolve_num_nodes(args, repo_dir)
+    args.config_base_path = _freeze_config(args, repo_dir)
     inp = BisectInput(
         scene=args.scene,
         config_yaml=args.config_yaml,


### PR DESCRIPTION
### What this PR does / why we need it?

This is a temporary diagnostic carrier for the first-stage DeepSeek-V4-Pro Nightly performance regression. It must not be merged.

- Adds one four-node external-DP performance case using the official P4096, concurrency-48 configuration.
- Keeps the official 869.13 TPS baseline and 0.95 threshold, so the PASS boundary is 825.6735 TPS.
- Removes the unrelated accuracy case to keep each bisect round bounded.
- Freezes the selected YAML outside the Git checkout before auto-bisect, so commits older than the YAML can still run the same experiment definition.

Planned interval after endpoint validation:
- candidate good: fa8d8375dc7d693bd466363119e338ab5d878318 (main immediately before the vLLM 0.24 upgrade; pins v0.23.0; not yet performance-validated)
- known bad: b481d79c7de49ab285e61cec689172931c124429 (723.474 TPS)

The two endpoints are on one first-parent chain with 298 commits in good..bad. Auto-bisect must first verify that bad is FAIL and candidate good is PASS. A SKIP or FAIL at the candidate good endpoint invalidates this interval and must not be reported as a culprit.

### Does this PR introduce _any_ user-facing change?

No. Diagnostic-only Draft PR; do not merge.

### How was this patch tested?

- Parsed the diagnostic YAML successfully.
- Verified it contains only warmup plus the official concurrency-48 performance case.
- Verified the threshold boundary is 825.6735 TPS.
- Verified the frozen-config helper copies the YAML outside the repository and rejects path traversal.
- Verified Python syntax and git diff whitespace checks.
- Full pytest was not run locally because the Windows environment lacks the repository pytest dependencies; NPU execution is intentionally left to Nightly CI.