### PR TITLE
[Feature][KV Transfer] Add Mooncake P/D delayed-release metrics

### DIFF
--- a/tests/ut/distributed/ascend_store/test_ascend_store_connector.py
+++ b/tests/ut/distributed/ascend_store/test_ascend_store_connector.py
@@ -96,10 +96,8 @@ class TestAscendStoreConnector(unittest.TestCase):
             role=KVConnectorRole.SCHEDULER,
             kv_cache_config=MagicMock(),
         )
-        stats = MagicMock()
-        mock_scheduler_cls.return_value.get_stats.return_value = stats
         mock_scheduler_cls.assert_called_once()
-        self.assertIs(connector.get_kv_connector_stats(), stats)
+        self.assertIsNone(connector.get_kv_connector_stats())
 
     @patch("vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.ascend_store_connector.LookupKeyServer")
     @patch("vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.ascend_store_connector.KVPoolWorker")

--- a/tests/ut/distributed/ascend_store/test_metrics.py
+++ b/tests/ut/distributed/ascend_store/test_metrics.py
@@ -37,17 +37,13 @@ class _Metric:
 
 def test_stats_aggregate_and_reduce():
     first = AscendStoreKVConnectorStats()
-    first.set_delayed_release(1, 2)
     first.record_operation("load_get", 0.01, 3)
     second = AscendStoreKVConnectorStats()
-    second.set_delayed_release(2, 5)
     second.record_operation("load_get", 0.02, 5)
 
     first.aggregate(second)
 
     assert first.reduce() == {
-        "ascend_store_delayed_release_requests": 2,
-        "ascend_store_delayed_release_blocks": 5,
         "ascend_store_load_get_count": 2,
         "ascend_store_load_get_avg_ms": 15.0,
         "ascend_store_load_get_keys": 8,
@@ -61,14 +57,10 @@ def test_prom_metrics_observe():
     ascend_store_prom = AscendStorePromMetrics(MagicMock(), metric_types, labelnames, labelvalues)
     ascend_store_prom.observe(
         {
-            "delayed_release_requests": 2,
-            "delayed_release_blocks": 5,
             "load_get_duration_seconds": [0.01, 0.02],
             "load_get_keys": 8,
         }
     )
 
-    assert ascend_store_prom._delayed_release_requests[0].value == 2
-    assert ascend_store_prom._delayed_release_blocks[0].value == 5
     assert ascend_store_prom._load_get_duration[0].observed == [0.01, 0.02]
     assert ascend_store_prom._load_get_keys[0].value == 8

--- a/tests/ut/distributed/ascend_store/test_pool_scheduler.py
+++ b/tests/ut/distributed/ascend_store/test_pool_scheduler.py
@@ -235,7 +235,7 @@ class TestKVPoolScheduler(unittest.TestCase):
         self.assertEqual(result, (False, None))
 
     @patch("vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.pool_scheduler.LookupKeyClient")
-    def test_request_finished_with_saved_tokens(self, mock_client_cls):
+    def test_request_finished_with_saved_tokens_frees_immediately(self, mock_client_cls):
         config = self._make_config()
         scheduler = KVPoolScheduler(config, use_layerwise=False)
         from vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.metadata import RequestTracker
@@ -249,7 +249,7 @@ class TestKVPoolScheduler(unittest.TestCase):
         request = MagicMock()
         request.request_id = "r1"
         delay, _ = scheduler.request_finished(request, [1, 2])
-        self.assertTrue(delay)
+        self.assertFalse(delay)
 
     @patch("vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.pool_scheduler.LookupKeyClient")
     def test_request_finished_empty_blocks(self, mock_client_cls):
@@ -641,26 +641,8 @@ class TestKVPoolSchedulerFloorGranularity(unittest.TestCase):
         self.assertEqual(scheduler._floor_to_cache_transfer_granularity(15), 0)
 
 
-class TestKVPoolSchedulerGetSwClippedBlocks(unittest.TestCase):
-    """Test get_sw_clipped_blocks."""
-
-    @patch("vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.pool_scheduler.LookupKeyClient")
-    def test_sw_clipped_blocks(self, mock_client_cls):
-        cases = [
-            (False, [0], [[1, 2, 3]], [[1, 2, 3]]),
-            (True, [2], [[1, 2, 3, 4, 5]], [[4, 5]]),
-            (False, [0], [], []),
-        ]
-        for use_hybrid, num_swa_blocks, blocks, expected in cases:
-            with self.subTest(use_hybrid=use_hybrid, blocks=blocks):
-                scheduler = KVPoolScheduler(make_config(), use_layerwise=False)
-                scheduler.use_hybrid = use_hybrid
-                scheduler.num_swa_blocks = num_swa_blocks
-                self.assertEqual(scheduler.get_sw_clipped_blocks(blocks), expected)
-
-
 class TestKVPoolSchedulerUpdateFinished(unittest.TestCase):
-    """Test update_finished_sending and update_finished_recving."""
+    """Test update_finished_recving."""
 
     @patch("vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.pool_scheduler.LookupKeyClient")
     def _make_scheduler(self, mock_client_cls):
@@ -668,25 +650,15 @@ class TestKVPoolSchedulerUpdateFinished(unittest.TestCase):
 
     def test_update_finished(self):
         cases = [
-            ("sending", {"r1", "r2", "r3"}, {"r1", "r2"}, {"r3"}),
-            ("sending", {"r1"}, None, {"r1"}),
-            ("recving", {"r1", "r2"}, {"r1"}, {"r2"}),
-            ("recving", {"r1"}, None, {"r1"}),
+            ({"r1", "r2"}, {"r1"}, {"r2"}),
+            ({"r1"}, None, {"r1"}),
         ]
-        for direction, initial, finished, expected in cases:
-            with self.subTest(direction=direction, finished=finished):
+        for initial, finished, expected in cases:
+            with self.subTest(finished=finished):
                 scheduler = self._make_scheduler()
-                attribute = "_delayed_free_req_ids" if direction == "sending" else "_loading_req_ids"
-                if direction == "sending":
-                    for req_id in initial:
-                        scheduler._set_delayed_free(req_id, 1)
-                else:
-                    setattr(scheduler, attribute, initial)
-                getattr(scheduler, f"update_finished_{direction}")(finished)
-                self.assertEqual(getattr(scheduler, attribute), expected)
-                if direction == "sending":
-                    self.assertEqual(scheduler._delayed_free_blocks_by_req, dict.fromkeys(expected, 1))
-                    self.assertEqual(scheduler._num_delayed_free_blocks, len(expected))
+                scheduler._loading_req_ids = initial
+                scheduler.update_finished_recving(finished)
+                self.assertEqual(scheduler._loading_req_ids, expected)
 
 
 class TestKVPoolSchedulerUpdateConnectorOutput(unittest.TestCase):
@@ -717,9 +689,11 @@ class TestKVPoolSchedulerUpdateConnectorOutput(unittest.TestCase):
                 scheduler.sending_blocks = {1: [10, 20]}
                 scheduler._expected_worker_count = 2
                 output = MagicMock(kv_connector_worker_meta=AscendStoreKVConnectorWorkerMetadata({1: 1}))
+                self.assertTrue(scheduler.has_pending_push_work())
                 scheduler.update_connector_output(output)
                 self.assertEqual(scheduler._block_pool.free_blocks.called, should_free)
                 self.assertEqual(1 in scheduler.sending_blocks, not should_free)
+                self.assertEqual(scheduler.has_pending_push_work(), not should_free)
 
     def test_invalid_event_id(self):
         scheduler = self._make_scheduler()
@@ -744,28 +718,13 @@ class TestKVPoolSchedulerUpdateConnectorOutput(unittest.TestCase):
         scheduler.update_connector_output(output)
         scheduler._block_pool.free_blocks.assert_not_called()
 
-    def test_finished_send_updates_delayed_release_metrics(self):
-        scheduler = self._make_scheduler()
-        scheduler._set_delayed_free("r1", 3)
-
-        entered = scheduler.get_stats()
-        self.assertEqual(entered.data["delayed_release_requests"], 1)
-        self.assertEqual(entered.data["delayed_release_blocks"], 3)
-
-        scheduler.update_finished_sending({"r1"})
-        released = scheduler.get_stats()
-        self.assertEqual(released.data["delayed_release_requests"], 0)
-        self.assertEqual(released.data["delayed_release_blocks"], 0)
-
 
 class TestKVPoolSchedulerRequestFinishedAllGroups(unittest.TestCase):
     """Test request_finished_all_groups."""
 
     @patch("vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.pool_scheduler.LookupKeyClient")
     def _make_scheduler(self, mock_client_cls, kv_role="kv_producer"):
-        scheduler = KVPoolScheduler(make_config(kv_role), use_layerwise=False)
-        scheduler.num_swa_blocks = [0]
-        return scheduler
+        return KVPoolScheduler(make_config(kv_role), use_layerwise=False)
 
     def test_consumer_no_put(self):
         scheduler = self._make_scheduler(kv_role="kv_consumer")
@@ -779,13 +738,13 @@ class TestKVPoolSchedulerRequestFinishedAllGroups(unittest.TestCase):
         request = MagicMock()
         request.request_id = "r_nonexist"
         delay, _ = scheduler.request_finished_all_groups(request, ([1, 2],))
-        self.assertTrue(delay)
+        self.assertFalse(delay)
 
     def test_tracker_not_saved(self):
         scheduler = self._make_scheduler()
         from vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.metadata import RequestTracker
 
-        for request_id, add_tracker, expected in [("missing", False, True), ("r1", True, False)]:
+        for request_id, add_tracker in [("missing", False), ("r1", True)]:
             with self.subTest(request_id=request_id):
                 scheduler = self._make_scheduler()
                 if add_tracker:
@@ -794,9 +753,9 @@ class TestKVPoolSchedulerRequestFinishedAllGroups(unittest.TestCase):
                     )
                 request = MagicMock(request_id=request_id)
                 delay, _ = scheduler.request_finished_all_groups(request, ([1, 2],))
-                self.assertEqual(delay, expected)
+                self.assertFalse(delay)
 
-    def test_delay_free_with_blocks(self):
+    def test_free_immediately_with_blocks(self):
         scheduler = self._make_scheduler()
         from vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.metadata import RequestTracker
 
@@ -804,8 +763,7 @@ class TestKVPoolSchedulerRequestFinishedAllGroups(unittest.TestCase):
         request = MagicMock()
         request.request_id = "r1"
         delay, _ = scheduler.request_finished_all_groups(request, ([1, 2],))
-        self.assertTrue(delay)
-        self.assertEqual(scheduler._delayed_free_blocks_by_req["r1"], 2)
+        self.assertFalse(delay)
 
     def test_no_delay_empty_blocks(self):
         scheduler = self._make_scheduler()

--- a/tests/ut/distributed/ascend_store/test_pool_worker.py
+++ b/tests/ut/distributed/ascend_store/test_pool_worker.py
@@ -771,7 +771,7 @@ class TestKVPoolWorkerRegisterAndTransfer(unittest.TestCase):
         worker.kv_send_thread.add_stored_request.assert_not_called()
         worker.kv_send_thread.request_queue.join.assert_not_called()
 
-    def test_get_finished_producer(self):
+    def test_get_finished_producer_clears_synchronous_completions(self):
         worker = self._make_worker(kv_role="kv_producer")
 
         send_thread = MagicMock()
@@ -779,14 +779,15 @@ class TestKVPoolWorkerRegisterAndTransfer(unittest.TestCase):
         worker.kv_send_thread = send_thread
 
         meta = AscendConnectorMetadata(set(), set())
-        done_s, done_r = worker.get_finished({"r1"}, meta)
-        self.assertIn("r1", done_s)
+        done_s, done_r = worker.get_finished(meta)
+        self.assertEqual(done_s, set())
         self.assertEqual(done_r, set())
+        send_thread.get_and_clear_finished_requests.assert_called_once_with()
 
     def test_get_finished_consumer(self):
         worker = self._make_worker(kv_role="kv_consumer")
         meta = AscendConnectorMetadata(set(), set())
-        done_s, done_r = worker.get_finished(set(), meta)
+        done_s, done_r = worker.get_finished(meta)
         self.assertEqual(done_s, set())
 
     def test_lookup_scheduler_all_cached(self):
@@ -914,7 +915,7 @@ class TestKVPoolWorkerGetFinishedAsync(unittest.TestCase):
 
         loading_req_ids = {"r1"}
         meta = AscendConnectorMetadata(set(), loading_req_ids=loading_req_ids)
-        done_s, done_r = worker.get_finished(set(), meta)
+        done_s, done_r = worker.get_finished(meta)
         self.assertEqual(done_s, set())
         self.assertEqual(done_r, {"r1"})
         recv_thread.get_and_clear_finished_requests.assert_called_once_with(loading_req_ids)
@@ -922,7 +923,7 @@ class TestKVPoolWorkerGetFinishedAsync(unittest.TestCase):
         recv_thread.reset_mock()
         recv_thread.get_and_clear_finished_requests.return_value = set()
         meta = AscendConnectorMetadata({"r_preempted"}, loading_req_ids=set())
-        worker.get_finished(set(), meta)
+        worker.get_finished(meta)
         recv_thread.discard_finished_requests.assert_called_once_with({"r_preempted"})
 
     def test_get_finished_layerwise_send_thread(self):
@@ -935,7 +936,7 @@ class TestKVPoolWorkerGetFinishedAsync(unittest.TestCase):
         worker.kv_recv_thread = None
 
         meta = AscendConnectorMetadata(set())
-        done_s, done_r = worker.get_finished(set(), meta)
+        done_s, done_r = worker.get_finished(meta)
         self.assertEqual(done_s, set())
         self.assertEqual(done_r, set())
         send_thread.get_and_clear_finished_requests.assert_called_once_with()

--- a/tests/ut/kv_offload/mooncake_v2/test_connector.py
+++ b/tests/ut/kv_offload/mooncake_v2/test_connector.py
@@ -45,11 +45,13 @@ def test_facade_delegates_scheduler_methods() -> None:
     output = MagicMock()
     connector.connector_scheduler.get_num_new_matched_tokens.return_value = (8, True)
     connector.connector_scheduler.request_finished.return_value = (True, {"remote": True})
+    connector.connector_scheduler.get_kv_connector_stats.return_value = MagicMock()
 
     assert connector.get_num_new_matched_tokens(request, 4) == (8, True)
     connector.update_state_after_alloc(request, blocks, 8)
     connector.update_connector_output(output)
     assert connector.request_finished(request, [1, 2]) == (True, {"remote": True})
+    assert connector.get_kv_connector_stats() is connector.connector_scheduler.get_kv_connector_stats.return_value
 
     connector.connector_scheduler.update_state_after_alloc.assert_called_once_with(request, blocks, 8)
     connector.connector_scheduler.request_finished.assert_called_once_with(request, ([1, 2],))

--- a/tests/ut/kv_offload/mooncake_v2/test_pull_scheduler.py
+++ b/tests/ut/kv_offload/mooncake_v2/test_pull_scheduler.py
@@ -25,6 +25,9 @@ from vllm_ascend.distributed.kv_transfer.kv_p2p.mooncake.pull_scheduler import (
     MooncakeSchedulerRecvingThread,
     MooncakeSchedulerSendingThread,
 )
+from vllm_ascend.distributed.kv_transfer.kv_p2p.mooncake.stats import (
+    MooncakeKVConnectorStats,
+)
 
 from .helpers import make_blocks, make_full_spec, make_mamba_spec, make_request, make_transfer_metadata
 
@@ -66,6 +69,8 @@ def make_pull_scheduler() -> MooncakePullConnectorScheduler:
     scheduler._reqs_recv_info = {}
     scheduler._sending_thread = None
     scheduler._recving_thread = None
+    scheduler._num_delayed_release_blocks = 0
+    scheduler._kv_stats = MooncakeKVConnectorStats()
     return scheduler
 
 
@@ -381,6 +386,10 @@ def test_request_finished_delays_blocks_and_builds_remote_params() -> None:
     assert params["remote_request_id"] == "request-p"
     assert params["last_token_id"] == 123
     scheduler._sending_thread.add_delayed_request.assert_called_once()
+    stats = scheduler.get_kv_connector_stats()
+    assert stats is not None
+    assert stats.data["delayed_release_requests"] == 1
+    assert stats.data["delayed_release_blocks"] == 3
 
 
 def test_update_connector_output_routes_worker_completion_and_scheduler_ack() -> None:
@@ -389,7 +398,8 @@ def test_update_connector_output_routes_worker_completion_and_scheduler_ack() ->
     scheduler._sending_thread = MagicMock()
     scheduler._sending_thread.get_and_clear_finished_requests.return_value = {"request-p"}
     scheduler._reqs_recv_info["request-d"] = ("10.0.0.1", 6000, "request-p")
-    scheduler._reqs_need_send["request-p"] = time.time()
+    scheduler._reqs_need_send["request-p"] = 3
+    scheduler._num_delayed_release_blocks = 3
     output = SimpleNamespace(finished_recving={"request-d"}, finished_sending=None)
 
     scheduler.update_connector_output(output)  # type: ignore[arg-type]
@@ -397,6 +407,10 @@ def test_update_connector_output_routes_worker_completion_and_scheduler_ack() ->
     scheduler._recving_thread.add_request.assert_called_once_with("10.0.0.1", 6000, "request-p")
     assert output.finished_sending == {"request-p"}
     assert scheduler._reqs_need_send == {}
+    stats = scheduler.get_kv_connector_stats()
+    assert stats is not None
+    assert stats.data["delayed_release_requests"] == 0
+    assert stats.data["delayed_release_blocks"] == 0
 
 
 class _StopLoop(BaseException):

--- a/tests/ut/kv_offload/mooncake_v2/test_stats.py
+++ b/tests/ut/kv_offload/mooncake_v2/test_stats.py
@@ -1,6 +1,13 @@
 # SPDX-License-Identifier: Apache-2.0
 
-from vllm_ascend.distributed.kv_transfer.kv_p2p.mooncake.stats import MooncakeKVConnectorStats
+from unittest.mock import MagicMock, call
+
+from prometheus_client import Counter, Gauge, Histogram
+
+from vllm_ascend.distributed.kv_transfer.kv_p2p.mooncake.stats import (
+    MooncakeKVConnectorStats,
+    MooncakePromMetrics,
+)
 
 
 def test_stats_record_reduce_and_reset() -> None:
@@ -35,3 +42,31 @@ def test_stats_aggregate_ignores_empty_and_merges_nonempty() -> None:
     assert stats.data["transfer_duration"] == [0.1]
     assert stats.data["bytes_transferred"] == [1024]
     assert stats.data["num_failed_transfers"] == [1]
+
+
+def test_stats_aggregate_uses_latest_delayed_release_snapshot() -> None:
+    stats = MooncakeKVConnectorStats(data={})
+    entered = MooncakeKVConnectorStats(data={})
+    entered.set_delayed_release(2, 7)
+    released = MooncakeKVConnectorStats(data={})
+    released.set_delayed_release(0, 0)
+
+    stats.aggregate(entered).aggregate(released)
+
+    assert stats.data["delayed_release_requests"] == 0
+    assert stats.data["delayed_release_blocks"] == 0
+    assert not stats.is_empty()
+
+
+def test_prom_metrics_observes_delayed_release_snapshot() -> None:
+    gauge_cls = MagicMock()
+    metric_types = {Gauge: gauge_cls, Counter: MagicMock(), Histogram: MagicMock()}
+    metrics = MooncakePromMetrics(MagicMock(), metric_types, ["model_name"], {0: ["test-model"]})
+
+    metrics.observe({"delayed_release_requests": 2, "delayed_release_blocks": 7})
+
+    assert [metric.kwargs["name"] for metric in gauge_cls.call_args_list] == [
+        "vllm:mooncake_pd_delayed_release_requests",
+        "vllm:mooncake_pd_delayed_release_blocks",
+    ]
+    assert gauge_cls.return_value.labels.return_value.set.call_args_list == [call(2), call(7)]

--- a/vllm_ascend/distributed/kv_transfer/kv_p2p/mooncake/base_scheduler.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_p2p/mooncake/base_scheduler.py
@@ -25,6 +25,9 @@ from vllm_ascend.ascend_config import (
     get_ascend_config,
     init_ascend_config,
 )
+from vllm_ascend.distributed.kv_transfer.kv_p2p.mooncake.stats import (
+    MooncakeKVConnectorStats,
+)
 
 if TYPE_CHECKING:
     from vllm.v1.core.kv_cache_manager import KVCacheBlocks
@@ -85,6 +88,7 @@ class MooncakeBaseConnectorScheduler:
         self.group_block_size = [group.kv_cache_spec.block_size for group in self.kv_cache_groups]
         self.group_unique_specs = [self._get_group_unique_specs(group) for group in self.kv_cache_groups]
         self.need_truncate = self._needs_prefill_token_truncation()
+        self._kv_stats = MooncakeKVConnectorStats()
 
         logger.info("Initializing Mooncake Scheduler %s", engine_id)
 
@@ -166,6 +170,13 @@ class MooncakeBaseConnectorScheduler:
         request.num_prompt_tokens -= 1
         request.max_tokens = 1
         params["_p_side_truncated"] = True
+
+    def get_kv_connector_stats(self) -> MooncakeKVConnectorStats | None:
+        if "delayed_release_requests" not in self._kv_stats.data:
+            return None
+        stats = self._kv_stats
+        self._kv_stats = MooncakeKVConnectorStats()
+        return stats
 
     def on_new_request(self, request: "Request") -> None:
         raise NotImplementedError

--- a/vllm_ascend/distributed/kv_transfer/kv_p2p/mooncake/connector.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_p2p/mooncake/connector.py
@@ -177,9 +177,11 @@ class MooncakeBaseConnector(KVConnectorBase_V1, SupportsHMA):
         return self.connector_worker.get_block_ids_with_load_errors()
 
     def get_kv_connector_stats(self) -> KVConnectorStats | None:
-        if self.connector_worker is None:
-            return None
-        return self.connector_worker.get_kv_connector_stats()
+        if self.connector_scheduler is not None:
+            return self.connector_scheduler.get_kv_connector_stats()
+        if self.connector_worker is not None:
+            return self.connector_worker.get_kv_connector_stats()
+        return None
 
     @classmethod
     def build_kv_connector_stats(cls, data: dict[str, Any] | None = None) -> KVConnectorStats:

--- a/vllm_ascend/distributed/kv_transfer/kv_p2p/mooncake/pull_scheduler.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_p2p/mooncake/pull_scheduler.py
@@ -457,7 +457,8 @@ class MooncakePullConnectorScheduler(MooncakeBaseConnectorScheduler):
         # Requests waiting for the worker to start a READ transfer.
         self._reqs_need_recv: dict[str, tuple[Request, BlockIds, BlockIds, int]] = {}
         # Producer requests whose blocks must remain allocated until read.
-        self._reqs_need_send: dict[str, float] = {}
+        self._reqs_need_send: dict[str, int] = {}
+        self._num_delayed_release_blocks = 0
         self._reqs_in_batch: set[str] = set()
         # D request -> (P scheduler host, port, P request id).
         self._reqs_recv_info: dict[str, tuple[str, int, str]] = {}
@@ -623,12 +624,18 @@ class MooncakePullConnectorScheduler(MooncakeBaseConnectorScheduler):
                 request.request_id,
             )
             delay_start_time = time.time()
-            self._reqs_need_send[request.request_id] = delay_start_time
+            num_delayed_release_blocks = sum(len(group_block_ids) for group_block_ids in block_ids)
+            self._reqs_need_send[request.request_id] = num_delayed_release_blocks
+            self._num_delayed_release_blocks += num_delayed_release_blocks
             if self._sending_thread is None:
                 raise RuntimeError("Mooncake scheduler metadata has not been initialized")
             self._sending_thread.add_delayed_request(
                 request.request_id,
                 delay_start_time,
+            )
+            self._kv_stats.set_delayed_release(
+                len(self._reqs_need_send),
+                self._num_delayed_release_blocks,
             )
 
         return delay_free_blocks, {
@@ -667,7 +674,11 @@ class MooncakePullConnectorScheduler(MooncakeBaseConnectorScheduler):
         )
         if finished_sending:
             for req_id in finished_sending:
-                self._reqs_need_send.pop(req_id, None)
+                self._num_delayed_release_blocks -= self._reqs_need_send.pop(req_id, 0)
+            self._kv_stats.set_delayed_release(
+                len(self._reqs_need_send),
+                self._num_delayed_release_blocks,
+            )
             if connector_output.finished_sending is None:
                 connector_output.finished_sending = finished_sending
             else:

--- a/vllm_ascend/distributed/kv_transfer/kv_p2p/mooncake/stats.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_p2p/mooncake/stats.py
@@ -28,7 +28,7 @@ class MooncakeKVConnectorStats(KVConnectorStats):
     def reset(self) -> None:
         # Values must remain serializable because worker stats are aggregated
         # outside of the worker process.
-        self.data: dict[str, list[float | int]] = {
+        self.data = {
             "transfer_duration": [],
             "bytes_transferred": [],
             "num_failed_transfers": [],
@@ -51,21 +51,27 @@ class MooncakeKVConnectorStats(KVConnectorStats):
         return previous
 
     def is_empty(self) -> bool:
-        return self.num_successful_transfers == 0 and not self.data["num_failed_transfers"]
+        return (
+            self.num_successful_transfers == 0
+            and not self.data.get("num_failed_transfers")
+            and "delayed_release_requests" not in self.data
+        )
 
     def aggregate(self, other: KVConnectorStats) -> KVConnectorStats:
-        if not other.is_empty():
-            for key, values in other.data.items():
-                accumulator = self.data[key]
-                assert isinstance(accumulator, list)
-                accumulator.extend(values)
+        for key in ("transfer_duration", "bytes_transferred", "num_failed_transfers"):
+            if values := other.data.get(key):
+                self.data.setdefault(key, []).extend(values)
+        for key in ("delayed_release_requests", "delayed_release_blocks"):
+            if key in other.data:
+                self.data[key] = other.data[key]
         return self
 
     def reduce(self) -> dict[str, int | float]:
+        num_failed_transfers = len(self.data.get("num_failed_transfers", []))
         if self.num_successful_transfers == 0:
             return {
                 "Num successful transfers": 0,
-                "Num failed transfers": len(self.data["num_failed_transfers"]),
+                "Num failed transfers": num_failed_transfers,
                 "Avg xfer time (ms)": 0,
                 "P90 xfer time (ms)": 0,
                 "Avg MB per transfer": 0,
@@ -79,16 +85,20 @@ class MooncakeKVConnectorStats(KVConnectorStats):
 
         return {
             "Num successful transfers": self.num_successful_transfers,
-            "Num failed transfers": len(self.data["num_failed_transfers"]),
+            "Num failed transfers": num_failed_transfers,
             "Avg xfer time (ms)": round(durations.mean() * 1e3, 3),
             "P90 xfer time (ms)": round(np.percentile(durations, 90).item() * 1e3, 3),
             "Avg MB per transfer": round(megabytes.mean(), 3),
             "Throughput (MB/s)": round(float(throughput), 3),
         }
 
+    def set_delayed_release(self, num_requests: int, num_blocks: int) -> None:
+        self.data["delayed_release_requests"] = num_requests
+        self.data["delayed_release_blocks"] = num_blocks
+
     @property
     def num_successful_transfers(self) -> int:
-        return len(self.data["transfer_duration"])
+        return len(self.data.get("transfer_duration", []))
 
 
 class MooncakePromMetrics(KVConnectorPromMetrics):
@@ -144,10 +154,39 @@ class MooncakePromMetrics(KVConnectorPromMetrics):
         )
         self.failed_transfers = create_metric_per_engine(failed_transfers, self.per_engine_labelvalues)
 
+        delayed_release_requests = self._gauge_cls(
+            name="vllm:mooncake_pd_delayed_release_requests",
+            documentation=(
+                "Number of finished prefill requests whose KV cache blocks "
+                "are retained until Mooncake P/D transfer completes."
+            ),
+            labelnames=labelnames,
+        )
+        self.delayed_release_requests = create_metric_per_engine(
+            delayed_release_requests,
+            self.per_engine_labelvalues,
+        )
+
+        delayed_release_blocks = self._gauge_cls(
+            name="vllm:mooncake_pd_delayed_release_blocks",
+            documentation=(
+                "Number of KV cache block references retained for finished "
+                "prefill requests until Mooncake P/D transfer completes."
+            ),
+            labelnames=labelnames,
+        )
+        self.delayed_release_blocks = create_metric_per_engine(
+            delayed_release_blocks,
+            self.per_engine_labelvalues,
+        )
+
     def observe(self, transfer_stats_data: dict[str, Any], engine_idx: int = 0) -> None:
-        for duration in transfer_stats_data["transfer_duration"]:
+        for duration in transfer_stats_data.get("transfer_duration", ()):
             self.transfer_duration[engine_idx].observe(duration)
-        for num_bytes in transfer_stats_data["bytes_transferred"]:
+        for num_bytes in transfer_stats_data.get("bytes_transferred", ()):
             self.bytes_transferred[engine_idx].observe(num_bytes)
-        for failure in transfer_stats_data["num_failed_transfers"]:
+        for failure in transfer_stats_data.get("num_failed_transfers", ()):
             self.failed_transfers[engine_idx].inc(failure)
+        if "delayed_release_requests" in transfer_stats_data:
+            self.delayed_release_requests[engine_idx].set(transfer_stats_data["delayed_release_requests"])
+            self.delayed_release_blocks[engine_idx].set(transfer_stats_data["delayed_release_blocks"])

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/ascend_store_connector.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/ascend_store_connector.py
@@ -172,6 +172,9 @@ class AscendStoreConnector(KVConnectorBase_V1, SupportsHMA):
         assert self.connector_scheduler is not None
         return self.connector_scheduler.request_finished_all_groups(request, block_ids)
 
+    def has_pending_push_work(self) -> bool:
+        return self.connector_scheduler is not None and self.connector_scheduler.has_pending_push_work()
+
     def update_connector_output(self, connector_output: KVConnectorOutput):
         """
         Update KVConnector state from worker-side connectors output.
@@ -298,7 +301,7 @@ class AscendStoreConnector(KVConnectorBase_V1, SupportsHMA):
         assert self.connector_worker is not None
         self.connector_worker.wait_for_save(self._get_connector_metadata())
 
-    def get_finished(self, finished_req_ids: set[str]) -> tuple[set[str], set[str]]:
+    def get_finished(self, _finished_req_ids: set[str]) -> tuple[set[str], set[str]]:
         """Get the finished recving and sending requests."""
         assert self.connector_worker is not None
         metadata = self._get_connector_metadata()
@@ -307,7 +310,7 @@ class AscendStoreConnector(KVConnectorBase_V1, SupportsHMA):
                 self.connector_worker.ensure_store_initialized()
             finally:
                 self._current_step_has_real_forward = False
-        done_sending, done_recving = self.connector_worker.get_finished(finished_req_ids, metadata)
+        done_sending, done_recving = self.connector_worker.get_finished(metadata)
         return done_sending, done_recving
 
     def get_block_ids_with_load_errors(self) -> set[int]:
@@ -337,8 +340,6 @@ class AscendStoreConnector(KVConnectorBase_V1, SupportsHMA):
         return self.connector_worker.build_connector_worker_meta()
 
     def get_kv_connector_stats(self) -> KVConnectorStats | None:
-        if self.connector_scheduler is not None:
-            return self.connector_scheduler.get_stats()
         if self.connector_worker is not None:
             return self.connector_worker.get_stats()
         return None

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/metadata.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/metadata.py
@@ -1102,12 +1102,10 @@ class AscendConnectorMetadata(KVConnectorMetadata):
         self,
         preempted_req_ids,
         loading_req_ids: set[str] | None = None,
-        delayed_free_req_ids: set[str] | None = None,
     ):
         self.requests: list[ReqMeta] = []
         self.preempted_req_ids = preempted_req_ids
         self.loading_req_ids = loading_req_ids or set()
-        self.delayed_free_req_ids = delayed_free_req_ids or set()
 
     def add_request(self, req_meta: ReqMeta) -> None:
         """Add a request to the metadata."""

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/metrics.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/metrics.py
@@ -48,16 +48,10 @@ class AscendStoreKVConnectorStats(KVConnectorStats):
             self.data.setdefault("load_get_duration_seconds", []).extend(durations)
         if num_keys := other.data.get("load_get_keys"):
             self.data["load_get_keys"] = self.data.get("load_get_keys", 0) + num_keys
-        if "delayed_release_requests" in other.data:
-            self.data["delayed_release_requests"] = other.data["delayed_release_requests"]
-            self.data["delayed_release_blocks"] = other.data["delayed_release_blocks"]
         return self
 
     def reduce(self) -> dict[str, int | float]:
-        reduced: dict[str, int | float] = {
-            "ascend_store_delayed_release_requests": self.data.get("delayed_release_requests", 0),
-            "ascend_store_delayed_release_blocks": self.data.get("delayed_release_blocks", 0),
-        }
+        reduced: dict[str, int | float] = {}
         if durations := self.data.get("load_get_duration_seconds"):
             reduced["ascend_store_load_get_count"] = len(durations)
             reduced["ascend_store_load_get_avg_ms"] = round(fmean(durations) * 1e3, 3)
@@ -70,10 +64,6 @@ class AscendStoreKVConnectorStats(KVConnectorStats):
         self.data.setdefault("load_get_duration_seconds", []).append(duration_seconds)
         self.data["load_get_keys"] = self.data.get("load_get_keys", 0) + num_keys
 
-    def set_delayed_release(self, num_requests: int, num_blocks: int) -> None:
-        self.data["delayed_release_requests"] = num_requests
-        self.data["delayed_release_blocks"] = num_blocks
-
 
 class AscendStorePromMetrics(KVConnectorPromMetrics):
     def __init__(
@@ -84,28 +74,6 @@ class AscendStorePromMetrics(KVConnectorPromMetrics):
         per_engine_labelvalues: dict[int, list[object]],
     ) -> None:
         super().__init__(vllm_config, metric_types, labelnames, per_engine_labelvalues)
-        self._delayed_release_requests = create_metric_per_engine(
-            self._gauge_cls(
-                name="vllm:ascend_store_delayed_release_requests",
-                documentation=(
-                    "Number of finished requests whose KV cache block release is "
-                    "delayed by an asynchronous AscendStore save."
-                ),
-                labelnames=labelnames,
-            ),
-            per_engine_labelvalues,
-        )
-        self._delayed_release_blocks = create_metric_per_engine(
-            self._gauge_cls(
-                name="vllm:ascend_store_delayed_release_blocks",
-                documentation=(
-                    "Number of KV cache block references retained for finished "
-                    "requests while asynchronous AscendStore saves complete."
-                ),
-                labelnames=labelnames,
-            ),
-            per_engine_labelvalues,
-        )
         self._load_get_duration = create_metric_per_engine(
             self._histogram_cls(
                 name="vllm:ascend_store_load_get_duration_seconds",
@@ -132,11 +100,3 @@ class AscendStorePromMetrics(KVConnectorPromMetrics):
         metric = self._load_get_keys.get(engine_idx)
         if metric is not None:
             metric.inc(transfer_stats_data.get("load_get_keys", 0))
-        metric = self._delayed_release_requests.get(engine_idx)
-        if metric is not None:
-            if "delayed_release_requests" in transfer_stats_data:
-                metric.set(transfer_stats_data["delayed_release_requests"])
-        metric = self._delayed_release_blocks.get(engine_idx)
-        if metric is not None:
-            if "delayed_release_blocks" in transfer_stats_data:
-                metric.set(transfer_stats_data["delayed_release_blocks"])

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/pool_scheduler.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/pool_scheduler.py
@@ -1,13 +1,12 @@
 import importlib
 import math
-from typing import Any, cast
+from typing import Any
 
 import vllm.envs as envs
 import zmq
 from vllm.config import VllmConfig
 from vllm.distributed.kv_transfer.kv_connector.v1.base import KVConnectorMetadata
 from vllm.logger import logger
-from vllm.utils.math_utils import cdiv
 from vllm.utils.network_utils import make_zmq_socket
 from vllm.v1.core.block_pool import BlockPool
 from vllm.v1.core.kv_cache_manager import KVCacheBlocks
@@ -16,7 +15,6 @@ from vllm.v1.core.sched.output import SchedulerOutput
 from vllm.v1.kv_cache_interface import (
     KVCacheConfig,
     MambaSpec,
-    SlidingWindowSpec,
     UniformTypeKVCacheSpecs,
 )
 from vllm.v1.outputs import KVConnectorOutput
@@ -52,9 +50,6 @@ from vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.metadata import (
     normalize_block_ids_by_group,
     uses_hybrid_kv_cache,
 )
-from vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.metrics import (
-    AscendStoreKVConnectorStats,
-)
 
 
 class KVPoolScheduler:
@@ -81,7 +76,6 @@ class KVPoolScheduler:
             else [0]
         )
         self.kv_cache_group_families = infer_group_cache_families(kv_cache_groups, self.compress_ratios, self.hf_config)
-        self.num_swa_blocks = self._infer_swa_blocks()
         if kv_cache_config is not None:
             for kv_cache_group in kv_cache_config.kv_cache_groups:
                 kv_cache_spec = kv_cache_group.kv_cache_spec
@@ -143,11 +137,6 @@ class KVPoolScheduler:
         )
         self._unfinished_requests: dict[str, tuple[Request, list[list[int]]]] = {}
         self._loading_req_ids: set[str] = set()
-        self._delayed_free_req_ids: set[str] = set()
-        self._delayed_free_blocks_by_req: dict[str, int] = {}
-        self._num_delayed_free_blocks = 0
-        self._kv_stats = AscendStoreKVConnectorStats()
-
         self._block_pool: BlockPool | None = None
         self.sending_event_id = 0
         # {event_id, flattened block_ids}
@@ -414,42 +403,6 @@ class KVPoolScheduler:
             if isinstance(kv_cache_spec, MambaSpec):
                 mamba_group_ids.append(group_id)
         return mamba_group_ids
-
-    def _infer_swa_blocks(self) -> list[int]:
-        if self.kv_cache_config is None:
-            return []
-
-        num_swa_blocks: list[int] = []
-        for group in self.kv_cache_config.kv_cache_groups:
-            kv_cache_spec = group.kv_cache_spec
-            if isinstance(kv_cache_spec, UniformTypeKVCacheSpecs):
-                group_specs = []
-                for layer_name in group.layer_names:
-                    layer_spec = kv_cache_spec.kv_cache_specs[layer_name]
-                    if layer_spec not in group_specs:
-                        group_specs.append(layer_spec)
-            else:
-                group_specs = [kv_cache_spec]
-
-            first_spec = group_specs[0]
-            if isinstance(first_spec, SlidingWindowSpec):
-                num_swa_blocks.append(cdiv(first_spec.sliding_window, first_spec.block_size) + 1)
-            else:
-                num_swa_blocks.append(0)
-        return num_swa_blocks
-
-    def get_sw_clipped_blocks(
-        self,
-        block_ids: tuple[list[int], ...] | list[list[int]],
-    ) -> tuple[list[int], ...] | list[list[int]]:
-        if len(block_ids) == 0 or not self.use_hybrid:
-            return block_ids
-        assert len(block_ids) == len(self.num_swa_blocks), "Number of KV cache groups must match"
-        clipped = [
-            blocks[-self.num_swa_blocks[group_id] :] if self.num_swa_blocks[group_id] > 0 else blocks
-            for group_id, blocks in enumerate(block_ids)
-        ]
-        return tuple(clipped) if isinstance(block_ids, tuple) else clipped
 
     def get_num_new_matched_tokens(
         self,
@@ -843,12 +796,9 @@ class KVPoolScheduler:
             self._request_trackers.pop(req_id, None)
             self._unfinished_requests.pop(req_id, None)
             self._loading_req_ids.discard(req_id)
-            self._set_delayed_free(req_id, 0)
-
         meta = AscendConnectorMetadata(
             scheduler_output.preempted_req_ids,
             self._loading_req_ids.copy(),
-            self._delayed_free_req_ids.copy(),
         )
 
         for request in scheduler_output.scheduled_new_reqs:
@@ -933,8 +883,6 @@ class KVPoolScheduler:
         """
         hand the connector_output, free non-null mamba blocks and so on.
         """
-        self.update_finished_sending(connector_output.finished_sending)
-
         meta = connector_output.kv_connector_worker_meta
         if not isinstance(meta, AscendStoreKVConnectorWorkerMetadata) or self._block_pool is None:
             return
@@ -960,80 +908,27 @@ class KVPoolScheduler:
         request: "Request",
         block_ids: list[int],
     ) -> tuple[bool, dict[str, Any] | None]:
-        """
-        Once a request is finished, determine whether request blocks
-        should be freed now or will be sent asynchronously and freed later.
-        """
-        if self.kv_role == "kv_consumer" and not self.consumer_is_to_put:
-            self._set_delayed_free(request.request_id, 0)
-            return False, None
-        if self.use_layerwise:
-            self._set_delayed_free(request.request_id, 0)
-            return False, None
-        tracker = self._request_trackers.get(request.request_id)
-        if tracker is None or tracker.num_saved_tokens <= 0:
-            self._set_delayed_free(request.request_id, 0)
-            return False, None
-        num_blocks = len(block_ids)
-        self._set_delayed_free(request.request_id, num_blocks)
-        return num_blocks > 0, None
+        """Allow the scheduler to free blocks after synchronous saving."""
+        return False, None
 
     def request_finished_all_groups(
         self,
         request: "Request",
         block_ids: tuple[list[int], ...],
     ) -> tuple[bool, dict[str, Any] | None]:
-        """HMA path for hybrid KV cache groups."""
-        if self.kv_role == "kv_consumer" and not self.consumer_is_to_put:
-            self._set_delayed_free(request.request_id, 0)
-            return False, None
-        if self.use_layerwise:
-            # Free now: layerwise records no sending event, so delay-free would leak.
-            self._set_delayed_free(request.request_id, 0)
-            return False, None
-        tracker = self._request_trackers.get(request.request_id)
-        if tracker is not None and tracker.num_saved_tokens <= 0:
-            self._set_delayed_free(request.request_id, 0)
-            return False, None
-        block_ids = cast(tuple[list[int], ...], self.get_sw_clipped_blocks(block_ids))
-        num_blocks = sum(map(len, block_ids))
-        self._set_delayed_free(request.request_id, num_blocks)
-        return num_blocks > 0, None
+        """Allow the scheduler to free all groups after synchronous saving."""
+        return False, None
 
     def bind_gpu_block_pool(self, gpu_block_pool: "BlockPool") -> None:
         self._block_pool = gpu_block_pool
 
-    def update_finished_sending(self, finished_sending: set[str] | None) -> None:
-        if finished_sending:
-            for req_id in finished_sending:
-                self._set_delayed_free(req_id, 0)
+    def has_pending_push_work(self) -> bool:
+        """Keep stepping until synchronous Mamba save completions are collected."""
+        return bool(self.sending_events)
 
     def update_finished_recving(self, finished_recving: set[str] | None) -> None:
         if finished_recving:
             self._loading_req_ids.difference_update(finished_recving)
-
-    def _set_delayed_free(self, req_id: str, num_blocks: int) -> None:
-        if num_blocks:
-            if req_id in self._delayed_free_req_ids:
-                return
-            self._delayed_free_req_ids.add(req_id)
-            self._delayed_free_blocks_by_req[req_id] = num_blocks
-            self._num_delayed_free_blocks += num_blocks
-            logger.debug("Delaying free of %d blocks for request %s", num_blocks, req_id)
-        else:
-            if req_id not in self._delayed_free_req_ids:
-                return
-            self._delayed_free_req_ids.discard(req_id)
-            num_blocks = self._delayed_free_blocks_by_req.pop(req_id)
-            self._num_delayed_free_blocks -= num_blocks
-        self._kv_stats.set_delayed_release(len(self._delayed_free_req_ids), self._num_delayed_free_blocks)
-
-    def get_stats(self) -> AscendStoreKVConnectorStats | None:
-        if self._kv_stats.is_empty():
-            return None
-        stats = self._kv_stats
-        self._kv_stats = AscendStoreKVConnectorStats()
-        return stats
 
 
 class LookupKeyClient:

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/pool_worker.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/pool_worker.py
@@ -2111,22 +2111,17 @@ class KVPoolWorker:
         finally:
             send_thread.dec_stored_request(req_id)  # type: ignore[attr-defined]
 
-    def get_finished(self, finished_req_ids: set[str], meta: AscendConnectorMetadata) -> tuple[set[str], set[str]]:
+    def get_finished(self, meta: AscendConnectorMetadata) -> tuple[set[str], set[str]]:
+        done_sending = set()
         if self.kv_send_thread is not None:
             send_thread = self.kv_send_thread
             for req_id in meta.preempted_req_ids:
                 if isinstance(send_thread, (KVCacheStoreSendingThread, KVCacheStoreLayerSendingThread)):
                     send_thread.delete_finished_stored_request(req_id)
             self.kv_send_thread.discard_finished_requests(meta.preempted_req_ids)
-            if self.use_layerwise:
-                self.kv_send_thread.get_and_clear_finished_requests()
-                done_sending = set()
-            else:
-                stale_finished_req_ids = finished_req_ids - meta.delayed_free_req_ids
-                self.kv_send_thread.discard_finished_requests(stale_finished_req_ids)
-                done_sending = self.kv_send_thread.get_and_clear_finished_requests(meta.delayed_free_req_ids)
-        else:
-            done_sending = set()
+            # Saves complete synchronously in wait_for_save(), so the scheduler
+            # never waits for a request-level finished_sending notification.
+            self.kv_send_thread.get_and_clear_finished_requests()
 
         done_recving = set()
         if self.kv_recv_thread is not None:


### PR DESCRIPTION
### What this PR does / why we need it?

Adds current-state delayed KV block release metrics to `MooncakeConnectorV2` for P/D disaggregation:

- `vllm:mooncake_pd_delayed_release_requests`: finished prefill requests whose KV blocks remain retained until the Mooncake P/D transfer is acknowledged.
- `vllm:mooncake_pd_delayed_release_blocks`: KV cache block references retained by those requests.

Both are Gauges reported by the P scheduler. They move up when a request actually returns `delay_free=True` and move down, including to zero, when the P scheduler drains D-side acknowledgements. The implementation reuses the existing `_reqs_need_send` map, keeps one running block total, and reports only state transitions. It adds no request-ID labels, lock, RPC, collective, NPU synchronization, or per-step request scan.

The patch also adopts the synchronous AscendStore release semantics from vLLM Ascend #16119. `wait_for_save()` completes queued saves before output is returned, so AscendStore no longer maintains a redundant request-level delayed-free handshake or delayed-release Gauges. Hybrid Mamba completion events remain protected, and `has_pending_push_work()` keeps the engine stepping until those events are collected.

The non-layerwise AscendStore GET metrics from #16137 remain available:

- `vllm:ascend_store_load_get_duration_seconds`
- `vllm:ascend_store_load_get_keys_total`

### Design references

- [vLLM Ascend #16119 — remove redundant AscendStore delayed block free tracking](https://github.com/vllm-project/vllm-ascend/pull/16119)
- [vLLM Ascend #16137 — AscendStore load metrics](https://github.com/vllm-project/vllm-ascend/pull/16137)
- [vLLM #43392 — MooncakeStore connector metrics](https://github.com/vllm-project/vllm/pull/43392)

The implementation uses the existing vLLM connector metrics hooks (`get_kv_connector_stats`, `build_kv_connector_stats`, and `build_prom_metrics`). `MultiConnector` routes the Mooncake and AscendStore child stats through the upstream `MultiKVConnectorStats` and `MultiKVConnectorPromMetrics` path.

Transfer observations remain event data and are appended during aggregation. Delayed-release values are current-state snapshots and therefore use latest-value-wins aggregation. A zero snapshot is intentionally non-empty so the upstream scheduler does not filter it and leave a stale non-zero Gauge.

### Does this PR introduce _any_ user-facing change?

Yes. Two MooncakeConnectorV2 Gauge families are exposed through the standard `/metrics` endpoint. The obsolete AscendStore delayed-release Gauge families are removed because AscendStore save completion is synchronous before block release.

### How was this patch tested?

- `python -m ruff check` on all 16 changed Python files: passed.
- `python -m ruff format --check` on all 16 changed Python files: passed.
- `python -m compileall -q` on the changed Mooncake and AscendStore modules: passed.
- MooncakeConnectorV2 focused UTs: `40 passed`.
- AscendStore focused UTs: `141 passed`.
- Real `prometheus_client` registry verification confirmed HELP/TYPE/sample output and the state transition from `requests=1, blocks=3` to `requests=0, blocks=0`.
- A 300,000-cycle CPU bookkeeping microbenchmark measured approximately `0.246 us` additional work per delayed-request enter+exit cycle. This is not an NPU throughput benchmark; the bookkeeping runs only on delayed-request state transitions, not per token.
- DP1/TP2 P/D startup was attempted with `MooncakeConnectorV2` plus `AscendStoreConnector(backend=mooncake)`. The current container could not complete a stable API startup because of Mooncake multi-client startup and installed CANN extension/source compatibility issues. No complete NPU request-path result is claimed; CI and a matched runtime image are required for full E2E verification.

- vLLM main: https://github.com/vllm-project/vllm/commit/b2f685834a6456197e7033966fdef52a23f1abcd
